### PR TITLE
FIX: posts.rss route  when left clicked.

### DIFF
--- a/app/assets/javascripts/discourse/lib/url.js.es6
+++ b/app/assets/javascripts/discourse/lib/url.js.es6
@@ -99,7 +99,17 @@ const DiscourseURL = Ember.Object.createWithMixins({
   **/
 
   isInternalPathButNotEmber: function(path){
-    return path.indexOf("posts.rss") >= 0
+   /*
+   RSSwhitelist = ["posts.rss", "support.rss", "bug.rss", "feature.rss", "dev.rss", "ux.rss", "installation.rss",
+   "meta.rss", "marketplace.rss", "hosting.rss", "howto.rss", "plugin.rss", "praise.rss", "blog.rss", "faq.rss", "releases.rss"];
+
+   This array contains some of the .rss routes on Discourse, several of them are categories, and the method is
+   extracting the .rss route and verifying if the indexOf is >= to zero.
+   */
+
+   let pathStripped =  path.split("/").pop();
+   return path.indexOf(pathStripped) >= 0;
+
   },
 
   routeTo(path, opts) {

--- a/app/assets/javascripts/discourse/lib/url.js.es6
+++ b/app/assets/javascripts/discourse/lib/url.js.es6
@@ -97,10 +97,15 @@ const DiscourseURL = Ember.Object.createWithMixins({
     It contains the logic necessary to route within a topic using replaceState to
     keep the history intact.
   **/
+
+  isInternalPathButNotEmber: function(path){
+    return path.indexOf("posts.rss") >= 0
+  },
+
   routeTo(path, opts) {
     if (Em.isEmpty(path)) { return; }
 
-    if (Discourse.get('requiresRefresh')) {
+    if (Discourse.get('requiresRefresh') || this.isInternalPathButNotEmber(path)) {
       document.location.href = Discourse.getURL(path);
       return;
     }


### PR DESCRIPTION
I made a quick fix for the route **/posts.rss** when it's right clicked, the bug is that the path is not being sent to the server or being handle by Ember, it just don't send the post, but this quick fix works. We need to check out how the **handleURL** function works.

This PR fix this bug:

https://meta.discourse.org/t/left-clicking-link-to-posts-rss-does-not-work/41437