### PR TITLE
make unknown routes do server-side refresh

### DIFF
--- a/app/assets/javascripts/discourse/lib/url.js.es6
+++ b/app/assets/javascripts/discourse/lib/url.js.es6
@@ -316,12 +316,7 @@ const DiscourseURL = Ember.Object.extend({
 
     const router = this.get('router');
 
-    if (opts.replaceURL) {
-      this.replaceState(path);
-    } else {
-      router.router.updateURL(path);
-    }
-
+    const fullpath = path;
     const split = path.split('#');
     let elementId;
 
@@ -332,6 +327,20 @@ const DiscourseURL = Ember.Object.extend({
 
     const transition = router.handleURL(path);
     transition._discourse_intercepted = true;
+
+    if (transition.targetName == "unknown")
+    {
+      transition.abort();
+      document.location = fullpath;
+      return;
+    }
+
+    if (opts.replaceURL) {
+      this.replaceState(path);
+    } else {
+      router.router.updateURL(path);
+    }
+
     const promise = transition.promise || transition;
     promise.then(() => jumpToElement(elementId));
   }

--- a/app/assets/javascripts/discourse/lib/url.js.es6
+++ b/app/assets/javascripts/discourse/lib/url.js.es6
@@ -328,7 +328,7 @@ const DiscourseURL = Ember.Object.extend({
     const transition = router.handleURL(path);
     transition._discourse_intercepted = true;
 
-    if (transition.targetName == "unknown")
+    if (transition.targetName === "unknown")
     {
       transition.abort();
       document.location = fullpath;


### PR DESCRIPTION
There are URLs that are known to the Rails backend or HTTP server but
not known to the Ember.js router. Since the Rails backend can return a
404 page just as well as Ember.js, lets default to always trying to
query the backend if the Ember.js router would have shown a 404 page
with the "unknown" route.

This should address some of the concerns in posts like:

  https://meta.discourse.org/t/left-clicking-raw-links-return-404-errors/31314/7
  https://meta.discourse.org/t/left-clicking-same-domain-links-to-urls-not-on-the-whitelist-is-broken/54722

It is still necessary to leave in the SERVER_SIDE_ONLY routes, because
there are some routes that are prefixed by valid Ember.js routes, and
we want to short-circuit the Ember.js router in those cases, because
it will think that the path is to a route when it should be going to a
backend route. For example, a .rss route is simply a topic URL with
.rss added to the end. The Ember.js router recognizes this as a topic
URL even though it should be an RSS URL.