### PR TITLE
FIX uploadLocation when window.location.port is empty

### DIFF
--- a/app/assets/javascripts/discourse/lib/utilities.js.es6
+++ b/app/assets/javascripts/discourse/lib/utilities.js.es6
@@ -244,7 +244,7 @@ export function uploadLocation(url) {
   } else {
     var protocol = window.location.protocol + '//',
       hostname = window.location.hostname,
-      port = ':' + window.location.port;
+      port = window.location.port ? ':' + window.location.port : '';
     return protocol + hostname + port + url;
   }
 }


### PR DESCRIPTION
More information available: https://meta.discourse.org/t/uploaded-video-are-not-embedded-and-display-a-link/53346