### PR TITLE
FIX: attachment links in mail lacks protocol

### DIFF
--- a/lib/email/styles.rb
+++ b/lib/email/styles.rb
@@ -27,6 +27,7 @@ module Email
     def format_basic
       uri = URI(Discourse.base_url)
 
+      # images
       @fragment.css('img').each do |img|
 
         next if img['class'] == 'site-logo'
@@ -49,6 +50,20 @@ module Email
         # ensure no schemaless urls
         if img['src'] && img['src'].starts_with?("//")
           img['src'] = "#{uri.scheme}:#{img['src']}"
+        end
+      end
+
+      # attachments
+      @fragment.css('a.attachment').each do |a|
+
+        # ensure all urls are absolute
+        if a['href'] =~ /^\/[^\/]/
+          a['href'] = "#{Discourse.base_url}#{a['href']}"
+        end
+
+        # ensure no schemaless urls
+        if a['href'] && a['href'].starts_with?("//")
+          a['href'] = "#{uri.scheme}:#{a['href']}"
         end
       end
     end

--- a/spec/components/email/styles_spec.rb
+++ b/spec/components/email/styles_spec.rb
@@ -113,6 +113,11 @@ describe Email::Styles do
         frag.at('a')['href'].should == "http://test.localhost/discourse"
       end
 
+      it "rewrites the href for attachment files to have http" do
+        frag = html_fragment('<a class="attachment" href="//try-discourse.global.ssl.fastly.net/uploads/default/368/40b610b0aa90cfcf.txt">attachment_file.txt</a>')
+        frag.at('a')['href'].should == "http://try-discourse.global.ssl.fastly.net/uploads/default/368/40b610b0aa90cfcf.txt"
+      end
+
       it "rewrites the src to have http" do
         frag = html_fragment('<img src="//test.localhost/blah.jpg">')
         frag.at('img')['src'].should == "http://test.localhost/blah.jpg"
@@ -124,9 +129,14 @@ describe Email::Styles do
         SiteSetting.stubs(:use_https).returns(true)
       end
 
-      it "rewrites the forum URL to have http" do
+      it "rewrites the forum URL to have https" do
         frag = html_fragment('<a href="//test.localhost/discourse">hello</a>')
         frag.at('a')['href'].should == "https://test.localhost/discourse"
+      end
+
+      it "rewrites the href for attachment files to have https" do
+        frag = html_fragment('<a class="attachment" href="//try-discourse.global.ssl.fastly.net/uploads/default/368/40b610b0aa90cfcf.txt">attachment_file.txt</a>')
+        frag.at('a')['href'].should == "https://try-discourse.global.ssl.fastly.net/uploads/default/368/40b610b0aa90cfcf.txt"
       end
 
       it "rewrites the src to have https" do


### PR DESCRIPTION
[Bug report here](https://meta.discourse.org/t/links-to-attachments-in-mail-still-lack-protocol/19491?u=techapj)

cc @eviltrout 
