### PR TITLE
Tweak avatar UI on topic list

### DIFF
--- a/app/assets/stylesheets/desktop/topic-list.scss
+++ b/app/assets/stylesheets/desktop/topic-list.scss
@@ -100,17 +100,11 @@
       &:last-of-type {
         margin-right: 0;
       }
+      .avatar:not(.latest) {
+        opacity: 0.3;
+      }
     }
   }
-
-  .posters a:first-child .avatar.latest:not(.single) {
-     box-shadow: 0 0 3px 1px desaturate(scale-color($tertiary, $lightness: 65%), 35%);
-     border: 2px solid desaturate(scale-color($tertiary, $lightness: 50%), 40%);
-     position: relative;
-     top: -2px;
-     left: -2px;
-  }
-
 
   .sortable {
     cursor: pointer;


### PR DESCRIPTION
Of the avatars shown, make any previous posters semi-transparent, so only the latest poster is shown prominently. Previously, if the first avatar was the latest poster to the topic, a blue border was used as a highlight around the avatar. This is no longer necessary. Overall the topic list page looks less "busy" after this change.

![discourse-topic-list-avatars-tweak](https://cloud.githubusercontent.com/assets/930131/21292648/37368d22-c571-11e6-844b-ce2ac69ef165.jpg)