### PR TITLE
Fix: remove hardcoded minimum for username length validation

### DIFF
--- a/app/assets/javascripts/discourse/controllers/create-account.js.es6
+++ b/app/assets/javascripts/discourse/controllers/create-account.js.es6
@@ -20,6 +20,7 @@ export default DiscourseController.extend(ModalFunctionality, {
   canCreateLocal: Discourse.computed.setting('enable_local_logins'),
   showCreateForm: Em.computed.or('hasAuthOptions', 'canCreateLocal'),
   maxUsernameLength: Discourse.computed.setting('max_username_length'),
+  minUsernameLength: Discourse.computed.setting('min_username_length'),
 
   resetForm: function() {
 
@@ -227,7 +228,7 @@ export default DiscourseController.extend(ModalFunctionality, {
   }.property('accountUsername'),
 
   shouldCheckUsernameMatch: function() {
-    return !this.blank('accountUsername') && this.get('accountUsername').length > 2;
+    return !this.blank('accountUsername') && this.get('accountUsername').length >= this.get('minUsernameLength');
   },
 
   checkUsernameAvailability: Discourse.debounce(function() {

--- a/app/assets/javascripts/discourse/controllers/preferences/username.js.es6
+++ b/app/assets/javascripts/discourse/controllers/preferences/username.js.es6
@@ -8,12 +8,13 @@ export default ObjectController.extend({
   newUsername: null,
 
   maxLength: Discourse.computed.setting('max_username_length'),
+  minLength: Discourse.computed.setting('min_username_length'),
   newUsernameEmpty: Em.computed.empty('newUsername'),
   saveDisabled: Em.computed.or('saving', 'newUsernameEmpty', 'taken', 'unchanged', 'errorMessage'),
   unchanged: Discourse.computed.propertyEqual('newUsername', 'username'),
 
   checkTaken: function() {
-    if( this.get('newUsername') && this.get('newUsername').length < 3 ) {
+    if( this.get('newUsername') && this.get('newUsername').length < this.get('minLength') ) {
       this.set('errorMessage', I18n.t('user.name.too_short'));
     } else {
       var self = this;


### PR DESCRIPTION
apply to account creation(new account) , and account modification under account preference
