### PR TITLE
Fix error in secured categories scope

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -29,11 +29,10 @@ class Category < ActiveRecord::Base
 
   scope :latest, ->{ order('topic_count desc') }
 
-  scope :secured, lambda { |guardian|
-    ids = nil
+  scope :secured, ->(guardian = nil) {
     ids = guardian.secure_category_ids if guardian
     if ids.present?
-      where("categories.secure ='f' or categories.id = :cats ", cats: ids)
+      where("categories.secure ='f' or categories.id in (:cats)", cats: ids)
     else
       where("categories.secure ='f'")
     end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -19,9 +19,12 @@ describe Category do
   it { should have_many :featured_topics }
 
   describe "security" do
-    it "secures categories correctly" do
-      category = Fabricate(:category)
+    let(:category) { Fabricate(:category) }
+    let(:category_2) { Fabricate(:category) }
+    let(:user) { Fabricate(:user) }
+    let(:group) { Fabricate(:group) }
 
+    it "secures categories correctly" do
       category.secure?.should be_false
 
       category.deny(:all)
@@ -30,10 +33,8 @@ describe Category do
       category.allow(:all)
       category.secure?.should be_false
 
-      user = Fabricate(:user)
-      user.secure_categories.to_a.should == []
+      user.secure_categories.should be_empty
 
-      group = Fabricate(:group)
       group.add(user)
       group.save
 
@@ -41,8 +42,18 @@ describe Category do
       category.save
 
       user.reload
-      user.secure_categories.to_a.should == [category]
+      user.secure_categories.should == [category]
+    end
 
+    it "lists all secured categories correctly" do
+      group.add(user)
+      category.allow(group)
+
+      Category.secured.should == [category]
+
+      category_2.allow(group)
+
+      Category.secured.should =~ [category, category_2]
     end
   end
 


### PR DESCRIPTION
The entire application would crash after setting up more than one secure category. This tweaks the query to use `IN` rather than `=` when checking for the presence of a category ID in a list, and adds a test for that scope.
