### PR TITLE
Added Findery and Zappos entries to the Oneboxer::Whitelist.

### DIFF
--- a/lib/oneboxer/whitelist.rb
+++ b/lib/oneboxer/whitelist.rb
@@ -1,8 +1,19 @@
-module Oneboxer
+#******************************************************************************#
+#                                                                              #
+# Oneboxer already supports most sites using OpenGraph via the OpenGraphOnebox #
+# class. If the site you want to create a onebox for supports OpenGraph,       # 
+# please try adding the site to the whitelist below before creating a custom   #
+# parser or template.                                                          #
+#                                                                              #
+#******************************************************************************#
 
+module Oneboxer
+  
   module Whitelist
     def self.entries
       [
+       Entry.new(/^https?:\/\/(?:www\.)?findery\.com\/.+/),
+       Entry.new(/^https?:\/\/(?:www\.)?zappos\.com\/.+/),
        Entry.new(/^https?:\/\/(?:www\.)?slideshare\.net\/.+/),
        Entry.new(/^https?:\/\/(?:www\.)?rottentomatoes\.com\/.+/),
        Entry.new(/^https?:\/\/(?:www\.)?cnn\.com\/.+/),


### PR DESCRIPTION
Both Findery and Zappos support OpenGraph and work with the OpenGraphOneboxer. Added a comment at the top of whitelist.rb asking developers to check for OpenGraph support prior to creating a custom Onebox.
