### PR TITLE
FIX: j/k place tab focus accordingly so tab will go to the first link…

### DIFF
--- a/app/assets/javascripts/discourse/lib/keyboard_shortcuts.js
+++ b/app/assets/javascripts/discourse/lib/keyboard_shortcuts.js
@@ -234,7 +234,7 @@ Discourse.KeyboardShortcuts = Ember.Object.createWithMixins({
 
         if ($article.is('.topic-post')) {
           var tabLoc = $article.find('a.tabLoc');
-          if (tabLoc.length == 0) {
+          if (tabLoc.length === 0) {
             tabLoc = $('<a href="#" class="tabLoc"></a>');
             $article.prepend(tabLoc);
           }


### PR DESCRIPTION
…ed item in the selected post/row

Allow tabbing to continue from the selected post/topic when using the j/k keyboard shortcuts
https://meta.discourse.org/t/when-a-post-is-selected-tab-should-take-you-to-the-first-link/16212
