### PR TITLE
Allow dollar sign for inline dialects

### DIFF
--- a/vendor/assets/javascripts/better_markdown.js
+++ b/vendor/assets/javascripts/better_markdown.js
@@ -335,7 +335,7 @@
       // __foo__ is reserved and not a pattern
       if ( i.match( /^__.*__$/) )
         continue;
-      var l = i.replace( /([\\.*+?|()\[\]${}])/g, "\\$1" )
+      var l = i.replace( /([\\.*+?^$|()\[\]{}])/g, "\\$1" )
                .replace( /\n/, "\\n" );
       patterns.push( i.length === 1 ? l : "(?:" + l + ")" );
     }


### PR DESCRIPTION
With this change it is possible to use the dollar ($) sign for inline dialects. I have tested this using vagrant. 

I have updated the [mathjax plugin](http://meta.discourse.org/t/brand-new-plugin-interface/8793/61) so that it escapes everything between $...$ signs from the markdown parser. This one character change need to be pulled to let this part of the plugin work correctly:

```
Discourse.Dialect.inlineBetween({
  start: '$',
  stop: '$',
  rawContents: true,
  emitter: function(contents) { return '$'+contents+'$';  }
});
```

[This](http://meta.discourse.org/t/problem-with-dollar-sign-in-custom-markdown-dialect/11065/3) is the related topic at meta.discourse.org.
