### PR TITLE
Fix Arabic Pluralization Rules for Client

### DIFF
--- a/app/assets/javascripts/locales/ar.js.erb
+++ b/app/assets/javascripts/locales/ar.js.erb
@@ -7,6 +7,6 @@ I18n.pluralizationRules['ar'] = function (n) {
   if (n == 1) return "one";
   if (n == 2) return "two";
   if (n%100 >= 3 && n%100 <= 10) return "few";
-  if (n%100 >= 11) return "many";
+  if (n%100 >= 11 && n%100 <= 99) return "many";
   return "other";
 };


### PR DESCRIPTION
According to [Language Plural Rules](http://www.unicode.org/cldr/charts/29/supplemental/language_plural_rules.html#ar) this how `many` should be calculated.