### PR TITLE
Simplify the pull_translations script

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,92 +1,57 @@
 [main]
 host = https://www.transifex.com
+lang_map = es_ES: es, fr_FR: fr, ko_KR: ko, pt_PT: pt
 
 [discourse-org.clientenyml]
 file_filter = config/locales/client.<lang>.yml
 source_file = config/locales/client.en.yml
 source_lang = en
-trans.es_ES = config/locales/client.es.yml
-trans.fr_FR = config/locales/client.fr.yml
-trans.ko_KR = config/locales/client.ko.yml
-trans.pt_PT = config/locales/client.pt.yml
 type = YML
 
 [discourse-org.serverenyml]
 file_filter = config/locales/server.<lang>.yml
 source_file = config/locales/server.en.yml
 source_lang = en
-trans.es_ES = config/locales/server.es.yml
-trans.fr_FR = config/locales/server.fr.yml
-trans.ko_KR = config/locales/server.ko.yml
-trans.pt_PT = config/locales/server.pt.yml
 type = YML
 
 [discourse-org.pollclientenyml]
 file_filter = plugins/poll/config/locales/client.<lang>.yml
 source_file = plugins/poll/config/locales/client.en.yml
 source_lang = en
-trans.es_ES = plugins/poll/config/locales/client.es.yml
-trans.fr_FR = plugins/poll/config/locales/client.fr.yml
-trans.ko_KR = plugins/poll/config/locales/client.ko.yml
-trans.pt_PT = plugins/poll/config/locales/client.pt.yml
 type = YML
 
 [discourse-org.pollserverenyml]
 file_filter = plugins/poll/config/locales/server.<lang>.yml
 source_file = plugins/poll/config/locales/server.en.yml
 source_lang = en
-trans.es_ES = plugins/poll/config/locales/server.es.yml
-trans.fr_FR = plugins/poll/config/locales/server.fr.yml
-trans.ko_KR = plugins/poll/config/locales/server.ko.yml
-trans.pt_PT = plugins/poll/config/locales/server.pt.yml
 type = YML
 
 [discourse-org.imgurserverenyml]
 file_filter = vendor/gems/discourse_imgur/lib/discourse_imgur/locale/server.<lang>.yml
 source_file = vendor/gems/discourse_imgur/lib/discourse_imgur/locale/server.en.yml
 source_lang = en
-trans.es_ES = vendor/gems/discourse_imgur/lib/discourse_imgur/locale/server.es.yml
-trans.fr_FR = vendor/gems/discourse_imgur/lib/discourse_imgur/locale/server.fr.yml
-trans.ko_KR = vendor/gems/discourse_imgur/lib/discourse_imgur/locale/server.ko.yml
-trans.pt_PT = vendor/gems/discourse_imgur/lib/discourse_imgur/locale/server.pt.yml
 type = YML
 
 [discourse-org.403html]
 file_filter = public/403.<lang>.html
 source_file = public/403.html
 source_lang = en
-trans.es_ES = public/403.es.html
-trans.fr_FR = public/403.fr.html
-trans.ko_KR = public/403.ko.html
-trans.pt_PT = public/403.pt.html
 type = HTML
 
 [discourse-org.422html]
 file_filter = public/422.<lang>.html
 source_file = public/422.html
 source_lang = en
-trans.es_ES = public/422.es.html
-trans.fr_FR = public/422.fr.html
-trans.ko_KR = public/422.ko.html
-trans.pt_PT = public/422.pt.html
 type = HTML
 
 [discourse-org.500html]
 file_filter = public/500.<lang>.html
 source_file = public/500.html
 source_lang = en
-trans.es_ES = public/500.es.html
-trans.fr_FR = public/500.fr.html
-trans.ko_KR = public/500.ko.html
-trans.pt_PT = public/500.pt.html
 type = HTML
 
 [discourse-org.503html]
 file_filter = public/503.<lang>.html
 source_file = public/503.html
 source_lang = en
-trans.es_ES = public/503.es.html
-trans.fr_FR = public/503.fr.html
-trans.ko_KR = public/503.ko.html
-trans.pt_PT = public/503.pt.html
 type = HTML

--- a/script/pull_translations.rb
+++ b/script/pull_translations.rb
@@ -8,28 +8,29 @@
 require 'open3'
 
 if `which tx`.strip.empty?
-  puts "", "The Transifex client needs to be installed to use this script."
-  puts "Instructions are here: http://docs.transifex.com/developer/client/setup"
-  puts "", "On Mac:", ""
-  puts "  curl -O https://raw.github.com/pypa/pip/master/contrib/get-pip.py"
-  puts "  sudo python get-pip.py"
-  puts "  sudo pip install transifex-client", ""
+  puts '', 'The Transifex client needs to be installed to use this script.'
+  puts 'Instructions are here: http://docs.transifex.com/developer/client/setup'
+  puts '', 'On Mac:', ''
+  puts '  curl -O https://raw.github.com/pypa/pip/master/contrib/get-pip.py'
+  puts '  sudo python get-pip.py'
+  puts '  sudo pip install transifex-client', ''
   exit 1
 end
 
-puts "Pulling new translations...", ""
+locales = Dir.glob(File.expand_path('../../config/locales/client.*.yml', __FILE__)).map {|x| x.split('.')[-2]}.select {|x| x != 'en'}.sort.join(',')
 
-command = "tx pull --mode=developer #{ARGV.include?('force') ? '-f' : ''}"
+puts 'Pulling new translations...', ''
+command = "tx pull --mode=developer --language=#{locales} #{ARGV.include?('force') ? '-f' : ''}"
 
 Open3.popen2e(command) do |stdin, stdout_err, wait_thr|
-  while line = stdout_err.gets
+  while (line = stdout_err.gets)
     puts line
   end
 end
-puts ""
+puts ''
 
 unless $?.success?
-  puts "Something failed. Check the output above.", ""
+  puts 'Something failed. Check the output above.', ''
   exit $?.exitstatus
 end
 
@@ -42,51 +43,14 @@ YML_FILE_COMMENTS = <<END
 # https://www.transifex.com/projects/p/discourse-org/
 END
 
-ALL_LOCALES = Dir.glob( File.expand_path("../../config/locales/client.*.yml", __FILE__) ).map {|x| x.split('.')[-2]}.sort
-
-LOCALE_MAPPINGS = [['fr', 'fr_FR'],
-                   ['es', 'es_ES'],
-                   ['pt', 'pt_PT'],
-                   ['ko', 'ko_KR']]
-
 YML_DIRS = ['config/locales',
             'plugins/poll/config/locales',
             'vendor/gems/discourse_imgur/lib/discourse_imgur/locale']
 
-# Change root element in yml files for some languages because Transifex uses a different
-# locale code.
-LOCALE_MAPPINGS.each do |ours, theirs|
-  ['client', 'server'].each do |base|
-    YML_DIRS.each do |dir|
-      contents = []
-      file_name = File.expand_path("../../#{dir}/#{base}.#{ours}.yml", __FILE__)
-      found = false
-      next unless File.exists?(file_name)
-      File.open(file_name, 'r') do |file|
-        file.each_line do |line|
-          if found or line.strip != "#{theirs}:"
-            contents << line
-          else
-            contents << "#{ours}:"
-            found = true
-          end
-        end
-      end
-
-      File.open(file_name, 'w+') do |f|
-        f.puts(YML_FILE_COMMENTS, '') unless contents[0][0] == '#'
-        f.puts contents
-      end
-    end
-  end
-end
-
 # Add comments to the top of files
-(ALL_LOCALES - LOCALE_MAPPINGS.map(&:first)).each do |locale|
-  ['client', 'server'].each do |base|
-    YML_DIRS.each do |dir|
-      file_name = File.expand_path("../../#{dir}/#{base}.#{locale}.yml", __FILE__)
-      next unless File.exists?(file_name)
+['client', 'server'].each do |base|
+  YML_DIRS.each do |dir|
+    Dir.glob(File.expand_path("../../#{dir}/#{base}.*.yml", __FILE__)).each do |file_name|
       contents = File.readlines(file_name)
       File.open(file_name, 'w+') do |f|
         f.puts(YML_FILE_COMMENTS, '') unless contents[0][0] == '#'


### PR DESCRIPTION
- There's no need for configuring `trans.<lang>` for each resource.
  Using the global `lang_map` in the Transifex client config is enough.
- The Transifex client can rename locales. No need to do this manually.
- Pull all translation files for each locale that has a file named
  `config/locales/client.<lang>.yml`. Up until now the script did only
  update existing files, but didn't add missing ones. That is why there
  are so many translation files for the poll plugin missing.