### PR TITLE
Minor typo fix in czech translation

### DIFF
--- a/config/locales/client.cs.yml
+++ b/config/locales/client.cs.yml
@@ -697,7 +697,7 @@ cs:
         success: "Díky! Odeslali jsme pozvánku na <b>{{email}}</b>. Dáme vám vědět, až bude pozvánka vyzvednuta. Na záložce pozvánek na vaší uživatelské stránce můžete sledovat koho jste pozvali."
         error: "Bohužel se nepodařilo pozvat tuto osobu. Není již registrovaným uživatelem?"
 
-      login_reply: 'Přihlašte se, chcete-li odpovědět'
+      login_reply: 'Přihlaste se, chcete-li odpovědět'
 
       filters:
         user: "{{n_posts}} {{by_n_users}}."

--- a/config/locales/server.cs.yml
+++ b/config/locales/server.cs.yml
@@ -1035,7 +1035,7 @@ cs:
   login_required:
     welcome_message: |
       #[Vítejte na %{title}](#welcome)
-      Jsme rádi, že vás tu máme a že přispíváte do tématu %{title}. Prosím, vytvořte si účet nebo se přihlašte pro pokračování.
+      Jsme rádi, že vás tu máme a že přispíváte do tématu %{title}. Prosím, vytvořte si účet nebo se přihlaste pro pokračování.
 
   terms_of_service:
     user_content_license: |


### PR DESCRIPTION
Changes occurences of "Přihlašte se" to correct "Přihlaste se".

Grammar source: http://www.proofreading.cz/?p=377
