### PR TITLE
FIX: modal was not opening after navigating back in browser

### DIFF
--- a/app/assets/javascripts/discourse/routes/discourse.js.es6
+++ b/app/assets/javascripts/discourse/routes/discourse.js.es6
@@ -94,7 +94,7 @@ export function cleanDOM() {
   $(document.activeElement).not("body").not(".no-blur").blur();
 
   Discourse.set('notifyCount',0);
-  $('#discourse-modal').modal('hide');
+  Discourse.__container__.lookup('route:application').send('closeModal');
   const hideDropDownFunction = $('html').data('hide-dropdown');
   if (hideDropDownFunction) { hideDropDownFunction(); }
 


### PR DESCRIPTION
Bug report here: https://meta.discourse.org/t/cant-open-history-popup-after-using-browser-back-button/43898?u=techapj

This is happening for all the modals, after using browser back button while the modal is open, the modal remains hidden, probably due [this code](https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/routes/discourse.js.es6#L97).

Not sure if this a perfect fix, but it detects if the modal has content and makes it visible again.

@eviltrout can you review this PR?