### PR TITLE
Added a line to activate the user from the rails console

### DIFF
--- a/docs/INSTALL-ubuntu.md
+++ b/docs/INSTALL-ubuntu.md
@@ -298,6 +298,7 @@ and create an account by logging in normally, then run the commands:
 
     # (in rails console)
     > me = User.find_by_username_or_email('myemailaddress@me.com')[0]
+    > me.activate #use this in case you haven't configured your mail server and therefore can't receive the activation mail.
     > me.admin = true
     > me.save
 


### PR DESCRIPTION
I added a line to activate the user from the rails console, for the case when the mail server hasn't been configured yet and discourse can't send activation mails. It is a pretty minor steps but I believe it may avoid confusion while trying to deploy discourse the first time, which I just did myself.
