### PR TITLE
New AWS S3 Storage Mumbai region added

### DIFF
--- a/app/models/s3_region_site_setting.rb
+++ b/app/models/s3_region_site_setting.rb
@@ -18,6 +18,7 @@ class S3RegionSiteSetting < EnumSiteSetting
       'eu-central-1',
       'ap-southeast-1',
       'ap-southeast-2',
+      'ap-south-1',
       'ap-northeast-1',
       'ap-northeast-2',
       'sa-east-1',

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -183,6 +183,7 @@ en:
         eu_central_1: "EU (Frankfurt)"
         ap_southeast_1: "Asia Pacific (Singapore)"
         ap_southeast_2: "Asia Pacific (Sydney)"
+        ap_south_1: "Asia Pacific (Mumbai)"
         ap_northeast_1: "Asia Pacific (Tokyo)"
         ap_northeast_2: "Asia Pacific (Seoul)"
         sa_east_1: "South America (Sao Paulo)"

--- a/spec/models/s3_region_site_setting_spec.rb
+++ b/spec/models/s3_region_site_setting_spec.rb
@@ -14,7 +14,7 @@ describe S3RegionSiteSetting do
 
   describe 'values' do
     it 'returns all the S3 regions' do
-      expect(S3RegionSiteSetting.values.map {|x| x[:value]}.sort).to eq(['us-east-1', 'us-west-1', 'us-west-2', 'us-gov-west-1', 'eu-west-1', 'eu-central-1', 'ap-southeast-1', 'ap-southeast-2', 'ap-northeast-1', 'ap-northeast-2', 'sa-east-1', 'cn-north-1'].sort)
+      expect(S3RegionSiteSetting.values.map {|x| x[:value]}.sort).to eq(['us-east-1', 'us-west-1', 'us-west-2', 'us-gov-west-1', 'eu-west-1', 'eu-central-1', 'ap-southeast-1', 'ap-southeast-2', 'ap-south-1', 'ap-northeast-1', 'ap-northeast-2', 'sa-east-1', 'cn-north-1'].sort)
     end
   end
 


### PR DESCRIPTION
New AWS S3 Storage Asia Pacific (Mumbai) _ap-south-1_ region added.

as per discourse topic https://meta.discourse.org/t/mumbai-region-missing-on-amazon-s3-region-selection/47328