### PR TITLE
FIX: open login modal fails because of missing parameters

### DIFF
--- a/app/assets/javascripts/discourse/components/login-buttons.js.es6
+++ b/app/assets/javascripts/discourse/components/login-buttons.js.es6
@@ -1,4 +1,5 @@
 import { findAll }  from 'discourse/models/login-method';
+import { getOwner } from 'discourse-common/lib/get-owner';
 
 export default Ember.Component.extend({
   elementId: 'login-buttons',
@@ -7,7 +8,7 @@ export default Ember.Component.extend({
   hidden: Ember.computed.equal('buttons.length', 0),
 
   buttons: function() {
-    return findAll(this.siteSettings);
+    return findAll(this.siteSettings, getOwner(this).lookup('capabilities:main'), this.site.isMobileDevice);
   }.property(),
 
   actions: {


### PR DESCRIPTION
This may fail when auto login starts. Introduced from the refactor: https://github.com/discourse/discourse/commit/56f07529bb318aefbb582f8a317d50d07e347ee2#diff-1919f3193c69594c86ee146d84448c23R10