### PR TITLE
FEATURE: include topic context in topic invite

### DIFF
--- a/app/helpers/user_notifications_helper.rb
+++ b/app/helpers/user_notifications_helper.rb
@@ -1,5 +1,5 @@
 module UserNotificationsHelper
-  
+
   def self.sanitize_options
     return @sanitize_options if @sanitize_options
     @sanitize_options = Sanitize::Config::RELAXED.deep_dup

--- a/app/mailers/invite_mailer.rb
+++ b/app/mailers/invite_mailer.rb
@@ -9,11 +9,24 @@ class InviteMailer < ActionMailer::Base
 
     # If they were invited to a topic
     if first_topic.present?
+      # get invitee name (based on site setting)
+      invitee_name = invite.invited_by.username
+      if (SiteSetting.enable_names)
+        invitee_name = "#{invite.invited_by.name} (#{invite.invited_by.username})"
+      end
+
+      # get topic excerpt
+      topic_excerpt = ""
+      if first_topic.excerpt
+        topic_excerpt = first_topic.excerpt.gsub("\n", " ")
+      end
+
       build_email(invite.email,
                   template: 'invite_mailer',
-                  invitee_name: invite.invited_by.username,
+                  invitee_name: invitee_name,
                   invite_link: "#{Discourse.base_url}/invites/#{invite.invite_key}",
                   topic_title: first_topic.try(:title),
+                  topic_excerpt: topic_excerpt,
                   site_description: SiteSetting.site_description,
                   site_title: SiteSetting.title)
     else

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1051,7 +1051,9 @@ en:
     text_body_template: |
       %{invitee_name} invited you to a discussion
 
-      > %{topic_title}
+      > **%{topic_title}**
+      >
+      > %{topic_excerpt}
 
       at
 

--- a/spec/mailers/invite_mailer_spec.rb
+++ b/spec/mailers/invite_mailer_spec.rb
@@ -3,14 +3,62 @@ require "spec_helper"
 describe InviteMailer do
 
   describe "send_invite" do
-    let(:invite) { Fabricate(:invite) }
-    subject { InviteMailer.send_invite(invite) }
 
-    its(:to) { should == [invite.email] }
-    its(:subject) { should be_present }
-    its(:body) { should be_present }
-    its(:from) { should == [SiteSetting.notification_email] }
+    context "invite to site" do
+      let(:invite) { Fabricate(:invite) }
+      let(:invite_mail) { InviteMailer.send_invite(invite) }
+
+      it 'renders the invitee email' do
+        expect(invite_mail.to).to eql([invite.email])
+      end
+
+      it 'renders the subject' do
+        expect(invite_mail.subject).to be_present
+      end
+
+      it 'renders the body' do
+        expect(invite_mail.body).to be_present
+      end
+
+      it 'renders the inviter email' do
+        expect(invite_mail.from).to eql([SiteSetting.notification_email])
+      end
+
+      it 'renders invite link' do
+        expect(invite_mail.body.encoded).to match("#{Discourse.base_url}/invites/#{invite.invite_key}")
+      end
+    end
+
+    context "invite to topic" do
+      let(:topic) { Fabricate(:topic, excerpt: "Topic invite support is now available in Discourse!") }
+      let(:invite) { topic.invite(topic.user, 'name@example.com') }
+      let(:invite_mail) { InviteMailer.send_invite(invite) }
+
+      it 'renders the invitee email' do
+        expect(invite_mail.to).to eql(['name@example.com'])
+      end
+
+      it 'renders the subject' do
+        expect(invite_mail.subject).to be_present
+      end
+
+      it 'renders the body' do
+        expect(invite_mail.body).to be_present
+      end
+
+      it 'renders the inviter email' do
+        expect(invite_mail.from).to eql([SiteSetting.notification_email])
+      end
+
+      it 'renders invite link' do
+        expect(invite_mail.body.encoded).to match("#{Discourse.base_url}/invites/#{invite.invite_key}")
+      end
+
+      it 'renders topic title' do
+        expect(invite_mail.body.encoded).to match(topic.title)
+      end
+    end
+
   end
-
 
 end


### PR DESCRIPTION
Include topic context in topic invite mail. [Specified here](https://meta.discourse.org/t/improve-topic-invites/17184).
