### PR TITLE
Implicit semicolon hiding draft status

### DIFF
--- a/app/assets/javascripts/discourse/models/composer.js
+++ b/app/assets/javascripts/discourse/models/composer.js
@@ -563,8 +563,7 @@ Discourse.Composer = Discourse.Model.extend({
     var composer = this;
 
     // try to save the draft
-    return Discourse.Draft.save(this.get('draftKey'), this.get('draftSequence'), data)
-      .then(function() {
+    Discourse.Draft.save(this.get('draftKey'), this.get('draftSequence'), data).then(function() {
         composer.set('draftStatus', I18n.t('composer.saved_draft_tip'));
       }, function() {
         composer.set('draftStatus', I18n.t('composer.drafts_offline'));

--- a/app/assets/javascripts/discourse/views/composer/composer_view.js
+++ b/app/assets/javascripts/discourse/views/composer/composer_view.js
@@ -221,7 +221,7 @@ Discourse.ComposerView = Discourse.View.extend(Ember.Evented, {
     this.loadingChanged();
 
     var saveDraft = Discourse.debounce((function() {
-      return self.get('controller').saveDraft();
+      self.get('controller').saveDraft();
     }), 2000);
 
     $wmdInput.keyup(function() {


### PR DESCRIPTION
Because the `.then()` call was on the next line, JS inserts an implicit semicolon, resulting in the draft status never updating.
