### PR TITLE
Have DiskSpace.{free,used} use BigDecimal instead of directly doing F…

### DIFF
--- a/lib/disk_space.rb
+++ b/lib/disk_space.rb
@@ -1,3 +1,5 @@
+require "bigdecimal"
+
 class DiskSpace
 
   extend ActionView::Helpers::NumberHelper
@@ -57,11 +59,12 @@ class DiskSpace
   protected
 
   def self.free(path)
-    `df -Pk #{path} | awk 'NR==2 {print $4 * 1024;}'`.to_i
+    number = `df -Pk #{path} | awk 'NR==2 {print $4 * 1024;}'`.strip
+    BigDecimal.new(number).to_i
   end
 
   def self.used(path)
-    `du -s #{path}`.to_i * 1024
+    number = `du -s #{path}`
+    BigDecimal.new(number).to_i * 1024
   end
-
 end


### PR DESCRIPTION
…ixnum#to_i

As it stands the way Discourse handles Disk usage and free space reporting it can lead to nearly 0 disk space being reported to Discourse, this is because when a the command is ran and returned (at first through `awk`, the latter is for consistency) it returns notation, `Fixnum#to_i` returns the number to the left rather than anything from the left and right combined and expanded, leading to something like `8.76138e+09` (what is returned on our systems with that command) to be 8, meaning we only have 8 bytes available to Discourse according to it. By using BigDecimal to wrap that and then run `Fixnum#to_i` we get the proper number `8761380000`, you can optionally also just run `#to_f.to_i` but that looks nasty compared to just using STDLib's BigDecimal.