### PR TITLE
Add visible/invisible status for Advanced Users

### DIFF
--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -290,6 +290,8 @@ class TopicQuery
           result = result.where('topics.archived')
         when 'visible'
           result = result.where('topics.visible')
+        when 'invisible'
+          result = result.where('NOT topics.visible')
         end
       end
 


### PR DESCRIPTION
Add the ability to filter the topic list to show visible/invisible topics
https://meta.discourse.org/t/add-visible-invisible-filter-for-advanced-users/19956
