### PR TITLE
UX: Shift notification badge down on mobile.

### DIFF
--- a/app/assets/stylesheets/mobile/header.scss
+++ b/app/assets/stylesheets/mobile/header.scss
@@ -19,6 +19,7 @@
 
   .icons {
     .badge-notification {
+      top: -5px;
       color: $secondary;
     }
 


### PR DESCRIPTION
## Before
![screenshot from 2015-07-09 19 18 25](https://cloud.githubusercontent.com/assets/4335742/8594020/b6e468c0-266f-11e5-9c91-ffa4caf6e466.png)

## After
![screenshot from 2015-07-09 19 17 52](https://cloud.githubusercontent.com/assets/4335742/8594021/b6e569aa-266f-11e5-9b1e-af16677183ce.png)

https://meta.discourse.org/t/notification-count-badge-cut-off-on-mobile/30794