### PR TITLE
Unsubscribe via email

### DIFF
--- a/app/mailers/subscription_mailer.rb
+++ b/app/mailers/subscription_mailer.rb
@@ -1,0 +1,14 @@
+require_dependency 'email/message_builder'
+
+class SubscriptionMailer < ActionMailer::Base
+  include Email::BuildEmailHelper
+
+  def confirm_unsubscribe(user, opts={})
+    unsubscribe_key = DigestUnsubscribeKey.create_key_for(user)
+    build_email user.email,
+                template: "unsubscribe_mailer",
+                site_title: SiteSetting.title,
+                site_domain_name: Discourse.current_hostname,
+                confirm_unsubscribe_link: "#{Discourse.base_url}/unsubscribe/#{unsubscribe_key}?from_all=true"
+  end
+end

--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -307,6 +307,7 @@ class UserNotifications < ActionMailer::Base
       context: context,
       username: username,
       add_unsubscribe_link: !user.staged,
+      add_unsubscribe_via_email_link: user.mailing_list_mode,
       unsubscribe_url: post.topic.unsubscribe_url,
       allow_reply_by_email: allow_reply_by_email,
       use_site_subject: use_site_subject,

--- a/app/views/email/notification.html.erb
+++ b/app/views/email/notification.html.erb
@@ -19,7 +19,7 @@
   <hr>
 
   <div class='footer'>%{respond_instructions}</div>
-  <div class='footer'>%{unsubscribe_link}</div>
+  <div class='footer'>%{unsubscribe_link}%{unsubscribe_via_email_link}</div>
 
 </div>
 

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1104,6 +1104,9 @@ en:
     short_email_length: "Short email length in Bytes"
     display_name_on_email_from: "Display full names on email from fields"
 
+    unsubscribe_via_email: "Allow users to unsubscribe from emails by sending an email with 'unsubscribe' in the subject or body"
+    unsubscribe_via_email_footer: "Attach an unsubscribe link to the footer of sent emails"
+
     pop3_polling_enabled: "Poll via POP3 for email replies."
     pop3_polling_ssl: "Use SSL while connecting to the POP3 server. (Recommended)"
     pop3_polling_period_mins: "The period in minutes between checking the POP3 account for email. NOTE: requires restart."
@@ -1378,6 +1381,17 @@ en:
     ip_address:
       blocked: "New registrations are not allowed from your IP address."
       max_new_accounts_per_registration_ip: "New registrations are not allowed from your IP address (maximum limit reached). Contact a staff member."
+
+  unsubscribe_mailer:
+    subject_template: "Confirm you no longer want to receive email updates from %{site_title}"
+    text_body_template: |
+      Someone (possibly you?) requested to no longer send email updates from %{site_domain_name} to this address.
+      If you with to confirm this, please click this link:
+
+      %{confirm_unsubscribe_link}
+
+
+      I you want to continue receiving email updates, you may ignore this email.
 
   invite_mailer:
     subject_template: "%{invitee_name} invited you to '%{topic_title}' on %{site_domain_name}"
@@ -1940,7 +1954,10 @@ en:
       text_body_template: "The `download_remote_images_to_local` setting was disabled because the disk space limit at `download_remote_images_threshold` was reached."
 
   unsubscribe_link: |
-    To stop receiving notifications for this particular topic, [click here](%{unsubscribe_url}). To unsubscribe from these emails, change your [user preferences](%{user_preferences_url}).
+    To stop receiving notifications for this particular topic, [click here](%{unsubscribe_url}). To unsubscribe from these emails, change your [user preferences](%{user_preferences_url})
+
+  unsubscribe_via_email_link: |
+    or, [click here](mailto:reply@%{hostname}?subject=unsubscribe) to unsubscribe via email.
 
   subject_re: "Re: "
   subject_pm: "[PM] "

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -535,6 +535,10 @@ email:
   short_email_length: 2800
   display_name_on_email_from:
     default: true
+  unsubscribe_via_email:
+    default: true
+  unsubscribe_via_email_footer:
+    default: false
 
 files:
   max_image_size_kb: 3072

--- a/lib/email/message_builder.rb
+++ b/lib/email/message_builder.rb
@@ -63,6 +63,13 @@ module Email
       if @opts[:add_unsubscribe_link]
         unsubscribe_link = PrettyText.cook(I18n.t('unsubscribe_link', template_args), sanitize: false).html_safe
         html_override.gsub!("%{unsubscribe_link}", unsubscribe_link)
+
+        if SiteSetting.unsubscribe_via_email_footer && @opts[:add_unsubscribe_via_email_link]
+          unsubscribe_via_email_link = PrettyText.cook(I18n.t('unsubscribe_via_email_link', hostname: Discourse.current_hostname), sanitize: false).html_safe
+          html_override.gsub!("%{unsubscribe_via_email_link}", unsubscribe_via_email_link)
+        else
+          html_override.gsub!("%{unsubscribe_via_email_link}", "")
+        end
       else
         html_override.gsub!("%{unsubscribe_link}", "")
       end
@@ -103,6 +110,9 @@ module Email
       if @opts[:add_unsubscribe_link]
         body << "\n"
         body << I18n.t('unsubscribe_link', template_args)
+        if SiteSetting.unsubscribe_via_email_footer && @opts[:add_unsubscribe_via_email_link]
+          body << I18n.t('unsubscribe_via_email_link', hostname: Discourse.current_hostname)
+        end
       end
 
       body

--- a/spec/components/email/message_builder_spec.rb
+++ b/spec/components/email/message_builder_spec.rb
@@ -181,6 +181,23 @@ describe Email::MessageBuilder do
 
     end
 
+    context "with unsubscribe_via_email_link true" do
+      let(:message_with_unsubscribe_via_email) { Email::MessageBuilder.new(to_address,
+                                                                           body: 'hello world',
+                                                                           add_unsubscribe_link: true,
+                                                                           add_unsubscribe_via_email_link: true,
+                                                                           unsubscribe_url: "/t/1234/unsubscribe") }
+
+      it "can add an unsubscribe via email link" do
+        SiteSetting.stubs(:unsubscribe_via_email_footer).returns(true)
+        expect(message_with_unsubscribe_via_email.body).to match(/mailto:reply@#{Discourse.current_hostname}\?subject=unsubscribe/)
+      end
+
+      it "does not add unsubscribe via email link without site setting set" do
+        expect(message_with_unsubscribe_via_email.body).to_not match(/mailto:reply@#{Discourse.current_hostname}\?subject=unsubscribe/)        
+      end
+    end
+
   end
 
   context "template_args" do

--- a/spec/controllers/email_controller_spec.rb
+++ b/spec/controllers/email_controller_spec.rb
@@ -39,8 +39,22 @@ describe EmailController do
 
   context '.unsubscribe' do
 
-    let(:user) { Fabricate(:user) }
+    let(:user) { Fabricate(:user, email_digests: true, email_direct: true, email_private_messages: true, email_always: true) }
     let(:key) { DigestUnsubscribeKey.create_key_for(user) }
+
+    context 'from confirm unsubscribe email' do
+      before do
+        get :unsubscribe, key: key, from_all: true
+        user.reload
+      end
+
+      it 'unsubscribes from all emails' do
+        expect(user.email_digests).to eq false
+        expect(user.email_direct).to eq false
+        expect(user.email_private_messages).to eq false
+        expect(user.email_always).to eq false
+      end
+    end
 
     context 'with a valid key' do
       before do

--- a/spec/fixtures/emails/unsubscribe_body.eml
+++ b/spec/fixtures/emails/unsubscribe_body.eml
@@ -1,0 +1,10 @@
+Return-Path: <discourse@bar.com>
+From: Foo Bar <discourse@bar.com>
+To: reply+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com
+Date: Thu, 13 Jun 2013 17:03:48 -0400
+Message-ID: <55@foo.bar.mail>
+Mime-Version: 1.0
+Content-Type: text/plain;
+Content-Transfer-Encoding: 7bit
+
+UNSUBSCRIBE

--- a/spec/fixtures/emails/unsubscribe_subject.eml
+++ b/spec/fixtures/emails/unsubscribe_subject.eml
@@ -1,0 +1,11 @@
+Return-Path: <discourse@bar.com>
+From: Foo Bar <discourse@bar.com>
+To: reply@bar.com
+Date: Thu, 13 Jun 2013 17:03:48 -0400
+Message-ID: <56@foo.bar.mail>
+Subject: UnSuBScRiBe
+Mime-Version: 1.0
+Content-Type: text/plain;
+Content-Transfer-Encoding: 7bit
+
+I've basically had enough of your mailing list and would very much like it if you went away.


### PR DESCRIPTION
Thought I'd open this up for review, as I know it's a somewhat contentious feature.

Currently:
- Emailing reply@ or reply+{key}@<hostname> initiates an 'unsubscribe from all' confirmation email
- ^^ this can be controlled by site setting, default on
- All user notification emails can have an additional link in them to initiate the 'unsubscribe from all' confirmation email from there via a mailto: link
- ^^ this can be controlled by site setting, default off
- Clicking on the confirmation link in the email turns off the digest, email_via_pm, and email_direct settings on the user (and email_always for good measure)
(is this satisfactory, or is there more that needs to be done to 'shut off all emails' to an address?)

TODO: 
- rate limit kicking off the unsubscribe process, especially for when the second site setting is flipped to 'on'.
- Force the user to visit the site and click a button to kick off the unsubscribe process, via Jeff's comments here: https://meta.discourse.org/t/feature-unsubscribe-from-topic-by-email/37051/9?u=gdpelican (?)