### PR TITLE
FIX: Properly name tag intersection route

### DIFF
--- a/app/assets/javascripts/discourse/routes/app-route-map.js.es6
+++ b/app/assets/javascripts/discourse/routes/app-route-map.js.es6
@@ -132,7 +132,7 @@ export default function() {
       this.route('showCategory' + filter.capitalize(), {path: '/c/:category/:tag_id/l/' + filter});
       this.route('showParentCategory' + filter.capitalize(), {path: '/c/:parent_category/:category/:tag_id/l/' + filter});
     });
-    this.route('show', {path: 'intersection/:tag_id/*additional_tags'});
+    this.route('intersection', {path: 'intersection/:tag_id/*additional_tags'});
   });
 
   this.resource('tagGroups', {path: '/tag_groups'}, function() {


### PR DESCRIPTION
Looks like I named the intersection route the same as the tags show route, which makes it impossible to properly reference the existing tags:show route, like this:

```
{{#link-to 'tags.show' tag}}
```