### PR TITLE
prevent duplicate actions on a post

### DIFF
--- a/spec/models/post_action_type_spec.rb
+++ b/spec/models/post_action_type_spec.rb
@@ -1,5 +1,0 @@
-require 'spec_helper'
-
-describe PostActionType do
-
-end


### PR DESCRIPTION
This improves [PR 810](https://github.com/discourse/discourse/pull/810) by generalizing the check on duplicate user actions as per @SamSaffron's suggestion.

Also refactored a bit `post_actions_controller.rb` and removed the empty `post_action_type_spec.rb`.
