### PR TITLE
Use consistent date formatting in date helpers

### DIFF
--- a/app/assets/javascripts/discourse/helpers/application_helpers.js.coffee
+++ b/app/assets/javascripts/discourse/helpers/application_helpers.js.coffee
@@ -72,8 +72,7 @@ Handlebars.registerHelper 'avatar', (user, options) ->
 
 Handlebars.registerHelper 'unboundDate', (property, options) ->
   dt = new Date(Ember.Handlebars.get(this, property, options))
-  month = Date.SugarMethods.getLocale.method().months[12 + dt.getMonth()]
-  "#{dt.getDate()} #{month}, #{dt.getFullYear()} #{dt.getHours()}:#{dt.getMinutes()}"
+  dt.format("{d} {Mon}, {yyyy} {hh}:{mm}")
 
 Handlebars.registerHelper 'editDate', (property, options) ->
   dt = Date.create(Ember.Handlebars.get(this, property, options))


### PR DESCRIPTION
Makes casing on month name the same as on posts, but more importantly fixes times like `03:07` appearing as `3:7`
