### PR TITLE
Enable autohighlighting of highlight.js for all code blocks

### DIFF
--- a/app/assets/javascripts/discourse/lib/syntax_highlighting.js
+++ b/app/assets/javascripts/discourse/lib/syntax_highlighting.js
@@ -16,7 +16,8 @@ Discourse.SyntaxHighlighting = {
     @param {jQuery.selector} $elem The element we want to apply our highlighting to
   **/
   apply: function($elem) {
-    $('pre code[class]', $elem).each(function(i, e) {
+    var selector = Discourse.SiteSettings.autohighlight_all_code ? 'pre code' : 'pre code[class]';
+    $(selector, $elem).each(function(i, e) {
       return $LAB.script("/javascripts/highlight.pack.js").wait(function() {
         return hljs.highlightBlock(e);
       });

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -856,6 +856,7 @@ en:
     short_progress_text_threshold: "After the number of posts in a topic goes above this number, the progress bar will only show the current post number. If you change the progress bar's width, you may need to change this value."
     default_code_lang: "Default programming language syntax highlighting applied to GitHub code blocks (lang-auto, ruby, python etc.)"
     warn_reviving_old_topic_age: "When someone starts replying to a topic older than this many days, a warning will be displayed to discourage the user from reviving an old discussion. Disable by setting to 0."
+    autohighlight_all_code: "Apply code highlighting to all preformatted code blocks even when the didn't specify the language"
 
     embeddable_host: "Host that can embed the comments from this Discourse forum"
     feed_polling_enabled: "Whether to import a RSS/ATOM feed as posts"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -235,6 +235,9 @@ posting:
     client: true
     default: "lang-auto"
   warn_reviving_old_topic_age: 180
+  autohighlight_all_code:
+    client: true
+    default: false
 
 email:
   email_time_window_mins: 10


### PR DESCRIPTION
by removing the restriction to only be applied when the user specified a language through the syntax but every time we find a code in a pre-tag. I don't think there is a good case when we want to prevent this from apply ...

See https://meta.discourse.org/t/support-auto-highlighting-for-preformatted-code/14234 .
