### PR TITLE
FEATURE: Mentions stream on user profile

### DIFF
--- a/app/assets/javascripts/discourse/models/user_action_stat.js
+++ b/app/assets/javascripts/discourse/models/user_action_stat.js
@@ -19,7 +19,6 @@ Discourse.UserActionStat = Discourse.Model.extend({
   isResponse: function() {
     var actionType = this.get('action_type');
     return actionType === Discourse.UserAction.TYPES.replies ||
-           actionType === Discourse.UserAction.TYPES.mentions ||
            actionType === Discourse.UserAction.TYPES.quotes;
   }.property('action_type')
 

--- a/app/assets/javascripts/discourse/models/user_stream.js
+++ b/app/assets/javascripts/discourse/models/user_stream.js
@@ -20,7 +20,6 @@ Discourse.UserStream = Discourse.Model.extend({
     var filter = this.get('filter');
     if (filter === Discourse.UserAction.TYPES.replies) {
       return [Discourse.UserAction.TYPES.replies,
-              Discourse.UserAction.TYPES.mentions,
               Discourse.UserAction.TYPES.quotes].join(",");
     }
 

--- a/app/assets/javascripts/discourse/routes/user-activity-mentions.js.es6
+++ b/app/assets/javascripts/discourse/routes/user-activity-mentions.js.es6
@@ -1,0 +1,5 @@
+import UserActivityStreamRoute from "discourse/routes/user-activity-stream";
+
+export default UserActivityStreamRoute.extend({
+  userActionType: Discourse.UserAction.TYPES["mentions"]
+});

--- a/app/assets/javascripts/discourse/views/activity-filter.js.es6
+++ b/app/assets/javascripts/discourse/views/activity-filter.js.es6
@@ -54,6 +54,7 @@ export default Ember.Component.extend(StringBuffer, {
       case Discourse.UserAction.TYPES.bookmarks: return "bookmark";
       case Discourse.UserAction.TYPES.edits: return "pencil";
       case Discourse.UserAction.TYPES.replies: return "reply";
+      case Discourse.UserAction.TYPES.mentions: return "at";
     }
   }.property("content.action_type")
 });


### PR DESCRIPTION
Meta: https://meta.discourse.org/t/mention-noise-central-dashboard/24755/

We need to upgrade font awesome, because current has `fa-at` and we can use that instead of a literal `@` in the notifications menu. Remember to remove the diff I added here in user.scss when that happens.

Desktop
> <img src="https://meta.discourse.org/uploads/default/38559/de5d904a618fe518.png" width="588" height="351"> 

Mobile
> <img src="https://meta.discourse.org/uploads/default/38558/51638dcbccff770d.png" width="690" height="160">  