### PR TITLE
FIX: properly insert images in markdown inline format

### DIFF
--- a/app/jobs/regular/pull_hotlinked_images.rb
+++ b/app/jobs/regular/pull_hotlinked_images.rb
@@ -63,6 +63,8 @@ module Jobs
               raw.gsub!(/\[!\[([^\]]*)\]\(#{escaped_src}\)\]/) { "[<img src='#{url}' alt='#{$1}'>]" }
               # Markdown inline - ![alt](http://...)
               raw.gsub!(/!\[([^\]]*)\]\(#{escaped_src}\)/) { "![#{$1}](#{url})" }
+              # Markdown inline - ![](http://... "image title")
+              raw.gsub!(/!\[\]\(#{escaped_src} "([^\]]*)"\)/) { "![](#{url})" }
               # Markdown reference - [x]: http://
               raw.gsub!(/\[([^\]]+)\]:\s?#{escaped_src}/) { "[#{$1}]: #{url}" }
               # Direct link


### PR DESCRIPTION
Images are getting downloaded but not replaced for Markdown syntax like:

```
![](https://d2r1vs3d9006ap.cloudfront.net/s3_images/1274993/RackMultipart20150911-10494-17p8i3n-baboons_inline.PNG?1441996106 "Image https//d2r1vs3d9006apcloudfrontnet/s3\_images/1274993/RackMultipart20150911-10494-17p8i3n-baboons\_inlinePNG1441996106")  
```

This image markdown syntax is generated by [reverse_markdown](https://github.com/xijo/reverse_markdown) gem.

This PR fixes the issue.