### PR TITLE
Add a GET route that logs a user out for Single Sign Out.

### DIFF
--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -4,7 +4,7 @@ require_dependency 'single_sign_on'
 class SessionController < ApplicationController
 
   skip_before_filter :redirect_to_login_if_required
-  skip_before_filter :check_xhr, only: ['sso', 'sso_login', 'become', 'sso_provider']
+  skip_before_filter :check_xhr, only: ['sso', 'sso_login', 'sso_logout', 'become', 'sso_provider']
 
   def csrf
     render json: {csrf: form_authenticity_token }
@@ -99,6 +99,14 @@ class SessionController < ApplicationController
 
       render text: I18n.t("sso.unknown_error"), status: 500
     end
+  end
+
+  def sso_logout
+    unless SiteSetting.enable_sso
+      return render(nothing: true, status: 404)
+    end
+
+    destroy
   end
 
   def create

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -207,6 +207,7 @@ Discourse::Application.routes.draw do
 
   get "session/sso" => "session#sso"
   get "session/sso_login" => "session#sso_login"
+  get "session/sso_logout" => "session#sso_logout"
   get "session/sso_provider" => "session#sso_provider"
   get "session/current" => "session#current"
   get "session/csrf" => "session#csrf"


### PR DESCRIPTION
We use this to allow our centralized authentication service to log a user out without needing to coordinate  Cross Origin POST/DELETE.