### PR TITLE
FIX: Added two user badge triggers

### DIFF
--- a/app/models/user_badge.rb
+++ b/app/models/user_badge.rb
@@ -12,10 +12,12 @@ class UserBadge < ActiveRecord::Base
 
   after_create do
     Badge.increment_counter 'grant_count', self.badge_id
+    DiscourseEvent.trigger(:user_badge_granted, badge_id, user_id)
   end
 
   after_destroy do
     Badge.decrement_counter 'grant_count', self.badge_id
+    DiscourseEvent.trigger(:user_badge_removed, badge_id, user_id)
   end
 end
 

--- a/app/models/user_badge.rb
+++ b/app/models/user_badge.rb
@@ -12,12 +12,12 @@ class UserBadge < ActiveRecord::Base
 
   after_create do
     Badge.increment_counter 'grant_count', self.badge_id
-    DiscourseEvent.trigger(:user_badge_granted, badge_id, user_id)
+    DiscourseEvent.trigger(:user_badge_granted, self.badge_id, self.user_id)
   end
 
   after_destroy do
     Badge.decrement_counter 'grant_count', self.badge_id
-    DiscourseEvent.trigger(:user_badge_removed, badge_id, user_id)
+    DiscourseEvent.trigger(:user_badge_removed, self.badge_id, self.user_id)
   end
 end
 

--- a/spec/controllers/user_badges_controller_spec.rb
+++ b/spec/controllers/user_badges_controller_spec.rb
@@ -63,13 +63,23 @@ describe UserBadgesController do
 
     it 'grants badges from staff' do
       admin = Fabricate(:admin)
+      post = create_post
+
       log_in_user admin
+
       StaffActionLogger.any_instance.expects(:log_badge_grant).once
-      xhr :post, :create, badge_id: badge.id, username: user.username
+
+      xhr :post, :create, badge_id: badge.id,
+                          username: user.username,
+                          reason: Discourse.base_url + post.url
+
       expect(response.status).to eq(200)
+
       user_badge = UserBadge.find_by(user: user, badge: badge)
+
       expect(user_badge).to be_present
       expect(user_badge.granted_by).to eq(admin)
+      expect(user_badge.post_id).to eq(post.id)
     end
 
     it 'does not grant badges from regular api calls' do


### PR DESCRIPTION
Created two triggers that trigger events when a badge is granted or removed.

Trigger 1:
user_badge_granted
 Variable - badge_id
 Variable - user_id

Trigger 2:
user_badge_removed
 Variable - badge_id
 Variable - user_id