### PR TITLE
Support single redis DB.

### DIFF
--- a/lib/discourse_redis.rb
+++ b/lib/discourse_redis.rb
@@ -63,9 +63,7 @@ class DiscourseRedis
       puts "Check your redis.yml and make sure it has configuration for the environment you're trying to use.", ''
       raise 'Redis config not found'
     end
-    redis_store = ActiveSupport::Cache::RedisStore.new "redis://#{(':' + redis_config['password'] + '@') if redis_config['password']}#{redis_config['host']}:#{redis_config['port']}/#{redis_config['cache_db']}"
-    redis_store.options[:namespace] = -> { DiscourseRedis.namespace }
-    redis_store
+    ActiveSupport::Cache::RedisStore.new host:redis_config['host'], port:redis_config['port'], password:redis_config['password'], db:redis_config['db'], namespace:->{ DiscourseRedis.namespace + "_cache" }
   end
 
 

--- a/spec/components/redis_store_spec.rb
+++ b/spec/components/redis_store_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+require 'cache'
+
+describe "Redis Store" do
+
+  let :cache do
+    Cache.new
+  end
+
+  let :store do
+    DiscourseRedis.new_redis_store
+  end
+
+  before(:each) do
+    cache.redis.del "key"
+    store.delete "key"
+  end
+
+  it "can store stuff" do
+    store.fetch "key" do
+      "key in store"
+    end
+
+    r = store.read "key"
+
+    r.should == "key in store"
+  end
+
+  it "doesn't collide with our Cache" do
+    store.fetch "key" do
+      "key in store"
+    end
+   
+    cache.fetch "key" do
+      "key in cache"
+    end
+ 
+    r = store.read "key"
+    
+    r.should == "key in store"
+  end
+
+  it "can be cleared without clearing our cache" do
+    store.fetch "key" do
+      "key in store"
+    end
+
+    cache.fetch "key" do
+      "key in cache"
+    end
+
+    store.clear
+    store.read("key").should be_nil
+    cache.fetch("key").should == "key in cache"
+  end
+
+end


### PR DESCRIPTION
Fixed pull request https://github.com/discourse/discourse/pull/1431
In addition this patch assumes the redis-store lambda namespace patch is applied (see: https://github.com/redis-store/redis-store/pull/212)
I suggest applying that to the redis-store gem used by discourse and then accepting this pull.
