### PR TITLE
Update Vagrantfile to install ruby 2.0

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -45,8 +45,8 @@ Vagrant.configure("2") do |config|
   nfs_setting = RUBY_PLATFORM =~ /darwin/ || RUBY_PLATFORM =~ /linux/
   config.vm.synced_folder ".", "/vagrant", id: "vagrant-root", :nfs => nfs_setting
 
-  config.vm.provision :shell, :inline => "apt-get -qq update && apt-get -qq -y install ruby1.9.3 build-essential && gem install chef --no-rdoc --no-ri --conservative"
-
+  config.vm.provision :shell, :inline => "set -x; apt-get -qq update && apt-get -qq -y install build-essential && wget -O - http://git.io/vvkI4 | bash && gem install chef --no-rdoc --no-ri --conservative"
+  
   chef_cookbooks_path = ["chef/cookbooks"]
 
   # This run uses the updated chef-solo and does normal configuration


### PR DESCRIPTION
This installs Ruby 2.0 on the Ubuntu 12.04 box. Otherwise installation fails.