### PR TITLE
Don't limit @mention autocomplete to latin characters

### DIFF
--- a/app/assets/javascripts/discourse/lib/user-search.js.es6
+++ b/app/assets/javascripts/discourse/lib/user-search.js.es6
@@ -88,11 +88,6 @@ export default function userSearch(options) {
   currentTerm = term;
 
   return new Ember.RSVP.Promise(function(resolve) {
-    // TODO site setting for allowed regex in username
-    if (term.match(/[^a-zA-Z0-9_\.]/)) {
-      resolve([]);
-      return;
-    }
     if (((new Date() - cacheTime) > 30000) || (cacheTopicId !== topicId)) {
       cache = {};
     }


### PR DESCRIPTION
The userSearch() function, used for @mention autocomplete, returned an empty
list if the query string included non-latin characters or spaces. This removes
this restriction, so you can search users by any characters in their display
name, including spaces.