### PR TITLE
UX: Trigger autocompleter only for specific characters.

### DIFF
--- a/app/assets/javascripts/discourse/lib/autocomplete.js.es6
+++ b/app/assets/javascripts/discourse/lib/autocomplete.js.es6
@@ -6,6 +6,8 @@
 
 export var CANCELLED_STATUS = "__CANCELLED";
 
+const allowedLettersRegex = /[\s\t\[\{\(]/;
+
 var keys = {
   backSpace: 8,
   tab: 9,
@@ -287,7 +289,7 @@ export default function(options) {
     if (options.key && e.which === options.key.charCodeAt(0)) {
       caretPosition = Discourse.Utilities.caretPosition(me[0]);
       var prevChar = me.val().charAt(caretPosition - 1);
-      if (!prevChar || /[^\w\)\]]/.test(prevChar)) {
+      if (!prevChar || allowedLettersRegex.test(prevChar)) {
         completeStart = completeEnd = caretPosition;
         updateAutoComplete(options.dataSource(""));
       }
@@ -341,7 +343,7 @@ export default function(options) {
         stopFound = prev === options.key;
         if (stopFound) {
           prev = me[0].value[c - 1];
-          if (!prev || /[^\w\)\]]/.test(prev)) {
+          if (!prev || allowedLettersRegex.test(prev)) {
             completeStart = c;
             caretPosition = completeEnd = initial;
             term = me[0].value.substring(c + 1, initial);


### PR DESCRIPTION
https://meta.discourse.org/t/default-emoji-plugin-how-to-disable/3415/18