### PR TITLE
Allow localhost as an embeddable host

### DIFF
--- a/app/models/embeddable_host.rb
+++ b/app/models/embeddable_host.rb
@@ -25,7 +25,8 @@ class EmbeddableHost < ActiveRecord::Base
 
     def host_must_be_valid
       if host !~ /\A[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,7}(:[0-9]{1,5})?(\/.*)?\Z/i &&
-         host !~ /\A(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})\Z/
+         host !~ /\A(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})\Z/ &&
+         host !~ /\A([a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.)?localhost(\:[0-9]{1,5})?(\/.*)?\Z/i
         errors.add(:host, I18n.t('errors.messages.invalid'))
       end
     end

--- a/spec/models/embeddable_host_spec.rb
+++ b/spec/models/embeddable_host_spec.rb
@@ -26,6 +26,29 @@ describe EmbeddableHost do
     expect(eh.host).to eq('192.168.0.1')
   end
 
+  it "supports localhost" do
+    eh = EmbeddableHost.new(host: 'localhost')
+    expect(eh).to be_valid
+    expect(eh.host).to eq('localhost')
+  end
+
+  it "supports ports of localhost" do
+    eh = EmbeddableHost.new(host: 'localhost:8080')
+    expect(eh).to be_valid
+    expect(eh.host).to eq('localhost:8080')
+  end
+
+  it "supports subdomains of localhost" do
+    eh = EmbeddableHost.new(host: 'discourse.localhost')
+    expect(eh).to be_valid
+    expect(eh.host).to eq('discourse.localhost')
+  end
+
+  it "rejects misspellings of localhost" do
+    eh = EmbeddableHost.new(host: 'alocalhost')
+    expect(eh).not_to be_valid
+  end
+
   describe "allows_embeddable_host" do
     let!(:host) { Fabricate(:embeddable_host) }
 


### PR DESCRIPTION
Hostnames containing localhost do not currently pass embeddable host validations. This prevents the user from embedding comments into a page hosted on localhost.

This fix causes these hostnames to pass validation.