### PR TITLE
Bugfix: Mailing list mode disables PM emails

### DIFF
--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -100,7 +100,8 @@ class UserNotifications < ActionMailer::Base
     opts[:allow_reply_by_email] = true
 
     # We use the 'user_posted' event when you are emailed a post in a PM.
-    opts[:notification_type] = 'posted'
+    # but it must get through to email in mailing list mode
+    opts[:notification_type] = 'postedprivate'
 
     notification_email(user, opts)
   end
@@ -155,6 +156,12 @@ class UserNotifications < ActionMailer::Base
 
     return if user.mailing_list_mode &&
        ["replied", "mentioned", "quoted", "posted"].include?(notification_type)
+
+    # We use the 'user_posted' event when you are emailed a post in a PM.
+    # but it must get through to email in mailing list mode
+    if notification_type == 'postedprivate'
+      notification_type = 'posted'
+    end
 
     title = @notification.data_hash[:topic_title]
     allow_reply_by_email = opts[:allow_reply_by_email] unless user.suspended?


### PR DESCRIPTION
Emailing a PM uses the user_posted event/format, but Mailing List Mode disables emails with this format.

We work around this by temporarily using "postedprivate", and then reverting back to "posted" efter the Mailing List Mode check.
