### PR TITLE
FEATURE: Socialcast Importer: Set category and tags based on group

### DIFF
--- a/lib/oneboxer.rb
+++ b/lib/oneboxer.rb
@@ -1,4 +1,4 @@
-require_dependency "./lib/onebox/discourse_onebox_sanitize_config"
+require_dependency "#{Rails.root}/lib/onebox/discourse_onebox_sanitize_config"
 Dir["#{Rails.root}/lib/onebox/engine/*_onebox.rb"].sort.each { |f| require f }
 
 module Oneboxer

--- a/script/import_scripts/socialcast/README.md
+++ b/script/import_scripts/socialcast/README.md
@@ -10,12 +10,22 @@ password: 'my-socialcast-password'
 ```
 
 Create the directory for the json files to export: `mkdir output`
-Then run `ruby export.rb /path/to/config.yml`
+Then run `bundle exec ruby export.rb /path/to/config.yml`
 
-Create a category named "Socialcast Import" or all topics will be imported into
-the "Uncategorized" category.
+If desired, edit the `socialcast_message.rb` file to set the category
+and tags for each topic based on the name of the Socialcast group it was
+originally posted to.
 
-Topics will be tagged with the names of the groups they were originally posted
-in on Socialcast.
+You must create categories with the same names first in your site.
 
-To run the import, run `ruby import.rb`
+All topics will get the `DEFAULT_TAG` at minimum.
+
+Topics posted to a group that matches any group name in the `TAGS_AND_CATEGORIES`
+map will get the associated category and tags.
+
+Other topics will be tagged with the original groupname and placed in the
+`DEFAULT_CATEGORY`.
+
+To run the import, run `bundle exec ruby import.rb`
+
+To run the import in a production, run `RAILS_ENV=production bundle exec ruby import.rb`

--- a/script/import_scripts/socialcast/import.rb
+++ b/script/import_scripts/socialcast/import.rb
@@ -65,7 +65,6 @@ class ImportScripts::Socialcast < ImportScripts::Base
       post = Post.find(post_id) # already imported this topic
     else
       topic[:user_id] = user_id_from_imported_user_id(topic[:author_id]) || -1
-      topic[:category] = 'Socialcast Import'
 
       post = create_post(topic, topic[:id])
 

--- a/script/import_scripts/socialcast/socialcast_message.rb
+++ b/script/import_scripts/socialcast/socialcast_message.rb
@@ -5,6 +5,19 @@ require_relative 'create_title.rb'
 
 class SocialcastMessage
 
+  DEFAULT_CATEGORY = "Socialcast Import"
+  DEFAULT_TAG = "socialcast-import"
+  TAGS_AND_CATEGORIES = {
+    "somegroupname" => {
+      category: "Apple Stems",
+      tags: ["waxy", "tough"]
+    },
+    "someothergroupname" => {
+      category: "Orange Peels",
+      tags: ["oily"]
+    }
+   }
+
    def initialize message_json
      @parsed_json = JSON.parse message_json
    end
@@ -16,7 +29,8 @@ class SocialcastMessage
      topic[:title] = title
      topic[:raw] = @parsed_json['body']
      topic[:created_at] = Time.parse @parsed_json['created_at']
-     topic[:tags] = [group] if group
+     topic[:tags] = tags
+     topic[:category] = category
      topic
    end
 
@@ -24,8 +38,30 @@ class SocialcastMessage
      CreateTitle.from_body @parsed_json['body']
    end
 
+   def tags
+     tags = []
+     if group
+       if TAGS_AND_CATEGORIES[group]
+         tags = TAGS_AND_CATEGORIES[group][:tags]
+       else
+         tags << group
+       end
+     end
+     tags << DEFAULT_TAG
+     tags
+   end
+
+
+   def category
+     category = DEFAULT_CATEGORY
+     if group && TAGS_AND_CATEGORIES[group]
+       category = TAGS_AND_CATEGORIES[group][:category]
+     end
+     category
+   end
+
    def group
-     @parsed_json['group']['groupname'] if @parsed_json['group']
+     @parsed_json['group']['groupname'].downcase if @parsed_json['group'] && @parsed_json['group']['groupname']
    end
 
    def url


### PR DESCRIPTION
If desired, edit the `socialcast_message.rb` file to set the category
and tags for each topic based on the name of the Socialcast group it was
originally posted to.

You must create categories with the same names first in your site.

All topics will get the `DEFAULT_TAG` at minimum.

Topics posted to a group that matches any group name in the `TAGS_AND_CATEGORIES`
map will get the associated category and tags.

Other topics will be tagged with the original groupname and placed in the
`DEFAULT_CATEGORY`.
