### PR TITLE
FEATURE: User preference to always include context

### DIFF
--- a/app/assets/javascripts/discourse/models/user.js
+++ b/app/assets/javascripts/discourse/models/user.js
@@ -186,6 +186,7 @@ Discourse.User = Discourse.Model.extend({
                                'email_digests',
                                'email_direct',
                                'email_always',
+                               'email_force_context',
                                'email_private_messages',
                                'dynamic_favicon',
                                'digest_after_days',

--- a/app/assets/javascripts/discourse/templates/user/preferences.hbs
+++ b/app/assets/javascripts/discourse/templates/user/preferences.hbs
@@ -182,6 +182,7 @@
       {{preference-checkbox labelKey="user.email_private_messages" checked=email_private_messages}}
       {{preference-checkbox labelKey="user.email_direct" checked=email_direct}}
       {{preference-checkbox labelKey="user.mailing_list_mode" checked=mailing_list_mode}}
+      {{preference-checkbox labelKey="user.email_force_context" checked=email_force_context}}
       {{preference-checkbox labelKey="user.email_always" checked=email_always}}
 
       <div class='instructions'>

--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -153,7 +153,7 @@ class UserNotifications < ActionMailer::Base
     include UserNotificationsHelper
   end
 
-  def self.get_context_posts(post, topic_user)
+  def self.get_context_posts(post, topic_user, force_context)
 
     context_posts = Post.where(topic_id: post.topic_id)
                         .where("post_number < ?", post.post_number)
@@ -162,7 +162,7 @@ class UserNotifications < ActionMailer::Base
                         .order('created_at desc')
                         .limit(SiteSetting.email_posts_context)
 
-    if topic_user && topic_user.last_emailed_post_number
+    if topic_user && topic_user.last_emailed_post_number && !force_context
       context_posts = context_posts.where("post_number > ?", topic_user.last_emailed_post_number)
     end
 
@@ -230,7 +230,7 @@ class UserNotifications < ActionMailer::Base
 
     context = ""
     tu = TopicUser.get(post.topic_id, user)
-    context_posts = self.class.get_context_posts(post, tu)
+    context_posts = self.class.get_context_posts(post, tu, user.email_force_context)
 
     # make .present? cheaper
     context_posts = context_posts.to_a

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -911,6 +911,7 @@ end
 #  title                         :string(255)
 #  uploaded_avatar_id            :integer
 #  email_always                  :boolean          default(FALSE), not null
+#  email_force_context           :boolean          default(FALSE), not null
 #  mailing_list_mode             :boolean          default(FALSE), not null
 #  locale                        :string(10)
 #  primary_group_id              :integer

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -76,6 +76,7 @@ class UserSerializer < BasicUserSerializer
                      :email_private_messages,
                      :email_direct,
                      :email_always,
+                     :email_force_context,
                      :digest_after_days,
                      :mailing_list_mode,
                      :auto_track_topics_after_msecs,

--- a/app/services/user_updater.rb
+++ b/app/services/user_updater.rb
@@ -11,6 +11,7 @@ class UserUpdater
       :email_always,
       :email_direct,
       :email_private_messages,
+      :email_force_context,
       :external_links_in_new_tab,
       :enable_quoting,
       :dynamic_favicon,

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -457,6 +457,7 @@ en:
       email_direct: "Send me an email when someone quotes me, replies to my post, or mentions my @username"
       email_private_messages: "Send me an email when someone private messages me"
       email_always: "Do not suppress email notifications when I am active on the site"
+      email_force_context: "Always include previous posts in notifications"
 
       other_settings: "Other"
       categories_settings: "Categories"

--- a/db/migrate/20150221181500_add_email_force_context_to_users.rb
+++ b/db/migrate/20150221181500_add_email_force_context_to_users.rb
@@ -1,0 +1,5 @@
+class AddEmailForceContextToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :email_force_context, :boolean, default: false, null: false
+  end
+end

--- a/spec/mailers/user_notifications_spec.rb
+++ b/spec/mailers/user_notifications_spec.rb
@@ -20,7 +20,17 @@ describe UserNotifications do
       reply3.hidden = true
       reply3.save
 
-      expect(UserNotifications.get_context_posts(reply4, nil).count).to eq(1)
+      expect(UserNotifications.get_context_posts(reply4, nil, false).count).to eq(1)
+    end
+
+    it "respects the user option to always include context" do
+      post = create_post
+      reply1 = create_post(topic: post.topic)
+      reply2 = create_post(topic: post.topic)
+      reply3 = create_post(topic: post.topic)
+      reply4 = create_post(topic: post.topic)
+
+      expect(UserNotifications.get_context_posts(reply4, nil, true).count).to eq(4)
     end
   end
 
@@ -93,6 +103,8 @@ describe UserNotifications do
       SiteSetting.enable_names = true
       SiteSetting.display_name_on_posts = true
       mail = UserNotifications.user_replied(response.user, post: response, notification: notification)
+
+      expect(response.user.email_force_context).to eql(false)
 
       # from should include full user name
       expect(mail[:from].display_names).to eql(['John Doe'])


### PR DESCRIPTION
This adds an option in the user preferences area that allows a user to always include context in notification emails. Currently the amount of context is the amount set by the site administrator (a default of 5), but in the future I can see this being more customisable by the user (perhaps a preset dropdown list or an input box like in the admin panel).

Added a unit test to verify functionality.