### PR TITLE
FIX: You can't change a subject whilst Flagging

### DIFF
--- a/app/assets/javascripts/discourse/views/modal/flag_view.js
+++ b/app/assets/javascripts/discourse/views/modal/flag_view.js
@@ -35,7 +35,7 @@ Discourse.FlagView = Discourse.ModalBodyView.extend({
     this.set('postActionTypeId', action.id);
     this.set('isCustomFlag', action.is_custom_flag);
     this.set('selected', action);
-    Em.run.schedule('afterRender', function() {
+    Em.run.next(function() {
       $('#radio_' + action.name_key).prop('checked', 'true');
     });
     return false;


### PR DESCRIPTION
Meta: [You can't change a subject whilst Flagging](http://meta.discourse.org/t/you-can-t-change-a-subject-whilst-flagging/6887)

This revert a change made by @eviltrout in b794830a259d0c76bf804227ab2653b4f9118eb6 in the `flag_view.js`.
The `Em.run.schedule('afterRender', function() {...})` is apparently not enough. Had to schedule the event on the next run loop.

Hopefully, the PR emberjs/ember.js#1235 will soon be merged in and we'll have a proper radio button control in Ember.js.
