### PR TITLE
FIX: Whoops, DiscourseLocalOnebox became DiscourseGlobalOnebox

### DIFF
--- a/lib/onebox/engine/discourse_local_onebox.rb
+++ b/lib/onebox/engine/discourse_local_onebox.rb
@@ -17,7 +17,8 @@ module Onebox
             route = Rails.application.routes.recognize_path(uri.path)
             case route[:controller]
             when 'topics'
-              true
+              # super will use matches_regexp to match the domain name
+              super
             else
               false
             end


### PR DESCRIPTION
https://meta.discourse.org/t/quoting-across-discourse-instances-with-links-getting-process-as-local-links/27889/