### PR TITLE
FIX: broken onebox avatar image

### DIFF
--- a/lib/pretty_text.rb
+++ b/lib/pretty_text.rb
@@ -267,7 +267,7 @@ module PrettyText
     protect do
       v8.eval <<JS
       avatarTemplate = #{avatar_template.inspect};
-      size = #{size.to_i};
+      size = #{size.inspect};
 JS
       decorate_context(v8)
       v8.eval("Discourse.Utilities.avatarImg({ avatarTemplate: avatarTemplate, size: size });")


### PR DESCRIPTION
This commit fixes the broken avatar image on internal oneboxes, as seen here:

https://meta.discourse.org/t/how-to-open-reply-window-via-url/44781/2?u=techapj

The issue is: in above case the `size` is `tiny`, and `size.to_i` converts it to zero, causing broken image.

@SamSaffron can you review this please? Thanks!