### PR TITLE
Refactor OneBox::Engine::DiscourseLocalOnebox into smaller methods

### DIFF
--- a/lib/onebox/engine/discourse_local_onebox.rb
+++ b/lib/onebox/engine/discourse_local_onebox.rb
@@ -1,3 +1,5 @@
+require_relative 'discourse_local_onebox/choose_renderer'
+
 module Onebox
   module Engine
     class DiscourseLocalOnebox
@@ -11,77 +13,9 @@ module Onebox
       end
 
       def to_html
-        uri = URI::parse(@url)
-        route = Rails.application.routes.recognize_path(uri.path)
-
-        args = {original_url: @url}
-
-        # Figure out what kind of onebox to show based on the URL
-        case route[:controller]
-        when 'topics'
-
-          linked = "<a href='#{@url}'>#{@url}</a>"
-          if route[:post_number].present? && route[:post_number].to_i > 1
-            # Post Link
-            post = Post.where(topic_id: route[:topic_id], post_number: route[:post_number].to_i).first
-            return linked unless post
-            return linked unless Guardian.new.can_see?(post)
-
-            topic = post.topic
-            slug = Slug.for(topic.title)
-
-            excerpt = post.excerpt(SiteSetting.post_onebox_maxlength)
-            excerpt.gsub!("\n"," ")
-            # hack to make it render for now
-            excerpt.gsub!("[/quote]", "[quote]")
-            quote = "[quote=\"#{post.user.username}, topic:#{topic.id}, slug:#{slug}, post:#{post.post_number}\"]#{excerpt}[/quote]"
-
-            cooked = PrettyText.cook(quote)
-            return cooked
-
-          else
-            # Topic Link
-            topic = Topic.where(id: route[:topic_id].to_i).includes(:user).first
-            return linked unless topic
-            return linked unless Guardian.new.can_see?(topic)
-
-            post = topic.posts.first
-
-            posters = topic.posters_summary.map do |p|
-              {
-                username: p[:user].username,
-                avatar: PrettyText.avatar_img(p[:user].avatar_template, 'tiny'),
-                description: p[:description],
-                extras: p[:extras]
-              }
-            end
-
-            category = topic.category
-            if category
-              category = "<a href=\"/category/#{category.slug}\" class=\"badge badge-category\" style=\"background-color: ##{category.color}; color: ##{category.text_color}\">#{category.name}</a>"
-            end
-
-            quote = post.excerpt(SiteSetting.post_onebox_maxlength)
-            args.merge! title: topic.title,
-                        avatar: PrettyText.avatar_img(topic.user.avatar_template, 'tiny'),
-                        posts_count: topic.posts_count,
-                        last_post: FreedomPatches::Rails4.time_ago_in_words(topic.last_posted_at, false, scope: :'datetime.distance_in_words_verbose'),
-                        age: FreedomPatches::Rails4.time_ago_in_words(topic.created_at, false, scope: :'datetime.distance_in_words_verbose'),
-                        views: topic.views,
-                        posters: posters,
-                        quote: quote,
-                        category: category,
-                        topic: topic.id
-
-            @template = 'topic'
-          end
-
+        if renderer = ChooseRenderer.call(url: @url)
+          renderer.call
         end
-
-        return nil unless @template
-        Mustache.render(File.read("#{Rails.root}/lib/onebox/templates/discourse_#{@template}_onebox.handlebars"), args)
-      rescue ActionController::RoutingError
-        nil
       end
 
     end

--- a/lib/onebox/engine/discourse_local_onebox/choose_renderer.rb
+++ b/lib/onebox/engine/discourse_local_onebox/choose_renderer.rb
@@ -1,0 +1,71 @@
+require_relative 'render_link'
+require_relative 'render_post'
+require_relative 'render_topic'
+
+module Onebox
+  module Engine
+    class DiscourseLocalOnebox
+      class ChooseRenderer
+        def self.call(options={})
+          new(options).call
+        end
+
+        def initialize(options={})
+          @url = options.fetch(:url)
+        end
+
+        def call
+          return unless valid_route?
+
+          if post_link?
+            render_post
+          else
+            render_topic
+          end
+        end
+
+        private
+        attr_reader :url, :route
+
+        def valid_route?
+          route && route[:controller] == 'topics'
+        end
+
+        def render_post
+          post ? RenderPost.new(post: post) : RenderLink.new(url: url)
+        end
+
+        def render_topic
+          topic ? RenderTopic.new(url: url, topic: topic) : RenderLink.new(url: url)
+        end
+
+        def route
+          @route ||= begin
+            uri = URI::parse(url)
+            Rails.application.routes.recognize_path(uri.path)
+          rescue ActionController::RoutingError
+            nil
+          end
+        end
+
+        def post_link?
+          route[:post_number].present? && route[:post_number].to_i > 1
+        end
+
+        def post
+          @post ||= begin
+            post = Post.where(topic_id: route[:topic_id], post_number: route[:post_number].to_i).first
+            post && Guardian.new.can_see?(post) ? post : nil
+          end
+        end
+
+        def topic
+          @topic ||= begin
+            topic = Topic.where(id: route[:topic_id].to_i).includes(:user).first
+            topic && Guardian.new.can_see?(topic) ? topic : nil
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/onebox/engine/discourse_local_onebox/render_link.rb
+++ b/lib/onebox/engine/discourse_local_onebox/render_link.rb
@@ -1,0 +1,22 @@
+module Onebox
+  module Engine
+    class DiscourseLocalOnebox
+      class RenderLink
+        def self.call(options={})
+          new(options).call
+        end
+
+        def initialize(options={})
+          @url = options.fetch(:url)
+        end
+
+        def call
+          "<a href='#{url}'>#{url}</a>"
+        end
+
+        private
+        attr_reader :url
+      end
+    end
+  end
+end

--- a/lib/onebox/engine/discourse_local_onebox/render_post.rb
+++ b/lib/onebox/engine/discourse_local_onebox/render_post.rb
@@ -1,0 +1,43 @@
+module Onebox
+  module Engine
+    class DiscourseLocalOnebox
+      class RenderPost
+        def self.call(options={})
+          new(options).call
+        end
+
+        def initialize(options={})
+          @post = options.fetch(:post)
+        end
+
+        def call
+          PrettyText.cook(quote)
+        end
+
+        private
+        attr_reader :post
+
+        def topic
+          post.topic
+        end
+
+        def slug
+          Slug.for(topic.title)
+        end
+
+        def excerpt
+          post.excerpt(SiteSetting.post_onebox_maxlength).tap do |text|
+            text.gsub!("\n"," ")
+
+            # hack to make it render for now
+            text.gsub!("[/quote]", "[quote]")
+          end
+        end
+
+        def quote
+          %Q([quote="#{post.user.username}, topic:#{topic.id}, slug:#{slug}, post:#{post.post_number}"]#{excerpt}[/quote])
+        end
+      end
+    end
+  end
+end

--- a/lib/onebox/engine/discourse_local_onebox/render_topic.rb
+++ b/lib/onebox/engine/discourse_local_onebox/render_topic.rb
@@ -1,0 +1,84 @@
+module Onebox
+  module Engine
+    class DiscourseLocalOnebox
+      class RenderTopic
+        def self.call(options={})
+          new(options).call
+        end
+
+        def initialize(options={})
+          @url = options.fetch(:url)
+          @topic = options.fetch(:topic)
+        end
+
+        def call
+          Mustache.render(File.read(template_path), template_options)
+        end
+
+        private
+        attr_reader :url, :topic
+
+        def post
+          @post ||= topic.posts.first
+        end
+
+        def category
+          @category ||= topic.category
+        end
+
+        def category_html
+          if category
+            %Q("<a href="/category/#{category.slug}" class="badge badge-category" style="background-color: ##{category.color}; color: ##{category.text_color}">#{category.name}</a>")
+          end
+        end
+
+        def posters
+          @posters ||= topic.posters_summary.map do |p|
+            {
+              username: p[:user].username,
+              avatar: PrettyText.avatar_img(p[:user].avatar_template, 'tiny'),
+              description: p[:description],
+              extras: p[:extras]
+            }
+          end
+        end
+
+        def quote
+          post.excerpt(SiteSetting.post_onebox_maxlength)
+        end
+
+        def avatar
+          PrettyText.avatar_img(topic.user.avatar_template, 'tiny')
+        end
+
+        def last_post
+          FreedomPatches::Rails4.time_ago_in_words(topic.last_posted_at, false, scope: :'datetime.distance_in_words_verbose')
+        end
+
+        def age
+          FreedomPatches::Rails4.time_ago_in_words(topic.created_at, false, scope: :'datetime.distance_in_words_verbose')
+        end
+
+        def template_path
+          "#{Rails.root}/lib/onebox/templates/discourse_topic_onebox.handlebars"
+        end
+
+        def template_options
+          {
+            original_url: url,
+            title: topic.title,
+            avatar: avatar,
+            posts_count: topic.posts_count,
+            last_post: last_post,
+            age: age,
+            views: topic.views,
+            posters: posters,
+            quote: quote,
+            category: category_html,
+            topic: topic.id
+          }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
In order to improve the CodeClimate score, I tackled one of the service objects in `lib/` and extracted it into separate renderers and helper methods.

https://codeclimate.com/github/pithyless/discourse/compare/refactor-discourse-local-onebox

Please let me know if these kinds of refactors are appreciated and if there is something that does not fit the Discourse style guides.

I realize it's not a very small diff, but my intention was to make the flow of control more explicit, while not changing any of the existing logic, branches or hacks.
