### PR TITLE
Api key should be easy to copy

### DIFF
--- a/app/assets/javascripts/admin/templates/user_index.hbs
+++ b/app/assets/javascripts/admin/templates/user_index.hbs
@@ -225,7 +225,7 @@
 
     {{#if api_key}}
       <div class='long-value'>
-        {{api_key.key}}
+        <input type="text" value="{{api_key.key}}" onclick="this.select()" style="width:450px">
         <button class='btn' {{action "regenerateApiKey"}}><i class="fa fa-undo"></i>{{i18n 'admin.api.regenerate'}}</button>
         <button {{action "revokeApiKey"}} class="btn"><i class="fa fa-times"></i>{{i18n 'admin.api.revoke'}}</button>
       </div>

--- a/app/assets/javascripts/admin/templates/user_index.hbs
+++ b/app/assets/javascripts/admin/templates/user_index.hbs
@@ -143,7 +143,7 @@
     {{#each uf in userFields}}
       <div class='display-row'>
         <div class='field'>{{uf.name}}</div>
-        <div class='value'>
+        <div class='value'> 
           {{#if uf.value}}
             {{uf.value}}
           {{else}}
@@ -225,7 +225,7 @@
 
     {{#if api_key}}
       <div class='long-value'>
-        <input type="text" value="{{api_key.key}}" onclick="this.select()" style="width:450px">
+        <input type="text" value="{{api_key.key}}" style="width:450px">
         <button class='btn' {{action "regenerateApiKey"}}><i class="fa fa-undo"></i>{{i18n 'admin.api.regenerate'}}</button>
         <button {{action "revokeApiKey"}} class="btn"><i class="fa fa-times"></i>{{i18n 'admin.api.revoke'}}</button>
       </div>


### PR DESCRIPTION
On Windows/Chrome, double clicking on the api key will also select the label, so if you don't pay attention you will copy the _key_ part as well (and also a nice whitespace at the end):

```
Key80575586ae7514facbc68b0e4f2227508d6f595af87831d5936c0d723962bca8
```

This PR should fix this.