### PR TITLE
FIX: HTML not being stripped in description meta tag.

### DIFF
--- a/app/controllers/list_controller.rb
+++ b/app/controllers/list_controller.rb
@@ -230,7 +230,7 @@ class ListController < ApplicationController
     @category = Category.query_category(slug_or_id, parent_category_id)
     raise Discourse::NotFound if !@category
 
-    @description_meta = @category.description
+    @description_meta = @category.description_text
     guardian.ensure_can_see!(@category)
   end
 


### PR DESCRIPTION
@SamSaffron Could you review this? Thanks!

fixes https://meta.discourse.org/t/description-meta-tag-for-category-page-does-not-strip-html-generated-by-markdown/31667