### PR TITLE
Plugin-Outlets-defaults for template overriding

### DIFF
--- a/app/assets/javascripts/discourse/helpers/plugin-outlet.js.es6
+++ b/app/assets/javascripts/discourse/helpers/plugin-outlet.js.es6
@@ -83,5 +83,15 @@ export default function(connectionName, options) {
       })
     });
     return Ember.Handlebars.helpers.view.call(this, CustomContainerView, options);
+  } else {
+    return Ember.Handlebars.helpers.view.call(this,
+              Ember.View.extend({
+                isVirtual: true,
+                tagName: '',
+                template: function() {
+                  return options.hash.template;
+                }.property()
+              }),
+            options);
   }
 }


### PR DESCRIPTION
This PR extends plugin-outlets to provide support for yielding template data to be rendered if no plugin is using that slot. 

Therefore acting as a fall-back or default behaviour unless a plugin explicitly overwrites it. It uses the same template syntax known and used for components already. A plugin-outlet with a default rendering would look like this:

``` handlebars
{{#plugin-outlet "outlet-name"}}
<label>Default Content</label>
{{/plugin-outlet}}
```

By wrapping parts of the existing UI into these new outlet-formats we can allow plugins to overwrite existing parts of the UI to not only add (like before) but replace existing behavior. One example I am using that at is for the [questions archetype plugin](https://github.com/ligthyear/discourse-plugin-questions) to allow that [to overwrite the composer-title](https://github.com/ligthyear/discourse-plugin-questions/blob/master/assets/javascripts/discourse/templates/connectors/composer-open-title/selectable_archetype.js.handlebars) for archetype selection. Thus after applying patch at the end, by activating the plugin this:

![screen shot 2014-06-16 at 15 03 07](https://cloud.githubusercontent.com/assets/40496/3287546/58e9e9ea-f559-11e3-8923-63c876385caa.png)

will become

![screen shot 2014-06-16 at 15 02 53](https://cloud.githubusercontent.com/assets/40496/3287552/61ebc98c-f559-11e3-945b-b5d31587cd5f.png)

And by just deactivating the plugin it will revert to the old state.

Details:
- allows passing of template data to the plugin-outlet to be rendered if no plugin is using that slot
- acts as a fallback when no plugin is found
- allows wrapping of existing features inside a plugin-outlet that then plugins can overwrite with their own behavior
- backwards compatible
- uses invisible ember views (as Ember.Component does)
- the template has full-access to the controller and view, should be totally transparent
- with this added, HAQL is completely obsolete

---

Example Patch:

``` diff
diff --git a/app/assets/javascripts/discourse/templates/composer.js.handlebars b/app/assets/javascripts/discourse/templates/composer.js.handlebars
index 1911ddd..1edc9b7 100644
--- a/app/assets/javascripts/discourse/templates/composer.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/composer.js.handlebars
@@ -12,7 +12,9 @@
         {{plugin-outlet "composer-open"}}

         <div class='reply-to'>
-          {{{model.actionTitle}}}:
+          {{#plugin-outlet "composer-open-title"}}
+            {{{model.actionTitle}}}:
+          {{/plugin-outlet}}
           {{#if canEdit}}
             {{#if showEditReason}}
               <div class="edit-reason-input">
```
