### PR TITLE
FIX: Don't expire ratelimits at midnight server time

### DIFF
--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -190,7 +190,7 @@ class Invite < ActiveRecord::Base
   end
 
   def limit_invites_per_day
-    RateLimiter.new(invited_by, "invites-per-day:#{Date.today}", SiteSetting.max_invites_per_day, 1.day.to_i)
+    RateLimiter.new(invited_by, "invites-per-day", SiteSetting.max_invites_per_day, 1.day.to_i)
   end
 
   def self.base_directory

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -88,7 +88,7 @@ class Post < ActiveRecord::Base
 
   def limit_posts_per_day
     if user.created_at > 1.day.ago && post_number > 1
-      RateLimiter.new(user, "first-day-replies-per-day:#{Date.today}", SiteSetting.max_replies_in_first_day, 1.day.to_i)
+      RateLimiter.new(user, "first-day-replies-per-day", SiteSetting.max_replies_in_first_day, 1.day.to_i)
     end
   end
 

--- a/app/models/post_action.rb
+++ b/app/models/post_action.rb
@@ -320,7 +320,7 @@ class PostAction < ActiveRecord::Base
 
     %w(like flag bookmark).each do |type|
       if send("is_#{type}?")
-        @rate_limiter = RateLimiter.new(user, "create_#{type}:#{Date.today}", SiteSetting.send("max_#{type}s_per_day"), 1.day.to_i)
+        @rate_limiter = RateLimiter.new(user, "create_#{type}", SiteSetting.send("max_#{type}s_per_day"), 1.day.to_i)
         return @rate_limiter
       end
     end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -812,7 +812,7 @@ class Topic < ActiveRecord::Base
   end
 
   def apply_per_day_rate_limit_for(key, method_name)
-    RateLimiter.new(user, "#{key}-per-day:#{Date.today}", SiteSetting.send(method_name), 1.day.to_i)
+    RateLimiter.new(user, "#{key}-per-day", SiteSetting.send(method_name), 1.day.to_i)
   end
 
 end


### PR DESCRIPTION
This fixes the error message returned when you exceed the rate limit by not throwing out the action data when the date rolls over.