### PR TITLE
Facebook auth without an email should allow user to enter email

### DIFF
--- a/lib/auth/facebook_authenticator.rb
+++ b/lib/auth/facebook_authenticator.rb
@@ -12,7 +12,7 @@ class Auth::FacebookAuthenticator < Auth::Authenticator
     facebook_hash = session_info[:facebook]
 
     result.email = email = session_info[:email]
-    result.email_valid = true
+    result.email_valid = !email.blank?
     result.name = facebook_hash[:name]
 
     result.extra_data = facebook_hash


### PR DESCRIPTION
In some cases Facebook doesn't send back a user's email. In this
case, allow the user to enter their email address.

See
https://meta.discourse.org/t/facebook-initial-login-create-account-dialog-leaves-email-field-blank/13815/15
