### PR TITLE
Change flatten and reverse.each

### DIFF
--- a/app/services/badge_granter.rb
+++ b/app/services/badge_granter.rb
@@ -131,8 +131,8 @@ class BadgeGranter
     items = items.group_by{|i| i["type"]}
 
     items.each do |type, list|
-      post_ids = list.map{|i| i["post_ids"]}.flatten.compact.uniq
-      user_ids = list.map{|i| i["user_ids"]}.flatten.compact.uniq
+      post_ids = list.flat_map(&:i["post_ids"]).compact.uniq
+      user_ids = list.flat_map(&:i["user_ids"]).compact.uniq
 
       next unless post_ids.present? || user_ids.present?
       find_by_type(type).each{ |badge|

--- a/script/import_scripts/muut.rb
+++ b/script/import_scripts/muut.rb
@@ -122,7 +122,7 @@ class ImportScripts::Muut < ImportScripts::Base
 
         # create replies
         if thread["replies"].present? && thread["replies"].count > 0
-          thread["replies"].reverse.each do |post|
+          thread["replies"].reverse_each do |post|
 
             if post_id_from_imported_post_id(post["id"])
               next # already imported this post


### PR DESCRIPTION
Change on flat_map with flatten because flat_map better  is no need to
create an intermediate array.
Change on reverse_each because reverse_each loops in reverse order (no
intermediate array created).
These changes should have a positive impact on performance.
Please review.