### PR TITLE
FIX: thumbnailing isn't working with CDN enabled

### DIFF
--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -91,7 +91,7 @@ class Upload < ActiveRecord::Base
   end
 
   def self.is_relative?(url)
-    url.start_with?("/uploads/")
+    url.start_with?(LocalStore.directory)
   end
 
   def self.is_local?(url)
@@ -103,6 +103,8 @@ class Upload < ActiveRecord::Base
   end
 
   def self.get_from_url(url)
+    # we store relative urls, so we need to remove any host/cdn
+    url = url.gsub(/^#{LocalStore.asset_host}/i, "") if LocalStore.asset_host.present?
     Upload.where(url: url).first if has_been_uploaded?(url)
   end
 

--- a/lib/local_store.rb
+++ b/lib/local_store.rb
@@ -4,7 +4,7 @@ module LocalStore
     unique_sha1 = Digest::SHA1.hexdigest("#{Time.now.to_s}#{file.original_filename}")[0,16]
     extension = File.extname(file.original_filename)
     clean_name = "#{unique_sha1}#{extension}"
-    url_root = "/uploads/#{RailsMultisite::ConnectionManagement.current_db}/#{upload_id}"
+    url_root = "#{directory}/#{upload_id}"
     path = "#{Rails.root}/public#{url_root}"
 
     FileUtils.mkdir_p path
@@ -41,7 +41,7 @@ module LocalStore
   end
 
   def self.asset_host
-    ActionController::Base.asset_host
+    Rails.configuration.action_controller.asset_host
   end
 
 end

--- a/spec/components/cooked_post_processor_spec.rb
+++ b/spec/components/cooked_post_processor_spec.rb
@@ -65,13 +65,13 @@ describe CookedPostProcessor do
     context "with locally uploaded images" do
 
       let(:upload) { Fabricate(:upload) }
-      let(:post) { Fabricate(:post_with_uploaded_images) }
+      let(:post) { Fabricate(:post_with_uploaded_image) }
       let(:cpp) { CookedPostProcessor.new(post) }
-      before { FastImage.stubs(:size) }
+      before { FastImage.stubs(:size).returns([200, 400]) }
 
       # all in one test to speed things up
       it "works" do
-        Upload.expects(:get_from_url).returns(upload).twice
+        Upload.expects(:get_from_url).returns(upload)
         cpp.post_process_images
         # ensures absolute urls on uploaded images
         cpp.html.should =~ /#{LocalStore.base_url}/
@@ -148,7 +148,7 @@ describe CookedPostProcessor do
     context "topic image" do
 
       let(:topic) { build(:topic, id: 1) }
-      let(:post) { Fabricate(:post_with_uploaded_images, topic: topic) }
+      let(:post) { Fabricate(:post_with_uploaded_image, topic: topic) }
       let(:cpp) { CookedPostProcessor.new(post) }
 
       it "adds a topic image if there's one in the post" do

--- a/spec/fabricators/post_fabricator.rb
+++ b/spec/fabricators/post_fabricator.rb
@@ -43,11 +43,8 @@ Fabricator(:post_with_images_in_quote_and_onebox, from: :post) do
 '
 end
 
-Fabricator(:post_with_uploaded_images, from: :post) do
-  cooked '
-<img src="/uploads/default/2/3456789012345678.png" width="1500" height="2000">
-<img src="/uploads/default/1/1234567890123456.jpg">
-'
+Fabricator(:post_with_uploaded_image, from: :post) do
+  cooked '<img src="/uploads/default/2/3456789012345678.png" width="1500" height="2000">'
 end
 
 Fabricator(:post_with_an_attachment, from: :post) do


### PR DESCRIPTION
FIX: image thumbnailing isn't working when CDN is enabled.

The issue was that by the time we'd run the `CookedPostCreator` job, we'd have already prepended the cdn (`PrettyText.apply_cdn`) to all the assets in the cooked post. So we need to remove any cdn before trying to retrieve the corresponding upload from the databse (where urls are stored relatively).

Also fixed/cleaned-up some tests.
