### PR TITLE
digest email had hardcoded English date format

### DIFF
--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -40,7 +40,7 @@ class UserNotifications < ActionMailer::Base
 
     @site_name = SiteSetting.title
 
-    @last_seen_at = (@user.last_seen_at || @user.created_at).strftime("%m-%d-%Y")
+    @last_seen_at = (@user.last_seen_at || @user.created_at).strftime(I18n.t('user_notifications.digest.date_format'))
 
     # A list of new topics to show the user
     @new_topics = Topic.new_topics(min_date)
@@ -54,7 +54,7 @@ class UserNotifications < ActionMailer::Base
            from: "#{I18n.t('user_notifications.digest.from', site_name: SiteSetting.title)} <#{SiteSetting.notification_email}>",
            subject: I18n.t('user_notifications.digest.subject_template',
                             :site_name => @site_name,
-                            :date => Time.now.strftime("%m-%d-%Y"))
+                            :date => Time.now.strftime(I18n.t('user_notifications.digest.date_format')))
     end
   end
 

--- a/config/locales/server.cs.yml
+++ b/config/locales/server.cs.yml
@@ -718,6 +718,7 @@ cs:
       unsubscribe: "Tento souhrnný email je zaslán jako oznámení od %{site_link}, pokud jste se nepřihlásil za posledních 7 dní.\nPokud nechcete tento souhrn dostávat, navštivte %{unsubscribe_link}."
       click_here: "klikněte zde"
       from: "souhrn z %{site_name}"
+      date_format: "%d.%m.%Y"
 
     private_message:
       subject_template: "[%{site_name}] %{subject_prefix}%{topic_title}"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -718,6 +718,7 @@ en:
       unsubscribe: "This summary email is sent as a courtesy notification from %{site_link} when we haven't seen you in a while.\nIf you'd like to turn it off or change your email preferences, %{unsubscribe_link}."
       click_here: "click here"
       from: "%{site_name} digest"
+      date_format: "%m-%d-%Y"
 
     private_message:
       subject_template: "[%{site_name}] %{subject_prefix}%{topic_title}"


### PR DESCRIPTION
Email digest gets sent with hardcoded mm-dd-yyyy format of date. I am not sure if locales/server.en.yml is the best place to store localized date formats, is there somewhere better?

Also there are probably more server-side places where date gets formatted in hardcoded english format. I will try to locate these.
