### PR TITLE
PERF: Tame eager-loading of category definition topic

### DIFF
--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -246,7 +246,7 @@ class TopicQuery
       end
 
       result = apply_ordering(result, options)
-      result = result.listable_topics.includes(category: :topic_only_relative_url)
+      result = result.listable_topics.includes(:category)
       result = result.where('categories.name is null or categories.name <> ?', options[:exclude_category]).references(:categories) if options[:exclude_category]
 
       # Don't include the category topics if excluded


### PR DESCRIPTION
With this change, the EXPLAIN on the topic query is reduced in estimated cost by about 12%, and script/bench.rb results are improved by about 30% on the homepage.

No new N+1 queries are introduced.

In short, **better than expected**.

---

Explain topic query, cost at root level:

cost=641.84..641.92 --> cost=570.03..570.11

script/bench.rb result, 50th percentile:
## BEFORE

```
categories_admin: 95
home_admin: 80
topic_admin: 33
categories: 71
home: 51
topic: 15
```
## AFTER

```
categories_admin: 78
home_admin: 58
topic_admin: 49
categories: 40
home: 34
topic: 30
```
