### PR TITLE
Make Facebook login popup taller

### DIFF
--- a/app/assets/javascripts/discourse/models/login_method.js
+++ b/app/assets/javascripts/discourse/models/login_method.js
@@ -45,7 +45,7 @@ Discourse.LoginMethod.reopenClass({
           params.frameWidth = 850;
           params.frameHeight = 500;
         } else if (name === "facebook") {
-          params.frameHeight = 420;
+          params.frameHeight = 450;
         }
 
         methods.pushObject(Discourse.LoginMethod.create(params));


### PR DESCRIPTION
Fixes https://meta.discourse.org/t/facebook-login-popup-not-big-enough/14044
