### PR TITLE
fixes bug when modifying the category of a topic but cancelling the edit

### DIFF
--- a/app/assets/javascripts/discourse/views/topic_view.js
+++ b/app/assets/javascripts/discourse/views/topic_view.js
@@ -347,6 +347,11 @@ Discourse.TopicView = Discourse.View.extend(Discourse.Scrolling, {
   },
 
   cancelEdit: function() {
+    // set the previous category back
+    this.set('controller.content.category', this.get('previousCategory'));
+    // clear the previous category
+    this.set('previousCategory', null);
+    // close editing mode
     this.set('editingTopic', false);
   },
 
@@ -358,12 +363,18 @@ Discourse.TopicView = Discourse.View.extend(Discourse.Scrolling, {
       topic.set('title', new_val);
       topic.set('fancy_title', new_val);
       topic.save();
+      // clear the previous category
+      this.set('previousCategory', null);
+      // close editing mode
       this.set('editingTopic', false);
     }
   },
 
   editTopic: function() {
     if (!this.get('topic.can_edit')) return false;
+    // save the category so we can get it back when cancelling the edit
+    this.set('previousCategory', this.get('controller.content.category'));
+    // enable editing mode
     this.set('editingTopic', true);
     return false;
   },


### PR DESCRIPTION
Meta: [Editing a topic title and canceling the edit](http://meta.discourse.org/t/editing-a-topic-title-and-canceling-the-edit/4722)
