### PR TITLE
Add imagemagick to basic setup apt-get install.

### DIFF
--- a/docs/DEVELOPER-ADVANCED.md
+++ b/docs/DEVELOPER-ADVANCED.md
@@ -57,7 +57,7 @@ Vagrant version 1.1.2. With this Vagrantfile:
     ln -sf /usr/share/zoneinfo/Canada/Eastern /etc/localtime
     apt-get -yqq update
     apt-get -yqq install python-software-properties
-    apt-get -yqq install vim curl expect debconf-utils git-core build-essential zlib1g-dev libssl-dev openssl libcurl4-openssl-dev libreadline6-dev libpcre3 libpcre3-dev
+    apt-get -yqq install vim curl expect debconf-utils git-core build-essential zlib1g-dev libssl-dev openssl libcurl4-openssl-dev libreadline6-dev libpcre3 libpcre3-dev imagemagick
 
 ## Unicode
 


### PR DESCRIPTION
Imagemagick is mentioned in the "first steps" section, but it's not actually listed anywhere in an `apt-get install` statements, which makes it easy to forget about, so I added it to the last such statement at the end of the basic setup section.
