### PR TITLE
Clear 'Saved' message when clicking Save button in user preferences.

### DIFF
--- a/app/assets/javascripts/discourse/controllers/preferences_controller.js.coffee
+++ b/app/assets/javascripts/discourse/controllers/preferences_controller.js.coffee
@@ -42,6 +42,7 @@ Discourse.PreferencesController = Ember.ObjectController.extend Discourse.Presen
 
   save: ->
     @set('saving', true)
+    @set('saved', false)
 
     # Cook the bio for preview
     @get('content').save (result) =>


### PR DESCRIPTION
Tiny thing, but... clicking Save for a user's preferences shows the text _Saved!_ next to the _Save Changes_ button. Press the button again, and if the action takes a little but of time, it still shows the _Saved!_ text next to it. This just clears it when starting to save. I've written too much already explaining it than what it took to change. Thanks.
