### PR TITLE
Fix for Debian Ruby 1.9

### DIFF
--- a/lib/discourse_redis.rb
+++ b/lib/discourse_redis.rb
@@ -43,7 +43,8 @@ class DiscourseRedis
        lindex linsert llen lpop lpush lpushx lrange lrem lset ltrim mget move mset msetnx persist pexpire pexpireat psetex
        pttl rename renamenx rpop rpoplpush rpush rpushx sadd scard sdiff set setbit setex setnx setrange sinter
        sismember smembers sort spop srandmember srem strlen sunion ttl type watch zadd zcard zcount zincrby
-       zrange zrangebyscore zrank zrem zremrangebyrank zremrangebyscore zrevrange zrevrangebyscore zrevrank zrangebyscore).each do |m|
+       zrange zrangebyscore zrank zrem zremrangebyrank zremrangebyscore zrevrange zrevrangebyscore zrevrank zrangebyscore
+  ).map(&:to_sym).each do |m|
     define_method m do |*args|
       args[0] = "#{DiscourseRedis.namespace}:#{args[0]}"
       @redis.send(m, *args)


### PR DESCRIPTION
I know Discourse requires Ruby 1.9.3 but I tried running Discourse with the Debian Squeeze ruby1.9 package which is 1.9.2. It works fine so far except when you use `__method__` in `lib/discourse_redis.rb`.

I can't find why you wouldn't use the variable `m` here instead of `__method__`, even on Ruby 1.9.3, so I suggest this change.
