### PR TITLE
refactors Discourse.Model

### DIFF
--- a/app/assets/javascripts/discourse/models/model.js
+++ b/app/assets/javascripts/discourse/models/model.js
@@ -16,12 +16,11 @@ Discourse.Model = Ember.Object.extend(Discourse.Presence, {
     @param {Object} attrs The attributes we want to merge with
   **/
   mergeAttributes: function(attrs) {
-    var _this = this;
-    _.each(attrs, function(v,k) {
-      _this.set(k, v);
+    var self = this;
+    _.each(attrs, function(v, k) {
+      self.set(k, v);
     });
   }
-
 });
 
 Discourse.Model.reopenClass({
@@ -31,16 +30,13 @@ Discourse.Model.reopenClass({
 
     @method extractByKey
     @param {Object} collection The collection of values
-    @param {Object} klass Optional The class to instantiate
+    @param {Object} klass The class to instantiate
   **/
   extractByKey: function(collection, klass) {
     var retval = {};
-    if (!collection) return retval;
-    _.each(collection,function(c) {
-      retval[c.id] = klass.create(c);
+    _.each(collection, function(item) {
+      retval[item.id] = klass.create(item);
     });
     return retval;
   }
 });
-
-


### PR DESCRIPTION
- binds context to self
- fixes extractByKey method comment (klass is not really optional, without this parameter method breaks)
- removes redundant empty collection checking (if it is empty or undefined, _.each just does not trigger and everything still works as expected)

changes covered by https://github.com/discourse/discourse/blob/master/test/javascripts/models/model_test.js
