### PR TITLE
fixing loading spinner alignment and striping

### DIFF
--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -201,7 +201,7 @@ body {
 }
 
 .spinner {
-  margin: 30px auto 0 auto;
+  margin: 20px auto 20px auto;
   position: relative;
   -webkit-animation: rotate-forever 1s infinite linear;
   animation: rotate-forever 1s infinite linear;

--- a/app/assets/stylesheets/desktop/topic-list.scss
+++ b/app/assets/stylesheets/desktop/topic-list.scss
@@ -61,10 +61,10 @@
   }
 
   > tbody > tr {
-    &:nth-child(even) {
+    &:nth-child(odd) {
         background-color: darken($secondary, 3%);
     }
-    &:nth-child(odd) {
+    &:nth-child(even) {
         background-color: $secondary;
     }
     &.highlighted {

--- a/app/assets/stylesheets/mobile/topic-list.scss
+++ b/app/assets/stylesheets/mobile/topic-list.scss
@@ -30,10 +30,10 @@
 .topic-list {
 
   > tbody > tr {
-    &:nth-child(odd) {
+    &:nth-child(even) {
       background-color: darken($secondary, 3%);
       }
-    &:nth-child(even) {
+    &:nth-child(odd) {
       background-color: $secondary;
       }
     &.highlighted {


### PR DESCRIPTION
loading spinner didn't have any margin below it when scrolling back up a topic with a bunch of posts... 

Fixed topic list striping order change caused by the removal of metamorphs (should start with grey, not white)

:trumpet::snake:
