### PR TITLE
FIX: 'q' keyboard shortcut not working.

### DIFF
--- a/app/assets/javascripts/discourse/lib/keyboard-shortcuts.js.es6
+++ b/app/assets/javascripts/discourse/lib/keyboard-shortcuts.js.es6
@@ -99,7 +99,7 @@ export default {
     $('.topic-post.selected button.create').click();
     // lazy but should work for now
     setTimeout(function() {
-      $('#wmd-quote-post').click();
+      $('.wmd-quote-post').click();
     }, 500);
   },
 


### PR DESCRIPTION
meta: https://meta.discourse.org/t/various-keyboard-shortcuts-no-longer-working/32679/4

Use Class not ID xD
https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/lib/Markdown.Editor.js#L1410