### PR TITLE
Don't show blank page for external links with no click track record

### DIFF
--- a/app/assets/javascripts/discourse/lib/click_track.js
+++ b/app/assets/javascripts/discourse/lib/click_track.js
@@ -15,7 +15,7 @@ Discourse.ClickTrack = {
     @param {jQuery.Event} e The click event that occurred
   **/
   trackClick: function(e) {
-    if (Discourse.Utilities.selectedText()!=="") return false;  //cancle click if triggered as part of selection.
+    if (Discourse.Utilities.selectedText()!=="") return false;  // cancel click if triggered as part of selection.
     var $link = $(e.currentTarget);
     if ($link.hasClass('lightbox')) return true;
 
@@ -112,8 +112,9 @@ Discourse.ClickTrack = {
     // restore href
     setTimeout(function() {
       $link.removeClass('no-href');
-      $link.attr('href', $link.data('href'));
+      $link.attr('href', href);
       $link.data('href', null);
+      $link.data('auto-route', false);
     }, 50);
 
     // Otherwise, use a custom URL with a redirect

--- a/app/controllers/clicks_controller.rb
+++ b/app/controllers/clicks_controller.rb
@@ -10,10 +10,13 @@ class ClicksController < ApplicationController
       @redirect_url = TopicLinkClick.create_from(params)
     end
 
-    # Sometimes we want to record a link without a 302. Since XHR has to load the redirected
-    # URL we want it to not return a 302 in those cases.
-    if params[:redirect] == 'false' || @redirect_url.blank?
-      render nothing: true
+    if @redirect_url.blank?
+      # Couldn't find the URL in the post. give the user an escape hatch
+      @given_url = params[:url]
+      render template: 'clicks/failure', layout: false
+    elsif params[:redirect] == 'false'
+      # This is set by the JS when we're tracking an internal link
+      render nothing: true, status: 204
     else
       redirect_to(@redirect_url)
     end

--- a/app/views/clicks/failure.html.erb
+++ b/app/views/clicks/failure.html.erb
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title><%= I18n.t('click_fail.title', site_name: SiteSetting.title) %></title>
+</head>
+<body>
+<h3>
+  <%= I18n.t('click_fail.header') %>
+</h3>
+<p>
+  <%= I18n.t('click_fail.body') %>
+</p>
+<p>
+  <a href="<%= h @given_url %>"><%= h @given_url %></a>
+</p>
+</body>
+</html>

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1904,6 +1904,11 @@ en:
     search_title: "Search this site"
     search_google: "Google"
 
+  click_fail:
+    title: "Uh-oh - %{site_name}"
+    header: "Whoops! Something's wrong."
+    body: "It doesn't seem like that URL is in the post. To continue anyways, click the link below."
+
   login_required:
     welcome_message: |
       #[Welcome to %{title}](#welcome)

--- a/spec/controllers/clicks_controller_spec.rb
+++ b/spec/controllers/clicks_controller_spec.rb
@@ -25,6 +25,7 @@ describe ClicksController do
           TopicLinkClick.expects(:create_from).returns(nil)
           xhr :get, :track, url: 'http://discourse.org', post_id: 123
           expect(response).not_to be_redirect
+          expect(response.status).to eq(200)
         end
       end
 
@@ -47,6 +48,7 @@ describe ClicksController do
           TopicLinkClick.expects(:create_from).with('url' => url, 'post_id' => '123', 'ip' => '192.168.0.1', 'redirect' => 'false').returns(url)
           xhr :get, :track, url: url, post_id: 123, redirect: 'false'
           expect(response).not_to be_redirect
+          expect(response.status).to eq(204)
         end
 
       end


### PR DESCRIPTION
Instead of showing a white screen, give an unstyled interstitial page with a click-through to the destination. This should keep the security aspect of preventing Discourse sites from being open redirects, while still achieving the goal of not landing the user on a blank page when they click a link.

I also cleaned up a dodgy bit of code in click_track where the "restore href" wasn't quite the inverse of the original operation.