### PR TITLE
The Rails JSON encoder API requires `as_json` to take an optional arg

### DIFF
--- a/app/models/admin_dashboard_data.rb
+++ b/app/models/admin_dashboard_data.rb
@@ -61,7 +61,7 @@ class AdminDashboardData
     AdminDashboardData.new.problems
   end
 
-  def as_json
+  def as_json(options = nil)
     @json ||= {
       reports: REPORTS.map { |type| Report.find(type).as_json },
       admins: User.admins.count,

--- a/app/models/incoming_links_report.rb
+++ b/app/models/incoming_links_report.rb
@@ -8,7 +8,7 @@ class IncomingLinksReport
     @data = nil
   end
 
-  def as_json
+  def as_json(options = nil)
     {
       type: self.type,
       title: I18n.t("reports.#{self.type}.title"),

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -11,7 +11,7 @@ class Report
     @prev30Days = nil
   end
 
-  def as_json
+  def as_json(options = nil)
     {
      type: self.type,
      title: I18n.t("reports.#{self.type}.title"),

--- a/lib/search/grouped_search_results.rb
+++ b/lib/search/grouped_search_results.rb
@@ -15,7 +15,7 @@ class Search
       return topic_results.result_ids
     end
 
-    def as_json
+    def as_json(options = nil)
       @by_type.values.map do |grouped_result|
         grouped_result.as_json
       end

--- a/lib/search/search_result.rb
+++ b/lib/search/search_result.rb
@@ -15,7 +15,7 @@ class Search
       @url, @id, @title = row[:url], row[:id], row[:title]
     end
 
-    def as_json
+    def as_json(options = nil)
       json = {id: @id, title: @title, url: @url}
       json[:avatar_template] = @avatar_template if @avatar_template.present?
       json[:color] = @color if @color.present?

--- a/lib/search/search_result_type.rb
+++ b/lib/search/search_result_type.rb
@@ -20,7 +20,7 @@ class Search
       @result_ids << result.id
     end
 
-    def as_json
+    def as_json(options = nil)
       { type: @type.to_s,
         name: I18n.t("search.types.#{@type.to_s}"),
         more: @more,


### PR DESCRIPTION
This bug is not triggered on Rails 4, but some patches to the JSON encoder in master caused this bug to surface.
