### PR TITLE
Get rid of unnecessary controller reference in poll template

### DIFF
--- a/plugins/poll/assets/javascripts/discourse/templates/poll.js.handlebars
+++ b/plugins/poll/assets/javascripts/discourse/templates/poll.js.handlebars
@@ -1,11 +1,11 @@
 <table>
   {{#each poll.options}}
     <tr {{bind-attr class=checked:active}} {{action selectOption option}}>
-      <td class="radio"><input type="radio" name="poll" {{bind-attr checked=checked disabled=controller.disableRadio}}></td>
+      <td class="radio">
+        <input type="radio" name="poll" {{bind-attr checked=checked disabled=controller.disableRadio}}>
+      </td>
       <td class="option">
-        <div class="option">
-          {{{ option }}}
-        </div>
+        <div class="option">{{{option}}}</div>
         {{#if controller.showResults}}
           <div class="result">{{i18n poll.voteCount count=votes}}</div>
         {{/if}}
@@ -24,7 +24,7 @@
   {{/if}}
 </button>
 
-{{#if controller.showToggleClosePoll}}
+{{#if showToggleClosePoll}}
   <button {{action toggleClosePoll}} class="btn btn-small">
     {{#if poll.closed}}
       <i class="fa fa-unlock-alt"></i>


### PR DESCRIPTION
I wasn't able to get rid of the `controller.`s inside the each helper, for some reason using the {{#each x in y}} form wasn't setting the scope as I would have expected. The other one was actually not needed at all.

cc @eviltrout
