### PR TITLE
Fix reply by email encoding error when using non-ASCII & non-UTF8 charset

### DIFF
--- a/lib/email/receiver.rb
+++ b/lib/email/receiver.rb
@@ -57,21 +57,27 @@ module Email
       if @message.multipart?
         @message.parts.each do |p|
           if p.content_type =~ /text\/plain/
-            @body = p.body.to_s
+            @body = p.charset ? p.body.decoded.force_encoding(p.charset).encode("UTF-8").to_s : p.body.to_s
             return @body
           elsif p.content_type =~ /text\/html/
-            html = p.body.to_s
+            html = p.charset ? p.body.decoded.force_encoding(p.charset).encode("UTF-8").to_s : p.body.to_s
           end
         end
       end
 
-      html = @message.body.to_s if @message.content_type =~ /text\/html/
+      if @message.content_type =~ /text\/html/
+        if defined? @message.charset
+          html = @message.body.decoded.force_encoding(@message.charset).encode("UTF-8").to_s 
+        else
+          html = @message.body.to_s
+        end
+      end
       if html.present?
         @body = scrub_html(html)
         return @body
       end
 
-      @body = @message.body.to_s.strip
+      @body = @message.charset ? @message.body.decoded.force_encoding(@message.charset).encode("UTF-8").to_s.strip : @message.body.to_s
 
       # Certain trigger phrases that means we didn't parse correctly
       @body = nil if @body =~ /Content\-Type\:/ ||

--- a/spec/components/email/receiver_spec.rb
+++ b/spec/components/email/receiver_spec.rb
@@ -73,6 +73,17 @@ stripped from my reply?")
     end
   end
 
+  describe "It supports a non UTF-8 reply" do
+    let(:big5) { File.read("#{Rails.root}/spec/fixtures/emails/big5.eml") }
+    let(:receiver) { Email::Receiver.new(big5) }
+
+    it "processes correctly" do
+      I18n.expects(:t).with('user_notifications.previous_discussion').returns('媽！我上電視了！')
+      receiver.process
+      expect(receiver.body).to eq("媽！我上電視了！")
+    end
+  end
+
   describe "via" do
     let(:wrote) { File.read("#{Rails.root}/spec/fixtures/emails/via_line.eml") }
     let(:receiver) { Email::Receiver.new(wrote) }

--- a/spec/fixtures/emails/big5.eml
+++ b/spec/fixtures/emails/big5.eml
@@ -1,0 +1,26 @@
+
+Delivered-To: discourse-reply+cd480e301683c9902891f15968bf07a5@discourse.org
+Received: by 10.194.216.104 with SMTP id op8csp80593wjc;
+        Wed, 24 Jul 2013 07:59:14 -0700 (PDT)
+Return-Path: <walter.white@googlemail.com>
+References: <topic/5043@discourse.org> <51efeb9b36c34_66dc2dfce6811866@discourse.mail>
+From: Walter White <walter.white@googlemail.com>
+In-Reply-To: <51efeb9b36c34_66dc2dfce6811866@discourse.mail>
+Mime-Version: 1.0 (1.0)
+Date: Wed, 24 Jul 2013 15:59:10 +0100
+Message-ID: <4597127794206131679@unknownmsgid>
+Subject: Re: [Discourse] new reply to your post in 'Crystal Blue'
+To: walter via Discourse <discourse-reply+cd480e301683c9902891f15968bf07a5@discourse.org>
+Content-Type: multipart/alternative; boundary=20cf301cc47ada510404f040b262
+
+--20cf301cc47ada510404f040b262
+Content-Type: text/plain; charset=Big5
+Content-Transfer-Encoding: base64
+
+tv2hSafapFe5cbX4pEahSQ0K
+--20cf301cc47ada510404f040b262
+Content-Type: text/html; charset=Big5
+Content-Transfer-Encoding: base64
+
+PGRpdiBkaXI9Imx0ciI+tv2hSafapFe5cbX4pEahSTxicj48L2Rpdj4NCg==
+--20cf301cc47ada510404f040b262--


### PR DESCRIPTION
I submitted an issue here 
https://github.com/discourse/discourse/issues/1834

Now it passed all rspecs.
