### PR TITLE
Failover messages really aren't warnings

### DIFF
--- a/lib/discourse_redis.rb
+++ b/lib/discourse_redis.rb
@@ -28,10 +28,10 @@ class DiscourseRedis
     def initiate_fallback_to_master
       begin
         slave_client = ::Redis::Client.new(@slave_config)
-        logger.warn "#{log_prefix}: Checking connection to master server..."
+        logger.info "#{log_prefix}: Checking connection to master server..."
 
         if slave_client.call([:info]).split("\r\n").include?(MASTER_LINK_STATUS)
-          logger.warn "#{log_prefix}: Master server is active, killing all connections to slave..."
+          logger.info "#{log_prefix}: Master server is active, killing all connections to slave..."
 
           CONNECTION_TYPES.each do |connection_type|
             slave_client.call([:client, [:kill, 'type', connection_type]])


### PR DESCRIPTION
"I'm going to do something entirely sane and reasonable" doesn't warrant a
warning-level log message.  It's perfectly fine and reasonable to just log
that sort of thing at info level.