### PR TITLE
[patch] When a post is split out to be a new topic

### DIFF
--- a/app/models/post_mover.rb
+++ b/app/models/post_mover.rb
@@ -41,6 +41,7 @@ class PostMover
     notify_users_that_posts_have_moved
     update_statistics
     update_user_actions
+    set_last_post_user_id(destination_topic)
 
     destination_topic
   end
@@ -136,5 +137,11 @@ class PostMover
         raise Discourse::InvalidParameters.new(:post_ids) if posts.empty?
       end
     end
+  end
+
+  def set_last_post_user_id(topic)
+    user_id = topic.posts.last.user_id rescue nil
+    return if user_id.nil?
+    topic.update_attribute :last_post_user_id, user_id
   end
 end

--- a/spec/models/post_mover_spec.rb
+++ b/spec/models/post_mover_spec.rb
@@ -74,6 +74,7 @@ describe PostMover do
           new_topic.reload
           new_topic.posts_count.should == 2
           new_topic.highest_post_number.should == 2
+          new_topic.last_post_user_id.should == new_topic.posts.last.user_id
           expect(new_topic.last_posted_at).to be_present
 
           p2.reload


### PR DESCRIPTION
the topic's last_post_user_id is set to the user who split out
the post.  But, this should really be the user_id of the last post
of the split out posts.
