### PR TITLE
FIX: allow site_name to be present in rejection email subject

### DIFF
--- a/app/mailers/rejection_mailer.rb
+++ b/app/mailers/rejection_mailer.rb
@@ -3,7 +3,7 @@ require_dependency 'email/message_builder'
 class RejectionMailer < ActionMailer::Base
   include Email::BuildEmailHelper
 
-  DISALLOWED_TEMPLATE_ARGS = [:to, :from, :site_name, :base_url,
+  DISALLOWED_TEMPLATE_ARGS = [:to, :from, :base_url,
                               :user_preferences_url,
                               :include_respond_instructions, :html_override,
                               :add_unsubscribe_link, :respond_instructions,

--- a/spec/mailers/rejection_mailer_spec.rb
+++ b/spec/mailers/rejection_mailer_spec.rb
@@ -1,0 +1,29 @@
+require "spec_helper"
+
+describe RejectionMailer do
+
+  describe "send_rejection" do
+
+    context 'sends rejection email' do
+      let (:user) { Fabricate(:user) }
+      let (:template_args) { {former_title: "Mail Subject", destination: user.email, site_name: SiteSetting.title} }
+      let (:reject_mail) { RejectionMailer.send_rejection("email_reject_topic_not_found", user.email, template_args) }
+
+      it 'renders the senders email' do
+        expect(reject_mail.to).to eql([user.email])
+      end
+
+      it 'renders the subject' do
+        expect(reject_mail.subject).to be_present
+      end
+
+      it 'renders site title in subject' do
+        expect(reject_mail.subject).to match(SiteSetting.title)
+      end
+
+      it 'renders the body' do
+        expect(reject_mail.body).to be_present
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes this error: https://meta.discourse.org/t/error-polling-for-reply-emails/28207?u=techapj