### PR TITLE
FIX: Load fallback locales in Sidekiq jobs

### DIFF
--- a/app/jobs/base.rb
+++ b/app/jobs/base.rb
@@ -149,6 +149,7 @@ module Jobs
             begin
               RailsMultisite::ConnectionManagement.establish_connection(db: db)
               I18n.locale = SiteSetting.default_locale
+              I18n.fallbacks.ensure_loaded!
               begin
                 execute(opts)
               rescue => e


### PR DESCRIPTION
Not sure if this is the right place for fixing this, but it seems to work...
https://meta.discourse.org/t/sidekiq-sending-email-digests-fails-missingtranslationdata/32500/8