### PR TITLE
Fixing apple touch icon and favicon mixup.

### DIFF
--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -1,13 +1,10 @@
 <meta name="author" content="">
 <meta name="generator" content="Discourse <%= Discourse::VERSION::STRING %> - https://github.com/discourse/discourse version <%= Discourse.git_version %>">
 <%- if SiteSetting.favicon_url.present? %>
-<link rel="icon" type="image/png" href="<%=SiteSetting.favicon_url%>">
+<link rel="icon" href="<%=SiteSetting.favicon_url%>">
 <%- end %>
 <%- if SiteSetting.apple_touch_icon_url.present? %>
-<link rel="apple-touch-icon" type="image/png" href="<%=SiteSetting.apple_touch_icon_url%>">
-<%- end %>
-<%- if (SiteSetting.apple_touch_icon_url != "/images/default-apple-touch-icon.png") && SiteSetting.apple_touch_icon_url.present? %>
-<link rel="icon" sizes="144x144" href="<%=SiteSetting.apple_touch_icon_url%>">
+<link rel="apple-touch-icon" href="<%=SiteSetting.apple_touch_icon_url%>">
 <%- end %>
 <meta name="theme-color" content="#<%= ColorScheme.hex_for_name('header_background') %>">
 <% if mobile_view? %>


### PR DESCRIPTION
Firefox would load the last `<link rel="icon">` containing the apple touch icon.
Removed also all unnecessary mime type attributes.