### PR TITLE
FEATURE: Display emojis in user stream.

### DIFF
--- a/app/serializers/user_action_serializer.rb
+++ b/app/serializers/user_action_serializer.rb
@@ -32,7 +32,7 @@ class UserActionSerializer < ApplicationSerializer
 
   def excerpt
     cooked = object.cooked || PrettyText.cook(object.raw)
-    PrettyText.excerpt(cooked, 300) if cooked
+    PrettyText.excerpt(cooked, 300, { keep_emojis: true }) if cooked
   end
 
   def avatar_template

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -196,7 +196,7 @@ class UserSerializer < BasicUserSerializer
   end
 
   def bio_excerpt
-    object.user_profile.bio_excerpt(350 ,keep_newlines: true)
+    object.user_profile.bio_excerpt(350 , { keep_newlines: true, keep_emojis: true })
   end
 
   def include_suspend_reason?

--- a/lib/excerpt_parser.rb
+++ b/lib/excerpt_parser.rb
@@ -13,6 +13,7 @@ class ExcerptParser < Nokogiri::XML::SAX::Document
     @text_entities = options[:text_entities] == true
     @markdown_images = options[:markdown_images] == true
     @keep_newlines = options[:keep_newlines] == true
+    @keep_emojis = options[:keep_emojis] == true
     @start_excerpt = false
   end
 
@@ -48,10 +49,15 @@ class ExcerptParser < Nokogiri::XML::SAX::Document
     case name
       when "img"
 
+        attributes = Hash[*attributes.flatten]
+
+        if @keep_emojis && attributes["class"] == 'emoji'
+          return include_tag(name, attributes)
+        end
+
         # If include_images is set, include the image in markdown
         characters("!") if @markdown_images
 
-        attributes = Hash[*attributes.flatten]
         if attributes["alt"]
           characters("[#{attributes["alt"]}]")
         elsif attributes["title"]

--- a/spec/components/pretty_text_spec.rb
+++ b/spec/components/pretty_text_spec.rb
@@ -230,6 +230,11 @@ describe PrettyText do
       expect(PrettyText.excerpt("&#39;", 500, text_entities: true)).to eq("'")
     end
 
+    it "should have an option to preserve emojis" do
+      emoji_image = "<img src='/images/emoji/emoji_one/heart.png?v=0' title=':heart:' class='emoji' alt='heart'>"
+      expect(PrettyText.excerpt(emoji_image, 100, { keep_emojis: true })).to match_html(emoji_image)
+    end
+
   end
 
   describe "strip links" do


### PR DESCRIPTION
https://meta.discourse.org/t/emoji-dont-appear-in-user-card-description-or-user-profile-posts/29904

![screenshot from 2015-07-23 23 28 44](https://cloud.githubusercontent.com/assets/4335742/8854457/95ba2a6c-3192-11e5-984a-617caf06ff96.png)

![screenshot from 2015-07-23 23 50 29](https://cloud.githubusercontent.com/assets/4335742/8855043/9f0c0006-3195-11e5-9f00-1d33ad6f70c0.png)
