### PR TITLE
Collapse user activity items loaded from message bus

### DIFF
--- a/app/assets/javascripts/discourse/models/user.js
+++ b/app/assets/javascripts/discourse/models/user.js
@@ -102,10 +102,17 @@
         cache: 'false',
         success: function(result) {
           if (result) {
+            var action;
+          
             if ((_this.get('streamFilter') || result.action_type) !== result.action_type) {
               return;
             }
-            return stream.insertAt(0, Discourse.UserAction.create(result));
+            
+            action = Em.A();
+            action.pushObject(Discourse.UserAction.create(result));
+            action = Discourse.UserAction.collapseStream(action);
+            
+            return stream.insertAt(0, action[0]);
           }
         }
       });


### PR DESCRIPTION
User activity items that get special grouping treatment come out a bit wrong when loaded on-demand from message bus. While this leads to kind of funny messages...

![borked activity item](https://f.cloud.github.com/assets/449006/183503/a1455ede-7c9e-11e2-9425-e05f5b706ef9.png)

...performing the "grouping" on the newly loaded item helps to maintain a consistent display of likes, etc. 
