### PR TITLE
fix user listing and search on non-US locale

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -3,7 +3,7 @@ class Admin::UsersController < Admin::AdminController
   def index
     # Sort order
     if params[:query] == "active"
-      @users = User.order("COALESCE(last_seen_at, '01-01-1970') DESC, username")
+      @users = User.order("COALESCE(last_seen_at, '1970-01-01') DESC, username")
     else
       @users = User.order("created_at DESC, username")
     end

--- a/lib/search.rb
+++ b/lib/search.rb
@@ -21,7 +21,7 @@ module Search
                   NULL AS color
           FROM users AS u
           JOIN users_search s on s.id = u.id
-          WHERE s.search_data @@ TO_TSQUERY(:query)
+          WHERE s.search_data @@ TO_TSQUERY('english', :query)
           ORDER BY last_posted_at desc
     "
   end
@@ -36,13 +36,13 @@ module Search
     FROM topics AS ft
       JOIN posts AS p ON p.topic_id = ft.id AND p.post_number = 1
       JOIN posts_search s on s.id = p.id
-    WHERE s.search_data @@ TO_TSQUERY(:query)
+    WHERE s.search_data @@ TO_TSQUERY('english', :query)
       AND ft.deleted_at IS NULL
       AND ft.visible
       AND ft.archetype <> '#{Archetype.private_message}'
     ORDER BY 
-            TS_RANK_CD(TO_TSVECTOR('english', ft.title), TO_TSQUERY(:query)) desc,
-            TS_RANK_CD(search_data, TO_TSQUERY(:query)) desc,
+            TS_RANK_CD(TO_TSVECTOR('english', ft.title), TO_TSQUERY('english', :query)) desc,
+            TS_RANK_CD(search_data, TO_TSQUERY('english', :query)) desc,
             bumped_at desc"
   end  
 
@@ -57,13 +57,13 @@ module Search
     FROM topics AS ft
       JOIN posts AS p ON p.topic_id = ft.id AND p.post_number <> 1
       JOIN posts_search s on s.id = p.id
-    WHERE s.search_data @@ TO_TSQUERY(:query)
+    WHERE s.search_data @@ TO_TSQUERY('english', :query)
       AND ft.deleted_at IS NULL and p.deleted_at IS NULL
       AND ft.visible
       AND ft.archetype <> '#{Archetype.private_message}'
     ORDER BY 
-            TS_RANK_CD(TO_TSVECTOR('english', ft.title), TO_TSQUERY(:query)) desc,
-            TS_RANK_CD(search_data, TO_TSQUERY(:query)) desc,
+            TS_RANK_CD(TO_TSVECTOR('english', ft.title), TO_TSQUERY('english', :query)) desc,
+            TS_RANK_CD(search_data, TO_TSQUERY('english', :query)) desc,
             bumped_at desc" 
   end  
 
@@ -76,7 +76,7 @@ module Search
             c.color
     FROM categories AS c
     JOIN categories_search s on s.id = c.id
-    WHERE s.search_data @@ TO_TSQUERY(:query)
+    WHERE s.search_data @@ TO_TSQUERY('english', :query)
     ORDER BY topics_month desc
     "
   end


### PR DESCRIPTION
This commit fixes two issues that appear on systems with non-US:
- Trying to show the list of users (as admin) fails when Postgre is complaining that it does not understand the date format "01-01-1970". I changed that to the ISO format, "1970-01-01".
- Search is broken and it does not find words that are clearly present. This also causes several tests in spec/components/search_spec.rb to fail. I fixed that by forcing the "english" config (stemmer), because discourse is using this config anyway on other places, e.g. when updating the search index.
