### PR TITLE
Category Moderators feature, phase 1; back-end only

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -33,7 +33,9 @@ class CategoriesController < ApplicationController
 
   def upload
     params.require(:image_type)
-    guardian.ensure_can_create!(Category)
+    # TODO: should really be checking upload permission for specific category,
+    # but no category_id is provided in this API call
+    guardian.ensure_can_upload_for_category!
 
     file = params[:file] || params[:files].first
     upload = Upload.create_for(current_user.id, file.tempfile, file.original_filename, File.size(file.tempfile))
@@ -138,7 +140,9 @@ class CategoriesController < ApplicationController
                         :logo_url,
                         :background_url,
                         :allow_badges,
-                        :permissions => [*p.try(:keys)])
+                        :permissions => [*p.try(:keys)],
+                        :moderators => []
+                     )
       end
     end
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -257,9 +257,10 @@ class PostsController < ApplicationController
   end
 
   def wiki
-    guardian.ensure_can_wiki!
-
     post = find_post_from_params
+
+    guardian.ensure_can_wiki!(post)
+
     post.revise(current_user, { wiki: params[:wiki] })
 
     render nothing: true

--- a/app/serializers/basic_category_serializer.rb
+++ b/app/serializers/basic_category_serializer.rb
@@ -18,6 +18,8 @@ class BasicCategorySerializer < ApplicationSerializer
              :background_url,
              :can_edit
 
+  has_many :moderators, serializer: BasicUserSerializer, embed: :objects
+
   def include_parent_category_id?
     parent_category_id
   end

--- a/db/migrate/20141103230951_add_category_moderators.rb
+++ b/db/migrate/20141103230951_add_category_moderators.rb
@@ -1,0 +1,5 @@
+class AddCategoryModerators < ActiveRecord::Migration
+  def change
+    add_column :category_users, :moderator, :boolean, null: false, default: false
+  end
+end

--- a/lib/guardian/category_guardian.rb
+++ b/lib/guardian/category_guardian.rb
@@ -7,7 +7,10 @@ module CategoryGuardian
     (
       SiteSetting.allow_moderators_to_create_categories &&
       is_moderator?
-    )
+    ) ||
+      (
+        parent && @user.doth_moderate?(parent)
+      )
   end
 
   # Editing Method
@@ -17,7 +20,8 @@ module CategoryGuardian
       SiteSetting.allow_moderators_to_create_categories &&
       is_moderator? &&
       can_see_category?(category)
-    )
+    ) ||
+      @user.doth_moderate?(category)
   end
 
   def can_delete_category?(category)
@@ -61,4 +65,9 @@ module CategoryGuardian
   def topic_create_allowed_category_ids
     @topic_create_allowed_category_ids ||= @user.topic_create_allowed_category_ids
   end
+
+  def can_appoint_moderator?(cat)
+    is_staff?
+  end
+  alias_method :can_dismiss_moderator?, :can_appoint_moderator?
 end

--- a/lib/guardian/post_guardian.rb
+++ b/lib/guardian/post_guardian.rb
@@ -76,7 +76,7 @@ module PostGuardian
       return false
     end
 
-    if is_staff? || @user.has_trust_level?(TrustLevel[4])
+    if is_staff? || is_user_leader? || user.doth_moderate?(post.topic)
       return true
     end
 
@@ -117,7 +117,7 @@ module PostGuardian
     # You can delete your own posts
     return !post.user_deleted? if is_my_own?(post)
 
-    is_staff?
+    is_staff? || @user.doth_moderate?(post.topic)
   end
 
   # Recovery Method
@@ -160,8 +160,8 @@ module PostGuardian
     is_admin?
   end
 
-  def can_wiki?
-    is_staff? || @user.has_trust_level?(TrustLevel[4])
+  def can_wiki?(post = nil)
+    is_staff? || is_user_leader? || (post && can_edit_post?(post))
   end
 
   def can_change_post_type?

--- a/spec/models/category_user_spec.rb
+++ b/spec/models/category_user_spec.rb
@@ -54,3 +54,132 @@ describe CategoryUser do
 
   end
 end
+
+# A Category Moderator is marked by the `moderator` flag in the CategoryUser table.
+# The tests here span several different Guardian models.
+describe "Category Moderator" do
+
+  context "an unmoderated category" do
+    before do
+      @category = Fabricate(:category)
+    end
+
+    it "has no moderators" do
+      @category.should_not be_moderated
+      @category.moderators.should be_empty
+    end
+
+    it "accepts moderator appointments" do
+      user1 = Fabricate(:user)
+      user2 = Fabricate(:user)
+      @category.appoint_moderator(user1)
+      @category.appoint_moderator(user2)
+
+      @category.should be_moderated
+      @category.moderators.to_set.should eq([user1, user2].to_set)
+
+      [user1, user2].each do |u|
+        u.should be_moderating
+        u.doth_moderate?(@category).should be_truthy
+        u.moderated_categories.should eq([@category])
+      end
+    end
+
+    it "can appoint existing category users" do
+      user3 = Fabricate(:user)
+
+      CategoryUser.set_notification_level_for_category(user3, 2, @category.id)
+      @category.category_users.count.should eq(1)
+      @category.appoint_moderator(user3)
+      @category.category_users.count.should eq(1)
+    end
+  end
+
+  context "a moderated category" do
+    before do
+      @category = Fabricate(:category)
+      @category.appoint_moderator(Fabricate(:user))
+    end
+
+    it "has a moderator" do
+      @category.should be_moderated
+    end
+  end
+
+  context "a category moderator" do
+    before do
+      @category = Fabricate(:category)
+      @moderator = Fabricate(:user)
+      @category.appoint_moderator(@moderator)
+      @topic = Fabricate(:topic, category: @category)
+      @guardian = Guardian.new(@moderator)
+    end
+
+    it "can be dismissed" do
+      @category.dismiss_moderator(@moderator)
+      @category.reload
+
+      @category.should_not be_moderated
+      # not deleted, just demoted
+      @category.category_users.should_not be_empty
+    end
+
+    it "can edit (rename) the category" do
+      @guardian.can_edit?(@category).should be_truthy
+    end
+
+    it "can see, create & moderate (post, close, open, unlist, pin, archive) any topic in the category" do
+      @guardian.can_see_topic?(@topic).should be_truthy
+      @guardian.can_create_topic_on_category?(@category).should be_truthy
+      @guardian.can_moderate?(@topic).should be_truthy
+    end
+
+    it "can edit (rename) & recategorize any topic in the category" do
+      @guardian.can_edit?(@topic).should be_truthy
+    end
+
+    it "cannot appoint or dismiss moderators" do
+      @guardian.can_appoint_moderator?(@category).should be_falsey
+      @guardian.can_dismiss_moderator?(@category).should be_falsey
+    end
+
+    it "can create sub-categories" do
+      @guardian.can_create?(@category).should be_truthy
+    end
+
+    it "can moderate any sub-categories" do
+      subcat = Fabricate(:category, name: "Subcategory")
+      subcat.parent_category = @category
+      subcat.save
+
+      @guardian.can_moderate?(subcat).should be_truthy
+    end
+
+    it "can delete & edit posts" do
+      post = Fabricate.build(:post, topic: @topic)
+      @guardian.can_delete?(post).should be_truthy
+      @guardian.can_edit?(post).should be_truthy
+      @guardian.can_see_post?(post).should be_truthy
+    end
+
+    it "can invite users" do
+      @guardian.can_invite_to_forum?.should be_truthy
+    end
+
+    it "can edit, delete, wikify posts" do
+      post1 = Fabricate(:post, topic: @topic)
+      post2 = Fabricate(:post, topic: @topic)
+      @guardian.can_edit?(post1).should be_truthy
+      @guardian.can_delete?(post2).should be_truthy # never delete first post
+      @guardian.can_wiki?(post1).should be_truthy
+    end
+
+    # TODO: see CategoriesController#upload; should be validating permission
+    # for the specific category, but category_id is not currently provided;
+    # update this when the client side can be updated to match
+    it "can upload images for category" do
+      @guardian.can_upload_for_category?.should be_truthy
+    end
+  end
+
+end


### PR DESCRIPTION
https://meta.discourse.org/t/category-specific-moderators-phase-1-rfc/21900
- adds a moderator flag to the `CATEGORY_USERS` table
- all the checks are in `Guardian` and subclasses
- tests are mostly in `category_user_spec.rb`
- no alterations to UI or existing functionality; feature is invisible if not used
