### PR TITLE
FIX: Change row name to "Replies" instead of "Posts" on the About section.

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -221,7 +221,7 @@ en:
         last_30_days: "Last 30 Days"
       like_count: "Likes"
       topic_count: "Topics"
-      post_count: "Posts"
+      post_count: "Replies"
       user_count: "New Users"
       active_user_count: "Active Users"
       contact: "Contact Us"


### PR DESCRIPTION
I changed this label on the Statistics table in order to fix this bug, the name of posts should be "Replies" not "Posts", posts are named as "Topics".

https://meta.discourse.org/t/about-page-site-statistics-doesnt-match-admin-dashboard-stats/41166