### PR TITLE
Fix group matching SQL query

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -123,7 +123,7 @@ class Group < ActiveRecord::Base
                 ALIAS_LEVELS[:members_mods_and_admins]]
     end
 
-    Group.where("name LIKE :term_like AND (" +
+    Group.where("name ILIKE :term_like AND (" +
         " alias_level in (:levels)" +
         " OR (alias_level = #{ALIAS_LEVELS[:members_mods_and_admins]} AND id in (" +
             "SELECT group_id FROM group_users WHERE user_id= :user_id)" +


### PR DESCRIPTION
The check there is intended for the :members_mods_and_admins level, which is not automatically checked for normal users. Instead, the :everyone level is the one used, which would always fulfill the "alias_level in :levels" check.

This changes the :everyone level to :members_mods_and_admins, which was originally intended.
- [x] Tested
