### PR TITLE
User prefrence: align all control groups on top. And some padding for category.

### DIFF
--- a/app/assets/javascripts/discourse/templates/user/preferences.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/user/preferences.js.handlebars
@@ -13,7 +13,7 @@
       <div class="controls">
         <span class='static'>{{username}}</span>
         {{#if can_edit_username}}
-          {{#link-to "preferences.username" class="btn pad-left"}}<i class="fa fa-pencil"></i>{{/link-to}}
+          {{#link-to "preferences.username" class="btn btn-small pad-left no-text"}}<i class="fa fa-pencil"></i>{{/link-to}}
         {{/if}}
       </div>
       <div class='instructions'>
@@ -42,7 +42,7 @@
         <label class="control-label">{{i18n user.title.title}}</label>
         <div class="controls">
           <span class="static">{{title}}</span>
-          {{#link-to "preferences.badgeTitle" class="btn pad-left"}}<i class="fa fa-pencil"></i>{{/link-to}}
+          {{#link-to "preferences.badgeTitle" class="btn btn-small pad-left no-text"}}<i class="fa fa-pencil"></i>{{/link-to}}
         </div>
       </div>
     {{/if}}
@@ -52,7 +52,7 @@
       <div class="controls">
         <span class='static'>{{email}}</span>
         {{#if can_edit_email}}
-          {{#link-to "preferences.email" class="btn pad-left no-text"}}<i class="fa fa-pencil"></i>{{/link-to}}
+          {{#link-to "preferences.email" class="btn btn-small pad-left no-text"}}<i class="fa fa-pencil"></i>{{/link-to}}
         {{/if}}
       </div>
       <div class='instructions'>

--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -44,24 +44,22 @@ div.ac-wrap.disabled {
 div.ac-wrap {
   background-color: $secondary;
   border: 1px solid scale-color($primary, $lightness: 90%);
-  padding: 5px 10px;
+  padding: 5px 4px 1px 4px;
   div.item {
     float: left;
+    margin-bottom: 4px;
     margin-right: 10px;
-    margin-bottom: 5px;
     span {
-      padding-left: 5px;
-      height: 22px;
+      height: 24px;
       display: inline-block;
-      line-height: 22px;
-      vertical-align: bottom;
+      line-height: 20px;
     }
     a.remove {
       margin-left: 4px;
-      font-size: 10px;
+      font-size: 11px;
       line-height: 10px;
-      padding: 2px 1px 1px 3px;
-      border-radius: 10px;
+      padding: 1.5px 1.5px 1.5px 2.5px;
+      border-radius: 12px;
       width: 10px;
       display: inline-block;
       border: 1px solid scale-color($primary, $lightness: 90%);
@@ -75,10 +73,11 @@ div.ac-wrap {
   }
   input[type="text"] {
     float: left;
-    margin-top: 5px;
+    margin-bottom: 4px;
+    height: 24px;
+    display: block;
     border: 0;
     padding: 0;
-    margin: 4px 0 0;
     box-shadow: none;
   }
 }

--- a/app/assets/stylesheets/desktop/discourse.scss
+++ b/app/assets/stylesheets/desktop/discourse.scss
@@ -328,6 +328,7 @@ body {
     }
   }
   .control-group {
+    margin-bottom: 9px;
     &.warning {
       > label {
         color: $danger;
@@ -463,9 +464,6 @@ body {
     display: none;
   }
 
-  .control-group {
-    margin-bottom: 9px;
-  }
   .form-horizontal {
     .control-group {
       margin-bottom: 18px;
@@ -486,7 +484,6 @@ body {
     .control-label {
       float: left;
       width: 140px;
-      padding-top: 5px;
       text-align: right;
       font-weight: bold;
     }

--- a/app/assets/stylesheets/desktop/user.scss
+++ b/app/assets/stylesheets/desktop/user.scss
@@ -58,8 +58,6 @@
 
   .static {
     color: $primary;
-    margin-top: 5px;
-    margin-left: 5px;
     display: inline-block;
   }
   .instructions {
@@ -84,7 +82,6 @@
   }
 
   .other .controls {
-    margin-top: 10px;
     select {
       width: 280px;
     }


### PR DESCRIPTION
Before:
![screenshot 2014-05-18 16 41 35](https://cloud.githubusercontent.com/assets/297343/3007063/451453e0-de68-11e3-9f7f-e11d732e8c1c.png)
&
## ![screenshot 2014-05-18 16 41 40](https://cloud.githubusercontent.com/assets/297343/3007064/4553ec12-de68-11e3-9baf-02f57210f5b2.png)

After:
![screenshot 2014-05-18 16 30 07](https://cloud.githubusercontent.com/assets/297343/3007053/62df2ea0-de67-11e3-8b96-6172dc236fe6.png)
&
![screenshot 2014-05-18 16 29 58](https://cloud.githubusercontent.com/assets/297343/3007052/62dca356-de67-11e3-8f54-23b6b444bdbc.png)
