### PR TITLE
Update RU pluralization to use 3 keys: one, few, other (as by Transifex)

### DIFF
--- a/app/assets/javascripts/locales/ru.js.erb
+++ b/app/assets/javascripts/locales/ru.js.erb
@@ -3,8 +3,7 @@
 <%= JsLocaleHelper.output_locale(:ru) %>
 
 I18n.pluralizationRules['ru'] = function (n) {
-  if (n == 0) return ["zero", "none", "other"];
   if (n % 10 == 1 && n % 100 != 11) return "one";
-  if (n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 10 || n % 100 >= 20)) return "few";
-  return "many";
+  if (n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 12 || n % 100 > 14)) return "few";
+  return "other";
 };

--- a/config/locales/plurals.rb
+++ b/config/locales/plurals.rb
@@ -80,7 +80,7 @@
   :pt => { :i18n => { :plural => { :keys => [:one, :other], :rule => lambda { |n| [0, 1].include?(n) ? :one : :other } } } },
   :"pt-PT" => { :i18n => { :plural => { :keys => [:one, :other], :rule => lambda { |n| n == 1 ? :one : :other } } } },
   :ro => { :i18n => { :plural => { :keys => [:one, :few, :other], :rule => lambda { |n| n == 1 ? :one : n == 0 ? :few : :other } } } },
-  :ru => { :i18n => { :plural => { :keys => [:one, :few, :many, :other], :rule => lambda { |n| n % 10 == 1 && n % 100 != 11 ? :one : [2, 3, 4].include?(n % 10) && ![12, 13, 14].include?(n % 100) ? :few : n % 10 == 0 || [5, 6, 7, 8, 9].include?(n % 10) || [11, 12, 13, 14].include?(n % 100) ? :many : :other } } } },
+  :ru => { :i18n => { :plural => { :keys => [:one, :few, :other], :rule => lambda { |n| n % 10 == 1 && n % 100 != 11 ? :one : [2, 3, 4].include?(n % 10) && ![12, 13, 14].include?(n % 100) ? :few : :other } } } },
   :se => { :i18n => { :plural => { :keys => [:one, :two, :other], :rule => lambda { |n| n == 1 ? :one : n == 2 ? :two : :other } } } },
   :sh => { :i18n => { :plural => { :keys => [:one, :few, :many, :other], :rule => lambda { |n| n % 10 == 1 && n % 100 != 11 ? :one : [2, 3, 4].include?(n % 10) && ![12, 13, 14].include?(n % 100) ? :few : n % 10 == 0 || [5, 6, 7, 8, 9].include?(n % 10) || [11, 12, 13, 14].include?(n % 100) ? :many : :other } } } },
   :sk => { :i18n => { :plural => { :keys => [:one, :few, :other], :rule => lambda { |n| n == 1 ? :one : [2, 3, 4].include?(n) ? :few : :other } } } },

--- a/lib/javascripts/locale/ru.js
+++ b/lib/javascripts/locale/ru.js
@@ -1,14 +1,11 @@
 MessageFormat.locale.ru = function (n) {
-  if ((n % 10) == 1 && (n % 100) != 11) {
+  var r10 = n % 10, r100 = n % 100;
+
+  if (r10 == 1 && r100 != 11)
     return 'one';
-  }
-  if ((n % 10) >= 2 && (n % 10) <= 4 &&
-      ((n % 100) < 12 || (n % 100) > 14) && n == Math.floor(n)) {
+
+  if (r10 >= 2 && r10 <= 4 && (r100 < 12 || r100 > 14) && n == Math.floor(n))
     return 'few';
-  }
-  if ((n % 10) === 0 || ((n % 10) >= 5 && (n % 10) <= 9) ||
-      ((n % 100) >= 11 && (n % 100) <= 14) && n == Math.floor(n)) {
-    return 'many';
-  }
+
   return 'other';
 };


### PR DESCRIPTION
Currently, Transifex proposes `one`, `few` and `other` keys for Russian pluralization.

This commit updates corresponding pluralization functions in Discourse to match the Russian translation files retrieved from Transifex. 

![image](https://cloud.githubusercontent.com/assets/282177/4020633/0e664210-2ac4-11e4-842e-b72277d21107.png)

P.S. Previously there were 4 keys: `one`, `few`, `many` and `other`, and the Discourse GUI, when switched to RU locale, showed a lot of `xxx.yyy.many` strings instead of real translations.
