### PR TITLE
Webhooks features

### DIFF
--- a/app/assets/javascripts/admin/templates/web-hooks-show.hbs
+++ b/app/assets/javascripts/admin/templates/web-hooks-show.hbs
@@ -60,6 +60,8 @@
       </div>
     </div>
 
+    {{plugin-outlet name="web-hook-fields" args=(hash model=model)}}
+
     <div>
       {{input type="checkbox" name="verify_certificate" checked=model.verify_certificate}} {{i18n 'admin.web_hooks.verify_certificate'}}
     </div>

--- a/app/models/web_hook.rb
+++ b/app/models/web_hook.rb
@@ -41,11 +41,11 @@ class WebHook < ActiveRecord::Base
   end
 
   def self.enqueue_topic_hooks(event, topic, user=nil)
-    WebHook.enqueue_hooks(:topic, topic_id: topic.id, user_id: user&.id, category_id: topic&.category_id, event_name: event.to_s)
+    WebHook.enqueue_hooks(:topic, topic_id: topic.id, category_id: topic&.category_id, event_name: event.to_s)
   end
 
   def self.enqueue_post_hooks(event, post, user=nil)
-    WebHook.enqueue_hooks(:post, post_id: post.id, topic_id: post&.topic_id, user_id: user&.id, category_id: post&.topic&.category_id, event_name: event.to_s)
+    WebHook.enqueue_hooks(:post, post_id: post.id, category_id: post&.topic&.category_id, event_name: event.to_s)
   end
 
   %i(topic_destroyed topic_recovered).each do |event|

--- a/app/models/web_hook_event_type.rb
+++ b/app/models/web_hook_event_type.rb
@@ -15,7 +15,7 @@ class WebHookEventType < ActiveRecord::Base
     end
 
     def self.serializer
-      TopicViewSerializer
+      WebHookTopicViewSerializer
     end
   end
 
@@ -25,7 +25,7 @@ class WebHookEventType < ActiveRecord::Base
     end
 
     def self.serializer
-      PostSerializer
+      WebHookPostSerializer
     end
   end
 
@@ -35,7 +35,7 @@ class WebHookEventType < ActiveRecord::Base
     end
 
     def self.serializer
-      UserSerializer
+      WebHookUserSerializer
     end
   end
 end

--- a/app/models/web_hook_event_type.rb
+++ b/app/models/web_hook_event_type.rb
@@ -8,6 +8,36 @@ class WebHookEventType < ActiveRecord::Base
   default_scope { order('id ASC') }
 
   validates :name, presence: true, uniqueness: true
+
+  module TopicType
+    def self.load_record(topic_id)
+      TopicView.new(topic_id.to_i, Discourse.system_user) rescue nil
+    end
+
+    def self.serializer
+      TopicViewSerializer
+    end
+  end
+
+  module PostType
+    def self.load_record(post_id)
+      Post.find_by(id: post_id.to_i)
+    end
+
+    def self.serializer
+      PostSerializer
+    end
+  end
+
+  module UserType
+    def self.load_record(user_id)
+      User.find_by(id: user_id.to_i)
+    end
+
+    def self.serializer
+      UserSerializer
+    end
+  end
 end
 
 # == Schema Information

--- a/app/serializers/web_hook_post_serializer.rb
+++ b/app/serializers/web_hook_post_serializer.rb
@@ -1,0 +1,17 @@
+class WebHookPostSerializer < PostSerializer
+  def include_can_edit?
+    false
+  end
+
+  def can_delete
+    false
+  end
+
+  def can_recover
+    false
+  end
+
+  def can_wiki
+    false
+  end
+end

--- a/app/serializers/web_hook_topic_view_serializer.rb
+++ b/app/serializers/web_hook_topic_view_serializer.rb
@@ -1,0 +1,11 @@
+require_dependency 'pinned_check'
+
+class WebHookTopicViewSerializer < TopicViewSerializer
+  def include_post_stream?
+    false
+  end
+
+  def include_timeline_lookup?
+    false
+  end
+end

--- a/app/serializers/web_hook_user_serializer.rb
+++ b/app/serializers/web_hook_user_serializer.rb
@@ -1,0 +1,6 @@
+class WebHookUserSerializer < UserSerializer
+  # remove staff attributes
+  def self.staff_attributes(*attrs)
+    return
+  end
+end

--- a/spec/jobs/emit_web_hook_event_spec.rb
+++ b/spec/jobs/emit_web_hook_event_spec.rb
@@ -10,12 +10,8 @@ describe Jobs::EmitWebHookEvent do
     expect { subject.execute(event_type: 'post') }.to raise_error(Discourse::InvalidParameters)
   end
 
-  it 'raises an error when there is no event name' do
+  it 'raises an error when there is no event type' do
     expect { subject.execute(web_hook_id: 1) }.to raise_error(Discourse::InvalidParameters)
-  end
-
-  it 'raises an error when event name is invalid' do
-    expect { subject.execute(web_hook_id: post_hook.id, event_type: 'post_random') }.to raise_error(Discourse::InvalidParameters)
   end
 
   it "doesn't emit when the hook is inactive" do

--- a/spec/models/web_hook_event_type_spec.rb
+++ b/spec/models/web_hook_event_type_spec.rb
@@ -2,4 +2,49 @@ require 'rails_helper'
 
 describe WebHookEventType do
   it { is_expected.to validate_presence_of :name }
+
+  describe 'TopicType' do
+    subject { WebHookEventType::TopicType }
+    let(:topic) { Fabricate(:topic) }
+
+    it 'loads the topic accordingly' do
+      expect {
+        subject.load_record(topic.id)
+      }.not_to raise_error
+    end
+
+    it 'returns nil when topic is not found' do
+      expect(subject.load_record(0)).to be_nil
+    end
+  end
+
+  describe 'PostType' do
+    subject { WebHookEventType::PostType }
+    let(:post) { Fabricate(:post) }
+
+    it 'loads the post accordingly' do
+      expect {
+        subject.load_record(post.id)
+      }.not_to raise_error
+    end
+
+    it 'returns nil when post is not found' do
+      expect(subject.load_record(0)).to be_nil
+    end
+  end
+
+  describe 'UserType' do
+    subject { WebHookEventType::UserType }
+    let(:user) { Fabricate(:user) }
+
+    it 'loads the user accordingly' do
+      expect {
+        subject.load_record(user.id)
+      }.not_to raise_error
+    end
+
+    it 'returns nil when user is not found' do
+      expect(subject.load_record(0)).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
This PR is made of two commits. @tgxworld 

The first commit makes the webhook types easier to be customized.

The other is about payload size. There are many requests asking to reduce the payload in the webhooks feedback section. https://meta.discourse.org/t/webhooks-feedback/49046 So serveral customized webhook serializers are created for that reason.