### PR TITLE
FEATURE: send `set password` instructions after invite redemption

### DIFF
--- a/app/jobs/regular/invite_password_instructions_email.rb
+++ b/app/jobs/regular/invite_password_instructions_email.rb
@@ -1,0 +1,17 @@
+require_dependency 'email/sender'
+
+module Jobs
+
+  # Asynchronously send an email
+  class InvitePasswordInstructionsEmail < Jobs::Base
+
+    def execute(args)
+      raise Discourse::InvalidParameters.new(:username) unless args[:username].present?
+      user = User.find_by_username_or_email(args[:username])
+      message = InviteMailer.send_password_instructions(user)
+      Email::Sender.new(message, :invite_password_instructions).send
+    end
+
+  end
+
+end

--- a/app/mailers/invite_mailer.rb
+++ b/app/mailers/invite_mailer.rb
@@ -42,4 +42,13 @@ class InviteMailer < ActionMailer::Base
 
   end
 
+  def send_password_instructions(user)
+    if user.present?
+      email_token = user.email_tokens.create(email: user.email)
+      build_email(user.email,
+                  template: 'invite_password_instructions',
+                  email_token: email_token.token)
+    end
+  end
+
 end

--- a/app/models/invite_redeemer.rb
+++ b/app/models/invite_redeemer.rb
@@ -48,6 +48,7 @@ InviteRedeemer = Struct.new(:invite, :username, :name) do
     send_welcome_message
     approve_account_if_needed
     notify_invitee
+    send_password_instructions
   end
 
   def invite_was_redeemed?
@@ -100,6 +101,12 @@ InviteRedeemer = Struct.new(:invite, :username, :name) do
 
   def approve_account_if_needed
     invited_user.approve(invite.invited_by_id, false)
+  end
+
+  def send_password_instructions
+    if !SiteSetting.enable_sso && SiteSetting.enable_local_logins && !invited_user.has_password?
+      Jobs.enqueue(:invite_password_instructions_email, username: invited_user.username)
+    end
   end
 
   def notify_invitee

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1156,6 +1156,14 @@ en:
 
       This invitation is from a trusted user, so you won't need to log in.
 
+  invite_password_instructions:
+    subject_template: "Set password for your %{site_name} account"
+    text_body_template: |
+      Thanks for accepting your invitation to %{site_name} -- welcome!
+
+      To log in again, click the following link to choose a password:
+      %{base_url}/users/password-reset/%{email_token}
+
   test_mailer:
     subject_template: "[%{site_name}] Email Deliverability Test"
     text_body_template: |

--- a/spec/models/invite_spec.rb
+++ b/spec/models/invite_spec.rb
@@ -161,6 +161,33 @@ describe Invite do
       invite.redeem.should be_blank
     end
 
+    context 'enqueues a job to email "set password" instructions' do
+
+      it 'does not enqueue an email if sso is enabled' do
+        SiteSetting.stubs(:enable_sso).returns(true)
+        Jobs.expects(:enqueue).with(:invite_password_instructions_email, has_key(:username)).never
+        invite.redeem
+      end
+
+      it 'does not enqueue an email if local login is disabled' do
+        SiteSetting.stubs(:enable_local_logins).returns(false)
+        Jobs.expects(:enqueue).with(:invite_password_instructions_email, has_key(:username)).never
+        invite.redeem
+      end
+
+      it 'does not enqueue an email if the user has already set password' do
+        user = Fabricate(:user, email: invite.email, password_hash: "7af7805c9ee3697ed1a83d5e3cb5a3a431d140933a87fdcdc5a42aeef9337f81")
+        Jobs.expects(:enqueue).with(:invite_password_instructions_email, has_key(:username)).never
+        invite.redeem
+      end
+
+      it 'enqueues an email if all conditions are satisfied' do
+        Jobs.expects(:enqueue).with(:invite_password_instructions_email, has_key(:username))
+        invite.redeem
+      end
+
+    end
+
     context "when inviting to groups" do
       it "add the user to the correct groups" do
         group = Fabricate(:group)


### PR DESCRIPTION
As soon as the user will redeem invite, they will get an email instructing them to set their password, along with password reset link:

![screen shot 2014-10-10 at 23 00 24](https://cloud.githubusercontent.com/assets/5732281/4596626/579ad174-50a5-11e4-991e-db8c56e4a19d.png)
