### PR TITLE
Adding Piwik as a analytics option

### DIFF
--- a/app/assets/javascripts/discourse/initializers/page-tracking.js.es6
+++ b/app/assets/javascripts/discourse/initializers/page-tracking.js.es6
@@ -26,6 +26,17 @@ export default {
       return;
     }
 
+    // Out of the box, Discourse tries to track Piwik Analytics
+    // if it is present
+    if (typeof window._paq !== 'undefined') {
+      pageTracker.on('change', function(url, title) {
+        window._paq.push(["setCustomUrl", url]);
+        window._paq.push(["trackPageView"]);
+        window._paq.push(["setDocumentTitle", document.title]);
+      });
+      return;
+    }
+
     // Also use Universal Analytics if it is present
     if (typeof window.ga !== 'undefined') {
       pageTracker.on('change', function(url, title) {

--- a/app/helpers/common_helper.rb
+++ b/app/helpers/common_helper.rb
@@ -10,4 +10,10 @@ module CommonHelper
       render partial: "common/google_analytics"
     end
   end
+
+  def render_piwik_analytics_code
+    if Rails.env.production? && SiteSetting.piwik_domain_name.present? && SiteSetting.piwik_site_id.present?
+      render partial: "common/piwik_analytics"
+    end
+  end
 end

--- a/app/views/common/_piwik_analytics.html.erb
+++ b/app/views/common/_piwik_analytics.html.erb
@@ -1,0 +1,13 @@
+<script type="text/javascript">
+  var _paq = _paq || [];
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="//<%= SiteSetting.piwik_domain_name %>/";
+    _paq.push(['setTrackerUrl', u+'piwik.php']);
+    _paq.push(['setSiteId', <%= SiteSetting.piwik_site_id %>]);
+    _paq.push(['setCustomVariable', 1, 'Anonymous', <%= !current_user %>, 'site']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<noscript><p><img src="//<%= SiteSetting.piwik_domain_name %>/piwik.php?idsite=<%= SiteSetting.piwik_site_id %>" style="border:0;" alt="" /></p></noscript>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -93,6 +93,8 @@
 
     <%= render_google_analytics_code %>
 
+    <%= render_piwik_analytics_code %>
+
     <%- unless customization_disabled? %>
       <%= raw SiteCustomization.custom_body_tag(session[:preview_style]) %>
     <%- end %>

--- a/app/views/layouts/crawler.html.erb
+++ b/app/views/layouts/crawler.html.erb
@@ -28,6 +28,7 @@
       <p><%= t 'powered_by_html' %></p>
     </footer>
     <%= render_google_analytics_code %>
+    <%= render_piwik_analytics_code %>
     <%- unless customization_disabled? %>
       <%= raw SiteCustomization.custom_body_tag(session[:preview_style]) %>
     <%- end %>

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -822,6 +822,8 @@ en:
     ga_domain_name: "Google analytics (ga.js) domain name, eg: mysite.com; see http://google.com/analytics"
     ga_universal_tracking_code: "Google Universal Analytics (analytics.js) tracking code code, eg: UA-12345678-9; see http://google.com/analytics"
     ga_universal_domain_name: "Google Universal Analytics (analytics.js) domain name, eg: mysite.com; see http://google.com/analytics"
+    piwik_domain_name: "Piwik domain name (Eg: stats.example.com)"
+    piwik_site_id: "Piwik site ID (Eg: 1)"
     enable_escaped_fragments: "Fall back to Google's Ajax-Crawling API if no webcrawler is detected. See https://support.google.com/webmasters/answer/174992?hl=en"
     enable_noscript_support: "Enable standard webcrawler search engine support via the noscript tag"
     allow_moderators_to_create_categories: "Allow moderators to create new categories"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -81,6 +81,12 @@ basic:
   ga_domain_name:
     client: true
     default: ''
+  piwik_domain_name:
+    client: true
+    default: ''
+  piwik_site_id:
+    client: true
+    default: ''
   top_menu:
     client: true
     refresh: true


### PR DESCRIPTION
As requested here (https://meta.discourse.org/t/support-for-piwik-analytics-as-an-alternative-to-google-analytics/7512/51) by several people this allows people to use Piwik as an alternative to GA.

I don't know if this PR will be accepted, but I'm hoping for it to be part of the Discourse core as opposed to having to build a plugin for this functionality.

I haven't updated all the languages, do I need to? Apologies if I've missed something else.