### PR TITLE
Added travis-ci build status image

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ This vision translates to the following functional commitments:
 
 ## Contributing
 
+[![Build Status](https://travis-ci.org/discourse/discourse.png)](https://travis-ci.org/discourse/discourse)
+
 Discourse is **100% free** and **open-source**. We encourage and support an active, healthy community that
 accepts contributions from the public, and we'd like you to be a part of that community.
 


### PR DESCRIPTION
Now that discourse is using travis-ci, why not show the build status right in the README?

Note: not sure where to place it...

Documentation is over here: http://about.travis-ci.org/docs/user/status-images/
