### PR TITLE
adds unit tests for Discourse.debouncePromise

### DIFF
--- a/app/assets/javascripts/discourse/components/debounce.js
+++ b/app/assets/javascripts/discourse/components/debounce.js
@@ -49,9 +49,10 @@ Discourse.debounce = function(func, wait) {
 Discourse.debouncePromise = function(func, wait) {
   var timeout = null;
   var args = null;
+  var context = null;
 
   return function() {
-    var context = this;
+    context = this;
     var promise = Ember.Deferred.create();
     args = arguments;
 

--- a/test/javascripts/components/debounce_promise_test.js
+++ b/test/javascripts/components/debounce_promise_test.js
@@ -1,0 +1,91 @@
+var clock, original, debounced, originalPromiseResolvesWith, callback;
+
+var nothingFired = function(additionalMessage) {
+  ok(!original.called, "original function is not called " + additionalMessage);
+  ok(!callback.called, "debounced promise is not resolved " + additionalMessage);
+};
+
+var originalAndCallbackFiredOnce = function(additionalMessage) {
+  ok(original.calledOnce, "original function is called once " + additionalMessage);
+  ok(callback.calledOnce, "debounced promise is resolved once " + additionalMessage);
+};
+
+module("Discourse.debouncePromise", {
+  setup: function() {
+    clock = sinon.useFakeTimers();
+
+    originalPromiseResolvesWith = null;
+    original = sinon.spy(function() {
+      var promise = Ember.Deferred.create();
+      promise.resolve(originalPromiseResolvesWith);
+      return promise;
+    });
+
+    debounced = Discourse.debouncePromise(original, 100);
+    callback = sinon.spy();
+  },
+
+  teardown: function() {
+    clock.restore();
+  }
+});
+
+test("delays execution till the end of the timeout", function() {
+  debounced().then(callback);
+  nothingFired("immediately after calling debounced function");
+
+  clock.tick(99);
+  nothingFired("just before the end of the timeout");
+
+  clock.tick(1);
+  originalAndCallbackFiredOnce("exactly at the end of the timeout");
+});
+
+test("executes only once, no matter how many times debounced function is called during the timeout", function() {
+  debounced().then(callback);
+  debounced().then(callback);
+
+  clock.tick(100);
+  originalAndCallbackFiredOnce("(second call was supressed)");
+});
+
+test("does not prolong the timeout when the debounced function is called for the second time during the timeout", function() {
+  debounced().then(callback);
+
+  clock.tick(50);
+  debounced().then(callback);
+
+  clock.tick(50);
+  originalAndCallbackFiredOnce("exactly at the end of the original timeout");
+});
+
+test("preserves last call's context and params when executing delayed function", function() {
+  var firstObj = {};
+  var secondObj = {};
+
+  debounced.call(firstObj, "first");
+  debounced.call(secondObj, "second");
+
+  clock.tick(100);
+  ok(original.calledOn(secondObj), "the context of the second of two subsequent calls is preserved");
+  ok(original.calledWithExactly("second"), "param passed during the second of two subsequent calls is preserved");
+});
+
+test("can be called again after timeout passes", function() {
+  debounced().then(callback);
+
+  clock.tick(100);
+  debounced().then(callback);
+
+  clock.tick(100);
+  ok(original.calledTwice, "original function is called for the second time");
+  ok(callback.calledTwice, "debounced promise is resolved for the second time");
+});
+
+test("passes resolved value from the original promise as a param to the debounced promise's callback", function() {
+  originalPromiseResolvesWith = "original promise return value";
+  debounced().then(callback);
+
+  clock.tick(100);
+  ok(callback.calledWith("original promise return value"));
+});


### PR DESCRIPTION
Second half of the tests for Discourse debouncing mechanism. As discussed here: https://github.com/discourse/discourse/pull/1489 debouncing related code will need further refactoring, but this pull request should help doing it more safely.

As a side effect of writing this test, I've discovered also one issue: when issuing two subsequent debounce calls, Discourse.debounce preserves context and params from the first call, _.debounce from the last call but Discourse.debouncePromise preserves context from the first call but params from the last call - what is clearly a mismatch and a bug. This pull request, apart from the tests, contains also a fix for this bug (I believed that invoking the same debounced function with different params is much more common than with different contexts, so I decided params to be the "leading" one and made the context behave the same way as params - so both of them are now preserved from the last call).

PS: during the process I have also discovered, that Ember itself has a debounce function: http://emberjs.com/api/classes/Ember.run.html#method_debounce that operates inside a run loop etc. - so maybe this is the best way to go? I'll do some more research on how the debounce code is currently used throughout a project, and present some results with possible consequences of using various debounce mechanisms as a topic on meta.
