### PR TITLE
Post abandon dialog: add explicit confirm button text

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -904,7 +904,10 @@ en:
         image_upload_not_allowed_for_new_user: "Sorry, new users can not upload images."
         attachment_upload_not_allowed_for_new_user: "Sorry, new users can not upload attachments."
 
-      abandon: "Are you sure you want to abandon your post?"
+      abandon:
+        confirm: "Are you sure you want to abandon your post?"
+        yes_value: "Yes, abandon"
+        no_value: "No, keep"
 
       archetypes:
         save: 'Save Options'


### PR DESCRIPTION
The abandon post dialog uses plain Yes/No default button text. Instead, each button should say what it does more explicitly.

This text hasn't been changed since the initial release of Discourse (though it has moved around a bit).

The change passes yamllint.com checks, and follows the style found in the rest of the document, but I don't know if this change actually has the desired effect and I have no means to test it.
