### PR TITLE
UX: show category badge underneath title in user stream

### DIFF
--- a/app/assets/javascripts/discourse/templates/user/stream.hbs
+++ b/app/assets/javascripts/discourse/templates/user/stream.hbs
@@ -7,7 +7,7 @@
       <span class="title">
         <a href="{{unbound item.postUrl}}">{{unbound item.title}}</a>
       </span>
-      <span class="category">{{category-link item.category}}</span>
+      <div class="category">{{category-link item.category}}</div>
     </div>
     <p class='excerpt'>{{{unbound item.excerpt}}}</p>
     {{#each child in item.children}}

--- a/app/assets/stylesheets/desktop/user.scss
+++ b/app/assets/stylesheets/desktop/user.scss
@@ -402,9 +402,6 @@
 
 
   .user-stream {
-    .category {
-      margin-left: 3px;
-    }
     .excerpt {
       margin: 5px 0;
       font-size: 0.929em;


### PR DESCRIPTION
Example:

![screen shot 2015-06-03 at 12 28 30](https://cloud.githubusercontent.com/assets/5732281/7954332/482fdff8-09ec-11e5-803e-d1b601d2d229.png)

cc @coding-horror 