### PR TITLE
Have activate user return json

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -198,7 +198,7 @@ class Admin::UsersController < Admin::AdminController
   def activate
     guardian.ensure_can_activate!(@user)
     @user.activate
-    render nothing: true
+    render json: success_json
   end
 
   def deactivate

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -360,14 +360,22 @@ describe Admin::UsersController do
       end
     end
 
+    context 'activate' do
+      before do
+        @reg_user = Fabricate(:inactive_user)
+      end
+
+      it "returns success" do
+        xhr :put, :activate, user_id: @reg_user.id
+        response.should be_success
+        json = ::JSON.parse(response.body)
+        json['success'].should == "OK"
+      end
+    end
+
     context 'log_out' do
       before do
         @reg_user = Fabricate(:user)
-      end
-
-      it 'returns JSON' do
-        xhr :put, :log_out, user_id: @reg_user.id
-        ::JSON.parse(response.body).should be_present
       end
 
       it "returns success" do


### PR DESCRIPTION
- Change activate user from admin controller to return json
- Test that it returns json
- Remove unnessary test from log_out spec

This commit was created so that when you activate a user through the api
it returns a json response.
