### PR TITLE
Instruct developers to prepare the test DB before launching guard

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -62,6 +62,7 @@ To use it, follow all the above steps. Once rails is running, open a new termina
 
 ```
 vagrant ssh
+bundle exec rake db:test:prepare
 bundle exec guard -p
 ```
 


### PR DESCRIPTION
Just a reminder to prepare the test DB before running the specs.
