### PR TITLE
FIX: Add missing translation

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2058,6 +2058,7 @@ en:
             delete_post: "delete post"
             impersonate: "impersonate"
             anonymize_user: "anonymize user"
+            roll_up: "roll up IP blocks"
         screened_emails:
           title: "Screened Emails"
           description: "When someone tries to create a new account, the following email addresses will be checked and the registration will be blocked, or some other action performed."


### PR DESCRIPTION
https://meta.discourse.org/t/missing-translation-in-logs-for-system-ip-rollup/30417