### PR TITLE
Fix Plugin-Outlets: remove block from views so Ember doesn't complain

### DIFF
--- a/app/assets/javascripts/discourse/helpers/plugin-outlet.js.es6
+++ b/app/assets/javascripts/discourse/helpers/plugin-outlet.js.es6
@@ -103,6 +103,7 @@ export default function(connectionName, options) {
     } else {
       view = childViews[0];
     }
+    delete options.fn;  // we don't need the default template since we have a connector
     return Ember.Handlebars.helpers.view.call(this, view, options);
   } else if (options.fn) {
 


### PR DESCRIPTION
When you are adding a plugin-outlet with a block like `{{#plugin-outlet blockname}}<h1>hello</h2>{{/plugin-outlet}}` and have a plugin overwrite it Ember complains saying `You cannot provide a template block if you also specified a templateName` and stops the entire application.

This patch removes the block-function in case we've found ourself replacing it with a view to prevent ember from complaining both are given.
