### PR TITLE
fix: Editing a topic with an invalid title will still push it to the top

### DIFF
--- a/app/jobs/regular/export_csv_file.rb
+++ b/app/jobs/regular/export_csv_file.rb
@@ -225,13 +225,15 @@ module Jobs
             elsif attr == 'staff_user'
               user = User.find_by(id: staff_action.attributes['acting_user_id'])
               user.username if !user.nil?
+            elsif attr == 'subject'
+              user = User.find_by(id: staff_action.attributes['target_user_id'])
+              user.nil? ? staff_action.attributes[attr] : "#{user.username} #{staff_action.attributes[attr]}" 
             else
               staff_action.attributes[attr]
             end
 
             staff_action_array.push(data)
         end
-
         staff_action_array
       end
 

--- a/lib/post_revisor.rb
+++ b/lib/post_revisor.rb
@@ -363,7 +363,7 @@ class PostRevisor
   end
 
   def bypass_bump?
-    !@post_successfully_saved || @opts[:bypass_bump] == true
+    !@post_successfully_saved || @topic_changes.errored? || @opts[:bypass_bump] == true
   end
 
   def is_last_post?


### PR DESCRIPTION
I tried to fix the bug in order to contribute to open source. following is the link of the bug.
https://meta.discourse.org/t/editing-a-topic-with-an-invalid-title-will-still-push-it-to-the-top/39742.

Please review.

Thanks!
Shakti