### PR TITLE
make sure Category.topic_count is consistent with week/year stats

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -61,11 +61,13 @@ class Category < ActiveRecord::Base
                .where("categories.topic_id <> topics.id")
                .visible
 
+    topic_count = topics.to_sql
     topics_year = topics.created_since(1.year.ago).to_sql
     topics_month = topics.created_since(1.month.ago).to_sql
     topics_week = topics.created_since(1.week.ago).to_sql
 
-    Category.update_all("topics_year = (#{topics_year}),
+    Category.update_all("topic_count = (#{topic_count}),
+                         topics_year = (#{topics_year}),
                          topics_month = (#{topics_month}),
                          topics_week = (#{topics_week})")
   end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -177,6 +177,10 @@ describe Category do
       it 'updates topics_year' do
         @category.topics_year.should == 1
       end
+
+      it 'updates topic_count' do
+        @category.topic_count.should == 1
+      end
     end
 
     context 'with deleted topics' do
@@ -197,6 +201,10 @@ describe Category do
 
       it 'does not count deleted topics for topics_year' do
         @category.topics_year.should == 0
+      end
+
+      it 'does not count deleted topics for topic_count' do
+        @category.topic_count.should == 0
       end
     end
   end


### PR DESCRIPTION
Trying to fix the issue described here: http://meta.discourse.org/t/topic-counts-in-categories/4838

Basically, this patch simply updates `topic_count` the same way that `topics_year`, `topics_week` get calculated.
