### PR TITLE
Avoiding double manifest files

### DIFF
--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -9,6 +9,7 @@ task 'assets:precompile' => 'environment' do
     regex = /(-{1}[a-z0-9]{32}*\.{1}){1}/
     assets.each do |file|
       next if File.directory?(file) || file !~ regex
+      next if File.extname(file) == ".json" # Avoid duplicate manifest
 
       source = file.split('/')
       source.push(source.pop.gsub(regex, '.'))


### PR DESCRIPTION
Capistrano chokes if there's two manifest files. 
http://meta.discourse.org/t/rails-4-non-digest-assets-and-capistrano/10948?u=scotterc
