### PR TITLE
Add shortcuts for Profile Menu and Hamburger Menu

### DIFF
--- a/app/assets/javascripts/discourse/lib/keyboard_shortcuts.js
+++ b/app/assets/javascripts/discourse/lib/keyboard_shortcuts.js
@@ -35,7 +35,9 @@ Discourse.KeyboardShortcuts = Ember.Object.createWithMixins({
     'm r': 'div.notification-options li[data-id="1"] a',          // mark topic as regular
     'm t': 'div.notification-options li[data-id="2"] a',          // mark topic as tracking
     'm w': 'div.notification-options li[data-id="3"] a',          // mark topic as watching
-    'n': '#user-notifications',                                   // open notifictions menu
+    'n': '#user-notifications',                                   // open notifications menu
+    '=': '#site-map',                                             // open site map menu
+    'p': '#current-user',                                         // open current user menu
     'o,enter': '.topic-list tr.selected a.title',                 // open selected topic
     'shift+r': '#topic-footer-buttons button.create',             // reply to topic
     'shift+s': '#topic-footer-buttons button.share',              // share topic

--- a/app/assets/javascripts/discourse/templates/modal/keyboard_shortcuts_help.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/modal/keyboard_shortcuts_help.js.handlebars
@@ -24,6 +24,8 @@
       <ul>
         <li>{{{i18n keyboard_shortcuts_help.application.create}}}</li>
         <li>{{{i18n keyboard_shortcuts_help.application.notifications}}}</li>
+        <li>{{{i18n keyboard_shortcuts_help.application.site_map_menu}}}</li>
+        <li>{{{i18n keyboard_shortcuts_help.application.user_profile_menu}}}</li>
         <li>{{{i18n keyboard_shortcuts_help.application.search}}}</li>
         <li>{{{i18n keyboard_shortcuts_help.application.help}}}</li>
       </ul>

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2052,6 +2052,8 @@ en:
         title: 'Application'
         create: '<b>c</b> Create a new topic'
         notifications: '<b>n</b> Open notifications'
+        site_map_menu: '<b>=</b> Open site map menu'
+        user_profile_menu: '<b>p</b> Open user profile menu'
         search: '<b>/</b> Search'
         help: '<b>?</b> Open keyboard shortcuts help'
       actions:


### PR DESCRIPTION
Add shortcuts for Profile Menu and Hamburger Menu

Added shortcuts of p and = for the profile and hamburger menu
https://meta.discourse.org/t/keyboard-shortcuts-wish-list/15952

I'll submit another pull request to set the focus to the first link once I have it figured out
