### PR TITLE
Position the selected post more reliably below the header

### DIFF
--- a/app/assets/javascripts/discourse/views/topic_view.js
+++ b/app/assets/javascripts/discourse/views/topic_view.js
@@ -494,14 +494,22 @@ window.Discourse.TopicView.reopenClass({
   // Scroll to a given post, if in the DOM. Returns whether it was in the DOM or not.
   scrollTo: function(topicId, postNumber, callback) {
     // Make sure we're looking at the topic we want to scroll to
-    var existing;
+    var existing, header, title, expectedOffset;
     if (parseInt(topicId, 10) !== parseInt($('#topic').data('topic-id'), 10)) return false;
     existing = $("#post_" + postNumber);
     if (existing.length) {
       if (postNumber === 1) {
         $('html, body').scrollTop(0);
       } else {
-        $('html, body').scrollTop(existing.offset().top - 55);
+        header = $('header');
+        title = $('#topic-title');
+        expectedOffset = title.height() - header.find('.contents').height();
+        
+        if (expectedOffset < 0) {
+            expectedOffset = 0;
+        }
+        
+        $('html, body').scrollTop(existing.offset().top - (header.outerHeight(true) + expectedOffset));
       }
       return true;
     }


### PR DESCRIPTION
Linked meta post: [The upper part of a post is hidden when the topic title is too long](http://meta.discourse.org/t/the-upper-part-of-a-post-is-hidden-when-the-topic-title-is-too-long)

It'd probably be better if we could just take the outer height of the header after the transformation performed when `showExtraInfo` is set on the header controller, but I don't think there's really a clean way to make that happen from `scrollTo()`.

I also considered triggering the initial scroll and then resampling the height and adjusting as necessary, but that ended up being far messier, and I was worried about it being jumpy.
