### PR TITLE
FEATURE: Allow <3 and ❤ to trigger like via email

### DIFF
--- a/lib/email/receiver.rb
+++ b/lib/email/receiver.rb
@@ -384,7 +384,7 @@ module Email
     end
 
     def likes
-      @likes ||= Set.new ["+1", I18n.t('post_action_types.like.title').downcase]
+      @likes ||= Set.new ["+1", "<3", "❤", I18n.t('post_action_types.like.title').downcase]
     end
 
     def subscription_action_for(body, subject)


### PR DESCRIPTION
Had someone bug me about this this other day, referenced [here](https://meta.discourse.org/t/feature-like-via-email/37052/19?u=gdpelican)
