### PR TITLE
Fix visual bug from excessive LIs being rendered around Category breadcrumbs

### DIFF
--- a/app/assets/javascripts/discourse/templates/components/bread-crumbs.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/components/bread-crumbs.js.handlebars
@@ -1,11 +1,7 @@
-<li>
-  {{category-drop category=firstCategory categories=parentCategories}}
-</li>
+{{category-drop category=firstCategory categories=parentCategories}}
 
 {{#if childCategories}}
-  <li>
-    {{category-drop category=secondCategory parentCategory=firstCategory categories=childCategories subCategory="true" noSubcategories=noSubcategories}}
-  </li>
+  {{category-drop category=secondCategory parentCategory=firstCategory categories=childCategories subCategory="true" noSubcategories=noSubcategories}}
 {{/if}}
 
 <div class='clear'></div>


### PR DESCRIPTION
The category breadcrumb template in `templates/components/bread-crumbs.js.handlebars` contains LI tag wrappers around the references to the category-drop component (`components/categorydrop.component.js`). However, the component is already a LI itself, so the browser receives a HTML sequence `<li> <li>foo</li> </li>` from the Ember buffer. The first LI tag is automatically closed by the browser, leading to the rendered structure being `<li></li> <li>foo</li> ...`. This extra LI tag causes a visual issue, which by coincidence isn't visible on the default theme. See screenshot below.

![categorybreadcrumbli](https://f.cloud.github.com/assets/5316880/2480507/2b7a5122-b0bf-11e3-9b19-cd85302063dc.png)

Commit message:
Prevent rendering of excessive `<li>` wrapper around a category breadcrumb which already is a `<li>`.

The excessive `<li>` wrapper coming from the template is automatically closed by the browser during the HTML parsing step, causing an empty `<li>` being visible in the rendered source (preceding the first breadcrumb). This causes a visual bug when not using the default Discourse stylesheet, because the extra LI element pushes the content to the right and sometimes also renders an extra black pixel.
