### PR TITLE
FIX: Links to URLs not in the Ember router now work

### DIFF
--- a/app/assets/javascripts/discourse.js
+++ b/app/assets/javascripts/discourse.js
@@ -120,10 +120,14 @@ window.Discourse = Ember.Application.createWithMixins(Discourse.Ajax, {
 
   },
 
-  requiresRefresh: function(){
+  requestRefresh: function() {
+    this.set("refreshRequested", true);
+  },
+
+  requiresRefresh: function() {
     var desired = Discourse.get("desiredAssetVersion");
-    return desired && Discourse.get("currentAssetVersion") !== desired;
-  }.property("currentAssetVersion", "desiredAssetVersion"),
+    return this.get("refreshRequested") || (desired && Discourse.get("currentAssetVersion") !== desired);
+  }.property("currentAssetVersion", "desiredAssetVersion", "refreshRequested"),
 
   assetVersion: function(prop, val) {
     if(val) {

--- a/app/assets/javascripts/discourse/mixins/ajax.js
+++ b/app/assets/javascripts/discourse/mixins/ajax.js
@@ -54,8 +54,8 @@ Discourse.Ajax = Em.Mixin.create({
         args.headers = { 'Discourse-Track-View': true };
       }
 
-      args.success = function(xhr) {
-        Ember.run(null, resolve, xhr);
+      args.success = function(response) {
+        Ember.run(null, resolve, response);
       };
 
       args.error = function(xhr, textStatus) {

--- a/app/assets/javascripts/discourse/routes/unknown.js.es6
+++ b/app/assets/javascripts/discourse/routes/unknown.js.es6
@@ -1,5 +1,14 @@
 export default Discourse.Route.extend({
-  model: function() {
-    return Discourse.ajax("/404-body", { dataType: 'html' });
+  model: function(params, transition) {
+    // Check if the URL exists on the server
+    Discourse.ajax("/" + params.path, { type: 'HEAD' }).then(function() {
+      transition.abort();
+      Discourse.requestRefresh();
+      document.location.href = "/" + params.path;
+      return null;
+    }).catch(function() {
+      // Display 404 page
+      return Discourse.ajax("/404-body", { dataType: 'html' });
+    });
   }
 });

--- a/app/assets/javascripts/discourse/views/unknown.js.es6
+++ b/app/assets/javascripts/discourse/views/unknown.js.es6
@@ -1,7 +1,14 @@
+import LoadingSpinner from 'discourse/views/loading'
+
 export default Em.View.extend({
   classNameBindings: [':container'],
 
   render: function(buffer) {
-    buffer.push(this.get('controller.model'));
+    var model = this.get('controller.model');
+    if (!model) {
+      LoadingSpinner.create({}).render(buffer);
+    } else {
+      buffer.push(model);
+    }
   }
 });


### PR DESCRIPTION
This fixes links like `https://meta.discourse.org/raw/25023/6?u=riking` and `/admin/upgrade` and `/logs/show/456hexhexhex789` - those paths don't exist in the Ember router, but they exist on the server, so a HEAD request will succeed.