### PR TITLE
FEATURE: Add user name in search results 

### DIFF
--- a/app/assets/javascripts/discourse/widgets/search-menu-results.js.es6
+++ b/app/assets/javascripts/discourse/widgets/search-menu-results.js.es6
@@ -46,7 +46,7 @@ function postResult(result, link, term) {
 }
 
 createSearchResult('user', 'path', function(u) {
-  return [ avatarImg('small', { template: u.avatar_template, username: u.username }), ' ', u.username ];
+  return [ avatarImg('small', { template: u.avatar_template, username: u.username }), ' ', h('span.user-results', h('b', u.username)), ' ',  h('span.user-results', u.name ? u.name : '') ];
 });
 
 createSearchResult('topic', 'url', function(result, term) {

--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -184,6 +184,10 @@
       display: block;
       padding: 5px;
       transition: all linear .15s;
+
+      .user-results {
+        color: dark-light-choose(scale-color($primary, $lightness: 30%), scale-color($secondary, $lightness: 70%));
+      }
     }
 
     &:hover a:not(.badge-notification) {

--- a/app/serializers/grouped_search_result_serializer.rb
+++ b/app/serializers/grouped_search_result_serializer.rb
@@ -1,6 +1,6 @@
 class GroupedSearchResultSerializer < ApplicationSerializer
   has_many :posts, serializer: SearchPostSerializer
-  has_many :users, serializer: BasicUserSerializer
+  has_many :users, serializer: SearchResultUserSerializer
   has_many :categories, serializer: BasicCategorySerializer
   attributes :more_posts, :more_users, :more_categories
 end

--- a/app/serializers/search_result_user_serializer.rb
+++ b/app/serializers/search_result_user_serializer.rb
@@ -1,0 +1,3 @@
+class SearchResultUserSerializer < BasicUserSerializer
+  attributes :name
+end


### PR DESCRIPTION
I add a user original name next to username in search reults.

Based on #pr-welcome issue: 
https://meta.discourse.org/t/in-search-result-drop-box-add-given-name-next-to-username/48735/4

QUESTION:
I try to search if there is any test to fix but i didn't find any. Akthiugh i'm pretty new to contributing to discourse so if you have any suggestion about being sure to find test if written and being sure that each test passed, please share with me