### PR TITLE
Get secret_token from ENV['SECRET_TOKEN'] (e.g. for Heroku)

### DIFF
--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -13,9 +13,7 @@
 if Rails.env.test? || Rails.env.development?
   Discourse::Application.config.secret_token = "47f5390004bf6d25bb97083fb98e7cc133ab450ba814dd19638a78282b4ca291"
 else
-  if Rails.env.production? && ENV['SECRET_TOKEN'].blank?
-    raise 'SECRET_TOKEN environment variable must be set!'
-  end
+  raise "You must set a secret token in ENV['SECRET_TOKEN'] or in config/initializers/secret_token.rb" if ENV['SECRET_TOKEN'].blank?
   Discourse::Application.config.secret_token = ENV['SECRET_TOKEN']
 end
 


### PR DESCRIPTION
Hi,
i just had a setup on Heroku where i needed to store my secret token in a env-variable.
Maybe this can be useful for some other people :yum: 
