### PR TITLE
fix column name in admin email logs

### DIFF
--- a/app/assets/javascripts/admin/templates/email_logs.js.handlebars
+++ b/app/assets/javascripts/admin/templates/email_logs.js.handlebars
@@ -1,7 +1,7 @@
 <table class='table'>
   <tr>
     <th>{{i18n admin.email.sent_at}}</th>
-    <th>{{i18n user.title}}</th>
+    <th>{{i18n admin.email.user}}</th>
     <th>{{i18n admin.email.to_address}}</th>
     <th>{{i18n admin.email.email_type}}</th>
     <th>{{i18n admin.email.reply_key}}</th>

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -157,7 +157,6 @@ en:
 
     user:
       profile: Profile
-      title: "User"
       mute: Mute
       edit: Edit Preferences
       download_archive: "download archive of my posts"
@@ -1104,6 +1103,7 @@ en:
         settings: "Settings"
         logs: "Logs"
         sent_at: "Sent At"
+        user: "User"
         email_type: "Email Type"
         to_address: "To Address"
         test_email_address: "email address to test"

--- a/config/locales/client.fr.yml
+++ b/config/locales/client.fr.yml
@@ -165,7 +165,6 @@ fr:
 
     user:
       profile: "profil"
-      title: "Utilisateur"
       mute: "couper"
       edit: "Éditer les préférences"
       download_archive: "télécharger l'archive de mes messages"
@@ -1060,6 +1059,7 @@ fr:
         logs: "Logs"
         title: "Historique des mails"
         sent_at: "Envoyer à"
+        user: "Utilisateur"
         email_type: "Type d'email"
         to_address: "À l'adresse"
         test_email_address: "Adresse mail à tester"


### PR DESCRIPTION
Prevent this from happening:

![discourse_meta](https://f.cloud.github.com/assets/362783/757216/c87570ca-e67a-11e2-855d-35ad55a0a3d6.png)
