### PR TITLE
bump binding_of_caller version for ruby 2.0.0 support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,7 +105,8 @@ GEM
     better_errors (0.5.0)
       coderay (>= 1.0.0)
       erubis (>= 2.6.6)
-    binding_of_caller (0.6.8)
+    binding_of_caller (0.7.1)
+      debug_inspector (>= 0.0.1)
     bourne (1.1.2)
       mocha (= 0.10.5)
     builder (3.0.4)
@@ -141,6 +142,7 @@ GEM
     coffee-script-source (1.4.0)
     connection_pool (1.0.0)
     daemons (1.1.9)
+    debug_inspector (0.0.2)
     diff-lcs (1.1.3)
     em-redis (0.3.0)
       eventmachine


### PR DESCRIPTION
Now that Iconv was removed, this is the remaining change to allow Discourse to bundle and boot on Ruby 2.0 as well (2.0 makes dev Rails server boot much faster!).

It doesn't break better_errors REPL or anything, and I tested it in my debian vm and osx.
