### PR TITLE
Removing more stuff from the sanitizer whitelist

### DIFF
--- a/app/assets/javascripts/defer/html-sanitizer-bundle.js
+++ b/app/assets/javascripts/defer/html-sanitizer-bundle.js
@@ -916,6 +916,7 @@ html4.ELEMENTS = {
   'abbr': 0,
   'acronym': 0,
   'address': 0,
+  'article': 0,
   'aside': 0,
   'b': 0,
   'base': 274,


### PR DESCRIPTION
- Remove everything related to forms
- Remove stuff related to making certain parts of an image clickable

I found some cool stuff that I liked, though:
`<details>` makes a collapsible section - keep! (although it appears to be webkit-only right now :frowning: )
`<progress>` and `<meter>` (screenshot: ![image](https://f.cloud.github.com/assets/627891/2168110/4fee2f0c-952f-11e3-8353-829aaae76ca1.png) ![image](https://f.cloud.github.com/assets/627891/2168112/55aa310c-952f-11e3-939a-d345af19e8d6.png)) should be restyled
