### PR TITLE
fixing bookmarks and blockquotes for mobile

### DIFF
--- a/app/assets/stylesheets/mobile/topic-post.css.scss
+++ b/app/assets/stylesheets/mobile/topic-post.css.scss
@@ -413,3 +413,57 @@ iframe {
 span.btn-text {display: none;}
 
   
+
+.read-icon {
+    &:before {
+    font-family: "FontAwesome";
+    content: "\f02e";
+    }
+    &.unseen {
+    &:before {
+      content: "\f097";
+    }
+    }
+    &.last-read {
+    color: #770000;
+    }
+    &.bookmarked {
+    &:before {
+      color: #0088CC;
+    }
+    }
+}
+
+blockquote {
+  margin: 0;
+}
+
+.quote-controls {
+  float: right;
+  color: #323232;
+  a {
+  margin: 0;
+  }
+
+    .back:before,
+    .quote-other-topic:before {
+    display: inline-block;
+    margin-left: 8px;
+    color: #323232;
+    font-family: "FontAwesome";
+    }
+    .back:before {
+    content: "\f062";
+    }
+    .quote-other-topic:before {
+    content: "\f061";
+    }
+}
+
+
+.quote .title {
+border-left: 5px solid #bebebe;
+background-color: #f1f1f1;
+padding: 10px 10px 0 12px;
+  .avatar {margin-right: 7px;}
+}


### PR DESCRIPTION
The bookmark icon now changes colors appropriately, and blockquotes have controls in the right place. I also removed the blockquote margin because it was kind of nuts on mobile 

![screen shot 2013-09-12 at 4 02 46 pm](https://f.cloud.github.com/assets/1681963/1133886/51be50f4-1be6-11e3-9d4e-ebf2a262b7bd.png)
