### PR TITLE
fix a syntax error in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,20 +32,20 @@ gem 'rack-mini-profiler', :git => 'git://github.com/SamSaffron/MiniProfiler'
 gem 'oauth', :require => false
 gem 'fast_xs'
 gem 'pbkdf2'
-gem 'simple_handlebars_rails', path: 'vendor/gems/simple_handlebars_rails'
+gem 'simple_handlebars_rails', :path => 'vendor/gems/simple_handlebars_rails'
 
 # Gem that enables support for plugins. It is required
-gem 'discourse_plugin', path: 'vendor/gems/discourse_plugin'
+gem 'discourse_plugin', :path => 'vendor/gems/discourse_plugin'
 
 # Discourse Plugins (optional)
 # Polls and Tasks have been disabled for launch, we need think all sorts of stuff through before adding them back in
 #   biggest concern is core support for custom sort orders, but there is also styling that just gets mishmashed into our core theme. 
-# gem 'discourse_poll', path: 'vendor/gems/discourse_poll'
-gem 'discourse_emoji', path: 'vendor/gems/discourse_emoji'
-# gem 'discourse_task', path: 'vendor/gems/discourse_task'
+# gem 'discourse_poll', :path => 'vendor/gems/discourse_poll'
+gem 'discourse_emoji', :path => 'vendor/gems/discourse_emoji'
+# gem 'discourse_task', :path => 'vendor/gems/discourse_task'
 
-gem 'rails_multisite', path: 'vendor/gems/rails_multisite'
-gem 'message_bus', path: 'vendor/gems/message_bus'
+gem 'rails_multisite', :path => 'vendor/gems/rails_multisite'
+gem 'message_bus', :path => 'vendor/gems/message_bus'
 
 gem 'koala', :require => false
 gem 'multi_json'


### PR DESCRIPTION
this happened for me on macosx + homebrew ruby1.9 + latest bundler.

```
$ bundle install
/Users/sridharr/as/s/discourse/Gemfile:35:in `evaluate': compile error
/Users/sridharr/as/s/discourse/Gemfile:35: syntax error, unexpected ':', expecting $end
...imple_handlebars_rails', path: 'vendor/gems/simple_handlebar...
                              ^ (SyntaxError)
       /Library/Ruby/Gems/1.8/gems/bundler-1.1.5/lib/bundler/definition.rb:18:in `build'
       /Library/Ruby/Gems/1.8/gems/bundler-1.1.5/lib/bundler.rb:135:in `definition'
       /Library/Ruby/Gems/1.8/gems/bundler-1.1.5/lib/bundler/cli.rb:220:in `install'
       /Library/Ruby/Gems/1.8/gems/bundler-1.1.5/lib/bundler/vendor/thor/task.rb:22:in `send'
       /Library/Ruby/Gems/1.8/gems/bundler-1.1.5/lib/bundler/vendor/thor/task.rb:22:in `run'
       /Library/Ruby/Gems/1.8/gems/bundler-1.1.5/lib/bundler/vendor/thor/invocation.rb:118:in `invoke_task'
       /Library/Ruby/Gems/1.8/gems/bundler-1.1.5/lib/bundler/vendor/thor.rb:263:in `dispatch'
       /Library/Ruby/Gems/1.8/gems/bundler-1.1.5/lib/bundler/vendor/thor/base.rb:386:in `start'
       /Library/Ruby/Gems/1.8/gems/bundler-1.1.5/bin/bundle:13
       /usr/bin/bundle:19:in `load'
       /usr/bin/bundle:19
There was an error in your Gemfile, and Bundler cannot continue.
```
