### PR TITLE
FIX: admin margin

### DIFF
--- a/app/assets/stylesheets/common/admin/admin_base.scss
+++ b/app/assets/stylesheets/common/admin/admin_base.scss
@@ -23,8 +23,6 @@ $mobile-breakpoint: 700px;
 
 .admin-contents {
   position: relative;
-  margin-left: -10px;
-  margin-right: -10px;
 }
 
 .admin-contents table {
@@ -1683,6 +1681,8 @@ table#user-badges {
 // Mobile specific styles
 // Mobile view text-inputs need some padding
 .mobile-view .admin-contents {
+  margin-left: -10px;
+  margin-right: -10px;
   input[type="text"] {
     padding: 4px;
   }


### PR DESCRIPTION
I previously set a margin of -10px on `.admin-contents`. That margin should only have been applied to the mobile view. Applying it to the desktop view pushes `.admin-contents` out of the wrapper.

We don't want this:
![screenshot 2015-10-11 12 36 34](https://cloud.githubusercontent.com/assets/2975917/10418624/49a2f638-7015-11e5-94b0-0ad72a9ab5a2.png)

This is how it looks with this change:
![screenshot 2015-10-11 12 37 14](https://cloud.githubusercontent.com/assets/2975917/10418628/6b26daa4-7015-11e5-8cdc-9c33f25c3254.png)

The negative margin on mobile is to bring some elements right up to the edge of the window:
![screenshot 2015-10-11 12 43 58](https://cloud.githubusercontent.com/assets/2975917/10418643/f212bfd8-7015-11e5-9625-a0ea26891fdc.png)


