### PR TITLE
Move purge_unactivated to PurgeInactive where it belongs

### DIFF
--- a/app/jobs/scheduled/purge_inactive.rb
+++ b/app/jobs/scheduled/purge_inactive.rb
@@ -2,9 +2,22 @@ module Jobs
   class PurgeInactive < Jobs::Scheduled
     every 1.day
 
+    # Delete unactivated accounts (without verified email) that are over a week old
     def execute(args)
-      User.purge_unactivated
+      to_destroy = User.where(active: false)
+                       .joins('INNER JOIN user_stats AS us ON us.user_id = users.id')
+                       .where("created_at < ?", SiteSetting.purge_unactivated_users_grace_period_days.days.ago)
+                       .where('NOT admin AND NOT moderator')
+                       .limit(200)
+
+      destroyer = UserDestroyer.new(Discourse.system_user)
+      to_destroy.each do |u|
+        begin
+          destroyer.destroy(u, context: I18n.t(:purge_reason))
+        rescue Discourse::InvalidAccess, UserDestroyer::PostsExistError
+          # if for some reason the user can't be deleted, continue on to the next one
+        end
+      end
     end
   end
 end
-

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -995,24 +995,6 @@ class User < ActiveRecord::Base
     end
   end
 
-  # Delete unactivated accounts (without verified email) that are over a week old
-  def self.purge_unactivated
-    to_destroy = User.where(active: false)
-                     .joins('INNER JOIN user_stats AS us ON us.user_id = users.id')
-                     .where("created_at < ?", SiteSetting.purge_unactivated_users_grace_period_days.days.ago)
-                     .where('NOT admin AND NOT moderator')
-                     .limit(200)
-
-    destroyer = UserDestroyer.new(Discourse.system_user)
-    to_destroy.each do |u|
-      begin
-        destroyer.destroy(u, context: I18n.t(:purge_reason))
-      rescue Discourse::InvalidAccess, UserDestroyer::PostsExistError
-        # if for some reason the user can't be deleted, continue on to the next one
-      end
-    end
-  end
-
   def trigger_user_created_event
     DiscourseEvent.trigger(:user_created, self)
     true

--- a/spec/jobs/purge_inactive_spec.rb
+++ b/spec/jobs/purge_inactive_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe Jobs::PurgeInactive do
+  let!(:user) { Fabricate(:user) }
+  let!(:inactive) { Fabricate(:user, active: false) }
+  let!(:inactive_old) { Fabricate(:user, active: false, created_at: 1.month.ago) }
+
+  it 'should only remove old, unactivated users' do
+    Jobs::PurgeInactive.new.execute(1)
+    all_users = User.all
+    expect(all_users.include?(user)).to eq(true)
+    expect(all_users.include?(inactive)).to eq(true)
+    expect(all_users.include?(inactive_old)).to eq(false)
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1116,20 +1116,6 @@ describe User do
     end
   end
 
-  describe "#purge_unactivated" do
-    let!(:user) { Fabricate(:user) }
-    let!(:inactive) { Fabricate(:user, active: false) }
-    let!(:inactive_old) { Fabricate(:user, active: false, created_at: 1.month.ago) }
-
-    it 'should only remove old, unactivated users' do
-      User.purge_unactivated
-      all_users = User.all
-      expect(all_users.include?(user)).to eq(true)
-      expect(all_users.include?(inactive)).to eq(true)
-      expect(all_users.include?(inactive_old)).to eq(false)
-    end
-  end
-
   describe "hash_passwords" do
 
     let(:too_long) { "x" * (User.max_password_length + 1) }


### PR DESCRIPTION
The logic for `purge_unactivated` really doesn't need to be in the `User` class

As a side benefit there is one fewer untested class and there isn't a confusing naming thing with `inactive` vs `unactivated`.

... This commit doesn't include any new code, it's just a minor refactor.