### PR TITLE
FIX: cannot read property 'forEach' of undefined that prevents embed from working in Chrome

### DIFF
--- a/public/javascripts/embed.js
+++ b/public/javascripts/embed.js
@@ -3,8 +3,9 @@
   var DE = window.DiscourseEmbed || {};
   var comments = document.getElementById('discourse-comments');
   var iframe = document.createElement('iframe');
+  var DEparms = ['discourseUrl', 'discourseEmbedUrl', 'discourseUserName'];
 
-  ['discourseUrl', 'discourseEmbedUrl', 'discourseUserName'].forEach(function(i) {
+  DEparms.forEach(function(i) {
     if (window[i]) { DE[i] = DE[i] || window[i]; }
   });
 


### PR DESCRIPTION
Fixes "Uncaught TypeError: Cannot read property 'forEach' of undefine…d" in Chrome that stops discourse embed.js from working.

See https://meta.discourse.org/t/how-can-i-troubleshoot-discourse-comments-embedding-feature/30323/10