### PR TITLE
Fix right clicking username on profile card takes you to profile page

### DIFF
--- a/app/assets/javascripts/discourse/templates/user-card.hbs
+++ b/app/assets/javascripts/discourse/templates/user-card.hbs
@@ -6,7 +6,7 @@
   <div class="names">
     <span>
       <h1 class="{{staff}} {{new_user}}">
-        <a href {{action "showUser"}}>{{username}} {{user-status user currentUser=currentUser}}</a>
+        <a href {{action "showUser"}}>{{#link-to 'user' user}}{{username}} {{user-status user currentUser=currentUser}}{{/link-to}}</a>
       </h1>
 
       {{#if user.name}}


### PR DESCRIPTION
bug: https://meta.discourse.org/t/middle-right-clicking-on-username-of-profile-card-takes-you-to-the-page-you-are-viewing-not-the-profile/30404

Hey I have added the link-to helper and I believe this fixes the issue :)