### PR TITLE
Add didRender hook for widgets

### DIFF
--- a/app/assets/javascripts/discourse/widgets/widget.js.es6
+++ b/app/assets/javascripts/discourse/widgets/widget.js.es6
@@ -189,7 +189,13 @@ export default class Widget {
       }
     }
 
-    return this.draw(h, this.attrs, this.state);
+    let result = this.draw(h, this.attrs, this.state);
+    this.didRenderWidget();
+    return result;
+  }
+
+  didRenderWidget() {
+    return true;
   }
 
   _findAncestorWithProperty(property) {


### PR DESCRIPTION
Hey @eviltrout , I'm attempting to perform some (conditional) action each time a widget is re-rendered (specifically, I'd like to ensure that a scroll event is present on a particular element in the widget).

I'm able to call `afterRender` in the parent component (in my case the `SiteHeader`) like this:

```
afterRender() {
  Ember.run.scheduleOnce('afterRender' () => { console.log('I just rendered!') })
}
```

but would prefer that the SiteHeader not care about this action at all (considering it's nested maybe 2 or 3 widgets down, and has nothing to do with the header). This PR would enable

```
# my-widget.js.es6
didRenderWidget() { console.log('I just rendered!') } 
```

but I wonder if there's a better way?

In my particular case, the ideal would be to write a `WidgetScrollHook` to attach to a widget, which could then define a `scroll() {}` method, similar to how `click() {}` works, but of course there's the gotcha that scroll events don't bubble, which made that feel slightly tricky.