### PR TITLE
Add URL blocking functionality

### DIFF
--- a/app/assets/javascripts/discourse/dialects/censored_dialect.js
+++ b/app/assets/javascripts/discourse/dialects/censored_dialect.js
@@ -1,3 +1,4 @@
 Discourse.Dialect.addPreProcessor(function(text) {
+  text = Discourse.BlockedUrls.blockUrl(text);
   return Discourse.CensoredWords.censor(text);
 });

--- a/app/assets/javascripts/discourse/lib/blocked-urls.js
+++ b/app/assets/javascripts/discourse/lib/blocked-urls.js
@@ -1,0 +1,19 @@
+Discourse.BlockedUrls = {
+  blockUrl: function(text) {
+    var blockRegexp,
+        blocked = Discourse.SiteSettings.blocked_urls;
+
+    if (blocked && blocked.length) {
+      if (!blockRegexp) {
+        var split = blocked.split("|");
+        if (split && split.length) {
+          blockRegexp = new RegExp(split.map(function (t) { return "\\]\\([^\\)]*" + t.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&') + "[^\\)]*\\)"; }).join("|"), "ig");
+        }
+      }
+      if (blockRegexp) {
+        text = text.replace(blockRegexp, "]()");
+      }
+    }
+    return text;
+  }
+};

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -497,6 +497,11 @@ posting:
     default: ''
     refresh: true
     type: list
+  blocked_urls:
+    client: true
+    default: ''
+    refresh: true
+    type: list
   enable_emoji:
     default: true
     client: true

--- a/lib/pretty_text.rb
+++ b/lib/pretty_text.rb
@@ -125,6 +125,7 @@ module PrettyText
       "app/assets/javascripts/discourse/dialects/dialect.js",
       "app/assets/javascripts/discourse/lib/censored-words.js",
       "app/assets/javascripts/discourse/lib/markdown.js",
+      "app/assets/javascripts/discourse/lib/blocked-urls.js",
     )
 
     Dir["#{app_root}/app/assets/javascripts/discourse/dialects/**.js"].sort.each do |dialect|

--- a/test/javascripts/lib/markdown-test.js.es6
+++ b/test/javascripts/lib/markdown-test.js.es6
@@ -574,6 +574,19 @@ test("censoring", function() {
          "it won't break links by censoring them.");
 });
 
+test("blocking", function() {
+  Discourse.SiteSettings.blocked_urls = "forbidden|notsafe";
+  cooked("[bad link](http://www.forbidden.com)[bad link](http://www.notsafe.com)",
+         "<p><a>bad link</a><a>bad link</a></p>",
+         "it blocks urls in the Site Settings");
+  cooked("[good link](http://www.safe.com/)[bad link](http://www.safe.com/notsafe)",
+         "<p><a href=\"http://www.safe.com/\">good link</a><a>bad link</a></p>",
+         "it blocks urls when a blocked word is anywhere in the url");
+  cooked("[bad link](http://www.theforbiddenkingdom.com/)",
+         "<p><a>bad link</a></p>",
+         "it blocks urls with partial matches");
+});
+
 test("code blocks/spans hoisting", function() {
   cooked("```\n\n    some code\n```",
          "<p><pre><code class=\"lang-auto\">    some code</code></pre></p>",


### PR DESCRIPTION
Admins can now add websites to a blocked list or add words that
should be blocked. Blocked sites can be added through the Settings >
Posting > Blocked URLs section.