### PR TITLE
FIX: generate API key not working

### DIFF
--- a/app/assets/javascripts/admin/controllers/admin_api_controller.js
+++ b/app/assets/javascripts/admin/controllers/admin_api_controller.js
@@ -1,3 +1,0 @@
-Discourse.AdminApiController = Ember.Controller.extend({
-
-});

--- a/app/assets/javascripts/admin/models/admin_api.js
+++ b/app/assets/javascripts/admin/models/admin_api.js
@@ -11,6 +11,10 @@ Discourse.AdminApi = Discourse.Model.extend({
     Discourse.ajax(Discourse.getURL('/admin/api/generate_key'),{type: 'POST'}).then(function (result) {
       adminApi.set('key', result.key);
     });
+  },
+
+  regenerateKey: function(){
+    alert(Em.String.i18n('not_implemented'));
   }
 });
 

--- a/app/assets/javascripts/admin/templates/api.js.handlebars
+++ b/app/assets/javascripts/admin/templates/api.js.handlebars
@@ -1,7 +1,7 @@
 <!-- Hold off on localizing for a few days while I finalize this page -->
 <h3>API Information</h3>
 {{#if content.keyExists}}
-  <strong>Key:</strong> {{content.key}} <button {{action regenerateKey}}>Regenerate API Key</button>
+  <strong>Key:</strong> {{content.key}} <button {{action regenerateKey target="content"}}>Regenerate API Key</button>
   <p>Keep this key <strong>secret</strong>, all users that have it may create arbirary posts on the forum as any user.</p>
 {{else}}
   <p>Your API key will allow you to create and update topics using JSON calls.</p>


### PR DESCRIPTION
Meta: [Generate API key not working](http://meta.discourse.org/t/generate-api-key-not-working/5830)

This fixes a regression regarding the generation of the API key. There was an empty Controller that was messing it up.

I also created the `regenerateKey` function that will display an alert saying it isn't implemented yet.
