### PR TITLE
FIX: keyboard navigation in the search box results dropdown

### DIFF
--- a/app/assets/javascripts/discourse/controllers/search_controller.js
+++ b/app/assets/javascripts/discourse/controllers/search_controller.js
@@ -23,7 +23,7 @@ Discourse.SearchController = Em.ArrayController.extend(Discourse.Presence, {
 
   searchTerm: Discourse.debouncePromise(function(term, typeFilter) {
     var searchController = this;
-    this.set('count', 0);
+    this.set('resultCount', 0);
 
     var searcher = Discourse.Search.forTerm(term, {
       typeFilter: typeFilter,
@@ -48,7 +48,7 @@ Discourse.SearchController = Em.ArrayController.extend(Discourse.Presence, {
             })
             .value();
 
-        searchController.set('count', index);
+        searchController.set('resultCount', index);
         searchController.set('content', results);
       }
 


### PR DESCRIPTION
Currently (can be verified on meta.discourse.org/) it is possible to navigate (by pressing down arrow) past the last result displayed in the search dropdown. This PR fixes the bug, so the navigation stops at the last row.
