### PR TITLE
adds QUnit test helper simplifying usage of #qunit-fixture

### DIFF
--- a/test/javascripts/helpers/qunit_helpers.js
+++ b/test/javascripts/helpers/qunit_helpers.js
@@ -40,3 +40,10 @@ function asyncTestDiscourse(text, func) {
     });
   });
 }
+
+function fixture(selector) {
+  if (selector) {
+    return $("#qunit-fixture").find(selector);
+  }
+  return $("#qunit-fixture");
+}


### PR DESCRIPTION
reason for this helper:

When using #qunit-fixture element it is important to focus all subsequent searches to this element. E.g. assertion `equal($("a").href(), someURL);` is incorrect, as such jQuery search is global and can catch links outside of #qunit-fixture (e.g. inside test runner results or inside integration tests container. The correct version of this assertion is `equal($("#qunit-fixture a").href(), someURL);` or `equal($("#qunit-fixture").find("a").href(), someURL);`.

Explicitly adding #qunit-fixture to every selector used in every unit tests is tedious and error prone - this helper is intended to provide an abstraction layer to simplify and encapsulate this.

It can be used like: `equal(fixture("a").href(), someUrl);`. It can be also used without sub-selector - it then returns the #qunit-fixture element itself, what is useful for writing into this element, e.g.: `view.appendTo(fixture());`
