### PR TITLE
Update INSTALL-ubuntu.md

### DIFF
--- a/docs/INSTALL-ubuntu.md
+++ b/docs/INSTALL-ubuntu.md
@@ -332,8 +332,6 @@ The corresponding site setting is:
     # Here, run the command to start bluepill.
     # Get it from the crontab output above.
 
-Note that if bluepill *itself* needs to be restarted, it must be killed with `bluepill quit` and restarted with the same command that's in crontab
-
 ### Check sample configuration files for new settings
 
 Check the sample configuration files provided in the repo with the ones being used for additional recommended settings and merge those in:


### PR DESCRIPTION
The removed paragraph was useful for a previous version of the "Updating Discourse" code above it. It seems useless now, as precise instructions are already in the code comments. In fact, it became incoherent, as we explicitily have "bluepill quit" in the code now.
