### PR TITLE
Remove deprecated finder method calls

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -193,7 +193,7 @@ class Group < ActiveRecord::Base
     deletions = Set.new(deletions.map{|d| map[d]})
 
     @deletions = []
-    group_users.delete_if do |gu|
+    group_users.each do |gu|
       @deletions << gu if deletions.include?(gu.user_id)
     end
 
@@ -221,7 +221,7 @@ class Group < ActiveRecord::Base
     if @deletions
       @deletions.each do |gu|
         gu.destroy
-        User.update_all 'primary_group_id = NULL', ['id = ? AND primary_group_id = ?', gu.user_id, gu.group_id]
+        User.where('id = ? AND primary_group_id = ?', gu.user_id, gu.group_id).update_all 'primary_group_id = NULL'
       end
     end
     @deletions = nil

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -200,7 +200,7 @@ class Topic < ActiveRecord::Base
         modifications: changes.extract!(:category_id, :title)
       )
 
-      Post.update_all({version: number}, id: first_post_id)
+      Post.where(id: first_post_id).update_all(version: number)
     end
   end
 


### PR DESCRIPTION
I'm testing discourse against [Rails 4.1.0.rc2](https://github.com/chancancode/discourse/issues/1). This pull requests fixes two problems on the discourse side.
- Rails 4.1 no longer depends on the [activerecord-deprecated_finders](https://github.com/rails/activerecord-deprecated_finders) gem, so we need to either remove those calls or add that dependency to the Gemfile. It turns out that those are really easy to remove and it works on both 4.0 and 4.1, so that's what I did.
  
  From the gem's README and Rail's upgrade guide it's not very obvious that these are deprecated, so I'll see if we can make that obvious by mentioning them explicitly in the README and the upgrade guide.
  
  _However_, these calls are supposed to print a deprecation warning to the console, and I'm not seeing those when running the tests. Is this expected? (That the warnings are muted during testing.) If not, then we have a bug somewhere.
- The other problem is that relation no longer delegates `delete_if` to `Array`, see https://github.com/rails/rails/pull/12590. This never worked, we just stopped pretending that it did.
  
  Since this does absolutely nothing at the moment, I changed it to `each` for now to make that obvious. The more appropriate fix might be something like `group_users = group_users.to_a.delete_if do ...`, but I'm not sure if the hack is intended to defer that until after the record is saved, so I'm not sure how best to "fix" this here.
  
  I'll see if we can print a more helpful message to the console and/or make this clear in the upgrade guides.

There's another failing test, but we decided that Rails should fix that. You can see the details on https://github.com/chancancode/discourse/issues/1.

cc @SamSaffron, @rafaelfranca
