### PR TITLE
Mobile: Fix parts of reply panel out of viewport

### DIFF
--- a/app/assets/stylesheets/mobile/compose.scss
+++ b/app/assets/stylesheets/mobile/compose.scss
@@ -86,6 +86,7 @@ display: none;
   }
   // The various states
   &.open {
+    max-height: 100%; // ensure no overflow e.g. on small Android
     height: 270px;
   }
   &.closed {
@@ -155,6 +156,7 @@ display: none;
   // a small screen mobile device
   &.edit-title {
     &.open {
+      max-height: 100%; // ensure no overflow e.g. on small Android
       height: 250px;
     }
     .contents {


### PR DESCRIPTION
Fix not all content in reply panel visible due to panel overflowing on small Androids with keyboard up.

The bug presents itself on Chrome, e.g. on a 800x480 device (reported viewport width 320px), due to the URL bar chrome reappearing as the Reply panel opens (even if the URL bar was hidden before).
Even Chrome@Moto G (1280x720, viewport width 360px) has a bit of overflow.

![replypanelpartsinvisible](https://cloud.githubusercontent.com/assets/5316880/3490872/6b88e3cc-057f-11e4-81ce-65f6934ccefa.png)
