### PR TITLE
FEATURE: Add options to inject class / page into emoji toolbar

### DIFF
--- a/app/assets/javascripts/discourse/lib/emoji/emoji-toolbar.js.es6
+++ b/app/assets/javascripts/discourse/lib/emoji/emoji-toolbar.js.es6
@@ -163,11 +163,8 @@ function showSelector(options) {
   $('.emoji-modal-wrapper').click(() => closeSelector());
 
   if (Discourse.Site.currentProp('mobileView')) { PER_ROW = 9; }
-  if (options.page) {
-    var page = _.findIndex(groups, (g) => { return g.name == options.page })
-  } else {
-    var page = keyValueStore.getInt("emojiPage", 0)
-  }
+  const page = options.page ? _.findIndex(groups, (g) => { return g.name === options.page; })
+                            : keyValueStore.getInt("emojiPage", 0);
   const offset = keyValueStore.getInt("emojiOffset", 0);
 
   render(page, offset, options);

--- a/app/assets/javascripts/discourse/lib/emoji/emoji-toolbar.js.es6
+++ b/app/assets/javascripts/discourse/lib/emoji/emoji-toolbar.js.es6
@@ -132,7 +132,7 @@ function render(page, offset, options) {
 
   for(let i=offset; i<max; i++){
     if(!icons[i]){ break; }
-    if(row.length === PER_ROW){
+    if(row.length === (options.perRow || PER_ROW)){
       rows.push(row);
       row = [];
     }
@@ -144,7 +144,8 @@ function render(page, offset, options) {
     toolbarItems: toolbarItems,
     rows: rows,
     prevDisabled: offset === 0,
-    nextDisabled: (max + 1) > icons.length
+    nextDisabled: (max + 1) > icons.length,
+    modalClass: options.modalClass
   };
 
   $('.emoji-modal', options.appendTo).remove();
@@ -162,7 +163,11 @@ function showSelector(options) {
   $('.emoji-modal-wrapper').click(() => closeSelector());
 
   if (Discourse.Site.currentProp('mobileView')) { PER_ROW = 9; }
-  const page = keyValueStore.getInt("emojiPage", 0);
+  if (options.page) {
+    var page = _.findIndex(groups, (g) => { return g.name == options.page })
+  } else {
+    var page = keyValueStore.getInt("emojiPage", 0)
+  }
   const offset = keyValueStore.getInt("emojiOffset", 0);
 
   render(page, offset, options);

--- a/app/assets/javascripts/discourse/templates/emoji-toolbar.raw.hbs
+++ b/app/assets/javascripts/discourse/templates/emoji-toolbar.raw.hbs
@@ -1,4 +1,4 @@
-<div class='emoji-modal'>
+<div class='emoji-modal {{modalClass}}'>
   <ul class='toolbar'>
     {{#each toolbarItems as |item|}}<li><a title='{{item.title}}' {{#if item.selected}}class='selected'{{/if}} data-group-id='{{item.groupId}}'><img src='{{item.src}}' class='emoji'></a></li>{{/each}}
   </ul>


### PR DESCRIPTION
I'm looking for a slightly more flexible emoji toolbar, which will let me inject some options to allow for limited emojisets for the [retort](www.github.com/gdpelican/retort) plugin.

![](http://g.recordit.co/2nOn5r1Amy.gif)

Any objections to these?