### PR TITLE
Fallback to using the first list if [poll] isn't present

### DIFF
--- a/plugins/poll/assets/javascripts/poll_ui.js
+++ b/plugins/poll/assets/javascripts/poll_ui.js
@@ -97,7 +97,13 @@ Discourse.PostView.reopen({
     }
 
     var view = initializePollView(this);
-    view.replaceElement($post.find(".poll-ui:first"));
+
+    var pollContainer = $post.find(".poll-ui:first");
+    if (pollContainer.length == 0) {
+      pollContainer = $post.find("ul:first");
+    }
+
+    view.replaceElement(pollContainer);
     this.set('pollView', view);
 
   }.on('postViewInserted'),

--- a/plugins/poll/poll.rb
+++ b/plugins/poll/poll.rb
@@ -26,9 +26,10 @@ module ::PollPlugin
 
     def options
       cooked = PrettyText.cook(@post.raw, topic_id: @post.topic_id)
-      poll_div = Nokogiri::HTML(cooked).css(".poll-ui").first
-      if poll_div
-        poll_div.css("li").map {|x| x.children.to_s.strip }.uniq
+      parsed = Nokogiri::HTML(cooked)
+      poll_list = parsed.css(".poll-ui ul").first || parsed.css("ul").first
+      if poll_list
+        poll_list.css("li").map {|x| x.children.to_s.strip }.uniq
       else
         []
       end

--- a/plugins/poll/spec/poll_plugin/poll_spec.rb
+++ b/plugins/poll/spec/poll_plugin/poll_spec.rb
@@ -18,6 +18,13 @@ describe PollPlugin::Poll do
     expect(poll.options).to eq(["Chitoge", "Onodera"])
   end
 
+  it "should fall back to using the first list if [poll] markup is not present" do
+    topic = create_topic(title: "This is not a poll topic")
+    post = create_post(topic: topic, raw: "Pick one.\n\n* Chitoge\n* Onodera")
+    poll = PollPlugin::Poll.new(post)
+    expect(poll.options).to eq(["Chitoge", "Onodera"])
+  end
+
   it "should get details correctly" do
     expect(poll.details).to eq({"Chitoge" => 0, "Onodera" => 0})
   end


### PR DESCRIPTION
I haven't completely removed the `[poll]...[/poll]` markup because I think it will be useful to add additional options like allowing multiple selections in the future, but now if the poll markup doesn't exist in a post it will fall back to using the first list.
