### PR TITLE
Post processing of images adds prefix second time

### DIFF
--- a/lib/cooked_post_processor.rb
+++ b/lib/cooked_post_processor.rb
@@ -45,7 +45,7 @@ class CookedPostProcessor
 
     images.each do |img|
       src = img['src']
-      src = Discourse.base_url + src if src[0] == "/"
+      src = Discourse.base_url_no_prefix + src if src[0] == "/"
 
       if src.present? && (img['width'].blank? || img['height'].blank?)
 

--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -26,7 +26,7 @@ module Discourse
     end
   end
 
-  def self.base_url
+  def self.base_url_no_prefix
     protocol = "http"
     protocol = "https" if SiteSetting.use_ssl?
     if SiteSetting.force_hostname.present?
@@ -35,8 +35,11 @@ module Discourse
       result = "#{protocol}://#{current_hostname}"
     end
     result << ":#{SiteSetting.port}" if SiteSetting.port.present? && SiteSetting.port.to_i > 0
-    result << ActionController::Base.config.relative_url_root if !ActionController::Base.config.relative_url_root.blank?
     result
+  end
+
+  def self.base_url
+    return base_url_no_prefix + base_uri
   end
 
   def self.enable_maintenance_mode


### PR DESCRIPTION
Post processing of images in post adds prefix second time when post processing images.

This is because Discourse::base_url has /prefix in it. Split it into two methods and invoking the second one in post processing.
