### PR TITLE
Add UTF-8 encoding to stop the invalid multibyte error

### DIFF
--- a/lib/cooked_post_processor.rb
+++ b/lib/cooked_post_processor.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 # Post processing that we can do after a post has already been cooked.
 # For example, inserting the onebox content, or image sizes/thumbnails.
 

--- a/spec/components/cooked_post_processor_spec.rb
+++ b/spec/components/cooked_post_processor_spec.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require 'spec_helper'
 require 'cooked_post_processor'
 


### PR DESCRIPTION
Had to add this in order to boot Rails with 1.9.3.
