### PR TITLE
FIX: Remove g and m flags from autolink regex

### DIFF
--- a/app/assets/javascripts/discourse/dialects/autolink_dialect.js
+++ b/app/assets/javascripts/discourse/dialects/autolink_dialect.js
@@ -3,7 +3,7 @@
   a hrefs for them.
 **/
 var urlReplacerArgs = {
-  matcher: /^((?:https?:(?:\/{1,3}|[a-z0-9%])|www\d{0,3}[.])(?:[^\s()<>]+|\([^\s()<>]+\))+(?:\([^\s()<>]+\)|[^`!()\[\]{};:'".,<>?«»“”‘’\s]))/gm,
+  matcher: /^((?:https?:(?:\/{1,3}|[a-z0-9%])|www\d{0,3}[.])(?:[^\s()<>]+|\([^\s()<>]+\))+(?:\([^\s()<>]+\)|[^`!()\[\]{};:'".,<>?«»“”‘’\s]))/,
   spaceOrTagBoundary: true,
 
   emitter: function(matches) {


### PR DESCRIPTION
Fixes issue where a non-link is falsely identified as a link and given the link text of a later link.

More info in thread: https://meta.discourse.org/t/http-gets-parsed-incorrectly-in-posts/24866

The `g` and `m` flags together caused the above case. How this regex works, there isn't any reason to use `g` as the regex should match at the start of the given text being tested, and for `m` that is for matching across lines, and links are not valid with multiple lines.