### PR TITLE
Allow removing users from private conversations

### DIFF
--- a/app/assets/javascripts/discourse/controllers/topic_controller.js
+++ b/app/assets/javascripts/discourse/controllers/topic_controller.js
@@ -471,7 +471,17 @@ Discourse.TopicController = Discourse.ObjectController.extend(Discourse.Selected
   },
 
   removeAllowedUser: function(username) {
-    this.get('details').removeAllowedUser(username);
+    var self = this;
+    bootbox.dialog(I18n.t("private_message_info.remove_allowed_user", {name: username}), [
+      {label: I18n.t("no_value"),
+       'class': 'btn-danger rightg'},
+      {label: I18n.t("yes_value"),
+       'class': 'btn-primary',
+        callback: function() {
+          self.get('details').removeAllowedUser(username);
+        }
+      }
+    ]);
   }
 
 });

--- a/app/assets/javascripts/discourse/models/topic_details.js
+++ b/app/assets/javascripts/discourse/models/topic_details.js
@@ -57,11 +57,7 @@ Discourse.TopicDetails = Discourse.Model.extend({
       type: 'PUT',
       data: { username: username }
     }).then(function(res) {
-      users.forEach(function(user, i) {
-        if (user.username === username) {
-          users.removeAt(i);
-        }
-      });
+      users.removeObject(users.findProperty('username', username));
     });
   }
 });

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -382,7 +382,12 @@ class Topic < ActiveRecord::Base
   def remove_allowed_user(username)
     user = User.where(username: username).first
     if user
-      topic_allowed_users.where(user_id: user.id).first.destroy
+      topic_user = topic_allowed_users.where(user_id: user.id).first
+      if topic_user
+        topic_user.destroy
+      else
+        false
+      end
     end
   end
 

--- a/config/locales/client.de.yml
+++ b/config/locales/client.de.yml
@@ -373,6 +373,7 @@ de:
     private_message_info:
       title: "Privates Gespräch"
       invite: "Andere einladen..."
+      remove_allowed_user: "Willst du {{name}} wirklich aus diesem Gespräch entfernen?"
 
     email: 'Mail'
     username: 'Benutzername'

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -372,6 +372,7 @@ en:
     private_message_info:
       title: "Private Message"
       invite: "Invite Others..."
+      remove_allowed_user: "Do you really want to remove {{name}} from this private message?"
 
     email: 'Email'
     username: 'Username'


### PR DESCRIPTION
Before, clicking the small "X" just threw an error:

```
Uncaught TypeError: Object [object Object] has no method 'removeAllowedUser'
```

Now, it performs the necessary request and removes the user from the local model.

Any tips or concerns?
If not, this would be very useful for our forum :smile: 
