### PR TITLE
Allow all /my URLs

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -81,7 +81,7 @@ class UsersController < ApplicationController
   end
 
   def my_redirect
-    if current_user.present? && params[:path] =~ /^[a-z\-]+$/
+    if current_user.present? && params[:path] =~ /^[a-z\-\/]+$/
       redirect_to "/users/#{current_user.username}/#{params[:path]}"
       return
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -185,7 +185,7 @@ Discourse::Application.routes.draw do
   get "users/activate-account/:token" => "users#activate_account"
   get "users/authorize-email/:token" => "users#authorize_email"
   get "users/hp" => "users#get_honeypot_value"
-  get "my/:path", to: 'users#my_redirect'
+  get "my/*path", to: 'users#my_redirect'
 
   get "user_preferences" => "users#user_preferences_redirect"
   get "users/:username/private-messages" => "user_actions#private_messages", constraints: {username: USERNAME_ROUTE_FORMAT}

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1330,6 +1330,11 @@ describe UsersController do
         get :my_redirect, path: "preferences"
         response.should be_redirect
       end
+
+      it "permits forward slashes" do
+        get :my_redirect, path: "activity/posts"
+        response.should be_redirect
+      end
     end
   end
 


### PR DESCRIPTION
This lets a request for `/my/activity/posts` etc through.

If you use `*param` instead of `:param`, it will match everything, including forward slashes.

See: https://stackoverflow.com/questions/4273205/rails-routing-with-a-parameter-that-includes-slash

Test included.
