### PR TITLE
Logging in with username and password does not work when using prefix URLs

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -65,4 +65,8 @@ module ApplicationHelper
   def privacy_path
     return "#{Discourse::base_uri}/privacy"
   end
+
+  def login_path
+    return "#{Discourse::base_uri}/login"
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,7 +22,7 @@
 
   <body>
     <% unless current_user %>
-      <form id='hidden-login-form' method="post" action="/login" style="display: none;">
+      <form id='hidden-login-form' method="post" action="<%=login_path%>" style="display: none;">
         <input name="username" type="text"     id="signin_username">
         <input name="password" type="password" id="signin_password">
         <input name="redirect" type="hidden">


### PR DESCRIPTION
Logging in with username and password does not work when using prefix URLs because the login form has /login hardcoded.

Here is a fix.
