### PR TITLE
Add pl_PL locale for emoji plugin

### DIFF
--- a/plugins/emoji/config/locales/client.pl_PL.yml
+++ b/plugins/emoji/config/locales/client.pl_PL.yml
@@ -1,0 +1,6 @@
+pl_PL:
+  admin_js:
+    admin:
+      site_settings:
+        categories:
+          plugins: "Wtyczki"

--- a/plugins/emoji/config/locales/server.pl_PL.yml
+++ b/plugins/emoji/config/locales/server.pl_PL.yml
@@ -1,0 +1,3 @@
+pl_PL:
+  site_settings:
+    enable_emoji: "Włącz wyświetlanie Emoji"


### PR DESCRIPTION
I was using my own locale files for some time and I missed the fact that upstream does not have emoji one for `pl_PL`.
This PR fixes that. 
