### PR TITLE
Allow reading notifications without marking them as read

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -8,7 +8,7 @@ class NotificationsController < ApplicationController
     if notifications.present?
       # ordering can be off due to PMs
       max_id = notifications.map(&:id).max
-      current_user.saw_notification_id(max_id)
+      current_user.saw_notification_id(max_id) unless params.has_key?(:silent)
     end
     current_user.reload
     current_user.publish_notifications_state

--- a/spec/controllers/notifications_controller_spec.rb
+++ b/spec/controllers/notifications_controller_spec.rb
@@ -5,12 +5,24 @@ describe NotificationsController do
   context 'when logged in' do
     let!(:user) { log_in }
 
-    before do
+    it 'should succeed' do
       xhr :get, :index
+      response.should be_success
     end
 
-    subject { response }
-    it { should be_success }
+    it 'should mark notifications as viewed' do
+      notification = Fabricate(:notification, user: user)
+      user.reload.unread_notifications.should == 1
+      xhr :get, :index
+      user.reload.unread_notifications.should == 0
+    end
+
+    it 'should not mark notifications as viewed if silent param is present' do
+      notification = Fabricate(:notification, user: user)
+      user.reload.unread_notifications.should == 1
+      xhr :get, :index, silent: true
+      user.reload.unread_notifications.should == 1
+    end
   end
 
   context 'when not logged in' do


### PR DESCRIPTION
@fractalemagic needs to be able to read forum notifications without marking them as read to implement push notifications for his Hummingbird mobile app. I added a `silent` parameter which can be used for this purpose.
