### PR TITLE
Email in the admin menu should be in the plural form

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2100,7 +2100,7 @@ en:
 
 
       email:
-        title: "Email"
+        title: "Emails"
         settings: "Settings"
         all: "All"
         sending_test: "Sending test Email..."


### PR DESCRIPTION
The view shows dozens or hundreds emails.

Email -> Emails