### PR TITLE
improve quote reply selection

### DIFF
--- a/app/assets/javascripts/discourse/controllers/quote_button_controller.js
+++ b/app/assets/javascripts/discourse/controllers/quote_button_controller.js
@@ -36,17 +36,13 @@ Discourse.QuoteButtonController = Discourse.Controller.extend({
     if (!this.get('controllers.topic.content.can_create_post')) return;
 
     // retrieve the selected range
-    var range = window.getSelection().getRangeAt(0);
-    var cloned = range.cloneRange();
+    var range = window.getSelection().getRangeAt(0),
+        cloned = range.cloneRange(),
+        $ancestor = $(range.commonAncestorContainer);
 
     // don't display the "quote reply" button if you select text spanning two posts
-    // this basically look for the first "DIV" container...
-    var commonDivAncestorContainer = range.commonAncestorContainer;
-    while (commonDivAncestorContainer.nodeName !== 'DIV') {
-      commonDivAncestorContainer = commonDivAncestorContainer.parentNode;
-    }
-    // ... and check it has the 'cooked' class (which indicates we're in a post)
-    if (commonDivAncestorContainer.className.indexOf('cooked') === -1) return;
+    // note: the ".contents" is here to prevent selection of the topic summary
+    if ($ancestor.closest('.topic-body > .contents').length === 0) return;
 
     var selectedText = Discourse.Utilities.selectedText();
     if (this.get('buffer') === selectedText) return;

--- a/app/assets/javascripts/discourse/views/post_view.js
+++ b/app/assets/javascripts/discourse/views/post_view.js
@@ -53,7 +53,7 @@ Discourse.PostView = Discourse.View.extend({
     }
 
     if (!Discourse.get('currentUser.enable_quoting')) return;
-    if ($(e.target).closest('.cooked').length === 0) return;
+    if ($(e.target).closest('.topic-body').length === 0) return;
 
     var qbc = this.get('controller.controllers.quoteButton');
     if (qbc) {

--- a/app/assets/stylesheets/application/topic-post.css.scss
+++ b/app/assets/stylesheets/application/topic-post.css.scss
@@ -89,11 +89,6 @@
   pre code {
     max-height: 690px;
   }
-  .post-menu-area {
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-  }
   @include hover {
     .gutter {
       .reply-new,
@@ -104,6 +99,7 @@
   }
 
   .gutter {
+    @include unselectable;
     .reply-new{
       .discourse-no-touch & {
         opacity: 0;
@@ -248,11 +244,13 @@
   }
 
   section.post-menu-area {
+    @include unselectable;
     background-color: $post_footer;
     border-top: 1px solid $inner_border;
     overflow: hidden;
     @include box-shadow(inset 0 -4px 4px -4px rgba($black, 0.14));
     nav.post-controls {
+      @include unselectable;
       float: right;
       padding: 0px;
       button {
@@ -390,9 +388,6 @@
     @include hover {
       background-color: mix($gray, $light_gray, 5%);
     }
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
   }
   .embedded-posts.bottom {
     @include border-radius-bottom(4px);
@@ -749,6 +744,7 @@
     }
   }
   .buttons {
+    @include unselectable;
     float: right;
     .btn {
       border: 0;

--- a/app/assets/stylesheets/foundation/mixins.scss
+++ b/app/assets/stylesheets/foundation/mixins.scss
@@ -160,3 +160,14 @@
       border: 1px solid $color;
   box-shadow: 0 0 5px $color;
 }
+
+//
+// --------------------------------------------------
+
+// Unselectable
+
+@mixin unselectable {
+  -webkit-user-select: none;
+     -moz-user-select: none;
+      -ms-user-select: none;
+}


### PR DESCRIPTION
This improve the quote-reply selection based on Harald Eilertsen's feedback on [meta](http://meta.discourse.org/t/quote-reply-gets-in-the-way/1495/67).

The previous _algorithm_ for detecting whether the selection was spanning two posts was based on the `.cooked` class which was too restrictive.

The new _algorithm_ instead bases its detection on the `.topic-body` class with a slight edge case for the first post (which has a summary).

I've also taken the liberty to refactor some CSS into the `unselectable` mixin and applied it wherever it improved the selection.

This has been tested on:
- [x] IE 10 (Windows 8)
- [x] FF 20 (Windows 8)
- [x] Chrome 26 (Windows 8)
- [x] Safari 6 (OS X)
- [x] Safari (iOS 6.3.1)
- [x] Chrome (iOS 6.3.1)

_Damn_! Browsers compatibility _is_ hard... :triumph:

Note: @coding-horror, I checked [caniuse](http://caniuse.com/#feat=user-select-none) in order to provide the minimum prefixes, but this feature is not well supported...
