### PR TITLE
correct trust level name

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -288,7 +288,7 @@ en:
     leader:
       title: "regular"
     elder:
-      title: "elder"
+      title: "leader"
     change_failed_explanation: "You attempted to demote %{user_name} to '%{new_trust_level}'. However their trust level is already '%{current_trust_level}'. %{user_name} will remain at '%{current_trust_level}'"
 
 


### PR DESCRIPTION
I suggest that the keys for trust levels should be renamed to `trust_level_1` etc.
Currently it's quite confusing and leads to errors like this one.
