### PR TITLE
FIX: Update vagrant box for ruby and phantomjs versions

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,8 +3,8 @@
 # See https://github.com/discourse/discourse/blob/master/docs/VAGRANT.md
 #
 Vagrant.configure("2") do |config|
-  config.vm.box = 'discourse-0.9.9.13'
-  config.vm.box_url = "https://d3fvb7b7auiut8.cloudfront.net/discourse-0.9.9.13.box"
+  config.vm.box= "edgibbs/discourse-0.9.9.15.box"
+  config.vm.box_url = "https://vagrantcloud.com/edgibbs/discourse-0.9.9.15.box"
 
   # Make this VM reachable on the host network as well, so that other
   # VM's running other browsers can access our dev server.

--- a/chef/cookbooks/discourse/recipes/default.rb
+++ b/chef/cookbooks/discourse/recipes/default.rb
@@ -1,26 +1,26 @@
-execute "upgrade-rvm" do
-  command "gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3"
-  command "rvm get stable && rvm reload"
-  action :nothing
-end
-
-execute "upgrade-ruby" do
-  command "yes | rvm install ruby-2.1.5 --verify-downloads 1"
-  action :nothing
-end
-
-execute "set-ruby" do
-  command "rvm use ruby-2.1.5"
-  user "vagrant"
-  action :nothing
-end
-
-ruby_block "ruby-upgrade-message" do
-  block do
-    Chef::Log.info "Upgrading ruby. This will take a while."
-  end
-  notifies :run, "execute[upgrade-rvm]", :immediately
-  notifies :run, "execute[upgrade-ruby]", :immediately
-  notifies :run, "execute[set-ruby]", :immediately
-  action :create
-end
+# execute "upgrade-rvm" do
+#   command "gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3"
+#   command "rvm get stable && rvm reload"
+#   action :nothing
+# end
+#
+# execute "upgrade-ruby" do
+#   command "yes | rvm install ruby-2.1.5 --verify-downloads 1"
+#   action :nothing
+# end
+#
+# execute "set-ruby" do
+#   command "rvm use ruby-2.1.5"
+#   user "vagrant"
+#   action :nothing
+# end
+#
+# ruby_block "ruby-upgrade-message" do
+#   block do
+#     Chef::Log.info "Upgrading ruby. This will take a while."
+#   end
+#   notifies :run, "execute[upgrade-rvm]", :immediately
+#   notifies :run, "execute[upgrade-ruby]", :immediately
+#   notifies :run, "execute[set-ruby]", :immediately
+#   action :create
+# end


### PR DESCRIPTION
Cleaned up the actual Vagrant box since it was setup with an old Ruby and an old PhantomJS.  It now passes a test run as per the documentation.  The current vagrant image is hosted here:

https://d3fvb7b7auiut8.cloudfront.net/discourse-0.9.9.13.box

I uploaded this image to Atlas, but I can push it somewhere else for hosting if there's a better spot:

https://vagrantcloud.com/edgibbs/discourse-0.9.9.15.box


