### PR TITLE
Speech bubble waiting for an ajax response prior to rendering

### DIFF
--- a/app/assets/javascripts/discourse/controllers/header.js.es6
+++ b/app/assets/javascripts/discourse/controllers/header.js.es6
@@ -10,6 +10,7 @@ export default Discourse.Controller.extend({
   topic: null,
   showExtraInfo: null,
   notifications: null,
+  loading_notifications: null,
 
   showStarButton: function() {
     return Discourse.User.current() && !this.get('topic.isPrivateMessage');
@@ -25,11 +26,17 @@ export default Discourse.Controller.extend({
     showNotifications: function(headerView) {
       var self = this;
 
-      Discourse.ajax("/notifications").then(function(result) {
-        self.set("notifications", result);
-        self.set("currentUser.unread_notifications", 0);
-        headerView.showDropdownBySelector("#user-notifications");
-      });
+      if (self.get('currentUser.unread_notifications') || self.get('currentUser.unread_private_messages') || !self.get('notifications')) {
+        self.set("loading_notifications", true);
+        Discourse.ajax("/notifications").then(function(result) {
+          self.setProperties({
+            notifications: result,
+            loading_notifications: false,
+            'currentUser.unread_notifications': 0
+          });
+        });
+      }
+      headerView.showDropdownBySelector("#user-notifications");
     },
 
     jumpToTopPost: function () {
@@ -41,5 +48,3 @@ export default Discourse.Controller.extend({
   }
 
 });
-
-

--- a/app/assets/javascripts/discourse/controllers/notifications_controller.js
+++ b/app/assets/javascripts/discourse/controllers/notifications_controller.js
@@ -1,3 +1,4 @@
 Discourse.NotificationsController = Ember.ArrayController.extend(Discourse.HasCurrentUser, {
+  needs: ['header'],
   itemController: "notification"
 });

--- a/app/assets/javascripts/discourse/templates/notifications.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/notifications.js.handlebars
@@ -1,14 +1,18 @@
 <section class="d-dropdown" id="notifications-dropdown">
-  {{#if content}}
-    <ul>
-      {{#each}}
-        <li {{bind-attr class="read"}}>{{unbound boundI18n scope linkBinding="link" usernameBinding="username"}}</li>
-      {{/each}}
-      <li class="read last">
-        <a {{bind-attr href="currentUser.path"}}>{{i18n notifications.more}} &hellip;</a>
-      </li>
-    </ul>
+  {{#unless controllers.header.loading_notifications}}
+    {{#if content}}
+      <ul>
+        {{#each}}
+          <li {{bind-attr class="read"}}>{{unbound boundI18n scope linkBinding="link" usernameBinding="username"}}</li>
+        {{/each}}
+        <li class="read last">
+          <a {{bind-attr href="currentUser.path"}}>{{i18n notifications.more}} &hellip;</a>
+        </li>
+      </ul>
+    {{else}}
+      <div class="none">{{i18n notifications.none}}</div>
+    {{/if}}
   {{else}}
-    <div class="none">{{i18n notifications.none}}</div>
-  {{/if}}
+    <div class='loading'><i class='fa fa-spinner fa-spin'></i></div>
+  {{/unless}}
 </section>

--- a/app/assets/stylesheets/desktop/header.scss
+++ b/app/assets/stylesheets/desktop/header.scss
@@ -204,6 +204,13 @@
     .none {
       padding: 5px;
     }
+    .loading {
+      padding: 10px;
+      display: block;
+      color: lighten($primary_text_color, 50%);
+      font-size: 24px;
+      text-align: center;
+    }
   }
 
   // Search

--- a/app/assets/stylesheets/mobile/header.scss
+++ b/app/assets/stylesheets/mobile/header.scss
@@ -194,6 +194,13 @@
     .none {
       padding: 5px;
     }
+    .loading {
+      padding: 10px;
+      display: block;
+      color: #777;
+      font-size: 24px;
+      text-align: center;
+    }
   }
 
   // Search

--- a/test/javascripts/controllers/header_controller_test.js
+++ b/test/javascripts/controllers/header_controller_test.js
@@ -23,7 +23,7 @@ test("showNotifications action", function() {
 
   equal(controller.get("notifications"), null, "notifications are null before data has finished loading");
   equal(Discourse.User.current().get("unread_notifications"), 1, "current user's unread notifications count is not zeroed before data has finished loading");
-  ok(viewSpy.showDropdownBySelector.notCalled, "dropdown with notifications is not shown before data has finished loading");
+  ok(viewSpy.showDropdownBySelector.calledWith("#user-notifications"), "dropdown with loading glyph is shown before data has finished loading");
 
 
   Ember.run(function() {

--- a/test/javascripts/controllers/notifications_controller_test.js
+++ b/test/javascripts/controllers/notifications_controller_test.js
@@ -17,7 +17,9 @@ module("Discourse.NotificationsController", {
       return [scope, options.username, options.link].join(" ").trim();
     });
 
-    controller = Discourse.NotificationsController.create();
+    controller = Discourse.NotificationsController.create({
+      container: Discourse.__container__
+    });
 
     view = Ember.View.create({
       container: Discourse.__container__,


### PR DESCRIPTION
I've tried to address speech bubble ajax response problem, this PR does following changes:
- On clicking speech bubble, the ajax request will be made if any of the following condition is true:
  - User has unread/new notifications.
  - User has unread/new private messages.
  - User clicks on speech bubble for the first time, and `notifications` are empty/null.
- If any of the above condition is not true, then no ajax request will be made, thus improving notification render significantly. 

**TO-DO**:
- Find a better way to detect that user clicked on speech bubble for the first time, instead of `!self.get("notifications")`. 
- Show drop-down immediately with spinning icon when ajax request is made.

PS, I am just getting started with Ember, please let me know if there's a better way to do this.
