### PR TITLE
fix deep link to post in search

### DIFF
--- a/lib/search/search_result.rb
+++ b/lib/search/search_result.rb
@@ -41,7 +41,9 @@ class Search
     end
 
     def self.from_post(p)
-      SearchResult.from_topic(p.topic)
+      # we want the topic link when it's the OP
+      return SearchResult.from_topic(p.topic) if p.post_number == 1
+      SearchResult.new(type: :topic, id: p.topic.id, title: p.topic.title, url: p.url)
     end
 
   end

--- a/spec/components/search_spec.rb
+++ b/spec/components/search_spec.rb
@@ -126,6 +126,18 @@ describe Search do
       end
     end
 
+    context 'searching for a post' do
+      let!(:post) { Fabricate(:post, topic: topic, user: topic.user) }
+      let!(:reply) { Fabricate(:basic_reply, topic: topic, user: topic.user) }
+      let(:result) { first_of_type(Search.new('quote', type_filter: 'topic').execute, 'topic') }
+
+      it 'returns the post' do
+        result.should be_present
+        result[:title].should == topic.title
+        result[:url].should == reply.url
+      end
+    end
+
     context "search for a topic by id" do
       let(:result) { first_of_type(Search.new(topic.id, type_filter: 'topic').execute, 'topic') }
 
@@ -148,6 +160,7 @@ describe Search do
 
     context 'security' do
       let!(:post) { Fabricate(:post, topic: topic, user: topic.user) }
+
       def result(current_user)
         first_of_type(Search.new('hello', guardian: current_user).execute, 'topic')
       end


### PR DESCRIPTION
Returns the deep link to a post in the search result instead of always returning a link to the topic.
