### PR TITLE
save height on small screens

### DIFF
--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -1026,3 +1026,16 @@ and (max-width : 767px) {
   }
 
 }
+
+@media all
+and (max-height: 700px) {
+
+   .post-menu-area {
+      margin-bottom: 0px;
+      margin-top: -18px;
+   }
+
+   .topic-body {
+      padding: 5px 11px 2px;
+   }
+}


### PR DESCRIPTION
There is a lot of white space between each post, that annoys on small screens.

This will minimize the used space if the screen is lower than 700px in height.

Rework of #3820