### PR TITLE
Removed Strange Test-Output

### DIFF
--- a/spec/components/search_spec.rb
+++ b/spec/components/search_spec.rb
@@ -72,7 +72,7 @@ describe Search do
   end
 
   it 'escapes non alphanumeric characters' do
-    Search.query(':!$);}]>@\#\"\'').should be_blank # There are at least three levels of sanitation for Search.query!
+    Search.query('foo :!$);}]>@\#\"\'').should be_blank # There are at least three levels of sanitation for Search.query!
   end
 
   it 'works when given two terms with spaces' do


### PR DESCRIPTION
When running all specs, you find this:

```
NOTICE:  text-search query contains only stop words or doesn't contain lexemes, ignored
NOTICE:  text-search query contains only stop words or doesn't contain lexemes, ignored
NOTICE:  text-search query contains only stop words or doesn't contain lexemes, ignored
NOTICE:  text-search query contains only stop words or doesn't contain lexemes, ignored
NOTICE:  text-search query contains only stop words or doesn't contain lexemes, ignored
NOTICE:  text-search query contains only stop words or doesn't contain lexemes, ignored
NOTICE:  text-search query contains only stop words or doesn't contain lexemes, ignored
NOTICE:  text-search query contains only stop words or doesn't contain lexemes, ignored
```

while running spec/components/search_spec.rb. I fixed that, because it was somehow annoying :octocat: 
