### PR TITLE
FIX: Broken private message search context.

### DIFF
--- a/app/assets/javascripts/discourse/controllers/search.js.es6
+++ b/app/assets/javascripts/discourse/controllers/search.js.es6
@@ -14,9 +14,9 @@ export default Em.Controller.extend({
         return Ember.get(searchContext, 'type');
       }
     },
-    set(key, value) {
+    set(value, searchContext) {
       // a bit hacky, consider cleaning this up, need to work through all observers though
-      const context = $.extend({}, this.get('searchContext'));
+      const context = $.extend({}, searchContext);
       context.type = value;
       this.set('searchContext', context);
       return this.get('searchContext.type');


### PR DESCRIPTION
When using [ember-computed-decorators](https://github.com/rwjblue/ember-computed-decorators#real-world-getset-syntax), we don't have to specify the key.

cc @eviltrout 