### PR TITLE
reverting changes to the markdown conversion pipeline order

### DIFF
--- a/app/assets/javascripts/discourse/components/markdown.js
+++ b/app/assets/javascripts/discourse/components/markdown.js
@@ -109,8 +109,7 @@ Discourse.Markdown = {
 
     // Extract quotes so their contents are not passed through markdown.
     converter.hooks.chain("preConversion", function(text) {
-      var formated = Discourse.BBCode.format(text, opts);
-      var extracted = Discourse.BBCode.extractQuotes(formated);
+      var extracted = Discourse.BBCode.extractQuotes(text);
       quoteTemplate = extracted.template;
       return extracted.text;
     });
@@ -185,7 +184,7 @@ Discourse.Markdown = {
         text = quoteTemplate(text);
       }
 
-      return text;
+      return Discourse.BBCode.format(text, opts);
     });
 
     if (opts.sanitize) {

--- a/test/javascripts/components/markdown_test.js
+++ b/test/javascripts/components/markdown_test.js
@@ -68,16 +68,16 @@ test("Links", function() {
 test("Quotes", function() {
   cookedOptions("1[quote=\"bob, post:1\"]my quote[/quote]2",
                 { topicId: 2, lookupAvatar: function(name) { return "" + name; } },
-                "<p>1</p><aside class='quote' data-post=\"1\" > <br>\n  <div class='title'>\n    <div class='quote-controls'></div>\n" +
-                "  bob\n  bob\n  said:\n  </div>\n  <blockquote>my quote</blockquote>\n</aside> <br>\n<p>2</p>",
+                "<p>1</p><aside class='quote' data-post=\"1\" >\n  <div class='title'>\n    <div class='quote-controls'></div>\n" +
+                "  bob\n  bob\n  said:\n  </div>\n  <blockquote>my quote</blockquote>\n</aside>\n<p> <br>\n2</p>",
                 "handles quotes properly");
 
   cookedOptions("1[quote=\"bob, post:1\"]my quote[/quote]2",
                 { topicId: 2, lookupAvatar: function(name) { } },
-                "<p>1</p><aside class='quote' data-post=\"1\" > <br>\n  <div class='title'>\n    <div class='quote-controls'></div></p>\n" +
-                "\n<p>bob\n  said:\n  </div>\n  <blockquote>my quote</blockquote>\n</aside> <br>\n<p>2</p>",
+                "<p>1</p><aside class='quote' data-post=\"1\" >\n  <div class='title'>\n    <div class='quote-controls'></div>\n" +
+                "  \n  bob\n  said:\n  </div>\n  <blockquote>my quote</blockquote>\n</aside>\n<p> <br>\n2</p>",
                 "includes no avatar if none is found");
-});
+}); 
 
 test("Mentions", function() {
   cookedOptions("Hello @sam", { mentionLookup: (function() { return true; }) },
@@ -120,8 +120,9 @@ test("SanitizeHTML", function() {
 
 });
 
-test("with BBCode", function() {
-  cooked("[img]http://eviltrout.com/eviltrout.png[/img]",
-         "<p><img src=\"http://eviltrout.com/eviltrout.png\"></p>",
-         "BBCode is parsed first");
-});
+// TODO
+// test("with BBCode", function() {
+//   cooked("[img]http://eviltrout.com/eviltrout.png[/img]",
+//          "<p><img src=\"http://eviltrout.com/eviltrout.png\"></p>",
+//          "BBCode is parsed first");
+// });


### PR DESCRIPTION
Reverting the changes in the markdown's conversion pipeline order as this was messing up with quotes :cry: 

Need to find out another way to get `[IMG]http://foo.com/image.png[/IMG]` working.
