### PR TITLE
FEATURE: allow users to wikify their own posts based on trust level

### DIFF
--- a/app/assets/javascripts/discourse/components/post-menu.js.es6
+++ b/app/assets/javascripts/discourse/components/post-menu.js.es6
@@ -349,6 +349,21 @@ const PostMenuComponent = Ember.Component.extend(StringBuffer, {
     this.sendAction('toggleBookmark', post);
   },
 
+  // Wiki button
+  buttonForWiki(post) {
+    if (!post.get('can_wiki')) return;
+
+    if (post.get('wiki')) {
+      return new Button('wiki', 'post.controls.unwiki', 'pencil-square-o', {className: 'wiki wikied'});
+    } else {
+      return new Button('wiki', 'post.controls.wiki', 'pencil-square-o', {className: 'wiki'});
+    }
+  },
+
+  clickWiki(post) {
+    this.sendAction('toggleWiki', post);
+  },
+
   buttonForAdmin() {
     if (!Discourse.User.currentProp('canManageTopic')) { return; }
     return new Button('admin', 'post.controls.admin', 'wrench');
@@ -357,10 +372,7 @@ const PostMenuComponent = Ember.Component.extend(StringBuffer, {
   renderAdminPopup(post, buffer) {
     if (!Discourse.User.currentProp('canManageTopic')) { return; }
 
-    const isWiki = post.get('wiki'),
-          wikiIcon = iconHTML('pencil-square-o'),
-          wikiText = isWiki ? I18n.t('post.controls.unwiki') : I18n.t('post.controls.wiki'),
-          isModerator = post.get('post_type') === this.site.get('post_types.moderator_action'),
+    const isModerator = post.get('post_type') === this.site.get('post_types.moderator_action'),
           postTypeIcon = iconHTML('shield'),
           postTypeText = isModerator ? I18n.t('post.controls.revert_to_regular') : I18n.t('post.controls.convert_to_moderator'),
           rebakePostIcon = iconHTML('cog'),
@@ -373,7 +385,6 @@ const PostMenuComponent = Ember.Component.extend(StringBuffer, {
     const html = '<div class="post-admin-menu popup-menu">' +
                  '<h3>' + I18n.t('admin_title') + '</h3>' +
                  '<ul>' +
-                   '<li class="btn" data-action="toggleWiki">' + wikiIcon + wikiText + '</li>' +
                    (Discourse.User.currentProp('staff') ? '<li class="btn" data-action="togglePostType">' + postTypeIcon + postTypeText + '</li>' : '') +
                    '<li class="btn" data-action="rebakePost">' + rebakePostIcon + rebakePostText + '</li>' +
                    (post.hidden ? '<li class="btn" data-action="unhidePost">' + unhidePostIcon + unhidePostText + '</li>' : '') +
@@ -391,10 +402,6 @@ const PostMenuComponent = Ember.Component.extend(StringBuffer, {
       $postAdminMenu.hide();
       $("html").off("mouseup.post-admin-menu");
     });
-  },
-
-  clickToggleWiki() {
-    this.sendAction('toggleWiki', this.get('post'));
   },
 
   clickTogglePostType() {

--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -174,6 +174,10 @@ nav.post-controls {
           box-shadow: none;
         }
 
+        &.wikied {
+          color: green;
+        }
+
         &.bookmark {padding: 8px 11px; }
 
         .read-icon {

--- a/app/assets/stylesheets/mobile/topic-post.scss
+++ b/app/assets/stylesheets/mobile/topic-post.scss
@@ -58,6 +58,7 @@ button {
     margin:10px 0 10px 0;
   }
   &.has-like {color: $love;}
+  &.wikied { color: green; }
   .read-icon {
     &:before {
       font-family: "FontAwesome";

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -305,9 +305,9 @@ class PostsController < ApplicationController
   end
 
   def wiki
-    guardian.ensure_can_wiki!
-
     post = find_post_from_params
+    guardian.ensure_can_wiki!(post)
+
     post.revise(current_user, { wiki: params[:wiki] })
 
     render nothing: true

--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -38,6 +38,7 @@ class PostSerializer < BasicPostSerializer
              :can_edit,
              :can_delete,
              :can_recover,
+             :can_wiki,
              :link_counts,
              :read,
              :user_title,
@@ -128,6 +129,10 @@ class PostSerializer < BasicPostSerializer
 
   def can_recover
     scope.can_recover_post?(object)
+  end
+
+  def can_wiki
+    scope.can_wiki?(object)
   end
 
   def display_username

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1017,6 +1017,8 @@ en:
 
     min_trust_to_edit_wiki_post: "The minimum trust level required to edit post marked as wiki."
 
+    min_trust_to_allow_self_wiki: "The minimum trust level required to make user's own post wiki."
+
     min_trust_to_send_messages: "The minimum trust level required to create new private messages."
 
     newuser_max_links: "How many links a new user can add to a post."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -105,7 +105,7 @@ basic:
   post_menu:
     client: true
     type: list
-    default: 'like-count|like|share|flag|edit|bookmark|delete|admin|reply'
+    default: 'like-count|like|share|flag|edit|bookmark|wiki|delete|admin|reply'
     choices:
      - like-count
      - like
@@ -116,10 +116,11 @@ basic:
      - bookmark
      - admin
      - reply
+     - wiki
   post_menu_hidden_items:
     client: true
     type: list
-    default: 'bookmark|edit|delete|admin'
+    default: 'bookmark|edit|wiki|delete|admin'
     choices:
      - like
      - edit
@@ -129,6 +130,7 @@ basic:
      - bookmark
      - admin
      - reply
+     - wiki
   share_links:
     client: true
     type: list
@@ -622,6 +624,9 @@ trust:
     enum: 'TrustLevelSetting'
   min_trust_to_edit_wiki_post:
     default: 1
+    enum: 'TrustLevelSetting'
+  min_trust_to_allow_self_wiki:
+    default: 3
     enum: 'TrustLevelSetting'
   min_trust_to_send_messages:
     default: 1

--- a/lib/guardian/post_guardian.rb
+++ b/lib/guardian/post_guardian.rb
@@ -173,8 +173,9 @@ module PostGuardian
     is_admin?
   end
 
-  def can_wiki?
-    is_staff? || @user.has_trust_level?(TrustLevel[4])
+  def can_wiki?(post)
+    return false unless authenticated?
+    is_staff? || @user.has_trust_level?(TrustLevel[4]) || (@user.has_trust_level?(SiteSetting.min_trust_to_allow_self_wiki) && is_my_own?(post))
   end
 
   def can_change_post_type?

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -408,7 +408,7 @@ describe PostsController do
       let(:post) {Fabricate(:post, user: user)}
 
       it "raises an error if the user doesn't have permission to wiki the post" do
-        Guardian.any_instance.expects(:can_wiki?).returns(false)
+        Guardian.any_instance.expects(:can_wiki?).with(post).returns(false)
 
         xhr :put, :wiki, post_id: post.id, wiki: 'true'
 
@@ -416,7 +416,7 @@ describe PostsController do
       end
 
       it "can wiki a post" do
-        Guardian.any_instance.expects(:can_wiki?).returns(true)
+        Guardian.any_instance.expects(:can_wiki?).with(post).returns(true)
 
         xhr :put, :wiki, post_id: post.id, wiki: 'true'
 
@@ -426,7 +426,7 @@ describe PostsController do
 
       it "can unwiki a post" do
         wikied_post = Fabricate(:post, user: user, wiki: true)
-        Guardian.any_instance.expects(:can_wiki?).returns(true)
+        Guardian.any_instance.expects(:can_wiki?).with(wikied_post).returns(true)
 
         xhr :put, :wiki, post_id: wikied_post.id, wiki: 'false'
 


### PR DESCRIPTION
Feature request here: https://meta.discourse.org/t/setting-min-trust-to-wiki-fy-post/32265/14?u=techapj

This PR adds site setting `min_trust_to_allow_self_wiki` which allows users to make their own posts Wiki. The default trust level for self wiki is `3`.

There is also a UX change here: Instead of adding "Make Wiki" button in post Admin wrench (like we do now), I added a separate button for Wiki, as this is no longer a Staff/Elder only feature now.

*Screenshots*

Not Wiki post:

![screen shot 2016-01-11 at 22 08 53](https://cloud.githubusercontent.com/assets/5732281/12240799/7e43cd84-b8b5-11e5-95b8-a94a47e84394.png)

Wiki post:

![screen shot 2016-01-11 at 22 09 23](https://cloud.githubusercontent.com/assets/5732281/12240804/84c918da-b8b5-11e5-85d9-22b3fbeabeae.png)