### PR TITLE
FIX: validate user locale for email notifications

### DIFF
--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -188,7 +188,7 @@ class UserNotifications < ActionMailer::Base
   protected
 
   def user_locale(user)
-    user.respond_to?(:locale) ? user.locale : nil
+    (user.locale.present? && I18n.available_locales.include?(user.locale.to_sym)) ? user.locale : nil
   end
 
   def email_post_markdown(post)

--- a/spec/mailers/user_notifications_spec.rb
+++ b/spec/mailers/user_notifications_spec.rb
@@ -429,5 +429,19 @@ describe UserNotifications do
         end
       end
     end
+
+    context "user locale is not a valid locale" do
+      %w(signup signup_after_approval authorize_email forgot_password admin_login account_created).each do |mail_type|
+        include_examples "notification derived from template" do
+          SiteSetting.default_locale = "en"
+          let(:locale) { "invalid" }
+          let(:mail_type) { mail_type }
+          it "sets the locale" do
+            expects_build_with(has_entry(:locale, nil))
+          end
+        end
+      end
+    end
+
   end
 end

--- a/spec/mailers/user_notifications_spec.rb
+++ b/spec/mailers/user_notifications_spec.rb
@@ -430,11 +430,11 @@ describe UserNotifications do
       end
     end
 
-    context "user locale is not a valid locale" do
+    context "user locale is an empty string" do
       %w(signup signup_after_approval authorize_email forgot_password admin_login account_created).each do |mail_type|
         include_examples "notification derived from template" do
           SiteSetting.default_locale = "en"
-          let(:locale) { "invalid" }
+          let(:locale) { "" }
           let(:mail_type) { mail_type }
           it "sets the locale" do
             expects_build_with(has_entry(:locale, nil))


### PR DESCRIPTION
Sets the locale to `nil`for invalid locales and empty strings.
It seems unlikely that an invalid locale can exist in the database - it's not possible to log in with one, but it is possible to have "" as a locale. Setting an empty string as the locale value for `I18n.t` produces an I18n::InvalidLocale error.