### PR TITLE
[bug fix] Use with_deleted when looking up soft deleted topics for recovery

### DIFF
--- a/lib/post_destroyer.rb
+++ b/lib/post_destroyer.rb
@@ -54,8 +54,9 @@ class PostDestroyer
     elsif @user.staff? || @user.id == @post.user_id
       user_recovered
     end
-    @post.topic.recover! if @post.post_number == 1
-    @post.topic.update_statistics
+    topic = Topic.with_deleted.find @post.topic_id
+    topic.recover! if @post.post_number == 1
+    topic.update_statistics
   end
 
   def staff_recovered


### PR DESCRIPTION
When recovering a post, at times the topic related to the post still returns nil.  I'm not sure if this is bc the reference to the post that PostDestroyer stores needs to be reloaded first, but using the with_deleted method to lookup the topic works well.

This was a bug we ran into when working on Akismet plugin.  
