### PR TITLE
Add an Email Services Template page

### DIFF
--- a/docs/ADMIN-QUICK-START-GUIDE.md
+++ b/docs/ADMIN-QUICK-START-GUIDE.md
@@ -73,8 +73,7 @@ Email is required for new account signups and notifications. **Test your email t
 
 - You got the test email? Great! **Read that email closely**, it has important email deliverability tips.
 - You didn't get the test email? This means your users probably aren't getting any signup or notification emails either.
-
-Email deliverability can be hard. We strongly recommend using dedicated email services like [SendGrid](https://sendgrid.com/), [SparkPost](https://www.sparkpost.com/), [MailGun](http://www.mailgun.com/), or [MailJet](https://www.mailjet.com/), which offer generous free plans that work fine for most communities.
+- Email deliverability can be hard. Read [**Email Service Configuration**](https://github.com/discourse/discourse/blob/master/docs/INSTALL-email.md).
 
 If you'd like to enable *replying* to topics via email, [see this howto](https://meta.discourse.org/t/set-up-reply-via-email-support/14003).
 

--- a/docs/INSTALL-cloud.md
+++ b/docs/INSTALL-cloud.md
@@ -61,7 +61,7 @@ We recommend Nano because it's simple; just use your arrow keys to edit.
 
 - Set `DISCOURSE_HOSTNAME` to `discourse.example.com`, this means you want your Discourse available at `http://discourse.example.com/`. You'll need to update the DNS A record for this domain with the IP address of your server.
 
-- Place your mail credentials in `DISCOURSE_SMTP_ADDRESS`, `DISCOURSE_SMTP_PORT`, `DISCOURSE_SMTP_USER_NAME`, `DISCOURSE_SMTP_PASSWORD`. Be sure you remove the comment `#` character and space from the front of these lines as necessary.
+- Place your [mail credentials][mailconfig] in `DISCOURSE_SMTP_ADDRESS`, `DISCOURSE_SMTP_PORT`, `DISCOURSE_SMTP_USER_NAME`, `DISCOURSE_SMTP_PASSWORD`. Be sure you remove the comment `#` character and space from the front of these lines as necessary.
 
 - If you are using a 1 GB instance, set `UNICORN_WORKERS` to 2 and `db_shared_buffers` to 128MB so you have more memory room.
 
@@ -75,11 +75,11 @@ Please be careful while editing and double check your work; YAML is _very_ sensi
 
 - Already have a mail server? Great. Use your existing mail server credentials.
 
-- No existing mail server? Create a free account on [SendGrid][sg] (12k emails/month) [SparkPost][sp] (100k emails/month) [Mailgun][gun] (10k emails/month), [Mailjet][jet] (6k emails/month), and use the credentials provided in the dashboard.
+- No existing mail server? Read [**Email Service Configuration**][mailconfig].
 
 - For proper email deliverability, you must set correct SPF and DKIM records in your DNS. See your email provider instructions for specifics.
 
-If you need to change or fix your email settings after bootstrapping, you must edit the `app.yml` file again and `./launcher rebuild app`, otherwise your changes will not take effect.
+If you need to change or fix your email settings after bootstrapping, you must edit the `app.yml` file again and `./launcher rebuild app`, otherwise your changes will not take effect. If you didn't receive an email from your install, read [Register New Account and Become Admin][#register-new-account-and-become-admin] for troubleshooting.
 
 # Bootstrap Discourse
 
@@ -173,11 +173,8 @@ Do you want...
 Help us improve this guide! Feel free to ask about it on [meta.discourse.org][meta], or even better, submit a pull request.
 
    [dd]: https://github.com/discourse/discourse_docker
-   [sp]: https://www.sparkpost.com/
   [ssh]: https://help.github.com/articles/generating-ssh-keys
  [meta]: https://meta.discourse.org
    [do]: https://www.digitalocean.com/?refcode=5fa48ac82415
-  [jet]: https://www.mailjet.com/pricing
-  [gun]: http://www.mailgun.com/
-   [sg]: https://sendgrid.com/
   [put]: http://www.chiark.greenend.org.uk/~sgtatham/putty/download.html
+  [mailconfig]: https://github.com/discourse/discourse/blob/master/docs/INSTALL-email.md

--- a/docs/INSTALL-email.md
+++ b/docs/INSTALL-email.md
@@ -1,0 +1,45 @@
+## Email Is Important
+
+We strongly recommend using dedicated email services.
+
+The following are template configurations for email service providers who offer generous free plans that work for most communities.
+
+Use these values when you [edit the Discourse configuration](https://github.com/discourse/discourse/blob/master/docs/INSTALL-cloud.md#edit-discourse-configuration) (`app.yml`). Replace the bracketed values with your values from the service.
+
+#### [SparkPost][sp] configuration (100k emails/month)
+
+```yml
+DISCOURSE_SMTP_ADDRESS: smtp.sparkpostmail.com
+DISCOURSE_SMTP_PORT: 587
+DISCOURSE_SMTP_USER_NAME: SMTP_Injection
+DISCOURSE_SMTP_PASSWORD: [Any API key with Send via SMTP permission]
+```
+
+#### [SendGrid][sg] configuration (12k emails/month)
+
+```yml
+DISCOURSE_SMTP_ADDRESS: smtp.sendgrid.net
+DISCOURSE_SMTP_PORT: 587
+DISCOURSE_SMTP_USER_NAME: [SendGrid username]
+DISCOURSE_SMTP_PASSWORD: [SendGrid password]
+```
+
+#### [Mailgun][gun] configuration (10k emails/month)
+
+
+```yml
+DISCOURSE_SMTP_ADDRESS: smtp.mailgun.org
+DISCOURSE_SMTP_PORT: 587
+DISCOURSE_SMTP_USER_NAME: [SMTP credentials for your domain under Mailgun domains tab]
+DISCOURSE_SMTP_PASSWORD: [SMTP credentials for your domain under Mailgun domains tab]
+```
+
+#### [Mailjet][jet] configuration (6k emails/month)
+
+Go to [My Account page](https://www.mailjet.com/account) and click on the ["SMTP and SEND API Settings"](https://www.mailjet.com/account/setup) link.
+
+
+   [sp]: https://www.sparkpost.com/
+  [jet]: https://www.mailjet.com/pricing
+  [gun]: http://www.mailgun.com/
+   [sg]: https://sendgrid.com/


### PR DESCRIPTION
- Link Admin Quick Start and basic install to services page
- Provide templates for various email service providers

I think this helps make setting up email services clearer...