### PR TITLE
FIX: Firefox - Topic List Keyboard shortcut Previous(K) does not scroll properly leaving selected item hidden

### DIFF
--- a/app/assets/javascripts/discourse/lib/keyboard_shortcuts.js
+++ b/app/assets/javascripts/discourse/lib/keyboard_shortcuts.js
@@ -243,8 +243,8 @@ Discourse.KeyboardShortcuts = Ember.Object.createWithMixins({
   },
 
   _scrollList: function($article, direction) {
-    var $body = $('body'),
-        distToElement = $article.position().top + $article.height() - $(window).height() - $body.scrollTop();
+    var $document = $(document),
+        distToElement = $article.position().top + $article.height() - $(window).height() - $document.scrollTop();
 
     // cut some bottom slack
     distToElement += 40;
@@ -254,7 +254,7 @@ Discourse.KeyboardShortcuts = Ember.Object.createWithMixins({
       return;
     }
 
-    $('html, body').scrollTop($body.scrollTop() + distToElement);
+    $('html, body').scrollTop($document.scrollTop() + distToElement);
   },
 
   _findArticles: function() {


### PR DESCRIPTION
Using k wouldn't always bring the topic in focus as you moved up the topic list, now the functionality behaves exactly the same way Chrome does.
https://meta.discourse.org/t/topic-list-keyboard-shortcut-previous-k-does-not-scroll-properly-leaving-selected-item-hidden-firefox/20050
