### PR TITLE
FIX: remove incorrect comment and rule from menu-panel.scss

### DIFF
--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -1,8 +1,6 @@
 .menu-panel.slide-in {
   position: fixed;
-  // positions are relative to the .d-header .panel div
   right: 0;
-  top: 0;
 
   .panel-body {
     position: absolute;


### PR DESCRIPTION
I had added an incorrect comment to menu-panel.scss.  This PR removes it. It also removes the rule `.menu-panel.slide-in { top: 0; }` It is incorrect. It is also never used, as the slide-in menu is positioned with inline styles that are added with javascript.