### PR TITLE
Thread title fixer should ignore special cases like iLetter

### DIFF
--- a/lib/text_cleaner.rb
+++ b/lib/text_cleaner.rb
@@ -28,8 +28,8 @@ class TextCleaner
     text.gsub!(/\?+/, '?') if opts[:deduplicate_question_marks]
     # Replace all-caps text with regular case letters
     text.tr!('A-Z', 'a-z') if opts[:replace_all_upper_case] && (text =~ /[A-Z]+/) && (text == text.upcase)
-    # Capitalize first letter
-    text.sub!(/\A([a-z])/) { |first| first.capitalize } if opts[:capitalize_first_letter]
+    # Capitalize first letter, but only when entire first word is lowercase
+    text.sub!(/\A([a-z]*)\b/) { |first| first.capitalize } if opts[:capitalize_first_letter]
     # Remove unnecessary periods at the end
     text.sub!(/([^.])\.+(\s*)\z/, '\1\2') if opts[:remove_all_periods_from_the_end]
     # Remove extraneous space before the end punctuation

--- a/spec/components/text_cleaner_spec.rb
+++ b/spec/components/text_cleaner_spec.rb
@@ -57,15 +57,18 @@ describe TextCleaner do
 
     let(:lowercased) { "this is awesome" }
     let(:capitalized) { "This is awesome" }
+    let(:iletter) { "iLetter" }
 
     it "ignores first letter case by default" do
       TextCleaner.clean(lowercased).should == lowercased
       TextCleaner.clean(capitalized).should == capitalized
+      TextCleaner.clean(iletter).should == iletter
     end
 
     it "capitalizes first letter when enabled" do
       TextCleaner.clean(lowercased, capitalize_first_letter: true).should == capitalized
       TextCleaner.clean(capitalized, capitalize_first_letter: true).should == capitalized
+      TextCleaner.clean(iletter, capitalize_first_letter: true).should == iletter
     end
 
   end


### PR DESCRIPTION
When user posts a thread like "iPhone doesn't work after I used it as a brick", the thread fixer automatically fixes it into ugly "IPhone". I have changed it so the entire word has to be lowercase for this filter to work.
