### PR TITLE
fix js dates in chinese

### DIFF
--- a/app/assets/javascripts/locales/date_locales.js
+++ b/app/assets/javascripts/locales/date_locales.js
@@ -32,5 +32,5 @@ Date.addLocale('cs', {
     }
 });
 
-// set the current date locale
-Date.setLocale(I18n.locale);
+// set the current date locale, replace underscore with dash to make zh_CN work
+Date.setLocale(I18n.locale.replace("_","-"));


### PR DESCRIPTION
We have locale named "zh_CN", but Sugar.js uses "zh-CN" (with a dash). This makes sure Date format is properly loaded in chinese locale.
