### PR TITLE
Fix Post-rendering bug

### DIFF
--- a/app/assets/javascripts/discourse/helpers/application_helpers.js
+++ b/app/assets/javascripts/discourse/helpers/application_helpers.js
@@ -7,9 +7,10 @@
 Handlebars.registerHelper('breakUp', function(property, hint, options) {
   var prop = Ember.Handlebars.get(this, property, options);
   if (!prop) return "";
-  hint = Ember.Handlebars.get(this, hint, options);
+  if (typeof(hint) !== 'string') hint = property;
 
-  return Discourse.Formatter.breakUp(prop, hint);
+  hint = Ember.Handlebars.get(this, hint, options);
+  return new Handlebars.SafeString(Discourse.Formatter.breakUp(prop, hint));
 });
 
 /**


### PR DESCRIPTION
Ember.Handlebars.normalizePath was being called with an object as
argument which caused it to error out.
also wrapped the return in a SafeString, so the html will not get
escaped again.
This fixes the [error with post-rendering](https://meta.discourse.org/t/error-after-update-to-0-9-8-1/11903) after migrating a forum to v0.9.81

This is not very pretty... I'm happy for any suggestions.
