### PR TITLE
Trigger UserActionObserver when updating TopicUser

### DIFF
--- a/app/models/topic_user.rb
+++ b/app/models/topic_user.rb
@@ -100,6 +100,8 @@ class TopicUser < ActiveRecord::Base
       rows = TopicUser.update_all({last_visited_at: now}, {topic_id: topic.id, user_id: user.id})
       if rows == 0
         TopicUser.create(topic_id: topic.id, user_id: user.id, last_visited_at: now, first_visited_at: now)
+      else
+        observe_after_save_callbacks_for topic.id, user.id
       end
     end
 

--- a/spec/models/topic_user_spec.rb
+++ b/spec/models/topic_user_spec.rb
@@ -107,6 +107,10 @@ describe TopicUser do
       topic_user.last_visited_at.to_i.should == today.to_i
     end
 
+    it 'triggers the observer callbacks when updating' do
+      UserActionObserver.instance.expects(:after_save).twice
+      2.times { TopicUser.track_visit!(topic, user) }
+    end
   end
 
   describe 'read tracking' do


### PR DESCRIPTION
This fixes #482. Thanks @ZogStriP for the troubleshooting.

The `after_save` callbacks are not triggered when calling `TopicUser.update_all` in [`TopicUser.change`](https://github.com/discourse/discourse/blob/d4360798013e754e770f136eade711ae5de93fd1/app/models/topic_user.rb#L78) and [`TopicUser.track_visit!`](https://github.com/discourse/discourse/blob/d4360798013e754e770f136eade711ae5de93fd1/app/models/topic_user.rb#L98)

This PR fixes that. Favorite counts are accurate on my machine after this fix.
