### PR TITLE
Remove useless routing for ForumsController

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,7 +57,6 @@ Discourse::Application.routes.draw do
 
   get "site_customizations/:key" => "site_customizations#show"
 
-  resources :forums
   get "srv/status" => "forums#status"
 
   get "wizard" => "wizard#index"


### PR DESCRIPTION
`ForumsController` doesn't provide all necessary methods for `resources :forums`.

    $ bundle exec rake routes | grep forum
           forums GET      /forums(.:format)                forums#index
                  POST     /forums(.:format)                forums#create
        new_forum GET      /forums/new(.:format)            forums#new
       edit_forum GET      /forums/:id/edit(.:format)       forums#edit
            forum GET      /forums/:id(.:format)            forums#show
                  PATCH    /forums/:id(.:format)            forums#update
                  PUT      /forums/:id(.:format)            forums#update
                  DELETE   /forums/:id(.:format)            forums#destroy
       srv_status GET      /srv/status(.:format)            forums#status

`ForumsController` provides only `status` and `home_redirect` methods.

I don't see any reasons to keep it. I believe we should drop it, because [it doesn't allow to create permalinks with forums/* address](https://meta.discourse.org/t/not-able-to-create-a-permalink-with-forums-address/52100).

