### PR TITLE
users can now cancel image upload

### DIFF
--- a/app/assets/javascripts/discourse/models/composer.js
+++ b/app/assets/javascripts/discourse/models/composer.js
@@ -248,7 +248,6 @@ Discourse.Composer = Discourse.Model.extend({
     if (opts.postId) {
       this.set('loading', true);
       Discourse.Post.load(opts.postId).then(function(result) {
-        console.log(result);
         composer.set('post', result);
         composer.set('loading', false);
       });

--- a/app/assets/javascripts/discourse/templates/composer.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/composer.js.handlebars
@@ -53,7 +53,7 @@
                <div class='saving-draft'></div>
                {{#if view.loadingImage}}
                 <div id="image-uploading">
-                  {{i18n image_selector.uploading_image}} {{view.uploadProgress}}% <a {{action cancelUpload target="view"}}>{{i18n cancel}}</a>
+                  {{i18n image_selector.uploading_image}} {{view.uploadProgress}}% <a id="cancel-image-upload">{{i18n cancel}}</a>
                 </div>
               {{/if}}
             {{/if}}


### PR DESCRIPTION
This allows users to cancel their image uploads.

**Note:** It does not show any confirmation dialog before cancelling the upload as this is quite complicated to handle correctly in an asynchronous environment.
