### PR TITLE
Add 'session' to auth hash in OAuth complete method

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -32,6 +32,7 @@ class Users::OmniauthCallbacksController < ApplicationController
 
   def complete
     auth = request.env["omniauth.auth"]
+    auth[:session] = session
 
     authenticator = self.class.find_authenticator(params[:provider])
 


### PR DESCRIPTION
If you're creating an authenticator as a plugin, it may be useful to have access to session data at some point during the authentication process.  This could be during either the after_authenticate or after_create_account methods.  Per Sam's suggestions, I am including session data within the auth hash found in the OAuth complete method.

In our case, the way our current_user method works is by checking if a certain token exists within a session before each page load (we do not store the token in the database as our security team does not want us to do so).  A few members of the Discourse team have access to our repo to take a look at how we'd use this: https://github.com/newrelic/forum/blob/new_user/plugins/golden_gate_client/plugin.rb
