### PR TITLE
Return 404 instead 500 when plugin is disabled.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -94,7 +94,9 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  rescue_from Discourse::NotFound do
+  class PluginDisabled < StandardError; end
+
+  rescue_from Discourse::NotFound, PluginDisabled do
     rescue_discourse_actions(:not_found, 404)
   end
 
@@ -119,8 +121,6 @@ class ApplicationController < ActionController::Base
       render text: build_not_found_page(status_code, include_ember ? 'application' : 'no_ember')
     end
   end
-
-  class PluginDisabled < StandardError; end
 
   # If a controller requires a plugin, it will raise an exception if that plugin is
   # disabled. This allows plugins to be disabled programatically.


### PR DESCRIPTION
https://meta.discourse.org/logs/show/1fa6f998b88d9a15e6bc2bedb8ece9f2

@SamSaffron Please review :) When a plugin is disabled, we don't want users to be seeing internal server errors.

