### PR TITLE
Adds new QUnit assertion ("not") complementary to built-in "ok"

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -14,6 +14,7 @@
     "integration",
     "test",
     "ok",
+    "not",
     "expect",
     "equal",
     "blank",

--- a/test/javascripts/helpers/assertions.js
+++ b/test/javascripts/helpers/assertions.js
@@ -18,3 +18,7 @@ function blank(obj, text) {
 function containsInstance(collection, klass, text) {
   ok(klass.detectInstance(_.first(collection)), text);
 }
+
+function not(state, message) {
+  ok(!state, message);
+}


### PR DESCRIPTION
Strangely, almost all QUnit assertions have complementary, negated version (`equal` and `notEqual` etc.) except of the basic `ok` assertion. Having to use `ok(!something);` all the time is not very readable and quite error prone (exclamation mark is easy to miss) - I was bitten by it at least a few times when writing JS tests. This PR adds a complementary assertion `not` (that is just a negated `ok`). It makes possible asserting `not(something);` what is much more readable than `ok(!something);`
