### PR TITLE
Remove href attribute from tab link to prevent duplicate event on enter.

### DIFF
--- a/app/assets/javascripts/discourse/lib/keyboard_shortcuts.js
+++ b/app/assets/javascripts/discourse/lib/keyboard_shortcuts.js
@@ -237,7 +237,7 @@ Discourse.KeyboardShortcuts = Ember.Object.createWithMixins({
       if ($article.is('.topic-post')) {
         var tabLoc = $article.find('a.tabLoc');
         if (tabLoc.length === 0) {
-          tabLoc = $('<a href="#" class="tabLoc"></a>');
+          tabLoc = $('<a class="tabLoc"></a>');
           $article.prepend(tabLoc);
         }
         tabLoc.focus();


### PR DESCRIPTION
Because Discourse doesn't preventDefault on links with an href of "#" this tab-able link was firing a click event when enter was pressed. This had the unfortunate side effect of breaking the history, making routing and navigation unreliable.

Related to this bug: https://meta.discourse.org/t/cant-load-suggested-topics-using-keyboard/20457
