### PR TITLE
add support for arrays to PluginStore

### DIFF
--- a/app/models/plugin_store.rb
+++ b/app/models/plugin_store.rb
@@ -31,14 +31,24 @@ class PluginStore
 
 
   def self.determine_type(value)
-    value.is_a?(Hash) ? "JSON" : value.class.to_s
+    value.is_a?(Hash) || value.is_a?(Array) ? "JSON" : value.class.to_s
+  end
+
+  def self.map_json(item)
+    if item.is_a? Hash
+      ActiveSupport::HashWithIndifferentAccess.new item
+    elsif item.is_a? Array
+      item.map { |subitem| map_json subitem}
+    else
+      item
+    end
   end
 
   def self.cast_value(type, value)
     case type
     when "Fixnum" then value.to_i
     when "TrueClass", "FalseClass" then value == "true"
-    when "JSON" then ActiveSupport::HashWithIndifferentAccess.new(::JSON.parse(value))
+    when "JSON" then map_json(::JSON.parse(value))
     else value
     end
   end

--- a/spec/models/plugin_store_spec.rb
+++ b/spec/models/plugin_store_spec.rb
@@ -51,6 +51,34 @@ describe PluginStore do
     expect(result[:hi]).to eq("there")
   end
 
+  it "handles nested hashes correctly" do
+
+    val = {"hi" => "there", "nested" => {"a" => "b", "with list" => ["a", "b", 3] }}
+    set("hello", val)
+    result = get("hello")
+
+    expect(result).to eq(val)
+
+    # ensure indiff access holds
+    expect(result[:hi]).to eq("there")
+    expect(result[:nested][:a]).to eq("b")
+    expect(result[:nested]["with list"]).to eq(["a", "b", 3])
+  end
+
+  it "handles arrays correctly" do
+
+    val = ["a", "b", {"hash"=> "inside", "c"=> 1}]
+    set("hello", val)
+    result = get("hello")
+
+    expect(result).to eq(val)
+
+    # ensure indiff access holds
+    expect(result[2][:hash]).to eq("inside")
+    expect(result[2]["c"]).to eq(1)
+
+  end
+
   it "removes correctly" do
     set("hello", true)
     remove_row("hello")


### PR DESCRIPTION
Dunno, why that wasn't in there from the beginning, JSON supports arrays as well as hashes as the root-object. Having to wrap a list into a hash just so that the PluginStore doesn't complain is weird. Therefore, I added "array support" to the plugin store.
