### PR TITLE
fixes wrong placement of expect in header integration test

### DIFF
--- a/test/javascripts/integration/header_test.js
+++ b/test/javascripts/integration/header_test.js
@@ -1,14 +1,10 @@
 integration("Header");
 
 test("/", function() {
+  expect(2);
 
   visit("/").then(function() {
-    expect(2);
-
     ok(exists("header"), "The header was rendered");
     ok(exists("#site-logo"), "The logo was shown");
   });
-
 });
-
-


### PR DESCRIPTION
QUnit's expect() doesn't make sense inside the async method - it will be called only if visit() method results in success and it should verify exactly the opposite situation. I've moved it to its correct place at the top of the test.
