### PR TITLE
include category in List-Id instead of topic

### DIFF
--- a/lib/email/sender.rb
+++ b/lib/email/sender.rb
@@ -70,11 +70,22 @@ module Email
         @message.header['In-Reply-To'] = topic_identifier
         @message.header['References'] = topic_identifier
 
+        topic = Topic.where(id: topic_id).first
+
         # http://www.ietf.org/rfc/rfc2919.txt
-        list_id = "<topic.#{topic_id}.#{host}>"
+        if topic && topic.category && !topic.category.uncategorized?
+          list_id = "<#{topic.category.name.downcase}.#{host}>"
+
+          # subcategory case
+          if !topic.category.parent_category_id.nil?
+            parent_category_name = Category.find_by(id: topic.category.parent_category_id).name
+            list_id = "<#{topic.category.name.downcase}.#{parent_category_name.downcase}.#{host}>"
+          end
+        else
+          list_id = "<#{host}>"
+        end
         @message.header['List-ID'] = list_id
 
-        topic = Topic.where(id: topic_id).first
         @message.header['List-Archive'] = topic.url if topic
       end
 

--- a/spec/components/email/sender_spec.rb
+++ b/spec/components/email/sender_spec.rb
@@ -64,11 +64,14 @@ describe Email::Sender do
       email_sender.send
     end
 
-    # will fail since topic ID has to be present
-    #it "adds a List-ID header to identify the forum" do
-    #  email_sender.send
-    #  message.header['List-ID'].should be_present
-    #end
+    context "adds a List-ID header to identify the forum" do
+      before do
+        message.header['X-Discourse-Topic-Id'] = 5577
+      end
+
+      When { email_sender.send }
+      Then { expect(message.header['List-ID']).to be_present }
+    end
 
     context 'email logs' do
       let(:email_log) { EmailLog.last }


### PR DESCRIPTION
Example for topic in category "book":

`List-ID: <book.discourse.example.com>`

For topic in subcategory "author":

`List-ID: <author.book.discourse.example.com>`

For PM or uncategorized topics:

`List-ID: <discourse.example.com>`
