### PR TITLE
Stop URLs from being censored

### DIFF
--- a/app/assets/javascripts/discourse/lib/censored-words.js
+++ b/app/assets/javascripts/discourse/lib/censored-words.js
@@ -7,14 +7,14 @@ Discourse.CensoredWords = {
       if (!censorRegexp) {
         var split = censored.split("|");
         if (split && split.length) {
-          censorRegexp = new RegExp("\\b(?:" + split.map(function (t) { return "(" + t.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&') + ")"; }).join("|") + ")\\b", "ig");
+          censorRegexp = new RegExp("(\\b(?:" + split.map(function (t) { return "(" + t.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&') + ")"; }).join("|") + ")\\b)(?![^\\(]*\\))", "ig");
         }
       }
       if (censorRegexp) {
         var m = censorRegexp.exec(text);
         while (m && m[0]) {
           var replacement = new Array(m[0].length+1).join('&#9632;');
-          text = text.replace(new RegExp("\\b" + m[0] + "\\b", "ig"), replacement);
+          text = text.replace(new RegExp("(\\b" + m[0] + "\\b)(?![^\\(]*\\))", "ig"), replacement);
           m = censorRegexp.exec(text);
         }
 

--- a/test/javascripts/lib/markdown-test.js.es6
+++ b/test/javascripts/lib/markdown-test.js.es6
@@ -569,6 +569,9 @@ test("censoring", function() {
   cooked("you are a whizzer! I love cheesewhiz. Whiz.",
          "<p>you are a &#9632;&#9632;&#9632;&#9632;&#9632;&#9632;&#9632;! I love cheesewhiz. &#9632;&#9632;&#9632;&#9632;.</p>",
          "it censors words even if previous partial matches exist.");
+  cooked("The link still works. [whiz](http://www.whiz.com)",
+         "<p>The link still works. <a href=\"http://www.whiz.com\">&#9632;&#9632;&#9632;&#9632;</a></p>",
+         "it won't break links by censoring them.");
 });
 
 test("code blocks/spans hoisting", function() {


### PR DESCRIPTION
URLs that contained a censored word were being altered by
censored-words.js and ulimately this broke the links. As an example
www.expertsexchange.com would get censored when it would link to a
legitimate website.  This URL blocking functionality should be
handled through other settings.