### PR TITLE
In the case of an expired nonce, return a 400 status code instead of 500

### DIFF
--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -57,7 +57,7 @@ class SessionController < ApplicationController
 
     sso = DiscourseSingleSignOn.parse(request.query_string)
     if !sso.nonce_valid?
-      return render(text: I18n.t("sso.timeout_expired"), status: 400)
+      return render(text: I18n.t("sso.timeout_expired"), status: 419)
     end
 
     if ScreenedIpAddress.should_block?(request.remote_ip)

--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -57,7 +57,7 @@ class SessionController < ApplicationController
 
     sso = DiscourseSingleSignOn.parse(request.query_string)
     if !sso.nonce_valid?
-      return render(text: I18n.t("sso.timeout_expired"), status: 500)
+      return render(text: I18n.t("sso.timeout_expired"), status: 400)
     end
 
     if ScreenedIpAddress.should_block?(request.remote_ip)


### PR DESCRIPTION
500 status codes are for unexpected server-side error scenarios. When an expired nonce is used by the client, a 4XX-level error is more appropriate because the client has submitted a bad request (by using an expired nonce). A 500 also causes Internet Explorer to show its default 500 page which does not show the error message and leads to a bad end user experience. I am choosing 400 for the new status rather than 401 or 403 because 401 requires a WWW-Authenticate header which would be difficult to generate in an SSO scenario and a 403 implies that no re-authentication will address the failure.