### PR TITLE
exit if RETRY is false

### DIFF
--- a/lib/tasks/qunit.rake
+++ b/lib/tasks/qunit.rake
@@ -52,6 +52,7 @@ task "qunit:test" => :environment do
     begin
       sh(cmd)
     rescue
+      exit if ENV['RETRY'].present? && ENV['RETRY'] == 'false'
       sleep 2
       tries += 1
       retry unless tries == 10


### PR DESCRIPTION
It doesn't make a lot of sense to retry when you want to run filtered tests via rake. I created this flag. There is room for improvement but it works :)