### PR TITLE
Prepare for Teatro

### DIFF
--- a/.teatro.yml
+++ b/.teatro.yml
@@ -1,0 +1,6 @@
+stage:
+  before:
+    - export DISCOURSE_DB_NAME=teatro
+    - export DISCOURSE_DB_USERNAME=teatro
+
+  database: RAILS_ENV=development bundle exec rake db:create db:migrate

--- a/config/initializers/verify_config.rb
+++ b/config/initializers/verify_config.rb
@@ -16,7 +16,7 @@ END
     raise "Invalid host_names in database.yml"
   end
 
-  if !Dir.glob(File.join(Rails.root,'public','assets','application*.js')).present?
+  if !ENV["TEATRO"] && !Dir.glob(File.join(Rails.root,'public','assets','application*.js')).present?
     puts <<END
 
       Assets have not been precompiled. Please run the following command


### PR DESCRIPTION
Hey!

I am developer at Teatro.io and I want to offer you our service — it automatically creates a staging server for each opened pull request.

Teatro.io is free for open source projects and some large projects like GitLab, ErrBit, OpenProject, Spree and others are already using Teatro for free stage servers.

Here's URL of Teatro stage server for my fork of discourse: http://teatro.divineforest-discourse-51d3c00407c3a4a9be8e.ttrcloud.com/

When you connect project to Teatro, we'll automatically post a comment (via @TeatroIO) with link to unique stage server that was made for this specific branch (see divineforest#3 for example).

To use Teatro you need:
— sign in using Github account on https://teatro.io
— add your project

Benefits:
— demo for new users (always up to date!)
— the way to test changes: each Pull Request gets separate stage server
— FREE for open source!