### PR TITLE
FEATURE: Add web manifest for Chrome users.

### DIFF
--- a/app/controllers/manifest_json_controller.rb
+++ b/app/controllers/manifest_json_controller.rb
@@ -1,0 +1,15 @@
+class ManifestJsonController < ApplicationController
+  layout false
+  skip_before_filter :preload_json, :check_xhr
+
+  def index
+    manifest = {
+      short_name: SiteSetting.title,
+      display: 'browser',
+      orientation: 'portrait',
+      start_url: "#{Discourse.base_uri}/"
+    }
+
+    render json: manifest.to_json
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,6 +31,7 @@
     <%- end %>
 
     <%= render_google_universal_analytics_code %>
+    <link rel="manifest" href="<%= Discourse.base_uri %>/manifest.json">
 
     <%= yield :head %>
   </head>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -533,6 +533,7 @@ Discourse::Application.routes.draw do
   get "favicon/proxied" => "static#favicon", format: false
 
   get "robots.txt" => "robots_txt#index"
+  get "manifest.json" => "manifest_json#index", as: :manifest
 
   Discourse.filters.each do |filter|
     root to: "list##{filter}", constraints: HomePageConstraint.new("#{filter}"), :as => "list_#{filter}"

--- a/spec/controllers/manifest_json_controller_spec.rb
+++ b/spec/controllers/manifest_json_controller_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+RSpec.describe ManifestJsonController do
+  context 'index' do
+    it 'returns the right output' do
+      title = 'MyApp'
+      SiteSetting.title = title
+      get :index
+      expect(response.body).to include(title)
+    end
+  end
+end


### PR DESCRIPTION
This is the bare minimum we need for the manifest file and act as the ground work for further features like ServiceWorkers and app install banners in chrome.