### PR TITLE
No more rails 4 deprecation warnings

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -43,9 +43,9 @@ class Category < ActiveRecord::Base
   scope :secured, ->(guardian = nil) {
     ids = guardian.secure_category_ids if guardian
     if ids.present?
-      where("NOT categories.read_restricted or categories.id in (:cats)", cats: ids)
+      where("NOT categories.read_restricted or categories.id in (:cats)", cats: ids).references(:categories)
     else
-      where("NOT categories.read_restricted")
+      where("NOT categories.read_restricted").references(:categories)
     end
   }
 
@@ -65,7 +65,7 @@ class Category < ActiveRecord::Base
 
   def self.scoped_to_permissions(guardian, permission_types)
     if guardian && guardian.is_staff?
-      scoped
+      rails4? ? all : scoped
     else
       permission_types = permission_types.map{ |permission_type|
         CategoryGroup.permission_types[permission_type]

--- a/app/models/incoming_links_report.rb
+++ b/app/models/incoming_links_report.rb
@@ -89,7 +89,8 @@ class IncomingLinksReport
     num_clicks  = link_count_per_topic
     num_clicks = num_clicks.to_a.sort_by {|x| x[1]}.last(10).reverse # take the top 10
     report.data = []
-    topics = Topic.select('id, slug, title').where('id in (?)', num_clicks.map {|z| z[0]}).all
+    topics = Topic.select('id, slug, title').where('id in (?)', num_clicks.map {|z| z[0]})
+    topics = topics.all unless rails4?
     num_clicks.each do |topic_id, num_clicks_element|
       topic = topics.find {|t| t.id == topic_id}
       if topic

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -135,7 +135,7 @@ class User < ActiveRecord::Base
       { username_lower: username_or_email.downcase }
     end
 
-    users = User.where(conditions).all
+    users = User.where(conditions).to_a
 
     if users.size > 1
       raise Discourse::TooManyMatches
@@ -504,7 +504,7 @@ class User < ActiveRecord::Base
   end
 
   def secure_category_ids
-    cats = self.staff? ? Category.select(:id).where(read_restricted: true) : secure_categories.select('categories.id')
+    cats = self.staff? ? Category.select(:id).where(read_restricted: true) : secure_categories.select('categories.id').references(:categories)
     cats.map { |c| c.id }.sort
   end
 

--- a/lib/search.rb
+++ b/lib/search.rb
@@ -115,10 +115,10 @@ class Search
     def category_search
       categories = Category.includes(:category_search_data)
                            .where("category_search_data.search_data @@ #{ts_query}")
+                           .references(:category_search_data)
                            .order("topics_month DESC")
                            .secured(@guardian)
                            .limit(@limit)
-                           .references(:category_search_data)
 
       categories.each do |c|
         @results.add_result(SearchResult.from_category(c))
@@ -164,9 +164,9 @@ class Search
                    .order("topics.bumped_at DESC")
 
       if secure_category_ids.present?
-        posts = posts.where("(categories.id IS NULL) OR (NOT categories.read_restricted) OR (categories.id IN (?))", secure_category_ids)
+        posts = posts.where("(categories.id IS NULL) OR (NOT categories.read_restricted) OR (categories.id IN (?))", secure_category_ids).references(:categories)
       else
-        posts = posts.where("(categories.id IS NULL) OR (NOT categories.read_restricted)")
+        posts = posts.where("(categories.id IS NULL) OR (NOT categories.read_restricted)").references(:categories)
       end
       posts.limit(limit)
     end

--- a/spec/components/search_spec.rb
+++ b/spec/components/search_spec.rb
@@ -279,7 +279,7 @@ describe Search do
       # should find topic in searched category first
       Then          { first_of_type(search_cat, 'topic')[:id].should == topic.id }
       # results should also include topic without category
-      And          { result_ids_for_type(search_cat, 'topic').should include topic_no_cat.id } 
+      And          { result_ids_for_type(search_cat, 'topic').should include topic_no_cat.id }
 
     end
 

--- a/spec/controllers/admin/groups_controller_spec.rb
+++ b/spec/controllers/admin/groups_controller_spec.rb
@@ -72,7 +72,7 @@ describe Admin::GroupsController do
           usernames: usernames,
           name: " bob "
         }
-      }.should_not raise_error(ActiveRecord::RecordInvalid)
+      }.should_not raise_error()
       Group.where(name: "bob").count.should == 1
     end
   end

--- a/spec/models/post_action_spec.rb
+++ b/spec/models/post_action_spec.rb
@@ -214,7 +214,7 @@ describe PostAction do
       u1 = Fabricate(:evil_trout)
       PostAction.act(u1, post, PostActionType.types[:spam])
       PostAction.remove_act(u1, post, PostActionType.types[:spam])
-      lambda { PostAction.act(u1, post, PostActionType.types[:off_topic]) }.should_not raise_error(PostAction::AlreadyActed)
+      lambda { PostAction.act(u1, post, PostActionType.types[:off_topic]) }.should_not raise_error()
     end
 
     it 'should update counts when you clear flags' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -913,7 +913,7 @@ describe User do
 
     context 'when multiple users are found' do
       it 'raises an exception' do
-        user_query = stub(all: [stub, stub])
+        user_query = stub(to_a: [stub, stub])
         User.stubs(:where).with(username_lower: 'bob').returns(user_query)
 
         expect { User.find_by_username_or_email('bob') }.to raise_error(Discourse::TooManyMatches)


### PR DESCRIPTION
This PR results in there being only one remaining Rails4 deprecation warning (which pertains to [`secret_key_base`](http://edgeguides.rubyonrails.org/upgrading_ruby_on_rails.html) and should not be fixed until the point at which we migrate to Rails 4). 

The main types of deprecation warnings fixed here include:
- Deprecation of `Model.scoped` -- replace with `Model.all`
- Use `ActiveRecord::QueryMethods.references`
- rspec deprecates `expect { }.not_to raise_error(SomeSpecificError)` and requires a general `expect { }.not_to raise_error()` 

**Note:**
- There is some noise in the specs relating to `sh: convert: command not found`, `unknown encoding ASCII-8BIT` 
- There is a failing spec (for Rails4) `spec/components/post_revisor_spec.rb:209` - this failure should exist on the current master branch (it is not introduced by this PR)
