### PR TITLE
Remove topic_auto_close_at from PostSerializer

### DIFF
--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -27,7 +27,6 @@ class PostSerializer < BasicPostSerializer
              :yours,
              :topic_id,
              :topic_slug,
-             :topic_auto_close_at,
              :display_username,
              :primary_group_name,
              :version,
@@ -70,10 +69,6 @@ class PostSerializer < BasicPostSerializer
 
   def topic_slug
     object.try(:topic).try(:slug)
-  end
-
-  def topic_auto_close_at
-    object.try(:topic).try(:auto_close_at)
   end
 
   def moderator?


### PR DESCRIPTION
We should look at extracting some of the cruft from these repsonses.

This isn't used by the client, the client uses `auto_close_at` from the topic `details`.