### PR TITLE
hide groups nav link from non-admins

### DIFF
--- a/app/assets/javascripts/admin/templates/admin.js.handlebars
+++ b/app/assets/javascripts/admin/templates/admin.js.handlebars
@@ -9,7 +9,9 @@
           <li>{{#linkTo 'adminSiteContents'}}{{i18n admin.site_content.title}}{{/linkTo}}</li>
         {{/if}}
         <li>{{#linkTo 'adminUsersList'}}{{i18n admin.users.title}}{{/linkTo}}</li>
-        <li>{{#linkTo 'admin.groups'}}{{i18n admin.groups.title}}{{/linkTo}}</li>
+        {{#if currentUser.admin}}
+          <li>{{#linkTo 'admin.groups'}}{{i18n admin.groups.title}}{{/linkTo}}</li>
+        {{/if}}
         <li>{{#linkTo 'adminEmail'}}{{i18n admin.email.title}}{{/linkTo}}</li>
         <li>{{#linkTo 'adminFlags'}}{{i18n admin.flags.title}}{{/linkTo}}</li>
         {{#if currentUser.admin}}


### PR DESCRIPTION
I'm making this change based on the current route constraint that restricts access to /admin/groups to admins only. I did a quick search on meta to see if anyone has discussed giving mods access to this page, but didn't see anything. 
