### PR TITLE
Fixed calculation of user-card position.

### DIFF
--- a/app/assets/javascripts/discourse/views/user-card.js.es6
+++ b/app/assets/javascripts/discourse/views/user-card.js.es6
@@ -86,7 +86,7 @@ export default Discourse.View.extend(CleansUp, {
             position.top += target.height() + 8;
           }
 
-          position.top -= $('#main-outlet').offset().top;
+          position.top -= $('#main').offset().top;
           self.$().css(position);
         }
       }


### PR DESCRIPTION
User-card is set to position:absolute. The original calculation is done based on #main-outlet offset but the actual position is absolute wrt #main (#main is the first element going up the heirarchy with position != static). This should fix the last few subset of alignment issues with the user-card.
