### PR TITLE
FIX: Add missing translation in groups page

### DIFF
--- a/app/assets/javascripts/discourse/controllers/group.js.es6
+++ b/app/assets/javascripts/discourse/controllers/group.js.es6
@@ -4,6 +4,11 @@ var Tab = Em.Object.extend({
   @computed('name')
   location(name) {
     return 'group.' + name;
+  },
+
+  @computed('name')
+  message(name) {
+    return I18n.t('groups.' + name);
   }
 });
 

--- a/app/assets/javascripts/discourse/templates/group.hbs
+++ b/app/assets/javascripts/discourse/templates/group.hbs
@@ -4,8 +4,8 @@
     <ul class='action-list nav-stacked'>
       {{#each tabs as |tab|}}
         <li class="{{if tab.active 'active'}}">
-          {{#link-to tab.location model}}
-            {{tab.name}}
+          {{#link-to tab.location model title=tab.message}}
+            {{tab.message}}
             {{#if tab.count}}<span class='count'>({{tab.count}})</span>{{/if}}
           {{/link-to}}
         </li>

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -364,7 +364,10 @@ en:
         one: "group"
         other: "groups"
       members: "Members"
+      topics: "Topics"
       posts: "Posts"
+      mentions: "Mentions"
+      messages: "Messages"
       alias_levels:
         title: "Who can message and @mention this group?"
         nobody: "Nobody"


### PR DESCRIPTION
(Chinese) A user reported sidebar on group page is not translated. https://meta.discoursecn.org/t/%E7%99%BB%E5%BD%95%E6%8F%92%E4%BB%B6%E6%97%A0%E6%B3%95%E4%B8%80%E9%94%AE%E7%99%BB%E5%BD%95/965

About this change:

![image](https://cloud.githubusercontent.com/assets/297343/13600374/adf1977e-e528-11e5-891c-6c531e4a665a.png)

![image](https://cloud.githubusercontent.com/assets/297343/13600389/c59a3d86-e528-11e5-8340-97e5bf79688b.png)


￼
￼