### PR TITLE
validate category user_id presence to match DB constraint.

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -10,6 +10,7 @@ class Category < ActiveRecord::Base
   has_many :category_featured_users
   has_many :featured_users, through: :category_featured_users, source: :user
 
+  validates_presence_of :user_id
   validates_presence_of :name
   validates_uniqueness_of :name
   validate :uncategorized_validator

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -4,6 +4,7 @@ require 'spec_helper'
 
 describe Category do
 
+  it { should validate_presence_of :user_id }
   it { should validate_presence_of :name }
 
   it 'validates uniqueness of name' do


### PR DESCRIPTION
I added a validation + spec to mirror db constraint.

Before:

``` ruby
category = Category.new(name: "Test Category")

category.valid? 
#=> true

category.save
#=> BEGIN
#   INSERT INTO "categories" ...
#   ROLLBACK
#   PG::Error: null value in "user_id" violates not-null constraint.
```

After:

``` ruby
category.valid?
#=> false

category.save
#=> false

category.errors?
#=> { user_id: ["can't be blank"] }
```
