### PR TITLE
More advance unsubscribing via email

### DIFF
--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -211,6 +211,10 @@ class UserNotifications < ActionMailer::Base
       email_opts[:from_alias] = from_alias
     end
 
+    if tu
+      email_opts[:notification_level] = tu.notification_level
+    end
+
     TopicUser.change(user.id, post.topic_id, last_emailed_post_number: post.post_number)
 
     build_email(user.email, email_opts)

--- a/app/views/notifications/set_from_email.erb
+++ b/app/views/notifications/set_from_email.erb
@@ -1,0 +1,10 @@
+<div id='simple-container'>
+  <div class='alert alert-info'>
+    <p>
+      <h2><%= t 'notification.level_changed_successful' %></h2>
+    </p>
+    <p><%= raw t('notification.level_changed', topic_title: @topic.title, notification_level: @notification_level) %>
+    </p>
+    <p><%= link_to(t('notification.continue_to_topic'), @topic.relative_url) %></p>
+  </div>
+</div>

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -344,6 +344,11 @@ en:
     welcome_to: "Welcome to %{site_name}!"
     approval_required: "A moderator must manually approve your new account before you can access this forum. You'll get an email when your account is approved!"
 
+  notification:
+    level_changed_successful: "Notification level changed successfully"
+    level_changed: "The notification level for <i>%{topic_title}</i> has been changed to <i>%{notification_level}</i>."
+    continue_to_topic: "Continue to topic"
+
   post_action_types:
     off_topic:
       title: 'Off-Topic'
@@ -1254,6 +1259,11 @@ en:
         [Please review them in the admin section](%{base_url}/admin/users/list/pending).
 
   unsubscribe_link: "To unsubscribe from these emails, visit your [user preferences](%{user_preferences_url})."
+  change_notification_level:
+    from_regular: "Change notification alert level for topic from _Regular_ to [Watching](%{base_url}/notifications/set/%{action_key}/3), [Tracking](%{base_url}/notifications/set/%{action_key}/2) or [Muted](%{base_url}/notifications/set/%{action_key}/0)"
+    from_watching: "Change notification alert level for topic from _Watching_ to [Tracking](%{base_url}/notifications/set/%{action_key}/2), [Regular](%{base_url}/notifications/set/%{action_key}/1) or [Muted](%{base_url}/notifications/set/%{action_key}/0)"
+    from_tracking: "Change notification alert level for topic from _Tracking_ to [Watching](%{base_url}/notifications/set/%{action_key}/3), [Regular](%{base_url}/notifications/set/%{action_key}/1) or [Muted](%{base_url}/notifications/set/%{action_key}/0)"
+  change_notification_levels: ""
 
   user_notifications:
     previous_discussion: "Previous Replies"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -221,7 +221,9 @@ Discourse::Application.routes.draw do
 
   get "p/:post_id/:user_id" => "posts#short_link"
 
-  resources :notifications
+  get "/notifications/set/:reply_key/:notification_level" => "notifications#set_from_email"
+
+  resources :notifications, only: [:index]
 
   match "/auth/:provider/callback", to: "users/omniauth_callbacks#complete", via: [:get, :post]
   match "/auth/failure", to: "users/omniauth_callbacks#failure", via: [:get, :post]


### PR DESCRIPTION
( As discussed and specified here: https://meta.discourse.org/t/notification-subscription-options/13328/8 )
- emails now always contain the reply-key
- which is used to compile direct links in the footer to change the notification level
- the controller behind it changes the notification level for the topic and user giving through the reply-key without any other identification for users convenience
- it spits out an immediate no_js-layouted website showing the topic and the new notification level with a handy link to the topic for quick feedback on click even on mobile
- contains test (which on current master seem to not be run for other reasons)

This is what the simple confirmation then looks like:
![screen shot 2014-03-28 at 12 04 25](https://cloud.githubusercontent.com/assets/40496/2548794/c856159a-b668-11e3-8c1e-2572558c2a2b.png)
