### PR TITLE
Adjust Brewfile to follow homebrew-bundle syntax

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,22 +1,19 @@
 # Install development dependencies on Mac OS X using Homebrew (http://mxcl.github.com/homebrew)
 
-# ensure that Homebrew's sources are up to date
-update
-
 # add this repo to Homebrew's sources
-tap homebrew/dupes
+tap 'homebrew/dupes'
 
 # install the gcc compiler required for ruby
-install apple-gcc42
+brew 'apple-gcc42'
 
 # you probably already have git installed; ensure that it is the latest version
-install git
+brew 'git'
 
 # install the PostgreSQL database
-install postgresql
+brew 'postgresql'
 
 # install the Redis datastore
-install redis
+brew 'redis'
 
 # install headless Javascript testing library
-install phantomjs
+brew 'phantomjs'


### PR DESCRIPTION
According to https://meta.discourse.org/t/brew-bundle-is-dead/23962
the official replacement for `brew bundle` is homebrew-bundle
(https://github.com/Homebrew/homebrew-bundle) and its syntax changed a
little bit.