### PR TITLE
Refactor Topic

### DIFF
--- a/app/controllers/admin/impersonate_controller.rb
+++ b/app/controllers/admin/impersonate_controller.rb
@@ -3,10 +3,8 @@ class Admin::ImpersonateController < Admin::AdminController
   def create
     requires_parameters(:username_or_email)
 
-    user = User.where(['username_lower = lower(?) or lower(email) = lower(?) or lower(name) = lower(?)',
-                        params[:username_or_email],
-                        params[:username_or_email],
-                        params[:username_or_email]]).first
+    user = User.find_by_username_or_email(params[:username_or_email]).first
+
     raise Discourse::NotFound if user.blank?
 
     guardian.ensure_can_impersonate!(user)

--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -144,4 +144,8 @@ class SiteSetting < ActiveRecord::Base
     self.enforce_global_nicknames? and self.discourse_org_access_key.present?
   end
 
+  def self.topic_title_length
+    min_topic_title_length..max_topic_title_length
+  end
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -166,8 +166,12 @@ class User < ActiveRecord::Base
   def self.find_by_temporary_key(key)
     user_id = $redis.get("temporary_key:#{key}")
     if user_id.present?
-      User.where(id: user_id.to_i).first
+      where(id: user_id.to_i).first
     end
+  end
+
+  def self.find_by_username_or_email(username_or_email)
+    where("username_lower = :user or lower(username) = :user or lower(email) = :user or lower(name) = :user", user: username_or_email.downcase)
   end
 
   # tricky, we need our bus to be subscribed from the right spot

--- a/spec/models/site_setting_spec.rb
+++ b/spec/models/site_setting_spec.rb
@@ -107,4 +107,13 @@ describe SiteSetting do
     end
   end
 
+  describe 'topic_title_length' do
+    it 'returns a range of min/max topic title length' do
+      SiteSetting.min_topic_title_length = 1
+      SiteSetting.max_topic_title_length = 2
+
+      SiteSetting.topic_title_length.should == (1..2)
+    end
+  end
+
 end


### PR DESCRIPTION
- move finding by username/email to User
- make SiteSetting return a range of possible post title lengths
- remove unnecessary conditions
