### PR TITLE
Update favcount.js to v1.4.0

### DIFF
--- a/vendor/assets/javascripts/favcount.js
+++ b/vendor/assets/javascripts/favcount.js
@@ -1,5 +1,5 @@
 /*
- * favcount.js v1.1.0
+ * favcount.js v1.4.0
  * http://chrishunt.co/favcount
  * Dynamically updates the favicon with a number.
  *
@@ -10,7 +10,9 @@
 (function(){
   function Favcount(icon) {
     this.icon = icon;
+    this.opacity = 0.4;
     this.canvas = document.createElement('canvas');
+    this.font = "Helvetica, Arial, sans-serif";
   }
 
   Favcount.prototype.set = function(count) {
@@ -19,12 +21,12 @@
 
     if (self.canvas.getContext) {
       img.onload = function() {
-        drawCanvas(self.canvas, img, normalize(count));
+        drawCanvas(self.canvas, self.opacity, self.font, img, normalize(count));
       };
 
       img.src = this.icon;
     }
-  }
+  };
 
   function normalize(count) {
     count = Math.round(count);
@@ -40,7 +42,7 @@
     }
   }
 
-  function drawCanvas(canvas, img, count) {
+  function drawCanvas(canvas, opacity, font, img, count) {
     var head = document.getElementsByTagName('head')[0],
         favicon = document.createElement('link'),
         multiplier, fontSize, context, xOffset, yOffset, border, shadow;
@@ -57,10 +59,10 @@
 
     canvas.height = canvas.width = img.width;
     context = canvas.getContext('2d');
-    context.font = 'bold ' + fontSize + 'px "helvetica", sans-serif';
+    context.font = 'bold ' + fontSize + 'px ' + font;
 
     // Draw faded favicon background
-    if (count) { context.globalAlpha = 0.4; }
+    if (count) { context.globalAlpha = opacity; }
     context.drawImage(img, 0, 0);
     context.globalAlpha = 1.0;
 
@@ -94,5 +96,5 @@
 }).call(this);
 
 (function(){
-  Favcount.VERSION = '1.1.0';
+  Favcount.VERSION = '1.4.0';
 }).call(this);


### PR DESCRIPTION
Inspired by [meta/11825](https://meta.discourse.org/t/security-error-on-console-noticed-on-meta/11825) to bump [favcount](https://github.com/chrishunt/favcount) to the latest version.

There are no behavioral changes. This just adds a missing semicolon and allows customization of opacity and font, both of which have the same defaults.
