### PR TITLE
Warnings cleanup, with 3 bugfixes

### DIFF
--- a/app/assets/javascripts/discourse/controllers/static.js.es6
+++ b/app/assets/javascripts/discourse/controllers/static.js.es6
@@ -3,7 +3,10 @@ export default Em.ObjectController.extend({
 
   actions: {
     markFaqRead: function() {
-      Discourse.ajax("/users/read-faq", { method: "POST" });
+      // Anons can't get FAQ credit (where to store it in the DB?)
+      if (Discourse.User.current()) {
+        Discourse.ajax("/users/read-faq", { method: "POST" });
+      }
     }
   }
 });

--- a/app/controllers/about_controller.rb
+++ b/app/controllers/about_controller.rb
@@ -5,4 +5,7 @@ class AboutController < ApplicationController
     @about = About.new
     render_serialized(@about, AboutSerializer)
   end
+
+  def show
+  end
 end

--- a/app/controllers/admin/badges_controller.rb
+++ b/app/controllers/admin/badges_controller.rb
@@ -38,7 +38,7 @@ class Admin::BadgesController < Admin::AdminController
 
     params[:names].each_with_index do |name,index|
       id = ids[index].to_i
-      group = badge_groupings.find{|b| b.id == id} || BadgeGrouping.new()
+      group = badge_groupings.find{|b| b.id == id} || BadgeGrouping.new
       group.name = name
       group.position = index
       group.save

--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -5,7 +5,7 @@ class Admin::ReportsController < Admin::AdminController
   def show
     report_type = params[:type]
 
-    raise Discourse::NotFound.new unless report_type =~ /^[a-z0-9\_]+$/
+    raise Discourse::NotFound.new unless report_type =~ /^[a-z0-9_]+$/
 
     start_date = 1.month.ago
     start_date = Time.parse(params[:start_date]) if params[:start_date].present?

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -292,8 +292,8 @@ class Admin::UsersController < Admin::AdminController
 
     email = params[:email]
     unless user = User.find_by_email(email)
-      name = params[:name] if params[:name].present?
-      username = params[:username] if params[:username].present?
+      name = params[:name] || nil
+      username = params[:username] || nil
 
       user = User.new(email: email)
       user.password = SecureRandom.hex

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -80,7 +80,6 @@ class ApplicationController < ActionController::Base
   # If they hit the rate limiter
   rescue_from RateLimiter::LimitExceeded do |e|
 
-    time_left = ""
     if e.available_in < 1.minute.to_i
       time_left = I18n.t("rate_limiter.seconds", count: e.available_in)
     elsif e.available_in < 1.hour.to_i

--- a/app/controllers/embed_controller.rb
+++ b/app/controllers/embed_controller.rb
@@ -41,7 +41,7 @@ class EmbedController < ApplicationController
       topic_embeds = TopicEmbed.where(embed_url: urls).includes(:topic).references(:topic)
 
       topic_embeds.each do |te|
-        url = te.embed_url 
+        url = te.embed_url
         url = "#{url}#discourse-comments" unless params[:embed_url].include?(url)
         by_url[url] = I18n.t('embed.replies', count: te.topic.posts_count - 1)
       end

--- a/app/controllers/list_controller.rb
+++ b/app/controllers/list_controller.rb
@@ -115,7 +115,7 @@ class ListController < ApplicationController
       target_user = fetch_user_from_params
       guardian.ensure_can_see_private_messages!(target_user.id) unless action == :topics_by
       list = generate_list_for(action.to_s, target_user, list_opts)
-      url_prefix = "topics" unless action == :topics_by
+      url_prefix = ("topics" unless action == :topics_by) || nil
       list.more_topics_url = url_for(construct_next_url_with(list_opts, url_prefix))
       list.prev_topics_url = url_for(construct_prev_url_with(list_opts, url_prefix))
       respond(list)
@@ -134,7 +134,7 @@ class ListController < ApplicationController
 
     render 'list', formats: [:rss]
   end
-  
+
   def top(options=nil)
     options ||= {}
     period = ListController.best_period_for(current_user.try(:previous_visit_at), options[:category])
@@ -242,7 +242,7 @@ class ListController < ApplicationController
     end
 
     @category = Category.query_category(slug_or_id, parent_category_id)
-    raise Discourse::NotFound.new if !@category
+    raise Discourse::NotFound.new unless @category
 
     @description_meta = @category.description
     guardian.ensure_can_see!(@category)

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -5,7 +5,9 @@ require_dependency 'distributed_memoizer'
 class PostsController < ApplicationController
 
   # Need to be logged in for all actions here
-  before_filter :ensure_logged_in, except: [:show, :replies, :by_number, :short_link, :reply_history, :revisions, :latest_revision, :expand_embed, :markdown, :raw, :cooked]
+  before_filter :ensure_logged_in, except: [:show, :replies, :by_number,
+                    :short_link, :reply_history, :revisions, :latest_revision,
+                    :expand_embed, :markdown_id, :markdown_num, :cooked]
 
   skip_before_filter :check_xhr, only: [:markdown_id, :markdown_num, :short_link]
 
@@ -52,7 +54,7 @@ class PostsController < ApplicationController
     key = params_key(params)
     error_json = nil
 
-    if (is_api?)
+    if is_api?
       payload = DistributedMemoizer.memoize(key, 120) do
         success, json = create_post(params)
         unless success

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -24,7 +24,6 @@ class SearchController < ApplicationController
       klass = search_context[:type].classify.constantize
 
       # A user is found by username
-      context_obj = nil
       if search_context[:type] == 'user'
         context_obj = klass.find_by(username_lower: params[:search_context][:id].downcase)
       else

--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -3,7 +3,7 @@ require_dependency 'rate_limiter'
 class SessionController < ApplicationController
 
   skip_before_filter :redirect_to_login_if_required
-  skip_before_filter :check_xhr, only: ['sso', 'sso_login', 'become']
+  skip_before_filter :check_xhr, only: [:sso, :sso_login, :become]
 
   def csrf
     render json: {csrf: form_authenticity_token }
@@ -35,7 +35,7 @@ class SessionController < ApplicationController
     end
 
     sso = DiscourseSingleSignOn.parse(request.query_string)
-    if !sso.nonce_valid?
+    unless sso.nonce_valid?
       render text: I18n.t("sso.timeout_expired"), status: 500
       return
     end

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -24,7 +24,7 @@ class StaticController < ApplicationController
     @page = 'faq' if @page == 'guidelines'
 
     # Don't allow paths like ".." or "/" or anything hacky like that
-    @page.gsub!(/[^a-z0-9\_\-]/, '')
+    @page.gsub!(/[^a-z0-9_\-]/, '')
 
     if map.has_key?(@page)
       @topic = Topic.find_by_id(SiteSetting.send(map[@page][:topic_id]))

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -52,9 +52,13 @@ class TopicsController < ApplicationController
     begin
       @topic_view = TopicView.new(params[:id] || params[:topic_id], current_user, opts)
     rescue Discourse::NotFound
-      topic = Topic.find_by(slug: params[:id].downcase) if params[:id]
-      raise Discourse::NotFound unless topic
-      redirect_to_correct_topic(topic, opts[:post_number]) && return
+      if params[:id]
+        topic = Topic.find_by(slug: params[:id].downcase)
+        if topic
+          return redirect_to_correct_topic(topic, opts[:post_number])
+        end
+      end
+      raise
     end
 
     page = params[:page].to_i
@@ -143,10 +147,14 @@ class TopicsController < ApplicationController
     title, raw = params[:title], params[:raw]
     [:title, :raw].each { |key| check_length_of(key, params[key]) }
 
-    # Only suggest similar topics if the site has a minimum amount of topics present.
-    topics = Topic.similar_to(title, raw, current_user).to_a if Topic.count_exceeds_minimum?
+    if Topic.count_exceeds_minimum?
+      # Only suggest similar topics if the site has a minimum amount of topics present.
+      topics = Topic.similar_to(title, raw, current_user).to_a
 
-    render_serialized(topics, BasicTopicSerializer)
+      render_serialized(topics, BasicTopicSerializer)
+    else
+      render json: []
+    end
   end
 
   def status

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -23,9 +23,9 @@ class UploadsController < ApplicationController
   end
 
   def show
-    return render_404 if !RailsMultisite::ConnectionManagement.has_db?(params[:site])
+    return render_404 unless RailsMultisite::ConnectionManagement.has_db?(params[:site])
 
-    RailsMultisite::ConnectionManagement.with_connection(params[:site]) do |db|
+    RailsMultisite::ConnectionManagement.with_connection(params[:site]) do |_|
       return render_404 unless Discourse.store.internal?
       return render_404 if SiteSetting.prevent_anons_from_downloading_files && current_user.nil?
 

--- a/app/controllers/user_avatars_controller.rb
+++ b/app/controllers/user_avatars_controller.rb
@@ -54,6 +54,7 @@ class UserAvatarsController < ApplicationController
     version = params[:version].to_i
     return render_dot unless version > 0 && user_avatar = user.user_avatar
 
+    upload = nil
     upload = Upload.find_by(id: version) if user_avatar.contains_upload?(version)
     upload ||= user.uploaded_avatar if user.uploaded_avatar_id == version
 

--- a/app/controllers/user_badges_controller.rb
+++ b/app/controllers/user_badges_controller.rb
@@ -61,9 +61,8 @@ class UserBadgesController < ApplicationController
 
     # Get the badge from either the badge name or id specified in the params.
     def fetch_badge_from_params
-      badge = nil
-
       params.permit(:badge_name)
+
       if params[:badge_name].nil?
         params.require(:badge_id)
         badge = Badge.find_by(id: params[:badge_id], enabled: true)


### PR DESCRIPTION
Bugs fixed:
- Don't require login to view post raw.
- Don't try to submit read-guidelines credit for anonymous users.
- Properly render an empty array if too few topics to suggest similar ones, instead of passing `nil` to an array serializer. (extremely fragile code)

---

Detail:

Two files: Remove redundant parentheses from method calls.
Two files: Remove escaping of `_` in regexes.
Three times: Replace unused but necessary variables with `_`.
Three files: Remove initial values for variables that get values in every branch.
Five times: Replace simple `if !condition` with `unless condition`. (Careful judgement was used on whether it enhanced readability.)
about_controller: Line 2 removes a before_filter on the `show` method, so I explicitly define the `show` action to be empty.
users_controller: Potential uninitialized variable. Hashes give nil on not-found, so I made the optional nature explicit with a `|| nil`. Definitely cleaner.
list_controller: Uninitialized variable. Nil is what we want, so explicitly set it.
posts_controller: **Don't require login to view post raw.**
session_controller: Use symbols in `skip_before_filter` for codebase consistency.
topics_controller: Restructure the rescue to eliminate an uninitialized variable usage.
topics_controller: **Properly return an empty array** instead of relying on default behavior for an array serializer passed nil.
users_avatar_controller: Add initial nil values for `upload`.
users_controller: Change an if-statement to unless. (line 229)
users_controller: Include an else in the case statement.
users_controller: **Give a not-logged-in error** for anons submitting FAQ read credit (we don't save it, anyways.)

---

This is mostly style cleanup, but it has some legitimate bugfixes in it.
