### PR TITLE
Profile page: Use "I" to refer to the user

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -511,7 +511,7 @@ en:
       muted_users: "Muted"
       muted_users_instructions: "Suppress all notifications from these users."
       muted_topics_link: "Show muted topics"
-      automatically_unpin_topics: "Automatically unpin topics when you reach the bottom."
+      automatically_unpin_topics: "Automatically unpin topics when I reach the bottom."
 
       staff_counters:
         flags_given: "helpful flags"


### PR DESCRIPTION
This is consistent with "Don't jump to my post after I reply", "Send me an email when someone messages me", ...

---

I signed your CLA. Furthermore, I hereby declare that anybody has the right to use this contribution under any license whatsoever. This is to fight the asymmetry in the CLA, which (in a sneaky way, IMHO), turns this GPL-ed project into "GPL for everybody, BSD-like for The Company", violating the usual principle that everybody but the author has the same rights on a piece of open-source software. See https://mjg59.dreamwidth.org/25376.html for further explanations of this issue.