### PR TITLE
FIX: FAQ/TOS displays [object Object]

### DIFF
--- a/app/assets/javascripts/discourse/controllers/static_controller.js
+++ b/app/assets/javascripts/discourse/controllers/static_controller.js
@@ -21,7 +21,7 @@ Discourse.StaticController = Discourse.Controller.extend({
       this.set('content', text);
     } else {
       return Discourse.ajax(path + ".json").then(function (result) {
-        staticController.set('content', result);
+        staticController.set('content', result.responseText);
       });
     }
   }


### PR DESCRIPTION
Meta: [Can’t see defined site contents: No FAQ/TOS, no user hints](http://meta.discourse.org/t/can-t-see-defined-site-contents-no-faq-tos-no-user-hints/6515)

Same bug/solution as #838, but for static content.
