### PR TITLE
FIX: @username mentions when there are multiple code blocks in a post.

### DIFF
--- a/app/assets/javascripts/discourse/components/markdown.js
+++ b/app/assets/javascripts/discourse/components/markdown.js
@@ -143,8 +143,8 @@ Discourse.Markdown = {
       if (!text) return "";
 
       // don't do @username mentions inside <pre> or <code> blocks
-      text = text.replace(/<(pre|code)>([\s\S]*?@[\s\S]*?)<\/(pre|code)>/gi, function(wholeMatch, m1, m2, m3) {
-        return "<" + m1 + ">" + (m2.replace(/@/g, '&#64;')) + "</" + m3 + ">";
+      text = text.replace(/<(pre|code)>([\s\S](?!<(pre|code)>))*?@([\s\S](?!<(pre|code)>))*?<\/(pre|code)>/gi, function(m) {
+        return m.replace(/@/g, '&#64;');
       });
 
       // add @username mentions, if valid; must be bounded on left and right by non-word characters

--- a/spec/javascripts/components/markdown_spec.js
+++ b/spec/javascripts/components/markdown_spec.js
@@ -92,6 +92,14 @@ describe("Discourse.Markdown", function() {
         expect(cook("@EvilTrout yo")).toBe("<p><span class='mention'>@EvilTrout</span> yo</p>");
       });
 
+      it("doesn't do @username mentions inside <pre> or <code> blocks", function() {
+        expect(cook("`@EvilTrout yo`")).toBe("<p><code>&#64;EvilTrout yo</code></p>");
+      });
+
+      it("deals correctly with multiple <code> blocks", function() {
+        expect(cook("`evil` @EvilTrout `trout`")).toBe("<p><code>evil</code> <span class='mention'>@EvilTrout</span> <code>trout</code></p>");
+      });
+
     });
 
     describe("Oneboxing", function() {


### PR DESCRIPTION
Meta: [All of my internal users show as coming from 127.0.0.1!](http://meta.discourse.org/t/all-of-my-internal-users-show-as-coming-from-127-0-0-1/6607)

This fixes the regular expression used to identify @ inside `<code>` or `<pre>` blocks in the `postConversion` hook.

One drawback of this fix is that the regex has now become _really_ complex.
