### PR TITLE
Update admin rake task

### DIFF
--- a/lib/tasks/admin.rake
+++ b/lib/tasks/admin.rake
@@ -1,24 +1,59 @@
 desc "Creates a forum administrator"
 task "admin:create" => :environment do
   require 'highline/import'
+
   begin
-    admin = User.new
-    admin.email = ask("Email:")
-    admin.username = "admin"
-    begin
-      password = ask("Password:") {|q| q.echo = false}
-      password_confirmation = ask("Repeat password:") {|q| q.echo = false}
-    end while password != password_confirmation
-    admin.password = password
-    # admin.email_confirmed = true
+    email = ask("Email:")
+    existing_user = User.find_by_email(email)
+
+    # check if user account already exixts
+    if !existing_user.nil?
+      # user already exists, ask for password reset
+      admin = existing_user
+      reset_password = ask("User with this email already exists! Do you want to reset the password for this email? Type 'Y' for Yes, 'N' for No.")
+      if (reset_password.downcase == 'y')
+        begin
+          password = ask("Password:") {|q| q.echo = false}
+          password_confirmation = ask("Repeat password:") {|q| q.echo = false}
+        end while password != password_confirmation
+        admin.password = password
+      end
+    else
+      # create new user
+      admin = User.new
+      admin.email = email
+      username_random = Random.new()
+      admin.username = "admin_#{username_random.rand(9999)}"
+      begin
+        password = ask("Password:") {|q| q.echo = false}
+        password_confirmation = ask("Repeat password:") {|q| q.echo = false}
+      end while password != password_confirmation
+      admin.password = password
+    end
+
+    # save/update user account
     saved = admin.save
     if !saved
       puts admin.errors.full_messages.join("\n")
       next
     end
   end while !saved
-  admin.grant_admin!
-  admin.change_trust_level!(TrustLevel.levels.max_by{|k, v| v}[0])
-  admin.email_tokens.update_all  confirmed: true
-  admin.activate
+
+  if !existing_user.nil?
+    say("\nAccount updated successfully!")
+  else
+    say("\nAccount created successfully with username #{admin.username}")
+  end
+
+  # grant admin privileges
+  reset_password = ask("Do you want to grant Admin privileges to this account? Type 'Y' for Yes, 'N' for No.")
+  if (reset_password.downcase == 'y')
+    admin.grant_admin!
+    admin.change_trust_level!(TrustLevel.levels.max_by{|k, v| v}[0])
+    admin.email_tokens.update_all  confirmed: true
+    admin.activate
+
+    say("\nYour account now has Admin privileges!")
+  end
+
 end


### PR DESCRIPTION
Updated `admin:create` task, this PR adds:
- Checks if the email already exists in database
- If email already exists, asks user if they want to update password
- Asks user if they want to grant admin privileges
- In case of new account, the username is generated randomly (exp. admin_2476), earlier the username was fixed `admin`, so this task was usable only once
- Added confirmations, so user knows exactly what is happening
