### PR TITLE
Update persian translate

### DIFF
--- a/app/assets/javascripts/locales/fa_IR.js.erb
+++ b/app/assets/javascripts/locales/fa_IR.js.erb
@@ -1,3 +1,6 @@
 //= depend_on 'client.fa_IR.yml'
 //= require locales/i18n
 <%= JsLocaleHelper.output_locale(:fa_IR) %>
+I18n.pluralizationRules['fa_IR'] = function (n) {
+    return "other";
+};

--- a/config/locales/client.fa_IR.yml
+++ b/config/locales/client.fa_IR.yml
@@ -76,7 +76,7 @@ fa_IR:
         x_days:
           other: "%{count} روز پیش"
     share:
-      topic: 'پیوندی به این جستار را به اشتراک بگذارید'
+      topic: 'پیوندی به این موضوع را به اشتراک بگذارید'
       post: 'ارسال #%{postNumber}'
       close: 'بسته'
       twitter: 'این پیوند را در توییتر به اشتراک بگذارید.'
@@ -85,7 +85,8 @@ fa_IR:
       email: 'این پیوند را با ایمیل بفرستید'
     topic_admin_menu: "اقدامات مدیریت موضوع"
     emails_are_disabled: "تمام ایمیل های خروجی بصورت جهانی توسط مدیر قطع شده. هیچ ایمیل اخطاریه های ارسال نخواهد شد."
-    edit: 'سرنویس و دستهٔ این جستار را ویرایش کنید'
+    s3_deprecation_warning: "اخطار! آمازون S3 برای ذخیره سازی تصویر / فایل ضمیمه توصیه نمی شود. لطفا، به دنبال <a href='https://meta.discourse.org/t/warning-amazon-s3-is-deprecated-in-1-3-for-image-attachment-storage/26594'>دستورالعمل ها</a> و مهاجرت به ذخیره سازی محلی."
+    edit: 'سرنویس و دستهٔ این موضوع را ویرایش کنید'
     not_implemented: "آن ویژگی هنوز به کار گرفته نشده، متأسفیم!"
     no_value: "نه"
     yes_value: "بله"
@@ -94,7 +95,7 @@ fa_IR:
     sign_up: "ثبت نام"
     log_in: "ورود"
     age: "سن"
-    joined: "عضو"
+    joined: "ملحق شده در"
     admin_title: "مدیر"
     flags_title: "پرچم‌ها"
     show_more: "بیش‌تر نشان بده"
@@ -123,7 +124,7 @@ fa_IR:
     character_count:
       other: "{{count}} نویسه"
     suggested_topics:
-      title: "مباحث پیشنهادی"
+      title: "موضوعات پیشنهادی"
     about:
       simple_title: "درباره"
       title: "درباره %{title}"
@@ -135,7 +136,7 @@ fa_IR:
         last_7_days: "7 روز اخیر"
         last_30_days: "30 روز گذشته"
       like_count: "لایک ها "
-      topic_count: "مباحث"
+      topic_count: "موضوعات"
       post_count: "پست ها"
       user_count: "کاربران جدید"
       active_user_count: "کاربران فعال"
@@ -145,25 +146,25 @@ fa_IR:
       title: "نشانک"
       clear_bookmarks: "پاک کردن نشانک ها"
       help:
-        bookmark: "برای نشانک گذاری به اولین نوشته این جستار مراجعه نمایید"
-        unbookmark: "برای حذف تمام نشانک های این جستار کلیک کنید"
+        bookmark: "برای نشانک گذاری به اولین نوشته این موضوع مراجعه نمایید"
+        unbookmark: "برای حذف تمام نشانک های این موضوع کلیک کنید"
     bookmarks:
-      not_logged_in: "متأسفیم، شما باید به درون بیایید تا روی دیدگاه‌ها نشانک بگذارید."
-      created: "شما این دیدگاه را نشانک گذاشته‌اید."
-      not_bookmarked: "شما این دیدگاه را خوانده‌اید؛ بفشارید تا روی آن نشانک بگذارید."
-      last_read: "این آخرین دیدگاهی است که خوانده‌اید؛ بفشارید تا روی آن نشانک بگذارید."
+      not_logged_in: "متأسفیم، شما باید به وارد شوید تا روی نوشته ها نشانک بگذارید."
+      created: "شما این نوشته ها را نشانک گذاشته‌اید."
+      not_bookmarked: "شما این نوشته را خوانده‌اید؛ بفشارید تا روی آن نشانک بگذارید."
+      last_read: "این آخرین نوشته ای  است که خوانده‌اید؛ بفشارید تا روی آن نشانک بگذارید."
       remove: "پاک کردن نشانک"
-      confirm_clear: "آیا مطمئنید که می‌خواهید همه بوک‌ مارک‌ها را از این جستار پاک کنید؟"
+      confirm_clear: "آیا مطمئنید که می‌خواهید همه نشانک ها را از این موضوع پاک کنید؟"
     topic_count_latest:
-      other: "{{count}} جستار‌های تازه یا به‌ روز شده."
+      other: "{{count}} موضوعات تازه یا به‌ روز شده."
     topic_count_unread:
-      other: "{{count}} جستار خوانده نشده."
+      other: "{{count}} موضوعات خوانده نشده."
     topic_count_new:
-      other: "{{count}} جستار تازه."
+      other: "{{count}} موضوعات تازه."
     click_to_show: "برای نمایش کلیک کنید."
     preview: "پیش‌نمایش"
     cancel: "لغو"
-    save: "اندوختن تغییرها"
+    save: "ذخیره سازی تغییرات"
     saving: "در حال ذخیره سازی ..."
     saved: "ذخیره شد!"
     upload: "بارگذاری"
@@ -177,20 +178,20 @@ fa_IR:
     banner:
       close: "این سردر را رد بده."
     choose_topic:
-      none_found: "جستاری یافت نشد."
+      none_found: "موضوعی یافت نشد."
       title:
-        search: "جستجو برای یک جستار از روی نام، نشانی (url) یا شناسه (id)"
-        placeholder: "سرنویس جستار را اینجا بنویسید"
+        search: "جستجو برای یک موضوع از روی نام، نشانی (url) یا شناسه (id)"
+        placeholder: "سرنویس موضوع را اینجا بنویسید"
     user_action:
       user_posted_topic: "<a href='{{userUrl}}'>{{user}}</a> posted <a href='{{topicUrl}}'>the topic</a>"
-      you_posted_topic: "<a href='{{userUrl}}'>شما</a> در <a href='{{topicUrl}}'>این جستار</a> دیدگاه گذاشتید"
+      you_posted_topic: "<a href='{{userUrl}}'>شما</a> در <a href='{{topicUrl}}'>این موضوع</a> نوشته گذاشتید"
       user_replied_to_post: "<a href='{{userUrl}}'>{{user}}</a> replied to <a href='{{postUrl}}'>{{post_number}}</a>"
       you_replied_to_post: "<a href='{{userUrl}}'>You</a> replied to <a href='{{postUrl}}'>{{post_number}}</a>"
       user_replied_to_topic: "<a href='{{userUrl}}'>{{user}}</a> replied to <a href='{{topicUrl}}'>the topic</a>"
       you_replied_to_topic: "<a href='{{userUrl}}'>You</a> replied to <a href='{{topicUrl}}'>the topic</a>"
       user_mentioned_user: "<a href='{{user1Url}}'>{{user}}</a> mentioned <a href='{{user2Url}}'>{{another_user}}</a>"
       user_mentioned_you: "<a href='{{user1Url}}'>{{user}}</a> mentioned <a href='{{user2Url}}'>you</a>"
-      you_mentioned_user: "<a href='{{user1Url}}'>You</a> mentioned <a href='{{user2Url}}'>{{another_user}}</a>"
+      you_mentioned_user: "<a href='{{user1Url}}'>شما</a>  نام برده شده اید <a href='{{user2Url}}'>{{another_user}}</a>"
       posted_by_user: "Posted by <a href='{{userUrl}}'>{{user}}</a>"
       posted_by_you: "Posted by <a href='{{userUrl}}'>you</a>"
       sent_by_user: "Sent by <a href='{{userUrl}}'>{{user}}</a>"
@@ -203,7 +204,7 @@ fa_IR:
       topics_entered: "وارد شده"
       topics_entered_long: "موضوعات وارد شده"
       time_read: "زمان خوانده‌شده"
-      topic_count: "مباحث"
+      topic_count: "موضوعات"
       topic_count_long: "موضوعات ساخته شده"
       post_count: "پاسخ ها"
       post_count_long: "پاسخ داده شده ها"
@@ -218,20 +219,20 @@ fa_IR:
       visible: "همهٔ کاربران گروه را می‌بینند"
       title:
         other: "گروه‌ها"
-      members: "کاربران"
-      posts: "دیدگاه‌ها"
+      members: "اعضا"
+      posts: "نوشته ها"
       alias_levels:
         title: "چه کسی می تواند این گروه به عنوان یک نام مستعار استفاده کند؟"
         nobody: "هیچ‌کس"
         only_admins: "تنها مدیران"
-        mods_and_admins: "تنها ناظمان و مدیران"
-        members_mods_and_admins: "تنها کاربران گروه، ناظمان و مدیران"
+        mods_and_admins: "تنها مدیران کل و مدیران"
+        members_mods_and_admins: "تنها کاربران گروه، مدیران ومدیران کل"
         everyone: "هرکس"
     user_action_groups:
       '1': "پسندهای اعطایی"
       '2': "پسندهای دریافتی"
       '3': "نشانک‌ها"
-      '4': "جُستارها"
+      '4': "موضوعات"
       '5': "پاسخ ها"
       '6': "واکنش"
       '7': "اشاره‌ها"
@@ -241,21 +242,22 @@ fa_IR:
       '12': "فرستاده‌ها"
       '13': "صندوق دریافت"
     categories:
-      all: "همهٔ دسته‌ها"
+      all: "همهٔ دسته‌بندی ها"
       all_subcategories: "همه"
       no_subcategory: "هیچی"
-      category: "دسته"
-      posts: "دیدگاه‌ها"
-      topics: "جستارها"
+      category: "دسته بندی"
+      posts: "نوشته ها"
+      topics: "موضوعات"
       latest: "آخرین"
       latest_by: "آخرین توسط"
-      subcategories: "زیردسته‌ها"
-      topic_stats: "شمار جستارهای تازه."
+      toggle_ordering: "ضامن کنترل مرتب سازی"
+      subcategories: "زیر دسته‌ بندی ها"
+      topic_stats: "شمار موضوعات تازه."
       topic_stat_sentence:
-        other: "%{count} جستار تازه در %{unit} گذشته."
-      post_stats: "شمار دیدگاهی تازه."
+        other: "%{count} موضوعات تازه در %{unit} گذشته."
+      post_stats: "شمار نوشته های تازه."
       post_stat_sentence:
-        other: "%{count} دیدگاه تازه در %{unit} گذشته."
+        other: "%{count} نوشته تازه در %{unit} گذشته."
     ip_lookup:
       title: جستجوی نشانی IP
       hostname: نام میزبان
@@ -268,7 +270,7 @@ fa_IR:
       username: "نام کاربری"
       trust_level: "TL"
       read_time: "زمان خواندن"
-      topics_entered: "مباحث وارد شده"
+      topics_entered: "موضوعات وارد شده"
       post_count: "# نوشته ها"
       confirm_delete_other_accounts: "آیا مطمئن هستید که می خواهید این حساب کاربری را حذف نمایید؟"
     user:
@@ -277,8 +279,8 @@ fa_IR:
       mute: "بی صدا"
       edit: "ویرایش تنظیمات"
       download_archive: "بار گیری نوشته های من ."
-      new_private_message: "پیغام های جدید"
-      private_message: "پیغام"
+      new_private_message: "پیام های جدید"
+      private_message: "پیام"
       private_messages: "پیام‌ها"
       activity_stream: "فعالیت"
       preferences: "تنظیمات"
@@ -291,24 +293,24 @@ fa_IR:
       dismiss_notifications_tooltip: "علامت گذاری همه اطلاعیه های خوانده نشده به عنوان خوانده شده"
       disable_jump_reply: "بعد از پاسخ من به پست من پرش نکن"
       dynamic_favicon: "آگاه‌سازی پیام‌های آمده را در favicon نمایش بده (آزمایشی)"
-      edit_history_public: "اجازه بده کاربران دیگر اصلاحات دیدگاه مرا ببینند"
+      edit_history_public: "اجازه بده کاربران دیگر اصلاحات نوشته مرا ببینند"
       external_links_in_new_tab: "همهٔ پیوندهای برون‌رو را در یک تب جدید باز کن"
       enable_quoting: "فعال کردن نقل قول گرفتن از متن انتخاب شده"
       change: "تغییر"
-      moderator: "{{user}} یک ناظم است"
-      admin: "{{user}} یک مدیر است"
-      moderator_tooltip: "این کاربر یک ناظم است"
+      moderator: "{{user}} یک مدیر است"
+      admin: "{{user}} یک مدیر کل است"
+      moderator_tooltip: "این کاربر یک مدیر است"
       admin_tooltip: "این کاربر یک مدیر است"
       suspended_notice: "این کاربر تا {{date}} در وضعیت معلق است."
-      suspended_reason: "در جابه‌جایی دیدگاه‌ها به جستار خطایی روی داد."
+      suspended_reason: "در جابه‌جایی نوشته‌ها به موضوع خطایی روی داد."
       github_profile: "گیت هاب"
-      mailing_list_mode: "برای هر دیدگاه جدید، رایانامه‌ای برای من بفرست (مگر اینکه من جستار یا دسته‌بندی را ساکت کنم)"
+      mailing_list_mode: "برای هر نوشته جدید، رایانامه‌ای برای من بفرست (مگر اینکه من موضوع یا دسته‌بندی را ساکت کنم)"
       watched_categories: "تماشا"
-      watched_categories_instructions: "شما همهٔ‌ جستارهای تازه در این دسته‌ها را خودکار خواهید دید. از همهٔ دیدگاه‌ها و جستارهای تازه آگاه خواهید شد، هم‌چنین شمار دیدگاه‌های تازه و نخوانده پس از فهرست جستار نشان داده می‌شود."
+      watched_categories_instructions: "شما همهٔ‌ موضوعات تازه در این دسته‌بندی ها را خودکار خواهید دید. از همهٔ نوشته ها و موضوعات تازه آگاه خواهید شد، هم‌چنین شمار نوشته های تازه و نخوانده پس از فهرست موضوع نشان داده می‌شود."
       tracked_categories: "پی‌گیری"
-      tracked_categories_instructions: "شما همهٔ‌ موضوعات تازه در این دسته‌ها را به صورت خودکار دنبال خواهید کرد. تعداد نوشته‌های تازه و خوانده نشده بعد از موضوع نشان داده خواهد شد."
+      tracked_categories_instructions: "شما همهٔ‌ موضوعات تازه در این دسته‌ بندی ها را به صورت خودکار دنبال خواهید کرد. تعداد نوشته‌های تازه و خوانده نشده بعد از موضوع نشان داده خواهد شد."
       muted_categories: "ساکت"
-      muted_categories_instructions: "از هر آن‌چه درباره جستارهای تازه در این دسته‌ها روی دهد، شما آگاه نخواهید شد و در تب نخواندهٔ‌ شما نمایش داده نمی‌شوند."
+      muted_categories_instructions: "از هر آن‌چه درباره موضوعات تازه در این دسته‌ بندی ها روی دهد، شما آگاه نخواهید شد و در تب نخواندهٔ‌ شما نمایش داده نمی‌شوند."
       delete_account: "حساب من را پاک کن"
       delete_account_confirm: "آیا مطمئنید که می‌خواهید شناسه‌تان را برای همیشه پاک کنید؟ برگشتی در کار نیست!"
       deleted_yourself: "حساب‌ کاربری شما با موفقیت حذف شد."
@@ -316,29 +318,29 @@ fa_IR:
       unread_message_count: "پیام‌ها"
       admin_delete: "پاک کردن"
       users: "کاربران"
-      muted_users: "بی شدا شد"
+      muted_users: "بی صدا شده"
       muted_users_instructions: "توقیف تمام اطلاعیه های این کاربران."
       staff_counters:
-        flags_given: "نسانه گذاری های مفید"
-        flagged_posts: "نوشته های نشانه گذاری شده"
+        flags_given: "پرچم گذاری های مفید"
+        flagged_posts: "نوشته های پرچم گذاری شده"
         deleted_posts: "پست های حذف شده"
         suspensions: "تعلیق کردن"
         warnings_received: "هشدار ها"
       messages:
         all: "همه"
         mine: "خودم"
-        unread: "نخوانده"
+        unread: "خوانده‌ نشده‌"
       change_password:
         success: "(رایانامه فرستاده شد)"
         in_progress: "(در حال فرستادن رایانامه)"
         error: "(خطا)"
         action: "ارسال کلمه عبور به ایمیل"
-        set_password: "تغییر رمز عبور"
+        set_password: "تغییر کلمه عبور"
       change_about:
         title: "تغییر «دربارهٔ من»"
       change_username:
         title: "تغییر نام کاربری"
-        confirm: "اگر نام کاربری خود را تغییر دهید، همهٔ نقل‌قول‌های پیشین از دیدگاه‌های شما و اشاره‌های @name از کار می‌افتند. آیا برای انجام این کار اطمینان کامل دارید؟"
+        confirm: "اگر نام کاربری خود را تغییر دهید، همهٔ نقل‌قول‌های پیشین از نوشته‌های شما و اشاره‌های @name از کار می‌افتند. آیا برای انجام این کار اطمینان کامل دارید؟"
         taken: "متأسفیم، آن نام کاربری گرفته شده است."
         error: "در فرآیند تغییر نام کاربری شما خطایی روی داد."
         invalid: "آن نام کاربری نامعتبر است. تنها باید عددها و حرف‌ها را در بر بگیرد."
@@ -351,11 +353,12 @@ fa_IR:
         title: "عکس نمایه خود را تغییر دهید"
         gravatar: "<a href='//gravatar.com/emails' target='_blank'>گراواتا</a>, بر اساس"
         refresh_gravatar_title: "تازه‌سازی گراواتارتان"
+        letter_based: "سیستم تصویر پرفایل را اختصاص داده است"
         uploaded_avatar: "تصویر شخصی"
         uploaded_avatar_empty: "افزودن تصویر شخصی"
         upload_title: "تصویرتان را بار بگذارید"
         upload_picture: "بارگذاری تصویر"
-        image_is_not_a_square: "هشدار: تصویرتان را برش داده‌ایم؛ چهارگوش نیست."
+        image_is_not_a_square: "اخطار : ما تصویر شما بریدیم;طول و عرض برابر نبود"
       change_profile_background:
         title: "پس‌زمینه نمایه"
         instructions: "تصاویر پس‌زمینه نمایه‌ها در مرکز قرار میگیرند و به صورت پیش‌فرض طول 850px دارند."
@@ -370,11 +373,12 @@ fa_IR:
         authenticated: "ایمیل شما تصدیق شد توسط {{provider}}"
         frequency:
           zero: "ما برای شما سریعا ایمیلی می فرستیم در صورتی که چیزهای فرستاده شده در ایمیل را نخوانده باشید"
-          one: "ما در صورتی به شما ایمیل می زنیم که شما در لحظه آخر ندیده باشیم"
-          other: "ما در صورتی به شما ایمیل می زنیم که شما را در آخرین دقیقه {{شمار}}  ندیده باشیم "
+          one: "ما در صورتی به شما ایمیل می زنیم که شما را تا آخرین لحظه ندیده باشیم"
+          other: "ما در صورتی به شما ایمیل می زنیم که شما را تا دقیقه {{count}}  ندیده باشیم "
       name:
         title: "نام"
         instructions: "نام کامل (اختیاری)"
+        instructions_required: "نام کامل شما"
         too_short: "نام انتخابی شما خیلی کوتاه است"
         ok: "نام انتخابی شما به نطر می رسد خوب است"
       username:
@@ -396,10 +400,10 @@ fa_IR:
         default: "(پیش‌فرض)"
       password_confirmation:
         title: "رمز عبور را مجدد وارد نمایید"
-      last_posted: "آخرین دیدگاه"
+      last_posted: "آخرین نوشته"
       last_emailed: "آخرین ایمیل فرستاده شده"
       last_seen: "مشاهده"
-      created: "پیوست"
+      created: "ملحق شده در"
       log_out: "خروج"
       location: "موقعیت"
       card_badge:
@@ -412,10 +416,20 @@ fa_IR:
         every_three_days: "هر سه روز"
         weekly: "هفتگی"
         every_two_weeks: "هر دو هفته "
-      email_direct: "برای من ایمیلی بفرست  هنگامی که کاربری گفتهٔ من را نقل‌قول می‌کند، روی دیدگاه من پاسخی می‌فرستد، یا به @نام‌کاربری من اشاره می‌کند"
+      email_direct: "به من ایمیل ارسال کن هنگامی که کسی از من نقل قول کرد،با نوشته های من پاسخ داد،یا به من اشاره کرد @username کاربری یا مرا به موضوعی دعوت کردند."
+      email_private_messages: "به من ایمیل ارسال کن وقتی کسی به من پیام خصوصی فرستاد"
       email_always: "برای من ایمیل آگاه سازی نفرست هنگامی که در سایت فعال هستم"
       other_settings: "موارد دیگر"
-      categories_settings: "دسته‌ها"
+      categories_settings: "دسته‌بندی ها"
+      new_topic_duration:
+        label: "موضوعات را جدید در نظر بگیر وقتی که"
+        not_viewed: "من هنوز آن ها را ندیدم"
+        last_here: "آخرین باری که اینجا بودم ساخته شده‌اند"
+        after_n_days:
+          other: " در {{count}} روز گذشته ساخته شده‌"
+        after_n_weeks:
+          other: "در {{count}} هفته گذشته ساخته شده‌"
+      auto_track_topics: "دنبال کردن خودکار موضوعاتی که وارد می‌شوم"
       auto_track_options:
         never: "هرگز"
         always: "همیشه"
@@ -429,9 +443,10 @@ fa_IR:
         user: "کاربر فراخوانده شده"
         none: "هنوز هیچ‌کسی را به اینجا فرانخوانده‌اید"
         truncated: "نمایش {{count}} فراخوانهٔ نخست"
+        redeemed: "آزاد سازی دعوتنامه"
         redeemed_at: "آزاد سازی"
         pending: "فراخوانه‌های بی‌پاسخ"
-        topics_entered: "جستارها بازدید شد"
+        topics_entered: "موضوعات بازدید شد"
         posts_read_count: "خواندن نوشته ها"
         expired: "این دعوت منقضی شده است."
         rescind: "پاک کردن"
@@ -443,12 +458,17 @@ fa_IR:
         account_age_days: "عمر حساب بر اساس روز"
         create: "فرستادن یک فراخوانه"
         bulk_invite:
+          none: "شما هنوز کسی را اینجا دعوت نکرده اید. می توانید بصورت تکی یا گروهی یکجا دعوتنامه را بفرستید از طریق  <a href='http://discours.ir'>بارگذار فراخوانه فله ای </a>."
+          text: "دعوت گروهی از طریق فایل"
           uploading: "در حال بار گذاری ..."
+          success: "فایل با موفقیت بارگذاری شد٬  وقتی که پروسس تمام شد  به شما را از طریق پیام اطلاع می دهیم. "
           error: "در بارگذاری «{{filename}}» خطایی روی داد: {{message}}"
       password:
         title: "گذرواژه"
         too_short: "گذرواژه‌تان خیلی کوتاه است"
         common: "گذرواژهٔ خیلی ساده‌ای است"
+        same_as_username: "رمز عبورتان با نام کاربری شما برابر است."
+        same_as_email: "رمز عبورتان با ایمیل شما برابر است. "
         ok: "گذرواژهٔ خوبی است."
         instructions: "در آخرین %{count} کاراکتر"
       associated_accounts: "ورود ها"
@@ -465,19 +485,20 @@ fa_IR:
       stream:
         posted_by: "فرستنده:"
         sent_by: "فرستنده:"
-        the_topic: "این جستار"
+        private_message: "پیام"
+        the_topic: "موضوع"
     loading: "بارگذاری"
     errors:
       prev_page: "هنگام تلاش برای بارگزاری"
       reasons:
         network: "خطای شبکه"
-        server: "ارور سرور"
+        server: "خطای سرور"
         forbidden: "دسترسی قطع شده است"
         unknown: "خطا"
       desc:
         network: "ارتباط اینترنتی‌تان را بررسی کنید."
         network_fixed: "به نظر می رسد اون برگشت."
-        server: "کد ارور : {{status}}"
+        server: "کد خطا : {{status}}"
         forbidden: "شما اجازه دیدن آن را ندارید."
         unknown: "اشتباهی روی داد."
       buttons:
@@ -488,29 +509,38 @@ fa_IR:
     assets_changed_confirm: "به نظر می رسد به روز رانی شده است،بارگزاری مجدد برای آخرین نسخه ؟"
     logout: "شما از سایت خارج شده اید"
     refresh: "تازه کردن"
+    read_only_mode:
+      enabled: "مدیر حالت فقط برای خواندن را فعال کرده.  می توانید به جستجو در وب سایت ادامه دهید ولی ممکن است تعاملات کار نکند."
+      login_disabled: "ورود به سیستم غیر فعال شده همزمان با اینکه سایت در حال فقط خواندنی است."
+    too_few_topics_notice: " 5 موضوع عمومی و  %{posts} نوشته عمومی ایجاد کنید،تا گفتگو آغاز شود. و کاربران جدید میزان اعتماد را بدست بیاورند و محتوایی برای خواندن موجود باشد. این پیغام فقط به مدیران نشان داده می شود"
     learn_more: "بیشتر بدانید..."
     year: 'سال'
-    year_desc: 'جستارهایی که در ۳۶۵ روز گذشته باز شده‌اند'
+    year_desc: 'موضوعاتی که در 365 روز گذشته باز شده‌اند'
     month: 'ماه'
-    month_desc: 'جستارهایی که در ۳۰ روز گذشته باز شده‌اند'
+    month_desc: 'موضوعاتی که در 30 روز گذشته باز شده‌اند'
     week: 'هفته'
-    week_desc: 'جستارهایی که در ۷ روز گذشته باز شده‌اند'
+    week_desc: 'موضوعاتی که در 7 روز گذشته باز شده‌اند'
     day: 'روز'
-    first_post: دیدگاه نخست
+    first_post: نوشته نخست
     mute: بی صدا
     unmute: صدادار
-    last_post: آخرین دیدگاه
+    last_post: آخرین نوشته
     last_post_lowercase: آخرین نوشته
     summary:
+      enabled_description: "شما خلاصه ای از این موضوع را می بینید:  بالاترین‌ نوشته های  انتخاب شده توسط انجمن."
       description: "<b>{{count}}</b> پاسخ"
+      description_time: "وجود دارد <b>{{count}}</b> پاسخ ها برا اساس زمان خواندن<b>{{readingTime}} دقیقه</b>."
       enable: 'خلاصه این موضوع'
-      disable: 'نمایش همه دیدگاه‌ها'
+      disable: 'نمایش همه نوشته‌ها'
     deleted_filter:
+      enabled_description: "محتویات این موضوع باعث حذف نوشته شده٬ که پنهان شده است."
+      disabled_description: "پست های حذف شده در موضوع نشان داده است"
       enable: "مخفی کردن نوشته های حذف شده"
       disable: "نشان دادن نوشته های حذف شده"
     private_message_info:
-      title: "پیغام"
+      title: "پیام"
       invite: "فراخواندن دیگران..."
+      remove_allowed_user: "آیا واقعا می خواهید اسم {{name}} از پیام برداشته شود ؟ "
     email: 'رایانامه'
     username: 'نام کاربری'
     last_seen: 'مشاهده'
@@ -526,6 +556,10 @@ fa_IR:
       action: "گذرواژه‌ام را فراموش کرده‌ام"
       invite: "نام‌کاربری و نشانی رایانامهٔ خود را بنویسید و ما رایانامهٔ بازیابی گذرواژه را برایتان می‌فرستیم."
       reset: "باز یابی رمز عبور"
+      complete_username: "اگر حساب کاربری مشابه نام کاربری  <b>%{username}</b> ,است،شما باید با استفاده از ایمیل رمز عبور حساب کاربری خود را مجدد تنظیم نمایید."
+      complete_email: "اگر حساب کاربری مشابه ایمیل <b>%{email}</b>, است،شما باید با استفاده از ایمیل رمز عبور حساب کاربری خود را مجدد تنظیم نمایید."
+      complete_username_found: "ما حساب کاربری مشابه نام کاربری   <b>%{username}</b>,پیدا کردیم،شما باید با استفاده از ایمیل رمز عبور حساب کاربری خود را مجدد تنظیم نمایید."
+      complete_email_found: "ما حساب کاربری مشابه با ایمیل  <b>%{email}</b>, پیدا کردیم،شما باید با استفاده از ایمیل رمز عبور حساب کاربری خود را مجدد تنظیم نمایید."
       complete_username_not_found: "هیچ حساب کاربری مشابه نام کاربری <b>%{username}</b> وجود ندارد"
       complete_email_not_found: "هیچ حساب کاربری مشابه با <b>%{email}</b> وجود ندارد"
     login:
@@ -573,40 +607,40 @@ fa_IR:
     composer:
       emoji: "شکلک :smile:"
       add_warning: "این یک هشدار رسمی است."
-      posting_not_on_topic: "به کدام جستار می‌خواهید پاسخ دهید؟"
+      posting_not_on_topic: "به کدام موضوع می‌خواهید پاسخ دهید؟"
       saving_draft_tip: "در حال ذخیره سازی ..."
       saved_draft_tip: "اندوخته شد"
       saved_local_draft_tip: "ذخیره سازی به صورت محلی"
-      similar_topics: "جستار شما نزدیک است به..."
+      similar_topics: "موضوع شما شبیه است به..."
       drafts_offline: "پیش نویس آنلاین"
       error:
         title_missing: "سرنویس الزامی است"
         title_too_short: "سرنویس دست‌کم باید {{min}} نویسه باشد"
         title_too_long: "سرنویس نمی‌تواند بیش‌تر از {{max}} نویسه باشد"
-        post_missing: "دیدگاه نمی‌تواند تهی باشد"
-        post_length: "دیدگاه باید دست‌کم {{min}} نویسه داشته باشد"
+        post_missing: "نوشته نمی‌تواند تهی باشد"
+        post_length: "نوشته باید دست‌کم {{min}} نویسه داشته باشد"
         category_missing: "باید یک دسته برگزینید"
-      save_edit: "اندوختن ویرایش"
-      reply_original: "پاسخ دادن در جستار اصلی"
+      save_edit: "ذخیره سازی ویرایش"
+      reply_original: "پاسخ دادن در موضوع اصلی"
       reply_here: "پاسخ‌دادن همین‌جا"
       reply: "پاسخ"
       cancel: "لغو کردن"
       create_topic: "ایجاد موضوع"
-      create_pm: "پیغام"
+      create_pm: "پیام"
       title: "یا Ctrl+Enter را بفشارید"
       users_placeholder: "افزودن یک کاربر"
-      title_placeholder: "در یک جملهٔ‌کوتاه، این جستار در چه موردی است؟"
+      title_placeholder: "در یک جملهٔ‌ کوتاه، این موضوع در چه موردی است؟"
       edit_reason_placeholder: "چرا ویرایش می‌کنید؟"
       show_edit_reason: "(افزودن دلیل ویرایش)"
       reply_placeholder: "اینجا بنویسید. برای آرایش از Markdown یا BBCode استفاده کنید. برای باگذاری تصویر، آن را به اینجا بکشید یا بچسبانید."
-      view_new_post: "دیدگاه تازه‌تان را ببینید."
-      saving: "اندوختن..."
+      view_new_post: "نوشته تازه‌تان را ببینید."
+      saving: "در حال ذخیره سازی..."
       saved: "اندوخته شد!"
       saved_draft: "در حال حاضر پیشنویس وجود دارد . برای از سر گیری انتخاب نمایید."
       uploading: "بارگذاری..."
       show_preview: 'نشان دادن پیش‌نمایش &laquo;'
       hide_preview: '&raquo; پنهان کردن پیش‌نمایش'
-      quote_post_title: "نقل‌قول همهٔ‌ دیدگاه"
+      quote_post_title: "نقل‌قول همهٔ‌ نوشته"
       bold_title: "زخیم"
       bold_text: "تکست زخیم"
       italic_title: "تاکید"
@@ -618,9 +652,11 @@ fa_IR:
       quote_title: "نقل قول"
       quote_text: "نقل قول"
       code_title: "نوشته تنظیم نشده"
+      code_text: "متن تورفتگی تنظیم نشده توسط 4 فضا خالی"
       upload_title: "بارگذاری"
       upload_description: "توضیح بارگذاری را در اینجا بنویسید"
       olist_title: "لیست شماره گذاری شد"
+      ulist_title: "لیست بولت"
       list_item: "فهرست موارد"
       heading_title: "عنوان"
       heading_text: "عنوان"
@@ -629,15 +665,22 @@ fa_IR:
       redo_title: "دوباره‌گردانی"
       help: "راهنمای ویرایش با Markdown"
       toggler: "مخفی یا نشان دادن پنل نوشتن"
+      admin_options_title: "تنظیمات اختیاری مدیران برای این موضوع"
       auto_close:
         label: "بستن خودکار موضوع در زمان :"
         error: "لطفا یک مقدار معتبر وارد نمایید."
+        based_on_last_post: "آیا تا آخرین نوشته یک موضوع بسته نشده در این قدیمی است."
+        all:
+          examples: 'عدد ساعت را وارد نمایید (24)،زمان کامل (17:30) یا برچسب زمان (2013-11-22 14:00).'
         limited:
           units: "(# از ساعت ها)"
           examples: 'لطفا عدد ساعت را وارد نمایید (24).'
     notifications:
+      title: "اطلاع رسانی با اشاره به @name ،پاسخ ها به نوشته ها و موضوعات شما،پیام ها ، و ..."
+      none: "قادر به بار گذاری آگاه سازی ها در این زمان نیستیم."
       more: "دیدن آگاه‌سازی‌های پیشن"
-      total_flagged: "همهٔ دیدگاه‌های پرچم خورده"
+      total_flagged: "همهٔ نوشته‌های پرچم خورده"
+      mentioned: "<i title='mentioned' class='fa fa-at'></i><p><span>{{username}}</span> {{description}}</p>"
       quoted: "<i title='quoted' class='fa fa-quote-right'></i><p><span>{{username}}</span> {{description}}</p>"
       replied: "<i title='replied' class='fa fa-reply'></i><p><span>{{username}}</span> {{description}}</p>"
       posted: "<i title='replied' class='fa fa-reply'></i><p><span>{{username}}</span> {{description}}</p>"
@@ -645,6 +688,7 @@ fa_IR:
       liked: "<i title='liked' class='fa fa-heart'></i><p><span>{{username}}</span> {{description}}</p>"
       private_message: "<i title='private message' class='fa fa-envelope-o'></i><p><span>{{username}}</span> {{description}}</p>"
       invited_to_private_message: "<i title='private message' class='fa fa-envelope-o'></i><p><span>{{username}}</span> {{description}}</p>"
+      invited_to_topic: "<i title='invited to topic' class='fa fa-hand-o-right'></i><p><span>{{username}}</span> {{description}}</p>"
       invitee_accepted: "<i title='accepted your invitation' class='fa fa-user'></i><p><span>{{username}}</span> accepted your invitation</p>"
       moved_post: "<i title='moved post' class='fa fa-sign-out'></i><p><span>{{username}}</span> moved {{description}}</p>"
       linked: "<i title='linked post' class='fa fa-arrow-left'></i><p><span>{{username}}</span> {{description}}</p>"
@@ -657,166 +701,229 @@ fa_IR:
       remote_tip: "لینک به تصویر"
       remote_tip_with_attachments: "لطفا لینک تصویر یا فایل ({{authorized_extensions}})"
       local_tip: "بفشارید تا تصویری را از روی دستگاه خود برگزینید"
+      local_tip_with_attachments: "برای انتخاب یک تصویر یا فایل از دستگاه خود کلیک کنید ({{authorized_extensions}})"
+      hint: "(برای آپلود می توانید فایل را کیشده و در ویرایشگر رها کنید)"
+      hint_for_supported_browsers: "(شما همچنین می توانید با کشیدن و رها کردن یا چسباندن تصاویر در ویرایشگر آن ها را بار گذاری نمایید)"
       uploading: "در حال بروز رسانی "
+      image_link: "به لینک تصویر خود اشاره کنید"
     search:
-      title: "جستجوی جستارها، دیدگاه‌ها، کاربران یا دسته‌ها"
+      title: "جستجوی موضوعات، نوشته ها، کاربران یا دسته‌ بندی ها"
       no_results: "چیزی یافت نشد."
       searching: "جستجو کردن..."
       post_format: "#{{post_number}} توسط {{username}}"
       context:
-        user: "جستجوی دیدگاه‌های @{{username}}"
+        user: "جستجوی نوشته‌های @{{username}}"
         category: "جستجوی دستهٔ «{{category}}»"
-        topic: "جستجوی این جستار"
-        private_messages: "جستجوی پیغام"
-    site_map: "به فهرست جستار یا دسته‌ای دیگر بروید"
+        topic: "جستجوی این موضوع"
+        private_messages: "جستجوی پیام"
+    site_map: "به فهرست موضوع یا دسته‌ای دیگر بروید"
     go_back: 'برگردید'
+    not_logged_in_user: 'صفحه کاربر با خلاصه ای از فعالیت های و تنظیمات'
     current_user: 'به نمایه‌تان بروید'
     topics:
       bulk:
+        reset_read: "تنظیم مجدد خوانده شده"
         delete: "حذف موضوعات"
         dismiss_posts: "بستن نوشته ها"
         dismiss_topics: "بستن موضوعات"
         dismiss_topics_tooltip: "نشان دادن این تاپیک را از لیست خوانده نشده متوقف کن وقتی پست های جدید بوجود آمد"
         dismiss_new: "بستن جدید"
+        toggle: "ضامن انتخاب یکباره موضوعات"
+        actions: "عملیات یکجا"
         change_category: "تغییر دسته بندی"
-        close_topics: "بستن جستارها"
+        close_topics: "بستن موضوعات"
         archive_topics: "آرشیو موضوعات"
         notification_level: "تغییر سطح آگاه‌سازی"
+        choose_new_category: "یک دسته بندی جدید برای موضوع انتخاب نمایید"
+        selected:
+          other: "شما تعداد <b>{{count}}</b> موضوع را انتخاب کرده اید."
       none:
-        unread: "جستار خوانده نشده‌ای ندارید."
-        new: "شما هیچ جستار تازه‌ای ندارید"
-        read: "هنوز هیچ جستاری را نخوانده‌اید."
-        posted: "هنوز در هیچ جستاری دیدگاه نگذاشته‌اید."
-        latest: "هیچ جستار تازه‌ای نیست. چه بد!"
-        hot: "هیچ جستار داغی نیست."
+        unread: "موضوع خوانده نشده‌ای ندارید."
+        new: "شما هیچ موضوع تازه‌ای ندارید"
+        read: "هنوز هیچ موضوعاتی را نخوانده‌اید."
+        posted: "هنوز در هیچ موضوعی  نوشته نگذاشته‌اید."
+        latest: "هیچ موضوع تازه‌ای نیست. چه بد!"
+        hot: "هیچ موضوع داغی نیست."
         bookmarks: "هنوز هیچ موضوع نشانک‌گذاری شده‌ای ندارید."
-        category: "هیچ جستاری در {{category}} نیست."
+        category: "هیچ موضوعاتی در {{category}} نیست."
         top: "برترین موضوعی وجود ندارد"
+        search: "دیگر هیچ نتیجه جستجویی وجود ندارد."
+        educate:
+          new: '<p>موضوعات جدید در اینجا قرار می گیرند.</p><p>به طور پیش فرض، موضوعات جدید در نظر گرفته خواهند شد و نشان داده می شوند <span class="badge new-topic badge-notification" style="vertical-align:middle;line-height:inherit;">جدید</span> شاخص اگر آنها در 2 روز گذشته ایجاد شده باشند </p><p>شما می توانید این را برای خود تغییر دهید <a href="%{userPrefsUrl}">تنظیمات</a>.</p>'
+          unread: '<p>موضوعات خوانده نشده شما در اینجا قرار می گیرند.</p><p>به طور پیش فرض، موضوعات خوانده نشده در نظر گرفته خواهند شد و شمارش خوانده نشده ها نشان داده می شود <span class="badge new-posts badge-notification">1</span> اگر شما:</p><ul><li>موضوع ایجاد کرده اید</li><li>به موضوع پاسخ داده اید</li><li>خواندن موضوع  در بیش از 4 دقیقه</li></ul><p>و یا اگر شما به صراحت مجموعه ای از موضوع مورد ردیابی و یا تماشا از طریق کنترل اطلاع رسانی در پایین هر موضوع انتخاب کرده اید.</p><p>شما می توانید این را تغییر دهید. <a href="%{userPrefsUrl}">تنظیمات</a>.</p>'
       bottom:
-        latest: "جستار تازهٔ دیگری نیست."
-        hot: "جستار داغ دیگری نیست."
+        latest: "موضوع تازهٔ دیگری نیست."
+        hot: "موضوع داغ دیگری نیست."
         posted: "هیچ موضوعات نوشته شده وجود دارد."
-        read: "جستار خوانده شدهٔ‌دیگری نیست."
-        new: "جستار تازهٔ دیگری نیست."
-        unread: "جستاره خوانده نشدهٔ دیگری نیست."
-        category: "هیچ جستار دیگری در {{category}} نیست."
+        read: "موضوع خوانده شدهٔ‌دیگری نیست."
+        new: "موضوع تازهٔ دیگری نیست."
+        unread: "موضوع خوانده نشدهٔ دیگری نیست."
+        category: "هیچ موضوع دیگری در {{category}} نیست."
+        top: "بالاترین‌ موضوعات بیشتری وجود ندارد"
         bookmarks: "موضوعات نشانک‌گذاری شده‌ی دیگری وجود ندارد."
+        search: "نتیجه جستجوی دیگری وجود ندارد"
     topic:
       filter_to: "{{post_count}} نوشته در موضوع "
       create: 'موضوع جدید'
-      create_long: 'ساختن یک جُستار تازه'
-      private_message: 'شروع یک پیغام'
-      list: 'جستارها'
-      new: 'جستار تازه'
+      create_long: 'ساختن یک موضوع تازه'
+      private_message: 'شروع یک پیام'
+      list: 'موضوعات'
+      new: 'موضوع تازه'
       unread: 'خوانده نشده'
       new_topics:
         other: '{{count}} موضوعات جدید'
       unread_topics:
-        other: '{{count}} جستار خوانده نشده'
-      title: 'جستار'
+        other: '{{count}} موضوع خوانده نشده'
+      title: 'موضوع'
       invalid_access:
-        title: "جستار خصوصی است"
-        description: "متأسفیم، شما دسترسی به این جستار ندارید!"
+        title: "موضوع خصوصی است"
+        description: "متأسفیم، شما دسترسی به این موضوع ندارید!"
         login_required: "برای مشاهده‌ی موضوع باید وارد سیستم شوید."
       server_error:
-        title: "شکست در بارگذاری جستار"
-        description: "متأسفیم، نتوانستیم جستار را بار بگذاریم، شاید به دلیل یک مشکل ارتباطی. لطفاً دوباره تلاش کنید. اگر مشکل پابرجا بود، ما را آگاه کنید."
+        title: "شکست در بارگذاری موضوع"
+        description: "متأسفیم، نتوانستیم موضوع را بار بگذاریم، شاید به دلیل یک مشکل ارتباطی. لطفاً دوباره تلاش کنید. اگر مشکل پابرجا بود، ما را آگاه کنید."
       not_found:
-        title: "جستار یافت نشد"
-        description: "متأسفیم، نتوانستیم آن جستار را بیابیم. شاید کارمندی آن را پاک کرده؟"
+        title: "موضوع یافت نشد"
+        description: "متأسفیم، نتوانستیم آن موضوع را بیابیم. شاید کارمندی آن را پاک کرده؟"
+      total_unread_posts:
+        other: "شما تعداد {{count}} نوشته خوانده نشده در این موضوع دارید"
+      unread_posts:
+        other: "شما تعداد {{count}} نوشته خوانده نشده قدیمی در این موضوع دارید"
+      new_posts:
+        other: "تعداد {{count}} نوشته های جدید در این موضوع از آخرین خواندن شما وجود دارد"
       likes:
-        other: "{{count}} پسند در این جستار داده شده است"
-      back_to_list: "بازگشت به فهرست جستار"
-      options: "گزینه‌های جستار"
-      show_links: "نمایش پیوندهای درون این جستار"
+        other: "{{count}} پسند در این موضوع داده شده است"
+      back_to_list: "بازگشت به فهرست موضوع"
+      options: "گزینه‌های موضوع"
+      show_links: "نمایش پیوندهای درون این موضوع"
+      toggle_information: " ضامن جزئیات موضوع"
+      read_more_in_category: "می خواهید بیشتر بخوانید? به موضوعات دیگر را مرور کنید {{catLink}} یا {{latestLink}}."
+      read_more: "می خواهید بیشتر بخوانید? {{catLink}} یا {{latestLink}}."
       read_more_MF: "There { UNREAD, plural, =0 {} one { is <a href='/unread'>1 unread</a> } other { are <a href='/unread'># unread</a> } } { NEW, plural, =0 {} one { {BOTH, select, true{and } false {is } other{}} <a href='/new'>1 new</a> topic} other { {BOTH, select, true{and } false {are } other{}} <a href='/new'># new</a> topics} } remaining, or {CATEGORY, select, true {browse other topics in {catLink}} false {{latestLink}} other {}}."
-      browse_all_categories: جست‌وجوی همهٔ دسته‌ها
+      browse_all_categories: جستوجوی همهٔ دسته‌ها
       view_latest_topics: مشاهده آخرین موضوع
-      suggest_create_topic: چرا یک جستار نسازید؟
+      suggest_create_topic: چرا یک موضوع نسازید؟
       jump_reply_up: رفتن به جدید ترین پاسخ
       jump_reply_down: رفتن به آخرین پاسخ
-      deleted: "جستار پاک شده است."
-      auto_close_notice: "این جستار خودکار بسته خواهد شد %{timeLeft}."
+      deleted: "موضوع پاک شده است."
+      auto_close_notice: "این موضوع خودکار بسته خواهد شد %{timeLeft}."
       auto_close_notice_based_on_last_post: "این نوشته بعد از  %{duration} آخرین پاسخ بشته خواهد شد ."
       auto_close_title: 'تنضیمات قفل خوکار'
       auto_close_save: "دخیره"
-      auto_close_remove: "این جستار را خوکار قفل نکن"
+      auto_close_remove: "این موضوع را خوکار قفل نکن"
       progress:
         title: نوشته ی در حال اجرا
         go_top: "بالا"
         go_bottom: "پایین"
         go: "برو"
         jump_bottom_with_number: "رفتن به نوشته ی %{post_number}"
-        total: همهٔ دیدگاه‌ها
-        current: دیدگاه کنونی
+        total: همهٔ نوشته‌ها
+        current: نوشته کنونی
         position: "نوشته %{current} از %{total}"
       notifications:
         reasons:
-          '3_6': 'شما آگاه‌سازی‌ها را دریافت خواهید کرد، زیرا این دسته را تماشا می‌کنید.'
-          '3_5': 'شما آگاه‌سازی‌ها را دریافت خواهید کرد، زیرا تماشای خودکار این جستار را آغاز کرده‌اید.'
-          '3_2': 'از آنجا که این جستار را تماشا می‌کنید، از رویدادهای آن آگاه خواهید شد.'
-          '3_1': 'از آنجا که این جستار را ساخته‌اید، از رویدادهای آن آگاه خواهید شد.'
-          '3': 'از آنجا که این جستار را تماشا می‌کنید، از رویدادهای آن آگاه خواهید شد.'
-          '2_4': 'از آنجا که یه این جستار پاسخی فرستادید، از رویدادهای آن آگاه خواهید شد.'
-          '2_2': 'از آنجا که این جستار را دنبال می‌کنید، از رویدادهای آن آگاه خواهید شد.'
+          '3_6': 'شما آگاه‌سازی‌ها را دریافت خواهید کرد، زیرا این دسته بندی را تماشا می‌کنید.'
+          '3_5': 'شما آگاه‌سازی‌ها را دریافت خواهید کرد، زیرا تماشای خودکار این موضوع را آغاز کرده‌اید.'
+          '3_2': 'از آنجا که این موضوع را تماشا می‌کنید، از رویدادهای آن آگاه خواهید شد.'
+          '3_1': 'از آنجا که این موضوع را ساخته‌اید، از رویدادهای آن آگاه خواهید شد.'
+          '3': 'از آنجا که این موضوع را تماشا می‌کنید، از رویدادهای آن آگاه خواهید شد.'
+          '2_8': 'شما آگاه سازی دریافت خواهید کرد چون شما این دسته بندی را پی گیری می کنید.'
+          '2_4': 'از آنجا که یه این موضوع پاسخی فرستادید، از رویدادهای آن آگاه خواهید شد.'
+          '2_2': 'از آنجا که این موضوع را دنبال می‌کنید، از رویدادهای آن آگاه خواهید شد.'
           '2': 'شما اطلاعیه ای دریافت خواهید کرد چون  <a href="/users/{{username}}/preferences">این موضوع را مطالعه نماید</a>.'
+          '1_2': 'به شما اطلاع داده خواهد شد اگر کسی به شما اشاره @name یا پاسخ ها به نوشته شما'
+          '1': 'به شما اطلاع داده خواهد شد اگر کسی به شما اشاره @name یا پاسخ ها به نوشته شما'
+          '0_7': 'شما کل آگاه سازی های این دسته بندی را نادیده گرفته اید'
+          '0_2': 'شما کل آگاه سازی های این موضوع را نادیده گرفته اید'
+          '0': 'شما کل آگاه سازی های این موضوع را نادیده گرفته اید'
         watching_pm:
           title: "در حال مشاهده"
+          description: "به شما اطلاع رسانی خواهد شدهر نوشته جدید در این پیام،تعداد نوشته های خوانده نشده در کنار موضوع پدیدار می شود"
+        watching:
+          title: "در حال مشاهده"
+          description: "به شما اطلاع رسانی خواهد شد هر نوشته جدید در این موضوع، و تعداد نوشته های خوانده نشده در کنار موضوع پدیدار می شود."
         tracking_pm:
           title: "ردگیری"
+          description: "تعداد نوشته های خوانده نشده و نوشته های جدید به عنوان پیام پدیدار می شود،به شما اطلاع داده خواهد شد اگر کسی به شما اشاره @name یا به نوشته های شما پاسخ دهند"
         tracking:
           title: "ردگیری"
+          description: "تعداد نوشته های خوانده نشده و نوشته های جدید به در کنار موضوع پدیدار می شود،به شما اطلاع داده خواهد شد اگر کسی به شما اشاره @name یا به نوشته های شما پاسخ دهند"
         regular:
           title: "منظم"
+          description: "به شما اطلاع داده خواهد شد اگر کسی به شما اشاره @name یا به نوشته های شما پاسخ دهند"
         regular_pm:
           title: "عادی"
+          description: "به شما در قالب پیام اطلاع داده خواهد شد اگر کسی به شما اشاره @name یا به نوشته های شما پاسخ دهند،"
         muted_pm:
           title: "بی صدا شد"
+          description: "شما هرگز اطلاع رسانی نخواهید شد در باره این پیام"
         muted:
           title: "بی صدا شد"
+          description: "شما هرگز اطلاع رسانی نخواهید شد در باره این موضوع، و در کنار موضوع شماره خوانده نشده ها پدیدار نمی شود"
       actions:
-        recover: "بازیابی جستار"
-        delete: "پاک کردن جستار"
-        open: "برداستن قفل جستار"
-        close: "بستن جستار"
+        recover: "بازیابی موضوع"
+        delete: "پاک کردن موضوع"
+        open: "برداستن قفل موضوع"
+        close: "بستن موضوع"
         auto_close: "بستن خودکار"
         make_banner: "اعلان موضوع"
         remove_banner: "حذف اعلان موضوع"
-        pin: "سنجاق زدن جستار"
-        unpin: "برداشتن سنجاق جستار"
+        pin: "سنجاق زدن موضوع"
+        unpin: "برداشتن سنجاق موضوع"
         pin_globally: "سنجاق کردن موضوع در سطح سراسری"
-        unarchive: "جستار بایگانی نشده"
-        archive: "بایگانی کردن جستار"
+        unarchive: "موضوع بایگانی نشده"
+        archive: "بایگانی کردن موضوع"
+        invisible: "خارج کردن از لیست"
+        visible: "فهرست ساخته شد"
         reset_read: "تنظیم مجدد خواندن داده ها"
-        multi_select: "گزیدن دیدگاه‌ها"
+        multi_select: "گزیدن نوشته‌ها"
       reply:
         title: 'پاسخ'
         help: 'آغاز ارسال یک پاسخ به این موضوع'
       clear_pin:
         title: "برداشتن سنجاق"
-        help: "سنجاق جستار را بردارید که پس از آن دیگر این جستار در بالای فهرست جستارهای شما دیده نمی‌شود."
+        help: "سنجاق موضوع را بردارید که پس از آن دیگر این موضوع در بالای فهرست موضوعات شما دیده نمی‌شود."
       share:
         title: 'اشتراک‌گذاری'
+        help: 'اشتراک گذاری یک پیوند برای این موضوع'
       flag_topic:
         title: 'پرچم'
-        success_message: 'شما باموفقیت این جستار را پرچم زدید'
+        success_message: 'شما باموفقیت این موضوع را پرچم زدید'
       feature_topic:
         title: " ویژگی های این موضوع"
+        pin: "این موضوع را قابل رویت در دسته بندی {{categoryLink}} کن."
+        unpin: "این موضوع را از لیست بالاترین‌ های دسته بندی {{categoryLink}} حذف کن"
+        pin_note: "کاربران می توانند موضوع را بصورت جداگانه برای خود از سنجاق در بیاورند"
         already_pinned:
-          one: "موضوعات سنجاق شده {{categoryLink}}: <strong class='badge badge-notification unread'>1</strong>"
+          zero: "دیگر هیچ موضوعات سنجاق شده وجود ندارد در {{categoryLink}}."
+          one: "موضوعات در حال حاضر به صورت سراسری سنجاق شده اند {{categoryLink}}: <strong class='badge badge-notification unread'>1</strong>."
+          other: "موضوعات در حال حاضر به صورت سراسری سنجاق شده اند {{categoryLink}}: <strong class='badge badge-notification unread'>{{count}}</strong>."
+        unpin_globally: "حذف این موضوع انجمن از بالای همه لیست موضوعات"
+        global_pin_note: "کاربران می توانند موضوع را بصورت جداگانه برای خود از سنجاق در بیاورند"
         already_pinned_globally:
-          one: "موضوعاتی که در سطح سراسر سنجاق شده اند : <strong class='badge badge-notification unread'>1</strong>"
+          zero: "هیچ موضوعی که به صورت سرسری سنجاق شده باشد وجود ندارد."
+          one: "موضوعات در سطح سراسری سنجاق شده است: <strong class='badge badge-notification unread'>1</strong>."
+          other: "موضوعات در سطح سراسری سنجاق شده است: <strong class='badge badge-notification unread'>{{count}}</strong>."
+        remove_banner: "حذف اعلان از بالای تمام صفحات."
+        banner_note: "کاربران می توانند اعلان را با بستن آنها رد کنند. فقط یک موضوع را می توان بصورت اعلان در هرزمان نمایش داد"
+        already_banner:
+          zero: "هیچ موضوع سرصفحه وجود ندارد"
+          one: "در حال حاضر یک موضوع اعلان <strong class='badge badge-notification unread'>is</strong> وجود دارد."
       inviting: "فراخوانی..."
       invite_private:
+        title: 'دعوت به پیام خصوصی'
         email_or_username: "رایانامه یا نام کاربر فراخوان شده"
         email_or_username_placeholder: "نشانی رایانامه یا نام کاربری"
         action: "فراخوانی"
+        success: "ما آن کاربر را برای شرکت در این پیام دعوت کردیم."
+        error: "با معذرت٬ یک خطا برای دعوت آن کاربر وجود داشت"
         group_name: "نام گروه"
       invite_reply:
         title: 'فراخوانی'
-        action: 'فراخوانی رایانامه‌ای'
-        help: 'ارسال دعوتنامه به دوستان، به گونه‌ای که بتوانند با یک کلیک به این موضوع پاسخ دهند.'
-        to_topic: "ما رایانامهٔ کوتاهی را برای دوست‌تان می‌فرستیم تا بی‌درنگ عضو شود و با فشردن یک پیوند، به این جستار پاسخ دهد، بی‌نیاز از درون آمدن."
+        action: 'ارسال دعوت'
+        help: 'دعوت دیگران به این موضوع با ایمیل یا اطلاعیه '
+        to_forum: "ما ایملی کوتاه برای شما می فرستیم که دوست شما با کلیک کردن بر روی لینک سریعا ملحق شود٫‌ به ورود سیستم نیازی نیست. "
+        to_topic_blank: "نام کاربری یا ایمیل کسی را که می خواهید برای این موضوع دعوت کنید را وارد نمایید"
         email_placeholder: 'name@example.com'
       login_reply: 'برای پاسخ وارد شوید'
       filters:
@@ -827,16 +934,20 @@ fa_IR:
         title: "انتقال به موضوع موجود"
         action: "انتقال به موضوع جدید"
         topic_name: "نام موضوع تازه"
+        error: "اینجا یک ایراد بود برای جابجایی نوشته ها به موضوع جدید."
       merge_topic:
         title: "انتقال به موضوع موجود"
         action: "انتقال به موضوع موجود"
+        error: "اینجا یک ایراد بود برای جابجایی نوشته ها به  آن موضوع. "
         instructions:
           other: "لطفاً موضوعی را که قصد دارید <b>{{count}}</b> تا از نوشته‌ها را به آن انتقال دهید، انتخاب نمایید."
       change_owner:
         title: "تغییر صاحب نوشته ها"
         action: "تغییر مالکیت"
+        error: "آنجا یک ایراد برای تغییر مالکیت آن پست وجود داشت. "
         label: "نوشته مالک جدید"
         placeholder: "نام کاربری مالک جدید"
+        instructions_warn: "نکته٬ هر گونه آگاه سازی برای این پست  همانند سابق برای کاربر جدید فرستاده نمی شود. .<br> اخطار: در حال حاضر٬‌ هیچگونه اطلاعات قبلی به کاربر جدید فرستاده نشده. با احتیاط استفاده شود. "
       multi_select:
         select: 'انتخاب کنید'
         selected: 'انتخاب کنید({{count}}) '
@@ -846,36 +957,47 @@ fa_IR:
         select_all: انتخاب همه
         deselect_all: عدم انتخاب همه
         description:
-          other: شما <b>{{count}}</b> نوشته انتخاب کرده اید
+          other: شما تعداد <b>{{count}}</b> نوشته انتخاب کرده اید
     post:
+      reply: "در حال پاسخ به {{link}} {{replyAvatar}} {{username}}"
       reply_topic: "پاسخ به {{link}}"
       quote_reply: "پاسخ با نقل‌قول"
+      edit: "در حال ویرایش {{link}} {{replyAvatar}} {{username}}"
       edit_reason: "دلیل:"
       post_number: "نوشته {{number}}"
       in_reply_to: "پاسخ به"
-      last_edited_on: "آخرین ویرایش دیدگاه در"
+      last_edited_on: "آخرین ویرایش نوشته در"
       reply_as_new_topic: "پاسخگویی به عنوان یک موضوع لینک شده"
-      continue_discussion: "دنبالهٔ جستار {{postLink}}:"
-      follow_quote: "برو به دیدگاهی که نقل‌قول شده"
-      show_full: "نمایش کامل دیدگاه"
+      continue_discussion: "دنبالهٔ موضوع {{postLink}}:"
+      follow_quote: "برو به نوشته ای که نقل‌قول شده"
+      show_full: "نمایش کامل نوشته"
       show_hidden: 'نمایش درون‌مایهٔ پنهان'
       expand_collapse: "باز کردن/گستردن"
       gap:
-        other: "{{count}} دیدگاه پنهان"
+        other: "{{count}} نوشته پنهان"
       more_links: "{{count}} مورد دیگر..."
       unread: "نوشته خوانده نشده است"
       has_replies:
         other: "پاسخ‌ها"
       errors:
-        create: "متأسفیم، در فرستادن دیدگاه شما خطایی روی داد. لطفاً دوباره تلاش کنید."
-        edit: "متأسفیم، در ویرایش دیدگاه شما خطایی روی داد. لطفاً دوباره تلاش کنید."
+        create: "متأسفیم، در فرستادن نوشته شما خطایی روی داد. لطفاً دوباره تلاش کنید."
+        edit: "متأسفیم، در ویرایش نوشته شما خطایی روی داد. لطفاً دوباره تلاش کنید."
         upload: "متأسفیم، در بارگذاری آن پرونده خطایی روی داد. لطفاً دوباره تلاش کنید."
+        attachment_too_large: "با عرض پوزش٬ فایلی را که تلاش برای ارسال آن دارید بسیار بزرگ است (حداکثر سایز {{max_size_kb}}kb است)"
+        file_too_large: "با عرض پوزش٬ فایلی را که تلاش برای ارسال آن دارید بسیار بزرگ است (حداکثر سایز {{max_size_kb}}kb است)"
         too_many_uploads: "متأسفیم، هر بار تنها می‌توانید یک پرونده را بار بگذارید."
+        too_many_dragged_and_dropped_files: "با عرض پوزش، شما همزمان فقط می توانید 10 فایل را گرفته و رها کنید."
         upload_not_authorized: "متأسفیم، پرونده‌ای که تلاش دارید آن را بار بگذارید، پروانه‌دار نیست (پسوندهای پروانه‌دار: {{authorized_extensions})"
+        image_upload_not_allowed_for_new_user: "با عرض پوزش، کاربران جدید نمی توانند تصویر بار گذاری نماییند."
+        attachment_upload_not_allowed_for_new_user: "با عرض پوزش، کاربران جدید نمی توانند فایل پیوست بار گذاری نماییند."
+        attachment_download_requires_login: "با عرض پوزش، شما برای دانلود فایل پیوست باید وارد سایت شوید."
       abandon:
+        confirm: "آیا شما مطمئن هستید که میخواهید نوشته خود را رها کنید؟"
         no_value: "خیر، نگه دار"
         yes_value: "بله، رها کن"
       via_email: "این نوشته از طریق ایمیل ارسال شده است"
+      wiki:
+        about: "این یک نوشته ویکی است;کاربران عادی می توانند آن را ویرایش نماییند"
       archetypes:
         save: ' ذخیره تنظیمات'
       controls:
@@ -890,7 +1012,10 @@ fa_IR:
         share: "اشتراک گذاری یک لینک در این نوشته"
         more: "بیشتر"
         delete_replies:
-          no_value: "نه، تنها این دیدگاه"
+          confirm:
+            other: "آیا شما می خواهیدتعداد {{count}} پاسخ را از این نوشته حذف کنید ؟"
+          yes_value: "بله، پاسخ ها را حذف کن"
+          no_value: "نه، تنها این نوشته"
         admin: "عملیات مدیریت نوشته"
         wiki: "ساخت ویکی"
         unwiki: "حذف ویکی"
@@ -920,10 +1045,12 @@ fa_IR:
         people:
           off_topic: "{{icons}} برای این مورد پرچم آف-‌تاپیک زد"
           spam: "{{icons}} برای این مورد پرچم هرزنامه زد"
-          spam_with_url: "{{icons}} نشانه گذاری شد<a href='{{postUrl}}'>این یک هرزنامه است</a>"
+          spam_with_url: "{{icons}} پرچم گذاری شد<a href='{{postUrl}}'>این یک هرزنامه است</a>"
           inappropriate: "{{icons}} این مورد را نامناسب دانست"
-          notify_moderators: "{{icons}} ناظمان را آگاه کرد"
-          notify_moderators_with_url: "{{icons}} <a href='{{postUrl}}'>ناظمان را آگاه کرد</a>"
+          notify_moderators: "{{icons}} مدیران را آگاه کرد"
+          notify_moderators_with_url: "{{icons}} <a href='{{postUrl}}'>مدیران را آگاه کرد</a>"
+          notify_user: "{{icons}} ارسال یک پیام خصوصی"
+          notify_user_with_url: "{{icons}} ارسال <a href='{{postUrl}}'>پیام خصوصی</a>"
           bookmark: "{{icons}} این را نشانه‌گذاری کرد"
           like: "{{icons}} این مورد را پسندید"
           vote: "{{icons}} به این مورد رأی داد"
@@ -932,9 +1059,10 @@ fa_IR:
           spam: "شما برای این مورد پرچم هرزنامه زدید"
           inappropriate: "شما این مورد را نامناسب گزارش کردید."
           notify_moderators: "شما این مورد را برای بررسی پرچم زدید"
-          bookmark: "شما  روی این دیدگاه نشانک گذاشتید"
-          like: "شما این دیدگاه را پسند کردید"
-          vote: "شما به این دیدگاه رأی دادید"
+          notify_user: "شما یک پیام به این کاربر ارسال کردید"
+          bookmark: "شما  روی این نوشته نشانک گذاشتید"
+          like: "شما این نوشته را پسند کردید"
+          vote: "شما به این نوشته رأی دادید"
         by_you_and_others:
           off_topic:
             other: "شما و {{count}} کاربر دیگر این مورد را آف-تاپیک گزارش کردید"
@@ -944,12 +1072,14 @@ fa_IR:
             other: "شما و {{count}} کاربر دیگر این مورد را نامناسب گزارش کردید"
           notify_moderators:
             other: "شما و {{count}} کاربر دیگر این مورد را برای بررسی گزارش کردید"
+          notify_user:
+            other: "شما و {{count}} افراد دیگر به این کاربر پیام فرستاده اید"
           bookmark:
-            other: "شما و {{count}} کاربر دیگر روی این دیدگاه نشانک گذاشتید"
+            other: "شما و {{count}} کاربر دیگر روی این نوشته نشانک گذاشتید"
           like:
             other: "شما و {{count}} کاربر دیگر این مورد را پسند کردید"
           vote:
-            other: "شما و {{count}} کاربر دیگر به این دیدگاه رأی دادید"
+            other: "شما و {{count}} کاربر دیگر به این نوشته رأی دادید"
         by_others:
           off_topic:
             other: "{{count}} کاربر ین مورد را آف-تاپیک گزارش کردند"
@@ -959,19 +1089,21 @@ fa_IR:
             other: "{{count}} کاربر این مورد را نامناسب گزارش کردند"
           notify_moderators:
             other: "{{count}} کاربر این مورد را برای بررسی گزارش کردند"
+          notify_user:
+            other: "{{count}} ارسال پیام به این کاربر"
           bookmark:
-            other: "{{count}} کاربر روی این دیدگاه نشانک گذاشتند"
+            other: "{{count}} کاربر روی این نوشته نشانک گذاشتند"
           like:
             other: "{{count}} کاربر این مورد را پسند کردند"
           vote:
-            other: "{{count}} کاربر به این دیدگاه رأی دادند"
+            other: "{{count}} کاربر به این نوشته رأی دادند"
       edits:
         one: ۱ ویرایش
         other: "{{count}} ویرایش"
         zero: هیچ ویرایشی
       delete:
         confirm:
-          other: "آیا مطمئنید که می‌خواهید همهٔ آن دیدگاه‌ها را پاک کنید؟"
+          other: "آیا مطمئنید که می‌خواهید همهٔ آن نوشته ها را پاک کنید؟"
       revisions:
         controls:
           first: "بازبینی نخست"
@@ -983,6 +1115,7 @@ fa_IR:
           comparing_previous_to_current_out_of_total: "<strong>{{previous}}</strong> در مقابل <strong>{{current}}</strong> / {{total}}"
         displays:
           inline:
+            title: "نمایش خروجی رندر با اضافات و از بین بردن درون خطی"
             button: '<i class="fa fa-square-o"></i> اچ تی ام ال'
           side_by_side:
             button: '<i class="fa fa-columns"></i> اچ تی ام ال'
@@ -996,15 +1129,16 @@ fa_IR:
       choose: 'انتخاب یک دسته بندی&hellip;'
       edit: 'ویرایش'
       edit_long: "ویرایش"
-      view: 'نمایش جستارهای دسته'
+      view: 'نمایش موضوعات دسته'
       general: 'عمومی'
       settings: 'تنظیمات'
       delete: 'پاک کردن دسته'
       create: 'دسته بندی جدید'
-      save: 'اندوختن دسته'
+      save: 'ذخیره سازی دسته بندی'
       slug: 'Slug دسته بندی'
+      slug_placeholder: '(اختیاری) dash-کلمه برای دسته بندی'
       creation_error: خطایی در ساخت این دسته بروز کرد.
-      save_error: خطایی در اندوختن این دسته روی داد.
+      save_error: خطایی در ذخیره سازی این دسته بندی روی داد.
       name: "نام دسته"
       description: "توضیح"
       topic: "دسته بندی موضوع"
@@ -1016,45 +1150,67 @@ fa_IR:
       name_placeholder: "حداکثر یک با دوکلمه"
       color_placeholder: "هر رنگ وب"
       delete_confirm: "آیا مطمئنید که می‌خواهید این دسته‌بندی را پاک کنید؟"
-      list: "فهرست دسته‌ها"
+      delete_error: "هنگام حذف دسته بندی خطایی رخ داد."
+      list: "فهرست دسته‌ بندی ها"
+      no_description: "لطفا برای این دسته بندی توضیحاتی اضافه نمایید."
       change_in_category_topic: "ویرایش توضیحات"
+      already_used: 'این رنگ توسط یک دسته بندی دیگر گزیده شده است'
       security: "امنیت"
       images: "تصاویر"
-      auto_close_label: "بسته شدن خودکار جستارها پس از:"
+      auto_close_label: "بسته شدن خودکار موضوعات پس از:"
       auto_close_units: "ساعت ها"
+      email_in: "آدرس ایمیل های دریافتی سفارشی:"
+      email_in_disabled: "ارسال پست با رایانامه در تنظیمات سایت غیر فعال است. برای فعال سازی ارسال موضوع با ایمیل, "
+      email_in_disabled_click: 'فعال کردن تنظیمات "email in".'
+      allow_badges_label: "اجازی برای اهداء مدال در این دسته بندی"
       edit_permissions: "ویرایش پروانه‌ها"
       add_permission: "افزودن پروانه"
       this_year: "امسال"
       position: "موقعیت"
       default_position: "موقعیت پیش فرض"
+      position_disabled: "Categories will be displayed in order of activity. To control the order of categories in lists, "
+      position_disabled_click: 'در تنظیمات "مکان دسته بندی ثابت"  فعال را کنید.'
       parent: "دسته مادر"
       notifications:
         watching:
           title: "در حال تماشا"
+          description: "شما به صورت خود کار تمام نوشته های این دسته بندی را مشاهده خواهید کرد،به شما اطلاع رسانی خواهد شد تمام نوشته های جدید در موضوعات، بعلاوه تعداد نوشته های خوانده نشده و و نوشته های جدید در کنار موضوعات پدیدار میشود"
         tracking:
           title: "پیگیری"
+          description: "شما به صورت خود کار تمام موضوعات جدید در این دسته بندی را پی گیری خواهیدکرد،و تعداد نوشته های خوانده نشده در کنار موشوعات پدیدار می شود"
         regular:
           title: "منظم"
+          description: "به شما اطلاع داده خواهد شد اگر کسی به شما اشاره @name یا به نوشته های شما پاسخ دهند"
         muted:
           title: "بی صدا شد"
+          description: "به شما اطلاع داده خواهد شد همه چیز در رابطه با این دسته بندی ، و آن های پیدار نمی شود در تب خوانده نشده ها"
     flagging:
-      action: 'پرچم‌گذاری دیدگاه'
+      title: 'تشکر برای کمک به جامعه مدنی انجمن ما!'
+      private_reminder: 'پرچم های خصوصی, <b>فقط</b> قابل مشاهده برای مدیران'
+      action: 'پرچم‌گذاری نوشته'
       take_action: "اقدام"
+      notify_action: 'پیام'
       delete_spammer: "پاک کردن هرزنگار"
       yes_delete_spammer: "بله، پاک‌کردن هرزنگار"
       ip_address_missing: "(N/A)"
       hidden_email_address: "(مخفی)"
-      cant: "متأسفیم، در این زمان نمی‌توانید روی این دیدگاه بگذارید."
+      submit_tooltip: "ایجاد پرچم خصوصی"
+      cant: "متأسفیم، در این زمان نمی‌توانید پرچم روی این نوشته بگذارید."
       formatted_name:
+        off_topic: "آن موضوع قدیمی است"
+        inappropriate: "این نامناسب است"
         spam: "آن هرز نامه است"
       custom_message:
         at_least: "دست‌کم {{n}} نویسه بنویسید"
         more: "{{n}} نویسهٔ دیگر تا بتوانید بفرستید"
         left: "{{n}} نویسهٔ دیگر جا دارد"
     flagging_topic:
-      action: "پرچم‌گذاری جستار"
+      title: "تشکر برای کمک به جامعه مدنی انجمن ما!"
+      action: "پرچم‌گذاری موضوع"
+      notify_action: "پیام"
     topic_map:
-      title: "چکیدهٔ جستار"
+      title: "چکیدهٔ موضوع"
+      links_shown: "نمایش همه {{totalLinks}} پیوند ها..."
       clicks:
         other: "%{count} کلیک ها"
     topic_statuses:
@@ -1063,23 +1219,36 @@ fa_IR:
       bookmarked:
         help: "شما بر روی این موضوع نشانک گذاشته‌اید."
       locked:
-        help: "این جستار بسته شده؛ پاسخ‌های تازه اینجا پذیرفته نمی‌شوند"
+        help: "این موضوع بسته شده؛ پاسخ‌های تازه اینجا پذیرفته نمی‌شوند"
+      unpinned:
+        title: "خارج کردن از سنجاق"
+        help: "این موضوع برای شما شنجاق نشده است، آن طور منظم نمایش داده خواهد شد"
+      pinned_globally:
+        title: "به صورت سراسری سنجاق شد"
+        help: "این موضوع بصورت سراسری سنجاق شده است، آن بالای تمامی موضوعات نمایش داده خواهد شد"
       pinned:
         title: "سنجاق شد"
+        help: "این موضوع برای شما سنجاق شده است، آن  طور منظم در بالای دسته بندی نمایش داده خواهد شد."
       archived:
-        help: "این جستار بایگانی شده؛ یخ زده و نمی‌تواند تغییر کند."
-    posts: "دیدگاه‌ها"
+        help: "این موضوع بایگانی شده؛ یخ زده و نمی‌تواند تغییر کند."
+    posts: "نوشته‌ها"
     posts_lowercase: "نوشته ها"
-    posts_long: "این جستار {{number}} دیدگاه دارد"
-    original_post: "دیدگاه اصلی"
+    posts_long: "این موضوع {{number}} نوشته دارد"
+    posts_likes_MF: |
+      این موضوع است {count, plural, one {1 reply} other {# replies}} {ratio, select,
+        low {with a high like to post ratio}
+        med {with a very high like to post ratio}
+        high {with an extremely high like to post ratio}
+        other {}}
+    original_post: "نوشته اصلی"
     views: "نمایش‌ها"
     views_lowercase: "بازدید ها"
     replies: "پاسخ‌ها"
-    views_long: "از این جستار {{number}} بار بازدید شده"
+    views_long: "از این موضوع {{number}} بار بازدید شده"
     activity: "فعالیت"
     likes: "پسندها"
     likes_lowercase: "پسند ها"
-    likes_long: "{{number}} پسند در این جستار وجود دارد"
+    likes_long: "{{number}} پسند در این موضوع وجود دارد"
     users: "کاربران"
     users_lowercase: "کاربران"
     category_title: "دسته"
@@ -1088,27 +1257,30 @@ fa_IR:
     raw_email:
       title: "ایمیل خام"
       not_available: "در دسترس نیست!"
-    categories_list: "فهرست دسته‌ها"
+    categories_list: "فهرست دسته‌ بندی ها"
     filters:
       with_topics: "%{filter} موضوعات"
       with_category: "%{filter} %{category} موضوعات"
       latest:
-        title: "تازه‌ها"
-        help: "جستارهای با دیدگاه‌های تازه"
+        title: "آخرین ها"
+        help: "موضوعات با نوشته های تازه"
       hot:
         title: "داغ"
-        help: "گزینشی از داغ‌ترین جستارها"
+        help: "گزینشی از داغ‌ترین موضوعات"
       read:
         title: "خواندن"
+      search:
+        title: "جستجو"
+        help: "جستجوی تمام موضوعات"
       categories:
-        title: "دسته‌ها"
+        title: "دسته‌ بندی ها"
         title_in: "دسته بندی - {{categoryName}}"
-        help: "همهٔ جستارها در دسته‌ها جای گرفتند"
+        help: "همهٔ موضوعات در دسته‌ بندی ها جای گرفتند"
       unread:
         title:
-          zero: "نخوانده"
-          one: "نخوانده (۱)"
-          other: "نخوانده ({{count}})"
+          zero: "خوانده‌ نشده‌"
+          one: "خوانده‌ نشده‌ (۱)"
+          other: "خوانده‌ نشده‌ ({{count}})"
         lower_title_with_count:
           one: "1 خوانده نشده"
           other: "{{count}} خوانده نشده"
@@ -1121,8 +1293,9 @@ fa_IR:
           zero: "جدید"
           one: "جدید (1)"
           other: "جدید ({{count}})"
+        help: "موضوعاتی که در چند روز گذشته ایجاد شده"
       posted:
-        title: "دیدگاه‌های من"
+        title: "نوشته‌های من"
         help: "در این موضوع شما نوشته داردید"
       bookmarks:
         title: "نشانک ها"
@@ -1132,23 +1305,23 @@ fa_IR:
           zero: "{{categoryName}}"
           one: "{{categoryName}} (۱)"
           other: "{{categoryName}} ({{count}})"
-        help: "جستارهای تازه در دستهٔ {{categoryName}}"
+        help: "موضوعات تازه در دستهٔ {{categoryName}}"
       top:
-        title: "برگزیده"
+        title: "بالاترین‌ ها"
         yearly:
-          title: "بهترین سالانه"
+          title: "بالاترین‌ سالانه"
         monthly:
-          title: "بهترین ماهانه"
+          title: "بالاترین‌ ماهانه"
         weekly:
-          title: "بهترین هفتهگی"
+          title: "بالاترین‌ هفتهگی"
         daily:
-          title: "بهترین روزانه"
+          title: "بالاترین‌ روزانه"
         all: "تمام زمان ها"
         this_year: "امسال"
         this_month: "این ماه"
         this_week: "این هفته"
         today: "امروز"
-        other_periods: "دیدن بهترین موضوعات بیشتر "
+        other_periods: "دیدن بالاترین‌ موضوعات بیشتر "
     browser_update: 'متاسفانه, <a href="http://discours.ir/t/topic/117">مرورگر شما خیلی قدیمی است برای ادامه کار در این وب سایت</a>. لطفا <a href="http://browsehappy.com">مرورگر خود را بروز رسانی نمایید</a>.'
     permission_types:
       full: "ساختن / پاسخ دادن / دیدن"
@@ -1164,6 +1337,8 @@ fa_IR:
         last_updated: "آخرین به‌روزرسانی پیش‌خوان"
         version: "نسخه"
         up_to_date: "شما به روز هستید!"
+        critical_available: "به روز رسانی حیاتی در دسترس است."
+        updates_available: "بروز رسانی در درسترس است."
         please_upgrade: "لطفا ارتقاء دهید!"
         no_check_performed: "بررسی برای بروزرسانی انجام نشد. از اجرای  sidekiq اطمینان حاصل کنید."
         stale_data: "بررسی برای بروزرسانی اخیراً انجام نگرفته است. از اجرای  sidekiq اطمینان حاصل کنید."
@@ -1177,10 +1352,16 @@ fa_IR:
         admins: 'مدیران کل:'
         blocked: 'مسدود شده ها:'
         suspended: 'تعلیق شده:'
+        private_messages_short: "پیام"
+        private_messages_title: "پیام"
         space_free: "{{size}} آزاد"
         uploads: "بارگذاری ها"
         backups: "پشتیبان ها"
         traffic_short: "ترافیک"
+        traffic: "درخواست های نرم افزار وب"
+        page_views: "درخواست های API"
+        page_views_short: "درخواست های API"
+        show_traffic_report: "نمایش دقیق گزارش ترافیک"
         reports:
           today: "امروز"
           yesterday: "دیروز"
@@ -1196,41 +1377,62 @@ fa_IR:
           start_date: "تاریخ شروع"
           end_date: "تاریخ پایان"
       commits:
+        latest_changes: "آخرین تغییرات: لطفا دوباره به روز رسانی کنید!"
         by: "توسط"
       flags:
-        title: "نشانه گذاری ها"
+        title: "پرچم گذاری ها"
         old: "قدیمی"
         active: "فعال"
         agree: "موافقت کردن"
+        agree_title: "تایید این پرچم به عنوان معتبر و صحیح"
         agree_flag_modal_title: "موافقت کردن و ..."
+        agree_flag_hide_post: "موافقت با (مخفی کردن نوشته + ارسال پیام خصوصی)"
         agree_flag_restore_post: "موافقم (بازگرداندی نوشته)"
         agree_flag_restore_post_title: "بازگردانی این نوشته"
-        agree_flag: "موافقت با نشانه گذاری"
+        agree_flag: "موافقت با پرچم گذاری"
+        agree_flag_title: "موافقت با پرچم و نگه داشتن نوشته بدون تغییر"
         defer_flag: " واگذار کردن"
+        defer_flag_title: "خذف این پرچم،بدون نیاز به اقدام در این زمان"
         delete: "حذف"
+        delete_title: "حذف پرچم نوشته و اشاره به."
+        delete_post_defer_flag: "حذف نوشته و  رها کردن پرچم"
+        delete_post_defer_flag_title: "حذف نوشته; اگر اولین نوشته است،موضوع را حذف نمایید."
+        delete_post_agree_flag: "حذف نوشته و موافقت با پرچم"
+        delete_post_agree_flag_title: "حذف نوشته; اگر اولین نوشته است،موضوع را حذف نمایید."
         delete_flag_modal_title: "حذف و..."
         delete_spammer: "حذف اسپمر"
+        delete_spammer_title: "حذف کاربر و تمام نوشته ها و موضوعات این کاربر"
         disagree_flag_unhide_post: "مخالفم (با رویت نوشته)"
+        disagree_flag_unhide_post_title: "حذف تمام پرچم های این نوشته و دوباره نوشته را قابل نمایش کن "
         disagree_flag: "مخالف"
+        disagree_flag_title: "انکار این پرچم به عنوان نامعتبر است و یا نادرست"
         clear_topic_flags: "تأیید"
-        clear_topic_flags_title: "جستار بررسی و موضوع حل شده است. تأیید را بفشارید تا پرچم‌ها برداشته شوند."
+        clear_topic_flags_title: "موضوع بررسی و موضوع حل شده است. تأیید را بفشارید تا پرچم‌ها برداشته شوند."
+        more: "(پاسخ های بیشتر...)"
         dispositions:
           agreed: "موافقت شد"
           disagreed: "مخالفت شد"
           deferred: "دیرفرست"
+        flagged_by: "پرچم شده توسط"
+        resolved_by: "حل شده توسط"
+        took_action: "زمان عمل"
         system: "سیستم"
         error: "اشتباهی روی داد"
         reply_message: "پاسخ دادن"
         no_results: "هیچ پرچمی نیست"
-        topic_flagged: "این <strong>جستار</strong> پرچم خورده است."
-        visit_topic: "برای اقدام لازم، جستار را ببینید"
+        topic_flagged: "این <strong>موضوع</strong> پرچم خورده است."
+        visit_topic: "برای اقدام لازم، موضوع را ببینید"
+        was_edited: "نوشته پس از پرچم اول ویرایش شد"
+        previous_flags_count: "این موضوع در حال حاضر چندین با {{count}} پرچم گذاری شده است."
         summary:
+          action_type_3:
+            other: "موضوعات غیرفعال x{{count}}"
           action_type_4:
             other: "نامناسب X{{count}}"
           action_type_6:
-            other: "رسم x{{count}}"
+            other: "دلخواه x{{count}}"
           action_type_7:
-            other: "رسم x{{count}}"
+            other: "دلخواه x{{count}}"
           action_type_8:
             other: " هرزنامه x{{count}}"
       groups:
@@ -1241,6 +1443,8 @@ fa_IR:
         refresh: "تازه کردن"
         new: "جدید"
         selector_placeholder: "نام کاربری را وارد نمایید ."
+        name_placeholder: "نام گروه، بدون فاصله، همان قاعده نام کاربری"
+        about: "ویرایش عضویت در گروه شما و نام ها اینجا"
         group_members: "اعضای گروه"
         delete: "حذف"
         delete_confirm: "حذف این گروه؟"
@@ -1248,17 +1452,22 @@ fa_IR:
         name: "نام"
         add: "اضافه کردن"
         add_members: "اضافه کردن عضو"
-        custom: "رسم"
+        custom: "دلخواه"
         automatic: "خودکار"
       api:
+        generate_master: "ایجاد کلید اصلی API"
+        none: "هم اکنون هیچ کلید API فعالی وجود ندارد"
         user: "کاربر"
         title: "API"
         key: "کلید API"
         generate: "تولید کردن"
         regenerate: "احیاء کردن"
         revoke: "لغو کردن"
-        info_html: "جستارهای تازه پس از آخرین بازدید شما"
+        confirm_regen: "آیا می خواهید API موجود را با یک API جدید جایگزین کنید؟"
+        confirm_revoke: "آیا مطمئن هستید که می خواهید کلید را برگردانید؟"
+        info_html: "موضوعات تازه پس از آخرین بازدید شما"
         all_users: "همه کاربران"
+        note_html: "این کلید را <strong>امن</strong> نگهدارید، ممکن است از آن سوئ استفاده شود."
       plugins:
         title: "افزونه ها"
         installed: "افزونه های نصب شده"
@@ -1266,7 +1475,7 @@ fa_IR:
         none_installed: "شما هیچ افزونه نصب شده ای  ندارید"
         version: "نسخه"
         change_settings: "تغییر تنظیمات"
-        howto: "<a href=\"http://discours.ir\">چگونه یک افزونه نصب کنیم؟ </a>"
+        howto: "چگونه یک افزونه نصب کنیم؟"
       backups:
         title: "پشتیبان گیری"
         menu:
@@ -1276,9 +1485,11 @@ fa_IR:
         read_only:
           enable:
             title: "به کار گرفتن شیوهٔ‌ فقط-خواندنی"
+            label: "غیر فعال کردن مد فقط خواندن"
             confirm: "آیا مطمئنید که می‌خواهید حالت فقط-خواندنی را به کار بیاندازید؟"
           disable:
             title: "از کار انداختن حالت فقط-خواندنی"
+            label: "غیر فعال کردن مد فقط خواندن"
         logs:
           none: "هنوز بدون گزارش است ..."
         columns:
@@ -1286,16 +1497,22 @@ fa_IR:
           size: "اندازه"
         upload:
           label: "بار گذاری"
+          title: "آپلود یک نسخه پشتیبان برای این نمونه"
           uploading: "در حال بار گذاری ..."
+          success: "'{{filename}}' با موفقیت آپلود شد."
+          error: "هنگام آپلود خطایی رخ می دهد '{{filename}}': {{message}}"
         operations:
           is_running: "عملیاتی در جریان است..."
+          failed: "در {{operation}} ناموفق. لطفا گزارشات را بررسی نمایید."
           cancel:
             label: "لغو کردن"
             title: "کنار گذاشتن عملیات کنونی"
             confirm: "آیا مطمئنید که می‌خواهید عملیات کنونی را کنار بگذارید؟"
           backup:
-            label: "پشتیبان"
+            label: "پشتیبان گیری"
             title: "ساختن یک پشتیبان"
+            confirm: "آیا می خواید یک پشیبان گیری را آغاز نمایید ؟"
+            without_uploads: "بله (فایل ها را شامل نمی شود)"
           download:
             label: "دانلود"
             title: "بارگیری پشتیبان"
@@ -1311,7 +1528,15 @@ fa_IR:
             label: "عقبگرد"
       export_csv:
         user_archive_confirm: "آیا مطمئنید که می‌خواهید نوشته‌هایتان را دانلود کنید؟"
+        success: "فرایند برون ریزی، به شما ار سریق پیام اطلاع رسانی خواهد شد اگر این فرایند تکمیل شود."
+        failed: "برون ریزی شکست خورد، لطفا لوگ گزارشات را مشاهده فرمایید"
         button_text: "خروجی گرفتن"
+        button_title:
+          user: "برون ریزی لیست تمام کاربران با قالب CSV ."
+          staff_action: "برون ریزی تمام کار های مدیران با فرمت CSV ."
+          screened_email: "برون ریزی کامل لیست ایمیل به نمایش در آمده در فرمت CSV."
+          screened_ip: "برون ریزی کامل لیست ای پی به نمایش در آمده در فرمت CSV."
+          screened_url: "برون ریزی کامل لیست URL به نمایش در آمده در فرمت CSV."
       invite:
         button_text: "ارسال دعوتنامه"
         button_title: "ارسال دعوتنامه"
@@ -1326,12 +1551,14 @@ fa_IR:
           text: "</head>"
         body_tag:
           text: "</body>"
+        override_default: "حاوی شیوه نامه استاندارد نیست"
         enabled: "فعال شد؟"
         preview: "پیش‌نمایش"
         undo_preview: "حذف پیش نمایش"
         rescue_preview: "استایل پیش فرض"
         explain_preview: "مشاهده‌ی سایت با این قالب سفارشی"
-        save: "اندوختن"
+        explain_rescue_preview: "دیدن سایت با شیوه نامه پیش فرض"
+        save: "ذخیره سازی"
         new: "تازه"
         new_style: "سبک جدید"
         delete: "پاک کردن"
@@ -1353,6 +1580,7 @@ fa_IR:
           revert: "برگشت"
           primary:
             name: 'اولیه'
+            description: 'متن بیشتر، آیکون ها، و کناره ها.'
           secondary:
             name: 'دومی'
           tertiary:
@@ -1443,6 +1671,7 @@ fa_IR:
           show: "نمایش"
           modal_title: "جزئیات"
           no_previous: "هیچ مقدار قبلی وجود دارد."
+          deleted: "بدون مقدار جدید. رکورد حذف شد."
           actions:
             delete_user: "حذف کاربر"
             change_trust_level: "تغییر دادن سطح اعتماد"
@@ -1471,6 +1700,7 @@ fa_IR:
         screened_ips:
           title: "نمایش آپی پی ها"
           delete_confirm: "آیا از حذف قانون وضع شده برای {ip_address}% اطمینان دارید؟"
+          rolled_up_no_subnet: "هیچ چیز برای ذخیره کردن وجود ندارد."
           actions:
             block: "بستن"
             do_nothing: "اجازه دادن"
@@ -1486,11 +1716,13 @@ fa_IR:
           title: "گزارش خطا"
       impersonate:
         title: "جعل هویت کردن"
+        help: "با استفاده از این ابزار یک حساب کاربری را برای اشکال زدایی انتخاب نمایید،شما باید بعد از اتمام کار یک بار خارج شوید."
       users:
         title: 'کاربران'
         create: 'اضافه کردن کاربر ادمین'
         last_emailed: "آخرین ایمیل فرستاده شده"
         not_found: "lj"
+        id_not_found: "با عرض پوزش،کاربری با این ID در سیستم ما وجود ندارد"
         active: "فعال"
         show_emails: "نشان دادن ایمیل ها"
         nav:
@@ -1523,6 +1755,8 @@ fa_IR:
           suspect: 'کاربران مشکوک'
         reject_successful:
           other: "کاربران %{count}  با موفقیت رد شدند"
+        reject_failures:
+          other: "رد کاربران %{count} ناموفق بود"
         not_verified: "تایید نشده"
         check_email:
           text: "نشان دادن"
@@ -1534,7 +1768,8 @@ fa_IR:
         suspend_reason_label: "شما چرا معلق شده‌اید؟ این متن بر روی صفحه‌ی نمایه‌ی کاربر <b/>برای همه قابل مشاهده خواهد بود<b>، و در هنگام ورود به سیستم نیز به خود کاربر نشان داده خواهد شد. لطفاً خلاصه بنویسید."
         suspend_reason: "دلیل"
         suspended_by: "تعلیق شده توسط"
-        delete_all_posts: "پاک کردن همهٔ دیدگاه‌ها"
+        delete_all_posts: "پاک کردن همهٔ نوشته‌ها"
+        delete_all_posts_confirm: "شما می خواهید تعداد %{posts}  نوشته و تعداد %{topics} موضوع خذف کنید،آیا مطمئن هستید؟"
         suspend: "تعلیق"
         unsuspend: "خارج کردن از تعلیق"
         suspended: "تعلیق شد ؟"
@@ -1543,35 +1778,55 @@ fa_IR:
         blocked: "مسدود شد ؟"
         show_admin_profile: "مدیر"
         edit_title: "ویرایش سرنویس"
-        save_title: "اندوختن سرنویس"
+        save_title: "ذخیره سازی سرنویس"
         refresh_browsers: "تازه کردن اجباری مرورگر"
         refresh_browsers_message: "ارسال پیام به تمام مشتری ها! "
         show_public_profile: "نماش نمایه همگانی"
         impersonate: 'جعل هویت کردن'
         ip_lookup: "مشاهده ای پی"
         log_out: "خروج"
+        logged_out: "کاربر از کل دستگاه ها خارج شد."
         revoke_admin: 'لغو مدیریت'
         grant_admin: 'اعطای مدیریت'
+        revoke_moderation: 'پس گرفتن مدیریت'
+        grant_moderation: 'اعطای مدیریت'
+        unblock: 'قفل کردن'
         block: 'عقب'
         reputation: ' سابقه'
         permissions: پروانه‌ها
         activity: فعالیت
         like_count: لایک‌های اعطایی/دریافتی
         last_100_days: 'در 100 روز گذشته'
-        private_topics_count: جستارهای خصوصی
+        private_topics_count: موضوعات خصوصی
+        posts_read_count: خواندن نوشته ها
         post_count: پست ایجاد شده
         topics_entered: بازدید موضوعات
+        flags_given_count: پرچم های ارسالی
+        flags_received_count: پرچم های دریافتی
+        warnings_received_count: اخطار های دریافتی
+        flags_given_received_count: 'پرچم های  ارسالی / دریافتی'
         approve: 'تصویب'
         approved_by: "تصویب شده توسط"
+        approve_success: "کاربر تایید و ایمیل با دستورالعمل فعال سازی ارسال شد."
+        approve_bulk_success: "موفق!همه کاربران انتخاب شده تایید و اطلاعیه ارسال شد."
+        time_read: "زمان خوانده شده"
         anonymize: "کاربر ناشناس"
+        anonymize_yes: "بله ، این یک حساب کاربری ناشناس است."
+        anonymize_failed: "یک مشکل با حساب کاربری ناشناس وجود دارد"
         delete: "پاک کردن کاربر"
-        delete_forbidden_because_staff: "مدیران و ناظمان را نمی‌توانید پاک کنید"
+        delete_forbidden_because_staff: "مدیران کل و مدیران را نمی‌توانید پاک کنید"
+        delete_posts_forbidden_because_staff: "نمی توان همه نوشته های مدیران کل و مدیران را خذف کرد"
         delete_forbidden:
-          other: "نمی‌توانید کاربرانی را که جستار دارند پاک کنید. پیش از تلاش برای پاک کردن کاربر، نخست همهٔ‌ جستارهایش را پاک کنید. (جستارهایی که بیش از %{count}  روز پیش فرستاده شده باشند، نمی‌توانند پاک شوند.)"
+          other: "نمی‌توانید کاربرانی را که موضوع دارند پاک کنید. پیش از تلاش برای پاک کردن کاربر، نخست همهٔ‌ موضوعاتش را پاک کنید. (موضوعات که بیش از %{count}  روز پیش فرستاده شده باشند، نمی‌توانند پاک شوند.)"
+        cant_delete_all_posts:
+          other: "نمی توان همه نوشته ها را خذف کرد. برخی نوشته ها قدیمی تر از %{count} هستند.(در delete_user_max_post_age setting.)"
+        cant_delete_all_too_many_posts:
+          other: "نمی توان همه نوشته ها را خذف کرد. چون تعداد کاربران از %{count} تعداد نوشته ها بیشتر است.(delete_all_posts_max)"
+        delete_confirm: "آیا مطمئن هستید که می خواهید این کاربر را حذف کنید ؟ این کار دائمی است!"
         delete_and_block: "حذف و <b>مسدود</b>کن این آی پی و آدرس ایمل را"
         delete_dont_block: "فقط حذف"
         deleted: "کاربر پاک شد."
-        delete_failed: "خطایی در پاک کردن آن کاربر روی داد. پیش از تلاش برای پاک کردن کاربر، مطمئن شوید همهٔ‌جستارها پاک شوند."
+        delete_failed: "خطایی در پاک کردن آن کاربر روی داد. پیش از تلاش برای پاک کردن کاربر، مطمئن شوید همهٔ‌ موضوعات پاک شوند."
         send_activation_email: "فرستادن رایانامه فعال‌سازی"
         activation_email_sent: "یک رایانامه فعال‌سازی فرستاده شده است."
         send_activation_email_failed: "در فرستادن رایانامهٔ‌ فعال‌سازی دیگری مشکلی داریم.\n%{error}"
@@ -1582,9 +1837,10 @@ fa_IR:
         unblock_failed: 'در برداشتن قفل این کاربر مشکلی پیش آمد.'
         block_failed: 'در قفل کردن این کاربر مشکلی پیش آمد.'
         suspended_explanation: "کاربر تعلیق شده نمی‌تواند وارد سیستم شود."
-        block_explanation: "کاربر قفل شده نمی‌تواند دیدگاهی بگذارد یا جستاری آغاز کند."
+        block_explanation: "کاربر قفل شده نمی‌تواند نوشته ای بگذارد یا موضوعی آغاز کند."
         trust_level_change_failed: "در تغییر سطح اعتماد کاربر مشکلی پیش آمد."
         grant_admin_failed: "در اعطای اختیارات مدیریت مشکلی پیش آمد."
+        grant_moderation_failed: "یک مشکل در  اعطای امتیازات مدیریت وجود دارد."
         suspend_modal_title: "کاربران تعلیق شده"
         trust_level_2_users: "کاربران سطح اعتماد 2"
         trust_level_3_requirements: "مقررات سطح اعتماد 3"
@@ -1604,7 +1860,7 @@ fa_IR:
           topics_viewed_all_time: "موضوعات مشاهده شده ( تمام مدت )"
           posts_read: "نوشته‌های خوانده شده"
           posts_read_all_time: "نوشته‌های خوانده شده ( تمام مدت )"
-          flagged_posts: "دیدگاه‌های پرچم‌خورده"
+          flagged_posts: "نوشته‌های پرچم‌خورده"
           flagged_by_users: "کاربرانی که پرچم خورده‌اند"
           likes_given: "لایک‌های اعطایی"
           likes_received: "لایک‌های دریافتی"
@@ -1675,6 +1931,7 @@ fa_IR:
           onebox: "یک جعبه"
           seo: 'SEO'
           spam: 'هرزنامه'
+          rate_limits: 'میزان محدودیت'
           developer: 'توسعه دهنده'
           embedding: "توکاری"
           legal: "حقوقی"
@@ -1683,7 +1940,7 @@ fa_IR:
           login: "ورود"
           plugins: "افزونه ها"
       badges:
-        title: مدالها
+        title: مدال ها
         new_badge: مدال جدید
         new: جدید
         name: نام
@@ -1697,7 +1954,7 @@ fa_IR:
         granted_by: اعطا شده توسط
         granted_at: اعطا شده در
         reason_help: (یک لینک به یک نوشته یا موضوع)
-        save: اندوختن
+        save: ذخیره سازی
         delete: پاک کردن
         delete_confirm: آیا مطمئنید که می‌خواهید این مدال را پاک کنید؟
         revoke: بازیافت
@@ -1706,25 +1963,32 @@ fa_IR:
         revoke_confirm: آیا مطمئنید که می‌خواهید این مدال را بازیافت کنید؟
         edit_badges: ویرایش مدال‌ها
         grant_badge: اعطای مدال
-        granted_badges: مدالها اعطایی
+        granted_badges: مدال ها اعطایی
         grant: اهداء
         no_user_badges: "%{name} هیچ مدالی دریافت نکرده است."
         no_badges: مدالی برای اعطا کردن وجود ندارد.
         none_selected: "برای شروع یک مدال رو انتخاب کنید"
+        allow_title: اجازه برای استفاده مدال در عنوان
+        multiple_grant: نمی توان چندین با اهداء کرد
+        listable: نشان دادن مدال در صفحه مدال های عمومی
         enabled: به‌کارگیری مدال
         icon: آیکن
         image: تصویر
         query: پرس جوی مدال (SQL)
+        target_posts: پرس و جو نوشته های هدف
         trigger: گیره
         trigger_type:
           none: "به‌روزرسانی روزانه"
-          post_action: "هنگامی‌که کاربری روی دیدگاهی کاری انجام می‌دهد"
-          post_revision: "هنگی که یک کاربر دیدگاهی ویرایش می‌کند یا فرستد"
+          post_action: "هنگامی‌که کاربری روی نوشته ای کاری انجام می‌دهد"
+          post_revision: "هنگی که یک کاربر نوشته ای  ویرایش می‌کند یا فرستد"
           trust_level_change: "هنگامی که کاربری سطح اعتماد را تغییر می‌دهد"
           user_change: "هنگامی که کاربری ویرایش یا ساخته می‌شود"
         preview:
+          link_text: "پیش نمایش مدال های اعطایی"
           plan_text: "پیشنمایش با طرح پرس و جو"
           modal_title: "پیشنمایش پرس و جو مدال "
+          sql_error_header: "خطایی با پرس و جو وجود دارد"
+          error_help: "پیروی کنید از پیوند برای کمک در رابطه با پرس جوی مدال ها"
           bad_count_warning:
             header: "هشدار!"
           grant_count:
@@ -1767,7 +2031,7 @@ fa_IR:
         next_prev: '<b>shift</b>+<b>j</b>/<b>shift</b>+<b>k</b> بخش قبلی/بعدی'
       application:
         title: 'نرم‌افزار'
-        create: '<b>c</b> ساختن یک جستار نو'
+        create: '<b>c</b> ساختن یک موضوع جدید'
         notifications: '<b>n</b> باز کردن آگاه‌سازی‌ها'
         site_map_menu: '<b>=</b> باز کردن منوی سایت'
         user_profile_menu: '<b>p</b> باز کردن منوی کاربران'
@@ -1781,16 +2045,16 @@ fa_IR:
         bookmark_topic: '<b>f</b> تعویض نشانک موضوع'
         pin_unpin_topic: '<b>shift</b>+<b>p</b> سنجاق /لغو ساجاق موضوع'
         share_topic: '<b>shift</b>+<b>s</b> اشتراک گذاری نوشته'
-        share_post: 'به اشتراک‌گذاری دیدگاه'
+        share_post: 'به اشتراک‌گذاری نوشته'
         reply_as_new_topic: '<b>t</b> پاسخگویی به عنوان یک موضوع لینک شده'
         reply_topic: '<b>shift</b>+<b>r</b> پاسخ به موضوع'
-        reply_post: '<b>r</b> پاسخ به دیدگاه'
-        quote_post: 'نقل‌قول دیدگاه'
-        like: '<b>l</b> پسندیدن دیدگاه'
-        flag: '<b>!</b> پرچم‌گذاری دیدگاه'
-        bookmark: '<b>b</b> نشانک‌گذاری دیدگاه'
-        edit: '<b>e</b> ویرایش دیدگاه'
-        delete: '<b>d</b> پاک کردن دیدگاه'
+        reply_post: '<b>r</b> پاسخ به نوشته'
+        quote_post: 'نقل‌قول نوشته'
+        like: '<b>l</b> پسندیدن نوشته'
+        flag: '<b>!</b> پرچم‌گذاری نوشته'
+        bookmark: '<b>b</b> نشانک‌گذاری نوشته'
+        edit: '<b>e</b> ویرایش نوشته'
+        delete: '<b>d</b> پاک کردن نوشته'
         mark_muted: '<b>m</b>, <b>m</b> بی صدا کردن موضوع'
         mark_regular: '<b>m</b>, <b>r</b> تنظیم ( پیش فرض) موضوع'
         mark_tracking: '<b>m</b>, <b>t</b> Track tموضوع'
@@ -1804,7 +2068,7 @@ fa_IR:
       more_badges:
         other: "+%{count} بیش‌تر"
       granted:
-        other: "٪ {COUNT} اعطا شد"
+        other: "%{count} اعطا شد"
       select_badge_for_title: انتخاب یک مدال برای استفاده در عنوان خود
       none: "<none>"
       badge_grouping:
@@ -1821,12 +2085,12 @@ fa_IR:
       badge:
         editor:
           name: ویرایش‌گر
-          description: نخستین ویرایش دیدگاه
+          description: نخستین ویرایش نوشته
         basic_user:
           name: اساسی
           description: <a href="http://discours.ir/t/topic/98">اعطا کردن</a> تمام عملکرد های ضروری برای انجمن
         member:
-          name: اعضا
+          name: عضو
           description: <a href="http://discours.ir/t/topic/98">اعطا کردن</a> دعوت نامه
         regular:
           name: منظم
@@ -1876,13 +2140,13 @@ fa_IR:
           description: اشتراک گذاری نوشته با 1000 بازدید کننده منحصر به فرد
         first_like:
           name: نخستین پسند
-          description: دیدگاهی را پسندید
+          description: نوشته ای را پسندید
         first_flag:
           name: پرچم نخست
-          description: دیدگاهی را پرچم زد
+          description: نوشته را پرچم زد
         first_share:
           name: نخستین اشتراک‌گذاری
-          description: دیدگاهی به اشتراک گذاشت
+          description: نوشته ای به اشتراک گذاشت
         first_link:
           name: پیوند نخست
           description: لین های داخلی اضافه شده به دیگر موضوعات
@@ -1890,8 +2154,8 @@ fa_IR:
           name: نقل‌قول نخست
           description: نقل قول یک کاربر
         read_guidelines:
-          name: خواندن راهنماها
-          description: Read the <a href="/guidelines">community guidelines</a>
+          name: خواندن راهنما ها
+          description: خواندن <a href="/guidelines">آموزش های انجمن</a>
         reader:
           name: خواننده
           description: مطالعه تمام نوشته‌هایی که موضوعشان بیش از 100 نوشته دارد.

--- a/config/locales/client.fa_IR.yml
+++ b/config/locales/client.fa_IR.yml
@@ -15,2156 +15,974 @@
 # To validate this YAML file after you change it, please paste it into
 # http://yamllint.com/
 fa_IR:
-  js:
-    number:
-      human:
-        storage_units:
-          format: '%n %u'
-          units:
-            byte:
-              other: بایت
-            gb: GB
-            kb: KB
-            mb: MB
-            tb: TB
-    dates:
-      time: "h:mm a"
-      long_no_year: "MMM D h:mm a"
-      long_no_year_no_time: "MMM D"
-      long_with_year: "MMM D, YYYY h:mm a"
-      long_with_year_no_time: "MMM D, YYYY"
-      long_date_with_year: "MMM D, 'YY LT"
-      long_date_without_year: "MMM D, LT"
-      long_date_with_year_without_time: "MMM D, 'YY"
-      long_date_without_year_with_linebreak: "MMM D <br/>LT"
-      long_date_with_year_with_linebreak: "MMM D, 'YY <br/>LT"
-      tiny:
-        half_a_minute: "< ۱ دقیقه"
-        less_than_x_seconds:
-          other: "< %{count} ثانیه"
-        x_seconds:
-          other: "%{count} ثانیه"
-        less_than_x_minutes:
-          other: "< %{count} دقیقه"
-        x_minutes:
-          other: "%{count} دقیقه"
-        about_x_hours:
-          other: "%{count} ساعت"
-        x_days:
-          other: "%{count} روز"
-        about_x_years:
-          other: "%{count} سال"
-        over_x_years:
-          other: "> %{count} سال"
-        almost_x_years:
-          other: "%{count} سال"
-        date_month: "MMM D"
-        date_year: "MMM 'YY"
-      medium:
-        x_minutes:
-          other: "%{count} دقیقه"
-        x_hours:
-          other: "%{count} ساعت"
-        x_days:
-          other: "%{count} روز"
-        date_year: "MMM D, 'YY"
-      medium_with_ago:
-        x_minutes:
-          other: "%{count} دقیقه پیش"
-        x_hours:
-          other: "%{count} ساعت پیش"
-        x_days:
-          other: "%{count} روز پیش"
-    share:
-      topic: 'پیوندی به این موضوع را به اشتراک بگذارید'
-      post: 'ارسال #%{postNumber}'
-      close: 'بسته'
-      twitter: 'این پیوند را در توییتر به اشتراک بگذارید.'
-      facebook: 'این پیوند را در فیسبوک به اشتراک بگذارید.'
-      google+: 'این پیوند را در Google+‎ به اشتراک بگذارید.'
-      email: 'این پیوند را با ایمیل بفرستید'
-    topic_admin_menu: "اقدامات مدیریت موضوع"
-    emails_are_disabled: "تمام ایمیل های خروجی بصورت جهانی توسط مدیر قطع شده. هیچ ایمیل اخطاریه های ارسال نخواهد شد."
-    s3_deprecation_warning: "اخطار! آمازون S3 برای ذخیره سازی تصویر / فایل ضمیمه توصیه نمی شود. لطفا، به دنبال <a href='https://meta.discourse.org/t/warning-amazon-s3-is-deprecated-in-1-3-for-image-attachment-storage/26594'>دستورالعمل ها</a> و مهاجرت به ذخیره سازی محلی."
-    edit: 'سرنویس و دستهٔ این موضوع را ویرایش کنید'
-    not_implemented: "آن ویژگی هنوز به کار گرفته نشده، متأسفیم!"
-    no_value: "نه"
-    yes_value: "بله"
-    generic_error: "متأسفیم، خطایی روی داده."
-    generic_error_with_reason: "خطایی روی داد: %{error}"
-    sign_up: "ثبت نام"
-    log_in: "ورود"
-    age: "سن"
-    joined: "ملحق شده در"
-    admin_title: "مدیر"
-    flags_title: "پرچم‌ها"
-    show_more: "بیش‌تر نشان بده"
-    show_help: "کمک"
-    links: "پیوندها"
-    links_lowercase: "پیوندها"
-    faq: "پرسش‌های متداول"
-    guidelines: "راهنماها"
-    privacy_policy: "سیاست حریم خصوصی"
-    privacy: "حریم خصوصی"
-    terms_of_service: "شرایط استفاده از خدمات"
-    mobile_view: "نمایش برای موبایل "
-    desktop_view: "نمایش برای کامپیوتر"
-    you: "شما"
-    or: "یا"
-    now: "هم‌اکنون"
-    read_more: 'بیشتر بخوانید'
-    more: "بیشتر"
-    less: "کمتر"
-    never: "هرگز"
-    daily: "روزانه"
-    weekly: "هفتگی"
-    every_two_weeks: "هر دو هفته"
-    every_three_days: "هر سه روز"
-    max_of_count: "حداکثر {{count}}"
-    character_count:
-      other: "{{count}} نویسه"
-    suggested_topics:
-      title: "موضوعات پیشنهادی"
-    about:
-      simple_title: "درباره"
-      title: "درباره %{title}"
-      stats: "آمارهای سایت"
-      our_admins: "مدیران  ما"
-      our_moderators: "مدیران ما"
-      stat:
-        all_time: "تمام وقت"
-        last_7_days: "7 روز اخیر"
-        last_30_days: "30 روز گذشته"
-      like_count: "لایک ها "
-      topic_count: "موضوعات"
-      post_count: "پست ها"
-      user_count: "کاربران جدید"
-      active_user_count: "کاربران فعال"
-      contact: "ارتباط با ما"
-      contact_info: "در شرایط حساس و مسائل اضطراری مربوط به سایت٬‌ لطفا با تماس بگیرید از طریق %{contact_info}."
-    bookmarked:
-      title: "نشانک"
-      clear_bookmarks: "پاک کردن نشانک ها"
-      help:
-        bookmark: "برای نشانک گذاری به اولین نوشته این موضوع مراجعه نمایید"
-        unbookmark: "برای حذف تمام نشانک های این موضوع کلیک کنید"
-    bookmarks:
-      not_logged_in: "متأسفیم، شما باید به وارد شوید تا روی نوشته ها نشانک بگذارید."
-      created: "شما این نوشته ها را نشانک گذاشته‌اید."
-      not_bookmarked: "شما این نوشته را خوانده‌اید؛ بفشارید تا روی آن نشانک بگذارید."
-      last_read: "این آخرین نوشته ای  است که خوانده‌اید؛ بفشارید تا روی آن نشانک بگذارید."
-      remove: "پاک کردن نشانک"
-      confirm_clear: "آیا مطمئنید که می‌خواهید همه نشانک ها را از این موضوع پاک کنید؟"
-    topic_count_latest:
-      other: "{{count}} موضوعات تازه یا به‌ روز شده."
-    topic_count_unread:
-      other: "{{count}} موضوعات خوانده نشده."
-    topic_count_new:
-      other: "{{count}} موضوعات تازه."
-    click_to_show: "برای نمایش کلیک کنید."
-    preview: "پیش‌نمایش"
-    cancel: "لغو"
-    save: "ذخیره سازی تغییرات"
-    saving: "در حال ذخیره سازی ..."
-    saved: "ذخیره شد!"
-    upload: "بارگذاری"
-    uploading: "در حال بارگذاری..."
-    uploaded: "بارگذاری شد!"
-    enable: "فعال کردن"
-    disable: "ازکاراندازی"
-    undo: "برگردانی"
-    revert: "برگشت"
-    failed: "ناموفق"
-    banner:
-      close: "این سردر را رد بده."
-    choose_topic:
-      none_found: "موضوعی یافت نشد."
-      title:
-        search: "جستجو برای یک موضوع از روی نام، نشانی (url) یا شناسه (id)"
-        placeholder: "سرنویس موضوع را اینجا بنویسید"
-    user_action:
-      user_posted_topic: "<a href='{{userUrl}}'>{{user}}</a> posted <a href='{{topicUrl}}'>the topic</a>"
-      you_posted_topic: "<a href='{{userUrl}}'>شما</a> در <a href='{{topicUrl}}'>این موضوع</a> نوشته گذاشتید"
-      user_replied_to_post: "<a href='{{userUrl}}'>{{user}}</a> replied to <a href='{{postUrl}}'>{{post_number}}</a>"
-      you_replied_to_post: "<a href='{{userUrl}}'>You</a> replied to <a href='{{postUrl}}'>{{post_number}}</a>"
-      user_replied_to_topic: "<a href='{{userUrl}}'>{{user}}</a> replied to <a href='{{topicUrl}}'>the topic</a>"
-      you_replied_to_topic: "<a href='{{userUrl}}'>You</a> replied to <a href='{{topicUrl}}'>the topic</a>"
-      user_mentioned_user: "<a href='{{user1Url}}'>{{user}}</a> mentioned <a href='{{user2Url}}'>{{another_user}}</a>"
-      user_mentioned_you: "<a href='{{user1Url}}'>{{user}}</a> mentioned <a href='{{user2Url}}'>you</a>"
-      you_mentioned_user: "<a href='{{user1Url}}'>شما</a>  نام برده شده اید <a href='{{user2Url}}'>{{another_user}}</a>"
-      posted_by_user: "Posted by <a href='{{userUrl}}'>{{user}}</a>"
-      posted_by_you: "Posted by <a href='{{userUrl}}'>you</a>"
-      sent_by_user: "Sent by <a href='{{userUrl}}'>{{user}}</a>"
-      sent_by_you: "Sent by <a href='{{userUrl}}'>you</a>"
-    directory:
-      filter_name: "فیلتر بر اساس نام کاربری"
-      title: "کاربران"
-      likes_given: "داده"
-      likes_received: "رسید"
-      topics_entered: "وارد شده"
-      topics_entered_long: "موضوعات وارد شده"
-      time_read: "زمان خوانده‌شده"
-      topic_count: "موضوعات"
-      topic_count_long: "موضوعات ساخته شده"
-      post_count: "پاسخ ها"
-      post_count_long: "پاسخ داده شده ها"
-      no_results: "نتیجه ای یافت نشد."
-      days_visited: "بازدید ها"
-      days_visited_long: "بازدید روزانه"
-      posts_read: "خواندن"
-      posts_read_long: "خواندن نوشته ها"
-      total_rows:
-        other: "%{count} کاربران"
-    groups:
-      visible: "همهٔ کاربران گروه را می‌بینند"
-      title:
-        other: "گروه‌ها"
-      members: "اعضا"
-      posts: "نوشته ها"
-      alias_levels:
-        title: "چه کسی می تواند این گروه به عنوان یک نام مستعار استفاده کند؟"
-        nobody: "هیچ‌کس"
-        only_admins: "تنها مدیران"
-        mods_and_admins: "تنها مدیران کل و مدیران"
-        members_mods_and_admins: "تنها کاربران گروه، مدیران ومدیران کل"
-        everyone: "هرکس"
-    user_action_groups:
-      '1': "پسندهای اعطایی"
-      '2': "پسندهای دریافتی"
-      '3': "نشانک‌ها"
-      '4': "موضوعات"
-      '5': "پاسخ ها"
-      '6': "واکنش"
-      '7': "اشاره‌ها"
-      '9': "نقل‌قول‌ها"
-      '10': "ستاره‌دار"
-      '11': "ویرایش‌ها"
-      '12': "فرستاده‌ها"
-      '13': "صندوق دریافت"
-    categories:
-      all: "همهٔ دسته‌بندی ها"
-      all_subcategories: "همه"
-      no_subcategory: "هیچی"
-      category: "دسته بندی"
-      posts: "نوشته ها"
-      topics: "موضوعات"
-      latest: "آخرین"
-      latest_by: "آخرین توسط"
-      toggle_ordering: "ضامن کنترل مرتب سازی"
-      subcategories: "زیر دسته‌ بندی ها"
-      topic_stats: "شمار موضوعات تازه."
-      topic_stat_sentence:
-        other: "%{count} موضوعات تازه در %{unit} گذشته."
-      post_stats: "شمار نوشته های تازه."
-      post_stat_sentence:
-        other: "%{count} نوشته تازه در %{unit} گذشته."
-    ip_lookup:
-      title: جستجوی نشانی IP
-      hostname: نام میزبان
-      location: موقعیت
-      location_not_found: (ناشناس)
-      organisation: سزمان
-      phone: تلفن
-      other_accounts: "سایر حساب های کاربری با این ای پی ."
-      delete_other_accounts: "حذف %{count}"
-      username: "نام کاربری"
-      trust_level: "TL"
-      read_time: "زمان خواندن"
-      topics_entered: "موضوعات وارد شده"
-      post_count: "# نوشته ها"
-      confirm_delete_other_accounts: "آیا مطمئن هستید که می خواهید این حساب کاربری را حذف نمایید؟"
-    user:
-      said: "{{username}}:"
-      profile: "نمایه"
-      mute: "بی صدا"
-      edit: "ویرایش تنظیمات"
-      download_archive: "بار گیری نوشته های من ."
-      new_private_message: "پیام های جدید"
-      private_message: "پیام"
-      private_messages: "پیام‌ها"
-      activity_stream: "فعالیت"
-      preferences: "تنظیمات"
-      bookmarks: "نشانک‌ها"
-      bio: "درباره من"
-      invited_by: "فراخوان از سوی"
-      trust_level: "سطح اعتماد"
-      notifications: "آگاه‌سازی‌ها"
-      dismiss_notifications: "علامت گذاری همه به عنوان خوانده شده"
-      dismiss_notifications_tooltip: "علامت گذاری همه اطلاعیه های خوانده نشده به عنوان خوانده شده"
-      disable_jump_reply: "بعد از پاسخ من به پست من پرش نکن"
-      dynamic_favicon: "آگاه‌سازی پیام‌های آمده را در favicon نمایش بده (آزمایشی)"
-      edit_history_public: "اجازه بده کاربران دیگر اصلاحات نوشته مرا ببینند"
-      external_links_in_new_tab: "همهٔ پیوندهای برون‌رو را در یک تب جدید باز کن"
-      enable_quoting: "فعال کردن نقل قول گرفتن از متن انتخاب شده"
-      change: "تغییر"
-      moderator: "{{user}} یک مدیر است"
-      admin: "{{user}} یک مدیر کل است"
-      moderator_tooltip: "این کاربر یک مدیر است"
-      admin_tooltip: "این کاربر یک مدیر است"
-      suspended_notice: "این کاربر تا {{date}} در وضعیت معلق است."
-      suspended_reason: "در جابه‌جایی نوشته‌ها به موضوع خطایی روی داد."
-      github_profile: "گیت هاب"
-      mailing_list_mode: "برای هر نوشته جدید، رایانامه‌ای برای من بفرست (مگر اینکه من موضوع یا دسته‌بندی را ساکت کنم)"
-      watched_categories: "تماشا"
-      watched_categories_instructions: "شما همهٔ‌ موضوعات تازه در این دسته‌بندی ها را خودکار خواهید دید. از همهٔ نوشته ها و موضوعات تازه آگاه خواهید شد، هم‌چنین شمار نوشته های تازه و نخوانده پس از فهرست موضوع نشان داده می‌شود."
-      tracked_categories: "پی‌گیری"
-      tracked_categories_instructions: "شما همهٔ‌ موضوعات تازه در این دسته‌ بندی ها را به صورت خودکار دنبال خواهید کرد. تعداد نوشته‌های تازه و خوانده نشده بعد از موضوع نشان داده خواهد شد."
-      muted_categories: "ساکت"
-      muted_categories_instructions: "از هر آن‌چه درباره موضوعات تازه در این دسته‌ بندی ها روی دهد، شما آگاه نخواهید شد و در تب نخواندهٔ‌ شما نمایش داده نمی‌شوند."
-      delete_account: "حساب من را پاک کن"
-      delete_account_confirm: "آیا مطمئنید که می‌خواهید شناسه‌تان را برای همیشه پاک کنید؟ برگشتی در کار نیست!"
-      deleted_yourself: "حساب‌ کاربری شما با موفقیت حذف شد."
-      delete_yourself_not_allowed: "در حال حاضر شما نمی‌توانید حساب کاربری خود را حذف کنید. به این منظور  با یکی از مدیران تماس بگیرید."
-      unread_message_count: "پیام‌ها"
-      admin_delete: "پاک کردن"
-      users: "کاربران"
-      muted_users: "بی صدا شده"
-      muted_users_instructions: "توقیف تمام اطلاعیه های این کاربران."
-      staff_counters:
-        flags_given: "پرچم گذاری های مفید"
-        flagged_posts: "نوشته های پرچم گذاری شده"
-        deleted_posts: "پست های حذف شده"
-        suspensions: "تعلیق کردن"
-        warnings_received: "هشدار ها"
-      messages:
-        all: "همه"
-        mine: "خودم"
-        unread: "خوانده‌ نشده‌"
-      change_password:
-        success: "(رایانامه فرستاده شد)"
-        in_progress: "(در حال فرستادن رایانامه)"
-        error: "(خطا)"
-        action: "ارسال کلمه عبور به ایمیل"
-        set_password: "تغییر کلمه عبور"
-      change_about:
-        title: "تغییر «دربارهٔ من»"
-      change_username:
-        title: "تغییر نام کاربری"
-        confirm: "اگر نام کاربری خود را تغییر دهید، همهٔ نقل‌قول‌های پیشین از نوشته‌های شما و اشاره‌های @name از کار می‌افتند. آیا برای انجام این کار اطمینان کامل دارید؟"
-        taken: "متأسفیم، آن نام کاربری گرفته شده است."
-        error: "در فرآیند تغییر نام کاربری شما خطایی روی داد."
-        invalid: "آن نام کاربری نامعتبر است. تنها باید عددها و حرف‌ها را در بر بگیرد."
-      change_email:
-        title: "تغییر رایانامه"
-        taken: "متأسفیم، آن رایانامه در دسترس نیست."
-        error: "در تغییر رایانامه‌تان خطایی روی داد. شاید آن نشانی از پیش در حال استفاده است؟"
-        success: "ما رایانامه‌ای به آن نشانی فرستاده‌ایم. لطفاً دستورکار تأیید را در آن دنبال کنید."
-      change_avatar:
-        title: "عکس نمایه خود را تغییر دهید"
-        gravatar: "<a href='//gravatar.com/emails' target='_blank'>گراواتا</a>, بر اساس"
-        refresh_gravatar_title: "تازه‌سازی گراواتارتان"
-        letter_based: "سیستم تصویر پرفایل را اختصاص داده است"
-        uploaded_avatar: "تصویر شخصی"
-        uploaded_avatar_empty: "افزودن تصویر شخصی"
-        upload_title: "تصویرتان را بار بگذارید"
-        upload_picture: "بارگذاری تصویر"
-        image_is_not_a_square: "اخطار : ما تصویر شما بریدیم;طول و عرض برابر نبود"
-      change_profile_background:
-        title: "پس‌زمینه نمایه"
-        instructions: "تصاویر پس‌زمینه نمایه‌ها در مرکز قرار میگیرند و به صورت پیش‌فرض طول 850px دارند."
-      change_card_background:
-        title: "پس زمینه کارت کابر"
-        instructions: "تصاویر پس زمینه در مرکز قرار خواهند گرفت و عرض  پیشفرض آن 590 پیکسل است"
-      email:
-        title: "رایانامه"
-        instructions: "هرگز بصورت عمومی نشان نده"
-        ok: "رایانامه‌ی تایید را برایتان می‌فرستیم"
-        invalid: "لطفا یک آدرس رایانامه معتبر وارد کنید"
-        authenticated: "ایمیل شما تصدیق شد توسط {{provider}}"
-        frequency:
-          zero: "ما برای شما سریعا ایمیلی می فرستیم در صورتی که چیزهای فرستاده شده در ایمیل را نخوانده باشید"
-          one: "ما در صورتی به شما ایمیل می زنیم که شما را تا آخرین لحظه ندیده باشیم"
-          other: "ما در صورتی به شما ایمیل می زنیم که شما را تا دقیقه {{count}}  ندیده باشیم "
-      name:
-        title: "نام"
-        instructions: "نام کامل (اختیاری)"
-        instructions_required: "نام کامل شما"
-        too_short: "نام انتخابی شما خیلی کوتاه است"
-        ok: "نام انتخابی شما به نطر می رسد خوب است"
-      username:
-        title: "نام کاربری"
-        instructions: "منحصر به فرد،بدون فاصله،کوتاه"
-        short_instructions: "می توانید به کاربران دیگر اشاره کنید با@{{username}}"
-        available: "نام کاربری انتخابی برای شما در دسترس است"
-        global_match: "ایمیل منطبق نام کاربری ثبت شد."
-        global_mismatch: "از پیش ثبت شده. {{suggestion}} چطور است؟"
-        not_available: "فراهم نیست. {{suggestion}} چطور است؟"
-        too_short: "نام کاربری انتخابی شما خیلی کوتاه است"
-        too_long: "نام کاربری انتخابی شما بسیار بلند است"
-        checking: "بررسی فراهمی نام‌کاربری..."
-        enter_email: 'نام کاربری پیدا شد; ایمیل منطبق را وارد کن'
-        prefilled: "ایمیل منطبق لت با این نام کاربری ثبت شده "
-      locale:
-        title: "زبان رابط کاربر"
-        instructions: "زبان رابط کاربری. با تازه کردن صفحه تغییر خواهد کرد."
-        default: "(پیش‌فرض)"
-      password_confirmation:
-        title: "رمز عبور را مجدد وارد نمایید"
-      last_posted: "آخرین نوشته"
-      last_emailed: "آخرین ایمیل فرستاده شده"
-      last_seen: "مشاهده"
-      created: "ملحق شده در"
-      log_out: "خروج"
-      location: "موقعیت"
-      card_badge:
-        title: "کارت مدال کاربر"
-      website: "تارنما"
-      email_settings: "رایانامه"
-      email_digests:
-        title: "هنگامی که به سایت سر نمی‌زنم، گزارش کوتاهی از رویدادهای تازه را برایم ایمیل کن:"
-        daily: "روزانه"
-        every_three_days: "هر سه روز"
-        weekly: "هفتگی"
-        every_two_weeks: "هر دو هفته "
-      email_direct: "به من ایمیل ارسال کن هنگامی که کسی از من نقل قول کرد،با نوشته های من پاسخ داد،یا به من اشاره کرد @username کاربری یا مرا به موضوعی دعوت کردند."
-      email_private_messages: "به من ایمیل ارسال کن وقتی کسی به من پیام خصوصی فرستاد"
-      email_always: "برای من ایمیل آگاه سازی نفرست هنگامی که در سایت فعال هستم"
-      other_settings: "موارد دیگر"
-      categories_settings: "دسته‌بندی ها"
-      new_topic_duration:
-        label: "موضوعات را جدید در نظر بگیر وقتی که"
-        not_viewed: "من هنوز آن ها را ندیدم"
-        last_here: "آخرین باری که اینجا بودم ساخته شده‌اند"
-        after_n_days:
-          other: " در {{count}} روز گذشته ساخته شده‌"
-        after_n_weeks:
-          other: "در {{count}} هفته گذشته ساخته شده‌"
-      auto_track_topics: "دنبال کردن خودکار موضوعاتی که وارد می‌شوم"
-      auto_track_options:
-        never: "هرگز"
-        always: "همیشه"
-        after_n_seconds:
-          other: "پس از {{count}} ثانیه"
-        after_n_minutes:
-          other: "پس از {{count}} دقیقه"
-      invited:
-        search: "بنویسید تا فراخوانه‌ها را جستجو کنید..."
-        title: "فراخوانه‌ها"
-        user: "کاربر فراخوانده شده"
-        none: "هنوز هیچ‌کسی را به اینجا فرانخوانده‌اید"
-        truncated: "نمایش {{count}} فراخوانهٔ نخست"
-        redeemed: "آزاد سازی دعوتنامه"
-        redeemed_at: "آزاد سازی"
-        pending: "فراخوانه‌های بی‌پاسخ"
-        topics_entered: "موضوعات بازدید شد"
-        posts_read_count: "خواندن نوشته ها"
-        expired: "این دعوت منقضی شده است."
-        rescind: "پاک کردن"
-        rescinded: "فراخوانه پاک شد"
-        reinvite: "آخرین دعوت ها"
-        reinvited: "دوباره فرستاده دعوت"
-        time_read: "زمان خواندن"
-        days_visited: "روز های بازدید"
-        account_age_days: "عمر حساب بر اساس روز"
-        create: "فرستادن یک فراخوانه"
-        bulk_invite:
-          none: "شما هنوز کسی را اینجا دعوت نکرده اید. می توانید بصورت تکی یا گروهی یکجا دعوتنامه را بفرستید از طریق  <a href='http://discours.ir'>بارگذار فراخوانه فله ای </a>."
-          text: "دعوت گروهی از طریق فایل"
-          uploading: "در حال بار گذاری ..."
-          success: "فایل با موفقیت بارگذاری شد٬  وقتی که پروسس تمام شد  به شما را از طریق پیام اطلاع می دهیم. "
-          error: "در بارگذاری «{{filename}}» خطایی روی داد: {{message}}"
-      password:
-        title: "گذرواژه"
-        too_short: "گذرواژه‌تان خیلی کوتاه است"
-        common: "گذرواژهٔ خیلی ساده‌ای است"
-        same_as_username: "رمز عبورتان با نام کاربری شما برابر است."
-        same_as_email: "رمز عبورتان با ایمیل شما برابر است. "
-        ok: "گذرواژهٔ خوبی است."
-        instructions: "در آخرین %{count} کاراکتر"
-      associated_accounts: "ورود ها"
-      ip_address:
-        title: "آخرین نشانی IP"
-      registration_ip_address:
-        title: "نشانی IP ثبت‌نامی"
-      avatar:
-        title: "عکس نمایه"
-      title:
-        title: "سرنویس"
-      filters:
-        all: "همه"
-      stream:
-        posted_by: "فرستنده:"
-        sent_by: "فرستنده:"
-        private_message: "پیام"
-        the_topic: "موضوع"
-    loading: "بارگذاری"
+  dates:
+    short_date_no_year: "D MMM"
+    short_date: "D MMM, YYYY"
+    long_date: "MMMM D, YYYY h:mma"
+  title: "گفتمان"
+  topics: "موضوعات"
+  posts: "نوشته ها"
+  loading: "بارگذاری..."
+  powered_by_html: 'قدرت گرفته از<a href="http://www.discourse.org">دیسکورس</a>فارسی سازی<a href="http://discours.ir/t/1-0/33"> دیسکورس فارسی</a>, برای نمایش بهتر جاوا اسکریپت را فعال کنید.'
+  log_in: "ورود"
+  via: "%{username} از %{site_name}"
+  is_reserved: "محفوظ است"
+  errors:
+    format: '%{attribute} %{message}'
+    messages:
+      invalid_boolean: "اعشار نامعتبر است."
+      taken: "انتخاب شده است"
+      accepted: باید تایید شده باشد
+      blank: نباید خالی باشد
+      present: باید خالی باشد
+      confirmation: "همانند %{attribute} وجود ندارد"
+      empty: نمی تواند خالی باشد
+      equal_to: باید برابر %{count} باشد
+      even: باید زوج باشد
+      exclusion: محفوظ است
+      greater_than: باید بیشتر از %{count} باشد
+      greater_than_or_equal_to: باید بیشتر و یا مساوی %{count} باشد
+      inclusion: در لیست وجود ندارد
+      invalid: صحیح نیست
+      less_than: باید کمتر از %{count} باشد
+      less_than_or_equal_to: باید کمتر و یا مساوی %{count} باشد
+      not_a_number: یک عدد نمی باشد
+      not_an_integer: باید یک عدد صحیح باشد
+      odd: باید یک عدد فرد باشد
+      record_invalid: 'عملیات با خطا مواجه شد : %{errors}'
+      other_than: "باید غیر از {count}% باشد"
+    template:
+      body: 'مشکلاتی با زمینه های دنبال شده وجود دارد:'
+    embed:
+      load_from_remote: "خطایی در بارگذاری آن پست رخ داده است."
+  bulk_invite:
+    file_should_be_csv: "قالب پرونده‌ی بارگذاری شده باید csv و یا txt باشد."
+  backup:
+    backup_file_should_be_tar_gz: "پرونده‌ی پشتیبان باید یک فایل فشرده با پسوند tar.gz. باشد."
+    not_enough_space_on_disk: "فضای کافی برای بارگذاری این پشتیبان وجود ندارد."
+  not_logged_in: "برای اینکار شما باید وارد شوید."
+  not_found: "URL یا منبع درخواست شده یافت نشد."
+  invalid_access: "شما اجازه مشاهده منبع درخواست شده را ندارید."
+  read_only_mode_enabled: "سایت در حالت فقط خواندنی است. تداخلات غیرفعال هستند."
+  too_many_replies:
+    other: "متأسفیم، ولی کاربران جدید موقتا محدود به {count}% پاسخ در برخی از تاپیک ها هستند."
+  embed:
+    start_discussion: "مبحث جدید"
+    continue: "ادامه این بحث"
+    more_replies:
+      other: "%{count} پاسخ دیگر"
+    loading: "بارگزاری مبحث ..."
+    permalink: " پیوند یکتا"
+    in_reply_to: "▶ %{username}"
+    replies:
+      other: "%{count} پاسخ"
+  too_many_mentions:
+    zero: "متأسفیم، شما نمی‌توانید به کاربران دیگر اشاره کنید."
+    one: "متأسفیم، شما در هر دیدگاه تنها می‌توانید به یک کاربر اشاره کنید."
+    other: "متأسفیم، شما در هر دیدگاه تنها می‌توانید به %{count} کاربر اشاره کنید."
+  too_many_mentions_newuser:
+    zero: "متأسفیم، کاربران تازه نمی‌توانند به کاربران دیگر اشاره کنند."
+    one: "متأسفیم، کاربران تازه در هر دیدگاه تنها می‌توانید به یک کاربر دیگر اشاره کنند."
+    other: "متأسفیم، کاربران تازه در هر دیدگاه تنها می‌توانید به %{count} کاربر دیگر اشاره کنند."
+  too_many_images:
+    zero: "متأسفیم، کاربران تازه نمی‌توانند در دیدگاه‌ها تصویر بگذارند."
+    one: "متأسفیم، کاربران تازه تنها می‌توانند یک تصویر در هر دیدگاه بگذارند"
+    other: "متأسفیم، کاربران تازه تنها می‌توانند %{count} تصویر در هر دیدگاه بگذارند"
+  too_many_attachments:
+    zero: "متأسفیم، کاربران تازه امکان اضافه کردن فایل به ارسال هایشان را ندارند."
+    one: "متأسفیم ، کاربران تازه فقط امکان اتصال تنها یک فایل به ارسال هایشان را دارند."
+    other: "متأسفیم ، کاربران تازه تنها اجازه اتصال %{count} فایل به ارسالی شان را دارند."
+  too_many_links:
+    zero: "متأسفیم، کاربران تازه نمی‌توانند در دیدگاه‌ها پیوند بگذارند."
+    one: "متأسفیم، کاربران تازه تنها می‌توانند در هر دیدگاه یک پیوند بگذارند."
+    other: "متأسفیم، کاربران تازه تنها می‌توانند در هر دیدگاه %{count} پیوند بگذارند."
+  spamming_host: "متأسفانه شما نمی‌توانید پیوندی با آن نشانی را بفرستید."
+  just_posted_that: "به آن‌چه که به‌تازگی فرستادید بسیار نزدیک است"
+  has_already_been_used: "پیش‌تر استفاده شده است"
+  invalid_characters: "نویسه‌های نامعتبر در بر دارد."
+  is_invalid: "نامعتبر است. تلاش کنید که کمی بیش‌ترتوضیح بگذارید."
+  next_page: "صفحه بعد ←"
+  prev_page: "→ صفحه قبل"
+  page_num: "صفحه %{num}"
+  topics_in_category: "جستارهای دستهٔ‌ «%{category}»"
+  rss_posts_in_topic: "خوراک «%{topic}»"
+  rss_topics_in_category: "خوارک جستارهای دستهٔ «%{category}»"
+  author_wrote: "%{author} نوشت:"
+  num_posts: "ارسال ها:"
+  num_participants: "اشتراک در :"
+  read_full_topic: "مشاهده متن کامل"
+  private_message_abbrev: "پیام"
+  rss_description:
+    latest: "آخرین ارسال ها"
+    hot: "جستارهای داغ"
+  too_late_to_edit: "ارسالی مورد نظر مربوط به زمان بسیار گذشته می باشد. امکان ویرایش و حذف آن وجود ندارد."
+  excerpt_image: "تصویر"
+  groups:
     errors:
-      prev_page: "هنگام تلاش برای بارگزاری"
-      reasons:
-        network: "خطای شبکه"
-        server: "خطای سرور"
-        forbidden: "دسترسی قطع شده است"
-        unknown: "خطا"
-      desc:
-        network: "ارتباط اینترنتی‌تان را بررسی کنید."
-        network_fixed: "به نظر می رسد اون برگشت."
-        server: "کد خطا : {{status}}"
-        forbidden: "شما اجازه دیدن آن را ندارید."
-        unknown: "اشتباهی روی داد."
-      buttons:
-        back: "برگشت"
-        again: "تلاش دوباره"
-        fixed: "بارگذاری برگه"
-    close: "بستن"
-    assets_changed_confirm: "به نظر می رسد به روز رانی شده است،بارگزاری مجدد برای آخرین نسخه ؟"
-    logout: "شما از سایت خارج شده اید"
-    refresh: "تازه کردن"
-    read_only_mode:
-      enabled: "مدیر حالت فقط برای خواندن را فعال کرده.  می توانید به جستجو در وب سایت ادامه دهید ولی ممکن است تعاملات کار نکند."
-      login_disabled: "ورود به سیستم غیر فعال شده همزمان با اینکه سایت در حال فقط خواندنی است."
-    too_few_topics_notice: " 5 موضوع عمومی و  %{posts} نوشته عمومی ایجاد کنید،تا گفتگو آغاز شود. و کاربران جدید میزان اعتماد را بدست بیاورند و محتوایی برای خواندن موجود باشد. این پیغام فقط به مدیران نشان داده می شود"
-    learn_more: "بیشتر بدانید..."
-    year: 'سال'
-    year_desc: 'موضوعاتی که در 365 روز گذشته باز شده‌اند'
-    month: 'ماه'
-    month_desc: 'موضوعاتی که در 30 روز گذشته باز شده‌اند'
-    week: 'هفته'
-    week_desc: 'موضوعاتی که در 7 روز گذشته باز شده‌اند'
-    day: 'روز'
-    first_post: نوشته نخست
-    mute: بی صدا
-    unmute: صدادار
-    last_post: آخرین نوشته
-    last_post_lowercase: آخرین نوشته
-    summary:
-      enabled_description: "شما خلاصه ای از این موضوع را می بینید:  بالاترین‌ نوشته های  انتخاب شده توسط انجمن."
-      description: "<b>{{count}}</b> پاسخ"
-      description_time: "وجود دارد <b>{{count}}</b> پاسخ ها برا اساس زمان خواندن<b>{{readingTime}} دقیقه</b>."
-      enable: 'خلاصه این موضوع'
-      disable: 'نمایش همه نوشته‌ها'
-    deleted_filter:
-      enabled_description: "محتویات این موضوع باعث حذف نوشته شده٬ که پنهان شده است."
-      disabled_description: "پست های حذف شده در موضوع نشان داده است"
-      enable: "مخفی کردن نوشته های حذف شده"
-      disable: "نشان دادن نوشته های حذف شده"
-    private_message_info:
-      title: "پیام"
-      invite: "فراخواندن دیگران..."
-      remove_allowed_user: "آیا واقعا می خواهید اسم {{name}} از پیام برداشته شود ؟ "
-    email: 'رایانامه'
-    username: 'نام کاربری'
-    last_seen: 'مشاهده'
-    created: 'ساخته شد'
-    created_lowercase: 'ساخته شد'
-    trust_level: 'سطح اعتماد'
-    search_hint: 'نام کاربری ، ایمیل یا ای پی '
-    create_account:
-      title: "ساختن شناسهٔ تازه"
-      failed: "اشتباهی روی داده، شاید این نام کاربری پیش‌تر استفاده شده؛ پیوند فراموشی گذرواژه می‌تواند کمک کند."
-    forgot_password:
-      title: "باز یابی کلمه عبور"
-      action: "گذرواژه‌ام را فراموش کرده‌ام"
-      invite: "نام‌کاربری و نشانی رایانامهٔ خود را بنویسید و ما رایانامهٔ بازیابی گذرواژه را برایتان می‌فرستیم."
-      reset: "باز یابی رمز عبور"
-      complete_username: "اگر حساب کاربری مشابه نام کاربری  <b>%{username}</b> ,است،شما باید با استفاده از ایمیل رمز عبور حساب کاربری خود را مجدد تنظیم نمایید."
-      complete_email: "اگر حساب کاربری مشابه ایمیل <b>%{email}</b>, است،شما باید با استفاده از ایمیل رمز عبور حساب کاربری خود را مجدد تنظیم نمایید."
-      complete_username_found: "ما حساب کاربری مشابه نام کاربری   <b>%{username}</b>,پیدا کردیم،شما باید با استفاده از ایمیل رمز عبور حساب کاربری خود را مجدد تنظیم نمایید."
-      complete_email_found: "ما حساب کاربری مشابه با ایمیل  <b>%{email}</b>, پیدا کردیم،شما باید با استفاده از ایمیل رمز عبور حساب کاربری خود را مجدد تنظیم نمایید."
-      complete_username_not_found: "هیچ حساب کاربری مشابه نام کاربری <b>%{username}</b> وجود ندارد"
-      complete_email_not_found: "هیچ حساب کاربری مشابه با <b>%{email}</b> وجود ندارد"
-    login:
-      title: "ورود"
-      username: "کاربر"
-      password: "گذرواژه"
-      email_placeholder: "نشانی رایانامه یا نام کاربری"
-      caps_lock_warning: "Caps Lock روشن است"
-      error: "خطای ناشناخته"
-      blank_username_or_password: "لطفا نام کاربری یا ایمیل خود ، با پسورد وارد نمایید."
-      reset_password: 'نوسازی گذرواژه'
-      logging_in: "درون آمدن..."
-      or: "یا"
-      authenticating: "اعتبارسنجی..."
-      awaiting_confirmation: "شناسهٔ‌کاربری‌تان چشم به راه فعال‌سازی است، پیوند فراموشی گذرواژه را برای دریافت یک رایانامهٔ‌فعال‌سازی دیگر باز کنید."
-      awaiting_approval: "هنوز کارمندی شناسهٔ‌شما را تأیید نکرده است. پس از تأیید، یک رایانامه دریافت خواهید کرد."
-      requires_invite: "متأسفیم، دسترسی به این انجمن تنها با فراخوانه امکان دارد."
-      not_activated: "هنوز نمی‌توانید به درون بیایید. پیش‌تر یک رایانامهٔ فعال‌سازی برایتان به نشانی <b>{{sentTo}}</b> فرستادیم. لطفاً دستور کار آن رایانامه را برای فعال‌سازی شناسه‌تان دنبال کنید."
-      not_allowed_from_ip_address: "شما نمی توانید با این اپی ادرس وارد شوید."
-      admin_not_allowed_from_ip_address: "شما نمی تواند با این اپی آدرس وارد کنترل  پنل ادمین شوید."
-      resend_activation_email: "برای فرستادن دوبارهٔ رایانامهٔ‌فعال‌سازی، اینجا را بفشارید."
-      sent_activation_email_again: "رایانامهٔ‌فعال‌سازی دیگری را برایتان به نشانی <b>{{currentEmail}}</b> فرستادیم. چند دقیقه‌ای طول می‌:شد تا برسد. مطمئن شوید که پوشهٔ هرزنامه را بررسی می‌کنید."
-      google:
-        title: "با Google"
-        message: "اعتبارسنجی با گوگل (مطمئن شوید که بازدارنده‌های pop up فعال نباشند)"
-      google_oauth2:
-        title: "با گوگل"
-        message: "اهراز هویت با گوگل (لطفا برسی کنید پاپ بلوکر فعال نباشد)"
-      twitter:
-        title: "با Twitter"
-        message: "اعتبارسنجی با توئیتر (مطمئن شوید که بازدارنده‌های pop up فعال نباشند)"
-      facebook:
-        title: "با Facebook"
-        message: "اعتبارسنجی با فیسبوک (مطمئن شوید که بازدارنده‌های pop up فعال نباشند)"
-      yahoo:
-        title: "با یاهو"
-        message: "اعتبارسنجی با یاهو (مطمئن شوید که بازدارنده‌های pop up فعال نباشند)"
-      github:
-        title: "با GitHub"
-        message: "اعتبارسنجی با گیت‌هاب (مطمئن شوید که بازدارنده‌های pop up فعال نباشند)"
-    apple_international: "اپل / بین المللی"
-    google: "گوگل"
-    twitter: "تویتر"
-    emoji_one: "یک شکلک"
-    composer:
-      emoji: "شکلک :smile:"
-      add_warning: "این یک هشدار رسمی است."
-      posting_not_on_topic: "به کدام موضوع می‌خواهید پاسخ دهید؟"
-      saving_draft_tip: "در حال ذخیره سازی ..."
-      saved_draft_tip: "اندوخته شد"
-      saved_local_draft_tip: "ذخیره سازی به صورت محلی"
-      similar_topics: "موضوع شما شبیه است به..."
-      drafts_offline: "پیش نویس آنلاین"
-      error:
-        title_missing: "سرنویس الزامی است"
-        title_too_short: "سرنویس دست‌کم باید {{min}} نویسه باشد"
-        title_too_long: "سرنویس نمی‌تواند بیش‌تر از {{max}} نویسه باشد"
-        post_missing: "نوشته نمی‌تواند تهی باشد"
-        post_length: "نوشته باید دست‌کم {{min}} نویسه داشته باشد"
-        category_missing: "باید یک دسته برگزینید"
-      save_edit: "ذخیره سازی ویرایش"
-      reply_original: "پاسخ دادن در موضوع اصلی"
-      reply_here: "پاسخ‌دادن همین‌جا"
-      reply: "پاسخ"
-      cancel: "لغو کردن"
-      create_topic: "ایجاد موضوع"
-      create_pm: "پیام"
-      title: "یا Ctrl+Enter را بفشارید"
-      users_placeholder: "افزودن یک کاربر"
-      title_placeholder: "در یک جملهٔ‌ کوتاه، این موضوع در چه موردی است؟"
-      edit_reason_placeholder: "چرا ویرایش می‌کنید؟"
-      show_edit_reason: "(افزودن دلیل ویرایش)"
-      reply_placeholder: "اینجا بنویسید. برای آرایش از Markdown یا BBCode استفاده کنید. برای باگذاری تصویر، آن را به اینجا بکشید یا بچسبانید."
-      view_new_post: "نوشته تازه‌تان را ببینید."
-      saving: "در حال ذخیره سازی..."
-      saved: "اندوخته شد!"
-      saved_draft: "در حال حاضر پیشنویس وجود دارد . برای از سر گیری انتخاب نمایید."
-      uploading: "بارگذاری..."
-      show_preview: 'نشان دادن پیش‌نمایش &laquo;'
-      hide_preview: '&raquo; پنهان کردن پیش‌نمایش'
-      quote_post_title: "نقل‌قول همهٔ‌ نوشته"
-      bold_title: "زخیم"
-      bold_text: "تکست زخیم"
-      italic_title: "تاکید"
-      italic_text: "متن تاکید شده"
-      link_title: "لینک ارتباط دار"
-      link_description: "توضیحات لینک را اینجا وارد کنید."
-      link_dialog_title: "لینک را درج کنید"
-      link_optional_text: "سرنویس اختیاری"
-      quote_title: "نقل قول"
-      quote_text: "نقل قول"
-      code_title: "نوشته تنظیم نشده"
-      code_text: "متن تورفتگی تنظیم نشده توسط 4 فضا خالی"
-      upload_title: "بارگذاری"
-      upload_description: "توضیح بارگذاری را در اینجا بنویسید"
-      olist_title: "لیست شماره گذاری شد"
-      ulist_title: "لیست بولت"
-      list_item: "فهرست موارد"
-      heading_title: "عنوان"
-      heading_text: "عنوان"
-      hr_title: "خط کش افقی"
-      undo_title: "برگردانی"
-      redo_title: "دوباره‌گردانی"
-      help: "راهنمای ویرایش با Markdown"
-      toggler: "مخفی یا نشان دادن پنل نوشتن"
-      admin_options_title: "تنظیمات اختیاری مدیران برای این موضوع"
-      auto_close:
-        label: "بستن خودکار موضوع در زمان :"
-        error: "لطفا یک مقدار معتبر وارد نمایید."
-        based_on_last_post: "آیا تا آخرین نوشته یک موضوع بسته نشده در این قدیمی است."
-        all:
-          examples: 'عدد ساعت را وارد نمایید (24)،زمان کامل (17:30) یا برچسب زمان (2013-11-22 14:00).'
-        limited:
-          units: "(# از ساعت ها)"
-          examples: 'لطفا عدد ساعت را وارد نمایید (24).'
-    notifications:
-      title: "اطلاع رسانی با اشاره به @name ،پاسخ ها به نوشته ها و موضوعات شما،پیام ها ، و ..."
-      none: "قادر به بار گذاری آگاه سازی ها در این زمان نیستیم."
-      more: "دیدن آگاه‌سازی‌های پیشن"
-      total_flagged: "همهٔ نوشته‌های پرچم خورده"
-      mentioned: "<i title='mentioned' class='fa fa-at'></i><p><span>{{username}}</span> {{description}}</p>"
-      quoted: "<i title='quoted' class='fa fa-quote-right'></i><p><span>{{username}}</span> {{description}}</p>"
-      replied: "<i title='replied' class='fa fa-reply'></i><p><span>{{username}}</span> {{description}}</p>"
-      posted: "<i title='replied' class='fa fa-reply'></i><p><span>{{username}}</span> {{description}}</p>"
-      edited: "<i title='edited' class='fa fa-pencil'></i><p><span>{{username}}</span> {{description}}</p>"
-      liked: "<i title='liked' class='fa fa-heart'></i><p><span>{{username}}</span> {{description}}</p>"
-      private_message: "<i title='private message' class='fa fa-envelope-o'></i><p><span>{{username}}</span> {{description}}</p>"
-      invited_to_private_message: "<i title='private message' class='fa fa-envelope-o'></i><p><span>{{username}}</span> {{description}}</p>"
-      invited_to_topic: "<i title='invited to topic' class='fa fa-hand-o-right'></i><p><span>{{username}}</span> {{description}}</p>"
-      invitee_accepted: "<i title='accepted your invitation' class='fa fa-user'></i><p><span>{{username}}</span> accepted your invitation</p>"
-      moved_post: "<i title='moved post' class='fa fa-sign-out'></i><p><span>{{username}}</span> moved {{description}}</p>"
-      linked: "<i title='linked post' class='fa fa-arrow-left'></i><p><span>{{username}}</span> {{description}}</p>"
-      granted_badge: "<i title='badge granted' class='fa fa-certificate'></i><p>Earned '{{description}}'</p>"
-    upload_selector:
-      title: "افزودن یک تصویر"
-      title_with_attachments: "افزودن یک تصویر یا پرونده"
-      from_my_computer: "از دستگاه من"
-      from_the_web: "از وب"
-      remote_tip: "لینک به تصویر"
-      remote_tip_with_attachments: "لطفا لینک تصویر یا فایل ({{authorized_extensions}})"
-      local_tip: "بفشارید تا تصویری را از روی دستگاه خود برگزینید"
-      local_tip_with_attachments: "برای انتخاب یک تصویر یا فایل از دستگاه خود کلیک کنید ({{authorized_extensions}})"
-      hint: "(برای آپلود می توانید فایل را کیشده و در ویرایشگر رها کنید)"
-      hint_for_supported_browsers: "(شما همچنین می توانید با کشیدن و رها کردن یا چسباندن تصاویر در ویرایشگر آن ها را بار گذاری نمایید)"
-      uploading: "در حال بروز رسانی "
-      image_link: "به لینک تصویر خود اشاره کنید"
-    search:
-      title: "جستجوی موضوعات، نوشته ها، کاربران یا دسته‌ بندی ها"
-      no_results: "چیزی یافت نشد."
-      searching: "جستجو کردن..."
-      post_format: "#{{post_number}} توسط {{username}}"
-      context:
-        user: "جستجوی نوشته‌های @{{username}}"
-        category: "جستجوی دستهٔ «{{category}}»"
-        topic: "جستجوی این موضوع"
-        private_messages: "جستجوی پیام"
-    site_map: "به فهرست موضوع یا دسته‌ای دیگر بروید"
-    go_back: 'برگردید'
-    not_logged_in_user: 'صفحه کاربر با خلاصه ای از فعالیت های و تنظیمات'
-    current_user: 'به نمایه‌تان بروید'
-    topics:
-      bulk:
-        reset_read: "تنظیم مجدد خوانده شده"
-        delete: "حذف موضوعات"
-        dismiss_posts: "بستن نوشته ها"
-        dismiss_topics: "بستن موضوعات"
-        dismiss_topics_tooltip: "نشان دادن این تاپیک را از لیست خوانده نشده متوقف کن وقتی پست های جدید بوجود آمد"
-        dismiss_new: "بستن جدید"
-        toggle: "ضامن انتخاب یکباره موضوعات"
-        actions: "عملیات یکجا"
-        change_category: "تغییر دسته بندی"
-        close_topics: "بستن موضوعات"
-        archive_topics: "آرشیو موضوعات"
-        notification_level: "تغییر سطح آگاه‌سازی"
-        choose_new_category: "یک دسته بندی جدید برای موضوع انتخاب نمایید"
-        selected:
-          other: "شما تعداد <b>{{count}}</b> موضوع را انتخاب کرده اید."
-      none:
-        unread: "موضوع خوانده نشده‌ای ندارید."
-        new: "شما هیچ موضوع تازه‌ای ندارید"
-        read: "هنوز هیچ موضوعاتی را نخوانده‌اید."
-        posted: "هنوز در هیچ موضوعی  نوشته نگذاشته‌اید."
-        latest: "هیچ موضوع تازه‌ای نیست. چه بد!"
-        hot: "هیچ موضوع داغی نیست."
-        bookmarks: "هنوز هیچ موضوع نشانک‌گذاری شده‌ای ندارید."
-        category: "هیچ موضوعاتی در {{category}} نیست."
-        top: "برترین موضوعی وجود ندارد"
-        search: "دیگر هیچ نتیجه جستجویی وجود ندارد."
-        educate:
-          new: '<p>موضوعات جدید در اینجا قرار می گیرند.</p><p>به طور پیش فرض، موضوعات جدید در نظر گرفته خواهند شد و نشان داده می شوند <span class="badge new-topic badge-notification" style="vertical-align:middle;line-height:inherit;">جدید</span> شاخص اگر آنها در 2 روز گذشته ایجاد شده باشند </p><p>شما می توانید این را برای خود تغییر دهید <a href="%{userPrefsUrl}">تنظیمات</a>.</p>'
-          unread: '<p>موضوعات خوانده نشده شما در اینجا قرار می گیرند.</p><p>به طور پیش فرض، موضوعات خوانده نشده در نظر گرفته خواهند شد و شمارش خوانده نشده ها نشان داده می شود <span class="badge new-posts badge-notification">1</span> اگر شما:</p><ul><li>موضوع ایجاد کرده اید</li><li>به موضوع پاسخ داده اید</li><li>خواندن موضوع  در بیش از 4 دقیقه</li></ul><p>و یا اگر شما به صراحت مجموعه ای از موضوع مورد ردیابی و یا تماشا از طریق کنترل اطلاع رسانی در پایین هر موضوع انتخاب کرده اید.</p><p>شما می توانید این را تغییر دهید. <a href="%{userPrefsUrl}">تنظیمات</a>.</p>'
-      bottom:
-        latest: "موضوع تازهٔ دیگری نیست."
-        hot: "موضوع داغ دیگری نیست."
-        posted: "هیچ موضوعات نوشته شده وجود دارد."
-        read: "موضوع خوانده شدهٔ‌دیگری نیست."
-        new: "موضوع تازهٔ دیگری نیست."
-        unread: "موضوع خوانده نشدهٔ دیگری نیست."
-        category: "هیچ موضوع دیگری در {{category}} نیست."
-        top: "بالاترین‌ موضوعات بیشتری وجود ندارد"
-        bookmarks: "موضوعات نشانک‌گذاری شده‌ی دیگری وجود ندارد."
-        search: "نتیجه جستجوی دیگری وجود ندارد"
-    topic:
-      filter_to: "{{post_count}} نوشته در موضوع "
-      create: 'موضوع جدید'
-      create_long: 'ساختن یک موضوع تازه'
-      private_message: 'شروع یک پیام'
-      list: 'موضوعات'
-      new: 'موضوع تازه'
-      unread: 'خوانده نشده'
-      new_topics:
-        other: '{{count}} موضوعات جدید'
-      unread_topics:
-        other: '{{count}} موضوع خوانده نشده'
-      title: 'موضوع'
-      invalid_access:
-        title: "موضوع خصوصی است"
-        description: "متأسفیم، شما دسترسی به این موضوع ندارید!"
-        login_required: "برای مشاهده‌ی موضوع باید وارد سیستم شوید."
-      server_error:
-        title: "شکست در بارگذاری موضوع"
-        description: "متأسفیم، نتوانستیم موضوع را بار بگذاریم، شاید به دلیل یک مشکل ارتباطی. لطفاً دوباره تلاش کنید. اگر مشکل پابرجا بود، ما را آگاه کنید."
-      not_found:
-        title: "موضوع یافت نشد"
-        description: "متأسفیم، نتوانستیم آن موضوع را بیابیم. شاید کارمندی آن را پاک کرده؟"
-      total_unread_posts:
-        other: "شما تعداد {{count}} نوشته خوانده نشده در این موضوع دارید"
-      unread_posts:
-        other: "شما تعداد {{count}} نوشته خوانده نشده قدیمی در این موضوع دارید"
-      new_posts:
-        other: "تعداد {{count}} نوشته های جدید در این موضوع از آخرین خواندن شما وجود دارد"
-      likes:
-        other: "{{count}} پسند در این موضوع داده شده است"
-      back_to_list: "بازگشت به فهرست موضوع"
-      options: "گزینه‌های موضوع"
-      show_links: "نمایش پیوندهای درون این موضوع"
-      toggle_information: " ضامن جزئیات موضوع"
-      read_more_in_category: "می خواهید بیشتر بخوانید? به موضوعات دیگر را مرور کنید {{catLink}} یا {{latestLink}}."
-      read_more: "می خواهید بیشتر بخوانید? {{catLink}} یا {{latestLink}}."
-      read_more_MF: "There { UNREAD, plural, =0 {} one { is <a href='/unread'>1 unread</a> } other { are <a href='/unread'># unread</a> } } { NEW, plural, =0 {} one { {BOTH, select, true{and } false {is } other{}} <a href='/new'>1 new</a> topic} other { {BOTH, select, true{and } false {are } other{}} <a href='/new'># new</a> topics} } remaining, or {CATEGORY, select, true {browse other topics in {catLink}} false {{latestLink}} other {}}."
-      browse_all_categories: جستوجوی همهٔ دسته‌ها
-      view_latest_topics: مشاهده آخرین موضوع
-      suggest_create_topic: چرا یک موضوع نسازید؟
-      jump_reply_up: رفتن به جدید ترین پاسخ
-      jump_reply_down: رفتن به آخرین پاسخ
-      deleted: "موضوع پاک شده است."
-      auto_close_notice: "این موضوع خودکار بسته خواهد شد %{timeLeft}."
-      auto_close_notice_based_on_last_post: "این نوشته بعد از  %{duration} آخرین پاسخ بشته خواهد شد ."
-      auto_close_title: 'تنضیمات قفل خوکار'
-      auto_close_save: "دخیره"
-      auto_close_remove: "این موضوع را خوکار قفل نکن"
-      progress:
-        title: نوشته ی در حال اجرا
-        go_top: "بالا"
-        go_bottom: "پایین"
-        go: "برو"
-        jump_bottom_with_number: "رفتن به نوشته ی %{post_number}"
-        total: همهٔ نوشته‌ها
-        current: نوشته کنونی
-        position: "نوشته %{current} از %{total}"
-      notifications:
-        reasons:
-          '3_6': 'شما آگاه‌سازی‌ها را دریافت خواهید کرد، زیرا این دسته بندی را تماشا می‌کنید.'
-          '3_5': 'شما آگاه‌سازی‌ها را دریافت خواهید کرد، زیرا تماشای خودکار این موضوع را آغاز کرده‌اید.'
-          '3_2': 'از آنجا که این موضوع را تماشا می‌کنید، از رویدادهای آن آگاه خواهید شد.'
-          '3_1': 'از آنجا که این موضوع را ساخته‌اید، از رویدادهای آن آگاه خواهید شد.'
-          '3': 'از آنجا که این موضوع را تماشا می‌کنید، از رویدادهای آن آگاه خواهید شد.'
-          '2_8': 'شما آگاه سازی دریافت خواهید کرد چون شما این دسته بندی را پی گیری می کنید.'
-          '2_4': 'از آنجا که یه این موضوع پاسخی فرستادید، از رویدادهای آن آگاه خواهید شد.'
-          '2_2': 'از آنجا که این موضوع را دنبال می‌کنید، از رویدادهای آن آگاه خواهید شد.'
-          '2': 'شما اطلاعیه ای دریافت خواهید کرد چون  <a href="/users/{{username}}/preferences">این موضوع را مطالعه نماید</a>.'
-          '1_2': 'به شما اطلاع داده خواهد شد اگر کسی به شما اشاره @name یا پاسخ ها به نوشته شما'
-          '1': 'به شما اطلاع داده خواهد شد اگر کسی به شما اشاره @name یا پاسخ ها به نوشته شما'
-          '0_7': 'شما کل آگاه سازی های این دسته بندی را نادیده گرفته اید'
-          '0_2': 'شما کل آگاه سازی های این موضوع را نادیده گرفته اید'
-          '0': 'شما کل آگاه سازی های این موضوع را نادیده گرفته اید'
-        watching_pm:
-          title: "در حال مشاهده"
-          description: "به شما اطلاع رسانی خواهد شدهر نوشته جدید در این پیام،تعداد نوشته های خوانده نشده در کنار موضوع پدیدار می شود"
-        watching:
-          title: "در حال مشاهده"
-          description: "به شما اطلاع رسانی خواهد شد هر نوشته جدید در این موضوع، و تعداد نوشته های خوانده نشده در کنار موضوع پدیدار می شود."
-        tracking_pm:
-          title: "ردگیری"
-          description: "تعداد نوشته های خوانده نشده و نوشته های جدید به عنوان پیام پدیدار می شود،به شما اطلاع داده خواهد شد اگر کسی به شما اشاره @name یا به نوشته های شما پاسخ دهند"
-        tracking:
-          title: "ردگیری"
-          description: "تعداد نوشته های خوانده نشده و نوشته های جدید به در کنار موضوع پدیدار می شود،به شما اطلاع داده خواهد شد اگر کسی به شما اشاره @name یا به نوشته های شما پاسخ دهند"
-        regular:
-          title: "منظم"
-          description: "به شما اطلاع داده خواهد شد اگر کسی به شما اشاره @name یا به نوشته های شما پاسخ دهند"
-        regular_pm:
-          title: "عادی"
-          description: "به شما در قالب پیام اطلاع داده خواهد شد اگر کسی به شما اشاره @name یا به نوشته های شما پاسخ دهند،"
-        muted_pm:
-          title: "بی صدا شد"
-          description: "شما هرگز اطلاع رسانی نخواهید شد در باره این پیام"
-        muted:
-          title: "بی صدا شد"
-          description: "شما هرگز اطلاع رسانی نخواهید شد در باره این موضوع، و در کنار موضوع شماره خوانده نشده ها پدیدار نمی شود"
-      actions:
-        recover: "بازیابی موضوع"
-        delete: "پاک کردن موضوع"
-        open: "برداستن قفل موضوع"
-        close: "بستن موضوع"
-        auto_close: "بستن خودکار"
-        make_banner: "اعلان موضوع"
-        remove_banner: "حذف اعلان موضوع"
-        pin: "سنجاق زدن موضوع"
-        unpin: "برداشتن سنجاق موضوع"
-        pin_globally: "سنجاق کردن موضوع در سطح سراسری"
-        unarchive: "موضوع بایگانی نشده"
-        archive: "بایگانی کردن موضوع"
-        invisible: "خارج کردن از لیست"
-        visible: "فهرست ساخته شد"
-        reset_read: "تنظیم مجدد خواندن داده ها"
-        multi_select: "گزیدن نوشته‌ها"
-      reply:
-        title: 'پاسخ'
-        help: 'آغاز ارسال یک پاسخ به این موضوع'
-      clear_pin:
-        title: "برداشتن سنجاق"
-        help: "سنجاق موضوع را بردارید که پس از آن دیگر این موضوع در بالای فهرست موضوعات شما دیده نمی‌شود."
-      share:
-        title: 'اشتراک‌گذاری'
-        help: 'اشتراک گذاری یک پیوند برای این موضوع'
-      flag_topic:
-        title: 'پرچم'
-        success_message: 'شما باموفقیت این موضوع را پرچم زدید'
-      feature_topic:
-        title: " ویژگی های این موضوع"
-        pin: "این موضوع را قابل رویت در دسته بندی {{categoryLink}} کن."
-        unpin: "این موضوع را از لیست بالاترین‌ های دسته بندی {{categoryLink}} حذف کن"
-        pin_note: "کاربران می توانند موضوع را بصورت جداگانه برای خود از سنجاق در بیاورند"
-        already_pinned:
-          zero: "دیگر هیچ موضوعات سنجاق شده وجود ندارد در {{categoryLink}}."
-          one: "موضوعات در حال حاضر به صورت سراسری سنجاق شده اند {{categoryLink}}: <strong class='badge badge-notification unread'>1</strong>."
-          other: "موضوعات در حال حاضر به صورت سراسری سنجاق شده اند {{categoryLink}}: <strong class='badge badge-notification unread'>{{count}}</strong>."
-        unpin_globally: "حذف این موضوع انجمن از بالای همه لیست موضوعات"
-        global_pin_note: "کاربران می توانند موضوع را بصورت جداگانه برای خود از سنجاق در بیاورند"
-        already_pinned_globally:
-          zero: "هیچ موضوعی که به صورت سرسری سنجاق شده باشد وجود ندارد."
-          one: "موضوعات در سطح سراسری سنجاق شده است: <strong class='badge badge-notification unread'>1</strong>."
-          other: "موضوعات در سطح سراسری سنجاق شده است: <strong class='badge badge-notification unread'>{{count}}</strong>."
-        remove_banner: "حذف اعلان از بالای تمام صفحات."
-        banner_note: "کاربران می توانند اعلان را با بستن آنها رد کنند. فقط یک موضوع را می توان بصورت اعلان در هرزمان نمایش داد"
-        already_banner:
-          zero: "هیچ موضوع سرصفحه وجود ندارد"
-          one: "در حال حاضر یک موضوع اعلان <strong class='badge badge-notification unread'>is</strong> وجود دارد."
-      inviting: "فراخوانی..."
-      invite_private:
-        title: 'دعوت به پیام خصوصی'
-        email_or_username: "رایانامه یا نام کاربر فراخوان شده"
-        email_or_username_placeholder: "نشانی رایانامه یا نام کاربری"
-        action: "فراخوانی"
-        success: "ما آن کاربر را برای شرکت در این پیام دعوت کردیم."
-        error: "با معذرت٬ یک خطا برای دعوت آن کاربر وجود داشت"
-        group_name: "نام گروه"
-      invite_reply:
-        title: 'فراخوانی'
-        action: 'ارسال دعوت'
-        help: 'دعوت دیگران به این موضوع با ایمیل یا اطلاعیه '
-        to_forum: "ما ایملی کوتاه برای شما می فرستیم که دوست شما با کلیک کردن بر روی لینک سریعا ملحق شود٫‌ به ورود سیستم نیازی نیست. "
-        to_topic_blank: "نام کاربری یا ایمیل کسی را که می خواهید برای این موضوع دعوت کنید را وارد نمایید"
-        email_placeholder: 'name@example.com'
-      login_reply: 'برای پاسخ وارد شوید'
-      filters:
-        n_posts:
-          other: "{{count}} نوشته ها"
-        cancel: "حذف فیلتر"
-      split_topic:
-        title: "انتقال به موضوع موجود"
-        action: "انتقال به موضوع جدید"
-        topic_name: "نام موضوع تازه"
-        error: "اینجا یک ایراد بود برای جابجایی نوشته ها به موضوع جدید."
-      merge_topic:
-        title: "انتقال به موضوع موجود"
-        action: "انتقال به موضوع موجود"
-        error: "اینجا یک ایراد بود برای جابجایی نوشته ها به  آن موضوع. "
-        instructions:
-          other: "لطفاً موضوعی را که قصد دارید <b>{{count}}</b> تا از نوشته‌ها را به آن انتقال دهید، انتخاب نمایید."
-      change_owner:
-        title: "تغییر صاحب نوشته ها"
-        action: "تغییر مالکیت"
-        error: "آنجا یک ایراد برای تغییر مالکیت آن پست وجود داشت. "
-        label: "نوشته مالک جدید"
-        placeholder: "نام کاربری مالک جدید"
-        instructions_warn: "نکته٬ هر گونه آگاه سازی برای این پست  همانند سابق برای کاربر جدید فرستاده نمی شود. .<br> اخطار: در حال حاضر٬‌ هیچگونه اطلاعات قبلی به کاربر جدید فرستاده نشده. با احتیاط استفاده شود. "
-      multi_select:
-        select: 'انتخاب کنید'
-        selected: 'انتخاب کنید({{count}}) '
-        select_replies: 'انتخاب کردن + جواب دادن'
-        delete: حذف انتخاب شده ها
-        cancel: لغو انتخاب
-        select_all: انتخاب همه
-        deselect_all: عدم انتخاب همه
-        description:
-          other: شما تعداد <b>{{count}}</b> نوشته انتخاب کرده اید
-    post:
-      reply: "در حال پاسخ به {{link}} {{replyAvatar}} {{username}}"
-      reply_topic: "پاسخ به {{link}}"
-      quote_reply: "پاسخ با نقل‌قول"
-      edit: "در حال ویرایش {{link}} {{replyAvatar}} {{username}}"
-      edit_reason: "دلیل:"
-      post_number: "نوشته {{number}}"
-      in_reply_to: "پاسخ به"
-      last_edited_on: "آخرین ویرایش نوشته در"
-      reply_as_new_topic: "پاسخگویی به عنوان یک موضوع لینک شده"
-      continue_discussion: "دنبالهٔ موضوع {{postLink}}:"
-      follow_quote: "برو به نوشته ای که نقل‌قول شده"
-      show_full: "نمایش کامل نوشته"
-      show_hidden: 'نمایش درون‌مایهٔ پنهان'
-      expand_collapse: "باز کردن/گستردن"
-      gap:
-        other: "{{count}} نوشته پنهان"
-      more_links: "{{count}} مورد دیگر..."
-      unread: "نوشته خوانده نشده است"
-      has_replies:
-        other: "پاسخ‌ها"
-      errors:
-        create: "متأسفیم، در فرستادن نوشته شما خطایی روی داد. لطفاً دوباره تلاش کنید."
-        edit: "متأسفیم، در ویرایش نوشته شما خطایی روی داد. لطفاً دوباره تلاش کنید."
-        upload: "متأسفیم، در بارگذاری آن پرونده خطایی روی داد. لطفاً دوباره تلاش کنید."
-        attachment_too_large: "با عرض پوزش٬ فایلی را که تلاش برای ارسال آن دارید بسیار بزرگ است (حداکثر سایز {{max_size_kb}}kb است)"
-        file_too_large: "با عرض پوزش٬ فایلی را که تلاش برای ارسال آن دارید بسیار بزرگ است (حداکثر سایز {{max_size_kb}}kb است)"
-        too_many_uploads: "متأسفیم، هر بار تنها می‌توانید یک پرونده را بار بگذارید."
-        too_many_dragged_and_dropped_files: "با عرض پوزش، شما همزمان فقط می توانید 10 فایل را گرفته و رها کنید."
-        upload_not_authorized: "متأسفیم، پرونده‌ای که تلاش دارید آن را بار بگذارید، پروانه‌دار نیست (پسوندهای پروانه‌دار: {{authorized_extensions})"
-        image_upload_not_allowed_for_new_user: "با عرض پوزش، کاربران جدید نمی توانند تصویر بار گذاری نماییند."
-        attachment_upload_not_allowed_for_new_user: "با عرض پوزش، کاربران جدید نمی توانند فایل پیوست بار گذاری نماییند."
-        attachment_download_requires_login: "با عرض پوزش، شما برای دانلود فایل پیوست باید وارد سایت شوید."
-      abandon:
-        confirm: "آیا شما مطمئن هستید که میخواهید نوشته خود را رها کنید؟"
-        no_value: "خیر، نگه دار"
-        yes_value: "بله، رها کن"
-      via_email: "این نوشته از طریق ایمیل ارسال شده است"
-      wiki:
-        about: "این یک نوشته ویکی است;کاربران عادی می توانند آن را ویرایش نماییند"
-      archetypes:
-        save: ' ذخیره تنظیمات'
-      controls:
-        reply: "آغاز ساخت یک پاسخ به این نوشته"
-        like: "شبیه این نوشته"
-        has_liked: "شما این نوشته را لایک کرده اید"
-        undo_like: "خنثی کردن لایک"
-        edit: "ویرایش این نوشته"
-        edit_anonymous: "با عرض پوزش، اما شما برای ویرایش این نوشته باید وارد سیستم شوید."
-        delete: "حذف این نوشته"
-        undelete: "بازگردانی این نوشته"
-        share: "اشتراک گذاری یک لینک در این نوشته"
-        more: "بیشتر"
-        delete_replies:
-          confirm:
-            other: "آیا شما می خواهیدتعداد {{count}} پاسخ را از این نوشته حذف کنید ؟"
-          yes_value: "بله، پاسخ ها را حذف کن"
-          no_value: "نه، تنها این نوشته"
-        admin: "عملیات مدیریت نوشته"
-        wiki: "ساخت ویکی"
-        unwiki: "حذف ویکی"
-        convert_to_moderator: "اضافه کردن رنگ مدیر"
-        revert_to_regular: "حذف زنگ مدیر"
-        rebake: "باز سازی اچ تی ام ال"
-        unhide: "آشکار کردن"
-      actions:
-        flag: 'پرچم'
-        defer_flags:
-          other: "پرچم تسلیم"
-        it_too:
-          off_topic: "هم‌چنین آن یکی را پرچم بزنید"
-          spam: "هم‌چنین آن یکی را پرچم بزنید"
-          inappropriate: "هم‌چنین آن یکی را پرچم بزنید"
-          custom_flag: "هم‌چنین آن یکی را پرچم بزنید"
-          bookmark: "هم‌چنین نشانک‌گذاری آن یکی"
-          like: "هم‌چنین آن یکی را پسند کنید"
-          vote: "هم‌چنین به آن یکی رأی دهید"
-        undo:
-          off_topic: "برداشتن پرچم"
-          spam: "برداشتن پرچم"
-          inappropriate: "خنثی سازی علامت گذاری"
-          bookmark: "برداشتن نشانک"
-          like: "خنثی سازی لایک"
-          vote: "خنثی سازی امتیاز"
-        people:
-          off_topic: "{{icons}} برای این مورد پرچم آف-‌تاپیک زد"
-          spam: "{{icons}} برای این مورد پرچم هرزنامه زد"
-          spam_with_url: "{{icons}} پرچم گذاری شد<a href='{{postUrl}}'>این یک هرزنامه است</a>"
-          inappropriate: "{{icons}} این مورد را نامناسب دانست"
-          notify_moderators: "{{icons}} مدیران را آگاه کرد"
-          notify_moderators_with_url: "{{icons}} <a href='{{postUrl}}'>مدیران را آگاه کرد</a>"
-          notify_user: "{{icons}} ارسال یک پیام خصوصی"
-          notify_user_with_url: "{{icons}} ارسال <a href='{{postUrl}}'>پیام خصوصی</a>"
-          bookmark: "{{icons}} این را نشانه‌گذاری کرد"
-          like: "{{icons}} این مورد را پسندید"
-          vote: "{{icons}} به این مورد رأی داد"
-        by_you:
-          off_topic: "شما برای این مورد پرچم آف-تاپیک زدید"
-          spam: "شما برای این مورد پرچم هرزنامه زدید"
-          inappropriate: "شما این مورد را نامناسب گزارش کردید."
-          notify_moderators: "شما این مورد را برای بررسی پرچم زدید"
-          notify_user: "شما یک پیام به این کاربر ارسال کردید"
-          bookmark: "شما  روی این نوشته نشانک گذاشتید"
-          like: "شما این نوشته را پسند کردید"
-          vote: "شما به این نوشته رأی دادید"
-        by_you_and_others:
-          off_topic:
-            other: "شما و {{count}} کاربر دیگر این مورد را آف-تاپیک گزارش کردید"
-          spam:
-            other: "شما و {{count}} کاربر دیگر این مورد را هرزنامه گزارش کردید"
-          inappropriate:
-            other: "شما و {{count}} کاربر دیگر این مورد را نامناسب گزارش کردید"
-          notify_moderators:
-            other: "شما و {{count}} کاربر دیگر این مورد را برای بررسی گزارش کردید"
-          notify_user:
-            other: "شما و {{count}} افراد دیگر به این کاربر پیام فرستاده اید"
-          bookmark:
-            other: "شما و {{count}} کاربر دیگر روی این نوشته نشانک گذاشتید"
-          like:
-            other: "شما و {{count}} کاربر دیگر این مورد را پسند کردید"
-          vote:
-            other: "شما و {{count}} کاربر دیگر به این نوشته رأی دادید"
-        by_others:
-          off_topic:
-            other: "{{count}} کاربر ین مورد را آف-تاپیک گزارش کردند"
-          spam:
-            other: "{{count}} کاربر ین مورد را هرزنامه گزارش کردند"
-          inappropriate:
-            other: "{{count}} کاربر این مورد را نامناسب گزارش کردند"
-          notify_moderators:
-            other: "{{count}} کاربر این مورد را برای بررسی گزارش کردند"
-          notify_user:
-            other: "{{count}} ارسال پیام به این کاربر"
-          bookmark:
-            other: "{{count}} کاربر روی این نوشته نشانک گذاشتند"
-          like:
-            other: "{{count}} کاربر این مورد را پسند کردند"
-          vote:
-            other: "{{count}} کاربر به این نوشته رأی دادند"
-      edits:
-        one: ۱ ویرایش
-        other: "{{count}} ویرایش"
-        zero: هیچ ویرایشی
-      delete:
-        confirm:
-          other: "آیا مطمئنید که می‌خواهید همهٔ آن نوشته ها را پاک کنید؟"
-      revisions:
-        controls:
-          first: "بازبینی نخست"
-          previous: "بازبینی پیشین"
-          next: "بازبینی پسین"
-          last: "بازبینی نهایی"
-          hide: "مخفی کردن نسخه"
-          show: "نمایش نسخه"
-          comparing_previous_to_current_out_of_total: "<strong>{{previous}}</strong> در مقابل <strong>{{current}}</strong> / {{total}}"
-        displays:
-          inline:
-            title: "نمایش خروجی رندر با اضافات و از بین بردن درون خطی"
-            button: '<i class="fa fa-square-o"></i> اچ تی ام ال'
-          side_by_side:
-            button: '<i class="fa fa-columns"></i> اچ تی ام ال'
-          side_by_side_markdown:
-            button: '<i class="fa fa-columns"></i> خام'
-        details:
-          edited_by: "ویرایش‌گر:"
-    category:
-      can: 'can&hellip; '
-      none: '(بدون دسته)'
-      choose: 'انتخاب یک دسته بندی&hellip;'
-      edit: 'ویرایش'
-      edit_long: "ویرایش"
-      view: 'نمایش موضوعات دسته'
-      general: 'عمومی'
-      settings: 'تنظیمات'
-      delete: 'پاک کردن دسته'
-      create: 'دسته بندی جدید'
-      save: 'ذخیره سازی دسته بندی'
-      slug: 'Slug دسته بندی'
-      slug_placeholder: '(اختیاری) dash-کلمه برای دسته بندی'
-      creation_error: خطایی در ساخت این دسته بروز کرد.
-      save_error: خطایی در ذخیره سازی این دسته بندی روی داد.
-      name: "نام دسته"
-      description: "توضیح"
-      topic: "دسته بندی موضوع"
-      logo: "تصویر لوگو برای دسته بندی"
-      background_image: "تصویر پس زمینه برای دسته بندی"
-      badge_colors: "رنگ مدال ها"
-      background_color: "رنگ پس زمینه"
-      foreground_color: "رنگ پیش زمینه"
-      name_placeholder: "حداکثر یک با دوکلمه"
-      color_placeholder: "هر رنگ وب"
-      delete_confirm: "آیا مطمئنید که می‌خواهید این دسته‌بندی را پاک کنید؟"
-      delete_error: "هنگام حذف دسته بندی خطایی رخ داد."
-      list: "فهرست دسته‌ بندی ها"
-      no_description: "لطفا برای این دسته بندی توضیحاتی اضافه نمایید."
-      change_in_category_topic: "ویرایش توضیحات"
-      already_used: 'این رنگ توسط یک دسته بندی دیگر گزیده شده است'
-      security: "امنیت"
-      images: "تصاویر"
-      auto_close_label: "بسته شدن خودکار موضوعات پس از:"
-      auto_close_units: "ساعت ها"
-      email_in: "آدرس ایمیل های دریافتی سفارشی:"
-      email_in_disabled: "ارسال پست با رایانامه در تنظیمات سایت غیر فعال است. برای فعال سازی ارسال موضوع با ایمیل, "
-      email_in_disabled_click: 'فعال کردن تنظیمات "email in".'
-      allow_badges_label: "اجازی برای اهداء مدال در این دسته بندی"
-      edit_permissions: "ویرایش پروانه‌ها"
-      add_permission: "افزودن پروانه"
-      this_year: "امسال"
-      position: "موقعیت"
-      default_position: "موقعیت پیش فرض"
-      position_disabled: "Categories will be displayed in order of activity. To control the order of categories in lists, "
-      position_disabled_click: 'در تنظیمات "مکان دسته بندی ثابت"  فعال را کنید.'
-      parent: "دسته مادر"
-      notifications:
-        watching:
-          title: "در حال تماشا"
-          description: "شما به صورت خود کار تمام نوشته های این دسته بندی را مشاهده خواهید کرد،به شما اطلاع رسانی خواهد شد تمام نوشته های جدید در موضوعات، بعلاوه تعداد نوشته های خوانده نشده و و نوشته های جدید در کنار موضوعات پدیدار میشود"
-        tracking:
-          title: "پیگیری"
-          description: "شما به صورت خود کار تمام موضوعات جدید در این دسته بندی را پی گیری خواهیدکرد،و تعداد نوشته های خوانده نشده در کنار موشوعات پدیدار می شود"
-        regular:
-          title: "منظم"
-          description: "به شما اطلاع داده خواهد شد اگر کسی به شما اشاره @name یا به نوشته های شما پاسخ دهند"
-        muted:
-          title: "بی صدا شد"
-          description: "به شما اطلاع داده خواهد شد همه چیز در رابطه با این دسته بندی ، و آن های پیدار نمی شود در تب خوانده نشده ها"
-    flagging:
-      title: 'تشکر برای کمک به جامعه مدنی انجمن ما!'
-      private_reminder: 'پرچم های خصوصی, <b>فقط</b> قابل مشاهده برای مدیران'
-      action: 'پرچم‌گذاری نوشته'
-      take_action: "اقدام"
-      notify_action: 'پیام'
-      delete_spammer: "پاک کردن هرزنگار"
-      yes_delete_spammer: "بله، پاک‌کردن هرزنگار"
-      ip_address_missing: "(N/A)"
-      hidden_email_address: "(مخفی)"
-      submit_tooltip: "ایجاد پرچم خصوصی"
-      cant: "متأسفیم، در این زمان نمی‌توانید پرچم روی این نوشته بگذارید."
-      formatted_name:
-        off_topic: "آن موضوع قدیمی است"
-        inappropriate: "این نامناسب است"
-        spam: "آن هرز نامه است"
-      custom_message:
-        at_least: "دست‌کم {{n}} نویسه بنویسید"
-        more: "{{n}} نویسهٔ دیگر تا بتوانید بفرستید"
-        left: "{{n}} نویسهٔ دیگر جا دارد"
-    flagging_topic:
-      title: "تشکر برای کمک به جامعه مدنی انجمن ما!"
-      action: "پرچم‌گذاری موضوع"
-      notify_action: "پیام"
-    topic_map:
-      title: "چکیدهٔ موضوع"
-      links_shown: "نمایش همه {{totalLinks}} پیوند ها..."
-      clicks:
-        other: "%{count} کلیک ها"
-    topic_statuses:
-      warning:
-        help: "این یک هشدار رسمی است."
-      bookmarked:
-        help: "شما بر روی این موضوع نشانک گذاشته‌اید."
-      locked:
-        help: "این موضوع بسته شده؛ پاسخ‌های تازه اینجا پذیرفته نمی‌شوند"
-      unpinned:
-        title: "خارج کردن از سنجاق"
-        help: "این موضوع برای شما شنجاق نشده است، آن طور منظم نمایش داده خواهد شد"
-      pinned_globally:
-        title: "به صورت سراسری سنجاق شد"
-        help: "این موضوع بصورت سراسری سنجاق شده است، آن بالای تمامی موضوعات نمایش داده خواهد شد"
-      pinned:
-        title: "سنجاق شد"
-        help: "این موضوع برای شما سنجاق شده است، آن  طور منظم در بالای دسته بندی نمایش داده خواهد شد."
-      archived:
-        help: "این موضوع بایگانی شده؛ یخ زده و نمی‌تواند تغییر کند."
-    posts: "نوشته‌ها"
-    posts_lowercase: "نوشته ها"
-    posts_long: "این موضوع {{number}} نوشته دارد"
-    posts_likes_MF: |
-      این موضوع است {count, plural, one {1 reply} other {# replies}} {ratio, select,
-        low {with a high like to post ratio}
-        med {with a very high like to post ratio}
-        high {with an extremely high like to post ratio}
-        other {}}
-    original_post: "نوشته اصلی"
-    views: "نمایش‌ها"
-    views_lowercase: "بازدید ها"
-    replies: "پاسخ‌ها"
-    views_long: "از این موضوع {{number}} بار بازدید شده"
-    activity: "فعالیت"
-    likes: "پسندها"
-    likes_lowercase: "پسند ها"
-    likes_long: "{{number}} پسند در این موضوع وجود دارد"
-    users: "کاربران"
-    users_lowercase: "کاربران"
-    category_title: "دسته"
-    history: "تاریخچه"
-    changed_by: "توسط {{author}}"
-    raw_email:
-      title: "ایمیل خام"
-      not_available: "در دسترس نیست!"
-    categories_list: "فهرست دسته‌ بندی ها"
-    filters:
-      with_topics: "%{filter} موضوعات"
-      with_category: "%{filter} %{category} موضوعات"
-      latest:
-        title: "آخرین ها"
-        help: "موضوعات با نوشته های تازه"
-      hot:
-        title: "داغ"
-        help: "گزینشی از داغ‌ترین موضوعات"
-      read:
-        title: "خواندن"
-      search:
-        title: "جستجو"
-        help: "جستجوی تمام موضوعات"
-      categories:
-        title: "دسته‌ بندی ها"
-        title_in: "دسته بندی - {{categoryName}}"
-        help: "همهٔ موضوعات در دسته‌ بندی ها جای گرفتند"
-      unread:
-        title:
-          zero: "خوانده‌ نشده‌"
-          one: "خوانده‌ نشده‌ (۱)"
-          other: "خوانده‌ نشده‌ ({{count}})"
-        lower_title_with_count:
-          one: "1 خوانده نشده"
-          other: "{{count}} خوانده نشده"
-      new:
-        lower_title_with_count:
-          one: "۱ تازه"
-          other: "{{count}} تازه"
-        lower_title: "جدید"
-        title:
-          zero: "جدید"
-          one: "جدید (1)"
-          other: "جدید ({{count}})"
-        help: "موضوعاتی که در چند روز گذشته ایجاد شده"
-      posted:
-        title: "نوشته‌های من"
-        help: "در این موضوع شما نوشته داردید"
-      bookmarks:
-        title: "نشانک ها"
-        help: "موضوعاتی که نشانک‌گذاری کرده‌اید."
+      can_not_modify_automatic: "شما امکان تغییر یک گروه خودکار را ندارید."
+    default_names:
+      everyone: "همه"
+      admins: "مدیران"
+      moderators: "ناظمان"
+      staff: "کارمند"
+      trust_level_0: "کاربر سطح 0"
+      trust_level_1: "کاربر سطح 1"
+      trust_level_2: "کاربر سطح 2"
+      trust_level_3: "کاربر سطح 3"
+      trust_level_4: "کاربر سطح 4"
+  education:
+    until_posts:
+      other: "%{count} ارسال"
+  activerecord:
+    attributes:
       category:
-        title:
-          zero: "{{categoryName}}"
-          one: "{{categoryName}} (۱)"
-          other: "{{categoryName}} ({{count}})"
-        help: "موضوعات تازه در دستهٔ {{categoryName}}"
-      top:
-        title: "بالاترین‌ ها"
-        yearly:
-          title: "بالاترین‌ سالانه"
-        monthly:
-          title: "بالاترین‌ ماهانه"
-        weekly:
-          title: "بالاترین‌ هفتهگی"
-        daily:
-          title: "بالاترین‌ روزانه"
-        all: "تمام زمان ها"
-        this_year: "امسال"
-        this_month: "این ماه"
-        this_week: "این هفته"
-        today: "امروز"
-        other_periods: "دیدن بالاترین‌ موضوعات بیشتر "
-    browser_update: 'متاسفانه, <a href="http://discours.ir/t/topic/117">مرورگر شما خیلی قدیمی است برای ادامه کار در این وب سایت</a>. لطفا <a href="http://browsehappy.com">مرورگر خود را بروز رسانی نمایید</a>.'
-    permission_types:
-      full: "ساختن / پاسخ دادن / دیدن"
-      create_post: "پاسخ دادن / دیدن"
-      readonly: "دیدن"
-  admin_js:
-    type_to_filter: "بنویسید تا فیلتر کنید..."
-    admin:
-      title: 'ادمین دیسکورس'
-      moderator: 'مدیران'
-      dashboard:
-        title: "پیشخوان"
-        last_updated: "آخرین به‌روزرسانی پیش‌خوان"
-        version: "نسخه"
-        up_to_date: "شما به روز هستید!"
-        critical_available: "به روز رسانی حیاتی در دسترس است."
-        updates_available: "بروز رسانی در درسترس است."
-        please_upgrade: "لطفا ارتقاء دهید!"
-        no_check_performed: "بررسی برای بروزرسانی انجام نشد. از اجرای  sidekiq اطمینان حاصل کنید."
-        stale_data: "بررسی برای بروزرسانی اخیراً انجام نگرفته است. از اجرای  sidekiq اطمینان حاصل کنید."
-        version_check_pending: "گویا به‌تازگی به‌روز کرده‌اید. عالیه!"
-        installed_version: "نصب"
-        latest_version: "آخرین"
-        last_checked: " آخرین چک شده"
-        refresh_problems: "تازه کردن"
-        no_problems: "هیچ مشکلات پیدا نشد."
-        moderators: 'مدیران:'
-        admins: 'مدیران کل:'
-        blocked: 'مسدود شده ها:'
-        suspended: 'تعلیق شده:'
-        private_messages_short: "پیام"
-        private_messages_title: "پیام"
-        space_free: "{{size}} آزاد"
-        uploads: "بارگذاری ها"
-        backups: "پشتیبان ها"
-        traffic_short: "ترافیک"
-        traffic: "درخواست های نرم افزار وب"
-        page_views: "درخواست های API"
-        page_views_short: "درخواست های API"
-        show_traffic_report: "نمایش دقیق گزارش ترافیک"
-        reports:
-          today: "امروز"
-          yesterday: "دیروز"
-          last_7_days: "7 روز اخیر"
-          last_30_days: "آخرین 30 روز"
-          all_time: "همه زمان ها"
-          7_days_ago: "7 روز پیش"
-          30_days_ago: "30 روز پیش"
-          all: "همه"
-          view_table: "جدول"
-          view_chart: "نمودار میله ها"
-          refresh_report: "تازه کردن گزارش"
-          start_date: "تاریخ شروع"
-          end_date: "تاریخ پایان"
-      commits:
-        latest_changes: "آخرین تغییرات: لطفا دوباره به روز رسانی کنید!"
-        by: "توسط"
-      flags:
-        title: "پرچم گذاری ها"
-        old: "قدیمی"
-        active: "فعال"
-        agree: "موافقت کردن"
-        agree_title: "تایید این پرچم به عنوان معتبر و صحیح"
-        agree_flag_modal_title: "موافقت کردن و ..."
-        agree_flag_hide_post: "موافقت با (مخفی کردن نوشته + ارسال پیام خصوصی)"
-        agree_flag_restore_post: "موافقم (بازگرداندی نوشته)"
-        agree_flag_restore_post_title: "بازگردانی این نوشته"
-        agree_flag: "موافقت با پرچم گذاری"
-        agree_flag_title: "موافقت با پرچم و نگه داشتن نوشته بدون تغییر"
-        defer_flag: " واگذار کردن"
-        defer_flag_title: "خذف این پرچم،بدون نیاز به اقدام در این زمان"
-        delete: "حذف"
-        delete_title: "حذف پرچم نوشته و اشاره به."
-        delete_post_defer_flag: "حذف نوشته و  رها کردن پرچم"
-        delete_post_defer_flag_title: "حذف نوشته; اگر اولین نوشته است،موضوع را حذف نمایید."
-        delete_post_agree_flag: "حذف نوشته و موافقت با پرچم"
-        delete_post_agree_flag_title: "حذف نوشته; اگر اولین نوشته است،موضوع را حذف نمایید."
-        delete_flag_modal_title: "حذف و..."
-        delete_spammer: "حذف اسپمر"
-        delete_spammer_title: "حذف کاربر و تمام نوشته ها و موضوعات این کاربر"
-        disagree_flag_unhide_post: "مخالفم (با رویت نوشته)"
-        disagree_flag_unhide_post_title: "حذف تمام پرچم های این نوشته و دوباره نوشته را قابل نمایش کن "
-        disagree_flag: "مخالف"
-        disagree_flag_title: "انکار این پرچم به عنوان نامعتبر است و یا نادرست"
-        clear_topic_flags: "تأیید"
-        clear_topic_flags_title: "موضوع بررسی و موضوع حل شده است. تأیید را بفشارید تا پرچم‌ها برداشته شوند."
-        more: "(پاسخ های بیشتر...)"
-        dispositions:
-          agreed: "موافقت شد"
-          disagreed: "مخالفت شد"
-          deferred: "دیرفرست"
-        flagged_by: "پرچم شده توسط"
-        resolved_by: "حل شده توسط"
-        took_action: "زمان عمل"
-        system: "سیستم"
-        error: "اشتباهی روی داد"
-        reply_message: "پاسخ دادن"
-        no_results: "هیچ پرچمی نیست"
-        topic_flagged: "این <strong>موضوع</strong> پرچم خورده است."
-        visit_topic: "برای اقدام لازم، موضوع را ببینید"
-        was_edited: "نوشته پس از پرچم اول ویرایش شد"
-        previous_flags_count: "این موضوع در حال حاضر چندین با {{count}} پرچم گذاری شده است."
-        summary:
-          action_type_3:
-            other: "موضوعات غیرفعال x{{count}}"
-          action_type_4:
-            other: "نامناسب X{{count}}"
-          action_type_6:
-            other: "دلخواه x{{count}}"
-          action_type_7:
-            other: "دلخواه x{{count}}"
-          action_type_8:
-            other: " هرزنامه x{{count}}"
-      groups:
-        primary: "گروه اولیه"
-        no_primary: "(بدون گروه اولیه)"
-        title: "گروه‌ها"
-        edit: "ویرایش گروه‌ها"
-        refresh: "تازه کردن"
-        new: "جدید"
-        selector_placeholder: "نام کاربری را وارد نمایید ."
-        name_placeholder: "نام گروه، بدون فاصله، همان قاعده نام کاربری"
-        about: "ویرایش عضویت در گروه شما و نام ها اینجا"
-        group_members: "اعضای گروه"
-        delete: "حذف"
-        delete_confirm: "حذف این گروه؟"
-        delete_member_confirm: "حذف کردن '%{username}' از '%{group}' گروه?"
-        name: "نام"
-        add: "اضافه کردن"
-        add_members: "اضافه کردن عضو"
-        custom: "دلخواه"
-        automatic: "خودکار"
-      api:
-        generate_master: "ایجاد کلید اصلی API"
-        none: "هم اکنون هیچ کلید API فعالی وجود ندارد"
-        user: "کاربر"
-        title: "API"
-        key: "کلید API"
-        generate: "تولید کردن"
-        regenerate: "احیاء کردن"
-        revoke: "لغو کردن"
-        confirm_regen: "آیا می خواهید API موجود را با یک API جدید جایگزین کنید؟"
-        confirm_revoke: "آیا مطمئن هستید که می خواهید کلید را برگردانید؟"
-        info_html: "موضوعات تازه پس از آخرین بازدید شما"
-        all_users: "همه کاربران"
-        note_html: "این کلید را <strong>امن</strong> نگهدارید، ممکن است از آن سوئ استفاده شود."
-      plugins:
-        title: "افزونه ها"
-        installed: "افزونه های نصب شده"
-        name: "نام"
-        none_installed: "شما هیچ افزونه نصب شده ای  ندارید"
-        version: "نسخه"
-        change_settings: "تغییر تنظیمات"
-        howto: "چگونه یک افزونه نصب کنیم؟"
-      backups:
-        title: "پشتیبان گیری"
-        menu:
-          backups: "پشتیبان ها"
-          logs: "گزارش ها"
-        none: "هیچ پشتیبانی در دسترس نیست."
-        read_only:
-          enable:
-            title: "به کار گرفتن شیوهٔ‌ فقط-خواندنی"
-            label: "غیر فعال کردن مد فقط خواندن"
-            confirm: "آیا مطمئنید که می‌خواهید حالت فقط-خواندنی را به کار بیاندازید؟"
-          disable:
-            title: "از کار انداختن حالت فقط-خواندنی"
-            label: "غیر فعال کردن مد فقط خواندن"
-        logs:
-          none: "هنوز بدون گزارش است ..."
-        columns:
-          filename: "نام پرونده"
-          size: "اندازه"
-        upload:
-          label: "بار گذاری"
-          title: "آپلود یک نسخه پشتیبان برای این نمونه"
-          uploading: "در حال بار گذاری ..."
-          success: "'{{filename}}' با موفقیت آپلود شد."
-          error: "هنگام آپلود خطایی رخ می دهد '{{filename}}': {{message}}"
-        operations:
-          is_running: "عملیاتی در جریان است..."
-          failed: "در {{operation}} ناموفق. لطفا گزارشات را بررسی نمایید."
-          cancel:
-            label: "لغو کردن"
-            title: "کنار گذاشتن عملیات کنونی"
-            confirm: "آیا مطمئنید که می‌خواهید عملیات کنونی را کنار بگذارید؟"
-          backup:
-            label: "پشتیبان گیری"
-            title: "ساختن یک پشتیبان"
-            confirm: "آیا می خواید یک پشیبان گیری را آغاز نمایید ؟"
-            without_uploads: "بله (فایل ها را شامل نمی شود)"
-          download:
-            label: "دانلود"
-            title: "بارگیری پشتیبان"
-          destroy:
-            title: "پاک کردن پشتیبان"
-            confirm: "آیا مطمئنید که می‌خواهید پشتیبان را از بین ببرید؟"
-          restore:
-            is_disabled: "بازگردانی در تنظیمات انجمن از کار انداخته شده است."
-            label: "بازگرداندن"
-            title: "بازگردانی پشتیبان"
-            confirm: "آیا مطمئنید که می‌خواهید پشتیبان را برگردانید؟"
-          rollback:
-            label: "عقبگرد"
-      export_csv:
-        user_archive_confirm: "آیا مطمئنید که می‌خواهید نوشته‌هایتان را دانلود کنید؟"
-        success: "فرایند برون ریزی، به شما ار سریق پیام اطلاع رسانی خواهد شد اگر این فرایند تکمیل شود."
-        failed: "برون ریزی شکست خورد، لطفا لوگ گزارشات را مشاهده فرمایید"
-        button_text: "خروجی گرفتن"
-        button_title:
-          user: "برون ریزی لیست تمام کاربران با قالب CSV ."
-          staff_action: "برون ریزی تمام کار های مدیران با فرمت CSV ."
-          screened_email: "برون ریزی کامل لیست ایمیل به نمایش در آمده در فرمت CSV."
-          screened_ip: "برون ریزی کامل لیست ای پی به نمایش در آمده در فرمت CSV."
-          screened_url: "برون ریزی کامل لیست URL به نمایش در آمده در فرمت CSV."
-      invite:
-        button_text: "ارسال دعوتنامه"
-        button_title: "ارسال دعوتنامه"
-      customize:
-        title: "سفارشی‌سازی"
-        long_title: "شخصی‌سازی انجمن"
-        css: "سی اس اس"
-        header: "سردر"
-        top: "بالا"
-        footer: "پانوشته "
-        head_tag:
-          text: "</head>"
-        body_tag:
-          text: "</body>"
-        override_default: "حاوی شیوه نامه استاندارد نیست"
-        enabled: "فعال شد؟"
-        preview: "پیش‌نمایش"
-        undo_preview: "حذف پیش نمایش"
-        rescue_preview: "استایل پیش فرض"
-        explain_preview: "مشاهده‌ی سایت با این قالب سفارشی"
-        explain_rescue_preview: "دیدن سایت با شیوه نامه پیش فرض"
-        save: "ذخیره سازی"
-        new: "تازه"
-        new_style: "سبک جدید"
-        delete: "پاک کردن"
-        delete_confirm: "پاک کردن این شخصی‌سازی؟"
-        color: "رنگ"
-        opacity: "تاری"
-        copy: "رونوشت"
-        css_html:
-          title: "CSS/HTML"
-          long_title: "شخصی‌سازی CSS و HTML"
-        colors:
-          title: "رنگ‌ها"
-          long_title: "طرح‌های رنگی"
-          new_name: "طرح رنگ جدید"
-          copy_name_prefix: "نمونه سازی از"
-          delete_confirm: "این طرح رنگ پاک شود؟"
-          undo: "خنثی کردن"
-          undo_title: "برگشت دادن رنگ دخیره شده خود به آخرین رنگی که ذخیره شده است"
-          revert: "برگشت"
-          primary:
-            name: 'اولیه'
-            description: 'متن بیشتر، آیکون ها، و کناره ها.'
-          secondary:
-            name: 'دومی'
-          tertiary:
-            name: 'سومی'
-            description: 'لینک ها، برخی از دکمه ها، اطلاعیه ها، و مد رنگ.'
-          quaternary:
-            name: "چهارمی"
-            description: "لینک های ناوبری."
-          header_background:
-            name: "پس زمینه هدر"
-            description: "رنگ پس زمینه هدر سایت"
-          header_primary:
-            name: "هدر اولیه"
-            description: "نوشته و آیکن های هدر سایت"
-          highlight:
-            name: 'برجسته کردن'
-          danger:
-            name: 'خطرناک'
-          success:
-            name: 'موفقیت'
-          love:
-            name: 'دوست داشتن'
-            description: "رنگ دکمه های لایک"
-          wiki:
-            name: 'ویکی'
-      email:
-        title: "رایانامه"
-        settings: "تنظیمات"
-        all: "همه"
-        sending_test: "فرستادن رایانامهٔ آزمایشی..."
-        error: "<b>خطا</b> - %{server_error}"
-        test_error: "در ارسال ایمیل آزمایشی مشکلی وجود داشته است. لطفاً مجدداً تنظیمات ایمیل خود را بررسی کنید، از این که هاستتان اتصالات ایمیل را مسدود نکرده اطمینان حاصل کرده و مجدداً تلاش کنید."
-        sent: "فرستاده شده"
-        skipped: "رد داده شده"
-        sent_at: "ارسال شده در"
-        time: "زمان"
-        user: "کاربر"
-        email_type: "گونهٔ رایانامه"
-        to_address: "به آدرس"
-        test_email_address: "آدرس ایمیل برای تست"
-        send_test: "ارسال ایمیل تست "
-        sent_test: "فرستادیم!"
-        delivery_method: "روش تحویل"
-        preview_digest: "پیشنمایش خلاصه"
-        refresh: "تازه‌سازی"
-        format: "به شکل"
-        html: "html"
-        text: "متن"
-        last_seen_user: "آخرین مشاهده کاربر :"
-        reply_key: "کلید پاسخ"
-        skipped_reason: "رد دادن دلیل"
-        logs:
-          none: "هیچ آماری یافت نشد."
-          filters:
-            title: "فیلتر"
-            user_placeholder: "نام کاربری"
-            address_placeholder: "name@example.com"
-            type_placeholder: "خلاصه،نام نویسی ..."
-            reply_key_placeholder: "کلید پاسخ"
-            skipped_reason_placeholder: "دلیل"
-      logs:
-        title: "گزارش ها"
-        action: "اقدام"
-        created_at: "ساخته شد"
-        last_match_at: "آخرین همسان ها"
-        match_count: "همتا ها"
-        ip_address: "IP"
-        topic_id: "ای دی موضوع"
-        post_id: "ای دی نوشته"
-        delete: 'حذف'
-        edit: 'ویرایش‌'
-        save: 'ذخیر'
-        screened_actions:
-          block: "بلوک"
-          do_nothing: "هیچ کاری انجام نشد"
-        staff_actions:
-          title: "عملیات مدیران"
-          clear_filters: "نشان دادن همه چیز"
-          staff_user: "کاربران مدیر"
-          target_user: "کاربران هدف"
-          subject: "عنوان"
-          when: "چه زمانی"
-          context: "متن"
-          details: "جزئیات"
-          previous_value: "پیشین"
-          new_value: "بعدی"
-          diff: "تفاوت"
-          show: "نمایش"
-          modal_title: "جزئیات"
-          no_previous: "هیچ مقدار قبلی وجود دارد."
-          deleted: "بدون مقدار جدید. رکورد حذف شد."
-          actions:
-            delete_user: "حذف کاربر"
-            change_trust_level: "تغییر دادن سطح اعتماد"
-            change_username: "تغییر نام کاربری"
-            change_site_setting: "تغییر تنظیمات سایت"
-            change_site_customization: "تغییر سفارشی‌سازی سایت"
-            delete_site_customization: "پاک‌کردن سفارشی‌سازی سایت"
-            suspend_user: "کاربر تعلیق شده"
-            unsuspend_user: "کابر تعلیق نشده"
-            grant_badge: "اعطای مدال"
-            revoke_badge: "لغو کردن مدال"
-            check_email: "برسی ایمل"
-            delete_topic: "حذف موضوع"
-            delete_post: "حذف نوشته"
-            impersonate: "جعل هویت کردن"
-            anonymize_user: "کاربر ناشناس"
-        screened_emails:
-          title: "ایمیل ها نمایش داده شده"
-          email: "آدرس ای‌میل"
-          actions:
-            allow: "اجازه"
-        screened_urls:
-          title: "URL های نمایش داده شده"
-          url: "نشانی اینترنتی"
-          domain: "دامنه"
-        screened_ips:
-          title: "نمایش آپی پی ها"
-          delete_confirm: "آیا از حذف قانون وضع شده برای {ip_address}% اطمینان دارید؟"
-          rolled_up_no_subnet: "هیچ چیز برای ذخیره کردن وجود ندارد."
-          actions:
-            block: "بستن"
-            do_nothing: "اجازه دادن"
-            allow_admin: "اجازه دادن به مدیر"
-          form:
-            label: "جدید:"
-            ip_address: "نشانی IP"
-            add: "افزودن"
-            filter: "جستجو"
-          roll_up:
-            text: "جمع کردن"
-        logster:
-          title: "گزارش خطا"
-      impersonate:
-        title: "جعل هویت کردن"
-        help: "با استفاده از این ابزار یک حساب کاربری را برای اشکال زدایی انتخاب نمایید،شما باید بعد از اتمام کار یک بار خارج شوید."
-      users:
-        title: 'کاربران'
-        create: 'اضافه کردن کاربر ادمین'
-        last_emailed: "آخرین ایمیل فرستاده شده"
-        not_found: "lj"
-        id_not_found: "با عرض پوزش،کاربری با این ID در سیستم ما وجود ندارد"
-        active: "فعال"
-        show_emails: "نشان دادن ایمیل ها"
-        nav:
-          new: "تازه"
-          active: "فعال"
-          pending: "چشم‌به‌راه"
-          staff: 'مدیران'
-          suspended: 'معلق شد'
-          blocked: 'مسدود شده'
-          suspect: 'مشکوک'
-        approved: "تایید شد ؟"
-        approved_selected:
-          other: "کاربران تایید شده  ({{count}})"
-        reject_selected:
-          other: "کاربران رد شده  ({{count}})"
-        titles:
-          active: 'کاربران فعال'
-          new: 'کاربران تازه'
-          pending: 'کاربران در انتظار بررسی'
-          newuser: 'کاربران در سطح اعتماد 0 (کاربران جدید)'
-          basic: 'کاربران در سطح اعتماد 1 (کاربر اصلی)'
-          regular: 'کاربران در سطح اعتماد 2 (عضو رسمی)'
-          leader: 'کاربران در سطح اعتماد 3 (منظم)'
-          elder: 'کاربران در سطح اعتماد 4 (رهبر)'
-          staff: "مدیر"
-          admins: 'کاربران مدیر'
-          moderators: 'مدیران'
-          blocked: 'کاربران مسدود شده'
-          suspended: 'کاربران تعلیق شده'
-          suspect: 'کاربران مشکوک'
-        reject_successful:
-          other: "کاربران %{count}  با موفقیت رد شدند"
-        reject_failures:
-          other: "رد کاربران %{count} ناموفق بود"
-        not_verified: "تایید نشده"
-        check_email:
-          text: "نشان دادن"
-      user:
-        suspend_failed: "در جریان به تعلیق درآوردن این کاربر اشتباهی رخ داد. {{error}}"
-        unsuspend_failed: "در جریان خارج کردن این کاربر از تعلیق، اشتباهی رخ داد {{error}}"
-        suspend_duration: "کاربر چه مدت در تعلیق خواهد بود؟"
-        suspend_duration_units: "(روز ها)"
-        suspend_reason_label: "شما چرا معلق شده‌اید؟ این متن بر روی صفحه‌ی نمایه‌ی کاربر <b/>برای همه قابل مشاهده خواهد بود<b>، و در هنگام ورود به سیستم نیز به خود کاربر نشان داده خواهد شد. لطفاً خلاصه بنویسید."
-        suspend_reason: "دلیل"
-        suspended_by: "تعلیق شده توسط"
-        delete_all_posts: "پاک کردن همهٔ نوشته‌ها"
-        delete_all_posts_confirm: "شما می خواهید تعداد %{posts}  نوشته و تعداد %{topics} موضوع خذف کنید،آیا مطمئن هستید؟"
-        suspend: "تعلیق"
-        unsuspend: "خارج کردن از تعلیق"
-        suspended: "تعلیق شد ؟"
-        moderator: "مدیر ؟ "
-        admin: "مدیر؟"
-        blocked: "مسدود شد ؟"
-        show_admin_profile: "مدیر"
-        edit_title: "ویرایش سرنویس"
-        save_title: "ذخیره سازی سرنویس"
-        refresh_browsers: "تازه کردن اجباری مرورگر"
-        refresh_browsers_message: "ارسال پیام به تمام مشتری ها! "
-        show_public_profile: "نماش نمایه همگانی"
-        impersonate: 'جعل هویت کردن'
-        ip_lookup: "مشاهده ای پی"
-        log_out: "خروج"
-        logged_out: "کاربر از کل دستگاه ها خارج شد."
-        revoke_admin: 'لغو مدیریت'
-        grant_admin: 'اعطای مدیریت'
-        revoke_moderation: 'پس گرفتن مدیریت'
-        grant_moderation: 'اعطای مدیریت'
-        unblock: 'قفل کردن'
-        block: 'عقب'
-        reputation: ' سابقه'
-        permissions: پروانه‌ها
-        activity: فعالیت
-        like_count: لایک‌های اعطایی/دریافتی
-        last_100_days: 'در 100 روز گذشته'
-        private_topics_count: موضوعات خصوصی
-        posts_read_count: خواندن نوشته ها
-        post_count: پست ایجاد شده
-        topics_entered: بازدید موضوعات
-        flags_given_count: پرچم های ارسالی
-        flags_received_count: پرچم های دریافتی
-        warnings_received_count: اخطار های دریافتی
-        flags_given_received_count: 'پرچم های  ارسالی / دریافتی'
-        approve: 'تصویب'
-        approved_by: "تصویب شده توسط"
-        approve_success: "کاربر تایید و ایمیل با دستورالعمل فعال سازی ارسال شد."
-        approve_bulk_success: "موفق!همه کاربران انتخاب شده تایید و اطلاعیه ارسال شد."
-        time_read: "زمان خوانده شده"
-        anonymize: "کاربر ناشناس"
-        anonymize_yes: "بله ، این یک حساب کاربری ناشناس است."
-        anonymize_failed: "یک مشکل با حساب کاربری ناشناس وجود دارد"
-        delete: "پاک کردن کاربر"
-        delete_forbidden_because_staff: "مدیران کل و مدیران را نمی‌توانید پاک کنید"
-        delete_posts_forbidden_because_staff: "نمی توان همه نوشته های مدیران کل و مدیران را خذف کرد"
-        delete_forbidden:
-          other: "نمی‌توانید کاربرانی را که موضوع دارند پاک کنید. پیش از تلاش برای پاک کردن کاربر، نخست همهٔ‌ موضوعاتش را پاک کنید. (موضوعات که بیش از %{count}  روز پیش فرستاده شده باشند، نمی‌توانند پاک شوند.)"
-        cant_delete_all_posts:
-          other: "نمی توان همه نوشته ها را خذف کرد. برخی نوشته ها قدیمی تر از %{count} هستند.(در delete_user_max_post_age setting.)"
-        cant_delete_all_too_many_posts:
-          other: "نمی توان همه نوشته ها را خذف کرد. چون تعداد کاربران از %{count} تعداد نوشته ها بیشتر است.(delete_all_posts_max)"
-        delete_confirm: "آیا مطمئن هستید که می خواهید این کاربر را حذف کنید ؟ این کار دائمی است!"
-        delete_and_block: "حذف و <b>مسدود</b>کن این آی پی و آدرس ایمل را"
-        delete_dont_block: "فقط حذف"
-        deleted: "کاربر پاک شد."
-        delete_failed: "خطایی در پاک کردن آن کاربر روی داد. پیش از تلاش برای پاک کردن کاربر، مطمئن شوید همهٔ‌ موضوعات پاک شوند."
-        send_activation_email: "فرستادن رایانامه فعال‌سازی"
-        activation_email_sent: "یک رایانامه فعال‌سازی فرستاده شده است."
-        send_activation_email_failed: "در فرستادن رایانامهٔ‌ فعال‌سازی دیگری مشکلی داریم.\n%{error}"
-        activate: "فعال‌سازی شناسه کاربری"
-        activate_failed: "در فعال‌سازی این کاربر مشکلی پیش آمد."
-        deactivate_account: "غیرفعال‌کردن شناسه کاربری"
-        deactivate_failed: "در غیرفعال کردن این کاربر مشکلی پیش آمد."
-        unblock_failed: 'در برداشتن قفل این کاربر مشکلی پیش آمد.'
-        block_failed: 'در قفل کردن این کاربر مشکلی پیش آمد.'
-        suspended_explanation: "کاربر تعلیق شده نمی‌تواند وارد سیستم شود."
-        block_explanation: "کاربر قفل شده نمی‌تواند نوشته ای بگذارد یا موضوعی آغاز کند."
-        trust_level_change_failed: "در تغییر سطح اعتماد کاربر مشکلی پیش آمد."
-        grant_admin_failed: "در اعطای اختیارات مدیریت مشکلی پیش آمد."
-        grant_moderation_failed: "یک مشکل در  اعطای امتیازات مدیریت وجود دارد."
-        suspend_modal_title: "کاربران تعلیق شده"
-        trust_level_2_users: "کاربران سطح اعتماد 2"
-        trust_level_3_requirements: "مقررات سطح اعتماد 3"
-        trust_level_locked_tip: "سطح اعتماد بسته شده است. سیستم قادر به ترفیع/تنزل درجه‌ی کاربر نیست."
-        trust_level_unlocked_tip: "سطح اعتماد باز شده است. سیستم قادر به ترفیع/تنزل درجه‌ی کاربر خواهد بود."
-        lock_trust_level: "بستن سطح اعتماد"
-        unlock_trust_level: "باز کردن سطح اعتماد"
-        tl3_requirements:
-          title: "شرایط لازم برای سطح اعتماد 3."
-          table_title: "در ۱۰۰ روز اخیر:"
-          value_heading: "مقدار"
-          requirement_heading: "نیازمندی‌ها"
-          visits: "نمایش ها"
-          days: "روز ها"
-          topics_replied_to: "پاسخ به موضوعات"
-          topics_viewed: "بازدید موضوعات"
-          topics_viewed_all_time: "موضوعات مشاهده شده ( تمام مدت )"
-          posts_read: "نوشته‌های خوانده شده"
-          posts_read_all_time: "نوشته‌های خوانده شده ( تمام مدت )"
-          flagged_posts: "نوشته‌های پرچم‌خورده"
-          flagged_by_users: "کاربرانی که پرچم خورده‌اند"
-          likes_given: "لایک‌های اعطایی"
-          likes_received: "لایک‌های دریافتی"
-          likes_received_days: "لایک‌های دریافتی: روزهای خاص"
-          likes_received_users: "لایک‌های دریافتی: کاربران خاص"
-          qualifies: "دارای صلاحیت برای سطح اعتماد 3."
-          does_not_qualify: "فاقد صلاحیت برای سطح اعتماد 3."
-          will_be_promoted: "به‌زودی ترفیع درجه خواهد گرفت."
-          will_be_demoted: "به‌زودی تنزل درجه خواهد گرفت."
-          locked_will_not_be_promoted: "سطح اعتماد بسته شده. دیگر ترفیع درجه نخواهد گرفت."
-          locked_will_not_be_demoted: "سطح اعتماد بسته شده. دیگر تنزل درجه نخواهد گرفت."
-        sso:
-          title: "ورود یکپارچه به سیستم"
-          external_id: "ای دی خارجی"
-          external_username: "نام کاربری"
-          external_name: "نام"
-          external_email: "ایمیل"
-          external_avatar_url: "URL تصویر نمایه"
-      user_fields:
-        title: "فیلد های کاربر"
-        help: "به فیلدهایی که کاربرانتان می‌توانند پر کنند اضافه کنید."
-        create: "ساخت فیلد برای کاربر"
-        untitled: "بدون عنوان"
-        name: "نام فیلد"
-        type: "نوع فیلد"
-        description: "توضیحات فیلد"
-        save: "ذخیره کردن"
-        edit: "ویرایش"
-        delete: "حذف"
-        cancel: "لغو کردن"
-        delete_confirm: "آیا از این که این فیلد کاربری را حذف می کنید مطمئن هستید ؟"
-        required:
-          title: "مورد نیاز در ثبت نام؟"
-          enabled: "ضروری"
-          disabled: "غیر ضروری"
-        editable:
-          title: "قابل ویرایش بعد از ثبت نام؟"
-          enabled: "قابل ویرایش"
-          disabled: "غیر قابل ویرایش"
-        show_on_profile:
-          title: "در نمایه عمومی نمایش داده شود؟"
-          enabled: "نمایش در نمایه"
-          disabled: "در نمایه نشان ندهد"
-        field_types:
-          text: 'فیلد متن'
-          confirm: 'تایید'
-      site_text:
-        none: "یک دسته‌ از محتویات را برای آغاز ویرایش انتخاب کنید."
-        title: 'محتویات متن'
-      site_settings:
-        show_overriden: 'تنها بازنویسی‌شده‌ها را نمایش بده'
-        title: 'تنظیمات'
-        reset: 'تنظیم مجدد'
-        none: 'هیچ کدام'
-        no_results: "چیزی یافت نشد."
-        clear_filter: "واضح"
-        add_url: "اضافه کردن URL"
-        categories:
-          all_results: 'همه'
-          required: 'ضروری'
-          basic: 'راه اندازی اولیه'
-          users: 'کاربران'
-          posting: 'در حال نوشتن'
-          email: 'رایانامه'
-          files: 'پرونده‌ها'
-          trust: 'سطح اعتماد'
-          security: 'امنیت'
-          onebox: "یک جعبه"
-          seo: 'SEO'
-          spam: 'هرزنامه'
-          rate_limits: 'میزان محدودیت'
-          developer: 'توسعه دهنده'
-          embedding: "توکاری"
-          legal: "حقوقی"
-          uncategorized: 'دیگر'
-          backups: "پشتیبان‌ها"
-          login: "ورود"
-          plugins: "افزونه ها"
-      badges:
-        title: مدال ها
-        new_badge: مدال جدید
-        new: جدید
-        name: نام
-        badge: مدال
-        display_name: نام نمایشی
-        description: توضیح
-        badge_type: نوع مدال
-        badge_grouping: گروه
-        badge_groupings:
-          modal_title: گروه بندی مدال
-        granted_by: اعطا شده توسط
-        granted_at: اعطا شده در
-        reason_help: (یک لینک به یک نوشته یا موضوع)
-        save: ذخیره سازی
-        delete: پاک کردن
-        delete_confirm: آیا مطمئنید که می‌خواهید این مدال را پاک کنید؟
-        revoke: بازیافت
-        reason: دلیل
-        expand: گستردن hellip&;
-        revoke_confirm: آیا مطمئنید که می‌خواهید این مدال را بازیافت کنید؟
-        edit_badges: ویرایش مدال‌ها
-        grant_badge: اعطای مدال
-        granted_badges: مدال ها اعطایی
-        grant: اهداء
-        no_user_badges: "%{name} هیچ مدالی دریافت نکرده است."
-        no_badges: مدالی برای اعطا کردن وجود ندارد.
-        none_selected: "برای شروع یک مدال رو انتخاب کنید"
-        allow_title: اجازه برای استفاده مدال در عنوان
-        multiple_grant: نمی توان چندین با اهداء کرد
-        listable: نشان دادن مدال در صفحه مدال های عمومی
-        enabled: به‌کارگیری مدال
-        icon: آیکن
-        image: تصویر
-        query: پرس جوی مدال (SQL)
-        target_posts: پرس و جو نوشته های هدف
-        trigger: گیره
-        trigger_type:
-          none: "به‌روزرسانی روزانه"
-          post_action: "هنگامی‌که کاربری روی نوشته ای کاری انجام می‌دهد"
-          post_revision: "هنگی که یک کاربر نوشته ای  ویرایش می‌کند یا فرستد"
-          trust_level_change: "هنگامی که کاربری سطح اعتماد را تغییر می‌دهد"
-          user_change: "هنگامی که کاربری ویرایش یا ساخته می‌شود"
-        preview:
-          link_text: "پیش نمایش مدال های اعطایی"
-          plan_text: "پیشنمایش با طرح پرس و جو"
-          modal_title: "پیشنمایش پرس و جو مدال "
-          sql_error_header: "خطایی با پرس و جو وجود دارد"
-          error_help: "پیروی کنید از پیوند برای کمک در رابطه با پرس جوی مدال ها"
-          bad_count_warning:
-            header: "هشدار!"
-          grant_count:
-            zero: "هیچ مدالی برای اختصاص دادن وجود ندارد"
-            one: "<b>1</b> مدال اختصاص داده شد."
-            other: "<B>٪ {COUNT} </ B> مدال ها اختصاص داده شد"
-          sample: "نمونه:"
-          grant:
-            with: <span class="username">%{username}</span>
-            with_post: <span class="username">%{username}</span> برای نوشته در %{link}
-            with_post_time: <span class="username">%{username}</span> برای نوشته %{link} در <span class="time">%{time}</span>
-            with_time: <span class="username">%{username}</span> در <span class="time">%{time}</span>
-      emoji:
-        title: "شکلک"
-        help: "اضافه کردن شکلک های جدید که در دسترس همگان خواهد بود. (PROTIP: کشیدن و رها کردن فایل های چندگانه در یک بار)"
-        add: "افزودن یک شکلک جدید"
-        name: "نام"
-        image: "تصویر"
-        delete_confirm: "آیا مطمئنید که می‌خواهید شکلک :{name}%: را پاک کنید؟"
-    lightbox:
-      download: "بارگیری"
-    search_help:
-      title: 'کمک جستجو'
-    keyboard_shortcuts_help:
-      title: 'میانبر‌های تخته‌کلید'
-      jump_to:
-        title: 'بپر به'
-        home: '<b>g</b>, <b>h</b> خانه (آخرین ها)'
-        latest: '<b>g</b>, <b>l</b>آخرین'
-        new: '<b>g</b>, <b>n</b> جدید'
-        unread: '<b>g</b>, <b>u</b> خوانده نشده'
-        categories: '<b>g</b>, <b>c</b> دسته بندی'
-        top: '<b>g</b>, <b>t</b> بالا ترین'
-      navigation:
-        title: 'راهبری'
-        jump: '<b>#</b> رفتن به نوشته #'
-        back: 'برگشت'
-        up_down: '<b>k</b>/<b>j</b> انتقال انتخاب شده &uarr; &darr;'
-        open: '<b>o</b> or <b>Enter</b> باز کردن موضوع انتخاب شده'
-        next_prev: '<b>shift</b>+<b>j</b>/<b>shift</b>+<b>k</b> بخش قبلی/بعدی'
-      application:
-        title: 'نرم‌افزار'
-        create: '<b>c</b> ساختن یک موضوع جدید'
-        notifications: '<b>n</b> باز کردن آگاه‌سازی‌ها'
-        site_map_menu: '<b>=</b> باز کردن منوی سایت'
-        user_profile_menu: '<b>p</b> باز کردن منوی کاربران'
-        show_incoming_updated_topics: '<b>.</b> نمایش موضوعات بروز شده'
-        search: '<b>/</b> جستجو'
-        help: '<b>?</b> باز کردن راهنمای کیبورد'
-        dismiss_new_posts: '<b>x</b>, <b>r</b>بستن جدید/نوشته ها '
-        dismiss_topics: '<b>x</b>, <b>t</b> بستن موضوعات'
-      actions:
-        title: 'عملیات'
-        bookmark_topic: '<b>f</b> تعویض نشانک موضوع'
-        pin_unpin_topic: '<b>shift</b>+<b>p</b> سنجاق /لغو ساجاق موضوع'
-        share_topic: '<b>shift</b>+<b>s</b> اشتراک گذاری نوشته'
-        share_post: 'به اشتراک‌گذاری نوشته'
-        reply_as_new_topic: '<b>t</b> پاسخگویی به عنوان یک موضوع لینک شده'
-        reply_topic: '<b>shift</b>+<b>r</b> پاسخ به موضوع'
-        reply_post: '<b>r</b> پاسخ به نوشته'
-        quote_post: 'نقل‌قول نوشته'
-        like: '<b>l</b> پسندیدن نوشته'
-        flag: '<b>!</b> پرچم‌گذاری نوشته'
-        bookmark: '<b>b</b> نشانک‌گذاری نوشته'
-        edit: '<b>e</b> ویرایش نوشته'
-        delete: '<b>d</b> پاک کردن نوشته'
-        mark_muted: '<b>m</b>, <b>m</b> بی صدا کردن موضوع'
-        mark_regular: '<b>m</b>, <b>r</b> تنظیم ( پیش فرض) موضوع'
-        mark_tracking: '<b>m</b>, <b>t</b> Track tموضوع'
-        mark_watching: '<b>m</b>, <b>w</b> مشاهده موضوع'
-    badges:
-      title: مدال‌ها
-      allow_title: "می تواند برای یک عنوان استفاده کنید"
-      multiple_grant: "می توان چندین بار اهدا کرد"
-      badge_count:
-        other: "%{count} مدال"
-      more_badges:
-        other: "+%{count} بیش‌تر"
-      granted:
-        other: "%{count} اعطا شد"
-      select_badge_for_title: انتخاب یک مدال برای استفاده در عنوان خود
-      none: "<none>"
-      badge_grouping:
-        getting_started:
-          name: شروع
-        community:
-          name: انجمن
-        trust_level:
-          name: سطح اعتماد
-        other:
-          name: دیگر
-        posting:
-          name: در حال نوشتن
-      badge:
-        editor:
-          name: ویرایش‌گر
-          description: نخستین ویرایش نوشته
-        basic_user:
-          name: اساسی
-          description: <a href="http://discours.ir/t/topic/98">اعطا کردن</a> تمام عملکرد های ضروری برای انجمن
-        member:
-          name: عضو
-          description: <a href="http://discours.ir/t/topic/98">اعطا کردن</a> دعوت نامه
-        regular:
-          name: منظم
-          description: '<a href="http://discours.ir/t/topic/98">اعطا کردن</
+        name: "نام دسته"
+      post:
+        raw: "متن"
+      user_profile:
+        bio_raw: "درباره من"
+    errors:
+      messages:
+        is_invalid: "نامعتبر است. تلاش کنید که کمی بیش‌تر توضیح بگذارید."
+        has_already_been_used: "موجود می باشد"
+      models:
+        topic:
+          attributes:
+            base:
+              warning_requires_pm: "شما فقط قادر به ضمیمه کردن اخطارها در پیام های خصوصی هستید."
+              too_many_users: "شما در هر بار می توانید به یک کاربر اخطار ها را ارسال نمایید."
+              cant_send_pm: "متأسفانه ، شما نمیتوانید به این کاربر پیام خصوصی بفرستید."
+              no_user_selected: "باید یک کاربر درست را انتخاب کنید"
+        user:
+          attributes:
+            password:
+              same_as_username: "همانند نام کاربری شما است. لطفا از رمز عبور امن تری استفاده نمایید."
+              same_as_email: "همانند ایمیل شما است. لطفا از رمز عبور امن تری استفاده نمایید."
+            ip_address:
+              signup_not_allowed: "ثبت نام از این حساب  ممنوع می باشد."
+        color_scheme_color:
+          attributes:
+            hex:
+              invalid: "این یک رنگ معتبر نیست"
+  vip_category_name: "زبان"
+  meta_category_name: "متا"
+  staff_category_name: "کارکنان"
+  category:
+    topic_prefix: "در رابطه با دسته بندی {category}% "
+    cannot_delete:
+      uncategorized: "بدون دسته بندی را نمی توان حذف کرد"
+      has_subcategories: "این دسته بندی به دلیل داشتن زیردسته قابل پاک شدن نیست."
+  trust_levels:
+    newuser:
+      title: "کاربر جدید"
+    basic:
+      title: "کاربر پایه"
+    regular:
+      title: "عضو"
+    leader:
+      title: "عمومی"
+    elder:
+      title: "رهبر"
+  rate_limiter:
+    slow_down: "شما این عمل را بیش از حد انجام داده اید، بعدا دوباره تلاش کنید"
+    hours:
+      other: "%{count} ساعت"
+    minutes:
+      other: "%{count} دقیقه"
+    seconds:
+      other: "%{count} ثانیه"
+  datetime:
+    distance_in_words:
+      half_a_minute: "< 1دقیقه"
+      less_than_x_seconds:
+        other: "< %{count}ثانیه"
+      x_seconds:
+        other: "%{count}ثانیه"
+      less_than_x_minutes:
+        other: "< %{count}دقیقه"
+      x_minutes:
+        other: "%{count}دقیقه"
+      about_x_hours:
+        other: "%{count}ساعت"
+      x_days:
+        other: "%{count}روز"
+      about_x_months:
+        other: "%{count}ماه"
+      x_months:
+        other: "%{count}ماه"
+      about_x_years:
+        other: "%{count}سال"
+      over_x_years:
+        other: "> %{count}سال"
+      almost_x_years:
+        other: "%{count}سال"
+    distance_in_words_verbose:
+      half_a_minute: "هم اکنون"
+      less_than_x_seconds:
+        other: "هم اکنون"
+      x_seconds:
+        other: "%{count} ثانیه قبل"
+      less_than_x_minutes:
+        other: "کمتر از %{count} دقیقه قبل"
+      x_minutes:
+        other: "%{count} دقیقه قبل"
+      about_x_hours:
+        other: "%{count} ساعت قبل"
+      x_days:
+        other: "%{count} روز قبل"
+      about_x_months:
+        other: "حدودا %{count} ماه قبل"
+      x_months:
+        other: "%{count} ماه قبل"
+      about_x_years:
+        other: "حدودا %{count} سال قبل"
+      over_x_years:
+        other: "بیش از %{count} سال قبل"
+      almost_x_years:
+        other: "حداقل %{count} سال قبل"
+  password_reset:
+    choose_new: "لطفا یک رمز عبور جدید وارد کنید"
+    choose: "لطفا یک رمز عبور وارد کنید"
+    update: 'به‌روز کردن گذرواژه'
+    save: 'تنظیم رمز عبور'
+    title: 'بازیابی گذرواژه'
+    success_unapproved: "شما با موفقیت رمز عبورتان را تغییر دادید."
+    continue: "برو به %{site_name}"
+  change_email:
+    confirmed: "ایمیل شما به روز شد."
+    please_continue: "برو به %{site_name}"
+  activation:
+    action: "حساب کاربریتان را فعال کنید"
+    continue_button: "برو به %{site_name}"
+    welcome_to: "به %{site_name} خوش آمدید!"
+  post_action_types:
+    spam:
+      title: 'هرزنامه'
+      long_form: 'نشانه گذاری به عنوان هرزنامه'
+      email_body: "%{link}\n\n%{message}"
+    inappropriate:
+      title: 'نامناسب'
+      long_form: 'این مورد نامناسب دانسته شد.'
+    notify_user:
+      title: 'پیام @{{username}}'
+      email_title: 'نوشته ی شما در "{title}%"'
+      email_body: "%{link}\n\n%{message}"
+    notify_moderators:
+      title: "یک چیز دیگر"
+      email_body: "%{link}\n\n%{message}"
+    bookmark:
+      title: 'نشانک گذاری'
+      description: 'نشنانک‌گذاری این دیدگاه'
+      long_form: 'این نوشته نشانک گذاری شد'
+    like:
+      title: 'پسندیدن'
+      description: 'پسندیدن این دیدگاه'
+      long_form: 'این مورد پسندیده شد'
+    vote:
+      title: 'امتیاز'
+      description: 'به این دیدگاه رای دهید'
+      long_form: 'به این دیدگاه رای داده شد'
+  topic_flag_types:
+    spam:
+      title: 'هرز نامه'
+    inappropriate:
+      title: 'نامناسب'
+    notify_moderators:
+      title: "یک چیز دیگر"
+      email_body: "%{link}\n\n%{message}"
+  unsubscribed:
+    title: 'اشتراک لغو شده'
+    description: "اشتراک شما لغو شد. دیگر با شما تماس نخواهیم گرفت!"
+    error: "خطا در لغو اشتراک"
+  reports:
+    visits:
+      title: "بازدید کاربران"
+      xaxis: "روز"
+      yaxis: "تعداد بازدید ها"
+    signups:
+      title: "کاربران جدید"
+      xaxis: "روز"
+      yaxis: "تعداد کاربران جدید"
+    topics:
+      title: "جُستارها"
+      xaxis: "روز"
+      yaxis: "تعداد جستارهای جدید"
+    posts:
+      title: "نوشته ها"
+      xaxis: "روز"
+      yaxis: "تعداد دیدگاه‌های جدید"
+    likes:
+      title: "پسندها"
+      xaxis: "روز"
+      yaxis: "شمار پسندهای تازه"
+    flags:
+      title: "پرچم ها"
+      xaxis: "روز"
+      yaxis: "تعداد پرچم ها"
+    bookmarks:
+      title: "نشانک ها"
+      xaxis: "روز"
+      yaxis: "تعداد نشانک های جدید"
+    starred:
+      title: "ستاره دار شد"
+      xaxis: "روز"
+      yaxis: "تعداد موضوعات تازه آغاز شده"
+    users_by_trust_level:
+      xaxis: "سطح اعتماد"
+      yaxis: "تعداد کاربران"
+    emails:
+      title: "ایمیل ها ارسال شد"
+      xaxis: "روز"
+      yaxis: "تعداد ایمیل ها"
+    user_to_user_private_messages:
+      title: "کاربر به کاربر"
+      xaxis: "روز"
+      yaxis: "تعداد پیام ها"
+    system_private_messages:
+      title: "سیستم"
+      xaxis: "روز"
+      yaxis: "تعداد پیام ها"
+    moderator_warning_private_messages:
+      title: "هشدل مدیر"
+      xaxis: "روز"
+      yaxis: "تعداد پیام ها"
+    notify_moderators_private_messages:
+      title: "اطلاعیه مدیران"
+      xaxis: "روز"
+      yaxis: "تعداد پیام ها"
+    notify_user_private_messages:
+      title: "اطلاعیه کاربر"
+      xaxis: "روز"
+      yaxis: "تعداد پیام ها"
+    top_referrers:
+      title: "رفتن به بالا"
+      xaxis: "کاربر"
+      num_clicks: "کلیک ها"
+      num_topics: "موضوعات"
+    top_traffic_sources:
+      title: "بالاترین ترافیک منابع"
+      xaxis: "دومین"
+      num_clicks: "کلیک ها"
+      num_topics: "موضوعات"
+      num_users: "کاربران"
+    top_referred_topics:
+      title: "بالاترین موضوعات مورد مراجعه"
+      xaxis: "موضوعات"
+      num_clicks: "کلیک ها"
+    page_view_anon_reqs:
+      title: "ناشناس"
+      xaxis: "روز"
+    page_view_logged_in_reqs:
+      title: "وارد شده در"
+      xaxis: "روز"
+    page_view_crawler_reqs:
+      title: "خزنده وب"
+      xaxis: "روز"
+    page_view_total_reqs:
+      title: "کل"
+      xaxis: "روز"
+    http_background_reqs:
+      title: "پس زمینه"
+      xaxis: "روز"
+    http_2xx_reqs:
+      xaxis: "روز"
+    http_3xx_reqs:
+      xaxis: "روز"
+    http_4xx_reqs:
+      title: "HTTP 4xx (ارور کلاینت)"
+      xaxis: "روز"
+    http_5xx_reqs:
+      title: "HTTP 5xx (ارور سرور)"
+      xaxis: "روز"
+      yaxis: "ارور سرور (وضعیت 5xx)"
+    http_total_reqs:
+      title: "مجموع"
+      xaxis: "روز"
+      yaxis: "کل درخواست ها"
+  content_types:
+    welcome_user:
+      title: "خوش آمدیده اید : کاربر جدید"
+    head:
+      title: "HTML head"
+  site_settings:
+    default_locale: "زبان پیشفرض برای دیسکورس  (ISO 639-1 کد)"
+    allow_user_locale: "اجازه برای کاربران تا بتوانند زبان مورد نظر خود را انتخاب نماییند"
+    title: "نام این وب سایت،استفاده شده در عنوان تگ"
+    show_subcategory_list: "نمایش زیر دسته بندی ها به جای لیست موضوع هنگام ورود به یک دسته بندی."
+    allow_moderators_to_create_categories: "اجازه دادن به مدیران برای ساخت دسته‌بندی‌های جدید"
+    enable_badges: "فعال سازی سیستم مدال دهی"
+    min_password_length: "حداقل طول رمز عبور"
+    suggested_topics: "نعداد موضوعات پیشنهادی در پایین هر موضوع"
+    allow_uploaded_avatars: "اجازه دادن به کاربران برای بارگذاری آواتارهای سفارشی"
+    enable_names: "نام کامل کاربران را در نمایه، کارت کاربری و ایمیل‌هایشان نمایش بده. قابلیت پنهان کردن نام کامل را در هرجایی غیرفعال کن."
+    enable_emoji: "فعالسازی ایموجی"
+    emoji_set: "می‌خواهید ایموجی شما چطور باشد؟"
+  search:
+    types:
+      category: 'دسته‌ها'
+      user: 'کاربران'
+  original_poster: "نویسنده اصلی"
+  move_posts:
+    new_topic_moderator_post:
+      other: "من {count}% تا از نوشته‌ها را به این موضوع جدید انتقال دادم: {topic_link}%"
+    existing_topic_moderator_post:
+      other: "من {count}% تا از نوشته‌ها را به این موضوع انتقال دادم: {topic_link}%"
+  change_owner:
+    post_revision_text: "حق مالکیت از کاربر {old_user}% به کاربر {new_user}% منتقل شد"
+  emoji:
+    errors:
+      name_already_exists: "متأسفیم، در حال حاضر نام '{name}%' توسط ایموجی دیگری استفاده می‌شود."
+      error_while_storing_emoji: "متأسفیم، در هنگام ذخیره‌سازی ایموجی خطایی رخ داده است."
+  topic_statuses:
+    closed_enabled: "این موضوع در حال حاضر بسته شده است. پاسخ جدید دیگر مجاز نیست."
+    closed_disabled: "موضوع اکنون باز است. پاسخ‌های جدید اجازه‌ی ثبت دارند."
+    autoclosed_enabled_days:
+      other: "این موضوع به صورت خود کار بعد از %{count} روز بسته شد. پاسخ جدید دیگر مجاز نیست."
+    autoclosed_enabled_hours:
+      other: "این موضوع به صورت خود کار بعد از %{count} ساعت بسته شد. پاسخ جدید دیگر مجاز نیست."
+    autoclosed_enabled_minutes:
+      other: "این موضوع به صورت خود کار بعد از %{count} دقیقه بسته شد. پاسخ جدید دیگر مجاز نیست."
+    autoclosed_enabled_lastpost_days:
+      other: "این موضوع به صورت خود کار بعد از %{count} روز بعد از آخرین پاسخ بسته شد. پاسخ جدید دیگر مجاز نیست."
+    autoclosed_enabled_lastpost_hours:
+      other: "این موضوع به صورت خود کار بعد از %{count} ساعت بعد از آخرین پاسخ بسته شد. پاسخ جدید دیگر مجاز نیست."
+    autoclosed_enabled_lastpost_minutes:
+      other: "این موضوع به صورت خود کار بعد از %{count} دقیقه بعد از آخرین پاسخ بسته شد. پاسخ جدید دیگر مجاز نیست."
+    autoclosed_disabled: "این موضوع اکنون باز است. پاسخ‌های جدید اجازه‌ی ثبت دارند."
+    autoclosed_disabled_lastpost: "این موضوع اکنون باز است. پاسخ‌های جدید اجازه‌ی ثبت دارند."
+  login:
+    incorrect_username_email_or_password: "نام کاربری، ایمیل یا رمز عبور نادرست"
+    active: "حساب کاربریتان فعال شده و آماده‌ی استفاده است."
+    not_allowed_from_ip_address: "شما نمی‌توانید با این آی‌پی آدرس وارد حساب کاربری {username}% شوید."
+    admin_not_allowed_from_ip_address: "شما نمی تواند با این اپی آدرس به عنوان مدیر وارد سیستم شوید."
+    suspended: "شما تا تاریخ {date}% نمی‌توانید وارید سیستم شوید."
+    suspended_with_reason: "شما تا تاریخ {date}% نمی‌توانید وارید سیستم شوید. علت مسدود شدن حسابتان: {reason}%"
+    errors: "{errors}%"
+    new_registrations_disabled: "ثبت حساب‌ کاربری جدید اکنون امکان‌پذیر نیست."
+    password_too_long: "رمزهای عبور به 200 کاراکتر محدود شده‌اند."
+  invite_password_instructions:
+    subject_template: "تنظیم رمز عبور برای حساب کاربری {site_name}%"
+  test_mailer:
+    text_body_template: |
+      This is a test email from
 
-            a> دعوت نامه تغییر دسته بندی، تغییر نام دهید، به دنبال کردن لینک ها و سالن'
-        leader:
-          name: رهبر
-          description: '<a href="http://discours.ir/t/topic/98">اعطا کردن</a>
+      [**%{base_url}**][0]
 
-            ویرایش سراسری، پین، بستن، بایگانی، تقسیم و ادغام'
-        welcome:
-          name: خوش آمدید
-          description: دریافت یک پسند
-        autobiographer:
-          name: نویسندهء شرح حال خود
-          description: فیلد کاربر <a href="/my/preferences">نمایه </a>اطلاعات
-        anniversary:
-          name: سالگرد
-          description: عضو فعال به مدت یک سال،ارسال شده حداقل یک بار
-        nice_post:
-          name: نوشته‌ی دلپذیر
-          description: دریافت 10 پسند در یک نوشته. این نشان را می توان چندین بار اعطا کرد
-        good_post:
-          name: نوشته‌ی خوب
-          description: دریافت 25 پسند در یک نوشته. این نشان را می توان چندین بار اعطا کرد
-        great_post:
-          name: نوشته‌ی عالی
-          description: دریافت 50 پسند در یک نوشته. این نشان را می توان چندین بار اعطا کرد
-        nice_topic:
-          name: موضوع دلپذیر
-          description: دریافت 10 پسند در یک موضوع. این نشان را می توان چندین بار اعطا کرد
-        good_topic:
-          name: موضوع خوب
-          description: دریافت 25 پسند در یک موضوع. این نشان را می توان چندین بار اعطا کرد
-        great_topic:
-          name: موضوع عالی
-          description: دریافت 50 پسند در یک موضوع. این نشان را می توان چندین بار اعطا کرد
-        nice_share:
-          name: ا‌شتراک‌گذاری دلپذیر
-          description: اشتراک گذاری نوشته با 25 بازدید کننده منحصر به فرد
-        good_share:
-          name: اشتراک‌گذاری خوب
-          description: اشتراک گذاری نوشته با 300 بازدید کننده منحصر به فرد
-        great_share:
-          name: اشتراک‌گذاری عالی
-          description: اشتراک گذاری نوشته با 1000 بازدید کننده منحصر به فرد
-        first_like:
-          name: نخستین پسند
-          description: نوشته ای را پسندید
-        first_flag:
-          name: پرچم نخست
-          description: نوشته را پرچم زد
-        first_share:
-          name: نخستین اشتراک‌گذاری
-          description: نوشته ای به اشتراک گذاشت
-        first_link:
-          name: پیوند نخست
-          description: لین های داخلی اضافه شده به دیگر موضوعات
-        first_quote:
-          name: نقل‌قول نخست
-          description: نقل قول یک کاربر
-        read_guidelines:
-          name: خواندن راهنما ها
-          description: خواندن <a href="/guidelines">آموزش های انجمن</a>
-        reader:
-          name: خواننده
-          description: مطالعه تمام نوشته‌هایی که موضوعشان بیش از 100 نوشته دارد.
-    google_search: |
-      <h2>جستجو با گوگل</h2>
+      Email deliverability is complicated. Here are a few important things you should check first:
+
+      - Be *sure* to set the `notification email` from: address correctly in your site settings. **The domain specified in the "from" address of the emails you send is the domain your email will be validated against**.
+
+      - Know how to view the raw source of the email in your mail client, so you can examine email headers for important clues. in Gmail, it is the "show original" option in the drop-down menu at the top right of each mail.
+
+      - **IMPORTANT:** Does your ISP have a reverse DNS record entered to associate the domain names and IP addresses you send mail from? [Test your Reverse PTR record][2] here. If your ISP does not enter the proper reverse DNS pointer record, it's very unlikely any of your email will be delivered.
+
+      - Is your domain's [SPF record][8] correct? [Test your SPF record][1] here. Note that TXT is the correct official record type for SPF.
+
+      - Is your domain's [DKIM record][3] correct? This will significantly improve email deliverability. [Test your DKIM record][7] here.
+
+      - If you run your own mail server, check to make sure the IPs of your mail server are [not on any email blacklists][4]. Also verify that it is definitely sending a fully-qualified hostname that resolves in DNS in its HELO message. If not, this will cause your email to be rejected by many mail services.
+
+      (The *easy* way is to create a free account on [Mandrill][md] or [Mailgun][mg] or [Mailjet][mj], which have free generous free mailing plans and will be fine for small communities. You'll still need to set up the SPF and DKIM records in your DNS, though!)
+
+      We hope you received this email deliverability test OK!
+
+      Good luck,
+
+      Your friends at [Discourse](http://www.discourse.org)
+
+      [0]: %{base_url}
+      [1]: http://www.kitterman.com/spf/validate.html
+      [2]: http://mxtoolbox.com/ReverseLookup.aspx
+      [3]: http://www.dkim.org/
+      [4]: http://whatismyipaddress.com/blacklist-check
+      [7]: http://dkimcore.org/tools/dkimrecordcheck.html
+      [8]: http://www.openspf.org/SPF_Record_Syntax
+      [md]: http://mandrill.com
+      [mg]: http://www.mailgun.com/
+      [mj]: https://www.mailjet.com/pricing
+  new_version_mailer_with_notes:
+    subject_template: "[%{site_name}] بروزرسانی در دسترس"
+  flags_reminder:
+    post_number: "نوشته"
+    subject_template:
+      other: "%{count} نشانه ها منتظر استفاده"
+  system_messages:
+    welcome_invite:
+      subject_template: "به %{site_name} خوش آمدید!"
+    pending_users_reminder:
+      subject_template:
+        other: "%{count} کاربران منتظر تایید"
+  user_notifications:
+    previous_discussion: "پاسخ‌های قبلی"
+    unsubscribe:
+      title: "لغو اشتراک"
+      description: "آیا تمایلی به دریافت این ایمیل‌ها ندارید؟ مشکلی نیست! اینجا را کلیک کنید تا اشتراک آن هم‌اکنون حذف شود."
+    visit_link_to_respond: "برای پاسخگویی، لینک {base_url}%{url}% را در مرورگر خود مشاهده کنید."
+    posted_by: "نوشته شده توسط {username}% در تاریخ {post_date}%"
+    user_replied:
+      subject_template: "[%{site_name}] %{topic_title}"
+      text_body_template: |
+        {message}%
+
+        {context}%
+
+        ---
+        {respond_instructions}%
+    user_quoted:
+      subject_template: "[%{site_name}] %{topic_title}"
+    user_mentioned:
+      subject_template: "[%{site_name}] %{topic_title}"
+    user_posted:
+      subject_template: "[%{site_name}] %{topic_title}"
+    user_posted_pm:
+      subject_template: "[%{site_name}] [PM] %{topic_title}"
+    digest:
+      subject_template: "[%{site_name}] خلاصه"
+      new_activity: "فعالیت جدید در موضوعات و نوشته‌های شما:"
+      top_topics: "نوشته‌های محبوب"
+      other_new_topics: "موضوعات محبوب"
+      click_here: "اینجا کلیک کنید"
+      from: "%{site_name} خلاصه"
+      read_more: "بیش‌تر بخوانید"
+      more_topics_category: "موضوعات جدید بیشتر"
+      posts:
+        other: "%{count} نوشته ها"
+  page_not_found:
+    popular_topics: "محبوب"
+    recent_topics: "اخیر"
+    see_more: "بیشتر"
+    search_title: "جستجو در این سایت"
+    search_google: "گوگل"
+  terms_of_service:
+    title: "شرایط استفاده از خدمات"
+  deleted: 'حذف شد'
+  upload:
+    unauthorized: "متأسفم، پرونده‌ای که می‌خواهید بارگذاری کنید معتبر نیست ( پسوندهای معتبر عبارتند از: {authorized_extensions}% )."
+    attachments:
+      too_large: "متأسفم، پرونده‌ای که می‌خواهید بارگذاری کنید بسیار بزرگ است! ( حداکثر حجم پرونده باید {max_size_kb}% کیلوبایت باشد. )"
+    images:
+      unknown_image_type: "متأسفم، اما به نظر می‌رسد پرونده‌ای که می‌خواهید بارگذاری کنید، از نوع «تصویر» نیست."
+  color_schemes:
+    base_theme_name: "پایه"
+  about: "درباره"
+  guidelines: "دستورالعمل های"
+  privacy: "خصوصی"
+  edit_this_page: "ویرایش این صحفه"
+  csv_export:
+    boolean_yes: "بله"
+    boolean_no: "خیر"
+  guidelines_topic:
+    title: "پرسش و پاسخ / دستورالعمل"
+    body: |
+      <a name="civilized"></a>
+
+      ## [This is a Civilized Place for Public Discussion](#civilized)
+
+      Please treat this discussion forum with the same respect you would a public park.  We, too, are a shared community resource &mdash; a place to share skills, knowledge and interests through ongoing conversation.
+
+      These are not hard and fast rules, merely aids to the human judgment of our community. Use these guidelines to keep this a clean, well-lighted place for civilized public discourse.
+
+      <a name="improve"></a>
+
+      ## [Improve the Discussion](#improve)
+
+      Help us make this a great place for discussion by always working to improve the discussion in some way, however small. If you are not sure your post adds to the conversation, think over what you want to say and try again later.
+
+      The topics discussed here matter to us, and we want you to act as if they matter to you, too. Be respectful of the topics and the people discussing them, even if you disagree with some of what is being said.
+
+      One way to improve the discussion is by discovering ones that are already happening. Please spend some time browsing the topics here before replying or starting your own, and you’ll have a better chance of meeting others who share your interests.
+
+      <a name="agreeable"></a>
+
+      ## [Be Agreeable, Even When You Disagree](#agreeable)
+
+      You may wish to respond to something by disagreeing with it. That’s fine. But, remember to _criticize ideas, not people_. Please avoid:
+
+      *   Name-calling.
+      *   Ad hominem attacks.
+      *   Responding to a post’s tone instead of its actual content.
+      *   Knee-jerk contradiction.
+
+      Instead, provide reasoned counter-arguments that improve the conversation.
+
+      <a name="participate"></a>
+
+      ## [Your Participation Counts](#participate)
+
+      The conversations we have here set the tone for everyone. Help us influence the future of this community by choosing to engage in discussions that make this forum an interesting place to be &mdash; and avoiding those that do not.
+
+      Discourse provides tools that enable the community to collectively identify the best (and worst) contributions: favorites, bookmarks, likes, flags, replies, edits, and so forth. Use these tools to improve your own experience, and everyone else’s, too.
+
+      Let’s try to leave our park better than we found it.
+
+      <a name="flag-problems"></a>
+
+      ## [If You See a Problem, Flag It](#flag-problems)
+
+      Moderators have special authority; they are responsible for this forum. But so are you. With your help, moderators can be community facilitators, not just janitors or police.
+
+      When you see bad behavior, don’t reply. It encourages the bad behavior by acknowledging it, consumes your energy, and wastes everyone’s time. _Just flag it_. If enough flags accrue, action will be taken, either automatically or by moderator intervention.
+
+      In order to maintain our community, moderators reserve the right to remove any content and any user account for any reason at any time. Moderators do not preview new posts in any way; the moderators and site operators take no responsibility for any content posted by the community.
+
+      <a name="be-civil"></a>
+
+      ## [Always Be Civil](#be-civil)
+
+      Nothing sabotages a healthy conversation like rudeness:
+
+      *   Be civil. Don’t post anything that a reasonable person would consider offensive, abusive, or hate speech.
+      *   Keep it clean. Don’t post anything obscene or sexually explicit.
+      *   Respect each other. Don’t harass or grief anyone, impersonate people, or expose their private information.
+      *   Respect our forum. Don’t post spam or otherwise vandalize the forum.
+
+      These are not concrete terms with precise definitions &mdash; avoid even the _appearance_ of any of these things. If you’re unsure, ask yourself how you would feel if your post was featured on the front page of the New York Times.
+
+      This is a public forum, and search engines index these discussions. Keep the language, links, and images safe for family and friends.
+
+      <a name="keep-tidy"></a>
+
+      ## [Keep It Tidy](#keep-tidy)
+
+      Make the effort to put things in the right place, so that we can spend more time discussing and less cleaning up. So:
+
+      *   Don’t start a topic in the wrong category.
+      *   Don’t cross-post the same thing in multiple topics.
+      *   Don’t post no-content replies.
+      *   Don’t divert a topic by changing it midstream.
+      *   Don’t sign your posts &mdash; every post has your profile information attached to it.
+
+      Rather than posting “+1” or “Agreed”, use the Like button. Rather than taking an existing topic in a radically different direction, use Reply as a Linked Topic.
+
+      <a name="stealing"></a>
+
+      ## [Post Only Your Own Stuff](#stealing)
+
+      You may not post anything digital that belongs to someone else without permission. You may not post descriptions of, links to, or methods for stealing someone’s intellectual property (software, video, audio, images), or for breaking any other law.
+
+      <a name="power"></a>
+
+      ## [Powered by You](#power)
+
+      This site is operated by your [friendly local staff](/about) and *you*, the community. If you have any further questions about how things should work here, open a new topic in the [meta category](/c/meta) and let's discuss! If there's a critical or urgent issue that can't be handled by a meta topic or flag, contact us via the [staff page](/about).
+
+      <a name="tos"></a>
+
+      ## [Terms of Service](#tos)
+
+      Yes, legalese is boring, but we must protect ourselves &ndash; and by extension, you and your data &ndash; against unfriendly folks. We have a [Terms of Service](/tos) describing your (and our) behavior and rights related to content, privacy, and laws. To use this service, you must agree to abide by our [TOS](/tos).
+  tos_topic:
+    title: "شرایط استفاده از خدمات"
+    body: |
+      The following terms and conditions govern all use of the %{company_domain} website and all content, services and products available at or through the website, including, but not limited to, %{company_domain} Forum Software, %{company_domain} Support Forums and the %{company_domain} Hosting service ("Hosting"), (taken together, the Website). The Website is owned and operated by %{company_full_name} ("%{company_name}"). The Website is offered subject to your acceptance without modification of all of the terms and conditions contained herein and all other operating rules, policies (including, without limitation, %{company_domain}’s [Privacy Policy](/privacy) and [Community Guidelines](/faq)) and procedures that may be published from time to time on this Site by %{company_name} (collectively, the "Agreement").
+
+      Please read this Agreement carefully before accessing or using the Website. By accessing or using any part of the web site, you agree to become bound by the terms and conditions of this agreement. If you do not agree to all the terms and conditions of this agreement, then you may not access the Website or use any services. If these terms and conditions are considered an offer by %{company_name}, acceptance is expressly limited to these terms. The Website is available only to individuals who are at least 13 years old.
+
+      <a name="1"></a>
+
+      ## [1. Your %{company_domain} Account](#1)
+
+      If you create an account on the Website, you are responsible for maintaining the security of your account and you are fully responsible for all activities that occur under the account. You must immediately notify %{company_name} of any unauthorized uses of your account or any other breaches of security. %{company_name} will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions.
+
+      <a name="2"></a>
+
+      ## [2. Responsibility of Contributors](#2)
+
+      If you post material to the Website, post links on the Website, or otherwise make (or allow any third party to make) material available by means of the Website (any such material, "Content"), You are entirely responsible for the content of, and any harm resulting from, that Content. That is the case regardless of whether the Content in question constitutes text, graphics, an audio file, or computer software. By making Content available, you represent and warrant that:
+
+      *   the downloading, copying and use of the Content will not infringe the proprietary rights, including but not limited to the copyright, patent, trademark or trade secret rights, of any third party;
+      *   if your employer has rights to intellectual property you create, you have either (i) received permission from your employer to post or make available the Content, including but not limited to any software, or (ii) secured from your employer a waiver as to all rights in or to the Content;
+      *   you have fully complied with any third-party licenses relating to the Content, and have done all things necessary to successfully pass through to end users any required terms;
+      *   the Content does not contain or install any viruses, worms, malware, Trojan horses or other harmful or destructive content;
+      *   the Content is not spam, is not machine- or randomly-generated, and does not contain unethical or unwanted commercial content designed to drive traffic to third party sites or boost the search engine rankings of third party sites, or to further unlawful acts (such as phishing) or mislead recipients as to the source of the material (such as spoofing);
+      *   the Content is not pornographic, does not contain threats or incite violence, and does not violate the privacy or publicity rights of any third party;
+      *   your content is not getting advertised via unwanted electronic messages such as spam links on newsgroups, email lists, blogs and web sites, and similar unsolicited promotional methods;
+      *   your content is not named in a manner that misleads your readers into thinking that you are another person or company; and
+      *   you have, in the case of Content that includes computer code, accurately categorized and/or described the type, nature, uses and effects of the materials, whether requested to do so by %{company_name} or otherwise.
+
+      <a name="3"></a>
+
+      ## [3. User Content License](#3)
+
+      User contributions are licensed under a [Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License](http://creativecommons.org/licenses/by-nc-sa/3.0/deed.en_US). Without limiting any of those representations or warranties, %{company_name} has the right (though not the obligation) to, in %{company_name}’s sole discretion (i) refuse or remove any content that, in %{company_name}’s reasonable opinion, violates any %{company_name} policy or is in any way harmful or objectionable, or (ii) terminate or deny access to and use of the Website to any individual or entity for any reason, in %{company_name}’s sole discretion. %{company_name} will have no obligation to provide a refund of any amounts previously paid.
+
+
+      <a name="4"></a>
+
+      ## [4. Payment and Renewal](#4)
+
+      ### General Terms
+
+      Optional paid services or upgrades may be available on the Website. When utilizing an optional paid service or upgrade, you agree to pay %{company_name} the monthly or annual subscription fees indicated. Payments will be charged on a pre-pay basis on the day you begin utilizing the service or upgrade and will cover the use of that service or upgrade for a monthly or annual subscription period as indicated. These fees are not refundable.
+
+      ### Automatic Renewal
+
+      Unless you notify %{company_name} before the end of the applicable subscription period that you want to cancel a service or upgrade, your subscription will automatically renew and you authorize us to collect the then-applicable annual or monthly subscription fee (as well as any taxes) using any credit card or other payment mechanism we have on record for you. Subscriptions can be canceled at any time.
+
+      <a name="5"></a>
+
+      ## [5. Services](#5)
+
+      ### Hosting, Support Services
+
+      Optional Hosting and Support services may be provided by %{company_name} under the terms and conditions for each such service. By signing up for a Hosting/Support or Support services account, you agree to abide by such terms and conditions.
+
+      <a name="6"></a>
+
+      ## [6. Responsibility of Website Visitors](#6)
+
+      %{company_name} has not reviewed, and cannot review, all of the material, including computer software, posted to the Website, and cannot therefore be responsible for that material’s content, use or effects. By operating the Website, %{company_name} does not represent or imply that it endorses the material there posted, or that it believes such material to be accurate, useful or non-harmful. You are responsible for taking precautions as necessary to protect yourself and your computer systems from viruses, worms, Trojan horses, and other harmful or destructive content. The Website may contain content that is offensive, indecent, or otherwise objectionable, as well as content containing technical inaccuracies, typographical mistakes, and other errors. The Website may also contain material that violates the privacy or publicity rights, or infringes the intellectual property and other proprietary rights, of third parties, or the downloading, copying or use of which is subject to additional terms and conditions, stated or unstated. %{company_name} disclaims any responsibility for any harm resulting from the use by visitors of the Website, or from any downloading by those visitors of content there posted.
+
+      <a name="7"></a>
+
+      ## [7. Content Posted on Other Websites](#7)
+
+      We have not reviewed, and cannot review, all of the material, including computer software, made available through the websites and webpages to which %{company_domain} links, and that link to %{company_domain}. %{company_name} does not have any control over those non-%{company_domain} websites and webpages, and is not responsible for their contents or their use. By linking to a non-%{company_domain} website or webpage, %{company_name} does not represent or imply that it endorses such website or webpage. You are responsible for taking precautions as necessary to protect yourself and your computer systems from viruses, worms, Trojan horses, and other harmful or destructive content. %{company_name} disclaims any responsibility for any harm resulting from your use of non-%{company_domain} websites and webpages.
+
+      <a name="8"></a>
+
+      ## [8. Copyright Infringement and DMCA Policy](#8)
+
+      As %{company_name} asks others to respect its intellectual property rights, it respects the intellectual property rights of others. If you believe that material located on or linked to by %{company_domain} violates your copyright, and if this website resides in the USA, you are encouraged to notify %{company_name} in accordance with %{company_name}’s [Digital Millennium Copyright Act](http://en.wikipedia.org/wiki/Digital_Millennium_Copyright_Act) ("DMCA") Policy. %{company_name} will respond to all such notices, including as required or appropriate by removing the infringing material or disabling all links to the infringing material. %{company_name} will terminate a visitor’s access to and use of the Website if, under appropriate circumstances, the visitor is determined to be a repeat infringer of the copyrights or other intellectual property rights of %{company_name} or others. In the case of such termination, %{company_name} will have no obligation to provide a refund of any amounts previously paid to %{company_name}.
+
+      <a name="9"></a>
+
+      ## [9. Intellectual Property](#9)
+
+      This Agreement does not transfer from %{company_name} to you any %{company_name} or third party intellectual property, and all right, title and interest in and to such property will remain (as between the parties) solely with %{company_name}. %{company_name}, %{company_domain}, the %{company_domain} logo, and all other trademarks, service marks, graphics and logos used in connection with %{company_domain}, or the Website are trademarks or registered trademarks of %{company_name} or %{company_name}’s licensors. Other trademarks, service marks, graphics and logos used in connection with the Website may be the trademarks of other third parties. Your use of the Website grants you no right or license to reproduce or otherwise use any %{company_name} or third-party trademarks.
+
+      <a name="10"></a>
+
+      ## [10. Advertisements](#10)
+
+      %{company_name} reserves the right to display advertisements on your content unless you have purchased an Ad-free Upgrade or a Services account.
+
+      <a name="11"></a>
+
+      ## [11. Attribution](#11)
+
+      %{company_name} reserves the right to display attribution links such as ‘Powered by %{company_domain},’ theme author, and font attribution in your content footer or toolbar. Footer credits and the %{company_domain} toolbar may not be removed regardless of upgrades purchased.
+
+      <a name="12"></a>
+
+      ## [12. Changes](#12)
+
+      %{company_name} reserves the right, at its sole discretion, to modify or replace any part of this Agreement. It is your responsibility to check this Agreement periodically for changes. Your continued use of or access to the Website following the posting of any changes to this Agreement constitutes acceptance of those changes. %{company_name} may also, in the future, offer new services and/or features through the Website (including, the release of new tools and resources). Such new features and/or services shall be subject to the terms and conditions of this Agreement.
+
+      <a name="13"></a>
+
+      ## [13. Termination](#13)
+
+      %{company_name} may terminate your access to all or any part of the Website at any time, with or without cause, with or without notice, effective immediately. If you wish to terminate this Agreement or your %{company_domain} account (if you have one), you may simply discontinue using the Website. All provisions of this Agreement which by their nature should survive termination shall survive termination, including, without limitation, ownership provisions, warranty disclaimers, indemnity and limitations of liability.
+
+      <a name="14"></a>
+
+      ## [14. Disclaimer of Warranties](#14)
+
+      The Website is provided "as is". %{company_name} and its suppliers and licensors hereby disclaim all warranties of any kind, express or implied, including, without limitation, the warranties of merchantability, fitness for a particular purpose and non-infringement. Neither %{company_name} nor its suppliers and licensors, makes any warranty that the Website will be error free or that cess thereto will be continuous or uninterrupted. If you’re actually reading this, here’s [a treat](http://www.newyorker.com/online/blogs/shouts/2012/12/the-hundred-best-lists-of-all-time.html). You understand that you download from, or otherwise obtain content or services through, the Website at your own discretion and risk.
+
+      <a name="15"></a>
+
+      ## [15. Limitation of Liability](#15)
+
+      In no event will %{company_name}, or its suppliers or licensors, be liable with respect to any subject matter of this agreement under any contract, negligence, strict liability or other legal or equitable theory for: (i) any special, incidental or consequential damages; (ii) the cost of procurement for substitute products or services; (iii) for interruption of use or loss or corruption of data; or (iv) for any amounts that exceed the fees paid by you to %{company_name} under this agreement during the twelve (12) month period prior to the cause of action. %{company_name} shall have no liability for any failure or delay due to matters beyond their reasonable control. The foregoing shall not apply to the extent prohibited by applicable law.
+
+      <a name="16"></a>
+
+      ## [16. General Representation and Warranty](#16)
+
+      You represent and warrant that (i) your use of the Website will be in strict accordance with the %{company_name} [Privacy Policy](/privacy), [Community Guidelines](/guidelines), with this Agreement and with all applicable laws and regulations (including without limitation any local laws or regulations in your country, state, city, or other governmental area, regarding online conduct and acceptable content, and including all applicable laws regarding the transmission of technical data exported from the country in which this website resides or the country in which you reside) and (ii) your use of the Website will not infringe or misappropriate the intellectual property rights of any third party.
+
+      <a name="17"></a>
+
+      ## [17. Indemnification](#17)
+
+      You agree to indemnify and hold harmless %{company_name}, its contractors, and its licensors, and their respective directors, officers, employees and agents from and against any and all claims and expenses, including attorneys’ fees, arising out of your use of the Website, including but not limited to your violation of this Agreement.
+
+      <a name="18"></a>
+
+      ## [18. Miscellaneous](#18)
+
+      This Agreement constitutes the entire agreement between %{company_name} and you concerning the subject matter hereof, and they may only be modified by a written amendment signed by an authorized executive of %{company_name}, or by the posting by %{company_name} of a revised version. Except to the extent applicable law, if any, provides otherwise, this Agreement, any access to or use of the Website will be governed by the laws of the state of California, U.S.A., excluding its conflict of law provisions, and the proper venue for any disputes arising out of or relating to any of the same will be the state and federal courts located in San Francisco County, California. Except for claims for injunctive or equitable relief or claims regarding intellectual property rights (which may be brought in any competent court without the posting of a bond), any dispute arising under this Agreement shall be finally settled in accordance with the Comprehensive Arbitration Rules of the Judicial Arbitration and Mediation Service, Inc. (“JAMS”) by three arbitrators appointed in accordance with such Rules. The arbitration shall take place in San Francisco, California, in the English language and the arbitral decision may be enforced in any court. The prevailing party in any action or proceeding to enforce this Agreement shall be entitled to costs and attorneys’ fees. If any part of this Agreement is held invalid or unenforceable, that part will be construed to reflect the parties’ original intent, and the remaining portions will remain in full force and effect. A waiver by either party of any term or condition of this Agreement or any breach thereof, in any one instance, will not waive such term or condition or any subsequent breach thereof. You may assign your rights under this Agreement to any party that consents to, and agrees to be bound by, its terms and conditions; %{company_name} may assign its rights under this Agreement without condition. This Agreement will be binding upon and will inure to the benefit of the parties, their successors and permitted assigns.
+
+      This document is CC-BY-SA. It was last updated May 31, 2013.
+
+      Originally adapted from the [WordPress Terms of Service](http://en.wordpress.com/tos/).
+  privacy_topic:
+    title: "سیاست حفظ حریم خصوصی"
+    body: |
+      <a name="collect"></a>
+
+      ## [What information do we collect?](#collect)
+
+      We collect information from you when you register on our site and gather data when you participate in the forum by reading, writing, and evaluating the content shared here.
+
+      When registering on our site, you may be asked to enter your name and e-mail address. You may, however, visit our site without registering. Your e-mail address will be verified by an email containing a unique link. If that link is visited, we know that you control the e-mail address.
+
+      When registered and posting, we record the IP address that the post originated from. We also may retain server logs which include the IP address of every request to our server.
+
+      <a name="use"></a>
+
+      ## [What do we use your information for?](#use)
+
+      Any of the information we collect from you may be used in one of the following ways:
+
+      *   To personalize your experience &mdash; your information helps us to better respond to your individual needs.
+      *   To improve our site &mdash; we continually strive to improve our site offerings based on the information and feedback we receive from you.
+      *   To improve customer service &mdash; your information helps us to more effectively respond to your customer service requests and support needs.
+      *   To send periodic emails &mdash; The email address you provide may be used to send you information, notifications that you request about changes to topics or in response to your user name, respond to inquiries, and/or other requests or questions.
+
+      <a name="protect"></a>
+
+      ## [How do we protect your information?](#protect)
+
+      We implement a variety of security measures to maintain the safety of your personal information when you enter, submit, or access your personal information.
+
+      <a name="data-retention"></a>
+
+      ## [What is your data retention policy?](#data-retention)
+
+      We will make a good faith effort to:
+
+      *   Retain server logs containing the IP address of all requests to this server no more than 90 days.
+      *   Retain the IP addresses associated with registered users and their posts no more than 5 years.
+
+      <a name="cookies"></a>
+
+      ## [Do we use cookies?](#cookies)
+
+      Yes. Cookies are small files that a site or its service provider transfers to your computer's hard drive through your Web browser (if you allow). These cookies enable the site to recognize your browser and, if you have a registered account, associate it with your registered account.
+
+      We use cookies to understand and save your preferences for future visits and compile aggregate data about site traffic and site interaction so that we can offer better site experiences and tools in the future. We may contract with third-party service providers to assist us in better understanding our site visitors. These service providers are not permitted to use the information collected on our behalf except to help us conduct and improve our business.
+
+      <a name="disclose"></a>
+
+      ## [Do we disclose any information to outside parties?](#disclose)
+
+      We do not sell, trade, or otherwise transfer to outside parties your personally identifiable information. This does not include trusted third parties who assist us in operating our site, conducting our business, or servicing you, so long as those parties agree to keep this information confidential. We may also release your information when we believe release is appropriate to comply with the law, enforce our site policies, or protect ours or others rights, property, or safety. However, non-personally identifiable visitor information may be provided to other parties for marketing, advertising, or other uses.
+
+      <a name="third-party"></a>
+
+      ## [Third party links](#third-party)
+
+      Occasionally, at our discretion, we may include or offer third party products or services on our site. These third party sites have separate and independent privacy policies. We therefore have no responsibility or liability for the content and activities of these linked sites. Nonetheless, we seek to protect the integrity of our site and welcome any feedback about these sites.
+
+      <a name="coppa"></a>
+
+      ## [Children's Online Privacy Protection Act Compliance](#coppa)
+
+      Our site, products and services are all directed to people who are at least 13 years old or older. If this server is in the USA, and you are under the age of 13, per the requirements of COPPA ([Children's Online Privacy Protection Act](http://en.wikipedia.org/wiki/Children)), do not use this site.
+
+      <a name="online"></a>
+
+      ## [Online Privacy Policy Only](#online)
+
+      This online privacy policy applies only to information collected through our site and not to information collected offline.
+
+      <a name="consent"></a>
+
+      ## [Your Consent](#consent)
+
+      By using our site, you consent to our web site privacy policy.
+
+      <a name="changes"></a>
+
+      ## [Changes to our Privacy Policy](#changes)
+
+      If we decide to change our privacy policy, we will post those changes on this page.
+
+      This document is CC-BY-SA. It was last updated May 31, 2013.
+  static:
+    search_help: |
+      <h2>راهنمایی</h2>
       <p>
-        <form action='//google.com/search' id='google-search' onsubmit="document.getElementById('google-query').value = 'site:' + window.location.host + ' ' + document.getElementById('user-query').value; return true;">
-          <input type="text" id='user-query' value="">
-          <input type='hidden' id='google-query' name="q">
-          <button class="btn btn-primary">گوگل</button>
-        </form>
+      <ul>
+        <li>Title matches are prioritized, so when in doubt, search for titles</li>
+        <li>Unique, uncommon words will always produce the best results</li>
+        <li>Whenever possible, scope your search to a particular category, user, or topic</li>
+      </ul>
       </p>
+      <h2>گزینه ها</h2>
+      <p>
+        <table>
+        <tr><td><code>order:views</code></td><td><code>order:latest</code></td><td colspan=3></td></tr>
+        <tr><td><code>status:open</code></td><td><code>status:closed</code></td><td><code>status:archived</code></td><td><code>status:noreplies</code></td><td><code>status:singleuser</code></td></tr>
+        <tr><td><code>category:foo</code></td><td><code>user:foo</code></td><td colspan=3></td></tr>
+        <tr><td><code>in:likes</code></td><td><code>in:posted</code></td><td><code>in:watching</code></td><td><code>in:tracking</code></td><td><code>in:private</code></td></tr>
+        <tr><td><code>in:bookmarks</code></td><td colspan=4></td></tr>
+        </table>
+      </p>
+      <p>
+        <code>rainbows category:parks status:open order:latest</code> will search for topics containing the word "rainbows" in the category "parks" that are not closed or archived, ordered by date of last post.
+      </p>
+  badges:
+    long_descriptions:
+      autobiographer: |
+        اه اه اه
+        اه اه اه
+      first_like: |
+        اه اه اه
+        اه اه اه
+      first_link: |
+        اه اه اه
+        اه اه اه
+      first_quote: |
+        اه اه اه
+        اه اه اه
+      first_share: |
+        اه اه اه
+        اه اه اه
+      read_guidelines: |
+        اه اه اه
+        اه اه اه
+      reader: |
+        اه اه اه
+        اه اه اه
+      editor: |
+        اه اه اه
+        اه اه اه
+      nice_share: |
+        اه اه اه
+        اه اه اه
+      welcome: |
+        اه اه اه
+        اه اه اه
+      anniversary: |
+        اه اه اه
+        اه اه اه
+      good_share: |
+        اه اه اه
+        اه اه اه
+      great_share: |
+        اه اه اه
+        اه اه اه
+      nice_post: |
+        اه اه اه
+        اه اه اه
+      nice_topic: |
+        اه اه اه
+        اه اه اه
+      good_post: |
+        اه اه اه
+        اه اه اه
+      good_topic: |
+        اه اه اه
+        اه اه اه
+      great_post: |
+        اه اه اه
+        اه اه اه
+      great_topic: |
+        اه اه اه
+        اه اه اه
+      basic: |
+        اه اه اه
+        اه اه اه
+      member: |
+        اه اه اه
+        اه اه اه
+      regular: |
+        اه اه اه
+        اه اه اه
+      leader: |
+        اه اه اه
+        اه اه اه


### PR DESCRIPTION
1: Update persian translate
2: It adds a pluralization rule to fa_IR.js.erb. The rule always returns 'other'. This is because the fa_IR translation files do not use the 'one' key for pluralization.
Persian does not distinguish between the singular and plural forms
of nouns in the same way as English does. For numbered elements,
always return the 'other' key from the translation file.