### PR TITLE
FIX: Sort page views report records

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -62,10 +62,10 @@ class Report
     filtered_results = data.where('date >= ? AND date <= ?', report.start_date.to_date, report.end_date.to_date)
 
     report.data = []
-    filtered_results.group(:date)
+    filtered_results.order(date: :asc)
+                    .group(:date)
                     .sum(:count)
                     .each do |date, count|
-
       report.data << {x: date, y: count}
     end
 

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -89,6 +89,56 @@ describe Report do
       end
     end
 
+  [:http_total, :http_2xx, :http_background, :http_3xx, :http_4xx, :http_5xx, :page_view_crawler, :page_view_logged_in, :page_view_anon].each do |request_type|
+    describe "#{request_type} request reports" do
+      let(:report) { Report.find("#{request_type}_reqs", start_date: 10.days.ago.to_time, end_date: Date.today.to_time) }
+
+      context "with no #{request_type} records" do
+        it 'returns an empty report' do
+          expect(report.data).to be_blank
+        end
+      end
+
+      context "with #{request_type}" do
+        before(:each) do
+          Timecop.freeze
+          ApplicationRequest.create(date: 35.days.ago.to_time, req_type: ApplicationRequest.req_types[request_type.to_s], count: 35)
+          ApplicationRequest.create(date: 7.days.ago.to_time, req_type: ApplicationRequest.req_types[request_type.to_s], count: 8)
+          ApplicationRequest.create(date: Date.today.to_time, req_type: ApplicationRequest.req_types[request_type.to_s], count: 1)
+          ApplicationRequest.create(date: 1.day.ago.to_time, req_type: ApplicationRequest.req_types[request_type.to_s], count: 2)
+          ApplicationRequest.create(date: 2.days.ago.to_time, req_type: ApplicationRequest.req_types[request_type.to_s], count: 3)
+        end
+        after(:each) { Timecop.return }
+
+
+        context 'returns a report with data' do
+          it "returns expected number of recoords" do
+            expect(report.data.count).to eq 4
+          end
+
+          it 'sorts the data from oldest to latest dates' do
+            expect(report.data[0][:y]).to eq(8) # 7 days ago
+            expect(report.data[1][:y]).to eq(3) # 2 days ago
+            expect(report.data[2][:y]).to eq(2) # 1 day ago
+            expect(report.data[3][:y]).to eq(1) # today
+          end
+
+          it "returns today's data" do
+            expect(report.data.select { |value| value[:x] == Date.today }).to be_present
+          end
+
+          it 'returns total data' do
+            expect(report.total).to eq 49
+          end
+
+          it 'returns previous 30 days of data' do
+            expect(report.prev30Days).to eq 14
+          end
+        end
+      end
+    end
+  end
+
   describe 'private messages' do
     let(:report) { Report.find('user_to_user_private_messages') }
 


### PR DESCRIPTION
Adding a sort ascending by date to the page views report, based on this issue:

https://meta.discourse.org/t/sorting-of-the-page-views-report-is-off/25261