### PR TITLE
make post actions (likes, flags) translatable as whole sentences

### DIFF
--- a/app/assets/javascripts/discourse/models/action_summary.js
+++ b/app/assets/javascripts/discourse/models/action_summary.js
@@ -10,16 +10,15 @@ Discourse.ActionSummary = Discourse.Model.extend({
 
   // Description for the action
   description: (function() {
+    var action = this.get('actionType.name_key');
     if (this.get('acted')) {
-      return Em.String.i18n('post.actions.by_you_and_others', {
-        count: this.get('count') - 1,
-        long_form: this.get('actionType.long_form')
-      });
+      if (this.get('count') <= 1) {
+        return Em.String.i18n('post.actions.by_you.' + action);
+      } else {
+        return Em.String.i18n('post.actions.by_you_and_others.' + action, { count: this.get('count') - 1 });
+      }
     } else {
-      return Em.String.i18n('post.actions.by_others', {
-        count: this.get('count'),
-        long_form: this.get('actionType.long_form')
-      });
+      return Em.String.i18n('post.actions.by_others.' + action, { count: this.get('count') });
     }
   }).property('count', 'acted', 'actionType'),
 
@@ -113,5 +112,3 @@ Discourse.ActionSummary = Discourse.Model.extend({
   }
 
 });
-
-

--- a/app/assets/javascripts/discourse/models/post_action_type.js
+++ b/app/assets/javascripts/discourse/models/post_action_type.js
@@ -8,16 +8,4 @@
 **/
 Discourse.PostActionType = Discourse.Model.extend({
 
-  alsoName: (function() {
-    if (this.get('is_flag')) return Em.String.i18n('post.actions.flag');
-    return this.get('name');
-  }).property('is_flag', 'name'),
-
-  alsoNameLower: (function() {
-    var _ref;
-    return (_ref = this.get('alsoName')) ? _ref.toLowerCase() : void 0;
-  }).property('alsoName')
-
 });
-
-

--- a/app/assets/javascripts/discourse/models/site.js
+++ b/app/assets/javascripts/discourse/models/site.js
@@ -49,7 +49,7 @@ Discourse.Site.reopenClass({
         result.postActionByIdLookup = Em.Object.create();
         result.post_action_types = result.post_action_types.map(function(p) {
           var actionType;
-          actionType = Discourse.PostActionType.create(p);
+          actionType = Discourse.Model.create(p);
           result.postActionByIdLookup.set("action" + p.id, actionType);
           return actionType;
         });

--- a/app/assets/javascripts/discourse/views/actions_history_view.js
+++ b/app/assets/javascripts/discourse/views/actions_history_view.js
@@ -24,32 +24,33 @@ Discourse.ActionsHistoryView = Discourse.View.extend({
 
     if (!this.present('content')) return;
     return this.get('content').forEach(function(c) {
-      var alsoName;
+      var actionString, iconsHtml;
       buffer.push("<div class='post-action'>");
 
       if (c.get('users')) {
+        iconsHtml = "";
         c.get('users').forEach(function(u) {
-          buffer.push("<a href=\"" + Discourse.getURL("/users/") + (u.get('username_lower')) + "\">");
-          buffer.push(Discourse.Utilities.avatarImg({
+          iconsHtml += "<a href=\"" + Discourse.getURL("/users/") + (u.get('username_lower')) + "\">";
+          iconsHtml += Discourse.Utilities.avatarImg({
             size: 'small',
             username: u.get('username'),
             avatarTemplate: u.get('avatar_template')
-          }));
-          return buffer.push("</a>");
+          });
+          iconsHtml += "</a>";
         });
-        buffer.push(" " + (c.get('actionType.long_form')) + ".");
+        buffer.push(" " + Em.String.i18n('post.actions.people.' + c.get('actionType.name_key'), { icons: iconsHtml }) + ".");
       } else {
         buffer.push("<a href='#' data-who-acted='" + (c.get('id')) + "'>" + (c.get('description')) + "</a>.");
       }
 
       if (c.get('can_act')) {
-        alsoName = Em.String.i18n("post.actions.it_too", { alsoName: c.get('actionType.alsoName') });
-        buffer.push(" <a href='#' data-act='" + (c.get('id')) + "'>" + alsoName + "</a>.");
+        actionString = Em.String.i18n("post.actions.it_too." + c.get('actionType.name_key'));
+        buffer.push(" <a href='#' data-act='" + (c.get('id')) + "'>" + actionString + "</a>.");
       }
 
       if (c.get('can_undo')) {
-        alsoName = Em.String.i18n("post.actions.undo", { alsoName: c.get('actionType.alsoNameLower') });
-        buffer.push(" <a href='#' data-undo='" + (c.get('id')) + "'>" + alsoName + "</a>.");
+        actionString = Em.String.i18n("post.actions.undo." + c.get('actionType.name_key') );
+        buffer.push(" <a href='#' data-undo='" + (c.get('id')) + "'>" + actionString + "</a>.");
       }
 
       if (c.get('can_clear_flags')) {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -584,15 +584,82 @@ en:
         clear_flags:
           one: "Clear flag"
           other: "Clear flags"
-        it_too: "{{alsoName}} it too"
-        undo: "Undo {{alsoName}}"
+        it_too:
+          off_topic: "Flag it too"
+          spam: "Flag it too"
+          inappropriate: "Flag it too"
+          custom_flag: "Flag it too"
+          bookmark: "Bookmark it too"
+          like: "Like it too"
+          vote: "Vote for it too"
+        undo:
+          off_topic: "Undo flag"
+          spam: "Undo flag"
+          inappropriate: "Undo flag"
+          custom_flag: "Undo flag"
+          bookmark: "Undo bookmark"
+          like: "Undo like"
+          vote: "Undo vote"
+        people:
+          off_topic: "{{icons}} marked this as off-topic"
+          spam: "{{icons}} marked this as spam"
+          inappropriate: "{{icons}} marked this as inappropriate"
+          custom_flag: "{{icons}} flagged this"
+          bookmark: "{{icons}} bookmarked this"
+          like: "{{icons}} liked this"
+          vote: "{{icons}} voted for this"
+        by_you:
+          off_topic: "You flagged this as off-topic"
+          spam: "You flagged this as spam"
+          inappropriate: "You flagged this as inappropriate"
+          custom_flag: "You flagged this for moderation"
+          bookmark: "You bookmarked this post"
+          like: "You liked this"
+          vote: "You voted for this post"
         by_you_and_others:
-          zero: "You {{long_form}}"
-          one: "You and 1 other person {{long_form}}"
-          other: "You and {{count}} other people {{long_form}}"
+          off_topic:
+            one: "You and 1 other flagged this as off-topic"
+            other: "You and {{count}} other people flagged this as off-topic"
+          spam:
+            one: "You and 1 other flagged this as spam"
+            other: "You and {{count}} other people flagged this as spam"
+          inappropriate:
+            one: "You and 1 other flagged this as inappropriate"
+            other: "You and {{count}} other people flagged this as inappropriate"
+          custom_flag:
+            one: "You and 1 other flagged this for moderation"
+            other: "You and {{count}} other people flagged this for moderation"
+          bookmark:
+            one: "You and 1 other bookmarked this post"
+            other: "You and {{count}} other people bookmarked this post"
+          like:
+            one: "You and 1 other liked this"
+            other: "You and {{count}} other people liked this"
+          vote:
+            one: "You and 1 other voted for this post"
+            other: "You and {{count}} other people voted for this post"
         by_others:
-          one: "1 person {{long_form}}"
-          other: "{{count}} people {{long_form}}"
+          off_topic:
+            one: "1 person flagged this as off-topic"
+            other: "{{count}} people flagged this as off-topic"
+          spam:
+            one: "1 person flagged this as spam"
+            other: "{{count}} people flagged this as spam"
+          inappropriate:
+            one: "1 person flagged this as inappropriate"
+            other: "{{count}} people flagged this as inappropriate"
+          custom_flag:
+            one: "1 person flagged this for moderation"
+            other: "{{count}} people flagged this for moderation"
+          bookmark:
+            one: "1 person bookmarked this post"
+            other: "{{count}} people bookmarked this post"
+          like:
+            one: "1 person liked this"
+            other: "{{count}} people liked this"
+          vote:
+            one: "1 person voted for this post"
+            other: "{{count}} people voted for this post"
 
       edits:
         one: 1 edit


### PR DESCRIPTION
This is a pull request following the conversation at https://github.com/discourse/discourse/pull/605. Basically, there is a lot of trouble when trying to correctly translate this:

```
"You {{long_form}}"
"You and 1 other person {{long_form}}"
"You and {{count}} other people {{long_form}}"
"{{count}} people {{long_form}}"
"{{alsoName}} it too"
```

Although the new approach might seem worse (there is a lot of duplication), it makes correct translations possible. E.g. in Czech language, you can't have all these action in the form "{{subject}} {{did_something}}", because the spelling of subject differs for the different actions.

Note: I don't want to involve genders into this, that would be the next (and much more complicated) step.
