### PR TITLE
Have anon users follow default external link setting

### DIFF
--- a/app/assets/javascripts/discourse.js
+++ b/app/assets/javascripts/discourse.js
@@ -95,6 +95,14 @@ window.Discourse = Ember.Application.createWithMixins(Discourse.Ajax, {
     if(this.get('loginRequired')) { route.transitionTo('login'); }
   },
 
+  externalLinksInNewTab: function() {
+    var userSetting = Discourse.User.currentProp('external_links_in_new_tab');
+    if (userSetting === undefined) { // no current user
+      return Discourse.SiteSettings.default_external_links_in_new_tab;
+    }
+    return userSetting;
+  },
+
   /**
     Add an initializer hook for after the Discourse Application starts up.
 

--- a/app/assets/javascripts/discourse/lib/click_track.js
+++ b/app/assets/javascripts/discourse/lib/click_track.js
@@ -102,7 +102,7 @@ Discourse.ClickTrack = {
     }
 
     // Otherwise, use a custom URL with a redirect
-    if (Discourse.User.currentProp('external_links_in_new_tab')) {
+    if (Discourse.externalLinksInNewTab) {
       var win = window.open(trackingUrl, '_blank');
       win.focus();
     } else {

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -34,7 +34,9 @@ basic:
   suggested_topics:
     client: true
     default: 5
-  default_external_links_in_new_tab: false
+  default_external_links_in_new_tab:
+    default: false
+    client: true
   track_external_right_clicks:
     client: true
     default: false


### PR DESCRIPTION
> Security analysis: This sends another SiteSetting to the client - default_external_links_in_new_tab. This is a boolean setting, so information disclosed is limited. Additionally, it is the default for a setting that users are allowed to change. This does not reveal much other than something that might be a personal preference of the site owner, and not anything about the site itself. Sending this site setting has a clear purpose and no real risk.

Is there a better place to put this, other than in `discourse.js`?
