### PR TITLE
filter by username in email digest preview

### DIFF
--- a/app/assets/javascripts/admin/controllers/admin-email-preview-digest.js.es6
+++ b/app/assets/javascripts/admin/controllers/admin-email-preview-digest.js.es6
@@ -5,7 +5,7 @@ export default Ember.Controller.extend({
       const model = this.get('model');
 
       this.set('loading', true);
-      Discourse.EmailPreview.findDigest(this.get('lastSeen')).then(email => {
+      Discourse.EmailPreview.findDigest(this.get('lastSeen'), this.get('username')).then(email => {
         model.setProperties(email.getProperties('html_content', 'text_content'));
         this.set('loading', false);
       });

--- a/app/assets/javascripts/admin/models/email_preview.js
+++ b/app/assets/javascripts/admin/models/email_preview.js
@@ -9,18 +9,20 @@
 Discourse.EmailPreview = Discourse.Model.extend({});
 
 Discourse.EmailPreview.reopenClass({
-  findDigest: function(lastSeenAt) {
+  findDigest: function(lastSeenAt, username) {
 
     if (Em.isEmpty(lastSeenAt)) {
       lastSeenAt = moment().subtract(7, 'days').format('YYYY-MM-DD');
     }
 
+    if (Em.isEmpty(username)) {
+      username = Discourse.User.current().username;
+    }
+
     return Discourse.ajax("/admin/email/preview-digest.json", {
-      data: {last_seen_at: lastSeenAt}
+      data: { last_seen_at: lastSeenAt, username: username }
     }).then(function (result) {
       return Discourse.EmailPreview.create(result);
     });
   }
 });
-
-

--- a/app/assets/javascripts/admin/templates/email_preview_digest.hbs
+++ b/app/assets/javascripts/admin/templates/email_preview_digest.hbs
@@ -4,6 +4,8 @@
   <div class='span7 controls'>
     <label for='last-seen'>{{i18n 'admin.email.last_seen_user'}}</label>
     {{input type="date" value=lastSeen id="last-seen"}}
+    <label>{{i18n 'admin.email.user'}}:</label>
+    {{user-selector single="true" usernames=username}}
     <button class='btn' {{action "refresh"}}>{{i18n 'admin.email.refresh'}}</button>
     <div class="toggle">
       <label>{{i18n 'admin.email.format'}}</label>

--- a/app/assets/stylesheets/common/admin/admin_base.scss
+++ b/app/assets/stylesheets/common/admin/admin_base.scss
@@ -213,6 +213,14 @@ td.flaggers td {
     display: inline-block;
     margin-right: 5px;
   }
+  #last-seen {
+    float: none;
+  }
+  .ac-wrap {
+    display: inline-block;
+    vertical-align: middle;
+    padding: 0;
+  }
 }
 
 .paste-users {

--- a/app/controllers/admin/email_controller.rb
+++ b/app/controllers/admin/email_controller.rb
@@ -34,7 +34,9 @@ class Admin::EmailController < Admin::AdminController
 
   def preview_digest
     params.require(:last_seen_at)
-    renderer = Email::Renderer.new(UserNotifications.digest(current_user, since: params[:last_seen_at]))
+    params.require(:username)
+    user = User.find_by_username(params[:username])
+    renderer = Email::Renderer.new(UserNotifications.digest(user, since: params[:last_seen_at]))
     render json: MultiJson.dump(html_content: renderer.html, text_content: renderer.text)
   end
 

--- a/spec/controllers/admin/email_controller_spec.rb
+++ b/spec/controllers/admin/email_controller_spec.rb
@@ -66,7 +66,7 @@ describe Admin::EmailController do
     end
 
     it "previews the digest" do
-      xhr :get, :preview_digest, last_seen_at: 1.week.ago
+      xhr :get, :preview_digest, last_seen_at: 1.week.ago, username: user.username
       expect(response).to be_success
     end
   end


### PR DESCRIPTION
As per: [Filter by group in digest preview](https://meta.discourse.org/t/filter-by-group-in-digest-preview/19553/4?u=leomca)

This PR adds a user option to the email digest preview, and fixes some broken styling (and ensures the user input doesn't look terrible), like so:

![screenshot from 2015-10-30 18-17-24](https://cloud.githubusercontent.com/assets/755354/10854292/b8e2c484-7f32-11e5-9dd0-f3b2003882a9.png)

My first PR to Discourse! (So please be gentle...)