### PR TITLE
FIX: Don't diplay character reference in HTML diffs

### DIFF
--- a/lib/discourse_diff.rb
+++ b/lib/discourse_diff.rb
@@ -261,7 +261,7 @@ class DiscourseDiff
     end
 
     def characters(string)
-      @tokens.concat string.scan(/(\W|\w+[ \t]*)/).flatten.map { |x| CGI::escapeHTML(x) }
+      @tokens.concat string.scan(/\W|\w+[ \t]*/).map { |x| CGI::escapeHTML(x) }
     end
 
   end

--- a/lib/discourse_diff.rb
+++ b/lib/discourse_diff.rb
@@ -261,8 +261,7 @@ class DiscourseDiff
     end
 
     def characters(string)
-      string = CGI::escapeHTML(string)
-      @tokens.concat string.scan(/(\W|\w+[ \t]*)/).flatten
+      @tokens.concat string.scan(/(\W|\w+[ \t]*)/).flatten.map { |x| CGI::escapeHTML(x) }
     end
 
   end

--- a/spec/components/discourse_diff_spec.rb
+++ b/spec/components/discourse_diff_spec.rb
@@ -49,6 +49,12 @@ describe DiscourseDiff do
       expect(DiscourseDiff.new(before, after).inline_html).to eq("<div class=\"inline-diff\"><p class=\"diff-del\">this is the first paragraph</p><p>this is the second paragraph</p></div>")
     end
 
+    it "does not break diff on character references" do
+      before = "<p>'</p>"
+      after = "<p></p>"
+      expect(DiscourseDiff.new(before, after).inline_html).to eq("<div class=\"inline-diff\"><p><del>&#39;</del></p></div>")
+    end
+
   end
 
   describe "side_by_side_html" do
@@ -84,6 +90,12 @@ describe DiscourseDiff do
       before = "<p>this is the first paragraph</p><p>this is the second paragraph</p>"
       after = "<p>this is the second paragraph</p>"
       expect(DiscourseDiff.new(before, after).side_by_side_html).to eq("<div class=\"span8\"><p class=\"diff-del\">this is the first paragraph</p><p>this is the second paragraph</p></div><div class=\"span8 offset1\"><p>this is the second paragraph</p></div>")
+    end
+
+    it "does not break diff on character references" do
+      before = "<p>'</p>"
+      after = "<p></p>"
+      expect(DiscourseDiff.new(before, after).side_by_side_html).to eq("<div class=\"span8\"><p><del>&#39;</del></p></div><div class=\"span8 offset1\"><p></p></div>")
     end
 
   end


### PR DESCRIPTION
Before this change, HTML escaping was done before splitting text into tokens, so token splitter saw literals like "&#39;", and split them as it was normal text into parts into ["&", "#", "39", ";"]. This caused diff to display character references, as those tokens used separate HTML tags to display their insertion/deletion status.

![spectacle zb8627](https://cloud.githubusercontent.com/assets/1297598/14930720/65a3a95a-0e66-11e6-89db-27815c97cc50.png)
