### PR TITLE
Minor additions to script/bench.rb

### DIFF
--- a/script/bench.rb
+++ b/script/bench.rb
@@ -2,6 +2,7 @@ require "socket"
 require "csv"
 require "yaml"
 require "optparse"
+require "fileutils"
 
 @include_env = false
 @result_file = nil
@@ -170,6 +171,7 @@ begin
 
   pid = if @unicorn
           ENV['UNICORN_PORT'] = @port.to_s
+          FileUtils.mkdir_p(File.join('tmp', 'pids'))
           spawn("bundle exec unicorn -c config/unicorn.conf.rb")
         else
           spawn("bundle exec thin start -p #{@port}")


### PR DESCRIPTION
Hi Sam,

Noticed that a lot of the benchmark tooling is Linux specific at the moment. Is there any interest in OS X support for memstats.rb on your end? We're using discourse as a sandbox for dogfooding a GC tool for automatic tuning of GC params:

Only run this script against an empty DB
== Reccommendations ==
RSS: 151632
== Configuration for memory consumption
RUBY_GC_HEAP_INIT_SLOTS=311376 RUBY_GC_HEAP_FREE_SLOTS=6227 RUBY_GC_HEAP_GROWTH_FACTOR=0.07 RUBY_GC_HEAP_GROWTH_MAX_SLOTS=6227 RUBY_GC_MALLOC_LIMIT=2000000 RUBY_GC_OLDMALLOC_LIMIT=2000000 RUBY_GC_MALLOC_LIMIT_MAX=4000000 RUBY_GC_OLDMALLOC_LIMIT_MAX=4000000 RUBY_GC_MALLOC_LIMIT_GROWTH_FACTOR=0.11 RUBY_GC_OLDMALLOC_LIMIT_GROWTH_FACTOR=0.11 RUBY_GC_HEAP_OLDOBJECT_LIMIT_FACTOR=0.11
== Configuration for speed
RUBY_GC_HEAP_INIT_SLOTS=311376 RUBY_GC_HEAP_FREE_SLOTS=186825 RUBY_GC_HEAP_GROWTH_FACTOR=1.2 RUBY_GC_HEAP_GROWTH_MAX_SLOTS=124550 RUBY_GC_MALLOC_LIMIT=64000000 RUBY_GC_OLDMALLOC_LIMIT=64000000 RUBY_GC_MALLOC_LIMIT_MAX=128000000 RUBY_GC_OLDMALLOC_LIMIT_MAX=128000000 RUBY_GC_MALLOC_LIMIT_GROWTH_FACTOR=1.2 RUBY_GC_OLDMALLOC_LIMIT_GROWTH_FACTOR=1.2 RUBY_GC_HEAP_OLDOBJECT_LIMIT_FACTOR=0
Getting api key

I'll sync with you shortly about that, but just wanted to understand at first if there's an interest in contributions and platform support to discourse benchmark tools as well?

Best,
- Lourens
