### PR TITLE
scroll preview to the bottom after all changes are made to the preview

### DIFF
--- a/app/assets/javascripts/discourse/views/composer/composer_view.js
+++ b/app/assets/javascripts/discourse/views/composer/composer_view.js
@@ -154,7 +154,6 @@ Discourse.ComposerView = Discourse.View.extend(Ember.Evented, {
     // if the caret is on the last line ensure preview scrolled to bottom
     var caretPosition = Discourse.Utilities.caretPosition(this.wmdInput[0]);
     if (!this.wmdInput.val().substring(caretPosition).match(/\n/)) {
-      var $wmdPreview = $('#wmd-preview');
       if ($wmdPreview.is(':visible')) {
         $wmdPreview.scrollTop($wmdPreview[0].scrollHeight);
       }


### PR DESCRIPTION
I think it is best to scroll the preview to the bottom after all changes are made to the preview. This also fixes: http://meta.discourse.org/t/preview-not-scrolled-to-the-bottom-with-mathjax/11239
