### PR TITLE
Fix serialization of ActiveRecord::Associations::CollectionProxy in Rails 4

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -134,7 +134,7 @@ class ApplicationController < ActionController::Base
   def serialize_data(obj, serializer, opts={})
     # If it's an array, apply the serializer as an each_serializer to the elements
     serializer_opts = {scope: guardian}.merge!(opts)
-    if obj.is_a?(Array)
+    if obj.is_a?(Array) or obj.is_a?(ActiveRecord::Associations::CollectionProxy)
       serializer_opts[:each_serializer] = serializer
       ActiveModel::ArraySerializer.new(obj, serializer_opts).as_json
     else


### PR DESCRIPTION
In Rails 4, associations (such as `post.replies`) return a ActiveRecord::Associations::CollectionProxy rather than an actual array. The collection proxy needs to be serialised using the ArraySerializer. The post#replies action was broken because of this (possibly others too, but NewRelic was only reporting this one).
