### PR TITLE
FEATURE: Make it easy to override the home logo

### DIFF
--- a/app/assets/javascripts/discourse/components/home-logo.js.es6
+++ b/app/assets/javascripts/discourse/components/home-logo.js.es6
@@ -4,9 +4,14 @@ import { setting } from 'discourse/lib/computed';
 export default Ember.Component.extend({
   classNames: ["title"],
 
-  linkUrl: function() {
-    return Discourse.getURL('/');
+  targetUrl: function() {
+    // For overriding by customizations
+    return '/';
   }.property(),
+
+  linkUrl: function() {
+    return Discourse.getURL(this.get('targetUrl'));
+  }.property('targetUrl'),
 
   showSmallLogo: function() {
     return !Discourse.Mobile.mobileView && this.get("minimized");
@@ -27,7 +32,7 @@ export default Ember.Component.extend({
 
     e.preventDefault();
 
-    DiscourseURL.routeTo('/');
+    DiscourseURL.routeTo(this.get('targetUrl'));
     return false;
   }
 });


### PR DESCRIPTION
https://meta.discourse.org/t/redirect-for-non-logged-in-users/33500/4

Usage example:

```
Discourse.SiteSettings.top_menu = 'categories|latest|top';
  var HomeLogoComponent = require('discourse/components/home-logo').default;
  HomeLogoComponent.reopen({
   targetUrl: function() {
       return '/latest';
   }.property(),   
  });
```