### PR TITLE
FIX: keep topic admin icon from overlapping drop-down menu

### DIFF
--- a/app/assets/stylesheets/common/base/topic-admin-menu.scss
+++ b/app/assets/stylesheets/common/base/topic-admin-menu.scss
@@ -4,7 +4,7 @@
   position: fixed;
   top: 120px;
   right: 10px;
-  z-index: 1000;
+  z-index: 999;
   outline: 0;
 }
 


### PR DESCRIPTION
The drop-down menu inherits a z-index of 1000 from its parent's stacking context (the header). The admin wrench also has a z-index of 1000, but occurs later in the document so it appears on top of the menu. Reducing `.show-topic-admin` z-index to 999 allows the drop-down menu to appear overtop of the wrench.

I'm not sure that `.show-topic-admin` needs a z-index set on it at all.