### PR TITLE
Bump recommended minimum PostgreSQL version to 9.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Browse [lots more notable Discourse instances](http://www.discourse.org/faq/cust
 
 2. If you're familiar with how Rails works and are comfortable setting up your own environment, use our [**Discourse Advanced Developer Guide**](docs/DEVELOPER-ADVANCED.md). 
 
-Before you get started, ensure you have the following minimum versions: [Ruby 2.0.0+](http://www.ruby-lang.org/en/downloads/), [PostgreSQL 9.1+](http://www.postgresql.org/download/), [Redis 2.6+](http://redis.io/download). If you're having trouble, please see our [**TROUBLESHOOTING GUIDE**](docs/TROUBLESHOOTING.md) first!
+Before you get started, ensure you have the following minimum versions: [Ruby 2.0.0+](http://www.ruby-lang.org/en/downloads/), [PostgreSQL 9.3+](http://www.postgresql.org/download/), [Redis 2.6+](http://redis.io/download). If you're having trouble, please see our [**TROUBLESHOOTING GUIDE**](docs/TROUBLESHOOTING.md) first!
 
 ## Setting up a Discourse Forum
 

--- a/docs/DEVELOPER-ADVANCED.md
+++ b/docs/DEVELOPER-ADVANCED.md
@@ -6,7 +6,7 @@ Note: If you are developing on a Mac, you will probably want to look at [these i
 
 ## First Steps
 
-1. Install and configure PostgreSQL 9.2+.
+1. Install and configure PostgreSQL 9.3+.
   1. Run `postgres -V` to see if you already have it.
   1. Make sure that the server's messages language is English; this is [required](https://github.com/rails/rails/blob/3006c59bc7a50c925f6b744447f1d94533a64241/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L1140) by the ActiveRecord Postgres adapter.
 2. Install and configure Redis 2+.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -20,7 +20,7 @@ Hosting Rails applications is complicated. Even if you already have Postgres, Re
 
 ### Software Requirements
 
-- [Postgres 9.2+](http://www.postgresql.org/download/)
+- [Postgres 9.3+](http://www.postgresql.org/download/)
 - [Redis 2.6+](http://redis.io/download)
 - [Ruby 2.0+](http://www.ruby-lang.org/en/downloads/) (we recommend 2.0.0-p353 or higher)
 

--- a/docs/TROUBLESHOOTING-prod.md
+++ b/docs/TROUBLESHOOTING-prod.md
@@ -12,7 +12,7 @@ something like:
     `ruby 2.0.0p195 (2013-05-14 revision 40734) [x86_64-linux]`
 
 
-1. Are you on Postgres 9.2 or later with HSTORE enabled?
+1. Are you on Postgres 9.3 or later with HSTORE enabled?
 
    You can check your postgres version by typing `psql --version`. To see if
 hstore is installed, open a session to postgres and type `\dx` and see if

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -10,7 +10,7 @@ reaching out to the community for help:
    `ruby -v` and checking the response.
 
 
-2. Are you on Postgres 9.2 or later with HSTORE enabled?
+2. Are you on Postgres 9.3 or later with HSTORE enabled?
 
    You can check your postgres version by typing `psql --version`. To see if hstore is
    installed, open a session to postgres and type `\dx` and see if hstore is listed.


### PR DESCRIPTION
After [discussion on meta][1], this fixes references to 9.1/9.2 in the docs. I left `docs/INSTALL-ubuntu.md` alone since it's deprecated. I wasn't sure what to do about `docs/DEVELOPMENT-OSX-NATIVE.md` as I'm not familiar with brew.

[1]: https://meta.discourse.org/t/postgresql-minimum-version/29168