### PR TITLE
make Redis config easier on Heroku

### DIFF
--- a/config/redis.yml.sample
+++ b/config/redis.yml.sample
@@ -1,5 +1,5 @@
 defaults: &defaults
-  uri: <%= uri = URI.parse(ENV['SET_REDIS_PROVIDER_URL'] || "redis://localhost:6379") %>
+  uri: <%= uri = URI.parse(ENV['REDIS_PROVIDER_URL'] || "redis://localhost:6379") %>
   host: <%= uri.host %>
   port: <%= uri.port %>
   password: <%= uri.password %>

--- a/docs/HEROKU.md
+++ b/docs/HEROKU.md
@@ -12,14 +12,9 @@ For details on how to reduce the monthly cost of your application, see [Advanced
         cd discourse
         git checkout -b heroku
 
-2. Modify the redis.yml file to use the environment variable provided by Heroku and the Redis provider of your choice.
+2. Create a redis.yml file.
 
-    *config/redis.yml*
-
-    ```erb
-     - uri: <%= uri = URI.parse(ENV['SET_REDIS_PROVIDER_URL'] || "redis://localhost:6379") %>
-     + uri: <%= uri = URI.parse(ENV['OPENREDIS_URL'] || "redis://localhost:6379") %>
-    ```
+        cp config/redis.yml.sample config/redis.yml
 
 3. Comment out or delete `config/redis.yml` from .gitignore. We want to include redis.yml when we push to Heroku.
 
@@ -59,19 +54,24 @@ For details on how to reduce the monthly cost of your application, see [Advanced
 
         heroku addons:add openredis:micro
 
-3. Add the [Heroku Scheduler](https://addons.heroku.com/scheduler) add-on, this saves us from running a separate clock process, reducing the cost of the app.
+3. Point the app at your redis provider's URL
+
+        heroku config:get OPENREDIS_URL
+        heroku config:set REDIS_PROVIDER_URL=<result of above command>
+
+4. Add the [Heroku Scheduler](https://addons.heroku.com/scheduler) add-on, this saves us from running a separate clock process, reducing the cost of the app.
 
         heroku addons:add scheduler:standard
 
-4. Generate a secret token in the terminal.
+5. Generate a secret token in the terminal.
 
         rake secret
 
-5. Push the secret to the stored heroku environment variables, this will now be available to your app globally.
+6. Push the secret to the stored heroku environment variables, this will now be available to your app globally.
 
         heroku config:add SECRET_TOKEN=<generated secret>
 
-6. Precompile assets.
+7. Precompile assets.
 
     There are two options for precompilation. Either precompile locally, **before each deploy** or enable [Heroku's experimental user-env-compile](https://devcenter.heroku.com/articles/labs-user-env-compile) feature and Heroku will precompile your assets for you.
 
@@ -102,11 +102,11 @@ For details on how to reduce the monthly cost of your application, see [Advanced
             # Unset var
             unset SECRET_TOKEN
 
-7. Push your heroku branch to Heroku.
+8. Push your heroku branch to Heroku.
 
         git push heroku heroku:master
 
-8. Migrate and seed the database.
+9. Migrate and seed the database.
 
         heroku run rake db:migrate db:seed_fu
 


### PR DESCRIPTION
I've modified the Heroku docs so that the Redis provider doesn't need to be hardcoded into redis.yml, it can instead be set via heroku config.

I also tweaked the name of the dummy ENV var in redis.yml.sample to accommodate this convention.

And while I was in there I fixed the language for one of the code blocks in the heroku doc.
