### PR TITLE
Fix bug where create topic is suggested when insufficient permissions

### DIFF
--- a/app/assets/javascripts/discourse/routes/build-category-route.js.es6
+++ b/app/assets/javascripts/discourse/routes/build-category-route.js.es6
@@ -63,9 +63,15 @@ export default (filter, params) => {
 
     setupController(controller, model) {
       const topics = this.get('topics'),
-            periodId = topics.get('for_period') || (filter.indexOf('/') > 0 ? filter.split('/')[1] : '');
+            periodId = topics.get('for_period') || (filter.indexOf('/') > 0 ? filter.split('/')[1] : ''),
+            canCreateTopic = topics.get('can_create_topic'),
+            canCreateTopicOnCategory = model.get('permission') === Discourse.PermissionType.FULL;
 
-      this.controllerFor('navigation/category').set('canCreateTopic', topics.get('can_create_topic'));
+      this.controllerFor('navigation/category').setProperties({
+        canCreateTopicOnCategory: canCreateTopicOnCategory,
+        cannotCreateTopicOnCategory: !canCreateTopicOnCategory,
+        canCreateTopic: canCreateTopic
+      });
       this.controllerFor('discovery/topics').setProperties({
         model: topics,
         category: model,
@@ -74,7 +80,9 @@ export default (filter, params) => {
         noSubcategories: params && !!params.no_subcategories,
         order: topics.get('params.order'),
         ascending: topics.get('params.ascending'),
-        expandAllPinned: true
+        expandAllPinned: true,
+        canCreateTopic: canCreateTopic,
+        canCreateTopicOnCategory: canCreateTopicOnCategory
       });
 
       this.searchService.set('searchContext', model.get('searchContext'));

--- a/app/assets/javascripts/discourse/templates/discovery/topics.hbs
+++ b/app/assets/javascripts/discourse/templates/discovery/topics.hbs
@@ -67,7 +67,7 @@
       </div>
       <h3>
         {{footerMessage}}
-        {{#if model.can_create_topic}}<a href {{action "createTopic"}}>{{i18n 'topic.suggest_create_topic'}}</a>{{/if}}
+        {{#if canCreateTopicOnCategory}}<a href {{action "createTopic"}}>{{i18n 'topic.suggest_create_topic'}}</a>{{/if}}
       </h3>
     {{else}}
       {{#if top}}

--- a/app/assets/javascripts/discourse/templates/navigation/category.hbs
+++ b/app/assets/javascripts/discourse/templates/navigation/category.hbs
@@ -11,7 +11,12 @@
 {{/if}}
 
 {{#if canCreateTopic}}
-  {{d-button id="create-topic" class="btn-default" action="createTopic" icon="plus" label="topic.create"}}
+  {{d-button  id="create-topic"
+              class="btn-default"
+              action="createTopic"
+              icon="plus"
+              label="topic.create"
+              disabled=cannotCreateTopicOnCategory}}
 {{/if}}
 
 {{#if canEditCategory}}


### PR DESCRIPTION
When a user is viewing a category they do not have permission to create
a topic in, they are still prompted to create a topic if they are at the
bottom of the topics. This fixes the issue, as well as disabling the
New Topic button if they don't have permission to create a topic for
that category.

![screenshot from 2015-09-18 19 32 55](https://cloud.githubusercontent.com/assets/1613599/9973150/21f1b24a-5e3c-11e5-9bd0-8c191ad7e458.png)

This is related to the ux issue [here](https://meta.discourse.org/t/creating-a-topic-where-permission-does-not-exist-assumes-uncategorised/18801) and a bug filed [here](https://meta.discourse.org/t/why-not-create-a-topic-in-category-without-topic-creating-permissions/31611)