### PR TITLE
Change logo link to /

### DIFF
--- a/app/assets/javascripts/discourse/templates/components/home-logo.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/components/home-logo.js.handlebars
@@ -1,4 +1,4 @@
-<a href='#'>
+<a href="/">
   {{#if showSmallLogo}}
     {{#if smallLogoUrl}}
       <img class="logo-small" src="{{unbound smallLogoUrl}}" width="33" height="33">


### PR DESCRIPTION
https://meta.discourse.org/t/miniaturized-logo-doesnt-really-link-to-home-page/16389
