### PR TITLE
fix mentions in code blocks

### DIFF
--- a/app/models/post_analyzer.rb
+++ b/app/models/post_analyzer.rb
@@ -51,6 +51,9 @@ class PostAnalyzer
     return @raw_mentions if @raw_mentions.present?
     raw_stripped = @raw.gsub(/\[quote=(.*)\]([^\[]*?)\[\/quote\]/im, '')
 
+    # Process markdown so that code blocks can be generated and subsequently ignored
+    raw_stripped = PrettyText.markdown(raw_stripped)
+
     # Strip pre and code tags
     doc = Nokogiri::HTML.fragment(raw_stripped)
     doc.search("pre").remove

--- a/spec/models/post_analyzer_spec.rb
+++ b/spec/models/post_analyzer_spec.rb
@@ -188,6 +188,11 @@ describe PostAnalyzer do
       post_analyzer.raw_mentions.should == ['jake']
     end
 
+    it "ignores code in markdown-formatted code blocks" do
+      post_analyzer = PostAnalyzer.new("    @Jake @Finn\n@Ryan", default_topic_id)
+      post_analyzer.raw_mentions.should == ['ryan']
+    end
+
     it "ignores quotes" do
       post_analyzer = PostAnalyzer.new("[quote=\"Evil Trout\"]@Jake[/quote] @Finn", default_topic_id)
       post_analyzer.raw_mentions.should == ['finn']


### PR DESCRIPTION
This fixes #1128
# raw_mentions method was unable to remove the code blocks because the post was not being run through the markdown formatter before checking for mentions.
