### PR TITLE
initial rake db:migrate was failing if hstore was already set

### DIFF
--- a/db/migrate/20120921162512_add_meta_data_to_forum_threads.rb
+++ b/db/migrate/20120921162512_add_meta_data_to_forum_threads.rb
@@ -1,6 +1,6 @@
 class AddMetaDataToForumThreads < ActiveRecord::Migration
   def change
-    execute "CREATE EXTENSION IF NOT EXITS hstore" 
+    execute "CREATE EXTENSION IF NOT EXISTS hstore" 
     add_column :forum_threads, :meta_data, :hstore
   end
 end


### PR DESCRIPTION
- changed migration to account for hstore, and was able to complete full rake:db migrate with a fresh install
