### PR TITLE
FEATURE: Add job to clean up Redis keys that are not used.

### DIFF
--- a/app/jobs/scheduled/clean_up_redis_keys.rb
+++ b/app/jobs/scheduled/clean_up_redis_keys.rb
@@ -1,0 +1,37 @@
+module Jobs
+  class CleanUpRedisKeys < Jobs::Scheduled
+    every 1.week
+
+    def execute(args)
+      return unless Rails.configuration.multisite
+      return unless SiteSetting.clean_up_redis_keys
+
+      dbs = RailsMultisite::ConnectionManagement.all_dbs
+      dbs << Discourse::SIDEKIQ_NAMESPACE
+
+      regexp = /((\$(?<message_bus>\w+)$)|(^?(?<namespace>\w+):))/
+
+      cursor = 0
+      redis = $redis.without_namespace
+
+      loop do
+        cursor, keys = redis.scan(cursor)
+        cursor = cursor.to_i
+
+        redis.multi do
+          keys.each do |key|
+            if match = key.match(regexp)
+              db_name = match[:message_bus] || match[:namespace]
+
+              if !dbs.include?(db_name)
+                redis.del(key)
+              end
+            end
+          end
+        end
+
+        break if cursor == 0
+      end
+    end
+  end
+end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1069,6 +1069,7 @@ en:
     limit_suggested_to_category: "Only show topics from the current category in suggested topics."
     suggested_topics_max_days_old: "Suggested topics should not be more than n days old."
 
+    clean_up_redis_keys: "Remove Redis keys that are no longer being used by the application."
     clean_up_uploads: "Remove orphan unreferenced uploads to prevent illegal hosting. WARNING: you may want to back up of your /uploads directory before enabling this setting."
     clean_orphan_uploads_grace_period_hours: "Grace period (in hours) before an orphan upload is removed."
     purge_deleted_uploads_grace_period_days: "Grace period (in days) before a deleted upload is erased."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1001,6 +1001,8 @@ developer:
   wizard_enabled:
     default: true
     hidden: true
+  clean_up_redis_keys:
+    default: true
 
 embedding:
   feed_polling_enabled:

--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -369,9 +369,11 @@ module Discourse
     end
   end
 
+  SIDEKIQ_NAMESPACE ||= 'sidekiq'.freeze
+
   def self.sidekiq_redis_config
     conf = GlobalSetting.redis_config.dup
-    conf[:namespace] = 'sidekiq'
+    conf[:namespace] = SIDEKIQ_NAMESPACE
     conf
   end
 

--- a/spec/jobs/clean_up_redis_keys_spec.rb
+++ b/spec/jobs/clean_up_redis_keys_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+describe Jobs::CleanUpRedisKeys do
+  let(:redis) { $redis.without_namespace }
+
+  before do
+    @multisite = Rails.configuration.multisite
+    Rails.configuration.multisite = true
+  end
+
+  after do
+    Rails.configuration.multisite = @multisite
+  end
+
+  it 'should clean up the right keys' do
+    active_keys = [
+      '__mb_backlog_id_n_/users/someusername$|$default',
+      'default:user-last-seen:607',
+      'sidekiq:something:do:something',
+      'somekeytonotbetouched'
+    ]
+
+    orphan_keys = [
+      'tgxworld:user-last-seen:607',
+      '__mb_backlog_id_n_/users/someusername$|$tgxworld'
+    ]
+
+    (active_keys | orphan_keys).each do |key|
+      redis.set(key, 1)
+    end
+
+    described_class.new.execute({})
+
+    active_keys.each do |key|
+      expect(redis.get(key)).to eq('1')
+    end
+
+    orphan_keys.each do |key|
+      expect(redis.get(key)).to eq(nil)
+    end
+  end
+end


### PR DESCRIPTION
@SamSaffron Can you review this? Thank you!

I feel like MessageBus needs to have a TTL on all the keys that it sets such that keys don't stay in the db forever.