### PR TITLE
FIX: Add padding to container

### DIFF
--- a/app/assets/javascripts/discourse/templates/discovery.hbs
+++ b/app/assets/javascripts/discourse/templates/discovery.hbs
@@ -4,8 +4,8 @@
   {{discourse-banner user=currentUser banner=site.banner}}
 </div>
 
-<div class='list-controls'>
-  <div class="container">
+<div class='container'>
+  <div class="list-controls">
     {{outlet "navigation-bar"}}
   </div>
 </div>

--- a/app/assets/javascripts/discourse/templates/topic.hbs
+++ b/app/assets/javascripts/discourse/templates/topic.hbs
@@ -10,8 +10,8 @@
 
 {{#if model.postStream.loaded}}
   {{#if model.postStream.firstPostPresent}}
-    <div id='topic-title'>
-      <div class='container'>
+    <div class='container'>
+      <div id='topic-title'>
 
         <div class="title-wrapper">
           {{#if editingTopic}}

--- a/app/assets/stylesheets/desktop/discourse.scss
+++ b/app/assets/stylesheets/desktop/discourse.scss
@@ -2,6 +2,10 @@
 // BEWARE: changing these styles implies they take effect anywhere they are seen
 // throughout the Discourse application
 
+.container {
+  padding: 0 10px;
+}
+
 @include medium-width {
   body {
     min-width: $medium-width;

--- a/app/assets/stylesheets/desktop/topic-list.scss
+++ b/app/assets/stylesheets/desktop/topic-list.scss
@@ -293,19 +293,26 @@ button.dismiss-read {
   margin-right: 15px;
 }
 
+/* Add left padding for small screens */
+@media all
+and (max-width : 1005px) {
+
+  .list-controls {
+    padding: 0 5px;
+  }
+
+  #topic-title,
+  .container.posts,
+  .topic-list-bottom {
+    padding-left: 10px;
+  }
+
+}
+
 /* Tablet (portrait) ----------- */
 
 @media all
 and (max-width : 850px) {
-
-  // add some left padding to topics otherwise everything is 100% flush
-  // with left edge in portrait tablet, which looks awful
-  #topic-title {
-    padding-left: 10px;
-  }
-  .container.posts {
-    padding-left: 10px;
-  }
 
   .nav-pills {
     > li > a {
@@ -315,7 +322,6 @@ and (max-width : 850px) {
   }
 
   .list-controls {
-    padding: 0 5px;
 
     .btn {
         font-size: 1em

--- a/app/assets/stylesheets/desktop/topic-list.scss
+++ b/app/assets/stylesheets/desktop/topic-list.scss
@@ -6,6 +6,8 @@
 // --------------------------------------------------
 
 .list-controls {
+  padding: 0 5px;
+
   .nav {
     float: left;
     margin-bottom: 18px;
@@ -237,6 +239,7 @@
 
 .topic-list-bottom {
   margin: 20px 0;
+  padding-left: 10px;
 }
 
 // Misc. stuff
@@ -291,22 +294,6 @@ button.dismiss-read {
   float: left;
   margin-bottom: 15px;
   margin-right: 15px;
-}
-
-/* Add left padding for small screens */
-@media all
-and (max-width : 1005px) {
-
-  .list-controls {
-    padding: 0 5px;
-  }
-
-  #topic-title,
-  .container.posts,
-  .topic-list-bottom {
-    padding-left: 10px;
-  }
-
 }
 
 /* Tablet (portrait) ----------- */

--- a/app/assets/stylesheets/desktop/topic-list.scss
+++ b/app/assets/stylesheets/desktop/topic-list.scss
@@ -6,6 +6,7 @@
 // --------------------------------------------------
 
 .list-controls {
+  @include clearfix;
 
   .nav {
     float: left;

--- a/app/assets/stylesheets/desktop/topic-list.scss
+++ b/app/assets/stylesheets/desktop/topic-list.scss
@@ -6,7 +6,6 @@
 // --------------------------------------------------
 
 .list-controls {
-  padding: 0 5px;
 
   .nav {
     float: left;
@@ -239,7 +238,6 @@
 
 .topic-list-bottom {
   margin: 20px 0;
-  padding-left: 10px;
 }
 
 // Misc. stuff

--- a/app/assets/stylesheets/desktop/topic.scss
+++ b/app/assets/stylesheets/desktop/topic.scss
@@ -19,6 +19,7 @@
   z-index: 1000;
   padding-top: 14px;
   margin-bottom: 10px;
+  @include clearfix;
   .star {
     font-size: 1.429em;
     margin-top: 6px;

--- a/app/assets/stylesheets/desktop/topic.scss
+++ b/app/assets/stylesheets/desktop/topic.scss
@@ -1,7 +1,3 @@
-.container.posts {
-  padding-left: 10px;
-}
-
 .post-actions {
   @include unselectable;
   clear: both;
@@ -22,7 +18,6 @@
 #topic-title {
   z-index: 1000;
   padding-top: 14px;
-  padding-left: 10px;
   margin-bottom: 10px;
   .star {
     font-size: 1.429em;

--- a/app/assets/stylesheets/desktop/topic.scss
+++ b/app/assets/stylesheets/desktop/topic.scss
@@ -1,3 +1,7 @@
+.container.posts {
+  padding-left: 10px;
+}
+
 .post-actions {
   @include unselectable;
   clear: both;
@@ -18,6 +22,7 @@
 #topic-title {
   z-index: 1000;
   padding-top: 14px;
+  padding-left: 10px;
   margin-bottom: 10px;
   .star {
     font-size: 1.429em;


### PR DESCRIPTION
At screen widths between 850px and 1005px there is no left margin on the page. There are a few possible fixes. Here is one.

- puts `.list-controls` and `#topic-title` inside of `.container`
- removes padding from `#topic-title`, `.container.posts`, and `.list-controls`
- adds 10px padding to `.container`

Doing it this way allows for the option of setting  separate backgrounds  on the html and `.container` elements. Having padding as a property of the container makes sense. You can control all the padding in one place and everything will line up. 

![screenshot 2015-07-19 11 08 17](https://cloud.githubusercontent.com/assets/2975917/8767229/917361e8-2e0a-11e5-9ec2-8f5e36daed27.png)
