### PR TITLE
FEATURE: revert post to a specific revision

### DIFF
--- a/app/assets/javascripts/discourse/models/post.js.es6
+++ b/app/assets/javascripts/discourse/models/post.js.es6
@@ -271,6 +271,10 @@ const Post = RestModel.extend({
       json = Post.munge(json);
       this.set('actions_summary', json.actions_summary);
     }
+  },
+
+  revertToRevision(version) {
+    return Discourse.ajax(`/posts/${this.get('id')}/revisions/${version}/revert`, { type: 'PUT' });
   }
 
 });

--- a/app/assets/javascripts/discourse/routes/topic.js.es6
+++ b/app/assets/javascripts/discourse/routes/topic.js.es6
@@ -73,6 +73,7 @@ const TopicRoute = Discourse.Route.extend({
     showHistory(model) {
       showModal('history', { model });
       this.controllerFor('history').refresh(model.get("id"), "latest");
+      this.controllerFor('history').set('post', model);
       this.controllerFor('modal').set('modalClass', 'history-modal');
     },
 

--- a/app/assets/javascripts/discourse/templates/modal/history.hbs
+++ b/app/assets/javascripts/discourse/templates/modal/history.hbs
@@ -10,12 +10,6 @@
       </div>
       {{d-button action="loadNextVersion" icon="forward" title="post.revisions.controls.next" disabled=loadNextDisabled}}
       {{d-button action="loadLastVersion" icon="fast-forward" title="post.revisions.controls.last" disabled=loadLastDisabled}}
-      {{#if displayHide}}
-        {{d-button action="hideVersion" icon="trash-o" title="post.revisions.controls.hide" class="btn-danger" disabled=loading}}
-      {{/if}}
-      {{#if displayShow}}
-        {{d-button action="showVersion" icon="undo" title="post.revisions.controls.show" disabled=loading}}
-      {{/if}}
     </div>
     <div id="display-modes">
       {{d-button action="displayInline" label="post.revisions.displays.inline.button" title="post.revisions.displays.inline.title" class=inlineClass}}
@@ -85,5 +79,15 @@
     <div class="row">
       {{{bodyDiff}}}
     </div>
+
+    {{#if displayRevert}}
+      {{d-button action="revertToVersion" icon="undo" label="post.revisions.controls.revert" class="btn-danger" disabled=loading}}
+    {{/if}}
+    {{#if displayHide}}
+      {{d-button action="hideVersion" icon="eye-slash" label="post.revisions.controls.hide" class="btn-danger" disabled=loading}}
+    {{/if}}
+    {{#if displayShow}}
+      {{d-button action="showVersion" icon="eye" label="post.revisions.controls.show" disabled=loading}}
+    {{/if}}
   </div>
 </div>

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1639,6 +1639,7 @@ en:
           last: "Last revision"
           hide: "Hide revision"
           show: "Show revision"
+          revert: "Revert to this revision"
           comparing_previous_to_current_out_of_total: "<strong>{{previous}}</strong> <i class='fa fa-arrows-h'></i> <strong>{{current}}</strong> / {{total}}"
         displays:
           inline:

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -204,6 +204,7 @@ en:
     top: "Top topics"
     posts: "Latest posts"
   too_late_to_edit: "That post was created too long ago. It can no longer be edited or deleted."
+  revert_version_same: "The current version is same as the version you are trying to revert to."
 
   excerpt_image: "image"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -386,6 +386,7 @@ Discourse::Application.routes.draw do
     get "revisions/:revision" => "posts#revisions", constraints: { revision: /\d+/ }
     put "revisions/:revision/hide" => "posts#hide_revision", constraints: { revision: /\d+/ }
     put "revisions/:revision/show" => "posts#show_revision", constraints: { revision: /\d+/ }
+    put "revisions/:revision/revert" => "posts#revert", constraints: { revision: /\d+/ }
     put "recover"
     collection do
       delete "destroy_many"


### PR DESCRIPTION
This PR adds a "Revert" button under the bottom of every revision. Clicking on this button will revert the post to that specific revision.

![screen shot 2016-03-10 at 18 10 10](https://cloud.githubusercontent.com/assets/5732281/13669740/705f58fa-e6eb-11e5-933f-ca82fa9b5d65.png)

Revert button will only be visible to staff, and reverting a post will create a new revision.

@eviltrout can you please review this PR?