### PR TITLE
FIX: quoting non-existing messages would break SMF2 importer

### DIFF
--- a/lib/pretty_text.rb
+++ b/lib/pretty_text.rb
@@ -8,7 +8,7 @@ module PrettyText
   class Helpers
 
     def t(key, opts)
-      str = I18n.t("js." + key)
+      str = I18n.t("js." + key, opts)
       if opts
         # TODO: server localisation has no parity with client should be fixed
         str = str.dup

--- a/script/import_scripts/smf2.rb
+++ b/script/import_scripts/smf2.rb
@@ -421,7 +421,7 @@ class ImportScripts::Smf2 < ImportScripts::Base
         quote = "[quote=\"#{params['author']}"
         if QuoteParamsPattern =~ params['link']
           tl = topic_lookup_from_imported_post_id($~[:msg].to_i)
-          quote << ", post:#{tl[:post_number]}, topic:#{tl[:topic_id]}"
+          quote << ", post:#{tl[:post_number]}, topic:#{tl[:topic_id]}" if tl
         end
         quote << "\"]#{inner}[/quote]"
       else
@@ -606,7 +606,7 @@ class ImportScripts::Smf2 < ImportScripts::Base
       end
 
       def quoted
-        @quoted.map {|id| @graph[id] }
+        @quoted.map {|id| @graph[id] }.reject(&:nil?)
       end
 
       def ignore_quotes?
@@ -634,7 +634,13 @@ class ImportScripts::Smf2 < ImportScripts::Base
       end
 
       def inspect
-        "#<#{self.class.name}: id=#{id.inspect}, prev=#{prev.try(:id).inspect}, quoted=#{quoted.map{|e|e.id}.inspect}>"
+        "#<#{self.class.name}: id=#{id.inspect}, prev=#{safe_id(@prev)}, quoted=[#{@quoted.map(&method(:safe_id)).join(', ')}]>"
+      end
+
+      private
+
+      def safe_id(id)
+        @graph[id].present? ? @graph[id].id.inspect : "(#{id})"
       end
     end #Node
 


### PR DESCRIPTION
Fixes issues with the SMF2 importer:
- error when non-existent message is quoted,
- possibly invalid quotation markdown,
- error in I18n when generating markdown for uploads.
