### PR TITLE
FIX: add missing username properties to usercard

### DIFF
--- a/app/assets/javascripts/discourse/controllers/user-card.js.es6
+++ b/app/assets/javascripts/discourse/controllers/user-card.js.es6
@@ -63,7 +63,7 @@ export default Ember.Controller.extend({
       return;
     }
 
-    this.setProperties({ user: null, userLoading: username, cardTarget: target, topicPostCount: null });
+    this.setProperties({ user: null, username, userLoading: username, cardTarget: target, topicPostCount: null });
 
     const args = { stats: false };
     args.include_post_count_for = this.get('controllers.topic.model.id');


### PR DESCRIPTION
Fix: https://meta.discourse.org/t/usercards-dont-show-shortnames-when-switched-directly/29150