### PR TITLE
Add Re: to email messages subjects for replies to posts or pms

### DIFF
--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -93,11 +93,13 @@ class UserNotifications < ActionMailer::Base
 
   def user_posted(user, opts)
     opts[:allow_reply_by_email] = true
+    opts[:use_reply_subject] = true
     notification_email(user, opts)
   end
 
   def user_private_message(user, opts)
     opts[:allow_reply_by_email] = true
+    opts[:use_reply_subject] = true
 
     # We use the 'user_posted' event when you are emailed a post in a PM.
     opts[:notification_type] = 'posted'
@@ -158,12 +160,14 @@ class UserNotifications < ActionMailer::Base
 
     title = @notification.data_hash[:topic_title]
     allow_reply_by_email = opts[:allow_reply_by_email] unless user.suspended?
+    use_reply_subject = opts[:use_reply_subject] && @post.post_number > 1
 
     send_notification_email(
       title: title,
       post: @post,
       from_alias: username,
       allow_reply_by_email: allow_reply_by_email,
+      use_reply_subject: use_reply_subject,
       notification_type: notification_type,
       user: user
     )
@@ -174,6 +178,7 @@ class UserNotifications < ActionMailer::Base
     post = opts[:post]
     title = opts[:title]
     allow_reply_by_email = opts[:allow_reply_by_email]
+    use_reply_subject = opts[:use_reply_subject]
     from_alias = opts[:from_alias]
     notification_type = opts[:notification_type]
     user = opts[:user]
@@ -215,6 +220,7 @@ class UserNotifications < ActionMailer::Base
       username: from_alias,
       add_unsubscribe_link: true,
       allow_reply_by_email: allow_reply_by_email,
+      use_reply_subject: use_reply_subject,
       include_respond_instructions: !user.suspended?,
       template: template,
       html_override: html,

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1378,6 +1378,7 @@ en:
 
     user_posted:
       subject_template: "[%{site_name}] %{topic_title}"
+      reply_subject_template: "Re: [%{site_name}] %{topic_title}"
       text_body_template: |
         %{message}
 
@@ -1388,6 +1389,7 @@ en:
 
     user_posted_pm:
       subject_template: "[%{site_name}] [PM] %{topic_title}"
+      reply_subject_template: "Re: [%{site_name}] [PM] %{topic_title}"
       text_body_template: |
         %{message}
 

--- a/lib/email/message_builder.rb
+++ b/lib/email/message_builder.rb
@@ -41,7 +41,10 @@ module Email
 
     def subject
       subject = @opts[:subject]
-      subject = I18n.t("#{@opts[:template]}.subject_template", template_args) if @opts[:template]
+      if @opts[:template]
+        subject_template = @opts[:use_reply_subject] ? "reply_subject_template" : "subject_template"
+        subject = I18n.t("#{@opts[:template]}." + subject_template, template_args)
+      end
       subject
     end
 

--- a/spec/components/email/message_builder_spec.rb
+++ b/spec/components/email/message_builder_spec.rb
@@ -180,6 +180,18 @@ describe Email::MessageBuilder do
 
   end
 
+  context "reply_subject_template" do
+
+    let(:templated_builder) { Email::MessageBuilder.new(to_address, template: 'mystery', use_reply_subject:true) }
+    let(:rendered_template) { "rendered template" }
+
+    it "has the reply subject rendered from a template" do
+      I18n.expects(:t).with("mystery.reply_subject_template", templated_builder.template_args).returns(rendered_template)
+      expect(templated_builder.subject).to eq(rendered_template)
+    end
+
+  end
+
   context "from field" do
 
     it "has the default from" do


### PR DESCRIPTION
Adds reply_subject_template to server.en.yml which will need some localization for other languages
