### PR TITLE
Button container should be no wider than suggested topics

### DIFF
--- a/app/assets/stylesheets/application/topic.css.scss
+++ b/app/assets/stylesheets/application/topic.css.scss
@@ -272,9 +272,9 @@
   #topic-footer-buttons {
     margin: 20px 0 0 103px;
 
-    width: 1110px;
-    @include medium-width { width: 970px; }
-    @include small-width { width: 870px; }
+    width: 1027px;
+    @include medium-width { width: 887px; }
+    @include small-width { width: 787px; }
 
     .btn-group {
       margin-top: 20px;


### PR DESCRIPTION
The button container sticks out farther than necessary because of the
left margin, causing unnecessary horizontal scrolling at supported
resolutions
