### PR TITLE
Include pry-rails in production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -132,6 +132,7 @@ gem 'omniauth-oauth2', require: false
 gem 'oj'
 # while resolving https://groups.google.com/forum/#!topic/ruby-pg/5_ylGmog1S4
 gem 'pg', '0.15.1'
+gem 'pry-rails', require: false
 gem 'rake'
 
 
@@ -176,7 +177,6 @@ group :test, :development do
   gem 'simplecov', require: false
   gem 'timecop'
   gem 'rspec-given'
-  gem 'pry-rails'
   gem 'pry-nav'
   gem 'spork-rails'
 end


### PR DESCRIPTION
If you `./launcher ssh app` followed by `rails c` on a production server, you get irb. In development, you get pry inside of Vagrant.
Because sometimes the rails console will be used in production, being stuck with `irb` is a travesty. Therefore, `pry-rails` is moved to the outer gemfile (which will pull in `pry`).
