### PR TITLE
keep favorite/star button's title in sync with starred status

### DIFF
--- a/app/assets/javascripts/discourse/models/topic.js
+++ b/app/assets/javascripts/discourse/models/topic.js
@@ -141,6 +141,14 @@ Discourse.Topic = Discourse.Model.extend({
     });
   },
 
+  favoriteTooltipKey: (function() {
+    return this.get('starred') ? 'favorite.help.unstar' : 'favorite.help.star';
+  }).property('starred'),
+
+  favoriteTooltip: (function() {
+    return Em.String.i18n(this.get('favoriteTooltipKey'));
+  }).property('favoriteTooltipKey'),
+
   toggleStar: function() {
     var topic = this;
     topic.toggleProperty('starred');

--- a/app/assets/javascripts/discourse/templates/list/topic_list_item.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/list/topic_list_item.js.handlebars
@@ -1,7 +1,7 @@
 
   {{#if Discourse.currentUser.id}}
     <td class='star'>
-      <a {{bindAttr class=":star :icon-star starred:starred"}} {{action toggleStar this target="controller"}} href='#' title='{{i18n favorite.help}}'></a>
+      <a {{bindAttr class=":star :icon-star starred:starred"}} {{action toggleStar this target="controller"}} href='#' {{bindAttr title="favoriteTooltip"}}></a>
     </td>
   {{/if}}
 

--- a/app/assets/javascripts/discourse/templates/topic.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/topic.js.handlebars
@@ -6,7 +6,7 @@
       <div class='container'>
         <div class='inner'>
           {{#if view.showFavoriteButton}}
-            <a {{bindAttr class=":star view.topic.starred:starred"}} {{action toggleStar target="controller"}} href='#' title="{{i18n favorite.help}}"></a>
+            <a {{bindAttr class=":star view.topic.starred:starred"}} {{action toggleStar target="controller"}} href='#' {{bindAttr title="favoriteTooltip"}}></a>
           {{/if}}
           {{#if view.editingTopic}}
             <input id='edit-title' type='text' {{bindAttr value="view.topic.title"}}>

--- a/app/assets/javascripts/discourse/templates/topic_extra_info.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/topic_extra_info.js.handlebars
@@ -1,5 +1,5 @@
 {{#if view.showFavoriteButton}}
-  <a {{bindAttr class=":star view.topic.starred:starred"}} {{action toggleStar target="controller"}} href='#' title="{{i18n favorite.help}}"></a>
+  <a {{bindAttr class=":star view.topic.starred:starred"}} {{action toggleStar target="controller"}} href='#' {{bindAttr title="view.topic.favoriteTooltip"}}></a>
 {{/if}}
 
 <h1>

--- a/app/assets/javascripts/discourse/views/topic_footer_buttons_view.js
+++ b/app/assets/javascripts/discourse/views/topic_footer_buttons_view.js
@@ -40,7 +40,7 @@ Discourse.TopicFooterButtonsView = Ember.ContainerView.extend({
 
         this.addObject(Discourse.ButtonView.createWithMixins({
           textKey: 'favorite.title',
-          helpKey: 'favorite.help',
+          helpKeyBinding: 'controller.content.favoriteTooltipKey',
 
           favoriteChanged: (function() {
             this.rerender();

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -357,7 +357,9 @@ en:
 
     favorite:
       title: 'Favorite'
-      help: 'add this topic to your favorites list'
+      help:
+        star: 'add this topic to your favorites list'
+        unstar: 'remove this topic from your favorites list'
 
     topics:
       none:

--- a/config/locales/client.fr.yml
+++ b/config/locales/client.fr.yml
@@ -361,7 +361,9 @@ fr:
 
     favorite:
       title: 'Favoris'
-      help: 'ajouter cette discussion à vos favoris'
+      help:
+        star: 'ajouter cette discussion à vos favoris'
+        unstar: 'enlever cette discussion de vos favoris'
 
     topics:
       none:


### PR DESCRIPTION
Meta: [‘Favourite’ Should Read ‘Unfavourite’ When a Topic Is Favourited](http://meta.discourse.org/t/favourite-should-read-unfavourite-when-a-topic-is-favourited/3231) & [Filtering topic by user is very buggy/laggy](http://meta.discourse.org/t/filtering-topic-by-user-is-very-buggy-laggy/4813/3)

This will keep the title of both the favorite button and the stars in sync with the starred status of the topic.

![Screenshot_18_03_13_00_22](https://f.cloud.github.com/assets/362783/268801/85cc6d32-8f59-11e2-83b6-327da3c71bb6.png)
- [x] added **2** methods to the `topic` model
  - `favoriteTooltipKey` that will return the translation key depending on the _starred_ status of the topic
  - `favoriteTooltip` that will return the translated string based on the previous method
- [x] binded the title attributes to `favoriteTooltip` for the stars (in the `topic_list_item`, `topic` and `topic_extra_info` templates)
- [x] binded the `helpKey` property to `favoriteTooltipKey` for the favorite button
- [x] added globalization for the **2** strings

I've checked the following places:
- the star on a topic list
- the star next to the topic title when viewing a topic
- the star next to the topic title when viewing a topic and scrolled down
- the favorite button when viewing a topic

Please, do not hesitate to tell me whether I missed one :wink:
