### PR TITLE
FIX: Don't join on tags unnecessarily when matching all tags

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -299,7 +299,7 @@ class TagsController < ::ApplicationController
         options[:no_tags] = true
       else
         options[:tags] = tag_params
-        options[:match_all_tags] = true if tag_params.size > 1
+        options[:match_all_tags] = true
       end
 
       options

--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -459,7 +459,6 @@ class TopicQuery
         result = result.preload(:tags)
 
         if @options[:tags] && @options[:tags].size > 0
-          result = result.joins(:tags)
 
           if @options[:match_all_tags]
             # ALL of the given tags:
@@ -476,6 +475,7 @@ class TopicQuery
             end
           else
             # ANY of the given tags:
+            result = result.joins(:tags)
             if @options[:tags][0].is_a?(Integer)
               result = result.where("tags.id in (?)", @options[:tags])
             else


### PR DESCRIPTION
This is... a bit of a weird one.

When we join on tags before doing the sequential join for matching all tags, then this call in `topic_query#311:latest_topics`:

```
result = remove_muted_categories(result, @user, exclude: options[:category])
```

returns 15 results instead of the proper 30.

Here's the SQL for the existing behaviour:
```
SELECT <stuff> FROM "topics"
INNER JOIN "topic_tags" ON "topic_tags"."topic_id" = "topics"."id"
INNER JOIN "tags" ON "tags"."id" = "topic_tags"."tag_id"
LEFT OUTER JOIN "categories" ON "categories"."id" = "topics"."category_id"
LEFT OUTER JOIN topic_users AS tu ON (topics.id = tu.topic_id AND tu.user_id = 1)
INNER JOIN topic_tags t0 ON t0.topic_id = topics.id AND t0.tag_id = 2
INNER JOIN topic_tags t1 ON t1.topic_id = topics.id AND t1.tag_id = 1
WHERE (topics.archetype <> 'private_message') 
  AND (topics.deleted_at IS NULL)
  AND (COALESCE(tu.notification_level,1) > 0)
  AND (
          NOT EXISTS (
            SELECT 1
              FROM category_users cu
             WHERE cu.user_id = 1
               AND cu.category_id = topics.category_id
               AND cu.notification_level = 0
               AND cu.category_id <> -1
               AND (tu.notification_level IS NULL OR tu.notification_level < 2)
        ))
LIMIT 30
```

And for the new (working) behaviour
```
SELECT <stuff> FROM "topics"
LEFT OUTER JOIN "categories" ON "categories"."id" = "topics"."category_id"
LEFT OUTER JOIN topic_users AS tu ON (topics.id = tu.topic_id AND tu.user_id = 1)
INNER JOIN topic_tags t0 ON t0.topic_id = topics.id AND t0.tag_id = 2
INNER JOIN topic_tags t1 ON t1.topic_id = topics.id AND t1.tag_id = 1
WHERE (topics.archetype <> 'private_message') 
  AND (topics.deleted_at IS NULL) AND (COALESCE(tu.notification_level,1) > 0)
  AND (
          NOT EXISTS (
            SELECT 1
              FROM category_users cu
             WHERE cu.user_id = 1
               AND cu.category_id = topics.category_id
               AND cu.notification_level = 0
               AND cu.category_id <> -1
               AND (tu.notification_level IS NULL OR tu.notification_level < 2)
          ))
LIMIT 30
```

The only difference being that double inner join at the beginning. @nlalonde Any idea why this would be the case? 