### PR TITLE
FIX: Show eye-slash icon when able to mark a topic as Unlisted, and e…

### DIFF
--- a/app/assets/javascripts/discourse/widgets/topic-admin-menu.js.es6
+++ b/app/assets/javascripts/discourse/widgets/topic-admin-menu.js.es6
@@ -144,7 +144,7 @@ export default createWidget('topic-admin-menu', {
     const visible = topic.get('visible');
     buttons.push({ className: 'topic-admin-visible',
                    action: 'toggleVisibility',
-                   icon: visible ? 'eye' : 'eye-slash',
+                   icon: visible ? 'eye-slash' : 'eye',
                    label: visible ? 'actions.invisible' : 'actions.visible' });
 
     if (this.currentUser.get('staff')) {


### PR DESCRIPTION
…ye icon when able to mark it Listed

Meta Discussion
https://meta.discourse.org/t/unlisted-listed-icon-reversed/45264