### PR TITLE
Text Cleaner now removes all periods from the end of the title

### DIFF
--- a/app/assets/javascripts/discourse/views/topic_view.js
+++ b/app/assets/javascripts/discourse/views/topic_view.js
@@ -317,7 +317,14 @@ Discourse.TopicView = Discourse.View.extend(Discourse.Scrolling, {
         categoryName: newCategoryName
       });
       // save the modifications
-      topic.save();
+      topic.save().then(function(result){
+        // update the title if it has been changed (cleaned up) server-side
+        var title = result.basic_topic.fancy_title;
+        topic.setProperties({
+          title: title,
+          fancy_title: title
+        });
+      });
       // close editing mode
       this.set('editingTopic', false);
     }

--- a/lib/text_cleaner.rb
+++ b/lib/text_cleaner.rb
@@ -10,7 +10,7 @@ class TextCleaner
       deduplicate_question_marks: SiteSetting.title_prettify,
       replace_all_upper_case: SiteSetting.title_prettify,
       capitalize_first_letter: SiteSetting.title_prettify,
-      remove_unnecessary_period: SiteSetting.title_prettify,
+      remove_all_periods_from_the_end: SiteSetting.title_prettify,
       remove_extraneous_space: SiteSetting.title_prettify && SiteSetting.default_locale == "en",
       fixes_interior_spaces: true,
       strip_whitespaces: true
@@ -30,8 +30,8 @@ class TextCleaner
     text.tr!('A-Z', 'a-z') if opts[:replace_all_upper_case] && (text =~ /[A-Z]+/) && (text == text.upcase)
     # Capitalize first letter
     text.sub!(/\A([a-z])/) { |first| first.capitalize } if opts[:capitalize_first_letter]
-    # Remove unnecessary period at the end
-    text.sub!(/([^.])\.(\s*)\z/, '\1\2') if opts[:remove_unnecessary_period]
+    # Remove unnecessary periods at the end
+    text.sub!(/([^.])\.+(\s*)\z/, '\1\2') if opts[:remove_all_periods_from_the_end]
     # Remove extraneous space before the end punctuation
     text.sub!(/\s+([!?]\s*)\z/, '\1') if opts[:remove_extraneous_space]
     # Fixes interior spaces

--- a/spec/components/text_cleaner_spec.rb
+++ b/spec/components/text_cleaner_spec.rb
@@ -70,26 +70,24 @@ describe TextCleaner do
 
   end
 
-  context "period at the end" do
+  context "periods at the end" do
 
-    let(:with_period) { "oops." }
-    let(:with_periods) { "oops..." }
+    let(:with_one_period) { "oops." }
+    let(:with_several_periods) { "oops..." }
     let(:without_period) { "oops" }
 
-    it "ignores unnecessary period at the end by default" do
-      TextCleaner.clean(with_period).should == with_period
+    it "ignores unnecessary periods at the end by default" do
+      TextCleaner.clean(with_one_period).should == with_one_period
+      TextCleaner.clean(with_several_periods).should == with_several_periods
     end
 
-    it "removes unnecessary period at the end when enabled" do
-      TextCleaner.clean(with_period, remove_unnecessary_period: true).should == without_period
-    end
-
-    it "keeps ellipsis when enabled" do
-      TextCleaner.clean(with_periods, remove_unnecessary_period: true).should == with_periods
+    it "removes unnecessary periods at the end when enabled" do
+      TextCleaner.clean(with_one_period, remove_all_periods_from_the_end: true).should == without_period
+      TextCleaner.clean(with_several_periods, remove_all_periods_from_the_end: true).should == without_period
     end
 
     it "keeps trailing whitespaces when enabled" do
-      TextCleaner.clean(with_periods + " ", remove_unnecessary_period: true).should == with_periods + " "
+      TextCleaner.clean(with_several_periods + " ", remove_all_periods_from_the_end: true).should == without_period + " "
     end
 
   end


### PR DESCRIPTION
As per @coding-horror [comments](https://github.com/discourse/discourse/pull/684#issuecomment-16538221) on #684, this updates `Text Cleaner` to remove **all** periods from the end of the title.

_[should have been in #684]_ I've also updated the `topic_view` so that it takes into account any title modifications made server-side (when you edit the title of the topic using the pencil _button_)
