### PR TITLE
Fix topic list colors: copy from mobile, only define once

### DIFF
--- a/app/assets/stylesheets/desktop/topic-list.scss
+++ b/app/assets/stylesheets/desktop/topic-list.scss
@@ -67,8 +67,9 @@
   a.title:visited:not(.badge-notification) {color: scale-color($primary, $lightness: 35%);}
 
   > tbody > tr {
+    background-color: mix($primary, $secondary, 0%);
     &:nth-child(even) {
-      background-color: scale-color($primary, $lightness: 96%);
+      background-color: mix($primary, $secondary, 3%);
     }
     &.archived a {
       opacity: 0.6;
@@ -361,9 +362,6 @@
 
 .category-list-item {
   margin-bottom: 10px;
-  #topic-list tbody tr:nth-child(even) {
-    background-color: $secondary;
-  }
   th .badge-category {
     float: left;
     margin: 1px 4px 0 0;

--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -467,10 +467,10 @@ a.star {
   clear: left;
   padding: 20px 0 15px 0;
   #topic-list > tbody > tr:nth-child(even) {
-    background-color: scale-color($primary, $lightness: 97%);
+    background-color: mix($primary, $secondary, 3%);
   }
   #topic-list > tbody > tr:nth-child(odd) {
-    background-color: $secondary;
+    background-color: mix($primary, $secondary, 0%);
   }
   table {
     box-shadow: none;

--- a/app/assets/stylesheets/mobile/topic-list.scss
+++ b/app/assets/stylesheets/mobile/topic-list.scss
@@ -47,9 +47,9 @@
   border-top: 1px solid scale-color($primary, $lightness: 90%);
 
   > tbody > tr {
-    background-color: $secondary;
+    background-color: mix($primary, $secondary, 0%);
     &:nth-child(even) {
-      background-color: darken($secondary, 4%);
+      background-color: mix($primary, $secondary, 3%);
     }
     &.archived a {
       opacity: 0.6;
@@ -229,9 +229,6 @@
 
 .category-list-item {
   margin-bottom: 10px;
-  #topic-list tbody tr:nth-child(even) {
-    background-color: $secondary;
-  }
   .badge-category {
     float: left;
     margin: 1px 4px 0 0;


### PR DESCRIPTION
The first diff is copied from the mobile topic-list.css.

![image](https://cloud.githubusercontent.com/assets/627891/2979664/9a7ce488-dbd3-11e3-8cae-b9df83a8f5da.png)
![image](https://cloud.githubusercontent.com/assets/627891/2979671/baaa9278-dbd3-11e3-8471-ec4976e1f595.png)
![image](https://cloud.githubusercontent.com/assets/627891/2979665/a31c4412-dbd3-11e3-8bad-8a6928e29b95.png)
![image](https://cloud.githubusercontent.com/assets/627891/2979667/b0e0198e-dbd3-11e3-9db5-f1e85cf4a314.png)
