### PR TITLE
Strip spaces from group names upon creation

### DIFF
--- a/app/controllers/admin/groups_controller.rb
+++ b/app/controllers/admin/groups_controller.rb
@@ -31,7 +31,7 @@ class Admin::GroupsController < Admin::AdminController
 
   def create
     group = Group.new
-    group.name = params[:group][:name]
+    group.name = params[:group][:name].strip
     group.usernames = params[:group][:usernames] if params[:group][:usernames]
     group.save!
     render_serialized(group, BasicGroupSerializer)

--- a/spec/controllers/admin/groups_controller_spec.rb
+++ b/spec/controllers/admin/groups_controller_spec.rb
@@ -48,19 +48,33 @@ describe Admin::GroupsController do
     end
   end
 
-  it "is able to create a group" do
-    xhr :post, :create, group: {
-      usernames: @admin.username,
-      name: "bob"
-    }
+  context '.create' do
+    let(:usernames) { @admin.username }
 
-    response.status.should == 200
+    it "is able to create a group" do
+      xhr :post, :create, group: {
+        usernames: usernames,
+        name: "bob"
+      }
 
-    groups = Group.where(name: "bob").to_a
+      response.status.should == 200
 
-    groups.count.should == 1
-    groups[0].usernames.should == @admin.username
-    groups[0].name.should == "bob"
+      groups = Group.where(name: "bob").to_a
+
+      groups.count.should == 1
+      groups[0].usernames.should == usernames
+      groups[0].name.should == "bob"
+    end
+
+    it "strips spaces from group name" do
+      lambda {
+        xhr :post, :create, group: {
+          usernames: usernames,
+          name: " bob "
+        }
+      }.should_not raise_error(ActiveRecord::RecordInvalid)
+      Group.where(name: "bob").count.should == 1
+    end
   end
 
   it "is able to update group members" do


### PR DESCRIPTION
More stripping! :dancer: 
This partially fixes #1024 - The bug is gone, but validation errors still need to be displayed. I opened up #1248 for that task.
