### PR TITLE
Fix: Set title for multiple youtube video player with the same ID  (dont rely on id to set title)

### DIFF
--- a/plugins/lazyYT/assets/javascripts/lazyYT.js
+++ b/plugins/lazyYT/assets/javascripts/lazyYT.js
@@ -33,7 +33,9 @@
         })
             .html('<p id="lazyYT-title-' + id + '" class="lazyYT-title"></p><div class="lazyYT-button"></div>')
             .addClass('lazyYT-image-loaded');
-            $el_title = $el.find("p.lazyYT-title");  //get reference to the current container title element
+            
+        var $el_title = $el.find("p.lazyYT-title");  //get reference to the current container title element
+        
         $.getJSON('https://gdata.youtube.com/feeds/api/videos/' + id + '?v=2&alt=json', function (data) {
             $el_title.text(data.entry.title.$t); 
         });


### PR DESCRIPTION
When an identical youtube video is embedded multiple times on the same page. 
it will only be successful setting title to 1st element in the dom matching a unique id which is based on the actual youtube video id.

![image](https://cloud.githubusercontent.com/assets/8693091/4638618/f58b3dd8-53fc-11e4-9ffd-c0bf4860c128.png)
