### PR TITLE
FIX: if full user name is not provided, username should be present in em...

### DIFF
--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -127,7 +127,7 @@ class UserNotifications < ActionMailer::Base
       title: post.topic.title,
       post: post,
       username: post.user.username,
-      from_alias: SiteSetting.enable_email_names ? post.user.name : post.user.username,
+      from_alias: (SiteSetting.enable_email_names && !post.user.name.empty?) ? post.user.name : post.user.username,
       allow_reply_by_email: true,
       use_site_subject: true,
       add_re_to_subject: true,
@@ -173,7 +173,7 @@ class UserNotifications < ActionMailer::Base
 
     user_name = @notification.data_hash[:original_username]
     if @post && SiteSetting.enable_email_names
-      user_name = User.find_by(id: @post.user_id).name
+      user_name = User.find_by(id: @post.user_id).name if !User.find_by(id: @post.user_id).name.empty?
     end
 
     notification_type = opts[:notification_type] || Notification.types[@notification.notification_type].to_s


### PR DESCRIPTION
...ail From header

[Bug report here](https://meta.discourse.org/t/email-from-address-missing-name-part/22776?u=techapj).
