### PR TITLE
Support for cyrillic letters in slugs (while in :ru locale)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,7 +57,7 @@ gem 'discourse_plugin', path: 'vendor/gems/discourse_plugin'
 
 # Discourse Plugins (optional)
 # Polls and Tasks have been disabled for launch, we need think all sorts of stuff through before adding them back in
-#   biggest concern is core support for custom sort orders, but there is also styling that just gets mishmashed into our core theme. 
+#   biggest concern is core support for custom sort orders, but there is also styling that just gets mishmashed into our core theme.
 # gem 'discourse_poll', path: 'vendor/gems/discourse_poll'
 gem 'discourse_emoji', path: 'vendor/gems/discourse_emoji'
 # gem 'discourse_task', path: 'vendor/gems/discourse_task'
@@ -82,7 +82,7 @@ group :test, :development do
   gem 'certified'
   gem 'fabrication'
   gem 'guard-jasmine'
-  gem 'guard-rspec' 
+  gem 'guard-rspec'
   gem 'guard-spork'
   gem 'jasminerice'
   gem 'mocha', require: false
@@ -94,14 +94,17 @@ group :test, :development do
   gem 'terminal-notifier-guard', require: RUBY_PLATFORM.include?('darwin') && 'terminal-notifier-guard'
 end
 
-group :development do 
+group :development do
   gem 'better_errors'
   gem 'binding_of_caller' # I tried adding this and got an occational crash
   gem 'librarian', '>= 0.0.25', require: false
-  gem 'pry-rails'  
+  gem 'pry-rails'
 end
 
 # IMPORTANT: mini profiler monkey patches, so it better be required last
 #  If you want to amend mini profiler to do the monkey patches in the railstie
 #  we are open to it.
 gem 'rack-mini-profiler', git: 'git://github.com/SamSaffron/MiniProfiler'
+
+# Gem with correct I18n for russian language
+gem 'russian', '~> 0.6.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -377,6 +377,8 @@ GEM
       rspec-mocks (~> 2.12.0)
     ruby-hmac (0.4.0)
     ruby-openid (2.2.2)
+    russian (0.6.0)
+      i18n (>= 0.5.0)
     sanitize (2.0.3)
       nokogiri (>= 1.4.4, < 1.6)
     sass (3.2.5)
@@ -505,6 +507,7 @@ DEPENDENCIES
   rest-client
   rinku
   rspec-rails
+  russian (~> 0.6.0)
   sanitize
   sass
   sass-rails

--- a/spec/components/slug_spec.rb
+++ b/spec/components/slug_spec.rb
@@ -17,11 +17,11 @@ describe Slug do
     Slug.for('evil#trout').should == 'evil-trout'
   end
 
-  it 'handles a.b.c properly' do 
+  it 'handles a.b.c properly' do
     Slug.for("a.b.c").should == "a-b-c"
   end
 
-  it 'handles double dots right' do 
+  it 'handles double dots right' do
     Slug.for("a....b.....c").should == "a-b-c"
   end
 
@@ -43,5 +43,10 @@ describe Slug do
     Slug.for("o_o_o").should == "o-o-o"
   end
 
+  it 'processes cyrillic letters in :ru locale' do
+    I18n.locale = :ru
+    Slug.for("первый пост").should == "pervyy-post"
+    I18n.locale = :en
+  end
 end
 


### PR DESCRIPTION
I've fixed an issue occured with empty post slugs (causing routing errors, #217) for posts with titles consisting totally of cyrillic characters.

I've added gem `russian`, which activates correct cyrillic processing when `I18n.locale = :ru`.
Nethertheless, it breaks classical ASCII transliteration, so I've messed with `I18n.locale` variable in `slug_spec.rb` a little bit.
