### PR TITLE
UX: Add keyboard binding for reply as new topic

### DIFF
--- a/app/assets/javascripts/discourse/lib/keyboard_shortcuts.js
+++ b/app/assets/javascripts/discourse/lib/keyboard_shortcuts.js
@@ -22,7 +22,8 @@ Discourse.KeyboardShortcuts = Ember.Object.createWithMixins({
     'e': 'editPost',
     'l': 'toggleLike',
     'r': 'replyToPost',
-    '!': 'showFlags'
+    '!': 'showFlags',
+    't': 'replyAsNewTopic'
   },
 
   CLICK_BINDINGS: {

--- a/app/assets/javascripts/discourse/templates/modal/keyboard_shortcuts_help.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/modal/keyboard_shortcuts_help.js.handlebars
@@ -36,6 +36,7 @@
         <li>{{{i18n keyboard_shortcuts_help.actions.star}}}</li>
         <li>{{{i18n keyboard_shortcuts_help.actions.share_topic}}}</li>
         <li>{{{i18n keyboard_shortcuts_help.actions.share_post}}}</li>
+        <li>{{{i18n keyboard_shortcuts_help.actions.reply_as_new_topic}}}</li>
         <li>{{{i18n keyboard_shortcuts_help.actions.reply_topic}}}</li>
         <li>{{{i18n keyboard_shortcuts_help.actions.reply_post}}}</li>
         <li>{{{i18n keyboard_shortcuts_help.actions.quote_post}}}</li>

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2063,6 +2063,7 @@ en:
         star: '<b>f</b> Star topic'
         share_topic: '<b>shift s</b> Share topic'
         share_post: '<b>s</b> Share post'
+        reply_as_new_topic: '<b>t</b> Reply as new topic'
         reply_topic: '<b>shift r</b> Reply to topic'
         reply_post: '<b>r</b> Reply to post'
         quote_post: '<b>q</b> Quote post'


### PR DESCRIPTION
Added keyboard binding for reply as new topic, 't', when a post is selected.
https://meta.discourse.org/t/reply-as-new-topic-keyboard-problem/15807/19
