### PR TITLE
FIX: removed typo in invitation email template

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1369,7 +1369,7 @@ en:
 
         1. Log in using any method you like -- but it must resolve to the **same email address** that you received your original invitation email at. Otherwise we won't be able to tell it is you!
 
-        2. Create a unique password for on [your user profile][prefs], and use it to log in.
+        2. Create a unique password for [your user profile][prefs], and use it to log in.
 
         %{new_user_tips}
 


### PR DESCRIPTION
Fixes a very minor typo in invitation email, as pointed out [here](https://meta.discourse.org/t/typo-in-prepended-text-for-invited-users-in-welcome-message-not-editable/20210).
