### PR TITLE
allow polls to be closed independently of topic

### DIFF
--- a/plugins/poll/assets/javascripts/poll_ui.js
+++ b/plugins/poll/assets/javascripts/poll_ui.js
@@ -38,7 +38,7 @@ var PollController = Discourse.Controller.extend({
   poll: null,
   showResults: false,
 
-  disableRadio: Em.computed.any('poll.post.topic.closed', 'loading'),
+  disableRadio: Em.computed.any('poll.post.poll_details.closed', 'loading'),
 
   actions: {
     selectOption: function(option) {

--- a/plugins/poll/config/locales/server.en.yml
+++ b/plugins/poll/config/locales/server.en.yml
@@ -14,3 +14,4 @@ en:
     cannot_have_modified_options: "cannot be modified after the first five minutes. Contact a moderator if you need to change them."
     cannot_add_or_remove_options: "can only be edited, not added or removed. If you need to add or remove options you should lock this topic and create a new one."
     prefix: "Poll:"
+    closed_prefix: "Closed Poll:"

--- a/plugins/poll/config/locales/server.es.yml
+++ b/plugins/poll/config/locales/server.es.yml
@@ -14,3 +14,4 @@ es:
     cannot_have_modified_options: "no se pueden modificar las respuestas de la encuesta pasados 5 minutos"
     cannot_add_or_remove_options: "solo se puede modificar, no se pueden añadir o quitar. Si necesitas añadir o quitar respuestas debes bloquear este tema y crear una encuesta nueva."
     prefix: "Encuesta:"
+    closed_prefix: "Encuesta Cerrada:"

--- a/plugins/poll/config/locales/server.fr.yml
+++ b/plugins/poll/config/locales/server.fr.yml
@@ -20,3 +20,4 @@ fr:
     cannot_have_modified_options: "ne peuvent pas être modifiés après 5 minutes. Merci de contacter un moderateur, si vous souhaitez les modifier"
     cannot_add_or_remove_options: "peuvent seulement être modifiés. Si vous souhaitez en supprimer ou en ajouter, veuillez créer un nouveau sujet."
     prefix: "Sondage\\s?:"
+    closed_prefix: "Sondage\\s? Fermé:"

--- a/plugins/poll/config/locales/server.it.yml
+++ b/plugins/poll/config/locales/server.it.yml
@@ -14,3 +14,4 @@ it:
     cannot_have_modified_options: "non possono essere modificate dopo i primi cinque minuti. Contatta un moderatore se hai bisogno di cambiarle."
     cannot_add_or_remove_options: "non possono essere modificate, aggiunte o rimosse. Se vuoi aggiungere o rimuovere opzioni al sondaggio, devi bloccare questo topice crearne uno nuovo."
     prefix: "Sondaggio:"
+    closed_prefix: "Sondaggio Chiuso:"

--- a/plugins/poll/poll.rb
+++ b/plugins/poll/poll.rb
@@ -21,7 +21,7 @@ module ::PollPlugin
         return false
       end
 
-      topic.title =~ /^#{I18n.t('poll.prefix')}/i
+      topic.title =~ /^(#{I18n.t('poll.prefix')}|#{I18n.t('poll.closed_prefix')})/i
     end
 
     def has_poll_details?
@@ -57,6 +57,10 @@ module ::PollPlugin
         # Regular user, tell them to contact a moderator.
         @post.errors.add(:poll_options, I18n.t('poll.cannot_have_modified_options'))
       end
+    end
+
+    def is_closed?
+      @post.topic.closed? || (@post.topic.title =~ /^#{I18n.t('poll.closed_prefix')}/i) === 0
     end
 
     def options
@@ -136,7 +140,7 @@ module ::PollPlugin
     end
 
     def set_vote!(user, option)
-      return if @post.topic.closed?
+      return if is_closed?
 
       # Get the user's current vote.
       vote = get_vote(user)
@@ -152,7 +156,7 @@ module ::PollPlugin
 
     def serialize(user)
       return nil if details.nil?
-      {options: details, selected: get_vote(user)}
+      {options: details, selected: get_vote(user), closed: is_closed?}
     end
 
     private


### PR DESCRIPTION
From [this discussion about closing polls](https://meta.discourse.org/t/poll-how-do-you-close-a-poll/14539), this pull request allows a poll to be closed by changing the topic title from `Poll: foo` to `Closed Poll: foo` rather than requiring the topic to be closed.  This approach allows discussion to continue beyond the end of voting.
