### PR TITLE
Add digital ocean guide link

### DIFF
--- a/docs/INSTALL-digital-ocean.md
+++ b/docs/INSTALL-digital-ocean.md
@@ -178,7 +178,7 @@ If anything needs to be improved in this guide, feel free to ask on [meta.discou
    [dd]: https://github.com/discourse/discourse_docker
   [man]: https://mandrillapp.com
   [ssh]: https://help.github.com/articles/generating-ssh-keys
- [meta]: https://meta.discourse.org
+ [meta]: https://meta.discourse.org/t/beginners-guide-to-deploy-discourse-on-digital-ocean-using-docker/12156
    [do]: https://www.digitalocean.com/?refcode=5fa48ac82415
   [lts]: https://wiki.ubuntu.com/LTS
   [jet]: http://www.mailjet.com/pricing


### PR DESCRIPTION
Added [digital ocean guide](https://meta.discourse.org/t/beginners-guide-to-deploy-discourse-on-digital-ocean-using-docker/12156) link, so folks will know where to ask for improvements/problems regarding installation, instead of creating new topics on meta.

[Inspiration for this PR came from [this topic](https://meta.discourse.org/t/rack-mini-profiler-showing-up-in-production-for-admins/14735), this should not have been a new topic, instead it should be a comment on [digital ocean guide](https://meta.discourse.org/t/beginners-guide-to-deploy-discourse-on-digital-ocean-using-docker/12156) topic.]
