### PR TITLE
FIX: attachment links in topic map were giving 404

### DIFF
--- a/app/assets/javascripts/discourse/templates/components/topic-map.hbs
+++ b/app/assets/javascripts/discourse/templates/components/topic-map.hbs
@@ -72,7 +72,7 @@
               <span class='badge badge-notification clicks' title='{{i18n 'topic_map.clicks' count=clicks}}'>{{link.clicks}}</span>
             </td>
             <td>
-              <a href="{{unbound link.url}}" target="_blank" class='topic-link track-link' data-user-id="{{unbound link.user_id}}" data-ignore-post-id="true" title="{{unbound link.url}}">
+              <a href="{{unbound link.url}}" target="_blank" class='topic-link track-link {{if link.attachment "attachment"}}' data-user-id="{{unbound link.user_id}}" data-ignore-post-id="true" title="{{unbound link.url}}">
                 {{#if link.title}}{{link.title}}{{else}}{{shorten-url link.url}}{{/if}}
               </a>
               {{link-domain link}}

--- a/app/serializers/topic_link_serializer.rb
+++ b/app/serializers/topic_link_serializer.rb
@@ -4,6 +4,7 @@ class TopicLinkSerializer < ApplicationSerializer
              :title,
              :fancy_title,
              :internal,
+             :attachment,
              :reflection,
              :clicks,
              :user_id,
@@ -23,6 +24,10 @@ class TopicLinkSerializer < ApplicationSerializer
 
   def internal
     object['internal'] == 't'
+  end
+
+  def attachment
+    Discourse.store.has_been_uploaded?(object['url'])
   end
 
   def reflection


### PR DESCRIPTION
Reported here -- https://meta.discourse.org/t/links-to-uploaded-files-in-topic-details-are-wrong-try-discourse-org/25537?u=techapj