### PR TITLE
Apply notification styles to mailing list email manually

### DIFF
--- a/app/helpers/user_notifications_helper.rb
+++ b/app/helpers/user_notifications_helper.rb
@@ -65,9 +65,9 @@ module UserNotificationsHelper
       normalize_name(post.user.name) != normalize_name(post.user.username)
   end
 
-  def format_for_email(post, use_excerpt, style = nil)
+  def format_for_email(post, use_excerpt)
     html = use_excerpt ? post.excerpt : post.cooked
-    PrettyText.format_for_email(html, post, style).html_safe
+    PrettyText.format_for_email(html, post).html_safe
   end
 
 end

--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -83,11 +83,9 @@ class UserNotifications < ActionMailer::Base
     return unless @posts_by_topic.present?
 
     build_summary_for(user)
-    build_email @user.email,
-                from_alias: I18n.t('user_notifications.mailing_list.from', site_name: SiteSetting.title),
-                subject: I18n.t('user_notifications.mailing_list.subject_template',
-                                site_name: @site_name,
-                                date: @date)
+    apply_notification_styles build_email @user.email,
+      from_alias: I18n.t('user_notifications.mailing_list.from', site_name: SiteSetting.title),
+      subject:    I18n.t('user_notifications.mailing_list.subject_template', site_name: @site_name, date: @date)
   end
 
   def digest(user, opts={})
@@ -417,5 +415,13 @@ class UserNotifications < ActionMailer::Base
     @anchor_color    = ColorScheme.hex_for_name('tertiary')
     @markdown_linker = MarkdownLinker.new(@base_url)
     @unsubscribe_key = UnsubscribeKey.create_key_for(@user, "digest")
+  end
+
+  def apply_notification_styles(email)
+    email.html_part.body = Email::Styles.new(email.html_part.body.to_s).tap do |styles|
+      styles.format_basic
+      styles.format_notification
+    end.to_html
+    email
   end
 end

--- a/app/views/email/_post.html.erb
+++ b/app/views/email/_post.html.erb
@@ -23,7 +23,7 @@
       </td>
     </tr>
     <tr>
-      <td class='body'><%= format_for_email(post, use_excerpt, :notification) %></td>
+      <td class='body'><%= format_for_email(post, use_excerpt) %></td>
     </tr>
   </tbody>
 </table>

--- a/app/views/user_notifications/mailing_list.html.erb
+++ b/app/views/user_notifications/mailing_list.html.erb
@@ -60,7 +60,7 @@
               <span> - </span>
               <span><%= I18n.l(post.created_at, format: :long) %></span>
             </p>
-            <%= raw format_for_email(post, false, :notification) %>
+            <%= raw format_for_email(post, false) %>
             <hr />
           </div>
         <% end %>

--- a/lib/pretty_text.rb
+++ b/lib/pretty_text.rb
@@ -394,16 +394,31 @@ JS
     fragment.to_html
   end
 
+ # Given a Nokogiri doc, convert all links to absolute
+ def self.make_all_links_absolute(doc)
+   site_uri = nil
+   doc.css("a").each do |link|
+     href = link["href"].to_s
+     begin
+       uri = URI(href)
+       site_uri ||= URI(Discourse.base_url)
+       link["href"] = "#{site_uri}#{link['href']}" unless uri.host.present?
+     rescue URI::InvalidURIError, URI::InvalidComponentError
+       # leave it
+     end
+   end
+ end
+
   def self.strip_image_wrapping(doc)
     doc.css(".lightbox-wrapper .meta").remove
   end
 
-  def self.format_for_email(html, post = nil, style = nil)
-    Email::Styles.new(html, style: style).tap do |doc|
-      DiscourseEvent.trigger(:reduce_cooked, doc, post)
-      doc.make_all_links_absolute
-      doc.send :"format_#{style}" if style
-    end.to_html
+  def self.format_for_email(html, post = nil)
+    doc = Nokogiri::HTML.fragment(html)
+    DiscourseEvent.trigger(:reduce_cooked, doc, post)
+    strip_image_wrapping(doc)
+    make_all_links_absolute(doc)
+    doc.to_html
   end
 
   protected

--- a/spec/components/pretty_text_spec.rb
+++ b/spec/components/pretty_text_spec.rb
@@ -318,7 +318,7 @@ HTML
     it "adds base url to relative links" do
       html = "<p><a class=\"mention\" href=\"/users/wiseguy\">@wiseguy</a>, <a class=\"mention\" href=\"/users/trollol\">@trollol</a> what do you guys think? </p>"
       output = described_class.format_for_email(html, post)
-      expect(output).to eq("<p><a href=\"#{base_url}/users/wiseguy\">@wiseguy</a>, <a href=\"#{base_url}/users/trollol\">@trollol</a> what do you guys think? </p>")
+      expect(output).to eq("<p><a class=\"mention\" href=\"#{base_url}/users/wiseguy\">@wiseguy</a>, <a class=\"mention\" href=\"#{base_url}/users/trollol\">@trollol</a> what do you guys think? </p>")
     end
 
     it "doesn't change external absolute links" do


### PR DESCRIPTION
Remove changes from PrettyText, apply notification styles to mailing list email manually.

Notification email:
![screen shot 2016-06-20 at 9 49 35 pm](https://cloud.githubusercontent.com/assets/750477/16215635/e7e7738a-3731-11e6-947f-4e1d54dc681d.png)

Mailing list summary email:
![screen shot 2016-06-20 at 9 49 42 pm](https://cloud.githubusercontent.com/assets/750477/16215638/ec24d096-3731-11e6-8b3b-62393807d4d3.png)
