### PR TITLE
set_locale of application_controller.rb must be called earlier

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,6 +25,7 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  before_filter :set_locale
   before_filter :set_mobile_view
   before_filter :inject_preview_style
   before_filter :disable_customization
@@ -33,7 +34,6 @@ class ApplicationController < ActionController::Base
   before_filter :store_incoming_links
   before_filter :preload_json
   before_filter :check_xhr
-  before_filter :set_locale
   before_filter :redirect_to_login_if_required
 
   rescue_from Exception do |exception|


### PR DESCRIPTION
The set_locale filter must be executed before check_xhr filter because check_xhr filter renders html in some cases.
And I think it is safe to execute set_locale filter as soon as possible.

Fixed bug: 
Locale will be :en at the very first request after server restart regardless of your SiteSettings.default_locale when the first request is for some pages not skipping check_xhr filter.

Bug generation step:
1) Set your SiteSettings.default_locale to some locale other than :en.
2) Browse http://your.site.com/admin
3) Restart your server.
4) Refresh the page.
