### PR TITLE
FIX: URL encoding was not working for %23 in links

### DIFF
--- a/app/assets/javascripts/discourse/lib/Markdown.Editor.js
+++ b/app/assets/javascripts/discourse/lib/Markdown.Editor.js
@@ -1676,7 +1676,7 @@
                 return querypart.replace(/\+/g, " "); // in the query string, a plus and a space are identical
             });
             link = decodeURIComponent(link); // unencode first, to prevent double encoding
-            link = encodeURI(link).replace(/'/g, '%27').replace(/\(/g, '%28').replace(/\)/g, '%29');
+            link = encodeURI(link).replace(/#/g, '%23').replace(/'/g, '%27').replace(/\(/g, '%28').replace(/\)/g, '%29');
             link = link.replace(/\?.*$/, function (querypart) {
                 return querypart.replace(/\+/g, "%2b"); // since we replaced plus with spaces in the query part, all pluses that now appear where originally encoded
             });


### PR DESCRIPTION
Fixes [this issue](https://meta.discourse.org/t/link-with-23-getting-converted/15329?u=techapj)
