### PR TITLE
Use English as fallback for missing strings when generating translation ...

### DIFF
--- a/lib/js_locale_helper.rb
+++ b/lib/js_locale_helper.rb
@@ -8,13 +8,21 @@ module JsLocaleHelper
 
     # load default translations
     translations ||= YAML::load(File.open("#{Rails.root}/config/locales/client.#{locale_str}.yml"))
+    default ||= YAML::load(File.open("#{Rails.root}/config/locales/client.en.yml"))
+    # insert fallback translation
+    translations[locale_str] = default['en'].deep_merge(translations[locale_str])
     # load plugins translations
     plugin_translations = {}
-    Dir["#{Rails.root}/plugins/*/config/locales/client.#{locale_str}.yml"].each do |file|
+    Dir["#{Rails.root}/plugins/*/config/locales/client.#{locale_str}.yml","#{Rails.root}/plugins/*/config/locales/client.en.yml"].each do |file|
       plugin_translations.deep_merge! YAML::load(File.open(file))
     end
     # merge translations (plugin translations overwrite default translations)
-    translations[locale_str]['js'].deep_merge!(plugin_translations[locale_str]['js']) if translations[locale_str] && plugin_translations[locale_str] && plugin_translations[locale_str]['js']
+    # insert fallback translations
+    if translations[locale_str] && plugin_translations[locale_str] && plugin_translations[locale_str]['js']
+      translations[locale_str]['js'].deep_merge!(plugin_translations['en']['js'].deep_merge(translations[locale_str]['js']))
+    else
+      translations[locale_str]['js'] = plugin_translations['en']['js']
+    end
 
     # We used to split the admin versus the client side, but it's much simpler to just
     # include both for now due to the small size of the admin section.

--- a/lib/js_locale_helper.rb
+++ b/lib/js_locale_helper.rb
@@ -19,9 +19,9 @@ module JsLocaleHelper
     # merge translations (plugin translations overwrite default translations)
     # insert fallback translations
     if translations[locale_str] && plugin_translations[locale_str] && plugin_translations[locale_str]['js']
-      translations[locale_str]['js'].deep_merge!(plugin_translations['en']['js'].deep_merge(translations[locale_str]['js']))
+      translations[locale_str]['js'].deep_merge!(plugin_translations['en']['js'].deep_merge(plugin_translations[locale_str]['js']))
     else
-      translations[locale_str]['js'] = plugin_translations['en']['js']
+      translations[locale_str]['js'].deep_merge!(plugin_translations['en']['js'])
     end
 
     # We used to split the admin versus the client side, but it's much simpler to just


### PR DESCRIPTION
Generate client translation js with English fallback as suggested in https://meta.discourse.org/t/missing-translation-defaults-to-english/15771/9