### PR TITLE
provide a better title on topic pages for crawlers

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title><%=t :title%></title>
+    <title><%= content_for?(:title) ? yield(:title) + ' - ' + t(:title) : t(:title) %></title>
     <meta content="width=device-width, initial-scale=1.0" name="viewport">
     <meta content="" name="description">
     <meta content="" name="author">

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -28,3 +28,5 @@
                           description: @topic_view.summary,
                           image: @topic_view.image_url) %>
 <% end %>
+
+<% content_for(:title) { @topic_view.title } %>


### PR DESCRIPTION
Meta: [Will posts show up on Google](http://meta.discourse.org/t/will-posts-show-up-on-google/1184/10)
- [x] allows any view to provide a custom title
- [x] if a title is provided, the name of the site will be appended at the end (like it's done on StackOverflow)
- [x] set the topic title as the title of the topic page for better SEO
