### PR TITLE
removing any :focus and/or outline definition

### DIFF
--- a/app/assets/stylesheets/common/components/buttons.css.scss
+++ b/app/assets/stylesheets/common/components/buttons.css.scss
@@ -8,13 +8,8 @@
 // Base
 // --------------------------------------------------
 
-button {
-  outline: 0;
-}
-
 .btn {
   display: inline-block;
-  outline: 0;
   margin: 0;
   padding: 6px 12px;
   font-weight: 500;

--- a/app/assets/stylesheets/common/foundation/base.scss
+++ b/app/assets/stylesheets/common/foundation/base.scss
@@ -26,9 +26,6 @@ a {
   &:hover {
     color: $link-color-hover;
   }
-  &:focus {
-    outline: 0;
-  }
   &:active {
     color: $link-color-active;
   }

--- a/app/assets/stylesheets/desktop/discourse.scss
+++ b/app/assets/stylesheets/desktop/discourse.scss
@@ -423,18 +423,9 @@ body {
       height: auto;
     }
     &:focus {
-      outline: thin dotted $primary;
-      outline: 5px auto -webkit-focus-ring-color;
-      outline-offset: -2px;
     }
   }
-  input {
-    &[type="file"]:focus, &[type="radio"]:focus, &[type="checkbox"]:focus {
-      outline: thin dotted $primary;
-      outline: 5px auto -webkit-focus-ring-color;
-      outline-offset: -2px;
-    }
-  }
+ 
   .radio, .checkbox {
     min-height: 18px;
     padding-left: 18px;

--- a/app/assets/stylesheets/desktop/magnific-popup.scss
+++ b/app/assets/stylesheets/desktop/magnific-popup.scss
@@ -256,7 +256,6 @@ button {
     border: 0;
     -webkit-appearance: none;
     display: block;
-    outline: none;
     padding: 0;
     z-index: $z-index-base + 6;
     -webkit-box-shadow: none;

--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -147,7 +147,6 @@ nav.post-controls {
     border: none;
     margin-left: 3px;
     transition: all linear 0.15s;
-    outline: none;
          &:hover {
           background: lighten($primary_light, 20%);
           color: $primary_medium;
@@ -803,7 +802,6 @@ button.show-replies {
 
 .btn-group .dropdown-toggle:active,
 .btn-group.open .dropdown-toggle {
-  outline: 0;
 }
 
 .dropdown {
@@ -814,7 +812,6 @@ button.show-replies {
 }
 .dropdown-toggle:active,
 .open .dropdown-toggle {
-  outline: 0;
 }
 .caret {
   display: inline-block;

--- a/app/assets/stylesheets/vendor/normalize.css
+++ b/app/assets/stylesheets/vendor/normalize.css
@@ -78,15 +78,6 @@ body {
 /* ==========================================================================
    Links
    ========================================================================== */
-
-/**
- * Address `outline` inconsistency between Chrome and other browsers.
- */
-
-a:focus {
-    outline: thin dotted;
-}
-
 /**
  * Improve readability when focused and also mouse hovered in all browsers.
  */


### PR DESCRIPTION
This allows :focus from keyboard navigation to fall back on browser styles

:snowflake: 
