### PR TITLE
FIX: Length for hashtags, increased to 101 characters.

### DIFF
--- a/app/assets/javascripts/discourse/dialects/category_hashtag_dialect.js
+++ b/app/assets/javascripts/discourse/dialects/category_hashtag_dialect.js
@@ -4,7 +4,7 @@
 **/
 Discourse.Dialect.inlineRegexp({
   start: '#',
-  matcher: /^#([\w-:]{1,50})/i,
+  matcher: /^#([\w-:]{1,101})/i,
   spaceOrTagBoundary: true,
 
   emitter: function(matches) {


### PR DESCRIPTION
I increased the char length for the hashtags to 101 characters with @tgxworld help, in order to solve this bug: https://meta.discourse.org/t/hashtag-linking-to-categories-doesn-t-always-work/41003/7