### PR TITLE
fix: git-version isn't showing up

### DIFF
--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -105,7 +105,9 @@ module Discourse
 
   def self.git_version
     return $git_version if $git_version
-    f = Rails.root.to_s + "/lib/version"
+
+    # load the version stamped by the "build:stamp" task
+    f = Rails.root.to_s + "/config/version"
     require f if File.exists?("#{f}.rb")
 
     begin


### PR DESCRIPTION
Fix the git-version in the source-code of the generated pages.

![202677v1-max-250x250](https://f.cloud.github.com/assets/362783/904040/70f1592c-fbba-11e2-816a-79483945660a.png)
