### PR TITLE
FIX: new users are allowed to upload images to your servers

### DIFF
--- a/app/assets/javascripts/discourse/components/utilities.js
+++ b/app/assets/javascripts/discourse/components/utilities.js
@@ -172,6 +172,11 @@ Discourse.Utilities = {
         return false;
       } else if (files.length > 0) {
         var upload = files[0];
+        // ensures that new users can upload image
+        if (Discourse.User.current('trust_level') === 0 && Discourse.SiteSettings.newuser_max_images === 0) {
+          bootbox.alert(Em.String.i18n('post.errors.upload_not_allowed_for_new_user'));
+          return false;
+        }
         // if the image was pasted, sets its name to a default one
         if (upload instanceof Blob && !(upload instanceof File) && upload.type === "image/png") { upload.name = "blob.png"; }
         // check that the uploaded file is authorized

--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -205,7 +205,7 @@ class SiteSetting < ActiveRecord::Base
   setting(:max_word_length, 30)
 
   setting(:newuser_max_links, 2)
-  setting(:newuser_max_images, 0)
+  client_setting(:newuser_max_images, 0)
 
   setting(:newuser_spam_host_threshold, 3)
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -746,6 +746,7 @@ en:
         upload_too_large: "Sorry, the file you are trying to upload is too big (maximum size is {{max_size_kb}}kb), please resize it and try again."
         too_many_uploads: "Sorry, you can only upload one file at a time."
         upload_not_authorized: "Sorry, the file you are trying to upload is not authorized (authorized extension: {{authorized_extensions}})."
+        upload_not_allowed_for_new_user: "Sorry, new users can not upload images."
 
       abandon: "Are you sure you want to abandon your post?"
 

--- a/config/locales/client.fr.yml
+++ b/config/locales/client.fr.yml
@@ -729,6 +729,7 @@ fr:
         upload_too_large: "Désolé, le fichier que vous êtes en train d'envoyer est trop grand (maximum {{max_size_kb}}Kb). Merci de le redimensionner et de réessayer."
         too_many_uploads: "Désolé, vous ne pouvez envoyer qu'un seul fichier à la fois."
         upload_not_authorized: "Désole, le fichier que vous êtes en train d'uploader n'est pas autorisé (extensions autorisées : {{authorized_extensions}})."
+        upload_not_allowed_for_new_user: "Désolé, les nouveaux utilisateurs ne peuvent pas uploader d'images."
 
       abandon: "Voulez-vous vraiment abandonner ce message ?"
 

--- a/test/javascripts/components/utilities_test.js
+++ b/test/javascripts/components/utilities_test.js
@@ -23,6 +23,15 @@ test("uploading one file", function() {
   ok(bootbox.alert.calledWith(Em.String.i18n('post.errors.too_many_uploads')));
 });
 
+test("new user", function() {
+  Discourse.SiteSettings.newuser_max_images = 0;
+  this.stub(Discourse.User, 'current').withArgs("trust_level").returns(0);
+  this.stub(bootbox, "alert");
+
+  ok(!validUpload([1]));
+  ok(bootbox.alert.calledWith(Em.String.i18n('post.errors.upload_not_allowed_for_new_user')));
+});
+
 test("ensures an authorized upload", function() {
   var html = { name: "unauthorized.html" };
   var extensions = Discourse.SiteSettings.authorized_extensions.replace(/\|/g, ", ");


### PR DESCRIPTION
Meta: [New user allowed to upload images to your servers](http://meta.discourse.org/t/new-user-allowed-to-upload-images-to-your-servers/8073)

Prevents new users to upload images whenever the `newuser_max_images` site setting is set to **0**.
