### PR TITLE
FIX: Prefer user's primary group when setting title

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -280,6 +280,13 @@ class Group < ActiveRecord::Base
     managers << user
   end
 
+  def destroy
+    self.users.each do |user|
+      remove(user)
+    end
+    super
+  end
+
   protected
 
     def name_format_validator
@@ -305,26 +312,10 @@ class Group < ActiveRecord::Base
 
     def update_title
       return if new_record? && !self.title.present?
+      return unless self.title_changed?
 
-      if self.title_changed?
-        sql = <<SQL
-        UPDATE users SET title = :title
-        WHERE (title = :title_was OR
-              title = '' OR
-              title IS NULL) AND
-              COALESCE(title,'') <> COALESCE(:title,'') AND
-              id IN (
-                SELECT user_id
-                FROM group_users
-                WHERE group_id = :id
-              )
-SQL
-
-        self.class.exec_sql(sql,
-              title: title,
-              title_was: title_was,
-              id: id
-        )
+      self.users.each do |user|
+        user.set_title_from_groups(title_was)
       end
     end
 

--- a/app/models/group_user.rb
+++ b/app/models/group_user.rb
@@ -21,7 +21,7 @@ class GroupUser < ActiveRecord::Base
   end
 
   def remove_primary_group
-    if user.primary_group
+    if user && group && user.primary_group
       self.class.exec_sql("UPDATE users
                            SET primary_group_id = NULL
                            WHERE id = :user_id AND primary_group_id = :id",

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -73,6 +73,7 @@ describe Group do
   it "Correctly handles title" do
 
     group = Fabricate(:group, title: 'Super Awesome')
+    group2 = Fabricate(:group, name: "second_group", title: 'Different Title')
     user = Fabricate(:user)
 
     expect(user.title).to eq nil
@@ -99,6 +100,33 @@ describe Group do
 
     user.reload
     expect(user.title).to eq "BOB"
+
+    group2.add(user)
+    user.reload
+
+    expect(user.title).to eq 'BOB'
+
+    user.primary_group = group
+    user.save
+    user.reload
+
+    expect(user.title).to eq 'BOB'
+
+    user.primary_group = group2
+    user.reload
+
+    expect(user.title).to eq 'Different Title'
+
+    group2.title = 'Title 3'
+    group2.save
+    user.reload
+
+    expect(user.title).to eq 'Title 3'
+
+    group2.remove(user)
+    user.reload
+
+    expect(user.title).to eq 'BOB'
 
     group.remove(user)
 


### PR DESCRIPTION
https://meta.discourse.org/t/invited-person-s-account-should-have-its-title-set-from-the-primary-group/31465