### PR TITLE
Scroll to top on Site-Setting category render

### DIFF
--- a/app/assets/javascripts/admin/views/site_setting_view.js
+++ b/app/assets/javascripts/admin/views/site_setting_view.js
@@ -6,7 +6,7 @@
   @namespace Discourse
   @module Discourse
 **/
-Discourse.SiteSettingView = Discourse.View.extend({
+Discourse.SiteSettingView = Discourse.View.extend(Discourse.ScrollTop, {
   classNameBindings: [':row', ':setting', 'content.overridden'],
 
   templateName: function() {


### PR DESCRIPTION
Navigating between Site Setting categories on the Admin dashboard does not adjust the page's scroll. For categories with few settings, it's possible for the page to render with all of the settings above the top of the screen. This is really confusing, as it appears that there are no settings for this category. This PR scrolls to the top on render.

![image](https://f.cloud.github.com/assets/3401659/2180844/d2d6bf5a-9733-11e3-91fa-b8d83dc6d53d.png)
