### PR TITLE
FIX: Default sort grantable badges by name

### DIFF
--- a/app/assets/javascripts/admin/controllers/admin-user-badges.js.es6
+++ b/app/assets/javascripts/admin/controllers/admin-user-badges.js.es6
@@ -32,7 +32,7 @@ export default Ember.ArrayController.extend({
       }
     });
 
-    return badges;
+    return _.sortBy(badges, "name");
   }.property('badges.@each', 'model.@each'),
 
   /**

--- a/test/javascripts/admin/controllers/admin-user-badges-test.js.es6
+++ b/test/javascripts/admin/controllers/admin-user-badges-test.js.es6
@@ -1,0 +1,16 @@
+moduleFor('controller:admin-user-badges', 'Admin User Badges Controller', {
+  needs: ['controller:adminUser']
+});
+
+test("grantableBadges", function() {
+  var badge_first = Discourse.Badge.create({id: 3, name: "A Badge"});
+  var badge_middle = Discourse.Badge.create({id: 1, name: "My Badge"});
+  var badge_last = Discourse.Badge.create({id: 2, name: "Zoo Badge"});
+  var controller = this.subject({ badges: [badge_last, badge_first, badge_middle] });
+  var sorted_names = [badge_first.name, badge_middle.name, badge_last.name];
+  var badge_names = controller.get('grantableBadges').map(function(badge) {
+    return badge.name;
+  });
+
+  deepEqual(badge_names, sorted_names, "sorts badges by name");
+});


### PR DESCRIPTION
  Currently has no default sort and was stated as a bug here:
  https://meta.discourse.org/t/badges-not-sorted-in-grant-badge-dropdown/23739
  (Post was recently deleted or made private?)

Not sure if you'd still like to change this to do a default sort by name, but I added a test for the ember controller and made the change to sort by name for grantable badges by default.