### PR TITLE
FEATURE: add site setting for setting locale from header

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -165,7 +165,7 @@ class ApplicationController < ActionController::Base
 
   def set_locale
     if !current_user
-      if SiteSetting.allow_user_locale
+      if SiteSetting.set_locale_from_accept_language_header
         I18n.locale = locale_from_header
       else
         I18n.locale = SiteSetting.default_locale

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1308,6 +1308,7 @@ en:
       pop3_polling_authentication_failed: "POP3 authentication failed. Please verify your pop3 credentials."
       reply_by_email_address_is_empty: "You must set a 'reply by email address' before enabling reply by email."
       pop3_polling_disabled: "You must first enabled POP3 polling before enabling reply by email."
+      user_locale_not_enabled: "You must first enable 'allow user locale' before enabling this setting."
 
   notification_types:
     group_mentioned: "%{group_name} was mentioned in %{link}"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -787,6 +787,7 @@ en:
     delete_old_hidden_posts: "Auto-delete any hidden posts that stay hidden for more than 30 days."
     default_locale: "The default language of this Discourse instance (ISO 639-1 Code)"
     allow_user_locale: "Allow users to choose their own language interface preference"
+    set_locale_from_accept_language_header: "set interface language for anonymous users from their web browser's language headers."
     min_post_length: "Minimum allowed post length in characters"
     min_first_post_length: "Minimum allowed first post (topic body) length in characters"
     min_private_message_post_length: "Minimum allowed post length in characters for messages"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -64,6 +64,9 @@ basic:
   allow_user_locale:
     client: true
     default: false
+  set_locale_from_accept_language_header:
+    default: false
+    validator: "AllowUserLocaleEnabledValidator"
   suggested_topics:
     client: true
     default: 5

--- a/lib/validators/allow_user_locale_enabled_validator.rb
+++ b/lib/validators/allow_user_locale_enabled_validator.rb
@@ -12,7 +12,7 @@ class AllowUserLocaleEnabledValidator
   end
 
   def error_message
-    "You must first enable 'allow user locale' before enabling this setting."
+    I18n.t("site_settings.errors.user_locale_not_enabled");
   end
 
 end

--- a/lib/validators/allow_user_locale_enabled_validator.rb
+++ b/lib/validators/allow_user_locale_enabled_validator.rb
@@ -1,0 +1,18 @@
+class AllowUserLocaleEnabledValidator
+
+  def initialize(opts={})
+    @opts = opts
+  end
+
+  def valid_value?(val)
+    # only validate when enabling setting locale from headers
+    return true if val == "f"
+    # ensure that allow_user_locale is enabled
+    SiteSetting.allow_user_locale
+  end
+
+  def error_message
+    "You must first enable 'allow user locale' before enabling this setting."
+  end
+
+end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -148,10 +148,11 @@ describe TopicsController do
       end
     end
 
-    context "allow_user_locale enabled" do
+    context "set_locale_from_accept_language_header enabled" do
       context "accept-language header differs from default locale" do
         before do
           SiteSetting.stubs(:allow_user_locale).returns(true)
+          SiteSetting.stubs(:set_locale_from_accept_language_header).returns(true)
           SiteSetting.stubs(:default_locale).returns("en")
           set_accept_language("fr")
         end
@@ -178,7 +179,7 @@ describe TopicsController do
 
       context "the preferred locale includes a region" do
         it "returns the locale and region separated by an underscore" do
-          SiteSetting.stubs(:allow_user_locale).returns(true)
+          SiteSetting.stubs(:set_locale_from_accept_language_header).returns(true)
           SiteSetting.stubs(:default_locale).returns("en")
           set_accept_language("zh-CN")
 


### PR DESCRIPTION
See https://meta.discourse.org/t/different-behaviour-of-text-direction-for-not-logged-in-visitors/40747

Adds a site setting for setting the locale from accept language headers. The new setting defaults to false and is dependent on `allow_user_locale` being set to true.

![screenshot 2016-03-14 16 01 05](https://cloud.githubusercontent.com/assets/2975917/13763156/5b7cf67c-ea01-11e5-914a-daeae34319d0.png)
