### PR TITLE
FIX: avatar and username should be side-by-side in post-notification email

### DIFF
--- a/app/views/email/_post.html.erb
+++ b/app/views/email/_post.html.erb
@@ -1,19 +1,25 @@
 <table class='post-wrapper <%= post.whisper? ? "whisper" : "" %>'>
   <tbody>
     <tr>
-      <td class='user-avatar'>
-        <img src="<%= post.user.small_avatar_url %>" title="<%= post.user.username%>">
-      </td>
       <td>
-        <a class="username" href="<%=Discourse.base_url%>/users/<%= post.user.username_lower%>" target="_blank"><%= post.user.username %></a>
-        <%- if show_name_on_post(post) %>
-          <a class="user-name" href="<%=Discourse.base_url%>/users/<%= post.user.username_lower%>" target="_blank"><%= post.user.name %></a>
-        <% end %>
-        <%- if post.user.title.present? %>
-          <span class='user-title'><%= post.user.title %></span>
-        <% end %>
-        <br>
-        <span class='notification-date'><%= l post.created_at, format: :short_no_year %></span>
+        <table>
+          <tr>
+            <td class='user-avatar'>
+              <img src="<%= post.user.small_avatar_url %>" title="<%= post.user.username%>">
+            </td>
+            <td>
+              <a class="username" href="<%=Discourse.base_url%>/users/<%= post.user.username_lower%>" target="_blank"><%= post.user.username %></a>
+              <%- if show_name_on_post(post) %>
+                <a class="user-name" href="<%=Discourse.base_url%>/users/<%= post.user.username_lower%>" target="_blank"><%= post.user.name %></a>
+              <% end %>
+              <%- if post.user.title.present? %>
+                <span class='user-title'><%= post.user.title %></span>
+              <% end %>
+              <br>
+              <span class='notification-date'><%= l post.created_at, format: :short_no_year %></span>
+            </td>
+          </tr>
+        </table>
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
On Outlook 2013 the username is pushed to the right edge of the post-notification email. See: https://meta.discourse.org/t/first-link-in-post-footer-very-distracting/37726/26?u=simon_cossar

The fix is to put the avatar/username row into a nested table. I've copied and pasted the html source from a user-notification email into the Litmus email builder. This is from my local computer, so the avatar images aren't being generated.

Here are before the fix and after the fix screenshots  on Outlook 2013 and Gmail webmail:


(before) ![screenshot 2016-01-17 12 42 17](https://cloud.githubusercontent.com/assets/2975917/12379925/9e8ab05e-bd19-11e5-9111-ba315216c472.png)

(after)![screenshot 2016-01-17 12 33 41](https://cloud.githubusercontent.com/assets/2975917/12379927/a90e349c-bd19-11e5-8f7b-963ec6bd224e.png)

(before)![screenshot 2016-01-17 12 42 43](https://cloud.githubusercontent.com/assets/2975917/12379928/b198d68a-bd19-11e5-95d2-98574c3c509d.png)

(after)![screenshot 2016-01-17 12 34 21](https://cloud.githubusercontent.com/assets/2975917/12379932/c7150664-bd19-11e5-9b65-161ec80c0a12.png)

On Outlook 2013 it displays properly with the change. On Gmail webmail it displays properly in both instances.

I'll be able to test this more thoroughly later this week.

 