### PR TITLE
Add notification reason for muted category

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -785,10 +785,11 @@ en:
           "2_4": 'You will receive notifications because you posted a reply to this topic.'
           "2_2": 'You will receive notifications because you are tracking this topic.'
           "2": 'You will receive notifications because you <a href="/users/{{username}}/preferences">read this topic</a>.'
-          "1": 'You will be notified only if someone mentions your @name or replies to your post.'
           "1_2": 'You will be notified only if someone mentions your @name or replies to your post.'
-          "0": 'You are ignoring all notifications on this topic.'
+          "1": 'You will be notified only if someone mentions your @name or replies to your post.'
+          "0_7": 'You are ignoring all notifications in this category.'
           "0_2": 'You are ignoring all notifications on this topic.'
+          "0": 'You are ignoring all notifications on this topic.'
         watching_pm:
           title: "Watching"
           description: "You will be notified of every new post in this private message. The count of unread and new posts will also appear next to the topic's listing."


### PR DESCRIPTION
I'm not sure why this wasn't caught before. But someone reported it on TDWTF.
