### PR TITLE
FEATURE: ability to hide/show specific post revisions

### DIFF
--- a/app/assets/javascripts/discourse/controllers/history.js.es6
+++ b/app/assets/javascripts/discourse/controllers/history.js.es6
@@ -25,6 +25,20 @@ export default ObjectController.extend(ModalFunctionality, {
     });
   },
 
+  hide: function(postId, postVersion) {
+    var self = this;
+    Discourse.Post.hideRevision(postId, postVersion).then(function (result) {
+      self.refresh(postId, postVersion);
+    });
+  },
+
+  show: function(postId, postVersion) {
+    var self = this;
+    Discourse.Post.showRevision(postId, postVersion).then(function (result) {
+      self.refresh(postId, postVersion);
+    });
+  },
+
   createdAtDate: function() { return moment(this.get("created_at")).format("LLLL"); }.property("created_at"),
 
   previousVersion: function() { return this.get("version") - 1; }.property("version"),
@@ -34,6 +48,9 @@ export default ObjectController.extend(ModalFunctionality, {
   displayRevisions: Em.computed.gt("revisions_count", 2),
   displayGoToNext: function() { return this.get("version") < this.get("revisions_count"); }.property("version", "revisions_count"),
   displayGoToLast: function() { return this.get("version") < this.get("revisions_count") - 1; }.property("version", "revisions_count"),
+
+  displayShow: function() { return this.get("hidden") && Discourse.User.currentProp('staff'); }.property("hidden"),
+  displayHide: function() { return !this.get("hidden") && Discourse.User.currentProp('staff'); }.property("hidden"),
 
   displayingInline: Em.computed.equal("viewMode", "inline"),
   displayingSideBySide: Em.computed.equal("viewMode", "side_by_side"),
@@ -117,6 +134,9 @@ export default ObjectController.extend(ModalFunctionality, {
     loadPreviousVersion: function() { this.refresh(this.get("post_id"), this.get("version") - 1); },
     loadNextVersion: function() { this.refresh(this.get("post_id"), this.get("version") + 1); },
     loadLastVersion: function() { this.refresh(this.get("post_id"), this.get("revisions_count")); },
+
+    hideVersion: function() { this.hide(this.get("post_id"), this.get("version")); },
+    showVersion: function() { this.show(this.get("post_id"), this.get("version")); },
 
     displayInline: function() { this.set("viewMode", "inline"); },
     displaySideBySide: function() { this.set("viewMode", "side_by_side"); },

--- a/app/assets/javascripts/discourse/models/_post.js
+++ b/app/assets/javascripts/discourse/models/_post.js
@@ -471,6 +471,14 @@ Discourse.Post.reopenClass({
     });
   },
 
+  hideRevision: function(postId, version) {
+    return Discourse.ajax("/posts/" + postId + "/revisions/" + version + "/hide", { type: 'PUT' });
+  },
+
+  showRevision: function(postId, version) {
+    return Discourse.ajax("/posts/" + postId + "/revisions/" + version + "/show", { type: 'PUT' });
+  },
+
   loadQuote: function(postId) {
     return Discourse.ajax("/posts/" + postId + ".json").then(function (result) {
       var post = Discourse.Post.create(result);

--- a/app/assets/javascripts/discourse/templates/modal/history.hbs
+++ b/app/assets/javascripts/discourse/templates/modal/history.hbs
@@ -6,6 +6,12 @@
       <div id="revision-numbers" {{bind-attr class="displayRevisions::invisible"}}>{{{boundI18n revisionsTextKey previousBinding="previousVersion" currentBinding="version" totalBinding="revisions_count"}}}</div>
       <button title="{{i18n post.revisions.controls.next}}" {{bind-attr class=":btn :standard displayGoToNext::invisible" disabled=loading}} {{action "loadNextVersion"}}><i class="fa fa-forward"></i></button>
       <button title="{{i18n post.revisions.controls.last}}" {{bind-attr class=":btn :standard displayGoToLast::invisible" disabled=loading}} {{action "loadLastVersion"}}><i class="fa fa-fast-forward"></i></button>
+      {{#if displayHide}}
+        <button title="{{i18n post.revisions.controls.hide}}" {{bind-attr class=":btn :standard" disabled=loading}} {{action "hideVersion"}}><i class="fa fa-trash-o"></i></button>
+      {{/if}}
+      {{#if displayShow}}
+        <button title="{{i18n post.revisions.controls.show}}" {{bind-attr class=":btn :standard" disabled=loading}} {{action "showVersion"}}><i class="fa fa-undo"></i></button>
+      {{/if}}
     </div>
     {{#if loading}}<div id='revision-loading'><i class='fa fa-spinner fa-spin'></i>{{i18n loading}}</div>{{/if}}
     <div id="display-modes">

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -216,6 +216,20 @@ class PostsController < ApplicationController
     render_json_dump(post_revision_serializer)
   end
 
+  def hide_revision
+    post_revision = find_post_revision_from_params
+    guardian.ensure_can_hide_post_revision! post_revision
+    post_revision.hide!
+    render nothing: true
+  end
+
+  def show_revision
+    post_revision = find_post_revision_from_params
+    guardian.ensure_can_show_post_revision! post_revision
+    post_revision.show!
+    render nothing: true
+  end
+
   def bookmark
     post = find_post_from_params
     if current_user

--- a/app/models/post_revision.rb
+++ b/app/models/post_revision.rb
@@ -29,8 +29,8 @@ class PostRevision < ActiveRecord::Base
   end
 
   def wiki_changes
-    prev = lookup("wiki", 0)
-    cur = lookup("wiki", 1)
+    prev = previous("wiki")
+    cur = current("wiki")
     return if prev == cur
 
     {
@@ -40,8 +40,8 @@ class PostRevision < ActiveRecord::Base
   end
 
   def post_type_changes
-    prev = lookup("post_type", 0)
-    cur = lookup("post_type", 1)
+    prev = previous("post_type")
+    cur = current("post_type")
     return if prev == cur
 
     {
@@ -75,46 +75,94 @@ class PostRevision < ActiveRecord::Base
   end
 
   def previous(field)
-    lookup_with_fallback(field, 0)
+    val = lookup(field)
+    if val.nil?
+      val = lookup_in_previous_revisions(field)
+    end
+
+    if val.nil?
+      val = lookup_in_post(field)
+    end
+
+    val
   end
 
   def current(field)
-    lookup_with_fallback(field, 1)
+    val = lookup_in_next_revision(field)
+    if val.nil?
+      val = lookup_in_post(field)
+    end
+
+    if val.nil?
+      val = lookup(field)
+    end
+
+    if val.nil?
+      val = lookup_in_previous_revisions(field)
+    end
+
+    return val
   end
 
   def previous_revisions
-    @previous_revs ||= PostRevision.where("post_id = ? AND number < ?", post_id, number)
+    @previous_revs ||= PostRevision.where("post_id = ? AND number < ? AND hidden = ?", post_id, number, false)
                                    .order("number desc")
                                    .to_a
+  end
+
+  def next_revision
+    @next_revision ||= PostRevision.where("post_id = ? AND number > ? AND hidden = ?", post_id, number, false)
+                                   .order("number asc")
+                                   .to_a.first
   end
 
   def has_topic_data?
     post && post.post_number == 1
   end
 
-  def lookup_with_fallback(field, index)
-
-    unless val = lookup(field, index)
-      previous_revisions.each do |v|
-        break if val = v.lookup(field, 1)
-      end
+  def lookup_in_previous_revisions(field)
+    previous_revisions.each do |v|
+      val = v.lookup(field)
+      return val unless val.nil?
     end
 
-    unless val
-      if ["cooked", "raw"].include?(field)
-        val = post.send(field)
-      else
-        val = post.topic.send(field)
-      end
+    nil
+  end
+
+  def lookup_in_next_revision(field)
+    if next_revision
+      return next_revision.lookup(field)
+    end
+  end
+
+  def lookup_in_post(field)
+    if !post
+      return
+    elsif ["cooked", "raw"].include?(field)
+      val = post.send(field)
+    elsif ["title", "category_id"].include?(field)
+      val = post.topic.send(field)
     end
 
     val
   end
 
-  def lookup(field, index)
-    if mod = modifications[field]
-      mod[index]
+  def lookup(field)
+    return nil if hidden
+    mod = modifications[field]
+    unless mod.nil?
+      mod[0]
     end
+  end
+
+  def hide!
+    self.hidden = true
+    self.save!
+  end
+
+  def show!
+    self.hidden = false
+    self.save!
   end
 
 end

--- a/app/serializers/post_revision_serializer.rb
+++ b/app/serializers/post_revision_serializer.rb
@@ -12,7 +12,8 @@ class PostRevisionSerializer < ApplicationSerializer
              :category_changes,
              :user_changes,
              :wiki_changes,
-             :post_type_changes
+             :post_type_changes,
+             :hidden
 
   def include_title_changes?
     object.has_topic_data?
@@ -20,6 +21,10 @@ class PostRevisionSerializer < ApplicationSerializer
 
   def include_category_changes?
     object.has_topic_data?
+  end
+
+  def hidden
+    object.hidden
   end
 
   def version
@@ -43,7 +48,7 @@ class PostRevisionSerializer < ApplicationSerializer
   end
 
   def edit_reason
-    object.lookup("edit_reason", 1)
+    object.current("edit_reason")
   end
 
   def user_changes

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1233,6 +1233,8 @@ en:
           previous: "Previous revision"
           next: "Next revision"
           last: "Last revision"
+          hide: "Hide revision"
+          show: "Show revision"
           comparing_previous_to_current_out_of_total: "<strong>{{previous}}</strong> vs <strong>{{current}}</strong> / {{total}}"
         displays:
           inline:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -277,6 +277,8 @@ Discourse::Application.routes.draw do
     put "unhide"
     get "replies"
     get "revisions/:revision" => "posts#revisions"
+    put "revisions/:revision/hide" => "posts#hide_revision"
+    put "revisions/:revision/show" => "posts#show_revision"
     put "recover"
     collection do
       delete "destroy_many"

--- a/db/migrate/20141014032859_add_hidden_to_post_revision.rb
+++ b/db/migrate/20141014032859_add_hidden_to_post_revision.rb
@@ -1,0 +1,5 @@
+class AddHiddenToPostRevision < ActiveRecord::Migration
+  def change
+    add_column :post_revisions, :hidden, :boolean, null: false, default: false
+  end
+end

--- a/lib/guardian/post_guardian.rb
+++ b/lib/guardian/post_guardian.rb
@@ -157,6 +157,14 @@ module PostGuardian
     can_see_post?(post)
   end
 
+  def can_hide_post_revision?(post_revision)
+    is_staff?
+  end
+
+  def can_show_post_revision?(post_revision)
+    is_staff?
+  end
+
   def can_vote?(post, opts={})
     post_can_act?(post,:vote, opts)
   end

--- a/spec/models/post_revision_spec.rb
+++ b/spec/models/post_revision_spec.rb
@@ -12,18 +12,19 @@ describe PostRevision do
     PostRevision.create!(post_id: post_id, user_id: 1, number: @number, modifications: modifications)
   end
 
-  it "can grab history from current object" do
+  it "ignores deprecated current values in history" do
     p = PostRevision.new(modifications: {"foo" => ["bar", "bar1"]})
     p.previous("foo").should == "bar"
-    p.current("foo").should == "bar1"
+    p.current("foo").should == "bar"
   end
 
   it "can fallback to previous revisions if needed" do
-    create_rev("foo" => ["A", "B"])
-    r2 = create_rev("bar" => ["C", "D"])
+    r1 = create_rev("foo" => ["A", "B"])
+    r2 = create_rev("foo" => ["C", "D"])
 
-    r2.current("foo").should == "B"
-    r2.previous("foo").should == "B"
+    r1.current("foo").should == "C"
+    r2.current("foo").should == "C"
+    r2.previous("foo").should == "C"
   end
 
   it "can fallback to post if needed" do
@@ -36,6 +37,16 @@ describe PostRevision do
     r.previous("cooked").should == post.cooked
   end
 
+  it "can fallback to post for current rev only if needed" do
+    post = Fabricate(:post)
+    r = create_rev({"raw" => ["A"], "cooked" => ["AA"]}, post.id)
+
+    r.current("raw").should == post.raw
+    r.previous("raw").should == "A"
+    r.current("cooked").should == post.cooked
+    r.previous("cooked").should == "AA"
+  end
+
   it "can fallback to topic if needed" do
     post = Fabricate(:post)
     r = create_rev({"foo" => ["A", "B"]}, post.id)
@@ -45,37 +56,64 @@ describe PostRevision do
   end
 
   it "can find title changes" do
-    r = create_rev({"title" => ["hello", "frog"]})
-    r.title_changes[:inline].should =~ /frog.*hello/
-    r.title_changes[:side_by_side].should =~ /hello.*frog/
+    r1 = create_rev({"title" => ["hello"]})
+    r2 = create_rev({"title" => ["frog"]})
+    r1.title_changes[:inline].should =~ /frog.*hello/
+    r1.title_changes[:side_by_side].should =~ /hello.*frog/
   end
 
   it "can find category changes" do
     cat1 = Fabricate(:category, name: "cat1")
     cat2 = Fabricate(:category, name: "cat2")
 
-    r = create_rev({"category_id" => [cat1.id, cat2.id]})
+    r1 = create_rev({"category_id" => [cat1.id, cat2.id]})
+    r2 = create_rev({"category_id" => [cat2.id, cat1.id]})
 
-    changes = r.category_changes
+    changes = r1.category_changes
     changes[:previous_category_id].should == cat1.id
     changes[:current_category_id].should == cat2.id
 
   end
 
   it "can find wiki changes" do
-    r = create_rev("wiki" => [false, true])
+    r1 = create_rev("wiki" => [false])
+    r2 = create_rev("wiki" => [true])
 
-    changes = r.wiki_changes
+    changes = r1.wiki_changes
     changes[:previous_wiki].should == false
     changes[:current_wiki].should == true
   end
 
   it "can find post_type changes" do
-    r = create_rev("post_type" => [1, 2])
+    r1 = create_rev("post_type" => [1])
+    r2 = create_rev("post_type" => [2])
 
-    changes = r.post_type_changes
+    changes = r1.post_type_changes
     changes[:previous_post_type].should == 1
     changes[:current_post_type].should == 2
+  end
+
+  it "hides revisions that were hidden" do
+    r1 = create_rev({"raw" => ["one"]})
+    r2 = create_rev({"raw" => ["two"]})
+    r3 = create_rev({"raw" => ["three"]})
+
+    r2.hide!
+
+    r1.current("raw").should == "three"
+    r2.previous("raw").should == "one"
+  end
+
+  it "shows revisions that were shown" do
+    r1 = create_rev({"raw" => ["one"]})
+    r2 = create_rev({"raw" => ["two"]})
+    r3 = create_rev({"raw" => ["three"]})
+
+    r2.hide!
+    r2.show!
+
+    r2.previous("raw").should == "two"
+    r1.current("raw").should == "two"
   end
 
 end


### PR DESCRIPTION
Follow-up to PR #2872 

As discussed here (and in a few linked topics)
https://meta.discourse.org/t/ability-to-hide-or-delete-old-revisions-on-selected-posts/19389

This has the full functionality to hide/show specific post revisions.
1. PostRevision only looks at the left-hand side of a given record.
   (But at this point, both sides are still saved to the database)
2. Added methods to hide! (or later show!) a given revision
   revisions are hidden when modification => hidden == true
3. A little bit of refactoring so all fields use current(field) and previous(field) methods
4. Falls back to previous/next revision or post, depending on what is available / not hidden
5. UX: Show / Hide buttons are only shown to staff
          When content is hidden, its hidden from everyone (and its not leaked through the 'previous' revision)

Example:

some content you want to hide:

![screen shot 2014-10-13 at 1 26 25 am](https://cloud.githubusercontent.com/assets/2217652/4610690/d7738260-52b2-11e4-8825-88b7d2cb5cbf.png)

after it's hidden, falls back to previous revision (and button to show it appears):

![screen shot 2014-10-13 at 1 26 39 am](https://cloud.githubusercontent.com/assets/2217652/4610695/e0a5fef8-52b2-11e4-8f31-7bd1dd6b37df.png)

after navigating to previous revision, it's still hidden from the right side:

![screen shot 2014-10-13 at 1 27 06 am](https://cloud.githubusercontent.com/assets/2217652/4610700/f784591c-52b2-11e4-80df-6157e58e196c.png)
