### PR TITLE
FIX: Get composer height after transition.

### DIFF
--- a/app/assets/javascripts/discourse/views/composer.js.es6
+++ b/app/assets/javascripts/discourse/views/composer.js.es6
@@ -532,10 +532,13 @@ const ComposerView = Discourse.View.extend(Ember.Evented, {
     const self = this;
 
     Em.run.next(() => {
-      const sizePx = self.get('composeState') === Discourse.Composer.CLOSED ? 0 : $('#reply-control').height();
-      $('#main-outlet').css('padding-bottom', sizePx);
+      $('#main-outlet').css('padding-bottom', 0);
       // need to wait a bit for the "slide down" transition of the composer
       Em.run.later(() => {
+        if (self.get('composeState') !== Discourse.Composer.CLOSED) {
+          $('#main-outlet').css('padding-bottom', $('#reply-control').height());
+        }
+
         this.appEvents.trigger("composer:closed");
       }, 400);
     });


### PR DESCRIPTION
@SamSaffron I didn't catch this the last time. We need to wait for the transition to finish before calculating the height.

This is one small caveat to this fix:

```
1. Open the composer
2. Enter some text
3. Scroll all the way down
4. Close the composer
5. 'See more topics' is hidden behind the draft post
6. Scroll down futher to reveal 'See more topics'
```

![bug_report-3](https://cloud.githubusercontent.com/assets/4335742/9189538/7ad6a700-401c-11e5-9faf-41beae66ccfd.gif)

Ideally, there shouldn't be a need for step 6 but there isn't a decent way for us to obtain the height without hardcoding the value.