### PR TITLE
FEATURE: ?include_raw parameter for /t/id/posts.json

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -110,7 +110,7 @@ class TopicsController < ApplicationController
     params.require(:post_ids)
 
     @topic_view = TopicView.new(params[:topic_id], current_user, post_ids: params[:post_ids])
-    render_json_dump(TopicViewPostsSerializer.new(@topic_view, scope: guardian, root: false))
+    render_json_dump(TopicViewPostsSerializer.new(@topic_view, scope: guardian, root: false, include_raw: !!params[:include_raw]))
   end
 
   def destroy_timings


### PR DESCRIPTION
include_raw is not added for the wordpress view because it uses the
BasicPostSerializer, and is not a one-line change.

This is the only use of the TopicViewPostsSerializer class, and the
previous change covered the only use of the TopicViewSerializer class.
No other locations include the PostStreamSerializerMixin. Therefore,
this feature is most likely complete.

(This is a patch for incomplete PR #2938 )

https://meta.discourse.org/t/any-way-to-get-raw-posts-in-bulk/21615/11?u=riking
