### PR TITLE
add label for boolean setting

### DIFF
--- a/app/assets/javascripts/admin/templates/site_settings/setting_bool.js.handlebars
+++ b/app/assets/javascripts/admin/templates/site_settings/setting_bool.js.handlebars
@@ -3,7 +3,9 @@
     <h3>{{unbound setting}}</h3>
   </div>
   <div class="span11">
-    {{view Ember.Checkbox checkedBinding="enabled" value="true"}}
-    {{unbound description}}
+    <label>
+      {{view Ember.Checkbox checkedBinding="enabled" value="true"}}
+      {{unbound description}}
+    </label>
   </div>
 {{/with}}


### PR DESCRIPTION
Add a `label` around boolean settings (ie. checkboxes) so that you can enable/disable a setting by clicking the description too.
