### PR TITLE
Revert "FIX: hidden helper class is important"

### DIFF
--- a/app/assets/stylesheets/common/foundation/helpers.scss
+++ b/app/assets/stylesheets/common/foundation/helpers.scss
@@ -22,11 +22,11 @@
 
 .hide,
 .hidden {
-  display: none !important;
+  display: none;
 }
 
 .invisible {
-  visibility: hidden !important;
+  visibility: hidden;
 }
 
 .sr-only {


### PR DESCRIPTION
Reverts discourse/discourse#2573

This breaks modals (cc #fantasticfears) -> https://meta.discourse.org/t/popups-are-broken/17934
