### PR TITLE
automatically resize images

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,9 @@ gem 'hiredis'
 # note: for image_optim to correctly work you need
 # sudo apt-get install -y advancecomp gifsicle jpegoptim libjpeg-progs optipng pngcrush
 gem 'image_optim'
+# note: for image_sorcery to correctly work you need
+# sudo apt-get install -y imagemagick
+gem 'image_sorcery'
 gem 'jquery-rails'
 gem 'minitest'
 gem 'multi_json'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -219,6 +219,7 @@ GEM
       in_threads (~> 1.1.1)
       progress (~> 2.4.0)
     image_size (1.1.1)
+    image_sorcery (1.1.0)
     in_threads (1.1.1)
     ipaddress (0.8.0)
     jasminerice (0.0.10)

--- a/lib/cooked_post_processor.rb
+++ b/lib/cooked_post_processor.rb
@@ -2,9 +2,9 @@
 # example, inserting the onebox content, or image sizes.
 
 require_dependency 'oneboxer'
+require_dependency 'image_optimizer'
 
 class CookedPostProcessor
-  require 'open-uri'
 
   def initialize(post, opts={})
     @dirty = false
@@ -34,58 +34,59 @@ class CookedPostProcessor
     images = @doc.search("img")
     return unless images.present?
 
+    images.each do |img|
+      src = img['src']
+      src = Discourse.base_url_no_prefix + src if src[0] == "/"
+
+      if src.present?
+
+        if img['width'].blank? || img['height'].blank?
+          w, h = get_size_from_image_sizes(src, @opts[:image_sizes]) || image_dimensions(src)
+
+          if w && h
+            img['width'] = w.to_s
+            img['height'] = h.to_s
+            @dirty = true
+          end
+        end
+
+        if src != img['src']
+          img['src'] = src
+          @dirty = true
+        end
+
+        convert_to_link!(img)
+        img['src'] = optimize_image(img)
+
+      end
+    end
+
     # Extract the first image from the first post and use it as the 'topic image'
     if @post.post_number == 1
       img = images.first
       @post.topic.update_column :image_url, img['src'] if img['src'].present?
     end
 
-    images.each do |img|
-      src = img['src']
-      src = Discourse.base_url_no_prefix + src if src[0] == "/"
-
-      if src.present? && (img['width'].blank? || img['height'].blank?)
-
-        w,h =
-          get_size_from_image_sizes(src, @opts[:image_sizes]) ||
-          image_dimensions(src)
-
-        if w && h
-          img['width'] = w.to_s
-          img['height'] = h.to_s
-          @dirty = true
-        end
-      end
-
-      if src.present?
-        if src != img['src']
-          img['src'] = src
-          @dirty = true
-        end
-        convert_to_link!(img)
-        img.set_attribute('src', optimize_image(src))
-      end
-
-    end
   end
 
-  def optimize_image(src)
-    # uri = get_image_uri(src)
-    # uri.open(read_timeout: 20) do |f|
-    #
-    # end
+  def optimize_image(img)
+    src = img["src"]
 
-    src
+    # supports only local uploads
+    return src if SiteSetting.enable_imgur? || SiteSetting.enable_s3_uploads?
+
+    width, height = img["width"].to_i, img["height"].to_i
+
+    ImageOptimizer.new(src).optimized_image_url(width, height)
   end
 
   def convert_to_link!(img)
     src = img["src"]
-    width = img["width"].to_i
-    height = img["height"].to_i
+    width, height = img["width"].to_i, img["height"].to_i
 
     return unless src.present? && width > SiteSetting.auto_link_images_wider_than
 
-    original_width, original_height  = get_size(src)
+    original_width, original_height = get_size(src)
 
     return unless original_width.to_i > width && original_height.to_i > height
 

--- a/spec/components/cooked_post_processor_spec.rb
+++ b/spec/components/cooked_post_processor_spec.rb
@@ -41,6 +41,7 @@ describe CookedPostProcessor do
       before do
         @topic = Fabricate(:topic)
         @post = Fabricate.build(:post_with_image_url, topic: @topic, user: @topic.user)
+        ImageSorcery.any_instance.stubs(:convert).returns(false)
         @cpp = CookedPostProcessor.new(@post, image_sizes: {'http://www.forumwarz.com/images/header/logo.png' => {'width' => 111, 'height' => 222}})
         @cpp.expects(:get_size).returns([111,222])
       end
@@ -63,6 +64,7 @@ describe CookedPostProcessor do
 
       before do
         FastImage.stubs(:size).returns([123, 456])
+        ImageSorcery.any_instance.stubs(:convert).returns(false)
         CookedPostProcessor.any_instance.expects(:image_dimensions).returns([123, 456])
         creator = PostCreator.new(user, raw: Fabricate.build(:post_with_images).raw, topic_id: topic.id)
         @post = creator.create
@@ -70,7 +72,7 @@ describe CookedPostProcessor do
 
       it "adds a topic image if there's one in the post" do
         @post.topic.reload
-        @post.topic.image_url.should == "/path/to/img.jpg"
+        @post.topic.image_url.should == "http://test.localhost/path/to/img.jpg"
       end
 
       it "adds the height and width to images that don't have them" do

--- a/spec/models/post_action_spec.rb
+++ b/spec/models/post_action_spec.rb
@@ -3,6 +3,10 @@ require_dependency 'post_destroyer'
 
 describe PostAction do
 
+  before do
+    ImageSorcery.any_instance.stubs(:convert).returns(false)
+  end
+
   it { should belong_to :user }
   it { should belong_to :post }
   it { should belong_to :post_action_type }

--- a/spec/models/post_alert_observer_spec.rb
+++ b/spec/models/post_alert_observer_spec.rb
@@ -3,6 +3,10 @@ require_dependency 'post_destroyer'
 
 describe PostAlertObserver do
 
+  before do
+    ImageSorcery.any_instance.stubs(:convert).returns(false)
+  end
+
   let!(:evil_trout) { Fabricate(:evil_trout) }
   let(:post) { Fabricate(:post) }
 

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -3,6 +3,10 @@ require_dependency 'post_destroyer'
 
 describe Post do
 
+  before do
+    ImageSorcery.any_instance.stubs(:convert).returns(false)
+  end
+
   it { should belong_to :user }
   it { should belong_to :topic }
   it { should validate_presence_of :raw }


### PR DESCRIPTION
This pull request adds support for **automatically** resizing (ie. reducing) images when cooking a post.

This uses `image_sorcery`, a wrapper aroung `Image Magick`, to create thumbnails of every images posted.

Uploaded images are _always_ resized whereas images linked within a post are _only_ resized when the `crawl_images?` site setting is enabled.

Cached images (ie. the ones that are downloaded from the links provided in posts) are stored in: `public/downloads/#{RailsMultisite::ConnectionManagement.current_db}` and are named after the first 16 characters of the SHA1 of their link.

Optimized images are stored & served from: `public/images/#{RailsMultisite::ConnectionManagement.current_db}`

I'll add some tests once this feature is validated by the core team.
