### PR TITLE
FIX: Show groups that user is owner of on groups page.

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -18,12 +18,7 @@ class GroupsController < ApplicationController
     page_size = 30
     page = params[:page]&.to_i || 0
 
-    groups = Group.order(name: :asc).where(visible: true)
-
-    if !guardian.is_admin?
-      groups = groups.where(automatic: false)
-    end
-
+    groups = Group.visible_groups(current_user)
     count = groups.count
     groups = groups.offset(page * page_size).limit(page_size)
 


### PR DESCRIPTION
cc @techAPJ Can you review this for me? Thank you!

https://meta.discourse.org/t/group-owners-cannot-see-group-if-group-is-visible-to-all-users-is-off/56688/10