### PR TITLE
Feature: resend invites

### DIFF
--- a/app/assets/javascripts/discourse/controllers/user-invited.js.es6
+++ b/app/assets/javascripts/discourse/controllers/user-invited.js.es6
@@ -72,6 +72,17 @@ export default Ember.ObjectController.extend({
       return false;
     },
 
+    /**
+      Resend a given invite
+
+      @method reinvite
+      @param {Discourse.Invite} invite the invite to resend.
+    **/
+    reinvite: function(invite) {
+      invite.reinvite();
+      return false;
+    },
+
     loadMore: function() {
       var self = this;
       var model = self.get('model');

--- a/app/assets/javascripts/discourse/models/invite.js
+++ b/app/assets/javascripts/discourse/models/invite.js
@@ -15,6 +15,14 @@ Discourse.Invite = Discourse.Model.extend({
       data: { email: this.get('email') }
     });
     this.set('rescinded', true);
+  },
+
+  reinvite: function() {
+    Discourse.ajax('/invites/reinvite', {
+      type: 'POST',
+      data: { email: this.get('email') }
+    });
+    this.set('reinvited', true);
   }
 
 });
@@ -46,5 +54,3 @@ Discourse.Invite.reopenClass({
   }
 
 });
-
-

--- a/app/assets/javascripts/discourse/templates/user/invited.hbs
+++ b/app/assets/javascripts/discourse/templates/user/invited.hbs
@@ -51,11 +51,18 @@
               <td colspan='6'>
                 {{#if invite.expired}}
                   {{i18n user.invited.expired}}
+                  &nbsp;&nbsp;&nbsp;&nbsp;
                 {{/if}}
                 {{#if invite.rescinded}}
                   {{i18n user.invited.rescinded}}
                 {{else}}
                   <button class='btn' {{action "rescind" invite}}><i class="fa fa-times"></i>{{i18n user.invited.rescind}}</button>
+                {{/if}}
+                &nbsp;&nbsp;&nbsp;&nbsp;
+                {{#if invite.reinvited}}
+                  {{i18n user.invited.reinvited}}
+                {{else}}
+                  <button class='btn' {{action "reinvite" invite}}><i class="fa fa-envelope"></i>{{i18n user.invited.reinvite}}</button>
                 {{/if}}
               </td>
             {{/if}}

--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -3,7 +3,7 @@ class InvitesController < ApplicationController
   skip_before_filter :check_xhr
   skip_before_filter :redirect_to_login_if_required
 
-  before_filter :ensure_logged_in, only: [:destroy, :create, :check_csv_chunk, :upload_csv_chunk]
+  before_filter :ensure_logged_in, only: [:destroy, :create, :resend_invite, :check_csv_chunk, :upload_csv_chunk]
   before_filter :ensure_new_registrations_allowed, only: [:show, :redeem_disposable_invite]
 
   def show
@@ -92,6 +92,16 @@ class InvitesController < ApplicationController
     invite = Invite.find_by(invited_by_id: current_user.id, email: params[:email])
     raise Discourse::InvalidParameters.new(:email) if invite.blank?
     invite.trash!(current_user)
+
+    render nothing: true
+  end
+
+  def resend_invite
+    params.require(:email)
+
+    invite = Invite.find_by(invited_by_id: current_user.id, email: params[:email])
+    raise Discourse::InvalidParameters.new(:email) if invite.blank?
+    invite.resend_invite
 
     render nothing: true
   end

--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -95,7 +95,6 @@ class Invite < ActiveRecord::Base
     invite
   end
 
-
   # generate invite tokens without email
   def self.generate_disposable_tokens(invited_by, quantity=nil, group_names=nil)
     invite_tokens = []
@@ -177,6 +176,11 @@ class Invite < ActiveRecord::Base
       user = InviteRedeemer.new(invite, username, name).redeem
     end
     user
+  end
+
+  def resend_invite
+    self.update_columns(created_at: Time.zone.now, updated_at: Time.zone.now)
+    Jobs.enqueue(:invite_email, invite_id: self.id)
   end
 
   def self.base_directory

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -474,6 +474,8 @@ en:
         expired: "This invite has expired."
         rescind: "Remove"
         rescinded: "Invite removed"
+        reinvite: "Resend Invite"
+        reinvited: "Invite re-sent"
         time_read: "Read Time"
         days_visited: "Days Visited"
         account_age_days: "Account age in days"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -413,6 +413,7 @@ Discourse::Application.routes.draw do
       post "upload" => "invites#upload_csv_chunk"
     end
   end
+  post "invites/reinvite" => "invites#resend_invite"
   post "invites/disposable" => "invites#create_disposable_invite"
   get "invites/redeem/:token" => "invites#redeem_disposable_invite"
   delete "invites" => "invites#destroy"

--- a/spec/controllers/invites_controller_spec.rb
+++ b/spec/controllers/invites_controller_spec.rb
@@ -280,6 +280,40 @@ describe InvitesController do
 
   end
 
+  context '.resend_invite' do
+
+    it 'requires you to be logged in' do
+      lambda {
+        delete :resend_invite, email: 'first_name@example.com'
+      }.should raise_error(Discourse::NotLoggedIn)
+    end
+
+    context 'while logged in' do
+      let!(:user) { log_in }
+      let!(:invite) { Fabricate(:invite, invited_by: user) }
+      let(:another_invite) { Fabricate(:invite, email: 'last_name@example.com') }
+
+      it 'raises an error when the email is missing' do
+        lambda { post :resend_invite }.should raise_error(ActionController::ParameterMissing)
+      end
+
+      it "raises an error when the email cannot be found" do
+        lambda { post :resend_invite, email: 'first_name@example.com' }.should raise_error(Discourse::InvalidParameters)
+      end
+
+      it 'raises an error when the invite is not yours' do
+        lambda { post :resend_invite, email: another_invite.email }.should raise_error(Discourse::InvalidParameters)
+      end
+
+      it "resends the invite" do
+        Invite.any_instance.expects(:resend_invite)
+        post :resend_invite, email: invite.email
+      end
+
+    end
+
+  end
+
   context '.check_csv_chunk' do
     it 'requires you to be logged in' do
       lambda {


### PR DESCRIPTION
Clicking on _Resend Invite_ button will update the `Invite.created_at` date to `Time.zone.now` and will send an invitation email (with the same invite key).

Example:

![invites](https://cloud.githubusercontent.com/assets/5732281/4533066/269a92c6-4d99-11e4-8454-8da14afbe4d8.png)

[Meta Topic](https://meta.discourse.org/t/re-inviting-resending-invites-to-users/14387?u=techapj)
