### PR TITLE
Add embed/info endpoint for TopicEmbed queries

### DIFF
--- a/app/serializers/topic_embed_serializer.rb
+++ b/app/serializers/topic_embed_serializer.rb
@@ -1,0 +1,15 @@
+class TopicEmbedSerializer < ApplicationSerializer
+  attributes \
+    :topic_id,
+    :post_id,
+    :topic_slug,
+    :comment_count
+
+  def topic_slug
+    object.topic.slug
+  end
+
+  def comment_count
+    object.topic.posts_count - 1
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -441,6 +441,7 @@ Discourse::Application.routes.draw do
 
   get 'embed/comments' => 'embed#comments'
   get 'embed/count' => 'embed#count'
+  get 'embed/info' => 'embed#info'
 
   get "new-topic" => "list#latest"
 

--- a/spec/controllers/embed_controller_spec.rb
+++ b/spec/controllers/embed_controller_spec.rb
@@ -29,6 +29,40 @@ describe EmbedController do
     end
   end
 
+  context ".info" do
+    context "without api key" do
+      it "fails" do
+        get :info, format: :json
+        expect(response).not_to be_success
+      end
+    end
+
+    context "with api key" do
+
+      let(:api_key) { ApiKey.create_master_key }
+
+      context "with valid embed url" do
+        let(:topic_embed) { Fabricate(:topic_embed, embed_url: embed_url) }
+
+        it "returns information about the topic" do
+          get :info, format: :json, embed_url: topic_embed.embed_url, api_key: api_key.key, api_username: "system"
+          json = JSON.parse(response.body)
+          expect(json['topic_id']).to eq(topic_embed.topic.id)
+          expect(json['post_id']).to eq(topic_embed.post.id)
+          expect(json['topic_slug']).to eq(topic_embed.topic.slug)
+        end
+      end
+
+      context "without invalid embed url" do
+        it "returns error response" do
+          get :info, format: :json, embed_url: "http://nope.com", api_key: api_key.key, api_username: "system"
+          json = JSON.parse(response.body)
+          expect(json["error_type"]).to eq("not_found")
+        end
+      end
+    end
+  end
+
   context "with a host" do
     let!(:embeddable_host) { Fabricate(:embeddable_host) }
 

--- a/spec/fabricators/topic_embed_fabricator.rb
+++ b/spec/fabricators/topic_embed_fabricator.rb
@@ -1,0 +1,4 @@
+Fabricator(:topic_embed) do
+  post
+  topic {|te| te[:post].topic }
+end


### PR DESCRIPTION
`TopicEmbed` requires a unique `embed_url`, however there is no API endpoint for fetching information about a url that may already exist in the system.

This means that plugins like the wordpress discourse plugin can fail if the plugin has sent information to discourse successfully but for some reason hasn't updated their own system. This can make them get into a continuous loop of sending data to discourse and getting back unhelpful error messages and never knowing what topic their url has been created and associated with.

This new `#info` endpoint will allow these plugins to initially query if their url is already in the system and get back information. Then if nothing is returned, they know they can safely request a new URL to be added.