### PR TITLE
Fix to heredoc in discource plugin

### DIFF
--- a/plugins/discourse-nginx-performance-report/app/jobs/scheduled/daily_performance_report.rb
+++ b/plugins/discourse-nginx-performance-report/app/jobs/scheduled/daily_performance_report.rb
@@ -10,7 +10,7 @@ module Jobs
 
         report_data =
           if result.strip.empty?
-            <<~TEXT
+            <<-TEXT
             Report is only available in latest image, please run:
 
             ```text


### PR DESCRIPTION
Changed heredoc syntax to be properly ruby 2.0+ compliant.