### PR TITLE
FIX: 404 on old thumbnails

### DIFF
--- a/db/migrate/20130828192526_fix_optimized_images_urls.rb
+++ b/db/migrate/20130828192526_fix_optimized_images_urls.rb
@@ -1,0 +1,19 @@
+class FixOptimizedImagesUrls < ActiveRecord::Migration
+  def up
+    # `AddUrlToOptimizedImages` was wrongly computing the URLs. This fixes it!
+    execute "UPDATE optimized_images
+             SET url = substring(oi.url from '^\/uploads\/[^/]+\/_optimized/[0-9a-f]{3}/[0-9a-f]{3}/[0-9a-f]{11}')
+                    || '_'
+                    || oi.width
+                    || 'x'
+                    || oi.height
+                    || substring(oi.url from '\.\w{3,4}$')
+             FROM optimized_images oi
+             WHERE optimized_images.id = oi.id
+               AND oi.url ~ '^\/uploads\/[^/]+\/_optimized\/[0-9a-f]{3}/[0-9a-f]{3}/[0-9a-f]{11}\.';"
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
The urls computed in the [`AddUrlToOptimizedImages`](https://github.com/discourse/discourse/blob/master/db/migrate/20130728172550_add_url_to_optimized_images.rb) migration were wrong.
They were missing the `_{width}x{height}` suffix. 

This fixes it :fire: 
