### PR TITLE
Make topic lists show last activity more intuitively

### DIFF
--- a/app/assets/javascripts/discourse/models/topic.js
+++ b/app/assets/javascripts/discourse/models/topic.js
@@ -127,11 +127,6 @@ Discourse.Topic = Discourse.Model.extend({
     return this.get('archetype') === 'private_message';
   }).property('archetype'),
 
-  // Does this topic only have a single post?
-  singlePost: (function() {
-    return this.get('posts_count') === 1;
-  }).property('posts_count'),
-
   toggleStatus: function(property) {
     this.toggleProperty(property);
     return $.post("" + (this.get('url')) + "/status", {

--- a/app/assets/javascripts/discourse/templates/list/topic_list_item.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/list/topic_list_item.js.handlebars
@@ -38,16 +38,16 @@
 
   <td class='num'>{{number views numberKey="views_long"}}</td>
 
-  {{#if singlePost}}
-    <td class='num activity'>
-      <a href="{{url}}" class='age' title='{{i18n first_post}}: {{{unboundDate created_at}}}'>{{{age}}}</a>
-    </td>
-    <td></td>
-  {{else}}
+  {{#if bumped}}
     <td class='num activity'>
       <a href="{{url}}" {{{bindAttr class=":age ageCold"}}} title='{{i18n first_post}}: {{{unboundDate created_at}}}' >{{{age}}}</a>
     </td>
     <td class='num activity last'>
-      <a href="{{lastPostUrl}}" class='age' title='{{i18n last_post}}: {{{unboundDate last_posted_at}}}'>{{{last_post_age}}}</a>
+      <a href="{{lastPostUrl}}" class='age' title='{{i18n last_post}}: {{{unboundDate bumped_at}}}'>{{{bumped_age}}}</a>
     </td>
+  {{else}}
+    <td class='num activity'>
+      <a href="{{url}}" class='age' title='{{i18n first_post}}: {{{unboundDate created_at}}}'>{{{age}}}</a>
+    </td>
+    <td></td>
   {{/if}}

--- a/app/assets/javascripts/discourse/templates/suggested_topic.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/suggested_topic.js.handlebars
@@ -25,18 +25,18 @@
 
   <td class='num'>{{number views numberKey="views_long"}}</td>
 
-  {{#if singlePost}}
-    <td class='num activity'>
-      <a href="{{url}}" class='age' title='{{i18n first_post}}: {{{unboundDate created_at}}}'>{{{age}}}</a>
-    </td>
-    <td></td>
-  {{else}}
+  {{#if bumped}}
     <td class='num activity'>
       <a href="{{url}}" {{{bindAttr class=":age ageCold"}}} title='{{i18n first_post}}: {{{unboundDate created_at}}}' >{{{age}}}</a>
     </td>
     <td class='num activity last'>
-      <a href="{{lastPostUrl}}" class='age' title='{{i18n last_post}}: {{{unboundDate last_posted_at}}}'>{{{last_post_age}}}</a>
+      <a href="{{lastPostUrl}}" class='age' title='{{i18n last_post}}: {{{unboundDate bumped_at}}}'>{{{bumped_age}}}</a>
     </td>
+  {{else}}
+    <td class='num activity'>
+      <a href="{{url}}" class='age' title='{{i18n first_post}}: {{{unboundDate created_at}}}'>{{{age}}}</a>
+    </td>
+    <td></td>
   {{/if}}
 
   {{/group}}

--- a/app/serializers/listable_topic_serializer.rb
+++ b/app/serializers/listable_topic_serializer.rb
@@ -8,6 +8,9 @@ class ListableTopicSerializer < BasicTopicSerializer
              :image_url,
              :created_at,
              :last_posted_at,
+             :bumped,
+             :bumped_at,
+             :bumped_age,
              :age,
              :unseen,
              :last_read_post_number,
@@ -18,6 +21,16 @@ class ListableTopicSerializer < BasicTopicSerializer
   def age
     AgeWords.age_words(Time.now - (object.created_at || Time.now))
   end
+  
+  def bumped
+    object.created_at < object.bumped_at
+  end
+  
+  def bumped_age
+    return nil if object.bumped_at.blank?
+    AgeWords.age_words(Time.now - object.bumped_at)
+  end
+  alias include_bumped_age? :bumped
 
   def seen
     object.user_data.present?

--- a/app/serializers/suggested_topic_serializer.rb
+++ b/app/serializers/suggested_topic_serializer.rb
@@ -1,11 +1,6 @@
 class SuggestedTopicSerializer < ListableTopicSerializer
 
-  attributes :archetype, :like_count, :views, :last_post_age
+  attributes :archetype, :like_count, :views
   has_one :category, embed: :objects
-
-  def last_post_age
-    return nil if object.last_posted_at.blank?
-    AgeWords.age_words(Time.now - object.last_posted_at)
-  end
 
 end

--- a/app/serializers/topic_list_item_serializer.rb
+++ b/app/serializers/topic_list_item_serializer.rb
@@ -8,18 +8,12 @@ class TopicListItemSerializer < ListableTopicSerializer
              :pinned,
              :closed,
              :archived,
-             :last_post_age,
              :starred,
              :has_best_of,
              :archetype
 
   has_one :category
   has_many :posters, serializer: TopicPosterSerializer, embed: :objects
-
-  def last_post_age
-    return nil if object.last_posted_at.blank?
-    AgeWords.age_words(Time.now - object.last_posted_at)
-  end
 
   def starred
     object.user_data.starred?


### PR DESCRIPTION
Apparently editing the most recent (and only the most recent) post in a topic [causes the topic to be bumped](https://github.com/discourse/discourse/blob/master/lib/post_revisor.rb#L56), which can be confusing since the displayed date on the topic list is the last _post_ date.

I tweaked things a little so the last activity date will be displayed as the `bumped_at` age when appropriate, and the tooltip will contain both pieces of information. The last post date is now also shown when the topic is bumped even when there are no replies (i.e. the topic post itself was edited).

I tried to avoid confusion by reducing the opacity when the value for the second column is due to the bump instead of to a new reply being posted by lowering the opacity, like in the following screenshot:

![tooltip for new activity](https://f.cloud.github.com/assets/449006/166156/5ea325bc-798c-11e2-8bfc-e8336a52f50d.png)

I'm not positive this is the best solution, but unless bumping on edit is dropped completely the current behaviour seems more confusing.
