### PR TITLE
Allow Chinese characters in Topic titles

### DIFF
--- a/lib/text_sentinel.rb
+++ b/lib/text_sentinel.rb
@@ -41,7 +41,7 @@ class TextSentinel
     (@text.gsub(TextSentinel.non_symbols_regexp, '').size > 0) &&
 
     # Don't allow super long words if there is a word length maximum
-    (@opts[:max_word_length].blank? || @text.split(/\W/).map(&:size).max <= @opts[:max_word_length] ) &&
+    (@opts[:max_word_length].blank? || @text.split(/\s/).map(&:size).max <= @opts[:max_word_length] ) &&
 
     # We don't allow all upper case content in english
     not((@text =~ /[A-Z]+/) && (@text == @text.upcase)) &&

--- a/spec/components/validators/quality_title_validator_spec.rb
+++ b/spec/components/validators/quality_title_validator_spec.rb
@@ -33,6 +33,11 @@ describe "A record validated with QualityTitleValidator" do
     topic.should be_valid
   end
 
+  it 'allows Chinese characters' do
+    topic.title = '现在发现使用中文标题没法发帖子了'
+    topic.should be_valid
+  end
+
   it "allows anything in a private message" do
     topic.stubs(:private_message? => true)
     [short_title, long_title, xxxxx_title].each do |bad_title|


### PR DESCRIPTION
Thanks @kejinlu. Fixes: [meta/6883](http://meta.discourse.org/t/i-found-that-i-can-t-post-when-the-title-contains-only-chinese-characters/6883/4)

Chinese titles are currently not allowed because of the way we validate word length in titles. There are no tests indicating that we want to count dashed-words or underscored_words in titles as separate words, so this is an easy fix that validates word length based on spaces instead of non-word characters.
