### PR TITLE
Prevent click from being trapped in the editor field

### DIFF
--- a/app/assets/javascripts/discourse/controllers/composer_controller.js.coffee
+++ b/app/assets/javascripts/discourse/controllers/composer_controller.js.coffee
@@ -129,7 +129,6 @@ window.Discourse.ComposerController = Ember.Controller.extend Discourse.Presence
   click: ->
     if @get('content.composeState') == Discourse.Composer.DRAFT
       @set('content.composeState', Discourse.Composer.OPEN)
-    false
 
   shrink: ->
     if @get('content.reply') == @get('content.originalText') then @close() else @collapse()


### PR DESCRIPTION
Fixes [issue where enter stops working in editor](http://meta.discourse.org/t/enter-key-doesnt-work-when-search-window-open-repro-inside/1545) when search box is open. The other option would be to selectively stop intercepting <kbd>enter</kbd>, but closing the search box like would happen when you click elsewhere seems more intuitive.

I don't _think_ that `false` is necessary anywhere else, but if for whatever reason it is it's possible to switch the composer view to explicitly return `true` after calling the controller `click()` instead.
