### PR TITLE
FIX: poll builder should ignore empty lines

### DIFF
--- a/plugins/poll/assets/javascripts/controllers/poll-ui-builder.js.es6
+++ b/plugins/poll/assets/javascripts/controllers/poll-ui-builder.js.es6
@@ -111,7 +111,9 @@ export default Ember.Controller.extend({
     output += `${pollHeader}\n`;
 
     if (pollOptions.length > 0 && !isNumber) {
-      output += `${pollOptions.split("\n").map(option => `* ${option}`).join("\n")}\n`;
+      pollOptions.split("\n").forEach(option => {
+        if (option.length !== 0) output += `* ${option}\n`;
+      });
     }
 
     output += '[/poll]';

--- a/plugins/poll/test/javascripts/controllers/poll-ui-builder-test.js.es6
+++ b/plugins/poll/test/javascripts/controllers/poll-ui-builder-test.js.es6
@@ -210,7 +210,7 @@ test("multiple pollOutput", function() {
     isMultiple: true,
     pollType: controller.get("multiplePollType"),
     pollMin: 1,
-    pollOptions: "1\n2"
+    pollOptions: "\n\n1\n\n2"
   });
 
   equal(controller.get("pollOutput"), "[poll type=multiple min=1 max=2]\n* 1\n* 2\n[/poll]", "it should return the right output");


### PR DESCRIPTION
Although pollOptionsCount skips empty lines, pollOutput inserts empty
lines. Skip them instead.

Signed-off-by: Loic Dachary <loic@dachary.org>