### PR TITLE
OpenSearch improvements, including Firefox bug fix

### DIFF
--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -17,4 +17,4 @@
 <% end %>
 <%= canonical_link_tag %>
 <%= render_sitelinks_search_tag %>
-<link rel="search" type="application/opensearchdescription+xml" href="<%= Discourse.base_url %>/opensearch.xml">
+<link rel="search" type="application/opensearchdescription+xml" href="<%= Discourse.base_url %>/opensearch.xml" title="<%= SiteSetting.title %> Search">

--- a/app/views/metadata/opensearch.xml.erb
+++ b/app/views/metadata/opensearch.xml.erb
@@ -1,12 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
-<ShortName><%= SiteSetting.title %> Search</ShortName>
-<Description>Search for posts on <%= SiteSetting.title %></Description>
-<Tags>discourse forum</Tags>
-<% if SiteSetting.favicon_url =~ /\.ico$/ -%>
+  <ShortName><%= SiteSetting.title %> Search</ShortName>
+  <Description>Search for posts on <%= SiteSetting.title %></Description>
+  <Tags>discourse forum</Tags>
+  <% if SiteSetting.favicon_url =~ /\.ico$/ -%>
   <Image height="16" width="16" type="image/vnd.microsoft.icon"><%= UrlHelper.absolute SiteSetting.favicon_url %></Image>
-<%- else -%>
+  <%- else -%>
   <Image type="image/png"><%= UrlHelper.absolute SiteSetting.favicon_url %></Image>
-<%- end %>
-<Url type="text/html" method="get" template="<%= Discourse.base_url %>/search?q={searchTerms}"/>
-<Query role="example" searchTerms="search term"/>
+  <%- end %>
+  <Url type="text/html" method="get" template="<%= Discourse.base_url %>/search?q={searchTerms}"/>
+  <Query role="example" searchTerms="search term"/>
 </OpenSearchDescription>

--- a/app/views/metadata/opensearch.xml.erb
+++ b/app/views/metadata/opensearch.xml.erb
@@ -8,6 +8,7 @@
   <%- else -%>
   <Image type="image/png"><%= UrlHelper.absolute SiteSetting.favicon_url %></Image>
   <%- end %>
-  <Url type="text/html" method="get" template="<%= Discourse.base_url %>/search?q={searchTerms}"/>
+  <Url type="application/opensearchdescription+xml" rel="self" template="<%= Discourse.base_url %>/opensearch.xml"/>
+  <Url type="text/html" template="<%= Discourse.base_url %>/search?q={searchTerms}"/>
   <Query role="example" searchTerms="search term"/>
 </OpenSearchDescription>


### PR DESCRIPTION
I made changes to Discourse's OpenSearch to use well-formed XML in line with the official [specifications](http://www.opensearch.org/Specifications/OpenSearch/1.1) and fixed the meta tag to include the "title" parameter, which is apparently required by Firefox.

Additionally, I added a line to the OpenSearch file to allow for future updates to the search engine after it's been added to and cached in users' browsers.