### PR TITLE
Fix broken markup on invites tab

### DIFF
--- a/app/assets/javascripts/discourse/templates/user/invited.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/user/invited.js.handlebars
@@ -69,7 +69,7 @@
     {{/if}}
 
   {{else}}
-    {{i18n user.invited.none}}
+    {{{i18n user.invited.none}}}
   {{/if}}
 
 </section>


### PR DESCRIPTION
Not sure if this is the right way to fix this, but current copyedit is breaking markup on invites tab.

Before:

![screen shot 2014-06-12 at 17 01 39](https://cloud.githubusercontent.com/assets/5732281/3257290/51007822-f228-11e3-8dab-febffb45a208.png)

After:

![screen shot 2014-06-12 at 17 23 58](https://cloud.githubusercontent.com/assets/5732281/3257291/52d7397e-f228-11e3-839e-2b09e1925958.png)
