### PR TITLE
FIX: user education displays [object Object]

### DIFF
--- a/app/assets/javascripts/discourse/controllers/composer_controller.js
+++ b/app/assets/javascripts/discourse/controllers/composer_controller.js
@@ -133,7 +133,7 @@ Discourse.ComposerController = Discourse.Controller.extend({
     var educationKey = this.get('content.creatingTopic') ? 'new-topic' : 'new-reply';
     var composerController = this;
     Discourse.ajax("/education/" + educationKey).then(function(result) {
-      composerController.set('educationContents', result);
+      composerController.set('educationContents', result.responseText);
     });
   }.observes('typedReply', 'content.creatingTopic', 'Discourse.currentUser.reply_count'),
 


### PR DESCRIPTION
Meta: [Can’t see defined site contents: No FAQ/TOS, no user hints](http://meta.discourse.org/t/can-t-see-defined-site-contents-no-faq-tos-no-user-hints/6515)

This fixes an issue regarding user education:

![image](https://f.cloud.github.com/assets/362783/488079/f294d78a-b973-11e2-8bcd-15587dfad019.png)
