### PR TITLE
removes unused context binding from Discourse.Site

### DIFF
--- a/app/assets/javascripts/discourse/models/site.js
+++ b/app/assets/javascripts/discourse/models/site.js
@@ -45,7 +45,6 @@ Discourse.Site.reopenClass(Discourse.Singleton, {
   },
 
   create: function(obj) {
-    var _this = this;
     var result = this._super(obj);
 
     if (result.categories) {


### PR DESCRIPTION
refactoring covered by https://github.com/discourse/discourse/blob/master/test/javascripts/models/site_test.js (Discourse.Site.current() indirectly invokes create, thus exercising this change)
