### PR TITLE
changes: topic title editor layout, badge alignment in scrolled header

### DIFF
--- a/app/assets/javascripts/discourse/templates/topic.hbs
+++ b/app/assets/javascripts/discourse/templates/topic.hbs
@@ -17,10 +17,12 @@
           {{#if editingTopic}}
             {{#if isPrivateMessage}}
               <span class="private-message-glyph">{{fa-icon envelope}}</span>
+              {{text-field id='edit-title' value=newTitle maxLength=maxTitleLength}}
             {{else}}
+              {{text-field id='edit-title' value=newTitle maxLength=maxTitleLength}}
+              </br>
               {{category-chooser valueAttribute="id" value=newCategoryId source=category_id}}
             {{/if}}
-            {{text-field id='edit-title' value=newTitle maxLength=maxTitleLength}}
 
             <button class='btn btn-primary btn-small no-text' {{action "finishedEditingTopic"}}>{{fa-icon check}}</button>
             <button class='btn btn-small no-text' {{action "cancelEditingTopic"}}>{{fa-icon times}}</button>

--- a/app/assets/stylesheets/common/base/combobox.scss
+++ b/app/assets/stylesheets/common/base/combobox.scss
@@ -8,7 +8,7 @@
     display: inline-block;
   }
   .highlighted .topic-count, .select2-highlighted .category-desc {
-    color: $secondary;
+    color: $primary;
   }
   .category-desc {
     color: scale-color($primary, $lightness: 45%);

--- a/app/assets/stylesheets/common/base/header.scss
+++ b/app/assets/stylesheets/common/base/header.scss
@@ -12,7 +12,7 @@
     }
 
     .contents {
-      margin: 10px 0;
+      margin: 8px 0;
     }
 
     .title {

--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -560,7 +560,7 @@ iframe {
   }
 
   .badge-wrapper {
-    margin: 0;
+    margin: 0 0 0 2px;
     padding: 0;
 
     .badge-category {

--- a/app/assets/stylesheets/desktop/topic.scss
+++ b/app/assets/stylesheets/desktop/topic.scss
@@ -26,7 +26,7 @@
   }
   #edit-title { width: 500px; }
   .category-combobox {
-    width: 250px;
+    width: 350px;
     .select2-drop {
       left: -9000px;
       width: 248px;

--- a/app/assets/stylesheets/vendor/select2.scss
+++ b/app/assets/stylesheets/vendor/select2.scss
@@ -331,8 +331,8 @@ Version: @@ver@@ Timestamp: @@timestamp@@
 .select2-results-dept-7 .select2-result-label { padding-left: 120px }
 
 .select2-results .select2-highlighted {
-    background: #3875d7;
-    color: #fff;
+    background: dark-light-diff($highlight, $secondary, 50%, -80%);
+    color: $primary;
 }
 
 .select2-results li em {


### PR DESCRIPTION
when you edit a topic title, it follows the new category-below-title pattern

![screenshot 2014-10-07 11 40 56](https://cloud.githubusercontent.com/assets/1681963/4545130/97acb580-4e38-11e4-9a37-fd7084bb89ad.png)

and 

![screenshot 2014-10-07 11 43 22](https://cloud.githubusercontent.com/assets/1681963/4545150/b34ca0ca-4e38-11e4-9d00-8e02b72f8a69.png)

:dog2: :dash: 
