### PR TITLE
French Translations Updates

### DIFF
--- a/app/views/static/faq.fr.html.erb
+++ b/app/views/static/faq.fr.html.erb
@@ -7,7 +7,7 @@
 <%= markdown_content(:faq) do %>
 
 <div id="civilized"></div>
-<h2><a href="#civilized">C'est une endroit civilisé pour un discussion publique</a></h2>
+<h2><a href="#civilized">C'est un endroit civilisé pour un discussion publique</a></h2>
 <p>Merci de traiter ce forum de discussion avec le même respect que vous pourriez avoir dans un parc public. Nous, aussi, sommes une ressource partagé par la communauté — un endroit pour partager des compétences, savoir et intérêts au travers de conversation.</p>
 <div class="more">
   <p>Il ne s'agit pas de règles absolues, uniquement des aides au bon sens de notre communauté. Suivez ces instructions pour garder cet endroit propre et bien éclairé pour le débat public civilisé.</p>

--- a/app/views/static/privacy.fr.html.erb
+++ b/app/views/static/privacy.fr.html.erb
@@ -1,7 +1,7 @@
 <ul class="nav-pills">
-  <li><a class="active" href="<%=faq_path%>">FAQ</a></li>
+  <li><a href="<%=faq_path%>">FAQ</a></li>
   <li><a href="<%=tos_path%>">Conditions générales d'utilisation</a></li>
-  <li><a href="<%=privacy_path%>">Protection des données</a></li>
+  <li><a class="active" href="<%=privacy_path%>">Protection des données</a></li>
 </ul>
 
 <%= markdown_content(:privacy_policy) do %>

--- a/app/views/static/tos.fr.html.erb
+++ b/app/views/static/tos.fr.html.erb
@@ -1,7 +1,7 @@
 <ul class="nav-pills">
   <li><a href="<%=faq_path%>">FAQ</a></li>
-  <li><a class="active" href="<%=tos_path%>">Conditions Générales d'Utilisation</a></li>
-  <li><a href="<%=privacy_path%>">Confidentialité</a></li>
+  <li><a class="active" href="<%=tos_path%>">Conditions générales d'utilisation</a></li>
+  <li><a href="<%=privacy_path%>">Protection des données</a></li>
 </ul>
 
 <p>

--- a/config/locales/client.fr.yml
+++ b/config/locales/client.fr.yml
@@ -5,6 +5,7 @@
 # Pour toute question contactez
 # <Maxime QUANDALLE> "maxime@quandalle.com"
 # <Julien DUMETIER> "julien@dumetier.net"
+# <Sebastien MIQUEROLLE> "s.miquerolle@gmail.com"
 #
 # To work with us on translations, see:
 # https://www.transifex.com/projects/p/discourse-pt-br/
@@ -546,6 +547,7 @@ fr:
       invitee_accepted: "<i title='a accepté votre invitation' class='fa fa-envelope-o'></i> {{username}} a accepté votre invitation"
       moved_post: "<i title='message déplacée' class='fa fa-arrow-right'></i> {{username}} a déplacé {{link}}"
       total_flagged: "Nombre total de messages signalés"
+      linked: "<i title='linked post' class='fa fa-arrow-left'></i> {{username}} {{link}}"
     upload_selector:
       title: "Ajouter une image"
       title_with_attachments: "Ajouter une image ou un fichier"
@@ -578,7 +580,7 @@ fr:
     topics:
       bulk:
         reset_read: "Réinitialiser la lecture"
-        dismiss_read: "Ignorer Lecture"
+        dismiss_read: "Ignorer les sujets non-lus"
         dismiss_new: "Ignorer Nouveaux"
         toggle: "activer la sélection multiple des sujets"
         actions: "Actions sur sélection multiple"
@@ -777,6 +779,8 @@ fr:
         select_replies: 'selectionner +réponses'
         delete: supprimer la sélection
         cancel: annuler la sélection
+        select_all: tout sélectionner
+        deselect_all: tout désélectionner
         description:
           one: vous avez sélectionné <b>1</b> message.
           other: Vous avez sélectionné <b>{{count}}</b> messages.
@@ -798,8 +802,8 @@ fr:
       deleted_by: "supprimé par"
       expand_collapse: "étendre/réduire"
       gap:
-        one: "1 message masqué"
-        other: "{{count}} messages masqués"
+        one: "1 message caché"
+        other: "{{count}} messages cachés"
       has_replies:
         one: "Réponse"
         other: "Réponses"
@@ -995,7 +999,7 @@ fr:
       title: 'Pourquoi signalez vous secrètement ce message ?'
       action: 'Signaler ce message'
       take_action: "Signaler"
-      notify_action: 'Notifier'
+      notify_action: 'Message privé'
       delete_spammer: "Supprimer le spammeur"
       delete_confirm: "Vous vous apprêtez à supprimer <b>%{posts}</b> messages et  <b>%{topics}</b> sujets de cet utilisateur, supprimer son compte, bloquer les inscriptions depuis son adresse IP <b>%{ip_address}</b> et à ajouter son email <b>%{email}</b> à la liste des utilisateurs bloqués. Etes-vous sûr que cet utilisateur est un spammeur ?"
       yes_delete_spammer: "Oui, supprimer le spammeur"
@@ -1009,7 +1013,7 @@ fr:
     flagging_topic:
       title: "Pourquoi signalez-vous secrètement ce sujet ?"
       action: "Signaler Sujet"
-      notify_action: "Notifier"
+      notify_action: "Message privé"
     topic_map:
       title: "Résumé du sujet"
       links_shown: "montrer les {{totalLinks}} liens..."
@@ -1284,6 +1288,8 @@ fr:
         title: "Email"
         settings: "Paramètres"
         all: "Tous"
+        sending_test: "Envoi en cours de l'email de test..."
+        test_error: "Il y a eu un problème avec l'envoi de l'email. Veuillez vérifier vos paramètres et réessayer."
         sent: "Envoyé"
         skipped: "Passé"
         sent_at: "Envoyer à"
@@ -1351,6 +1357,8 @@ fr:
             delete_site_customization: "Supprimer la personnalisation du site"
             suspend_user: "suspendre l'utilisateur"
             unsuspend_user: "retirer la suspension de l'utilisateur"
+            grant_badge: "accorder le badge"
+            revoke_badge: "retirer le badge"
         screened_emails:
           title: "Emails affichés"
           description: "Lorsque quelqu'un essaye de créé un nouveau compte, les adresses mail suivantes seront vérifiées et l'inscription sera bloquée, ou une autre action sera réalisée."
@@ -1539,9 +1547,19 @@ fr:
         display_name: Nom affiché
         description: Description
         badge_type: Type de badge
+        granted_by: Accorder par
+        granted_at: Accorder depuis
         save: Sauvegarder
         delete: Supprimer
         delete_confirm: Etes vous sûr de vouloir supprimer ce badge ?
+        revoke: Retirer
+        revoke_confirm: Etes vous sur de vouloir retirer ce badge à cet utilisateur ?
+        edit_badges: Modifier les badges
+        grant_badge: Accorder le badge
+        granted_badges: Badges accordés
+        grant: Accorder
+        no_user_badges: "%{name} ne s'est vu accordé aucun badge."
+        no_badges: Il n'y a aucun badge qui peuvent être accorder.
     lightbox:
       download: "télécharger"
     keyboard_shortcuts_help:

--- a/config/locales/server.fr.yml
+++ b/config/locales/server.fr.yml
@@ -7,6 +7,7 @@
 # <Maxime QUANDALLE> "maxime@quandalle.com"
 # <Thomas BENTKOWSKI> "thomasbentkowski@gmail.com"
 # <Julien DUMETIER> "julien@dumetier.net"
+# <Sebastien MIQUEROLLE> "s.miquerolle@gmail.com"
 #
 # To work with us on translations, see:
 # https://www.transifex.com/projects/p/discourse-pt-br/
@@ -49,7 +50,7 @@ fr:
       other: "%{count} réponses supplémentaires"
     loading: "Chargement de la discussion..."
     permalink: "Lien permanent"
-    imported_from: "Sujet en provenance de l'article du blog : %{link}"
+    imported_from: "Il s'agit d'un sujet en provenance de l'article : %{link}"
     in_reply_to: "en réponse à %{username}"
     replies:
       one: "1 réponse"
@@ -464,10 +465,11 @@ fr:
     sidekiq_warning: 'Sidekiq n''est pas lancé. De nombreuses tâches, comme l''envoie d''e-mails, sont executées de manière asynchrome par sidekiq. Assurez-vous d''avoir au moins un processus sidekiq de lancé. <a href="https://github.com/mperham/sidekiq">En savoir plus sur sidekiq</a>.'
     queue_size_warning: 'Il y a %{queue_size} tâches dans la file d''attente, ce qui est beaucoup. Cela peut provenir d''un problème avec les processus Sidekiq, ou à un manque de processus Sidekiq travailleurs.'
     memory_warning: 'Votre serveur dispose de moins de 1 Go de mémoire vive. Au moins 1 Go de RAM est recommandé.'
-    facebook_config_warning: 'Le serveur est configuré pour permettre l''authentification par Facebook (enable_facebook_logins), mais les paramètres facebook_app_id et facebook_app_secret ne sont pas renseignés. Vous pouvez modifier ces paramètres dans <a href="/admin/site_settings">l''interface d''administration</a>, <a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide#enable-facebook-logins" target="_blank">voir le guide pour en savoir plus</a>.'
-    twitter_config_warning: 'Le serveur est configuré pour permettre l''authentification par Twitter (enable_twitter_logins), mais les paramètres key et secret ne sont pas renseignés. Vous pouvez modifier ces paramètres dans le <a href="/admin/site_settings">Paramétrage du Site</a>. <a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide#enable-twitter-logins" target="_blank">voir le guide pour en savoir plus</a>.'
-    github_config_warning: 'Le serveur est configuré pour permettre l''authentification par GitHub (enable_github_logins), mais les paramètres github_client_id et github_client_secret ne sont pas renseignés. Vous pouvez modifier ces paramètres dans <a href=\"/admin/site_settings\">l''interface d''administration</a>. <a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide" target="_blank">voir le guide pour en savoir plus</a>.'
+    facebook_config_warning: 'Le serveur est configuré pour permettre l''authentification par Facebook (enable_facebook_logins), mais les paramètres facebook_app_id et facebook_app_secret ne sont pas renseignés. Allez dans les <a href="/admin/site_settings">Paramètres du Site</a> et mettez les à jour. <a href="https://meta.discourse.org/t/configuring-facebook-login-for-discourse/13394" target="_blank">Voir le guide pour en savoir plus</a>.'
+    twitter_config_warning: 'Le serveur est configuré pour permettre l''authentification par Twitter (enable_twitter_logins), mais les paramètres key et secret ne sont pas renseignés. Allez dans les <a href="/admin/site_settings">Paramétres du Site</a> et mettez les à jour. <a href="https://meta.discourse.org/t/configuring-twitter-login-for-discourse/13395" target="_blank">Voir le guide pour en savoir plus</a>.'
+    github_config_warning: 'Le serveur est configuré pour permettre l''authentification par GitHub (enable_github_logins), mais les paramètres github_client_id et github_client_secret ne sont pas renseignés. Allez dans les <a href=\"/admin/site_settings\">Paramètres du Site</a> et mettez les à jour. <a href="https://meta.discourse.org/t/configuring-github-login-for-discourse/13745" target="_blank">Voir le guide pour en savoir plus</a>.'
     s3_config_warning: 'Le serveur est configuré pour charger les fichiers vers s3, mais au moins un de ces paramètre n''est pas configuré : s3_access_key_id, s3_secret_access_key or s3_upload_bucket. Vous pouvez modifier ces paramètres dans <a href=\"/admin/site_settings\">l''interface d''administration</a>. <a href="http://meta.discourse.org/t/how-to-set-up-image-uploads-to-s3/7229" target="_blank">Voir le guide "Comment charger les images sur S3 ?" pour en savoir plus</a>'
+    s3_backup_config_warning: 'Le serveur est configuré pour envoyer les sauvegardes sur S3, mais l''un des paramètres suivants n''est pas renseigné: s3_access_key_id, s3_secret_access_key or s3_backup_bucket. Allez dans les <a href="/admin/site_settings">Paramètres du site</a> et mettez les à jour. <a href="http://meta.discourse.org/t/how-to-set-up-image-uploads-to-s3/7229" target="_blank">Voir "Comment mettre en place une sauvegarde sur S3?" pour en savoir plus</a>.'
     image_magick_warning: 'Le serveur est configuré pour créer des aperçus des grandes images, mais ImageMagick n''est pas installé. Installez ImageMagick en utilisant votre gestionnaire de paquets favori ou bien allez  ici <a href="http://www.imagemagick.org/script/binary-releases.php" target="_blank">pour télécharger la dernière version</a>.'
     failing_emails_warning: 'Il y a %{num_failed_jobs} tâches d''envois d''email en erreur. Vérifiez votre fichier config/discourse.conf et assurez-vous de la conformité des paramètres du serveur de mail. <a href="/sidekiq/retries" target="_blank">Regarder les processus en échec dans  Sidekiq</a>.'
     default_logo_warning: "Vous n'avez pas changé le logo de votre site. Merci de mettre à jour les <a href='/admin/site_settings'>paramètres du site</a> suivant : logo_url, logo_small_url et favicon_url."
@@ -566,6 +568,7 @@ fr:
     category_post_template: "Le modèle de message utilisé lorsque vous créez une nouvelle catégorie"
     onebox_max_chars: "Nombre maximal de caractères qu'une boîte peut importer d'un site externe dans un message."
     logo_url: "Le logo de votre site, par exemple : http://example.com/logo.png"
+    digest_logo_url: "Le logo qui sera utilisé dans les emails de votre site. Si non renseigné, alors `logo_url` sera utilisé, par exemple : http://example.com/logo.png"
     logo_small_url: "La version minifiée du logo de votre site lorsque vous faites défilez vers le bas les messages d'un sujet ex : http://example.com/logo-small.png"
     favicon_url: "Le favicon de votre site, voir http://fr.wikipedia.org/wiki/Favicon"
     apple_touch_icon_url: "Icône utilisée pour les appareils d'Apple. Taille recommandée 144 px par 144 px."
@@ -717,7 +720,7 @@ fr:
     white_listed_spam_host_domains: "Une liste des domaines exclus des hôtes testés comme spam séparé par des virgules, les nouveaux utilisateurs seront en mesure de créer un nombre illimité de messages avec des liens vers ce domaine"
     staff_like_weight: "Poids supplémentaire donné aux Likes du staff lors d'une recherche."
     reply_by_email_enabled: "Activer répondre aux sujets via email"
-    reply_by_email_address: "Modèle pour la réponse par adresse email par exemple : %{reply_key}@reply.myforum.com"
+    reply_by_email_address: "Modèle pour la réponse par adresse email entrante; exemple : %{reply_key}@reply.example.com ou replies+%{reply_key}@example.com"
     pop3s_polling_enabled: "Utiliser le polling via POP3S pour les réponses par email"
     pop3s_polling_port: "Le port à utiliser pour le polling sur le POPS3"
     pop3s_polling_host: "L'hôte utilisé pour le polling pour l'email via POP3S"
@@ -746,6 +749,7 @@ fr:
     dominating_topic_minimum_percent: "Quel est le pourcentage de messages d'un utilisateur doit poster dans un sujet avant que nous considérions qu'il est dominant."
     suppress_uncategorized_badge: "Ne pas afficher le badge pour les sujets non catégorisés dans les listes des sujets"
     min_posts_for_search_in_topic: "Désactiver la recherche dans les sujets si les sujets ont moins du minimum de messages"
+    global_notice: "Affiche un bandeau global pour tout les utilisateurs du site, laissez vide pour le caché (HTML autorisé)"
     enable_names: "Permettre aux utilisateurs d'afficher leurs noms et prénoms"
     display_name_on_posts: "Afficher également le nom complet de l'utilisateur dans ses messages"
     invites_shown: "Nombre maximum d'invitations affichées sur une page utilisateur"
@@ -756,6 +760,7 @@ fr:
     feed_polling_enabled: "Si vous souhaitez importer un flux RSS/ATOM en tant que messages"
     feed_polling_url: "URL du flux RSS/ATOM à importer"
     embed_by_username: "Pseudo de l'utilisateur Discourse qui crée les sujets"
+    embed_truncate: "Tronquer les messages importés"
     embed_category: "Catégorie des sujets créés"
     embed_post_limit: "Le nombre maximum de messages à incorporer"
     tos_accept_required: "Si il est activé, les utilisateurs devront cocher une case sur le formulaire d'inscription pour confirmer qu'ils acceptent les conditions de service. Modifier \"Formulaire d'inscription : Message des Conditions d'utilisation» dans l'onglet Contenu pour modifier le message."
@@ -770,6 +775,7 @@ fr:
     private_message: "%{display_username} vous a envoyé un message privé: %{link}"
     invited_to_private_message: "%{display_username} vous a invité dans une conversation privée: %{link}"
     invitee_accepted: "%{display_username} a accepté votre invitation"
+    linked: "%{display_username} a mentionné l'un de vos messages : %{link}"
   search:
     within_post: "#%{post_number} par %{username}: %{excerpt}"
     types:
@@ -781,7 +787,7 @@ fr:
   most_recent_poster: "Auteur le plus récent"
   frequent_poster: "Auteur fréquent"
   redirected_to_top_reasons:
-    new_user: "Bienvenue! En tant que nouveau visiteur, ceci sera votre page d'accueil jusqu'à ce que vous ayez pris le temps de faire un peu le tour du forum. Pour vous, une sélection des sujets les plus populaires."
+    new_user: "Bienvenue! En tant que nouveau visiteur, ceci sera votre page d'accueil jusqu'à ce que vous ayez pris le temps de faire un peu le tour du forum. Retrouvez ici une sélection des sujets les plus populaires."
     not_seen_in_a_month: "Bon retour parmi nous! Nous ne vous avons pas vu depuis un moment, voici les meilleurs sujets de discussions depuis votre absence."
   move_posts:
     new_topic_moderator_post:
@@ -1023,9 +1029,29 @@ fr:
     export_succeeded:
       subject_template: "Export terminé avec succès"
       text_body_template: "L'export a réussi."
+    export_failed:
+      subject_template: "Echec de l'export"
+      text_body_template: |
+        L'export a échoué.
+
+        Voici le détail:
+
+        ```
+        %{logs}
+        ```
     import_succeeded:
       subject_template: "Import terminé avec succès"
       text_body_template: "L'import a réussi."
+    import_failed:
+      subject_template: "Echec de l'import"
+      text_body_template: |
+        L'import a échoué.
+
+        Voici le détail:
+
+        ```
+        %{logs}
+        ```
     email_error_notification:
       subject_template: "Erreur d'analyse de l'email"
       text_body_template: |
@@ -1189,7 +1215,7 @@ fr:
       text_body_template: |
         Bienvenue sur %{site_name} !
 
-        Vous avez été approuvé pour rejoindre %{site_name}, bienvenue !
+        Un membre de l'équipe a approuvé votre compte sur %{site_name}.
 
         Cliquez sur le lien suivant pour confirmer et activer votre nouveau compte :
         %{base_url}/users/activate-account/%{email_token}


### PR DESCRIPTION
Updates client and server
Fix wrong "active" in privacy.html
Use same same terms between faq/tos/privacy page.

---

J'ai un doute sur "Notifier" -> "Message privé", mais c'est un changement sur le EN, donc je conserve l'esprit originel.
