### PR TITLE
FIX: Modal dialogs now truely center and work at all screen sizes (mobile)

### DIFF
--- a/app/assets/javascripts/discourse/templates/modal/modal.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/modal/modal.js.handlebars
@@ -1,16 +1,22 @@
-<div class="modal-header">
-  <a class="close" {{action closeModal}}><i class='icon-remove icon'></i></a>
-  <h3>{{title}}</h3>
-</div>
-<div id='modal-alert'></div>
+<div id='modal-outer-container'>
+  <div id='modal-middle-container'>
+    <div id='modal-inner-container'>
 
-{{outlet modalBody}}
+      <div class="modal-header">
+        <a class="close" {{action closeModal}}><i class='icon-remove icon'></i></a>
+        <h3>{{title}}</h3>
+      </div>
+      <div id='modal-alert'></div>
 
-{{#each errors}}
-  <div class="alert alert-error">
-    <button class="close" data-dismiss="alert">×</button>
-    {{this}}
+      {{outlet modalBody}}
+
+      {{#each errors}}
+        <div class="alert alert-error">
+          <button class="close" data-dismiss="alert">×</button>
+          {{this}}
+        </div>
+      {{/each}}
+
+    </div>
   </div>
-{{/each}}
-
-
+</div>

--- a/app/assets/stylesheets/application/modal.css.scss
+++ b/app/assets/stylesheets/application/modal.css.scss
@@ -38,14 +38,18 @@
   filter: alpha(opacity=80);
 }
 
-.modal {
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  z-index: 1050;
-  overflow: auto;
-  width: 610px;
-  margin: -250px 0 0 -305px;
+#modal-outer-container {
+  display:table;
+  width:100%;
+  height:100%;
+}
+#modal-middle-container {
+  display:table-cell;
+  vertical-align: middle;
+}
+#modal-inner-container {
+  max-width: 610px;
+  margin: 0 auto;
   background-color: #ffffff;
   border: 1px solid #999;
   border: 1px solid rgba(0, 0, 0, 0.3);
@@ -55,6 +59,14 @@
   @include border-radius-all (6px);
   box-shadow: 0 3px 7px rgba(0, 0, 0, 0.3);
   background-clip: padding-box;
+}
+.modal {
+  position: fixed;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 1050;
+  overflow: auto;
 }
 .modal.fade {
   -webkit-transition: opacity .3s linear, top .3s ease-out;


### PR DESCRIPTION
Fixes modal dialogs, having them be centered vertically and horizontally, and allows them to work at any screen size by allowing scrolling if needed (perfect test: Notify dialog on iPhone 4).

Yes, the 4 divs for a dialog are needed:
- One to define the "screen", to allow scrolling when the content gets too big/screen too small (#discourse-modal)
- Two to define a "table" to allow it to be vertically aligned (#modal-outer-container and #modal-middle-container)
- One finally to hold the modal dialog (#modal-inner-container)

Because this scales to smaller screen sizes, no additional styles are needed to make modals work on mobile :thumbsup:
