### PR TITLE
Add a plugin outlet beside the poster's name.

### DIFF
--- a/app/assets/javascripts/discourse/templates/post.hbs
+++ b/app/assets/javascripts/discourse/templates/post.hbs
@@ -25,6 +25,7 @@
     <div class='topic-body'>
       <div class='topic-meta-data'>
         {{poster-name post=this}}
+        {{plugin-outlet "poster-name-right"}}
         <div class='post-info'>
           <a class='post-date' {{bind-attr href="shareUrl" data-share-url="shareUrl" data-post-number="post_number"}}>{{age-with-tooltip created_at}}</a>
         </div>


### PR DESCRIPTION
Need this outlet for [its your birthday plugin](https://meta.discourse.org/t/you-say-its-your-birthday/24594)