### PR TITLE
UX: improve readability of video titles in lazyYT oneboxes

### DIFF
--- a/plugins/lazyYT/assets/stylesheets/lazyYT.css
+++ b/plugins/lazyYT/assets/stylesheets/lazyYT.css
@@ -13,10 +13,12 @@
     left: 12px!important;
     position: absolute!important;
     margin: 0!important;
-    padding: 0!important;
+    padding: 1em!important;
     line-height: 1!important;
     font-style: normal!important;
     font-weight: normal!important;
+    background-color: rgba(0,0,0,0.8)!important;
+    border-radius: 0.5em!important;
 }
 
 .lazyYT-button {


### PR DESCRIPTION
This PR adds background to video titles in lazyYT oneboxes.

Some titles were just painful to read, especially on a bright background.
I tried to follow the visual style of already present button so that it looks natural.

**Before/After:**
![2014-09-23-215920_557x311_scrot](https://cloud.githubusercontent.com/assets/157609/4379156/3104408a-435e-11e4-99c0-fb5a6616ec53.png)
