### PR TITLE
FIX: TL4 flag on TL0 post as spam, hides the post

### DIFF
--- a/app/models/post_action.rb
+++ b/app/models/post_action.rb
@@ -384,7 +384,7 @@ class PostAction < ActiveRecord::Base
     return if post.hidden
 
     if post_action_type == :spam &&
-       acting_user.trust_level == TrustLevel[3] &&
+       acting_user.has_trust_level?(TrustLevel[3]) &&
        post.user.trust_level == TrustLevel[0]
 
        hide_post!(post, post_action_type, Post.hidden_reasons[:flagged_by_tl3_user])


### PR DESCRIPTION
https://meta.discourse.org/t/spam-tl-0-post-is-not-automatically-hidden-by-tl-4/22311
