### PR TITLE
Avoid gzip "-k" option for wider OS compatibility

### DIFF
--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -118,7 +118,7 @@ end
 
 def gzip(path)
   STDERR.puts "gzip #{path}"
-  STDERR.puts `gzip -f -k -9 #{path}`
+  STDERR.puts `gzip -f -c -9 #{path} > #{path}.gz`
 end
 
 def compress(from,to)


### PR DESCRIPTION
The "-k" option tells gzip to keep the original files intact and is an
alternative to `gzip -c file > file.gz`. It was implemented in 2013:
http://git.savannah.gnu.org/cgit/gzip.git/commit/?id=0192f02

There are a few popular operating systems (ie, Red Hat 7, Debian Wheezy)
whose version of gzip does not have the "-k" option. Compiling assets
breaks on these operating systems. Using "-c" instead ensures that it
works even with older versions of gzip.