### PR TITLE
FIX: Loading of Emoji files depended on working directory

### DIFF
--- a/app/models/emoji.rb
+++ b/app/models/emoji.rb
@@ -65,7 +65,7 @@ class Emoji
   end
 
   def self.db_file
-    "lib/emoji/db.json"
+    "#{Rails.root}/lib/emoji/db.json"
   end
 
   def self.load_standard

--- a/lib/pretty_text.rb
+++ b/lib/pretty_text.rb
@@ -75,14 +75,14 @@ module PrettyText
       "app/assets/javascripts/discourse/lib/markdown.js"
     )
 
-    Dir["#{Rails.root}/app/assets/javascripts/discourse/dialects/**.js"].sort.each do |dialect|
+    Dir["#{app_root}/app/assets/javascripts/discourse/dialects/**.js"].sort.each do |dialect|
       unless dialect =~ /\/dialect\.js$/
         ctx.load(dialect)
       end
     end
 
     # custom emojis
-    emoji = ERB.new(File.read("app/assets/javascripts/discourse/lib/emoji/emoji.js.erb"))
+    emoji = ERB.new(File.read("#{app_root}/app/assets/javascripts/discourse/lib/emoji/emoji.js.erb"))
     ctx.eval(emoji.result)
 
     Emoji.custom.each do |emoji|


### PR DESCRIPTION
The importer scripts could not be used unless the working directory was the Discourse root directory.