### PR TITLE
Fix: Editing a topic with an invalid title will still push it to the top

### DIFF
--- a/lib/post_revisor.rb
+++ b/lib/post_revisor.rb
@@ -363,7 +363,7 @@ class PostRevisor
   end
 
   def bypass_bump?
-    !@post_successfully_saved || @opts[:bypass_bump] == true
+    !@post_successfully_saved || @topic_changes.errored? || @opts[:bypass_bump] == true
   end
 
   def is_last_post?

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -488,6 +488,13 @@ describe Topic do
           @topic.reload
         }.not_to change(@topic, :bumped_at)
       end
+
+      it "doesn't bump the topic when a post have invalid topic title while edit" do
+        expect {
+          @last_post.revise(Fabricate(:moderator), { title: 'invalid title' })
+          @topic.reload
+        }.not_to change(@topic, :bumped_at)
+      end
     end
   end
 


### PR DESCRIPTION
Fixes of this issue 
https://meta.discourse.org/t/editing-a-topic-with-an-invalid-title-will-still-push-it-to-the-top/39742