### PR TITLE
UX: cleaner trending up/down stats colors

### DIFF
--- a/app/assets/stylesheets/common/admin/admin_base.scss
+++ b/app/assets/stylesheets/common/admin/admin_base.scss
@@ -799,14 +799,14 @@ table.api-keys {
       }
 
       &.trending-up {
-        color: $success;
         i.up {
+          color: $success;
           display: inline;
         }
       }
       &.trending-down {
-        color: $danger;
         i.down {
+          color: $danger;
           display: inline;
         }
       }


### PR DESCRIPTION
Before:
![before](https://cloud.githubusercontent.com/assets/1285361/6975265/a6cb967e-d99a-11e4-84d5-70ffc4f9ffc2.png)

After:
![after](https://cloud.githubusercontent.com/assets/1285361/6975266/ab4d18f8-d99a-11e4-8c6b-8e610bb84448.png)

The reason for this is that if, say, I have `1000 (down arrow)` all colored in red, then I'm led to believe that that stat has *decreased by 1000* (which is not necessarily the case, maybe it decreased by 1).