### PR TITLE
FIX: Avoid bang methods in Disqus importer.

### DIFF
--- a/script/import_scripts/disqus.rb
+++ b/script/import_scripts/disqus.rb
@@ -151,8 +151,7 @@ class DisqusSAX < Nokogiri::XML::SAX::Document
         @threads.delete(id)
       else
         # Normalize titles
-        t[:title].gsub!(@strip, '') if @strip.present?
-        t[:title].strip!
+        t[:title] = [:title].gsub(@strip, '').strip if @strip.present?
       end
     end
 


### PR DESCRIPTION
Meta: https://meta.discourse.org/t/disqus-importer-fails-undefined-method/36200