### PR TITLE
Replace uncategorized_description setting with translation

### DIFF
--- a/app/serializers/basic_category_serializer.rb
+++ b/app/serializers/basic_category_serializer.rb
@@ -26,7 +26,7 @@ class BasicCategorySerializer < ApplicationSerializer
   end
 
   def description
-    object.uncategorized? ? SiteSetting.uncategorized_description : object.description
+    object.uncategorized? ? I18n.t('category.uncategorized_description') : object.description
   end
 
   def can_edit

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -364,6 +364,7 @@ en:
         one: "Can't delete this category because is has 1 topic. Oldest topic is %{topic_link}."
         other: "Can't delete this category because it has %{count} topics. Oldest topic is %{topic_link}."
       topic_exists_no_oldest: "Can't delete this category because topic count is %{count}."
+    uncategorized_description: "Topics that don't need a category, or don't fit into any other existing category."
   trust_levels:
     newuser:
       title: "new user"
@@ -764,7 +765,6 @@ en:
     min_search_term_length: "Minimum valid search term length in characters"
     search_tokenize_chinese_japanese_korean: "Force search to tokenize Chinese/Japanese/Korean even on non CJK sites"
     allow_uncategorized_topics: "Allow topics to be created without a category. WARNING: If there are any uncategorized topics, you must recategorize them before turning this off."
-    uncategorized_description: "The description of the uncategorized category. Leave blank for no description."
     allow_duplicate_topic_titles: "Allow topics with identical, duplicate titles."
     unique_posts_mins: "How many minutes before a user can make a post with the same content again"
     educate_until_posts: "When the user starts typing their first (n) new posts, show the pop-up new user education panel in the composer."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -394,7 +394,6 @@ posting:
     client: true
     default: true
     refresh: true
-  uncategorized_description: "Topics that don't need a category, or don't fit into any other existing category."
   allow_duplicate_topic_titles: false
   min_title_similar_length:
     client: true

--- a/db/migrate/20160127222802_migrate_uncategorized_description_setting.rb
+++ b/db/migrate/20160127222802_migrate_uncategorized_description_setting.rb
@@ -1,0 +1,11 @@
+class MigrateUncategorizedDescriptionSetting < ActiveRecord::Migration
+  def change
+    execute "INSERT INTO translation_overrides (locale, translation_key, value, created_at, updated_at)
+             SELECT '#{I18n.locale}', 'category.uncategorized_description', value, created_at, updated_at
+             FROM site_settings
+             WHERE name = 'uncategorized_description'
+               AND value <> 'Topics that don''t need a category, or don''t fit into any other existing category.'"
+
+    execute "DELETE FROM site_settings WHERE name = 'uncategorized_description'"
+  end
+end


### PR DESCRIPTION
Moves the `uncategorized_description` site setting into a locale file.
The existing setting value gets migrated into the `translation_overrides` table.

https://meta.discourse.org/t/new-localizable-resources/21452