### PR TITLE
FIX: Toggling staff color on a post doesn’t change button text

### DIFF
--- a/app/assets/javascripts/discourse/views/post-menu.js.es6
+++ b/app/assets/javascripts/discourse/views/post-menu.js.es6
@@ -57,6 +57,7 @@ export default Discourse.View.extend(StringBuffer, {
     'post.topic.deleted_at',
     'post.replies.length',
     'post.wiki',
+    'post.post_type',
     'collapsed'],
 
   _collapsedByDefault: function() {


### PR DESCRIPTION
This PR fixes the "text not changing for button when adding staff color" issue (this was affecting all users: TL4, Mod-only, Admin-only and Mod+Admin).

Edit: "Not allow TL4 user to set staff color" issue is a WIP. But this PR is safe to merge.