### PR TITLE
Rewrite POP3 initialization to not use globals

### DIFF
--- a/spec/jobs/poll_mailbox_spec.rb
+++ b/spec/jobs/poll_mailbox_spec.rb
@@ -30,9 +30,8 @@ describe Jobs::PollMailbox do
 
     it "logs an error on pop authentication error" do
       error = Net::POPAuthenticationError.new
-      data = { limit_once_per: 1.hour, message_params: { error: error }}
 
-      Net::POP3.expects(:start).raises(error)
+      Net::POP3.any_instance.expects(:start).raises(error)
 
       Discourse.expects(:handle_exception)
 


### PR DESCRIPTION
Net::POP3.enable/disable_ssl sets a global variable for all new
Net::POP3 instances, which causes configuration bleed on multisite.
