### PR TITLE
FIX: fix eslint error due to removing the search_help

### DIFF
--- a/app/assets/javascripts/discourse/controllers/full-page-search.js.es6
+++ b/app/assets/javascripts/discourse/controllers/full-page-search.js.es6
@@ -1,6 +1,5 @@
 import { ajax } from 'discourse/lib/ajax';
 import { translateResults, searchContextDescription, getSearchKey, isValidSearchTerm } from "discourse/lib/search";
-import showModal from 'discourse/lib/show-modal';
 import { default as computed, observes } from 'ember-addons/ember-computed-decorators';
 import Category from 'discourse/models/category';
 import { escapeExpression } from 'discourse/lib/utilities';


### PR DESCRIPTION
Related commit that made eslint unhappy
https://github.com/discourse/discourse/commit/c51992cf5e0bc9a636ae4c7a9f8c3bd11186e936