### PR TITLE
Update username should return a json response

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -91,7 +91,10 @@ class UsersController < ApplicationController
     result = user.change_username(params[:new_username])
     raise Discourse::InvalidParameters.new(:new_username) unless result
 
-    render nothing: true
+    render json: {
+      id: user.id,
+      username: user.username
+    }
   end
 
   def check_emails

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -636,6 +636,11 @@ describe UsersController do
         response.should be_success
       end
 
+      it 'should return a JSON response with the updated username' do
+        xhr :put, :username, username: user.username, new_username: new_username
+        ::JSON.parse(response.body)['username'].should == new_username
+      end
+
     end
   end
 


### PR DESCRIPTION
- Have update username return json response that contains the updated
  username and id. I figured this would be better than just return "OK".
- Add test to verify that the new username is returned.

This commit is also for fixing a [bad test](https://github.com/discourse/discourse_api/blob/master/spec/discourse_api/api/users_spec.rb#L87) in the discourse_api that is checking for a json response body but there isn't one.
