### PR TITLE
mem_info.rb: Refactor the code and have it not fail on systems without /...

### DIFF
--- a/lib/mem_info.rb
+++ b/lib/mem_info.rb
@@ -1,15 +1,15 @@
 class MemInfo
-
   # Total memory in kb. Only works on systems with /proc/meminfo.
   # Returns nil if it cannot be determined.
   def mem_total
     @mem_total ||= begin
-      if s = `grep MemTotal /proc/meminfo`
-        /(\d+)/.match(s)[0].try(:to_i)
-      else
-        nil
-      end
+      $&.try(:to_i) if grepped_mem_total_output =~ /(\d)+/
     end
   end
 
+  private
+
+  def grepped_mem_total_output
+    `grep MemTotal /proc/meminfo 2>&1`
+  end
 end


### PR DESCRIPTION
...proc/meminfo

Refactored the code and made it not bomb on a Mac (the regex didn't match "" and the [0] bombed)
