### PR TITLE
add requires_restart attribute to site settings

### DIFF
--- a/app/assets/javascripts/admin/controllers/admin_site_settings_controller.js
+++ b/app/assets/javascripts/admin/controllers/admin_site_settings_controller.js
@@ -9,6 +9,7 @@
 Discourse.AdminSiteSettingsController = Ember.ArrayController.extend(Discourse.Presence, {
   filter: null,
   onlyOverridden: false,
+  restartRequired: false,
 
   /**
     The list of settings based on the current filters

--- a/app/assets/javascripts/admin/models/site_setting.js
+++ b/app/assets/javascripts/admin/models/site_setting.js
@@ -76,6 +76,7 @@ Discourse.SiteSetting = Discourse.Model.extend({
       data: { value: this.get('value') },
       type: 'PUT',
       success: function() {
+        if(!!setting.get('requires_restart')) Discourse.__container__.lookup('controller:adminSiteSettings').set('restartRequired', true);
         setting.set('originalValue', setting.get('value'));
       }
     });
@@ -91,10 +92,11 @@ Discourse.SiteSetting.reopenClass({
   **/
   findAll: function() {
     var result = Em.A();
-    $.get(Discourse.getURL("/admin/site_settings"), function(settings) {
-      return settings.each(function(s) {
+    $.get(Discourse.getURL("/admin/site_settings"), function(data) {
+      Discourse.__container__.lookup('controller:adminSiteSettings').set('restartRequired', data.restart_required);
+      data.settings.each(function(s) {
         s.originalValue = s.value;
-        return result.pushObject(Discourse.SiteSetting.create(s));
+        result.pushObject(Discourse.SiteSetting.create(s));
       });
     });
     return result;

--- a/app/assets/javascripts/admin/templates/site_settings.js.handlebars
+++ b/app/assets/javascripts/admin/templates/site_settings.js.handlebars
@@ -8,7 +8,10 @@
   <div class='search controls'>
     {{view Discourse.TextField valueBinding="controller.filter" placeholderKey="type_to_filter"}}
   </div>
-
 </div>
+
+{{#if controller.restartRequired}}
+  <div class='search controls alert alert-error'>{{i18n admin.site_settings.restart_required}}</div>
+{{/if}}
 
 {{collection contentBinding="filteredContent" classNames="form-horizontal settings" itemViewClass="Discourse.SiteSettingView"}}

--- a/app/assets/javascripts/admin/templates/site_settings/setting_bool.js.handlebars
+++ b/app/assets/javascripts/admin/templates/site_settings/setting_bool.js.handlebars
@@ -5,5 +5,8 @@
   <div class="span11">
     {{view Ember.Checkbox checkedBinding="enabled" value="true"}}
     {{unbound description}}
+    {{#if requires_restart}}
+      <div class='alert'>{{i18n admin.site_settings.requires_restart}}</div>
+    {{/if}}
   </div>
 {{/with}}

--- a/app/assets/javascripts/admin/templates/site_settings/setting_string.js.handlebars
+++ b/app/assets/javascripts/admin/templates/site_settings/setting_string.js.handlebars
@@ -5,6 +5,9 @@
   <div class="span11">
     {{view Ember.TextField valueBinding="value" classNames="input-xxlarge"}}
     <div class='desc'>{{unbound description}}</div>
+    {{#if requires_restart}}
+      <div class='alert'>{{i18n admin.site_settings.requires_restart}}</div>
+    {{/if}}
   </div>
   {{#if dirty}}
     <div class='span3'>

--- a/app/controllers/admin/site_settings_controller.rb
+++ b/app/controllers/admin/site_settings_controller.rb
@@ -1,8 +1,11 @@
 class Admin::SiteSettingsController < Admin::AdminController
 
   def index
-    @site_settings = SiteSetting.all_settings
-    render_json_dump(@site_settings.as_json)
+    settings = {
+      restart_required: Discourse.restart_required?,
+      settings: SiteSetting.all_settings,
+    }
+    render_json_dump(settings.as_json)
   end
 
   def update

--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -6,7 +6,7 @@ class SiteSetting < ActiveRecord::Base
   validates_presence_of :name
   validates_presence_of :data_type
 
-  attr_accessible :description, :name, :value, :data_type
+  attr_accessible :description, :name, :value, :data_type, :requires_restart
 
   # settings available in javascript under Discourse.SiteSettings
   client_setting(:title, "Discourse")
@@ -17,7 +17,7 @@ class SiteSetting < ActiveRecord::Base
   setting(:company_domain, 'www.example.com')
   setting(:api_key, '')
   client_setting(:traditional_markdown_linebreaks, false)
-  client_setting(:top_menu, 'popular|new|unread|favorited|categories')
+  client_setting(:top_menu, 'popular|new|unread|favorited|categories', requires_restart: true)
   client_setting(:post_menu, 'like|edit|flag|delete|share|bookmark|reply')
   client_setting(:share_links, 'twitter|facebook|google+')
   client_setting(:track_external_right_clicks, false)

--- a/config/initializers/05-site_settings.rb
+++ b/config/initializers/05-site_settings.rb
@@ -1,5 +1,7 @@
 RailsMultisite::ConnectionManagement.each_connection do
   begin
+    # clean-up the 'requires_restart' application flag
+    Discourse.application_started
     SiteSetting.refresh!
   rescue ActiveRecord::StatementInvalid
     # This will happen when migrating a new database

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -817,3 +817,5 @@ en:
         show_overriden: 'Only show overridden'
         title: 'Site Settings'
         reset: 'reset to default'
+        requires_restart: 'You need to restart Discourse for this setting to take effect'
+        restart_required: 'You have changed a setting that requires Discourse to be restarted in order to be applied'

--- a/config/locales/client.fr.yml
+++ b/config/locales/client.fr.yml
@@ -815,4 +815,6 @@ fr:
         show_overriden: 'Ne montrer que ce qui a été changé'
         title: 'Paramètres du site'
         reset: 'rétablir par défaut'
+        requires_restart: 'Vous devrez redémarrer Discourse pour que les modifications de ce paramètre prennent effet'
+        restart_required: 'Vous devrez redémarrer Discourse afin de prendre en compte vos dernières modifications'
 

--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -20,7 +20,7 @@ module Discourse
 
   def self.base_uri
     if !ActionController::Base.config.relative_url_root.blank?
-      return ActionController::Base.config.relative_url_root 
+      return ActionController::Base.config.relative_url_root
     else
       return ""
     end
@@ -65,10 +65,28 @@ module Discourse
     end
   end
 
+  def self.require_restart
+    $redis.set requires_restart_key, 1
+    true
+  end
+
+  def self.application_started
+    $redis.del requires_restart_key
+    true
+  end
+
+  def self.restart_required?
+    !!$redis.get( requires_restart_key )
+  end
 
 private
 
   def self.maintenance_mode_key
     'maintenance_mode'
   end
+
+  def self.requires_restart_key
+    'requires_restart'
+  end
+
 end

--- a/spec/models/site_setting_spec.rb
+++ b/spec/models/site_setting_spec.rb
@@ -85,7 +85,7 @@ describe SiteSetting do
     end
 
     context "when overridden" do
-      after :each do 
+      after :each do
         SiteSetting.remove_override!(:test_hello?)
       end
 
@@ -161,4 +161,21 @@ describe SiteSetting do
       SiteSetting.post_length.should == (1..2)
     end
   end
+
+  describe "requires a restart when needed" do
+
+    it "sets the require_restart flag when overriding a setting that requires a restart" do
+      Discourse.expects(:require_restart).once
+      SiteSetting.setting(:test_flag, false, requires_restart: true)
+      SiteSetting.test_flag = true
+    end
+
+    it "does not set the require_restart flag when overriding a standard setting" do
+      Discourse.expects(:require_restart).never
+      SiteSetting.setting(:test_flag, false)
+      SiteSetting.test_flag = true
+    end
+
+  end
+
 end


### PR DESCRIPTION
This is part **1** of **2** of the work needed to get #481 to work properly.
## What's new?

This adds the `requires_restart` attribute to the site settings.
You can now define a site setting as follow:

``` ruby
client_setting(:top_menu, 'popular|new|unread|favorited|categories', requires_restart: true)
```

This will display a warning message below the site setting:
![Screenshot_27_03_13_00_35](https://f.cloud.github.com/assets/362783/306105/54347b54-966e-11e2-941e-bbafa6e8fecf.png)

When saved, a message will be displayed warning the administrator he has to restart Discourse for the setting to take effect:
![Screenshot_27_03_13_00_36](https://f.cloud.github.com/assets/362783/306118/a37b9828-966e-11e2-937d-b9edfb3dfc6d.png)

The message will **only** disappear if the application is restarted.
## How is it done?
### Special Application Flag

First, we need a special application flag that is triggered if you change certain settings and is communicated to all the processes, saying a restart is required for some settings to take effect.

My first idea was to use a file but I was having two concerns: performance and multi-sites requirement. So I decided to use **Redis** and implemented the `require_restart` flag in the `lib/discourse.rb` file.

I made sure the flag is removed when the application is started by calling the `Discourse.application_started` method in the `site_setting` initializer.
### The `requires_restart` attribute

I then proceeded to add the `requires_restart` attribute to the `site_setting` model. Most of the changes went into the `lib/site_setting_extension.rb` module. They're pretty straigtforward except one thing: I made sure that the `requires_restart` attributes is **only** serialized when its value is `true`, hence reducing the data to be transmitted to the client (in the `all_settings` method).

I also modified both `add_override!` and the _only-used-in-test_ `remove_override!` methods so that they set the application-wise `require_restart` flag.
### The client-side

In order to inform the administrator, I had to convey the information to the JS application.

I updated both `setting_bool` and `setting_string` templates to display the warning message when the setting requires a restart _(side-note: they should probably be refactored someday)_

I modified the `index` method of the `admin/site_settings_controller.rb` to include the previously defined flag alongside the site settings.

I added the `restartRequired` property to the `AdminSiteSettingsController` and updated both the `findAll` and `save` methods of the `site_setting` emberjs model to make sure it is kept up to date on the client-side.

**Note:** this line feels hacky _ish_, but I don't know other way to get a controller's instance.

``` javascript
Discourse.__container__.lookup('controller:adminSiteSettings').set('restartRequired', data.restart_required);
```

Finally, I added the warning message to be displayed at the top of the site setting template whenever a restart is required.
