### PR TITLE
UX: Double show double `hr` when there aren't any notifications.

### DIFF
--- a/app/assets/javascripts/discourse/templates/components/user-menu.hbs
+++ b/app/assets/javascripts/discourse/templates/components/user-menu.hbs
@@ -23,8 +23,8 @@
 
   <div class='notifications'>
     {{#conditional-loading-spinner condition=loadingNotifications containerClass="spinner-container"}}
-      <hr>
       {{#if notifications}}
+        <hr>
         <ul>
           {{#each notifications as |n|}}
             {{notification-item notification=n}}


### PR DESCRIPTION
### Before
![screenshot from 2016-02-29 12-31-26](https://cloud.githubusercontent.com/assets/4335742/13385828/621ca0e4-dee0-11e5-90b1-317eb6788667.png)

### After
![screenshot from 2016-02-29 12-31-06](https://cloud.githubusercontent.com/assets/4335742/13385829/621e29a0-dee0-11e5-8234-67c92c863c91.png)