### PR TITLE
slug should replace underscores

### DIFF
--- a/lib/slug.rb
+++ b/lib/slug.rb
@@ -6,7 +6,7 @@
 module Slug
 
   def self.for(string)
-    string.parameterize
+    string.parameterize.gsub("_", "-")
   end
 
 end

--- a/spec/components/slug_spec.rb
+++ b/spec/components/slug_spec.rb
@@ -39,5 +39,9 @@ describe Slug do
     Slug.for(from).should == to
   end
 
+  it 'replaces underscores' do
+    Slug.for("o_o_o").should == "o-o-o"
+  end
+
 end
 


### PR DESCRIPTION
`String#parameterize` already hyphenates, but it doesn't convert underscores since they're url-valid.

Added a spec for this regression.

``` ruby
    # Before
    Slug.for("o-o_o-o") #=> "o-o_o-o"

    # After
    Slug.for("o-o_o-o") #=> "o-o-o-o"
```
