### PR TITLE
Use consistent link color for website name

### DIFF
--- a/app/assets/stylesheets/desktop/user-card.scss
+++ b/app/assets/stylesheets/desktop/user-card.scss
@@ -159,6 +159,12 @@ $user_card_background: #222;
     }
   }
 
+  .website-name {
+    a {
+      color: $user_card_primary;
+    }
+  }
+
   img.avatar {
     float: left;
     margin-right: 10px;


### PR DESCRIPTION


before

<img width="586" alt="screen shot 2016-04-12 at 11 11 39 pm" src="https://cloud.githubusercontent.com/assets/2217652/14484320/58ab26b6-0104-11e6-9ac3-cd83d2a1e4bc.png">

after

<img width="587" alt="screen shot 2016-04-12 at 11 11 25 pm" src="https://cloud.githubusercontent.com/assets/2217652/14484324/60cec064-0104-11e6-9e7c-fbc5598e383f.png">



