### PR TITLE
Basic caching for topic/category RSS feeds

### DIFF
--- a/app/controllers/list_controller.rb
+++ b/app/controllers/list_controller.rb
@@ -51,13 +51,16 @@ class ListController < ApplicationController
     raise Discourse::InvalidParameters.new('Category RSS of "uncategorized"') if params[:category] == Slug.for(SiteSetting.uncategorized_name) || params[:category] == SiteSetting.uncategorized_name
 
     @category = Category.where("slug = ?", params[:category]).includes(:featured_users).first
+
     guardian.ensure_can_see!(@category)
-    @topic_list = TopicQuery.new.list_new_in_category(@category)
-    render 'list', formats: [:rss]
+
+    anonymous_etag(@category) do
+      @topic_list = TopicQuery.new.list_new_in_category(@category)
+      render 'list', formats: [:rss]
+    end
   end
 
   protected
-
 
   def respond(list)
 

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -83,7 +83,6 @@ class TopicsController < ApplicationController
     toggle_mute(false)
   end
 
-
   def destroy
     topic = Topic.where(id: params[:id]).first
     guardian.ensure_can_delete!(topic)
@@ -143,7 +142,9 @@ class TopicsController < ApplicationController
 
   def feed
     @topic_view = TopicView.new(params[:topic_id])
-    render 'topics/show', formats: [:rss]
+    anonymous_etag(@topic_view.topic) do
+      render 'topics/show', formats: [:rss]
+    end
   end
 
   private


### PR DESCRIPTION
Uses the `anonymous_etag` helper to set up caching for RSS feeds.

Is there a good way to test this?
