### PR TITLE
Avoid Breakage in production, check if Annotate is defined

### DIFF
--- a/lib/tasks/auto_annotate_models.rake
+++ b/lib/tasks/auto_annotate_models.rake
@@ -1,7 +1,8 @@
 # NOTE: only doing this in development as some production environments (Heroku)
 # NOTE: are sensitive to local FS writes, and besides -- it's just not proper
 # NOTE: to have a dev-mode tool do its thing in production.
-if(Rails.env.development?) && defined?(Annotate)
+begin
+if(Rails.env.development?)
   task :set_annotation_options do
     # You can override any of these by setting an environment variable of the
     # same name.
@@ -29,6 +30,7 @@ if(Rails.env.development?) && defined?(Annotate)
       'trace'                => "false",
     })
   end
-
   Annotate.load_tasks
+rescue NameError => e
+  #do nothing
 end


### PR DESCRIPTION
This code caused Ruby Uninitialized Constant NameError in production on my VPS as I with bundled `--without development` option. 

This patch first checks if Annotate is defined; then ONLY load it.Thus,  Avoids causing `NameError` in production
