### PR TITLE
FIX: Move vagrant box to discourse hosting

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,8 +3,8 @@
 # See https://github.com/discourse/discourse/blob/master/docs/VAGRANT.md
 #
 Vagrant.configure("2") do |config|
-  config.vm.box= "edgibbs/discourse-0.9.9.15.box"
-  config.vm.box_url = "https://vagrantcloud.com/edgibbs/discourse-0.9.9.15.box"
+  config.vm.box= "discourse/discourse-0.9.9.15.box"
+  config.vm.box_url = "https://vagrantcloud.com/discourse/discourse-0.9.9.15.box"
 
   # Make this VM reachable on the host network as well, so that other
   # VM's running other browsers can access our dev server.


### PR DESCRIPTION
This change just moves the Vagrant box to the discourse account at
Atlas.