### PR TITLE
Fix parsing of boolean attribute in SSO

### DIFF
--- a/lib/single_sign_on.rb
+++ b/lib/single_sign_on.rb
@@ -2,7 +2,7 @@ class SingleSignOn
   ACCESSORS = [:nonce, :name, :username, :email, :avatar_url, :avatar_force_update, :require_activation,
                :about_me, :external_id, :return_sso_url, :admin, :moderator, :suppress_welcome_message]
   FIXNUMS = []
-  BOOLS = [:avatar_force_update, :admin, :moderator, :suppress_welcome_message]
+  BOOLS = [:avatar_force_update, :admin, :moderator, :require_activation, :suppress_welcome_message]
   NONCE_EXPIRY_TIME = 10.minutes
 
   attr_accessor(*ACCESSORS)

--- a/spec/models/discourse_single_sign_on_spec.rb
+++ b/spec/models/discourse_single_sign_on_spec.rb
@@ -19,6 +19,7 @@ describe DiscourseSingleSignOn do
     sso.username = "sam"
     sso.name = "sam saffron"
     sso.external_id = "100"
+    sso.require_activation = false
     sso.custom_fields["a"] = "Aa"
     sso.custom_fields["b.b"] = "B.b"
     sso
@@ -30,6 +31,7 @@ describe DiscourseSingleSignOn do
     expect(parsed.username).to eq sso.username
     expect(parsed.name).to eq sso.name
     expect(parsed.external_id).to eq sso.external_id
+    expect(parsed.require_activation).to eq false
     expect(parsed.custom_fields["a"]).to eq "Aa"
     expect(parsed.custom_fields["b.b"]).to eq "B.b"
   end


### PR DESCRIPTION
The `require_activation` field was added and intended to be a boolean, but wasn't being parsed as one (i.e. if anything was present, including "false", it evaluated to true). 