### PR TITLE
fix replay btn position on mobile and desktop

### DIFF
--- a/app/assets/javascripts/discourse/templates/topic.hbs
+++ b/app/assets/javascripts/discourse/templates/topic.hbs
@@ -200,7 +200,9 @@
                     replyToPost=(action "replyToPost")
                     }}
                 {{else}}
-                  {{d-button icon="reply" class="btn-primary" action="showLogin" label="topic.reply.title"}}
+                  <div id="topic-footer-button">
+                    {{d-button icon="reply" class="btn-primary pull-right" action="showLogin" label="topic.reply.title"}}
+                  </div>
                 {{/if}}
               {{/if}}
 

--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -442,6 +442,10 @@ a.star {
   }
 }
 
+#topic-footer-button {
+  width: 757px;
+}
+
 #suggested-topics {
   clear: left;
   padding: 20px 0 15px 0;

--- a/app/assets/stylesheets/mobile/topic-post.scss
+++ b/app/assets/stylesheets/mobile/topic-post.scss
@@ -330,6 +330,11 @@ a.star {
   color: dark-light-choose(scale-color($primary, $lightness: 50%), scale-color($secondary, $lightness: 50%));
 }
 
+#topic-footer-button {
+  width: 100px;
+  margin: 0 auto;
+}
+
 #suggested-topics {
   clear: left;
   padding: 20px 0 15px 0;


### PR DESCRIPTION
Move replay button at the bottom of topic when the user is log out.
Move the button on the right on desktop and central on mobile.

Related to: https://meta.discourse.org/t/position-of-reply-button-to-the-right/49573/2

