### PR TITLE
Add “pop3_polling_openssl_verify” setting to turn off TLS server certificate verification

### DIFF
--- a/app/jobs/scheduled/poll_mailbox.rb
+++ b/app/jobs/scheduled/poll_mailbox.rb
@@ -29,7 +29,14 @@ module Jobs
 
     def poll_pop3
       pop3 = Net::POP3.new(SiteSetting.pop3_polling_host, SiteSetting.pop3_polling_port)
-      pop3.enable_ssl if SiteSetting.pop3_polling_ssl
+
+      if SiteSetting.pop3_polling_ssl
+        if SiteSetting.pop3_polling_openssl_verify
+          pop3.enable_ssl
+        else
+          pop3.enable_ssl(OpenSSL::SSL::VERIFY_NONE)
+        end
+      end
 
       pop3.start(SiteSetting.pop3_polling_username, SiteSetting.pop3_polling_password) do |pop|
         pop.delete_all do |p|

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1248,6 +1248,7 @@ en:
     manual_polling_enabled: "Push emails using the API for email replies."
     pop3_polling_enabled: "Poll via POP3 for email replies."
     pop3_polling_ssl: "Use SSL while connecting to the POP3 server. (Recommended)"
+    pop3_polling_openssl_verify: "Verify TLS server certificate (Default: enabled)"
     pop3_polling_period_mins: "The period in minutes between checking the POP3 account for email. NOTE: requires restart."
     pop3_polling_port: "The port to poll a POP3 account on."
     pop3_polling_host: "The host to poll for email via POP3."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -603,6 +603,7 @@ email:
     default: false
     validator: "POP3PollingEnabledSettingValidator"
   pop3_polling_ssl: true
+  pop3_polling_openssl_verify: true
   pop3_polling_period_mins: 5
   pop3_polling_host: ''
   pop3_polling_port: 995


### PR DESCRIPTION
We needed a new setting like “smtp_openssl_verify_mode”, only for controlling the same thing for fetching emails using POP3 when running a mail server with self-signed certificates.
The new setting defaults to “true”, so it does not change the current behavior.