### PR TITLE
UX: Remove !important from header .discourse-tag

### DIFF
--- a/app/assets/stylesheets/common/base/tagging.scss
+++ b/app/assets/stylesheets/common/base/tagging.scss
@@ -136,7 +136,7 @@ $tag-color: scale-color($primary, $lightness: 40%);
   top: -0.1em;
 }
 
-header .discourse-tag {color: $tag-color !important; }
+header .discourse-tag {color: $tag-color }
 
 .list-tags {
   display: inline;


### PR DESCRIPTION
per https://meta.discourse.org/t/planned-tag-color-issue-when-scrolled-down/53582/4?u=cpradio