### PR TITLE
Fix SQLite datetime issues

### DIFF
--- a/script/import_scripts/mbox.rb
+++ b/script/import_scripts/mbox.rb
@@ -100,7 +100,7 @@ class ImportScripts::Mbox < ImportScripts::Base
     db = open_db
     db.execute "UPDATE emails SET reply_to = null WHERE reply_to = ''"
 
-    rows = db.execute "SELECT msg_id, title, reply_to FROM emails ORDER BY email_date ASC"
+    rows = db.execute "SELECT msg_id, title, reply_to FROM emails ORDER BY datetime(email_date) ASC"
 
     msg_ids = {}
     titles = {}
@@ -199,6 +199,7 @@ class ImportScripts::Mbox < ImportScripts::Base
       title = clean_title(mail['Subject'].to_s)
       reply_to = mail['In-Reply-To'].to_s
       email_date = mail['date'].to_s
+      email_date = DateTime.parse(email_date).to_s unless email_date.blank?
 
       db.execute "INSERT OR IGNORE INTO emails (msg_id,
                                                 from_email,


### PR DESCRIPTION
The raw datetime string from raw emails doesn't conform to SQLite standard. Therefore it can't be sorted. This fix will make it conforming and sort-able by SQLite.