### PR TITLE
Don't render 'Reply' button when user can't post

### DIFF
--- a/app/assets/javascripts/discourse/views/buttons/reply_button.js
+++ b/app/assets/javascripts/discourse/views/buttons/reply_button.js
@@ -8,9 +8,7 @@
 **/
 Discourse.ReplyButton = Discourse.ButtonView.extend({
   classNames: ['btn', 'btn-primary', 'create'],
-  attributeBindings: ['disabled'],
   helpKey: 'topic.reply.help',
-  disabled: Em.computed.not('controller.model.details.can_create_post'),
 
   text: function() {
     var archetypeCapitalized = this.get('controller.content.archetype').capitalize();

--- a/app/assets/javascripts/discourse/views/topic_footer_buttons_view.js
+++ b/app/assets/javascripts/discourse/views/topic_footer_buttons_view.js
@@ -31,7 +31,9 @@ Discourse.TopicFooterButtonsView = Discourse.ContainerView.extend({
           this.attachViewClass(Discourse.FlagTopicButton);
         }
       }
-      this.attachViewClass(Discourse.ReplyButton);
+      if (this.get('topic.details.can_create_post')) {
+        this.attachViewClass(Discourse.ReplyButton);
+      }
       this.attachViewClass(Discourse.NotificationsButton);
 
       this.trigger('additionalButtons', this);


### PR DESCRIPTION
This removes the 'Reply' button from the topic footer when a user cannot post a reply. See [conversation on meta](https://meta.discourse.org/t/closed-topics-should-change-the-hovertext-of-reply-button/10970/5).

![image](https://f.cloud.github.com/assets/3401659/2174162/28799ba0-95ac-11e3-95c9-cd6bdbdec076.png)
