### PR TITLE
z-index tweaks for #user-dropdown and align the #topic-admin-menu icon

### DIFF
--- a/app/assets/stylesheets/desktop/topic-admin-menu.scss
+++ b/app/assets/stylesheets/desktop/topic-admin-menu.scss
@@ -4,7 +4,7 @@
   position: fixed;
   top: 70px;
   right: 10px;
-  z-index: 1000;
+  z-index: 999;
 }
 
 .topic-admin-menu {
@@ -25,5 +25,9 @@
   button {
     width: 200px;
     margin-bottom: 5px;
+
+    i {
+      width: 14px;
+    }
   }
 }


### PR DESCRIPTION
- Minus #show-topic-admin button z-index by 1 which will be covered by #user-dropdown
- Add 14px width for #topic-admin-menu icon, align the button text

Before
![2](https://cloud.githubusercontent.com/assets/297343/2601795/e4f8171e-bb15-11e3-9067-7980ee495b95.png)
After
![1](https://cloud.githubusercontent.com/assets/297343/2601794/e4f6e6c8-bb15-11e3-867c-75a83f050504.png)
![3](https://cloud.githubusercontent.com/assets/297343/2601796/e4fdc574-bb15-11e3-9e98-1d7cc9ba7fb5.png)
