### PR TITLE
Remove duplicate create method in PostCreator

### DIFF
--- a/lib/post_creator.rb
+++ b/lib/post_creator.rb
@@ -7,10 +7,6 @@ class PostCreator
 
   attr_reader :errors, :opts
 
-  def self.create(user,opts)
-    self.new(user,opts).create
-  end
-
   # Acceptable options:
   #
   #   raw                     - raw text of post


### PR DESCRIPTION
When reading through the code in the PostCreator class for examples of service objects, I noticed that there are two `create` methods defined on self. This removed the most recently added one.
