### PR TITLE
Fix missing avatar while a post is being created

### DIFF
--- a/app/assets/javascripts/discourse/models/composer.js
+++ b/app/assets/javascripts/discourse/models/composer.js
@@ -161,7 +161,7 @@ Discourse.Composer = Discourse.Model.extend({
     return this.get('reply') !== this.get('originalText');
   }.property('reply', 'originalText'),
 
-/**
+  /**
     Number of missing characters in the title until valid.
 
     @property missingTitleCharacters
@@ -453,6 +453,7 @@ Discourse.Composer = Discourse.Model.extend({
       display_username: currentUser.get('name'),
       username: currentUser.get('username'),
       user_id: currentUser.get('id'),
+      avatar_template: currentUser.get('avatar_template'),
       metaData: this.get('metaData'),
       archetype: this.get('archetypeId'),
       post_type: Discourse.Site.currentProp('post_types.regular'),


### PR DESCRIPTION
This makes it so that the avatar is displayed while the post is still being saved, earlier it would display only the username next to the post and show the avatar after receiving a response from the server.

The user title and staff/new user coloring are also added after saving but I didn't add them, didn't think they were too important since they are subtle whereas the avatar suddenly appearing is pretty jarring.
