### PR TITLE
Help long titles wrap more cleanly

### DIFF
--- a/app/assets/javascripts/discourse/templates/user/stream.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/user/stream.js.handlebars
@@ -4,7 +4,9 @@
       <div class='clearfix info'>
         <a href="/users/{{unbound username}}" class='avatar-link'><div class='avatar-wrapper'>{{avatar this imageSize="large" extraClasses="actor" avatarTemplatePath="avatar_template" ignoreTitle="true"}}</div></a>
         <span class='time'>{{date path="created_at" leaveAgo="true"}}</span>
-        <a class="title" href="{{unbound postUrl}}">{{unbound title}}</a><br>
+        <span class="title">
+          <a href="{{unbound postUrl}}">{{unbound title}}</a>
+        </span>
         {{#unless description}}
           <span class="type">
           {{#if isPM}}

--- a/app/assets/stylesheets/application/user.css.scss
+++ b/app/assets/stylesheets/application/user.css.scss
@@ -273,7 +273,7 @@
     margin-right: 10px;
   }
   .title {
-    display: inline-block;
+    display: block;
     margin-bottom: 4px;
     font-size: 14px;
   }


### PR DESCRIPTION
Long titles push themselves under the user avatar in the activity stream:

![long title](https://f.cloud.github.com/assets/449006/183419/67417c50-7c98-11e2-9173-e7e18e5962e2.png)

This change makes sure they wrap more cleanly, at the cost of adding an additional span to prevent the `a` target area from blocking.
