### PR TITLE
fix a few typos in the German translation

### DIFF
--- a/config/locales/client.de.yml
+++ b/config/locales/client.de.yml
@@ -2254,7 +2254,7 @@ de:
         moderator: "Moderator?"
         admin: "Administrator?"
         blocked: "Geblockt?"
-        staged: "Insziniert?"
+        staged: "Inszeniert?"
         show_admin_profile: "Administration"
         edit_title: "Titel bearbeiten"
         save_title: "Titel speichern"

--- a/config/locales/server.de.yml
+++ b/config/locales/server.de.yml
@@ -1013,7 +1013,7 @@ de:
     feed_polling_enabled: "NUR WENN EINGEBETTET: Bestimmt, ob Inhalte eines RSS-/ATOM-Feeds als zusätzliche Beiträge dargestellt werden."
     feed_polling_url: "NUR WENN EINGEBETTET: URL des einzubettenden RSS-/ATOM-Feeds."
     embed_by_username: "Discourse-Benutzername des Benutzers, der die eingebetteten Themen erstellt."
-    embed_username_key_from_feed: "Schlüsse, um Discourse-Benutzernamen aus Feed zu ziehen."
+    embed_username_key_from_feed: "Schlüssel, um Discourse-Benutzernamen aus Feed zu ermitteln."
     embed_truncate: "Kürze die eingebetteten Beiträge"
     embed_post_limit: "Maximale Anzahl der Beiträge die eingebettet werden."
     embed_username_required: "Der Benutzername ist für die Betragserstellung notwendig"


### PR DESCRIPTION
This fixes two typos in the German translation.

I have to say that I find `stage_explanation` pretty incomprehensible. But I find it equally incomprehensible in German and English, so the translation is not at fault ;-) . In particular, it is unclear to me whether `can only post via email in specific topics` means that in the other topics, the user can *not post at all*, or whether in the other topics, she can post normally through the web-interface, but not via e-mail. Also, which are these `specific` topics?

---

I signed your CLA. Furthermore, I hereby declare that *anybody* has the right to use this contribution under *any* license whatsoever. This is to fight the asymmetry in the CLA, which (in a sneaky way, IMHO), turns this GPL-ed project into "GPL for everybody, BSD-like for The Company", violating the usual principle that everybody but the author has the same rights on a piece of open-source software. See <https://mjg59.dreamwidth.org/25376.html> for further explanations of this issue.