### PR TITLE
Fix Romanian pluralization rules

### DIFF
--- a/app/assets/javascripts/locales/ro.js.erb
+++ b/app/assets/javascripts/locales/ro.js.erb
@@ -4,6 +4,6 @@
 
 I18n.pluralizationRules['ro'] = function (n) {
   if (n == 1) return "one";
-  if (n >= 1 && n <= 19) return "few";
+  if (n === 0 || n % 100 >= 1 && n % 100 <= 19) return "few";
   return "other";
 };


### PR DESCRIPTION
Adds missing conditions to the Romanian pluralization rules (related to https://github.com/discourse/discourse/pull/4126 and https://github.com/discourse/discourse/pull/4128). 
Third time's a charm. :smiley:

cc @iamntz