### PR TITLE
Allow running discourse with prefix with passenger without requiring a symlink

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,3 +1,6 @@
 # This file is used by Rack-based servers to start the application.
 require ::File.expand_path('../config/environment',  __FILE__)
-run Discourse::Application
+map ActionController::Base.config.try(:relative_url_root) || "/" do
+  run Discourse::Application
+end
+


### PR DESCRIPTION
This allows running the application with a prefix without requiring a symlink in Apache htdocs. This does not affect running in thin.

This is done by BitNami (as we require it to allow changing prefix) and does not affect non-prefix stacks in anyway. We want to make as little changes to discourse that are not in the discourse repository as possible - therefore we to include it so we do not have to apply the patch.
