### PR TITLE
Add onebox for GitHub pull requests

### DIFF
--- a/lib/oneboxer/github_pullrequest_onebox.rb
+++ b/lib/oneboxer/github_pullrequest_onebox.rb
@@ -1,0 +1,26 @@
+require_dependency 'oneboxer/handlebars_onebox'
+
+module Oneboxer
+  class GithubPullrequestOnebox < HandlebarsOnebox
+
+    matcher /^https?:\/\/(?:www\.)?github\.com\/[^\/]+\/[^\/]+\/pull\/.+/
+    favicon 'github.png'
+
+    def translate_url
+      @url.match(
+        /github\.com\/(?<owner>[^\/]+)\/(?<repo>[^\/]+)\/pull\/(?<number>[^\/]+)/mi
+      ) do |match|
+        "https://api.github.com/repos/#{match[:owner]}/#{match[:repo]}/pulls/#{match[:number]}"
+      end
+    end
+
+    def parse(data)
+      result = JSON.parse(data)
+
+      result['created_at'] =
+        Time.parse(result['created_at']).strftime("%I:%M%p - %d %b %y")
+
+      result
+    end
+  end
+end

--- a/lib/oneboxer/templates/github_pullrequest_onebox.hbrs
+++ b/lib/oneboxer/templates/github_pullrequest_onebox.hbrs
@@ -1,0 +1,39 @@
+<div class="onebox-result">
+  {{#host}}
+    <div class="source">
+      <div class="info">
+        <a href="{{html_url}}" class="track-link" target="_blank">
+          {{#favicon}}
+            <img class="favicon" src="{{favicon}}">
+          {{/favicon}}
+          {{host}}
+        </a>
+      </div>
+    </div>
+  {{/host}}
+
+  <div class="onebox-result-body">
+    {{#user.avatar_url}}
+      <a href="{{user.html_url}}" target="_blank">
+        <img alt="{{user.login}}" src="{{user.avatar_url}}">
+      </a>
+    {{/user.avatar_url}}
+
+    <h4>
+      <a href="{{html_url}}" target="_blank">{{title}}</a>
+    </h4>
+
+    <div class="date">
+      by <a href="{{user.html_url}}" target="_blank">{{user.login}}</a>
+      on <a href="{{html_url}}" target="_blank">{{created_at}}</a>
+    </div>
+
+    <div class="github-commit-stats">
+      <strong>{{commits}} commits</strong>
+      changed <strong>{{changed_files}} files</strong>
+      with <strong>{{additions}} additions</strong>
+      and <strong>{{deletions}} deletions</strong>.
+    </div>
+  </div>
+  <div class="clearfix"></div>
+</div>

--- a/spec/components/oneboxer/github_pullrequest_onebox_spec.rb
+++ b/spec/components/oneboxer/github_pullrequest_onebox_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+require 'oneboxer'
+require 'oneboxer/github_pullrequest_onebox'
+
+describe Oneboxer::GithubPullrequestOnebox do
+  describe '#translate_url' do
+    it 'returns the api url for the given pull request' do
+      onebox = described_class.new(
+        'https://github.com/discourse/discourse/pull/988'
+      )
+      expect(onebox.translate_url).to eq(
+        'https://api.github.com/repos/discourse/discourse/pulls/988'
+      )
+    end
+  end
+end
+


### PR DESCRIPTION
I'm tired of seeing my pr links on meta without the fancy box :frowning: 

This adds a onebox for GitHub pull request links.

It turns this:

`https://github.com/discourse/discourse/pull/988`

Into this:

![pr-onebox](https://f.cloud.github.com/assets/65323/627879/875b1c90-d061-11e2-8642-ddcaeb86282f.png)
