### PR TITLE
FIX: lightbox wasn't working when using s3 upload

### DIFF
--- a/db/migrate/20130622110348_add_url_index_to_uploads.rb
+++ b/db/migrate/20130622110348_add_url_index_to_uploads.rb
@@ -1,0 +1,5 @@
+class AddUrlIndexToUploads < ActiveRecord::Migration
+  def change
+    add_index :uploads, :url
+  end
+end

--- a/lib/local_store.rb
+++ b/lib/local_store.rb
@@ -20,4 +20,8 @@ module LocalStore
   rescue Errno::ENOENT
   end
 
+  def self.uploaded_regex
+    /\/uploads\/#{RailsMultisite::ConnectionManagement.current_db}\/(?<upload_id>\d+)\/[0-9a-f]{16}\.(png|jpg|jpeg|gif|tif|tiff|bmp)/
+  end
+
 end

--- a/lib/s3.rb
+++ b/lib/s3.rb
@@ -9,7 +9,11 @@ module S3
 
     # if this fails, it will throw an exception
     file = S3.upload(file, remote_filename, directory)
-    return "//#{SiteSetting.s3_upload_bucket}.s3.amazonaws.com/#{remote_filename}"
+    "#{S3.base_url}/#{remote_filename}"
+  end
+
+  def self.base_url
+    "//#{SiteSetting.s3_upload_bucket}.s3.amazonaws.com"
   end
 
   def self.remove_file(url)

--- a/spec/components/cooked_post_processor_spec.rb
+++ b/spec/components/cooked_post_processor_spec.rb
@@ -164,15 +164,15 @@ describe CookedPostProcessor do
     end
   end
 
-  context 'get_image_uri' do
+  context 'is_valid_image_uri?' do
 
-    it "returns nil unless the scheme is either http or https" do
-      cpp.get_image_uri("http://domain.com").should   == URI.parse("http://domain.com")
-      cpp.get_image_uri("https://domain.com").should  == URI.parse("https://domain.com")
-      cpp.get_image_uri("ftp://domain.com").should    == nil
-      cpp.get_image_uri("ftps://domain.com").should   == nil
-      cpp.get_image_uri("//domain.com").should        == nil
-      cpp.get_image_uri("/tmp/image.png").should      == nil
+    it "needs the scheme to be either http or https" do
+      cpp.is_valid_image_uri?("http://domain.com").should   == true
+      cpp.is_valid_image_uri?("https://domain.com").should  == true
+      cpp.is_valid_image_uri?("ftp://domain.com").should    == false
+      cpp.is_valid_image_uri?("ftps://domain.com").should   == false
+      cpp.is_valid_image_uri?("//domain.com").should        == false
+      cpp.is_valid_image_uri?("/tmp/image.png").should      == false
     end
 
   end

--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -71,8 +71,15 @@ describe Upload do
       Upload.has_been_uploaded?("http://my.cdn.com/upload/1234/42/0123456789ABCDEF.jpg").should == true
     end
 
+    it "identifies S3 uploads" do
+      SiteSetting.stubs(:enable_s3_uploads).returns(true)
+      SiteSetting.stubs(:s3_upload_bucket).returns("bucket")
+      Upload.has_been_uploaded?("//bucket.s3.amazonaws.com/1337.png").should == true
+    end
+
     it "identifies external urls" do
       Upload.has_been_uploaded?("http://domain.com/upload/1234/42/0123456789ABCDEF.jpg").should == false
+      Upload.has_been_uploaded?("//bucket.s3.amazonaws.com/1337.png").should == false
     end
 
   end


### PR DESCRIPTION
Meta: [7432/14](http://meta.discourse.org/t/file-uploads-with-filepicker-io/7432/14)

Lightbox wasn't working when using s3 upload because `FastImage` can't deal with schemaless URIs.
