### PR TITLE
Add group names to user export csv

### DIFF
--- a/app/jobs/regular/export_csv_file.rb
+++ b/app/jobs/regular/export_csv_file.rb
@@ -25,7 +25,9 @@ module Jobs
 
           user_data.each do |user|
             user_array = Array.new
+            group_names = get_group_names(user).join(';')
             user_array.push(user['id']).push(user['name']).push(user['username']).push(user['email'])
+            user_array.push(group_names) if group_names != ''
             data.push(user_array)
           end
       end
@@ -39,6 +41,15 @@ module Jobs
     end
 
     private
+
+      def get_group_names(user)
+        group_names = []
+        groups = user.custom_groups
+        groups.each do |group|
+          group_names.push(group.name)
+        end
+        return group_names
+      end
 
       def set_file_path
         @file_name = "export_#{SecureRandom.hex(4)}.csv"


### PR DESCRIPTION
Add group names in User Export CSV. Multiple group names are separated with colon (;)

Example:

![screen shot 2014-09-06 at 21 17 44](https://cloud.githubusercontent.com/assets/5732281/4175604/3b90195e-35dd-11e4-9bcf-4fe9ceae5a12.png)
