### PR TITLE
UX: Social login buttons alignment off on mobile.

### DIFF
--- a/app/assets/stylesheets/common/components/buttons.css.scss
+++ b/app/assets/stylesheets/common/components/buttons.css.scss
@@ -128,8 +128,7 @@
   &:before {
     margin-right: 9px;
     font-family: FontAwesome;
-    line-height: 1.6em;
-    font-size: 1.3em;
+    font-size: 17px;
   }
   &.google, &.google_oauth2 {
     background: $google;


### PR DESCRIPTION
## Before

![screenshot from 2015-08-01 11 50 34](https://cloud.githubusercontent.com/assets/4335742/9020547/f40776f6-3845-11e5-8164-faa44eb30cd4.png)

![screenshot from 2015-08-01 11 55 50](https://cloud.githubusercontent.com/assets/4335742/9020546/efe5d2b6-3845-11e5-95fa-6f1689fc96c6.png)


<hr>

## Current (Alignment off on chrome but fine on firefox)
![screenshot from 2015-08-01 12 04 54](https://cloud.githubusercontent.com/assets/4335742/9020541/93996680-3845-11e5-89ab-c4cd520595ec.png)

![screenshot from 2015-08-01 12 04 44](https://cloud.githubusercontent.com/assets/4335742/9020542/93cb6b30-3845-11e5-8f82-b231c4891055.png)

<hr>

## With Fix
![screenshot from 2015-08-01 12 10 12](https://cloud.githubusercontent.com/assets/4335742/9020556/49a0d56c-3846-11e5-8609-0741aa15e288.png)
![screenshot from 2015-08-01 12 10 03](https://cloud.githubusercontent.com/assets/4335742/9020555/499e4a86-3846-11e5-9952-f5227196a97a.png)

cc/ @SamSaffron I'm not sure if the increase height of the buttons was intended so I reverted back to the previous height.
