### PR TITLE
stripping port information from Discourse.BaseUrl

### DIFF
--- a/app/views/common/_discourse_javascript.html.erb
+++ b/app/views/common/_discourse_javascript.html.erb
@@ -31,7 +31,7 @@
 
 <script>
   Discourse.CDN = '<%= Rails.configuration.action_controller.asset_host %>';
-  Discourse.BaseUrl = '<%= RailsMultisite::ConnectionManagement.current_hostname %>';
+  Discourse.BaseUrl = '<%= RailsMultisite::ConnectionManagement.current_hostname %>'.replace(/:[\d]*$/,"");
   Discourse.BaseUri = '<%= Discourse::base_uri "/" %>';
   Discourse.Environment = '<%= Rails.env %>';
   Discourse.SiteSettings = PreloadStore.get('siteSettings');


### PR DESCRIPTION
Port information if presented in Discourse.BaseUrl may break user avatar URL in the template generation.

https://github.com/discourse/discourse/edit/master/app/assets/javascripts/discourse/models/user.js
avatarTemplate()

In the future there should be a way to reference baseUrl with or without port information
