### PR TITLE
UX: set max-width for topic list

### DIFF
--- a/app/assets/stylesheets/mobile/topic-list.scss
+++ b/app/assets/stylesheets/mobile/topic-list.scss
@@ -77,6 +77,7 @@
   td {
     padding: 7px 0;
     color: dark-light-choose(scale-color($primary, $lightness: 50%), scale-color($secondary, $lightness: 50%));
+    max-width: 300px;
   }
 
   a.title {color: $primary;}


### PR DESCRIPTION
Bug report: https://meta.discourse.org/t/horizontal-scroll-on-mobile/37858

Before:

![screenshot_2016-01-15-01-40-52](https://cloud.githubusercontent.com/assets/5732281/12336380/47b4ac4e-bb2a-11e5-9fcb-1cc8e5e042f9.png)

After:

![screenshot_2016-01-15-01-40-15](https://cloud.githubusercontent.com/assets/5732281/12336379/47b3cb58-bb2a-11e5-839f-4f4f0d282deb.png)

Can be reproduced on Latest Chrome on Android.

----

Tested the fix on:

- Chrome: OnePlus One (Android 5), iPhone 6, iPad mini 2, iPad 4
- Safari: iPhone 6, iPad mini 2, iPad 4

in portrait/landscape mode.