### PR TITLE
fixing the reply-to tab z-index bug

### DIFF
--- a/app/assets/javascripts/discourse/templates/post.hbs
+++ b/app/assets/javascripts/discourse/templates/post.hbs
@@ -6,17 +6,7 @@
 
 <article {{bind-attr class=":boxed via_email" id="postElementId" data-post-id="id" data-user-id="user_id"}}>
   <div class='row'>
-    {{#if showUserReplyTab}}
-      <a href {{action "toggleReplyHistory" this target="view"}} class='reply-to-tab'>
-        {{#if loadingReplyHistory}}
-          {{i18n loading}}
-        {{else}}
-          <i class="fa fa-mail-forward"></i>
-          {{avatar reply_to_user imageSize="tiny"}}
-          <span>{{reply_to_user.username}}</span>
-        {{/if}}
-      </a>
-    {{/if}}
+
     <div class='topic-avatar'>
       <div class="contents">
         {{#unless userDeleted}}
@@ -58,6 +48,17 @@
           {{else}}
             <div class="post-info via-email" title="{{i18n post.via_email}}">{{fa-icon "envelope-o"}}</div>
           {{/if}}
+        {{/if}}
+        {{#if showUserReplyTab}}
+        <a href {{action "toggleReplyHistory" this target="view"}} class='reply-to-tab'>
+          {{#if loadingReplyHistory}}
+          {{i18n loading}}
+          {{else}}
+          <i class="fa fa-mail-forward"></i>
+          {{avatar reply_to_user imageSize="tiny"}}
+          <span>{{reply_to_user.username}}</span>
+          {{/if}}
+        </a>
         {{/if}}
         <div {{bind-attr class=":read-state read"}} title="{{i18n post.unread}}">{{fa-icon "circle"}}</div>
       </div>

--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -30,13 +30,11 @@ h1 .topic-statuses .topic-status i {
   }
 
 .reply-to-tab {
-  position: absolute;
-  right: 420px;
   z-index: 400;
-  padding: 13px 6px 5px;
-  font-size: 12px;
+  font-size: 13px;
+  float: right;
+  margin: 1px 25px 0 0;
   color: scale-color($primary, $lightness: 50%);
-
 }
 
 .via-email .reply-to-tab {


### PR DESCRIPTION
As discussed here:
https://meta.discourse.org/t/admin-menu-on-post-gets-layered-under-reply-indicator/21930

Moved the reply tab somewhere that makes more sense in the markup — removes the necessity for an absolute position, which was also causing some overlap problems when the date/edits line got really long 
