### PR TITLE
Improved action descriptions/links on user stream items

### DIFF
--- a/app/assets/javascripts/discourse/models/user_action.js.coffee
+++ b/app/assets/javascripts/discourse/models/user_action.js.coffee
@@ -2,10 +2,19 @@ window.Discourse.UserAction = Discourse.Model.extend
   postUrl:(->
     Discourse.Utilities.postUrl(@get('slug'), @get('topic_id'), @get('post_number'))
   ).property()
+  
+  replyUrl: (->
+    Discourse.Utilities.postUrl(@get('slug'), @get('topic_id'), @get('reply_to_post_number'))
+  ).property()
 
   isPM: (->
     a = @get('action_type')
-    a == UserAction.NEW_PRIVATE_MESSAGE || UserAction.GOT_PRIVATE_MESSAGE
+    a == Discourse.UserAction.NEW_PRIVATE_MESSAGE || a == Discourse.UserAction.GOT_PRIVATE_MESSAGE
+  ).property()
+  
+  isPostAction: (->
+    a = @get('action_type')
+    a == Discourse.UserAction.RESPONSE || a == Discourse.UserAction.POST || a == Discourse.UserAction.NEW_TOPIC
   ).property()
 
   addChild: (action)->

--- a/app/assets/javascripts/discourse/templates/user/stream.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/user/stream.js.handlebars
@@ -5,9 +5,31 @@
         <a href="/users/{{unbound username}}" class='avatar-link'><div class='avatar-wrapper'>{{avatar this imageSize="large" extraClasses="actor" avatarTemplatePath="avatar_template" ignoreTitle="true"}}</div></a>
         <span class='time'>{{date path="created_at" leaveAgo="true"}}</span>
         <a class="title" href="{{unbound postUrl}}">{{unbound title}}</a><br>
+        {{#unless description}}
+          <span class="type">
+          {{#if isPM}}
+            <i class="icon icon-lock" title="{{i18n user.stream.private_message}}"></i>
+            {{i18n user.stream.sent_by}}
+          {{else}}
+            {{i18n user.stream.posted_by}}
+          {{/if}}
+          </span>
+        {{/unless}}
         <a class='name' href="/users/{{unbound username}}">{{personalizedName name usernamePath="username"}}</a>
-        <span class='type'>{{unbound description}}</span>
-        <a class="post-number" href="{{unbound postUrl}}">#{{unbound post_number}}</a>
+        {{#if description}}
+          <span class='type'>{{unbound description}}</span>
+          {{#if isPostAction}}
+            <a class="post-number" href="{{unbound replyUrl}}">
+            {{#if reply_to_post_number}}
+              #{{unbound reply_to_post_number}}
+            {{else}}
+              {{i18n user.stream.the_topic}}
+            {{/if}}
+            </a>
+          {{else}}
+            <span class="name">{{personalizedName view.parentView.parentView.user.name usernamePath="view.parentView.parentView.user.username"}}</span>
+          {{/if}}
+        {{/if}}
       </div>
       <p class='excerpt'>
       {{{unbound excerpt}}}

--- a/app/assets/stylesheets/application/user.css.scss
+++ b/app/assets/stylesheets/application/user.css.scss
@@ -258,6 +258,9 @@
   .type {
     color: lighten($black, 40%);
   }
+  span.name {
+    color: lighten($black, 40%);
+  }
   .time {
     display: block;
     float: right;

--- a/app/models/user_action.rb
+++ b/app/models/user_action.rb
@@ -79,6 +79,7 @@ class UserAction < ActiveRecord::Base
 SELECT 
   t.title, a.action_type, a.created_at, t.id topic_id, 
   coalesce(p.post_number, 1) post_number, 
+  p.reply_to_post_number,
   pu.email ,pu.username, pu.name, pu.id user_id, 
   u.email acting_email, u.username acting_username, u.name acting_name, u.id acting_user_id, 
   coalesce(p.cooked, p2.cooked) cooked

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -168,7 +168,13 @@ en:
         instructions: "We use <a href='https://gravatar.com' target='_blank'>Gravatar</a> for avatars based on your email"
 
       filters:
-        all: "All"        
+        all: "All"
+        
+      stream:
+        posted_by: "Posted by"
+        sent_by: "Sent by"
+        private_message: "private message"
+        the_topic: "the topic"
 
     loading: "Loading..."
     close: "Close"


### PR DESCRIPTION
Tidied up action descriptions on user activity stream so that "replied to" links point to the actual post replied to, PMs don't awkwardly have `{{username}} #{{post_number}}`. etc.

`view.parentView.parentView.user.name` is kind of lengthy though, is there an easier way to get at that information?
