### PR TITLE
remove another reference to now-extinct db dumps

### DIFF
--- a/docs/DEVELOPER-ADVANCED.md
+++ b/docs/DEVELOPER-ADVANCED.md
@@ -13,7 +13,6 @@ Note: If you are developing on a Mac, you will probably want to look at [these i
 5. Clone the project and bundle.
 6. Copy `config/database.yml.development-sample` to `config/database.yml`. Copy `config/redis.yml.sample` to `config/redis.yml`. Edit the files to point to your postgres and redis instances.
 7. Create the "vagrant" user and the development and test databases in postgres. See the postgres section in "Building your own Vagrant VM", below.
-8. Install the seed data to set up an admin account and meta topic: `psql DATABASE_NAME < pg_dumps/production-image.sql`
 
 
 ## Before you start Rails


### PR DESCRIPTION
The `bundle exec rake db:migrate db:test:prepare db:seed_fu` step just below takes care of this now.
