### PR TITLE
add image authorization on upload_avatar

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -302,6 +302,10 @@ class UsersController < ApplicationController
 
     file = params[:file] || params[:files].first
 
+    unless SiteSetting.authorized_image?(file)
+      return render status: 422, text: I18n.t("upload.images.unknown_image_type")
+    end
+
     # check the file size (note: this might also be done in the web server)
     filesize = File.size(file.tempfile)
     max_size_kb = SiteSetting.max_image_size_kb * 1024

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -966,6 +966,12 @@ describe UsersController do
         response.status.should eq 413
       end
 
+      it 'rejects unauthorized images' do
+        SiteSetting.stubs(:authorized_image?).returns(false)
+        xhr :post, :upload_avatar, username: user.username, file: avatar
+        response.status.should eq 422
+      end
+
       it 'is successful' do
         upload = Fabricate(:upload)
         Upload.expects(:create_for).returns(upload)


### PR DESCRIPTION
Checks that the file uploaded as an avatar has an autorized image extension. It was possible to upload any type of file.
