### PR TITLE
Remove `enable_email_names` setting

### DIFF
--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -127,7 +127,7 @@ class UserNotifications < ActionMailer::Base
       title: post.topic.title,
       post: post,
       username: post.user.username,
-      from_alias: (SiteSetting.enable_email_names && !post.user.name.empty?) ? post.user.name : post.user.username,
+      from_alias: (SiteSetting.enable_names && !post.user.name.empty?) ? post.user.name : post.user.username,
       allow_reply_by_email: true,
       use_site_subject: true,
       add_re_to_subject: true,
@@ -172,7 +172,7 @@ class UserNotifications < ActionMailer::Base
     return unless @post = opts[:post]
 
     user_name = @notification.data_hash[:original_username]
-    if @post && SiteSetting.enable_email_names
+    if @post && SiteSetting.enable_names
       user_name = User.find_by(id: @post.user_id).name if !User.find_by(id: @post.user_id).name.empty?
     end
 

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -953,8 +953,6 @@ en:
     strip_images_from_short_emails: "Strip images from emails having size less than 2800 Bytes"
     short_email_length: "Short email length in Bytes"
 
-    enable_email_names: "Allow showing user full name in emails. Disable to hide full name in emails."
-
     pop3_polling_enabled: "Poll via POP3 for email replies."
     pop3_polling_ssl: "Use SSL while connecting to the POP3 server. (Recommended)"
     pop3_polling_period_mins: "The period in minutes between checking the POP3 account for email. NOTE: requires restart."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -432,7 +432,6 @@ email:
   disable_emails: false
   strip_images_from_short_emails: true
   short_email_length: 2800
-  enable_email_names: true
 
 files:
   max_image_size_kb:

--- a/spec/mailers/user_notifications_spec.rb
+++ b/spec/mailers/user_notifications_spec.rb
@@ -90,7 +90,7 @@ describe UserNotifications do
     let(:notification) { Fabricate(:notification, user: user) }
 
     it 'generates a correct email' do
-      SiteSetting.stubs(:enable_email_names).returns(true)
+      SiteSetting.stubs(:enable_names).returns(true)
       mail = UserNotifications.user_replied(response.user, post: response, notification: notification)
 
       # from should include full user name
@@ -138,7 +138,7 @@ describe UserNotifications do
     let(:notification) { Fabricate(:notification, user: user, data: {original_username: response_by_user.username}.to_json) }
 
     it 'generates a correct email' do
-      SiteSetting.stubs(:enable_email_names).returns(false)
+      SiteSetting.stubs(:enable_names).returns(false)
       mail = UserNotifications.user_posted(response.user, post: response, notification: notification)
 
       # from should not include full user name if "show user full names" is disabled
@@ -170,7 +170,7 @@ describe UserNotifications do
     let(:notification) { Fabricate(:notification, user: user, data: {original_username: response_by_user.username}.to_json) }
 
     it 'generates a correct email' do
-      SiteSetting.stubs(:enable_email_names).returns(true)
+      SiteSetting.stubs(:enable_names).returns(true)
       mail = UserNotifications.user_private_message(response.user, post: response, notification: notification)
 
       # from should include username if full user name is not provided
@@ -268,7 +268,7 @@ describe UserNotifications do
       end
 
       it "has a from alias" do
-        SiteSetting.stubs(:enable_email_names).returns(true)
+        SiteSetting.stubs(:enable_names).returns(true)
         expects_build_with(has_entry(:from_alias, "#{user.name}"))
       end
 


### PR DESCRIPTION
Remove `enable_email_names` setting and use `enable_names` instead for showing full name in emails.