### PR TITLE
Poll UX: Remove danger from close poll button.

### DIFF
--- a/plugins/poll/assets/javascripts/discourse/templates/poll.hbs
+++ b/plugins/poll/assets/javascripts/discourse/templates/poll.hbs
@@ -55,7 +55,7 @@
     {{#if isClosed}}
       {{d-button class="toggle-status" title="poll.open.title" label="poll.open.label" icon="unlock-alt" action="toggleStatus"}}
     {{else}}
-      {{d-button class="toggle-status btn-danger" title="poll.close.title" label="poll.close.label" icon="lock" action="toggleStatus"}}
+      {{d-button class="toggle-status" title="poll.close.title" label="poll.close.label" icon="lock" action="toggleStatus"}}
     {{/if}}
   {{/if}}
 </div>


### PR DESCRIPTION
Goal: Make the close poll button less distracting.

Justification: The close poll button is much more prominent than the cast votes button, even though it doesn't really pose any danger (which would justify its red colour), as closed polls can be re-opened.