### PR TITLE
add rake task and seed data for discourse_api

### DIFF
--- a/db/api_test_seeds.rb
+++ b/db/api_test_seeds.rb
@@ -1,0 +1,2 @@
+User.create(name: "Test User", email: "test_user@example.com", password: "password", username: "test_user", approved: true, active: true, auth_token: "39a925803ddc658a68a7e276e558ed62", admin: true)
+ApiKey.create(key: 'test_d7fd0429940', user_id: 1, created_by_id: 1)

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -25,6 +25,11 @@ task 'test:prepare' => 'environment' do
   SeedFu.seed
 end
 
+task 'db:api_test_seed' => 'environment' do
+  puts "Loading test data for discourse_api"
+  load Rails.root + 'db/api_test_seeds.rb'
+end
+
 desc 'Rebuild indexes'
 task 'db:rebuild_indexes' => 'environment' do
   if Import::backup_tables_count > 0


### PR DESCRIPTION
Add seed data for running the discourse_api tests. See "Testing" section in thediscourse_api [README](https://github.com/discourse/discourse_api/blob/master/README.md)
