### PR TITLE
Replace certain uses of 'gsub' with 'tr' / 'chomp' for a speed improvement

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -296,13 +296,12 @@ class ApplicationController < ActionController::Base
   def fetch_user_from_params(opts=nil)
     opts ||= {}
     user = if params[:username]
-      username_lower = params[:username].downcase
-      username_lower.gsub!(/\.json$/, '')
+      username_lower = params[:username].downcase.chomp('.json')
       find_opts = { username_lower: username_lower }
       find_opts[:active] = true unless opts[:include_inactive] || current_user.try(:staff?)
       User.find_by(find_opts)
     elsif params[:external_id]
-      external_id = params[:external_id].gsub(/\.json$/, '')
+      external_id = params[:external_id].chomp('.json')
       SingleSignOnRecord.find_by(external_id: external_id).try(:user)
     end
     raise Discourse::NotFound if user.blank?
@@ -335,9 +334,9 @@ class ApplicationController < ActionController::Base
         # Rails I18n uses underscores between the locale and the region; the request
         # headers use hyphens.
         require 'http_accept_language' unless defined? HttpAcceptLanguage
-        available_locales = I18n.available_locales.map { |locale| locale.to_s.gsub(/_/, '-') }
+        available_locales = I18n.available_locales.map { |locale| locale.to_s.tr('_', '-') }
         parser = HttpAcceptLanguage::Parser.new(request.env["HTTP_ACCEPT_LANGUAGE"])
-        parser.language_region_compatible_from(available_locales).gsub(/-/, '_')
+        parser.language_region_compatible_from(available_locales).tr('-', '_')
       rescue
         # If Accept-Language headers are not set.
         I18n.default_locale
@@ -493,7 +492,7 @@ class ApplicationController < ActionController::Base
       @recent = Topic.where.not(id: category_topic_ids).recent(10)
       @slug =  params[:slug].class == String ? params[:slug] : ''
       @slug =  (params[:id].class == String ? params[:id] : '') if @slug.blank?
-      @slug.gsub!('-',' ')
+      @slug.tr!('-',' ')
       render_to_string status: status, layout: layout, formats: [:html], template: '/exceptions/not_found'
     end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -38,7 +38,7 @@ module ApplicationHelper
   def script(*args)
     if SiteSetting.enable_cdn_js_debugging && GlobalSetting.cdn_url
       tags = javascript_include_tag(*args, "crossorigin" => "anonymous")
-      tags.gsub!("/assets/", "/cdn_asset/#{Discourse.current_hostname.gsub(".","_")}/")
+      tags.gsub!("/assets/", "/cdn_asset/#{Discourse.current_hostname.tr(".","_")}/")
       tags.gsub!(".js\"", ".js?v=1&origin=#{CGI.escape request.base_url}\"")
       tags.html_safe
     else

--- a/app/mailers/invite_mailer.rb
+++ b/app/mailers/invite_mailer.rb
@@ -22,7 +22,7 @@ class InviteMailer < ActionMailer::Base
       # get topic excerpt
       topic_excerpt = ""
       if first_topic.excerpt
-        topic_excerpt = first_topic.excerpt.gsub("\n", " ")
+        topic_excerpt = first_topic.excerpt.tr("\n", " ")
       end
 
       template = 'invite_mailer'

--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -341,7 +341,7 @@ class UserNotifications < ActionMailer::Base
       else
         invite_template = "user_notifications.invited_to_topic_body"
       end
-      topic_excerpt = post.excerpt.gsub("\n", " ") if post.is_first_post? && post.excerpt
+      topic_excerpt = post.excerpt.tr("\n", " ") if post.is_first_post? && post.excerpt
       message = I18n.t(invite_template, username: username, topic_title: title, topic_excerpt: topic_excerpt, site_title: SiteSetting.title, site_description: SiteSetting.site_description)
       html = UserNotificationRenderer.new(Rails.configuration.paths["app/views"]).render(
         template: 'email/invite',

--- a/app/models/badge.rb
+++ b/app/models/badge.rb
@@ -203,7 +203,7 @@ SQL
   end
 
   def i18n_name
-    self.name.downcase.gsub(' ', '_')
+    self.name.downcase.tr(' ', '_')
   end
 end
 

--- a/app/models/topic_status_update.rb
+++ b/app/models/topic_status_update.rb
@@ -102,7 +102,7 @@ TopicStatusUpdate = Struct.new(:topic, :user) do
     end
 
     def locale_key
-      "topic_statuses.#{action_code.gsub('.', '_')}"
+      "topic_statuses.#{action_code.tr('.', '_')}"
     end
 
     def reopening_topic?

--- a/lib/email/sender.rb
+++ b/lib/email/sender.rb
@@ -94,12 +94,12 @@ module Email
 
         # http://www.ietf.org/rfc/rfc2919.txt
         if topic && topic.category && !topic.category.uncategorized?
-          list_id = "<#{topic.category.name.downcase.gsub(' ', '-')}.#{host}>"
+          list_id = "<#{topic.category.name.downcase.tr(' ', '-')}.#{host}>"
 
           # subcategory case
           if !topic.category.parent_category_id.nil?
             parent_category_name = Category.find_by(id: topic.category.parent_category_id).name
-            list_id = "<#{topic.category.name.downcase.gsub(' ', '-')}.#{parent_category_name.downcase.gsub(' ', '-')}.#{host}>"
+            list_id = "<#{topic.category.name.downcase.tr(' ', '-')}.#{parent_category_name.downcase.tr(' ', '-')}.#{host}>"
           end
         else
           list_id = "<#{host}>"

--- a/lib/ip_addr.rb
+++ b/lib/ip_addr.rb
@@ -16,7 +16,7 @@ class IPAddr
     (4 - parts.size).times { parts << '*' } # support strings like 192.*
     v = parts.join('.')
 
-    "#{v.gsub('*', '0')}/#{32 - (v.count('*') * 8)}"
+    "#{v.tr('*', '0')}/#{32 - (v.count('*') * 8)}"
   end
 
   def to_cidr_s

--- a/lib/slug.rb
+++ b/lib/slug.rb
@@ -20,9 +20,9 @@ module Slug
   private
 
   def self.ascii_generator(string)
-    string.gsub("'", "")
+    string.tr("'", "")
           .parameterize
-          .gsub("_", "-")
+          .tr("_", "-")
   end
 
   def self.encoded_generator(string)


### PR DESCRIPTION
String#tr is faster than String#gsub for single character substitutions: https://github.com/JuanitoFatas/fast-ruby#stringgsub-vs-stringtr-code

String#chomp is faster than String#[g]sub for replacing end of string characters: https://github.com/JuanitoFatas/fast-ruby#stringsub-vs-stringchomp-code