### PR TITLE
Bump favcount.js to v1.5.0

### DIFF
--- a/vendor/assets/javascripts/favcount.js
+++ b/vendor/assets/javascripts/favcount.js
@@ -1,5 +1,5 @@
 /*
- * favcount.js v1.4.0
+ * favcount.js v1.5.0
  * http://chrishunt.co/favcount
  * Dynamically updates the favicon with a number.
  *
@@ -98,5 +98,5 @@
 }).call(this);
 
 (function(){
-  Favcount.VERSION = '1.4.0';
+  Favcount.VERSION = '1.5.0';
 }).call(this);


### PR DESCRIPTION
We fixed a CORS issue in https://github.com/discourse/discourse/commit/7b20079d852dfef62f8afca2949c9a2f9c43d49f :sparkles:, but I'm bumping the version here as well to [match upstream](https://github.com/chrishunt/favcount/commit/7687447096444c4f234ca500fa983c20bfca4372).

Thank you!

cc @eviltrout https://github.com/chrishunt/favcount/pull/8
