### PR TITLE
Remove database steps in DEVELOPER-ADVANCED.md

### DIFF
--- a/docs/DEVELOPER-ADVANCED.md
+++ b/docs/DEVELOPER-ADVANCED.md
@@ -6,7 +6,7 @@ Note: If you are developing on a Mac, you will probably want to look at [these i
 
 ## First Steps
 
-1. Install and configure PostgreSQL 9.1+. 
+1. Install and configure PostgreSQL 9.1+.
   1. Run `postgres -V` to see if you already have it.
   1. Make sure that the server's messages language is English; this is [required](https://github.com/rails/rails/blob/3006c59bc7a50c925f6b744447f1d94533a64241/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L1140) by the ActiveRecord Postgres adapter.
 2. Install and configure Redis 2+.
@@ -15,9 +15,6 @@ Note: If you are developing on a Mac, you will probably want to look at [these i
 4. Install libxml2, g++, and make.
 5. Install Ruby 2.1.3 and Bundler.
 6. Clone the project and bundle.
-7. Copy `config/database.yml.development-sample` to `config/database.yml`. Copy `config/redis.yml.sample` to `config/redis.yml`. Edit the files to point to your postgres and redis instances.
-8. Create the "vagrant" user and the development and test databases in postgres. See the postgres section in "Building your own Vagrant VM", below.
-
 
 ## Before you start Rails
 


### PR DESCRIPTION
I just went through the developer install guide and noticed that the postgres and redis sample files aren't being used anymore. Read through [this](https://meta.discourse.org/t/enough-with-the-sample-files/10351) thread on meta as well so I'm assuming discourse is moving away from using sample files?

I also removed "add vagrant user" since it was in the vagrant section further down the doc. FWIW, I didn't do steps 7 & 8 and was able to get it running great.
