### PR TITLE
UX: user invite email style should be consistent with other user notifications

### DIFF
--- a/app/views/email/invite.html.erb
+++ b/app/views/email/invite.html.erb
@@ -1,0 +1,13 @@
+<div id='main' class=<%= classes %>>
+
+  <div class='header-instructions'>%{header_instructions}</div>
+
+  <% if message.present? %>
+    <div><%= message %></div>
+  <% end %>
+
+  <hr>
+  <div class='footer'>%{respond_instructions}</div>
+  <div class='footer'>%{unsubscribe_link}%{unsubscribe_via_email_link}</div>
+
+</div>

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2067,53 +2067,57 @@ en:
 
     posted_by: "Posted by %{username} on %{post_date}"
 
+    invited_to_private_message_body: |
+      %{username} invited you to a message
+
+      > **%{topic_title}**
+      >
+      > %{topic_excerpt}
+
+      at
+
+      > %{site_title} -- %{site_description}
+
+    invited_to_topic_body: |
+      %{username} invited you to a discussion
+
+      > **%{topic_title}**
+      >
+      > %{topic_excerpt}
+
+      at
+
+      > %{site_title} -- %{site_description}
+
     user_invited_to_private_message_pm:
       subject_template: "[%{site_name}] %{username} invited you to a message '%{topic_title}'"
       text_body_template: |
+        %{header_instructions}
 
-        %{username} invited you to a message
+        %{message}
 
-        > **%{topic_title}**
-        >
-        > %{topic_excerpt}
-
-        at
-
-        > %{site_title} -- %{site_description}
-
-        Please visit this link to view the message: %{base_url}%{url}
+        ---
+        %{respond_instructions}
 
     user_invited_to_private_message_pm_staged:
       subject_template: "[%{site_name}] %{username} invited you to a message '%{topic_title}'"
       text_body_template: |
+        %{header_instructions}
 
-        %{username} invited you to a message
+        %{message}
 
-        > **%{topic_title}**
-        >
-        > %{topic_excerpt}
-
-        at
-
-        > %{site_title} -- %{site_description}
-
-        Please visit this link to view the message: %{base_url}%{url}
+        ---
+        %{respond_instructions}
 
     user_invited_to_topic:
       subject_template: "[%{site_name}] %{username} invited you to '%{topic_title}'"
       text_body_template: |
+        %{header_instructions}
 
-        %{username} invited you to a discussion
+        %{message}
 
-        > **%{topic_title}**
-        >
-        > %{topic_excerpt}
-
-        at
-
-        > %{site_title} -- %{site_description}
-
-        Please visit this link to view the message: %{base_url}%{url}
+        ---
+        %{respond_instructions}
 
     user_replied:
       subject_template: "[%{site_name}] %{topic_title}"


### PR DESCRIPTION
This PR makes "user invited to topic" and "user invited to message" email style consistent with other user notification emails.

Before:

<img width="1280" alt="screen shot 2016-03-25 at 18 27 12" src="https://cloud.githubusercontent.com/assets/5732281/14045194/00cf10be-f2be-11e5-9a34-05def0271cdb.png">

After:

<img width="1276" alt="screen shot 2016-03-25 at 18 14 57" src="https://cloud.githubusercontent.com/assets/5732281/14045199/08c0788a-f2be-11e5-8e30-8292056b0ae6.png">

@eviltrout can you review this PR?