### PR TITLE
Prevent errors in case #{rails_root}/tmp does not exist

### DIFF
--- a/config/discourse.pill.sample
+++ b/config/discourse.pill.sample
@@ -45,10 +45,8 @@ Bluepill.application("discourse", :base_dir => ENV["HOME"] + '/.bluepill') do |a
   app.uid = user
 
   app.working_dir = rails_root
-  tmpdir  = "#{rails_root}/tmp"
-  sockdir = "#{tmpdir}/sockets"
-  File.directory? tmpdir or Dir.mkdir tmpdir
-  File.directory? sockdir or Dir.mkdir sockdir
+  sockdir = "#{rails_root}/tmp/sockets"
+  File.directory? sockdir or FileUtils.mkdir_p sockdir
   num_webs.times do |i|
     app.process("thin-#{i}") do |process|
       process.start_command  = "bundle exec thin start -e production -t 0 --socket #{sockdir}/thin.#{i}.sock --pid #{rails_root}/tmp/pids/thin#{i}.pid --log #{rails_root}/log/thin-#{i}.log --daemonize"


### PR DESCRIPTION
Dir.mkdir is not recursive. i.e - It doesn't do the equivalent of `mkdir -p` but just plain `mkdir`.
And that is a problem if #{rails_root}/tmp is missing. More here.
http://meta.discourse.org/t/keep-getting-the-same-error-every-start/8214
