### PR TITLE
Fix "Server Error: [missing {{code}} value]" page

### DIFF
--- a/app/assets/javascripts/discourse/controllers/exception.js.es6
+++ b/app/assets/javascripts/discourse/controllers/exception.js.es6
@@ -41,6 +41,7 @@ export default ObjectController.extend({
     if (this.get('thrown.jqTextStatus') === "timeout") return true;
     return false;
   }.property(),
+  isForbidden: Em.computed.equal('thrown.status', 403),
   isServer: Em.computed.gte('thrown.status', 500),
   isUnknown: Em.computed.none('isNetwork', 'isServer'),
 
@@ -59,6 +60,8 @@ export default ObjectController.extend({
       return I18n.t('errors.reasons.network');
     } else if (this.get('isServer')) {
       return I18n.t('errors.reasons.server');
+    } else if (this.get('isForbidden')) {
+      return I18n.t('errors.reasons.forbidden');
     } else {
       // TODO
       return I18n.t('errors.reasons.unknown');
@@ -73,7 +76,7 @@ export default ObjectController.extend({
     } else if (this.get('isNetwork')) {
       return I18n.t('errors.desc.network');
     } else if (this.get('isServer')) {
-      return I18n.t('errors.desc.server', this.get('thrown.statusText'));
+      return I18n.t('errors.desc.server', { status: this.get('thrown.status') + " " + this.get('thrown.statusText') });
     } else {
       // TODO
       return I18n.t('errors.desc.unknown');
@@ -85,8 +88,6 @@ export default ObjectController.extend({
       return [ButtonLoadPage];
     } else if (this.get('isNetwork')) {
       return [ButtonBackDim, ButtonTryAgain];
-    } else if (this.get('isServer')) {
-      return [ButtonBackBright];
     } else {
       return [ButtonBackBright, ButtonTryAgain];
     }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -507,12 +507,13 @@ en:
       prev_page: "while trying to load"
       reasons:
         network: "Network Error"
-        server: "Server Error: {{code}}"
+        server: "Server Error"
+        forbidden: "Access Denied"
         unknown: "Error"
       desc:
         network: "Please check your connection."
         network_fixed: "Looks like it's back."
-        server: "Something went wrong."
+        server: "Error code: {{status}}"
         unknown: "Something went wrong."
       buttons:
         back: "Go Back"


### PR DESCRIPTION
The translation was expecting a non-existent parameter.

![image](https://cloud.githubusercontent.com/assets/627891/4038527/de633aec-2cb6-11e4-91a5-1520cd2740b0.png)
