### PR TITLE
Add 'alt' tag to logo img in digest email

### DIFF
--- a/app/views/user_notifications/digest.html.erb
+++ b/app/views/user_notifications/digest.html.erb
@@ -5,7 +5,7 @@
     <%- if logo_url.blank? %>
       <%= SiteSetting.title %>
     <%- else %>
-      <img src="<%= logo_url %>" style="max-height: 35px; min-height: 35px; height: 35px;" class='site-logo'>
+      <img src="<%= logo_url %>" style="max-height: 35px; min-height: 35px; height: 35px;" class='site-logo' alt="<%= SiteSetting.title %>">
     <%- end %>
     </a>
   </td>


### PR DESCRIPTION
The rationale for this is that the logo, as any other image, is not loaded by default by many email clients. In absence of an 'alt' tag, it shows an empty space in the email. Having the site title in there seems better.