### PR TITLE
fix user_name_suggester spec

### DIFF
--- a/spec/components/user_name_suggester_spec.rb
+++ b/spec/components/user_name_suggester_spec.rb
@@ -10,6 +10,9 @@ describe UserNameSuggester do
   end
 
   describe '.suggest' do
+    before do
+      User.stubs(:username_length).returns(3..15)
+    end
 
     it "doesn't raise an error on nil username" do
       UserNameSuggester.suggest(nil).should be_nil


### PR DESCRIPTION
If you want to allow a different username length, some tests fail because you assume it's always 3..15 and it could be a different range.
