### PR TITLE
UX: Distinguish between noun and verb for "Archive"

### DIFF
--- a/app/assets/javascripts/discourse/templates/user/messages.hbs
+++ b/app/assets/javascripts/discourse/templates/user/messages.hbs
@@ -54,7 +54,7 @@
 
     {{#if canArchive}}
     <button {{action "archive"}} class="btn btn-archive">
-      {{i18n "user.messages.archive"}}
+      {{i18n "user.messages.move_to_archive"}}
     </button>
     {{/if}}
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -525,6 +525,7 @@ en:
         groups: "My Groups"
         bulk_select: "Select messages"
         move_to_inbox: "Move to Inbox"
+        move_to_archive: "Archive"
         failed_to_move: "Failed to move selected messages (perhaps your network is down)"
         select_all: "Select All"
 


### PR DESCRIPTION
The noun "archive" shouldn't be reused as verb.

![image](https://cloud.githubusercontent.com/assets/473736/12596026/83722e52-c47e-11e5-9444-87ad8d03ba08.png)