### PR TITLE
Topic and admin dashboard not retrieving data properly when using prefix

### DIFF
--- a/app/assets/javascripts/admin/models/admin_dashboard.js
+++ b/app/assets/javascripts/admin/models/admin_dashboard.js
@@ -3,7 +3,7 @@ Discourse.AdminDashboard = Discourse.Model.extend({});
 Discourse.AdminDashboard.reopenClass({
   find: function() {
     var model = Discourse.AdminDashboard.create();
-    return $.ajax("/admin/dashboard", {
+    return $.ajax(Discourse.getURL("/admin/dashboard"), {
       type: 'GET',
       dataType: 'json',
       success: function(json) {

--- a/app/assets/javascripts/discourse/models/topic.js
+++ b/app/assets/javascripts/discourse/models/topic.js
@@ -389,7 +389,7 @@ Discourse.Topic.reopenClass({
     @returns A promise that will resolve to the topics
   **/
   findSimilarTo: function(title, body) {
-    return $.ajax({url: "/topics/similar_to", data: {title: title, raw: body} }).then(function (results) {
+    return $.ajax({url: Discourse.getURL("/topics/similar_to"), data: {title: title, raw: body} }).then(function (results) {
       return results.map(function(topic) { return Discourse.Topic.create(topic) });
     });
   },


### PR DESCRIPTION
The AJAX calls do not use Discourse.getURL and fail when running discourse with a prefix.
