### PR TITLE
Update eventmachine to 1.0.4.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,7 +80,7 @@ GEM
     ember-source (1.9.0.beta.4)
       handlebars-source (~> 2.0)
     erubis (2.7.0)
-    eventmachine (1.0.3)
+    eventmachine (1.0.4)
     excon (0.39.6)
     execjs (2.2.2)
     exifr (1.1.3)


### PR DESCRIPTION
This will allow the gem to be installed on Ruby 2.2.
