### PR TITLE
Fix buggy autocomplete behaviour for non-US keyboards

### DIFF
--- a/app/assets/javascripts/discourse/lib/autocomplete.js.es6
+++ b/app/assets/javascripts/discourse/lib/autocomplete.js.es6
@@ -259,19 +259,20 @@ export default function(options) {
   });
 
   $(this).keypress(function(e) {
-    var caretPosition = Discourse.Utilities.caretPosition(me[0]),
-        term;
+    var caretPosition, term;
 
     if (!options.key) return;
 
     // keep hunting backwards till you hit a the @ key
     if (e.which === options.key.charCodeAt(0)) {
+      caretPosition = Discourse.Utilities.caretPosition(me[0]);
       var prevChar = me.val().charAt(caretPosition - 1);
       if (!prevChar || /\s/.test(prevChar)) {
         completeStart = completeEnd = caretPosition;
         updateAutoComplete(options.dataSource(""));
       }
     } else if ((completeStart !== null) && (e.charCode !== 0)) {
+      caretPosition = Discourse.Utilities.caretPosition(me[0]),
       term = me.val().substring(completeStart + (options.key ? 1 : 0), caretPosition);
       term += String.fromCharCode(e.charCode);
       updateAutoComplete(options.dataSource(term));


### PR DESCRIPTION
This change moves the code for actually entering data from the keydown handler to the
keypress handler, which can reliably catch the character entered (rather than
the key pressed).

Apart from that, I've translated the magic keycodes still present in the code for extra legibility. 

This is my second attempt at
https://meta.discourse.org/t/typing-shows-on-non-us-keyboard-layouts/20449
without doing dangerous refactoring.

This does not fix the issue reported in
https://meta.discourse.org/t/overly-aggresive-emoji-autocomplete/20691/7
as that is a different bug (and present in the original).
