### PR TITLE
UX: add line break before time for post navigator

### DIFF
--- a/app/assets/javascripts/discourse/controllers/topic-entrance.js.es6
+++ b/app/assets/javascripts/discourse/controllers/topic-entrance.js.es6
@@ -8,12 +8,12 @@ function entranceDate(dt, showTime) {
   if (dt.getYear() === today.getYear()) {
     // No year
     return moment(dt).format(
-      showTime ? I18n.t("dates.long_date_without_year") : I18n.t("dates.long_no_year_no_time")
+      showTime ? I18n.t("dates.long_date_without_year_with_linebreak") : I18n.t("dates.long_no_year_no_time")
     );
   }
 
   return moment(dt).format(
-    showTime ? I18n.t('dates.long_date_with_year') : I18n.t('dates.long_date_with_year_without_time')
+    showTime ? I18n.t('dates.long_date_with_year_with_linebreak') : I18n.t('dates.long_date_with_year_without_time')
   );
 }
 

--- a/app/assets/javascripts/discourse/templates/topic-entrance.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/topic-entrance.js.handlebars
@@ -1,6 +1,6 @@
 <button {{action enterTop}} class='btn full no-text jump-top'>
-  <i class='fa fa-caret-up'></i> {{topDate}}
+  <i class='fa fa-caret-up'></i> {{{topDate}}}
 </button>
 <button {{action enterBottom}} class='btn full no-text jump-bottom'>
-  {{bottomDate}} <i class='fa fa-caret-down'></i>
+  {{{bottomDate}}} <i class='fa fa-caret-down'></i>
 </button>

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -38,6 +38,8 @@ en:
       long_date_with_year: "MMM D, 'YY LT"
       long_date_without_year: "MMM D, LT"
       long_date_with_year_without_time: "MMM D, 'YY"
+      long_date_without_year_with_linebreak: "MMM D <br/>LT"
+      long_date_with_year_with_linebreak: "MMM D, 'YY <br/>LT"
       tiny:
         half_a_minute: "< 1m"
         less_than_x_seconds:


### PR DESCRIPTION
Example:
- with year:

![screen shot 2014-08-30 at 16 25 06](https://cloud.githubusercontent.com/assets/5732281/4098751/fbdf49ea-3034-11e4-837b-69a05ca040e3.png)
- without year:

![screen shot 2014-08-30 at 16 24 08](https://cloud.githubusercontent.com/assets/5732281/4098750/fbdeace2-3034-11e4-98b7-fffdcd7cf01f.png)
