### PR TITLE
Add reopenWidget method

### DIFF
--- a/app/assets/javascripts/discourse/lib/plugin-api.js.es6
+++ b/app/assets/javascripts/discourse/lib/plugin-api.js.es6
@@ -5,7 +5,7 @@ import { addButton } from 'discourse/widgets/post-menu';
 import { includeAttributes } from 'discourse/lib/transform-post';
 import { addToolbarCallback } from 'discourse/components/d-editor';
 import { addWidgetCleanCallback } from 'discourse/components/mount-widget';
-import { createWidget, decorateWidget, changeSetting } from 'discourse/widgets/widget';
+import { createWidget, reopenWidget, decorateWidget, changeSetting } from 'discourse/widgets/widget';
 import { onPageChange } from 'discourse/lib/page-tracker';
 import { preventCloak } from 'discourse/widgets/post-stream';
 import { h } from 'virtual-dom';
@@ -305,6 +305,16 @@ class PluginApi {
    **/
   createWidget(name, args) {
     return createWidget(name, args);
+  }
+
+  /**
+   * Exposes the widget update ability to plugins. Updates the widget
+   * registry for the given widget name to include the properties on args
+   * See `reopenWidget` in `discourse/widgets/widget` from more ifo.
+  **/
+
+  reopenWidget(name, args) {
+    return reopenWidget(name, args);
   }
 
   /**

--- a/app/assets/javascripts/discourse/lib/plugin-api.js.es6
+++ b/app/assets/javascripts/discourse/lib/plugin-api.js.es6
@@ -367,7 +367,7 @@ class PluginApi {
 let _pluginv01;
 function getPluginApi(version) {
   version = parseFloat(version);
-  if (version <= 0.6) {
+  if (version <= 0.7) {
     if (!_pluginv01) {
       _pluginv01 = new PluginApi(version, Discourse.__container__);
     }

--- a/app/assets/javascripts/discourse/widgets/widget.js.es6
+++ b/app/assets/javascripts/discourse/widgets/widget.js.es6
@@ -125,6 +125,17 @@ export function createWidget(name, opts) {
   return result;
 }
 
+export function reopenWidget(name, opts) {
+  let existing = _registry[name]
+  if (!existing) {
+    console.error(`Could not find widget ${name} in registry`);
+    return
+  }
+
+  Object.keys(opts).forEach(k => existing.prototype[k] = opts[k])
+  return existing
+}
+
 export default class Widget {
   constructor(attrs, register, opts) {
     opts = opts || {};

--- a/app/assets/javascripts/discourse/widgets/widget.js.es6
+++ b/app/assets/javascripts/discourse/widgets/widget.js.es6
@@ -126,14 +126,14 @@ export function createWidget(name, opts) {
 }
 
 export function reopenWidget(name, opts) {
-  let existing = _registry[name]
+  let existing = _registry[name];
   if (!existing) {
     console.error(`Could not find widget ${name} in registry`);
     return
   }
 
-  Object.keys(opts).forEach(k => existing.prototype[k] = opts[k])
-  return existing
+  Object.keys(opts).forEach(k => existing.prototype[k] = opts[k]);
+  return existing;
 }
 
 export default class Widget {


### PR DESCRIPTION
This is a little bit of mad science that I needed for Babble; I figured I'd offer it up; you may or may not want to support it in core.

This allows us to add or override existing methods / properties on widgets, similar to Ember's `reopenClass` method. I found myself needing it to overwrite the `url()` method in `notification-item`, because I want to point chat notifications to the full page chat. I call it like this:

```
import { reopenWidget } from 'discourse/widgets/widget'

reopenWidget('notification-item', {
  url() {
    console.log("I am a custom function!")
  }
})
```

Supporting `this._super()` as well would be ideal here, but Ember's got a whole crazy scheme for supporting that, which I don't really want to reimplement (I was able to get the super method in other ways)