### PR TITLE
Only warn about necromancy when replying

### DIFF
--- a/lib/composer_messages_finder.rb
+++ b/lib/composer_messages_finder.rb
@@ -129,6 +129,8 @@ class ComposerMessagesFinder
 
     topic = Topic.where(id: @details[:topic_id]).first
 
+    return unless replying?
+
     return if topic.nil? ||
               SiteSetting.warn_reviving_old_topic_age < 1 ||
               topic.last_posted_at > SiteSetting.warn_reviving_old_topic_age.days.ago


### PR DESCRIPTION
It doesn't make sense to warn about necromancy when you're editing your old posts.
