### PR TITLE
FEATURE: Use HTML badge description on individual display

### DIFF
--- a/app/assets/javascripts/discourse/templates/badges/show.hbs
+++ b/app/assets/javascripts/discourse/templates/badges/show.hbs
@@ -9,7 +9,7 @@
     <tbody>
       <tr>
         <td class='badge'>{{user-badge badge=this}}</td>
-        <td class='description'>{{displayDescription}}</td>
+        <td class='description'>{{{displayDescriptionHtml}}}</td>
         <td class='grant-count'>{{i18n 'badges.granted' count=grant_count}}</td>
         <td class='info'>{{i18n 'badges.allow_title'}} {{{view.allowTitle}}}<br>{{i18n 'badges.multiple_grant'}} {{{view.multipleGrant}}}
         </td>


### PR DESCRIPTION
https://meta.discourse.org/t/html-in-badge-descriptions-not-present-on-badge-page/22082