### PR TITLE
Set Turkish pluralization rules

### DIFF
--- a/app/assets/javascripts/locales/tr_TR.js.erb
+++ b/app/assets/javascripts/locales/tr_TR.js.erb
@@ -1,3 +1,5 @@
 //= depend_on 'client.tr_TR.yml'
 //= require locales/i18n
 <%= JsLocaleHelper.output_locale(:tr_TR) %>
+
+I18n.pluralizationRules['tr_TR'] = function(n) { return "other"; }


### PR DESCRIPTION
Turkish does not have different forms for singulars next to numerals
https://meta.discourse.org/t/turkish-translation-missing-many-singular-strings/23334/12