### PR TITLE
Don't display edits during user's name update

### DIFF
--- a/app/assets/javascripts/discourse/controllers/preferences_controller.js
+++ b/app/assets/javascripts/discourse/controllers/preferences_controller.js
@@ -14,12 +14,14 @@ Discourse.PreferencesController = Discourse.ObjectController.extend({
   // By default we haven't saved anything
   saved: false,
 
+  newNameInput: null,
+
   saveDisabled: function() {
     if (this.get('saving')) return true;
-    if (Discourse.SiteSettings.enable_names && this.blank('name')) return true;
+    if (Discourse.SiteSettings.enable_names && this.blank('newNameInput')) return true;
     if (this.blank('email')) return true;
     return false;
-  }.property('saving', 'name', 'email'),
+  }.property('saving', 'newNameInput', 'email'),
 
   canEditName: function() {
     return Discourse.SiteSettings.enable_names;
@@ -57,6 +59,7 @@ Discourse.PreferencesController = Discourse.ObjectController.extend({
 
       // Cook the bio for preview
       var model = this.get('model');
+      model.set('name', this.get('newNameInput'));
       return model.save().then(function() {
         // model was saved
         self.set('saving', false);

--- a/app/assets/javascripts/discourse/routes/preferences_routes.js
+++ b/app/assets/javascripts/discourse/routes/preferences_routes.js
@@ -11,8 +11,8 @@ Discourse.PreferencesRoute = Discourse.RestrictedUserRoute.extend({
     return this.modelFor('user');
   },
 
-  setupController: function(controller, model) {
-    controller.set('model', model);
+  setupController: function(controller, user) {
+    controller.setProperties({ model: user, newNameInput: user.get('name') });
     this.controllerFor('user').set('indexStream', false);
   },
 

--- a/app/assets/javascripts/discourse/templates/user/preferences.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/user/preferences.js.handlebars
@@ -19,7 +19,7 @@
       <div class="control-group">
         <label class="control-label">{{i18n user.name.title}}</label>
         <div class="controls">
-          {{textField value=name classNames="input-xxlarge"}}
+          {{textField value=newNameInput classNames="input-xxlarge"}}
         </div>
         <div class='instructions'>
           {{i18n user.name.instructions}}


### PR DESCRIPTION
![image](https://f.cloud.github.com/assets/3401659/2178173/0c437ef0-965c-11e3-9822-8c95943a0b63.png)
Per [discussion on meta](https://meta.discourse.org/t/changes-in-profile-preferences-dont-get-saved-automatically/12198/2) this unbinds the name field on the user preferences page so that the display of the user's name does not update until the form is saved. 

I verified that input validation still works.
