### PR TITLE
FIX: Title popup tip not positioned correctly.

### DIFF
--- a/app/assets/stylesheets/desktop/compose.scss
+++ b/app/assets/stylesheets/desktop/compose.scss
@@ -220,6 +220,7 @@
     padding: 10px;
     min-width: 1280px;
     .form-element {
+      position: relative;
       display: inline-block;
       .select2-container {
         width: 400px;
@@ -323,8 +324,8 @@
   }
   .title-input .popup-tip {
     width: 300px;
-    left: -8px;
-    margin-top: 8px;
+    left: 0px;
+    top: -30px;
   }
   .category-input .popup-tip {
     width: 240px;


### PR DESCRIPTION
meta: https://meta.discourse.org/t/placement-of-the-title-is-required-dialog/30828/4

![screenshot from 2015-08-24 18 18 42](https://cloud.githubusercontent.com/assets/4335742/9437924/9b2b989c-4a8c-11e5-97b9-1a0eb5b050a0.png)
