### PR TITLE
mailcatcher dependency added for dev environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -152,6 +152,7 @@ group :development do
   gem 'binding_of_caller'
   gem 'annotate'
   gem 'foreman', require: false
+  gem 'mailcatcher'
 end
 
 # this is an optional gem, it provides a high performance replacement

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,6 +120,8 @@ GEM
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     guess_html_encoding (0.0.11)
+    haml (4.0.7)
+      tilt
     hashie (3.4.4)
     highline (1.7.8)
     hiredis (0.6.1)
@@ -152,6 +154,16 @@ GEM
     lru_redux (1.1.0)
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
+    mailcatcher (0.2.4)
+      eventmachine
+      haml
+      i18n
+      json
+      mail
+      sinatra
+      skinny (>= 0.1.2)
+      sqlite3-ruby
+      thin
     memory_profiler (0.9.6)
     message_bus (2.0.2)
       rack (>= 1.1.3)
@@ -360,6 +372,9 @@ GEM
       rack (~> 1.4)
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
+    skinny (0.2.2)
+      eventmachine (~> 1.0)
+      thin
     slop (3.6.0)
     sorcerer (1.0.2)
     spork (1.0.0rc4)
@@ -373,6 +388,9 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    sqlite3 (1.3.12)
+    sqlite3-ruby (1.3.3)
+      sqlite3 (>= 1.3.3)
     stackprof (0.2.10)
     thin (1.7.0)
       daemons (~> 1.0, >= 1.0.9)
@@ -434,6 +452,7 @@ DEPENDENCIES
   logster
   lru_redux
   mail
+  mailcatcher
   memory_profiler
   message_bus
   mime-types

--- a/bin/docker/mailcatcher
+++ b/bin/docker/mailcatcher
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-CMD="mailcatcher --http-ip 0.0.0.0 -f || (apt-get install -y libsqlite3-dev && gem install mailcatcher && mailcatcher --http-ip 0.0.0.0 -f)"
+CMD="mailcatcher --http-ip 0.0.0.0 -f"
 docker exec -it discourse_dev /bin/bash -c "$CMD"


### PR DESCRIPTION
In reference to the https://github.com/discourse/discourse_docker/pull/317 the gem is added in the Gemfile and inline install command cleaned up from the mailcatcher binstub.