### PR TITLE
Change supported version of ruby

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To learn more about the philosophy and goals of the project, [visit **discourse.
 
 2. If you're familiar with how Rails works and are comfortable setting up your own environment, use our [**Discourse Advanced Developer Guide**](docs/DEVELOPER-ADVANCED.md). 
 
-Before you get started, ensure you have the following minimum versions: [Ruby 1.9.3+](http://www.ruby-lang.org/en/downloads/), [PostgreSQL 9.1+](http://www.postgresql.org/download/), [Redis 2.6+](http://redis.io/download). If you're having trouble, please see our [**TROUBLESHOOTING GUIDE**](docs/TROUBLESHOOTING.md) first!
+Before you get started, ensure you have the following minimum versions: [Ruby 2.0.0+](http://www.ruby-lang.org/en/downloads/), [PostgreSQL 9.1+](http://www.postgresql.org/download/), [Redis 2.6+](http://redis.io/download). If you're having trouble, please see our [**TROUBLESHOOTING GUIDE**](docs/TROUBLESHOOTING.md) first!
 
 ## Setting up a Discourse Forum
 


### PR DESCRIPTION
According to [this post on the meta](https://meta.discourse.org/t/dropping-support-for-ruby-1-9/20428) we're dropping support for ruby 1.9.

This PR just changes the README.md to reflect this decision. 
