### PR TITLE
FEATURE: make "trust level 3" requirements time period admin setting

### DIFF
--- a/app/assets/javascripts/admin/models/tl3-requirements.js.es6
+++ b/app/assets/javascripts/admin/models/tl3-requirements.js.es6
@@ -1,10 +1,10 @@
 const TL3Requirements = Discourse.Model.extend({
   days_visited_percent: function() {
-    return ((this.get('days_visited') * 100) / this.get('time_period'));
+    return Math.round((this.get('days_visited') * 100) / this.get('time_period'));
   }.property('days_visited', 'time_period'),
 
   min_days_visited_percent: function() {
-    return ((this.get('min_days_visited') * 100) / this.get('time_period'));
+    return Math.round((this.get('min_days_visited') * 100) / this.get('time_period'));
   }.property('min_days_visited', 'time_period'),
 
   met: function() {

--- a/app/assets/javascripts/admin/templates/user-tl3-requirements.hbs
+++ b/app/assets/javascripts/admin/templates/user-tl3-requirements.hbs
@@ -10,7 +10,7 @@
 <div class="admin-container tl3-requirements">
   <h2>{{model.username}} - {{i18n 'admin.user.tl3_requirements.title'}}</h2>
   <br/>
-  <p>{{i18n 'admin.user.tl3_requirements.table_title'}}</p>
+  <p>{{i18n 'admin.user.tl3_requirements.table_title' time_period=model.tl3Requirements.time_period}}</p>
 
   <table class="table" style="width: auto;">
     <thead>

--- a/app/models/trust_level3_requirements.rb
+++ b/app/models/trust_level3_requirements.rb
@@ -4,8 +4,6 @@ class TrustLevel3Requirements
 
   include ActiveModel::Serialization
 
-  TIME_PERIOD = 100 # days
-
   LOW_WATER_MARK = 0.9
 
   attr_accessor :days_visited, :min_days_visited,
@@ -60,6 +58,10 @@ class TrustLevel3Requirements
     num_likes_received_days < min_likes_received_days * LOW_WATER_MARK
   end
 
+  def time_period
+    SiteSetting.tl3_time_period
+  end
+
   def trust_level_locked
     @user.trust_level_locked
   end
@@ -69,7 +71,7 @@ class TrustLevel3Requirements
   end
 
   def days_visited
-    @user.user_visits.where("visited_at > ? and posts_read > 0", TIME_PERIOD.days.ago).count
+    @user.user_visits.where("visited_at > ? and posts_read > 0", time_period.days.ago).count
   end
 
   def min_days_visited
@@ -77,7 +79,7 @@ class TrustLevel3Requirements
   end
 
   def num_topics_replied_to
-    @user.posts.select('distinct topic_id').where('created_at > ? AND post_number > 1', TIME_PERIOD.days.ago).count
+    @user.posts.select('distinct topic_id').where('created_at > ? AND post_number > 1', time_period.days.ago).count
   end
 
   def min_topics_replied_to
@@ -89,7 +91,7 @@ class TrustLevel3Requirements
   end
 
   def topics_viewed
-    topics_viewed_query.where('viewed_at > ?', TIME_PERIOD.days.ago).count
+    topics_viewed_query.where('viewed_at > ?', time_period.days.ago).count
   end
 
   def min_topics_viewed
@@ -97,7 +99,7 @@ class TrustLevel3Requirements
   end
 
   def posts_read
-    @user.user_visits.where('visited_at > ?', TIME_PERIOD.days.ago).pluck(:posts_read).sum
+    @user.user_visits.where('visited_at > ?', time_period.days.ago).pluck(:posts_read).sum
   end
 
   def min_posts_read
@@ -147,7 +149,7 @@ class TrustLevel3Requirements
   end
 
   def num_likes_given
-    UserAction.where(user_id: @user.id, action_type: UserAction::LIKE).where('created_at > ?', TIME_PERIOD.days.ago).count
+    UserAction.where(user_id: @user.id, action_type: UserAction::LIKE).where('created_at > ?', time_period.days.ago).count
   end
 
   def min_likes_given
@@ -155,7 +157,7 @@ class TrustLevel3Requirements
   end
 
   def num_likes_received_query
-    UserAction.where(user_id: @user.id, action_type: UserAction::WAS_LIKED).where('created_at > ?', TIME_PERIOD.days.ago)
+    UserAction.where(user_id: @user.id, action_type: UserAction::WAS_LIKED).where('created_at > ?', time_period.days.ago)
   end
 
   def num_likes_received
@@ -197,7 +199,7 @@ class TrustLevel3Requirements
 
   def self.num_topics_in_time_period
     $redis.get(NUM_TOPICS_KEY) || begin
-      count = Topic.listable_topics.visible.created_since(TIME_PERIOD.days.ago).count
+      count = Topic.listable_topics.visible.created_since(SiteSetting.tl3_time_period.days.ago).count
       $redis.setex NUM_TOPICS_KEY, CACHE_DURATION, count
       count
     end
@@ -205,7 +207,7 @@ class TrustLevel3Requirements
 
   def self.num_posts_in_time_period
     $redis.get(NUM_POSTS_KEY) || begin
-      count = Post.public_posts.visible.created_since(TIME_PERIOD.days.ago).count
+      count = Post.public_posts.visible.created_since(SiteSetting.tl3_time_period.days.ago).count
       $redis.setex NUM_POSTS_KEY, CACHE_DURATION, count
       count
     end
@@ -214,7 +216,7 @@ class TrustLevel3Requirements
   def flagged_post_ids
     @_flagged_post_ids ||= @user.posts
                                 .with_deleted
-                                .where('created_at > ? AND (spam_count > 0 OR inappropriate_count > 0)', TIME_PERIOD.days.ago)
+                                .where('created_at > ? AND (spam_count > 0 OR inappropriate_count > 0)', time_period.days.ago)
                                 .pluck(:id)
   end
 end

--- a/app/serializers/trust_level3_requirements_serializer.rb
+++ b/app/serializers/trust_level3_requirements_serializer.rb
@@ -16,10 +16,6 @@ class TrustLevel3RequirementsSerializer < ApplicationSerializer
              :num_likes_received_days, :min_likes_received_days,
              :num_likes_received_users, :min_likes_received_users
 
-  def time_period
-    TrustLevel3Requirements::TIME_PERIOD
-  end
-
   def requirements_met
     object.requirements_met?
   end

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2449,7 +2449,7 @@ en:
         unlock_trust_level: "Unlock Trust Level"
         tl3_requirements:
           title: "Requirements for Trust Level 3"
-          table_title: "In the last 100 days:"
+          table_title: "In the last %{time_period} days:"
           value_heading: "Value"
           requirement_heading: "Requirement"
           visits: "Visits"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -997,6 +997,7 @@ en:
     tl2_requires_likes_given: "How many likes a user must cast before promotion to trust level 2."
     tl2_requires_topic_reply_count: "How many topics user must reply to before promotion to trust level 2."
 
+    tl3_time_period: "Trust Level 3 requirements time period"
     tl3_requires_days_visited: "Minimum number of days that a user needs to have visited the site in the last 100 days to qualify for promotion to trust level 3. (0 to 100)"
     tl3_requires_topics_replied_to: "Minimum number of topics a user needs to have replied to in the last 100 days to qualify for promotion to trust level 3. (0 or higher)"
     tl3_requires_topics_viewed: "The percentage of topics created in the last 100 days that a user needs to have viewed to qualify for promotion to trust level 3. (0 to 100)"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -638,6 +638,9 @@ trust:
   tl2_requires_likes_received: 1
   tl2_requires_likes_given: 1
   tl2_requires_topic_reply_count: 3
+  tl3_time_period:
+    default: 100
+    min: 1
   tl3_requires_days_visited:
     default: 50
     min: 0

--- a/spec/models/trust_level3_requirements_spec.rb
+++ b/spec/models/trust_level3_requirements_spec.rb
@@ -14,6 +14,11 @@ describe TrustLevel3Requirements do
   end
 
   describe "requirements" do
+    it "time_period uses site setting" do
+      SiteSetting.stubs(:tl3_time_period).returns(80)
+      expect(tl3_requirements.time_period).to eq(80)
+    end
+
     it "min_days_visited uses site setting" do
       SiteSetting.stubs(:tl3_requires_days_visited).returns(66)
       expect(tl3_requirements.min_days_visited).to eq(66)
@@ -65,13 +70,24 @@ describe TrustLevel3Requirements do
   end
 
   describe "days_visited" do
-    it "counts visits when posts were read no further back than 100 days ago" do
+    it "counts visits when posts were read no further back than 100 days (default time period) ago" do
       user.save
       user.update_posts_read!(1, at: 2.days.ago)
       user.update_posts_read!(1, at: 3.days.ago)
       user.update_posts_read!(0, at: 4.days.ago)
       user.update_posts_read!(3, at: 101.days.ago)
       expect(tl3_requirements.days_visited).to eq(2)
+    end
+
+    it "respects tl3_time_period setting" do
+      SiteSetting.tl3_time_period = 200
+      user.save
+      user.update_posts_read!(1, at: 2.days.ago)
+      user.update_posts_read!(1, at: 3.days.ago)
+      user.update_posts_read!(0, at: 4.days.ago)
+      user.update_posts_read!(3, at: 101.days.ago)
+      user.update_posts_read!(4, at: 201.days.ago)
+      expect(tl3_requirements.days_visited).to eq(3)
     end
   end
 
@@ -93,13 +109,24 @@ describe TrustLevel3Requirements do
   end
 
   describe "topics_viewed" do
-    it "counts topics views within last 100 days, not counting a topic more than once" do
+    it "counts topics views within last 100 days (default time period), not counting a topic more than once" do
       user.save
       make_view(9, 1.day.ago,    user.id)
       make_view(9, 3.days.ago,   user.id) # same topic, different day
       make_view(3, 4.days.ago,   user.id)
       make_view(2, 101.days.ago, user.id) # too long ago
       expect(tl3_requirements.topics_viewed).to eq(2)
+    end
+
+    it "counts topics views within last 200 days, respecting tl3_time_period setting" do
+      SiteSetting.tl3_time_period = 200
+      user.save
+      make_view(9, 1.day.ago,    user.id)
+      make_view(9, 3.days.ago,   user.id) # same topic, different day
+      make_view(3, 4.days.ago,   user.id)
+      make_view(2, 101.days.ago, user.id)
+      make_view(4, 201.days.ago, user.id) # too long ago
+      expect(tl3_requirements.topics_viewed).to eq(3)
     end
   end
 


### PR DESCRIPTION
This PR makes TL3 requirements time period an admin setting.

Feature request here: https://meta.discourse.org/t/make-tl3-100-days-a-changeable-setting/36923

----

@nlalonde can you please review this PR?