### PR TITLE
Improve email_subject setting copy

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -683,7 +683,7 @@ en:
 
     notification_email: "The from: email address used when sending all essential system emails. The domain specified here must have SPF, DKIM and reverse PTR records set correctly for email to arrive."
     email_custom_headers: "A pipe-delimited list of custom email headers"
-    email_subject: "Subject format for standard emails."
+    email_subject: "Customizable subject format for standard emails. See https://meta.discourse.org/t/customize-subject-format-for-standard-emails/20801"
     use_https: "Should the full url for the site (Discourse.base_url) be http or https? DO NOT ENABLE THIS UNLESS HTTPS IS ALREADY SET UP AND WORKING!"
     summary_score_threshold: "The minimum score required for a post to be included in 'Summarize This Topic'"
     summary_posts_required: "Minimum posts in a topic before 'Summarize This Topic' is enabled"


### PR DESCRIPTION
Added a link to the [howto](https://meta.discourse.org/t/customize-subject-format-for-standard-emails/20801).

cc @SamSaffron 
