### PR TITLE
FIX: include topic excerpt in topic/message invite mail for existing user

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1771,16 +1771,34 @@ en:
     user_invited_to_private_message_pm:
       subject_template: "[%{site_name}] %{username} invited you to a message '%{topic_title}'"
       text_body_template: |
-        %{username} invited you to a message '%{topic_title}' on %{site_name}:
 
-        Please visit this link to view the topic: %{base_url}%{url}
+        %{username} invited you to a message
+
+        > **%{topic_title}**
+        >
+        > %{topic_excerpt}
+
+        at
+
+        > %{site_title} -- %{site_description}
+
+        Please visit this link to view the message: %{base_url}%{url}
 
     user_invited_to_topic:
       subject_template: "[%{site_name}] %{username} invited you to a topic '%{topic_title}'"
       text_body_template: |
-        %{username} invited you to a topic '%{topic_title}' on %{site_name}:
 
-        Please visit this link to view the topic: %{base_url}%{url}
+        %{username} invited you to a discussion
+
+        > **%{topic_title}**
+        >
+        > %{topic_excerpt}
+
+        at
+
+        > %{site_title} -- %{site_description}
+
+        Please visit this link to view the message: %{base_url}%{url}
 
     user_replied:
       subject_template: "[%{site_name}] %{topic_title}"


### PR DESCRIPTION
Reported [here](https://meta.discourse.org/t/inviting-user-to-a-topic-message-sends-out-incorrect-email/27254/3?u=techapj)