### PR TITLE
fix for nil session in mobile_detection.rb

### DIFF
--- a/lib/mobile_detection.rb
+++ b/lib/mobile_detection.rb
@@ -10,7 +10,7 @@ module MobileDetection
 
     session[:mobile_view] = params[:mobile_view] if params && params.has_key?(:mobile_view)
 
-    if session[:mobile_view]
+    if session && session[:mobile_view]
       session[:mobile_view] == '1'
     else
       mobile_device?(user_agent)


### PR DESCRIPTION
fixes this problem when logged out and enable_moble_theme is checked:

```
Unexpected error while processing request: undefined method `[]' for nil:NilClass
        /var/www/discourse/lib/mobile_detection.rb:13:in `resolve_mobile_view!'
        /var/www/discourse/lib/middleware/anonymous_cache.rb:28:in `is_mobile?'
        /var/www/discourse/lib/middleware/anonymous_cache.rb:33:in `cache_key'
        /var/www/discourse/lib/middleware/anonymous_cache.rb:37:in `cache_key_body'
        /var/www/discourse/lib/middleware/anonymous_cache.rb:53:in `cached'
        /var/www/discourse/lib/middleware/anonymous_cache.rb:102:in `call'
        /var/www/discourse/vendor/bundle/ruby/2.0.0/gems/railties-4.0.2/lib/rails/engine.rb:511:in `call'
        /var/www/discourse/vendor/bundle/ruby/2.0.0/gems/railties-4.0.2/lib/rails/application.rb:97:in `call'
        /var/www/discourse/vendor/bundle/ruby/2.0.0/gems/railties-4.0.2/lib/rails/railtie/configurable.rb:30:in `method_missing'
        /var/www/discourse/vendor/bundle/ruby/2.0.0/gems/rack-1.5.2/lib/rack/builder.rb:138:in `call'
        /var/www/discourse/vendor/bundle/ruby/2.0.0/gems/rack-1.5.2/lib/rack/urlmap.rb:65:in `block in call'
        /var/www/discourse/vendor/bundle/ruby/2.0.0/gems/rack-1.5.2/lib/rack/urlmap.rb:50:in `each'
        /var/www/discourse/vendor/bundle/ruby/2.0.0/gems/rack-1.5.2/lib/rack/urlmap.rb:50:in `call'
        /var/www/discourse/vendor/bundle/ruby/2.0.0/gems/thin-1.6.1/lib/thin/connection.rb:82:in `block in pre_process'
        /var/www/discourse/vendor/bundle/ruby/2.0.0/gems/thin-1.6.1/lib/thin/connection.rb:80:in `catch'
        /var/www/discourse/vendor/bundle/ruby/2.0.0/gems/thin-1.6.1/lib/thin/connection.rb:80:in `pre_process'
        /var/www/discourse/vendor/bundle/ruby/2.0.0/gems/thin-1.6.1/lib/thin/connection.rb:55:in `process'
        /var/www/discourse/vendor/bundle/ruby/2.0.0/gems/thin-1.6.1/lib/thin/connection.rb:41:in `receive_data'
        /var/www/discourse/vendor/bundle/ruby/2.0.0/gems/eventmachine-1.0.3/lib/eventmachine.rb:187:in `run_machine'
        /var/www/discourse/vendor/bundle/ruby/2.0.0/gems/eventmachine-1.0.3/lib/eventmachine.rb:187:in `run'
        /var/www/discourse/vendor/bundle/ruby/2.0.0/gems/thin-1.6.1/lib/thin/backends/base.rb:73:in `start'
        /var/www/discourse/vendor/bundle/ruby/2.0.0/gems/thin-1.6.1/lib/thin/server.rb:162:in `start'
        /var/www/discourse/vendor/bundle/ruby/2.0.0/gems/thin-1.6.1/lib/thin/controllers/controller.rb:87:in `start'
        /var/www/discourse/vendor/bundle/ruby/2.0.0/gems/thin-1.6.1/lib/thin/runner.rb:200:in `run_command'
        /var/www/discourse/vendor/bundle/ruby/2.0.0/gems/thin-1.6.1/lib/thin/runner.rb:156:in `run!'
        /var/www/discourse/vendor/bundle/ruby/2.0.0/gems/thin-1.6.1/bin/thin:6:in `<top (required)>'
        /usr/local/rvm/gems/ruby-2.0.0-p353@discourse/bin/thin:23:in `load'
        /usr/local/rvm/gems/ruby-2.0.0-p353@discourse/bin/thin:23:in `<main>'
        /usr/local/rvm/gems/ruby-2.0.0-p353@discourse/bin/ruby_executable_hooks:15:in `eval'
        /usr/local/rvm/gems/ruby-2.0.0-p353@discourse/bin/ruby_executable_hooks:15:in `<main>'
```
