### PR TITLE
PERF: Uglify and gzip assets concurrently.

### DIFF
--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -116,6 +116,16 @@ def compress(from,to)
   end
 end
 
+def concurrent?
+  if ENV["CONCURRENT"] == "1"
+    concurrent_compressors = []
+    yield(Proc.new { |&block| concurrent_compressors << Concurrent::Future.execute { block.call } })
+    concurrent_compressors.each(&:wait!)
+  else
+    yield(Proc.new { |&block| block.call })
+  end
+end
+
 task 'assets:precompile' => 'assets:precompile:before' do
   # Run after assets:precompile
   Rake::Task["assets:precompile:css"].invoke
@@ -124,30 +134,34 @@ task 'assets:precompile' => 'assets:precompile:before' do
     puts "Compressing Javascript and Generating Source Maps"
     manifest = Sprockets::Manifest.new(assets_path)
 
-    to_skip = Rails.configuration.assets.skip_minification || []
-    manifest.files
-            .select{|k,v| k =~ /\.js$/}
-            .each do |file, info|
+    concurrent? do |proc|
+      to_skip = Rails.configuration.assets.skip_minification || []
+      manifest.files
+              .select{|k,v| k =~ /\.js$/}
+              .each do |file, info|
 
-        path = "#{assets_path}/#{file}"
-        _file = (d = File.dirname(file)) == "." ? "_#{file}" : "#{d}/_#{File.basename(file)}"
-        _path = "#{assets_path}/#{_file}"
+          path = "#{assets_path}/#{file}"
+          _file = (d = File.dirname(file)) == "." ? "_#{file}" : "#{d}/_#{File.basename(file)}"
+          _path = "#{assets_path}/#{_file}"
 
-        if File.exists?(_path)
-          STDERR.puts "Skipping: #{file} already compressed"
-        else
-          STDERR.puts "Compressing: #{file}"
+          if File.exists?(_path)
+            STDERR.puts "Skipping: #{file} already compressed"
+          else
+            STDERR.puts "Compressing: #{file}"
 
-          # We can specify some files to never minify
-          unless (ENV["DONT_MINIFY"] == "1") || to_skip.include?(info['logical_path'])
-            FileUtils.mv(path, _path)
-            compress(_file,file)
+            proc.call do
+              # We can specify some files to never minify
+              unless (ENV["DONT_MINIFY"] == "1") || to_skip.include?(info['logical_path'])
+                FileUtils.mv(path, _path)
+                compress(_file,file)
+              end
+
+              info["size"] = File.size(path)
+              info["mtime"] = File.mtime(path).iso8601
+              gzip(path)
+            end
           end
-
-          info["size"] = File.size(path)
-          info["mtime"] = File.mtime(path).iso8601
-          gzip(path)
-        end
+      end
     end
 
     # protected


### PR DESCRIPTION
@SamSaffron I noticed [this pattern being used in Sprockets](https://github.com/rails/sprockets/blob/9db6aa1c8bec0c445c58d2783d7166f7c44a58f0/lib/sprockets/manifest.rb#L163-L207) and realized we could utilize it in our custom rake task. The output is abit mangled now but let me know if this is ok and I'll clean that up.


## Local Benchmarks
### Before 
```
real  1m15.908s
user  1m19.148s
sys 0m3.084s

real  1m13.481s
user  1m16.924s
sys 0m2.756s
```

### After
```
real  0m50.162s
user  1m35.632s
sys 0m3.204s

real  0m50.692s
user  1m36.164s
sys 0m3.284s
```