### PR TITLE
Always use locale fallback on server

### DIFF
--- a/config/initializers/i18n.rb
+++ b/config/initializers/i18n.rb
@@ -22,16 +22,5 @@ class FallbackLocaleList < Hash
   end
 end
 
-class NoFallbackLocaleList < FallbackLocaleList
-  def [](locale)
-    [locale]
-  end
-end
-
-
-if Rails.env.development?
-  I18n.fallbacks = NoFallbackLocaleList.new
-else
-  I18n.fallbacks = FallbackLocaleList.new
-  I18n.config.missing_interpolation_argument_handler = proc { throw(:exception) }
-end
+I18n.fallbacks = FallbackLocaleList.new
+I18n.config.missing_interpolation_argument_handler = proc { throw(:exception) }


### PR DESCRIPTION
Currently missing translations in server.yml can lead to errors that do no exist in production environment, which makes it quite hard to debug i18n issues.

This PR restores the previous locale fallback behavior in development environment. It uses the English text instead of showing en error message when a translation is missing on the server. That's the way it was before https://github.com/discourse/discourse/pull/3609.

The client side behavior is still unchanged: It uses fallback in production mode and shows the missing translation key in development mode.

Without this change:
![image](https://cloud.githubusercontent.com/assets/473736/9642294/980dd784-51bb-11e5-8cf2-dd4b04fed84b.png)

With this change:
![image](https://cloud.githubusercontent.com/assets/473736/9642271/87556902-51bb-11e5-9190-7df7fcaba4da.png)

https://meta.discourse.org/t/always-enable-localization-fallback/32314