### PR TITLE
FIX: When 410 is received, display proper error message instead of generic.

### DIFF
--- a/app/assets/javascripts/discourse/models/post-stream.js.es6
+++ b/app/assets/javascripts/discourse/models/post-stream.js.es6
@@ -738,7 +738,8 @@ export default RestModel.extend({
     topic.set('errorLoading', true);
 
     // If the result was 404 the post is not found
-    if (status === 404) {
+    // If it was 410 the post is deleted and the user should not see it
+    if (status === 404 || status === 410) {
       topic.set('notFoundHtml', result.jqXHR.responseText);
       return;
     }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -110,7 +110,7 @@ class ApplicationController < ActionController::Base
     if (request.format && request.format.json?) || (request.xhr?)
       # HACK: do not use render_json_error for topics#show
       if request.params[:controller] == 'topics' && request.params[:action] == 'show'
-        return render status: status_code, layout: false, text: (status_code == 404) ? build_not_found_page(status_code) : I18n.t(type)
+        return render status: status_code, layout: false, text: (status_code == 404 || status_code == 410) ? build_not_found_page(status_code) : I18n.t(type)
       end
 
       render_json_error I18n.t(type), type: type, status: status_code


### PR DESCRIPTION
This fixes
https://meta.discourse.org/t/clicking-a-link-to-a-private-or-deleted-topic-shows-as-a-network-error/35797.