### PR TITLE
Allow plugins to register their own locale files.

### DIFF
--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -92,7 +92,10 @@ class Plugin::Instance
     @javascripts ||= []
     @javascripts << js
   end
-
+  
+  def register_locale(locale)
+    I18n.load_path += locale
+  end
 
   def register_asset(file,opts=nil)
     full_path = File.dirname(path) << "/assets/" << file


### PR DESCRIPTION
An example would be something like

  register_locale([File.expand_path('../locale.yml', **FILE**)])

down next to where the call to register_css in a plugin.
