### PR TITLE
DEBUG: Send all email processing errors to admins

### DIFF
--- a/app/mailers/rejection_mailer.rb
+++ b/app/mailers/rejection_mailer.rb
@@ -4,7 +4,7 @@ class RejectionMailer < ActionMailer::Base
   include Email::BuildEmailHelper
 
   def send_rejection(from, body)
-    build_email(from, template: 'email_reject_notification', from: from, body: body)
+    build_email(from, template: 'email_error_notification', from: from, body: body)
   end
 
   def send_trust_level(from, body, to)


### PR DESCRIPTION
Let's just do this for now.

Also, fixed a localization typo in a method that is never called. Will probably be called from the replacement for this GroupMessage code once we figure out the backscatter problem.
