### PR TITLE
Add rake task for running plugin tests.

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -157,7 +157,7 @@ module Discourse
     config.active_record.whitelist_attributes = false unless rails4?
 
     require 'auth'
-    Discourse.activate_plugins! unless Rails.env.test?
+    Discourse.activate_plugins! unless Rails.env.test? and ENV['LOAD_PLUGINS'] != "true"
 
     config.after_initialize do
       # So open id logs somewhere sane

--- a/lib/tasks/plugin.rake
+++ b/lib/tasks/plugin.rake
@@ -42,3 +42,15 @@ task 'plugin:update', :plugin do |t, args|
   update_status = system('git --git-dir "' + plugin_path + '/.git" --work-tree "' + plugin_path + '" pull')
   abort('Unable to pull latest version of plugin') unless update_status
 end
+
+desc 'run plugin specs'
+task 'plugin:spec', :plugin do |t, args|
+  args.with_defaults(plugin: "**")
+  ruby = `which ruby`.strip
+  files = Dir.glob("./plugins/#{args[:plugin]}/spec/*.rb")
+  if files.length > 0
+    sh "LOAD_PLUGINS=true #{ruby} -S rspec #{files.join(' ')}"
+  else
+    abort "No specs found."
+  end
+end


### PR DESCRIPTION
This makes it possible to run Discourse tests with plugins loaded by setting `LOAD_PLUGINS=true`, as well as to run specs defined in a `spec/` directory inside plugins by running either `rake plugin:spec` for all plugins or `rake plugin:spec[pluginname]` for a specific plugin.

Since most plugins aren't going to be complicated enough to require sub-directories inside of the `spec/` folder I don't recursively glob, all specs need to be directly in the `spec/` directory.

So it becomes easy to write tests for plugin functionality like this one:

``` ruby
require 'spec_helper'
require 'post_creator'

describe PostCreator do
  let(:user) { Fabricate(:user) }

  context "new topic" do
    it "poll cannot be created without a list of options" do
      post = PostCreator.create(user, {title: "Poll: This is a poll", raw: "body does not contain a list"})
      post.errors[:raw].should be_present
    end
  end
end
```
