### PR TITLE
Updated Enum for closing window on new topic

### DIFF
--- a/app/assets/javascripts/discourse/controllers/composer_controller.js.coffee
+++ b/app/assets/javascripts/discourse/controllers/composer_controller.js.coffee
@@ -164,7 +164,7 @@ window.Discourse.ComposerController = Ember.Controller.extend Discourse.Presence
 
   # ESC key hit
   hitEsc: ->
-    @shrink() if @get('content.composeState') == @OPEN
+    @shrink() if @get('content.composeState') == Discourse.Composer.OPEN
 
 
   showOptions: ->


### PR DESCRIPTION
Updated to use the staticly defined OPEN enum instead of relying on it to generate a this.OPEN for Discourse.Composer.OPEN
