### PR TITLE
Fix bug when adding new custom group

### DIFF
--- a/app/assets/javascripts/admin/controllers/admin-group.js.es6
+++ b/app/assets/javascripts/admin/controllers/admin-group.js.es6
@@ -75,13 +75,14 @@ export default Ember.Controller.extend({
 
     save() {
       const group = this.get('model'),
-            groupsController = this.get("controllers.adminGroupsType");
+            groupsController = this.get("controllers.adminGroupsType"),
+            groupType = groupsController.get("type");
 
       this.set('disableSave', true);
 
       let promise = group.get("id") ? group.save() : group.create().then(() => groupsController.addObject(group));
 
-      promise.then(() => this.transitionToRoute("adminGroup", group))
+      promise.then(() => this.transitionToRoute("adminGroup", groupType, group.get('name')))
              .catch(popupAjaxError)
              .finally(() => this.set('disableSave', false));
     },
@@ -90,6 +91,11 @@ export default Ember.Controller.extend({
       const group = this.get('model'),
             groupsController = this.get('controllers.adminGroupsType'),
             self = this;
+
+      if (!group.get('id')) {
+        self.transitionToRoute('adminGroupsType.index', 'custom');
+        return;
+      }
 
       this.set('disableSave', true);
 

--- a/app/assets/javascripts/admin/routes/admin-group.js.es6
+++ b/app/assets/javascripts/admin/routes/admin-group.js.es6
@@ -1,8 +1,17 @@
+import Group from 'discourse/models/group';
+
 export default Discourse.Route.extend({
 
   model: function(params) {
-    var groups = this.modelFor('adminGroupsType'),
-        group = groups.findProperty('name', params.name);
+    var groups = this.modelFor('adminGroupsType');
+    if (params.name === 'new') {
+      return Group.create({
+        automatic: false,
+        visible: true
+      });
+    }
+
+    var group = groups.findProperty('name', params.name);
 
     if (!group) { return this.transitionTo('adminGroups.index'); }
 

--- a/app/assets/javascripts/admin/routes/admin-groups-type.js.es6
+++ b/app/assets/javascripts/admin/routes/admin-groups-type.js.es6
@@ -9,15 +9,5 @@ export default Discourse.Route.extend({
   setupController(controller, model){
     controller.set("type", this.get("type"));
     controller.set("model", model);
-  },
-
-  actions: {
-    newGroup() {
-      const self = this;
-      this.transitionTo("adminGroupsType", "custom").then(function() {
-        var group = Discourse.Group.create({ automatic: false, visible: true });
-        self.transitionTo("adminGroup", group);
-      });
-    }
   }
 });

--- a/app/assets/javascripts/admin/templates/groups_type.hbs
+++ b/app/assets/javascripts/admin/templates/groups_type.hbs
@@ -9,7 +9,9 @@
       {{/each}}
     </ul>
     <div class='controls'>
-      {{d-button action="newGroup" icon="plus" label="admin.groups.new"}}
+      {{#link-to 'adminGroup' 'new' class="btn"}}
+        {{fa-icon "plus"}} {{i18n 'admin.groups.new'}}
+      {{/link-to}}
       {{#if controller.isAuto}}
       {{d-button action="refreshAutoGroups" icon="refresh" label="admin.groups.refresh" disabled=refreshingAutoGroups}}
       {{/if}}


### PR DESCRIPTION
When adding a new group, if Delete was clicked before saving the
group, the modal would come up, but the Yes confirmation would
do nothing. This fixes that by taking an approach similar to the
Badges and checks to see if the Group is new, and if it is, just
returns to the index instead of invoking the confirm modal.

This also fixes the redirect after saving a new Group.

This was reported at https://meta.discourse.org/t/another-very-minor-admin-bug-when-creating-a-new-group/32734