### PR TITLE
FIX: lazyYT youtube links not getting included in email

### DIFF
--- a/lib/email/styles.rb
+++ b/lib/email/styles.rb
@@ -4,10 +4,15 @@
 #
 module Email
   class Styles
+    @@plugin_callbacks = []
 
     def initialize(html)
       @html = html
       @fragment = Nokogiri::HTML.fragment(@html)
+    end
+
+    def self.register_plugin_style(&block)
+      @@plugin_callbacks.push(block)
     end
 
     def add_styles(node, new_styles)
@@ -60,6 +65,7 @@ module Email
       correct_footer_style
       reset_tables
       onebox_styles
+      plugin_styles
     end
 
     def onebox_styles
@@ -113,6 +119,12 @@ module Email
       style('.featured-topic a', 'text-decoration: none; font-weight: bold; color: #006699; margin-right: 5px')
 
       onebox_styles
+      plugin_styles
+    end
+
+    # this method is reserved for styles specific to plugin
+    def plugin_styles
+      @@plugin_callbacks.each { |block| block.call(@fragment) }
     end
 
     def to_html

--- a/plugins/lazyYT/plugin.rb
+++ b/plugins/lazyYT/plugin.rb
@@ -43,3 +43,21 @@ class Onebox::Engine::YoutubeOnebox
     result
   end
 end
+
+after_initialize do
+
+  Email::Styles.register_plugin_style do |fragment|
+    # YouTube onebox can't go in emails, so replace them with clickable links
+    fragment.css('.lazyYT').each do |i|
+      begin
+        src = "https://www.youtube.com/embed/#{i['data-youtube-id']}?autoplay=1&#{i['data-parameters']}"
+        src_uri = URI(src)
+        display_src = "https://#{src_uri.host}#{src_uri.path}"
+        i.replace "<p><a href='#{src_uri.to_s}'>#{display_src}</a><p>"
+      rescue URI::InvalidURIError
+        # If the URL is weird, remove it
+        i.remove
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes [this issue](https://meta.discourse.org/t/youtube-link-not-included-in-email-not-proto-agnostic/18971) reported on meta.
