### PR TITLE
FIX: Selection logic error in applySurround

### DIFF
--- a/app/assets/javascripts/discourse/components/d-editor.js.es6
+++ b/app/assets/javascripts/discourse/components/d-editor.js.es6
@@ -375,7 +375,7 @@ export default Ember.Component.extend({
       let [hval, hlen] = getHead(head);
       if (lines.length === 1 && pre.slice(-tlen) === tail && post.slice(0, hlen) === hval) {
         this.set('value', `${pre.slice(0, -hlen)}${sel.value}${post.slice(tlen)}`);
-        this._selectText(sel.start - hlen, sel.value.length);
+        this._selectText(sel.start + hlen, sel.value.length);
       } else {
         const contents = this._getMultilineContents(lines, head, hval, hlen, tail, tlen);
 


### PR DESCRIPTION
sel.start - hlen is guaranteed to be before the text we're talking about, so it doesn't make any sense. All the other selectText() calls use sel.start + hlen, so that's clearly the correct operation.