### PR TITLE
Imported users shouldn't get an email immediately after the import

### DIFF
--- a/script/import_scripts/base.rb
+++ b/script/import_scripts/base.rb
@@ -293,6 +293,7 @@ class ImportScripts::Base
     opts[:trust_level] = TrustLevel[1] unless opts[:trust_level]
     opts[:active] = opts.fetch(:active, true)
     opts[:import_mode] = true
+    opts[:last_emailed_at] = opts.fetch(:last_emailed_at, Time.now)
 
     u = User.new(opts)
     u.custom_fields["import_id"] = import_id


### PR DESCRIPTION
This sets the `last_emailed_at` for imported users to now which postpones the sending of digest emails for the configured amount of time. Therefore, the first digest email gets sent after 1 week (the default value of `default_digest_email_frequency`).
As suggested in https://meta.discourse.org/t/dont-trigger-digests-on-migration/26345/7