### PR TITLE
Change SendGrid info to use api key

### DIFF
--- a/docs/INSTALL-email.md
+++ b/docs/INSTALL-email.md
@@ -26,9 +26,10 @@ If not using **the exact** domain you verified (e.g. you're using a subdomain of
 ```yml
 DISCOURSE_SMTP_ADDRESS: smtp.sendgrid.net
 DISCOURSE_SMTP_PORT: 587
-DISCOURSE_SMTP_USER_NAME: [SendGrid username]
-DISCOURSE_SMTP_PASSWORD: [SendGrid password]
+DISCOURSE_SMTP_USER_NAME: apikey
+DISCOURSE_SMTP_PASSWORD: [SendGrid API Key]
 ```
+We recommend creating an [API Key][sg2] instead of using your SendGrid username and password.
 
 #### [Mailgun][gun] (10k emails/month)
 
@@ -49,3 +50,4 @@ Go to [My Account page](https://www.mailjet.com/account) and click on the ["SMTP
   [jet]: https://www.mailjet.com/pricing
   [gun]: http://www.mailgun.com/
    [sg]: https://sendgrid.com/
+  [sg2]: https://sendgrid.com/docs/Classroom/Send/How_Emails_Are_Sent/api_keys.html


### PR DESCRIPTION
While it does work I don't think using your SendGrid username and password is good practice so we probably shouldn't promote it. API Keys should be used instead.