### PR TITLE
Add link to the main Discourse Plugin page for the PLUGINS doc.

### DIFF
--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -3,4 +3,8 @@
 **Note: This is a work in progress!**
 
 
+# List of Discourse Plugins
 
+A list of the Discourse plugins is available at Discourses [plugin discussion page](https://meta.discourse.org/category/extensibility/plugin)
+
+This is the most up to date place for plugin discussion and listing.


### PR DESCRIPTION
Sorry for all of the crazy commits. I got my branches mixed up, I
should be good now.

This adds a link to the main discourse plugin page
