### PR TITLE
Strip path from restore filenames

### DIFF
--- a/script/discourse
+++ b/script/discourse
@@ -40,6 +40,7 @@ WHERE table_schema='public' and (data_type like 'char%' or data_type like 'text%
 
   desc "backup", "Backup a discourse forum"
   def backup(filename = nil)
+    filename = File.basename(filename)
     load_rails
     require "backup_restore"
     require "export/exporter"
@@ -62,6 +63,7 @@ WHERE table_schema='public' and (data_type like 'char%' or data_type like 'text%
 
   desc "restore", "Restore a Discourse backup"
   def restore(filename)
+    filename = File.basename(filename)
     load_rails
     require "backup_restore"
     require "import/importer"


### PR DESCRIPTION
This has annoyed me several times, so let's fix it.

Basically, this allows you to use tab-completion when selecting a backup to restore from.

```
cd /var/www/discourse
script/discourse restore pu<TAB>b<TAB><TAB><TAB TAB><look at list of backups>v<TAB>5<TAB><ENTER>
# Results in
script/discourse public/backups/default/vagrant-discourse-2014-05-15-035437.tar.gz
```
