### PR TITLE
FIX: Move post edit cooking into PostRevisor

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -401,7 +401,6 @@ class Post < ActiveRecord::Base
 
   before_save do
     self.last_editor_id ||= user_id
-    self.cooked = cook(raw, topic_id: topic_id) unless new_record?
     self.baked_at = Time.new
     self.baked_version = BAKED_VERSION
   end

--- a/lib/post_revisor.rb
+++ b/lib/post_revisor.rb
@@ -108,6 +108,8 @@ class PostRevisor
       @post.unhide!
     end
 
+    @post.cooked = @post.cook(@new_raw, topic_id: @post.topic_id)
+
     @post.extract_quoted_post_numbers
     @post.save(validate: !@opts[:skip_validations])
 


### PR DESCRIPTION
Little bit urgent, this is causing revisions to be uncooked.

This was caused by me wrapping PostRevisor in a transaction, which threw off the timing of the `before_save` block.
