### PR TITLE
A red meh icon is less ambiguous than a red-smile

### DIFF
--- a/app/assets/javascripts/admin/templates/version-checks.hbs
+++ b/app/assets/javascripts/admin/templates/version-checks.hbs
@@ -48,7 +48,7 @@
               {{else}}
                 <span {{bind-attr class=":icon versionCheck.critical_updates:critical-updates-available:updates-available"}}>
                   {{#if versionCheck.behindByOneVersion}}
-                    {{fa-icon "smile-o"}}
+                    {{fa-icon "meh-o"}}
                   {{else}}
                     {{fa-icon "frown-o"}}
                   {{/if}}


### PR DESCRIPTION
Builds on https://meta.discourse.org/t/why-a-frowny-face-on-admin-version/27895/

Please attribute this to discourse user @watchmanmonitor  ?