### PR TITLE
Remove group name validation case sensitivity

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -10,7 +10,7 @@ class Group < ActiveRecord::Base
   after_save :destroy_deletions
 
   validate :name_format_validator
-  validates_uniqueness_of :name
+  validates_uniqueness_of :name, case_sensitive: false
 
   AUTO_GROUPS = {
     :everyone => 0,

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -54,7 +54,7 @@ en:
     messages:
       too_long_validation: "is limited to %{max} characters; you entered %{length}."
       invalid_boolean: "Invalid boolean."
-      taken: "has already been taken"
+      taken: "has already been taken. (group names are case insensitive)"
     embed:
       load_from_remote: "There was an error loading that post."
 

--- a/db/migrate/20141216112341_resolve_duplicate_group_names.rb
+++ b/db/migrate/20141216112341_resolve_duplicate_group_names.rb
@@ -1,0 +1,23 @@
+class ResolveDuplicateGroupNames < ActiveRecord::Migration
+
+  def up
+    results = Group.exec_sql 'SELECT id FROM groups
+                              WHERE name ILIKE
+                               (SELECT lower(name)
+                                FROM groups
+                                GROUP BY lower(name)
+                                HAVING count(*) > 1);'
+
+    groups  = Group.where id: results.map { |r| r['id'] }
+    groups.group_by { |g| g.name.downcase }.each do |key, value|
+      value.each_with_index do |dup, index|
+        dup.update! name: "#{dup.name[0..18]}_#{index+1}" if index > 0
+      end
+    end
+  end
+
+  def down
+    # does not reverse changes
+  end
+
+end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -27,6 +27,12 @@ describe Group do
       group.name = "this is_a_name"
       group.valid?.should == false
     end
+
+    it "is invalid for case-insensitive existing names" do
+      build(:group, name: 'this_is_a_name').save
+      group.name = 'This_Is_A_Name'
+      group.valid?.should == false
+    end
   end
 
   def real_admins


### PR DESCRIPTION
For issue mentioned [here](https://meta.discourse.org/t/group-names-are-case-insensitive-can-be-duplicated-typed-wrong-in-invite-csv/23002/3)
