### PR TITLE
A draft for metadata storage to be used in plugins.

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -36,6 +36,8 @@ class Post < ActiveRecord::Base
 
   has_many :post_revisions
   has_many :revisions, foreign_key: :post_id, class_name: 'PostRevision'
+  
+  has_many :metadata, class_name: 'PostMeta', dependent: :destroy
 
   validates_with ::Validators::PostValidator
 
@@ -301,6 +303,13 @@ class Post < ActiveRecord::Base
 
   def url
     Post.url(topic.slug, topic.id, post_number)
+  end
+  
+  def meta
+    metadata.where(client: true).all.inject({}) do |hsh, mkv|
+      hsh[mkv.key] = mkv.value
+      hsh
+    end
   end
 
   def self.url(slug, topic_id, post_number)

--- a/app/models/post_meta.rb
+++ b/app/models/post_meta.rb
@@ -1,0 +1,3 @@
+class PostMeta < ActiveRecord::Base
+  belongs_to :post
+end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -77,6 +77,8 @@ class Topic < ActiveRecord::Base
   has_many :allowed_group_users, through: :allowed_groups, source: :users
   has_many :allowed_groups, through: :topic_allowed_groups, source: :group
   has_many :allowed_users, through: :topic_allowed_users, source: :user
+  
+  has_many :metadata, class_name: 'TopicMeta', dependent: :destroy
 
   has_one :top_topic
   belongs_to :user
@@ -297,6 +299,14 @@ class Topic < ActiveRecord::Base
   def meta_data_string(key)
     return unless meta_data.present?
     meta_data[key.to_s]
+  end
+  
+  # Only return client-enabled metadata for the serializer
+  def meta
+    metadata.where(client: true).all.inject({}) do |hsh, mkv|
+      hsh[mkv.key] = mkv.value
+      hsh
+    end
   end
 
   def self.listable_count_per_day(sinceDaysAgo=30)

--- a/app/models/topic_meta.rb
+++ b/app/models/topic_meta.rb
@@ -1,0 +1,3 @@
+class TopicMeta < ActiveRecord::Base
+  belongs_to :topic
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,6 +31,7 @@ class User < ActiveRecord::Base
   has_many :invites, dependent: :destroy
   has_many :topic_links, dependent: :destroy
   has_many :uploads
+  has_many :metadata, class_name: 'UserMeta', dependent: :destroy
 
   has_one :facebook_user_info, dependent: :destroy
   has_one :twitter_user_info, dependent: :destroy
@@ -386,6 +387,14 @@ class User < ActiveRecord::Base
     return false if staff? || Topic.where(id: topic_id, user_id: id).exists?
 
     trust_level == TrustLevel.levels[:newuser] && (Post.where(topic_id: topic_id, user_id: id).count >= SiteSetting.newuser_max_replies_per_topic)
+  end
+  
+  # Only return client-enabled metadata for the serializer
+  def meta
+    metadata.where(client: true).all.inject({}) do |hsh, mkv|
+      hsh[mkv.key] = mkv.value
+      hsh
+    end
   end
 
   def bio_excerpt

--- a/app/models/user_meta.rb
+++ b/app/models/user_meta.rb
@@ -1,0 +1,3 @@
+class UserMeta < ActiveRecord::Base
+  belongs_to :user
+end

--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -45,7 +45,8 @@ class PostSerializer < BasicPostSerializer
              :deleted_at,
              :deleted_by,
              :user_deleted,
-             :edit_reason
+             :edit_reason,
+             :meta
 
 
   def moderator?

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -20,7 +20,8 @@ class UserSerializer < BasicUserSerializer
              :admin,
              :title,
              :suspend_reason,
-             :suspended_till
+             :suspended_till,
+             :meta
 
   has_one :invited_by, embed: :object, serializer: BasicUserSerializer
   has_many :custom_groups, embed: :object, serializer: BasicGroupSerializer

--- a/db/migrate/20140306211903_create_user_meta.rb
+++ b/db/migrate/20140306211903_create_user_meta.rb
@@ -1,0 +1,16 @@
+class CreateUserMeta < ActiveRecord::Migration
+  def up
+    create_table :user_meta do |t|
+      t.belongs_to :user
+      t.boolean :client, default: false, null: false
+      t.string :key, limit: 100, null: false
+      t.text :value
+    end
+    
+    add_index :user_meta, :key, unique: true
+  end
+  
+  def down
+    drop_table :user_meta
+  end
+end

--- a/db/migrate/20140306211904_create_topic_meta.rb
+++ b/db/migrate/20140306211904_create_topic_meta.rb
@@ -1,0 +1,16 @@
+class CreateTopicMeta < ActiveRecord::Migration
+  def up
+    create_table :topic_meta do |t|
+      t.belongs_to :topic
+      t.boolean :client, default: false, null: false
+      t.string :key, limit: 100, null: false
+      t.text :value
+    end
+    
+    add_index :topic_meta, :key, unique: true
+  end
+  
+  def down
+    drop_table :topic_meta
+  end
+end

--- a/db/migrate/20140306211905_create_post_meta.rb
+++ b/db/migrate/20140306211905_create_post_meta.rb
@@ -1,0 +1,16 @@
+class CreatePostMeta < ActiveRecord::Migration
+  def up
+    create_table :post_meta do |t|
+      t.belongs_to :post
+      t.boolean :client, default: false, null: false
+      t.string :key, limit: 100, null: false
+      t.text :value
+    end
+    
+    add_index :post_meta, :key, unique: true
+  end
+  
+  def down
+    drop_table :post_meta
+  end
+end


### PR DESCRIPTION
As title says, this is a draft, and I would like some input on how I have structured it, and wheter it might be something that could be put in the core.

The initial idea, written [here](https://meta.discourse.org/t/custom-database-models-example-plugin/13014/9), kinda goes like this:
- Implement tables similar to wp_usermeta in WordPress, but for users, posts and topics(for now)
- Expose these on server-side in the correct models, and leave it open for plugin devs to use
- Optionally allow read-only exposure to the frontend for metadata with client set to true.

The small changes would give plugin devs the possibility to do many basic things without filling the existing tables for users/posts/topics, and without the need to deploy their own tables.

---
#### Some notes
- In the topic Model, I found that a key->value system named meta_data was already in place(using Postgres hstore). What is this used for and could it possibly be moved to this new system?
- I did not write anything in the topic serializer, as I was not sure where to expose the metadata there. Where would it be most useful?
