### PR TITLE
FIX: do not show send invites button if sso is enabled

### DIFF
--- a/app/assets/javascripts/admin/templates/users_list.hbs
+++ b/app/assets/javascripts/admin/templates/users_list.hbs
@@ -13,7 +13,9 @@
     </ul>
   </div>
   <div class="pull-right">
-    {{d-button action="sendInvites" title="admin.invite.button_title" icon="user-plus" label="admin.invite.button_text"}}
+    {{#unless siteSettings.enable_sso}}
+      {{d-button action="sendInvites" title="admin.invite.button_title" icon="user-plus" label="admin.invite.button_text"}}
+    {{/unless}}
     {{d-button action="exportUsers" title="admin.export_csv.button_title.user" icon="download" label="admin.export_csv.button_text"}}
   </div>
 </div>


### PR DESCRIPTION
Fixes [this issue](https://meta.discourse.org/t/unable-to-add-existing-users-to-private-message-with-sso-enabled/20364/11?u=techapj)