### PR TITLE
Added airbrake initializer stub.

### DIFF
--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -2,5 +2,5 @@
 # free account here: https://signup.airbrake.io/account/new/Free
 # and add your API key below
 Airbrake.configure do |config|                                                                                                     
-  # config.api_key = ''                           
+  config.api_key = ''                           
 end


### PR DESCRIPTION
For those that may want to use Airbrake when the deploy Discourse (it's helped me with a few issues so far), this is the same stub that I use.

There wasn't an obvious place to update documentation. I get the impression that you're trying to dissuade early adopters from running in production, and so mentioning this in the docs might just confuse someone. Let me know if you disagree and I can add it!
