### PR TITLE
Tweak autocomplete/caret_position logic to not exclude the index 0 case

### DIFF
--- a/app/assets/javascripts/discourse/components/autocomplete.js
+++ b/app/assets/javascripts/discourse/components/autocomplete.js
@@ -126,7 +126,7 @@
         });
       };
       updateAutoComplete = function(r) {
-        if (!completeStart) return;
+        if (completeStart === null) return;
         
         autocompleteOptions = r;
         if (!r || r.length === 0) {
@@ -197,7 +197,7 @@
         if (e.which === 16) {
           return;
         }
-        if ((!completeStart) && e.which === 8 && options.key) {
+        if ((completeStart === null) && e.which === 8 && options.key) {
           c = Discourse.Utilities.caretPosition(me[0]);
           next = me[0].value[c];
           nextIsGood = next === void 0 || /\s/.test(next);
@@ -222,13 +222,13 @@
           }
         }
         if (e.which === 27) {
-          if (completeStart) {
+          if (completeStart !== null) {
             closeAutocomplete();
             return false;
           }
           return true;
         }
-        if (completeStart) {
+        if (completeStart !== null) {
           caretPosition = Discourse.Utilities.caretPosition(me[0]);
           /* If we've backspaced past the beginning, cancel unless no key
           */

--- a/app/assets/javascripts/discourse/components/caret_position.js
+++ b/app/assets/javascripts/discourse/components/caret_position.js
@@ -70,7 +70,7 @@
       });
       before = void 0;
       after = void 0;
-      pos = options && options.pos ? options.pos : getCaret(textarea[0]);
+      pos = options && (options.pos || options.pos === 0) ? options.pos : getCaret(textarea[0]);
       val = textarea.val().replace("\r", "");
       if (options && options.key) {
         val = val.substring(0, pos) + options.key + val.substring(pos);


### PR DESCRIPTION
Fixes situation where autocomplete would bail if the cursor was at the beginning of the textarea, so usernames can be autocompleted as the first thing entered.
