### PR TITLE
Fixing Amazon uploads to not be hardcoded to https

### DIFF
--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -57,7 +57,7 @@ class Upload < ActiveRecord::Base
                                   public: true,
                                   content_type: file.content_type)
     upload.width, upload.height = ImageSizer.resize(*image_info.size)
-    upload.url = "https://#{SiteSetting.s3_upload_bucket}.s3.amazonaws.com#{path}/#{remote_filename}"
+    upload.url = "//#{SiteSetting.s3_upload_bucket}.s3.amazonaws.com#{path}/#{remote_filename}"
 
     upload.save
 


### PR DESCRIPTION
Amazon S3 uploads are currently hardcoded to use https, where they should probably use whatever protocol the rest of the site is using. Removing the protocol and just using "//" links should accomplish that.
