### PR TITLE
Deboxify .nav-stacked on user-page

### DIFF
--- a/app/assets/stylesheets/common/components/navs.css.scss
+++ b/app/assets/stylesheets/common/components/navs.css.scss
@@ -47,13 +47,12 @@
 .nav-stacked {
   position: relative;
   @extend %nav;
-  border: 1px solid scale-color($primary, $lightness: 60%);
   padding: 0;
   overflow: hidden;
   background-color: scale-color-diff();
   @include box-shadow(0 1px 0 scale-color-diff());
   > li {
-    border-bottom: 1px solid scale-color($primary, $lightness: 60%);
+    border-bottom: 2px solid scale-color($primary, $lightness: 80%);
     &:last-of-type {
       border-bottom: 0;
     }


### PR DESCRIPTION
As per https://meta.discourse.org/t/user-activity-tabs/16308/13, deboxify the lefthand nav on user page and use less cutting color.

Before:
![img](http://jaetkow.se/i/b003cf817f.png)

After:
![img](http://jaetkow.se/i/e6336796c3.png)
