### PR TITLE
prepend the username in the participant alt-text in the topic list

### DIFF
--- a/app/assets/javascripts/discourse/helpers/application_helpers.js
+++ b/app/assets/javascripts/discourse/helpers/application_helpers.js
@@ -139,7 +139,18 @@ Handlebars.registerHelper('avatar', function(user, options) {
 
     var title;
     if (!options.hash.ignoreTitle) {
-      title = Em.get(user, 'title') || Em.get(user, 'description');
+      // first try to get a title
+      title = Em.get(user, 'title');
+      // if there was no title provided
+      if (!title) {
+        // try to retrieve a description
+        var description = Em.get(user, 'description');
+        // if a description has been provided
+        if (description && description.length > 0) {
+          // preprend the username before the description
+          title = username + " - " + description;
+        }
+      }
     }
 
     return new Handlebars.SafeString(Discourse.Utilities.avatarImg({


### PR DESCRIPTION
Meta: [Alt-text for avatar images](http://meta.discourse.org/t/alt-text-for-avatar-images/6363)

This will prepend the username of the participant in the _alt-text_ (`title` attribute) of the participants in the topic list view:

![image](https://f.cloud.github.com/assets/362783/464329/e32511ba-b5d7-11e2-8649-f718099dc632.png)
