### PR TITLE
Fix for reply to user avatar and picture uploading not working when editing post when using prefix

### DIFF
--- a/app/assets/javascripts/discourse/components/utilities.js
+++ b/app/assets/javascripts/discourse/components/utilities.js
@@ -53,7 +53,7 @@ Discourse.Utilities = {
     if (template) {
       return template.replace(/\{size\}/g, rawSize);
     }
-    return "/users/" + (username.toLowerCase()) + "/avatar/" + rawSize + "?__ws=" + (encodeURIComponent(Discourse.BaseUrl || ""));
+    return Discourse.getURL("/users/") + (username.toLowerCase()) + "/avatar/" + rawSize + "?__ws=" + (encodeURIComponent(Discourse.BaseUrl || ""));
   },
 
   avatarImg: function(options) {

--- a/app/assets/javascripts/discourse/views/composer_view.js
+++ b/app/assets/javascripts/discourse/views/composer_view.js
@@ -270,7 +270,7 @@ Discourse.ComposerView = Discourse.View.extend({
     $uploadTarget.off();
 
     $uploadTarget.fileupload({
-        url: '/uploads',
+        url: Discourse.getURL('/uploads'),
         dataType: 'json',
         timeout: 20000,
         formData: { topic_id: 1234 }

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -48,7 +48,7 @@ class Upload < ActiveRecord::Base
     File.open("#{path}/#{clean_name}", "wb") do |f|
       f.write File.read(file.tempfile)
     end
-    upload.url = "#{url_root}/#{clean_name}"
+    upload.url = Discourse::base_uri + "#{url_root}/#{clean_name}"
     upload.save
 
     upload


### PR DESCRIPTION
Fix for reply to user avatar and picture uploading not working when editing post with discourse running in a prefix
