### PR TITLE
workaround a bundler crash during 'bundle install'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,8 @@
+if RUBY_VERSION =~ /1.9/
+  Encoding.default_external = Encoding::UTF_8
+  Encoding.default_internal = Encoding::UTF_8
+end
+
 source 'https://rubygems.org'
 
 gem 'redis'


### PR DESCRIPTION
on ubuntu 12.04 and its native ruby-1.9.3 package, 'bundle install' leads to an encoding error. the fix suggested at http://stackoverflow.com/a/13650994 works.
