### PR TITLE
FIX: email button padding for Outlook

### DIFF
--- a/lib/email/styles.rb
+++ b/lib/email/styles.rb
@@ -214,7 +214,7 @@ module Email
         element.css('a').each do |inner|
           # we want the first footer link to be specially highlighted as IMPORTANT
           if footernum == 0 and linknum == 0
-            inner['style'] = "font-size: 16px; font-family: Helvetica, Arial, sans-serif; background-color: #006699; color:#ffffff; border-top: 12px solid #006699; border-bottom: 12px solid #006699; border-right: 18px solid #006699; border-left: 18px solid #006699; display: inline-block;"
+            inner['style'] = "font-size: 16px; background-color: #006699; color:#ffffff; border-top: 12px solid #006699; border-bottom: 12px solid #006699; border-right: 18px solid #006699; border-left: 18px solid #006699; display: inline-block;"
           else
             inner['style'] = "color:#666;"
           end

--- a/lib/email/styles.rb
+++ b/lib/email/styles.rb
@@ -214,7 +214,7 @@ module Email
         element.css('a').each do |inner|
           # we want the first footer link to be specially highlighted as IMPORTANT
           if footernum == 0 and linknum == 0
-            inner['style'] = "background-color:#006699;color:#fff;padding:4px 6px;"
+            inner['style'] = "font-size: 16px; font-family: Helvetica, Arial, sans-serif; background-color: #006699; color:#ffffff; border-top: 12px solid #006699; border-bottom: 12px solid #006699; border-right: 18px solid #006699; border-left: 18px solid #006699; display: inline-block;"
           else
             inner['style'] = "color:#666;"
           end

--- a/lib/email/styles.rb
+++ b/lib/email/styles.rb
@@ -214,7 +214,7 @@ module Email
         element.css('a').each do |inner|
           # we want the first footer link to be specially highlighted as IMPORTANT
           if footernum == 0 and linknum == 0
-            inner['style'] = "font-size: 16px; background-color: #006699; color:#ffffff; border-top: 12px solid #006699; border-bottom: 12px solid #006699; border-right: 18px solid #006699; border-left: 18px solid #006699; display: inline-block;"
+            inner['style'] = "background-color: #006699; color:#ffffff; border-top: 6px solid #006699; border-right: 8px solid #006699; border-bottom: 6px solid #006699; border-left: 6px solid #006699; display: inline-block;"
           else
             inner['style'] = "color:#666;"
           end

--- a/lib/email/styles.rb
+++ b/lib/email/styles.rb
@@ -214,7 +214,7 @@ module Email
         element.css('a').each do |inner|
           # we want the first footer link to be specially highlighted as IMPORTANT
           if footernum == 0 and linknum == 0
-            inner['style'] = "background-color: #006699; color:#ffffff; border-top: 6px solid #006699; border-right: 8px solid #006699; border-bottom: 6px solid #006699; border-left: 6px solid #006699; display: inline-block;"
+            inner['style'] = "background-color: #006699; color:#ffffff; border-top: 4px solid #006699; border-right: 6px solid #006699; border-bottom: 4px solid #006699; border-left: 6px solid #006699; display: inline-block;"
           else
             inner['style'] = "color:#666;"
           end


### PR DESCRIPTION
The 'Visit Topic' button for emails currently has no horizontal padding on Outlook 2013. This is because Outlook doesn't recognize horizontal padding on the `<a>` tag. 

The general recommendation for buttons in html emails is to put the link in a table `td` element. That works, but to do it for the 'Visit Topic' link would involve changing some code - the link would need to be separated from the respond instructions in `user_notifications.visit_link_to_respond`.

Instead of doing that, this PR pads out the link with a borders. The only downside that I can see is that the border is slightly narrower on Outlook than on other clients. See https://litmus.com/blog/a-guide-to-bulletproof-buttons-in-email-design ( 3) BORDER-BASED BUTTONS) for a reference.

You might want to reduce the font-size and border widths from what I have set.

It is possible to add some extra horizontal padding to Outlook 2013 by conditionally adding `&nbsp;` characters on either side of the link, but to do this would require separating the link from the reply text.

Here are some screen shots:

![screenshot 2016-01-18 14 29 36](https://cloud.githubusercontent.com/assets/2975917/12404437/6eeffc3c-bdf0-11e5-99e5-7ddc6add6ab1.png)

![screenshot 2016-01-18 14 26 54](https://cloud.githubusercontent.com/assets/2975917/12404445/7b687c78-bdf0-11e5-87f7-4399cf88aaba.png)


![screenshot 2016-01-18 14 27 57](https://cloud.githubusercontent.com/assets/2975917/12404453/866b67ca-bdf0-11e5-8643-79d91743971c.png)

![screenshot 2016-01-18 14 28 25](https://cloud.githubusercontent.com/assets/2975917/12404462/94fc0e98-bdf0-11e5-9fc7-22a95abf26e1.png)



 
