### PR TITLE
Update INSTALL-digital-ocean.md

### DIFF
--- a/docs/INSTALL-digital-ocean.md
+++ b/docs/INSTALL-digital-ocean.md
@@ -1,4 +1,4 @@
-The [Discourse Docker Image][dd] makes it easy to set up Discourse on a cloud server. We will use [Digital Ocean][do], although these steps may work on other cloud providers.
+The [Discourse Docker Image][dd] makes it easy to set up Discourse on a cloud server. We will use [Digital Ocean][do], although these steps may work on other cloud providers. Docker does not support OpenVZ/Virtuozzo.
 
 This guide assumes that you have no knowledge of Ruby/Rails or Linux shell. 
 


### PR DESCRIPTION
I've been hopping around on some newer providers and I often forget that Docker will (likely) never support running inside an OpenVZ container... in most cases. Often these providers run older kernels without AUFS support, and won't spin up a special kernel.

I'm not sure if this note is the "best" place to include the disclaimer; because this guide is very targeted. But it may save some upcoming support requests.
