### PR TITLE
FIX: optimized images url when using a CDN

### DIFF
--- a/lib/image_optimizer.rb
+++ b/lib/image_optimizer.rb
@@ -90,7 +90,7 @@ private
   end
 
   def optimized_url
-    @optimized_url ||= Discourse::base_uri + "/images/#{RailsMultisite::ConnectionManagement.current_db}/#{file_name(cached_path)}"
+    @optimized_url ||= Discourse.base_url_no_prefix + "/images/#{RailsMultisite::ConnectionManagement.current_db}/#{file_name(cached_path)}"
   end
 
 end


### PR DESCRIPTION
The change made to `image_optimizer.rb` provides compatibility with Rails when using a CDN defined in the `config.action_controller.asset_host` setting.

I've also updated `cooked_post_processor.rb` so that it takes into account the _eventually_ defined CDN setting when trying to do its magic lightbox treatment.

/cc @SamSaffron & @Supermathie
