### PR TITLE
Added TravisCI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,6 @@ rvm:
   - 1.9.3
 before_script:
   - psql -c 'create database discourse_test;' -U postgres
+  - rake db:migrate
 services:
   - redis-server


### PR DESCRIPTION
I've added .travis.yml file to the project that will allow using TravisCI. I'm not sure what kind of CI you use internally, but this will be useful for the community, as it is publicly visible and will run on every pull request.

Here's a sample build run: https://travis-ci.org/arikfr/discourse/builds/4649833

To actually enable TravisCI:
1. Merge this pull request.
2. [Setup the service hook](http://about.travis-ci.org/docs/user/getting-started/#Step-two%3A-Activate-GitHub-Service-Hook)

I've added the `rake db:migrate` task to run before each build, as was instructed in the project README file, but I think that in the long run it will be better to do something like `db:schema:load`.

Some more details:
Currently it runs the builds with only Ruby 1.9.3. Travis can be setup to run the builds with different versions of Ruby -- let me know if you think other versions should be added to the default builds.

(I've signed the CLA)
