### PR TITLE
Unescape topic title before setting it as the document title

### DIFF
--- a/app/assets/javascripts/discourse/views/topic_view.js
+++ b/app/assets/javascripts/discourse/views/topic_view.js
@@ -49,7 +49,7 @@ Discourse.TopicView = Discourse.View.extend(Discourse.Scrolling, {
 
   _updateTitle: function() {
     var title = this.get('topic.title');
-    if (title) return Discourse.set('title', title);
+    if (title) return Discourse.set('title', _.unescape(title));
   }.observes('topic.loaded', 'topic.title'),
 
   _composeChanged: function() {


### PR DESCRIPTION
Currently having a topic title with `<` in it will result in it being replaced with `&lt;` in the document title. 

Since the document title is set using `$('title').text(...)` and `document.title = ...` this is a safe change to make.

Example: http://try.discourse.org/t/topic-with-lt-in-the-title/190
