### PR TITLE
FIX: Add css class 'star' for respective table header element. 

### DIFF
--- a/app/assets/javascripts/discourse/templates/discovery/topics.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/discovery/topics.js.handlebars
@@ -31,7 +31,7 @@
       <thead>
       <tr>
         {{#if currentUser}}
-        <th>
+        <th class='star'>
           {{#if canBulkSelect}}
           <button class='btn bulk-select' {{action toggleBulkSelect}} title="{{i18n topics.bulk.toggle}}"><i class='fa fa-list'></i></button>
           {{/if}}


### PR DESCRIPTION
Allows custom css rules to hide the "star" column.
