### PR TITLE
FIX: users tab in admin panel doesn’t stay highlighted

### DIFF
--- a/app/assets/javascripts/admin/routes/admin-users-list-index.js.es6
+++ b/app/assets/javascripts/admin/routes/admin-users-list-index.js.es6
@@ -1,0 +1,5 @@
+export default Discourse.Route.extend({
+  redirect: function() {
+    this.replaceWith('adminUsersList.show', 'active');
+  }
+});

--- a/app/assets/javascripts/admin/templates/admin.hbs
+++ b/app/assets/javascripts/admin/templates/admin.hbs
@@ -8,7 +8,7 @@
         {{#if currentUser.admin}}
           <li>{{#link-to 'adminSiteSettings'}}{{i18n 'admin.site_settings.title'}}{{/link-to}}</li>
         {{/if}}
-        <li>{{#link-to 'adminUsersList.show' 'active'}}{{i18n 'admin.users.title'}}{{/link-to}}</li>
+        <li>{{#link-to 'adminUsersList'}}{{i18n 'admin.users.title'}}{{/link-to}}</li>
         {{#if showBadges}}
           <li>{{#link-to 'adminBadges.index'}}{{i18n 'admin.badges.title'}}{{/link-to}}</li>
         {{/if}}
@@ -34,4 +34,3 @@
     </div>
   </div>
 </div>
-


### PR DESCRIPTION
[Bug report on meta](https://meta.discourse.org/t/users-tab-in-admin-panel-doesnt-stay-highlighted/23637?u=techapj)