### PR TITLE
FIX: repairs title attr in the link

### DIFF
--- a/app/assets/javascripts/discourse/templates/header.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/header.js.handlebars
@@ -86,7 +86,7 @@
         </li>
         <li class='current-user'>
           {{#if currentUser}}
-            {{#link-to 'userActivity.index' currentUser titleKey="current_user" class="icon"}}{{boundAvatar currentUser imageSize="medium" }}{{/link-to}}
+            {{#titledLinkTo 'userActivity.index' currentUser titleKey="current_user" class="icon"}}{{boundAvatar currentUser imageSize="medium" }}{{/titledLinkTo}}
           {{else}}
             <div class="icon not-logged-in-avatar" {{action showLogin}}><i class='icon-user'></i></div>
           {{/if}}


### PR DESCRIPTION
titleKey attr is not available in normal link helper (and was not displayed). I believe titledLinkTo helper was supposed to be used here...
