### PR TITLE
removes unused context binding from Discourse.SyntaxHighlighting

### DIFF
--- a/app/assets/javascripts/discourse/components/syntax_highlighting.js
+++ b/app/assets/javascripts/discourse/components/syntax_highlighting.js
@@ -16,7 +16,6 @@ Discourse.SyntaxHighlighting = {
     @param {jQuery.selector} $elem The element we want to apply our highlighting to
   **/
   apply: function($elem) {
-    var _this = this;
     return $('pre code[class]', $elem).each(function(i, e) {
       return $LAB.script("/javascripts/highlight-handlebars.pack.js").wait(function() {
         return hljs.highlightBlock(e);


### PR DESCRIPTION
Not covered by any unit tests, but this is identical tradeoff as in this case: https://github.com/discourse/discourse/pull/1521 (straightforward and safe refactoring vs complicated test setup)
