### PR TITLE
FIX: Issue with Vagrant image failing specs.

### DIFF
--- a/chef/cookbooks/discourse/recipes/default.rb
+++ b/chef/cookbooks/discourse/recipes/default.rb
@@ -1,42 +1,26 @@
-# Upgrade ruby. I don't know chef, so this is probably more complicated than it needs to be:
-# execute "upgrade-rvm" do
-#   command "rvm get stable && rvm reload"
-#   action :nothing
-# end
+execute "upgrade-rvm" do
+  command "gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3"
+  command "rvm get stable && rvm reload"
+  action :nothing
+end
 
-# execute "upgrade-ruby" do
-#   command "yes | rvm install 2.0.0-p247-turbo"
-#   action :nothing
-# end
+execute "upgrade-ruby" do
+  command "yes | rvm install ruby-2.1.5 --verify-downloads 1"
+  action :nothing
+end
 
+execute "set-ruby" do
+  command "rvm use ruby-2.1.5"
+  user "vagrant"
+  action :nothing
+end
 
-
-# TODO: set-default-ruby SUCCEEDS BY DOES NOTHING. HOW TO GET THIS TO WORK??
-
-# execute "set-default-ruby" do
-#   command "rvm --default use ruby-2.0.0-p247-turbo"
-#   user "vagrant"
-#   action :nothing
-# end
-
-
-
-
-# execute "install-gems" do
-#   command "gem install bundler && bundle install"
-#   user "vagrant"
-#   cwd "/vagrant"
-#   action :nothing
-# end
-
-# ruby_block "ruby-upgrade-message" do
-#   block do
-#     Chef::Log.info "Upgrading ruby. This will take a while."
-#   end
-#   only_if { `ruby -v`.include?('2.0.0p0') }
-#   notifies :run, "execute[upgrade-rvm]", :immediately
-#   notifies :run, "execute[upgrade-ruby]", :immediately
-#   notifies :run, "execute[set-default-ruby]", :immediately
-#   notifies :run, "execute[install-gems]", :immediately
-#   action :create
-# end
+ruby_block "ruby-upgrade-message" do
+  block do
+    Chef::Log.info "Upgrading ruby. This will take a while."
+  end
+  notifies :run, "execute[upgrade-rvm]", :immediately
+  notifies :run, "execute[upgrade-ruby]", :immediately
+  notifies :run, "execute[set-ruby]", :immediately
+  action :create
+end


### PR DESCRIPTION
Submitting this in response to a discussion thread:

https://meta.discourse.org/t/why-are-my-tests-failing/23434

It turns out the Vagrant file was using ruby-2.0.0-p0-turbo.  I updated the chef solo file for discourse to add a Ruby 2.1 image with rvm and select it.  A better solution is probably to update the discourse base box, but this works for now.