### PR TITLE
FIX: use short date format for timestamp

### DIFF
--- a/app/assets/javascripts/discourse/helpers/application_helpers.js
+++ b/app/assets/javascripts/discourse/helpers/application_helpers.js
@@ -162,7 +162,7 @@ Handlebars.registerHelper('raw-date', function(property, options) {
   @for Handlebars
 **/
 Em.Handlebars.helper('bound-raw-date', function (date) {
-  return Discourse.Formatter.longDate(new Date(date));
+  return Discourse.Formatter.longDateNoYear(new Date(date));
 });
 
 /**

--- a/app/assets/javascripts/discourse/lib/formatter.js
+++ b/app/assets/javascripts/discourse/lib/formatter.js
@@ -1,7 +1,7 @@
 /* global BreakString:true */
 
 var updateRelativeAge, autoUpdatingRelativeAge, relativeAge, relativeAgeTiny,
-    relativeAgeMedium, relativeAgeMediumSpan, longDate, toTitleCase,
+    relativeAgeMedium, relativeAgeMediumSpan, longDate, longDateNoYear, toTitleCase,
     shortDate, shortDateNoYear, tinyDateYear, relativeAgeTinyShowsYear;
 
 /*
@@ -73,6 +73,17 @@ toTitleCase = function toTitleCase(str) {
 longDate = function(dt) {
   if (!dt) return;
   return moment(dt).longDate();
+};
+
+// suppress year, if current year
+longDateNoYear = function(dt) {
+  if (!dt) return;
+
+  if ((new Date()).getFullYear() !== dt.getFullYear()) {
+    return moment(dt).format("MMM D, 'YY LT");
+  } else {
+    return moment(dt).format("MMM D, LT");
+  }
 };
 
 updateRelativeAge = function(elems) {
@@ -258,6 +269,7 @@ var number = function(val) {
 
 Discourse.Formatter = {
   longDate: longDate,
+  longDateNoYear: longDateNoYear,
   relativeAge: relativeAge,
   autoUpdatingRelativeAge: autoUpdatingRelativeAge,
   updateRelativeAge: updateRelativeAge,


### PR DESCRIPTION
Before:

![screen shot 2014-08-27 at 11 43 44](https://cloud.githubusercontent.com/assets/5732281/4055949/5ffc8612-2db1-11e4-8624-deca890e1b7b.png)

After:
- for current year:

![screen shot 2014-08-27 at 11 29 32](https://cloud.githubusercontent.com/assets/5732281/4055952/7232cb70-2db1-11e4-9a0a-4fc9048057f0.png)
- other than current year:

![screen shot 2014-08-27 at 11 37 29](https://cloud.githubusercontent.com/assets/5732281/4055956/7caf9218-2db1-11e4-94cc-ab3312446ccc.png)

cc @coding-horror 
