### PR TITLE
FIX: typo in category-unread.hbs

### DIFF
--- a/app/assets/javascripts/discourse/templates/components/category-unread.hbs
+++ b/app/assets/javascripts/discourse/templates/components/category-unread.hbs
@@ -2,5 +2,5 @@
   <a href="{{unbound category.unreadUrl}}" class='badge new-posts badge-notification' title='{{i18n 'topic.unread_topics' count=category.unreadTopics}}'>{{i18n 'filters.unread.lower_title_with_count' count=category.unreadTopics}}</a>
 {{/if}}
 {{#if category.newTopics}}
-  <a href="{{unbound category.newUrl}}" class='badge new-posts badge-notification' title='{{i18n 'topic.new_topics' count=ctegory.newTopics}}'>{{i18n 'filters.new.lower_title_with_count' count=category.newTopics}}</a>
+  <a href="{{unbound category.newUrl}}" class='badge new-posts badge-notification' title='{{i18n 'topic.new_topics' count=category.newTopics}}'>{{i18n 'filters.new.lower_title_with_count' count=category.newTopics}}</a>
 {{/if}}


### PR DESCRIPTION
Typo in `category-unread.hbs` is causing category-unread.newTopics to return a title of [object][object]. This is what shows up in the tooltip.

![screenshot 2015-10-04 13 21 36](https://cloud.githubusercontent.com/assets/2975917/10270030/fdb2b63e-6a9a-11e5-8723-f9f3688ed548.png)
