### PR TITLE
[bugfix] Fix for '/' keyboard shortcut putting '/' into search input

### DIFF
--- a/app/assets/javascripts/discourse/components/keyboard_shortcuts_component.js
+++ b/app/assets/javascripts/discourse/components/keyboard_shortcuts_component.js
@@ -36,7 +36,6 @@ Discourse.KeyboardShortcuts = Ember.Object.createWithMixins({
     'R': 'article.selected button.create',                        // reply to selected post
     's': '#topic-footer-buttons button.share',                    // share topic
     'S': 'article.selected button.share',                         // share selected post
-    '/': '#search-button',                                        // focus search
     '!': 'article.selected button.flag'                           // flag selected post
   },
 
@@ -48,6 +47,7 @@ Discourse.KeyboardShortcuts = Ember.Object.createWithMixins({
     'u': 'goBack',
     '`': 'nextSection',
     '~': 'prevSection',
+    '/': 'showSearch',
     '?': 'showHelpModal'                                          // open keyboard shortcut help
   },
 
@@ -90,6 +90,11 @@ Discourse.KeyboardShortcuts = Ember.Object.createWithMixins({
 
   prevSection: function() {
     this._changeSection(-1);
+  },
+
+  showSearch: function() {
+    $('#search-button').click();
+    return false;
   },
 
   showHelpModal: function() {


### PR DESCRIPTION
Changed the search button binding from a click binding in mousetrap.js to a function binding.
Added a showSearch function that uses jquery to click the '#search-button' element
and the function returns false preventing the default action and stops the keydown event
from bubbling upwards.

Meta Discourse Bug Thread: https://meta.discourse.org/t/shortcut-for-search-leaves-a-in-the-search-field/14394
Mousetrap reference: http://craig.is/killing/mice
