### PR TITLE
Perf UX : reduce page paint on scrolling, due to fixed header element union with progress bar area

### DIFF
--- a/app/assets/stylesheets/common/base/header.scss
+++ b/app/assets/stylesheets/common/base/header.scss
@@ -8,6 +8,7 @@
 
     .docked & {
       position: fixed;
+      backface-visibility: hidden;  /** do magic for scrolling performance **/
     }
 
     .contents {


### PR DESCRIPTION
Should provide some performance improvement for scrolling on chrome
The fixed header and the fixed progress bar on both ends  of the screen will invoke a complete visible page redraw.

For whatever reason this css should make things better for low performance devices. only tested on chrome superficially.