### PR TITLE
BUGFIX: Correct markup syntax in locale files

### DIFF
--- a/config/locales/client.ja.yml
+++ b/config/locales/client.ja.yml
@@ -39,7 +39,7 @@ ja:
           other: "> %{count} 年"
         almost_x_years:
           other: "%{count} 年"
-        date_month: "MMMDo"
+        date_month: "M月D日"
         date_year: "MMM 'YY"
       medium:
         x_minutes:
@@ -92,23 +92,26 @@ ja:
     daily: "毎日"
     weekly: "毎週"
     every_two_weeks: "隔週"
+    max: "最大"
     character_count:
       other: "{{count}} 文字"
     in_n_seconds:
-      other: "{{count}} 秒で"
+      other: "あと{{count}}秒"
     in_n_minutes:
-      other: "{{count}} 分で"
+      other: "あと{{count}}分"
     in_n_hours:
-      other: "{{count}} 時間で"
+      other: "あと{{count}}時間"
     in_n_days:
-      other: "{{count}} 日で"
+      other: "あと{{count}}日"
     suggested_topics:
       title: "関連トピック"
     bookmarks:
-      created: "あなたはこのポストをお気に入りに追加しました"
-      not_bookmarked: "あなたはこのポストを読みまし。ブックマークに追加する"
+      not_logged_in: "ポストをブックマークするには、ログインする必要がありま"
+      created: "このポストをブックマークしました"
+      not_bookmarked: "このポストをブックマークする"
+      last_read: "このポストをブックマークする"
       remove: "ブックマークを削除"
-    new_topics_inserted: "{{count}} 新しいポスト"
+    new_topics_inserted: "新しいトピックが {{count}}個あります"
     show_new_topics: "クリックして表示。"
     preview: "プレビュー"
     cancel: "キャンセル"
@@ -142,10 +145,18 @@ ja:
       sent_by_user: "<a href='{{userUrl}}'>{{user}}</a> が送信"
       sent_by_you: "<a href='{{userUrl}}'>あなた</a> が送信"
     groups:
+      visible: "このグループは全てのユーザに表示されています。"
       title:
         other: "グルップ"
       members: "メンバー"
       posts: "ポスト"
+      alias_levels:
+        title: "このグループを仮名として使えるユーザ"
+        nobody: "だれも"
+        only_admins: "アドミンのみ"
+        mods_and_admins: "アドミンとモデレータのみ"
+        members_mods_and_admins: "アドミン、モデレータとグループメンバーのみ"
+        everyone: "だれでも"
     user_action_groups:
       '1': "「いいね！」 した"
       '2': "「いいね！」 された"
@@ -161,8 +172,8 @@ ja:
       '13': "インボックス"
     categories:
       all: "全てのカテゴリ"
-      all_subcategories: "全部"
-      no_subcategory: "無し"
+      all_subcategories: "全てのサブカテゴリ"
+      no_subcategory: "サブカテゴリなし"
       category: "カテゴリ"
       posts: "ポスト"
       topics: "トピック"
@@ -172,25 +183,26 @@ ja:
       subcategories: "サブカテゴリ:"
       topic_stats: "新しいトピック数"
       topic_stat_sentence:
-        other: "過去 %{unit} 間 %{count} 新しいトピック。"
+        other: "過去 %{unit} 間 %{count}つ 新しいトピック。"
       post_stats: "新しいトピック数："
       post_stat_sentence:
-        other: "過去一%{unit}間%{count}新しいポスト。"
+        other: "過去一%{unit}間%{count}つ新しいポスト。"
     user:
       said: "{{username}} のコメント:"
       profile: "プロフィール"
       show_profile: "プロフィールを見る"
       mute: "ミュート"
-      edit: "プロフィール設定を編集"
+      edit: "プロフィールを編集"
       download_archive: "ポストのアーカイブをダウンロード"
       private_message: "プライベートメッセージ"
       private_messages: "メッセージ"
       activity_stream: "アクティビティ"
-      preferences: "プロフィール設定"
+      preferences: "設定"
       bio: "自己紹介"
       invited_by: "招待者"
       trust_level: "トラストレベル"
       notifications: "通知"
+      disable_jump_reply: "回答後新しいポストに移動しない。"
       dynamic_favicon: "favicon に受信したメッセージ通知を表示する"
       external_links_in_new_tab: "外部リンクを全て新しいタブで開く"
       enable_quoting: "ハイライトしたテキストを引用して回答する"
@@ -200,10 +212,17 @@ ja:
       deleted: "(削除済)"
       suspended_notice: "このユーザは {{date}} までサスペンド状態です。"
       suspended_reason: "理由: "
-      tracked_categories: "トラックしました"
-      muted_categories: "ミュートされました"
+      mailing_list_mode: "フォーラムに投稿がされる度にメールで通知を受け取る(ミュートしているトピックやカテゴリ以外)"
+      watched_categories: "ウォッチ中"
+      watched_categories_instructions: "これらのカテゴリに新しく作成される全てのトピックが自動的にウォッチされます。全ての新しい投稿やトピックについて通知が行われ、未読や新着の数がトピック一覧の隣に表示されるようになります。"
+      tracked_categories: "トラック中"
+      tracked_categories_instructions: "これらのカテゴリに新しく作成される全てのトピックが自動的にトラックされます。未読や新着の数がトピック一覧の隣に表示されるようになります。"
+      muted_categories: "ミュート中"
+      muted_categories_instructions: "これらのカテゴリについて何も通知されなくなり、未読タブにも表示されなくなります。"
       delete_account: "アカウントを削除する"
+      delete_account_confirm: "本当にアカウントを削除しますか？削除されたアカウントを復元できません。"
       deleted_yourself: "あなたのアカウントは削除されました。"
+      delete_yourself_not_allowed: "アカウントを削除できませんでした。サイトアドミンを連絡してください。"
       unread_message_count: "メッセージ"
       messages:
         all: "すべて"
@@ -231,9 +250,12 @@ ja:
       change_avatar:
         title: "アバターの変更"
         gravatar: "<a href='//gravatar.com/emails' target='_blank'>Gravatar</a>, based on"
+        refresh_gravatar_title: "グラバターを更新する"
+        letter_based: "システムアバター"
         uploaded_avatar: "カスタム画像"
         uploaded_avatar_empty: "カスタム画像を追加"
         upload_title: "画像をアップロード"
+        upload_picture: "画像アップロード"
         image_is_not_a_square: "警告: 画像が正方形ではなかったためクロップしました。"
       change_profile_background:
         title: "プロフィール背景"
@@ -285,10 +307,15 @@ ja:
       email_private_messages: "プライベートメッセージを受けた際にメール通知を受け取る"
       email_always: "フォーラムにアクティブに参加している状態でも常にメール通知やダイジェストを受け取る"
       other_settings: "その他"
-      categories_settings: "カテゴリ"
+      categories_settings: "カテゴリ設定"
       new_topic_duration:
         label: "以下の条件でトピックを新規と見なす"
         not_viewed: "未読のもの"
+        last_here: "前回ログアウト後に投稿されたもの"
+        after_n_days:
+          other: "過去{{count}}日に投稿されたもの"
+        after_n_weeks:
+          other: "過去{{count}}週に投稿されたもの"
       auto_track_topics: "以下のタイミングで、自分が投稿したトピックを自動的にトラックする"
       auto_track_options:
         never: "トラックしない"
@@ -314,7 +341,7 @@ ja:
         time_read: "リード時間"
         days_visited: "訪問日数"
         account_age_days: "アカウント有効日数"
-        create: "招待を送信する"
+        create: "友人をこのフォーラムに招待"
       password:
         title: "パスワード"
         too_short: "パスワードが短すぎます。"
@@ -323,6 +350,8 @@ ja:
         instructions: "%{count} 文字以上の長さにしてください。"
       ip_address:
         title: "最終 IP アドレス"
+      registration_ip_address:
+        title: "IPアドレスの登録"
       avatar:
         title: "アバター"
       title:
@@ -336,13 +365,18 @@ ja:
         the_topic: "トピック"
     loading: "読み込み中..."
     close: "閉じる"
+    assets_changed_confirm: "Discourseはアップデートされました。ページ更新して最新バージョンを導入しますか？"
+    read_only_mode:
+      enabled: "読み取り専用モードにされています。サイトインターアクションを無効されています。"
+      login_disabled: "読み取り専用モードにされています。ログインできません。"
+    too_few_topics_notice: "Create at least 5 public topics and 30 public posts to get discussion started. New users will not be able to earn trust levels unless there's content for them to read."
     learn_more: "より詳しく..."
     year: '年'
-    year_desc: '過去365日間に作成トピック'
+    year_desc: '過去365日間に投稿されたトピック'
     month: '月'
-    month_desc: '過去30日間に作成トピック'
+    month_desc: '過去30日間に投稿されたトピック'
     week: '週'
-    week_desc: '過去7日間に作成トピック'
+    week_desc: '過去7日間に投稿されたトピック'
     day: '日'
     first_post: 最初のポスト
     mute: ミュート
@@ -364,6 +398,7 @@ ja:
     created: '作成'
     trust_level: 'トラストレベル'
     create_account:
+      title: "アカウントの作成"
       failed: "エラーが発生しました。既にこのメールアドレスは使用中かもしれません。「パスワードを忘れました」リンクを試してみてください"
     forgot_password:
       title: "パスワードを忘れました"
@@ -372,7 +407,7 @@ ja:
       reset: "パスワードをリセット"
     login:
       title: "サインイン"
-      username: "ユーザ"
+      username: "ログイン名"
       password: "パスワード"
       email_placeholder: "メールアドレスかユーザ名"
       error: "不明なエラー"
@@ -389,6 +424,9 @@ ja:
       google:
         title: "Googleで"
         message: "Google による認証 (ポップアップがブロックされていないことを確認してください)"
+      google_oauth2:
+        title: "Googleで"
+        message: "グーグルで認証（必ずポップアップブロッカーを無効にしてください）"
       twitter:
         title: "Twitterで"
         message: "Twitter による認証 (ポップアップがブロックされていないことを確認してください)"
@@ -412,12 +450,12 @@ ja:
         need_more_for_title: "タイトルにあと{{n}}文字必要"
         need_more_for_reply: "ポストにあと{{n}}文字必要"
       error:
-        title_missing: "タイトルが必要です"
+        title_missing: "タイトルを入力してください。"
         title_too_short: "タイトルは{{min}}文字以上必要です。"
         title_too_long: "タイトルは最長で{{max}}未満です。"
         post_missing: "ポスト内容が空です。"
         post_length: "ポストは{{min}}文字以上必要です。"
-        category_missing: "カテゴリを選択下さい"
+        category_missing: "カテゴリを選択してください。"
       save_edit: "編集内容を保存"
       reply_original: "元のトピックに回答"
       reply_here: "ここに回答"
@@ -425,6 +463,7 @@ ja:
       cancel: "キャンセル"
       create_topic: "トピックを作成"
       create_pm: "プライベートメッセージの作成"
+      title: "またはCtrl+Enter"
       users_placeholder: "ユーザの追加"
       title_placeholder: "トピックのタイトルをここに入力してください。"
       edit_reason_placeholder: "編集理由は何ですか?"
@@ -465,6 +504,7 @@ ja:
       admin_options_title: "このトピックの詳細設定"
       auto_close_label: "このトピックを自動的に終了する時間:"
       auto_close_units: "(何時間後か、自動終了する具体的な時間、またはタイムスタンプ)"
+      auto_close_examples: '例: 24, 17:00, 2013-11-22 14:00'
       auto_close_error: "正しい値を入力してください。"
     notifications:
       title: "@ユーザ名 メンションやあなたのポストやトピックへの回答、プライベートメッセージなどの通知"
@@ -481,6 +521,8 @@ ja:
       invitee_accepted: "<i title='accepted your invitation' class='fa fa-sign-in'></i> {{username}} が招待を受理しました"
       moved_post: "<i title='moved post' class='fa fa-sign-out'></i> {{username}} が {{link}}を移動しました"
       total_flagged: "フラグがたったポストの総数"
+      linked: "<i title='linked post' class='fa fa-arrow-left'></i> {{username}} {{link}}"
+      granted_badge: "<i title='badge granted' class='fa fa-certificate'></i> 付与されました{{link}}"
     upload_selector:
       title: "画像のアップロード"
       title_with_attachments: "画像/ファイルをアップロード"
@@ -491,7 +533,9 @@ ja:
       local_tip: "クリックしてアップロードする画像を選択してください"
       local_tip_with_attachments: "クリックしてアップロードする画像/ファイルを選択してください (使用可能な拡張子: {{authorized_extensions}})"
       hint: "(アップロードする画像をエディタにドラッグ&ドロップすることもできます)"
+      hint_for_supported_browsers: "(アップロードする画像をエディタにドラッグ&ドロップまたは貼り付けることもできます)"
       uploading: "アップロード中"
+      image_link: "イメージのリンク先"
     search:
       title: "トピック、ポスト、ユーザ、カテゴリを探す"
       placeholder: "検索ワードを入力してください"
@@ -502,6 +546,7 @@ ja:
         category: "検索結果は {{category}} を優先します"
     site_map: "別のトピックリストやカテゴリに移動"
     go_back: '戻る'
+    not_logged_in_user: 'ユーザアクチビティと設定ページ'
     current_user: 'ユーザページに移動'
     starred:
       title: '気に入り'
@@ -510,10 +555,18 @@ ja:
         unstar: 'このトピックを気に入りリストから削除'
     topics:
       bulk:
+        reset_read: "未読に設定"
+        dismiss_read: "既読に設定"
+        dismiss_new: "既読に設定"
+        toggle: "選択したトピックを切り替え"
+        actions: "操作"
+        change_category: "カテゴリ変更"
         close_topics: "トピックを閉じる"
+        notification_level: "通知レベル変更"
         selected:
           other: "あなたは <b>{{count}}</b> トピックを選択しました。"
       none:
+        starred: "まだどのトピックも気に入りにしてません。トピックを気に入りリストに追加するには、タイトルの横にある☆をクリック（タップ）してください。"
         unread: "未読トピックはありません。"
         new: "新着トピックはありません。"
         read: "またトピックを一つも読んでいません。"
@@ -529,7 +582,9 @@ ja:
         read: "未読トピックは以上です。"
         new: "新規トピックは以上です。"
         unread: "未読のトピックは以上です。"
+        starred: "気に入りトピックはありません。"
         category: "{{category}} トピックは以上です。"
+        top: "トップトピックはありません。"
     topic:
       filter_to: "トピック内の{{post_count}}個のポストを表示"
       create: 'トピックを作成する'
@@ -538,15 +593,16 @@ ja:
       list: 'トピック'
       new: '新規トピック'
       new_topics:
-        other: '{{count}} 新しいトピック'
+        other: '{{count}}個の新規トピック'
       unread_topics:
-        other: '{{count}} 未読トピック'
+        other: '{{count}}個の未読トピック'
       title: 'トピック'
       loading_more: "さらにトピックを読み込み中..."
       loading: 'トピックを読み込み中...'
       invalid_access:
         title: "トピックはプライベートです"
         description: "申し訳ありませんが、このトピックへのアクセスは許可されていません!"
+        login_required: "ポストを閲覧するには、サインインする必要があります"
       server_error:
         title: "トピックの読み込みに失敗しました"
         description: "申し訳ありませんが、トピックの読み込みに失敗しました。もう一度試してください。もし問題が継続する場合はお知らせください。"
@@ -554,11 +610,11 @@ ja:
         title: "トピックが見つかりませんでした"
         description: "申し訳有りませんがトピックが見つかりませんでした。モデレータによって削除された可能性があります。"
       unread_posts:
-        other: "このトピックには {{count}} 件未読ポストがあります。"
+        other: "このトピックに未読のポストが{{count}}つあります。"
       new_posts:
-        other: "このトピックには {{count}} 件新しいポストがあります。"
+        other: "前回閲覧時より、このトピックに新しいポストが{{count}}個投稿されています"
       likes:
-        other: "このトピックは{{count}}「いいね！」された"
+        other: "このトピックには{{count}}個「いいね！」がついています"
       back_to_list: "トピックリストに戻る"
       options: "トピックオプション"
       show_links: "このトピック内のリンクを表示"
@@ -587,23 +643,29 @@ ja:
         position: "ポスト%{current}/%{total}"
       notifications:
         reasons:
+          '3_6': 'このカテゴリを監視中のため通知されます'
+          '3_5': 'このトピックを監視中のため通知されます'
           '3_2': 'このトピックを監視中のため通知されます。'
           '3_1': 'このトピックを作成したため通知されます。'
           '3': 'このトピックを監視中のため通知されます。'
+          '2_8': 'このカテゴリをトラック中のため通知されます。'
           '2_4': 'このトピックに回答したため通知されます。'
           '2_2': 'このトピックをトラック中のため通知されます。'
           '2': '<a href="/users/{{username}}/preferences">このトピックを閲覧した</a>ため通知されます。'
           '1_2': '誰かから @ユーザ名 でメンションを受けた際と、あなたのポストに回答がついた際に通知されます。'
           '1': '誰かから @ユーザ名 でメンションを受けた際と、あなたのポストに回答がついた際に通知されます。'
+          '0_7': 'このカテゴリに関して一切通知を受けません。'
           '0_2': 'このトピックに関して一切通知を受けません。'
           '0': 'このトピックに関して一切通知を受けません。'
         watching_pm:
           title: "監視中"
+          description: "このプライベートメッセージに新しいポストを投稿された場合には通知します。"
         watching:
           title: "監視中"
           description: "トラック中と同様です。加えて、新規ポストが投稿されるたびに通知されます。"
         tracking_pm:
-          description: "トラック中"
+          title: "トラック中"
+          description: "誰かから @ユーザ名 でメンションを受けた際と、あなたのポストに回答がついた際に通知されます。"
         tracking:
           title: "トラック中"
           description: "誰かから @ユーザ名 でメンションを受けた際と、あなたのポストに回答がついた際に通知されます。これに加えて、未読および新規ポストの数を確認します。"
@@ -612,6 +674,7 @@ ja:
           description: "誰かから @ユーザ名 でメンションを受けた際と、あなたのポストに回答がついた際に通知されます。"
         muted_pm:
           title: "ミュートされました"
+          description: "このプライベートメッセージについて何の通知も受けません。"
         muted:
           title: "ミュート"
           description: "このトピックについて何の通知も受けません。また未読タブにも表示されません。"
@@ -623,6 +686,7 @@ ja:
         auto_close: "自動終了"
         unpin: "トピックのピン留め解除"
         pin: "トピックのピン留め"
+        pin_globally: "トピックを全サイト的にピン留めする"
         unarchive: "トピックのアーカイブ解除"
         archive: "トピックのアーカイブ"
         invisible: "非表示にする"
@@ -641,6 +705,7 @@ ja:
         help: 'このトピックへのリンクをシェアする'
       flag_topic:
         title: 'フラグ'
+        help: '密かに注目したいトピックにフラグを立てることで、それについての通知をプライベートに受け取ることが出来ます'
         success_message: 'このトピックをフラグしました。'
       inviting: "招待中..."
       invite_private:
@@ -652,7 +717,7 @@ ja:
         error: "申し訳ありませんが、ユーザ招待中にエラーが発生しました。"
         group_name: "グループ名"
       invite_reply:
-        title: '招待する'
+        title: '友人を招待して回答してもらう'
         action: 'メールで招待'
         help: 'このトピックにワンクリックで回答ができるように友人を招待メールを送る'
         to_topic: "このトピックに（ログインすることなく）ワンクリックで回答ができるようにあなたの友人にメールを送ります。"
@@ -660,7 +725,7 @@ ja:
         email_placeholder: 'メールアドレス'
         success: "ありがとうございます! <b>{{email}}</b> 宛に招待メールを送信しました。友人により招待が受理されたらお知らせします。招待した友人の一覧は、ユーザページの招待タブにて確認できます。"
         error: "申し訳ありませんが招待に失敗しました。既にユーザ登録済かもしれません。"
-      login_reply: 'サイインして返信'
+      login_reply: 'サイインして回答'
       filters:
         n_posts:
           other: "{{count}} ポスト"
@@ -670,18 +735,32 @@ ja:
         action: "新規トピックに移動"
         topic_name: "新規トピック名:"
         error: "新規トピックへのポスト移動中にエラーが発生しました。"
+        instructions:
+          other: "新たにトピックを作成し、選択した<b>{{count}}</b>個のポストをこのトピックに移動しようとしています。"
       merge_topic:
         title: "既存トピックに移動"
         action: "既存トピックに移動"
         error: "指定トピックへのポスト移動中にエラーが発生しました。"
+        instructions:
+          other: "これら<b>{{count}}</b>個のポストをどのトピックに移動するか選択してください。"
+      change_owner:
+        title: "ポストの作者を変更する"
+        action: "所有権を変更"
+        error: "所有権の変更ができませんでした。"
+        label: "ポストの新しい所有者"
+        placeholder: "新しい所有者のユーザ名"
+        instructions:
+          other: "この {{count}} つポストの新しい所有者を選択してください。（元所有者：<b>{{old_user}}</b>）"
       multi_select:
         select: '選択'
         selected: '選択中 ({{count}})'
         select_replies: '全ての回答と共に選択'
         delete: 選択中のものを削除
         cancel: deselect all
+        select_all: 全てを選択する
+        deselect_all: 全ての選択を外す
         description:
-          other: <b>{{count}}</b> ポストを選択しました。
+          other: 現在<b>{{count}}</b>個のポストを選択中。
     post:
       reply: "{{replyAvatar}} {{username}} による {{link}} に回答"
       reply_topic: "{{link}} に回答"
@@ -689,17 +768,22 @@ ja:
       edit: "{{replyAvatar}} {{username}} による {{link}} を編集"
       edit_reason: "理由: "
       post_number: "ポスト{{number}}"
-      in_reply_to: "に返信"
+      in_reply_to: "こちらへの回答"
       last_edited_on: "ポストの最終編集日"
       reply_as_new_topic: "新規トピックとして回答"
       continue_discussion: "{{postLink}} からの議論を継続:"
       follow_quote: "引用ポストに移動"
+      show_full: "全て表示"
+      deleted_by_author:
+        other: "(ポストは執筆者により取り下げられました。フラグがつかない場合%{count}時間後に自動的に削除されます)"
       deleted_by: "削除者"
       expand_collapse: "展開/折りたたみ"
       gap:
-        other: "{{count}} ポストを隠されています"
+        other: "{{count}}個のポストを除外"
+      more_links: "{{count}} つリンク..."
+      unread: "未読ポスト"
       has_replies:
-        other: "返信"
+        other: "回答"
       errors:
         create: "申し訳ありませんが、ポスト作成中にエラーが発生しました。もう一度やり直してください。"
         edit: "申し訳ありませんが、ポスト編集中にエラーが発生しました。もう一度やり直してください。"
@@ -727,13 +811,16 @@ ja:
         more: "もっと読む"
         delete_replies:
           confirm:
-            other: "このポストに付いて{{count}}つの返信も一緒に削除しますか？"
+            other: "このポストに対する{{count}}個の回答を削除しますか?"
           yes_value: "はい、回答も一緒に削除する"
           no_value: "いいえ、ポストのみ削除する"
+        admin: "ポスト管理"
+        wiki: "Wikiポストする"
+        unwiki: "Wikiポストに削除"
       actions:
         flag: 'フラグ'
         clear_flags:
-          other: "フラグをクリアする"
+          other: "フラグをクリア"
         it_too:
           off_topic: "フラグをたてる"
           spam: "フラグをたてる"
@@ -767,33 +854,49 @@ ja:
           notify_moderators: "あなたがモデレータ確認を要するとフラグをたてました"
           notify_user: "あなたがこのユーザにプライベートメッセージを送信しました"
           bookmark: "あなたがこのポストをブックマークしました"
-          like: "あなたが「いいね！」した"
+          like: "あなたが「いいね！」しました"
           vote: "あなたがこのポストに投票しました"
         by_you_and_others:
+          off_topic:
+            other: "あなたと他{{count}}人がオフトピックであるとフラグをたてました"
+          spam:
+            other: "あなたと他{{count}}人がスパムであるとフラグをたてました"
+          inappropriate:
+            other: "あなたと他{{count}}人が不適切であるとフラグをたてました"
+          notify_moderators:
+            other: "あなたと他{{count}}人がモデレータ確認を要するとフラグをたてました"
+          notify_user:
+            other: "あなたと他{{count}}人がこのユーザにプライベートメッセージを送信しました"
+          bookmark:
+            other: "あなたと他{{count}}人がこのポストをブックマークしました"
           like:
-            other: "あなたと{{count}}人が「いいね！」した。"
+            other: "あなたと他{{count}}人が「いいね！」しました"
+          vote:
+            other: "あなたと他{{count}}人がこのポストに投票しました"
         by_others:
           off_topic:
-            other: "{{count}} 人がこのポストをオフトピックにフラグしました。"
+            other: "{{count}}人のユーザがオフトピックであるとフラグをたてました"
           spam:
-            other: "{{count}} 人がこのポストをスパムにフラグしました。"
+            other: "{{count}}人のユーザがスパムであるとフラグをたてました"
           inappropriate:
-            other: "{{count}} 人がこのポストを不適切にフラグしました。"
+            other: "{{count}}人のユーザが不適切であるとフラグをたてました"
+          notify_moderators:
+            other: "{{count}}人のユーザがモデレータ確認を要するとフラグをたてました"
           notify_user:
-            other: "{{count}} 人がこのユーザにプライベートメッセージを送りました。"
+            other: "{{count}}人のユーザがこのユーザにプライベートメッセージを送信しました"
           bookmark:
-            other: "{{count}} 人がこのポストをブックマークしました"
+            other: "{{count}}人のユーザがこのポストをブックマークしました"
           like:
-            other: "{{count}} 人が「いいね！」した"
+            other: "{{count}}人のユーザが「いいね！」しました"
           vote:
-            other: "{{count}} 人がこのポストを投票しました"
+            other: "{{count}}人のユーザがこのポストに投票しました"
       edits:
         one: 1回編集
         other: "{{count}}回編集"
         zero: 編集なし
       delete:
         confirm:
-          other: "全部のポストを削除しますか？"
+          other: "本当にこれらのポストを削除しますか?"
       revisions:
         controls:
           first: "最初のリビジョン"
@@ -818,7 +921,7 @@ ja:
       none: '(カテゴリなし)'
       choose: 'カテゴリを選択&hellip;'
       edit: '編集'
-      edit_long: "編集する"
+      edit_long: "カテゴリを編集"
       view: 'カテゴリ内のトピックを見る'
       general: '一般'
       settings: '設定'
@@ -839,18 +942,33 @@ ja:
       delete_confirm: "本当にこのカテゴリを削除してもよいですか?"
       delete_error: "カテゴリ削除に失敗しました。"
       list: "カテゴリをリストする"
-      no_description: "このカテゴリの説明文書を追加してください。"
+      no_description: "このカテゴリの説明はありません。トピック定義を編集してください。"
       change_in_category_topic: "カテゴリ内容を編集"
       already_used: 'この色は他のカテゴリで利用しています'
       security: "セキュリティ"
       auto_close_label: "トピックを自動的に閉じるまでの時間:"
       auto_close_units: "時間"
+      email_in: "カスタムメールアドレス"
+      email_in_allow_strangers: "登録されていないユーザからメールを受け入れます"
       edit_permissions: "パーミッションを編集"
       add_permission: "パーミッションを追加"
       this_year: "今年"
       position: "ポジション"
       default_position: "デフォルトポジション"
       parent: "親カテゴリ"
+      notifications:
+        watching:
+          title: "カテゴリ監視中"
+          description: "このカテゴリ中の最新トピックを自動的に監視します。新規ポスト及びトピックが投稿されるたびに通知されます。"
+        tracking:
+          title: "監視中"
+          description: "このカテゴリ中の最新トピックを自動的に監視します。"
+        regular:
+          title: "レギュラー"
+          description: "誰かから @ユーザ名 でメンションを受けた際と、あなたのポストに回答がついた際に通知されます。"
+        muted:
+          title: "ミュート中"
+          description: "このカテゴリに投稿されたトピックについて何の通知も受けません。また未読タブにも表示されません"
     flagging:
       title: 'このポストにフラグをつける理由は何ですか?'
       action: 'フラグをつける'
@@ -867,7 +985,9 @@ ja:
         more: "あと{{n}}文字..."
         left: "残り{{n}}文字"
     flagging_topic:
-      action: "トピックをフラグする"
+      title: "このトピックに密かにフラグを立てる理由は何ですか？"
+      action: "トピックにフラグを立てる"
+      notify_action: "プライベートメッセージ"
     topic_map:
       title: "トピックのサマリー"
       links_shown: "全{{totalLinks}}リンクを表示..."
@@ -876,7 +996,14 @@ ja:
     topic_statuses:
       locked:
         help: "このトピックは終了しています。新たに回答を投稿することはできません\""
+      unpinned:
+        title: "ピン留め解除しました"
+        help: "このトピックはピン留めされていません；既定の順番に表示されます。"
+      pinned_globally:
+        title: "全サイト的にピン留めされました"
+        help: "このトピックは全サイト的にピン留めされました；全てのリストのトップに表示されます。"
       pinned:
+        title: "ピン留め"
         help: "このトピックはピン留めされています。常にカテゴリのトップに表示されます"
       archived:
         help: "このトピックはアーカイブされています。凍結状態のため一切の変更ができません"
@@ -922,6 +1049,10 @@ ja:
           other: "未読 ({{count}})"
         help: "未読ポストのあるトピック"
       new:
+        lower_title_with_count:
+          one: "１件"
+          other: "{{count}}件"
+        lower_title: "新着"
         title:
           zero: "新規"
           one: "新規 (1)"
@@ -938,16 +1069,19 @@ ja:
         help: "{{categoryName}} カテゴリの最新トピック"
       top:
         title: "トップ"
+        help: "過去年間、月間、週間及び日間のベストトピック"
         yearly:
           title: "年間トップ"
         monthly:
           title: "月間トップ"
         weekly:
           title: "週間トップ"
+        daily:
+          title: "日間トップ"
         this_year: "今年"
         this_month: "今月"
         this_week: "今週"
-        today: "今日"
+        today: "本日"
         other_periods: "トップとピックをもっと見る"
     browser_update: '<a href="http://www.discourse.org/faq/#browser">ご使用中のブラウザが古すぎるため Discourse フォーラムが正しく動作しません</a>。<a href="http://browsehappy.com">ブラウザをアップグレードしてください</a>。'
     permission_types:
@@ -1011,13 +1145,15 @@ ja:
         disagree: "反対"
         disagree_title: "フラグに反対。このポストのフラグをクリア"
         delete_spammer_title: "ユーザを削除し、全てのポストとトピックを削除。"
-        clear_topic_flags: "完了"
+        clear_topic_flags: "トピックのフラグをクリアしました"
+        clear_topic_flags_title: "このトピックについての問題が解決されました。「完了」をクリックしてフラグを外します。"
         flagged_by: "フラグをたてた人"
         system: "システム"
         error: "何かがうまくいきませんでした"
         view_message: "回答"
         no_results: "フラグはありません。"
         topic_flagged: "この <strong>トピック</strong> はフラグされました。"
+        visit_topic: "トピックを閲覧して問題を調査してくさだい"
         summary:
           action_type_3:
             other: "オフトピック x{{count}}"
@@ -1030,11 +1166,16 @@ ja:
           action_type_8:
             other: "スパム x{{count}}"
       groups:
+        primary: "プライマリーグループ"
+        no_primary: "（プライマリーグループなし）"
         title: "グループ"
         edit: "グループの編集"
+        refresh: "リフレッシュ"
+        new: "新規"
         selector_placeholder: "ユーザの追加"
         name_placeholder: "グループ名を入力 (ユーザ名同様にスペースなし)"
         about: "グループメンバーとグループ名を編集"
+        group_members: "グループメンバー"
         delete: "削除"
         delete_confirm: "このグループを削除しますか?"
         delete_failed: "グループの削除に失敗しました。自動作成グループを削除することはできません。"
@@ -1053,14 +1194,40 @@ ja:
         all_users: "全てのユーザ"
         note_html: "このキーは<strong>秘密</strong>情報です。キーを知るユーザは、任意のユーザとして任意のポストを作成することができます。"
       backups:
+        title: "バックアップ"
         menu:
+          backups: "バックアップ"
           logs: "ログ"
+        none: "バックアップはありません"
+        read_only:
+          enable:
+            title: "読み取り専用モードに有効する"
+            text: "読み取り専用モードにする"
+            confirm: "本当に読み取り専用モードを有効しますか？"
+          disable:
+            title: "読み取り専用モードを無効にする"
+            text: "読み取り専用モードをやめる"
+        logs:
+          none: "ログがありません"
         columns:
           filename: "ファイル名"
           size: "サイズ"
+        upload:
+          text: "アップロード"
+          uploading: "アップロード中"
+          success: "ファイル'{{filename}}' がアップロードされました。"
+          error: "ファイル '{{filename}}'アップロードエラー: {{message}}"
         operations:
+          is_running: "バックアップ作業を実行中..."
+          failed: "{{operation}}失敗しました。ログをチェックください。"
           cancel:
             text: "キャンセル"
+            title: "バックアップ作業をキャンセルする"
+            confirm: "本当に実行中バックアップ作業をキャンセルしますか？"
+          backup:
+            text: "バックアップ"
+            title: "バックアップを作成します"
+            confirm: "本当に新しいバックアップを作成しますか？"
           download:
             text: "ダウンロード"
             title: "バックアップをダウンロード"
@@ -1068,6 +1235,15 @@ ja:
             text: "削除"
             title: "バックアップを削除"
             confirm: "このバックアップを削除しますか？"
+          restore:
+            is_disabled: "バックアップ復元を無効されています。"
+            text: "復元"
+            title: "バックアップを復元"
+            confirm: "本当にバックアップを復元しますか？"
+          rollback:
+            text: "ロールバック"
+            title: "データベースを元の作業状態にロールバックする"
+            confirm: "本当にデータベースを元の作業状態にロールバックしますか？"
       customize:
         title: "カスタマイズ"
         long_title: "サイトのカスタマイズ"
@@ -1084,6 +1260,10 @@ ja:
         new_style: "新規スタイル"
         delete: "削除"
         delete_confirm: "このカスタマイズ設定を削除しますか?"
+        about: "サイトカスタマイズ設定により、サイトのヘッダとスタイルシートを変更できます。設定を選択するか、編集を開始して新たな設定を追加してください。"
+        color: "色"
+        opacity: "透明度"
+        copy: "コピー"
         css_html:
           title: "CSS, HTML"
           long_title: "CSS と HTML のカスタマイズ"
@@ -1091,11 +1271,32 @@ ja:
           title: "色"
           long_title: "色スキーマ"
           new_name: "新しい色スキーマ"
+          copy_name_prefix: "のコピー"
+          delete_confirm: "このカラースキームを削除しますか？"
           undo: "取り消す"
+          revert: "取り戻す"
+          revert_title: "既定の配色に戻る"
+          primary:
+            name: 'プライマリー'
+            description: 'テキスト、アイコンと枠の色'
+          secondary:
+            name: 'セカンダリー'
+            description: 'メイン背景とボタンのテキスト色'
+          quaternary:
+            description: "ナビゲーションリンク"
+          header_background:
+            name: "ヘッダー背景"
+            description: "ヘッダー背景色"
       email:
         title: "メール"
         settings: "設定"
+        all: "全て"
+        sending_test: "テストメールを送信中..."
+        test_error: "テストメールを送れませんでした。メール設定、またはホストをメールコネクションをブロックされていないようを確認してください。"
+        sent: "送信済み"
+        skipped: "スキップ済み"
         sent_at: "送信時間"
+        time: "日付"
         user: "ユーザ"
         email_type: "メールタイプ"
         to_address: "送信先アドレス"
@@ -1111,6 +1312,15 @@ ja:
         text: "text"
         last_seen_user: "ユーザが最後にサイトを訪れた日:"
         reply_key: "回答キー"
+        skipped_reason: "スキップの理由"
+        logs:
+          none: "ログなし"
+          filters:
+            title: "フィルター"
+            user_placeholder: "ユーザ名"
+            address_placeholder: "em@il.com"
+            type_placeholder: "ダイジェスト、サインアップ..."
+            skipped_reason_placeholder: "理由"
       logs:
         title: "ログ"
         action: "アクション"
@@ -1149,10 +1359,14 @@ ja:
             delete_site_customization: "サイトのカスタマイズ設定を削除"
             suspend_user: "ユーザをサスペンドにする"
             unsuspend_user: "ユーザのサスペンドを解除する"
+            grant_badge: "バッジを付与する"
+            revoke_badge: "バッジを取り消す"
         screened_emails:
           title: "ブロック対象アドレス"
           description: "新規アカウント作成時、次のメールアドレスからの登録をブロックする。"
           email: "メールアドレス"
+          actions:
+            allow: "許可する"
         screened_urls:
           title: "ブロック対象URL"
           description: "スパマーからのポストにおいて引用されていた URL のリスト。"
@@ -1191,9 +1405,9 @@ ja:
           blocked: 'ブロック中'
         approved: "承認?"
         approved_selected:
-          other: "承認したユーザ ({{count}})"
+          other: "承認ユーザ ({{count}})"
         reject_selected:
-          other: "ユーザーを拒否する ({{count}})"
+          other: "拒否ユーザ ({{count}})"
         titles:
           active: 'アクティブユーザ'
           new: '新規ユーザ'
@@ -1208,9 +1422,9 @@ ja:
           blocked: 'ブロック中のユーザ'
           suspended: 'サスペンド中のユーザ'
         reject_successful:
-          other: "%{count} ユーザーを拒否しました。"
+          other: "%{count}人のユーザの拒否に成功しました。"
         reject_failures:
-          other: "%{count} ユーザーを拒否失敗。"
+          other: "%{count}人のユーザの拒否に失敗しました。"
       user:
         suspend_failed: "ユーザのサスペンドに失敗しました {{error}}"
         unsuspend_failed: "ユーザのサスペンド解除に失敗しました {{error}}"
@@ -1233,6 +1447,8 @@ ja:
         refresh_browsers: "ブラウザを強制リフレッシュ"
         show_public_profile: "一般プロファイルを表示"
         impersonate: 'このユーザになりすます'
+        log_out: "ログアウト"
+        logged_out: "すべてのデバイスでログアウトしました"
         revoke_admin: '管理者権限を剥奪'
         grant_admin: '管理者権限を付与'
         revoke_moderation: 'モデレータ権限を剥奪'
@@ -1255,6 +1471,13 @@ ja:
         approve_bulk_success: "成功! 選択したユーザ全員が承認され、メールが送信されました。"
         time_read: "リード時間"
         delete: "ユーザを削除"
+        delete_forbidden_because_staff: "アドミンおよびもモデレータアカウントは削除できません。"
+        delete_forbidden:
+          other: "ポスト投稿済のユーザは削除できません。ユーザ削除の前に全てのポストを削除してください。（投稿後%{count}日以上が経過したポストは削除できません ）"
+        cant_delete_all_posts:
+          other: "全てのポストを削除できませんでした。%{count}日以上が経過したポストがあります。（設定：delete_user_max_post_age）"
+        cant_delete_all_too_many_posts:
+          other: "全てのポストを削除できませんでした。ユーザは%{count} つ以上のポストを投稿しています。(delete_all_posts_max)"
         delete_confirm: "本当にこのユーザを削除しますか? この操作はやり直しできません!"
         delete_and_block: "<b>はい</b>。さらにこのメールアドレスからのサインアップを以後<b>ブロック</b>"
         delete_dont_block: "<b>はい</b>。ただしこのメールアドレスからのサインアップは<b>許可</b>"
@@ -1275,10 +1498,20 @@ ja:
         trust_level_change_failed: "ユーザのトラストレベル変更に失敗しました。"
         suspend_modal_title: "サスペンド中ユーザ"
         trust_level_2_users: "トラストレベル2のユーザ"
-        trust_level_3_requirements: "トラストレベル3の要件"
+        trust_level_3_requirements: "トラストレベル3の条件"
         tl3_requirements:
-          title: "トラストレベル3の要件"
+          title: "トラストレベル3の条件"
+          table_title: "過去100日に："
+          value_heading: "値"
+          requirement_heading: "条件"
+          visits: "訪問"
           days: "日"
+          topics_with_replies: "回答されたトピック"
+          topics_replied_to: "回答したトピック"
+          quality_content: "良いコンテンツ"
+          reading: "閲覧中"
+          site_promotion: "サイトプロモーション"
+          flagged_posts: "フラグ付きのポスト"
       site_content:
         none: "編集するコンテンツのタイプを選択してください。"
         title: 'コンテンツ'
@@ -1286,7 +1519,7 @@ ja:
       site_settings:
         show_overriden: '上書き部分のみ表示'
         title: '設定'
-        reset: 'リセット'
+        reset: 'デフォルトに戻す'
         none: 'なし'
         no_results: "何も見つかりませんでした。."
         clear_filter: "クリア"
@@ -1300,12 +1533,38 @@ ja:
           files: 'ファイル'
           trust: 'トラストレベル'
           security: 'セキュリティ'
+          onebox: "Onebox"
           seo: 'SEO'
           spam: 'スパム'
           rate_limits: '投稿制限'
           developer: '開発者向け'
-          embedding: "埋め込む中"
+          embedding: "埋め込む"
+          legal: "法律に基づく情報"
           uncategorized: 'その他'
+          backups: "バックアップ"
+      badges:
+        title: バッジ
+        new_badge: 新しいバッジ
+        new: 新規
+        name: バッジ名
+        badge: バッジ
+        display_name: バッジ表示名
+        description: バッジ説明
+        badge_type: バッジ種類
+        granted_by: バッジ付与者
+        save: バッジを保存する
+        delete: バッジを削除する
+        delete_confirm: 本当にこのバッジを削除しますか？
+        revoke: 取り消す
+        revoke_confirm: このバッジを取り消しますか？
+        edit_badges: バッジを編集する
+        grant_badge: バッジを付与
+        granted_badges: 付与されたバッジ
+        grant: 付与する
+        no_user_badges: "%{name} はバッジを付与されていません。"
+        no_badges: 付与できるバッジがありません
+        allow_title: バッジは、タイトルとして使用されることを許可する
+        multiple_grant: 複数回付与することができます
     lightbox:
       download: "ダウンロード"
     keyboard_shortcuts_help:
@@ -1329,3 +1588,12 @@ ja:
         edit: '<b>e</b> ポストを編集'
         delete: '<b>d</b> ポストを削除する'
         mark_muted: '<b>m</b> 後 <b>m</b> ミュートトピックにマークする'
+    badges:
+      title: バッジ
+      badge_count:
+        other: "%{count} バッジ"
+      more_badges:
+        other: "+%{count} もっと"
+      granted:
+        other: "%{count} つバッジを付与されました"
+      select_badge_for_title: タイトルとして使用するバッジを選択

--- a/config/locales/server.fr.yml
+++ b/config/locales/server.fr.yml
@@ -324,7 +324,7 @@ fr:
       long_form: 'signalé comme spam'
     inappropriate:
       title: 'Inapproprié'
-      description: 'Ce message contient du contenu qu''une personne raisonnable jugerait offensant, abusif ou en violation des <a href="/faq">règles de notre communauté </ a>.'
+      description: 'Ce message contient du contenu qu''une personne raisonnable jugerait offensant, abusif ou en violation des <a href="/faq">règles de notre communauté</a>.'
       long_form: 'signalé comme inapproprié'
     notify_user:
       title: 'Avertir {{username}}'
@@ -357,7 +357,7 @@ fr:
       long_form: 'signalé comme spam'
     inappropriate:
       title: 'Inapproprié'
-      description: 'Ce message contient du contenu qu''une personne raisonnable jugerait offensant, abusif ou en violation des <a href="/faq">règles de notre communauté</ a>.'
+      description: 'Ce message contient du contenu qu''une personne raisonnable jugerait offensant, abusif ou en violation des <a href="/faq">règles de notre communauté</a>.'
       long_form: 'signalé comme inapproprié'
     notify_moderators:
       title: 'Avertir les modérateurs'
@@ -763,6 +763,7 @@ fr:
     enable_mobile_theme: "Les appareils mobiles utilisent un thème adapté aux mobiles, avec la possibilité de passer à la totalité du site. Désactivez cette option si vous voulez utiliser une feuille de style personnalisée qui réponde à tous les types de clients."
     dominating_topic_minimum_percent: "Quel est le pourcentage de messages d'un utilisateur doit poster dans un sujet avant que nous considérions qu'il est dominant."
     suppress_uncategorized_badge: "Ne pas afficher le badge pour les sujets non catégorisés dans les listes des sujets"
+    min_posts_for_search_in_topic: "Désactiver la recherche dans les sujets si les sujets ont moins du minimum de messages"
     global_notice: "Affiche un bandeau global URGENT pour tout les utilisateurs du site, laissez vide pour le caché (HTML autorisé)"
     enable_names: "Autoriser les utilisateurs à afficher leur nom complet"
     display_name_on_posts: "Afficher également le nom complet de l'utilisateur dans ses messages"
@@ -784,6 +785,8 @@ fr:
     notify_about_flags_after: "Si il y a des signalements qui n'ont pas été traités après ce nombre d'heure, envoyer un email à contact_email.  Désactiver la fonctionnalité en indiquant: 0."
     enable_cdn_js_debugging: "Autorise /logs a affiché les correctement les erreurs en ajoutant des permissions de crossorigin sur toutes les inclusions de js."
     show_create_topics_notice: "Si le site contient moins de 5 sujets publics, afficher un message pour demander aux admins de creer d'autres sujets."
+    errors:
+      invalid_email: "Adresse email invalide."
   notification_types:
     mentioned: "%{display_username} vous a mentionné dans %{link}"
     liked: "%{display_username} a aimé votre message dans %{link}"
@@ -1079,6 +1082,8 @@ fr:
         Ceci est un message automatique de %{site_name} pour vous informer que vos messages ont été bloqués par un membre de l'équipe.
 
         Pour plus d'informations, merci de vous en référer à la [FAQ](%{base_url}/faq).
+    user_automatically_blocked:
+      subject_template: "Nouvel utilisateur %{username} bloqué à cause de signalements de la communauté"
     unblocked:
       subject_template: "Compte débloqué"
       text_body_template: |

--- a/config/locales/server.pt_BR.yml
+++ b/config/locales/server.pt_BR.yml
@@ -43,6 +43,7 @@ pt_BR:
       other: "%{count} respostas a mais"
     loading: "Carregando Discussão..."
     permalink: "Permalink"
+    imported_from: "Este é um tópico de discussão companheiro para a postagem original em %{link}"
     in_reply_to: "▶ %{username}"
     replies:
       one: "1 resposta"
@@ -166,14 +167,20 @@ pt_BR:
               common: "é uma das 10000 senhas mais comuns. Por favor, use uma senha mais segura."
             ip_address:
               signup_not_allowed: "Cadastro não é permitido a partir desta conta."
+        color_scheme_color:
+          attributes:
+            hex:
+              invalid: "Não é uma cor válida"
   user_profile:
     no_info_me: "<div class='missing-profile'>o campo Sobre mim do seu perfil está em branco, <a href='/users/%{username_lower}/preferences/about-me'>quer completar?</a></div>"
     no_info_other: "<div class='missing-profile'>%{name} ainda não colocou nada no campo Sobre Mim</div>"
+  vip_category_name: "sala de descanso"
   vip_category_description: "Uma categoria exclusiva para membros com nível de confiança 3 e superior."
   meta_category_name: "meta"
   meta_category_description: "Discussão sobre este fórum, sua organização, como ele funciona e como podemos melhorá-lo."
   staff_category_name: "equipe"
   staff_category_description: "Categoria particular para as discussões da equipe. Tópicos só são visíveis para os administradores e moderadores."
+  assets_topic_body: "Esse é um tópico permanente, visível apenas para a equipe, para arquivar imagens e arquivos usados no design do fórum. Não o delete!\n\n\nAqui está como:\n\n\n1. Responda a esse tópico.\n2. Envie todas as imagens que você deseja para serem usadas como logos, favicons e assim por diante aqui. (Utilize o ícone da barra de upload no editor de post, arraste e solte ou cole imagens.)\n3. Enviar sua resposta para publicá-la.\n4. Clique com o botão direito do mouse nas imagens em sua nova postagem para obter o endereço das imagens enviadas, ou clique no ícone de edição para editar o seu post e recuperar o caminho para as imagens. Copie o endereço da imagem.\n5. Copie o endereço das imagens nas [configurações básicas](/admin/site_settings/category/required).\n\nTambém, se você precisa ativar diferentes tipos de envios de arquivos, edite o `authorized_extensions` em [configurações de arquivo](/admin/site_settings/category/files)."
   category:
     topic_prefix: "Sobre a categoria %{category} "
     replace_paragraph: "[Substitua este primeiro parágrafo com uma breve descrição de sua nova categoria. Esta orientação será exibida na área de seleção de categoria, assim, tente mantê-lo abaixo de 200 caracteres. Até que você edite o texto ou crie tópicos, esta categoria não aparecerá na página de categorias.]"
@@ -305,7 +312,7 @@ pt_BR:
       long_form: 'sinalizado como spam'
     inappropriate:
       title: 'Inapropriado'
-      description: 'Esta mensagem contém conteúdo que uma pessoa razoável consideraria ofensivo, abusivo ou uma violação das <a href="/faq">nossas diretrizes de comunidade</ a>.'
+      description: 'Esta mensagem contém conteúdo que uma pessoa razoável consideraria ofensivo, abusivo ou uma violação das <a href="/faq">nossas diretrizes de comunidade</a>.'
       long_form: 'sinalizado como inapropriado'
     notify_user:
       title: 'Notificar {{username}}'
@@ -446,6 +453,9 @@ pt_BR:
     sidekiq_warning: 'Sidekiq não está em execução. Muitas tarefas, como envio de emails, são executadas de forma assíncrona pelo sidekiq. Por favor certifique-se de que ao menos um processo sidekiq esteja execução. <a href="https://github.com/mperham/sidekiq" target="_blank">Aprenda sobre Sidekiq aqui</a>.'
     queue_size_warning: 'O número de tarefas agendadas é %{queue_size}, o que é alto. Isto pode indicar um problema com o(s) processo(s) Sidekiq, ou você pode estar precisando de mais Sidekiq workers.'
     memory_warning: 'Seu servidor está rodando com menos de 1 GB de memória total. Pelo menos 1 GB é quantidade de memória recomendada.'
+    enable_google_logins_warning: "Você está usando uma versão descontinuada da autenticação Google's OpenID. Google vai parar de dar suporte para o OpenID em 20 de Abril de 2015. Comece a usar o Google OAuth2 assim que possível. <a href='https://meta.discourse.org/t/configuring-google-login-for-discourse/15858' target='_blank'>Veja esse guia para entender mais</a>"
+    both_googles_warning: "Você tem enable_google_logins e enable_google_oauth2_logins ativados nas configurações do site. Desative o enable_google_logins."
+    google_oauth2_config_warning: 'O servidor está configurado para permitir o signup e login com Google OAuth2 (enable_google_oauth2_logins), mas os valores de Cliend Id e Secret não estão configurados. Vá para <a href="/admin/site_settings">as Configurações do Site</a> e atualize as configurações. <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">Veja este guia e aprenda mais</a>.'
     facebook_config_warning: 'O servidor está configurado para permitir o signup e login com Facebook (enable_facebook_logins), mas os valores do App Id e App Secret não estão configurados. Vá para <a href="/admin/site_settings">as Configurações do Site</a> e atualize as configurações. <a href="https://meta.discourse.org/t/configuring-facebook-login-for-discourse/13394" target="_blank">Veja este guia e aprenda mais</a>.'
     twitter_config_warning: 'O servidor está configurado para permitir o signup e login com Twitter (enable_twitter_logins), mas os valores de Key e Secret não estão configurados. Vá para <a href="/admin/site_settings">as Configurações do Site</a> e atualize as configurações. <a href="https://meta.discourse.org/t/configuring-twitter-login-for-discourse/13395" target="_blank">Veja este guia e aprenda mais</a>.'
     github_config_warning: 'O servidor está configurado para permitir o signup e login com GitHub (enable_twitter_logins), mas os valores de Cliend Id e Secret não estão configurados. Vá para <a href="/admin/site_settings">the Site Settings</a> e atualize as configurações. <a href="https://meta.discourse.org/t/configuring-github-login-for-discourse/13745" target="_blank">Veja este guia e aprenda mais</a>.'
@@ -509,6 +519,9 @@ pt_BR:
     tos_signup_form_message:
       title: "Formulário de Cadastro: Termos do Serviço de Mensagens"
       description: "A mensagem que aparecerá ao lado de uma caixa de seleção no formulário de cadastro se a configuração do site tos_accept_required estiver habilitada."
+    notification_email_top:
+      title: "Topo dos emails de notificação"
+      description: "Uma mensagem que vai ser exibida no topo de todas as notificações por email."
   site_settings:
     default_locale: "Idioma padrão para esta instância do Discourse (ISO 639-1 Code)"
     allow_user_locale: "Permitir que os usuários escolham suas próprias preferências de idioma de interface"
@@ -535,6 +548,7 @@ pt_BR:
     crawl_images: "permitir mostrar imagens de sites terceiros"
     download_remote_images_to_local: "Baixa uma cópia das imagens remotas linkadas nas mensagens"
     download_remote_images_threshold: "Quantidade mínima de espaço disponível em disco necessário para fazer download de imagens remotas localmente (em percentagem)"
+    disabled_image_download_domains: "Uma lista delimitada por tubo de domínios dos quais imagens nunca serão baixadas."
     ninja_edit_window: "quão rápido é possivél fazer uma alteração sem guardar uma nova versão, em segundos."
     post_edit_time_limit: "Quantidade de tempo em minutos em que as mensagens podem ser editadas e apagadas pelo autor. Ajuste para 0 para permitir a edição e exclusão de mensagens a qualquer momento."
     edit_history_visible_to_public: "Permitir que todos vejam as versões anteriores de uma postagem editada. Quando desativado, somente membros do staff podem ver o histórico de alterações."
@@ -542,10 +556,12 @@ pt_BR:
     max_image_width: "máxima largura para uma imagem numa postagem"
     max_image_height: "Tamanho máximo permitido para altura de imagens em um post"
     category_featured_topics: "Número de tópicos exibidos por categoria na página /categories. Depois de alterar este valor, levará até 15 minutos para a página de categorias atualizar-se."
+    fixed_category_positions: "Se selecionado, você será capaz de organizar as categorias em uma ordem fixa. Se nada for feito, as categorias serão listadas em ordem de atividade."
     add_rel_nofollow_to_user_content: "Adicionar rel nofollow em todos os conteúdos submetidos pelo utilizador, excepto links internos (incluido dominios parentes) mudando isto exige uma atualização a todos os teus baked markdown"
     exclude_rel_nofollow_domains: "Lista de domínios separados por barras verticais (|) onde o nofollow não é adicionado (tld.com irá automaticamente disponibilizar sub.tld.com também) "
     post_excerpt_maxlength: "Tamanho máximo em caracteres para um post."
     post_onebox_maxlength: "Tamanho máximo para um oneboxed discourse post."
+    onebox_domains_whitelist: "Lista de domínios permitidos para oneboxing. (Exemplo: eviltrout.com)"
     category_post_template: "O modelo de mensagem usado quando você cria uma nova categoria"
     logo_url: "O logo para o seu site eg: http://example.com/logo.png"
     digest_logo_url: "O logotipo usado no resumo por e-mail do site. Se estiver em branco, `logo_url` será usado. Ex: http://example.com/logo.png"
@@ -583,18 +599,21 @@ pt_BR:
     ga_universal_domain_name: "Nome de domínio do Google Universal Analytics (analytics.js), ex: meusite.com; veja http://google.com/analytics"
     enable_escaped_fragments: "Fallback para a API Ajax-Crawling do Google  se um rastreador não é detectado."
     enable_noscript_support: "Ativar suporte a tag &lt;noscript&gt;"
+    allow_moderators_to_create_categories: "Permitir a criação de categorias por moderadores"
     top_menu: "Determine quais itens aparecem na navegação da homepage e em que ordem. Exemplo latest|new|unread|starred|categories|top|read|posted"
     post_menu: "A ordem dos items no menu da postagem."
     share_links: "Determine quais ítens aparecerem no diálogo de compartilhar, e em que ordem. Por exemplo: twitter|facebook|google+|email"
     track_external_right_clicks: "Rastrear cliques externos que são clicados com o botão direito (ex: abrir em nova aba) desativado por padrão, pois tem que reescrever urls, quebrando a usabilidade"
     topics_per_page: "Quantos tópicos carregados por padrão na página da lista de tópicos e quando carregar mais tópicos"
     posts_per_page: "Quantas postagens são requisitados numa página de tópico"
+    desktop_post_slack_ratio: "Número de telas de mensagens processados no DOM no Desktop"
     site_contact_username: "Nome do Usuário que envia as mensagens do sistema"
     send_welcome_message: "Novos usuários recebem mensagem particular de boas-vindas?"
     suppress_reply_directly_below: "Não exibir contagem do número de respostas na postagem quando houver apenas uma resposta diretamente abaixo"
     suppress_reply_directly_above: "Não exibir \"em resposta a\" numa postagem quando houver apenas uma resposta diretamente a seguir"
     topics_per_period_in_top_summary: "Quantos tópicos carregados no resumo de melhores tópicos"
     topics_per_period_in_top_page: "Quantos tópicos carregado na página de melhores tópicos"
+    redirect_users_to_top_page: "Redirecionar automaticamente os usuários novos e de-longa-data-perdidos para a página topo"
     enable_badges: "Habilita o sistema de emblemas (experimental)"
     allow_index_in_robots_txt: "Site deve ser indexado por mecanismos de busca (atualize robots.txt)"
     email_domains_blacklist: "Uma lista delimitada por barras (|) de domínios de email que não são permitidos. Exemplo: mailinator.com|trashmail.net"
@@ -607,7 +626,9 @@ pt_BR:
     invite_only: "Registro público está desativado, usuários novos tem que ser convidados"
     login_required: "Exigir autenticação para ler as postagens"
     min_username_length: "Comprimento mínimo do nome de usuário. (Não se aplica caso exclusividade global de apelido está forçada)"
+    max_username_length: "Comprimento máximo do Nome de Usuário. (Não se aplica caso a exclusividade global de apelido estiver forçada)"
     min_password_length: "Comprimento mínimo da senha."
+    block_common_passwords: "Não permitir senhas que estão entre as 10000 senhas mais comuns."
     enable_sso: "Ativar logon único através de um site externo"
     sso_url: "URL destino do logon único"
     sso_secret: "Cadeia secreta usada para criptografar/descriptografar informações SSO, certifique-se que tenha 10 caracteres ou mais"
@@ -615,7 +636,11 @@ pt_BR:
     sso_overrides_username: "Substitui nome de usuário local com nome de usuário do site externo do servidor SSO (ATENÇÃO: discrepâncias podem ocorrer devido a diferenças nos requerimentos de comprimento de nome de usuário)"
     sso_overrides_name: "Substitui nome local com o nome do site externo do servidor SSO (ATENÇÃO: discrepâncias podem ocorrer devido à normalização de nomes locais)"
     enable_local_logins: "Ativar autenticação local"
+    enable_google_logins: "(obsoleto) Habilitar a autenticação do Google. Este é o método de autenticação OpenID que o Google está abandonando. Novas instalações não vai funcionar com isso. Use o Google Oauth2 ao invés. Instalações existentes devem passar para Google Oauth2 até 20 de Abril de 2015."
     enable_yahoo_logins: "Ativar autenticação pelo Yahoo"
+    enable_google_oauth2_logins: "Ativar autentincação Google Oauth2. Esse é o método de autenticação que o Google atualmente suporta. Necessita de uma chave e chave secreta."
+    google_oauth2_client_id: "Client ID da sua aplicação Google."
+    google_oauth2_client_secret: "Client secret da sua aplicação Google."
     enable_twitter_logins: "Ativar autenticação pelo Twitter, requer twitter_consumer_key e twitter_consumer_secret"
     twitter_consumer_key: "consumer key registrada em dev.twitter.com (usada para fazer autenticação via twitter)"
     twitter_consumer_secret: "consumer secret registrada em dev.twitter.com (usada para fazer autenticação via twitter)"
@@ -625,6 +650,7 @@ pt_BR:
     enable_github_logins: "Ativar autenticação via Github, requer github_client_id e github_client_secret"
     github_client_id: "Client id para autenticação via Github, registrado em https://github.com/settings/applications"
     github_client_secret: "Client secret para autenticação via Github, registrado em https://github.com/settings/applications"
+    allow_restore: "Permitir restauração, que pode substituir todos os dados do site! Deixe falsa, a menos que você pretenda restaurar um backup"
     maximum_backups: "A quantidade máxima de backups para manter no disco. Backups mais antigos são excluídos automaticamente"
     backup_daily: "Criar automaticamente um backup do site uma vez por dia"
     enable_s3_backups: "Enviar backups para o Amazon S3 quando completos. Certifique-se de ter preenchido as suas credenciais S3."
@@ -664,6 +690,7 @@ pt_BR:
     regular_requires_likes_given: "Quantas curtidas um usuário básico deve dar antes de ser promovido para usuário regular, nível de confiança (2)"
     regular_requires_topic_reply_count: "Quantos tópicos um usuário básico deve responder antes de ser promovido para usuário regular, nível de confiança (2)"
     min_trust_to_create_topic: "O nível de confiança mínimo necessário para criar um novo tópico."
+    min_trust_to_edit_wiki_post: "O nível de confiança mínimo necessário para editar uma postagem marcada como wiki."
     newuser_max_links: "Quantos links um usuário novo pode adicionar a uma postagem"
     newuser_max_images: "Quantas imagens um usuário novo pode adicionar em uma postagem"
     newuser_max_attachments: "Quantos anexos um novo usuário pode adicionar à sua postagem"
@@ -694,6 +721,7 @@ pt_BR:
     tos_url: "Se você tem um documento de Termos de Serviço hospedado em algum outro local que você queira usar, forneça a URL completa aqui."
     privacy_policy_url: "Se você tem um documento de Política de Privacidade hospedado em algum outro local que você queira usar, forneça a URL completa aqui."
     newuser_spam_host_threshold: "Quantas vezes um usuário pode postar um link para o mesmo site dentro de`newuser_spam_host_posts` posts antes de ser considerado spam."
+    white_listed_spam_host_domains: "Uma lista delimitada por virgula de domínios excluídos do host testador de spam, novos usuários serão capazes de criar uma quantidade irrestrita de postagens com links para estes domínios"
     staff_like_weight: "Fator extra de peso para curtidas dados pelo staff."
     reply_by_email_enabled: "Se este fórum suporta respostas por email"
     reply_by_email_address: "Template de resposta por email, por exemplo: %{reply_key}@reply.example.com or replies+%{reply_key}@example.com"
@@ -715,22 +743,28 @@ pt_BR:
     email_editable: "Permitir que os usuários alterem o seu endereço de e-mail após o registro."
     allow_uploaded_avatars: "Permitir que os usuários façam envio de seus avatares personalizados"
     allow_animated_avatars: "Permitir aos usuários usar gif animado para avatares. AVISO: é altamente recomendado executar a tarefa rake avatars:regenerate depois de mudar essa configuração."
+    automatically_download_gravatars: "Baixar gravatars para usuários após a criação de conta ou mudança de email"
+    digest_topics: "O montante máximo de tópicos para exibir em um resumo por e-mail"
     digest_min_excerpt_length: "Quantos caracteres buscaremos em cada mensagem no e-mail de resumo"
     default_digest_email_frequency: "Quantas vezes os usuários recebem emails de resumo por padrão. Eles podem alterar essa configuração em suas preferências."
     default_external_links_in_new_tab: "Abrir links externos em uma nova guia. Os usuários podem mudar isso em suas preferências."
     detect_custom_avatars: "Se deve ou não verificar se os usuários enviaram avatares personalizados"
     max_daily_gravatar_crawls: "A quantidade máxima de vezes que Discourse irá verificar gravatar para avatares personalizados em um dia"
+    public_user_custom_fields: "Uma lista de permissões de campos personalizados para um usuário que pode ser mostrado publicamente."
     allow_profile_backgrounds: "Permitir usuários carregar plano de fundo para o perfil "
     sequential_replies_threshold: "A quantidade de mensagens que um usuário tem para fazer em uma fila em um tópico antes de ser notificado"
     enable_mobile_theme: "Os dispositivos móveis usam um tema mobile-friendly, com a possibilidade de mudar para o site completo. Desative isso se você quiser usar um estilo personalizado que é totalmente responsivo."
     dominating_topic_minimum_percent: "Qual a percentagem de mensagens de um usuário em um tópico antes de considerá-lo dominante."
     suppress_uncategorized_badge: "Não exibir emblema para assuntos não categorizados em listas de tópicos"
+    min_posts_for_search_in_topic: "Desativar pesquisa dentro do tópico se tópicos tem um número mínimo de mensagens"
+    global_notice: "Mostrar um banner global URGENTE, de EMERGÊNCIA para todos os visitantes, mude para branco para esconder (HTML permitido)."
     enable_names: "Permitir que usuários exibam seus nomes completos"
     display_name_on_posts: "Também exibir o nome completo do usuário em suas mensagens"
     invites_shown: "Máximos convites exibidos em uma página de usuário"
     short_progress_text_threshold: "Após o número de mensagens em um tópico for acima deste número, a barra de progresso mostrará apenas o número  da mensagem atual. Se você alterar a largura da barra de progresso, você pode precisar alterar este valor."
     default_code_lang: "Realce de sintaxe padrão da linguagem de programação aplicada a blocos de código GitHub (lang-auto, Ruby, Python, etc)"
     warn_reviving_old_topic_age: "Quando alguém começa a responder a um tópico mais velho do que este número de dias, um aviso será exibido para desencorajar o usuário de reviver uma velha discussão. Desabilite definindo para 0."
+    autohighlight_all_code: "Aplicar código destacando todos os blocos de código pré-formatados, mesmo quando não for específica o idioma"
     embeddable_host: "Host que pode incorporar os comentários deste fórum do Discourse"
     feed_polling_enabled: "Se um feed RSS/ATOM são importados como mensagens"
     feed_polling_url: "URL do feed RSS/ATOM para importar"
@@ -738,8 +772,14 @@ pt_BR:
     embed_truncate: "Truncar as mensagens importadas"
     embed_category: "Categoria de tópicos criados"
     embed_post_limit: "Número máximo de respostas para embutir"
+    embed_whitelist_selector: "seletor css para elementos que são permitidos em incorporações"
+    embed_blacklist_selector: "seletor css para elementos que são removidos a partir de incorporações"
     tos_accept_required: "Se ativado, os usuários terão de verificar uma caixa no formulário de cadastro para confirmar que aceitam os termos do serviço. Editar \"Formulário de Cadastro: Termos do Serviço de Mensagens\" na guia Conteúdo para alterar a mensagem."
     notify_about_flags_after: "Se houver sinalizações sem ações após muitas horas, envia um e-mail para contact_email. Ajuste para 0 para desligar."
+    enable_cdn_js_debugging: "Permitir /logs para mostrar erros próprios, adicionando permissões crossorigin em todos os js  includes"
+    show_create_topics_notice: "Se o site tem menos de 5 tópicos públicos, mostrar um aviso pedindo para os administradores criarem alguns tópicos."
+    errors:
+      invalid_email: "Endereço de email inválido"
   notification_types:
     mentioned: "%{display_username} mencionou-te em %{link}"
     liked: "%{display_username} curtiu sua postagem em %{link}"
@@ -752,6 +792,7 @@ pt_BR:
     invited_to_private_message: "%{display_username} convidou-te para uma conversa privada: %{link}"
     invitee_accepted: "%{display_username} aceitou o seu convite"
     linked: "%{display_username} linkou você em %{link}"
+    granted_badge: "Foi concedido a você %{link}"
   search:
     within_post: "#%{post_number} por %{username}: %{excerpt}"
     types:
@@ -763,6 +804,7 @@ pt_BR:
   most_recent_poster: "Maior parte das Postagens Recentes"
   frequent_poster: "Postador frequente"
   redirected_to_top_reasons:
+    new_user: "Bem vindo a nossa comunidade! Aqui estão os nosso tópicos populares mais recentes."
     not_seen_in_a_month: "Bem-vindo de volta! Nós não o vemos a um tempo. Estes são os principais tópicos de discussão desde que você foi embora."
   move_posts:
     new_topic_moderator_post:
@@ -771,6 +813,8 @@ pt_BR:
     existing_topic_moderator_post:
       one: "Eu movi uma postagem para este tópico: %{topic_link}"
       other: "Eu movi %{count} postagens para este tópico: %{topic_link}"
+  change_owner:
+    post_revision_text: "Autoria transferida de %{old_user} para %{new_user}"
   topic_statuses:
     archived_enabled: "Este tópico está agora arquivado. Está congelado e não pode ser alterado de qualquer forma."
     archived_disabled: "Este tópico foi agora desarquivado. Já não está congelado, e pode ser alterado."
@@ -791,6 +835,8 @@ pt_BR:
     autoclosed_disabled: "Este tópico está aberto agora. Novas respostas estão permitidas."
     pinned_enabled: "Este tópico está agora afixado. Irá aparecer no topo das suas categorias"
     pinned_disabled: "Este tópico deixou de estár afixado. Não irá mais aparecer no topo das suas categorias."
+    pinned_globally_enabled: "Esse tópico agora está fixado globalmente. Ele irá aparecer no topo dessa categoria e de todas as listagens de tópicos até que seja desfixado pela equipe para todo mundo, ou para usuários individuais por eles mesmo."
+    pinned_globally_disabled: "Esse tópico está desafixado agora. Não irá mais aparecer no topo dessa categoria."
     visible_enabled: "Este tópico está agora visivél. Irá aparecer na lista dos tópicos."
     visible_disabled: "Este tópico está agora invisivel. Não irá mais aparecer em qualquer listagem de tópicos. A única forma de aceder a este tópico é com o link direto."
   login:
@@ -850,13 +896,51 @@ pt_BR:
       \ rua Principal 55, QualquerCidade,  BRA 12345. Se você gostaria de optar por cancelar futuros e-mails, [clique aqui para cancelar a inscrição][5]. </ Small> \n\n\n\n\n\n\n\n\n\n"
   new_version_mailer:
     subject_template: "[%{site_name}] Nova versão do Discourse, atualização disponível"
+    text_body_template: |
+      Uma nova versão do Discourse está disponível.
+
+      Sua versão: %{installed_version}
+      Nova versão: **%{new_version}**
+
+      Você talvez queira:
+      - Ver o que há de novo nas [mudanças do GitHub] (https://github.com/discourse/discourse/commits/master)
+
+      - Atualizar visitando  [%{base_url}/admin/docker](%{base_url}/admin/docker) e pressionando o botão de "Atualizar".
+
+      - Visitar [meta.discourse.org](http://meta.discourse.org) para notícias, discussões e suporte para o Discourse.
   new_version_mailer_with_notes:
     subject_template: "[%{site_name}] atualização disponível"
+    text_body_template: |
+      Uma nova versão do Discourse está disponível.
+
+      Sua versão: %{installed_version}
+      Nova versão: **%{new_version}**
+
+      Você talvez queira:
+      - Ver o que há de novo nas [mudanças do GitHub] (https://github.com/discourse/discourse/commits/master)
+
+      - Atualizar visitando  [%{base_url}/admin/docker](%{base_url}/admin/docker) e pressionando o botão de "Atualizar".
+
+      - Visitar [meta.discourse.org](http://meta.discourse.org) para notícias, discussões e suporte para o Discourse.
+
+      ### Notas de lançamento
+
+      %{notes}
   flags_reminder:
     flags_were_submitted:
       one: "Há sinalizações que foram enviadas a mais de 1 hora."
       other: "Há sinalizações que foram enviadas a mais de %{count} horas atrás."
+    please_review: "Por favor, revise eles."
     post_number: "mensagem"
+    how_to_disable: "Desativar esse email mudando o notify_about_flags_after para 0."
+    subject_template:
+      one: "1 sinalização está esperando para ser verificada"
+      other: "%{count} sinalizações estão esperando para serem verificadas"
+  flag_reasons:
+    off_topic: "Sua postagem foi sinalizada como ***off-topic**: a comunidade pensa que ela não se encaixa nesse tópico, atualmente definido pelo título e sua primeira postagem."
+    inappropriate: "Sua postagem foi sinaliza como **inapropriada**: a comunidade pensa que é ofensiva, abusiva ou viola as [regras da comunidade](/faq)."
+    spam: "Sua postagem foi sinalizada como **spam*: a comunidade pensa que isso é uma propaganda não necessária ou relevante ao tópico, promocional por natureza."
+    notify_moderators: "Sua postagem foi sinalizada **para a atenção da moderação**: a comunidade pensa algo sobre a postagem que precisa a intervenção da moderação."
   system_messages:
     post_hidden:
       subject_template: "%{site_name} Aviso: Postagem escondida devido a Sinalização pela Comunidade"
@@ -893,6 +977,26 @@ pt_BR:
         Desfrute da sua estadia!
     welcome_invite:
       subject_template: "Bem-vindo em %{site_name}!"
+      text_body_template: |
+        Obrigado por aceitar o convite para o %{site_name}, e seja bem vindo!
+
+        Nós geramos um Nome de Usuário automaticamente pra você: **%{username}**, mas você pode mudar isso a qualquer momento visitando [seu perfil de usuário][prefs].
+
+        Para entrar novamente:
+
+        1. Entre da maneira que quiser -- mas esse login deve ser criado com o mesmo **endereço de e-mail** no qual você recebeu o convite. Caso contrário não seremos capazes de dizer que é você!
+
+        2. Crie uma senha única para o %{site_name} no [seu perfil de usuário][prefs], depois entre com ele.
+
+        %{site_password}
+
+        %{new_user_tips}
+
+        Nós acreditamos em [um comportamento de comunidade civilizado](%{base_url}/faq) sempre.
+
+        Aproveite sua estadia!
+
+        [prefs]: %{user_preferences_url}
     export_succeeded:
       subject_template: "Exportação completada com sucesso"
       text_body_template: "A exportação foi bem sucedida."
@@ -922,6 +1026,14 @@ pt_BR:
         ```
     email_error_notification:
       subject_template: "Erro ao analisar e-mail"
+      text_body_template: |
+        Isso é uma mensagem automática.
+
+        Analisando o-mail de entrada falhou. Por favor, verifique o seguinte erro:
+
+        `%{error}`
+
+        %{source}
     email_reject_trust_level:
       subject_template: "Mensagem rejeitada"
       text_body_template: "A mensagem que você enviou para %{to} foi rejeitada pelo sistema. \n \nVocê não tem a confiança necessária para criar novos tópicos para este endereço de e-mail. \n"
@@ -943,6 +1055,26 @@ pt_BR:
         Esta é uma mensagem automática de %{site_name} para informar que sua conta foi bloqueada por um membro da staff.⏎
         ⏎
         Para informações adicionais, por favor, consulte nossa [FAQ](%{base_url}/faq).⏎
+    user_automatically_blocked:
+      subject_template: "Novo usuário %{username} foi bloqueado devido a denúncias da comunidade"
+      text_body_template: |
+        Essa é uma mensagem automática.
+
+        O novo usuário [%{username}](%{base_url}%{user_url}) foi automaticamente bloqueado por ter recebido múltiplas sinalizações %{username}'s postagem(ns).
+
+        Por favor [reveja as sinalzações](%{base_url}/admin/flags). Se %{username} foi bloqueado injustamente, clique no botão de desbloquear na [página de administração desse usuário](%{base_url}%{user_url}).
+
+        Este limite pode ser alterado através da configuração `block_new_user` do site.
+    spam_post_blocked:
+      subject_template: "Novo usuário %{username} teve postagem bloqueada por repetidos links"
+      text_body_template: |
+        Essa é uma mensagem automática.
+
+        O novo usuário [%{username}](%{base_url}%{user_url}) tentou criar múltiplas postagens com link para %{domains}, mas essas postagens foram bloqueadas para evitar spam. O usuário ainda está apto a criar novas postagens que não tenham links para %{domains}.
+
+        Por favor, [reveja esse usuário](%{base_url}%{user_url}).
+
+        Isso pode ser modificado na configuração `newuser_spam_host_threshold` e `white_listed_spam_host_domains` do site.
     unblocked:
       subject_template: "Conta desbloqueada"
       text_body_template: |
@@ -956,6 +1088,9 @@ pt_BR:
         one: "1 usuário aguardando aprovação"
         other: "%{count} usuários aguardando aprovação"
       text_body_template: "Há novos cadastros de usuários à espera de serem aprovados (ou rejeitados), antes de poderem acessar este fórum. \n \n[Por favor, analisá-los na seção de administração] ( %{base_url}/admin/users/list/pending).\n"
+    download_remote_images_disabled:
+      subject_template: "Baixar imagens remotas desativado"
+      text_body_template: "A configuração `download_remote_images_to_local` está desativada porque o espaço limite no disco configurado em `download_remote_images_threshold` foi alcançado."
   unsubscribe_link: "Se você deseja se desinscrever destes emails, visite suas [preferências do usuário](%{user_preferences_url})."
   user_notifications:
     previous_discussion: "Respostas Anteriores"
@@ -1027,6 +1162,8 @@ pt_BR:
       click_here: "clique aqui"
       from: "resumo de %{site_name}"
       read_more: "Leia Mais"
+      more_topics: "Há %{new_topics_since_seen} outros novos tópicos postados desde a sua última visita em %{last_seen_at}."
+      more_topics_category: "Há %{new_topics_since_seen} outros novos tópicos publicados nessa categoria desde a sua última visita em %{last_seen_at}:"
       posts:
         one: "1 mensagem"
         other: "%{count} mensagens"
@@ -1097,6 +1234,7 @@ pt_BR:
     edit_reason: "cópias baixadas das imagens remotas"
     unauthorized: "Desculpe-nos, o arquivo que você está tentando enviar não é autorizado (extensões autorizadas: %{authorized_extensions})."
     pasted_image_filename: "Imagem colada"
+    store_failure: "Falha ao arquivar o upload #%{upload_id} do usuário #%{user_id}."
     attachments:
       too_large: "Desculpe, o arquivo que você está tentando enviar é muito grande (tamanho máximo é %{max_size_kb}%kb)."
     images:
@@ -1106,6 +1244,7 @@ pt_BR:
       size_not_found: "Desculpe, mas não conseguimos determinar o tamanho da imagem. É possível que seu arquivo de imagem esteja corrompido?"
   flag_reason:
     sockpuppet: "Um novo usuário criou um tópico e outro novo usuário no mesmo endereço IP respondeu. Veja a configuração flag_sockpuppets."
+    spam_hosts: "Esse novo usuário tentou criar múltiplas postagens com links do mesmo domínio. Veja a configuração newuser_spam_host_threshold do site."
   email_log:
     no_user: "Não foi possível encontrar usuário com id %{user_id}"
     suspended_not_pm: "Usuário está suspenso e e-mail não é uma mensagem privada"


### PR DESCRIPTION
As [reported on meta](https://meta.discourse.org/t/moderation-bug-redirection-to-faq/16380), the flag modal had unexpected behaviour when clicking on links.

Turns out that in French and Portuguese locale files the anchor tag syntax was invalid `</ a>` instead of `</a>` which breaks the markup.

I submitted the corrected translations to Transifex, pulled the translations via Transifex client, and verified it's working locally.

Confirmed test suite is passing. cc @nlalonde 
