### PR TITLE
Optional 'no_user_found_return_sso_url' parameter for using Discourse as SSO

### DIFF
--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -35,6 +35,7 @@ class SessionController < ApplicationController
     if SiteSetting.enable_sso_provider
       sso = SingleSignOn.parse(payload, SiteSetting.sso_secret)
       if current_user
+        sso.user_found = true;
         sso.name = current_user.name
         sso.username = current_user.username
         sso.email = current_user.email
@@ -46,6 +47,10 @@ class SessionController < ApplicationController
         else
           redirect_to sso.to_url(sso.return_sso_url)
         end
+      elsif (sso.no_user_found_return_sso_url != "" && !sso.no_user_found_return_sso_url.nil? )
+        sso.user_found = false;
+        no_user_URL = sso.no_user_found_return_sso_url
+        redirect_to sso.to_url(no_user_URL)
       else
         session[:sso_payload] = request.query_string
         redirect_to path('/login')

--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -35,7 +35,7 @@ class SessionController < ApplicationController
     if SiteSetting.enable_sso_provider
       sso = SingleSignOn.parse(payload, SiteSetting.sso_secret)
       if current_user
-        sso.user_found = true;
+        sso.user_found = true
         sso.name = current_user.name
         sso.username = current_user.username
         sso.email = current_user.email
@@ -47,13 +47,14 @@ class SessionController < ApplicationController
         else
           redirect_to sso.to_url(sso.return_sso_url)
         end
-      elsif (sso.no_user_found_return_sso_url != "" && !sso.no_user_found_return_sso_url.nil? )
-        sso.user_found = false;
-        no_user_URL = sso.no_user_found_return_sso_url
-        redirect_to sso.to_url(no_user_URL)
       else
-        session[:sso_payload] = request.query_string
-        redirect_to path('/login')
+        sso.user_found = false
+        if sso.return_sso_unlogged_in_url.present?
+          redirect_to sso.to_url(sso.return_sso_unlogged_in_url)
+        else
+          session[:sso_payload] = request.query_string
+          redirect_to path('/login')
+        end
       end
     else
       render nothing: true, status: 404

--- a/lib/single_sign_on.rb
+++ b/lib/single_sign_on.rb
@@ -1,7 +1,7 @@
 class SingleSignOn
   ACCESSORS = [:nonce, :name, :username, :email, :avatar_url, :avatar_force_update, :require_activation,
-                :no_user_found_return_sso_url,:user_found, :about_me, :external_id, :return_sso_url,
-                :admin, :moderator, :suppress_welcome_message]
+               :return_sso_unlogged_in_url,:user_found, :about_me, :external_id, :return_sso_url,
+               :admin, :moderator, :suppress_welcome_message]
   FIXNUMS = []
   BOOLS = [:user_found, :avatar_force_update, :admin, :moderator, :require_activation, :suppress_welcome_message]
   NONCE_EXPIRY_TIME = 10.minutes

--- a/lib/single_sign_on.rb
+++ b/lib/single_sign_on.rb
@@ -1,8 +1,9 @@
 class SingleSignOn
   ACCESSORS = [:nonce, :name, :username, :email, :avatar_url, :avatar_force_update, :require_activation,
-               :about_me, :external_id, :return_sso_url, :admin, :moderator, :suppress_welcome_message]
+                :no_user_found_return_sso_url,:user_found, :about_me, :external_id, :return_sso_url,
+                :admin, :moderator, :suppress_welcome_message]
   FIXNUMS = []
-  BOOLS = [:avatar_force_update, :admin, :moderator, :require_activation, :suppress_welcome_message]
+  BOOLS = [:user_found, :avatar_force_update, :admin, :moderator, :require_activation, :suppress_welcome_message]
   NONCE_EXPIRY_TIME = 10.minutes
 
   attr_accessor(*ACCESSORS)


### PR DESCRIPTION
Implemented an optional 'no_user_found_return_sso_url' parameter to be called by the client when client is using Discourse as an SSO and wants Discourse to redirect back to a place of the client's choosng when a user is not found.

Currently, the Discourse as an SSO implementation checks the cookies `_t` and `_session_forum` to see if the user is registered and present in the database (`_t` is the token that is located in the users table).  If a user is not found, the current implemenation forwards to the forum's /login URL.  This behavior may be what the client wants, but it would be good to give an option to the client to send somewhere else. 

This commit allows the client to embed an optional 'no_user_found_return_sso_url' parameter in the payload, prior to base64 and URL-encoding.  If the Discoure SSO endpoint detects that this parameter is present in the payload (and has a non-empty value) the Discourse server will redirect to this new location if it does not detect the user.  If this parameter is not present, then the redirection to /login will take place as it currently does. 

Additionally, as the client may choose to use the same URL for 'no_user_found_return_sso_url' as for 'return_url', this commit introduces a new query-string name-value pair to be sent back to the client 'no_user_found_return_sso_url' location. This parameter 'user_found' will **ALWAYS** be sent back to the client, either when the user is found and 'return_url' is used or when the user is not found 'no_user_found_return_sso_url' is used (values will be 'true' and 'false' respectively). 
