### PR TITLE
Add site setting for category of topics created by embedding

### DIFF
--- a/app/models/topic_embed.rb
+++ b/app/models/topic_embed.rb
@@ -19,7 +19,12 @@ class TopicEmbed < ActiveRecord::Base
     # If there is no embed, create a topic, post and the embed.
     if embed.blank?
       Topic.transaction do
-        creator = PostCreator.new(user, title: title, raw: absolutize_urls(url, contents), skip_validations: true, cook_method: Post.cook_methods[:raw_html])
+        creator = PostCreator.new(user,
+                                  title: title,
+                                  raw: absolutize_urls(url, contents),
+                                  skip_validations: true,
+                                  cook_method: Post.cook_methods[:raw_html],
+                                  category: SiteSetting.embed_category)
         post = creator.create
         if post.present?
           TopicEmbed.create!(topic_id: post.topic_id,

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -794,6 +794,7 @@ en:
     feed_polling_enabled: "Whether to import a RSS/ATOM feed as posts"
     feed_polling_url: "URL of RSS/ATOM feed to import"
     embed_by_username: "Discourse username of the user who creates the topics"
+    embed_category: "Category of created topics"
     embed_post_limit: "Maximum number of posts to embed"
 
   notification_types:

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -356,6 +356,7 @@ embedding:
   feed_polling_enabled: false
   feed_polling_url: ''
   embed_by_username: ''
+  embed_category: ''
   embed_post_limit: 100
 
 uncategorized:


### PR DESCRIPTION
This patch adds a site setting (under 'Embedding') for the category that is used for topics created when a blog post is retrieved when first embedding comments on that post. This is as suggested on a thread in meta:

https://meta.discourse.org/t/discourse-plugin-for-static-site-generators-like-jekyll-or-octopress/7965/106

I have only provided the English string localisation of the setting description.

Because of the difficulties of setting up a sandboxed development environment to test this, requiring both a Discourse server and a static blog server (e.g., Jekyll), I found it easier to test this rather small patch _in situ_ on my production servers. It worked.
