### PR TITLE
Proxy letter avatars by default

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -475,7 +475,7 @@ class User < ActiveRecord::Base
       url.gsub! "{color}", letter_avatar_color(username.downcase)
       url.gsub! "{username}", username
       url.gsub! "{first_letter}", username[0].downcase
-      url.gsub! "{hostname}", RailsMultisite::ConnectionManagement.current_hostname
+      url.gsub! "{hostname}", Discourse.current_hostname
       url
     else
       "#{Discourse.base_uri}/letter_avatar/#{username.downcase}/{size}/#{LetterAvatar.version}.png"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -475,6 +475,7 @@ class User < ActiveRecord::Base
       url.gsub! "{color}", letter_avatar_color(username.downcase)
       url.gsub! "{username}", username
       url.gsub! "{first_letter}", username[0].downcase
+      url.gsub! "{hostname}", RailsMultisite::ConnectionManagement.current_hostname
       url
     else
       "#{Discourse.base_uri}/letter_avatar/#{username.downcase}/{size}/#{LetterAvatar.version}.png"

--- a/config/nginx.sample.conf
+++ b/config/nginx.sample.conf
@@ -192,6 +192,11 @@ server {
       break;
     }
 
+    location /letter_avatar_proxy {
+      rewrite /letter_avatar_proxy/(.*)$ /$1 break;
+      proxy_pass https://avatars.discourse.org;
+    }
+
     # this means every file in public is tried first
     try_files $uri @discourse;
   }

--- a/config/nginx.sample.conf
+++ b/config/nginx.sample.conf
@@ -173,7 +173,7 @@ server {
     # This big block is needed so we can selectively enable
     # acceleration for backups and avatars
     # see note about repetition above
-    location ~ ^/(letter_avatar|user_avatar|highlight-js|stylesheets|favicon/proxied) {
+    location ~ ^/(letter_avatar/|user_avatar|highlight-js|stylesheets|favicon/proxied) {
       proxy_set_header Host $http_host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -192,9 +192,23 @@ server {
       break;
     }
 
-    location /letter_avatar_proxy {
-      rewrite /letter_avatar_proxy/(.*)$ /$1 break;
-      proxy_pass https://avatars.discourse.org;
+    location /letter_avatar_proxy/ {
+      # Don't send any client headers to the avatars service
+      proxy_method GET;
+      proxy_pass_request_headers off;
+      proxy_pass_request_body off;
+
+      # Don't let cookies interrupt caching, and don't pass them to the
+      # client
+      proxy_ignore_headers "Set-Cookie";
+      proxy_hide_header "Set-Cookie";
+
+      proxy_cache one;
+      proxy_cache_key $uri;
+      proxy_cache_valid 200 7d;
+      proxy_cache_valid 404 1m;
+
+      proxy_pass https://avatars.discourse.org/;
     }
 
     # this means every file in public is tried first

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -593,9 +593,9 @@ files:
     client: true
     shadowed_by_global: true
   external_system_avatars_url:
-    default: "https://avatars.discourse.org/v2/letter/{first_letter}/{color}/{size}.png"
+    default: "//{hostname}/letter_avatar_proxy/v2/letter/{first_letter}/{color}/{size}.png"
     client: true
-    regex: '^https?:\/\/.+[^\/]'
+    regex: '^((https?:)?\/)?\/.+[^\/]'
   default_opengraph_image_url: ''
 
 trust:

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -593,7 +593,7 @@ files:
     client: true
     shadowed_by_global: true
   external_system_avatars_url:
-    default: "//{hostname}/letter_avatar_proxy/v2/letter/{first_letter}/{color}/{size}.png"
+    default: "/letter_avatar_proxy/v2/letter/{first_letter}/{color}/{size}.png"
     client: true
     regex: '^((https?:)?\/)?\/.+[^\/]'
   default_opengraph_image_url: ''

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -912,7 +912,7 @@ describe User do
       expect(user.small_avatar_url).to eq("//test.localhost/letter_avatar/sam/45/#{LetterAvatar.version}.png")
 
       SiteSetting.external_system_avatars_enabled = true
-      expect(user.small_avatar_url).to eq("https://avatars.discourse.org/v2/letter/s/5f9b8f/45.png")
+      expect(user.small_avatar_url).to eq("//test.localhost/letter_avatar_proxy/v2/letter/s/5f9b8f/45.png")
     end
 
   end


### PR DESCRIPTION
On sites that don't otherwise configure an avatar fallback, Discourse will
now tell the client to get its letter avatars from a location which nginx
proxies to the centralised `avatars.discourse.org` service.  This alleviates
privacy concerns, whilst still providing some degree of performance benefit
(no need for every site to delay avatar response by 300ms for image
rendering).

It is still possible to gain the benefits of global image caching and the
lower latency of requesting directly from a CDN, by explicitly changing the
`external_system_avatars_url` site setting to
`https://avatars.discourse.org/letter/{first_letter}/{color}/{size}.png`.