### PR TITLE
spoiler tag uses replaceBBCode

### DIFF
--- a/app/assets/javascripts/discourse/dialects/bbcode_dialect.js
+++ b/app/assets/javascripts/discourse/dialects/bbcode_dialect.js
@@ -133,16 +133,10 @@ Discourse.Markdown.whiteListTag('span', 'class', /^bbcode-[bius]$/);
 Discourse.BBCode.replaceBBCode('ul', function(contents) { return ['ul'].concat(Discourse.BBCode.removeEmptyLines(contents)); });
 Discourse.BBCode.replaceBBCode('ol', function(contents) { return ['ol'].concat(Discourse.BBCode.removeEmptyLines(contents)); });
 Discourse.BBCode.replaceBBCode('li', function(contents) { return ['li'].concat(Discourse.BBCode.removeEmptyLines(contents)); });
+Discourse.BBCode.replaceBBCode('spoiler', function(contents) { return ['span', {'class': 'spoiler'}].concat(contents); });
 
 Discourse.BBCode.rawBBCode('img', function(contents) { return ['img', {href: contents}]; });
 Discourse.BBCode.rawBBCode('email', function(contents) { return ['a', {href: "mailto:" + contents, 'data-bbcode': true}, contents]; });
-Discourse.BBCode.rawBBCode('spoiler', function(contents) {
-  if (/<img/i.test(contents)) {
-    return ['div', { 'class': 'spoiler' }, contents];
-  } else {
-    return ['span', { 'class': 'spoiler' }, contents];
-  }
-});
 
 Discourse.BBCode.replaceBBCode('url', function(contents) {
   if (!Array.isArray(contents)) { return; }

--- a/test/javascripts/lib/bbcode-test.js.es6
+++ b/test/javascripts/lib/bbcode-test.js.es6
@@ -51,7 +51,10 @@ test('code', function() {
 test('spoiler', function() {
   format("[spoiler]it's a sled[/spoiler]", "<span class=\"spoiler\">it's a sled</span>", "supports spoiler tags on text");
   format("[spoiler]<img src='http://eviltrout.com/eviltrout.png' width='50' height='50'>[/spoiler]",
-         "<div class=\"spoiler\"><img src=\"http://eviltrout.com/eviltrout.png\" width=\"50\" height=\"50\"></div>", "supports spoiler tags on images");
+         "<span class=\"spoiler\"><img src=\"http://eviltrout.com/eviltrout.png\" width=\"50\" height=\"50\"></span>", "supports spoiler tags on images");
+  format("[spoiler] This is the **bold** :smiley: [/spoiler]", "<span class=\"spoiler\"> This is the <strong>bold</strong> <img src=\"/images/emoji/undefined/smiley.png?v=0\" title=\":smiley:\" class=\"emoji\" alt=\"smiley\"> </span>", "supports spoiler tags on emojis");
+  format("[spoiler] Why not both <img src='http://eviltrout.com/eviltrout.png' width='50' height='50'>?[/spoiler]", "<span class=\"spoiler\"> Why not both <img src=\"http://eviltrout.com/eviltrout.png\" width=\"50\" height=\"50\">?</span>", "supports images and text");
+  format("In a p tag a spoiler [spoiler] <img src='http://eviltrout.com/eviltrout.png' width='50' height='50'>[/spoiler] can work.", "In a p tag a spoiler <span class=\"spoiler\"> <img src=\"http://eviltrout.com/eviltrout.png\" width=\"50\" height=\"50\"></span> can work.", "supports images and text in a p tag");
 });
 
 test('lists', function() {


### PR DESCRIPTION
Allows the application of blur effects to both images and text in a single spoiler tag.

Fix for https://meta.discourse.org/t/spoiler-does-not-support-emoji/29902, this also requires https://github.com/discourse/discourse-spoiler-alert/pull/12 to work.

Initial:
<img width="1341" alt="screen shot 2015-08-18 at 5 48 40 pm" src="https://cloud.githubusercontent.com/assets/1270189/9346775/daee3900-45d5-11e5-94f3-f0578798296c.png">

Hover:
<img width="1358" alt="screen shot 2015-08-18 at 5 48 54 pm" src="https://cloud.githubusercontent.com/assets/1270189/9346776/dea1785a-45d5-11e5-9844-68ba37210c93.png">

Click:
<img width="1347" alt="screen shot 2015-08-18 at 5 49 07 pm" src="https://cloud.githubusercontent.com/assets/1270189/9346778/e2ea9e64-45d5-11e5-9860-f30a26f9ec9e.png">

