### PR TITLE
Lean on Inflector for slug transliteration.

### DIFF
--- a/lib/slug.rb
+++ b/lib/slug.rb
@@ -6,20 +6,24 @@
 module Slug
 
   def self.for(string)
-
-    str = string.dup
-    str.gsub!(/^\s+|\s+$/, '')
-    str.downcase!
-
+    str = string.dup.strip.downcase
+    
     # The characters we want to replace with a hyphen
     str.tr!("·/_,:;.", "\-")
 
     # Convert to ASCII or remove if transliteration is unknown.
     str = ActiveSupport::Inflector.transliterate(str, '')
-
+    
+    # Remove everything except alphanumberic, space, and hyphen characters.
     str.gsub!(/[^a-z0-9 -]/, '')
+    
+    # Replace multiple spaces with one hyphen.
     str.gsub!(/\s+/, '-')
+    
+    # Replace multiple hyphens with one hyphen.
     str.gsub!(/\-+/, '-')
+    
+    # Remove leading and trailing hyphens
     str.gsub!(/^-|-$/, '')
 
     str

--- a/spec/components/slug_spec.rb
+++ b/spec/components/slug_spec.rb
@@ -1,11 +1,9 @@
 # encoding: utf-8
 
 require 'spec_helper'
-
 require 'slug'
 
 describe Slug do
-
 
   it 'replaces spaces with hyphens' do
     Slug.for("hello world").should == 'hello-world'


### PR DESCRIPTION
By leaning on ActiveSupport::Inflector, the slugger is I18n-locale aware. It also saves us from reinventing the transliteration wheel, freeing us from issues like #118. 

I also included a meager cleanup to make the extraction of some sort of Slugger class obvious if this is approved.
