### PR TITLE
FIX: Don't stop the badge grant after the first failure

### DIFF
--- a/app/jobs/scheduled/badge_grant.rb
+++ b/app/jobs/scheduled/badge_grant.rb
@@ -11,7 +11,12 @@ module Jobs
       return unless SiteSetting.enable_badges
 
       Badge.all.each do |b|
-        BadgeGranter.backfill(b)
+        begin
+          BadgeGranter.backfill(b)
+        rescue => ex
+          # TODO - expose errors in UI
+          Discourse.handle_job_exception(ex, error_context({}, code_desc: 'Exception granting badges', extra: {badge_id: b.id}))
+        end
       end
 
       BadgeGranter.revoke_ungranted_titles!

--- a/app/services/badge_granter.rb
+++ b/app/services/badge_granter.rb
@@ -120,7 +120,9 @@ class BadgeGranter
       user_ids = list.map{|i| i["user_ids"]}.flatten.compact.uniq
 
       next unless post_ids.present? || user_ids.present?
-      find_by_type(type).each{|badge| backfill(badge, post_ids: post_ids, user_ids: user_ids)}
+      find_by_type(type).each{ |badge|
+        backfill(badge, post_ids: post_ids, user_ids: user_ids)
+      }
     end
   end
 


### PR DESCRIPTION
https://meta.discourse.org/t/solved-badges-update-daily-wont-trigger/25659/3