### PR TITLE
FIX: Update post replies when we move posts.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -315,9 +315,7 @@ class ApplicationController < ActionController::Base
   def post_ids_including_replies
     post_ids = params[:post_ids].map {|p| p.to_i}
     if params[:reply_post_ids]
-      post_ids << PostReply.where(post_id: params[:reply_post_ids].map {|p| p.to_i}).pluck(:reply_id)
-      post_ids.flatten!
-      post_ids.uniq!
+      post_ids |= PostReply.where(post_id: params[:reply_post_ids].map {|p| p.to_i}).pluck(:reply_id)
     end
     post_ids
   end

--- a/app/models/post_mover.rb
+++ b/app/models/post_mover.rb
@@ -76,6 +76,12 @@ class PostMover
     posts.each do |post|
       post.is_first_post? ? create_first_post(post) : move(post)
     end
+
+    PostReply.where("reply_id in (:post_ids) OR post_id in (:post_ids)", post_ids: post_ids).each do |post_reply|
+      if post_reply.reply.topic_id != post_reply.post.topic_id
+        PostReply.delete_all(reply_id: post_reply.reply.id, post_id: post_reply.post.id)
+      end
+    end
   end
 
   def create_first_post(post)

--- a/app/models/post_reply.rb
+++ b/app/models/post_reply.rb
@@ -3,6 +3,18 @@ class PostReply < ActiveRecord::Base
   belongs_to :reply, class_name: 'Post'
 
   validates_uniqueness_of :reply_id, scope: :post_id
+  validate :ensure_same_topic
+
+  private
+
+  def ensure_same_topic
+    if post.topic_id != reply.topic_id
+      self.errors.add(
+        :base,
+        I18n.t("activerecord.errors.models.post_reply.base.different_topic")
+      )
+    end
+  end
 end
 
 # == Schema Information

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -346,6 +346,10 @@ en:
           attributes:
             hex:
               invalid: "is not a valid color"
+        post_reply:
+          base:
+            different_topic: "Post and reply must belong to the same topic."
+
 
   user_profile:
     no_info_me: "<div class='missing-profile'>the About Me field of your profile is currently blank, <a href='/users/%{username_lower}/preferences/about-me'>would you like to fill it out?</a></div>"

--- a/spec/models/post_reply_spec.rb
+++ b/spec/models/post_reply_spec.rb
@@ -1,8 +1,27 @@
 require 'rails_helper'
 
 describe PostReply do
+  let(:topic) { Fabricate(:topic) }
+  let(:post) { Fabricate(:post, topic: topic) }
+  let(:other_post) { Fabricate(:post, topic: topic) }
 
   it { is_expected.to belong_to :post }
   it { is_expected.to belong_to :reply }
 
+  context "validation" do
+    it "should ensure that the posts belong in the same topic" do
+      expect(PostReply.new(post: post, reply: other_post)).to be_valid
+
+      other_topic = Fabricate(:topic)
+      other_post.update_attributes!(topic_id: other_topic.id)
+      other_post.reload
+
+      post_reply = PostReply.new(post: post, reply: other_post)
+      expect(post_reply).to_not be_valid
+
+      expect(post_reply.errors[:base]).to include(
+        I18n.t("activerecord.errors.models.post_reply.base.different_topic")
+      )
+    end
+  end
 end


### PR DESCRIPTION
https://meta.discourse.org/t/removed-posts-show-up-when-reply-button-is-clicked/47186/3