### PR TITLE
Custom filters for Topic View

### DIFF
--- a/spec/components/topic_view_spec.rb
+++ b/spec/components/topic_view_spec.rb
@@ -310,6 +310,22 @@ describe TopicView do
       end
     end
 
+    context "custom filters" do
+      it "can be applied" do
+        TopicView.add_custom_filter(:only_post_id) do |results, topic_view|
+          results = results.where('posts.id = ?', p5.id)
+          results
+        end
+
+        filtered = TopicView.new(topic.id, coding_horror)
+
+        expect(filtered.posts.map(&:id)).to eq([p5.id])
+        expect(filtered.contains_gaps?).to eq(true)
+
+        TopicView.remove_custom_filter(:only_post_id)
+      end
+    end
+
     it "#restricts to correct topic" do
       t2 = Fabricate(:topic)
 


### PR DESCRIPTION
Added functions to TopicView which allow for plugins to add custom filters. This lets plugins make use of the "view x hidden replies option". For example, discourse-solved could use it for hiding any posts between the question and the answer as described [here](https://meta.discourse.org/t/option-to-move-accepted-answer-to-the-top/58386)

The implementation is based on the TopicQuery custom filters added recently. A test has also been added to the spec file for TopicView.

Example usage:
<img width="500" alt="screen shot 2017-03-06 at 20 04 35" src="https://cloud.githubusercontent.com/assets/6270921/23628291/c0d09790-02ab-11e7-8fd0-370d6f9b8dd2.png">
