### PR TITLE
FIX: Bind action admin/users#show to GET /admin/users/list

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,7 +75,7 @@ Discourse::Application.routes.draw do
 
     resources :users, id: USERNAME_ROUTE_FORMAT, except: [:show] do
       collection do
-        get 'list' => 'users#show'
+        get 'list' => redirect('admin/users/list/active')
         get "list/:query" => "users#index"
         get "ip-info" => "users#ip_info"
         delete "delete-others-with-same-ip" => "users#delete_other_accounts_with_same_ip"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,6 +75,7 @@ Discourse::Application.routes.draw do
 
     resources :users, id: USERNAME_ROUTE_FORMAT, except: [:show] do
       collection do
+        get 'list' => 'users#show'
         get "list/:query" => "users#index"
         get "ip-info" => "users#ip_info"
         delete "delete-others-with-same-ip" => "users#delete_other_accounts_with_same_ip"


### PR DESCRIPTION
I bisected the code and found commit 35142847ba3968d2a8e70357b20d1a2b116bccd1 caused this problem as part of PR https://github.com/discourse/discourse/pull/3822

Simply reverting the option `except: [:show]` won't work because that will make `admin/users/_id_.json` and `admin/users/_id_/_username_` invalid. As a result I had to be specific.

Please note that `/admin/users/list/active` has always been working.

This is a fix for https://meta.discourse.org/t/middle-click-on-users-admin-panel-fails/40289