### PR TITLE
Add plugin outlet to user card metadata

### DIFF
--- a/app/assets/javascripts/discourse/templates/user-card.hbs
+++ b/app/assets/javascripts/discourse/templates/user-card.hbs
@@ -63,6 +63,7 @@
         <h3><span class='desc'>{{i18n 'last_post'}}</span> {{format-date user.last_posted_at leaveAgo="true"}}</h3>
       {{/if}}
       <h3><span class='desc'>{{i18n 'joined'}}</span> {{format-date user.created_at leaveAgo="true"}}</h3>
+      {{plugin-outlet "user-card-metadata"}}
     </div>
   {{/if}}
 


### PR DESCRIPTION
This PR adds a plugin-outlet in the "metadata" area of the user card, allowing plugins to easily extend the content there. 

In the example, that I am currently building, we want to show the (very important) points of reputation someone gained on their user card directly (hint, it's the _Reputation 10 Points_ part ;) ):

![screen shot 2015-06-11 at 15 26 19](https://cloud.githubusercontent.com/assets/40496/8108146/17bec8fc-104f-11e5-80fa-8fa2687ffbd1.png)
