### PR TITLE
enable_names site setting functionality

### DIFF
--- a/app/assets/javascripts/discourse/controllers/preferences_controller.js
+++ b/app/assets/javascripts/discourse/controllers/preferences_controller.js
@@ -16,10 +16,14 @@ Discourse.PreferencesController = Discourse.ObjectController.extend({
 
   saveDisabled: function() {
     if (this.get('saving')) return true;
-    if (this.blank('name')) return true;
+    if (Discourse.SiteSettings.enable_names && this.blank('name')) return true;
     if (this.blank('email')) return true;
     return false;
   }.property('saving', 'name', 'email'),
+
+  canEditName: function() {
+    return Discourse.SiteSettings.enable_names;
+  }.property(),
 
   digestFrequencies: [{ name: I18n.t('user.email_digests.daily'), value: 1 },
                       { name: I18n.t('user.email_digests.weekly'), value: 7 },

--- a/app/assets/javascripts/discourse/models/user.js
+++ b/app/assets/javascripts/discourse/models/user.js
@@ -36,6 +36,20 @@ Discourse.User = Discourse.Model.extend({
   }.property('username_lower'),
 
   /**
+    This user's display name. Returns the name if possible, otherwise returns the
+    username.
+
+    @property displayName
+    @type {String}
+  **/
+  displayName: function() {
+    if (Discourse.SiteSettings.enable_names && !this.blank('name')) {
+      return this.get('name');
+    }
+    return this.get('username');
+  }.property('username', 'name'),
+
+  /**
     This user's website.
 
     @property websiteName

--- a/app/assets/javascripts/discourse/models/user_action.js
+++ b/app/assets/javascripts/discourse/models/user_action.js
@@ -85,7 +85,7 @@ Discourse.UserAction = Discourse.Model.extend({
       post_number: '#' + this.get('reply_to_post_number'),
       user1Url: this.get('userUrl'),
       user2Url: this.get('targetUserUrl'),
-      another_user: this.get('target_name')
+      another_user: this.get('targetDisplayName')
     }));
 
   }.property('descriptionKey'),
@@ -99,6 +99,9 @@ Discourse.UserAction = Discourse.Model.extend({
   }.property('target_username'),
 
   presentName: Em.computed.any('name', 'username'),
+  targetDisplayName: Em.computed.any('target_name', 'target_username'),
+  actingDisplayName: Em.computed.any('acting_name', 'acting_username'),
+
 
   targetUserUrl: Discourse.computed.url('target_username', '/users/%@'),
   usernameLower: function() {
@@ -170,7 +173,7 @@ Discourse.UserAction = Discourse.Model.extend({
     this.setProperties({
       username: this.get('acting_username'),
       avatar_template: this.get('acting_avatar_template'),
-      name: this.get('acting_name')
+      name: this.get('actingDisplayName')
     });
   }
 });

--- a/app/assets/javascripts/discourse/templates/header.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/header.js.handlebars
@@ -30,7 +30,7 @@
       {{#unless showExtraInfo}}
         <div class='current-username'>
           {{#if currentUser}}
-            <span class='username'><a {{bindAttr href="currentUser.path"}}>{{currentUser.name}}</a></span>
+            <span class='username'><a {{bindAttr href="currentUser.path"}}>{{currentUser.displayName}}</a></span>
           {{else}}
             <button {{action showLogin}} class='btn btn-primary btn-small'>{{i18n log_in}}</button>
           {{/if}}

--- a/app/assets/javascripts/discourse/templates/user/preferences.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/user/preferences.js.handlebars
@@ -15,15 +15,17 @@
       </div>
     </div>
 
-    <div class="control-group">
-      <label class="control-label">{{i18n user.name.title}}</label>
-      <div class="controls">
-        {{textField value=name classNames="input-xxlarge"}}
+    {{#if canEditName}}
+      <div class="control-group">
+        <label class="control-label">{{i18n user.name.title}}</label>
+        <div class="controls">
+          {{textField value=name classNames="input-xxlarge"}}
+        </div>
+        <div class='instructions'>
+          {{i18n user.name.instructions}}
+        </div>
       </div>
-      <div class='instructions'>
-        {{i18n user.name.instructions}}
-      </div>
-    </div>
+    {{/if}}
 
     <div class="control-group">
       <label class="control-label">{{i18n user.email.title}}</label>

--- a/app/serializers/basic_user_serializer.rb
+++ b/app/serializers/basic_user_serializer.rb
@@ -1,3 +1,7 @@
 class BasicUserSerializer < ApplicationSerializer
   attributes :id, :username, :avatar_template
+
+  def include_name?
+    SiteSetting.enable_names?
+  end
 end

--- a/app/serializers/user_action_serializer.rb
+++ b/app/serializers/user_action_serializer.rb
@@ -45,6 +45,18 @@ class UserActionSerializer < ApplicationSerializer
     )
   end
 
+  def include_name?
+    SiteSetting.enable_names?
+  end
+
+  def include_target_name?
+    include_name?
+  end
+
+  def include_acting_name?
+    include_name?
+  end
+
   def slug
     Slug.for(object.title)
   end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -94,10 +94,6 @@ class UserSerializer < BasicUserSerializer
     User.gravatar_template(object.email)
   end
 
-  def include_name?
-    SiteSetting.enable_names?
-  end
-
   def include_suspended?
     object.suspended?
   end


### PR DESCRIPTION
Currently all the enable_names setting does when it is disabled is to remove the `name` field from the user serializer output. 

If enable_names if false:
- Don’t disable saving user preferences if the name field is blank.
- Don’t allow changing name in preferences.
- Set every user’s name to their username in an initializer. This is the part I am not too sure about. It is needed because there are places such as the header template which assume that the name is set. One alternative would be to have a computed property like nameOrUsername that would return the correct string, but I wonder if it might be better to always return a name from the server, but if enable_names is false to return the username in place of the name everywhere. This can be done fairly easily by adding a getter to the user model. I suspect doing it server-side would be the cleanest approach (it would also fix the first issue noted below), but I figured I’d check first before implementing it?

Issues I noticed which I haven’t fixed:
- The User Action serializer includes names, e.g. http://forums.hummingbird.me/user_actions.json?offset=0&username=reaperofspades. Same problem with the preloaded currentUser object.
- Should probably hide the name field during account creation?
- (Unrelated) If the user makes changes to their preferences but doesn’t save them, the changes are still shown to the user until the page is refreshed. It would make sense to revert changes when transitioning out of the preferences route if the user doesn’t save their changes.
