### PR TITLE
FIX: avatars in quotes/oneboxes

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,7 +3,8 @@ require_dependency 'user_name_suggester'
 
 class UsersController < ApplicationController
 
-  skip_before_filter :check_xhr, only: [:show, :password_reset, :update, :activate_account, :authorize_email, :user_preferences_redirect]
+  skip_before_filter :authorize_mini_profiler, only: [:avatar]
+  skip_before_filter :check_xhr, only: [:show, :password_reset, :update, :activate_account, :authorize_email, :user_preferences_redirect, :avatar]
 
   before_filter :ensure_logged_in, only: [:username, :update, :change_email, :user_preferences_redirect]
 
@@ -316,7 +317,29 @@ class UsersController < ApplicationController
                                           methods: :avatar_template) }
   end
 
+  # [LEGACY] avatars in quotes/oneboxes might still be pointing to this route
+  # fixing it requires a rebake of all the posts
   def avatar
+    user = User.select(:email).where(username_lower: params[:username].downcase).first
+    if user.present?
+      size = determine_avatar_size(params[:size])
+      url = user.avatar_template.gsub("{size}", size.to_s)
+      expires_in 1.day
+      redirect_to url
+    else
+      raise ActiveRecord::RecordNotFound
+    end
+  end
+
+  def determine_avatar_size(size)
+    size = size.to_i
+    size = 64 if size == 0
+    size = 10 if size < 10
+    size = 128 if size > 128
+    size
+  end
+
+  def upload_avatar
     user = fetch_user_from_params
     guardian.ensure_can_edit!(user)
 

--- a/config/nginx.sample.conf
+++ b/config/nginx.sample.conf
@@ -30,6 +30,13 @@ server {
     #  }
     #}
 
+    ## [LEGACY] this is deprecated, leaving it there for a small transition period
+    location ~ ^/t\/[0-9]+\/[0-9]+\/avatar {
+      expires 1d;
+      add_header Cache-Control public;
+      add_header ETag "";
+    }
+
     location ~ ^/(assets|uploads)/ {
       expires 1y;
       add_header Cache-Control public;

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -135,9 +135,11 @@ Discourse::Application.routes.draw do
   get 'users/:username/preferences/about-me' => 'users#preferences', constraints: {username: USERNAME_ROUTE_FORMAT}
   get 'users/:username/preferences/username' => 'users#preferences', constraints: {username: USERNAME_ROUTE_FORMAT}
   put 'users/:username/preferences/username' => 'users#username', constraints: {username: USERNAME_ROUTE_FORMAT}
+  # LEGACY ROUTE
+  get 'users/:username/avatar(/:size)' => 'users#avatar', constraints: {username: USERNAME_ROUTE_FORMAT}
   get 'users/:username/preferences/avatar' => 'users#preferences', constraints: {username: USERNAME_ROUTE_FORMAT}
   put 'users/:username/preferences/avatar/toggle' => 'users#toggle_avatar', constraints: {username: USERNAME_ROUTE_FORMAT}
-  post 'users/:username/preferences/avatar' => 'users#avatar', constraints: {username: USERNAME_ROUTE_FORMAT}
+  post 'users/:username/preferences/avatar' => 'users#upload_avatar', constraints: {username: USERNAME_ROUTE_FORMAT}
   get 'users/:username/invited' => 'users#invited', constraints: {username: USERNAME_ROUTE_FORMAT}
   post 'users/:username/send_activation_email' => 'users#send_activation_email', constraints: {username: USERNAME_ROUTE_FORMAT}
   get 'users/:username/activity' => 'users#show', constraints: {username: USERNAME_ROUTE_FORMAT}


### PR DESCRIPTION
Avatars in quotes/oneboxes are still pointing to the old `/users/:username/avatar(/:size)` route.
So, this adds back the old avatar route for the transition period.
