### PR TITLE
Don't run plugin gem tests

### DIFF
--- a/lib/tasks/plugin.rake
+++ b/lib/tasks/plugin.rake
@@ -45,7 +45,7 @@ end
 
 desc 'run plugin specs'
 task 'plugin:spec', :plugin do |t, args|
-  args.with_defaults(plugin: "**")
+  args.with_defaults(plugin: "*")
   ruby = `which ruby`.strip
   files = Dir.glob("./plugins/#{args[:plugin]}/spec/**/*.rb")
   if files.length > 0


### PR DESCRIPTION
Use a single \* to avoid running plugin gem tests, pointed out by @shivpkumar here: https://meta.discourse.org/t/how-do-we-test-plugins/11887/7
