### PR TITLE
FEATURE: show exact error for test email

### DIFF
--- a/app/assets/javascripts/admin/controllers/admin-email-index.js.es6
+++ b/app/assets/javascripts/admin/controllers/admin-email-index.js.es6
@@ -36,8 +36,12 @@ export default DiscourseController.extend({
         data: { email_address: this.get('testEmailAddress') }
       }).then(function () {
         self.set('sentTestEmail', true);
-      }).catch(function () {
-        bootbox.alert(I18n.t('admin.email.test_error'));
+      }, function(e) {
+        if (e.responseJSON && e.responseJSON.errors) {
+          bootbox.alert(I18n.t('admin.email.error', { server_error: e.responseJSON.errors[0] }));
+        } else {
+          bootbox.alert(I18n.t('admin.email.test_error'));
+        }
       }).finally(function() {
         self.set('sendingEmail', false);
       });

--- a/app/controllers/admin/email_controller.rb
+++ b/app/controllers/admin/email_controller.rb
@@ -9,8 +9,12 @@ class Admin::EmailController < Admin::AdminController
 
   def test
     params.require(:email_address)
-    Jobs::TestEmail.new.execute(to_address: params[:email_address])
-    render nothing: true
+    begin
+      Jobs::TestEmail.new.execute(to_address: params[:email_address])
+      render nothing: true
+    rescue => e
+      render json: {errors: [e.message]}, status: 422
+    end
   end
 
   def all

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -52,4 +52,3 @@ Discourse::Application.configure do
     config.developer_emails = emails.split(",").map(&:strip)
   end
 end
-

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1760,6 +1760,7 @@ en:
         settings: "Settings"
         all: "All"
         sending_test: "Sending test Email..."
+        error: "<b>ERROR</b> - %{server_error}"
         test_error: "There was a problem sending the test email. Please double-check your mail settings, verify that your host is not blocking mail connections, and try again."
         sent: "Sent"
         skipped: "Skipped"


### PR DESCRIPTION
Example:

![screen shot 2014-11-19 at 9 20 35 pm](https://cloud.githubusercontent.com/assets/5732281/5108688/30132dd4-7032-11e4-9cfb-7bc3157cad7a.png)

cc @SamSaffron 
