### PR TITLE
Remove duplicate mixing in of Discourse.Presence

### DIFF
--- a/app/assets/javascripts/admin/controllers/admin_email_index_controller.js
+++ b/app/assets/javascripts/admin/controllers/admin_email_index_controller.js
@@ -6,7 +6,7 @@
   @namespace Discourse
   @module Discourse
 **/
-Discourse.AdminEmailIndexController = Discourse.Controller.extend(Discourse.Presence, {
+Discourse.AdminEmailIndexController = Discourse.Controller.extend({
 
   /**
     Is the "send test email" button disabled?

--- a/app/assets/javascripts/admin/controllers/admin_email_preview_digest_controller.js
+++ b/app/assets/javascripts/admin/controllers/admin_email_preview_digest_controller.js
@@ -6,7 +6,7 @@
   @namespace Discourse
   @module Discourse
 **/
-Discourse.AdminEmailPreviewDigestController = Discourse.ObjectController.extend(Discourse.Presence, {
+Discourse.AdminEmailPreviewDigestController = Discourse.ObjectController.extend({
 
   refresh: function() {
     var model = this.get('model');

--- a/test/javascripts/controllers/admin_email_index_controller_test.js
+++ b/test/javascripts/controllers/admin_email_index_controller_test.js
@@ -1,0 +1,5 @@
+module("Discourse.AdminEmailIndexController");
+
+test("mixes in Discourse.Presence", function() {
+  ok(Discourse.Presence.detect(Discourse.AdminEmailIndexController.create()));
+});

--- a/test/javascripts/controllers/admin_email_preview_digest_controller_test.js
+++ b/test/javascripts/controllers/admin_email_preview_digest_controller_test.js
@@ -1,0 +1,5 @@
+module("Discourse.AdminEmailPreviewDigestController");
+
+test("mixes in Discourse.Presence", function() {
+  ok(Discourse.Presence.detect(Discourse.AdminEmailPreviewDigestController.create()));
+});


### PR DESCRIPTION
AdminEmailIndexController and AdminEmailPreviewDigestController explicitely mix in Discourse.Presence, but they extend base classes Discourse.Controller and Discourse.ObjectController that already mix in Discourse.Presence, so this explicit inclusion is redundant.
