### PR TITLE
Better padding for spoiler text

### DIFF
--- a/app/assets/stylesheets/desktop/topic.css.scss
+++ b/app/assets/stylesheets/desktop/topic.css.scss
@@ -171,6 +171,7 @@
   span.spoiler {
     background-color: $black;
     color: $black;
+    padding: 2px;
     @include hover {
       color: $white;
     }


### PR DESCRIPTION
With no padding currently surrounding [spoiler] text, the white text
gets close enough to the white post background that it's a bit more
difficult to read than it reasonably could be. Pad spoiler text with 2px
to alleviate this difficulty.

Here's a quick example so you can see what I mean: hover over the
spoiler text in [this post](http://meta.discourse.org/t/how-do-you-spoiler-an-image-or-onebox/55)

Signed-off-by: David Celis me@davidcel.is
