### PR TITLE
Generate proper URIs for iframes in emails

### DIFF
--- a/lib/email/styles.rb
+++ b/lib/email/styles.rb
@@ -127,8 +127,8 @@ module Email
           src_uri = URI(i['src'])
 
           # If an iframe is protocol relative, use SSL when displaying it
-          display_src = "#{src_uri.scheme || 'https://'}#{src_uri.host}#{src_uri.path}"
-          i.replace "<p><a href='#{src_uri.to_s}'>#{display_src}</a><p>"
+          display_src = "#{src_uri.scheme || 'https'}://#{src_uri.host}#{src_uri.path}#{src_uri.query.nil? ? '' : '?' + src_uri.query}#{src_uri.fragment.nil? ? '' : '#' + src_uri.fragment}"
+          i.replace "<p><a href='#{src_uri.to_s}'>#{CGI.escapeHTML(display_src)}</a><p>"
         rescue URI::InvalidURIError
           # If the URL is weird, remove it
           i.remove


### PR DESCRIPTION
When iframes are turned into links for emails, so far; query strings and fragments were stripped and the `://` to separate scheme and domain was missing. This fixes both problems.

Disclaimer: I could not test this in a proper dev environment, just by playing around with a small test ruby script.