### PR TITLE
FIX: Forward to SSO login automatically

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -389,7 +389,13 @@ class ApplicationController < ActionController::Base
 
       # save original URL in a cookie
       cookies[:destination_url] = request.original_url unless request.original_url =~ /uploads/
-      redirect_to :login if SiteSetting.login_required?
+
+      # redirect user to the SSO page if we need to log in AND SSO is enabled
+      if (SiteSetting.enable_sso && SiteSetting.login_required)
+        redirect_to '/session/sso'
+      elsif SiteSetting.login_required?
+        redirect_to :login
+      end
     end
 
     def block_if_readonly_mode

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -391,10 +391,12 @@ class ApplicationController < ActionController::Base
       cookies[:destination_url] = request.original_url unless request.original_url =~ /uploads/
 
       # redirect user to the SSO page if we need to log in AND SSO is enabled
-      if (SiteSetting.enable_sso && SiteSetting.login_required)
-        redirect_to '/session/sso'
-      elsif SiteSetting.login_required?
-        redirect_to :login
+      if SiteSetting.login_required?
+        if SiteSetting.enable_sso?
+          redirect_to '/session/sso'
+        else
+          redirect_to :login
+        end
       end
     end
 


### PR DESCRIPTION
Forward to SSO login URL automatically if SSO is enabled and login is required.

Makes it simpler for users to log in automatically.