### PR TITLE
UX: Remove the negative right margin from like count button

### DIFF
--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -73,7 +73,6 @@ nav.post-controls {
 
     .like-count {
       font-size: inherit;
-      margin-right: -5px;
     }
 
     padding: 0;


### PR DESCRIPTION
See https://meta.discourse.org/t/overlapping-5-likes-and-heart-icon-buttons/34246/1

Doesn't affect Mobile (I double checked)