### PR TITLE
Moving posts issues

### DIFF
--- a/app/models/post_mover.rb
+++ b/app/models/post_mover.rb
@@ -155,8 +155,6 @@ class PostMover
       action_code: "split_topic"
     )
 
-    return unless moderator_post
-
     # We want to insert the moderator post where the previous posts were
     # in the stream, not at the end.
     moderator_post.update_attributes!(post_number: @first_post_number_moved, sort_order: @first_post_number_moved) if @first_post_number_moved.present?

--- a/app/models/post_mover.rb
+++ b/app/models/post_mover.rb
@@ -146,15 +146,20 @@ class PostMover
   def create_moderator_post_in_original_topic
     move_type_str = PostMover.move_types[@move_type].to_s
 
-    original_topic.add_moderator_post(
+    moderator_post = original_topic.add_moderator_post(
       user,
       I18n.t("move_posts.#{move_type_str}_moderator_post",
              count: post_ids.count,
              topic_link: "[#{destination_topic.title}](#{destination_topic.relative_url})"),
       post_type: Post.types[:small_action],
-      action_code: "split_topic",
-      post_number: @first_post_number_moved
+      action_code: "split_topic"
     )
+
+    return unless moderator_post
+
+    # We want to insert the moderator post where the previous posts were
+    # in the stream, not at the end.
+    moderator_post.update_attributes!(post_number: @first_post_number_moved, sort_order: @first_post_number_moved) if @first_post_number_moved.present?
   end
 
   def posts

--- a/app/models/post_mover.rb
+++ b/app/models/post_mover.rb
@@ -157,7 +157,7 @@ class PostMover
 
     # We want to insert the moderator post where the previous posts were
     # in the stream, not at the end.
-    moderator_post.update_attributes!(post_number: @first_post_number_moved, sort_order: @first_post_number_moved) if @first_post_number_moved.present?
+    moderator_post.update_columns(post_number: @first_post_number_moved, sort_order: @first_post_number_moved) if @first_post_number_moved.present?
   end
 
   def posts

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -652,9 +652,6 @@ SQL
 
     if (new_post = creator.create) && new_post.present?
       increment!(:moderator_posts_count) if new_post.persisted?
-      # If we are moving posts, we want to insert the moderator post where the previous posts were
-      # in the stream, not at the end.
-      new_post.update_attributes!(post_number: opts[:post_number], sort_order: opts[:post_number]) if opts[:post_number].present?
 
       # Grab any links that are present
       TopicLink.extract_from(new_post)

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -650,13 +650,13 @@ SQL
                               skip_validations: true,
                               custom_fields: opts[:custom_fields])
 
-    if (new_post = creator.create) && new_post.present?
-      increment!(:moderator_posts_count) if new_post.persisted?
+    new_post = creator.create
 
-      # Grab any links that are present
-      TopicLink.extract_from(new_post)
-      QuotedPost.extract_from(new_post)
-    end
+    increment!(:moderator_posts_count) if new_post.persisted?
+
+    # Grab any links that are present
+    TopicLink.extract_from(new_post)
+    QuotedPost.extract_from(new_post)
 
     new_post
   end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -639,7 +639,6 @@ SQL
 
   def add_moderator_post(user, text, opts=nil)
     opts ||= {}
-    new_post = nil
     creator = PostCreator.new(user,
                               raw: text,
                               post_type: opts[:post_type] || Post.types[:moderator_action],

--- a/lib/post_creator.rb
+++ b/lib/post_creator.rb
@@ -107,8 +107,8 @@ class PostCreator
       topic_creator = TopicCreator.new(@user, guardian, @opts)
       return false unless skip_validations? || validate_child(topic_creator)
     else
-      @topic = Topic.find_by(id: @opts[:topic_id])
-      if (@topic.blank? || !guardian.can_create?(Post, @topic))
+      @topic = Topic.with_deleted.find_by(id: @opts[:topic_id])
+      if (@topic.blank? || !guardian.can_create?(Post, @topic)) && !skip_validations?
         errors[:base] << I18n.t(:topic_not_found)
         return false
       end
@@ -362,13 +362,15 @@ class PostCreator
   end
 
   def create_topic
-    return if @topic
-    begin
-      topic_creator = TopicCreator.new(@user, guardian, @opts)
-      @topic = topic_creator.create
-    rescue ActiveRecord::Rollback
-      rollback_from_errors!(topic_creator)
+    unless @topic
+      begin
+        topic_creator = TopicCreator.new(@user, guardian, @opts)
+        @topic = topic_creator.create
+      rescue ActiveRecord::Rollback
+        rollback_from_errors!(topic_creator)
+      end
     end
+
     @post.topic_id = @topic.id
     @post.topic = @topic
     if @topic && @topic.category && @topic.category.all_topics_wiki

--- a/spec/models/post_mover_spec.rb
+++ b/spec/models/post_mover_spec.rb
@@ -64,6 +64,12 @@ describe PostMover do
         topic.move_posts(user, [p2.id, p4.id], title: "new testing topic name")
         expect(topic.posts).to include(a_moderator_post(post_number: 2, sort_order: 2))
       end
+
+      it "adds a moderator post even if it doesn't meet length requirements" do
+        SiteSetting.stubs(:min_post_length).returns(999)
+        topic.move_posts(user, [p2.id, p4.id], title: "new testing topic name")
+        expect(topic.reload.posts).to include(a_moderator_post)
+      end
     end
 
     context "errors" do

--- a/spec/models/post_mover_spec.rb
+++ b/spec/models/post_mover_spec.rb
@@ -315,6 +315,17 @@ describe PostMover do
 
       end
 
+      context "moving from a deleted topic" do
+        before do
+          topic.trash!
+        end
+
+        it "adds a moderator post at the location of the first moved post" do
+          topic.move_posts(user, [p2.id, p4.id], title: "new testing topic name")
+          expect(topic.posts).to include(a_moderator_post(post_number: 2, sort_order: 2))
+        end
+      end
+
       context "to an existing topic with a deleted post" do
         let!(:destination_topic) { Fabricate(:topic, user: user ) }
         let!(:destination_op) { Fabricate(:post, topic: destination_topic, user: user) }

--- a/spec/models/post_mover_spec.rb
+++ b/spec/models/post_mover_spec.rb
@@ -1,6 +1,14 @@
 require 'rails_helper'
 
 describe PostMover do
+  RSpec::Matchers.define :a_moderator_post do |attributes|
+    match do |post|
+      expected_attributes =
+        (attributes || {}).merge(post_type: Post.types[:small_action], action_code: "split_topic")
+
+      expect(post).to have_attributes(expected_attributes)
+    end
+  end
 
   describe '#move_types' do
     context "verify enum sequence" do
@@ -47,16 +55,15 @@ describe PostMover do
     context 'success' do
 
       it "enqueues a job to notify users" do
-        topic.stubs(:add_moderator_post)
+        Jobs.stubs(:enqueue)
         Jobs.expects(:enqueue).with(:notify_moved_posts, post_ids: [p2.id, p4.id], moved_by_id: user.id)
         topic.move_posts(user, [p2.id, p4.id], title: "new testing topic name")
       end
 
       it "adds a moderator post at the location of the first moved post" do
-        topic.expects(:add_moderator_post).with(user, instance_of(String), has_entries(post_number: 2))
         topic.move_posts(user, [p2.id, p4.id], title: "new testing topic name")
+        expect(topic.posts).to include(a_moderator_post(post_number: 2, sort_order: 2))
       end
-
     end
 
     context "errors" do
@@ -152,7 +159,6 @@ describe PostMover do
       context "to a new topic" do
 
         it "works correctly" do
-          topic.expects(:add_moderator_post).once
           new_topic = topic.move_posts(user, [p2.id, p4.id], title: "new testing topic name", category_id: category.id)
 
           expect(TopicUser.find_by(user_id: user.id, topic_id: topic.id).last_read_post_number).to eq(p3.post_number)
@@ -183,8 +189,8 @@ describe PostMover do
           topic.reload
           expect(topic.featured_user1_id).to be_blank
           expect(topic.like_count).to eq(0)
-          expect(topic.posts_count).to eq(2)
-          expect(topic.posts.by_post_number).to match_array([p1, p3])
+          expect(topic.posts_count).to eq(3)
+          expect(topic.posts.by_post_number).to match_array([p1, p3, a_moderator_post])
           expect(topic.highest_post_number).to eq(p3.post_number)
 
           # both the like and was_liked user actions should be correct
@@ -193,7 +199,6 @@ describe PostMover do
         end
 
         it "moving all posts will close the topic" do
-          topic.expects(:add_moderator_post).twice
           new_topic = topic.move_posts(user, [p1.id, p2.id, p3.id, p4.id], title: "new testing topic name", category_id: category.id)
           expect(new_topic).to be_present
 
@@ -215,7 +220,6 @@ describe PostMover do
         let!(:destination_op) { Fabricate(:post, topic: destination_topic, user: user) }
 
         it "works correctly" do
-          topic.expects(:add_moderator_post).once
           moved_to = topic.move_posts(user, [p2.id, p4.id], destination_topic_id: destination_topic.id)
           expect(moved_to).to eq(destination_topic)
 
@@ -247,8 +251,8 @@ describe PostMover do
           expect(topic.highest_post_number).to eq(3)
           expect(topic.featured_user1_id).to be_blank
           expect(topic.like_count).to eq(0)
-          expect(topic.posts_count).to eq(2)
-          expect(topic.posts.by_post_number).to match_array([p1, p3])
+          expect(topic.posts_count).to eq(3)
+          expect(topic.posts.by_post_number).to match_array([p1, p3, a_moderator_post])
           expect(topic.highest_post_number).to eq(p3.post_number)
 
           # Should update last reads
@@ -256,7 +260,6 @@ describe PostMover do
         end
 
         it "moving all posts will close the topic" do
-          topic.expects(:add_moderator_post).twice
           moved_to = topic.move_posts(user, [p1.id, p2.id, p3.id, p4.id], destination_topic_id: destination_topic.id)
           expect(moved_to).to be_present
 
@@ -268,7 +271,6 @@ describe PostMover do
       context "moving the first post" do
 
         it "copies the OP, doesn't delete it" do
-          topic.expects(:add_moderator_post).once
           new_topic = topic.move_posts(user, [p1.id, p2.id], title: "new testing topic name")
 
           expect(new_topic).to be_present
@@ -296,7 +298,7 @@ describe PostMover do
           expect(p2.reply_count).to eq(0)
 
           topic.reload
-          expect(topic.posts.by_post_number).to match_array([p1, p3, p4])
+          expect(topic.posts.by_post_number).to match_array([p1, p3, p4, a_moderator_post])
           expect(topic.highest_post_number).to eq(p4.post_number)
         end
 
@@ -314,11 +316,6 @@ describe PostMover do
       end
 
       context "to an existing topic with a deleted post" do
-
-        before do
-          topic.expects(:add_moderator_post)
-        end
-
         let!(:destination_topic) { Fabricate(:topic, user: user ) }
         let!(:destination_op) { Fabricate(:post, topic: destination_topic, user: user) }
         let!(:destination_deleted_reply) { Fabricate(:post, topic: destination_topic, user: another_user) }

--- a/spec/models/post_mover_spec.rb
+++ b/spec/models/post_mover_spec.rb
@@ -244,7 +244,6 @@ describe PostMover do
 
           # Check out the original topic
           topic.reload
-          expect(topic.posts_count).to eq(2)
           expect(topic.highest_post_number).to eq(3)
           expect(topic.featured_user1_id).to be_blank
           expect(topic.like_count).to eq(0)

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -590,14 +590,11 @@ describe Topic do
     it 'creates a moderator post' do
       mod_post = topic.add_moderator_post(
         moderator,
-        "Moderator did something. http://discourse.org",
-        post_number: 999
+        "Moderator did something. http://discourse.org"
       )
 
       expect(mod_post).to be_present
       expect(mod_post.post_type).to eq(Post.types[:moderator_action])
-      expect(mod_post.post_number).to eq(999)
-      expect(mod_post.sort_order).to eq(999)
       expect(topic.topic_links.count).to eq(1)
       expect(topic.reload.moderator_posts_count).to eq(1)
     end

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -599,18 +599,14 @@ describe Topic do
       expect(topic.reload.moderator_posts_count).to eq(1)
     end
 
-    context "when moderator post fails to be created" do
-      before do
-        user.toggle!(:blocked)
-      end
+    it "creates a moderator post ignoring validations" do
+      user.toggle!(:blocked)
+      mod_post = topic.add_moderator_post(
+        user,
+        "Moderator did something. http://discourse.org",
+      )
 
-      it "should not increment moderator_posts_count" do
-        expect(topic.moderator_posts_count).to eq(0)
-
-        topic.add_moderator_post(user, "winter is never coming")
-
-        expect(topic.moderator_posts_count).to eq(0)
-      end
+      expect(mod_post).to be_present
     end
   end
 


### PR DESCRIPTION
Hi!

We've noticed two issues when moving posts in our discourse instance.

* We get a crash when moving a post to a closed topic. The crash looks like this error https://meta.discourse.org/t/error-when-moving-post-to-existing-topic/38790 and I think the first commit here should fix it.

* We also get a crash when moving a post to a topic in the case where the autogenerated moderator post ("a post was moved to topic [link-to-topic]") does not meet our configured min post length validation. The second commit here should fix that.

Let me know your thoughts! :)
