### PR TITLE
FIX: “Your search term is too short” message when no search term is entered at all

### DIFF
--- a/app/assets/javascripts/discourse/widgets/search-menu.js.es6
+++ b/app/assets/javascripts/discourse/widgets/search-menu.js.es6
@@ -97,14 +97,15 @@ export default createWidget('search-menu', {
     const results = [this.attach('search-term', { value: searchData.term, contextEnabled }),
                      this.attach('search-context', { contextEnabled })];
 
-    if (searchData.term)
-    if (searchData.loading) {
-      results.push(h('div.searching', h('div.spinner')));
-    } else {
-      results.push(this.attach('search-menu-results', { term: searchData.term,
-                                                        noResults: searchData.noResults,
-                                                        results: searchData.results,
-                                                        invalidTerm: searchData.invalidTerm }));
+    if (searchData.term) {
+      if (searchData.loading) {
+        results.push(h('div.searching', h('div.spinner')));
+      } else {
+        results.push(this.attach('search-menu-results', { term: searchData.term,
+                                                          noResults: searchData.noResults,
+                                                          results: searchData.results,
+                                                          invalidTerm: searchData.invalidTerm }));
+      }
     }
 
     return results;

--- a/app/assets/javascripts/discourse/widgets/search-menu.js.es6
+++ b/app/assets/javascripts/discourse/widgets/search-menu.js.es6
@@ -97,6 +97,7 @@ export default createWidget('search-menu', {
     const results = [this.attach('search-term', { value: searchData.term, contextEnabled }),
                      this.attach('search-context', { contextEnabled })];
 
+    if (searchData.term)
     if (searchData.loading) {
       results.push(h('div.searching', h('div.spinner')));
     } else {


### PR DESCRIPTION
PR for https://meta.discourse.org/t/your-search-term-is-too-short-message-when-no-search-term-is-entered-at-all/49070