### PR TITLE
removes unused context binding from Discourse.Lightbox

### DIFF
--- a/app/assets/javascripts/discourse/components/lightbox.js
+++ b/app/assets/javascripts/discourse/components/lightbox.js
@@ -7,7 +7,6 @@
 **/
 Discourse.Lightbox = {
   apply: function($elem) {
-    var _this = this;
     $LAB.script("/javascripts/jquery.magnific-popup-min.js").wait(function() {
       $('a.lightbox', $elem).each(function(i, e) {
         $(e).magnificPopup({ type: 'image', closeOnContentClick: true });


### PR DESCRIPTION
This is not covered by any unit tests, but the whole method is 3 lines and it is very clear that _this (nor this) is not used anywhere. Unit tests to cover this method would require quite complex setup (method loads external script asynchronously then binds it as jQuery plugin) so I think removing this line without test is a reasonable tradeoff - but it's your call if you want to accept such pull request.
