### PR TITLE
Added flatten func for applyDecorators

### DIFF
--- a/app/assets/javascripts/discourse/widgets/hamburger-menu.js.es6
+++ b/app/assets/javascripts/discourse/widgets/hamburger-menu.js.es6
@@ -144,7 +144,7 @@ export default createWidget('hamburger-menu', {
                    label: this.site.mobileView ? "desktop_view" : "mobile_view" });
     }
 
-    const extraLinks = applyDecorators(this, 'footerLinks', this.attrs, this.state);
+    const extraLinks = flatten(applyDecorators(this, 'footerLinks', this.attrs, this.state));
     return links.concat(extraLinks).map(l => this.attach('link', l));
   },
 


### PR DESCRIPTION
flatten function added for applyDecorators of footerLinks same like [generalLinks](https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/widgets/hamburger-menu.js.es6#L110). Else custom footerLinks not working in some cases.