### PR TITLE
FEATURE: add Precedence header

### DIFF
--- a/lib/email/sender.rb
+++ b/lib/email/sender.rb
@@ -87,6 +87,9 @@ module Email
         @message.header['List-ID'] = list_id
 
         @message.header['List-Archive'] = topic.url if topic
+
+        # http://www.ietf.org/rfc/rfc3834.txt
+        @message.header['Precedence'] = 'list'
       end
 
       if reply_key.present?

--- a/spec/components/email/sender_spec.rb
+++ b/spec/components/email/sender_spec.rb
@@ -73,6 +73,15 @@ describe Email::Sender do
       Then { expect(message.header['List-ID']).to be_present }
     end
 
+    context "adds Precedence header" do
+      before do
+        message.header['X-Discourse-Topic-Id'] = 5577
+      end
+
+      When { email_sender.send }
+      Then { expect(message.header['Precedence']).to be_present }
+    end
+
     context 'email logs' do
       let(:email_log) { EmailLog.last }
 


### PR DESCRIPTION
Added [Precedence](http://www.ietf.org/rfc/rfc3834.txt) header in emails where Topic ID is present (so as to avoid adding it in emails like "confirmation of accounts", "invites", etc).
