### PR TITLE
Remove some calls to `all`

### DIFF
--- a/app/controllers/admin/email_controller.rb
+++ b/app/controllers/admin/email_controller.rb
@@ -16,7 +16,7 @@ class Admin::EmailController < Admin::AdminController
   end
 
   def logs
-    @email_logs = EmailLog.limit(50).includes(:user).order('created_at desc').all
+    @email_logs = EmailLog.limit(50).includes(:user).order('created_at desc').to_a
     render_serialized(@email_logs, EmailLogSerializer)
   end
 

--- a/app/controllers/admin/groups_controller.rb
+++ b/app/controllers/admin/groups_controller.rb
@@ -1,6 +1,6 @@
 class Admin::GroupsController < Admin::AdminController
   def index
-    groups = Group.order(:name).all
+    groups = Group.order(:name).to_a
     render_serialized(groups, BasicGroupSerializer)
   end
 

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -3,7 +3,7 @@ class NotificationsController < ApplicationController
   before_filter :ensure_logged_in
 
   def index
-    notifications = current_user.notifications.recent.includes(:topic).all.to_a
+    notifications = current_user.notifications.recent.includes(:topic)
 
     if notifications.present?
       notifications += current_user.notifications
@@ -11,9 +11,9 @@ class NotificationsController < ApplicationController
         .where(read: false, notification_type: Notification.types[:private_message])
         .where('id < ?', notifications.last.id)
         .limit(5)
-        .to_a
     end
 
+    notifications = notifications.to_a
     current_user.saw_notification_id(notifications.first.id) if notifications.present?
     current_user.reload
     current_user.publish_notifications_state

--- a/app/controllers/post_actions_controller.rb
+++ b/app/controllers/post_actions_controller.rb
@@ -31,7 +31,7 @@ class PostActionsController < ApplicationController
     users = User.select(['null as post_url','users.id', 'users.username', 'users.username_lower', 'users.email','post_actions.related_post_id'])
                 .joins(:post_actions)
                 .where(['post_actions.post_id = ? and post_actions.post_action_type_id = ? and post_actions.deleted_at IS NULL', @post.id, @post_action_type_id])
-                .all
+                .to_a
 
     urls = Post.urls(users.map{|u| u.related_post_id})
     users.each do |u|

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -140,7 +140,7 @@ class Category < ActiveRecord::Base
   end
 
   def publish_categories_list
-    MessageBus.publish('/categories', {categories: ActiveModel::ArraySerializer.new(Category.latest.all).as_json})
+    MessageBus.publish('/categories', {categories: ActiveModel::ArraySerializer.new(Category.latest).as_json})
   end
 
   def uncategorized_validator

--- a/app/models/post_action.rb
+++ b/app/models/post_action.rb
@@ -345,7 +345,7 @@ class PostAction < ActiveRecord::Base
 
     # TODO add serializer so we can skip this
     posts.map!(&:marshal_dump)
-    [posts, User.select([:id, :username, :email]).where(id: users.to_a).all]
+    [posts, User.select([:id, :username, :email]).where(id: users.to_a).to_a]
   end
 
   protected

--- a/app/models/post_action_type.rb
+++ b/app/models/post_action_type.rb
@@ -3,7 +3,7 @@ require_dependency 'enum'
 class PostActionType < ActiveRecord::Base
   class << self
     def ordered
-      order('position asc').all
+      order('position asc')
     end
 
     def types

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -253,7 +253,6 @@ class Topic < ActiveRecord::Base
          .listable_topics
          .limit(SiteSetting.max_similar_results)
          .order('similarity desc')
-         .all
   end
 
   def update_status(status, enabled, user)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -223,7 +223,7 @@ describe User do
 
     it 'allows moderator to delete all posts' do
       @user.delete_all_posts!(@guardian)
-      expect(Post.where(id: @posts.map(&:id)).all).to be_empty
+      expect(Post.where(id: @posts.map(&:id))).to be_empty
       @posts.each do |p|
         if p.post_number == 1
           expect(Topic.where(id: p.topic_id).first).to be_nil


### PR DESCRIPTION
They are not required, and Rails4 raises warnings about them.
