### PR TITLE
i18n of new/unread text next to topics

### DIFF
--- a/app/assets/javascripts/discourse/templates/components/basic-topic-list.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/components/basic-topic-list.js.handlebars
@@ -30,13 +30,13 @@
             {{topicStatus topic=topic}}
             <a class='title' href="{{unbound topic.lastUnreadUrl}}">{{{unbound topic.fancy_title}}}</a>
             {{#if unread}}
-              <a href="{{unbound topic.lastUnreadUrl}}" class='badge unread badge-notification' title='{{i18n topic.unread_posts count="unread"}}'>{{unbound topic.unread}} Unread</a>
+              <a href="{{unbound topic.lastUnreadUrl}}" class='badge unread badge-notification' title='{{i18n topic.unread_posts count="unread"}}'>{{unbound topic.unread}} {{i18n filters.unread.title.zero}}</a>
             {{/if}}
             {{#if topic.new_posts}}
-              <a href="{{unbound topic.lastUnreadUrl}}" class='badge new-posts badge-notification' title='{{i18n topic.new_posts count="new_posts"}}'>{{unbound topic.new_posts}} New</a>
+              <a href="{{unbound topic.lastUnreadUrl}}" class='badge new-posts badge-notification' title='{{i18n topic.new_posts count="new_posts"}}'>{{unbound topic.new_posts}} {{i18n filters.new.title.zero}}</a>
             {{/if}}
             {{#if topic.unseen}}
-              <a href="{{unbound topic.lastUnreadUrl}}" class='badge new-posts badge-notification' title='{{i18n topic.new}}'>New</a>
+              <a href="{{unbound topic.lastUnreadUrl}}" class='badge new-posts badge-notification' title='{{i18n topic.new}}'>{{i18n filters.new.title.zero}}</a>
             {{/if}}
           </td>
 

--- a/app/assets/javascripts/discourse/templates/discovery/categories.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/discovery/categories.js.handlebars
@@ -20,10 +20,10 @@
                 {{#if controller.ordering}}<i class="fa fa-bars"></i>{{/if}}
                 {{categoryLink this allowUncategorized=true}}
                 {{#if unreadTopics}}
-                  <a href={{unbound unreadUrl}} class='badge new-posts badge-notification' title='{{i18n topic.unread_topics count="unreadTopics"}}'>{{unbound unreadTopics}} Unread</a>
+                  <a href={{unbound unreadUrl}} class='badge new-posts badge-notification' title='{{i18n topic.unread_topics count="unreadTopics"}}'>{{unbound unreadTopics}} {{i18n filters.unread.title.zero}}</a>
                 {{/if}}
                 {{#if newTopics}}
-                  <a href={{unbound newUrl}} class='badge new-posts badge-notification' title='{{i18n topic.new_topics count="newTopics"}}'>{{unbound newTopics}} New</a>
+                  <a href={{unbound newUrl}} class='badge new-posts badge-notification' title='{{i18n topic.new_topics count="newTopics"}}'>{{unbound newTopics}} {{i18n filters.new.title.zero}}</a>
                 {{/if}}
               </div>
               <div class='featured-users'>
@@ -47,7 +47,7 @@
                     <a href={{unbound unreadUrl}} class='badge new-posts badge-notification' title='{{i18n topic.unread_topics count="unreadTopics"}}'>{{unbound unreadTopics}}</a>
                   {{/if}}
                   {{#if newTopics}}
-                    <a href={{unbound newUrl}} class='badge new-posts badge-notification' title='{{i18n topic.new_topics count="newTopics"}}'>{{unbound newTopics}} New</a>
+                    <a href={{unbound newUrl}} class='badge new-posts badge-notification' title='{{i18n topic.new_topics count="newTopics"}}'>{{unbound newTopics}} {{i18n filters.new.title.zero}}</a>
                   {{/if}}
                 {{/each}}
               </div>
@@ -59,13 +59,13 @@
                 {{topicStatus topic=this}}
                 <a class='title' href="{{unbound lastUnreadUrl}}">{{{unbound fancy_title}}}</a>
                 {{#if unread}}
-                  <a href="{{unbound lastUnreadUrl}}" class='badge unread badge-notification' title='{{i18n topic.unread_posts count="unread"}}'>{{unread}} Unread</a>
+                  <a href="{{unbound lastUnreadUrl}}" class='badge unread badge-notification' title='{{i18n topic.unread_posts count="unread"}}'>{{unread}} {{i18n filters.unread.title.zero}}</a>
                 {{/if}}
                 {{#if new_posts}}
-                  <a href="{{unbound lastUnreadUrl}}" class='badge new-posts badge-notification' title='{{i18n topic.new_posts count="new_posts"}}'>{{new_posts}} New</a>
+                  <a href="{{unbound lastUnreadUrl}}" class='badge new-posts badge-notification' title='{{i18n topic.new_posts count="new_posts"}}'>{{new_posts}} {{i18n filters.new.title.zero}}</a>
                 {{/if}}
                 {{#if unseen}}
-                  <a href="{{unbound lastUnreadUrl}}" class='badge new-posts badge-notification' title='{{i18n topic.new}}'>New</a>
+                  <a href="{{unbound lastUnreadUrl}}" class='badge new-posts badge-notification' title='{{i18n topic.new}}'>{{i18n filters.new.title.zero}}</a>
                 {{/if}}
 
                 {{#if controller.latestTopicOnly}}

--- a/app/assets/javascripts/discourse/templates/list/topic_list_item.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/list/topic_list_item.js.handlebars
@@ -14,13 +14,13 @@
   {{topicStatus topic=this}}
   {{{topicLink this}}}
   {{#if unread}}
-    <a href="{{lastUnreadUrl}}" class='badge unread badge-notification' title='{{i18n topic.unread_posts count="unread"}}'>{{unread}} Unread</a>
+    <a href="{{lastUnreadUrl}}" class='badge unread badge-notification' title='{{i18n topic.unread_posts count="unread"}}'>{{unread}} {{i18n filters.unread.title.zero}}</a>
   {{/if}}
   {{#if displayNewPosts}}
-    <a href="{{lastUnreadUrl}}" class='badge new-posts badge-notification' title='{{i18n topic.new_posts count="displayNewPosts"}}'>{{displayNewPosts}} New</a>
+    <a href="{{lastUnreadUrl}}" class='badge new-posts badge-notification' title='{{i18n topic.new_posts count="displayNewPosts"}}'>{{displayNewPosts}} {{i18n filters.new.title.zero}}</a>
   {{/if}}
   {{#if unseen}}
-    <a href="{{lastUnreadUrl}}" class='badge new-posts badge-notification' title='{{i18n topic.new}}'>New</a>
+    <a href="{{lastUnreadUrl}}" class='badge new-posts badge-notification' title='{{i18n topic.new}}'>{{i18n filters.new.title.zero}}</a>
   {{/if}}
 
   {{#if hasExcerpt}}

--- a/app/assets/javascripts/discourse/templates/site_map/_category.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/site_map/_category.js.handlebars
@@ -4,7 +4,7 @@
     <a href={{unbound unreadUrl}} class='badge unread-posts badge-notification' title='{{i18n topic.unread_topics count="unreadTopics"}}'>{{unreadTopics}}</a>
   {{/if}}
   {{#if newTopics}}
-    <a href={{unbound newUrl}} class='badge new-posts badge-notification' title='{{i18n topic.new_topics count="newTopics"}}'>{{newTopics}} New</a>
+    <a href={{unbound newUrl}} class='badge new-posts badge-notification' title='{{i18n topic.new_topics count="newTopics"}}'>{{newTopics}} {{i18n filters.new.title.zero}}</a>
   {{/if}}
 {{else}}
   <b class="topics-count">{{unbound topic_count}}</b>

--- a/test/javascripts/templates/site_map_test.js
+++ b/test/javascripts/templates/site_map_test.js
@@ -199,7 +199,6 @@ test("category links part is rendered correctly", function() {
   ok($firstCategoryNewTopicsLink.hasClass("badge") && $firstCategoryNewTopicsLink.hasClass("badge-notification"), "the new topics link has correct classes");
   equal($firstCategoryNewTopicsLink.attr("title"), "topic.new_topics 20", "the new topics link has correct title");
   notEqual($firstCategoryNewTopicsLink.text().indexOf("20"), -1, "the new topics link contains correct text");
-  ok(exists($firstCategoryNewTopicsLink.find(".fa-asterisk")), "the new topics link contains correct icon");
 
   var $firstCategoryAllTopicsCount = $categories.first().find(".topics-count");
   ok(!exists($firstCategoryAllTopicsCount), "the count of all topics is not shown");


### PR DESCRIPTION
I reused the filters.unread.title string which isn't ideal but I figured it would save having to create a translation in every language. Should I create a new i18n string for this?

(Also this fixes the tests by removing the JS test that looks for the asterisk.)
