### PR TITLE
Added rake admin:create task for creating an administrator

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,7 @@ gem 'strong_parameters' # remove when we upgrade to Rails 4
 gem 'therubyracer', require: 'v8'
 gem 'thin'
 gem 'diffy', require: false
+gem 'highline', require: false
 
 # Gem that enables support for plugins. It is required.
 gem 'discourse_plugin', path: 'vendor/gems/discourse_plugin'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -503,6 +503,7 @@ DEPENDENCIES
   guard-rspec
   guard-spork
   has_ip_address
+  highline
   hiredis
   image_optim
   image_sorcery

--- a/docs/DEVELOPER-ADVANCED.md
+++ b/docs/DEVELOPER-ADVANCED.md
@@ -11,7 +11,6 @@ to rails, you are likely much better off with our **[Discourse Vagrant Developer
 3. Clone the project.
 4. Create development and test databases in postgres.
 5. Copy `config/database.yml.development-sample` and `config/redis.yml.sample` to `config/database.yml` and `config/redis.yml` and input the correct values to point to your postgres and redis instances.
-6. Install the seed data to set up an admin account and meta topic: `psql DATABASE_NAME < pg_dumps/production-image.sql`
 
 
 ## Before you start Rails
@@ -20,10 +19,11 @@ to rails, you are likely much better off with our **[Discourse Vagrant Developer
 2. `rake db:migrate`
 3. `rake db:test:prepare`
 4. `rake db:seed_fu`
-5. Try running the specs: `bundle exec rake autospec`
-6. `bundle exec rails server`
+5. Create admin account `rake admin:create`
+6. Try running the specs: `bundle exec rake autospec`
+7. `bundle exec rails server`
 
-You should now be able to connect to rails on http://localhost:3000 - try it out! The seed data includes a pinned topic that explains how to get an admin account, so start there! Happy hacking!
+You should now be able to connect to rails on http://localhost:3000 - try it out! Sign in as `admin` with password entered in step 5. Happy hacking!
 
 
 # Building your own Vagrant VM
@@ -103,11 +103,6 @@ Edit /etc/postgresql/9.1/main/pg_hba.conf to have this:
     host all all ::1/128 trust
     host all all 0.0.0.0/0 trust # wide-open
 
-Load the seed data (as vagrant user):
-
-    psql -d discourse_development < pg_dumps/development-image.sql
-
-(You may wish to try the `production-image.sql` file for a good seed for a production database.)
 
 ## Redis
 

--- a/lib/tasks/admin.rake
+++ b/lib/tasks/admin.rake
@@ -1,0 +1,23 @@
+desc "Creates a forum administrator"
+task "admin:create" => :environment do
+  require 'highline/import'
+  begin
+    admin = User.new
+    admin.email = ask("Email:")
+    admin.username = "admin"
+    begin
+      password = ask("Password:") {|q| q.echo = false}
+      password_confirmation = ask("Repeat password:") {|q| q.echo = false}
+    end while password != password_confirmation
+    admin.password = password
+    # admin.email_confirmed = true
+    saved = admin.save
+    if !saved
+      puts admin.errors.full_messages.join("\n")
+      next
+    end
+  end while !saved
+  admin.grant_admin!
+  admin.change_trust_level!(TrustLevel.levels.max_by{|k, v| v}[0])
+  admin.email_tokens.update_all  confirmed: true
+end


### PR DESCRIPTION
The pg_dumps are obsolete and mess up database schema if loaded. `admin:create` task asks for email and password (I think creating the user with default password is a bad idea) and creates an admin.
