### PR TITLE
FEATURE: Allow title override for user avatars

### DIFF
--- a/app/assets/javascripts/discourse/helpers/user-avatar.js.es6
+++ b/app/assets/javascripts/discourse/helpers/user-avatar.js.es6
@@ -11,8 +11,8 @@ function renderAvatar(user, options) {
 
     if (!username || !avatarTemplate) { return ''; }
 
-    let title;
-    if (!options.ignoreTitle) {
+    let title = options.title;
+    if (!title && !options.ignoreTitle) {
       // first try to get a title
       title = Em.get(user, 'title');
       // if there was no title provided


### PR DESCRIPTION
A couple little tweaks in relation to the plugin discussed here:
https://meta.discourse.org/t/paid-fullstack-dev-for-bidimensionnal-navigation/45388/3

This is so that I can pass in my own title (in this case, the topic's title), when rendering a user avatar.