### PR TITLE
Add admin title to trophy tooltip in admin users list

### DIFF
--- a/app/assets/javascripts/admin/templates/users_list.js.handlebars
+++ b/app/assets/javascripts/admin/templates/users_list.js.handlebars
@@ -72,7 +72,7 @@
           {{/if}}
         </td>
         {{/if}}
-        <td>{{#if admin}}<i class="icon-trophy"></i>{{/if}}<td>
+        <td>{{#if admin}}<i class="icon-trophy" title="{{i18n admin.title}}"></i>{{/if}}<td>
       </tr>
     {{/each}}
 


### PR DESCRIPTION
I had to look into the source to confirm that the trophy meant admin, so this should save others some time.
