### PR TITLE
Allow to use a text logo when logo_url setting is set to an empty value

### DIFF
--- a/app/assets/javascripts/discourse/views/header_view.js
+++ b/app/assets/javascripts/discourse/views/header_view.js
@@ -87,20 +87,25 @@ Discourse.HeaderView = Discourse.View.extend({
 
   /**
     Display the correct logo in the header, showing a custom small icon if it exists.
-
+    In case the logo_url setting is empty, shows the site title as the logo.
     @property logoHTML
   **/
   logoHTML: function() {
     var result = "<div class='title'><a href='" + Discourse.getURL("/") + "'>";
     if (this.get('controller.showExtraInfo')) {
-      var logo = Discourse.SiteSettings.logo_small_url;
-      if (logo && logo.length > 1) {
-        result += "<img class='logo-small' src='" + logo + "' width='33' height='33'>";
+      var logoSmall = Discourse.SiteSettings.logo_small_url;
+      if (logoSmall && logoSmall.length > 1) {
+        result += "<img class='logo-small' src='" + logoSmall + "' width='33' height='33'>";
       } else {
         result += "<i class='icon-home'></i>";
       }
     } else {
-      result += "<img class='logo-big' src=\"" + Discourse.SiteSettings.logo_url + "\" alt=\"" + Discourse.SiteSettings.title + "\" id='site-logo'>";
+      var logo = Discourse.SiteSettings.logo_url;
+      if(logo && logo.length > 1) {
+        result += "<img class='logo-big' src=\"" + logo + "\" alt=\"" + Discourse.SiteSettings.title + "\" id='site-logo'>";
+      } else {
+        result += "<h2 class='text-logo' id='site-text-logo'>" + Discourse.SiteSettings.title + "</h2>"
+      }
     }
     result += "</a></div>";
     return new Handlebars.SafeString(result);


### PR DESCRIPTION
Added a conditional that now tests if the logo_url is empty. In case it is, the logoHTML function now returns a header tag with the site_title as its value, instead of returning an image tag that would only show the alt text in the browser.

Situation: SiteSetting.logo_url = ""

Before changes:

![screen shot 2013-06-20 at 1 28 53 pm](https://f.cloud.github.com/assets/2272207/682409/9b57dee0-d9c6-11e2-93c8-dfc85760c833.png)

After changes:

![screen shot 2013-06-20 at 1 15 58 pm](https://f.cloud.github.com/assets/2272207/682317/db1c9478-d9c4-11e2-8851-4c5908105c7a.png)
