### PR TITLE
FEATURE: Allow keyboard shortcuts for topic list to start from last viewed topic

### DIFF
--- a/app/assets/javascripts/discourse/components/topic-list-item.js.es6
+++ b/app/assets/javascripts/discourse/components/topic-list-item.js.es6
@@ -113,11 +113,12 @@ export default Ember.Component.extend(StringBuffer, {
     }
   },
 
-  highlight() {
+  highlight(isLastViewedTopic = false) {
     const $topic = this.$();
     const originalCol = $topic.css('backgroundColor');
     $topic
       .addClass('highlighted')
+      .attr('data-islastviewedtopic', isLastViewedTopic)
       .stop()
       .animate({ backgroundColor: originalCol }, 2500, 'swing', function() {
         $topic.removeClass('highlighted');
@@ -128,7 +129,7 @@ export default Ember.Component.extend(StringBuffer, {
     // highlight the last topic viewed
     if (this.session.get('lastTopicIdViewed') === this.get('topic.id')) {
       this.session.set('lastTopicIdViewed', null);
-      this.highlight();
+      this.highlight(true);
     } else if (this.get('topic.highlight')) {
       // highlight new topics that have been loaded from the server or the one we just created
       this.set('topic.highlight', false);

--- a/app/assets/javascripts/discourse/components/topic-list-item.js.es6
+++ b/app/assets/javascripts/discourse/components/topic-list-item.js.es6
@@ -113,12 +113,12 @@ export default Ember.Component.extend(StringBuffer, {
     }
   },
 
-  highlight(isLastViewedTopic = false) {
+  highlight(opts = { isLastViewedTopic: false }) {
     const $topic = this.$();
     const originalCol = $topic.css('backgroundColor');
     $topic
       .addClass('highlighted')
-      .attr('data-islastviewedtopic', isLastViewedTopic)
+      .attr('data-islastviewedtopic', opts.isLastViewedTopic)
       .stop()
       .animate({ backgroundColor: originalCol }, 2500, 'swing', function() {
         $topic.removeClass('highlighted');
@@ -129,7 +129,7 @@ export default Ember.Component.extend(StringBuffer, {
     // highlight the last topic viewed
     if (this.session.get('lastTopicIdViewed') === this.get('topic.id')) {
       this.session.set('lastTopicIdViewed', null);
-      this.highlight(true);
+      this.highlight({ isLastViewedTopic: true });
     } else if (this.get('topic.highlight')) {
       // highlight new topics that have been loaded from the server or the one we just created
       this.set('topic.highlight', false);

--- a/app/assets/javascripts/discourse/lib/keyboard-shortcuts.js.es6
+++ b/app/assets/javascripts/discourse/lib/keyboard-shortcuts.js.es6
@@ -277,7 +277,9 @@ export default {
       return;
     }
 
-    const $selected = $articles.filter('.selected');
+    const $selected = ($articles.filter('.selected').length !== 0)
+      ? $articles.filter('.selected')
+      : $articles.filter('[data-islastviewedtopic=true]');
     let index = $articles.index($selected);
 
     if ($selected.length !== 0) { //boundries check


### PR DESCRIPTION
Relevant Discussion
https://meta.discourse.org/t/keyboard-navigation-shortcuts-dont-remember-topic-list-position-on-return/48138?u=cpradio