### PR TITLE
Poll UX: Highlight cast votes button and add icon.

### DIFF
--- a/plugins/poll/assets/javascripts/discourse/templates/poll.hbs
+++ b/plugins/poll/assets/javascripts/discourse/templates/poll.hbs
@@ -41,7 +41,7 @@
 <div class="poll-buttons">
   {{#if isMultiple}}
     {{#unless hideResultsDisabled}}
-      {{d-button class="cast-votes" title="poll.cast-votes.title" label="poll.cast-votes.label" disabled=castVotesDisabled action="castVotes"}}
+      {{d-button class="cast-votes btn-primary" title="poll.cast-votes.title" label="poll.cast-votes.label" icon="paper-plane-o" disabled=castVotesDisabled action="castVotes"}}
     {{/unless}}
   {{/if}}
 


### PR DESCRIPTION
Goal: Make it clearer that one has to click the button to cast one's votes (in polls of `type=multiple`).