### PR TITLE
add phpBB urls to SERVER_SIDE_ONLY regexes

### DIFF
--- a/app/assets/javascripts/discourse/lib/url.js.es6
+++ b/app/assets/javascripts/discourse/lib/url.js.es6
@@ -15,6 +15,8 @@ const SERVER_SIDE_ONLY = [
   /^\/posts\/\d+\/raw/,
   /\.rss$/,
   /\.json$/,
+  /^\/viewtopic.php/,
+  /^\/viewforum.php/,
 ];
 
 let _jumpScheduled = false;


### PR DESCRIPTION
We migrated our forum from phpBB to nginx. We use nginx in front of
Discourse to redirect the phpBB URLs to the Discourse URLs. Without
this PR, any link to a phpBB URL from inside Discourse does not work
by left clicking on it.

We could fix this by adding an option to Discourse to allow custom
SERVER_SIDE_ONLY regexes, but it seems easier to fix the problem by
adding them here.