### PR TITLE
Fix: Send proper page title to Google Analytics

### DIFF
--- a/app/assets/javascripts/discourse/initializers/page-tracking.js.es6
+++ b/app/assets/javascripts/discourse/initializers/page-tracking.js.es6
@@ -8,14 +8,17 @@ export default {
   initialize: function() {
     var pageTracker = Discourse.PageTracker.current();
     pageTracker.start();
+    var _ga_later = null;
 
     // Out of the box, Discourse tries to track google analytics
     // if it is present
     if (typeof window._gaq !== 'undefined') {
       pageTracker.on('change', function() {
-        Em.run.later(function() {
-          window._gaq.push(["_set", "title", Discourse.title]);
-          window._gaq.push(['_trackPageview', window.location.pathname+window.location.search]);
+         Em.run.cancel(_ga_later);
+         _ga_later = Em.run.later(function(){
+            _gaq.push(["_set", "title", Discourse.title]);
+            window._gaq.push(['_trackPageview', window.location.pathname+window.location.search]);
+            _ga_later = null;
         },350);
       });
       return;
@@ -24,9 +27,11 @@ export default {
     // Also use Universal Analytics if it is present
     if (typeof window.ga !== 'undefined') {
       pageTracker.on('change', function() {
-        Em.run.later(function() {
-          window.ga('send', 'pageview', {'page':window.location.pathname+window.location.search,'title':Discourse.title});
-        },350);
+         Em.run.cancel(_ga_later.event);
+          _ga_later = Em.run.later(function (){
+            window.ga('send', 'pageview', {'page':window.location.pathname+window.location.search,'title':Discourse.title});
+            _ga_later=null;
+          },350);
       });
     }
   }


### PR DESCRIPTION
1. I have only tested this solution with Universal Analytics method 
2. I added a delay to the analytic call due Discourse.title not getting updated "on time" 
   I have choose an arbitrary 350ms delay. it is possible that a smaller delay might still work.
   my baseline was another delay I encountered that might not be related <a href="https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse.js#L52">Here discourse.js#L52</a>

Ideally a way without delay should be desired.  
