### PR TITLE
UX: group pages should not show Messages tab to unauthorised users

### DIFF
--- a/app/assets/javascripts/discourse/controllers/group.js.es6
+++ b/app/assets/javascripts/discourse/controllers/group.js.es6
@@ -16,6 +16,13 @@ var Tab = Em.Object.extend({
 export default Ember.Controller.extend({
   counts: null,
   showing: 'members',
+  tabs: [
+    Tab.create({ name: 'members', active: true, 'location': 'group.index' }),
+    Tab.create({ name: 'posts' }),
+    Tab.create({ name: 'topics' }),
+    Tab.create({ name: 'mentions' }),
+    Tab.create({ name: 'messages', requiresMembership: true })
+  ],
 
   @observes('counts')
   countsChanged() {
@@ -34,11 +41,8 @@ export default Ember.Controller.extend({
     });
   },
 
-  tabs: [
-    Tab.create({ name: 'members', active: true, 'location': 'group.index' }),
-    Tab.create({ name: 'posts' }),
-    Tab.create({ name: 'topics' }),
-    Tab.create({ name: 'mentions' }),
-    Tab.create({ name: 'messages' }),
-  ]
+  @computed('model.is_member')
+  getTabs(isMember) {
+    return this.get('tabs').filter(t => isMember || !t.get('requiresMembership'));
+  }
 });

--- a/app/assets/javascripts/discourse/templates/group.hbs
+++ b/app/assets/javascripts/discourse/templates/group.hbs
@@ -2,7 +2,7 @@
   <div class="wrapper">
   <section class='user-navigation'>
     <ul class='action-list nav-stacked'>
-      {{#each tabs as |tab|}}
+      {{#each getTabs as |tab|}}
         <li class="{{if tab.active 'active'}}">
           {{#link-to tab.location model title=tab.message}}
             {{tab.message}}

--- a/app/serializers/basic_group_serializer.rb
+++ b/app/serializers/basic_group_serializer.rb
@@ -13,6 +13,7 @@ class BasicGroupSerializer < ApplicationSerializer
              :incoming_email,
              :notification_level,
              :has_messages,
+             :is_member,
              :mentionable
 
   def include_incoming_email?
@@ -30,6 +31,14 @@ class BasicGroupSerializer < ApplicationSerializer
 
   def mentionable
     object.mentionable?(scope.user, object.id)
+  end
+
+  def is_member
+    scope.is_admin? || GroupUser.where(group_id: object.id, user_id: scope.user.id).present?
+  end
+
+  def include_is_member?
+    scope.authenticated?
   end
 
 end

--- a/spec/controllers/admin/groups_controller_spec.rb
+++ b/spec/controllers/admin/groups_controller_spec.rb
@@ -34,6 +34,7 @@ describe Admin::GroupsController do
         "incoming_email"=>nil,
         "notification_level"=>2,
         "has_messages"=>false,
+        "is_member"=>true,
         "mentionable"=>false
       }])
     end


### PR DESCRIPTION
Meta topic: https://meta.discourse.org/t/group-pages-should-not-show-messages-tab-to-unauthorised-users/46946?u=techapj

Can you please review this PR @eviltrout?