### PR TITLE
Clean up site_settings.yml

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -31,6 +31,13 @@ basic:
   allow_user_locale:
     client: true
     default: false
+  suggested_topics:
+    client: true
+    default: 5
+  default_external_links_in_new_tab: false
+  track_external_right_clicks:
+    client: true
+    default: false
   ga_tracking_code:
     client: true
     default: ''
@@ -43,19 +50,6 @@ basic:
   ga_universal_domain_name:
     client: true
     default: 'auto'
-  category_featured_topics:
-    client: true
-    default: 3
-  topics_per_page: 30
-  posts_per_page:
-    client: true
-    default: 20
-  suggested_topics:
-    client: true
-    default: 5
-  enable_mobile_theme:
-    client: true
-    default: true
   top_menu:
     client: true
     refresh: true
@@ -69,31 +63,27 @@ basic:
   category_colors:
     client: true
     default: 'BF1E2E|F1592A|F7941D|9EB83B|3AB54A|12A89D|25AAE2|0E76BD|652D90|92278F|ED207B|8C6238|231F20|808281|B3B5B4|283890'
+  enable_mobile_theme:
+    client: true
+    default: true
   relative_date_duration:
     client: true
     default: 30
   topics_per_period_in_top_summary: 20
   topics_per_period_in_top_page: 50
   redirect_new_users_to_top_page_duration: 7
+  category_featured_topics:
+    client: true
+    default: 3
+  topics_per_page: 30
+  posts_per_page:
+    client: true
+    default: 20
   enable_badges:
     client: true
     default: false
 
 users:
-  enable_sso:
-    client: true
-    default: false
-  sso_url: ''
-  sso_secret: ''
-  sso_overrides_email: false
-  sso_overrides_username: false
-  sso_overrides_name: false
-  enable_local_logins:
-    client: true
-    default: true
-  enable_local_account_create:
-    client: true
-    default: true
   invite_only:
     client: true
     default: false
@@ -103,6 +93,12 @@ users:
   must_approve_users:
     client: true
     default: false
+  enable_local_logins:
+    client: true
+    default: true
+  enable_local_account_create:
+    client: true
+    default: true
   min_username_length:
     client: true
     default: 3
@@ -131,14 +127,23 @@ users:
     default: false
   github_client_id: ''
   github_client_secret: ''
+  enable_sso:
+    client: true
+    default: false
+  sso_url: ''
+  sso_secret: ''
+  sso_overrides_email: false
+  sso_overrides_username: false
+  sso_overrides_name: false
   enforce_global_nicknames: false
   discourse_org_access_key: ''
-  invite_expiry_days: 4
   username_change_period: 3
+  auto_track_topics_after: 240000
   email_editable: true
   enable_names:
     client: true
     default: true
+  invite_expiry_days: 4
   invites_shown:
     client: true
     default: 30
@@ -146,7 +151,6 @@ users:
     client: true
     default: 60
   delete_all_posts_max: 15
-  default_external_links_in_new_tab: false
 
 posting:
   min_post_length:
@@ -164,12 +168,14 @@ posting:
     default:
       test: 4000
       default: 32000
+  body_min_entropy: 7
   min_topic_title_length:
     client: true
     default: 15
   max_topic_title_length:
     client: true
     default: 255
+  title_min_entropy: 10
   title_prettify: true
   title_fancy_entities: true
   min_private_message_title_length:
@@ -209,8 +215,6 @@ posting:
   newuser_max_replies_per_topic: 3
   newuser_max_mentions_per_post: 2
   onebox_max_chars: 5000
-  title_min_entropy: 10
-  body_min_entropy: 7
   max_word_length: 30
   newuser_max_links: 2
   newuser_max_images:
@@ -280,6 +284,11 @@ files:
   max_image_height:
     client: true
     default: 500
+  download_remote_images_to_local:
+    default:
+      test: false
+      default: true
+  download_remote_images_threshold: 20
   create_thumbnails: true
   clean_up_uploads: false
   clean_orphan_uploads_grace_period_hours: 1
@@ -302,15 +311,13 @@ files:
     default: false
   detect_custom_avatars: true
   max_daily_gravatar_crawls: 500
-  download_remote_images_to_local:
-    default:
-      test: false
-      default: true
-  download_remote_images_threshold: 20
 
 trust:
   default_trust_level: 0
   default_invitee_trust_level: 1
+  min_trust_to_create_topic:
+    default: 0
+    enum: 'MinTrustToCreateTopicSetting'
   basic_requires_topics_entered: 5
   basic_requires_read_posts: 50
   basic_requires_time_spent_mins: 15
@@ -321,28 +328,21 @@ trust:
   regular_requires_likes_received: 1
   regular_requires_likes_given: 1
   regular_requires_topic_reply_count: 3
-  min_trust_to_create_topic:
-    default: 0
-    enum: 'MinTrustToCreateTopicSetting'
 
 security:
   enable_flash_video_onebox: false
   use_https: false
   enable_escaped_fragments: true
-
-seo:
-  add_rel_nofollow_to_user_content: true
-  exclude_rel_nofollow_domains: ''
   allow_index_in_robots_txt: true
   enable_noscript_support: true
 
 spam:
+  add_rel_nofollow_to_user_content: true
+  exclude_rel_nofollow_domains: ''
   email_domains_blacklist: 'mailinator.com'
   email_domains_whitelist: ''
   flags_required_to_hide_post: 3
   cooldown_minutes_after_hiding_posts: 10
-  max_topics_in_first_day: 5
-  max_replies_in_first_day: 10
   num_flags_to_block_new_user: 3
   num_users_to_block_new_user: 3
   notify_mods_when_user_blocked: false
@@ -364,6 +364,8 @@ rate_limits:
   max_flags_per_day: 20
   max_edits_per_day: 30
   max_stars_per_day: 20
+  max_topics_in_first_day: 5
+  max_replies_in_first_day: 10
 
 developer:
   force_hostname: ''
@@ -375,6 +377,20 @@ developer:
     default:
       test: false
       default: true
+  enable_long_polling:
+    client: true
+    default: true
+  long_polling_interval: 15000
+  polling_interval:
+    client: true
+    default: 3000
+  anon_polling_interval:
+    client: true
+    default: 30000
+  flush_timings_secs:
+    client: true
+    default: 5
+  active_user_rate_limit_secs: 60
 
 embedding:
   embeddable_host: ''
@@ -395,6 +411,9 @@ legal:
   tos_accept_required:
     client: true
     default: false
+  faq_url:
+    client: true
+    default: ''
 
 backups:
   allow_restore:
@@ -413,47 +432,35 @@ backups:
     client: false
 
 uncategorized:
-
-  faq_url:
-    client: true
-    default: ''
-
-  track_external_right_clicks:
-    client: true
-    default: false
-
-  enable_long_polling:
-    client: true
-    default: true
-  polling_interval:
-    client: true
-    default: 3000
-  anon_polling_interval:
-    client: true
-    default: 30000
-  min_search_term_length:
-    client: true
-    default: 3
-  flush_timings_secs:
-    client: true
-    default: 5
   version_checks:
     client: true
     default: true
   new_version_emails: true
-  auto_track_topics_after: 240000
+  send_welcome_message: true
+
+  suppress_uncategorized_badge:
+    client: true
+    default: true
+
+  # Search
+  min_posts_for_search_in_topic: 10
+  min_search_term_length:
+    client: true
+    default: 3
+  max_similar_results: 7
+  minimum_topics_similar: 50
+
   new_topic_duration_minutes: 2880
-  long_polling_interval: 15000
-  active_user_rate_limit_secs: 60
   previous_visit_timeout_hours: 1
   staff_like_weight: 3
+
+  # Summary mode
   summary_score_threshold: 15
   summary_posts_required: 50
   summary_likes_required: 1
   summary_percent_filter: 20
-  send_welcome_message: true
-  educate_until_posts: 2
-  max_similar_results: 7
+
+  # View heat thresholds
   topic_views_heat_low:
     client: true
     default: 1000
@@ -463,12 +470,13 @@ uncategorized:
   topic_views_heat_high:
     client: true
     default: 5000
-  minimum_topics_similar: 50
+
+  # Warnings
+  educate_until_posts: 2
   sequential_replies_threshold: 2
   dominating_topic_minimum_percent: 20
-  suppress_uncategorized_badge:
-    client: true
-    default: true
+
+  # Category IDs
   lounge_category_id:
     default: -1
     hidden: true
@@ -478,5 +486,4 @@ uncategorized:
   staff_category_id:
     default: -1
     hidden: true
-  min_posts_for_search_in_topic: 10
 


### PR DESCRIPTION
- Hide several variables that the client does not use
- Use concise default syntax when possible

Notes:
- `allow_restore`, the two `delete_*` settings, `email_in`, `ga_*`, `invites_shown`, `version_checks` are all used on the client
