### PR TITLE
Fix missing bracket in name selector in url anchor jumping

### DIFF
--- a/app/assets/javascripts/discourse/lib/url.js
+++ b/app/assets/javascripts/discourse/lib/url.js
@@ -89,7 +89,7 @@ Discourse.URL = Ember.Object.createWithMixins({
     Em.run.schedule('afterRender', function() {
       var $elem = $(id);
       if ($elem.length === 0) {
-        $elem = $("[name=" + id.replace('#', ''));
+        $elem = $("[name='" + id.replace('#', '') + "']");
       }
       if ($elem.length > 0) {
         $('html,body').scrollTop($elem.offset().top - $('header').height() - 15);


### PR DESCRIPTION
The missing bracket was causing errors in Safari and Firefox. See [this meta thread](https://meta.discourse.org/t/intra-post-anchor-links-dont-work-in-safari-firefox/29125/7).
