### PR TITLE
FIX: Duplicate badge titles can still occur

### DIFF
--- a/app/assets/javascripts/discourse/controllers/preferences/badge-title.js.es6
+++ b/app/assets/javascripts/discourse/controllers/preferences/badge-title.js.es6
@@ -20,7 +20,7 @@ export default Ember.ArrayController.extend({
 
   selectableUserBadges: function() {
     var items = this.get('model').filterBy('badge.allow_title', true);
-    items = _.uniq(items, true, function(e) { return e.get('badge.name'); });
+    items = _.uniq(items, false, function(e) { return e.get('badge.name'); });
     items.unshiftObject(Em.Object.create({
           badge: Discourse.Badge.create({name: I18n.t('badges.no_title')})
     }));


### PR DESCRIPTION
Send false instead of true to .uniq as the badges are not sorted.
https://meta.discourse.org/t/set-title-dialog-shows-multiple-instances-of-the-same-badge-2/19495
