### PR TITLE
improve & refactor quote reply

### DIFF
--- a/app/assets/javascripts/discourse/controllers/quote_button_controller.js
+++ b/app/assets/javascripts/discourse/controllers/quote_button_controller.js
@@ -29,17 +29,15 @@ Discourse.QuoteButtonController = Discourse.Controller.extend({
 
     @method selectText
   **/
-  selectText: function(e) {
+  selectText: function(postId) {
     // anonymous users cannot "quote-reply"
     if (!Discourse.get('currentUser')) return;
     // don't display the "quote-reply" button if we can't create a post
     if (!this.get('controllers.topic.content.can_create_post')) return;
 
     var selection = window.getSelection();
-
     // no selections
     if (selection.rangeCount === 0) return;
-
     // retrieve the selected range
     var range = selection.getRangeAt(0),
         cloned = range.cloneRange(),
@@ -51,9 +49,17 @@ Discourse.QuoteButtonController = Discourse.Controller.extend({
 
     var selectedText = Discourse.Utilities.selectedText();
     if (this.get('buffer') === selectedText) return;
-    if (this.get('lastSelected') === selectedText) return;
 
-    this.set('post', e.context);
+    // we need to retrieve the post data from the posts collection in the topic controller
+    var posts = this.get('controllers.topic.posts'),
+        length = posts.length,
+        post;
+
+    for (var p = 0; p < length; p++) {
+      if (posts[p].id === postId) { post = posts[p]; break; }
+    }
+
+    this.set('post', post);
     this.set('buffer', selectedText);
 
     // collapse the range at the beginning of the selection
@@ -117,6 +123,18 @@ Discourse.QuoteButtonController = Discourse.Controller.extend({
     }
     this.set('buffer', '');
     return false;
+  },
+
+  /**
+    Deselect the currently selected text
+
+    @method deselectText
+  **/
+  deselectText: function() {
+    // clear selected text
+    window.getSelection().removeAllRanges();
+    // clean up the buffer
+    this.set('buffer', '');
   }
 
 });

--- a/app/assets/javascripts/discourse/views/post_view.js
+++ b/app/assets/javascripts/discourse/views/post_view.js
@@ -43,34 +43,19 @@ Discourse.PostView = Discourse.View.extend({
     this.set('context', this.get('content'));
   },
 
-  mouseDown: function(e) {
-    this.set('isMouseDown', true);
-  },
-
   mouseUp: function(e) {
     if (this.get('controller.multiSelect') && (e.metaKey || e.ctrlKey)) {
       this.toggleProperty('post.selected');
     }
-
-    if (!Discourse.get('currentUser.enable_quoting')) return;
-    if ($(e.target).closest('.topic-body').length === 0) return;
-
-    var qbc = this.get('controller.controllers.quoteButton');
-    if (qbc) {
-      e.context = this.get('post');
-      qbc.selectText(e);
-    }
-
-    this.set('isMouseDown', false);
   },
 
-  selectText: (function() {
+  selectText: function() {
     return this.get('post.selected') ? Em.String.i18n('topic.multi_select.selected', { count: this.get('controller.selectedCount') }) : Em.String.i18n('topic.multi_select.select');
-  }).property('post.selected', 'controller.selectedCount'),
+  }.property('post.selected', 'controller.selectedCount'),
 
-  repliesHidden: (function() {
+  repliesHidden: function() {
     return !this.get('repliesShown');
-  }).property('repliesShown'),
+  }.property('repliesShown'),
 
   // Click on the replies button
   showReplies: function() {
@@ -262,30 +247,5 @@ Discourse.PostView = Discourse.View.extend({
     if (controller && controller.postRendered) {
       controller.postRendered(post);
     }
-
-    // make the selection work under iOS
-    // "selectionchange" event is only supported in IE, Safari & Chrome
-    var postView = this;
-    $(document).on('selectionchange', function(e) {
-      // quoting as been disabled by the user
-      if (!Discourse.get('currentUser.enable_quoting')) return;
-      // there is no need to handle this event when the mouse is down
-      if (postView.get('isMouseDown')) return;
-      // find out whether we currently are selecting inside a post
-      var closestPosts = $(window.getSelection().anchorNode).closest('.topic-post');
-      if (closestPosts.length === 0) return;
-      // this event is bound for every posts in the topic, but is triggered on "document"
-      // we should therefore filter the event to only the right post
-      if (closestPosts[0].id !== postView.elementId) return;
-      var qbc = postView.get('controller.controllers.quoteButton');
-      if (qbc) {
-        e.context = postView.get('post');
-        qbc.selectText(e);
-      }
-    });
-  },
-
-  willDestroyElement: function() {
-    $(document).off('selectionchange');
   }
 });


### PR DESCRIPTION
Improving & refactoring the `quote reply` pop-up a bit according to @SamSaffron's suggestion [on meta](http://meta.discourse.org/p/14218/1995).

I ended up removing all selection related code from the `post` controller and putting it into both `quote reply` controller and view.

The only issue I had from refactoring this code was that I had to find out which post was currently being selected. To find it out I extracted the `post-id` data from the nearest `.boxed` element and used it to find the matching post in the `controllers.topic.posts` collection.

I also fixed **2** bugs I discovered while testing:
- totally weird behaviour when searching for something using browser's native search
- the selection was not cleared when clicking on the arrow below the first post to toggle topic details.
