### PR TITLE
restore bg-color for New Topic / New Post rows of Topic-List Categories

### DIFF
--- a/app/assets/stylesheets/desktop/topic-list.scss
+++ b/app/assets/stylesheets/desktop/topic-list.scss
@@ -233,10 +233,10 @@
   th.posts {
     position: relative;
   }
-  tbody tr:nth-child(odd) {
+  > tbody > tr:nth-child(odd) {
     background-color: darken($secondary, 3%);
   }
-  tbody tr:nth-child(even) {
+  > tbody > tr:nth-child(even) {
     background-color: $secondary;
   }
   th .toggle-admin {


### PR DESCRIPTION
More narrowly target the "major-rows" within table#topic-list.categories, 
without inadvertently applying the styles to nested tables and "child-rows"
