### PR TITLE
[refactor] Topics#set_auto_close

### DIFF
--- a/lib/topics/auto_closer.rb
+++ b/lib/topics/auto_closer.rb
@@ -1,0 +1,79 @@
+module Topics
+  module AutoCloser
+    extend self
+
+    # Valid arguments:
+    #  * An integer, which is the number of hours from now to close the topic.
+    #  * A time, like "12:00", which is the time at which the topic will close in the current day
+    #    or the next day if that time has already passed today.
+    #  * A timestamp, like "2013-11-25 13:00", when the topic should close.
+    #  * A timestamp with timezone in JSON format. (e.g., "2013-11-26T21:00:00.000Z")
+    #  * nil, to prevent the topic from automatically closing.
+    def get_closer_method(arg)
+      auto_closes_by_json(arg) ||
+        auto_closes_by_hour_string(arg) ||
+        auto_closes_by_num_hours(arg) ||
+        does_not_auto_close
+    end
+
+  protected
+
+    def auto_closes_by_json(timestamp)
+      matches = /^([\d]{1,2}):([\d]{1,2})$/.match(timestamp.to_s.strip).to_a
+      return if matches.empty?
+      ->(closeable) {
+        close_via_json_date_time(closeable, matches)
+      }
+    end
+
+    def auto_closes_by_hour_string(hour)
+      return unless hour.to_s.include?('-') && timestamp = Time.zone.parse(hour.to_s)
+      ->(closeable) {
+        close_via_hour_string(closeable, timestamp)
+      }
+    end
+
+    def auto_closes_by_num_hours(num_hours)
+      return if num_hours.to_i == 0
+      ->(closeable) {
+        close_via_num_hours(closeable, num_hours)
+      }
+    end
+
+    def does_not_auto_close
+      ->(closeable) {
+        closeable.auto_close_at = nil
+        closeable.auto_close_started_at = nil
+      }
+    end
+
+    def close_via_json_date_time(closeable, matches)
+      now = Time.zone.now
+      closeable.auto_close_at = Time.zone.local(now.year, now.month, now.day,
+                                                matches[1].to_i, matches[2].to_i)
+      if closeable.auto_close_at < now
+        closeable.auto_close_at += 1.day
+      else
+        nil
+      end
+    end
+
+    def close_via_hour_string(closeable, timestamp)
+      closeable.auto_close_at = timestamp
+      if timestamp < Time.zone.now
+        closeable.errors.add(:auto_close_at, :invalid)
+      else
+        nil
+      end
+    end
+
+    def close_via_num_hours(closeable, num_hours)
+      num_hours = num_hours.to_i
+      if num_hours > 0
+        closeable.auto_close_at = num_hours.hours.from_now
+      else
+        nil
+      end
+    end
+  end
+end

--- a/spec/lib/topics/auto_closer_spec.rb
+++ b/spec/lib/topics/auto_closer_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+require 'topics/auto_closer'
+
+describe Topics::AutoCloser do
+  let(:frozen_time) { Time.zone.local(2013, 11, 26, 17, 0, 0)}
+
+  describe "JSON format" do
+    let(:closer) { Topics::AutoCloser.get_closer_method("2013-11-26T21:00:00.000Z") }
+
+    it "must update the topic auto close at to the json date" do
+      Timecop.travel(frozen_time) do
+        closer.call(topic = Topic.new)
+        topic.auto_close_at.should == "Tue, 26 Nov 2013 16:00:00 EST -05:00:Time"
+      end
+    end
+  end
+
+  describe "hour string format" do
+    let(:closer) { Topics::AutoCloser.get_closer_method("12:00") }
+
+    it "must update the topic auto close at to 12 the next day" do
+      Timecop.travel(frozen_time) do
+        closer.call(topic = Topic.new)
+        topic.auto_close_at.should == "Wed, 27 Nov 2013 12:00:00 EST -05:00"
+      end
+    end
+  end
+
+  describe "a timestamp format" do
+    let(:closer) { Topics::AutoCloser.get_closer_method("2013-11-25 13:00") }
+
+    it "must update the topic auto close at to the timestamp" do
+      Timecop.travel(frozen_time) do
+        closer.call(topic = Topic.new)
+        topic.auto_close_at.should == "Mon, 25 Nov 2013 13:00:00 EST -05:00"
+      end
+    end
+  end
+
+  describe "a nil" do
+    let(:closer) { Topics::AutoCloser.get_closer_method(nil) }
+
+    it "must set the auto close to nil" do
+      Timecop.travel(frozen_time) do
+        closer.call(topic = Topic.new)
+        topic.auto_close_at.should == nil
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
The large complicated conditional block has been refactored away
using an object that returns a lambda with the correct behavior
to update the topic auto close date.

Topics::AutoCloser.get_closer_method(arg).call(self)
- arg:  The arg is a date string of various formats or nil
- self: The object with the auto_close fields

This will improve your code climate score and remove an eye-sore
conditional mess.
- Added new object in lib, Topics::AutoCloser
- Added integrartion tests for the new object
