### PR TITLE
FEATURE: Add way to access all screened IP addresses through json

### DIFF
--- a/app/controllers/admin/screened_ip_addresses_controller.rb
+++ b/app/controllers/admin/screened_ip_addresses_controller.rb
@@ -3,7 +3,15 @@ class Admin::ScreenedIpAddressesController < Admin::AdminController
   before_filter :fetch_screened_ip_address, only: [:update, :destroy]
 
   def index
-    screened_ip_addresses = ScreenedIpAddress.limit(200).order('match_count desc').to_a
+    query = ScreenedIpAddress.limit(200).order('match_count desc, id asc')
+    if params[:after]
+      m = params[:after].match /(\d+),(\d+)/
+      return render_json_error I18n.t('errors.messages.bad_format') unless m
+      count, id = m[1], m[2]
+      query.where!('match_count <= ?', count)
+      query.where!('id > ?', id)
+    end
+    screened_ip_addresses = query.to_a
     render_serialized(screened_ip_addresses, ScreenedIpAddressSerializer)
   end
 

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -55,6 +55,7 @@ en:
       too_long_validation: "is limited to %{max} characters; you entered %{length}."
       invalid_boolean: "Invalid boolean."
       taken: "has already been taken. (group names are case insensitive)"
+      bad_format: "Invalid input format."
     embed:
       load_from_remote: "There was an error loading that post."
 


### PR DESCRIPTION
Expected client behavior:

 1. Get the first 200 screened IP addresses with no query parameters
 2. Take the match_count and id of the last entry
 3. Request with ?after={match_count},{id}
 4. Repeat steps 2-3 until less than 200 are returned

No UI is provided in this commit.

https://meta.discourse.org/t/ip-address-no-longer-shown-on-the-admin-users-listings/23320/8?u=riking