### PR TITLE
Scroll to Top of Topic instead of Reloading

### DIFF
--- a/app/assets/javascripts/discourse/controllers/header_controller.js
+++ b/app/assets/javascripts/discourse/controllers/header_controller.js
@@ -30,6 +30,13 @@ Discourse.HeaderController = Discourse.Controller.extend({
         self.set("currentUser.unread_notifications", 0);
         headerView.showDropdownBySelector("#user-notifications");
       });
+    },
+
+    jumpToTopPost: function () {
+      var topic = this.get('topic');
+      if (topic) {
+        Discourse.URL.routeTo(topic.get('firstPostUrl'));
+      }
     }
   }
 

--- a/app/assets/javascripts/discourse/controllers/topic_controller.js
+++ b/app/assets/javascripts/discourse/controllers/topic_controller.js
@@ -22,7 +22,7 @@ Discourse.TopicController = Discourse.ObjectController.extend(Discourse.Selected
 
   actions: {
     jumpTop: function() {
-      Discourse.URL.routeTo(this.get('url'));
+      Discourse.URL.routeTo(this.get('firstPostUrl'));
     },
 
     jumpBottom: function() {

--- a/app/assets/javascripts/discourse/models/topic.js
+++ b/app/assets/javascripts/discourse/models/topic.js
@@ -68,7 +68,7 @@ Discourse.Topic = Discourse.Model.extend({
   // Helper to build a Url with a post number
   urlForPostNumber: function(postNumber) {
     var url = this.get('url');
-    if (postNumber && (postNumber > 1)) {
+    if (postNumber && (postNumber > 0)) {
       if (postNumber >= this.get('highest_post_number')) {
         url += "/last";
       } else {
@@ -90,6 +90,10 @@ Discourse.Topic = Discourse.Model.extend({
   lastPostUrl: function() {
     return this.urlForPostNumber(this.get('highest_post_number'));
   }.property('url', 'highest_post_number'),
+
+  firstPostUrl: function () {
+    return this.urlForPostNumber(1);
+  }.property('url'),
 
   lastPosterUrl: function() {
     return Discourse.getURL("/users/") + this.get("last_poster.username");

--- a/app/assets/javascripts/discourse/templates/header.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/header.js.handlebars
@@ -19,7 +19,7 @@
           {{boundCategoryLink topic.category}}
           {{#if topic.details.loaded}}
             {{topicStatus topic=topic}}
-            <a class='topic-link' href='{{unbound topic.url}}'>{{{topic.fancy_title}}}</a>
+            <a class='topic-link' href='{{unbound topic.url}}' {{action jumpToTopPost}}>{{{topic.fancy_title}}}</a>
           {{else}}
             {{#if topic.errorLoading}}
               {{topic.errorTitle}}

--- a/app/assets/javascripts/discourse/templates/topic.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/topic.js.handlebars
@@ -35,7 +35,7 @@
               {{boundCategoryLink category}}
               {{#if details.loaded}}
                 {{topicStatus topic=model}}
-                <a href='{{unbound url}}'>
+                <a href='{{unbound url}}' {{action jumpTop}}>
                   {{#if topicSaving}}
                     {{fancy_title}}
                   {{else}}


### PR DESCRIPTION
This PR changes the following links to use URLs with the first post rather than the topic url:
1. Clicking a Topic's header. 
2. Quotes and Replies to the first post. 
3. Jump to Top button in the Progress Bar.

For example. We'll now link to `/t/discourse-general-polish/13184/1/` instead of than `/t/discourse-general-polish/13184`. This loads the topic much more quickly than the full page reload.

From: https://meta.discourse.org/t/discourse-general-polish/13184

> We unconditionally reload topic page if you click on "title". instead it should scroll you to top if post 0 is already in memory. Same for in between posts navigation (eg quoting and so on)
