### PR TITLE
.gitignore: Fix typo in the word refreshing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,7 +60,7 @@ config/fog_credentials.yml
 /public/uploads
 /public/stylesheet-cache/*
 
-# Scripts used for downloading/refshing db
+# Scripts used for downloading/refreshing db
 script/download_db
 script/refresh_db
 


### PR DESCRIPTION
Fix a minor type in the .gitignore file
