### PR TITLE
FIX: position admin-nav absolutely

### DIFF
--- a/app/assets/stylesheets/common/admin/admin_base.scss
+++ b/app/assets/stylesheets/common/admin/admin_base.scss
@@ -253,7 +253,7 @@ td.flaggers td {
   position: relative;
   // The admin-nav becomes a slide-out menu at the mobile-nav breakpoint
   @media (max-width: $mobile-breakpoint) {
-    position: static;
+    position: absolute;
     z-index: 0;
     width: 50%;
   }


### PR DESCRIPTION
The admin-nav needs to be positioned absolutely on small screens for it to work as a slide-out menu. It's position has been changed to static. I'm not sure if that was done for a reason. Positioning it absolutely doesn't seem to cause any problems anywhere. This PR changes it back to `position: absolute`.

How it looks now:

![screenshot 2015-11-12 10 08 35](https://cloud.githubusercontent.com/assets/2975917/11126822/ab6fda74-8925-11e5-8484-4e2127416075.png)

How it looks with `position: absolute`

![screenshot 2015-11-12 10 09 46](https://cloud.githubusercontent.com/assets/2975917/11126838/d2c91112-8925-11e5-8f76-fd143fa25ea7.png)

![screenshot 2015-11-12 10 09 56](https://cloud.githubusercontent.com/assets/2975917/11126843/da225dc4-8925-11e5-9653-cea709242fd8.png)


 