### PR TITLE
FIX: Remove unnecessary padding and margins from mobile view

### DIFF
--- a/app/assets/stylesheets/mobile/discourse.scss
+++ b/app/assets/stylesheets/mobile/discourse.scss
@@ -6,12 +6,20 @@ body {
   background-color: $secondary;
 }
 
+// This sets the space between the application content and the edge of the
+// screen. This value is required in 'mobile/header.scss' to set the position
+// of the drop-down menu.
+$mobile-wrapper-padding: 10px;
+.wrap {
+  padding: 0 $mobile-wrapper-padding;
+}
+
 body {
 
   .boxed {
     height: 100%;
     .contents {
-      padding: 10px;
+      padding: 10px 0;
     }
     &.white {
       background-color: $secondary;

--- a/app/assets/stylesheets/mobile/header.scss
+++ b/app/assets/stylesheets/mobile/header.scss
@@ -43,6 +43,7 @@
 .d-dropdown {
   width: 290px;
   margin-top: -1px;
+  right: -$mobile-wrapper-padding; // Line-up with edge of screen, not edge of padding
 
   // Common
 

--- a/app/assets/stylesheets/mobile/topic-list.scss
+++ b/app/assets/stylesheets/mobile/topic-list.scss
@@ -9,7 +9,7 @@
   .category-breadcrumb.hidden {
     display: none;
   }
-  margin: 5px;
+  margin: 5px 0;
   .nav {
     float: left;
     margin-right: 15px;
@@ -71,7 +71,7 @@
 
   th,
   td {
-    padding: 7px 5px;
+    padding: 7px 0;
     color: scale-color($primary, $lightness: 50%);
   }
 
@@ -223,7 +223,7 @@ tr.category-topic-link {
 
 
 .topic-list-bottom {
-  margin: 20px 12px 0 12px;
+  margin: 20px 0 0 0;
 }
 
 

--- a/app/assets/stylesheets/mobile/topic-post.scss
+++ b/app/assets/stylesheets/mobile/topic-post.scss
@@ -167,7 +167,7 @@ a.star {
 
 .topic-map {
 
-  margin: 10px;
+  margin: 10px 0;
   background: dark-light-diff($primary, $secondary, 97%, -45%);
   border: 1px solid dark-light-diff($primary, $secondary, 90%, -65%);
   border-top: none; // would cause double top border
@@ -300,8 +300,9 @@ a.star {
 }
 
 #topic-footer-buttons {
+  @include clearfix;
   border-top: 1px solid dark-light-diff($primary, $secondary, 90%, -60%);
-  padding: 20px 10px 0 10px;
+  padding: 20px 0 0 0;
   .fa-bookmark.bookmarked { color: $tertiary; }
 }
 
@@ -313,7 +314,7 @@ a.star {
 
 #suggested-topics {
   clear: left;
-  padding: 20px 10px 15px 10px;
+  padding: 20px 0 15px 0;
     th.views, td.views, td.activity, th.activity, th.likes, td.likes {
     display: none;
     }
@@ -344,7 +345,7 @@ span.post-count {
 #topic-title {
   z-index: 1000;
   margin: 0 0 0 0 !important;
-  padding: 15px 10px 15px 10px;
+  padding: 15px 0;
 }
 
 .topic-post {

--- a/app/assets/stylesheets/mobile/topic.scss
+++ b/app/assets/stylesheets/mobile/topic.scss
@@ -14,8 +14,8 @@
 .edits {margin-right: 5px;}
 
 #topic-title {
-  margin-bottom: 20px;
-  margin: 0 60px 10px 20px;
+  //margin-bottom: 20px;
+  margin: 0 60px 10px 0;
   h1 {
     font-size: 1.5em;
     line-height: 1.25em;


### PR DESCRIPTION
Lines up all content in mobile view with padding set on `.wrap`.

Alignment of elements in mobile-view was previously set individually on each element with margins and padding. This PR removes left and right padding from elements that span the full-screen width in the mobile-view. They are all now aligned with the padding set on `.wrap`.

Instead of making these changes, it would also be possible to set the left and right padding on `.wrap`  to 0 for the mobile view.