### PR TITLE
Fix 'Generate API Key' Button

### DIFF
--- a/app/assets/javascripts/admin/models/admin_api.js
+++ b/app/assets/javascripts/admin/models/admin_api.js
@@ -20,8 +20,10 @@ Discourse.AdminApi = Discourse.Model.extend({
 
 Discourse.AdminApi.reopenClass({
   find: function() {
-    return Discourse.ajax("/admin/api").then(function(data) {
-      return Discourse.AdminApi.create(data);
+    var model = Discourse.AdminApi.create();
+    Discourse.ajax("/admin/api").then(function(data) {
+      model.setProperties(data);
     });
+    return model;
   }
 });


### PR DESCRIPTION
Fixes #941

Might have also been the cause of both [meta/6279/5](http://meta.discourse.org/t/cannot-generate-api-key/6279/5) and [meta/5830/11](http://meta.discourse.org/t/generate-api-key-not-working/5830/11)

When /admin/api is accessed by navigation, the template finishes rendering before the `AdminApi` model is returned, which means the 'Generate API Key' button does not work. If we navigate directly to the url manually or refresh, the ajax response completes in time so the button works.

To fix this, we can return the correct model immediately and update the model attributes when the ajax response comes back, allowing Ember's magical observers :sparkles: to take it from there.
