### PR TITLE
Prevent deleting 'uncategorized' category

### DIFF
--- a/app/assets/javascripts/discourse/controllers/edit_category_controller.js
+++ b/app/assets/javascripts/discourse/controllers/edit_category_controller.js
@@ -53,7 +53,7 @@ Discourse.EditCategoryController = Discourse.ObjectController.extend(Discourse.M
   }.property('saving', 'name', 'color', 'deleting'),
 
   deleteVisible: function() {
-    return (this.get('id') && this.get('topic_count') === 0);
+    return (this.get('id') && this.get('topic_count') === 0 && !this.get("isUncategorizedCategory"));
   }.property('id', 'topic_count'),
 
   deleteDisabled: function() {

--- a/app/assets/javascripts/discourse/models/category.js
+++ b/app/assets/javascripts/discourse/models/category.js
@@ -168,8 +168,11 @@ Discourse.Category = Discourse.Model.extend({
       if (stats.length === 2) return false;
     }, this);
     return stats;
-  }
+  },
 
+  isUncategorizedCategory: function() {
+    return this.get('id') === Discourse.Site.currentProp("uncategorized_category_id");
+  }.property('id')
 });
 
 Discourse.Category.reopenClass({

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -338,6 +338,10 @@ SQL
 
     [read_restricted, mapped]
   end
+
+  def uncatgorized?
+    id == SiteSetting.uncategorized_category_id
+  end
 end
 
 # == Schema Information

--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -320,7 +320,7 @@ class Guardian
   end
 
   def can_delete_category?(category)
-    is_staff? && category.topic_count == 0
+    is_staff? && category.topic_count == 0 && !category.uncatgorized?
   end
 
   def can_delete_topic?(topic)

--- a/spec/components/guardian_spec.rb
+++ b/spec/components/guardian_spec.rb
@@ -800,6 +800,12 @@ describe Guardian do
         Guardian.new(moderator).can_delete?(category).should be_false
       end
 
+      it "can't be deleted if it is the Uncategorizied Category" do
+        uncategorized_cat_id = SiteSetting.uncategorized_category_id
+        uncategorized_category = Category.find(uncategorized_cat_id)
+        Guardian.new(admin).can_delete?(uncategorized_category).should be_false
+      end
+
     end
 
     context 'can_suspend?' do


### PR DESCRIPTION
Hi!

I'm looking for some feedback on this. This prevents deleting the 'uncategorized' category referenced in [this bug report on meta discourse](http://meta.discourse.org/t/uncategorized-pinned-post-not-shown-for-anon-user/10717).

This solves the issue by hiding the Delete Category Button, but I'm interested to see:
1. if there is a better way than 'cat_id !== Discourse.Site.currentProp("uncategorized_category_id"))'. The `edit_category_controller` references `isUncategorized`, but I couldn't figure out how to use that (am not very familiar with ember or js).
2. Would it be a good idea to add a `before_destroy` filter to the Category model prevent deleting the 'uncategorized' category?

Looking for any other feedback as well!
Thanks
