### PR TITLE
set indent_style to valid value

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,7 @@ root = true
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
-indent_style = spaces
+indent_style = space
 indent_size = 2
 
 [*.md]


### PR DESCRIPTION
Per the documentation for editorconfig the two valid values for `indent_style`  are 'tab' or 'space'.
http://editorconfig.org/#file-format-details
