### PR TITLE
Adds JS integration tests for search

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -20,6 +20,7 @@
     "blank",
     "present",
     "visit",
+    "andThen",
     "click",
     "currentPath",
     "currentRouteName",

--- a/app/assets/javascripts/discourse/templates/search.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/search.js.handlebars
@@ -1,4 +1,4 @@
-{{view Discourse.SearchTextField valueBinding="term" searchContextBinding="searchContext"}}
+{{view Discourse.SearchTextField valueBinding="term" searchContextBinding="searchContext" id="search-term"}}
 {{#unless loading}}
   {{#unless noResults}}
     {{#each resultType in content}}

--- a/test/javascripts/integration/header_test.js
+++ b/test/javascripts/integration/header_test.js
@@ -11,6 +11,8 @@ integration("Header", {
       return scope;
     });
 
+    sinon.stub(Ember.run, "debounce").callsArg(1);
+
     var originalCategories = Discourse.Category.list();
     sinon.stub(Discourse.Category, "list").returns(originalCategories);
 
@@ -20,6 +22,7 @@ integration("Header", {
 
   teardown: function() {
     I18n.t.restore();
+    Ember.run.debounce.restore();
     Discourse.Category.list.restore();
     Discourse.User.current.restore();
   }
@@ -117,5 +120,54 @@ test("sitemap dropdown", function() {
 
     ok(exists($siteMapDropdown.find(".category-links")), "has categories correctly bound");
     ok(exists($siteMapDropdown.find(".new-posts")), "has displaying category badges correctly bound");
+  });
+});
+
+test("search dropdown", function() {
+  Discourse.SiteSettings.min_search_term_length = 2;
+  Ember.run(function() {
+    Discourse.URL_FIXTURES["/search"] = [
+      {
+        type: "topic",
+        more: true,
+        results: [
+          {
+            url: "some-url"
+          }
+        ]
+      }
+    ];
+  });
+
+  visit("/");
+  andThen(function() {
+    not(exists("#search-dropdown:visible"), "initially search box is closed");
+  });
+  click("#search-button");
+  andThen(function() {
+    ok(exists("#search-dropdown:visible"), "after clicking a button search box opens");
+    not(exists("#search-dropdown .heading"), "initially, immediately after opening, search box is empty");
+  });
+  fillIn("#search-term", "ab");
+  andThen(function() {
+    ok(exists("#search-dropdown .heading"), "when user completes a search, search box shows search results");
+    equal(find("#search-dropdown .selected a").attr("href"), "some-url", "the first search result is selected");
+  });
+  andThen(function() {
+    Discourse.URL_FIXTURES["/search"] = [
+      {
+        type: "topic",
+        more: true,
+        results: [
+          {
+            url: "another-url"
+          }
+        ]
+      }
+    ];
+  });
+  click("#search-dropdown .filter");
+  andThen(function() {
+    equal(find("#search-dropdown .selected a").attr("href"), "another-url", "after clicking 'more of type' link, results are reloaded");
   });
 });

--- a/test/javascripts/templates/search_test.js
+++ b/test/javascripts/templates/search_test.js
@@ -1,4 +1,4 @@
-var controller, oldSearchTextField, oldSearchResultsTypeView;
+var controller, oldSearchTextField, oldSearchResultsTypeView, oldViews;
 
 var SearchTextFieldStub = Ember.View.extend({
   classNames: ["search-text-field-stub"],
@@ -18,7 +18,6 @@ var setUpController = function(properties) {
 
 var appendView = function() {
   Ember.run(function() {
-    Discourse.advanceReadiness();
     Ember.View.create({
       container: Discourse.__container__,
       controller: controller,
@@ -42,6 +41,9 @@ module("Template: search", {
     oldSearchResultsTypeView = Discourse.SearchResultsTypeView;
     Discourse.SearchResultsTypeView = SearchResultsTypeViewStub;
 
+    oldViews = Ember.View.views;
+    Ember.View.views = {};
+
     controller = Ember.ArrayController.create();
   },
 
@@ -50,6 +52,8 @@ module("Template: search", {
 
     Discourse.SearchTextField = oldSearchTextField;
     Discourse.SearchResultsTypeView = oldSearchResultsTypeView;
+
+    Ember.View.views = oldViews;
   }
 });
 


### PR DESCRIPTION
In my previous PR that fixed .jshintrc to allow new Ember e2e tests syntax (https://github.com/discourse/discourse/pull/1883) I forgot about one method (`andThen`), what was revealed when writing this test - so this PR additionally fixes .jshintrc.
