### PR TITLE
Set focus on first item in drop down (textbox, link, whatever it may be)

### DIFF
--- a/app/assets/javascripts/discourse/views/header.js.es6
+++ b/app/assets/javascripts/discourse/views/header.js.es6
@@ -58,7 +58,7 @@ export default Discourse.View.extend({
     // fade it fast
     $dropdown.fadeIn('fast');
     // autofocus any text input field
-    $dropdown.find('input[type=text]').focus().select();
+    $dropdown.find('input[type=text],a:first').focus().select();
 
     $html.on('click.d-dropdown', function(e) {
       return $(e.target).closest('.d-dropdown').length > 0 ? true : hideDropdown.apply(self);


### PR DESCRIPTION
Set focus on first item in the drop down for keyboard users, so they can quickly tab to the link/item of their choosing.
https://meta.discourse.org/t/keyboard-shortcuts-wish-list/15952
