### PR TITLE
Log the actual promise object instead of a useless name

### DIFF
--- a/app/views/common/_discourse_javascript.html.erb
+++ b/app/views/common/_discourse_javascript.html.erb
@@ -20,7 +20,7 @@
           console.log(e.message);
           console.log(e.stack);
         } else {
-          console.log("Uncaught promise: " + e.toString());
+          console.log("Uncaught promise: ", e);
         }
       } else {
         console.log("A promise failed but was not caught.");


### PR DESCRIPTION
console.log has support for objects including introspection, use this instead of logging useless names.

Makes
![screen shot 2014-05-09 at 11 19 45](https://cloud.githubusercontent.com/assets/40496/2926342/1b596176-d75b-11e3-9ff9-3ca7812ca513.png)

to

![screen shot 2014-05-09 at 11 18 28](https://cloud.githubusercontent.com/assets/40496/2926346/21df541a-d75b-11e3-852a-ada31b7342c2.png)

In development.
