### PR TITLE
fix onebox cannot detect relative url bug

### DIFF
--- a/app/assets/javascripts/discourse/dialects/autolink_dialect.js
+++ b/app/assets/javascripts/discourse/dialects/autolink_dialect.js
@@ -3,7 +3,7 @@
   a hrefs for them.
 **/
 var urlReplacerArgs = {
-  matcher: /^((?:https?:(?:\/{1,3}|[a-z0-9%])|www\d{0,3}[.])(?:[^\s()<>]+|\([^\s()<>]+\))+(?:\([^\s()<>]+\)|[^`!()\[\]{};:'".,<>?«»“”‘’\s]))/gm,
+  matcher: /^((?:https?|(?:\/{1,3}|[a-z0-9%])|www\d{0,3}[.])(?:[^\s()<>]+|\([^\s()<>]+\))+(?:\([^\s()<>]+\)|[^`!()\[\]{};:'".,<>?«»“”‘’\s]))/gm,
   spaceOrTagBoundary: true,
 
   emitter: function(matches) {
@@ -23,3 +23,4 @@ var urlReplacerArgs = {
 
 Discourse.Dialect.inlineRegexp(_.merge({start: 'http'}, urlReplacerArgs));
 Discourse.Dialect.inlineRegexp(_.merge({start: 'www'}, urlReplacerArgs));
+Discourse.Dialect.inlineRegexp(_.merge({start: '//'}, urlReplacerArgs));

--- a/app/assets/javascripts/discourse/lib/onebox.js
+++ b/app/assets/javascripts/discourse/lib/onebox.js
@@ -32,7 +32,7 @@ Discourse.Onebox = {
     if ($elem.data('onebox-loaded')) return;
     if ($elem.hasClass('loading-onebox')) return;
 
-    var url = e.href;
+    var url = $elem.attr('href');
 
     // Unless we're forcing a refresh...
     if (!refresh) {

--- a/vendor/assets/javascripts/better_markdown.js
+++ b/vendor/assets/javascripts/better_markdown.js
@@ -335,7 +335,7 @@
       // __foo__ is reserved and not a pattern
       if ( i.match( /^__.*__$/) )
         continue;
-      var l = i.replace( /([\\.*+?^$|()\[\]{}])/g, "\\$1" )
+      var l = i.replace( /([\/\\.*+?^$|()\[\]{}])/g, "\\$1" )
                .replace( /\n/, "\\n" );
       patterns.push( i.length === 1 ? l : "(?:" + l + ")" );
     }


### PR DESCRIPTION
With this fix, url starts with '//' will be considered as a link by `better_markdown`, and thus able to be converted to onebox preview.