### PR TITLE
rake task to regenerate avatars

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -669,7 +669,7 @@ en:
     username_change_period: "The number of days after registration that accounts can change their username."
 
     allow_uploaded_avatars: "Allow users to upload their custom avatars"
-    allow_animated_avatars: "Allow users to use animated gif for avatars"
+    allow_animated_avatars: "Allow users to use animated gif for avatars. WARNING: it is highly recommended to run the avatars:regenerate rake task after changing that setting."
     default_digest_email_frequency: "How often users receive digest emails by default. They can change this setting in their preferences."
 
   notification_types:

--- a/lib/tasks/avatars.rake
+++ b/lib/tasks/avatars.rake
@@ -1,0 +1,13 @@
+desc "re-generate avatars"
+task "avatars:regenerate" => :environment do
+  RailsMultisite::ConnectionManagement.each_connection do |db|
+    puts "Generating avatars for: #{db}"
+
+    User.select(:uploaded_avatar_id).where("uploaded_avatar_id IS NOT NULL").all.each do |u|
+      Jobs.enqueue(:generate_avatars, upload_id: u.uploaded_avatar_id)
+      putc "."
+    end
+
+  end
+  puts "\ndone."
+end


### PR DESCRIPTION
Adds the `avatars:regenerate` rake task to _re-generate_ all the uploaded avatars. This is useful when changing the `allow_animated_avatars` setting (it will freeze or animate avatars depending on the value of the setting)
