### PR TITLE
Rename elder to leader

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -294,7 +294,7 @@ en:
     leader:
       title: "regular"
     elder:
-      title: "elder"
+      title: "leader"
     change_failed_explanation: "You attempted to demote %{user_name} to '%{new_trust_level}'. However their trust level is already '%{current_trust_level}'. %{user_name} will remain at '%{current_trust_level}'"
 
 


### PR DESCRIPTION
As per [new naming](https://meta.discourse.org/t/poll-veteran-vs-leader/19454), rename TL4 from _elder_ to _leader_.
