### PR TITLE
Better filenames for export

### DIFF
--- a/app/assets/javascripts/discourse/models/export_csv.js
+++ b/app/assets/javascripts/discourse/models/export_csv.js
@@ -30,7 +30,7 @@ Discourse.ExportCsv.reopenClass({
     @method export_user_list
   **/
   exportUserList: function() {
-    return Discourse.ajax("/export_csv/export_entity.json", {data: {entity_type: 'admin', entity: 'user'}});
+    return Discourse.ajax("/export_csv/export_entity.json", {data: {entity_type: 'admin', entity: 'user_list'}});
   },
 
   /**

--- a/app/controllers/export_csv_controller.rb
+++ b/app/controllers/export_csv_controller.rb
@@ -15,7 +15,7 @@ class ExportCsvController < ApplicationController
   def show
     params.require(:id)
     filename = params.fetch(:id)
-    export_id = filename.split('_')[1].split('.')[0]
+    export_id = filename.split('-')[2].split('.')[0]
     export_initiated_by_user_id = 0
     export_initiated_by_user_id = UserExport.where(id: export_id)[0].user_id unless UserExport.where(id: export_id).empty?
     export_csv_path = UserExport.get_download_path(filename)

--- a/app/jobs/regular/export_csv_file.rb
+++ b/app/jobs/regular/export_csv_file.rb
@@ -24,6 +24,7 @@ module Jobs
 
     def execute(args)
       entity = args[:entity]
+      @file_name = entity
 
       if entity == "user_archive"
         @entity_type = "user"
@@ -56,12 +57,12 @@ module Jobs
       end
     end
 
-    def user_export
+    def user_list_export
       query = ::AdminUserIndexQuery.new
       user_data = query.find_users_query.to_a
       user_data.map do |user|
         group_names = get_group_names(user).join(';')
-        user_array = get_user_fields(user)
+        user_array = get_user_list_fields(user)
         user_array.push(group_names) if group_names != ''
         user_array
       end
@@ -168,7 +169,7 @@ module Jobs
         user_archive_array
       end
 
-      def get_user_fields(user)
+      def get_user_list_fields(user)
         user_array = []
 
         HEADER_ATTRS_FOR['user'].each do |attr|
@@ -271,7 +272,8 @@ module Jobs
 
       def set_file_path
         @file = UserExport.create(export_type: @entity_type, user_id: @current_user.id)
-        @file_name = "export_#{@file.id}.csv"
+        file_name_prefix = @file_name.split('_').join('-')
+        @file_name = "#{file_name_prefix}-#{@file.id}.csv"
 
         # ensure directory exists
         dir = File.dirname("#{UserExport.base_directory}/#{@file_name}")

--- a/spec/controllers/export_csv_controller_spec.rb
+++ b/spec/controllers/export_csv_controller_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe ExportCsvController do
-  let(:export_filename) { "export_999.csv" }
+  let(:export_filename) { "user-archive-999.csv" }
 
 
   context "while logged in as normal user" do
@@ -30,7 +30,7 @@ describe ExportCsvController do
     describe ".download" do
       it "uses send_file to transmit the export file" do
         file = UserExport.create(export_type: "user", user_id: @user.id)
-        file_name = "export_#{file.id}.csv"
+        file_name = "user-archive-#{file.id}.csv"
         controller.stubs(:render)
         export = UserExport.new()
         UserExport.expects(:get_download_path).with(file_name).returns(export)
@@ -74,7 +74,7 @@ describe ExportCsvController do
     describe ".download" do
       it "uses send_file to transmit the export file" do
         file = UserExport.create(export_type: "admin", user_id: @admin.id)
-        file_name = "export_#{file.id}.csv"
+        file_name = "screened-email-#{file.id}.csv"
         controller.stubs(:render)
         export = UserExport.new()
         UserExport.expects(:get_download_path).with(file_name).returns(export)

--- a/spec/jobs/export_csv_file_spec.rb
+++ b/spec/jobs/export_csv_file_spec.rb
@@ -8,16 +8,16 @@ describe Jobs::ExportCsvFile do
     end
   end
 
-  let :user_header do
+  let :user_list_header do
     Jobs::ExportCsvFile.new.get_header('user')
   end
 
-  let :user_export do
-    Jobs::ExportCsvFile.new.user_export
+  let :user_list_export do
+    Jobs::ExportCsvFile.new.user_list_export
   end
 
   def to_hash(row)
-    Hash[*user_header.zip(row).flatten]
+    Hash[*user_list_header.zip(row).flatten]
   end
 
   it 'exports sso data' do
@@ -25,10 +25,9 @@ describe Jobs::ExportCsvFile do
     user = Fabricate(:user)
     user.create_single_sign_on_record(external_id: "123", last_payload: "xxx", external_email: 'test@test.com')
 
-    user = to_hash(user_export.find{|u| u[0] == user.id})
+    user = to_hash(user_list_export.find{|u| u[0] == user.id})
 
     user["external_id"].should == "123"
     user["external_email"].should == "test@test.com"
   end
 end
-


### PR DESCRIPTION
Example file names: 

`user-archive-89.csv`, `staff-action-90.csv`, `screened-email-91.csv`, `screened-ip-92.csv`, `screened-url-93.csv`

cc @coding-horror 