### PR TITLE
Take filename to write to as optional parameter to export_category

### DIFF
--- a/lib/import_export/import_export.rb
+++ b/lib/import_export/import_export.rb
@@ -6,8 +6,8 @@ require "json"
 
 module ImportExport
 
-  def self.export_category(category_id)
-    ImportExport::CategoryExporter.new(category_id).perform.save_to_file
+  def self.export_category(category_id, filename=nil)
+    ImportExport::CategoryExporter.new(category_id).perform.save_to_file(filename)
   end
 
   def self.import_category(filename)

--- a/script/discourse
+++ b/script/discourse
@@ -135,12 +135,12 @@ class DiscourseCLI < Thor
   end
 
   desc "export_category", "Export a category, all its topics, and all users who posted in those topics"
-  def export_category(category_id)
+  def export_category(category_id, filename=nil)
     raise "Category id argument is missing!" unless category_id
 
     load_rails
     load_import_export
-    ImportExport.export_category(category_id)
+    ImportExport.export_category(category_id, filename)
     puts "", "Done", ""
   end
 


### PR DESCRIPTION
My discourse instance will be making regular automated public backups
of specific categories. It's preferred to be able to directly control
the path and filename of the output, rather than letting discourse
choose for me. This was already mostly supported, a filename parameter
just needed to be passed through the cli app.