### PR TITLE
Sample Apache2 configuration

### DIFF
--- a/config/apache2.conf.sample
+++ b/config/apache2.conf.sample
@@ -1,0 +1,49 @@
+# Apache2 Virtual Host file to proxy Discourse to Thin cluster
+
+<VirtualHost *:80>
+ServerName forum.example.org.uk
+DocumentRoot /html/discourse/public/
+LogLevel debug
+#  ErrorLog  /html/discourse/log/error.log
+#  CustomLog /html/discourse/log/access.log combined
+
+# Hide some server information, since we can..
+Header set Server "Sample Server Name"
+
+ <IfModule mod_security2.c>
+   SecRuleEngine On
+   # Remove any rules that prevent Discourse from running at all
+   SecRuleRemoveById  <rule id>
+  </IfModule>
+
+ <Directory /html/discourse/public/>
+  Require all granted
+ </Directory>
+
+ <LocationMatch "^/assets/.*$">
+	# Set caching headers here, providing advice to downstream cache
+	Header set Cache-Control "public, max-age = 604800"
+ </LocationMatch>
+
+ RewriteEngine On
+
+ <Proxy balancer://thinservers>
+   BalancerMember http://127.0.0.1:3000
+   BalancerMember http://127.0.0.1:3001
+   BalancerMember http://127.0.0.1:3002
+ </Proxy>
+ 
+ # Prevent requests for /assets from being passed upstream
+ ProxyPass /assets !
+ 
+ # Pass the everything else
+ ProxyPass / balancer://thinservers/
+ ProxyPassReverse / balancer://thinservers/
+ ProxyPreserveHost on
+
+ <Proxy *>
+   Require all granted
+ </Proxy>
+ 
+</VirtualHost>
+


### PR DESCRIPTION
Sample Apache2 Virtualhost showing how to:
- Proxy requests to thinserver cluster,
- Server static files locally, 
- Set headers for downstream server to cache static assets, 
- Exclude mod_security rules that interfere with Discourse.
