### PR TITLE
Allow access to safari hack applicable function

### DIFF
--- a/app/assets/javascripts/discourse/lib/safari-hacks.js.es6
+++ b/app/assets/javascripts/discourse/lib/safari-hacks.js.es6
@@ -1,4 +1,4 @@
-function applicable() {
+export function applicable() {
   // IE has no DOMNodeInserted so can not get this hack despite saying it is like iPhone
   // This will apply hack on all iDevices
   return navigator.userAgent.match(/(iPad|iPhone|iPod)/g) &&

--- a/app/assets/javascripts/discourse/lib/safari-hacks.js.es6
+++ b/app/assets/javascripts/discourse/lib/safari-hacks.js.es6
@@ -1,4 +1,4 @@
-export function applicable() {
+export function isAppleDevice() {
   // IE has no DOMNodeInserted so can not get this hack despite saying it is like iPhone
   // This will apply hack on all iDevices
   return navigator.userAgent.match(/(iPad|iPhone|iPod)/g) &&
@@ -32,7 +32,7 @@ export function isWorkaroundActive() {
 
 // per http://stackoverflow.com/questions/29001977/safari-in-ios8-is-scrolling-screen-when-fixed-elements-get-focus/29064810
 function positioningWorkaround($fixedElement) {
-  if (!applicable()) {
+  if (!isAppleDevice()) {
     return;
   }
 


### PR DESCRIPTION
Hey, how do we feel about giving access to the 'applicable' function, which will allow poor plugin authors like me the ability to construct our own filthy iDevice hacks?

I also might be interested in renaming this to `isAppleDevice` or something, to make the exported function name a bit more descriptive.