### PR TITLE
Fix for long emoji names in autocomplete

### DIFF
--- a/app/assets/javascripts/discourse/templates/emoji-selector-autocomplete.raw.hbs
+++ b/app/assets/javascripts/discourse/templates/emoji-selector-autocomplete.raw.hbs
@@ -4,7 +4,8 @@
       <li>
         <a href>
           {{#if option.src}}
-            <img src={{option.src}} class='emoji'> {{option.code}}
+            <img src={{option.src}} class='emoji'>
+            <span class='emoji-shortname'>{{option.code}}</span>
           {{else}}
             {{option.label}}
           {{/if}}

--- a/app/assets/stylesheets/common/base/emoji.scss
+++ b/app/assets/stylesheets/common/base/emoji.scss
@@ -100,3 +100,11 @@ table.emoji-page td {
 .emoji-modal .nav a {
   color: dark-light-choose(#333, #ccc);
 }
+
+.emoji-shortname {
+  display: inline-block;
+  max-width: 200px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  vertical-align: middle;
+}


### PR DESCRIPTION
Before:
![screen shot 2016-03-23 at 7 57 42 am](https://cloud.githubusercontent.com/assets/750477/13964487/d028c9d2-f0ce-11e5-8265-83387d331889.png)

After:
![screen shot 2016-03-23 at 8 11 01 am](https://cloud.githubusercontent.com/assets/750477/13964488/d64bc65c-f0ce-11e5-80bd-2c7cbada0659.png)
