### PR TITLE
added more file uploads test for better coverage

### DIFF
--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -157,7 +157,11 @@ class SiteSetting < ActiveRecord::Base
 
   setting(:enforce_global_nicknames, true)
   setting(:discourse_org_access_key, '')
+  
   setting(:enable_s3_uploads, false)
+  setting(:s3_access_key_id, '')
+  setting(:s3_secret_access_key, '')
+  setting(:s3_region, 'us-west-1')
   setting(:s3_upload_bucket, '')
 
   setting(:default_trust_level, 0)

--- a/config/fog_credentials.yml.sample
+++ b/config/fog_credentials.yml.sample
@@ -1,4 +1,0 @@
-default:
-  aws_access_key_id: 'your-aws-access-key-id'
-  aws_secret_access_key: 'your-aws-secret-access-key/'
-  region: 'your-aws-region'

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -544,6 +544,9 @@ en:
 
     enable_s3_uploads: "Place uploads on Amazon S3"
     s3_upload_bucket: "The Amazon S3 bucket name that files will be uploaded into"
+    s3_access_key_id: "The Amazon S3 access key id that will be used to upload images"
+    s3_secret_access_key: "The Amazon S3 secret access key that will be used to upload images"
+    s3_region: "The Amazon S3 region name that will be used to upload images"
 
     default_invitee_trust_level: "Default trust level (0-4) for invited users"
     default_trust_level: "Default trust level (0-4) for users"


### PR DESCRIPTION
Meta: [s3 links default to https](http://meta.discourse.org/t/s3-links-default-to-https/5758/9)
- [x] Added tests for image uploads to provide better coverage of the image upload feature.
  Those 3 tests are pretty basic but should cover the happy-path.
- [x] Removed the `config/fog_credentials.yml.sample` file and extracted its settings into the following site settings: `s3_access_key_id`, `s3_secret_access_key` and `s3_region`.
  I find it better to have them in the site settings as they are now more _local_ to the `enable_s3_uploads` setting.
- [x] Refactored `create_on_s3` a bit and changed the format of the url used to store images on s3 (previous format felt a bit noisy and provided no useful information).
