### PR TITLE
FIX: Disable pasting hack for Firefox 50+

### DIFF
--- a/app/assets/javascripts/discourse/components/composer-editor.js.es6
+++ b/app/assets/javascripts/discourse/components/composer-editor.js.es6
@@ -296,7 +296,13 @@ export default Ember.Component.extend({
   // Believe it or not pasting an image in Firefox doesn't work without this code
   _firefoxPastingHack() {
     const uaMatch = navigator.userAgent.match(/Firefox\/(\d+)\.\d/);
-    if (uaMatch && parseInt(uaMatch[1]) >= 24) {
+    if (uaMatch) {
+      let uaVersion = parseInt(uaMatch[1]);
+      if (uaVersion < 24 || 50 <= uaVersion) {
+        // The hack is no longer required in FF 50 and later.
+        // See: https://bugzilla.mozilla.org/show_bug.cgi?id=906420
+        return;
+      }
       this.$().append( Ember.$("<div id='contenteditable' contenteditable='true' style='height: 0; width: 0; overflow: hidden'></div>") );
       this.$("textarea").off('keydown.contenteditable');
       this.$("textarea").on('keydown.contenteditable', event => {


### PR DESCRIPTION
**Background**:
There has been an image pasting hack in Discourse to allow pasting images in Firefox which did not implement the Clipboard API so far. As mentioned on [Meta](https://meta.discourse.org/t/firefox-50-makes-image-pasting-hack-superfluous/48017/3), FF 50 and later now [implement this](https://bugzilla.mozilla.org/show_bug.cgi?id=906420) though.

**Impact**:
This change in Firefox renders the workaround obsolete and more precisely requires it to be disabled for these versions. Otherwise pasted images are uploaded and inserted twice (*).

**Solution**:
Extend the existing version constraint to only enable the workaround in FF versions prior to 50.

(*) Note: There is currently still a bug in the FF 50 Clipboard API implementation which causes pasted images to be uploaded twice (one PNG and one JPEG) or three times respectively (with the pasting hack enabled), but [a fix for this is on the way](https://bugzilla.mozilla.org/show_bug.cgi?id=1290688) and disabling the pasting hack is necessary in either case.