### PR TITLE
FIX: padding and alignment issues

### DIFF
--- a/app/assets/javascripts/discourse/templates/application.hbs
+++ b/app/assets/javascripts/discourse/templates/application.hbs
@@ -1,6 +1,6 @@
 {{render "header"}}
 
-<div id='main-outlet'>
+<div id='main-outlet' class='wrap'>
   {{outlet}}
   {{render "user-card"}}
 </div>

--- a/app/assets/javascripts/discourse/templates/header.hbs
+++ b/app/assets/javascripts/discourse/templates/header.hbs
@@ -1,4 +1,4 @@
-<div class='container'>
+<div class='wrap'>
   <div class='contents clearfix'>
 
     {{home-logo minimized=showExtraInfo}}

--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -10,7 +10,7 @@ img.avatar {
   @extend .clearfix;
   margin-right: auto;
   margin-left: auto;
-  padding: 8px;
+  padding: 0 8px;
   .contents {
     position: relative;
   }

--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -4,8 +4,13 @@ img.avatar {
 
 .container {
   @extend .clearfix;
+}
+
+.wrap {
+  @extend .clearfix;
   margin-right: auto;
   margin-left: auto;
+  padding: 8px;
   .contents {
     position: relative;
   }

--- a/app/assets/stylesheets/desktop/discourse.scss
+++ b/app/assets/stylesheets/desktop/discourse.scss
@@ -6,7 +6,7 @@
   body {
     min-width: $medium-width;
   }
-  .container,
+  .wrap,
   .full-width {
     width: $medium-width;
   }
@@ -17,7 +17,7 @@ and (max-width : 570px) {
   body {
     min-width: 0;
   }
-  .container,
+  .wrap,
   .full-width {
     min-width: 0;
   }

--- a/app/assets/stylesheets/desktop/topic-list.scss
+++ b/app/assets/stylesheets/desktop/topic-list.scss
@@ -298,12 +298,6 @@ button.dismiss-read {
 @media all
 and (max-width : 850px) {
 
-  // add some left padding to topics otherwise everything is 100% flush
-  // with left edge in portrait tablet, which looks awful
-  #topic-title {
-    padding-left: 10px;
-  }
-
   .nav-pills {
     > li > a {
       font-size: 1em;
@@ -312,7 +306,6 @@ and (max-width : 850px) {
   }
 
   .list-controls {
-    padding: 0 5px;
 
     .btn {
         font-size: 1em

--- a/app/assets/stylesheets/desktop/topic-list.scss
+++ b/app/assets/stylesheets/desktop/topic-list.scss
@@ -303,9 +303,6 @@ and (max-width : 850px) {
   #topic-title {
     padding-left: 10px;
   }
-  .container.posts {
-    padding-left: 10px;
-  }
 
   .nav-pills {
     > li > a {

--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -1,8 +1,5 @@
-.container {
-  @extend .clearfix;
+.wrap {
   max-width: $large-width;
-  margin-right: auto;
-  margin-left: auto;
 }
 
 .full-width {


### PR DESCRIPTION
This adds the class `.wrap` to the `#main-outlet` div. It serves to wrap all content. It defines a width, a margin relative to the browser window, and padding relative to the application content. It is set with a consistent padding left and right of 8px.  This can be adjusted. The `.container` class is redefined to just extend `.clearfix`. 

This relates to this topic on Discourse: https://meta.discourse.org/t/borders-have-a-unsweet-spot-of-window-size/31049

![screenshot 2015-07-20 01 09 40](https://cloud.githubusercontent.com/assets/2975917/8772115/de858920-2e7d-11e5-9958-e12e1567be78.png)
