### PR TITLE
FIX: images in the preview have rounded corners

### DIFF
--- a/app/assets/stylesheets/application/compose.css.scss
+++ b/app/assets/stylesheets/application/compose.css.scss
@@ -294,10 +294,6 @@
       color: $black;
       img {
         max-width: 100%;
-        border-radius: 4px;
-        moz-border-radius: 4px;
-        webkit-border-radius: 4px;
-        ms-border-radius: 4px;
       }
 
       video {


### PR DESCRIPTION
I want more squares! (cc @supermathie)

![square-watermellons](https://f.cloud.github.com/assets/362783/989652/58508594-0918-11e3-9fd0-e0ad49ea2185.png)
