### PR TITLE
FIX: j/k place tab focus accordingly so tab will go to the first linked ...

### DIFF
--- a/app/assets/javascripts/discourse/lib/keyboard_shortcuts.js
+++ b/app/assets/javascripts/discourse/lib/keyboard_shortcuts.js
@@ -233,6 +233,15 @@ Discourse.KeyboardShortcuts = Ember.Object.createWithMixins({
     if ($article.size() > 0) {
       $articles.removeClass('selected');
       $article.addClass('selected');
+
+      if ($article.is('.topic-post')) {
+        var tabLoc = $article.find('a.tabLoc');
+        if (tabLoc.length === 0) {
+          tabLoc = $('<a href="#" class="tabLoc"></a>');
+          $article.prepend(tabLoc);
+        }
+        tabLoc.focus();
+      }
       
       var rgx = new RegExp("post-cloak-(\\d+)").exec($article.parent()[0].id);
       if (rgx === null || typeof rgx[1] === 'undefined') {


### PR DESCRIPTION
...item in the selected post/row

Allow tabbing to continue from the selected post/topic when using the j/k keyboard shortcuts
https://meta.discourse.org/t/when-a-post-is-selected-tab-should-take-you-to-the-first-link/16212
