### PR TITLE
makes upload buttons less shouty

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -479,7 +479,7 @@ en:
         bulk_invite:
           none: "You haven't invited anyone here yet. You can send individual invites, or invite a bunch of people at once by <a href='https://meta.discourse.org/t/send-bulk-invites/16468'>uploading a bulk invite file</a>."
           text: "Bulk Invite from File"
-          uploading: "UPLOADING"
+          uploading: "Uploading..."
           success: "File uploaded successfully, you will be notified shortly with progress."
           error: "There was an error uploading '{{filename}}': {{message}}"
 
@@ -1613,8 +1613,8 @@ en:
           filename: "Filename"
           size: "Size"
         upload:
-          text: "UPLOAD"
-          uploading: "UPLOADING"
+          text: "Upload"
+          uploading: "Uploading..."
           success: "'{{filename}}' has successfully been uploaded."
           error: "There has been an error while uploading '{{filename}}': {{message}}"
         operations:


### PR DESCRIPTION
A few of the upload buttons in the admin panel are quite shouty for some reason.

https://meta.discourse.org/t/arbitrary-all-caps-upload-button-on-backups-page/19967
