### PR TITLE
Remove actionpack-action_caching gem from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,8 +25,6 @@ else
   gem 'seed-fu', '~> 2.3.3'
 end
 
-gem 'actionpack-action_caching'
-
 # Rails 4.1.6+ will relax the mail gem version requirement to `~> 2.5, >= 2.5.4`.
 # However, mail gem 2.6.x currently does not work with discourse because of the
 # reference to `Mail::RFC2822Parser` in `lib/email.rb`. This ensure discourse

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,8 +15,6 @@ GEM
       activesupport (= 4.1.10)
       rack (~> 1.5.2)
       rack-test (~> 0.6.2)
-    actionpack-action_caching (1.1.1)
-      actionpack (>= 4.0.0, < 5.0)
     actionview (4.1.10)
       activesupport (= 4.1.10)
       builder (~> 3.1)
@@ -392,7 +390,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  actionpack-action_caching
   active_model_serializers (~> 0.8.3)
   annotate
   aws-sdk


### PR DESCRIPTION
Discourse is not using the gem.

Please close this PR if using the gem at somewhere :ok_hand: 