### PR TITLE
UX: unified About / Privacy / ToS / FAQ topnav

### DIFF
--- a/app/assets/javascripts/discourse/controllers/about.js.es6
+++ b/app/assets/javascripts/discourse/controllers/about.js.es6
@@ -1,6 +1,10 @@
 import ObjectController from 'discourse/controllers/object';
 
 export default ObjectController.extend({
+  faqOverriden: function() {
+    return !(this.siteSettings.faq_url.length === 0);
+  }.property(),
+
   contactInfo: function() {
     if (Discourse.SiteSettings.contact_email) {
       return I18n.t('about.contact_info', {contact_email: Discourse.SiteSettings.contact_email});

--- a/app/assets/javascripts/discourse/controllers/about.js.es6
+++ b/app/assets/javascripts/discourse/controllers/about.js.es6
@@ -1,9 +1,7 @@
 import ObjectController from 'discourse/controllers/object';
 
 export default ObjectController.extend({
-  faqOverriden: function() {
-    return !(this.siteSettings.faq_url.length === 0);
-  }.property(),
+  faqOverriden: Ember.computed.gt('siteSettings.faq_url.length', 0),
 
   contactInfo: function() {
     if (Discourse.SiteSettings.contact_email) {

--- a/app/assets/javascripts/discourse/templates/about.hbs
+++ b/app/assets/javascripts/discourse/templates/about.hbs
@@ -1,82 +1,97 @@
-<div class='container body-page'>
-  <section class='about'>
-    <h2>{{i18n 'about.title' title=title}}</h2>
-    <p>{{description}}</p>
-  </section>
+<div class='container'>
+  <div class='contents clearfix body-page'>
 
-  {{#if admins}}
-    <section class='about admins'>
-      <h3>{{i18n 'about.our_admins'}}</h3>
+    <ul class="nav-pills">
+      <li class="nav-item-about">{{#link-to 'about' class="active"}}{{i18n 'about.simple_title'}}{{/link-to}}</li>
+      {{#if faqOverriden}}
+        <li class="nav-item-guidelines">{{#link-to 'guidelines'}}{{i18n 'guidelines'}}{{/link-to}}</li>
+        <li class="nav-item-faq">{{#link-to 'faq'}}{{i18n 'faq'}}{{/link-to}}</li>
+      {{else}}
+        <li class="nav-item-faq">{{#link-to 'faq'}}{{i18n 'faq'}}{{/link-to}}</li>
+      {{/if}}
+      <li class="nav-item-tos">{{#link-to 'tos'}}{{i18n 'terms_of_service'}}{{/link-to}}</li>
+      <li class="nav-item-privacy">{{#link-to 'privacy'}}{{i18n 'privacy'}}{{/link-to}}</li>
+    </ul>
 
-      {{#each a in admins}}
-        {{user-small user=a}}
-      {{/each}}
-      <div class='clearfix'></div>
-
+    <section class='about'>
+      <h2>{{i18n 'about.title' title=title}}</h2>
+      <p>{{description}}</p>
     </section>
-  {{/if}}
 
-  {{#if moderators}}
-    <section class='about moderators'>
-      <h3>{{i18n 'about.our_moderators'}}</h3>
+    {{#if admins}}
+      <section class='about admins'>
+        <h3>{{i18n 'about.our_admins'}}</h3>
 
-      <div class='users'>
-        {{#each m in moderators}}
-          {{user-small user=m}}
+        {{#each a in admins}}
+          {{user-small user=a}}
         {{/each}}
-      </div>
-      <div class='clearfix'></div>
+        <div class='clearfix'></div>
+
+      </section>
+    {{/if}}
+
+    {{#if moderators}}
+      <section class='about moderators'>
+        <h3>{{i18n 'about.our_moderators'}}</h3>
+
+        <div class='users'>
+          {{#each m in moderators}}
+            {{user-small user=m}}
+          {{/each}}
+        </div>
+        <div class='clearfix'></div>
+      </section>
+    {{/if}}
+
+    <section class='about stats'>
+      <h3>{{i18n 'about.stats'}}</h3>
+
+      <table class='table'>
+        <tr>
+          <th>&nbsp;</th>
+          <th>{{i18n 'about.stat.all_time'}}</th>
+          <th>{{i18n 'about.stat.last_7_days'}}</th>
+          <th>{{i18n 'about.stat.last_30_days'}}</th>
+        </tr>
+        <tr>
+          <td class='title'>{{i18n 'about.topic_count'}}</td>
+          <td>{{number stats.topic_count}}</td>
+          <td>{{number stats.topics_7_days}}</td>
+          <td>{{number stats.topics_30_days}}</td>
+        </tr>
+        <tr>
+          <td>{{i18n 'about.post_count'}}</td>
+          <td>{{number stats.post_count}}</td>
+          <td>{{number stats.posts_7_days}}</td>
+          <td>{{number stats.posts_30_days}}</td>
+        </tr>
+        <tr>
+          <td>{{i18n 'about.user_count'}}</td>
+          <td>{{number stats.user_count}}</td>
+          <td>{{number stats.users_7_days}}</td>
+          <td>{{number stats.users_30_days}}</td>
+        </tr>
+        <tr>
+          <td>{{i18n 'about.active_user_count'}}</td>
+          <td>&mdash;</td>
+          <td>{{number stats.active_users_7_days}}</td>
+          <td>{{number stats.active_users_30_days}}</td>
+        </tr>
+        <tr>
+          <td>{{i18n 'about.like_count'}}</td>
+          <td>{{number stats.like_count}}</td>
+          <td>{{number stats.likes_7_days}}</td>
+          <td>{{number stats.likes_30_days}}</td>
+        </tr>
+      </table>
     </section>
-  {{/if}}
 
-  <section class='about stats'>
-    <h3>{{i18n 'about.stats'}}</h3>
+    {{#if contactInfo}}
+      <section class='about contact'>
+          <h3>{{i18n 'about.contact'}}</h3>
+          <p>{{contactInfo}}</p>
+      </section>
+    {{/if}}
 
-    <table class='table'>
-      <tr>
-        <th>&nbsp;</th>
-        <th>{{i18n 'about.stat.all_time'}}</th>
-        <th>{{i18n 'about.stat.last_7_days'}}</th>
-        <th>{{i18n 'about.stat.last_30_days'}}</th>
-      </tr>
-      <tr>
-        <td class='title'>{{i18n 'about.topic_count'}}</td>
-        <td>{{number stats.topic_count}}</td>
-        <td>{{number stats.topics_7_days}}</td>
-        <td>{{number stats.topics_30_days}}</td>
-      </tr>
-      <tr>
-        <td>{{i18n 'about.post_count'}}</td>
-        <td>{{number stats.post_count}}</td>
-        <td>{{number stats.posts_7_days}}</td>
-        <td>{{number stats.posts_30_days}}</td>
-      </tr>
-      <tr>
-        <td>{{i18n 'about.user_count'}}</td>
-        <td>{{number stats.user_count}}</td>
-        <td>{{number stats.users_7_days}}</td>
-        <td>{{number stats.users_30_days}}</td>
-      </tr>
-      <tr>
-        <td>{{i18n 'about.active_user_count'}}</td>
-        <td>&mdash;</td>
-        <td>{{number stats.active_users_7_days}}</td>
-        <td>{{number stats.active_users_30_days}}</td>
-      </tr>
-      <tr>
-        <td>{{i18n 'about.like_count'}}</td>
-        <td>{{number stats.like_count}}</td>
-        <td>{{number stats.likes_7_days}}</td>
-        <td>{{number stats.likes_30_days}}</td>
-      </tr>
-    </table>
-  </section>
-
-  {{#if contactInfo}}
-    <section class='about contact'>
-        <h3>{{i18n 'about.contact'}}</h3>
-        <p>{{contactInfo}}</p>
-    </section>
-  {{/if}}
-
+  </div>
 </div>

--- a/app/assets/javascripts/discourse/templates/components/user-small.hbs
+++ b/app/assets/javascripts/discourse/templates/components/user-small.hbs
@@ -1,4 +1,7 @@
 {{#link-to 'user' user.username}}
   {{avatar user imageSize="tiny"}}
   {{user.username}}
+  {{#if user.name}}
+    ({{user.name}})
+  {{/if}}
 {{/link-to}}

--- a/app/serializers/about_serializer.rb
+++ b/app/serializers/about_serializer.rb
@@ -1,6 +1,6 @@
 class AboutSerializer < ApplicationSerializer
-  has_many :moderators, serializer: BasicUserSerializer, embed: :objects
-  has_many :admins, serializer: BasicUserSerializer, embed: :objects
+  has_many :moderators, serializer: UserNameSerializer, embed: :objects
+  has_many :admins, serializer: UserNameSerializer, embed: :objects
 
   attributes :stats,
              :description,

--- a/app/serializers/user_name_serializer.rb
+++ b/app/serializers/user_name_serializer.rb
@@ -1,0 +1,20 @@
+class UserNameSerializer < ApplicationSerializer
+  attributes :id, :username, :name, :uploaded_avatar_id, :avatar_template
+
+  def include_name?
+    SiteSetting.enable_names?
+  end
+
+  def avatar_template
+    if Hash === object
+      User.avatar_template(user[:username], user[:uploaded_avatar_id])
+    else
+      object.avatar_template
+    end
+  end
+
+  def user
+    object[:user] || object
+  end
+
+end

--- a/app/views/static/show.html.erb
+++ b/app/views/static/show.html.erb
@@ -1,4 +1,5 @@
 <ul class="nav-pills">
+  <li class="nav-item-about"><%= link_to t('about'), '/about' %></a></li>
   <% if @faq_overriden %>
     <li class="nav-item-guidelines"><a class="<%= @page == 'faq' ? 'active' : '' %>" href="<%=guidelines_path%>"><%=t "guidelines" %></a></li>
     <li class="nav-item-faq"><a href="<%=faq_path%>"><%=t "js.faq" %></a></li>

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1955,6 +1955,7 @@ en:
   color_schemes:
     base_theme_name: "Base"
 
+  about: "About"
   guidelines: "Guidelines"
   privacy: "Privacy"
 


### PR DESCRIPTION
This PR encapsulates 2 changes:

* [unified About / Privacy / ToS / FAQ topnav](https://github.com/techAPJ/discourse/commit/ddb8378ab049e46200b76ad80a672cc0cc50e3d6)

* [show real name(s) on the about page](https://github.com/techAPJ/discourse/commit/5e8938c7b613a6a9d2c72c09947745bf32cd0822)

Screenshot:

![screenshot from 2015-02-23 20 22 24](https://cloud.githubusercontent.com/assets/5732281/6331138/8de31944-bba3-11e4-91a4-1c32a37ffa26.png)

[Relevant post on meta](https://meta.discourse.org/t/disclaimer-section-on-the-about-page/25461/13?u=techapj)