### PR TITLE
FEATURE: add m4a to list of audio file extensions

### DIFF
--- a/app/assets/javascripts/discourse/lib/utilities.js
+++ b/app/assets/javascripts/discourse/lib/utilities.js
@@ -265,7 +265,7 @@ Discourse.Utilities = {
   getUploadMarkdown: function(upload) {
     if (Discourse.Utilities.isAnImage(upload.original_filename)) {
       return '<img src="' + upload.url + '" width="' + upload.width + '" height="' + upload.height + '">';
-    } else if (!Discourse.SiteSettings.prevent_anons_from_downloading_files && (/\.(mov|mp4|webm|ogv|mp3|ogg|wav)$/i).test(upload.original_filename)) {
+    } else if (!Discourse.SiteSettings.prevent_anons_from_downloading_files && (/\.(mov|mp4|webm|ogv|mp3|ogg|wav|m4a)$/i).test(upload.original_filename)) {
       // is Audio/Video
       return Discourse.Utilities.uploadLocation(upload.url);
     } else {


### PR DESCRIPTION
Allow m4a files to be oneboxed - will need to be added to `audio_onebox.rb` as well. Doing this makes it easy to record, upload and playback audio from a phone.