### PR TITLE
FIX: combo-box should assign default value on initialize

### DIFF
--- a/app/assets/javascripts/discourse/components/combo-box.js.es6
+++ b/app/assets/javascripts/discourse/components/combo-box.js.es6
@@ -74,6 +74,7 @@ export default Ember.Component.extend({
       }
       self.set('value', val);
     });
+    $elem.trigger('change');
   }.on('didInsertElement'),
 
   _destroyDropdown: function() {


### PR DESCRIPTION
This fixes the bug where admins could post to uncategorized even when it was disabled.