### PR TITLE
Add outlet after navigation bar

### DIFF
--- a/app/assets/javascripts/discourse/templates/components/navigation-bar.hbs
+++ b/app/assets/javascripts/discourse/templates/components/navigation-bar.hbs
@@ -1,4 +1,5 @@
 {{#each navItems as |navItem|}}
   {{navigation-item content=navItem filterMode=filterMode}}
 {{/each}}
+{{plugin-outlet "after-navigation-bar" tagName="li"}}
 {{custom-html "extraNavItem"}}

--- a/app/assets/javascripts/discourse/templates/mobile/components/navigation-bar.hbs
+++ b/app/assets/javascripts/discourse/templates/mobile/components/navigation-bar.hbs
@@ -9,5 +9,6 @@
   {{#each navItems as |navItem|}}
     {{navigation-item content=navItem filterMode=filterMode}}
   {{/each}}
+  {{plugin-outlet "after-mobile-navigation-bar" tagName="li"}}
 </ul>
 {{/if}}


### PR DESCRIPTION
We're using it for Babble like this:

![](https://meta-s3-cdn.global.ssl.fastly.net/original/3X/f/b/fb2645a9f2d92a2432d56b6afe05066faf6463e4.gif)