### PR TITLE
[WIP] FEATURE: per-language defaults for site settings

### DIFF
--- a/config/default_settings/zh_CN.yml
+++ b/config/default_settings/zh_CN.yml
@@ -1,0 +1,11 @@
+posting:
+  min_post_length: 8
+  min_first_post_length: 8
+  min_private_message_post_length: 4
+  min_topic_title_length: 5
+  uncategorized_description: 不需要分类的主题，或者不适用于任何分类的主题。
+  min_title_similar_length: 5
+  min_body_similar_length: 6
+
+uncategorized:
+  min_search_term_length: 2

--- a/lib/site_setting_extension.rb
+++ b/lib/site_setting_extension.rb
@@ -66,6 +66,13 @@ module SiteSettingExtension
     @validators ||= {}
   end
 
+  def override_setting_default(name_arg, default)
+    name = name_arg.to_sym
+    mutex.synchronize do
+      self.defaults[name] = default
+    end
+  end
+
   def setting(name_arg, default = nil, opts = {})
     name = name_arg.to_sym
     mutex.synchronize do
@@ -291,6 +298,8 @@ module SiteSettingExtension
     provider.save(name, val, type)
     current[name] = convert(val, type)
     clear_cache!
+
+    SiteSetting.refresh_defaults! if name.to_sym == :default_locale
   end
 
   def notify_changed!


### PR DESCRIPTION
have to use `refresh!` twice to get it work for two circumstances:
- Rails booting
- `default_locale` changed. 

Where should we put the overrides? File approach may be not so helpful since the overrides is not big.

https://meta.discourse.org/t/setting-default-site-settings-and-scss-based-on-locale/25217