### PR TITLE
Load plugin settings.

### DIFF
--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -7,13 +7,22 @@ class SiteSetting < ActiveRecord::Base
   validates_presence_of :name
   validates_presence_of :data_type
 
-  SiteSettings::YamlLoader.new( File.join( Rails.root, 'config', 'site_settings.yml') ).load do |category, name, default, opts|
-    if opts.delete(:client)
-      client_setting(name, default, opts.merge(category: category))
-    else
-      setting(name, default, opts.merge(category: category))
+  def self.load_settings(file)
+    SiteSettings::YamlLoader.new(file).load do |category, name, default, opts|
+      if opts.delete(:client)
+        client_setting(name, default, opts.merge(category: category))
+      else
+        setting(name, default, opts.merge(category: category))
+      end
     end
   end
+
+  load_settings(File.join(Rails.root, 'config', 'site_settings.yml'))
+
+  Dir[File.join(Rails.root, "plugins", "*", "config", "settings.yml")].each do |file|
+    load_settings(file)
+  end
+
 
   def self.call_discourse_hub?
     self.enforce_global_nicknames? && self.discourse_org_access_key.present?


### PR DESCRIPTION
Along the lines for loading the locale files for a plugin we should also load the settings.yml for a plugin.  Updated version 04f3e09 that moves the loading to a function. I do not understand why it was necessary to define the function physically earlier in the file as I thought ruby did two pass but that may only apply to functions and not stray code in the class.
