### PR TITLE
Don't call to_sym on param

### DIFF
--- a/app/controllers/education_controller.rb
+++ b/app/controllers/education_controller.rb
@@ -4,7 +4,7 @@ class EducationController < ApplicationController
 
   def show
     raise Discourse::InvalidAccess.new unless params[:id] =~ /^[a-z0-9\-\_]+$/
-    raise Discourse::NotFound.new unless I18n.t(:education).include?(params[:id].to_sym)
+    raise Discourse::NotFound.new if I18n.t("education.#{params[:id]}", default: MISSING_KEY) == MISSING_KEY
 
     education_posts_text = I18n.t('education.until_posts', count: SiteSetting.educate_until_posts)
 
@@ -13,5 +13,8 @@ class EducationController < ApplicationController
                                        education_posts_text: education_posts_text)
     render text: PrettyText.cook(markdown_content)
   end
+
+  private
+  MISSING_KEY = '_MISSING_KEY_'.freeze
 
 end


### PR DESCRIPTION
Calling to_sym on user input is dangerous because symbols aren't garbage-collected.
