### PR TITLE
Log RecordInvalid when verbose_sso_logging enabled

### DIFF
--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -126,6 +126,14 @@ class SessionController < ApplicationController
         render text: I18n.t("sso.not_found"), status: 500
       end
     rescue ActiveRecord::RecordInvalid => e
+      if SiteSetting.verbose_sso_logging
+        Rails.logger.warn(<<-EOF)
+          Verbose SSO log: Record was invalid: #{e.record.class.name} #{e.record.id}\n
+          #{e.record.errors.to_h}\n
+          \n
+          #{sso.diagnostics}
+        EOF
+      end
       render text: I18n.t("sso.unknown_error"), status: 500
     rescue => e
       message = "Failed to create or lookup user: #{e}."


### PR DESCRIPTION
I find this to be *extremely* helpful in debugging.

Turns out we had some accounts whose emails hadn't been synced recently, and they were causing SSO to fail due to a uniqueness constraint on that column.

Wouldn't have figured that out if not for this patch.