### PR TITLE
Consolidate custom exception handling

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -93,14 +93,14 @@ class ApplicationController < ActionController::Base
       time_left = I18n.t("rate_limiter.hours", count: (e.available_in / 1.hour.to_i))
     end
 
-    render_json_error I18n.t("rate_limiter.too_many_requests", time_left: time_left), 'rate_limit', 429
+    render_json_error I18n.t("rate_limiter.too_many_requests", time_left: time_left), :rate_limit, 429
   end
 
   rescue_from Discourse::NotLoggedIn do |e|
     raise e if Rails.env.test?
 
     if (request.format && request.format.json?) || request.xhr? || !request.get?
-      rescue_discourse_actions('not_logged_in', 403, true)
+      rescue_discourse_actions(:not_logged_in, 403, true)
     else
       redirect_to "/"
     end
@@ -108,15 +108,15 @@ class ApplicationController < ActionController::Base
   end
 
   rescue_from Discourse::NotFound do
-    rescue_discourse_actions('not_found', 404)
+    rescue_discourse_actions(:not_found, 404)
   end
 
   rescue_from Discourse::InvalidAccess do
-    rescue_discourse_actions('invalid_access', 403, true)
+    rescue_discourse_actions(:invalid_access, 403, true)
   end
 
   rescue_from Discourse::ReadOnly do
-    render_json_error I18n.t('read_only_mode_enabled'), 'read_only', 405
+    render_json_error I18n.t('read_only_mode_enabled'), :read_only, 405
   end
 
   def rescue_discourse_actions(type, status_code, include_ember=false)

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -118,6 +118,8 @@ en:
     not_enough_space_on_disk: "There is not enough space on disk to upload this backup."
 
   not_logged_in: "You need to be logged in to do that."
+  not_found: "The requested URL or resource could not be found."
+  invalid_access: "You are not permitted to view the requested resource."
   read_only_mode_enabled: "The site is in read only mode. Interactions are disabled."
 
   too_many_replies:

--- a/lib/json_error.rb
+++ b/lib/json_error.rb
@@ -1,6 +1,14 @@
 module JsonError
 
-  def create_errors_json(obj)
+  def create_errors_json(obj, type=nil)
+    errors = create_errors_array obj
+    errors[:error_type] = type if type
+    errors
+  end
+
+  private
+
+  def create_errors_array(obj)
 
     # If we're passed a string, assume that is the error message
     return {errors: [obj]} if obj.is_a?(String)
@@ -21,10 +29,8 @@ module JsonError
     JsonError.generic_error
   end
 
-  private
-
-    def self.generic_error
-      {errors: [I18n.t('js.generic_error')]}
-    end
+  def self.generic_error
+    {errors: [I18n.t('js.generic_error')]}
+  end
 
 end


### PR DESCRIPTION
This PR started from the following goals:

 - If a client requests JSON, they should get JSON; never something that looks 'pretty close'.
 - Do NOT break existing code. It just so happens that in the majority of cases, none of the code was looking at this stuff.
    - This resulted in a few notable things: the "BAD CSRF" return is not changed, and `rescue_discourse_actions` has a hack to keep behavior for `TopicsController#show`.
 - Errors should be machine-parsable as well as human-readable. If the error is translated, that ruins machine parsing.
 - The client-side error handling is pretty terrible. This commit is one of the building blocks towards improving it.

### Overview

HTML is no longer stuffed into the response for a JSON request except when the client is expecting that.

The standard errors are now machine-parsable, and gained translations.

### Details

The new "standard" error json response now looks like this:

```
{
  errors: ["Human-Readable text", "More human text"]
  error_type: 'rate_limit'
}
```

It is both compatible with the old format ("`errors` is an array of strings") and more machine-readable due to the new error_type field.

`render_json_error` takes a second parameter, `type`, which is placed in the response as `error_type`.

The following exceptions now conform to this standard format: `RateLimiter::LimitExceeded`, `Discourse::NotLoggedIn`, `Discourse::NotFound`, `Discourse::InvalidAccess`, `Discourse::ReadOnly`.

Discourse::NotLoggedIn got a behavior change - if the request is JSON or an XHR, (in addition to the previous "not a GET" condition) it returns an error instead of redirecting to the root page.

Discourse::NotFound and Discourse::InvalidAccess also got a behavior change. *If it was not raised by TopicsController#show*, and the request is a XHR or json request, it returns a JSON error instead of returning HTML.

When the client requests `TopicsController#show`, however, it expects the 404 page body to be returned if the topic doesn't exist. To minimize the chance of breakage, that behavior is placed in `rescue_discourse_actions`.