### PR TITLE
FEATURE: new site setting contact_url

### DIFF
--- a/app/assets/javascripts/discourse/controllers/about.js.es6
+++ b/app/assets/javascripts/discourse/controllers/about.js.es6
@@ -4,8 +4,10 @@ export default ObjectController.extend({
   faqOverriden: Ember.computed.gt('siteSettings.faq_url.length', 0),
 
   contactInfo: function() {
-    if (Discourse.SiteSettings.contact_email) {
-      return I18n.t('about.contact_info', {contact_email: Discourse.SiteSettings.contact_email});
+    if (this.siteSettings.contact_url) {
+      return I18n.t('about.contact_info', {contact_info: "<a href='"+ this.siteSettings.contact_url +"' target='_blank'>"+ this.siteSettings.contact_url +"</a>"});
+    } else if (this.siteSettings.contact_email) {
+      return I18n.t('about.contact_info', {contact_info: this.siteSettings.contact_email});
     } else {
       return null;
     }

--- a/app/assets/javascripts/discourse/templates/about.hbs
+++ b/app/assets/javascripts/discourse/templates/about.hbs
@@ -89,7 +89,7 @@
     {{#if contactInfo}}
       <section class='about contact'>
           <h3>{{i18n 'about.contact'}}</h3>
-          <p>{{contactInfo}}</p>
+          <p>{{{contactInfo}}}</p>
       </section>
     {{/if}}
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -163,7 +163,7 @@ en:
       user_count: "New Users"
       active_user_count: "Active Users"
       contact: "Contact Us"
-      contact_info: "In the event of a critical issue or urgent matter affecting this site, please contact us at %{contact_email}."
+      contact_info: "In the event of a critical issue or urgent matter affecting this site, please contact us at %{contact_info}."
 
     bookmarked:
       title: "Bookmark"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -756,6 +756,7 @@ en:
     title: "The name of this site, as used in the title tag."
     site_description: "Describe this site in one sentence, as used in the meta description tag."
     contact_email: "Email address of key contact responsible for this site. Used for critical notifications such as unhandled flags, as well as on the /about contact form for urgent matters."
+    contact_url: "Contact URL for this site. Used on the /about contact form for urgent matters."
     queue_jobs: "DEVELOPER ONLY! WARNING! By default, queue jobs in sidekiq. If disabled, your site will be broken."
     crawl_images: "Retrieve images from remote URLs to insert the correct width and height dimensions."
     download_remote_images_to_local: "Convert remote images to local images by downloading them; this prevents broken images."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -25,6 +25,9 @@ required:
     client: true
     default: ''
     type: email
+  contact_url:
+    client: true
+    default: ''
   notification_email:
     default: 'noreply@unconfigured.discourse.org'
     type: email


### PR DESCRIPTION
If the Contact URL is provided, that will be shown on `/about` page, instead of Contact Email.