### PR TITLE
Explicit button text in abandon dialog in all lang

### DIFF
--- a/app/assets/javascripts/discourse/controllers/composer_controller.js
+++ b/app/assets/javascripts/discourse/controllers/composer_controller.js
@@ -335,7 +335,8 @@ Discourse.ComposerController = Discourse.Controller.extend({
 
     return new Ember.RSVP.Promise(function (resolve) {
       if (self.get('model.hasMetaData') || self.get('model.replyDirty')) {
-        bootbox.confirm(I18n.t("post.abandon"), I18n.t("no_value"), I18n.t("yes_value"), function(result) {
+        bootbox.confirm(I18n.t("post.abandon.confirm"), I18n.t("post.abandon.no_value"),
+            I18n.t("post.abandon.yes_value"), function(result) {
           if (result) {
             self.destroyDraft();
             self.get('model').clearState();

--- a/config/locales/client.cs.yml
+++ b/config/locales/client.cs.yml
@@ -772,7 +772,10 @@ cs:
         image_upload_not_allowed_for_new_user: "Bohužel, noví uživatelé nemohou nahrávat obrázky."
         attachment_upload_not_allowed_for_new_user: "Bohužel, noví uživatelé nemohou nahrávat přílohy."
 
-      abandon: "Opravdu chcete opustit váš příspěvek?"
+      abandon:
+        confirm: "Opravdu chcete opustit váš příspěvek?"
+        no_value: "Ne"
+        yes_value: "Ano"
 
       archetypes:
         save: 'Uložit nastavení'

--- a/config/locales/client.da.yml
+++ b/config/locales/client.da.yml
@@ -839,7 +839,10 @@ da:
         image_upload_not_allowed_for_new_user: "Beklager, nye brugere kan ikke uploade billeder."
         attachment_upload_not_allowed_for_new_user: "Beklager, nye brugere kan ikke uploade vedhæftede filer."
 
-      abandon: "Er du sikker på, at du vil droppe dit indlæg?"
+      abandon:
+        confirm: "Er du sikker på, at du vil droppe dit indlæg?"
+        no_value: "Nej"
+        yes_value: "Ja"
 
       archetypes:
         save: 'Gem indstillinger'

--- a/config/locales/client.de.yml
+++ b/config/locales/client.de.yml
@@ -873,7 +873,10 @@ de:
         image_upload_not_allowed_for_new_user: "Entschuldige, neue Benutzer dürfen keine Bilder hochladen."
         attachment_upload_not_allowed_for_new_user: "Entschuldige, neue Benutzer dürfen keine Dateien hochladen."
 
-      abandon: "Willst Du diesen Beitrag wirklich verwerfen?"
+      abandon:
+        confirm: "Willst Du diesen Beitrag wirklich verwerfen?"
+        no_value: "Nein"
+        yes_value: "Ja"
 
       archetypes:
         save: 'Speicheroptionen'

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -904,7 +904,10 @@ en:
         image_upload_not_allowed_for_new_user: "Sorry, new users can not upload images."
         attachment_upload_not_allowed_for_new_user: "Sorry, new users can not upload attachments."
 
-      abandon: "Are you sure you want to abandon your post?"
+      abandon:
+        confirm: "Are you sure you want to abandon your post?"
+        no_value: "No, keep"
+        yes_value: "Yes, abandon"
 
       archetypes:
         save: 'Save Options'

--- a/config/locales/client.es.yml
+++ b/config/locales/client.es.yml
@@ -745,7 +745,10 @@ es:
         edit: "Lo sentimos, hubo un error al editar tu publicación. Por favor, inténtalo de nuevo."
         upload: "Lo sentimos, hubo un error al subir el archivo. Por favor, inténtalo de nuevo."
 
-      abandon: "¿Estás seguro que deseas abandonar tu publicación?"
+      abandon:
+        confirm: "¿Estás seguro que deseas abandonar tu publicación?"
+        no_value: "No"
+        yes_value: "Sí"
 
       archetypes:
         save: 'Guardar opciones'

--- a/config/locales/client.fr.yml
+++ b/config/locales/client.fr.yml
@@ -896,7 +896,10 @@ fr:
         image_upload_not_allowed_for_new_user: "Désolé, les nouveaux utilisateurs ne peuvent pas envoyer d'image."
         attachment_upload_not_allowed_for_new_user: "Désolé, les nouveaux utilisateurs ne peuvent pas envoyer de fichier."
 
-      abandon: "Voulez-vous vraiment abandonner ce message ?"
+      abandon:
+        confirm: "Voulez-vous vraiment abandonner ce message ?"
+        no_value: "Non"
+        yes_value: "Oui"
 
       archetypes:
         save: 'Sauvegarder les options'

--- a/config/locales/client.id.yml
+++ b/config/locales/client.id.yml
@@ -499,7 +499,10 @@ id:
         edit: "Sorry, there was an error editing your post. Please try again."
         upload: "Sorry, there was an error uploading that file. Please try again."
 
-      abandon: "Are you sure you want to abandon your post?"
+      abandon:
+        confirm: "Are you sure you want to abandon your post?"
+        no_value: "Tidak"
+        yes_value: "Ya"
 
       archetypes:
         save: 'Save Options'

--- a/config/locales/client.it.yml
+++ b/config/locales/client.it.yml
@@ -759,7 +759,10 @@ it:
         image_too_large: "Spiacenti, il file che stai cercando di caricare è troppo grande (la dimensione massima è {{max_size_kb}}kb), per favore ridimensionalo e prova di nuovo."
         too_many_uploads: "Spiacenti, puoi caricare un'immagine per volta."
 
-      abandon: "Sei sicuro di voler abbandonare il tuo post?"
+      abandon:
+        confirm: "Sei sicuro di voler abbandonare il tuo post?"
+        no_value: "No"
+        yes_value: "Si"
 
       archetypes:
         save: 'Opzioni di Salvataggio'

--- a/config/locales/client.ja.yml
+++ b/config/locales/client.ja.yml
@@ -786,7 +786,10 @@ ja:
         image_upload_not_allowed_for_new_user: "申し訳ありませんが、新規ユーザは画像のアップロードができません。"
         attachment_upload_not_allowed_for_new_user: "申し訳ありませんが、新規ユーザはファイルの添付ができません。"
 
-      abandon: "編集中のポストを破棄してもよろしいですか?"
+      abandon:
+        confirm: "編集中のポストを破棄してもよろしいですか?"
+        no_value: "いいえ"
+        yes_value: "はい"
 
       archetypes:
         save: '保存オプション'

--- a/config/locales/client.ko.yml
+++ b/config/locales/client.ko.yml
@@ -807,7 +807,10 @@ ko:
         image_upload_not_allowed_for_new_user: "죄송합니다. 새로운 유저는 이미지를 업로드 하실 수 없습니다."
         attachment_upload_not_allowed_for_new_user: "죄송합니다. 새로운 유저는 파일 첨부를 업로드 하실 수 없습니다."
 
-      abandon: "게시물 작성을 취소 하시겠습니까?"
+      abandon:
+        confirm: "게시물 작성을 취소 하시겠습니까?"
+        no_value: "아니오"
+        yes_value: "예"
 
       archetypes:
         save: '옵션 저장'
@@ -1410,6 +1413,3 @@ ko:
           rate_limits: '제한'
           developer: '개발자'
           uncategorized: '카테고리 없음'
-
-
-

--- a/config/locales/client.nb_NO.yml
+++ b/config/locales/client.nb_NO.yml
@@ -655,7 +655,10 @@ nb_NO:
         image_too_large: "Beklager, filen du prøve å laste opp er for stor (maks størrelse er {{max_size_kb}}kb), vennligst reduser størrelsen og prøv igjen."
         too_many_uploads: "Beklager, du kan bare laste opp ett bilde om gangen."
 
-      abandon: "Er du sikker på at du vil forlate innlegget ditt?"
+      abandon:
+        confirm: "Er du sikker på at du vil forlate innlegget ditt?"
+        no_value: "Nei"
+        yes_value: "Ja"
 
       archetypes:
         save: 'Lagre Alternativene'

--- a/config/locales/client.nl.yml
+++ b/config/locales/client.nl.yml
@@ -855,7 +855,10 @@ nl:
         image_upload_not_allowed_for_new_user: "Sorry, nieuwe gebruikers mogen nog geen afbeeldingen uploaden."
         attachment_upload_not_allowed_for_new_user: "Sorry, nieuwe gebruikers mogen nog geen bestanden uploaden."
 
-      abandon: Weet je zeker dat je het schrijven van dit bericht wil afbreken?
+      abandon:
+        confirm: Weet je zeker dat je het schrijven van dit bericht wil afbreken?
+        no_value: Nee
+        yes_value: Ja
 
       archetypes:
         save: Bewaar instellingen

--- a/config/locales/client.pt.yml
+++ b/config/locales/client.pt.yml
@@ -470,7 +470,10 @@ pt:
         edit: "Desculpa, houve um erro ao editar o teu post. Por favor tenta outra vez."
         upload: "Desculpa, houve um erro ao enviar esse ficheiro. Por favor tenta otura vez."
 
-      abandon: "De certeza que queres abandonar o teu post?"
+      abandon:
+        confirm: "De certeza que queres abandonar o teu post?"
+        no_value: "Não"
+        yes_value: "Sim"
 
       archetypes:
         save: 'Guardar as Opções'

--- a/config/locales/client.pt_BR.yml
+++ b/config/locales/client.pt_BR.yml
@@ -796,7 +796,10 @@ pt_BR:
         image_upload_not_allowed_for_new_user: "Desculpe, novos usuários não podem enviar imagens."
         attachment_upload_not_allowed_for_new_user: "Desculpe, novos usuários não podem enviar arquivos."
 
-      abandon: "Tem certeza que quer abandonar o seu post?"
+      abandon:
+        confirm: "Tem certeza que quer abandonar o seu post?"
+        no_value: "Não"
+        yes_value: "Sim"
 
       archetypes:
         save: 'Guardar as Opções'

--- a/config/locales/client.ru.yml
+++ b/config/locales/client.ru.yml
@@ -889,7 +889,10 @@ ru:
         upload_not_authorized: 'К сожалению, вы не можете загрузить файл данного типа (список разрешенных типов файлов: {{authorized_extensions}}).'
         image_upload_not_allowed_for_new_user: 'К сожалению, загрузка изображений недоступна новым пользователям.'
         attachment_upload_not_allowed_for_new_user: 'К сожалению, загрузка файлов недоступна новым пользователям.'
-      abandon: 'Удалить сохраненный черновик?'
+      abandon:
+        confirm: 'Удалить сохраненный черновик?'
+        no_value: "Нет"
+        yes_value: "Да"
       archetypes:
         save: 'Параметры сохранения'
       controls:

--- a/config/locales/client.sv.yml
+++ b/config/locales/client.sv.yml
@@ -821,7 +821,10 @@ sv:
         image_upload_not_allowed_for_new_user: "Tyvärr, nya användare kan inte ladda upp bilder."
         attachment_upload_not_allowed_for_new_user: "Tyvärr, nya användare kan inte ladda upp filer."
 
-      abandon: "Är du säker på att du vill överge ditt inlägg?"
+      abandon:
+        confirm: "Är du säker på att du vill överge ditt inlägg?"
+        no_value: "Nej"
+        yes_value: "Ja"
 
       archetypes:
         save: 'Spara Inställningar'

--- a/config/locales/client.zh_CN.yml
+++ b/config/locales/client.zh_CN.yml
@@ -868,7 +868,10 @@ zh_CN:
         image_upload_not_allowed_for_new_user: "抱歉，新注册用户无法上传图片。"
         attachment_upload_not_allowed_for_new_user: "抱歉，新注册用户无法上传附件。"
 
-      abandon: "你确定要丢弃你的帖子吗？"
+      abandon:
+        confirm: "你确定要丢弃你的帖子吗？"
+        no_value: "否"
+        yes_value: "是"
 
       archetypes:
         save: '保存选项'

--- a/config/locales/client.zh_TW.yml
+++ b/config/locales/client.zh_TW.yml
@@ -834,7 +834,10 @@ zh_TW:
         image_upload_not_allowed_for_new_user: "抱歉，新用戶不可上傳圖片。"
         attachment_upload_not_allowed_for_new_user: "抱歉，新用戶不可上傳附件。"
 
-      abandon: "你確定要捨棄你的貼文嗎?"
+      abandon:
+        confirm: "你確定要捨棄你的貼文嗎?"
+        no_value: "否"
+        yes_value: "是"
 
       archetypes:
         save: '儲存選項'


### PR DESCRIPTION
The current post abandon dialog displays typical yes/no buttons and should instead show more informative button text.

This commit updates all `config/locales/client.*.yml` files and **alters the structure** of the `post.abandon` node, and **adds three new nodes** under it: `confirm`, `yes_value`, and `no_value`. The current value of the `post.abandon` node is moved into `post.abandon.confirm` for all languages. For English language text, the nodes `post.abandon.yes_value` and `.no_value` are changed to `"Yes, abandon"` and `"No, keep"`, respectively. For other languages, the standard yes/no values are copied, allowing simple copyedits to make them more explicit in the future, otherwise there should be no net visible change.

I also make the necessary changes to the `composer_controller.js` file so the new values are used correctly.

All changed language files pass yamllint.com checks. English was tested directly, but **none of the other languages were confirmed to work**.

![image](https://f.cloud.github.com/assets/133882/2300636/cdad5f32-a0fe-11e3-95d9-57f46faf91ff.png)
