### PR TITLE
FIX: Slugs for badges

### DIFF
--- a/app/assets/javascripts/discourse/routes/badges-show.js.es6
+++ b/app/assets/javascripts/discourse/routes/badges-show.js.es6
@@ -12,7 +12,7 @@ export default Discourse.Route.extend({
   serialize(model) {
     return {
       id: model.get("id"),
-      slug: model.get("name").replace(/[^A-Za-z0-9_]+/g, "-").toLowerCase()
+      slug: model.get("slug")
     };
   },
 

--- a/app/serializers/badge_serializer.rb
+++ b/app/serializers/badge_serializer.rb
@@ -1,7 +1,7 @@
 class BadgeSerializer < ApplicationSerializer
   attributes :id, :name, :description, :grant_count, :allow_title,
              :multiple_grant, :icon, :image, :listable, :enabled, :badge_grouping_id,
-             :system, :long_description
+             :system, :long_description, :slug
 
   has_one :badge_type
 
@@ -17,12 +17,27 @@ class BadgeSerializer < ApplicationSerializer
     if object.long_description.present?
       object.long_description
     else
-      key = "badges.long_descriptions.#{object.name.downcase.gsub(" ", "_")}"
+      key = "badges.long_descriptions.#{i18n_name}"
       if I18n.exists?(key)
         I18n.t(key)
       else
         ""
       end
     end
+  end
+
+  def slug
+    Slug.for(display_name, '')
+  end
+
+  private
+
+  def i18n_name
+    object.name.downcase.gsub(' ', '_')
+  end
+
+  def display_name
+    key = "admin_js.badges.badge.#{i18n_name}.name"
+    I18n.t(key, default: object.name)
   end
 end


### PR DESCRIPTION
FIX: Use translated badge names for slugs
FIX: Use configured slug generater method for badges

https://meta.discourse.org/t/german-umlauts-are-not-handled-correct-for-badges/31675