### PR TITLE
[WIP] Hide 'boring' PMs in their own tab

### DIFF
--- a/app/assets/javascripts/discourse/controllers/user.js.es6
+++ b/app/assets/javascripts/discourse/controllers/user.js.es6
@@ -1,6 +1,7 @@
 import { exportUserArchive } from 'discourse/lib/export-csv';
 import CanCheckEmails from 'discourse/mixins/can-check-emails';
 import computed from 'ember-addons/ember-computed-decorators';
+import { propertyNotEqual } from 'discourse/lib/computed';
 
 export default Ember.Controller.extend(CanCheckEmails, {
   indexStream: false,
@@ -58,9 +59,17 @@ export default Ember.Controller.extend(CanCheckEmails, {
     }
   }.property('model.user_fields.@each.value'),
 
-  privateMessagesActive: Em.computed.equal('pmView', 'index'),
+  privateMessagesInboxActive: Em.computed.equal('pmView', 'inbox'),
+  privateMessagesAllActive: Em.computed.equal('pmView', 'all'),
+  privateMessagesBoringActive: Em.computed.equal('pmView', 'boring'),
   privateMessagesMineActive: Em.computed.equal('pmView', 'mine'),
   privateMessagesUnreadActive: Em.computed.equal('pmView', 'unread'),
+
+  pmShowAll: propertyNotEqual('model.private_messages_stats.inbox', 'model.private_messages_stats.all'),
+  @computed('model.private_messages_stats.boring')
+  pmShowBoring(boringCount) {
+    return boringCount > 0;
+  },
 
   actions: {
     expandProfile: function() {

--- a/app/assets/javascripts/discourse/routes/app-route-map.js.es6
+++ b/app/assets/javascripts/discourse/routes/app-route-map.js.es6
@@ -68,8 +68,10 @@ export default function() {
     this.route('deletedPosts', { path: '/deleted-posts' });
 
     this.resource('userPrivateMessages', { path: '/messages' }, function() {
+      this.route('all');
       this.route('mine');
       this.route('unread');
+      this.route('boring');
     });
 
     this.resource('preferences', function() {

--- a/app/assets/javascripts/discourse/routes/user-private-messages-all.js.es6
+++ b/app/assets/javascripts/discourse/routes/user-private-messages-all.js.es6
@@ -1,3 +1,3 @@
 import createPMRoute from "discourse/routes/build-user-topic-list-route";
 
-export default createPMRoute('inbox', 'private-messages-inbox');
+export default createPMRoute('all', 'private-messages-all');

--- a/app/assets/javascripts/discourse/routes/user-private-messages-boring.js.es6
+++ b/app/assets/javascripts/discourse/routes/user-private-messages-boring.js.es6
@@ -1,3 +1,3 @@
 import createPMRoute from "discourse/routes/build-user-topic-list-route";
 
-export default createPMRoute('inbox', 'private-messages-inbox');
+export default createPMRoute('boring', 'private-messages-boring');

--- a/app/assets/javascripts/discourse/templates/user/user.hbs
+++ b/app/assets/javascripts/discourse/templates/user/user.hbs
@@ -178,12 +178,20 @@
       {{#if canSeePrivateMessages}}
         <h3>{{fa-icon "envelope"}} {{i18n 'user.private_messages'}}</h3>
         <ul class='action-list nav-stacked'>
-          <li {{bind-attr class=":noGlyph privateMessagesActive:active"}}>
+          <li {{bind-attr class=":noGlyph privateMessagesInboxActive:active"}}>
             {{#link-to 'userPrivateMessages.index' model}}
-              {{i18n 'user.messages.all'}}
-              {{#if model.hasPMs}}<span class='count'>({{model.private_messages_stats.all}})</span>{{/if}}
+              {{i18n 'user.messages.inbox'}}
+              {{#if model.hasPMs}}<span class='count'>({{model.private_messages_stats.inbox}})</span>{{/if}}
             {{/link-to}}
           </li>
+          {{#if pmShowAll}}
+            <li {{bind-attr class=":noGlyph privateMessagesAllActive:active"}}>
+              {{#link-to 'userPrivateMessages.all' model}}
+                {{i18n 'user.messages.all'}}
+                {{#if model.hasPMs}}<span class='count'>({{model.private_messages_stats.all}})</span>{{/if}}
+              {{/link-to}}
+            </li>
+          {{/if}}
           <li {{bind-attr class=":noGlyph privateMessagesMineActive:active"}}>
             {{#link-to 'userPrivateMessages.mine' model}}
               {{i18n 'user.messages.mine'}}
@@ -196,6 +204,14 @@
               {{#if model.hasUnreadPMs}}<span class='badge-notification unread-private-messages'>{{model.private_messages_stats.unread}}</span>{{/if}}
             {{/link-to}}
           </li>
+          {{#if pmShowBoring}}
+            <li {{bind-attr class=":noGlyph privateMessagesBoringActive:active"}}>
+              {{#link-to 'userPrivateMessages.boring' model}}
+                {{i18n 'user.messages.boring'}}
+                {{#if model.hasPMs}}<span class='count'>({{model.private_messages_stats.boring}})</span>{{/if}}
+              {{/link-to}}
+            </li>
+          {{/if}}
         </ul>
       {{/if}}
 

--- a/app/controllers/list_controller.rb
+++ b/app/controllers/list_controller.rb
@@ -102,7 +102,7 @@ class ListController < ApplicationController
     end
   end
 
-  [:topics_by, :private_messages, :private_messages_sent, :private_messages_unread].each do |action|
+  [:topics_by, :private_messages_all, :private_messages_inbox, :private_messages_boring, :private_messages_sent, :private_messages_unread].each do |action|
     define_method("#{action}") do
       list_opts = build_topic_list_options
       target_user = fetch_user_from_params

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -480,8 +480,10 @@ en:
 
       messages:
         all: "All"
+        inbox: "Inbox"
         mine: "Mine"
         unread: "Unread"
+        boring: "Boring"
 
       change_password:
         success: "(email sent)"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -435,7 +435,10 @@ Discourse::Application.routes.draw do
 
   get "topics/feature_stats"
   get "topics/created-by/:username" => "list#topics_by", as: "topics_by", constraints: {username: USERNAME_ROUTE_FORMAT}
-  get "topics/private-messages/:username" => "list#private_messages", as: "topics_private_messages", constraints: {username: USERNAME_ROUTE_FORMAT}
+  get "topics/private-messages/:username" => "list#private_messages_all", as: "topics_private_messages_legacy", constraints: {username: USERNAME_ROUTE_FORMAT} # legacy
+  get "topics/private-messages-all/:username" => "list#private_messages_all", as: "topics_private_messages_all", constraints: {username: USERNAME_ROUTE_FORMAT}
+  get "topics/private-messages-inbox/:username" => "list#private_messages_inbox", as: "topics_private_messages_inbox", constraints: {username: USERNAME_ROUTE_FORMAT}
+  get "topics/private-messages-boring/:username" => "list#private_messages_boring", as: "topics_private_messages_boring", constraints: {username: USERNAME_ROUTE_FORMAT}
   get "topics/private-messages-sent/:username" => "list#private_messages_sent", as: "topics_private_messages_sent", constraints: {username: USERNAME_ROUTE_FORMAT}
   get "topics/private-messages-unread/:username" => "list#private_messages_unread", as: "topics_private_messages_unread", constraints: {username: USERNAME_ROUTE_FORMAT}
 

--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -112,14 +112,27 @@ class TopicQuery
     end
   end
 
-  def list_private_messages(user)
+  # Keep these in sync with UserAction#private_messages_stats
+  def list_private_messages_all(user)
     list = private_messages_for(user)
+    create_list(:private_messages, {}, list)
+  end
+
+  def list_private_messages_inbox(user)
+    list = private_messages_for(user)
+    list = list.where("topics.id NOT IN (#{TopicQuerySQL.boring_qualifications_query(user)})")
     create_list(:private_messages, {}, list)
   end
 
   def list_private_messages_sent(user)
     list = private_messages_for(user)
     list = list.where(user_id: user.id)
+    create_list(:private_messages, {}, list)
+  end
+
+  def list_private_messages_boring(user)
+    list = private_messages_for(user)
+    list = list.where("topics.id IN (#{TopicQuerySQL.boring_qualifications_query(user)})")
     create_list(:private_messages, {}, list)
   end
 


### PR DESCRIPTION
The conditions for a PM to be "boring" are:

 - Messages from the site contact user are only boring to the sender until there's a reply
 - Flag -> notify moderators is always boring unless there's a non-auto-inserted reply
 - Flag -> notify user is only boring to the sender until there's a reply

The implementation needs to change - we can't have this monster SQL firing off all the time.

Proposed implementation: A column on the topic holding the 'boringness'.

0 - not boring to anyone, 1 - boring to topic creator, 2 - boring to all participants.
When a topic is created, the boringness is 0 unless specified otherwise in the PostCreator options.
Whenever a reply is made to a topic, unless the reply is an auto-inserted reply from resolving a Notify Moderators flag, the boringness is set to 0.

Messages from the site contact user, and Flag -> Notify User are boring 1.
Flag -> Notify Moderators are boring 2.

We can adapt the queries present in this WIP version of the patch to backfill the boringness for all topics in a migration.

Then, the list queries would just be `.where("topics.boringness = 0 OR (topics.boringness = 1 AND topics.user_id = :user_id)")` and `.where("topics.boringness = 2 OR (topics.boringness = 1 AND topics.user_id <> :user_id)")`.

WIP, on hold. If you want to take up this feature, notify me (leave a comment on the PR?)