### PR TITLE
tiger striping on mobile categories

### DIFF
--- a/app/assets/javascripts/discourse/templates/mobile/discovery/categories.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/mobile/discovery/categories.js.handlebars
@@ -14,9 +14,9 @@
           </td>
         </tr>
       {{/if}}
-
+      
       {{#each topics}}
-        <tr {{bind-attr class="archived"}}>
+        <tr class="category-topic-link" {{bind-attr class="archived"}}>
           <td class='main-link'>
             <div class='topic-inset'>
               {{topic-status topic=this}}
@@ -48,8 +48,8 @@
           <td class='num posts'>{{number posts_count}}</td>
           <td class='num age'><span class="{{cold-age-class created_at}}" title='{{raw-date created_at}}'>{{{age created_at}}}</span></td>
         </tr>
-      {{/each}}
 
+      {{/each}}
       {{#if subcategories}}
         <tr>
           <td>

--- a/app/assets/stylesheets/mobile/topic-list.scss
+++ b/app/assets/stylesheets/mobile/topic-list.scss
@@ -81,7 +81,9 @@
 // Category list
 // --------------------------------------------------
 
-
+tr.category-topic-link:nth-of-type(odd) {
+    background-color: darken($secondary, 3%) !important;
+    }
 
 #topic-list.categories {
   td.latest {


### PR DESCRIPTION
this works only on the topic titles and not subcategories, but needs fixes:
1. tiger striping is too specific elsewhere, requiring !important here
2. should probably wrap the category-topic-link TRs in their own separate div
