### PR TITLE
FIX: Don't escape test in topic excerpt for mobile.

### DIFF
--- a/app/assets/javascripts/discourse/templates/mobile/components/basic-topic-list.hbs
+++ b/app/assets/javascripts/discourse/templates/mobile/components/basic-topic-list.hbs
@@ -15,7 +15,7 @@
 
               {{#if t.hasExcerpt}}
                 <div class="topic-excerpt">
-                  {{t.excerpt}}
+                  {{{t.excerpt}}}
                   {{#if t.excerptTruncated}}
                     {{#unless t.canClearPin}}<a href="{{unbound t.url}}">{{i18n 'read_more'}}</a>{{/unless}}
                   {{/if}}


### PR DESCRIPTION
Stopped escaping topic excerpt in the mobile handlebars template to ensure things like quotes don't get escaped.  Bug if from this post:

https://meta.discourse.org/t/double-escaped-single-quotes-in-suggested-posts/24271