### PR TITLE
Support image copy-paste for Firefox 24+

### DIFF
--- a/app/assets/javascripts/discourse/views/composer/composer_view.js
+++ b/app/assets/javascripts/discourse/views/composer/composer_view.js
@@ -326,7 +326,7 @@ Discourse.ComposerView = Discourse.View.extend(Ember.Evented, {
     // Ctrl+v to paste so we should be conservative about what browsers this runs
     // in.
     var uaMatch = navigator.userAgent.match(/Firefox\/(\d+)\.\d/);
-    if (uaMatch && parseInt(uaMatch[1]) >= 26) {
+    if (uaMatch && parseInt(uaMatch[1]) >= 24) {
       self.$().append( Ember.$("<div id='contenteditable' contenteditable='true' style='height: 0; width: 0; overflow: hidden'></div>") );
       self.$().off('keydown.contenteditable');
       self.$().on('keydown.contenteditable', function(event) {


### PR DESCRIPTION
Just tested this on Firefox 24, works as expected.

I don't think there's any easy way to get it working on IE, though. 
