### PR TITLE
Bugfix: Mailing list mode disables PM emails (take 2)

### DIFF
--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -153,7 +153,7 @@ class UserNotifications < ActionMailer::Base
     username = @notification.data_hash[:original_username]
     notification_type = opts[:notification_type] || Notification.types[@notification.notification_type].to_s
 
-    return if user.mailing_list_mode &&
+    return if user.mailing_list_mode && !@post.topic.private_message? &&
        ["replied", "mentioned", "quoted", "posted"].include?(notification_type)
 
     title = @notification.data_hash[:topic_title]


### PR DESCRIPTION
Mailing List Mode disables normal emails, but mailing list mode does not email private_messages.

To avoid this, mailing list mode should only disable emails if they are not private_messages.

There are no tests for this commit as UserNotifications does not appear to be instantiated in the spec suite.
