### PR TITLE
prevent useless queries for fetching participants' avatar on list view

### DIFF
--- a/app/assets/javascripts/discourse/templates/list/topic_list_item.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/list/topic_list_item.js.handlebars
@@ -1,4 +1,3 @@
-
   {{#if Discourse.currentUser.id}}
     <td class='star'>
       <a {{bindAttr class=":star :icon-star starred:starred"}} {{action toggleStar this target="controller"}} href='#' title='{{i18n favorite.help}}'></a>
@@ -24,7 +23,7 @@
 
   <td class='posters'>
     {{#each posters}}
-      <a href="/users/{{user.username_lower}}">{{avatar this usernamePath="user.username" imageSize="small"}}</a>
+      <a href="/users/{{user.username_lower}}">{{avatar user imageSize="small"}}</a>
     {{/each}}
   </td>
 


### PR DESCRIPTION
correcting the behaviour identified in the issue #243
