### PR TITLE
Clarify what happens when newuser_max_links is exceeded

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1035,7 +1035,7 @@ en:
 
     min_trust_to_edit_wiki_post: "The minimum trust level required to edit post marked as wiki."
 
-    newuser_max_links: "How many links a new user can add to a post."
+    newuser_max_links: "How many links a new user can add to a post before requiring approval."
     newuser_max_images: "How many images a new user can add to a post."
     newuser_max_attachments: "How many attachments a new user can add to a post."
     newuser_max_mentions_per_post: "Maximum number of @name notifications a new user can use in a post."


### PR DESCRIPTION
While reading the [TL0 post](https://meta.discourse.org/t/what-do-user-trust-levels-do/4924/3?u=dandv) it was unclear if exceeding the limits there will prevent the user from posting, or if the post will be sent to the approval queue.

I've tested posting more than `newuser_max_links` links from a new user and the post was sent to the approval queue.

Other values may benefit from the same clarification; especially the first one in the `Posting` settings page.