### PR TITLE
FIX: pinned topic excerpt is not properly truncated

### DIFF
--- a/lib/pretty_text.rb
+++ b/lib/pretty_text.rb
@@ -247,13 +247,9 @@ module PrettyText
     end
 
     def self.get_excerpt(html, length, options)
-
       me = self.new(length,options)
       parser = Nokogiri::HTML::SAX::Parser.new(me)
       begin
-        copy = "<div>"
-        copy << html unless html.nil?
-        copy << "</div>"
         parser.parse(html) unless html.nil?
       rescue DoneException
         # we are done
@@ -302,8 +298,9 @@ module PrettyText
     def characters(string, truncate = true, count_it = true, encode = true)
       return if @in_quote
       encode = encode ? lambda{|s| ERB::Util.html_escape(s)} : lambda {|s| s}
-      if @current_length + string.length > @length && count_it
-        @excerpt << encode.call(string[0..(@length-@current_length)-1]) if truncate
+      if count_it && @current_length + string.length > @length
+        length = [0, @length - @current_length - 1].max
+        @excerpt << encode.call(string[0..length]) if truncate
         @excerpt << "&hellip;"
         @excerpt << "</a>" if @in_a
         raise DoneException.new
@@ -318,4 +315,3 @@ module PrettyText
   end
 
 end
-

--- a/spec/components/pretty_text_spec.rb
+++ b/spec/components/pretty_text_spec.rb
@@ -131,6 +131,7 @@ test
 
     it "should truncate stuff properly" do
       PrettyText.excerpt("hello world",5).should == "hello&hellip;"
+      PrettyText.excerpt("<p>hello</p><p>world</p>",6).should == "hello w&hellip;"
     end
 
     it "should insert a space between to Ps" do
@@ -168,6 +169,7 @@ test
     it "should handle nil" do
       PrettyText.excerpt(nil,100).should == ''
     end
+
   end
 
 


### PR DESCRIPTION
Meta: [Limiting the size of pinned topic excerpts](http://meta.discourse.org/t/limiting-the-size-of-pinned-topic-excerpts/6522)

Prevent this from happening:

![35279e0133a067a2 1](https://f.cloud.github.com/assets/362783/487499/abd70258-b95c-11e2-8004-165ebbb28d73.png)

The issue was that there was an edge-case that wasn't taken into account when truncating the html of the first post.

``` ruby
@excerpt << encode.call(string[0..(@length-@current_length)-1]) if truncate
```

would return the **whole** string when `@length == @current_length` instead of _truncating_ it.
