### PR TITLE
Prevent Firefox from using the wrong placeholder colour

### DIFF
--- a/app/assets/stylesheets/vendor/bootstrap.css.scss
+++ b/app/assets/stylesheets/vendor/bootstrap.css.scss
@@ -1419,7 +1419,7 @@ body {
     box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.025);
   }
   :-moz-placeholder {
-    color: #999999;
+    color: #999999 !important;
   }
   ::-webkit-input-placeholder {
     color: #999999;


### PR DESCRIPTION
Firefox will use the field's `color:` value as the colour for the placeholder text in cases where the field's text colour is defined under a more specific selector than `:-moz-placeholder`. Throwing an `!important` on there is the easiest fix. 
