### PR TITLE
Change user update to use #fetch for defaults

### DIFF
--- a/app/services/user_updater.rb
+++ b/app/services/user_updater.rb
@@ -1,27 +1,33 @@
 class UserUpdater
+
+  CATEGORY_IDS = {
+    watched_category_ids: :watching,
+    tracked_category_ids: :tracking,
+    muted_category_ids: :muted
+  }
+
+  USER_ATTR =   [
+      :email_digests,
+      :email_always,
+      :email_direct,
+      :email_private_messages,
+      :external_links_in_new_tab,
+      :enable_quoting,
+      :dynamic_favicon,
+      :watch_new_topics
+  ]
+
   def initialize(actor, user)
     @user = user
     @guardian = Guardian.new(actor)
   end
 
   def update(attributes = {})
-    user.website = format_url(attributes[:website]) || user.website
+    user.website = format_url(attributes.fetch(:website) { user.website })
 
-    user.bio_raw = attributes[:bio_raw] || user.bio_raw
-    user.name = attributes[:name] || user.name
-    user.digest_after_days = attributes[:digest_after_days] || user.digest_after_days
-
-    if ids = attributes[:watched_category_ids]
-      CategoryUser.batch_set(user, :watching, ids)
-    end
-
-    if ids = attributes[:tracked_category_ids]
-      CategoryUser.batch_set(user, :tracking, ids)
-    end
-
-    if ids = attributes[:muted_category_ids]
-      CategoryUser.batch_set(user, :muted, ids)
-    end
+    user.bio_raw = attributes.fetch(:bio_raw) { user.bio_raw }
+    user.name = attributes.fetch(:name) { user.name }
+    user.digest_after_days = attributes.fetch(:digest_after_days) { user.digest_after_days }
 
     if attributes[:auto_track_topics_after_msecs]
       user.auto_track_topics_after_msecs = attributes[:auto_track_topics_after_msecs].to_i
@@ -32,19 +38,16 @@ class UserUpdater
     end
 
     if guardian.can_grant_title?(user)
-      user.title = attributes[:title] || user.title
+      user.title = attributes.fetch(:title) { user.title }
     end
 
-    [
-      :email_digests,
-      :email_always,
-      :email_direct,
-      :email_private_messages,
-      :external_links_in_new_tab,
-      :enable_quoting,
-      :dynamic_favicon,
-      :watch_new_topics
-    ].each do |attribute|
+    CATEGORY_IDS.each do |attribute, level|
+      if ids = attributes[attribute]
+        CategoryUser.batch_set(user, level, ids)
+      end
+    end
+
+    USER_ATTR.each do |attribute|
       if attributes[attribute].present?
         user.send("#{attribute.to_s}=", attributes[attribute] == 'true')
       end


### PR DESCRIPTION
This changes the use of the || operator when setting the default of the
user attribute if the key does not exist to #fetch. This will make sure
that if false is passed in as the value it will still fail and use the
default setting.

This also adds constants to define and array and a hash of symbols which
is iterated over to set the users attributes.

The motivation for this refactor was the code climate score. I would like to extract setting of the attributes into methods like set_category_ids or set_user_values to make the methods smaller and easier to maintain. I would appreciate any feedback on how you would want to go about it or if it is even possible. 
