### PR TITLE
fix: adminPlugins:index route is missing

### DIFF
--- a/app/assets/javascripts/admin/routes/admin-route-map.js.es6
+++ b/app/assets/javascripts/admin/routes/admin-route-map.js.es6
@@ -83,6 +83,8 @@ export default function() {
       this.route('show', { path: '/:badge_id' });
     });
 
-    this.route('adminPlugins', { path: '/plugins', resetNamespace: true });
+    this.route('adminPlugins', { path: '/plugins', resetNamespace: true }, function() {
+      this.route('index', { path: '/' });
+    });
   });
 };


### PR DESCRIPTION
I am not sure about is this exact solution or not. I just tried and it's fixing me the below error

https://meta.discourse.org/t/admin-plugin-page-is-blank-error-there-is-no-route-named-adminplugins-index/53550