### PR TITLE
Add meta_data to TopicViewSerializer

### DIFF
--- a/app/serializers/topic_view_serializer.rb
+++ b/app/serializers/topic_view_serializer.rb
@@ -23,7 +23,8 @@ class TopicViewSerializer < ApplicationSerializer
      :slug,
      :category_id,
      :word_count,
-     :deleted_at]
+     :deleted_at,
+     :meta_data]
   end
 
   attributes :draft,


### PR DESCRIPTION
Would like to use a topic's meta_data in a view.  This seems to surface it in the proper way.
