### PR TITLE
FEATURE: Add groups support to Bulk Invite

### DIFF
--- a/spec/jobs/bulk_invite_spec.rb
+++ b/spec/jobs/bulk_invite_spec.rb
@@ -17,12 +17,14 @@ describe Jobs::BulkInvite do
     end
 
     context '.read_csv_file' do
+      let(:user) { Fabricate(:user) }
       let(:bulk_invite) { Jobs::BulkInvite.new }
       let(:csv_file) { File.new("#{Rails.root}/spec/fixtures/csv/discourse.csv") }
-      let(:user) { Fabricate(:user) }
 
       it 'reads csv file' do
-        bulk_invite.read_csv_file(csv_file, user)
+        bulk_invite.current_user = user
+        bulk_invite.read_csv_file(csv_file)
+        Invite.where(email: 'robin@outlook.com').exists?.should be_true
       end
     end
 
@@ -33,7 +35,8 @@ describe Jobs::BulkInvite do
       let(:email) { "evil@trout.com" }
 
       it 'creates an invite to the group' do
-        bulk_invite.send_invite_with_groups(email, group.name, user, 1)
+        bulk_invite.current_user = user
+        bulk_invite.send_invite_with_groups(email, group.name, 1)
         invite = Invite.where(email: email).first
         invite.should be_present
         InvitedGroup.where(invite_id: invite.id, group_id: group.id).exists?.should be_true
@@ -46,7 +49,8 @@ describe Jobs::BulkInvite do
       let(:email) { "evil@trout.com" }
 
       it 'creates an invite' do
-        bulk_invite.send_invite_without_group(email, user)
+        bulk_invite.current_user = user
+        bulk_invite.send_invite_without_group(email)
         Invite.where(email: email).exists?.should be_true
       end
     end


### PR DESCRIPTION
This PR adds group(s) membership support in Bulk Invite feature. Admin can now invite user to single/multiple group(s) by adding semicolon separated group names in second column, eg:

![screen shot 2014-06-25 at 04 07 55](https://cloud.githubusercontent.com/assets/5732281/3379342/4bfc5c48-fbf0-11e3-809e-84646a798dfd.png)

If the group name is incorrect and doesn't exist in database, a PM notification will be sent to Admin:

![screen shot 2014-06-25 at 03 19 38](https://cloud.githubusercontent.com/assets/5732281/3379347/74e19bb4-fbf0-11e3-878f-5015be9eca59.png)

The group name(s) must be entered in second column, in semicolon separated format, else user will not be added to group.

TODO:
- Update [how-to](https://meta.discourse.org/t/send-bulk-invites/16468) to reflect this change.

cc @sam, @eviltrout
