### PR TITLE
Use userfield serializer in json dump

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -80,7 +80,9 @@ class Site
       return {
         periods: TopTopic.periods.map(&:to_s),
         filters: Discourse.filters.map(&:to_s),
-        user_fields: UserField.all
+        user_fields: UserField.all.map do |userfield|
+          UserFieldSerializer.new(userfield, root: false, scope: guardian)
+        end
       }.to_json
     end
 


### PR DESCRIPTION
**Problem:**
When anonymous and authentication is required, the json dump does not include user field options. This leads to the options not being shown in the registration form.

Also see discussion at [meta](https://meta.discourse.org/t/custom-user-field-enhancements/31572/4).

**Solution:**
Use userfield serializer for json dump to make sure that also the options are serialized correctly.

Warning: Please review this PR carefully to ensure no critical data is leaked.