### PR TITLE
make category's RSS feed actually order by topic.created_at

### DIFF
--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -176,7 +176,7 @@ class TopicQuery
   end
 
   def list_new_in_category(category)
-    create_list(:new_in_category) {|l| l.where(category_id: category.id).by_newest.first(25)}
+    create_list(:new_in_category, unordered: true) {|l| l.where(category_id: category.id).by_newest.first(25)}
   end
 
   def self.new_filter(list, treat_as_new_topic_start_date)


### PR DESCRIPTION
http://meta.discourse.org/t/rss-support-for-categories-topics/2075/47

`create_list` applies an order unless you tell it not to.
