### PR TITLE
FIX: Fixing margin-top in .card-content element when have an image background

### DIFF
--- a/app/assets/stylesheets/desktop/user-card.scss
+++ b/app/assets/stylesheets/desktop/user-card.scss
@@ -30,7 +30,6 @@ $user_card_background: #222;
   .card-content {
     padding: 12px 12px 0 12px;
     background: rgba($user_card_background, .85);
-    margin-top: 80px;
 
     &:after {
       content: '';
@@ -41,10 +40,6 @@ $user_card_background: #222;
 
   &.no-bg {
     min-height: 50px;
-
-    .card-content {
-      margin-top: 0;
-    }
   }
 
   .avatar-placeholder {


### PR DESCRIPTION
When the user have an image background, the .card-content element have
a weird margin-top: 80px; I just remove this margin. See the evidence in image:

![screen-shot-2015-10-15-at-8 45 16-pm](https://cloud.githubusercontent.com/assets/1918210/10530497/dfb677d2-737e-11e5-9bba-83657f7e7a66.jpg)
