### PR TITLE
Fixed facebook's og:image

### DIFF
--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -28,7 +28,7 @@
   <%= auto_discovery_link_tag(@topic_view, {action: :feed, format: :rss, slug: @topic_view.topic.slug, topic_id: @topic_view.topic.id}, title: t('rss_posts_in_topic', topic: @topic_view.title), type: 'application/rss+xml') %>
   <%= crawlable_meta_data(title: @topic_view.title,
                           description: @topic_view.summary,
-                          image: @topic_view.image_url) %>
+                          image: @topic_view.image_url.gsub('//', 'http://')) %>
 <% end %>
 
 <% content_for(:title) { @topic_view.title } %>


### PR DESCRIPTION
Facebook doesn't support // urls and need the full http://
