### PR TITLE
FIX: full user names were showing up in crawlers and rss feeds in spite ...

### DIFF
--- a/app/views/list/list.rss.erb
+++ b/app/views/list/list.rss.erb
@@ -14,10 +14,10 @@
         <% topic_url = Discourse.base_url + topic.relative_url -%>
         <item>
           <title><%= topic.title %></title>
-          <author><%= "no-reply@example.com (@#{topic.user.username}#{" #{topic.user.name}" if topic.user.name.present?})" -%></author>
+          <author><%= "no-reply@example.com (@#{topic.user.username}#{" #{topic.user.name}" if (topic.user.name.present? && SiteSetting.enable_names?)})" -%></author>
           <category><%= topic.category.name %></category>
           <description><![CDATA[
-            <p><%= t('author_wrote', author: link_to(topic.user.name, user_url(topic.user.username_lower))).html_safe %></p>
+            <p><%= t('author_wrote', author: link_to("@#{topic.user.username}", user_url(topic.user.username_lower))).html_safe %></p>
             <blockquote>
               <%= topic.posts.first.cooked.html_safe %>
             </blockquote>

--- a/app/views/topics/plain.html.erb
+++ b/app/views/topics/plain.html.erb
@@ -11,7 +11,7 @@
 <% @topic_view.posts.each do |post| %>
   <% if post.user %>
     <div class='creator'>
-      <b><%= post.user.username %></b> <%= "(#{post.user.name})" if SiteSetting.display_name_on_posts %> at <%= post.created_at.to_formatted_s(:long_ordinal) %> — #<%= post.post_number %>
+      <b><%= post.user.username %></b> <%= "(#{post.user.name})" if (SiteSetting.display_name_on_posts && SiteSetting.enable_names?) %> at <%= post.created_at.to_formatted_s(:long_ordinal) %> — #<%= post.post_number %>
     </div>
     <div class='post'>
       <% if post.hidden %>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -10,7 +10,7 @@
   <% if post.user %>
     <div class='creator'>
       <b><%= post.user.username %></b>
-       <%= "(#{post.user.name})" if SiteSetting.display_name_on_posts %> —
+       <%= "(#{post.user.name})" if (SiteSetting.display_name_on_posts && SiteSetting.enable_names?) %> —
        <%= post.created_at.to_formatted_s(:iso8601) %> —
        #<%= post.post_number %>
     </div>

--- a/app/views/topics/show.rss.erb
+++ b/app/views/topics/show.rss.erb
@@ -15,10 +15,10 @@
       <% next unless post.user %>
       <item>
         <title><%= @topic_view.title %></title>
-        <author><%= "no-reply@example.com (@#{post.user.username}#{" #{post.user.name}" if post.user.name.present?})" -%></author>
+        <author><%= "no-reply@example.com (@#{post.user.username}#{" #{post.user.name}" if (post.user.name.present? && SiteSetting.enable_names?)})" -%></author>
         <description><![CDATA[
           <% post_url = Discourse.base_url + post.url %>
-          <p><%= t('author_wrote', author: link_to(post.user.name, user_url(post.user.username_lower))).html_safe %></p>
+          <p><%= t('author_wrote', author: link_to("@#{post.user.username}", user_url(post.user.username_lower))).html_safe %></p>
           <blockquote>
             <% if post.hidden %>
               <%= t('flagging.user_must_edit').html_safe %>


### PR DESCRIPTION
...enables_names setting being disabled