### PR TITLE
FEATURE: Make abbreviated numbers (k, M) localizable

### DIFF
--- a/app/assets/javascripts/discourse/lib/formatter.js
+++ b/app/assets/javascripts/discourse/lib/formatter.js
@@ -258,14 +258,18 @@ relativeAge = function(date, options) {
 };
 
 var number = function(val) {
+  var formattedNumber;
+
   val = parseInt(val, 10);
   if (isNaN(val)) val = 0;
 
   if (val > 999999) {
-    return (val / 1000000).toFixed(1) + "M";
+    formattedNumber = I18n.toNumber(val / 1000000, {precision: 1});
+    return I18n.t("number.short.millions", {number: formattedNumber});
   }
   if (val > 999) {
-    return (val / 1000).toFixed(1) + "K";
+    formattedNumber = I18n.toNumber(val / 1000, {precision: 1});
+    return I18n.t("number.short.thousands", {number: formattedNumber});
   }
   return val.toString();
 };

--- a/config/locales/client.ar.yml
+++ b/config/locales/client.ar.yml
@@ -8,6 +8,9 @@
 ar:
   js:
     number:
+      format:
+        separator: "."
+        delimiter: ","
       human:
         storage_units:
           format: '%n %u'
@@ -23,6 +26,9 @@ ar:
             kb: كيلو بايت
             mb: ميجا
             tb: تيرا
+      short:
+        thousands: "{{number}}k"
+        millions: "{{number}}M"
     dates:
       time: "h:mm a"
       long_no_year: "MMM D h:mm a"

--- a/config/locales/client.bs_BA.yml
+++ b/config/locales/client.bs_BA.yml
@@ -8,6 +8,9 @@
 bs_BA:
   js:
     number:
+      format:
+        separator: "."
+        delimiter: ","
       human:
         storage_units:
           format: '%n %u'
@@ -16,6 +19,9 @@ bs_BA:
             kb: KB
             mb: MB
             tb: TB
+      short:
+        thousands: "{{number}}k"
+        millions: "{{number}}M"
     dates:
       time: "h:mm a"
       long_no_year: "MMM D h:mm a"

--- a/config/locales/client.cs.yml
+++ b/config/locales/client.cs.yml
@@ -8,6 +8,9 @@
 cs:
   js:
     number:
+      format:
+        separator: "."
+        delimiter: ","
       human:
         storage_units:
           format: '%n %u'
@@ -20,6 +23,9 @@ cs:
             kb: KB
             mb: MB
             tb: TB
+      short:
+        thousands: "{{number}}k"
+        millions: "{{number}}M"
     dates:
       time: "h:mm a"
       long_no_year: "MMM D h:mm a"

--- a/config/locales/client.da.yml
+++ b/config/locales/client.da.yml
@@ -8,6 +8,9 @@
 da:
   js:
     number:
+      format:
+        separator: "."
+        delimiter: ","
       human:
         storage_units:
           format: '%n %u'
@@ -19,6 +22,9 @@ da:
             kb: KB
             mb: MB
             tb: TB
+      short:
+        thousands: "{{number}}k"
+        millions: "{{number}}M"
     dates:
       time: "h:mm a"
       long_no_year: "MMM D h:mm a"

--- a/config/locales/client.de.yml
+++ b/config/locales/client.de.yml
@@ -8,6 +8,9 @@
 de:
   js:
     number:
+      format:
+        separator: ","
+        delimiter: "."
       human:
         storage_units:
           format: '%n %u'
@@ -19,6 +22,9 @@ de:
             kb: KB
             mb: MB
             tb: TB
+      short:
+        thousands: "{{number}}k"
+        millions: "{{number}}M"
     dates:
       time: "HH:mm"
       long_no_year: "DD. MMM HH:mm"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -18,6 +18,9 @@
 en:
   js:
     number:
+      format:
+        separator: "."
+        delimiter: ","
       human:
         storage_units:
           format: '%n %u'
@@ -29,6 +32,9 @@ en:
             kb: KB
             mb: MB
             tb: TB
+      short:
+        thousands: "{{number}}k"
+        millions: "{{number}}M"
     dates:
       time: "h:mm a"
       long_no_year: "MMM D h:mm a"

--- a/config/locales/client.es.yml
+++ b/config/locales/client.es.yml
@@ -8,6 +8,9 @@
 es:
   js:
     number:
+      format:
+        separator: "."
+        delimiter: ","
       human:
         storage_units:
           format: '%n %u'
@@ -19,6 +22,9 @@ es:
             kb: KB
             mb: MB
             tb: TB
+      short:
+        thousands: "{{number}}k"
+        millions: "{{number}}M"
     dates:
       time: "h:mm a"
       long_no_year: "MMM D h:mm a"

--- a/config/locales/client.fa_IR.yml
+++ b/config/locales/client.fa_IR.yml
@@ -8,6 +8,9 @@
 fa_IR:
   js:
     number:
+      format:
+        separator: "."
+        delimiter: ","
       human:
         storage_units:
           format: '%n %u'
@@ -18,6 +21,9 @@ fa_IR:
             kb: KB
             mb: MB
             tb: TB
+      short:
+        thousands: "{{number}}k"
+        millions: "{{number}}M"
     dates:
       time: "h:mm a"
       long_no_year: "MMM D h:mm a"

--- a/config/locales/client.fi.yml
+++ b/config/locales/client.fi.yml
@@ -8,6 +8,9 @@
 fi:
   js:
     number:
+      format:
+        separator: "."
+        delimiter: ","
       human:
         storage_units:
           format: '%n %u'
@@ -19,6 +22,9 @@ fi:
             kb: Kt
             mb: Mt
             tb: Tt
+      short:
+        thousands: "{{number}}k"
+        millions: "{{number}}M"
     dates:
       time: "H:mm"
       long_no_year: "D. MMMM[ta] H:mm"

--- a/config/locales/client.fr.yml
+++ b/config/locales/client.fr.yml
@@ -8,6 +8,9 @@
 fr:
   js:
     number:
+      format:
+        separator: "."
+        delimiter: ","
       human:
         storage_units:
           format: '%n %u'
@@ -19,6 +22,9 @@ fr:
             kb: Ko
             mb: Mo
             tb: To
+      short:
+        thousands: "{{number}}k"
+        millions: "{{number}}M"
     dates:
       time: "H:mm"
       long_no_year: "DD MMM H:mm"

--- a/config/locales/client.he.yml
+++ b/config/locales/client.he.yml
@@ -8,6 +8,9 @@
 he:
   js:
     number:
+      format:
+        separator: "."
+        delimiter: ","
       human:
         storage_units:
           format: '%n %u'
@@ -19,6 +22,9 @@ he:
             kb: KB
             mb: MB
             tb: TB
+      short:
+        thousands: "{{number}}k"
+        millions: "{{number}}M"
     dates:
       time: "h:mm a"
       long_no_year: "MMM D h:mm a"

--- a/config/locales/client.id.yml
+++ b/config/locales/client.id.yml
@@ -8,6 +8,9 @@
 id:
   js:
     number:
+      format:
+        separator: "."
+        delimiter: ","
       human:
         storage_units:
           format: '%n %u'
@@ -18,6 +21,9 @@ id:
             kb: KB
             mb: MB
             tb: TB
+      short:
+        thousands: "{{number}}k"
+        millions: "{{number}}M"
     dates:
       time: "j:mm a"
       long_no_year: "BBB H j:mm a"

--- a/config/locales/client.it.yml
+++ b/config/locales/client.it.yml
@@ -8,6 +8,9 @@
 it:
   js:
     number:
+      format:
+        separator: "."
+        delimiter: ","
       human:
         storage_units:
           format: '%n %u'
@@ -19,6 +22,9 @@ it:
             kb: KB
             mb: MB
             tb: TB
+      short:
+        thousands: "{{number}}k"
+        millions: "{{number}}M"
     dates:
       time: "h:mm a"
       long_no_year: "D MMM h:mm a"

--- a/config/locales/client.ja.yml
+++ b/config/locales/client.ja.yml
@@ -8,6 +8,9 @@
 ja:
   js:
     number:
+      format:
+        separator: "."
+        delimiter: ","
       human:
         storage_units:
           format: '%n %u'
@@ -18,6 +21,9 @@ ja:
             kb: KB
             mb: MB
             tb: TB
+      short:
+        thousands: "{{number}}k"
+        millions: "{{number}}M"
     dates:
       time: "h:mm a"
       long_no_year: "MMM D h:mm a"

--- a/config/locales/client.ko.yml
+++ b/config/locales/client.ko.yml
@@ -8,6 +8,9 @@
 ko:
   js:
     number:
+      format:
+        separator: "."
+        delimiter: ","
       human:
         storage_units:
           format: '%n %u'
@@ -18,6 +21,9 @@ ko:
             kb: KB
             mb: MB
             tb: TB
+      short:
+        thousands: "{{number}}k"
+        millions: "{{number}}M"
     dates:
       time: "a h:mm"
       long_no_year: "MMM D a h:mm "

--- a/config/locales/client.nb_NO.yml
+++ b/config/locales/client.nb_NO.yml
@@ -8,6 +8,9 @@
 nb_NO:
   js:
     number:
+      format:
+        separator: "."
+        delimiter: ","
       human:
         storage_units:
           format: '%n %u'
@@ -19,6 +22,9 @@ nb_NO:
             kb: KB
             mb: MB
             tb: TB
+      short:
+        thousands: "{{number}}k"
+        millions: "{{number}}M"
     dates:
       time: "h:mm a"
       long_no_year: "D MMM h:mm a"

--- a/config/locales/client.nl.yml
+++ b/config/locales/client.nl.yml
@@ -8,6 +8,9 @@
 nl:
   js:
     number:
+      format:
+        separator: "."
+        delimiter: ","
       human:
         storage_units:
           format: '%n %u'
@@ -19,6 +22,9 @@ nl:
             kb: KB
             mb: MB
             tb: TB
+      short:
+        thousands: "{{number}}k"
+        millions: "{{number}}M"
     dates:
       time: "h:mm a"
       long_no_year: "MMM D h:mm a"

--- a/config/locales/client.pl_PL.yml
+++ b/config/locales/client.pl_PL.yml
@@ -8,6 +8,9 @@
 pl_PL:
   js:
     number:
+      format:
+        separator: "."
+        delimiter: ","
       human:
         storage_units:
           format: '%n %u'
@@ -20,6 +23,9 @@ pl_PL:
             kb: KB
             mb: MB
             tb: TB
+      short:
+        thousands: "{{number}}k"
+        millions: "{{number}}M"
     dates:
       time: "H:mm"
       long_no_year: "D MMM H:mm"

--- a/config/locales/client.pt.yml
+++ b/config/locales/client.pt.yml
@@ -8,6 +8,9 @@
 pt:
   js:
     number:
+      format:
+        separator: "."
+        delimiter: ","
       human:
         storage_units:
           format: '%n %u'
@@ -19,6 +22,9 @@ pt:
             kb: KB
             mb: MB
             tb: TB
+      short:
+        thousands: "{{number}}k"
+        millions: "{{number}}M"
     dates:
       time: "hh:mm"
       long_no_year: "DD MMM hh:mm"

--- a/config/locales/client.pt_BR.yml
+++ b/config/locales/client.pt_BR.yml
@@ -8,6 +8,9 @@
 pt_BR:
   js:
     number:
+      format:
+        separator: "."
+        delimiter: ","
       human:
         storage_units:
           format: '%n %u'
@@ -19,6 +22,9 @@ pt_BR:
             kb: KB
             mb: MB
             tb: TB
+      short:
+        thousands: "{{number}}k"
+        millions: "{{number}}M"
     dates:
       time: "h:mm a"
       long_no_year: "MMM D h:mm a"

--- a/config/locales/client.ro.yml
+++ b/config/locales/client.ro.yml
@@ -8,6 +8,9 @@
 ro:
   js:
     number:
+      format:
+        separator: "."
+        delimiter: ","
       human:
         storage_units:
           format: '%n %u'
@@ -20,6 +23,9 @@ ro:
             kb: KB
             mb: MB
             tb: TB
+      short:
+        thousands: "{{number}}k"
+        millions: "{{number}}M"
     dates:
       time: "HH:mm"
       long_no_year: "DD MMM HH:mm"

--- a/config/locales/client.ru.yml
+++ b/config/locales/client.ru.yml
@@ -8,6 +8,9 @@
 ru:
   js:
     number:
+      format:
+        separator: "."
+        delimiter: ","
       human:
         storage_units:
           format: '%n %u'
@@ -21,6 +24,9 @@ ru:
             kb: КБ
             mb: МБ
             tb: ТБ
+      short:
+        thousands: "{{number}}тыс."
+        millions: "{{number}}млн"
     dates:
       time: "HH:mm"
       long_no_year: "D MMM HH:mm"

--- a/config/locales/client.sq.yml
+++ b/config/locales/client.sq.yml
@@ -8,6 +8,9 @@
 sq:
   js:
     number:
+      format:
+        separator: "."
+        delimiter: ","
       human:
         storage_units:
           format: '%n %u'
@@ -19,6 +22,9 @@ sq:
             kb: KB
             mb: MB
             tb: TB
+      short:
+        thousands: "{{number}}k"
+        millions: "{{number}}M"
     dates:
       time: "h:mm a"
       long_no_year: "MMM D h:mm a"

--- a/config/locales/client.sv.yml
+++ b/config/locales/client.sv.yml
@@ -8,6 +8,9 @@
 sv:
   js:
     number:
+      format:
+        separator: "."
+        delimiter: ","
       human:
         storage_units:
           format: '%n %u'
@@ -19,6 +22,9 @@ sv:
             kb: KB
             mb: MB
             tb: TB
+      short:
+        thousands: "{{number}}k"
+        millions: "{{number}}M"
     dates:
       time: "h:mm a"
       long_no_year: "MMM D h:mm a"

--- a/config/locales/client.te.yml
+++ b/config/locales/client.te.yml
@@ -8,6 +8,9 @@
 te:
   js:
     number:
+      format:
+        separator: "."
+        delimiter: ","
       human:
         storage_units:
           format: '%n %u'
@@ -19,6 +22,9 @@ te:
             kb: కేబీ
             mb: యంబీ
             tb: టీబీ
+      short:
+        thousands: "{{number}}k"
+        millions: "{{number}}M"
     dates:
       time: "h:mm a"
       long_no_year: "MMM D h:mm a"

--- a/config/locales/client.tr_TR.yml
+++ b/config/locales/client.tr_TR.yml
@@ -8,6 +8,9 @@
 tr_TR:
   js:
     number:
+      format:
+        separator: "."
+        delimiter: ","
       human:
         storage_units:
           format: '%n %u'
@@ -18,6 +21,9 @@ tr_TR:
             kb: KB
             mb: MB
             tb: TB
+      short:
+        thousands: "{{number}}k"
+        millions: "{{number}}M"
     dates:
       time: "h:mm a"
       long_no_year: "D MMM h:mm a"

--- a/config/locales/client.uk.yml
+++ b/config/locales/client.uk.yml
@@ -8,6 +8,9 @@
 uk:
   js:
     number:
+      format:
+        separator: "."
+        delimiter: ","
       human:
         storage_units:
           format: '%n %u'
@@ -20,6 +23,9 @@ uk:
             kb: КБ
             mb: МБ
             tb: ТБ
+      short:
+        thousands: "{{number}}k"
+        millions: "{{number}}M"
     dates:
       time: "HH:mm"
       tiny:

--- a/config/locales/client.zh_CN.yml
+++ b/config/locales/client.zh_CN.yml
@@ -8,6 +8,9 @@
 zh_CN:
   js:
     number:
+      format:
+        separator: "."
+        delimiter: ","
       human:
         storage_units:
           format: '%n %u'
@@ -18,6 +21,9 @@ zh_CN:
             kb: KB
             mb: MB
             tb: TB
+      short:
+        thousands: "{{number}}k"
+        millions: "{{number}}M"
     dates:
       time: "ah:mm"
       long_no_year: "MMMDoah:mm"

--- a/config/locales/client.zh_TW.yml
+++ b/config/locales/client.zh_TW.yml
@@ -8,6 +8,9 @@
 zh_TW:
   js:
     number:
+      format:
+        separator: "."
+        delimiter: ","
       human:
         storage_units:
           format: '%n %u'
@@ -18,6 +21,9 @@ zh_TW:
             kb: KB
             mb: MB
             tb: TB
+      short:
+        thousands: "{{number}}k"
+        millions: "{{number}}M"
     dates:
       time: "h:mm"
       long_no_year: "MMM D h:mm a"

--- a/test/javascripts/lib/formatter-test.js.es6
+++ b/test/javascripts/lib/formatter-test.js.es6
@@ -203,6 +203,7 @@ test("breakUp", function(){
 test("number", function() {
   equal(Discourse.Formatter.number(123), "123", "it returns a string version of the number");
   equal(Discourse.Formatter.number("123"), "123", "it works with a string command");
-  equal(Discourse.Formatter.number(NaN), "0", "it reeturns 0 for NaN");
-  equal(Discourse.Formatter.number(3333), "3.3K", "it abbreviates thousands");
+  equal(Discourse.Formatter.number(NaN), "0", "it returns 0 for NaN");
+  equal(Discourse.Formatter.number(3333), "3.3k", "it abbreviates thousands");
+  equal(Discourse.Formatter.number(2499999), "2.5M", "it abbreviates millions");
 });


### PR DESCRIPTION
- Makes the decimal separator and thousands delimiter localizable
- Adds translations for all languages, otherwise this will look very ugly
- English locale: Changes the thousands delimiter from uppercase K to [lowercase k](https://en.wikipedia.org/wiki/Unit_prefix).

https://meta.discourse.org/t/is-there-a-way-to-translate-numbers-e-g-1-3k-in-the-views-column/30374