### PR TITLE
FIX: On clicking edit category button, notification level is set to default

### DIFF
--- a/app/serializers/basic_category_serializer.rb
+++ b/app/serializers/basic_category_serializer.rb
@@ -38,4 +38,7 @@ class BasicCategorySerializer < ApplicationSerializer
     scope && scope.can_edit?(object)
   end
 
+  def notification_level
+    object.notification_level || CategoryUser.where(user: object.user, category: object).first.try(:notification_level)
+  end
 end


### PR DESCRIPTION
This fixes 
https://meta.discourse.org/t/cancelling-edit-category-screen-changes-following-status/31861/2.

The received value of notification_level is set to null so we need to set it up before returning category.