### PR TITLE
FIX: Tagging plugin was blocking composer status on smaller screens.

### DIFF
--- a/app/assets/stylesheets/desktop/compose.scss
+++ b/app/assets/stylesheets/desktop/compose.scss
@@ -288,6 +288,7 @@
     }
 
     .submit-panel {
+      width: 28%;
       position: absolute;
       display: block;
       bottom: 8px;


### PR DESCRIPTION
Fixes: https://meta.discourse.org/t/saved-hidden-behind-tags-box/29576/6

In conjunction with: https://github.com/discourse/discourse-tagging/pull/34

![](https://lh3.googleusercontent.com/lURX-v1CKSiCYb8SxJ3vCP37nbnH4z5WfB1Kqkp_IHw=w1156-h499-no)
![](https://lh3.googleusercontent.com/7UqUHQpKel88qSZHfDnOC8ZC6XUBif5mwE_5oENeiaY=w1156-h499-no)