### PR TITLE
FIX: Consider using default top setting when user returns or enough data exists for Top Page Results

### DIFF
--- a/app/controllers/list_controller.rb
+++ b/app/controllers/list_controller.rb
@@ -334,16 +334,18 @@ class ListController < ApplicationController
       return period if top_topics.count >= SiteSetting.topics_per_period_in_top_page
     end
     # default period is yearly
-    SiteSetting.top_page_default_timeframe
+    SiteSetting.top_page_default_timeframe.to_sym
   end
 
   def self.best_periods_for(date)
     date ||= 1.year.ago
+    default_period = SiteSetting.top_page_default_timeframe.to_sym
     periods = []
-    periods << :daily   if date >   8.days.ago
-    periods << :weekly  if date >  35.days.ago
-    periods << :monthly if date > 180.days.ago
-    periods << :yearly
+    periods << default_period if :all     != default_period
+    periods << :daily         if :daily   != default_period && date >   8.days.ago
+    periods << :weekly        if :weekly  != default_period && date >  35.days.ago
+    periods << :monthly       if :monthly != default_period && date > 180.days.ago
+    periods << :yearly        if :yearly  != default_period
     periods
   end
 

--- a/spec/controllers/list_controller_spec.rb
+++ b/spec/controllers/list_controller_spec.rb
@@ -224,26 +224,60 @@ describe ListController do
   describe "best_periods_for" do
 
     it "returns yearly for more than 180 days" do
+      SiteSetting.stubs(:top_page_default_timeframe).returns("all")
       expect(ListController.best_periods_for(nil)).to eq([:yearly])
       expect(ListController.best_periods_for(180.days.ago)).to eq([:yearly])
     end
 
     it "includes monthly when less than 180 days and more than 35 days" do
+      SiteSetting.stubs(:top_page_default_timeframe).returns("all")
       (35...180).each do |date|
         expect(ListController.best_periods_for(date.days.ago)).to eq([:monthly, :yearly])
       end
     end
 
     it "includes weekly when less than 35 days and more than 8 days" do
+      SiteSetting.stubs(:top_page_default_timeframe).returns("all")
       (8...35).each do |date|
         expect(ListController.best_periods_for(date.days.ago)).to eq([:weekly, :monthly, :yearly])
       end
     end
 
     it "includes daily when less than 8 days" do
+      SiteSetting.stubs(:top_page_default_timeframe).returns("all")
       (0...8).each do |date|
         expect(ListController.best_periods_for(date.days.ago)).to eq([:daily, :weekly, :monthly, :yearly])
       end
+    end
+
+    it "returns default even for more than 180 days" do
+      SiteSetting.stubs(:top_page_default_timeframe).returns("monthly")
+      expect(ListController.best_periods_for(nil)).to eq([:monthly, :yearly])
+      expect(ListController.best_periods_for(180.days.ago)).to eq([:monthly, :yearly])
+    end
+
+    it "returns default even when less than 180 days and more than 35 days" do
+      SiteSetting.stubs(:top_page_default_timeframe).returns("weekly")
+      (35...180).each do |date|
+        expect(ListController.best_periods_for(date.days.ago)).to eq([:weekly, :monthly, :yearly])
+      end
+    end
+
+    it "returns default even when less than 35 days and more than 8 days" do
+      SiteSetting.stubs(:top_page_default_timeframe).returns("daily")
+      (8...35).each do |date|
+        expect(ListController.best_periods_for(date.days.ago)).to eq([:daily, :weekly, :monthly, :yearly])
+      end
+    end
+
+    it "doesn't return default when set to all" do
+      SiteSetting.stubs(:top_page_default_timeframe).returns("all")
+      expect(ListController.best_periods_for(nil)).to eq([:yearly])
+    end
+
+    it "doesn't return value twice when matches default" do
+      SiteSetting.stubs(:top_page_default_timeframe).returns("yearly")
+      expect(ListController.best_periods_for(nil)).to eq([:yearly])
     end
 
   end


### PR DESCRIPTION
Return default top setting as part of best_periods_for to see if it can be used