### PR TITLE
FIX: reworked handling URL bbcode tags

### DIFF
--- a/test/javascripts/lib/bbcode-test.js.es6
+++ b/test/javascripts/lib/bbcode-test.js.es6
@@ -16,7 +16,6 @@ test('basic bbcode', function() {
   format("[u]underlined[/u]", "<span class=\"bbcode-u\">underlined</span>", "underlines text");
   format("[s]strikethrough[/s]", "<span class=\"bbcode-s\">strikethrough</span>", "strikes-through text");
   format("[img]http://eviltrout.com/eviltrout.png[/img]", "<img src=\"http://eviltrout.com/eviltrout.png\">", "links images");
-  format("[url]http://bettercallsaul.com[/url]", "<a href=\"http://bettercallsaul.com\">http://bettercallsaul.com</a>", "supports [url] without a title");
   format("[email]eviltrout@mailinator.com[/email]", "<a href=\"mailto:eviltrout@mailinator.com\">eviltrout@mailinator.com</a>", "supports [email] without a title");
   format("[b]evil [i]trout[/i][/b]",
          "<span class=\"bbcode-b\">evil <span class=\"bbcode-i\">trout</span></span>",
@@ -25,7 +24,10 @@ test('basic bbcode', function() {
   format("[b]strong [b]stronger[/b][/b]", "<span class=\"bbcode-b\">strong <span class=\"bbcode-b\">stronger</span></span>", "accepts nested bbcode tags");
 });
 
-test('url with images', function() {
+test('urls', function() {
+  format("[url]not a url[/url]", "not a url", "supports [url] that isn't a url");
+  format("[url]http://bettercallsaul.com[/url]", "<a href=\"http://bettercallsaul.com\">http://bettercallsaul.com</a>", "supports [url] without parameter");
+  format("[url=http://example.com]example[/url]", "<a href=\"http://example.com\">example</a>", "supports [url] with given href");
   format("[url=http://www.example.com][img]http://example.com/logo.png[/img][/url]",
          "<a href=\"http://www.example.com\"><img src=\"http://example.com/logo.png\"></a>",
          "supports [url] with an embedded [img]");


### PR DESCRIPTION
Reworked how [url] tags are handled. Most importantly, the new code doesn't break on gargabe, e.g. `[url]not a url[/url]`.
