### PR TITLE
Add '+' and '-' support to the autocomplete plugin

### DIFF
--- a/app/assets/javascripts/discourse/components/autocomplete.js
+++ b/app/assets/javascripts/discourse/components/autocomplete.js
@@ -294,6 +294,10 @@ $.fn.autocomplete = function(options) {
           term = me.val().substring(completeStart + (options.key ? 1 : 0), caretPosition);
           if (e.which >= 48 && e.which <= 90) {
             term += String.fromCharCode(e.which);
+          } else if (e.which === 187) {
+            term += "+";
+          } else if (e.which === 189) {
+            term += "-";
           } else {
             if (e.which !== 8) {
               term += ",";


### PR DESCRIPTION
This prevents the autocomplete from closing when the user is trying to type the :+1: (`:+1:`) and :-1: (`:-1:`) emojis.
