### PR TITLE
FIX: when topic is closed, you can still invite someone to reply

### DIFF
--- a/app/assets/javascripts/discourse/views/topic_footer_buttons_view.js
+++ b/app/assets/javascripts/discourse/views/topic_footer_buttons_view.js
@@ -24,9 +24,14 @@ Discourse.TopicFooterButtonsView = Ember.ContainerView.extend({
 
         // We hide some controls from private messages
         if (this.get('topic.can_invite_to')) {
-          this.addObject(Discourse.ButtonView.create({
+          this.addObject(Discourse.ButtonView.createWithMixins({
             textKey: 'topic.invite_reply.title',
             helpKey: 'topic.invite_reply.help',
+            attributeBindings: ['disabled'],
+
+            disabled: function(){
+              return this.get('controller.content.archived') || this.get('controller.content.closed');
+            }.property('controller.content.archived', 'controller.content.closed'),
 
             renderIcon: function(buffer) {
               buffer.push("<i class='icon icon-group'></i>");


### PR DESCRIPTION
Meta: [When topic is closed, you can still invite someone to reply](http://meta.discourse.org/t/when-topic-is-closed-you-can-still-invite-someone-to-reply/6292)

This disables the `invite` button when the topic is **archived** or **closed**:

![image](https://f.cloud.github.com/assets/362783/451860/953812ca-b2be-11e2-998c-32c9a6de179e.png)
