### PR TITLE
FIX: Revised post not updated correctly when merging posts.

### DIFF
--- a/lib/post_merger.rb
+++ b/lib/post_merger.rb
@@ -27,9 +27,9 @@ class PostMerger
       edit_reason: I18n.t("merge_posts.edit_reason", count: posts.length, username: @user.username)
     }
 
-    Post.transaction do
-      revisor = PostRevisor.new(post, post.topic)
-      revisor.revise!(@user, changes, {})
+    revisor = PostRevisor.new(post, post.topic)
+
+    revisor.revise!(@user, changes) do
       posts.each { |p| PostDestroyer.new(@user, p).destroy }
     end
   end

--- a/lib/post_revisor.rb
+++ b/lib/post_revisor.rb
@@ -137,6 +137,7 @@ class PostRevisor
     Post.transaction do
       revise_post
 
+      yield if block_given?
       # TODO: these callbacks are being called in a transaction
       # it is kind of odd, because the callback is called "before_edit"
       # but the post is already edited at this point

--- a/spec/components/post_merger_spec.rb
+++ b/spec/components/post_merger_spec.rb
@@ -15,7 +15,11 @@ describe PostMerger do
       reply3 = create_post(topic: topic, raw: 'The third reply', post_number: 4, user: user)
       replies = [reply3, reply2, reply1]
 
-      PostMerger.new(admin, replies).merge
+      message = MessageBus.track_publish { PostMerger.new(admin, replies).merge }.last
+
+      expect(message.channel).to eq("/topic/#{topic.id}")
+      expect(message.data[:type]).to eq(:revised)
+      expect(message.data[:post_number]).to eq(reply3.post_number)
 
       expect(reply1.trashed?).to eq(true)
       expect(reply2.trashed?).to eq(true)


### PR DESCRIPTION
Calling `PostRevisor` in a transaction results in the old record being fetched by the client when it is notify of changes as the transaction has not been completed.