### PR TITLE
fix: can't click on avatars when on my profile page

### DIFF
--- a/app/assets/javascripts/discourse/components/utilities.js
+++ b/app/assets/javascripts/discourse/components/utilities.js
@@ -96,6 +96,10 @@ Discourse.Utilities = {
     return url;
   },
 
+  userUrl: function(username) {
+    return Discourse.getURL("/users/" + username);
+  },
+
   emailValid: function(email) {
    // see:  http://stackoverflow.com/questions/46155/validate-email-address-in-javascript
    var re;

--- a/app/assets/javascripts/discourse/models/user_action.js
+++ b/app/assets/javascripts/discourse/models/user_action.js
@@ -8,6 +8,10 @@
 **/
 Discourse.UserAction = Discourse.Model.extend({
 
+  userUrl: (function() {
+    return Discourse.Utilities.userUrl(this.get('username'));
+  }).property(),
+
   postUrl: (function() {
     return Discourse.Utilities.postUrl(this.get('slug'), this.get('topic_id'), this.get('post_number'));
   }).property(),

--- a/app/assets/javascripts/discourse/templates/user/stream.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/user/stream.js.handlebars
@@ -2,7 +2,7 @@
   {{#collection contentBinding="stream" itemClass="item"}}
     {{#with view.content}}
       <div class='clearfix info'>
-        <a href="{{unbound usernameUrl}}" class='avatar-link'><div class='avatar-wrapper'>{{avatar this imageSize="large" extraClasses="actor" ignoreTitle="true"}}</div></a>
+        <a href="{{unbound userUrl}}" class='avatar-link'><div class='avatar-wrapper'>{{avatar this imageSize="large" extraClasses="actor" ignoreTitle="true"}}</div></a>
         <span class='time'>{{date path="created_at" leaveAgo="true"}}</span>
         <span class="title">
           <a href="{{unbound postUrl}}">{{unbound title}}</a>
@@ -17,7 +17,7 @@
           {{/if}}
           </span>
         {{/unless}}
-        <a class='name' href="{{unbound usernameUrl}}">{{personalizedName name usernamePath="username"}}</a>
+        <a class='name' href="{{unbound userUrl}}">{{personalizedName name usernamePath="username"}}</a>
         {{#if description}}
           <span class='type'>{{unbound description}}</span>
           {{#if isPostAction}}
@@ -40,7 +40,7 @@
         <div class='child-actions'>
           <i class="icon {{unbound icon}}"></i>
         {{#each items}}
-        <a href="{{unbound usernameUrl}}" class='avatar-link'><div class='avatar-wrapper'>{{avatar this imageSize="tiny" extraClasses="actor" ignoreTitle="true"}}</div></a>
+        <a href="{{unbound userUrl}}" class='avatar-link'><div class='avatar-wrapper'>{{avatar this imageSize="tiny" extraClasses="actor" ignoreTitle="true"}}</div></a>
         {{/each}}
         </div>
       {{/each}}


### PR DESCRIPTION
Meta: [Can’t click on avatars when on my own profile page](http://meta.discourse.org/t/can-t-click-on-avatars-when-on-my-own-profile-page/4977)
- [x] added a `userUrl` utility method
- [x] added a `userUrl` property on `user_action` calling the previous method
- [x] updated the template to use this property
