### PR TITLE
FEATURE: unbind font awesome icon in share button

### DIFF
--- a/app/assets/javascripts/discourse/initializers/sharing-sources.js.es6
+++ b/app/assets/javascripts/discourse/initializers/sharing-sources.js.es6
@@ -14,7 +14,7 @@ export default {
 
     Sharing.addSource({
       id: 'twitter',
-      iconClass: 'fa-twitter-square',
+      faIcon: 'fa-twitter-square',
       generateUrl: function(link, title) {
         return "http://twitter.com/intent/tweet?url=" + encodeURIComponent(link) + "&text=" + encodeURIComponent(title);
       },
@@ -24,7 +24,7 @@ export default {
 
     Sharing.addSource({
       id: 'facebook',
-      iconClass: 'fa-facebook-square',
+      faIcon: 'fa-facebook-square',
       generateUrl: function(link, title) {
         return "http://www.facebook.com/sharer.php?u=" + encodeURIComponent(link) + '&t=' + encodeURIComponent(title);
       },
@@ -33,7 +33,7 @@ export default {
 
     Sharing.addSource({
       id: 'google+',
-      iconClass: 'fa-google-plus-square',
+      faIcon: 'fa-google-plus-square',
       generateUrl: function(link) {
         return "https://plus.google.com/share?url=" + encodeURIComponent(link);
       },
@@ -43,7 +43,7 @@ export default {
 
     Sharing.addSource({
       id: 'email',
-      iconClass: 'fa-envelope-square',
+      faIcon: 'fa-envelope-square',
       generateUrl: function(link, title) {
         return "mailto:?to=&subject=" + encodeURIComponent('[' + Discourse.SiteSettings.title + '] ' + title) + "&body=" + encodeURIComponent(link);
       }

--- a/app/assets/javascripts/discourse/lib/sharing.js.es6
+++ b/app/assets/javascripts/discourse/lib/sharing.js.es6
@@ -9,8 +9,10 @@
       // This id must be present in the `share_links` site setting too
       id: 'twitter',
 
-      // The icon that will be displayed
-      iconClass: 'fa-twitter-square',
+      // The icon that will be displayed, choose between font awesome class name `faIcon` and custom HTML `htmlIcon`.
+      // When both provided, prefer `faIcon`
+      faIcon: 'fa-twitter-square'
+      htmlIcon: '<img src="example.com/example.jpg">',
 
       // A callback for generating the remote link from the `link` and `title`
       generateUrl: function(link, title) {

--- a/app/assets/javascripts/discourse/templates/components/share-source.hbs
+++ b/app/assets/javascripts/discourse/templates/components/share-source.hbs
@@ -1,1 +1,7 @@
-<a href {{action "share" source}} {{bind-attr title="title"}}><i {{bind-attr class=":fa source.iconClass"}}></i></a>
+<a href {{action "share" source}} {{bind-attr title="title"}}>
+  {{#if source.faIcon}}
+    <i {{bind-attr class=":fa source.faIcon"}}></i>
+  {{else}}
+    {{{source.htmlIcon}}}
+  {{/if}}
+</a>

--- a/app/assets/javascripts/discourse/templates/share.hbs
+++ b/app/assets/javascripts/discourse/templates/share.hbs
@@ -6,7 +6,7 @@
   {{/if}}
 
   <div>
-    <input type='text' />
+    <input type='text'>
     <div class="share-for-touch"><div class="overflow-ellipsis"><a></a></div></div>
   </div>
 


### PR DESCRIPTION
- extract font awesome class from share link
- add another share services

PS: `<input>` is a void element which doesn't need to close itself in HTML5. So I removed it.