### PR TITLE
Clicking on the Discourse header logo scroll back to top in homepage

### DIFF
--- a/app/assets/javascripts/discourse/views/header_view.js
+++ b/app/assets/javascripts/discourse/views/header_view.js
@@ -87,6 +87,11 @@
       this.$('a.unread-private-messages, a.unread-notifications, a[data-notifications]').on('click touchstart', function(e) {
         return _this.showNotifications(e);
       });
+      this.$('div.title').on('click', function() {
+        if (window.location.pathname === '/') {
+          window.scrollTo(0, 0);
+        }
+      });
       jQuery(window).bind('scroll.discourse-dock', function() {
         return _this.examineDockHeader();
       });


### PR DESCRIPTION
When on the homepage, and you click on the Discourse logo, you're now taken to the top of the browser. As per [this request](http://meta.discourse.org/t/discourse-logo-link-back-to-top-of-thread-list-on-home-page/3592/2).

**Note:** I did not add a _touchstart_ bind to the logo because it then fires twice. This got me wondering about the other bindings using both -- here is one example

```
this.$('a[data-dropdown]').on('click touchstart', function(e) {
        return _this.showDropdown(jQuery(e.currentTarget));
      });
```

Doing both then results in the callback function being fired twice, when tapping on an iPad. I'm not sure if this is a concern for you guys.
