### PR TITLE
add category-navigation plugin outlet

### DIFF
--- a/app/assets/javascripts/discourse/templates/navigation/category.hbs
+++ b/app/assets/javascripts/discourse/templates/navigation/category.hbs
@@ -33,4 +33,6 @@
   {{#if canEditCategory}}
     {{d-button class="btn-default edit-category" action="editCategory" actionParam=category icon="wrench" label="category.edit_long"}}
   {{/if}}
+
+  {{plugin-outlet name="category-navigation" args=(hash category=category)}}
 </div>


### PR DESCRIPTION
I need this for some email-in improvements I'm working on for Mozilla

![screen shot 2017-01-19 at 16 47 12](https://cloud.githubusercontent.com/assets/755354/22118004/f86ab5f8-de6d-11e6-8fd9-16a0b5949aae.png)
