### PR TITLE
Change default for mailing list mode frequency

### DIFF
--- a/app/models/user_option.rb
+++ b/app/models/user_option.rb
@@ -134,6 +134,7 @@ end
 #  user_id                       :integer          not null, primary key
 #  email_always                  :boolean          default(FALSE), not null
 #  mailing_list_mode             :boolean          default(FALSE), not null
+#  mailing_list_mode_frequency   :integer          default(1), not null
 #  email_digests                 :boolean
 #  email_direct                  :boolean          default(TRUE), not null
 #  email_private_messages        :boolean          default(TRUE), not null

--- a/db/migrate/20160526195202_set_default_mailing_list.rb
+++ b/db/migrate/20160526195202_set_default_mailing_list.rb
@@ -1,0 +1,5 @@
+class SetDefaultMailingList < ActiveRecord::Migration
+  def change
+    change_column_default :user_options, :mailing_list_mode_frequency, 1
+  end
+end


### PR DESCRIPTION
Make it so new user options are set to 'individual' by default

Means that we preserve existing mailing list user's settings. :D 