### PR TITLE
FEATURE: Tags intersection page

### DIFF
--- a/app/assets/javascripts/discourse/controllers/tags-show.js.es6
+++ b/app/assets/javascripts/discourse/controllers/tags-show.js.es6
@@ -43,7 +43,7 @@ export default Ember.Controller.extend(BulkTopicSelection, {
   needs: ["application"],
 
   tag: null,
-  secondaryTag: null,
+  additionalTags: null,
   list: null,
   canAdminTag: Ember.computed.alias("currentUser.staff"),
   filterMode: null,
@@ -73,8 +73,8 @@ export default Ember.Controller.extend(BulkTopicSelection, {
   }.property(),
 
   showAdminControls: function() {
-    return !this.get('secondaryTag') && this.get('canAdminTag') && !this.get('category');
-  }.property('secondaryTag', 'canAdminTag', 'category'),
+    return this.get('additionalTags') && this.get('canAdminTag') && !this.get('category');
+  }.property('additionalTags', 'canAdminTag', 'category'),
 
   loadMoreTopics() {
     return this.get("list").loadMore();

--- a/app/assets/javascripts/discourse/controllers/tags-show.js.es6
+++ b/app/assets/javascripts/discourse/controllers/tags-show.js.es6
@@ -74,7 +74,7 @@ export default Ember.Controller.extend(BulkTopicSelection, {
 
   showAdminControls: function() {
     return !this.get('secondaryTag') && this.get('canAdminTag') && !this.get('category');
-  }.property('canAdminTag', 'category'),
+  }.property('secondaryTag', 'canAdminTag', 'category'),
 
   loadMoreTopics() {
     return this.get("list").loadMore();

--- a/app/assets/javascripts/discourse/controllers/tags-show.js.es6
+++ b/app/assets/javascripts/discourse/controllers/tags-show.js.es6
@@ -43,6 +43,7 @@ export default Ember.Controller.extend(BulkTopicSelection, {
   needs: ["application"],
 
   tag: null,
+  secondaryTag: null,
   list: null,
   canAdminTag: Ember.computed.alias("currentUser.staff"),
   filterMode: null,
@@ -72,7 +73,7 @@ export default Ember.Controller.extend(BulkTopicSelection, {
   }.property(),
 
   showAdminControls: function() {
-    return this.get('canAdminTag') && !this.get('category');
+    return !this.get('secondaryTag') && this.get('canAdminTag') && !this.get('category');
   }.property('canAdminTag', 'category'),
 
   loadMoreTopics() {

--- a/app/assets/javascripts/discourse/routes/app-route-map.js.es6
+++ b/app/assets/javascripts/discourse/routes/app-route-map.js.es6
@@ -132,6 +132,7 @@ export default function() {
       this.route('showCategory' + filter.capitalize(), {path: '/c/:category/:tag_id/l/' + filter});
       this.route('showParentCategory' + filter.capitalize(), {path: '/c/:parent_category/:category/:tag_id/l/' + filter});
     });
+    this.route('show', {path: 'intersection/:tag_id/:secondary_tag_id'});
   });
 
   this.resource('tagGroups', {path: '/tag_groups'}, function() {

--- a/app/assets/javascripts/discourse/routes/app-route-map.js.es6
+++ b/app/assets/javascripts/discourse/routes/app-route-map.js.es6
@@ -132,7 +132,7 @@ export default function() {
       this.route('showCategory' + filter.capitalize(), {path: '/c/:category/:tag_id/l/' + filter});
       this.route('showParentCategory' + filter.capitalize(), {path: '/c/:parent_category/:category/:tag_id/l/' + filter});
     });
-    this.route('show', {path: 'intersection/:tag_id/:secondary_tag_id'});
+    this.route('show', {path: 'intersection/:tag_id/*additional_tags'});
   });
 
   this.resource('tagGroups', {path: '/tag_groups'}, function() {

--- a/app/assets/javascripts/discourse/routes/tags-show.js.es6
+++ b/app/assets/javascripts/discourse/routes/tags-show.js.es6
@@ -12,11 +12,10 @@ export default Discourse.Route.extend({
 
   model(params) {
     var tag = this.store.createRecord("tag", { id: Handlebars.Utils.escapeExpression(params.tag_id) }),
-        secondaryTag = null,
         f = '';
 
     if (params.secondary_tag_id) {
-      this.set("secondaryTag", this.store.createRecord("tag", { id: Handlebars.Utils.escapeExpression(params.secondary_tag_id) }))
+      this.set("secondaryTag", this.store.createRecord("tag", { id: Handlebars.Utils.escapeExpression(params.secondary_tag_id) }));
     }
 
     if (params.category) {
@@ -51,7 +50,7 @@ export default Discourse.Route.extend({
     const parentCategorySlug = this.get('parentCategorySlug');
     const filter = this.get('navMode');
     const tag_id = (tag ? tag.id : 'none');
-    const secondary_tag_id = this.get('secondaryTag.id')
+    const secondary_tag_id = this.get('secondaryTag.id');
 
     if (categorySlug) {
       var category = Discourse.Category.findBySlug(categorySlug, parentCategorySlug);

--- a/app/assets/javascripts/discourse/routes/tags-show.js.es6
+++ b/app/assets/javascripts/discourse/routes/tags-show.js.es6
@@ -15,8 +15,8 @@ export default Discourse.Route.extend({
         f = '';
 
     if (params.additional_tags) {
-      this.set("additionalTags", params.additional_tags.split('/').map((tag) => {
-        return this.store.createRecord("tag", { id: Handlebars.Utils.escapeExpression(tag) }).id;
+      this.set("additionalTags", params.additional_tags.split('/').map((t) => {
+        return this.store.createRecord("tag", { id: Handlebars.Utils.escapeExpression(t) }).id;
       }));
     }
 

--- a/app/assets/javascripts/discourse/routes/tags-show.js.es6
+++ b/app/assets/javascripts/discourse/routes/tags-show.js.es6
@@ -15,10 +15,9 @@ export default Discourse.Route.extend({
         f = '';
 
     if (params.additional_tags) {
-      this.set("additionalTags", _.compact(params.additional_tags.split('/')).map((tag) => {
-        return this.store.createRecord("tag", { id: Handlebars.Utils.escapeExpression(tag) });
+      this.set("additionalTags", params.additional_tags.split('/').map((tag) => {
+        return this.store.createRecord("tag", { id: Handlebars.Utils.escapeExpression(tag) }).id;
       }));
-      this.set("additionalTagIds", _.pluck(this.get("additionalTags"), 'id'));
     }
 
     if (params.category) {
@@ -63,8 +62,8 @@ export default Discourse.Route.extend({
       }
 
       this.set('category', category);
-    } else if (_.any(this.get("additionalTags"))) {
-      params.filter = `tags/intersection/${tag_id}/${this.get('additionalTagIds').join('/')}`;
+    } else if (this.get("additionalTags")) {
+      params.filter = `tags/intersection/${tag_id}/${this.get('additionalTags').join('/')}`;
       this.set('category', null);
     } else {
       params.filter = `tags/${tag_id}/l/${filter}`;
@@ -134,7 +133,7 @@ export default Discourse.Route.extend({
         // Pre-fill the tags input field
         if (controller.get('model.id')) {
           var c = self.controllerFor('composer').get('model');
-          c.set('tags', _.flatten([controller.get('model.id')], controller.get('additionalTagIds')));
+          c.set('tags', _.flatten([controller.get('model.id')], controller.get('additionalTags')));
         }
       });
     },

--- a/app/assets/javascripts/discourse/routes/tags-show.js.es6
+++ b/app/assets/javascripts/discourse/routes/tags-show.js.es6
@@ -14,6 +14,8 @@ export default Discourse.Route.extend({
     var tag = this.store.createRecord("tag", { id: Handlebars.Utils.escapeExpression(params.tag_id) }),
         f = '';
 
+    this.set("secondaryTagId", params.secondary_tag_id)
+
     if (params.category) {
       f = 'c/';
       if (params.parent_category) { f += params.parent_category + '/'; }
@@ -43,6 +45,7 @@ export default Discourse.Route.extend({
     const params = controller.getProperties('order', 'ascending');
 
     const categorySlug = this.get('categorySlug');
+    const secondaryTagId = this.get('secondaryTagId')
     const parentCategorySlug = this.get('parentCategorySlug');
     const filter = this.get('navMode');
     const tag_id = (tag ? tag.id : 'none');
@@ -56,6 +59,9 @@ export default Discourse.Route.extend({
       }
 
       this.set('category', category);
+    } else if (secondaryTagId) {
+      params.filter = `tags/intersection/${tag_id}/${secondaryTagId}`;
+      this.set('category', null);
     } else {
       params.filter = `tags/${tag_id}/l/${filter}`;
       this.set('category', null);

--- a/app/assets/javascripts/discourse/routes/tags-show.js.es6
+++ b/app/assets/javascripts/discourse/routes/tags-show.js.es6
@@ -12,9 +12,12 @@ export default Discourse.Route.extend({
 
   model(params) {
     var tag = this.store.createRecord("tag", { id: Handlebars.Utils.escapeExpression(params.tag_id) }),
+        secondaryTag = null,
         f = '';
 
-    this.set("secondaryTagId", params.secondary_tag_id)
+    if (params.secondary_tag_id) {
+      this.set("secondaryTag", this.store.createRecord("tag", { id: Handlebars.Utils.escapeExpression(params.secondary_tag_id) }))
+    }
 
     if (params.category) {
       f = 'c/';
@@ -45,10 +48,10 @@ export default Discourse.Route.extend({
     const params = controller.getProperties('order', 'ascending');
 
     const categorySlug = this.get('categorySlug');
-    const secondaryTagId = this.get('secondaryTagId')
     const parentCategorySlug = this.get('parentCategorySlug');
     const filter = this.get('navMode');
     const tag_id = (tag ? tag.id : 'none');
+    const secondary_tag_id = this.get('secondaryTag.id')
 
     if (categorySlug) {
       var category = Discourse.Category.findBySlug(categorySlug, parentCategorySlug);
@@ -59,8 +62,8 @@ export default Discourse.Route.extend({
       }
 
       this.set('category', category);
-    } else if (secondaryTagId) {
-      params.filter = `tags/intersection/${tag_id}/${secondaryTagId}`;
+    } else if (secondary_tag_id) {
+      params.filter = `tags/intersection/${tag_id}/${secondary_tag_id}`;
       this.set('category', null);
     } else {
       params.filter = `tags/${tag_id}/l/${filter}`;
@@ -100,6 +103,7 @@ export default Discourse.Route.extend({
     this.controllerFor('tags.show').setProperties({
       model,
       tag: model,
+      secondaryTag: this.get('secondaryTag'),
       category: this.get('category'),
       filterMode: this.get('filterMode'),
       navMode: this.get('navMode'),
@@ -129,7 +133,7 @@ export default Discourse.Route.extend({
         // Pre-fill the tags input field
         if (controller.get('model.id')) {
           var c = self.controllerFor('composer').get('model');
-          c.set('tags', [controller.get('model.id')]);
+          c.set('tags', _.compact([controller.get('model.id'), controller.get('secondaryTag.id')]));
         }
       });
     },

--- a/app/assets/javascripts/discourse/templates/tags/show.hbs
+++ b/app/assets/javascripts/discourse/templates/tags/show.hbs
@@ -34,7 +34,7 @@
         {{fa-icon "angle-right"}}
         {{discourse-tag-bound tagRecord=tag style="simple"}}
         {{#if secondaryTag}}
-          <span>&</span>
+          <span>&amp;</span>
           {{discourse-tag-bound tagRecord=secondaryTag style="simple"}}
         {{/if}}
       </h2>

--- a/app/assets/javascripts/discourse/templates/tags/show.hbs
+++ b/app/assets/javascripts/discourse/templates/tags/show.hbs
@@ -5,8 +5,10 @@
 <div class="list-controls">
   <div class="container">
     {{#if tagNotification}}
-      {{tag-notifications-button action="changeTagNotification"
-                                 notificationLevel=tagNotification.notification_level}}
+      {{#unless secondaryTag}}
+        {{tag-notifications-button action="changeTagNotification"
+                                   notificationLevel=tagNotification.notification_level}}
+      {{/unless}}
     {{/if}}
 
     {{#if showAdminControls}}
@@ -31,6 +33,10 @@
         {{#link-to 'tags'}}{{i18n "tagging.tags"}}{{/link-to}}
         {{fa-icon "angle-right"}}
         {{discourse-tag-bound tagRecord=tag style="simple"}}
+        {{#if secondaryTag}}
+          <span>&</span>
+          {{discourse-tag-bound tagRecord=secondaryTag style="simple"}}
+        {{/if}}
       </h2>
     {{/if}}
   </div>

--- a/app/assets/javascripts/discourse/templates/tags/show.hbs
+++ b/app/assets/javascripts/discourse/templates/tags/show.hbs
@@ -5,7 +5,7 @@
 <div class="list-controls">
   <div class="container">
     {{#if tagNotification}}
-      {{#unless secondaryTag}}
+      {{#unless additionalTags}}
         {{tag-notifications-button action="changeTagNotification"
                                    notificationLevel=tagNotification.notification_level}}
       {{/unless}}
@@ -33,10 +33,10 @@
         {{#link-to 'tags'}}{{i18n "tagging.tags"}}{{/link-to}}
         {{fa-icon "angle-right"}}
         {{discourse-tag-bound tagRecord=tag style="simple"}}
-        {{#if secondaryTag}}
+        {{#each additionalTags as |tag|}}
           <span>&amp;</span>
-          {{discourse-tag-bound tagRecord=secondaryTag style="simple"}}
-        {{/if}}
+          {{discourse-tag-bound tagRecord=tag style="simple"}}
+        {{/each}}
       </h2>
     {{/if}}
   </div>

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -44,6 +44,7 @@ class TagsController < ::ApplicationController
   Discourse.filters.each do |filter|
     define_method("show_#{filter}") do
       @tag_id = DiscourseTagging.clean_tag(params[:tag_id])
+      @secondary_tag_id = DiscourseTagging.clean_tag(params[:secondary_tag_id]) if params[:secondary_tag_id]
 
       page = params[:page].to_i
       list_opts = build_topic_list_options
@@ -71,7 +72,7 @@ class TagsController < ::ApplicationController
       @list.more_topics_url = construct_url_with(:next, list_opts)
       @list.prev_topics_url = construct_url_with(:prev, list_opts)
       @rss = "tag"
-      @description_meta = I18n.t("rss_by_tag", tag: @tag_id)
+      @description_meta = I18n.t("rss_by_tag", tag: [@tag_id, @secondary_tag_id].compact.join(' & '))
       @title = @description_meta
 
       canonical_url "#{Discourse.base_url_no_prefix}#{public_send(url_method(params.slice(:category, :parent_category)))}"
@@ -297,7 +298,8 @@ class TagsController < ::ApplicationController
       if params[:tag_id] == 'none'
         options[:no_tags] = true
       else
-        options[:tags] = [params[:tag_id]]
+        options[:tags] = [params[:tag_id], params[:secondary_tag_id]].compact
+        options[:match_all_tags] = true
       end
 
       options

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -44,7 +44,7 @@ class TagsController < ::ApplicationController
   Discourse.filters.each do |filter|
     define_method("show_#{filter}") do
       @tag_id = DiscourseTagging.clean_tag(params[:tag_id])
-      @secondary_tag_id = DiscourseTagging.clean_tag(params[:secondary_tag_id]) if params[:secondary_tag_id]
+      @additional_tags = params[:additional_tag_ids].to_s.split('/').map { |tag| DiscourseTagging.clean_tag(tag) }
 
       page = params[:page].to_i
       list_opts = build_topic_list_options
@@ -72,7 +72,7 @@ class TagsController < ::ApplicationController
       @list.more_topics_url = construct_url_with(:next, list_opts)
       @list.prev_topics_url = construct_url_with(:prev, list_opts)
       @rss = "tag"
-      @description_meta = I18n.t("rss_by_tag", tag: [@tag_id, @secondary_tag_id].compact.join(' & '))
+      @description_meta = I18n.t("rss_by_tag", tag: tag_params.join(' & '))
       @title = @description_meta
 
       canonical_url "#{Discourse.base_url_no_prefix}#{public_send(url_method(params.slice(:category, :parent_category)))}"
@@ -298,7 +298,7 @@ class TagsController < ::ApplicationController
       if params[:tag_id] == 'none'
         options[:no_tags] = true
       else
-        options[:tags] = [params[:tag_id], params[:secondary_tag_id]].compact
+        options[:tags] = tag_params
         options[:match_all_tags] = true
       end
 
@@ -316,5 +316,9 @@ class TagsController < ::ApplicationController
         # redirect to 404
         raise Discourse::NotFound
       end
+    end
+
+    def tag_params
+      [@tag_id].concat(Array(@additional_tags))
     end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -630,6 +630,7 @@ Discourse::Application.routes.draw do
       get '/:tag_id' => 'tags#show', as: 'tag_show'
       get '/c/:category/:tag_id' => 'tags#show', as: 'tag_category_show'
       get '/c/:parent_category/:category/:tag_id' => 'tags#show', as: 'tag_parent_category_category_show'
+      get '/intersection/:tag_id/:secondary_tag_id' => 'tags#show', as: 'tag_intersection'
       get '/:tag_id/notifications' => 'tags#notifications'
       put '/:tag_id/notifications' => 'tags#update_notifications'
       put '/:tag_id' => 'tags#update'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -630,7 +630,7 @@ Discourse::Application.routes.draw do
       get '/:tag_id' => 'tags#show', as: 'tag_show'
       get '/c/:category/:tag_id' => 'tags#show', as: 'tag_category_show'
       get '/c/:parent_category/:category/:tag_id' => 'tags#show', as: 'tag_parent_category_category_show'
-      get '/intersection/:tag_id/:secondary_tag_id' => 'tags#show', as: 'tag_intersection'
+      get '/intersection/:tag_id/*additional_tag_ids' => 'tags#show', as: 'tag_intersection'
       get '/:tag_id/notifications' => 'tags#notifications'
       put '/:tag_id/notifications' => 'tags#update_notifications'
       put '/:tag_id' => 'tags#update'

--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -464,10 +464,16 @@ class TopicQuery
 
           if @options[:match_all_tags]
             # ALL of the given tags:
+            tags_count = @options[:tags].length
             @options[:tags] = Tag.where(name: @options[:tags]).pluck(:id) unless @options[:tags][0].is_a?(Integer)
-            @options[:tags].each_with_index do |tag, index|
-              sql_alias = ['t', index].join
-              result = result.joins("INNER JOIN topic_tags #{sql_alias} ON #{sql_alias}.topic_id = topics.id AND #{sql_alias}.tag_id = #{tag}")
+
+            if tags_count == @options[:tags].length
+              @options[:tags].each_with_index do |tag, index|
+                sql_alias = ['t', index].join
+                result = result.joins("INNER JOIN topic_tags #{sql_alias} ON #{sql_alias}.topic_id = topics.id AND #{sql_alias}.tag_id = #{tag}")
+              end
+            else
+              result = result.none # don't return any results unless all tags exist in the database
             end
           else
             # ANY of the given tags:

--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -20,6 +20,7 @@ class TopicQuery
                      visible
                      category
                      tags
+                     match_all_tags
                      no_tags
                      order
                      ascending
@@ -460,11 +461,21 @@ class TopicQuery
 
         if @options[:tags] && @options[:tags].size > 0
           result = result.joins(:tags)
-          # ANY of the given tags:
-          if @options[:tags][0].is_a?(Integer)
-            result = result.where("tags.id in (?)", @options[:tags])
+
+          # ALL of the given tags:
+          if @options[:match_all_tags]
+            @options[:tags] = Tag.where(name: @options[:tags]).pluck(:id) unless @options[:tags][0].is_a?(Integer)
+            @options[:tags].each_with_index do |tag, index|
+              sql_alias = ['t', index].join
+              result = result.joins("INNER JOIN topic_tags #{sql_alias} ON #{sql_alias}.topic_id = topics.id AND #{sql_alias}.tag_id = #{tag}")
+            end
           else
-            result = result.where("tags.name in (?)", @options[:tags])
+            # ANY of the given tags:
+            if @options[:tags][0].is_a?(Integer)
+              result = result.where("tags.id in (?)", @options[:tags])
+            else
+              result = result.where("tags.name in (?)", @options[:tags])
+            end
           end
         elsif @options[:no_tags]
           # the following will do: ("topics"."id" NOT IN (SELECT DISTINCT "topic_tags"."topic_id" FROM "topic_tags"))

--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -462,8 +462,8 @@ class TopicQuery
         if @options[:tags] && @options[:tags].size > 0
           result = result.joins(:tags)
 
-          # ALL of the given tags:
           if @options[:match_all_tags]
+            # ALL of the given tags:
             @options[:tags] = Tag.where(name: @options[:tags]).pluck(:id) unless @options[:tags][0].is_a?(Integer)
             @options[:tags].each_with_index do |tag, index|
               sql_alias = ['t', index].join

--- a/spec/components/topic_query_spec.rb
+++ b/spec/components/topic_query_spec.rb
@@ -145,6 +145,10 @@ describe TopicQuery do
         # expect(TopicQuery.new(moderator, tags: [tag.id, other_tag.id]).list_latest.topics.map(&:id)).to eq([tagged_topic3.id].sort)
       end
 
+      it "can return topics with all specified tags" do
+        expect(TopicQuery.new(moderator, tags: [tag.name, other_tag.name], match_all_tags: true).list_latest.topics.map(&:id)).to eq([tagged_topic3.id])
+      end
+
       it "can return topics with no tags" do
         expect(TopicQuery.new(moderator, no_tags: true).list_latest.topics.map(&:id)).to eq([no_tags_topic.id])
       end

--- a/spec/components/topic_query_spec.rb
+++ b/spec/components/topic_query_spec.rb
@@ -149,6 +149,10 @@ describe TopicQuery do
         expect(TopicQuery.new(moderator, tags: [tag.name, other_tag.name], match_all_tags: true).list_latest.topics.map(&:id)).to eq([tagged_topic3.id])
       end
 
+      it "returns an empty relation when an invalid tag is passed" do
+        expect(TopicQuery.new(moderator, tags: [tag.name, 'notatag'], match_all_tags: true).list_latest.topics).to be_empty
+      end
+
       it "can return topics with no tags" do
         expect(TopicQuery.new(moderator, no_tags: true).list_latest.topics.map(&:id)).to eq([no_tags_topic.id])
       end

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -3,8 +3,12 @@ require 'rails_helper'
 describe TagsController do
   describe 'show_latest' do
     let(:tag)         { Fabricate(:tag) }
+    let(:other_tag)   { Fabricate(:tag) }
     let(:category)    { Fabricate(:category) }
     let(:subcategory) { Fabricate(:category, parent_category_id: category.id) }
+
+    let(:single_tag_topic) { Fabricate(:topic, tags: [tag]) }
+    let(:multi_tag_topic)  { Fabricate(:topic, tags: [tag, other_tag]) }
 
     context 'tagging disabled' do
       it "returns 404" do
@@ -21,6 +25,14 @@ describe TagsController do
       it "can filter by tag" do
         xhr :get, :show_latest, tag_id: tag.name
         expect(response).to be_success
+      end
+
+      it "can filter by multiple tags" do
+        single_tag_topic; multi_tag_topic
+        xhr :get, :show_latest, tag_id: tag.name, secondary_tag_id: other_tag.name
+        expect(response).to be_success
+        expect(assigns(:list).topics).to include multi_tag_topic
+        expect(assigns(:list).topics).to_not include single_tag_topic
       end
 
       it "can filter by category and tag" do


### PR DESCRIPTION
As discussed here:
https://meta.discourse.org/t/tag-intersections-page/47952

*Tags page with single tag (as existed before):*
![screen shot 2016-08-12 at 3 49 41 pm](https://cloud.githubusercontent.com/assets/750477/17635511/cc8a3b66-60a5-11e6-9c82-4d5e3a46a679.png)

*Tags page with intersection (this is new):*
![screen shot 2016-08-12 at 3 49 27 pm](https://cloud.githubusercontent.com/assets/750477/17635498/ba92c8c4-60a5-11e6-9d50-0476f967be76.png)

NB that this exposes a route,
`tags/intersection/:tag_a/:tag_b`, which will allow access to an intersection of tags, but does not present that route in the interface anywhere.