### PR TITLE
Add another previewRefreshed trigger that is not debounced

### DIFF
--- a/app/assets/javascripts/discourse/views/composer/composer_view.js
+++ b/app/assets/javascripts/discourse/views/composer/composer_view.js
@@ -202,7 +202,8 @@ Discourse.ComposerView = Discourse.View.extend(Ember.Evented, {
     };
 
     this.editor.hooks.onPreviewRefresh = function() {
-      return composerView.afterRender();
+      composerView.afterRender();
+      composerView.trigger('previewRefreshed2');
     };
 
     this.editor.run();


### PR DESCRIPTION
I need this trigger for the mathjax plugin. The `previewRefreshed` trigger already exists, but this is called in a debounced function which causes the mathjax plugin to flicker. I've made a recording of my screen to show the the flickering in the preview, and how it good looks with this pull request:
http://www.screenr.com/TxiH
