### PR TITLE
Change the name displayed in the header on profile update

### DIFF
--- a/app/assets/javascripts/discourse/controllers/preferences_controller.js
+++ b/app/assets/javascripts/discourse/controllers/preferences_controller.js
@@ -53,14 +53,18 @@ Discourse.PreferencesController = Discourse.ObjectController.extend({
   }).property(),
 
   save: function() {
-    var _this = this;
+    var _this = this, model = this.get('content');
     this.set('saving', true);
     this.set('saved', false);
 
     // Cook the bio for preview
-    return this.get('content').save(function(result) {
+    return model.save(function(result) {
       _this.set('saving', false);
       if (result) {
+        if (Discourse.currentUser.id === model.get('id')) {
+          Discourse.currentUser.set('name', model.get('name'));
+        }
+      
         _this.set('content.bio_cooked', Discourse.Utilities.cook(_this.get('content.bio_raw')));
         return _this.set('saved', true);
       } else {

--- a/app/assets/javascripts/discourse/templates/header.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/header.js.handlebars
@@ -8,7 +8,7 @@
       {{#unless controller.showExtraInfo}}
         <div class='current-username'>
           {{#if view.currentUser}}
-          <span class='username'><a {{bindAttr href="view.currentUser.path"}}>{{unbound view.currentUser.name}}</a></span>
+          <span class='username'><a {{bindAttr href="view.currentUser.path"}}>{{view.currentUser.name}}</a></span>
           {{else}}
             <button {{action showLogin}} class='btn btn-primary btn-small'>{{i18n log_in}}</button>
           {{/if}}


### PR DESCRIPTION
Linked Meta post: [Profile: Save after name edit does not automatically update page header](http://meta.discourse.org/t/profile-save-after-name-edit-does-not-automatically-update-page-header/4324)
