### PR TITLE
Fix 1px button cut off on topic progress up / down buttons.

### DIFF
--- a/app/assets/stylesheets/application/topic.css.scss
+++ b/app/assets/stylesheets/application/topic.css.scss
@@ -387,7 +387,7 @@ kbd {
     z-index: 1;
   }
   button {
-    padding: 0;
+    padding: 0 1px;
     cursor: pointer;
     z-index: 1000;
     position: absolute;


### PR DESCRIPTION
This fixes an incredibly minor issue with the up / down buttons being cut off by 1px on Chrome & Safari.

![Screen Shot 2013-02-11 at 12 02 10](https://f.cloud.github.com/assets/822528/144923/74e31b7c-7444-11e2-8d1a-c85f24c27de6.png)
