### PR TITLE
FIX: Do not show unconfirmed users in search results

### DIFF
--- a/lib/search.rb
+++ b/lib/search.rb
@@ -263,7 +263,7 @@ class Search
 
     def user_search
       users = User.includes(:user_search_data)
-                  .where("user_search_data.search_data @@ #{ts_query("simple")}")
+                  .where("active = true AND user_search_data.search_data @@ #{ts_query("simple")}")
                   .order("CASE WHEN username_lower = '#{@original_term.downcase}' THEN 0 ELSE 1 END")
                   .order("last_posted_at DESC")
                   .limit(@limit)

--- a/spec/components/search_spec.rb
+++ b/spec/components/search_spec.rb
@@ -87,6 +87,15 @@ describe Search do
     end
   end
 
+  context 'inactive users' do
+    let!(:inactive_user) { Fabricate(:inactive_user, active: false) }
+    let(:result) { Search.execute('bruce') }
+
+    it 'does not return a result' do
+      result.users.length.should == 0
+    end
+  end
+
   context 'topics' do
     let(:post) { Fabricate(:post) }
     let(:topic) { post.topic}

--- a/spec/fabricators/user_fabricator.rb
+++ b/spec/fabricators/user_fabricator.rb
@@ -32,6 +32,13 @@ Fabricator(:walter_white, from: :user) do
   password 'letscook'
 end
 
+Fabricator(:inactive_user, from: :user) do
+  name 'Inactive User'
+  username 'inactive_user'
+  email 'inactive@idontexist.com'
+  active false
+end
+
 Fabricator(:moderator, from: :user) do
   name { sequence(:name) {|i| "A#{i} Moderator"} }
   username { sequence(:username) {|i| "moderator#{i}"} }


### PR DESCRIPTION
Do not show unconfirmed users in search results
https://meta.discourse.org/t/unconfirmed-members-show-in-search-results/21378
