### PR TITLE
Fix pretty text vs libxml 2 9 0

### DIFF
--- a/spec/components/pretty_text_spec.rb
+++ b/spec/components/pretty_text_spec.rb
@@ -15,15 +15,15 @@ test
     end
 
     it "produces a quote even with new lines in it" do
-      PrettyText.cook("[quote=\"EvilTrout, post:123, topic:456, full:true\"]ddd\n[/quote]").should == "<p></p><aside class=\"quote\" data-post=\"123\" data-topic=\"456\" data-full=\"true\"><div class=\"title\">\n    <div class=\"quote-controls\"></div>\n  <img width=\"20\" height=\"20\" src=\"/users/eviltrout/avatar/40?__ws=http%3A%2F%2Ftest.localhost\" class=\"avatar \" title=\"\">\n  EvilTrout\n  said:\n  </div>\n  <blockquote>ddd</blockquote>\n</aside><p></p>"
+      PrettyText.cook("[quote=\"EvilTrout, post:123, topic:456, full:true\"]ddd\n[/quote]").should =~ %r{^<p></p><aside class="quote" data-post="123" data-topic="456" data-full="true">(\n\s+)?<div class="title">\n\s+<div class="quote-controls"></div>\n\s+<img width="20" height="20" src="/users/eviltrout/avatar/40\?__ws=http%3A%2F%2Ftest\.localhost" class="avatar " title="">\n\s+EvilTrout\n\s+said:\n\s+</div>\n\s+<blockquote>ddd</blockquote>\n</aside>(\n)?<p></p>}
     end
 
     it "should produce a quote" do
-      PrettyText.cook("[quote=\"EvilTrout, post:123, topic:456, full:true\"]ddd[/quote]").should == "<p></p><aside class=\"quote\" data-post=\"123\" data-topic=\"456\" data-full=\"true\"><div class=\"title\">\n    <div class=\"quote-controls\"></div>\n  <img width=\"20\" height=\"20\" src=\"/users/eviltrout/avatar/40?__ws=http%3A%2F%2Ftest.localhost\" class=\"avatar \" title=\"\">\n  EvilTrout\n  said:\n  </div>\n  <blockquote>ddd</blockquote>\n</aside><p></p>"
+      PrettyText.cook("[quote=\"EvilTrout, post:123, topic:456, full:true\"]ddd[/quote]").should =~ %r{<p></p><aside class="quote" data-post="123" data-topic="456" data-full="true">(\n\s+)?<div class="title">\n\s+<div class="quote-controls"></div>\n\s+<img width="20" height="20" src="/users/eviltrout/avatar/40\?__ws=http%3A%2F%2Ftest\.localhost" class="avatar " title="">\n\s+EvilTrout\n\s+said:\n\s+</div>\n\s+<blockquote>ddd</blockquote>\n</aside>(\n)?<p></p>}
     end
 
     it "trims spaces on quote params" do
-      PrettyText.cook("[quote=\"EvilTrout, post:555, topic: 666\"]ddd[/quote]").should == "<p></p><aside class=\"quote\" data-post=\"555\" data-topic=\"666\"><div class=\"title\">\n    <div class=\"quote-controls\"></div>\n  <img width=\"20\" height=\"20\" src=\"/users/eviltrout/avatar/40?__ws=http%3A%2F%2Ftest.localhost\" class=\"avatar \" title=\"\">\n  EvilTrout\n  said:\n  </div>\n  <blockquote>ddd</blockquote>\n</aside><p></p>"
+      PrettyText.cook("[quote=\"EvilTrout, post:555, topic: 666\"]ddd[/quote]").should =~ %r{<p></p><aside class="quote" data-post="555" data-topic="666">(\n\s+)?<div class="title">\n\s+<div class="quote-controls"></div>\n\s+<img width="20" height="20" src="/users/eviltrout/avatar/40\?__ws=http%3A%2F%2Ftest\.localhost" class="avatar " title="">\n\s+EvilTrout\n\s+said:\n\s+</div>\n\s+<blockquote>ddd</blockquote>\n</aside>(\n)?<p></p>}
     end
 
 


### PR DESCRIPTION
pretty_text_spec.rb was comparing against exact string matches. libxmll2 2.9.0 changed the way it outputs, inserting new lines and indents where it previously left some things inline.

The spec has been revised to match a regular expression that fits both 2.7.6 and 2.9.0 output.
