### PR TITLE
Add nginx sample config with SSL enabled

### DIFF
--- a/config/nginx.sample.ssl.conf
+++ b/config/nginx.sample.ssl.conf
@@ -38,7 +38,7 @@ server {
   # Put your ssl cert in your main nginx config directory (/etc/nginx)
   ssl_certificate your-hostname-cert.pem;
   ssl_certificate_key your-hostname-cert.key;
-  ssl_protocols SSLv3 TLSv1 TLSv1.1 TLSv1.2;
+  ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
   ssl_ciphers HIGH:!aNULL:!MD5;
 
   gzip on;

--- a/config/nginx.sample.ssl.conf
+++ b/config/nginx.sample.ssl.conf
@@ -1,0 +1,172 @@
+# Additional MIME types that you'd like nginx to handle go in here
+types {
+    text/csv csv;
+}
+
+upstream discourse {
+  server unix:/var/www/discourse/tmp/sockets/thin.0.sock;
+  server unix:/var/www/discourse/tmp/sockets/thin.1.sock;
+  server unix:/var/www/discourse/tmp/sockets/thin.2.sock;
+  server unix:/var/www/discourse/tmp/sockets/thin.3.sock;
+}
+
+proxy_cache_path /var/nginx/cache keys_zone=one:10m max_size=200m;
+
+# If you are going to use Puma, use these:
+#
+# upstream discourse {
+#   server unix:/var/www/discourse/tmp/sockets/puma.sock;
+# }
+
+
+# attempt to preserve the proto, must be in http context
+map $http_x_forwarded_proto $thescheme {
+  default $scheme;
+  https https;
+}
+
+server {
+   listen 80;
+   server_name enter.your.web.hostname.here;
+   rewrite ^/(.*) https://enter.your.web.hostname.here/$1 permanent;
+}
+
+server {
+
+  listen 443 ssl;
+  server_name enter.your.web.hostname.here;
+  # Put your ssl cert in your main nginx config directory (/etc/nginx)
+  ssl_certificate your-hostname-cert.pem;
+  ssl_certificate_key your-hostname-cert.key;
+  ssl_protocols SSLv3 TLSv1 TLSv1.1 TLSv1.2;
+  ssl_ciphers HIGH:!aNULL:!MD5;
+
+  gzip on;
+  gzip_vary on;
+  gzip_min_length 1000;
+  gzip_comp_level 5;
+  gzip_types application/json text/css application/x-javascript application/javascript;
+
+  sendfile on;
+
+  keepalive_timeout 65;
+
+  # maximum file upload size (keep up to date when changing the corresponding site setting)
+  client_max_body_size 3m;
+
+  # path to discourse's public directory
+  set $public /var/www/discourse/public;
+
+  # Prevent Internet Explorer 10 "compatibility mode", which breaks Discourse.
+  # If other subdomains under your domain are supposed to use Internet Explorer Compatibility mode,
+  # it may be used for this one too, unless you explicitly tell IE not to use it.  Alternatively,
+  # some people have reported having compatibility mode "stuck" on for some reason.
+  # (This will also prevent compatibility mode in IE 8 and 9, but those browsers aren't supported anyway.
+  add_header X-UA-Compatible "IE=edge";
+
+  # without weak etags we get zero benefit from etags on dynamically compressed content
+  # further more etags are based on the file in nginx not sha of data
+  # use dates, it solves the problem fine even cross server
+  etag off;
+
+  location / {
+    root $public;
+    add_header ETag "";
+
+    location ~* \.(eot|ttf|woff|ico)$ {
+      expires 1y;
+      add_header Cache-Control public;
+      add_header Access-Control-Allow-Origin *;
+     }
+
+    location ~ ^/assets/ {
+      expires 1y;
+      # asset pipeline enables this
+      gzip_static on;
+      add_header Cache-Control public;
+      break;
+    }
+
+    location ~ ^/uploads/ {
+
+      # NOTE: it is really annoying that we can't just define headers
+      # at the top level and inherit.
+      #
+      # proxy_set_header DOES NOT inherit, by design, we must repeat it,
+      # otherwise headers are not set correctly
+
+      proxy_set_header Host $http_host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $thescheme;
+      proxy_set_header X-Sendfile-Type X-Accel-Redirect;
+      proxy_set_header X-Accel-Mapping $public/=/downloads/;
+      expires 1y;
+      add_header Cache-Control public;
+
+      ## optional upload anti-hotlinking rules
+      #valid_referers none blocked mysite.com *.mysite.com;
+      #if ($invalid_referer) { return 403; }
+
+      # custom CSS
+      location ~ /stylesheet-cache/ {
+          try_files $uri =404;
+      }
+      # this allows us to bypass rails
+      location ~* \.(gif|png|jpg|jpeg|bmp|tif|tiff)$ {
+          try_files $uri =404;
+      }
+      # thumbnails & optimized images
+      location ~ /_optimized/ {
+          try_files $uri =404;
+      }
+
+      proxy_pass http://discourse;
+      break;
+    }
+
+    location ~ ^/admin/backups/ {
+      proxy_set_header Host $http_host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $thescheme;
+      proxy_set_header X-Sendfile-Type X-Accel-Redirect;
+      proxy_set_header X-Accel-Mapping $public/=/downloads/;
+      proxy_pass http://discourse;
+      break;
+    }
+
+    # This big block is needed so we can selectively enable
+    # acceleration for backups and avatars
+    # see note about repetition above
+    location ~ ^/(letter_avatar|user_avatar) {
+      proxy_set_header Host $http_host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $thescheme;
+      # note x-accel-redirect can not be used with proxy_cache
+      proxy_cache one;
+      proxy_cache_valid any 1m;
+      proxy_cache_valid 200 301 302 7d;
+      proxy_pass http://discourse;
+      break;
+    }
+
+    # this means every file in public is tried first
+    try_files $uri @discourse;
+  }
+
+  location /downloads/ {
+    internal;
+    alias $public/;
+  }
+
+  location @discourse {
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $thescheme;
+    proxy_pass http://discourse;
+  }
+
+}


### PR DESCRIPTION
There is no good SSL setup example for nginx users, so this
adds a sample config that works for https. This follows the
patterns and defaults of the existing nginx.sample.conf.