### PR TITLE
Respect cookie[:destination_url] in Single Sign On

### DIFF
--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -11,8 +11,16 @@ class SessionController < ApplicationController
   end
 
   def sso
+    if params[:return_path]
+      return_path = params[:return_path]
+    elsif cookies[:destination_url]
+      return_path = URI::parse(cookies[:destination_url]).path
+    else
+      return_path = path('/')
+    end
+
     if SiteSetting.enable_sso
-      redirect_to DiscourseSingleSignOn.generate_url(params[:return_path] || path('/'))
+      redirect_to DiscourseSingleSignOn.generate_url(return_path)
     else
       render nothing: true, status: 404
     end

--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -11,15 +11,15 @@ class SessionController < ApplicationController
   end
 
   def sso
-    if params[:return_path]
-      return_path = params[:return_path]
-    elsif cookies[:destination_url]
-      return_path = URI::parse(cookies[:destination_url]).path
+    return_path = if params[:return_path]
+      params[:return_path]
+    elsif session[:destination_url]
+      URI::parse(session[:destination_url]).path
     else
-      return_path = path('/')
+      path('/')
     end
 
-    if SiteSetting.enable_sso
+    if SiteSetting.enable_sso?
       redirect_to DiscourseSingleSignOn.generate_url(return_path)
     else
       render nothing: true, status: 404


### PR DESCRIPTION
When the login_required setting is true, the destination URL is dropped. This change means it will be
respected at login time