### PR TITLE
Fix: CSS to reveal hidden or partially visible avatars on 2nd line topic map

### DIFF
--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -384,7 +384,7 @@ a.star {
 
     /* limit to one line of avatars for now */
     height:30px;
-    overflow:hidden;
+    overflow:visible;
   }
 
   .avatar {
@@ -415,6 +415,7 @@ a.star {
   .avatars,
   .links,
   .information {
+    clear:left;
     padding: 7px 10px 15px 10px;
     color: $primary;
   }


### PR DESCRIPTION
clear:left was added to an existing selector that match other elements that may no need it.
in case of a negative affect it should be moved to its own selector

```
.topic-map .links {
}
```

https://meta.discourse.org/t/topic-details-participants-avatars-not-all-items-can-be-shown/18781
