### PR TITLE
fixes Ember's deprecation errors in NotificationsController unit tests

### DIFF
--- a/test/javascripts/controllers/notifications_controller_test.js
+++ b/test/javascripts/controllers/notifications_controller_test.js
@@ -20,6 +20,7 @@ module("Discourse.NotificationsController", {
     controller = Discourse.NotificationsController.create();
 
     view = Ember.View.create({
+      container: Discourse.__container__,
       controller: controller,
       templateName: "notifications"
     });


### PR DESCRIPTION
Without this fix the test works correctly, but Ember outputs "Using the defaultContainer is no longer supported." deprecation warning, which pollutes the console output.

Sorry again for checking only test results, not the console output, when creating these unit tests!
