### PR TITLE
make topics consume their own scope

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -147,11 +147,11 @@ class Topic < ActiveRecord::Base
     false
   end
 
-  # Returns new topics since a date
+  # Returns new topics since a date for display in email digest.
   def self.new_topics(since)
     Topic
       .visible
-      .where("created_at >= ?", since)
+      .created_since(since)
       .listable_topics
       .topic_list_order
       .includes(:user)


### PR DESCRIPTION
Minor DRY-up on the `Topic.created_since` scope.

Also clarified the comment since `Topic.new_topics` is a pretty specific daisy-chain of scopes that's only used in the user mailer digest.
