### PR TITLE
Fixed Youtube videos appearing on top of compose panel

### DIFF
--- a/lib/oneboxer/base_onebox.rb
+++ b/lib/oneboxer/base_onebox.rb
@@ -37,6 +37,11 @@ module Oneboxer
         var.gsub! /https?:\/\//, '//' if var.is_a? String
       end
 
+      # Add wmode=opaque to the iframe src URL so that the flash player is rendered within the document flow instead of on top
+      def append_embed_wmode(var)
+        var.gsub! /(src="[^"]+)/, '\1&wmode=opaque"' if var.is_a? String
+      end
+
     end
 
     def initialize(url, opts={})

--- a/lib/oneboxer/flash_video_onebox.rb
+++ b/lib/oneboxer/flash_video_onebox.rb
@@ -7,7 +7,7 @@ module Oneboxer
 
     def onebox
       if SiteSetting.enable_flash_video_onebox
-        "<object width='100%' height='100%'><param name='#{@url}' value='#{@url}'><embed src='#{@url}' width='100%' height='100%'></embed></object>"
+        "<object width='100%' height='100%' wmode='opaque'><param name='#{@url}' value='#{@url}'><embed src='#{@url}' width='100%' height='100%' wmode='opaque'></embed></object>"
       else
         "<a href='#{@url}'>#{@url}</a>"
       end

--- a/lib/oneboxer/youtube_onebox.rb
+++ b/lib/oneboxer/youtube_onebox.rb
@@ -8,8 +8,13 @@ module Oneboxer
     end
 
     def onebox
-      # Youtube allows HTTP and HTTPS, so replace them with the protocol-agnostic variant
-      super.each { |entry| BaseOnebox.replace_agnostic entry }
+      super.each do |entry|
+        # Youtube allows HTTP and HTTPS, so replace them with the protocol-agnostic variant
+        BaseOnebox.replace_agnostic entry
+
+        # Add wmode=opaque to the iframe src URL so that the flash player is rendered within the document flow instead of on top
+        BaseOnebox.append_embed_wmode entry
+      end
     end
   end
 end


### PR DESCRIPTION
Added wmode=opaque to embed elements so that they are rendered within the expected stacking context

Details: http://meta.discourse.org/t/youtube-embeds-cover-compose-panel/2285
