### PR TITLE
FIX: display issues in the admin area for RTL forums

### DIFF
--- a/app/assets/stylesheets/common/base/rtl.scss
+++ b/app/assets/stylesheets/common/base/rtl.scss
@@ -28,6 +28,11 @@
   @include rotate(180);
 }
 
+// Make code blocks always display LTR.
+.rtl code {
+  direction: ltr !important;
+}
+
 // Admin RTL styles
 
 // Changes the triangle arrow direction in .nav-stacked .active

--- a/app/assets/stylesheets/common/base/rtl.scss
+++ b/app/assets/stylesheets/common/base/rtl.scss
@@ -28,6 +28,8 @@
   @include rotate(180);
 }
 
+// Admin RTL styles
+
 // Changes the triangle arrow direction in .nav-stacked .active
 // The 'left' and 'right' in these selectors is not being flipped by r2.
 .rtl .nav-stacked .active > a::after {

--- a/app/assets/stylesheets/common/base/rtl.scss
+++ b/app/assets/stylesheets/common/base/rtl.scss
@@ -1,6 +1,9 @@
 // Right to left styles.
-// *** These styles are all going to be flipped by the r2 gem ***
-// There may be a 'do not flip' flag that can be used, but I haven't found it.
+// *** These styles are all going to be processed by the r2 method ***
+// Adding the '!important' flag after a value will keep that value from being flipped.
+// For example 'float: right !important;' is not changed to 'float: left !important;'
+// Adding the '!important' flag to a value does not keep it's key from being flipped.
+// For example 'left: 0 !important;' will become 'right: 0!important';
 
 // Keep the topic admin menu on the page
 .rtl .topic-admin-menu {
@@ -30,4 +33,51 @@
 .rtl .nav-stacked .active > a::after {
   border-left-color: transparent !important;
   border-right-color: $secondary !important;
+}
+
+// Fixes the admin controls for the custom editor.
+.rtl .customize .current-style .admin-controls .nav-pills li {
+  float: left !important;
+}
+
+// pull-left is redefined in admin.css. This keeps it from being over ridden.
+.rtl .pull-left {
+  float: right !important;
+}
+
+.rtl .admin-detail {
+  padding: 30px 30px 30px 0 !important;
+}
+
+// Give the row 'position: relative' so we can reverse the positions of .setting-label and .setting-controls.
+.rtl .admin-detail .row {
+  position: relative;
+
+  .setting-label {
+    position: absolute;
+    left: 0 !important; /* 'left' will be flipped to 'right' */
+  }
+
+  .setting-controls {
+    position: absolute;
+    right: 12% !important; /* 'right' will be flipped to 'left' */
+  }
+  
+  .setting-value {
+    float: right !important;
+    margin-left: 25% !important; /* is flipped to 'margin-right' */
+  }
+
+  // Reposition background image for closing select2-search-choice items.
+  .select2-search-choice-close {
+    background: url(/assets/select2.png) left top no-repeat; /* 'left' is flipped to 'right' */
+  }
+
+  .select2-container-multi .select2-choices .select2-search-choice .select2-search-choice-close:hover {
+    background-position: left -11px; /* 'left' is flipped to 'right' */
+  }
+  .select2-container-multi .select2-choices .select2-search-choice-focus .select2-search-choice-close {
+    background-position: left -11px; /* 'left' is flipped to 'right' */
+  }
+
 }


### PR DESCRIPTION
admin.css is not being processed by the `R2.r2` method.  It mostly works, but there are a few display issues. Here are before and after images for what this PR fixes.

`.nav-stacked` needs to be pulled-right. `.setting-controls` and `.setting-label` need their positions reversed.
![screenshot 2015-05-07 11 38 05](https://cloud.githubusercontent.com/assets/2975917/7523544/3bc9915a-f4b1-11e4-94c5-cf032661911e.png)

![screenshot 2015-05-07 11 42 17](https://cloud.githubusercontent.com/assets/2975917/7523584/7751010e-f4b1-11e4-9fda-f1b72c037cd8.png)

The background image for `.select2-search-choice-close` needs to be repositioned.
![screenshot 2015-05-07 11 39 03](https://cloud.githubusercontent.com/assets/2975917/7523597/88fbc0ce-f4b1-11e4-8a28-fe1a5e99ba6a.png)

![screenshot 2015-05-07 11 42 40](https://cloud.githubusercontent.com/assets/2975917/7523602/925df1c8-f4b1-11e4-855b-c7d1fbdf916a.png)

The admin controls in the `.current-style` editor need to be floated left.
![screenshot 2015-05-07 09 16 47](https://cloud.githubusercontent.com/assets/2975917/7540576/a6a1a582-f563-11e4-9b91-29598eb34843.png)

![screenshot 2015-05-07 09 18 00](https://cloud.githubusercontent.com/assets/2975917/7540583/b294d9e0-f563-11e4-973d-63c924738189.png)

It also adds a rule to `.rtl.scss` to force code blocks to always display LTR.

