### PR TITLE
Copyedits on tracking descriptions

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -251,7 +251,7 @@ en:
       tracked_categories: "Tracked"
       tracked_categories_instructions: "You will automatically track all new and existing topics providing you a count of unread and new posts"
       muted_categories: "Muted"
-      muted_categories_instructions: "You will not be notified of anything about this topic, and it will not appear on your unread tab."
+      muted_categories_instructions: "You will not be notified of anything about new topics in these categories."
       delete_account: "Delete My Account"
       delete_account_confirm: "Are you sure you want to permanently delete your account? This action cannot be undone!"
       deleted_yourself: "Your account has been deleted successfully."
@@ -741,9 +741,9 @@ en:
           "3_2": 'You will receive notifications because you are watching this topic.'
           "3_1": 'You will receive notifications because you created this topic.'
           "3": 'You will receive notifications because you are watching this topic.'
-          "2_4": 'You will receive notifications because you posted a reply to this topic.'
-          "2_2": 'You will receive notifications because you are tracking this topic.'
-          "2": 'You will receive notifications because you <a href="/users/{{username}}/preferences">read this topic</a>.'
+          "2_4": 'You will see unread counts because you posted a reply to this topic.'
+          "2_2": 'You will see unread counts because you are tracking this topic.'
+          "2": 'You will see unread counts because you <a href="/users/{{username}}/preferences">read this topic</a>.'
           "1": 'You will be notified only if someone mentions your @name or replies to your post.'
           "1_2": 'You will be notified only if someone mentions your @name or replies to your post.'
           "0": 'You are ignoring all notifications on this topic.'
@@ -759,7 +759,7 @@ en:
           description: "you will be notified of @name mentions and replies to your posts"
         tracking:
           title: "Tracking"
-          description: "you will be notified of @name mentions and replies to your posts, plus you will see a count of unread and new posts."
+          description: "you will see a count of unread and new posts, and be notified only if someone mentions your @name or replies to your post."
         regular:
           title: "Regular"
           description: "you will be notified only if someone mentions your @name or replies to your post."
@@ -768,7 +768,7 @@ en:
           description: "you will not be notified of anything about this private message."
         muted:
           title: "Muted"
-          description: "you will not be notified of anything about this topic, and it will not appear on your unread tab."
+          description: "you will not be notified of anything about this topic."
 
       actions:
         recover: "Un-Delete Topic"


### PR DESCRIPTION
- Simplified description of Muted
- Swapped order of features in Tracked
- Changed "Recieve notifications" to "see unread counts" in the tracking reasons
- Pluralized instructions for muted categories
