### PR TITLE
Add a SSO logout endpoint.

### DIFF
--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -4,7 +4,8 @@ require_dependency 'single_sign_on'
 class SessionController < ApplicationController
 
   skip_before_filter :redirect_to_login_if_required
-  skip_before_filter :check_xhr, only: ['sso', 'sso_login', 'become', 'sso_provider']
+  skip_before_filter :check_xhr, only: ['sso', 'sso_login', 'sso_logout', 'become', 'sso_provider']
+  skip_before_filter :verify_authenticity_token, only: ['sso_logout']
 
   def csrf
     render json: {csrf: form_authenticity_token }
@@ -99,6 +100,14 @@ class SessionController < ApplicationController
 
       render text: I18n.t("sso.unknown_error"), status: 500
     end
+  end
+
+  def sso_logout
+    unless SiteSetting.enable_sso
+      return render(nothing: true, status: 404)
+    end
+
+    destroy
   end
 
   def create

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -207,6 +207,8 @@ Discourse::Application.routes.draw do
 
   get "session/sso" => "session#sso"
   get "session/sso_login" => "session#sso_login"
+  # Use sso/ here to avoid conflict with session/:id delete route
+  delete "session/sso/logout" => "session#sso_logout"
   get "session/sso_provider" => "session#sso_provider"
   get "session/current" => "session#current"
   get "session/csrf" => "session#csrf"


### PR DESCRIPTION
I tried adding a SSO logout endpoint via GET [before](https://github.com/discourse/discourse/pull/3413) but was told to perform a logout via CORS.

Currently there is a problem with making requests that require pre-flighting via CORS: https://meta.discourse.org/t/cors-preflight-checks-dont-get-porper-headers/28779

This works around that issue and allows for calling logout without first needing to make a request to `/session/csrf` (which the CORS preflight problem prevents us from doing).

Using _method = DELETE and a POST request this can be run without a pre-flight request. The check-xhr skip for this endpoint is to avoid setting custom headers on CORS requests, since custom headers require a pre-flight request.