### PR TITLE
Make Vagrantfile more resilient

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,6 +14,7 @@ Vagrant.configure("2") do |config|
   # use SSH private keys that are present on the host without copying
   # them into the VM.
   config.ssh.forward_agent = true
+  config.ssh.proxy_command = false
 
   config.vm.provider :virtualbox do |v|
     # This setting gives the VM 1024MB of RAM instead of the default 384.
@@ -44,5 +45,7 @@ Vagrant.configure("2") do |config|
 
   nfs_setting = RUBY_PLATFORM =~ /darwin/ || RUBY_PLATFORM =~ /linux/
   config.vm.synced_folder ".", "/vagrant", id: "vagrant-root", :nfs => nfs_setting
+# If you use NFSv4, replace the previous line with this:
+#  config.vm.synced_folder ".", "/vagrant", id: "vagrant-root", :nfs => nfs_setting, :mount_options => ['vers=4']
 
 end


### PR DESCRIPTION
This includes two changes in Vagrantfile:

1. Disable SSH proxy

When you're using SSH configuration extensively, you may use `ProxyCommand`, in which case `vagrant ssh` may fail.  As there's no obvious reason to proxy access to a local development machine, disable it.

2. NFSv4 support

By default `vagrant` uses NFSv3, which may be incompatible with your setup.  This adds a comment to hint about how to make it work with NFSv4.

No other functionality is affected.

