### PR TITLE
ignore some more runy management files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,5 +79,8 @@ chef/tmp/*
 # exclude our git version file for now
 config/version.rb
 
-# ignore the Ruby Version manager (rvm) file
+# ignore the Ruby Version manager (rvm) file and other ruby managers
 .rvmrc
+.ruby-version
+.ruby-gemset
+.rbenv


### PR DESCRIPTION
it has become more standard that RVM now recommends using a non-`.rvmrc` file, and other ruby managers seem to follow convention of using the `.ruby-version` notation for the ruby binary selection.
rvm adds the use of `.ruby-gemset` for gemset selection.
