### PR TITLE
Fix `NoMethodError` in TopicEmbed#find_remote

### DIFF
--- a/app/models/topic_embed.rb
+++ b/app/models/topic_embed.rb
@@ -80,7 +80,7 @@ class TopicEmbed < ActiveRecord::Base
     doc.search(tags.keys.join(',')).each do |node|
       url_param = tags[node.name]
       src = node[url_param]
-      unless (src.empty?)
+      unless (src.nil? || src.empty?)
         begin
           uri = URI.parse(src)
           unless uri.host


### PR DESCRIPTION
This fix stops TopicEmbed#find_remote from generating `NoMethodError: undefined method `empty?' for nil:NilClass` exceptions.

I encountered this issue when attempting to embed a forum topic into a non-RSS page using the embed snippet.

I couldn't get a test environment up and running because the Vagrant environment is [out of date](https://meta.discourse.org/t/localhost-createqueuedposts-error/27715/6), so a working test will have to wait. For now, this fix worked for my purposes so I thought I'd share.