### PR TITLE
Fix shortenUrl helper to not crash when URL doesn't include any "/".

### DIFF
--- a/app/assets/javascripts/discourse/helpers/application_helpers.js
+++ b/app/assets/javascripts/discourse/helpers/application_helpers.js
@@ -106,10 +106,11 @@ Handlebars.registerHelper('titledLinkTo', function(name, object) {
   @for Handlebars
 **/
 Handlebars.registerHelper('shortenUrl', function(property, options) {
-  var url;
+  var url, matches;
   url = Ember.Handlebars.get(this, property, options);
   // Remove trailing slash if it's a top level URL
-  if (url.match(/\//g).length === 3) {
+  matches = url.match(/\//g);
+  if (matches && matches.length === 3) {
     url = url.replace(/\/$/, '');
   }
   url = url.replace(/^https?:\/\//, '');


### PR DESCRIPTION
If `shortenUrl` is sent a URL (href) w/o "/" (like a mailto: for eg.) it crashes and makes the the whole page crash and everything else after that stops working. Puppies die. Babies cries. Not pretty.
