### PR TITLE
FIX: combobox were not working properly

### DIFF
--- a/app/assets/javascripts/discourse/templates/user/preferences.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/user/preferences.js.handlebars
@@ -71,7 +71,7 @@
 
       {{#if email_digests}}
         <div class='control-indent'>
-          {{combobox valueAttribute="value" content=digestFrequencies value="digest_after_days"}}
+          {{combobox valueAttribute="value" content=digestFrequencies value=digest_after_days}}
         </div>
       {{/if}}
       <label>{{view Ember.Checkbox checkedBinding="email_private_messages"}}
@@ -88,12 +88,12 @@
     <label class="control-label">{{i18n user.other_settings}}</label>
     <div class="controls">
       <label>{{i18n user.auto_track_topics}}</label>
-      {{combobox valueAttribute="value" content=autoTrackDurations value="auto_track_topics_after_msecs"}}
+      {{combobox valueAttribute="value" content=autoTrackDurations value=auto_track_topics_after_msecs}}
     </div>
 
     <div class="controls">
       <label>{{i18n user.new_topic_duration.label}}</label>
-      {{combobox valueAttribute="value" content=considerNewTopicOptions value="new_topic_duration_minutes"}}
+      {{combobox valueAttribute="value" content=considerNewTopicOptions value=new_topic_duration_minutes}}
     </div>
 
     <div class="controls">

--- a/app/assets/javascripts/discourse/views/combobox_view.js
+++ b/app/assets/javascripts/discourse/views/combobox_view.js
@@ -24,7 +24,7 @@ Discourse.ComboboxView = Discourse.View.extend({
     if (this.get('content')) {
 
       var comboboxView = this;
-      return this.get('content').each(function(o) {
+      this.get('content').each(function(o) {
         var val = o[comboboxView.get('valueAttribute')];
         if (val) { val = val.toString(); }
 
@@ -44,12 +44,12 @@ Discourse.ComboboxView = Discourse.View.extend({
   valueChanged: function() {
     var $combo = this.$();
     var val = this.get('value');
-    if (val) {
+    if (val !== undefined && val !== null) {
       $combo.val(val.toString());
     } else {
       $combo.val(null);
     }
-    $combo.trigger("liszt:updated")
+    $combo.trigger("liszt:updated");
   }.observes('value'),
 
   didInsertElement: function() {
@@ -66,12 +66,12 @@ Discourse.ComboboxView = Discourse.View.extend({
     }
     if (this.classNames && this.classNames.length > 0) {
       // Apply the classes to Chosen's dropdown div too:
-      this.classNames.each( function(c) {
+      this.classNames.each(function(c) {
         $elem.chosen().next().addClass(c);
       });
     }
 
-    $elem.change(function(e) {
+    $elem.chosen().change(function(e) {
       comboboxView.set('value', $(e.target).val());
     });
   }


### PR DESCRIPTION
This fixes 3 issues on the preferences' comboboxes
- [x] The value wasn't properly bound and the comboboxes were always displaying as having the first item selected
- [x] The change event wasn't correctly firing (it was omitting the first change)
- [x] The value couldn't be bound to `0`
