### PR TITLE
Nickname unavailable generates error json

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -217,15 +217,8 @@ class UsersController < ApplicationController
     end
   rescue ActiveRecord::StatementInvalid
     render json: { success: false, message: I18n.t("login.something_already_taken") }
-  rescue DiscourseHub::NicknameUnavailable
-    render json: { success: false,
-      message: I18n.t(
-        "login.errors",
-        errors:I18n.t(
-          "login.not_available", suggestion: UserNameSuggester.suggest(params[:username])
-        )
-    )
-    }
+  rescue DiscourseHub::NicknameUnavailable=> e
+    render json: e.response_message
   rescue RestClient::Forbidden
     render json: { errors: [I18n.t("discourse_hub.access_token_problem")] }
   end

--- a/lib/discourse_hub.rb
+++ b/lib/discourse_hub.rb
@@ -3,7 +3,24 @@ require_dependency 'version'
 
 module DiscourseHub
 
-  class NicknameUnavailable < RuntimeError; end
+  class NicknameUnavailable < RuntimeError
+    def initialize(nickname)
+      @nickname = nickname
+    end
+
+    def response_message
+      {
+        success: false,
+        message: I18n.t(
+          "login.errors",
+          errors:I18n.t(
+            "login.not_available", suggestion: UserNameSuggester.suggest(@nickname)
+          )
+        )
+      }
+    end 
+
+  end
 
   def self.nickname_available?(nickname)
     json = get('/users/nickname_available', {nickname: nickname})
@@ -20,7 +37,7 @@ module DiscourseHub
     if json.has_key?('success')
       true
     else
-      raise NicknameUnavailable  # TODO: report ALL the errors
+      raise NicknameUnavailable.new(nickname)  # TODO: report ALL the errors
     end
   end
 
@@ -34,7 +51,7 @@ module DiscourseHub
     if json.has_key?('success')
       true
     else
-      raise NicknameUnavailable  # TODO: report ALL the errors
+      raise NicknameUnavailable.new(new_nickname)  # TODO: report ALL the errors
     end
   end
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -477,7 +477,7 @@ describe UsersController do
     context 'when nickname is unavailable in DiscourseHub' do
       before do
         SiteSetting.stubs(:call_discourse_hub?).returns(true)
-        DiscourseHub.stubs(:register_nickname).raises(DiscourseHub::NicknameUnavailable)
+        DiscourseHub.stubs(:register_nickname).raises(DiscourseHub::NicknameUnavailable.new(@user.name))
       end
       let(:create_params) {{
         name: @user.name,


### PR DESCRIPTION
A NicknameUnavailable error always applies to a specific nickname. Therefore it has all the information it need to generate the Hash that is rendered as a JSON response.
