### PR TITLE
Fixes for I18n and translation overrides

### DIFF
--- a/lib/freedom_patches/translate_accelerator.rb
+++ b/lib/freedom_patches/translate_accelerator.rb
@@ -105,8 +105,7 @@ module I18n
 
       by_site = @overrides_by_site[site]
 
-      by_locale = nil
-      unless by_site
+      unless by_site && by_site.has_key?(locale)
         by_site = @overrides_by_site[site] = {}
 
         # Load overrides

--- a/lib/freedom_patches/translate_accelerator.rb
+++ b/lib/freedom_patches/translate_accelerator.rb
@@ -28,6 +28,7 @@ module I18n
       @overrides_by_site = {}
 
       reload_no_cache!
+      ensure_all_loaded!
     end
 
     LOAD_MUTEX = Mutex.new

--- a/lib/i18n/backend/discourse_i18n.rb
+++ b/lib/i18n/backend/discourse_i18n.rb
@@ -43,7 +43,13 @@ module I18n
       end
 
       def search(locale, query)
-        find_results(/#{query}/i, {}, translations[locale])
+        results = {}
+
+        fallbacks(locale).each do |fallback|
+          find_results(/#{query}/i, results, translations[fallback])
+        end
+
+        results
       end
 
       protected
@@ -54,7 +60,9 @@ module I18n
             k = k_sym.to_s
             key_path = path ? "#{path}.#{k}" : k
             if v.is_a?(String)
-              results[key_path] = v if key_path =~ regexp || v =~ regexp
+              unless results.has_key?(key_path)
+                results[key_path] = v if key_path =~ regexp || v =~ regexp
+              end
             elsif v.is_a?(Hash)
               find_results(regexp, results, v, key_path)
             end

--- a/spec/components/discourse_i18n_spec.rb
+++ b/spec/components/discourse_i18n_spec.rb
@@ -40,6 +40,11 @@ describe I18n::Backend::DiscourseI18n do
     expect(results['items.other']).to eq('%{count} items')
   end
 
+  it 'uses fallback locales for searching' do
+    expect(backend.search(:de, 'bar')).to eq({'bar' => 'Bar in :de'})
+    expect(backend.search(:de, 'foo')).to eq({'foo' => 'Foo in :en'})
+  end
+
   describe '#exists?' do
     it 'returns true when a key is given that exists' do
       expect(backend.exists?(:de, :bar)).to eq(true)

--- a/spec/components/discourse_i18n_spec.rb
+++ b/spec/components/discourse_i18n_spec.rb
@@ -15,6 +15,7 @@ describe I18n::Backend::DiscourseI18n do
   end
 
   after do
+    I18n.locale = :en
     I18n.reload!
   end
 
@@ -78,13 +79,21 @@ describe I18n::Backend::DiscourseI18n do
   end
 
   describe 'with overrides' do
-    it 'returns the overriden key' do
+    it 'returns the overridden key' do
       TranslationOverride.upsert!('en', 'foo', 'Overwritten foo')
       expect(I18n.translate('foo')).to eq('Overwritten foo')
 
       TranslationOverride.upsert!('en', 'foo', 'new value')
-      I18n.reload!
       expect(I18n.translate('foo')).to eq('new value')
+    end
+
+    it 'returns the overridden key after switching the locale' do
+      TranslationOverride.upsert!('en', 'foo', 'Overwritten foo in EN')
+      TranslationOverride.upsert!('de', 'foo', 'Overwritten foo in DE')
+
+      expect(I18n.translate('foo')).to eq('Overwritten foo in EN')
+      I18n.locale = :de
+      expect(I18n.translate('foo')).to eq('Overwritten foo in DE')
     end
 
     it "can be searched" do


### PR DESCRIPTION
This PR includes a couple of fixed for I18n and translation overrides:
- Makes it possible to overrides texts that aren't translated in Transifex by using the fallback locale.
- It wasn't possible to use overrides for more than one language.
- Translations from fallback locales were missing after `I18n.reload!`

This should fix the problems reported [here](https://meta.discourse.org/t/customization-text-reverses-after-update/39019), [here](https://meta.discourse.org/t/please-help-all-custom-translations-lost/37559), [here](https://meta.discourse.org/t/customize-all-text-in-discourse/36092/11) and [here](https://meta.discourse.org/t/customize-all-text-in-discourse/36092/28).

I removed the `MessageBus` call that is executing `I18n.reload!` since `I18n.reload!` is already called in `translation_override.rb`. I'll put it back in if somebody can name a good reason why `MessageBus` was used. :wink: 