### PR TITLE
add option to override user attributes from SSO payload

### DIFF
--- a/app/models/discourse_single_sign_on.rb
+++ b/app/models/discourse_single_sign_on.rb
@@ -39,31 +39,19 @@ class DiscourseSingleSignOn < SingleSignOn
     "SSO_NONCE_#{nonce}"
   end
 
-
   def lookup_or_create_user
     sso_record = SingleSignOnRecord.where(external_id: external_id).first
-    if sso_record && sso_record.user
+    
+    if sso_record && user = sso_record.user
       sso_record.last_payload = unsigned_payload
-      sso_record.save
     else
-      user = User.where(email: Email.downcase(email)).first
-
-      user_params = {
-          email: email,
-          name:  User.suggest_name(name || username || email),
-          username: UserNameSuggester.suggest(username || name || email),
-      }
-
-      if user || user = User.create(user_params)
-        if sso_record = user.single_sign_on_record
-          sso_record.last_payload = unsigned_payload
-          sso_record.external_id = external_id
-          sso_record.save!
-        else
-          sso_record = user.create_single_sign_on_record(last_payload: unsigned_payload,
-                                            external_id: external_id)
-        end
-      end
+      user = match_email_or_create_user
+      sso_record = user.single_sign_on_record
+    end
+    
+    # if the user isn't new or it's attached to the SSO record we might be overriding username or email
+    unless user.new_record?
+      change_external_attributes_and_override(sso_record, user)
     end
 
     if sso_record && (user = sso_record.user) && !user.active
@@ -71,8 +59,62 @@ class DiscourseSingleSignOn < SingleSignOn
       user.save
       user.enqueue_welcome_message('welcome_user')
     end
+    
+    # optionally save the user and sso_record if they have changed
+    user.save!
+    sso_record.save!
 
     sso_record && sso_record.user
   end
-end
+  
+  private
+  
+  def match_email_or_create_user
+    user = User.where(email: Email.downcase(email)).first
 
+    user_params = {
+        email: email,
+        name:  User.suggest_name(name || username || email),
+        username: UserNameSuggester.suggest(username || name || email),
+    }
+
+    if user || user = User.create(user_params)
+      if sso_record = user.single_sign_on_record
+        sso_record.last_payload = unsigned_payload
+        sso_record.external_id = external_id
+      else
+        sso_record = user.create_single_sign_on_record(last_payload: unsigned_payload,
+                                          external_id: external_id,
+                                          external_username: username,
+                                          external_email: email,
+                                          external_name: name)
+      end
+    end
+    
+    user
+  end
+  
+  def change_external_attributes_and_override(sso_record, user)
+    if SiteSetting.sso_overrides_email && email != sso_record.external_email
+      # set the user's email to whatever came in the payload
+      user.email = email
+    end
+    
+    if SiteSetting.sso_overrides_username && username != sso_record.external_username && user.username != username
+      # we have an external username change, and the user's current username doesn't match
+      # run it through the UserNameSuggester to override it
+      user.username = UserNameSuggester.suggest(username || name || email)  
+    end
+    
+    if SiteSetting.sso_overrides_name && name != sso_record.external_name && user.name != name
+      # we have an external name change, and the user's current name doesn't match
+      # run it through the name suggester to override it
+      user.name = User.suggest_name(name || username || email)
+    end
+    
+    # change external attributes for sso record
+    sso_record.external_username = username
+    sso_record.external_email = email
+    sso_record.external_name = name
+  end
+end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -676,6 +676,9 @@ en:
     enable_sso: "Enable single sign on via an external site"
     sso_url: "URL of single sign on endpoint"
     sso_secret: "Secret string used to encrypt/decrypt SSO information, be sure it is 10 chars or longer"
+    sso_overrides_email: "Overrides local email with external site email from SSO payload (WARNING: discrepancies can occur due to normalization of local emails)"
+    sso_overrides_username: "Overrides local username with external site username from SSO payload (WARNING: discrepancies can occur due to differences in username length/requirements)"
+    sso_overrides_name: "Overrides local name with external site name from SSO payload (WARNING: discrepancies can occur due to normalization of local names)"
 
     enable_local_logins: "Enable traditional, local username and password authentication"
     enable_local_account_create: "Enable creating new local accounts"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -78,6 +78,15 @@ users:
     default: ''
   sso_secret:
     defalt: ''
+  sso_overrides_email:
+    client: true
+    default: false
+  sso_overrides_username:
+    client: true
+    default: false
+  sso_overrides_name:
+    client: true
+    default: false
   enable_local_logins:
     client: true
     default: true

--- a/db/migrate/20140228005443_add_external_username_to_single_sign_on_record.rb
+++ b/db/migrate/20140228005443_add_external_username_to_single_sign_on_record.rb
@@ -1,0 +1,5 @@
+class AddExternalUsernameToSingleSignOnRecord < ActiveRecord::Migration
+  def change
+    add_column :single_sign_on_records, :external_username, :string
+  end
+end

--- a/db/migrate/20140228173431_add_external_email_and_external_name_to_single_sign_on_record.rb
+++ b/db/migrate/20140228173431_add_external_email_and_external_name_to_single_sign_on_record.rb
@@ -1,0 +1,6 @@
+class AddExternalEmailAndExternalNameToSingleSignOnRecord < ActiveRecord::Migration
+  def change
+    add_column :single_sign_on_records, :external_email, :string
+    add_column :single_sign_on_records, :external_name, :string
+  end
+end

--- a/lib/single_sign_on.rb
+++ b/lib/single_sign_on.rb
@@ -1,5 +1,5 @@
 class SingleSignOn
-  ACCESSORS = [:nonce, :name, :username, :email, :about_me, :external_id]
+  ACCESSORS = [:nonce, :name, :username, :email, :about_me, :external_email, :external_username, :external_name, :external_id]
   FIXNUMS = []
   NONCE_EXPIRY_TIME = 10.minutes
 


### PR DESCRIPTION
- adds external_username, external_email, external_name to track the last attributes from SSO payload
- adds settings to site settings which allow overriding of any of the three attributes (default to false)
- according to setting, attempts to override name, email, and/or username during sso login process
