### PR TITLE
Topic progress does change its X coordinate when switching between static and float views

### DIFF
--- a/app/assets/stylesheets/application/topic.css.scss
+++ b/app/assets/stylesheets/application/topic.css.scss
@@ -362,6 +362,7 @@ kbd {
 #topic-progress-wrapper.docked {
   #topic-progress {
     border-bottom: 1px solid $gray;
+    margin-left: 6px;
   }
   position: absolute;
 }


### PR DESCRIPTION
This patch fixes an issue with the topic progress indicator when it is in its docked position.

When the indicator is in the docked position it becomes positioned relative to the posts wrapper, as opposed to its undocked state when it is positioned relative to the viewport. The posts wrapper is not centred relative to the viewport, so the horizontal position of the topic indicator will differ when it is positioned absolutely relative to it.

I have added a margin to the topic progress indicator to offset the amount that the posts wrapper is off-centre by (a negative margin property on Twitter Bootstrap rows).

Tested on:
- [x] Firefox 19.0.2
- [x] Chrome 26.0.1410.43
- [x] Safari 6.0.3
- [x] Internet Explorer 10.0.9200
- [x] iOS Simulator (iPad) iOS 6.1
