### PR TITLE
Show composer messages popup overtop of preview window

### DIFF
--- a/app/assets/javascripts/discourse/views/composer-messages.js.es6
+++ b/app/assets/javascripts/discourse/views/composer-messages.js.es6
@@ -18,8 +18,7 @@ export default Ember.CollectionView.extend({
     }.on('init'),
 
     _initCss: function() {
-      var composerHeight = $('#reply-control').height() || 0;
-      this.$().css('bottom', composerHeight + "px").show();
+      this.$().show();
     }.on('didInsertElement')
   })
 });

--- a/app/assets/javascripts/discourse/views/composer.js.es6
+++ b/app/assets/javascripts/discourse/views/composer.js.es6
@@ -24,7 +24,6 @@ const ComposerView = Ember.View.extend({
   movePanels(sizePx) {
 
     $('#main-outlet').css('padding-bottom', sizePx);
-    $('.composer-popup').css('bottom', sizePx);
 
     // signal the progress bar it should move!
     this.appEvents.trigger("composer:resized");

--- a/app/assets/stylesheets/desktop/compose.scss
+++ b/app/assets/stylesheets/desktop/compose.scss
@@ -21,6 +21,19 @@
 }
 
 .composer-popup {
+  position: absolute;
+  width: calc(50% - 55px);
+  max-width: 724px;
+  top: 16px;
+  bottom: 16px;
+  left: 50%;
+  // The composer goes off-center at 1550px
+  @media (min-width: 1550px) {
+    left: calc(50% - 15px);
+  }
+  overflow-y: auto;
+  z-index: 110;
+  padding: 10px;
 
   box-shadow: 3px 3px 3px rgba(0,0,0, 0.34);
   background: dark-light-diff($highlight, $secondary, 50%, -80%);
@@ -52,9 +65,6 @@
     opacity: 1.0;
   }
 
-  padding: 10px;
-  width: 600px;
-  position: absolute;
 
   ul.topics {
     list-style: none;
@@ -96,6 +106,7 @@
 
 .composer-popup:nth-of-type(2) {
   margin-left: 10px;
+  width: calc(50% - 65px);
 }
 
 // hide cancel upload link on IE9 (not supported)


### PR DESCRIPTION
This moves the composer messages popup overtop of the composer preview window. This change affects all window heights. It would be possible, but slightly more complicated, to do a media query for the window height and only move the messages for window heights <  725px.

![screenshot 2015-12-28 12 28 08](https://cloud.githubusercontent.com/assets/2975917/12026206/ed30272e-ad6b-11e5-82b8-0ed817ce03be.png)

![screenshot 2015-12-28 12 32 23](https://cloud.githubusercontent.com/assets/2975917/12026218/03ac09f0-ad6c-11e5-88ba-b04174ae440a.png)

![screenshot 2015-12-28 13 55 51](https://cloud.githubusercontent.com/assets/2975917/12026224/0f23af18-ad6c-11e5-91cd-adc093d0b31c.png)
