### PR TITLE
Convert discovery controllers to ES6

### DIFF
--- a/app/assets/javascripts/discourse/controllers/discovery_categories.js.es6
+++ b/app/assets/javascripts/discourse/controllers/discovery_categories.js.es6
@@ -6,7 +6,7 @@
   @namespace Discourse
   @module Discourse
 **/
-Discourse.DiscoveryCategoriesController = Discourse.DiscoveryController.extend({
+export default Discourse.DiscoveryController.extend({
   needs: ['modal', 'discovery'],
 
   actions: {

--- a/app/assets/javascripts/discourse/controllers/discovery_sortable.js.es6
+++ b/app/assets/javascripts/discourse/controllers/discovery_sortable.js.es6
@@ -1,4 +1,4 @@
-Discourse.DiscoverySortableController = Discourse.Controller.extend({
+export default Discourse.Controller.extend({
   needs: ['discoveryTopics'],
   queryParams: ['order', 'ascending'],
   order: Em.computed.alias('controllers.discoveryTopics.order'),

--- a/app/assets/javascripts/discourse/controllers/discovery_top.js.es6
+++ b/app/assets/javascripts/discourse/controllers/discovery_top.js.es6
@@ -6,7 +6,7 @@
   @namespace Discourse
   @module Discourse
 **/
-Discourse.DiscoveryTopController = Discourse.DiscoveryController.extend({
+export default Discourse.DiscoveryController.extend({
   needs: ['discovery'],
 
   actions: {

--- a/app/assets/javascripts/discourse/controllers/discovery_topics.js.es6
+++ b/app/assets/javascripts/discourse/controllers/discovery_topics.js.es6
@@ -6,7 +6,7 @@
   @namespace Discourse
   @module Discourse
 **/
-Discourse.DiscoveryTopicsController = Discourse.DiscoveryController.extend({
+export default Discourse.DiscoveryController.extend({
   needs: ['discovery'],
   bulkSelectEnabled: false,
   selected: [],


### PR DESCRIPTION
Mostly just adding export default and changing name.

Was looking for a small thing to contribute and this seemed like a good start.  I tried to take the lead of 2e0fcc6aa.  Didn't see any unit tests around these controllers, but I only took a cursory look.

Have also signed the CLA.
