### PR TITLE
UX: Filter for "Reply key" was not translatable in Transifex

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1740,7 +1740,7 @@ en:
             user_placeholder: "username"
             address_placeholder: "name@example.com"
             type_placeholder: "digest, signup..."
-            reply_key_placeholder: ""
+            reply_key_placeholder: "reply key"
             skipped_reason_placeholder: "reason"
 
       logs:


### PR DESCRIPTION
Empty strings are not translatable in Transifex.
