### PR TITLE
Remove invalid comment.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,8 +74,6 @@ gem 'active_model_serializers'
 
 gem 'onebox', git: 'https://github.com/dysania/onebox.git'
 
-# we had issues with latest, stick to the rev till we figure this out
-# PR that makes it all hang together welcome
 gem 'ember-rails'
 gem 'ember-source', '~> 1.2.0.1'
 gem 'handlebars-source', '~> 1.1.2'


### PR DESCRIPTION
This was added in 1076aa50a8ffa4f5ab50369807527542a7b87372 when
ember-rails was installed from a revision number. This was changed to
use the latest gem release in ad6705cca759c6b8d40330d24d981190623cdc43
