### PR TITLE
Upgraded rails to 4.0.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -153,7 +153,7 @@ gem 'rack-protection' # security
 # in production environments by default.
 # allow everywhere for now cause we are allowing asset debugging in prd
 group :assets do
-  gem 'sass-rails'
+  gem 'sass-rails', '~> 4.0.2'
   gem 'uglifier'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -303,10 +303,11 @@ GEM
       nokogiri (>= 1.4.2)
     sanitize (2.1.0)
       nokogiri (>= 1.4.4)
-    sass (3.3.2)
-    sass-rails (4.0.1)
+    sass (3.2.16)
+    sass-rails (4.0.2)
       railties (>= 4.0.0, < 5.0)
-      sass (>= 3.1.10)
+      sass (~> 3.2.0)
+      sprockets (~> 2.8, <= 2.11.0)
       sprockets-rails (~> 2.0.0)
     seed-fu-discourse (2.2.0)
       activerecord (>= 3.1, < 4.1)
@@ -344,7 +345,7 @@ GEM
     spork-rails (4.0.0)
       rails (>= 3.0.0, < 5)
       spork (>= 1.0rc0)
-    sprockets (2.12.0)
+    sprockets (2.11.0)
       hike (~> 1.2)
       multi_json (~> 1.0)
       rack (~> 1.0)
@@ -363,7 +364,7 @@ GEM
       eventmachine (>= 1.0.0)
       rack (>= 1.0.0)
     thor (0.18.1)
-    thread_safe (0.2.0)
+    thread_safe (0.3.0)
       atomic (>= 1.1.7, < 2)
     tilt (1.4.1)
     timecop (0.7.1)
@@ -458,7 +459,7 @@ DEPENDENCIES
   ruby-readability
   sanitize
   sass
-  sass-rails
+  sass-rails (~> 4.0.2)
   seed-fu-discourse
   shoulda
   sidekiq


### PR DESCRIPTION
Rails 4.0.4 has been released! I was testing discourse against 4.0.4 to see if there are any regressions on rails side, but everything seems fine, so maybe we can apply this to discourse master as well? :smile: 
