### PR TITLE
BUGFIX: adjust page padding when composer view open

### DIFF
--- a/app/assets/javascripts/discourse/views/composer/composer_view.js
+++ b/app/assets/javascripts/discourse/views/composer/composer_view.js
@@ -75,7 +75,7 @@ Discourse.ComposerView = Discourse.View.extend(Ember.Evented, {
       var replyControl = $('#reply-control');
       var h = replyControl.height() || 0;
       var sizePx = "" + h + "px";
-      $('.topic-area').css('padding-bottom', sizePx);
+      $('#main-outlet').css('padding-bottom', sizePx);
       $('.composer-popup').css('bottom', sizePx);
     });
   }.observes('model.composeState'),
@@ -438,6 +438,7 @@ Discourse.ComposerView = Discourse.View.extend(Ember.Evented, {
   },
 
   childWillDestroyElement: function() {
+    $('#main-outlet').css('padding-bottom', 0);
     this._unbindUploadTarget();
   },
 


### PR DESCRIPTION
From https://meta.discourse.org/t/discourse-general-polish/13184 :

"Footer padding gets out of sync: start typing a new topic in the composer ... size it big ... got to random topic ... footer padding is not added so you can not see the last post on topic. (workaround, resize composer once more so footer padding is added). This need to be added everywhere automatically. Including admin screens."
