### PR TITLE
Putting rootURL in JavaScript using Discourse::base_uri and erb

### DIFF
--- a/app/assets/javascripts/discourse.js
+++ b/app/assets/javascripts/discourse.js
@@ -22,10 +22,8 @@ Discourse = Ember.Application.createWithMixins({
   // The highest seen post number by topic
   highestSeenByTopic: {},
 
-  rootURL: '/',
-
   getURL: function(url) {
-    var u = this.get('rootURL');
+    var u = (Discourse.BaseUri === undefined ? "/" : Discourse.BaseUri);
     if (u[u.length-1] === '/') {
       u = u.substring(0, u.length-1);
     }

--- a/app/assets/javascripts/discourse/components/url.js
+++ b/app/assets/javascripts/discourse/components/url.js
@@ -14,14 +14,6 @@ Discourse.URL = {
   MORE_REGEXP: /\/more$/,
 
   /**
-    Will be pre-pended to path upon state change
-
-    @property rootURL
-    @default '/'
-  */
-  rootURL: '/',
-
-  /**
     @private
 
     Get a handle on the application's router. Note that currently it uses `__container__` which is not
@@ -73,7 +65,8 @@ Discourse.URL = {
       If the URL is absolute, remove rootURL
      */
     if (path.match(/^\//)) {
-      var rootURL = this.rootURL.replace(/\/$/, '');
+      var rootURL = (Discourse.BaseUri === undefined ? "/" : Discourse.BaseUri);
+      rootURL = rootURL.replace(/\/$/, '');
       path = path.replace(rootURL, '');
     }
 

--- a/app/assets/javascripts/discourse/routes/discourse_location.js
+++ b/app/assets/javascripts/discourse/routes/discourse_location.js
@@ -36,14 +36,6 @@ Ember.DiscourseLocation = Ember.Object.extend({
   },
 
   /**
-    Will be pre-pended to path upon state change
-
-    @property rootURL
-    @default '/'
-  */
-  rootURL: '/',
-
-  /**
     @private
 
     Returns the current `location.pathname` without rootURL
@@ -51,7 +43,7 @@ Ember.DiscourseLocation = Ember.Object.extend({
     @method getURL
   */
   getURL: function() {
-    var rootURL = get(this, 'rootURL'),
+    var rootURL = (Discourse.BaseUri === undefined ? "/" : Discourse.BaseUri),
         url = get(this, 'location').pathname;
 
     rootURL = rootURL.replace(/\/$/, '');
@@ -154,7 +146,7 @@ Ember.DiscourseLocation = Ember.Object.extend({
         var currentState = self.get('currentState');
         if (currentState) {
           var url = e.state.path,
-              rootURL = get(self, 'rootURL');
+              rootURL = (Discourse.BaseUri === undefined ? "/" : Discourse.BaseUri);
 
           rootURL = rootURL.replace(/\/$/, '');
           url = url.replace(rootURL, '');
@@ -176,7 +168,7 @@ Ember.DiscourseLocation = Ember.Object.extend({
     @param url {String}
   */
   formatURL: function(url) {
-    var rootURL = get(this, 'rootURL');
+    var rootURL = (Discourse.BaseUri === undefined ? "/" : Discourse.BaseUri);
 
     if (url !== '') {
       rootURL = rootURL.replace(/\/$/, '');

--- a/app/views/common/_discourse_javascript.html.erb
+++ b/app/views/common/_discourse_javascript.html.erb
@@ -35,6 +35,7 @@
 <script>
   Discourse.CDN = '<%= Rails.configuration.action_controller.asset_host  %>';
   Discourse.BaseUrl = '<%= RailsMultisite::ConnectionManagement.current_hostname  %>';
+  Discourse.BaseUri = '<%= Discourse::base_uri "/" %>';
   Discourse.Environment = '<%= Rails.env %>';
   Discourse.Router.map(function() {
     return Discourse.routeBuilder.call(this);

--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -18,11 +18,11 @@ module Discourse
     RailsMultisite::ConnectionManagement.current_hostname
   end
 
-  def self.base_uri
+  def self.base_uri default_value=""
     if !ActionController::Base.config.relative_url_root.blank?
       return ActionController::Base.config.relative_url_root 
     else
-      return ""
+      return default_value
     end
   end
 


### PR DESCRIPTION
Putting rootURL in JavaScript using Discourse::base_uri and erb

This is mainly meant for running discourse with a prefix, and mainly meant to ease deploying the website with a prefix (so no manual changes in *.js files are needed).
