### PR TITLE
FIX: prevent share-view being clipped at viewport bounds

### DIFF
--- a/app/assets/javascripts/discourse/views/share_view.js
+++ b/app/assets/javascripts/discourse/views/share_view.js
@@ -60,14 +60,24 @@ Discourse.ShareView = Discourse.View.extend({
         url = window.location.protocol + "//" + window.location.host + url;
       }
 
-      var x = e.pageX - 150;
+      var shareLinkWidth = $('#share-link').width();
+      var x = e.pageX - (shareLinkWidth / 2);
       if (x < 25) {
         x = 25;
+      }
+      if (x + shareLinkWidth > $(window).width()) {
+        x -= shareLinkWidth / 2;
+      }
+
+      var header = $('.d-header');
+      var y = e.pageY - ($('#share-link').height() + 20);
+      if (y < header.offset().top + header.height()) {
+        y = e.pageY + 10;
       }
 
       $('#share-link').css({
         left: "" + x + "px",
-        top: "" + (e.pageY - 100) + "px"
+        top: "" + y + "px"
       });
       shareView.set('controller.link', url);
       shareView.set('controller.postNumber', postNumber);


### PR DESCRIPTION
Prevents the share view popup from being clipped when the associated post is near the edge of the viewport. This is especially problematic in the mobile layout and in the desktop layout whenever a post is scrolled close to the header.
