### PR TITLE
Bugfix: double selection of categories in user preferences 

### DIFF
--- a/app/assets/javascripts/discourse/components/category_group_component.js
+++ b/app/assets/javascripts/discourse/components/category_group_component.js
@@ -11,7 +11,8 @@ Discourse.CategoryGroupComponent = Ember.Component.extend({
         return Discourse.Category.list().filter(function(category){
           var regex = new RegExp(term, "i");
           return category.get("name").match(regex) &&
-            !_.contains(self.get('categories'), category);
+            !_.contains(self.get('blacklist') || [], category) &&
+            !_.contains(self.get('categories'), category) ;
         });
       },
       onChangeItems: function(items) {

--- a/app/assets/javascripts/discourse/controllers/preferences_controller.js
+++ b/app/assets/javascripts/discourse/controllers/preferences_controller.js
@@ -15,6 +15,10 @@ Discourse.PreferencesController = Discourse.ObjectController.extend({
     return Discourse.SiteSettings.allow_user_locale;
   }.property(),
 
+  selectedCategories: function(){
+    return [].concat(this.get("watchedCategories"), this.get("trackedCategories"), this.get("mutedCategories"));
+  }.property("watchedCategories", "trackedCategories", "mutedCategories"),
+
   // By default we haven't saved anything
   saved: false,
 

--- a/app/assets/javascripts/discourse/templates/user/preferences.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/user/preferences.js.handlebars
@@ -187,17 +187,17 @@
       <label class="control-label">{{i18n user.categories_settings}}</label>
       <div class="controls category-controls">
         <label>{{i18n user.watched_categories}}</label>
-        {{category-group categories=watchedCategories}}
+        {{category-group categories=watchedCategories blacklist=selectedCategories}}
       </div>
       <div class="instructions">{{i18n user.watched_categories_instructions}}</div>
       <div class="controls category-controls">
         <label>{{i18n user.tracked_categories}}</label>
-        {{category-group categories=trackedCategories}}
+        {{category-group categories=trackedCategories blacklist=selectedCategories}}
       </div>
       <div class="instructions">{{i18n user.tracked_categories_instructions}}</div>
       <div class="controls category-controls">
         <label>{{i18n user.muted_categories}}</label>
-        {{category-group categories=mutedCategories}}
+        {{category-group categories=mutedCategories blacklist=selectedCategories}}
       </div>
       <div class="instructions">{{i18n user.muted_categories_instructions}}</div>
     </div>


### PR DESCRIPTION
Prevent user from selecting the same category twice for different notification levels in their preferences. Before this patch this was possible, legit and not prevented:

![screen shot 2014-04-09 at 16 39 32](https://cloud.githubusercontent.com/assets/40496/2656731/dd215d5a-bff4-11e3-9937-2253afe2acf3.png)

With this patch, the UI prevent double selection. You need to remove the item from the other list first otherwise it doesn't show in the autocomplete. (Though the backend would still accept double selection).
