### PR TITLE
FIX: Onebox link target is discourse instance

### DIFF
--- a/lib/oneboxer/whitelist.rb
+++ b/lib/oneboxer/whitelist.rb
@@ -56,7 +56,7 @@ module Oneboxer
        Entry.new(/^https?:\/\/(?:www\.)?bloomberg\.com\/.+/),
        Entry.new(/^https?:\/\/(?:www\.)?ign\.com\/.+/),
        Entry.new(/^https?:\/\/(?:www\.)?twitpic\.com\/.+/),
-       Entry.new(/^https?:\/\/(?:www\.)?techcrunch\.com\/.+/),
+       Entry.new(/^https?:\/\/(?:www\.)?techcrunch\.com\/.+/, false),
        Entry.new(/^https?:\/\/(?:www\.)?usatoday\.com\/.+/),
        Entry.new(/^https?:\/\/(?:www\.)?go\.com\/.+/),
        Entry.new(/^https?:\/\/(?:www\.)?businessinsider\.com\/.+/),


### PR DESCRIPTION
Meta: [Onebox link target is discourse instance](http://meta.discourse.org/t/onebox-link-target-is-discourse-instance/6596)

This is the _quickest_ fix to get Techcrunch oneboxes working by preventing oembed oneboxing for Techcrunch.

The **right** fix would be to update the oembed onebox to work properly for the "link" type.

If you guys think we should indeed make the right fix, please feel free to close this PR :wink: 
