### PR TITLE
FIX: eliminate 3px gap under mobile menu-panel

### DIFF
--- a/app/assets/javascripts/discourse/components/menu-panel.js.es6
+++ b/app/assets/javascripts/discourse/components/menu-panel.js.es6
@@ -56,7 +56,7 @@ export default Ember.Component.extend({
       }
 
       $panelBody.height('100%');
-      this.$().css({ left: "auto", top: (menuTop - 2) + "px", height });
+      this.$().css({ left: "auto", top: (menuTop) + "px", height });
       $('body').removeClass('drop-down-visible');
     }
 

--- a/app/assets/javascripts/discourse/views/header.js.es6
+++ b/app/assets/javascripts/discourse/views/header.js.es6
@@ -51,5 +51,5 @@ export function headerHeight() {
   const $header = $('header.d-header');
   const headerOffset = $header.offset();
   const headerOffsetTop = (headerOffset) ? headerOffset.top : 0;
-  return parseInt($header.height() + headerOffsetTop - $(window).scrollTop() + 5);
+  return parseInt($header.outerHeight() + headerOffsetTop - $(window).scrollTop());
 }


### PR DESCRIPTION
@eviltrout 
Uses outerHeight() instead of height() to calculate header height in header.js.es6. There is padding on the header in the desktop view, but none in the mobile view. outerHeight() includes the padding in its calculation - this allows .menu-panel.slide-in to have its top position calculated more easily.