### PR TITLE
fixing a handful of issues

### DIFF
--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -18,6 +18,7 @@
   border-collapse: separate;
   border-spacing: 0;
   border-top: 1px solid scale-color-diff();
+  background: rgba($secondary, .8);
 
   > tbody > tr {
     &:nth-child(even) {

--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -538,8 +538,7 @@ iframe {
 
 .extra-info-wrapper {
   float: left;
-  width: 78%;
-  max-width: 800px;
+  max-width: 875px;
   .topic-statuses {
     i         { color: $header_primary; }
     .unpinned { color: $header_primary; }
@@ -550,14 +549,14 @@ iframe {
 
 @include medium-width {
   .extra-info-wrapper {
-  max-width: 740px;
+  max-width: 770px;
 }
 }
 
 
 @include small-width {
     .extra-info-wrapper {
-  max-width: 680px;
+  max-width: 720px;
 }
 }
 
@@ -565,7 +564,7 @@ iframe {
   h1 {
     margin: 5px 0 0 0;
     font-size: 1.6em;
-    line-height: 1.2em;
+    line-height: 1.3em;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/app/assets/stylesheets/desktop/topic.scss
+++ b/app/assets/stylesheets/desktop/topic.scss
@@ -131,6 +131,7 @@ a:hover.reply-new {
       height: 20px;
       text-align: center;
       margin-bottom: 0;
+      font-size: 16px;
     }
     button.btn {
       float: right;

--- a/app/assets/stylesheets/mobile/topic.scss
+++ b/app/assets/stylesheets/mobile/topic.scss
@@ -90,6 +90,7 @@
       width: 45px;
       height: 20px;
       text-align: center;
+      font-size: 16px;
     }
     button.btn {
       float: right !important;

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -1,5 +1,5 @@
 
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, user-scalable=yes, minimum-scale=0.75, maximum-scale=3.0" />
     <meta name="author" content="">
     <meta name="generator" content="Discourse <%= Discourse::VERSION::STRING %> - https://github.com/discourse/discourse version <%= Discourse.git_version %>">
 


### PR DESCRIPTION
- background on topic-list (matches primary background) so category background images don't render topic pages unreadable
- added more width to the extra-info-wrapper so there's less title white space on the right
- changed meta viewport to solve issue discussed here https://meta.discourse.org/t/zooming-and-initial-display-with-portrait-orientation-on-ipad/16814
- bumping up font size on topic-progress input to solve for https://meta.discourse.org/t/android-input-focus-cause-zoom/17113/3
