### PR TITLE
Return user_fields and custom_fields on directory_items api call.

### DIFF
--- a/app/serializers/user_name_serializer.rb
+++ b/app/serializers/user_name_serializer.rb
@@ -1,3 +1,3 @@
 class UserNameSerializer < BasicUserSerializer
-  attributes :name, :title
+  attributes :name, :title, :custom_fields, :user_fields
 end


### PR DESCRIPTION
The goal here was to address the request to have custom fields in the user directory: https://meta.discourse.org/t/can-we-display-custom-fields-in-user-directory-list/35506.  

Added user_fields and custom_fields to the user_name_serializer.
This results in the directory_items api call returning the fields,
which allows us to easily include custom fields in the user directory
by lightly customizing some html if we anyone so desires.