### PR TITLE
Documentation: prefix `gem install mailcatcher` with sudo

### DIFF
--- a/docs/VAGRANT.md
+++ b/docs/VAGRANT.md
@@ -130,7 +130,7 @@ Then in a browser, go to [http://localhost:4080](http://localhost:4080). Sent em
 If for some reason mailcatcher is not installed, install and launch it with these commands:
 
 ```
-gem install mailcatcher
+sudo gem install mailcatcher
 mailcatcher --http-ip 0.0.0.0
 ```
 


### PR DESCRIPTION
Resolves the gem installation issue described in [this topic](https://meta.discourse.org/t/permission-denied-when-installing-mailcatcher-in-vagrant-box/25999) by installing mailcatcher with superuser permissions.