### PR TITLE
Change to use weak reference incase object is collected by GC

### DIFF
--- a/lib/memory_diagnostics.rb
+++ b/lib/memory_diagnostics.rb
@@ -20,7 +20,7 @@ module MemoryDiagnostics
 
     require 'objspace'
     diff = diff.map do |id|
-      ObjectSpace._id2ref(id) rescue nil
+      WeakRef.new(ObjectSpace._id2ref(id)) rescue nil
     end
     diff.compact!
 
@@ -31,8 +31,8 @@ module MemoryDiagnostics
     summary = {}
     diff.each do |obj|
       begin
-        summary[obj.class] ||= 0
-        summary[obj.class] += 1
+        summary[obj.__getobj__.class] ||= 0
+        summary[obj.__getobj__.class] += 1
       rescue
         # don't care
       end


### PR DESCRIPTION
I was getting some seg faults from referencing an already collected object (I have no idea how this is even possible).  Changing to use a `WeakRef` will just raise an exception when object has already been GC'd.

Obviously, this will introduce a ton more objects if there is a big diff.