### PR TITLE
Correcting link to Mailcatcher

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -70,7 +70,7 @@ Wait a minute while it runs all our unit tests. Once it has completed, live relo
 
 ### Sending Email
 
-Mailcatcher is used to avoid the whole issue of actually sending emails: https://github.com/sj26/mailcatcher5
+Mailcatcher is used to avoid the whole issue of actually sending emails: https://github.com/sj26/mailcatcher
 
 To start mailcatcher, run the following command in the vagrant image:
 


### PR DESCRIPTION
The link to Mailcatcher was broken in DEVELOPMENT.md. Quick fix.

Already signed the CLA.
