### PR TITLE
FIX: press ESC can close user card

### DIFF
--- a/app/assets/javascripts/discourse/views/user-card.js.es6
+++ b/app/assets/javascripts/discourse/views/user-card.js.es6
@@ -120,6 +120,14 @@ export default Discourse.View.extend(CleansUp, {
     this.get('controller').close();
   },
 
+  keyUp(e) {
+    if (e.keyCode === 27) { // ESC
+      const target = this.get('controller.cardTarget');
+      this.cleanUp();
+      target.focus();
+    }
+  },
+
   _removeEvents: function() {
     $('html').off(clickOutsideEventName);
 


### PR DESCRIPTION
fix https://meta.discourse.org/t/no-way-to-dismiss-usercard-when-opened-by-keyboard/26709