### PR TITLE
Staff scope defined in User model but not used in staff_constraint

### DIFF
--- a/lib/staff_constraint.rb
+++ b/lib/staff_constraint.rb
@@ -4,7 +4,7 @@ class StaffConstraint
 
   def matches?(request)
     return false unless request.session[:current_user_id].present?
-    User.where("admin = 't' or moderator = 't'").where(id: request.session[:current_user_id].to_i).exists?
+    User.staff.where(id: request.session[:current_user_id].to_i).exists?
   end
 
 end


### PR DESCRIPTION
In User model:

``` ruby
scope :staff, ->{ where("moderator = 't' or admin = 't'") }
```

In lib/staff_constraint.rb:

``` ruby
User.where("admin = 't' or moderator = 't'")
```

I think it would be nice to use given scopes.

If you expand the scope in User model you had also to change the value in `lib/staff_constraint.rb`.
