### PR TITLE
Fix: size on onebox-avatar

### DIFF
--- a/app/assets/stylesheets/common/base/onebox.scss
+++ b/app/assets/stylesheets/common/base/onebox.scss
@@ -139,9 +139,11 @@ aside.onebox {
   }
 }
 
-.onebox-avatar {
-  height: 90px !important;
-  width: 90px !important;
+aside.onebox .onebox-body .onebox-avatar {
+  max-height: none;
+  max-width: none;
+  height: 90px;
+  width: 90px;
 }
 
 blockquote {


### PR DESCRIPTION
Fixes the size of the onebox avatar image at 90px.

The issue this is addressing is that avatar images in oneboxes are being distorted at small browser sizes.

From looking at the code I assume the intention is for onebox images to be responsive, but for onebox avatars to have a fixed size of 90px. If this is the case, it is not working because in css `max-height` and `max-width` override `height` and `width`. (I just found that out :)) 

I have set `max-height` and `max-width` to `none` and added enough specificity to be able to get rid of the `!important` flag.