### PR TITLE
FIX: Use overage to keep usercard from going off browser

### DIFF
--- a/app/assets/javascripts/discourse/views/user-card.js.es6
+++ b/app/assets/javascripts/discourse/views/user-card.js.es6
@@ -83,7 +83,7 @@ export default Discourse.View.extend(CleansUp, {
 
           var overage = ($(window).width() - 50) - (position.left + width);
           if (overage < 0) {
-            position.left -= (width/2) - 10;
+            position.left += overage;
             position.top += target.height() + 8;
           }
 


### PR DESCRIPTION
Reverting this change (https://github.com/discourse/discourse/commit/246f77c98d48df011a2e80ae5d33bee1104b6366) since it makes the user card flow out of the browser when clicking near the right side of the browser edge.
