### PR TITLE
FIX: vertically align category badge-wrapper in suggested-topics h3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -484,6 +484,3 @@ DEPENDENCIES
   uglifier
   unf
   unicorn
-
-BUNDLED WITH
-   1.10.3

--- a/app/assets/javascripts/discourse/templates/topic.hbs
+++ b/app/assets/javascripts/discourse/templates/topic.hbs
@@ -110,7 +110,7 @@
                 <div class='topics'>
                   {{basic-topic-list topics=model.details.suggested_topics postsAction="showTopicEntrance"}}
                 </div>
-                <h3>{{{view.browseMoreMessage}}}</h3>
+                <h3 class='topics-more'>{{{view.browseMoreMessage}}}</h3>
               </div>
             {{/if}}
 

--- a/app/assets/javascripts/discourse/templates/topic.hbs
+++ b/app/assets/javascripts/discourse/templates/topic.hbs
@@ -110,7 +110,7 @@
                 <div class='topics'>
                   {{basic-topic-list topics=model.details.suggested_topics postsAction="showTopicEntrance"}}
                 </div>
-                <h3 class='topics-more'>{{{view.browseMoreMessage}}}</h3>
+                <h3 class='topics-other'>{{{view.browseMoreMessage}}}</h3>
               </div>
             {{/if}}
 

--- a/app/assets/stylesheets/desktop/topic.scss
+++ b/app/assets/stylesheets/desktop/topic.scss
@@ -227,6 +227,24 @@ a:hover.reply-new {
   z-index: 495
 }
 
+// Position the .topics-more .badge-wrapper relative to its surrounding text.
+.topics-more,
+.topics-more .badge-wrapper {
+  position: relative;
+}
+
+.topics-more .badge-wrapper.bullet {
+  top: 2px;
+}
+
+.topics-more .badge-wrapper.box {
+  top: 5px;
+}
+
+.topics-more .badge-wrapper.bar {
+  top: -1px;
+}
+
 @media all
 and (max-width : 940px) {
 

--- a/app/assets/stylesheets/desktop/topic.scss
+++ b/app/assets/stylesheets/desktop/topic.scss
@@ -228,8 +228,7 @@ a:hover.reply-new {
 }
 
 // Position the .topics-more .badge-wrapper relative to its surrounding text.
-.topics-more,
-.topics-more .badge-wrapper {
+.topics-more {
   position: relative;
 }
 

--- a/app/assets/stylesheets/desktop/topic.scss
+++ b/app/assets/stylesheets/desktop/topic.scss
@@ -227,20 +227,20 @@ a:hover.reply-new {
   z-index: 495
 }
 
-// Position the .topics-more .badge-wrapper relative to its surrounding text.
-.topics-more {
+// Position the .topics-other .badge-wrapper relative to its surrounding text.
+.topics-other {
   position: relative;
 }
 
-.topics-more .badge-wrapper.bullet {
+.topics-other .badge-wrapper.bullet {
   top: 2px;
 }
 
-.topics-more .badge-wrapper.box {
+.topics-other .badge-wrapper.box {
   top: 5px;
 }
 
-.topics-more .badge-wrapper.bar {
+.topics-other .badge-wrapper.bar {
   top: -1px;
 }
 

--- a/app/assets/stylesheets/mobile/topic.scss
+++ b/app/assets/stylesheets/mobile/topic.scss
@@ -187,3 +187,20 @@ sup sup, sub sup, sup sub, sub sub { top: 0; }
     width: 95% !important;
   }
 }
+
+// Position the .topics-other .badge-wrapper relative to its surrounding text.
+.topics-other {
+  position: relative;
+}
+
+.topics-other .badge-wrapper.bullet {
+  top: 2px;
+}
+
+.topics-other .badge-wrapper.box {
+  top: 5px;
+}
+
+.topics-other .badge-wrapper.bar {
+  top: -1px;
+}


### PR DESCRIPTION
The category badges in the suggested-topics h3 have a different font size than their parent. The category-badges also have different line-heights, depending on whether they have the class .bullet, .box, or .bar. 

This adds a class to the parent h3 and sets its position to relative. Each of the category badge-wrapper classes can now have their vertical position set through their top value in `topic.scss`.

![screenshot 2015-06-14 02 46 41](https://cloud.githubusercontent.com/assets/2975917/8148090/b2d18c20-123f-11e5-84f9-00e9bd3b7034.png)
 