### PR TITLE
Disallow posting replies to deleted topic

### DIFF
--- a/app/assets/javascripts/discourse/controllers/composer.js.es6
+++ b/app/assets/javascripts/discourse/controllers/composer.js.es6
@@ -155,8 +155,8 @@ export default DiscourseController.extend({
   },
 
   disableSubmit: function() {
-    return this.get('model.loading');
-  }.property('model.loading'),
+    return this.get('model.loading') || this.get('model.topic.deleted');
+  }.property('model.loading', 'model.topic.deleted'),
 
   save: function(force) {
     var composer = this.get('model'),

--- a/app/assets/javascripts/discourse/models/composer.js
+++ b/app/assets/javascripts/discourse/models/composer.js
@@ -120,6 +120,9 @@ Discourse.Composer = Discourse.Model.extend({
     // reply is always required
     if (this.get('missingReplyCharacters') > 0) return true;
 
+    // ensure topic is not deleted
+    if (this.get('topic.deleted')) return true;
+
     if (this.get("privateMessage")) {
       // need at least one user when sending a PM
       return this.get('targetUsernames') && (this.get('targetUsernames').trim() + ',').indexOf(',') === 0;
@@ -130,7 +133,7 @@ Discourse.Composer = Discourse.Model.extend({
             !this.get('categoryId') &&
             !Discourse.User.currentProp('staff');
     }
-  }.property('loading', 'canEditTitle', 'titleLength', 'targetUsernames', 'replyLength', 'categoryId', 'missingReplyCharacters'),
+  }.property('loading', 'canEditTitle', 'titleLength', 'targetUsernames', 'replyLength', 'categoryId', 'missingReplyCharacters', 'topic.deleted'),
 
   /**
     Is the title's length valid?

--- a/app/assets/javascripts/discourse/models/post-stream.js.es6
+++ b/app/assets/javascripts/discourse/models/post-stream.js.es6
@@ -453,13 +453,18 @@ const PostStream = Ember.Object.extend({
         existing = postIdentityMap.get(postId);
 
     if(existing){
-      const url = "/posts/" + postId;
-      Discourse.ajax(url).then(
+      const postUrl = "/posts/" + postId,
+            topicUrl = "/t/" + existing.topic_id;
+      Discourse.ajax(postUrl).then(
         function(p){
           self.storePost(Discourse.Post.create(p));
         },
         function(){
           self.removePosts([existing]);
+        });
+      Discourse.ajax(topicUrl).then(
+        function(t){
+          self.get('topic').updateFromJson(t);
         });
     }
   },

--- a/app/assets/javascripts/discourse/views/composer.js.es6
+++ b/app/assets/javascripts/discourse/views/composer.js.es6
@@ -557,17 +557,20 @@ var ComposerView = Discourse.View.extend(Ember.Evented, {
   replyValidation: function() {
     var replyLength = this.get('model.replyLength'),
         missingChars = this.get('model.missingReplyCharacters'),
+        topicDeleted = this.get('model.topic.deleted'),
         reason;
     if( replyLength < 1 ){
       reason = I18n.t('composer.error.post_missing');
     } else if( missingChars > 0 ) {
       reason = I18n.t('composer.error.post_length', {min: this.get('model.minimumPostLength')});
+    } else if ( topicDeleted ) {
+      reason = I18n.t('composer.error.topic_deleted');
     }
 
     if( reason ) {
       return Discourse.InputValidation.create({ failed: true, reason: reason });
     }
-  }.property('model.reply', 'model.replyLength', 'model.missingReplyCharacters', 'model.minimumPostLength'),
+  }.property('model.reply', 'model.replyLength', 'model.missingReplyCharacters', 'model.minimumPostLength', 'model.topic.deleted'),
 
   _unbindUploadTarget: function() {
     var $uploadTarget = $('#reply-control');

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -685,6 +685,7 @@ en:
         post_missing: "Post can't be empty"
         post_length: "Post must be at least {{min}} characters"
         category_missing: "You must choose a category"
+        topic_deleted: "This topic has been deleted."
 
       save_edit: "Save Edit"
       reply_original: "Reply on Original Topic"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -161,6 +161,7 @@ en:
     other: "Sorry, new users can only put %{count} links in a post."
   spamming_host: "Sorry you cannot post a link to that host."
   user_is_suspended: "Suspended users are not allowed to post."
+  topic_not_found: "This topic could not be found. It may have been deleted."
 
   just_posted_that: "is too similar to what you recently posted"
   has_already_been_used: "has already been used"

--- a/lib/post_creator.rb
+++ b/lib/post_creator.rb
@@ -204,7 +204,13 @@ class PostCreator
       end
     else
       topic = Topic.find_by(id: @opts[:topic_id])
-      guardian.ensure_can_create!(Post, topic)
+      if topic.blank?
+        @errors = Post.new.errors
+        @errors.add(:base, I18n.t(:topic_not_found))
+        raise ActiveRecord::Rollback.new
+      else
+        guardian.ensure_can_create!(Post, topic)
+      end
     end
     @topic = topic
   end

--- a/spec/components/post_creator_spec.rb
+++ b/spec/components/post_creator_spec.rb
@@ -347,6 +347,18 @@ describe PostCreator do
 
   end
 
+  context 'missing topic' do
+    let!(:topic) { Fabricate(:topic, user: user, deleted_at: 5.minutes.ago) }
+    let(:creator) { PostCreator.new(user, raw: 'test reply', topic_id: topic.id, reply_to_post_number: 4) }
+
+    it 'responds with an error message' do
+      post = creator.create
+      expect(post).to be_blank
+      expect(creator.errors.count).to eq 1
+      expect(creator.errors.messages[:base][0]).to match I18n.t(:topic_not_found)
+    end
+  end
+
   context "cooking options" do
     let(:raw) { "this is my awesome message body hello world" }
 


### PR DESCRIPTION
For replying to deleted topic issue described [here](https://meta.discourse.org/t/replying-to-a-deleted-topic-returns-a-cryptic-message/17035/)

**Before topic is deleted:**
![screenshot from 2015-02-14 12 10 26](https://cloud.githubusercontent.com/assets/750477/6196958/3f871122-b443-11e4-83e2-9d93dd349476.png)

**After topic is deleted:**
![screenshot from 2015-02-14 12 11 03](https://cloud.githubusercontent.com/assets/750477/6196960/47327a6a-b443-11e4-9195-bd28865a22c2.png)
