### PR TITLE
do not disable the radio button in the avatar selection modal

### DIFF
--- a/app/assets/javascripts/discourse/templates/modal/avatar_selector.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/modal/avatar_selector.js.handlebars
@@ -1,10 +1,12 @@
 <div class="modal-body">
   <div>
-    <input type="radio" id="avatar" name="avatar" value="gravatar" {{action toggleUseUploadedAvatar false}}>
-    <label class="radio" for="avatar">{{avatar controller imageSize="large" template="gravatar_template"}} {{{i18n user.change_avatar.gravatar}}} {{currentUser.email}}</label>
-    <a href="//gravatar.com/emails" target="_blank" title="{{i18n user.change_avatar.gravatar_title}}" class="btn"><i class="icon-pencil"></i></a>
     <div>
-      <input type="radio" id="uploaded_avatar" name="avatar" value="uploaded_avatar" {{action toggleUseUploadedAvatar true}} {{bindAttr disabled="view.uploadedAvatarDisabled" }}>
+      <input type="radio" id="avatar" name="avatar" value="gravatar" {{action toggleUseUploadedAvatar false}}>
+      <label class="radio" for="avatar">{{avatar controller imageSize="large" template="gravatar_template"}} {{{i18n user.change_avatar.gravatar}}} {{currentUser.email}}</label>
+      <a href="//gravatar.com/emails" target="_blank" title="{{i18n user.change_avatar.gravatar_title}}" class="btn"><i class="icon-pencil"></i></a>
+    </div>
+    <div>
+      <input type="radio" id="uploaded_avatar" name="avatar" value="uploaded_avatar" {{action toggleUseUploadedAvatar true}}>
       <label class="radio" for="uploaded_avatar">
         {{#if has_uploaded_avatar}}
           {{boundAvatar controller imageSize="large" template="uploaded_avatar_template"}} {{i18n user.change_avatar.uploaded_avatar}}
@@ -24,6 +26,6 @@
 </div>
 
 <div class="modal-footer">
-  <button class="btn btn-primary" {{action saveAvatarSelection}} data-dismiss="modal">{{i18n save}}</button>
+  <button class="btn btn-primary" {{action saveAvatarSelection}} data-dismiss="modal" {{bindAttr disabled="view.saveDisabled"}}>{{i18n save}}</button>
   <a data-dismiss="modal">{{i18n cancel}}</a>
 </div>

--- a/app/assets/javascripts/discourse/views/modal/avatar_selector_view.js
+++ b/app/assets/javascripts/discourse/views/modal/avatar_selector_view.js
@@ -12,7 +12,9 @@ Discourse.AvatarSelectorView = Discourse.ModalBodyView.extend({
   title: I18n.t('user.change_avatar.title'),
   uploading: false,
   uploadProgress: 0,
-  uploadedAvatarDisabled: Em.computed.not("controller.has_uploaded_avatar"),
+  useGravatar: Em.computed.not("controller.use_uploaded_avatar"),
+  canSaveAvatarSelection: Em.computed.or("useGravatar", "controller.has_uploaded_avatar"),
+  saveDisabled: Em.computed.not("canSaveAvatarSelection"),
 
   didInsertElement: function() {
     var view = this;


### PR DESCRIPTION
You can now select the second radio button even though you haven't uploaded a custom avatar yet.
When you select it, the save button will be disabled until you upload a picture.

![profile_-_zogstrip_-_discourse](https://f.cloud.github.com/assets/362783/997040/d020b6e4-09da-11e3-8215-1fd97df21372.png)
