### PR TITLE
Add message in usercard for empty 'About Me'

### DIFF
--- a/app/assets/javascripts/discourse/templates/poster_expansion.handlebars
+++ b/app/assets/javascripts/discourse/templates/poster_expansion.handlebars
@@ -13,7 +13,11 @@
     {{groups-list groups=user.custom_groups}}
 
     <div class='bottom'>
-      {{#if user.bio_cooked}}<div class='bio'>{{{user.bio_cooked}}}</div>{{/if}}
+      {{#if user.bio_cooked}}
+          <div class='bio'>{{{user.bio_cooked}}}</div>
+      {{else}}
+          <div class='bio bio-empty'>{{i18n empty_about_me}}</div>
+      {{/if}}
 
       {{#if user.can_send_private_message_to_user}}
         <button class='btn' {{action composePrivateMessage user}}><i class='fa fa-envelope'></i>{{i18n user.private_message}}</button>

--- a/app/assets/stylesheets/desktop/poster_expansion.scss
+++ b/app/assets/stylesheets/desktop/poster_expansion.scss
@@ -77,4 +77,8 @@
   .new-user a {
     color: $primary_medium;
   }
+
+  .bio-empty {
+    font-style: italic;
+  }
 }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1196,6 +1196,8 @@ en:
 
     browser_update: 'Unfortunately, <a href="http://www.discourse.org/faq/#browser">your browser is too old to work on this Discourse forum</a>. Please <a href="http://browsehappy.com">upgrade your browser</a>.'
 
+    empty_about_me: 'This user has not yet filled out the About Me section of their profile.'
+
     permission_types:
       full: "Create / Reply / See"
       create_post: "Reply / See"


### PR DESCRIPTION
![image](https://f.cloud.github.com/assets/627891/2237001/b80bb0a8-9b80-11e3-85da-b422c01026ad.png)

This should, hopefully, be a gentle nudge to filling the info out. Looking around at Meta Discourse, most peoples' are empty.
