### PR TITLE
Move finder logic out of the group-selector component

### DIFF
--- a/app/assets/javascripts/discourse/components/group-selector.js.es6
+++ b/app/assets/javascripts/discourse/components/group-selector.js.es6
@@ -34,8 +34,8 @@ export default Em.Component.extend({
         return g.name;
       },
       dataSource: function(term) {
-        // TODO: Components should definitely not perform queries
-        return Discourse.Group.findAll({search: term, ignore_automatic: true}).then(function(groups){
+        return self.get("groupFinder")(term).then(function(groups){
+
           if(!selectedGroups){
             return groups;
           }

--- a/app/assets/javascripts/discourse/controllers/invite.js.es6
+++ b/app/assets/javascripts/discourse/controllers/invite.js.es6
@@ -48,7 +48,7 @@ export default Discourse.ObjectController.extend(Discourse.ModalFunctionality, {
   }.property('model'),
 
   /**
-    Is Private Topic? (i.e. visible only to specific group members) 
+    Is Private Topic? (i.e. visible only to specific group members)
 
     @property isPrivateTopic
   **/
@@ -79,6 +79,13 @@ export default Discourse.ObjectController.extend(Discourse.ModalFunctionality, {
       return I18n.t('topic.automatically_add_to_groups_optional');
     }
   }.property('isPrivateTopic'),
+
+  /**
+    Function to find groups.
+  **/
+  groupFinder: function(term) {
+    return Discourse.Group.findAll({search: term, ignore_automatic: true});
+  },
 
   /**
     The "success" text for when the invite was created.

--- a/app/assets/javascripts/discourse/templates/modal/invite.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/modal/invite.js.handlebars
@@ -15,7 +15,7 @@
 
     {{#if isAdmin}}
       <label>{{{groupInstructions}}}</label>
-      {{group-selector includeAuto=false groupNames=groupNames placeholderKey="topic.invite_private.group_name"}}
+      {{group-selector includeAuto=false groupFinder=groupFinder groupNames=groupNames placeholderKey="topic.invite_private.group_name"}}
     {{/if}}
   {{/if}}
 </div>


### PR DESCRIPTION
There shouldn't be any finder code inside the ES components themselves; this change moves the finder to the controller, and the template is then responsible for wiring the two pieces together. See:

https://meta.discourse.org/t/javascript-move-query-out-of-ember-component/17893/2
