### PR TITLE
FEATURE: add setting permanent_session_cookie to configure session st…

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -890,6 +890,7 @@ en:
     post_undo_action_window_mins: "Number of minutes users are allowed to undo recent actions on a post (like, flag, etc)."
     must_approve_users: "Staff must approve all new user accounts before they are allowed to access the site. WARNING: enabling this for a live site will revoke access for existing non-staff users!"
     pending_users_reminder_delay: "Notify moderators if new users have been waiting for approval for longer than this many hours. Set to -1 to disable notifications."
+    permanent_session_cookie: "Use a permanent cookie that persists after closing the browser. When disabling this, you may want to log out everyone programmatically."
     ga_tracking_code: "Google analytics (ga.js) tracking code code, eg: UA-12345678-9; see http://google.com/analytics"
     ga_domain_name: "Google analytics (ga.js) domain name, eg: mysite.com; see http://google.com/analytics"
     ga_universal_tracking_code: "Google Universal Analytics (analytics.js) tracking code code, eg: UA-12345678-9; see http://google.com/analytics"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -289,6 +289,7 @@ login:
   pending_users_reminder_delay:
     min: -1
     default: 8
+  permanent_session_cookie: true
 
 users:
   min_username_length:

--- a/lib/auth/default_current_user_provider.rb
+++ b/lib/auth/default_current_user_provider.rb
@@ -66,7 +66,11 @@ class Auth::DefaultCurrentUserProvider
       user.auth_token = SecureRandom.hex(16)
       user.save!
     end
-    cookies.permanent[TOKEN_COOKIE] = { value: user.auth_token, httponly: true }
+    if SiteSetting.permanent_session_cookie
+      cookies.permanent[TOKEN_COOKIE] = { value: user.auth_token, httponly: true }
+    else
+      cookies[TOKEN_COOKIE] = { value: user.auth_token, httponly: true }
+    end
     make_developer_admin(user)
     enable_bootstrap_mode(user)
     @env[CURRENT_USER_KEY] = user


### PR DESCRIPTION
…ickiness

Now admins can turn make the login cookie die after the browser is closed, so the user needs to log in everytime.

See https://meta.discourse.org/t/session-timeout/34686/17?u=falco