### PR TITLE
FIX: Incorrect check when no text is selected.

### DIFF
--- a/app/assets/javascripts/discourse/controllers/quote-button.js.es6
+++ b/app/assets/javascripts/discourse/controllers/quote-button.js.es6
@@ -27,7 +27,7 @@ export default DiscourseController.extend({
 
     const selection = window.getSelection();
     // no selections
-    if (selection.rangeCount === 0) return;
+    if (selection.isCollapsed) return;
 
     // retrieve the selected range
     const range = selection.getRangeAt(0),


### PR DESCRIPTION
When I click on a post and even if no text is selected, `rangeCount` will still be `1`. Therefore, we're running unnecessary code until we check it against the buffer.

From the [documentation](https://developer.mozilla.org/en-US/docs/Web/API/Selection/isCollapsed), `isCollapsed` checks if any text has been selected.

cc/ @SamSaffron 

EDIT: Just spotted this in the Docs.
> Keep in mind that a collapsed selection may still have one (or more, in Gecko) Ranges, so Selection.rangeCount may not be zero.