### PR TITLE
FEATURE: Add ?status=deleted querystring

### DIFF
--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -233,7 +233,7 @@ class TopicQuery
       options.reverse_merge!(per_page: SiteSetting.topics_per_page)
 
       # Start with a list of all topics
-      result = Topic
+      result = Topic.unscoped
 
       if @user
         result = result.joins("LEFT OUTER JOIN topic_users AS tu ON (topics.id = tu.topic_id AND tu.user_id = #{@user.id.to_i})")
@@ -286,6 +286,7 @@ class TopicQuery
                                         notification_level = ?)', @user.id, level)
       end
 
+      require_deleted_clause = true
       if status = options[:status]
         case status
         when 'open'
@@ -298,9 +299,15 @@ class TopicQuery
           result = result.where('topics.visible')
         when 'invisible'
           result = result.where('NOT topics.visible')
+        when 'deleted'
+          if @user && @user.is_staff?
+            result = result.where('topics.deleted_at IS NOT NULL')
+            require_deleted_clause = false
+          end
         end
       end
 
+      result = result.where('topics.deleted_at IS NULL') if require_deleted_clause
       result = result.where('topics.posts_count <= ?', options[:max_posts]) if options[:max_posts].present?
       result = result.where('topics.posts_count >= ?', options[:min_posts]) if options[:min_posts].present?
 


### PR DESCRIPTION
Add ?status=deleted as an advanced querystring argument.

To test this I did the following:
1) Logged the original latest topics query as an Admin, Moderator, user, and anonymous
2) Logged the latest topics query after my changes as an Admin, Moderator, user, and anonymous

Compared the WHERE clauses to verify that all conditions were still being applied.
Added my querystring to verify that it replaced the deleted_at IS NULL condition with deleted_at IS NOT NULL

Oh, and there is a @user.is_staff? check around the deleted_at IS NOT NULL so that regular/anonymous members cannot see deleted topics.
