### PR TITLE
Fix email_preview AJAX call to use Discourse.ajax

### DIFF
--- a/app/assets/javascripts/admin/models/email_preview.js
+++ b/app/assets/javascripts/admin/models/email_preview.js
@@ -10,7 +10,7 @@ Discourse.EmailPreview = Discourse.Model.extend({});
 
 Discourse.EmailPreview.reopenClass({
   findDigest: function(last_seen_at) {
-    return $.ajax("/admin/email/preview-digest.json", {
+    return Discourse.ajax("/admin/email/preview-digest.json", {
       data: {last_seen_at: last_seen_at}
     }).then(function (result) {
       return Discourse.EmailPreview.create(result);


### PR DESCRIPTION
This fixes a problem in subdirectory installs where the wrong URL is used in the AJAX call.
