### PR TITLE
FIX: Pressing Ctrl+F twice should close Discourse search window

### DIFF
--- a/app/assets/javascripts/discourse/lib/keyboard-shortcuts.js.es6
+++ b/app/assets/javascripts/discourse/lib/keyboard-shortcuts.js.es6
@@ -368,14 +368,14 @@ export default {
   },
 
   _stopCallback() {
-    const oldStopCallback = this.keyTrapper.stopCallback;
+    const oldStopCallback = this.keyTrapper.prototype.stopCallback;
 
-    this.keyTrapper.stopCallback = function(e, element, combo) {
+    this.keyTrapper.prototype.stopCallback = function(e, element, combo, sequence) {
       if ((combo === 'ctrl+f' || combo === 'command+f') && element.id === 'search-term') {
         return false;
       }
 
-      return oldStopCallback(e, element, combo);
+      return oldStopCallback(e, element, combo, sequence);
     };
   }
 };


### PR DESCRIPTION
Make it work with Mousetrap 1.5.3 that was added in bb21902954511c66b622ce36ca3aa9afbe49db4b.
Overwriting the `stopCallback` was moved to the `prototype` (https://github.com/ccampbell/mousetrap/issues/288).