### PR TITLE
Do not show mail password in email settings

### DIFF
--- a/spec/controllers/admin/email_controller_spec.rb
+++ b/spec/controllers/admin/email_controller_spec.rb
@@ -10,11 +10,21 @@ describe Admin::EmailController do
 
   context '.index' do
     before do
+      subject.expects(:action_mailer_settings).returns({
+        username: 'username',
+        password: 'secret'
+      })
+
       xhr :get, :index
     end
 
-    subject { response }
-    it { should be_success }
+    it 'does not include the password in the response' do
+      mail_settings = JSON.parse(response.body)['settings']
+
+      expect(
+        mail_settings.select { |setting| setting['name'] == 'password' }
+      ).to be_empty
+    end
   end
 
   context '.logs' do


### PR DESCRIPTION
Fixes [meta/7386](http://meta.discourse.org/t/mail-settings-shows-password-in-clear-text/7386)

There's no reason we need to see the mail password when looking at the mail settings (and it's probably not something you want in plain text anyway). This removes the setting from the response.
