### PR TITLE
FIX: topic list header

### DIFF
--- a/app/assets/stylesheets/desktop/topic-list.scss
+++ b/app/assets/stylesheets/desktop/topic-list.scss
@@ -130,6 +130,7 @@
   }
   .category {
     min-width: 80px;
+    text-align: center;
   }
 
   .post-actions {

--- a/app/assets/stylesheets/desktop/topic-list.scss
+++ b/app/assets/stylesheets/desktop/topic-list.scss
@@ -147,7 +147,7 @@
     }
   }
   .activity {
-    width: 60px;
+    width: 65px;
     &:lang(zh_CN) {
       width: 80px;
     }

--- a/app/assets/stylesheets/desktop/topic-list.scss
+++ b/app/assets/stylesheets/desktop/topic-list.scss
@@ -128,6 +128,9 @@
   .posts {
     width: 65px;
   }
+  .category {
+    min-width: 80px;
+  }
 
   .post-actions {
     clear: both;


### PR DESCRIPTION
The topic-list `category` header does not have a set width. Toggling it to display topics with no categories causes the width to collapse to the width of the word `category`. This causes the chevron icon to display underneath the text.

![screenshot 2015-05-14 10 58 57](https://cloud.githubusercontent.com/assets/2975917/7638245/4b41c2b6-fa28-11e4-80a1-e911041c7585.png)

A solution is to add a min-with rule for `.topic-list .category`.  It also needs to be center aligned to match the other topic-list headers

![screenshot 2015-05-14 11 12 09](https://cloud.githubusercontent.com/assets/2975917/7638497/25ffcf46-fa2a-11e4-9d59-b89c21393a29.png)

The topic-list `activity` header is set to 60px. This causes the chevron icon to display below the text.

![screenshot 2015-05-14 11 06 40](https://cloud.githubusercontent.com/assets/2975917/7638411/50ffe452-fa29-11e4-8f2a-f89dd211f9f5.png)

The replies (`.posts`) and `views` topic list headers are set at 65px. They display with the chevron icon to their right. Setting the `activity` header to 65px solves this problem.

![screenshot 2015-05-14 11 09 45](https://cloud.githubusercontent.com/assets/2975917/7638453/c5866684-fa29-11e4-91c5-53958c5a7bba.png)


