### PR TITLE
displays a message when a failure happen while creating a new category

### DIFF
--- a/app/assets/javascripts/discourse/templates/modal/edit_category.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/modal/edit_category.js.handlebars
@@ -1,7 +1,7 @@
-<div class="modal-body">    
+<div class="modal-body">
   <form>
     <label>{{i18n category.name}}</label>
-    {{view Discourse.TextField valueBinding="view.category.name" placeholderKey="category.name_placeholder"}}
+    {{view Discourse.TextField valueBinding="view.category.name" placeholderKey="category.name_placeholder" maxlength="50"}}
 
     <div class='description-controls' style="margin-bottom: 20px">
       <label>{{i18n category.description}}</label>
@@ -12,7 +12,7 @@
           <a href="#" {{action showCategoryTopic target="view"}}>{{i18n category.change_in_category_topic}}</a>
         {{/if}}
       {{else}}
-        {{i18n category.no_description}} 
+        {{i18n category.no_description}}
           {{#if view.category.topic_url}}
           <a {{action showCategoryTopic target="view"}} href="#">{{i18n category.change_in_category_topic}}</a>
           {{/if}}}
@@ -31,4 +31,4 @@
 </div>
 <div class="modal-footer">
   <button class='btn btn-primary' {{bindAttr disabled="view.disabled"}} {{action saveCategory target="view"}}>{{view.buttonTitle}}</button>
-</div>  
+</div>

--- a/app/assets/javascripts/discourse/views/modal/edit_category_view.js
+++ b/app/assets/javascripts/discourse/views/modal/edit_category_view.js
@@ -59,7 +59,12 @@ Discourse.EditCategoryView = Discourse.ModalBodyView.extend({
         _this.saveSuccess(result);
       },
       error: function(errors) {
+        // displays a generic error message when none is sent from the server
+        // this might happen when some "after" callbacks throws an exception server-side
+        if(errors.length === 0) errors.push(Em.String.i18n("category.creation_error"));
+        // display the errors
         _this.displayErrors(errors);
+        // not saving anymore
         _this.set('saving', false);
       }
     });

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -14,7 +14,7 @@ class Category < ActiveRecord::Base
   has_many :featured_users, through: :category_featured_users, source: :user
 
   validates :user_id, presence: true
-  validates :name, presence: true, uniqueness: true
+  validates :name, presence: true, uniqueness: true, length: { in: 1..50 }
   validate :uncategorized_validator
 
   before_save :ensure_slug
@@ -27,7 +27,7 @@ class Category < ActiveRecord::Base
   delegate :post_template, to: 'self.class'
 
   def create_category_definition
-    create_topic(title: I18n.t("category.topic_prefix", category: name), user: user, pinned_at: Time.now)
+    create_topic!(title: I18n.t("category.topic_prefix", category: name), user: user, pinned_at: Time.now)
     update_column(:topic_id, topic.id)
     topic.update_column(:category_id, id)
     topic.posts.create(raw: post_template, user: user)

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -583,6 +583,7 @@ en:
       view: 'View Topics in Category'
       delete: 'Delete Category'
       create: 'Create Category'
+      creation_error: There has been an error during the creation of the category.
       more_posts: "view all {{posts}}..."
       name: "Category Name"
       description: "Description"

--- a/config/locales/client.fr.yml
+++ b/config/locales/client.fr.yml
@@ -587,6 +587,7 @@ fr:
       view: 'Voir les discussions dans cette catégorie'
       delete: 'Supprimer la catégorie'
       create: 'Créer la catégorie'
+      creation_error: "Il y a eu une erreur lors de la création de la catégorie."
       more_posts: "voir tous les {{posts}}..."
       name: "Nom de la catégorie"
       description: "Description"


### PR DESCRIPTION
Meta: [Failed to create new category when set the default_locale to zh_CN](http://meta.discourse.org/t/failed-to-create-new-category-when-set-the-default-locale-to-zh-cn/4703/4)

This PR changes the `create_category_definition` after_create callback to use the `!` version of the `create_topic` method that will make Rails throw an exception which allows the application to respond with a `422` code instead of the `500` code.

Unfortunately, I did not manage to get Rails to pass the error messages coming from the callback. Instead, I added a test in the `edit_category_view` in the `error` callback to add a generic error message whenever the server respond with a `422` code but without any error message.

I've also added some length validation (both client & server side) to the `name` property of the `category` so that it generates better error messages.
