### PR TITLE
Style: align the "13 days later" element

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -292,7 +292,7 @@ table.md-table {
 
 .small-action {
   .topic-avatar {
-    padding: 5px 0;
+    padding: 5px 0 3px;
     border-top: none;
     float: left;
     i {
@@ -305,7 +305,7 @@ table.md-table {
 
   .small-action-desc {
     padding: 0.5em 0 0.5em 4em;
-    margin-top: 5px;
+    margin-top: 6px;
     text-transform: uppercase;
     font-weight: bold;
     font-size: 0.9em;


### PR DESCRIPTION
Hi, this mini request aligns the "X days later" element between topic posts. It wasn't quite vertically aligned. Now it is.

Before

![screen shot 2016-04-03 at 13 28 08](https://cloud.githubusercontent.com/assets/184567/14232176/6ca8d188-f9a0-11e5-9a87-134348c1d196.png)

After

![screen shot 2016-04-03 at 13 27 40](https://cloud.githubusercontent.com/assets/184567/14232179/8d8cc62a-f9a0-11e5-807a-a40bab51f7fe.png)