### PR TITLE
rounding the post-count squares in topic summaries

### DIFF
--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -350,12 +350,13 @@ a.star {
     }
     .post-count {
       position: absolute;
-      top: 2px;
-      right: 6px;
-      padding: 0 4px;
+      right: 3px;
+      border-radius: 100px;
+      padding: 4px 5px 2px 5px;
+      text-align: center;
       font-weight: normal;
       font-size: 11px;
-      line-height: 14px;
+      line-height: 1;
     }
   }
 

--- a/app/assets/stylesheets/mobile/topic-post.scss
+++ b/app/assets/stylesheets/mobile/topic-post.scss
@@ -188,14 +188,14 @@ a.star {
     }
     .post-count {
       position: absolute;
-      top: 2px;
-      right: 6px;
-      padding: 0 4px;
+      right: 3px;
+      border-radius: 100px;
+      padding: 4px 5px 2px 5px;
+      text-align: center;
       font-weight: normal;
       font-size: 11px;
-      line-height: 14px;
+      line-height: 1;
     }
-
   }
 
   /* in expanded avatar view, limit to one line for now */
@@ -500,4 +500,3 @@ span.highlighted {
 .read-state {
   display: none;
 }
-


### PR DESCRIPTION
As discussed here: https://meta.discourse.org/t/round-number-count-badges-everywhere/27263

![screenshot 2015-04-08 16 33 28](https://cloud.githubusercontent.com/assets/1681963/7054798/019f570e-de0d-11e4-841a-45a68905a4e5.png)


 :large_blue_circle: :white_circle: :red_circle: 