### PR TITLE
improving the font-rendering issue caused by css transitions in safari

### DIFF
--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -725,7 +725,8 @@ $topic-avatar-width: 45px;
 
 .posts-wrapper {
   position: relative;
-}
+  -webkit-font-smoothing: subpixel-antialiased;
+  }
 
 .dropdown {
   position: relative;


### PR DESCRIPTION
Problem discussed here: https://meta.discourse.org/t/odd-change-in-boldness-of-font-on-safari-macbook-retina-when-scrolling/23605/

Fix from the discussion here: http://stackoverflow.com/questions/12502234/how-to-prevent-webkit-text-rendering-change-during-css-transition

"With both Safari and Chrome where the default font rendering uses subpixel-antialiasing, any CSS that forces GPU based rendering, like the suggestions above to use a transform using translateZ or a even just a scale transition, will cause Safari and Chrome to automatically "give up" on subpixel-antialiased font smoothing and instead switch to just antialiased text, which looks a lot lighter and thinner, especially on Safari.

Other responses have focused on maintaining a constant rendering by simply setting or forcing font-smoothing to the thinner antiailiased text. To my eye using translateZ or backface hidden significantly degrades the quality of the text rendering and the best solution if you want the text to just stay consistent and you're OK with the thinner text is just to use -webkit-font-smoothing: antialiased. However, explicitly setting -webkit-font-smoothing: subpixel-antialiased does actually have some effect - the text does still change slightly and is just about visibly thinner during transitions rendered on the GPU but not as thin as it goes without this setting. So it looks like this at least partially prevents the switch to straight antiailiased text."

All other solutions I find seem to think that the best option is to put _all_ animations on their own plane in the z-index above other page elements, but that seems like a crazy solution for a complex application.