### PR TITLE
FEATURE: Add user title to SSO payload

### DIFF
--- a/app/models/discourse_single_sign_on.rb
+++ b/app/models/discourse_single_sign_on.rb
@@ -79,6 +79,8 @@ class DiscourseSingleSignOn < SingleSignOn
     user.admin = admin unless admin.nil?
     user.moderator = moderator unless moderator.nil?
 
+    user.title = title unless title.nil?
+
     # optionally save the user and sso_record if they have changed
     user.user_avatar.save! if user.user_avatar
     user.save!

--- a/lib/single_sign_on.rb
+++ b/lib/single_sign_on.rb
@@ -1,6 +1,6 @@
 class SingleSignOn
   ACCESSORS = [:nonce, :name, :username, :email, :avatar_url, :avatar_force_update, :require_activation,
-               :bio, :external_id, :return_sso_url, :admin, :moderator, :suppress_welcome_message,
+               :bio, :external_id, :return_sso_url, :admin, :moderator, :suppress_welcome_message, :title,
                :add_groups, :remove_groups]
   FIXNUMS = []
   BOOLS = [:avatar_force_update, :admin, :moderator, :require_activation, :suppress_welcome_message]

--- a/spec/models/discourse_single_sign_on_spec.rb
+++ b/spec/models/discourse_single_sign_on_spec.rb
@@ -27,6 +27,7 @@ describe DiscourseSingleSignOn do
     sso.moderator = false
     sso.suppress_welcome_message = false
     sso.require_activation = false
+    sso.title = "user title"
     sso.custom_fields["a"] = "Aa"
     sso.custom_fields["b.b"] = "B.b"
     sso
@@ -45,6 +46,7 @@ describe DiscourseSingleSignOn do
     expect(parsed.moderator).to eq sso.moderator
     expect(parsed.suppress_welcome_message).to eq sso.suppress_welcome_message
     expect(parsed.require_activation).to eq false
+    expect(parsed.title).to eq sso.title
     expect(parsed.custom_fields["a"]).to eq "Aa"
     expect(parsed.custom_fields["b.b"]).to eq "B.b"
   end
@@ -267,6 +269,33 @@ describe DiscourseSingleSignOn do
       User.any_instance.expects(:enqueue_welcome_message).never
       sso.suppress_welcome_message = true
       user = sso.lookup_or_create_user(ip_address)
+    end
+  end
+
+  context 'setting title for a user' do
+    let(:sso) {
+      sso = DiscourseSingleSignOn.new
+      sso.username = 'test'
+      sso.name = 'test'
+      sso.email = 'test@test.com'
+      sso.external_id = '100'
+      sso.title = "The User's Title"
+      sso
+    }
+
+    it 'can set title if supplied on new users' do
+      user = sso.lookup_or_create_user(ip_address)
+      expect(user.title).to eq(sso.title)
+    end
+
+    it 'sets the title if user has an empty title' do
+      sso.title = ' '
+      user = sso.lookup_or_create_user(ip_address)
+
+      sso.title = 'I am a new title'
+      user = sso.lookup_or_create_user(ip_address)
+
+      expect(user.title).to eq(sso.title)
     end
   end
 


### PR DESCRIPTION
# TL;DR

Added title to SSO user payload

# Details

Open the option to set the user title in the SingleSignOn payload.

The following changes to the codebase have been made:

* Added the following to the model test for `DiscourseSingleSignOn`
  * Test parsed payload
  * Test the setting of the title for new users
  * Test the setting of the title for existing user with blank title
* Added `:title` to the `SingleSignOn::ACCESSORS` list
* Added the setting of `title` on user if title is not nil in the `DiscourseSingleSignOn` model under `.lookup_or_create_user`