### PR TITLE
updated sublime-project & vagrant file

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,8 +25,7 @@ Vagrant::Config.run do |config|
   config.vm.forward_port 3000, 4000
   config.vm.forward_port 1080, 4080 # Mailcatcher
 
-  nfs_setting = (RUBY_PLATFORM =~ /darwin/ or
-                 RUBY_PLATFORM =~ /linux/) ? true : false
+  nfs_setting = RUBY_PLATFORM =~ /darwin/ || RUBY_PLATFORM =~ /linux/
   config.vm.share_folder("v-root", "/vagrant", ".", :nfs => nfs_setting)
 
   chef_cookbooks_path = ["chef/cookbooks"]
@@ -49,6 +48,6 @@ Vagrant::Config.run do |config|
     chef.add_recipe "recipe[apt]"
     chef.add_recipe "recipe[build-essential]"
     chef.add_recipe "recipe[phantomjs]"
-    chef.add_recipe "recipe[vim]"    
+    chef.add_recipe "recipe[vim]"
   end
 end

--- a/sublime-project
+++ b/sublime-project
@@ -1,23 +1,25 @@
 {
   "folders":
-    [
-      {
-        "path": "app",
-        "folder_exclude_patterns": ["external", "external_production", "images", "imported", "fonts", "defer"]
-      },
-      {"path": "config"},
-      {
-        "path": "db",
-        "file_exclude_patterns": ["*.sqlite3"]
-      },
-      {"path": "lib"},
-      {"path": "script"},
-      {"path": "cookbooks"},
-      {"path": "spec"}
-    ],
-  "settings":
+  [
     {
-        "tab_size": 2,
-        "translate_tabs_to_spaces": true
-    }
+      "path": "app",
+      "folder_exclude_patterns": ["external", "external_production", "images", "imported", "fonts", "defer"]
+    },
+    { "path": "config" },
+    {
+      "path": "db",
+      "file_exclude_patterns": ["*.sqlite3"]
+    },
+    { "path": "lib" },
+    { "path": "script" },
+    { "path": "cookbooks" },
+    { "path": "spec" }
+  ],
+  "settings":
+  {
+    // indentation
+    "tab_size": 2,
+    "translate_tabs_to_spaces": true,
+    "trim_trailing_white_space_on_save": true,
+  }
 }


### PR DESCRIPTION
added the "trim_trailing_white_space_on_save setting" so developpers
using sublime text will now trim trailing white space one save

updated the vagrant configuration file so it uses ruby convention
