### PR TITLE
Mbox importer improvements (attachments and better subject strip)

### DIFF
--- a/script/import_scripts/mbox.rb
+++ b/script/import_scripts/mbox.rb
@@ -179,6 +179,22 @@ class ImportScripts::Mbox < ImportScripts::Base
 
         title = mail.subject
 
+        # import the attachments
+        mail.attachments.each do |attachment|
+          tmp = Tempfile.new("discourse-email-attachment")
+          begin
+            # read attachment
+            File.open(tmp.path, "w+b") { |f| f.write attachment.body.decoded }
+            # create the upload for the user
+            upload = Upload.create_for(user_id_from_imported_user_id(mail.from.first) || Discourse::SYSTEM_USER_ID, tmp, attachment.filename, tmp.size )
+            if upload && upload.errors.empty?
+              raw << "\n\n#{receiver.attachment_markdown(upload)}\n\n"
+            end
+          ensure
+            tmp.try(:close!) rescue nil
+          end
+        end
+
         { id: t['id'],
           title: clean_title(title),
           user_id: user_id_from_imported_user_id(mail.from.first) || Discourse::SYSTEM_USER_ID,
@@ -217,6 +233,22 @@ class ImportScripts::Mbox < ImportScripts::Base
 
         selected = receiver.select_body
         raw = selected.force_encoding(selected.encoding).encode("UTF-8")
+
+        # import the attachments
+        mail.attachments.each do |attachment|
+          tmp = Tempfile.new("discourse-email-attachment")
+          begin
+            # read attachment
+            File.open(tmp.path, "w+b") { |f| f.write attachment.body.decoded }
+            # create the upload for the user
+            upload = Upload.create_for(user_id_from_imported_user_id(mail.from.first) || Discourse::SYSTEM_USER_ID, tmp, attachment.filename, tmp.size )
+            if upload && upload.errors.empty?
+              raw << "\n\n#{receiver.attachment_markdown(upload)}\n\n"
+            end
+          ensure
+            tmp.try(:close!) rescue nil
+          end
+        end
 
         { id: id,
           topic_id: topic_id,

--- a/script/import_scripts/mbox.rb
+++ b/script/import_scripts/mbox.rb
@@ -95,7 +95,28 @@ class ImportScripts::Mbox < ImportScripts::Base
   end
 
   def clean_title(title)
-    title.gsub(/^Re: */i, '')
+    #Strip mailing list name from subject
+    title = title.gsub(/\[[^\]]+\]+/, '').strip
+
+    original_length = title.length
+
+    #Strip Reply prefix from title (Standard and localized)
+    title = title.gsub(/^Re: */i, '')
+    title = title.gsub(/^R: */i, '') #Italian
+    title = title.gsub(/^RIF: */i, '') #Italian
+
+    #Strip Forward prefix from title (Standard and localized)
+    title = title.gsub(/^Fwd: */i, '')
+    title = title.gsub(/^I: */i, '') #Italian
+
+    title.strip
+
+    #In case of mixed localized prefixes there could be many of them if the mail client didn't strip the localized ones
+    if original_length >  title.length
+      clean_title(title)
+    else
+      title
+    end
   end
 
   def clean_raw(raw)
@@ -156,7 +177,7 @@ class ImportScripts::Mbox < ImportScripts::Base
 
         raw = selected.force_encoding(selected.encoding).encode("UTF-8")
 
-        title = mail.subject.gsub(/\[[^\]]+\]+/, '').strip
+        title = mail.subject
 
         { id: t['id'],
           title: clean_title(title),


### PR DESCRIPTION
Improve the mbox importer: 

1. strip localized reply prefixes (just Italian right now but more can be easily added)
2. strip localized and standard forward prefixes (just Italian right now but more can be easily added)
3. Import attachments on the emails to the topic/reply