### PR TITLE
Disable byebug when RubyMine is used for debugging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -121,7 +121,7 @@ group :test, :development do
   gem 'rspec-given'
   gem 'pry-nav'
   gem 'spork-rails'
-  gem 'byebug'
+  gem 'byebug', require: ENV['RM_INFO'].nil?
 end
 
 group :development do


### PR DESCRIPTION
Debugger in RubyMine doesn't work well with byebug.
For example, debugging Sidekiq jobs doesn't work when byebug is loaded.