### PR TITLE
fix malformed qunit url

### DIFF
--- a/lib/tasks/qunit.rake
+++ b/lib/tasks/qunit.rake
@@ -35,7 +35,7 @@ task "qunit:test", [:timeout] => :environment do |_, args|
   begin
     success = true
     test_path = "#{Rails.root}/vendor/assets/javascripts"
-    cmd = "phantomjs #{test_path}/run-qunit.js http://localhost:#{port}/qunit #{args[:timeout]}"
+    cmd = "phantomjs #{test_path}/run-qunit.js http://localhost:#{port}/qunit"
 
     options = {}
 
@@ -45,6 +45,10 @@ task "qunit:test", [:timeout] => :environment do |_, args|
 
     if options.present?
       cmd += "?#{options.to_query.gsub('+', '%20')}"
+    end
+
+    if args[:timeout].present?
+      cmd += " #{args[:timeout]}"
     end
 
     # wait for server to respond, will exception out on failure


### PR DESCRIPTION
this removes the space between the query string and the URL

```
$ MODULE='Acceptance: Search' bundle exec rake qunit:test\[20000\]
....
Running: {"module":"Acceptance: Search"}
... http://localhost:60099/qunit?module=Acceptance%3A%20Search 20000
```

The timeout value seems to work fine.

Note the back slashes are only needed for zsh shell. Otherwise run:

```
$ MODULE='Acceptance: Search' bundle exec rake qunit:test[20000]
```