### PR TITLE
Add sample Capistrano deployment files

### DIFF
--- a/Capfile.sample
+++ b/Capfile.sample
@@ -1,0 +1,4 @@
+load 'deploy' if respond_to?(:namespace)
+load 'deploy/assets'
+Dir['vendor/plugins/*/recipes/*.rb'].each { |plugin| load(plugin) }
+load 'config/deploy'

--- a/config/deploy.rb.sample
+++ b/config/deploy.rb.sample
@@ -1,0 +1,98 @@
+# This is a set of sample deployment recipes for deploying via Capistrano.
+# One of the recipes (deploy:symlink_nginx) assumes you have an nginx configuration
+# file at config/nginx.conf. You can make this easily from the provided sample
+# nginx configuration file.
+
+require 'bundler/capistrano'
+require 'sidekiq/capistrano'
+
+# Repo Settings
+# You should change this to your fork of discourse
+set :repository, 'git@github.com:discourse/discourse.git'
+set :deploy_via, :remote_cache
+set :branch, fetch(:branch, 'master')
+set :scm, :git
+ssh_options[:forward_agent] = true
+
+# General Settings
+set :deploy_type, :deploy
+default_run_options[:pty] = true
+
+# Server Settings
+set :user, 'admin'
+set :use_sudo, false
+set :rails_env, :production
+
+role :app, 'SERVER_ADDRESS_HERE', primary: true
+role :db,  'SERVER_ADDRESS_HERE', primary: true
+role :web, 'SERVER_ADDRESS_HERE', primary: true
+
+# Application Settings
+set :application, 'discourse'
+set :deploy_to, "/var/www/#{application}"
+
+# Perform an initial bundle
+after "deploy:setup" do
+  run "cd #{current_path} && bundle install"
+end
+
+# Tasks to start/stop/restart thin
+namespace :deploy do
+  desc 'Start thin servers'
+  task :start, :roles => :app, :except => { :no_release => true } do
+    run "cd #{current_path} && RUBY_GC_MALLOC_LIMIT=90000000 bundle exec thin -C config/thin.yml start", :pty => false
+  end
+
+  desc 'Stop thin servers'
+  task :stop, :roles => :app, :except => { :no_release => true } do
+    run "cd #{current_path} && bundle exec thin -C config/thin.yml stop"
+  end
+
+  desc 'Restart thin servers'
+  task :restart, :roles => :app, :except => { :no_release => true } do
+    run "cd #{current_path} && RUBY_GC_MALLOC_LIMIT=90000000 bundle exec thin -C config/thin.yml restart"
+  end
+end
+
+# Symlink config/nginx.conf to /etc/nginx/sites-enabled. Make sure to restart
+# nginx so that it picks up the configuration file.
+namespace :config do
+  task :nginx, roles: :app do
+    puts "Symlinking your nginx configuration..."
+    sudo "ln -nfs #{release_path}/config/nginx.conf /etc/nginx/sites-enabled/#{application}"
+  end
+end
+
+after "deploy:setup", "config:nginx"
+
+# Tasks to start/stop/restart a daemonized clockwork instance
+namespace :clockwork do
+  desc "Start clockwork"
+  task :start, :roles => [:app] do
+    run "cd #{current_path} && RAILS_ENV=#{rails_env} bundle exec clockworkd -c #{current_path}/config/clock.rb --pid-dir #{shared_path}/pids --log --log-dir #{shared_path}/log start"
+  end
+
+  task :stop, :roles => [:app] do
+    run "cd #{current_path} && RAILS_ENV=#{rails_env} bundle exec clockworkd -c #{current_path}/config/clock.rb --pid-dir #{shared_path}/pids --log --log-dir #{shared_path}/log stop"
+  end
+
+  task :restart, :roles => [:app] do
+    run "cd #{current_path} && RAILS_ENV=#{rails_env} bundle exec clockworkd -c #{current_path}/config/clock.rb --pid-dir #{shared_path}/pids --log --log-dir #{shared_path}/log restart"
+  end
+end
+
+after  "deploy:stop",    "clockwork:stop"
+after  "deploy:start",   "clockwork:start"
+before "deploy:restart", "clockwork:restart"
+
+# Seed your database with the initial production image. Note that the production
+# image assumes an empty, unmigrated database.
+namespace :db do
+  desc 'Seed your database for the first time'
+  task :seed do
+    run "cd #{current_path} && psql -d discourse_production < pg_dumps/production-image.sql"
+  end
+end
+
+# Migrate the database with each deployment
+after  'deploy:update_code', 'deploy:migrate'

--- a/config/thin.yml.sample
+++ b/config/thin.yml.sample
@@ -1,0 +1,15 @@
+---
+chdir: /var/www/discourse/current
+environment: production
+address: 0.0.0.0
+port: 3000
+timeout: 30
+log: /var/www/discourse/shared/log/thin.log
+pid: /var/www/discourse/shared/pids/thin.pid
+socket: /var/www/discourse/tmp/thin.sock
+max_conns: 1024
+max_persistent_conns: 100
+require: []
+wait: 30
+servers: 4
+daemonize: true


### PR DESCRIPTION
Add the following sample Capistrano configuration files to ease
deployment to a VPS using Capistrano:
- `config/deploy.rb.sample`
- `config/thin.yml.sample`
- `Capfile.sample`

The sample Capfile will additionally load any recipes provided by
Discourse plugins.

Signed-off-by: David Celis me@davidcel.is
