### PR TITLE
FIX: check for site direction before positioning d-editor-modal

### DIFF
--- a/app/assets/javascripts/discourse/components/d-editor-modal.js.es6
+++ b/app/assets/javascripts/discourse/components/d-editor-modal.js.es6
@@ -11,7 +11,9 @@ export default Ember.Component.extend({
         const $parent = this.$().closest('.d-editor');
         const w = $parent.width();
         const h = $parent.height();
-        $modal.css({ left: (w / 2) - ($modal.outerWidth() / 2) });
+        const dir = $('html').css('direction') === 'rtl' ? 'right' : 'left';
+        const offset = (w / 2) - ($modal.outerWidth() / 2);
+        $modal.css(dir, offset + 'px');
         parent.$('.d-editor-overlay').removeClass('hidden').css({ width: w, height: h});
         this.$('input').focus();
       });


### PR DESCRIPTION
The d-editor-modal is positioned off the screen for RTL layouts. This checks the site direction and sets the appropriate direction for positioning. 

Something like this: `const dir = $('html').css('direction') === 'rtl' ? 'right' : 'left';` is also used in `views/user-card.js.es6`. It will come up anytime there is inline horizontal positioning. Maybe there is a better way to check if the layout is rtl?