### PR TITLE
Modify search drop-down options text

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -179,7 +179,7 @@ en:
     admin_title: "Admin"
     flags_title: "Flags"
     show_more: "show more"
-    show_help: "options"
+    show_help: "Search help"
     links: "Links"
     links_lowercase:
       one: "link"


### PR DESCRIPTION
Search options text is inconsistent between on-screen and full-page search.  "Options" seems to imply the ability to change search parameters when clicked, not simply provide a help screen.  On-screen search text changed to reflect that.