### PR TITLE
DEV: exclude the script folder from code climate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,12 @@
+languages:
+   Ruby: true
+   JavaScript: true
+   Python: false
+   PHP: false
+
+exclude_paths:
+ - "public/*"
+ - "script/*"
+ - "spec/*"
+ - "test/*"
+ - "vendor/*"


### PR DESCRIPTION
I think scripts especially import scripts are always complicated. It's not the hotspot and it don't need to be analyzed. Maybe it's better to exclude them.