### PR TITLE
flash draft status when requirements are not met for new users

### DIFF
--- a/app/assets/javascripts/discourse/models/composer.js
+++ b/app/assets/javascripts/discourse/models/composer.js
@@ -459,6 +459,14 @@ Discourse.Composer = Discourse.Model.extend({
       });
   },
 
+  flashDraftStatusForNewUser: function() {
+    var $draftStatus = $('#draft-status');
+    if (Discourse.get('currentUser.trust_level') === 0) {
+      $draftStatus.toggleClass('flash', true);
+      setTimeout(function() { $draftStatus.removeClass('flash'); }, 250);
+    }
+  },
+
   updateDraftStatus: function() {
     var $title = $('#reply-title'),
         $reply = $('#wmd-input');
@@ -467,6 +475,7 @@ Discourse.Composer = Discourse.Model.extend({
     if ($title.is(':focus')) {
       var titleDiff = this.get('missingTitleCharacters');
       if (titleDiff > 0) {
+        this.flashDraftStatusForNewUser();
         return this.set('draftStatus', Em.String.i18n('composer.min_length.need_more_for_title', { n: titleDiff }));
       }
     // 'reply' is focused

--- a/app/assets/javascripts/discourse/templates/composer.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/composer.js.handlebars
@@ -50,7 +50,7 @@
             </div>
             {{#if Discourse.currentUser}}
                <a href="#" {{action togglePreview target="controller"}} class='toggle-preview'>{{{content.toggleText}}}</a>
-               <div class='draft-status'></div>
+               <div id='draft-status'></div>
                {{#if view.loadingImage}}
                 <div id="image-uploading">
                   {{i18n image_selector.uploading_image}} {{view.uploadProgress}}% <a id="cancel-image-upload">{{i18n cancel}}</a>

--- a/app/assets/javascripts/discourse/views/composer_view.js
+++ b/app/assets/javascripts/discourse/views/composer_view.js
@@ -27,7 +27,7 @@ Discourse.ComposerView = Discourse.View.extend({
   }.property('content.composeState'),
 
   draftStatus: function() {
-    this.$('.draft-status').text(this.get('content.draftStatus') || "");
+    $('#draft-status').text(this.get('content.draftStatus') || "");
   }.observes('content.draftStatus'),
 
   // Disable fields when we're loading

--- a/app/assets/stylesheets/application/compose.css.scss
+++ b/app/assets/stylesheets/application/compose.css.scss
@@ -96,7 +96,7 @@
   .requirements-not-met {
     background-color: rgba(255, 0, 0, 0.12);
   }
-  .toggle-preview, .draft-status, #image-uploading {
+  .toggle-preview, #draft-status, #image-uploading {
     position: absolute;
     bottom: -31px;
     margin-top: 0px;
@@ -110,9 +110,12 @@
     font-size: 12px;
     color: darken($gray, 40);
   }
-  .draft-status {
+  #draft-status {
     right: 51%;
     color: lighten($black, 60);
+    &.flash {
+      color: lighten($red, 20);
+    }
   }
   @include transition(height 0.4s ease);
   width: 100%;
@@ -219,7 +222,7 @@
     margin-right: auto;
     float: none;
   }
-  
+
   // When the post is new (new topic) the sizings are different
   &.edit-title {
     &.open {

--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -9,8 +9,9 @@ class CurrentUserSerializer < BasicUserSerializer
              :moderator?,
              :reply_count,
              :topic_count,
-             :enable_quoting, 
-             :external_links_in_new_tab
+             :enable_quoting,
+             :external_links_in_new_tab,
+             :trust_level
 
   # we probably want to move this into site, but that json is cached so hanging it off current user seems okish
 


### PR DESCRIPTION
Meta: [Title length restrictions are not obvious](http://meta.discourse.org/t/title-length-restrictions-are-not-obvious/6152)

Trying the suggestion from @coding-horror to flash the draft status in red while the requirements are not met for **new** **users** **_only**_.

![flash](https://f.cloud.github.com/assets/362783/435084/f1fd232c-af9b-11e2-924f-b50478940ff0.gif)

_(EDIT: I don't know why, but the .gif is 2x as fast...)_

Notes:
- This is only flashing for the title (but this behavior can _easily_ be added to the reply)
- I changed the `draft-status` from a `class` to an `id` for better CSS selection performance
- I added the `trust_level` to the `CurrentUserSerializer` so that I can know if the user is new
