### PR TITLE
Fix the OOBGC's delta tuning

### DIFF
--- a/lib/middleware/unicorn_oobgc.rb
+++ b/lib/middleware/unicorn_oobgc.rb
@@ -106,13 +106,11 @@ module Middleware::UnicornOobgc
       @max_delta ||= delta
 
       if delta > @max_delta
-        new_delta = (delta * 1.5).to_i
-        @max_delta = [new_delta, delta].min
+        @max_delta = (@max_delta * 1.5).to_i
       else
         # this may seem like a very tiny decay rate, but some apps using caching
         # can really mess stuff up, if our delta is too low the algorithm fails
-        new_delta = (delta * 0.995).to_i
-        @max_delta = [new_delta, delta].max
+        @max_delta = (@max_delta * 0.995).to_i
       end
 
       if @max_delta < MIN_FREE_SLOTS


### PR DESCRIPTION
The prior implementation effectively just set @max_delta=delta.  This approach iteratively tunes @max_delta over time.

---

I believe this patch follows the original intent of the delta tuning, but I want to emphasise I haven't been able to properly test this change on a production server yet - we're still on 1.9.3, which AFAICT doesn't update :heap_live_num until GC runs, which means that my live-num-delta is always 0.  So, I understand if you'd rather not merge this just yet.
