### PR TITLE
Fix spelling of noscript in the settings page.

### DIFF
--- a/config/locales/server.cs.yml
+++ b/config/locales/server.cs.yml
@@ -534,7 +534,7 @@ cs:
     ga_tracking_code: "Kód pro sledování přes 'Google analytics', např. UA-12345678-9; viz http://google.com/analytics"
     ga_domain_name: "Doménové jméno pro Google analytics, např. mysite.com; viz http://google.com/analytics"
     enable_escaped_fragments: "Povolit alternativní řešení, které pomůže starým webovým robotům indexovat váš web. VAROVÁNÍ: povolte pouze v případě, že to opravdu potřebujete."
-    enable_noscript_support: "Povolit podporu &lt;noscipt&gt; tagu"
+    enable_noscript_support: "Povolit podporu &lt;noscript&gt; tagu"
     top_menu: "Určuje, které položky se zobrazí v navigaci na hlavní stránce a v jakém pořadí. Příklad: latest|hot|read|favorited|unread|new|posted|categories"
     post_menu: "Určuje, které položky se zobrazí v menu u příspěvku a v jakém pořadí. Příklad: like|edit|flag|delete|share|bookmark|reply"
     share_links: "Určuje, které položky se zobrazí ve sdílecím dialogu a v jakém pořadí. Příklad: twitter|facebook|google+"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -512,7 +512,7 @@ en:
     ga_tracking_code: "Google analytics tracking code code, eg: UA-12345678-9; see http://google.com/analytics"
     ga_domain_name: "Google analytics domain name, eg: mysite.com; see http://google.com/analytics"
     enable_escaped_fragments: "Enable workaround solution to help old crawlers to index your site. WARNING: enable it only if you are really have to do it."
-    enable_noscript_support: "Enable supporting &lt;noscipt&gt; tag"
+    enable_noscript_support: "Enable supporting &lt;noscript&gt; tag"
     top_menu: "Determine which items appear in the homepage navigation, and in what order. Example latest|hot|read|favorited|unread|new|posted|categories"
     post_menu: "Determine which items appear on the post menu, and in what order. Example like|edit|flag|delete|share|bookmark|reply"
     share_links: "Determine which items appear on the share dialog, and in what order. Example twitter|facebook|google+|email"

--- a/config/locales/server.nl.yml
+++ b/config/locales/server.nl.yml
@@ -507,7 +507,7 @@ nl:
     ga_tracking_code: "Google analytics trackingcode, zie: http://google.com/analytics"
     ga_domain_name: "Google analytics domeinnaam, bijv. mijnsite.nl; zie http://google.com/analytics"
     enable_escaped_fragments: "Schakel workaround in om oude crawlers je site te kunnen laten indexeren. WAARSCHUWING: gebruik dit alleen als je het echt nodig hebt."
-    enable_noscript_support: "Ondersteun &lt;noscipt&gt; tag"
+    enable_noscript_support: "Ondersteun &lt;noscript&gt; tag"
     top_menu: "De volgorde en selectie van items in het hoofdmenu. Bijvoorbeeld latest|hot|read|favorited|unread|new|posted|categories"
     post_menu: "De volgorde en selectie van items in het berichtmenu. Bijvoorbeeld like|edit|flag|delete|share|bookmark|reply"
     share_links: "De volgorde en selectie van items in het deelmenu. Bijvoorbeeld twitter|facebook|google+"

--- a/config/locales/server.pt_BR.yml
+++ b/config/locales/server.pt_BR.yml
@@ -467,7 +467,7 @@ pt_BR:
     ga_tracking_code: "Código de rastreamento do Google Analytics, veja: http://google.com/analytics"
     ga_domain_name: "Nome de domínio no Google Analytics, exemplo: meusite.com; see http://google.com/analytics"
     enable_escaped_fragments: "Ativa solução alternativa que ajuda os mecanismos de busca antigos a indexarem o seu site. ALERTA: apenas ative se você realmente precisa disto."
-    enable_noscript_support: "Ativar suporte a tag &lt;noscipt&gt;"
+    enable_noscript_support: "Ativar suporte a tag &lt;noscript&gt;"
     top_menu: "A ordem dos items no menu de cima. Exemplo latest|hot|read|favorited|unread|new|posted|categories"
     post_menu: "A ordem dos items no menu da postagem."
     share_links: "Determine quais ítens aparecerem no diálogo de compartilhar, e em que ordem. Por exemplo: twitter|facebook|google+|email"

--- a/config/locales/server.ru.yml
+++ b/config/locales/server.ru.yml
@@ -566,7 +566,7 @@ ru:
     ga_tracking_code: 'Google analytics tracking code, например: UA-12345678-9; смотрите http://google.com/analytics'
     ga_domain_name: 'Доменное имя для Google analytics, например: mysite.com; смотрите http://google.com/analytics'
     enable_escaped_fragments: Включить поддержку устаревших поисковых систем (таких как Яндекс) для индексации вашего сайта. ВНИМАНИЕ! Используйте данную опцию только в том случае, если вы знаете зачем она нужна.
-    enable_noscript_support: Включить поддержку тэга  noscipt
+    enable_noscript_support: Включить поддержку тэга  noscript
     top_menu: 'Определите, как должны располагаться элементы в навигации на главной странице. Пример: latest|hot|read|favorited|unread|new|posted|categories'
     post_menu: 'Определите, какие элементы должны отображаться в меню у сообщения и в какой последовательности.  Пример: like|edit|flag|delete|share|bookmark|reply'
     share_links: 'Определите, какие элементы должны отображаться в меню «Поделиться» и в какой последовательности. Пример: twitter|facebook|google+'


### PR DESCRIPTION
The settings page spelled "noscript" as "noscipt" in a few languages.
