### PR TITLE
updating the composer category selector style

### DIFF
--- a/app/assets/stylesheets/common/base/combobox.scss
+++ b/app/assets/stylesheets/common/base/combobox.scss
@@ -1,4 +1,5 @@
 .category-combobox, .select2-drop {
+
   .badge-category {
     display: inline-block;
   }
@@ -11,10 +12,48 @@
     color: $primary;
   }
   .category-desc {
-    /* leave this color as non-variable -- it is displayed on a white background in a dropdown */
-    color: #333;
+    color: $primary;
     margin: 6px 0 0 3px;
     font-size: 0.857em;
     line-height: 16px;
   }
+}
+
+.select2-drop {
+  background: $secondary;
+}
+
+.select2-search input {
+  background: url(/assets/select2.png) no-repeat 100% -22px, $secondary 0 0
+}
+
+.select2-container {
+  border-radius: 3px;
+}
+
+.select2-container a.select2-choice {
+  background: $secondary;
+  border-radius: 3px;
+  border-color: $secondary;
+  color: $primary;
+}
+
+.select2-dropdown-open a.select2-choice {
+  box-shadow: none;
+  border-radius: 3px 3px 0 0;
+  border-color: $tertiary;
+}
+
+.select2-drop-active {
+  border: 1px solid $tertiary;
+  border-top: 0;
+}
+
+.select2-container-active {
+  box-shadow:  $tertiary 0px 0px 6px 0px;
+}
+
+.select2-results .select2-no-results, .select2-results .select2-searching, .select2-results .select2-selection-limit {
+  background: $secondary;
+  color: $primary;
 }


### PR DESCRIPTION
Updating select2 dropdown styles on composer to work with dark themes

discussed here: https://meta.discourse.org/t/dark-color-theme-categories-selection-unusable/24879

![screenshot 2015-02-07 23 24 53](https://cloud.githubusercontent.com/assets/1681963/6095245/559eddf0-af20-11e4-862f-f5ad5e08f0c0.png)

:telescope: :crocodile: 