### PR TITLE
Allow handling of back/forward buttons in browser when running with prefix (i.e. as /discourse)

### DIFF
--- a/app/assets/javascripts/discourse/routes/discourse_location.js
+++ b/app/assets/javascripts/discourse/routes/discourse_location.js
@@ -153,7 +153,12 @@ Ember.DiscourseLocation = Ember.Object.extend({
       if (e.state) {
         var currentState = self.get('currentState');
         if (currentState) {
-          callback(e.state.path);
+          var url = e.state.path,
+              rootURL = get(self, 'rootURL');
+
+          rootURL = rootURL.replace(/\/$/, '');
+          url = url.replace(rootURL, '');
+          callback(url);
         } else {
           this.set('currentState', e.state);
         }


### PR DESCRIPTION
Allow handling of back/forward buttons in browser when running with prefix (i.e. as /discourse)
