### PR TITLE
FIX: Image Lightbox on Subfolder Install

### DIFF
--- a/lib/file_store/local_store.rb
+++ b/lib/file_store/local_store.rb
@@ -35,7 +35,7 @@ module FileStore
     end
 
     def relative_base_url
-      "/uploads/#{RailsMultisite::ConnectionManagement.current_db}"
+      "#{Discourse.base_uri}/uploads/#{RailsMultisite::ConnectionManagement.current_db}"
     end
 
     def external?

--- a/lib/file_store/local_store.rb
+++ b/lib/file_store/local_store.rb
@@ -34,8 +34,12 @@ module FileStore
       "#{Discourse.asset_host}#{relative_base_url}"
     end
 
+    def upload_path
+      "/uploads/#{RailsMultisite::ConnectionManagement.current_db}"
+    end
+
     def relative_base_url
-      "#{Discourse.base_uri}/uploads/#{RailsMultisite::ConnectionManagement.current_db}"
+      "#{Discourse.base_uri}#{upload_path}"
     end
 
     def external?
@@ -57,7 +61,7 @@ module FileStore
     end
 
     def get_path_for(type, upload_id, sha, extension)
-      "#{relative_base_url}/#{super(type, upload_id, sha, extension)}"
+      "#{upload_path}/#{super(type, upload_id, sha, extension)}"
     end
 
     def copy_file(file, path)

--- a/spec/components/cooked_post_processor_spec.rb
+++ b/spec/components/cooked_post_processor_spec.rb
@@ -130,7 +130,7 @@ describe CookedPostProcessor do
 
     context "with large images when using subfolders" do
 
-      let(:subfolder_upload) { Fabricate(:subfolder_upload) }
+      let(:upload) { Fabricate(:upload) }
       let(:post) { Fabricate(:post_with_large_image_on_subfolder) }
       let(:cpp) { CookedPostProcessor.new(post) }
       let(:base_url) { "http://test.localhost/subfolder" }
@@ -142,7 +142,7 @@ describe CookedPostProcessor do
         Discourse.stubs(:base_url).returns(base_url)
         Discourse.stubs(:base_uri).returns(base_uri)
 
-        Upload.expects(:get_from_url).returns(subfolder_upload)
+        Upload.expects(:get_from_url).returns(upload)
         FastImage.stubs(:size).returns([1000, 2000])
 
         # hmmm this should be done in a cleaner way

--- a/spec/components/cooked_post_processor_spec.rb
+++ b/spec/components/cooked_post_processor_spec.rb
@@ -128,6 +128,39 @@ describe CookedPostProcessor do
 
     end
 
+    context "with large images when using subfolders" do
+
+      let(:subfolder_upload) { Fabricate(:subfolder_upload) }
+      let(:post) { Fabricate(:post_with_large_image_on_subfolder) }
+      let(:cpp) { CookedPostProcessor.new(post) }
+      let(:base_url) { "http://test.localhost/subfolder" }
+      let(:base_uri) { "/subfolder" }
+
+      before do
+        SiteSetting.max_image_height = 2000
+        SiteSetting.create_thumbnails = true
+        Discourse.stubs(:base_url).returns(base_url)
+        Discourse.stubs(:base_uri).returns(base_uri)
+
+        Upload.expects(:get_from_url).returns(subfolder_upload)
+        FastImage.stubs(:size).returns([1000, 2000])
+
+        # hmmm this should be done in a cleaner way
+        OptimizedImage.expects(:resize).returns(true)
+
+        FileStore::BaseStore.any_instance.expects(:get_depth_for).returns(0)
+      end
+
+      it "generates overlay information" do
+        cpp.post_process_images
+        expect(cpp.html).to match_html '<p><div class="lightbox-wrapper"><a data-download-href="/subfolder/uploads/default/e9d71f5ee7c92d6dc9e92ffdad17b8bd49418f98" href="/subfolder/uploads/default/1/1234567890123456.jpg" class="lightbox" title="logo.png"><img src="/subfolder/uploads/default/optimized/1X/e9d71f5ee7c92d6dc9e92ffdad17b8bd49418f98_1_690x1380.png" width="690" height="1380"><div class="meta">
+<span class="filename">logo.png</span><span class="informations">1000x2000 1.21 KB</span><span class="expand"></span>
+</div></a></div></p>'
+        expect(cpp).to be_dirty
+      end
+
+    end
+
     context "with title" do
 
       let(:upload) { Fabricate(:upload) }

--- a/spec/fabricators/post_fabricator.rb
+++ b/spec/fabricators/post_fabricator.rb
@@ -83,6 +83,10 @@ Fabricator(:post_with_large_image_and_title, from: :post) do
   raw '<img src="/uploads/default/1/1234567890123456.jpg" title="WAT">'
 end
 
+Fabricator(:post_with_large_image_on_subfolder, from: :post) do
+  raw '<img src="/subfolder/uploads/default/1/1234567890123456.jpg">'
+end
+
 Fabricator(:post_with_uploads, from: :post) do
   raw '
 <a href="/uploads/default/2/2345678901234567.jpg">Link</a>

--- a/spec/fabricators/upload_fabricator.rb
+++ b/spec/fabricators/upload_fabricator.rb
@@ -8,16 +8,6 @@ Fabricator(:upload) do
   url  "/uploads/default/1/1234567890123456.png"
 end
 
-Fabricator(:subfolder_upload, from: :upload) do
-  user
-  sha1 "e9d71f5ee7c92d6dc9e92ffdad17b8bd49418f98"
-  original_filename "logo.png"
-  filesize 1234
-  width 100
-  height 200
-  url  "/uploads/default/1/1234567890123456.png"
-end
-
 Fabricator(:attachment, from: :upload) do
   id 42
   user

--- a/spec/fabricators/upload_fabricator.rb
+++ b/spec/fabricators/upload_fabricator.rb
@@ -8,6 +8,16 @@ Fabricator(:upload) do
   url  "/uploads/default/1/1234567890123456.png"
 end
 
+Fabricator(:subfolder_upload, from: :upload) do
+  user
+  sha1 "e9d71f5ee7c92d6dc9e92ffdad17b8bd49418f98"
+  original_filename "logo.png"
+  filesize 1234
+  width 100
+  height 200
+  url  "/uploads/default/1/1234567890123456.png"
+end
+
 Fabricator(:attachment, from: :upload) do
   id 42
   user


### PR DESCRIPTION
Since LocalStore.is_relative wasn't subfolder aware, images on subfolder install weren't getting lightboxed.

Gotta add some tests to LocalStore and Post Cook.