### PR TITLE
vBulletin user import missing email field

### DIFF
--- a/script/import_scripts/vbulletin.rb
+++ b/script/import_scripts/vbulletin.rb
@@ -58,11 +58,9 @@ class ImportScripts::VBulletin < ImportScripts::Base
 
     user_count = mysql_query("SELECT COUNT(userid) count FROM user").first["count"]
 
-    # TODO: add email back in when using real data
-
     batches(BATCH_SIZE) do |offset|
       users = mysql_query <<-SQL
-          SELECT userid, username, homepage, usertitle, usergroupid, joindate
+          SELECT userid, username, homepage, usertitle, usergroupid, joindate, email
             FROM user
         ORDER BY userid
            LIMIT #{BATCH_SIZE}


### PR DESCRIPTION
Importers is not selecting the email field and is currently generating a random email for all imported users.