### PR TITLE
Add plugin specs to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ before_script:
   - export RUBY_GC_MALLOC_LIMIT=50000000
   - bundle exec rake db:migrate
 bundler_args: --without development
-script: 'bundle exec rspec && bundle exec rake qunit:test'
+script: 'bundle exec rspec && bundle exec rake plugin:spec && bundle exec rake qunit:test'
 services:
   - redis-server


### PR DESCRIPTION
Seems like a good idea to run plugin specs (ie. the poll plugin's specs right now) as part of the Travis build?
