### PR TITLE
category badge now falls below topic title & other small fixes

### DIFF
--- a/app/assets/javascripts/discourse/templates/topic.hbs
+++ b/app/assets/javascripts/discourse/templates/topic.hbs
@@ -30,12 +30,7 @@
               {{#unless is_warning}}
                 <span class="private-message-glyph"><i class='fa fa-envelope'></i></span>
               {{/unless}}
-              {{#unless isPrivateMessage}}
-                {{#if category.parentCategory}}
-                  {{bound-category-link category.parentCategory}}
-                {{/if}}
-                {{bound-category-link category}}
-              {{/unless}}
+
               {{#if details.loaded}}
                 {{topic-status topic=model}}
                 <a href='{{unbound url}}' {{action "jumpTop"}}>
@@ -52,6 +47,16 @@
                 <a href='#' {{action "editTopic"}} class='edit-topic' title='{{i18n edit}}'><i class="fa fa-pencil"></i></a>
               {{/if}}
             </h1>
+
+            <div class="title-category-wrapper">
+            {{#unless isPrivateMessage}}
+              {{#if category.parentCategory}}
+                {{bound-category-link category.parentCategory}}
+              {{/if}}
+              {{bound-category-link category}}
+            {{/unless}}
+          </div>
+
           {{/if}}
           {{plugin-outlet "topic-title"}}
         </div>

--- a/app/assets/stylesheets/desktop/poster_expansion.scss
+++ b/app/assets/stylesheets/desktop/poster_expansion.scss
@@ -53,6 +53,8 @@
     font-weight: normal;
     margin-top: 0;
     color: scale-color($primary, $lightness: 50%);
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
   .groups {
     font-size: 13px;
@@ -120,7 +122,7 @@
     .badge-section {
       margin-top: 10px;
       float: left;
-      width: 300px;
+      width: 270px;
 
       h3 {
         color: $primary;

--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -415,7 +415,7 @@ a.star {
   .avatars,
   .links,
   .information {
-    padding: 7px 10px;
+    padding: 7px 10px 15px 10px;
     color: $primary;
   }
   .information {
@@ -716,7 +716,7 @@ blockquote > *:last-child {
       margin-top: -2px;
       margin-left: -17px;
     }
-    
+
     a.toggle-more {
       display: block;
       text-align: right;

--- a/app/assets/stylesheets/desktop/topic.scss
+++ b/app/assets/stylesheets/desktop/topic.scss
@@ -49,6 +49,10 @@
       }
     a.edit-topic { font-size: 15px; position: absolute; margin-left: 8px; }
   }
+  .title-category-wrapper {
+    margin: 5px 0 0 26px;
+    .badge-category {margin-bottom: 5px;}
+  }
   .topic-statuses {
     margin-top: -2px;
 


### PR DESCRIPTION
![screenshot 2014-10-01 22 53 39](https://cloud.githubusercontent.com/assets/1681963/4486331/8611abbc-49df-11e4-8429-2f6c3f3d9b16.png)

as discussed here: https://meta.discourse.org/t/should-category-go-below-the-topic-title-on-the-topic-page/20377

and also fixed popup overlap 
https://meta.discourse.org/t/long-locations-can-cover-badges-in-user-information-popup/19107
