### PR TITLE
FIX: month was not showing in user suspended error message

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -26,7 +26,7 @@ en:
     formats:
       short: "%m-%d-%Y"
       short_no_year: "%B %-d"
-      date_only: "%b %-d, %Y"
+      date_only: "%B %-d, %Y"
   date:
     <<: *datetime
   time:


### PR DESCRIPTION
Reported here: https://meta.discourse.org/t/text-on-suspension-message-is-cut-off/29395?u=techapj