### PR TITLE
Specify type in topic RSS autodiscovery tag

### DIFF
--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -23,5 +23,5 @@
 <p>Powered by <a href="http://www.discourse.org">Discourse</a>, best viewed with JavaScript enabled</p>
 
 <% content_for :head do %>
-  <%= auto_discovery_link_tag(@topic_view, {action: :feed, format: :rss}, title: "RSS feed of '#{@topic_view.title}'") %>
+  <%= auto_discovery_link_tag(@topic_view, {action: :feed, format: :rss}, title: "RSS feed of '#{@topic_view.title}'", type: 'application/rss+xml') %>
 <% end %>


### PR DESCRIPTION
Left out the `type` attribute, whoops! This should make autodiscovery work.
