### PR TITLE
prevent users from liking a post more than once

### DIFF
--- a/app/models/post_action.rb
+++ b/app/models/post_action.rb
@@ -3,6 +3,7 @@ require_dependency 'system_message'
 
 class PostAction < ActiveRecord::Base
   class AlreadyFlagged < StandardError; end
+  class AlreadyLiked < StandardError; end
 
   include RateLimiter::OnCreateRecord
 
@@ -156,6 +157,10 @@ class PostAction < ActiveRecord::Base
   end
 
   before_create do
+    raise AlreadyLiked if is_like? && PostAction.where(user_id: user_id,
+                                                       post_id: post_id,
+                                                       post_action_type_id: PostActionType.types[:like]).exists?
+    
     raise AlreadyFlagged if is_flag? && PostAction.where(user_id: user_id,
                                                          post_id: post_id,
                                                          post_action_type_id: PostActionType.flag_types.values).exists?

--- a/spec/models/post_action_spec.rb
+++ b/spec/models/post_action_spec.rb
@@ -85,14 +85,15 @@ describe PostAction do
 
   end
 
-  it "increases the post's bookmark count when saved" do
-    lambda { bookmark.save; post.reload }.should change(post, :bookmark_count).by(1)
-  end
+  describe "when a user bookmark something" do
+    it "increases the post's bookmark count when saved" do
+      lambda { bookmark.save; post.reload }.should change(post, :bookmark_count).by(1)
+    end
 
-  it "increases the forum topic's bookmark count when saved" do
-    lambda { bookmark.save; post.topic.reload }.should change(post.topic, :bookmark_count).by(1)
+    it "increases the forum topic's bookmark count when saved" do
+      lambda { bookmark.save; post.topic.reload }.should change(post.topic, :bookmark_count).by(1)
+    end
   end
-
 
   describe 'when a user likes something' do
     it 'should increase the post counts when a user likes' do
@@ -109,10 +110,17 @@ describe PostAction do
       }.should change(post.topic, :like_count).by(1)
     end
 
+    it 'should not allow users to like more than once' do
+      lambda {
+        PostAction.act(codinghorror, post, PostActionType.types[:like])
+        PostAction.act(codinghorror, post, PostActionType.types[:like])
+      }.should raise_error(PostAction::AlreadyLiked)
+    end
+
   end
 
   describe 'when a user votes for something' do
-    it 'should increase the vote counts when a user likes' do
+    it 'should increase the vote counts when a user votes' do
       lambda {
         PostAction.act(codinghorror, post, PostActionType.types[:vote])
         post.reload


### PR DESCRIPTION
Part of my morning routine is to check what's new on [meta](http://meta.discourse.org/).
What I usually do is to middle-click every new/unread topics and then check every tab.

This morning, I opened [a topic](http://meta.discourse.org/t/should-you-be-editing-css-manually-or-using-site-customization/6350) twice and for _some reason_ I liked the first post twice (in different tabs), resulting in:

![image](https://f.cloud.github.com/assets/362783/458297/c7663e52-b3d1-11e2-8a89-fe76b181bd7b.png)

This pull request prevents this.
