### PR TITLE
Refactor Users#upload_avatar method

### DIFF
--- a/lib/avatar_upload_service.rb
+++ b/lib/avatar_upload_service.rb
@@ -1,0 +1,43 @@
+class AvatarUploadService
+
+  attr_accessor :source
+  attr_reader :filesize, :file
+
+  def initialize(file, source)
+    @source = source
+    @file , @filesize = construct(file)
+  end
+
+  def construct(file)
+    case source
+    when :url
+      build_from_url(file)
+    when :image
+      [file, File.size(file.tempfile)]
+    end
+  end
+
+  private
+
+  def build_from_url(url)
+    temp = ::UriAdapter.new(url)
+    return temp.build_uploaded_file, temp.file_size
+  end
+
+end
+
+class AvatarUploadPolicy
+
+  def initialize(avatar)
+    @avatar = avatar
+  end
+
+  def max_size_kb
+    SiteSetting.max_image_size_kb * 1024
+  end
+
+  def too_big?
+    @avatar.filesize > max_size_kb
+  end
+
+end

--- a/spec/components/avatar_upload_service_spec.rb
+++ b/spec/components/avatar_upload_service_spec.rb
@@ -1,0 +1,66 @@
+require "spec_helper"
+require "avatar_upload_service"
+
+describe AvatarUploadService do
+  let(:file) do
+    ActionDispatch::Http::UploadedFile.new({
+      filename: 'logo.png',
+      tempfile: File.new("#{Rails.root}/spec/fixtures/images/logo.png")
+    })
+  end
+
+  let(:url) { "http://cdn.discourse.org/assets/logo.png" }
+
+  describe "#construct" do
+    context "when avatar is in the form of a file upload" do
+      let(:avatar_file) { AvatarUploadService.new(file, :image) }
+
+      it "should have a filesize" do
+        expect(avatar_file.filesize).to eq(2290)
+      end
+
+      it "should have a source as 'image'" do
+        expect(avatar_file.source).to eq(:image)
+      end
+
+      it "is an instance of File class" do
+        file = avatar_file.file
+        expect(file.tempfile).to be_instance_of File
+      end
+
+      it "returns the file object built from File" do
+        file = avatar_file.file
+        file.should be_instance_of(ActionDispatch::Http::UploadedFile)
+        file.original_filename.should == "logo.png"
+      end
+    end
+
+    context "when file is in the form of a URL" do
+      let(:avatar_file) { AvatarUploadService.new(url, :url) }
+
+      before :each do
+        UriAdapter.any_instance.stubs(:open).returns StringIO.new(fixture_file("images/logo.png"))
+      end
+
+      it "should have a filesize" do
+        expect(avatar_file.filesize).to eq(2290)
+      end
+
+      it "should have a source as 'url'" do
+        expect(avatar_file.source).to eq(:url)
+      end
+
+      it "is an instance of Tempfile class" do
+        file = avatar_file.file
+        expect(file.tempfile).to be_instance_of Tempfile
+      end
+
+      it "returns the file object built from URL" do
+        file = avatar_file.file
+        file.should be_instance_of(ActionDispatch::Http::UploadedFile)
+        file.original_filename.should == "logo.png"
+      end
+    end
+  end
+
+end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -996,7 +996,7 @@ describe UsersController do
         end
 
         it 'rejects large images' do
-          SiteSetting.stubs(:max_image_size_kb).returns(1)
+          AvatarUploadPolicy.any_instance.stubs(:too_big?).returns(true)
           xhr :post, :upload_avatar, username: user.username, file: avatar
           response.status.should eq 413
         end
@@ -1041,7 +1041,7 @@ describe UsersController do
           end
 
           it 'rejects large images' do
-            SiteSetting.stubs(:max_image_size_kb).returns(1)
+            AvatarUploadPolicy.any_instance.stubs(:too_big?).returns(true)
             xhr :post, :upload_avatar, username: user.username, file: avatar_url
             response.status.should eq 413
           end


### PR DESCRIPTION
Moved avatar file upload code to `AvatarUploadService` class and `AvatarUploadPolicy`
Added specs for `AvatarUploadServiceSpec`

Is this fair enough? Any feedback or concerns on this ? :)

@eviltrout @SamSaffron @ZogStriP
