### PR TITLE
Includes lines in release notes from comments with a blank like after the first one

### DIFF
--- a/lib/tasks/release_note.rake
+++ b/lib/tasks/release_note.rake
@@ -6,7 +6,7 @@ task "release_note:generate", :tag do |t, args|
   new_features = Set.new
   ux_changes = Set.new
 
-  `git log --pretty=format:%s #{tag}..HEAD`.each_line do |comment|
+  `git log #{tag}..HEAD`.each_line do |comment|
     split_comments(comment).each do |line|
       if line =~ /^FIX:/
         bug_fixes << better(line)


### PR DESCRIPTION
Include FIX and FEATURE lines in release notes from commit messages like [this one](https://github.com/discourse/discourse/commit/e7f251c105472f45778ad092e5a2dc1ec82f95c1) which include a blank line after the first one.
