### PR TITLE
change the pipe into a bullet in the lightbox overlay

### DIFF
--- a/lib/cooked_post_processor.rb
+++ b/lib/cooked_post_processor.rb
@@ -164,7 +164,7 @@ class CookedPostProcessor
 
     filename = get_filename(upload, img['src'])
     informations = "#{original_width}x#{original_height}"
-    informations << " | #{number_to_human_size(upload.filesize)}" if upload
+    informations << " • #{number_to_human_size(upload.filesize)}" if upload
 
     meta.add_child create_span_node("filename", filename)
     meta.add_child create_span_node("informations", informations)

--- a/spec/components/cooked_post_processor_spec.rb
+++ b/spec/components/cooked_post_processor_spec.rb
@@ -138,7 +138,7 @@ describe CookedPostProcessor do
       it "generates overlay information" do
         cpp.post_process_images
         cpp.html.should match_html '<div><a href="http://test.localhost/uploads/default/1/1234567890123456.jpg" class="lightbox"><img src="http://test.localhost/uploads/default/_optimized/da3/9a3/ee5e6b4b0d3_100x200.jpg" width="690" height="1380"><div class="meta">
-<span class="filename">uploaded.jpg</span><span class="informations">1000x2000 | 1.21 KB</span><span class="expand"></span>
+<span class="filename">uploaded.jpg</span><span class="informations">1000x2000 • 1.21 KB</span><span class="expand"></span>
 </div></a></div>'
         cpp.should be_dirty
       end


### PR DESCRIPTION
Changes the "|" (pipe) to a "•" (bullet) in the lightbox overlay.

![no-bullets-in-these-guns-but-my-bear-is-fully-loaded](https://f.cloud.github.com/assets/362783/837820/67728f78-f30f-11e2-9438-269c2be2cc4a.jpg)
