### PR TITLE
Mobile and tablet video rendering fix

### DIFF
--- a/app/assets/stylesheets/application/compose.css.scss
+++ b/app/assets/stylesheets/application/compose.css.scss
@@ -299,6 +299,10 @@
         webkit-border-radius: 4px;
         ms-border-radius: 4px;
       }
+      video {
+        max-width: 100%;
+        height: auto;
+      }
     }
     #wmd-preview {
       border: 1px dashed $gray;

--- a/app/assets/stylesheets/application/topic-post.css.scss
+++ b/app/assets/stylesheets/application/topic-post.css.scss
@@ -515,6 +515,10 @@
     img {
       max-width: 100%;
     }
+    video {
+      max-width: 100%;
+      height: auto;
+    }
     .topic-body {
       position: relative;
       .contents {

--- a/lib/oneboxer/video_onebox.rb
+++ b/lib/oneboxer/video_onebox.rb
@@ -6,7 +6,7 @@ module Oneboxer
     matcher /^https?:\/\/.*\.(mov|mp4|ogg)$/
 
     def onebox
-      "<video width='100%' height='100%' controls><source src='#{@url}'><a href='#{@url}'>#{@url}</a></video>"
+      "<video controls><source src='#{@url}'><a href='#{@url}'>#{@url}</a></video>"
     end
 
   end


### PR DESCRIPTION
http://meta.discourse.org/t/chrome-for-ipad-iphone-breaks-with-this-video-embed/7983
#### Safari on iPhone:

<img src="https://f.cloud.github.com/assets/2722987/765507/1cf1141a-e82e-11e2-8b5e-599a7e64e300.jpg" width="50%" height="50%"></img>
