### PR TITLE
FIX: Topic#last_posted_at was not being set when changing topic times…

### DIFF
--- a/spec/services/post_timestamp_changer_spec.rb
+++ b/spec/services/post_timestamp_changer_spec.rb
@@ -21,6 +21,8 @@ describe PostTimestampChanger do
       [:created_at, :updated_at].each do |column|
         expect(p1.public_send(column)).to be_within_one_second_of(new_timestamp)
       end
+
+      expect(topic.last_posted_at).to be_within_one_second_of(p2.reload.created_at)
     end
 
     describe 'predated timestamp' do


### PR DESCRIPTION
…tamp.

meta: https://meta.discourse.org/t/changing-timestamp-doesnt-update-topic-list-on-front-page/34684