### PR TITLE
Add keyPress hook to widgets

### DIFF
--- a/app/assets/javascripts/discourse/widgets/hooks.js.es6
+++ b/app/assets/javascripts/discourse/widgets/hooks.js.es6
@@ -4,6 +4,7 @@ const CLICK_ATTRIBUTE_NAME         = '_discourse_click_widget';
 const CLICK_OUTSIDE_ATTRIBUTE_NAME = '_discourse_click_outside_widget';
 const KEY_UP_ATTRIBUTE_NAME        = '_discourse_key_up_widget';
 const KEY_DOWN_ATTRIBUTE_NAME      = '_discourse_key_down_widget';
+const KEY_PRESS_ATTRIBUTE_NAME     = '_discourse_key-press_widget';
 const DRAG_ATTRIBUTE_NAME          = '_discourse_drag_widget';
 
 function buildHook(attributeName, setAttr) {
@@ -32,6 +33,7 @@ export const WidgetClickHook = buildHook(CLICK_ATTRIBUTE_NAME);
 export const WidgetClickOutsideHook = buildHook(CLICK_OUTSIDE_ATTRIBUTE_NAME, 'data-click-outside');
 export const WidgetKeyUpHook = buildHook(KEY_UP_ATTRIBUTE_NAME);
 export const WidgetKeyDownHook = buildHook(KEY_DOWN_ATTRIBUTE_NAME);
+export const WidgetKeyPressHook = buildHook(KEY_PRESS_ATTRIBUTE_NAME);
 export const WidgetDragHook = buildHook(DRAG_ATTRIBUTE_NAME);
 
 
@@ -109,6 +111,10 @@ WidgetClickHook.setupDocumentCallback = function() {
 
   $(document).on('keydown.discourse-widget', e => {
     nodeCallback(e.target, KEY_DOWN_ATTRIBUTE_NAME, w => w.keyDown(e));
+  });
+
+  $(document).on('keypress.discourse-widget', e => {
+    nodeCallback(e.target, KEY_PRESS_ATTRIBUTE_NAME, w => w.keyPress(e));
   });
 
   _watchingDocument = true;

--- a/app/assets/javascripts/discourse/widgets/widget.js.es6
+++ b/app/assets/javascripts/discourse/widgets/widget.js.es6
@@ -2,6 +2,7 @@ import { WidgetClickHook,
          WidgetClickOutsideHook,
          WidgetKeyUpHook,
          WidgetKeyDownHook,
+         WidgetKeyPressHook,
          WidgetDragHook } from 'discourse/widgets/hooks';
 import { h } from 'virtual-dom';
 import DecoratorHelper from 'discourse/widgets/decorator-helper';
@@ -78,6 +79,10 @@ function drawWidget(builder, attrs, state) {
 
   if (this.keyDown) {
     properties['widget-key-down'] = new WidgetKeyDownHook(this);
+  }
+
+  if (this.keyPress) {
+    properties['widget-key-press'] = new WidgetKeyPressHook(this);
   }
 
   if (this.clickOutside) {


### PR DESCRIPTION
I'm specifically looking for keyPress, as opposed to keyUp or keyDown, because I want to listen only for character inputs.

![screen shot 2016-11-18 at 3 11 16 pm](https://cloud.githubusercontent.com/assets/750477/20444987/51e55ca8-ada1-11e6-94fd-abf044a62928.png)


