### PR TITLE
Be more liberal when users wants to change their own body to a previous version

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -101,12 +101,13 @@ class Post < ActiveRecord::Base
 
   def store_unique_post_key
     if SiteSetting.unique_posts_mins > 0
-      $redis.setex(unique_post_key, SiteSetting.unique_posts_mins.minutes.to_i, "1")
+      $redis.setex(unique_post_key, SiteSetting.unique_posts_mins.minutes.to_i, id)
     end
   end
 
   def matches_recent_post?
-    $redis.exists(unique_post_key)
+    post_id = $redis.get(unique_post_key)
+    post_id != nil and post_id != id
   end
 
   def raw_hash


### PR DESCRIPTION
Be more liberal when the similar content of the post to be saved turns out to be the same post:
- instead of setting a random number, we actually store the post id in redis now
- and when checking for matching recent post and it is the same, we allow it still

Fixes the issue that we prevent a user from reverting to a previous state within the unique_posts_min time window.

Also see https://github.com/ligthyear/discourse-plugin-checklist/issues/2 and https://meta.discourse.org/t/checklist-a-simple-markdownified-checkbox-plugin-with-inline-updating/13428/7?u=bhaelochon
