### PR TITLE
Expose poll_maximum_options to client

### DIFF
--- a/plugins/poll/config/settings.yml
+++ b/plugins/poll/config/settings.yml
@@ -3,3 +3,4 @@ plugins:
     default: true
   poll_maximum_options:
     default: 20
+    client: true


### PR DESCRIPTION
At present this doesn't actually seem to be exposed to the client.

I discovered this by accident whilst trying to write my own plugin:

https://github.com/discourse/discourse/blob/7b6d6b76eb3b7dbf1982c382a1f0e981e7ff8eee/app/models/site_setting.rb#L17-L18