### PR TITLE
Remove documentation references to "pg_dumps/development-image.sql".

### DIFF
--- a/docs/DEVELOPER-ADVANCED.md
+++ b/docs/DEVELOPER-ADVANCED.md
@@ -103,12 +103,6 @@ Edit /etc/postgresql/9.1/main/pg_hba.conf to have this:
     host all all ::1/128 trust
     host all all 0.0.0.0/0 trust # wide-open
 
-Load the seed data (as vagrant user):
-
-    psql -d discourse_development < pg_dumps/development-image.sql
-
-(You may wish to try the `production-image.sql` file for a good seed for a production database.)
-
 ## Redis
 
     sudo su -

--- a/script/osx_dev
+++ b/script/osx_dev
@@ -87,10 +87,6 @@ fi
 
 brew services start redis
 
-## Load seed data ##
-echo "Loading seed data..."
-psql -d discourse_development < pg_dumps/development-image.sql
-
 ## Install gems ##
 echo "Installing gems..."
 bundle install


### PR DESCRIPTION
There is no such file sql file in the git repo. Seeding is accomplished via the rake tasks as of
9ab743f351e612830a27afaab8e9b3ddd59da9e2.
