### PR TITLE
Widget hook for 'input' event

### DIFF
--- a/app/assets/javascripts/discourse/widgets/hooks.js.es6
+++ b/app/assets/javascripts/discourse/widgets/hooks.js.es6
@@ -4,6 +4,7 @@ const CLICK_ATTRIBUTE_NAME         = '_discourse_click_widget';
 const CLICK_OUTSIDE_ATTRIBUTE_NAME = '_discourse_click_outside_widget';
 const KEY_UP_ATTRIBUTE_NAME        = '_discourse_key_up_widget';
 const KEY_DOWN_ATTRIBUTE_NAME      = '_discourse_key_down_widget';
+const KEY_PRESS_ATTRIBUTE_NAME     = '_discourse_key-press_widget';
 const DRAG_ATTRIBUTE_NAME          = '_discourse_drag_widget';
 
 function buildHook(attributeName, setAttr) {
@@ -32,6 +33,7 @@ export const WidgetClickHook = buildHook(CLICK_ATTRIBUTE_NAME);
 export const WidgetClickOutsideHook = buildHook(CLICK_OUTSIDE_ATTRIBUTE_NAME, 'data-click-outside');
 export const WidgetKeyUpHook = buildHook(KEY_UP_ATTRIBUTE_NAME);
 export const WidgetKeyDownHook = buildHook(KEY_DOWN_ATTRIBUTE_NAME);
+export const WidgetKeyPressHook = buildHook(KEY_PRESS_ATTRIBUTE_NAME);
 export const WidgetDragHook = buildHook(DRAG_ATTRIBUTE_NAME);
 
 
@@ -109,6 +111,10 @@ WidgetClickHook.setupDocumentCallback = function() {
 
   $(document).on('keydown.discourse-widget', e => {
     nodeCallback(e.target, KEY_DOWN_ATTRIBUTE_NAME, w => w.keyDown(e));
+  });
+
+  $(document).on('keypress.discourse-widget', e => {
+    nodeCallback(e.target, KEY_PRESS_ATTRIBUTE_NAME, w => w.keyPress(e));
   });
 
   _watchingDocument = true;

--- a/app/assets/javascripts/discourse/widgets/hooks.js.es6
+++ b/app/assets/javascripts/discourse/widgets/hooks.js.es6
@@ -4,7 +4,7 @@ const CLICK_ATTRIBUTE_NAME         = '_discourse_click_widget';
 const CLICK_OUTSIDE_ATTRIBUTE_NAME = '_discourse_click_outside_widget';
 const KEY_UP_ATTRIBUTE_NAME        = '_discourse_key_up_widget';
 const KEY_DOWN_ATTRIBUTE_NAME      = '_discourse_key_down_widget';
-const KEY_PRESS_ATTRIBUTE_NAME     = '_discourse_key-press_widget';
+const INPUT_ATTRIBUTE_NAME         = '_discourse_input_widget';
 const DRAG_ATTRIBUTE_NAME          = '_discourse_drag_widget';
 
 function buildHook(attributeName, setAttr) {
@@ -33,7 +33,7 @@ export const WidgetClickHook = buildHook(CLICK_ATTRIBUTE_NAME);
 export const WidgetClickOutsideHook = buildHook(CLICK_OUTSIDE_ATTRIBUTE_NAME, 'data-click-outside');
 export const WidgetKeyUpHook = buildHook(KEY_UP_ATTRIBUTE_NAME);
 export const WidgetKeyDownHook = buildHook(KEY_DOWN_ATTRIBUTE_NAME);
-export const WidgetKeyPressHook = buildHook(KEY_PRESS_ATTRIBUTE_NAME);
+export const WidgetInputHook = buildHook(INPUT_ATTRIBUTE_NAME);
 export const WidgetDragHook = buildHook(DRAG_ATTRIBUTE_NAME);
 
 
@@ -113,8 +113,8 @@ WidgetClickHook.setupDocumentCallback = function() {
     nodeCallback(e.target, KEY_DOWN_ATTRIBUTE_NAME, w => w.keyDown(e));
   });
 
-  $(document).on('keypress.discourse-widget', e => {
-    nodeCallback(e.target, KEY_PRESS_ATTRIBUTE_NAME, w => w.keyPress(e));
+  $(document).on('input.discourse-widget', e => {
+    nodeCallback(e.target, INPUT_ATTRIBUTE_NAME, w => w.input(e));
   });
 
   _watchingDocument = true;

--- a/app/assets/javascripts/discourse/widgets/widget.js.es6
+++ b/app/assets/javascripts/discourse/widgets/widget.js.es6
@@ -2,7 +2,7 @@ import { WidgetClickHook,
          WidgetClickOutsideHook,
          WidgetKeyUpHook,
          WidgetKeyDownHook,
-         WidgetKeyPressHook,
+         WidgetInputHook,
          WidgetDragHook } from 'discourse/widgets/hooks';
 import { h } from 'virtual-dom';
 import DecoratorHelper from 'discourse/widgets/decorator-helper';
@@ -81,8 +81,8 @@ function drawWidget(builder, attrs, state) {
     properties['widget-key-down'] = new WidgetKeyDownHook(this);
   }
 
-  if (this.keyPress) {
-    properties['widget-key-press'] = new WidgetKeyPressHook(this);
+  if (this.input) {
+    properties['widget-input'] = new WidgetInputHook(this);
   }
 
   if (this.clickOutside) {

--- a/app/assets/javascripts/discourse/widgets/widget.js.es6
+++ b/app/assets/javascripts/discourse/widgets/widget.js.es6
@@ -2,6 +2,7 @@ import { WidgetClickHook,
          WidgetClickOutsideHook,
          WidgetKeyUpHook,
          WidgetKeyDownHook,
+         WidgetKeyPressHook,
          WidgetDragHook } from 'discourse/widgets/hooks';
 import { h } from 'virtual-dom';
 import DecoratorHelper from 'discourse/widgets/decorator-helper';
@@ -78,6 +79,10 @@ function drawWidget(builder, attrs, state) {
 
   if (this.keyDown) {
     properties['widget-key-down'] = new WidgetKeyDownHook(this);
+  }
+
+  if (this.keyPress) {
+    properties['widget-key-press'] = new WidgetKeyPressHook(this);
   }
 
   if (this.clickOutside) {


### PR DESCRIPTION
Hm, okay; how about the 'input' event, which seems to have wider support?
https://developer.mozilla.org/en-US/docs/Web/Events/input

Is 'input' too generic of a function name to be pointing the widget event to? (I wish 'beforeinput' were actually a thing.. seems to have fallen of the face of the internet.)