### PR TITLE
Fix Graphical Error on Admin Dashboard

### DIFF
--- a/app/assets/javascripts/admin/routes/admin_flags_route.js
+++ b/app/assets/javascripts/admin/routes/admin_flags_route.js
@@ -1,0 +1,14 @@
+/**
+  Handles routes related to viewing flags.
+
+  @class AdminFlagsRoute
+  @extends Discourse.Route
+  @namespace Discourse
+  @module Discourse
+**/
+
+Discourse.AdminFlagsRoute = Discourse.Route.extend({
+  redirect: function() {
+    this.transitionTo('adminFlags.active');
+  }
+});

--- a/app/assets/javascripts/admin/routes/admin_users_list_routes.js
+++ b/app/assets/javascripts/admin/routes/admin_users_list_routes.js
@@ -9,6 +9,9 @@
 Discourse.AdminUsersListRoute = Discourse.Route.extend({
   renderTemplate: function() {
     this.render('admin/templates/users_list', {into: 'admin/templates/admin'});
+  },
+  redirect: function() {
+    this.transitionTo('adminUsersList.active');
   }
 });
 

--- a/app/assets/javascripts/admin/templates/admin.js.handlebars
+++ b/app/assets/javascripts/admin/templates/admin.js.handlebars
@@ -8,10 +8,10 @@
           <li>{{#linkTo 'admin.site_settings'}}{{i18n admin.site_settings.title}}{{/linkTo}}</li>
           <li>{{#linkTo 'adminSiteContents'}}{{i18n admin.site_content.title}}{{/linkTo}}</li>
         {{/if}}
-        <li>{{#linkTo 'adminUsersList.active'}}{{i18n admin.users.title}}{{/linkTo}}</li>
+        <li>{{#linkTo 'adminUsersList'}}{{i18n admin.users.title}}{{/linkTo}}</li>
         <li>{{#linkTo 'admin.groups'}}{{i18n admin.groups.title}}{{/linkTo}}</li>
         <li>{{#linkTo 'adminEmail'}}{{i18n admin.email.title}}{{/linkTo}}</li>
-        <li>{{#linkTo 'adminFlags.active'}}{{i18n admin.flags.title}}{{/linkTo}}</li>
+        <li>{{#linkTo 'adminFlags'}}{{i18n admin.flags.title}}{{/linkTo}}</li>
         {{#if currentUser.admin}}
           <li>{{#linkTo 'admin.customize'}}{{i18n admin.customize.title}}{{/linkTo}}</li>
           <li>{{#linkTo 'admin.api'}}{{i18n admin.api.title}}{{/linkTo}}</li>


### PR DESCRIPTION
When clicking on a subsection of the Users section of the admin dashboard, the "Users" link loses its active state.

![screen shot 2013-07-18 at 11 28 10 pm](https://f.cloud.github.com/assets/860486/823833/881aa57e-f023-11e2-8ba3-75ff9b1f559e.png)

Compare this to the Email section, which works properly:

![screen shot 2013-07-18 at 11 33 21 pm](https://f.cloud.github.com/assets/860486/823838/fe7e5ba2-f023-11e2-8f74-aea8c12fe78a.png)

This is because the "active" route is specifically linked to.  Compare the following, from `app/assets/javascripts/admin/templates/admin.js.handlebars`:

```
<li>{{#linkTo 'adminUsersList.active'}}{{i18n admin.users.title}}{{/linkTo}}</li>
...
<li>{{#linkTo 'adminEmail'}}{{i18n admin.email.title}}{{/linkTo}}</li>
```

To resolve this, I am redirecting to the "default" page instead of linking directly to it.  Flags has the same issue and was correctly similarly.

Feedback welcome, thanks!
