### PR TITLE
cleans up setup of header integration test

### DIFF
--- a/test/javascripts/integration/header_test.js
+++ b/test/javascripts/integration/header_test.js
@@ -1,4 +1,4 @@
-module("Integration: Header", {
+integration("Header", {
   setup: function() {
     sinon.stub(I18n, "t", function(scope, options) {
       if (options) {


### PR DESCRIPTION
Before this pull request https://github.com/discourse/discourse/pull/1614 I had to use a normal module instead of integration helper, because I needed to have additional setup / teardown code in this integration test.

Now when integration helper is enhanced with the option to pass additional setup / teardown code, header test can be refactored to use this helper again.
