### PR TITLE
Fix customize HTML/CSS only show desktop code

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -284,9 +284,10 @@ class ApplicationController < ActionController::Base
     end
 
     def custom_html_json
+      target = view_context.mobile_view? ? :mobile : :desktop
       data = {
-        top: SiteCustomization.custom_top(session[:preview_style]),
-        footer: SiteCustomization.custom_footer(session[:preview_style])
+        top: SiteCustomization.custom_top(session[:preview_style], target),
+        footer: SiteCustomization.custom_footer(session[:preview_style], target)
       }
 
       if DiscoursePluginRegistry.custom_html


### PR DESCRIPTION
custom_top and custom_footer method in SiteCustomization is setting
:desktop as default argument for `target`

It output the desktop version of the custom_top, custom_footer even
user in mobile_view.

This fix is adding the missing target into method argument.

I believe this will fix [his](https://meta.discourse.org/t/best-way-to-customize-the-header/13368/14) issue.