### PR TITLE
FIX: Tags on topic crawler view

### DIFF
--- a/app/helpers/topics_helper.rb
+++ b/app/helpers/topics_helper.rb
@@ -15,7 +15,7 @@ module TopicsHelper
       breadcrumb.push url: category.url, name: category.name
     end
 
-    if (tags = topic.tags).present?
+    if SiteSetting.tagging_enabled && (tags = topic.tags).present?
       tags.each do |tag|
         url = "#{Discourse.base_url}/tags/#{tag.name}"
         breadcrumb << {url: url, name: tag.name}

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -18,16 +18,6 @@
 </div>
 <% end %>
 
-<%- if SiteSetting.tagging_enabled && @topic_view.topic.tags.present? %>
-  <div class='tags'>
-    <%= t 'js.tagging.tags' %>:
-
-    <%- @topic_view.topic.tags.each do |t| %>
-      <%= t %>
-    <%- end %>
-  </div>
-<% end %>
-
 <%= server_plugin_outlet "topic_header" %>
 
 <hr>


### PR DESCRIPTION
- Remove tag object id
- Remove duplicate tag list
- Don't display tags when tagging is disabled