### PR TITLE
make CommonHelper's methods available in the layout

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,6 +9,7 @@ module ApplicationHelper
   include CurrentUser
   include CanonicalURL::Helpers
   include ConfigurableUrls
+  include CommonHelper
 
   def discourse_csrf_tags
     # anon can not have a CSRF token cause these are all pages


### PR DESCRIPTION
`render_google_analytics_code` method used in the layout is not available as it is defined out of ApplicationHelper and raises `NoMethodError` exception.
