### PR TITLE
Added and updated Spanish translations

### DIFF
--- a/config/locales/client.es.yml
+++ b/config/locales/client.es.yml
@@ -127,6 +127,16 @@ es:
     saving: "Guardando..."
     saved: "¡Guardado!"
 
+    upload: "Subir"
+    uploading: "Subiendo..."
+    uploaded: "Subido!"
+
+    choose_topic:
+      none_found: "Ningún tema encontrado."
+      title:
+        search: "Buscar un Tema por nombre, url o id:"
+        placeholder: "escribe el título de tema aquí"
+
     user_action:
       user_posted_topic: "<a href='{{userUrl}}'>{{user}}</a> publicó <a href='{{topicUrl}}'>el tema</a>"
       you_posted_topic: "<a href='{{userUrl}}'>Tú</a> publicaste <a href='{{topicUrl}}'>el tema</a>"
@@ -160,20 +170,31 @@ es:
 
     user_action_descriptions:
       "6": "Respuestas"
-      
+
     categories:
       all: "Todas las categorías"
-      only_category: "Solo {{categoryName}}"
+      all_subcategories: "Todas las subcategorías"
+      no_subcategory: "Ninguna categoría"
       category: "Categoría"
       posts: "Posts"
       topics: "Temas"
       latest: "Últimos"
       latest_by: "último por"
       toggle_ordering: "activar ordenamiento"
-      subcategories: "Subcategorías:"
+      subcategories: "Subcategorías"
+      topic_stats: "El número de temas nuevos."
+      topic_stat_sentence:
+        one: "%{count} tema nuevo en los pasados %{unit}."
+        other: "%{count} temas nuevos en los pasados %{unit}."
+      post_stats: "El número de comentarios nuevos"
+      post_stat_sentence:
+        one: "%{count} nuevo comentario en los pasados %{unit}"
+        other: "%{count} nuevos comentarios en los pasados %{unit}"
 
     user:
+      said: "{{username}} dice:"
       profile: Perfil
+      show_profile: "Visitar perfil"
       title: "Usuario"
       mute: Silenciar
       edit: Editar Preferencias
@@ -183,11 +204,24 @@ es:
       activity_stream: "Actividad"
       preferences: "Preferencias"
       bio: "Acerca de mí"
-      change_password: "cambiar"
       invited_by: "Invitado por"
       trust_level: "Nivel de Confianza"
+      notifications: "Notificaciones"
+      dynamic_favicon: "Mostrar notificaciones de mensajes de entrada en favicon (experimental)"
       external_links_in_new_tab: "Abrir todos los links externos en una nueva pestaña"
       enable_quoting: "Activar respuesta citando el texto resaltado"
+      change: "cambio"
+      moderator: "{{user} es un moderador"
+      deleted: "(borrado)"
+      suspended_notice: "Este usuario ha sido suspendido hasta {{date}}."
+      suspended_reason: "Causa: "
+      mailing_list_mode: "Recibe un email cada vez que se crea un nuevo post en el forum (a menos que el tema o categoría esté silenciado)"
+      watched_categories: "Haciendo visto"
+      watched_categories_instructions: "El mismo que Tracking, además serás notificado de todas las publicaciones y temas nuevos."
+      tracked_categories: "Rastreado"
+      tracked_categories_instructions: "Automáticamente estarás suscrito a todos los temas nuevos y existentes, manteniéndote informado sobre el número de publicaciones nuevas y no leídas"
+      muted_categories: "Silenciado"
+      muted_categories_instructions: "No recibirás nada sobre este tema, y no aparecerá en tu pestaña de no leídos."
 
       messages:
         all: "Todos"
@@ -195,10 +229,14 @@ es:
         unread: "No leídos"
 
       change_password:
-        action: "cambiar"
         success: "(email enviado)"
         in_progress: "(enviando email)"
         error: "(error)"
+        action: "cambiar"
+        set_password: "Configurar Contraseña"
+
+      change_about:
+        title: "Cambiar 'Acerca de Mí'"
 
       change_username:
         action: "cambiar"
@@ -207,12 +245,22 @@ es:
         taken: "Lo sentimos, pero este nombre de usuario no está disponible."
         error: "Ha ocurrido un error al cambiar tu nombre de usuario."
         invalid: "Este nombre de usuario no es válido. Debe incluir sólo números y letras"
+
       change_email:
         action: 'cambiar'
         title: "Cambiar Email"
         taken: "Lo sentimos, pero este email no está disponible."
         error: "Ha ocurrido un error al cambiar tu email. ¿Tal vez esa dirección ya está en uso?"
         success: "Te hemos enviado un email a esa dirección. Por favor sigue las instrucciones de confirmación."
+
+      change_avatar:
+        title: "Cambiar tu avatar"
+        gravatar: "<a href='//gravatar.com/emails' target='_blank'>Gravatar</a>, basado en"
+        gravatar_title: "Cambiar tu avatar en la página de Gravatar"
+        uploaded_avatar: "Foto personalizada"
+        uploaded_avatar_empty: "Añade una foto personalizada"
+        upload_title: "Sube tu foto"
+        image_is_not_a_square: "Peligro: hemos recortado su foto; no es cuadrada."
 
       email:
         title: "Email"
@@ -284,29 +332,38 @@ es:
           other: "después de {{count}} minutos"
 
       invited:
+        search: "escribe para buscar invitaciones..."
         title: "Invitaciones"
         user: "Invitar Usuario"
-        none: "{{username}} no ha invitado a ningún usuario al sitio."
+        none: "Ningún usuario ha sido invitado al sitio."
+        truncated: "Mostrando las primeras {{count}} invitaciones."
         redeemed: "Invitaciones aceptadas"
         redeemed_at: "Aceptada el"
         pending: "Invitaciones pendientes"
         topics_entered: "temas vistos"
         posts_read_count: "Publicaciones leídas"
+        expired: "Esta invitación ha vencido."
         rescind: "Eliminar invitación"
         rescinded: "Invitación eliminada"
         time_read: "Tiempo de lectura"
         days_visited: "Días visitados"
         account_age_days: "Antigüedad de la cuenta en días"
+        create: "Invitar Amigos a este foro"
 
       password:
         title: "Contraseña"
         too_short: "Tu contraseña es muy corta."
+        common: "Esa contraseña es muy común."
         ok: "Tu contraseña es valida."
+        instructions: "Debe tener por lo menos %{count} caracteres."
 
       ip_address:
         title: "Última dirección IP"
       avatar:
         title: "Avatar"
+      title:
+        title: "Título"
+
       filters:
         all: "Todos"
 
@@ -326,6 +383,7 @@ es:
     month_desc: 'temas publicados en los últimos 30 días'
     week: 'semana'
     week_desc: 'temas publicados en los últimos 7 días'
+    day: 'día'
 
     first_post: Primera publicación
     mute: Silenciar
@@ -444,7 +502,7 @@ es:
       undo_title: "Deshacer"
       redo_title: "Rehacer"
       help: "Ayuda de edición Markdown"
-      
+
       admin_options_title: "Opciones de moderación para este tema"
       auto_close_label: "Hora de auto-cierre:"
       auto_close_units: "(# de horas, una fecha, o marca de tiempo)"
@@ -540,7 +598,7 @@ es:
       options: "Opciones del tema"
       show_links: "mostrar enlaces dentro de este tema"
       toggle_information: "detalles del tema"
-      read_more_in_category: "Quieres leer mas? Consulta otros temas en {{catLink}} or {{latestLink}}."
+      read_more_in_category: "Quieres leer más? Consulta otros temas en {{catLink}} or {{latestLink}}."
       read_more: "¿Quieres seguir leyendo? {{catLink}} or {{latestLink}}."
       browse_all_categories: Ver todas las categorías
       auto_close_save: "Guardar"
@@ -628,7 +686,7 @@ es:
         help: 'enviar invitaciones a tus amigos para que puedan responder a este tema con un solo click'
         email: "Le enviaremos a tu amigo un breve email permitiéndole responder a este tema haciendo click en un enlace."
         email_placeholder: 'dirección de email'
-        success: "¡Gracias! Hemos enviado una invitación a <b>{{email}}</b>. Te avisaremos cuando acepte su invitación. Verifica la pestaña de invitaciones en tu pagina de usuario para llevar un registro de quién has invitado."
+        success: "¡Gracias! Hemos enviado una invitación a <b>{{email}}</b>. Te avisaremos cuando acepte su invitación. Verifica la pestaña de invitaciones en tu página de usuario para llevar un registro de quién has invitado."
         error: "Lo sentimos, no podemos invitar a esa persona. ¿Tal vez ya es un usuario?"
 
       login_reply: 'Inicia sesión para responder'
@@ -785,10 +843,14 @@ es:
     categories_list: "Lista de categorías"
 
     filters:
-      with_topics: "Temas %{filter}"
+      with_topics: "Temas de %{filter}"
+      with_category: "Temas de %{filter} %{category}"
       latest:
-        title: "Populares"
-        help: "los temas más recientes más populares"
+        title: "Los Más Recientes"
+        help: "los temas con publicaciones más recientes"
+      hot:
+        title: "Popular"
+        help: "una selección de los temas más populares"
       starred:
         title: "Favoritos"
         help: "temas que has marcado como favoritos"
@@ -820,36 +882,64 @@ es:
           one: "{{categoryName}} (1)"
           other: "{{categoryName}} ({{count}})"
         help: "últimos temas en el {{categoryName}} categoría"
+      top:
+        title: "De Los Mejores Temas"
+        help: "una selección de los temas más populares en el último año, mes, semana, o día"
+        yearly:
+          title: "De Los Mejores Temas del Año"
+        monthly:
+          title: "De Los Mejores Temas del Mes"
+        weekly:
+          title: "De Los Mejores Temas de la Semana"
+        daily:
+          title: "De Los Mejores Temas del Día"
+        this_year: "Este año"
+        this_month: "Este mes"
+        this week: "Esta semana"
+        today: "Hoy"
+        other_periods: "ver más de los mejores temas"
+        redirect_reasons:
+          new_user: "Bienvenido! Como un visitante nuevo, esta debería ser tu página de início hasta que hayas tenido tiempo para explorar el foro. Aquí tienes algunos de los temas más populares del pasado."
+          not_seen_in_a_month: "Bienvenido de vuelta! No te hemos visto en algún tiempo. Estas son los temas de discusión más populares desde la última vez que nos visitaste."
+
+    browser_update: 'Desafortunadamente, <a href="http://www.discourse.org/faq/#browser">tu navegador es demasiado viejo para funcionar en este foro de Discourse</a>. Por favor <a href="http://browsehappy.com">actualiza tu navegador</a>.'
+
+    permission_types:
+      full: "Crear / Responder / Ver"
+      create_post: "Responder / Ver"
+      readonly: "Ver"
 
   # This section is exported to the javascript for i18n in the admin section
   admin_js:
-    type_to_filter: "Tipea para filtrar..."
+    type_to_filter: "categorías a ser filtradas..."
 
     admin:
-      title: 'Administrador'
+      title: 'Administrador de Discourse'
+      moderator: 'Moderador'
 
       dashboard:
         title: "Panel"
-        last_updated: "Última actualización del panel:"
-        version: "Versión"
+        last_updated: 'Panel actualizado el:'
+        version: "Versión instalada"
         up_to_date: "Está ejecutando la última versión de Discourse."
         critical_available: "Actualización crítica disponible."
         updates_available: "Hay actualizaciones disponibles."
-        please_upgrade: "Por favor actualice!"
-        no_check_performed: "No se han comprobado actualizaciones. Asegúrate que Sidekiq está corriendo."
-        stale_data: "No se han comprobado actualizaciones últimamente. Asegúrate que Sidekiq está corriendo."
+        please_upgrade: "Por favor actualiza!"
+        no_check_performed: "A check for updates has not been performed. Ensure sidekiq is running."
+        no_check_performed: "Una revisión de actualizaciones no ha sido realizada aún. Asegúrate de que sidekiq está funcionando."
+        stale_data: "Una revisión de actualizaciones no ha sido realizada recientemente. Asegúrate de que sidekiq está funcionando."
         version_check_pending: "Parece que has actualizado recientemente. Fantástico!"
-        installed_version: "Versión instalada"
+        installed_version: "Instalado"
         latest_version: "Última versión"
-        problems_found: "Se han encontrado algunos problemas con tu instalación de Discourse:"
+        problems_found: "Algunos problemas han sido encontrados en tu instalación de Discourse"
+        last_checked: "Ultima vez revisado"
         refresh_problems: "Refrescar"
-        last_checked: "Última comprobación"
-        no_problems: "No se han encontrado problemas."
-        moderators: 'Moderadores:'
-        admins: 'Administradores:'
-        blocked: 'Bloqueados:'
-        suspended: 'Suspendidos:'
-        private_messages_short: "MPs"
+        no_problems: "Ningun problema ha sido encontrado."
+        moderators: "Moderadores:"
+        admins: "Administradores:"
+        blocked: "Bloqueado:"
+        suspended: "Suspendido:"
+        private_messages_short: "PMs"
         private_messages_title: "Mensajes Privados"
 
         reports:
@@ -860,20 +950,57 @@ es:
           all_time: "Todo el tiempo"
           7_days_ago: "Hace 7 Días"
           30_days_ago: "Hace 30 Días"
-          7_days_ago: "Hace 7 Días"
-          30_days_ago: "Hace 30 Días"
-          all: "Todos"
-          view_table: "Ver como Tabla"
-          view_chart: "Ver como Gráfico de Barras"
+          all: "Todo"
+          view_table: "Ver como tabla"
+          view_chart: "Ver como grafico de tablas"
 
       commits:
-        latest_changes: "Últimos cambios: por favor actualiza a menudo!"
+        latest_changes: "Ultimos cambios: por favor actualiza más a menudo!"
         by: "por"
 
       flags:
         title: "Banderas"
         old: "Antiguo"
         active: "Activo"
+
+        agree_hide: "Aceptar (esconder comentatio + enviar PM)"
+        agree_hide_title: "Hide this post and automatically send the user a private message urging them to edit it"
+        defer: "Defer"
+        defer_title: "No action is necessary at this time, defer any action on this flag until a later date, or never"
+        delete_post: "Delete Post"
+        delete_post_title: "Delete post; if the first post, delete the topic"
+        disagree_unhide: "Disagree (unhide post)"
+        disagree_unhide_title: "Remove any flags from this post and make the post visible again"
+        disagree: "Disagree"
+        disagree_title: "Disagree with flag, remove any flags from this post"
+        delete_spammer_title: "Delete the user and all its posts and topics."
+        clear_topic_flags: "Done"
+        clear_topic_flags_title: "The topic has been investigated and issues have been resolved. Click Done to remove the flags."
+
+        flagged_by: "Reportado por"
+        system: "Sistema"
+        error: "Algo falló"
+        view_message: "Responder"
+        no_results: "No hay ningún reporte."
+        topic_flagged: "Este <strong>tema</strong> ha sido reportado."
+        visit_topic: "Visita el tema para investigar y tomar acción."
+
+        summary:
+          action_type_3:
+            one: "no relacionado al tema"
+            other: "no relacionado al tema x{{count}}"
+          action_type_4:
+            one: "inapropriado"
+            other: "inapropriado x{{count}}"
+          action_type_6:
+            one: "a medida"
+            other: "a medida x{{count}}"
+          action_type_7:
+            one: "a medida"
+            other: "a medida x{{count}}"
+          action_type_8:
+            one: "spam"
+            other: "spam x{{count}}"
 
         agree_hide: "De acuerdo (ocultar + enviar MP)"
         agree_hide_title: "Ocultar este mensaje y automáticamente enviar al usuario un mensaje privado instándolo a editarlo"
@@ -914,32 +1041,78 @@ es:
             one: "spam"
             other: "spam x{{count}}"
       groups:
-        primary: "Grupo Principal"
-        no_primary: "(No hay un grupo principal)"
+        primary: "Grupo Primario"
+        no_primary: "(ningún grupo primario)"
         title: "Grupos"
         edit: "Editar Grupos"
-        selector_placeholder: "Agregar usuarios"
-        name_placeholder: "Nombre del grupo, sin espacios"
-        about: "Edita tus membresías a grupos y nombres aquí"
-        delete: "Eliminar"
-        delete_confirm: "Eliminar este grupo?"
-        delete_failed: "Imposible eliminar grupo. Si éste es un grupo automático, no puede ser destruido."
+        selector_placeholder: "añadir usuarios"
+        name_placeholder: "Nombre del grupo, sin espacios, al igual que la regla del nombre usuario"
+        about: "Editar tu membresía de grupo y nombres aquí"
+        delete: "Borrar"
+        delete_confirm: "Borrar este grupo?"
+        delete_failed: "No se pudo borrar el grupo. Si este es un grupo automático, no se puede destruir."
 
       api:
-        generate_master: "Generar API Key Maestra"
-        none: "No hay ninguna API Key activa en este momento."
+        generate_master: "Generar Clave Maestra de API"
+        none: "No hay ninguna clave de API activa en este momento."
         user: "Usuario"
         title: "API"
-        long_title: "API Information"
-        key: "Key"
-        generate: "Generar"
-        regenerate: "Regenerar"
+        key: "Clave de API"
+        generate: "Generar Clave de API"
+        regenerate: "Regenerar Clave de API"
         revoke: "Revocar"
-        confirm_regen: "Seguro que deseas reemplazar esa API Key por una nueva?"
-        confirm_revoke: "Seguro que deseas revocar esa API Key?"
-        info_html: "Tu API Key te permitirá crear y actualizar temas usando llamadas JSON."
-        all_users: "Todos los Usuarios"
-        note_html: "Mantén esta Key en <strong>secreto</strong>, cualquier usuario que la tenga podría crear mensajes arbitrarios en el foro como cualquier otro usuario."
+        confirm_regen: "Estás seguro que quieres reemplazar esa Clave de API con una nueva?"
+        confirm_revoke: "Estás seguro que quieres revocar esa clave?"
+        info_html: "Tu clave de API te permitirá crear y actualizar temas usando llamadas a JSON."
+        all_users: "Todos Los Usuarios"
+        note_html: "Keep this key <strong>secret</strong>, all users that have it may create arbitrary posts on the forum as any user."
+
+      backups:
+        title: "Respaldos"
+        menu:
+          backups: "Respaldos"
+          logs: "Registros"
+        none: "Ningún respaldo disponible."
+        read_only:
+          enable:
+            title: "Habilitar el modo de 'solo-lectura'"
+            text: "Habilitar el modo de 'solo-lectura'"
+            confirm: "Estás seguro que quieres habilitar el modo de 'solo-lectura'?"
+          disable:
+            title: "Deshabilitar el modo de 'solo-lectura'"
+            text: "Deshabilitar el modo de 'solo-lectura'"
+        logs:
+          none: "Ningún registro hasta ahora..."
+        columns:
+          filename: "Nombre de archivo"
+          size: "Tamaño"
+        operations:
+          is_running: "Actualmente una operación está corriendo..."
+          failed: "La {{operation}} falló. Por favor revisa tus registros."
+          cancel:
+            text: "Cancelar"
+            title: "Cancelar la operación actual"
+            confirm: "Estás seguro que quieres cancelar la operación actual?"
+          backup:
+            text: "Respaldo"
+            title: "Crear un respaldo"
+            confirm: "Estás seguro que quieres empezar un nuevo respaldo?"
+          download:
+            text: "Descargar"
+            title: "Descargar el respaldo"
+          destroy:
+            text: "Borrar"
+            title: "Remover el respaldo"
+            confirm: "Estás seguro que quieres borrar este respaldo?"
+          restore:
+            is_disabled: "Restaurar está deshabilitado en la configuración del sitio."
+            text: "Restaurar"
+            title: "Restaurar el respaldo"
+            confirm: "Estás seguro que quieres restaurar el respaldo?"
+          rollback:
+            text: "Deshacer"
+            title: "Regresar la base de datos al estado funcional anterior"
+            confirm: "Estás seguro que quieres regresar la base de datos al estado funcional anterior?"
 
       customize:
         title: "Personalizar"
@@ -976,10 +1149,10 @@ es:
         refresh: "Actualizar"
         format: "Formato"
         html: "html"
-        text: "text"
+        text: "texto"
         last_seen_user: "Último usuario visto:"
         reply_key: "Key de Respuesta"
-      
+
       logs:
         title: "Logs"
         action: "Acción"
@@ -997,47 +1170,47 @@ es:
           title: "Acciones del Staff"
           instructions: "Haz click en nombres de usuario y acciones para filtrar la lista. Haz click en los avatares para ir a las páginas del los usuarios."
           clear_filters: "Mostrar todo"
-          staff_user: "Usuario del Staff"
-          target_user: "Usuario Objetivo"
-          subject: "Asunto"
+          staff_user: "Usuario Administrador"
+          target_user: "Usuario Enfocado"
+          subject: "Sujeto"
           when: "Cuándo"
           context: "Contexto"
           details: "Detalles"
-          previous_value: "Previo"
+          previous_value: "Anterior"
           new_value: "Nuevo"
           diff: "Diff"
-          show: "Ver"
+          show: "Mostrar"
           modal_title: "Detalles"
-          no_previous: "No hay un valor anterior."
-          deleted: "No hay valores nuevos. El registro ha sido eliminado."
+          no_previous: "No existe un valor anterior."
+          deleted: "No hay un valor nuevo. El registro ha sido borrado."
           actions:
-            delete_user: "Eliminar usuario"
-            change_trust_level: "Cambiar nivel de confianza"
-            change_site_setting: "Cambiar ajuste del sitio"
-            change_site_customization: "Cambiar personalización del sitio"
-            delete_site_customization: "Eliminar personalización del sitio"
-            suspend_user: "Suspender usuario"
-            unsuspend_user: "Des-suspender usuario"
+            delete_user: "Borrar usuario"
+            change_trust_level: "cambiar nivel de confianza"
+            change_site_setting: "cambiar configuración del sitio"
+            change_site_customization: "cambiar customización del sitio"
+            delete_site_customization: "borrar customización del sitio"
+            suspend_user: "suspender usuario"
+            unsuspend_user: "desbloquear usuario"
         screened_emails:
-          title: "Emails filtrados"
-          description: "Cuando alguien trata de crear una nueva cuenta, las siguientes direcciones de correo electrónico serán comprobadas y el registro será bloqueado, o se realizará alguna otra acción."
-          email: "Dirección de email"
+          title: "Correos Bloqueados"
+          description: "Cuando alguien trata de crear una cuenta nueva, los siguientes correos serán revisados y el registro será bloqueado, o alguna otra acción será realizada."
+          email: "Correo Electrónico"
         screened_urls:
-          title: "URLs filtradas"
-          description: "Las URLs listadas aquí han sido usadas en mensajes por usuarios que han sido identificados como spammers."
+          title: "URLs Bloqueados"
+          description: "Los URLs listados aquí fueron usados en las publicaciones por los usuarios, quienes han sido identificados como spammers."
           url: "URL"
           domain: "Dominio"
         screened_ips:
-          title: "IPs Filtradas"
-          description: 'Direcciones IP que están siendo observadas. Usa "Permitir" to habilitar Direcciones IP.'
-          delete_confirm: "Estás seguro que deseas remover la regla para %{ip_address}?"
+          title: "IPs Bloqueados"
+          description: 'Direcciones IP que están siendo observadas. Usa "Permitir" para permitir direcciones IP.'
+          delete_confirm: "Estás seguro que quieres remover el bloqueo para %{ip_address}?"
           actions:
             block: "Bloquear"
             do_nothing: "Permitir"
           form:
             label: "Nueva:"
             ip_address: "Dirección IP"
-            add: "Agregar"
+            add: "Añadir"
 
       impersonate:
         title: "Impersonar Usuario"
@@ -1088,21 +1261,24 @@ es:
           other: "Error al rechazar %{count} usuarios."
 
       user:
-        suspend_failed: "Algo salió mal suspendiendo a este usuario {{error}}"
-        unsuspend_failed: "Algo salió mal quitando la suspensión a este usuario {{error}}"
-        suspend_duration: "Por cuánto tiempo estará este usuario suspendido?"
+        suspend_failed: "Algo salió mal baneando este usuario {{error}}"
+        unsuspend_failed: "Algo salió mal quitando ban a este usuario {{error}}"
+        suspend_duration: "¿Cuánto tiempo le gustaría aplicar ban al usuario? (days)"
         suspend_duration_units: "(días)"
-        suspend_reason_label: "¿Por qué estás suspendiendo? Este texto <b>será visible a todos </ b> en la página del perfil del usuario, y se muestra al usuario cuando intenta entrar. Sea breve."
-        suspend_reason: "Razón"
+        suspend_reason_label: "Por qué lo estás suspendiendo? Este texto <b>será visible para todos</b> en la página de perfil del usuario, y además será mostrado al usuario cuando trate de ingresar el sitio. Mantenlo simple."
+        suspend_reason: "Causa"
+        suspended_by: "Suspendido por"
         delete_all_posts: "Eliminar todos los mensajes"
-        delete_all_posts_confirm: "Estás a punto de eliminar %{posts} mensajes y %{topics} temas. Estás seguro?"
+        delete_all_posts_confirm: "Estás a punto de borrar %{posts} publicaciones y %{topics} temas. Estás seguro?"
         suspend: "Suspender"
-        unsuspend: "Quitar Suspensión"
-        suspended: "Suspendido?"
+        unsuspend: "Quitar ban"
+        suspended: "Baneado?"
         moderator: "Moderador?"
         admin: "Administrador?"
         blocked: "Bloqueado?"
         show_admin_profile: "Administrador"
+        edit_title: "Editar Título"
+        save_title: "Guardar Título"
         refresh_browsers: "Forzar recarga del navegador"
         show_public_profile: "Ver perfil público"
         impersonate: 'Impersonar a'
@@ -1115,7 +1291,7 @@ es:
         reputation: Reputación
         permissions: Permisos
         activity: Actividad
-        like_count: Me gusta Recibidos
+        like_count: Número de 'Me gusta' Recibidos
         private_topics_count: Temas Privados
         posts_read_count: Mensajes Leídos
         post_count: Mensajes Creados
@@ -1124,47 +1300,48 @@ es:
         flags_received_count: Reportes Recibidos
         approve: 'Aprobar'
         approved_by: "aprobado por"
-        approve_success: "Usuario aprobado y email enviado con instrucciones de activación."
+        approve_success: "Usuario aprobado y email enviado con instrucciones para la activación."
+        approve_bulk_success: "Exito! Todos los usuarios seleccionados han sido aprobados y notificados."
         time_read: "Tiempo de lectura"
-        delete: "Eliminar Usuario"
+        delete: "Borrar Usuario"
         delete_forbidden_because_staff: "Administradores y moderadores no pueden ser eliminados"
         delete_forbidden:
-          one: "Usuarios no pueden ser eliminados si se han registrado hace más de %{count} día, o si tienen mensajes. Elimina todos sus mensajes antes de eliminar un usuario."
-          other: "Usuarios no pueden ser eliminados si se han registrado hace más de %{count} días, o si tienen mensajes. Elimina todos sus mensajes antes de eliminar un usuario."
-        delete_confirm: "Estás SEGURO que deseas eliminar este usuario? Esta acción es permanente!"
-        delete_and_block: "<b>Sí</b>, y <b>bloquear</b> futuros registros de este email y dirección IP"
-        delete_dont_block: "<b>Sí</b>, sólo elimina este usuario"
-        deleted: "El usuario ha sido eliminado."
-        delete_failed: "Ocurrió un error al eliminar el usuario. Asegúrate que todos sus mensajes han sido eliminados antes de eliminar al usuario."
-        send_activation_email: "Enviar email de activación"
-        activation_email_sent: "Un email de activación ha sido enviado."
-        send_activation_email_failed: "Ocurrió un error al enviar el email de activación. %{error}"
+          one: "Los usuarios no se pueden borrar si han sido registrados hace más de %{count} día, o si tienen publicaciones. Borra todas publicaciones antes de tratar de borrar un usuario."
+          other: "Los usuarios no se pueden borrar si han sido registrados hace más de %{count} días, o si tienen publicaciones. Borra todas publicaciones antes de tratar de borrar un usuario."
+        delete_confirm: "Estás SEGURO que quieres borrar este usuario? Esta acción es permanente!"
+        delete_and_block: "<b>Sí</b>, y <b>bloquear</b> futuros registros de este correo y dirección IP"
+        delete_dont_block: "<b>Sí</b>, solamente borrar el usuario"
+        deleted: "El usuario fue borrado."
+        delete_failed: "Ha habido un error al borrar ese usuario. Asegúrate que todos las publicaciones han sido borrados antes de tratando de borrar este usuario."
+        send_activation_email: "Enviar Correo de Activación"
+        activation_email_sent: "Un correo de activación ha sido enviado."
+        send_activation_email_failed: "Ha habido un problema enviando otro correo de activación. %{error}"
         activate: "Activar Cuenta"
-        activate_failed: "Ocurrió un problema al activar el usuario."
-        deactivate_account: "Desactivar cuenta"
-        deactivate_failed: "Ocurrió un problema al desactivar el usuario."
-        unblock_failed: 'Ocurrió un problema al desbloquear el usuario.'
-        block_failed: 'Ocurrió un problema bloqueado al usuario.'
-        deactivate_explanation: "Un usuario desactivado debe revalidar su dirección de email."
-        suspended_explanation: "Un usuario suspendido no puede iniciar sesión."
-        block_explanation: "Un usuario bloqueado no puede publicar mensajes o crear temas."
-        trust_level_change_failed: "Ocurrió un problema cambiando el Nivel de Confianza del usuario."
+        activate_failed: "Ha habido un problem activando el usuario."
+        deactivate_account: "Desactivar Cuenta"
+        deactivate_failed: "Ha habido un problema desactivando el usuario."
+        unblock_failed: 'Ha habido un problema desbloqueando el usuario.'
+        block_failed: 'Ha habido un problema bloqueando el usuario.'
+        deactivate_explanation: "Un usuario desactivado debe rehabilitar su dirección de correo."
+        suspended_explanation: "Un usuario suspendido no puede ingresar al sitio."
+        block_explanation: "Un usuario bloqueado no puede crear publicaciones ni empezer temas."
+        trust_level_change_failed: "Ha habido un problema cambiando el nivel de confianza del usuario."
         suspend_modal_title: "Suspender Usuario"
-        trust_level_2_users: "Usuarios de Nivel de Confianza 2"
-        trust_level_3_requirements: "Requerimientos para Nivel de Confianza 3"
+        trust_level_2_users: "Usuarios del Nivel de Confianza 2"
+        trust_level_3_requirements: "Requerimientos para Nivel de confianza 3"
         tl3_requirements:
-          title: "Requerimientos para Nivel de Confianza 3"
+          title: "Requerimientos para el Nivel de Confianza 3"
           table_title: "En los últimos 100 días:"
           value_heading: "Valor"
           requirement_heading: "Requerimiento"
           visits: "Visitas"
           days: "días"
           topics_with_replies: "Temas con Respuestas"
-          topics_replied_to: "Temas Respondidos"
-          quality_content: "Calidad del Contenido"
+          topics_replied_to: "Temas Respondidos A"
+          quality_content: "Contenido de Calidad"
           reading: "Leyendo"
           site_promotion: "Promoción del Sitio"
-          flagged_posts: "Mensajes Reportados"
+          flagged_posts: "Publicaciones Marcadas"
 
       site_content:
         none: "Elige un tipo de contenido para empezar a editar."
@@ -1173,67 +1350,67 @@ es:
 
       site_settings:
         show_overriden: 'Sólo mostrar lo sobreescrito'
-        title: 'Ajustes'
-        reset: 'Reestablecer'
-        none: 'Ninguno'
-        no_results: "No hay resultados."
+        title: 'Ajustes del Sitio'
+        reset: 'Reestabler los ajustes por defecto'
+        none: 'ninguno'
+        no_results: "Ningun resultado encontrado"
         clear_filter: "Limpiar"
         categories:
-          all_results: 'Todos'
-          required: 'Requeridos'
-          basic: 'Config. Básica'
+          all_results: 'Todo'
+          required: 'Requerido'
+          basic: 'Setup Básico'
           users: 'Usuarios'
-          posting: 'Mensajes'
+          posting: 'Posteando'
           email: 'Email'
           files: 'Archivos'
-          trust: 'Niveles de Confianza'
+          trust: 'Niveles de confianza'
           security: 'Seguridad'
           seo: 'SEO'
           spam: 'Spam'
-          rate_limits: 'Límites'
+          rate_limits: 'Límites de velocidad'
           developer: 'Desarrollador'
           embedding: "Embebido"
           legal: "Legal"
-          uncategorized: 'Sin Categoría'
+          uncategorized: 'No clasificados'
 
-    lightbox:
-      download: "Descargar"
+          lightbox:
+            download: "descargar"
 
-    keyboard_shortcuts_help:
-      title: 'Atajos de Teclado (experimental)'
-      jump_to:
-        title: 'Ir A'
-        home: '<b>g</b> seguido de <b>h</b> Home (Recientes)'
-        latest: '<b>g</b> seguido de <b>l</b> Reciente'
-        new: '<b>g</b> seguido de <b>n</b> Nuevo'
-        unread: '<b>g</b> seguido de <b>u</b> No Leído'
-        starred: '<b>g</b> seguido de <b>f</b> Favoritos'
-        categories: '<b>g</b> seguido de <b>c</b> Categorías'
-      navigation:
-        title: 'Navegación'
-        back: '<b>u</b> Atrás'
-        up_down: '<b>k</b>/<b>j</b> Mover selección abajo/arriba'
-        open: '<b>o</b> o <b>Enter</b> Abrir tema seleccionado'
-        next_prev: '<b>`</b>/<b>~</b> Sección anterior/siguiente'
-      application:
-        title: 'Aplicación'
-        create: '<b>c</b> Crear tema nuevo'
-        notifications: '<b>n</b> Abrir notificaciones'
-        search: '<b>/</b> Buscar'
-        help: '<b>?</b> Abrir ayuda para atajos de teclado'
-      actions:
-        title: 'Acciones'
-        star: '<b>f</b> Añadir estrella al tema'
-        share_topic: '<b>s</b> Compartir tema'
-        share_post: '<b>shift s</b> Compartir mensaje'
-        reply_topic: '<b>r</b> Responder al tema'
-        reply_post: '<b>shift r</b> Responder al mensaje'
-        like: '<b>l</b> Me gusta el mensaje'
-        flag: '<b>!</b> Reportar mensaje'
-        bookmark: '<b>b</b> Añadir mensaje a marcadores'
-        edit: '<b>e</b> Editar mensaje'
-        delete: '<b>d</b> Eliminar mensaje'
-        mark_muted: '<b>m</b> seguido de <b>m</b> Marcar tema como mudo'
-        mark_regular: '<b>m</b> seguido de <b>r</b> Marcar tema como regular'
-        mark_tracking: '<b>m</b> seguido de <b>t</b> Seguir tema'
-        mark_watching: '<b>m</b> seguido de <b>w</b> Observar tema'
+          keyboard_shortcuts_help:
+            title: 'Teclas de escape (experimental)'
+            jump_to:
+              title: 'Ir a'
+              home: '<b>g</b> entonces <b>h</b> Home (lo último)'
+              latest: '<b>g</b> entonces <b>l</b> Lo último'
+              new: '<b>g</b> entonces <b>n</b> Nuevo'
+              unread: '<b>g</b> entonces <b>u</b> No leído'
+              starred: '<b>g</b> entonces <b>f</b> Favorito'
+              categories: '<b>g</b> entonces <b>c</b> Categorías'
+            navigation:
+              title: 'Navegación'
+              back: '<b>u</b> Atrás'
+              up_down: '<b>k</b>/<b>j</b> Mover selección arriba/abajo'
+              open: '<b>o</b> or <b>Enter</b> Abrir tema seleccionado'
+              next_prev: '<b>`</b>/<b>~</b> siguiente/anterior sección'
+            application:
+              title: 'Aplicación'
+              create: '<b>c</b> Crear un nuevo tema'
+              notifications: '<b>n</b> Abrir Notificaciones'
+              search: '<b>/</b> Buscar'
+              help: '<b>?</b> Abrir Teclas shortcuts ayuda'
+            actions:
+              title: 'Acciones'
+              star: '<b>f</b> Tema Favorito'
+              share_topic: '<b>s</b> Compartir tema'
+              share_post: '<b>shift s</b> Compartir publicación'
+              reply_topic: '<b>r</b> Responder al tema'
+              reply_post: '<b>shift r</b> Responder publicación'
+              like: '<b>l</b> Me gusta la publicación'
+              flag: '<b>!</b> Marcar publicación'
+              bookmark: '<b>b</b> Señalar publicación'
+              edit: '<b>e</b> Editar publicación'
+              delete: '<b>d</b> Borrar publicación'
+              mark_muted: '<b>m</b> entonces <b>m</b> Marcar tema como silenciado'
+              mark_regular: '<b>m</b> entonces <b>r</b> Marcar tema como regular'
+              mark_tracking: '<b>m</b> entonces <b>t</b> Marcar tema como rastreado'
+              mark_watching: '<b>m</b> entonces <b>w</b> Marcar tema como observado'

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -524,8 +524,7 @@ en:
       description: "Your site's FAQ. Leave blank for the default FAQ."
     login_required_welcome_message:
       title: "Login Required: Welcome Message"
-      description: "Welcome message that is displayed to logged out users when
-        the 'login required' setting is enabled."
+      description: "Welcome message that is displayed to logged out users when the 'login required' setting is enabled."
     tos_user_content_license:
       title: "Terms of Service: Content License"
       description: "The text for the Content License section of the Terms of Service."
@@ -537,13 +536,13 @@ en:
       description: "The text displayed for unauthorized users when login is required on the site."
     head:
       title: "HTML head"
-      description: "HTML that will be inserted inside the <head></head> tags"
+      description: "HTML that will be inserted inside the <head></head> tags."
     top:
       title: "Top of the pages"
-      description: "HTML that will be added at the top of every pages (after the header, before the navigation or the topic title)."
+      description: "HTML that will be added at the top of every page (after the header, before the navigation or the topic title)."
     bottom:
       title: "Bottom of the pages"
-      description: "HTML that will be added at the bottom of every pages"
+      description: "HTML that will be added at the bottom of every page."
     tos_signup_form_message:
       title: "Signup Form: Terms of Service Message"
       description: "The message that will appear beside a checkbox on the signup form if the tos_accept_required site setting is enabled."

--- a/config/locales/server.es.yml
+++ b/config/locales/server.es.yml
@@ -85,7 +85,7 @@ es:
     post_template: "%{replace_paragraph}\n\nUse the following paragraphs for a longer description, as well as to establish any category guidelines or rules.\n\nSome things to consider in any discussion replies below:\n\n- What is this category for? Why should people select this category for their topic?\n\n- How is this different than the other categories we already have?\n\n- Do we need this category?\n\n- Should we merge this with another category, or split it into more categories?\n"
 
   trust_levels:
-    new:
+    newuser:
       title: "nuevo usuario"
     basic:
       title: "usuario básico"
@@ -269,14 +269,138 @@ es:
       title: "Nuevos posts"
       xaxis: "día"
       yaxis: "Número de nuevos posts"
-    total_users:
-      title: "Usuarios totales"
+    likes:
+      title: "Me gusta"
       xaxis: "Día"
-      yaxis: "Número total de usuarios"
+      yaxis: "Número de nuevos 'me gusta'"
     flags:
       title: "Marcados"
       xaxis: "Día"
       yaxis: "Número de marcados"
+    bookmarks:
+      title: "Marcadores"
+      xaxis: "Día"
+      yaxis: "Número de nuevos marcadores"
+    starred:
+      title: "Favorito"
+      xaxis: "Día"
+      yaxis: "Número de temas nuevos favoritos"
+    users_by_trust_level:
+      title: "Usuarios por Nivel de Confianza"
+      xaxis: "Día"
+      yaxis: "Número de Usuarios"
+    emails:
+      title: "Correos Enviados"
+      xaxis: "Día"
+      yaxis: "Número de Correos"
+    user_to_user_private_messages:
+      title: "Usuario-a-Usuario"
+      xaxis: "Día"
+      yaxis: "Número de mensajes privados"
+    system_private_messages:
+      title: "Sistema"
+      xaxis: "Día"
+      yaxis: "Número de mensajes privados"
+    moderator_warning_private_messages:
+      title: "Advertencia del Moderador"
+      xaxis: "Día"
+      yaxis: "Número de mensajes privados"
+    notify_moderators_private_messages:
+      title: "Notificar a los Moderadores"
+      xaxis: "Día"
+      yaxis: "Número de mensajes privados"
+    notify_user_private_messages:
+      title: "Notificar Usuario"
+      xaxis: "Día"
+      yaxis: "Número de mensajes privados"
+    top_referrers:
+      title: "Los Mejores Recomendantes"
+      xaxis: "Usuario"
+      num_clicks: "Clicks"
+      num_topics: "Temas"
+    top_traffic_sources:
+      title: "Las Fuentes de Tráfico Más Altas"
+      xaxis: "Dominio"
+      num_clicks: "Clicks"
+      num_topics: "Temas"
+      num_users: "Usuarios"
+    top_referred_topics:
+      title: "Los Temas Referidos Más Altos"
+      xaxis: "Tema"
+      num_clicks: "Clicks"
+
+  dashboard:
+    rails_env_warning: "Tu servidor está funcionando en modo de %{env}."
+    ruby_version_warning: "Tú estás utilizando una versión de Ruby 2.0.0 que es conocida por tener problemas. Actualiza al nivel de parche 247 o más nuevo."
+    host_names_warning: "Tu archivo 'config/database.yml' está utilizando un hostname predeterminado de 'localhost'. Actualízalo para usar el hostname de tu sitio."
+    gc_warning: 'Tu servidor está usando recolección de residuos predeterminada por Ruby, que no te proveerá el mejor rendimiento. Lee este tema acerca de optimización del rendimiento: <a href="http://meta.discourse.org/t/tuning-ruby-and-rails-for-discourse/4126" target="_blank">Tuning Ruby and Rails for Discourse</a>.'
+    sidekiq_warning: 'Sidekiq no está funcionando. Muchas tareas, por ejemplo el envío de correos, están realizadas desincronizadamente por sidekiq. Por favor asegúrate de que por lo menos un proceso de sidekiq está funcionando. <a href="https://github.com/mperham/sidekiq" target="_blank">Learn about Sidekiq here</a>.'
+    queue_size_warning: 'El número de tareas en espera es %{queue_size}, que es elevado. Esto podría indicar un problema con el proceso(s) de Sidekiq, o tal vez necesitas añadir más trabajadores de Sidekiq.'
+    memory_warning: 'Tu servidor está funcionando con menos de 1 GB de memoria total. Por lo menos 1 GB de memoria es recomendado.'
+    facebook_config_warning: 'El servidor está configurado para permitir crear una cuenta e ingresar utilizando Facebook (enable_facebook_logins), pero los valores id y secreto de la app no están configurados. Ingresa a <a href="/admin/site_settings">la Configuración del Sitio</a> y actualiza la configuración. <a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide#enable-facebook-logins" target="_blank">Revisa la guía para aprender más</a>.'
+    twitter_config_warning: 'El servidor está configurado para permitir crear una cuenta e ingresar utilizando Twitter (enable_twitter_logins), pero los valores clave y secreto de la app no están configurados. Ingresa a <a href="/admin/site_settings">la Configuración del Sitio</a> y actualiza la configuración. <a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide#enable-twitter-logins" target="_blank">Revisa la guía para aprender más</a>.'
+    github_config_warning: 'El servidor está configurado para permitir crear una cuenta e ingresar utilizando GitHub (enable_github_logins), pero los valores de cliente clave y cliente secreto no están configurados. Ingresa a <a href="/admin/site_settings">la Configuración del Sitio</a> y actualiza la configuración. <a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide" target="_blank">Revisa la guía para aprender más</a>.'
+    s3_config_warning: 'El servidor está configurado para permitir actualizar los archivos a s3, pero por lo menos una de las siguientes configuraciones no está realizada: s3_access_key_id, s3_secret_access_key o s3_upload_bucket. Ingresa a <a href="/admin/site_settings">la Configuración del Sitio</a> y actualiza la configuración. <a href="http://meta.discourse.org/t/how-to-set-up-image-uploads-to-s3/7229" target="_blank">Revisa "How to set up image uploads to S3?" para aprender más</a>.'
+    image_magick_warning: 'El servidor está configurado para permitir miniaturas de imágenes grandes, pero ImageMagick no está instalado. Instala ImageMagick usando tu administrador de paquetes favorito o <a href="http://www.imagemagick.org/script/binary-releases.php" target="_blank">descárgate la última versión</a>.'
+    failing_emails_warning: 'Hay %{num_failed_jobs} de tareas de email que fallaron. Revisa tu archivo config/discourse.conf y asegúrate que la configuración del servidor de email esté correcta. <a href="/sidekiq/retries" target="_blank">Revisa las tareas fallidas en Sidekiq</a>.'
+    default_logo_warning: "No has personalizado los imágenes del logo para tu sitio. Actualiza logo_url, logo_small_url, y favicon_url en la <a href='/admin/site_settings'>Configuración del Sitio</a>."
+    contact_email_missing: "No has proveido un correo de contacto para tu sitio. Por favor actualiza contact_email en la <a href='/admin/site_settings'>Configuración del Sitio</a>."
+    contact_email_invalid: "La dirección email de contacto es inválida. Por favor actualiza contact_email en la <a href='/admin/site_settings'>Configuración del Sitio</a>."
+    title_nag: "El título Site Setting todavía está configurado al valor predeterminado. Por favor actualízalo con el título de tu sitio en la <a href='/admin/site_settings'>Configuración del Sitio</a>."
+    site_description_missing: "La site_description configuración está vacía. Escribe una breve descripción de este foro en la <a href='/admin/site_settings'>Configuración del Sitio</a>."
+    consumer_email_warning: "Tu sitio está configurado para Utilizar Gmail (u otro servicio de email de consumidor) para enviar email. <a href='http://support.google.com/a/bin/answer.py?hl=en&answer=166852' target='_blank'>Gmail limita la cantidad de emails que puedes enviar</a>. Considera usar un proveedor de servicio email como mandrill.com para asegurarte la entrega de los emails."
+    access_password_removal: "Tu sitio estaba usando la access_password configuración, que ha sido removida. Las login_required y must_approve_users configuraciones han sido habilitadas, que deberían ser usadas en su lugar. Las puedes cambiar en la <a href='/admin/site_settings'>Configuración del Sitio</a>. Asegúrate <a href='/admin/users/list/pending'>de aprobar los usuarios en la lista de Usuarios Pendientes</a>. (Este mensaje desaparecerá en 2 días.)"
+    site_contact_username_warning: "La site_contact_username configuración está vacía. Por favor actualízala en la <a href='/admin/site_settings'>Configuración del Sitio</a>. Configúrala al nombre de usuario de un administrador quien debe ser el enviador de mensajes de sistema."
+    notification_email_warning: "La configuración notification_email está vacía. Por favor actualízala en la <a href='/admin/site_settings'>Configuración del Sitio</a>."
+    enforce_global_nicknames_warning: "La configuración enforce_global_nicknames ha sido chequeada, pero la de discourse_org_access_key está vacía. Una clave de acceso Discourse.org es requerida para usar la configuración enforce_global_nicknames. Por favor actualiza tu <a href='/admin/site_settings'>Configuración del Sitio</a>."
+
+  content_types:
+    education_new_reply:
+      title: "Educación de Nuevo Usuario: Primeras Respuestas"
+      description: "Un mensaje emergente de guia 'justo a tiempo' aparecerá automáticamente sobre el compositor cuando nuevos usuarios empiecen ingresar sus dos primeras respuestas."
+    education_new_topic:
+      title: "Educación de Nuevo Usuario: Primeros Temas"
+      description: "Un mensaje emergente de guia 'justo a tiempo' aparecerá automáticamente sobre el compositor cuando nuevos usuarios empiecen ingresar sus dos primeras respuestas."
+    usage_tips:
+      title: "Consejos para Nuevos Usuarios"
+      description: "Consejos de uso común, información esencial de foro, y guia importante para nuevos usuarios."
+    welcome_user:
+      title: "Bienvenido: Nuevo Usuario"
+      description: "Un mensaje privado enviado automáticamente a todos los nuevos usuarios cuando se registren."
+    welcome_invite:
+      title: "Bienvenido: Usuario Invitado"
+      description: "Un mensaje privado enviado automáticamente a todos los usuarios invitados cuando se acepten la invitación de otro usuario para participar."
+    privacy_policy:
+      title: "Política de Privacidad"
+      description: "Your site's privacy policy. Leave blank for default policy."
+      description: "La política de privacidad de tu sitio. Deja en blanco para política de privacidad predeterminada."
+    faq:
+      title: "Preguntas Frecuentes"
+      description: "Las preguntas frecuentes de tu sitio. Deja en blanco para las preguntas frecuentes predeterminadas."
+    login_required_welcome_message:
+      title: "Registro Requerido: Mensaje de Bienvenida"
+      description: "El mensaje de bienvenida que se muestra a los usuarios que han salido cuando la configuración de 'login required' está activada."
+    tos_user_content_license:
+      title: "Términos del Servicio: Licencia de Contenido"
+      description: "El texto para la sección de Licencia de Contenido de los Términos del Servicio."
+    tos_miscellaneous:
+      title: "Términos del Servicio: Misceláneo"
+      description: "El texto para la sección de Misceláneo de los Términos del Servicio."
+    login_required:
+      title: "Registro Requerido: Homepage"
+      description: "El texto mostrado para usuarios no autorizados cuando el registro es requerido en el sitio."
+    head:
+      title: "HTML head"
+      description: "HTML que va a ser insertado dentro de las <head></head> etiquetas"
+    top:
+      title: "Encabezado de página"
+      description: "HTML que va a ser añadido encima de cada página (después del header, y antes de la navegación o el título del tema)."
+    bottom:
+      title: "Base de la página"
+      description: "HTML que va a ser añadido en la base de cada página."
+    tos_signup_form_message:
+      title: "Página de Registro: Mensaje de Términos del Servicio"
+      description: "El mensaje que aparecerá junto un checkbox en la página de registro si la configuración del sitio 'tos_accept_required' está activada."
 
   site_settings:
     default_locale: "El lenguaje por defecto de la instancia de Discourse (ISO 639-1 Code)"
@@ -285,8 +409,8 @@ es:
     min_topic_title_length: "Mínimo número de caracteres en la longitud de un título"
     max_topic_title_length: "Máxima número de caracteres en la longitud de un título"
     min_search_term_length: "Mínima longitud de un término de búsqueda"
-    allow_duplicate_topic_titles: "Permitir topics con identico título"
-    unique_posts_mins: "Cuantos minutos antes de que un usuario pueda hacer un post con el mismo contenido de nuevo"
+    allow_duplicate_topic_titles: "Permitir temas con identico título"
+    unique_posts_mins: "Cuántos minutos antes de que un usuario pueda hacer un post con el mismo contenido de nuevo"
     enforce_global_nicknames: "Obligar unicidad en los nicknames (ADVERTENCIA: cambia solo esto en el setup inicial)"
     discourse_org_access_key: "La clave de acceso utilizada para acceder al 'Discourse Hub nickname registry' en discourse.org"
     educate_until_posts: "Mostrar el pop-up con el panel de educación hasta que el usuario haya hecho este número de posts"
@@ -321,7 +445,7 @@ es:
     polling_interval: "¿Qué a menusdo deben hacer poll los usuarios logados en milisegundos"
     anon_polling_interval: "¿Qué a menudo deben hacer poll los usuarios anónimos en milisegundos"
 
-    auto_track_topics_after: "Milisegundos globales por defecto antes de que un topic sea automaticamente trackeado, los usuarios pueden sobreescribirlo (0 para siempre, -1 para nunca)"
+    auto_track_topics_after: "Milisegundos globales por defecto antes de que un topic sea automáticamente trackeado, los usuarios pueden sobreescribirlo (0 para siempre, -1 para nunca)"
     new_topic_duration_minutes: "Minutos globales por defecto en los que un topic es considerado nuevo, los usuarios pueden sobreescribirlo (-1 para siempre, -2 para la última visita)"
 
     flags_required_to_hide_post: "Número de flags que causan que un post se oculte auomática un MP sea enviado al usuario (0 para nunca)"
@@ -334,8 +458,8 @@ es:
     top_menu: "Determinar que items aparecen en la navegación de la home y en qué orden. Ejemplo latest|new|unread|starred|categories|top|read|posted"
     post_menu: "Determinar que items aparecen en el menú de post y en qué orden. Ejemplo like|edit|flag|delete|share|bookmark|reply"
     track_external_right_clicks: "Track external links that are right clicked (eg: open in new tab) disabled by default because it rewrites URLs"
-    topics_per_page: "Cuantos topics son cargados por defecto en la página de lista de topics"
-    posts_per_page: "Cuantos posts son devueltos en una página de topic"
+    topics_per_page: "Cuántos topics son cargados por defecto en la página de lista de topics"
+    posts_per_page: "Cuántos posts son devueltos en una página de topic"
     site_contact_username: "Nombre de usuario para el autor de mensajes privados enviados por el foro"
     send_welcome_message: "¿Reciben los nuevos usuarios un mensaje privado de bienvenida?"
     suppress_reply_directly_below: "No mostrar el contador de respuestas en un pot cuando una única respuesta directamente debajo"
@@ -372,8 +496,8 @@ es:
 
     max_mentions_per_post: "Maximo número de notificaciones @name que se pueden usar en un post"
 
-    rate_limit_create_topic: "Cuantos segundos, después de crear un topic, deben pasar antes de poder crear otro topic"
-    rate_limit_create_post: "Cuantos segundos, después de crear un post, deben pasar antes de poder crear otro post"
+    rate_limit_create_topic: "Cuántos segundos, después de crear un topic, deben pasar antes de poder crear otro topic"
+    rate_limit_create_post: "Cuántos segundos, después de crear un post, deben pasar antes de poder crear otro post"
 
     max_likes_per_day: "Máximo número de likes por usuario por día"
     max_flags_per_day: "Máximo número de flags por usuario por día"
@@ -391,13 +515,12 @@ es:
     default_invitee_trust_level: "Nivel de confianza por defecto (0-4) para usuarios invitados"
     default_trust_level: "Nivel de confianza por defecto (0-4) para usuarios"
 
-    basic_requires_topics_entered: "Cuantos topics debe introducir un usuario antes de ser promocionado al nivel básico (1) de confianza"
-    basic_requires_read_posts: "Cuantos post debe un usuario leer antes de ser promocionado al nivel básico (1) de confianza"
-    basic_requires_time_spent_mins: "Cuantos minutos un usuario debe leer posts antes de ser promocionado al nivel básico (1) de confianza"
+    basic_requires_topics_entered: "Cuántos topics debe introducir un usuario antes de ser promocionado al nivel básico (1) de confianza"
+    basic_requires_read_posts: "Cuántos post debe un usuario leer antes de ser promocionado al nivel básico (1) de confianza"
+    basic_requires_time_spent_mins: "Cuántos minutos un usuario debe leer posts antes de ser promocionado al nivel básico (1) de confianza"
 
-    email_time_window_mins: "Cuantos minutos esperamos antes de enviar un mail a un usuario, para darles la oportunidad de verlo antes"
-    flush_timings_secs: "How frequently we flush timing data to the server, in seconds"
-    max_word_length: "La máxima longitud de palabra permitida, en caracteres en el título de un topic"
+    email_time_window_mins: "Cuántos minutos esperamos antes de enviar un mail a un usuario, para darles la oportunidad de verlo antes"
+    flush_timings_secs: "Con cuánta frecuencia enviamos datos de coordinación de tiempo al servidor, está configurado para permitirord_length: 'La máxima longitud de palabra permitida, en caracteres en el título de un topic.'"
     title_min_entropy: "La mínima entropía permitida (caracteres únicos) requerida para el título de un topic"
     body_min_entropy: "La mínima entropía permitida (caracteres únicos) requerida para el cuerpo de un post"
     title_fancy_entities: "Convertir caracteres ASCII comunes en entidades HTML de adorno en el título de los topics, ala SmartyPants http://daringfireball.net/projects/smartypants/"
@@ -554,7 +677,7 @@ es:
 
         Ten en cuenta que multiples miembros de la comunidad han marcado este post antes de que haya sido ocultado, por tanto considera como podrías revisar el post para reflejar su feedback.
 
-        Podrás editar el post después de %{edit_delay} minutos, y será automaticamente mostrado. Esto incrementara tu nivel de confianza en el foro.
+        Podrás editar el post después de %{edit_delay} minutos, y será automáticamente mostrado. Esto incrementara tu nivel de confianza en el foro.
 
         Sin embargo, si el post es ocultado por la comunidad una segunda vez, los moderadores serán notificados -- y habrá posibles consecuencias, como la posible suspensión de tu cuenta.
 
@@ -568,7 +691,7 @@ es:
 
         No hay botones de siguiente página o números de página - para leer más, solo sigue haciendo scroll y ¡Más contenido será cargado!
 
-        Conforme lleguen nuevas respuestas, estas aparecerán automaticamente al final del topic. No hay necesidad de refrescar la página o volver a entrar en el topic para ver nuevos posts.
+        Conforme lleguen nuevas respuestas, estas aparecerán automáticamente al final del topic. No hay necesidad de refrescar la página o volver a entrar en el topic para ver nuevos posts.
 
         ### ¿Cómo contesto?
 
@@ -616,7 +739,7 @@ es:
       text_body_template: |
         Gracias por aceptar tu invitación a %{site_name}, ¡Y bienvenido a nuestro foro de discusión!
 
-        Hemos generado automaticamente un nombre de usuario para ti: **%{username}**, pero puedes cambiarlo en cualquier momento visitando [your user profile][prefs].
+        Hemos generado automáticamente un nombre de usuario para ti: **%{username}**, pero puedes cambiarlo en cualquier momento visitando [your user profile][prefs].
 
         Para volver a hacer log in, puedes:
 


### PR DESCRIPTION
Updated the following files:
1. `client.es.yml`
2. `server.es.yml`
3. `server.en.yml`

Our goal was to remove the most glaring omissions from the Spanish versions of the .yml files, where "glaring" defined as missing yaml errors showing up in the most regularly-traversed parts of the platform.

We focused on the admin panel(s) and main user pages. 

We added a lot of missing yaml (relative to the latest version of their English counterparts) to both `client.es.yml` and `server.es.yml`.

We also found a handful of English typos/grammatical errors, hence the edits to `server.en.yml`. 

We hope you find these changes to be improvements and amenable!

cc @jsl 
