### PR TITLE
FIX: Fallbacks for missing interpolation arguments

### DIFF
--- a/config/initializers/i18n.rb
+++ b/config/initializers/i18n.rb
@@ -28,8 +28,10 @@ class NoFallbackLocaleList < FallbackLocaleList
   end
 end
 
-if Rails.env.production?
-  I18n.fallbacks = FallbackLocaleList.new
-else
+
+if Rails.env.development?
   I18n.fallbacks = NoFallbackLocaleList.new
+else
+  I18n.fallbacks = FallbackLocaleList.new
+  I18n.config.missing_interpolation_argument_handler = proc { throw(:exception) }
 end


### PR DESCRIPTION
This takes effect when an interpolation is removed from a translation in
a Discourse update.

How this works:

The I18n::Backend::Fallbacks loops with a catch(:exception), so calling throw(:exception) will cause it to use the next locale, until it reaches English which is assumed to be correct.

```
        I18n.fallbacks[locale].each do |fallback|
          begin
            catch(:exception) do
              result = super(fallback, key, options)
              return result unless result.nil?
            end
          rescue I18n::InvalidLocale
            # we do nothing when the locale is invalid, as this is a fallback anyways.
          end
        end
```

Also, enable fallbacks in everything except development (#3724 for more discussion) - we should be able to test the fallbacks.
