### PR TITLE
indicate that lists can be pasted if pipe-delimited

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -850,8 +850,8 @@ en:
     enable_badges: "Enable the badge system"
 
     allow_index_in_robots_txt: "Specify in robots.txt that this site is allowed to be indexed by web search engines."
-    email_domains_blacklist: "A list of email domains that users are not allowed to register accounts with. Example: mailinator.com trashmail.net"
-    email_domains_whitelist: "A list of email domains that users MUST register accounts with. WARNING: Users with email domains other than those listed will not be allowed!"
+    email_domains_blacklist: "A pipe-delimited list of email domains that users are not allowed to register accounts with. Example: mailinator.com|trashmail.net"
+    email_domains_whitelist: "A pipe-delimited list of email domains that users MUST register accounts with. WARNING: Users with email domains other than those listed will not be allowed!"
     forgot_password_strict: "Don't inform users of an account's existance when they use the forgot password dialog."
     log_out_strict: "When logging out, log out ALL sessions for the user on all devices"
     version_checks: "Ping the Discourse Hub for version updates and show new version messages on the /admin dashboard"


### PR DESCRIPTION
In the configuration for a list-setting component, the Select2 component is initialized with a pipe ("|") as the separator. (app/assets/javascripts/admin/components/list-setting.js.es6)

This should be communicated to the user in the event they want to paste a list of domains for the blacklist/whitelist.

Current display:
![current_display](https://cloud.githubusercontent.com/assets/4079975/7163001/a3291eb8-e365-11e4-8d66-bb21ebdb072d.png)
