### PR TITLE
fixing title truncation issues in firefox

### DIFF
--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -310,14 +310,12 @@ nav.post-controls {
 }
 
 .bottom-round nav.post-controls .show-replies {
-background: scale-color-diff();
-margin-bottom: 0;
-padding-bottom: 8px;
+  background: scale-color-diff();
+  margin-bottom: 0;
+  padding-bottom: 8px;
   &:hover {background: scale-color-diff();
   }
 }
-
-
 
 .post-action {
   .relative-date {
@@ -538,25 +536,35 @@ iframe {
 
 .extra-info-wrapper {
   float: left;
-  max-width: 875px;
+  width: 76%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
   .topic-statuses {
     i         { color: $header_primary; }
     .unpinned { color: $header_primary; }
   }
-  .topic-link { color: $header_primary; }
+  .topic-link { color: $header_primary;
+  display: block;
+white-space: nowrap;
+overflow: hidden;
+text-overflow: ellipsis;
+
+  }
 }
 
 
 @include medium-width {
   .extra-info-wrapper {
-  max-width: 770px;
+  width: 73%;
 }
 }
 
 
 @include small-width {
     .extra-info-wrapper {
-  max-width: 720px;
+  width: 70%;
 }
 }
 
@@ -565,9 +573,6 @@ iframe {
     margin: 5px 0 0 0;
     font-size: 1.6em;
     line-height: 1.3em;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
 
   }
 
@@ -584,6 +589,8 @@ iframe {
   .badge-category {
     vertical-align: top;
     margin-top: 2px;
+    float: left;
+    margin-right: 5px;
   }
 
 }

--- a/app/assets/stylesheets/desktop/topic.scss
+++ b/app/assets/stylesheets/desktop/topic.scss
@@ -41,13 +41,16 @@
     line-height: 1.2em;
     overflow: hidden;
     a {color: $primary;}
-    a.badge-category { vertical-align: top; margin-top: 2px; }
+    a.badge-category {
+      float: left;
+      vertical-align: top;
+      margin-top: 2px;
+      margin-right: 5px;
+      }
     a.edit-topic { font-size: 15px; position: absolute; margin-left: 8px; }
   }
   .topic-statuses {
     margin-top: -2px;
-    .fa-thumb-tack { padding-left: 3px;
- }
 
   }
   .select2-container {


### PR DESCRIPTION
- titles no longer truncate prematurely
- the lock/pin should align properly now

the max-width differences between browsers is suuuuuper annoying :rainbow: 
