### PR TITLE
FIX: post removal message is in portuguese

### DIFF
--- a/config/locales/client.id.yml
+++ b/config/locales/client.id.yml
@@ -1,7 +1,7 @@
 # This file contains content for the client portion of Discourse, sent out
 # to the Javascript app.
 
-en:
+id:
   js:
     share:
       topic: "Bagikan tautan ke topik ini"

--- a/config/locales/client.pt.yml
+++ b/config/locales/client.pt.yml
@@ -1,7 +1,7 @@
 # This file contains content for the client portion of Discourse, sent out
 # to the Javascript app.
 
-en:
+pt:
   js:
     share:
       topic: 'partilhe um link para este tópico'


### PR DESCRIPTION
Meta: [Post Removal Notices (Not|Too) Localised](http://meta.discourse.org/t/post-removal-notices-not-too-localised/4865)

Some locales files were overwriting the en locale.

I've been thinking about adding a test that would check that the name of every files in the `config/locales` folder actually matches the locale they are defining. Would that be helpful or just a waste of time?
