### PR TITLE
Put a second admin dashboard link in header

### DIFF
--- a/app/assets/javascripts/discourse/templates/user_dropdown.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/user_dropdown.js.handlebars
@@ -2,7 +2,7 @@
   <ul class='user-dropdown-links'>
     <li>{{#link-to 'user' currentUser class="user-activity-link" }}{{i18n user.profile}}{{/link-to}}</li>
     {{#if showAdminLinks}}
-      <li>{{#link-to 'adminUser' currentUser.username }}{{i18n admin_title}}{{/link-to}}</li>
+      <li>{{#link-to 'admin.dashboard'}}{{i18n admin_title}}{{/link-to}}</li>
     {{/if}}
     <li>
     {{#link-to 'userPrivateMessages.index' currentUser class='user-messages-link'}}


### PR DESCRIPTION
As per https://meta.discourse.org/t/admin-link-under-user-avatar-is-confusing/19117
