### PR TITLE
FIX: Whitelist parentheses and brackets in autocomplete.

### DIFF
--- a/app/assets/javascripts/discourse/lib/autocomplete.js.es6
+++ b/app/assets/javascripts/discourse/lib/autocomplete.js.es6
@@ -287,7 +287,7 @@ export default function(options) {
     if (options.key && e.which === options.key.charCodeAt(0)) {
       caretPosition = Discourse.Utilities.caretPosition(me[0]);
       var prevChar = me.val().charAt(caretPosition - 1);
-      if (!prevChar || /\W/.test(prevChar)) {
+      if (!prevChar || /[^\w\)\]]/.test(prevChar)) {
         completeStart = completeEnd = caretPosition;
         updateAutoComplete(options.dataSource(""));
       }
@@ -341,7 +341,7 @@ export default function(options) {
         stopFound = prev === options.key;
         if (stopFound) {
           prev = me[0].value[c - 1];
-          if (!prev || /\W/.test(prev)) {
+          if (!prev || /[^\w\)\]]/.test(prev)) {
             completeStart = c;
             caretPosition = completeEnd = initial;
             term = me[0].value.substring(c + 1, initial);


### PR DESCRIPTION
https://meta.discourse.org/t/default-emoji-plugin-how-to-disable/3415/14