### PR TITLE
FIX: avatar not shown correctly when there is a port in the URL

### DIFF
--- a/lib/pretty_text.rb
+++ b/lib/pretty_text.rb
@@ -31,7 +31,7 @@ module PrettyText
         avatar_template = user.avatar_template
       end
 
-      UrlHelper.schemaless UrlHelper.absolute avatar_template
+      Discourse.base_uri avatar_template
     end
 
     def is_username_valid(username)

--- a/lib/pretty_text.rb
+++ b/lib/pretty_text.rb
@@ -1,6 +1,5 @@
 require 'v8'
 require 'nokogiri'
-require_dependency 'url_helper'
 require_dependency 'excerpt_parser'
 require_dependency 'post'
 


### PR DESCRIPTION
I noticed that if the URL contains a port (e.g. `localhost:4000`, when using Vagrant), the little avatar beside a quote is not shown. Before-after screenshots:

![little avatar not showing](https://cloud.githubusercontent.com/assets/1285361/10925091/9228ea42-828b-11e5-905c-c32e1cc099df.png)

In the Vagrant case, the computed path was `//localhost:3000/user_avatar/localhost/eviltrout/40/1_1.png`. So the port is there, is just wrong for some reason. In my real word use case the path was just `//example.com/user_avatar/...` without the port. However, now it's just: `/user_avatar/localhost/eviltrout/40/1_1.png` so I guess it's better either way?