### PR TITLE
FIX: eliminate clipped menu content on small screens

### DIFF
--- a/app/assets/javascripts/discourse/components/menu-panel.js.es6
+++ b/app/assets/javascripts/discourse/components/menu-panel.js.es6
@@ -2,7 +2,6 @@ import { default as computed, on, observes } from 'ember-addons/ember-computed-d
 import { headerHeight } from 'discourse/views/header';
 
 const PANEL_BODY_MARGIN = 30;
-//const PANEL_BODY_PADDING = 7;
 const mutationSupport = !!window['MutationObserver'];
 
 export default Ember.Component.extend({
@@ -14,7 +13,7 @@ export default Ember.Component.extend({
     if (!this.get('visible')) { return; }
 
     const $window = $(window);
-    let width = this.get('maxWidth') || 300;
+    let width = this.get('maxWidth') || 314;
     const windowWidth = parseInt($window.width());
 
     if ((windowWidth - width) < 50) {

--- a/app/assets/javascripts/discourse/components/menu-panel.js.es6
+++ b/app/assets/javascripts/discourse/components/menu-panel.js.es6
@@ -2,7 +2,7 @@ import { default as computed, on, observes } from 'ember-addons/ember-computed-d
 import { headerHeight } from 'discourse/views/header';
 
 const PANEL_BODY_MARGIN = 30;
-const PANEL_BODY_PADDING = 7;
+//const PANEL_BODY_PADDING = 7;
 const mutationSupport = !!window['MutationObserver'];
 
 export default Ember.Component.extend({
@@ -23,7 +23,7 @@ export default Ember.Component.extend({
 
     const viewMode = this.get('viewMode');
     const $panelBody = this.$('.panel-body');
-    let contentHeight = parseInt(this.$('.panel-body-contents').height());
+    let contentHeight = parseInt(this.$('.panel-body-contents').outerHeight());
 
     if (viewMode === 'drop-down') {
       const $buttonPanel = $('header ul.icons');
@@ -51,7 +51,7 @@ export default Ember.Component.extend({
       if ((menuTop + contentHeight) < ($(window).height() - 20)) {
         height = contentHeight + "px";
       } else {
-        height = $(window).height() - menuTop - (2 * PANEL_BODY_PADDING);
+        height = $(window).height() - menuTop;
       }
 
       $panelBody.height('100%');

--- a/app/assets/javascripts/discourse/components/menu-panel.js.es6
+++ b/app/assets/javascripts/discourse/components/menu-panel.js.es6
@@ -2,6 +2,7 @@ import { default as computed, on, observes } from 'ember-addons/ember-computed-d
 import { headerHeight } from 'discourse/views/header';
 
 const PANEL_BODY_MARGIN = 30;
+const PANEL_BODY_PADDING = 7;
 const mutationSupport = !!window['MutationObserver'];
 
 export default Ember.Component.extend({
@@ -50,7 +51,7 @@ export default Ember.Component.extend({
       if ((menuTop + contentHeight) < ($(window).height() - 20)) {
         height = contentHeight + "px";
       } else {
-        height = $(window).height() - menuTop;
+        height = $(window).height() - menuTop - (2 * PANEL_BODY_PADDING);
       }
 
       $panelBody.height('100%');

--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -3,13 +3,6 @@
   // positions are relative to the .d-header .panel div
   right: 0;
   top: 0;
-
-  .panel-body {
-    position: absolute;
-    top: 3px;
-    bottom: 37px;
-    width: 97%;
-  }
 }
 
 .menu-panel.drop-down {
@@ -24,7 +17,6 @@
   box-shadow: 0 2px 2px rgba(0,0,0, .25);
   background-color: $secondary;
   z-index: 1100;
-  padding: 0.5em;
   width: 300px;
 
   hr {

--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -9,7 +9,7 @@
   position: absolute;
   // positions are relative to the .d-header .panel div
   top: 100%; // directly underneath .panel
-  right: -10px; // 10px to the right of .panel - adjust as needed
+  right: -15px; // 15px to the right of .panel - adjust as needed
 }
 
 .menu-panel {
@@ -17,7 +17,7 @@
   box-shadow: 0 2px 2px rgba(0,0,0, .25);
   background-color: $secondary;
   z-index: 1100;
-  width: 300px;
+  width: 314px;
 
   hr {
     margin: 3px 0;
@@ -74,6 +74,7 @@
     float: left;
     background-color: transparent;
     width: 50%;
+    -moz-box-sizing: border-box; // For Firefix <29
     box-sizing: border-box;
     padding: 5px 5px 0 8px;
     .box {margin-top: 0;}

--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -73,8 +73,9 @@
   li.category-link {
     float: left;
     background-color: transparent;
-    width: 45%;
-    margin: 5px 5px 0 8px;
+    width: 50%;
+    box-sizing: border-box;
+    padding: 5px 5px 0 8px;
     .box {margin-top: 0;}
     .badge-notification {
       color: dark-light-choose(scale-color($primary, $lightness: 50%), scale-color($secondary, $lightness: 50%));

--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -28,6 +28,10 @@
     right: 20px;
   }
 
+  .panel-body-contents {
+    padding: 0.5em;
+  }
+
   ul {
     list-style: none;
     margin: 0;


### PR DESCRIPTION
@eviltrout 
The height calculation for the slide-out menu in menu-panel.js.es6 is not taking the padding on the menu panel into account. This results in the menu-panel extending below the window when the window height is less than the menu contents. This fix is one way to do it. ~~It sets the PANEL_BODY_PADDING as a constant.~~