### PR TITLE
Fix a typo on Discourse Vagrant documentation

### DIFF
--- a/docs/VAGRANT.md
+++ b/docs/VAGRANT.md
@@ -138,4 +138,3 @@ When you're done working on Discourse, you can shut down Vagrant with:
 ```
 vagrant halt
 ```
-k


### PR DESCRIPTION
Just a small typo fix.