### PR TITLE
FIX: use transform mixin for mobile admin settings

### DIFF
--- a/app/assets/stylesheets/common/admin/admin_base.scss
+++ b/app/assets/stylesheets/common/admin/admin_base.scss
@@ -198,7 +198,7 @@ td.flaggers td {
     }
     // Hide the search checkbox for very small screens
     // Todo: find somewhere to display it - probably requires switching its order in the html
-    @media (max-width: 450px) {
+    @media (max-width: 550px) {
       display: none;
     }
   }

--- a/app/assets/stylesheets/common/admin/admin_base.scss
+++ b/app/assets/stylesheets/common/admin/admin_base.scss
@@ -3,7 +3,7 @@
 @import "common/foundation/mixins";
 @import "common/foundation/helpers";
 
-$mobile-breakpoint: 600px;
+$mobile-breakpoint: 700px;
 
 // Change the box model for .admin-content
 @media (max-width: $mobile-breakpoint) {

--- a/app/assets/stylesheets/common/admin/admin_base.scss
+++ b/app/assets/stylesheets/common/admin/admin_base.scss
@@ -278,15 +278,15 @@ td.flaggers td {
 
 .admin-detail.mobile-open {
   @media (max-width: $mobile-breakpoint) {
-    transition: transform 0.3s ease;
-    transform: (translateX(50%));
+    @include transition(transform 0.3s ease);
+    @include transform(translateX(50%));
   }
 }
 
 .admin-detail.mobile-closed {
   @media (max-width: $mobile-breakpoint) {
-    transition: transform 0.3s ease;
-    transform: (translateX(0));
+    @include transition(transform 0.3s ease);
+    @include transform(translateX(0));
   }
 }
 

--- a/app/assets/stylesheets/common/admin/admin_base.scss
+++ b/app/assets/stylesheets/common/admin/admin_base.scss
@@ -3,7 +3,7 @@
 @import "common/foundation/mixins";
 @import "common/foundation/helpers";
 
-$mobile-breakpoint: 700px;
+$mobile-breakpoint: 600px;
 
 // Change the box model for .admin-content
 @media (max-width: $mobile-breakpoint) {
@@ -278,14 +278,14 @@ td.flaggers td {
 
 .admin-detail.mobile-open {
   @media (max-width: $mobile-breakpoint) {
-    @include transition(transform 0.3s ease);
+    transition: transform 0.3s ease;
     @include transform(translateX(50%));
   }
 }
 
 .admin-detail.mobile-closed {
   @media (max-width: $mobile-breakpoint) {
-    @include transition(transform 0.3s ease);
+    transition: transform 0.3s ease;
     @include transform(translateX(0));
   }
 }

--- a/app/assets/stylesheets/common/foundation/mixins.scss
+++ b/app/assets/stylesheets/common/foundation/mixins.scss
@@ -113,11 +113,3 @@
 	-webkit-transform: $transforms;
           transform: $transforms;
 }
-
-@mixin transition($transitions) {
-  -o-transition: $transitions;
-  -moz-transition: $transitions;
-  -webkit-transition: $transitions;
-  transition: $transitions;
-}
-

--- a/app/assets/stylesheets/common/foundation/mixins.scss
+++ b/app/assets/stylesheets/common/foundation/mixins.scss
@@ -113,3 +113,11 @@
 	-webkit-transform: $transforms;
           transform: $transforms;
 }
+
+@mixin transition($transitions) {
+  -o-transition: $transitions;
+  -moz-transition: $transitions;
+  -webkit-transition: $transitions;
+  transition: $transitions;
+}
+


### PR DESCRIPTION
The transition in `admin_base.scss` needs the webkit prefix.