### PR TITLE
Fix URL for composer /education paths when using prefix for Discourse

### DIFF
--- a/app/assets/javascripts/discourse/controllers/composer_controller.js
+++ b/app/assets/javascripts/discourse/controllers/composer_controller.js
@@ -132,7 +132,7 @@ Discourse.ComposerController = Discourse.Controller.extend({
     // If visible update the text
     var educationKey = this.get('content.creatingTopic') ? 'new-topic' : 'new-reply';
     var composerController = this;
-    $.get("/education/" + educationKey).then(function(result) {
+    $.get(Discourse.getURL("/education/") + educationKey).then(function(result) {
       composerController.set('educationContents', result);
     });
   }.observes('typedReply', 'content.creatingTopic', 'Discourse.currentUser.reply_count'),


### PR DESCRIPTION
Fix URL for composer /education paths when using prefix for Discourse
