### PR TITLE
Fix 'resend activation mail throws 404' issue

### DIFF
--- a/app/assets/javascripts/discourse/controllers/login.js.es6
+++ b/app/assets/javascripts/discourse/controllers/login.js.es6
@@ -46,9 +46,19 @@ export default Discourse.Controller.extend(Discourse.ModalFunctionality, {
 
   actions: {
     login: function() {
-      this.set('loggingIn', true);
-
       var loginController = this;
+      loginController.set('loggingIn', true);
+
+      // if user is logging with email change loginName to username
+      // first check if loginName is email
+      if (Discourse.Utilities.emailValid(loginController.get('loginName'))) {
+        Discourse.ajax("users/get_username_from_email", {
+          data: { email: loginController.get('loginName')},
+          type: 'GET'
+        }).then(function (result) {
+          loginController.set('loginName', result.username);
+        });
+      }
       Discourse.ajax("/session", {
         data: { login: this.get('loginName'), password: this.get('loginPassword') },
         type: 'POST'

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -285,6 +285,15 @@ class UsersController < ApplicationController
     render nothing: true
   end
 
+  def get_username_from_email
+    user = User.find_by(email: params[:email])
+    if user
+      render json: { username: user.username_lower }
+    else
+      render json: { username: params[:email] }
+    end
+  end
+
   def enqueue_activation_email
     @email_token ||= @user.email_tokens.create(email: @user.email)
     Jobs.enqueue(:user_email, type: :signup, user_id: @user.id, email_token: @email_token.token)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -183,6 +183,7 @@ Discourse::Application.routes.draw do
   get "users/activate-account/:token" => "users#activate_account"
   get "users/authorize-email/:token" => "users#authorize_email"
   get "users/hp" => "users#get_honeypot_value"
+  get "users/get_username_from_email" => "users#get_username_from_email"
   get "my/:path", to: 'users#my_redirect'
 
   get "user_preferences" => "users#user_preferences_redirect"


### PR DESCRIPTION
I added a check if user is logging with email then it gets the relevant
username and uses it to send the activation email. Issue url: https://meta.discourse.org/t/resend-activation-mail-throws-404/14313
