### PR TITLE
Add Arabic Pluralization Rules for Client

### DIFF
--- a/app/assets/javascripts/locales/ar.js.erb
+++ b/app/assets/javascripts/locales/ar.js.erb
@@ -1,3 +1,12 @@
 //= depend_on 'client.ar.yml'
 //= require locales/i18n
 <%= JsLocaleHelper.output_locale(:ar) %>
+
+I18n.pluralizationRules['ar'] = function (n) {
+  if (n == 0) return "zero";
+  if (n == 1) return "one";
+  if (n == 2) return "two";
+  if (n%100 >= 3 && n%100 <= 10) return "few";
+  if (n%100 >= 11) return "many";
+  return "other";
+};


### PR DESCRIPTION
The pluralization rules exists for the server, but not for the client.
As a result, Arabic Plural forms wasn't being displayed correctly. This fixes that.