### PR TITLE
Add a clear pin link in the list topics view

### DIFF
--- a/app/assets/javascripts/discourse/controllers/list_topics_controller.js
+++ b/app/assets/javascripts/discourse/controllers/list_topics_controller.js
@@ -53,6 +53,11 @@ Discourse.ListTopicsController = Discourse.ObjectController.extend({
     topic.toggleStar();
   },
 
+  // clear a pinned topic
+  clearPin: function(topic) {
+    topic.clearPin();
+  },
+
   toggleRankDetails: function() {
     this.toggleProperty('rankDetailsVisible');
   },

--- a/app/assets/javascripts/discourse/models/topic.js
+++ b/app/assets/javascripts/discourse/models/topic.js
@@ -371,13 +371,17 @@ Discourse.Topic = Discourse.Model.extend({
   },
 
   hasExcerpt: function() {
-    return this.get('excerpt') && this.get('excerpt').length > 0;
-  }.property('excerpt'),
+    return this.get('pinned') && this.get('excerpt') && this.get('excerpt').length > 0;
+  }.property('pinned', 'excerpt'),
 
   excerptTruncated: function() {
     var e = this.get('excerpt');
     return( e && e.substr(e.length - 8,8) === '&hellip;' );
-  }.property('excerpt')
+  }.property('excerpt'),
+
+  canClearPin: function() {
+    return this.get('pinned') && (this.get('last_read_post_number') === this.get('highest_post_number'));
+  }.property('pinned', 'last_read_post_number', 'highest_post_number')
 });
 
 Discourse.Topic.reopenClass({

--- a/app/assets/javascripts/discourse/templates/list/topic_list_item.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/list/topic_list_item.js.handlebars
@@ -29,11 +29,14 @@
       <a href="{{lastReadUrl}}" class='badge new-posts badge-notification' title='{{i18n topic.new}}'><i class='icon icon-asterisk'></i></a>
     {{/if}}
 
-    {{#if excerpt}}
+    {{#if hasExcerpt}}
       <div class="topic-excerpt">
         {{excerpt}}
         {{#if excerptTruncated}}
-          <a href="{{lastReadUrl}}">{{i18n read_more}}</a>
+          {{#unless canClearPin}}<a href="{{lastReadUrl}}">{{i18n read_more}}</a>{{/unless}}
+        {{/if}}
+        {{#if canClearPin}}
+          <a href="#" {{action clearPin this target="controller"}} title="{{unbound i18n topic.clear_pin.help}}">{{i18n topic.clear_pin.title}}</a>
         {{/if}}
       </div>
     {{/if}}


### PR DESCRIPTION
Meta: [Idea: Welcome message area on the home page for anonymous users](http://meta.discourse.org/t/idea-welcome-message-area-on-the-home-page-for-anonymous-users/6154/36)

As per @SamSaffron's suggestion, this adds a `clear pin` link in the list topics view **_once**_ the user has read the whole topic.

It will also **replace**  the `read more` link when the excerpt is too long.

![image](https://f.cloud.github.com/assets/362783/456583/467bb27e-b370-11e2-99b9-b346402dcf5b.png)
