### PR TITLE
Update install guide link in SECURITY.md

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -43,4 +43,4 @@ Discourse extends the built-in Rails CSRF protection in the following ways:
 
 ### Deployment concerns
 
-We strongly recommend that the various Discourse processes (web server, sidekiq) run under a non-elevated account. See [our install guide](https://github.com/discourse/discourse/blob/master/docs/INSTALL-ubuntu.md) for details.
+We strongly recommend that the various Discourse processes (web server, sidekiq) run under a non-elevated account. See [our install guide](https://github.com/discourse/discourse/blob/master/docs/INSTALL.md) for details.


### PR DESCRIPTION
Since [Ubuntu install guide](https://github.com/discourse/discourse/blob/master/docs/INSTALL-ubuntu.md) is deprecated, so I updated the link to [standard Install instructions](https://github.com/discourse/discourse/blob/master/docs/INSTALL.md). 
