### PR TITLE
fix title of "quote post" button

### DIFF
--- a/app/assets/javascripts/pagedown_custom.js
+++ b/app/assets/javascripts/pagedown_custom.js
@@ -4,7 +4,7 @@ window.PagedownCustom = {
   insertButtons: [
     {
       id: 'wmd-quote-post',
-      description: I18n.t("js.composer.quote_title"),
+      description: I18n.t("js.composer.quote_post_title"),
       execute: function() {
         // AWFUL but I can't figure out how to call a controller method from outside our app
         return Discourse.__container__.lookup('controller:composer').importQuote();

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -303,6 +303,7 @@ en:
       show_preview: 'show preview &raquo;'
       hide_preview: '&laquo; hide preview'
 
+      quote_post_title: "Quote whole post"
       bold_title: "Strong"
       bold_text: "strong text"
       italic_title: "Emphasis"
@@ -312,7 +313,7 @@ en:
       link_dialog_title: "Insert Hyperlink"
       link_optional_text: "optional title"
       quote_title: "Blockquote"
-      quote_text: "Quote whole post"
+      quote_text: "Blockquote"
       code_title: "Code Sample"
       code_text: "enter code here"
       image_title: "Image"

--- a/config/locales/client.es.yml
+++ b/config/locales/client.es.yml
@@ -303,7 +303,7 @@ es:
       link_dialog_title: "Insert Hyperlink"
       link_optional_text: "optional title"
       quote_title: "Blockquote"
-      quote_text: "Quote whole post"
+      quote_text: "Blockquote"
       code_title: "Code Sample"
       code_text: "enter code here"
       image_title: "Image"

--- a/config/locales/client.it.yml
+++ b/config/locales/client.it.yml
@@ -304,7 +304,7 @@ it:
       link_dialog_title: "Inserisci Link"
       link_optional_text: "titolo facoltativo"
       quote_title: "Blockquote"
-      quote_text: "Quote whole post"
+      quote_text: "Blockquote"
       code_title: "Code Sample"
       code_text: "inserisci il codice qui"
       image_title: "Immagine"


### PR DESCRIPTION
This is a PR regarding a recent commit by @codinghorror: https://github.com/discourse/discourse/commit/0d26c819a02aba9ab40dfcf24a120e328242fc17

Currently there are two "quote" buttons, both titled "Blockquote". I believe Jeff's intention was to have the first button titled "Quote whole post" and the other one unchanged. This PR reverts Jeff's changes and does that instead :)
