### PR TITLE
FIX: scale large vertial images for onebox

### DIFF
--- a/app/assets/stylesheets/common/base/onebox.scss
+++ b/app/assets/stylesheets/common/base/onebox.scss
@@ -131,7 +131,7 @@ aside.onebox {
 
     img {
       max-height: 80%;
-      max-width: 25%;
+      max-width: 20%;
       height: auto;
       float: left;
       margin-right: 10px;


### PR DESCRIPTION
Before:

![screen shot 2015-04-14 at 8 07 05 am](https://cloud.githubusercontent.com/assets/5732281/7129431/e1b36078-e27d-11e4-993c-5d114e6bb6c8.png)

![screen shot 2015-04-14 at 7 58 14 am](https://cloud.githubusercontent.com/assets/5732281/7129360/011406f8-e27d-11e4-940b-9fcb77f03c08.png)

After:

![screen shot 2015-04-14 at 8 11 07 am](https://cloud.githubusercontent.com/assets/5732281/7129432/e59d520c-e27d-11e4-8b5b-fa9003b4896e.png)

![screen shot 2015-04-14 at 7 58 44 am](https://cloud.githubusercontent.com/assets/5732281/7129362/0226b4d2-e27d-11e4-9278-bc360f721d8f.png)