### PR TITLE
UX: Add g, t keyboard shortcut to modal window for go to top

### DIFF
--- a/app/assets/javascripts/discourse/templates/modal/keyboard_shortcuts_help.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/modal/keyboard_shortcuts_help.js.handlebars
@@ -9,6 +9,7 @@
         <li>{{{i18n keyboard_shortcuts_help.jump_to.unread}}}</li>
         <li>{{{i18n keyboard_shortcuts_help.jump_to.starred}}}</li>
         <li>{{{i18n keyboard_shortcuts_help.jump_to.categories}}}</li>
+        <li>{{{i18n keyboard_shortcuts_help.jump_to.top}}}</li>
       </ul>
       <h4>{{i18n keyboard_shortcuts_help.navigation.title}}</h4>
       <ul>

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2064,6 +2064,7 @@ en:
         unread: '<b>g</b>, <b>u</b> Unread'
         starred: '<b>g</b>, <b>f</b> Starred'
         categories: '<b>g</b>, <b>c</b> Categories'
+        top: '<b>g</b>, <b>t</b> Top'
       navigation:
         title: 'Navigation'
         jump: '<b>#</b> Go to post number'


### PR DESCRIPTION
Add go to top shortcut to the keyboard shortcut modal window
https://meta.discourse.org/t/add-shortcut-g-t-to-go-to-top-page/19586
