### PR TITLE
Strip leading and trailing slug punctuation.

### DIFF
--- a/lib/slug.rb
+++ b/lib/slug.rb
@@ -23,6 +23,7 @@ module Slug
     str.gsub!(/[^a-z0-9 -]/, '')
     str.gsub!(/\s+/, '-')
     str.gsub!(/\-+/, '-')
+    str.gsub!(/^-|-$/, '')
 
     str
   end

--- a/spec/components/slug_spec.rb
+++ b/spec/components/slug_spec.rb
@@ -27,6 +27,13 @@ describe Slug do
     Slug.for("a....b.....c").should == "a-b-c"
   end
 
+  it 'strips trailing punctuation' do
+    Slug.for("hello...").should == "hello"
+  end
+
+  it 'strips leading punctuation' do
+    Slug.for("...hello").should == "hello"
+  end
 
 end
 


### PR DESCRIPTION
Reported by [BhaelOchon](http://meta.discourse.org/users/BhaelOchon) in meta thread ["Not all trailing hyphens trimmed from topic URLs"](http://meta.discourse.org/t/not-all-trailing-hyphens-trimmed-from-topic-urls/1555).

![](http://cdn.discourse.org/uploads/meta_discourse/99/blob.png)
