### PR TITLE
reports don't work when default_locale != en + some missing translations

### DIFF
--- a/app/assets/javascripts/admin/helpers/report_helpers.js
+++ b/app/assets/javascripts/admin/helpers/report_helpers.js
@@ -7,7 +7,7 @@
 Handlebars.registerHelper('valueAtDaysAgo', function(property, i) {
   var data = Ember.Handlebars.get(this, property);
   if( data ) {
-    var wantedDate = Date.create(i + ' days ago').format('{yyyy}-{MM}-{dd}');
+    var wantedDate = Date.create(i + ' days ago', 'en').format('{yyyy}-{MM}-{dd}');
     var item = data.find( function(d, i, arr) { return d.x === wantedDate; } );
     if( item ) {
       return item.y;
@@ -26,7 +26,7 @@ Handlebars.registerHelper('valueAtDaysAgo', function(property, i) {
 Handlebars.registerHelper('sumLast', function(property, numDays) {
   var data = Ember.Handlebars.get(this, property);
   if( data ) {
-    var earliestDate = Date.create(numDays + ' days ago');
+    var earliestDate = Date.create(numDays + ' days ago', 'en');
     var sum = 0;
     data.each(function(d){
       if(Date.create(d.x) >= earliestDate) {

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -245,12 +245,20 @@ en:
   reports:
     visits:
       title: "Users Visits"
+      xaxis: "Day"
+      yaxis: "Number of visits"
     signups:
       title: "New Users"
+      xaxis: "Day"
+      yaxis: "Number of new users"
     topics:
       title: "New Topics"
+      xaxis: "Day"
+      yaxis: "Number of new topics"
     posts:
       title: "New Posts"
+      xaxis: "Day"
+      yaxis: "Number of new posts"
 
   site_settings:
     default_locale: "The default language of this Discourse instance (ISO 639-1 Code)"


### PR DESCRIPTION
1) `Date.create(i + ' days ago')` is no longer valid, since Date can have switched locale

2) `I18n.t("reports.#{self.type}.title")` in models/report.rb is missing the translation string in server.en.yml
