### PR TITLE
Make composer requirements more visible

### DIFF
--- a/app/assets/javascripts/discourse/models/composer.js
+++ b/app/assets/javascripts/discourse/models/composer.js
@@ -469,12 +469,14 @@ Discourse.Composer = Discourse.Model.extend({
     // 'title' is focused
     if ($('#reply-title').is(':focus')) {
       var titleDiff = Discourse.SiteSettings.min_topic_title_length - this.get('titleLength');
+      $('#reply-title').toggleClass("has-error", titleDiff > 0);
       if (titleDiff > 0) {
         return this.set('draftStatus', Em.String.i18n('composer.min_length.need_more_for_title', { n: titleDiff }));
       }
     // 'reply' is focused
     } else if ($('#wmd-input').is(':focus')) {
       var replyDiff = Discourse.SiteSettings.min_post_length - this.get('replyLength');
+      $('.textarea-wrapper').toggleClass("has-error", replyDiff > 0);
       if (replyDiff > 0) {
         return this.set('draftStatus', Em.String.i18n('composer.min_length.need_more_for_reply', { n: replyDiff }));
       }

--- a/app/assets/stylesheets/application/compose.css.scss
+++ b/app/assets/stylesheets/application/compose.css.scss
@@ -55,6 +55,12 @@
 }
 
 #reply-control {
+  .has-error {
+    border: solid 1px #f00;
+            box-shadow: 0 0 5px rgba(255, 0, 0, 0.75);
+       -moz-box-shadow: 0 0 5px rgba(255, 0, 0, 0.75);
+    -webkit-box-shadow: 0 0 5px rgba(255, 0, 0, 0.75);
+  }
   .toggle-preview, .saving-draft, #image-uploading {
     position: absolute;
     bottom: -31px;


### PR DESCRIPTION
Meta: [Title character requirements not very visible](http://meta.discourse.org/t/title-character-requirements-not-very-visible/5542/11)

This adds a red border on `title` and `reply` fields whenever the minimum characters requirements are not met:

![Screenshot_04_04_13_04_11](https://f.cloud.github.com/assets/362783/337308/6920b3ce-9ccd-11e2-8703-17c627a12a9e.png)
