### PR TITLE
FEATURE: Allow manual excerpt to be defined past the beginning of the po...

### DIFF
--- a/lib/excerpt_parser.rb
+++ b/lib/excerpt_parser.rb
@@ -63,6 +63,8 @@ class ExcerptParser < Nokogiri::XML::SAX::Document
 
       when "div", "span"
         if attributes.include?(["class", "excerpt"])
+          @excerpt = ""
+          @current_length = 0
           @start_excerpt = true
         end
         # Preserve spoilers

--- a/spec/components/pretty_text_spec.rb
+++ b/spec/components/pretty_text_spec.rb
@@ -190,10 +190,20 @@ describe PrettyText do
       PrettyText.excerpt(nil,100).should == ''
     end
 
-    it "handles span excerpt" do
+    it "handles span excerpt at the beginning of a post" do
       PrettyText.excerpt("<span class='excerpt'>hi</span> test",100).should == 'hi'
       post = Fabricate(:post, raw: "<span class='excerpt'>hi</span> test")
       post.excerpt.should == "hi"
+    end
+
+    it "handles span excerpt that starts before the max length" do
+      text =  "123456789 123456789 12345679 123456789 123456789 " +
+              "as long as span starts before max length of the " +
+              "<span class='excerpt'>the specified excerpt</span>" +
+              "of the post  will be used"
+      PrettyText.excerpt(text, 100).should == 'the specified excerpt'
+      post = Fabricate(:post, raw: text)
+      post.excerpt.should == 'the specified excerpt'
     end
 
   end


### PR DESCRIPTION
There is still a limitation that the span excerpt must begin before the post_excerpt_max_length.
