### PR TITLE
No need to include all ActionView::Helpers in Topic

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -7,7 +7,7 @@ require_dependency 'text_cleaner'
 require_dependency 'trashable'
 
 class Topic < ActiveRecord::Base
-  include ActionView::Helpers
+  include ActionView::Helpers::SanitizeHelper
   include RateLimiter::OnCreateRecord
   include Trashable
 


### PR DESCRIPTION
No need to include all ActionView::Helpers in Topic, we only need the sanitize helper.

This also fixes a bug in Rails 4 where image_url gets accidentally overridden.
