### PR TITLE
Always allow reply as new topic, for users who can reply as new topic

### DIFF
--- a/app/serializers/topic_view_serializer.rb
+++ b/app/serializers/topic_view_serializer.rb
@@ -103,11 +103,11 @@ class TopicViewSerializer < ApplicationSerializer
   end
 
   def can_reply_as_new_topic
-    scope.can_reply_as_new_topic?(object.topic)
+    true
   end
 
   def include_can_reply_as_new_topic?
-    scope.can_create?(Post, object.topic)
+    scope.can_reply_as_new_topic?(object.topic)
   end
 
   def can_create_post


### PR DESCRIPTION
Per [Jeff's request](http://meta.discourse.org/t/should-reply-as-new-topic-still-be-allowed-on-closed-posts/4626/3), always allow reply as new topic for users who are allowed to reply as new topic in the general case.
