### PR TITLE
fixing close topic/footer button/suggested topics alignment

### DIFF
--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -371,7 +371,7 @@ a.star {
 }
 
 #topic-footer-buttons {
-  padding: 10px 10px 0 10px;
+  padding: 10px 10px 0 0;
   p {
     line-height: 32px;
     color: $secondary_text_color;
@@ -381,7 +381,7 @@ a.star {
 
 #suggested-topics {
   clear: left;
-  padding: 20px 10px 15px 10px;
+  padding: 20px 0 15px 0;
 
   .topics table tbody tr {background: $primary_background_color;}
 


### PR DESCRIPTION
now everything's all left-aligned and :thumbsup: 
![screenshot 2014-03-07 14 56 32](https://f.cloud.github.com/assets/1681963/2361642/d0ff3568-a633-11e3-81c3-1a708c816bca.png)
