### PR TITLE
Preserve spoiler tags in post excerpts

### DIFF
--- a/lib/excerpt_parser.rb
+++ b/lib/excerpt_parser.rb
@@ -49,8 +49,16 @@ class ExcerptParser < Nokogiri::XML::SAX::Document
           include_tag(name, attributes)
           @in_a = true
         end
+
       when "aside"
         @in_quote = true
+
+      when "div", "span"
+        # Preserve spoilers
+        if attributes.any? {|x| x == ["class", "spoiler"] }
+          include_tag("span", attributes)
+          @in_spoiler = true
+        end
     end
   end
 
@@ -65,6 +73,9 @@ class ExcerptParser < Nokogiri::XML::SAX::Document
       characters(" ")
     when "aside"
       @in_quote = false
+    when "div", "span"
+      characters("</span>", false, false, false) if @in_spoiler
+      @in_spoiler = false
     end
   end
 

--- a/spec/components/pretty_text_spec.rb
+++ b/spec/components/pretty_text_spec.rb
@@ -92,6 +92,10 @@ describe PrettyText do
         PrettyText.excerpt("<img src='http://cnn.com/a.gif' title='car'>", 100, markdown_images: true).should == "![car](http://cnn.com/a.gif)"
       end
 
+      it "should keep spoilers" do
+        PrettyText.excerpt("<div class='spoiler'><img src='http://cnn.com/a.gif'></div>", 100).should == "<span class='spoiler'>[image]</span>"
+        PrettyText.excerpt("<span class='spoiler'>spoiler</div>", 100).should == "<span class='spoiler'>spoiler</span>"
+      end
     end
 
     it "should have an option to strip links" do


### PR DESCRIPTION
I still haven't figured out how to handle emails, in the mean time this will fix the spoiler tags so they work in the activity stream.
