### PR TITLE
Revert "use RFC-complient signature separator dash-dash-space"

### DIFF
--- a/lib/email/message_builder.rb
+++ b/lib/email/message_builder.rb
@@ -40,7 +40,7 @@ module Email
             string = allow_reply_by_email? ? "user_notifications.reply_by_email" : "user_notifications.visit_link_to_respond"
             string << "_pm" if @opts[:private_reply]
           end
-          @template_args[:respond_instructions] = "-- \n" + I18n.t(string, @template_args)
+          @template_args[:respond_instructions] = "---\n" + I18n.t(string, @template_args)
         end
 
         if @opts[:add_unsubscribe_link]


### PR DESCRIPTION
Reverts discourse/discourse#4699 as this is not the right way to fix this issue.