### PR TITLE
hide category name for Uncategorized topics while oneboxing

### DIFF
--- a/lib/onebox/engine/discourse_local_onebox.rb
+++ b/lib/onebox/engine/discourse_local_onebox.rb
@@ -57,9 +57,10 @@ module Onebox
               }
             end
 
+            category_name = ''
             category = topic.category
-            if category
-              category = "<a href=\"#{category.url}\" class=\"badge badge-category\" style=\"background-color: ##{category.color}; color: ##{category.text_color}\">#{category.name}</a>"
+            if category && !category.uncategorized?
+              category_name = "<a href=\"#{category.url}\" class=\"badge badge-category\" style=\"background-color: ##{category.color}; color: ##{category.text_color}\">#{category.name}</a>"
             end
 
             quote = post.excerpt(SiteSetting.post_onebox_maxlength)
@@ -71,7 +72,7 @@ module Onebox
                         views: topic.views,
                         posters: posters,
                         quote: quote,
-                        category: category,
+                        category_name: category_name,
                         topic: topic.id
 
             @template = 'topic'

--- a/lib/onebox/templates/discourse_topic_onebox.handlebars
+++ b/lib/onebox/templates/discourse_topic_onebox.handlebars
@@ -2,7 +2,7 @@
   <div class='title'>
     <div class='quote-controls'></div>
     {{{avatar}}}
-    <a href="{{original_url}}">{{title}}</a> {{{category}}}
+    <a href="{{original_url}}">{{title}}</a> {{{category_name}}}
   </div>
   <blockquote>{{{quote}}}
     <div class='topic-info'>


### PR DESCRIPTION
If the topic category is "Uncategorized" then do not show category badge in onebox. Example:

![screen shot 2014-09-04 at 15 12 39](https://cloud.githubusercontent.com/assets/5732281/4147381/e0f25f1e-3417-11e4-9a94-25422a5eeb52.png)
