### PR TITLE
FIX: convert error in test

### DIFF
--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -979,14 +979,11 @@ describe UsersController do
         user.uploaded_avatar.id.should == upload.id
         # automatically set "use_uploaded_avatar"
         user.use_uploaded_avatar.should == true
-      end
-
-      it 'returns the url, width and height of the uploaded image' do
-        xhr :post, :upload_avatar, username: user.username, file: avatar
+        # returns the url, width and height of the uploaded image
         json = JSON.parse(response.body)
-        json['url'].should_not be_nil
-        json['width'].should == 244
-        json['height'].should == 66
+        json['url'].should == "/uploads/default/1/1234567890123456.jpg"
+        json['width'].should == 100
+        json['height'].should == 200
       end
 
     end


### PR DESCRIPTION
This fixes the `sh: 1: convert: not found` errors while running the ruby specs.
