### PR TITLE
FIX: tag topic list header href leading to 404

### DIFF
--- a/app/views/list/list.erb
+++ b/app/views/list/list.erb
@@ -4,7 +4,7 @@
 
 <%- if SiteSetting.tagging_enabled && @tag_id %>
   <h1>
-    <%= link_to "#{Discourse.base_url}/t/#{@tag_id}", itemprop: 'item' do %>
+    <%= link_to "#{Discourse.base_url}/tags/#{@tag_id}", itemprop: 'item' do %>
       <span itemprop='name'><%= @tag_id %></span>
     <% end %>
   </h1>


### PR DESCRIPTION
I believe commit discourse/discourse-tagging@da528ed may have introduced an
error in tag list header href, [still present after merge](https://github.com/discourse/discourse/blob/master/app/views/list/list.erb#L7)
at the moment of the present commit.

While this is not really important in the standard, js-enabled application
browsing, it generates erroneous links that are displayed for SEO crawlers
such as Googlebot. This can be verified in the source of any tag page with
the proper user agent.

![tag-list-seen-as-bot](https://cloud.githubusercontent.com/assets/37416/15069315/16c69f92-137d-11e6-84a1-38cf27f56ebe.jpg)

![four-oh-four](https://cloud.githubusercontent.com/assets/37416/15069320/1d6123f4-137d-11e6-9a0e-0ee1349e9c00.jpg)

This introduces 404s to the site as a whole, and may be ranking some pages
(and the site) down.