### PR TITLE
PERF: Deferred loading of suggested topics.

### DIFF
--- a/app/assets/javascripts/discourse/components/suggested-topics.js.es6
+++ b/app/assets/javascripts/discourse/components/suggested-topics.js.es6
@@ -1,0 +1,69 @@
+import { categoryBadgeHTML } from 'discourse/helpers/category-link';
+import computed from 'ember-addons/ember-computed-decorators';
+
+export default Ember.Component.extend({
+  loading: false,
+
+  didInsertElement() {
+    this._super();
+
+    this.set('loading', true);
+    this.set('suggestedTopics', []);
+
+    this.get('model').fetchSuggestedTopics().then(topics => {
+      this.set('suggestedTopics', topics);
+    }).finally(() => this.set('loading', false));
+  },
+
+  @computed('model.isPrivateMessage', 'pmPath')
+  suggestedTitle(isPrivateMessage, pmPath) {
+    if (isPrivateMessage) {
+      return `
+        <a href="${pmPath}">
+          <i class='private-message-glyph fa fa-envelope'></i>
+        </a> ${I18n.t("suggested_topics.pm_title")}
+      `;
+    } else {
+      return I18n.t("suggested_topics.title");
+    }
+  },
+
+  @computed('model.isPrivateMessage', 'model.category', 'topicTrackingState.messageCount')
+  browseMoreMessage(isPrivateMessage, category) {
+
+    // TODO decide what to show for pms
+    if (isPrivateMessage) { return; }
+
+    const opts = { latestLink: `<a href="${Discourse.getURL("/latest")}">${I18n.t("topic.view_latest_topics")}</a>` };
+
+    if (category && Em.get(category, 'id') === Discourse.Site.currentProp("uncategorized_category_id")) {
+      category = null;
+    }
+
+    if (category) {
+      opts.catLink = categoryBadgeHTML(category);
+    } else {
+      opts.catLink = "<a href=\"" + Discourse.getURL("/categories") + "\">" + I18n.t("topic.browse_all_categories") + "</a>";
+    }
+
+    const unreadTopics = this.topicTrackingState.countUnread();
+    const newTopics = this.topicTrackingState.countNew();
+
+    if (newTopics + unreadTopics > 0) {
+      const hasBoth = unreadTopics > 0 && newTopics > 0;
+
+      return I18n.messageFormat("topic.read_more_MF", {
+        "BOTH": hasBoth,
+        "UNREAD": unreadTopics,
+        "NEW": newTopics,
+        "CATEGORY": category ? true : false,
+        latestLink: opts.latestLink,
+        catLink: opts.catLink
+      });
+    } else if (category) {
+      return I18n.t("topic.read_more_in_category", opts);
+    } else {
+      return I18n.t("topic.read_more", opts);
+    }
+  }
+});

--- a/app/assets/javascripts/discourse/controllers/topic.js.es6
+++ b/app/assets/javascripts/discourse/controllers/topic.js.es6
@@ -7,7 +7,6 @@ import { popupAjaxError } from 'discourse/lib/ajax-error';
 import computed from 'ember-addons/ember-computed-decorators';
 import Composer from 'discourse/models/composer';
 import DiscourseURL from 'discourse/lib/url';
-import { categoryBadgeHTML } from 'discourse/helpers/category-link';
 import Post from 'discourse/models/post';
 import debounce from 'discourse/lib/debounce';
 import isElementInViewport from "discourse/lib/is-element-in-viewport";
@@ -64,56 +63,9 @@ export default Ember.Controller.extend(SelectedPostsCount, BufferedContent, {
     return this.capabilities.isAndroid && loading;
   },
 
-  @computed('model', 'topicTrackingState.messageCount')
-  browseMoreMessage(model) {
-
-    // TODO decide what to show for pms
-    if (model.get('isPrivateMessage')) { return; }
-
-    const opts = { latestLink: `<a href="${Discourse.getURL("/latest")}">${I18n.t("topic.view_latest_topics")}</a>` };
-    let category = model.get('category');
-
-    if (category && Em.get(category, 'id') === Discourse.Site.currentProp("uncategorized_category_id")) {
-      category = null;
-    }
-
-    if (category) {
-      opts.catLink = categoryBadgeHTML(category);
-    } else {
-      opts.catLink = "<a href=\"" + Discourse.getURL("/categories") + "\">" + I18n.t("topic.browse_all_categories") + "</a>";
-    }
-
-    const unreadTopics = this.topicTrackingState.countUnread();
-    const newTopics = this.topicTrackingState.countNew();
-
-    if (newTopics + unreadTopics > 0) {
-      const hasBoth = unreadTopics > 0 && newTopics > 0;
-
-      return I18n.messageFormat("topic.read_more_MF", {
-        "BOTH": hasBoth,
-        "UNREAD": unreadTopics,
-        "NEW": newTopics,
-        "CATEGORY": category ? true : false,
-        latestLink: opts.latestLink,
-        catLink: opts.catLink
-      });
-    } else if (category) {
-      return I18n.t("topic.read_more_in_category", opts);
-    } else {
-      return I18n.t("topic.read_more", opts);
-    }
-  },
-
   @computed('model')
   pmPath(model) {
     return this.currentUser && this.currentUser.pmPath(model);
-  },
-
-  @computed('model')
-  suggestedTitle(model) {
-    return model.get('isPrivateMessage') ?
-      `<a href="${this.get('pmPath')}"><i class='private-message-glyph fa fa-envelope'></i></a> ${I18n.t("suggested_topics.pm_title")}` :
-      I18n.t("suggested_topics.title");
   },
 
   init() {

--- a/app/assets/javascripts/discourse/models/topic-details.js.es6
+++ b/app/assets/javascripts/discourse/models/topic-details.js.es6
@@ -18,13 +18,6 @@ const TopicDetails = RestModel.extend({
       });
     }
 
-    if (details.suggested_topics) {
-      const store = this.store;
-      details.suggested_topics = details.suggested_topics.map(function (st) {
-        return store.createRecord('topic', st);
-      });
-    }
-
     if (details.participants) {
       details.participants = details.participants.map(function (p) {
         p.topic = topic;

--- a/app/assets/javascripts/discourse/models/topic.js.es6
+++ b/app/assets/javascripts/discourse/models/topic.js.es6
@@ -471,6 +471,14 @@ const Topic = RestModel.extend({
     return ajax(`/t/${this.get('id')}/convert-topic/${type}`, {type: 'PUT'}).then(() => {
       window.location.reload();
     }).catch(popupAjaxError);
+  },
+
+  fetchSuggestedTopics() {
+    return ajax(`/t/${this.get('id')}/suggested_topics`).then(topics => {
+      return topics.map(topic => {
+        return this.store.createRecord('topic', topic);
+      });
+    });
   }
 });
 

--- a/app/assets/javascripts/discourse/templates/components/suggested-topics.hbs
+++ b/app/assets/javascripts/discourse/templates/components/suggested-topics.hbs
@@ -1,0 +1,17 @@
+{{#conditional-loading-spinner condition=loading}}
+  {{#if suggestedTopics.length}}
+    <div id="suggested-topics">
+      <h3>{{{suggestedTitle}}}</h3>
+      <div class="topics">
+        {{#if isPrivateMessage}}
+          {{basic-topic-list hideCategory="true"
+                             showPosters="true"
+                             topics=suggestedTopics}}
+        {{else}}
+          {{basic-topic-list topics=suggestedTopics}}
+        {{/if}}
+      </div>
+      <h3>{{{browseMoreMessage}}}</h3>
+    </div>
+  {{/if}}
+{{/conditional-loading-spinner}}

--- a/app/assets/javascripts/discourse/templates/topic.hbs
+++ b/app/assets/javascripts/discourse/templates/topic.hbs
@@ -225,22 +225,7 @@
 
               {{plugin-outlet name="topic-above-suggested" args=(hash model=model)}}
 
-              {{#if model.details.suggested_topics.length}}
-                <div id="suggested-topics">
-                  <h3>{{{suggestedTitle}}}</h3>
-                  <div class="topics">
-                    {{#if model.isPrivateMessage}}
-                      {{basic-topic-list hideCategory="true"
-                                         showPosters="true"
-                                         topics=model.details.suggested_topics}}
-                    {{else}}
-                      {{basic-topic-list topics=model.details.suggested_topics}}
-                    {{/if}}
-                  </div>
-                  <h3>{{{browseMoreMessage}}}</h3>
-                </div>
-              {{/if}}
-
+              {{suggested-topics model=model pmPath=pmPath}}
             {{/if}}
           {{/conditional-loading-spinner}}
 

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -133,6 +133,13 @@ class TopicsController < ApplicationController
     raise ex
   end
 
+  def suggested_topics
+    render_serialized(
+      TopicView.new(params[:topic_id], current_user).suggested_topics.topics,
+      SuggestedTopicSerializer
+    )
+  end
+
   def unsubscribe
     if current_user.blank?
       cookies[:destination_url] = request.fullpath

--- a/app/serializers/topic_view_serializer.rb
+++ b/app/serializers/topic_view_serializer.rb
@@ -90,12 +90,6 @@ class TopicViewSerializer < ApplicationSerializer
       end
     end
 
-    if object.suggested_topics.try(:topics).present?
-      result[:suggested_topics] = object.suggested_topics.topics.map do |topic|
-        SuggestedTopicSerializer.new(topic, scope: scope, root: false)
-      end
-    end
-
     if object.links.present?
       result[:links] = object.links.map do |user|
         TopicLinkSerializer.new(user, scope: scope, root: false)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -587,6 +587,7 @@ Discourse::Application.routes.draw do
   put "t/:topic_id/recover" => "topics#recover", constraints: {topic_id: /\d+/}
   get "t/:topic_id/:post_number" => "topics#show", constraints: {topic_id: /\d+/, post_number: /\d+/}
   get "t/:topic_id/last" => "topics#show", post_number: 99999999, constraints: {topic_id: /\d+/}
+  get "t/:topic_id/suggested_topics" => "topics#suggested_topics", constraints: {topic_id: /\d+/}
   get "t/:slug/:topic_id.rss" => "topics#feed", format: :rss, constraints: {topic_id: /\d+/}
   get "t/:slug/:topic_id" => "topics#show", constraints: {topic_id: /\d+/}
   get "t/:slug/:topic_id/:post_number" => "topics#show", constraints: {topic_id: /\d+/, post_number: /\d+/}


### PR DESCRIPTION
cc @SamSaffron 

For most topics, the suggested topics don't come into view until the user reaches the end of the topic. The query to load suggested topics is hurting us on perf for the initial load as shown by the mini-profiler results below.

![screenshot from 2017-01-18 16-48-32](https://cloud.githubusercontent.com/assets/4335742/22057040/fa28d0e4-dd9d-11e6-903e-c1381bb01afc.png)

The approach taken here is to only load the suggested topics when the user reaches the end of the topic stream. Even for shorter topics, it has the added benefit of reducing our first load time.