### PR TITLE
copyedits on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,15 @@ Whenever you need ...
 
 ## Getting Started
 
-If you're interested in helping us develop Discourse, please start with our **[Discourse Vagrant Developer Guide](https://github.com/discourse/discourse/blob/master/docs/VAGRANT.md)**, which includes instructions to get up and running in a development environment using a virtual machine. It's the easiest way to hack on Discourse!
+If you're interested in helping us develop Discourse, please start with our [**Discourse Vagrant Developer Guide**](https://github.com/discourse/discourse/blob/master/docs/VAGRANT.md), which includes instructions to get up and running in a development environment using a virtual machine. It's the easiest way to hack on Discourse!
 
-If you're familiar with how Rails works and are comfortable setting up your own environment, use our **[Discourse Advanced Developer Guide](https://github.com/discourse/discourse/blob/master/docs/DEVELOPER-ADVANCED.md)**.
+If you're familiar with how Rails works and are comfortable setting up your own environment, use our [**Discourse Advanced Developer Guide**](https://github.com/discourse/discourse/blob/master/docs/DEVELOPER-ADVANCED.md).
 
 ### Requirements
 
-- Ruby 1.9.3+
-- PostgreSQL 9.1+
-- Redis 2.6+
+- [Ruby 1.9.3+](http://www.ruby-lang.org/en/downloads/)
+- [PostgreSQL 9.1+](http://www.postgresql.org/download/)
+- [Redis 2.6+](http://redis.io/download)
 
 ## Vision
 
@@ -64,9 +64,9 @@ accepts contributions from the public, and we'd like you to be a part of that co
 
 Before contributing to Discourse, please:
 
-1. Review the **VISION** section above, which will help you understand the needs of the team, and the focus of the project,
-2. Read and sign the **[Electronic Discourse Forums Contribution License Agreement](https://docs.google.com/a/discourse.org/spreadsheet/viewform?formkey=dGUwejFfbDhDYXR4bVFMRG1TUENqLWc6MQ)**, to confirm you've read and acknowledged the legal aspects of your contributions, and
-3. Dig into **[CONTRIBUTING.MD](https://github.com/discourse/discourse/blob/master/docs/CONTRIBUTING.md)**, which houses all of the necessary info to:
+1. Review the [**VISION**](#vision) section above, which will help you understand the needs of the team, and the focus of the project,
+2. Read and sign the [**Electronic Discourse Forums Contribution License Agreement**](http://discourse.org/cla), to confirm you've read and acknowledged the legal aspects of your contributions, and
+3. Dig into [**CONTRIBUTING.MD**](https://github.com/discourse/discourse/blob/master/docs/CONTRIBUTING.md), which houses all of the necessary info to:
    - submit bugs,
    - request new features, and
    - step you through the entire process of preparing your code for a Pull Request.
@@ -89,7 +89,7 @@ In order to be an effective contributor, familiarize yourself with the various o
 
 ### Ruby Gems
 
-The complete list of Ruby Gems used by Discourse can be found in [SOFTWARE.md](https://github.com/discourse/discourse/blob/master/docs/SOFTWARE.md).
+The complete list of Ruby Gems used by Discourse can be found in [**SOFTWARE.MD**](https://github.com/discourse/discourse/blob/master/docs/SOFTWARE.md).
 
 ## Versioning
 
@@ -109,7 +109,7 @@ For more information on SemVer, please visit http://semver.org/.
 
 ## The Discourse Team
 
-The Discourse code contributors can be found in [AUTHORS.MD](https://github.com/discourse/discourse/blob/master/docs/AUTHORS.md). For a complete list of the many individuals that contributed to the design and implementation of Discourse, please refer to the official website.
+The Discourse code contributors can be found in [**AUTHORS.MD**](https://github.com/discourse/discourse/blob/master/docs/AUTHORS.md). For a complete list of the many individuals that contributed to the design and implementation of Discourse, please refer to the official website.
 
 ## Copyright / License
 


### PR DESCRIPTION
What has been done
- added direct links to download requirements
- added link to the VISION anchor
- changed the link to the CLA to the canonical one
