### PR TITLE
FIX: Do not recall prior DRAFT in a given category when using the Create...

### DIFF
--- a/app/assets/javascripts/discourse/lib/keyboard_shortcuts.js
+++ b/app/assets/javascripts/discourse/lib/keyboard_shortcuts.js
@@ -132,7 +132,7 @@ Discourse.KeyboardShortcuts = Ember.Object.createWithMixins({
   },
 
   createTopic: function() {
-    Discourse.__container__.lookup('controller:composer').open({action: Discourse.Composer.CREATE_TOPIC, draftKey: Discourse.Composer.DRAFT});
+    Discourse.__container__.lookup('controller:composer').open({action: Discourse.Composer.CREATE_TOPIC, draftKey: Discourse.Composer.CREATE_TOPIC});
   },
 
   pinUnpinTopic: function() {


### PR DESCRIPTION
Do not recall prior DRAFT in a given category when using the Create Topic keyboard shortcut.
