### PR TITLE
use shared_examples_for versioning for posts, topics

### DIFF
--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -21,6 +21,7 @@ describe Post do
     {user: topic.user, topic: topic} 
   end
 
+  it_behaves_like "a versioned model"
 
   describe 'post uniqueness' do
 
@@ -263,10 +264,6 @@ describe Post do
 
     let(:post) { Fabricate(:post, post_args) }
     let(:first_version_at) { post.last_version_at }
-
-    it 'has an initial version of 1' do
-      post.cached_version.should == 1
-    end
 
     it 'has one version in all_versions' do
       post.all_versions.size.should == 1

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -23,6 +23,8 @@ describe Topic do
 
   it { should rate_limit }
 
+  it_behaves_like "a versioned model"
+
   context '.title_quality' do
 
     it "strips a title when identifying length" do

--- a/spec/support/versioning/shared_examples_for_versioned_model.rb
+++ b/spec/support/versioning/shared_examples_for_versioned_model.rb
@@ -1,0 +1,12 @@
+shared_examples_for "a versioned model" do
+  let(:model) { Fabricate(described_class.to_s.downcase) }
+  let(:first_version_at) { model.last_version_at }
+
+  it 'should be versioned' do
+    model.should respond_to(:version)
+  end
+
+  it 'has an initial version of 1' do
+    model.version.should == 1
+  end
+end


### PR DESCRIPTION
I'll be submitting a larger pull request to start thinning up the Post model, but I can at least peel this part away now.  Both posts and topics are versioned, so it makes sense for them to use shared_examples_for versioning.

All specs pass.
