### PR TITLE
Twitter oauth login failing: fix for javascript error

### DIFF
--- a/spec/views/facebook/complete.html.erb_spec.rb
+++ b/spec/views/facebook/complete.html.erb_spec.rb
@@ -1,0 +1,15 @@
+require "spec_helper"
+
+describe "facebook/complete.html.erb" do
+  it "renders data " do
+    assign(:data, {:username =>"username", :auth_provider=>"Facebook", :awaiting_activation=>true})
+
+    render
+
+    rendered_data = JSON.parse(rendered.match(/window.opener.Discourse.authenticationComplete\((.*)\)/)[1])
+
+    rendered_data["username"].should eq("username")
+    rendered_data["auth_provider"].should eq("Facebook")
+    rendered_data["awaiting_activation"].should eq(true)
+  end
+end

--- a/spec/views/twitter/complete.html.erb_spec.rb
+++ b/spec/views/twitter/complete.html.erb_spec.rb
@@ -1,0 +1,15 @@
+require "spec_helper"
+
+describe "twitter/complete.html.erb" do
+  it "renders data " do
+    assign(:data, {:username =>"username", :auth_provider=>"Twitter", :awaiting_activation=>true})
+
+    render
+
+    rendered_data = JSON.parse(rendered.match(/window.opener.Discourse.authenticationComplete\((.*)\)/)[1])
+
+    rendered_data["username"].should eq("username")
+    rendered_data["auth_provider"].should eq("Twitter")
+    rendered_data["awaiting_activation"].should eq(true)
+  end
+end

--- a/spec/views/user_open_ids/complete.html.erb_spec.rb
+++ b/spec/views/user_open_ids/complete.html.erb_spec.rb
@@ -1,0 +1,15 @@
+require "spec_helper"
+
+describe "user_open_ids/complete.html.erb" do
+  it "renders data " do
+    assign(:data, {:username =>"username", :auth_provider=>"OpenId", :awaiting_activation=>true})
+
+    render
+
+    rendered_data = JSON.parse(rendered.match(/window.opener.Discourse.authenticationComplete\((.*)\)/)[1])
+
+    rendered_data["username"].should eq("username")
+    rendered_data["auth_provider"].should eq("OpenId")
+    rendered_data["awaiting_activation"].should eq(true)
+  end
+end


### PR DESCRIPTION
Twitter login is currently failing because of html-escaping in the twitter/complete view; simple fix to mark data as `html_safe`.

![twitter oauth](https://www.evernote.com/shard/s111/sh/c5dafd76-4fe2-4f94-996c-1acaa8b1b643/2951c83b6c375a4b3cde9b3c272250bf/res/c38d2cde-dce0-4111-915a-9da5a785903b/skitch.png?resizeSmall&width=832)
