### PR TITLE
Fix italics/bold WYSIWYG bug with nothing highlighted.

### DIFF
--- a/app/assets/javascripts/discourse/lib/Markdown.Editor.js
+++ b/app/assets/javascripts/discourse/lib/Markdown.Editor.js
@@ -1550,13 +1550,13 @@
 
         // Don't show the fallback text if more than one line is selected,
         // it's probably a break between paragraphs.
-        if(lines.length > 1) {
-          fallbackText = ""
+        if (lines.length > 1) {
+            fallbackText = "";
         }
 
         for(var i=0; i<lines.length; i++) {
             // Split before, selection and after up.
-            var lineMatch = lines[i].match(/^(\**)(.*?)(\**)$/);
+            var lineMatch = lines[i].match(/^(\s*\**)(.*?)(\**\s*)$/);
 
             var newChunk = new Chunks();
             newChunk.before = lineMatch[1];
@@ -1564,8 +1564,16 @@
             newChunk.after = lineMatch[3];
 
             this.doSurroundLine(newChunk, postProcessing, nStars, fallbackText);
-            lines[i] = newChunk.before + newChunk.selection + newChunk.after;
+
+            if (lines.length > 1) {
+                lines[i] = newChunk.before + newChunk.selection + newChunk.after;
+            } else {
+                realChunk.startTag = newChunk.before;
+                realChunk.endTag = newChunk.after;
+                lines[i] = newChunk.selection;
+            }
         }
+
         realChunk.selection = lines.join("\n");
     };
 
@@ -1591,11 +1599,11 @@
             }
 
             // Only operate if it's not a blank line
-            if(chunk.selection) {
-              // Add the true markup.
-              var markup = nStars === 1 ? "*" : "**";
-              chunk.before = chunk.before + markup;
-              chunk.after = markup + chunk.after;
+            if (chunk.selection) {
+                // Add the true markup.
+                var markup = nStars === 1 ? "*" : "**";
+                chunk.before = chunk.before + markup;
+                chunk.after = markup + chunk.after;
             }
         }
     };


### PR DESCRIPTION
This bug was reported here: https://meta.discourse.org/t/ctrl-b-selects-asterisks/27215 - It was something I broke whilst writing PR3288.

The fix checks if it is a multiline selection, if it is not (which includes blank selections) it will leave the asterisks unhighlighted.

Also fix a bug where asterisks would not be stripped if there was whitespace at the beginning of a line in a multiline selection.

Also fix styling issues I missed last time so that it matches the rest of the document. Specifically, 4 character tabs and spaces after "if"s.