### PR TITLE
Fix: Custom user fields on user card could show for wrong user.

### DIFF
--- a/app/assets/javascripts/discourse/controllers/user-card.js.es6
+++ b/app/assets/javascripts/discourse/controllers/user-card.js.es6
@@ -27,7 +27,7 @@ export default Ember.Controller.extend({
   showMoreBadges: Em.computed.gt('moreBadgesCount', 0),
   showDelete: Em.computed.and("viewingAdmin", "showName", "user.canBeDeleted"),
 
-  @computed('model.user_fields.@each.value')
+  @computed('user.user_fields.@each.value')
   publicUserFields() {
     const siteUserFields = this.site.get('user_fields');
     if (!Ember.isEmpty(siteUserFields)) {


### PR DESCRIPTION
Fix issue:

User A has custom fields set
User B does not

If you click on User A and then User B, the custom fields would for User A show up on card for User B.