### PR TITLE
use canonical-url plugin to make view more clean

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 require 'current_user'
+require 'canonical_url'
 require_dependency 'discourse'
 require_dependency 'custom_renderer'
 require 'archetype'
@@ -6,6 +7,8 @@ require_dependency 'rate_limiter'
 
 class ApplicationController < ActionController::Base
   include CurrentUser
+  
+  include CanonicalURL::ControllerExtensions
 
   serialization_scope :guardian
 

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -30,6 +30,8 @@ class TopicsController < ApplicationController
       track_visit_to_topic
       perform_show_response
     end
+
+    canonical_url @topic_view.canonical_path
   end
 
   def destroy_timings

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,10 +1,12 @@
 require 'current_user'
+require 'canonical_url'
 require_dependency 'guardian'
 require_dependency 'unread'
 require_dependency 'age_words'
 
 module ApplicationHelper
   include CurrentUser
+  include CanonicalURL::Helpers
 
   def with_format(format, &block)
     old_formats = formats

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,14 +6,8 @@
     <meta name="viewport" content="target-densitydpi=device-dpi, width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0" />
     <meta content="" name="description">
     <meta content="" name="author">
-    <%- 
-      canonical = capture{yield :canonical} 
-      if canonical
-    %>
-    <meta rel="canonical" href="<%= canonical %>">
-    <%-
-      end
-    %>
+
+    <%= canonical_link_tag %>
 
     <link rel="icon" type="image/png" href=<%=SiteSetting.favicon_url%>>
     <%= javascript_include_tag "preload_store" %>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -19,8 +19,5 @@
   </p>
 <% end %>
 
-<%- content_for :canonical do %>
-  <%= "#{request.protocol}#{request.host_with_port}#{@topic_view.canonical_path}" %>
-<%- end %>
 
 <p>Powered by <a href="http://www.discourse.org">Discourse</a>, best viewed with JavaScript enabled</p>

--- a/lib/canonical_url.rb
+++ b/lib/canonical_url.rb
@@ -1,0 +1,43 @@
+module CanonicalURL
+  module ControllerExtensions
+    def canonical_url(url_for_options = {})
+      case url_for_options
+      when Hash
+        @canonical_url = url_for(url_for_options)
+      else
+        @canonical_url = url_for_options
+      end
+    end
+  end
+
+  module Helpers
+    def canonical_link_tag(url = nil)
+
+      return '' unless url || @canonical_url
+      tag('link', :rel => 'canonical', :href => url || @canonical_url || request.url)
+    end
+  end
+end
+
+# https://github.com/mbleigh/canonical-url/blob/master/lib/canonical_url.rb
+
+# Copyright (c) 2009 Michael Bleigh and Intridea, Inc.
+# 
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+# 
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.# 


### PR DESCRIPTION
- make canonical_link more maintainable
- i.e. https://github.com/mbleigh/canonical-url is Rails 2.x Gem, and it's no longer maintained, so I borrow the helper itself and place MIT LICENSE.
