### PR TITLE
FIX: Autocomplete, missing charcode for correct term

### DIFF
--- a/app/assets/javascripts/discourse/components/autocomplete.js
+++ b/app/assets/javascripts/discourse/components/autocomplete.js
@@ -302,7 +302,7 @@ $.fn.autocomplete = function(options) {
             return false;
           }
           term = me.val().substring(completeStart + (options.key ? 1 : 0), caretPosition);
-          if (e.which > 48 && e.which < 90) {
+          if (e.which >= 48 && e.which <= 90) {
             term += String.fromCharCode(e.which);
           } else {
             if (e.which !== 8) {


### PR DESCRIPTION
Current code ignores char '0' and 'z'.
