### PR TITLE
username as from in emails

### DIFF
--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -156,7 +156,9 @@ class UserNotifications < ActionMailer::Base
       title: post.topic.title,
       post: post,
       username: post.user.username,
-      from_alias: (SiteSetting.enable_names && SiteSetting.display_name_on_posts && post.user.name.present?) ? post.user.name : post.user.username,
+      from_alias: (SiteSetting.enable_names &&
+                   SiteSetting.display_name_on_email_from &&
+                   post.user.name.present?) ? post.user.name : post.user.username,
       allow_reply_by_email: true,
       use_site_subject: true,
       add_re_to_subject: true,
@@ -202,7 +204,8 @@ class UserNotifications < ActionMailer::Base
     return unless @post = opts[:post]
 
     user_name = @notification.data_hash[:original_username]
-    if @post && SiteSetting.enable_names && SiteSetting.display_name_on_posts
+    
+    if @post && SiteSetting.enable_names && SiteSetting.display_name_on_email_from
       name = User.where(id: @post.user_id).pluck(:name).first
       user_name = name unless name.blank?
     end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1098,6 +1098,7 @@ en:
 
     strip_images_from_short_emails: "Strip images from emails having size less than 2800 Bytes"
     short_email_length: "Short email length in Bytes"
+    display_name_on_email_from: "Display full names on email from fields"
 
     pop3_polling_enabled: "Poll via POP3 for email replies."
     pop3_polling_ssl: "Use SSL while connecting to the POP3 server. (Recommended)"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -529,6 +529,8 @@ email:
     client: true
   strip_images_from_short_emails: true
   short_email_length: 2800
+  display_name_on_email_from:
+    default: true
 
 files:
   max_image_size_kb: 3072


### PR DESCRIPTION
Allow username to display in from field for email notifications even when full name fields are set to display in posts.