### PR TITLE
FEATURE: Admin user list sortable

### DIFF
--- a/app/assets/javascripts/admin/components/admin-directory-toggle.js.es6
+++ b/app/assets/javascripts/admin/components/admin-directory-toggle.js.es6
@@ -4,13 +4,7 @@ import { bufferedRender } from 'discourse-common/lib/buffered-render';
 export default Ember.Component.extend(bufferedRender({
   tagName: 'th',
   classNames: ['sortable'],
-  attributeBindings: ['title'],
-  rerenderTriggers: ['order', 'asc'],
-
-  title: function() {
-    const labelKey = this.get('field');
-    return I18n.t(labelKey + '_long', { defaultValue: I18n.t(labelKey) });
-  }.property('field'),
+  rerenderTriggers: ['order', 'ascending'],
 
   buildBuffer(buffer) {
     const icon = this.get('icon');
@@ -18,23 +12,21 @@ export default Ember.Component.extend(bufferedRender({
       buffer.push(iconHTML(icon));
     }
 
-    const field = this.get('field');
-    buffer.push(I18n.t(field));
+    buffer.push(I18n.t(this.get('i18nKey')));
 
-    if (field === this.get('order')) {
-      buffer.push(iconHTML(this.get('asc') ? 'chevron-up' : 'chevron-down'));
+    if (this.get('field') === this.get('order')) {
+      buffer.push(iconHTML(this.get('ascending') ? 'chevron-up' : 'chevron-down'));
     }
   },
 
   click() {
-    const currentOrder = this.get('order'),
-          field = this.get('field');
-    console.log(this);
+    const currentOrder = this.get('order');
+    const field = this.get('field');
 
     if (currentOrder === field) {
-      this.set('asc', this.get('asc') ? null : true);
+      this.set('ascending', this.get('ascending') ? null : true);
     } else {
-      this.setProperties({ order: field, asc: null });
+      this.setProperties({ order: field, ascending: null });
     }
   }
 }));

--- a/app/assets/javascripts/admin/components/admin-directory-toggle.js.es6
+++ b/app/assets/javascripts/admin/components/admin-directory-toggle.js.es6
@@ -1,0 +1,40 @@
+import { iconHTML } from 'discourse-common/helpers/fa-icon';
+import { bufferedRender } from 'discourse-common/lib/buffered-render';
+
+export default Ember.Component.extend(bufferedRender({
+  tagName: 'th',
+  classNames: ['sortable'],
+  attributeBindings: ['title'],
+  rerenderTriggers: ['order', 'asc'],
+
+  title: function() {
+    const labelKey = this.get('field');
+    return I18n.t(labelKey + '_long', { defaultValue: I18n.t(labelKey) });
+  }.property('field'),
+
+  buildBuffer(buffer) {
+    const icon = this.get('icon');
+    if (icon) {
+      buffer.push(iconHTML(icon));
+    }
+
+    const field = this.get('field');
+    buffer.push(I18n.t(field));
+
+    if (field === this.get('order')) {
+      buffer.push(iconHTML(this.get('asc') ? 'chevron-up' : 'chevron-down'));
+    }
+  },
+
+  click() {
+    const currentOrder = this.get('order'),
+          field = this.get('field');
+    console.log(this);
+
+    if (currentOrder === field) {
+      this.set('asc', this.get('asc') ? null : true);
+    } else {
+      this.setProperties({ order: field, asc: null });
+    }
+  }
+}));

--- a/app/assets/javascripts/admin/controllers/admin-users-list-show.js.es6
+++ b/app/assets/javascripts/admin/controllers/admin-users-list-show.js.es6
@@ -7,7 +7,7 @@ import { observes } from 'ember-addons/ember-computed-decorators';
 export default Ember.Controller.extend({
   query: null,
   queryParams: ['order', 'ascending'],
-  order: '',
+  order: 'seen',
   ascending: null,
   showEmails: false,
   refreshing: false,
@@ -44,21 +44,12 @@ export default Ember.Controller.extend({
     this._refreshUsers();
   }, 250).observes('listFilter'),
 
+
+  @observes('order', 'ascending')
   _refreshUsers: function() {
     this.set('refreshing', true);
 
-    AdminUser.findAll( { filter: this.get('listFilter'), show_emails: this.get('showEmails') }).then( (result) => {
-      this.set('model', result);
-    }).finally( () => {
-      this.set('refreshing', false);
-    });
-  },
-
-  @observes('order', 'ascending')
-  sortUsers: function() {
-    this.set('refreshing', true);
-
-    AdminUser.findAll(this.get('query'), {order: this.get('order'), ascending: this.get('ascending')} ).then( (result) => {
+    AdminUser.findAll(this.get('query'), { filter: this.get('listFilter'), show_emails: this.get('showEmails'), order: this.get('order'), ascending: this.get('ascending') }).then( (result) => {
       this.set('model', result);
     }).finally( () => {
       this.set('refreshing', false);

--- a/app/assets/javascripts/admin/controllers/admin-users-list-show.js.es6
+++ b/app/assets/javascripts/admin/controllers/admin-users-list-show.js.es6
@@ -1,9 +1,14 @@
 import debounce from 'discourse/lib/debounce';
 import { i18n } from 'discourse/lib/computed';
 import AdminUser from 'admin/models/admin-user';
+import { observes } from 'ember-addons/ember-computed-decorators';
+
 
 export default Ember.Controller.extend({
   query: null,
+  queryParams: ['order', 'ascending'],
+  order: '',
+  ascending: null,
   showEmails: false,
   refreshing: false,
   listFilter: null,
@@ -40,13 +45,23 @@ export default Ember.Controller.extend({
   }, 250).observes('listFilter'),
 
   _refreshUsers: function() {
-    var self = this;
     this.set('refreshing', true);
 
-    AdminUser.findAll(this.get('query'), { filter: this.get('listFilter'), show_emails: this.get('showEmails') }).then(function (result) {
-      self.set('model', result);
-    }).finally(function() {
-      self.set('refreshing', false);
+    AdminUser.findAll( { filter: this.get('listFilter'), show_emails: this.get('showEmails') }).then( (result) => {
+      this.set('model', result);
+    }).finally( () => {
+      this.set('refreshing', false);
+    });
+  },
+
+  @observes('order', 'ascending')
+  sortUsers: function() {
+    this.set('refreshing', true);
+
+    AdminUser.findAll(this.get('query'), {order: this.get('order'), ascending: this.get('ascending')} ).then( (result) => {
+      this.set('model', result);
+    }).finally( () => {
+      this.set('refreshing', false);
     });
   },
 

--- a/app/assets/javascripts/admin/routes/admin-users-list-show.js.es6
+++ b/app/assets/javascripts/admin/routes/admin-users-list-show.js.es6
@@ -13,6 +13,5 @@ export default Discourse.Route.extend({
       showEmails: false,
       refreshing: false,
     });
-    controller.sortUsers();
   }
 });

--- a/app/assets/javascripts/admin/routes/admin-users-list-show.js.es6
+++ b/app/assets/javascripts/admin/routes/admin-users-list-show.js.es6
@@ -13,5 +13,6 @@ export default Discourse.Route.extend({
       showEmails: false,
       refreshing: false,
     });
+    controller.sortUsers();
   }
 });

--- a/app/assets/javascripts/admin/templates/users-list-show.hbs
+++ b/app/assets/javascripts/admin/templates/users-list-show.hbs
@@ -34,7 +34,7 @@
         {{admin-directory-toggle field="topics_viewed" i18nKey="admin.user.topics_entered" order=order ascending=ascending}}
         {{admin-directory-toggle field="posts_read" i18nKey="admin.user.posts_read_count" order=order ascending=ascending}}
         {{admin-directory-toggle field="read_time" i18nKey="admin.user.time_read" order=order ascending=ascending}}
-        <th>{{admin-directory-toggle field="created" i18nKey="created" order=order ascending=ascending}}</th>
+        {{admin-directory-toggle field="created" i18nKey="created" order=order ascending=ascending}}
         {{#if showApproval}}
           <th>{{i18n 'admin.users.approved'}}</th>
         {{/if}}
@@ -92,10 +92,10 @@
             {{/if}}
             <td>
               {{#if user.admin}}
-                <i class="fa fa-shield" title="{{i18n 'admin.title'}}"></i>
+                {{fa-icon "shield" title="admin.title" }}
               {{/if}}
               {{#if user.moderator}}
-                <i class="fa fa-shield" title="{{i18n 'admin.moderator'}}"></i>
+                {{fa-icon "shield" title="admin.moderator" }}
               {{/if}}
             </td>
           </tr>

--- a/app/assets/javascripts/admin/templates/users-list-show.hbs
+++ b/app/assets/javascripts/admin/templates/users-list-show.hbs
@@ -22,7 +22,7 @@
 {{#conditional-loading-spinner condition=refreshing}}
   {{#if model}}
     <table class='table users-list'>
-      <tr>
+      <thead>
         {{#if showApproval}}
           <th>{{input type="checkbox" checked=selectAll}}</th>
         {{/if}}
@@ -30,54 +30,59 @@
         <th>{{i18n 'username'}}</th>
         <th>{{i18n 'email'}}</th>
         <th>{{i18n 'admin.users.last_emailed'}}</th>
-        <th>{{i18n 'last_seen'}}</th>
-        <th>{{i18n 'admin.user.topics_entered'}}</th>
-        <th>{{i18n 'admin.user.posts_read_count'}}</th>
-        <th>{{i18n 'admin.user.time_read'}}</th>
+        {{admin-directory-toggle field="last_seen" order=order asc=asc}}
+        {{admin-directory-toggle field="admin.user.topics_entered" order=order asc=asc}}
+        {{admin-directory-toggle field="admin.user.posts_read_count" order=order asc=asc}}
+        {{admin-directory-toggle field="admin.user.time_read" order=order asc=asc}}
         <th>{{i18n 'created'}}</th>
         {{#if showApproval}}
           <th>{{i18n 'admin.users.approved'}}</th>
         {{/if}}
         <th>&nbsp;</th>
-      </tr>
+      </thead>
+      <tbody>
+        {{#each model as |user|}}
+          <tr class="user {{user.selected}} {{unless user.active 'not-activated'}}">
+            {{#if showApproval}}
+              <td>
+                {{#if user.can_approve}}
+                  {{input type="checkbox" checked=user.selected}}
+                {{/if}}
+              </td>
+            {{/if}}
+            <td><a href="{{unbound user.path}}" data-user-card="{{unbound user.username}}">{{avatar user imageSize="small"}}</a></td>
+            <td>{{#link-to 'adminUser' user}}{{unbound user.username}}{{/link-to}}</td>
+            <td class='email'>{{unbound user.email}}</td>
+            <td>{{{unbound user.last_emailed_age}}}</td>
+            <td>{{{unbound user.last_seen_age}}}</td>
+            <td>{{number user.topics_entered}}</td>
+            <td>{{number user.posts_read_count}}</td>
+            <td>{{{unbound user.time_read}}}</td>
 
-      {{#each model as |user|}}
-        <tr class="user {{user.selected}} {{unless user.active 'not-activated'}}">
-          {{#if showApproval}}
+            <td>{{{unbound user.created_at_age}}}</td>
+
+            {{#if showApproval}}
+              <td>
+                {{#if user.approved}}
+                  {{i18n 'yes_value'}}
+                {{else}}
+                  {{i18n 'no_value'}}
+                {{/if}}
+              </td>
+            {{/if}}
             <td>
-              {{#if user.can_approve}}
-                {{input type="checkbox" checked=user.selected}}
+              {{#if user.admin}}
+                <i class="fa fa-shield" title="{{i18n 'admin.title'}}"></i>
+              {{/if}}
+              {{#if user.moderator}}
+                <i class="fa fa-shield" title="{{i18n 'admin.moderator'}}"></i>
               {{/if}}
             </td>
-          {{/if}}
-          <td><a href="{{unbound user.path}}" data-user-card="{{unbound user.username}}">{{avatar user imageSize="small"}}</a></td>
-          <td>{{#link-to 'adminUser' user}}{{unbound user.username}}{{/link-to}}</td>
-          <td class='email'>{{unbound user.email}}</td>
-          <td>{{{unbound user.last_emailed_age}}}</td>
-          <td>{{{unbound user.last_seen_age}}}</td>
-          <td>{{number user.topics_entered}}</td>
-          <td>{{number user.posts_read_count}}</td>
-          <td>{{{unbound user.time_read}}}</td>
-
-          <td>{{{unbound user.created_at_age}}}</td>
-
-          {{#if showApproval}}
-          <td>
-            {{#if user.approved}}
-              {{i18n 'yes_value'}}
-            {{else}}
-              {{i18n 'no_value'}}
-            {{/if}}
-          </td>
-          {{/if}}
-          <td>
-            {{#if user.admin}}<i class="fa fa-shield" title="{{i18n 'admin.title'}}"></i>{{/if}}
-            {{#if user.moderator}}<i class="fa fa-shield" title="{{i18n 'admin.moderator'}}"></i>{{/if}}
-          </td>
-        </tr>
-      {{/each}}
-
+          </tr>
+        {{/each}}
+      </tbody>
     </table>
+    {{conditional-loading-spinner condition=model.loadingMore}}
   {{else}}
     <p>{{i18n 'search.no_results'}}</p>
   {{/if}}

--- a/app/assets/javascripts/admin/templates/users-list-show.hbs
+++ b/app/assets/javascripts/admin/templates/users-list-show.hbs
@@ -30,11 +30,11 @@
         <th>{{i18n 'username'}}</th>
         <th>{{i18n 'email'}}</th>
         <th>{{i18n 'admin.users.last_emailed'}}</th>
-        {{admin-directory-toggle field="last_seen" order=order asc=asc}}
-        {{admin-directory-toggle field="admin.user.topics_entered" order=order asc=asc}}
-        {{admin-directory-toggle field="admin.user.posts_read_count" order=order asc=asc}}
-        {{admin-directory-toggle field="admin.user.time_read" order=order asc=asc}}
-        <th>{{i18n 'created'}}</th>
+        {{admin-directory-toggle field="seen" i18nKey='last_seen' order=order ascending=ascending}}
+        {{admin-directory-toggle field="topics_viewed" i18nKey="admin.user.topics_entered" order=order ascending=ascending}}
+        {{admin-directory-toggle field="posts_read" i18nKey="admin.user.posts_read_count" order=order ascending=ascending}}
+        {{admin-directory-toggle field="read_time" i18nKey="admin.user.time_read" order=order ascending=ascending}}
+        <th>{{admin-directory-toggle field="created" i18nKey="created" order=order ascending=ascending}}</th>
         {{#if showApproval}}
           <th>{{i18n 'admin.users.approved'}}</th>
         {{/if}}
@@ -44,22 +44,42 @@
         {{#each model as |user|}}
           <tr class="user {{user.selected}} {{unless user.active 'not-activated'}}">
             {{#if showApproval}}
-              <td>
-                {{#if user.can_approve}}
-                  {{input type="checkbox" checked=user.selected}}
-                {{/if}}
-              </td>
+            <td>
+              {{#if user.can_approve}}
+                {{input type="checkbox" checked=user.selected}}
+              {{/if}}
+            </td>
             {{/if}}
-            <td><a href="{{unbound user.path}}" data-user-card="{{unbound user.username}}">{{avatar user imageSize="small"}}</a></td>
-            <td>{{#link-to 'adminUser' user}}{{unbound user.username}}{{/link-to}}</td>
-            <td class='email'>{{unbound user.email}}</td>
-            <td>{{{unbound user.last_emailed_age}}}</td>
-            <td>{{{unbound user.last_seen_age}}}</td>
-            <td>{{number user.topics_entered}}</td>
-            <td>{{number user.posts_read_count}}</td>
-            <td>{{{unbound user.time_read}}}</td>
+            <td>
+              <a href="{{unbound user.path}}" data-user-card="{{unbound user.username}}">
+                {{avatar user imageSize="small"}}
+              </a>
+            </td>
+            <td>
+              {{#link-to 'adminUser' user}}{{unbound user.username}}{{/link-to}}
+            </td>
+            <td class='email'>
+              {{unbound user.email}}
+            </td>
+            <td>
+              {{{unbound user.last_emailed_age}}}
+            </td>
+            <td>
+              {{{unbound user.last_seen_age}}}
+            </td>
+            <td>
+              {{number user.topics_entered}}
+            </td>
+            <td>
+              {{number user.posts_read_count}}
+            </td>
+            <td>
+              {{{unbound user.time_read}}}
+            </td>
 
-            <td>{{{unbound user.created_at_age}}}</td>
+            <td>
+              {{{unbound user.created_at_age}}}
+            </td>
 
             {{#if showApproval}}
               <td>
@@ -82,7 +102,7 @@
         {{/each}}
       </tbody>
     </table>
-    {{conditional-loading-spinner condition=model.loadingMore}}
+
   {{else}}
     <p>{{i18n 'search.no_results'}}</p>
   {{/if}}

--- a/app/assets/stylesheets/common/admin/admin_base.scss
+++ b/app/assets/stylesheets/common/admin/admin_base.scss
@@ -31,8 +31,10 @@ $mobile-breakpoint: 700px;
   width: 100%;
   tr {text-align: left;}
   td, th {padding: 8px;}
-  th {border-top: 1px solid dark-light-diff($primary, $secondary, 90%, -60%);}
+  th {border-top: 1px solid dark-light-diff($primary, $secondary, 90%, -60%); text-align: left;}
   td {border-bottom: 1px solid dark-light-diff($primary, $secondary, 90%, -60%); border-top: 1px solid dark-light-diff($primary, $secondary, 90%, -60%);}
+  th.sortable i.fa-chevron-down,
+  th.sortable i.fa-chevron-up {margin-left: 0.5em;}
   tr:hover { background-color: darken($secondary, 2.5%); }
   tr.selected { background-color: lighten($primary, 80%); }
   .filters input { margin-bottom: 0; }


### PR DESCRIPTION
Added sortable functionality to admin users list using api `order` and `ascending` in four different columns: `Seen` `Topics Viewed` `Posts Read` and `Read Time`

Related meta issue:
https://meta.discourse.org/t/make-admin-users-list-sortable-suggestion/47649
