### PR TITLE
Change fixed width of logo in header to max-height. 

### DIFF
--- a/app/assets/stylesheets/desktop/header.scss
+++ b/app/assets/stylesheets/desktop/header.scss
@@ -30,7 +30,8 @@
     }
   }
   #site-logo {
-    width: 122px;
+    max-height: 40px;
+    max-width: 350px;
   }
   .icon-home {
     font-size: 20px;


### PR DESCRIPTION
Addresses issue #1045. 

This isn't an ideal solution for that issue, since it doesn't reflow the body container to accommodate a larger logo. But, max-height allows a more fluid height and width of the logo and will use css to resize a larger logo to a size that fits in the header.
