### PR TITLE
FIX: fetch YouTube video title via oEmbed

### DIFF
--- a/plugins/lazyYT/assets/javascripts/lazyYT.js
+++ b/plugins/lazyYT/assets/javascripts/lazyYT.js
@@ -16,11 +16,11 @@
     height = $el.data('height'),
     ratio = ($el.data('ratio')) ? $el.data('ratio') : settings.default_ratio,
     id = $el.data('youtube-id'),
+    title = $el.data('youtube-title'),
     padding_bottom,
     innerHtml = [],
     $thumb,
     thumb_img,
-    loading_text = $el.text() ? $el.text() : settings.loading_text,
     youtube_parameters = $el.data('parameters') || '';
 
     ratio = ratio.split(":");
@@ -64,8 +64,12 @@
     innerHtml.push('<div class="html5-info-bar">');
     innerHtml.push('<div class="html5-title">');
     innerHtml.push('<div class="html5-title-text-wrapper">');
-    innerHtml.push('<a id="lazyYT-title-', id, '" class="html5-title-text" target="_blank" tabindex="3100" href="https://www.youtube.com/watch?v=', id, '">');
-    innerHtml.push(loading_text);
+    innerHtml.push('<a class="html5-title-text" target="_blank" tabindex="3100" href="https://www.youtube.com/watch?v=', id, '">');
+    if (title === null || title === '') {
+      innerHtml.push('https://www.youtube.com/watch?v=' + id);
+    } else {
+      innerHtml.push(title);
+    }
     innerHtml.push('</a>');
     innerHtml.push('</div>'); // .html5-title
     innerHtml.push('</div>'); // .html5-title-text-wrapper
@@ -102,15 +106,10 @@
       }
     });
 
-    $.getJSON('https://gdata.youtube.com/feeds/api/videos/' + id + '?v=2&alt=json', function (data) {
-      $el.find('#lazyYT-title-' + id).text(data.entry.title.$t);
-    });
-
   }
 
   $.fn.lazyYT = function (newSettings) {
     var defaultSettings = {
-      loading_text: 'Loading...',
       default_ratio: '16:9',
       callback: null, // ToDO execute callback if given
       container_class: 'lazyYT-container'

--- a/plugins/lazyYT/plugin.rb
+++ b/plugins/lazyYT/plugin.rb
@@ -18,7 +18,7 @@ class Onebox::Engine::YoutubeOnebox
   def to_html
     if video_id
       # Put in the LazyYT div instead of the iframe
-      "<div class=\"lazyYT\" data-youtube-id=\"#{video_id}\" data-width=\"480\" data-height=\"270\" data-parameters=\"#{embed_params}\"></div>"
+      "<div class=\"lazyYT\" data-youtube-id=\"#{video_id}\" data-youtube-title=\"#{video_title}\" data-width=\"480\" data-height=\"270\" data-parameters=\"#{embed_params}\"></div>"
     else
       super
     end


### PR DESCRIPTION
Reported here: https://meta.discourse.org/t/embedded-youtube-videos-url-always-showing-https-youtube-com-devicesupport/28415?u=techapj

Also merge: https://github.com/discourse/onebox/pull/298