### PR TITLE
FIX: Fix the logout functionality in core

### DIFF
--- a/app/assets/javascripts/discourse/components/user-menu.js.es6
+++ b/app/assets/javascripts/discourse/components/user-menu.js.es6
@@ -1,5 +1,6 @@
 import { url } from 'discourse/lib/computed';
 import { default as computed, observes } from 'ember-addons/ember-computed-decorators';
+import User from 'discourse/models/user';
 
 export default Ember.Component.extend({
   classNames: ['user-menu'],
@@ -69,6 +70,9 @@ export default Ember.Component.extend({
       Discourse.ajax("/users/toggle-anon", {method: 'POST'}).then(function(){
         window.location.reload();
       });
+    },
+    logout() {
+      User.logout();
     }
   }
 });


### PR DESCRIPTION
The logout action was missing from core, so it was throwing an error when the setting was enabled.