### PR TITLE
FIX: Category autocomplete breaks when search menu widget rerenders.

### DIFF
--- a/app/assets/javascripts/discourse/lib/autocomplete.js.es6
+++ b/app/assets/javascripts/discourse/lib/autocomplete.js.es6
@@ -261,7 +261,11 @@ export default function(options) {
       left: "-1000px"
     });
 
-    me.parent().append(div);
+    if (options.appendSelector) {
+      me.parents(options.appendSelector).append(div);
+    } else {
+      me.parent().append(div);
+    }
 
     if (!isInput && !options.treatAsTextarea) {
       vOffset = div.height();

--- a/app/assets/javascripts/discourse/lib/search.js.es6
+++ b/app/assets/javascripts/discourse/lib/search.js.es6
@@ -130,14 +130,14 @@ export function isValidSearchTerm(searchTerm) {
   }
 };
 
-export function applySearchAutocomplete($input, siteSettings, appEvents) {
+export function applySearchAutocomplete($input, siteSettings, appEvents, options) {
   const afterComplete = function() {
     if (appEvents) {
       appEvents.trigger("search-autocomplete:after-complete");
     }
   };
 
-  $input.autocomplete({
+  $input.autocomplete(_.merge({
     template: findRawTemplate('category-tag-autocomplete'),
     key: '#',
     width: '100%',
@@ -153,9 +153,9 @@ export function applySearchAutocomplete($input, siteSettings, appEvents) {
       return searchCategoryTag(term, siteSettings);
     },
     afterComplete
-  });
+  }, options));
 
-  $input.autocomplete({
+  $input.autocomplete(_.merge({
     template: findRawTemplate('user-selector-autocomplete'),
     key: "@",
     width: '100%',
@@ -163,5 +163,5 @@ export function applySearchAutocomplete($input, siteSettings, appEvents) {
     transformComplete: v => v.username || v.name,
     dataSource: term => userSearch({ term, includeGroups: true }),
     afterComplete
-  });
+  }, options));
 };

--- a/app/assets/javascripts/discourse/widgets/header.js.es6
+++ b/app/assets/javascripts/discourse/widgets/header.js.es6
@@ -262,7 +262,10 @@ export default createWidget('header', {
       Ember.run.schedule('afterRender', () => {
         const $searchInput = $('#search-term');
         $searchInput.focus().select();
-        applySearchAutocomplete($searchInput, this.siteSettings, this.appEvents);
+
+        applySearchAutocomplete($searchInput, this.siteSettings, this.appEvents, {
+          appendSelector: '.menu-panel'
+        });
       });
     }
   },


### PR DESCRIPTION
https://github.com/discourse/discourse/pull/4717#issuecomment-28491458

As the default category autocomplete search results has already been cached on page load, rendering the category autocomplete is fast. Being too fast here causes the element to be included when VDOM runs its diffing algorithm to figure out what has changed. For some reason that is beyond my understanding of the VDOM library, the autocomplete popup is being replaced with the `search-menu-results` div but results in an error in the process. This PR fixes the issue by ensuring that we do not append the autocomplete popup with the div that is being re-rendered by instead append it in a parent div that is will not re-render as the search term is changed.

@eviltrout Can you review this? Thank you so much!

cc @cpradio

![screenshot from 2017-03-08 20-12-43](https://cloud.githubusercontent.com/assets/4335742/23703905/4633615a-043d-11e7-9841-2610cf95cbd7.png)
