### PR TITLE
Enable/disable the possibility of editing user's nickname or email

### DIFF
--- a/app/assets/javascripts/discourse/templates/user/preferences.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/user/preferences.js.handlebars
@@ -27,7 +27,9 @@
     <label class="control-label">{{i18n user.email.title}}</label>
     <div class="controls">
       <span class='static'>{{email}}</span>
-      {{#linkTo "preferences.email" class="btn pad-left"}}<i class="icon-pencil"></i>{{/linkTo}}
+      {{#if can_edit_email}}
+        {{#linkTo "preferences.email" class="btn pad-left"}}<i class="icon-pencil"></i>{{/linkTo}}
+      {{/if}}
     </div>
     <div class='instructions'>
       {{i18n user.email.instructions}}

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -205,7 +205,7 @@ class UsersController < ApplicationController
   def change_email
     params.require(:email)
     user = fetch_user_from_params
-    guardian.ensure_can_edit!(user)
+    guardian.ensure_can_edit_email!(user)
     lower_email = Email.downcase(params[:email]).strip
 
     # Raise an error if the email is already in use

--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -251,6 +251,7 @@ class SiteSetting < ActiveRecord::Base
   setting(:delete_all_posts_max, 10)
 
   setting(:username_change_period, 3) # days
+  setting(:email_editable, true)
 
   client_setting(:allow_uploaded_avatars, true)
   client_setting(:allow_animated_avatars, false)

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -10,6 +10,7 @@ class UserSerializer < BasicUserSerializer
              :website,
              :can_edit,
              :can_edit_username,
+             :can_edit_email,
              :stats,
              :can_send_private_message_to_user,
              :bio_excerpt,
@@ -76,6 +77,10 @@ class UserSerializer < BasicUserSerializer
 
   def can_edit_username
     scope.can_edit_username?(object)
+  end
+
+  def can_edit_email
+    scope.can_edit_email?(object)
   end
 
   def stats

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -684,7 +684,8 @@ en:
     relative_date_duration: "Number of days after posting where post dates will be shown as relative instead of absolute. Examples: relative date: 7d, absolute date: 20 Feb"
     delete_user_max_age: "The maximum age of a user, in days, which can be deleted by an admin."
     delete_all_posts_max: "The maximum number of posts that can be deleted at once with the Delete All Posts button. If a user has more than this many posts, the posts cannot all be deleted at once and the user can't be deleted."
-    username_change_period: "The number of days after registration that accounts can change their username."
+    username_change_period: "The number of days after registration that accounts can change their username (0 to disallow username change)."
+    email_editable: "Allow users to change their e-mail address after registration."
 
     allow_uploaded_avatars: "Allow users to upload their custom avatars"
     allow_animated_avatars: "Allow users to use animated gif for avatars. WARNING: it is highly recommended to run the avatars:regenerate rake task after changing that setting."

--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -285,7 +285,15 @@ class Guardian
   end
 
   def can_edit_username?(user)
-    is_staff? || (is_me?(user) && (user.post_count == 0 || user.created_at > SiteSetting.username_change_period.days.ago))
+    return true if is_staff?
+    return false if SiteSetting.username_change_period <= 0
+    is_me?(user) && (user.post_count == 0 || user.created_at > SiteSetting.username_change_period.days.ago)
+  end
+
+  def can_edit_email?(user)
+    return true if is_staff?
+    return false unless SiteSetting.email_editable?
+    can_edit?(user)
   end
 
   # Deleting Methods

--- a/spec/components/guardian_spec.rb
+++ b/spec/components/guardian_spec.rb
@@ -1195,6 +1195,72 @@ describe Guardian do
         end
       end
     end
+
+    context 'when editing is disabled in preferences' do
+      before do
+        SiteSetting.stubs(:username_change_period).returns(0)
+      end
+
+      include_examples "staff can always change usernames"
+
+      it "is false for the user to change his own username" do
+        Guardian.new(user).can_edit_username?(user).should be_false
+      end
+    end
+  end
+
+  describe "can_edit_email?" do
+    context 'when allowed in settings' do
+      before do
+        SiteSetting.stubs(:email_editable?).returns(true)
+      end
+
+      it "is false when not logged in" do
+        Guardian.new(nil).can_edit_email?(build(:user, created_at: 1.minute.ago)).should be_false
+      end
+
+      it "is false for regular users to edit another user's email" do
+        Guardian.new(build(:user)).can_edit_email?(build(:user, created_at: 1.minute.ago)).should be_false
+      end
+
+      it "is true for a regular user to edit his own email" do
+        Guardian.new(user).can_edit_email?(user).should be_true
+      end
+
+      it "is true for moderators" do
+        Guardian.new(moderator).can_edit_email?(user).should be_true
+      end
+
+      it "is true for admins" do
+        Guardian.new(admin).can_edit_email?(user).should be_true
+      end
+    end
+
+    context 'when not allowed in settings' do
+      before do
+        SiteSetting.stubs(:email_editable?).returns(false)
+      end
+
+      it "is false when not logged in" do
+        Guardian.new(nil).can_edit_email?(build(:user, created_at: 1.minute.ago)).should be_false
+      end
+
+      it "is false for regular users to edit another user's email" do
+        Guardian.new(build(:user)).can_edit_email?(build(:user, created_at: 1.minute.ago)).should be_false
+      end
+
+      it "is false for a regular user to edit his own email" do
+        Guardian.new(user).can_edit_email?(user).should be_false
+      end
+
+      it "is true for admins" do
+        Guardian.new(admin).can_edit_email?(user).should be_true
+      end
+
+      it "is true for moderators" do
+        Guardian.new(moderator).can_edit_email?(user).should be_true
+      end
+    end
   end
 
 end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -181,8 +181,8 @@ describe UsersController do
         lambda { xhr :put, :change_email, username: user.username }.should raise_error(ActionController::ParameterMissing)
       end
 
-      it "raises an error if you can't edit the user" do
-        Guardian.any_instance.expects(:can_edit?).with(user).returns(false)
+      it "raises an error if you can't edit the user's email" do
+        Guardian.any_instance.expects(:can_edit_email?).with(user).returns(false)
         xhr :put, :change_email, username: user.username, email: new_email
         response.should be_forbidden
       end


### PR DESCRIPTION
I added 2 settings to completely enable/disable the possibility of users to edit their nickname and/or email address in their profile page.

This is part of my modifications to allow for the integration of Discourse in a website using only the containing website users (basic user details and authentication, I let users manage their Discourse-only parameters like bio, avatars, mail preferences...). The session management and automatic creation of Discouse users is quite intrusive into the existing Discourse codebase (and not very "clean" yet), but the 2 settings I'm committing here are completely orthogonal to these big modifications. Since they might be useful for other workflows, I'm submitting this PR if you find it useful (of course I'm completely open to discussions about it!).
