### PR TITLE
Use `natural` orientation for web app manifest.

### DIFF
--- a/app/controllers/metadata_controller.rb
+++ b/app/controllers/metadata_controller.rb
@@ -17,7 +17,7 @@ class MetadataController < ApplicationController
       name: SiteSetting.title,
       short_name: SiteSetting.title,
       display: 'standalone',
-      orientation: 'any',
+      orientation: 'natural',
       start_url: "#{Discourse.base_uri}/",
       background_color: "##{ColorScheme.hex_for_name('secondary')}",
       theme_color: "##{ColorScheme.hex_for_name('header_background')}",


### PR DESCRIPTION
The `any` orientation forces the rotation even when the device's screen
 rotation is disabled. Using `natural` respects that and restores the
 expected behaviour.