### PR TITLE
Quick fix for Boolean SiteSettings 

### DIFF
--- a/lib/site_setting_extension.rb
+++ b/lib/site_setting_extension.rb
@@ -144,7 +144,7 @@ module SiteSettingExtension
     type = get_data_type(defaults[name])
 
     if type == Types::Bool && val != true && val != false
-      val = (val == "t" || val == "true")
+      val = (val == "t" || val == "true") ? 't' : 'f'
     end
 
     if type == Types::Fixnum && !(Fixnum === val)


### PR DESCRIPTION
Boolean SiteSettings are saved as 't' or 'f' on create!, but are being saved as 1 or 0 after update and save (settings.save). This quick fix maintains consistency, allowing boolean values to be updated and saved. 
