### PR TITLE
FIX: rescale image during cooked_post_processor when only height or width is specified

### DIFF
--- a/lib/cooked_post_processor.rb
+++ b/lib/cooked_post_processor.rb
@@ -94,7 +94,20 @@ class CookedPostProcessor
 
   def get_size_from_attributes(img)
     w, h = img["width"].to_i, img["height"].to_i
-    return [w, h] if w > 0 && h > 0
+    return [w, h] unless w <= 0 || h <= 0
+    # if only width or height are specified attempt to scale image
+    if w > 0 || h > 0
+      w = w.to_f
+      h = h.to_f
+      original_width, original_height = get_size(img["src"]).map {|integer| integer.to_f}
+      if w > 0
+        ratio = w/original_width
+        return [w.floor, (original_height*ratio).floor]
+      else
+        ratio = h/original_height
+        return [(original_width*ratio).floor, h.floor]
+      end
+    end
   end
 
   def get_size_from_image_sizes(src, image_sizes)

--- a/spec/components/cooked_post_processor_spec.rb
+++ b/spec/components/cooked_post_processor_spec.rb
@@ -182,6 +182,37 @@ describe CookedPostProcessor do
 
   end
 
+  context ".get_size_from_attributes" do
+
+    let(:post) { build(:post) }
+    let(:cpp) { CookedPostProcessor.new(post) }
+
+    it "returns the size when width and height are specified" do
+      img = { 'src' => 'http://foo.bar/image3.png', 'width' => 50, 'height' => 70}
+      expect(cpp.get_size_from_attributes(img)).to eq([50, 70])
+    end
+
+    it "returns the size when width and height are floats" do
+      img = { 'src' => 'http://foo.bar/image3.png', 'width' => 50.2, 'height' => 70.1}
+      expect(cpp.get_size_from_attributes(img)).to eq([50, 70])
+    end
+
+    it "resizes when only width is specified" do
+      img = { 'src' => 'http://foo.bar/image3.png', 'width' => 100}
+      SiteSetting.stubs(:crawl_images?).returns(true)
+      FastImage.expects(:size).returns([200, 400])
+      expect(cpp.get_size_from_attributes(img)).to eq([100, 200])
+    end
+
+    it "resizes when only height is specified" do
+      img = { 'src' => 'http://foo.bar/image3.png', 'height' => 100}
+      SiteSetting.stubs(:crawl_images?).returns(true)
+      FastImage.expects(:size).returns([100, 300])
+      expect(cpp.get_size_from_attributes(img)).to eq([33, 100])
+    end
+
+  end
+
   context ".get_size_from_image_sizes" do
 
     let(:post) { build(:post) }


### PR DESCRIPTION
Fix for https://meta.discourse.org/t/img-width-and-height-attribute-oddities/26891

When adding an image in the composer with only a width or height attribute, ie:

```
<img src="/uploads/default/original/1X/892174c24f4ddca8c145a8e35d6ba90cadca59ad.jpg" height="100"> 
```

The cooked_post_processor will rescale that relative to the original dimensions:
```
<img src="//localhost:3000/uploads/default/original/1X/892174c24f4ddca8c145a8e35d6ba90cadca59ad.jpg" height="100" width="200">
```

<img width="1096" alt="screen shot 2015-08-29 at 3 01 40 pm" src="https://cloud.githubusercontent.com/assets/1270189/9564525/f8a25f6c-4e5e-11e5-8298-1fdd5653a486.png">

<img width="858" alt="screen shot 2015-08-29 at 3 01 06 pm" src="https://cloud.githubusercontent.com/assets/1270189/9564524/f30acb84-4e5e-11e5-9df8-e8163c41cceb.png">