### PR TITLE
Bugfix: Keep import path and context for plugin's scss imports

### DIFF
--- a/lib/discourse_sass_importer.rb
+++ b/lib/discourse_sass_importer.rb
@@ -42,7 +42,7 @@ class DiscourseSassImporter < Sass::Importers::Filesystem
         stylesheets = DiscoursePluginRegistry.mobile_stylesheets
       end
       contents = ""
-      stylesheets.each {|css| contents << File.read(css) }
+      stylesheets.each {|css| contents << "@import '#{css}';" }
       Sass::Engine.new(contents, options.merge(
         filename: "#{name}.scss",
         importer: self,


### PR DESCRIPTION
Instead of concatenating all files into one gigantic file reuse the importer by creating an intermediate "scss" containing only the `@import`-statements to all plugin styles. Which then triggers a recursive call to load each individual one of them with the appropriate relative paths still in tact.

Fixes https://meta.discourse.org/t/uses-of-scss-in-plugins/14644
