### PR TITLE
Feature: Add support for AWS China

### DIFF
--- a/app/models/s3_region_site_setting.rb
+++ b/app/models/s3_region_site_setting.rb
@@ -20,7 +20,8 @@ class S3RegionSiteSetting < EnumSiteSetting
       'ap-southeast-2',
       'ap-northeast-1',
       'ap-northeast-2',
-      'sa-east-1'
+      'sa-east-1',
+      'cn-north-1'
     ]
   end
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -186,6 +186,7 @@ en:
         ap_northeast_1: "Asia Pacific (Tokyo)"
         ap_northeast_2: "Asia Pacific (Seoul)"
         sa_east_1: "South America (Sao Paulo)"
+        cn_north_1: "China (Beijing)"
 
     edit: 'edit the title and category of this topic'
     not_implemented: "That feature hasn't been implemented yet, sorry!"

--- a/config/locales/client.zh_CN.yml
+++ b/config/locales/client.zh_CN.yml
@@ -132,6 +132,7 @@ zh_CN:
         ap_northeast_1: "亚洲太平洋（Tokyo）"
         ap_northeast_2: "亚洲太平洋（Seoul）"
         sa_east_1: "南美（Sao Paulo）"
+        cn_north_1: "中国 (北京)"
     edit: '编辑本主题的标题和分类'
     not_implemented: "非常抱歉，此功能暂时尚未实现！"
     no_value: "否"

--- a/lib/file_store/s3_store.rb
+++ b/lib/file_store/s3_store.rb
@@ -62,6 +62,8 @@ module FileStore
       # cf. http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
       @absolute_base_url ||= if SiteSetting.s3_region == "us-east-1"
         "//#{s3_bucket}.s3.amazonaws.com"
+      elsif SiteSetting.s3_region == 'cn-north-1'
+        "//#{s3_bucket}.s3.cn-north-1.amazonaws.com.cn"
       else
         "//#{s3_bucket}.s3-#{SiteSetting.s3_region}.amazonaws.com"
       end

--- a/spec/components/file_store/s3_store_spec.rb
+++ b/spec/components/file_store/s3_store_spec.rb
@@ -81,6 +81,10 @@ describe FileStore::S3Store do
 
       SiteSetting.stubs(:s3_region).returns("us-east-2")
       expect(FileStore::S3Store.new(s3_helper).absolute_base_url).to eq("//s3_upload_bucket.s3-us-east-2.amazonaws.com")
+
+      SiteSetting.stubs(:s3_region).returns("cn-north-1")
+      expect(FileStore::S3Store.new(s3_helper).absolute_base_url).to eq("//s3_upload_bucket.s3.cn-north-1.amazonaws.com.cn")
+
     end
 
   end

--- a/spec/models/s3_region_site_setting_spec.rb
+++ b/spec/models/s3_region_site_setting_spec.rb
@@ -14,7 +14,7 @@ describe S3RegionSiteSetting do
 
   describe 'values' do
     it 'returns all the S3 regions' do
-      expect(S3RegionSiteSetting.values.map {|x| x[:value]}.sort).to eq(['us-east-1', 'us-west-1', 'us-west-2', 'us-gov-west-1', 'eu-west-1', 'eu-central-1', 'ap-southeast-1', 'ap-southeast-2', 'ap-northeast-1', 'ap-northeast-2', 'sa-east-1'].sort)
+      expect(S3RegionSiteSetting.values.map {|x| x[:value]}.sort).to eq(['us-east-1', 'us-west-1', 'us-west-2', 'us-gov-west-1', 'eu-west-1', 'eu-central-1', 'ap-southeast-1', 'ap-southeast-2', 'ap-northeast-1', 'ap-northeast-2', 'sa-east-1', 'cn-north-1'].sort)
     end
   end
 


### PR DESCRIPTION
### What

Add support for AWS China for S3 store when uploading files.

### Why

AWS China is a unique system which don't share the same credentials with other regions and also have different domain name for S3 files.