### PR TITLE
 added a hook to discourse plugin allowing plugins to register a new nav item 

### DIFF
--- a/app/assets/javascripts/discourse/models/nav_item.js
+++ b/app/assets/javascripts/discourse/models/nav_item.js
@@ -7,7 +7,7 @@
   @module Discourse
 **/
 var validAnon, validNavNames;
-validNavNames = ['read', 'popular', 'categories', 'favorited', 'category', 'unread', 'new', 'posted'];
+validNavNames = ["read", "popular", "categories", "favorited", "category", "unread", "new", "posted"];
 validAnon = ['popular', 'category', 'categories'];
 
 Discourse.NavItem = Discourse.Model.extend({

--- a/spec/components/discourse_plugin_registry_spec.rb
+++ b/spec/components/discourse_plugin_registry_spec.rb
@@ -61,4 +61,23 @@ describe DiscoursePluginRegistry do
     end
   end
 
+  context '.register_nav_item' do
+    before do
+      registry.register_nav_item('Click Here!')
+    end
+
+    it 'is returned by DiscoursePluginRegistry.valid_nav_items' do
+      registry.valid_nav_items.include?('Click Here!').should be_true
+    end
+    
+    it 'wont add the same nav item twice' do
+      lambda { registry.register_nav_item('Click Here!') }.should_not change(registry.valid_nav_items, :size)
+    end
+    
+    after do
+      registry.register_nav_item('resetting', true)
+    end
+    
+  end
+
 end

--- a/vendor/gems/discourse_plugin/lib/discourse_plugin/discourse_plugin.rb
+++ b/vendor/gems/discourse_plugin/lib/discourse_plugin/discourse_plugin.rb
@@ -46,6 +46,10 @@ class DiscoursePlugin
     return unless self.respond_to?(event_name)
     DiscourseEvent.on(event_name, &self.method(event_name))
   end
+  
+  def register_nav_item(nav_item_name)
+    @registry.register_nav_item
+  end
 
 end
 


### PR DESCRIPTION
via register_nav_item method.

This was a bit ambitious for me, but I think it's an important feature for extensibility.

Mistakenly touched nav_item.js, but I left in the PR to illustrate that I'm a bit wary of tests that write to source code. Is there a better way to test this?
