### PR TITLE
removes rounded corners on images in posts

### DIFF
--- a/app/assets/stylesheets/application/topic-post.css.scss
+++ b/app/assets/stylesheets/application/topic-post.css.scss
@@ -527,10 +527,6 @@
     }
     img {
       max-width: 100%;
-      border-radius: 4px;
-      webkit-border-radius: 4px;
-      ms-border-radius: 4px;
-      moz-border-radius: 4px;
     }
     .topic-body {
       position: relative;


### PR DESCRIPTION
Meta: [Why did my image get rounded corners?](http://meta.discourse.org/t/why-did-my-image-get-rounded-corners/6310)

This removes the rounded corners applied on images in posts in the _default_ theme.

Other forums might override it with:

``` css
.topic-post article.boxed img {
  border-radius: 4px;
}
```
