### PR TITLE
Revert "Don't vacuum for a long time until we fix it"

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1214,7 +1214,7 @@ uncategorized:
 
   disable_edit_notifications: false
 
-  vacuum_db_days: 9000
+  vacuum_db_days: 90
   last_vacuum:
     default: 0
     hidden: true


### PR DESCRIPTION
This reverts commit 88712bc5480eb8977ee7923e43f6b20faad38ffa.

We're no long running `VACUUM FULL` and is running a much safer `VACUUM ANALYZE` instead.