### PR TITLE
trigger "browser password manager" for password reset page

### DIFF
--- a/app/views/users/password_reset.html.erb
+++ b/app/views/users/password_reset.html.erb
@@ -21,7 +21,6 @@
         <br>
         <br>
         <a class="btn" href="/"><%= t('password_reset.continue', site_name: SiteSetting.title) %></a>
-        <%= render partial: 'auto_redirect_home' %>
       <% end %>
     </p>
   <% else %>
@@ -36,8 +35,9 @@
 
       <%=form_tag({}, method: :put) do %>
         <p>
-        <input id="user_password" name="password" size="30" type="password" maxlength="<%= User.max_password_length %>">
-        <label><%= t('js.user.password.instructions', count: SiteSetting.min_password_length) %></label>
+          <span style="display: none;"><input name="username" type="text" value="<%= @user.username %>"></span>
+          <input id="user_password" name="password" size="30" type="password" maxlength="<%= User.max_password_length %>">
+          <label><%= t('js.user.password.instructions', count: SiteSetting.min_password_length) %></label>
         </p>
         <p>
         <%=submit_tag( @user.has_password? ? t('password_reset.update') : t('password_reset.save'), class: 'btn')%>


### PR DESCRIPTION
Example:

![screenshot from 2014-10-01 19 56 00](https://cloud.githubusercontent.com/assets/5732281/4477376/b7682608-497d-11e4-836a-e92f3fc43e2e.png)

Also disabled auto-redirection after 5 seconds on password reset confirmation page.

cc @nlalonde @SamSaffron 
