### PR TITLE
Refactor current user provider.

### DIFF
--- a/lib/auth/current_user_provider.rb
+++ b/lib/auth/current_user_provider.rb
@@ -1,9 +1,51 @@
 module Auth; end
 class Auth::CurrentUserProvider
 
+  API_KEY ||= "_DISCOURSE_API"
+  CURRENT_USER_KEY ||= "_DISCOURSE_CURRENT_USER"
+
   # do all current user initialization here
   def initialize(env)
-    raise NotImplementedError
+    @env = env
+    @request = Rack::Request.new(env)
+  end
+
+  # Wrapper around the current_user function to handle memoization, suspending
+  # users, updating last seen and IP address, and detecting API calls.
+  def current_user_wrapper
+    return @env[CURRENT_USER_KEY] if @env.key?(CURRENT_USER_KEY)
+
+    user = current_user
+
+    if user && user.suspended?
+      user = nil
+    end
+
+    if user
+      user.update_last_seen!
+      user.update_ip_address!(@request.ip)
+    end
+
+    # possible we have an api call, impersonate
+    unless user
+      if api_key_value = @request["api_key"]
+        api_key = ApiKey.where(key: api_key_value).includes(:user).first
+        if api_key.present?
+          @env[API_KEY] = true
+          api_username = @request["api_username"]
+
+          if api_key.user.present?
+            raise Discourse::InvalidAccess.new if api_username && (api_key.user.username_lower != api_username.downcase)
+            user = api_key.user
+          elsif api_username
+            user = User.where(username_lower: api_username.downcase).first
+          end
+
+        end
+      end
+    end
+
+    @env[CURRENT_USER_KEY] = user
   end
 
   # our current user, return nil if none is found
@@ -18,7 +60,8 @@ class Auth::CurrentUserProvider
 
   # api has special rights return true if api was detected
   def is_api?
-    raise NotImplementedError
+    current_user_wrapper
+    @env[API_KEY]
   end
 
   # we may need to know very early on in the middleware if an auth token
@@ -26,7 +69,6 @@ class Auth::CurrentUserProvider
   def has_auth_cookie?
     raise NotImplementedError
   end
-
 
   def log_off_user(session, cookies)
     raise NotImplementedError

--- a/lib/auth/default_current_user_provider.rb
+++ b/lib/auth/default_current_user_provider.rb
@@ -1,60 +1,15 @@
 require_dependency "auth/current_user_provider"
 
-class Auth::DefaultCurrentUserProvider
+class Auth::DefaultCurrentUserProvider < Auth::CurrentUserProvider
 
-  CURRENT_USER_KEY ||= "_DISCOURSE_CURRENT_USER"
-  API_KEY ||= "_DISCOURSE_API"
   TOKEN_COOKIE ||= "_t"
-
-  # do all current user initialization here
-  def initialize(env)
-    @env = env
-    @request = Rack::Request.new(env)
-  end
 
   # our current user, return nil if none is found
   def current_user
-    return @env[CURRENT_USER_KEY] if @env.key?(CURRENT_USER_KEY)
-
-    request = Rack::Request.new(@env)
-
-    auth_token = request.cookies[TOKEN_COOKIE]
-
-    current_user = nil
-
+    auth_token = @request.cookies[TOKEN_COOKIE]
     if auth_token && auth_token.length == 32
-      current_user = User.where(auth_token: auth_token).first
+      User.where(auth_token: auth_token).first
     end
-
-    if current_user && current_user.suspended?
-      current_user = nil
-    end
-
-    if current_user
-      current_user.update_last_seen!
-      current_user.update_ip_address!(request.ip)
-    end
-
-    # possible we have an api call, impersonate
-    unless current_user
-      if api_key_value = request["api_key"]
-        api_key = ApiKey.where(key: api_key_value).includes(:user).first
-        if api_key.present?
-          @env[API_KEY] = true
-          api_username = request["api_username"]
-
-          if api_key.user.present?
-            raise Discourse::InvalidAccess.new if api_username && (api_key.user.username_lower != api_username.downcase)
-            current_user = api_key.user
-          elsif api_username
-            current_user = User.where(username_lower: api_username.downcase).first
-          end
-
-        end
-      end
-    end
-
-    @env[CURRENT_USER_KEY] = current_user
   end
 
   def log_on_user(user, session, cookies)
@@ -80,16 +35,8 @@ class Auth::DefaultCurrentUserProvider
     cookies[TOKEN_COOKIE] = nil
   end
 
-
-  # api has special rights return true if api was detected
-  def is_api?
-    current_user
-    @env[API_KEY]
-  end
-
   def has_auth_cookie?
-    request = Rack::Request.new(@env)
-    cookie = request.cookies[TOKEN_COOKIE]
+    cookie = @request.cookies[TOKEN_COOKIE]
     !cookie.nil? && cookie.length == 32
   end
 end

--- a/lib/current_user.rb
+++ b/lib/current_user.rb
@@ -5,7 +5,7 @@ module CurrentUser
   end
 
   def self.lookup_from_env(env)
-    Discourse.current_user_provider.new(env).current_user
+    Discourse.current_user_provider.new(env).current_user_wrapper
   end
 
 
@@ -27,7 +27,7 @@ module CurrentUser
   end
 
   def current_user
-    current_user_provider.current_user
+    current_user_provider.current_user_wrapper
   end
 
   private

--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -192,6 +192,14 @@ module Discourse
 
   def self.current_user_provider=(val)
     @current_user_provider = val
+
+    # Needed for legacy current user providers that don't inherit from 
+    # Auth::CurrentUserProvider.
+    @current_user_provider.class_eval do
+      unless method_defined?(:current_user_wrapper)
+        define_method(:current_user_wrapper) { current_user }
+      end
+    end
   end
 
   def self.asset_host

--- a/spec/components/auth/current_user_provider_spec.rb
+++ b/spec/components/auth/current_user_provider_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+# In the ghetto ... getting the spec to run in autospec
+#  thing is we need to load up all auth really early pre-fork
+#  it means that the require is not going to get a new copy
+Auth.send(:remove_const, :CurrentUserProvider)
+load 'auth/current_user_provider.rb'
+
+describe Auth::CurrentUserProvider do
+  it "should memoize current_user" do
+    env = Rack::MockRequest.env_for("http://example.com/")
+    provider = Auth::CurrentUserProvider.new(env)
+    provider.expects(:current_user)
+    2.times { provider.current_user_wrapper }
+  end
+
+  it "should not allow suspended users to be logged in" do
+    env = Rack::MockRequest.env_for("http://example.com/")
+    user = Fabricate(:user, auth_token: EmailToken.generate_token)
+    user.suspended_till = Time.now + 5.minutes
+    provider = Auth::CurrentUserProvider.new(env)
+    provider.stubs(:current_user).returns(user)
+    provider.current_user_wrapper.should == nil
+  end
+
+  it "should update last seen and IP address" do
+    env = Rack::MockRequest.env_for("http://example.com/")
+    user = Fabricate(:user, auth_token: EmailToken.generate_token)
+    user.expects(:update_last_seen!)
+    user.expects(:update_ip_address!)
+    provider = Auth::CurrentUserProvider.new(env)
+    provider.stubs(:current_user).returns(user)
+    provider.current_user_wrapper
+  end
+
+  it "should detect API requests" do
+    api_key = ApiKey.create_master_key
+    env = Rack::MockRequest.env_for("http://example.com/", params: {api_key: api_key.key})
+    provider = Auth::CurrentUserProvider.new(env)
+    provider.stubs(:current_user).returns(nil)
+    provider.is_api?.should == true
+  end
+end


### PR DESCRIPTION
This simplifies the implementation of custom current user providers. (See: https://meta.discourse.org/t/amending-current-user-logic-in-discourse/10278/8)

Should be backwards compatible, all of the tests pass both with the new and old DefaultCurrentUserProvider.
