### PR TITLE
FIX: typo in rate_limiter edit_post message

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -492,7 +492,7 @@ en:
       pms_per_day: "You've reached the maximum number of messages today. Please wait %{time_left} before trying again."
       create_like: "You've reached the maximum number of likes today. Please wait %{time_left} before trying again."
       create_bookmark: "You've reached the maximum number of bookmarks today. Please wait %{time_left} before trying again."
-      edit_post: "You've reached the maximun number of edits today. Please wait %{time_left} before trying again."
+      edit_post: "You've reached the maximum number of edits today. Please wait %{time_left} before trying again."
       live_post_counts: "You're asking for live post counts too quickly. Please wait %{time_left} before trying again."
       unsubscribe_via_email: "You've reached the maximum number of unsubscribe via email today. Please wait %{time_left} before trying again."
       topic_invitations_per_day: "You've reached the maximum number of topic invitations today. Please wait %{time_left} before trying again."


### PR DESCRIPTION
Just the typo, nothing more.
I spotted error on meta: https://meta.discourse.org/t/has-anyone-hit-the-maximum-number-of-edits-in-a-forum/58162