### PR TITLE
FEATURE: Allow plugins to add admin dashboard warnings

### DIFF
--- a/app/models/admin_dashboard_data.rb
+++ b/app/models/admin_dashboard_data.rb
@@ -32,28 +32,37 @@ class AdminDashboardData
 
   MOBILE_REPORTS ||= ['mobile_visits'] + ApplicationRequest.req_types.keys.select {|r| r =~ /mobile/}.map { |r| r + "_reqs" }
 
+  def self.add_problem_check(*syms, &blk)
+    @problem_syms ||= []
+    @problem_blocks ||= []
+
+    @problem_syms.push(*syms) if syms
+    @problem_blocks << blk if blk
+  end
+  class << self; attr_reader :problem_syms, :problem_blocks; end
+
   def problems
-    [ rails_env_check,
-      ruby_version_check,
-      host_names_check,
-      gc_checks,
-      sidekiq_check || queue_size_check,
-      ram_check,
-      google_oauth2_config_check,
-      facebook_config_check,
-      twitter_config_check,
-      github_config_check,
-      s3_config_check,
-      image_magick_check,
-      failing_emails_check,
-      default_logo_check,
-      contact_email_check,
-      send_consumer_email_check,
-      title_check,
-      site_description_check,
-      site_contact_username_check,
-      notification_email_check
-    ].compact
+    problems = []
+    AdminDashboardData.problem_syms.each do |sym|
+      problems << send(sym)
+    end
+    AdminDashboardData.problem_blocks.each do |blk|
+      problems << instance_exec(&blk)
+    end
+    problems.compact
+  end
+
+  add_problem_check :rails_env_check, :ruby_version_check, :host_names_check,
+                    :gc_checks, :ram_check, :google_oauth2_config_check,
+                    :facebook_config_check, :twitter_config_check,
+                    :github_config_check, :s3_config_check, :image_magick_check,
+                    :failing_emails_check, :default_logo_check, :contact_email_check,
+                    :send_consumer_email_check, :title_check,
+                    :site_description_check, :site_contact_username_check,
+                    :notification_email_check
+
+  add_problem_check do
+    sidekiq_check || queue_size_check
   end
 
 

--- a/app/models/admin_dashboard_data.rb
+++ b/app/models/admin_dashboard_data.rb
@@ -33,9 +33,6 @@ class AdminDashboardData
   MOBILE_REPORTS ||= ['mobile_visits'] + ApplicationRequest.req_types.keys.select {|r| r =~ /mobile/}.map { |r| r + "_reqs" }
 
   def self.add_problem_check(*syms, &blk)
-    @problem_syms ||= []
-    @problem_blocks ||= []
-
     @problem_syms.push(*syms) if syms
     @problem_blocks << blk if blk
   end
@@ -52,19 +49,25 @@ class AdminDashboardData
     problems.compact
   end
 
-  add_problem_check :rails_env_check, :ruby_version_check, :host_names_check,
-                    :gc_checks, :ram_check, :google_oauth2_config_check,
-                    :facebook_config_check, :twitter_config_check,
-                    :github_config_check, :s3_config_check, :image_magick_check,
-                    :failing_emails_check, :default_logo_check, :contact_email_check,
-                    :send_consumer_email_check, :title_check,
-                    :site_description_check, :site_contact_username_check,
-                    :notification_email_check
+  # used for testing
+  def self.reset_problem_checks
+    @problem_syms = []
+    @problem_blocks = []
 
-  add_problem_check do
-    sidekiq_check || queue_size_check
+    add_problem_check :rails_env_check, :ruby_version_check, :host_names_check,
+                      :gc_checks, :ram_check, :google_oauth2_config_check,
+                      :facebook_config_check, :twitter_config_check,
+                      :github_config_check, :s3_config_check, :image_magick_check,
+                      :failing_emails_check, :default_logo_check, :contact_email_check,
+                      :send_consumer_email_check, :title_check,
+                      :site_description_check, :site_contact_username_check,
+                      :notification_email_check
+
+    add_problem_check do
+      sidekiq_check || queue_size_check
+    end
   end
-
+  reset_problem_checks
 
   def self.fetch_stats
     AdminDashboardData.new.as_json

--- a/spec/models/admin_dashboard_data_spec.rb
+++ b/spec/models/admin_dashboard_data_spec.rb
@@ -2,6 +2,32 @@ require 'spec_helper'
 
 describe AdminDashboardData do
 
+  describe "adding new checks" do
+    it 'calls the passed block' do
+      called = false
+      AdminDashboardData.add_problem_check do
+        called = true
+      end
+
+      AdminDashboardData.fetch_problems
+      expect(called).to eq(true)
+    end
+
+    it 'calls the passed method' do
+      $test_AdminDashboardData_global = false
+      class AdminDashboardData
+        def my_test_method
+          $test_AdminDashboardData_global = true
+        end
+      end
+      AdminDashboardData.add_problem_check :my_test_method
+
+      AdminDashboardData.fetch_problems
+      expect($test_AdminDashboardData_global).to eq(true)
+      $test_AdminDashboardData_global = nil
+    end
+  end
+
   describe "rails_env_check" do
     subject { described_class.new.rails_env_check }
 

--- a/spec/models/admin_dashboard_data_spec.rb
+++ b/spec/models/admin_dashboard_data_spec.rb
@@ -3,6 +3,10 @@ require 'spec_helper'
 describe AdminDashboardData do
 
   describe "adding new checks" do
+    after do
+      AdminDashboardData.reset_problem_checks
+    end
+
     it 'calls the passed block' do
       called = false
       AdminDashboardData.add_problem_check do


### PR DESCRIPTION
Have wanted this in a few plugins for a while.

Need to add a helper to automatically do the plugin enabled checks, though.