### PR TITLE
migrate_to_s3: check for missing local files

### DIFF
--- a/lib/tasks/uploads.rake
+++ b/lib/tasks/uploads.rake
@@ -134,7 +134,7 @@ def migrate_to_s3
     # retrieve the path to the local file
     path = local.path_for(upload)
     # make sure the file exists locally
-    if !File.exists?(path)
+    if !path or !File.exists?(path)
       putc "X"
       next
     end


### PR DESCRIPTION
If an image is already on S3, but not available locally (eg. if they're already migrated), `path` is nil. This crashes the task, because File.exists?(nil) is not valid.