### PR TITLE
Using host Linux (Ubuntu 12.04); performance was abysmal.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,6 +19,21 @@ Vagrant.configure("2") do |config|
     # This setting gives the VM 1024MB of RAM instead of the default 384.
     v.customize ["modifyvm", :id, "--memory", [ENV['DISCOURSE_VM_MEM'].to_i, 1024].max]
 
+    # Who has a single core cpu these days anyways?
+    cpu_count = 2
+
+    # Determine the available cores in host system.
+    # This mostly helps on linux, but it couldn't hurt on MacOSX.
+    if RUBY_PLATFORM =~ /linux/
+      cpu_count = `nproc`.to_i
+    elsif RUBY_PLATFORM =~ /darwin/
+      cpu_count = `sysctl -n hw.ncpu`.to_i
+    end
+
+    # Assign additional cores to the guest OS.
+    v.customize ["modifyvm", :id, "--cpus", cpu_count]
+    v.customize ["modifyvm", :id, "--ioapic", "on"]
+
     # This setting makes it so that network access from inside the vagrant guest
     # is able to resolve DNS using the hosts VPN connection.
     v.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]


### PR DESCRIPTION
On initial load of localhost:4000, the http calls for
additional Javascript files via the browser appears to take
more than a few minutes with *.js endpoints loading in one
file at a time very slowly.

It was observed that the Ruby process was consistently
pegged at 95% and up.  This behaviour is not observed
using a Mac OSX.

However, adding a single core to the guest OS
(from 1 to 2) improved performance considerably.

The patch detects if the host system is Mac OSX or
Linux and attempts to assign the same number of cores
as is present on the host.
