### PR TITLE
Latest posts endpoint at /posts.json

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -155,7 +155,7 @@ class ApplicationController < ActionController::Base
   # If we are rendering HTML, preload the session data
   def preload_json
     # We don't preload JSON on xhr or JSON request
-    return if request.xhr?
+    return if request.xhr? || request.format.json?
 
     preload_anonymous_data
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -26,8 +26,14 @@ class PostsController < ApplicationController
   end
 
   def latest
+    params.permit(:before)
+    last_post_id = params[:before].to_i
+    last_post_id = Post.last.id if last_post_id <= 0
+
+    # last 50 post IDs only, to avoid counting deleted posts in security check
     posts = Post.order(created_at: :desc)
-                .where('posts.id > ?', Post.last.id - 50) # last 50 post IDs only, to avoid counting deleted posts in security check
+                .where('posts.id <= ?', last_post_id)
+                .where('posts.id > ?', last_post_id - 50)
                 .includes(topic: :category)
                 .includes(:user)
                 .limit(50)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -269,6 +269,7 @@ Discourse::Application.routes.draw do
   get "uploads/:site/:sha" => "uploads#show", constraints: { site: /\w+/, sha: /[a-z0-9]{40}/}
   post "uploads" => "uploads#create"
 
+  get "posts" => "posts#latest"
   get "posts/by_number/:topic_id/:post_number" => "posts#by_number"
   get "posts/:id/reply-history" => "posts#reply_history"
   get "posts/:username/deleted" => "posts#deleted_posts", constraints: {username: USERNAME_ROUTE_FORMAT}


### PR DESCRIPTION
It will return the posts with the **last 50 ids**, in order, with posts you can't see filtered out. You can attach a `?before=5678` to only see post IDs 5629 thru 5678. With that scheme, it should be fairly easy to make sure your service sees every post it has access to, even if more than 50 posts occur between two checks.

I think this will satisfy several people's needs for an extensibility point. If they need message bus notifications, I think we could do that too.