### PR TITLE
do not lightbox oneboxed images

### DIFF
--- a/lib/cooked_post_processor.rb
+++ b/lib/cooked_post_processor.rb
@@ -22,7 +22,7 @@ class CookedPostProcessor
   end
 
   def post_process_images
-    images = @doc.search("img")
+    images = @doc.css("img") - @doc.css(".onebox-result img")
     return unless images.present?
 
     images.each do |img|

--- a/spec/components/cooked_post_processor_spec.rb
+++ b/spec/components/cooked_post_processor_spec.rb
@@ -111,6 +111,21 @@ describe CookedPostProcessor do
       end
     end
 
+    context 'with a oneboxed image' do
+      let(:user) { Fabricate(:user) }
+      let(:topic) { Fabricate(:topic, user: user) }
+      let(:post) { Fabricate.build(:post_with_oneboxed_image, topic: topic, user: user) }
+      let(:processor) { CookedPostProcessor.new(post) }
+
+      before do
+        processor.post_process_images
+      end
+
+      it "doesn't lightbox" do
+        processor.html.should_not =~ /class="lightbox"/
+      end
+    end
+
   end
 
   context 'link convertor' do

--- a/spec/fabricators/post_fabricator.rb
+++ b/spec/fabricators/post_fabricator.rb
@@ -46,6 +46,14 @@ Fabricator(:post_with_uploads, from: :post) do
   "
 end
 
+Fabricator(:post_with_oneboxed_image, from: :post) do
+  cooked "
+<div class='onebox-result'>
+<img src='/uploads/default/1/1234567890123456.jpg' height='100' width='100'>
+</div>
+  "
+end
+
 
 Fabricator(:basic_reply, from: :post) do
   user(:coding_horror)


### PR DESCRIPTION
This prevent the lightboxing treatment from happening when there are images inside _pre-cooked_ oneboxes (this happens when the oneboxes are already in the cache and are being injected during the cooking of the post before the `CookedPostProcessor` has a chance to do its job).
