### PR TITLE
Switch from MMM D to D MMM to separate from year

### DIFF
--- a/config/locales/client.cs.yml
+++ b/config/locales/client.cs.yml
@@ -62,7 +62,7 @@ cs:
           one: 1r
           few: '%{count}r'
           other: '%{count}let'
-        date_month: MMM D
+        date_month: "D MMM"
         date_year: "MMM 'YY"
       medium:
         x_minutes:

--- a/config/locales/client.da.yml
+++ b/config/locales/client.da.yml
@@ -52,7 +52,7 @@ da:
         almost_x_years:
           one:   "1å"
           other: "%{count}å"
-        date_month: "MMM D"
+        date_month: "D MMM"
         date_year: "MMM 'YY"
       medium:
         x_minutes:

--- a/config/locales/client.de.yml
+++ b/config/locales/client.de.yml
@@ -52,7 +52,7 @@ de:
         almost_x_years:
           one:   "1J"
           other: "%{count}J"
-        date_month: "MMM D"
+        date_month: "D. MMM"
         date_year: "MMM 'YY"
       medium:
         x_minutes:

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -52,7 +52,7 @@ en:
         almost_x_years:
           one:   "1y"
           other: "%{count}y"
-        date_month: "MMM D"
+        date_month: "D MMM"
         date_year: "MMM 'YY"
       medium:
         x_minutes:

--- a/config/locales/client.es.yml
+++ b/config/locales/client.es.yml
@@ -54,7 +54,7 @@ es:
         almost_x_years:
           one:   "1a"
           other: "%{count}a"
-        date_month: "MMM D"
+        date_month: "D MMM"
         date_year: "MMM 'YY"
       medium:
         x_minutes:

--- a/config/locales/client.it.yml
+++ b/config/locales/client.it.yml
@@ -52,7 +52,7 @@ it:
         almost_x_years:
           one:   "1a"
           other: "%{count}a"
-        date_month: "MMM D"
+        date_month: "D MMM"
         date_year: "MMM 'YY"
       medium:
         x_minutes:

--- a/config/locales/client.nl.yml
+++ b/config/locales/client.nl.yml
@@ -56,7 +56,7 @@ nl:
         almost_x_years:
           one:   1j
           other: "%{count}j"
-        date_month: "MMM D"
+        date_month: "D MMM"
         date_year: "MMM 'YY"
       medium:
         x_minutes:

--- a/config/locales/client.pt_BR.yml
+++ b/config/locales/client.pt_BR.yml
@@ -52,7 +52,7 @@ pt_BR:
         almost_x_years:
           one: "1y"
           other: "%{count}y"
-        date_month: "MMM D"
+        date_month: "D MMM"
         date_year: "MMM 'YY"
       medium:
         x_minutes:

--- a/config/locales/client.ru.yml
+++ b/config/locales/client.ru.yml
@@ -72,7 +72,7 @@ ru:
           other: '%{count}лет'
           few: '%{count}лет'
           many: '%{count}лет'
-        date_month: 'MMM D'
+        date_month: 'D MMM'
         date_year: 'MMM ''YY'
       medium:
         x_minutes:

--- a/config/locales/client.sv.yml
+++ b/config/locales/client.sv.yml
@@ -52,7 +52,7 @@ sv:
         almost_x_years:
           one:   "1y"
           other: "%{count}y"
-        date_month: "MMM D"
+        date_month: "D MMM"
         date_year: "MMM 'YY"
       medium:
         x_minutes:

--- a/config/locales/client.zh_TW.yml
+++ b/config/locales/client.zh_TW.yml
@@ -52,7 +52,7 @@ zh_TW:
         almost_x_years:
           one:   "1 年"
           other: "%{count} 年"
-        date_month: "MMM D"
+        date_month: "D MMM"
         date_year: "MMM 'YY"
       medium:
         x_minutes:


### PR DESCRIPTION
Additionally, in German, the format is 'D. MMM'.

Per the lack of loud dissent in https://meta.discourse.org/t/change-to-dd-mmm-mmm-yy-for-post-dates/13625
