### PR TITLE
username characters validation error should include underscores

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -857,7 +857,7 @@ en:
     username:
       short: "must be longer than %{min} characters"
       long: "must be shorter than %{max} characters"
-      characters: "must only include numbers and letters"
+      characters: "must only include numbers, letters and underscores"
       unique: "must be unique"
       blank: "must be present"
       must_begin_with_alphanumeric: "must begin with a letter or number"


### PR DESCRIPTION
According to the `username_validator.rb`, the `username_char_valid?` method checks that the username only includes letters, numbers or underscores.  The error received when trying to add any other characters to the username currently reads "must only include numbers and letters".  Simply updating this error message to include underscores, since those are also allowed.

![categories_list_-_community_forum-3](https://f.cloud.github.com/assets/3858670/1883336/baec9ab2-7984-11e3-9bdb-605350aee4bd.gif)
