### PR TITLE
Use "command -v" to test for convert instead of "which -s"

### DIFF
--- a/app/models/admin_dashboard_data.rb
+++ b/app/models/admin_dashboard_data.rb
@@ -107,7 +107,7 @@ class AdminDashboardData
   end
 
   def image_magick_check
-    I18n.t('dashboard.image_magick_warning') if SiteSetting.create_thumbnails and !system("which -s convert")
+    I18n.t('dashboard.image_magick_warning') if SiteSetting.create_thumbnails and !system("command -v convert >/dev/null;")
   end
 
   def failing_emails_check


### PR DESCRIPTION
Command -v is generally considered to be more portable, see also the discussion here: http://meta.discourse.org/t/admin-warns-imagemagick-not-installed-when-it-is/7673/4
