### PR TITLE
Add Discourse.getURL to the url passed into page view events

### DIFF
--- a/app/assets/javascripts/discourse/lib/page-tracker.js.es6
+++ b/app/assets/javascripts/discourse/lib/page-tracker.js.es6
@@ -21,7 +21,7 @@ const PageTracker = Ember.Object.extend(Ember.Evented, {
 
     router.on('didTransition', function() {
       this.send('refreshTitle');
-      var url = this.get('url');
+      var url = Discourse.getURL(this.get('url'));
 
       // Refreshing the title is debounced, so we need to trigger this in the
       // next runloop to have the correct title.


### PR DESCRIPTION
This means that instances in a subdirectory correctly receive the subfolder string as a part of the path.

What we were getting:
![image](https://cloud.githubusercontent.com/assets/1182199/11888510/78825dce-a592-11e5-87c3-f0c62bac9df8.png)

What this will give us:
![image](https://cloud.githubusercontent.com/assets/1182199/11888546/c8088f9e-a592-11e5-8d0a-bf6723809b9a.png)

(The `dp` value overwrites the `dl` value, meaning the analytics end up observing the incomplete path)

cc @cpradio 