### PR TITLE
Move from [] -> Notification.none

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -148,7 +148,7 @@ class Notification < ActiveRecord::Base
         end
       end.take(count)
     else
-      []
+      Notification.none
     end
 
   end


### PR DESCRIPTION
Returning [] as an 'empty collection' generally needs more code when calling it to do with the response.
e.g. in the case of 
Replacing it with `.none` is a pretty safe bet.

http://apidock.com/rails/v4.0.2/ActiveRecord/QueryMethods/none