### PR TITLE
README: Fix link to Admin Quick Start Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To learn more about the philosophy and goals of the project, [visit discourse.or
 
 1. If you're **brand new to Ruby and Rails**, please see [**Discourse as Your First Rails App**](http://blog.discourse.org/2013/04/discourse-as-your-first-rails-app/) or our [**Discourse Vagrant Developer Guide**](https://github.com/discourse/discourse/blob/master/docs/VAGRANT.md), which includes instructions to get up and running in a development environment using a virtual machine. This beginner's guide is also adequate for developers ready to sink their teeth quickly; it's the easiest way to hack on Discourse!
 
-2. Once you have Discourse up and running, be sure to load [the appropriate seed data](pg_dumps) on your forum, either the **developer** seed data, which is the same data you'll see on [try.discourse.org](http://try.discourse.org), or the **production** seed data which includes the [Discourse Admin Quick Start Guide](https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide) and meta guidance.
+2. Once you have Discourse up and running, be sure to load [the appropriate seed data](pg_dumps) on your forum, either the **developer** seed data, which is the same data you'll see on [try.discourse.org](http://try.discourse.org), or the **production** seed data which includes the [Discourse Admin Quick Start Guide](https://github.com/discourse/discourse/blob/master/docs/ADMIN-QUICK-START-GUIDE.md) and meta guidance.
 
 3. If you're familiar with how Rails works and are comfortable setting up your own environment, use our [**Discourse Advanced Developer Guide**](docs/DEVELOPER-ADVANCED.md).
 


### PR DESCRIPTION
In the README, Item 2 of the Getting Started Section links to 
https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide which has a link pointing users to visit https://github.com/discourse/discourse/blob/master/docs/ADMIN-QUICK-START-GUIDE.md

This changes the README to directly link to https://github.com/discourse/discourse/blob/master/docs/ADMIN-QUICK-START-GUIDE.md
