### PR TITLE
Add spec for website name when url has subdomain

### DIFF
--- a/spec/serializers/user_serializer_spec.rb
+++ b/spec/serializers/user_serializer_spec.rb
@@ -88,16 +88,32 @@ describe UserSerializer do
     end
 
     context "with filled out website" do
-      before do
-        user.user_profile.website = 'http://example.com/user'
+      context "when website has a path" do
+        before do
+          user.user_profile.website = 'http://example.com/user'
+        end
+
+        it "has a website with a path" do
+          expect(json[:website]).to eq 'http://example.com/user'
+        end
+
+        it "returns complete website name with path" do
+          expect(json[:website_name]).to eq 'example.com/user'
+        end
       end
 
-      it "has a website" do
-        expect(json[:website]).to eq 'http://example.com/user'
-      end
+      context "when website has a subdomain" do
+        before do
+          user.user_profile.website = 'http://www.example.com/user'
+        end
 
-      it "returns complete website name with path" do
-        expect(json[:website_name]).to eq 'example.com/user'
+        it "has a website with a subdomain" do
+          expect(json[:website]).to eq 'http://www.example.com/user'
+        end
+
+        it "returns website name with the subdomain" do
+          expect(json[:website_name]).to eq 'www.example.com/user'
+        end
       end
 
       context "when website includes query parameters" do


### PR DESCRIPTION
Follow up re: the point here about subdomains:
https://github.com/discourse/discourse/pull/4158#issuecomment-208163236

Adding spec for current behavior when URL has a subdomain.

Perhaps it was intentional to strip this before, but that's not what happens right now.  Also, there's a case to be made that it should be included (It's somewhat typical for people that have their website on a hosted service that gives out subdomains for free... eg `mysite.github.io`).

