### PR TITLE
FIX: Let skip_validations bypass guardian at post creation

### DIFF
--- a/lib/post_creator.rb
+++ b/lib/post_creator.rb
@@ -108,7 +108,7 @@ class PostCreator
       return false unless skip_validations? || validate_child(topic_creator)
     else
       @topic = Topic.find_by(id: @opts[:topic_id])
-      if (@topic.blank? || !guardian.can_create?(Post, @topic))
+      if (@topic.blank? || (!guardian.can_create?(Post, @topic) && !skip_validations?))
         errors[:base] << I18n.t(:topic_not_found)
         return false
       end


### PR DESCRIPTION
https://meta.discourse.org/t/guardian-bypassed-through-skip-validations-in-topiccreator-but-not-in-postcreator/55341