### PR TITLE
FIX: right click on selection deselects

### DIFF
--- a/app/assets/javascripts/discourse/views/quote_button_view.js
+++ b/app/assets/javascripts/discourse/views/quote_button_view.js
@@ -48,7 +48,8 @@ Discourse.QuoteButtonView = Discourse.View.extend({
     .on("mousedown.quote-button", function(e) {
       view.set('isMouseDown', true);
       if ($(e.target).hasClass('quote-button') || $(e.target).hasClass('create')) return;
-      controller.deselectText();
+      // deselects only when the user left-click
+      if (e.which === 1) controller.deselectText();
     })
     .on('mouseup.quote-button', function(e) {
       view.selectText(e.target, controller);


### PR DESCRIPTION
Meta: [Right click on selection deselects](http://meta.discourse.org/t/right-click-on-selection-deselects/6215)

This prevents the selection from being cleared when the user is right-clicking it to bring up the context menu.
