### PR TITLE
respect newlines in About Me on profile page

### DIFF
--- a/app/assets/javascripts/discourse/templates/user/user.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/user/user.js.handlebars
@@ -41,7 +41,7 @@
           <h1>{{username}} {{{statusIcon}}}</h1>
           <h2>{{name}}</h2>
 
-          <div class='bio'>{{{bio_excerpt}}}</div>
+          <div class='bio'>{{{bio_cooked}}}</div>
 
           {{#if isSuspended}}
             <div class='suspended'>


### PR DESCRIPTION
It's irked me since I created an account on meta that the newlines in the About Me on my profile don't show up. Newlines are respected everywhere else I can find a user's About Me, so they should probably be respected on profiles as well.
