### PR TITLE
Adding ViewAction into email notifications

### DIFF
--- a/app/views/email/notification.html.erb
+++ b/app/views/email/notification.html.erb
@@ -23,3 +23,9 @@
 %{unsubscribe_link}
 </div>
 </div>
+<div itemscope itemtype="http://schema.org/EmailMessage" style="display:none">
+    <div itemprop="action" itemscope itemtype="http://schema.org/ViewAction">
+        <link itemprop="url" href="<%= Discourse.base_url %><%= post.url  %>" />
+        <meta itemprop="name" content="<%= t 'read_full_topic' %>"/>
+    </div>
+</div>


### PR DESCRIPTION
See: https://meta.discourse.org/t/integrate-viewactions-one-click-actions-schemas-into-discourse-emails/27056

This is the initial pull request. I hope to add a further `ViewAction` for signup.