### PR TITLE
Added test case for nickname registration failure

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -167,7 +167,7 @@ class UsersController < ApplicationController
     if user.save
       activator = UserActivator.new(user, session, cookies)
       message = activator.activation_message
-      create_third_party_auth_records(user, auth) if auth.present?
+      create_third_party_auth_records(user, auth)
 
       # Clear authentication session.
       session[:authentication] = nil
@@ -408,6 +408,8 @@ class UsersController < ApplicationController
     end
 
     def create_third_party_auth_records(user, auth)
+      return unless auth.present?
+
       if twitter_auth?(auth)
         TwitterUserInfo.create(
           user_id: user.id,

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -490,6 +490,21 @@ describe UsersController do
       include_examples 'failed signup'
     end
 
+    context 'when nickname is unavailable in DiscourseHub' do
+      before do
+        SiteSetting.stubs(:call_discourse_hub?).returns(true)
+        DiscourseHub.stubs(:register_nickname).raises(DiscourseHub::NicknameUnavailable)
+      end
+      let(:create_params) {{
+        name: @user.name,
+        username: @user.username,
+        password: 'strongpassword',
+        email: @user.email
+      }}
+
+      include_examples 'failed signup'
+    end
+
     context 'when an Exception is raised' do
 
       [ ActiveRecord::StatementInvalid,


### PR DESCRIPTION
- Also made a minor readability change by moving the auth.present? check from UsersController#create into #create_third_party_auth_records which is the method that relies on the check.
