### PR TITLE
remove useless console.log

### DIFF
--- a/app/assets/javascripts/discourse/models/composer.js
+++ b/app/assets/javascripts/discourse/models/composer.js
@@ -248,7 +248,6 @@ Discourse.Composer = Discourse.Model.extend({
     if (opts.postId) {
       this.set('loading', true);
       Discourse.Post.load(opts.postId).then(function(result) {
-        console.log(result);
         composer.set('post', result);
         composer.set('loading', false);
       });

--- a/app/assets/javascripts/discourse/views/composer_view.js
+++ b/app/assets/javascripts/discourse/views/composer_view.js
@@ -281,7 +281,6 @@ Discourse.ComposerView = Discourse.View.extend({
     });
 
     var addImages = function (e, data) {
-      console.log('addImages');
       // can only upload one image at a time
       if (data.files.length > 1) {
         bootbox.alert(Em.String.i18n('post.errors.upload_too_many_images'));
@@ -336,8 +335,7 @@ Discourse.ComposerView = Discourse.View.extend({
     // I hate to use Em.run.later, but I don't think there's a way of waiting for a CSS transition
     // to finish.
     return Em.run.later(jQuery, (function() {
-      var replyTitle;
-      replyTitle = $('#reply-title');
+      var replyTitle = $('#reply-title');
       _this.resize();
       if (replyTitle.length) {
         return replyTitle.putCursorAtEnd();


### PR DESCRIPTION
This removes a `console.log` I left in #606 and another one in `composer.js` :blush: 
