### PR TITLE
Add .byebug_history to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,9 @@ log/
 # Ignore Eclipse .buildpath file
 /.buildpath
 
+# Ignore byebug history
+/.byebug_history
+
 # Ignore RubyMine settings
 /.idea
 


### PR DESCRIPTION
Using byebug results in a `.byebug_history` file which stores a list of the previous commands fed to byebug, which doesn't belong in the repo and can be a bit annoying to step over any time a commit is made. Should be safe to git ignore.