### PR TITLE
Added endpoint for the 'site' JSON (In the preload store)

### DIFF
--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -1,0 +1,10 @@
+require_dependency 'site_serializer'
+
+class SiteController < ApplicationController
+
+  def index      
+    @site = Site.new(guardian)
+    render_serialized(@site, SiteSerializer)
+  end
+    
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,8 @@ Discourse::Application.routes.draw do
   match "/404", to: "exceptions#not_found", via: [:get, :post]
 
   mount Sidekiq::Web => "/sidekiq", constraints: AdminConstraint.new
+  
+  get "site" => "site#index"
 
   resources :forums
   get "srv/status" => "forums#status"


### PR DESCRIPTION
Added endpoint for the 'site' JSON, as per [Robin's (EvilTrout) suggestion](https://github.com/discourse/discourse/pull/1949) to [my issue](https://meta.discourse.org/t/subcategories-in-categories-json/11445/10).

All this is doing is making an endpoint for the 'site' json that is found in the preload store. 
