### PR TITLE
Refactor duplicated #log method

### DIFF
--- a/lib/jobs.rb
+++ b/lib/jobs.rb
@@ -18,6 +18,14 @@ module Jobs
   class Base
     include Sidekiq::Worker
 
+    def log(*args)
+      puts args
+      args.each do |arg|
+        Rails.logger.info "#{Time.now.to_formatted_s(:db)}: [#{self.class.name.upcase}] #{arg}"
+      end
+      true
+    end
+
     def self.delayed_perform(opts={})
       self.new.perform(opts)
     end

--- a/lib/jobs/exporter.rb
+++ b/lib/jobs/exporter.rb
@@ -106,14 +106,6 @@ module Jobs
       true
     end
 
-    def log(*args)
-      puts args
-      args.each do |arg|
-        Rails.logger.info "#{Time.now.to_formatted_s(:db)}: [EXPORTER] #{arg}"
-      end
-      true
-    end
-
   end
 
 end

--- a/lib/jobs/importer.rb
+++ b/lib/jobs/importer.rb
@@ -276,14 +276,6 @@ module Jobs
       @warnings << message
     end
 
-    def log(*args)
-      puts args
-      args.each do |arg|
-        Rails.logger.info "#{Time.now.to_formatted_s(:db)}: [IMPORTER] #{arg}"
-      end
-      true
-    end
-
   end
 
 end


### PR DESCRIPTION
As an exercise and an introduction, @vipulnsward and I picked some low-hanging fruit (according to Code Climate).

For this one, there is one behavioral change, in that the logger will now log `[JOBS::EXPORTER]` rather than `[EXPORTER]`. We discussed using `demodulize` but decided to leave it as-is. Tests were not changed as logging was explicitly stubbed in the corresponding `Jobs` specs.

The work was done so we figured we might as well open the PR. Feedback is more than welcome.
