### PR TITLE
:scissors: scoped for Rails 4 compat

### DIFF
--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -89,7 +89,7 @@ class Invite < ActiveRecord::Base
         filter: "%#{email_or_username.downcase}%"
       )
     else
-      scoped
+      rails4? ? all : scoped
     end
   end
 end


### PR DESCRIPTION
This is required for upgrading discourse to work on 4.1, because `scoped` is deprecated in Rails 4. I traced the commits, there are d87389b3 and f99acebd to eliminate these calls, so I am guessing this is just introduced by accident in 77b59b54. Anyhow, I ran the tests on Rails 4 and everything is green :)

cc @salbertson 
