### PR TITLE
FIX: Unicode aware text sentinel

### DIFF
--- a/lib/text_sentinel.rb
+++ b/lib/text_sentinel.rb
@@ -1,3 +1,7 @@
+# Whe use ActiveSupport mb_chars from here to properly support non ascii downcase
+# TODO remove when ruby 2.4 lands
+require 'active_support/core_ext/string/multibyte'
+
 #
 # Given a string, tell us whether or not is acceptable.
 #
@@ -72,8 +76,8 @@ class TextSentinel
 
 
   def seems_quiet?
-    # We don't allow all upper case content in english
-    SiteSetting.allow_uppercase_posts || not((@text =~ /[A-Z]+/) && !(@text =~ /[^[:ascii:]]/) && (@text == @text.upcase))
+    # We don't allow all upper case content
+    SiteSetting.allow_uppercase_posts || @text == @text.mb_chars.downcase.to_s || @text != @text.mb_chars.upcase.to_s
   end
 
 end

--- a/spec/components/text_sentinel_spec.rb
+++ b/spec/components/text_sentinel_spec.rb
@@ -49,7 +49,7 @@ describe TextSentinel do
     [ 'evil trout is evil',
       "去年十社會警告",
       "P.S. Пробирочка очень толковая и весьма умная, так что не обнимайтесь.",
-      "LOOK: 去年十社會警告"
+      "Look: 去年十社會警告"
     ].each do |valid_body|
       it "handles a valid body in a private message" do
         expect(TextSentinel.body_sentinel(valid_body, private_message: true)).to be_valid
@@ -72,6 +72,10 @@ describe TextSentinel do
 
     it "doesn't allow all caps topics" do
       expect(TextSentinel.new(valid_string.upcase)).not_to be_valid
+    end
+
+    it "doesn't allow all caps foreign topics" do
+      expect(TextSentinel.new('É COM VOCÊ LOMBARDIAM. MA VEJAM SÓ, VEJAM SÓ. VALENDO UM MILHÃO DE REAISAMMM. MA VALE DÉRREAISAM?')).not_to be_valid
     end
 
     it "allows all caps topics when loud posts are allowed" do


### PR DESCRIPTION
This makes text_sentinel blocks people from shouting in non-english too :mega: :loudspeaker:  