### PR TITLE
Don't abuse as_json, it's not meant for consumption

### DIFF
--- a/spec/components/discourse_updates_spec.rb
+++ b/spec/components/discourse_updates_spec.rb
@@ -14,7 +14,7 @@ describe DiscourseUpdates do
     Jobs::VersionCheck.any_instance.stubs(:execute).returns(true)
   end
 
-  subject { DiscourseUpdates.check_version.as_json }
+  subject { DiscourseUpdates.check_version.instance_values }
 
   context 'version check was done at the current installed version' do
     before do


### PR DESCRIPTION
The `as_json` API is a hook for JSON encoders to call, not meant for
consumption like this, and the result is not guarenteed to be stable
across Rails versions.

There might be other cases like this that we should revisit later, but
this one in particular is causing a test to fail on Rails master.
