### PR TITLE
site setting for category colors

### DIFF
--- a/app/assets/javascripts/discourse/templates/modal/edit_category.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/modal/edit_category.js.handlebars
@@ -28,13 +28,13 @@
         <div class='input-prepend input-append' style="margin-top: 10px;">
           <span class='color-title'>{{i18n category.background_color}}:</span>
           <span class='add-on'>#</span>{{view Discourse.TextField valueBinding="view.category.color" placeholderKey="category.color_placeholder" maxlength="6"}}
-          {{view Discourse.ColorsView colorsBinding="view.predefinedColors" valueBinding="view.category.color"}}
+          {{view Discourse.ColorsView colorsBinding="view.backgroundColors" valueBinding="view.category.color"}}
         </div>
 
         <div class='input-prepend input-append'>
           <span class='color-title'>{{i18n category.foreground_color}}:</span>
           <span class='add-on'>#</span>{{view Discourse.TextField valueBinding="view.category.text_color" placeholderKey="category.color_placeholder" maxlength="6"}}
-          {{view Discourse.ColorsView colorsBinding="view.predefinedColors" valueBinding="view.category.text_color"}}
+          {{view Discourse.ColorsView colorsBinding="view.foregroundColors" valueBinding="view.category.text_color"}}
         </div>
     </div>
 

--- a/app/assets/javascripts/discourse/views/modal/edit_category_view.js
+++ b/app/assets/javascripts/discourse/views/modal/edit_category_view.js
@@ -21,8 +21,13 @@ Discourse.EditCategoryView = Discourse.ModalBodyView.extend({
     return "background-color: #" + (this.get('category.color')) + "; color: #" + (this.get('category.text_color')) + ";";
   }).property('category.color', 'category.text_color'),
 
-  predefinedColors: ["FFFFFF", "000000", "AECFC6", "836953", "77DD77", "FFB347", "FDFD96", "536878",
-      "EC5800", "0096E0", "7C4848", "9AC932", "BA160C", "003366", "B19CD9", "E4717A"],
+  // background colors are available as a pipe-separated string
+  backgroundColors: (function() {
+    return Discourse.SiteSettings.category_colors.split("|").map(function(i) { return i.toUpperCase(); });
+  }).property('Discourse.SiteSettings.category_colors'),
+
+  // black & white only for foreground colors
+  foregroundColors: ['FFFFFF', '000000'],
 
   title: (function() {
     if (this.get('category.id')) return Em.String.i18n("category.edit_long");

--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -36,6 +36,8 @@ class SiteSetting < ActiveRecord::Base
   client_setting(:version_checks, true)
   client_setting(:min_title_similar_length, 10)
   client_setting(:min_body_similar_length, 15)
+  # cf. https://github.com/discourse/discourse/pull/462#issuecomment-14991562
+  client_setting(:category_colors, 'BF1E2E|F1592A|F7941D|9EB83B|3AB54A|12A89D|25AAE2|0E76BD|652D90|92278F|ED207B|8C6238|231F20|808281|B3B5B4|283890')
 
   # settings only available server side
   setting(:auto_track_topics_after, 300000)

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -415,6 +415,8 @@ en:
     min_title_similar_length: "The minimum length of a title before it will be checked for similar topics"
     min_body_similar_length: "The minimum length of a post's body before it will be checked for similar topics"
 
+    category_colors: "A pipe (|) separated list of hexadecimal color values allowed for categories"
+
   notification_types:
     mentioned: "%{display_username} mentioned you in %{link}"
     liked: "%{display_username} liked your post in %{link}"

--- a/config/locales/server.fr.yml
+++ b/config/locales/server.fr.yml
@@ -422,6 +422,8 @@ fr:
     min_title_similar_length: "La taille minimale du titre avant que l'on vérifie l'existence de discussions identiques"
     min_body_similar_length: "La taille minimale du message avant que l'on vérifie l'existence de discussions identiques"
 
+    category_colors: "Une liste de couleurs autorisées pour les catégories (au format hexadécimal, séparés par un |)"
+
   notification_types:
     mentioned: "%{display_username} vous a mentionné dans %{link}"
     liked: "%{display_username} a aimé votre message dans %{link}"


### PR DESCRIPTION
![Screenshot_17_03_13_01_44](https://f.cloud.github.com/assets/362783/267549/e6ee0800-8e9b-11e2-94c6-e9d1dea129ba.png)
- [x] category colors is now a site setting
- [x] default category colors are [DESIGNER APPROVED](https://github.com/discourse/discourse/pull/462#issuecomment-14991562)
- [x] differentiated foreground and background colors
- [x] only **black & white** is available for foreground colors
- [x] localized explanatory strings

_original pull request: #476_
