### PR TITLE
add step to drop and recreate database before changing seed

### DIFF
--- a/docs/VAGRANT.md
+++ b/docs/VAGRANT.md
@@ -110,6 +110,7 @@ commands:
 ```
 vagrant ssh
 cd /vagrant
+bundle exec rake db:drop db:create
 psql discourse_development < pg_dumps/production-image.sql
 rake db:migrate
 rake db:test:prepare


### PR DESCRIPTION
This helped me resolve the error described in #949 when changing the database seed between `pg_dumps/development-image.sql` and `pg_dumps/production-image.sql`.
