### PR TITLE
FIX: Autocomplete and Emojis when bounded by non-word characters.

### DIFF
--- a/app/assets/javascripts/discourse/lib/autocomplete.js.es6
+++ b/app/assets/javascripts/discourse/lib/autocomplete.js.es6
@@ -277,7 +277,7 @@ export default function(options) {
     if (options.key && e.which === options.key.charCodeAt(0)) {
       caretPosition = Discourse.Utilities.caretPosition(me[0]);
       var prevChar = me.val().charAt(caretPosition - 1);
-      if (!prevChar || /\s/.test(prevChar)) {
+      if (!prevChar || /\W/.test(prevChar)) {
         completeStart = completeEnd = caretPosition;
         updateAutoComplete(options.dataSource(""));
       }
@@ -331,7 +331,7 @@ export default function(options) {
         stopFound = prev === options.key;
         if (stopFound) {
           prev = me[0].value[c - 1];
-          if (!prev || /\s/.test(prev)) {
+          if (!prev || /\W/.test(prev)) {
             completeStart = c;
             caretPosition = completeEnd = initial;
             term = me[0].value.substring(c + 1, initial);

--- a/app/assets/javascripts/discourse/lib/emoji/emoji.js.erb
+++ b/app/assets/javascripts/discourse/lib/emoji/emoji.js.erb
@@ -113,7 +113,7 @@ function checkPrev(prev) {
     var lastToken = prev[prev.length-1];
     if (lastToken && lastToken.charAt) {
       var lastChar = lastToken.charAt(lastToken.length-1);
-      if (!/\s/.test(lastChar)) return false;
+      if (!/\W/.test(lastChar)) return false;
     }
   }
   return true;


### PR DESCRIPTION
meta: https://meta.discourse.org/t/two-emojis-delimited-by-a-dot-the-second-one-does-not-render/32111
          https://meta.discourse.org/t/pinging-in-parentheses-doesnt-auto-suggest/21377

The logic is a little hard to follow here but I hope I didn't break anything :stuck_out_tongue_closed_eyes: 

![screenshot from 2015-08-26 17 26 04](https://cloud.githubusercontent.com/assets/4335742/9489997/8e55096e-4c17-11e5-8ab3-7ab0c545e9df.png)
