### PR TITLE
Replace unused showNames-if with new plugin-outlet on user-cards

### DIFF
--- a/app/assets/javascripts/discourse/templates/user-card.hbs
+++ b/app/assets/javascripts/discourse/templates/user-card.hbs
@@ -16,10 +16,8 @@
       {{#if user.title}}
         <h2>{{user.title}}</h2>
       {{/if}}
-
-      {{#if showName}}
-      <h2><a href={{user.path}} {{action "showUser"}}>{{name}}</a></h2>
-      {{/if}}
+      
+      {{plugin-outlet "user-card-post-names"}}
     </span>
   </div>
 


### PR DESCRIPTION
**tl;dr** This PR proposes to remove an used part from the user-card template and replace it with the new `user-card-post-names` plugin-outlet.

---

**About removing the showNames property part**

I was just investigating possibilities to extend the content in the user-card, when I found the [showNames section in the `names`-div](https://github.com/discourse/discourse/blob/9cf77bc01da10609a6af21e2a498f2fc3902f783/app/assets/javascripts/discourse/templates/user-card.hbs#L6-L24)
```handlebars
  <div class="names">
    <span>
      <h1 class="{{staff}} {{new_user}}">
        <a href={{user.path}} {{action "showUser"}}>{{username}} {{user-status user currentUser=currentUser}}</a>
      </h1>

      {{#if user.name}}
        <h2>{{user.name}}</h2>
      {{/if}}

      {{#if user.title}}
        <h2>{{user.title}}</h2>
      {{/if}}

      {{#if showName}}
      <h2><a href={{user.path}} {{action "showUser"}}>{{name}}</a></h2>
      {{/if}}
    </span>
  </div>
```

Finding it odd that `showName` is supposed to render the name if it is different from the username, although we already render both before, I was searching for any case in which it shows up twice. Turns out it never does, because `{{name}}` goes to an empty reference. Meaning we always render it, though it isn't actually visible to anyone as it is empty (screenshot from meta):

![screen shot 2015-08-19 at 12 34 36](https://cloud.githubusercontent.com/assets/40496/9354358/180619b2-4670-11e5-9137-3171086200f7.png)

This PR removes that part, not the `showNames`-property though, as it is still used for other properties.


---

**About the plugin outlet**

This PR replaces that section with a plugin-outlet `user-card-post-names`, allowing plugins to add another part in the names-section of the user-card. Until now it was only possible for plugins to extend the metadata-section. Though this seems trivial, for a (soon to be open sourced) plugin I am working on, a client wants to show (linked) Company/Organisation information in the User-Card as well as on the profile page. Though you could abuse the "metadata"-area for it, the names area is a lot more appropriate.

Here is an example of what that will look like (the building and `Namati` being added by a plugin):

![screen shot 2015-08-19 at 12 54 16](https://cloud.githubusercontent.com/assets/40496/9354537/75be9006-4671-11e5-81d8-cae5abf36958.png)





