### PR TITLE
FIX: Dirty edit can toggle to another edit.

### DIFF
--- a/app/assets/javascripts/discourse/controllers/composer.js.es6
+++ b/app/assets/javascripts/discourse/controllers/composer.js.es6
@@ -399,7 +399,7 @@ export default Ember.Controller.extend({
         // If we're already open, we don't have to do anything
         if (composerModel.get('composeState') === Discourse.Composer.OPEN &&
             composerModel.get('draftKey') === opts.draftKey &&
-            composerModel.get('action') === opts.action ) {
+            self._isComposerReply(composerModel, opts)) {
           return resolve();
         }
 
@@ -407,7 +407,7 @@ export default Ember.Controller.extend({
         if (composerModel.get('composeState') === Discourse.Composer.DRAFT &&
             composerModel.get('draftKey') === opts.draftKey) {
           composerModel.set('composeState', Discourse.Composer.OPEN);
-          if (composerModel.get('action') === opts.action) return resolve();
+          if (self._isComposerReply(composerModel, opts)) return resolve();
         }
 
         // If it's a different draft, cancel it and try opening again.
@@ -428,6 +428,11 @@ export default Ember.Controller.extend({
       self._setModel(composerModel, opts);
       resolve();
     });
+  },
+
+  _isComposerReply(composerModel, opts) {
+    return (composerModel.get('action') === Discourse.Composer.REPLY &&
+            composerModel.get('action') === opts.action);
   },
 
   // Given a potential instance and options, set the model for this composer.

--- a/app/assets/javascripts/discourse/models/composer.js.es6
+++ b/app/assets/javascripts/discourse/models/composer.js.es6
@@ -371,7 +371,7 @@ const Composer = RestModel.extend({
 
     const composer = this;
     if (!replyBlank &&
-        ((opts.reply || opts.action === this.EDIT) && this.get('replyDirty'))) {
+        ((opts.reply || opts.action === EDIT) && this.get('replyDirty'))) {
       return;
     }
 

--- a/test/javascripts/acceptance/composer-test.js.es6
+++ b/test/javascripts/acceptance/composer-test.js.es6
@@ -200,6 +200,21 @@ test("Composer can switch between edits", () => {
   });
 });
 
+test("Composer with dirty edit can toggle to another edit", () => {
+  visit("/t/this-is-a-test-topic/9");
+
+  click('.topic-post:eq(0) button[data-action=edit]');
+  fillIn('.wmd-input', 'This is a dirty reply');
+  click('.topic-post:eq(1) button[data-action=edit]');
+  andThen(() => {
+    ok(exists('.bootbox.modal'), 'it pops up a confirmation dialog');
+  });
+  click('.modal-footer a:eq(0)');
+  andThen(() => {
+    equal(find('.wmd-input').val().indexOf('This is the second post.'), 0, 'it populates the input with the post text');
+  });
+});
+
 test("Composer can toggle between edit and reply", () => {
   visit("/t/this-is-a-test-topic/9");
 


### PR DESCRIPTION
Follow up to https://github.com/discourse/discourse/pull/3649#issuecomment-133227526.

Meta: https://meta.discourse.org/t/reply-doesnt-clear-the-edit-post-text-if-clicked-after-edit/26012