### PR TITLE
Split post_actions table into views

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -460,6 +460,7 @@ class ApplicationController < ActionController::Base
       post_serializer = PostSerializer.new(post, scope: guardian, root: false)
       post_serializer.add_raw = add_raw
 
+      # TODO - refactor
       counts = PostAction.counts_for([post], current_user)
       if counts && counts = counts[post.id]
         post_serializer.post_actions = counts

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -6,9 +6,8 @@ class Bookmark < PostAction
   self.pa_type = PostActionType.bookmark
 
   before_create do
-    raise AlreadyActed if PostAction.where(user_id: user_id)
+    raise AlreadyActed if Bookmark.where(user_id: user_id)
                             .where(post_id: post_id)
-                            .where(post_action_type_id: pa_type)
                             .where(deleted_at: nil)
                             .exists?
   end

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -1,10 +1,10 @@
 
-class Like < PostAction
+class Bookmark < PostAction
 
-  self.table_name = :likes
+  self.table_name = :bookmarks
 
   def self.pa_type
-    PostActionType.like
+    PostActionType.bookmark
   end
 
   def pa_type
@@ -40,11 +40,11 @@ class Like < PostAction
   end
 
   def is_bookmark?
-    false
+    true
   end
 
   def is_like?
-    true
+    false
   end
 
   def is_flag?
@@ -59,7 +59,7 @@ end
 
 # == Schema Information
 #
-# Table name: likes
+# Table name: bookmarks
 #
 #  id                  :integer          primary key
 #  post_id             :integer

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -1,35 +1,9 @@
 
 class Bookmark < PostAction
+  include PostActionSubclassMixin
 
   self.table_name = :bookmarks
-
-  def self.pa_type
-    PostActionType.bookmark
-  end
-
-  def pa_type
-    self.class.pa_type
-  end
-
-  # === BEGIN CRAZY SUBCLASSING MADNESS === #
-
-  def self.sti_name
-    pa_type
-  end
-
-  def self.type_condition(table = arel_table)
-    table[:post_action_type_id].in([pa_type])
-  end
-
-  before_save do
-    self.post_action_type_id = pa_type
-  end
-
-  def ensure_proper_type
-    write_attribute(:post_action_type_id, pa_type)
-  end
-
-  # === END CRAZY SUBCLASSING MADNESS === #
+  self.pa_type = PostActionType.bookmark
 
   before_create do
     raise AlreadyActed if PostAction.where(user_id: user_id)

--- a/app/models/flag.rb
+++ b/app/models/flag.rb
@@ -1,0 +1,76 @@
+
+class Flag < PostAction
+
+  self.table_name = :flags
+
+  validates_presence_of :post_action_type_id
+
+  # === BEGIN CRAZY SUBCLASSING MADNESS === #
+
+  def self.sti_name
+    # apparently this works lol
+    PostActionType.all_flag_type_ids
+  end
+
+  def self.type_condition(table = arel_table)
+    table[:post_action_type_id].in(PostActionType.all_flag_type_ids)
+  end
+
+  def ensure_proper_type
+    raise ActiveRecord::ValidationError "Bad post_action_type_id value for Flag" unless
+          PostActionType.all_flag_type_ids.include? post_action_type_id
+  end
+
+  # === END CRAZY SUBCLASSING MADNESS === #
+
+  before_create do
+    raise AlreadyActed if PostAction.where(user_id: user_id)
+                            .where(post_id: post_id)
+                            .where(post_action_type_id: PostActionType.all_flag_type_ids)
+                            .where(deleted_at: nil)
+                            .where(disagreed_at: nil)
+                            .where(targets_topic: targets_topic)
+                            .exists?
+  end
+
+  def is_bookmark?
+    false
+  end
+
+  def is_like?
+    false
+  end
+
+  def is_flag?
+    true
+  end
+
+  def is_private_message?
+    post_action_type_id == PostActionType.types[:notify_user] ||
+    post_action_type_id == PostActionType.types[:notify_moderators]
+  end
+
+end
+
+# == Schema Information
+#
+# Table name: flags
+#
+#  id                  :integer          primary key
+#  post_id             :integer
+#  user_id             :integer
+#  post_action_type_id :integer
+#  deleted_at          :datetime
+#  created_at          :datetime
+#  updated_at          :datetime
+#  deleted_by_id       :integer
+#  related_post_id     :integer
+#  staff_took_action   :boolean
+#  deferred_by_id      :integer
+#  targets_topic       :boolean
+#  agreed_at           :datetime
+#  agreed_by_id        :integer
+#  deferred_at         :datetime
+#  disagreed_at        :datetime
+#  disagreed_by_id     :integer
+#

--- a/app/models/flag.rb
+++ b/app/models/flag.rb
@@ -1,9 +1,9 @@
 
 class Flag < PostAction
-
   self.table_name = :flags
 
   validates_presence_of :post_action_type_id
+  after_save :enforce_rules
 
   # === BEGIN CRAZY SUBCLASSING MADNESS === #
 
@@ -17,8 +17,12 @@ class Flag < PostAction
   end
 
   def ensure_proper_type
-    raise ActiveRecord::ValidationError "Bad post_action_type_id value for Flag" unless
-          PostActionType.all_flag_type_ids.include? post_action_type_id
+    if post_action_type_id.present?
+      raise ActiveRecord::ValidationError "Bad post_action_type_id value for Flag" unless
+        PostActionType.all_flag_type_ids.include? post_action_type_id
+    else
+      write_attribute(:post_action_type_id, PostActionType.all_flag_type_ids.first)
+    end
   end
 
   # === END CRAZY SUBCLASSING MADNESS === #
@@ -26,7 +30,7 @@ class Flag < PostAction
   before_create do
     raise AlreadyActed if PostAction.where(user_id: user_id)
                             .where(post_id: post_id)
-                            .where(post_action_type_id: PostActionType.all_flag_type_ids)
+                            .where(post_action_type_id: PostActionType.flag_types.values) # exclude PM
                             .where(deleted_at: nil)
                             .where(disagreed_at: nil)
                             .where(targets_topic: targets_topic)
@@ -50,6 +54,258 @@ class Flag < PostAction
     post_action_type_id == PostActionType.types[:notify_moderators]
   end
 
+  def enforce_rules
+    post = Post.with_deleted.where(id: post_id).first
+    Flag.auto_close_if_threshold_reached(post.topic)
+    Flag.auto_hide_if_needed(user, post, post_action_type_key)
+    SpamRulesEnforcer.enforce!(post.user) if post_action_type_key == :spam
+  end
+
+  def self.flag_count_by_date(start_date, end_date, category_id=nil)
+    result = Flag.where('flags.created_at >= ? AND flags.created_at <= ?', start_date, end_date)
+    result = result.where(post_action_type_id: PostActionType.flag_types.values)
+    result = result.joins(post: :topic).where("topics.category_id = ?", category_id) if category_id
+    result.group('date(flags.created_at)')
+      .order('date(flags.created_at)')
+      .count
+  end
+
+  def self.update_flagged_posts_count
+    posts_flagged_count = Flag.active
+                            .flags
+                            .joins(post: :topic)
+                            .where('posts.deleted_at' => nil)
+                            .where('topics.deleted_at' => nil)
+                            .count('DISTINCT posts.id')
+
+    $redis.set('posts_flagged_count', posts_flagged_count)
+    user_ids = User.staff.pluck(:id)
+    MessageBus.publish('/flagged_counts', { total: posts_flagged_count }, { user_ids: user_ids })
+  end
+
+  def self.flagged_posts_count
+    $redis.get('posts_flagged_count').to_i
+  end
+
+  def self.active_flags_counts_for(collection)
+    return {} if collection.blank?
+
+    collection_ids = collection.map(&:id)
+
+    post_actions = Flag.active.flags.where(post_id: collection_ids)
+
+    user_actions = {}
+    post_actions.each do |post_action|
+      user_actions[post_action.post_id] ||= {}
+      user_actions[post_action.post_id][post_action.post_action_type_id] ||= []
+      user_actions[post_action.post_id][post_action.post_action_type_id] << post_action
+    end
+
+    user_actions
+  end
+  def self.agree_flags!(post, moderator, delete_post=false)
+    actions = PostAction.active
+                .where(post_id: post.id)
+                .where(post_action_type_id: PostActionType.flag_types.values)
+
+    trigger_spam = false
+    actions.each do |action|
+      action.agreed_at = Time.zone.now
+      action.agreed_by_id = moderator.id
+      # so callback is called
+      action.save
+      action.add_moderator_post_if_needed(moderator, :agreed, delete_post)
+      @trigger_spam = true if action.post_action_type_id == PostActionType.types[:spam]
+    end
+
+    DiscourseEvent.trigger(:confirmed_spam_post, post) if @trigger_spam
+
+    update_flagged_posts_count
+  end
+
+  def self.clear_flags!(post, moderator)
+    # -1 is the automatic system cleary
+    action_type_ids = moderator.id == -1 ?
+      PostActionType.auto_action_flag_types.values :
+      PostActionType.flag_types.values
+
+    actions = PostAction.where(post_id: post.id)
+                .where(post_action_type_id: action_type_ids)
+
+    actions.each do |action|
+      action.disagreed_at = Time.zone.now
+      action.disagreed_by_id = moderator.id
+      # so callback is called
+      action.save
+      action.add_moderator_post_if_needed(moderator, :disagreed)
+    end
+
+    # reset all cached counters
+    f = action_type_ids.map { |t| ["#{PostActionType.types[t]}_count", 0] }
+    Post.with_deleted.where(id: post.id).update_all(Hash[*f.flatten])
+
+    update_flagged_posts_count
+  end
+
+  def self.defer_flags!(post, moderator, delete_post=false)
+    actions = PostAction.active
+                .where(post_id: post.id)
+                .where(post_action_type_id: PostActionType.flag_types.values)
+
+    actions.each do |action|
+      action.deferred_at = Time.zone.now
+      action.deferred_by_id = moderator.id
+      # so callback is called
+      action.save
+      action.add_moderator_post_if_needed(moderator, :deferred, delete_post)
+    end
+
+    update_flagged_posts_count
+  end
+
+  def add_moderator_post_if_needed(moderator, disposition, delete_post=false)
+    return unless SiteSetting.auto_respond_to_flag_actions
+    return if related_post.nil? || related_post.topic.nil?
+    return if staff_already_replied?(related_post.topic)
+    message_key = "flags_dispositions.#{disposition}"
+    message_key << "_and_deleted" if delete_post
+    related_post.topic.add_moderator_post(moderator, I18n.t(message_key))
+  end
+
+  def staff_already_replied?(topic)
+    topic.posts.where("user_id IN (SELECT id FROM users WHERE moderator OR admin) OR (post_type != :regular_post_type)", regular_post_type: Post.types[:regular]).exists?
+  end
+
+  def self.create_message_for_post_action(user, post, post_action_type_id, opts)
+    post_action_type = PostActionType.types[post_action_type_id]
+
+    return unless opts[:message] && [:notify_moderators, :notify_user, :spam].include?(post_action_type)
+
+    title = I18n.t("post_action_types.#{post_action_type}.email_title", title: post.topic.title)
+    body = I18n.t("post_action_types.#{post_action_type}.email_body", message: opts[:message], link: "#{Discourse.base_url}#{post.url}")
+
+    title = title.truncate(255, separator: /\s/)
+
+    opts = {
+      archetype: Archetype.private_message,
+      title: title,
+      raw: body
+    }
+
+    if [:notify_moderators, :spam].include?(post_action_type)
+      opts[:subtype] = TopicSubtype.notify_moderators
+      opts[:target_group_names] = "moderators"
+    else
+      opts[:subtype] = TopicSubtype.notify_user
+      opts[:target_usernames] = if post_action_type == :notify_user
+                                  post.user.username
+                                elsif post_action_type != :notify_moderators
+                                  # this is a hack to allow a PM with no recipients, we should think through
+                                  # a cleaner technique, a PM with myself is valid for flagging
+                                  'x'
+                                end
+    end
+
+    PostCreator.new(user, opts).create.try(:id)
+  end
+
+  # Returns the flag counts for a post, taking into account that some users
+  # can weigh flags differently.
+  def self.flag_counts_for(post_id)
+    flag_counts = exec_sql("SELECT SUM(CASE
+                                         WHEN pa.disagreed_at IS NULL AND pa.staff_took_action THEN :flags_required_to_hide_post
+                                         WHEN pa.disagreed_at IS NULL AND NOT pa.staff_took_action THEN 1
+                                         ELSE 0
+                                       END) AS new_flags,
+                                   SUM(CASE
+                                         WHEN pa.disagreed_at IS NOT NULL AND pa.staff_took_action THEN :flags_required_to_hide_post
+                                         WHEN pa.disagreed_at IS NOT NULL AND NOT pa.staff_took_action THEN 1
+                                         ELSE 0
+                                       END) AS old_flags
+                            FROM flags AS pa
+                              INNER JOIN users AS u ON u.id = pa.user_id
+                            WHERE pa.post_id = :post_id
+                              AND pa.post_action_type_id IN (:post_action_types)
+                              AND pa.deleted_at IS NULL",
+                           post_id: post_id,
+                           post_action_types: PostActionType.auto_action_flag_types.values,
+                           flags_required_to_hide_post: SiteSetting.flags_required_to_hide_post).first
+
+    [flag_counts['old_flags'].to_i, flag_counts['new_flags'].to_i]
+  end
+
+  def self.auto_close_if_threshold_reached(topic)
+    return if topic.nil? || topic.closed?
+
+    flags = Flag.active
+              .flags
+              .joins(:post)
+              .where("posts.topic_id = ?", topic.id)
+              .where.not(user_id: Discourse::SYSTEM_USER_ID)
+              .group("flags.user_id")
+              .pluck("flags.user_id, COUNT(post_id)")
+
+    # we need a minimum number of unique flaggers
+    return if flags.count < SiteSetting.num_flaggers_to_close_topic
+    # we need a minimum number of flags
+    return if flags.sum { |f| f[1] } < SiteSetting.num_flags_to_close_topic
+
+    # the threshold has been reached, we will close the topic waiting for intervention
+    message = I18n.t("temporarily_closed_due_to_flags")
+    topic.update_status("closed", true, Discourse.system_user, message: message)
+  end
+
+  def self.auto_hide_if_needed(acting_user, post, post_action_type)
+    return if post.hidden
+
+    if post_action_type == :spam &&
+      acting_user.has_trust_level?(TrustLevel[3]) &&
+      post.user.trust_level == TrustLevel[0]
+
+      hide_post!(post, post_action_type, Post.hidden_reasons[:flagged_by_tl3_user])
+
+    elsif PostActionType.auto_action_flag_types.include?(post_action_type) &&
+      SiteSetting.flags_required_to_hide_post > 0
+
+      old_flags, new_flags = PostAction.flag_counts_for(post.id)
+
+      if new_flags >= SiteSetting.flags_required_to_hide_post
+        hide_post!(post, post_action_type, guess_hide_reason(old_flags))
+      end
+    end
+  end
+
+  def self.hide_post!(post, post_action_type, reason=nil)
+    return if post.hidden
+
+    unless reason
+      old_flags,_ = Flag.flag_counts_for(post.id)
+      reason = guess_hide_reason(old_flags)
+    end
+
+    Post.where(id: post.id).update_all(["hidden = true, hidden_at = ?, hidden_reason_id = COALESCE(hidden_reason_id, ?)", Time.now, reason])
+    Topic.where("id = :topic_id AND NOT EXISTS(SELECT 1 FROM POSTS WHERE topic_id = :topic_id AND NOT hidden)", topic_id: post.topic_id).update_all(visible: false)
+
+    # inform user
+    if post.user
+      options = {
+        url: post.url,
+        edit_delay: SiteSetting.cooldown_minutes_after_hiding_posts,
+        flag_reason: I18n.t("flag_reasons.#{post_action_type}"),
+      }
+      SystemMessage.create(post.user, :post_hidden, options)
+    end
+  end
+
+  def self.guess_hide_reason(old_flags)
+    old_flags > 0 ?
+      Post.hidden_reasons[:flag_threshold_reached_again] :
+      Post.hidden_reasons[:flag_threshold_reached]
+  end
+
+  def self.target_moderators
+    Group[:moderators].name
+  end
 end
 
 # == Schema Information

--- a/app/models/flag.rb
+++ b/app/models/flag.rb
@@ -1,19 +1,15 @@
 
 class Flag < PostAction
+  include PostActionSubclassMixin
+
   self.table_name = :flags
+  self.pa_type = PostActionType.all_flag_type_ids
 
   validates :post_action_type_id, inclusion: { in: PostActionType.all_flag_type_ids, message: '%{value} is not a flag action ID' }
   after_save :enforce_rules
 
-  # === BEGIN CRAZY SUBCLASSING MADNESS === #
-
-  def self.sti_name
-    # apparently this works lol
-    PostActionType.all_flag_type_ids
-  end
-
   def self.type_condition(table = arel_table)
-    table[:post_action_type_id].in(PostActionType.all_flag_type_ids)
+    table[:post_action_type_id].in(pa_type)
   end
 
   def ensure_proper_type
@@ -24,8 +20,6 @@ class Flag < PostAction
       write_attribute(:post_action_type_id, PostActionType.all_flag_type_ids.first)
     end
   end
-
-  # === END CRAZY SUBCLASSING MADNESS === #
 
   before_create do
     raise AlreadyActed if PostAction.where(user_id: user_id)

--- a/app/models/flag.rb
+++ b/app/models/flag.rb
@@ -2,7 +2,7 @@
 class Flag < PostAction
   self.table_name = :flags
 
-  validates_presence_of :post_action_type_id
+  validates :post_action_type_id, inclusion: { in: PostActionType.all_flag_type_ids, message: '%{value} is not a flag action ID' }
   after_save :enforce_rules
 
   # === BEGIN CRAZY SUBCLASSING MADNESS === #

--- a/app/models/flag.rb
+++ b/app/models/flag.rb
@@ -22,7 +22,7 @@ class Flag < PostAction
   end
 
   before_create do
-    raise AlreadyActed if PostAction.where(user_id: user_id)
+    raise AlreadyActed if Flag.where(user_id: user_id)
                             .where(post_id: post_id)
                             .where(post_action_type_id: PostActionType.flag_types.values) # exclude PM
                             .where(deleted_at: nil)

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -1,0 +1,84 @@
+
+class Like < PostAction
+
+  self.table_name = :likes
+
+  def self.pa_type
+    PostActionType.like
+  end
+
+  def pa_type
+    self.class.pa_type
+  end
+
+  # === BEGIN CRAZY SUBCLASSING MADNESS === #
+
+  def self.sti_name
+    pa_type
+  end
+
+  def self.type_condition(table = arel_table)
+    table[:post_action_type_id].in([pa_type])
+  end
+
+  before_save do
+    self.post_action_type_id = 2
+  end
+
+  # === END CRAZY SUBCLASSING MADNESS === #
+
+  before_create do
+    raise AlreadyActed if PostAction.where(user_id: user_id)
+                            .where(post_id: post_id)
+                            .where(post_action_type_id: pa_type)
+                            .where(deleted_at: nil)
+                            .exists?
+  end
+
+  def self.lookup_for(user, topics)
+    PostAction.lookup_for(user, topics, pa_type)
+  end
+
+  def self.count_per_day(opts=nil)
+    PostAction.count_per_day(pa_type, opts)
+  end
+
+  def self.act(user, post, opts = {})
+    PostAction.act(user, post, pa_type, opts)
+  end
+
+  def self.remove_act(user, post)
+    PostAction.remove_act(user, post, pa_type)
+  end
+
+  def is_bookmark?
+    false
+  end
+
+  def is_like?
+    true
+  end
+
+  def is_flag?
+    false
+  end
+
+  def is_private_message?
+    false
+  end
+
+end
+
+# == Schema Information
+#
+# Table name: likes
+#
+#  id                  :integer          primary key
+#  post_id             :integer
+#  user_id             :integer
+#  created_at          :datetime
+#  updated_at          :datetime
+#  deleted_by_id       :integer
+#  deleted_at          :datetime
+#  post_action_type_id :integer
+#

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -1,35 +1,9 @@
 
 class Like < PostAction
+  include PostActionSubclassMixin
 
   self.table_name = :likes
-
-  def self.pa_type
-    PostActionType.like
-  end
-
-  def pa_type
-    self.class.pa_type
-  end
-
-  # === BEGIN CRAZY SUBCLASSING MADNESS === #
-
-  def self.sti_name
-    pa_type
-  end
-
-  def self.type_condition(table = arel_table)
-    table[:post_action_type_id].in([pa_type])
-  end
-
-  before_save do
-    self.post_action_type_id = pa_type
-  end
-
-  def ensure_proper_type
-    write_attribute(:post_action_type_id, pa_type)
-  end
-
-  # === END CRAZY SUBCLASSING MADNESS === #
+  self.pa_type = PostActionType.like
 
   before_create do
     raise AlreadyActed if PostAction.where(user_id: user_id)

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -6,9 +6,8 @@ class Like < PostAction
   self.pa_type = PostActionType.like
 
   before_create do
-    raise AlreadyActed if PostAction.where(user_id: user_id)
+    raise AlreadyActed if Like.where(user_id: user_id)
                             .where(post_id: post_id)
-                            .where(post_action_type_id: pa_type)
                             .where(deleted_at: nil)
                             .exists?
   end

--- a/app/models/post_action.rb
+++ b/app/models/post_action.rb
@@ -21,7 +21,6 @@ class PostAction < ActiveRecord::Base
   scope :active, -> { where(disagreed_at: nil, deferred_at: nil, agreed_at: nil, deleted_at: nil) }
 
   after_save :update_counters
-  after_save :enforce_rules
   after_commit :notify_subscribers
 
   # === BEGIN CRAZY SUBCLASSING MADNESS === #
@@ -73,6 +72,17 @@ class PostAction < ActiveRecord::Base
     compute_type_int(attrs[:post_action_type_id].to_i)
   end
 
+  class << self
+    [
+      :flag_count_by_date, :update_flagged_posts_count, :flagged_posts_count,
+      :active_flags_counts_for, :agree_flags!, :clear_flags!, :defer_flags!,
+      :create_message_for_post_action, :flag_counts_for, :auto_close_if_threshold_reached,
+      :auto_hide_if_needed, :hide_post!, :guess_hide_reason, :target_moderators
+    ].each do |sym|
+      delegate sym, to: Flag
+    end
+  end
+
   # === END CRAZY SUBCLASSING MADNESS === #
 
   def disposed_by_id
@@ -88,32 +98,6 @@ class PostAction < ActiveRecord::Base
     return :agreed if agreed_at
     return :deferred if deferred_at
     nil
-  end
-
-  def self.flag_count_by_date(start_date, end_date, category_id=nil)
-    result = where('post_actions.created_at >= ? AND post_actions.created_at <= ?', start_date, end_date)
-    result = result.where(post_action_type_id: PostActionType.flag_types.values)
-    result = result.joins(post: :topic).where("topics.category_id = ?", category_id) if category_id
-    result.group('date(post_actions.created_at)')
-          .order('date(post_actions.created_at)')
-          .count
-  end
-
-  def self.update_flagged_posts_count
-    posts_flagged_count = PostAction.active
-                                    .flags
-                                    .joins(post: :topic)
-                                    .where('posts.deleted_at' => nil)
-                                    .where('topics.deleted_at' => nil)
-                                    .count('DISTINCT posts.id')
-
-    $redis.set('posts_flagged_count', posts_flagged_count)
-    user_ids = User.staff.pluck(:id)
-    MessageBus.publish('/flagged_counts', { total: posts_flagged_count }, { user_ids: user_ids })
-  end
-
-  def self.flagged_posts_count
-    $redis.get('posts_flagged_count').to_i
   end
 
   def self.counts_for(collection, user)
@@ -158,23 +142,6 @@ SQL
     map
   end
 
-  def self.active_flags_counts_for(collection)
-    return {} if collection.blank?
-
-    collection_ids = collection.map(&:id)
-
-    post_actions = PostAction.active.flags.where(post_id: collection_ids)
-
-    user_actions = {}
-    post_actions.each do |post_action|
-      user_actions[post_action.post_id] ||= {}
-      user_actions[post_action.post_id][post_action.post_action_type_id] ||= []
-      user_actions[post_action.post_id][post_action.post_action_type_id] << post_action
-    end
-
-    user_actions
-  end
-
   def self.count_per_day_for_type(post_action_type, opts=nil)
     opts ||= {}
     opts[:since_days_ago] ||= 30
@@ -184,112 +151,6 @@ SQL
     result.group('date(post_actions.created_at)')
           .order('date(post_actions.created_at)')
           .count
-  end
-
-  def self.agree_flags!(post, moderator, delete_post=false)
-    actions = PostAction.active
-                        .where(post_id: post.id)
-                        .where(post_action_type_id: PostActionType.flag_types.values)
-
-    trigger_spam = false
-    actions.each do |action|
-      action.agreed_at = Time.zone.now
-      action.agreed_by_id = moderator.id
-      # so callback is called
-      action.save
-      action.add_moderator_post_if_needed(moderator, :agreed, delete_post)
-      @trigger_spam = true if action.post_action_type_id == PostActionType.types[:spam]
-    end
-
-    DiscourseEvent.trigger(:confirmed_spam_post, post) if @trigger_spam
-
-    update_flagged_posts_count
-  end
-
-  def self.clear_flags!(post, moderator)
-    # -1 is the automatic system cleary
-    action_type_ids = moderator.id == -1 ?
-        PostActionType.auto_action_flag_types.values :
-        PostActionType.flag_types.values
-
-    actions = PostAction.where(post_id: post.id)
-                        .where(post_action_type_id: action_type_ids)
-
-    actions.each do |action|
-      action.disagreed_at = Time.zone.now
-      action.disagreed_by_id = moderator.id
-      # so callback is called
-      action.save
-      action.add_moderator_post_if_needed(moderator, :disagreed)
-    end
-
-    # reset all cached counters
-    f = action_type_ids.map { |t| ["#{PostActionType.types[t]}_count", 0] }
-    Post.with_deleted.where(id: post.id).update_all(Hash[*f.flatten])
-
-    update_flagged_posts_count
-  end
-
-  def self.defer_flags!(post, moderator, delete_post=false)
-    actions = PostAction.active
-                        .where(post_id: post.id)
-                        .where(post_action_type_id: PostActionType.flag_types.values)
-
-    actions.each do |action|
-      action.deferred_at = Time.zone.now
-      action.deferred_by_id = moderator.id
-      # so callback is called
-      action.save
-      action.add_moderator_post_if_needed(moderator, :deferred, delete_post)
-    end
-
-    update_flagged_posts_count
-  end
-
-  def add_moderator_post_if_needed(moderator, disposition, delete_post=false)
-    return unless SiteSetting.auto_respond_to_flag_actions
-    return if related_post.nil? || related_post.topic.nil?
-    return if staff_already_replied?(related_post.topic)
-    message_key = "flags_dispositions.#{disposition}"
-    message_key << "_and_deleted" if delete_post
-    related_post.topic.add_moderator_post(moderator, I18n.t(message_key))
-  end
-
-  def staff_already_replied?(topic)
-    topic.posts.where("user_id IN (SELECT id FROM users WHERE moderator OR admin) OR (post_type != :regular_post_type)", regular_post_type: Post.types[:regular]).exists?
-  end
-
-  def self.create_message_for_post_action(user, post, post_action_type_id, opts)
-    post_action_type = PostActionType.types[post_action_type_id]
-
-    return unless opts[:message] && [:notify_moderators, :notify_user, :spam].include?(post_action_type)
-
-    title = I18n.t("post_action_types.#{post_action_type}.email_title", title: post.topic.title)
-    body = I18n.t("post_action_types.#{post_action_type}.email_body", message: opts[:message], link: "#{Discourse.base_url}#{post.url}")
-
-    title = title.truncate(255, separator: /\s/)
-
-    opts = {
-      archetype: Archetype.private_message,
-      title: title,
-      raw: body
-    }
-
-    if [:notify_moderators, :spam].include?(post_action_type)
-      opts[:subtype] = TopicSubtype.notify_moderators
-      opts[:target_group_names] = "moderators"
-    else
-      opts[:subtype] = TopicSubtype.notify_user
-      opts[:target_usernames] = if post_action_type == :notify_user
-                                  post.user.username
-                                elsif post_action_type != :notify_moderators
-                                  # this is a hack to allow a PM with no recipients, we should think through
-                                  # a cleaner technique, a PM with myself is valid for flagging
-                                  'x'
-                                end
-    end
-
-    PostCreator.new(user, opts).create.try(:id)
   end
 
   def self.act(user, post, post_action_type_id, opts = {})
@@ -414,31 +275,6 @@ SQL
                                     .exists?
   end
 
-  # Returns the flag counts for a post, taking into account that some users
-  # can weigh flags differently.
-  def self.flag_counts_for(post_id)
-    flag_counts = exec_sql("SELECT SUM(CASE
-                                         WHEN pa.disagreed_at IS NULL AND pa.staff_took_action THEN :flags_required_to_hide_post
-                                         WHEN pa.disagreed_at IS NULL AND NOT pa.staff_took_action THEN 1
-                                         ELSE 0
-                                       END) AS new_flags,
-                                   SUM(CASE
-                                         WHEN pa.disagreed_at IS NOT NULL AND pa.staff_took_action THEN :flags_required_to_hide_post
-                                         WHEN pa.disagreed_at IS NOT NULL AND NOT pa.staff_took_action THEN 1
-                                         ELSE 0
-                                       END) AS old_flags
-                            FROM post_actions AS pa
-                              INNER JOIN users AS u ON u.id = pa.user_id
-                            WHERE pa.post_id = :post_id
-                              AND pa.post_action_type_id IN (:post_action_types)
-                              AND pa.deleted_at IS NULL",
-                            post_id: post_id,
-                            post_action_types: PostActionType.auto_action_flag_types.values,
-                            flags_required_to_hide_post: SiteSetting.flags_required_to_hide_post).first
-
-    [flag_counts['old_flags'].to_i, flag_counts['new_flags'].to_i]
-  end
-
   def post_action_type_key
     PostActionType.types[post_action_type_id]
   end
@@ -484,97 +320,15 @@ SQL
 
   end
 
-  def enforce_rules
-    post = Post.with_deleted.where(id: post_id).first
-    PostAction.auto_close_if_threshold_reached(post.topic)
-    PostAction.auto_hide_if_needed(user, post, post_action_type_key)
-    SpamRulesEnforcer.enforce!(post.user) if post_action_type_key == :spam
-  end
-
   def notify_subscribers
     if (is_like? || is_flag?) && post
       post.publish_change_to_clients! :acted
     end
   end
 
-  MAXIMUM_FLAGS_PER_POST = 3
-
-  def self.auto_close_if_threshold_reached(topic)
-    return if topic.nil? || topic.closed?
-
-    flags = PostAction.active
-                      .flags
-                      .joins(:post)
-                      .where("posts.topic_id = ?", topic.id)
-                      .where.not(user_id: Discourse::SYSTEM_USER_ID)
-                      .group("post_actions.user_id")
-                      .pluck("post_actions.user_id, COUNT(post_id)")
-
-    # we need a minimum number of unique flaggers
-    return if flags.count < SiteSetting.num_flaggers_to_close_topic
-    # we need a minimum number of flags
-    return if flags.sum { |f| f[1] } < SiteSetting.num_flags_to_close_topic
-
-    # the threshold has been reached, we will close the topic waiting for intervention
-    message = I18n.t("temporarily_closed_due_to_flags")
-    topic.update_status("closed", true, Discourse.system_user, message: message)
-  end
-
-  def self.auto_hide_if_needed(acting_user, post, post_action_type)
-    return if post.hidden
-
-    if post_action_type == :spam &&
-       acting_user.has_trust_level?(TrustLevel[3]) &&
-       post.user.trust_level == TrustLevel[0]
-
-       hide_post!(post, post_action_type, Post.hidden_reasons[:flagged_by_tl3_user])
-
-    elsif PostActionType.auto_action_flag_types.include?(post_action_type) &&
-          SiteSetting.flags_required_to_hide_post > 0
-
-      old_flags, new_flags = PostAction.flag_counts_for(post.id)
-
-      if new_flags >= SiteSetting.flags_required_to_hide_post
-        hide_post!(post, post_action_type, guess_hide_reason(old_flags))
-      end
-    end
-  end
-
-  def self.hide_post!(post, post_action_type, reason=nil)
-    return if post.hidden
-
-    unless reason
-      old_flags,_ = PostAction.flag_counts_for(post.id)
-      reason = guess_hide_reason(old_flags)
-    end
-
-    Post.where(id: post.id).update_all(["hidden = true, hidden_at = ?, hidden_reason_id = COALESCE(hidden_reason_id, ?)", Time.now, reason])
-    Topic.where("id = :topic_id AND NOT EXISTS(SELECT 1 FROM POSTS WHERE topic_id = :topic_id AND NOT hidden)", topic_id: post.topic_id).update_all(visible: false)
-
-    # inform user
-    if post.user
-      options = {
-        url: post.url,
-        edit_delay: SiteSetting.cooldown_minutes_after_hiding_posts,
-        flag_reason: I18n.t("flag_reasons.#{post_action_type}"),
-      }
-      SystemMessage.create(post.user, :post_hidden, options)
-    end
-  end
-
-  def self.guess_hide_reason(old_flags)
-    old_flags > 0 ?
-      Post.hidden_reasons[:flag_threshold_reached_again] :
-      Post.hidden_reasons[:flag_threshold_reached]
-  end
-
   def self.post_action_type_for_post(post_id)
     post_action = PostAction.find_by(deferred_at: nil, post_id: post_id, post_action_type_id: PostActionType.flag_types.values, deleted_at: nil)
     PostActionType.types[post_action.post_action_type_id]
-  end
-
-  def self.target_moderators
-    Group[:moderators].name
   end
 
 end

--- a/app/models/post_action.rb
+++ b/app/models/post_action.rb
@@ -258,14 +258,16 @@ SQL
   end
 
   before_create do
-    post_action_type_ids = is_flag? ? PostActionType.flag_types.values : post_action_type_id
-    raise AlreadyActed if PostAction.where(user_id: user_id)
-                                    .where(post_id: post_id)
-                                    .where(post_action_type_id: post_action_type_ids)
-                                    .where(deleted_at: nil)
-                                    .where(disagreed_at: nil)
-                                    .where(targets_topic: targets_topic)
-                                    .exists?
+    unless is_flag? || is_like? || is_bookmark?
+      # Like, Flag, Bookmark do their own uniqueness checks
+      raise AlreadyActed if PostAction.where(user_id: user_id)
+                              .where(post_id: post_id)
+                              .where(post_action_type_id: post_action_type_id)
+                              .where(deleted_at: nil)
+                              .where(disagreed_at: nil)
+                              .where(targets_topic: targets_topic)
+                              .exists?
+    end
   end
 
   def post_action_type_key

--- a/app/models/post_action.rb
+++ b/app/models/post_action.rb
@@ -1,5 +1,6 @@
 require_dependency 'rate_limiter'
 require_dependency 'system_message'
+require 'post_action_subclass_mixin'
 
 class PostAction < ActiveRecord::Base
   class AlreadyActed < StandardError; end
@@ -23,18 +24,12 @@ class PostAction < ActiveRecord::Base
   after_save :update_counters
   after_commit :notify_subscribers
 
-  # === BEGIN CRAZY SUBCLASSING MADNESS === #
-
   include ActiveRecord::Inheritance
 
   self.inheritance_column = :post_action_type_id
 
   def self.store_full_sti_class
     false
-  end
-
-  def self.sti_name
-    raise 'needs override'
   end
 
   def self.compute_type_int(type_id)
@@ -82,8 +77,6 @@ class PostAction < ActiveRecord::Base
       delegate sym, to: Flag
     end
   end
-
-  # === END CRAZY SUBCLASSING MADNESS === #
 
   def disposed_by_id
     disagreed_by_id || agreed_by_id || deferred_by_id

--- a/app/models/post_action.rb
+++ b/app/models/post_action.rb
@@ -40,11 +40,11 @@ class PostAction < ActiveRecord::Base
 
   def self.compute_type_int(type_id)
     if type_id == PostActionType.bookmark
-      PostAction # TODO
+      Bookmark
     elsif type_id == PostActionType.like
       Like
     elsif PostActionType.all_flag_type_ids.include? type_id
-      PostAction # TODO
+      Flag
     elsif type_id == PostActionType.types[:vote]
       PostAction
     elsif type_id == nil

--- a/app/models/post_action_type.rb
+++ b/app/models/post_action_type.rb
@@ -17,6 +17,14 @@ class PostActionType < ActiveRecord::Base
                           :spam)
     end
 
+    def like
+      types[:like]
+    end
+
+    def bookmark
+      types[:bookmark]
+    end
+
     def auto_action_flag_types
       @auto_action_flag_types ||= flag_types.except(:notify_user, :notify_moderators)
     end
@@ -31,6 +39,10 @@ class PostActionType < ActiveRecord::Base
 
     def flag_types
       @flag_types ||= types.only(:off_topic, :spam, :inappropriate, :notify_moderators)
+    end
+
+    def all_flag_type_ids
+      @all_flag_types ||= types.only(:off_topic, :spam, :inappropriate, :notify_moderators, :notify_user).values
     end
 
     # flags resulting in mod notifications

--- a/app/models/post_alert_observer.rb
+++ b/app/models/post_alert_observer.rb
@@ -1,5 +1,5 @@
 class PostAlertObserver < ActiveRecord::Observer
-  observe :post_action, :post_revision
+  observe :post_action, :post_revision, :like
 
   def alerter
     @alerter ||= PostAlerter.new
@@ -17,13 +17,13 @@ class PostAlertObserver < ActiveRecord::Observer
     send(method_name, model) if respond_to?(method_name)
   end
 
-  def after_save_post_action(post_action)
+  def after_save_like(post_action)
     # We only care about deleting post actions for now
     return if post_action.deleted_at.blank?
     Notification.where(post_action_id: post_action.id).each(&:destroy)
   end
 
-  def after_create_post_action(post_action)
+  def after_create_like(post_action)
     # We only notify on likes for now
     return unless post_action.is_like?
 

--- a/db/migrate/20150728202123_create_post_action_views.rb
+++ b/db/migrate/20150728202123_create_post_action_views.rb
@@ -1,0 +1,31 @@
+class CreatePostActionViews < ActiveRecord::Migration
+
+  def up
+    execute <<SQL
+CREATE VIEW likes AS
+SELECT id, post_id, user_id, created_at, updated_at, deleted_by_id, deleted_at, post_action_type_id
+FROM post_actions
+WHERE post_action_type_id = 2
+SQL
+
+    execute <<SQL
+CREATE VIEW bookmarks AS
+SELECT id, post_id, user_id, created_at, updated_at, deleted_by_id, deleted_at, post_action_type_id
+FROM post_actions
+WHERE post_action_type_id = 1
+SQL
+
+    execute <<SQL
+CREATE VIEW flags AS
+SELECT *
+FROM post_actions
+WHERE post_action_type_id IN (3,4,6,7,8)
+SQL
+  end
+
+  def down
+    execute "DROP VIEW likes"
+    execute "DROP VIEW bookmarks"
+    execute "DROP VIEW flags"
+  end
+end

--- a/db/migrate/20150728202123_create_post_action_views.rb
+++ b/db/migrate/20150728202123_create_post_action_views.rb
@@ -17,7 +17,7 @@ SQL
 
     execute <<SQL
 CREATE VIEW flags AS
-SELECT *
+SELECT id, post_id, user_id, created_at, updated_at, deleted_by_id, deleted_at, post_action_type_id, related_post_id, staff_took_action, deferred_by_id, targets_topic, agreed_at, agreed_by_id, deferred_at, disagreed_at, disagreed_by_id
 FROM post_actions
 WHERE post_action_type_id IN (3,4,6,7,8)
 SQL

--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -298,7 +298,9 @@ class Guardian
   end
 
   def method_name_for(action, obj)
-    method_name = :"can_#{action}_#{obj.class.name.underscore}?"
+    clazz = obj.class
+    clazz = PostAction if clazz < PostAction
+    method_name = :"can_#{action}_#{clazz.name.underscore}?"
     return method_name if respond_to?(method_name)
   end
 

--- a/lib/post_action_subclass_mixin.rb
+++ b/lib/post_action_subclass_mixin.rb
@@ -1,0 +1,34 @@
+
+module PostActionSubclassMixin
+
+  def self.included(cls)
+    cls.extend PostActionSubclassMixin::ClassMethods
+    cls.before_save :ensure_proper_type
+  end
+
+  module ClassMethods
+    def pa_type=(type)
+      @pa_type = type
+    end
+
+    def pa_type
+      @pa_type
+    end
+
+    def sti_name
+      pa_type
+    end
+
+    def type_condition(table = arel_table)
+      table[:post_action_type_id].in([pa_type])
+    end
+  end
+
+  def pa_type
+    self.class.pa_type
+  end
+
+  def ensure_proper_type
+    write_attribute(:post_action_type_id, pa_type)
+  end
+end


### PR DESCRIPTION
Splitting the post actions table. Will make some of the refactorings in the future easier.

 - Adds an updatable view, so you can create a Like object and save it (but we don't, because PostAction.act is the creation method)
 - Uses ActiveRecord single-table inheritance on the post_action_type_id column
 - Flag-only class methods on PostAction were moved & forwarded

I have verified with the SQL console that the likes and bookmarks views can be INSERTed into.

~~Tests pass, but no new tests were added.~~ Added tests for the subclassing.