### PR TITLE
Add missing handlebar in featured_topics template

### DIFF
--- a/app/assets/javascripts/discourse/templates/featured_topics.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/featured_topics.js.handlebars
@@ -18,7 +18,7 @@
       <td class='main-link'>
         <div class='topic-inset'>
           {{topicStatus topic=this}}
-          {{{topicLink this}}
+          {{{topicLink this}}}
         {{#if unread}}
           <a href="{{unbound lastReadUrl}}" class='badge unread badge-notification' title='{{i18n topic.unread_posts unread="unread"}}'>{{unbound unread}}</a>
         {{/if}}


### PR DESCRIPTION
This could be related to http://meta.discourse.org/t/no-more-topics-in-category-list/7043/10
