### PR TITLE
Changes RSS item creation to prevent encoding errors

### DIFF
--- a/app/jobs/scheduled/poll_feed.rb
+++ b/app/jobs/scheduled/poll_feed.rb
@@ -86,11 +86,15 @@ module Jobs
       end
 
       def content
-        @article_rss_item.content || @article_rss_item.description
+        if @article_rss_item.content
+          @article_rss_item.content.scrub
+        else
+          @article_rss_item.description.scrub
+        end
       end
 
       def title
-        @article_rss_item.title
+        @article_rss_item.title.scrub
       end
 
       def user


### PR DESCRIPTION
SimpleRss is unreliable with parsing RSS feeds that contain German Umlauts. 
For example this feed http://www.lauffeuer-lb.de/api/v2/articles.xml can't be parsed by SimpleRss. Discourse's logs are full of  

```
Job exception: Wrapped Encoding::CompatibilityError: incompatible character encodings: ASCII-8BIT and UTF-8  
Job exception: incompatible character encodings: ASCII-8BIT and UTF-8
```

The embedding fails because the feed can't be parsed.  

This change forces the encoding which prevents the numerous encoding errors.