### PR TITLE
Fixing map-marker FontAwesome typo

### DIFF
--- a/app/assets/javascripts/discourse/templates/user/user.hbs
+++ b/app/assets/javascripts/discourse/templates/user/user.hbs
@@ -67,7 +67,7 @@
               <h3>{{title}}</h3>
             {{/if}}
             <h3>
-            {{#if location}}{{fa-icon "map-maker"}}{{location}}{{/if}}
+            {{#if location}}{{fa-icon "map-marker"}}{{location}}{{/if}}
             {{#if websiteName}}
               {{fa-icon "globe"}}
               {{#if linkWebsite}}


### PR DESCRIPTION
The correct icon is map-marker, not map-maker.
http://fontawesome.io/icon/map-marker/