### PR TITLE
FIX: Auto-link URLs that are inside parentheses

### DIFF
--- a/app/assets/javascripts/pretty-text/engines/discourse-markdown.js.es6
+++ b/app/assets/javascripts/pretty-text/engines/discourse-markdown.js.es6
@@ -500,7 +500,7 @@ function invalidBoundary(args, prev) {
 
   if (args.wordBoundary && (!last.match(/\W$/))) { return true; }
   if (args.spaceBoundary && (!last.match(/\s$/))) { return true; }
-  if (args.spaceOrTagBoundary && (!last.match(/(\s|\>)$/))) { return true; }
+  if (args.spaceOrTagBoundary && (!last.match(/(\s|\>|\()$/))) { return true; }
 }
 
 function countLines(str) {

--- a/test/javascripts/lib/pretty-text-test.js.es6
+++ b/test/javascripts/lib/pretty-text-test.js.es6
@@ -159,9 +159,18 @@ test("Links", function() {
          "<p><a href=\"http://discourse.org\">http://google.com ... wat</a></p>",
          "it supports links within links");
 
+  cooked("[http://google.com](http://discourse.org)",
+         "<p><a href=\"http://discourse.org\">http://google.com</a></p>",
+         "it supports markdown links where the name and link match");
+
+
   cooked("[Link](http://www.example.com) (with an outer \"description\")",
          "<p><a href=\"http://www.example.com\">Link</a> (with an outer \"description\")</p>",
          "it doesn't consume closing parens as part of the url");
+
+  cooked("A link inside parentheses (http://www.example.com)",
+         "<p>A link inside parentheses (<a href=\"http://www.example.com\">http://www.example.com</a>)</p>",
+         "it auto-links a url within parentheses");
 
   cooked("[ul][1]\n\n[1]: http://eviltrout.com",
          "<p><a href=\"http://eviltrout.com\">ul</a></p>",


### PR DESCRIPTION
https://meta.discourse.org/t/links-in-parentheses-are-not-hyperlinked/24121