### PR TITLE
Advance draft sequence in PostRevisor if edit contains no changes

### DIFF
--- a/lib/post_revisor.rb
+++ b/lib/post_revisor.rb
@@ -154,6 +154,7 @@ class PostRevisor
     POST_TRACKED_FIELDS.each do |field|
       return true if @fields.has_key?(field) && @fields[field] != @post.send(field)
     end
+    advance_draft_sequence
     false
   end
 


### PR DESCRIPTION
Simplest version of the server-side fix for
https://meta.discourse.org/t/draft-not-cleared-properly-when-empty-edit-of-post-is-saved/40939