### PR TITLE
horizontal scroll on search dropdown be gone!

### DIFF
--- a/app/assets/stylesheets/common/base/header.scss
+++ b/app/assets/stylesheets/common/base/header.scss
@@ -231,7 +231,7 @@
   }
 
   input[type='text'] {
-    width: 298px;
+    width: 93%;
     height: 22px;
     margin: 5px;
     padding: 5px;


### PR DESCRIPTION
scrollbars hate him! this one weird trick can... :scroll: 

The search box needs to be flexible to accommodate for the vertical scrollbar when present, otherwise the horizontal scrollbar will appear to house the full width of the search box (the other text breaks naturally).  
