### PR TITLE
added a reverse index of user uploads + rake task

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -17,7 +17,6 @@ class Post < ActiveRecord::Base
 
   rate_limit
 
-
   belongs_to :user
   belongs_to :topic, counter_cache: :posts_count
   belongs_to :reply_to_user, class_name: "User"
@@ -25,6 +24,8 @@ class Post < ActiveRecord::Base
   has_many :post_replies
   has_many :replies, through: :post_replies
   has_many :post_actions
+
+  has_and_belongs_to_many :upload
 
   has_one :post_search_data
 

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -7,6 +7,8 @@ class Upload < ActiveRecord::Base
   belongs_to :user
   belongs_to :topic
 
+  has_and_belongs_to_many :post
+
   validates_presence_of :filesize
   validates_presence_of :original_filename
 

--- a/db/migrate/20130612200846_create_post_upload_join_table.rb
+++ b/db/migrate/20130612200846_create_post_upload_join_table.rb
@@ -1,0 +1,12 @@
+class CreatePostUploadJoinTable < ActiveRecord::Migration
+  def change
+  	create_table :posts_uploads, id: false do |t|
+  		t.integer :post_id
+  		t.integer :upload_id
+  	end
+
+  	add_index :posts_uploads, :post_id
+  	add_index :posts_uploads, :upload_id
+  	add_index :posts_uploads, [:post_id, :upload_id], unique: true
+  end
+end

--- a/lib/tasks/images.rake
+++ b/lib/tasks/images.rake
@@ -10,3 +10,39 @@ task "images:compress" => :environment do
   end
 end
 
+desc "updates reverse index of image uploads"
+task "images:reindex" => :environment do
+	RailsMultisite::ConnectionManagement.each_connection do |db|
+		puts "Reindexing #{db}"
+    Post.select([:id, :cooked]).find_each do |p|
+			doc = Nokogiri::HTML::fragment(p.cooked)
+			doc.search("img").each do |img|
+				src = img['src']
+				if src.present? && has_been_uploaded?(src) && m = uploaded_regex.match(src)
+          begin
+  					Post.exec_sql("INSERT INTO posts_uploads (post_id, upload_id) VALUES (?, ?)", p.id, m[:upload_id])
+          rescue ActiveRecord::RecordNotUnique
+          end
+				end
+			end
+			putc "."
+		end
+  end
+  puts "\ndone."
+end
+
+def uploaded_regex
+  /\/uploads\/#{RailsMultisite::ConnectionManagement.current_db}\/(?<upload_id>\d+)\/[0-9a-f]{16}\.(png|jpg|jpeg|gif|tif|tiff|bmp)/
+end
+
+def has_been_uploaded?(url)
+  url =~ /^\/[^\/]/ || url.start_with?(base_url) || (asset_host.present? && url.start_with?(asset_host))
+end
+
+def base_url
+  asset_host.present? ? asset_host : Discourse.base_url_no_prefix
+end
+
+def asset_host
+  ActionController::Base.asset_host
+end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -26,6 +26,8 @@ describe Post do
   it { should have_many :post_replies }
   it { should have_many :replies }
 
+  it { should have_and_belong_to_many :upload }
+
   it { should rate_limit }
 
   let(:topic) { Fabricate(:topic) }

--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -5,6 +5,8 @@ describe Upload do
   it { should belong_to :user }
   it { should belong_to :topic }
 
+  it { should have_and_belong_to_many :post }
+
   it { should validate_presence_of :original_filename }
   it { should validate_presence_of :filesize }
 
@@ -38,7 +40,7 @@ describe Upload do
     end
 
     context "s3" do
-      before(:each) do 
+      before(:each) do
         SiteSetting.stubs(:enable_s3_uploads?).returns(true)
         S3.stubs(:store_file).returns(url)
       end


### PR DESCRIPTION
This adds a reverse index of user uploads (ie. mapping posts to uploads).
There's also a rake task (`rake images:reindex`) to backfill the index. 
