### PR TITLE
[discussion] Disabling the observers by default in test

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -67,6 +67,13 @@ Spork.prefork do
       DiscoursePluginRegistry.clear
     end
 
+    # allows temporary activation of observers
+    config.include ManagedObservers
+    # desactivate all observers by default
+    config.before(:all) do
+      ActiveRecord::Base.observers.disable(:all)
+    end
+
   end
 
   class DateTime

--- a/spec/support/managed_observers.rb
+++ b/spec/support/managed_observers.rb
@@ -1,0 +1,13 @@
+module ManagedObservers
+
+  # Temporarily activates a list of observers
+  def with_observer(*observers)
+    ActiveRecord::Base.observers.enable(*observers)
+    yield
+    ActiveRecord::Base.observers.disable(:all)
+  end
+
+  # plural alias to the previous method
+  alias_method :with_observers, :with_observer
+
+end


### PR DESCRIPTION
### /!\ WORK IN PROGRESS /!\

I found out that disabling the observers and manually enabling them when needed might help improving the speed of the test suite.

This is a [POC](http://en.wikipedia.org/wiki/Proof_of_concept) and is in no way finished, thus it is normal the tests are failing :wink: 

With these modifications, I've managed to gain about **10 %** on the specifications for the user actions:

``` bash
# running
$ time bundle exec rspec spec/models/user_action_spec.rb

# before
...
Finished in 9.25 seconds

real    0m33.464s
user    0m23.325s
sys     0m4.636s

# after
...
Finished in 6.34 seconds

real    0m30.495s
user    0m21.401s
sys     0m4.028s
```

**Questions:**
- Is it something worth doing for the whole test suite?
- Should we start migrating off Observers instead? (as they have been [extracted out of Rails 4](http://blog.remarkablelabs.com/2012/12/observers-gem-extraction-rails-4-countdown-to-2013))

**Note:** solution base on this article: [Test Observers with Rails 3.2.6](https://coderwall.com/p/asrvsw)
