### PR TITLE
add more SERVER_SIDE_ONLY routes; use pathname in matching

### DIFF
--- a/app/assets/javascripts/discourse/lib/url.js.es6
+++ b/app/assets/javascripts/discourse/lib/url.js.es6
@@ -7,9 +7,14 @@ const TOPIC_REGEXP = /\/t\/([^\/]+)\/(\d+)\/?(\d+)?/;
 
 // We can add links here that have server side responses but not client side.
 const SERVER_SIDE_ONLY = [
+  /^\/assets\//,
+  /^\/uploads\//,
+  /^\/stylesheets\//,
+  /^\/site_customizations\//,
+  /^\/raw\//,
   /^\/posts\/\d+\/raw/,
   /\.rss$/,
-  /\.json/,
+  /\.json$/,
 ];
 
 let _jumpScheduled = false;
@@ -121,8 +126,9 @@ const DiscourseURL = Ember.Object.extend({
       return;
     }
 
+    const pathname = path.replace(/(https?\:)?\/\/[^\/]+/, '');
     const serverSide = SERVER_SIDE_ONLY.some(r => {
-      if (path.match(r)) {
+      if (pathname.match(r)) {
         document.location = path;
         return true;
       }


### PR DESCRIPTION
Following up on https://github.com/discourse/discourse/pull/4645 here are some route fixes. I also changed it to match on the pathname instead of the full path, since it seems like that was what was intended anyway (judging by the "^/posts" regex).