### PR TITLE
i18n transliteration map from Russian Cyrillic to ASCII

### DIFF
--- a/config/locales/transliterate.ru.yml
+++ b/config/locales/transliterate.ru.yml
@@ -1,0 +1,73 @@
+# encoding: utf-8
+# This file contains content for the i18n transliteration map from
+# Russian Cyrillic to ASCII (ISO-9:1995 / GOST 7.79-2000, table B)
+#
+# To validate this YAML file after you change it, please paste it into
+# http://yamllint.com/
+
+ru:
+  i18n:
+    transliterate:
+      rule:
+        А: A
+        а: a
+        Б: B
+        б: b
+        В: V
+        в: v
+        Г: G
+        г: g
+        Д: D
+        д: d
+        Е: E
+        е: e
+        Ё: Yo
+        ё: yo
+        Ж: Zh
+        ж: zh
+        З: Z
+        з: z
+        И: I
+        и: i
+        Й: J
+        й: j
+        К: K
+        к: k
+        Л: L
+        л: l
+        М: M
+        м: m
+        Н: N
+        н: n
+        О: O
+        о: o
+        П: P
+        п: p
+        Р: R
+        р: r
+        С: S
+        с: s
+        Т: T
+        т: t
+        У: U
+        у: u
+        Ф: F
+        ф: f
+        Х: X
+        х: x
+        Ц: Cz
+        ц: cz
+        Ч: Ch
+        ч: ch
+        Ш: Sh
+        ш: sh
+        Щ: Shh
+        щ: shh
+        Ы: Y
+        ы: y
+        Э: E
+        э: e
+        Ю: Yu
+        ю: yu
+        Я: Ya
+        я: ya


### PR DESCRIPTION
i18n transliteration map from Russian Cyrillic to ASCII
(ISO-9:1995 / GOST 7.79-2000, table B) for pretty URLs (slug)
