### PR TITLE
FIX: SSO provider redirect now works if user is initially not logged in

### DIFF
--- a/app/assets/javascripts/discourse/controllers/login.js.es6
+++ b/app/assets/javascripts/discourse/controllers/login.js.es6
@@ -74,6 +74,13 @@ export default Ember.Controller.extend(ModalFunctionality, {
           }
         } else {
           self.set('loggedIn', true);
+
+          // Redirect to SSO provider callback URL
+          if (result.sso_provider) {
+            window.location.href = result.return_sso_url;
+            return;
+          }
+
           // Trigger the browser's password manager using the hidden static login form:
           const $hidden_login_form = $('#hidden-login-form');
           const destinationUrl = $.cookie('destination_url');


### PR DESCRIPTION
A fix for https://meta.discourse.org/t/discourse-sso-provider-login-unknown-error/28231

When logging in, we should not redirect to SSO callback URL but instead return it and then redirect using JavaScript. I'm not sure if this is the best fix. Open to suggestions and improvements.