### PR TITLE
FIX: support start time in lazyYT

### DIFF
--- a/plugins/lazyYT/plugin.rb
+++ b/plugins/lazyYT/plugin.rb
@@ -17,12 +17,28 @@ class Onebox::Engine::YoutubeOnebox
     if video_id
       # Avoid making HTTP requests if we are able to get the video ID from the
       # URL.
-      html = "<div class=\"lazyYT\" data-youtube-id=\"#{video_id}\" data-width=\"480\" data-height=\"270\"></div>"
+      html = "<div class=\"lazyYT\" data-youtube-id=\"#{video_id}\" data-width=\"480\" data-height=\"270\" data-parameters=\"start=0\"></div>"
     else
       # Fall back to making HTTP requests.
       html = raw[:html] || ""
     end
 
     rewrite_agnostic(append_params(html))
+  end
+
+  def append_params(html)
+    result = html.dup
+    result.gsub! /(src="[^"]+)/, '\1&wmode=opaque'
+    if url =~ /t=(\d+h)?(\d+m)?(\d+s?)?/
+      h = Regexp.last_match[1].to_i
+      m = Regexp.last_match[2].to_i
+      s = Regexp.last_match[3].to_i
+
+      total = (h * 60 * 60) + (m * 60) + s
+      start_time = "\"start=#{total}\""
+
+      result.gsub!('"start=0"', start_time)
+    end
+    result
   end
 end


### PR DESCRIPTION
see -- https://meta.discourse.org/t/ytlight-a-lightweight-youtube-oneboxer/12455/22?u=techapj

<s>Do not merge this PR. Working on -- `support the direct time link formats in mobile and desktop urls as well`.</s> **Done!**
