### PR TITLE
Fix regression on editing private messages

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -133,7 +133,7 @@ class TopicsController < ApplicationController
     end
 
     changes.delete(:title) if topic.title == changes[:title]
-    changes.delete(:category_id) if topic.category_id == changes[:category_id].to_i
+    changes.delete(:category_id) if topic.category_id.to_i == changes[:category_id].to_i
 
     success = true
     if changes.length > 0

--- a/spec/controllers/topics_controller_spec.rb
+++ b/spec/controllers/topics_controller_spec.rb
@@ -752,6 +752,22 @@ describe TopicsController do
           expect(response).to be_success
         end
 
+        context 'when topic is private' do
+          before do
+            @topic.archetype = Archetype.private_message
+            @topic.category = nil
+            @topic.save!
+          end
+
+          context 'when there are no changes' do
+            it 'does not call the PostRevisor' do
+              PostRevisor.any_instance.expects(:revise!).never
+              xhr :put, :update, topic_id: @topic.id, slug: @topic.title, title: @topic.title, category_id: nil
+              expect(response).to be_success
+            end
+          end
+        end
+
         context "allow_uncategorized_topics is false" do
           before do
             SiteSetting.stubs(:allow_uncategorized_topics).returns(false)


### PR DESCRIPTION
v1.2.0beta9 has introduced a regression in edit of a private topic
(first post). Previously a check for no change in TopicsController was
made but it has been changed without considering that the topic could
be private.

By simply forcing a conversion of `topic.category_id` to integer, the case
where its value is nil is handled correctly as it was previously.