### PR TITLE
FIX: Correctly import users and passwords from phpBB 3.1

### DIFF
--- a/script/import_scripts/phpbb3/database/database_3_1.rb
+++ b/script/import_scripts/phpbb3/database/database_3_1.rb
@@ -1,16 +1,20 @@
 require_relative 'database_3_0'
-require_relative '../support/constants/constants'
+require_relative '../support/constants'
 
 module ImportScripts::PhpBB3
   class Database_3_1 < Database_3_0
     def fetch_users(offset)
       query(<<-SQL)
-        SELECT u.user_id, u.user_email, u.username, u.user_password, u.user_regdate, u.user_lastvisit, u.user_ip,
+        SELECT u.user_id, u.user_email, u.username,
+          CASE WHEN u.user_password LIKE '$2y$%'
+            THEN CONCAT('$2a$', SUBSTRING(u.user_password, 5))
+            ELSE u.user_password
+          END AS user_password, u.user_regdate, u.user_lastvisit, u.user_ip,
           u.user_type, u.user_inactive_reason, g.group_name, b.ban_start, b.ban_end, b.ban_reason,
           u.user_posts, f.pf_phpbb_website AS user_website, f.pf_phpbb_location AS user_from,
           u.user_birthday, u.user_avatar_type, u.user_avatar
         FROM #{@table_prefix}_users u
-          JOIN #{@table_prefix}_profile_fields_data f ON (u.user_id = f.user_id)
+          LEFT OUTER JOIN #{@table_prefix}_profile_fields_data f ON (u.user_id = f.user_id)
           JOIN #{@table_prefix}_groups g ON (g.group_id = u.group_id)
           LEFT OUTER JOIN #{@table_prefix}_banlist b ON (
             u.user_id = b.ban_userid AND b.ban_exclude = 0 AND


### PR DESCRIPTION
- [Ruby doesn't support the $2y$ prefix](http://stackoverflow.com/a/20981781) used for bcrypt hashes.
- The importer ignored users that didn't have optional profile fields.