### PR TITLE
Add Private Message count to User Dropdown

### DIFF
--- a/app/assets/javascripts/discourse/templates/user_dropdown.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/user_dropdown.js.handlebars
@@ -4,7 +4,11 @@
     {{#if showAdminLinks}}
       <li>{{#link-to 'adminUser' currentUser.username }}{{i18n admin_title}}{{/link-to}}</li>
     {{/if}}
-    <li>{{#link-to 'userPrivateMessages.index' currentUser}}{{i18n user.private_messages}}{{/link-to}}</li>
+    <li>
+    {{#link-to 'userPrivateMessages.index' currentUser class='user-messages-link'}}
+      {{i18n user.unread_message_count count=currentUser.unread_private_messages}}
+    {{/link-to}}
+    </li>
     <li>{{#link-to 'preferences' currentUser}}{{i18n user.preferences}}{{/link-to}}</li>
     <li><button {{action "logout"}} class='btn btn-danger right logout'><i class='fa fa-sign-out'></i>{{i18n user.log_out}}</button></li>
   </ul>

--- a/app/assets/stylesheets/desktop/header.scss
+++ b/app/assets/stylesheets/desktop/header.scss
@@ -239,7 +239,7 @@
   }
 
   &#user-dropdown {
-    width: 154px;
+    width: 155px;
   }
 
   .btn {

--- a/app/assets/stylesheets/mobile/header.scss
+++ b/app/assets/stylesheets/mobile/header.scss
@@ -241,7 +241,7 @@
   }
 
   &#user-dropdown {
-    width: 154px;
+    width: 155px;
   }
 
   .btn {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -256,6 +256,10 @@ en:
       delete_account_confirm: "Are you sure you want to permanently delete your account? This action cannot be undone!"
       deleted_yourself: "Your account has been deleted successfully."
       delete_yourself_not_allowed: "You cannot delete your account right now. Contact an admin to do delete your account for you."
+      unread_message_count:
+        one: "Messages (1)"
+        other: "Messages ({{count}})"
+        zero: "Messages"
 
       messages:
         all: "All"


### PR DESCRIPTION
This adds an unread message count to the user dropdown, suggested in Sam's comment https://github.com/discourse/discourse/pull/1937#issuecomment-34951738  

_User with 2 unread private messages:_
![image](https://f.cloud.github.com/assets/3401659/2164193/af1e5714-94e8-11e3-9a78-1b9413ea9dd1.png)

_User has no unread PMs:_
![image](https://f.cloud.github.com/assets/3401659/2164159/32b3239e-94e8-11e3-91c5-28881d0ad6d9.png)

I also considered using {{i18n user.messages.unread}} so it would display (in English): "Messages (2 Unread)", but I'm not sure if that would translate cleanly. Let me know if we should user that or some other alternative wording.
