### PR TITLE
Secure gravatar

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -315,7 +315,7 @@ class User < ActiveRecord::Base
     email_hash = self.email_hash(email)
     # robohash was possibly causing caching issues
     # robohash = CGI.escape("http://robohash.org/size_") << "{size}x{size}" << CGI.escape("/#{email_hash}.png")
-    "http://www.gravatar.com/avatar/#{email_hash}.png?s={size}&r=pg&d=identicon"
+    "https://www.gravatar.com/avatar/#{email_hash}.png?s={size}&r=pg&d=identicon"
   end
 
   # return null for local avatars, a template for gravatar


### PR DESCRIPTION
This closes #292 and deals with some of my own concerns as well.

I doubt there will be any difficulties with mandatory activation of https for all Gravatar requests.
