### PR TITLE
FIX: destroy CategoryGroup when Category or Group is destroyed

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -19,7 +19,7 @@ class Category < ActiveRecord::Base
   has_many :category_featured_users
   has_many :featured_users, through: :category_featured_users, source: :user
 
-  has_many :category_groups
+  has_many :category_groups, dependent: :destroy
   has_many :groups, through: :category_groups
 
   validates :user_id, presence: true

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,7 +1,7 @@
 class Group < ActiveRecord::Base
   include HasCustomFields
 
-  has_many :category_groups
+  has_many :category_groups, dependent: :destroy
   has_many :group_users, dependent: :destroy
 
   has_many :categories, through: :category_groups

--- a/db/migrate/20140831191346_remove_category_groups_orphaned_by_removing_category_or_group.rb
+++ b/db/migrate/20140831191346_remove_category_groups_orphaned_by_removing_category_or_group.rb
@@ -1,0 +1,13 @@
+class RemoveCategoryGroupsOrphanedByRemovingCategoryOrGroup < ActiveRecord::Migration
+  def up
+    execute "DELETE FROM category_groups
+             WHERE group_id NOT IN (
+                 SELECT groups.id FROM groups)
+              OR category_id NOT IN (
+                 SELECT categories.id FROM categories)"
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
Fixes https://meta.discourse.org/t/destroying-a-category-does-not-destroy-dependent-categorygroup-models/18937
