### PR TITLE
Consider User trust level while showing Invites tab

### DIFF
--- a/app/assets/javascripts/discourse/controllers/user.js.es6
+++ b/app/assets/javascripts/discourse/controllers/user.js.es6
@@ -27,6 +27,15 @@ export default Discourse.ObjectController.extend({
            (this.get('userActionType') === Discourse.UserAction.TYPES.messages_received);
   }.property('userActionType'),
 
+  /**
+    Can the currently logged in user invite users to the site
+
+    @property canInviteToForum
+  **/
+  canInviteToForum: function() {
+    return Discourse.User.currentProp('can_invite_to_forum');
+  }.property(),
+
   privateMessagesActive: Em.computed.equal('pmView', 'index'),
   privateMessagesMineActive: Em.computed.equal('pmView', 'mine'),
   privateMessagesUnreadActive: Em.computed.equal('pmView', 'unread')

--- a/app/assets/javascripts/discourse/templates/user/invited.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/user/invited.js.handlebars
@@ -1,75 +1,79 @@
-<section class='user-content'>
+{{#if canInviteToForum}}
+  <section class='user-content'>
 
-  <h2>{{i18n user.invited.title}}</h2>
+    <h2>{{i18n user.invited.title}}</h2>
 
-  <div class="pull-right">
-    {{#if canInviteToForum}}
+    <div class="pull-right">
       <button {{action showInvite}} class='btn'>{{i18n user.invited.create}}</button>
-    {{/if}}
-    {{#if canBulkInvite}}
-      {{resumable-upload target="/invites/upload" success="uploadSuccess" error="uploadError" uploadText=uploadText}}
-    {{/if}}
-  </div>
+      {{#if canBulkInvite}}
+        {{resumable-upload target="/invites/upload" success="uploadSuccess" error="uploadError" uploadText=uploadText}}
+      {{/if}}
+    </div>
 
-  {{#if showSearch}}
-  <form>
-    {{text-field value=searchTerm placeholderKey="user.invited.search"}}
-  </form>
-  {{/if}}
+    {{#if showSearch}}
+      <form>
+        {{text-field value=searchTerm placeholderKey="user.invited.search"}}
+      </form>
+    {{/if}}
 
-  {{#if model.invites}}
-    <table class='table'>
-      <tr>
-        <th>{{i18n user.invited.user}}</th>
-        <th>{{i18n user.invited.redeemed_at}}</th>
-        {{#if can_see_invite_details}}
-          <th>{{i18n user.last_seen}}</th>
-          <th>{{i18n user.invited.topics_entered}}</th>
-          <th>{{i18n user.invited.posts_read_count}}</th>
-          <th>{{i18n user.invited.time_read}}</th>
-          <th>{{i18n user.invited.days_visited}}</th>
-        {{/if}}
-      </tr>
-      {{#each invite in model.invites}}
+    {{#if model.invites}}
+      <table class='table'>
         <tr>
-          {{#if invite.user}}
-            <td>
-              {{#link-to 'user' invite.user}}{{avatar invite.user imageSize="tiny"}}{{/link-to}}
-              {{#link-to 'user' invite.user}}{{invite.user.username}}{{/link-to}}
-            </td>
-            <td>{{date invite.redeemed_at}}</td>
-            {{#if can_see_invite_details}}
-              <td>{{date invite.user.last_seen_at}}</td>
-              <td>{{number invite.user.topics_entered}}</td>
-              <td>{{number invite.user.posts_read_count}}</td>
-              <td>{{{unbound invite.user.time_read}}}</td>
-              <td><span title="{{i18n user.invited.days_visited}}">{{{unbound invite.user.days_visited}}}</span>
-                  /
-                <span title="{{i18n user.invited.account_age_days}}">{{{unbound invite.user.days_since_created}}}</span></td>
-            {{/if}}
-          {{else}}
-            <td>{{unbound invite.email}}</td>
-            <td colspan='6'>
-              {{#if invite.expired}}
-                {{i18n user.invited.expired}}
-              {{/if}}
-              {{#if invite.rescinded}}
-                {{i18n user.invited.rescinded}}
-              {{else}}
-                <button class='btn' {{action rescind invite}}><i class="fa fa-times"></i>{{i18n user.invited.rescind}}</button>
-              {{/if}}
-            </td>
+          <th>{{i18n user.invited.user}}</th>
+          <th>{{i18n user.invited.redeemed_at}}</th>
+          {{#if can_see_invite_details}}
+            <th>{{i18n user.last_seen}}</th>
+            <th>{{i18n user.invited.topics_entered}}</th>
+            <th>{{i18n user.invited.posts_read_count}}</th>
+            <th>{{i18n user.invited.time_read}}</th>
+            <th>{{i18n user.invited.days_visited}}</th>
           {{/if}}
         </tr>
-      {{/each}}
-    </table>
+        {{#each invite in model.invites}}
+          <tr>
+            {{#if invite.user}}
+              <td>
+                {{#link-to 'user' invite.user}}{{avatar invite.user imageSize="tiny"}}{{/link-to}}
+                {{#link-to 'user' invite.user}}{{invite.user.username}}{{/link-to}}
+              </td>
+              <td>{{date invite.redeemed_at}}</td>
+              {{#if can_see_invite_details}}
+                <td>{{date invite.user.last_seen_at}}</td>
+                <td>{{number invite.user.topics_entered}}</td>
+                <td>{{number invite.user.posts_read_count}}</td>
+                <td>{{{unbound invite.user.time_read}}}</td>
+                <td><span title="{{i18n user.invited.days_visited}}">{{{unbound invite.user.days_visited}}}</span>
+                    /
+                  <span title="{{i18n user.invited.account_age_days}}">{{{unbound invite.user.days_since_created}}}</span></td>
+              {{/if}}
+            {{else}}
+              <td>{{unbound invite.email}}</td>
+              <td colspan='6'>
+                {{#if invite.expired}}
+                  {{i18n user.invited.expired}}
+                {{/if}}
+                {{#if invite.rescinded}}
+                  {{i18n user.invited.rescinded}}
+                {{else}}
+                  <button class='btn' {{action rescind invite}}><i class="fa fa-times"></i>{{i18n user.invited.rescind}}</button>
+                {{/if}}
+              </td>
+            {{/if}}
+          </tr>
+        {{/each}}
+      </table>
 
-    {{#if truncated}}
-      <p>{{i18n user.invited.truncated count=maxInvites}}</p>
+      {{#if truncated}}
+        <p>{{i18n user.invited.truncated count=maxInvites}}</p>
+      {{/if}}
+
+    {{else}}
+      {{#if canBulkInvite}}
+        {{{i18n user.invited.bulk_invite.none}}}
+      {{else}}
+        {{i18n user.invited.none}}
+      {{/if}}
     {{/if}}
 
-  {{else}}
-    {{{i18n user.invited.none}}}
-  {{/if}}
-
-</section>
+  </section>
+{{/if}}

--- a/app/assets/javascripts/discourse/templates/user/user.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/user/user.js.handlebars
@@ -134,7 +134,9 @@
             {{#link-to 'preferences' class="btn right"}}<i class='fa fa-cog'></i>{{i18n user.preferences}}{{/link-to}}
           {{/if}}
 
-          {{#link-to 'user.invited' class="btn right"}}<i class='fa fa-envelope-o'></i>{{i18n user.invited.title}}{{/link-to}}
+          {{#if canInviteToForum}}
+            {{#link-to 'user.invited' class="btn right"}}<i class='fa fa-envelope-o'></i>{{i18n user.invited.title}}{{/link-to}}
+          {{/if}}
 
         </section>
       </section>

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -403,7 +403,7 @@ en:
         search: "type to search invites..."
         title: "Invites"
         user: "Invited User"
-        none: "You haven't invited anyone here yet. You can send individual invites, or invite a bunch of people at once by <a href='https://meta.discourse.org/t/send-bulk-invites/16468'>uploading a bulk invite file</a>."
+        none: "You haven't invited anyone here yet."
         truncated: "Showing the first {{count}} invites."
         redeemed: "Redeemed Invites"
         redeemed_at: "Redeemed"
@@ -418,6 +418,7 @@ en:
         account_age_days: "Account age in days"
         create: "Send an Invite"
         bulk_invite:
+          none: "You haven't invited anyone here yet. You can send individual invites, or invite a bunch of people at once by <a href='https://meta.discourse.org/t/send-bulk-invites/16468'>uploading a bulk invite file</a>."
           text: "Bulk Invite from File"
           uploading: "UPLOADING"
           success: "File uploaded successfully, you will be notified shortly with progress."


### PR DESCRIPTION
Currently the Invites link and Invites tab content does not take User Trust Level into account. This PR does following changes:
- Trust Level 0 and 1 users will not see Invites link, and even if they try to access Invites section with URL, the content will not be shown.

![screen shot 2014-06-15 at 00 21 15](https://cloud.githubusercontent.com/assets/5732281/3279315/852395c0-f3f5-11e3-94bc-728bc451a316.png)
- Trust Level 2 and above will see Invites link and content, but they will not see extended message for Bulk Invite feature.

![screen shot 2014-06-15 at 00 09 06](https://cloud.githubusercontent.com/assets/5732281/3279313/851b1828-f3f5-11e3-8703-fb4fecda20cd.png)
- Only Admins will be able to see extended message for Bulk Invite feature.

![screen shot 2014-06-15 at 00 09 53](https://cloud.githubusercontent.com/assets/5732281/3279314/851f3eb2-f3f5-11e3-9e2f-e621a692453d.png)

cc @coding-horror, @nlalonde 
