### PR TITLE
Only pass search context type and id in search request

### DIFF
--- a/app/assets/javascripts/discourse/components/search.js
+++ b/app/assets/javascripts/discourse/components/search.js
@@ -23,7 +23,13 @@ Discourse.Search = {
     // Only include the data we have
     var data = { term: term }
     if (opts.typeFilter) data.type_filter = opts.typeFilter;
-    if (opts.searchContext) data.search_context = opts.searchContext;
+
+    if (opts.searchContext) {
+      data.search_context = {
+        type: opts.searchContext.type,
+        id: opts.searchContext.id
+      };
+    }
 
     return Discourse.ajax('/search', { data: data });
   }


### PR DESCRIPTION
Search is currently broke on master for category and user search. To reproduce, visit [meta/category/bug](http://meta.discourse.org/category/bug) and try to do a search. Keep the console open if you want to see the error.

Details about the search context were added to the search text field yesterday in [`4cf1d9c2`](https://github.com/discourse/discourse/commit/4cf1d9c2667b80e8cc18b2929b14a6b938cc16e3).

Unfortunately, the entire object being searched is now being passed in the data for the search request in [`search.js#26`](https://github.com/discourse/discourse/blob/b82a5dfd5642b4b8440752d1cb9f612785b94ca7/app/assets/javascripts/discourse/components/search.js#L26). For some reason, this makes the request fail and I don't know why. But whatever the reason, we don't need to pass that object all in the request, so it should not be put in there.

This PR just grabs the `type` and `id` from the search context and puts that in the request.

I'm totally happy to do this a different way if someone has ideas, but this seemed like the easiest fix to me.
