### PR TITLE
FIX: Middle click on user card image and name not working.

### DIFF
--- a/app/assets/javascripts/discourse/templates/user-card.hbs
+++ b/app/assets/javascripts/discourse/templates/user-card.hbs
@@ -1,7 +1,7 @@
 {{#if controller.visible}}
 <div class="card-content">
 
-  <a href {{action "showUser"}}>{{bound-avatar avatar "huge"}}</a>
+  <a href={{user.path}} {{action "showUser"}}>{{bound-avatar avatar "huge"}}</a>
 
   <div class="names">
     <span>
@@ -18,7 +18,7 @@
       {{/if}}
 
       {{#if showName}}
-      <h2><a href {{action "showUser"}}>{{name}}</a></h2>
+      <h2><a href={{user.path}} {{action "showUser"}}>{{name}}</a></h2>
       {{/if}}
     </span>
   </div>


### PR DESCRIPTION
Extension of https://github.com/discourse/discourse/commit/0a9e2f54ff8f97ebac800dd027715347b5f70976.

cc/ @eviltrout 