### PR TITLE
Don't append the base url to absolute image urls without protocol.

### DIFF
--- a/lib/cooked_post_processor.rb
+++ b/lib/cooked_post_processor.rb
@@ -36,7 +36,7 @@ class CookedPostProcessor
 
     images.each do |img|
       src = img['src']
-      src = Discourse.base_url_no_prefix + src if src[0] == "/"
+      src = Discourse.base_url_no_prefix + src if src =~ /^\/[^\/]/
 
       if src.present?
 

--- a/spec/components/cooked_post_processor_spec.rb
+++ b/spec/components/cooked_post_processor_spec.rb
@@ -81,6 +81,23 @@ describe CookedPostProcessor do
       end
 
     end
+
+    context 'with an absolute image path without protocol' do
+      let(:user) { Fabricate(:user) }
+      let(:topic) { Fabricate(:topic, user: user) }
+      let(:post) { Fabricate.build(:post_with_s3_image_url, topic: topic, user: user) }
+      let(:processor) { CookedPostProcessor.new(post) }
+
+      before do
+        ImageSorcery.any_instance.stubs(:convert).returns(false)
+        processor.post_process_images
+      end
+
+      it "doesn't change the protocol" do
+        processor.html.should =~ /src="\/\/bucket\.s3\.amazonaws\.com\/uploads\/6\/4\/123\.png"/
+      end
+    end
+
   end
 
   context 'link convertor' do

--- a/spec/fabricators/post_fabricator.rb
+++ b/spec/fabricators/post_fabricator.rb
@@ -34,6 +34,11 @@ Fabricator(:post_with_image_url, from: :post) do
   "
 end
 
+Fabricator(:post_with_s3_image_url, from: :post) do
+  cooked "
+<img src=\"//bucket.s3.amazonaws.com/uploads/6/4/123.png\">
+  "
+end
 
 Fabricator(:basic_reply, from: :post) do
   user(:coding_horror)


### PR DESCRIPTION
Prior to this commit the post processor appended the site base url to images with an absolute path that doesn't have a protocol, like images from S3. So the processor converted all S3 images from

```
<img src="//bucket.s3.amazonaws.com/uploads/6/4/123.png">
```

to

```
<img src="http://ec2-23-21-129-81.compute-1.amazonaws.com//bucket.s3.amazonaws.com/uploads/6/4/123.png">
```

on Heroku, which of course broke the image.
