### PR TITLE
added observer to Discourse.PagedownEditor value to refresh previewer

### DIFF
--- a/app/assets/javascripts/discourse/views/pagedown_editor.js
+++ b/app/assets/javascripts/discourse/views/pagedown_editor.js
@@ -34,7 +34,14 @@ Discourse.PagedownEditor = Ember.ContainerView.extend({
     $wmdInput.data('init', true);
     this.editor = Discourse.Markdown.createEditor();
     return this.editor.run();
-  }
+  },
+
+  observeValue: (function() {
+    var _this = this;
+    Ember.run.next(null, function() {
+      _this.editor && _this.editor.refreshPreview();
+    });
+  }).observes('value')
 
 });
 


### PR DESCRIPTION
Added an observer to the Discourse.PagedownEditor class so that any changes to the value refresh the Markdown preview.
