### PR TITLE
Add no-text class to buttons with no text

### DIFF
--- a/app/assets/javascripts/admin/templates/user_index.js.handlebars
+++ b/app/assets/javascripts/admin/templates/user_index.js.handlebars
@@ -58,8 +58,8 @@
     <div class='controls'>
       {{#if primaryGroupDirty}}
         <div>
-        <button class='btn ok' {{action savePrimaryGroup}}><i class='fa fa-check'></i></button>
-        <button class='btn cancel' {{action resetPrimaryGroup}}><i class='fa fa-times'></i></button>
+        <button class='btn ok no-text' {{action savePrimaryGroup}}><i class='fa fa-check'></i></button>
+        <button class='btn cancel no-text' {{action resetPrimaryGroup}}><i class='fa fa-times'></i></button>
         </div>
       {{/if}}
     </div>
@@ -226,8 +226,8 @@
 
       {{#if dirty}}
         <div>
-        <button class='btn ok' {{action saveTrustLevel target="content"}}><i class='fa fa-check'></i></button>
-        <button class='btn cancel' {{action restoreTrustLevel target="content"}}><i class='fa fa-times'></i></button>
+        <button class='btn ok no-text' {{action saveTrustLevel target="content"}}><i class='fa fa-check'></i></button>
+        <button class='btn cancel no-text' {{action restoreTrustLevel target="content"}}><i class='fa fa-times'></i></button>
         </div>
       {{/if}}
     </div>

--- a/app/assets/javascripts/discourse/templates/discovery/topics.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/discovery/topics.js.handlebars
@@ -1,6 +1,6 @@
 {{#if selected}}
   <div id='bulk-select'>
-    <button class='btn' {{action showBulkActions}}><i class="fa fa-wrench"></i></button>
+    <button class='btn no-text' {{action showBulkActions}}><i class="fa fa-wrench"></i></button>
   </div>
 {{/if}}
 

--- a/app/assets/javascripts/discourse/templates/topic.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/topic.js.handlebars
@@ -22,8 +22,8 @@
             {{/if}}
             {{textField id='edit-title' value=newTitle}}
 
-            <button class='btn btn-primary btn-small' {{action finishedEditingTopic}}><i class='fa fa-check'></i></button>
-            <button class='btn btn-small' {{action cancelEditingTopic}}><i class='fa fa-times'></i></button>
+            <button class='btn btn-primary btn-small no-text' {{action finishedEditingTopic}}><i class='fa fa-check'></i></button>
+            <button class='btn btn-small no-text' {{action cancelEditingTopic}}><i class='fa fa-times'></i></button>
           {{else}}
             <h1>
               <span class="private-message-glyph"><i class='fa fa-envelope'></i></span>

--- a/app/assets/stylesheets/desktop/topic-list.scss
+++ b/app/assets/stylesheets/desktop/topic-list.scss
@@ -539,9 +539,6 @@ ol.category-breadcrumb {
   right: 20px;
   padding: 5px;
   background-color: $primary_background_color;
-  button {
-    padding: 3px 0 3px 6px;
-  }
 }
 
 button.dismiss-read {


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/627891/2560591/9633961a-b7d4-11e3-9f83-0b56ec6e8050.png)
![image](https://cloud.githubusercontent.com/assets/627891/2560595/ace6bc8e-b7d4-11e3-8f21-9537e88f8313.png)
![image](https://cloud.githubusercontent.com/assets/627891/2560600/b6cc3a8a-b7d4-11e3-933f-a5c529e78211.png)
![image](https://cloud.githubusercontent.com/assets/627891/2560602/c1ddc682-b7d4-11e3-8963-cb3731b10684.png)

Note: This is the regex I used

```
ack "<button class=[\"\']((?"'!'"no-text).)*[\"\'] .*?><i class=.*?></i></button>"
```

It has one more match, and that's the button to start bulk-selecting topics. The no-text class style doesn't look better there than the current one, so I left it alone.
