### PR TITLE
FEATURE: Show "load more" button on tall screens

### DIFF
--- a/app/assets/javascripts/discourse/mixins/scrolling.js
+++ b/app/assets/javascripts/discourse/mixins/scrolling.js
@@ -33,6 +33,7 @@ Discourse.Scrolling = Em.Mixin.create({
     }
 
     Discourse.ScrollingDOMMethods.bindOnScroll(onScrollMethod, opts.name);
+    Em.run.scheduleOnce('afterRender', onScrollMethod);
   },
 
   /**


### PR DESCRIPTION
Simple workaround for https://meta.discourse.org/t/infiniscroll-not-working-if-the-last-item-of-first-batch-is-not-off-screen-part-deux/23596/12

![image](https://cloud.githubusercontent.com/assets/627891/9047973/6d8bffa6-39ea-11e5-9cb4-ac44dce33cde.png)
