### PR TITLE
Add site preference for standard subjects, including support for Re:

### DIFF
--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -79,26 +79,33 @@ class UserNotifications < ActionMailer::Base
 
   def user_replied(user, opts)
     opts[:allow_reply_by_email] = true
+    opts[:use_site_subject] = true
     notification_email(user, opts)
   end
 
   def user_quoted(user, opts)
     opts[:allow_reply_by_email] = true
+    opts[:use_site_subject] = true
     notification_email(user, opts)
   end
 
   def user_mentioned(user, opts)
     opts[:allow_reply_by_email] = true
+    opts[:use_site_subject] = true
     notification_email(user, opts)
   end
 
   def user_posted(user, opts)
     opts[:allow_reply_by_email] = true
+    opts[:use_site_subject] = true
+    opts[:add_re_to_subject] = true
     notification_email(user, opts)
   end
 
   def user_private_message(user, opts)
     opts[:allow_reply_by_email] = true
+    opts[:use_site_subject] = true
+    opts[:add_re_to_subject] = true
 
     # We use the 'user_posted' event when you are emailed a post in a PM.
     opts[:notification_type] = 'posted'
@@ -112,6 +119,8 @@ class UserNotifications < ActionMailer::Base
       post: post,
       from_alias: post.user.username,
       allow_reply_by_email: true,
+      use_site_subject: true,
+      add_re_to_subject: true,
       notification_type: "posted",
       user: user
     )
@@ -159,12 +168,16 @@ class UserNotifications < ActionMailer::Base
 
     title = @notification.data_hash[:topic_title]
     allow_reply_by_email = opts[:allow_reply_by_email] unless user.suspended?
+    use_site_subject = opts[:use_site_subject]
+    add_re_to_subject = opts[:add_re_to_subject]
 
     send_notification_email(
       title: title,
       post: @post,
       from_alias: username,
       allow_reply_by_email: allow_reply_by_email,
+      use_site_subject: use_site_subject,
+      add_re_to_subject: add_re_to_subject,
       notification_type: notification_type,
       user: user
     )
@@ -175,6 +188,8 @@ class UserNotifications < ActionMailer::Base
     post = opts[:post]
     title = opts[:title]
     allow_reply_by_email = opts[:allow_reply_by_email]
+    use_site_subject = opts[:use_site_subject]
+    add_re_to_subject = opts[:add_re_to_subject] && post.post_number > 1
     from_alias = opts[:from_alias]
     notification_type = opts[:notification_type]
     user = opts[:user]
@@ -216,6 +231,8 @@ class UserNotifications < ActionMailer::Base
       username: from_alias,
       add_unsubscribe_link: true,
       allow_reply_by_email: allow_reply_by_email,
+      use_site_subject: use_site_subject,
+      add_re_to_subject: add_re_to_subject,
       private_reply: post.topic.private_message?,
       include_respond_instructions: !user.suspended?,
       template: template,

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -681,6 +681,7 @@ en:
 
     notification_email: "The from: email address used when sending all essential system emails. The domain specified here must have SPF, DKIM and reverse PTR records set correctly for email to arrive."
     email_custom_headers: "A pipe-delimited list of custom email headers"
+    email_subject: "Subject format for standard emails."
     use_https: "Should the full url for the site (Discourse.base_url) be http or https? DO NOT ENABLE THIS UNLESS HTTPS IS ALREADY SET UP AND WORKING!"
     summary_score_threshold: "The minimum score required for a post to be included in 'Summarize This Topic'"
     summary_posts_required: "Minimum posts in a topic before 'Summarize This Topic' is enabled"
@@ -1541,6 +1542,8 @@ en:
       text_body_template: "The `download_remote_images_to_local` setting was disabled because the disk space limit at `download_remote_images_threshold` was reached."
 
   unsubscribe_link: "To unsubscribe from these emails, visit your [user preferences](%{user_preferences_url})."
+  subject_re: "Re: "
+  subject_pm: "[PM] "
 
   user_notifications:
     previous_discussion: "Previous Replies"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -375,6 +375,7 @@ email:
     default: 7
     enum: 'DigestEmailSiteSetting'
   email_custom_headers: 'Auto-Submitted: auto-generated'
+  email_subject: '%{optional_re}[%{site_name}] %{optional_pm}%{topic_title}'
   reply_by_email_enabled: false
   reply_by_email_address: ''
   pop3s_polling_enabled: false

--- a/lib/email/message_builder.rb
+++ b/lib/email/message_builder.rb
@@ -40,8 +40,16 @@ module Email
     end
 
     def subject
-      subject = @opts[:subject]
-      subject = I18n.t("#{@opts[:template]}.subject_template", template_args) if @opts[:template]
+      if @opts[:use_site_subject]
+        subject = String.new(SiteSetting.email_subject)
+        subject.gsub!("%{site_name}",@template_args[:site_name])
+        subject.gsub!("%{optional_re}",@opts[:add_re_to_subject] ? I18n.t('subject_re', template_args) : '')
+        subject.gsub!("%{optional_pm}",private_reply? ? I18n.t('subject_pm', template_args) : '')
+        subject.gsub!("%{topic_title}",@template_args[:topic_title]) # must be last for safety
+      else
+        subject = @opts[:subject]
+        subject = I18n.t("#{@opts[:template]}.subject_template", template_args) if @opts[:template]
+      end
       subject
     end
 


### PR DESCRIPTION
Template format similar to reply_key is used.  Tokens supported include:

%{site_name} - email site name preference
%{optional_re} - "Re: " if it is a reply (not first post), "" otherwise
%{optional_pm} - "[PM] " if it is a private message, "" otherwise
%{topic_title} - topic title

Default subject is: %{optional_re}[%{site_name}] %{optional_pm}%{topic_title}

If preferred, %{optional_re} could be omitted from the default subject.

optional_re and optional_pm are backed by subject_re and subject_pm locale translation strings.

Having upgrade my Mac, my local Discourse test system is no longer functional, and my attempt to spin up a Digital Ocean test system failed, so there is currently no tests.

Hopefully someone can provide some appropriate tests to go along with this patch.
