### PR TITLE
FIX: updating  needs a restart

### DIFF
--- a/lib/validators/topic_title_length_validator.rb
+++ b/lib/validators/topic_title_length_validator.rb
@@ -1,16 +1,12 @@
 class TopicTitleLengthValidator < ActiveModel::EachValidator
 
-  def initialize(options)
-    @topic_title_validator = ActiveModel::Validations::LengthValidator.new({attributes: :title, in: SiteSetting.topic_title_length, allow_blank: true})
-    @private_message_title_validator = ActiveModel::Validations::LengthValidator.new({attributes: :title, in: SiteSetting.private_message_title_length, allow_blank: true})
-    super
-  end
-
   def validate_each(record, attribute, value)
     if record.private_message?
-      @private_message_title_validator.validate_each(record, attribute, value)
+      private_message_title_validator = ActiveModel::Validations::LengthValidator.new({attributes: :title, in: SiteSetting.private_message_title_length, allow_blank: true})
+      private_message_title_validator.validate_each(record, attribute, value)
     else
-      @topic_title_validator.validate_each(record, attribute, value)
+      topic_title_validator = ActiveModel::Validations::LengthValidator.new({attributes: :title, in: SiteSetting.topic_title_length, allow_blank: true})
+      topic_title_validator.validate_each(record, attribute, value)
     end
   end
 end

--- a/spec/components/validators/topic_title_length_validator_spec.rb
+++ b/spec/components/validators/topic_title_length_validator_spec.rb
@@ -5,8 +5,11 @@ require 'validators/topic_title_length_validator'
 
 describe TopicTitleLengthValidator do
 
-  let(:validator) { TopicTitleLengthValidator.new({attributes: :title}) }
-  subject(:validate) { validator.validate_each(record,:title,record.title) }
+  # simulate Rails behavior (singleton)
+  def validate
+    @validator ||= TopicTitleLengthValidator.new({ attributes: :title })
+    @validator.validate_each(record,:title,record.title)
+  end
 
   shared_examples "validating any topic title" do
     it 'adds an error when topic title is greater than SiteSetting.max_topic_title_length' do
@@ -31,14 +34,22 @@ describe TopicTitleLengthValidator do
       expect(record.errors[:title]).to_not be_present
     end
 
+    it 'is up to date' do
+      record.title = 'a' * (SiteSetting.min_topic_title_length)
+      validate
+      expect(record.errors[:title]).to_not be_present
+
+      SiteSetting.stubs(:min_topic_title_length).returns(2)
+
+      record.title = 'aaa'
+      validate
+      expect(record.errors[:title]).to_not be_present
+    end
+
     include_examples "validating any topic title"
   end
 
   describe 'private message' do
-    before do
-      SiteSetting.stubs(:min_private_message_title_length).returns(3)
-    end
-
     let(:record) { Fabricate.build(:private_message_topic) }
 
     it 'adds an error when topic title is shorter than SiteSetting.min_private_message_title_length' do
@@ -48,7 +59,6 @@ describe TopicTitleLengthValidator do
     end
 
     it 'does not add an error when topic title is shorter than SiteSetting.min_topic_title_length' do
-      SiteSetting.stubs(:min_topic_title_length).returns(15)
       record.title = 'a' * (SiteSetting.min_private_message_title_length)
       validate
       expect(record.errors[:title]).to_not be_present


### PR DESCRIPTION
Updating the `min-topic-title-length` setting wasn't updating the server-side validation for creating a new topic.

![39247914](https://f.cloud.github.com/assets/362783/725356/1fb62f22-e05f-11e2-8a25-42d585bbf949.jpg)
