### PR TITLE
FEATURE: Use created_at to remove an ip if its last_match_at is null

### DIFF
--- a/app/jobs/scheduled/clean_up_unmatched_ips.rb
+++ b/app/jobs/scheduled/clean_up_unmatched_ips.rb
@@ -11,7 +11,7 @@ module Jobs
 
       # remove old unmatched IP addresses
       ScreenedIpAddress.where(action_type: ScreenedIpAddress.actions[:block])
-                       .where("last_match_at < ?", last_match_threshold)
+                       .where("last_match_at < ? OR (last_match_at IS NULL AND created_at < ?)", last_match_threshold, last_match_threshold)
                        .destroy_all
     end
 


### PR DESCRIPTION
Only use created_at if the last_match_at is NULL (or not populated) to ensure all IPs are appropriately cleaned up
https://meta.discourse.org/t/look-at-created-at-when-deleting-ips-if-last-match-at-is-null/29682