### PR TITLE
Fix: Do not mess with external link href. change mouseup to click to allow preventDefault

### DIFF
--- a/app/assets/javascripts/discourse/lib/click_track.js
+++ b/app/assets/javascripts/discourse/lib/click_track.js
@@ -86,7 +86,6 @@ Discourse.ClickTrack = {
     if (!$link.data('href')) {
       $link.addClass('no-href');
       $link.data('href', $link.attr('href'));
-      $link.attr('href', null);
       // Don't route to this URL
       $link.data('auto-route', true);
     }

--- a/app/assets/javascripts/discourse/views/topic.js.es6
+++ b/app/assets/javascripts/discourse/views/topic.js.es6
@@ -42,7 +42,7 @@ export default Discourse.View.extend(AddCategoryClass, Discourse.Scrolling, {
       self.scrolled();
     });
 
-    this.$().on('mouseup.discourse-redirect', '.cooked a, a.track-link', function(e) {
+    this.$().on('click.discourse-redirect', '.cooked a, a.track-link', function(e) {
       var selection = window.getSelection && window.getSelection();
       // bypass if we are selecting stuff
       if (selection.type === "Range" || selection.rangeCount > 0) { return true; }
@@ -61,7 +61,7 @@ export default Discourse.View.extend(AddCategoryClass, Discourse.Scrolling, {
     $(window).unbind('resize.discourse-on-scroll');
 
     // Unbind link tracking
-    this.$().off('mouseup.discourse-redirect', '.cooked a, a.track-link');
+    this.$().off('click.discourse-redirect', '.cooked a, a.track-link');
 
     this.resetExamineDockCache();
 


### PR DESCRIPTION
Removing the hackish removal of href attribute for external links to cancel a "click" 
It was originally added since preventDefault() have no affect on mouseup event in the aspect of canceling a click.
