### PR TITLE
Added JSHint support for travis builds

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,26 @@
+{
+	"bitwise" :true,
+	"eqeqeq": true,
+	"forin": false,
+	"immed": true,
+	"latedef": true,
+	"noarg": true,
+	"noempty": true,
+	"nonew": true,
+	"strict": true,
+	"trailing": true,
+	"undef": true,
+	"unused": true,
+	"quotmark": "single",
+
+	"browser": true,
+	"loopfunc": true,
+	"laxbreak": true,
+	"smarttabs": true,
+
+	"predef": [
+		"mw",
+		"$",
+		"prompt"
+	]
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ before_script:
   - cp config/redis.yml.sample config/redis.yml
   - psql -c 'create database discourse_test;' -U postgres
   - rake db:migrate
+  - npm install -g jshint
 script: 'rake spec && bundle exec guard-jasmine --server-timeout=60'
+after_script:
+  - jshint .
 services:
   - redis-server


### PR DESCRIPTION
Added .jshintrc to the project (configuration file)

added the JShint command to the after script so that it doesnt fail the build at the present moment, if you move it to the before script it will fail the build

after_script:

jshint .
Before script build
https://travis-ci.org/billybonks/discourse/builds/4938503
