### PR TITLE
fix inconsistency with bookmark icon label under post

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -142,10 +142,10 @@ en:
       title: "Suggested Topics"
 
     bookmarks:
-      not_logged_in: "Sorry, you must be logged in to bookmark posts."
-      created: "You've bookmarked this post."
-      not_bookmarked: "You've read this post; click to bookmark it."
-      last_read: "This is the last post you've read; click to bookmark it."
+      not_logged_in: "sorry, you must be logged in to bookmark posts"
+      created: "you've bookmarked this post"
+      not_bookmarked: "you've read this post; click to bookmark it"
+      last_read: "this is the last post you've read; click to bookmark it"
 
     new_topics_inserted: "{{count}} new topics."
     show_new_topics: "Click to show."


### PR DESCRIPTION
the bookmark icon under post should follow style from other
icons - downcased, no ending dot
