### PR TITLE
Refactor User and TrustLevel a bit

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -143,7 +143,7 @@ class UsersController < ApplicationController
     if auth && auth[:email] == params[:email] && auth[:email_valid]
       user.active = true
     end
-    user.password_required unless auth
+    user.password_required! unless auth
 
     DiscourseHub.register_nickname( user.username, user.email ) if user.valid? and SiteSetting.call_discourse_hub?
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1239,7 +1239,7 @@ CREATE TABLE categories (
 --
 
 CREATE SEQUENCE categories_id_seq
-    START WITH 1
+    START WITH 5
     INCREMENT BY 1
     NO MINVALUE
     NO MAXVALUE
@@ -1324,7 +1324,7 @@ CREATE TABLE draft_sequences (
 --
 
 CREATE SEQUENCE draft_sequences_id_seq
-    START WITH 1
+    START WITH 20
     INCREMENT BY 1
     NO MINVALUE
     NO MAXVALUE
@@ -1358,7 +1358,7 @@ CREATE TABLE drafts (
 --
 
 CREATE SEQUENCE drafts_id_seq
-    START WITH 1
+    START WITH 2
     INCREMENT BY 1
     NO MINVALUE
     NO MAXVALUE
@@ -1391,7 +1391,7 @@ CREATE TABLE email_logs (
 --
 
 CREATE SEQUENCE email_logs_id_seq
-    START WITH 1
+    START WITH 3
     INCREMENT BY 1
     NO MINVALUE
     NO MAXVALUE
@@ -1426,7 +1426,7 @@ CREATE TABLE email_tokens (
 --
 
 CREATE SEQUENCE email_tokens_id_seq
-    START WITH 1
+    START WITH 3
     INCREMENT BY 1
     NO MINVALUE
     NO MAXVALUE
@@ -1672,7 +1672,7 @@ CREATE TABLE onebox_renders (
 --
 
 CREATE SEQUENCE onebox_renders_id_seq
-    START WITH 1
+    START WITH 2
     INCREMENT BY 1
     NO MINVALUE
     NO MAXVALUE
@@ -1706,7 +1706,7 @@ CREATE TABLE post_action_types (
 --
 
 CREATE SEQUENCE post_action_types_id_seq
-    START WITH 1
+    START WITH 6
     INCREMENT BY 1
     NO MINVALUE
     NO MAXVALUE
@@ -1837,7 +1837,7 @@ CREATE TABLE posts (
 --
 
 CREATE SEQUENCE posts_id_seq
-    START WITH 1
+    START WITH 16
     INCREMENT BY 1
     NO MINVALUE
     NO MAXVALUE
@@ -1928,7 +1928,7 @@ CREATE TABLE site_settings (
 --
 
 CREATE SEQUENCE site_settings_id_seq
-    START WITH 1
+    START WITH 4
     INCREMENT BY 1
     NO MINVALUE
     NO MAXVALUE
@@ -1960,7 +1960,7 @@ CREATE TABLE topic_allowed_users (
 --
 
 CREATE SEQUENCE topic_allowed_users_id_seq
-    START WITH 1
+    START WITH 3
     INCREMENT BY 1
     NO MINVALUE
     NO MAXVALUE
@@ -2152,7 +2152,7 @@ CREATE TABLE topics (
 --
 
 CREATE SEQUENCE topics_id_seq
-    START WITH 1
+    START WITH 16
     INCREMENT BY 1
     NO MINVALUE
     NO MAXVALUE
@@ -2258,7 +2258,7 @@ CREATE TABLE user_actions (
 --
 
 CREATE SEQUENCE user_actions_id_seq
-    START WITH 1
+    START WITH 40
     INCREMENT BY 1
     NO MINVALUE
     NO MAXVALUE
@@ -2322,7 +2322,7 @@ CREATE TABLE user_visits (
 --
 
 CREATE SEQUENCE user_visits_id_seq
-    START WITH 1
+    START WITH 4
     INCREMENT BY 1
     NO MINVALUE
     NO MAXVALUE
@@ -2389,7 +2389,7 @@ CREATE TABLE users (
 --
 
 CREATE SEQUENCE users_id_seq
-    START WITH 1
+    START WITH 3
     INCREMENT BY 1
     NO MINVALUE
     NO MAXVALUE

--- a/lib/promotion.rb
+++ b/lib/promotion.rb
@@ -13,7 +13,7 @@ class Promotion
     # nil users are never promoted
     return false if @user.blank?
 
-    trust_key = TrustLevel.Levels.invert[@user.trust_level]
+    trust_key = TrustLevel.level_key(@user.trust_level)
 
     review_method = :"review_#{trust_key.to_s}"
     return send(review_method) if respond_to?(review_method)

--- a/lib/trust_level.rb
+++ b/lib/trust_level.rb
@@ -2,18 +2,33 @@ class TrustLevel
 
   attr_reader :id, :name
 
-  def self.Levels
-    {:new => 0,
-     :basic => 1,
-     :regular => 2,
-     :experienced => 3,
-     :advanced => 4,
-     :moderator => 5}
-  end
+  class << self
+    def levels
+      { new: 0,
+        basic: 1,
+        regular: 2,
+        experienced: 3,
+        advanced: 4,
+        moderator: 5 }
+    end
+    alias_method :Levels, :levels
 
-  def self.all
-    self.Levels.map do |name_key, id|
-      TrustLevel.new(name_key, id)
+    def all
+      levels.map do |name_key, id|
+        TrustLevel.new(name_key, id)
+      end
+    end
+
+    def valid_level?(level)
+      levels.has_key?(level)
+    end
+
+    def compare(current_level, level)
+      (current_level || levels[:new]) >= levels[level]
+    end
+
+    def level_key(level)
+      levels.invert[level]
     end
   end
 
@@ -23,6 +38,6 @@ class TrustLevel
   end
 
   def serializable_hash
-    {id: @id, name: @name}
+    { id: @id, name: @name }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -87,7 +87,7 @@ describe User do
 
   end
 
-  describe '.approve!' do
+  describe '.approve' do
     let(:user) { Fabricate(:user) }
     let(:admin) { Fabricate(:admin) }
 
@@ -231,7 +231,7 @@ describe User do
       User.new.trust_level.should == TrustLevel.Levels[:advanced]
     end
 
-    describe 'has_trust_level' do
+    describe 'has_trust_level?' do
 
       it "raises an error with an invalid level" do
         lambda { user.has_trust_level?(:wat) }.should raise_error


### PR DESCRIPTION
- rename `User#password_required` to `User#password_required!`
- emails with "i" @ something are a special case as well
- get rid of `self.` and returns where possible
- prefer "unless a" instead of "if !a"
- `unread_notifications` without manually iterating
- introduce `User#moderator?`
- introduce `TrustLevel#valid_key?`, `TrustLevel#compare`, and `TrustLevel#level_key`
