### PR TITLE
Run after_fork hooks correctly on Phusion Passenger

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -167,3 +167,11 @@ module Discourse
 
   end
 end
+
+if defined?(PhusionPassenger)
+  PhusionPassenger.on_event(:starting_worker_process) do |forked|
+    if forked
+      Discourse.after_fork
+    end
+  end
+end


### PR DESCRIPTION
This uses Phusion Passenger's hook APIs.
