### PR TITLE
Fix missing pin icon.

### DIFF
--- a/app/assets/javascripts/discourse/components/topic_status_component.js
+++ b/app/assets/javascripts/discourse/components/topic_status_component.js
@@ -26,7 +26,7 @@ Discourse.TopicStatusComponent = Ember.Component.extend({
     this.trigger('addCustomIcon', buffer);
 
     renderIconIf('topic.closed', 'lock', 'locked');
-    renderIconIf('topic.pinned', 'pushpin', 'pinned');
+    renderIconIf('topic.pinned', 'thumb-tack', 'pinned');
     renderIconIf('topic.invisible', 'eye-close', 'invisible');
   }
 });


### PR DESCRIPTION
pushpin was renamed to thumb-tack in Font Awesome 4.0.

(Ref: https://github.com/FortAwesome/Font-Awesome/issues/2397)
