### PR TITLE
add line-height on page-not-found for h1

### DIFF
--- a/app/assets/stylesheets/desktop/discourse.scss
+++ b/app/assets/stylesheets/desktop/discourse.scss
@@ -123,6 +123,9 @@ body {
   }
 
   /* page not found styles */
+  h1.page-not-found {
+    line-height: 30px;
+  }
 
   .page-not-found {
     margin: 20px 0 40px 0;


### PR DESCRIPTION
if localized (h1) headline for page-not-found spans multiple multilple lines, some line-height is missing...