### PR TITLE
background on topic-list, more width on extra-info-wrapper, meta viewport fix

### DIFF
--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -18,6 +18,7 @@
   border-collapse: separate;
   border-spacing: 0;
   border-top: 1px solid scale-color-diff();
+  background: rgba($secondary, .8);
 
   > tbody > tr {
     &:nth-child(even) {

--- a/app/assets/stylesheets/common/foundation/base.scss
+++ b/app/assets/stylesheets/common/foundation/base.scss
@@ -11,7 +11,15 @@ html {
   background-color: $secondary;
   overflow-y: scroll;
   -webkit-font-smoothing: subpixel-antialiased;
-}
+  height: 100%;
+  body {
+    height: 100%;
+    #main {
+      height: 100%; 
+      }
+    }
+  }
+
 
 // Links
 // --------------------------------------------------

--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -537,10 +537,9 @@ iframe {
 
 .extra-info-wrapper {
   float: left;
-  width: 78%;
-  max-width: 800px;
+  max-width: 875px;
   .topic-statuses {
-    i         { color: $header_primary; }
+            i { color: $header_primary; }
     .unpinned { color: $header_primary; }
   }
   .topic-link { color: $header_primary; }
@@ -549,14 +548,14 @@ iframe {
 
 @include medium-width {
   .extra-info-wrapper {
-  max-width: 740px;
+  max-width: 770px;
 }
 }
 
 
 @include small-width {
     .extra-info-wrapper {
-  max-width: 680px;
+  max-width: 720px;
 }
 }
 
@@ -564,7 +563,7 @@ iframe {
   h1 {
     margin: 5px 0 0 0;
     font-size: 1.6em;
-    line-height: 1.2em;
+    line-height: 1.3em;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -1,5 +1,6 @@
 
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, user-scalable=yes, minimum-scale=0.75, maximum-scale=3.0" />
+
     <meta name="author" content="">
     <meta name="generator" content="Discourse <%= Discourse::VERSION::STRING %> - https://github.com/discourse/discourse version <%= Discourse.git_version %>">
 


### PR DESCRIPTION
- background on topic-list (matches primary background) so category background images don't render topic pages unreadable
- added more width to the extra-info-wrapper so there's less title white space on the right
- changed meta viewport to solve issue discussed here https://meta.discourse.org/t/zooming-and-initial-display-with-portrait-orientation-on-ipad/16814
