### PR TITLE
Update INSTALL-digital-ocean.md to include chmod 744 on launcher

### DIFF
--- a/docs/INSTALL-digital-ocean.md
+++ b/docs/INSTALL-digital-ocean.md
@@ -81,8 +81,9 @@ After completing your edits, press <kbd>Ctrl</kbd><kbd>O</kbd> then <kbd>Enter</
 
 # Bootstrap Discourse
 
-Save the `app.yml` file, and begin bootstrapping Discourse:
+Save the `app.yml` file, then make the `launcher` executable, and begin bootstrapping Discourse:
 
+    chmod 744 launcher
     ./launcher bootstrap app
 
 This command takes about 8 minutes. It is automagically configuring your Discourse environment.


### PR DESCRIPTION
Following the instructions `launcher` is `-rw-r--r--  1 root root 14553 Oct 20 07:41 launcher`.

When I tried to run `./launcher bootstrap app` I got `-bash: ./launcher: Permission denied`.
