### PR TITLE
Style 'urgent' composer popups differently

### DIFF
--- a/app/assets/stylesheets/desktop/compose.scss
+++ b/app/assets/stylesheets/desktop/compose.scss
@@ -18,6 +18,12 @@
 
   @include box-shadow(3px 3px 3px rgba($primary_shadow_color, 0.14));
   background: lighten($highlight, 15%);
+  border: 1px solid $highlight_border_color;
+
+  &.urgent {
+    background: lighten($warning_border_color, 15%);
+    border: 1px solid $warning_border_color;
+  }
 
   h3 {
     margin-bottom: 10px;
@@ -38,7 +44,6 @@
     opacity: 1.0;
   }
 
-  border: 1px solid $highlight_border_color;
   padding: 10px;
   width: 600px;
   position: absolute;

--- a/lib/composer_messages_finder.rb
+++ b/lib/composer_messages_finder.rb
@@ -88,6 +88,7 @@ class ComposerMessagesFinder
 
     {templateName: 'composer/education',
      wait_for_typing: true,
+     extraClass: 'urgent',
      body: PrettyText.cook(I18n.t('education.sequential_replies')) }
   end
 
@@ -118,6 +119,7 @@ class ComposerMessagesFinder
 
     {templateName: 'composer/education',
      wait_for_typing: true,
+     extraClass: 'urgent',
      body: PrettyText.cook(I18n.t('education.dominating_topic', percent: (ratio * 100).round)) }
   end
 


### PR DESCRIPTION
The two "bad behavior" composer popups get the 'urgent' class, which colors them red.

![image](https://f.cloud.github.com/assets/627891/2352315/7e6171e6-a588-11e3-89df-516246cd8b8c.png)

This took me a good hour of looking around the code to do :/

<hr>
### Rationale

After seeing the education messages four times, you start to ignore them. By coloring the 'bad behavior' popups differently than the education messages, it's more likely that you recognize it as something different, something to pay attention to.
