### PR TITLE
FEATURE: include email_prefix in digest email subject instead of site title

### DIFF
--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -54,7 +54,7 @@ class UserNotifications < ActionMailer::Base
 
     min_date = opts[:since] || @user.last_emailed_at || @user.last_seen_at || 1.month.ago
 
-    @site_name = SiteSetting.title
+    @site_name = SiteSetting.email_prefix.presence || SiteSetting.title
 
     @header_color = ColorScheme.hex_for_name('header_background')
     @last_seen_at = short_date(@user.last_seen_at || @user.created_at)

--- a/spec/mailers/user_notifications_spec.rb
+++ b/spec/mailers/user_notifications_spec.rb
@@ -77,6 +77,13 @@ describe UserNotifications do
         expect(subject.text_part.body.to_s).to be_present
       end
 
+      it "includes email_prefix in email subject instead of site title" do
+        SiteSetting.email_prefix = "Try Discourse"
+        SiteSetting.title = "Discourse Meta"
+
+        expect(subject.subject).to match(/Try Discourse/)
+        expect(subject.subject).not_to match(/Discourse Meta/)
+      end
     end
   end
 


### PR DESCRIPTION
Meta topic: https://meta.discourse.org/t/site-title-being-used-in-subject-despite-email-prefix-being-used/29578?u=techapj