### PR TITLE
FIX: Revert bd61cdf, use allowUncat render option instead

### DIFF
--- a/app/assets/javascripts/discourse/views/topic.js.es6
+++ b/app/assets/javascripts/discourse/views/topic.js.es6
@@ -126,12 +126,12 @@ var TopicView = Discourse.View.extend(AddCategoryClass, Discourse.Scrolling, {
     var opts = { latestLink: "<a href=\"" + Discourse.getURL("/latest") + "\">" + I18n.t("topic.view_latest_topics") + "</a>" },
         category = this.get('controller.content.category');
 
-    if(category && Em.get(category, 'id') === Discourse.Site.currentProp("uncategorized_category_id")) {
+    if (Em.get(category, 'id') === Discourse.Site.currentProp("uncategorized_category_id")) {
       category = null;
     }
 
     if (category) {
-      opts.catLink = categoryBadgeHTML(category);
+      opts.catLink = categoryBadgeHTML(category, {allowUncategorized: Discourse.SiteSettings.allow_uncategorized_topics && !Discourse.SiteSettings.suppress_uncategorized_badge});
     } else {
       opts.catLink = "<a href=\"" + Discourse.getURL("/categories") + "\">" + I18n.t("topic.browse_all_categories") + "</a>";
     }

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -43,12 +43,7 @@ class Site
         .secured(@guardian)
         .includes(:topic_only_relative_url)
         .order(:position)
-
-      unless SiteSetting.allow_uncategorized_topics
-        categories = categories.where('categories.id <> ?', SiteSetting.uncategorized_category_id)
-      end
-
-      categories = categories.to_a
+        .to_a
 
       allowed_topic_create = Set.new(Category.topic_create_allowed(@guardian).pluck(:id))
 


### PR DESCRIPTION
site.json needs to have all categories a user can see.

This reverts https://github.com/discourse/discourse/commit/bd61cdf21c7348eeaf4246eb91889f2b7f644a1c

@SamSaffron I think that your site had `allow_uncategorized_topics=false` and `suppress_uncategorized_badge=false`.