### PR TITLE
Fix: Set title for multiple youtube video player with the same ID

### DIFF
--- a/plugins/lazyYT/assets/javascripts/lazyYT.js
+++ b/plugins/lazyYT/assets/javascripts/lazyYT.js
@@ -35,7 +35,8 @@
             .addClass('lazyYT-image-loaded');
 
         $.getJSON('https://gdata.youtube.com/feeds/api/videos/' + id + '?v=2&alt=json', function (data) {
-            $('#lazyYT-title-' + id).text(data.entry.title.$t);
+            //$('#lazyYT-title-' + id).text(data.entry.title.$t);         //will only find a single element with a given id
+            $('p[id=lazyYT-title-' + id + ']').text(data.entry.title.$t); //will find all elements with given id
         });
 
         $el.on('click', function (e) {


### PR DESCRIPTION
When an identical youtube video is embedded multiple times on the same page. 
it will only be successful setting title to 1st element in the dom matching a unique id which is based on the actual youtube video id.

![image](https://cloud.githubusercontent.com/assets/8693091/4638514/a7e5f3e4-53fb-11e4-80e9-b03d02515979.png)
