### PR TITLE
Make permalink import from phpBB3 configurable

### DIFF
--- a/script/import_scripts/phpbb3/importer.rb
+++ b/script/import_scripts/phpbb3/importer.rb
@@ -33,6 +33,12 @@ module ImportScripts::PhpBB3
       import_bookmarks if @settings.import_bookmarks
     end
 
+    def change_site_settings
+      super
+
+      @importers.permalink_importer.change_site_settings
+    end
+
     def get_site_settings_for_import
       settings = super
 
@@ -108,29 +114,6 @@ module ImportScripts::PhpBB3
       end
     end
 
-    # uncomment below lines to create permalink for categories
-    # def create_category(opts, import_id)
-    #   new_category = super
-    #   url = "viewforum.php?f=#{import_id}"
-    #   if !Permalink.find_by(url: url)
-    #     Permalink.create(url: url, category_id: new_category.id)
-    #   end
-    #   new_category
-    # end
-
-    # uncomment below lines to create permalink for topics
-    # def create_post(opts, import_id)
-    #   post = super
-    #   if post && (topic = post.topic) && (category = topic.category)
-    #     url = "viewtopic.php?f=#{category.custom_fields["import_id"]}&t=#{opts[:import_topic_id]}"
-
-    #     if !Permalink.find_by(url: url)
-    #       Permalink.create(url: url, topic_id: topic.id)
-    #     end
-    #   end
-    #   post
-    # end
-
     def import_private_messages
       if @settings.fix_private_messages
         puts '', 'fixing private messages'
@@ -172,8 +155,7 @@ module ImportScripts::PhpBB3
       # no need for this since the importer sets last_seen_at for each user during the import
     end
 
-    # Do not use the bbcode_to_md in base.rb. If enabled, it will be
-    # used in text_processor.rb instead.
+    # Do not use the bbcode_to_md in base.rb. It will be used in text_processor.rb instead.
     def use_bbcode_to_md?
       false
     end

--- a/script/import_scripts/phpbb3/importers/category_importer.rb
+++ b/script/import_scripts/phpbb3/importers/category_importer.rb
@@ -2,9 +2,11 @@ module ImportScripts::PhpBB3
   class CategoryImporter
     # @param lookup [ImportScripts::LookupContainer]
     # @param text_processor [ImportScripts::PhpBB3::TextProcessor]
-    def initialize(lookup, text_processor)
+    # @param permalink_importer [ImportScripts::PhpBB3::PermalinkImporter]
+    def initialize(lookup, text_processor, permalink_importer)
       @lookup = lookup
       @text_processor = text_processor
+      @permalink_importer = permalink_importer
     end
 
     def map_category(row)
@@ -14,6 +16,7 @@ module ImportScripts::PhpBB3
         parent_category_id: @lookup.category_id_from_imported_category_id(row[:parent_id]),
         post_create_action: proc do |category|
           update_category_description(category, row)
+          @permalink_importer.create_for_category(category, row[:forum_id])
         end
       }
     end

--- a/script/import_scripts/phpbb3/importers/importer_factory.rb
+++ b/script/import_scripts/phpbb3/importers/importer_factory.rb
@@ -5,6 +5,7 @@ require_relative 'category_importer'
 require_relative 'message_importer'
 require_relative 'poll_importer'
 require_relative 'post_importer'
+require_relative 'permalink_importer'
 require_relative 'user_importer'
 require_relative '../support/smiley_processor'
 require_relative '../support/text_processor'
@@ -29,11 +30,11 @@ module ImportScripts::PhpBB3
     end
 
     def category_importer
-      CategoryImporter.new(@lookup, text_processor)
+      CategoryImporter.new(@lookup, text_processor, permalink_importer)
     end
 
     def post_importer
-      PostImporter.new(@lookup, text_processor, attachment_importer, poll_importer, @settings)
+      PostImporter.new(@lookup, text_processor, attachment_importer, poll_importer, permalink_importer, @settings)
     end
 
     def message_importer
@@ -42,6 +43,10 @@ module ImportScripts::PhpBB3
 
     def bookmark_importer
       BookmarkImporter.new
+    end
+
+    def permalink_importer
+      @permalink_importer ||= PermalinkImporter.new(@settings.permalinks)
     end
 
     protected

--- a/script/import_scripts/phpbb3/importers/permalink_importer.rb
+++ b/script/import_scripts/phpbb3/importers/permalink_importer.rb
@@ -1,0 +1,56 @@
+module ImportScripts::PhpBB3
+  class PermalinkImporter
+    POST_LINK_NORMALIZATION = '/(viewtopic.php\?)(?:.*&)?(p=\d+).*/\1\2'
+    TOPIC_LINK_NORMALIZATION = '/(viewtopic.php\?)(?:.*&)?(t=\d+).*/\1\2'
+
+    # @param settings [ImportScripts::PhpBB3::PermalinkSettings]
+    def initialize(settings)
+      @settings = settings
+    end
+
+    def change_site_settings
+      normalizations = SiteSetting.permalink_normalizations
+      normalizations = normalizations.blank? ? [] : normalizations.split('|')
+
+      if @settings.create_post_links && !normalizations.include?(POST_LINK_NORMALIZATION)
+        normalizations << POST_LINK_NORMALIZATION
+      end
+
+      if @settings.create_topic_links && !normalizations.include?(TOPIC_LINK_NORMALIZATION)
+        normalizations << TOPIC_LINK_NORMALIZATION
+      end
+
+      SiteSetting.permalink_normalizations = normalizations.join('|')
+    end
+
+    def create_for_category(category, import_id)
+      return unless @settings.create_category_links && category
+
+      url = "viewforum.php?f=#{import_id}"
+
+      if !Permalink.find_by(url: url)
+        Permalink.create(url: url, category_id: category.id)
+      end
+    end
+
+    def create_for_topic(topic, import_id)
+      return unless @settings.create_topic_links && topic
+
+      url = "viewtopic.php?t=#{import_id}"
+
+      if !Permalink.find_by(url: url)
+        Permalink.create(url: url, topic_id: topic.id)
+      end
+    end
+
+    def create_for_post(post, import_id)
+      return unless @settings.create_topic_links && post
+
+      url = "viewtopic.php?p=#{import_id}"
+
+      if !Permalink.find_by(url: url)
+        Permalink.create(url: url, post_id: post.id)
+      end
+    end
+  end
+end

--- a/script/import_scripts/phpbb3/settings.yml
+++ b/script/import_scripts/phpbb3/settings.yml
@@ -26,6 +26,12 @@ import:
     original: oldsite.example.com/forums    # without http(s)://
     new: http://discourse.example.com       # with http:// or https://
 
+  # Enable this, if you want to redirect old forum links to the the new locations.
+  permalinks:
+    categories: true  # redirects   /viewforum.php?f=1            to  /c/category-name
+    topics: true      # redirects   /viewtopic.php?f=6&t=43       to  /t/topic-name/81
+    posts: false      # redirects   /viewtopic.php?p=2455#p2455   to  /t/topic-name/81/4
+
   avatars:
     uploaded: true  # import uploaded avatars
     gallery: true   # import the predefined avatars phpBB offers

--- a/script/import_scripts/phpbb3/support/settings.rb
+++ b/script/import_scripts/phpbb3/support/settings.rb
@@ -24,6 +24,7 @@ module ImportScripts::PhpBB3
     attr_reader :original_site_prefix
     attr_reader :new_site_prefix
     attr_reader :base_dir
+    attr_reader :permalinks
 
     attr_reader :username_as_name
     attr_reader :emojis
@@ -50,6 +51,7 @@ module ImportScripts::PhpBB3
       @original_site_prefix = import_settings['site_prefix']['original']
       @new_site_prefix = import_settings['site_prefix']['new']
       @base_dir = import_settings['phpbb_base_dir']
+      @permalinks = PermalinkSettings.new(import_settings['permalinks'])
 
       @username_as_name = import_settings['username_as_name']
       @emojis = import_settings.fetch('emojis', [])
@@ -77,6 +79,18 @@ module ImportScripts::PhpBB3
       @schema = yaml['schema']
       @table_prefix = yaml['table_prefix']
       @batch_size = yaml['batch_size']
+    end
+  end
+
+  class PermalinkSettings
+    attr_reader :create_category_links
+    attr_reader :create_topic_links
+    attr_reader :create_post_links
+
+    def initialize(yaml)
+      @create_category_links = yaml['categories']
+      @create_topic_links = yaml['topics']
+      @create_post_links = yaml['posts']
     end
   end
 end


### PR DESCRIPTION
This PR includes a few changes to the original permalink import:
- adds permalinks for posts
- does not create incorrect permalinks for private messages
- adds permalink normalizations for topics and posts (strips offsets and other query parameters)
- creation of permalinks can be configured (categories and topics are on by default, posts are off by default)