### PR TITLE
Improve the omniauth controller specs. Fix the email provided by CAS. Get name from CAS attributes.

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -140,9 +140,22 @@ class Users::OmniauthCallbacksController < ApplicationController
 
   def create_or_sign_on_user_using_cas(auth_token)
     logger.error "authtoken #{auth_token}"
-    email = "#{auth_token[:extra][:user]}@#{SiteSetting.cas_domainname}"
+
+    email = auth_token[:info][:email] if auth_token[:info]
+    email ||= if SiteSetting.cas_domainname.present?
+      "#{auth_token[:extra][:user]}@#{SiteSetting.cas_domainname}"
+    else
+      auth_token[:extra][:user]
+    end
+
     username = auth_token[:extra][:user]
-    name = auth_token["uid"]
+
+    name = if auth_token[:info] && auth_token[:info][:name]
+      auth_token[:info][:name]
+    else
+      auth_token["uid"]
+    end
+
     cas_user_id = auth_token["uid"]
 
     session[:authentication] = {


### PR DESCRIPTION
Our main issue was the email ending in "@" if no cas_domainname was configured. The specs got improved along the way.
/cc @eriko
- Make omniauth controller specs more robust by using shared examples for all authentication providers in controller spec. – Still passing. Yay!
- Return "casuser", instead of "casuser@" when no cas_domainname is configured.
- If no cas_domainname is configured, the CAS authentication would return "casuser@" for the users email field, because it tried to assume the email adress of the CAS user by it's username + cas_domainname.
  Now it just returns the username instead of adding an "@" if cas_domainname is not configured.
  This especially makes sense on CAS setups where the username equals the users email adress.
  The old behaviour, if cas_domainname is configured, was not changed.
- Fetch the email from CAS attributes if provided
  If the cas:authenticationSuccess (handled via omniauth-cas) response gives us an email use that.
  If not, behave as before (username or username@cas_domainname).
- Fetch the (full) name from CAS attributes if provided
  If the CAS response by omniauth provides a [:info][:name] field, prefer this over the uid, because we want the name to be a "Full Name", instead of just a "shortname"
