### PR TITLE
FIX: add margin to allow for right and left box-shadow blur on search input

### DIFF
--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -114,9 +114,9 @@
   }
 
   input[type='text'] {
-    margin: 0.5em 0 0.5em;
+    margin: 0.5em 3px;
     box-sizing: border-box;
-    width: 100%;
+    width: calc(100% - 6px);
     height: 32px;
     padding: 5px;
   }


### PR DESCRIPTION
There is an 8px blur on input[type="text"]:focus. The box-shadow is not accounted for by setting the input's box-sizing to border-box. This fix adds a 3px right and left margin to the input and then subtracts 6px from the input's width (margins are not included in border-box either.) 