### PR TITLE
fixed password validator on equality with email

### DIFF
--- a/lib/validators/password_validator.rb
+++ b/lib/validators/password_validator.rb
@@ -10,7 +10,7 @@ class PasswordValidator < ActiveModel::EachValidator
       record.errors.add(attribute, :too_short, count: SiteSetting.min_password_length)
     elsif record.username.present? && value == record.username
       record.errors.add(attribute, :same_as_username)
-    elsif record.username.present? && value == record.email
+    elsif record.email.present? && value == record.email
       record.errors.add(attribute, :same_as_email)
     elsif SiteSetting.block_common_passwords && CommonPasswords.common_password?(value)
       record.errors.add(attribute, :common)


### PR DESCRIPTION
Fixed password validator on equality to email, on elsif which check presence of username instead of password