### PR TITLE
Fix auto close topic modal when pressing enter

### DIFF
--- a/app/assets/javascripts/discourse/templates/modal/auto_close.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/modal/auto_close.js.handlebars
@@ -1,10 +1,10 @@
-<div class="modal-body">
-  <form>
+<form {{action saveAutoClose on="submit"}}>
+  <div class="modal-body">
     {{auto-close-form autoCloseTime=auto_close_time autoCloseValid=auto_close_valid}}
-  </form>
-</div>
-<div class="modal-footer">
-  <button class='btn btn-primary' {{action saveAutoClose}} {{bindAttr disabled="auto_close_invalid"}}>{{i18n topic.auto_close_save}}</button>
-  <a {{action closeModal}}>{{i18n cancel}}</a>
-  <button class='btn pull-right' {{action removeAutoClose}}>{{i18n topic.auto_close_remove}}</button>
-</div>
+  </div>
+  <div class="modal-footer">
+    <button class='btn btn-primary' type='submit' {{bindAttr disabled="auto_close_invalid"}}>{{i18n topic.auto_close_save}}</button>
+    <a {{action closeModal}}>{{i18n cancel}}</a>
+    <button class='btn pull-right' {{action removeAutoClose}}>{{i18n topic.auto_close_remove}}</button>
+  </div>
+</form>


### PR DESCRIPTION
Currently if you hit enter after typing in a number in the auto close topic modal the page reloads and nothing else happens. This can be fixed by triggering the action on form submit rather than clicking on the button.

Doing a quick search suggests that there are seven other modals with the same problem. I'll take a look and make the same change to them if needed, and add to this pull request shortly. 
