### PR TITLE
Clarify the unit of time for ninja_edit_window

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -212,7 +212,7 @@ en:
     access_password: "restrict_access is enabled ensure that this password is entered"
     queue_jobs: "queue various jobs in sidekiq, if false queues are inline"
     crawl_images: "enable retrieving of images from third party sources"
-    ninja_edit_window: "how quickly you can make an edit without it saving a new version"
+    ninja_edit_window: "how quickly you can make an edit without it saving a new version, in seconds."
     enable_imgur: "enable imgur api for uploading, don't host files locally"
     imgur_api_key: "imgur.com api key - required for image upload"
     imgur_endpoint: "end point for uploading imgur.com images"


### PR DESCRIPTION
The other settings had the unit of time specified such as `active_user_rate_limit_secs` and `previous_visit_timeout_hours`; adding unit of time to `ninja_edit_window` as well.
