### PR TITLE
update i18n:stats task to count pluralization based on locale setting

### DIFF
--- a/config/locales/plurals.rb
+++ b/config/locales/plurals.rb
@@ -109,6 +109,8 @@
   :wa => { :i18n => { :plural => { :keys => [:one, :other], :rule => lambda { |n| [0, 1].include?(n) ? :one : :other } } } },
   :yo => { :i18n => { :plural => { :keys => [:other], :rule => lambda { |n| :other } } } },
   :zh => { :i18n => { :plural => { :keys => [:other], :rule => lambda { |n| :other } } } },
+  :zh_CN => { :i18n => { :plural => { :keys => [:other], :rule => lambda { |n| :other } } } },
+  :zh_TW => { :i18n => { :plural => { :keys => [:other], :rule => lambda { |n| :other } } } },
   :zu => { :i18n => { :plural => { :keys => [:one, :other], :rule => lambda { |n| n == 1 ? :one : :other } } } }
 }
 


### PR DESCRIPTION
I modified the i18n:stats script to correctly count missing/surplus pluralizable strings. Also, I had to specifically add pluralization rules for zh_CN and zh_TW locales.
