### PR TITLE
FIX: do not inject nofollow in all subdomain links

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -187,6 +187,9 @@ gem 'rmmseg-cpp', require: false
 
 gem 'logster'
 
+# Domain Name parser based on the Public Suffix List. https://github.com/weppos/publicsuffix-ruby
+gem 'public_suffix'
+
 # perftools only works on 1.9 atm
 group :profile do
   # travis refuses to install this, instead of fuffing, just avoid it for now

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -227,6 +227,7 @@ GEM
       pry (>= 0.9.10, < 0.11.0)
     pry-rails (0.3.3)
       pry (>= 0.9.10)
+    public_suffix (1.5.1)
     puma (2.11.1)
       rack (>= 1.1, < 2.0)
     r2 (0.2.5)
@@ -446,6 +447,7 @@ DEPENDENCIES
   pg
   pry-nav
   pry-rails
+  public_suffix
   puma
   r2 (~> 0.2.5)
   rack-mini-profiler

--- a/spec/components/pretty_text_spec.rb
+++ b/spec/components/pretty_text_spec.rb
@@ -55,6 +55,7 @@ describe PrettyText do
     before do
       SiteSetting.stubs(:add_rel_nofollow_to_user_content).returns(true)
       SiteSetting.stubs(:exclude_rel_nofollow_domains).returns("foo.com|bar.com")
+      Discourse.stubs(:base_url).returns("http://try.discourse.org")
     end
 
     it "should inject nofollow in all user provided links" do
@@ -62,11 +63,13 @@ describe PrettyText do
     end
 
     it "should not inject nofollow in all local links" do
-      expect(PrettyText.cook("<a href='#{Discourse.base_url}/test.html'>cnn</a>") !~ /nofollow/).to eq(true)
+      expect(PrettyText.cook("<a href='http://try.discourse.org/test'>try</a>") !~ /nofollow/).to eq(true)
     end
 
     it "should not inject nofollow in all subdomain links" do
-      expect(PrettyText.cook("<a href='#{Discourse.base_url.sub('http://', 'http://bla.')}/test.html'>cnn</a>") !~ /nofollow/).to eq(true)
+      expect(PrettyText.cook("<a href='http://meta.discourse.org/test.html'>meta</a>") !~ /nofollow/).to eq(true)
+      expect(PrettyText.cook("<a href='http://www.discourse.org/about'>www</a>") !~ /nofollow/).to eq(true)
+      expect(PrettyText.cook("<a href='http://discourse.org'>discourse</a>") !~ /nofollow/).to eq(true)
     end
 
     it "should not inject nofollow for foo.com" do
@@ -75,6 +78,10 @@ describe PrettyText do
 
     it "should not inject nofollow for bar.foo.com" do
       expect(PrettyText.cook("<a href='http://bar.foo.com/test.html'>cnn</a>") !~ /nofollow/).to eq(true)
+    end
+
+    it "should inject nofollow for nofoo.com" do
+      expect(PrettyText.cook("<a href='http://nofoo.com/test.html'>cnn</a>")).to match(/nofollow/)
     end
 
     it "should not inject nofollow if omit_nofollow option is given" do


### PR DESCRIPTION
https://meta.discourse.org/t/add-rel-nofollow-admin-setting-is-not-working-right-its-making-parent-domain-link-as-nofollow/29226?u=techapj

Also there was bug when domain like `foo.com` is added in `exclude_rel_nofollow_domains` setting, then domain like `nofoo.com` was also being allowed to be excluded from nofollow.