### PR TITLE
Add comments to relevant sections denoting "create new topic" …

### DIFF
--- a/app/assets/javascripts/discourse/components/composer-editor.js.es6
+++ b/app/assets/javascripts/discourse/components/composer-editor.js.es6
@@ -137,6 +137,8 @@ export default Ember.Component.extend({
   },
 
   _renderUnseenMentions($preview, unseen) {
+    // 'Create a New Topic' scenario is not supported (per conversation with codinghorror)
+    // https://meta.discourse.org/t/taking-another-1-7-release-task/51986/7
     fetchUnseenMentions(unseen, this.get('topic.id')).then(() => {
       linkSeenMentions($preview, this.siteSettings);
       this._warnMentionedGroups($preview);

--- a/app/assets/javascripts/discourse/lib/link-mentions.js.es6
+++ b/app/assets/javascripts/discourse/lib/link-mentions.js.es6
@@ -51,6 +51,8 @@ export function linkSeenMentions($elem, siteSettings) {
   return [];
 }
 
+// 'Create a New Topic' scenario is not supported (per conversation with codinghorror)
+// https://meta.discourse.org/t/taking-another-1-7-release-task/51986/7
 export function fetchUnseenMentions(usernames, topic_id) {
   return ajax("/users/is_local_username", { data: { usernames, topic_id } }).then(r => {
     r.valid.forEach(v => found[v] = true);

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -242,6 +242,8 @@ class UsersController < ApplicationController
     usernames -= groups
     usernames.each(&:downcase!)
 
+    # Create a New Topic Scenario is not supported (per conversation with codinghorror)
+    # https://meta.discourse.org/t/taking-another-1-7-release-task/51986/7
     cannot_see = []
     topic_id = params[:topic_id]
     unless topic_id.blank?


### PR DESCRIPTION
…scenario is not supported for cannot-see-mention (per @coding-horror instruction)

Please see
https://meta.discourse.org/t/taking-another-1-7-release-task/51986/12?u=cpradio

@coding-horror wanted me to add comments to the relevant code sections so we don't have to re-hash this discussion.
