### PR TITLE
UX: show category when moving post to exisiting topic

### DIFF
--- a/app/assets/javascripts/discourse/lib/search.js
+++ b/app/assets/javascripts/discourse/lib/search.js
@@ -86,4 +86,3 @@ Discourse.Search = {
   }
 
 };
-

--- a/app/assets/javascripts/discourse/templates/choose_topic.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/choose_topic.js.handlebars
@@ -12,6 +12,10 @@
       <div class='controls'>
         <label class='radio'>
         <input type='radio' id="choose-topic-{{unbound id}}" name='choose_topic_id' {{action chooseTopic this target="view"}}>{{title}}
+        {{#if category.parentCategory}}
+          {{bound-category-link category.parentCategory}}
+        {{/if}}
+        {{bound-category-link category}}
         </label>
       </div>
     {{/each}}


### PR DESCRIPTION
[Meta topic](https://meta.discourse.org/t/move-to-existing-topic-should-show-category/20128).

![screen shot 2014-09-19 at 20 52 17](https://cloud.githubusercontent.com/assets/5732281/4337756/6da508de-4012-11e4-98b9-f4c6cec728fe.png)
