### PR TITLE
Update new_user top page redirect reason

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1154,7 +1154,7 @@ en:
         today: "Today"
         other_periods: "see more top topics"
         redirect_reasons:
-          new_user: "Welcome! As a new visitor, we thought you might like to start with the top discussion topics."
+          new_user: "Welcome! As a new visitor, this will be your homepage until you've had some time to look around at the forum. Here's some of the most popular topics from the past."
           not_seen_in_a_month: "Welcome back! We haven't seen you in a while. These are the top discussion topics since you've been away."
 
     browser_update: 'Unfortunately, <a href="http://www.discourse.org/faq/#browser">your browser is too old to work on this Discourse forum</a>. Please <a href="http://browsehappy.com">upgrade your browser</a>.'


### PR DESCRIPTION
The goal of this text is to sublty hint that reading is the way to graduate out of it.

As suggested in https://meta.discourse.org/t/new-visitor-message-confusing-people/12508/12?u=riking

![image](https://f.cloud.github.com/assets/627891/2105394/af8e2740-8f8b-11e3-8d67-5f20c8c2125e.png)
