### PR TITLE
RTL direction assigned to Urdu language

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -135,7 +135,7 @@ module ApplicationHelper
   end
 
   def rtl?
-    ["ar", "fa_IR", "he"].include? I18n.locale.to_s
+    ["ar", "ur", "fa_IR", "he"].include? I18n.locale.to_s
   end
 
   def user_locale


### PR DESCRIPTION
An array of RTL languages is present in two places, one in the RTL model class and the other in the application helper class. Previously, Urdu was only added in the RTL model class which was not taking affect on the interface. This PR should fix it.