### PR TITLE
Forgot to specify "dependent: destroy" for UserBadges

### DIFF
--- a/app/models/badge.rb
+++ b/app/models/badge.rb
@@ -1,5 +1,6 @@
 class Badge < ActiveRecord::Base
   belongs_to :badge_type
+  has_many :user_badges, dependent: :destroy
 
   validates :name, presence: true, uniqueness: true
   validates :badge_type, presence: true

--- a/spec/models/badge.rb
+++ b/spec/models/badge.rb
@@ -4,6 +4,7 @@ require_dependency 'badge'
 describe Badge do
 
   it { should belong_to :badge_type }
+  it { should have_many(:user_badges).dependent(:destroy) }
 
   context 'validations' do
     before(:each) { Fabricate(:badge) }


### PR DESCRIPTION
This fixes the problem when deleting a badge after assigning it to users.
