### PR TITLE
FIX: Importers should create duplicate categories if the parent category is different

### DIFF
--- a/script/import_scripts/bbpress.rb
+++ b/script/import_scripts/bbpress.rb
@@ -87,7 +87,7 @@ class ImportScripts::Bbpress < ImportScripts::Base
         mapped[:custom_fields] = {import_id: post["id"]}
 
         if post["post_type"] == "topic"
-          mapped[:category] = category_from_imported_category_id(post["post_parent"]).try(:name)
+          mapped[:category] = category_id_from_imported_category_id(post["post_parent"])
           mapped[:title] = CGI.unescapeHTML post["post_title"]
         else
           parent = topic_lookup_from_imported_post_id(post["post_parent"])

--- a/script/import_scripts/bespoke_1.rb
+++ b/script/import_scripts/bespoke_1.rb
@@ -199,7 +199,7 @@ class ImportScripts::Bespoke < ImportScripts::Base
         topic = topics[post[:topic_id]]
 
         unless topic[:post_id]
-          mapped[:category] = category_from_imported_category_id(topic[:category_id]).try(:name)
+          mapped[:category] = category_id_from_imported_category_id(topic[:category_id])
           mapped[:title] = post[:title]
           topic[:post_id] = post[:id]
         else

--- a/script/import_scripts/discuz_x.rb
+++ b/script/import_scripts/discuz_x.rb
@@ -171,8 +171,7 @@ class ImportScripts::DiscuzX < ImportScripts::Base
         position: row['position'].to_i + max_position
       }
       if row['parent_id'].to_i > 0
-        parent = category_from_imported_category_id(row['parent_id'])
-        h[:parent_category_id] = parent.id if parent
+        h[:parent_category_id] = category_id_from_imported_category_id(row['parent_id'])
       end
       h
     end
@@ -217,7 +216,7 @@ class ImportScripts::DiscuzX < ImportScripts::Base
         mapped[:created_at] = Time.zone.at(m['post_time'])
 
         if m['is_first_post'] == 1
-          mapped[:category] = category_from_imported_category_id(m['category_id']).try(:name)
+          mapped[:category] = category_id_from_imported_category_id(m['category_id'])
           mapped[:title] = CGI.unescapeHTML(m['title'])
           @first_post_id_by_topic_id[m['topic_id']] = m['id']
         else

--- a/script/import_scripts/drupal.rb
+++ b/script/import_scripts/drupal.rb
@@ -122,7 +122,7 @@ class ImportScripts::Drupal < ImportScripts::Base
         {
           id: "nid:#{row['nid']}",
           user_id: user_id_from_imported_user_id(row['uid']) || -1,
-          category: category_from_imported_category_id(row['tid']).try(:name),
+          category: category_id_from_imported_category_id(row['tid']),
           raw: row['body'],
           created_at: Time.zone.at(row['created']),
           pinned_at: row['sticky'].to_i == 1 ? Time.zone.at(row['created']) : nil,

--- a/script/import_scripts/drupal_qa.rb
+++ b/script/import_scripts/drupal_qa.rb
@@ -61,7 +61,7 @@ class ImportScripts::DrupalQA < ImportScripts::Drupal
         {
           id: "nid:#{row['nid']}",
           user_id: user_id_from_imported_user_id(row['uid']) || -1,
-          category: category_from_imported_category_id((row['tid'] || '').split(',')[0]).try(:name),
+          category: category_id_from_imported_category_id((row['tid'] || '').split(',')[0]),
           raw: row['body'],
           created_at: Time.zone.at(row['created']),
           pinned_at: nil,

--- a/script/import_scripts/kunena.rb
+++ b/script/import_scripts/kunena.rb
@@ -41,8 +41,7 @@ class ImportScripts::Kunena < ImportScripts::Base
     create_categories(@client.query("SELECT id, parent, name, description, ordering FROM jos_kunena_categories ORDER BY parent, id;")) do |c|
       h = {id: c['id'], name: c['name'], description: c['description'], position: c['ordering'].to_i}
       if c['parent'].to_i > 0
-        parent = category_from_imported_category_id(c['parent'])
-        h[:parent_category_id] = parent.id if parent
+        h[:parent_category_id] = category_id_from_imported_category_id(c['parent'])
       end
       h
     end
@@ -121,7 +120,7 @@ class ImportScripts::Kunena < ImportScripts::Base
         mapped[:created_at] = Time.zone.at(m['time'])
 
         if m['id'] == m['thread']
-          mapped[:category] = category_from_imported_category_id(m['catid']).try(:name)
+          mapped[:category] = category_id_from_imported_category_id(m['catid'])
           mapped[:title] = m['subject']
         else
           parent = topic_lookup_from_imported_post_id(m['parent'])

--- a/script/import_scripts/mybb.rb
+++ b/script/import_scripts/mybb.rb
@@ -69,8 +69,7 @@ class ImportScripts::MyBB < ImportScripts::Base
     create_categories(results) do |row|
       h = {id: row['id'], name: CGI.unescapeHTML(row['name']), description: CGI.unescapeHTML(row['description'])}
       if row['parent_id'].to_i > 0
-        parent = category_from_imported_category_id(row['parent_id'])
-        h[:parent_category_id] = parent.id if parent
+        h[:parent_category_id] = category_id_from_imported_category_id(row['parent_id'])
       end
       h
     end
@@ -125,7 +124,7 @@ class ImportScripts::MyBB < ImportScripts::Base
         mapped[:created_at] = Time.zone.at(m['post_time'])
 
         if m['id'] == m['first_post_id']
-          mapped[:category] = category_from_imported_category_id(m['category_id']).try(:name)
+          mapped[:category] = category_id_from_imported_category_id(m['category_id'])
           mapped[:title] = CGI.unescapeHTML(m['title'])
         else
           parent = topic_lookup_from_imported_post_id(m['first_post_id'])

--- a/script/import_scripts/ning.rb
+++ b/script/import_scripts/ning.rb
@@ -200,7 +200,7 @@ class ImportScripts::Ning < ImportScripts::Base
           mapped[:user_id] = user_id_from_imported_user_id(topic["contributorName"]) || -1
           mapped[:created_at] = Time.zone.parse(topic["createdDate"])
           unless topic["category"].nil? || topic["category"].downcase == "uncategorized"
-            mapped[:category] = category_from_imported_category_id(topic["category"]).try(:name)
+            mapped[:category] = category_id_from_imported_category_id(topic["category"])
           end
           if topic["category"].nil? && default_category
             mapped[:category] = default_category

--- a/script/import_scripts/phpbb3.rb
+++ b/script/import_scripts/phpbb3.rb
@@ -114,8 +114,7 @@ class ImportScripts::PhpBB3 < ImportScripts::Base
     create_categories(results) do |row|
       h = {id: row['id'], name: CGI.unescapeHTML(row['name']), description: CGI.unescapeHTML(row['description'])}
       if row['parent_id'].to_i > 0
-        parent = category_from_imported_category_id(row['parent_id'])
-        h[:parent_category_id] = parent.id if parent
+        h[:parent_category_id] = category_id_from_imported_category_id(row['parent_id'])
       end
       h
     end
@@ -156,7 +155,7 @@ class ImportScripts::PhpBB3 < ImportScripts::Base
         mapped[:created_at] = Time.zone.at(m['post_time'])
 
         if m['id'] == m['first_post_id']
-          mapped[:category] = category_from_imported_category_id(m['category_id']).try(:name)
+          mapped[:category] = category_id_from_imported_category_id(m['category_id'])
           mapped[:title] = CGI.unescapeHTML(m['title'])
         else
           parent = topic_lookup_from_imported_post_id(m['first_post_id'])

--- a/script/import_scripts/smf2.rb
+++ b/script/import_scripts/smf2.rb
@@ -145,7 +145,7 @@ class ImportScripts::Smf2 < ImportScripts::Base
       FROM {prefix}boards
       ORDER BY id_parent ASC, id_board ASC
     SQL
-      parent_id = category_from_imported_category_id(board[:id_parent]).id if board[:id_parent] > 0
+      parent_id = category_id_from_imported_category_id(board[:id_parent]) if board[:id_parent] > 0
       groups = (board[:member_groups] || "").split(/,/).map(&:to_i)
       restricted = !groups.include?(GUEST_GROUP) && !groups.include?(MEMBER_GROUP)
       {
@@ -257,7 +257,7 @@ class ImportScripts::Smf2 < ImportScripts::Base
         end
       }
       if message[:id_msg] == message[:id_first_msg]
-        post[:category] = category_from_imported_category_id(message[:id_board]).try(:name)
+        post[:category] = category_id_from_imported_category_id(message[:id_board])
         post[:title] = decode_entities(message[:subject])
       else
         parent = topic_lookup_from_imported_post_id(message[:id_first_msg])

--- a/script/import_scripts/vanilla.rb
+++ b/script/import_scripts/vanilla.rb
@@ -144,8 +144,7 @@ class ImportScripts::Vanilla < ImportScripts::Base
         description: clean_up(category[:description]),
       }
       if category[:parent_category_id] != "-1"
-        parent_category = category_from_imported_category_id(category[:parent_category_id])
-        c[:parent_category_id] = parent_category.id if parent_category
+        c[:parent_category_id] = category_id_from_imported_category_id(category[:parent_category_id])
       end
       c
     end
@@ -162,7 +161,7 @@ class ImportScripts::Vanilla < ImportScripts::Base
           id: "discussion#" + discussion[:discussion_id],
           user_id: user_id_from_imported_user_id(discussion[:insert_user_id]) || Discourse::SYSTEM_USER_ID,
           title: discussion[:name],
-          category: category_from_imported_category_id(discussion[:category_id]).try(:name),
+          category: category_id_from_imported_category_id(discussion[:category_id]),
           raw: clean_up(discussion[:body]),
           created_at: parse_date(discussion[:date_inserted]),
         }

--- a/script/import_scripts/vbulletin.rb
+++ b/script/import_scripts/vbulletin.rb
@@ -181,7 +181,7 @@ class ImportScripts::VBulletin < ImportScripts::Base
         name: @htmlentities.decode(category["title"]).strip,
         position: category["displayorder"],
         description: @htmlentities.decode(category["description"]).strip,
-        parent_category_id: category_from_imported_category_id(category["parentid"]).try(:[], "id")
+        parent_category_id: category_id_from_imported_category_id(category["parentid"])
       }
     end
   end
@@ -216,7 +216,7 @@ class ImportScripts::VBulletin < ImportScripts::Base
           id: topic_id,
           user_id: user_id_from_imported_user_id(topic["postuserid"]) || Discourse::SYSTEM_USER_ID,
           title: @htmlentities.decode(topic["title"]).strip[0...255],
-          category: category_from_imported_category_id(topic["forumid"]).try(:name),
+          category: category_id_from_imported_category_id(topic["forumid"]),
           raw: raw,
           created_at: parse_timestamp(topic["dateline"]),
           visible: topic["visible"].to_i == 1,

--- a/script/import_scripts/vbulletin_old.rb
+++ b/script/import_scripts/vbulletin_old.rb
@@ -460,7 +460,7 @@ class ImportScripts::VBulletinOld < ImportScripts::Base
           id: id,
           user_id: user_id_from_imported_user_id(topic[:postuserid]) || Discourse::SYSTEM_USER_ID,
           title: CGI.unescapeHTML(topic[:title]).strip[0...255],
-          category: category_from_imported_category_id(topic[:forumid]).try(:name),
+          category: category_id_from_imported_category_id(topic[:forumid]),
           raw: post[:raw],
           created_at: Time.at(topic[:dateline].to_i),
           visible: topic[:visible].to_i == 1,


### PR DESCRIPTION
https://meta.discourse.org/t/phpbb-3-importer-goes-slow/26182/8?u=gerhard

This changes the content of `@categories_lookup` in the base importer from `Category` objects to IDs since the category names aren't needed anymore. The lookup method has been renamed too.
All importers (except askbot which seems to do this differently) were changed to use the category ID instead of name.