### PR TITLE
UX: add space between location icon and text

### DIFF
--- a/app/assets/javascripts/discourse/templates/user/user.hbs
+++ b/app/assets/javascripts/discourse/templates/user/user.hbs
@@ -67,7 +67,7 @@
               <h3>{{model.title}}</h3>
             {{/if}}
             <h3>
-            {{#if model.location}}{{fa-icon "map-marker"}}{{model.location}}{{/if}}
+            {{#if model.location}}{{fa-icon "map-marker"}} {{model.location}}{{/if}}
             {{#if websiteName}}
               {{fa-icon "globe"}}
               {{#if linkWebsite}}


### PR DESCRIPTION
Before:

![before](https://cloud.githubusercontent.com/assets/5732281/7675549/66c2b644-fd57-11e4-85ae-6fa0fc02e508.png)

After:

![after](https://cloud.githubusercontent.com/assets/5732281/7675550/69c17b96-fd57-11e4-8117-1b82eb35d4d9.png)
