### PR TITLE
Check Rails.version instead of ENV

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -117,7 +117,7 @@ module Discourse
     # see: http://stackoverflow.com/questions/11894180/how-does-one-correctly-add-custom-sql-dml-in-migrations/11894420#11894420
     config.active_record.schema_format = :sql
 
-    if rails_master?
+    if Rails.version >= "4.2.0"
       # Opt-into the default behavior in Rails 5
       # config.active_record.raise_in_transactional_callbacks = true
     end

--- a/config/initializers/00-rails-master-polyfills.rb
+++ b/config/initializers/00-rails-master-polyfills.rb
@@ -1,8 +1,6 @@
-unless rails_master?
-
-class Mail::Message
-  alias_method :deliver_now,  :deliver
-  alias_method :deliver_now!, :deliver!
-end
-
+if Rails.version < "4.2.0"
+  class Mail::Message
+    alias_method :deliver_now,  :deliver
+    alias_method :deliver_now!, :deliver!
+  end
 end

--- a/lib/freedom_patches/pool_drainer.rb
+++ b/lib/freedom_patches/pool_drainer.rb
@@ -1,5 +1,5 @@
 
-if rails_master?
+if Rails.version >= "4.2.0"
   class ActiveRecord::ConnectionAdapters::AbstractAdapter
     module LastUseExtension
       attr_reader :last_use

--- a/lib/sql_builder.rb
+++ b/lib/sql_builder.rb
@@ -72,7 +72,7 @@ class SqlBuilder
   #AS reloads this on tests
   remove_const :FTYPE_MAP if defined? FTYPE_MAP
 
-  if rails_master?
+  if Rails.version >= "4.2.0"
     FTYPE_MAP = {
       23 => ActiveRecord::Type::Integer.new,
       1114 => ActiveRecord::Type::DateTime.new,
@@ -102,7 +102,7 @@ class SqlBuilder
       setters.each_with_index do |mapper, index|
         translated = row[index]
         if mapper[1] && !translated.nil?
-          if rails_master?
+          if Rails.version >= "4.2.0"
             translated = mapper[1].type_cast_from_database(translated)
           else
             translated = ActiveRecord::ConnectionAdapters::Column.send mapper[1], translated

--- a/spec/mailers/user_notifications_spec.rb
+++ b/spec/mailers/user_notifications_spec.rb
@@ -114,7 +114,7 @@ describe UserNotifications do
       response.user.mailing_list_mode = true
       mail = UserNotifications.user_replied(response.user, post: response, notification: notification)
 
-      if rails_master?
+      if Rails.version >= "4.2.0"
         expect(mail.message.class).to eq(ActionMailer::Base::NullMail)
       else
         expect(mail.class).to eq(ActionMailer::Base::NullMail)
@@ -123,7 +123,7 @@ describe UserNotifications do
       response.user.mailing_list_mode = nil
       mail = UserNotifications.user_replied(response.user, post: response, notification: notification)
 
-      if rails_master?
+      if Rails.version >= "4.2.0"
         expect(mail.message.class).not_to eq(ActionMailer::Base::NullMail)
       else
         expect(mail.class).not_to eq(ActionMailer::Base::NullMail)
@@ -196,7 +196,7 @@ describe UserNotifications do
     UserNotifications.any_instance.expects(:build_email).with(user.email, condition)
     mailer = UserNotifications.send(mail_type, user, notification: notification, post: notification.post)
 
-    if rails_master?
+    if Rails.version >= "4.2.0"
       # Starting from Rails 4.2, calling MyMailer.some_method no longer result
       # in an immediate call to MyMailer#some_method. Instead, a "lazy proxy" is
       # returned (this is changed to support #deliver_later). As a quick hack to


### PR DESCRIPTION
Like that we can have code that works on multiple Rails versions, and we
dont need to mix a new method on `Kernel`.
Also, this makes easier to test have multiple versions, example 4.2 and master.

review @SamSaffron @chancancode