### PR TITLE
FIX: Emoji toolbar too wide on mobile.

### DIFF
--- a/app/assets/javascripts/discourse/lib/emoji/emoji-toolbar.js.es6
+++ b/app/assets/javascripts/discourse/lib/emoji/emoji-toolbar.js.es6
@@ -4,7 +4,9 @@ import KeyValueStore from "discourse/lib/key-value-store";
 const keyValueStore = new KeyValueStore("discourse_emojis_");
 const EMOJI_USAGE = "emojiUsage";
 
-const PER_ROW = 12, PER_PAGE = 60;
+let PER_ROW = 12;
+const PER_PAGE = 60;
+
 let ungroupedIcons, recentlyUsedIcons;
 
 if (!keyValueStore.getObject(EMOJI_USAGE)) {
@@ -159,6 +161,7 @@ function showSelector(options) {
   options.appendTo.append('<div class="emoji-modal-wrapper"></div>');
   $('.emoji-modal-wrapper').click(() => closeSelector());
 
+  if (Discourse.Mobile.mobileView) PER_ROW = 9;
   const page = keyValueStore.getInt("emojiPage", 0);
   const offset = keyValueStore.getInt("emojiOffset", 0);
 


### PR DESCRIPTION
This was removed in https://github.com/discourse/discourse/commit/94b60e62a263322ee7e4c0765b8d1307575f37e0#diff-d63881c9f1e1fbeeb8d94b2d881120e1L240

cc/ @eviltrout 