### PR TITLE
FIX: add missing dependency

### DIFF
--- a/lib/locale_file_walker.rb
+++ b/lib/locale_file_walker.rb
@@ -1,4 +1,5 @@
 require 'psych'
+require 'set'
 
 class LocaleFileWalker
   protected


### PR DESCRIPTION
Oops, forgot to add a dependency in my PR https://github.com/discourse/discourse/pull/3787 :blush: 
It's needed in order to run `pull_translations.rb` without bundler.