### PR TITLE
UX: do not show last post label in user card if user never posted

### DIFF
--- a/app/assets/javascripts/discourse/templates/user-card.hbs
+++ b/app/assets/javascripts/discourse/templates/user-card.hbs
@@ -58,7 +58,9 @@
 
   {{#if user}}
     <div class="metadata">
-      <h3><span class='desc'>{{i18n 'last_post'}}</span> {{format-date user.last_posted_at leaveAgo="true"}}</h3>
+      {{#if user.last_posted_at}}
+        <h3><span class='desc'>{{i18n 'last_post'}}</span> {{format-date user.last_posted_at leaveAgo="true"}}</h3>
+      {{/if}}
       <h3><span class='desc'>{{i18n 'joined'}}</span> {{format-date user.created_at leaveAgo="true"}}</h3>
     </div>
   {{/if}}


### PR DESCRIPTION
Requested here: https://meta.discourse.org/t/user-card-displays-last-post-even-if-theyve-never-posted/28896?u=techapj