### PR TITLE
Fix: Resize event does not get cleared/unbind properly due to wrong usage of jQuery api.

### DIFF
--- a/app/assets/javascripts/discourse/views/topic.js.es6
+++ b/app/assets/javascripts/discourse/views/topic.js.es6
@@ -40,7 +40,7 @@ var TopicView = Discourse.View.extend(AddCategoryClass, Discourse.Scrolling, {
     this.bindScrolling({name: 'topic-view'});
 
     var self = this;
-    $(window).resize('resize.discourse-on-scroll', function() {
+    $(window).on('resize.discourse-on-scroll', function() {
       self.scrolled();
     });
 


### PR DESCRIPTION
...ong usage of jQuery api.

An handler get added each time a topic is loaded to the window object

jQuery resize api only pass data to the handler when triggered.
```.resize( [eventData ], handler ) ```

The unbind followed in willDestroyElement had no affect. 

.on(...) or bind(..) support the event.namespace

fix was tested.