### PR TITLE
Add post_number to PostWordpressSerializer

### DIFF
--- a/app/serializers/post_wordpress_serializer.rb
+++ b/app/serializers/post_wordpress_serializer.rb
@@ -1,5 +1,6 @@
 # The most basic attributes of a topic that we need to create a link for it.
 class PostWordpressSerializer < BasicPostSerializer
+  attributes :post_number
 
   include UrlHelper
 


### PR DESCRIPTION
The WP Discourse plugin [says it can use comment_url](https://github.com/discourse/wp-discourse/blob/6dd6ab554e62558a1fd85b6721d4112f30316886/wp-discourse.php#L542) but without the `post_number` sent through in the serializer this is impossible
