### PR TITLE
FEATURE: Add site setting for disabling mailing list mode site wide

### DIFF
--- a/app/assets/javascripts/discourse/templates/user/preferences.hbs
+++ b/app/assets/javascripts/discourse/templates/user/preferences.hbs
@@ -183,7 +183,9 @@
       {{preference-checkbox labelKey="user.email_in_reply_to" checked=model.user_option.email_in_reply_to}}
       {{preference-checkbox labelKey="user.email_private_messages" checked=model.user_option.email_private_messages}}
       {{preference-checkbox labelKey="user.email_direct" checked=model.user_option.email_direct}}
-      <span class="pref-mailing-list-mode">{{preference-checkbox labelKey="user.mailing_list_mode" checked=model.user_option.mailing_list_mode}}</span>
+      {{#unless siteSettings.disable_mailing_list_mode}}
+        {{preference-checkbox labelKey="user.mailing_list_mode" checked=model.user_option.mailing_list_mode}}
+      {{/unless}}
       {{preference-checkbox labelKey="user.email_always" checked=model.user_option.email_always}}
       {{#unless model.user_option.email_always}}
       <div class='instructions'>

--- a/app/models/user_option.rb
+++ b/app/models/user_option.rb
@@ -44,6 +44,11 @@ class UserOption < ActiveRecord::Base
     true
   end
 
+  def mailing_list_mode
+    return false if SiteSetting.disable_mailing_list_mode
+    super
+  end
+
   def update_tracked_topics
     return unless auto_track_topics_after_msecs_changed?
     TrackedTopicsUpdater.new(id, auto_track_topics_after_msecs).call

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1248,6 +1248,7 @@ en:
     default_email_private_messages: "Send an email when someone messages the user by default."
     default_email_direct: "Send an email when someone quotes/replies to/mentions or invites the user by default."
     default_email_mailing_list_mode: "Send an email for every new post by default."
+    disable_mailing_list_mode: "Disable sending an email for every new post for all users"
     default_email_always: "Send an email notification even when the user is active by default."
     default_email_previous_replies: "Include previous replies in emails by default."
 

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1248,7 +1248,7 @@ en:
     default_email_private_messages: "Send an email when someone messages the user by default."
     default_email_direct: "Send an email when someone quotes/replies to/mentions or invites the user by default."
     default_email_mailing_list_mode: "Send an email for every new post by default."
-    disable_mailing_list_mode: "Disable sending an email for every new post for all users"
+    disable_mailing_list_mode: "Disallow users from enabling mailing list mode."
     default_email_always: "Send an email notification even when the user is active by default."
     default_email_previous_replies: "Include previous replies in emails by default."
 

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1074,6 +1074,9 @@ user_preferences:
   default_email_private_messages: true
   default_email_direct: true
   default_email_mailing_list_mode: false
+  disable_mailing_list_mode:
+    default: false
+    client: true
   default_email_always: false
   default_email_previous_replies:
     enum: 'PreviousRepliesSiteSetting'

--- a/spec/models/user_option_spec.rb
+++ b/spec/models/user_option_spec.rb
@@ -18,7 +18,7 @@ describe UserOption do
 
   end
 
-  describe ".mailing_list_mode" do
+  describe "#mailing_list_mode" do
     let!(:forum_user) { Fabricate(:user) }
     let!(:mailing_list_user) { Fabricate(:user) }
 
@@ -28,13 +28,13 @@ describe UserOption do
     end
 
     it "should return false when `SiteSetting.disable_mailing_list_mode` is enabled" do
-      SiteSetting.expects(:disable_mailing_list_mode).twice.returns(true)
+      SiteSetting.disable_mailing_list_mode = true
       expect(forum_user.user_option.mailing_list_mode).to eq(false)
       expect(mailing_list_user.user_option.mailing_list_mode).to eq(false)
     end
 
     it "should return the stored value when `SiteSetting.disable_mailing_list_mode` is disabled" do
-      SiteSetting.expects(:disable_mailing_list_mode).twice.returns(false)
+      SiteSetting.disable_mailing_list_mode = false
       expect(forum_user.user_option.mailing_list_mode).to eq(false)
       expect(mailing_list_user.user_option.mailing_list_mode).to eq(true)
     end

--- a/spec/models/user_option_spec.rb
+++ b/spec/models/user_option_spec.rb
@@ -18,6 +18,28 @@ describe UserOption do
 
   end
 
+  describe ".mailing_list_mode" do
+    let!(:forum_user) { Fabricate(:user) }
+    let!(:mailing_list_user) { Fabricate(:user) }
+
+    before do
+      forum_user.user_option.update(mailing_list_mode: false)
+      mailing_list_user.user_option.update(mailing_list_mode: true)
+    end
+
+    it "should return false when `SiteSetting.disable_mailing_list_mode` is enabled" do
+      SiteSetting.expects(:disable_mailing_list_mode).twice.returns(true)
+      expect(forum_user.user_option.mailing_list_mode).to eq(false)
+      expect(mailing_list_user.user_option.mailing_list_mode).to eq(false)
+    end
+
+    it "should return the stored value when `SiteSetting.disable_mailing_list_mode` is disabled" do
+      SiteSetting.expects(:disable_mailing_list_mode).twice.returns(false)
+      expect(forum_user.user_option.mailing_list_mode).to eq(false)
+      expect(mailing_list_user.user_option.mailing_list_mode).to eq(true)
+    end
+  end
+
   describe ".redirected_to_top" do
     let!(:user) { Fabricate(:user) }
 


### PR DESCRIPTION
Playing around with the email settings some in anticipation of this work:
https://meta.discourse.org/t/more-granular-mailing-list-mode/38107

This change is discussed here:
https://meta.discourse.org/t/completely-disable-mailing-list-mode/37334/8