### PR TITLE
FIX: Remove existing characters when a new emoji is selected.

### DIFF
--- a/app/assets/javascripts/discourse/components/d-editor.js.es6
+++ b/app/assets/javascripts/discourse/components/d-editor.js.es6
@@ -301,7 +301,16 @@ export default Ember.Component.extend({
           showSelector({
             appendTo: self.$(),
             container,
-            onSelect: title => self._addText(self._getSelected(), `${title}:`)
+            onSelect: title => {
+              // Remove the previously type characters when a new emoji is selected from the selector.
+              let selected = self._getSelected();
+              let newPre = selected.pre.replace(/:[^:]+$/, ":");
+              let numOfRemovedChars = selected.pre.length - newPre.length;
+              selected.pre = newPre;
+              selected.start -= numOfRemovedChars;
+              selected.end -= numOfRemovedChars;
+              self._addText(selected, `${title}:`);
+            }
           });
           return "";
         }


### PR DESCRIPTION
When the user choose an emoji from the "More..." option, any previously typed character should be discarded.

This is a fix for https://meta.discourse.org/t/when-inputting-emoji-by-typing-and-choosing-more-the-result-includes-the-parenthesis/39785