### PR TITLE
setting static base font size

### DIFF
--- a/app/assets/stylesheets/common/foundation/variables.scss
+++ b/app/assets/stylesheets/common/foundation/variables.scss
@@ -22,8 +22,8 @@ $github: #6d6d6d !default;
 // Fonts
 // --------------------------------------------------
 
-$base-font-size: 0.875em !default; //14px base
-$base-line-height: 1.357em !default; 
+$base-font-size: 14px !default;
+$base-line-height: 19px !default; 
 $base-font-family: Helvetica, Arial, sans-serif !default;
 
 /* These files don't actually exist. They're injected by DiscourseSassImporter. */


### PR DESCRIPTION
Set a static base font size — otherwise if a browser has a different default font-size things will be sized differently 
