### PR TITLE
WIP - Reduce complexity of Post#raw_links

### DIFF
--- a/lib/post_analyser.rb
+++ b/lib/post_analyser.rb
@@ -1,0 +1,63 @@
+module PostAnalyser
+
+
+  def raw_mentions
+    return [] if raw.blank?
+
+    # We don't count mentions in quotes
+    return @raw_mentions if @raw_mentions.present?
+    raw_stripped = raw.gsub(/\[quote=(.*)\]([^\[]*?)\[\/quote\]/im, '')
+
+    # Strip pre and code tags
+    doc = Nokogiri::HTML.fragment(raw_stripped)
+    doc.search("pre").remove
+    doc.search("code").remove
+
+    results = doc.to_html.scan(PrettyText.mention_matcher)
+    @raw_mentions = results.uniq.map { |un| un.first.downcase.gsub!(/^@/, '') }
+  end
+
+  # Count how many hosts are linked in the post
+  def linked_hosts
+    return {} if raw_links.blank?
+
+    return @linked_hosts if @linked_hosts.present?
+
+    @linked_hosts = {}
+    raw_links.each do |u|
+      uri = URI.parse(u)
+      host = uri.host
+      @linked_hosts[host] ||= 1
+    end
+    @linked_hosts
+  end
+
+  # Returns an array of all links in a post excluding mentions
+  def raw_links
+    return [] unless raw.present?
+
+    return @raw_links if @raw_links.present?
+
+    # Don't include @mentions in the link count
+    @raw_links = []
+    cooked_document.search("a[href]").each do |l|
+      next if link_is_a_mention?(l)
+      url = l.attributes['href'].to_s
+      @raw_links << url
+    end
+    @raw_links
+  end
+
+  # How many links are present in the post
+  def link_count
+    raw_links.size
+  end
+
+  private
+
+  def link_is_a_mention?(l)
+    html_class = l.attributes['class']
+    return false if html_class.nil?
+    html_class.to_s == 'mention' && l.attributes['href'].to_s =~ /^\/users\//
+  end
+end


### PR DESCRIPTION
Working on reducing the complexity of the Post model, I picked the next most complex method - Post#raw_links. This PR reduces the complexity of this method from 27 to 14. 

I think we need to break Post up and would like some feedback on the approach. I have extracted some methods that pertain to analysing links, hosts and mentions in a post object and placed them in a module. Thus far this seems a bit meh but I'm happy to pursue this further and clean up the methods in the module if this extraction approach is acceptable.

If we are happy with the PostAnalyser module, I can continue to work on refactoring its contents in this or a subsequent PR.

Thanks.
