### PR TITLE
Fix rounding issue with humane.js (i.e. 60 minutes)

### DIFF
--- a/app/assets/javascripts/external/humane.js
+++ b/app/assets/javascripts/external/humane.js
@@ -99,10 +99,13 @@ function humaneDate(date, compareTo){
             }
 
             var val = Math.ceil(normalize(seconds, format[3]) / (format[3]));
-            return val +
-                    ' ' +
-                    (val != 1 ? format[2] : format[1]) +
-                    (i > 0 ? token : '');
+            
+            if (val * format[3] < format[0]) {            
+                return val +
+                        ' ' +
+                        (val != 1 ? format[2] : format[1]) +
+                        (i > 0 ? token : '');
+            }
         }
     }
 };


### PR DESCRIPTION
Linked Meta topic: [“24 hours” Timestamp Should Probably Be “1 day”](http://meta.discourse.org/t/24-hours-timestamp-should-probably-be-1-day/4643)

Simple rounding issue. I've just patched it in Discourse, but I'll make a note to submit a PR to the source project as well.
