### PR TITLE
Update INSTALL-digital-ocean.md

### DIFF
--- a/docs/INSTALL-digital-ocean.md
+++ b/docs/INSTALL-digital-ocean.md
@@ -63,7 +63,7 @@ Replace `192.168.1.1` with the IP address you got from Digital Ocean.
 
 Finish installing Docker:
 
-    wget -qO- https://get.docker.io/ | sh
+    sudo wget -qO- https://get.docker.io/ | sh
 
 <img src="https://meta-discourse.r.worldssl.net/uploads/default/3004/e75967a1a8e27ea3.png" width="567" height="307"> 
 


### PR DESCRIPTION
Why not use the docker install script? It has checks to make sure things are installed correctly. It could also be done via curl: 'curl -sL https://get.docker.io/ | sh'.

There's also https://get.docker.io/ubuntu/ as well, which has less checks.

Finally, should there be steps to set up an additional user and disable root login? Seems a little insecure.
