### PR TITLE
move i18n of UserActions to JS-side and make sentences translatable

### DIFF
--- a/app/assets/javascripts/discourse/models/user.js
+++ b/app/assets/javascripts/discourse/models/user.js
@@ -380,6 +380,7 @@ Discourse.User = Discourse.Model.extend({
         var stat = Em.Object.create(s);
         stat.set('isPM', stat.get('action_type') === Discourse.UserAction.NEW_PRIVATE_MESSAGE ||
                          stat.get('action_type') === Discourse.UserAction.GOT_PRIVATE_MESSAGE);
+        stat.set('description', Em.String.i18n('user_action_groups.' + stat.get('action_type')));
         return stat;
       }));
 
@@ -438,7 +439,7 @@ Discourse.User.reopenClass({
           found = true;
           if (!g[k]) {
             g[k] = Em.Object.create({
-              description: Em.String.i18n("user_action_descriptions." + k),
+              description: Em.String.i18n("user_action_groups." + k),
               count: 0,
               action_type: parseInt(k, 10)
             });

--- a/app/assets/javascripts/discourse/templates/user/stream.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/user/stream.js.handlebars
@@ -7,31 +7,7 @@
         <span class="title">
           <a href="{{unbound postUrl}}">{{unbound title}}</a>
         </span>
-        {{#unless description}}
-          <span class="type">
-          {{#if isPM}}
-            <i class="icon icon-envelope-alt" title="{{i18n user.stream.private_message}}"></i>
-            {{i18n user.stream.sent_by}}
-          {{else}}
-            {{i18n user.stream.posted_by}}
-          {{/if}}
-          </span>
-        {{/unless}}
-        <a class='name' href="{{unbound userUrl}}">{{personalizedName name usernamePath="username"}}</a>
-        {{#if description}}
-          <span class='type'>{{unbound description}}</span>
-          {{#if isPostAction}}
-            <a class="post-number" href="{{unbound replyUrl}}">
-            {{#if reply_to_post_number}}
-              #{{unbound reply_to_post_number}}
-            {{else}}
-              {{i18n user.stream.the_topic}}
-            {{/if}}
-            </a>
-          {{else}}
-            <span class="name">{{personalizedName view.parentView.parentView.user.name usernamePath="view.parentView.parentView.user.username"}}</span>
-          {{/if}}
-        {{/if}}
+        <span class="type">{{unbound descriptionHtml}}</span>
       </div>
       <p class='excerpt'>
       {{{unbound excerpt}}}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -48,8 +48,35 @@ en:
     saving: "Saving..."
     saved: "Saved!"
 
-    user_action_descriptions:
+    user_action:
+      user_posted_topic: "<u>{{user}}</u> posted <t>the topic</t>"
+      you_posted_topic: "<u>You</u> posted <t>the topic</t>"
+      user_replied_to_post: "<u>{{user}}</u> replied to <t>{{post_number}}</t>"
+      you_replied_to_post: "<u>You</u> replied to <t>{{post_number}}</t>"
+      user_replied_to_topic: "<u>{{user}}</u> replied to <t>the topic</t>"
+      you_replied_to_topic: "<u>You</u> replied to <t>the topic</t>"
+
+      user_mentioned_user: "<u1>{{user}}</u1> mentioned <u2>{{another_user}}</u2>"
+      user_mentioned_you: "<u1>{{user}}</u1> mentioned <u2>you</u2>"
+
+      posted_by_user: "Posted by <u>{{user}}</u>"
+      posted_by_you: "Posted by <u>you</u>"
+      sent_by_user: "Sent by <u>{{user}}</u>"
+      sent_by_you: "Sent by <u>you</u>"
+
+    user_action_groups:
+      "1": "Likes Given"
+      "2": "Likes Received"
+      "3": "Bookmarks"
+      "4": "Topics"
+      "5": "Posts"
       "6": "Responses"
+      "7": "Mentions"
+      "9": "Quotes"
+      "10": "Favorites"
+      "11": "Edits"
+      "12": "Sent Items"
+      "13": "Inbox"
 
     user:
       information: "User Information"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -518,31 +518,6 @@ en:
   most_recent_poster: "Most Recent Poster"
   frequent_poster: "Frequent Poster"
 
-  user_action_descriptions:
-    bookmarks: "Bookmarks"
-    topics: "Topics"
-    likes_received: "Likes Received"
-    likes_given: "Likes Given"
-    responses: "Responses"
-    topic_responses: "Topic Responses"
-    posts: "Posts"
-    mentions: "Mentions"
-    quotes: "Quotes"
-    edits: "Edits"
-    favorites: "Favorites"
-    sent_items: "Sent Items"
-    inbox: "Inbox"
-
-    was_liked: "was liked"
-    liked: "liked"
-    bookmarked: "bookmarked"
-    posted: "posted"
-    responded_to: "replied to"
-    mentioned: "mentioned"
-    quoted: "quoted"
-    favorited: "favorited"
-    edited: "edited"
-
   move_posts:
     moderator_post:
       one: "I moved a post to a new topic: %{topic_link}"


### PR DESCRIPTION
This is a pull request to make translations of user actions ("user1 mentioned user2"). Basically, the the whole thing is a way to have whole sentences in client.xx.yml:

```
  {{user}} posted the topic
  You replied to {{post_number}}
```

I also moved the creation of the sentence to the client side, and I there is one more thing: Since we want the "You" to be clickable, we have to either to split the sentence into parts (which makes it untranslatable again) or mark the parts of the string somehow. I chose this approach:

```
  user_replied_to_topic: "<u>{{user}}</u> replied to <t>the topic</t>"
  you_replied_to_topic: "<u>You</u> replied to <t>the topic</t>"
  user_mentioned_user: "<u1>{{user}}</u1> mentioned <u2>{{another_user}}</u2>"
  posted_by_user: "Posted by <u>{{user}}</u>"
```

Marking the various parts with meta-tags e.g. `<u1>...</u1>`, which get replaced in JS by a link instead.

Now if you look at the code, maybe you'll think that I replaced a neatly parametrized code by a giant switch, and you're right. But currently, Discourse assembles a sentence by concatenation ("subject" + "verb" + "object"), which makes it untranslatable. Also, we have to distinguish situations when subject is 1st person and when it is 2nd person (you), these usually translate differently.
