### PR TITLE
Remove route to action that doesn't exist

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -516,7 +516,6 @@ Discourse::Application.routes.draw do
 
   # Topics resource
   get "t/:id" => "topics#show"
-  post "t" => "topics#create"
   put "t/:id" => "topics#update"
   delete "t/:id" => "topics#destroy"
   put "t/:id/archive-message" => "topics#archive_message"


### PR DESCRIPTION
Removed the `post "t"` route from the routes file because the
`topics#create` action doesn't exist in the topics controller. New
topics are created in the posts controller.