### PR TITLE
FIX: Don't reject likes by email for closed topics

### DIFF
--- a/lib/email/receiver.rb
+++ b/lib/email/receiver.rb
@@ -404,11 +404,11 @@ module Email
 
     def create_reply(options={})
       raise TopicNotFoundError if options[:topic].nil? || options[:topic].trashed?
-      raise TopicClosedError   if options[:topic].closed?
 
       if post_action_type = post_action_for(options[:raw])
         create_post_action(options[:user], options[:post], post_action_type)
       else
+        raise TopicClosedError if options[:topic].closed?
         options[:topic_id] = options[:post].try(:topic_id)
         options[:reply_to_post_number] = options[:post].try(:post_number)
         options[:is_group_message] = options[:topic].private_message? && options[:topic].allowed_groups.exists?

--- a/spec/components/email/receiver_spec.rb
+++ b/spec/components/email/receiver_spec.rb
@@ -129,6 +129,11 @@ describe Email::Receiver do
       expect { process(:reply_user_matching) }.to raise_error(Email::Receiver::TopicClosedError)
     end
 
+    it "does not raise TopicClosedError when performing a like action" do
+      topic.update_columns(closed: true)
+      expect { process(:like) }.to change(PostAction, :count)
+    end
+
     it "raises an InvalidPost when there was an error while creating the post" do
       expect { process(:too_small) }.to raise_error(Email::Receiver::InvalidPost)
     end


### PR DESCRIPTION
Quick follow-on to that last fix; reported [here](https://meta.discourse.org/t/feature-like-via-email/37052/22)