### PR TITLE
single quote password in backup command

### DIFF
--- a/lib/backup_restore/backuper.rb
+++ b/lib/backup_restore/backuper.rb
@@ -174,7 +174,7 @@ module BackupRestore
     def pg_dump_command
       db_conf = BackupRestore.database_configuration
 
-      password_argument = "PGPASSWORD=#{db_conf.password}" if db_conf.password.present?
+      password_argument = "PGPASSWORD='#{db_conf.password}'" if db_conf.password.present?
       host_argument     = "--host=#{db_conf.host}"         if db_conf.host.present?
       port_argument     = "--port=#{db_conf.port}"         if db_conf.port.present?
       username_argument = "--username=#{db_conf.username}" if db_conf.username.present?


### PR DESCRIPTION
This protects against characters like '&' in passwords. Sometimes you are assigned passwords by idiots or are and idiot that uses pronounceable passwords.  Anyways this small change protects against ruby's shell interpreter from background the pg_dump command before it has really started.