### PR TITLE
A new guard for changing post timestamps

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -492,7 +492,7 @@ class TopicsController < ApplicationController
     params.require(:topic_id)
     params.require(:timestamp)
 
-    guardian.ensure_can_change_post_owner!
+    guardian.ensure_can_change_post_timestamps!
 
     begin
       PostTimestampChanger.new( topic_id: params[:topic_id].to_i,

--- a/lib/guardian/post_guardian.rb
+++ b/lib/guardian/post_guardian.rb
@@ -185,6 +185,10 @@ module PostGuardian
     is_admin?
   end
 
+  def can_change_post_timestamps?
+    is_admin?
+  end
+
   def can_wiki?(post)
     return false unless authenticated?
     return true if is_staff? || @user.has_trust_level?(TrustLevel[4])


### PR DESCRIPTION
Currently the guard used within the topics controller for handling `/ /t/:topic_id/change-timestamp` requests uses the `can_change_post_owner?` guard.

In order to make this more flexible and allow specific guarding of only timestamp changes, I've introduced a new guard called `can_change_post-timestamps?`