### PR TITLE
allow override for fetching more than 200 group members

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -18,7 +18,8 @@ class GroupsController < ApplicationController
 
   def members
     group = find_group(:group_id)
-    render_serialized(group.users.order('username_lower asc').limit(200).to_a, GroupUserSerializer)
+    limit = (params[:limit] || 200).to_i
+    render_serialized(group.users.order('username_lower asc').limit(limit).to_a, GroupUserSerializer)
   end
 
   private

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -67,5 +67,13 @@ describe GroupsController do
       xhr :get, :posts, group_id: group.name
       response.should be_success
     end
+
+    it "ensures that over 200 members can be retrieved" do
+      300.times { group.add(Fabricate(:user)) }
+      xhr :get, :members, group_id: group.name, limit: 400
+      response.should be_success
+      members = JSON.parse(response.body)
+      members.count.should eq(300)
+    end
   end
 end


### PR DESCRIPTION
`/groups/xxx/members.json?limit=NNN`

NNN defaults to the previously hard-coded 200. This just makes it possible to fetch more.
