### PR TITLE
Change translation of ":)" from smile to grinning

### DIFF
--- a/plugins/emoji/assets/javascripts/emoji.js.erb
+++ b/plugins/emoji/assets/javascripts/emoji.js.erb
@@ -23,30 +23,31 @@
 
   // Also support default emotions
   var translations = {
-    ':)'   : 'smile',
-    ':-)'   : 'smile',
-    ':('   : 'frowning',
+    ':)'    : 'grinning',
+    ':-)'   : 'grinning',
+    ':('    : 'frowning',
     ':-('   : 'frowning',
-    ';)'   : 'wink',
+    ':D'    : 'smiley',
+    ':-D'   : 'smiley',
+    ';)'    : 'wink',
     ';-)'   : 'wink',
-    ':\'(' : 'cry',
+    ':\'('  : 'cry',
     ':\'-(' : 'cry',
     ':-\'(' : 'cry',
-    ':p'   : 'stuck_out_tongue',
-    ':P'   : 'stuck_out_tongue',
+    ':p'    : 'stuck_out_tongue',
+    ':P'    : 'stuck_out_tongue',
+    ':-p'   : 'stuck_out_tougue',
     ':-P'   : 'stuck_out_tongue',
-    ':O'   : 'open_mouth',
+    ';P'    : 'stuck_out_tongue_winking_eye',
+    ';-P'   : 'stuck_out_tongue_winking_eye',
+    ';p'    : 'stuck_out_tongue_winking_eye',
+    ';-p'   : 'stuck_out_tongue_winking_eye',
+    ':O'    : 'open_mouth',
     ':-O'   : 'open_mouth',
-    ':D'   : 'smiley',
-    ':-D'   : 'smiley',
-    ':|'   : 'expressionless',
+    ':|'    : 'expressionless',
     ':-|'   : 'expressionless',
-    ";P"   : 'stuck_out_tongue_winking_eye',
-    ";-P"   : 'stuck_out_tongue_winking_eye',
-    ';)'   : 'wink',
-    ';-)'   : 'wink',
-    ":$"   : 'blush',
-    ":-$"   : 'blush'
+    ':$'    : 'blush',
+    ':-$'   : 'blush'
   };
 
   function checkPrev(prev) {


### PR DESCRIPTION
See discussion on meta here: https://meta.discourse.org/t/basic-smiley-smile-should-not-have-closed-eyes/21751

(Also rearranges and cleans up the existing translations slightly, and adds obvious missing variants like with upper vs lowercase p's for stuck out tongues.)
