### PR TITLE
FIX: Reenable console output for verbose localization

### DIFF
--- a/app/assets/javascripts/locales/i18n.js
+++ b/app/assets/javascripts/locales/i18n.js
@@ -522,7 +522,7 @@ I18n.enable_verbose_localization = function(){
       if (!_.isEmpty(value)) {
         message += ", parameters: " + JSON.stringify(value);
       }
-      //window.console.log(message);
+      Em.Logger.info(message);
     }
     return t.apply(I18n, [scope, value]) + " (t" + current + ")";
   };


### PR DESCRIPTION
It's a little bit useless if the translators can't see what the keys actually are...