### PR TITLE
Fix for autocomplete delete action removing only the last item

### DIFF
--- a/app/assets/javascripts/discourse/components/autocomplete.js
+++ b/app/assets/javascripts/discourse/components/autocomplete.js
@@ -64,7 +64,7 @@ $.fn.autocomplete = function(options) {
 
     d.find('a').click(function() {
       closeAutocomplete();
-      inputSelectedItems.splice($.inArray(item), 1);
+      inputSelectedItems.splice($.inArray(item, inputSelectedItems), 1);
       $(this).parent().parent().remove();
       if (options.single) {
         me.show();


### PR DESCRIPTION
As reported at the bottom of #887. Basically when removing users from a group, the user name would be removed from the user selection box, but the last user in the list is actually deleted upon a save.
