### PR TITLE
Give Anonymous a name

### DIFF
--- a/app/services/anonymous_shadow_creator.rb
+++ b/app/services/anonymous_shadow_creator.rb
@@ -34,7 +34,7 @@ class AnonymousShadowCreator
       shadow = User.create!(
         password: SecureRandom.hex,
         email: "#{SecureRandom.hex}@anon.#{Discourse.current_hostname}",
-        name: "Anonymous",
+        name: I18n.t(:anonymous),
         username: UserNameSuggester.suggest(I18n.t(:anonymous).downcase),
         active: true,
         trust_level: 1,

--- a/app/services/anonymous_shadow_creator.rb
+++ b/app/services/anonymous_shadow_creator.rb
@@ -34,7 +34,7 @@ class AnonymousShadowCreator
       shadow = User.create!(
         password: SecureRandom.hex,
         email: "#{SecureRandom.hex}@anon.#{Discourse.current_hostname}",
-        name: "",
+        name: "Anonymous",
         username: UserNameSuggester.suggest(I18n.t(:anonymous).downcase),
         active: true,
         trust_level: 1,


### PR DESCRIPTION
Simple fix to ensure that Anonymous mode can be used even when names are required.

Fixes:

    ActiveRecord::RecordInvalid (Validation failed: Name can't be blank)