### PR TITLE
fixed SiteSettings without defaults Type of Null

### DIFF
--- a/lib/site_setting_extension.rb
+++ b/lib/site_setting_extension.rb
@@ -151,6 +151,10 @@ module SiteSettingExtension
       val = val.to_i
     end
 
+    if type == Types::Null && val != ''
+      type = get_data_type(val)
+    end
+
     if setting
       setting.value = val
       setting.data_type = type


### PR DESCRIPTION
This resolves the issue of SiteSettings without defined defaults saving as the wrong data type in the db.  It resets the type to Null when the field is reset, and sets it to the the Type of the value when set. 

*This makes it work, but clicking 'reset to default' on a defaultless setting on a newly loaded page does not clear the field as one would expect. Perhaps someone with more experience of Ember can get the field to clear when the value is set to Null. This is purely cosmetic though, a page refresh will show the text field as being empty. 
