### PR TITLE
Add Digital Ocean Guide Header

### DIFF
--- a/docs/INSTALL-digital-ocean.md
+++ b/docs/INSTALL-digital-ocean.md
@@ -1,3 +1,5 @@
+# Discourse 30 Minute Cloud Install
+
 **Set up Discourse on a cloud server in under 30 minutes** with zero knowledge of Ruby, Rails or Linux shell using our [Discourse Docker image][dd]. We prefer [Digital Ocean][do], although these steps may work on other cloud providers that also support Docker. Let's begin!
 
 # Create New Digital Ocean Droplet


### PR DESCRIPTION
Added a header for digital-ocean install guide -- **Discourse 30 Minute Cloud Install** (taken from [Discourse blog post](http://blog.discourse.org/2014/04/install-discourse-in-under-30-minutes/)).
