### PR TITLE
use RFC-complient signature separator dash-dash-space

### DIFF
--- a/lib/email/message_builder.rb
+++ b/lib/email/message_builder.rb
@@ -40,7 +40,7 @@ module Email
             string = allow_reply_by_email? ? "user_notifications.reply_by_email" : "user_notifications.visit_link_to_respond"
             string << "_pm" if @opts[:private_reply]
           end
-          @template_args[:respond_instructions] = "---\n" + I18n.t(string, @template_args)
+          @template_args[:respond_instructions] = "-- \n" + I18n.t(string, @template_args)
         end
 
         if @opts[:add_unsubscribe_link]


### PR DESCRIPTION
currently, Discourse uses '---' in its notifications to
separate the signature with unsubscribe links etc. from
the body of the message.

The RFC standard defines '-- '.
https://www.ietf.org/rfc/rfc3676.txt (4.3)

The problem has been discussed in:

https://meta.discourse.org/t/previous-replies-separator-is-not-rfc-compliant/39410

And an incomplete fix has been added a year ago:
86819f08c3294313b9b414f3c38644e4a60284c8

The separator is important, because some mail clients strip off the
signature automatically in replies if the signature is recognised as such.