### PR TITLE
Detect and remove prefix being added twice when going to pages already in history

### DIFF
--- a/app/assets/javascripts/discourse/routes/discourse_location.js
+++ b/app/assets/javascripts/discourse/routes/discourse_location.js
@@ -174,6 +174,13 @@ Ember.DiscourseLocation = Ember.Object.extend({
       rootURL = rootURL.replace(/\/$/, '');
     }
 
+    // remove prefix from URL if it is already in url - i.e. /discourse/t/... -> /t/if rootURL is /discourse
+    // this sometimes happens when navigating to already visited location
+    if ((rootURL.length > 1) && (url.substring(0, rootURL.length + 1) === (rootURL + "/")))
+    {
+      url = url.substring(rootURL.length);
+    }
+
     return rootURL + url;
   },
 


### PR DESCRIPTION
This resolves the issue that discourse run with prefix sometimes generates URLs like /discourse/discourse/t/...

This can be reproduced by running discourse with a prefix, going to http://127.1/discourse/, then clicking on any topic, going back (using back button) and then clicking on same topic again.
