### PR TITLE
main logo size consistency fix

### DIFF
--- a/app/assets/stylesheets/desktop/header.scss
+++ b/app/assets/stylesheets/desktop/header.scss
@@ -29,8 +29,7 @@
     }
   }
   #site-logo {
-    max-height: 40px;
-    max-width: 350px;
+    width: 122px;
   }
   .icon-home {
     font-size: 20px;


### PR DESCRIPTION
this limits the size of the main logo, so that on scroll the main logo matches with the smaller logo 
