### PR TITLE
FIX: Incorrect subfolder authors urls when embedding

### DIFF
--- a/app/views/embed/comments.html.erb
+++ b/app/views/embed/comments.html.erb
@@ -16,11 +16,11 @@
       <%- end %>
 
       <div class='author'>
-        <a href='/users/<%= post.username %>' target="_blank"><img src='<%= post.user.small_avatar_url %>' alt=''></a>
+        <a href='<%= Discourse.base_url %>/users/<%= post.username %>' target="_blank"><img src='<%= post.user.small_avatar_url %>' alt=''></a>
       </div>
       <div class='cooked'>
         <h3 class='username'>
-          <a href='/users/<%= post.username %>' target="_blank" class='<% if post.user.staff? %>staff<% end %><% if post.user.new_user? %>new-user<% end %>'><%= post.user.username %></a>
+          <a href='<%= Discourse.base_url %>/users/<%= post.username %>' target="_blank" class='<% if post.user.staff? %>staff<% end %><% if post.user.new_user? %>new-user<% end %>'><%= post.user.username %></a>
           <%- if post.user.title.present? %>
             <span class='title'><%= post.user.title %></span>
           <%- end %>


### PR DESCRIPTION
Fix URLs for post authors and their avatars in embedded comments so they work when using subfolder installation.
See [this bug](https://meta.discourse.org/t/links-without-sub-folder-path-in-embedded-comments-continue-discussion-and-user-links/37836/3).
PS: I'm using `Discourse.base_url` here, may be it worth using `Discourse.base_uri` instead?
