### PR TITLE
UX: post content was moving up when viewing replies

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -135,7 +135,7 @@ aside.quote {
 
 // this ensures consistent top margin on topic posts even if the first line of a post
 // is a top-margin-less element like a list or image.
-.topic-body .contents {
+.topic-body .regular {
   margin-top: 15px;
 }
 


### PR DESCRIPTION
Before:

![before](https://cloud.githubusercontent.com/assets/5732281/7963111/ac3a054a-0a2e-11e5-9349-a68ed2495345.gif)

After:

![after](https://cloud.githubusercontent.com/assets/5732281/7963114/af6ba354-0a2e-11e5-9e23-a49061c9e29b.gif)


cc @coding-horror 