### PR TITLE
apply locale in sidekiq jobs

### DIFF
--- a/lib/jobs.rb
+++ b/lib/jobs.rb
@@ -38,6 +38,7 @@ module Jobs
         begin
           Jobs::Base.mutex.synchronize do
             RailsMultisite::ConnectionManagement.establish_connection(:db => db)
+            I18n.locale = SiteSetting.default_locale
             execute(opts)
           end
         ensure


### PR DESCRIPTION
Currently sidekiq jobs run in 'en' locale, which causes for example emails to be sent in English, even when `SiteSetting.default_locale` is set to other languages. This simply sets `I18n.locale = SiteSetting.default_locale` before every job to execute.
