### PR TITLE
FIX: approve invited user

### DIFF
--- a/spec/models/invite_spec.rb
+++ b/spec/models/invite_spec.rb
@@ -273,6 +273,7 @@ describe Invite do
 
     context 'inviting when must_approve_users? is enabled' do
       it 'correctly activates accounts' do
+        invite.invited_by = Fabricate(:admin)
         SiteSetting.stubs(:must_approve_users).returns(true)
         user = invite.redeem
         expect(user.approved?).to eq(true)


### PR DESCRIPTION
This commit fixes the case where invited users who typed in a password
would not be approved by default. Because we moved the user create logic
for an invited user there was a clash with the `save` in the user model
and the `save` in the invite_redeemer class.

- added approve logic into invite_redeemer class.
- added tests to verify that the user is approved