### PR TITLE
Revert "UX: Topic link should not take full width."

### DIFF
--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -520,7 +520,7 @@ video {
 
   .topic-link {
     color: $header_primary;
-    display: inline-block;
+    display: block;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;


### PR DESCRIPTION
Reverting it because it's causing issues with the category badge (cc @tgxworld)

![category badge issue](https://cloud.githubusercontent.com/assets/362783/10095520/b0e33950-636a-11e5-93d6-809bcf4a968c.png)
