### PR TITLE
enables passing additional setup / teardown code to integration test helper

### DIFF
--- a/test/javascripts/helpers/qunit_helpers.js
+++ b/test/javascripts/helpers/qunit_helpers.js
@@ -1,12 +1,20 @@
-function integration(name) {
+function integration(name, lifecycle) {
   module("Integration: " + name, {
     setup: function() {
       sinon.stub(Discourse.ScrollingDOMMethods, "bindOnScroll");
       sinon.stub(Discourse.ScrollingDOMMethods, "unbindOnScroll");
       Ember.run(Discourse, Discourse.advanceReadiness);
+
+      if (lifecycle && lifecycle.setup) {
+        lifecycle.setup.call(this);
+      }
     },
 
     teardown: function() {
+      if (lifecycle && lifecycle.teardown) {
+        lifecycle.teardown.call(this);
+      }
+
       Discourse.reset();
       Discourse.ScrollingDOMMethods.bindOnScroll.restore();
       Discourse.ScrollingDOMMethods.unbindOnScroll.restore();


### PR DESCRIPTION
QUnit doesn't allow nesting of modules, so it was either using integration helper as is, or duplicating its functionality (advanceReadiness, reset etc.) in cases when setup / teardown code for test is necessary.

This pull request allows passing the integration helper an object with setup / teardown methods that will be executed in addition to what is already provided by this helper.
