### PR TITLE
UX: Add missing German locale files

### DIFF
--- a/plugins/poll/config/locales/client.de.yml
+++ b/plugins/poll/config/locales/client.de.yml
@@ -1,0 +1,18 @@
+# encoding: utf-8
+#
+# Never edit this file. It will be overwritten when translations are pulled from Transifex.
+#
+# To work with us on translations, join this project:
+# https://www.transifex.com/projects/p/discourse-org/
+
+de:
+  js:
+    poll:
+      voteCount:
+        one: "1 Stimme"
+        other: "%{count} Stimmen"
+      results:
+        show: Ergebnisse anzeigen
+        hide: Ergebnisse ausblenden
+      close_poll: "Umfrage beenden"
+      open_poll: "Umfrage starten"

--- a/plugins/poll/config/locales/server.de.yml
+++ b/plugins/poll/config/locales/server.de.yml
@@ -1,0 +1,18 @@
+# encoding: utf-8
+#
+# Never edit this file. It will be overwritten when translations are pulled from Transifex.
+#
+# To work with us on translations, join this project:
+# https://www.transifex.com/projects/p/discourse-org/
+
+de:
+  activerecord:
+    attributes:
+      post:
+        poll_options: "Umfrageoptionen"
+  poll:
+    must_contain_poll_options: "muss eine Liste mit Umfrageoptionen enthalten"
+    cannot_have_modified_options: "können nach den ersten 5 Minuten nicht mehr geändert werden. Kontaktiere einen Moderator, wenn du sie ändern möchtest."
+    cannot_add_or_remove_options: "können nur bearbeitet, jedoch nicht hinzugefügt oder entfernt werden. Wenn du Optionen hinzufügen oder entfernen möchtest, solltest du dieses Thema sperren und ein neues erstellen."
+    prefix: "Umfrage"
+    closed_prefix: "Beendete Umfrage"

--- a/public/403.de.html
+++ b/public/403.de.html
@@ -1,0 +1,26 @@
+<html>
+<head>
+<title>Das darfst du nicht (403)</title>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<style type="text/css">
+    body { background-color: #fff; color: #666; text-align: center; font-family: arial, sans-serif; }
+    div.dialog {
+      width: 25em;
+      padding: 0 4em;
+      margin: 4em auto 0 auto;
+      border: 1px solid #ccc;
+      border-right-color: #999;
+      border-bottom-color: #999;
+    }
+    h1 { font-size: 400%; color: #f00; line-height: 1em; }
+  </style>
+</head>
+<body>
+  <div class="dialog">
+    <h1>403</h1>
+    <p>Du kannst diesen Inhalt nicht ansehen!</p>
+
+    <p>Das wird durch eine eigene Discourse 403 Seite ersetzt.</p>
+  </div>
+</body>
+</html>

--- a/public/422.de.html
+++ b/public/422.de.html
@@ -1,0 +1,25 @@
+<html>
+<head>
+<title>Die gewünschte Änderung wurde abgelehnt (422)</title>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<style type="text/css">
+    body { background-color: #fff; color: #666; text-align: center; font-family: arial, sans-serif; }
+    div.dialog {
+      width: 25em;
+      padding: 0 4em;
+      margin: 4em auto 0 auto;
+      border: 1px solid #ccc;
+      border-right-color: #999;
+      border-bottom-color: #999;
+    }
+    h1 { font-size: 100%; color: #f00; line-height: 1.5em; }
+  </style>
+</head>
+<body>
+  <!-- This file lives in public/422.html -->
+  <div class="dialog">
+    <h1>Die gewünschte Änderung wurde abgelehnt.</h1>
+    <p>Vielleicht hast du versucht etwas zu ändern, worauf du keinen Zugriff hast.</p>
+  </div>
+</body>
+</html>

--- a/public/500.de.html
+++ b/public/500.de.html
@@ -1,0 +1,12 @@
+<html>
+<head>
+<title>Hoppla - Fehler 500</title>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+</head>
+<body>
+    <h1>Hoppla</h1>
+    <p>Die von diesem Diskussionforum verwendete Software ist auf ein unerwartetes Problem gestoßen. Wir entschuldigen uns für die Unannehmlichkeit.</p>
+    <p>Detaillierte Informationen über den Fehler wurden gespeichert und eine automatische Benachrichtigung wurde generiert. Wir werden uns darum kümmern.</p>
+    <p>Du musst nichts Weiteres tun. Falls der Fehler jedoch bestehen bleibt, kannst du zusätzliche Details inkl. Schritte zur Reproduktion des Fehlers melden, indem du ein neues Thema in der <a href="/category/meta">Meta-Kategorie</a> erstellst.</p>
+</body>
+</html>

--- a/public/503.de.html
+++ b/public/503.de.html
@@ -1,0 +1,11 @@
+<html>
+<head>
+<title>Website wird gerade gewartet - Discourse.org</title>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+</head>
+<body>
+    <h1>Wir sind momentan nicht erreichbar, weil die Seite planmäßig gewartet wird</h1>
+    <p>Bitte komme <span id="when-to-check-back">in ein paar Minuten</span> wieder.</p>
+    <p id="apology">Entschuldige die Unannehmlichkeit!</p>
+</body>
+</html>


### PR DESCRIPTION
Some German translation files were missing. Looks like `pull_translations.rb` pulls only files that already exist (unless started with the parameter `force`).
