### PR TITLE
removing background gap on topic closures

### DIFF
--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -559,6 +559,7 @@ iframe {
 .moderator {
   .topic-body {
   background-color: $highlight_background_color;
+  border-bottom: 10px solid $highlight_background_color;
   }
 }
 
@@ -631,7 +632,7 @@ position: relative;
 
 
 .user-title {
-  margin-top: 8px;
+  margin-top: 5px;
   color: $secondary_text_color;
   overflow: hidden;
   font-size: 80%;


### PR DESCRIPTION
This 
![screenshot 2014-02-26 17 33 06](https://f.cloud.github.com/assets/1681963/2276656/460a43d4-9f36-11e3-8410-96e1e27a26d8.png)

becomes 

![screenshot 2014-02-26 17 33 31](https://f.cloud.github.com/assets/1681963/2276658/4be9efca-9f36-11e3-8a0c-2aba45369b5a.png)
