### PR TITLE
Route `serialize` hook argument is the model, not params

### DIFF
--- a/app/assets/javascripts/admin/routes/admin_user_route.js
+++ b/app/assets/javascripts/admin/routes/admin_user_route.js
@@ -8,8 +8,8 @@
 **/
 Discourse.AdminUserRoute = Discourse.Route.extend({
 
-  serialize: function(params) {
-    return { username: Em.get(params, 'username').toLowerCase() };
+  serialize: function(model) {
+    return { username: model.get('username').toLowerCase() };
   },
 
   model: function(params) {

--- a/app/assets/javascripts/discourse/routes/user_route.js
+++ b/app/assets/javascripts/discourse/routes/user_route.js
@@ -39,9 +39,9 @@ Discourse.UserRoute = Discourse.Route.extend({
     return this.modelFor('user').findDetails();
   },
 
-  serialize: function(params) {
-    if (!params) return {};
-    return { username: Em.get(params, 'username').toLowerCase() };
+  serialize: function(model) {
+    if (!model) return {};
+    return { username: model.get('username').toLowerCase() };
   },
 
   setupController: function(controller, user) {


### PR DESCRIPTION
I changed the name of the argument to the `serialize` hook from `params` to `model` in the two places it was incorrectly named.

Calling it `params` is super confusing since the _second_ argument to the `serialize` hook is `params`, an array of dynamic segment names.
