### PR TITLE
Update instructions on where to find port info to allow changes

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -5,7 +5,7 @@ development:
   pool: 5
   timeout: 5000
   host_names:
-    ### Don't include the port number here. Change the "port" site setting instead, at /admin/site_settings.
+    ### Don't include the port number here. Change the "port" site setting instead, at /config/site_settings.
     ### If you change this setting you will need to
     ###   - restart sidekiq if you change this setting
     ###   - rebake all to posts using: `RAILS_ENV=production bundle exec rake posts:rebake`


### PR DESCRIPTION
We were paired at the hack night and couldn't locate this admin/site_settings for the port.
Instead, we found it at config/site_settings.
