### PR TITLE
FIX: Show badge count of 1 on the badges page

### DIFF
--- a/app/assets/javascripts/discourse/components/badge-card.js.es6
+++ b/app/assets/javascripts/discourse/components/badge-card.js.es6
@@ -25,9 +25,11 @@ export default Ember.Component.extend({
 
   @computed('count', 'badge.grant_count')
   displayCount(count, grantCount) {
-    const c = parseInt(count || grantCount || 0);
-    if (c > 1) {
-      return c;
+    if (count == null) {
+      return grantCount;
+    }
+    if (count > 1) {
+      return count;
     }
   },
 


### PR DESCRIPTION
The badges page didn't show a count on the badge card if the badge was granted only once.
This changes it so that on user profiles only badge counts > 1 are shown and on the badges page counts > 0 are shown.