### PR TITLE
FIX: Add missing translation for Settings category 'groups'

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3221,6 +3221,7 @@ en:
           user_preferences: "User Preferences"
           tags: "Tags"
           search: "Search"
+          groups: "Groups"
 
       badges:
         title: Badges


### PR DESCRIPTION
Report: https://meta.discourse.org/t/missing-translate-enable-group-directory/54767?u=claas