### PR TITLE
FIX: check for full name in invite email subject

### DIFF
--- a/app/mailers/invite_mailer.rb
+++ b/app/mailers/invite_mailer.rb
@@ -9,7 +9,7 @@ class InviteMailer < ActionMailer::Base
 
     # get invitee name (based on site setting)
     invitee_name = invite.invited_by.username
-    if (SiteSetting.enable_names)
+    if SiteSetting.enable_names && invite.invited_by.name.present?
       invitee_name = "#{invite.invited_by.name} (#{invite.invited_by.username})"
     end
 


### PR DESCRIPTION
If the user has not provided full name, the invite email is being sent out with subject:

`(techapj) invited you to join discourse.example.com`

instead, it should be:

`techapj invited you to join discourse.example.com`