### PR TITLE
FIX: internal links in subfolder installs

### DIFF
--- a/app/models/topic_link.rb
+++ b/app/models/topic_link.rb
@@ -123,8 +123,10 @@ class TopicLink < ActiveRecord::Base
 
           if Discourse.store.has_been_uploaded?(url)
             internal = Discourse.store.internal?
-          elsif parsed.host == Discourse.current_hostname || !parsed.host
+          elsif (parsed.host == Discourse.current_hostname && parsed.path.start_with?(Discourse.base_uri)) || !parsed.host
             internal = true
+
+            parsed.path.slice!(Discourse.base_uri)
 
             route = Rails.application.routes.recognize_path(parsed.path)
 


### PR DESCRIPTION
https://meta.discourse.org/t/links-arent-showing-in-the-sidebar-or-topic-summaries-on-subfolder-installs/41787/15