### PR TITLE
UX: Add class to gutter links so you can infer if they are inbound or outbound using CSS

### DIFF
--- a/app/assets/javascripts/discourse/components/post-gutter.js.es6
+++ b/app/assets/javascripts/discourse/components/post-gutter.js.es6
@@ -33,11 +33,11 @@ export default Em.Component.extend({
 
       buffer.push("<ul class='post-links'>");
       toRender.forEach(function(l) {
-        var direction = Em.get(l, 'reflection') ? 'left' : 'right',
+        var direction = Em.get(l, 'reflection') ? 'inbound' : 'outbound',
             clicks = Em.get(l, 'clicks');
 
-        buffer.push("<li><a href='" + Em.get(l, 'url') + "' class='track-link'>");
-        /* suppress both left and right arrow for now */
+        buffer.push("<li><a href='" + Em.get(l, 'url') + "' class='track-link " + direction + "'>");
+
         var title = Em.get(l, 'title');
         if (!Em.isEmpty(title)) {
           buffer.push(Handlebars.Utils.escapeExpression(title));


### PR DESCRIPTION
Added a second class to the gutter links to indicate if they are inbound or outbound links so sites can customize the two types differently (if they want to).

No changes were made to the default CSS, so they remain without any physical indicator.