### PR TITLE
adding basic :focus style in for buttons in Firefox

### DIFF
--- a/app/assets/stylesheets/desktop/discourse.scss
+++ b/app/assets/stylesheets/desktop/discourse.scss
@@ -13,8 +13,6 @@ body {
   min-width: $large-width;
 }
 
-
-
 .container {
   @extend .clearfix;
   max-width: $large-width;
@@ -35,11 +33,7 @@ body {
   .full-width {
     width: $medium-width;
   }
-
-
 }
-
-/**/
 
 
 @include small-width {
@@ -50,7 +44,6 @@ body {
   .full-width {
     width: $small-width;
   }
-
 }
 
 a.no-href {
@@ -79,6 +72,12 @@ body {
       color: $tertiary_text_color;
     }
   }
+
+  // tab focus in firefox
+  button:focus::-moz-focus-inner {
+  border: 1px dotted;
+  }
+
   .coldmap-high {
     color: $coldmap-high !important;
   }


### PR DESCRIPTION
![screenshot 2014-03-05 22 19 44](https://f.cloud.github.com/assets/1681963/2341555/343cea1e-a4de-11e3-96a2-9d7b9875a653.png)

based on https://meta.discourse.org/t/focus-on-images-icons-not-noticeable-in-firefox/
