### PR TITLE
Using main site http(s) scheme when loading resources from cloudfront

### DIFF
--- a/app/assets/javascripts/admin/views/ace_editor_view.js
+++ b/app/assets/javascripts/admin/views/ace_editor_view.js
@@ -52,7 +52,7 @@ Discourse.AceEditorView = Discourse.View.extend({
     if (window.ace) {
       initAce();
     } else {
-      $LAB.script('http://d1n0x3qji82z53.cloudfront.net/src-min-noconflict/ace.js').wait(initAce);
+      $LAB.script('//d1n0x3qji82z53.cloudfront.net/src-min-noconflict/ace.js').wait(initAce);
     }
   }
 });


### PR DESCRIPTION
see also: http://meta.discourse.org/t/theres-no-style-editor-in-chrome-and-internet-explorer/7265
