### PR TITLE
Adding name to the list of uneditable items in preferences UI

### DIFF
--- a/app/assets/javascripts/discourse/templates/user/preferences.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/user/preferences.js.handlebars
@@ -25,7 +25,11 @@
       <div class="control-group">
         <label class="control-label">{{i18n user.name.title}}</label>
         <div class="controls">
-          {{textField value=newNameInput classNames="input-xxlarge"}}
+          {{#if can_edit_name}}
+            {{textField value=newNameInput classNames="input-xxlarge"}}
+          {{else}}
+            <span class='static'>{{name}}</span>
+          {{/if}}
         </div>
         <div class='instructions'>
           {{i18n user.name.instructions}}
@@ -73,7 +77,7 @@
         {{/if}}
       </div>
     </div>
-    
+
     {{#if Discourse.SiteSettings.allow_profile_backgrounds}}
     <div class="control-group">
       <label class="control-label">{{i18n user.change_profile_background.title}}</label>

--- a/lib/guardian/user_guardian.rb
+++ b/lib/guardian/user_guardian.rb
@@ -19,6 +19,13 @@ module UserGuardian
     can_edit?(user)
   end
 
+  def can_edit_name?(user)
+    return false if not(SiteSetting.enable_names?)
+    return false if (SiteSetting.sso_overrides_name? && SiteSetting.enable_sso?)
+    return true if is_staff?
+    can_edit?(user)
+  end
+
   def can_block_user?(user)
     user && is_staff? && not(user.staff?)
   end

--- a/spec/components/guardian_spec.rb
+++ b/spec/components/guardian_spec.rb
@@ -1448,5 +1448,68 @@ describe Guardian do
       end
     end
   end
+
+  describe 'can_edit_name?' do
+    it 'is false without a logged in user' do
+      Guardian.new(nil).can_edit_name?(build(:user, created_at: 1.minute.ago)).should be_false
+    end
+
+    it "is false for regular users to edit another user's name" do
+      Guardian.new(build(:user)).can_edit_name?(build(:user, created_at: 1.minute.ago)).should be_false
+    end
+
+    context 'for a new user' do
+      let(:target_user) { build(:user, created_at: 1.minute.ago) }
+
+      it 'is true for the user to change their own name' do
+        Guardian.new(target_user).can_edit_name?(target_user).should be_true
+      end
+
+      it 'is true for moderators' do
+        Guardian.new(moderator).can_edit_name?(user).should be_true
+      end
+
+      it 'is true for admins' do
+        Guardian.new(admin).can_edit_name?(user).should be_true
+      end
+    end
+
+    context 'when name is disabled in preferences' do
+      before do
+        SiteSetting.stubs(:enable_names).returns(false)
+      end
+
+      it 'is false for the user to change their own name' do
+        Guardian.new(user).can_edit_name?(user).should be_false
+      end
+
+      it 'is false for moderators' do
+        Guardian.new(moderator).can_edit_name?(user).should be_false
+      end
+
+      it 'is false for admins' do
+        Guardian.new(admin).can_edit_name?(user).should be_false
+      end
+    end
+
+    context 'when SSO name override is active' do
+      before do
+        SiteSetting.stubs(:enable_sso).returns(true)
+        SiteSetting.stubs(:sso_overrides_name).returns(true)
+      end
+
+      it 'is false for admins' do
+        Guardian.new(admin).can_edit_name?(admin).should be_false
+      end
+
+      it 'is false for moderators' do
+        Guardian.new(moderator).can_edit_name?(moderator).should be_false
+      end
+
+      it 'is false for users' do
+        Guardian.new(user).can_edit_name?(user).should be_false
+      end
+    end
+  end
 end
 


### PR DESCRIPTION
- If `enable_names`,  `enable_sso`, and `sso_overrides_name` settings are true.

See the following for reference.
https://github.com/discourse/discourse/pull/2033
https://github.com/discourse/discourse/pull/2080
https://github.com/discourse/discourse/pull/2091
