### PR TITLE
Allow clockwork to be run using the daemons gem

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -3,7 +3,7 @@ require 'rails/all'
 require 'redis-store' # HACK
 
 # Plugin related stuff
-require './lib/discourse_plugin_registry'
+require_relative '../lib/discourse_plugin_registry'
 
 if defined?(Bundler)
   # If you precompile assets before deploying to production, use this line


### PR DESCRIPTION
Clockwork ships with a helpful clockworkd executable, which uses the
daemons gem to daemonize clockwork. This provides an easy way to
start/stop/restart a deamonized clockwork process when deploying to
production servers manually. However, the daemons gem unfortunately does
funky things to the working directory that was preventing the
application from booting. Changing this `require` line to using
`require_relative` solves the issue and makes Discourse easier for Rails
devs to deploy to their own VPSes using, say, Capistrano.

Signed-off-by: David Celis me@davidcel.is
