### PR TITLE
FEATURE: Use `git describe` for dashboard version

### DIFF
--- a/app/assets/javascripts/admin/templates/version_checks.hbs
+++ b/app/assets/javascripts/admin/templates/version_checks.hbs
@@ -14,7 +14,7 @@
         {{#unless loading}}
           <tbody>
             <td class="title">{{i18n 'admin.dashboard.version'}}</td>
-            <td class="version-number"><a {{bind-attr href="versionCheck.gitLink"}} target="_blank">{{ versionCheck.installed_version }}</a></td>
+            <td class="version-number"><a {{bind-attr href="versionCheck.gitLink"}} target="_blank">{{ versionCheck.installed_describe }}</a></td>
 
             {{#if versionCheck.noCheckPerformed}}
               <td class="version-number">&nbsp;</td>

--- a/app/models/discourse_version_check.rb
+++ b/app/models/discourse_version_check.rb
@@ -1,5 +1,5 @@
 class DiscourseVersionCheck
   include ActiveModel::Model
 
-  attr_accessor :latest_version, :critical_updates, :installed_version, :installed_sha, :missing_versions_count, :updated_at, :version_check_pending
+  attr_accessor :latest_version, :critical_updates, :installed_version, :installed_sha, :installed_describe, :missing_versions_count, :updated_at, :version_check_pending
 end

--- a/lib/discourse_updates.rb
+++ b/lib/discourse_updates.rb
@@ -7,6 +7,7 @@ module DiscourseUpdates
         DiscourseVersionCheck.new(
           installed_version: Discourse::VERSION::STRING,
           installed_sha: (Discourse.git_version == 'unknown' ? nil : Discourse.git_version),
+          installed_describe: `git describe --dirty`,
           updated_at: nil
         )
       else
@@ -15,9 +16,15 @@ module DiscourseUpdates
           critical_updates: critical_updates_available?,
           installed_version: Discourse::VERSION::STRING,
           installed_sha: (Discourse.git_version == 'unknown' ? nil : Discourse.git_version),
+          installed_describe: `git describe --dirty`,
           missing_versions_count: missing_versions_count,
           updated_at: updated_at
         )
+      end
+
+      # replace -commit_count with +commit_count
+      if version_info.installed_describe =~ /-(\d+)-/
+        version_info.installed_describe = version_info.installed_describe.gsub(/-(\d+)-.*/, " +#{$1}")
       end
 
       if SiteSetting.version_checks?


### PR DESCRIPTION
This will give an indicator of how long it's been since the beta for people on the tests-passed/master branch.
