### PR TITLE
Add constraints to remove dots from username.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -115,7 +115,7 @@ Discourse::Application.routes.draw do
       post "reset_bounce_score"
     end
     get "users/:id.json" => 'users#show', defaults: {format: 'json'}
-    get 'users/:id/:username' => 'users#show'
+    get 'users/:id/:username' => 'users#show', constraints: {username: USERNAME_ROUTE_FORMAT}
     get 'users/:id/:username/badges' => 'users#show'
 
 


### PR DESCRIPTION
Rails is using dots as a separator for formatted routes. As a result
if the username has more than one dot it will not match the route.

Bug raised here -> https://meta.discourse.org/t/refreshing-a-users-detail-page-in-admin-doesnt-work-in-some-cases/44891