### PR TITLE
FIX: I18n.exists? should use locale fallbacks

### DIFF
--- a/lib/freedom_patches/i18n_fallbacks.rb
+++ b/lib/freedom_patches/i18n_fallbacks.rb
@@ -1,0 +1,17 @@
+module I18n
+  module Backend
+    module Fallbacks
+      def exists?(locale, key)
+        I18n.fallbacks[locale].each do |fallback|
+          begin
+            return true if super(fallback, key)
+          rescue I18n::InvalidLocale
+            # we do nothing when the locale is invalid, as this is a fallback anyways.
+          end
+        end
+
+        false
+      end
+    end
+  end
+end


### PR DESCRIPTION
`I18n.exists?` ignored the locale fallbacks.
https://meta.discourse.org/t/search-help-doesnt-work-for-some-locales/31350

I'll try to get this into [Ruby I18n](https://github.com/svenfuchs/i18n)...

BTW: The `NoFallbackLocaleList` is really annoying during development (#3724). :frowning: 