### PR TITLE
FIX: use short date format for post navigator

### DIFF
--- a/app/assets/javascripts/discourse/controllers/topic-entrance.js.es6
+++ b/app/assets/javascripts/discourse/controllers/topic-entrance.js.es6
@@ -8,12 +8,12 @@ function entranceDate(dt, showTime) {
   if (dt.getYear() === today.getYear()) {
     // No year
     return moment(dt).format(
-      showTime ? I18n.t("dates.long_no_year") : I18n.t("dates.long_no_year_no_time")
+      showTime ? I18n.t("dates.long_date_without_year") : I18n.t("dates.long_no_year_no_time")
     );
   }
 
   return moment(dt).format(
-    showTime ? I18n.t('dates.long_with_year') : I18n.t('dates.long_with_year_no_time')
+    showTime ? I18n.t('dates.long_date_with_year') : I18n.t('dates.long_date_with_year_without_time')
   );
 }
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -37,6 +37,7 @@ en:
       long_with_year_no_time: "MMM D, YYYY"
       long_date_with_year: "MMM D, 'YY LT"
       long_date_without_year: "MMM D, LT"
+      long_date_with_year_without_time: "MMM D, 'YY"
       tiny:
         half_a_minute: "< 1m"
         less_than_x_seconds:


### PR DESCRIPTION
Example:

![screenshot from 2014-08-30 11 35 33](https://cloud.githubusercontent.com/assets/5732281/4098221/c083d9c0-300b-11e4-9e15-df8e402b598c.png)
