### PR TITLE
FIX: j/k navigation for posts using Firefox

### DIFF
--- a/app/assets/javascripts/discourse/lib/keyboard_shortcuts.js
+++ b/app/assets/javascripts/discourse/lib/keyboard_shortcuts.js
@@ -211,7 +211,7 @@ Discourse.KeyboardShortcuts = Ember.Object.createWithMixins({
 
     // if nothing is selected go to the first post on screen
     if ($selected.length === 0) {
-      var scrollTop = $('body').scrollTop();
+      var scrollTop = $(document).scrollTop();
 
       index = 0;
       $articles.each(function(){


### PR DESCRIPTION
Using the j/k keyboard shortcuts was broken in Firefox for posts.
https://meta.discourse.org/t/j-k-navigation-in-lengthy-topics/18945
