### PR TITLE
UX: Use localized date format in digest email

### DIFF
--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -42,11 +42,10 @@ class UserNotifications < ActionMailer::Base
   end
 
   def short_date(dt)
-    current = Time.now
-    if dt.year == current.year
-      dt.strftime("%B #{dt.day.ordinalize}")
+    if dt.year == Time.now.year
+      I18n.l(dt, format: :short_no_year)
     else
-      dt.strftime("%B #{dt.day.ordinalize}, %Y")
+      I18n.l(dt, format: :short)
     end
   end
 


### PR DESCRIPTION
Use localized date format in digest email instead of the format introduced in https://github.com/discourse/discourse/commit/734c272de81baac8a70801e257a994a8a6e9f616

PR https://github.com/discourse/discourse/pull/3787 has been merged - the date formats are localizable. I liked the idea of omitting the year when it's the current year, so I left that in.
See also: https://meta.discourse.org/t/change-of-date-in-digest-email-body/34983

This is what the digest preview looks like for the English locale:
![image](https://cloud.githubusercontent.com/assets/473736/11157172/5128b7da-8a50-11e5-8e30-a86fc4a75baa.png)
![image](https://cloud.githubusercontent.com/assets/473736/11157186/65b143d4-8a50-11e5-8280-1b539f8b4aa5.png)

And here's the German locale:
![image](https://cloud.githubusercontent.com/assets/473736/11157191/7623cdd6-8a50-11e5-8e81-6c147dad00d5.png)
![image](https://cloud.githubusercontent.com/assets/473736/11157201/846001d0-8a50-11e5-8e8c-09a8785033cb.png)