### PR TITLE
Bump rails-observers to master version.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,7 +71,7 @@ end
 if rails_master?
   gem 'arel', git: 'https://github.com/rails/arel.git'
   gem 'rails', git: 'https://github.com/rails/rails.git'
-  gem 'rails-observers', git: 'https://github.com/SamSaffron/rails-observers.git'
+  gem 'rails-observers', git: 'https://github.com/rails/rails-observers.git'
   gem 'seed-fu', git: 'https://github.com/SamSaffron/seed-fu.git', branch: 'discourse'
 else
   gem 'seed-fu', '~> 2.3.3'


### PR DESCRIPTION
https://github.com/rails/rails-observers/commit/876c522184a4ed26d564833f496ef1bfa7af654a
Has the patched applied on SamSaffron/rails-observers.
Also that version should work for rails 4> , so we should not branch it to install

review @SamSaffron @chancancode