### PR TITLE
Normalize URL from Feed Entry after adding link to original in Topic

### DIFF
--- a/app/models/topic_embed.rb
+++ b/app/models/topic_embed.rb
@@ -14,12 +14,12 @@ class TopicEmbed < ActiveRecord::Base
   def self.import(user, url, title, contents)
     return unless url =~ /^https?\:\/\//
 
-    url = normalize_url(url)
-
     if SiteSetting.embed_truncate
       contents = first_paragraph_from(contents)
     end
     contents << "\n<hr>\n<small>#{I18n.t('embed.imported_from', link: "<a href='#{url}'>#{url}</a>")}</small>\n"
+
+    url = normalize_url(url)
 
     embed = TopicEmbed.where("lower(embed_url) = ?", url).first
     content_sha1 = Digest::SHA1.hexdigest(contents)

--- a/spec/models/topic_embed_spec.rb
+++ b/spec/models/topic_embed_spec.rb
@@ -41,6 +41,17 @@ describe TopicEmbed do
         post.cooked.should =~ /new contents/
       end
 
+      it "Should leave uppercase Feed Entry URL untouched in content" do
+        cased_url = 'http://eviltrout.com/ABCD'
+        post = TopicEmbed.import(user, cased_url, title, "some random content")
+        post.cooked.should =~ /#{cased_url}/
+      end
+
+      it "Should leave lowercase Feed Entry URL untouched in content" do
+        cased_url = 'http://eviltrout.com/abcd'
+        post = TopicEmbed.import(user, cased_url, title, "some random content")
+        post.cooked.should =~ /#{cased_url}/
+      end
     end
 
   end


### PR DESCRIPTION
Since a URL might be case sensitive, adding a link to the original
Feed Entry with changed case to the Topic could end in 404.
