### PR TITLE
FIX: topic links were getting dropped when post is rebaked

### DIFF
--- a/app/jobs/regular/process_post.rb
+++ b/app/jobs/regular/process_post.rb
@@ -33,11 +33,17 @@ module Jobs
           Rails.logger.warn("Cooked post processor in FATAL state, bypassing. You need to urgently restart sidekiq\norig: #{orig_cooked}\nrecooked: #{recooked}\ncooked: #{cooked}\npost id: #{post.id}")
         else
           post.update_column(:cooked, cp.html)
+          extract_links(post)
           post.publish_change_to_clients! :revised
         end
       end
     end
 
+    # onebox may have added some links, so extract them now
+    def extract_links(post)
+      TopicLink.extract_from(post)
+      QuotedPost.extract_from(post)
+    end
   end
 
 end

--- a/lib/cooked_post_processor.rb
+++ b/lib/cooked_post_processor.rb
@@ -35,14 +35,7 @@ class CookedPostProcessor
       optimize_urls
       pull_hotlinked_images(bypass_bump)
       grant_badges
-      extract_links
     end
-  end
-
-  # onebox may have added some links, so extract them now
-  def extract_links
-    TopicLink.extract_from(@post)
-    QuotedPost.extract_from(@post)
   end
 
   def has_emoji?

--- a/spec/components/cooked_post_processor_spec.rb
+++ b/spec/components/cooked_post_processor_spec.rb
@@ -602,16 +602,6 @@ describe CookedPostProcessor do
 
   end
 
-  context "extracts links" do
-    let(:post) { Fabricate(:post, raw: "sam has a blog at https://samsaffron.com") }
-
-    it "always re-extracts links on post process" do
-      TopicLink.destroy_all
-      CookedPostProcessor.new(post).post_process
-      expect(TopicLink.count).to eq(1)
-    end
-  end
-
   context "grant badges" do
     let(:cpp) { CookedPostProcessor.new(post) }
 

--- a/spec/jobs/process_post_spec.rb
+++ b/spec/jobs/process_post_spec.rb
@@ -46,6 +46,13 @@ describe Jobs::ProcessPost do
       expect(post.cooked).not_to match(/http/)
     end
 
+    it "always re-extracts links on post process" do
+      post.update_columns(raw: "sam has a blog at https://samsaffron.com")
+      TopicLink.destroy_all
+      Jobs::ProcessPost.new.execute(post_id: post.id)
+      expect(TopicLink.count).to eq(1)
+    end
+
   end
 
 


### PR DESCRIPTION
Bug report here: https://meta.discourse.org/t/clicks-dont-work-after-rebake-amazon-onebox-topic/56557/

Currently when a post with Amazon link in it is rebaked the Topic Link is extracted before the link is oneboxed (incomplete `post.cooked` data) which results in missing Topic Link record and the click tracking fails (no redirection happens).

In this PR I moved the topic link extraction code in the `ProcessPost` job right after the post is saved which fixes this issue.

@SamSaffron can you please review this PR?