### PR TITLE
Correct caption of 'Make Visible' button

### DIFF
--- a/app/assets/javascripts/discourse/controllers/topic_admin_menu_controller.js
+++ b/app/assets/javascripts/discourse/controllers/topic_admin_menu_controller.js
@@ -7,15 +7,15 @@
   @module Discourse
 **/
 Discourse.TopicAdminMenuController = Discourse.ObjectController.extend({
-  visible: false,
+  menuVisible: false,
   needs: ['modal'],
 
   show: function() {
-    this.set('visible', true);
+    this.set('menuVisible', true);
   },
 
   hide: function() {
-    this.set('visible', false);
+    this.set('menuVisible', false);
   }
 
 });

--- a/app/assets/javascripts/discourse/templates/topic_admin_menu.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/topic_admin_menu.js.handlebars
@@ -1,4 +1,4 @@
-{{#if visible}}
+{{#if menuVisible}}
   <div class="topic-admin-menu">
     <h3>{{i18n admin_title}}</h3>
 


### PR DESCRIPTION
The variable 'visible' is also used for toggling the admin menu visibility,
so it is always true when the visibility toggle is shown. Hence, it's caption
is always 'Make Invisible', even when the topic already is invisible.
