### PR TITLE
Update to ruby 2.3.1 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ rvm:
   - 2.0.0
   - 2.1
   - 2.2
-  - 2.3.0
+  - 2.3.1
 
 services:
   - redis-server


### PR DESCRIPTION
2.3.0 has many regressions. 2.3.1 can be a good start.