### PR TITLE
Fix: Forced trailing slash on messageBus.baseUrl

### DIFF
--- a/app/assets/javascripts/discourse/initializers/message-bus.js.es6
+++ b/app/assets/javascripts/discourse/initializers/message-bus.js.es6
@@ -29,7 +29,7 @@ export default {
 
     messageBus.callbackInterval = siteSettings.anon_polling_interval;
     messageBus.backgroundCallbackInterval = siteSettings.background_polling_interval;
-    messageBus.baseUrl = siteSettings.long_polling_base_url;
+    messageBus.baseUrl = siteSettings.long_polling_base_url.replace(/\/$/, '') + '/';
 
     if (messageBus.baseUrl !== '/') {
       // zepto compatible, 1 param only


### PR DESCRIPTION
If the `long polling base url` setting doesn't have a trailing slash then the message bus will make requests to the wrong path.

This simply ensures there's a trailing slash on the Message Bus base URL.