### PR TITLE
FIX: force encoding for title field

### DIFF
--- a/app/models/search_observer.rb
+++ b/app/models/search_observer.rb
@@ -41,7 +41,7 @@ class SearchObserver < ActiveRecord::Observer
   end
 
   def self.update_posts_index(post_id, cooked, title, category)
-    search_data = scrub_html_for_search(cooked) << " " << title.force_encoding('UTF-8')
+    search_data = scrub_html_for_search(cooked) << " " << title.dup.force_encoding('UTF-8')
     search_data << " " << category if category
     update_index('post', post_id, search_data)
   end


### PR DESCRIPTION
## Job exception: incompatible character encodings: UTF-8 and ASCII-8BIT

/var/www/discourse/app/models/search_observer.rb:44:in `update_posts_index'
/var/www/discourse/app/models/search_observer.rb:62:in`index'
/var/www/discourse/app/models/search_observer.rb:89:in `after_save'
...
/var/www/discourse/lib/post_creator.rb:238:in`save_post'
/var/www/discourse/lib/post_creator.rb:72:in `block in create'
/var/www/discourse/lib/post_creator.rb:131:in`call'
/var/www/discourse/lib/post_creator.rb:131:in `block in transaction'
...
/var/www/discourse/lib/post_creator.rb:129:in`transaction'
/var/www/discourse/lib/post_creator.rb:68:in `create'
/var/www/discourse/app/models/topic_embed.rb:40:in`block in import'
...
/var/www/discourse/app/models/topic_embed.rb:33:in `import'
/var/www/discourse/app/jobs/scheduled/poll_feed.rb:39:in`import_topic'
/var/www/discourse/app/jobs/scheduled/poll_feed.rb:33:in `block in import_topics'
/var/www/discourse/app/jobs/scheduled/poll_feed.rb:32:in`each'
/var/www/discourse/app/jobs/scheduled/poll_feed.rb:32:in `import_topics'
/var/www/discourse/app/jobs/scheduled/poll_feed.rb:26:in`poll_feed'
/var/www/discourse/app/jobs/scheduled/poll_feed.rb:16:in `execute'
/var/www/discourse/app/jobs/base.rb:154:in`block (2 levels) in perform'

This exception rise up for correct(!) UTF-8 cyrillic (in my case, but non-latin overall, I suppose) in title field during RSS polling (feed polling url) and breaks topics creation.
So, just force_encoding() makes it work.
