### PR TITLE
FIX: Allow closing polls in multi-locale sites

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -147,8 +147,8 @@ class ApplicationController < ActionController::Base
   end
 
   def set_locale
-    I18n.locale = if SiteSetting.allow_user_locale && current_user && current_user.locale.present?
-                    current_user.locale
+    I18n.locale = if current_user
+                    current_user.effective_locale
                   else
                     SiteSetting.default_locale
                   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -138,6 +138,14 @@ class User < ActiveRecord::Base
     User.where(username_lower: lower).blank?
   end
 
+  def effective_locale
+    if SiteSetting.allow_user_locale && self.locale.present?
+      self.locale
+    else
+      SiteSetting.default_locale
+    end
+  end
+
   EMAIL = %r{([^@]+)@([^\.]+)}
 
   def self.new_from_params(params)

--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -118,11 +118,7 @@ class PostAlerter
     if collapsed
       post = first_unread_post(user,post.topic) || post
       count = unread_count(user, post.topic)
-      I18n.with_locale(if SiteSetting.allow_user_locale && user.locale.present?
-                         user.locale
-                       else
-                         SiteSetting.default_locale
-                       end) do
+      I18n.with_locale(user.effective_locale) do
         opts[:display_username] = I18n.t('embed.replies', count: count) if count > 1
       end
     end

--- a/plugins/poll/README.md
+++ b/plugins/poll/README.md
@@ -9,7 +9,7 @@ Allows you to add a poll to the first post of a topic.
 
 ## Closing the poll
 
-Change the start of the topic title from "Poll: " to "Closed Poll: ". This feature is disabled if the `allow_user_locale` site setting is enabled.
+Change the start of the topic title from "Poll: " to "Closed Poll: ". This feature uses the locale of the user who started the topic.
 
 _Note: closing a topic will also close the poll._
 

--- a/plugins/poll/assets/javascripts/controllers/poll.js.es6
+++ b/plugins/poll/assets/javascripts/controllers/poll.js.es6
@@ -5,7 +5,7 @@ export default DiscourseController.extend({
   showResults: Em.computed.oneWay('poll.closed'),
   disableRadio: Em.computed.any('poll.closed', 'loading'),
   showToggleClosePoll: function() {
-    return this.get('poll.post.topic.details.can_edit') && !Discourse.SiteSettings.allow_user_locale;
+    return this.get('poll.post.topic.details.can_edit');
   }.property('poll.post.topic.details.can_edit'),
 
   actions: {

--- a/plugins/poll/plugin.rb
+++ b/plugins/poll/plugin.rb
@@ -80,10 +80,12 @@ after_initialize do
         end
 
         # Modify topic title.
-        if topic.title =~ /^(#{I18n.t('poll.prefix').strip})\s?:/i
-          topic.title = topic.title.gsub(/^(#{I18n.t('poll.prefix').strip})\s?:/i, I18n.t('poll.closed_prefix') + ':')
-        elsif topic.title =~ /^(#{I18n.t('poll.closed_prefix').strip})\s?:/i
-          topic.title = topic.title.gsub(/^(#{I18n.t('poll.closed_prefix').strip})\s?:/i, I18n.t('poll.prefix') + ':')
+        I18n.with_locale(topic.user.effective_locale) do
+          if topic.title =~ /^(#{I18n.t('poll.prefix').strip})\s?:/i
+            topic.title = topic.title.gsub(/^(#{I18n.t('poll.prefix').strip})\s?:/i, I18n.t('poll.closed_prefix') + ':')
+          elsif topic.title =~ /^(#{I18n.t('poll.closed_prefix').strip})\s?:/i
+            topic.title = topic.title.gsub(/^(#{I18n.t('poll.closed_prefix').strip})\s?:/i, I18n.t('poll.prefix') + ':')
+          end
         end
 
         topic.acting_user = current_user


### PR DESCRIPTION
Meta: https://meta.discourse.org/t/polls-cannot-be-closed-if-allow-user-locale-is-enabled/24247

Screenshot (English interface, russian closed poll) 

![](http://what.thedailywtf.com/uploads/default/14292/5c4a13f27c2e3bb1.png)