### PR TITLE
Use settingName in settings_list like the others

### DIFF
--- a/app/assets/javascripts/admin/templates/site_settings/setting_list.js.handlebars
+++ b/app/assets/javascripts/admin/templates/site_settings/setting_list.js.handlebars
@@ -1,5 +1,5 @@
 <div class='setting-label'>
-    <h3>{{unbound setting}}</h3>
+    <h3>{{unbound settingName}}</h3>
 </div>
 <div class="setting-value">
   {{list-setting settingValue=value choices=choices}}


### PR DESCRIPTION
https://meta.discourse.org/t/some-settings-options-do-not-get-split-by-underscrore-in-the-settings-page/18054
