### PR TITLE
phpBB3 importer: fixes for internal links and guest users

### DIFF
--- a/script/import_scripts/phpbb3/importers/user_importer.rb
+++ b/script/import_scripts/phpbb3/importers/user_importer.rb
@@ -51,7 +51,7 @@ module ImportScripts::PhpBB3
 
       {
         id: username,
-        email: "anonymous_no_email_#{username}",
+        email: "anonymous_no_email_#{SecureRandom.hex}",
         username: username,
         name: '',
         created_at: Time.zone.at(row[:first_post_time]),

--- a/script/import_scripts/phpbb3/importers/user_importer.rb
+++ b/script/import_scripts/phpbb3/importers/user_importer.rb
@@ -53,7 +53,7 @@ module ImportScripts::PhpBB3
         id: username,
         email: "anonymous_no_email_#{SecureRandom.hex}",
         username: username,
-        name: '',
+        name: @settings.username_as_name ? username : '',
         created_at: Time.zone.at(row[:first_post_time]),
         active: true,
         trust_level: TrustLevel[0],

--- a/script/import_scripts/phpbb3/support/text_processor.rb
+++ b/script/import_scripts/phpbb3/support/text_processor.rb
@@ -137,7 +137,7 @@ module ImportScripts::PhpBB3
 
     def create_internal_link_regexps(original_site_prefix)
       host = original_site_prefix.gsub('.', '\.')
-      link_regex = "http(?:s)?://#{host}/viewtopic\\.php\\?(?:\\S*)(?:t=(\\d+)|p=(\\d+)(?:#p\\d+)?)"
+      link_regex = "http(?:s)?://#{host}/viewtopic\\.php\\?(?:\\S*)(?:t=(\\d+)|p=(\\d+)(?:#p\\d+)?)(?:\\S*)"
 
       @long_internal_link_regexp = Regexp.new(%Q|<!-- l --><a(?:.+)href="#{link_regex}"(?:.*)</a><!-- l -->|, Regexp::IGNORECASE)
       @short_internal_link_regexp = Regexp.new(link_regex, Regexp::IGNORECASE)


### PR DESCRIPTION
- Ignore irrelevant query parameters in internal links (see [topic on meta](https://meta.discourse.org/t/phpbb3-importers-link-conversion-breaks-links-with-additional-parameters/47225))
- Don't fail if guest usernames differ only by case (see [topic on meta](https://meta.discourse.org/t/phpbb-importer-fails-to-import-anonymous-users-differing-only-by-letter-case/47083))
- Import username as name for guest users if enabled in settings (see [topic on meta](https://meta.discourse.org/t/phpbb3-importer-username-as-name-setting-doesnt-apply-to-anonymous-users/47232))