### PR TITLE
Fix group aliases causing private messages to not be created

### DIFF
--- a/app/assets/javascripts/discourse/lib/autocomplete.js
+++ b/app/assets/javascripts/discourse/lib/autocomplete.js
@@ -89,7 +89,7 @@ $.fn.autocomplete = function(options) {
     if (options.transformComplete) { transformedItem = options.transformComplete(transformedItem); }
     // dump what we have in single mode, just in case
     if (options.single) { inputSelectedItems = []; }
-    if (!_.isArray(transformedItem)) { transformed = [transformedItem || item]; }
+    transformed = _.isArray(transformedItem) ? transformedItem : [transformedItem || item];
 
     var divs = transformed.map(function(itm) {
       var d = $("<div class='item'><span>" + itm + "<a class='remove' href='#'><i class='fa fa-times'></i></a></span></div>");

--- a/app/assets/javascripts/discourse/views/user_selector_view.js
+++ b/app/assets/javascripts/discourse/views/user_selector_view.js
@@ -4,6 +4,14 @@ Discourse.UserSelector = Discourse.TextField.extend({
     var userSelectorView = this,
         selected = [];
 
+    function excludedUsernames() {
+      var exclude = selected;
+      if (userSelectorView.get('excludeCurrentUser')) {
+        exclude = exclude.concat([Discourse.User.currentProp('username')]);
+      }
+      return exclude;
+    }
+
     $(this.get('element')).val(this.get('usernames')).autocomplete({
       template: Discourse.UserSelector.templateFunction(),
 
@@ -12,14 +20,10 @@ Discourse.UserSelector = Discourse.TextField.extend({
       allowAny: this.get('allowAny'),
 
       dataSource: function(term) {
-        var exclude = selected;
-        if (userSelectorView.get('excludeCurrentUser')) {
-          exclude = exclude.concat([Discourse.User.currentProp('username')]);
-        }
         return Discourse.UserSearch.search({
           term: term,
           topicId: userSelectorView.get('topicId'),
-          exclude: exclude,
+          exclude: excludedUsernames(),
           include_groups: userSelectorView.get('include_groups')
         });
       },
@@ -28,7 +32,11 @@ Discourse.UserSelector = Discourse.TextField.extend({
         if (v.username) {
           return v.username;
         } else {
-          return v.usernames;
+          var excludes = excludedUsernames();
+          return v.usernames.filter(function(item){
+                // include only, those not found in the exclude list
+                return excludes.indexOf(item) === -1;
+              });
         }
       },
 


### PR DESCRIPTION
Bug:
- Open the private message in discourse
- in the user selector, select a user group you are part of
- send the message

What should happen:
- the private message should be created

What happens:
- the user is thrown a weird "Archetype" error, stating the user isn't able to send to this user:

![screen shot 2014-02-21 at 11 11 05](https://f.cloud.github.com/assets/40496/2228909/a3d642e4-9ae3-11e3-8a4d-341d82cd08c2.png)
(The writing user here is "eviltrout").

---

This Pull-Request fixes that issue by applying the exclusion of the own username as well as already selected usernames to group aliases, too. Therefore preventing to accidentally selecting yourself by choosing a group you are part of and - as a side effect - prevent double selecting of users.
