### PR TITLE
FIX: delete PostgreSQL dump before gzipping archive

### DIFF
--- a/lib/backup_restore/backuper.rb
+++ b/lib/backup_restore/backuper.rb
@@ -257,6 +257,8 @@ module BackupRestore
         end
       end
 
+      remove_tmp_directory
+
       log "Gzipping archive, this may take a while..."
       `gzip -5 #{tar_filename}`
     end
@@ -284,7 +286,6 @@ module BackupRestore
     def clean_up
       log "Cleaning stuff up..."
       remove_tar_leftovers
-      remove_tmp_directory
       unpause_sidekiq
       disable_readonly_mode if Discourse.readonly_mode?
       mark_backup_as_not_running


### PR DESCRIPTION
Currently the SQL dump is deleted after the `.tar` file is gzipped, this is causing low disk space issue on sites that have large SQL dump (in my case ~10GB).

This PR will delete the `/tmp/backups/default/x` folder as soon as the tar archive is created which gives enough disk space to gzip process.

@ZogStriP Please review?