### PR TITLE
FIX: Pressing Ctrl+F twice should show browser find

### DIFF
--- a/app/assets/javascripts/discourse/lib/keyboard-shortcuts.js.es6
+++ b/app/assets/javascripts/discourse/lib/keyboard-shortcuts.js.es6
@@ -3,7 +3,7 @@ import DiscourseURL from 'discourse/lib/url';
 const bindings = {
   '!':               {postAction: 'showFlags'},
   '#':               {handler: 'toggleProgress', anonymous: true},
-  '/':               {handler: 'showSearch', anonymous: true},
+  '/':               {handler: 'toggleSearch', anonymous: true},
   '=':               {handler: 'toggleHamburgerMenu', anonymous: true},
   '?':               {handler: 'showHelpModal', anonymous: true},
   '.':               {click: '.alert.alert-info.clickable', anonymous: true}, // show incoming/updated topics
@@ -142,6 +142,11 @@ export default {
   },
 
   showBuiltinSearch() {
+    if (this.container.lookup('controller:header').get('searchVisible')) {
+      this.toggleSearch();
+      return true;
+    }
+
     this.searchService.set('searchContextEnabled', false);
 
     const currentPath = this.container.lookup('controller:application').get('currentPath'),
@@ -157,7 +162,7 @@ export default {
 
     if (showSearch) {
       this.searchService.set('searchContextEnabled', true);
-      this.showSearch();
+      this.toggleSearch();
       return false;
     }
 
@@ -176,7 +181,7 @@ export default {
     this.container.lookup('controller:topic-progress').send('toggleExpansion', {highlight: true});
   },
 
-  showSearch() {
+  toggleSearch() {
     this.container.lookup('controller:header').send('toggleSearch');
     return false;
   },


### PR DESCRIPTION
https://meta.discourse.org/t/you-can-no-longer-press-ctrl-f-twice-to-use-native-find/34265