### PR TITLE
UPDATE: VAGRANT.md, link to become eviltrout admin.

### DIFF
--- a/docs/VAGRANT.md
+++ b/docs/VAGRANT.md
@@ -94,7 +94,7 @@ In a few seconds, rails will start serving pages. To access them, open a web bro
 
 If you want to log in as a user, a shortcut you can use in development mode is to follow this link to log in as `eviltrout`:
 
-http://localhost:4000/session/eviltrout/become
+[http://localhost:4000/session/eviltrout/become](http://localhost:4000/session/eviltrout/become)
 
 You can now edit files on your local file system, using your favorite text editor or IDE. When you reload your web browser, it should have the latest changes.
 


### PR DESCRIPTION
I updated the VAGRANT.md file to add a link to become **eviltrout** instead of only a label, as is posted on this section:

> In a few seconds, rails will start serving pages. To access them, open a web browser to [http://localhost:4000](http://localhost:4000) - if it all worked you should see discourse! Congratulations, you are ready to start working!
