### PR TITLE
FIX: adds fixture test helper to JSHint config

### DIFF
--- a/config/jshint.yml
+++ b/config/jshint.yml
@@ -86,6 +86,7 @@ predef:
   - count
   - exists
   - asyncTestDiscourse
+  - fixture
   - find
   - sinon
   - controllerFor

--- a/test/javascripts/jshint_all.js.erb
+++ b/test/javascripts/jshint_all.js.erb
@@ -114,6 +114,7 @@ var jsHintOpts = {
     "count",
     "exists",
     "asyncTestDiscourse",
+    "fixture",
     "find",
     "sinon",
     "moment",


### PR DESCRIPTION
When creating this test helper: https://github.com/discourse/discourse/pull/1624, I didn't notice that helpers also need to be added to JSHint config, otherwise when you try to use this helper in a test, JSHint complains about using undeclared function.

This pull request fixes this issue.
