### PR TITLE
Allow any username character in user search

### DIFF
--- a/app/assets/javascripts/discourse/lib/user-search.js.es6
+++ b/app/assets/javascripts/discourse/lib/user-search.js.es6
@@ -91,7 +91,7 @@ export default function userSearch(options) {
 
   return new Ember.RSVP.Promise(function(resolve) {
     // TODO site setting for allowed regex in username
-    if (term.match(/[^a-zA-Z0-9_\.\-]/)) {
+    if (term.match(/[^\w\.\-]/)) {
       resolve([]);
       return;
     }


### PR DESCRIPTION
See [discussion on meta](https://meta.discourse.org/t/mention-full-name-autocomplete-doesnt-work-with-international-characters/29819/28) - this allows matching non-ASCII names too.