### PR TITLE
FIX: make sure the best post is not the worst

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -245,7 +245,7 @@ class Topic < ActiveRecord::Base
   end
 
   def best_post
-    posts.order('score desc').limit(1).first
+    posts.order('score desc nulls last').limit(1).first
   end
 
   def has_flags?


### PR DESCRIPTION
By default Postgres returns NULLs first when sorting in descending order. As a result, best_post() would often actually return the "worst" post of the topic. And it would then be included in digest emails in "popular posts".