### PR TITLE
Feature: Add CORS-Configuration Option

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,6 +27,7 @@ class ApplicationController < ActionController::Base
   end
 
   before_filter :set_locale
+  before_filter :set_cors
   before_filter :set_mobile_view
   before_filter :inject_preview_style
   before_filter :disable_customization
@@ -110,6 +111,12 @@ class ApplicationController < ActionController::Base
     else
       render text: build_not_found_page(error, include_ember ? 'application' : 'no_js')
     end
+  end
+
+  def set_cors
+    return unless SiteSetting.cors_header
+    return unless request.format && request.format.json?
+    response.headers['Access-Control-Allow-Origin'] = SiteSetting.cors_header
   end
 
   def set_locale

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -605,6 +605,7 @@ en:
     notification_email: "The return email address used when sending system emails such as notifying users of lost passwords, new accounts etc"
     email_custom_headers: "A pipe-delimited list of custom email headers"
     use_https: "Should the full url for the site (Discourse.base_url) be http or https?"
+    cors_header: "Set the 'Access-Control-Allow-Origin'-Header to allow Ajax-Requests on websites of specified domains"
     summary_score_threshold: "The minimum score of a post to be included in the 'summary'"
     summary_posts_required: "Minimum posts in a topic before 'summary' mode is enabled"
     summary_likes_required: "Minimum likes in a topic before the 'summary' mode will be enabled"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -305,6 +305,7 @@ trust:
 security:
   enable_flash_video_onebox: false
   use_https: false
+  cors_header: ""
   enable_escaped_fragments:
     client: true
     default: true


### PR DESCRIPTION
 Allow admin to specify 'Access-Control-Allow-Origin' for CROSS-Domain Ajax requests. [See MDN to learn more about CORS](https://developer.mozilla.org/en-US/docs/HTTP/Access_control_CORS). 
