### PR TITLE
Copy actions when moving first post

### DIFF
--- a/app/models/post_action.rb
+++ b/app/models/post_action.rb
@@ -305,6 +305,23 @@ SQL
     PostAction.where(where_attrs).first
   end
 
+  def self.copy(original_post, target_post)
+    cols_to_copy =
+      column_names.reject { |name| %w(id post_id).include?(name) }.join(', ')
+
+    exec_sql <<-SQL.squish
+      INSERT INTO post_actions(post_id, #{cols_to_copy})
+      SELECT #{target_post.id}, #{cols_to_copy}
+      FROM post_actions
+      WHERE post_id = #{original_post.id}
+    SQL
+
+    post_cols_to_copy =
+      PostActionType.types.keys.map { |key| :"#{key}_count" } + [:like_score]
+
+    target_post.update_columns(original_post.slice(*post_cols_to_copy))
+  end
+
   def self.remove_act(user, post, post_action_type_id)
 
     limit_action!(user,post,post_action_type_id)

--- a/app/models/post_mover.rb
+++ b/app/models/post_mover.rb
@@ -92,6 +92,7 @@ class PostMover
       acting_user: user,
       skip_validations: true
     )
+    PostAction.copy(post, p)
     p.update_column(:reply_count, @reply_count[1] || 0)
   end
 

--- a/spec/models/post_mover_spec.rb
+++ b/spec/models/post_mover_spec.rb
@@ -284,6 +284,18 @@ describe PostMover do
           expect(topic.highest_post_number).to eq(p4.post_number)
         end
 
+        it "preserves post actions in the new post" do
+          PostAction.act(another_user, p1, PostActionType.types[:like])
+          topic.expects(:add_moderator_post).once
+
+          new_topic = topic.move_posts(user, [p1.id], title: "new testing topic name")
+          expect(new_topic.like_count).to eq(1)
+
+          new_first = new_topic.posts.where(post_number: 1).first
+          expect(new_first.like_count).to eq(1)
+          expect(new_first.post_actions.size).to eq(1)
+        end
+
       end
 
       context "to an existing topic with a deleted post" do

--- a/spec/models/post_mover_spec.rb
+++ b/spec/models/post_mover_spec.rb
@@ -267,7 +267,7 @@ describe PostMover do
           p1.reload
           expect(p1.sort_order).to eq(1)
           expect(p1.post_number).to eq(1)
-          p1.topic_id == topic.id
+          expect(p1.topic_id).to eq(topic.id)
           expect(p1.reply_count).to eq(0)
 
           # New first post
@@ -278,7 +278,7 @@ describe PostMover do
           p2.reload
           expect(p2.post_number).to eq(2)
           expect(p2.sort_order).to eq(2)
-          p2.topic_id == new_topic.id
+          expect(p2.topic_id).to eq(new_topic.id)
           expect(p2.reply_to_post_number).to eq(1)
           expect(p2.reply_count).to eq(0)
 

--- a/spec/models/post_mover_spec.rb
+++ b/spec/models/post_mover_spec.rb
@@ -256,10 +256,7 @@ describe PostMover do
           new_topic = topic.move_posts(user, [p1.id, p2.id], title: "new testing topic name")
 
           expect(new_topic).to be_present
-          new_topic.posts.reload
           expect(new_topic.posts.by_post_number.first.raw).to eq(p1.raw)
-
-          new_topic.reload
           expect(new_topic.posts_count).to eq(2)
           expect(new_topic.highest_post_number).to eq(2)
 


### PR DESCRIPTION
This is an attempt to fix https://meta.discourse.org/t/transfer-likes-when-moving-a-new-topic-into-an-existing-one/44234, which has been biting us lately.

I went with the "updating DB directly" approach since I don't think we want any of the automatic callback behavior triggered on post action creation.

Let me know what you think.