### PR TITLE
FIX: youtube mobile width

### DIFF
--- a/app/assets/stylesheets/mobile/topic-post.scss
+++ b/app/assets/stylesheets/mobile/topic-post.scss
@@ -562,3 +562,8 @@ span.highlighted {
 .read-state {
   display: none;
 }
+
+// fixes youtube embed width for lazyYT plugin
+.lazyYT {
+  max-width: 100%;
+}


### PR DESCRIPTION
Not sure if `app/assets/stylesheets/mobile/topic-post.scss` is the best place to fix mobile width for `lazyYT` plugin.

cc @coding-horror @SamSaffron @awesomerobot
