### PR TITLE
save height on small screens

### DIFF
--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -1025,3 +1025,17 @@ and (max-width : 767px) {
   }
 
 }
+
+@media all
+and (max-height: 700px) {
+   .topic-body{
+      padding-bottom:0px;
+      margin-bottom:-15px;
+   }
+   .ember-view{
+     margin-bottom: 10px;
+   }
+   nav.post-controls{
+    margin-top: -18px;
+   }
+}


### PR DESCRIPTION
there is a lot of white space wetween each post, that annoys on small screens.

This will minimize the used space if the screen is lower than 700px in height