### PR TITLE
Have log_out method return json

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -66,10 +66,14 @@ class Admin::UsersController < Admin::AdminController
   end
 
   def log_out
-    @user.auth_token = nil
-    @user.save!
-    MessageBus.publish "/logout", @user.id, user_ids: [@user.id]
-    render nothing: true
+    if @user
+      @user.auth_token = nil
+      @user.save!
+      MessageBus.publish "/logout", @user.id, user_ids: [@user.id]
+      render json: success_json
+    else
+      render json: {error: I18n.t('admin_js.admin.users.id_not_found')}, status: 404
+    end
   end
 
   def refresh_browsers

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1887,6 +1887,7 @@ en:
         create: 'Add Admin User'
         last_emailed: "Last Emailed"
         not_found: "Sorry, that username doesn't exist in our system."
+        id_not_found: "Sorry, that user id doesn't exist in our system."
         active: "Active"
         show_emails: "Show Emails"
         nav:

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -360,6 +360,29 @@ describe Admin::UsersController do
       end
     end
 
+    context 'log_out' do
+      before do
+        @reg_user = Fabricate(:user)
+      end
+
+      it 'returns JSON' do
+        xhr :put, :log_out, user_id: @reg_user.id
+        ::JSON.parse(response.body).should be_present
+      end
+
+      it "returns success" do
+        xhr :put, :log_out, user_id: @reg_user.id
+        response.should be_success
+        json = ::JSON.parse(response.body)
+        json['success'].should == "OK"
+      end
+
+      it "returns 404 when user_id does not exist" do
+        xhr :put, :log_out, user_id: 123123
+        response.should_not be_success
+      end
+    end
+
     context 'block' do
       before do
         @reg_user = Fabricate(:user)


### PR DESCRIPTION
This commit helps improve the discourse_api experience so that we can
check the json response if it was a success or not. Please see the
discourse_api pull-request #50 for more info:

https://github.com/discourse/discourse_api/pull/50

I'll hopefully have time this weekend to submit another pull request to address
the 500 error for an invalid user_id in log_out.
