### PR TITLE
data.archetype should be data.payload.archetype in topic_tracking_state.js.es6

### DIFF
--- a/app/assets/javascripts/discourse/models/topic-tracking-state.js.es6
+++ b/app/assets/javascripts/discourse/models/topic-tracking-state.js.es6
@@ -103,7 +103,7 @@ const TopicTrackingState = Discourse.Model.extend({
 
   notify(data) {
     if (!this.newIncoming) { return; }
-    if (data.archetype === "private_message") { return; }
+    if (data.payload && data.payload.archetype === "private_message") { return; }
 
     const filter = this.get("filter");
     const filterCategory = this.get("filterCategory");


### PR DESCRIPTION
The MessageBus sends messages that include the archetype of the post in the payload seciton of the message, as in:

      def self.publish_new(topic)

        message = {
          topic_id: topic.id,
          message_type: "new_topic",
          payload: {
            last_read_post_number: nil,
            highest_post_number: 1,
            created_at: topic.created_at,
            topic_id: topic.id,
            category_id: topic.category_id,
            archetype: topic.archetype # <-- HERE
          }
        }

        group_ids = topic.category && topic.category.secure_group_ids

        MessageBus.publish("/new", message.as_json, group_ids: group_ids)
        publish_read(topic.id, 1, topic.user_id)
      end

in topic_tracking_state.rb

However, when the messages are read off, the archetype property is being accessed outside of the payload object:

      notify(data) {
        if (!this.newIncoming) { return; }
        if (data.archetype === "private_message") { return; } // <-- HERE

        const filter = this.get("filter");
        const filterCategory = this.get("filterCategory");
        const categoryId = data.payload && data.payload.category_id;

        if (filterCategory && filterCategory.get("id") !== categoryId) {
          const category = categoryId && Discourse.Category.findById(categoryId);
          if (!category || category.get("parentCategory.id") !== filterCategory.get('id')) {
            return;
          }
        }
        ...
      }
in topic_tracking_state.js.es6

Therefor, without this change, the check for whether the archetype is a private_message will always be false, because the archetype would be undefined.