### PR TITLE
Always trigger clearing of saved drafts from client after save promise resolves

### DIFF
--- a/app/assets/javascripts/discourse/controllers/composer.js.es6
+++ b/app/assets/javascripts/discourse/controllers/composer.js.es6
@@ -294,18 +294,15 @@ export default Ember.Controller.extend({
     });
 
     const promise = composer.save({ imageSizes, editReason: this.get("editReason")}).then(function(result) {
+      self.destroyDraft();
+
       if (result.responseJson.action === "enqueued") {
         self.send('postWasEnqueued', result.responseJson);
-        self.destroyDraft();
         self.close();
         self.appEvents.trigger('post-stream:refresh');
         return result;
       }
 
-      // If user "created a new topic/post" or "replied as a new topic" successfully, remove the draft.
-      if (result.responseJson.action === "create_post" || self.get('replyAsNewTopicDraft')) {
-        self.destroyDraft();
-      }
       if (self.get('model.action') === 'edit') {
         self.appEvents.trigger('post-stream:refresh', { id: parseInt(result.responseJson.id) });
       } else {


### PR DESCRIPTION
When a post is created the clearing of any drafts of the post is triggered from the client. However when a post is edited, the clearing of drafts is handled on the server by incrementing the draft sequence. Both types of saved content should be triggered from the client. As well as improving consistency, this fixes edge cases like that discussed here: https://meta.discourse.org/t/draft-not-cleared-properly-when-empty-edit-of-post-is-saved/40939