### PR TITLE
Video onebox

### DIFF
--- a/lib/oneboxer/video_onebox.rb
+++ b/lib/oneboxer/video_onebox.rb
@@ -6,7 +6,7 @@ module Oneboxer
     matcher /^https?:\/\/.*\.(mov|mp4|ogg)$/
 
     def onebox
-      "<video width='100%' height='100%' controls><source src='#{@url}'></video>"
+      "<video width='100%' height='100%' controls><source src='#{@url}'><a href='#{@url}'>#{@url}</a></video>"
     end
 
   end


### PR DESCRIPTION
Uses an HTML5 video tag and fallsback to a link.

Example URL:
http://get.pow.cx/media/screencast.mov
