### PR TITLE
FEATURE: allow to disable stringex for symbolizing the topic and category title

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -849,6 +849,7 @@ en:
     email_domains_whitelist: "A list of email domains that users MUST register accounts with. WARNING: Users with email domains other than those listed will not be allowed!"
     forgot_password_strict: "Don't inform users of an account's existance when they use the forgot password dialog."
     log_out_strict: "When logging out, log out ALL sessions for the user on all devices"
+    enable_stringex: "Enable the stringex for allowing Discourse to generate symbolized slug. (This is only useful for zh_CN and ja)"
     version_checks: "Ping the Discourse Hub for version updates and show new version messages on the /admin dashboard"
     new_version_emails: "Send an email to the contact_email address when a new version of Discourse is available."
 

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -738,6 +738,8 @@ backups:
     regex: "^[^\\.]*$"
 
 uncategorized:
+  enable_stringex: false
+
   version_checks:
     client: true
     default: true

--- a/lib/slug.rb
+++ b/lib/slug.rb
@@ -6,7 +6,7 @@ module Slug
   def self.for(string)
     # TODO review if ja should use this
     # ko asked for it to be removed
-    if ['zh_CN', 'ja'].include?(SiteSetting.default_locale)
+    if SiteSetting.enable_stringex && ['zh_CN', 'ja'].include?(SiteSetting.default_locale)
       unless defined? Stringex
         require 'stringex_lite'
       end


### PR DESCRIPTION
I received a lot of request to remove the symbolized the slug for Chinese. They think the slug generated by stringex is not good enough but they are totally fine with the default `topic`.

As we can already set the category slug manually, it's cool to make the slug for title optional. This PR is a compromising effect since disabling slugger(`Slug.for`) may lead to other components collapsed.

I found several place use `Slug.for` which I can't understand. So I would postpone to refactor them until I know why it's there.

If the team are open to this change, I will fix the spec