### PR TITLE
FIX: Digest broken anchor tag for blank/SVG logo

### DIFF
--- a/app/views/user_notifications/digest.html.erb
+++ b/app/views/user_notifications/digest.html.erb
@@ -5,8 +5,9 @@
     <%- if logo_url.blank? %>
       <%= SiteSetting.title %>
     <%- else %>
-      <img src="<%= logo_url %>" style="max-height: 35px; min-height: 35px; height: 35px;" class='site-logo'></a>
+      <img src="<%= logo_url %>" style="max-height: 35px; min-height: 35px; height: 35px;" class='site-logo'>
     <%- end %>
+    </a>
   </td>
 </tr>
 <tr>


### PR DESCRIPTION
Highlighted here:
https://meta.discourse.org/t/svg-image-as-digest-logo-has-limited-support/39935/11?u=deanmarktaylor