### PR TITLE
Lock `mail` gem to ~> 2.5.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,6 +80,8 @@ else
 end
 gem 'rails-observers'
 
+gem 'mail', '~> 2.5.4'
+
 #gem 'redis-rails'
 gem 'hiredis'
 gem 'redis', require:  ["redis", "redis/connection/hiredis"]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -436,6 +436,7 @@ DEPENDENCIES
   listen (= 0.7.3)
   logster
   lru_redux
+  mail (~> 2.5.4)
   memory_profiler
   message_bus
   minitest


### PR DESCRIPTION
Rails 4.1.6+ will relax the mail gem version requirement to `~> 2.5, >= 2.5.4`.
However, mail gem 2.6.x currently does not work with discourse because of the
reference to `Mail::RFC2822Parser` in `lib/email.rb`. This ensure discourse
would continue to work with Rails 4.1.6+ when it is released.

Related: https://github.com/chancancode/discourse/issues/3
