### PR TITLE
Link to category slug instead of name in onebox

### DIFF
--- a/lib/oneboxer/discourse_local_onebox.rb
+++ b/lib/oneboxer/discourse_local_onebox.rb
@@ -64,7 +64,7 @@ module Oneboxer
 
           category = topic.category
           if category
-            category = "<a href=\"/category/#{category.name}\" class=\"badge badge-category\" style=\"background-color: ##{category.color}\">#{category.name}</a>"
+            category = "<a href=\"/category/#{category.slug}\" class=\"badge badge-category\" style=\"background-color: ##{category.color}\">#{category.name}</a>"
           end
 
           quote = post.excerpt(SiteSetting.post_onebox_maxlength)


### PR DESCRIPTION
Fixes [`meta/7255`](http://meta.discourse.org/t/category-label-not-linking-correctly/7255)

category name != slug
