### PR TITLE
Anchor is not necessary for avatars, change to span

### DIFF
--- a/app/assets/javascripts/discourse/templates/post/poster-avatar.raw.hbs
+++ b/app/assets/javascripts/discourse/templates/post/poster-avatar.raw.hbs
@@ -1,1 +1,1 @@
-<a href="{{post.usernameUrl}}" classNames="trigger-user-card {{classNames}}" data-user-card="{{post.username}}">{{avatar post imageSize="large"}}</a>
+<span classNames="trigger-user-card {{classNames}}" data-user-card="{{post.username}}">{{avatar post imageSize="large"}}</span>

--- a/app/assets/javascripts/discourse/widgets/post.js.es6
+++ b/app/assets/javascripts/discourse/widgets/post.js.es6
@@ -25,9 +25,9 @@ export function avatarImg(wanted, attrs) {
 }
 
 export function avatarFor(wanted, attrs) {
-  return h('a', {
+  return h('span', {
     className: `trigger-user-card ${attrs.className || ''}`,
-    attributes: { href: attrs.url, 'data-user-card': attrs.username }
+    attributes: { 'data-user-card': attrs.username }
   }, avatarImg(wanted, attrs));
 }
 

--- a/test/javascripts/widgets/post-test.js.es6
+++ b/test/javascripts/widgets/post-test.js.es6
@@ -119,14 +119,14 @@ widgetTest('like count button', {
     click('button.like-count');
     andThen(() => {
       assert.ok(this.$('.who-liked').length === 1);
-      assert.ok(this.$('.who-liked a.trigger-user-card').length === 1);
+      assert.ok(this.$('.who-liked span.trigger-user-card').length === 1);
     });
 
     // toggle it off
     click('button.like-count');
     andThen(() => {
       assert.ok(this.$('.who-liked').length === 0);
-      assert.ok(this.$('.who-liked a.trigger-user-card').length === 0);
+      assert.ok(this.$('.who-liked span.trigger-user-card').length === 0);
     });
   }
 });


### PR DESCRIPTION
I recommend replacing the anchor '<a>' tag to a span '<span>' tag because anchor tells Google to pass page rank to user pages, which are not crawled anyways and those links are not linked to the user page, but used to trigger an overlay with user info.

I also removed the href property when applicable. In fact, some avatar links like the small ones in the topic first post don't even have an href property.

The event will still work because it is triggered on the 'trigger-user-card' selector.

I highly recommend that we make the change, a big boost for SEO with more importance to the topic pages, no page rank goes to waste.