### PR TITLE
FIX: CDN doesn't work with S3

### DIFF
--- a/lib/pretty_text.rb
+++ b/lib/pretty_text.rb
@@ -166,17 +166,18 @@ module PrettyText
     return html unless url
 
     image = /\.(jpg|jpeg|gif|png|tiff|tif|bmp)$/
+    relative = /^\/[^\/]/
 
     doc = Nokogiri::HTML.fragment(html)
 
     doc.css("a").each do |l|
       href = l["href"].to_s
-      l["href"] = url + href if href[0] == '/' && href =~ image
+      l["href"] = url + href if href =~ relative && href =~ image
     end
 
     doc.css("img").each do |l|
       src = l["src"].to_s
-      l["src"] = url + src if src[0] == '/'
+      l["src"] = url + src if src =~ relative
     end
 
     doc.to_s

--- a/spec/components/cooked_post_processor_spec.rb
+++ b/spec/components/cooked_post_processor_spec.rb
@@ -62,7 +62,7 @@ describe CookedPostProcessor do
 
     end
 
-    context "with uploaded images" do
+    context "with locally uploaded images" do
 
       let(:upload) { Fabricate(:upload) }
       let(:post) { Fabricate(:post_with_uploaded_images) }

--- a/spec/components/pretty_text_spec.rb
+++ b/spec/components/pretty_text_spec.rb
@@ -213,9 +213,15 @@ test
       PrettyText.apply_cdn("<a href='/hello.png'>hello</a><img src='/a.jpeg'>","http://a.com").should ==
         "<a href=\"http://a.com/hello.png\">hello</a><img src=\"http://a.com/a.jpeg\">"
     end
+
     it "should not touch non images" do
       PrettyText.apply_cdn("<a href='/hello'>hello</a>","http://a.com").should ==
         "<a href=\"/hello\">hello</a>"
+    end
+
+    it "should not touch schemaless links" do
+      PrettyText.apply_cdn("<a href='//hello'>hello</a>","http://a.com").should ==
+        "<a href=\"//hello\">hello</a>"
     end
   end
 end


### PR DESCRIPTION
Meta: [CDN doesn't work with S3](http://meta.discourse.org/t/cdn-doesnt-work-with-s3/8262)

This make sure we don't prepend the CDN when using schemaless urls (eg. S3 uploads).
