### PR TITLE
FEATURE: Integrity hashes for scripts

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,6 @@
 require 'current_user'
 require 'canonical_url'
+require 'integrity_hash'
 require_dependency 'guardian'
 require_dependency 'unread'
 require_dependency 'age_words'
@@ -44,6 +45,18 @@ module ApplicationHelper
     else
       javascript_include_tag(*args)
     end
+  end
+
+  def javascript_include_tag(*sources)
+    options = sources.extract_options!.stringify_keys
+    path_options = options.extract!('protocol', 'extname').symbolize_keys
+    sources.uniq.map { |source|
+      tag_options = {
+        "src" => path_to_javascript(source, path_options),
+        "integrity" => Discourse::IntegrityHash.for_asset(source)
+      }.merge!(options)
+      content_tag(:script, "", tag_options)
+    }.join("\n").html_safe
   end
 
   def discourse_csrf_tags

--- a/app/models/site_customization.rb
+++ b/app/models/site_customization.rb
@@ -1,6 +1,7 @@
 require_dependency 'sass/discourse_sass_compiler'
 require_dependency 'sass/discourse_stylesheets'
 require_dependency 'distributed_cache'
+require 'integrity_hash'
 
 class SiteCustomization < ActiveRecord::Base
   ENABLED_KEY = '7e202ef2-56d7-47d5-98d8-a9c8d15e57dd'
@@ -159,13 +160,13 @@ class SiteCustomization < ActiveRecord::Base
   def self.stylesheet_link_tag(key, target, content)
     return "" unless content.present?
 
-    hash = Digest::MD5.hexdigest(content)
-    link_css_tag "/site_customizations/#{key}.css?target=#{target}&v=#{hash}"
+    hash = Discourse::IntegrityHash.for_string(content)
+    link_css_tag "/site_customizations/#{key}.css?target=#{target}&v=#{hash}", hash
   end
 
-  def self.link_css_tag(href)
+  def self.link_css_tag(href, integrity_hash='')
     href = (GlobalSetting.cdn_url || "") + "#{GlobalSetting.relative_url_root}#{href}&__ws=#{Discourse.current_hostname}"
-    %Q{<link class="custom-css" rel="stylesheet" href="#{href}" type="text/css" media="all">}.html_safe
+    %Q{<link class="custom-css" rel="stylesheet" integrity="#{integrity_hash}" href="#{href}" type="text/css" media="all">}.html_safe
   end
 end
 

--- a/app/views/common/_logster_javascript.html.erb
+++ b/app/views/common/_logster_javascript.html.erb
@@ -1,0 +1,25 @@
+<script>
+  // Report JS errors
+(function(){var last=null;
+window.onerror=function(m,u,i,c,o){
+var n=new Date(),g=window.Logster,e={message:m,url:u,line:i,column:c,window_location:window.location+""},x=new XMLHttpRequest()
+if((!last||n-last>60000)&&(!g||g.enabled)){
+if(o&&o.stack){e.stacktrace=o.stack}last=n
+x.open('POST','<%= Discourse.base_uri%>/logs/report_js_error',!0)
+<%
+if current_user
+%>
+x.setRequestHeader('X-CSRF-Token','<%= form_authenticity_token %>')
+x.send(JSON.stringify(e))
+<%
+else
+%>
+var y=new XMLHttpRequest()
+y.onreadystatechange=function(){if(y.readyState==4){
+x.setRequestHeader('X-CSRF-Token',JSON.parse(y.responseText).csrf)
+x.send(JSON.stringify(e))}}
+y.open('GET','/session/csrf.json',!0);y.send()
+<%
+end
+%>
+}}})()</script>

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -9,5 +9,4 @@
 <meta name="theme-color" content="#<%= ColorScheme.hex_for_name('header_background') %>">
 
 <meta name="viewport" content="width=device-width, minimum-scale=1.0, maximum-scale=1.0, user-scalable=yes">
-
 <%= canonical_link_tag %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,6 +5,8 @@
     <meta charset="utf-8">
     <title><%= content_for?(:title) ? yield(:title) + ' - ' + SiteSetting.title : SiteSetting.title %></title>
     <meta name="description" content="<%= @description_meta || SiteSetting.site_description %>">
+    <%- # Before any JS or CSS resources %>
+    <%= render partial: "common/logster_javascript" %>
     <%= render partial: "layouts/head" %>
     <%= render partial: "common/special_font_face" %>
     <%= render partial: "common/discourse_stylesheet" %>

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -856,6 +856,7 @@ en:
     enable_escaped_fragments: "Fall back to Google's Ajax-Crawling API if no webcrawler is detected. See https://support.google.com/webmasters/answer/174992?hl=en"
     enable_noscript_support: "Enable standard webcrawler search engine support via the noscript tag"
     allow_moderators_to_create_categories: "Allow moderators to create new categories"
+    use_integrity_hashes: "Include subresource integrity (SRI) hashes for the JS and CSS assets. More information: http://www.w3.org/TR/SRI/ https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity"
     cors_origins: "Allowed origins for cross-origin requests (CORS). Each origin must include http:// or https://. The DISCOURSE_ENABLE_CORS env variable must be set to true to enable CORS."
     top_menu: "Determine which items appear in the homepage navigation, and in what order. Example latest|new|unread|categories|top|read|posted|bookmarks"
     post_menu: "Determine which items appear on the post menu, and in what order. Example like|edit|flag|delete|share|bookmark|reply"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -640,6 +640,7 @@ security:
   allow_index_in_robots_txt: true
   enable_noscript_support: true
   allow_moderators_to_create_categories: false
+  use_integrity_hashes: false
   cors_origins:
     default: ''
     type: list

--- a/lib/integrity_hash.rb
+++ b/lib/integrity_hash.rb
@@ -8,14 +8,25 @@ class Discourse::IntegrityHash
     asset = Rails.application.assets[asset_name]
     @integrity_hashes ||= {}
     if !@integrity_hashes[asset_name] || @integrity_hashes[asset_name][:mtime] != asset.mtime
-      digest = new_hash
-      coder = {}
-      asset.encode_with(coder)
-      digest.update(coder['source'])
-      @integrity_hashes[asset_name] = {
-        digest: "sha256-#{digest.base64digest}",
-        mtime: asset.mtime
-      }
+      if Rails.env.production?
+        if asset_name == 'vendor'
+          # FIXME https://code.google.com/p/chromium/issues/detail?id=527286
+          return ''
+        end
+        @integrity_hashes[asset_name] = {
+          digest: for_file(File.join(Rails.root, 'public/assets', asset.digest_path)),
+          mtime: asset.mtime
+        }
+      else
+        digest = new_hash
+        coder = {}
+        asset.encode_with(coder)
+        digest.update(coder['source'])
+        @integrity_hashes[asset_name] = {
+          digest: "sha256-#{digest.base64digest}",
+          mtime: asset.mtime
+        }
+      end
     end
     @integrity_hashes[asset_name][:digest]
   end

--- a/lib/integrity_hash.rb
+++ b/lib/integrity_hash.rb
@@ -5,6 +5,7 @@ class Discourse::IntegrityHash
   end
 
   def self.for_asset(asset_name)
+    return '' unless SiteSetting.use_integrity_hashes
     asset = Rails.application.assets[asset_name]
     @integrity_hashes ||= {}
     if !@integrity_hashes[asset_name] || @integrity_hashes[asset_name][:mtime] != asset.mtime
@@ -32,6 +33,7 @@ class Discourse::IntegrityHash
   end
 
   def self.for_file(filename)
+    return '' unless SiteSetting.use_integrity_hashes
     digest = new_hash
     File.open(filename, 'r') do |f|
       digest.update(f.read(2**16)) until f.eof?
@@ -40,6 +42,7 @@ class Discourse::IntegrityHash
   end
 
   def self.for_string(content)
+    return '' unless SiteSetting.use_integrity_hashes
     "sha256-#{new_hash.base64digest(content)}"
   end
 end

--- a/lib/sass/discourse_stylesheets.rb
+++ b/lib/sass/discourse_stylesheets.rb
@@ -24,7 +24,8 @@ class DiscourseStylesheets
       builder = self.new(target)
       builder.compile unless File.exists?(builder.stylesheet_fullpath)
       builder.ensure_digestless_file
-      tag = %[<link href="#{Rails.env.production? ? builder.stylesheet_cdnpath : builder.stylesheet_relpath_no_digest + '?body=1'}" media="all" rel="stylesheet" />]
+      digest = Discourse::IntegrityHash.for_file(builder.stylesheet_fullpath)
+      tag = %[<link href="#{Rails.env.production? ? builder.stylesheet_cdnpath : builder.stylesheet_relpath_no_digest + '?body=1'}" integrity="#{digest}" media="all" rel="stylesheet" />]
 
       cache[target] = tag
 


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity

![image](https://cloud.githubusercontent.com/assets/627891/9711198/a4471112-54f6-11e5-8519-270dfb149e83.png)
---
![image](https://cloud.githubusercontent.com/assets/627891/9711951/215433e2-54fc-11e5-8004-95c649f00953.png)


The `logster_javascript` partial will only take effect when there is an error before vendor.js loads and runs & puts in the real onerror handler, but this is necessary to get reports of integrity violations.

---

~~don't pull this, it breaks prod atm: https://code.google.com/p/chromium/issues/detail?id=527286~~ Worked around