### PR TITLE
simple change that grants a bit more flexibility to the category and title in the topic list

### DIFF
--- a/app/assets/stylesheets/desktop/topic-list.scss
+++ b/app/assets/stylesheets/desktop/topic-list.scss
@@ -85,9 +85,6 @@
       padding-left: 5px;
     }
   }
-  .main-link {
-    width: 495px;
-  }
 
   .badge-notification {
     position: relative;


### PR DESCRIPTION
As discussed here: https://meta.discourse.org/t/the-end-of-clown-vomit-or-simplified-category-styles/24249/123

