### PR TITLE
Support saml idp initiated sso

### DIFF
--- a/app/views/users/omniauth_callbacks/complete.html.erb
+++ b/app/views/users/omniauth_callbacks/complete.html.erb
@@ -26,9 +26,12 @@
 
        // On facebook browser, just redirect and don't close
        var ua = navigator.userAgent || navigator.vendor || window.opera;
-       if ((ua.indexOf("FBAN") > -1) || (ua.indexOf("FBAV") > -1) || (window.opener.Discourse == undefined)) {
+       if ((ua.indexOf("FBAN") > -1) || (ua.indexOf("FBAV") > -1)) {
          localStorage.setItem('lastAuthResult', JSON.stringify(authResult));
          window.location.href = '<%= Discourse.base_url.html_safe %>?authComplete=true';
+       } else if (window.opener == null){
+         localStorage.setItem('lastAuthResult', JSON.stringify(authResult));
+         window.location.href = '<%= Discourse.base_url.html_safe %>';         
        } else {
          window.opener.Discourse.authenticationComplete(authResult);
          window.close();

--- a/app/views/users/omniauth_callbacks/complete.html.erb
+++ b/app/views/users/omniauth_callbacks/complete.html.erb
@@ -26,7 +26,7 @@
 
        // On facebook browser, just redirect and don't close
        var ua = navigator.userAgent || navigator.vendor || window.opera;
-       if ((ua.indexOf("FBAN") > -1) || (ua.indexOf("FBAV") > -1)) {
+       if ((ua.indexOf("FBAN") > -1) || (ua.indexOf("FBAV") > -1) || (window.opener.Discourse == undefined)) {
          localStorage.setItem('lastAuthResult', JSON.stringify(authResult));
          window.location.href = '<%= Discourse.base_url.html_safe %>?authComplete=true';
        } else {


### PR DESCRIPTION
The current auth complete callback view assumes that either your doing SSO through Facebook or that you are doing SSO through a pop-up window from the main discourse login flow.  

There is another flow, at least using SAML, that allows the idp to have a registry of applications such that a user can click the icon and the browser opens a new window that transparently signs the user directly in to the application. Ultimately the SSO service is still calling the auth complete callback page, but in this case that page is not in a pop-up from the original discourse web page.

This change simply updates the auth complete view with a check to see if it is actually in a pop-up window, and if not, similar to the Facebook flow, simply set the local storage with the auth token and then redirect the page to the main discourse site.

The allows customers to setup discourse with SAML such that they can do idp-initiated SSO.