### PR TITLE
.gitignore: Allow the binstubs folder generated by bundler to be ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ dump.rdb
 .sass-cache/*
 
 # Ignore bundler config
+/bin
 /.bundle
 /.vagrant
 /.vagrantfile


### PR DESCRIPTION
I believe it is now recommended to stop using "bundle exec" and instead use:

``` bash
bundle install --binstubs
export PATH="./bin:$PATH"
rspec # Look ma, no bundle exec
```

This will allow the "bin" folder to not show up in a "git status", thats all
