### PR TITLE
Fix for notifications not being shown when running with prefix

### DIFF
--- a/app/assets/javascripts/discourse/views/header_view.js
+++ b/app/assets/javascripts/discourse/views/header_view.js
@@ -54,7 +54,7 @@ Discourse.HeaderView = Discourse.View.extend({
   showNotifications: function() {
 
     var headerView = this;
-    Discourse.ajax('/notifications').then(function(result) {
+    Discourse.ajax(Discourse.getURL('/notifications')).then(function(result) {
       headerView.set('notifications', result.map(function(n) {
         return Discourse.Notification.create(n);
       }));


### PR DESCRIPTION
Related to

http://meta.discourse.org/t/things-that-break-after-moving-a-discourse-instance-to-a-sub-uri/5871
