### PR TITLE
Fixed broken links in HTML version of Digest email

### DIFF
--- a/app/views/user_notifications/digest.html.erb
+++ b/app/views/user_notifications/digest.html.erb
@@ -13,7 +13,7 @@
       <h3><%=t 'user_notifications.digest.top_topics' %></h3>
 
       <%- @featured_topics.each_with_index do |t, i| %>
-        <%= link_to t.title, t.relative_url %>
+        <%= link_to t.title, "#{Discourse.base_url}#{t.relative_url}" %>
 
         <%- if t.best_post.present? %>
           <div class='digest-post'>


### PR DESCRIPTION
Based on @eviltrout's fix from 7a60eacca95f7e036bb83ea512cec7225dc73c2c.

Reported at http://meta.discourse.org/t/some-links-in-emails-not-including-the-full-url/11211
