### PR TITLE
UX: Rename search "options" to "Advanced Search"

### DIFF
--- a/app/assets/javascripts/discourse/widgets/search-menu-controls.js.es6
+++ b/app/assets/javascripts/discourse/widgets/search-menu-controls.js.es6
@@ -46,8 +46,8 @@ createWidget('search-context', {
 
     if (!attrs.contextEnabled) {
       result.push(this.attach('link', { href: attrs.url,
-                                        label: 'show_help',
-                                        className: 'show-help' }));
+                                        label: 'open_advanced_search',
+                                        className: 'open-advanced-search' }));
     }
 
     result.push(h('div.clearfix'));

--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -103,7 +103,7 @@
 
 .search-menu {
 
-  .search-context .show-help {
+  .search-context .open-advanced-search {
     float: right;
   }
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -200,7 +200,7 @@ en:
     admin_title: "Admin"
     flags_title: "Flags"
     show_more: "show more"
-    show_help: "options"
+    open_advanced_search: "Advanced Search"
     links: "Links"
     links_lowercase:
       one: "link"

--- a/test/javascripts/acceptance/search-test.js.es6
+++ b/test/javascripts/acceptance/search-test.js.es6
@@ -17,7 +17,7 @@ test("search", (assert) => {
     assert.ok(exists('.search-menu .results ul li'), 'it shows results');
   });
 
-  click('.show-help');
+  click('.open-advanced-search');
 
   andThen(() => {
     assert.equal(find('.full-page-search').val(), 'dev', 'it shows the search term');


### PR DESCRIPTION
This renames the "options" link in the search popup to "Advanced Search" since it opens the Advanced Search instead of showing the old search help text.

Before:
![image](https://cloud.githubusercontent.com/assets/473736/19745543/5b3bb9cc-9bd2-11e6-9390-1e8a3afd8c08.png)

After:
![image](https://cloud.githubusercontent.com/assets/473736/19745562/6f69bd2c-9bd2-11e6-8ac6-32645ab7d058.png)
