### PR TITLE
FIX: If the tag is first used in a deleted topic the tag shouldn't be stuck

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -13,7 +13,7 @@ class Tag < ActiveRecord::Base
   has_many :tag_groups, through: :tag_group_memberships
 
   def self.tags_by_count_query(opts={})
-    q = TopicTag.joins(:tag, :topic).group("topic_tags.tag_id, tags.name").order('count_all DESC')
+    q = Topic.unscoped { TopicTag.joins(:tag, :topic).group("topic_tags.tag_id, tags.name").order('count_all DESC') }
     q = q.limit(opts[:limit]) if opts[:limit]
     q
   end


### PR DESCRIPTION
This fixes https://meta.discourse.org/t/tag-gets-broken-if-the-first-topic-to-use-it-is-deleted/51701?u=falco

But is only works on Active Record > 4.2.7.1 that hasn't been released yet.