### PR TITLE
Update open_id_authenticator.rb

### DIFF
--- a/lib/auth/open_id_authenticator.rb
+++ b/lib/auth/open_id_authenticator.rb
@@ -22,7 +22,7 @@ class Auth::OpenIdAuthenticator < Auth::Authenticator
 
     user_open_id = UserOpenId.find_by_url(identity_url)
 
-    if !user_open_id && @opts[:trusted] && user = User.find_by_email(email)
+    if !user_open_id && @opts[:trusted] && user = User.find_by_email(email).first 
       user_open_id = UserOpenId.create(url: identity_url , user_id: user.id, email: email, active: true)
     end
 


### PR DESCRIPTION
User.find_by_email(...) may return set of rows and hence it might be a good idea to return the first row else there will be an exception (posted in a separate comment) 

Even with the previous code my installation of discourse worked perfectly fine but I ran into problem once I had a multi-site installation. I do not know the underlying details but this change fixed the issue.
