### PR TITLE
Resolve raw templates in 'javascripts/mobile' and 'javascripts' on mobile

### DIFF
--- a/app/assets/javascripts/discourse/lib/raw-templates.js.es6
+++ b/app/assets/javascripts/discourse/lib/raw-templates.js.es6
@@ -2,7 +2,9 @@ import { getResolverOption } from 'discourse-common/resolver';
 
 export function findRawTemplate(name) {
   if (getResolverOption('mobileView')) {
-    return Discourse.RAW_TEMPLATES[`mobile/${name}`] ||
+    return Discourse.RAW_TEMPLATES[`javascripts/mobile/${name}`] ||
+           Discourse.RAW_TEMPLATES[`javascripts/${name}`] ||
+           Discourse.RAW_TEMPLATES[`mobile/${name}`] ||
            Discourse.RAW_TEMPLATES[name];
   }
 


### PR DESCRIPTION
Further to [this discussion](https://meta.discourse.org/t/upgrading-ember-to-2-10/52724/69?u=angus), the same changes need to be made for mobile raw templates.

I've added both ``javascripts/mobile`` and ``javascripts`` as options as some raw mobile templates reference raw non-mobile templates, [see e.g.](https://github.com/angusmcleod/discourse-topic-previews/blob/master/assets/javascripts/discourse/templates/mobile/list/topic-list-item.raw.hbs) 