### PR TITLE
FIX: use strict_encode64 in sso

### DIFF
--- a/lib/single_sign_on.rb
+++ b/lib/single_sign_on.rb
@@ -30,7 +30,7 @@ class SingleSignOn
       end
     end
 
-    decoded = Base64.decode64(parsed["sso"])
+    decoded = Base64.strict_decode64(parsed["sso"])
     decoded_hash = Rack::Utils.parse_query(decoded)
 
     ACCESSORS.each do |k|
@@ -85,7 +85,7 @@ class SingleSignOn
   end
 
   def payload
-    payload = Base64.encode64(unsigned_payload)
+    payload = Base64.strict_encode64(unsigned_payload)
     "sso=#{CGI::escape(payload)}&sig=#{sign(payload)}"
   end
 


### PR DESCRIPTION
This avoids weird `\n` padding that all other languages do not do in their basic decode/encode 64 implementations.
possible ref https://stackoverflow.com/questions/2620975/strange-n-in-base64-encoded-string-in-ruby

Could be breaking if SSO consumers were looking for line feed(s) that MUST be here
for stripping them or something.