### PR TITLE
FIX: Support J/K bindings on German Keyboards

### DIFF
--- a/app/assets/javascripts/discourse/lib/keyboard_shortcuts.js
+++ b/app/assets/javascripts/discourse/lib/keyboard_shortcuts.js
@@ -52,8 +52,6 @@ Discourse.KeyboardShortcuts = Ember.Object.createWithMixins({
     'shift+k': 'prevSection',
     'k': 'selectUp',
     'u': 'goBack',
-    '`': 'nextSection',
-    '~': 'prevSection',
     '/': 'showSearch',
     '=': 'showSiteMap',                                             // open site map menu
     'p': 'showCurrentUser',                                         // open current user menu

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2049,7 +2049,7 @@ en:
         back: '<b>u</b> Back'
         up_down: '<b>k</b>/<b>j</b> Move selection up/down'
         open: '<b>o</b> or <b>Enter</b> Open selected topic'
-        next_prev: '<b>`</b>/<b>~</b> Next/previous section'
+        next_prev: '<b>shift j</b>/<b>shift k</b> Next/previous section'
       application:
         title: 'Application'
         create: '<b>c</b> Create a new topic'


### PR DESCRIPTION
Added shift+k and shift+j to the keyboard bindings to help those with german keyboard layouts.
https://meta.discourse.org/t/keyboard-shortcuts-for-next-previous-section-do-not-work-with-german-keyboard-layout/18902
