### PR TITLE
Support for insecure POP3 (without SSL)

### DIFF
--- a/app/jobs/scheduled/poll_mailbox.rb
+++ b/app/jobs/scheduled/poll_mailbox.rb
@@ -39,7 +39,9 @@ module Jobs
     end
 
     def poll_pop3s
-      Net::POP3.enable_ssl(OpenSSL::SSL::VERIFY_NONE)
+      if !SiteSetting.pop3s_polling_insecure
+        Net::POP3.enable_ssl(OpenSSL::SSL::VERIFY_NONE)
+      end
       Net::POP3.start(SiteSetting.pop3s_polling_host,
                       SiteSetting.pop3s_polling_port,
                       SiteSetting.pop3s_polling_username,

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -844,6 +844,7 @@ en:
     reply_by_email_address: "Template for reply by email incoming email address, for example: %{reply_key}@reply.example.com or replies+%{reply_key}@example.com"
 
     pop3s_polling_enabled: "Poll via POP3S for email replies"
+    pop3s_polling_insecure: "Poll using plain text POP3 without SSL"
     pop3s_polling_port: "The port to poll a POP3S account on"
     pop3s_polling_host: "The host to poll for email via POP3S"
     pop3s_polling_username: "The username for the POP3S account to poll for email"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -274,6 +274,7 @@ email:
   reply_by_email_enabled: false
   reply_by_email_address: ''
   pop3s_polling_enabled: false
+  pop3s_polling_insecure: false
   pop3s_polling_host: ''
   pop3s_polling_port: 995
   pop3s_polling_username: ''


### PR DESCRIPTION
Ideally it would be a menu selection to select POP3, POP3S, and potentially other future protocols like IMAP if desired, but I didn't want to deal with data migration at this point.  And then I was going to have a checkbox for "Secure" (on by default, obviously), but that was very hard to word as to how it was different given everything else referred to pop3s and I couldn't change that either.  So I settled on a preference:

pop3s_polling_insecure: "Poll using plain text POP3 without SSL"

Off by default.

This makes it very clear that as to what turning on that checkbox will be, and by calling it "insecure" makes sure people will think twice before turning it on.

I have not attempted to do any of the translations of the preference, I'm ot sure how you handle that.
