### PR TITLE
FIX[WIP]: return correct path for uploads stored on s3

### DIFF
--- a/app/assets/javascripts/discourse/lib/utilities.js
+++ b/app/assets/javascripts/discourse/lib/utilities.js
@@ -249,16 +249,25 @@ Discourse.Utilities = {
             .join(", ");
   },
 
+  uploadUrl: function(url) {
+    if (Discourse.CDN) {
+      return Discourse.CDN.startsWith('//') ? "http:" + Discourse.getURLWithCDN(upload.url) : Discourse.getURLWithCDN(upload.url);
+    } else if (Discourse.SiteSettings.enable_s3_uploads) {
+      return 'https:' + url;
+    } else {
+      var protocol = window.location.protocol + '//',
+        hostname = window.location.hostname,
+        port = ':' + window.location.port;
+        return protocol + hostname + port + url;
+    }
+  },
+
   getUploadMarkdown: function(upload) {
     if (Discourse.Utilities.isAnImage(upload.original_filename)) {
       return '<img src="' + upload.url + '" width="' + upload.width + '" height="' + upload.height + '">';
     } else if (!Discourse.SiteSettings.prevent_anons_from_downloading_files && (/\.(mov|mp4|webm|ogv|mp3|ogg|wav)$/i).test(upload.original_filename)) {
       // is Audio/Video
-      if (Discourse.CDN) {
-        return Discourse.CDN.startsWith('//') ? "http:" + Discourse.getURLWithCDN(upload.url) : Discourse.getURLWithCDN(upload.url);
-      } else {
-        return "http://" + Discourse.BaseUrl + upload.url;
-      }
+      return Discourse.Utilities.uploadUrl(upload.url);
     } else {
       return '<a class="attachment" href="' + upload.url + '">' + upload.original_filename + '</a> (' + I18n.toHumanSize(upload.filesize) + ')';
     }

--- a/app/assets/javascripts/discourse/lib/utilities.js
+++ b/app/assets/javascripts/discourse/lib/utilities.js
@@ -249,9 +249,9 @@ Discourse.Utilities = {
             .join(", ");
   },
 
-  uploadUrl: function(url) {
+  uploadLocation: function(url) {
     if (Discourse.CDN) {
-      return Discourse.CDN.startsWith('//') ? "http:" + Discourse.getURLWithCDN(upload.url) : Discourse.getURLWithCDN(upload.url);
+      return Discourse.CDN.startsWith('//') ? "http:" + Discourse.getURLWithCDN(url) : Discourse.getURLWithCDN(url);
     } else if (Discourse.SiteSettings.enable_s3_uploads) {
       return 'https:' + url;
     } else {
@@ -267,7 +267,7 @@ Discourse.Utilities = {
       return '<img src="' + upload.url + '" width="' + upload.width + '" height="' + upload.height + '">';
     } else if (!Discourse.SiteSettings.prevent_anons_from_downloading_files && (/\.(mov|mp4|webm|ogv|mp3|ogg|wav)$/i).test(upload.original_filename)) {
       // is Audio/Video
-      return Discourse.Utilities.uploadUrl(upload.url);
+      return Discourse.Utilities.uploadLocation(upload.url);
     } else {
       return '<a class="attachment" href="' + upload.url + '">' + upload.original_filename + '</a> (' + I18n.toHumanSize(upload.filesize) + ')';
     }


### PR DESCRIPTION
When assets are stored on S3 without a CDN, audio and video uploads are returning the wrong url.

`http://tests.testeleven.com//testeleven-forum-assets.s3-us-west-1.amazonaws.com/original/1X/06c34a2cb749a93f3551224a283080483cb417d4.wav`

The Discourse.BaseUrl is being added to the upload url without first checking if S3 is being used.

This PR adds a method to return the uploadLocation.

Issues:

 - at the moment, I am not able to test it with a CDN.

- is it safe to always use `https:` for accessing the Amazon bucket?