### PR TITLE
Use the latest version of seed-fu

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,9 +67,7 @@ unless Bundler::Dependency::PLATFORM_MAP.include? :mri_21
    end
 end
 
-# see: https://github.com/mbleigh/seed-fu/pull/54
-# taking forever to get changes upstream in seed-fu
-gem 'seed-fu-discourse', require: 'seed-fu'
+gem 'seed-fu', '~> 2.3.3'
 
 if rails_master?
   gem 'rails', git: 'https://github.com/rails/rails.git'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -331,7 +331,7 @@ GEM
       sass (~> 3.2.0)
       sprockets (~> 2.8, <= 2.11.0)
       sprockets-rails (~> 2.0.0)
-    seed-fu-discourse (2.2.1)
+    seed-fu (2.3.3)
       activerecord (>= 3.1, < 4.2)
       activesupport (>= 3.1, < 4.2)
     shoulda (3.5.0)
@@ -480,7 +480,7 @@ DEPENDENCIES
   sanitize
   sass
   sass-rails (~> 4.0.2)
-  seed-fu-discourse
+  seed-fu (~> 2.3.3)
   shoulda
   sidekiq
   simple-rss


### PR DESCRIPTION
seed-fu#54 has been merged, so we don't have to use the custom fork anymore.
It also include some changes that are required for Rails 4.2+, at least for now.

See https://github.com/rails/rails/commit/d6c1205584b1ba597db4071b168681678b1e9875#commitcomment-7502487
