### PR TITLE
Don't double-up on #main-outlet when static content is preloaded

### DIFF
--- a/app/assets/javascripts/discourse/controllers/static_controller.js
+++ b/app/assets/javascripts/discourse/controllers/static_controller.js
@@ -18,7 +18,8 @@ Discourse.StaticController = Discourse.Controller.extend({
     $preloaded = $("noscript[data-path=\"" + path + "\"]");
     if ($preloaded.length) {
       text = $preloaded.text();
-      text = text.replace(/<header[\s\S]*<\/header\>/, '');
+      text = text.match(/<!-- preload-content: -->((?:.|[\n\r])*)<!-- :preload-content -->/);
+      text = text[1];
       return this.set('content', text);
     } else {
       return jQuery.ajax({

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -40,7 +40,9 @@
           </div>
         </header>
         <div id="main-outlet" class="container">
+          <!-- preload-content: -->
           <%= yield %>
+          <!-- :preload-content -->
         </div>
       </noscript>
     </section>


### PR DESCRIPTION
Linked Meta post: [Page width size for FAQ](http://meta.discourse.org/t/page-width-size-for-faq/4370)

The alternative is to do `text()` -> HTML, then take the contents of `#main-outlet` and convert them back to a string. Since this is a pretty simple use case I figured regex'ing on the comments was the easier (and perhaps slightly more efficient) approach, even if it is kind of deliberate.
