### PR TITLE
Remove best standards support for Rails 4 (Removed from ActionDispatch)

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -18,7 +18,7 @@ Discourse::Application.configure do
   config.active_support.deprecation = :log
 
   # Only use best-standards-support built into browsers
-  config.action_dispatch.best_standards_support = :builtin
+  config.action_dispatch.best_standards_support = :builtin unless rails4?
 
   # Do not compress assets
   config.assets.compress = false


### PR DESCRIPTION
See rails/rails@3bccd12
