### PR TITLE
FIX: Use translated badge name and slug within notifications

### DIFF
--- a/app/assets/javascripts/discourse/components/notification-item.js.es6
+++ b/app/assets/javascripts/discourse/components/notification-item.js.es6
@@ -22,8 +22,14 @@ export default Ember.Component.extend({
     const it = this.get('notification');
     const badgeId = it.get("data.badge_id");
     if (badgeId) {
-      const badgeName = it.get("data.badge_name");
-      return Discourse.getURL('/badges/' + badgeId + '/' + badgeName.replace(/[^A-Za-z0-9_]+/g, '-').toLowerCase());
+      var badgeSlug = it.get("data.badge_slug");
+
+      if (!badgeSlug) {
+        const badgeName = it.get("data.badge_name");
+        badgeSlug = badgeName.replace(/[^A-Za-z0-9_]+/g, '-').toLowerCase();
+      }
+
+      return Discourse.getURL('/badges/' + badgeId + '/' + badgeSlug);
     }
 
     const topicId = it.get('topic_id');

--- a/app/models/badge.rb
+++ b/app/models/badge.rb
@@ -329,11 +329,37 @@ SQL
     Badge.find_each(&:reset_grant_count!)
   end
 
+  def display_name
+    if self.system?
+      key = "admin_js.badges.badge.#{i18n_name}.name"
+      I18n.t(key, default: self.name)
+    else
+      self.name
+    end
+  end
+
+  def long_description
+    if self[:long_description].present?
+      self[:long_description]
+    else
+      key = "badges.long_descriptions.#{i18n_name}"
+      I18n.t(key, default: '')
+    end
+  end
+
+  def slug
+    Slug.for(self.display_name, '-')
+  end
+
   protected
   def ensure_not_system
     unless id
       self.id = [Badge.maximum(:id) + 1, 100].max
     end
+  end
+
+  def i18n_name
+    self.name.downcase.gsub(' ', '_')
   end
 end
 

--- a/app/serializers/badge_serializer.rb
+++ b/app/serializers/badge_serializer.rb
@@ -12,32 +12,4 @@ class BadgeSerializer < ApplicationSerializer
   def include_long_description?
     options[:include_long_description]
   end
-
-  def long_description
-    if object.long_description.present?
-      object.long_description
-    else
-      key = "badges.long_descriptions.#{i18n_name}"
-      if I18n.exists?(key)
-        I18n.t(key)
-      else
-        ""
-      end
-    end
-  end
-
-  def slug
-    Slug.for(display_name, '')
-  end
-
-  private
-
-  def i18n_name
-    object.name.downcase.gsub(' ', '_')
-  end
-
-  def display_name
-    key = "admin_js.badges.badge.#{i18n_name}.name"
-    I18n.t(key, default: object.name)
-  end
 end

--- a/app/services/badge_granter.rb
+++ b/app/services/badge_granter.rb
@@ -41,10 +41,12 @@ class BadgeGranter
         end
 
         if SiteSetting.enable_badges?
-          notification = @user.notifications.create(
-                  notification_type: Notification.types[:granted_badge],
-                  data: { badge_id: @badge.id, badge_name: @badge.name }.to_json)
-          user_badge.update_attributes notification_id: notification.id
+          I18n.with_locale(@user.effective_locale) do
+            notification = @user.notifications.create(
+              notification_type: Notification.types[:granted_badge],
+              data: { badge_id: @badge.id, badge_name: @badge.display_name }.to_json)
+            user_badge.update_attributes notification_id: notification.id
+          end
         end
       end
     end

--- a/app/services/badge_granter.rb
+++ b/app/services/badge_granter.rb
@@ -44,7 +44,7 @@ class BadgeGranter
           I18n.with_locale(@user.effective_locale) do
             notification = @user.notifications.create(
               notification_type: Notification.types[:granted_badge],
-              data: { badge_id: @badge.id, badge_name: @badge.display_name }.to_json)
+              data: { badge_id: @badge.id, badge_name: @badge.display_name, badge_slug: @badge.slug }.to_json)
             user_badge.update_attributes notification_id: notification.id
           end
         end


### PR DESCRIPTION
I had to revert some of the changes made in https://github.com/discourse/discourse/pull/3791 and move the code from `BadgeSerializer` to `Badge` in order to reuse the `displayName` and `slug` for notifications.