### PR TITLE
FIX: Allow displaying posts by deleted users.

### DIFF
--- a/app/assets/javascripts/discourse/lib/transform-post.js.es6
+++ b/app/assets/javascripts/discourse/lib/transform-post.js.es6
@@ -85,9 +85,11 @@ export default function transformPost(currentUser, site, post, prevPost, nextPos
 
   const postAtts = transformBasicPost(post);
 
+  const createdBy = details.created_by || {};
+
   postAtts.topicId = topic.id;
-  postAtts.topicOwner = details.created_by.id === post.user_id;
-  postAtts.topicCreatedById = details.created_by.id;
+  postAtts.topicOwner = createdBy.id === post.user_id;
+  postAtts.topicCreatedById = createdBy.id;
   postAtts.post_type = postType;
   postAtts.via_email = post.via_email;
   postAtts.isModeratorAction = postType === postTypes.moderator_action;
@@ -120,8 +122,8 @@ export default function transformPost(currentUser, site, post, prevPost, nextPos
   if (showTopicMap) {
     postAtts.showTopicMap = true;
     postAtts.topicCreatedAt = topic.created_at;
-    postAtts.createdByUsername = details.created_by.username;
-    postAtts.createdByAvatarTemplate = details.created_by.avatar_template;
+    postAtts.createdByUsername = createdBy.username;
+    postAtts.createdByAvatarTemplate = createdBy.avatar_template;
 
     postAtts.lastPostUrl = topic.get('lastPostUrl');
     postAtts.lastPostUsername = details.last_poster.username;


### PR DESCRIPTION
Before this change, as reported on https://meta.discourse.org/t/topic-not-deleted-after-deleting-spammer/41348:

![](https://meta-s3-cdn.global.ssl.fastly.net/original/3X/c/9/c9e15e831d607755017be8082f921f0af439804d.png)

After this change:

![](https://cloud.githubusercontent.com/assets/1297598/13912927/3dd4279e-ef42-11e5-8971-df52a0bd38cd.png)

Apparently, Discourse intentionally doesn't remove permanently posts by spammers, but makes them invisible from non-staff. However, the code responsible for displaying posts couldn't handle the case of null user without throwing an exception.