### PR TITLE
FIX: [security bug] XHR check bypass

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -38,7 +38,6 @@ class ApplicationController < ActionController::Base
 
   # Some exceptions
   class RenderEmpty < Exception; end
-  class NotLoggedIn < Exception; end
 
   # Render nothing unless we are an xhr request
   rescue_from RenderEmpty do
@@ -246,10 +245,7 @@ class ApplicationController < ActionController::Base
     def check_xhr
       unless (controller_name == 'forums' || controller_name == 'user_open_ids')
         # bypass xhr check on PUT / POST / DELETE provided api key is there, otherwise calling api is annoying
-        if !request.get? && request["api_key"]
-          return
-        end
-
+        return if !request.get? && request["api_key"] && SiteSetting.api_key_valid?(request["api_key"])
         raise RenderEmpty.new unless ((request.format && request.format.json?) || request.xhr?)
       end
     end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
-describe 'api' do 
-  before do 
+describe 'api' do
+  before do
     fake_key = SecureRandom.hex(32)
     SiteSetting.stubs(:api_key).returns(fake_key)
   end
@@ -11,26 +11,28 @@ describe 'api' do
       Fabricate(:user)
     end
 
-    let(:post) do 
+    let(:post) do
       Fabricate(:post)
     end
-    
+
     # choosing an arbitrarily easy to mock trusted activity
     it 'allows users with api key to bookmark posts' do
-      PostAction.expects(:act).with(user,post,PostActionType.types[:bookmark]).returns(true)
-      put :bookmark, bookmarked: "true" ,post_id: post.id , api_key: SiteSetting.api_key, api_username: user.username
+      PostAction.expects(:act).with(user, post, PostActionType.types[:bookmark]).once
+      put :bookmark, bookmarked: "true", post_id: post.id, api_key: SiteSetting.api_key, api_username: user.username, format: :json
     end
 
     it 'disallows phonies to bookmark posts' do
-      lambda do 
-        put :bookmark, bookmarked: "true" ,post_id: post.id , api_key: SecureRandom.hex(32), api_username: user.username
+      PostAction.expects(:act).with(user, post, PostActionType.types[:bookmark]).never
+      lambda do
+        put :bookmark, bookmarked: "true", post_id: post.id, api_key: SecureRandom.hex(32), api_username: user.username, format: :json
       end.should raise_error Discourse::NotLoggedIn
     end
-    
+
     it 'disallows blank api' do
       SiteSetting.stubs(:api_key).returns("")
-      lambda do 
-        put :bookmark, bookmarked: "true" ,post_id: post.id , api_key: "", api_username: user.username
+      PostAction.expects(:act).with(user, post, PostActionType.types[:bookmark]).never
+      lambda do
+        put :bookmark, bookmarked: "true", post_id: post.id, api_key: "", api_username: user.username, format: :json
       end.should raise_error Discourse::NotLoggedIn
     end
   end


### PR DESCRIPTION
This fixes the _security_ bug reported in meta: [Security bug: XHR check bypass](http://meta.discourse.org/t/security-bug-xhr-check-bypass/6237)

This will **only** bypass the XHR check on `PUT`/`POST`/`DELETE` provided an api key is there **and** is valid.
