### PR TITLE
Improve the "develop inside Docker" experience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ public/plugins/*
 public/tombstone/*
 
 # Ignore bundler config
-/bin
 /.bundle
 /.vagrant
 /.vagrantfile

--- a/bin/docker/README.md
+++ b/bin/docker/README.md
@@ -1,0 +1,39 @@
+# Developing using Docker
+
+Since Discourse runs in Docker, why not develop there?  If you have Docker installed, you should be able to run Discourse directly from your source directory using a Discourse development container.
+
+## Step-by-step
+
+It should be as easy as (from your source root):
+
+```sh
+./bin/docker/boot_dev --init
+    # wait while:
+    #   - dependencies are installed,
+    #   - the database is migrated, and
+    #   - an admin user is created (you'll need to interact with this)
+./bin/docker/rails s
+```
+
+... then open a browser on http://localhost:3000 and _voila!_, you should see Discourse.
+
+When you're done, you can kill the Docker container with:
+
+```sh
+./bin/docker/shutdown_dev
+```
+
+Note that data is persisted between invocations of the container in your source root `tmp/postgres` directory.
+
+## Caveats
+
+There seems to be an issue with the ember-data-source gem installed by default (2.3.0.beta.5).  It's missing its `dist` directory.  I've worked around this by acquiring that commit, building the distribution locally, and patching it into `/usr/local/lib/ruby/gems/2.3.0/gems/ember-data-source-2.3.0.beta.5` by hand.  I _believe_ later versions of the gem fix this, but the very next version (2.3.0 proper) bumps the ember-source dependency up to 2.0, which Discourse isn't using yet.
+
+You can get `boot_dev` to patch for you by passing `--patch local/path/to/ember-data-source/dist` on the command-line.  You should only have to do this once (like `--init`).
+
+
+## Other Notes
+
+##### Where is the container image/Dockerfile defined?
+
+The Dockerfile comes from [discourse/discourse_docker on GitHub](https://github.com/discourse/discourse_docker), in particular [image/discourse_dev](https://github.com/discourse/discourse_docker/tree/master/image/discourse_dev).

--- a/bin/docker/boot_dev
+++ b/bin/docker/boot_dev
@@ -52,7 +52,7 @@ echo "Using data in:   ${DATA_DIR}"
 
 mkdir -p "${DATA_DIR}"
 
-docker run -d -p 3000:3000 -v $DATA_DIR:/shared/postgres_data -v $SOURCE_DIR:/src --hostname=discourse --name=discourse_dev --restart=always discourse/discourse_dev:1.3.7 /sbin/boot
+docker run -d -p 3000:3000 -v $DATA_DIR:/shared/postgres_data -v $SOURCE_DIR:/src --hostname=discourse --name=discourse_dev --restart=always discourse/discourse_dev:latest /sbin/boot
 
 if [ "${initialize}" = "initialize" ]; then
     echo "Installing gems..."

--- a/bin/docker/boot_dev
+++ b/bin/docker/boot_dev
@@ -1,14 +1,74 @@
 #!/bin/bash
-
-pushd `dirname $0` > /dev/null
-SCRIPTPATH=`pwd -P`
-popd > /dev/null
-
-
-SOURCE_DIR=`(cd $SCRIPTPATH && cd ../../ && pwd)`
+SCRIPTPATH=$(cd "$(dirname "$0")"; pwd -P)
+SOURCE_DIR=$(cd "$SCRIPTPATH" && cd ../.. && pwd -P)
 DATA_DIR=$SOURCE_DIR/tmp/postgres
 
-echo $SOURCE_DIR
-echo $DATA_DIR
+show_help() {
+cat <<EOF
+Usage: ${0##*/} [-h] [--init [--patch DIR]]
 
-docker run -d -p 3000:3000 -v $DATA_DIR:/shared/postgres_data -v $SOURCE_DIR:/src --hostname=discourse_dev --name=discourse_dev --restart=always discourse/dev /sbin/boot
+    --init        perform first-time initialization
+
+    --patch DIR   patch ember-data-source with missing dist files from DIR
+                  (for example, "--patch ~/repos/ember-source-data/dist")
+                  requires --init to also be passed
+
+EOF
+}
+
+initialize=""
+patch_source=""
+
+while [ "${#@}" -ne "0" ]; do
+    case "$1" in
+        -h | --help)
+            show_help
+            exit 0
+            ;;
+        -i | --init)
+            initialize="initialize"
+            ;;
+        -p | --patch)
+            patch_source="$2"
+            shift
+            ;;
+        *)
+            echo "unexpected argument: $1" >& 2
+            show_help >& 2
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+if [ -n "${patch_source}" ] && [ "${initialize}" != "initialize" ]; then
+    echo "error: the --init flag is required when using --patch" >& 2
+    show_help >& 2
+    exit 2
+fi
+
+echo "Using source in: ${SOURCE_DIR}"
+echo "Using data in:   ${DATA_DIR}"
+
+mkdir -p "${DATA_DIR}"
+
+docker run -d -p 3000:3000 -v $DATA_DIR:/shared/postgres_data -v $SOURCE_DIR:/src --hostname=discourse --name=discourse_dev --restart=always discourse/discourse_dev:1.3.7 /sbin/boot
+
+if [ "${initialize}" = "initialize" ]; then
+    echo "Installing gems..."
+    ${SCRIPTPATH}/bundle install
+
+    if [ -n "${patch_source}" ]; then
+        echo "Patching ember-data-source-2.3.0.beta.5 gems..."
+        docker exec discourse_dev /bin/bash -c "mkdir -p /usr/local/lib/ruby/gems/2.3.0/gems/ember-data-source-2.3.0.beta.5/dist"
+        for f in "${patch_source}"/globals/*.js; do
+            docker cp $f discourse_dev:/usr/local/lib/ruby/gems/2.3.0/gems/ember-data-source-2.3.0.beta.5/dist/$(basename $f)
+        done
+    fi
+
+    echo "Migrating database..."
+    ${SCRIPTPATH}/rake db:migrate
+
+    echo "Creating admin user..."
+    ${SCRIPTPATH}/rake admin:create
+fi

--- a/bin/docker/bundle
+++ b/bin/docker/bundle
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 PARAMS="$@"
-CMD="cd /src && HOME=/home/discourse chpst -u discourse:discourse bundle $PARAMS"
-docker exec -it discourse_dev /bin/bash -c "$CMD"
+CMD="cd /src && RAILS_ENV=${RAILS_ENV:=development} bundle $PARAMS"
+docker exec -it -u discourse:discourse discourse_dev /bin/bash -c "$CMD"

--- a/bin/docker/psql
+++ b/bin/docker/psql
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 PARAMS="$@"
-CMD="chpst -u postgres psql $PARAMS"
-docker exec -it discourse_dev /bin/bash -c "$CMD"
+CMD="psql $PARAMS"
+docker exec -it -u postgres discourse_dev /bin/bash -c "$CMD"

--- a/bin/docker/rails
+++ b/bin/docker/rails
@@ -5,5 +5,5 @@ if [[ $# = 1 ]] && [[ "$1" =~ "s" ]];
 then
   PARAMS="$PARAMS -b 0.0.0.0"
 fi
-CMD="cd /src && HOME=/home/discourse RAILS_ENV=${RAILS_ENV:=development} chpst -u discourse:discourse rails $PARAMS"
-docker exec -it discourse_dev /bin/bash -c "$CMD"
+CMD="cd /src && RAILS_ENV=${RAILS_ENV:=development} rails $PARAMS"
+docker exec -it -u discourse:discourse discourse_dev /bin/bash -c "$CMD"

--- a/bin/docker/rake
+++ b/bin/docker/rake
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 PARAMS="$@"
-CMD="cd /src && HOME=/home/discourse RAILS_ENV=${RAILS_ENV:=development} chpst -u discourse:discourse rake $PARAMS"
-docker exec -it discourse_dev /bin/bash -c "$CMD"
+CMD="cd /src && RAILS_ENV=${RAILS_ENV:=development} rake $PARAMS"
+docker exec -it -u discourse:discourse discourse_dev /bin/bash -c "$CMD"

--- a/bin/docker/reset_db
+++ b/bin/docker/reset_db
@@ -1,12 +1,8 @@
 #!/bin/bash
-
-pushd `dirname $0` > /dev/null
-SCRIPTPATH=`pwd -P`
-popd > /dev/null
-
-
-SOURCE_DIR=`(cd $SCRIPTPATH && cd ../../ && pwd)`
+SCRIPTPATH=$(cd "$(dirname "$0")"; pwd -P)
+SOURCE_DIR=$(cd "$SCRIPTPATH" && cd ../.. && pwd -P)
 DATA_DIR=$SOURCE_DIR/tmp/postgres
 
-
-docker run -it -v $DATA_DIR:/shared/postgres_data samsaffron/discourse_dev:1.0.13 /bin/bash -c "rm -fr /shared/postgres_data/*"
+# Should this also run /etc/runit/1.d/ensure_database, or will that
+# happen automatically?
+docker run -it -v $DATA_DIR:/shared/postgres_data discourse/dev /bin/bash -c "rm -fr /shared/postgres_data/*"

--- a/bin/docker/shell
+++ b/bin/docker/shell
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker exec -it -u discourse:discourse discourse_dev /bin/bash


### PR DESCRIPTION
This PR is intended to work in concert with the discourse_docker changes in https://github.com/discourse/discourse_docker/pull/292.  I have used those changes to build a local "discourse_dev" image, and then _**these**_ changes to easily spin up and work on Discourse and plugin functionality.  It's working well for me, but of course YMMV.

Add `--init` and `--patch` options to bin/docker/boot_dev to make it easier to spin up a container running Discourse out of a development directory.

Add `bin/docker/README.md` to explain how to go about using the docker command-line tools.

Tweak the Docker command-line tools to use the `-u` option to specify user rather than changing to the user "inside" the container via `chpst` (This way, we don't have to explicitly specify the HOME environment variable, either.)

Add `bin/docker/shell` command to make it easy to jump inside the running container.