### PR TITLE
Prevent crashes during migration in certain PostgreSQL configurations

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,3 +5,8 @@
 require File.expand_path('../config/application', __FILE__)
 
 Discourse::Application.load_tasks
+
+# this prevents crashes when migrating a database in production in certain
+# PostgreSQL configuations when trying to create structure.sql
+Rake::Task["db:structure:dump"].clear if Rails.env.production?
+


### PR DESCRIPTION
This change prevents crashes when migrating a database in production in certain PostgreSQL configuations when trying to create structure.sql.

This happens because RoR calls pg_dump without passing password from config.yml, and is a common problem - for example:

http://stackoverflow.com/questions/12413306/error-when-doing-rake-dbmigrate-on-heroku
https://rails.lighthouseapp.com/projects/8994/tickets/5776-rake-dbstructuredump-fails-with-postgresql-90-and-ident-authentication

And also happens with BitNami, which uses password based authentication.

Generating structure.sql is needed for production anyway.
