### PR TITLE
FEATURE: Add slide-out menu for small screens on admin settings page

### DIFF
--- a/app/assets/javascripts/admin/controllers/admin-site-settings.js.es6
+++ b/app/assets/javascripts/admin/controllers/admin-site-settings.js.es6
@@ -64,6 +64,10 @@ export default Ember.ArrayController.extend({
         filter: '',
         onlyOverridden: false
       });
+    },
+
+    toggleMenu() {
+      $('.admin-detail').toggleClass('mobile-closed mobile-open');
     }
   }
 

--- a/app/assets/javascripts/admin/templates/site-settings.hbs
+++ b/app/assets/javascripts/admin/templates/site-settings.hbs
@@ -6,6 +6,7 @@
     </label>
   </div>
   <div class='controls'>
+    <button {{action "toggleMenu"}} class="menu-toggle">{{fa-icon "bars"}}</button>
     {{text-field value=filter placeholderKey="type_to_filter" class="no-blur"}}
     <button {{action "clearFilter"}} class="btn">{{i18n 'admin.site_settings.clear_filter'}}</button>
   </div>
@@ -26,7 +27,7 @@
   </ul>
 </div>
 
-<div class="admin-detail pull-left">
+<div class="admin-detail pull-left mobile-closed">
   {{outlet}}
 </div>
 

--- a/app/assets/stylesheets/common/admin/admin_base.scss
+++ b/app/assets/stylesheets/common/admin/admin_base.scss
@@ -21,6 +21,12 @@ $mobile-breakpoint: 700px;
   }
 }
 
+.admin-contents {
+  position: relative;
+  margin-left: -10px;
+  margin-right: -10px;
+}
+
 .admin-contents table {
   width: 100%;
   tr {text-align: left;}
@@ -145,6 +151,24 @@ td.flaggers td {
   .controls {
     margin-left: 10px;
   }
+
+  .controls .menu-toggle {
+    display: none;
+    float: left;
+    font-size: 24px;
+    padding: 3px 6px;
+    margin-right: 32px;
+    border: 1px solid lighten($primary, 40%);
+    border-radius: 3px;
+    background: transparent;
+    color: $primary;
+    &:hover {
+      background-color: lighten($primary, 60%);
+    }
+    @media (max-width: $mobile-breakpoint) {
+      display: inline-block;
+    }
+  }
   button {
     margin-right: 5px;
 
@@ -214,12 +238,19 @@ td.flaggers td {
 
 .admin-nav {
   width: 18.018%;
+  position: relative;
+  // The admin-nav becomes a slide-out menu at the mobile-nav breakpoint
   @media (max-width: $mobile-breakpoint) {
-    width: 33%;
+    position: absolute;
+    z-index: 0;
+    width: 50%;
   }
   margin-top: 30px;
   .nav-stacked {
     border-right: none;
+    @media (max-width: $mobile-breakpoint) {
+      //margin-right: 10px;
+    }
   }
   li a.active {
     color: $secondary;
@@ -230,18 +261,38 @@ td.flaggers td {
 .admin-detail {
   width: 76.5765%;
   @media (max-width: $mobile-breakpoint) {
-    width: 67%;
+    z-index: 10;
+    width: 100%;
   }
-  min-height: 800px;
+  background-color: $secondary;
+  // Todo: set this properly - it needs to be >= the menu height
+  min-height: 875px;
   margin-left: 0;
   border-left: solid 1px dark-light-diff($primary, $secondary, 90%, -60%);
   padding: 30px 0 30px 30px;
   @media (max-width: $mobile-breakpoint) {
-    padding: 30px 0 30px 16px;
+    padding: 30px 0;
+    border: none;
+  }
+}
+
+.admin-detail.mobile-open {
+  @media (max-width: $mobile-breakpoint) {
+    transition: transform 0.3s ease;
+    transform: (translateX(50%));
+  }
+}
+
+.admin-detail.mobile-closed {
+  @media (max-width: $mobile-breakpoint) {
+    transition: transform 0.3s ease;
+    transform: (translateX(0));
   }
 }
 
 .settings {
+  margin-left: 10px;
+  margin-right: 10px;
   .setting {
     padding-bottom: 20px;
 


### PR DESCRIPTION
The menu is toggled with a button that is added to the admin-controls div. I haven't added any functionality to close the menu when a menu item is selected. I'm not sure how to best add an action to the link-to helper.

I have overridden the 10px padding that is set on `.wrap` by adding a -10px margin to the admin-contents div. Setting left and right padding on the outer `.wrap` div was probably a mistake (my mistake from a previous commit) - many containing elements for mobile need to extend to the edge of the screen.

![screenshot 2015-08-16 11 11 13](https://cloud.githubusercontent.com/assets/2975917/9294631/128bcb22-4408-11e5-8034-4ee705cf0ce5.png)

![screenshot 2015-08-16 11 12 04](https://cloud.githubusercontent.com/assets/2975917/9294635/257be4c4-4408-11e5-9a57-75fee729f483.png)
