### PR TITLE
FIX: do not delete already redeemed invite

### DIFF
--- a/app/models/invite_redeemer.rb
+++ b/app/models/invite_redeemer.rb
@@ -117,6 +117,6 @@ InviteRedeemer = Struct.new(:invite, :username, :name) do
   end
 
   def delete_duplicate_invites
-    Invite.where('invites.email = ? and invites.id != ?', invite.email, invite.id).delete_all
+    Invite.where('invites.email = ? AND redeemed_at IS NULL AND invites.id != ?', invite.email, invite.id).delete_all
   end
 end

--- a/spec/models/invite_spec.rb
+++ b/spec/models/invite_spec.rb
@@ -198,6 +198,13 @@ describe Invite do
         expect(duplicate_invite).to be_nil
       end
 
+      it 'does not delete already redeemed invite' do
+        redeemed_invite = Fabricate(:invite, email: invite.email, invited_by: another_user, redeemed_at: 1.day.ago)
+        invite.redeem
+        used_invite = Invite.find_by(id: redeemed_invite.id)
+        expect(used_invite).not_to be_nil
+      end
+
     end
 
     context 'enqueues a job to email "set password" instructions' do


### PR DESCRIPTION
In case user has already been invited by someone, and the user accepts another invitation (via invite token URL, to be added into private/secret group), we should not delete the originally redeemed invite.