### PR TITLE
UX: allow youtube embed width and height to be passed as param

### DIFF
--- a/plugins/lazyYT/plugin.rb
+++ b/plugins/lazyYT/plugin.rb
@@ -17,8 +17,11 @@ class Onebox::Engine::YoutubeOnebox
 
   def to_html
     if video_id
+      video_width = (params['width'] && params['width'].to_i <= 695) ? params['width'] : 480 # embed width
+      video_height = (params['height'] && params['height'].to_i <= 500) ? params['height'] : 270 # embed height
+      
       # Put in the LazyYT div instead of the iframe
-      "<div class=\"lazyYT\" data-youtube-id=\"#{video_id}\" data-youtube-title=\"#{video_title}\" data-width=\"480\" data-height=\"270\" data-parameters=\"#{embed_params}\"></div>"
+      "<div class=\"lazyYT\" data-youtube-id=\"#{video_id}\" data-youtube-title=\"#{video_title}\" data-width=\"#{video_width}\" data-height=\"#{video_height}\" data-parameters=\"#{embed_params}\"></div>"
     else
       super
     end


### PR DESCRIPTION
https://www.youtube.com/watch?v=4CJvasYJP6o&width=690&height=400 oneboxes to:

![screen shot 2015-05-26 at 18 10 03](https://cloud.githubusercontent.com/assets/5732281/7812697/7d007118-03d2-11e5-8580-b21fda1d7f2b.png)


