### PR TITLE
Add a SiteSetting to control the pop3 polling period.

### DIFF
--- a/app/jobs/scheduled/poll_mailbox.rb
+++ b/app/jobs/scheduled/poll_mailbox.rb
@@ -8,7 +8,7 @@ require_dependency 'email/message_builder'
 
 module Jobs
   class PollMailbox < Jobs::Scheduled
-    every 5.minutes
+    every SiteSetting.pop3s_polling_period_mins.minutes
     sidekiq_options retry: false
     include Email::BuildEmailHelper
 

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -854,6 +854,7 @@ en:
 
     pop3s_polling_enabled: "Poll via POP3S for email replies"
     pop3s_polling_insecure: "Poll using plain text POP3 without SSL"
+    pop3s_polling_period_mins: "The period in minutes between checking the POP3S account for email"
     pop3s_polling_port: "The port to poll a POP3S account on"
     pop3s_polling_host: "The host to poll for email via POP3S"
     pop3s_polling_username: "The username for the POP3S account to poll for email"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -348,6 +348,7 @@ email:
   reply_by_email_address: ''
   pop3s_polling_enabled: false
   pop3s_polling_insecure: false
+  pop3s_polling_period_mins: 5
   pop3s_polling_host: ''
   pop3s_polling_port: 995
   pop3s_polling_username: ''


### PR DESCRIPTION
The default 5 minutes may add too much lag for some sites used to mailing list performance.

Unfortunately, this seems to require restarting the server for the change to be noticed - is there any way to avoid that, or otherwise should this be noted in the setting text?
