### PR TITLE
Update js_locale_helper.rb

### DIFF
--- a/lib/js_locale_helper.rb
+++ b/lib/js_locale_helper.rb
@@ -62,7 +62,7 @@ module JsLocaleHelper
       hash.each do |k,v|
         if Hash === v
           rval.merge!(strip_out_message_formats!(v, prefix + (prefix.length > 0 ? "." : "") << k, rval))
-        elsif k.end_with?("_MF")
+        elsif k.to_s().end_with?("_MF")
           rval[prefix + (prefix.length > 0 ? "." : "") << k] = v
           hash.delete(k)
         end


### PR DESCRIPTION
Fix "undefined method `end_with?' for 1:Fixnum" when field name in YML file is not quoted number like:

```
    user_action_groups:
      1: "Likes Given"
      2: "Likes Received"
```

(yamllint.com validates such file as valid YML file)
