### PR TITLE
FIX: browser password manager was saving name instead of username

### DIFF
--- a/app/assets/javascripts/discourse/controllers/create-account.js.es6
+++ b/app/assets/javascripts/discourse/controllers/create-account.js.es6
@@ -364,7 +364,7 @@ export default DiscourseController.extend(ModalFunctionality, {
         if (result.success) {
           // Trigger the browser's password manager using the hidden static login form:
           var $hidden_login_form = $('#hidden-login-form');
-          $hidden_login_form.find('input[name=username]').val(attrs.accountName);
+          $hidden_login_form.find('input[name=username]').val(attrs.accountUsername);
           $hidden_login_form.find('input[name=password]').val(attrs.accountPassword);
           $hidden_login_form.find('input[name=redirect]').val(Discourse.getURL('/users/account-created'));
           $hidden_login_form.submit();


### PR DESCRIPTION
cc @SamSaffron @coding-horror
