### PR TITLE
Some mobile optimisations - mainly for the header.

### DIFF
--- a/app/assets/stylesheets/application/discourse.css.scss
+++ b/app/assets/stylesheets/application/discourse.css.scss
@@ -307,4 +307,3 @@ blockquote {
 .profiler-results.profiler-left {
   top: 60px !important;
 }
-

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title><%=t :title%></title>
-    <meta content="width=device-width, initial-scale=1.0" name="viewport">
+    <meta name="viewport" content="target-densitydpi=device-dpi, width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0" />
     <meta content="" name="description">
     <meta content="" name="author">
     <%- 


### PR DESCRIPTION
This sets the container width to 100% under 966px and adds some padding - the header is now formatted appropriately for mobile.
