### PR TITLE
FIX: Consider reserved usernames as not 'available'

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -149,7 +149,7 @@ class User < ActiveRecord::Base
 
   def self.username_available?(username)
     lower = username.downcase
-    User.where(username_lower: lower).blank?
+    User.where(username_lower: lower).blank? && !SiteSetting.reserved_usernames.split("|").include?(username)
   end
 
   def effective_locale

--- a/spec/components/user_name_suggester_spec.rb
+++ b/spec/components/user_name_suggester_spec.rb
@@ -49,6 +49,12 @@ describe UserNameSuggester do
       expect(UserNameSuggester.suggest("myreallylongnam")).to eq('myreallylongna1')
     end
 
+    it "doesn't suggest reserved usernames" do
+      SiteSetting.reserved_usernames = 'admin|steve|steve1'
+      expect(UserNameSuggester.suggest("admin@hissite.com")).to eq('admin1')
+      expect(UserNameSuggester.suggest("steve")).to eq('steve2')
+    end
+
     it "removes leading character if it is not alphanumeric" do
       expect(UserNameSuggester.suggest("_myname")).to eq('myname')
     end


### PR DESCRIPTION
https://meta.discourse.org/t/reserved-usernames-ignored-by-invites/32490