### PR TITLE
Do not allow a user to change their password if local logins are disabled

### DIFF
--- a/app/assets/javascripts/discourse/controllers/preferences.js.es6
+++ b/app/assets/javascripts/discourse/controllers/preferences.js.es6
@@ -35,6 +35,10 @@ export default Discourse.ObjectController.extend({
     return Discourse.SiteSettings.enable_badges && this.get('model.has_title_badges');
   }.property('model.badge_count'),
 
+  canChangePassword: function() {
+    return !Discourse.SiteSettings.enable_sso && Discourse.SiteSettings.enable_local_logins;
+  }.property(),
+
   availableLocales: function() {
     return Discourse.SiteSettings.available_locales.split('|').map( function(s) {
       return {name: s, value: s};

--- a/app/assets/javascripts/discourse/templates/user/preferences.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/user/preferences.js.handlebars
@@ -60,7 +60,7 @@
       </div>
     </div>
 
-    {{#unless Discourse.SiteSettings.enable_sso }}
+    {{#if canChangePassword}}
     <div class="control-group pref-password">
       <label class="control-label">{{i18n user.password.title}}</label>
       <div class="controls">
@@ -74,7 +74,7 @@
         {{passwordProgress}}
       </div>
     </div>
-    {{/unless}}
+    {{/if}}
 
     <div class="control-group pref-avatar">
       <label class="control-label">{{i18n user.avatar.title}}</label>


### PR DESCRIPTION
Details for this request can be found here: https://meta.discourse.org/t/ability-to-disallow-changing-passwords/17961

With this change, a user can only change their password if the site is NOT using SSO **AND** local logins are enabled.  Otherwise, the password change option will not show on the preferences page.
