### PR TITLE
Add additional fields that indicate reply

### DIFF
--- a/lib/email/receiver.rb
+++ b/lib/email/receiver.rb
@@ -147,7 +147,7 @@ module Email
       end
     end
 
-    REPLYING_HEADER_LABELS = ['From', 'Sent', 'To', 'Subject', 'Reply To']
+    REPLYING_HEADER_LABELS = ['From', 'Sent', 'To', 'Subject', 'Reply To', 'Cc', 'Bcc', 'Date']
     REPLYING_HEADER_REGEX = Regexp.union(REPLYING_HEADER_LABELS.map { |lbl| "#{lbl}:" })
 
     def discourse_email_trimmer(body)


### PR DESCRIPTION
When scanning for where a reply starts, three lines in a row matching common email reply headers indicate the start of a reply. Add 'Cc', 'Bcc', and 'Date' because these are also common.
