### PR TITLE
Add missing fat arrow in bbcode_to_md method rescue block

### DIFF
--- a/script/import_scripts/phpbb3/support/text_processor.rb
+++ b/script/import_scripts/phpbb3/support/text_processor.rb
@@ -53,7 +53,7 @@ module ImportScripts::PhpBB3
     def bbcode_to_md(text)
       begin
         text.bbcode_to_md(false)
-      rescue e
+      rescue => e
         puts "Problem converting \n#{text}\n using ruby-bbcode-to-md"
         text
       end


### PR DESCRIPTION
Related to https://meta.discourse.org/t/undefined-local-variable-or-method-e-during-phpbb3-migration/48861