### PR TITLE
FEATURE:'No Echo' option for mailing list mode.

### DIFF
--- a/app/assets/javascripts/discourse/controllers/preferences.js.es6
+++ b/app/assets/javascripts/discourse/controllers/preferences.js.es6
@@ -79,7 +79,8 @@ export default Ember.Controller.extend(CanCheckEmails, {
   mailingListModeOptions() {
     return [
       {name: I18n.t('user.mailing_list_mode.daily'), value: 0},
-      {name: this.get('frequencyEstimate'), value: 1}
+      {name: this.get('frequencyEstimate'), value: 1},
+      {name: I18n.t('user.mailing_list_mode.individual_no_echo'), value: 2}
     ];
   },
 

--- a/app/jobs/regular/user_email.rb
+++ b/app/jobs/regular/user_email.rb
@@ -103,7 +103,7 @@ module Jobs
         end
 
         if user.user_option.mailing_list_mode? &&
-           user.user_option.mailing_list_mode_frequency == 1 && # don't catch notifications for users on daily mailing list mode
+           user.user_option.mailing_list_mode_frequency > 0 && # don't catch notifications for users on daily mailing list mode
            (!post.try(:topic).try(:private_message?)) &&
            NOTIFICATIONS_SENT_BY_MAILING_LIST.include?(email_args[:notification_type])
            # no need to log a reason when the mail was already sent via the mailing list job

--- a/app/models/mailing_list_mode_site_setting.rb
+++ b/app/models/mailing_list_mode_site_setting.rb
@@ -9,7 +9,8 @@ class MailingListModeSiteSetting < EnumSiteSetting
   def self.values
     @values ||= [
       { name: 'user.mailing_list_mode.daily',      value:  0 },
-      { name: 'user.mailing_list_mode.individual', value:  1 }
+      { name: 'user.mailing_list_mode.individual', value:  1 },
+      { name: 'user.mailing_list_mode.individual_no_echo', value:  2 }
     ]
   end
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -535,6 +535,7 @@ en:
           Muted topics and categories are not included in these emails.
         daily: "Send daily updates"
         individual: "Send an email for every new post"
+        individual_no_echo: "Send an email for every new post except my own"
         many_per_day: "Send me an email for every new post (about {{dailyEmailEstimate}} per day)"
         few_per_day: "Send me an email for every new post (about 2 per day)"
       tag_settings: "Tags"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2614,6 +2614,7 @@ en:
     message_to_blank: "message.to is blank"
     text_part_body_blank: "text_part.body is blank"
     body_blank: "body is blank"
+    no_echo_mailing_list_mode: "Mailing list notifications disabled for user's own posts"
 
   color_schemes:
     base_theme_name: "Base"

--- a/spec/jobs/enqueue_mailing_list_emails_spec.rb
+++ b/spec/jobs/enqueue_mailing_list_emails_spec.rb
@@ -82,6 +82,11 @@ describe Jobs::EnqueueMailingListEmails do
         expect(subject).to_not include user.id
       end
 
+      it "doesn't return users with mailing list mode set to 'individual_excluding_own'" do
+        user_option.update(mailing_list_mode_frequency: 2)
+        expect(subject).to_not include user.id
+      end
+
       it "doesn't return a user who has received the mailing list summary earlier" do
         user.update(first_seen_at: 5.hours.ago)
         expect(subject).to_not include user.id


### PR DESCRIPTION
Mailing list mode now includes the 'no echo' option: to only receive emails of posts not created
by you.  If you reply to an email thread in mailing list mode, your reply will not then be echoed
back to you in a duplicate email by the system.

This feature PR is in response to this thread on meta: https://meta.discourse.org/t/getting-email-after-my-own-reply/21158/4