### PR TITLE
Removes warning about "already initialized constant"

### DIFF
--- a/lib/rate_limiter.rb
+++ b/lib/rate_limiter.rb
@@ -4,7 +4,7 @@ require_dependency 'rate_limiter/on_create_record'
 # A redis backed rate limiter.
 class RateLimiter
 
-  KEY_PREFIX = "l-rate-limit:"
+  KEY_PREFIX = "l-rate-limit:" unless defined? KEY_PREFIX
 
   def self.disable
     @disabled = true


### PR DESCRIPTION
I always get the following warning since 6e862e0

```
/discourse/lib/rate_limiter.rb:7: warning: already initialized constant RateLimiter::KEY_PREFIX
/discourse/lib/rate_limiter.rb:7: warning: previous definition of KEY_PREFIX was here
```

This fixes it.