### PR TITLE
add a site setting for allowing animated avatars

### DIFF
--- a/app/assets/javascripts/discourse/views/modal/avatar_selector_view.js
+++ b/app/assets/javascripts/discourse/views/modal/avatar_selector_view.js
@@ -51,11 +51,17 @@ Discourse.AvatarSelectorView = Discourse.ModalBodyView.extend({
 
     // when the upload is successful
     $upload.on("fileuploaddone", function (e, data) {
-      // set some properties
+      // indicates the users is using an uploaded avatar
       view.get("controller").setProperties({
         has_uploaded_avatar: true,
-        use_uploaded_avatar: true,
-        uploaded_avatar_template: data.result.url
+        use_uploaded_avatar: true
+      });
+      // in order to be as much responsive as possible, we're cheating a bit here
+      // indeed, the server gives us back the url to the file we've just uploaded
+      // often, this file is not a square, so we need to crop it properly
+      // this will also capture the first frame of animated avatars when they're not allowed
+      Discourse.Utilities.cropAvatar(data.result.url, data.files[0].type).then(function(avatarTemplate) {
+        view.get("controller").set("uploaded_avatar_template", avatarTemplate);
       });
     });
 

--- a/app/models/optimized_image.rb
+++ b/app/models/optimized_image.rb
@@ -19,7 +19,7 @@ class OptimizedImage < ActiveRecord::Base
     temp_file = Tempfile.new(["discourse-thumbnail", File.extname(original_path)])
     temp_path = temp_file.path
 
-    if ImageSorcery.new(original_path).convert(temp_path, resize: "#{width}x#{height}")
+    if ImageSorcery.new("#{original_path}[0]").convert(temp_path, resize: "#{width}x#{height}")
       thumbnail = OptimizedImage.create!(
         upload_id: upload.id,
         sha1: Digest::SHA1.file(temp_path).hexdigest,

--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -245,6 +245,7 @@ class SiteSetting < ActiveRecord::Base
   setting(:username_change_period, 3) # days
 
   client_setting(:allow_uploaded_avatars, true)
+  client_setting(:allow_animated_avatars, false)
 
   def self.generate_api_key!
     self.api_key = SecureRandom.hex(32)

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -665,7 +665,8 @@ en:
     delete_all_posts_max: "The maximum number of posts that can be deleted at once with the Delete All Posts button. If a user has more than this many posts, the posts cannot all be deleted at once and the user can't be deleted."
     username_change_period: "The number of days after registration that accounts can change their username."
 
-    allow_uploaded_avatars: "Allow support for uploaded avatars"
+    allow_uploaded_avatars: "Allow users to upload their custom avatars"
+    allow_animated_avatars: "Allow users to use animated gif for avatars"
 
   notification_types:
     mentioned: "%{display_username} mentioned you in %{link}"

--- a/lib/jobs/generate_avatars.rb
+++ b/lib/jobs/generate_avatars.rb
@@ -15,6 +15,10 @@ module Jobs
         Discourse.store.path_for(upload)
       end
 
+      # we'll extract the first frame when it's a gif
+      source = original_path
+      source << "[0]" unless SiteSetting.allow_animated_avatars
+
       [120, 45, 32, 25, 20].each do |s|
         # handle retina too
         [s, s * 2].each do |size|
@@ -22,7 +26,7 @@ module Jobs
           temp_file = Tempfile.new(["discourse-avatar", File.extname(original_path)])
           temp_path = temp_file.path
           # create a centered square thumbnail
-          if ImageSorcery.new(original_path).convert(temp_path, gravity: "center", thumbnail: "#{size}x#{size}^", extent: "#{size}x#{size}", background: "transparent")
+          if ImageSorcery.new(source).convert(temp_path, gravity: "center", thumbnail: "#{size}x#{size}^", extent: "#{size}x#{size}", background: "transparent")
             Discourse.store.store_avatar(temp_file, upload, size)
           end
           # close && remove temp file

--- a/test/javascripts/components/utilities_test.js
+++ b/test/javascripts/components/utilities_test.js
@@ -132,3 +132,16 @@ test("avatarImg", function() {
   blank(Discourse.Utilities.avatarImg({avatarTemplate: "", size: 'tiny'}),
         "it doesn't render avatars for invalid avatar template");
 });
+
+module("Discourse.Utilities.cropAvatar with animated avatars", {
+  setup: function() { Discourse.SiteSettings.allow_animated_avatars = true; }
+});
+
+asyncTestDiscourse("cropAvatar", function() {
+  expect(1);
+
+  Discourse.Utilities.cropAvatar("/path/to/avatar.gif", "image/gif").then(function(avatarTemplate) {
+    equal(avatarTemplate, "/path/to/avatar.gif", "returns the url to the gif when animated gif are enabled");
+    start();
+  });
+});


### PR DESCRIPTION
:sparkles: This adds the `allow_animated_avatars` site setting (defaults to `false`). :sparkles:

![nod](http://media.giphy.com/media/4FvmJftU7yreg/giphy.gif)
#### Presentation

When a user uploads a gif for her avatar, it will use only the first frame when animated avatars are disabled.
#### Nice touch

Because avatars are only squares, we might crop the uploaded image when generating the thumbnails on the server.
While we're waiting for the server to finish this background task, we return to the client the url of the uploaded file. We'll simulate that eventual croping on the client-side to prevent the image from being stretched by the browser.
#### Note

:warning: This is not retroactive. If one of your users already uses an animated gif, you will have to upload it again to make it unanimated. I'll add a rake task later to make it easier though.
