### PR TITLE
Display tabs with smaller widths for code blocks

### DIFF
--- a/app/assets/stylesheets/common/foundation/base.scss
+++ b/app/assets/stylesheets/common/foundation/base.scss
@@ -85,6 +85,7 @@ fieldset {
 
 pre code {
   overflow: auto;
+  tab-size: 4;
 }
 
 // TODO figure out a clean place to put stuff like this


### PR DESCRIPTION
This small CSS edit changes the browser behavior regarding displaying of tab characters in embedded code blocks. The normal browser behavior is to display a tab character with 8 corresponding characters, which is often way too wide when reading code. This edit changes this behavior to 4 corresponding characters.

For browser support, see this article on MDN:
https://developer.mozilla.org/en-US/docs/Web/CSS/tab-size

For browsers that not support this CSS property (mainly IE), the default width of 8 characters is used.