### PR TITLE
Category year/month/week stats shouldn't include deleted topics.

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -167,7 +167,11 @@ class Topic < ActiveRecord::Base
   def self.visible
     where(visible: true)
   end
-
+  
+  def self.created_since(time_ago)
+    where("created_at > ?", time_ago)
+  end
+  
   def private_message?
     self.archetype == Archetype.private_message
   end

--- a/spec/fabricators/topic_fabricator.rb
+++ b/spec/fabricators/topic_fabricator.rb
@@ -3,6 +3,10 @@ Fabricator(:topic) do
   title { sequence(:title) { |i| "Test topic #{i}" } }
 end
 
+Fabricator(:deleted_topic, from: :topic) do
+  deleted_at Time.now 
+end
+
 Fabricator(:topic_allowed_user) do 
 end
 

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -157,31 +157,57 @@ describe Category do
   end
 
   describe 'update_stats' do
-
-    # We're going to test with one topic. That's enough for stats!
+    
     before do
       @category = Fabricate(:category)
-
-      # Create a non-invisible category to make sure count is 1
-      @topic = Fabricate(:topic, user: @category.user, category: @category)     
-
-      Category.update_stats
-      @category.reload
     end
+    
+    context 'with regular topics' do
 
-    it 'updates topics_week' do
-      @category.topics_week.should == 1
+      before do
+        @category.topics << Fabricate(:topic, 
+                                      user: @category.user)     
+        Category.update_stats
+        @category.reload
+      end
+
+      it 'updates topics_week' do
+        @category.topics_week.should == 1
+      end
+
+      it 'updates topics_month' do
+        @category.topics_month.should == 1
+      end
+
+      it 'updates topics_year' do
+        @category.topics_year.should == 1
+      end
+    
     end
+    
+    context 'with deleted topics' do
 
-    it 'updates topics_month' do
-      @category.topics_month.should == 1
-    end
+      before do
+        @category.topics << Fabricate(:deleted_topic, 
+                                      user: @category.user)
+        Category.update_stats
+        @category.reload
+      end
 
-    it 'updates topics_year' do
-      @category.topics_year.should == 1
+      it 'does not count deleted topics for topics_week' do
+        @category.topics_week.should == 0
+      end
+
+      it 'does not count deleted topics for topics_month' do
+        @category.topics_month.should == 0
+      end
+
+      it 'does not count deleted topics for topics_year' do
+        @category.topics_year.should == 0
+      end
+
     end
 
   end
 
 end
-


### PR DESCRIPTION
Fixes one of the issues expressed in Meta thread: [Year/Month/Week at bottom of Categories is broken](http://meta.discourse.org/t/year-month-week-at-bottom-of-categories-is-broken/1542/8).
- Refactored large query string into AR DSL with pretty much exact same SQL output.
- Introduced `Topic.created_since(1.week.ago)` scope. There are a lot of places where this can be reused.
