### PR TITLE
Fix admin badge UI style when no badge selected

### DIFF
--- a/app/assets/javascripts/admin/templates/badges-index.hbs
+++ b/app/assets/javascripts/admin/templates/badges-index.hbs
@@ -1,4 +1,4 @@
-<div class='span13'>
+<div class='current-badge span13'>
   <p>{{i18n 'admin.badges.none_selected'}}</p>
 
   <div>


### PR DESCRIPTION
Adds the `current-badge` class's margin to the placeholder text when no badge is selected.