### PR TITLE
Set window height as maximum height of div_resizer

### DIFF
--- a/app/assets/javascripts/discourse/components/div_resizer.js.coffee
+++ b/app/assets/javascripts/discourse/components/div_resizer.js.coffee
@@ -29,6 +29,7 @@
     thisMousePos = mousePosition(e).y
     size = originalDivHeight + (originalPos - thisMousePos)
     lastMousePos = thisMousePos
+    size = Math.min(size, $(window).height())
     size = Math.max(min, size)
     div.height size + "px"
     endDrag e,opts if size < min


### PR DESCRIPTION
This fixes the issue where a user can resize the div so that grippie is
no longer visible and is not able to re-size the div back.
