### PR TITLE
Add plugin for displaying sidekiq statistic in web ui

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,6 +90,7 @@ gem 'rinku'
 gem 'sanitize'
 gem 'sass'
 gem 'sidekiq'
+gem 'sidekiq-statistic'
 
 # for sidekiq web
 gem 'sinatra', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -333,6 +333,8 @@ GEM
       json (~> 1.0)
       redis (~> 3.2, >= 3.2.1)
       redis-namespace (~> 1.5, >= 1.5.2)
+    sidekiq-statistic (1.1.0)
+      sidekiq (~> 3.3, >= 3.3.4)
     simple-rss (1.3.1)
     simplecov (0.9.1)
       docile (~> 1.1.0)
@@ -474,6 +476,7 @@ DEPENDENCIES
   seed-fu (~> 2.3.3)
   shoulda
   sidekiq
+  sidekiq-statistic
   simple-rss
   simplecov
   sinatra


### PR DESCRIPTION
Hello,
I created simple [plugin](https://github.com/davydovanton/sidekiq-statistc) for displaying sidekiq statistic in web UI. Also I have some screenshots for index page with my plugin:
![screenshot 2015-09-03 01 22 32](https://cloud.githubusercontent.com/assets/1147484/9646304/ff871df2-51da-11e5-8e0f-db989dbd32a0.jpg)
![screenshot 2015-09-03 01 22 43](https://cloud.githubusercontent.com/assets/1147484/9646305/ffb6b9ea-51da-11e5-9124-475323127b85.jpg)
![screenshot 2015-09-03 01 22 50](https://cloud.githubusercontent.com/assets/1147484/9646306/ffba2c06-51da-11e5-88b7-d9d204b27354.jpg)

/cc @SamSaffron 