### PR TITLE
Sign the auth token cookie and make it httpOnly

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -117,7 +117,7 @@ class ApplicationController < ActionController::Base
       user.auth_token = SecureRandom.hex(16)
       user.save!
     end
-    cookies.permanent[:_t] = user.auth_token
+    cookies.permanent.signed[:_t] = { :value => user.auth_token, :httponly => true }
   end
 
   # This is odd, but it seems that in Rails `render json: obj` is about

--- a/lib/current_user.rb
+++ b/lib/current_user.rb
@@ -2,7 +2,7 @@ module CurrentUser
 
   def self.lookup_from_env(env)
     request = Rack::Request.new(env)
-    auth_token = request.cookies["_t"]
+    auth_token = request.cookies[:_t]
     user = nil
     if auth_token && auth_token.length == 32
       user = User.where(auth_token: auth_token).first 
@@ -16,7 +16,7 @@ module CurrentUser
 
     if session[:current_user_id].blank?
       # maybe we have a cookie? 
-      auth_token = cookies[:_t]
+      auth_token = cookies.signed[:_t]
       if auth_token && auth_token.length == 32
         @current_user = User.where(auth_token: auth_token).first
         session[:current_user_id] = @current_user.id if @current_user

--- a/spec/controllers/session_controller_spec.rb
+++ b/spec/controllers/session_controller_spec.rb
@@ -38,7 +38,7 @@ describe SessionController do
         end
 
         it 'sets a cookie with the auth token' do
-          cookies[:_t].should == user.auth_token
+          cookies.signed[:_t].should == user.auth_token
         end
       end
 


### PR DESCRIPTION
Since this seems to be a non-expiring value, eliminating the potential to make a lucky guess and protecting the cookie from XSS sniffing seems like the best call.
