### PR TITLE
Fix profile update when 'custom_fields' is blank

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -66,7 +66,7 @@ class UsersController < ApplicationController
     guardian.ensure_can_edit!(user)
 
     if params[:user_fields].present?
-      params[:custom_fields] ||= {}
+      params[:custom_fields] = {} if params[:custom_fields].blank?
       UserField.where(editable: true).each do |f|
         val = params[:user_fields][f.id.to_s]
         val = nil if val === "false"

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -955,17 +955,25 @@ describe UsersController do
           context "an editable field" do
             let!(:user_field) { Fabricate(:user_field) }
             let!(:optional_field) { Fabricate(:user_field, required: false ) }
+            let(:updated_user_field) { user.user_fields[user_field.id.to_s] }
 
             it "should update the user field" do
               put :update, username: user.username, name: 'Jim Tom', user_fields: { user_field.id.to_s => 'happy' }
               expect(response).to be_success
-              expect(user.user_fields[user_field.id.to_s]).to eq 'happy'
+              expect(updated_user_field).to eq 'happy'
             end
 
             it "cannot be updated to blank" do
               put :update, username: user.username, name: 'Jim Tom', user_fields: { user_field.id.to_s => '' }
               expect(response).not_to be_success
-              expect(user.user_fields[user_field.id.to_s]).not_to eq('happy')
+              expect(updated_user_field).not_to eq('happy')
+            end
+
+            context 'when :custom_fields is an empty string' do
+              it 'updates the user field as intended' do
+                put :update, username: user.username, name: 'Jim Tom', user_fields: { user_field.id.to_s => 'happy' }, custom_fields: ''
+                expect(updated_user_field).to eq 'happy'
+              end
             end
           end
 


### PR DESCRIPTION
It seems when custom user fields are enabled and exist, a
'custom_fields' parameter with an empty string as its value is sent when
updating a user profile.
This commit addresses this issue by checking that 'custom_fields' is
blank instead of just nil and assigns it an empty hash as it was done
before.