### PR TITLE
Use GlobalSetting to enable CORS at application level

### DIFF
--- a/config/discourse_defaults.conf
+++ b/config/discourse_defaults.conf
@@ -68,7 +68,7 @@ enable_mini_profiler = true
 # recommended, cdn used to access assets
 cdn_url =
 
-# comma delimited list of emails that have devloper level access
+# comma delimited list of emails that have developer level access
 developer_emails =
 
 # redis server address
@@ -82,3 +82,7 @@ redis_db = 0
 
 # redis password
 redis_password =
+
+# enable Cross-origin Resource Sharing (CORS) directly at the application level
+enable_cors = false
+cors_origin = '*'

--- a/config/initializers/08-rack-cors.rb
+++ b/config/initializers/08-rack-cors.rb
@@ -1,13 +1,10 @@
-if Rails.configuration.respond_to?(:enable_rack_cors) && Rails.configuration.enable_rack_cors
+if GlobalSetting.enable_cors
   require 'rack/cors'
-
-  cors_origins  = Rails.configuration.respond_to?(:rack_cors_origins) ? Rails.configuration.rack_cors_origins : ['*']
-  cors_resource = Rails.configuration.respond_to?(:rack_cors_resource) ? Rails.configuration.rack_cors_resource : ['*', { headers: :any, methods: [:get, :post, :options] }]
 
   Rails.configuration.middleware.use Rack::Cors do
     allow do
-      origins *cors_origins
-      resource *cors_resource
+      origins GlobalSetting.cors_origin
+      resource '*', headers: :any, methods: [:get, :post, :options]
     end
   end
 end


### PR DESCRIPTION
Hi,

first I would like to say that I understand that it's possible to control CORS using a front webserver like nginx/apache.

But I think that rack-cors should stay available in Discourse as it is a convenient way to enable CORS without changing its webserver config, when using only a simple webserver like thin in dev mode, and/or for simple use-cases.

As GlobalSetting is now the preferred way to set the global configuration, I've just switched the initializer to use it. Thanks.
