### PR TITLE
messagebus diagnostics process path on Mac OS

### DIFF
--- a/vendor/gems/message_bus/lib/message_bus/diagnostics.rb
+++ b/vendor/gems/message_bus/lib/message_bus/diagnostics.rb
@@ -1,8 +1,13 @@
 class MessageBus::Diagnostics
   def self.full_process_path
     begin
-      info = `ps -eo "%p|$|%a" | grep '^\\s*#{Process.pid}'`
-      info.strip.split('|$|')[1]
+      system = `uname`.strip
+      if system == "Darwin"
+        `ps -o "comm=" -p #{Process.pid}`
+      else
+        info = `ps -eo "%p|$|%a" | grep '^\\s*#{Process.pid}'`
+        info.strip.split('|$|')[1]
+      end
     rescue
       # skip it ... not linux or something weird
     end


### PR DESCRIPTION
Currently, every time I run rails (on my Mac OS X), this warning is shown on the console:

```
ps: %p|$|%a: keyword not found
ps: no valid keywords; valid keywords:
```

This is caused by MessageBus diagnostics, which during init, tries to get current process' full path using

```
info = `ps -eo "%p|$|%a" | grep '^\\s*#{Process.pid}'`
```

which uses Linux-specific syntax. To make it work on Mac OS too, I included a trivial OS check.
