### PR TITLE
Include binstubs generated by Rails 4

### DIFF
--- a/bin/bundle
+++ b/bin/bundle
@@ -1,0 +1,3 @@
+#!/usr/bin/env ruby
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
+load Gem.bin_path('bundler', 'bundle')

--- a/bin/rails
+++ b/bin/rails
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+APP_PATH = File.expand_path('../../config/application',  __FILE__)
+require_relative '../config/boot'
+require 'rails/commands'

--- a/bin/rake
+++ b/bin/rake
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+require_relative '../config/boot'
+require 'rake'
+Rake.application.run


### PR DESCRIPTION
Commit b516ecc added `bin/` to the .gitignore file. Now that Discourse
runs using Rails 4 by default, however, we should include the binstubs
generated by `rake rails:update:bin` in version control as this is the
recommendation of the Rails core team. Additionally, for those wishing
to deploy Discourse to Heroku, these binstubs are actually mandatory
according to [this article](https://devcenter.heroku.com/articles/rails4).

Other binstubs can continue to be ignored.

Signed-off-by: David Celis me@davidcel.is
