### PR TITLE
WIP: add ability to hide specific post revisions

### DIFF
--- a/app/models/post_revision.rb
+++ b/app/models/post_revision.rb
@@ -29,8 +29,8 @@ class PostRevision < ActiveRecord::Base
   end
 
   def wiki_changes
-    prev = lookup("wiki", 0)
-    cur = lookup("wiki", 1)
+    prev = previous("wiki")
+    cur = current("wiki")
     return if prev == cur
 
     {
@@ -40,8 +40,8 @@ class PostRevision < ActiveRecord::Base
   end
 
   def post_type_changes
-    prev = lookup("post_type", 0)
-    cur = lookup("post_type", 1)
+    prev = previous("post_type")
+    cur = current("post_type")
     return if prev == cur
 
     {
@@ -75,46 +75,96 @@ class PostRevision < ActiveRecord::Base
   end
 
   def previous(field)
-    lookup_with_fallback(field, 0)
+    val = lookup(field)
+    if val.nil?
+      val = lookup_in_previous_revisions(field)
+    end
+
+    if val.nil?
+      val = lookup_in_post(field)
+    end
+
+    val
   end
 
   def current(field)
-    lookup_with_fallback(field, 1)
+    val = lookup_in_next_revision(field)
+    if val.nil?
+      val = lookup_in_post(field)
+    end
+
+    if val.nil?
+      val = lookup(field)
+    end
+
+    if val.nil?
+      val = lookup_in_previous_revisions(field)
+    end
+
+    return val
   end
 
   def previous_revisions
     @previous_revs ||= PostRevision.where("post_id = ? AND number < ?", post_id, number)
                                    .order("number desc")
                                    .to_a
+    @previous_revs.select { |r| !r.modifications["hidden"] }.to_a
+  end
+
+  def next_revision
+    @next_revisions ||= PostRevision.where("post_id = ? AND number > ?", post_id, number)
+                                   .order("number asc")
+                                   .to_a
+    @next_revision = @next_revisions.select {|r| !r.modifications["hidden"] }.to_a.first
   end
 
   def has_topic_data?
     post && post.post_number == 1
   end
 
-  def lookup_with_fallback(field, index)
-
-    unless val = lookup(field, index)
-      previous_revisions.each do |v|
-        break if val = v.lookup(field, 1)
-      end
+  def lookup_in_previous_revisions(field)
+    previous_revisions.each do |v|
+      val = v.lookup(field)
+      return val unless val.nil?
     end
 
-    unless val
-      if ["cooked", "raw"].include?(field)
-        val = post.send(field)
-      else
-        val = post.topic.send(field)
-      end
+    nil
+  end
+
+  def lookup_in_next_revision(field)
+    if next_revision
+      return next_revision.lookup(field)
+    end
+  end
+
+  def lookup_in_post(field)
+    if !post
+      return
+    elsif ["cooked", "raw"].include?(field)
+      val = post.send(field)
+    elsif ["title", "category_id"].include?(field)
+      val = post.topic.send(field)
     end
 
     val
   end
 
-  def lookup(field, index)
-    if mod = modifications[field]
-      mod[index]
+  def lookup(field)
+    return nil if modifications["hidden"]
+    mod = modifications[field]
+    unless mod.nil?
+      mod[0]
     end
+  end
+
+  def hide!
+    modifications["hidden"] = true
+    self.save!
+  end
+
+  def show!
+    modifications["hidden"] = false
+    self.save!
   end
 
 end

--- a/app/serializers/post_revision_serializer.rb
+++ b/app/serializers/post_revision_serializer.rb
@@ -43,7 +43,7 @@ class PostRevisionSerializer < ApplicationSerializer
   end
 
   def edit_reason
-    object.lookup("edit_reason", 1)
+    object.current("edit_reason")
   end
 
   def user_changes

--- a/spec/models/post_revision_spec.rb
+++ b/spec/models/post_revision_spec.rb
@@ -12,18 +12,19 @@ describe PostRevision do
     PostRevision.create!(post_id: post_id, user_id: 1, number: @number, modifications: modifications)
   end
 
-  it "can grab history from current object" do
+  it "ignores deprecated current values in history" do
     p = PostRevision.new(modifications: {"foo" => ["bar", "bar1"]})
     p.previous("foo").should == "bar"
-    p.current("foo").should == "bar1"
+    p.current("foo").should == "bar"
   end
 
   it "can fallback to previous revisions if needed" do
-    create_rev("foo" => ["A", "B"])
-    r2 = create_rev("bar" => ["C", "D"])
+    r1 = create_rev("foo" => ["A", "B"])
+    r2 = create_rev("foo" => ["C", "D"])
 
-    r2.current("foo").should == "B"
-    r2.previous("foo").should == "B"
+    r1.current("foo").should == "C"
+    r2.current("foo").should == "C"
+    r2.previous("foo").should == "C"
   end
 
   it "can fallback to post if needed" do
@@ -36,6 +37,16 @@ describe PostRevision do
     r.previous("cooked").should == post.cooked
   end
 
+  it "can fallback to post for current rev only if needed" do
+    post = Fabricate(:post)
+    r = create_rev({"raw" => ["A"], "cooked" => ["AA"]}, post.id)
+
+    r.current("raw").should == post.raw
+    r.previous("raw").should == "A"
+    r.current("cooked").should == post.cooked
+    r.previous("cooked").should == "AA"
+  end
+
   it "can fallback to topic if needed" do
     post = Fabricate(:post)
     r = create_rev({"foo" => ["A", "B"]}, post.id)
@@ -45,37 +56,64 @@ describe PostRevision do
   end
 
   it "can find title changes" do
-    r = create_rev({"title" => ["hello", "frog"]})
-    r.title_changes[:inline].should =~ /frog.*hello/
-    r.title_changes[:side_by_side].should =~ /hello.*frog/
+    r1 = create_rev({"title" => ["hello"]})
+    r2 = create_rev({"title" => ["frog"]})
+    r1.title_changes[:inline].should =~ /frog.*hello/
+    r1.title_changes[:side_by_side].should =~ /hello.*frog/
   end
 
   it "can find category changes" do
     cat1 = Fabricate(:category, name: "cat1")
     cat2 = Fabricate(:category, name: "cat2")
 
-    r = create_rev({"category_id" => [cat1.id, cat2.id]})
+    r1 = create_rev({"category_id" => [cat1.id, cat2.id]})
+    r2 = create_rev({"category_id" => [cat2.id, cat1.id]})
 
-    changes = r.category_changes
+    changes = r1.category_changes
     changes[:previous_category_id].should == cat1.id
     changes[:current_category_id].should == cat2.id
 
   end
 
   it "can find wiki changes" do
-    r = create_rev("wiki" => [false, true])
+    r1 = create_rev("wiki" => [false])
+    r2 = create_rev("wiki" => [true])
 
-    changes = r.wiki_changes
+    changes = r1.wiki_changes
     changes[:previous_wiki].should == false
     changes[:current_wiki].should == true
   end
 
   it "can find post_type changes" do
-    r = create_rev("post_type" => [1, 2])
+    r1 = create_rev("post_type" => [1])
+    r2 = create_rev("post_type" => [2])
 
-    changes = r.post_type_changes
+    changes = r1.post_type_changes
     changes[:previous_post_type].should == 1
     changes[:current_post_type].should == 2
+  end
+
+  it "hides revisions that were hidden" do
+    r1 = create_rev({"raw" => ["one"]})
+    r2 = create_rev({"raw" => ["two"]})
+    r3 = create_rev({"raw" => ["three"]})
+
+    r2.hide!
+
+    r1.current("raw").should == "three"
+    r2.previous("raw").should == "one"
+  end
+
+  it "shows revisions that were shown" do
+    r1 = create_rev({"raw" => ["one"]})
+    r2 = create_rev({"raw" => ["two"]})
+    r3 = create_rev({"raw" => ["three"]})
+
+    r2.hide!
+    r2.show!
+
+    r2.previous("raw").should == "two"
+    r1.current("raw").should == "two"
   end
 
 end


### PR DESCRIPTION
This is a start for the feature described here:
https://meta.discourse.org/t/ability-to-hide-or-delete-old-revisions-on-selected-posts/19389

Changes so far:
1. PostRevision only looks at the left-hand side of a given record.
2. Added methods to hide! (or later show!) a given revision
3. A little bit of refactoring so all fields use current(field) and previous(field) methods
4. Fallbacks to previous/next revision or post, depending on what is available / not hidden

I haven't looked too closely yet at where to expose the methods via a controller or how to handle the ember side of things.

Also, both the left and right hand side are still saved to the database right now.

For starters, I just want to see if this approach is agreeable or if there's any other input.
