### PR TITLE
removes redundant context binding

### DIFF
--- a/app/assets/javascripts/preload_store.js
+++ b/app/assets/javascripts/preload_store.js
@@ -31,11 +31,9 @@ PreloadStore = {
     @returns {Ember.Deferred} a promise that will eventually be the object we want.
   **/
   getAndRemove: function(key, finder) {
-    var preloadStore = this;
-
-    if (preloadStore.data[key]) {
-      var promise = Ember.RSVP.resolve(preloadStore.data[key]);
-      delete preloadStore.data[key];
+    if (this.data[key]) {
+      var promise = Ember.RSVP.resolve(this.data[key]);
+      delete this.data[key];
       return promise;
     }
 


### PR DESCRIPTION
Mapping this to a var is unnecessary, this can be used directly. Covered by: https://github.com/discourse/discourse/blob/master/test/javascripts/components/preload_store_test.js
