### PR TITLE
force the browse dialog to only accept images...

### DIFF
--- a/app/assets/javascripts/discourse/templates/image_selector.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/image_selector.js.handlebars
@@ -10,7 +10,7 @@
 {{#if view.localSelected}}
 <div class='modal-body'>
   <form>
-    <input type="file" name="file" id="filename-input" value="browse"><br>
+    <input type="file" name="file" id="filename-input" value="browse" accept="image/*"><br>
     <span class='description'>{{i18n image_selector.local_tip}}</span> <br>
   </form>
 </div>


### PR DESCRIPTION
...on image upload.

This won't prevent the issue reported in #773 but it will at least provide a better experience for users as only images will show up in the dialog.

More information on the `accept` attribute available on [wufoo](http://www.wufoo.com/html5/attributes/07-accept.html).

**Note:** IE9 will take the attribute but won't filter.
