### PR TITLE
FIX: get urlWithCDN before appending protocol

### DIFF
--- a/app/assets/javascripts/discourse/lib/utilities.js
+++ b/app/assets/javascripts/discourse/lib/utilities.js
@@ -251,7 +251,8 @@ Discourse.Utilities = {
 
   uploadLocation: function(url) {
     if (Discourse.CDN) {
-      return Discourse.CDN.startsWith('//') ? "http:" + Discourse.getURLWithCDN(url) : Discourse.getURLWithCDN(url);
+      url = Discourse.getURLWithCDN(url);
+      return url.startsWith('//') ? 'http:' + url : url;
     } else if (Discourse.SiteSettings.enable_s3_uploads) {
       return 'https:' + url;
     } else {


### PR DESCRIPTION
Currently if the 's3 cdn url' is set audio and video uploads are being returned with 2 protocols (`http:http://cdn.example.com`)

This PR gets `Discourse.getURLWithCDN(url)` before appending the protocol. I've tested this with s3 uploads, with and without setting the `S3CDN` at constructivelearningspace.com.

