### PR TITLE
prevent users from uploading files other than images

### DIFF
--- a/app/assets/javascripts/discourse/views/composer_view.js
+++ b/app/assets/javascripts/discourse/views/composer_view.js
@@ -276,35 +276,40 @@ Discourse.ComposerView = Discourse.View.extend({
         formData: { topic_id: 1234 }
     });
 
-    var addImages = function (e, data) {
-      // can only upload one image at a time
+    var addFiles = function (e, data) {
+      // can only upload one file at a time
       if (data.files.length > 1) {
         bootbox.alert(Em.String.i18n('post.errors.upload_too_many_images'));
         return false;
       } else if (data.files.length > 0) {
-        // check image size
+        // check file size
         var fileSizeInKB = data.files[0].size / 1024;
         if (fileSizeInKB > Discourse.SiteSettings.max_upload_size_kb) {
           bootbox.alert(Em.String.i18n('post.errors.upload_too_large', { max_size_kb: Discourse.SiteSettings.max_upload_size_kb }));
           return false;
-        } else {
-          // reset upload status
-          _this.setProperties({
-            uploadProgress: 0,
-            loadingImage: true
-          });
-          return true;
         }
+        // check that the uploaded file is an image
+        // TODO: we should provide support for other types of file
+        if (data.files[0].type.indexOf('image/') !== 0) {
+          bootbox.alert(Em.String.i18n('post.errors.only_images_are_supported'));
+          return false; 
+        }
+        // everything is fine, reset upload status
+        _this.setProperties({
+          uploadProgress: 0,
+          loadingImage: true
+        });
+        return true;
       }
       // we need to return true here, otherwise it prevents the default paste behavior
       return true;
     };
 
     // paste
-    $uploadTarget.on('fileuploadpaste', addImages);
+    $uploadTarget.on('fileuploadpaste', addFiles);
 
     // drop
-    $uploadTarget.on('fileuploaddrop', addImages);
+    $uploadTarget.on('fileuploaddrop', addFiles);
 
     // send
     $uploadTarget.on('fileuploadsend', function (e, data) {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -561,7 +561,8 @@ en:
         edit: "Sorry, there was an error editing your post. Please try again."
         upload: "Sorry, there was an error uploading that file. Please try again."
         upload_too_large: "Sorry, the file you are trying to upload is too big (maximum size is {{max_size_kb}}kb), please resize it and try again."
-        upload_too_many_images: "Sorry, but you can only upload one image at a time."
+        upload_too_many_images: "Sorry, you can only upload one image at a time."
+        only_images_are_supported: "Sorry, only images uploading is supported."
 
       abandon: "Are you sure you want to abandon your post?"
 

--- a/config/locales/client.fr.yml
+++ b/config/locales/client.fr.yml
@@ -565,7 +565,8 @@ fr:
         edit: "Désolé, il y a eu une erreur lors de l'édition de votre message. Merci de réessayer."
         upload: "Désolé, il y a eu une erreur lors de l'envoi du fichier. Merci de réessayer."
         upload_too_large: "Désolé, le fichier que vous êtes en train d'envoyer est trop grand (maximum {{max_size_kb}}Kb). Merci de le redimensionner et de réessayer."
-        upload_too_many_images: "Désolé, mais vous ne pouvez envoyer qu'une seule image à la fois."
+        upload_too_many_images: "Désolé, vous ne pouvez envoyer qu'une seule image à la fois."
+        only_images_are_supported: "Désolé, seulement l'envoi d'image est supporté."
 
       abandon: "Voulez-vous vraiment abandonner ce message ?"
 


### PR DESCRIPTION
This will show a message when the user tries to upload a file that is not an image.

![image](https://f.cloud.github.com/assets/362783/327556/b0ca7e94-9b79-11e2-919b-75ed9d7472b8.png)

**Note:** the test is currently _only_ done client-side.
**Note 2:** this should be updated when we'll add [other file types support](http://meta.discourse.org/t/file-upload-support/2879/2).
