### PR TITLE
Add eu-central-1 to list of S3 buckets.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -117,7 +117,7 @@ gem 'fast_xs'
 
 gem 'fast_xor'
 gem 'fastimage'
-gem 'fog', '1.22.1', require: false
+gem 'fog', '1.26.0', require: false
 gem 'unf', require: false
 
 gem 'email_reply_parser'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    CFPropertyList (2.2.8)
     actionmailer (4.1.8)
       actionpack (= 4.1.8)
       actionview (= 4.1.8)
@@ -81,7 +82,7 @@ GEM
       handlebars-source (~> 2.0)
     erubis (2.7.0)
     eventmachine (1.0.4)
-    excon (0.39.6)
+    excon (0.42.1)
     execjs (2.2.2)
     exifr (1.1.3)
     fabrication (2.9.8)
@@ -99,27 +100,75 @@ GEM
     fastimage (1.6.3)
       addressable (~> 2.3, >= 2.3.5)
     ffi (1.9.6)
+    fission (0.5.0)
+      CFPropertyList (~> 2.2)
     flamegraph (0.1.0)
       fast_stack
-    fog (1.22.1)
-      fog-brightbox
-      fog-core (~> 1.22)
+    fog (1.26.0)
+      fog-atmos
+      fog-brightbox (~> 0.4)
+      fog-core (~> 1.27, >= 1.27.1)
+      fog-ecloud
       fog-json
+      fog-profitbricks
+      fog-radosgw (>= 0.0.2)
+      fog-sakuracloud (>= 0.0.4)
+      fog-softlayer
+      fog-storm_on_demand
+      fog-terremark
+      fog-vmfusion
+      fog-voxel
+      fog-xml (~> 0.1.1)
       ipaddress (~> 0.5)
       nokogiri (~> 1.5, >= 1.5.11)
-    fog-brightbox (0.5.1)
+    fog-atmos (0.1.0)
+      fog-core
+      fog-xml
+    fog-brightbox (0.7.1)
       fog-core (~> 1.22)
       fog-json
-      inflecto
-    fog-core (1.24.0)
+      inflecto (~> 0.0.2)
+    fog-core (1.27.2)
       builder
       excon (~> 0.38)
       formatador (~> 0.2)
       mime-types
       net-scp (~> 1.1)
       net-ssh (>= 2.1.3)
+    fog-ecloud (0.0.2)
+      fog-core
+      fog-xml
     fog-json (1.0.0)
       multi_json (~> 1.0)
+    fog-profitbricks (0.0.1)
+      fog-core
+      fog-xml
+      nokogiri
+    fog-radosgw (0.0.3)
+      fog-core (>= 1.21.0)
+      fog-json
+      fog-xml (>= 0.0.1)
+    fog-sakuracloud (0.1.1)
+      fog-core
+      fog-json
+    fog-softlayer (0.3.26)
+      fog-core
+      fog-json
+    fog-storm_on_demand (0.1.0)
+      fog-core
+      fog-json
+    fog-terremark (0.0.3)
+      fog-core
+      fog-xml
+    fog-vmfusion (0.0.1)
+      fission
+      fog-core
+    fog-voxel (0.0.2)
+      fog-core
+      fog-xml
+    fog-xml (0.1.1)
+      fog-core
+      nokogiri (~> 1.5, >= 1.5.11)
     foreman (0.75.0)
       dotenv (~> 0.11.1)
       thor (~> 0.19.1)
@@ -423,7 +472,7 @@ DEPENDENCIES
   fast_xs
   fastimage
   flamegraph
-  fog (= 1.22.1)
+  fog (= 1.26.0)
   foreman
   gctools
   handlebars-source (= 2.0.0)

--- a/app/models/s3_region_site_setting.rb
+++ b/app/models/s3_region_site_setting.rb
@@ -16,6 +16,7 @@ class S3RegionSiteSetting < EnumSiteSetting
       'us-west-2',
       'us-gov-west-1',
       'eu-west-1',
+      'eu-central-1',
       'ap-southeast-1',
       'ap-southeast-2',
       'ap-northeast-1',

--- a/spec/models/s3_region_site_setting_spec.rb
+++ b/spec/models/s3_region_site_setting_spec.rb
@@ -14,7 +14,7 @@ describe S3RegionSiteSetting do
 
   describe 'values' do
     it 'returns all the S3 regions and blank' do
-      expect(S3RegionSiteSetting.values.map {|x| x[:value]}.sort).to eq(['', 'us-east-1', 'us-west-1', 'us-west-2', 'us-gov-west-1', 'eu-west-1', 'ap-southeast-1', 'ap-southeast-2', 'ap-northeast-1', 'sa-east-1'].sort)
+      expect(S3RegionSiteSetting.values.map {|x| x[:value]}.sort).to eq(['', 'us-east-1', 'us-west-1', 'us-west-2', 'us-gov-west-1', 'eu-west-1', 'eu-central-1', 'ap-southeast-1', 'ap-southeast-2', 'ap-northeast-1', 'sa-east-1'].sort)
     end
   end
 


### PR DESCRIPTION
This PR does two things.
- Adds eu-central-1 (Frankfurt) to list of S3 buckets.
- Upgrades `fog` dependency version.

I had to upgrade fog because newer S3 bucket regions (Frankfurt in particular) use a different signing algorithm that wasn’t working with previous fog, but is working with this version.

After I upgraded the fog version in `Gemfile` and ran `bundle install`, a bunch of stuff (looks like fog components/dependencies) got added to `Gemfile.lock`. I’m not really a Ruby developer so I don’t know what to make of this.
