### PR TITLE
FIX: relatively position slide-in menu as a work around for ios scrolling behaviour

### DIFF
--- a/app/assets/javascripts/discourse/components/menu-panel.js.es6
+++ b/app/assets/javascripts/discourse/components/menu-panel.js.es6
@@ -15,6 +15,7 @@ export default Ember.Component.extend({
     const $window = $(window);
     let width = this.get('maxWidth') || 300;
     const windowWidth = parseInt($window.width());
+    const $menuControls = $('.d-header .panel');
 
     if ((windowWidth - width) < 50) {
       width = windowWidth - 50;
@@ -28,9 +29,10 @@ export default Ember.Component.extend({
       const $buttonPanel = $('header ul.icons');
       if ($buttonPanel.length === 0) { return; }
 
-      // These values need to be set here, not in the css file - this is to deal with the
-      // possibility of the window being resized and the menu changing from .slide-in to .drop-down.
-      this.$().css({ top: '100%', height: 'auto' });
+      // The menu will be positioned relative to the menu controls
+      $menuControls.addClass('relative-anchor');
+
+      this.$().css({ height: 'auto' });
 
       // adjust panel height
       const fullHeight = parseInt($window.height());
@@ -54,7 +56,10 @@ export default Ember.Component.extend({
       }
 
       $panelBody.height('100%');
-      this.$().css({ top: menuTop + "px", height });
+
+      // Positioning is relative to `.d-header .wrap` (the bottom of the header).
+      $menuControls.removeClass('relative-anchor');
+      this.$().css({ height });
       $('body').removeClass('drop-down-visible');
     }
 

--- a/app/assets/stylesheets/common/base/header.scss
+++ b/app/assets/stylesheets/common/base/header.scss
@@ -11,8 +11,15 @@
       backface-visibility: hidden;  /** do magic for scrolling performance **/
     }
 
+    .wrap {
+      // used for positioning .menu-panel.slide-in
+      position: relative;
+      height: 100%;
+    }
+
     .contents {
       margin: 8px 0;
+      position: static;
     }
 
     .title {
@@ -35,6 +42,11 @@
 
     .panel {
       float: right;
+      position: static;
+    }
+
+    // used for positioning .menu-panel.drop-down
+    .panel.relative-anchor {
       position: relative;
     }
 

--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -1,6 +1,8 @@
 .menu-panel.slide-in {
-  position: fixed;
+  position: absolute;
+  // Positioned relative to .d-header .wrap
   right: 0;
+  top: 100%;
 
   .panel-body {
     position: absolute;


### PR DESCRIPTION
ios devices have a built in 'elastic scrolling' feature. This allows for scrolling past the top and bottom of the webpage. It's causing some weird behaviour with the slide-in menu. When expanded, it's remaining fixed in position while the elements around it may be changing their position (see: https://meta.discourse.org/t/elastic-scrolling-on-ipad-causes-header-to-unstick-from-top-of-window/33481). The problem is worse when there is a custom header added to the page. 

![fixed-position-menu](https://cloud.githubusercontent.com/assets/2975917/9984877/609641c4-5fd5-11e5-8d61-317447e40654.gif)

This is a possible fix. It positions  `.menu-panel.slide-in` relative the the `.d-header.wrap` so that the header and the menu can't become separated from each other. The only risk that I can see from making this change is that it removes `position: relative` from `.d-header .contents` and adds it instead to `.d-header .wrap`. I've looked quite closely at it and it seems fine.


This isn't directly related to the PR but, in `menu-panel.scss` there is this rule for `.panel-body`:
```css
  .panel-body {
    position: absolute;
    top: 3px;
    bottom: 37px;
    width: 97%;
  }
```
I don't think that is required for anything. When there is a scrollbar on the slide-in menu it is causing .panel-body to override the padding that has been set on the slide-in menu.