### PR TITLE
Return 204 instead of 404 for favicon.ico requests

### DIFF
--- a/config/nginx.sample.conf
+++ b/config/nginx.sample.conf
@@ -80,11 +80,9 @@ server {
     internal;
   }
 
-  # return a cheap 404 for favicon cause lots of browsers like asking for it
-  # view source and old browsers, this bypasses the rails stack at the expense of
-  # having an ugly 404 page
+  # bypass rails stack with a cheap 204 for favicon.ico requests
   location /favicon.ico {
-    return 404;
+    return 204;
   }
 
   location / {

--- a/config/nginx.sample.conf
+++ b/config/nginx.sample.conf
@@ -83,6 +83,8 @@ server {
   # bypass rails stack with a cheap 204 for favicon.ico requests
   location /favicon.ico {
     return 204;
+    access_log off;
+    log_not_found off;
   }
 
   location / {


### PR DESCRIPTION
This saves some network bytes (especially if the admin has a heavy custom 404 page). Also saves some disk writes.