### PR TITLE
new: server plugin outlet for indexable robots.txt

### DIFF
--- a/app/views/robots_txt/index.erb
+++ b/app/views/robots_txt/index.erb
@@ -15,3 +15,5 @@ Disallow: /search
 Disallow: /search/
 Disallow: /tags
 Disallow: /tags/
+
+<%= server_plugin_outlet "robots_txt_index" %>


### PR DESCRIPTION
As per @SamSaffron's comment below I added a server plugin outlet.

> There is no built in extensibility to robots.txt generation, this needs to be added so it does not overwrite it completely (instead plugin should inject the instructions). Otherwise, each time we touch robots.txt plugin needs to be updated.

https://meta.discourse.org/t/discourse-sitemap-plugin/40348/32?u=vinothkannans