### PR TITLE
add Chef recipe for ImageMagick

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -44,6 +44,7 @@ Vagrant.configure("2") do |config|
     chef.add_recipe "recipe[build-essential]"
     chef.add_recipe "recipe[vim]"
     chef.add_recipe "recipe[java]"
+    chef.add_recipe "recipe[imagemagick]"
     chef.add_recipe "discourse"
   end
 end

--- a/chef/cookbooks/imagemagick/CHANGELOG.md
+++ b/chef/cookbooks/imagemagick/CHANGELOG.md
@@ -1,0 +1,11 @@
+Imagemagick CHANGELOG
+=====================
+
+v0.2.3 (2014-02-25)
+-------------------
+[COOK-3748] - Add support for Amazon Linux & Mac OS X
+
+
+v0.2.2
+----------
+- Fixes COOK-662

--- a/chef/cookbooks/imagemagick/README.md
+++ b/chef/cookbooks/imagemagick/README.md
@@ -1,0 +1,50 @@
+Description
+===========
+
+Installs ImageMagick and optionally Rmagick (RubyGem).
+
+Requirements
+============
+
+## Platform:
+
+Tested on:
+
+* Ubuntu (10.04)
+* RHEL (6.1, 5.7)
+
+Usage
+=====
+
+To install just ImageMagick,
+
+  include_recipe "imagemagick"
+
+In your own recipe/cookbook. To install the development libraries,
+
+  include_recipe "imagemagick::devel"
+
+To install the RubyGem rmagick,
+
+  include_recipe "imagemagick::rmagick"
+
+Which will install imagemagick, as well as the development libraries for imagemagick (so rmagick can be built).
+
+License and Author
+==================
+
+Author:: Joshua Timberman (<joshua@opscode.com>)
+
+Copyright:: 2009, Opscode, Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/chef/cookbooks/imagemagick/metadata.json
+++ b/chef/cookbooks/imagemagick/metadata.json
@@ -1,0 +1,37 @@
+{
+  "name": "imagemagick",
+  "version": "0.2.3",
+  "description": "Installs/Configures imagemagick",
+  "long_description": "Description\n===========\n\nInstalls ImageMagick and optionally Rmagick (RubyGem).\n\nRequirements\n============\n\n## Platform:\n\nTested on:\n\n* Ubuntu (10.04)\n* RHEL (6.1, 5.7)\n\nUsage\n=====\n\nTo install just ImageMagick,\n\n  include_recipe \"imagemagick\"\n\nIn your own recipe/cookbook. To install the development libraries,\n\n  include_recipe \"imagemagick::devel\"\n\nTo install the RubyGem rmagick,\n\n  include_recipe \"imagemagick::rmagick\"\n\nWhich will install imagemagick, as well as the development libraries for imagemagick (so rmagick can be built).\n\nLicense and Author\n==================\n\nAuthor:: Joshua Timberman (<joshua@opscode.com>)\n\nCopyright:: 2009, Opscode, Inc\n\nLicensed under the Apache License, Version 2.0 (the \"License\");\nyou may not use this file except in compliance with the License.\nYou may obtain a copy of the License at\n\n    http://www.apache.org/licenses/LICENSE-2.0\n\nUnless required by applicable law or agreed to in writing, software\ndistributed under the License is distributed on an \"AS IS\" BASIS,\nWITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\nSee the License for the specific language governing permissions and\nlimitations under the License.\n",
+  "maintainer": "Opscode, Inc.",
+  "maintainer_email": "cookbooks@opscode.com",
+  "license": "Apache 2.0",
+  "platforms": {
+    "fedora": ">= 0.0.0",
+    "centos": ">= 0.0.0",
+    "rhel": ">= 0.0.0",
+    "ubuntu": ">= 0.0.0",
+    "debian": ">= 0.0.0"
+  },
+  "dependencies": {
+  },
+  "recommendations": {
+  },
+  "suggestions": {
+  },
+  "conflicting": {
+  },
+  "providing": {
+  },
+  "replacing": {
+  },
+  "attributes": {
+  },
+  "groupings": {
+  },
+  "recipes": {
+    "imagemagick": "Installs imagemagick package",
+    "imagemagick::devel": "Installs imagemagick development libraries",
+    "imagemagick::rmagick": "Installs rmagick gem"
+  }
+}

--- a/chef/cookbooks/imagemagick/metadata.rb
+++ b/chef/cookbooks/imagemagick/metadata.rb
@@ -1,0 +1,15 @@
+name             "imagemagick"
+maintainer       "Opscode, Inc."
+maintainer_email "cookbooks@opscode.com"
+license          "Apache 2.0"
+description      "Installs/Configures imagemagick"
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version          "0.2.3"
+
+recipe "imagemagick", "Installs imagemagick package"
+recipe "imagemagick::devel", "Installs imagemagick development libraries"
+recipe "imagemagick::rmagick", "Installs rmagick gem"
+
+%w{fedora centos rhel ubuntu debian}.each do |os|
+  supports os
+end

--- a/chef/cookbooks/imagemagick/recipes/default.rb
+++ b/chef/cookbooks/imagemagick/recipes/default.rb
@@ -1,0 +1,25 @@
+#
+# Cookbook Name:: imagemagick
+# Recipe:: default
+#
+# Copyright 2009, Opscode, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+case node['platform_family']
+when 'rhel'
+  package 'ImageMagick'
+when 'debian', 'mac_os_x'
+  package 'imagemagick'
+end

--- a/chef/cookbooks/imagemagick/recipes/devel.rb
+++ b/chef/cookbooks/imagemagick/recipes/devel.rb
@@ -1,0 +1,32 @@
+#
+# Cookbook Name:: imagemagick
+# Recipe:: default
+#
+# Copyright 2009, Opscode, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include_recipe "imagemagick"
+
+dev_pkg = value_for_platform(
+  ["redhat", "centos", "fedora", "amazon"] => { "default" => "ImageMagick-devel" },
+  "debian" => { "default" => "libmagickwand-dev" },
+  "ubuntu" => {
+    "8.04" => "libmagick9-dev",
+    "8.10" => "libmagick9-dev",
+    "default" => "libmagickwand-dev"
+  }
+)
+
+package dev_pkg

--- a/chef/cookbooks/imagemagick/recipes/rmagick.rb
+++ b/chef/cookbooks/imagemagick/recipes/rmagick.rb
@@ -1,0 +1,22 @@
+#
+# Cookbook Name:: imagemagick
+# Recipe:: rmagick
+#
+# Copyright 2009, Opscode, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+include_recipe "imagemagick"
+include_recipe "imagemagick::devel"
+
+gem_package "rmagick"


### PR DESCRIPTION
Please see https://meta.discourse.org/t/migrations-fails-due-to-missing-image/16032/2

By the way I didn't add `cookbook 'imagemagick'` to `chef/Cheffile`. 
