### PR TITLE
Fix inviting others to private messages.

### DIFF
--- a/app/assets/javascripts/discourse/components/private_message_map_component.js
+++ b/app/assets/javascripts/discourse/components/private_message_map_component.js
@@ -15,7 +15,6 @@ Discourse.PrivateMessageMapComponent = Ember.View.extend({
   init: function() {
     this._super();
     this.set('context', this);
-    this.set('controller', this);
   },
 
   actions: {
@@ -34,7 +33,7 @@ Discourse.PrivateMessageMapComponent = Ember.View.extend({
     },
 
     showPrivateInvite: function() {
-      this.sendAction('showPrivateInviteAction');
+      this.get('controller').send('showPrivateInviteAction');
     }
   }
 


### PR DESCRIPTION
It looks like `PrivateMessageMapComponent` was recently converted into a view which don't have `sendAction` defined. 

Also note that the following files in `app/assets/javascripts/discourse/components` are (except for the last one) actually views and not components. The documentation string and template location is also incorrect. I haven't moved them to the correct places since I figured it was possible you might be in the middle of refactoring them.
- private_message_map_component.js
- toggle_summary_content.js
- topic_map_component.js
- keyboard_shortcuts_component.js
