### PR TITLE
Use existing request object if possible in default_current_user_provider

### DIFF
--- a/lib/admin_constraint.rb
+++ b/lib/admin_constraint.rb
@@ -3,7 +3,7 @@ require_dependency 'current_user'
 class AdminConstraint
 
   def matches?(request)
-    provider = Discourse.current_user_provider.new(request.env)
+    provider = Discourse.current_user_provider.new(request)
     provider.current_user && provider.current_user.admin?
   end
 

--- a/lib/current_user.rb
+++ b/lib/current_user.rb
@@ -8,10 +8,9 @@ module CurrentUser
     Discourse.current_user_provider.new(env).current_user
   end
 
-
   # can be used to pretend current user does no exist, for CSRF attacks
   def clear_current_user
-    @current_user_provider = Discourse.current_user_provider.new({})
+    @current_user_provider = nil
   end
 
   def log_on_user(user)
@@ -33,7 +32,7 @@ module CurrentUser
   private
 
   def current_user_provider
-    @current_user_provider ||= Discourse.current_user_provider.new(request.env)
+    @current_user_provider ||= Discourse.current_user_provider.new(request)
   end
 
 end

--- a/lib/homepage_constraint.rb
+++ b/lib/homepage_constraint.rb
@@ -4,7 +4,7 @@ class HomePageConstraint
   end
 
   def matches?(request)
-    provider = Discourse.current_user_provider.new(request.env)
+    provider = Discourse.current_user_provider.new(request)
     homepage = provider.current_user ? SiteSetting.homepage : SiteSetting.anonymous_homepage
     homepage == @filter
   end

--- a/lib/staff_constraint.rb
+++ b/lib/staff_constraint.rb
@@ -3,7 +3,7 @@ require_dependency 'current_user'
 class StaffConstraint
 
   def matches?(request)
-    provider = Discourse.current_user_provider.new(request.env)
+    provider = Discourse.current_user_provider.new(request)
     provider.current_user && provider.current_user.staff?
   end
 

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -10,7 +10,7 @@ module Helpers
   end
 
   def log_in_user(user)
-    provider = Discourse.current_user_provider.new(request.env)
+    provider = Discourse.current_user_provider.new(request)
     provider.log_on_user(user,session,cookies)
   end
 


### PR DESCRIPTION
Recreating the request object from the env can strip important data such as api_key and api_username.  It's still alright for when you want to check on the current user or cookies.

This was discovered when api requests were getting forbidden for no reason.
