### PR TITLE
Base importer: Store the original username during import

### DIFF
--- a/script/import_scripts/phpbb3/settings.yml
+++ b/script/import_scripts/phpbb3/settings.yml
@@ -53,7 +53,7 @@ import:
   polls: true
 
   # When true: each imported user will have the original username from phpBB as its name
-  # When false: the name of each user will be blank
+  # When false: the name of each imported user will be blank unless the username was changed during import
   username_as_name: false
 
   # Map Emojis to smilies used in phpBB. Most of the default smilies already have a mapping, but you can override


### PR DESCRIPTION
This commit contains two changes:
- We should always store the original username as `import_username` instead of the username that could have been changed during the import.
- Set the user's `name` to the original username if the user doesn't have a name and the username was changed during the import. This was [suggested on meta](https://meta.discourse.org/t/phpbb3-importer-username-as-name-setting-doesnt-apply-to-anonymous-users/47232).

