### PR TITLE
FIX: Don't root CSV export URLs

### DIFF
--- a/app/jobs/regular/export_csv_file.rb
+++ b/app/jobs/regular/export_csv_file.rb
@@ -146,7 +146,7 @@ module Jobs
           category_name = "-"
         end
         is_pm = topic_data.archetype == "private_message" ? I18n.t("csv_export.boolean_yes") : I18n.t("csv_export.boolean_no")
-        url = "#{Discourse.base_url}/t/#{topic_data.slug}/#{topic_data.id}/#{user_archive['post_number']}"
+        url = "#{Discourse.base_uri}/t/#{topic_data.slug}/#{topic_data.id}/#{user_archive['post_number']}"
 
         topic_hash = {"post" => user_archive['raw'], "topic_title" => topic_data.title, "category" => category_name, "sub_category" => sub_category, "is_pm" => is_pm, "url" => url}
         user_archive.merge!(topic_hash)
@@ -288,7 +288,7 @@ module Jobs
       def notify_user
         if @current_user
           if @file_name != "" && File.exists?("#{UserExport.base_directory}/#{@file_name}.gz")
-            SystemMessage.create_from_system_user(@current_user, :csv_export_succeeded, download_link: "#{Discourse.base_url}/export_csv/#{@file_name}.gz", file_name: "#{@file_name}.gz", file_size: number_to_human_size(File.size("#{UserExport.base_directory}/#{@file_name}.gz")))
+            SystemMessage.create_from_system_user(@current_user, :csv_export_succeeded, download_link: "#{Discourse.base_uri}/export_csv/#{@file_name}.gz", file_name: "#{@file_name}.gz", file_size: number_to_human_size(File.size("#{UserExport.base_directory}/#{@file_name}.gz")))
           else
             SystemMessage.create_from_system_user(@current_user, :csv_export_failed)
           end


### PR DESCRIPTION
Should fix https://meta.discourse.org/t/data-exports-wrong-redirect/30774 by making the link start with `/` instead of `//`.