### PR TITLE
fix wrongly escaped HTML in <noscript> tags

### DIFF
--- a/app/views/list/list.erb
+++ b/app/views/list/list.erb
@@ -8,7 +8,7 @@
 <p><a href="<%= @list.more_topics_url.sub('.json?','?') %>"><%= t 'next_page'%></a></p>
 <% end %>
 
-<p><%= t 'powered_by' %></p>
+<p><%= t 'powered_by_html' %></p>
 
 <% if @category %>
   <% content_for :head do %>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -20,7 +20,7 @@
 <% end %>
 
 
-<p><%= t 'powered_by' %></p>
+<p><%= t 'powered_by_html' %></p>
 
 <% content_for :head do %>
   <%= auto_discovery_link_tag(@topic_view, {action: :feed, format: :rss}, title: t('rss_posts_in_topic', topic: @topic_view.title), type: 'application/rss+xml') %>

--- a/config/locales/server.cs.yml
+++ b/config/locales/server.cs.yml
@@ -2,7 +2,7 @@ cs:
   title: "Discourse"
   topics: "Témata"
   loading: "Nahrávám"
-  powered_by: 'Systém běží na <a href="http://www.discourse.org">Discourse</a>, nejlepší zážitek je se zapnutým JavaScriptem'
+  powered_by_html: 'Systém běží na <a href="http://www.discourse.org">Discourse</a>, nejlepší zážitek je se zapnutým JavaScriptem'
 
   via: "%{username} přes %{site_name}"
   is_reserved: "je rezervováno"
@@ -13,7 +13,7 @@ cs:
   has_already_been_used: "již bylo použito"
   invalid_characters: "obsahuje neplatné znaky"
   is_invalid: "je neplatné; zkuste se vyjádřit více popisně"
-  next_page: "další strana &rarr;"
+  next_page: "další strana →"
   by: "Od"
   topics_in_category: "Témata v kategorii '%{category}'"
   rss_posts_in_topic: "RSS feed tématu '%{topic}'"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2,7 +2,7 @@ en:
   title: "Discourse"
   topics: "Topics"
   loading: "Loading"
-  powered_by: 'Powered by <a href="http://www.discourse.org">Discourse</a>, best viewed with JavaScript enabled'
+  powered_by_html: 'Powered by <a href="http://www.discourse.org">Discourse</a>, best viewed with JavaScript enabled'
 
   via: "%{username} via %{site_name}"
   is_reserved: "is reserved"
@@ -13,7 +13,7 @@ en:
   has_already_been_used: "has already been used"
   invalid_characters: "contains invalid characters"
   is_invalid: "is invalid; try to be a little more descriptive"
-  next_page: "next page &rarr;"
+  next_page: "next page →"
   by: "By"
   topics_in_category: "Topics in the '%{category}' category"
   rss_posts_in_topic: "RSS feed of '%{topic}'"

--- a/config/locales/server.fr.yml
+++ b/config/locales/server.fr.yml
@@ -9,7 +9,7 @@ fr:
   title: "Discourse"
   topics: "Discussions"
   loading: "Chargement"
-  powered_by: 'Propulsé par <a href="http://www.discourse.org">Discourse</a>, best viewed with JavaScript enabled'
+  powered_by_html: 'Propulsé par <a href="http://www.discourse.org">Discourse</a>, best viewed with JavaScript enabled'
 
   via: "%{username} via %{site_name}"
   is_reserved: "est réservé"
@@ -20,7 +20,7 @@ fr:
   has_already_been_used: "a déjà été utilisé"
   invalid_characters: "contient des caractères invalides"
   is_invalid: "est invalide; essayez d'être plus précis"
-  next_page: "page suivante &rarr;"
+  next_page: "page suivante →"
   by: "Par"
   topics_in_category: "Discussions dans la catégorie '%{category}'"
   rss_posts_in_topic: "Flux RSS de '%{topic}'"


### PR DESCRIPTION
Currently on master (and on meta.discourse.org), in `<noscript>` tags, there is:

```
<p><a href="/popular?page=1">next page &amp;rarr;</a></p>
<p>Powered by &lt;a href=&quot;http://www.discourse.org&quot;&gt;Discourse&lt;/a&gt;, best viewed with JavaScript enabled</p>
```

which is a wrongly escaped HTML. This happened because of translations, which escape HTML by default. This commit fixes it by inserting the arrow directly as a unicode character and changing the name of `powered_by` into `powered_by_html`.
