### PR TITLE
Link Twitter handles and hashtags in Twitter onebox

### DIFF
--- a/lib/oneboxer/twitter_onebox.rb
+++ b/lib/oneboxer/twitter_onebox.rb
@@ -24,15 +24,15 @@ module Oneboxer
       result['created_at'] =
         Time.parse(result['created_at']).strftime("%I:%M%p - %d %b %y")
 
-      result['text'] = link_urls_and_handles_in result['text']
+      result['text'] = link_all_the_things_in result['text']
 
       result
     end
 
     private
 
-    def link_urls_and_handles_in(text)
-      link_handles_in link_urls_in(text)
+    def link_all_the_things_in(text)
+      link_hashtags_in link_handles_in link_urls_in(text)
     end
 
     def link_urls_in(text)
@@ -48,6 +48,19 @@ module Oneboxer
         text.gsub!("@#{handle}", [
           "<a href='https://twitter.com/#{handle}' target='_blank'>",
             "@#{handle}",
+          "</a>"
+        ].join)
+      end
+
+      text
+    end
+
+    def link_hashtags_in(text)
+      text.scan(/\s#(\w+)/).flatten.uniq.each do |hashtag|
+        text.gsub!("##{hashtag}", [
+          "<a href='https://twitter.com/search?q=%23#{hashtag}' ",
+          "target='_blank'>",
+            "##{hashtag}",
           "</a>"
         ].join)
       end

--- a/spec/components/oneboxer/twitter_onebox_spec.rb
+++ b/spec/components/oneboxer/twitter_onebox_spec.rb
@@ -38,6 +38,19 @@ describe Oneboxer::TwitterOnebox do
         ].join)
       end
     end
+
+    context 'when the text contains a hashtag' do
+      let(:text) { 'No secrets. #NSA' }
+
+      it 'wraps each hashtag in a link' do
+        expect(subject.parse(data)['text']).to eq([
+          "No secrets. ",
+          "<a href='https://twitter.com/search?q=%23NSA' target='_blank'>",
+            "#NSA",
+          "</a>"
+        ].join)
+      end
+    end
   end
 end
 


### PR DESCRIPTION
Link all the things!

Besides linking twitter handles and hashtags, this PR also adds tests for `TwitterOnebox#parse`

![link-handles](https://f.cloud.github.com/assets/65323/652458/f516914c-d4a8-11e2-8e37-5b96ec4c91b2.jpg)

![link-hashtags](https://f.cloud.github.com/assets/65323/652459/f7f6de26-d4a8-11e2-9f7c-a3e8c40072e7.jpg)
