### PR TITLE
FIX: Double click on IE11 not highlighting word.

### DIFF
--- a/app/assets/javascripts/discourse/views/quote-button.js.es6
+++ b/app/assets/javascripts/discourse/views/quote-button.js.es6
@@ -50,7 +50,9 @@ export default Discourse.View.extend({
 
         // deselects only when the user left click
         // (allows anyone to `extend` their selection using shift+click)
-        if (e.which === 1 && !e.shiftKey) controller.deselectText();
+        if (!window.getSelection().isCollapsed &&
+            e.which === 1 &&
+            !e.shiftKey) controller.deselectText();
       })
       .on('mouseup.quote-button', function(e) {
         view.selectText(e.target, controller);


### PR DESCRIPTION
Issue: https://meta.discourse.org/t/ie11-cant-double-click-to-highlight-word/12601

I still don't really understand why the doubleclick to highlight word event isn't being triggered on IE11 if we're calling `window.getSelection().removeAllRanges()`. However, I realized that we can resolved this by checking that there is actually text being highlighted before clearing the user's selection. It also kind of make more sense to me to do it this way since every click on a post before was triggering `controller.deselectText()` even if no text has been selected.