### PR TITLE
PERF: Add indexes for post & user count, UserStat

### DIFF
--- a/db/migrate/20150131150032_add_missing_indexes.rb
+++ b/db/migrate/20150131150032_add_missing_indexes.rb
@@ -1,0 +1,8 @@
+class AddMissingIndexes < ActiveRecord::Migration
+  def change
+    add_index :user_stats, :user_id
+    add_index :users, :id, unique: true
+    execute "DROP INDEX IF EXISTS idx_posts_created_at_topic_id"
+    add_index :posts, [:created_at, :topic_id, :deleted_at]
+  end
+end


### PR DESCRIPTION
This was crippling performance on /about. Also, user_stat had no indexes, and it is in the critical first-render path.

See:

https://meta.discourse.org/t/about-page-slow-menu-slow-to-disapear/24635
https://meta.discourse.org/t/lets-find-missing-sql-indexes/24652


Queries:

```
SELECT COUNT(*) FROM "posts"  WHERE ("posts"."deleted_at" IS NULL)
SELECT COUNT(*) FROM "users"
SELECT COUNT(*) FROM "users"  WHERE (created_at > '2015-01-24 13:36:48.665697') -- Not addressed in this patch
SELECT COUNT(*) FROM "users"  WHERE (id > 0)
SELECT COUNT(*) FROM "posts" INNER JOIN "topics" ON "topics"."id" = "posts"."topic_id" AND ("topics"."deleted_at" IS NULL) WHERE ("posts"."deleted_at" IS NULL) AND (topics.archetype <> 'private_message')
( load user stat given user id )
```

```
( Rollback )
discourse_development=# VACUUM ANALYZE;
VACUUM
discourse_development=# EXPLAIN SELECT COUNT(*) FROM "posts"  WHERE ("posts"."deleted_at" IS NULL);
                            QUERY PLAN                             
-------------------------------------------------------------------
 Aggregate  (cost=15526.86..15526.87 rows=1 width=0)
   ->  Seq Scan on posts  (cost=0.00..15291.20 rows=94262 width=0)
         Filter: (deleted_at IS NULL)
(3 rows)

discourse_development=# EXPLAIN SELECT COUNT(*) FROM "users"  WHERE (id > 0);
                                        QUERY PLAN                                        
------------------------------------------------------------------------------------------
 Aggregate  (cost=1874.79..1874.80 rows=1 width=0)
   ->  Index Only Scan using users_pkey on users  (cost=0.29..1784.48 rows=36125 width=0)
         Index Cond: (id > 0)
(3 rows)

discourse_development=# EXPLAIN SELECT COUNT(*) FROM "posts" INNER JOIN "topics" ON "topics"."id" = "posts"."topic_id" AND ("topics"."deleted_at" IS NULL) WHERE ("posts"."deleted_at" IS NULL) AND (topics.archetype <> 'private_message');
                                                   QUERY PLAN                                                   
----------------------------------------------------------------------------------------------------------------
 Aggregate  (cost=16610.13..16610.14 rows=1 width=0)
   ->  Hash Join  (cost=179.94..16453.03 rows=62841 width=0)
         Hash Cond: (posts.topic_id = topics.id)
         ->  Seq Scan on posts  (cost=0.00..15291.20 rows=94262 width=4)
               Filter: (deleted_at IS NULL)
         ->  Hash  (cost=162.26..162.26 rows=1414 width=4)
               ->  Index Only Scan using idx_topics_front_page on topics  (cost=0.28..162.26 rows=1414 width=4)
                     Index Cond: (deleted_at IS NULL)
                     Filter: ((archetype)::text <> 'private_message'::text)
(9 rows)
```

```
( Migrate )
discourse_development=# VACUUM ANALYZE;
VACUUM
discourse_development=# EXPLAIN SELECT COUNT(*) FROM "posts"  WHERE ("posts"."deleted_at" IS NULL);
                                                             QUERY PLAN                                                              
-------------------------------------------------------------------------------------------------------------------------------------
 Aggregate  (cost=3799.34..3799.35 rows=1 width=0)
   ->  Index Only Scan using index_posts_on_created_at_and_topic_id_and_deleted_at on posts  (cost=0.42..3563.49 rows=94342 width=0)
         Index Cond: (deleted_at IS NULL)
(3 rows)

discourse_development=# EXPLAIN SELECT COUNT(*) FROM "users"  WHERE (id > 0);
                                           QUERY PLAN                                            
-------------------------------------------------------------------------------------------------
 Aggregate  (cost=1126.79..1126.80 rows=1 width=0)
   ->  Index Only Scan using index_users_on_id on users  (cost=0.29..1036.48 rows=36125 width=0)
         Index Cond: (id > 0)
(3 rows)

discourse_development=# EXPLAIN SELECT COUNT(*) FROM "posts" INNER JOIN "topics" ON "topics"."id" = "posts"."topic_id" AND ("topics"."deleted_at" IS NULL) WHERE ("posts"."deleted_at" IS NULL) AND (topics.archetype <> 'private_message');
                                                                QUERY PLAN                                                                 
-------------------------------------------------------------------------------------------------------------------------------------------
 Aggregate  (cost=4883.39..4883.40 rows=1 width=0)
   ->  Hash Join  (cost=180.35..4726.15 rows=62895 width=0)
         Hash Cond: (posts.topic_id = topics.id)
         ->  Index Only Scan using index_posts_on_created_at_and_topic_id_and_deleted_at on posts  (cost=0.42..3563.49 rows=94342 width=4)
               Index Cond: (deleted_at IS NULL)
         ->  Hash  (cost=162.26..162.26 rows=1414 width=4)
               ->  Index Only Scan using idx_topics_front_page on topics  (cost=0.28..162.26 rows=1414 width=4)
                     Index Cond: (deleted_at IS NULL)
                     Filter: ((archetype)::text <> 'private_message'::text)
(9 rows)

```