### PR TITLE
Fixed 'devloper' typo in quickstart config file

### DIFF
--- a/config/discourse_quickstart.conf
+++ b/config/discourse_quickstart.conf
@@ -34,7 +34,7 @@ smtp_enable_start_tls = true
 # recommended, cdn used to access assets. This can be left empty at first.
 cdn_url =
 
-# comma delimited list of emails that have devloper level access. 
+# comma delimited list of emails that have developer level access. 
 developer_emails =
 
 # More advanded settings. Unless you changed these in your enviroment, the defaults will work.


### PR DESCRIPTION
Found this while going through the setup guide. 
