### PR TITLE
sso_secret: cryptographically authenticate, not encrypt.

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -783,7 +783,7 @@ en:
     enable_sso: "Enable single sign on via an external site (WARNING: can prevent anyone from logging in if not properly configured when enabled; also disables invites)"
     enable_sso_provider: "Implement Discourse SSO protocol at the /session/sso_provider endpoint, requires sso_secret to be set"
     sso_url: "URL of single sign on endpoint"
-    sso_secret: "Secret string used to encrypt/decrypt SSO information, be sure it is 10 chars or longer"
+    sso_secret: "Secret string used to cryptographically authenticate SSO information, be sure it is 10 characters or longer"
     sso_overrides_email: "Overrides local email with external site email from SSO payload (WARNING: discrepancies can occur due to normalization of local emails)"
     sso_overrides_username: "Overrides local username with external site username from SSO payload (WARNING: discrepancies can occur due to differences in username length/requirements)"
     sso_overrides_name: "Overrides local name with external site name from SSO payload (WARNING: discrepancies can occur due to normalization of local names)"


### PR DESCRIPTION
The sso_secret is an input to HMAC, which is a hash-based message authentication code, not encryption.  Perhaps this is a minor nitpick, but I think it's important to get concepts and language correct when it comes to cryptography.  I noticed this in the screenshot at https://meta.discourse.org/t/official-single-sign-on-for-discourse/13045

This PR corrects the English phrase, but I'm not sure what the process is to get those translations updated.