### PR TITLE
Fix relative URLs in plain text emails

### DIFF
--- a/lib/email/sender.rb
+++ b/lib/email/sender.rb
@@ -47,6 +47,12 @@ module Email
       end
 
       @message.parts[0].body = @message.parts[0].body.to_s.gsub(/\[\/?email-indent\]/, '')
+      # Fix relative (ie upload) HTML links in markdown which do not work well in plain text emails.
+      # These are the links we add when a user uploads a file or image.
+      # Ideally we would parse general markdown into plain text, but that is almost an intractable problem.
+      url_prefix = Discourse.base_url
+      @message.parts[0].body = @message.parts[0].body.to_s.gsub(/<a class="attachment" href="(\/[^"]+)">([^<]*)<\/a>/, '[\2]('+url_prefix+'\1)')
+      @message.parts[0].body = @message.parts[0].body.to_s.gsub(/<img src="(\/[^"]+)"([^>]*)>/, '![]('+url_prefix+'\1)')
 
       @message.text_part.content_type = 'text/plain; charset=UTF-8'
 


### PR DESCRIPTION
When a user posts a message containing an image or file, JavaScript includes the file using a relative URL inside either an <a> or <img> HTML tag.

It could use a Markdown tag, but it doesn't.  In any event, the HTML is jarring in the plain text email and the relative URL (just a path really) is useless.

Ideally, we would parse the markdown to plain text, but since markdown can contain any HTML, that would require redering as HTML and then extracting the text which is a lot of work for something few people will see.

Instead, this simple patch just converts the links that the Upload JavaScript inserted into full URL relatively readable markdown links.