### PR TITLE
YoutubeOnebox: FIX HTTP-specific URLs

### DIFF
--- a/lib/oneboxer/base_onebox.rb
+++ b/lib/oneboxer/base_onebox.rb
@@ -32,6 +32,11 @@ module Oneboxer
         URI.escape(val, Regexp.new("[^#{URI::PATTERN::UNRESERVED}]"))
       end
 
+      # Replace any occurence of a HTTP or HTTPS URL in the string with the protocol-agnostic variant
+      def replace_agnostic(var)
+        var.gsub! /https?:\/\//, '//' if var.is_a? String
+      end
+
     end
 
     def initialize(url, opts={})

--- a/lib/oneboxer/youtube_onebox.rb
+++ b/lib/oneboxer/youtube_onebox.rb
@@ -6,5 +6,10 @@ module Oneboxer
     def oembed_endpoint
       "http://www.youtube.com/oembed?url=#{BaseOnebox.uriencode(@url.sub('https://', 'http://'))}&format=json"
     end
+
+    def onebox
+      # Youtube allows HTTP and HTTPS, so replace them with the protocol-agnostic variant
+      super.each { |entry| BaseOnebox.replace_agnostic entry }
+    end
   end
 end


### PR DESCRIPTION
This replaces them with protocol-agnostic URLs, for example `//youtube.com/watch?v=...`

Fixes the mixed-content warning for secure instances of discourse, at least for Youtube.
