### PR TITLE
Show results by default for closed polls

### DIFF
--- a/plugins/poll/assets/javascripts/poll_ui.js
+++ b/plugins/poll/assets/javascripts/poll_ui.js
@@ -36,7 +36,7 @@ var Poll = Discourse.Model.extend({
 
 var PollController = Discourse.Controller.extend({
   poll: null,
-  showResults: false,
+  showResults: Em.computed.oneWay('poll.post.poll_details.closed'),
 
   disableRadio: Em.computed.any('poll.post.poll_details.closed', 'loading'),
 


### PR DESCRIPTION
By using Em.computed.oneWay, the initial value of the property is the provided key but you can still change it with a call to set().
