### PR TITLE
This should be `validates`, not `validate`

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -34,7 +34,7 @@ class Group < ActiveRecord::Base
     :everyone => 99
   }
 
-  validate :alias_level, inclusion: { in: ALIAS_LEVELS.values}
+  validates :alias_level, inclusion: { in: ALIAS_LEVELS.values}
 
   def posts_for(guardian, before_post_id=nil)
     user_ids = group_users.map {|gu| gu.user_id}


### PR DESCRIPTION
Found this while testing discourse with Rails master. (It's that time of the year again :grin:)

Thanks to https://github.com/rails/rails/pull/16210, this now raises an exception on Rails master! <3 <3 <3

Obviously this was not doing what it's supposed to do before, so there's probably a hole in the test coverage somewhere, but I figure I'll send it first in case someone can do that before I get to it.
