### PR TITLE
cleaned up discourse_plugin

### DIFF
--- a/vendor/gems/discourse_plugin/lib/discourse_event.rb
+++ b/vendor/gems/discourse_plugin/lib/discourse_event.rb
@@ -2,27 +2,23 @@
 # So we can execute code when things happen.
 module DiscourseEvent
 
-  class << self
+  # Defaults to a hash where default values are empty sets.
+  def self.events
+    @events ||= Hash.new { |hash, key| hash[key] = Set.new }
+  end
 
-    def trigger(event_name, *params)
-
-      return unless @events      
-      return unless event_list = @events[event_name]
-
-      event_list.each do |ev|
-        ev.call(*params)
-      end
+  def self.trigger(event_name, *params)
+    events[event_name].each do |event|
+      event.call(*params)
     end
+  end
 
-    def on(event_name, &block)
-      @events ||= {}
-      @events[event_name] ||= Set.new
-      @events[event_name] << block
-    end
+  def self.on(event_name, &block)
+    events[event_name] << block
+  end
 
-    def clear
-      @events = {}
-    end
+  def self.clear
+    @events = nil
   end
 
 end

--- a/vendor/gems/discourse_plugin/spec/discourse_event_spec.rb
+++ b/vendor/gems/discourse_plugin/spec/discourse_event_spec.rb
@@ -4,13 +4,35 @@ require 'ostruct'
 
 describe DiscourseEvent do
 
-  it "doesn't raise an error if we call an event that doesn't exist" do
-    DiscourseEvent.trigger(:missing_event)
+  describe "#events" do
+    it "defaults to {}" do
+      DiscourseEvent.instance_variable_set(:@events, nil)
+      DiscourseEvent.events.should == {}
+    end
+
+    describe "key value" do
+      it "defaults to an empty set" do
+        DiscourseEvent.events["event42"].should == Set.new
+      end
+    end
   end
 
-  context 'with an event to call' do
+  describe ".clear" do
+    it "clears out events" do
+      DiscourseEvent.events["event42"] << "test event"
+      DiscourseEvent.clear
+      DiscourseEvent.events.should be_empty
+    end
+  end
 
-    let(:harvey) { OpenStruct.new(name: 'Harvey Dent', job: 'District Attorney') }
+  context 'when calling events' do
+
+    let(:harvey) {
+      OpenStruct.new(
+        name: 'Harvey Dent',
+        job: 'District Attorney'
+      )
+    }
 
     before do
       DiscourseEvent.on(:acid_face) do |user|
@@ -18,30 +40,42 @@ describe DiscourseEvent do
       end
     end
 
-    it "doesn't raise an error" do
-      DiscourseEvent.trigger(:acid_face, harvey)      
+    context 'when event does not exist' do
+
+      it "does not raise an error" do
+        DiscourseEvent.trigger(:missing_event)
+      end
+
     end
 
-    it "chnages the name" do
-      DiscourseEvent.trigger(:acid_face, harvey)      
-      harvey.name.should == 'Two Face'
-    end
+    context 'when single event exists' do
 
-    context 'multiple events' do
-      before do
-        DiscourseEvent.on(:acid_face) do |user|
-          user.job =  'Supervillian'
-        end        
+      it "doesn't raise an error" do
         DiscourseEvent.trigger(:acid_face, harvey)
       end
 
-      it 'triggerred the email event' do
-        harvey.job.should == 'Supervillian'
-      end
-
-      it 'triggerred the username change' do
+      it "changes the name" do
+        DiscourseEvent.trigger(:acid_face, harvey)
         harvey.name.should == 'Two Face'
       end
+
+    end
+
+    context 'when multiple events exist' do
+
+      before do
+        DiscourseEvent.on(:acid_face) do |user|
+          user.job =  'Supervillian'
+        end
+
+        DiscourseEvent.trigger(:acid_face, harvey)
+      end
+
+      it 'triggers both events' do
+        harvey.job.should == 'Supervillian'
+        harvey.name.should == 'Two Face'
+      end
+
     end
 
   end

--- a/vendor/gems/discourse_plugin/spec/discourse_plugin_spec.rb
+++ b/vendor/gems/discourse_plugin/spec/discourse_plugin_spec.rb
@@ -5,10 +5,21 @@ require 'ostruct'
 describe DiscoursePlugin do
 
   class TestPlugin < DiscoursePlugin
+    module SomeModule
+    end
+
+    module TestMixin
+    end
   end
 
   let(:registry) { mock }
   let(:plugin) { TestPlugin.new(registry) }
+
+  describe ".mixins" do
+    it "finds its mixins" do
+      TestPlugin.mixins.should == [TestPlugin::TestMixin]
+    end
+  end
 
   it "delegates adding js to the registry" do
     registry.expects(:register_js).with('test.js', any_parameters)
@@ -37,6 +48,5 @@ describe DiscoursePlugin do
     end
 
   end
-
 
 end


### PR DESCRIPTION
While working on a plugin, I found some low-hanging fruit.
- fixed whitespace
- added default `@events` hash and default `Set.new` key-values which removes need for explicit checks and simplifies the `discourse_event.rb` lib file.
- made the mixin search work in terms of the original comment in the file.
- added some tests to verify my changes.
- rearranged the DiscourseEvent spec into three context: nonexistent event, one event, multiple events.

This started as a typo correction so it's cool if I went too far. I fixed the typo, though. :chicken: 
