### PR TITLE
 Username/email change should not be allowed with SSO and username/email override enabled

### DIFF
--- a/lib/guardian/user_guardian.rb
+++ b/lib/guardian/user_guardian.rb
@@ -6,12 +6,14 @@ module UserGuardian
   end
 
   def can_edit_username?(user)
+    return false if (SiteSetting.sso_overrides_username? && SiteSetting.enable_sso?)
     return true if is_staff?
     return false if SiteSetting.username_change_period <= 0
     is_me?(user) && (user.post_count == 0 || user.created_at > SiteSetting.username_change_period.days.ago)
   end
 
   def can_edit_email?(user)
+    return false if (SiteSetting.sso_overrides_email? && SiteSetting.enable_sso?)
     return true if is_staff?
     return false unless SiteSetting.email_editable?
     can_edit?(user)


### PR DESCRIPTION
If both SiteSetting.enable_sso and SiteSetting.sso_overrides_username are enabled, username changing should be disabled globally, since that combination of settings would suggest that the external SSO database is fully authoritative with respect to usernames. Likewise, the same should apply for emails.
