### PR TITLE
FEATURE: bulk selection in the admin post selection

### DIFF
--- a/app/assets/javascripts/discourse/controllers/topic_controller.js
+++ b/app/assets/javascripts/discourse/controllers/topic_controller.js
@@ -5,6 +5,8 @@ Discourse.TopicController = Discourse.ObjectController.extend(Discourse.Selected
   editingTopic: false,
   selectedPosts: null,
   selectedReplies: null,
+  bulkSelectionOn: false,
+  bulkSelectionPost: null,
   queryParams: ['filter', 'username_filters', 'show_deleted'],
 
   contextChanged: function(){
@@ -257,6 +259,33 @@ Discourse.TopicController = Discourse.ObjectController.extend(Discourse.Selected
       } else {
         selectedReplies.removeObject(post);
       }
+    },
+
+    toggledBulkSelectionStart: function(post) {
+      this.set('bulkSelectionPost', post);
+      this.performTogglePost(post);
+      this.toggleProperty('bulkSelectionOn');
+    },
+
+    toggledBulkSelectionEnd: function(post) {
+      var startPostId = this.get('bulkSelectionPost').id,
+        endPostId = post.id, self = this, tmp;
+
+      self.performTogglePost(post);
+
+      if (startPostId > endPostId) {
+        tmp = startPostId;
+        startPostId = endPostId;
+        endPostId = tmp;
+      }
+
+      self.get('postStream.posts').forEach(function (p) {
+        if (p.id === startPostId || p.id === endPostId)
+          return true;
+        if (p.id > startPostId && p.id < endPostId)
+          self.performTogglePost(p);
+      });
+      self.toggleProperty('bulkSelectionOn');
     },
 
     deleteSelected: function() {

--- a/app/assets/javascripts/discourse/templates/post.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/post.js.handlebars
@@ -58,6 +58,11 @@
       </div>
 
       <div {{bind-attr class=":select-posts controller.multiSelect::hidden"}}>
+        {{#unless controller.bulkSelectionOn}}
+          <button {{action toggledBulkSelectionStart this}} {{bind-attr class="controller.bulkSelectionOn:selected"}}>{{i18n topic.multi_select.bulk_select_start}}</button>
+        {{else}}
+          <button {{action toggledBulkSelectionEnd this}}>{{i18n topic.multi_select.bulk_select_end}}</button>
+        {{/unless}}
         <button {{action toggledSelectedPostReplies this}} {{bind-attr class="view.canSelectReplies::hidden"}}>{{i18n topic.multi_select.select_replies}}</button>
         <button {{action toggledSelectedPost this}} class="select-post">{{view.selectPostText}}</button>
       </div>

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -964,6 +964,8 @@ en:
         select: 'select'
         selected: 'selected ({{count}})'
         select_replies: 'select +replies'
+        bulk_select_start: 'bulk select(begin)'
+        bulk_select_end: 'bulk select(end)'
         delete: delete selected
         cancel: cancel selecting
         select_all: select all


### PR DESCRIPTION
Adding a button to select multiple posts by iterating the post stream and toggle them, which means the posts selected would be unselected if they are in the marked zone.

![1](https://cloud.githubusercontent.com/assets/297343/3634028/1e9e0750-0f10-11e4-9beb-a5631ed9d97d.png)
![2](https://cloud.githubusercontent.com/assets/297343/3634029/1ecdb874-0f10-11e4-9a26-b4be5ea77bc4.png)
![3](https://cloud.githubusercontent.com/assets/297343/3634027/1e742688-0f10-11e4-9a27-1b15ecbc3c03.png)

Regarding: https://meta.discourse.org/t/add-select-below-and-select-above-admin-post-selection-action/14905
