### PR TITLE
Move notifications from ajax into MessageBus push

### DIFF
--- a/app/assets/javascripts/discourse/initializers/subscribe_user_notifications.js
+++ b/app/assets/javascripts/discourse/initializers/subscribe_user_notifications.js
@@ -17,6 +17,7 @@ Discourse.addInitializer(function() {
       });
     }
     bus.subscribe("/notification/" + user.get('id'), (function(data) {
+      user.set('recent_notifications', data.recent_notifications);
       user.set('unread_notifications', data.unread_notifications);
       user.set('unread_private_messages', data.unread_private_messages);
     }), user.notification_channel_position);

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -89,9 +89,8 @@ class Notification < ActiveRecord::Base
     Post.where(topic_id: topic_id, post_number: post_number).first
   end
 
-  def self.recent_report(user, count = nil)
-    count ||= 10
-    notifications = user.notifications.recent(count).includes(:topic).to_a
+  def self.recent_report(user, count = 10)
+    notifications = user.notifications.recent(count).includes(:topic)
 
     if notifications.present?
       notifications += user.notifications
@@ -122,12 +121,7 @@ class Notification < ActiveRecord::Base
   protected
 
   def refresh_notification_count
-    user_id = user.id
-    MessageBus.publish("/notification/#{user_id}",
-      {unread_notifications: user.unread_notifications,
-       unread_private_messages: user.unread_private_messages},
-      user_ids: [user_id] # only publish the notification to this user
-    )
+    user.publish_notifications_state
   end
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -234,11 +234,19 @@ class User < ActiveRecord::Base
   end
 
   def publish_notifications_state
+    serialized_notifications = ActiveModel::ArraySerializer.new(recent_notifications,
+                                   each_serializer: NotificationSerializer)
+
     MessageBus.publish("/notification/#{id}",
-                       {unread_notifications: unread_notifications,
-                        unread_private_messages: unread_private_messages},
-                       user_ids: [id] # only publish the notification to this user
+           { unread_notifications: unread_notifications,
+             unread_private_messages: unread_private_messages,
+             recent_notifications: serialized_notifications },
+             user_ids: [id] # only publish the notification to this user
     )
+  end
+
+  def recent_notifications
+    Notification.recent_report(self)
   end
 
   # A selection of people to autocomplete on @mention

--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -19,6 +19,8 @@ class CurrentUserSerializer < BasicUserSerializer
              :no_password,
              :can_delete_account
 
+  has_many :recent_notifications, class_name: :notifications, embed: :object
+
   def include_site_flagged_posts_count?
     object.staff?
   end

--- a/app/serializers/notification_serializer.rb
+++ b/app/serializers/notification_serializer.rb
@@ -1,6 +1,7 @@
 class NotificationSerializer < ApplicationSerializer
 
-  attributes :notification_type,
+  attributes :id,
+             :notification_type,
              :read,
              :created_at,
              :post_number,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -147,6 +147,9 @@ Discourse::Application.routes.draw do
       get "check_username"
       get "is_local_username"
     end
+    member do
+      put "saw_notification"
+    end
   end
 
   resources :static

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -537,6 +537,16 @@ describe UsersController do
     end
   end
 
+  context ".saw_notification" do
+    let!(:user) { log_in }
+    it "updates the user's last seen notification" do
+      notification_id = "1"
+      User.any_instance.expects(:saw_notification_id).with(notification_id)
+      xhr :put, :saw_notification, id: user.id, last_notification_id: notification_id
+      response.should be_success
+    end
+  end
+
   context '.check_username' do
     before do
       DiscourseHub.stubs(:nickname_available?).returns([true, nil])

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -213,12 +213,12 @@ describe Notification do
       p = Fabricate(:post)
       p2 = Fabricate(:post)
 
-      Notification.create!(read: false, user_id: p.user_id, topic_id: p.topic_id, post_number: p.post_number, data: '[]',
+      Notification.create!(read: false, user_id: p.user_id, topic_id: p.topic_id, post_number: p.post_number, data: '{}',
                            notification_type: Notification.types[:private_message])
-      Notification.create!(read: false, user_id: p2.user_id, topic_id: p2.topic_id, post_number: p2.post_number, data: '[]',
+      Notification.create!(read: false, user_id: p2.user_id, topic_id: p2.topic_id, post_number: p2.post_number, data: '{}',
                            notification_type: Notification.types[:private_message])
 
-      Notification.create!(read: false, user_id: p2.user_id, topic_id: p2.topic_id, post_number: p2.post_number, data: '[]',
+      Notification.create!(read: false, user_id: p2.user_id, topic_id: p2.topic_id, post_number: p2.post_number, data: '{}',
                            notification_type: Notification.types[:liked])
       p2.trash!(p.user)
 
@@ -240,7 +240,8 @@ describe Notification do
     def fab(type, read)
       @i ||= 0
       @i += 1
-      Notification.create!(read: read, user_id: user.id, topic_id: post.topic_id, post_number: post.post_number, data: '[]',
+      Notification.create!(read: read, user_id: user.id, topic_id: post.topic_id,
+                           post_number: post.post_number, data: '{}',
                            notification_type: type, created_at: @i.days.from_now)
     end
 

--- a/test/javascripts/integration/header_test.js
+++ b/test/javascripts/integration/header_test.js
@@ -50,13 +50,11 @@ test("logo", function() {
 });
 
 test("notifications dropdown", function() {
-  expect(4);
-
+  Ember.run(function(){
+  expect(3);
   var itemSelector = "#notifications-dropdown li";
-
-  Ember.run(function() {
-    Discourse.URL_FIXTURES["/notifications"] = [
-      {
+  var notification = {
+        id: 1,
         notification_type: 2, //replied
         read: true,
         post_number: 2,
@@ -66,14 +64,14 @@ test("notifications dropdown", function() {
           topic_title: "some title",
           display_username: "velesin"
         }
-      }
-    ];
-  });
+      };
+  var currentUser = Discourse.User.current();
+  currentUser.set('unread_notifications', 1);
+  currentUser.set('recent_notifications', [notification]);
+
+  Discourse.URL_FIXTURES["/users/" + currentUser.id + "/saw_notification"] = {success: 'OK'};
 
   visit("/")
-  .then(function() {
-    ok(!exists($(itemSelector)), "initially is empty");
-  })
   .click("#user-notifications")
   .then(function() {
     var $items = $(itemSelector);
@@ -81,6 +79,7 @@ test("notifications dropdown", function() {
     ok(exists($items), "is lazily populated after user opens it");
     ok($items.first().hasClass("read"), "correctly binds items' 'read' class");
     equal($items.first().html(), 'notifications.replied velesin <a href="/t/a-slug/1234/2">some title</a>', "correctly generates items' content");
+    });
   });
 });
 


### PR DESCRIPTION
This makes so the notifications dropdown doesn't wait for an ajax response to open per @SamSaffron's suggestion. Instead, notifications are pushed down in a MessageBus.

I tested the following:
1. Notifications appear upon logging in.
2. New notifications are pushed to the dropdown when the dropdown is already open.
3. The unread notifications count clears upon clicking the dropdown.
4. Unread notifications count stays the same after logging out then logging back in.

Thoughts? I really appreciate any code review suggestions.
