### PR TITLE
UX: Add password instructions to Reset Password page

### DIFF
--- a/app/views/users/password_reset.html.erb
+++ b/app/views/users/password_reset.html.erb
@@ -37,6 +37,7 @@
       <%=form_tag({}, method: :put) do %>
         <p>
         <input id="user_password" name="password" size="30" type="password">
+        <label><%= t('js.user.password.instructions', count: SiteSetting.min_password_length) %></label>
         </p>
         <p>
         <%=submit_tag( @user.has_password? ? t('password_reset.update') : t('password_reset.save'), class: 'btn')%>


### PR DESCRIPTION
Added the password instructions to the reset password page.
https://meta.discourse.org/t/reset-password-doesnt-give-password-requirements/19799
