### PR TITLE
Fix to add Slideshare's URL to oneboxer's whitelist

### DIFF
--- a/lib/oneboxer/whitelist.rb
+++ b/lib/oneboxer/whitelist.rb
@@ -3,6 +3,7 @@ module Oneboxer
   module Whitelist
     def self.entries
       [
+       Entry.new(/^https?:\/\/(?:www\.)?slideshare\.net\/.+/),
        Entry.new(/^https?:\/\/(?:www\.)?rottentomatoes\.com\/.+/),
        Entry.new(/^https?:\/\/(?:www\.)?cnn\.com\/.+/),
        Entry.new(/^https?:\/\/(?:www\.)?washingtonpost\.com\/.+/),


### PR DESCRIPTION
I forgot to add it before. 
