### PR TITLE
FIX: Emoji not unescaped in topic link.

### DIFF
--- a/app/assets/javascripts/discourse/components/post-gutter.js.es6
+++ b/app/assets/javascripts/discourse/components/post-gutter.js.es6
@@ -45,7 +45,8 @@ export default Em.Component.extend(StringBuffer, {
 
         var title = Em.get(l, 'title');
         if (!Em.isEmpty(title)) {
-          buffer.push(Handlebars.Utils.escapeExpression(title));
+          title = Handlebars.Utils.escapeExpression(title);
+          buffer.push(Discourse.Emoji.unescape(title));
         }
         if (clicks) {
           buffer.push("<span class='badge badge-notification clicks'>" + clicks + "</span>");


### PR DESCRIPTION
meta: https://meta.discourse.org/t/emoji-missing-in-linked-topics/32660