### PR TITLE
Allowing feed polling with UTF-8 titles

### DIFF
--- a/app/models/search_observer.rb
+++ b/app/models/search_observer.rb
@@ -36,7 +36,7 @@ class SearchObserver < ActiveRecord::Observer
   end
 
   def self.update_topics_index(topic_id, title, cooked)
-    search_data = title.dup << " " << scrub_html_for_search(cooked)[0...Topic::MAX_SIMILAR_BODY_LENGTH]
+    search_data = title.force_encoding(Encoding::UTF_8).dup << " " << scrub_html_for_search(cooked)[0...Topic::MAX_SIMILAR_BODY_LENGTH]
     update_index('topic', topic_id, search_data)
   end
 


### PR DESCRIPTION
This pull request prevents the following error when the pooled feed contains special characters:
```
Job exception: incompatible character encodings: ASCII-8BIT and UTF-8
```

Source: https://meta.discourse.org/t/embed-poll-feed-fail-with-utf8-title/25776