### PR TITLE
Align basic-topic-list table structure with Categories page topic-list table structure

### DIFF
--- a/app/assets/javascripts/discourse/templates/components/basic-topic-list.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/components/basic-topic-list.js.handlebars
@@ -1,75 +1,79 @@
 {{#if loaded}}
   {{#if topics}}
     <table id="topic-list">
-      <tr>
-        {{#sortable-heading sortBy="default" sortOrder=sortOrder}}
-          {{i18n topic.title}}
-        {{/sortable-heading}}
-        {{#unless controller.hideCategory}}
-          {{#sortable-heading sortBy="category" sortOrder=sortOrder}}
-            {{i18n category_title}}
+      <thead>
+        <tr>
+          {{#sortable-heading sortBy="default" sortOrder=sortOrder}}
+            {{i18n topic.title}}
           {{/sortable-heading}}
-        {{/unless}}
-        {{#sortable-heading sortBy="posts" number=true sortOrder=sortOrder}}
-          {{i18n posts}}
-        {{/sortable-heading}}
-        {{#sortable-heading sortBy="likes" number=true sortOrder=sortOrder}}
-          {{i18n likes}}
-        {{/sortable-heading}}
-        {{#sortable-heading sortBy="views" number=true sortOrder=sortOrder}}
-          {{i18n views}}
-        {{/sortable-heading}}
-        {{#sortable-heading sortBy="activity" number=true colspan="2" sortOrder=sortOrder}}
-          {{i18n activity}}
-        {{/sortable-heading}}
-      </tr>
-
-      {{#groupedEach topic in topics}}
-        <tr {{bind-attr class="archived"}}>
-          <td class='main-link'>
-            {{topicStatus topic=topic}}
-            <a class='title' href="{{unbound topic.lastUnreadUrl}}">{{{unbound topic.fancy_title}}}</a>
-            {{#if unread}}
-              <a href="{{unbound topic.lastUnreadUrl}}" class='badge unread badge-notification' title='{{i18n topic.unread_posts count="unread"}}'>{{unbound topic.unread}}</a>
-            {{/if}}
-            {{#if topic.new_posts}}
-              <a href="{{unbound topic.lastUnreadUrl}}" class='badge new-posts badge-notification' title='{{i18n topic.new_posts count="new_posts"}}'>{{unbound topic.new_posts}}</a>
-            {{/if}}
-            {{#if topic.unseen}}
-              <a href="{{unbound topic.lastUnreadUrl}}" class='badge new-posts badge-notification' title='{{i18n topic.new}}'>{{i18n filters.new.lower_title}}</a>
-            {{/if}}
-          </td>
-
           {{#unless controller.hideCategory}}
-          <td class="category">
-            {{categoryLink topic.category showParent=true}}
-          </td>
+            {{#sortable-heading sortBy="category" sortOrder=sortOrder}}
+              {{i18n category_title}}
+            {{/sortable-heading}}
           {{/unless}}
-
-          <td class='num posts'><a href="{{unbound topic.lastUnreadUrl}}" class='badge-posts'>{{number topic.posts_count numberKey="posts_long"}}</a></td>
-
-          <td class='num likes'>
-            {{#if topic.like_count}}
-              <a href='{{unbound topic.url}}{{#if topic.has_summary}}?filter=summary{{/if}}'>{{unbound topic.like_count}} <i class='fa fa-heart'></i></a>
-            {{/if}}
-          </td>
-
-          <td {{bind-attr class=":num :views topic.viewsHeat"}}>{{number topic.views numberKey="views_long"}}</td>
-          {{#if topic.bumped}}
-            <td class='num activity'>
-              <a href="{{unbound topic.url}}" class='{{coldAgeClass created_at}}' title='{{i18n first_post}}: {{{rawDate topic.created_at}}}' >{{unboundAge topic.created_at}}</a>
-            </td>
-            <td class='num activity last'>
-              <a href="{{unbound topic.lastPostUrl}}" class='{{coldAgeClass bumped_at}}' title='{{i18n last_post}}: {{{rawDate topic.bumped_at}}}'>{{unboundAge topic.bumped_at}}</a>
-            </td>
-          {{else}}
-            <td class='num activity'>
-              <a href="{{unbound topic.url}}" class='age' title='{{i18n first_post}}: {{{rawDate topic.created_at}}}'>{{unboundAge topic.created_at}}</a>
-            </td>
-            <td class="activity"></td>
-          {{/if}}
+          {{#sortable-heading sortBy="posts" number=true sortOrder=sortOrder}}
+            {{i18n posts}}
+          {{/sortable-heading}}
+          {{#sortable-heading sortBy="likes" number=true sortOrder=sortOrder}}
+            {{i18n likes}}
+          {{/sortable-heading}}
+          {{#sortable-heading sortBy="views" number=true sortOrder=sortOrder}}
+            {{i18n views}}
+          {{/sortable-heading}}
+          {{#sortable-heading sortBy="activity" number=true colspan="2" sortOrder=sortOrder}}
+            {{i18n activity}}
+          {{/sortable-heading}}
         </tr>
-      {{/groupedEach}}
+      </thead>
+
+      <tbody>
+        {{#groupedEach topic in topics}}
+          <tr {{bind-attr class="archived"}}>
+            <td class='main-link'>
+              {{topicStatus topic=topic}}
+              <a class='title' href="{{unbound topic.lastUnreadUrl}}">{{{unbound topic.fancy_title}}}</a>
+              {{#if unread}}
+                <a href="{{unbound topic.lastUnreadUrl}}" class='badge unread badge-notification' title='{{i18n topic.unread_posts count="unread"}}'>{{unbound topic.unread}}</a>
+              {{/if}}
+              {{#if topic.new_posts}}
+                <a href="{{unbound topic.lastUnreadUrl}}" class='badge new-posts badge-notification' title='{{i18n topic.new_posts count="new_posts"}}'>{{unbound topic.new_posts}}</a>
+              {{/if}}
+              {{#if topic.unseen}}
+                <a href="{{unbound topic.lastUnreadUrl}}" class='badge new-posts badge-notification' title='{{i18n topic.new}}'>{{i18n filters.new.lower_title}}</a>
+              {{/if}}
+            </td>
+
+            {{#unless controller.hideCategory}}
+            <td class="category">
+              {{categoryLink topic.category showParent=true}}
+            </td>
+            {{/unless}}
+
+            <td class='num posts'><a href="{{unbound topic.lastUnreadUrl}}" class='badge-posts'>{{number topic.posts_count numberKey="posts_long"}}</a></td>
+
+            <td class='num likes'>
+              {{#if topic.like_count}}
+                <a href='{{unbound topic.url}}{{#if topic.has_summary}}?filter=summary{{/if}}'>{{unbound topic.like_count}} <i class='fa fa-heart'></i></a>
+              {{/if}}
+            </td>
+
+            <td {{bind-attr class=":num :views topic.viewsHeat"}}>{{number topic.views numberKey="views_long"}}</td>
+            {{#if topic.bumped}}
+              <td class='num activity'>
+                <a href="{{unbound topic.url}}" class='{{coldAgeClass created_at}}' title='{{i18n first_post}}: {{{rawDate topic.created_at}}}' >{{unboundAge topic.created_at}}</a>
+              </td>
+              <td class='num activity last'>
+                <a href="{{unbound topic.lastPostUrl}}" class='{{coldAgeClass bumped_at}}' title='{{i18n last_post}}: {{{rawDate topic.bumped_at}}}'>{{unboundAge topic.bumped_at}}</a>
+              </td>
+            {{else}}
+              <td class='num activity'>
+                <a href="{{unbound topic.url}}" class='age' title='{{i18n first_post}}: {{{rawDate topic.created_at}}}'>{{unboundAge topic.created_at}}</a>
+              </td>
+              <td class="activity"></td>
+            {{/if}}
+          </tr>
+        {{/groupedEach}}
+      </tbody>
 
     </table>
   {{else}}


### PR DESCRIPTION
This is an optimization for people that choose their table row highlighting to be inverse of the default Discourse theme.
If people choose to have the heading row (or individual th columns) and 'even' rows highlighted in topic-list.scss for the Categories page, the alternate coloring is not carried over to the User Activity page's Messages list. Because the basic-topic-list table there doesn't use the THEAD and TBODY wrappers, the first data row is effectively an ' ~~odd~~ even' row, so highlighting is now applied both on the heading row and the first data row.
By adding the THEAD and TBODY wrappers, we make sure that the table structures across the app are the same and global row highlighting styles work out of the box also on the User Activity page.
