### PR TITLE
Fix: dialect block parser should not eat next block's whitespace

### DIFF
--- a/app/assets/javascripts/discourse/dialects/dialect.js
+++ b/app/assets/javascripts/discourse/dialects/dialect.js
@@ -462,7 +462,7 @@ Discourse.Dialect = {
           before = currentBlock.slice(0, actualEndPos).replace(/\n*$/, ""),
           after = currentBlock.slice(actualEndPos + stopLen).replace(/^\n*/, "");
       if (before.length > 0) contentBlocks.push(MD.mk_block(before, "", currentBlock.lineNumber));
-      if (after.length > 0) next.unshift(MD.mk_block(after, "", currentBlock.lineNumber + countLines(before)));
+      if (after.length > 0) next.unshift(MD.mk_block(after, currentBlock.trailing, currentBlock.lineNumber + countLines(before)));
 
       var emitterResult = args.emitter.call(this, contentBlocks, match, dialect.options);
       if (emitterResult) { result.push(emitterResult); }

--- a/test/javascripts/lib/markdown-test.js.es6
+++ b/test/javascripts/lib/markdown-test.js.es6
@@ -371,6 +371,10 @@ test("Code Blocks", function() {
   cooked("``` foo bar ```",
          "<p><code>foo bar</code></p>",
          "it tolerates misuse of code block tags as inline code");
+
+  cooked("```\nline1\n```\n```\nline2\n\nline3\n```",
+         "<p><pre><code class=\"lang-auto\">line1</code></pre></p>\n\n<p><pre><code class=\"lang-auto\">line2\n\nline3</code></pre></p>",
+         "it does not consume next block's trailing newlines");
 });
 
 test("sanitize", function() {


### PR DESCRIPTION
Fixes the block parser: trailing lines belonging to the next block were consumed, leading to https://meta.discourse.org/t/adjacent-fenced-code-blocks-confuse-parser/19282/2.
