### PR TITLE
removes redundant enclosing tag

### DIFF
--- a/app/assets/javascripts/discourse/components/home_logo_component.js
+++ b/app/assets/javascripts/discourse/components/home_logo_component.js
@@ -1,4 +1,5 @@
 Discourse.HomeLogoComponent = Ember.Component.extend({
+  classNames: ["title"],
 
   linkUrl: function() {
     return Discourse.getURL("/");

--- a/app/assets/javascripts/discourse/templates/components/home-logo.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/components/home-logo.js.handlebars
@@ -1,17 +1,15 @@
-<div class="title">
-  <a href="{{unbound linkUrl}}">
-    {{#if showSmallLogo}}
-      {{#if smallLogoUrl}}
-        <img class="logo-small" src="{{unbound smallLogoUrl}}" width="33" height="33">
-      {{else}}
-        <i class="icon-home"></i>
-      {{/if}}
+<a href="{{unbound linkUrl}}">
+  {{#if showSmallLogo}}
+    {{#if smallLogoUrl}}
+      <img class="logo-small" src="{{unbound smallLogoUrl}}" width="33" height="33">
     {{else}}
-      {{#if bigLogoUrl}}
-        <img id="site-logo" class="logo-big" src="{{unbound bigLogoUrl}}" alt="{{unbound title}}">
-      {{else}}
-        <h2 id="site-text-logo" class="text-logo">{{unbound title}}</h2>
-      {{/if}}
+      <i class="icon-home"></i>
     {{/if}}
-  </a>
-</div>
+  {{else}}
+    {{#if bigLogoUrl}}
+      <img id="site-logo" class="logo-big" src="{{unbound bigLogoUrl}}" alt="{{unbound title}}">
+    {{else}}
+      <h2 id="site-text-logo" class="text-logo">{{unbound title}}</h2>
+    {{/if}}
+  {{/if}}
+</a>


### PR DESCRIPTION
before this PR logo was enclosed not only by '<div class="title">' but also by another empty (and unnecessary) div.
