### PR TITLE
support setting category slug

### DIFF
--- a/app/assets/javascripts/discourse/models/category.js
+++ b/app/assets/javascripts/discourse/models/category.js
@@ -58,6 +58,7 @@ Discourse.Category = Discourse.Model.extend({
     return Discourse.ajax(url, {
       data: {
         name: this.get('name'),
+        slug: this.get('slug'),
         color: this.get('color'),
         text_color: this.get('text_color'),
         secure: this.get('secure'),

--- a/app/assets/javascripts/discourse/templates/modal/edit-category-general.hbs
+++ b/app/assets/javascripts/discourse/templates/modal/edit-category-general.hbs
@@ -4,6 +4,11 @@
     {{text-field value=name placeholderKey="category.name_placeholder" maxlength="50"}}
   </section>
 
+  <section class='field'>
+    <label>{{i18n 'category.slug'}}</label>
+    {{text-field value=slug placeholderKey="category.slug_placeholder" maxlength="255"}}
+  </section>
+
   {{#if canSelectParentCategory}}
     <section class='field'>
       {{#if subCategories}}

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -95,6 +95,18 @@ class CategoriesController < ApplicationController
     end
   end
 
+  def update_slug
+    @category = Category.find(params[:category_id].to_i)
+    guardian.ensure_can_edit!(@category)
+    @category.slug = params[:slug].to_s
+
+    if @category.save
+      render json: success_json
+    else
+      render_json_error(@category)
+    end
+  end
+
   def set_notifications
     category_id = params[:category_id].to_i
     notification_level = params[:notification_level].to_i
@@ -129,6 +141,7 @@ class CategoriesController < ApplicationController
         end
 
         params.permit(*required_param_keys,
+                        :slug,
                         :position,
                         :email_in,
                         :email_in_allow_strangers,

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -197,18 +197,20 @@ SQL
   end
 
   def ensure_slug
-    if name.present?
-      self.name.strip!
-      self.slug = Slug.for(name)
+    return unless name.present?
 
-      return if self.slug.blank?
+    self.name.strip!
 
-      # If a category with that slug already exists, set the slug to nil so the category can be found
-      # another way.
-      category = Category.where(slug: self.slug, parent_category_id: parent_category_id)
-      category = category.where("id != ?", id) if id.present?
-      self.slug = '' if category.exists?
-    end
+    # Use the optional slug params. If not provided, use default generator.
+    self.slug = Slug.for(slug) unless self.slug.blank?
+    self.slug = Slug.for(name) if self.slug.blank?
+    return if self.slug.blank?
+
+    # If a category with that slug already exists, set the slug to nil so the category can be found
+    # another way.
+    category = Category.where(slug: self.slug, parent_category_id: parent_category_id)
+    category = category.where("id != ?", id) if id.present?
+    self.slug = '' if category.exists?
   end
 
   def slug_for_url

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1274,6 +1274,8 @@ en:
       delete: 'Delete Category'
       create: 'New Category'
       save: 'Save Category'
+      slug: 'Category Slug'
+      slug_placeholder: '(Optional) dashed-words for url'
       creation_error: There has been an error during the creation of the category.
       save_error: There was an error saving the category.
       name: "Category Name"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -333,6 +333,7 @@ Discourse::Application.routes.draw do
   post "category/uploads" => "categories#upload"
   post "category/:category_id/move" => "categories#move"
   post "category/:category_id/notifications" => "categories#set_notifications"
+  put "category/:category_id/slug" => "categories#update_slug"
 
   get "c/:id/show" => "categories#show"
   get "c/:category.rss" => "list#category_feed", format: :rss

--- a/spec/controllers/categories_controller_spec.rb
+++ b/spec/controllers/categories_controller_spec.rb
@@ -202,4 +202,46 @@ describe CategoriesController do
 
   end
 
+  describe "update_slug" do
+    it "requires the user to be logged in" do
+      lambda { xhr :put, :update_slug, category_id: 'category'}.should raise_error(Discourse::NotLoggedIn)
+    end
+
+    describe "logged in" do
+      let(:valid_attrs) { {id: @category.id, slug: "fff"} }
+
+      before do
+        @user = log_in(:admin)
+        @category = Fabricate(:diff_category, user: @user)
+      end
+
+      it "accepts blank but generate default" do
+        xhr :put, :update_slug, category_id: @category.id, slug: nil
+        response.should be_success
+        category = Category.find(@category.id)
+        category.slug.should == "different-category"
+      end
+
+      it "accepts valid custom slug" do
+        xhr :put, :update_slug, category_id: @category.id, slug: 'valid-slug'
+        response.should be_success
+        category = Category.find(@category.id)
+        category.slug.should == "valid-slug"
+      end
+
+      it "accepts not well defined custom slug" do
+        xhr :put, :update_slug, category_id: @category.id, slug: ' valid slug'
+        response.should be_success
+        category = Category.find(@category.id)
+        category.slug.should == "valid-slug"
+      end
+
+      it "accepts invliad custom slug but generate default" do
+        xhr :put, :update_slug, category_id: @category.id, slug: '  '
+        response.should be_success
+        category = Category.find(@category.id)
+        category.slug.should == "different-category"
+      end
+    end
+  end
 end

--- a/spec/fabricators/category_fabricator.rb
+++ b/spec/fabricators/category_fabricator.rb
@@ -7,3 +7,7 @@ Fabricator(:diff_category, from: :category) do
   name "Different Category"
   user
 end
+
+Fabricator(:slug_diff_category, from: :diff_category) do
+  slug "custom-slug"
+end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -192,6 +192,14 @@ describe Category do
     end
   end
 
+  describe 'customized slug' do
+    let(:category) { Fabricate(:slug_diff_category) }
+
+    it 'can be created' do
+      category.slug_for_url.should == "custom-slug"
+    end
+  end
+
   describe 'description_text' do
     it 'correctly generates text description as needed' do
       c = Category.new


### PR DESCRIPTION
Related: https://meta.discourse.org/t/custom-value-for-category-slug/22812
1. slug param exists and valid: use the provided
2. slug param exists but invalid: use the default
3. slug param not exists: use the default

And also a slug api.
