### PR TITLE
fixing reply-tab bug and user profile background adjustment

### DIFF
--- a/app/assets/javascripts/discourse/templates/user/user.hbs
+++ b/app/assets/javascripts/discourse/templates/user/user.hbs
@@ -5,7 +5,7 @@
 
 <div class="container">
   <section class='user-main'>
-    <section {{bind-attr class="collapsedInfo :about profileBackground:has-background:no-background"}}>
+    <section {{bind-attr class="collapsedInfo :about profileBackground:has-background:no-background"}}  {{bind-attr style="profileBackground"}}>
     <div class='staff-counters'>
       {{#if number_of_flags_given}}
         <div><span class="helpful-flags">{{number_of_flags_given}}</span>&nbsp;{{i18n user.staff_counters.flags_given}}</div>
@@ -31,7 +31,7 @@
         <div><span class="warnings-received">{{number_of_warnings}}</span>&nbsp;{{i18n user.staff_counters.warnings_received}}</div>
       {{/if}}
     </div>
-      <div class='profile-image' {{bind-attr style="profileBackground"}}></div>
+      <div class='profile-image'></div>
       <div class='details'>
         <div class='primary'>
           {{bound-avatar model "huge"}}

--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -37,10 +37,6 @@ h1 .topic-statuses .topic-status i {
   color: scale-color($primary, $lightness: 50%);
 }
 
-.via-email .reply-to-tab {
-  padding: 13px 15px 5px;
-}
-
 .gutter {
   .reply-new {
     .discourse-no-touch & {

--- a/app/assets/stylesheets/desktop/user.scss
+++ b/app/assets/stylesheets/desktop/user.scss
@@ -182,8 +182,8 @@
   }
 
   .about {
-    background-size: 1110px 250px;
     background-position: center center;
+    background-size: cover;
     width: 100%;
     margin-bottom: 10px;
     overflow: hidden;


### PR DESCRIPTION
fixing this bug when the email icon appears:

![screenshot 2014-11-26 09 48 31](https://cloud.githubusercontent.com/assets/1681963/5204060/150c42e6-755a-11e4-88e0-4f9929c66906.png)

and allowing background images to scale to cover longer profiles... as discussed here:

https://forums.theanimenetwork.com/t/welcome-to-the-new-forums/7632/178
