### PR TITLE
FIX: Admin logging should not log permissions if none has been set.

### DIFF
--- a/app/services/staff_action_logger.rb
+++ b/app/services/staff_action_logger.rb
@@ -215,7 +215,7 @@ class StaffActionLogger
 
     changed_attributes = category.previous_changes.slice(*category_params.keys)
 
-    if old_permissions != category_params[:permissions]
+    if !old_permissions.empty? && (old_permissions != category_params[:permissions])
       changed_attributes.merge!({ permissions: [old_permissions.to_json, category_params[:permissions].to_json] })
     end
 

--- a/spec/services/staff_action_logger_spec.rb
+++ b/spec/services/staff_action_logger_spec.rb
@@ -306,6 +306,17 @@ describe StaffActionLogger do
       expect(name_user_history.previous_value).to eq('haha')
       expect(name_user_history.new_value).to eq('new_name')
     end
+
+    it "does not log permissions changes for category visible to everyone" do
+      attributes = { name: 'new_name' }
+      old_permission = category.permissions_params
+      category.update!(attributes)
+
+      logger.log_category_settings_change(category, attributes.merge({ permissions: { "everyone" => 1 } }), old_permission)
+
+      expect(UserHistory.count).to eq(1)
+      expect(UserHistory.find_by_subject('name').category).to eq(category)
+    end
   end
 
   describe 'log_category_deletion' do


### PR DESCRIPTION
Meta: https://meta.discourse.org/t/extra-admin-logs-generated-on-category-edit/36345