### PR TITLE
Require rspec-rails in Gemfile to fix 'spec' task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -103,7 +103,7 @@ group :test, :development do
   gem 'mocha', require: false
   gem 'rb-fsevent', require: RUBY_PLATFORM =~ /darwin/i ? 'rb-fsevent' : false
   gem 'rb-inotify', '~> 0.9', require: RUBY_PLATFORM =~ /linux/i ? 'rb-inotify' : false
-  gem 'rspec-rails', require: false
+  gem 'rspec-rails'
   gem 'shoulda', require: false
   gem 'simplecov', require: false
   gem 'terminal-notifier-guard', require: false


### PR DESCRIPTION
The `rspec-rails` gem was set to `require = false` a few days ago in [`b6bf95e7`](https://github.com/discourse/discourse/commit/b6bf95e74183fbfb5fee73441247d80f52e2081a), which causes the spec rake task to silently fail. Notice that the [latest Travis build](https://travis-ci.org/discourse/discourse/jobs/7261893) is no longer running the specs.

This PR fixes the spec rake task.
