### PR TITLE
FIX: Pink hearts on the badges section.

### DIFF
--- a/app/assets/stylesheets/common/base/user-badges.scss
+++ b/app/assets/stylesheets/common/base/user-badges.scss
@@ -20,15 +20,15 @@
   }
 
   &.badge-type-gold .fa {
-    color: #ffd700;
+    color: #ffd700 !important;
   }
 
   &.badge-type-silver .fa {
-    color: #c0c0c0;
+    color: #c0c0c0 !important;
   }
 
   &.badge-type-bronze .fa {
-    color: #cd7f32;
+    color: #cd7f32 !important;
   }
 }
 


### PR DESCRIPTION
On the badges section for users, hearts icons badges were being pink instead of bronze/silver/gold. I made this PR in order to fix this bug:

https://meta.discourse.org/t/heart-badge-icons-on-user-profiles-shouldnt-be-pink/41227/