### PR TITLE
Add tooltip to Admin & Moderator glyph

### DIFF
--- a/app/assets/javascripts/discourse/components/poster-name.js.es6
+++ b/app/assets/javascripts/discourse/components/poster-name.js.es6
@@ -23,7 +23,7 @@ var PosterNameComponent = Em.Component.extend({
       // Add a glyph if we have one
       var glyph = this.posterGlyph(post);
       if (!Em.isEmpty(glyph)) {
-        buffer.push("<i class='fa fa-" + glyph + "'></i>");
+        buffer.push(glyph);
       }
       buffer.push("</span>");
 
@@ -69,10 +69,14 @@ var PosterNameComponent = Em.Component.extend({
     @return {String} the glyph to render (or null for none)
   **/
   posterGlyph: function(post) {
-    if (post.get('admin')) {
-      return 'trophy';
-    } else if (post.get('moderator')) {
-      return 'magic';
+    var desc;
+
+    if(post.get('admin')) {
+      desc = I18n.t('user.admin_tooltip');
+      return '<i class="fa fa-trophy" title="' + desc +  '" alt="' + desc + '"></i>';
+    } else if(post.get('moderator')) {
+      desc = I18n.t('user.moderator_tooltip');
+      return '<i class="fa fa-magic" title="' + desc +  '" alt="' + desc + '"></i>';
     }
   }
 });

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -261,6 +261,8 @@ en:
       change: "change"
       moderator: "{{user}} is a moderator"
       admin: "{{user}} is an admin"
+      moderator_tooltip: "This user is a moderator"
+      admin_tooltip: "This user is an admin"
       deleted: "(deleted)"
       suspended_notice: "This user is suspended until {{date}}."
       suspended_reason: "Reason: "


### PR DESCRIPTION
Added tooltip to Admin & Moderator glyph ([relevant meta topic](https://meta.discourse.org/t/add-tooltips-to-admin-moderator-fontawesome-glyphs-in-topic-view/15548)).

![glyph-tooltip](https://cloud.githubusercontent.com/assets/5732281/3264085/6df44af6-f27a-11e3-9580-73a823caf917.png)
