### PR TITLE
BUGFIX: exception validating 'data-' attributes

### DIFF
--- a/app/assets/javascripts/discourse/lib/markdown.js
+++ b/app/assets/javascripts/discourse/lib/markdown.js
@@ -28,7 +28,7 @@ function validateAttribute(tagName, attribName, value) {
     // data-* attributes
     if (tag) {
       var allowed = tag[attribName] || tag['data-*'];
-      if (allowed === value || allowed.indexOf('*') !== -1) { return value; }
+      if (allowed && (allowed === value || allowed.indexOf('*') !== -1)) { return value; }
     }
   }
 


### PR DESCRIPTION
Fixed the exception when validating 'data-' attributes such as 'data-lightbox="group"' that might come from a blog post import.

https://meta.discourse.org/t/trouble-embedding-discourse-as-a-comment-engine-using-github-pages-and-digitalocean/17520
