### PR TITLE
Removed titleColSpan of uncategorized topics

### DIFF
--- a/app/assets/javascripts/discourse/controllers/topic-list-item.js.es6
+++ b/app/assets/javascripts/discourse/controllers/topic-list-item.js.es6
@@ -23,9 +23,7 @@ export default Ember.ObjectController.extend({
   }.property('controllers.discovery/topics.selected.length'),
 
   titleColSpan: function() {
-    // Uncategorized pinned topics will span the title and category column in the topic list.
-    return (!this.get('controllers.discovery/topics.hideCategory') &&
-             this.get('model.isPinnedUncategorized') ? 2 : 1);
+    return (!this.get('controllers.discovery/topics.hideCategory'));
   }.property('controllers.discovery/topics.hideCategory', 'model.isPinnedUncategorized'),
 
   hideCategory: function() {


### PR DESCRIPTION
This behaviour is not consistent any more. We can toggle "suppress uncategorized badge" in the admin page which has this description: "Don't show the badge for uncategorized topics in topic lists."

So I think the intended behaviour is "show the category", or "don't show the category". Not showing the badge on pinned topics is quite confusing when it's explicitly enabled in the admin settings.

There is also a thread an meta.discourse.org: https://meta.discourse.org/t/22245