### PR TITLE
Add reminder to run ./launcher restart after the restore completes

### DIFF
--- a/app/assets/javascripts/admin/routes/admin-backups.js.es6
+++ b/app/assets/javascripts/admin/routes/admin-backups.js.es6
@@ -83,6 +83,7 @@ export default Discourse.Route.extend({
           if (confirmed) {
             Discourse.User.currentProp("hideReadOnlyAlert", true);
             backup.restore().then(function() {
+              bootbox.alert(I18n.t("admin.backups.operations.restore.restart"));
               self.controllerFor("adminBackupsLogs").clear();
               self.controllerFor("adminBackups").set("model.isOperationRunning", true);
               self.transitionTo("admin.backups.logs");

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2120,6 +2120,7 @@ en:
             label: "Restore"
             title: "Restore the backup"
             confirm: "Are you sure you want to restore this backup?"
+            restart: "Remember to restart the container after the restore completes: `/var/discourse/launcher restart app`"
           rollback:
             label: "Rollback"
             title: "Rollback the database to previous working state"


### PR DESCRIPTION
See https://meta.discourse.org/t/restore-from-backup-does-not-restore-the-whole-state-of-my-forum/24903/14?u=dandv