### PR TITLE
move date formatting from server side to javascript, so we can reuse Sugar's i18n

### DIFF
--- a/app/assets/javascripts/discourse/views/modal/history_view.js
+++ b/app/assets/javascripts/discourse/views/modal/history_view.js
@@ -41,6 +41,11 @@ Discourse.HistoryView = Discourse.View.extend({
     this.set('postLeft', null);
     this.set('postRight', null);
     return this.get('originalPost').loadVersions(function(result) {
+      result.each(function(item) {
+        item.description = "v" + item.number + " - " + Date.create(item.created_at).relative() + " - " +
+          Em.String.i18n("changed_by", { author: item.display_username });
+      });
+
       _this.set('loading', false);
       _this.set('versionLeft', result.first());
       _this.set('versionRight', result.last());

--- a/app/serializers/version_serializer.rb
+++ b/app/serializers/version_serializer.rb
@@ -1,6 +1,6 @@
 class VersionSerializer < ApplicationSerializer
 
-  attributes :number, :display_username, :created_at, :description
+  attributes :number, :display_username, :created_at
 
   def number
     object[:number]
@@ -12,10 +12,6 @@ class VersionSerializer < ApplicationSerializer
 
   def created_at
     object[:created_at]
-  end
-
-  def description
-    "v#{object[:number]} - #{FreedomPatches::Rails4.time_ago_in_words(object[:created_at])} ago by #{object[:display_username]}"
   end
 
 end

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -629,6 +629,7 @@ en:
     top_contributors: "Participants"
     category_title: "Category"
     history: "History"
+    changed_by: "by {{author}}"
 
     categories_list: "Categories List"
 


### PR DESCRIPTION
Right now, we have a proper i18n relative date ("10 minutes ago") formatter in Sugar, but not on the server side. In post history versions serializer, we currently format a "description" on the server side, let's move the date formatting to client side and reuse the i18n formatter.
