### PR TITLE
Validate censored words

### DIFF
--- a/lib/site_setting_validations.rb
+++ b/lib/site_setting_validations.rb
@@ -5,6 +5,10 @@ module SiteSettingValidations
     raise Discourse::InvalidParameters.new(I18n.t("errors.site_settings.#{key}"))
   end
 
+  def validate_censored_words(new_val)
+    validate_error :invalid_character if new_val.match(/^\w*$/).nil?
+  end
+
   def validate_min_username_length(new_val)
     validate_error :min_username_length_range if new_val > SiteSetting.max_username_length
     validate_error :min_username_length_exists if User.where('length(username) < ?', new_val).exists?


### PR DESCRIPTION
This prevents admins from entering reserved characters in censored words which causes 500 errors when creating topics. 

<img width="756" alt="screen shot 2017-01-17 at 1 01 54 pm" src="https://cloud.githubusercontent.com/assets/64749/22005210/7c0efd7a-dcb5-11e6-8289-b84925a838b5.png">
