### PR TITLE
Show breakdown for site settings.

### DIFF
--- a/app/assets/javascripts/admin/controllers/admin-site-settings.js.es6
+++ b/app/assets/javascripts/admin/controllers/admin-site-settings.js.es6
@@ -39,6 +39,11 @@ export default Ember.ArrayController.extend(Presence, {
       });
       if (matches.length > 0) {
         matchesGroupedByCategory[0].siteSettings.pushObjects(matches);
+        matchesGroupedByCategory.pushObject({
+          nameKey: settingsCategory.nameKey,
+          name: I18n.t('admin.site_settings.categories.' + settingsCategory.nameKey),
+          siteSettings: matches
+        });
       }
     });
 


### PR DESCRIPTION
Fix: https://meta.discourse.org/t/items-filter-improperly-when-searching-admin-settings/28217/5

![optimised](https://cloud.githubusercontent.com/assets/4335742/8057889/d79df67a-0ee7-11e5-8e94-7d3d8d8f8895.gif)

@SamSaffron I didn't see any existing tests for this. Am I missing something?