### PR TITLE
Support for running discourse with a prefix (i.e. as http://servername/discourse)

### DIFF
--- a/app/assets/javascripts/admin/controllers/admin_email_logs_controller.js
+++ b/app/assets/javascripts/admin/controllers/admin_email_logs_controller.js
@@ -26,7 +26,7 @@ Discourse.AdminEmailLogsController = Ember.ArrayController.extend(Discourse.Pres
     var _this = this;
     _this.set('sentTestEmail', false);
     $.ajax({
-      url: '/admin/email_logs/test',
+      url: Discourse.getURL("/admin/email_logs/test"),
       type: 'POST',
       data: { email_address: this.get('testEmailAddress') },
       success: function() {

--- a/app/assets/javascripts/admin/models/admin_user.js
+++ b/app/assets/javascripts/admin/models/admin_user.js
@@ -7,10 +7,18 @@
   @module Discourse
 **/
 Discourse.AdminUser = Discourse.Model.extend({
+  path: (function() {
+    return Discourse.getURL("/users/") + (this.get('username_lower'));
+  }).property('username'),
+
+  adminPath: (function() {
+    return Discourse.getURL("/admin/users/") + (this.get('username_lower'));
+  }).property('username'),
+
 
   deleteAllPosts: function() {
     this.set('can_delete_all_posts', false);
-    $.ajax("/admin/users/" + (this.get('id')) + "/delete_all_posts", {type: 'PUT'});
+    $.ajax(Discourse.getURL("/admin/users/") + (this.get('id')) + "/delete_all_posts", {type: 'PUT'});
   },
 
   // Revoke the user's admin access
@@ -18,14 +26,14 @@ Discourse.AdminUser = Discourse.Model.extend({
     this.set('admin', false);
     this.set('can_grant_admin', true);
     this.set('can_revoke_admin', false);
-    return $.ajax("/admin/users/" + (this.get('id')) + "/revoke_admin", {type: 'PUT'});
+    return $.ajax(Discourse.getURL("/admin/users/") + (this.get('id')) + "/revoke_admin", {type: 'PUT'});
   },
 
   grantAdmin: function() {
     this.set('admin', true);
     this.set('can_grant_admin', false);
     this.set('can_revoke_admin', true);
-    $.ajax("/admin/users/" + (this.get('id')) + "/grant_admin", {type: 'PUT'});
+    $.ajax(Discourse.getURL("/admin/users/") + (this.get('id')) + "/grant_admin", {type: 'PUT'});
   },
 
   // Revoke the user's moderation access
@@ -33,18 +41,18 @@ Discourse.AdminUser = Discourse.Model.extend({
     this.set('moderator', false);
     this.set('can_grant_moderation', true);
     this.set('can_revoke_moderation', false);
-    return $.ajax("/admin/users/" + (this.get('id')) + "/revoke_moderation", {type: 'PUT'});
+    return $.ajax(Discourse.getURL("/admin/users/") + (this.get('id')) + "/revoke_moderation", {type: 'PUT'});
   },
 
   grantModeration: function() {
     this.set('moderator', true);
     this.set('can_grant_moderation', false);
     this.set('can_revoke_moderation', true);
-    $.ajax("/admin/users/" + (this.get('id')) + "/grant_moderation", {type: 'PUT'});
+    $.ajax(Discourse.getURL("/admin/users/") + (this.get('id')) + "/grant_moderation", {type: 'PUT'});
   },
 
   refreshBrowsers: function() {
-    $.ajax("/admin/users/" + (this.get('id')) + "/refresh_browsers", {type: 'POST'});
+    $.ajax(Discourse.getURL("/admin/users/") + (this.get('id')) + "/refresh_browsers", {type: 'POST'});
     bootbox.alert("Message sent to all clients!");
   },
 
@@ -52,7 +60,7 @@ Discourse.AdminUser = Discourse.Model.extend({
     this.set('can_approve', false);
     this.set('approved', true);
     this.set('approved_by', Discourse.get('currentUser'));
-    $.ajax("/admin/users/" + (this.get('id')) + "/approve", {type: 'PUT'});
+    $.ajax(Discourse.getURL("/admin/users/") + (this.get('id')) + "/approve", {type: 'PUT'});
   },
 
   username_lower: (function() {
@@ -79,7 +87,7 @@ Discourse.AdminUser = Discourse.Model.extend({
       _this = this;
     if (duration = parseInt(window.prompt(Em.String.i18n('admin.user.ban_duration')), 10)) {
       if (duration > 0) {
-        return $.ajax("/admin/users/" + this.id + "/ban", {
+        return $.ajax(Discourse.getURL("/admin/users/") + this.id + "/ban", {
           type: 'PUT',
           data: {duration: duration},
           success: function() {
@@ -99,7 +107,7 @@ Discourse.AdminUser = Discourse.Model.extend({
 
   unban: function() {
     var _this = this;
-    return $.ajax("/admin/users/" + this.id + "/unban", {
+    return $.ajax(Discourse.getURL("/admin/users/") + this.id + "/unban", {
       type: 'PUT',
       success: function() {
         window.location.reload();
@@ -116,7 +124,7 @@ Discourse.AdminUser = Discourse.Model.extend({
 
   impersonate: function() {
     var _this = this;
-    return $.ajax("/admin/impersonate", {
+    return $.ajax(Discourse.getURL("/admin/impersonate"), {
       type: 'POST',
       data: {
         username_or_email: this.get('username')
@@ -145,7 +153,7 @@ Discourse.AdminUser.reopenClass({
       user.set('can_approve', false);
       return user.set('selected', false);
     });
-    return $.ajax("/admin/users/approve-bulk", {
+    return $.ajax(Discourse.getURL("/admin/users/approve-bulk"), {
       type: 'PUT',
       data: {
         users: users.map(function(u) {
@@ -156,7 +164,7 @@ Discourse.AdminUser.reopenClass({
   },
 
   find: function(username) {
-    return $.ajax({url: "/admin/users/" + username}).then(function (result) {
+    return $.ajax({url: Discourse.getURL("/admin/users/") + username}).then(function (result) {
       return Discourse.AdminUser.create(result);
     })
   },
@@ -165,7 +173,7 @@ Discourse.AdminUser.reopenClass({
     var result;
     result = Em.A();
     $.ajax({
-      url: "/admin/users/list/" + query + ".json",
+      url: Discourse.getURL("/admin/users/list/") + query + ".json",
       data: {
         filter: filter
       },

--- a/app/assets/javascripts/admin/models/email_log.js
+++ b/app/assets/javascripts/admin/models/email_log.js
@@ -20,7 +20,7 @@ Discourse.EmailLog.reopenClass({
     var result;
     result = Em.A();
     $.ajax({
-      url: "/admin/email_logs.json",
+      url: Discourse.getURL("/admin/email_logs.json"),
       data: { filter: filter },
       success: function(logs) {
         logs.each(function(log) {

--- a/app/assets/javascripts/admin/models/flagged_post.js
+++ b/app/assets/javascripts/admin/models/flagged_post.js
@@ -47,14 +47,14 @@ Discourse.FlaggedPost = Discourse.Post.extend({
 
   deletePost: function() {
     if (this.get('post_number') === "1") {
-      return $.ajax("/t/" + this.topic_id, { type: 'DELETE', cache: false });
+      return $.ajax(Discourse.getURL("/t/") + this.topic_id, { type: 'DELETE', cache: false });
     } else {
-      return $.ajax("/posts/" + this.id, { type: 'DELETE', cache: false });
+      return $.ajax(Discourse.getURL("/posts/") + this.id, { type: 'DELETE', cache: false });
     }
   },
 
   clearFlags: function() {
-    return $.ajax("/admin/flags/clear/" + this.id, { type: 'POST', cache: false });
+    return $.ajax(Discourse.getURL("/admin/flags/clear/") + this.id, { type: 'POST', cache: false });
   },
 
   hiddenClass: (function() {
@@ -68,7 +68,7 @@ Discourse.FlaggedPost.reopenClass({
     var result;
     result = Em.A();
     $.ajax({
-      url: "/admin/flags/" + filter + ".json",
+      url: Discourse.getURL("/admin/flags/") + filter + ".json",
       success: function(data) {
         var userLookup;
         userLookup = {};

--- a/app/assets/javascripts/admin/models/report.js
+++ b/app/assets/javascripts/admin/models/report.js
@@ -3,7 +3,7 @@ Discourse.Report = Discourse.Model.extend({});
 Discourse.Report.reopenClass({
   find: function(type) {
     var model = Discourse.Report.create({type: type});
-    $.ajax("/admin/reports/" + type, {
+    $.ajax(Discourse.getURL("/admin/reports/") + type, {
       type: 'GET',
       success: function(json) {
         model.mergeAttributes(json.report);

--- a/app/assets/javascripts/admin/models/site_customization.js
+++ b/app/assets/javascripts/admin/models/site_customization.js
@@ -56,7 +56,7 @@ Discourse.SiteCustomization = Discourse.Model.extend({
       override_default_style: this.override_default_style
     };
     return $.ajax({
-      url: "/admin/site_customizations" + (this.id ? '/' + this.id : ''),
+      url: Discourse.getURL("/admin/site_customizations") + (this.id ? '/' + this.id : ''),
       data: {
         site_customization: data
       },
@@ -68,7 +68,7 @@ Discourse.SiteCustomization = Discourse.Model.extend({
     if (!this.id) return;
 
     return $.ajax({
-      url: "/admin/site_customizations/" + this.id,
+      url: Discourse.getURL("/admin/site_customizations/") + this.id,
       type: 'DELETE'
     });
   }
@@ -94,7 +94,7 @@ Discourse.SiteCustomization.reopenClass({
       loading: true
     });
     $.ajax({
-      url: "/admin/site_customizations",
+      url: Discourse.getURL("/admin/site_customizations"),
       dataType: "json",
       success: function(data) {
         if (data) {

--- a/app/assets/javascripts/admin/models/site_setting.js
+++ b/app/assets/javascripts/admin/models/site_setting.js
@@ -72,7 +72,7 @@ Discourse.SiteSetting = Discourse.Model.extend({
   save: function() {
     // Update the setting
     var setting = this;
-    return $.ajax("/admin/site_settings/" + (this.get('setting')), {
+    return $.ajax(Discourse.getURL("/admin/site_settings/") + (this.get('setting')), {
       data: { value: this.get('value') },
       type: 'PUT',
       success: function() {
@@ -91,7 +91,7 @@ Discourse.SiteSetting.reopenClass({
   **/
   findAll: function() {
     var result = Em.A();
-    $.get("/admin/site_settings", function(settings) {
+    $.get(Discourse.getURL("/admin/site_settings"), function(settings) {
       return settings.each(function(s) {
         s.originalValue = s.value;
         return result.pushObject(Discourse.SiteSetting.create(s));

--- a/app/assets/javascripts/admin/models/version_check.js
+++ b/app/assets/javascripts/admin/models/version_check.js
@@ -26,7 +26,7 @@ Discourse.VersionCheck = Discourse.Model.extend({
 
 Discourse.VersionCheck.reopenClass({
   find: function() {
-    return $.ajax({ url: '/admin/version_check', dataType: 'json' }).then(function(json) {
+    return $.ajax({ url: Discourse.getURL('/admin/version_check'), dataType: 'json' }).then(function(json) {
       return Discourse.VersionCheck.create(json);
     });
   }

--- a/app/assets/javascripts/admin/templates/email_logs.js.handlebars
+++ b/app/assets/javascripts/admin/templates/email_logs.js.handlebars
@@ -22,8 +22,8 @@
           <td>{{date view.content.created_at}}</td>
           <td>
             {{#if view.content.user}}
-              <a href="/admin/users/{{unbound view.content.user.username_lower}}">{{avatar view.content.user imageSize="tiny"}}</a>
-              <a href="/admin/users/{{unbound view.content.user.username_lower}}">{{view.content.user.username}}</a>
+              <a href="{{unbound view.content.user.adminPath}}">{{avatar view.content.user imageSize="tiny"}}</a>
+              <a href="{{unbound view.content.user.adminPath}}">{{view.content.user.username}}</a>
             {{else}}
               &mdash;
             {{/if}}

--- a/app/assets/javascripts/admin/templates/user.js.handlebars
+++ b/app/assets/javascripts/admin/templates/user.js.handlebars
@@ -5,7 +5,7 @@
     <div class='field'>{{i18n user.username.title}}</div>
     <div class='value'>{{content.username}}</div>
     <div class='controls'>
-      <a href="/users/{{unbound content.username_lower}}" class='btn'>
+      <a href="{{unbound content.path}}" class='btn'>
         <i class='icon icon-user'></i>
         {{i18n admin.user.show_public_profile}}
       </a> 
@@ -45,8 +45,8 @@
     <div class='value'>
       {{#if content.approved}}
         {{i18n admin.user.approved_by}}        
-        <a href="/admin/users/{{unbound content.approved_by.username_lower}}">{{avatar approved_by imageSize="small"}}</a>
-        <a href="/admin/users/{{unbound username_lower}}">{{content.approved_by.username}}</a>
+        <a href="{{unbound content.approved_by.adminPath}}">{{avatar approved_by imageSize="small"}}</a>
+        <a href="{{unbound adminPath}}">{{content.approved_by.username}}</a>
       {{else}}
         {{i18n no_value}}
       {{/if}}

--- a/app/assets/javascripts/admin/templates/users_list.js.handlebars
+++ b/app/assets/javascripts/admin/templates/users_list.js.handlebars
@@ -51,9 +51,9 @@
           </td>
         {{/if}}
         <td>
-          <a href="/admin/users/{{unbound username_lower}}">{{avatar this imageSize="small"}}</a>
+          <a href="{{unbound adminPath}}">{{avatar this imageSize="small"}}</a>
         </td>
-        <td><a href="/admin/users/{{unbound username_lower}}">{{unbound username}}</a></td>
+        <td><a href="{{unbound adminPath}}">{{unbound username}}</a></td>
         <td>{{shorten email}}</td>
         <td>{{{unbound last_emailed_age}}}</td>
         <td>{{{unbound last_seen_age}}}</td>

--- a/app/assets/javascripts/discourse.js
+++ b/app/assets/javascripts/discourse.js
@@ -22,6 +22,16 @@ Discourse = Ember.Application.createWithMixins({
   // The highest seen post number by topic
   highestSeenByTopic: {},
 
+  rootURL: '/',
+
+  getURL: function(url) {
+    var u = this.get('rootURL');
+    if (u[u.length-1] === '/') {
+      u = u.substring(0, u.length-1);
+    }
+    return u + url;
+  },
+
   titleChanged: function() {
     var title;
     title = "";
@@ -156,7 +166,7 @@ Discourse = Ember.Application.createWithMixins({
   **/
   logout: function() {
     Discourse.KeyValueStore.abandonLocal();
-    return $.ajax("/session/" + this.get('currentUser.username'), {
+    return $.ajax(Discourse.getURL("/session/") + this.get('currentUser.username'), {
       type: 'DELETE',
       success: function(result) {
         // To keep lots of our variables unbound, we can handle a redirect on logging out.

--- a/app/assets/javascripts/discourse/components/click_track.js
+++ b/app/assets/javascripts/discourse/components/click_track.js
@@ -44,7 +44,7 @@ Discourse.ClickTrack = {
     ownLink = userId && (userId === Discourse.get('currentUser.id'));
 
     // Build a Redirect URL
-    trackingUrl = "/clicks/track?url=" + encodeURIComponent(href);
+    trackingUrl = Discourse.getURL("/clicks/track?url=" + encodeURIComponent(href));
     if (postId && (!$a.data('ignore-post-id'))) {
       trackingUrl += "&post_id=" + encodeURI(postId);
     }
@@ -70,7 +70,7 @@ Discourse.ClickTrack = {
 
     // if they want to open in a new tab, do an AJAX request
     if (e.metaKey || e.ctrlKey || e.which === 2) {
-      $.get("/clicks/track", {
+      $.get(Discourse.getURL("/clicks/track"), {
         url: href,
         post_id: postId,
         topic_id: topicId,
@@ -82,7 +82,7 @@ Discourse.ClickTrack = {
 
     // If we're on the same site, use the router and track via AJAX
     if (href.indexOf(window.location.origin) === 0) {
-      $.get("/clicks/track", {
+      $.get(Discourse.getURL("/clicks/track"), {
         url: href,
         post_id: postId,
         topic_id: topicId,

--- a/app/assets/javascripts/discourse/components/markdown.js
+++ b/app/assets/javascripts/discourse/components/markdown.js
@@ -141,7 +141,7 @@ Discourse.Markdown = {
       // Add @mentions of names
       text = text.replace(/([\s\t>,:'|";\]])(@[A-Za-z0-9_-|\.]*[A-Za-z0-9_-|]+)(?=[\s\t<\!:|;',"\?\.])/g, function(x, pre, name) {
         if (mentionLookup(name.substr(1))) {
-          return pre + "<a href='/users/" + (name.substr(1).toLowerCase()) + "' class='mention'>" + name + "</a>";
+          return pre + "<a href='" + Discourse.getURL("/users/") + (name.substr(1).toLowerCase()) + "' class='mention'>" + name + "</a>";
         } else {
           return pre + "<span class='mention'>" + name + "</span>";
         }

--- a/app/assets/javascripts/discourse/components/mention.js
+++ b/app/assets/javascripts/discourse/components/mention.js
@@ -21,7 +21,7 @@ Discourse.Mention = (function() {
       callback(cached);
       return false;
     } else {
-      $.get("/users/is_local_username", {
+      $.get(Discourse.getURL("/users/is_local_username"), {
         username: name
       }, function(r) {
         cache(name, r.valid);
@@ -40,7 +40,7 @@ Discourse.Mention = (function() {
     username = username.substr(1);
     loading = lookup(username, function(valid) {
       if (valid) {
-        return $elem.replaceWith("<a href='/users/" + (username.toLowerCase()) + "' class='mention'>@" + username + "</a>");
+        return $elem.replaceWith("<a href='" + Discourse.getURL("/users/") + (username.toLowerCase()) + "' class='mention'>@" + username + "</a>");
       } else {
         return $elem.removeClass('mention-loading').addClass('mention-tested');
       }

--- a/app/assets/javascripts/discourse/components/message_bus.js
+++ b/app/assets/javascripts/discourse/components/message_bus.js
@@ -68,7 +68,7 @@ Discourse.MessageBus = (function() {
           data[c.channel] = c.last_id === void 0 ? -1 : c.last_id;
         });
         gotData = false;
-        _this.longPoll = $.ajax("/message-bus/" + clientId + "/poll?" + (isHidden() || !_this.enableLongPolling ? "dlp=t" : ""), {
+        _this.longPoll = $.ajax(Discourse.getURL("/message-bus/") + clientId + "/poll?" + (isHidden() || !_this.enableLongPolling ? "dlp=t" : ""), {
           data: data,
           cache: false,
           dataType: 'json',

--- a/app/assets/javascripts/discourse/components/screen_track.js
+++ b/app/assets/javascripts/discourse/components/screen_track.js
@@ -98,7 +98,7 @@ Discourse.ScreenTrack = Ember.Object.extend({
       highestSeenByTopic[topicId] = this.highestSeen;
     }
     if (!Object.isEmpty(newTimings)) {
-      $.ajax('/topics/timings', {
+      $.ajax(Discourse.getURL('/topics/timings'), {
         data: {
           timings: newTimings,
           topic_time: this.topicTime,

--- a/app/assets/javascripts/discourse/components/url.js
+++ b/app/assets/javascripts/discourse/components/url.js
@@ -14,6 +14,14 @@ Discourse.URL = {
   MORE_REGEXP: /\/more$/,
 
   /**
+    Will be pre-pended to path upon state change
+
+    @property rootURL
+    @default '/'
+  */
+  rootURL: '/',
+
+  /**
     @private
 
     Get a handle on the application's router. Note that currently it uses `__container__` which is not
@@ -61,6 +69,13 @@ Discourse.URL = {
   routeTo: function(path) {
     var oldPath = window.location.pathname;
     path = path.replace(/https?\:\/\/[^\/]+/, '');
+    /*
+      If the URL is absolute, remove rootURL
+     */
+    if (path.match(/^\//)) {
+      var rootURL = this.rootURL.replace(/\/$/, '');
+      path = path.replace(rootURL, '');
+    }
 
     /*
       If the URL is in the topic form, /t/something/:topic_id/:post_number

--- a/app/assets/javascripts/discourse/components/user_search.js
+++ b/app/assets/javascripts/discourse/components/user_search.js
@@ -15,7 +15,7 @@ cacheTime = null;
 
 doSearch = function(term, topicId, success) {
   return $.ajax({
-    url: '/users/search/users',
+    url: Discourse.getURL('/users/search/users'),
     dataType: 'JSON',
     data: {
       term: term,

--- a/app/assets/javascripts/discourse/components/utilities.js
+++ b/app/assets/javascripts/discourse/components/utilities.js
@@ -48,7 +48,7 @@ Discourse.Utilities = {
     description = Em.get(category, 'description');
 
     // Build the HTML link
-    result = "<a href=\"/category/" + this.categoryUrlId(category) + "\" class=\"badge-category\" ";
+    result = "<a href=\"" + Discourse.getURL("/category/") + this.categoryUrlId(category) + "\" class=\"badge-category\" ";
 
     // Add description if we have it
     if (description) result += "title=\"" + description + "\" ";
@@ -85,7 +85,7 @@ Discourse.Utilities = {
 
   postUrl: function(slug, topicId, postNumber) {
     var url;
-    url = "/t/";
+    url = Discourse.getURL("/t/");
     if (slug) {
       url += slug + "/";
     }

--- a/app/assets/javascripts/discourse/controllers/preferences_username_controller.js
+++ b/app/assets/javascripts/discourse/controllers/preferences_username_controller.js
@@ -51,7 +51,7 @@ Discourse.PreferencesUsernameController = Discourse.ObjectController.extend({
       if (result) {
         _this.set('saving', true);
         return _this.get('content').changeUsername(_this.get('newUsername')).then(function() {
-          window.location = "/users/" + (_this.get('newUsername').toLowerCase()) + "/preferences";
+          window.location = Discourse.getURL("/users/") + (_this.get('newUsername').toLowerCase()) + "/preferences";
         }, function() {
           /* Error
           */

--- a/app/assets/javascripts/discourse/controllers/static_controller.js
+++ b/app/assets/javascripts/discourse/controllers/static_controller.js
@@ -23,7 +23,7 @@ Discourse.StaticController = Discourse.Controller.extend({
       return this.set('content', text);
     } else {
       return $.ajax({
-        url: "" + path + ".json",
+        url: Discourse.getURL("" + path + ".json"),
         success: function(result) {
           return _this.set('content', result);
         }

--- a/app/assets/javascripts/discourse/models/action_summary.js
+++ b/app/assets/javascripts/discourse/models/action_summary.js
@@ -53,7 +53,7 @@ Discourse.ActionSummary = Discourse.Model.extend({
     // Create our post action
     var actionSummary = this;
     return $.ajax({
-      url: "/post_actions",
+      url: Discourse.getURL("/post_actions"),
       type: 'POST',
       data: {
         id: this.get('post.id'),
@@ -72,7 +72,7 @@ Discourse.ActionSummary = Discourse.Model.extend({
 
     // Remove our post action
     return $.ajax({
-      url: "/post_actions/" + (this.get('post.id')),
+      url: Discourse.getURL("/post_actions/") + (this.get('post.id')),
       type: 'DELETE',
       data: {
         post_action_type_id: this.get('id')
@@ -83,7 +83,7 @@ Discourse.ActionSummary = Discourse.Model.extend({
   clearFlags: function() {
     var _this = this;
     return $.ajax({
-      url: "/post_actions/clear_flags",
+      url: Discourse.getURL("/post_actions/clear_flags"),
       type: "POST",
       data: {
         post_action_type_id: this.get('id'),
@@ -98,7 +98,7 @@ Discourse.ActionSummary = Discourse.Model.extend({
 
   loadUsers: function() {
     var _this = this;
-    return $.getJSON("/post_actions/users", {
+    return $.getJSON(Discourse.getURL("/post_actions/users"), {
       id: this.get('post.id'),
       post_action_type_id: this.get('id')
     }, function(result) {

--- a/app/assets/javascripts/discourse/models/category.js
+++ b/app/assets/javascripts/discourse/models/category.js
@@ -9,7 +9,7 @@
 Discourse.Category = Discourse.Model.extend({
 
   url: (function() {
-    return "/category/" + (this.get('slug'));
+    return Discourse.getURL("/category/") + (this.get('slug'));
   }).property('name'),
 
   style: (function() {
@@ -24,9 +24,9 @@ Discourse.Category = Discourse.Model.extend({
     var url,
       _this = this;
 
-    url = "/categories";
+    url = Discourse.getURL("/categories");
     if (this.get('id')) {
-      url = "/categories/" + (this.get('id'));
+      url = Discourse.getURL("/categories/") + (this.get('id'));
     }
 
     return this.ajax(url, {
@@ -43,7 +43,7 @@ Discourse.Category = Discourse.Model.extend({
 
   "delete": function(callback) {
     var _this = this;
-    return $.ajax("/categories/" + (this.get('slug')), {
+    return $.ajax(Discourse.getURL("/categories/") + (this.get('slug')), {
       type: 'DELETE',
       success: function() {
         return callback();

--- a/app/assets/javascripts/discourse/models/category_list.js
+++ b/app/assets/javascripts/discourse/models/category_list.js
@@ -32,7 +32,7 @@ Discourse.CategoryList.reopenClass({
 
   list: function(filter) {
     var route = this;
-    return $.getJSON("/" + filter + ".json").then(function(result) {
+    return $.getJSON(Discourse.getURL("/") + filter + ".json").then(function(result) {
       var categoryList = Discourse.TopicList.create();
       categoryList.set('can_create_category', result.category_list.can_create_category);
       categoryList.set('categories', route.categoriesFrom(result));

--- a/app/assets/javascripts/discourse/models/draft.js
+++ b/app/assets/javascripts/discourse/models/draft.js
@@ -13,7 +13,7 @@ Discourse.Draft.reopenClass({
   clear: function(key, sequence) {
     return $.ajax({
       type: 'DELETE',
-      url: "/draft",
+      url: Discourse.getURL("/draft"),
       data: {
         draft_key: key,
         sequence: sequence
@@ -23,7 +23,7 @@ Discourse.Draft.reopenClass({
 
   get: function(key) {
     return $.ajax({
-      url: '/draft',
+      url: Discourse.getURL('/draft'),
       data: { draft_key: key },
       dataType: 'json'
     });
@@ -38,7 +38,7 @@ Discourse.Draft.reopenClass({
     data = typeof data === "string" ? data : JSON.stringify(data);
     return $.ajax({
       type: 'POST',
-      url: "/draft",
+      url: Discourse.getURL("/draft"),
       data: {
         draft_key: key,
         data: data,

--- a/app/assets/javascripts/discourse/models/invite.js
+++ b/app/assets/javascripts/discourse/models/invite.js
@@ -10,7 +10,7 @@
 Discourse.Invite = Discourse.Model.extend({
 
   rescind: function() {
-    $.ajax('/invites', {
+    $.ajax(Discourse.getURL('/invites'), {
       type: 'DELETE',
       data: { email: this.get('email') }
     });

--- a/app/assets/javascripts/discourse/models/invite_list.js
+++ b/app/assets/javascripts/discourse/models/invite_list.js
@@ -15,7 +15,7 @@ Discourse.InviteList = Discourse.Model.extend({
 Discourse.InviteList.reopenClass({
 
   findInvitedBy: function(user) {
-    return $.ajax({ url: "/users/" + (user.get('username_lower')) + "/invited.json" }).then(function (result) {
+    return $.ajax({ url: Discourse.getURL("/users/") + (user.get('username_lower')) + "/invited.json" }).then(function (result) {
       var invitedList = result.invited_list;
       if (invitedList.pending) {
         invitedList.pending = invitedList.pending.map(function(i) {

--- a/app/assets/javascripts/discourse/models/nav_item.js
+++ b/app/assets/javascripts/discourse/models/nav_item.js
@@ -27,9 +27,9 @@ Discourse.NavItem = Discourse.Model.extend({
     var name;
     name = this.get('name');
     if (name === 'category') {
-      return "/" + name + "/" + (this.get('categoryName'));
+      return Discourse.getURL("/") + name + "/" + (this.get('categoryName'));
     } else {
-      return "/" + name;
+      return Discourse.getURL("/") + name;
     }
   }).property()
 });

--- a/app/assets/javascripts/discourse/models/notification.js
+++ b/app/assets/javascripts/discourse/models/notification.js
@@ -17,7 +17,7 @@ Discourse.Notification = Discourse.Model.extend({
     var slug;
     if (this.blank('data.topic_title')) return "";
     slug = this.get('slug');
-    return "/t/" + slug + "/" + (this.get('topic_id')) + "/" + (this.get('post_number'));
+    return Discourse.getURL("/t/") + slug + "/" + (this.get('topic_id')) + "/" + (this.get('post_number'));
   }).property(),
 
   rendered: (function() {

--- a/app/assets/javascripts/discourse/models/post.js
+++ b/app/assets/javascripts/discourse/models/post.js
@@ -13,8 +13,12 @@ Discourse.Post = Discourse.Model.extend({
   }).property('post_number', 'topic_id', 'topic.slug'),
 
   originalPostUrl: (function() {
-    return "/t/" + (this.get('topic_id')) + "/" + (this.get('reply_to_post_number'));
+    return Discourse.getURL("/t/") + (this.get('topic_id')) + "/" + (this.get('reply_to_post_number'));
   }).property('reply_to_post_number'),
+
+  usernameUrl: (function() {
+    return Discourse.getURL("/users/" + this.get('username'));
+  }).property('username'),
 
   showUserReplyTab: (function() {
     return this.get('reply_to_user') && (this.get('reply_to_post_number') < (this.get('post_number') - 1));
@@ -65,7 +69,7 @@ Discourse.Post = Discourse.Model.extend({
   bookmarkedChanged: (function() {
     var _this = this;
     return $.ajax({
-      url: "/posts/" + (this.get('id')) + "/bookmark",
+      url: Discourse.getURL("/posts/") + (this.get('id')) + "/bookmark",
       type: 'PUT',
       data: {
         bookmarked: this.get('bookmarked') ? true : false
@@ -124,7 +128,7 @@ Discourse.Post = Discourse.Model.extend({
     if (!this.get('newPost')) {
       // We're updating a post
       return $.ajax({
-        url: "/posts/" + (this.get('id')),
+        url: Discourse.getURL("/posts/") + (this.get('id')),
         type: 'PUT',
         data: {
           post: { raw: this.get('raw') },
@@ -155,7 +159,7 @@ Discourse.Post = Discourse.Model.extend({
       }
       return $.ajax({
         type: 'POST',
-        url: "/posts",
+        url: Discourse.getURL("/posts"),
         data: data,
         success: function(result) {
           return typeof complete === "function" ? complete(Discourse.Post.create(result)) : void 0;
@@ -168,11 +172,11 @@ Discourse.Post = Discourse.Model.extend({
   },
 
   recover: function() {
-    return $.ajax("/posts/" + (this.get('id')) + "/recover", { type: 'PUT', cache: false });
+    return $.ajax(Discourse.getURL("/posts/") + (this.get('id')) + "/recover", { type: 'PUT', cache: false });
   },
 
   "delete": function(complete) {
-    return $.ajax("/posts/" + (this.get('id')), {
+    return $.ajax(Discourse.getURL("/posts/") + (this.get('id')), {
       type: 'DELETE',
       success: function(result) {
         return typeof complete === "function" ? complete() : void 0;
@@ -219,7 +223,7 @@ Discourse.Post = Discourse.Model.extend({
     this.set('replies', []);
 
     var parent = this;
-    return $.ajax({url: "/posts/" + (this.get('id')) + "/replies"}).then(function(loaded) {
+    return $.ajax({url: Discourse.getURL("/posts/") + (this.get('id')) + "/replies"}).then(function(loaded) {
       var replies = parent.get('replies');
       loaded.each(function(reply) {
         var post = Discourse.Post.create(reply);
@@ -231,7 +235,7 @@ Discourse.Post = Discourse.Model.extend({
   },
 
   loadVersions: function(callback) {
-    return $.get("/posts/" + (this.get('id')) + "/versions.json", function(result) {
+    return $.get(Discourse.getURL("/posts/") + (this.get('id')) + "/versions.json", function(result) {
       return callback(result);
     });
   },
@@ -287,7 +291,7 @@ Discourse.Post.reopenClass({
   },
 
   deleteMany: function(posts) {
-    return $.ajax("/posts/destroy_many", {
+    return $.ajax(Discourse.getURL("/posts/destroy_many"), {
       type: 'DELETE',
       data: {
         post_ids: posts.map(function(p) { return p.get('id'); })
@@ -296,26 +300,26 @@ Discourse.Post.reopenClass({
   },
 
   loadVersion: function(postId, version, callback) {
-    return $.ajax({url: "/posts/" + postId + ".json?version=" + version}).then(function(result) {
+    return $.ajax({url: Discourse.getURL("/posts/") + postId + ".json?version=" + version}).then(function(result) {
       return Discourse.Post.create(result);
     });
   },
 
   loadByPostNumber: function(topicId, postId) {
-    return $.ajax({url: "/posts/by_number/" + topicId + "/" + postId + ".json"}).then(function (result) {
+    return $.ajax({url: Discourse.getURL("/posts/by_number/") + topicId + "/" + postId + ".json"}).then(function (result) {
       return Discourse.Post.create(result);
     });
   },
 
   loadQuote: function(postId) {
-    return $.ajax({url: "/posts/" + postId + ".json"}).then(function(result) {
+    return $.ajax({url: Discourse.getURL("/posts/") + postId + ".json"}).then(function(result) {
       var post = Discourse.Post.create(result);
       return Discourse.BBCode.buildQuoteBBCode(post, post.get('raw'));
     });
   },
 
   load: function(postId) {
-    return $.ajax({url: "/posts/" + postId + ".json"}).then(function (result) {
+    return $.ajax({url: Discourse.getURL("/posts/") + postId + ".json"}).then(function (result) {
       return Discourse.Post.create(result);
     });
   }

--- a/app/assets/javascripts/discourse/models/topic.js
+++ b/app/assets/javascripts/discourse/models/topic.js
@@ -42,7 +42,7 @@ Discourse.Topic = Discourse.Model.extend({
     if (slug.isBlank()) {
       slug = "topic";
     }
-    return "/t/" + slug + "/" + (this.get('id'));
+    return Discourse.getURL("/t/") + slug + "/" + (this.get('id'));
   }).property('id', 'slug'),
 
   // Helper to build a Url with a post number
@@ -169,7 +169,7 @@ Discourse.Topic = Discourse.Model.extend({
 
   // Reset our read data for this topic
   resetRead: function(callback) {
-    return $.ajax("/t/" + (this.get('id')) + "/timings", {
+    return $.ajax(Discourse.getURL("/t/") + (this.get('id')) + "/timings", {
       type: 'DELETE',
       success: function() {
         return typeof callback === "function" ? callback() : void 0;
@@ -181,7 +181,7 @@ Discourse.Topic = Discourse.Model.extend({
   inviteUser: function(user) {
     return $.ajax({
       type: 'POST',
-      url: "/t/" + (this.get('id')) + "/invite",
+      url: Discourse.getURL("/t/") + (this.get('id')) + "/invite",
       data: {
         user: user
       }
@@ -190,7 +190,7 @@ Discourse.Topic = Discourse.Model.extend({
 
   // Delete this topic
   "delete": function(callback) {
-    return $.ajax("/t/" + (this.get('id')), {
+    return $.ajax(Discourse.getURL("/t/") + (this.get('id')), {
       type: 'DELETE',
       success: function() {
         return typeof callback === "function" ? callback() : void 0;
@@ -306,7 +306,7 @@ Discourse.Topic = Discourse.Model.extend({
     this.set('notification_level', v);
     this.set('notifications_reason_id', null);
     return $.ajax({
-      url: "/t/" + (this.get('id')) + "/notifications",
+      url: Discourse.getURL("/t/") + (this.get('id')) + "/notifications",
       type: 'POST',
       data: {
         notification_level: v
@@ -341,7 +341,7 @@ Discourse.Topic = Discourse.Model.extend({
     // Clear the pin optimistically from the object
     topic.set('pinned', false);
 
-    $.ajax("/t/" + this.get('id') + "/clear-pin", {
+    $.ajax(Discourse.getURL("/t/") + this.get('id') + "/clear-pin", {
       type: 'PUT',
       error: function() {
         // On error, put the pin back
@@ -391,7 +391,7 @@ Discourse.Topic.reopenClass({
   //    onLoad - the callback after the topic is loaded
   find: function(topicId, opts) {
     var data, promise, url;
-    url = "/t/" + topicId;
+    url = Discourse.getURL("/t/") + topicId;
 
     if (opts.nearPost) {
       url += "/" + opts.nearPost;
@@ -435,7 +435,7 @@ Discourse.Topic.reopenClass({
 
   // Create a topic from posts
   movePosts: function(topicId, title, postIds) {
-    return $.ajax("/t/" + topicId + "/move-posts", {
+    return $.ajax(Discourse.getURL(Discourse.getURL("/t/")) + topicId + "/move-posts", {
       type: 'POST',
       data: { title: title, post_ids: postIds }
     });

--- a/app/assets/javascripts/discourse/models/topic_list.js
+++ b/app/assets/javascripts/discourse/models/topic_list.js
@@ -13,7 +13,7 @@ Discourse.TopicList = Discourse.Model.extend({
     var moreUrl, _this = this;
 
     if (moreUrl = this.get('more_topics_url')) {
-      Discourse.URL.replaceState("/" + (this.get('filter')) + "/more");
+      Discourse.URL.replaceState(Discourse.getURL("/") + (this.get('filter')) + "/more");
       return $.ajax({url: moreUrl}).then(function (result) {
         var newTopics, topicIds, topics, topicsAdded = 0;
         if (result) {
@@ -91,7 +91,7 @@ Discourse.TopicList.reopenClass({
     topic_list = Discourse.TopicList.create();
     topic_list.set('inserted', Em.A());
     topic_list.set('filter', filter);
-    url = "/" + filter + ".json";
+    url = Discourse.getURL("/") + filter + ".json";
     if (menuItem.filters && menuItem.filters.length > 0) {
       url += "?exclude_category=" + menuItem.filters[0].substring(1);
     }

--- a/app/assets/javascripts/discourse/models/user.js
+++ b/app/assets/javascripts/discourse/models/user.js
@@ -45,7 +45,17 @@ Discourse.User = Discourse.Model.extend({
     @type {String}
   **/
   path: (function() {
-    return "/users/" + (this.get('username_lower'));
+    return Discourse.getURL("/users/") + (this.get('username_lower'));
+  }).property('username'),
+
+  /**
+    Path to this user's administration
+
+    @property adminPath
+    @type {String}
+  **/
+  adminPath: (function() {
+    return Discourse.getURL("/admin/users/") + (this.get('username_lower'));
   }).property('username'),
 
   /**
@@ -77,7 +87,7 @@ Discourse.User = Discourse.Model.extend({
   **/
   changeUsername: function(newUsername) {
     return $.ajax({
-      url: "/users/" + (this.get('username_lower')) + "/preferences/username",
+      url: Discourse.getURL("/users/") + (this.get('username_lower')) + "/preferences/username",
       type: 'PUT',
       data: {
         new_username: newUsername
@@ -94,7 +104,7 @@ Discourse.User = Discourse.Model.extend({
   **/
   changeEmail: function(email) {
     return $.ajax({
-      url: "/users/" + (this.get('username_lower')) + "/preferences/email",
+      url: Discourse.getURL("/users/") + (this.get('username_lower')) + "/preferences/email",
       type: 'PUT',
       data: {
         email: email
@@ -121,7 +131,7 @@ Discourse.User = Discourse.Model.extend({
   **/
   save: function(finished) {
     var _this = this;
-    $.ajax("/users/" + this.get('username').toLowerCase(), {
+    $.ajax(Discourse.getURL("/users/") + this.get('username').toLowerCase(), {
       data: this.getProperties('auto_track_topics_after_msecs',
                                'bio_raw',
                                'website',
@@ -154,7 +164,7 @@ Discourse.User = Discourse.Model.extend({
     var good;
     good = false;
   $.ajax({
-      url: '/session/forgot_password',
+      url: Discourse.getURL("/session/forgot_password"),
       dataType: 'json',
       data: {
         username: this.get('username')
@@ -200,7 +210,7 @@ Discourse.User = Discourse.Model.extend({
       _this = this;
     stream = this.get('stream');
     $.ajax({
-      url: "/user_actions/" + id + ".json",
+      url: Discourse.getURL("/user_actions/") + id + ".json",
       dataType: 'json',
       cache: 'false',
       success: function(result) {
@@ -236,7 +246,7 @@ Discourse.User = Discourse.Model.extend({
     stream = this.get('stream');
     if (!stream) return;
 
-    url = "/user_actions?offset=" + this.get('totalItems') + "&user_id=" + (this.get("id"));
+    url = Discourse.getURL("/user_actions?offset=") + this.get('totalItems') + "&user_id=" + (this.get("id"));
     if (this.get('streamFilter')) {
       url += "&filter=" + (this.get('streamFilter'));
     }
@@ -363,7 +373,7 @@ Discourse.User.reopenClass({
   **/
   checkUsername: function(username, email) {
     return $.ajax({
-      url: '/users/check_username',
+      url: Discourse.getURL('/users/check_username'),
       type: 'GET',
       data: {
         username: username,
@@ -428,7 +438,7 @@ Discourse.User.reopenClass({
 
     // Check the preload store first
     return PreloadStore.get("user_" + username, function() {
-      return $.ajax({ url: "/users/" + username + '.json' });
+      return $.ajax({ url: Discourse.getURL("/users/") + username + '.json' });
     }).then(function (json) {
 
       // Create a user from the resulting JSON
@@ -466,7 +476,7 @@ Discourse.User.reopenClass({
   **/
   createAccount: function(name, email, password, username, passwordConfirm, challenge) {
     return $.ajax({
-      url: '/users',
+      url: Discourse.getURL("/users"),
       dataType: 'json',
       data: {
         name: name,

--- a/app/assets/javascripts/discourse/templates/list/topic_list_item.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/list/topic_list_item.js.handlebars
@@ -24,7 +24,7 @@
 
   <td class='posters'>
     {{#each posters}}
-      <a href="/users/{{user.username_lower}}">{{avatar this usernamePath="user.username" imageSize="small"}}</a>
+      <a href="{{user.path}}">{{avatar this usernamePath="user.username" imageSize="small"}}</a>
     {{/each}}
   </td>
 

--- a/app/assets/javascripts/discourse/templates/post.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/post.js.handlebars
@@ -28,8 +28,8 @@
 
     <div class='topic-meta-data span2'>
       <div class='contents'>
-        <a href='/users/{{unbound username}}'>{{avatar this imageSize="large"}}</a>
-        <h3 {{bindAttr class="moderator new_user"}}><a href='/users/{{unbound username}}'>{{breakUp username}}</a></h3>
+        <a href='{{unbound usernameUrl}}'>{{avatar this imageSize="large"}}</a>
+        <h3 {{bindAttr class="moderator new_user"}}><a href='{{unbound usernameUrl}}'>{{breakUp username}}</a></h3>
 
         <div class='post-info'>
           <a href='#' class='post-date' {{bindAttr data-share-url="url"}}>{{date created_at}}</a>

--- a/app/assets/javascripts/discourse/templates/user/invited.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/user/invited.js.handlebars
@@ -21,8 +21,8 @@
             {{#each content.redeemed}}
               <tr>
                 <td>
-                  <a href="/users/{{unbound user.username_lower}}">{{avatar user imageSize="tiny"}}</a>
-                  <a href="/users/{{unbound user.username_lower}}">{{user.username}}</a>
+                  <a href="{{unbound user.path}}">{{avatar user imageSize="tiny"}}</a>
+                  <a href="{{unbound user.path}}">{{user.username}}</a>
                 </td>
                 <td>{{date redeemed_at}}</td>
                 <td>{{date user.last_seen_at}}</td>

--- a/app/assets/javascripts/discourse/templates/user/stream.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/user/stream.js.handlebars
@@ -2,7 +2,7 @@
   {{#collection contentBinding="stream" itemClass="item"}}
     {{#with view.content}}
       <div class='clearfix info'>
-        <a href="/users/{{unbound username}}" class='avatar-link'><div class='avatar-wrapper'>{{avatar this imageSize="large" extraClasses="actor" ignoreTitle="true"}}</div></a>
+        <a href="{{unbound usernameUrl}}" class='avatar-link'><div class='avatar-wrapper'>{{avatar this imageSize="large" extraClasses="actor" ignoreTitle="true"}}</div></a>
         <span class='time'>{{date path="created_at" leaveAgo="true"}}</span>
         <span class="title">
           <a href="{{unbound postUrl}}">{{unbound title}}</a>
@@ -17,7 +17,7 @@
           {{/if}}
           </span>
         {{/unless}}
-        <a class='name' href="/users/{{unbound username}}">{{personalizedName name usernamePath="username"}}</a>
+        <a class='name' href="{{unbound usernameUrl}}">{{personalizedName name usernamePath="username"}}</a>
         {{#if description}}
           <span class='type'>{{unbound description}}</span>
           {{#if isPostAction}}
@@ -40,7 +40,7 @@
         <div class='child-actions'>
           <i class="icon {{unbound icon}}"></i>
         {{#each items}}
-        <a href="/users/{{unbound username}}" class='avatar-link'><div class='avatar-wrapper'>{{avatar this imageSize="tiny" extraClasses="actor" ignoreTitle="true"}}</div></a>
+        <a href="{{unbound usernameUrl}}" class='avatar-link'><div class='avatar-wrapper'>{{avatar this imageSize="tiny" extraClasses="actor" ignoreTitle="true"}}</div></a>
         {{/each}}
         </div>
       {{/each}}

--- a/app/assets/javascripts/discourse/templates/user/user.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/user/user.js.handlebars
@@ -7,7 +7,7 @@
         <button {{action "logout" target="Discourse"}} class='btn'>{{i18n user.log_out}}</button>
       {{/if}}
       {{#if Discourse.currentUser.admin}}
-        <a href="/admin/users/{{unbound content.username_lower}}" class='btn'><i class="icon-wrench"></i>&nbsp;{{i18n admin.user.show_admin_profile}}</a>
+        <a href="{{unbound content.adminPath}}" class='btn'><i class="icon-wrench"></i>&nbsp;{{i18n admin.user.show_admin_profile}}</a>
       {{/if}}
       <ul class="nav nav-pills">
         <li>

--- a/app/assets/javascripts/discourse/views/actions_history_view.js
+++ b/app/assets/javascripts/discourse/views/actions_history_view.js
@@ -29,7 +29,7 @@ Discourse.ActionsHistoryView = Discourse.View.extend({
 
       if (c.get('users')) {
         c.get('users').forEach(function(u) {
-          buffer.push("<a href=\"/users/" + (u.get('username_lower')) + "\">");
+          buffer.push("<a href=\"" + Discourse.getURL("/users/") + (u.get('username_lower')) + "\">");
           buffer.push(Discourse.Utilities.avatarImg({
             size: 'small',
             username: u.get('username'),

--- a/app/assets/javascripts/discourse/views/header_view.js
+++ b/app/assets/javascripts/discourse/views/header_view.js
@@ -53,7 +53,7 @@ Discourse.HeaderView = Discourse.View.extend({
 
   showNotifications: function() {
     var _this = this;
-    $.get("/notifications").then(function(result) {
+    $.get(Discourse.getURL("/notifications")).then(function(result) {
       _this.set('notifications', result.map(function(n) {
         return Discourse.Notification.create(n);
       }));
@@ -93,7 +93,7 @@ Discourse.HeaderView = Discourse.View.extend({
     @property logoHTML
   **/
   logoHTML: function() {
-    var result = "<div class='title'><a href='/'>";
+    var result = "<div class='title'><a href='" + Discourse.getURL("/") + "'>";
     if (this.get('controller.showExtraInfo')) {
       var logo = Discourse.SiteSettings.logo_small_url;
       if (logo && logo.length > 1) {

--- a/app/assets/javascripts/discourse/views/modal/create_account_view.js
+++ b/app/assets/javascripts/discourse/views/modal/create_account_view.js
@@ -243,7 +243,7 @@ Discourse.CreateAccountView = Discourse.ModalBodyView.extend({
   fetchConfirmationValue: function() {
     var _this = this;
     return $.ajax({
-      url: '/users/hp.json',
+      url: Discourse.getURL('/users/hp.json'),
       success: function(json) {
         _this.set('accountPasswordConfirm', json.value);
         return _this.set('accountChallenge', json.challenge.split("").reverse().join(""));

--- a/app/assets/javascripts/discourse/views/modal/edit_category_view.js
+++ b/app/assets/javascripts/discourse/views/modal/edit_category_view.js
@@ -51,7 +51,7 @@ Discourse.EditCategoryView = Discourse.ModalBodyView.extend({
 
   saveSuccess: function(result) {
     $('#discourse-modal').modal('hide');
-    window.location = "/category/" + (Discourse.Utilities.categoryUrlId(result.category));
+    window.location = Discourse.getURL("/category/") + (Discourse.Utilities.categoryUrlId(result.category));
   },
 
   saveCategory: function() {

--- a/app/assets/javascripts/discourse/views/modal/forgot_password_view.js
+++ b/app/assets/javascripts/discourse/views/modal/forgot_password_view.js
@@ -16,7 +16,7 @@ Discourse.ForgotPasswordView = Discourse.ModalBodyView.extend({
   }).property('accountEmailOrUsername'),
 
   submit: function() {
-    $.post("/session/forgot_password", {
+    $.post(Discourse.getURL("/session/forgot_password"), {
       username: this.get('accountEmailOrUsername')
     });
     // don't tell people what happened, this keeps it more secure (ensure same on server)

--- a/app/assets/javascripts/discourse/views/modal/login_view.js
+++ b/app/assets/javascripts/discourse/views/modal/login_view.js
@@ -45,7 +45,7 @@ Discourse.LoginView = Discourse.ModalBodyView.extend({
   login: function() {
     var _this = this;
     this.set('loggingIn', true);
-    $.post("/session", {
+    $.post(Discourse.getURL("/session"), {
       login: this.get('loginName'),
       password: this.get('loginPassword')
     }).success(function(result) {
@@ -82,7 +82,7 @@ Discourse.LoginView = Discourse.ModalBodyView.extend({
     this.set('authenticate', 'twitter');
     left = this.get('lastX') - 400;
     top = this.get('lastY') - 200;
-    return window.open("/auth/twitter", "_blank", "menubar=no,status=no,height=400,width=800,left=" + left + ",top=" + top);
+    return window.open(Discourse.getURL("/auth/twitter"), "_blank", "menubar=no,status=no,height=400,width=800,left=" + left + ",top=" + top);
   },
 
   facebookLogin: function() {
@@ -90,7 +90,7 @@ Discourse.LoginView = Discourse.ModalBodyView.extend({
     this.set('authenticate', 'facebook');
     left = this.get('lastX') - 400;
     top = this.get('lastY') - 200;
-    return window.open("/auth/facebook", "_blank", "menubar=no,status=no,height=400,width=800,left=" + left + ",top=" + top);
+    return window.open(Discourse.getURL("/auth/facebook"), "_blank", "menubar=no,status=no,height=400,width=800,left=" + left + ",top=" + top);
   },
 
   openidLogin: function(provider) {
@@ -99,9 +99,9 @@ Discourse.LoginView = Discourse.ModalBodyView.extend({
     top = this.get('lastY') - 200;
     if (provider === "yahoo") {
       this.set("authenticate", 'yahoo');
-      return window.open("/auth/yahoo", "_blank", "menubar=no,status=no,height=400,width=800,left=" + left + ",top=" + top);
+      return window.open(Discourse.getURL("/auth/yahoo"), "_blank", "menubar=no,status=no,height=400,width=800,left=" + left + ",top=" + top);
     } else {
-      window.open("/auth/google", "_blank", "menubar=no,status=no,height=500,width=850,left=" + left + ",top=" + top);
+      window.open(Discourse.getURL("/auth/google"), "_blank", "menubar=no,status=no,height=500,width=850,left=" + left + ",top=" + top);
       return this.set("authenticate", 'google');
     }
   },
@@ -111,7 +111,7 @@ Discourse.LoginView = Discourse.ModalBodyView.extend({
     this.set('authenticate', 'github');
     left = this.get('lastX') - 400;
     top = this.get('lastY') - 200;
-    return window.open("/auth/github", "_blank", "menubar=no,status=no,height=400,width=800,left=" + left + ",top=" + top);
+    return window.open(Discourse.getURL("/auth/github"), "_blank", "menubar=no,status=no,height=400,width=800,left=" + left + ",top=" + top);
   },
 
   personaLogin: function() {

--- a/app/assets/javascripts/discourse/views/modal/not_activated_view.js
+++ b/app/assets/javascripts/discourse/views/modal/not_activated_view.js
@@ -12,7 +12,7 @@ Discourse.NotActivatedView = Discourse.ModalBodyView.extend({
   emailSent: false,
 
   sendActivationEmail: function() {
-    $.get('/users/' + this.get('username') + '/send_activation_email');
+    $.get(Discourse.getURL('/users/') + this.get('username') + '/send_activation_email');
     this.set('emailSent', true);
   }
 });

--- a/app/assets/javascripts/discourse/views/post_view.js
+++ b/app/assets/javascripts/discourse/views/post_view.js
@@ -149,7 +149,7 @@ Discourse.PostView = Discourse.View.extend({
           navLink = "<a href='" + (topic.urlForPostNumber(postNumber)) + "' title='" + quoteTitle + "' class='back'></a>";
         } else {
           // Made up slug should be replaced with canonical URL
-          navLink = "<a href='/t/via-quote/" + topicId + "/" + postNumber + "' title='" + quoteTitle + "' class='quote-other-topic'></a>";
+          navLink = "<a href='" + Discourse.getURL("/t/via-quote/") + topicId + "/" + postNumber + "' title='" + quoteTitle + "' class='quote-other-topic'></a>";
         }
       } else if (topic = this.get('controller.content')) {
         // assume the same topic
@@ -180,7 +180,7 @@ Discourse.PostView = Discourse.View.extend({
       if ($aside.data('topic')) {
         topic_id = $aside.data('topic');
       }
-      $.getJSON("/posts/by_number/" + topic_id + "/" + ($aside.data('post')), function(result) {
+      $.getJSON(Discourse.getURL("/posts/by_number/") + topic_id + "/" + ($aside.data('post')), function(result) {
         var parsed = $(result.cooked);
         parsed.replaceText(originalText, "<span class='highlighted'>" + originalText + "</span>");
         return $blockQuote.showHtml(parsed);

--- a/app/assets/javascripts/discourse/views/search/search_view.js
+++ b/app/assets/javascripts/discourse/views/search/search_view.js
@@ -96,7 +96,7 @@ Discourse.SearchView = Discourse.View.extend({
     }
     this.searcher = this.searcher || Discourse.debounce(function(term, typeFilter) {
       _this.currentSearch = $.ajax({
-        url: '/search',
+        url: Discourse.getURL('/search'),
         data: {
           term: term,
           type_filter: typeFilter

--- a/app/assets/javascripts/discourse/views/topic_view.js
+++ b/app/assets/javascripts/discourse/views/topic_view.js
@@ -487,7 +487,7 @@ Discourse.TopicView = Discourse.View.extend(Discourse.Scrolling, {
       opts.catLink = Discourse.Utilities.categoryLink(category);
       return Ember.String.i18n("topic.read_more_in_category", opts);
     } else {
-      opts.catLink = "<a href=\"/categories\">" + (Em.String.i18n("topic.browse_all_categories")) + "</a>";
+      opts.catLink = "<a href=\"" + Discourse.getURL("/categories") + "\">" + (Em.String.i18n("topic.browse_all_categories")) + "</a>";
       return Ember.String.i18n("topic.read_more", opts);
     }
   }).property(),

--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -19,7 +19,7 @@ class InvitesController < ApplicationController
 
         topic = invite.topics.first
         if topic.present?
-          redirect_to topic.relative_url
+          redirect_to "#{Discourse.base_uri}#{topic.relative_url}"
           return
         end
       end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -54,4 +54,15 @@ module ApplicationHelper
     result
   end
 
+  def faq_path
+    return "#{Discourse::base_uri}/faq"
+  end
+
+  def tos_path
+    return "#{Discourse::base_uri}/tos"
+  end
+
+  def privacy_path
+    return "#{Discourse::base_uri}/privacy"
+  end
 end

--- a/app/views/common/_persona_javascript.html.erb
+++ b/app/views/common/_persona_javascript.html.erb
@@ -8,7 +8,7 @@
 
           $.ajax({
             type: 'POST',
-            url: '/auth/persona/callback',
+            url: Discourse.getURL('/auth/persona/callback'),
             data: { 'assertion': assertion },
             success: function(data, textStatus, jqXHR) {
               Discourse.authenticationComplete(data);

--- a/app/views/common/_special_font_face.html.erb
+++ b/app/views/common/_special_font_face.html.erb
@@ -21,9 +21,9 @@
 
   @font-face {
         font-family: 'zocial';
-        src: url('/assets/zocial-regular-webfont.woff?<%= font_domain %>') format('woff'),
-            url('/assets/zocial-regular-webfont.ttf?<%= font_domain %>') format('truetype'),
-            url('/assets/zocial-regular-webfont.svg?<%= font_domain %>#zocialregular') format('svg');
+        src: url('<%=asset_path "zocial-regular-webfont.woff" %>?<%= font_domain %>') format('woff'),
+            url('<%=asset_path "zocial-regular-webfont.ttf" %>?<%= font_domain %>') format('truetype'),
+            url('<%=asset_path "zocial-regular-webfont.svg" %>?<%= font_domain %>#zocialregular') format('svg');
         font-weight: normal;
         font-style: normal;
 

--- a/app/views/static/faq.cs.html.erb
+++ b/app/views/static/faq.cs.html.erb
@@ -1,7 +1,7 @@
 <ul class="nav-pills">
-  <li><a class="active" href="/faq">FAQ</a></li>
-  <li><a href="/tos">Podmínky používání</a></li>
-  <li><a href="/privacy">Ochrana soukromí</a></li>
+  <li><a class="active" href="<%=faq_path%>">FAQ</a></li>
+  <li><a href="<%=tos_path%>">Podmínky používání</a></li>
+  <li><a href="<%=privacy_path%>">Ochrana soukromí</a></li>
 </ul>
 
 <div id="civilized"></div>
@@ -125,7 +125,7 @@
 <div id="tos"></div>
 <h2><a href="tos">Podmínky používání</a></h2>
 <p>
-  Ano, právničina je nudná, ale musíme se sami právně chránit &ndash; a také vás a vaše data &ndash; proti nepřátelským právníckám fíglům. Máme svoje <a href="/tos">Podmínky používání</a> popisující vaše (a naše) chování a práva ve vztahu k obsahu, soukromí a zákonům. Pokud chcete používat toto fórum, musíte souhlasit s tím, že budete dodržovat <a href="/tos">tyto podmínky</a>.
+  Ano, právničina je nudná, ale musíme se sami právně chránit &ndash; a také vás a vaše data &ndash; proti nepřátelským právníckám fíglům. Máme svoje <a href="<%=tos_path%>">Podmínky používání</a> popisující vaše (a naše) chování a práva ve vztahu k obsahu, soukromí a zákonům. Pokud chcete používat toto fórum, musíte souhlasit s tím, že budete dodržovat <a href="<%=tos_path%>">tyto podmínky</a>.
 </p>
 <div class="more">
 </div>

--- a/app/views/static/faq.en.html.erb
+++ b/app/views/static/faq.en.html.erb
@@ -1,7 +1,7 @@
 <ul class="nav-pills">
-  <li><a class="active" href="/faq">FAQ</a></li>
-  <li><a href="/tos">Terms of Service</a></li>
-  <li><a href="/privacy">Privacy</a></li>
+  <li><a class="active" href="<%=faq_path%>">FAQ</a></li>
+  <li><a href="<%=tos_path%>">Terms of Service</a></li>
+  <li><a href="<%=privacy_path%>">Privacy</a></li>
 </ul>
 
 <div id="civilized"></div>
@@ -125,7 +125,7 @@
 <div id="tos"></div>
 <h2><a href="tos">Terms of Service</a></h2>
 <p>
-  Yes, legalese is boring, but we must protect ourselves &ndash; and by extension, you and your data &ndash; against unfriendly folks. We have a <a href="/tos">Terms of Service</a> describing your (and our) behavior and rights related to content, privacy, and laws. To use this service, you must agree to abide by our <a href="/tos">TOS</a>.
+  Yes, legalese is boring, but we must protect ourselves &ndash; and by extension, you and your data &ndash; against unfriendly folks. We have a <a href="<%=tos_path%>">Terms of Service</a> describing your (and our) behavior and rights related to content, privacy, and laws. To use this service, you must agree to abide by our <a href="<%=tos_path%>">TOS</a>.
 </p>
 <div class="more">
 </div>

--- a/app/views/static/privacy.cs.html.erb
+++ b/app/views/static/privacy.cs.html.erb
@@ -1,7 +1,7 @@
 <ul class="nav-pills">
-  <li><a href="/faq">FAQ</a></li>
-  <li><a href="/tos">Podmínky používání</a></li>
-  <li><a class="active" href="/privacy">Ochrana soukromí</a></li>
+  <li><a href="<%=faq_path%>">FAQ</a></li>
+  <li><a href="<%=tos_path%>">Podmínky používání</a></li>
+  <li><a class="active" href="<%=privacy_path%>">Ochrana soukromí</a></li>
 </ul>
 
 <div id="collect"></div>

--- a/app/views/static/privacy.en.html.erb
+++ b/app/views/static/privacy.en.html.erb
@@ -1,7 +1,7 @@
 <ul class="nav-pills">
-  <li><a href="/faq">FAQ</a></li>
-  <li><a href="/tos">Terms of Service</a></li>
-  <li><a class="active" href="/privacy">Privacy</a></li>
+  <li><a href="<%=faq_path%>">FAQ</a></li>
+  <li><a href="<%=tos_path%>">Terms of Service</a></li>
+  <li><a class="active" href="<%=privacy_path%>">Privacy</a></li>
 </ul>
 
 <div id="collect"></div>

--- a/app/views/static/tos.cs.html.erb
+++ b/app/views/static/tos.cs.html.erb
@@ -1,11 +1,11 @@
 <ul class="nav-pills">
-  <li><a href="/faq">FAQ</a></li>
-  <li><a class="active" href="/tos">Podmínky používání</a></li>
-  <li><a href="/privacy">Ochrana soukromí</a></li>
+  <li><a href="<%=faq_path%>">FAQ</a></li>
+  <li><a class="active" href="<%=tos_path%>">Podmínky používání</a></li>
+  <li><a href="<%=privacy_path%>">Ochrana soukromí</a></li>
 </ul>
 
 <p>
-  The following terms and conditions govern all use of the <%= SiteSetting.company_domain %> website and all content, services and products available at or through the website, including, but not limited to, <%= SiteSetting.company_domain %> Forum Software, <%= SiteSetting.company_domain %> Support Forums and the <%= SiteSetting.company_domain %> Hosting service (“Hosting”), (taken together, the Website). The Website is owned and operated by <%= SiteSetting.company_full_name %> (“<%= SiteSetting.company_short_name %>”). The Website is offered subject to your acceptance without modification of all of the terms and conditions contained herein and all other operating rules, policies (including, without limitation, <%= SiteSetting.company_domain %>’s <a href="/privacy">Privacy Policy</a> and <a href="/faq">Community Guidelines</a>) and procedures that may be published from time to time on this Site by <%= SiteSetting.company_short_name %> (collectively, the “Agreement”).
+  The following terms and conditions govern all use of the <%= SiteSetting.company_domain %> website and all content, services and products available at or through the website, including, but not limited to, <%= SiteSetting.company_domain %> Forum Software, <%= SiteSetting.company_domain %> Support Forums and the <%= SiteSetting.company_domain %> Hosting service (“Hosting”), (taken together, the Website). The Website is owned and operated by <%= SiteSetting.company_full_name %> (“<%= SiteSetting.company_short_name %>”). The Website is offered subject to your acceptance without modification of all of the terms and conditions contained herein and all other operating rules, policies (including, without limitation, <%= SiteSetting.company_domain %>’s <a href="<%=privacy_path%>">Privacy Policy</a> and <a href="<%=faq_path%>">Community Guidelines</a>) and procedures that may be published from time to time on this Site by <%= SiteSetting.company_short_name %> (collectively, the “Agreement”).
 </p>
 
 <p>
@@ -122,7 +122,7 @@
 <div id="16"></div>
 <h2><a href="#16">16. General Representation and Warranty</a></h2>
 <p>
-  You represent and warrant that (i) your use of the Website will be in strict accordance with the <%= SiteSetting.company_short_name %> <a href="/privacy">Privacy Policy</a>, <a href="/faq">Community Guidelines</a>, with this Agreement and with all applicable laws and regulations (including without limitation any local laws or regulations in your country, state, city, or other governmental area, regarding online conduct and acceptable content, and including all applicable laws regarding the transmission of technical data exported from the United States or the country in which you reside) and (ii) your use of the Website will not infringe or misappropriate the intellectual property rights of any third party.
+  You represent and warrant that (i) your use of the Website will be in strict accordance with the <%= SiteSetting.company_short_name %> <a href="<%=privacy_path%>">Privacy Policy</a>, <a href="<%=faq_path%>">Community Guidelines</a>, with this Agreement and with all applicable laws and regulations (including without limitation any local laws or regulations in your country, state, city, or other governmental area, regarding online conduct and acceptable content, and including all applicable laws regarding the transmission of technical data exported from the United States or the country in which you reside) and (ii) your use of the Website will not infringe or misappropriate the intellectual property rights of any third party.
 </p>
 
 <div id="17"></div>

--- a/app/views/static/tos.en.html.erb
+++ b/app/views/static/tos.en.html.erb
@@ -1,11 +1,11 @@
 <ul class="nav-pills">
-  <li><a href="/faq">FAQ</a></li>
-  <li><a class="active" href="/tos">Terms of Service</a></li>
-  <li><a href="/privacy">Privacy</a></li>
+  <li><a href="<%=faq_path%>">FAQ</a></li>
+  <li><a class="active" href="<%=tos_path%>">Terms of Service</a></li>
+  <li><a href="<%=privacy_path%>">Privacy</a></li>
 </ul>
 
 <p>
-  The following terms and conditions govern all use of the <%= SiteSetting.company_domain %> website and all content, services and products available at or through the website, including, but not limited to, <%= SiteSetting.company_domain %> Forum Software, <%= SiteSetting.company_domain %> Support Forums and the <%= SiteSetting.company_domain %> Hosting service (“Hosting”), (taken together, the Website). The Website is owned and operated by <%= SiteSetting.company_full_name %> (“<%= SiteSetting.company_short_name %>”). The Website is offered subject to your acceptance without modification of all of the terms and conditions contained herein and all other operating rules, policies (including, without limitation, <%= SiteSetting.company_domain %>’s <a href="/privacy">Privacy Policy</a> and <a href="/faq">Community Guidelines</a>) and procedures that may be published from time to time on this Site by <%= SiteSetting.company_short_name %> (collectively, the “Agreement”).
+  The following terms and conditions govern all use of the <%= SiteSetting.company_domain %> website and all content, services and products available at or through the website, including, but not limited to, <%= SiteSetting.company_domain %> Forum Software, <%= SiteSetting.company_domain %> Support Forums and the <%= SiteSetting.company_domain %> Hosting service (“Hosting”), (taken together, the Website). The Website is owned and operated by <%= SiteSetting.company_full_name %> (“<%= SiteSetting.company_short_name %>”). The Website is offered subject to your acceptance without modification of all of the terms and conditions contained herein and all other operating rules, policies (including, without limitation, <%= SiteSetting.company_domain %>’s <a href="<%=privacy_path%>">Privacy Policy</a> and <a href="<%=faq_path%>">Community Guidelines</a>) and procedures that may be published from time to time on this Site by <%= SiteSetting.company_short_name %> (collectively, the “Agreement”).
 </p>
 
 <p>
@@ -122,7 +122,7 @@ In no event will <%= SiteSetting.company_short_name %>, or its suppliers or lice
 <div id="16"></div>
 <h2><a href="#16">16. General Representation and Warranty</a></h2>
 <p>
-You represent and warrant that (i) your use of the Website will be in strict accordance with the <%= SiteSetting.company_short_name %> <a href="/privacy">Privacy Policy</a>, <a href="/faq">Community Guidelines</a>, with this Agreement and with all applicable laws and regulations (including without limitation any local laws or regulations in your country, state, city, or other governmental area, regarding online conduct and acceptable content, and including all applicable laws regarding the transmission of technical data exported from the United States or the country in which you reside) and (ii) your use of the Website will not infringe or misappropriate the intellectual property rights of any third party.
+You represent and warrant that (i) your use of the Website will be in strict accordance with the <%= SiteSetting.company_short_name %> <a href="<%=privacy_path%>">Privacy Policy</a>, <a href="<%=faq_path%>">Community Guidelines</a>, with this Agreement and with all applicable laws and regulations (including without limitation any local laws or regulations in your country, state, city, or other governmental area, regarding online conduct and acceptable content, and including all applicable laws regarding the transmission of technical data exported from the United States or the country in which you reside) and (ii) your use of the Website will not infringe or misappropriate the intellectual property rights of any third party.
 </p>
 
 <div id="17"></div>

--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -18,6 +18,14 @@ module Discourse
     RailsMultisite::ConnectionManagement.current_hostname
   end
 
+  def self.base_uri
+    if !ActionController::Base.config.relative_url_root.blank?
+      return ActionController::Base.config.relative_url_root 
+    else
+      return ""
+    end
+  end
+
   def self.base_url
     protocol = "http"
     protocol = "https" if SiteSetting.use_ssl?
@@ -27,6 +35,7 @@ module Discourse
       result = "#{protocol}://#{current_hostname}"
     end
     result << ":#{SiteSetting.port}" if SiteSetting.port.present? && SiteSetting.port.to_i > 0
+    result << ActionController::Base.config.relative_url_root if !ActionController::Base.config.relative_url_root.blank?
     result
   end
 

--- a/lib/pretty_text.rb
+++ b/lib/pretty_text.rb
@@ -120,6 +120,7 @@ module PrettyText
       # we need to do this to work in a multi site environment, many sites, many settings
       v8.eval("Discourse.SiteSettings = #{SiteSetting.client_settings_json};")
       v8.eval("Discourse.BaseUrl = 'http://#{RailsMultisite::ConnectionManagement.current_hostname}';")
+      v8.eval("Discourse.getURL = function(url) {return '#{Discourse::base_uri}' + url};")
       v8['opts'] = opts || {}
       v8['raw'] = text
       v8.eval('opts["mentionLookup"] = function(u){return helpers.is_username_valid(u);}')


### PR DESCRIPTION
The following changes allow running Discourse with a prefix such as /discourse. The change does not affect running Discourse without a prefix.

The number of changes is large, but most of it is un-hardcoding the URLs for requests. It also includes Discourse.getURL() that uses rootURL to format the URL accordingly.

Running Discourse in a prefixed environment still requires changing "rootURL" value in JavaScript files directly, but is possible and all of the URLs work properly.

The code does includes changes to most of handlebars templates. For the remaining links, they work fine because JavaScript events capture and route them, the only thing not working is opening those links in a new tab.

We are working on getting those links working as well. If you have any suggestions on how to fix it, please let me know. 
