### PR TITLE
Separate the requirements from the draft status in the composer

### DIFF
--- a/app/assets/javascripts/discourse/controllers/composer_controller.js
+++ b/app/assets/javascripts/discourse/controllers/composer_controller.js
@@ -18,8 +18,8 @@ Discourse.ComposerController = Discourse.Controller.extend({
     this.get('content').importQuote();
   },
 
-  resetDraftStatus: function() {
-    this.get('content').resetDraftStatus();
+  updateDraftStatus: function() {
+    this.get('content').updateDraftStatus();
   },
 
   appendText: function(text) {

--- a/app/assets/javascripts/discourse/models/composer.js
+++ b/app/assets/javascripts/discourse/models/composer.js
@@ -458,14 +458,17 @@ Discourse.Composer = Discourse.Model.extend({
     this.set('draftStatus', Em.String.i18n('composer.saving_draft_tip'));
 
     var composer = this;
-    return Discourse.Draft.save(this.get('draftKey'), this.get('draftSequence'), data).then((function() {
-      composer.set('draftStatus', Em.String.i18n('composer.saved_draft_tip'));
-    }), (function() {
-      composer.set('draftStatus', Em.String.i18n('composer.drafts_offline'));
-    }));
+
+    // try to save the draft
+    return Discourse.Draft.save(this.get('draftKey'), this.get('draftSequence'), data)
+      .then(function() {
+        composer.set('draftStatus', Em.String.i18n('composer.saved_draft_tip'));
+      }, function() {
+        composer.set('draftStatus', Em.String.i18n('composer.drafts_offline'));
+      });
   },
 
-  resetDraftStatus: (function() {
+  updateDraftStatus: function() {
     // 'title' is focused
     if ($('#reply-title').is(':focus')) {
       var titleDiff = Discourse.SiteSettings.min_topic_title_length - this.get('titleLength');
@@ -482,7 +485,7 @@ Discourse.Composer = Discourse.Model.extend({
     // hide the counters if the currently focused text field is OK
     this.set('draftStatus', null);
 
-  }).observes('replyLength', 'titleLength'),
+  }.observes('replyLength', 'titleLength'),
 
   /**
     Computes the length of the title minus non-significant whitespaces

--- a/app/assets/javascripts/discourse/templates/composer.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/composer.js.handlebars
@@ -50,7 +50,7 @@
             </div>
             {{#if Discourse.currentUser}}
                <a href="#" {{action togglePreview target="controller"}} class='toggle-preview'>{{{content.toggleText}}}</a>
-               <div class='saving-draft'></div>
+               <div class='draft-status'></div>
                {{#if view.loadingImage}}
                 <div id="image-uploading">
                   {{i18n image_selector.uploading_image}} {{view.uploadProgress}}% <a id="cancel-image-upload">{{i18n cancel}}</a>

--- a/app/assets/javascripts/discourse/views/composer_view.js
+++ b/app/assets/javascripts/discourse/views/composer_view.js
@@ -27,7 +27,7 @@ Discourse.ComposerView = Discourse.View.extend({
   }.property('content.composeState'),
 
   draftStatus: function() {
-    this.$('.saving-draft').text(this.get('content.draftStatus') || "");
+    this.$('.draft-status').text(this.get('content.draftStatus') || "");
   }.observes('content.draftStatus'),
 
   // Disable fields when we're loading
@@ -87,7 +87,7 @@ Discourse.ComposerView = Discourse.View.extend({
 
   focusIn: function() {
     var controller = this.get('controller');
-    if(controller) controller.resetDraftStatus();
+    if (controller) controller.updateDraftStatus();
   },
 
   resize: function() {

--- a/app/assets/stylesheets/application/compose.css.scss
+++ b/app/assets/stylesheets/application/compose.css.scss
@@ -55,7 +55,7 @@
 }
 
 #reply-control {
-  .toggle-preview, .saving-draft, #image-uploading {
+  .toggle-preview, .draft-status, #image-uploading {
     position: absolute;
     bottom: -31px;
     margin-top: 0px;
@@ -69,7 +69,7 @@
     font-size: 12px;
     color: darken($gray, 40);
   }
-  .saving-draft {
+  .draft-status {
     right: 51%;
     color: lighten($black, 60);
   }


### PR DESCRIPTION
<del>Per @SamSaffron's [comment](https://github.com/ZogStriP/discourse/commit/b2ce1d574f2be24a35202a85a6571f81ca9bff0e#commitcomment-2940541): this separate the requirements from the draft status in the composer:</del>


![Screenshot_04_04_13_03_42](https://f.cloud.github.com/assets/362783/337244/5b428c04-9cc9-11e2-80c7-888b276f65c9.png)

<del>**Note:** I've modified the way the draft status (ie. `saving/saved/offline`) is cleared. 
It was cleared when the composer would get the focus and will now disappear **5 seconds** after being displayed.</del>

After some discussion, it appears that only one field is prefered. This PR only rename the div and a few methods to allow for a better understanding of the various components involved.
