### PR TITLE
Extracted default value initializers.

### DIFF
--- a/lib/discourse_plugin_registry.rb
+++ b/lib/discourse_plugin_registry.rb
@@ -9,10 +9,21 @@ class DiscoursePluginRegistry
     attr_accessor :stylesheets
   end
 
-  def register_js(filename, options={})
-    self.class.javascripts ||= Set.new
-    self.class.server_side_javascripts ||= Set.new
+  # Default accessor values
+  #
+  def self.stylesheets
+    @stylesheets ||= Set.new
+  end
+  
+  def self.javascripts
+    @javascripts ||= Set.new
+  end
+  
+  def self.server_side_javascripts
+    @server_side_javascripts ||= Set.new
+  end
 
+  def register_js(filename, options={})
     # If we have a server side option, add that too.
     self.class.server_side_javascripts << options[:server_side] if options[:server_side].present?
 
@@ -20,12 +31,11 @@ class DiscoursePluginRegistry
   end
 
   def register_css(filename)
-    self.class.stylesheets ||= Set.new
     self.class.stylesheets << filename
   end
 
   def stylesheets
-    self.class.stylesheets || Set.new
+    self.class.stylesheets
   end
 
   def register_archetype(name, options={})
@@ -33,17 +43,17 @@ class DiscoursePluginRegistry
   end
 
   def server_side_javascripts
-    self.class.javascripts || Set.new
+    self.class.javascripts
   end
 
   def javascripts
-    self.class.javascripts || Set.new
+    self.class.javascripts
   end
 
   def self.clear
-    self.stylesheets = Set.new
-    self.server_side_javascripts = Set.new
-    self.javascripts = Set.new
+    self.stylesheets = nil
+    self.server_side_javascripts = nil
+    self.javascripts = nil
   end
 
   def self.setup(plugin_class)    
@@ -51,7 +61,5 @@ class DiscoursePluginRegistry
     plugin = plugin_class.new(registry)
     plugin.setup
   end
-
-
 
 end

--- a/spec/components/discourse_plugin_registry_spec.rb
+++ b/spec/components/discourse_plugin_registry_spec.rb
@@ -4,6 +4,27 @@ require 'discourse_plugin_registry'
 describe DiscoursePluginRegistry do
 
   let(:registry) { DiscoursePluginRegistry.new }
+  
+  context '#stylesheets' do
+    it 'defaults to an empty Set' do
+      DiscoursePluginRegistry.stylesheets = nil
+      DiscoursePluginRegistry.stylesheets.should == Set.new
+    end
+  end
+
+  context '#javascripts' do
+    it 'defaults to an empty Set' do
+      DiscoursePluginRegistry.javascripts = nil
+      DiscoursePluginRegistry.javascripts.should == Set.new
+    end
+  end
+
+  context '#server_side_javascripts' do
+    it 'defaults to an empty Set' do
+      DiscoursePluginRegistry.server_side_javascripts = nil
+      DiscoursePluginRegistry.server_side_javascripts.should == Set.new
+    end
+  end
 
   context '.register_css' do
     before do


### PR DESCRIPTION
[Issue #73 undefined method `each' for nil:NilClass in application.css.erb](https://github.com/discourse/discourse/issues/73) brought to light the aspect that `DiscoursePluginRegistry` class-level accessors are not set to default values until their matching instance methods are called.

So I extracted the initialization.

In other words, where there once was this behavior:

``` ruby
DiscoursePluginRegistry.stylesheets = nil
DiscoursePluginRegistry.stylesheets #=> nil
DiscoursePluginRegistry.new.stylesheets
DiscoursePluginRegistry.stylesheets #=> Set.new
```

...there is now this behavior which I believe is intended:

``` ruby
DiscoursePluginRegistry.stylesheets = nil
DiscoursePluginRegistry.stylesheets #=> Set.new
```
