### PR TITLE
split i18n strings where there are 2 pluralizable variables

### DIFF
--- a/app/assets/javascripts/discourse/controllers/topic_controller.js
+++ b/app/assets/javascripts/discourse/controllers/topic_controller.js
@@ -165,13 +165,13 @@ Discourse.TopicController = Discourse.ObjectController.extend({
 
     if (postFilters.bestOf) {
       this.set('filterDesc', Em.String.i18n("topic.filters.best_of", {
-        filtered_posts_count: this.get('filtered_posts_count'),
-        posts_count: this.get('posts_count')
+        n_best_posts: Em.String.i18n("topic.filters.n_best_posts", { count: this.get('filtered_posts_count') }),
+        of_n_posts: Em.String.i18n("topic.filters.of_n_posts", { count: this.get('posts_count') })
       }));
     } else if (postFilters.userFilters.length > 0) {
       this.set('filterDesc', Em.String.i18n("topic.filters.user", {
-        filtered_posts_count: this.get('filtered_posts_count'),
-        count: postFilters.userFilters.length
+        n_posts: Em.String.i18n("topic.filters.n_posts", { count: this.get('filtered_posts_count') }),
+        by_n_users: Em.String.i18n("topic.filters.by_n_users", { count: postFilters.userFilters.length })
       }));
     } else {
       // Hide the bottom bar

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -505,10 +505,21 @@ en:
       login_reply: 'Log In to Reply'
 
       filters:
-        user:
-          one: "You're viewing only {{filtered_posts_count}} posts by a specific user."
-          other: "You're viewing only {{filtered_posts_count}} posts made by {{count}} specific users."
-        best_of: "You're viewing the {{filtered_posts_count}} best posts of {{posts_count}} in the topic."
+        user: "You're viewing only {{n_posts}} {{by_n_users}}."
+        n_posts:
+          one: "1 post"
+          other: "{{count}} posts"
+        by_n_users:
+          one: "made by 1 specific user"
+          other: "made by {{count}} specific users"
+
+        best_of: "You're viewing the {{n_best_posts}} {{of_n_posts}}."
+        n_best_posts:
+          one: "1 best post"
+          other: "{{count}} best posts"
+        of_n_posts:
+          one: "of 1 in the topic"
+          other: "of {{count}} in the topic"
         cancel: "Show all posts in this topic again."
 
       move_selected:


### PR DESCRIPTION
There is a problem with these pluralizable strings:

```
user:
  one: "You're viewing only {{filtered_posts_count}} posts by a specific user."
  other: "You're viewing only {{filtered_posts_count}} posts made by {{count}} specific users."
```

Obviously, it has multiple issues, but the biggest one is that it can't be properly translated into languages where you need more than 2 plural versions. In Czech, we use 3 versions (count=1, count=2..4, count>=5).
