### PR TITLE
FIX: show search filter only when invites are greater than or equal to ten

### DIFF
--- a/app/assets/javascripts/discourse/controllers/user-invited.js.es6
+++ b/app/assets/javascripts/discourse/controllers/user-invited.js.es6
@@ -58,9 +58,7 @@ export default Ember.ObjectController.extend({
 
     @property showSearch
   **/
-  showSearch: function() {
-    return !(Em.isNone(this.get('searchTerm')) && this.get('invites.length') === 0);
-  }.property('searchTerm', 'invites.length'),
+  showSearch: Em.computed.gte('invites.length', 10),
 
   /**
     Were the results limited by our `maxInvites`


### PR DESCRIPTION
Suppress invites search filter when invites are less than ten. cc @coding-horror
