### PR TITLE
Enable Admin-Javascript for plugins

### DIFF
--- a/app/assets/javascripts/admin.js.erb
+++ b/app/assets/javascripts/admin.js.erb
@@ -7,4 +7,6 @@ end
 
 require_asset("main_include_admin.js")
 
+DiscoursePluginRegistry.admin_javascripts.each { |js| require_asset(js) }
+
 %>

--- a/lib/discourse_plugin_registry.rb
+++ b/lib/discourse_plugin_registry.rb
@@ -6,12 +6,17 @@ class DiscoursePluginRegistry
   class << self
     attr_accessor :javascripts
     attr_accessor :server_side_javascripts
+    attr_accessor :admin_javascripts
     attr_accessor :stylesheets
     attr_accessor :handlebars
 
     # Default accessor values
     def javascripts
       @javascripts ||= Set.new
+    end
+
+    def admin_javascripts
+      @admin_javascripts ||= Set.new
     end
 
     def server_side_javascripts

--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -95,7 +95,12 @@ class Plugin::Instance
 
   def register_asset(file,opts=nil)
     full_path = File.dirname(path) << "/assets/" << file
-    assets << full_path
+    if opts == :admin
+      @admin_javascripts ||= []
+      @admin_javascripts << full_path
+    else
+      assets << full_path
+    end
     if opts == :server_side
       @server_side_javascripts ||= []
       @server_side_javascripts << full_path
@@ -165,6 +170,12 @@ class Plugin::Instance
       # TODO possibly amend this to a rails engine
       Rails.configuration.assets.paths << auto_generated_path
       Rails.configuration.assets.paths << File.dirname(path) + "/assets"
+    end
+
+    if @admin_javascripts
+      @admin_javascripts.each do |js|
+        DiscoursePluginRegistry.admin_javascripts << js
+      end
     end
 
     if @server_side_javascripts

--- a/spec/components/discourse_plugin_registry_spec.rb
+++ b/spec/components/discourse_plugin_registry_spec.rb
@@ -26,6 +26,13 @@ describe DiscoursePluginRegistry do
     end
   end
 
+  context '#admin_javascripts' do
+    it 'defaults to an empty Set' do
+      DiscoursePluginRegistry.admin_javascripts = nil
+      DiscoursePluginRegistry.admin_javascripts.should == Set.new
+    end
+  end
+
   context '.register_css' do
     before do
       registry.register_css('hello.css')


### PR DESCRIPTION
Currently plugins can only enhance the end user frontend javascript through the "register_asset" function. As the admin-javascripts are loaded after the app-assets, Admin-Javascripts aren't defined yet and therefore can't be extended through plugins.

This Pull-Requests add the `:admin` option to register_assets to allow the specification of "admin-only" javascripts coming from the plugin which are loaded only after the normal discourse admin javascripts are loaded.

Includes the common tests on the plugin registry.
