### PR TITLE
Workaround markdown-js links parser bug

### DIFF
--- a/test/javascripts/lib/markdown-test.js.es6
+++ b/test/javascripts/lib/markdown-test.js.es6
@@ -138,6 +138,10 @@ test("Links", function() {
   cooked("[http://google.com ... wat](http://discourse.org)",
          "<p><a href=\"http://discourse.org\">http://google.com ... wat</a></p>",
          "it supports linkins within links");
+
+  cooked("[Link](http://www.example.com) (with an outer \"description\")",
+         "<p><a href=\"http://www.example.com\">Link</a> (with an outer \"description\")</p>",
+         "it doesn't consume closing parens as part of the url")
 });
 
 test("simple quotes", function() {

--- a/vendor/assets/javascripts/better_markdown.js
+++ b/vendor/assets/javascripts/better_markdown.js
@@ -1310,7 +1310,7 @@
         // back based on if there a matching ones in the url
         //    ([here](/url/(test))
         // The parens have to be balanced
-        var m = text.match( /^\s*\([ \t]*([^"']*)(?:[ \t]+(["'])(.*?)\2)?[ \t]*\)/ );
+        var m = text.match( /^\s*\([ \t]*([^"'\s]*)(?:[ \t]+(["'])(.*?)\2)?[ \t]*\)/ );
         if ( m ) {
           var url = m[1].replace(/\s+$/, '');
           consumed += m[0].length;


### PR DESCRIPTION
The bug fixed is related to https://github.com/evilstreak/markdown-js/issues/147.

This fix requires that URLs in links not contain any whitespace. This eliminates the parser errors in the minimal repro sample but I don't consider it a proper fix because it's not actually matching matched parens, so I'm reluctant to submit this change to upstream.
