### PR TITLE
apple-gcc42 is now in homebrew/dupes

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -4,7 +4,7 @@
 update
 
 # add this repo to Homebrew's sources
-tap homebrew/versions
+tap homebrew/dupes
 
 # install the gcc compiler required for ruby
 install apple-gcc42


### PR DESCRIPTION
I was getting this error:

```
brew install apple-gcc42
Error: No available formula for apple-gcc42 
Searching taps...
homebrew/dupes/apple-gcc42
```

Indeed, you need to `brew tap homebrew/dupes`  for `install apple-gcc42` to work, and **I'm assuming `homebrew/versions` is where apple-gcc42 was before.**

Apologies about github adding a newline at the end of the file, I'm sure homebrew won't choke on this
