### PR TITLE
FIX: prevent horizontal scrollbar from appearing at 1000px screen width

### DIFF
--- a/app/assets/stylesheets/desktop/discourse.scss
+++ b/app/assets/stylesheets/desktop/discourse.scss
@@ -2,16 +2,6 @@
 // BEWARE: changing these styles implies they take effect anywhere they are seen
 // throughout the Discourse application
 
-@include medium-width {
-  body {
-    min-width: $medium-width;
-  }
-  .wrap,
-  .full-width {
-    width: $medium-width;
-  }
-}
-
 @media all
 and (max-width : 570px) {
   body {


### PR DESCRIPTION
Removes the medium-width rule that was setting the width of the `body`, `.wrap`and `.full-width` classes at 995px for screen sizes between 1000px and 1139px. Because Discourse is using `box-sizing: content-box` the padding on the outer `.wrap` class was being added to the 995px width and causing the horizontal scrollbar to appear. There is no need to set the `.wrap` width, other than with max-width. It can be allowed to fill the screen until it reaches that point.

The padding should still be removed from the `.wrap` class and added instead to `.container`.

