### PR TITLE
Rebundle after Gemfile change (omniauth-cas)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -250,10 +250,6 @@ GEM
     omniauth (1.1.4)
       hashie (>= 1.2, < 3)
       rack
-    omniauth-cas (1.0.4)
-      addressable (~> 2.3)
-      nokogiri (~> 1.6)
-      omniauth (~> 1.1.0)
     omniauth-facebook (1.5.1)
       omniauth-oauth2 (~> 1.1.0)
     omniauth-github (1.1.1)
@@ -495,7 +491,6 @@ DEPENDENCIES
   oj
   omniauth
   omniauth-browserid!
-  omniauth-cas
   omniauth-facebook
   omniauth-github
   omniauth-oauth2

--- a/Gemfile_rails4.lock
+++ b/Gemfile_rails4.lock
@@ -196,10 +196,6 @@ GEM
     omniauth (1.1.4)
       hashie (>= 1.2, < 3)
       rack
-    omniauth-cas (1.0.4)
-      addressable (~> 2.3)
-      nokogiri (~> 1.6)
-      omniauth (~> 1.1.0)
     omniauth-facebook (1.4.1)
       omniauth-oauth2 (~> 1.1.0)
     omniauth-github (1.1.1)
@@ -430,7 +426,6 @@ DEPENDENCIES
   nokogiri
   oj
   omniauth
-  omniauth-cas
   omniauth-facebook
   omniauth-github
   omniauth-oauth2

--- a/Gemfile_rails_master.lock
+++ b/Gemfile_rails_master.lock
@@ -223,10 +223,6 @@ GEM
     omniauth (1.1.4)
       hashie (>= 1.2, < 3)
       rack
-    omniauth-cas (1.0.4)
-      addressable (~> 2.3)
-      nokogiri (~> 1.6)
-      omniauth (~> 1.1.0)
     omniauth-facebook (1.4.1)
       omniauth-oauth2 (~> 1.1.0)
     omniauth-github (1.1.1)
@@ -445,7 +441,6 @@ DEPENDENCIES
   nokogiri
   oj
   omniauth
-  omniauth-cas
   omniauth-facebook
   omniauth-github
   omniauth-oauth2


### PR DESCRIPTION
This fixes regression brought on by
f1e8bdaee54b16070ac97bbaf88f9f5bfff2f57a.

I couldn't redeploy on my node anymore:

```
I, [2014-02-13T06:41:52.107873 #38]  INFO -- : > cd /var/www/discourse && sudo -E -u discourse bundle install --deployment --verbose --without test --without development
I, [2014-02-13T06:41:52.791870 #38]  INFO -- : You are trying to install in deployment mode after changing
your Gemfile. Run `bundle install` elsewhere and add the
updated Gemfile.lock to version control.

You have deleted from the Gemfile:
* omniauth-cas
Bundler::ProductionError: You are trying to install in deployment mode after changing
your Gemfile. Run `bundle install` elsewhere and add the
updated Gemfile.lock to version control.

You have deleted from the Gemfile:
* omniauth-cas

/usr/local/lib/ruby/gems/2.0.0/gems/bundler-1.3.5/lib/bundler/definition.rb:342:in `ensure_equivalent_gemfile_and_lockfile'
/usr/local/lib/ruby/gems/2.0.0/gems/bundler-1.3.5/lib/bundler/installer.rb:59:in `run'
/usr/local/lib/ruby/gems/2.0.0/gems/bundler-1.3.5/lib/bundler/installer.rb:14:in `install'
/usr/local/lib/ruby/gems/2.0.0/gems/bundler-1.3.5/lib/bundler/cli.rb:247:in `install'
/usr/local/lib/ruby/gems/2.0.0/gems/bundler-1.3.5/lib/bundler/vendor/thor/task.rb:27:in `run'
/usr/local/lib/ruby/gems/2.0.0/gems/bundler-1.3.5/lib/bundler/vendor/thor/invocation.rb:120:in `invoke_task'
/usr/local/lib/ruby/gems/2.0.0/gems/bundler-1.3.5/lib/bundler/vendor/thor.rb:344:in `dispatch'
/usr/local/lib/ruby/gems/2.0.0/gems/bundler-1.3.5/lib/bundler/vendor/thor/base.rb:434:in `start'
/usr/local/lib/ruby/gems/2.0.0/gems/bundler-1.3.5/bin/bundle:20:in `block in <top (required)>'
/usr/local/lib/ruby/gems/2.0.0/gems/bundler-1.3.5/lib/bundler/friendly_errors.rb:3:in `with_friendly_errors'
/usr/local/lib/ruby/gems/2.0.0/gems/bundler-1.3.5/bin/bundle:20:in `<top (required)>'
/usr/local/bin/bundle:23:in `load'
/usr/local/bin/bundle:23:in `<main>'

2014-02-13 06:41:52 UTC LOG:  received smart shutdown request
```
