### PR TITLE
Fix: Don't skip activities table in vanilla importer

### DIFF
--- a/script/import_scripts/vanilla.rb
+++ b/script/import_scripts/vanilla.rb
@@ -56,7 +56,6 @@ class ImportScripts::Vanilla < ImportScripts::Base
           end
           # PERF: don't parse useless tables
           useless_tables = ["user_meta"]
-          useless_tables << "activities" unless @use_lastest_activity_as_user_bio
           next if useless_tables.include?(table)
           # parse the data
           puts "parsing #{table}..."


### PR DESCRIPTION
Resolves null reference error of `activities` instance variable in `import_users` method after regression induced in 898ceb41e8e7f3cda91b136676fdd3bf2bd0dc45

See https://meta.discourse.org/t/paid-need-a-vanilla-2-import-tool/14852/49?u=evanw for output of original problem.
