### PR TITLE
FIX: setting min_topic_title_length is ignored

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -26,7 +26,7 @@ class Post < ActiveRecord::Base
   has_many :post_actions
 
   validates_presence_of :raw, :user_id, :topic_id
-  validates :raw, stripped_length: { in: SiteSetting.post_length }
+  validates :raw, stripped_length: { in: -> { SiteSetting.post_length } }
   validate :raw_quality
   validate :max_mention_validator
   validate :max_images_validator
@@ -40,8 +40,8 @@ class Post < ActiveRecord::Base
 
   scope :by_newest, order('created_at desc, id desc')
   scope :with_user, includes(:user)
-  scope :public_posts, lambda { joins(:topic).where('topics.archetype <> ?', [Archetype.private_message]) }
-  scope :private_posts, lambda { joins(:topic).where('topics.archetype = ?', Archetype.private_message) }
+  scope :public_posts, -> { joins(:topic).where('topics.archetype <> ?', Archetype.private_message) }
+  scope :private_posts, -> { joins(:topic).where('topics.archetype = ?', Archetype.private_message) }
 
   def self.hidden_reasons
     @hidden_reasons ||= Enum.new(:flag_threshold_reached, :flag_threshold_reached_again)

--- a/app/models/stripped_length_validator.rb
+++ b/app/models/stripped_length_validator.rb
@@ -2,7 +2,8 @@ class StrippedLengthValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     unless value.nil?
       stripped_length = value.strip.length
-      range = options[:in]
+      # the `in` parameter might be a lambda when the range is dynamic
+      range = options[:in].lambda? ? options[:in].call : options[:in]
       record.errors.add attribute, (options[:message] || I18n.t('errors.messages.too_short', count: range.begin)) unless
           stripped_length >= range.begin
       record.errors.add attribute, (options[:message] || I18n.t('errors.messages.too_long', count: range.end)) unless

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -27,7 +27,7 @@ class Topic < ActiveRecord::Base
 
   validate :title_quality
   validates_presence_of :title
-  validates :title, length: { in: SiteSetting.topic_title_length }
+  validate :title, -> { SiteSetting.topic_title_length.include? :length }
 
   serialize :meta_data, ActiveRecord::Coders::Hstore
 

--- a/spec/models/site_setting_spec.rb
+++ b/spec/models/site_setting_spec.rb
@@ -146,19 +146,14 @@ describe SiteSetting do
 
   describe 'topic_title_length' do
     it 'returns a range of min/max topic title length' do
-      SiteSetting.min_topic_title_length = 1
-      SiteSetting.max_topic_title_length = 2
-
-      SiteSetting.topic_title_length.should == (1..2)
+      SiteSetting.topic_title_length.should == 
+        (SiteSetting.defaults[:min_topic_title_length]..SiteSetting.defaults[:max_topic_title_length])
     end
   end
 
   describe 'post_length' do
     it 'returns a range of min/max post length' do
-      SiteSetting.min_post_length = 1
-      SiteSetting.max_post_length = 2
-
-      SiteSetting.post_length.should == (1..2)
+      SiteSetting.post_length.should == (SiteSetting.defaults[:min_post_length]..SiteSetting.defaults[:max_post_length])
     end
   end
 end


### PR DESCRIPTION
Meta: [Setting min_topic_title_length is ignored](http://meta.discourse.org/t/setting-min-topic-title-length-is-ignored/5737)

This fixes the issue reported by @sanderdatema regarding the `min_topic_title_length` setting.

The following code was actually being _parsed_ only **once**, during the first execution, and the `in` parameter was set to the default value of the `topic_title_length` and **never** to be changed.

``` ruby
validates :title, length: { in: SiteSetting.topic_title_length }
```

To fix it, we need to wrap it in a lambda:

``` ruby
validate :title, -> { SiteSetting.topic_title_length.include? :length }
```

I've also fixed the same issue for the `stripped_length` of the `raw` content of a `post` and updated the `SiteSetting` to prevent them from overriding the default value of several settings in test.
