### PR TITLE
Adds specs for PostsController#by_number.

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -119,7 +119,9 @@ class PostsController < ApplicationController
   end
 
   def by_number
-    @post = Post.where(topic_id: params[:topic_id], post_number: params[:post_number]).first
+    finder = Post.where(topic_id: params[:topic_id], post_number: params[:post_number])
+    finder = finder.with_deleted if current_user.try(:staff?)
+    @post = finder.first
     guardian.ensure_can_see!(@post)
     @post.revert_to(params[:version].to_i) if params[:version].present?
     render_post_json(@post)


### PR DESCRIPTION
by_number method wasn't covered by any tests. This PR ads tests for it and refactors tests for the nearly identical `show` method to use shared examples.

WARNING: when working on this PR I discovered that there is one difference between `show` and `by_number` methods: `show` method allows moderators to see trashed posts while `by_number` does not. I think that this was an omission and fixed `by_number` method to behave in the same way as `show`. If I'm wrong and this difference was intentional, don't merge this PR!
