### PR TITLE
FIX: Automatically add like-count to post menu

### DIFF
--- a/app/assets/stylesheets/common/base/onebox.scss
+++ b/app/assets/stylesheets/common/base/onebox.scss
@@ -238,3 +238,7 @@ pre.onebox code {
 .onebox-body .github-content-right{
   margin-left:100px;
 }
+
+.twitterstatus .onebox-body p {
+  white-space: pre-wrap;
+}

--- a/db/migrate/20150709021818_add_like_count_to_post_menu.rb
+++ b/db/migrate/20150709021818_add_like_count_to_post_menu.rb
@@ -1,0 +1,10 @@
+class AddLikeCountToPostMenu < ActiveRecord::Migration
+  def up
+    execute <<SQL
+UPDATE site_settings
+SET value = replace(value, 'like', 'like-count|like')
+WHERE name = 'post_menu'
+AND value NOT LIKE '%like-count%'
+SQL
+  end
+end


### PR DESCRIPTION
https://meta.discourse.org/t/missing-all-the-likes-on-every-post-after-upgrading-to-latest-version-53b0b70/30898/