### PR TITLE
Replaced before_filter with before_action

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,14 +14,14 @@ class ApplicationController < ActionController::Base
 
   protect_from_forgery
 
-  before_filter :inject_preview_style
-  before_filter :block_if_maintenance_mode
-  before_filter :check_restricted_access
-  before_filter :authorize_mini_profiler
-  before_filter :store_incoming_links
-  before_filter :preload_json
-  before_filter :check_xhr
-  before_filter :set_locale
+  before_action :inject_preview_style
+  before_action :block_if_maintenance_mode
+  before_action :check_restricted_access
+  before_action :authorize_mini_profiler
+  before_action :store_incoming_links
+  before_action :preload_json
+  before_action :check_xhr
+  before_action :set_locale
 
   rescue_from Exception do |exception|
     unless [ ActiveRecord::RecordNotFound, ActionController::RoutingError,

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -2,9 +2,9 @@ require_dependency 'category_serializer'
 
 class CategoriesController < ApplicationController
 
-  before_filter :ensure_logged_in, except: [:index, :show]
-  before_filter :fetch_category, only: [:show, :update, :destroy]
-  skip_before_filter :check_xhr, only: [:index]
+  before_action :ensure_logged_in, except: [:index, :show]
+  before_action :fetch_category, only: [:show, :update, :destroy]
+  skip_before_action :check_xhr, only: [:index]
 
   def index
     @list = CategoryList.new(current_user)

--- a/app/controllers/clicks_controller.rb
+++ b/app/controllers/clicks_controller.rb
@@ -1,6 +1,6 @@
 class ClicksController < ApplicationController
 
-  skip_before_filter :check_xhr
+  skip_before_action :check_xhr
 
   def track
     requires_parameter(:url)

--- a/app/controllers/draft_controller.rb
+++ b/app/controllers/draft_controller.rb
@@ -1,6 +1,6 @@
 class DraftController < ApplicationController
-  before_filter :ensure_logged_in
-  skip_before_filter :check_xhr
+  before_action :ensure_logged_in
+  skip_before_action :check_xhr
 
   def show
     seq = params[:sequence] || DraftSequence.current(current_user, params[:draft_key])

--- a/app/controllers/education_controller.rb
+++ b/app/controllers/education_controller.rb
@@ -1,6 +1,6 @@
 class EducationController < ApplicationController
 
-  before_filter :ensure_logged_in
+  before_action :ensure_logged_in
 
   def show
     raise Discourse::InvalidAccess.new unless params[:id] =~ /^[a-z0-9\-\_]+$/

--- a/app/controllers/email_controller.rb
+++ b/app/controllers/email_controller.rb
@@ -1,8 +1,8 @@
 class EmailController < ApplicationController
-  skip_before_filter :check_xhr
+  skip_before_action :check_xhr
   layout 'no_js'
 
-  before_filter :ensure_logged_in, only: :preferences_redirect
+  before_action :ensure_logged_in, only: :preferences_redirect
 
   def preferences_redirect
     redirect_to(email_preferences_path(current_user.username_lower))

--- a/app/controllers/exceptions_controller.rb
+++ b/app/controllers/exceptions_controller.rb
@@ -1,5 +1,5 @@
 class ExceptionsController < ApplicationController
-  skip_before_filter :check_xhr
+  skip_before_action :check_xhr
   layout 'no_js'
 
   def not_found

--- a/app/controllers/forums_controller.rb
+++ b/app/controllers/forums_controller.rb
@@ -1,8 +1,8 @@
 class ForumsController < ApplicationController
 
-  skip_before_filter :check_xhr, only: [:request_access, :request_access_submit, :status]
-  skip_before_filter :check_restricted_access, only: [:status]
-  skip_before_filter :authorize_mini_profiler, only: [:status]
+  skip_before_action :check_xhr, only: [:request_access, :request_access_submit, :status]
+  skip_before_action :check_restricted_access, only: [:status]
+  skip_before_action :authorize_mini_profiler, only: [:status]
 
   def status
     if $shutdown

--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -1,7 +1,7 @@
 class InvitesController < ApplicationController
 
-  skip_before_filter :check_xhr, :check_restricted_access
-  before_filter :ensure_logged_in, only: [:destroy]
+  skip_before_action :check_xhr, :check_restricted_access
+  before_action :ensure_logged_in, only: [:destroy]
 
   def show
     invite = Invite.where(invite_key: params[:id]).first

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,6 +1,6 @@
 class NotificationsController < ApplicationController
 
-  before_filter :ensure_logged_in
+  before_action :ensure_logged_in
 
   def index
     notifications = current_user.notifications.recent.includes(:topic).all

--- a/app/controllers/post_actions_controller.rb
+++ b/app/controllers/post_actions_controller.rb
@@ -2,9 +2,9 @@ require_dependency 'discourse'
 
 class PostActionsController < ApplicationController
 
-  before_filter :ensure_logged_in, except: :users
-  before_filter :fetch_post_from_params
-  before_filter :fetch_post_action_type_id_from_params
+  before_action :ensure_logged_in, except: :users
+  before_action :fetch_post_from_params
+  before_action :fetch_post_action_type_id_from_params
 
   def create
     guardian.ensure_post_can_act!(@post, PostActionType.types[@post_action_type_id])

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -4,10 +4,10 @@ require_dependency 'post_destroyer'
 class PostsController < ApplicationController
 
   # Need to be logged in for all actions here
-  before_filter :ensure_logged_in, except: [:show, :replies, :by_number, :short_link]
+  before_action :ensure_logged_in, except: [:show, :replies, :by_number, :short_link]
 
-  skip_before_filter :store_incoming_links, only: [:short_link]
-  skip_before_filter :check_xhr, only: [:markdown,:short_link]
+  skip_before_action :store_incoming_links, only: [:short_link]
+  skip_before_action :check_xhr, only: [:markdown,:short_link]
 
   def markdown
     post = Post.where(topic_id: params[:topic_id].to_i, post_number: (params[:post_number] || 1).to_i).first

--- a/app/controllers/request_access_controller.rb
+++ b/app/controllers/request_access_controller.rb
@@ -1,6 +1,6 @@
 class RequestAccessController < ApplicationController
 
-  skip_before_filter :check_xhr, :check_restricted_access
+  skip_before_action :check_xhr, :check_restricted_access
 
   def new
     @return_path = params[:return_path] || "/"

--- a/app/controllers/robots_txt_controller.rb
+++ b/app/controllers/robots_txt_controller.rb
@@ -1,7 +1,7 @@
 class RobotsTxtController < ApplicationController
   layout false
-  skip_before_filter :check_xhr
-  skip_before_filter :check_restricted_access
+  skip_before_action :check_xhr
+  skip_before_action :check_restricted_access
 
   def index
     path = if SiteSetting.allow_index_in_robots_txt && SiteSetting.access_password.blank?

--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -3,7 +3,7 @@ class SessionController < ApplicationController
   # we need to allow account login with bad CSRF tokens, if people are caching, the CSRF token on the 
   #  page is going to be empty, this means that server will see an invalid CSRF and blow the session
   #  once that happens you can't log in with social
-  skip_before_filter :verify_authenticity_token, only: [:create]
+  skip_before_action :verify_authenticity_token, only: [:create]
 
   def create
     requires_parameter(:login, :password)

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -1,6 +1,6 @@
 class StaticController < ApplicationController
 
-  skip_before_filter :check_xhr
+  skip_before_action :check_xhr
 
   def show
 

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -5,7 +5,7 @@ require 'actionpack/action_caching'
 class TopicsController < ApplicationController
 
   # Avatar is an image request, not XHR
-  before_filter :ensure_logged_in, only: [:timings,
+  before_action :ensure_logged_in, only: [:timings,
                                           :destroy_timings,
                                           :update,
                                           :star,
@@ -18,9 +18,9 @@ class TopicsController < ApplicationController
                                           :move_posts,
                                           :clear_pin]
 
-  before_filter :consider_user_for_promotion, only: :show
+  before_action :consider_user_for_promotion, only: :show
 
-  skip_before_filter :check_xhr, only: [:avatar, :show, :feed]
+  skip_before_action :check_xhr, only: [:avatar, :show, :feed]
   caches_action :avatar, cache_path: Proc.new {|c| "#{c.params[:post_number]}-#{c.params[:topic_id]}" }
 
   def show

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -1,5 +1,5 @@
 class UploadsController < ApplicationController
-  before_filter :ensure_logged_in
+  before_action :ensure_logged_in
 
   def create
     requires_parameter(:topic_id)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,16 +2,16 @@ require_dependency 'discourse_hub'
 
 class UsersController < ApplicationController
 
-  skip_before_filter :check_xhr, only: [:show, :password_reset, :update, :activate_account, :avatar, :authorize_email, :user_preferences_redirect]
-  skip_before_filter :authorize_mini_profiler, only: [:avatar]
-  skip_before_filter :check_restricted_access, only: [:avatar]
+  skip_before_action :check_xhr, only: [:show, :password_reset, :update, :activate_account, :avatar, :authorize_email, :user_preferences_redirect]
+  skip_before_action :authorize_mini_profiler, only: [:avatar]
+  skip_before_action :check_restricted_access, only: [:avatar]
 
-  before_filter :ensure_logged_in, only: [:username, :update, :change_email, :user_preferences_redirect]
+  before_action :ensure_logged_in, only: [:username, :update, :change_email, :user_preferences_redirect]
 
   # we need to allow account creation with bad CSRF tokens, if people are caching, the CSRF token on the 
   #  page is going to be empty, this means that server will see an invalid CSRF and blow the session
   #  once that happens you can't log in with social
-  skip_before_filter :verify_authenticity_token, only: [:create]
+  skip_before_action :verify_authenticity_token, only: [:create]
 
   def show
     @user = fetch_user_from_params


### PR DESCRIPTION
As per Rails 4 guidelines before_filter should be replaced with before_action. So, I replaced 'before_filter' with 'before_action'.

Source: https://github.com/rails/rails/commit/9d62e04838f01f5589fa50b0baa480d60c815e2c
