### PR TITLE
Make avatars in oneboxes round, too

### DIFF
--- a/app/assets/stylesheets/common/base/onebox.scss
+++ b/app/assets/stylesheets/common/base/onebox.scss
@@ -142,6 +142,8 @@ aside.onebox {
 .onebox-avatar {
   height: 90px !important;
   width: 90px !important;
+  border-radius: 50%;
+  box-shadow: 0 0 6px 0 rgba(0, 0, 0, .3);
 }
 
 blockquote {


### PR DESCRIPTION
Also adds a subtle shaded border around the avatar to smooth over the perceived greater gap between avatar and content.

See https://meta.discourse.org/t/round-avatars-in-topic-list/27098/106?u=elberet