### PR TITLE
Users like like posts

### DIFF
--- a/app/models/user_action.rb
+++ b/app/models/user_action.rb
@@ -44,9 +44,13 @@ class UserAction < ActiveRecord::Base
       .where(user_id: user_id)
       .group('action_type')
 
-    # should push this into the sql at some point, but its simple enough for now
+    # We apply similar filters in stream, might consider trying to consolidate somehow
     unless guardian.can_see_private_messages?(user_id)
       results = results.where('topics.archetype <> ?', Archetype::private_message)
+    end
+    
+    unless guardian.user && guardian.user.id == user_id
+      results = results.where("action_type <> ?", BOOKMARK)
     end
 
     results = results.to_a


### PR DESCRIPTION
There's no need to group by archetype, only to use it to filter out things the current user can't see. Ungrouping fixes an issue where the ["Likes Given" group appears twice](http://meta.discourse.org/t/likes-given-listed-twice-in-own-profile-with-wrong-number-of-likes/3230) despite the details being combined.

Also, users who can't see bookmarks shouldn't be shown the menu/count stat for it.

Technically the stats query should take into account deleted content as well, but doing so seems messy based on the stream query, and the gain is small.
