### PR TITLE
Add spec for topic_status_update event

### DIFF
--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -1584,4 +1584,20 @@ describe Topic do
 
     expect(topic.message_archived?(user)).to eq(true)
   end
+
+  it 'will trigger :topic_status_updated' do
+    topic = Fabricate(:topic)
+    user = topic.user
+    user.admin = true
+    @topic_status_event_triggered = false
+
+    DiscourseEvent.on(:topic_status_updated) do
+      @topic_status_event_triggered = true
+    end
+
+    topic.update_status('closed', true, user)
+    topic.reload
+    
+    expect(@topic_status_event_triggered).to eq(true)
+  end
 end


### PR DESCRIPTION
I'm hoping someone can give me a hand with this one. I'm attempting to add a spec for this event: https://github.com/discourse/discourse/pull/4037. I know the event works as I'm using it in a plugin, but have been unable to get a successful run on the tests.