### PR TITLE
New Private Message button for user topics

### DIFF
--- a/app/assets/javascripts/discourse/controllers/user-topics-list.js.es6
+++ b/app/assets/javascripts/discourse/controllers/user-topics-list.js.es6
@@ -1,7 +1,7 @@
 import ObjectController from 'discourse/controllers/object';
 
 // Lists of topics on a user's page.
-export default ObjectController.extend({
+export default ObjectController.extend(Discourse.HasCurrentUser, {
   needs: ["application"],
   hideCategory: false,
   showParticipants: false,

--- a/app/assets/javascripts/discourse/routes/user.js.es6
+++ b/app/assets/javascripts/discourse/routes/user.js.es6
@@ -15,11 +15,11 @@ export default Discourse.Route.extend({
       Discourse.logout();
     },
 
-    composePrivateMessage: function() {
-      var user = this.modelFor('user');
+    composePrivateMessage: function(user) {
+      var recipient = user ? user.username : '';
       return this.controllerFor('composer').open({
         action: Discourse.Composer.PRIVATE_MESSAGE,
-        usernames: user.get('username'),
+        usernames: recipient,
         archetypeId: 'private_message',
         draftKey: 'new_private_message'
       });

--- a/app/assets/javascripts/discourse/templates/list/user_topics_list.hbs
+++ b/app/assets/javascripts/discourse/templates/list/user_topics_list.hbs
@@ -1,3 +1,9 @@
+{{#if currentUser.can_send_private_messages}}
+  <div class="clearfix">
+    <a class='btn btn-primary pull-right new-private-message' {{action "composePrivateMessage"}}>{{fa-icon "envelope"}}{{i18n user.new_private_message}}</a>
+  </div>
+{{/if}}
+
 {{basic-topic-list topicList=model
                    hideCategory=hideCategory
                    showParticipants=showParticipants

--- a/app/assets/stylesheets/common/base/user.scss
+++ b/app/assets/stylesheets/common/base/user.scss
@@ -73,3 +73,6 @@
   }
 }
 
+.new-private-message {
+  margin-bottom: 15px;
+}

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -45,6 +45,7 @@ class UserSerializer < BasicUserSerializer
              :can_edit_email,
              :can_edit_name,
              :stats,
+             :can_send_private_messages,
              :can_send_private_message_to_user,
              :bio_excerpt,
              :trust_level,
@@ -176,6 +177,12 @@ class UserSerializer < BasicUserSerializer
 
   def stats
     UserAction.stats(object.id, scope)
+  end
+
+  # Needed because 'send_private_message_to_user' will always return false
+  # when the current user is being serialized
+  def can_send_private_messages
+    scope.can_send_private_message?(Discourse.system_user)
   end
 
   def can_send_private_message_to_user

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -293,6 +293,7 @@ en:
       mute: "Mute"
       edit: "Edit Preferences"
       download_archive: "download archive of my posts"
+      new_private_message: "New Private Message"
       private_message: "Private Message"
       private_messages: "Messages"
       activity_stream: "Activity"


### PR DESCRIPTION
This adds a new private message button to the user topics list, which opens up an empty send private message form.

To wit:

Before
![screenshot from 2014-11-30 15 13 29](https://cloud.githubusercontent.com/assets/750477/5236555/9ce53654-78a3-11e4-8b3d-7429d826b6aa.png)

After
![screenshot from 2014-11-30 15 14 18](https://cloud.githubusercontent.com/assets/750477/5236556/9ce5e130-78a3-11e4-92d4-07c489300951.png)

Could use some guidance around where the front-end tests for this stuff should go; I didn't find a whole lot of coverage under test/controllers, for example.
