### PR TITLE
FIX: fix dialect block ordering

### DIFF
--- a/app/assets/javascripts/discourse/dialects/dialect.js
+++ b/app/assets/javascripts/discourse/dialects/dialect.js
@@ -21,6 +21,11 @@ var parser = window.BetterMarkdown,
 **/
 function initializeDialects() {
   MD.buildBlockOrder(dialect.block);
+  var index = dialect.block.__order__.indexOf("code");
+  if (index > -1) {
+    dialect.block.__order__.splice(index, 1);
+    dialect.block.__order__.unshift("code");
+  }
   MD.buildInlinePatterns(dialect.inline);
   initialized = true;
 }

--- a/test/javascripts/lib/markdown-test.js.es6
+++ b/test/javascripts/lib/markdown-test.js.es6
@@ -379,6 +379,14 @@ test("Code Blocks", function() {
   cooked("```\nline1\n```\n```\nline2\n\nline3\n```",
          "<p><pre><code class=\"lang-auto\">line1</code></pre></p>\n\n<p><pre><code class=\"lang-auto\">line2\n\nline3</code></pre></p>",
          "it does not consume next block's trailing newlines");
+
+  cooked("    <pre>test</pre>",
+         "<pre><code>&lt;pre&gt;test&lt;/pre&gt;</code></pre>",
+         "it does not parse other block types in markdown code blocks");
+
+  cooked("    [quote]test[/quote]",
+         "<pre><code>[quote]test[/quote]</code></pre>",
+         "it does not parse other block types in markdown code blocks");
 });
 
 test("sanitize", function() {


### PR DESCRIPTION
See https://meta.discourse.org/t/preformatted-text-not-working-quite-right/19830/2?u=elberet

> the Discourse code dialect fires before the markdown code dialect. This reorders the block dialects so that the Gruber code handler is always called first.
