### PR TITLE
FIX: auto response email replies should not be accepted

### DIFF
--- a/lib/email/receiver.rb
+++ b/lib/email/receiver.rb
@@ -41,6 +41,7 @@ module Email
       end
 
       raise BadDestinationAddress if dest_info[:type] == :invalid
+      raise TopicNotFoundError if message.header.to_s =~ /auto-generated/ || message.header.to_s =~ /auto-replied/
 
       # TODO get to a state where we can remove this
       @message = message

--- a/spec/components/email/receiver_spec.rb
+++ b/spec/components/email/receiver_spec.rb
@@ -346,6 +346,14 @@ This is a link http://example.com"
       end
     end
 
+    describe "auto response email replies should not be accepted" do
+      let!(:reply_key) { '636ca428858779856c226bb145ef4fad' }
+      let!(:email_raw) { fixture_file("emails/auto_reply.eml") }
+      it "raises a TopicNotFoundError" do
+        expect { receiver.process }.to raise_error(Email::Receiver::TopicNotFoundError)
+      end
+    end
+
   end
 
   describe "posting reply to a closed topic" do

--- a/spec/fixtures/emails/auto_reply.eml
+++ b/spec/fixtures/emails/auto_reply.eml
@@ -1,0 +1,21 @@
+Return-Path: <jake@adventuretime.ooo>
+Received: from iceking.adventuretime.ooo ([unix socket]) by iceking (Cyrus v2.2.13-Debian-2.2.13-19+squeeze3) with LMTPA; Thu, 13 Jun 2013 17:03:50 -0400
+Received: from mail-ie0-x234.google.com (mail-ie0-x234.google.com [IPv6:2607:f8b0:4001:c03::234]) by iceking.adventuretime.ooo (8.14.3/8.14.3/Debian-9.4) with ESMTP id r5DL3nFJ016967 (version=TLSv1/SSLv3 cipher=RC4-SHA bits=128 verify=NOT) for <reply+59d8df8370b7e95c5a49fbf86aeb2c93@discourse.example.com>; Thu, 13 Jun 2013 17:03:50 -0400
+Received: by mail-ie0-f180.google.com with SMTP id f4so21977375iea.25 for <reply+59d8df8370b7e95c5a49fbf86aeb2c93@discourse.example.com>; Thu, 13 Jun 2013 14:03:48 -0700
+Received: by 10.0.0.1 with HTTP; Thu, 13 Jun 2013 14:03:48 -0700
+Date: Thu, 13 Jun 2013 17:03:48 -0400
+From: Jake the Dog <jake@adventuretime.ooo>
+To: reply+636ca428858779856c226bb145ef4fad@appmail.adventuretime.ooo
+Message-ID: <CADkmRc+rNGAGGbV2iE5p918UVy4UyJqVcXRO2=otppgzduJSg@mail.gmail.com>
+Subject: re: [Discourse Meta] eviltrout posted in 'Adventure Time Sux'
+Mime-Version: 1.0
+Content-Type: text/plain;
+ charset=ISO-8859-1
+Content-Transfer-Encoding: 7bit
+Auto-Submitted: auto-generated
+X-Sieve: CMU Sieve 2.2
+X-Received: by 10.0.0.1 with SMTP id n7mr11234144ipb.85.1371157428600; Thu,
+ 13 Jun 2013 14:03:48 -0700 (PDT)
+X-Scanned-By: MIMEDefang 2.69 on IPv6:2001:470:1d:165::1
+
+Test reply to Discourse email digest


### PR DESCRIPTION
[Fixes bug reported here](https://meta.discourse.org/t/auto-response-email-replies-to-digests-are-processed-as-new-topic/22564?u=techapj).

---

[more info regarding `Auto-Submitted Header` here](http://www.iana.org/assignments/auto-submitted-keywords/auto-submitted-keywords.xhtml).
