### PR TITLE
replace reinvention of #parameterize

### DIFF
--- a/lib/slug.rb
+++ b/lib/slug.rb
@@ -6,27 +6,7 @@
 module Slug
 
   def self.for(string)
-    str = string.dup.strip.downcase
-    
-    # The characters we want to replace with a hyphen
-    str.tr!("·/_,:;.", "\-")
-
-    # Convert to ASCII or remove if transliteration is unknown.
-    str = ActiveSupport::Inflector.transliterate(str, '')
-    
-    # Remove everything except alphanumberic, space, and hyphen characters.
-    str.gsub!(/[^a-z0-9 -]/, '')
-    
-    # Replace multiple spaces with one hyphen.
-    str.gsub!(/\s+/, '-')
-    
-    # Replace multiple hyphens with one hyphen.
-    str.gsub!(/\-+/, '-')
-    
-    # Remove leading and trailing hyphens
-    str.gsub!(/^-|-$/, '')
-
-    str
+    string.parameterize
   end
 
 end

--- a/spec/components/slug_spec.rb
+++ b/spec/components/slug_spec.rb
@@ -13,8 +13,8 @@ describe Slug do
     Slug.for('àllo').should == 'allo'
   end
 
-  it 'removes symbols' do
-    Slug.for('evil#trout').should == 'eviltrout'
+  it 'replaces symbols' do
+    Slug.for('evil#trout').should == 'evil-trout'
   end
 
   it 'handles a.b.c properly' do 


### PR DESCRIPTION
I didn't do this before because of the test: 

```
Slug.for("evil#trout").should == "eviltrout"
```

But if yall can live with this:

```
Slug.for("evil#trout").should == "evil-trout"`
```

...then we can drastically simplify the slugger instead of reinventing ActiveSupport's slugger.
