### PR TITLE
FIX: use utc time when generate reports; set boundary

### DIFF
--- a/app/models/post_action.rb
+++ b/app/models/post_action.rb
@@ -39,6 +39,13 @@ class PostAction < ActiveRecord::Base
     nil
   end
 
+  def self.flag_count_by_date(start_date, end_date)
+    where('created_at >= ? and created_at <= ?', start_date, end_date)
+      .where(post_action_type_id: PostActionType.flag_types.values)
+      .group('date(created_at)').order('date(created_at)')
+      .count
+  end
+
   def self.update_flagged_posts_count
     posts_flagged_count = PostAction.active
                                     .flags
@@ -92,7 +99,7 @@ class PostAction < ActiveRecord::Base
 
   def self.count_per_day_for_type(post_action_type, since_days_ago=30)
     unscoped.where(post_action_type_id: post_action_type)
-            .where('created_at > ?', since_days_ago.days.ago)
+            .where('created_at >= ?', since_days_ago.days.ago)
             .group('date(created_at)')
             .order('date(created_at)')
             .count

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -352,7 +352,7 @@ class Topic < ActiveRecord::Base
   end
 
   def self.listable_count_per_day(start_date, end_date)
-    listable_topics.where('created_at >= ? and created_at < ?', start_date, end_date).group('date(created_at)').order('date(created_at)').count
+    listable_topics.where('created_at >= ? and created_at <= ?', start_date, end_date).group('date(created_at)').order('date(created_at)').count
   end
 
   def private_message?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -531,7 +531,7 @@ class User < ActiveRecord::Base
   end
 
   def self.count_by_signup_date(start_date, end_date)
-    where('created_at >= ? and created_at < ?', start_date, end_date).group('date(created_at)').order('date(created_at)').count
+    where('created_at >= ? and created_at <= ?', start_date, end_date).group('date(created_at)').order('date(created_at)').count
   end
 
 

--- a/app/models/user_visit.rb
+++ b/app/models/user_visit.rb
@@ -2,7 +2,7 @@ class UserVisit < ActiveRecord::Base
 
   # A count of visits in the last month by day
   def self.by_day(start_date, end_date)
-    where("visited_at >= ? and visited_at < ?", start_date, end_date).group(:visited_at).order(:visited_at).count
+    where('visited_at >= ? and visited_at <= ?', start_date.to_date, end_date.to_date).group(:visited_at).order(:visited_at).count
   end
 
   def self.ensure_consistency!

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -1232,6 +1232,26 @@ describe Topic do
     end
   end
 
+  describe '#listable_count_per_day' do
+    before(:each) do
+      Timecop.freeze
+      Fabricate(:topic)
+      Fabricate(:topic, created_at: 1.day.ago)
+      Fabricate(:topic, created_at: 1.day.ago)
+      Fabricate(:topic, created_at: 2.days.ago)
+      Fabricate(:topic, created_at: 4.days.ago)
+    end
+    after(:each) do
+      Timecop.return
+    end
+    let(:listable_topics_count_per_day) { {1.day.ago.to_date => 2, 2.days.ago.to_date => 1, Time.now.utc.to_date => 1 } }
+
+    it 'collect closed interval listable topics count' do
+      Topic.listable_count_per_day(2.days.ago, Time.now).should include(listable_topics_count_per_day)
+      Topic.listable_count_per_day(2.days.ago, Time.now).should_not include({4.days.ago.to_date => 1})
+    end
+  end
+
   describe '#secure_category?' do
     let(:category){ Category.new }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -6,6 +6,25 @@ describe User do
   it { should validate_presence_of :username }
   it { should validate_presence_of :email }
 
+  describe '#count_by_signup_date' do
+    before(:each) do
+      User.destroy_all
+      Timecop.freeze
+      Fabricate(:user)
+      Fabricate(:user, created_at: 1.day.ago)
+      Fabricate(:user, created_at: 1.day.ago)
+      Fabricate(:user, created_at: 2.days.ago)
+      Fabricate(:user, created_at: 4.days.ago)
+    end
+    after(:each) { Timecop.return }
+    let(:signups_by_day) { {1.day.ago.to_date => 2, 2.days.ago.to_date => 1, Time.now.utc.to_date => 1} }
+
+    it 'collect closed interval signups' do
+      User.count_by_signup_date(2.days.ago, Time.now).should include(signups_by_day)
+      User.count_by_signup_date(2.days.ago, Time.now).should_not include({4.days.ago.to_date => 1})
+    end
+  end
+
   context '.enqueue_welcome_message' do
     let(:user) { Fabricate(:user) }
 


### PR DESCRIPTION
Related: #3065 @ZogStriP 
- mostly restricting reports by day to the closed interval
- several refactors to their own model
- more generic in `report.rb`
- use utc time in `report.rb`'s `start_date` and `end_date`, and they are also be adjust to the beginning of the day or the end of the day to maximized its range. This is because some column are `datetime`, while others are `date`.
