### PR TITLE
Removed the fallback mailcatcher install command

### DIFF
--- a/bin/docker/mailcatcher
+++ b/bin/docker/mailcatcher
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-CMD="mailcatcher --http-ip 0.0.0.0 -f || (apt-get install -y libsqlite3-dev && gem install mailcatcher && mailcatcher --http-ip 0.0.0.0 -f)"
+CMD="mailcatcher --http-ip 0.0.0.0 -f"
 docker exec -it discourse_dev /bin/bash -c "$CMD"


### PR DESCRIPTION
Since `apt-get install -y libsqlite3-dev && gem install mailcatcher` is now part of the Docker dev image, this fallback installation command is not needed.