### PR TITLE
UX: Move emoji setting into 'Plugins' category

### DIFF
--- a/plugins/emoji/config/locales/client.en.yml
+++ b/plugins/emoji/config/locales/client.en.yml
@@ -3,4 +3,4 @@ en:
     admin:
       site_settings:
         categories:
-          emoji: "Emoji"
+          plugins: "Plugins"

--- a/plugins/emoji/config/settings.yml
+++ b/plugins/emoji/config/settings.yml
@@ -1,4 +1,4 @@
-emoji:
+plugins:
   enable_emoji:
     default: true
     client: true


### PR DESCRIPTION
Rationale: currently, when I install  MathJax plugin I get two categories: Emoji and MathJax. Each has _only one item_. I think most of plugins have only one setting (enable/disable) which from UX point of view does not look good (visual cruft & waste of space).

The 'Plugin' category was discussed at meta: https://meta.discourse.org/t/create-a-settings-category-for-plugins/11018/7 but for some reason nobody introduced it in upstream and as a resut _each_ plugin usually creates _its own category_. 

Why create 'Plugin' category here?
As Emoji plugin is included by default and has one setting it guarantees that every Discourse instance will have 'Plugins' category present by default.  Having that, other plugins could move their settings there.
