### PR TITLE
FIX: Enable post username to be specified in embedded comments

### DIFF
--- a/app/controllers/embed_controller.rb
+++ b/app/controllers/embed_controller.rb
@@ -8,6 +8,7 @@ class EmbedController < ApplicationController
 
   def comments
     embed_url = params[:embed_url]
+    embed_username = params[:discourse_username]
 
     topic_id = nil
     if embed_url.present?
@@ -35,7 +36,7 @@ class EmbedController < ApplicationController
       end
 
     elsif embed_url.present?
-      Jobs.enqueue(:retrieve_topic, user_id: current_user.try(:id), embed_url: embed_url)
+      Jobs.enqueue(:retrieve_topic, user_id: current_user.try(:id), embed_url: embed_url, author_username: embed_username)
       render 'loading'
     end
 

--- a/spec/controllers/embed_controller_spec.rb
+++ b/spec/controllers/embed_controller_spec.rb
@@ -4,6 +4,7 @@ describe EmbedController do
 
   let(:host) { "eviltrout.com" }
   let(:embed_url) { "http://eviltrout.com/2013/02/10/why-discourse-uses-emberjs.html" }
+  let(:discourse_username) { "eviltrout" }
 
   it "is 404 without an embed_url" do
     get :comments
@@ -94,6 +95,12 @@ describe EmbedController do
         TopicView.expects(:new).with(123, nil, {limit: 100, exclude_first: true, exclude_deleted_users: true})
         get :comments, embed_url: embed_url
       end
+
+      it "provides the topic retriever with the discourse username when provided" do
+        TopicRetriever.expects(:new).with(embed_url, has_entry({author_username: discourse_username}))
+        get :comments, embed_url: embed_url, discourse_username: discourse_username
+      end
+
     end
   end
 


### PR DESCRIPTION
Although this appeared to be supported, it seems that it only worked via RSS polling.

The JavaScript allows you to specify a `discourseUserName` parameter, which it translates into the `discourse_username` URL parameter. This updates the EmbedController to pass that parameter from the URL into the TopicRetriever, ensuring that the new topic is created with the requested username.

https://meta.discourse.org/t/discourse-username-in-embedded-comments/40103