### PR TITLE
FEATURE: Hide Profile Text from non-staff if user is suspended

### DIFF
--- a/app/assets/javascripts/discourse/controllers/user.js.es6
+++ b/app/assets/javascripts/discourse/controllers/user.js.es6
@@ -25,6 +25,11 @@ export default Ember.Controller.extend(CanCheckEmails, {
     return (!indexStream || viewingSelf) && !forceExpand;
   },
 
+  @computed('model.isSuspended', 'currentUser.staff')
+  isNotSuspendedOrIsStaff(isSuspended, isStaff) {
+    return !isSuspended || isStaff;
+  },
+
   linkWebsite: Em.computed.not('model.isBasic'),
 
   @computed("model.trust_level")

--- a/app/assets/javascripts/discourse/templates/user.hbs
+++ b/app/assets/javascripts/discourse/templates/user.hbs
@@ -86,7 +86,9 @@
                   <b>{{i18n 'user.suspended_reason'}}</b> {{model.suspend_reason}}
                 </div>
               {{/if}}
-              {{{model.bio_cooked}}}
+              {{#if isNotSuspendedOrIsStaff}}
+                {{{model.bio_cooked}}}
+              {{/if}}
             </div>
 
             {{#if publicUserFields}}


### PR DESCRIPTION
Relevant discussion
https://meta.discourse.org/t/hide-about-me-for-suspended-users/53383