### PR TITLE
FIX: Email notification for different user being mentioned

### DIFF
--- a/lib/pretty_text.rb
+++ b/lib/pretty_text.rb
@@ -65,7 +65,7 @@ module PrettyText
   @mutex = Mutex.new
 
   def self.mention_matcher
-    /(\@[a-zA-Z0-9\-]+)/
+    Regexp.new("(\@[a-zA-Z0-9_]{#{User.username_length.begin},#{User.username_length.end}})")
   end
 
   def self.app_root

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -216,6 +216,11 @@ describe Post do
         post.raw_mentions.should == ['finn']
       end
 
+      it "handles underscore in username" do
+        post = Fabricate.build(:post, post_args.merge(raw: "@Jake @Finn @Jake_Old"))
+        post.raw_mentions.should == ['jake', 'finn', 'jake_old']
+      end
+
     end
 
     context "With a @mention limit of 1" do


### PR DESCRIPTION
Meta: [Email notification for different user being mentioned](http://meta.discourse.org/t/email-notification-for-different-user-being-mentioned/5155)

There was an issue when a user named `lee` would receive notifications that he was mentionned whereas the user `lee_dohm` actually was.
