### PR TITLE
Tweak avatar UI on topic list

### DIFF
--- a/app/assets/stylesheets/desktop/topic-list.scss
+++ b/app/assets/stylesheets/desktop/topic-list.scss
@@ -100,17 +100,11 @@
       &:last-of-type {
         margin-right: 0;
       }
+      .avatar:not(.latest) {
+        opacity: 0.3;
+      }
     }
   }
-
-  .posters a:first-child .avatar.latest:not(.single) {
-     box-shadow: 0 0 3px 1px desaturate(scale-color($tertiary, $lightness: 65%), 35%);
-     border: 2px solid desaturate(scale-color($tertiary, $lightness: 50%), 40%);
-     position: relative;
-     top: -2px;
-     left: -2px;
-  }
-
 
   .sortable {
     cursor: pointer;

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -977,7 +977,6 @@ en:
     prioritize_username_in_ux: "Show username first on user page, user card and posts (when disabled name is shown first)"
 
     email_token_valid_hours: "Forgot password / activate account tokens are valid for (n) hours."
-    email_token_grace_period_hours: "Forgot password / activate account tokens are still valid for a grace period of (n) hours after being redeemed."
 
     enable_badges: "Enable the badge system"
     enable_whispers: "Allow staff private communication within topics."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -389,7 +389,6 @@ users:
   email_token_valid_hours:
     default: 48
     min: 1
-  email_token_grace_period_hours: 0
   purge_unactivated_users_grace_period_days: 14
   public_user_custom_fields:
     type: list

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -266,6 +266,19 @@ describe UsersController do
         expect(session["password-#{token}"]).to be_blank
       end
 
+      it 'disallows double password reset' do
+
+        user = Fabricate(:user, auth_token: SecureRandom.hex(16))
+        token = user.email_tokens.create(email: user.email).token
+
+        get :password_reset, token: token
+        put :password_reset, token: token, password: 'hg9ow8yhg98o'
+        put :password_reset, token: token, password: 'test123123Asdfsdf'
+
+        user.reload
+        expect(user.confirm_password?('hg9ow8yhg98o')).to eq(true)
+      end
+
       it "redirects to the wizard if you're the first admin" do
         user = Fabricate(:admin, auth_token: SecureRandom.hex(16), auth_token_updated_at: Time.now)
         token = user.email_tokens.create(email: user.email).token

--- a/spec/models/email_token_spec.rb
+++ b/spec/models/email_token_spec.rb
@@ -90,16 +90,6 @@ describe EmailToken do
         expect(user.send_welcome_message).to eq true
       end
 
-      context "when using the code a second time" do
-
-        it "doesn't send the welcome message" do
-          SiteSetting.email_token_grace_period_hours = 1
-          EmailToken.confirm(email_token.token)
-          user = EmailToken.confirm(email_token.token)
-          expect(user.send_welcome_message).to eq false
-        end
-      end
-
     end
 
     context 'success' do
@@ -120,13 +110,7 @@ describe EmailToken do
         expect(email_token).to be_confirmed
       end
 
-      it "can be confirmed again" do
-        EmailToken.stubs(:confirm_valid_after).returns(1.hour.ago)
-
-        expect(EmailToken.confirm(email_token.token)).to eq user
-
-        # Unless `confirm_valid_after` has passed
-        EmailToken.stubs(:confirm_valid_after).returns(1.hour.from_now)
+      it "will not confirm again" do
         expect(EmailToken.confirm(email_token.token)).to be_blank
       end
     end


### PR DESCRIPTION
Of the avatars shown, make any previous posters semi-transparent, so only the latest poster is shown prominently. Previously, if the first avatar was the latest poster to the topic, a blue border was used as a highlight around the avatar. This is no longer necessary. Overall the topic list page looks less "busy" after this change.

![discourse-topic-list-avatars-tweak](https://cloud.githubusercontent.com/assets/930131/21292648/37368d22-c571-11e6-844b-ce2ac69ef165.jpg)