### PR TITLE
add ability to have post-menu button in second position

### DIFF
--- a/app/assets/javascripts/discourse/widgets/post-menu.js.es6
+++ b/app/assets/javascripts/discourse/widgets/post-menu.js.es6
@@ -270,6 +270,9 @@ export default createWidget('post-menu', {
               case 'first':
                 visibleButtons.unshift(button);
                 break;
+              case 'second':
+                visibleButtons.splice(1, 0, button);
+                break;
               case 'second-last-hidden':
                 if (!state.collapsed) {
                   visibleButtons.splice(visibleButtons.length-2, 0, button);


### PR DESCRIPTION
This applies to buttons created with `api.addPostMenuButton`. The case `second` will place the button after index 0.