### PR TITLE
Bbpress missing display name

### DIFF
--- a/script/import_scripts/bbpress.rb
+++ b/script/import_scripts/bbpress.rb
@@ -84,7 +84,7 @@ class ImportScripts::Bbpress < ImportScripts::Base
           id: u["id"].to_i,
           username: u["user_nicename"],
           email: u["user_email"].downcase,
-          name: u["display_name"].length > 0 ? u["display_name"] : u['user_nicename'],
+          name: u["display_name"].presence || u['user_nicename'],
           created_at: u["user_registered"],
           website: u["user_url"],
           bio_raw: users_description[u["id"]],

--- a/script/import_scripts/bbpress.rb
+++ b/script/import_scripts/bbpress.rb
@@ -82,7 +82,7 @@ class ImportScripts::Bbpress < ImportScripts::Base
           id: u["id"].to_i,
           username: u["user_nicename"],
           email: u["user_email"].downcase,
-          name: u["display_name"],
+          name: u["display_name"].length > 0 ? u["display_name"] : u['user_nicename'],
           created_at: u["user_registered"],
           website: u["user_url"],
           bio_raw: users_description[u["id"]],


### PR DESCRIPTION
Apparently, sometimes display_names are missing. This patch uses user_nicename if there is no display_name.