### PR TITLE
Bundle install error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,7 +147,7 @@ GEM
     librarian (0.1.2)
       highline
       thor (~> 0.15)
-    libv8 (5.0.71.48.3)
+    libv8 (5.3.332.38.1)
     listen (0.7.3)
     logster (1.2.5)
     loofah (2.0.3)
@@ -162,8 +162,8 @@ GEM
     method_source (0.8.2)
     mime-types (2.99.2)
     mini_portile2 (2.1.0)
-    mini_racer (0.1.3)
-      libv8 (~> 5.0)
+    mini_racer (0.1.5)
+      libv8 (~> 5.3)
     minitest (5.9.1)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
@@ -501,4 +501,4 @@ DEPENDENCIES
   unicorn
 
 BUNDLED WITH
-   1.13.4
+   1.13.5


### PR DESCRIPTION
———

- What I did
I've bundle install and error message
```
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

current directory:
/Users/arnonhongklay/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/mini_racer-0.1.3/ext/mini_racer_extension
/Users/arnonhongklay/.rbenv/versions/2.3.1/bin/ruby -r ./siteconf20161021-75424-hs1hgu.rb extconf.rb
checking for main() in -lpthread... yes
checking for main() in -lobjc... yes
creating Makefile

To see why this extension failed to compile, please check the mkmf.log which can be found here:

/Users/arnonhongklay/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/extensions/x86_64-darwin-16/2.3.0-static/mini_racer-0.1.3/mkmf.log

current directory:
/Users/arnonhongklay/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/mini_racer-0.1.3/ext/mini_racer_extension
make "DESTDIR=" clean

current directory:
/Users/arnonhongklay/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/mini_racer-0.1.3/ext/mini_racer_extension
make "DESTDIR="
compiling mini_racer_extension.cc
clang: warning: argument unused during compilation: '-rdynamic'
mini_racer_extension.cc:4:10: fatal error: 'include/v8.h' file not found
         ^
         1 error generated.
         make: *** [mini_racer_extension.o] Error 1

         make failed, exit code 2

         Gem files will remain installed in
         /Users/arnonhongklay/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/mini_racer-0.1.3 for inspection.
         Results logged to
         /Users/arnonhongklay/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/extensions/x86_64-darwin-16/2.3.0-static/mini_racer-0.1.3/gem_make.out

         An error occurred while installing mini_racer (0.1.3), and Bundler cannot continue.
         Make sure that `gem install mini_racer -v '0.1.3'` succeeds before bundling.
         Could not find rails-deprecated_sanitizer-1.0.3 in any of the sources
```

- How I did it
I've changed to upgrade mini racer version from 0.1.3 ro lastest version