### PR TITLE
FIX: Ember regression in read-only banner

### DIFF
--- a/app/assets/javascripts/discourse/initializers/read-only.js.es6
+++ b/app/assets/javascripts/discourse/initializers/read-only.js.es6
@@ -10,7 +10,7 @@ export default {
 
     var site = container.lookup('site:main');
     Discourse.MessageBus.subscribe("/site/read-only", function (enabled) {
-      site.currentProp('isReadOnly', enabled);
+      site.set('isReadOnly', enabled);
     });
   }
 };


### PR DESCRIPTION
Caused by https://github.com/discourse/discourse/commit/e1826e30