### PR TITLE
UX: Topic link should not take full width.

### DIFF
--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -520,7 +520,7 @@ video {
 
   .topic-link {
     color: $header_primary;
-    display: block;
+    display: inline-block;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;


### PR DESCRIPTION
Meta: https://meta.discourse.org/t/reply-as-linked-topic-clickable-link-target-is-double-the-length/33631/4