### PR TITLE
correct crontab entry for RVM system-wide installation

### DIFF
--- a/docs/INSTALL-ubuntu.md
+++ b/docs/INSTALL-ubuntu.md
@@ -285,6 +285,8 @@ Add the following line:
 
     @reboot RUBY_GC_MALLOC_LIMIT=90000000 RAILS_ROOT=~/discourse RAILS_ENV=production NUM_WEBS=4 /home/discourse/.rvm/bin/bootup_bluepill --no-privileged -c ~/.bluepill load ~/discourse/config/discourse.pill
 
+Note: in case of RVM system-wide installation RVM will be located in `/usr/local/rvm` directory instead of `/home/discourse/.rvm`, so update the line above respectively.
+
 Congratulations! You've got Discourse installed and running!
 
 Now make yourself an administrator account. Browse to your discourse instance


### PR DESCRIPTION
Run into this issue, when was installing Discourse. It's not noticeable right away, since it's inside the long command. The effect - Discourse silently doesn't start after rebooting. Hope this note will be useful especially for people who are not familiar with RVM, and are not sure which option to choose system-wide or single-user installation.
