### PR TITLE
Fix SSO avatar downloading issues.

### DIFF
--- a/app/models/discourse_single_sign_on.rb
+++ b/app/models/discourse_single_sign_on.rb
@@ -126,10 +126,12 @@ class DiscourseSingleSignOn < SingleSignOn
       avatar_force_update.to_i != 0 ||
       sso_record.external_avatar_url != avatar_url)
       begin
-        tempfile = FileHelper.download(avatar_url, 1.megabyte, "sso-avatar")
+        tempfile = FileHelper.download(avatar_url, 1.megabyte, "sso-avatar", true)
 
-        upload = Upload.create_for(user.id, tempfile, "external-avatar", File.size(tempfile.path), { origin: avatar_url })
+        ext = FastImage.type(tempfile).to_s
+        tempfile.rewind
 
+        upload = Upload.create_for(user.id, tempfile, "external-avatar." + ext, File.size(tempfile.path), { origin: avatar_url })
         user.uploaded_avatar_id = upload.id
 
         if !user.user_avatar.contains_upload?(upload.id)


### PR DESCRIPTION
Fixes some things I missed (sorry).
- Follow redirects when downloading SSO avatars. — Some servers does redirections (because of caching, whatsnot). A more valid use case are servers that redirects from http to https, which, unfortunately, OpenURI disables no matter what. The solution here is to just have the SSO host serve urls that don't redirect from http to https.
- Add proper image extensions to downloaded SSO avatars. — Used FastImage to detect the actual image type rather than relying on the filename.

`Upload.create_for` could, and should probably handle file detection/extension (right now, it just checks the supplied filename if it's an image). But I just went for the route which touches the least number of components.
