### PR TITLE
FIX: eliminate horizontal scrolling on category page for mobile

### DIFF
--- a/app/assets/stylesheets/mobile/topic-list.scss
+++ b/app/assets/stylesheets/mobile/topic-list.scss
@@ -110,6 +110,29 @@
 
 // Category list
 // --------------------------------------------------
+.categories-list .list-container {
+  margin-left: -10px; // Extend past the .wrap padding to the edge of the window
+}
+
+.category-list-item.category {
+  // Allow percentage widths on table cells to include their padding
+  box-sizing: border-box;
+  *, *:before, *:after {
+    box-sizing: inherit;
+  }
+
+  .main-link {
+    width: 80%;
+  }
+
+  .posts {
+    width: 10%;
+  }
+
+  .age {
+    width: 10%;
+  }
+}
 
 tr.category-topic-link {
   border-top: darken($secondary, 3%) 1px solid;


### PR DESCRIPTION
Sets percentage widths on .category-list-item table cells. Moves the category borders to the edge of the screen:

![screenshot 2015-09-11 11 45 22](https://cloud.githubusercontent.com/assets/2975917/9823665/8f4191c8-587c-11e5-981f-5cef8d3314b6.png)
