### PR TITLE
Better search

### DIFF
--- a/lib/search.rb
+++ b/lib/search.rb
@@ -100,7 +100,8 @@ module Search
   def self.query(term, type_filter=nil)
 
     return nil if term.blank?
-    sanitized_term = PG::Connection.escape_string(term) #term.gsub(/[^0-9a-zA-Z_ ]/, '')
+    sanitized_term = PG::Connection.escape_string(term.gsub(/[:()&!]/,'')) # Instead of original term.gsub(/[^0-9a-zA-Z_ ]/, '')
+    # We are stripping only symbols taking place in FTS and simply sanitizing the rest.
 
     # really short terms are totally pointless
     return nil if sanitized_term.blank? || sanitized_term.length < self.min_search_term_length

--- a/spec/components/search_spec.rb
+++ b/spec/components/search_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require 'spec_helper'
 require 'search'
 
@@ -70,8 +72,7 @@ describe Search do
   end
 
   it 'escapes non alphanumeric characters' do
-    ActiveRecord::Base.expects(:exec_sql).never
-    Search.query(':!$').should be_blank
+    Search.query(':!$);}]>@\#\"\'').should be_blank # There are at least three levels of sanitation for Search.query!
   end
 
   it 'works when given two terms with spaces' do
@@ -121,6 +122,20 @@ describe Search do
       end
     end
 
+  end
+
+  context 'cyrillic topic' do
+    let!(:cyrillic_topic) { Fabricate(:topic) do
+                                                user
+                                                title { sequence(:title) { |i| "Тестовая запись #{i}" } }
+                                              end
+    }
+    let!(:post) {Fabricate(:post, topic: cyrillic_topic, user: cyrillic_topic.user)}
+    let(:result) { first_of_type(Search.query('запись'), 'topic') }
+
+    it 'finds something when given cyrillic query' do
+      result.should be_present
+    end
   end
 
   context 'categories' do


### PR DESCRIPTION
Search now supports non-BasicLatin characters.
All required precautions are taken to avoid SQL injections. For example, there is no more direct query concationations, and named parameters substitutions are used instead.
TSQUERY parameters for Postgres FTS are now locale-dependent, so case-insensivity and stemming should work considering `I18n.locale` parameter. (Only `:ru`, `:fr`, `:sv` and `:nl` are currenly recognized, with accordance to existing translations. All other locale values are defaulting TSQUERY parameter  to `'english'`.)

This should fix search in most UTF-8 languages (bugs #255, #198 and #209).
