### PR TITLE
[code gardening] fix symbolic meaning of protected for class methods

### DIFF
--- a/app/models/application_request.rb
+++ b/app/models/application_request.rb
@@ -79,10 +79,7 @@ class ApplicationRequest < ActiveRecord::Base
     end
   end
 
-  protected
-
   def self.req_id(date,req_type,retries=0)
-
     req_type_id = req_types[req_type]
 
     # a poor man's upsert
@@ -96,10 +93,12 @@ class ApplicationRequest < ActiveRecord::Base
       raise
     end
   end
+  private_class_method :req_id
 
   def self.redis_key(req_type, time=Time.now.utc)
     "app_req_#{req_type}#{time.strftime('%Y%m%d')}"
   end
+  private_class_method :redis_key
 
   def self.stats
     s = HashWithIndifferentAccess.new({})
@@ -113,6 +112,7 @@ class ApplicationRequest < ActiveRecord::Base
 
     s
   end
+  private_class_method :stats
 end
 
 # == Schema Information

--- a/lib/disk_space.rb
+++ b/lib/disk_space.rb
@@ -51,17 +51,15 @@ class DiskSpace
     if stats
       JSON.parse(stats)
     end
-
   end
-
-  protected
 
   def self.free(path)
     `df -Pk #{path} | awk 'NR==2 {print $4 * 1024;}'`.to_i
   end
+  private_class_method :free
 
   def self.used(path)
     `du -s #{path}`.to_i * 1024
   end
-
+  private_class_method :used
 end

--- a/lib/distributed_memoizer.rb
+++ b/lib/distributed_memoizer.rb
@@ -48,7 +48,6 @@ class DistributedMemoizer
     "memoize_" << key
   end
 
-  protected
   def self.get_lock(redis, redis_lock_key)
     redis.watch(redis_lock_key)
     current = redis.get(redis_lock_key)
@@ -61,6 +60,7 @@ class DistributedMemoizer
     end
 
     redis.unwatch
-    return result == ["OK"]
+    result == ["OK"]
   end
+  private_class_method :get_lock
 end

--- a/lib/pbkdf2.rb
+++ b/lib/pbkdf2.rb
@@ -27,15 +27,15 @@ class Pbkdf2
     ret.bytes.map{|b| ("0" + b.to_s(16))[-2..-1]}.join("")
   end
 
-  protected
-
   # fallback xor in case we need it for jruby ... way slower
   def self.xor(x,y)
     x.bytes.zip(y.bytes).map{|x,y| x ^ y}.pack('c*')
   end
+  private_class_method :xor
 
   def self.prf(hash_function, password, data)
     OpenSSL::HMAC.digest(hash_function, password, data)
   end
+  private_class_method :prf
 
 end

--- a/lib/pretty_text.rb
+++ b/lib/pretty_text.rb
@@ -314,8 +314,6 @@ module PrettyText
     doc.to_html
   end
 
-  protected
-
   class JavaScriptError < StandardError
     attr_accessor :message, :backtrace
 

--- a/lib/unread.rb
+++ b/lib/unread.rb
@@ -7,7 +7,6 @@ class Unread
     @topic_user = topic_user
   end
 
-
   def unread_posts
     return 0 if do_not_notify?(@topic_user.notification_level)
     result = ((@topic_user.highest_seen_post_number||0) - (@topic_user.last_read_post_number||0))

--- a/spec/components/disk_space_spec.rb
+++ b/spec/components/disk_space_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+require 'disk_space'
+
+describe DiskSpace do
+  let(:private_api) { %i(free used) }
+
+  it 'hides private api' do
+    expect(
+      described_class.singleton_class.private_instance_methods(false)
+    ).to eq private_api
+    expect private_api.none? { |m| described_class.respond_to?(m) }
+  end
+end

--- a/spec/components/distributed_memoizer_spec.rb
+++ b/spec/components/distributed_memoizer_spec.rb
@@ -23,7 +23,6 @@ describe DistributedMemoizer do
   end
 
   it "return the old value once memoized" do
-
     memoize do
       "abc"
     end
@@ -49,7 +48,14 @@ describe DistributedMemoizer do
     threads.each(&:join)
     expect(results.uniq.length).to eq(1)
     expect(results.count).to eq(5)
-
   end
 
+  let(:private_api) { %i(get_lock) }
+
+  it 'hides private api' do
+    expect(
+      described_class.singleton_class.private_instance_methods(false)
+    ).to eq private_api
+    expect private_api.none? { |m| described_class.respond_to?(m) }
+  end
 end

--- a/spec/components/pbkdf2_spec.rb
+++ b/spec/components/pbkdf2_spec.rb
@@ -6,4 +6,12 @@ describe Pbkdf2 do
     expect(Pbkdf2.hash_password('test', 'abcd', 100)).to eq("0313a6aca54dd4c5d82a699a8a0f0ffb0191b4ef62414b8d9dbc11c0c5ac04da")
     expect(Pbkdf2.hash_password('test', 'abcd', 101)).to eq("c7a7b2891bf8e6f82d08cf8d83824edcf6c7c6bacb6a741f38e21fc7977bd20f")
   end
+
+  let(:private_api) { %i(xor prf) }
+  it 'hides private api' do
+    expect(
+      described_class.singleton_class.private_instance_methods(false)
+    ).to eq private_api
+    expect private_api.none? { |m| described_class.respond_to?(m) }
+  end
 end

--- a/spec/models/application_request_spec.rb
+++ b/spec/models/application_request_spec.rb
@@ -71,6 +71,14 @@ describe ApplicationRequest do
     ApplicationRequest.http_total.first.count.should == 3
     ApplicationRequest.http_2xx.first.count.should == 2
     ApplicationRequest.http_3xx.first.count.should == 4
+  end
 
+  let(:private_api) { %i(req_id redis_key stats) }
+
+  it 'hides private api' do
+    expect(
+      described_class.singleton_class.private_instance_methods(false)
+    ).to eq private_api
+    expect private_api.none? { |m| described_class.respond_to?(m) }
   end
 end


### PR DESCRIPTION
assuming that `protected` was used not only with symbolic intention but to hide class_methods which are not part of open API.
proper hide class methods that don't want to be open.
