### PR TITLE
FEATURE: Append tags bulk action for topics

### DIFF
--- a/app/assets/javascripts/discourse/controllers/topic-bulk-actions.js.es6
+++ b/app/assets/javascripts/discourse/controllers/topic-bulk-actions.js.es6
@@ -15,6 +15,7 @@ addBulkButton('showNotificationLevel', 'notification_level');
 addBulkButton('resetRead', 'reset_read');
 addBulkButton('unlistTopics', 'unlist_topics');
 addBulkButton('showTagTopics', 'change_tags');
+addBulkButton('showAppendTagTopics', 'append_tags');
 
 // Modal for performing bulk actions on topics
 export default Ember.Controller.extend(ModalFunctionality, {
@@ -78,11 +79,26 @@ export default Ember.Controller.extend(ModalFunctionality, {
   actions: {
     showTagTopics() {
       this.set('tags', '');
+      this.set('action', 'changeTags');
+      this.set('label', 'change_tags');
+      this.set('title', 'choose_new_tags');
       this.send('changeBulkTemplate', 'bulk-tag');
     },
 
     changeTags() {
       this.performAndRefresh({type: 'change_tags', tags: this.get('tags')});
+    },
+
+    showAppendTagTopics() {
+      this.set('tags', '');
+      this.set('action', 'appendTags');
+      this.set('label', 'append_tags');
+      this.set('title', 'choose_append_tags');
+      this.send('changeBulkTemplate', 'bulk-tag');
+    },
+
+    appendTags() {
+      this.performAndRefresh({type: 'append_tags', tags: this.get('tags')});
     },
 
     showChangeCategory() {

--- a/app/assets/javascripts/discourse/templates/bulk-tag.hbs
+++ b/app/assets/javascripts/discourse/templates/bulk-tag.hbs
@@ -1,5 +1,5 @@
-<p>{{i18n "topics.bulk.choose_new_tags"}}</p>
+<p>{{i18n (concat "topics.bulk." title)}}</p>
 
 <p>{{tag-chooser tags=tags categoryId=categoryId}}</p>
 
-{{d-button action="changeTags" disabled=emptyTags label="topics.bulk.change_tags"}}
+{{d-button action=action disabled=emptyTags label=(concat "topics.bulk." label)}}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1362,8 +1362,10 @@ en:
         selected:
           one: "You have selected <b>1</b> topic."
           other: "You have selected <b>{{count}}</b> topics."
-        change_tags: "Change Tags"
+        change_tags: "Replace Tags"
+        append_tags: "Append Tags"
         choose_new_tags: "Choose new tags for these topics:"
+        choose_append_tags: "Choose new tags to append for these topics:"
         changed_tags: "The tags of those topics were changed."
 
       none:

--- a/lib/discourse_tagging.rb
+++ b/lib/discourse_tagging.rb
@@ -4,7 +4,7 @@ module DiscourseTagging
   TAGS_FILTER_REGEXP = /[\/\?#\[\]@!\$&'\(\)\*\+,;=\.%\\`^\s|\{\}"<>]+/ # /?#[]@!$&'()*+,;=.%\`^|{}"<>
 
 
-  def self.tag_topic_by_names(topic, guardian, tag_names_arg)
+  def self.tag_topic_by_names(topic, guardian, tag_names_arg, append=false)
     if SiteSetting.tagging_enabled
       tag_names = DiscourseTagging.tags_for_saving(tag_names_arg, guardian) || []
 
@@ -29,6 +29,7 @@ module DiscourseTagging
 
       if tag_names.present?
         category = topic.category
+        tag_names = tag_names + old_tag_names if append
 
         # guardian is explicitly nil cause we don't want to strip all
         # staff tags that already passed validation

--- a/lib/topics_bulk_action.rb
+++ b/lib/topics_bulk_action.rb
@@ -11,7 +11,7 @@ class TopicsBulkAction
   def self.operations
     @operations ||= %w(change_category close archive change_notification_level
                        reset_read dismiss_posts delete unlist archive_messages
-                       move_messages_to_inbox change_tags)
+                       move_messages_to_inbox change_tags append_tags)
   end
 
   def self.register_operation(name, &block)
@@ -142,6 +142,20 @@ class TopicsBulkAction
             t.tags = []
           end
           @changed_ids << t.id
+        end
+      end
+    end
+
+    def append_tags
+      tags = @operation[:tags]
+      tags = DiscourseTagging.tags_for_saving(tags, guardian) if tags.present?
+
+      topics.each do |t|
+        if guardian.can_edit?(t)
+          if tags.present?
+            DiscourseTagging.tag_topic_by_names(t, guardian, tags, append=true)
+          end
+        @changed_ids << t.id
         end
       end
     end


### PR DESCRIPTION
Related meta forum topic: https://meta.discourse.org/t/bulk-actions-add-tags-in-addition-to-change-tags/40059

I added new button for appending tags to topics in bulk action and renamed old button to replace tags as suggested in https://meta.discourse.org/t/multi-select-change-tags-breaks-stuff/43727/6
