### PR TITLE
Test performance: define a lower post max length

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ config/environments/production.rb
 /tmp
 /plugins
 /logfile
+log/
 
 /spec/fixtures/plugins/my_plugin/auto_generated
 

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -134,7 +134,9 @@ posting:
       default: 10
   max_post_length:
     client: true
-    default: 32000
+    default: 
+      test: 4000
+      default: 32000
   min_topic_title_length:
     client: true
     default: 15


### PR DESCRIPTION
Hi there,

Just a little modification to improve the execution speed of the slowest test of the suite. 

Benchmark on my machine: 
#### Before

[vagrant@precise32:/vagrant (master)]$ rspec spec/models/post_spec.rb:20
Run options: include {:locations=>{"./spec/models/post_spec.rb"=>[20]}}
.

Finished in **8.45 seconds**
1 example, 0 failures
#### After

[vagrant@precise32:/vagrant (tests_performance)]$ rspec spec/models/post_spec.rb:20
Run options: include {:locations=>{"./spec/models/post_spec.rb"=>[20]}}
.

Finished in **1.08 seconds**
1 example, 0 failures

Thanks. 
