### PR TITLE
FIX: mark user as approved if an invite is already present

### DIFF
--- a/app/models/email_token.rb
+++ b/app/models/email_token.rb
@@ -60,7 +60,7 @@ class EmailToken < ActiveRecord::Base
       end
     end
     # redeem invite, if available
-    Invite.redeem_from_email(user.email)
+    return User.find_by(email: Email.downcase(user.email)) if Invite.redeem_from_email(user.email).present?
     user
   rescue ActiveRecord::RecordInvalid
     # If the user's email is already taken, just return nil (failure)

--- a/app/services/user_activator.rb
+++ b/app/services/user_activator.rb
@@ -23,7 +23,8 @@ class UserActivator
   end
 
   def factory
-    if SiteSetting.must_approve_users?
+    invite = Invite.find_by(email: Email.downcase(@user.email))
+    if SiteSetting.must_approve_users? && !(invite.present? && !invite.expired? && !invite.destroyed? && invite.link_valid?)
       ApprovalActivator
     elsif !user.active?
       EmailActivator


### PR DESCRIPTION
If the site has `must approve users` setting enabled and admin/moderator sends an invite to an email. Then if the user signs up on the forum without clicking invite link, his account should be automatically approved.

[Bug reported here](https://meta.discourse.org/t/user-was-forced-to-wait-for-approval-despite-a-pending-invitation/30276?u=techapj).