### PR TITLE
Deboxify topic-map

### DIFF
--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -329,7 +329,7 @@ a.star {
 
 .topic-map {
   margin: 20px 0 0 0;
-  border: 1px solid scale-color-diff();
+  background: scale-color(scale-color-diff(), $lightness: 40%);
 
   .buttons .btn {
     &:hover {border: 1px solid $primary !important;}
@@ -418,7 +418,7 @@ a.star {
     color: $primary;
   }
   .information {
-    border-top: 1px solid scale-color-diff();
+    border-top: 2px solid scale-color-diff();
   }
 
 .participants { // PMs //


### PR DESCRIPTION
I suggest that more complex SCSS features should be implemented for scale-color-diff(), as it is pretty hard to tweak stuff while keeping it color-independent.

Anyways heres the deboxification for topic-map, looks somewhat like this:
http://jaetkow.se/i/b31cc8cea9.png
