### PR TITLE
Don't set content-disposition header for images

### DIFF
--- a/lib/file_store/s3_store.rb
+++ b/lib/file_store/s3_store.rb
@@ -139,7 +139,11 @@ module FileStore
         public: true,
         body: file
       }
-      args[:content_disposition] = "attachment; filename=\"#{filename}\"" if filename
+
+      if filename && !FileHelper.is_image?(filename)
+        args[:content_disposition] = "attachment; filename=\"#{filename}\""
+      end
+
       args[:content_type] = content_type if content_type
 
       get_or_create_directory(s3_bucket).files.create(args)


### PR DESCRIPTION
If this header is set for images, clicking the image link causes them to automatically download the file, rather than viewing it inside the browser. This commit forces this behavior only for uploads that aren't images
