### PR TITLE
Don't look for external facts when benchmarking

### DIFF
--- a/script/bench.rb
+++ b/script/bench.rb
@@ -219,6 +219,9 @@ begin
 
   puts "Your Results: (note for timings- percentile is first, duration is second in millisecs)"
 
+  # Prevent using external facts because it breaks when running in the
+  # discourse/discourse_bench docker container.
+  Facter::Util::Config.external_facts_dirs = []
   facts = Facter.to_hash
 
   facts.delete_if{|k,v|
@@ -270,8 +273,6 @@ begin
     end
   end
 
-
-  # TODO include Facter.to_hash ... for all facts
 ensure
   Process.kill "KILL", pid
 end


### PR DESCRIPTION
When running `scripts/bench.rb` via the discourse/discourse_bench docker container, Facter throws an EACCES error attempting to load external puppet facts.  Since the benchmark script ends up ignoring everything except for seven specific keys, we can just avoid loading any external fact logic entirely.