### PR TITLE
Bump plugin version from 0.1 to 0.2

### DIFF
--- a/plugins/poll/plugin.rb
+++ b/plugins/poll/plugin.rb
@@ -1,6 +1,6 @@
 # name: poll
 # about: adds poll support to Discourse
-# version: 0.1
+# version: 0.2
 # authors: Vikhyat Korrapati
 # url: https://github.com/discourse/discourse/tree/master/plugins/poll
 


### PR DESCRIPTION
The plugin recently received a fix although was never bumped in version number. 

This should allow the plugin to be upgraded automatically through the `admin/upgrade` url. 