### PR TITLE
Oneboxes shouldn't explode when the remote causes an HTTPError

### DIFF
--- a/lib/oneboxer.rb
+++ b/lib/oneboxer.rb
@@ -42,7 +42,7 @@ module Oneboxer
         end
         (doc/"link[@type='text/json+oembed']").each do |oembed|
           return OembedOnebox.new(oembed[:href]).onebox   
-        end        
+        end
 
         # Check for opengraph
         open_graph = Oneboxer.parse_open_graph(doc)
@@ -50,7 +50,9 @@ module Oneboxer
       end
     end
 
-    nil    
+    nil
+  rescue OpenURI::HTTPError
+    nil
   end
 
   # Parse URLs out of HTML, returning the document when finished.


### PR DESCRIPTION
Catching the exception earlier on prevents the controller from returning a 500 to the client.

It might be nice to try and indicate the reason why a oneboxing failed in the future, especially for 404s, but I'll leave that for another day.
