### PR TITLE
Allow configuration of Redis DB and cache DB

### DIFF
--- a/config/discourse_defaults.conf
+++ b/config/discourse_defaults.conf
@@ -73,5 +73,11 @@ redis_host = localhost
 # redis server port
 redis_port = 6379
 
+# redis database
+redis_db = 0
+
+# redis database for caching
+redis_cache_db = 2
+
 # redis password
 redis_password =

--- a/config/redis.yml
+++ b/config/redis.yml
@@ -2,8 +2,8 @@ defaults: &defaults
   host: <%= GlobalSetting.redis_host %>
   port: <%= GlobalSetting.redis_port %>
   password: <%= GlobalSetting.redis_password %>
-  db: 0
-  cache_db: 2
+  db: <%= GlobalSetting.redis_db %>
+  cache_db: <%= GlobalSetting.redis_cache_db %>
 
 development:
   <<: *defaults


### PR DESCRIPTION
Hardcoding the Redis DB and Redis Caching DB to 0 and 2 in
`config/database.yml` makes an unsafe assumption that Discourse is the
only application using that install of redis-server. Instead of forcing
users to undergo yet another form of configuration, allow Discourse
admins a nicer way to configure the Redis databases used.

Signed-off-by: David Celis me@davidcel.is
