### PR TITLE
Update discourse.js

### DIFF
--- a/app/assets/javascripts/discourse.js
+++ b/app/assets/javascripts/discourse.js
@@ -25,6 +25,7 @@ Discourse = Ember.Application.createWithMixins(Discourse.Ajax, {
     if (u[u.length-1] === '/') {
       u = u.substring(0, u.length-1);
     }
+    if (url.indexOf(u) != -1) return url;
     return u + url;
   },
 


### PR DESCRIPTION
Inserted  if (url.indexOf(u) != -1) return url; in getURL function because of bug in subdirectory install on some urls doubles relative url prefix, for example /forum/forum/latest.json. With this fix it works fine.
