### PR TITLE
FIX: Non-secure warning from YouTube thumbnails

### DIFF
--- a/plugins/lazyYT/assets/javascripts/lazyYT.js
+++ b/plugins/lazyYT/assets/javascripts/lazyYT.js
@@ -27,7 +27,7 @@
             'height': height,
             'width': width,
             'padding-top': paddingTop,
-            'background': 'url(http://img.youtube.com/vi/' + id + '/hqdefault.jpg) center center no-repeat',
+            'background': 'url(//img.youtube.com/vi/' + id + '/hqdefault.jpg) center center no-repeat',
             'cursor': 'pointer',
             'background-size': 'cover'
         })


### PR DESCRIPTION
YouTube thumbnails where being loaded over `http` even on a `https` loaded page.
Causing the browser bar to change from green to yellow ![non-secure content loaded icon](http://i.imgur.com/c4GpwCQ.png)
