### PR TITLE
FIX: badge display name should be translated from server.en.yml file

### DIFF
--- a/app/models/badge.rb
+++ b/app/models/badge.rb
@@ -379,7 +379,7 @@ SQL
 
   def display_name
     if self.system?
-      key = "admin_js.badges.badge.#{i18n_name}.name"
+      key = "badges.#{i18n_name}.name"
       I18n.t(key, default: self.name)
     else
       self.name


### PR DESCRIPTION
Currently the badge display name is not getting translated, and this is causing the build to fail.

This PR picks up the translation for badge name from `server.en.yml` file as per Sam's [recent commit](https://github.com/discourse/discourse/commit/fe51f84aa7225e984730d9354e535507180e00ce).

Build is passing locally.

@SamSaffron can you review this PR?