### PR TITLE
altering topic-map widget's like count to show total topic like count

### DIFF
--- a/app/assets/javascripts/discourse/widgets/topic-map.js.es6
+++ b/app/assets/javascripts/discourse/widgets/topic-map.js.es6
@@ -81,7 +81,7 @@ createWidget('topic-map-summary', {
 
     if (attrs.topicLikeCount) {
       contents.push(h('li.secondary', [
-        numberNode(attrs.likeCount),
+        numberNode(attrs.topicLikeCount),
         h('h4', I18n.t('likes_lowercase', { count: attrs.likeCount }))
       ]));
     }

--- a/app/assets/javascripts/discourse/widgets/topic-map.js.es6
+++ b/app/assets/javascripts/discourse/widgets/topic-map.js.es6
@@ -82,7 +82,7 @@ createWidget('topic-map-summary', {
     if (attrs.topicLikeCount) {
       contents.push(h('li.secondary', [
         numberNode(attrs.topicLikeCount),
-        h('h4', I18n.t('likes_lowercase', { count: attrs.likeCount }))
+        h('h4', I18n.t('likes_lowercase', { count: attrs.topicLikeCount }))
       ]));
     }
 


### PR DESCRIPTION
Fixing bug where the `topic-map-summary` was only displaying the first post's like count rather than the entire topic's like count.