### PR TITLE
Prevent 'Quote reply' from appearing when using find in Chrome

### DIFF
--- a/app/assets/javascripts/discourse/views/quote_button_view.js
+++ b/app/assets/javascripts/discourse/views/quote_button_view.js
@@ -10,6 +10,7 @@ Discourse.QuoteButtonView = Discourse.View.extend({
   classNames: ['quote-button'],
   classNameBindings: ['visible'],
   isMouseDown: false,
+  isTouchInProgress: false,
 
   /**
     Determines whether the pop-up quote button should be visible.
@@ -56,9 +57,16 @@ Discourse.QuoteButtonView = Discourse.View.extend({
         view.selectText(e.target, controller);
         view.set('isMouseDown', false);
       })
+      .on('touchstart.quote-button', function(e){
+        view.set('isTouchInProgress', true);
+      })
+      .on('touchend.quote-button', function(e){
+        view.set('isTouchInProgress', false);
+      })
       .on('selectionchange', function() {
         // there is no need to handle this event when the mouse is down
-        if (view.get('isMouseDown')) return;
+        // or if there is not a touch in progress
+        if (view.get('isMouseDown') || !view.get('isTouchInProgress')) return;
         // `selection.anchorNode` is used as a target
         view.selectText(window.getSelection().anchorNode, controller);
       });
@@ -88,6 +96,8 @@ Discourse.QuoteButtonView = Discourse.View.extend({
     $(document)
       .off("mousedown.quote-button")
       .off("mouseup.quote-button")
+      .off("touchstart.quote-button")
+      .off("touchend.quote-button")
       .off("selectionchange");
   },
 


### PR DESCRIPTION
When doing a cmd+f find in Chrome on a topic, if the find jumps the page to a position that will cause an update of the URL, the find box will be dismissed and the Quote Reply box will appear for the matching found text.  

This change prevents the Quote Reply box from appearing when the find box is dismissed. 
