### PR TITLE
FIX: Race condition when wrapping `PostCreator#create` in a transaction.

### DIFF
--- a/app/jobs/regular/post_alert.rb
+++ b/app/jobs/regular/post_alert.rb
@@ -3,7 +3,7 @@ module Jobs
 
     def execute(args)
       # maybe it was removed by the time we are making the post
-      if post = Post.find_by(id: args[:post_id])
+      if post = Post.find(args[:post_id])
         # maybe the topic was deleted, so skip in that case as well
         PostAlerter.post_created(post) if post.topic
       end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -517,18 +517,16 @@ class Topic < ActiveRecord::Base
   def add_moderator_post(user, text, opts=nil)
     opts ||= {}
     new_post = nil
-    Topic.transaction do
-      creator = PostCreator.new(user,
-                                raw: text,
-                                post_type: opts[:post_type] || Post.types[:moderator_action],
-                                action_code: opts[:action_code],
-                                no_bump: opts[:bump].blank?,
-                                skip_notifications: opts[:skip_notifications],
-                                topic_id: self.id,
-                                skip_validations: true)
-      new_post = creator.create
-      increment!(:moderator_posts_count)
-    end
+    creator = PostCreator.new(user,
+                              raw: text,
+                              post_type: opts[:post_type] || Post.types[:moderator_action],
+                              action_code: opts[:action_code],
+                              no_bump: opts[:bump].blank?,
+                              skip_notifications: opts[:skip_notifications],
+                              topic_id: self.id,
+                              skip_validations: true)
+    new_post = creator.create
+    increment!(:moderator_posts_count) if new_post.persisted?
 
     if new_post.present?
       # If we are moving posts, we want to insert the moderator post where the previous posts were

--- a/spec/models/post_action_spec.rb
+++ b/spec/models/post_action_spec.rb
@@ -516,6 +516,22 @@ describe PostAction do
       topic.reload
       expect(topic.posts.count).to eq(1)
     end
+
+    it "should create a notification in the related topic" do
+      post = Fabricate(:post)
+      user = Fabricate(:user)
+      action = PostAction.act(user, post, PostActionType.types[:spam], message: "WAT")
+      topic = action.reload.related_post.topic
+      expect(user.notifications.count).to eq(0)
+
+      SiteSetting.expects(:auto_respond_to_flag_actions).returns(true)
+      PostAction.agree_flags!(post, admin)
+
+      user_notifications = user.notifications
+      expect(user_notifications.count).to eq(1)
+      expect(user_notifications.last.topic).to eq(topic)
+    end
+
   end
 
   describe "rate limiting" do


### PR DESCRIPTION
https://meta.discourse.org/t/automated-responses-to-flags-not-generating-notification/31151/3