### PR TITLE
Added `openssl_verify_mode` parameter for action_mailer.

### DIFF
--- a/config/discourse_defaults.conf
+++ b/config/discourse_defaults.conf
@@ -63,6 +63,10 @@ smtp_authentication = plain
 # enable TLS encryption for smtp connections
 smtp_enable_start_tls = true
 
+# mode for verifying smtp server certificates
+# to disable, set to 'none'
+smtp_openssl_verify_mode =
+
 # enable MiniProfiler for administrators
 enable_mini_profiler = true
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -36,7 +36,8 @@ Discourse::Application.configure do
       user_name:            GlobalSetting.smtp_user_name,
       password:             GlobalSetting.smtp_password,
       authentication:       GlobalSetting.smtp_authentication,
-      enable_starttls_auto: GlobalSetting.smtp_enable_start_tls
+      enable_starttls_auto: GlobalSetting.smtp_enable_start_tls,
+      openssl_verify_mode:  GlobalSetting.smtp_openssl_verify_mode
     }
 
     config.action_mailer.smtp_settings = settings.reject{|x,y| y.nil?}


### PR DESCRIPTION
This adds the parameter `openssl_verify_mode` to the action_mailer config, so you can override the verification mode from your environment settings, e.g. from docker.

With this patch, simply adding:

```
env:
  DISCOURSE_SMTP_OPENSSL_VERIFY_MODE: 'none'
```

to your docker config will disable certificate validation, for example if you are running a local relay server.

See also [this thread](https://meta.discourse.org/t/provide-more-settings-to-be-overridden-in-globalsetting/11560) for discussion.
