### PR TITLE
Improve noscript handling for old browsers

### DIFF
--- a/app/assets/javascripts/discourse.js
+++ b/app/assets/javascripts/discourse.js
@@ -100,8 +100,13 @@ window.Discourse = Ember.Application.createWithMixins(Discourse.Ajax, {
     @method start
   **/
   start: function() {
-
-    $('noscript').remove();
+    if (window.HaltDiscourse) {
+      // Browser is too old to run Discourse. Don't start.
+      // see browser-update.js
+      return;
+    } else {
+      $('#noscript').remove();
+    }
 
     // Load any ES6 initializers
     Ember.keys(requirejs._eak_seen).forEach(function(key) {

--- a/app/assets/javascripts/discourse/models/static_page.js
+++ b/app/assets/javascripts/discourse/models/static_page.js
@@ -5,16 +5,9 @@ Discourse.StaticPage.reopenClass({
     return new Em.RSVP.Promise(function(resolve) {
       // Models shouldn't really be doing Ajax request, but this is a huge speed boost if we
       // preload content.
-      var $preloaded = $("noscript[data-path=\"/" + path + "\"]");
-      if ($preloaded.length) {
-        var text = $preloaded.text();
-        text = text.match(/<!-- preload-content: -->((?:.|[\n\r])*)<!-- :preload-content -->/)[1];
-        resolve(Discourse.StaticPage.create({path: path, html: text}));
-      } else {
-        Discourse.ajax(path + ".html", {dataType: 'html'}).then(function (result) {
-          resolve(Discourse.StaticPage.create({path: path, html: result}));
-        });
-      }
+      Discourse.ajax(path + ".html", {dataType: 'html'}).then(function (result) {
+        resolve(Discourse.StaticPage.create({path: path, html: result}));
+      });
     });
   }
 });

--- a/app/assets/javascripts/discourse/models/static_page.js
+++ b/app/assets/javascripts/discourse/models/static_page.js
@@ -2,12 +2,16 @@ Discourse.StaticPage = Em.Object.extend();
 
 Discourse.StaticPage.reopenClass({
   find: function(path) {
-    return new Em.RSVP.Promise(function(resolve) {
-      // Models shouldn't really be doing Ajax request, but this is a huge speed boost if we
-      // preload content.
-      Discourse.ajax(path + ".html", {dataType: 'html'}).then(function (result) {
-        resolve(Discourse.StaticPage.create({path: path, html: result}));
+    // Models shouldn't really be doing Ajax request, but this is a huge speed boost if we
+    // preload content.
+    if (PreloadStore.get('static/' + path)) {
+      return PreloadStore.getAndRemove('static/' + path).then(function(htmlString) {
+        return Discourse.StaticPage.create({path: path, html: htmlString});
       });
-    });
+    } else {
+      return Discourse.ajax(path + ".html", {dataType: 'html'}).then(function (result) {
+        return Discourse.StaticPage.create({path: path, html: result});
+      });
+    }
   }
 });

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -32,12 +32,15 @@ class StaticController < ApplicationController
       raise Discourse::NotFound unless @topic
       @body = @topic.posts.first.cooked
       @faq_overriden = !SiteSetting.faq_url.blank?
+      store_preloaded("static/#{@page}", MultiJson.dump(@body))
       render :show, layout: !request.xhr?, formats: [:html]
       return
     end
 
     if I18n.exists?("static.#{@page}")
-      render text: I18n.t("static.#{@page}"), layout: !request.xhr?, formats: [:html]
+      text = I18n.t("static.#{@page}")
+      store_preloaded("static/#{@page}", MultiJson.dump(text))
+      render text: text, layout: !request.xhr?, formats: [:html]
       return
     end
 

--- a/app/views/common/_discourse_javascript.html.erb
+++ b/app/views/common/_discourse_javascript.html.erb
@@ -30,6 +30,11 @@
 </script>
 
 <script>
+window.HaltDiscourse = false; /* set by browser-update.js */
+</script>
+<%= script 'browser-update' %>
+<script>
+if (!window.HaltDiscourse) {
   Discourse.CDN = '<%= Rails.configuration.action_controller.asset_host %>';
   Discourse.BaseUrl = '<%= RailsMultisite::ConnectionManagement.current_hostname %>'.replace(/:[\d]*$/,"");
   Discourse.BaseUri = '<%= Discourse::base_uri "/" %>';
@@ -43,6 +48,5 @@
   Discourse.Route.mapRoutes();
   Discourse.start();
   Discourse.set('assetVersion','<%= Discourse.assets_digest %>');
+}
 </script>
-
-<%= script 'browser-update' %>

--- a/app/views/common/_discourse_javascript.html.erb
+++ b/app/views/common/_discourse_javascript.html.erb
@@ -35,6 +35,7 @@ window.HaltDiscourse = false; /* set by browser-update.js */
 <%= script 'browser-update' %>
 <script>
 if (!window.HaltDiscourse) {
+  $('html').addClass('js').removeClass('no-js');
   Discourse.CDN = '<%= Rails.configuration.action_controller.asset_host %>';
   Discourse.BaseUrl = '<%= RailsMultisite::ConnectionManagement.current_hostname %>'.replace(/:[\d]*$/,"");
   Discourse.BaseUri = '<%= Discourse::base_uri "/" %>';
@@ -48,5 +49,7 @@ if (!window.HaltDiscourse) {
   Discourse.Route.mapRoutes();
   Discourse.start();
   Discourse.set('assetVersion','<%= Discourse.assets_digest %>');
+} else {
+  $('html').addClass('no-js').removeClass('js');
 }
 </script>

--- a/app/views/common/_discourse_javascript.html.erb
+++ b/app/views/common/_discourse_javascript.html.erb
@@ -51,5 +51,6 @@ if (!window.HaltDiscourse) {
   Discourse.set('assetVersion','<%= Discourse.assets_digest %>');
 } else {
   $('html').addClass('no-js').removeClass('js');
+  document.getElementById('noscript').style.display = "block";
 }
 </script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -36,7 +36,8 @@
   </head>
 
   <body>
-    <noscript data-path="<%= request.env['PATH_INFO'] %>">
+    <!-- nb: first step in start() is to delete this -->
+    <div id="noscript">
       <header class="d-header">
         <div class="container">
           <div class="contents">
@@ -49,14 +50,12 @@
         </div>
       </header>
       <div id="main-outlet" class="container">
-        <!-- preload-content: -->
         <%= yield %>
-        <!-- :preload-content -->
       </div>
       <footer id='noscript-footer'>
         <p><%= t 'powered_by_html' %></p>
       </footer>
-    </noscript>
+    </div><!--end noscript div-->
 
     <!--[if IE 9]><script type="text/javascript">ie = "new";</script><![endif]-->
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
-<!--[if IE 9]><html lang="<%= SiteSetting.default_locale %>" class="ie9 <%= html_classes %>"><![endif]-->
-<!--[if (!IE 9) | (!IE)]><!--><html lang="<%= SiteSetting.default_locale %>" class="<%= html_classes %>"><!--<![endif]-->
+<!--[if IE 9]><html lang="<%= SiteSetting.default_locale %>" class="ie9 no-js <%= html_classes %>"><![endif]-->
+<!--[if (!IE 9) | (!IE)]><!--><html lang="<%= SiteSetting.default_locale %>" class="no-js <%= html_classes %>"><!--<![endif]-->
   <head>
     <meta charset="utf-8">
     <title><%= content_for?(:title) ? yield(:title) + ' - ' + SiteSetting.title : SiteSetting.title %></title>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -55,7 +55,9 @@
       <footer id='noscript-footer'>
         <p><%= t 'powered_by_html' %></p>
       </footer>
-    </div><!--end noscript div-->
+    </div>
+    <script>document.getElementById('noscript').style.display = "none";</script>
+    <!--end noscript div-->
 
     <!--[if IE 9]><script type="text/javascript">ie = "new";</script><![endif]-->
 

--- a/vendor/assets/javascripts/browser-update.js.erb
+++ b/vendor/assets/javascripts/browser-update.js.erb
@@ -58,6 +58,8 @@ var $buo = function() {
   // shift the body down to make room for our notification div
   document.body.style.marginTop = (div.clientHeight) + "px";
 
+  // Signal to Discourse to stop
+  window.HaltDiscourse = true;
 };
 
 $bu=$buo();


### PR DESCRIPTION
Previously, if a browser needed a feature that was required for Discourse to render anything, you would get a yellow banner saying 

>Sorry, but your browser is too old to work on this Discourse forum. Please upgrade your browser.

... with a vast sea of white below it.

This is because the "fallback content" is in a `<noscript>` element, and it's impossible to fetch the HTML out of a noscript element in a compatible way across all old browsers.

So, this PR:

 1. Changes the `<noscript>` to a `<div id="noscript">`
 2. Changes the `$('noscript').remove();` to `$('#noscript').remove();` in Discourse.start()
 3. Gates the removal of the noscript element by browser-update.js running, which will set `window.HaltDiscourse = true` if the browser is old
 4. Gives the html element a CSS class of `js` or `no-js` depending on the result of browser-update.js

Additionally, dead code in the StaticPage model was rewritten: by the time the code had executed, the noscript element would be long gone. It was changed to use PreloadStore.

![image](https://cloud.githubusercontent.com/assets/627891/5787661/2f3aace4-9dbd-11e4-9653-312ebb4ae280.png)
