### PR TITLE
FIX: double-escaped single quotes in URLs

### DIFF
--- a/app/assets/javascripts/discourse/lib/markdown.js
+++ b/app/assets/javascripts/discourse/lib/markdown.js
@@ -166,7 +166,7 @@ Discourse.Markdown = {
     var url = typeof(uri) === "string" ? uri : uri.toString();
 
     // escape single quotes
-    url = url.replace(/'/g, "&#39;");
+    url = url.replace(/'/g, "%27");
 
     // whitelist some iframe only
     if (hints && hints.XML_TAG === "iframe" && hints.XML_ATTR === "src") {

--- a/test/javascripts/lib/markdown-test.js.es6
+++ b/test/javascripts/lib/markdown-test.js.es6
@@ -458,7 +458,7 @@ test("urlAllowed", function() {
   allowed("//eviltrout.com/evil/trout", "allows protocol relative urls");
 
   equal(urlAllowed("http://google.com/test'onmouseover=alert('XSS!');//.swf"),
-        "http://google.com/test&#39;onmouseover=alert(&#39;XSS!&#39;);//.swf",
+        "http://google.com/test%27onmouseover=alert(%27XSS!%27);//.swf",
         "escape single quotes");
 });
 


### PR DESCRIPTION
As discussed here: https://meta.discourse.org/t/handle-single-quote-in-oneboxes/20206
