### PR TITLE
UX: show the hide revision button on mobile

### DIFF
--- a/app/assets/javascripts/discourse/controllers/history.js.es6
+++ b/app/assets/javascripts/discourse/controllers/history.js.es6
@@ -53,8 +53,8 @@ export default ObjectController.extend(ModalFunctionality, {
   displayGoToNext: function() { return this.get("next_revision") && this.get("current_revision") < this.get("next_revision"); }.property("current_revision", "next_revision"),
   displayGoToLast: function() { return this.get("current_revision") < this.get("last_revision"); }.property("current_revision", "last_revision"),
 
-  displayShow: function() { return !Discourse.Mobile.mobileView && this.get("previous_hidden") && Discourse.User.currentProp('staff'); }.property("previous_hidden"),
-  displayHide: function() { return !Discourse.Mobile.mobileView && !this.get("previous_hidden") && Discourse.User.currentProp('staff'); }.property("previous_hidden"),
+  displayShow: function() { return this.get("previous_hidden") && Discourse.User.currentProp('staff') && !this.get("loading"); }.property("previous_hidden", "loading"),
+  displayHide: function() { return !this.get("previous_hidden") && Discourse.User.currentProp('staff') && !this.get("loading"); }.property("previous_hidden", "loading"),
 
   isEitherRevisionHidden: Em.computed.or("previous_hidden", "current_hidden"),
 

--- a/app/assets/stylesheets/common/base/history.scss
+++ b/app/assets/stylesheets/common/base/history.scss
@@ -3,7 +3,7 @@
 .modal.history-modal {
   #revision-numbers {
     display: inline-block;
-    min-width: 100px;
+    min-width: 96px;
     text-align: center;
   }
   #revision-loading {


### PR DESCRIPTION
Shaving 4px off the min-width allows the button to stay visible on smaller screens even with double-digit revisions (screenshot of iPhone 4 in Chrome emulator)

![screen shot 2014-10-28 at 7 47 14 am](https://cloud.githubusercontent.com/assets/2217652/4811093/13b3b478-5eb8-11e4-81a0-297754f62e32.png)
