### PR TITLE
removes unused builders param from Discourse.Model.mergeAttributes

### DIFF
--- a/app/assets/javascripts/discourse/models/model.js
+++ b/app/assets/javascripts/discourse/models/model.js
@@ -14,24 +14,11 @@ Discourse.Model = Ember.Object.extend(Discourse.Presence, {
 
     @method mergeAttributes
     @param {Object} attrs The attributes we want to merge with
-    @param {Object} builders Optional builders to use when merging attributes
   **/
-  mergeAttributes: function(attrs, builders) {
+  mergeAttributes: function(attrs) {
     var _this = this;
     _.each(attrs, function(v,k) {
-      // If they're in a builder we use that
-      var builder, col;
-      if (typeof v === 'object' && builders && (builder = builders[k])) {
-        if (!_this.get(k)) {
-          _this.set(k, Em.A());
-        }
-        col = _this.get(k);
-        _.each(v,function(obj) {
-          col.pushObject(builder.create(obj));
-        });
-      } else {
-        _this.set(k, v);
-      }
+      _this.set(k, v);
     });
   }
 


### PR DESCRIPTION
Full text search over the whole project tree reveals that builders param is never used. Considering that Discourse.Model class was last modified about 4 months ago I assume this is some forgotten, legacy code and can be removed.

WARNING: I'm aware that the test suite for the JS part of the app is very incomplete and I'm too new to the project to be able to manually discover and test all the edge cases - so in theory there may be a situation that mergeAttributes method is invoked somewhere in a way difficult to catch by a full text search (e.g. method name built dynamically by string concatenation) - so please verify that my commit doesn't break anything before accepting this pull request.
