### PR TITLE
updated Gemfile.lock to take into account the rb-inotify's version bump

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -336,7 +336,7 @@ GEM
       thor (>= 0.14.6, < 2.0)
     rake (10.0.3)
     rb-fsevent (0.9.3)
-    rb-inotify (0.8.8)
+    rb-inotify (0.9.0)
       ffi (>= 0.5.0)
     rdoc (3.12.1)
       json (~> 1.4)
@@ -503,7 +503,7 @@ DEPENDENCIES
   rails_multisite!
   rake
   rb-fsevent
-  rb-inotify (~> 0.8.8)
+  rb-inotify (~> 0.9)
   redcarpet
   redis
   redis-rails


### PR DESCRIPTION
so developpers will get it updated when doing a `bundle install`
