### PR TITLE
FEATURE: include post image in OpenGraph image tag

### DIFF
--- a/app/models/color_scheme.rb
+++ b/app/models/color_scheme.rb
@@ -153,4 +153,6 @@ end
 #  version      :integer          default(1), not null
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
+#  via_wizard   :boolean          default(FALSE), not null
+#  theme_id     :string
 #

--- a/app/models/directory_item.rb
+++ b/app/models/directory_item.rb
@@ -160,5 +160,12 @@ end
 #
 # Indexes
 #
+#  index_directory_items_on_days_visited             (days_visited)
+#  index_directory_items_on_likes_given              (likes_given)
+#  index_directory_items_on_likes_received           (likes_received)
 #  index_directory_items_on_period_type_and_user_id  (period_type,user_id) UNIQUE
+#  index_directory_items_on_post_count               (post_count)
+#  index_directory_items_on_posts_read               (posts_read)
+#  index_directory_items_on_topic_count              (topic_count)
+#  index_directory_items_on_topics_entered           (topics_entered)
 #

--- a/app/models/embeddable_host.rb
+++ b/app/models/embeddable_host.rb
@@ -48,9 +48,10 @@ end
 #
 # Table name: embeddable_hosts
 #
-#  id          :integer          not null, primary key
-#  host        :string           not null
-#  category_id :integer          not null
-#  created_at  :datetime
-#  updated_at  :datetime
+#  id             :integer          not null, primary key
+#  host           :string           not null
+#  category_id    :integer          not null
+#  created_at     :datetime
+#  updated_at     :datetime
+#  path_whitelist :string
 #

--- a/app/models/facebook_user_info.rb
+++ b/app/models/facebook_user_info.rb
@@ -18,6 +18,10 @@ end
 #  link             :string
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
+#  avatar_url       :string
+#  about_me         :text
+#  location         :string
+#  website          :text
 #
 # Indexes
 #

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -498,6 +498,9 @@ end
 #  grant_trust_level                  :integer
 #  incoming_email                     :string
 #  has_messages                       :boolean          default(FALSE), not null
+#  flair_url                          :string
+#  flair_bg_color                     :string
+#  flair_color                        :string
 #
 # Indexes
 #

--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -285,6 +285,7 @@ end
 #  deleted_at     :datetime
 #  deleted_by_id  :integer
 #  invalidated_at :datetime
+#  moderator      :boolean          default(FALSE), not null
 #
 # Indexes
 #

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -719,6 +719,7 @@ end
 #  raw_email               :text
 #  public_version          :integer          default(1), not null
 #  action_code             :string
+#  image_url               :string
 #
 # Indexes
 #

--- a/app/models/single_sign_on_record.rb
+++ b/app/models/single_sign_on_record.rb
@@ -15,7 +15,7 @@ end
 #  external_username   :string
 #  external_email      :string
 #  external_name       :string
-#  external_avatar_url :string
+#  external_avatar_url :string(1000)
 #
 # Indexes
 #

--- a/app/models/user_api_key.rb
+++ b/app/models/user_api_key.rb
@@ -69,16 +69,15 @@ end
 #  client_id        :string           not null
 #  key              :string           not null
 #  application_name :string           not null
-#  read             :boolean          not null
-#  write            :boolean          not null
-#  push             :boolean          not null
 #  push_url         :string
 #  created_at       :datetime
 #  updated_at       :datetime
+#  revoked_at       :datetime
+#  scopes           :text             default([]), not null, is an Array
 #
 # Indexes
 #
-#  index_user_api_keys_on_client_id  (client_id)
+#  index_user_api_keys_on_client_id  (client_id) UNIQUE
 #  index_user_api_keys_on_key        (key) UNIQUE
 #  index_user_api_keys_on_user_id    (user_id)
 #

--- a/app/models/web_hook.rb
+++ b/app/models/web_hook.rb
@@ -84,6 +84,7 @@ end
 #  payload_url          :string           not null
 #  content_type         :integer          default(1), not null
 #  last_delivery_status :integer          default(1), not null
+#  status               :integer          default(1), not null
 #  secret               :string           default("")
 #  wildcard_web_hook    :boolean          default(FALSE), not null
 #  verify_certificate   :boolean          default(TRUE), not null

--- a/app/models/web_hook_event.rb
+++ b/app/models/web_hook_event.rb
@@ -24,7 +24,7 @@ end
 #  web_hook_id      :integer          not null
 #  headers          :string
 #  payload          :text
-#  status           :integer
+#  status           :integer          default(0)
 #  response_headers :string
 #  response_body    :text
 #  duration         :integer          default(0)

--- a/db/migrate/20161029181306_add_image_url_to_posts.rb
+++ b/db/migrate/20161029181306_add_image_url_to_posts.rb
@@ -1,0 +1,5 @@
+class AddImageUrlToPosts < ActiveRecord::Migration
+  def change
+    add_column :posts, :image_url, :string
+  end
+end

--- a/lib/cooked_post_processor.rb
+++ b/lib/cooked_post_processor.rb
@@ -84,7 +84,7 @@ class CookedPostProcessor
       convert_to_link!(img)
     end
 
-    update_topic_image
+    update_post_image
   end
 
   def extract_images
@@ -100,7 +100,7 @@ class CookedPostProcessor
     @doc.css(".quote img")
   end
 
-  def extract_images_for_topic
+  def extract_images_for_post
     # all image with a src attribute
     @doc.css("img[src]") -
     # minus, emojis
@@ -285,10 +285,11 @@ class CookedPostProcessor
     span
   end
 
-  def update_topic_image
-    if @post.is_first_post?
-      img = extract_images_for_topic.first
-      @post.topic.update_column(:image_url, img["src"][0...255]) if img["src"].present?
+  def update_post_image
+    img = extract_images_for_post.first
+    if img["src"].present?
+      @post.update_column(:image_url, img["src"][0...255]) # post
+      @post.topic.update_column(:image_url, img["src"][0...255]) if @post.is_first_post? # topic
     end
   end
 

--- a/lib/topic_view.rb
+++ b/lib/topic_view.rb
@@ -180,8 +180,12 @@ class TopicView
 
   def image_url
     if @post_number.present? && @post_number.to_i != 1 && @desired_post.present?
-      # show poster avatar
-      @desired_post.user.avatar_template_url.gsub("{size}", "100") if @desired_post.user
+      if @desired_post.image_url.present?
+        @desired_post.image_url
+      elsif @desired_post.user
+        # show poster avatar
+        @desired_post.user.avatar_template_url.gsub("{size}", "100")
+      end
     else
       @topic.image_url
     end

--- a/spec/components/cooked_post_processor_spec.rb
+++ b/spec/components/cooked_post_processor_spec.rb
@@ -242,19 +242,30 @@ describe CookedPostProcessor do
     end
 
     context "topic image" do
-
       let(:topic) { build(:topic, id: 1) }
       let(:post) { Fabricate(:post_with_uploaded_image, topic: topic) }
       let(:cpp) { CookedPostProcessor.new(post) }
 
-      it "adds a topic image if there's one in the post" do
+      it "adds a topic image if there's one in the first post" do
         FastImage.stubs(:size)
         expect(post.topic.image_url).to eq(nil)
         cpp.post_process_images
         post.topic.reload
         expect(post.topic.image_url).to be_present
       end
+    end
 
+    context "post image" do
+      let(:reply) { Fabricate(:post_with_uploaded_image, post_number: 2) }
+      let(:cpp) { CookedPostProcessor.new(reply) }
+
+      it "adds a post image if there's one in the post" do
+        FastImage.stubs(:size)
+        expect(reply.image_url).to eq(nil)
+        cpp.post_process_images
+        reply.reload
+        expect(reply.image_url).to be_present
+      end
     end
 
   end


### PR DESCRIPTION
Currently when sharing a Discourse post link on Twitter/Facebook the poster avatar image shows up. This PR makes it so that if the post contains image, that image will show up instead. In case of multiple images first image will be picked.