### PR TITLE
FEATURE: Allow disabling link tracking with .no-track-link class

### DIFF
--- a/app/assets/javascripts/discourse/lib/click-track.js.es6
+++ b/app/assets/javascripts/discourse/lib/click-track.js.es6
@@ -11,7 +11,7 @@ export default {
     if (Discourse.Utilities.selectedText() !== "") { return false; }
 
     var $link = $(e.currentTarget);
-    if ($link.hasClass('lightbox') || $link.hasClass('mention-group')) { return true; }
+    if ($link.hasClass('lightbox') || $link.hasClass('mention-group') || $link.hasClass('no-track-link')) { return true; }
 
     var href = $link.attr('href') || $link.data('href'),
         $article = $link.closest('article'),

--- a/test/javascripts/lib/click-track-test.js.es6
+++ b/test/javascripts/lib/click-track-test.js.es6
@@ -27,6 +27,7 @@ module("lib:click-track", {
             <a id="inside-onebox" href="http://www.google.com">google.com<span class="badge">1</span></a>
             <a id="inside-onebox-forced" class="track-link" href="http://www.google.com">google.com<span class="badge">1</span></a>
           </div>
+          <a class="no-track-link" href="http://www.google.com">google.com</a>
           <a id="same-site" href="http://discuss.domain.com">forum</a>
           <a class="attachment" href="http://discuss.domain.com/uploads/default/1234/1532357280.txt">log.txt</a>
           <a class="hashtag" href="http://discuss.domain.com">#hashtag</a>
@@ -55,6 +56,10 @@ test("it calls preventDefault when clicking on an a", function() {
   track(clickEvent);
   ok(clickEvent.preventDefault.calledOnce);
   ok(DiscourseURL.redirectTo.calledOnce);
+});
+
+test("does not track clicks when forcibly disabled", function() {
+  ok(track(generateClickEventOn('.no-track-link')));
 });
 
 test("does not track clicks on back buttons", function() {


### PR DESCRIPTION
I was running into some trouble with link tracking breaking a signup CTA link I'd insert into a onebox at runtime, because the `.onebox-results` ancestor doesn't trigger a return until much later — after the link has been rewritten. This allows disabling link tracking on any link just by adding a `no-track-link` class.  The name is kinda weird but I wanted to match the existing `track-link` class which enables link tracking on otherwise-disabled links.