### PR TITLE
Adjust example order to match description

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1826,9 +1826,9 @@ en:
 
         Your reply can be formatted using simple HTML, BBCode, or [Markdown](http://commonmark.org/help/):
 
-            This is **bold**.
             This is <b>bold</b>.
             This is [b]bold[/b].
+            This is **bold**.
 
         For more formatting tips, [try our fun 10 minute interactive tutorial!](http://commonmark.org/help/tutorial/)
 


### PR DESCRIPTION
Sorry for the ridiculousness of this change, just an over-eager eye.

This adjusts the order of the formatting examples in the activation email to match the order they are described in the previous line.

HTML -> BBCode  -> Markdown.