### PR TITLE
Feature: Merge multiple responses

### DIFF
--- a/app/assets/javascripts/discourse/controllers/topic.js.es6
+++ b/app/assets/javascripts/discourse/controllers/topic.js.es6
@@ -517,6 +517,25 @@ export default Ember.Controller.extend(SelectedPostsCount, BufferedContent, {
       });
     },
 
+    mergePosts() {
+      bootbox.confirm(I18n.t("post.delete.confirm", { count: this.get('selectedPostsCount')}), result => {
+        if (result) {
+          const selectedPosts = this.get('selectedPosts');
+          const selectedReplies = this.get('selectedReplies');
+          const postStream = this.get('model.postStream');
+
+          Discourse.Post.mergePosts(selectedPosts, selectedReplies);
+          //postStream.get('posts').forEach(p => {
+          //  if (this.postSelected(p)) {
+          //    p.set('deleted_at', new Date());
+          //  }
+          //});
+
+          this.send('toggleMultiSelect');
+        }
+      });
+    },
+
     expandHidden(post) {
       post.expandHidden();
     },
@@ -691,6 +710,11 @@ export default Ember.Controller.extend(SelectedPostsCount, BufferedContent, {
     if (!Discourse.User.current() || !Discourse.User.current().admin) return false;
     return this.get('selectedPostsUsername') !== undefined;
   }.property('selectedPostsUsername'),
+
+  canMergePosts: function() {
+    if (this.get('selectedPostsCount') < 2) return false;
+    return this.get('selectedPostsUsername') !== undefined;
+  }.property('selectedPostsCount'),
 
   categories: function() {
     return Discourse.Category.list();

--- a/app/assets/javascripts/discourse/controllers/topic.js.es6
+++ b/app/assets/javascripts/discourse/controllers/topic.js.es6
@@ -522,7 +522,7 @@ export default Ember.Controller.extend(SelectedPostsCount, BufferedContent, {
         if (result) {
           const selectedPosts = this.get('selectedPosts');
 
-          Discourse.Post.mergePosts(selectedPosts);
+          Post.mergePosts(selectedPosts);
           this.send('toggleMultiSelect');
         }
       });
@@ -709,12 +709,7 @@ export default Ember.Controller.extend(SelectedPostsCount, BufferedContent, {
     // Must be able to delete all of the posts, this makes it so
     // that the main post of a topic can't be part of the merged posts
     const selectedPosts = this.get('selectedPosts');
-    let canDelete = true;
-    selectedPosts.forEach(function(p) {
-      if (!p.get('can_delete')) {
-        canDelete = false;
-      }
-    });
+    let canDelete = selectedPosts.every(p => p.get('can_delete'));
     if(!canDelete) return false;
     // All the posts must have the same creator
     return this.get('selectedPostsUsername') !== undefined;

--- a/app/assets/javascripts/discourse/controllers/topic.js.es6
+++ b/app/assets/javascripts/discourse/controllers/topic.js.es6
@@ -712,7 +712,7 @@ export default Ember.Controller.extend(SelectedPostsCount, BufferedContent, {
     const selectedPosts = this.get('selectedPosts');
     let canDelete = true;
     selectedPosts.forEach(function(p) {
-      if (!canDelete || !p.get('can_delete')) {
+      if (!p.get('can_delete')) {
         canDelete = false;
       }
     });

--- a/app/assets/javascripts/discourse/controllers/topic.js.es6
+++ b/app/assets/javascripts/discourse/controllers/topic.js.es6
@@ -522,7 +522,6 @@ export default Ember.Controller.extend(SelectedPostsCount, BufferedContent, {
         if (result) {
           const selectedPosts = this.get('selectedPosts');
           const selectedReplies = this.get('selectedReplies');
-          const postStream = this.get('model.postStream');
 
           Discourse.Post.mergePosts(selectedPosts, selectedReplies);
           this.send('toggleMultiSelect');

--- a/app/assets/javascripts/discourse/controllers/topic.js.es6
+++ b/app/assets/javascripts/discourse/controllers/topic.js.es6
@@ -522,7 +522,7 @@ export default Ember.Controller.extend(SelectedPostsCount, BufferedContent, {
         if (result) {
           const selectedPosts = this.get('selectedPosts');
 
-          Post.mergePosts(selectedPosts);
+          Discourse.Post.mergePosts(selectedPosts);
           this.send('toggleMultiSelect');
         }
       });

--- a/app/assets/javascripts/discourse/controllers/topic.js.es6
+++ b/app/assets/javascripts/discourse/controllers/topic.js.es6
@@ -518,19 +518,13 @@ export default Ember.Controller.extend(SelectedPostsCount, BufferedContent, {
     },
 
     mergePosts() {
-      bootbox.confirm(I18n.t("post.delete.confirm", { count: this.get('selectedPostsCount')}), result => {
+      bootbox.confirm(I18n.t("post.merge.confirm", { count: this.get('selectedPostsCount')}), result => {
         if (result) {
           const selectedPosts = this.get('selectedPosts');
           const selectedReplies = this.get('selectedReplies');
           const postStream = this.get('model.postStream');
 
           Discourse.Post.mergePosts(selectedPosts, selectedReplies);
-          //postStream.get('posts').forEach(p => {
-          //  if (this.postSelected(p)) {
-          //    p.set('deleted_at', new Date());
-          //  }
-          //});
-
           this.send('toggleMultiSelect');
         }
       });
@@ -712,7 +706,19 @@ export default Ember.Controller.extend(SelectedPostsCount, BufferedContent, {
   }.property('selectedPostsUsername'),
 
   canMergePosts: function() {
+    // Two or more posts selected
     if (this.get('selectedPostsCount') < 2) return false;
+    // Must be able to delete all of the posts, this makes it so
+    // that the main post of a topic can't be part of the merged posts
+    const selectedPosts = this.get('selectedPosts');
+    let canDelete = true;
+    selectedPosts.forEach(function(p) {
+      if (!canDelete || !p.get('can_delete')) {
+        canDelete = false;
+      }
+    });
+    if(!canDelete) return false;
+    // All the posts must have the same creator
     return this.get('selectedPostsUsername') !== undefined;
   }.property('selectedPostsCount'),
 

--- a/app/assets/javascripts/discourse/controllers/topic.js.es6
+++ b/app/assets/javascripts/discourse/controllers/topic.js.es6
@@ -521,9 +521,8 @@ export default Ember.Controller.extend(SelectedPostsCount, BufferedContent, {
       bootbox.confirm(I18n.t("post.merge.confirm", { count: this.get('selectedPostsCount')}), result => {
         if (result) {
           const selectedPosts = this.get('selectedPosts');
-          const selectedReplies = this.get('selectedReplies');
 
-          Discourse.Post.mergePosts(selectedPosts, selectedReplies);
+          Discourse.Post.mergePosts(selectedPosts);
           this.send('toggleMultiSelect');
         }
       });

--- a/app/assets/javascripts/discourse/models/post.js.es6
+++ b/app/assets/javascripts/discourse/models/post.js.es6
@@ -324,13 +324,10 @@ Post.reopenClass({
     });
   },
 
-  mergePosts(selectedPosts, selectedReplies) {
+  mergePosts(selectedPosts) {
     return Discourse.ajax("/posts/merge_posts", {
       type: 'PUT',
-      data: {
-        post_ids: selectedPosts.map(function(p) { return p.get('id'); }),
-        reply_post_ids: selectedReplies.map(function(p) { return p.get('id'); })
-      }
+      data: {post_ids: selectedPosts.map(p => p.get('id'))}
     });
   },
 

--- a/app/assets/javascripts/discourse/models/post.js.es6
+++ b/app/assets/javascripts/discourse/models/post.js.es6
@@ -321,7 +321,7 @@ Post.reopenClass({
         post_ids: selectedPosts.map(function(p) { return p.get('id'); }),
         reply_post_ids: selectedReplies.map(function(p) { return p.get('id'); })
       }
-    });
+    }).catch(popupAjaxError);
   },
 
   mergePosts(selectedPosts) {

--- a/app/assets/javascripts/discourse/models/post.js.es6
+++ b/app/assets/javascripts/discourse/models/post.js.es6
@@ -324,6 +324,16 @@ Post.reopenClass({
     });
   },
 
+  mergePosts(selectedPosts, selectedReplies) {
+    return Discourse.ajax("/posts/merge_posts", {
+      type: 'PUT',
+      data: {
+        post_ids: selectedPosts.map(function(p) { return p.get('id'); }),
+        reply_post_ids: selectedReplies.map(function(p) { return p.get('id'); })
+      }
+    });
+  },
+
   loadRevision(postId, version) {
     return Discourse.ajax("/posts/" + postId + "/revisions/" + version + ".json")
                     .then(result => Ember.Object.create(result));

--- a/app/assets/javascripts/discourse/templates/selected-posts.hbs
+++ b/app/assets/javascripts/discourse/templates/selected-posts.hbs
@@ -24,4 +24,9 @@
   {{d-button action="changeOwner" icon="user" label="topic.change_owner.action"}}
 {{/if}}
 
+{{#if canMergePosts}}
+  {{d-button action="mergePosts" icon="arrows" label="topic.merge_posts.action"}}
+{{/if}}
+
+
 <p class='cancel'><a href {{action "toggleMultiSelect"}}>{{i18n 'topic.multi_select.cancel'}}</a></p>

--- a/app/assets/javascripts/discourse/templates/selected-posts.hbs
+++ b/app/assets/javascripts/discourse/templates/selected-posts.hbs
@@ -25,7 +25,7 @@
 {{/if}}
 
 {{#if canMergePosts}}
-  {{d-button action="mergePosts" icon="arrows" label="topic.merge_posts.action"}}
+  {{d-button action="mergePosts" icon="arrows-v" label="topic.merge_posts.action"}}
 {{/if}}
 
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -278,7 +278,7 @@ class PostsController < ApplicationController
     params.require(:post_ids)
 
     posts = Post.where(id: post_ids_including_replies).order(:id)
-    raise Discourse::InvalidParameters.new(:post_ids) if posts.blank?
+    raise Discourse::InvalidParameters.new(:post_ids) if posts.pluck(:id) == params[:post_ids]
 
     # Make sure we can delete the posts
     posts.each {|p| guardian.ensure_can_delete!(p) }

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -280,6 +280,9 @@ class PostsController < ApplicationController
     posts = Post.where(id: post_ids_including_replies).order(:id)
     raise Discourse::InvalidParameters.new(:post_ids) if posts.blank?
 
+    # Make sure we can delete the posts
+    posts.each {|p| guardian.ensure_can_delete!(p) }
+
     PostMerger.new(current_user, posts).merge
 
     render nothing: true

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -280,19 +280,7 @@ class PostsController < ApplicationController
     posts = Post.where(id: post_ids_including_replies).order(:id)
     raise Discourse::InvalidParameters.new(:post_ids) if posts.blank?
 
-    # Make sure we can delete the posts
-    posts.each {|p| guardian.ensure_can_delete!(p) }
-
     PostMerger.new(current_user, posts).merge
-
-    Post.transaction do
-      posts.each_with_index  do |p, index|
-        # do not delete the last post since in will have the content of the merged posts
-        if index < posts.length - 1
-          PostDestroyer.new(current_user, p).destroy
-        end
-      end
-    end
 
     render nothing: true
   end

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1520,9 +1520,6 @@ en:
         title: "Merge Selected Posts"
         action: "merge selected posts"
         error: "There was an error merging the selected posts."
-        instructions:
-          one: "Please choose the topic you'd like to move that post to."
-          other: "Please choose the topic you'd like to move those <b>{{count}}</b> posts to."
 
       change_owner:
         title: "Change Owner of Posts"
@@ -1742,6 +1739,11 @@ en:
         confirm:
           one: "Are you sure you want to delete that post?"
           other: "Are you sure you want to delete all those posts?"
+
+      merge:
+        confirm:
+          one: "Are you sure you want merge those posts?"
+          other: "Are you sure you want to merge those {{count}} posts?"
 
       revisions:
         controls:

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1516,6 +1516,14 @@ en:
           one: "Please choose the topic you'd like to move that post to."
           other: "Please choose the topic you'd like to move those <b>{{count}}</b> posts to."
 
+      merge_posts:
+        title: "Merge Selected Posts"
+        action: "merge selected posts"
+        error: "There was an error merging the selected posts."
+        instructions:
+          one: "Please choose the topic you'd like to move that post to."
+          other: "Please choose the topic you'd like to move those <b>{{count}}</b> posts to."
+
       change_owner:
         title: "Change Owner of Posts"
         action: "change ownership"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -410,6 +410,7 @@ Discourse::Application.routes.draw do
     put "recover"
     collection do
       delete "destroy_many"
+      put "merge_posts"
     end
   end
 

--- a/lib/post_merger.rb
+++ b/lib/post_merger.rb
@@ -15,7 +15,7 @@ class PostMerger
     post = @posts.last
     changes = {
       raw: postContent.join("\n\n"),
-      edit_reason: "Merging the posts"
+      edit_reason: "Merged #{@posts.length} posts by #{@posts.first.user.name}"
     }
     revisor = PostRevisor.new(post, post.topic)
     revisor.revise!(@user, changes, {})

--- a/lib/post_merger.rb
+++ b/lib/post_merger.rb
@@ -1,0 +1,24 @@
+#
+# This class contains the logic to merge two or more posts by the same user
+#
+class PostMerger
+
+  def initialize(user, posts)
+    @user = user
+    @posts = posts
+  end
+
+  def merge
+    postContent = []
+    @posts.each {|p| postContent.push(p.raw) }
+
+    post = @posts.last
+    changes = {
+      raw: postContent.join("\n\n"),
+      edit_reason: "Merging the posts"
+    }
+    revisor = PostRevisor.new(post, post.topic)
+    revisor.revise!(@user, changes, {})
+  end
+
+end

--- a/lib/post_merger.rb
+++ b/lib/post_merger.rb
@@ -10,6 +10,7 @@ class PostMerger
 
   def merge
     postContent = []
+
     @posts.each {|p| postContent.push(p.raw) }
 
     post = @posts.last
@@ -19,6 +20,15 @@ class PostMerger
     }
     revisor = PostRevisor.new(post, post.topic)
     revisor.revise!(@user, changes, {})
+
+    Post.transaction do
+      @posts.each_with_index  do |p, index|
+        # do not delete the last post since in will have the content of the merged posts
+        if index < @posts.length - 1
+          PostDestroyer.new(@user, p).destroy
+        end
+      end
+    end
   end
 
 end

--- a/lib/post_merger.rb
+++ b/lib/post_merger.rb
@@ -11,17 +11,17 @@ class PostMerger
   def merge
     postContent = []
 
-    @posts.each {|p| postContent.push(p.raw) }
+    @posts.each { |p| postContent.push(p.raw) }
 
     post = @posts.last
     changes = {
       raw: postContent.join("\n\n"),
       edit_reason: "Merged #{@posts.length} posts by #{@user.name}"
     }
-    revisor = PostRevisor.new(post, post.topic)
-    revisor.revise!(@user, changes, {})
 
     Post.transaction do
+      revisor = PostRevisor.new(post, post.topic)
+      revisor.revise!(@user, changes, {})
       @posts.each_with_index  do |p, index|
         # do not delete the last post since it will have the content of the merged posts
         if index < @posts.length - 1

--- a/lib/post_merger.rb
+++ b/lib/post_merger.rb
@@ -16,14 +16,14 @@ class PostMerger
     post = @posts.last
     changes = {
       raw: postContent.join("\n\n"),
-      edit_reason: "Merged #{@posts.length} posts by #{@posts.first.user.name}"
+      edit_reason: "Merged #{@posts.length} posts by #{@user.name}"
     }
     revisor = PostRevisor.new(post, post.topic)
     revisor.revise!(@user, changes, {})
 
     Post.transaction do
       @posts.each_with_index  do |p, index|
-        # do not delete the last post since in will have the content of the merged posts
+        # do not delete the last post since it will have the content of the merged posts
         if index < @posts.length - 1
           PostDestroyer.new(@user, p).destroy
         end

--- a/spec/components/post_merger_spec.rb
+++ b/spec/components/post_merger_spec.rb
@@ -16,9 +16,19 @@ describe PostMerger do
     it "merges 3 posts" do
       Fabricate(:admin)
       topic = post.topic
-      reply1 = create_post(topic: topic)
-      reply2 = create_post(topic: topic)
-      reply3 = create_post(topic: topic)
+      reply1 = create_post(topic: topic, raw: 'The first reply')
+      reply2 = create_post(topic: topic, raw: %q{The second reply
+Second line}
+)
+      reply3 = create_post(topic: topic, raw: 'The third reply')
+
+      expected_output = %q{The first reply
+
+The second reply
+Second line
+
+The third reply}
+
 
       replies = []
       replies.push(reply1)
@@ -34,7 +44,7 @@ describe PostMerger do
       expect(reply2.deleted_at).not_to eq(nil)
       expect(reply3.deleted_at).to eq(nil)
       expect(reply3.edit_reason).to eq("Merged 3 posts by " + admin.name)
-      expect(reply3.raw).to eq(postContent.join("\n\n"))
+      expect(reply3.raw).to eq(expected_output)
     end
 
     it "does not merge 1 topic and 2 posts" do

--- a/spec/components/post_merger_spec.rb
+++ b/spec/components/post_merger_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+require 'post_merger'
+
+describe PostMerger do
+
+  before do
+    ActiveRecord::Base.observers.enable :all
+  end
+
+  let(:moderator) { Fabricate(:moderator) }
+  let(:admin) { Fabricate(:admin) }
+  let(:post) { create_post }
+
+  describe "merge posts" do
+
+    it "merges 3 posts" do
+      Fabricate(:admin)
+      topic = post.topic
+      reply1 = create_post(topic: topic)
+      reply2 = create_post(topic: topic)
+      reply3 = create_post(topic: topic)
+
+      replies = []
+      replies.push(reply1)
+      replies.push(reply2)
+      replies.push(reply3)
+
+      postContent = []
+      replies.each {|p| postContent.push(p.raw) }
+
+      PostMerger.new(admin, replies).merge
+
+      expect(reply1.deleted_at).not_to eq(nil)
+      expect(reply2.deleted_at).not_to eq(nil)
+      expect(reply3.deleted_at).to eq(nil)
+      expect(reply3.edit_reason).to eq("Merged 3 posts by " + admin.name)
+      expect(reply3.raw).to eq(postContent.join("\n\n"))
+    end
+
+    it "does not merge 1 topic and 2 posts" do
+      Fabricate(:admin)
+      topic = post.topic
+      reply1 = create_post(topic: topic)
+      reply2 = create_post(topic: topic)
+
+      replies = []
+      replies.push(topic)
+      replies.push(reply1)
+      replies.push(reply2)
+
+      reply2Raw = reply2.raw
+
+      expect{PostMerger.new(admin, replies).merge}.to raise_error(NoMethodError)
+
+      expect(topic.deleted_at).to eq(nil)
+      expect(reply1.deleted_at).to eq(nil)
+      expect(reply2.deleted_at).to eq(nil)
+      expect(reply2.raw).to eq(reply2Raw)
+    end
+
+  end
+end
+


### PR DESCRIPTION
This feature was requested in meta [here](https://meta.discourse.org/t/add-a-merge-multiple-responses-admin-post-selection-action/14904).

It adds a button to a topic's administration menu enabling the admin to merge 2 or more posts by the same user.

**Necessary conditions to merge posts:**
* All posts must be deletable (so the main post of a topic cannot be among the selected posts)
* 2 or more posts must be selected
* All posts must be by the same user

There's no additional logic to account for posts that are replies to other responses, all posts will be merged in the same way, chronologically, with two new lines between each one.

The merged content will be edited into the last selected posts while the remaining responses will be marked as deleted.