### PR TITLE
update meta url

### DIFF
--- a/docs/INSTALL-digital-ocean.md
+++ b/docs/INSTALL-digital-ocean.md
@@ -7,7 +7,7 @@
 - Enter your domain `discourse.example.com` as the Droplet name.
 
 - The default of **1GB** RAM works fine for small Discourse communities. We do recommend 2 GB RAM for medium communities.
- 
+
 - The default of **Ubuntu 14.04 LTS x64** works fine. Always select the latest 64-bit [LTS distribution][lts].
 
 Create your new Droplet. You will receive a mail from Digital Ocean with the root password to your Droplet. (However, if you know [how to use SSH keys](https://www.google.com/search?q=digitalocean+ssh+keys), you may not need a password to log in.)
@@ -168,7 +168,7 @@ If anything needs to be improved in this guide, feel free to ask on [meta.discou
    [dd]: https://github.com/discourse/discourse_docker
   [man]: https://mandrillapp.com
   [ssh]: https://help.github.com/articles/generating-ssh-keys
- [meta]: https://meta.discourse.org/t/beginners-guide-to-deploy-discourse-on-digital-ocean-using-docker/12156
+ [meta]: https://meta.discourse.org
    [do]: https://www.digitalocean.com/?refcode=5fa48ac82415
   [lts]: https://wiki.ubuntu.com/LTS
   [jet]: http://www.mailjet.com/pricing


### PR DESCRIPTION
Since the original DO install guide is deleted on meta, updated the link to meta home page.