### PR TITLE
FIX: Make shortcut 'c' global for creating a topic

### DIFF
--- a/app/assets/javascripts/discourse/lib/keyboard_shortcuts.js
+++ b/app/assets/javascripts/discourse/lib/keyboard_shortcuts.js
@@ -131,7 +131,7 @@ Discourse.KeyboardShortcuts = Ember.Object.createWithMixins({
   },
 
   createTopic: function() {
-    Discourse.__container__.lookup('controller:composer').send('open', {action: Discourse.Composer.CREATE_TOPIC, draftKey: Discourse.Composer.DRAFT});
+    Discourse.__container__.lookup('controller:composer').open({action: Discourse.Composer.CREATE_TOPIC, draftKey: Discourse.Composer.DRAFT});
   },
 
   toggleProgress: function() {


### PR DESCRIPTION
Make shortcut 'c' global for creating a topic
https://meta.discourse.org/t/keyboard-shortcut-c-create-a-new-topic-does-not-work-globally/18975
