### PR TITLE
RSS for topics in a category

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -60,6 +60,8 @@ class Topic < ActiveRecord::Base
 
   scope :listable_topics, lambda { where('topics.archetype <> ?', [Archetype.private_message]) }
 
+  scope :by_newest, order('created_at desc, id desc')
+
   # Helps us limit how many favorites can be made in a day
   class FavoriteLimiter < RateLimiter
     def initialize(user)

--- a/app/views/list/list.erb
+++ b/app/views/list/list.erb
@@ -9,3 +9,9 @@
 <% end %>
 
 <p><%= t 'powered_by' %></p>
+
+<% if @category %>
+  <% content_for :head do %>
+    <%= auto_discovery_link_tag(@category, {action: :category_feed, format: :rss}, title: t('rss_topics_in_category', category: @category.name), type: 'application/rss+xml') %>
+  <% end %>
+<% end %>

--- a/app/views/list/list.rss.erb
+++ b/app/views/list/list.rss.erb
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title><%= @category.name %></title>
+    <link><%= Discourse.base_url %>/category/<%= @category.slug %>.rss</link>
+    <description><%= t 'topics_in_category', category: @category.name %><%= @category.description %></description>
+    <atom:link href="<%= Discourse.base_url %>/category/<%= @category.slug %>.rss" rel="self" type="application/rss+xml" />
+    <% @topic_list.topics.each do |topic| %>
+      <item>
+        <title><%= topic.title %></title>
+        <description><![CDATA[
+          <p><%= pluralize(topic.posts_count, 'post') %></p>
+          <p><%= t 'author_wrote', author: topic.posts.first.author_readable %></p>
+          <%= topic.posts.first.cooked.html_safe %>
+        ]]></description>
+        <link><%= Discourse.base_url %><%= topic.relative_url %></link>
+        <pubDate><%= topic.created_at.rfc2822 %></pubDate>
+        <guid><%= Discourse.base_url %><%= topic.relative_url %></guid>
+        <source url="<%= Discourse.base_url %><%= topic.relative_url %>.rss"><%= topic.title %></source>
+      </item>
+    <% end %>
+  </channel>
+</rss>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -23,5 +23,5 @@
 <p><%= t 'powered_by' %></p>
 
 <% content_for :head do %>
-  <%= auto_discovery_link_tag(@topic_view, {action: :feed, format: :rss}, title: t('rss_feed', topic: @topic_view.title), type: 'application/rss+xml') %>
+  <%= auto_discovery_link_tag(@topic_view, {action: :feed, format: :rss}, title: t('rss_posts_in_topic', topic: @topic_view.title), type: 'application/rss+xml') %>
 <% end %>

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -15,7 +15,10 @@ en:
   is_invalid: "is invalid; try to be a little more descriptive"
   next_page: "next page &rarr;"
   by: "By"
-  rss_feed: "RSS feed of %{topic}"
+  topics_in_category: "Topics in the '%{category}' category"
+  rss_posts_in_topic: "RSS feed of '%{topic}'"
+  rss_topics_in_category: "RSS feed of topics in the '%{category}' category"
+  author_wrote: "%{author} wrote:"
 
   education:
     until_posts:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -137,10 +137,13 @@ Discourse::Application.routes.draw do
   resources :user_actions
   resources :education
 
+  get 'category/:category.rss' => 'list#category_feed', format: :rss, as: 'category_feed'
   get 'category/:category' => 'list#category'
+  get 'category/:category' => 'list#category', as: 'category'
+  get 'category/:category/more' => 'list#category', as: 'category'
+  get 'categories' => 'categories#index'
   get 'popular' => 'list#index'
   get 'popular/more' => 'list#index'
-  get 'categories' => 'categories#index'
   get 'favorited' => 'list#favorited'
   get 'favorited/more' => 'list#favorited'
   get 'read' => 'list#read'
@@ -151,8 +154,6 @@ Discourse::Application.routes.draw do
   get 'new/more' => 'list#new'
   get 'posted' => 'list#posted'
   get 'posted/more' => 'list#posted'
-  get 'category/:category' => 'list#category', as: 'category'
-  get 'category/:category/more' => 'list#category', as: 'category'
 
   get 'search' => 'search#query'
 

--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -114,6 +114,10 @@ class TopicQuery
     new_results(limit: false).count
   end
 
+  def list_new_in_category(category)
+    return_list {|l| l.where(category_id: category.id).by_newest.first(25)}
+  end
+
   protected
 
     def return_list(list_opts={})

--- a/spec/components/topic_query_spec.rb
+++ b/spec/components/topic_query_spec.rb
@@ -51,6 +51,12 @@ describe TopicQuery do
     it "returns nothing when filtering by another category" do
       topic_query.list_category(Fabricate(:category, name: 'new cat')).topics.should be_blank
     end
+
+    describe '#list_new_in_category' do
+      it 'returns only the categorized topic' do
+        topic_query.list_new_in_category(category).topics.should == [topic_in_cat]
+      end
+    end
   end
 
   context 'unread / read topics' do

--- a/spec/controllers/list_controller_spec.rb
+++ b/spec/controllers/list_controller_spec.rb
@@ -43,6 +43,14 @@ describe ListController do
         it { should respond_with(:success) }
       end
 
+      describe 'feed' do
+        it 'renders RSS' do
+          get :category_feed, category: category.slug, format: :rss
+          response.should be_success
+          response.content_type.should == 'application/rss+xml'
+        end
+      end
+
     end
 
     context 'uncategorized' do
@@ -58,8 +66,6 @@ describe ListController do
       end
 
     end
-
-
 
   end
 

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -1033,4 +1033,17 @@ describe Topic do
 
   end
 
+  describe 'scopes' do
+    describe '#by_most_recently_created' do
+      it 'returns topics ordered by created_at desc, id desc' do
+        now = Time.now
+        a = Fabricate(:topic, created_at: now - 2.minutes)
+        b = Fabricate(:topic, created_at: now)
+        c = Fabricate(:topic, created_at: now)
+        d = Fabricate(:topic, created_at: now - 2.minutes)
+        Topic.by_newest.should == [c,b,d,a]
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
Creates a new route for category RSS. It raises if you try to get the RSS for "uncategorized".

Things I'm not happy about:
- having to assign `@category` so the normal show view can get at it to draw the autodiscovery tag
- all the URL nonsense in the RSS view
- that there isn't a feed for "uncategorized" *

\* I wanted there to be one, but it meant a slew of additional URL nonsense in the views.
