### PR TITLE
Make @mentions following a slash link to usercards

### DIFF
--- a/app/assets/javascripts/discourse/dialects/dialect.js
+++ b/app/assets/javascripts/discourse/dialects/dialect.js
@@ -135,7 +135,7 @@ function invalidBoundary(args, prev) {
   var last = prev[prev.length - 1];
   if (typeof last !== "string") { return false; }
 
-  if (args.wordBoundary && (last.match(/(\w|\/)$/))) { return true; }
+  if (args.wordBoundary && (!last.match(/\W$/))) { return true; }
   if (args.spaceBoundary && (!last.match(/\s$/))) { return true; }
   if (args.spaceOrTagBoundary && (!last.match(/(\s|\>)$/))) { return true; }
 }

--- a/test/javascripts/lib/markdown-test.js.es6
+++ b/test/javascripts/lib/markdown-test.js.es6
@@ -276,6 +276,10 @@ test("Mentions", function() {
          "<ol><li><p>this is  a list</p></li><li><p>this is an <span class=\"mention\">@eviltrout</span> mention</p></li></ol>",
          "it mentions properly in a list.");
 
+  cooked("Hello @foo/@bar",
+         "<p>Hello <span class=\"mention\">@foo</span>/<span class=\"mention\">@bar</span></p>",
+         "handles mentions separated by a slash.");
+
   cookedOptions("@eviltrout", alwaysTrue,
                 "<p><a class=\"mention\" href=\"/users/eviltrout\">@eviltrout</a></p>",
                 "it doesn't onebox mentions");


### PR DESCRIPTION
A slash preceding an `@mention` was causing the markup for the usercard link to not be generated. For example, the markdown `Pinging @bob/@joe` would generate a usercard for `@bob`, but not `@joe`.

The fix is actually just reverting [this change](https://github.com/discourse/discourse/commit/63f2187d72356dedc26d5e1d727580f2ba87b132) from two years ago. All the QUnit specs still pass, so I assume something else fixed the intraword italics issue in the meantime.

Resolves part of the bug [Slash preceeding an @mention does not generate usercard link](https://meta.discourse.org/t/slash-preceeding-an-mention-does-not-generate-usercard-link/25979).