### PR TITLE
workaround for code block being parsed before quote block.

### DIFF
--- a/app/assets/javascripts/discourse/dialects/code_dialect.js
+++ b/app/assets/javascripts/discourse/dialects/code_dialect.js
@@ -33,6 +33,7 @@ function codeFlattenBlocks(blocks) {
 Discourse.Dialect.replaceBlock({
   start: /^`{3}([^\n\[\]]+)?\n?([\s\S]*)?/gm,
   stop: /^```$/gm,
+  withoutLeading: /\[quote/gm, //if leading text contains a quote this should not match
   emitter: function(blockContents, matches) {
 
     var klass = Discourse.SiteSettings.default_code_lang;

--- a/app/assets/javascripts/discourse/dialects/dialect.js
+++ b/app/assets/javascripts/discourse/dialects/dialect.js
@@ -501,6 +501,12 @@ Discourse.Dialect = {
       var pos = args.start.lastIndex - match[0].length,
           leading = block.slice(0, pos),
           trailing = match[2] ? match[2].replace(/^\n*/, "") : "";
+
+      if(args.withoutLeading && args.withoutLeading.test(leading)) {
+        //The other leading block should be processed first! eg a code block wrapped around a code block.
+        return;
+      }
+
       // just give up if there's no stop tag in this or any next block
       args.stop.lastIndex = block.length - trailing.length;
       if (!args.stop.exec(block) && lastChance()) { return; }

--- a/test/javascripts/lib/bbcode-test.js.es6
+++ b/test/javascripts/lib/bbcode-test.js.es6
@@ -160,6 +160,13 @@ test("quote formatting", function() {
          "<aside class=\"quote\" data-post=\"1\" data-topic=\"1\"><div class=\"title\"><div class=\"quote-controls\"></div>Alice:" +
          "</div><blockquote><p>[quote=\"Bob, post:2, topic:1\"]</p></blockquote></aside>",
          "handles mismatched nested quote tags");
+
+  formatQ("[quote=\"Alice, post:1, topic:1\"]\n```javascript\nvar foo ='foo';\nvar bar = 'bar';\n```\n[/quote]",
+          "<aside class=\"quote\" data-post=\"1\" data-topic=\"1\"><div class=\"title\"><div class=\"quote-controls\"></div>Alice:</div><blockquote><p><pre><code class=\"lang-javascript\">var foo =&#x27;foo&#x27;;\nvar bar = &#x27;bar&#x27;;</code></pre></p></blockquote></aside>",
+          "quotes can have code blocks without leading newline");
+  formatQ("[quote=\"Alice, post:1, topic:1\"]\n\n```javascript\nvar foo ='foo';\nvar bar = 'bar';\n```\n[/quote]",
+          "<aside class=\"quote\" data-post=\"1\" data-topic=\"1\"><div class=\"title\"><div class=\"quote-controls\"></div>Alice:</div><blockquote><p><pre><code class=\"lang-javascript\">var foo =&#x27;foo&#x27;;\nvar bar = &#x27;bar&#x27;;</code></pre></p></blockquote></aside>",
+          "quotes can have code blocks with leading newline");
 });
 
 test("quotes with trailing formatting", function() {


### PR DESCRIPTION
This works around a parsing bug where a child code block would be processed before it's parent quote block, as described [here](https://meta.discourse.org/t/quotes-containing-code-block-must-start-with-newline/25369). There is a separate but related issue, where the [inline code block handling code is called instead of the multiline code block](https://meta.discourse.org/t/quoting-a-code-block-removes-new-lines/28290). That is not solved in this issue.

You can trigger the bug with the following:
```
    [quote="gwwar, post:1, topic:70", full="true"]
    ```javascript
    var foo = "foo";
    var bar = "bar";
    ```
    [/quote]
```
Broken:
<img width="1041" alt="screen shot 2015-08-31 at 10 36 14 am" src="https://cloud.githubusercontent.com/assets/1270189/9585483/2560944c-4fcc-11e5-9b78-67b9e42833e4.png">

Fixed:
<img width="1037" alt="screen shot 2015-08-31 at 10 37 16 am" src="https://cloud.githubusercontent.com/assets/1270189/9585515/4c9a59bc-4fcc-11e5-919e-4651dc90ac71.png">

This is actually a dialect markdown parsing issue that will most likely require changes to your modified `vendor/better_markdown.js`. I highly suggest you take a look. Basically the quote block returns incorrectly at this line: https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/dialects/dialect.js#L506 as blocks have been split in such a way that it can't detect the end block.