### PR TITLE
FIX: properly align username for suppressed avatar images

### DIFF
--- a/lib/email/styles.rb
+++ b/lib/email/styles.rb
@@ -140,6 +140,7 @@ module Email
     def strip_avatars_and_emojis
       @fragment.css('img').each do |img|
         if img['src'] =~ /user_avatar/
+          img.parent['style'] = "vertical-align: top;" if img.parent.name == 'td'
           img.remove
         end
 
@@ -188,7 +189,7 @@ module Email
     end
 
     def reset_tables
-      style('table',nil, cellspacing: '0', cellpadding: '0', border: '0')
+      style('table', nil, cellspacing: '0', cellpadding: '0', border: '0')
     end
 
     def style(selector, style, attribs = {})


### PR DESCRIPTION
Example:

![screen shot 2014-09-25 at 11 16 51](https://cloud.githubusercontent.com/assets/5732281/4399960/817c3972-4477-11e4-976f-18b364faea32.png)
