### PR TITLE
Whitelist :active param so that we can automatically create users that a...

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -400,7 +400,8 @@ class UsersController < ApplicationController
         :name,
         :email,
         :password,
-        :username
+        :username,
+        :active
       ).merge(ip_address: request.ip)
     end
 end


### PR DESCRIPTION
This addition whitelists the :active parameter so that we can create a user that is immediate active via an API request.
