### PR TITLE
FIX: hide/show preview in composer preference is saved in local storage

### DIFF
--- a/app/assets/javascripts/discourse/models/composer.js
+++ b/app/assets/javascripts/discourse/models/composer.js
@@ -67,7 +67,7 @@ Discourse.Composer = Discourse.Model.extend({
 
   togglePreview: function() {
     this.toggleProperty('showPreview');
-    Discourse.KeyValueStore.set({ key: 'showPreview', value: this.get('showPreview') });
+    Discourse.KeyValueStore.set({ key: 'composer.showPreview', value: this.get('showPreview') });
   },
 
   // Import a quote from the post


### PR DESCRIPTION
Meta: [Bigger Writing Area - “<< hide preview” link should have a state](http://meta.discourse.org/t/bigger-writing-area-lt-lt-hide-preview-link-should-have-a-state/6431)

The hide/show preview preference in the composer was not properly saved in the browser's local storage.
