### PR TITLE
FIX: Shift+Click to select text does not work in topics

### DIFF
--- a/app/assets/javascripts/discourse/controllers/quote_button_controller.js
+++ b/app/assets/javascripts/discourse/controllers/quote_button_controller.js
@@ -45,7 +45,10 @@ Discourse.QuoteButtonController = Discourse.Controller.extend({
 
     // don't display the "quote reply" button if you select text spanning two posts
     // note: the ".contents" is here to prevent selection of the topic summary
-    if ($ancestor.closest('.topic-body > .contents').length === 0) return;
+    if ($ancestor.closest('.topic-body > .contents').length === 0) {
+      this.set('buffer', '');
+      return;
+    }
 
     var selectedText = Discourse.Utilities.selectedText();
     if (this.get('buffer') === selectedText) return;

--- a/app/assets/javascripts/discourse/views/quote_button_view.js
+++ b/app/assets/javascripts/discourse/views/quote_button_view.js
@@ -49,7 +49,8 @@ Discourse.QuoteButtonView = Discourse.View.extend({
       view.set('isMouseDown', true);
       if ($(e.target).hasClass('quote-button') || $(e.target).hasClass('create')) return;
       // deselects only when the user left-click
-      if (e.which === 1) controller.deselectText();
+      // this also allow anyone to `extend` their selection using a shift+click
+      if (e.which === 1 && !e.shiftKey) controller.deselectText();
     })
     .on('mouseup.quote-button', function(e) {
       view.selectText(e.target, controller);


### PR DESCRIPTION
Meta: [Shift-Click to Select Text Does Not Work in Topics](http://meta.discourse.org/t/shift-click-to-select-text-does-not-work-in-topics/6238)

This allows users to _extend_ their selection using <KBD>shift</KBD>+click like so:

![shift-click](https://f.cloud.github.com/assets/362783/442038/458a6d44-b134-11e2-99e2-1bfe33b9b927.gif)

I also corrected a bug where the quote reply button would still be displayed when the user would _extend_ her selection using the keyboard (eg. <KBD>shift</KBD>+<KBD>→</KBD>) or the aforementioned technique:

![hide-quote-reply-button](https://f.cloud.github.com/assets/362783/442069/5e742e84-b135-11e2-8d2f-2f896a914066.gif)
