### PR TITLE
Move notification layout styles inline, into the layout

### DIFF
--- a/app/views/layouts/user_notifications.html.erb
+++ b/app/views/layouts/user_notifications.html.erb
@@ -13,7 +13,7 @@
   </style>
   <![endif]-->
 </head>
-<body style="Margin:0;padding:0;min-width:100%;background-color:#ffffff;">
+<body style="margin:0;padding:0;min-width:100%;background-color:#ffffff;">
 <center style="width:100%;table-layout:fixed;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%;">
   <div style="max-width:600px;">
     <!--[if (gte mso 9)|(IE)]>
@@ -21,7 +21,7 @@
     <tr>
     <td>
     <![endif]-->
-    <table align="center" style="Margin:0 auto;width:100%;max-width:600px;">
+    <table align="center" style="margin:0 auto;width:100%;max-width:600px;">
       <tr>
         <td style="padding:10px;">
 

--- a/app/views/layouts/user_notifications.html.erb
+++ b/app/views/layouts/user_notifications.html.erb
@@ -13,17 +13,17 @@
   </style>
   <![endif]-->
 </head>
-<body>
-<center class="wrapper">
-  <div class="webkit">
+<body style="Margin:0;padding:0;min-width:100%;background-color:#ffffff;">
+<center style="width:100%;table-layout:fixed;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%;">
+  <div style="max-width:600px;">
     <!--[if (gte mso 9)|(IE)]>
     <table width="600" align="center">
     <tr>
     <td>
     <![endif]-->
-    <table class="outer" align="center">
+    <table align="center" style="Margin:0 auto;width:100%;max-width:600px;">
       <tr>
-        <td class="container">
+        <td style="padding:10px;">
 
           <%= yield %>
 

--- a/lib/email/styles.rb
+++ b/lib/email/styles.rb
@@ -91,10 +91,6 @@ module Email
       style('.rtl', 'direction: rtl;')
       style('td.body', 'padding-top:5px;', colspan: "2")
       style('.whisper td.body', 'font-style: italic; color: #9c9c9c;')
-      style('.wrapper', 'width:100%;table-layout:fixed;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%;')
-      style('.webkit', 'max-width:600px;')
-      style('.outer', 'Margin: 0 auto; width: 100%; max-width: 600px;')
-      style('.container', 'padding: 10px;')
       correct_first_body_margin
       correct_footer_style
       reset_tables
@@ -142,7 +138,6 @@ module Email
     end
 
     def format_html
-      style('body', 'Margin: 0;padding:0;min-width:100%;background-color:#ffffff;')
       style('h3', 'margin: 15px 0 20px 0;')
       style('hr', 'background-color: #ddd; height: 1px; border: 1px;')
       style('a', 'text-decoration: none; font-weight: bold; color: #006699;')


### PR DESCRIPTION
This is the easiest way that I can see to get the layout styles included for the email digest. Currently, the email digest uses the user_notification layout, but the styles for the layout are not being inlined. This is because `Styles#format_notification` is not called for the email digest. The styles cannot be included in `Styles#format_html`, because, for the notifications, that method is called after the classes have been stripped from the html.

Without this change the digest is very wide on Outlook 2013.