### PR TITLE
FIX: "Quote Reply" button gets in the way

### DIFF
--- a/app/assets/javascripts/discourse/views/post_view.js
+++ b/app/assets/javascripts/discourse/views/post_view.js
@@ -29,8 +29,7 @@ Discourse.PostView = Discourse.View.extend({
   }).property('parentView'),
 
   postTypeClass: (function() {
-    if (this.get('post.post_type') === Discourse.get('site.post_types.moderator_action')) return 'moderator';
-    return 'regular';
+    return this.get('post.post_type') === Discourse.get('site.post_types.moderator_action') ? 'moderator' : 'regular';
   }).property('post.post_type'),
 
   // If the cooked content changed, add the quote controls
@@ -59,12 +58,7 @@ Discourse.PostView = Discourse.View.extend({
   },
 
   selectText: (function() {
-    if (this.get('post.selected')) {
-      return Em.String.i18n('topic.multi_select.selected', {
-        count: this.get('controller.selectedCount')
-      });
-    }
-    return Em.String.i18n('topic.multi_select.select');
+    return this.get('post.selected') ? Em.String.i18n('topic.multi_select.selected', { count: this.get('controller.selectedCount') }) : Em.String.i18n('topic.multi_select.select');
   }).property('post.selected', 'controller.selectedCount'),
 
   repliesHidden: (function() {
@@ -198,10 +192,9 @@ Discourse.PostView = Discourse.View.extend({
     var postView = this;
 
     return this.$('aside.quote').each(function(i, e) {
-      var $aside, $title;
-      $aside = $(e);
+      var $aside = $(e);
       postView.updateQuoteElements($aside, 'chevron-down');
-      $title = $('.title', $aside);
+      var $title = $('.title', $aside);
 
       // Unless it's a full quote, allow click to expand
       if (!($aside.data('full') || $title.data('has-quote-controls'))) {
@@ -261,5 +254,3 @@ Discourse.PostView = Discourse.View.extend({
     }
   }
 });
-
-

--- a/app/assets/javascripts/discourse/views/quote_button_view.js
+++ b/app/assets/javascripts/discourse/views/quote_button_view.js
@@ -16,23 +16,21 @@ Discourse.QuoteButtonView = Discourse.View.extend({
   },
 
   hasBuffer: (function() {
-    if (this.present('controller.buffer')) return 'visible';
-    return null;
+    return this.present('controller.buffer') ? 'visible' : null;
   }).property('controller.buffer'),
 
   willDestroyElement: function() {
-    $(document).unbind("mousedown.quote-button");
+    $(document).off("mousedown.quote-button");
   },
 
   didInsertElement: function() {
     // Clear quote button if they click elsewhere
     var quoteButtonView = this;
-    return $(document).bind("mousedown.quote-button", function(e) {
+    $(document).on("mousedown.quote-button", function(e) {
       if ($(e.target).hasClass('quote-button')) return;
       if ($(e.target).hasClass('create')) return;
-      quoteButtonView.controller.mouseDown(e);
       quoteButtonView.set('controller.lastSelected', quoteButtonView.get('controller.buffer'));
-      return quoteButtonView.set('controller.buffer', '');
+      quoteButtonView.set('controller.buffer', '');
     });
   },
 
@@ -42,5 +40,3 @@ Discourse.QuoteButtonView = Discourse.View.extend({
   }
 
 });
-
-

--- a/app/assets/stylesheets/application/topic.css.scss
+++ b/app/assets/stylesheets/application/topic.css.scss
@@ -240,7 +240,6 @@
     border: 5px solid rgba(0, 0, 0, 0.75);
     top: 10px;
     left: 10px;
-    z-index: 99999;
     position: absolute;
     display: none;
     @include border-radius-all(4px);


### PR DESCRIPTION
Meta:
- ["Quote Reply" gets in the way](http://meta.discourse.org/t/quote-reply-gets-in-the-way/1495)
- [Where should “quote reply” button appear?](http://meta.discourse.org/t/where-should-quote-reply-button-appear/4820/4)

This PR modifies the way the "Quote Reply" button is displayed.

It will now be displayed **near** the cursor when the user release the mouse's button. 

There are **2** selection cases:
### Forward selection

![Screenshot_25_03_13_02_15](https://f.cloud.github.com/assets/362783/296239/9f6404f4-94e9-11e2-854a-83fbae4cdff4.png)

The user starts its selection at `uccessfully` and ends at `accounts`. 
The "Quote Reply" button is displayed **centered & right under** the mouse. 
### Backward selection

![Screenshot_25_03_13_02_16](https://f.cloud.github.com/assets/362783/296240/cac89b64-94e9-11e2-8a34-d11a54914e41.png)

The user starts its selection at `play` and ends at `successfully`. 
The "Quote Reply" button is displayed **centered & right above** the mouse. 

This has been tested on Mac OS X (10.8.3) with
- [x] Chrome **25.0.1364.172**
- [x] Firefox **19.0.2**
- [x] Safari **6.0.3**

The code is based on @timdown's response to: [How can I position an element next to user text selection?](http://stackoverflow.com/questions/1589721/how-can-i-position-an-element-next-to-user-text-selection/1589912#1589912)
