### PR TITLE
FEATURE: Send notification by system user for bulk invite

### DIFF
--- a/app/jobs/regular/bulk_invite.rb
+++ b/app/jobs/regular/bulk_invite.rb
@@ -112,9 +112,9 @@ module Jobs
     def notify_user
       if @current_user
         if (@sent > 0 && @failed == 0)
-          SystemMessage.create(@current_user, :bulk_invite_succeeded, sent: @sent)
+          SystemMessage.create_from_system_user(@current_user, :bulk_invite_succeeded, sent: @sent)
         else
-          SystemMessage.create(@current_user, :bulk_invite_failed, sent: @sent, failed: @failed, logs: @logs.join("\n"))
+          SystemMessage.create_from_system_user(@current_user, :bulk_invite_failed, sent: @sent, failed: @failed, logs: @logs.join("\n"))
         end
       end
     end

--- a/lib/system_message.rb
+++ b/lib/system_message.rb
@@ -9,6 +9,10 @@ class SystemMessage
     self.new(recipient).create(type, params)
   end
 
+  def self.create_from_system_user(recipient, type, params = {})
+    self.new(recipient).create_from_system_user(type, params)
+  end
+
   def initialize(recipient)
     @recipient = recipient
   end
@@ -20,6 +24,20 @@ class SystemMessage
     raw = I18n.t("system_messages.#{type}.text_body_template", params)
 
     PostCreator.create(Discourse.site_contact_user,
+                       title: title,
+                       raw: raw,
+                       archetype: Archetype.private_message,
+                       target_usernames: @recipient.username,
+                       subtype: TopicSubtype.system_message)
+  end
+
+  def create_from_system_user(type, params = {})
+    params = defaults.merge(params)
+
+    title = I18n.t("system_messages.#{type}.subject_template", params)
+    raw = I18n.t("system_messages.#{type}.text_body_template", params)
+
+    PostCreator.create(Discourse.system_user,
                        title: title,
                        raw: raw,
                        archetype: Archetype.private_message,


### PR DESCRIPTION
Until now the notification message for bulk invite progress was sent by site contact user. This means that if site contact user himself tried to sent bulk invites, he will not get progress notifications.

Now the bulk invite progress notification will be sent by `system` user, so the Admin will receive notification message in all cases.

cc @coding-horror
