### PR TITLE
FIX: category-dropdown-menu badge-wrapper width

### DIFF
--- a/app/assets/stylesheets/common/components/badges.css.scss
+++ b/app/assets/stylesheets/common/components/badges.css.scss
@@ -190,6 +190,8 @@
         line-height: 1;
       }
     .badge-wrapper {
+      box-sizing: border-box;
+
       &.bar {
         padding: 5px 0;
         width: 100%;


### PR DESCRIPTION
The category-dropdown badge-wrapper has it's width set at 100%. Any added side-padding causes it to extend past its containing box. Changing its box-sizing to `border-box`  fixes this.

For consistency, I have made the change to `.list-controls .category-dropdown-menu .badge-wrapper`. The only badge-wrapper class that has side padding is `.badge-wrapper.bullet`, so it would also be possible to just make the change there.

see: https://meta.discourse.org/t/background-of-selected-from-category-dropdown-extends-past-menu-on-ios/38017 