### PR TITLE
translation status script

### DIFF
--- a/script/translation-status.rb
+++ b/script/translation-status.rb
@@ -1,0 +1,91 @@
+#!/usr/bin/env ruby
+# -*- encoding : utf-8 -*-
+
+require 'yaml'
+
+def to_dotted_hash(source, target = {}, namespace = nil)
+  prefix = "#{namespace}." if namespace
+  if source.kind_of?(Hash)
+    source.each do |key, value|
+      to_dotted_hash(value, target, "#{prefix}#{key}")
+    end
+  else
+    target[namespace] = source
+  end
+  target
+end
+
+def compare(a, b)
+  locale1 = /.*\.([^.]{2,})\.yml$/.match(a)[1]
+  locale2 = /.*\.([^.]{2,})\.yml$/.match(b)[1]
+
+  a = YAML.load_file("./config/locales/#{a}")[locale1]
+  b = YAML.load_file("./config/locales/#{b}")[locale2]
+  a = to_dotted_hash(a)
+  b = to_dotted_hash(b)
+
+  plus = []
+  minus = []
+  same = []
+  total = a.count
+
+  a.each do |key,value|
+    if b[key] == nil
+      minus << key
+    end
+    if a[key] == b[key]
+      same << key
+    end
+  end
+
+  b.each do |key,value|
+    if a[key] == nil
+      plus << key
+    end
+  end
+
+  return plus,minus,same,total
+end
+
+puts "Discourse Translation Status Script"
+puts "To show details about a specific locale, run as:"
+puts "    ./script/translation-status.rb locale"
+puts ""
+
+filemask = "client.*.yml"
+details = false
+if ARGV.count > 0
+  filemask = "client.#{ARGV[0]}.yml"
+  details = true
+end
+
+puts "   locale |  cli+  |  cli-  |  cli=  | cli tot|  srv+  |  srv-  |  srv=  | srv tot"
+puts "----------------------------------------------------------------------------------"
+
+Dir["./config/locales/#{filemask}"].each do |f|
+  locale = /.*\.([^.]{2,})\.yml$/.match(f)[1]
+  next if locale == "en"
+  next if !File.exists?("./config/locales/client.#{locale}.yml")
+  next if !File.exists?("./config/locales/server.#{locale}.yml")
+
+  plus1, minus1, same1, total1 = compare("client.en.yml", "client.#{locale}.yml")
+  plus2, minus2, same2, total2 = compare("server.en.yml", "server.#{locale}.yml")
+  puts "%10s %8s %8s %8s %8s %8s %8s %8s %8s" % [locale, plus1.count, minus1.count, same1.count, total1,
+                                                 plus2.count, minus2.count, same2.count, total2]
+
+  if details
+    puts ""
+    puts "Equal keys:"
+    same1.each { |k| puts "client: #{locale}.#{k}" }
+    same2.each { |k| puts "server: #{locale}.#{k}" }
+    puts ""
+    puts "Missing keys:"
+    minus1.each { |k| puts "client: #{locale}.#{k}" }
+    minus2.each { |k| puts "server: #{locale}.#{k}" }
+    puts ""
+    puts "Surplus keys:"
+    plus1.each { |k| puts "client: #{locale}.#{k}" }
+    plus2.each { |k| puts "server: #{locale}.#{k}" }
+  end
+end
+


### PR DESCRIPTION
This script calculates these statistics:

```
Discourse Translation Status Script
To show details about a specific locale, run as:
    ./script/translation-status.rb locale

   locale |  cli+  |  cli-  |  cli=  | cli tot|  srv+  |  srv-  |  srv=  | srv tot
----------------------------------------------------------------------------------
        cs        3        4       14      605        0        0       18      405
        de        7       42       22      605        4       37       11      405
        es        8       27      266      605        7       25      370      405
        fr        1        2       14      605        0        3       23      405
        nl       12      128       19      605        5       85       24      405
    pseudo        4        7        0      605        0        4        1      405
        pt       17      121       36      605        8       82       30      405
     zh_CN        8        9        8      605        6        8        2      405
     zh_TW        8        9        8      605        6        8        2      405
```

This can be useful to see which locales are completely translated and which ones are still in progress.
