### PR TITLE
Feature: (WIP) Send email notifications in user's preferred language

### DIFF
--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -11,37 +11,43 @@ class UserNotifications < ActionMailer::Base
   def signup(user, opts={})
     build_email(user.email,
                 template: "user_notifications.signup",
+                locale: user_locale(user),
                 email_token: opts[:email_token])
   end
 
   def signup_after_approval(user, opts={})
     build_email(user.email,
                 template: 'user_notifications.signup_after_approval',
+                locale: user_locale(user),
                 email_token: opts[:email_token],
-                new_user_tips: I18n.t('system_messages.usage_tips.text_body_template', base_url: Discourse.base_url))
+                new_user_tips: I18n.t('system_messages.usage_tips.text_body_template', base_url: Discourse.base_url, locale: locale))
   end
 
   def authorize_email(user, opts={})
     build_email(user.email,
                 template: "user_notifications.authorize_email",
+                locale: user_locale(user),
                 email_token: opts[:email_token])
   end
 
   def forgot_password(user, opts={})
     build_email(user.email,
                 template: user.has_password? ? "user_notifications.forgot_password" : "user_notifications.set_password",
+                locale: user_locale(user),
                 email_token: opts[:email_token])
   end
 
   def admin_login(user, opts={})
     build_email(user.email,
                 template: "user_notifications.admin_login",
+                locale: user_locale(user),
                 email_token: opts[:email_token])
   end
 
   def account_created(user, opts={})
     build_email(user.email,
                 template: "user_notifications.account_created",
+                locale: user_locale(user),
                 email_token: opts[:email_token])
   end
 
@@ -181,6 +187,10 @@ class UserNotifications < ActionMailer::Base
 
   protected
 
+  def user_locale(user)
+    user.respond_to?(:locale) ? user.locale : nil
+  end
+
   def email_post_markdown(post)
     result = "[email-indent]\n"
     result << "#{post.raw}\n\n"
@@ -264,6 +274,7 @@ class UserNotifications < ActionMailer::Base
     from_alias = opts[:from_alias]
     notification_type = opts[:notification_type]
     user = opts[:user]
+    locale = user_locale(user)
 
     # category name
     category = Topic.find_by(id: post.topic_id).category
@@ -338,6 +349,7 @@ class UserNotifications < ActionMailer::Base
       site_description: SiteSetting.site_description,
       site_title: SiteSetting.title,
       style: :notification,
+      locale: locale
     }
 
     # If we have a display name, change the from address

--- a/lib/email/message_builder.rb
+++ b/lib/email/message_builder.rb
@@ -28,7 +28,7 @@ module Email
       }.merge!(@opts)
 
       if @template_args[:url].present?
-        @template_args[:header_instructions] = I18n.t('user_notifications.header_instructions')
+        @template_args[:header_instructions] = I18n.t('user_notifications.header_instructions', locale: @opts[:locale])
 
         if @opts[:include_respond_instructions] == false
           @template_args[:respond_instructions] = ''
@@ -67,7 +67,7 @@ module Email
         html_override.gsub!("%{unsubscribe_link}", unsubscribe_link)
 
         if SiteSetting.unsubscribe_via_email_footer && @opts[:add_unsubscribe_via_email_link]
-          unsubscribe_via_email_link = PrettyText.cook(I18n.t('unsubscribe_via_email_link', hostname: Discourse.current_hostname), sanitize: false).html_safe
+          unsubscribe_via_email_link = PrettyText.cook(I18n.t('unsubscribe_via_email_link', hostname: Discourse.current_hostname, locale: @opts[:locale]), sanitize: false).html_safe
           html_override.gsub!("%{unsubscribe_via_email_link}", unsubscribe_via_email_link)
         else
           html_override.gsub!("%{unsubscribe_via_email_link}", "")
@@ -114,7 +114,7 @@ module Email
         body << "\n"
         body << I18n.t('unsubscribe_link', template_args)
         if SiteSetting.unsubscribe_via_email_footer && @opts[:add_unsubscribe_via_email_link]
-          body << I18n.t('unsubscribe_via_email_link', hostname: Discourse.current_hostname)
+          body << I18n.t('unsubscribe_via_email_link', hostname: Discourse.current_hostname, locale: @opts[:locale])
         end
       end
 


### PR DESCRIPTION
This is a part of the larger feature that is outlined in this topic:

https://meta.discourse.org/t/variable-default-interface-language-for-new-users/33741/8

Currently, all email notifications are sent in the site's default language. This PR adds a `locale` option to each of the notification methods (except digest) in `message_builder.rb`, so that notifications are sent in the user's preferred locale.

I have finished the rest of the larger feature  for setting the user's locale from the accept-language headers. I'll send it in a separate PR tomorrow. Any feedback on this would be greatly appreciated.