### PR TITLE
check the plugin mobile dir for templates

### DIFF
--- a/app/assets/javascripts/discourse/ember/resolver.js.es6
+++ b/app/assets/javascripts/discourse/ember/resolver.js.es6
@@ -141,8 +141,10 @@ export default Ember.DefaultResolver.extend({
   },
 
   findPluginMobileTemplate(parsedName) {
-    var pluginParsedName = this.parseName(parsedName.fullName.replace("template:", "template:javascripts/mobile/"));
-    return this.findTemplate(pluginParsedName);
+    if (this.mobileView) {
+      var pluginParsedName = this.parseName(parsedName.fullName.replace("template:", "template:javascripts/mobile/"));
+      return this.findTemplate(pluginParsedName);
+    }
   },
 
   findMobileTemplate(parsedName) {

--- a/app/assets/javascripts/discourse/ember/resolver.js.es6
+++ b/app/assets/javascripts/discourse/ember/resolver.js.es6
@@ -116,6 +116,7 @@ export default Ember.DefaultResolver.extend({
 
   resolveTemplate(parsedName) {
     return this.findPluginTemplate(parsedName) ||
+           this.findPluginMobileTemplate(parsedName) ||
            this.findMobileTemplate(parsedName) ||
            this.findTemplate(parsedName) ||
            Ember.TEMPLATES.not_found;
@@ -136,6 +137,11 @@ export default Ember.DefaultResolver.extend({
 
   findPluginTemplate(parsedName) {
     var pluginParsedName = this.parseName(parsedName.fullName.replace("template:", "template:javascripts/"));
+    return this.findTemplate(pluginParsedName);
+  },
+
+  findPluginMobileTemplate(parsedName) {
+    var pluginParsedName = this.parseName(parsedName.fullName.replace("template:", "template:javascripts/mobile/"));
     return this.findTemplate(pluginParsedName);
   },
 


### PR DESCRIPTION
The resolver does not check the mobile template directory in plugins for templates, meaning it is not possible to override mobile templates from a plugin. This adds a check for mobile templates in plugins to the resolver.