### PR TITLE
less brittle specs to os-specific line endings

### DIFF
--- a/spec/components/oneboxer/amazon_onebox_spec.rb
+++ b/spec/components/oneboxer/amazon_onebox_spec.rb
@@ -15,7 +15,7 @@ describe Oneboxer::AmazonOnebox do
   end
 
   it "generates the expected onebox for Amazon" do
-    @o.onebox.should == expected_amazon_result
+    @o.onebox.should match_html expected_amazon_result
   end
 
 private

--- a/spec/components/oneboxer/android_app_store_onebox_spec.rb
+++ b/spec/components/oneboxer/android_app_store_onebox_spec.rb
@@ -11,7 +11,7 @@ describe Oneboxer::AndroidAppStoreOnebox do
   end
 
   it "generates the expected onebox for Android App Store" do
-    @o.onebox.should == expected_android_app_store_result
+    @o.onebox.should match_html expected_android_app_store_result
   end
 
 private

--- a/spec/components/oneboxer/apple_app_onebox_spec.rb
+++ b/spec/components/oneboxer/apple_app_onebox_spec.rb
@@ -11,7 +11,7 @@ describe Oneboxer::AppleAppOnebox do
   end
 
   it "generates the expected onebox for Apple app" do
-    @o.onebox.should == expected_apple_app_result
+    @o.onebox.should match_html expected_apple_app_result
   end
 
 private

--- a/spec/components/oneboxer/flickr_onebox_spec.rb
+++ b/spec/components/oneboxer/flickr_onebox_spec.rb
@@ -11,7 +11,7 @@ describe Oneboxer::FlickrOnebox do
   end
 
   it "generates the expected onebox for Flickr" do
-    @o.onebox.should == expected_flickr_result
+    @o.onebox.should match_html expected_flickr_result
   end
 
 private

--- a/spec/components/oneboxer/rottentomatoes_onebox_spec.rb
+++ b/spec/components/oneboxer/rottentomatoes_onebox_spec.rb
@@ -13,19 +13,19 @@ describe Oneboxer::RottentomatoesOnebox do
   it 'generates the expected onebox for a fresh movie' do
     o = Oneboxer::RottentomatoesOnebox.new('http://www.rottentomatoes.com/m/mud_2012/')
     FakeWeb.register_uri(:get, o.translate_url, response: fixture_file('oneboxer/rottentomatoes_fresh.response'))
-    expect(o.onebox).to eq(expected_fresh_result)
+    o.onebox.should match_html expected_fresh_result
   end
 
   it 'generates the expected onebox for a rotten movie' do
     o = Oneboxer::RottentomatoesOnebox.new('http://www.rottentomatoes.com/m/the_big_wedding_2013/')
     FakeWeb.register_uri(:get, o.translate_url, response: fixture_file('oneboxer/rottentomatoes_rotten.response'))
-    expect(o.onebox).to eq(expected_rotten_result)
+    o.onebox.should match_html expected_rotten_result
   end
 
   it 'generates the expected onebox for a movie with an incomplete description' do
     o = Oneboxer::RottentomatoesOnebox.new('http://www.rottentomatoes.com/m/gunde_jaari_gallanthayyinde/')
     FakeWeb.register_uri(:get, o.translate_url, response: fixture_file('oneboxer/rottentomatoes_incomplete.response'))
-    expect(o.onebox).to eq(expected_incomplete_result)
+    o.onebox.should match_html expected_incomplete_result
   end
 
 private

--- a/spec/components/oneboxer/wikipedia_onebox_spec.rb
+++ b/spec/components/oneboxer/wikipedia_onebox_spec.rb
@@ -10,7 +10,7 @@ describe Oneboxer::WikipediaOnebox do
     o = Oneboxer::WikipediaOnebox.new('http://en.wikipedia.org/wiki/Ruby')
     FakeWeb.register_uri(:get, o.translate_url, response: fixture_file('oneboxer/wikipedia.response'))
     FakeWeb.register_uri(:get, 'http://en.m.wikipedia.org/wiki/Ruby', response: fixture_file('oneboxer/wikipedia_redirected.response'))
-    o.onebox.should == expected_wikipedia_result
+    o.onebox.should match_html expected_wikipedia_result
   end
 
   it "accepts .com extention" do

--- a/spec/support/match_html_matcher.rb
+++ b/spec/support/match_html_matcher.rb
@@ -1,17 +1,17 @@
 require 'nokogiri/xml/parse_options'
 RSpec::Matchers.define :match_html do |expected|
   match do |actual|
-    a = make_canonical_html expected
-    b = make_canonical_html actual
-    a.to_html == b.to_html
+    a = make_canonical_html(expected).to_html.gsub("\r\n", "\n")
+    b = make_canonical_html(actual).to_html.gsub("\r\n", "\n")
+    a == b
   end
 
   failure_message_for_should do |actual|
-    "after sanitizing for extra white space and compactness, expected #{actual} to match #{expected}"
+    "after sanitizing for extra white space and compactness, expected:\n#{actual}\n to match:\n#{expected}"
   end
 
   failure_message_for_should_not do |actual|
-    "after sanitizing for extra white space and compactness, expected #{actual} not to match #{expected}"
+    "after sanitizing for extra white space and compactness, expected:\n#{actual}\n not to match:\n#{expected}"
   end
 
   def make_canonical_html(html)


### PR DESCRIPTION
Specs now pass in the vagrant box when running it on Windows:

![image](https://f.cloud.github.com/assets/362783/647562/225a5e22-d409-11e2-831b-412c752fb049.png)
