### PR TITLE
Don't require params[:name] to be set when updating groups.

### DIFF
--- a/app/controllers/admin/groups_controller.rb
+++ b/app/controllers/admin/groups_controller.rb
@@ -18,7 +18,7 @@ class Admin::GroupsController < Admin::AdminController
     group = Group.find(params[:id].to_i)
     render_json_error if group.automatic
     group.usernames = params[:group][:usernames]
-    group.name = params[:group][:name] if params[:name]
+    group.name = params[:group][:name]
     group.save!
     render json: "ok"
   end

--- a/spec/controllers/admin/groups_controller_spec.rb
+++ b/spec/controllers/admin/groups_controller_spec.rb
@@ -63,7 +63,7 @@ describe Admin::GroupsController do
     group = Fabricate(:group)
     log_in(:admin)
 
-    xhr :put, :update, id: group.id, name: 'fred', group: {
+    xhr :put, :update, id: group.id, group: {
         name: 'fred',
         usernames: "#{user1.username},#{user2.username}"
     }


### PR DESCRIPTION
I'm not sure if this is the right way to fix group updating but since discourse/discourse@a1520f0dee9d762390d79822699764aa9ca7a1fd only sends `name` param nested under `group` param I decided that `params[:name]` is just redundant.
