### PR TITLE
Fix: block parser uses regexes for stop tags, allows stricter matching

### DIFF
--- a/app/assets/javascripts/discourse/dialects/bbcode_dialect.js
+++ b/app/assets/javascripts/discourse/dialects/bbcode_dialect.js
@@ -120,7 +120,7 @@ Discourse.Markdown.whiteListTag('span', 'class', /^bbcode-size-\d+$/);
 // Handles `[code] ... [/code]` blocks
 Discourse.Dialect.replaceBlock({
   start: /(\[code\])([\s\S]*)/igm,
-  stop: '[/code]',
+  stop: /\[\/code\]/igm,
   rawContents: true,
 
   emitter: function(blockContents) {

--- a/app/assets/javascripts/discourse/dialects/code_dialect.js
+++ b/app/assets/javascripts/discourse/dialects/code_dialect.js
@@ -21,7 +21,7 @@ function flattenBlocks(blocks) {
 
 Discourse.Dialect.replaceBlock({
   start: /^`{3}([^\n\[\]]+)?\n?([\s\S]*)?/gm,
-  stop: '```',
+  stop: /^```$/gm,
   emitter: function(blockContents, matches) {
 
     var klass = Discourse.SiteSettings.default_code_lang;
@@ -54,7 +54,7 @@ Discourse.Dialect.on('parseNode', function (event) {
 
 Discourse.Dialect.replaceBlock({
   start: /(<pre[^\>]*\>)([\s\S]*)/igm,
-  stop: '</pre>',
+  stop: /<\/pre>/igm,
   rawContents: true,
   skipIfTradtionalLinebreaks: true,
 

--- a/app/assets/javascripts/discourse/dialects/quote_dialect.js
+++ b/app/assets/javascripts/discourse/dialects/quote_dialect.js
@@ -6,7 +6,7 @@ var esc = Handlebars.Utils.escapeExpression;
 
 Discourse.Dialect.replaceBlock({
   start: new RegExp("\\[quote(=[^\\[\\]]+)?\\]([\\s\\S]*)", "igm"),
-  stop: '[/quote]',
+  stop: /\[\/quote\]/igm,
   emitter: function(blockContents, matches, options) {
 
     var params = {'class': 'quote'},

--- a/test/javascripts/lib/markdown-test.js.es6
+++ b/test/javascripts/lib/markdown-test.js.es6
@@ -365,13 +365,17 @@ test("Code Blocks", function() {
           "<p><pre><code class=\"lang-auto\">hello</code></pre></p>",
           "it doesn't not whitelist all classes");
 
-  cooked("```[quote=\"sam, post:1, topic:9441, full:true\"]This is `<not>` a bug.[/quote]```",
+  cooked("```\n[quote=\"sam, post:1, topic:9441, full:true\"]This is `<not>` a bug.[/quote]\n```",
          "<p><pre><code class=\"lang-auto\">[quote=&quot;sam, post:1, topic:9441, full:true&quot;]This is &#x60;&lt;not&gt;&#x60; a bug.[/quote]</code></pre></p>",
          "it allows code with backticks in it");
 
   cooked("    hello\n<blockquote>test</blockquote>",
          "<pre><code>hello</code></pre>\n\n<blockquote>test</blockquote>",
          "it allows an indented code block to by followed by a `<blockquote>`");
+
+  cooked("``` foo bar ```",
+         "<p><code>foo bar</code></p>",
+         "it tolerates misuse of code block tags as inline code");
 });
 
 test("sanitize", function() {


### PR DESCRIPTION
Solves https://meta.discourse.org/t/markdown-backticks/18823
