### PR TITLE
FEATURE: show Invite button to admin for private topics

### DIFF
--- a/app/assets/javascripts/discourse/views/topic-footer-buttons.js.es6
+++ b/app/assets/javascripts/discourse/views/topic-footer-buttons.js.es6
@@ -22,7 +22,7 @@ export default Discourse.ContainerView.extend({
     if (Discourse.User.current()) {
       if (!topic.get('isPrivateMessage')) {
         // We hide some controls from private messages
-        if (this.get('topic.details.can_invite_to') && !this.get('topic.category.read_restricted')) {
+        if (this.get('topic.details.can_invite_to') && (!this.get('topic.category.read_restricted') || Discourse.User.currentProp('admin'))) {
           this.attachViewClass(InviteReplyButton);
         }
         this.attachViewClass(StarButton);
@@ -44,5 +44,3 @@ export default Discourse.ContainerView.extend({
     }
   }
 });
-
-


### PR DESCRIPTION
Implemented first feature specified in [this post](https://meta.discourse.org/t/some-proposed-improvements-to-user-invites/17185/18).
