### PR TITLE
FIX: latest-version tag is shown by git-describe

### DIFF
--- a/lib/discourse_updates.rb
+++ b/lib/discourse_updates.rb
@@ -7,7 +7,7 @@ module DiscourseUpdates
         DiscourseVersionCheck.new(
           installed_version: Discourse::VERSION::STRING,
           installed_sha: (Discourse.git_version == 'unknown' ? nil : Discourse.git_version),
-          installed_describe: `git describe --dirty`,
+          installed_describe: `git describe --dirty --match "v[0-9]*"`,
           git_branch: Discourse.git_branch,
           updated_at: nil
         )
@@ -17,7 +17,7 @@ module DiscourseUpdates
           critical_updates: critical_updates_available?,
           installed_version: Discourse::VERSION::STRING,
           installed_sha: (Discourse.git_version == 'unknown' ? nil : Discourse.git_version),
-          installed_describe: `git describe --dirty`,
+          installed_describe: `git describe --dirty --match "v[0-9]*"`,
           missing_versions_count: missing_versions_count,
           git_branch: Discourse.git_branch,
           updated_at: updated_at


### PR DESCRIPTION
Adds the -match "v[0-9]*" parameter to git describe, this means that only version tags will be used.

See https://meta.discourse.org/t/latest-version-bug/58165/35