### PR TITLE
remove unnecessary return statement inside Discourse.Router.map

### DIFF
--- a/app/views/common/_discourse_javascript.html.erb
+++ b/app/views/common/_discourse_javascript.html.erb
@@ -22,7 +22,7 @@
   Discourse.BaseUri = '<%= Discourse::base_uri "/" %>';
   Discourse.Environment = '<%= Rails.env %>';
   Discourse.Router.map(function() {
-    return Discourse.routeBuilder.call(this);
+    Discourse.routeBuilder.call(this);
   });
   Discourse.start()
 </script>

--- a/test/javascripts/test_helper.js
+++ b/test/javascripts/test_helper.js
@@ -71,7 +71,7 @@ Discourse.injectTestHelpers();
 Discourse.bindDOMEvents();
 
 Discourse.Router.map(function() {
-  return Discourse.routeBuilder.call(this);
+  Discourse.routeBuilder.call(this);
 });
 
 


### PR DESCRIPTION
Ember's Router.map(callback) method doesn't expect any value to be
returned by callback function. Therefore, return statements present
inside Discourse.Router.map are unnecessary (and are silently ignored by
Ember).
