### PR TITLE
Update rvm install command

### DIFF
--- a/script/osx_dev
+++ b/script/osx_dev
@@ -34,11 +34,11 @@ gcc-4.2 -v # Check that GCC installed successfully
 
 ## Install RVM and Ruby 2.0.0 with turbo patchset ##
 echo "Installing RVM..."
-curl -L https://get.rvm.io | bash -s stable --rails --autolibs=enabled
+\curl -sSL https://get.rvm.io | bash -s stable --rails --autolibs=homebrew
 source ~/.rvm/scripts/rvm
 
 rvm get stable
-rvm autolibs 3 # Tell RVM to install anything it's missing
+rvm autolibs homebrew # Tell RVM to install anything it's missing with homebrew
 rvm requirements # This will install baseline requirements that might be missing
 rvm install 2.0.0-turbo # Now, install Ruby 2.0.0 with performance patches
 rvm --create --ruby-version use 2.0.0-turbo # Use this Ruby as the default in this directory


### PR DESCRIPTION
1. Prefer homebrew (otherwise macports gets used if installed)
2. It seems that the command has been updated to `\curl -sSL` instead of `curl -L` for clearly specific reasons.
