### PR TITLE
Added a link to the configuring SSO thread.

### DIFF
--- a/docs/INSTALL-digital-ocean.md
+++ b/docs/INSTALL-digital-ocean.md
@@ -150,6 +150,8 @@ Commands:
 
 Do you want...
 
+* Users to log in *only* via your pre-existing website's registration system? [Configure Single-Sign-On](https://meta.discourse.org/t/official-single-sign-on-for-discourse/13045).
+
 - Users to log in via Google? (new Oauth2 authentication) [Configure Google logins](https://meta.discourse.org/t/configuring-google-login-for-discourse/15858).
 
 - Users to log in via Facebook? [Configure Facebook logins](https://meta.discourse.org/t/configuring-facebook-login-for-discourse/13394).


### PR DESCRIPTION
Lots of folks who want SSO might not realize it's supported by Discourse out-of-the-box, so I linked to the appropriate thread on the meta forum.
