### PR TITLE
FIX: fix @mentions for 1 character usernames

### DIFF
--- a/app/assets/javascripts/discourse/dialects/mention_dialect.js
+++ b/app/assets/javascripts/discourse/dialects/mention_dialect.js
@@ -7,7 +7,7 @@ Discourse.Dialect.inlineRegexp({
   start: '@',
   // NOTE: we really should be using SiteSettings here, but it loads later in process
   // also, if we do, we must ensure serverside version works as well
-  matcher: /^(@[A-Za-z0-9][A-Za-z0-9_]{1,40})/m,
+  matcher: /^(@[A-Za-z0-9][A-Za-z0-9_]{0,40})/m,
   wordBoundary: true,
 
   emitter: function(matches) {


### PR DESCRIPTION
Super short usernames were effectively enabled by https://github.com/discourse/discourse/pull/2838 

This PR is just a cosmetic fix for @mentions: 

> ![](https://cloud.githubusercontent.com/assets/157609/4505109/d8708bd8-4aef-11e4-92be-3087ce956697.png)
