### PR TITLE
Add :title as attribute for basic_topic

### DIFF
--- a/app/assets/javascripts/discourse/controllers/topic_controller.js
+++ b/app/assets/javascripts/discourse/controllers/topic_controller.js
@@ -149,10 +149,11 @@ Discourse.TopicController = Discourse.ObjectController.extend(Discourse.Selected
       // save the modifications
       topic.save().then(function(result){
         // update the title if it has been changed (cleaned up) server-side
-        var title = result.basic_topic.fancy_title;
+        var title       = result.basic_topic.title;
+        var fancy_title = result.basic_topic.fancy_title;
         topic.setProperties({
           title: title,
-          fancy_title: title
+          fancy_title: fancy_title
         });
 
       }, function(error) {

--- a/app/serializers/basic_topic_serializer.rb
+++ b/app/serializers/basic_topic_serializer.rb
@@ -1,4 +1,4 @@
 # The most basic attributes of a topic that we need to create a link for it.
 class BasicTopicSerializer < ApplicationSerializer
-  attributes :id, :fancy_title, :slug, :posts_count
+  attributes :id, :title, :fancy_title, :slug, :posts_count
 end

--- a/app/serializers/listable_topic_serializer.rb
+++ b/app/serializers/listable_topic_serializer.rb
@@ -13,7 +13,6 @@ class ListableTopicSerializer < BasicTopicSerializer
              :last_read_post_number,
              :unread,
              :new_posts,
-             :title,
              :pinned,
              :excerpt,
              :visible,


### PR DESCRIPTION
When we update the `<title>` after editing a topic, we should use the raw
`topic.title` as `topic.fancy_title` may contains some htmlentities and
will be displayed as is in the browser tab.

This fix the following issue:

> Incorrect HTML title after editing title/category of topic
> http://meta.discourse.org/t/incorrect-html-title-after-editing-title-category-of-topic/8136
