### PR TITLE
Fix: Cancel link click if triggered as part of text selection

### DIFF
--- a/app/assets/javascripts/discourse/lib/click_track.js
+++ b/app/assets/javascripts/discourse/lib/click_track.js
@@ -6,7 +6,7 @@
   @module Discourse
 **/
 Discourse.ClickTrack = {
-
+  if (Discourse.Utilities.selectedText()!=="") return false; //cancle click if triggered as part of selection.
   /**
     Track a click on a link
 


### PR DESCRIPTION
Prevent a click if the user select content in a topic and release the mouse over a link.

https://meta.discourse.org/t/selecting-a-link-results-in-it-being-opened/14846
