### PR TITLE
ensure locales are not overwritten

### DIFF
--- a/spec/integrity/i18n_spec.rb
+++ b/spec/integrity/i18n_spec.rb
@@ -21,5 +21,17 @@ describe "i18n integrity checks" do
     end
   end
 
+  it "does not overwrite another language" do
+    Dir["#{Rails.root}/config/locales/*.yml"].each do |f|
+      locale = /.*\.([^.]{2,})\.yml$/.match(f)[1] + ':'
+      IO.foreach(f) do |line|
+        next if line.start_with? "#"
+        next if line.start_with? "---"
+        next if line.strip!.blank?
+        line.should eq locale
+        break
+      end
+    end
+  end
 
 end


### PR DESCRIPTION
This adds a test that will check that the name of every files in the `config/locales` folder actually matches the locale they are defining.

Prevent another #497
