### PR TITLE
Change post owner functionality

### DIFF
--- a/app/assets/javascripts/discourse/controllers/change_owner_controller.js
+++ b/app/assets/javascripts/discourse/controllers/change_owner_controller.js
@@ -1,0 +1,57 @@
+/**
+  Modal related to changing the ownership of posts
+
+  @class ChangeOwnerController
+  @extends Discourse.ObjectController
+  @namespace Discourse
+  @uses Discourse.ModalFunctionality
+  @module Discourse
+ **/
+Discourse.ChangeOwnerController = Discourse.ObjectController.extend(Discourse.SelectedPostsCount, Discourse.ModalFunctionality, {
+  needs: ['topic'],
+
+  topicController: Em.computed.alias('controllers.topic'),
+  selectedPosts: Em.computed.alias('topicController.selectedPosts'),
+
+  buttonDisabled: function() {
+    if (this.get('saving')) return true;
+    return this.blank('new_user');
+  }.property('saving', 'new_user'),
+
+  buttonTitle: function() {
+    if (this.get('saving')) return I18n.t('saving');
+    return I18n.t('topic.change_owner.action');
+  }.property('saving'),
+
+  onShow: function() {
+    this.setProperties({
+      saving: false,
+      new_user: ''
+    });
+  },
+
+  actions: {
+    changeOwnershipOfPosts: function() {
+      this.set('saving', true);
+
+      var postIds = this.get('selectedPosts').map(function(p) { return p.get('id'); }),
+          self = this,
+          saveOpts = {
+            post_ids: postIds,
+            username: this.get('new_user')
+          };
+
+      Discourse.Topic.changeOwners(this.get('id'), saveOpts).then(function(result) {
+        // success
+        self.send('closeModal');
+        self.get('topicController').send('toggleMultiSelect');
+        Em.run.next(function() { Discourse.URL.routeTo(result.url); });
+      }, function() {
+        // failure
+        self.flash(I18n.t('topic.change_owner.error'), 'alert-error');
+        self.set('saving', false);
+      });
+      return false;
+    }
+  }
+});

--- a/app/assets/javascripts/discourse/controllers/topic_controller.js
+++ b/app/assets/javascripts/discourse/controllers/topic_controller.js
@@ -265,6 +265,11 @@ Discourse.TopicController = Discourse.ObjectController.extend(Discourse.Selected
     return (this.get('selectedPostsCount') > 0);
   }.property('selectedPostsCount'),
 
+  canChangeOwner: function() {
+    if (!Discourse.User.current().admin) return false;
+    return !!this.get('selectedPostsUsername');
+  }.property('selectedPostsUsername'),
+
   categories: function() {
     return Discourse.Category.list();
   }.property(),

--- a/app/assets/javascripts/discourse/mixins/selected_posts_count.js
+++ b/app/assets/javascripts/discourse/mixins/selected_posts_count.js
@@ -19,8 +19,27 @@ Discourse.SelectedPostsCount = Em.Mixin.create({
     }
 
     return sum;
-  }.property('selectedPosts.length', 'allPostsSelected', 'selectedReplies.length')
+  }.property('selectedPosts.length', 'allPostsSelected', 'selectedReplies.length'),
 
+  /**
+    The username that owns every selected post, or undefined if no selection or if
+    ownership is mixed.
+
+    @returns {String|undefined} username that owns all selected posts
+  **/
+  selectedPostsUsername: function() {
+    // Don't proceed if replies are selected or usernames are mixed
+    // Changing ownership in those cases normally doesn't make sense
+    if (this.get('selectedReplies') && this.get('selectedReplies').length > 0) return;
+    if (this.get('selectedPosts').length <= 0) return;
+
+    var selectedPosts = this.get('selectedPosts'),
+        username = selectedPosts[0].username;
+
+    if (selectedPosts.every(function(post) { return post.username === username; })) {
+      return username;
+    }
+  }.property('selectedPosts.length', 'selectedReplies.length')
 });
 
 

--- a/app/assets/javascripts/discourse/models/topic.js
+++ b/app/assets/javascripts/discourse/models/topic.js
@@ -409,6 +409,17 @@ Discourse.Topic.reopenClass({
     return promise;
   },
 
+  changeOwners: function(topicId, opts) {
+    var promise = Discourse.ajax("/t/" + topicId + "/change-owner", {
+      type: 'POST',
+      data: opts
+    }).then(function (result) {
+      if (result.success) return result;
+      promise.reject(new Error("error changing ownership of posts"));
+    });
+    return promise;
+  },
+
   bulkOperation: function(topics, operation) {
     return Discourse.ajax("/topics/bulk", {
       type: 'PUT',

--- a/app/assets/javascripts/discourse/routes/topic_route.js
+++ b/app/assets/javascripts/discourse/routes/topic_route.js
@@ -67,6 +67,10 @@ Discourse.TopicRoute = Discourse.Route.extend({
       Discourse.Route.showModal(this, 'splitTopic', this.modelFor('topic'));
     },
 
+    changeOwner: function() {
+      Discourse.Route.showModal(this, 'changeOwner', this.modelFor('topic'));
+    },
+
     // Use replaceState to update the URL once it changes
     postChangedRoute: Discourse.debounce(function(currentPost) {
       // do nothing if we are transitioning to another route

--- a/app/assets/javascripts/discourse/templates/modal/change_owner.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/modal/change_owner.js.handlebars
@@ -1,0 +1,16 @@
+<div class="modal-body">
+  {{{i18n topic.change_owner.instructions count="selectedPostsCount" old_user="selectedPostsUsername"}}}
+  <p>
+      {{{i18n topic.change_owner.instructions_warn}}}
+  </p>
+
+  <form>
+      <label>{{i18n topic.change_owner.label}}</label>
+    {{userSelector single=true usernames=new_user include_groups="false" placeholderKey="topic.change_owner.placeholder"}}
+  </form>
+
+</div>
+
+<div class="modal-footer">
+    <button class='btn btn-primary' {{bind-attr disabled="buttonDisabled"}} {{action changeOwnershipOfPosts}}>{{buttonTitle}}</button>
+</div>

--- a/app/assets/javascripts/discourse/templates/modal/history.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/modal/history.js.handlebars
@@ -30,6 +30,11 @@
         {{{category_diff}}}
       </div>
     {{/if}}
+    {{#if user_changes}}
+      <div class="row">
+          {{boundAvatar user_changes.previous imageSize="small"}} {{user_changes.previous.username}} → {{boundAvatar user_changes.current imageSize="small"}} {{user_changes.current.username}}
+      </div>
+    {{/if}}
     {{{body_diff}}}
   </div>
 </div>

--- a/app/assets/javascripts/discourse/templates/selected_posts.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/selected_posts.js.handlebars
@@ -18,5 +18,8 @@
 {{#if canMergeTopic}}
   <button class='btn' {{action mergeTopic}}><i class='fa fa-sign-out'></i> {{i18n topic.merge_topic.action}}</button>
 {{/if}}
+{{#if canChangeOwner}}
+  <button class='btn' {{action changeOwner}}><i class='fa fa-user'></i> {{i18n topic.change_owner.action}}</button>
+{{/if}}
 
 <p class='cancel'><a href='#' {{action toggleMultiSelect}}>{{i18n topic.multi_select.cancel}}</a></p>

--- a/app/assets/javascripts/discourse/views/modal/change_owner_view.js
+++ b/app/assets/javascripts/discourse/views/modal/change_owner_view.js
@@ -1,0 +1,12 @@
+/**
+ A modal view for handling changing the owner of various posts
+
+ @class ChangeOwnerView
+ @extends Discourse.ModalBodyView
+ @namespace Discourse
+ @module Discourse
+ **/
+Discourse.ChangeOwnerView = Discourse.ModalBodyView.extend({
+  templateName: 'modal/change_owner',
+  title: I18n.t('topic.change_owner.title')
+});

--- a/app/assets/javascripts/discourse/views/modal/merge_topic_view.js
+++ b/app/assets/javascripts/discourse/views/modal/merge_topic_view.js
@@ -10,5 +10,3 @@ Discourse.MergeTopicView = Discourse.ModalBodyView.extend({
   templateName: 'modal/merge_topic',
   title: I18n.t('topic.merge_topic.title')
 });
-
-

--- a/app/assets/stylesheets/desktop/history.scss
+++ b/app/assets/stylesheets/desktop/history.scss
@@ -35,6 +35,8 @@
     word-wrap: break-word;
     .row, table {
       margin-top: 10px;
+      padding-bottom: 10px;
+      border-bottom: 1px dotted;
     }
   }
   img {

--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -622,13 +622,6 @@ iframe {
     }
 }
 
-#selected-posts {
-  padding-left: 20px;
-  .btn {
-    margin-bottom: 10px;
-  }
-}
-
 .post-select {
   float: right;
   margin-right: 20px;
@@ -914,8 +907,9 @@ blockquote { /* solo quotes */
 
 #selected-posts {
 
+  padding-left: 20px;
   margin-left: 330px;
-  width: 12%;
+  width: 200px;
   position: fixed;
   z-index: 1000;
   left: 50%;
@@ -927,7 +921,7 @@ blockquote { /* solo quotes */
 
 
   button {
-    width: 160px;
+    width: 180px;
     margin: 4px auto;
     display: inline-block;
     text-align: left;
@@ -958,9 +952,8 @@ blockquote { /* solo quotes */
     border: none;
     color: $tertiary_text_color;
     font-weight: normal;
-
-      color: $tertiary_text_color;
-      background: $btn-primary-background-color;
+    margin-bottom: 10px;
+    background: $btn-primary-background-color;
 
     &[href] {
       color: $tertiary_text_color;

--- a/app/models/post_revision.rb
+++ b/app/models/post_revision.rb
@@ -41,6 +41,17 @@ class PostRevision < ActiveRecord::Base
     }
   end
 
+  def user_changes
+    prev = previous("user_id")
+    cur = current("user_id")
+    return if prev == cur
+
+    {
+        previous_user: User.where(id: prev).first,
+        current_user: User.where(id: cur).first
+    }
+  end
+
   def previous(field)
     lookup_with_fallback(field, 0)
   end

--- a/app/serializers/post_revision_serializer.rb
+++ b/app/serializers/post_revision_serializer.rb
@@ -9,7 +9,8 @@ class PostRevisionSerializer < ApplicationSerializer
              :edit_reason,
              :body_changes,
              :title_changes,
-             :category_changes
+             :category_changes,
+             :user_changes
 
   def include_title_changes?
     object.has_topic_data?
@@ -41,6 +42,26 @@ class PostRevisionSerializer < ApplicationSerializer
 
   def edit_reason
     object.lookup("edit_reason", 1)
+  end
+
+  def user_changes
+    obj = object.user_changes
+    return unless obj
+    # same as below - if stuff is messed up, default to system
+    prev = obj[:previous_user] || Discourse.system_user
+    new = obj[:current_user] || Discourse.system_user
+    {
+        previous: {
+            username: prev.username_lower,
+            display_username: prev.username,
+            avatar_template: prev.avatar_template
+        },
+        current: {
+            username: new.username_lower,
+            display_username: new.username,
+            avatar_template: new.avatar_template
+        }
+    }
   end
 
   def user

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -802,7 +802,7 @@ en:
         invisible: "Make Invisible"
         visible: "Make Visible"
         reset_read: "Reset Read Data"
-        multi_select: "Select Posts to Move"
+        multi_select: "Select Posts"
         convert_to_topic: "Convert to Regular Topic"
 
       reply:
@@ -867,6 +867,17 @@ en:
         instructions:
           one: "Please choose the topic you'd like to move that post to."
           other: "Please choose the topic you'd like to move those <b>{{count}}</b> posts to."
+
+      change_owner:
+        title: "Change Owner of Posts"
+        action: "change ownership"
+        error: "There was an error changing the ownership of the posts."
+        label: "New Owner of Posts"
+        placeholder: "username of new owner"
+        instructions:
+          one: "Please choose the new owner of the post by <b>{{old_user}}</b>."
+          other: "Please choose the new owner of the {{count}} posts by <b>{{old_user}}</b>."
+        instructions_warn: "Note that any notifications about this post will not be transferred to the new user retroactively.<br>Warning: Currently, no post-dependent data is transferred over to the new user. Use with caution."
 
       multi_select:
         select: 'select'

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -910,6 +910,9 @@ en:
       one: "I moved a post to an existing topic: %{topic_link}"
       other: "I moved %{count} posts to an existing topic: %{topic_link}"
 
+  change_owner:
+    post_revision_text: "Ownership transferred from %{old_user} to %{new_user}"
+
   topic_statuses:
     archived_enabled: "This topic is now archived. It is frozen and cannot be changed in any way."
     archived_disabled: "This topic is now unarchived. It is no longer frozen, and can be changed."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -331,6 +331,7 @@ Discourse::Application.routes.draw do
   post "t/:topic_id/invite" => "topics#invite", constraints: {topic_id: /\d+/}
   post "t/:topic_id/move-posts" => "topics#move_posts", constraints: {topic_id: /\d+/}
   post "t/:topic_id/merge-topic" => "topics#merge_topic", constraints: {topic_id: /\d+/}
+  post "t/:topic_id/change-owner" => "topics#change_post_owners", constraints: {topic_id: /\d+/}
   delete "t/:topic_id/timings" => "topics#destroy_timings", constraints: {topic_id: /\d+/}
 
   post "t/:topic_id/notifications" => "topics#set_notifications" , constraints: {topic_id: /\d+/}

--- a/lib/guardian/post_guardian.rb
+++ b/lib/guardian/post_guardian.rb
@@ -125,4 +125,8 @@ module PostGuardain
   def can_vote?(post, opts={})
     post_can_act?(post,:vote, opts)
   end
+
+  def can_change_post_owner?
+    is_admin?
+  end
 end

--- a/lib/post_revisor.rb
+++ b/lib/post_revisor.rb
@@ -10,6 +10,7 @@ class PostRevisor
 
   # Recognized options:
   #  :edit_reason User-supplied edit reason
+  #  :new_user New owner of the post
   #  :revised_at changes the date of the revision
   #  :force_new_version bypass ninja-edit window
   #  :bypass_bump do not bump the topic, even if last post
@@ -45,7 +46,7 @@ class PostRevisor
   end
 
   def should_revise?
-    @post.raw != @new_raw
+    @post.raw != @new_raw || @opts[:changed_owner]
   end
 
   def revise_post
@@ -63,6 +64,7 @@ class PostRevisor
   def should_create_new_version?
     @post.last_editor_id != @editor.id ||
     get_revised_at - @post.last_version_at > SiteSetting.ninja_edit_window.to_i ||
+    @opts[:changed_owner] == true ||
     @opts[:force_new_version] == true
   end
 
@@ -93,6 +95,7 @@ class PostRevisor
     @post.word_count = @new_raw.scan(/\w+/).size
     @post.last_editor_id = @editor.id
     @post.edit_reason = @opts[:edit_reason] if @opts[:edit_reason]
+    @post.user_id = @opts[:new_user].id if @opts[:new_user]
 
     if @editor == @post.user && @post.hidden && @post.hidden_reason_id == Post.hidden_reasons[:flag_threshold_reached]
       @post.hidden = false


### PR DESCRIPTION
Some notes:
- Owner changes are logged as post revisions.
- The client UI won't let you change ownership of posts if you have mixed authors selected, but the backend has no such restriction.
- The spec is a bit lacking.

![image](https://cloud.githubusercontent.com/assets/627891/2552397/ce8e8a2a-b698-11e3-8ffc-cd8106258f15.png)
![image](https://cloud.githubusercontent.com/assets/627891/2552408/e7efc45c-b698-11e3-9a8a-2346eb10c219.png)
![image](https://cloud.githubusercontent.com/assets/627891/2552413/f0f83f98-b698-11e3-88a5-7ce20d3797ff.png)
