### PR TITLE
FIX: Change is_staff to is_admin for group posts to match other places

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -42,7 +42,7 @@ class Group < ActiveRecord::Base
                  .where('topics.archetype <> ?', Archetype.private_message)
                  .where(post_type: Post.types[:regular])
 
-    unless guardian.is_staff?
+    unless guardian.is_admin?
       allowed_ids = guardian.allowed_category_ids
       if allowed_ids.length > 0
         result = result.where('topics.category_id IS NULL or topics.category_id IN (?)', allowed_ids)


### PR DESCRIPTION
Change is_staff to is_admin to match other places where guardian.allowed_category_ids is used

https://meta.discourse.org/t/security-permissions-and-messages-displayed-on-group-url/22169/17
