### PR TITLE
FIX: emoji unescape

### DIFF
--- a/app/assets/javascripts/discourse/lib/emoji/emoji.js.erb
+++ b/app/assets/javascripts/discourse/lib/emoji/emoji.js.erb
@@ -30,16 +30,19 @@ for (var name in aliases) {
 }
 
 Discourse.Emoji.unescape = function(string) {
+  //this can be further improved by supporting matches of emoticons that don't begin with a colon
   if (Discourse.SiteSettings.enable_emoji && string.indexOf(":") >= 0) {
-    string = string.replace(/:[^\s:]+:?/g, function(m) {
-      var emoji = Discourse.Emoji.translations[m] ? Discourse.Emoji.translations[m] : m.slice(1, m.length - 1),
+    string = string.replace(/\B:[^\s:]+:?\B/g, function(m) {
+      var isEmoticon = !!Discourse.Emoji.translations[m],
+            emoji = isEmoticon ? Discourse.Emoji.translations[m] : m.slice(1, m.length - 1),
+            hasEndingColon = m.lastIndexOf(":") === m.length - 1,
             url = Discourse.Emoji.urlFor(emoji);
-      return url ? "<img src='" + url + "' title='" + emoji + "' alt='" + emoji + "' class='emoji'>" : m;
+      return url && (isEmoticon || hasEndingColon) ? "<img src='" + url + "' title='" + emoji + "' alt='" + emoji + "' class='emoji'>" : m;
     });
   }
 
   return string;
-}
+};
 
 Discourse.Emoji.urlFor = urlFor = function(code) {
   var url, set = Discourse.SiteSettings.emoji_set;
@@ -63,12 +66,12 @@ Discourse.Emoji.urlFor = urlFor = function(code) {
   }
 
   return url;
-}
+};
 
 Discourse.Emoji.exists = function(code){
   code = code.toLowerCase();
   return !!(extendedEmoji.hasOwnProperty(code) || emojiHash.hasOwnProperty(code));
-}
+};
 
 function imageFor(code) {
   code = code.toLowerCase();
@@ -204,6 +207,6 @@ Discourse.Emoji.search = function(term, options) {
   }
 
   return results;
-}
+};
 
 Discourse.Markdown.whiteListTag('img', 'class', 'emoji');

--- a/test/javascripts/helpers/site-settings.js
+++ b/test/javascripts/helpers/site-settings.js
@@ -91,6 +91,7 @@ Discourse.SiteSettingsOriginal = {
   "show_create_topics_notice":true,
   "available_locales":"cs|da|de|en|es|fr|he|id|it|ja|ko|nb_NO|nl|pl_PL|pt|pt_BR|ru|sv|uk|zh_CN|zh_TW",
   "highlighted_languages":"apache|bash|cs|cpp|css|coffeescript|diff|xml|http|ini|json|java|javascript|makefile|markdown|nginx|objectivec|ruby|perl|php|python|sql|handlebars",
-  "enable_emoji":true
+  "enable_emoji":true,
+  "emoji_set":"emoji_one"
 };
 Discourse.SiteSettings = jQuery.extend(true, {}, Discourse.SiteSettingsOriginal);

--- a/test/javascripts/lib/bbcode-test.js.es6
+++ b/test/javascripts/lib/bbcode-test.js.es6
@@ -52,7 +52,7 @@ test('spoiler', function() {
   format("[spoiler]it's a sled[/spoiler]", "<span class=\"spoiler\">it's a sled</span>", "supports spoiler tags on text");
   format("[spoiler]<img src='http://eviltrout.com/eviltrout.png' width='50' height='50'>[/spoiler]",
          "<span class=\"spoiler\"><img src=\"http://eviltrout.com/eviltrout.png\" width=\"50\" height=\"50\"></span>", "supports spoiler tags on images");
-  format("[spoiler] This is the **bold** :smiley: [/spoiler]", "<span class=\"spoiler\"> This is the <strong>bold</strong> <img src=\"/images/emoji/undefined/smiley.png?v=0\" title=\":smiley:\" class=\"emoji\" alt=\"smiley\"> </span>", "supports spoiler tags on emojis");
+  format("[spoiler] This is the **bold** :smiley: [/spoiler]", "<span class=\"spoiler\"> This is the <strong>bold</strong> <img src=\"/images/emoji/emoji_one/smiley.png?v=0\" title=\":smiley:\" class=\"emoji\" alt=\"smiley\"> </span>", "supports spoiler tags on emojis");
   format("[spoiler] Why not both <img src='http://eviltrout.com/eviltrout.png' width='50' height='50'>?[/spoiler]", "<span class=\"spoiler\"> Why not both <img src=\"http://eviltrout.com/eviltrout.png\" width=\"50\" height=\"50\">?</span>", "supports images and text");
   format("In a p tag a spoiler [spoiler] <img src='http://eviltrout.com/eviltrout.png' width='50' height='50'>[/spoiler] can work.", "In a p tag a spoiler <span class=\"spoiler\"> <img src=\"http://eviltrout.com/eviltrout.png\" width=\"50\" height=\"50\"></span> can work.", "supports images and text in a p tag");
 });

--- a/test/javascripts/lib/emoji-test.js.es6
+++ b/test/javascripts/lib/emoji-test.js.es6
@@ -1,10 +1,29 @@
 
 module('emoji');
 
+var testUnescape = function(input, expected, description) {
+  var unescaped = Discourse.Emoji.unescape(input);
+  equal(unescaped, expected, description);
+};
+
+test("Emoji.unescape", function(){
+
+  testUnescape("Not emoji :O) :frog) :smile)", "Not emoji :O) :frog) :smile)", "title without emoji");
+  testUnescape("Not emoji :frog :smile", "Not emoji :frog :smile", "end colon is not optional");
+  testUnescape("emoticons :)", "emoticons <img src='/images/emoji/emoji_one/smile.png?v=0' title='smile' alt='smile' class='emoji'>", "emoticons are still supported");
+  testUnescape("With emoji :O: :frog: :smile:",
+    "With emoji <img src='/images/emoji/emoji_one/o.png?v=0' title='O' alt='O' class='emoji'> <img src='/images/emoji/emoji_one/frog.png?v=0' title='frog' alt='frog' class='emoji'> <img src='/images/emoji/emoji_one/smile.png?v=0' title='smile' alt='smile' class='emoji'>",
+    "title with emoji");
+  testUnescape("a:smile:a", "a:smile:a", "word characters not allowed next to emoji");
+  testUnescape("(:frog:) :)", "(<img src='/images/emoji/emoji_one/frog.png?v=0' title='frog' alt='frog' class='emoji'>) <img src='/images/emoji/emoji_one/smile.png?v=0' title='smile' alt='smile' class='emoji'>", "non-word characters allowed next to emoji");
+  testUnescape(":smile: hi", "<img src='/images/emoji/emoji_one/smile.png?v=0' title='smile' alt='smile' class='emoji'> hi", "start of line");
+  testUnescape("hi :smile:", "hi <img src='/images/emoji/emoji_one/smile.png?v=0' title='smile' alt='smile' class='emoji'>", "end of line");
+
+});
+
 test("Emoji.search", function(){
 
   // able to find an alias
   equal(Discourse.Emoji.search("coll").length, 1);
 
 });
-

--- a/test/javascripts/models/topic-test.js.es6
+++ b/test/javascripts/models/topic-test.js.es6
@@ -76,6 +76,6 @@ test("recover", function() {
 test('fancyTitle', function() {
   var topic = Topic.create({ fancy_title: ":smile: with all :) the emojis :pear::peach:" });
   equal(topic.get('fancyTitle'),
-        "<img src='/images/emoji/undefined/smile.png?v=0' title='smile' alt='smile' class='emoji'> with all <img src='/images/emoji/undefined/smile.png?v=0' title='smile' alt='smile' class='emoji'> the emojis <img src='/images/emoji/undefined/pear.png?v=0' title='pear' alt='pear' class='emoji'><img src='/images/emoji/undefined/peach.png?v=0' title='peach' alt='peach' class='emoji'>",
+        "<img src='/images/emoji/emoji_one/smile.png?v=0' title='smile' alt='smile' class='emoji'> with all <img src='/images/emoji/emoji_one/smile.png?v=0' title='smile' alt='smile' class='emoji'> the emojis <img src='/images/emoji/emoji_one/pear.png?v=0' title='pear' alt='pear' class='emoji'><img src='/images/emoji/emoji_one/peach.png?v=0' title='peach' alt='peach' class='emoji'>",
         "supports emojis");
 });


### PR DESCRIPTION
Fix for https://meta.discourse.org/t/im-confused-by-o/30869/2 Unescape now checks if the emoji ends with a colon, or is an emoticon that begins with a colon. 

Title posts now only render emojis with ending colons.
<img width="807" alt="screen shot 2015-08-26 at 12 05 23 pm" src="https://cloud.githubusercontent.com/assets/1270189/9503273/c3c954e2-4bea-11e5-8d45-6d0871aa64d1.png">
