### PR TITLE
Ruby 1.8 is dead, goodbye hashrockets!

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -37,14 +37,14 @@ class Topic < ActiveRecord::Base
   rate_limit :limit_topics_per_day
   rate_limit :limit_private_messages_per_day
 
-  validates :title, :presence => true,
-                    :topic_title_length => true,
-                    :quality_title => { :unless => :private_message? },
-                    :unique_among  => { :unless => Proc.new { |t| (SiteSetting.allow_duplicate_topic_titles? || t.private_message?) },
-                                        :message => :has_already_been_used,
-                                        :allow_blank => true,
-                                        :case_sensitive => false,
-                                        :collection => Proc.new{ Topic.listable_topics } }
+  validates :title, presence: true,
+            topic_title_length: true,
+            quality_title: {unless: :private_message?},
+            unique_among: {unless: Proc.new { |t| (SiteSetting.allow_duplicate_topic_titles? || t.private_message?) },
+                           message: :has_already_been_used,
+                           allow_blank: true,
+                           case_sensitive: false,
+                           collection: Proc.new { Topic.listable_topics }}
 
   before_validation do
     self.sanitize_title
@@ -306,7 +306,7 @@ class Topic < ActiveRecord::Base
 
   def changed_to_category(cat)
 
-    return if cat.blank?
+    return unless cat
     return if Category.where(topic_id: id).first.present?
 
     Topic.transaction do


### PR DESCRIPTION
Avoid using .blank? to reduce db queries
Say goodbye to hashrockets
