### PR TITLE
FIX: Do not perform grants if badges are disabled

### DIFF
--- a/app/jobs/scheduled/badge_grant.rb
+++ b/app/jobs/scheduled/badge_grant.rb
@@ -8,6 +8,7 @@ module Jobs
     every 1.day
 
     def execute(args)
+      return unless SiteSetting.enable_badges
       Badge.all.each do |b|
         BadgeGranter.backfill(b)
       end

--- a/app/services/badge_granter.rb
+++ b/app/services/badge_granter.rb
@@ -68,6 +68,7 @@ class BadgeGranter
   end
 
   def self.queue_badge_grant(type,opt)
+    return unless SiteSetting.enable_badges
     payload = nil
 
     case type
@@ -208,6 +209,7 @@ class BadgeGranter
 
   MAX_ITEMS_FOR_DELTA = 200
   def self.backfill(badge, opts=nil)
+    return unless SiteSetting.enable_badges
     return unless badge.query.present? && badge.enabled
 
     post_ids = user_ids = nil

--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -108,7 +108,10 @@ class Guardian
   alias :can_move_posts? :can_moderate?
   alias :can_see_flags? :can_moderate?
   alias :can_send_activation_email? :can_moderate?
-  alias :can_grant_badges? :can_moderate?
+
+  def can_grant_badges?(_user)
+    SiteSetting.enable_badges && is_staff?
+  end
 
   def can_see_group?(group)
     group.present? && (is_admin? || group.visible?)


### PR DESCRIPTION
https://meta.discourse.org/t/discourse-keeps-granting-badges-even-though-badges-have-been-disabled/19510
