### PR TITLE
When finding user by email, should return only single user

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -124,21 +124,18 @@ class User < ActiveRecord::Base
   end
 
   def self.find_by_username_or_email(username_or_email)
-    users = if username_or_email.include?('@')
-              find_by_email(username_or_email)
-            else
-              find_by_username(username_or_email)
-            end
-
-    if users.size > 1
-      raise Discourse::TooManyMatches
+    if username_or_email.include?('@')
+      find_by_email(username_or_email)
     else
+      users = find_by_username(username_or_email)
+      raise Discourse::TooManyMatches if users.size > 1
       users.first
     end
   end
 
+  # Find a user by email, which is unique for users
   def self.find_by_email(email)
-    where(email: Email.downcase(email))
+    where(email: Email.downcase(email)).first
   end
 
   def self.find_by_username(username)


### PR DESCRIPTION
1) finding user by `email` will return a unique user, (as there is a uniqueness validation in place).
2) Also this would remove the requirement to do a `.first` at any place where the user is being looked up by email.

A question:
finding user by `username`  here checks for `users.size` , is this the intended behavior ?, as there seems to be a validation too, checking for uniqueness of `username` according to which, should  not `find_by_username`  return a single user instead of an array of users? 

Feedback? 
@eviltrout @SamSaffron
