### PR TITLE
group manager can issue invitations from restricted topics

### DIFF
--- a/app/assets/javascripts/discourse/controllers/invite.js.es6
+++ b/app/assets/javascripts/discourse/controllers/invite.js.es6
@@ -21,6 +21,7 @@ export default ObjectController.extend(ModalFunctionality, {
     if (this.get('saving')) return true;
     if (this.blank('email')) return true;
     if (!Discourse.Utilities.emailValid(this.get('email'))) return true;
+    if (this.get('model.details.can_invite_to')) return false;
     if (this.get('isPrivateTopic') && this.blank('groupNames')) return true;
     return false;
   }.property('email', 'isPrivateTopic', 'groupNames', 'saving'),

--- a/spec/components/guardian_spec.rb
+++ b/spec/components/guardian_spec.rb
@@ -266,6 +266,9 @@ describe Guardian do
     let(:user) { topic.user }
     let(:moderator) { Fabricate(:moderator) }
     let(:admin) { Fabricate(:admin) }
+    let(:private_category)  { Fabricate(:private_category, group: group) }
+    let(:group_private_topic) { Fabricate(:topic, category: private_category) }
+    let(:group_manager) { group_private_topic.user.tap { |u| group.add(u); group.appoint_manager(u) } }
 
     it 'handles invitation correctly' do
       expect(Guardian.new(nil).can_invite_to?(topic)).to be_falsey
@@ -298,6 +301,9 @@ describe Guardian do
       expect(Guardian.new(admin).can_invite_to?(private_topic)).to be_truthy
     end
 
+    it 'returns true for a group manager' do
+      expect(Guardian.new(group_manager).can_invite_to?(group_private_topic)).to be_truthy
+    end
   end
 
   describe 'can_see?' do

--- a/spec/fabricators/category_fabricator.rb
+++ b/spec/fabricators/category_fabricator.rb
@@ -13,3 +13,15 @@ Fabricator(:happy_category, from: :category) do
   slug 'happy'
   user
 end
+
+Fabricator(:private_category, from: :category) do
+  transient :group
+
+  name 'Private Category'
+  slug 'private'
+  user
+  after_build do |cat, transients|
+    cat.update!(read_restricted: true)
+    cat.category_groups.build(group_id: transients[:group].id, permission_type: :full)
+  end
+end

--- a/spec/models/invite_spec.rb
+++ b/spec/models/invite_spec.rb
@@ -127,6 +127,28 @@ describe Invite do
     end
   end
 
+  context 'to a group-private topic' do
+    let(:group) { Fabricate(:group) }
+    let(:private_category)  { Fabricate(:private_category, group: group) }
+    let(:group_private_topic) { Fabricate(:topic, category: private_category) }
+    let(:inviter) { group_private_topic.user }
+
+    before do
+      @invite = group_private_topic.invite_by_email(inviter, iceking)
+    end
+
+    it 'should add the groups to the invite' do
+      expect(@invite.groups).to eq([group])
+    end
+
+    context 'when duplicated' do
+      it 'should not duplicate the groups' do
+        expect(group_private_topic.invite_by_email(inviter, iceking)).to eq(@invite)
+        expect(@invite.groups).to eq([group])
+      end
+    end
+  end
+
   context 'an existing user' do
     let(:topic) { Fabricate(:topic, category_id: nil, archetype: 'private_message') }
     let(:coding_horror) { Fabricate(:coding_horror) }

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -1,4 +1,4 @@
-# encoding: UTF-8
+# encoding: utf-8
 
 require 'spec_helper'
 require_dependency 'post_destroyer'
@@ -1351,5 +1351,38 @@ describe Topic do
     SiteSetting.stubs(:min_topic_title_length).returns(15)
     topic.last_posted_at = 1.minute.ago
     expect(topic.save).to eq(true)
+  end
+
+  context 'invite by group manager' do
+    let(:group_manager) { Fabricate(:user) }
+    let(:group) { Fabricate(:group).tap { |g| g.add(group_manager); g.appoint_manager(group_manager) } }
+    let(:private_category)  { Fabricate(:private_category, group: group) }
+    let(:group_private_topic) { Fabricate(:topic, category: private_category, user: group_manager) }
+
+    context 'to an email' do
+      let(:randolph) { 'randolph@duke.ooo' }
+
+      it "should attach group to the invite" do
+        invite = group_private_topic.invite(group_manager, randolph)
+        expect(invite.groups).to eq([group])
+      end
+    end
+
+    # should work for an existing user - give access, send notification
+    context 'to an existing user' do
+      let(:walter) { Fabricate(:walter_white) }
+
+      it "should add user to the group" do
+        expect(Guardian.new(walter).can_see?(group_private_topic)).to be_falsey
+        invite = group_private_topic.invite(group_manager, walter.email)
+        expect(invite).to be_nil
+        expect(walter.groups).to include(group)
+        expect(Guardian.new(walter).can_see?(group_private_topic)).to be_truthy
+      end
+    end
+
+    context 'to a previously-invited user' do
+
+    end
   end
 end


### PR DESCRIPTION
See https://meta.discourse.org/t/invitations-to-group-restricted-topics/25895

Enables the Invite button on topics inside group-restricted categories, when the user is group manager for *all* groups that have access to that category. The group selector is not displayed on the Invite popup. Group membership is implicitly added to the invitation.