### PR TITLE
FIX: creating a user shouldn't error when optional fields aren't given

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -213,20 +213,19 @@ class UsersController < ApplicationController
     # Handle custom fields
     user_fields = UserField.all
     if user_fields.present?
-      if params[:user_fields].blank? && UserField.where(required: true).exists?
-        return fail_with("login.missing_user_field")
-      else
-        fields = user.custom_fields
-        user_fields.each do |f|
-          field_val = params[:user_fields][f.id.to_s]
-          if field_val.blank?
-            return fail_with("login.missing_user_field") if f.required?
-          else
-            fields["user_field_#{f.id}"] = field_val
-          end
+      field_params = params[:user_fields] || {}
+      fields = user.custom_fields
+
+      user_fields.each do |f|
+        field_val = field_params[f.id.to_s]
+        if field_val.blank?
+          return fail_with("login.missing_user_field") if f.required?
+        else
+          fields["user_field_#{f.id}"] = field_val
         end
-        user.custom_fields = fields
       end
+
+      user.custom_fields = fields
     end
 
     authentication = UserAuthenticator.new(user, session)

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -604,6 +604,28 @@ describe UsersController do
       end
     end
 
+    context "with only optional custom fields" do
+      let!(:user_field) { Fabricate(:user_field, required: false) }
+
+      context "without values for the fields" do
+        let(:create_params) { {
+          name: @user.name,
+          password: 'watwatwat',
+          username: @user.username,
+          email: @user.email,
+        } }
+
+        it "should succeed" do
+          xhr :post, :create, create_params
+          expect(response).to be_success
+          inserted = User.where(email: @user.email).first
+          expect(inserted).to be_present
+          expect(inserted.custom_fields).not_to be_present
+          expect(inserted.custom_fields["user_field_#{user_field.id}"]).to be_blank
+        end
+      end
+    end
+
   end
 
   context '.username' do


### PR DESCRIPTION
This fixes a bug where the server would 500 if the only user fields
where optional ones, and the create_user call didn't provide any
values so that `params[:user_fields]` was nil.

Additionally, don't bother double-checking for required fields, since we
iterate over all fields and will catch any that are required and blank.