### PR TITLE
FIX: urls in BBCode tags weren't working

### DIFF
--- a/test/javascripts/components/markdown_test.js
+++ b/test/javascripts/components/markdown_test.js
@@ -77,7 +77,7 @@ test("Quotes", function() {
                 "<p>1</p><aside class='quote' data-post=\"1\" >\n  <div class='title'>\n    <div class='quote-controls'></div>\n" +
                 "  \n  bob\n  said:\n  </div>\n  <blockquote>my quote</blockquote>\n</aside>\n<p> <br>\n2</p>",
                 "includes no avatar if none is found");
-}); 
+});
 
 test("Mentions", function() {
   cookedOptions("Hello @sam", { mentionLookup: (function() { return true; }) },
@@ -120,9 +120,18 @@ test("SanitizeHTML", function() {
 
 });
 
-// TODO
-// test("with BBCode", function() {
-//   cooked("[img]http://eviltrout.com/eviltrout.png[/img]",
-//          "<p><img src=\"http://eviltrout.com/eviltrout.png\"></p>",
-//          "BBCode is parsed first");
-// });
+test("URLs in BBCode tags", function() {
+
+  cooked("[img]http://eviltrout.com/eviltrout.png[/img][img]http://samsaffron.com/samsaffron.png[/img]",
+         "<p><img src=\"http://eviltrout.com/eviltrout.png\"><img src=\"http://samsaffron.com/samsaffron.png\"></p>",
+         "images are properly parsed");
+
+  cooked("[url]http://discourse.org[/url]",
+         "<p><a href=\"http://discourse.org\">http://discourse.org</a></p>",
+         "links are properly parsed");
+
+  cooked("[url=http://discourse.org]discourse[/url]",
+         "<p><a href=\"http://discourse.org\">discourse</a></p>",
+         "named links are properly parsed");
+
+});


### PR DESCRIPTION
BEFORE
![screen shot 2013-06-27 at 12 57 13 am](https://f.cloud.github.com/assets/362783/712876/d9895a94-deb3-11e2-9fd6-ccbc9279aa06.png)
AFTER
![screen shot 2013-06-27 at 12 57 44 am](https://f.cloud.github.com/assets/362783/712875/d9783304-deb3-11e2-935d-f88e688d90b7.png)

> "Live long and prosper" - Spock
