### PR TITLE
Fix unix socket paths in nginx sample config

### DIFF
--- a/config/nginx.sample.conf
+++ b/config/nginx.sample.conf
@@ -1,8 +1,8 @@
 upstream discourse {
-  server unix:///var/www/discourse/tmp/sockets/thin.0.sock;
-  server unix:///var/www/discourse/tmp/sockets/thin.1.sock;
-  server unix:///var/www/discourse/tmp/sockets/thin.2.sock;
-  server unix:///var/www/discourse/tmp/sockets/thin.3.sock;
+  server unix:/var/www/discourse/tmp/sockets/thin.0.sock;
+  server unix:/var/www/discourse/tmp/sockets/thin.1.sock;
+  server unix:/var/www/discourse/tmp/sockets/thin.2.sock;
+  server unix:/var/www/discourse/tmp/sockets/thin.3.sock;
 }
 
 server {


### PR DESCRIPTION
Fixes #869

nginx unix socket paths only require a single forward slash according to the [HttpUpstreamModule documentation](http://wiki.nginx.org/HttpUpstreamModule)
