### PR TITLE
Enumerate deferred scripts with a sprockets helper

### DIFF
--- a/app/helpers/deferred_scripts_helper.rb
+++ b/app/helpers/deferred_scripts_helper.rb
@@ -1,7 +1,7 @@
-module DeferredJavascriptsHelper
+module DeferredScriptsHelper
 
   # Provides a javascript map of the files in the 'defer' directory
-  def deferred_javascripts
+  def deferred_scripts
     files = {}
 
     Dir.glob("#{Rails.root}/app/assets/javascripts/defer/*.js").each do |file|
@@ -13,8 +13,4 @@ module DeferredJavascriptsHelper
     return files.to_json.html_safe
   end
 
-end
-
-module Sprockets::Rails::Helper
-  include DeferredJavascriptsHelper
 end

--- a/app/views/common/_discourse_javascript.html.erb
+++ b/app/views/common/_discourse_javascript.html.erb
@@ -1,7 +1,7 @@
 <script>
   window.assetPath = (function(){
 
-    var map = <%= deferred_javascripts %>;
+    var map = <%= deferred_scripts %>;
 
     return function(asset){ return map[asset]; };
   })();


### PR DESCRIPTION
Solves the issue of hard coding deferred javascripts into the template as outlined in this [issue](https://meta.discourse.org/t/ruby-populate-hardcoded-assets-automatically/17896) and this [file](https://github.com/discourse/discourse/blob/master/app/views/common/_discourse_javascript.html.erb#L4) by enumerating the `defer` directory with a sprockets helper.

It uses the `asset_path` helper to look up the script's path, so it should work in all rails environments.
