### PR TITLE
Allow mixed-case emails when creating an account

### DIFF
--- a/app/assets/javascripts/discourse/components/utilities.coffee
+++ b/app/assets/javascripts/discourse/components/utilities.coffee
@@ -46,7 +46,7 @@ Discourse.Utilities =
 
   emailValid: (email)->
     # see:  http://stackoverflow.com/questions/46155/validate-email-address-in-javascript
-    re = /^[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/
+    re = /^[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/i
     re.test(email)
 
   selectedText: ->


### PR DESCRIPTION
This one's for casperOne
