### PR TITLE
Fixed: DecoratorHelper.cooked passing wrong parameters to PostCooked class

### DIFF
--- a/app/assets/javascripts/discourse/widgets/decorator-helper.js.es6
+++ b/app/assets/javascripts/discourse/widgets/decorator-helper.js.es6
@@ -79,8 +79,8 @@ class DecoratorHelper {
    * return helper.cooked(`<p>Cook me</p>`);
    * ```
    **/
-  cooked(cookedText) {
-    return new PostCooked({ cookedText });
+  cooked(cooked) {
+    return new PostCooked({ cooked });
   }
 
   /**


### PR DESCRIPTION
Cooked post from widget was being rendered as undefined. The error seems to be in [this line]
(https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/widgets/decorator-helper.js.es6#L83).

`return new PostCooked({ cookedText });`

The function creates new PostCooked and passes cookedText as a parameter, but in PostCooked class, it uses [this.attrs.cooked](https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/widgets/post-cooked.js.es6#L27) instead of cookedText
>Fix made:
`cooked(cooked) {
  return new PostCooked({ cooked });
}`
