### PR TITLE
FIX: Substrings of reserved usernames no longer treated as reserved

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -231,7 +231,7 @@ class UsersController < ApplicationController
       return fail_with("login.password_too_long")
     end
 
-    if SiteSetting.reserved_usernames.include? params[:username].downcase
+    if SiteSetting.reserved_usernames.split("|").include? params[:username].downcase
       return fail_with("login.reserved_username")
     end
 


### PR DESCRIPTION
I'm assuming that's not intended functionality. For some background, it looks like SiteSetting.reserved_usernames is a string of usernames separated by "|". The current code checks incoming usernames against being a substring of SiteSetting.reserved_usernames. This causes, for example, "strator" to be considered reserved since it is a substring of "administrator". The fix is pretty straightforward, I simply tokenized the string into an array of reserved username strings.