### PR TITLE
Added category object to topic list item

### DIFF
--- a/app/serializers/topic_list_item_serializer.rb
+++ b/app/serializers/topic_list_item_serializer.rb
@@ -9,6 +9,8 @@ class TopicListItemSerializer < ListableTopicSerializer
              :category_id
 
   has_many :posters, serializer: TopicPosterSerializer, embed: :objects
+  
+  has_one :category, serializer: BasicCategorySerializer, embed: :object
 
   def starred
     object.user_data.starred?


### PR DESCRIPTION
[Reference Topic](https://meta.discourse.org/t/subcategories-in-categories-json/11445)
Although not exactly the same thing that I was trying to describe, it solves the same problem.

Basically, when using the API to make an app or 'widget', you'll probably want to call to /latest.json to retrieve the latest topics to display. That's all fine until you need to display the category data along side the post data (name and colours), which means that you would need to call to /categories.json as well to fetch the list of categories and their info. This is 'alright', but as soon as you start encountering subcategories which _aren't_ in the categories.json response then this method starts getting a little convoluted (one of the only solutions is to call to the category's show endpoint, which creates an even further mess).

I'm trying to remedy this by adding a category object to each topic, which includes all the needed information, and thus eliminating the need for more than one call just to get a list of topics. 
