### PR TITLE
FIX: Sharing link stood visible after using browser’s back button

### DIFF
--- a/app/assets/javascripts/discourse/views/share.js.es6
+++ b/app/assets/javascripts/discourse/views/share.js.es6
@@ -104,6 +104,8 @@ export default Discourse.View.extend({
   },
 
   willDestroyElement: function() {
+    this.get('controller').send('close');
+
     $('html').off('click.discoure-share-link')
              .off('mousedown.outside-share-link')
              .off('keydown.share-view');


### PR DESCRIPTION
This small piece of code fixes this bug: https://meta.discourse.org/t/dialog-for-sharing-link-stays-visible-after-using-browsers-back-and-forward-buttons/22178

;)
