### PR TITLE
FIX: Don't subscribe to Desktop Notifications on mobile.

### DIFF
--- a/app/assets/javascripts/discourse/initializers/subscribe-user-notifications.js.es6
+++ b/app/assets/javascripts/discourse/initializers/subscribe-user-notifications.js.es6
@@ -29,10 +29,6 @@ export default {
         });
       }
 
-      bus.subscribe("/notification-alert/" + user.get('id'), function(data){
-        onNotification(data, user);
-      });
-
       bus.subscribe("/notification/" + user.get('id'), function(data) {
         const oldUnread = user.get('unread_notifications');
         const oldPM = user.get('unread_private_messages');
@@ -85,7 +81,13 @@ export default {
       });
 
       if (!Ember.testing) {
-        initDesktopNotifications(bus);
+        if (!Discourse.Mobile.mobileView) {
+          bus.subscribe("/notification-alert/" + user.get('id'), function(data){
+            onNotification(data, user);
+          });
+
+          initDesktopNotifications(bus);
+        }
       }
     }
   }


### PR DESCRIPTION
On mobile, we're getting the follow error for trying to construct a `Notification` since it isn't supported on Android. On top of that, the `Notification` API is meant for Desktop notifications so we can avoid setting it up and subscribing to it on Mobile. 

```
Uncaught TypeError: Failed to construct ‘Notification’: Illegal constructor. Use ServiceWorkerRegistration.showNotification() instead
```

Related issue: https://code.google.com/p/chromium/issues/detail?id=481856

There was a suggestion to check for the error in the issue but it didn't make sense to me because it assumes that the permission has not been requested before. 