### PR TITLE
FIX: Where is a user notified that one of their actions has been throttled for the day?

### DIFF
--- a/app/assets/javascripts/discourse/models/action_summary.js
+++ b/app/assets/javascripts/discourse/models/action_summary.js
@@ -57,7 +57,7 @@ Discourse.ActionSummary = Discourse.Model.extend({
 
     // Create our post action
     var actionSummary = this;
-    return Discourse.ajax({
+    Discourse.ajax({
       url: Discourse.getURL("/post_actions"),
       type: 'POST',
       data: {
@@ -67,7 +67,8 @@ Discourse.ActionSummary = Discourse.Model.extend({
       }
     }).then(null, function (error) {
       actionSummary.removeAction();
-      return $.parseJSON(error.responseText).errors;
+      var message = $.parseJSON(error.responseText).errors;
+      bootbox.alert(message);
     });
   },
 


### PR DESCRIPTION
Meta: [Where is a user notified that one of their actions has been throttled for the day?](http://meta.discourse.org/t/where-is-a-user-notified-that-one-of-their-actions-has-been-throttled-for-the-day/6027)

This will display a nag whenever a user is getting his actions throttled:

![image](https://f.cloud.github.com/assets/362783/404489/fe7e93e4-a94a-11e2-9271-6122fc0469b5.png)
