### PR TITLE
make the "add user" placeholder in composer wider, so other languages can fit into that

### DIFF
--- a/app/assets/javascripts/discourse/components/autocomplete.js
+++ b/app/assets/javascripts/discourse/components/autocomplete.js
@@ -60,7 +60,7 @@ $.fn.autocomplete = function(options) {
     height = this.height();
     wrap = this.wrap("<div class='ac-wrap clearfix'/>").parent();
     wrap.width(width);
-    this.width(80);
+    this.width(150);
     this.attr('name', this.attr('name') + "-renamed");
     vals = this.val().split(",");
     vals.each(function(x) {


### PR DESCRIPTION
When creating a private conversation, there is a "add user" hint (with autocompleter). This field is however too small, and CS (and other) translations don't fit into that. Let's make it a little bit wider.
