### PR TITLE
Suppress share link for anonymous users

### DIFF
--- a/app/assets/javascripts/discourse/views/post-menu.js.es6
+++ b/app/assets/javascripts/discourse/views/post-menu.js.es6
@@ -223,6 +223,7 @@ export default Discourse.View.extend({
 
   // Share button
   buttonForShare: function(post) {
+    if (!Discourse.User.current()) return;
     var options = {
       shareUrl: post.get('shareUrl'),
       postNumber: post.get('post_number')


### PR DESCRIPTION
Removes share button, date marker still works for share.

cc @coding-horror @eviltrout
