### PR TITLE
Fix: rapid/continuous keyboard Next event under Topics List view may lose selected item on "load more"

### DIFF
--- a/app/assets/javascripts/discourse/lib/keyboard_shortcuts.js
+++ b/app/assets/javascripts/discourse/lib/keyboard_shortcuts.js
@@ -202,8 +202,11 @@ Discourse.KeyboardShortcuts = Ember.Object.createWithMixins({
     var $selected = $articles.filter('.selected'),
         index = $articles.index($selected);
 
-    // loop is not allowed
-    if (direction === -1 && index === 0) { return; }
+    if($selected.length !== 0){ //boundries check
+      // loop is not allowed
+      if (direction === -1 && index === 0) { return; }
+      if (direction === 1 && index === ($articles.size()-1) ) { return;}  
+    }
 
     // if nothing is selected go to the first post on screen
     if ($selected.length === 0) {
@@ -229,10 +232,8 @@ Discourse.KeyboardShortcuts = Ember.Object.createWithMixins({
 
     if ($article.size() > 0) {
       $articles.removeClass('selected');
-      Em.run.next(function(){
-        $article.addClass('selected');
-      });
-
+      $article.addClass('selected');
+      
       var rgx = new RegExp("post-cloak-(\\d+)").exec($article.parent()[0].id);
       if (rgx === null || typeof rgx[1] === 'undefined') {
           this._scrollList($article, direction);


### PR DESCRIPTION
Using Next keyboard shortcut (J) rapidly while reaching last item in the topic list and
causing a "load more". The handler might get into a state where it can not detect any selected item due to the delay from Em.run.next
and will result in position reset.

+added boundary check of last item on next, early in the handler to avoid unnecessary computations 

https://meta.discourse.org/t/keyboard-shortcut-next-previous-continues-key-down-reset-to-first-item-in-list-on-load-more/20042
