### PR TITLE
Added absolute dates to user list serializer

### DIFF
--- a/app/serializers/admin_user_list_serializer.rb
+++ b/app/serializers/admin_user_list_serializer.rb
@@ -4,6 +4,9 @@ class AdminUserListSerializer < BasicUserSerializer
              :active,
              :admin,
              :moderator,
+             :last_seen_at,
+             :last_emailed_at,
+             :created_at,
              :last_seen_age,
              :last_emailed_age,
              :created_at_age,
@@ -43,10 +46,20 @@ class AdminUserListSerializer < BasicUserSerializer
   def can_impersonate
     scope.can_impersonate?(object)
   end
+  
+  def last_emailed_at
+    return nil if object.last_emailed_at.blank?
+    object.last_emailed_at
+  end
 
   def last_emailed_age
     return nil if object.last_emailed_at.blank?
     AgeWords.age_words(Time.now - object.last_emailed_at)
+  end
+  
+  def last_seen_at
+    return nil if object.last_seen_at.blank?
+    object.last_seen_at
   end
 
   def last_seen_age
@@ -57,6 +70,10 @@ class AdminUserListSerializer < BasicUserSerializer
   def time_read
     return nil if object.user_stat.time_read.blank?
     AgeWords.age_words(object.user_stat.time_read)
+  end
+  
+  def created_at
+    object.created_at
   end
 
   def created_at_age


### PR DESCRIPTION
Added fields last_seen_at, last_emailed_at, and created_at to the admin user list serializer, to allow client applications to use those dates without having to parse the age string. This keeps it up to the client / UI to decide how a date should be rendered.

Referred to at: https://meta.discourse.org/t/api-returns-relative-times-instead-of-absolute-time-values
