### PR TITLE
FEATURE: Add ?status=deleted querystring

### DIFF
--- a/spec/components/topic_query_spec.rb
+++ b/spec/components/topic_query_spec.rb
@@ -40,6 +40,17 @@ describe TopicQuery do
 
   end
 
+  context 'deleted filter' do
+    it "filters deleted topics correctly" do
+      topic = Fabricate(:topic, deleted_at: 1.year.ago)
+
+      TopicQuery.new(admin, status: 'deleted').list_latest.topics.size.should == 1
+      TopicQuery.new(moderator, status: 'deleted').list_latest.topics.size.should == 1
+      TopicQuery.new(user, status: 'deleted').list_latest.topics.size.should == 0
+      TopicQuery.new(nil, status: 'deleted').list_latest.topics.size.should == 0
+    end
+  end
+
   context 'category filter' do
     let(:category) { Fabricate(:category) }
 


### PR DESCRIPTION
Add ?status=deleted as an advanced querystring argument.

To test this I did the following:
1) Logged the original latest topics query as an Admin, Moderator, user, and anonymous
2) Logged the latest topics query after my changes as an Admin, Moderator, user, and anonymous

Compared the WHERE clauses to verify that all conditions were still being applied.
Added my querystring to verify that it replaced the deleted_at IS NULL condition with deleted_at IS NOT NULL

Oh, and there is a guardian.is_staff? check around the deleted_at IS NOT NULL so that regular/anonymous members cannot see deleted topics.
