### PR TITLE
Tweak avatar UI on topic list

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -209,7 +209,7 @@ GEM
     omniauth-twitter (1.2.1)
       json (~> 1.3)
       omniauth-oauth (~> 1.1)
-    onebox (1.6.5)
+    onebox (1.6.7)
       fast_blank (>= 1.0.0)
       htmlentities (~> 4.3.4)
       moneta (~> 0.8)

--- a/app/assets/stylesheets/desktop/topic-list.scss
+++ b/app/assets/stylesheets/desktop/topic-list.scss
@@ -100,17 +100,11 @@
       &:last-of-type {
         margin-right: 0;
       }
+      .avatar:not(.latest) {
+        opacity: 0.3;
+      }
     }
   }
-
-  .posters a:first-child .avatar.latest:not(.single) {
-     box-shadow: 0 0 3px 1px desaturate(scale-color($tertiary, $lightness: 65%), 35%);
-     border: 2px solid desaturate(scale-color($tertiary, $lightness: 50%), 40%);
-     position: relative;
-     top: -2px;
-     left: -2px;
-  }
-
 
   .sortable {
     cursor: pointer;

--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -218,6 +218,9 @@ class SessionController < ApplicationController
     RateLimiter.new(nil, "forgot-password-hr-#{request.remote_ip}", 6, 1.hour).performed!
     RateLimiter.new(nil, "forgot-password-min-#{request.remote_ip}", 3, 1.minute).performed!
 
+    RateLimiter.new(nil, "forgot-password-login-hour-#{params[:login].to_s[0..100]}", 12, 1.hour).performed!
+    RateLimiter.new(nil, "forgot-password-login-min-#{params[:login].to_s[0..100]}", 3, 1.minute).performed!
+
     user = User.find_by_username_or_email(params[:login])
     user_presence = user.present? && user.id != Discourse::SYSTEM_USER_ID && !user.staged
     if user_presence

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -4,6 +4,9 @@ class UploadsController < ApplicationController
 
   def create
     type = params.require(:type)
+
+    raise Discourse::InvalidAccess.new unless type =~ /^[a-z\-\_]{1,100}$/
+
     file = params[:file] || params[:files].try(:first)
     url = params[:url]
     client_id = params[:client_id]
@@ -73,6 +76,7 @@ class UploadsController < ApplicationController
       # convert pasted images to HQ jpegs
       if filename == "blob.png" && SiteSetting.convert_pasted_images_to_hq_jpg
         jpeg_path = "#{File.dirname(tempfile.path)}/blob.jpg"
+        OptimizedImage.ensure_safe_paths!(tempfile.path, jpeg_path)
         `convert #{tempfile.path} -quality #{SiteSetting.convert_pasted_images_quality} #{jpeg_path}`
         # only change the format of the image when JPG is at least 5% smaller
         if File.size(jpeg_path) < File.size(tempfile.path) * 0.95

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -241,19 +241,35 @@ module ApplicationHelper
     MobileDetection.mobile_device?(request.user_agent)
   end
 
+  NO_CUSTOM = "no_custom".freeze
+  NO_PLUGINS = "no_plugins".freeze
+  ONLY_OFFICIAL = "only_official".freeze
+  SAFE_MODE = "safe_mode".freeze
+
   def customization_disabled?
-    safe_mode = params["safe_mode"]
-    session[:disable_customization] || (safe_mode && safe_mode.include?("no_custom"))
+    safe_mode = params[SAFE_MODE]
+    session[:disable_customization] || (safe_mode && safe_mode.include?(NO_CUSTOM))
   end
 
   def allow_plugins?
-    safe_mode = params["safe_mode"]
-    !(safe_mode && safe_mode.include?("no_plugins"))
+    safe_mode = params[SAFE_MODE]
+    !(safe_mode && safe_mode.include?(NO_PLUGINS))
   end
 
   def allow_third_party_plugins?
-    safe_mode = params["safe_mode"]
-    !(safe_mode && (safe_mode.include?("no_plugins") || safe_mode.include?("only_official")))
+    safe_mode = params[SAFE_MODE]
+    !(safe_mode && (safe_mode.include?(NO_PLUGINS) || safe_mode.include?(ONLY_OFFICIAL)))
+  end
+
+  def normalized_safe_mode
+    mode_string = params["safe_mode"]
+    safe_mode = nil
+    (safe_mode ||= []) << NO_CUSTOM if mode_string.include?(NO_CUSTOM)
+    (safe_mode ||= []) << NO_PLUGINS if mode_string.include?(NO_PLUGINS)
+    (safe_mode ||= []) << ONLY_OFFICIAL if mode_string.include?(ONLY_OFFICIAL)
+    if safe_mode
+      safe_mode.join(",").html_safe
+    end
   end
 
   def loading_admin?

--- a/app/models/optimized_image.rb
+++ b/app/models/optimized_image.rb
@@ -97,7 +97,24 @@ class OptimizedImage < ActiveRecord::Base
    !(url =~ /^(https?:)?\/\//)
   end
 
+  def self.safe_path?(path)
+    # this matches instructions which call #to_s
+    path = path.to_s
+    return false if path != File.expand_path(path)
+    return false if path !~ /\A[_\-a-zA-Z0-9\.\/]+\z/m
+    true
+  end
+
+  def self.ensure_safe_paths!(*paths)
+    paths.each do |path|
+      raise Discourse::InvalidAccess unless safe_path?(path)
+    end
+  end
+
+
   def self.resize_instructions(from, to, dimensions, opts={})
+    ensure_safe_paths!(from, to)
+
     # NOTE: ORDER is important!
     %W{
       convert
@@ -115,6 +132,8 @@ class OptimizedImage < ActiveRecord::Base
   end
 
   def self.resize_instructions_animated(from, to, dimensions, opts={})
+    ensure_safe_paths!(from, to)
+
     %W{
       gifsicle
       --colors=256
@@ -126,6 +145,8 @@ class OptimizedImage < ActiveRecord::Base
   end
 
   def self.crop_instructions(from, to, dimensions, opts={})
+    ensure_safe_paths!(from, to)
+
     %W{
       convert
       #{from}[0]
@@ -141,6 +162,8 @@ class OptimizedImage < ActiveRecord::Base
   end
 
   def self.crop_instructions_animated(from, to, dimensions, opts={})
+    ensure_safe_paths!(from, to)
+
     %W{
       gifsicle
       --crop 0,0+#{dimensions}
@@ -152,6 +175,8 @@ class OptimizedImage < ActiveRecord::Base
   end
 
   def self.downsize_instructions(from, to, dimensions, opts={})
+    ensure_safe_paths!(from, to)
+
     %W{
       convert
       #{from}[0]

--- a/app/views/common/_discourse_javascript.html.erb
+++ b/app/views/common/_discourse_javascript.html.erb
@@ -53,7 +53,7 @@
     Discourse.set('assetVersion','<%= Discourse.assets_digest %>');
     Discourse.Session.currentProp("disableCustomCSS", <%= loading_admin? %>);
     <%- if params["safe_mode"] %>
-        Discourse.Session.currentProp("safe_mode", <%= params["safe_mode"].inspect.html_safe %>);
+        Discourse.Session.currentProp("safe_mode", <%= normalized_safe_mode.inspect.html_safe %>);
     <%- end %>
     Discourse.HighlightJSPath = <%= HighlightJs.path.inspect.html_safe %>;
     <%- if SiteSetting.enable_s3_uploads %>

--- a/app/views/users/password_reset.html.erb
+++ b/app/views/users/password_reset.html.erb
@@ -49,6 +49,7 @@
 </div>
 
 <%- content_for(:no_ember_head) do %>
+  <meta name="referrer" content="never">
   <%= script "ember_jquery" %>
   <%= render_google_universal_analytics_code %>
 <%- end %>

--- a/spec/controllers/uploads_controller_spec.rb
+++ b/spec/controllers/uploads_controller_spec.rb
@@ -33,6 +33,20 @@ describe UploadsController do
         })
       end
 
+      it 'fails if type is invalid' do
+        xhr :post, :create, file: logo, type: "invalid type cause has space"
+        expect(response.status).to eq 403
+
+        xhr :post, :create, file: logo, type: "\\invalid"
+        expect(response.status).to eq 403
+
+        xhr :post, :create, file: logo, type: "invalid."
+        expect(response.status).to eq 403
+
+        xhr :post, :create, file: logo, type: "toolong"*100
+        expect(response.status).to eq 403
+      end
+
       it 'is successful with an image' do
         Jobs.expects(:enqueue).with(:create_thumbnails, anything)
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -237,6 +237,18 @@ describe UsersController do
     end
 
     context 'valid token' do
+      context 'when rendered' do
+        render_views
+
+        it 'renders referrer never on get requests' do
+          user = Fabricate(:user, auth_token: SecureRandom.hex(16))
+          token = user.email_tokens.create(email: user.email).token
+          get :password_reset, token: token
+
+          expect(response.body).to include('<meta name="referrer" content="never">')
+        end
+      end
+
       it 'returns success' do
         user = Fabricate(:user, auth_token: SecureRandom.hex(16))
         token = user.email_tokens.create(email: user.email).token

--- a/spec/models/optimized_image_spec.rb
+++ b/spec/models/optimized_image_spec.rb
@@ -5,6 +5,38 @@ describe OptimizedImage do
   let(:upload) { build(:upload) }
   before { upload.id = 42 }
 
+  describe ".safe_path?" do
+
+    it "correctly detects unsafe paths" do
+      expect(OptimizedImage.safe_path?("/path/A-AA/22_00.TIFF")).to eq(true)
+      expect(OptimizedImage.safe_path?("/path/AAA/2200.TIFF")).to eq(true)
+      expect(OptimizedImage.safe_path?("/tmp/a.png")).to eq(true)
+      expect(OptimizedImage.safe_path?("../a.png")).to eq(false)
+      expect(OptimizedImage.safe_path?("/tmp/a.png\\test")).to eq(false)
+      expect(OptimizedImage.safe_path?("/tmp/a.png\\test")).to eq(false)
+      expect(OptimizedImage.safe_path?("/path/\u1000.png")).to eq(false)
+      expect(OptimizedImage.safe_path?("/path/x.png\n")).to eq(false)
+      expect(OptimizedImage.safe_path?("/path/x.png\ny.png")).to eq(false)
+      expect(OptimizedImage.safe_path?("/path/x.png y.png")).to eq(false)
+      expect(OptimizedImage.safe_path?(nil)).to eq(false)
+    end
+
+  end
+
+  describe "ensure_safe_paths!" do
+    it "raises nothing on safe paths" do
+      expect {
+        OptimizedImage.ensure_safe_paths!("/a.png", "/b.png")
+      }.not_to raise_error
+    end
+
+    it "raises nothing on paths" do
+      expect {
+        OptimizedImage.ensure_safe_paths!("/a.png", "/b.png", "c.png")
+      }.to raise_error(Discourse::InvalidAccess)
+    end
+  end
+
   describe ".local?" do
 
     def local(url)


### PR DESCRIPTION
Of the avatars shown, make any previous posters semi-transparent, so only the latest poster is shown prominently. Previously, if the first avatar was the latest poster to the topic, a blue border was used as a highlight around the avatar. This is no longer necessary. Overall the topic list page looks less "busy" after this change.

![discourse-topic-list-avatars-tweak](https://cloud.githubusercontent.com/assets/930131/21292648/37368d22-c571-11e6-844b-ce2ac69ef165.jpg)
