### PR TITLE
improved images upload on the client side

### DIFF
--- a/app/assets/javascripts/discourse/templates/composer.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/composer.js.handlebars
@@ -51,6 +51,11 @@
             {{#if Discourse.currentUser}}
                <a href="#" {{action togglePreview target="controller"}} class='toggle-preview'>{{{content.toggleText}}}</a>
                <div class='saving-draft'></div>
+               {{#if view.loadingImage}}
+                <div id="image-uploading">
+                  {{i18n image_selector.uploading_image}} {{view.uploadProgress}}% <a {{action cancelUpload target="view"}}>{{i18n cancel}}</a>
+                </div>
+              {{/if}}
             {{/if}}
           </div>
 
@@ -58,11 +63,6 @@
             <div class='submit-panel'>
               <button {{action save target="controller"}} tabindex="4" {{bindAttr disabled="content.cantSubmitPost"}} class='btn btn-primary create'>{{view.content.saveText}}</button>
               <a href='#' {{action cancel target="controller"}} class='cancel' tabindex="4">{{i18n cancel}}</a>
-              {{#if view.loadingImage}}
-                <div id="image-uploading">
-                  {{i18n image_selector.uploading_image}} {{view.uploadProgress}}% <a {{action cancelUpload target="view"}}>{{i18n cancel}}</a>
-                </div>
-              {{/if}}
             </div>
           {{/if}}
 

--- a/app/assets/stylesheets/application/compose.css.scss
+++ b/app/assets/stylesheets/application/compose.css.scss
@@ -55,7 +55,7 @@
 }
 
 #reply-control {
-  .toggle-preview, .saving-draft {
+  .toggle-preview, .saving-draft, #image-uploading {
     position: absolute;
     bottom: -31px;
     margin-top: 0px;
@@ -63,6 +63,11 @@
   .toggle-preview {
     right: 5px;
     text-decoration: underline;
+  }
+  #image-uploading {
+    left: 51%;
+    font-size: 12px;
+    color: darken($gray, 40);
   }
   .saving-draft {
     right: 51%;
@@ -250,6 +255,10 @@
       img {
         // Otherwise we get the wrong size in JS
         max-width: none;
+        border-radius: 4px;
+        moz-border-radius: 4px;
+        webkit-border-radius: 4px;
+        ms-border-radius: 4px;
       }
     }
     #wmd-preview {
@@ -271,12 +280,6 @@
       position: absolute;
       display: block;
       bottom: 8px;
-      #image-uploading {
-        display: inline-block;
-        margin-left: 330px;
-        font-size: 12px;
-        color: darken($gray, 40);
-      }
     }
   }
 }

--- a/app/assets/stylesheets/application/topic-post.css.scss
+++ b/app/assets/stylesheets/application/topic-post.css.scss
@@ -526,6 +526,10 @@
     }
     img {
       max-width: 100%;
+      border-radius: 4px;
+      webkit-border-radius: 4px;
+      ms-border-radius: 4px;
+      moz-border-radius: 4px;
     }
     .topic-body {
       position: relative;

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -550,6 +550,7 @@ en:
         edit: "Sorry, there was an error editing your post. Please try again."
         upload: "Sorry, there was an error uploading that file. Please try again."
         upload_too_large: "Sorry, the file you are trying to upload is too big (maximum size is {{max_size_kb}}kb), please resize it and try again."
+        upload_too_many_images: "Sorry, but you can only upload one image at a time."
 
       abandon: "Are you sure you want to abandon your post?"
 

--- a/config/locales/client.fr.yml
+++ b/config/locales/client.fr.yml
@@ -552,6 +552,7 @@ fr:
         edit: "Désolé, il y a eu une erreur lors de l'édition de votre message. Merci de réessayer."
         upload: "Désolé, il y a eu une erreur lors de l'envoi du fichier. Merci de réessayer."
         upload_too_large: "Désolé, le fichier que vous êtes en train d'envoyer est trop grand (maximum {{max_size_kb}}Kb). Merci de le redimensionner et de réessayer."
+        upload_too_many_images: "Désolé, mais vous ne pouvez envoyer qu'une seule image à la fois."
 
       abandon: "Voulez-vous vraiment abandonner ce message ?"
 


### PR DESCRIPTION
This is the first part of some work regarding the handling of **images** in Discourse. 
This PR concerns only the client side aspect of it:
- [x] images are displayed using a rounded corner to match style (both in topic view and in the composer)
- [x] refactor fileuploader events bindings so they don't bind globally
- [x] check image size on client-side when pasting or droping an image (instead of waiting for the server)
- [x] display an error message when trying to upload several images at once
- [x] changed uploading message position (it was overlapping with the draft status)
#### Rounded corners

![Screenshot_01_04_13_03_00 2](https://f.cloud.github.com/assets/362783/322675/5be2cf5e-9a6a-11e2-9b62-b4db4728c6f5.png)
#### Uploading message's new position

![Screenshot_01_04_13_02_59](https://f.cloud.github.com/assets/362783/322676/5be957fc-9a6a-11e2-8f82-6daeb3be4e36.png)
