### PR TITLE
fixes the problem with perceived not mocked xhr call in tests

### DIFF
--- a/test/javascripts/controllers/header_controller_test.js
+++ b/test/javascripts/controllers/header_controller_test.js
@@ -1,22 +1,28 @@
-var server;
-
 module("Discourse.HeaderController", {
   setup: function() {
-    server = sinon.fakeServer.create();
+    sinon.stub(Discourse, "ajax");
   },
 
   teardown: function() {
-    server.restore();
+    Discourse.ajax.restore();
   }
 });
 
 test("showNotifications action", function() {
+  var resolveRequestWith;
+  var request = new Ember.RSVP.Promise(function(resolve) {
+    resolveRequestWith = resolve;
+  });
+
+
   var controller = Discourse.HeaderController.create();
   var viewSpy = {
     showDropdownBySelector: sinon.spy()
   };
   Discourse.User.current().set("unread_notifications", 1);
-  server.respondWith("/notifications", [200, { "Content-Type": "application/json" }, '["notification"]']);
+  Ember.run(function() {
+    Discourse.ajax.withArgs("/notifications").returns(request);
+  });
 
 
   Ember.run(function() {
@@ -28,7 +34,9 @@ test("showNotifications action", function() {
   ok(viewSpy.showDropdownBySelector.notCalled, "dropdown with notifications is not shown before data has finished loading");
 
 
-  server.respond();
+  Ember.run(function() {
+    resolveRequestWith(["notification"]);
+  });
 
   deepEqual(controller.get("notifications"), ["notification"], "notifications are set correctly after data has finished loading");
   equal(Discourse.User.current().get("unread_notifications"), 0, "current user's unread notifications count is zeroed after data has finished loading");


### PR DESCRIPTION
fixes the problem discussed here: https://github.com/discourse/discourse/pull/1642#issuecomment-28307514
(Instead of using low level xhr mock via sinon.server I've used higher level one, by mocking Discourse.ajax method - this prevents ajax test helper from perceiving this mock as a real non mocked xhr call)
