### PR TITLE
Add `after-site-map-links` plugin outlet

### DIFF
--- a/app/assets/javascripts/discourse/templates/components/hamburger-menu.hbs
+++ b/app/assets/javascripts/discourse/templates/components/hamburger-menu.hbs
@@ -73,6 +73,8 @@
 
     {{plugin-outlet "site-map-links-last"}}
   {{/menu-links}}
+  
+  {{plugin-outlet "after-site-map-links"}}
 
   {{mount-widget widget='hamburger-categories' args=(as-hash categories=categories)}}
   <hr>


### PR DESCRIPTION
For hummingbird.me I was hoping to shove some non-discourse-related links into the :hamburger: menu (mostly for mobile, where our full menu bar disappears), but there's a severe paucity of plugin outlets in there and the template is far too large to feasibly override.

This adds a plugin outlet in what I think is a fairly reasonable location for many purposes: below `site-map-links` and above the categories list.  If a plugin wants to add a section to the menu, this makes that possible (previously you could only really get it _inside_ the `site-map-links` list, unless you decorated the `hamburger-categories` widget to put something before it, even if you don't affect the categories list)