### PR TITLE
Convert author tag to dc:creator

### DIFF
--- a/app/views/list/list.rss.erb
+++ b/app/views/list/list.rss.erb
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<rss version="2.0" xmlns:discourse="http://www.discourse.org/" xmlns:atom="http://www.w3.org/2005/Atom">
+<rss version="2.0" xmlns:discourse="http://www.discourse.org/" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/">
   <channel>
     <% lang = SiteSetting.find_by_name('default_locale').try(:value) %>
     <% site_email = SiteSetting.find_by_name('contact_email').try(:value) %>
@@ -14,7 +14,7 @@
         <% topic_url = topic.url -%>
         <item>
           <title><%= topic.title %></title>
-          <author><%= "no-reply@example.com (@#{topic.user.username}#{" #{topic.user.name}" if (topic.user.name.present? && SiteSetting.enable_names?)})" -%></author>
+          <dc:creator><![CDATA[<%= "@#{topic.user.username}#{" #{topic.user.name}" if (topic.user.name.present? && SiteSetting.enable_names?)}" -%>]]></dc:creator>
           <category><%= topic.category.name %></category>
           <description><![CDATA[
           <p><%= t('author_wrote', author: link_to("@#{topic.user.username}", "#{Discourse.base_url}/users/#{topic.user.username_lower}")).html_safe %></p>

--- a/app/views/posts/latest.rss.erb
+++ b/app/views/posts/latest.rss.erb
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<rss version="2.0" xmlns:discourse="http://www.discourse.org/" xmlns:atom="http://www.w3.org/2005/Atom">
+<rss version="2.0" xmlns:discourse="http://www.discourse.org/" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/">
   <channel>
     <% lang = SiteSetting.find_by_name('default_locale').try(:value) %>
     <% site_email = SiteSetting.find_by_name('contact_email').try(:value) %>
@@ -10,7 +10,7 @@
       <% next unless post.user %>
       <item>
         <title><%= post.topic.title %></title>
-        <author><%= "no-reply@example.com (@#{post.user.username}#{" #{post.user.name}" if (post.user.name.present? && SiteSetting.enable_names?)})" -%></author>
+        <dc:creator><![CDATA[<%= "@#{post.user.username}#{" #{post.user.name}" if (post.user.name.present? && SiteSetting.enable_names?)}" -%>]]></dc:creator>
         <description><![CDATA[ <%= post.cooked.html_safe %> ]]></description>
         <link><%= Discourse.base_url + post.url %></link>
         <pubDate><%= post.created_at.rfc2822 %></pubDate>

--- a/app/views/topics/show.rss.erb
+++ b/app/views/topics/show.rss.erb
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/">
   <channel>
     <% topic_url = @topic_view.absolute_url %>
     <% lang = SiteSetting.find_by_name('default_locale').try(:value) %>
@@ -15,7 +15,7 @@
       <% next unless post.user %>
       <item>
         <title><%= @topic_view.title %></title>
-        <author><%= "no-reply@example.com (@#{post.user.username}#{" #{post.user.name}" if (post.user.name.present? && SiteSetting.enable_names?)})" -%></author>
+        <dc:creator><![CDATA[<%= "@#{post.user.username}#{" #{post.user.name}" if (post.user.name.present? && SiteSetting.enable_names?)}" -%>]]></dc:creator>
         <description><![CDATA[
           <% post_url = Discourse.base_url + post.url %>
           <p><%= t('author_wrote', author: link_to("@#{post.user.username}", user_url(post.user.username_lower))).html_safe %></p>


### PR DESCRIPTION
RSS spec says the author tag should be an email address, forcing us to put in a junk no-reply@example.com email. Instead, we should use dc:creator, which allows us to use any name we want for the user.