### PR TITLE
HandlebarsOneboxes: avoid constants multiple declarations

### DIFF
--- a/lib/oneboxer/stack_exchange_onebox.rb
+++ b/lib/oneboxer/stack_exchange_onebox.rb
@@ -2,17 +2,21 @@ require_dependency 'oneboxer/handlebars_onebox'
 
 module Oneboxer
   class StackExchangeOnebox < HandlebarsOnebox
-    DOMAINS = [
-      'stackexchange',
-      'stackoverflow',
-      'superuser',
-      'serverfault',
-      'askubuntu'
-    ]
+
+    unless defined? DOMAINS
+      DOMAINS = [
+        'stackexchange',
+        'stackoverflow',
+        'superuser',
+        'serverfault',
+        'askubuntu'
+      ]
+    end
 
     # http://rubular.com/r/V3T0I1VTPn
-    REGEX =
-      /^http:\/\/(?:(?:(?<subsubdomain>\w*)\.)?(?<subdomain>\w*)\.)?(?<domain>#{DOMAINS.join('|')})\.com\/(?:questions|q)\/(?<question>\d*)/
+    unless defined? REGEX
+      REGEX = /^http:\/\/(?:(?:(?<subsubdomain>\w*)\.)?(?<subdomain>\w*)\.)?(?<domain>#{DOMAINS.join('|')})\.com\/(?:questions|q)\/(?<question>\d*)/
+    end
 
     matcher REGEX
     favicon 'stackexchange.png'

--- a/lib/oneboxer/twitter_onebox.rb
+++ b/lib/oneboxer/twitter_onebox.rb
@@ -2,10 +2,14 @@ require_dependency 'oneboxer/handlebars_onebox'
 
 module Oneboxer
   class TwitterOnebox < HandlebarsOnebox
-    BASE_URL = 'https://api.twitter.com'.freeze
 
-    REGEX =
-      /^https?:\/\/(?:www\.)?twitter.com\/(?<user>[^\/]+)\/status\/(?<id>\d+)$/
+    unless defined? BASE_URL
+      BASE_URL = 'https://api.twitter.com'.freeze
+    end
+
+    unless defined? REGEX
+      REGEX = /^https?:\/\/(?:www\.)?twitter.com\/(?<user>[^\/]+)\/status\/(?<id>\d+)$/
+    end
 
     matcher REGEX
 


### PR DESCRIPTION
When requiring oneboxer in a plugin, reloading the code results in multiple constants declarations in this oneboxers.
