### PR TITLE
Suggest change 'cause' to 'because' for the reason that it is better English grammar

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2184,7 +2184,7 @@ en:
     To unsubscribe from these emails, [click here](%{unsubscribe_url}).
 
   unsubscribe_mailing_list: |
-    You are receiving these emails cause you have enabled mailing list mode.
+    You are receiving these emails because you have enabled mailing list mode.
 
     To unsubscribe from these emails, [click here](%{unsubscribe_url}).
 


### PR DESCRIPTION
Apologies if this seems a trivial pull request, but I recently noticed that the text in the footer of email I am getting as Admin of my Discourse instance says "You are receiving these emails cause you have enabled mailing list mode". I would suggest that this should say "You are receiving these emails because you have enabled mailing list mode", which is regarded as better English grammar and more professional sounding. Here is the amendment as a pull request. I have signed the Discourse CLA.