### PR TITLE
Add User Agent header for onebox requests

### DIFF
--- a/lib/oneboxer.rb
+++ b/lib/oneboxer.rb
@@ -58,7 +58,7 @@ module Oneboxer
       # TODO - only download HEAD section
       # TODO - sane timeout
       # TODO - FAIL if for any reason you are downloading more that 5000 bytes
-      page_html = open(url).read
+      page_html = open(url, "User-Agent" => "Discourse Onebox #{Discourse::VERSION::STRING}").read
       if page_html.present?
         doc = Nokogiri::HTML(page_html)
 


### PR DESCRIPTION
We do some header detection at 8tracks to render pages using open graph. Onebox uses the default header for ruby requests, but this change would make it easier for us to detect a Discourse request.
