### PR TITLE
PERF: Remove ordering by username.

### DIFF
--- a/app/controllers/directory_items_controller.rb
+++ b/app/controllers/directory_items_controller.rb
@@ -44,8 +44,7 @@ class DirectoryItemsController < ApplicationController
       end
     end
 
-    result = result.order('users.username')
-    result_count = result.dup.count
+    result_count = result.count
     result = result.limit(PAGE_SIZE).offset(PAGE_SIZE * page).to_a
 
     more_params = params.slice(:period, :order, :asc)

--- a/db/migrate/20161014171034_add_directory_items_indexes.rb
+++ b/db/migrate/20161014171034_add_directory_items_indexes.rb
@@ -1,0 +1,11 @@
+class AddDirectoryItemsIndexes < ActiveRecord::Migration
+  def change
+    add_index :directory_items, :likes_received
+    add_index :directory_items, :likes_given
+    add_index :directory_items, :topics_entered
+    add_index :directory_items, :topic_count
+    add_index :directory_items, :post_count
+    add_index :directory_items, :posts_read
+    add_index :directory_items, :days_visited
+  end
+end


### PR DESCRIPTION
* Ordering by username results in a very expensive query
for very little upside UX wise.

`DirectoryItem.where(period_type: 4).includes(:user).order("directory_items.likes_received").order("users.username").limit(50)` is the current query that we are running most of the time.

The query above results in a query plan of https://explain.depesz.com/s/SxQ where majority of the time is spent sorting and joining the two tables with all the rows being looked at. The main cause here is duo to `order('users.username')` which requires us to do a join on the users table and it results in a slower sort operation. 

UX wise, ordering by username on the users page has very little upside since `directory_items.#{order}` will usually take precedence over it most of the time. The only "obvious" case is when we order the `directory_items` in ASC order.

cc @SamSaffron Any thoughts on this? For a large `DirectoryItem` table of 6 million rows, the query can take up to 1500ms to execute. 
