### PR TITLE
UX: Fix links in gutter taking up full width.

### DIFF
--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -651,13 +651,13 @@ blockquote {
 
   .reply-new {
     padding-left: 27px;
-    display:block;
+    display: inline-block;
     overflow:hidden;
   }
 
   .track-link {
     padding-left: 10px;
-    display: block;
+    display: inline-block;
     overflow: hidden;
     }
 


### PR DESCRIPTION
Meta: https://meta.discourse.org/t/reply-as-linked-topic-clickable-link-target-is-double-the-length/33631