### PR TITLE
Add an sso option to suppress welcome emails

### DIFF
--- a/app/models/discourse_single_sign_on.rb
+++ b/app/models/discourse_single_sign_on.rb
@@ -60,7 +60,7 @@ class DiscourseSingleSignOn < SingleSignOn
     if sso_record && (user = sso_record.user) && !user.active
       user.active = true
       user.save!
-      user.enqueue_welcome_message('welcome_user')
+      user.enqueue_welcome_message('welcome_user') unless suppress_welcome_message
     end
 
     custom_fields.each do |k,v|

--- a/lib/single_sign_on.rb
+++ b/lib/single_sign_on.rb
@@ -1,8 +1,8 @@
 class SingleSignOn
   ACCESSORS = [:nonce, :name, :username, :email, :avatar_url, :avatar_force_update,
-               :about_me, :external_id, :return_sso_url, :admin, :moderator]
+               :about_me, :external_id, :return_sso_url, :admin, :moderator, :suppress_welcome_message]
   FIXNUMS = []
-  BOOLS = [:avatar_force_update, :admin, :moderator]
+  BOOLS = [:avatar_force_update, :admin, :moderator, :suppress_welcome_message]
   NONCE_EXPIRY_TIME = 10.minutes
 
   attr_accessor(*ACCESSORS)

--- a/spec/models/discourse_single_sign_on_spec.rb
+++ b/spec/models/discourse_single_sign_on_spec.rb
@@ -106,6 +106,28 @@ describe DiscourseSingleSignOn do
     expect(sso.nonce).to_not be_nil
   end
 
+  context 'welcome emails' do
+    let(:sso) {
+      sso = DiscourseSingleSignOn.new
+      sso.username = "test"
+      sso.name = "test"
+      sso.email = "test@example.com"
+      sso.external_id = "A"
+      sso
+    }
+
+    it "sends a welcome email by default" do
+      User.any_instance.expects(:enqueue_welcome_message).once
+      user = sso.lookup_or_create_user(ip_address)
+    end
+
+    it "suppresses the welcome email when asked to" do
+      User.any_instance.expects(:enqueue_welcome_message).never
+      sso.suppress_welcome_message = true
+      user = sso.lookup_or_create_user(ip_address)
+    end
+  end
+
   context 'when sso_overrides_avatar is enabled' do
     let!(:sso_record) { Fabricate(:single_sign_on_record, external_avatar_url: "http://example.com/an_image.png") }
     let!(:sso) {


### PR DESCRIPTION
As discussed here: https://meta.discourse.org/t/create-new-sso-users-without-sending-welcome-emails/24894