### PR TITLE
Move profile_background from User to UserProfile

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -357,7 +357,7 @@ class UsersController < ApplicationController
       when "avatar"
         upload_avatar_for(user, upload)
       when "profile_background"
-        upload_profile_background_for(user, upload)
+        upload_profile_background_for(user.user_profile, upload)
       end
     else
       render status: 422, text: upload.errors.full_messages
@@ -384,8 +384,7 @@ class UsersController < ApplicationController
     user = fetch_user_from_params
     guardian.ensure_can_edit!(user)
 
-    user.profile_background = ""
-    user.save!
+    user.user_profile.clear_profile_background
 
     render nothing: true
   end
@@ -429,8 +428,8 @@ class UsersController < ApplicationController
       render json: { upload_id: upload.id, url: upload.url, width: upload.width, height: upload.height }
     end
 
-    def upload_profile_background_for(user, upload)
-      user.upload_profile_background(upload)
+    def upload_profile_background_for(user_profile, upload)
+      user_profile.upload_profile_background(upload)
       # TODO: add a resize job here
 
       render json: { url: upload.url, width: upload.width, height: upload.height }

--- a/app/jobs/scheduled/clean_up_uploads.rb
+++ b/app/jobs/scheduled/clean_up_uploads.rb
@@ -6,7 +6,7 @@ module Jobs
     def execute(args)
       return unless SiteSetting.clean_up_uploads?
 
-      uploads_used_as_profile_backgrounds = User.uniq.where("profile_background IS NOT NULL AND profile_background != ''").pluck(:profile_background)
+      uploads_used_as_profile_backgrounds = UserProfile.uniq.where("profile_background IS NOT NULL AND profile_background != ''").pluck(:profile_background)
 
       grace_period = [SiteSetting.clean_orphan_uploads_grace_period_hours, 1].max
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -555,14 +555,6 @@ class User < ActiveRecord::Base
     created_at > 1.day.ago
   end
 
-  # TODO this is a MESS
-  # at most user table should have profile_background_upload_id
-  # best case is to move this to another table
-  def upload_profile_background(upload)
-    self.profile_background = upload.url
-    self.save!
-  end
-
   def generate_api_key(created_by)
     if api_key.present?
       api_key.regenerate!(created_by)
@@ -801,7 +793,6 @@ end
 #  mailing_list_mode             :boolean          default(FALSE), not null
 #  primary_group_id              :integer
 #  locale                        :string(10)
-#  profile_background            :string(255)
 #  registration_ip_address       :inet
 #  last_redirected_to_top_at     :datetime
 #  disable_jump_reply            :boolean          default(FALSE), not null

--- a/app/models/user_profile.rb
+++ b/app/models/user_profile.rb
@@ -1,11 +1,21 @@
 class UserProfile < ActiveRecord::Base
+  def upload_profile_background(upload)
+    self.profile_background = upload.url
+    self.save!
+  end
+
+  def clear_profile_background
+    self.profile_background = ""
+    self.save!
+  end
 end
 
 # == Schema Information
 #
 # Table name: user_profiles
 #
-#  user_id  :integer          not null, primary key
-#  location :string(255)
-#  website  :string(255)
+#  user_id                  :integer          not null, primary key
+#  profile_background       :string(255)
+#  location                 :string(255)
+#  website                  :string(255)
 #

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -124,6 +124,13 @@ class UserSerializer < BasicUserSerializer
     website.present?
   end
 
+  def profile_background
+    object.user_profile.profile_background
+  end
+  def include_profile_background?
+    profile_background.present?
+  end
+
   def stats
     UserAction.stats(object.id, scope)
   end

--- a/db/migrate/20140612010718_move_profile_background_to_user_profiles.rb
+++ b/db/migrate/20140612010718_move_profile_background_to_user_profiles.rb
@@ -1,0 +1,17 @@
+class MoveProfileBackgroundToUserProfiles < ActiveRecord::Migration
+  def up
+    add_column :user_profiles, :profile_background, :string, limit: 255
+
+    execute "UPDATE user_profiles SET profile_background = (SELECT profile_background FROM users WHERE user_profiles.user_id = users.id)"
+
+    remove_column :users, :profile_background
+  end
+
+  def down
+    add_column :users, :profile_background, :string, limit: 255
+
+    execute "UPDATE users SET profile_background = (SELECT profile_background FROM user_profiles WHERE user_profiles.user_id = users.id)"
+
+    remove_column :user_profiles, :profile_background
+  end
+end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1155,7 +1155,7 @@ describe UsersController do
           xhr :post, :upload_user_image, username: user.username, file: user_image, user_image_type: "profile_background"
           user.reload
 
-          user.profile_background.should == "/uploads/default/1/1234567890123456.png"
+          user.user_profile.profile_background.should == "/uploads/default/1/1234567890123456.png"
 
           # returns the url, width and height of the uploaded image
           json = JSON.parse(response.body)
@@ -1204,7 +1204,7 @@ describe UsersController do
             Upload.expects(:create_for).returns(upload)
             xhr :post, :upload_user_image, username: user.username, file: user_image_url, user_image_type: "profile_background"
             user.reload
-            user.profile_background.should == "/uploads/default/1/1234567890123456.png"
+            user.user_profile.profile_background.should == "/uploads/default/1/1234567890123456.png"
 
             # returns the url, width and height of the uploaded image
             json = JSON.parse(response.body)
@@ -1273,7 +1273,7 @@ describe UsersController do
 
       it 'it successful' do
         xhr :put, :clear_profile_background, username: user.username
-        user.reload.profile_background.should == ""
+        user.reload.user_profile.profile_background.should == ""
         response.should be_success
       end
 

--- a/spec/serializers/user_serializer_spec.rb
+++ b/spec/serializers/user_serializer_spec.rb
@@ -32,6 +32,16 @@ describe UserSerializer do
       end
     end
 
+    context "with filled out profile background" do
+      before do
+        user.user_profile.profile_background = 'http://background.com'
+      end
+
+      it "has a profile background" do
+        expect(json[:profile_background]).to eq 'http://background.com'
+      end
+    end
+
     context "with filled out website" do
       before do
         user.user_profile.website = 'http://example.com'


### PR DESCRIPTION
The last part of changes requested in https://meta.discourse.org/t/a-small-ruby-db-refactoring-task/16042.
`profile_background` is moved from User model to UserProfile.
