### PR TITLE
Update documentation

### DIFF
--- a/config/nginx.sample.conf
+++ b/config/nginx.sample.conf
@@ -1,8 +1,8 @@
 upstream discourse {
-  server unix:/home/discourse/discourse/tmp/sockets/thin.0.sock;
-  server unix:/home/discourse/discourse/tmp/sockets/thin.1.sock;
-  server unix:/home/discourse/discourse/tmp/sockets/thin.2.sock;
-  server unix:/home/discourse/discourse/tmp/sockets/thin.3.sock;
+  server unix:/var/www/discourse/tmp/sockets/thin.0.sock;
+  server unix:/var/www/discourse/tmp/sockets/thin.1.sock;
+  server unix:/var/www/discourse/tmp/sockets/thin.2.sock;
+  server unix:/var/www/discourse/tmp/sockets/thin.3.sock;
 }
 
 server {
@@ -20,7 +20,7 @@ server {
   client_max_body_size 2m;
 
   location / {
-    root /home/discourse/discourse/public;
+    root /var/www/discourse/public;
 
     ## optional upload anti-hotlinking rules
     #location ~ ^/uploads/ {


### PR DESCRIPTION
- Change recommendation for install path to /var/www/discourse
- Fix instructions for redis-server installation
- Set yourself as system user during install
- Clarify some instructions
