### PR TITLE
FIX: activy column title shows the non-i18n datetime

### DIFF
--- a/app/assets/javascripts/discourse/lib/formatter.js.es6
+++ b/app/assets/javascripts/discourse/lib/formatter.js.es6
@@ -74,7 +74,7 @@ export function toTitleCase(str) {
 
 export function longDate(dt) {
   if (!dt) return;
-  return moment(dt).longDate();
+  return moment(dt).format(I18n.t("dates.long_with_year"));
 }
 
 // suppress year, if current year

--- a/test/javascripts/lib/formatter-test.js.es6
+++ b/test/javascripts/lib/formatter-test.js.es6
@@ -1,6 +1,6 @@
 var clock;
 
-import { relativeAge, autoUpdatingRelativeAge, updateRelativeAge, breakUp, number } from 'discourse/lib/formatter';
+import { relativeAge, autoUpdatingRelativeAge, updateRelativeAge, breakUp, number, longDate } from 'discourse/lib/formatter';
 
 module("lib:formatter", {
   setup: function() {
@@ -72,7 +72,7 @@ test("formating medium length dates", function() {
   equal(strip(formatDays(100)), shortDate(100)); // eg: Jan 23
   equal(strip(formatDays(500)), shortDateYear(500));
 
-  equal($(formatDays(0)).attr("title"), moment().format('MMMM D, YYYY h:mma'));
+  equal($(formatDays(0)).attr("title"), longDate(new Date()));
   equal($(formatDays(0)).attr("class"), "date");
 
   clock.restore();
@@ -157,12 +157,12 @@ test("autoUpdatingRelativeAge", function() {
   equal($elem.attr('title'), undefined);
 
   $elem = $(autoUpdatingRelativeAge(d, {title: true}));
-  equal($elem.attr('title'), moment(d).longDate());
+  equal($elem.attr('title'), longDate(d));
 
   $elem = $(autoUpdatingRelativeAge(d,{format: 'medium', title: true, leaveAgo: true}));
   equal($elem.data('format'), "medium-with-ago");
   equal($elem.data('time'), d.getTime());
-  equal($elem.attr('title'), moment(d).longDate());
+  equal($elem.attr('title'), longDate(d));
   equal($elem.html(), '1 day ago');
 
   $elem = $(autoUpdatingRelativeAge(d,{format: 'medium'}));


### PR DESCRIPTION
`longDate()` utilizes a constant format string `MMMM D, YYYY h:mma` which can't be changed. The title of the activity column in topic list item will be strange in some language.