### PR TITLE
added a rake task to clean orphan uploaded files

### DIFF
--- a/lib/local_store.rb
+++ b/lib/local_store.rb
@@ -15,4 +15,9 @@ module LocalStore
     return Discourse::base_uri + "#{url_root}/#{clean_name}"
   end
 
+  def self.remove_file(url)
+    File.delete("#{Rails.root}/public#{url}")
+  rescue Errno::ENOENT
+  end
+
 end

--- a/lib/tasks/images.rake
+++ b/lib/tasks/images.rake
@@ -30,3 +30,22 @@ task "images:reindex" => :environment do
   end
   puts "\ndone."
 end
+
+desc "clean orphan uploaded files"
+task "images:clean_orphans" => :environment do
+  RailsMultisite::ConnectionManagement.each_connection do |db|
+    puts "Cleaning up #{db}"
+    # ligthweight safety net to prevent users from wiping all their uploads out
+    if PostUpload.count == 0 && Upload.count > 0
+      puts "The reverse index is empty. Make sure you run the `images:reindex` task"
+      next
+    end
+    Upload.joins("LEFT OUTER JOIN post_uploads ON uploads.id = post_uploads.upload_id")
+          .where("post_uploads.upload_id IS NULL")
+          .find_each do |u|
+      u.delete
+      putc "."
+    end
+  end
+  puts "\ndone."
+end

--- a/spec/components/local_store_spec.rb
+++ b/spec/components/local_store_spec.rb
@@ -15,7 +15,7 @@ describe LocalStore do
 
     let(:image_info) { FastImage.new(file) }
 
-    it 'returns the url of the S3 upload if successful' do
+    it 'returns the url of the uploaded file if successful' do
       # prevent the tests from creating directories & files...
       FileUtils.stubs(:mkdir_p)
       File.stubs(:open)

--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -62,17 +62,17 @@ describe Upload do
 
     it "identifies internal or relatives urls" do
       Discourse.expects(:base_url_no_prefix).returns("http://discuss.site.com")
-      Upload.has_been_uploaded?("http://discuss.site.com/upload/1234/42/ABCD.jpg").should == true
-      Upload.has_been_uploaded?("/upload/42/ABCD.jpg").should == true
+      Upload.has_been_uploaded?("http://discuss.site.com/upload/1234/42/0123456789ABCDEF.jpg").should == true
+      Upload.has_been_uploaded?("/upload/42/0123456789ABCDEF.jpg").should == true
     end
 
     it "identifies internal urls when using a CDN" do
       ActionController::Base.expects(:asset_host).returns("http://my.cdn.com").twice
-      Upload.has_been_uploaded?("http://my.cdn.com/upload/1234/42/ABCD.jpg").should == true
+      Upload.has_been_uploaded?("http://my.cdn.com/upload/1234/42/0123456789ABCDEF.jpg").should == true
     end
 
     it "identifies external urls" do
-      Upload.has_been_uploaded?("http://domain.com/upload/1234/42/ABCD.jpg").should == false
+      Upload.has_been_uploaded?("http://domain.com/upload/1234/42/0123456789ABCDEF.jpg").should == false
     end
 
   end


### PR DESCRIPTION
Meta: [Orphan uploaded files clean-up mechanism](http://meta.discourse.org/t/orphan-uploaded-files-clean-up-mechanism/7515/2)

This adds a the `images:clean_orphans` rake task that can be used to clean up all the orphan uploaded files.
