### PR TITLE
Fix LocalStore.remove_file to not raise if source doesn't exist

### DIFF
--- a/lib/file_store/local_store.rb
+++ b/lib/file_store/local_store.rb
@@ -14,7 +14,7 @@ module FileStore
       path = public_dir + url
       tombstone = public_dir + url.sub("/uploads/", "/tombstone/")
       FileUtils.mkdir_p(Pathname.new(tombstone).dirname)
-      FileUtils.move(path, tombstone)
+      FileUtils.move(path, tombstone, :force => true)
     rescue Errno::ENOENT
       # don't care if the file isn't there
     end


### PR DESCRIPTION
FileUtils.move actually ends up raising an "unknown file type" error if the file doesn't exist instead of Errno::ENOENT.

It's possible to rescue this, but in the end it's easier to just ask move not to throw an error, since we're going to throw it away anyway.