### PR TITLE
FIX: restore category when opening draft

### DIFF
--- a/app/assets/javascripts/discourse/controllers/composer_controller.js
+++ b/app/assets/javascripts/discourse/controllers/composer_controller.js
@@ -306,8 +306,10 @@ Discourse.ComposerController = Discourse.Controller.extend({
       }
     }
 
-    composer = composer || Discourse.Composer.create();
-    composer.open(opts);
+    if ( !composer ) {
+      composer = Discourse.Composer.create();
+      composer.open(opts);
+    }
 
     this.set('model', composer);
     composer.set('composeState', Discourse.Composer.OPEN);


### PR DESCRIPTION
This is a fix for the issue described in this [bug on meta-discourse](https://meta.discourse.org/t/new-topic-category-not-saved-as-part-of-draft/12277).

CategoryId exists in the composer after this line:
`composer = Discourse.Composer.loadDraft(opts.draftKey, opts.draftSequence, opts.draft);` because `loadDraft` makes a call to `#open`, loading the category. 

However, the second call to `composer.open(opts);` resets `composer`, this time without a category, because the opts hash doesn't directly contain a categoryId (it is nested inside of `opts.draft`).

Please provide any feedback! Another option I see would be pushing the logic from `.loadDraft` into `#open` and removing `.loadDraft` so we can make a single call. If that is a better option, let me know and I can give it a shot.
