### PR TITLE
FEATURE: add topic status namespace in RSS feed

### DIFF
--- a/app/controllers/list_controller.rb
+++ b/app/controllers/list_controller.rb
@@ -134,7 +134,7 @@ class ListController < ApplicationController
 
     render 'list', formats: [:rss]
   end
-  
+
   def top(options=nil)
     options ||= {}
     period = ListController.best_period_for(current_user.try(:previous_visit_at), options[:category])

--- a/app/views/list/list.rss.erb
+++ b/app/views/list/list.rss.erb
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+<rss version="2.0" xmlns:discourse="http://www.discourse.org/" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <% lang = SiteSetting.find_by_name('default_locale').try(:value) %>
     <% site_email = SiteSetting.find_by_name('contact_email').try(:value) %>
@@ -27,6 +27,9 @@
           ]]></description>
           <link><%= topic_url %></link>
           <pubDate><%= topic.created_at.rfc2822 %></pubDate>
+          <discourse:topicPinned><%= topic.pinned_at ? 'Yes' : 'No' %></discourse:topicPinned>
+          <discourse:topicClosed><%= topic.closed ? 'Yes' : 'No' %></discourse:topicClosed>
+          <discourse:topicArchived><%= topic.archived ? 'Yes' : 'No' %></discourse:topicArchived>
           <guid isPermaLink="false">topic-<%= topic.id %></guid>
           <source url="<%= topic_url %>.rss"><%= topic.title %></source>
         </item>


### PR DESCRIPTION
Fixes [this bug report](https://meta.discourse.org/t/option-to-remove-pinned-topics-from-rss/10700?u=techapj).

Added `discourse` [namespace in RSS feed](http://www.disobey.com/detergent/2002/extendingrss2/).

Example:

```
<discourse:topicPinned>Yes</discourse:topicPinned>
<discourse:topicClosed>Yes</discourse:topicClosed>
<discourse:topicArchived>No</discourse:topicArchived>
```
