### PR TITLE
BUGFIX: suppress error when scrolling at bottom of topic

### DIFF
--- a/app/assets/javascripts/discourse/controllers/topic_controller.js
+++ b/app/assets/javascripts/discourse/controllers/topic_controller.js
@@ -558,6 +558,8 @@ Discourse.TopicController = Discourse.ObjectController.extend(Discourse.Selected
     @params {Discourse.Post} post that is at the top
   **/
   topVisibleChanged: function(post) {
+    if (!post) { return; }
+
     var postStream = this.get('postStream'),
         firstLoadedPost = postStream.get('firstLoadedPost');
 
@@ -589,6 +591,8 @@ Discourse.TopicController = Discourse.ObjectController.extend(Discourse.Selected
     @params {Discourse.Post} post that is at the bottom
   **/
   bottomVisibleChanged: function(post) {
+    if (!post) { return; }
+
     var postStream = this.get('postStream'),
         lastLoadedPost = postStream.get('lastLoadedPost'),
         index = postStream.get('stream').indexOf(post.get('id'))+1;


### PR DESCRIPTION
Browse to a topic, then scroll all the way to the bottom of the page. Keep scrolling and watch the error console to see an "Uncaught TypeError: Cannot call method 'get' of null" error being thrown by topic_controller.

As far as I can tell the error doesn't actually break anything, so seems reasonable to just silence it and carry on.
