### PR TITLE
update the list of i18n postgre stemmers

### DIFF
--- a/lib/search.rb
+++ b/lib/search.rb
@@ -89,11 +89,16 @@ module Search
 
   def self.current_locale_long
     case I18n.locale         # Currently-present in /conf/locales/* only, sorry :-( Add as needed
-      when :ru then 'russian'
+      when :da then 'danish'
+      when :de then 'german'
+      when :en then 'english'
+      when :es then 'spanish'
       when :fr then 'french'
+      when :it then 'italian'
       when :nl then 'dutch'
+      when :pt then 'portuguese'
       when :sv then 'swedish'
-      else 'english'
+      else 'simple' # use the 'simple' stemmer for other languages
     end
   end
 


### PR DESCRIPTION
Just updated the list of languages for fulltext search. And changed the default stemmer to "simple" instead of "english" for unsupported languages.

There are however a few languages left that Postgres doesn't support out of the box (e.g. Czech). Still, users can add this support to Postgres manually, and then they would like to switch the used fulltext language. Is there a way we could make this a separate site setting?
