### PR TITLE
DOCS: Add additional help for how to use 'h' helper with virtual DOM

### DIFF
--- a/app/assets/javascripts/discourse/widgets/decorator-helper.js.es6
+++ b/app/assets/javascripts/discourse/widgets/decorator-helper.js.es6
@@ -19,6 +19,8 @@ class DecoratorHelper {
    * // renders `<div class='some-class'><p>paragraph</p></div>`
    * return helper.h('div.some-class', helper.h('p', 'paragraph'));
    * ```
+   * Check out  https://github.com/Matt-Esch/virtual-dom/blob/master/virtual-hyperscript/README.md
+   * for more details on how to construct markup with h.
    **/
   // h() is attached via `prototype` below
 


### PR DESCRIPTION
If you're a vdom n00b like me, constructing actually-useful markup (with styles, attributes, multiple children, etc.) with the 'h' helper isn't very straightforward. Thought this might save some poor soul from having to google the letter 'h'.

@eviltrout