### PR TITLE
Remove hard-coded fallback to English locale

### DIFF
--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -41,11 +41,8 @@ class UserNotifications < ActionMailer::Base
     build_email( user.email, template: "user_notifications.account_created", email_token: opts[:email_token])
   end
 
-  # On error, use english
   def short_date(dt)
     I18n.l(dt, format: :short)
-  rescue I18n::MissingTranslationData
-    I18n.l(dt, format: :short, locale: 'en')
   end
 
   def digest(user, opts={})


### PR DESCRIPTION
There's no need for this explicit fallback to English anymore:
- In production mode the English locale is always used as fallback.
- In development mode there is currently no fallback, so the English locale isn't loaded and the second call to `I18n.l()` fails too. PR https://github.com/discourse/discourse/pull/3724 would fix the error in development mode.