### PR TITLE
FIX: Add .cooked class to composer preview

### DIFF
--- a/app/assets/javascripts/discourse/templates/composer.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/composer.js.handlebars
@@ -62,8 +62,9 @@
             {{composer-text-area tabindex="3" value=model.reply}}
             {{popupInputTip validation=view.replyValidation shownAt=view.showReplyTip}}
           </div>
-          <div class='preview-wrapper'>
-            <div id='wmd-preview' {{bind-attr class="hidePreview:hidden"}}></div>
+          <!-- keep the classes here in sync with post.js.handlebars -->
+          <div class='preview-wrapper contents regular'>
+            <div id='wmd-preview' {{bind-attr class="hidePreview:hidden :cooked"}}></div>
           </div>
           <div class="composer-bottom-right">
             <a href="#" {{action togglePreview}} class='toggle-preview'>{{{model.toggleText}}}</a>

--- a/app/assets/javascripts/discourse/templates/post.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/post.js.handlebars
@@ -61,6 +61,7 @@
         <button {{action toggledSelectedPost this}} class="select-post">{{view.selectPostText}}</button>
       </div>
 
+      <!-- keep the classes here in sync with composer.js.handlebars -->
       <div {{bind-attr class="showUserReplyTab:avoid-tab view.repliesShown::bottom-round :contents :regular view.extraClass"}}>
         <div class='cooked'>
           {{{cooked}}}


### PR DESCRIPTION
This should make any custom styling apply to both the rendered posts and
the composer equally, as long as a .topic-body parent or a #wmd-preview
parent is not specified.
