### PR TITLE
Fix regression from 6b050825ffa that broke usage of the $link-color SASS variable

### DIFF
--- a/app/assets/stylesheets/common/foundation/variables.scss
+++ b/app/assets/stylesheets/common/foundation/variables.scss
@@ -40,10 +40,13 @@ $base-background-color: lighten($black, 60%) !default;
 // Links
 // --------------------------------------------------
 
-$link-color: $blue !default;
+$link-color: darken($blue, 10%) !default;
 $link-color-visited: darken($blue, 10%) !default;
 $link-color-hover: darken($blue, 10%) !default;
 $link-color-active: darken($blue, 10%) !default;
+$secondary_link_color: $white;
+$muted-link-color: lighten($black, 35%);
+$muted-important-link-color: lighten($black, 35%);
 
 // Badges
 // --------------------------------------------------
@@ -167,11 +170,6 @@ $warning_shadow_color: lighten($red, 20%);
 $success_shadow_color: $green;
 
 $highlight: $yellow;
-
-$link_color:  darken($blue, 10%);
-$secondary_link_color: $white;
-$muted-link-color: lighten($black, 35%);
-$muted-important-link-color: lighten($black, 35%);
 
 $attention_bg: lighten($blue, 50%);
 $attention_fg: $blue;

--- a/app/assets/stylesheets/desktop/compose.scss
+++ b/app/assets/stylesheets/desktop/compose.scss
@@ -69,7 +69,7 @@
   }
 
   .posts-count {
-    color: darken($link_color, 40%);
+    color: darken($link-color, 40%);
     font-size: 12px;
   }
 }

--- a/app/assets/stylesheets/desktop/onebox.scss
+++ b/app/assets/stylesheets/desktop/onebox.scss
@@ -121,12 +121,12 @@ aside.onebox {
     }
 
     a[href] {
-      color: $link_color;
+      color: $link-color;
       text-decoration: none;
     }
 
     a[href]:visited {
-      color: $link_color;
+      color: $link-color;
     }
 
     img {

--- a/app/assets/stylesheets/desktop/topic-list.scss
+++ b/app/assets/stylesheets/desktop/topic-list.scss
@@ -193,7 +193,7 @@
   }
   .avatar {
     &.latest {
-      @include box-shadow(0 0 6px 1px desaturate(lighten($link_color, 18%), 35%));
+      @include box-shadow(0 0 6px 1px desaturate(lighten($link-color, 18%), 35%));
     }
   }
   .num {

--- a/app/assets/stylesheets/desktop/user.scss
+++ b/app/assets/stylesheets/desktop/user.scss
@@ -4,7 +4,7 @@
 
 .groups {
   .group-link {
-    color: $link_color;
+    color: $link-color;
   }
 }
 
@@ -72,7 +72,7 @@
     margin-left: 3px;
   }
   .instructions a[href] {
-    color: $link_color;
+    color: $link-color;
   }
   .warning {
     background-color: $warning_background_color;
@@ -118,7 +118,7 @@
   h2 {
     a {
       font-size: 14px;
-      color: $link_color;
+      color: $link-color;
       cursor: pointer;
     }
   }


### PR DESCRIPTION
Fix regression from 6b050825ffa that broke usage of the $link-color (note the hyphen) variable by having introduced a $link_color (underscored naming) variable lower in variables.scss

Since hyphens and underscores are aliases of each other in SASS (https://github.com/nex3/sass/issues/334), by having included a $link_color variable in an unexpected place (rather than updating the $link-color variable in the link colors section at the top of the variables file), and compounded by not using a HEX value that could be searched for, but using a SASS function instead, 6b050825ffa introduced a hard to debug inconsistency. In places where $link-color is used, we suddenly start getting unexpected color values and changing $link-color in variables.scss does nothing. Someone not experienced enough with SASS to know that he should also look for $link_color is left puzzled about where the color values are coming from.

---

This happened precisely because
1) "separator is a stylistic preference, not a meaningful one." (https://github.com/nex3/sass/issues/334)
and 2) Discourse doesn't prevent the coexistence of the two styles
Guys, how about standardizing things like this one, hmm?
IMHO the CSS codebase leaves a lot to be desired. I also think it's not the best attitude that "pull requests consisting entirely of style changes are not welcome on this project" because regressions like this one can happen again because of it.
My 2c... ;)
