### PR TITLE
Group profile page template: add extra class so that we can differentiate group mode

### DIFF
--- a/app/assets/javascripts/discourse/templates/group.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/group.js.handlebars
@@ -15,7 +15,7 @@
   </section>
 
     <section class='user-main'>
-      <section class='about'>
+      <section class='about group'>
         <div class='details'>
           <h1>{{name}}</h1>
         </div>


### PR DESCRIPTION
Group profile page template: add extra class so that we can differentiate group details from user details in CSS

Since the layout of the "user details" section on the Group profile page is very different from a regular User profile page, we need to be able to selectively style the Group profile. Achieve this by adding a CSS flagging class when we're in the 'group' mode.

Related to https://github.com/discourse/discourse/pull/2299
