### PR TITLE
Add bundle exec for rake db:migrate and assets:precompile

### DIFF
--- a/docs/INSTALL-ubuntu.md
+++ b/docs/INSTALL-ubuntu.md
@@ -199,8 +199,8 @@ Initialize the database:
     # The database name here should match the production one in database.yml
     cd /var/www/discourse
     createdb discourse_prod
-    RUBY_GC_MALLOC_LIMIT=90000000 RAILS_ENV=production rake db:migrate
-    RUBY_GC_MALLOC_LIMIT=90000000 RAILS_ENV=production rake assets:precompile
+    RUBY_GC_MALLOC_LIMIT=90000000 RAILS_ENV=production bundle exec rake db:migrate
+    RUBY_GC_MALLOC_LIMIT=90000000 RAILS_ENV=production bundle exec rake assets:precompile
 
 Not english? Set the default language as appropriate:
 
@@ -334,8 +334,8 @@ The corresponding site setting is:
     # "Check sample configuration files for new settings"
     #
     bundle install --without test --deployment
-    RUBY_GC_MALLOC_LIMIT=90000000 RAILS_ENV=production rake db:migrate
-    RUBY_GC_MALLOC_LIMIT=90000000 RAILS_ENV=production rake assets:precompile
+    RUBY_GC_MALLOC_LIMIT=90000000 RAILS_ENV=production bundle exec rake db:migrate
+    RUBY_GC_MALLOC_LIMIT=90000000 RAILS_ENV=production bundle exec rake assets:precompile
     # restart bluepill
     crontab -l
     # Here, run the command to start bluepill.


### PR DESCRIPTION
several users in the forum had problems without bundle exec
http://meta.discourse.org/t/rake-db-migrate-failed/9971
