### PR TITLE
Fix: Added underscore to my_redirect regex

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -165,7 +165,7 @@ class UsersController < ApplicationController
   end
 
   def my_redirect
-    raise Discourse::NotFound if params[:path] !~ /^[a-z\-\/]+$/
+    raise Discourse::NotFound if params[:path] !~ /^[a-z_\-\/]+$/
 
     if current_user.blank?
       cookies[:destination_url] = "/my/#{params[:path]}"


### PR DESCRIPTION
With reference to [/my/messages/group/GROUPNAME link doesn’t work](https://meta.discourse.org/t/my-messages-group-groupname-link-doesnt-work/41198)