### PR TITLE
FIX: Only quote `.cooked` text.

### DIFF
--- a/app/assets/javascripts/discourse/components/quote-button.js.es6
+++ b/app/assets/javascripts/discourse/components/quote-button.js.es6
@@ -28,6 +28,9 @@ export default Ember.Component.extend({
     let firstRange, postId;
     for (let r = 0; r < selection.rangeCount; r++) {
       const range = selection.getRangeAt(r);
+
+      if ($(range.endContainer).closest('.cooked').length === 0) return;
+
       const $ancestor = $(range.commonAncestorContainer);
 
       firstRange = firstRange || range;


### PR DESCRIPTION
@ZogStriP Can I check if there are any scenarios where we might be quoting text outside `.cooked`? I'm worried that I might be introducing a regression here. Thank you!