### PR TITLE
Traverse symlinks to plugins in dev mode when compiling stylesheets

### DIFF
--- a/lib/sass/discourse_stylesheets.rb
+++ b/lib/sass/discourse_stylesheets.rb
@@ -56,10 +56,17 @@ class DiscourseStylesheets
   end
 
   def self.max_file_mtime
-    [ "#{Rails.root}/app/assets/stylesheets/**/*.*css",
-      "#{Rails.root}/plugins/**/*.*css",
-      "#{Rails.root}/plugins/**/plugin.rb" ].map do |pattern|
-        Dir.glob(pattern).map { |x| File.mtime(x) }.max
+    globs = ["#{Rails.root}/app/assets/stylesheets/**/*.*css"]
+
+    for path in (Discourse.plugins || []).map { |plugin| File.dirname(plugin.path) }
+      globs += [
+        "#{path}/plugin.rb",
+        "#{path}/**/*.*css",
+      ]
+    end
+
+    globs.map do |pattern|
+      Dir.glob(pattern).map { |x| File.mtime(x) }.max
     end.compact.max.to_i
   end
 


### PR DESCRIPTION
When developing plugins it's useful to symlink the to the plugin directory from the discourse directory, since that means the two are separate git repos.

However, Dir.glob doesn't by default traverse symlinks. This change means that the SASS compilation caching detects when any of a plugin's files have changed.
