### PR TITLE
FIX: Content-Lenght should be the size in octets

### DIFF
--- a/app/jobs/regular/emit_web_hook_event.rb
+++ b/app/jobs/regular/emit_web_hook_event.rb
@@ -42,7 +42,7 @@ module Jobs
         headers = {
           'Accept' => '*/*',
           'Connection' => 'close',
-          'Content-Length' => body.size,
+          'Content-Length' => body.bytesize,
           'Content-Type' => content_type,
           'Host' => uri.host,
           'User-Agent' => "Discourse/" + Discourse::VERSION::STRING,


### PR DESCRIPTION
https://meta.discourse.org/t/closing-brace-missing-in-webhook-json/50418