### PR TITLE
Presenting name for user stream description

### DIFF
--- a/app/assets/javascripts/discourse/models/user_action.js
+++ b/app/assets/javascripts/discourse/models/user_action.js
@@ -81,7 +81,7 @@ Discourse.UserAction = Discourse.Model.extend({
       replyUrl: this.get('replyUrl'),
       postUrl: this.get('postUrl'),
       topicUrl: this.get('replyUrl'),
-      user: this.get('name'),
+      user: this.get('presentName'),
       post_number: '#' + this.get('reply_to_post_number'),
       user1Url: this.get('userUrl'),
       user2Url: this.get('targetUserUrl'),
@@ -97,6 +97,8 @@ Discourse.UserAction = Discourse.Model.extend({
   targetUser: function() {
     return this.get('target_username') === Discourse.User.currentProp('username');
   }.property('target_username'),
+
+  presentName: Em.computed.any('name', 'username'),
 
   targetUserUrl: Discourse.computed.url('target_username', '/users/%@'),
   usernameLower: function() {


### PR DESCRIPTION
This arose from the issue of a user's name is not required to be present and therefore where it's used in the app, it should fallback to the user's username.  I noted this on [meta](http://meta.discourse.org/t/missing-user-value-in-chinese-localized-page/7406/8).

This isn't the cleanest JS because it's my first Ember contribution.  It should probably be moved to the User model and be used throughout the app when a name is required.
