### PR TITLE
FIX: Remove invalid translation keys from polls plugin

### DIFF
--- a/plugins/poll/config/locales/client.en.yml
+++ b/plugins/poll/config/locales/client.en.yml
@@ -1,19 +1,27 @@
 # encoding: utf-8
+# This file contains content for the client portion of the poll plugin, sent out
+# to the Javascript app.
 #
-# Never edit this file. It will be overwritten when translations are pulled from Transifex.
-#
-# To work with us on translations, join this project:
+# To work with us on translations, see:
 # https://www.transifex.com/projects/p/discourse-org/
+#
+# This is a "source" file, which is used by Transifex to get translations for other languages.
+# After this file is changed, it needs to be pushed by a maintainer to Transifex:
+#
+#   tx push -s
+#
+# Read more here: https://meta.discourse.org/t/contribute-a-translation-to-discourse/14882
+#
+# To validate this YAML file after you change it, please paste it into
+# http://yamllint.com/
 
 en:
   js:
     poll:
       voters:
-        zero: "voters"
         one: "voter"
         other: "voters"
       total_votes:
-        zero: "total votes"
         one: "total vote"
         other: "total votes"
 

--- a/plugins/poll/config/locales/server.en.yml
+++ b/plugins/poll/config/locales/server.en.yml
@@ -1,9 +1,18 @@
 # encoding: utf-8
+# This file contains content for the server portion of the poll plugin used by Ruby
 #
-# Never edit this file. It will be overwritten when translations are pulled from Transifex.
-#
-# To work with us on translations, join this project:
+# To work with us on translations, see:
 # https://www.transifex.com/projects/p/discourse-org/
+#
+# This is a "source" file, which is used by Transifex to get translations for other languages.
+# After this file is changed, it needs to be pushed by a maintainer to Transifex:
+#
+#   tx push -s
+#
+# Read more here: https://meta.discourse.org/t/contribute-a-translation-to-discourse/14882
+#
+# To validate this YAML file after you change it, please paste it into
+# http://yamllint.com/
 
 en:
   site_settings:


### PR DESCRIPTION
This removes invalid translation keys from polls plugin and should allow Transifex to detect those keys as pluralized. And it changes the file headers since they were wrong.

https://meta.discourse.org/t/polls-labels-russian-pluralization-missing-translations/30235