### PR TITLE
FIX: redirect output omniauth log to Rails logger instead of stdout

### DIFF
--- a/config/initializers/009-omniauth.rb
+++ b/config/initializers/009-omniauth.rb
@@ -9,3 +9,5 @@ Rails.application.config.middleware.use OmniAuth::Builder do
     authenticator.register_middleware(self)
   end
 end
+ 
+OmniAuth.config.logger = Rails.logger


### PR DESCRIPTION
It's easier to check logster output at `/logs` instead of `tail` unicorn.std...

Omniauth also respects the log level Discourse set.