### PR TITLE
Fix the regex for S3 bucket names

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -429,7 +429,7 @@ files:
     enum: 'S3RegionSiteSetting'
   s3_upload_bucket:
     default: ''
-    regex: "^[^\\.]*$"
+    regex: "^[a-z0-9]([a-z0-9\\-]\\.?)+[a-z0-9]$"
   allow_profile_backgrounds:
     client: true
     default: true
@@ -623,7 +623,7 @@ backups:
   s3_backup_bucket:
     client: false
     default: ''
-    regex: "^[^\\.]*$"
+    regex: "^[a-z0-9]([a-z0-9\\-]\\.?)+[a-z0-9]$"
 
 uncategorized:
   version_checks:

--- a/spec/models/site_setting_spec.rb
+++ b/spec/models/site_setting_spec.rb
@@ -93,4 +93,35 @@ describe SiteSetting do
 
   end
 
+  # See: https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html
+  shared_examples "s3 bucket naming conventions" do |s3_setting|
+    describe s3_setting do
+      it "disallows bucket names that start with ." do
+        expect { SiteSetting.send("#{s3_setting}=", ".foo.bar") }.to raise_error(Discourse::InvalidParameters)
+      end
+
+      it "disallows bucket names that end with ." do
+        expect { SiteSetting.send("#{s3_setting}=", "foo1.bar.") }.to raise_error(Discourse::InvalidParameters)
+      end
+
+      it "disallows bucket names that have more than one . in a row" do
+        expect { SiteSetting.send("#{s3_setting}=", "foo1..bar") }.to raise_error(Discourse::InvalidParameters)
+      end
+
+      it "disallows bucket names that are less than 3 characters long" do
+        expect { SiteSetting.send("#{s3_setting}=", "fo") }.to raise_error(Discourse::InvalidParameters)
+      end
+
+      it "allows bucket names that have . in it" do
+        expect { SiteSetting.send("#{s3_setting}=", "foo1.bar") }.not_to raise_error
+      end
+
+      it "allows bucket names that have - in it" do
+        expect { SiteSetting.send("#{s3_setting}=", "foo1-bar") }.not_to raise_error
+      end
+    end
+  end
+
+  it_behaves_like "s3 bucket naming conventions", :s3_upload_bucket
+  it_behaves_like "s3 bucket naming conventions", :s3_backup_bucket
 end


### PR DESCRIPTION
Current regex disallows valid bucket names like `foo.bar`.  This regex
complies with the guidelines laid out in the [S3 Bucket
Restrictions](https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html)
document.
