### PR TITLE
Add rudimentary HTTP error codes to ajax-error

### DIFF
--- a/app/assets/javascripts/discourse/lib/ajax-error.js.es6
+++ b/app/assets/javascripts/discourse/lib/ajax-error.js.es6
@@ -36,6 +36,12 @@ function extractError(error) {
     }
   }
 
+  if (!parsedError) {
+    if (error.status && error.status >= 400) {
+      parsedError = error.status + " " + error.statusText;
+    }
+  }
+
   return parsedError || I18n.t('generic_error');
 }
 

--- a/app/assets/javascripts/discourse/lib/ajax-error.js.es6
+++ b/app/assets/javascripts/discourse/lib/ajax-error.js.es6
@@ -28,7 +28,7 @@ function extractError(error) {
 
   if (parsedJSON) {
     if (parsedJSON.errors && parsedJSON.errors.length > 0) {
-      parsedError = parsedJSON.errors[0];
+      parsedError = parsedJSON.errors.join("<br>");
     } else if (parsedJSON.error) {
       parsedError = parsedJSON.error;
     } else if (parsedJSON.failed) {


### PR DESCRIPTION
Better error handling is better for everybody.

No localization for this, though :/ People can probably figure it out.