### PR TITLE
FIX: Disable validation during thumbnail creation

### DIFF
--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -34,7 +34,7 @@ class Upload < ActiveRecord::Base
       optimized_images << thumbnail
       self.width = width
       self.height = height
-      save!
+      save(validate: false)
     end
   end
 


### PR DESCRIPTION
This fixes problems with rebaking posts. There's no need to validate an upload during thumbnail creation.

https://meta.discourse.org/t/rebaking-posts-fails-when-attachments-arent-allowed-anymore/30429