### PR TITLE
Add regular notification level into topic_view_serializer 

### DIFF
--- a/app/serializers/topic_view_serializer.rb
+++ b/app/serializers/topic_view_serializer.rb
@@ -92,6 +92,8 @@ class TopicViewSerializer < ApplicationSerializer
     if has_topic_user?
       result[:notification_level] = object.topic_user.notification_level
       result[:notifications_reason_id] = object.topic_user.notifications_reason_id
+    else
+      result[:notification_level] = TopicUser.notification_levels[:regular]
     end
 
     result[:can_move_posts] = true if scope.can_move_posts?(object.topic)


### PR DESCRIPTION
for the user who enter the new topic.

This PR should fix highlight topic notification level dropdown for who is new to the topic.(not in topic_users)

Details: https://meta.discourse.org/t/topic-notification-option-is-not-highlight/14671
