### PR TITLE
FIX: Make `Jobs::MigrateUploadScheme` a scheduled job.

### DIFF
--- a/app/jobs/onceoff/migrate_upload_scheme.rb
+++ b/app/jobs/onceoff/migrate_upload_scheme.rb
@@ -1,8 +1,10 @@
 module Jobs
 
-  class MigrateUploadScheme < Jobs::Onceoff
+  class MigrateUploadScheme < Jobs::Scheduled
+    every 10.minutes
+    sidekiq_options retry: false
 
-    def execute_onceoff(args)
+    def execute(args)
       return unless SiteSetting.migrate_to_new_scheme
 
       # clean up failed uploads
@@ -11,7 +13,7 @@ module Jobs
             .destroy_all
 
       # migrate uploads to new scheme
-      problems = Upload.migrate_to_new_scheme
+      problems = Upload.migrate_to_new_scheme(50)
       problems.each do |hash|
         upload_id = hash[:upload].id
         Discourse.handle_job_exception(hash[:ex], error_context(args, "Migrating upload id #{upload_id}", upload_id: upload_id))
@@ -23,7 +25,7 @@ module Jobs
       OptimizedImage.where("upload_id NOT IN (SELECT id FROM uploads)").destroy_all
 
       # migrate optimized_images to new scheme
-      problems = OptimizedImage.migrate_to_new_scheme
+      problems = OptimizedImage.migrate_to_new_scheme(50)
       problems.each do |hash|
         optimized_image_id = hash[:optimized_image].id
         Discourse.handle_job_exception(hash[:ex], error_context(args, "Migrating optimized_image id #{optimized_image_id}", optimized_image_id: optimized_image_id))


### PR DESCRIPTION
This reverts https://github.com/discourse/discourse/commit/9d8db11c

If the job fails during execution or if `SiteSetting.migrate_to_new_scheme`
has been set to `false`, the job will be considered as executed even
though the migration has not been completed. As a result, the job
will have to be executed manually which is not desirable.