### PR TITLE
FIX: remove 'left: auto' for slide-in menu (required for RTL layouts)

### DIFF
--- a/app/assets/javascripts/discourse/components/menu-panel.js.es6
+++ b/app/assets/javascripts/discourse/components/menu-panel.js.es6
@@ -54,7 +54,7 @@ export default Ember.Component.extend({
       }
 
       $panelBody.height('100%');
-      this.$().css({ left: "auto", top: (menuTop) + "px", height });
+      this.$().css({ top: menuTop + "px", height });
       $('body').removeClass('drop-down-visible');
     }
 


### PR DESCRIPTION
Sorry, I left this out of the previous PR. It has no effect on LTR layouts, but is required for RTL layouts to work.