### PR TITLE
FIX: correct regex for username

### DIFF
--- a/plugins/discourse-nginx-performance-report/script/nginx_analyze.rb
+++ b/plugins/discourse-nginx-performance-report/script/nginx_analyze.rb
@@ -49,7 +49,7 @@ class LogAnalyzer
     private
 
     def self.sanitize_url(url)
-      url.gsub(/(api_key|api_username)=(\w+)/, '\1=[FILTERED]')
+      url.gsub(/(api_key|api_username)=([\w.\-]+)/, '\1=[FILTERED]')
     end
   end
 


### PR DESCRIPTION
The username was not correctly detected for non-word chars, so I reuse the regex from:

https://github.com/discourse/discourse/blob/3b792054f2e3e3611ea9c45326aaa8cd604759d0/config/routes.rb#L10