### PR TITLE
Fix bug: pressing enter on the "forgot password" modal does not submit the form

### DIFF
--- a/app/assets/javascripts/discourse/templates/modal/forgot_password.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/modal/forgot_password.js.handlebars
@@ -1,9 +1,9 @@
-<div class="modal-body">
-    <form>
+<form>
+    <div class="modal-body">
       <label for='username-or-email'>{{i18n forgot_password.invite}}</label>
       {{textField value=accountEmailOrUsername placeholderKey="login.email_placeholder" id="username-or-email" autocorrect="off" autocapitalize="off"}}
-    </form>
-</div>
-<div class="modal-footer">
-  <button class='btn btn-large btn-primary' {{bindAttr disabled="submitDisabled"}} {{action submit}}>{{i18n forgot_password.reset}}</button>
-</div>
+    </div>
+    <div class="modal-footer">
+      <button class='btn btn-large btn-primary' {{bindAttr disabled="submitDisabled"}} {{action submit}}>{{i18n forgot_password.reset}}</button>
+    </div>
+</form>


### PR DESCRIPTION
This fixes https://github.com/discourse/discourse/issues/1190

Move the `<form>` element so the button is in the same form as the text box.
