### PR TITLE
Split -vendor-placeholder selector by vendor.

### DIFF
--- a/app/assets/stylesheets/vendor/bootstrap.css.scss
+++ b/app/assets/stylesheets/vendor/bootstrap.css.scss
@@ -1418,7 +1418,13 @@ body {
     -moz-box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.025);
     box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.025);
   }
-  :-moz-placeholder, :-ms-input-placeholder, ::-webkit-input-placeholder {
+  :-moz-placeholder {
+    color: #999999;
+  }
+  ::-webkit-input-placeholder {
+    color: #999999;
+  }
+  :-ms-input-placeholder {
     color: #999999;
   }
   .help-block, .help-inline {


### PR DESCRIPTION
Some browsers (specifically Firefox(18) that I know of) fail to select
correctly if the selectors are combined. This was fixed in bootstrap
(https://github.com/twitter/bootstrap/blob/master/less/forms.less#L210).
Not sure of the exact commit but there is a nice comment.

This is related to http://meta.discourse.org/t/compose-forms-inline-labels-not-properly-ghosted/1326

I have signed the CLA.
