### PR TITLE
making menu accessible on mobile when in desktop mode

### DIFF
--- a/app/assets/stylesheets/desktop/discourse.scss
+++ b/app/assets/stylesheets/desktop/discourse.scss
@@ -24,6 +24,18 @@ html {font-size: 14px/19px;}
   }
 }
 
+@media all
+and (max-width : 570px) {
+  body {
+    min-width: 0;
+  }
+  .container,
+  .full-width {
+    min-width: 0;
+  }
+  .d-header .current-username a {display: none;}
+}
+
 header {
   margin-bottom: 15px;
 }

--- a/app/assets/stylesheets/desktop/header.scss
+++ b/app/assets/stylesheets/desktop/header.scss
@@ -19,6 +19,18 @@
   }
 }
 
+@media all
+and (max-width : 570px) {
+  .d-header {
+    .current-username {
+      a {
+        display:none;
+      }
+    }
+  }
+  .extra-info-wrapper {display: none;}
+}
+
 #main {
   position: relative;
 }


### PR DESCRIPTION
On screens more narrow than 570px (mainly phones) the min-width and username is removed from the header so the menu can fit. Within topics extra-info-wrapper is hidden (same as mobile layout) so menu can fit.

https://meta.discourse.org/t/once-you-switch-to-desktop-view-on-mobile-there-is-no-way-to-switch-back/18189
