### PR TITLE
fix: support for hyphens in group name

### DIFF
--- a/lib/pretty_text.rb
+++ b/lib/pretty_text.rb
@@ -73,7 +73,7 @@ module PrettyText
   @ctx_init = Mutex.new
 
   def self.mention_matcher
-    Regexp.new("\\W@(\\w{#{SiteSetting.min_username_length},#{SiteSetting.max_username_length}})\\b")
+    Regexp.new("\\W@([\\w\\-]{#{SiteSetting.min_username_length},#{SiteSetting.max_username_length}})\\b")
   end
 
   def self.app_root

--- a/spec/components/pretty_text_spec.rb
+++ b/spec/components/pretty_text_spec.rb
@@ -48,6 +48,11 @@ HTML
       expect(PrettyText.cook('@hello @hello @hello')).to match_html "<p><span class=\"mention\">@hello</span> <span class=\"mention\">@hello</span> <span class=\"mention\">@hello</span></p>"
     end
 
+    it "should handle group mentions with a hyphen and without" do
+      expect(PrettyText.cook('@hello @hello-hello')).to match_html "<p><span class=\"mention\">@hello</span> <span class=\"mention\">@hello-hello</span></p>"
+    end
+
+
     it "should sanitize the html" do
       expect(PrettyText.cook("<script>alert(42)</script>")).to match_html "<p></p>"
     end

--- a/spec/models/post_analyzer_spec.rb
+++ b/spec/models/post_analyzer_spec.rb
@@ -206,6 +206,11 @@ describe PostAnalyzer do
       expect(post_analyzer.raw_mentions).to eq(['jake', 'finn', 'jake_old'])
     end
 
+    it "handles hyphen in groupname" do
+      post_analyzer = PostAnalyzer.new("@org-board", default_topic_id)
+      expect(post_analyzer.raw_mentions).to eq(['org-board'])
+    end
+
     it "ignores emails" do
       post_analyzer = PostAnalyzer.new("1@test.com 1@best.com @best @not", default_topic_id)
       expect(post_analyzer.raw_mentions).to eq(['best', 'not'])

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -426,6 +426,11 @@ describe Post do
         expect(post.raw_mentions).to eq(['jake', 'finn', 'jake_old'])
       end
 
+      it "handles hyphen in groupname" do
+        post = Fabricate.build(:post, post_args.merge(raw: "@org-board"))
+        expect(post.raw_mentions).to eq(['org-board'])
+      end
+
     end
 
     context "max mentions" do

--- a/spec/services/post_alerter_spec.rb
+++ b/spec/services/post_alerter_spec.rb
@@ -112,13 +112,20 @@ describe PostAlerter do
 
       expect(GroupMention.count).to eq(1)
 
-      group.update_columns(alias_level: Group::ALIAS_LEVELS[:members_mods_and_admins])
+      Fabricate(:group, name: 'group-alt', alias_level: Group::ALIAS_LEVELS[:everyone])
 
+      expect {
+        create_post_with_alerts(raw: "Hello, @group-alt should not trigger a notification?")
+      }.to change(evil_trout.notifications, :count).by(0)
+
+      expect(GroupMention.count).to eq(2)
+
+      group.update_columns(alias_level: Group::ALIAS_LEVELS[:members_mods_and_admins])
       expect {
         create_post_with_alerts(raw: "Hello @group you are not mentionable")
       }.to change(evil_trout.notifications, :count).by(0)
 
-      expect(GroupMention.count).to eq(2)
+      expect(GroupMention.count).to eq(3)
     end
   end
 


### PR DESCRIPTION
The group mention @ORG-team triggers notifications for the group @ORG. This fix changes the RegExp, so that the group name is correctly extracted.

see: https://meta.discourse.org/t/group-mentions-that-begin-with-the-same-characters-may-be-incorrect/39892/12?u=rriemann