### PR TITLE
Allow to use the API when Login required site setting is on

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -281,7 +281,9 @@ class ApplicationController < ActionController::Base
     end
 
     def redirect_to_login_if_required
-      redirect_to :login if SiteSetting.login_required? && !current_user
+      return if current_user || (request.format.json? && api_key_valid?)
+
+      redirect_to :login if SiteSetting.login_required?
     end
 
     def build_not_found_page(status=404, layout=false)

--- a/spec/controllers/topics_controller_spec.rb
+++ b/spec/controllers/topics_controller_spec.rb
@@ -583,8 +583,20 @@ describe TopicsController do
       end
 
       context 'and the user is not logged in' do
+        let(:api_key) { topic.user.generate_api_key(topic.user) }
+
         it 'redirects to the login page' do
           get :show, topic_id: topic.id, slug: topic.slug
+          expect(response).to redirect_to login_path
+        end
+
+        it 'shows the topic if valid api key is provided' do
+          get :show, topic_id: topic.id, slug: topic.slug, api_key: api_key.key
+          expect(response).to be_successful
+        end
+
+        it 'redirects to the login page if invalid key is provided' do
+          get :show, topic_id: topic.id, slug: topic.slug, api_key: "bad"
           expect(response).to redirect_to login_path
         end
       end


### PR DESCRIPTION
Hello,

currently it is not possible to use the API when Login required site setting is on because of a filter which always redirects to the login page.

I've changed this filter so that it is possible to use the API if Login required is enabled and a correct API token is provided.

Thanks!
