### PR TITLE
Remove `has_many :views` from User

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,7 +29,6 @@ class User < ActiveRecord::Base
   has_many :topic_allowed_users, dependent: :destroy
   has_many :topics_allowed, through: :topic_allowed_users, source: :topic
   has_many :email_tokens, dependent: :destroy
-  has_many :views
   has_many :user_visits, dependent: :destroy
   has_many :invites, dependent: :destroy
   has_many :topic_links, dependent: :destroy


### PR DESCRIPTION
Not sure what 'views' are, but they don't seem to be a model (it's actually a column on the DB), and they break `as_json` on a User, so thinking it can go?

https://meta.discourse.org/t/uninitialized-constant-user-view/25177/10