### PR TITLE
FEATURE: Installed Version link shows GitHub Compare to branch being followed

### DIFF
--- a/app/assets/javascripts/admin/models/version-check.js.es6
+++ b/app/assets/javascripts/admin/models/version-check.js.es6
@@ -24,8 +24,11 @@ const VersionCheck = Discourse.Model.extend({
   }.property('missing_versions_count'),
 
   gitLink: function() {
+    const git_branch = this.get('git_branch');
+    if (git_branch)
+      return "https://github.com/discourse/discourse/compare/" + this.get('installed_sha') + "..." + git_branch;
     return "https://github.com/discourse/discourse/tree/" + this.get('installed_sha');
-  }.property('installed_sha'),
+  }.property('installed_sha', 'git_branch'),
 
   shortSha: function() {
     return this.get('installed_sha').substr(0,10);

--- a/app/models/discourse_version_check.rb
+++ b/app/models/discourse_version_check.rb
@@ -1,5 +1,5 @@
 class DiscourseVersionCheck
   include ActiveModel::Model
 
-  attr_accessor :latest_version, :critical_updates, :installed_version, :installed_sha, :installed_describe, :missing_versions_count, :updated_at, :version_check_pending
+  attr_accessor :latest_version, :critical_updates, :installed_version, :installed_sha, :installed_describe, :missing_versions_count, :git_branch, :updated_at, :version_check_pending
 end

--- a/lib/discourse_updates.rb
+++ b/lib/discourse_updates.rb
@@ -8,6 +8,7 @@ module DiscourseUpdates
           installed_version: Discourse::VERSION::STRING,
           installed_sha: (Discourse.git_version == 'unknown' ? nil : Discourse.git_version),
           installed_describe: `git describe --dirty`,
+          git_branch: Discourse.git_branch,
           updated_at: nil
         )
       else
@@ -18,6 +19,7 @@ module DiscourseUpdates
           installed_sha: (Discourse.git_version == 'unknown' ? nil : Discourse.git_version),
           installed_describe: `git describe --dirty`,
           missing_versions_count: missing_versions_count,
+          git_branch: Discourse.git_branch,
           updated_at: updated_at
         )
       end


### PR DESCRIPTION
I'm falling back to the old URL in the event that git_branch is undefined

Relevant Discussion
https://meta.discourse.org/t/docker-upgrade-links-point-only-to-the-repo-not-the-displayed-commit/20016/16