### PR TITLE
Trigger browser password manager after signing up

### DIFF
--- a/app/assets/javascripts/discourse/controllers/create-account.js.es6
+++ b/app/assets/javascripts/discourse/controllers/create-account.js.es6
@@ -347,8 +347,12 @@ export default DiscourseController.extend(ModalFunctionality, {
       var challenge = this.get('accountChallenge');
       return Discourse.User.createAccount(name, email, password, username, passwordConfirm, challenge).then(function(result) {
         if (result.success) {
-          self.flash(result.message);
-          self.set('complete', true);
+          // Trigger the browser's password manager using the hidden static login form:
+          var $hidden_login_form = $('#hidden-login-form');
+          $hidden_login_form.find('input[name=username]').val(self.get('accountName'));
+          $hidden_login_form.find('input[name=password]').val(self.get('accountPassword'));
+          $hidden_login_form.find('input[name=redirect]').val(Discourse.getURL('/users/account-created'));
+          $hidden_login_form.submit();
         } else {
           self.flash(result.message || I18n.t('create_account.failed'), 'error');
           if (result.errors && result.errors.email && result.errors.email.length > 0 && result.values) {

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,7 +6,7 @@ require_dependency 'rate_limiter'
 class UsersController < ApplicationController
 
   skip_before_filter :authorize_mini_profiler, only: [:avatar]
-  skip_before_filter :check_xhr, only: [:show, :password_reset, :update, :activate_account, :perform_account_activation, :authorize_email, :user_preferences_redirect, :avatar, :my_redirect]
+  skip_before_filter :check_xhr, only: [:show, :password_reset, :update, :account_created, :activate_account, :perform_account_activation, :authorize_email, :user_preferences_redirect, :avatar, :my_redirect]
 
   before_filter :ensure_logged_in, only: [:username, :update, :change_email, :user_preferences_redirect, :upload_user_image, :pick_avatar, :destroy_user_image, :destroy]
   before_filter :respond_to_suspicious_request, only: [:create]
@@ -18,6 +18,7 @@ class UsersController < ApplicationController
   skip_before_filter :redirect_to_login_if_required, only: [:check_username,
                                                             :create,
                                                             :get_honeypot_value,
+                                                            :account_created,
                                                             :activate_account,
                                                             :perform_account_activation,
                                                             :send_activation_email,
@@ -292,6 +293,11 @@ class UsersController < ApplicationController
     else
       flash[:error] = I18n.t('change_email.error')
     end
+    render layout: 'no_js'
+  end
+
+  def account_created
+    expires_now
     render layout: 'no_js'
   end
 

--- a/app/views/users/account_created.html.erb
+++ b/app/views/users/account_created.html.erb
@@ -1,0 +1,3 @@
+<div id='simple-container'>
+  <span style="font-size: 16px; line-height: 24px;"><%= t 'login.activate_email' %></span>
+</div>

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1089,7 +1089,7 @@ en:
     incorrect_username_email_or_password: "Incorrect username, email or password"
     wait_approval: "Thanks for signing up. We will notify you when your account has been approved."
     active: "Your account is activated and ready to use."
-    activate_email: "You're almost done! We sent an activation email to <b>%{email}</b>. Please follow the instructions in the email to activate your account."
+    activate_email: "You're almost done! We sent an activation mail to the email address you provided. Please follow the instructions in the email to activate your account."
     not_activated: "You can't log in yet. We sent an activation email to you. Please follow the instructions in the email to activate your account."
     not_allowed_from_ip_address: "You can't login as %{username} from that IP address."
     suspended: "You can't log in until %{date}."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -201,6 +201,7 @@ Discourse::Application.routes.draw do
 
   post "users/read-faq" => "users#read_faq"
   get "users/search/users" => "users#search_users"
+  get "users/account-created/" => "users#account_created"
   get "users/password-reset/:token" => "users#password_reset"
   put "users/password-reset/:token" => "users#password_reset"
   get "users/activate-account/:token" => "users#activate_account"

--- a/test/javascripts/integration/sign-in-test.js.es6
+++ b/test/javascripts/integration/sign-in-test.js.es6
@@ -52,9 +52,7 @@ test("create account", function() {
 
   click('.modal-footer .btn-primary');
   andThen(function() {
-    not(exists('.modal-body'), 'it hides the body when finished');
+    ok(exists('.modal-footer .btn-primary:disabled'), "create account is disabled");
   });
 
 });
-
-


### PR DESCRIPTION
When the user will submit sign-up form/modal, he/she will be redirected to this page:

![screen shot 2014-09-23 at 23 37 38](https://cloud.githubusercontent.com/assets/5732281/4377567/1618832a-4350-11e4-9f26-131fe8c4d234.png)

and the browser's password manager will be triggered, offering user to save username/pasword.

cc @eviltrout 
