### PR TITLE
FIX: Box style category dropdown forces scrollbar on Chrome

### DIFF
--- a/app/assets/stylesheets/common/components/badges.css.scss
+++ b/app/assets/stylesheets/common/components/badges.css.scss
@@ -213,7 +213,9 @@
         margin-top: 0;
         width: 100%;
         line-height: 1;
+        vertical-align: text-top;
         span.badge-category {
+          max-width: 100px;
           padding: 5px;
         }
       }


### PR DESCRIPTION
When the box-style category badge is used, it always forces a scrollbar in the category dropdown menu when using the latest Chrome browser. With Firefox `.cat` div is pushed down, producing a gap between categories, but it doesn't force a scrollbar. With Safari and iOS it displays properly (no gap between categories and no scrollbar.)

see: https://meta.discourse.org/t/box-style-category-dropdown-on-chrome-always-forces-scrollbar/40309

Before:

![screenshot 2016-05-15 21 51 53](https://cloud.githubusercontent.com/assets/2975917/15280627/6e9174c4-1ae7-11e6-9133-09d519d4897e.png)

After:

![screenshot 2016-05-15 21 52 42](https://cloud.githubusercontent.com/assets/2975917/15280631/76525b24-1ae7-11e6-87db-27feee074495.png)

