### PR TITLE
FIX: Timegap only shows up for sequential posts.

### DIFF
--- a/app/assets/javascripts/discourse/components/time-gap.js.es6
+++ b/app/assets/javascripts/discourse/components/time-gap.js.es6
@@ -2,6 +2,8 @@ import SmallActionComponent from 'discourse/components/small-action';
 
 export default SmallActionComponent.extend({
   classNames: ['time-gap'],
+  classNameBindings: ['hideTimeGap::hidden'],
+  hideTimeGap: Em.computed.alias('postStream.hasNoFilters'),
   icon: 'clock-o',
 
   description: function() {

--- a/app/assets/javascripts/discourse/models/post-stream.js.es6
+++ b/app/assets/javascripts/discourse/models/post-stream.js.es6
@@ -5,18 +5,13 @@ function calcDayDiff(p1, p2) {
   if (!p1) { return; }
 
   const date = p1.get('created_at');
-  if (date) {
-    if (p2) {
-      const numDiff = p1.get('post_number') - p2.get('post_number');
-      if (numDiff === 1) {
-        const lastDate = p2.get('created_at');
-        if (lastDate) {
-          const delta = new Date(date).getTime() - new Date(lastDate).getTime();
-          const days = Math.round(delta / (1000 * 60 * 60 * 24));
+  if (date && p2) {
+    const lastDate = p2.get('created_at');
+    if (lastDate) {
+      const delta = new Date(date).getTime() - new Date(lastDate).getTime();
+      const days = Math.round(delta / (1000 * 60 * 60 * 24));
 
-          p1.set('daysSincePrevious', days);
-        }
-      }
+      p1.set('daysSincePrevious', days);
     }
   }
 }

--- a/app/assets/javascripts/discourse/templates/post.hbs
+++ b/app/assets/javascripts/discourse/templates/post.hbs
@@ -1,7 +1,7 @@
 {{post-gap post=this postStream=controller.model.postStream before="true"}}
 
 {{#if hasTimeGap}}
-  {{time-gap daysAgo=daysSincePrevious}}
+  {{time-gap daysAgo=daysSincePrevious postStream=controller.model.postStream}}
 {{/if}}
 
 <div class='row'>


### PR DESCRIPTION
Meta:
* https://meta.discourse.org/t/large-time-gap-indicator-disappears-on-delete/30864/6
* https://meta.discourse.org/t/missing-x-months-ago-between-posts-when-post-numbers-are-not-continuous/32714

