### PR TITLE
Fix RestrictedUserRoute

### DIFF
--- a/app/assets/javascripts/discourse/routes/discourse_restricted_user_route.js
+++ b/app/assets/javascripts/discourse/routes/discourse_restricted_user_route.js
@@ -9,7 +9,7 @@
 Discourse.RestrictedUserRoute = Discourse.Route.extend({
 
   redirect: function(user) {
-    if (user.get('can_edit') === false) {
+    if (!user.get('can_edit')) {
       this.transitionTo('user.activity', user);
     }
   }


### PR DESCRIPTION
From: [meta/7279](http://meta.discourse.org/t/logging-out-from-account-on-settings-page-doesnt-fully-log-out-the-user/7279)

`User.can_edit` is `undefined` in some cases, meaning that you can logout of Discourse and navigate to any user's preferences, private messages, or any other restricted user route. The backend is still protecting again requests, so I don't think there's a real security issue, but it looks scary on the frontend.

I think this bug was introduced in [`046e6e5d`](https://github.com/discourse/discourse/commit/046e6e5d86db59016999dd0c4081fcf68278f791#L4L18) so it hasn't been around very long.

This PR just changes the redirect conditions so it happens bother when `user.can_view` is `false` and `undefined`
