### PR TITLE
Allow the use of DISCOURSE_REDIS_SOCKET for redis configuration

### DIFF
--- a/config/discourse_defaults.conf
+++ b/config/discourse_defaults.conf
@@ -82,6 +82,9 @@ redis_host = localhost
 # redis server port
 redis_port = 6379
 
+# redis server socket (non-empty to use)
+redis_socket =
+
 # redis database
 redis_db = 0
 

--- a/config/discourse_quickstart.conf
+++ b/config/discourse_quickstart.conf
@@ -61,6 +61,9 @@ developer_emails =
 # redis server port
 # redis_port = 6379
 
+# redis server socket, if using socket
+# redis_socket =
+
 # redis password
 # redis_password =
 

--- a/config/redis.yml
+++ b/config/redis.yml
@@ -1,6 +1,7 @@
 defaults: &defaults
   host: <%= GlobalSetting.redis_host %>
   port: <%= GlobalSetting.redis_port %>
+  socket: <%= GlobalSetting.redis_socket %>
   password: <%= GlobalSetting.redis_password %>
   db: <%= GlobalSetting.redis_db %>
 

--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -292,7 +292,8 @@ module Discourse
   end
 
   def self.sidekiq_redis_config
-    { url: $redis.url, namespace: 'sidekiq' }
+    # the db option here is a workaround for unix socket URLs, which cannot contain the db number
+    { url: $redis.url, namespace: 'sidekiq', db: $redis.config['db'] }
   end
 
   def self.static_doc_topic_ids

--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -293,7 +293,8 @@ module Discourse
 
   def self.sidekiq_redis_config
     # the db option here is a workaround for unix socket URLs, which cannot contain the db number
-    { url: $redis.url, namespace: 'sidekiq', db: $redis.config['db'] }
+    # the .try will fail if $redis is not a DiscourseRedis wrapper (... test environments, maybe?)
+    { url: $redis.url, namespace: 'sidekiq', db: $redis.try(:db) }
   end
 
   def self.static_doc_topic_ids

--- a/lib/discourse_redis.rb
+++ b/lib/discourse_redis.rb
@@ -49,6 +49,10 @@ class DiscourseRedis
     self.class.url(@config)
   end
 
+  def db
+    @config['db']
+  end
+
   # prefix the key with the namespace
   def method_missing(meth, *args, &block)
     if @redis.respond_to?(meth)


### PR DESCRIPTION
This mirrors the DISCOURSE_DB_SOCKET setting. This is intended for
multi-container setups that want to be IP-independent.