### PR TITLE
escape censored words

### DIFF
--- a/lib/validators/censored_words_validator.rb
+++ b/lib/validators/censored_words_validator.rb
@@ -1,6 +1,6 @@
 class CensoredWordsValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    if !SiteSetting.censored_words.blank? && value =~ /#{escape_censored_words}/i
+    if !SiteSetting.censored_words.blank? && value.match(escape_censored_words)
       record.errors.add(
         attribute, :contains_censored_words,
         censored_words: SiteSetting.censored_words
@@ -16,12 +16,6 @@ class CensoredWordsValidator < ActiveModel::EachValidator
   private
 
   def escape_censored_words
-    # TODO escape with single slashes
-    SiteSetting.censored_words
-                              .gsub('*', '\*')
-                              .gsub(')', '\)')
-                              .gsub('(', '\(')
-                              .gsub('[', '\[')
-                              .gsub(']', '\]')
+    Regexp.new(SiteSetting.censored_words.split('|').map { |w| Regexp.escape(w) }.join('|'), true)
   end
 end

--- a/lib/validators/censored_words_validator.rb
+++ b/lib/validators/censored_words_validator.rb
@@ -1,6 +1,6 @@
 class CensoredWordsValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    if !SiteSetting.censored_words.blank? && value =~ /#{SiteSetting.censored_words}/i
+    if !SiteSetting.censored_words.blank? && value =~ /#{escape_censored_words}/i
       record.errors.add(
         attribute, :contains_censored_words,
         censored_words: SiteSetting.censored_words
@@ -11,5 +11,17 @@ class CensoredWordsValidator < ActiveModel::EachValidator
         censored_pattern: SiteSetting.censored_pattern
       )
     end
+  end
+
+  private
+
+  def escape_censored_words
+    # TODO escape with single slashes
+    SiteSetting.censored_words
+                              .gsub('*', '\*')
+                              .gsub(')', '\)')
+                              .gsub('(', '\(')
+                              .gsub('[', '\[')
+                              .gsub(']', '\]')
   end
 end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -493,7 +493,7 @@ describe Post do
       expect(Fabricate.build(:post, post_args)).to be_valid
     end
 
-    it 'treate blank posts as invalid' do
+    it 'create blank posts as invalid' do
       expect(Fabricate.build(:post, raw: "")).not_to be_valid
     end
   end

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -11,7 +11,7 @@ describe Topic do
     let(:topic) { Fabricate.build(:topic) }
 
     describe 'escape special characters in censored words' do
-      site_setting(:censored_words, 'coc*nut|co(onut|co[onut|co)onut|co]onut|coc-nut')
+      site_setting(:censored_words, 'co(onut')
 
       it 'is valid' do
         topic.title = 'I have a coconut'
@@ -20,13 +20,11 @@ describe Topic do
         expect(topic.errors.full_messages).to be_empty
       end
 
-      ['coc*nut', 'co(onut', 'co[onut', 'co)onut', 'co]onut', 'coc-nut'].each do |str|
-        it "#{str} is not valid" do
-          topic.title = "I have a #{str}"
+      it 'is not valid' do
+        topic.title = "I have a co(onut"
 
-          expect(topic).to_not be_valid
-          expect(topic.errors.full_messages.first).to include(I18n.t('errors.messages.contains_censored_words', censored_words: SiteSetting.censored_words))
-        end
+        expect(topic).to_not be_valid
+        expect(topic.errors.full_messages.first).to include(I18n.t('errors.messages.contains_censored_words', censored_words: SiteSetting.censored_words))
       end
     end
 

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -10,6 +10,26 @@ describe Topic do
   context 'validations' do
     let(:topic) { Fabricate.build(:topic) }
 
+    describe 'escape special characters in censored words' do
+      site_setting(:censored_words, 'coc*nut|co(onut|co[onut|co)onut|co]onut|coc-nut')
+
+      it 'is valid' do
+        topic.title = 'I have a coconut'
+
+        expect(topic).to be_valid
+        expect(topic.errors.full_messages).to be_empty
+      end
+
+      ['coc*nut', 'co(onut', 'co[onut', 'co)onut', 'co]onut', 'coc-nut'].each do |str|
+        it "#{str} is not valid" do
+          topic.title = "I have a #{str}"
+
+          expect(topic).to_not be_valid
+          expect(topic.errors.full_messages.first).to include(I18n.t('errors.messages.contains_censored_words', censored_words: SiteSetting.censored_words))
+        end
+      end
+    end
+
     context "#title" do
       it { is_expected.to validate_presence_of :title }
 


### PR DESCRIPTION
This prevents regular expression errors for some special characters in censored words. 

For example "Co(onut" fails

Some of the character substitution is a little verbose but it works. Escaping and replacing with single backslashes is tricky :(

