### PR TITLE
Fix: Prevent moderators from seeing other users bookmarks

### DIFF
--- a/app/models/user_action.rb
+++ b/app/models/user_action.rb
@@ -342,11 +342,11 @@ SQL
     builder.where("COALESCE(p.post_type, p2.post_type) IN (:visible_post_types)", visible_post_types: visible_post_types)
 
     unless (guardian.user && guardian.user.id == user_id) || guardian.is_staff?
-      builder.where("a.action_type not in (#{BOOKMARK})")
       builder.where("t.visible")
     end
 
     unless guardian.can_see_notifications?(User.where(id: user_id).first)
+      builder.where("a.action_type not in (#{BOOKMARK})")
       builder.where('a.action_type <> :pending', pending: UserAction::PENDING)
     end
 


### PR DESCRIPTION
**What does this PR do?**

This PR prevents moderators from seeing another user's bookmarks. Although moderators already don't see the bookmark link the user's profile, they can still access the user's bookmarks by manually inputting the URL. This PR causes moderators to see nothing when they manually access the URL, similar to what currently happens to any user.

See https://meta.discourse.org/t/moderators-still-able-to-access-other-users-bookmarks/38962 and https://meta.discourse.org/t/moderators-cannot-view-bookmarks-on-other-users-activity-pages/37349 for more info. 

**How should this be manually tested?**

See https://meta.discourse.org/t/moderators-still-able-to-access-other-users-bookmarks/38962

**Screenshots**

Before
![screenshot from 2016-03-20 18 37 26](https://cloud.githubusercontent.com/assets/1075053/13906311/2e4fb954-eecb-11e5-9f32-1f14a8d6ac89.png)


After
![screenshot from 2016-03-20 18 36 40](https://cloud.githubusercontent.com/assets/1075053/13906313/335b4c1a-eecb-11e5-96c4-f0bd8f51779a.png)
