### PR TITLE
Add topic and post IDs to user posts archive

### DIFF
--- a/app/jobs/regular/export_csv_file.rb
+++ b/app/jobs/regular/export_csv_file.rb
@@ -5,7 +5,7 @@ module Jobs
 
   class ExportCsvFile < Jobs::Base
     HEADER_ATTRS_FOR = {}
-    HEADER_ATTRS_FOR['user_archive'] = ['raw','like_count','reply_count','created_at']
+    HEADER_ATTRS_FOR['user_archive'] = ['topic_id','post_number','id','raw','like_count','reply_count','created_at']
     HEADER_ATTRS_FOR['user'] = ['id','name','username','email','title','created_at','trust_level','active','admin','moderator','ip_address']
     HEADER_ATTRS_FOR['user_stats'] = ['topics_entered','posts_read_count','time_read','topic_count','post_count','likes_given','likes_received']
     HEADER_ATTRS_FOR['user_sso'] = ['external_id','external_email', 'external_username', 'external_name', 'external_avatar_url']


### PR DESCRIPTION
Simple change, except I also added an 'ensure' to the notify_user because I didn't get a failure message when I typed in the wrong field name.

Requested here, and seemed reasonable: http://what.thedailywtf.com/t/i-can-download-my-posts-now/5760/6?u=riking

I included topic, post_number, AND post_id because you need all three of those to quickly ask the live site for information. Leaving out any of the three would result in, at minimum, doubling the HTTP requests required.
