### PR TITLE
Poll - French Translation

### DIFF
--- a/plugins/poll/config/locales/client.fr.yml
+++ b/plugins/poll/config/locales/client.fr.yml
@@ -1,0 +1,23 @@
+# encoding: utf-8
+#
+# French translation - Traduction française
+#
+# This file contains content for the client portion of Discourse, sent out
+# to the Javascript app.
+#
+# To work with us on translations, see:
+# https://www.transifex.com/projects/p/discourse-pt-br/
+#
+# To validate this YAML file after you change it, please paste it into
+# http://yamllint.com/
+
+fr:
+  js:
+    poll:
+      voteCount:
+        one: "1 vote"
+        other: "%{count} votes"
+
+      results:
+        show: "Voir les résultats"
+        hide: "Cacher les résultats"

--- a/plugins/poll/config/locales/server.fr.yml
+++ b/plugins/poll/config/locales/server.fr.yml
@@ -1,0 +1,17 @@
+# encoding: utf-8
+#
+# French translation - Traduction française
+#
+# This file contains content for the server portion of Discourse used by Ruby
+#
+# To work with us on translations, see:
+# https://www.transifex.com/projects/p/discourse-pt-br/
+#
+# To validate this YAML file after you change it, please paste it into
+# http://yamllint.com/
+
+fr:
+  poll:
+    must_contain_poll_options: "doit contenir une liste de choix pour le sondage"
+    cannot_have_modified_options: "ne peut pas être modifié car il contient un sondage publié depuis plus de 5 minutes"
+    prefix: "Sondage:"


### PR DESCRIPTION
French translation for the plugin Poll.

I dunno if we could make the translation in the plugin directory itself, or in a folder like:
/config/locales/plugins/poll/client.*.yml

We need translation, because we cannot test this plugin on french forum, we cannot see number of votes ^^
