### PR TITLE
prevent double work in the i18n integrity specs

### DIFF
--- a/spec/integrity/i18n_spec.rb
+++ b/spec/integrity/i18n_spec.rb
@@ -21,17 +21,21 @@ describe "i18n integrity checks" do
     end
   end
 
-  it "has valid YAML for client and server" do
-    Dir["#{Rails.root}/config/locales/*.yml"].each do |f|
+  it "has valid YAML for client" do
+    Dir["#{Rails.root}/config/locales/client.*.yml"].each do |f|
       locale = /.*\.([^.]{2,})\.yml$/.match(f)[1]
-
       client = YAML.load_file("#{Rails.root}/config/locales/client.#{locale}.yml")
       client.count.should == 1
       client[locale].should_not == nil
       client[locale].count.should == 2
       client[locale]["js"].should_not == nil
       client[locale]["admin_js"].should_not == nil
+    end
+  end
 
+  it "has valid YAML for server" do
+    Dir["#{Rails.root}/config/locales/server.*.yml"].each do |f|
+      locale = /.*\.([^.]{2,})\.yml$/.match(f)[1]
       server = YAML.load_file("#{Rails.root}/config/locales/server.#{locale}.yml")
       server.count.should == 1
       server[locale].should_not == nil


### PR DESCRIPTION
the previous specs were loading yml files twice.
