### PR TITLE
Change the image upload icon to fa-image

### DIFF
--- a/app/assets/stylesheets/common/base/pagedown.scss
+++ b/app/assets/stylesheets/common/base/pagedown.scss
@@ -89,7 +89,7 @@
 }
 
 #wmd-image-button:before {
-  content: "\f093";
+  content: "\f03e";
 }
 
 #wmd-olist-button:before {


### PR DESCRIPTION
This is an update to the font awesome icon being used for image uploads as it appears when you create a new topic or reply to a topic. The current photo upload icon seems confusing and not specific to images - the upload option seems to only be used for uploading images, so it might as well be as specific as possible and use an icon that people recognize as an image upload button. 

[Current Icon](http://fortawesome.github.io/Font-Awesome/icon/upload/)
[Proposed Icon](http://fortawesome.github.io/Font-Awesome/icon/picture-o/)
