### PR TITLE
tweak RSS elements for W3C compatibility

### DIFF
--- a/app/views/list/list.rss.erb
+++ b/app/views/list/list.rss.erb
@@ -2,22 +2,21 @@
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <% lang = SiteSetting.find_by_name('default_locale').try(:value) %>
+    <% site_email = SiteSetting.find_by_name('contact_email').try(:value) %>
     <title><%= @title %></title>
     <link><%= @link %></link>
     <description><%= @description %></description>
-    <% if lang %>
-      <language><%= lang %></language>
-    <% end %>
+    <%= "<language>#{lang}</language>" if lang %>
     <lastBuildDate><%= @topic_list.topics.first.created_at.rfc2822 %></lastBuildDate>
     <atom:link href="<%= @atom_link %>" rel="self" type="application/rss+xml" />
     <% @topic_list.topics.each do |topic| %>
       <% topic_url = Discourse.base_url + topic.relative_url -%>
       <item>
         <title><%= topic.title %></title>
-        <author><%= "@#{topic.user.username} (#{topic.user.name})" -%></author>
+        <author><%= "#{site_email} (@#{topic.user.username}#{" #{topic.user.name}" if topic.user.name.present?})" -%></author>
         <category><%= topic.category.name %></category>
         <description><![CDATA[
-          <p><%= t('author_wrote', author: link_to(topic.user.name, topic.user)).html_safe %></p>
+          <p><%= t('author_wrote', author: link_to(topic.user.name, userpage_url(topic.user))).html_safe %></p>
           <blockquote>
             <%= topic.posts.first.cooked.html_safe %>
           </blockquote>

--- a/app/views/topics/show.rss.erb
+++ b/app/views/topics/show.rss.erb
@@ -3,23 +3,22 @@
   <channel>
     <% topic_url = Discourse.base_url + @topic_view.relative_url %>
     <% lang = SiteSetting.find_by_name('default_locale').try(:value) %>
+    <% site_email = SiteSetting.find_by_name('contact_email').try(:value) %>
     <title><%= @topic_view.title %></title>
     <link><%= topic_url %></link>
     <description><%= @topic_view.posts.first.raw %></description>
-    <% if lang %>
-      <language><%= lang %></language>
-    <% end %>
+    <%= "<language>#{lang}</language>" if lang %>
     <lastBuildDate><%= @topic_view.topic.created_at.rfc2822 %></lastBuildDate>
     <category><%= @topic_view.topic.category.name %></category>
     <atom:link href="<%= topic_url %>.rss" rel="self" type="application/rss+xml" />
     <% @topic_view.recent_posts.each do |post| %>
       <% next unless post.user %>
       <item>
-        <title><%= @topic_view.title %> at <%= post.created_at %></title>
-        <author><%= "@#{post.user.username} (#{post.user.name})" -%></author>
+        <title><%= @topic_view.title %></title>
+        <author><%= "#{site_email} (@#{post.user.username}#{" #{post.user.name}" if post.user.name.present?})" -%></author>
         <description><![CDATA[
           <% post_url = Discourse.base_url + post.url %>
-          <p><%= t('author_wrote', author: link_to(post.user.name, post.user)).html_safe %></p>
+          <p><%= t('author_wrote', author: link_to(post.user.name, userpage_url(post.user))).html_safe %></p>
           <blockquote>
             <%= post.cooked.html_safe %>
           </blockquote>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -140,7 +140,7 @@ Discourse::Application.routes.draw do
   get 'user_preferences' => 'users#user_preferences_redirect'
   get 'users/:username/private-messages' => 'user_actions#private_messages', constraints: {username: USERNAME_ROUTE_FORMAT}
   get 'users/:username/private-messages/:filter' => 'user_actions#private_messages', constraints: {username: USERNAME_ROUTE_FORMAT}
-  get 'users/:username' => 'users#show', constraints: {username: USERNAME_ROUTE_FORMAT}
+  get 'users/:username' => 'users#show', as: 'userpage', constraints: {username: USERNAME_ROUTE_FORMAT}
   put 'users/:username' => 'users#update', constraints: {username: USERNAME_ROUTE_FORMAT}
   get 'users/:username/preferences' => 'users#preferences', constraints: {username: USERNAME_ROUTE_FORMAT}, as: :email_preferences
   get 'users/:username/preferences/email' => 'users#preferences', constraints: {username: USERNAME_ROUTE_FORMAT}


### PR DESCRIPTION
The W3C's RSS feed validator had some things to complain about after [my last round of RSS tweaks](https://github.com/discourse/discourse/pull/1738):
- invalid email in the `<author>` elements
- relative URLs in the `<description>`
- invalid tags and attributes in the `<description>`

(Here are its lists of complaints for a [category feed](http://validator.w3.org/feed/check.cgi?url=http%3A%2F%2Fmeta.discourse.org%2Fcategory%2Ffeature.rss) and a [topic feed](http://validator.w3.org/feed/check.cgi?url=http%3A%2F%2Fmeta.discourse.org%2Ft%2Frss-support-for-categories-topics%2F2075.rss).)

I "fixed" the invalid email thing by pulling the `contact_email` admin setting if it's been set. (If it's not set, the installation will always produce invalid feeds; I'm not sure what the best solution for that is, since I don't think it's appropriate to expose the email addresses of actual users.)

Relative URLs are made absolute by using a (newly named) route helper. (Out of curiosity, why is the route name `user` reserved just for the `users#destroy` action?)

As for the invalid tags and attributes: it complains about the `data-foo` attributes on the `<aside>` created when you quote a post, and complains about the `<iframe>`s of youtube embeds. However, everything in the `<description>` is wrapped in a CDATA, so I'm not sure what it's so upset about...
