### PR TITLE
Get the "quote reply" button working on iOS

### DIFF
--- a/app/assets/javascripts/discourse/views/post_view.js
+++ b/app/assets/javascripts/discourse/views/post_view.js
@@ -49,10 +49,11 @@ Discourse.PostView = Discourse.View.extend({
       this.toggleProperty('post.selected');
     }
 
+    if (!Discourse.get('currentUser.enable_quoting')) return;
     if ($(e.target).closest('.cooked').length === 0) return;
 
     var qbc = this.get('controller.controllers.quoteButton');
-    if (qbc && Discourse.get('currentUser.enable_quoting')) {
+    if (qbc) {
       e.context = this.get('post');
       qbc.selectText(e);
     }
@@ -259,6 +260,29 @@ Discourse.PostView = Discourse.View.extend({
     if (controller && controller.postRendered) {
       controller.postRendered(post);
     }
+
+    // make the selection work under iOS
+    // "selectionchange" event is only supported in IE, Safari & Chrome
+    var postView = this;
+    $(document).on('selectionchange', function(e) {
+      // quoting as been disabled by the user
+      if (!Discourse.get('currentUser.enable_quoting')) return;
+      // find out whether we currently are selecting inside a post
+      var closestPosts = $(window.getSelection().anchorNode).closest('.topic-post');
+      if (closestPosts.length === 0) return;
+      // this event is bound for every posts in the topic, but is triggered on "document"
+      // we should therefore filter the event to only the right post
+      if (closestPosts[0].id !== postView.elementId) return;
+      var qbc = postView.get('controller.controllers.quoteButton');
+      if (qbc) {
+        e.context = postView.get('post');
+        qbc.selectText(e);
+      }
+    });
+  },
+
+  willDestroyElement: function() {
+    $(document).off('selectionchange');
   }
 });
 

--- a/app/assets/stylesheets/application/topic-post.css.scss
+++ b/app/assets/stylesheets/application/topic-post.css.scss
@@ -89,6 +89,11 @@
   pre code {
     max-height: 690px;
   }
+  .post-menu-area {
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+  }
   @include hover {
     .gutter {
       .reply-new,
@@ -387,6 +392,9 @@
     @include hover {
       background-color: mix($gray, $light_gray, 5%);
     }
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
   }
   .embedded-posts.bottom {
     @include border-radius-bottom(4px);


### PR DESCRIPTION
First attempt at getting the quote reply button to work on iOS.

This uses the `selectionchange` event that is triggered whenever the selection is changed.
This event is **only** available in IE, Chrome & Safari.

![Screenshot_29_03_13_16_47](https://f.cloud.github.com/assets/362783/319747/ad70c7a2-98dc-11e2-98b5-ac743e0404b6.png)

There are some **quirks** tough: for example, when the selection is short, the native `Cut/Copy/Paste` dialog will overlap with the button.

This requires #561 to work properly. If you test it now, the button will appear at `{0; 0}`, ie. at the top left of the page.

One good thing is that it solve the issue that the selected text would not be the one quoted when you first select some text with the mouse **and** then adjust your selection with the keyboard.
