### PR TITLE
FIX: Markdown parser: empty links and bbcode parsed as link refs

### DIFF
--- a/test/javascripts/lib/markdown-test.js.es6
+++ b/test/javascripts/lib/markdown-test.js.es6
@@ -119,6 +119,10 @@ test("Links", function() {
 
   cooked("[3]: http://eviltrout.com", "", "It doesn't autolink markdown link references");
 
+  cooked("[]: http://eviltrout.com", "<p>[]: <a href=\"http://eviltrout.com\">http://eviltrout.com</a></p>", "It doesn't accept empty link references");
+
+  cooked("[b]label[/b]: description", "<p><span class=\"bbcode-b\">label</span>: description</p>", "It doesn't accept BBCode as link references");
+
   cooked("http://discourse.org and http://discourse.org/another_url and http://www.imdb.com/name/nm2225369",
          "<p><a href=\"http://discourse.org\">http://discourse.org</a> and " +
          "<a href=\"http://discourse.org/another_url\">http://discourse.org/another_url</a> and " +

--- a/vendor/assets/javascripts/better_markdown.js
+++ b/vendor/assets/javascripts/better_markdown.js
@@ -1135,7 +1135,7 @@
       },
 
       referenceDefn: function referenceDefn( block, next) {
-        var re = /^\s*\[(.*?)\]:\s*(\S+)(?:\s+(?:(['"])(.*)\3|\((.*?)\)))?\n?/;
+        var re = /^\s*\[([^\[\]]+)\]:\s*(\S+)(?:\s+(?:(['"])(.*)\3|\((.*?)\)))?\n?/;
         // interesting matches are [ , ref_id, url, , title, title ]
 
         if ( !block.match(re) )
@@ -1294,6 +1294,8 @@
         if ( !res[1] ) {
           return [ res[0] + 1, text.charAt(0) ].concat(res[2]);
         }
+
+        if ( res[0] == 1 ) { return [ 2, "[]" ]; } // empty link found.
 
         var consumed = 1 + res[ 0 ],
             children = res[ 1 ],


### PR DESCRIPTION
See https://meta.discourse.org/t/content-disappears-presumably-attempting-to-find-a-matching-emoji-link/19462
