### PR TITLE
UX: remove category background image after the image is deleted

### DIFF
--- a/app/assets/javascripts/discourse/mixins/add-category-class.js.es6
+++ b/app/assets/javascripts/discourse/mixins/add-category-class.js.es6
@@ -11,7 +11,7 @@ export default {
 
     this._removeClass();
 
-    if (categoryFullSlug) {
+    if (categoryFullSlug && this.get("categoryBackgroundUrl")) {
       $("body").addClass("category-" + categoryFullSlug);
     }
   })),

--- a/app/assets/javascripts/discourse/views/navigation-category.js.es6
+++ b/app/assets/javascripts/discourse/views/navigation-category.js.es6
@@ -1,5 +1,6 @@
 import AddCategoryClass from 'discourse/mixins/add-category-class';
 
 export default Ember.View.extend(AddCategoryClass, {
-  categoryFullSlug: Ember.computed.alias('controller.category.fullSlug')
+  categoryFullSlug: Ember.computed.alias('controller.category.fullSlug'),
+  categoryBackgroundUrl: Ember.computed.alias('controller.category.background_url')
 });

--- a/app/assets/javascripts/discourse/views/topic.js.es6
+++ b/app/assets/javascripts/discourse/views/topic.js.es6
@@ -20,6 +20,7 @@ const TopicView = Ember.View.extend(AddCategoryClass, AddArchetypeClass, Scrolli
   SHORT_POST: 1200,
 
   categoryFullSlug: Em.computed.alias('topic.category.fullSlug'),
+  categoryBackgroundUrl: Em.computed.alias('topic.category.background_url'),
   postStream: Em.computed.alias('topic.postStream'),
   archetype: Em.computed.alias('topic.archetype'),
 


### PR DESCRIPTION
This PR adds a check if the category background image is present before adding the category class.

This is required because (as of now) once the category background image is deleted, the [relevant CSS](https://github.com/discourse/discourse/blob/master/lib/sass/discourse_sass_importer.rb#L57) is not removed until the hard refresh is done.

Issue reported here: https://meta.discourse.org/t/category-background-images-retain-after-being-deleted/40377?u=techapj

