### PR TITLE
Update DEVELOPER-ADVANCED.md

### DIFF
--- a/docs/DEVELOPER-ADVANCED.md
+++ b/docs/DEVELOPER-ADVANCED.md
@@ -13,8 +13,8 @@ Note: If you are developing on a Mac, you will probably want to look at [these i
   1. Run `redis-server -v` to see if you already have it.
 3. Install ImageMagick
 4. Install libxml2, libpq-dev, g++, and make.
-6. Install Ruby 2.1.3 and Bundler.
-7. Clone the project and bundle.
+5. Install Ruby 2.1.3 and Bundler.
+6. Clone the project and bundle.
 
 ## Before you start Rails
 


### PR DESCRIPTION
To install the gem pg-0.15.1, you need to have libpq-dev installed. Otherwise bundle install will fail.
See http://stackoverflow.com/questions/16788062/error-running-gem-install-pg-v-0-15-1
