### PR TITLE
updated sublime-project settings

### DIFF
--- a/sublime-project
+++ b/sublime-project
@@ -22,5 +22,7 @@
     "tab_size": 2,
     "translate_tabs_to_spaces": true,
     "trim_trailing_white_space_on_save": true
+    // ensure line endings is linux style (even when on Windows)
+    "default_line_ending": "LF"
   }
 }


### PR DESCRIPTION
'default_line_ending' is set to **LF** so it doesn't break line-ending-sensitive specs on Windows (like oneboxer's)
