### PR TITLE
New setting site_requires_login

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -3,7 +3,11 @@ require_dependency 'search'
 class SearchController < ApplicationController
 
   def query
-    search_result = Search.query(params[:term], params[:type_filter], SiteSetting.min_search_term_length)
+    search_result = if guardian.can_search?
+      Search.query(params[:term], params[:type_filter], SiteSetting.min_search_term_length)
+    else
+      []
+    end
     render_json_dump(search_result.as_json)
   end
 

--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -136,6 +136,8 @@ class SiteSetting < ActiveRecord::Base
 
   client_setting(:enable_persona_logins, false)
 
+  setting(:site_requires_login, false)
+
   setting(:enforce_global_nicknames, true)
   setting(:discourse_org_access_key, '')
   setting(:enable_s3_uploads, false)

--- a/app/models/topic_list.rb
+++ b/app/models/topic_list.rb
@@ -8,10 +8,12 @@ class TopicList
   def initialize(current_user, topics)
     @current_user = current_user
     @topics_input = topics
+    @guardian = Guardian.new(@current_user)
   end
 
   # Lazy initialization
   def topics
+    return [] unless @guardian.can_see_topics?
     return @topics if @topics.present?
 
     @topics = @topics_input.to_a

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -382,6 +382,8 @@ en:
 
     invite_expiry_days: "How long user invitation keys are valid, in days"
 
+    site_requires_login: "Hide all topics and categories from users who are not logged in"
+
     # TODO: perhaps we need a way of protecting these settings for hosted solution, global settings ...
 
     enable_google_logins: "Enable Google authentication"

--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -197,6 +197,10 @@ class Guardian
     true
   end
 
+  def can_search?
+    !(@user.blank? && SiteSetting.site_requires_login?)
+  end
+
   # Support for ensure_{blah}! methods.
   def method_missing(method, *args, &block)
     if method.to_s =~ /^ensure_(.*)\!$/
@@ -315,7 +319,20 @@ class Guardian
       return true if topic.allowed_users.include?(@user)
       return is_admin?
     end
-    true
+
+    can_see_topics?
+  end
+
+  def can_see_topics?
+    !(@user.blank? && SiteSetting.site_requires_login?)
+  end
+
+  def can_see_categories?
+    !(@user.blank? && SiteSetting.site_requires_login?)
+  end
+
+  def can_see_category?(_category)
+    can_see_categories?
   end
 
   def can_vote?(post, opts={})

--- a/spec/components/category_list_spec.rb
+++ b/spec/components/category_list_spec.rb
@@ -20,6 +20,14 @@ describe CategoryList do
         category.should be_present
       end
 
+      context "when the user cannot see categories" do
+        before { Guardian.any_instance.stubs(:can_see_categories?).returns(false) }
+
+        it "returns an empty list of categories" do
+          category_list.categories.should be_empty
+        end
+      end
+
       it "has the uncategorized label" do
         category.name.should == SiteSetting.uncategorized_name
       end
@@ -73,6 +81,14 @@ describe CategoryList do
 
       it "should contain our topic" do
         category.featured_topics.include?(topic).should be_true
+      end
+
+      context "when the user cannot see categories" do
+        before { Guardian.any_instance.stubs(:can_see_categories?).returns(false) }
+
+        it "returns an empty list of categories" do
+          category_list.categories.should be_empty
+        end
       end
     end
 

--- a/spec/components/guardian_spec.rb
+++ b/spec/components/guardian_spec.rb
@@ -240,9 +240,83 @@ describe Guardian do
       Guardian.new.can_see?(nil).should be_false
     end
 
-    describe 'a Topic' do
-      it 'allows non logged in users to view topics' do
-        Guardian.new.can_see?(topic).should be_true
+    describe 'Categories' do
+      let(:category) { Fabricate(:category) }
+
+      describe 'when site requires login' do
+        before { SiteSetting.stubs(:site_requires_login?).returns(true) }
+
+        describe 'when not logged in' do
+          let(:guardian) { Guardian.new }
+
+          it 'returns false for a specific category' do
+            guardian.can_see?(category).should be_false
+          end
+
+          it 'returns false for categories index' do
+            guardian.can_see_categories?.should be_false
+          end
+        end
+
+        describe 'when logged in' do
+          let(:guardian) { Guardian.new(user) }
+
+          it 'returns true for a specific category' do
+            guardian.can_see?(category).should be_true
+          end
+
+          it 'returns true for categories index' do
+            guardian.can_see_categories?.should be_true
+          end
+        end
+      end
+
+      describe 'when site does not require login' do
+        before { SiteSetting.stubs(:site_requires_login?).returns(false) }
+
+        it 'returns true for a specific category' do
+          Guardian.new.can_see?(category).should be_true
+          Guardian.new(user).can_see?(category).should be_true
+        end
+
+        it 'returns true for categories index' do
+          Guardian.new.can_see_categories?.should be_true
+          Guardian.new(user).can_see_categories?.should be_true
+        end
+      end
+    end
+
+    describe 'topics' do
+      describe 'when the site does not require login' do
+        before { SiteSetting.stubs(:site_requires_login?).returns(false) }
+
+        it 'allows non logged in users to view a topic' do
+          Guardian.new.can_see?(topic).should be_true
+        end
+
+        it 'allows non logged in users to view topics' do
+          Guardian.new.can_see_topics?.should be_true
+        end
+      end
+
+      describe 'when the site requires login' do
+        before { SiteSetting.stubs(:site_requires_login?).returns(true) }
+
+        it 'does not allow non logged in users to view topics' do
+          Guardian.new.can_see_topics?.should be_false
+        end
+
+        it 'does not allow non logged in users to view a topic' do
+          Guardian.new.can_see?(topic).should be_false
+        end
+
+        it 'allows logged in users to view topics' do
+          Guardian.new(user).can_see_topics?.should be_true
+        end
+
+        it 'allows logged in users to view a topic' do
+          Guardian.new(user).can_see?(topic).should be_true
+        end
       end
     end
   end
@@ -583,7 +657,27 @@ describe Guardian do
 
   end
 
+  context 'can_search?' do
+    context 'when site requires login' do
+      before { SiteSetting.stubs(:site_requires_login?).returns(true) }
 
+      it 'is false when not logged in' do
+        Guardian.new(nil).can_search?.should be_false
+      end
+
+      it 'is true when logged in' do
+        Guardian.new(user).can_search?.should be_true
+      end
+    end
+
+    context 'when site does not require login' do
+      before { SiteSetting.stubs(:site_requires_login?).returns(false) }
+
+      it 'is true' do
+        Guardian.new(nil).can_search?.should be_true
+      end
+    end
+  end
 
   context 'can_delete?' do
 

--- a/spec/components/topic_query_spec.rb
+++ b/spec/components/topic_query_spec.rb
@@ -30,6 +30,11 @@ describe TopicQuery do
       it "includes the invisible topic if you're an admin" do
         TopicQuery.new(admin).list_latest.topics.include?(invisible_topic).should be_true
       end
+
+      it "is empty when the guardian does not allow seeing topics" do
+        Guardian.any_instance.stubs(:can_see_topics?).returns(false)
+        TopicQuery.new.list_latest.topics.should be_empty
+      end
     end
 
     context 'after clearring a pinned topic' do
@@ -62,6 +67,13 @@ describe TopicQuery do
     it "returns only the topic category when filtering by another category" do
       another_category = Fabricate(:category, name: 'new cat')
       topic_query.list_category(another_category).topics.should == [another_category.topic]
+    end
+
+    it "is empty when the guardian does not allow seeing topcis" do
+      Guardian.any_instance.stubs(:can_see_topics?).returns(false)
+      topic_query = TopicQuery.new
+      topic_query.list_uncategorized.topics.should be_empty
+      topic_query.list_category(category).topics.should be_empty
     end
 
     describe '#list_new_in_category' do
@@ -253,6 +265,11 @@ describe TopicQuery do
 
       it "should return the new topic" do
         TopicQuery.new.list_suggested_for(topic).topics.should == [new_topic]
+      end
+
+      it "is empty when the guardian does not allow seeing topics" do
+        Guardian.any_instance.stubs(:can_see_topics?).returns(false)
+        TopicQuery.new.list_suggested_for(topic).topics.should be_empty
       end
     end
 

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -12,4 +12,11 @@ describe SearchController do
     xhr :get, :query, term: 'test', type_filter: 'topic'
   end
 
+  it 'is empty without querying when the guardian does not allow search' do
+    Guardian.any_instance.stubs(:can_search?).returns(false)
+    Search.expects(:query).never
+    xhr :get, :query, term: 'foo bar'
+    ActiveSupport::JSON.decode(response.body).should == []
+  end
+
 end


### PR DESCRIPTION
When enabled, this setting makes the site appear empty (no topics, no
categories) to anonymous users.  After logging in, topics and categories
become visible.

This is the same changeset as #590, all rebased into a single commit.
