### PR TITLE
FIX: uncategorized category was not loading updates in edit mode

### DIFF
--- a/app/assets/javascripts/discourse/routes/application.js.es6
+++ b/app/assets/javascripts/discourse/routes/application.js.es6
@@ -132,18 +132,13 @@ var ApplicationRoute = Discourse.Route.extend({
     },
 
     editCategory: function(category) {
-      var router = this;
+      var self = this;
 
-      if (category.get('isUncategorizedCategory')) {
-        Discourse.Route.showModal(router, 'editCategory', category);
-        router.controllerFor('editCategory').set('selectedTab', 'general');
-      } else {
-        Discourse.Category.reloadById(category.get('id')).then(function (c) {
-          Discourse.Site.current().updateCategory(c);
-          Discourse.Route.showModal(router, 'editCategory', c);
-          router.controllerFor('editCategory').set('selectedTab', 'general');
-        });
-      }
+      Discourse.Category.reloadById(category.get('id')).then(function (c) {
+        self.site.updateCategory(c);
+        Discourse.Route.showModal(self, 'editCategory', c);
+        self.controllerFor('editCategory').set('selectedTab', 'general');
+      });
     },
 
     /**


### PR DESCRIPTION
Bug originally reported [here](https://meta.discourse.org/t/creating-topics-by-email-to-users-rust-lang-org-or-internals-rust-lang-org-fails-with-email-issue-unknown-to-address/24595?u=techapj).

This bug was affecting all the fields in the `Settings` tab for "uncategorized" category. The fields were not showing as updated when opening in edit mode.