### PR TITLE
Markdown.Editor / Pagedown cleanup. Option to disable preview events.

### DIFF
--- a/app/assets/javascripts/discourse/components/markdown.js
+++ b/app/assets/javascripts/discourse/components/markdown.js
@@ -81,7 +81,8 @@ Discourse.Markdown = {
         redomac: I18n.t("js.composer.redo_title") + " - Ctrl+Shift+Z",
 
         help: I18n.t("js.composer.help")
-      }
+      },
+      manualPreview: true
     };
 
     return new Markdown.Editor(markdownConverter, undefined, editorOptions);

--- a/app/assets/javascripts/discourse/views/pagedown_editor.js
+++ b/app/assets/javascripts/discourse/views/pagedown_editor.js
@@ -13,8 +13,16 @@ Discourse.PagedownEditor = Ember.ContainerView.extend({
 
   init: function() {
     this._super();
-
-    $LAB.script(assetPath('defer/html-sanitizer-bundle'));
+    var _this = this;
+    $LAB.script(assetPath('defer/html-sanitizer-bundle')).wait(function(){
+      var editor = _this.get('editor');
+      if(editor){
+        //Call refresh preview on sanitizer script load because
+        //if it wasn't loaded before editor.run() was called then the
+        //preview is likely blank
+        editor.refreshPreview();
+      }
+    });
 
     // Add a button bar
     this.pushObject(Em.View.create({ elementId: 'wmd-button-bar' }));
@@ -30,10 +38,10 @@ Discourse.PagedownEditor = Ember.ContainerView.extend({
   },
 
   didInsertElement: function() {
-    var $wmdInput = $('#wmd-input');
-    $wmdInput.data('init', true);
-    this.set('editor', Discourse.Markdown.createEditor());
-    return this.get('editor').run();
+    $('#wmd-input').data('init', true);
+    var editor = Discourse.Markdown.createEditor();
+    this.set('editor', editor);
+    return editor.run();
   },
 
   observeValue: (function() {
@@ -43,5 +51,3 @@ Discourse.PagedownEditor = Ember.ContainerView.extend({
   }).observes('value')
 
 });
-
-


### PR DESCRIPTION
**Notes**
- cleaned up some variable caching and newlines / if blocks / strict equality comparisons.
- added option to disable automatic preview events
- added callback to html-sanitizer-bundle script load to ensure preview is generated on page load
- fixed a double timeout inside the refresh method (applyTimeout on a debounced method).

**Commit message**

Markdown.Editor cleanup. cached setScrollPanelTops calculations. Added option to set preview to manual, won't bind input events. removed double timeout call in refresh (applyTimeout + debounce). added wait callback in pagedown_editor to sanitizer script to refresh preview on load.
