### PR TITLE
Adding post details in preparation for the API importer code.

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -34,6 +34,8 @@ class Post < ActiveRecord::Base
 
   has_one :post_search_data
 
+  has_many :post_details
+
   validates_with ::Validators::PostValidator
 
   # We can pass several creating options to a post via attributes
@@ -54,6 +56,17 @@ class Post < ActiveRecord::Base
 
   def self.types
     @types ||= Enum.new(:regular, :moderator_action)
+  end
+
+  def self.find_by_detail(key, value)
+    includes(:post_details).where( "post_details.key = ? AND " +
+                                   "post_details.value = ?",
+                                   key,
+                                   value ).first
+  end
+
+  def add_detail(key, value, extra = nil)
+    post_details.build(key: key, value: value, extra: extra)
   end
 
   def limit_posts_per_day

--- a/app/models/post_detail.rb
+++ b/app/models/post_detail.rb
@@ -1,0 +1,6 @@
+class PostDetail < ActiveRecord::Base
+  belongs_to :post
+
+  validates_presence_of   :key, :value
+  validates_uniqueness_of :key, scope: :post_id
+end

--- a/db/migrate/20131015131652_create_post_details.rb
+++ b/db/migrate/20131015131652_create_post_details.rb
@@ -1,0 +1,14 @@
+class CreatePostDetails < ActiveRecord::Migration
+  def change
+    create_table :post_details do |t|
+      t.belongs_to :post
+      t.string     :key
+      t.string     :value, size: 512
+      t.text       :extra
+
+      t.timestamps
+    end
+
+    add_index :post_details, [:post_id, :key], unique: true
+  end
+end

--- a/spec/fabricators/post_detail_fabricator.rb
+++ b/spec/fabricators/post_detail_fabricator.rb
@@ -1,0 +1,5 @@
+Fabricator(:post_detail) do
+  post
+  key { sequence(:key) { |i| "key#{i}" } }
+  value "test value"
+end

--- a/spec/models/post_detail_spec.rb
+++ b/spec/models/post_detail_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe PostDetail do
+  it { should belong_to :post }
+
+  it { should validate_presence_of :key }
+  it { should validate_presence_of :value }
+  it { should validate_uniqueness_of(:key).scoped_to(:post_id) }
+end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -26,6 +26,8 @@ describe Post do
   it { should have_many :post_uploads }
   it { should have_many :uploads }
 
+  it { should have_many :post_details }
+
   it { should rate_limit }
 
   let(:topic) { Fabricate(:topic) }
@@ -757,6 +759,22 @@ describe Post do
       p1 = Fabricate(:post)
       p2 = Fabricate(:post)
       Post.urls([p1.id, p2.id]).should == {p1.id => p1.url, p2.id => p2.url}
+    end
+  end
+
+  describe "details" do
+    it "adds details" do
+      post = Fabricate.build(:post)
+      post.add_detail("key", "value")
+      post.post_details.size.should == 1
+      post.post_details.first.key.should == "key"
+      post.post_details.first.value.should == "value"
+    end
+
+    it "can find a post by a detail" do
+      detail = Fabricate(:post_detail)
+      post   = detail.post
+      Post.find_by_detail(detail.key, detail.value).id.should == post.id
     end
   end
 


### PR DESCRIPTION
This request adds the metadata @SamSaffron and I have been discussing.  I will need it for the import API endpoint I wish to add so that I can import the Google Groups messages from Parley.

I went with the name `PostDetail` which I realize isn't too awesome, but it avoids the pluralization problem with anything ending in data.  I tried to follow Sam's recommendations for everything else.

Just let me know if I need to change any of this.
