### PR TITLE
Fix suspended scope

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -88,7 +88,7 @@ class User < ActiveRecord::Base
   scope :blocked, -> { where(blocked: true) } # no index
   scope :not_blocked, -> { where(blocked: false) } # no index
   scope :suspended, -> { where('suspended_till IS NOT NULL AND suspended_till > ?', Time.zone.now) } # no index
-  scope :not_suspended, -> { where('suspended_till IS NULL') }
+  scope :not_suspended, -> { where('suspended_till IS NULL OR suspended_till <= ?', Time.zone.now) }
   # excluding fake users like the community user
   scope :real, -> { where('id > 0') }
 


### PR DESCRIPTION
:not_suspended should check if suspension is <= NOW, else one could end up in neither group.
That is, unless the scope is used to check if user was _never_ suspended.
