### PR TITLE
Remove cache headers in Rack::Cache::Discourse

### DIFF
--- a/config/initializers/99-rack-cache.rb
+++ b/config/initializers/99-rack-cache.rb
@@ -21,9 +21,9 @@ if Rails.configuration.respond_to?(:enable_rack_cache) && Rails.configuration.en
         super
       end
 
-      %w[Date Expires Cache-Control ETag Last-Modified].each do |header|
-        headers.delete header
-      end
+      cache_control = Rack::Cache::CacheControl.new(headers['Cache-Control'])
+      cache_control.merge!('public' => false, 'private' => true)
+      headers['Cache-Control'] = cache_control.to_s
 
       [status, headers, body]
     end


### PR DESCRIPTION
This change prevents cache headers from being sent upstream from rack cache. Before, if there was anything caching between discourse and the user (such as varnish), once a response got cached it would be served to every user regardless of login status. This change prevents such situations by removing all cache headers from going upstream.
