### PR TITLE
removes unused return statement from ContainerView.attachViewWithArgs

### DIFF
--- a/app/assets/javascripts/discourse/views/container_view.js
+++ b/app/assets/javascripts/discourse/views/container_view.js
@@ -15,13 +15,11 @@ Discourse.ContainerView = Ember.ContainerView.extend(Discourse.Presence, {
     @method attachViewWithArgs
     @param {Object} viewArgs The arguments to pass when creating the view
     @param {Class} klass The view class we want to create
-    @return {Ember.View} the view we created
   **/
   attachViewWithArgs: function(viewArgs, viewClass) {
     if (!viewClass) { viewClass = Ember.View.extend(); }
     var view = this.createChildView(viewClass, viewArgs);
     this.pushObject(view);
-    return view;
   },
 
   /**
@@ -29,7 +27,6 @@ Discourse.ContainerView = Ember.ContainerView.extend(Discourse.Presence, {
 
     @method attachViewClass
     @param {Class} klass The view class we want to create
-    @return {Ember.View} the view we created
   **/
   attachViewClass: function(viewClass) {
     this.attachViewWithArgs(null, viewClass);


### PR DESCRIPTION
There are two similar methods in Discourse.ContainerView: attachViewWithArgs and attachViewClass. First one (attachViewWithArgs) returns newly created view while the second one (attachViewClass) does not return anything. This is asymmetrical and should be unified, so either both methods return newly attached view or both methods return nothing.

I have checked all the places where attachViewWithArgsis is used, and the value returned from this method is never used (never assigned to anything), so I've chosen the simpler variant - both methods return nothing.
