### PR TITLE
FIX: Move store for readonly mode to DB.

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -932,6 +932,7 @@ en:
     github_client_id: "Client id for Github authentication, registered at https://github.com/settings/applications"
     github_client_secret: "Client secret for Github authentication, registered at https://github.com/settings/applications"
 
+    readonly_mode: "Sets the site to read-only mode."
     allow_restore: "Allow restore, which can replace ALL site data! Leave false unless you plan to restore a backup"
     maximum_backups: "The maximum amount of backups to keep on disk. Older backups are automatically deleted"
     automatic_backups_enabled: "Run automatic backups as defined in backup frequency"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -844,6 +844,7 @@ legal:
     default: ''
 
 backups:
+  readonly_mode: false
   allow_restore:
     default: false
   maximum_backups:


### PR DESCRIPTION
* The thread dies when the container is rebuilt causing the site
  to come out of readonly mode.

Not sure if there were other considerations previously.
cc/ @SamSaffron  @ZogStriP 