### PR TITLE
consistent behavior of the composer's create button

### DIFF
--- a/app/assets/javascripts/discourse/templates/composer.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/composer.js.handlebars
@@ -28,9 +28,9 @@
           {{#if content.editTitle}}
             <div class='form-element clearfix'>
                 {{#if content.creatingPrivateMessage}}
-                  {{view Discourse.TextField id="private-message-users" class="span8" placeholderKey="composer.users_placeholder"}}
+                  {{view Discourse.TextField id="private-message-users" class="span8" placeholderKey="composer.users_placeholder" tabindex="1"}}
                 {{/if}}
-                {{view Discourse.TextField valueBinding="content.title" tabindex="1" id="reply-title" maxlength="255" class="span8" placeholderKey="composer.title_placeholder"}}
+                {{view Discourse.TextField valueBinding="content.title" tabindex="2" id="reply-title" maxlength="255" class="span8" placeholderKey="composer.title_placeholder"}}
                 {{#unless content.creatingPrivateMessage}}
                   {{view Discourse.ComboboxViewCategory valueAttribute="name" contentBinding="Discourse.site.categories" valueBinding="content.categoryName"}}
                   {{#if content.archetype.hasOptions}}
@@ -43,7 +43,7 @@
           <div class='wmd-controls'>
             <div class='textarea-wrapper'>
               <div class='wmd-button-bar' id='wmd-button-bar'></div>
-              {{view Discourse.NotifyingTextArea parentBinding="view" tabindex="2" valueBinding="content.reply" id="wmd-input" placeholderKey="composer.reply_placeholder"}}
+              {{view Discourse.NotifyingTextArea parentBinding="view" tabindex="3" valueBinding="content.reply" id="wmd-input" placeholderKey="composer.reply_placeholder"}}
             </div>
             <div class='preview-wrapper'>
               <div id='wmd-preview' {{bindAttr class="controller.hidePreview:hidden"}}></div>
@@ -56,7 +56,7 @@
 
           {{#if Discourse.currentUser}}
             <div class='submit-panel'>
-              <button {{action save target="controller"}} tabindex="3" {{bindAttr disabled="content.cantSubmitPost"}} class='btn btn-primary create'>{{view.content.saveText}}</button>
+              <button {{action save target="controller"}} tabindex="4" {{bindAttr disabled="content.cantSubmitPost"}} class='btn btn-primary create'>{{view.content.saveText}}</button>
               <a href='#' {{action cancel target="controller"}} class='cancel' tabindex="4">{{i18n cancel}}</a>
               {{#if view.loadingImage}}
                 <div id="image-uploading">

--- a/app/assets/javascripts/discourse/templates/topic.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/topic.js.handlebars
@@ -9,7 +9,7 @@
             <a {{bindAttr class=":star view.topic.starred:starred"}} {{action toggleStar target="controller"}} href='#' title="{{i18n favorite.help}}"></a>
           {{/if}}
           {{#if view.editingTopic}}
-            <input id='edit-title' type='text' {{bindAttr value="view.topic.title"}}>
+            <input id='edit-title' type='text' {{bindAttr value="view.topic.title"}} autofocus>
             {{view Discourse.ComboboxViewCategory valueAttribute="name" contentBinding="Discourse.site.categories" sourceBinding="view.topic.categoryName"}}
             <button class='btn btn-primary btn-small' {{action finishedEdit target="view"}}><i class='icon-ok'></i></button>
             <button class='btn btn-small' {{action cancelEdit target="view"}}><i class='icon-remove'></i></button>


### PR DESCRIPTION
This pull request keep the create button disabled until all required information are met. 
- [x] updated the `cantSubmitPost` property so that
  - it checks for title when one is mandatory (ie. when creating a new topic, when editing the 1st post and when creating a private message)
  - it checks for at least one user when creating a private message
- [x] removed the test on the title's length when **saving** the draft. I think this should not prevent the draft to be saved. After all, isn't the body the most important part?
- [x] updated the `tabindexes` on the composer view so that it works better when creating a private message
- [x] autofocus the title textfield when editing a topic title using the pencil on the top of the page
