### PR TITLE
some possible improvements to build times

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
 
 before_script:
   - psql -c 'create database discourse_test;' -U postgres
-  - bundle exec rake db:schema:load
+  - bundle exec rake db:migrate
 
 bundler_args: --without development --deployment
 


### PR DESCRIPTION
- use our new infrastructure based on LXC and EC2
- enable caching for bundler
- use --deployment (best practice when a Gemfile.lock is around)
