### PR TITLE
Working out outdated migrations

### DIFF
--- a/db/migrate/20120523201329_add_featured_to_forum_threads.rb
+++ b/db/migrate/20120523201329_add_featured_to_forum_threads.rb
@@ -3,14 +3,6 @@ class AddFeaturedToForumThreads < ActiveRecord::Migration
     add_column :forum_threads, :featured_user1_id, :integer, null: true
     add_column :forum_threads, :featured_user2_id, :integer, null: true
     add_column :forum_threads, :featured_user3_id, :integer, null: true
-
-    # Migrate old threads
-    ForumThread.all.each do |forum_thread|
-      posts_count = Post.where(forum_thread_id: forum_thread.id).group(:user_id).order('count_all desc').limit(3).count
-      posts_count.keys.each_with_index {|user_id, i| forum_thread.send("featured_user#{i+1}_id=", user_id) }
-      forum_thread.save
-    end
-
   end
 
   def down

--- a/db/migrate/20120530160745_migrate_posted.rb
+++ b/db/migrate/20120530160745_migrate_posted.rb
@@ -1,8 +1,5 @@
 class MigratePosted < ActiveRecord::Migration
   def up
-    Post.all.each do |p|
-      ForumThreadUser.change(p.user, p.forum_thread_id, posted: true)
-    end
   end
 
   def down

--- a/db/migrate/20120809201855_migrate_bookmarks_to_post_actions.rb
+++ b/db/migrate/20120809201855_migrate_bookmarks_to_post_actions.rb
@@ -1,9 +1,5 @@
 class MigrateBookmarksToPostActions < ActiveRecord::Migration
   def up
-    execute "insert into post_actions(user_id, post_action_type_id, post_id, created_at, updated_at)
-    select distinct b.user_id, #{PostActionType.bookmark.id} , p.id, b.created_at, b.updated_at 
-from bookmarks b
-join posts p on p.forum_thread_id = b.forum_thread_id and p.post_number = b.post_number"
     drop_table "bookmarks"
   end
 

--- a/db/migrate/20120918205931_add_sub_tag_to_forum_threads.rb
+++ b/db/migrate/20120918205931_add_sub_tag_to_forum_threads.rb
@@ -2,13 +2,5 @@ class AddSubTagToForumThreads < ActiveRecord::Migration
   def change
     add_column :forum_threads, :sub_tag, :string
     add_index :forum_threads, [:category_id, :sub_tag, :bumped_at]
-
-    ForumThread.where("category_id is not null and title like '%:%'").each do |ft|
-      if ft.title =~ /^(([a-zA-Z0-9]+)\: )(.*)/
-        sub_tag = Regexp.last_match[2].downcase.strip
-        execute "UPDATE forum_threads SET sub_tag = '#{sub_tag}' WHERE id = #{ft.id}"
-      end
-    end
-
   end
 end

--- a/db/migrate/20120921162512_add_meta_data_to_forum_threads.rb
+++ b/db/migrate/20120921162512_add_meta_data_to_forum_threads.rb
@@ -1,5 +1,6 @@
 class AddMetaDataToForumThreads < ActiveRecord::Migration
   def change
+    execute "CREATE EXTENSION hstore" 
     add_column :forum_threads, :meta_data, :hstore
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,143 +11,138 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20120809201855) do
-
-  create_table "actions", :force => true do |t|
-    t.integer  "action_type",            :null => false
-    t.integer  "user_id",                :null => false
-    t.integer  "target_forum_thread_id"
-    t.integer  "target_post_id"
-    t.integer  "target_user_id"
-    t.integer  "acting_user_id"
-    t.datetime "created_at",             :null => false
-    t.datetime "updated_at",             :null => false
-  end
-
-  add_index "actions", ["acting_user_id"], :name => "index_actions_on_acting_user_id"
-  add_index "actions", ["user_id", "action_type"], :name => "index_actions_on_user_id_and_action_type"
+ActiveRecord::Schema.define(:version => 20130205021905) do
 
   create_table "categories", :force => true do |t|
-    t.string   "name",                 :limit => 50,                       :null => false
-    t.string   "color",                :limit => 6,  :default => "AB9364", :null => false
-    t.integer  "forum_thread_id"
-    t.integer  "top1_forum_thread_id"
-    t.integer  "top2_forum_thread_id"
+    t.string   "name",          :limit => 50,                       :null => false
+    t.string   "color",         :limit => 6,  :default => "AB9364", :null => false
+    t.integer  "topic_id"
+    t.integer  "top1_topic_id"
+    t.integer  "top2_topic_id"
     t.integer  "top1_user_id"
     t.integer  "top2_user_id"
-    t.integer  "forum_thread_count",                 :default => 0,        :null => false
-    t.datetime "created_at",                                               :null => false
-    t.datetime "updated_at",                                               :null => false
-    t.integer  "user_id",                                                  :null => false
-    t.integer  "threads_year"
-    t.integer  "threads_month"
-    t.integer  "threads_week"
+    t.integer  "topic_count",                 :default => 0,        :null => false
+    t.datetime "created_at",                                        :null => false
+    t.datetime "updated_at",                                        :null => false
+    t.integer  "user_id",                                           :null => false
+    t.integer  "topics_year"
+    t.integer  "topics_month"
+    t.integer  "topics_week"
+    t.string   "slug",                                              :null => false
   end
 
-  add_index "categories", ["forum_thread_count"], :name => "index_categories_on_forum_thread_count"
   add_index "categories", ["name"], :name => "index_categories_on_name", :unique => true
+  add_index "categories", ["topic_count"], :name => "index_categories_on_forum_thread_count"
 
-  create_table "category_featured_threads", :id => false, :force => true do |t|
-    t.integer  "category_id",     :null => false
-    t.integer  "forum_thread_id", :null => false
-    t.datetime "created_at",      :null => false
-    t.datetime "updated_at",      :null => false
+  create_table "categories_search", :id => false, :force => true do |t|
+    t.integer  "id",          :null => false
+    t.tsvector "search_data"
   end
 
-  add_index "category_featured_threads", ["category_id", "forum_thread_id"], :name => "cat_featured_threads", :unique => true
+  add_index "categories_search", ["search_data"], :name => "idx_search_category"
 
-  create_table "expression_types", :id => false, :force => true do |t|
-    t.string   "name",             :limit => 50,                     :null => false
-    t.string   "long_form",        :limit => 100,                    :null => false
-    t.datetime "created_at",                                         :null => false
-    t.datetime "updated_at",                                         :null => false
-    t.boolean  "flag",                            :default => false
-    t.text     "description"
-    t.integer  "expression_index"
-    t.string   "icon",             :limit => 20
+  create_table "category_featured_topics", :id => false, :force => true do |t|
+    t.integer  "category_id", :null => false
+    t.integer  "topic_id",    :null => false
+    t.datetime "created_at",  :null => false
+    t.datetime "updated_at",  :null => false
   end
 
-  add_index "expression_types", ["expression_index"], :name => "index_expression_types_on_expression_index", :unique => true
-  add_index "expression_types", ["name"], :name => "index_expression_types_on_name", :unique => true
+  add_index "category_featured_topics", ["category_id", "topic_id"], :name => "cat_featured_threads", :unique => true
 
-  create_table "expressions", :id => false, :force => true do |t|
-    t.integer  "post_id",          :null => false
-    t.integer  "expression_index", :null => false
-    t.integer  "user_id",          :null => false
-    t.datetime "created_at",       :null => false
-    t.datetime "updated_at",       :null => false
-  end
-
-  add_index "expressions", ["post_id", "expression_index", "user_id"], :name => "unique_by_user", :unique => true
-
-  create_table "forum_thread_links", :force => true do |t|
-    t.integer  "forum_thread_id",                                        :null => false
-    t.integer  "post_id"
-    t.integer  "user_id",                                                :null => false
-    t.string   "url",                  :limit => 500,                    :null => false
-    t.string   "domain",               :limit => 100,                    :null => false
-    t.boolean  "internal",                            :default => false, :null => false
-    t.integer  "link_forum_thread_id"
-    t.datetime "created_at",                                             :null => false
-    t.datetime "updated_at",                                             :null => false
-    t.boolean  "reflection",                          :default => false
-  end
-
-  add_index "forum_thread_links", ["forum_thread_id"], :name => "index_forum_thread_links_on_forum_thread_id"
-
-  create_table "forum_thread_users", :id => false, :force => true do |t|
-    t.integer "user_id",                                  :null => false
-    t.integer "forum_thread_id",                          :null => false
-    t.boolean "starred",               :default => false, :null => false
-    t.boolean "posted",                :default => false, :null => false
-    t.integer "last_read_post_number", :default => 1,     :null => false
-    t.integer "seen_post_count"
-  end
-
-  add_index "forum_thread_users", ["forum_thread_id", "user_id"], :name => "index_forum_thread_users_on_forum_thread_id_and_user_id", :unique => true
-
-  create_table "forum_threads", :force => true do |t|
-    t.string   "title",                                 :null => false
-    t.datetime "last_posted_at"
-    t.datetime "created_at",                            :null => false
-    t.datetime "updated_at",                            :null => false
-    t.integer  "views",               :default => 0,    :null => false
-    t.integer  "posts_count",         :default => 0,    :null => false
-    t.integer  "user_id",                               :null => false
-    t.integer  "last_post_user_id",                     :null => false
-    t.integer  "reply_count",         :default => 0,    :null => false
-    t.integer  "featured_user1_id"
-    t.integer  "featured_user2_id"
-    t.integer  "featured_user3_id"
-    t.integer  "avg_time"
-    t.datetime "deleted_at"
-    t.integer  "highest_post_number", :default => 0,    :null => false
-    t.string   "image_url"
-    t.integer  "expression1_count",   :default => 0,    :null => false
-    t.integer  "expression2_count",   :default => 0,    :null => false
-    t.integer  "expression3_count",   :default => 0,    :null => false
-    t.integer  "expression4_count",   :default => 0,    :null => false
-    t.integer  "expression5_count",   :default => 0,    :null => false
-    t.integer  "incoming_link_count", :default => 0,    :null => false
-    t.integer  "bookmark_count",      :default => 0,    :null => false
-    t.integer  "star_count",          :default => 0,    :null => false
+  create_table "category_featured_users", :force => true do |t|
     t.integer  "category_id"
-    t.boolean  "visible",             :default => true, :null => false
+    t.integer  "user_id"
+    t.datetime "created_at",  :null => false
+    t.datetime "updated_at",  :null => false
   end
 
-  add_index "forum_threads", ["last_posted_at"], :name => "index_forum_threads_on_last_posted_at"
+  add_index "category_featured_users", ["category_id", "user_id"], :name => "index_category_featured_users_on_category_id_and_user_id", :unique => true
+
+  create_table "draft_sequences", :force => true do |t|
+    t.integer "user_id",   :null => false
+    t.string  "draft_key", :null => false
+    t.integer "sequence",  :null => false
+  end
+
+  add_index "draft_sequences", ["user_id", "draft_key"], :name => "index_draft_sequences_on_user_id_and_draft_key", :unique => true
+
+  create_table "drafts", :force => true do |t|
+    t.integer  "user_id",                   :null => false
+    t.string   "draft_key",                 :null => false
+    t.text     "data",                      :null => false
+    t.datetime "created_at",                :null => false
+    t.datetime "updated_at",                :null => false
+    t.integer  "sequence",   :default => 0, :null => false
+  end
+
+  add_index "drafts", ["user_id", "draft_key"], :name => "index_drafts_on_user_id_and_draft_key"
+
+  create_table "email_logs", :force => true do |t|
+    t.string   "to_address", :null => false
+    t.string   "email_type", :null => false
+    t.integer  "user_id"
+    t.datetime "created_at", :null => false
+    t.datetime "updated_at", :null => false
+  end
+
+  add_index "email_logs", ["created_at"], :name => "index_email_logs_on_created_at", :order => {"created_at"=>:desc}
+  add_index "email_logs", ["user_id", "created_at"], :name => "index_email_logs_on_user_id_and_created_at", :order => {"created_at"=>:desc}
+
+  create_table "email_tokens", :force => true do |t|
+    t.integer  "user_id",                       :null => false
+    t.string   "email",                         :null => false
+    t.string   "token",                         :null => false
+    t.boolean  "confirmed",  :default => false, :null => false
+    t.boolean  "expired",    :default => false, :null => false
+    t.datetime "created_at",                    :null => false
+    t.datetime "updated_at",                    :null => false
+  end
+
+  add_index "email_tokens", ["token"], :name => "index_email_tokens_on_token", :unique => true
+
+  create_table "facebook_user_infos", :force => true do |t|
+    t.integer  "user_id",                       :null => false
+    t.integer  "facebook_user_id", :limit => 8, :null => false
+    t.string   "username",                      :null => false
+    t.string   "first_name"
+    t.string   "last_name"
+    t.string   "email"
+    t.string   "gender"
+    t.string   "name"
+    t.string   "link"
+    t.datetime "created_at",                    :null => false
+    t.datetime "updated_at",                    :null => false
+  end
+
+  add_index "facebook_user_infos", ["facebook_user_id"], :name => "index_facebook_user_infos_on_facebook_user_id", :unique => true
+  add_index "facebook_user_infos", ["user_id"], :name => "index_facebook_user_infos_on_user_id", :unique => true
 
   create_table "incoming_links", :force => true do |t|
-    t.string   "url",             :limit => 1000, :null => false
-    t.string   "referer",         :limit => 1000, :null => false
-    t.string   "domain",          :limit => 100,  :null => false
-    t.integer  "forum_thread_id"
+    t.string   "url",         :limit => 1000, :null => false
+    t.string   "referer",     :limit => 1000, :null => false
+    t.string   "domain",      :limit => 100,  :null => false
+    t.integer  "topic_id"
     t.integer  "post_number"
-    t.datetime "created_at",                      :null => false
-    t.datetime "updated_at",                      :null => false
+    t.datetime "created_at",                  :null => false
+    t.datetime "updated_at",                  :null => false
   end
 
-  add_index "incoming_links", ["forum_thread_id", "post_number"], :name => "incoming_index"
+  add_index "incoming_links", ["topic_id", "post_number"], :name => "incoming_index"
+
+  create_table "invites", :force => true do |t|
+    t.string   "invite_key",    :limit => 32, :null => false
+    t.string   "email",                       :null => false
+    t.integer  "invited_by_id",               :null => false
+    t.integer  "user_id"
+    t.datetime "redeemed_at"
+    t.datetime "created_at",                  :null => false
+    t.datetime "updated_at",                  :null => false
+    t.datetime "deleted_at"
+  end
+
+  add_index "invites", ["email", "invited_by_id"], :name => "index_invites_on_email_and_invited_by_id", :unique => true
+  add_index "invites", ["invite_key"], :name => "index_invites_on_invite_key", :unique => true
 
   create_table "message_bus", :force => true do |t|
     t.string   "name"
@@ -165,21 +160,32 @@ ActiveRecord::Schema.define(:version => 20120809201855) do
     t.boolean  "read",              :default => false, :null => false
     t.datetime "created_at",                           :null => false
     t.datetime "updated_at",                           :null => false
-    t.integer  "forum_thread_id"
+    t.integer  "topic_id"
     t.integer  "post_number"
+    t.integer  "post_action_id"
   end
 
+  add_index "notifications", ["post_action_id"], :name => "index_notifications_on_post_action_id"
   add_index "notifications", ["user_id", "created_at"], :name => "index_notifications_on_user_id_and_created_at"
 
-  create_table "post_action_types", :id => false, :force => true do |t|
-    t.integer  "id",                                            :null => false
-    t.string   "name",        :limit => 50,                     :null => false
-    t.string   "long_form",   :limit => 100,                    :null => false
-    t.boolean  "is_flag",                    :default => false, :null => false
-    t.text     "description"
-    t.string   "icon",        :limit => 20
-    t.datetime "created_at",                                    :null => false
-    t.datetime "updated_at",                                    :null => false
+  create_table "onebox_renders", :force => true do |t|
+    t.string   "url",        :null => false
+    t.text     "cooked",     :null => false
+    t.datetime "expires_at", :null => false
+    t.datetime "created_at", :null => false
+    t.datetime "updated_at", :null => false
+    t.text     "preview"
+  end
+
+  add_index "onebox_renders", ["url"], :name => "index_onebox_renders_on_url", :unique => true
+
+  create_table "post_action_types", :force => true do |t|
+    t.string   "name_key",   :limit => 50,                    :null => false
+    t.boolean  "is_flag",                  :default => false, :null => false
+    t.string   "icon",       :limit => 20
+    t.datetime "created_at",                                  :null => false
+    t.datetime "updated_at",                                  :null => false
+    t.integer  "position",                 :default => 0,     :null => false
   end
 
   create_table "post_actions", :force => true do |t|
@@ -189,10 +195,21 @@ ActiveRecord::Schema.define(:version => 20120809201855) do
     t.datetime "deleted_at"
     t.datetime "created_at",          :null => false
     t.datetime "updated_at",          :null => false
+    t.integer  "deleted_by"
+    t.text     "message"
   end
 
   add_index "post_actions", ["post_id"], :name => "index_post_actions_on_post_id"
-  add_index "post_actions", ["user_id", "post_action_type_id", "post_id"], :name => "idx_unique_actions", :unique => true
+  add_index "post_actions", ["user_id", "post_action_type_id", "post_id", "deleted_at"], :name => "idx_unique_actions", :unique => true
+
+  create_table "post_onebox_renders", :id => false, :force => true do |t|
+    t.integer  "post_id",          :null => false
+    t.integer  "onebox_render_id", :null => false
+    t.datetime "created_at",       :null => false
+    t.datetime "updated_at",       :null => false
+  end
+
+  add_index "post_onebox_renders", ["post_id", "onebox_render_id"], :name => "index_post_onebox_renders_on_post_id_and_onebox_render_id", :unique => true
 
   create_table "post_replies", :id => false, :force => true do |t|
     t.integer  "post_id"
@@ -204,57 +221,166 @@ ActiveRecord::Schema.define(:version => 20120809201855) do
   add_index "post_replies", ["post_id", "reply_id"], :name => "index_post_replies_on_post_id_and_reply_id", :unique => true
 
   create_table "post_timings", :id => false, :force => true do |t|
-    t.integer "forum_thread_id", :null => false
-    t.integer "post_number",     :null => false
-    t.integer "user_id",         :null => false
-    t.integer "msecs",           :null => false
+    t.integer "topic_id",    :null => false
+    t.integer "post_number", :null => false
+    t.integer "user_id",     :null => false
+    t.integer "msecs",       :null => false
   end
 
-  add_index "post_timings", ["forum_thread_id", "post_number", "user_id"], :name => "post_timings_unique", :unique => true
-  add_index "post_timings", ["forum_thread_id", "post_number"], :name => "post_timings_summary"
+  add_index "post_timings", ["topic_id", "post_number", "user_id"], :name => "post_timings_unique", :unique => true
+  add_index "post_timings", ["topic_id", "post_number"], :name => "post_timings_summary"
 
   create_table "posts", :force => true do |t|
-    t.integer  "user_id",                                :null => false
-    t.integer  "forum_thread_id",                        :null => false
-    t.integer  "post_number",                            :null => false
-    t.text     "raw",                                    :null => false
-    t.text     "cooked",                                 :null => false
-    t.datetime "created_at",                             :null => false
-    t.datetime "updated_at",                             :null => false
+    t.integer  "user_id",                                    :null => false
+    t.integer  "topic_id",                                   :null => false
+    t.integer  "post_number",                                :null => false
+    t.text     "raw",                                        :null => false
+    t.text     "cooked",                                     :null => false
+    t.datetime "created_at",                                 :null => false
+    t.datetime "updated_at",                                 :null => false
     t.integer  "reply_to_post_number"
-    t.integer  "cached_version",          :default => 1, :null => false
-    t.integer  "reply_count",             :default => 0, :null => false
-    t.integer  "quote_count",             :default => 0, :null => false
+    t.integer  "cached_version",          :default => 1,     :null => false
+    t.integer  "reply_count",             :default => 0,     :null => false
+    t.integer  "quote_count",             :default => 0,     :null => false
     t.integer  "reply_below_post_number"
     t.datetime "deleted_at"
-    t.integer  "expression1_count",       :default => 0, :null => false
-    t.integer  "expression2_count",       :default => 0, :null => false
-    t.integer  "expression3_count",       :default => 0, :null => false
-    t.integer  "expression4_count",       :default => 0, :null => false
-    t.integer  "expression5_count",       :default => 0, :null => false
-    t.integer  "incoming_link_count",     :default => 0, :null => false
-    t.integer  "bookmark_count",          :default => 0, :null => false
+    t.integer  "off_topic_count",         :default => 0,     :null => false
+    t.integer  "like_count",              :default => 0,     :null => false
+    t.integer  "incoming_link_count",     :default => 0,     :null => false
+    t.integer  "bookmark_count",          :default => 0,     :null => false
     t.integer  "avg_time"
     t.float    "score"
-    t.integer  "views",                   :default => 0, :null => false
+    t.integer  "reads",                   :default => 0,     :null => false
+    t.integer  "post_type",               :default => 1,     :null => false
+    t.integer  "vote_count",              :default => 0,     :null => false
+    t.integer  "sort_order"
+    t.integer  "last_editor_id"
+    t.boolean  "hidden",                  :default => false, :null => false
+    t.integer  "hidden_reason_id"
+    t.integer  "custom_flag_count",       :default => 0,     :null => false
+    t.integer  "spam_count",              :default => 0,     :null => false
+    t.integer  "illegal_count",           :default => 0,     :null => false
+    t.integer  "inappropriate_count",     :default => 0,     :null => false
+    t.datetime "last_version_at",                            :null => false
   end
 
-  add_index "posts", ["forum_thread_id", "post_number"], :name => "index_posts_on_forum_thread_id_and_post_number"
   add_index "posts", ["reply_to_post_number"], :name => "index_posts_on_reply_to_post_number"
-  add_index "posts", ["user_id"], :name => "index_posts_on_user_id"
+  add_index "posts", ["topic_id", "post_number"], :name => "index_posts_on_topic_id_and_post_number", :unique => true
+
+  create_table "posts_search", :id => false, :force => true do |t|
+    t.integer  "id",          :null => false
+    t.tsvector "search_data"
+  end
+
+  add_index "posts_search", ["search_data"], :name => "idx_search_post"
+
+  create_table "site_customizations", :force => true do |t|
+    t.string   "name",                                      :null => false
+    t.text     "stylesheet"
+    t.text     "header"
+    t.integer  "position",                                  :null => false
+    t.integer  "user_id",                                   :null => false
+    t.boolean  "enabled",                                   :null => false
+    t.string   "key",                                       :null => false
+    t.datetime "created_at",                                :null => false
+    t.datetime "updated_at",                                :null => false
+    t.boolean  "override_default_style", :default => false, :null => false
+    t.text     "stylesheet_baked",       :default => "",    :null => false
+  end
+
+  add_index "site_customizations", ["key"], :name => "index_site_customizations_on_key"
 
   create_table "site_settings", :force => true do |t|
-    t.string   "name",        :null => false
-    t.text     "description", :null => false
-    t.integer  "data_type",   :null => false
+    t.string   "name",       :null => false
+    t.integer  "data_type",  :null => false
     t.text     "value"
-    t.datetime "created_at",  :null => false
-    t.datetime "updated_at",  :null => false
+    t.datetime "created_at", :null => false
+    t.datetime "updated_at", :null => false
   end
+
+  create_table "topic_allowed_users", :force => true do |t|
+    t.integer  "user_id",    :null => false
+    t.integer  "topic_id",   :null => false
+    t.datetime "created_at", :null => false
+    t.datetime "updated_at", :null => false
+  end
+
+  add_index "topic_allowed_users", ["topic_id", "user_id"], :name => "index_topic_allowed_users_on_topic_id_and_user_id", :unique => true
+  add_index "topic_allowed_users", ["user_id", "topic_id"], :name => "index_topic_allowed_users_on_user_id_and_topic_id", :unique => true
+
+  create_table "topic_invites", :force => true do |t|
+    t.integer  "topic_id",   :null => false
+    t.integer  "invite_id",  :null => false
+    t.datetime "created_at", :null => false
+    t.datetime "updated_at", :null => false
+  end
+
+  add_index "topic_invites", ["invite_id"], :name => "index_topic_invites_on_invite_id"
+  add_index "topic_invites", ["topic_id", "invite_id"], :name => "index_topic_invites_on_topic_id_and_invite_id", :unique => true
+
+  create_table "topic_link_clicks", :force => true do |t|
+    t.integer  "topic_link_id",              :null => false
+    t.integer  "user_id"
+    t.integer  "ip",            :limit => 8, :null => false
+    t.datetime "created_at",                 :null => false
+    t.datetime "updated_at",                 :null => false
+  end
+
+  add_index "topic_link_clicks", ["topic_link_id"], :name => "index_forum_thread_link_clicks_on_forum_thread_link_id"
+
+  create_table "topic_links", :force => true do |t|
+    t.integer  "topic_id",                                        :null => false
+    t.integer  "post_id"
+    t.integer  "user_id",                                         :null => false
+    t.string   "url",           :limit => 500,                    :null => false
+    t.string   "domain",        :limit => 100,                    :null => false
+    t.boolean  "internal",                     :default => false, :null => false
+    t.integer  "link_topic_id"
+    t.datetime "created_at",                                      :null => false
+    t.datetime "updated_at",                                      :null => false
+    t.boolean  "reflection",                   :default => false
+    t.integer  "clicks",                       :default => 0,     :null => false
+    t.integer  "link_post_id"
+  end
+
+  add_index "topic_links", ["topic_id", "post_id", "url"], :name => "index_forum_thread_links_on_forum_thread_id_and_post_id_and_url", :unique => true
+  add_index "topic_links", ["topic_id"], :name => "index_forum_thread_links_on_forum_thread_id"
+
+  create_table "topic_users", :id => false, :force => true do |t|
+    t.integer  "user_id",                                     :null => false
+    t.integer  "topic_id",                                    :null => false
+    t.boolean  "starred",                  :default => false, :null => false
+    t.boolean  "posted",                   :default => false, :null => false
+    t.integer  "last_read_post_number"
+    t.integer  "seen_post_count"
+    t.datetime "starred_at"
+    t.datetime "last_visited_at"
+    t.datetime "first_visited_at"
+    t.integer  "notification_level",       :default => 1,     :null => false
+    t.datetime "notifications_changed_at"
+    t.integer  "notifications_reason_id"
+    t.integer  "total_msecs_viewed",       :default => 0,     :null => false
+  end
+
+  add_index "topic_users", ["topic_id", "user_id"], :name => "index_forum_thread_users_on_forum_thread_id_and_user_id", :unique => true
+
+# Could not dump table "topics" because of following StandardError
+#   Unknown type 'hstore' for column 'meta_data'
+
+  create_table "twitter_user_infos", :force => true do |t|
+    t.integer  "user_id",         :null => false
+    t.string   "screen_name",     :null => false
+    t.integer  "twitter_user_id", :null => false
+    t.datetime "created_at",      :null => false
+    t.datetime "updated_at",      :null => false
+  end
+
+  add_index "twitter_user_infos", ["twitter_user_id"], :name => "index_twitter_user_infos_on_twitter_user_id", :unique => true
+  add_index "twitter_user_infos", ["user_id"], :name => "index_twitter_user_infos_on_user_id", :unique => true
 
   create_table "uploads", :force => true do |t|
     t.integer  "user_id",           :null => false
-    t.integer  "forum_thread_id",   :null => false
+    t.integer  "topic_id",          :null => false
     t.string   "original_filename", :null => false
     t.integer  "filesize",          :null => false
     t.integer  "width"
@@ -264,8 +390,23 @@ ActiveRecord::Schema.define(:version => 20120809201855) do
     t.datetime "updated_at",        :null => false
   end
 
-  add_index "uploads", ["forum_thread_id"], :name => "index_uploads_on_forum_thread_id"
+  add_index "uploads", ["topic_id"], :name => "index_uploads_on_forum_thread_id"
   add_index "uploads", ["user_id"], :name => "index_uploads_on_user_id"
+
+  create_table "user_actions", :force => true do |t|
+    t.integer  "action_type",     :null => false
+    t.integer  "user_id",         :null => false
+    t.integer  "target_topic_id"
+    t.integer  "target_post_id"
+    t.integer  "target_user_id"
+    t.integer  "acting_user_id"
+    t.datetime "created_at",      :null => false
+    t.datetime "updated_at",      :null => false
+  end
+
+  add_index "user_actions", ["acting_user_id"], :name => "index_actions_on_acting_user_id"
+  add_index "user_actions", ["action_type", "user_id", "target_topic_id", "target_post_id", "acting_user_id"], :name => "idx_unique_rows", :unique => true
+  add_index "user_actions", ["user_id", "action_type"], :name => "index_actions_on_user_id_and_action_type"
 
   create_table "user_open_ids", :force => true do |t|
     t.integer  "user_id",    :null => false
@@ -278,26 +419,52 @@ ActiveRecord::Schema.define(:version => 20120809201855) do
 
   add_index "user_open_ids", ["url"], :name => "index_user_open_ids_on_url"
 
+  create_table "user_visits", :force => true do |t|
+    t.integer "user_id",    :null => false
+    t.date    "visited_at", :null => false
+  end
+
+  add_index "user_visits", ["user_id", "visited_at"], :name => "index_user_visits_on_user_id_and_visited_at", :unique => true
+
   create_table "users", :force => true do |t|
-    t.string   "username",             :limit => 20,                     :null => false
-    t.string   "avatar_url",                                             :null => false
-    t.datetime "created_at",                                             :null => false
-    t.datetime "updated_at",                                             :null => false
+    t.string   "username",                      :limit => 20,                     :null => false
+    t.datetime "created_at",                                                      :null => false
+    t.datetime "updated_at",                                                      :null => false
     t.string   "name"
-    t.text     "bio"
-    t.integer  "seen_notificaiton_id",                :default => 0,     :null => false
+    t.text     "bio_raw"
+    t.integer  "seen_notification_id",                         :default => 0,     :null => false
     t.datetime "last_posted_at"
-    t.string   "email",                :limit => 256,                    :null => false
-    t.string   "password_hash",        :limit => 64
-    t.string   "salt",                 :limit => 32
+    t.string   "email",                         :limit => 256,                    :null => false
+    t.string   "password_hash",                 :limit => 64
+    t.string   "salt",                          :limit => 32
     t.boolean  "active"
-    t.string   "username_lower",       :limit => 20,                     :null => false
-    t.string   "auth_token",           :limit => 32
+    t.string   "username_lower",                :limit => 20,                     :null => false
+    t.string   "auth_token",                    :limit => 32
     t.datetime "last_seen_at"
     t.string   "website"
-    t.string   "email_token",          :limit => 32
-    t.boolean  "admin",                               :default => false, :null => false
-    t.boolean  "moderator",                           :default => false, :null => false
+    t.boolean  "admin",                                        :default => false, :null => false
+    t.datetime "last_emailed_at"
+    t.boolean  "email_digests",                                :default => true,  :null => false
+    t.integer  "trust_level",                                                     :null => false
+    t.text     "bio_cooked"
+    t.boolean  "email_private_messages",                       :default => true
+    t.boolean  "email_direct",                                 :default => true,  :null => false
+    t.boolean  "approved",                                     :default => false, :null => false
+    t.integer  "approved_by_id"
+    t.datetime "approved_at"
+    t.integer  "topics_entered",                               :default => 0,     :null => false
+    t.integer  "posts_read_count",                             :default => 0,     :null => false
+    t.integer  "digest_after_days",                            :default => 7,     :null => false
+    t.datetime "previous_visit_at"
+    t.datetime "banned_at"
+    t.datetime "banned_till"
+    t.date     "date_of_birth"
+    t.integer  "auto_track_topics_after_msecs"
+    t.integer  "views",                                        :default => 0,     :null => false
+    t.integer  "flag_level",                                   :default => 0,     :null => false
+    t.integer  "time_read",                                    :default => 0,     :null => false
+    t.integer  "days_visited",                                 :default => 0,     :null => false
+    t.string   "ip_address",                    :limit => nil
   end
 
   add_index "users", ["auth_token"], :name => "index_users_on_auth_token"
@@ -305,6 +472,13 @@ ActiveRecord::Schema.define(:version => 20120809201855) do
   add_index "users", ["last_posted_at"], :name => "index_users_on_last_posted_at"
   add_index "users", ["username"], :name => "index_users_on_username", :unique => true
   add_index "users", ["username_lower"], :name => "index_users_on_username_lower", :unique => true
+
+  create_table "users_search", :id => false, :force => true do |t|
+    t.integer  "id",          :null => false
+    t.tsvector "search_data"
+  end
+
+  add_index "users_search", ["search_data"], :name => "idx_search_user"
 
   create_table "versions", :force => true do |t|
     t.integer  "versioned_id"
@@ -328,14 +502,13 @@ ActiveRecord::Schema.define(:version => 20120809201855) do
   add_index "versions", ["versioned_id", "versioned_type"], :name => "index_versions_on_versioned_id_and_versioned_type"
 
   create_table "views", :id => false, :force => true do |t|
-    t.integer  "parent_id",                 :null => false
-    t.string   "parent_type", :limit => 50, :null => false
-    t.integer  "ip",          :limit => 8,  :null => false
-    t.datetime "viewed_at",                 :null => false
-    t.integer  "user_id"
+    t.integer "parent_id",                 :null => false
+    t.string  "parent_type", :limit => 50, :null => false
+    t.integer "ip",          :limit => 8,  :null => false
+    t.date    "viewed_at",                 :null => false
+    t.integer "user_id"
   end
 
-  add_index "views", ["parent_id", "parent_type", "ip", "viewed_at"], :name => "unique_views", :unique => true
   add_index "views", ["parent_id", "parent_type"], :name => "index_views_on_parent_id_and_parent_type"
 
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -78,7 +78,7 @@ CREATE TABLE categories (
 --
 
 CREATE SEQUENCE categories_id_seq
-    START WITH 5
+    START WITH 1
     INCREMENT BY 1
     NO MINVALUE
     NO MAXVALUE
@@ -153,7 +153,7 @@ CREATE TABLE draft_sequences (
 --
 
 CREATE SEQUENCE draft_sequences_id_seq
-    START WITH 20
+    START WITH 1
     INCREMENT BY 1
     NO MINVALUE
     NO MAXVALUE
@@ -187,7 +187,7 @@ CREATE TABLE drafts (
 --
 
 CREATE SEQUENCE drafts_id_seq
-    START WITH 2
+    START WITH 1
     INCREMENT BY 1
     NO MINVALUE
     NO MAXVALUE
@@ -220,7 +220,7 @@ CREATE TABLE email_logs (
 --
 
 CREATE SEQUENCE email_logs_id_seq
-    START WITH 3
+    START WITH 1
     INCREMENT BY 1
     NO MINVALUE
     NO MAXVALUE
@@ -255,7 +255,7 @@ CREATE TABLE email_tokens (
 --
 
 CREATE SEQUENCE email_tokens_id_seq
-    START WITH 3
+    START WITH 1
     INCREMENT BY 1
     NO MINVALUE
     NO MAXVALUE
@@ -469,7 +469,7 @@ CREATE TABLE post_action_types (
 --
 
 CREATE SEQUENCE post_action_types_id_seq
-    START WITH 6
+    START WITH 1
     INCREMENT BY 1
     NO MINVALUE
     NO MAXVALUE
@@ -592,7 +592,7 @@ CREATE TABLE posts (
 --
 
 CREATE SEQUENCE posts_id_seq
-    START WITH 16
+    START WITH 1
     INCREMENT BY 1
     NO MINVALUE
     NO MAXVALUE
@@ -664,7 +664,7 @@ CREATE TABLE site_settings (
 --
 
 CREATE SEQUENCE site_settings_id_seq
-    START WITH 4
+    START WITH 1
     INCREMENT BY 1
     NO MINVALUE
     NO MAXVALUE
@@ -696,7 +696,7 @@ CREATE TABLE topic_allowed_users (
 --
 
 CREATE SEQUENCE topic_allowed_users_id_seq
-    START WITH 3
+    START WITH 1
     INCREMENT BY 1
     NO MINVALUE
     NO MAXVALUE
@@ -886,7 +886,7 @@ CREATE TABLE topics (
 --
 
 CREATE SEQUENCE topics_id_seq
-    START WITH 16
+    START WITH 1
     INCREMENT BY 1
     NO MINVALUE
     NO MAXVALUE
@@ -1023,7 +1023,7 @@ CREATE TABLE user_actions (
 --
 
 CREATE SEQUENCE user_actions_id_seq
-    START WITH 40
+    START WITH 1
     INCREMENT BY 1
     NO MINVALUE
     NO MAXVALUE
@@ -1087,7 +1087,7 @@ CREATE TABLE user_visits (
 --
 
 CREATE SEQUENCE user_visits_id_seq
-    START WITH 4
+    START WITH 1
     INCREMENT BY 1
     NO MINVALUE
     NO MAXVALUE
@@ -1145,7 +1145,7 @@ CREATE TABLE users (
 --
 
 CREATE SEQUENCE users_id_seq
-    START WITH 3
+    START WITH 1
     INCREMENT BY 1
     NO MINVALUE
     NO MAXVALUE


### PR DESCRIPTION
Several migrations were failing when running db:migrate at the initial release version from an empty database.  These changes took out statements that were causing migrations to fail, usually because of references to models that no longer exist.

Understood that the vagrant vm is kinda unofficially the only thing recommended at this stage, but it was trivial to get db:migrate to move with no problems, and all tests green from a working rvm/ruby and postgres.app on OS X 10.7.

Added `CREATE EXTENSION hstore` to the meta data migration, as that was missing when running postgres via postgres.app.
