### PR TITLE
enable args MODULE and FILTER for qunit:test rake task

### DIFF
--- a/lib/tasks/qunit.rake
+++ b/lib/tasks/qunit.rake
@@ -37,6 +37,16 @@ task "qunit:test" => :environment do
     test_path = "#{Rails.root}/vendor/assets/javascripts"
     cmd = "phantomjs #{test_path}/run-qunit.js http://localhost:#{port}/qunit"
 
+    options = {}
+
+    %w{module filter}.each do |arg|
+      options[arg] = ENV[arg.upcase] if ENV[arg.upcase].present?
+    end
+
+    if options.present?
+      cmd += "?#{options.to_query.gsub('+', '%20')}"
+    end
+
     # wait for server to respond, will exception out on failure
     tries = 0
     begin


### PR DESCRIPTION
This enables running filters specs via `rake`

Like so:

`rake qunit:test MODULE='Acceptance: About'`
`rake qunit:test FILTER=foo`

(can be a combination)


