### PR TITLE
Change Title background to red when requirements are not met

### DIFF
--- a/app/assets/javascripts/discourse/controllers/composer_controller.js
+++ b/app/assets/javascripts/discourse/controllers/composer_controller.js
@@ -18,8 +18,8 @@ Discourse.ComposerController = Discourse.Controller.extend({
     this.get('content').importQuote();
   },
 
-  resetDraftStatus: function() {
-    this.get('content').resetDraftStatus();
+  updateDraftStatus: function() {
+    this.get('content').updateDraftStatus();
   },
 
   appendText: function(text) {

--- a/app/assets/javascripts/discourse/models/topic_list.js
+++ b/app/assets/javascripts/discourse/models/topic_list.js
@@ -50,8 +50,6 @@ Discourse.TopicList = Discourse.Model.extend({
       unseen: true,
       highlight: true
     });
-    console.log(newTopic);
-
     this.get('inserted').unshiftObject(newTopic);
   }
 

--- a/app/assets/javascripts/discourse/routes/preferences_route.js
+++ b/app/assets/javascripts/discourse/routes/preferences_route.js
@@ -17,10 +17,7 @@ Discourse.PreferencesRoute = Discourse.RestrictedUserRoute.extend({
   },
 
   setupController: function(controller) {
-    console.log('prefereces');
     controller.set('content', this.controllerFor('user').get('content'));
   }
 
 });
-
-

--- a/app/assets/javascripts/discourse/templates/composer.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/composer.js.handlebars
@@ -50,7 +50,7 @@
             </div>
             {{#if Discourse.currentUser}}
                <a href="#" {{action togglePreview target="controller"}} class='toggle-preview'>{{{content.toggleText}}}</a>
-               <div class='saving-draft'></div>
+               <div class='draft-status'></div>
                {{#if view.loadingImage}}
                 <div id="image-uploading">
                   {{i18n image_selector.uploading_image}} {{view.uploadProgress}}% <a id="cancel-image-upload">{{i18n cancel}}</a>

--- a/app/assets/javascripts/discourse/views/composer_view.js
+++ b/app/assets/javascripts/discourse/views/composer_view.js
@@ -27,7 +27,7 @@ Discourse.ComposerView = Discourse.View.extend({
   }.property('content.composeState'),
 
   draftStatus: function() {
-    this.$('.saving-draft').text(this.get('content.draftStatus') || "");
+    this.$('.draft-status').text(this.get('content.draftStatus') || "");
   }.observes('content.draftStatus'),
 
   // Disable fields when we're loading
@@ -40,8 +40,7 @@ Discourse.ComposerView = Discourse.View.extend({
   }.observes('loading'),
 
   postMade: function() {
-    if (this.present('controller.createdPost')) return 'created-post';
-    return null;
+    return this.present('controller.createdPost') ? 'created-post' : null;
   }.property('content.createdPost'),
 
   observeReplyChanges: function() {
@@ -87,7 +86,7 @@ Discourse.ComposerView = Discourse.View.extend({
 
   focusIn: function() {
     var controller = this.get('controller');
-    if(controller) controller.resetDraftStatus();
+    if (controller) controller.updateDraftStatus();
   },
 
   resize: function() {
@@ -123,9 +122,9 @@ Discourse.ComposerView = Discourse.View.extend({
   },
 
   didInsertElement: function() {
-    var replyControl = $('#reply-control');
-    replyControl.DivResizer({ resize: this.resize, onDrag: this.movePanels });
-    Discourse.TransitionHelper.after(replyControl, this.resize);
+    var $replyControl = $('#reply-control');
+    $replyControl.DivResizer({ resize: this.resize, onDrag: this.movePanels });
+    Discourse.TransitionHelper.after($replyControl, this.resize);
   },
 
   click: function() {
@@ -260,9 +259,24 @@ Discourse.ComposerView = Discourse.View.extend({
       return true;
     });
 
-    $('#reply-title').keyup(function() {
+    var $replyTitle = $('#reply-title');
+
+    $replyTitle.keyup(function() {
       saveDraft();
+      // removes the red background once the requirements are met
+      if (_this.get('controller.content.missingTitleCharacters') <= 0) {
+        $replyTitle.removeClass("requirements-not-met");
+      }
       return true;
+    });
+
+    // when the title field loses the focus...
+    $replyTitle.blur(function(){
+      // ...and the requirements are not met (ie. the minimum number of characters)
+      if (_this.get('controller.content.missingTitleCharacters') > 0) {
+        // then, "redify" the background
+        $replyTitle.toggleClass("requirements-not-met", true);
+      }
     });
 
     // In case it's still bound somehow

--- a/app/assets/stylesheets/application/compose.css.scss
+++ b/app/assets/stylesheets/application/compose.css.scss
@@ -55,7 +55,10 @@
 }
 
 #reply-control {
-  .toggle-preview, .saving-draft, #image-uploading {
+  .requirements-not-met {
+    background-color: rgba(255, 0, 0, 0.12);
+  }
+  .toggle-preview, .draft-status, #image-uploading {
     position: absolute;
     bottom: -31px;
     margin-top: 0px;
@@ -69,7 +72,7 @@
     font-size: 12px;
     color: darken($gray, 40);
   }
-  .saving-draft {
+  .draft-status {
     right: 51%;
     color: lighten($black, 60);
   }


### PR DESCRIPTION
Another attempt at solving: [Title character requirements not very visible](http://meta.discourse.org/t/title-character-requirements-not-very-visible/5542/17)

As per @SamSaffron's last comment, this will **only** _redify_ the background of the `title` field whenever requirements are not met:

![image](https://f.cloud.github.com/assets/362783/338469/11032d0c-9d13-11e2-980b-44b3ec6bca12.png)
