### PR TITLE
Fix topic admin menu bottom offset. Calculate from #main's height.

### DIFF
--- a/app/assets/javascripts/discourse/widgets/topic-admin-menu.js.es6
+++ b/app/assets/javascripts/discourse/widgets/topic-admin-menu.js.es6
@@ -73,7 +73,7 @@ export default createWidget('topic-admin-menu', {
     const position = attrs.fixed ? 'fixed' : 'absolute';
 
     if (attrs.openUpwards) {
-      const bottom = $(document).height() - top - $('#main').offset().top;
+      const bottom = $("#main").height() - top - $("#main").offset().top;
       return { style: `position: ${position}; bottom: ${bottom}px; left: ${left}px;` };
     } else {
       return { style: `position: ${position}; top: ${top}px; left: ${left}px;` };


### PR DESCRIPTION
This was causing a small bug in short topics where #main doesn't span the whole document. The difference between #main's bottom and the document's bottom were pushing the menu above/away from the wrench.

You should be able to repro on a very short topic with a tall window. Just click on the admin wrench at the footer. Let me know if I'm off here.