### PR TITLE
Use Redis to cache Sass files in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -49,5 +49,9 @@ Discourse::Application.configure do
   if emails = GlobalSetting.developer_emails
     config.developer_emails = emails.split(",")
   end
+
+  # disk IO is slow in a vm, use Redis instead
+  require 'sass/plugin'
+  Sass::Plugin.options[:cache_store] = ActiveSupport::Cache::RedisStore.new
 end
 


### PR DESCRIPTION
As suggested by @briangonzalez on Meta:
https://meta.discourse.org/t/development-mode-super-slow/2179/51?u=riking

EDIT: I'm getting a NameError with this:

```
[vagrant@precise32:/vagrant (list-setting)]$ bundle exec rails c
/vagrant/config/environments/development.rb:55:in `block in <top (required)>': uninitialized constant ActiveSupport::Cache::RedisStore (NameError)
```
