### PR TITLE
Stop sso login processing after rendering error

### DIFF
--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -72,6 +72,7 @@ class SessionController < ApplicationController
 
         if SiteSetting.must_approve_users? && !user.approved?
           render text: I18n.t("sso.account_not_approved"), status: 403
+          return
         else
           log_on_user user
         end


### PR DESCRIPTION
This prevents a DoubleRenderError triggered on the redirect_to.