### PR TITLE
FIX: Update Topic#relative_url to Return Relative URL

### DIFF
--- a/app/models/permalink.rb
+++ b/app/models/permalink.rb
@@ -76,7 +76,7 @@ class Permalink < ActiveRecord::Base
   def target_url
     return external_url if external_url
     return "#{Discourse::base_uri}#{post.url}" if post
-    return topic.relative_url if topic
+    return topic.url if topic
     return category.url if category
     nil
   end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -893,7 +893,7 @@ SQL
   end
 
   def self.relative_url(id, slug, post_number=nil)
-    url = "#{Discourse.base_uri}/t/#{slug}/#{id}"
+    url = "/t/#{slug}/#{id}"
     url << "/#{post_number}" if post_number.to_i > 1
     url
   end

--- a/app/views/list/list.erb
+++ b/app/views/list/list.erb
@@ -30,7 +30,7 @@
   <% @list.topics.each_with_index do |t,i| %>
     <div itemprop='itemListElement' itemscope itemtype='http://schema.org/ListItem'>
       <meta itemprop='url' content='<%= t.url %>'>
-      <a href='<%= t.relative_url %>' itemprop='item'>
+      <a href='<%= t.url %>' itemprop='item'>
         <span itemprop='name'><%= t.title %></span>
       </a>
       <span class="page-links"><%= page_links(t) %></span>

--- a/spec/models/permalink_spec.rb
+++ b/spec/models/permalink_spec.rb
@@ -34,7 +34,7 @@ describe Permalink do
 
     it "returns a topic url when topic_id is set" do
       permalink.topic_id = topic.id
-      expect(target_url).to eq(topic.relative_url)
+      expect(target_url).to eq(topic.url)
     end
 
     it "returns nil when topic_id is set but topic is not found" do


### PR DESCRIPTION
# TL;DR

Removed `Discourse.base_uri` from the output of `Topic#relative_url` to make the method do what its name implies.

# Details

The following changes to the codebase are proposed:

* Remove `Discourse.base_uri` from `Topic#relative_url`.
* Alter the permalink model to use `Topic#url` instead of `Topic#relative_url`. Preserves the output (full URL) and makes the methods consistent within `Permalink#target_url`.
* Modify app/views/list/list.erb to use the full topic URL for consistency with the full category URL and to eliminate a potentially confusing or erroneous reference to Topic#relative_url.