### PR TITLE
FIX: user card can't expand when the username is number

### DIFF
--- a/app/assets/javascripts/discourse/controllers/user-card.js.es6
+++ b/app/assets/javascripts/discourse/controllers/user-card.js.es6
@@ -33,7 +33,7 @@ export default ObjectController.extend({
 
   show: function(username, target) {
     // XSS protection (should be encapsulated)
-    username = username.replace(/[^A-Za-z0-9_]/g, "");
+    username = username.toString().replace(/[^A-Za-z0-9_]/g, "");
     var url = "/users/" + username;
 
     // Don't show on mobile


### PR DESCRIPTION
username param may be a `Number` instead of `String` which is the root cause.
