### PR TITLE
first attempt to serve correct localized js files as rails pipeline assets

### DIFF
--- a/app/assets/javascripts/admin/translations.js.erb
+++ b/app/assets/javascripts/admin/translations.js.erb
@@ -1,7 +1,0 @@
-//= depend_on 'client.en.yml'
-
-<% SimplesIdeias::I18n.assert_usable_configuration! %>
-<% admin = SimplesIdeias::I18n.translation_segments['app/assets/javascripts/i18n/admin.en.js']
-   admin[:en][:js] = admin[:en].delete(:admin_js)
-%>
-jQuery.extend(true, I18n.translations, <%= admin.to_json %>);

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -21,7 +21,10 @@
 // The rest of the externals
 //= require_tree ./external
 //= require i18n
-//= require discourse/translations
+
+// The following needs to go right after including i18n, because other scripts
+// below require correctly set locale already
+//= require init_locale
 
 //= require ./discourse/helpers/i18n_helpers
 //= require ./discourse

--- a/app/assets/javascripts/discourse/translations.js.erb
+++ b/app/assets/javascripts/discourse/translations.js.erb
@@ -1,5 +1,0 @@
-//= depend_on 'client.en.yml'
-
-<% SimplesIdeias::I18n.assert_usable_configuration! %>
-var I18n = I18n || {};
-I18n.translations = <%= SimplesIdeias::I18n.translation_segments['app/assets/javascripts/i18n/en.js'].to_json %>;

--- a/app/assets/javascripts/init_locale.js
+++ b/app/assets/javascripts/init_locale.js
@@ -1,0 +1,1 @@
+I18n.locale = window.currentLocale;

--- a/app/assets/javascripts/locales/en.js.erb
+++ b/app/assets/javascripts/locales/en.js.erb
@@ -1,0 +1,2 @@
+//= depend_on 'client.en.yml'
+<%= JsLocaleHelper.output_locale(:en); %>

--- a/app/assets/javascripts/locales/fr.js.erb
+++ b/app/assets/javascripts/locales/fr.js.erb
@@ -1,0 +1,2 @@
+//= depend_on 'client.fr.yml'
+<%= JsLocaleHelper.output_locale(:fr); %>

--- a/app/assets/javascripts/locales/nl.js.erb
+++ b/app/assets/javascripts/locales/nl.js.erb
@@ -1,0 +1,2 @@
+//= depend_on 'client.nl.yml'
+<%= JsLocaleHelper.output_locale(:nl); %>

--- a/app/assets/javascripts/locales/pseudo.js.erb
+++ b/app/assets/javascripts/locales/pseudo.js.erb
@@ -1,0 +1,2 @@
+//= depend_on 'client.pseudo.yml'
+<%= JsLocaleHelper.output_locale(:pseudo); %>

--- a/app/helpers/js_locale_helper.rb
+++ b/app/helpers/js_locale_helper.rb
@@ -1,0 +1,21 @@
+module JsLocaleHelper
+
+  def self.output_locale(locale)
+
+    SimplesIdeias::I18n.assert_usable_configuration!
+
+    s = "var I18n = I18n || {};"
+    segment = "app/assets/javascripts/i18n/#{locale}.js"
+    s += "I18n.translations = " + SimplesIdeias::I18n.translation_segments[segment].to_json + ";"
+
+    segment = "app/assets/javascripts/i18n/admin.#{locale}.js"
+    admin = SimplesIdeias::I18n.translation_segments[segment]
+    admin[locale][:js] = admin[locale].delete(:admin_js)
+
+    s += "jQuery.extend(true, I18n.translations, " + admin.to_json + ");"
+
+    s
+
+  end
+
+end

--- a/app/views/common/_discourse_javascript.html.erb
+++ b/app/views/common/_discourse_javascript.html.erb
@@ -14,6 +14,13 @@
   })();
 </script>
 
+<%# load the selected locale before any other scripts %>
+<%= javascript_include_tag "locales/#{I18n.locale}" %>
+<%# store the locale into a variable, because the scripts need it, see init_locale.js %>
+<script>
+  window.currentLocale = "<%= I18n.locale %>";
+</script>
+
 <%- if mini_profiler_enabled? %>
   <%- Rack::MiniProfiler.step "application" do %>
     <%= javascript_include_tag "application" %>

--- a/config/i18n-js.yml
+++ b/config/i18n-js.yml
@@ -26,3 +26,13 @@ translations:
     only: 'en.js.*'
   - file: 'app/assets/javascripts/i18n/admin.en.js'
     only: 'en.admin_js.*'
+
+  - file: 'app/assets/javascripts/i18n/pseudo.js'
+    only: 'pseudo.js.*'
+  - file: 'app/assets/javascripts/i18n/admin.pseudo.js'
+    only: 'pseudo.admin_js.*'
+
+  - file: 'app/assets/javascripts/i18n/fr.js'
+    only: 'fr.js.*'
+  - file: 'app/assets/javascripts/i18n/admin.fr.js'
+    only: 'fr.admin_js.*'

--- a/spec/javascripts/spec.js
+++ b/spec/javascripts/spec.js
@@ -18,7 +18,6 @@
 // The rest of the externals
 //= require_tree ../../app/assets/javascripts/external
 //= require i18n
-//= require ../../app/assets/javascripts/discourse/translations
 
 //= require ../../app/assets/javascripts/discourse/helpers/i18n_helpers
 //= require ../../app/assets/javascripts/discourse


### PR DESCRIPTION
Hi, this is a first attempt to implement locale switching into Discourse. I removed translations.js.erb (from both discourse/ and admin/) and instead created individual en.js.erb, fr.js.erb, etc. files in app/assets/javascripts/locales.

Now, it's possible to change locale simply by `config.i18n.locale = :fr` in config/application.rb.

Note that setting the locale on the JS side is a little bit tricky. I loaded the correct strings js file at the very beginning of application.html.erb, but you can't set `I18n.locale = xxx`, because the i18n library is not yet initialized and it will be overriden back to 'en'. So I hacked this place to save the current locale to a `window.currentLocale` variable and at the right place (right after I18n is initialized), it is loaded into `I18n.locale`. Also note that you can't simply set the locale _after_ all the scripts, because some of them needs l10n strings already during their init (doing it will bring subtle bugs, e.g. some strings will be missing).

I also merged the "admin" strings into the strings files, because there were only a few strings. Not sure if this is better or not, but it's easy to change back.

Comments and changes are welcome.
