### PR TITLE
Admin User-IP locator

### DIFF
--- a/app/assets/javascripts/admin/templates/ip_locator.js.handlebars
+++ b/app/assets/javascripts/admin/templates/ip_locator.js.handlebars
@@ -1,0 +1,54 @@
+{{#if view.ip}}
+<button class='btn' {{action lookup target="view"}}>
+  <span class="fa fa-globe"></span> {{i18n admin.user.ip_lookup}}
+</button>
+{{/if}}
+{{#if view.showBox }}
+  <div class="location-box">
+    <h4>{{i18n ip_info.title}}</h4>
+    <dl>
+      {{#if view.location}}
+        {{#if view.location.hostname}}
+          <dt>{{i18n ip_info.hostname}}</dt>
+          <dd>{{view.location.hostname}}</dd>
+        {{/if}}
+
+        <dt>{{i18n ip_info.location}}</dt>
+        <dd>
+          {{#if view.location.loc}}
+            <a href="https://maps.google.com/maps?q={{unbound view.location.loc}}" target="_blank">{{view.location.loc}}</a><br>
+            {{view.location.city}}, {{view.location.region}}, {{view.location.country}}
+          {{else}}
+            {{i18n ip_info.location_not_found}}
+          {{/if}}
+        </dd>
+
+        {{#if view.location.org}}
+          <dt>{{i18n ip_info.organisation}}</dt>
+          <dd>{{view.location.org}}</dd>
+        {{/if}}
+
+        {{#if view.location.phone}}
+          <dt>{{i18n ip_info.phone}}</dt>
+          <dd>{{view.location.phone}}</dd>
+        {{/if}}
+      {{else}}
+        <div class='spinner'>{{i18n loading}}</div>
+      {{/if}}
+
+      <dt>{{i18n ip_info.other_accounts}}</dt>
+      <dd>
+        {{#if view.other_accounts_loading}}
+          {{i18n loading}}
+        {{else}}
+          {{#each view.other_accounts}}
+              {{#link-to 'adminUser' this}}{{avatar this usernamePath="user.username" imageSize="small"}}{{/link-to}}
+          {{else}}
+            {{i18n ip_info.no_other_accounts}}
+          {{/each}}
+        {{/if}}
+      <dd>
+    </dl>
+    <button class='btn close' {{action hideBox target="view" }}>{{i18n close}}</button>
+  </div>
+{{/if}}

--- a/app/assets/javascripts/admin/templates/user_index.js.handlebars
+++ b/app/assets/javascripts/admin/templates/user_index.js.handlebars
@@ -79,6 +79,7 @@
       <button class='btn' {{action refreshBrowsers target="content"}}>
         {{i18n admin.user.refresh_browsers}}
       </button>
+        {{view Discourse.AdminIpLocatorView ipBinding="ip_address"}}
       {{/if}}
     </div>
   </div>
@@ -86,7 +87,11 @@
   <div class='display-row'>
     <div class='field'>{{i18n user.registration_ip_address.title}}</div>
     <div class='value'>{{registration_ip_address}}</div>
-    <div class='controls'></div>
+    <div class='controls'>
+      {{#if currentUser.admin}}
+        {{view Discourse.AdminIpLocatorView ipBinding="registration_ip_address"}}
+      {{/if}}
+    </div>
   </div>
 
   {{#if showBadges}}

--- a/app/assets/javascripts/admin/views/admin_ip_locator_view.js
+++ b/app/assets/javascripts/admin/views/admin_ip_locator_view.js
@@ -1,0 +1,29 @@
+Discourse.AdminIpLocatorView = Discourse.View.extend({
+  templateName: 'admin/templates/ip_locator',
+  classNames: ["iplocator"],
+  actions: {
+    hideBox: function(){
+        this.set("showBox", false);
+    },
+    lookup: function(){
+      if (!this.get("location")){
+          $.get("http://ipinfo.io/" + this.get("ip"), function(response) {
+              this.set("location", response);
+          }.bind(this), "jsonp");
+      }
+
+      if (!this.get("other_accounts")){
+        this.set("other_accounts_loading", true);
+        Discourse.ajax("/admin/users/list/active.json", {
+                data: {"ip": this.get("ip"),
+                       "exclude": this.get("controller.id")
+                      }
+            }).then(function (users) {
+                this.set("other_accounts", users.map(function(u) { return Discourse.AdminUser.create(u);}));
+                this.set("other_accounts_loading", false);
+            }.bind(this));
+      }
+      this.set("showBox", true);
+    }
+  }
+});

--- a/app/assets/stylesheets/common/admin/admin_base.scss
+++ b/app/assets/stylesheets/common/admin/admin_base.scss
@@ -81,6 +81,25 @@
   };
 }
 
+.iplocator {
+  position: relative;
+  display: inline-block;
+
+  .location-box {
+    position: absolute;
+    width: 460px;
+    right: 0px;
+    z-index: 990;
+    box-shadow: 0 2px 6px scale-color-diff();
+    margin-top: -2px;
+    background-color: $secondary;
+    padding: 12px 12px 5px;
+    .close {
+      float: right;
+    }
+  }
+}
+
 .admin-container {
   margin-top: 20px;
 }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -238,6 +238,16 @@ en:
         one: "%{count} new post in the past %{unit}."
         other: "%{count} new posts in the past %{unit}."
 
+    ip_info:
+      title: ip_info_title
+      hostname: ip_info_hostname
+      location: ip_info_location
+      location_not_found: ip_info_location_not_found
+      organisation: ip_info_organisation
+      phone: ip_info_phone
+      other_accounts: ip_info_other_accounts
+      no_other_accounts: ip_info_no_other_accounts
+
     user:
       said: "{{username}} said:"
       profile: "Profile"
@@ -1713,6 +1723,7 @@ en:
         refresh_browsers: "Force browser refresh"
         show_public_profile: "Show Public Profile"
         impersonate: 'Impersonate'
+        ip_lookup: "ip_lookup"
         log_out: "Sign Out"
         logged_out: "User was logged out on all devices"
         revoke_admin: 'Revoke Admin'

--- a/lib/admin_user_index_query.rb
+++ b/lib/admin_user_index_query.rb
@@ -40,6 +40,19 @@ class AdminUserIndexQuery
     end
   end
 
+
+  def filter_by_ip
+    if params[:ip].present?
+      @query.where('ip_address = :ip or registration_ip_address = :ip', ip: params[:ip])
+    end
+  end
+
+  def filter_exclude
+    if params[:exclude].present?
+      @query.where('id != ?', params[:exclude])
+    end
+  end
+
   # this might not be needed in rails 4 ?
   def append(active_relation)
     @query = active_relation if active_relation
@@ -48,6 +61,8 @@ class AdminUserIndexQuery
   def find_users_query
     append filter_by_trust
     append filter_by_query_classification
+    append filter_by_ip
+    append filter_exclude
     append filter_by_search
     @query
   end


### PR DESCRIPTION
Implements the step 1-3 of the [Admin User-IP-Locator spec as discussed here](https://meta.discourse.org/t/add-ip-info-lookup-for-admins/15626):

![screen shot 2014-06-15 at 18 59 20](https://cloud.githubusercontent.com/assets/40496/3281475/4ca84190-f4af-11e3-8d19-4db7e54b44b4.png)

---

![screen shot 2014-06-15 at 18 58 27](https://cloud.githubusercontent.com/assets/40496/3281486/e20b9ce6-f4af-11e3-91d5-063ec4ba5007.png)

Details:
- when an IP given, with a click on the new "lookup" button the Admin can trigger an IP-Reverse look up
- uses ipinfo.io directly through jsonp (avoids round-trips)
- shows hostname, location and all known details (if found)
- automatically links long-lat to a google-maps link opening in a new window/tab
- looks up other users also using that IP and shows them under

Notes:
- misses copy-edit/translations (and therefore will probably fail the travis build)
- the "No Hostname" I receive back from ipinfo as a value
