### PR TITLE
FEATURE: topic support in disposable invites

### DIFF
--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -57,17 +57,23 @@ class InvitesController < ApplicationController
 
   def redeem_disposable_invite
     params.require(:email)
-    params.permit(:username, :name)
+    params.permit(:username, :name, :topic)
 
     invite = Invite.find_by(invite_key: params[:token])
 
     if invite.present?
-      user = Invite.redeem_from_token(params[:token], params[:email], params[:username], params[:name])
+      user = Invite.redeem_from_token(params[:token], params[:email], params[:username], params[:name], params[:topic].to_i)
       if user.present?
         log_on_user(user)
 
         # Send a welcome message if required
         user.enqueue_welcome_message('welcome_invite') if user.send_welcome_message
+
+        topic = invite.topics.first
+        if topic.present?
+          redirect_to "#{Discourse.base_uri}#{topic.relative_url}"
+          return
+        end
       end
     end
 

--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -168,10 +168,11 @@ class Invite < ActiveRecord::Base
     invite
   end
 
-  def self.redeem_from_token(token, email, username=nil, name=nil)
+  def self.redeem_from_token(token, email, username=nil, name=nil, topic_id=nil)
     invite = Invite.find_by(invite_key: token)
     if invite
       invite.update_column(:email, email)
+      invite.topic_invites.create!(invite_id: invite.id, topic_id: topic_id) if topic_id && Topic.find_by_id(topic_id)
       user = InviteRedeemer.new(invite, username, name).redeem
     end
     user


### PR DESCRIPTION
Support topic id in disposable invites URL -- `https://meta.discourse.org/invites/redeem/TOKEN?username=USERNAME&email=EMAIL&name=NAME&topic=TOPICID`
