### PR TITLE
Allow similar posts for delete post spec

### DIFF
--- a/spec/components/post_destroyer_spec.rb
+++ b/spec/components/post_destroyer_spec.rb
@@ -195,7 +195,6 @@ describe PostDestroyer do
   describe 'basic destroying' do
 
     it "as the creator of the post, doesn't delete the post" do
-      SiteSetting.stubs(:unique_posts_mins).returns(0)
       SiteSetting.stubs(:delete_removed_posts_after).returns(24)
 
       post2 = create_post # Create it here instead of with "let" so unique_posts_mins can do its thing

--- a/spec/components/post_destroyer_spec.rb
+++ b/spec/components/post_destroyer_spec.rb
@@ -195,7 +195,7 @@ describe PostDestroyer do
   describe 'basic destroying' do
 
     it "as the creator of the post, doesn't delete the post" do
-      SiteSetting.stubs(:unique_posts_mins).returns(5)
+      SiteSetting.stubs(:unique_posts_mins).returns(0)
       SiteSetting.stubs(:delete_removed_posts_after).returns(24)
 
       post2 = create_post # Create it here instead of with "let" so unique_posts_mins can do its thing
@@ -446,4 +446,3 @@ describe PostDestroyer do
   end
 
 end
-


### PR DESCRIPTION
Without this change, the second test run collides with the first and causes a fail. This spec is testing post deletion not the creation.

Fixes:

```
$ rspec ./spec/components/post_destroyer_spec.rb:197
...
1 example, 0 failures
$ rspec ./spec/components/post_destroyer_spec.rb:197 
...
PostDestroyer
  basic destroying
    as the creator of the post, doesn't delete the post (FAILED - 1)

Failures:

  1) PostDestroyer basic destroying as the creator of the post, doesn't delete the post
     Failure/Error: raise StandardError.new(creator.errors.full_messages.join(" "))

     StandardError:
       Body is too similar to what you recently posted
     # ./spec/support/helpers.rb:45:in `create_post'
     # ./spec/components/post_destroyer_spec.rb:201:in `block (3 levels) in <top (required)>'

```