### PR TITLE
change lib longDate to format('llll')

### DIFF
--- a/app/assets/javascripts/discourse/lib/formatter.js
+++ b/app/assets/javascripts/discourse/lib/formatter.js
@@ -72,7 +72,7 @@ toTitleCase = function toTitleCase(str) {
 
 longDate = function(dt) {
   if (!dt) return;
-  return moment(dt).longDate();
+  return moment(dt).format('llll');
 };
 
 updateRelativeAge = function(elems) {


### PR DESCRIPTION
.relative-date title is a random string generated by momentjs. The title attr just shows _tr早上n92014年4月7日早上tion 41i09ing: 1_CN.1早上t19.2014年4月7日ong_1早上t1_. This is because of a locale missing. 

Though I have no idea about what's going on here, I manage to get it work as expected. Now its title is _2014年4月7日星期一早上1点41_ which is correct.

I suspect longDate is the same as format('llll') here.
