### PR TITLE
FIX: allow digest unsubscribe text to be overridden

### DIFF
--- a/app/views/user_notifications/digest.html.erb
+++ b/app/views/user_notifications/digest.html.erb
@@ -58,7 +58,7 @@
         <div>
         <%- @new_by_category.first(10).each do |c| %>
           <span style='white-space: nowrap'>
-            <a href='<%= Discourse.base_url %><%= c[0].url %>' style='color: #<%= @anchor_color %>'><%= c[0].name %></b> <span style='color: #777; margin: 0 10px 0 5px; font-size: 0.9em;'> <%= c[1] %></span>
+            <a href='<%= Discourse.base_url %><%= c[0].url %>' style='color: #<%= @anchor_color %>'><%= c[0].name %></b> <span style='color: #777; margin: 0 10px 0 5px; font-size: 0.9em;'> <%= c[1] %></span></a>
           </span>
         <%- end %>
       </div>
@@ -71,7 +71,7 @@
 </table>
 
 <div class='footer'>
-  <%=raw(t :'user_notifications.digest.unsubscribe',
+  <%=raw(t 'user_notifications.digest.unsubscribe',
            site_link: html_site_link(@anchor_color),
            unsubscribe_link: link_to(t('user_notifications.digest.click_here'), email_unsubscribe_url(host: Discourse.base_url, key: @unsubscribe_key), {:style=>'color: #' + @anchor_color }))  %>
 </div>


### PR DESCRIPTION
See: https://meta.discourse.org/t/changes-in-digest-unsubscribe-text-is-not-applied/40930/5?u=simon_cossar

Changes translation key from symbol to string so that it can be used to select the translation override returned from I18n.overrides_by_local. This happens in a few other places. I have only changed it here because I'm not sure this is the right approach.

This also closes an anchor tag in digest.html.erb