### PR TITLE
Suppress trackback CSRF errors from Logster

### DIFF
--- a/config/initializers/logster.rb
+++ b/config/initializers/logster.rb
@@ -1,7 +1,9 @@
 if Rails.env.production?
-  # honestly, Rails should not be logging this, its real noisy
   Logster.store.ignore = [
-    /^ActionController::RoutingError \(No route matches/
+    # honestly, Rails should not be logging this, its real noisy
+    /^ActionController::RoutingError \(No route matches/,
+    # suppress trackback spam bots
+    Logster::IgnorePattern.new("Can't verify CSRF token authenticity", { REQUEST_URI: /\/trackback\/$/ })
   ]
 
   Logster.config.authorize_callback = lambda{|env|


### PR DESCRIPTION
## Do not pull UNTIL:
- Version bump of Logster https://github.com/discourse/logster/pull/19
- And logster version bumped in Discourse

Otherwise, this will NameError.

This removes all the CSRF errors from bots appending `/trackback/` to every URL and sending a POST request.
