### PR TITLE
Don't clear DiscoursePluginRegistry if LOAD_PLUGINS=true.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -76,7 +76,7 @@ Spork.prefork do
     end
 
     config.before(:all) do
-      DiscoursePluginRegistry.clear
+      DiscoursePluginRegistry.clear if ENV['LOAD_PLUGINS'] != "true"
       Discourse.current_user_provider = TestCurrentUserProvider
 
       # a bit odd, but this setting is actually preloaded


### PR DESCRIPTION
Without this server side javascripts weren't being registered when running `rake plugin:spec`.
