### PR TITLE
update redis dependency in documentation

### DIFF
--- a/docs/DEVELOPER-ADVANCED.md
+++ b/docs/DEVELOPER-ADVANCED.md
@@ -9,7 +9,7 @@ Note: If you are developing on a Mac, you will probably want to look at [these i
 1. Install and configure PostgreSQL 9.3+.
   1. Run `postgres -V` to see if you already have it.
   1. Make sure that the server's messages language is English; this is [required](https://github.com/rails/rails/blob/3006c59bc7a50c925f6b744447f1d94533a64241/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L1140) by the ActiveRecord Postgres adapter.
-2. Install and configure Redis 2+.
+2. Install and configure Redis 2.8.12+.
   1. Run `redis-server -v` to see if you already have it.
 3. Install ImageMagick
 4. Install libxml2, libpq-dev, g++, gifsicle, libjpeg-progs and make.


### PR DESCRIPTION
b1e0da starts using the redis ROLE command which is available in redis-server 2.8.12 and later.