### PR TITLE
Small change from xyz.com to example.com

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -282,8 +282,8 @@ en:
     new_topics_rollup: "How many new topics can be inserted on the topic list before rolling up into a count"
     onebox_max_chars: "Maximum characters a onebox will import from an external website into the post"
 
-    logo_url: "The logo for your site eg: http://xyz.com/x.png"
-    logo_small_url: "The small logo for your site used when scrolling down on topics eg: http://xyz.com/x-small.png"
+    logo_url: "The logo for your site eg: http://example.com/logo.png"
+    logo_small_url: "The small logo for your site used when scrolling down on topics eg: http://example.com/logo-small.png"
     favicon_url: "A favicon for your site, see http://en.wikipedia.org/wiki/Favicon"
     notification_email: "The return email address used when sending system emails such as notifying users of lost passwords, new accounts etc"
     use_ssl: "Should the site be accessible via SSL?"


### PR DESCRIPTION
Removed the reference to xyz.com since it is a real page and changed it to the example.com domain.  
