### PR TITLE
UX: show GitHub logo in front of URL for commit/PR/issue/gist

### DIFF
--- a/app/assets/stylesheets/common/base/onebox.scss
+++ b/app/assets/stylesheets/common/base/onebox.scss
@@ -105,6 +105,10 @@ aside.onebox {
   @include onebox-favicon('twitterstatus', 'twitter');
   @include onebox-favicon('wikipedia', 'wikipedia');
   @include onebox-favicon('githubblob', 'github');
+  @include onebox-favicon('githubcommit', 'github');
+  @include onebox-favicon('githubpullrequest', 'github');
+  @include onebox-favicon('githubissue', 'github');
+  @include onebox-favicon('githubgist', 'github');
   @include onebox-favicon('amazon', 'amazon');
 
 


### PR DESCRIPTION
Partly fulfills request here: https://meta.discourse.org/t/would-be-nice-to-see-repository-name-in-github-onebox/9708/2?u=techapj

Example commit onebox:

![screen shot 2015-03-10 at 20 01 21](https://cloud.githubusercontent.com/assets/5732281/6576930/5dab839c-c760-11e4-943a-b94b3a84126f.png)
