### PR TITLE
Enable CORS requests to pass necessary headers.

### DIFF
--- a/config/initializers/08-rack-cors.rb
+++ b/config/initializers/08-rack-cors.rb
@@ -29,7 +29,8 @@ if GlobalSetting.enable_cors
         end
 
         headers['Access-Control-Allow-Origin'] = origin || cors_origins[0]
-        headers['Access-Control-Allow-Credentials'] = "true"
+        headers['Access-Control-Allow-Headers'] = 'X-Requested-With, X-CSRF-Token'
+        headers['Access-Control-Allow-Credentials'] = 'true'
       end
 
       headers


### PR DESCRIPTION
To fully enable session deletion over CORS we need support for passing the
`X-Requested-With` header so that these requests can pass the `check-xhr` filter.

I also allowed the `X-CSRF-Token` to enable the alternative CSRF passing syntax.
