### PR TITLE
Force users to select an option in required custom user dropdown fields

### DIFF
--- a/app/assets/javascripts/discourse/components/user-field.js.es6
+++ b/app/assets/javascripts/discourse/components/user-field.js.es6
@@ -5,8 +5,6 @@ export default Ember.Component.extend({
   layoutName: fmt('field.field_type', 'components/user-fields/%@'),
 
   noneLabel: function() {
-    if (!this.get('field.required')) {
-      return 'user_fields.none';
-    }
-  }.property('field.required')
+    return 'user_fields.none';
+  }.property()
 });


### PR DESCRIPTION
**What does this PR do?**

This PR forces new users to select an option for all required custom user dropdown fields. Before this PR, the first option would come selected by default and the user could ignore the dropdown. See https://meta.discourse.org/t/custom-user-fields-dropdown-have-no-please-choose-option/40554

**Notes**

This is my first PR to Discourse and I could not find any frontend testing to which I could add a test for this feature/bugfix, as I could only find Rspec tests. If you think I should add tests to this, I ask that you point me in the direction of existing tests I can use an example.

**Screenshots**

Before
![before](https://cloud.githubusercontent.com/assets/1075053/13557081/a6d35912-e3e0-11e5-909d-5a07cb25928d.png)

After
![after](https://cloud.githubusercontent.com/assets/1075053/13557083/aa81ad52-e3e0-11e5-9d8b-1d7ae5f8dd30.png)
