### PR TITLE
FIX: shift+click on links

### DIFF
--- a/app/assets/javascripts/discourse.js
+++ b/app/assets/javascripts/discourse.js
@@ -129,7 +129,7 @@ Discourse = Ember.Application.createWithMixins({
     });
 
     $('#main').on('click.discourse', 'a', function(e) {
-      if (e.isDefaultPrevented() || e.metaKey || e.ctrlKey) return;
+      if (e.isDefaultPrevented() || e.shiftKey || e.metaKey || e.ctrlKey) return;
 
       var $currentTarget = $(e.currentTarget);
       var href = $currentTarget.attr('href');

--- a/app/assets/javascripts/discourse/components/click_track.js
+++ b/app/assets/javascripts/discourse/components/click_track.js
@@ -68,7 +68,7 @@ Discourse.ClickTrack = {
     }
 
     // if they want to open in a new tab, do an AJAX request
-    if (e.metaKey || e.ctrlKey || e.which === 2) {
+    if (e.shiftKey || e.metaKey || e.ctrlKey || e.which === 2) {
       Discourse.ajax(Discourse.getURL("/clicks/track"), {
         data: {
           url: href,

--- a/spec/javascripts/components/click_track_spec.js
+++ b/spec/javascripts/components/click_track_spec.js
@@ -152,25 +152,30 @@ describe("Discourse.ClickTrack", function() {
       spyOn(window, 'open');
     });
 
-    it("opens in a new tab when pressing alt", function() {
-      clickEvent.metaKey = true;
+    var expectItOpensInANewTab = function() {
       expect(track(clickEvent)).toBe(false);
       expect(Discourse.ajax).toHaveBeenCalled();
       expect(window.open).toHaveBeenCalledWith('http://www.google.com', '_blank');
+    };
+
+    it("opens in a new tab when pressing shift", function() {
+      clickEvent.shiftKey = true;
+      expectItOpensInANewTab();
+    });
+
+    it("opens in a new tab when pressing meta", function() {
+      clickEvent.metaKey = true;
+      expectItOpensInANewTab();
     });
 
     it("opens in a new tab when pressing ctrl", function() {
       clickEvent.ctrlKey = true;
-      expect(track(clickEvent)).toBe(false);
-      expect(Discourse.ajax).toHaveBeenCalled();
-      expect(window.open).toHaveBeenCalledWith('http://www.google.com', '_blank');
+      expectItOpensInANewTab();
     });
 
     it("opens in a new tab when middle clicking", function() {
       clickEvent.which = 2;
-      expect(track(clickEvent)).toBe(false);
-      expect(Discourse.ajax).toHaveBeenCalled();
-      expect(window.open).toHaveBeenCalledWith('http://www.google.com', '_blank');
+      expectItOpensInANewTab();
     });
 
   });


### PR DESCRIPTION
_This follows the discussion with @SamSaffron on #792._

Default browser's behavior when <kbd>shift</kbd>+clicking was messed up.

This adds the <kbd>shift</kbd> key to the list of click modifiers in both `click_track` and `discourse`.

Also updated & refactored a bit the `click_track_spec`.
