### PR TITLE
Update 20131017014509_add_post_count_to_categories.rb

### DIFF
--- a/db/migrate/20131017014509_add_post_count_to_categories.rb
+++ b/db/migrate/20131017014509_add_post_count_to_categories.rb
@@ -3,7 +3,7 @@ class AddPostCountToCategories < ActiveRecord::Migration
     add_column :categories, :post_count, :integer, null: false, default: 0
     execute <<SQL
     UPDATE categories
-    SET post_count = (SELECT SUM(posts_count) FROM topics
+    SET post_count = (SELECT COALESCE(SUM(posts_count),0) FROM topics
                       WHERE category_id = categories.id AND deleted_at IS NULL)
 SQL
   end


### PR DESCRIPTION
In case the category does not have any posts yet. You get a null value error running the migration if this is the case.
