### PR TITLE
FEATURE: support txt file to be uploaded for bulk invite

### DIFF
--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -71,7 +71,7 @@ class InvitesController < ApplicationController
     guardian.ensure_can_bulk_invite_to_forum!(current_user)
 
     filename = params.fetch(:resumableFilename)
-    return render status: 415, text: I18n.t("bulk_invite.file_should_be_csv") unless filename.to_s.end_with?(".csv")
+    return render status: 415, text: I18n.t("bulk_invite.file_should_be_csv") unless (filename.to_s.end_with?(".csv") || filename.to_s.end_with?(".txt"))
 
     file               = params.fetch(:file)
     identifier         = params.fetch(:resumableIdentifier)

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -40,7 +40,7 @@ en:
       load_from_remote: "There was an error loading that post."
 
   bulk_invite:
-    file_should_be_csv: "The uploaded file should be of csv format."
+    file_should_be_csv: "The uploaded file should be of csv or txt format."
 
   backup:
     operation_already_running: "An operation is currently running. Can't start a new job right now."


### PR DESCRIPTION
This PR adds support for 'txt' file to be uploaded for sending out bulk invitations. cc @coding-horror
