### PR TITLE
add more info to rss feeds

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -281,10 +281,6 @@ class Post < ActiveRecord::Base
     end
   end
 
-  def author_readable
-    user.readable_name
-  end
-
   def revise(updated_by, new_raw, opts = {})
     PostRevisor.new(self).revise!(updated_by, new_raw, opts)
   end

--- a/app/views/list/list.rss.erb
+++ b/app/views/list/list.rss.erb
@@ -1,22 +1,34 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
+    <% lang = SiteSetting.find_by_name('default_locale').try(:value) %>
     <title><%= @title %></title>
     <link><%= @link %></link>
     <description><%= @description %></description>
+    <% if lang %>
+      <language><%= lang %></language>
+    <% end %>
+    <lastBuildDate><%= @topic_list.topics.first.created_at.rfc2822 %></lastBuildDate>
     <atom:link href="<%= @atom_link %>" rel="self" type="application/rss+xml" />
     <% @topic_list.topics.each do |topic| %>
+      <% topic_url = Discourse.base_url + topic.relative_url -%>
       <item>
         <title><%= topic.title %></title>
+        <author><%= "@#{topic.user.username} (#{topic.user.name})" -%></author>
+        <category><%= topic.category.name %></category>
         <description><![CDATA[
-          <p><%= pluralize(topic.posts_count, 'post') %></p>
-          <p><%= t 'author_wrote', author: topic.posts.first.author_readable %></p>
-          <%= topic.posts.first.cooked.html_safe %>
+          <p><%= t('author_wrote', author: link_to(topic.user.name, topic.user)).html_safe %></p>
+          <blockquote>
+            <%= topic.posts.first.cooked.html_safe %>
+          </blockquote>
+          <p><%= t 'num_posts' %> <%= topic.posts_count %></p>
+          <p><%= t 'num_participants' %> <%= topic.participant_count %></p>
+          <p><%= link_to t('read_full_topic'), topic_url %></p>
         ]]></description>
-        <link><%= Discourse.base_url %><%= topic.relative_url %></link>
+        <link><%= topic_url %></link>
         <pubDate><%= topic.created_at.rfc2822 %></pubDate>
-        <guid><%= Discourse.base_url %><%= topic.relative_url %></guid>
-        <source url="<%= Discourse.base_url %><%= topic.relative_url %>.rss"><%= topic.title %></source>
+        <guid><%= topic_url %></guid>
+        <source url="<%= topic_url %>.rss"><%= topic.title %></source>
       </item>
     <% end %>
   </channel>

--- a/app/views/topics/show.rss.erb
+++ b/app/views/topics/show.rss.erb
@@ -1,24 +1,35 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
+    <% topic_url = Discourse.base_url + @topic_view.relative_url %>
+    <% lang = SiteSetting.find_by_name('default_locale').try(:value) %>
     <title><%= @topic_view.title %></title>
-    <link><%= Discourse.base_url %><%= @topic_view.relative_url %></link>
+    <link><%= topic_url %></link>
     <description><%= @topic_view.posts.first.raw %></description>
-    <atom:link href="<%= Discourse.base_url %><%= @topic_view.relative_url %>.rss" rel="self" type="application/rss+xml" />
+    <% if lang %>
+      <language><%= lang %></language>
+    <% end %>
+    <lastBuildDate><%= @topic_view.topic.created_at.rfc2822 %></lastBuildDate>
+    <category><%= @topic_view.topic.category.name %></category>
+    <atom:link href="<%= topic_url %>.rss" rel="self" type="application/rss+xml" />
     <% @topic_view.recent_posts.each do |post| %>
-      <% if post.user %>
-        <item>
-          <title><%= @topic_view.title %> at <%= post.created_at %></title>
-          <description><![CDATA[
-            <p><%= post.author_readable %> wrote:</p>
+      <% next unless post.user %>
+      <item>
+        <title><%= @topic_view.title %> at <%= post.created_at %></title>
+        <author><%= "@#{post.user.username} (#{post.user.name})" -%></author>
+        <description><![CDATA[
+          <% post_url = Discourse.base_url + post.url %>
+          <p><%= t('author_wrote', author: link_to(post.user.name, post.user)).html_safe %></p>
+          <blockquote>
             <%= post.cooked.html_safe %>
-          ]]></description>
-          <link><%= Discourse.base_url %><%= post.url %></link>
-          <pubDate><%= post.created_at.rfc2822 %></pubDate>
-          <guid><%= Discourse.base_url %><%= post.url %></guid>
-          <source url="<%= Discourse.base_url %><%= @topic_view.relative_url %>.rss"><%= @topic_view.title %></source>
-        </item>
-      <% end %>
+          </blockquote>
+          <p><%= link_to t('read_full_topic'), post_url %></p>
+        ]]></description>
+        <link><%= post_url %></link>
+        <pubDate><%= post.created_at.rfc2822 %></pubDate>
+        <guid><%= post_url %></guid>
+        <source url="<%= Discourse.base_url %><%= @topic_view.relative_url %>.rss"><%= @topic_view.title %></source>
+      </item>
     <% end %>
   </channel>
 </rss>

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -59,6 +59,9 @@ en:
   rss_posts_in_topic: "RSS feed of '%{topic}'"
   rss_topics_in_category: "RSS feed of topics in the '%{category}' category"
   author_wrote: "%{author} wrote:"
+  num_posts: "Posts:"
+  num_participants: "Participants:"
+  read_full_topic: "Read full topic"
   private_message_abbrev: "PM"
   rss_description:
     latest: "Latest topics"

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -742,13 +742,6 @@ describe Post do
 
   end
 
-  describe '#readable_author' do
-    it 'delegates to the associated user' do
-      User.any_instance.expects(:readable_name)
-      Fabricate(:post).author_readable
-    end
-  end
-
   describe 'urls' do
     it 'no-ops for empty list' do
       Post.urls([]).should == {}


### PR DESCRIPTION
[As requested](http://meta.discourse.org/t/rss-support-for-categories-topics/2075/68).

Additions to category RSS feed ([e.g.](http://meta.discourse.org/category/feature)):
- feed level (the category)
  - `<lang>` if it's found in site settings
  - `<lastBuildDate>`
- item level (the topics)
  - `<author>`
  - `<category`

Additions to topic RSS feed ([e.g.](http://meta.discourse.org/t/rss-support-for-categories-topics/2075/66.rss))
- feed level (the topic)
  - `<lang>` if it's found in site settings
  - `<lastBuildDate>`
  - `<category`
- item level (the posts)
  - `<author>`

I also tweaked the RSS content (`<description>`) a bit, in both feed types. Open to suggestions about what should and shouldn't be there.
