### PR TITLE
FIX: Permit Timeline Topic Status to receive dispatch events to handle keyboard shortcuts when the topic footer is not loaded

### DIFF
--- a/app/assets/javascripts/discourse/components/topic-timeline.js.es6
+++ b/app/assets/javascripts/discourse/components/topic-timeline.js.es6
@@ -55,5 +55,6 @@ export default MountWidget.extend(Docking, {
   didInsertElement() {
     this._super();
     this.dispatch('topic:current-post-scrolled', 'timeline-scrollarea');
+    this.dispatch('topic-notifications-button:keyboard-trigger', 'topic-notifications-button');
   }
 });


### PR DESCRIPTION
relevant discussion
https://meta.discourse.org/t/keyboard-shortcuts-for-tracking-topics-not-working/48489