### PR TITLE
Reduce z-index on reply tab so it's below the share box

### DIFF
--- a/app/assets/stylesheets/application/topic-post.css.scss
+++ b/app/assets/stylesheets/application/topic-post.css.scss
@@ -347,7 +347,7 @@
     }
   }
   .reply-to-tab {
-    z-index: 999;
+    z-index: 980;
     font-size: 12px;
     color: $darkish_gray;
     display: block;


### PR DESCRIPTION
Make sure the `z-index` of the reply tab is less than that of the share box to [prevent unintentional overlap](http://meta.discourse.org/t/weird-layer-ordering-in-ff-18-on-mountain-lion/2690).
