### PR TITLE
fix some issues when editing a topic title and then cancelling it

### DIFF
--- a/app/assets/javascripts/discourse/templates/topic.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/topic.js.handlebars
@@ -10,7 +10,7 @@
           {{/if}}
           {{#if view.editingTopic}}
             <input id='edit-title' type='text' {{bindAttr value="view.topic.title"}}>
-            {{view Discourse.ComboboxViewCategory valueAttribute="name" contentBinding="Discourse.site.categories" valueBinding="view.topic.categoryName"}}
+            {{view Discourse.ComboboxViewCategory valueAttribute="name" contentBinding="Discourse.site.categories" sourceBinding="view.topic.categoryName"}}
             <button class='btn btn-primary btn-small' {{action finishedEdit target="view"}}><i class='icon-ok'></i></button>
             <button class='btn btn-small' {{action cancelEdit target="view"}}><i class='icon-remove'></i></button>
           {{else}}

--- a/app/assets/javascripts/discourse/views/combobox_view_category.js
+++ b/app/assets/javascripts/discourse/views/combobox_view_category.js
@@ -9,6 +9,7 @@
 Discourse.ComboboxViewCategory = Discourse.ComboboxView.extend({
   none: 'category.none',
   dataAttributes: ['color', 'text_color', 'description'],
+  valueBinding: Ember.Binding.oneWay('source'),
 
   template: function(text, templateData) {
     if (!templateData.color) return text;

--- a/app/assets/javascripts/discourse/views/topic_view.js
+++ b/app/assets/javascripts/discourse/views/topic_view.js
@@ -345,24 +345,25 @@ Discourse.TopicView = Discourse.View.extend(Discourse.Scrolling, {
   },
 
   cancelEdit: function() {
-    // set the previous category back
-    this.set('controller.content.category', this.get('previousCategory'));
-    // clear the previous category
-    this.set('previousCategory', null);
     // close editing mode
     this.set('editingTopic', false);
   },
 
   finishedEdit: function() {
-    var new_val, topic;
     if (this.get('editingTopic')) {
-      topic = this.get('topic');
-      new_val = $('#edit-title').val();
-      topic.set('title', new_val);
-      topic.set('fancy_title', new_val);
+      var topic = this.get('topic');
+      // retrieve the title from the text field
+      var newTitle = $('#edit-title').val();
+      // retrieve the category from the combox box
+      var newCategoryName = $('#topic-title select option:selected').val();
+      // manually update the titles & category
+      topic.setProperties({
+        title: newTitle,
+        fancy_title: newTitle,
+        categoryName: newCategoryName
+      });
+      // save the modifications
       topic.save();
-      // clear the previous category
-      this.set('previousCategory', null);
       // close editing mode
       this.set('editingTopic', false);
     }
@@ -370,8 +371,6 @@ Discourse.TopicView = Discourse.View.extend(Discourse.Scrolling, {
 
   editTopic: function() {
     if (!this.get('topic.can_edit')) return false;
-    // save the category so we can get it back when cancelling the edit
-    this.set('previousCategory', this.get('controller.content.category'));
     // enable editing mode
     this.set('editingTopic', true);
     return false;


### PR DESCRIPTION
Meta: [Editing a topic title and canceling the edit](http://meta.discourse.org/t/editing-a-topic-title-and-canceling-the-edit/4722/)
- [x] updated the `ComboboxViewCategory` so that it uses a `oneWay` binding for the category name preventing direct update.
- [x] removed the patch done in #450 as it is no longer needed
