### PR TITLE
Need to define which ruby to use before installing gems in Docs

### DIFF
--- a/docs/INSTALL-ubuntu.md
+++ b/docs/INSTALL-ubuntu.md
@@ -137,6 +137,11 @@ Continue with Discourse installation
 
     # Build and install ruby
     rvm install 2.0.0
+    
+    # Use installed ruby as default
+    rvm use 2.0.0 --default
+    
+    # Install bundler
     gem install bundler
 
     # Pull down the latest release


### PR DESCRIPTION
I had to tell rvm which version to use, otherwise the auto suggester will tell you to install gem using apt-get.
