### PR TITLE
the composer will now count only significant whitespaces

### DIFF
--- a/app/assets/javascripts/discourse/models/composer.js
+++ b/app/assets/javascripts/discourse/models/composer.js
@@ -478,7 +478,7 @@ Discourse.Composer = Discourse.Model.extend({
   },
 
   /**
-    Computes the length of the reply minus the quote(s).
+    Computes the length of the reply minus the quote(s) and non-significant whitespaces
 
     @property replyLength
   **/
@@ -486,7 +486,7 @@ Discourse.Composer = Discourse.Model.extend({
     var reply = this.get('reply');
     if(!reply) reply = "";
     while (Discourse.BBCode.QUOTE_REGEXP.test(reply)) { reply = reply.replace(Discourse.BBCode.QUOTE_REGEXP, ""); }
-    return reply.trim().length;
+    return reply.replace(/\s+/img, " ").trim().length;
   }.property('reply')
 
 });

--- a/spec/javascripts/models/composer_spec.js
+++ b/spec/javascripts/models/composer_spec.js
@@ -10,8 +10,14 @@ describe("Discourse.Composer", function() {
     });
 
     it("trims whitespaces", function() {
-      var composer = Discourse.Composer.create({ reply: "\nbasic reply\t" });
+      var composer = Discourse.Composer.create({ reply: " \nbasic reply\t" });
       expect(composer.get('replyLength')).toBe(11);
+    });
+
+    it("count only significant whitespaces", function() {
+      // this will count the '\n' only once
+      var composer = Discourse.Composer.create({ reply: "ba sic\n\nreply" });
+      expect(composer.get('replyLength')).toBe(12);
     });
 
     it("removes quotes", function() {


### PR DESCRIPTION
updated the composer reply length counting procedure to take into account only significant whitespaces in order to match the preview.
### before

![Screenshot_13_03_13_00_00-2](https://f.cloud.github.com/assets/362783/251542/43123f1a-8b69-11e2-9c17-9a9c85ffc352.png)
### after

![Screenshot_13_03_13_00_05](https://f.cloud.github.com/assets/362783/251549/69c6a9c0-8b69-11e2-9dec-57de67ce769d.png)
