### PR TITLE
FIX: Title text should be correctly escaped since we are generating a raw html

### DIFF
--- a/app/assets/javascripts/discourse/helpers/application_helpers.js
+++ b/app/assets/javascripts/discourse/helpers/application_helpers.js
@@ -289,7 +289,7 @@ Handlebars.registerHelper('number', function(property, options) {
   var result = "<span class='" + classNames + "'";
 
   if (n !== title) {
-    result += " title='" + title + "'";
+    result += " title='" + Handlebars.Utils.escapeExpression(title) + "'";
   }
   result += ">" + n + "</span>";
 


### PR DESCRIPTION
Minor bug fix:
  I escaped title text with Handlebars.Utils.escapeExpression.

Bug generation step:
If you include a quote(') character in likes_long field in config/locales/client.?? file,
You will get an incorrectly formatted html in a topic list page.
And when you mouse over the like count, the text will be truncated.
