### PR TITLE
allow for custom username lengths via site settings

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -93,9 +93,15 @@ class User < ActiveRecord::Base
     ALWAYS = -1
     LAST_VISIT = -2
   end
+  
+  DEFAULT_USERNAME_LENGTH_RANGE = 3..15
 
   def self.username_length
-    3..15
+    if SiteSetting.enforce_global_nicknames
+      DEFAULT_USERNAME_LENGTH_RANGE
+    else
+      SiteSetting.min_username_length.to_i..SiteSetting.max_username_length.to_i
+    end
   end
 
   def custom_groups

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -669,7 +669,10 @@ en:
     invite_only: "Public registration is disabled, new users must be invited"
 
     login_required: "Require authentication to read posts"
-
+    
+    min_username_length: "Minimum username length. (Does not apply if global nickname uniqueness is forced)"
+    max_username_length: "Maximum username length. (Does not apply if global nickname uniqueness is forced)"
+    
     min_password_length: "Minimum password length."
     block_common_passwords: "Don't allow passwords that are in the 5000 most common passwords."
 

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -93,6 +93,12 @@ users:
   must_approve_users:
     client: true
     default: false
+  min_username_length:
+    client: true
+    default: 3
+  max_username_length:
+    client: true
+    default: 15
   min_password_length:
     client: true
     default: 8


### PR DESCRIPTION
SiteSetting.min_username_length and SiteSetting.max_username_length allow changing of min and max length for local usernames.

Note: the custom lengths are not considered and the default is used if `enforce_global_nicknames` is true
