### PR TITLE
FIX: staff should be immune to max_invites_per_day setting

### DIFF
--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -200,7 +200,7 @@ class Guardian
 
   def can_invite_to_forum?(groups=nil)
     authenticated? &&
-    SiteSetting.max_invites_per_day.to_i > 0 &&
+    (SiteSetting.max_invites_per_day.to_i > 0 || is_staff?) &&
     !SiteSetting.enable_sso &&
     SiteSetting.enable_local_logins &&
     (
@@ -213,8 +213,8 @@ class Guardian
   def can_invite_to?(object, group_ids=nil)
     return false if ! authenticated?
     return false unless ( SiteSetting.enable_local_logins && (!SiteSetting.must_approve_users? || is_staff?) )
-    return false if SiteSetting.max_invites_per_day.to_i == 0
     return true if is_admin?
+    return false if (SiteSetting.max_invites_per_day.to_i == 0 && !is_staff?)
     return false if ! can_see?(object)
     return false if group_ids.present?
 

--- a/spec/components/guardian_spec.rb
+++ b/spec/components/guardian_spec.rb
@@ -248,7 +248,10 @@ describe Guardian do
     it 'returns false when max_invites_per_day is 0' do
       # let's also break it while here
       SiteSetting.max_invites_per_day = "a"
-      expect(Guardian.new(moderator).can_invite_to_forum?).to be_falsey
+
+      expect(Guardian.new(user).can_invite_to_forum?).to be_falsey
+      # staff should be immune to max_invites_per_day setting
+      expect(Guardian.new(moderator).can_invite_to_forum?).to be_truthy
     end
 
     it 'returns false when the site requires approving users and is regular' do
@@ -283,7 +286,10 @@ describe Guardian do
       expect(Guardian.new(user).can_invite_to?(topic)).to be_falsey
 
       SiteSetting.max_invites_per_day = 0
-      expect(Guardian.new(moderator).can_invite_to?(topic)).to be_falsey
+
+      expect(Guardian.new(user).can_invite_to?(topic)).to be_falsey
+      # staff should be immune to max_invites_per_day setting
+      expect(Guardian.new(moderator).can_invite_to?(topic)).to be_truthy
     end
 
     it 'returns true when the site requires approving users and is mod' do


### PR DESCRIPTION
This was regressed in [this commit](https://github.com/discourse/discourse/commit/dd91d5b02f74bf0226a5d2b7502eb6f000f72dca).

cc @SamSaffron 