### PR TITLE
FIX: Index out of range error

### DIFF
--- a/app/assets/javascripts/discourse/models/user.js
+++ b/app/assets/javascripts/discourse/models/user.js
@@ -345,7 +345,7 @@ Discourse.User.reopenClass(Discourse.Singleton, {
     var result = Em.A();
     result.pushObjects(stats.rejectProperty('isResponse'));
 
-    var insertAt = 1;
+    var insertAt = 0;
     result.forEach(function(item, index){
      if(item.action_type === Discourse.UserAction.TYPES.topics || item.action_type === Discourse.UserAction.TYPES.posts){
        insertAt = index + 1;


### PR DESCRIPTION
Fixes 'index out of range error' that occurs when viewing a user's
profile page when they haven't yet posted a reply or created a topic
and is @mentioned in a topic.
### Disclaimer

I'm not sure I totally understand what this function is responsible for but the situation described above lead to trying to   `insertAt` index 1 of an empty `result` array. This seems to fix the issue and I haven't found any negative side effects.
### Steps to reproduce bug:
- Create a new user
- @mention that new user in a topic
- Try to view their profile page
