### PR TITLE
Rubygems upgrade needed for mailcatcher

### DIFF
--- a/docs/VAGRANT.md
+++ b/docs/VAGRANT.md
@@ -147,6 +147,11 @@ Mailcatcher is already installed in the vm, and there's an alias to launch it:
 ```
 mailcatcher --http-ip=0.0.0.0
 ```
+Running the above command might throw out the `'method_missing'` error in the terminal. This can be fixed by upgrading rubygems to the latest version which can be done by running the following in the /vagrant directory:
+
+```
+gem update --system
+```
 
 Then in a browser, go to [http://localhost:4080](http://localhost:4080). Sent emails will be received by mailcatcher and shown in its web ui.
 


### PR DESCRIPTION
Recent version of mailcatcher giving error for the default rubygems version. The proposed solution is as mentioned in this [mailcatcher issue](https://github.com/sj26/mailcatcher/issues/267).

The updated rubygems version was 2.6.6. Although I was able to execute the rails server after the update, as changing the version might possibly have wide spread unwanted consequences, I will leave it for the maintainers to decide whether to accept this pull request or not.