### PR TITLE
Add a Plugin category translation.

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1434,3 +1434,4 @@ en:
           rate_limits: 'Rate Limits'
           developer: 'Developer'
           uncategorized: 'Uncategorized'
+          plugin: "Plugin"


### PR DESCRIPTION
This can be used when a plugin registers settings using the category plugin: .  The setting can also do this it's self but added a consistent location is will clarify things.
