### PR TITLE
Fixed combo boxes display in edit history

### DIFF
--- a/app/assets/stylesheets/application/history.css.scss
+++ b/app/assets/stylesheets/application/history.css.scss
@@ -29,4 +29,8 @@
       position: 0 4px;
     };
   }
+  select {
+    height: auto;
+	width: auto;
+  }
 }


### PR DESCRIPTION
Combo boxes we're displaying incorrectly at edit history, width would cut-off larger names and height wouldn't let you see what was selected.
