### PR TITLE
Improving search result blurb

### DIFF
--- a/app/assets/javascripts/discourse/templates/full-page-search.hbs
+++ b/app/assets/javascripts/discourse/templates/full-page-search.hbs
@@ -107,9 +107,7 @@
             </span>
 
             {{#if result.blurb}}
-              {{#highlight-text highlight=q}}
-                {{{unbound result.blurb}}}
-              {{/highlight-text}}
+              {{{unbound result.blurb}}}
             {{/if}}
           </div>
 

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -12,8 +12,7 @@ class SearchController < ApplicationController
     search_args = {
       type_filter: 'topic',
       guardian: guardian,
-      include_blurbs: true,
-      blurb_length: 300
+      include_blurbs: true
     }
 
     context, type = lookup_search_context

--- a/app/controllers/similar_topics_controller.rb
+++ b/app/controllers/similar_topics_controller.rb
@@ -10,9 +10,6 @@ class SimilarTopicsController < ApplicationController
 
     attr_reader :topic
 
-    def blurb
-      Search::GroupedSearchResults.blurb_for(@topic.try(:blurb))
-    end
   end
 
   def index

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -459,8 +459,9 @@ class Topic < ActiveRecord::Base
 
     return [] unless candidate_ids.present?
 
-    similar = Topic.select(sanitize_sql_array(["topics.*, similarity(topics.title, :title) + similarity(topics.title, :raw) AS similarity, p.cooked as blurb", title: title, raw: raw]))
+    similar = Topic.select(sanitize_sql_array(["topics.*, similarity(topics.title, :title) + similarity(topics.title, :raw) AS similarity, COALESCE(ts_headline(#{Search.query_locale}, post_search_data.raw_data,#{ts_query}, 'StartSel=\"<span class=search-highlight>\",StopSel=\"</span>\",MaxWords=15,MinWords=10,MaxFragments=2'), '') AS blurb", title: title, raw: raw]))
                      .joins("JOIN posts AS p ON p.topic_id = topics.id AND p.post_number = 1")
+                     .joins("JOIN post_search_data ON post_search_data.post_id = p.id")
                      .limit(SiteSetting.max_similar_results)
                      .where("topics.id IN (?)", candidate_ids)
                      .where("similarity(topics.title, :title) + similarity(topics.title, :raw) > 0.2", raw: raw, title: title)

--- a/app/serializers/search_post_serializer.rb
+++ b/app/serializers/search_post_serializer.rb
@@ -4,6 +4,6 @@ class SearchPostSerializer < BasicPostSerializer
   attributes :like_count, :blurb, :post_number
 
   def blurb
-    options[:result].blurb(object)
+    object.blurb.to_str
   end
 end

--- a/app/serializers/similar_topic_serializer.rb
+++ b/app/serializers/similar_topic_serializer.rb
@@ -8,7 +8,7 @@ class SimilarTopicSerializer < ApplicationSerializer
   end
 
   def blurb
-    object.topic.blurb
+    object.topic['blurb']
   end
 
   def url

--- a/app/serializers/similar_topic_serializer.rb
+++ b/app/serializers/similar_topic_serializer.rb
@@ -8,7 +8,7 @@ class SimilarTopicSerializer < ApplicationSerializer
   end
 
   def blurb
-    object.blurb
+    object.topic.blurb
   end
 
   def url

--- a/app/services/search_indexer.rb
+++ b/app/services/search_indexer.rb
@@ -11,7 +11,7 @@ class SearchIndexer
   end
 
   def self.scrub_html_for_search(html)
-    HtmlScrubber.scrub(html)
+    HtmlScrubber.scrub(html).squish
   end
 
   def self.update_index(table, id, search_data, raw_data)
@@ -66,7 +66,7 @@ class SearchIndexer
 
   def self.update_posts_index(post_id, cooked, title, category)
     raw_data = scrub_html_for_search(cooked)
-    search_data = raw_data << " " << title.dup.force_encoding('UTF-8')
+    search_data = raw_data.dup << " " << title.dup.force_encoding('UTF-8')
     search_data << " " << category if category
     update_index('post', post_id, search_data, raw_data)
   end

--- a/db/migrate/20170308172101_fix_search_index.rb
+++ b/db/migrate/20170308172101_fix_search_index.rb
@@ -1,0 +1,5 @@
+class FixSearchIndex < ActiveRecord::Migration
+  def self.up
+    Rake::Task['search:reindex'].invoke
+  end
+end

--- a/lib/search.rb
+++ b/lib/search.rb
@@ -157,7 +157,6 @@ class Search
     @guardian = @opts[:guardian] || Guardian.new
     @search_context = @opts[:search_context]
     @include_blurbs = @opts[:include_blurbs] || false
-    @blurb_length = @opts[:blurb_length]
     @limit = Search.per_facet
     @valid = true
 
@@ -177,7 +176,7 @@ class Search
       @limit = Search.per_filter
     end
 
-    @results = GroupedSearchResults.new(@opts[:type_filter], term, @search_context, @include_blurbs, @blurb_length)
+    @results = GroupedSearchResults.new(@opts[:type_filter], term, @search_context, @include_blurbs)
   end
 
   def valid?
@@ -752,7 +751,9 @@ class Search
       return [] unless post_sql
 
       Post.includes(:topic => :category)
+        .select("posts.*, COALESCE(ts_headline(#{Search.query_locale}, post_search_data_posts.raw_data,#{ts_query}, 'StartSel=\"<span class=search-highlight>\",StopSel=\"</span>\",MaxWords=15,MinWords=10,MaxFragments=3'), '') AS blurb")
         .includes(:user)
+        .joins(:post_search_data)
         .joins("JOIN (#{post_sql}) x ON x.id = posts.topic_id AND x.post_number = posts.post_number")
         .order('row_number')
     end

--- a/lib/search.rb
+++ b/lib/search.rb
@@ -750,12 +750,16 @@ class Search
     def aggregate_posts(post_sql)
       return [] unless post_sql
 
-      Post.includes(:topic => :category)
-        .select("posts.*, COALESCE(ts_headline(#{Search.query_locale}, post_search_data_posts.raw_data,#{ts_query}, 'StartSel=\"<span class=search-highlight>\",StopSel=\"</span>\",MaxWords=15,MinWords=10,MaxFragments=3'), '') AS blurb")
-        .includes(:user)
-        .joins(:post_search_data)
-        .joins("JOIN (#{post_sql}) x ON x.id = posts.topic_id AND x.post_number = posts.post_number")
-        .order('row_number')
+      posts = Post.includes(:topic => :category)
+                .includes(:user)
+                .joins("JOIN (#{post_sql}) x ON x.id = posts.topic_id AND x.post_number = posts.post_number")
+                .order('row_number')
+
+      posts = posts.select("posts.*, COALESCE(ts_headline(#{Search.query_locale}, post_search_data_posts.raw_data,#{ts_query}, 'StartSel=\"<span class=search-highlight>\",StopSel=\"</span>\",MaxWords=15,MinWords=10,MaxFragments=3'), '') AS blurb")
+                   .joins(:post_search_data) if @term.present?
+
+      posts
+
     end
 
     def aggregate_search(opts = {})

--- a/lib/search/grouped_search_results.rb
+++ b/lib/search/grouped_search_results.rb
@@ -14,12 +14,11 @@ class Search
                 :more_posts, :more_categories, :more_users,
                 :term, :search_context, :include_blurbs
 
-    def initialize(type_filter, term, search_context, include_blurbs, blurb_length)
+    def initialize(type_filter, term, search_context, include_blurbs)
       @type_filter = type_filter
       @term = term
       @search_context = search_context
       @include_blurbs = include_blurbs
-      @blurb_length = blurb_length || 200
       @posts = []
       @categories = []
       @users = []
@@ -31,10 +30,6 @@ class Search
         topic_lookup = TopicUser.lookup_for(user, topics)
         topics.each { |ft| ft.user_data = topic_lookup[ft.id] }
       end
-    end
-
-    def blurb(post)
-      GroupedSearchResults.blurb_for(post.cooked, @term, @blurb_length)
     end
 
     def add(object)

--- a/spec/components/search_spec.rb
+++ b/spec/components/search_spec.rb
@@ -263,7 +263,6 @@ describe Search do
         p = result.posts[0]
         expect(p.topic.id).to eq(topic.id)
         expect(p.id).to eq(reply.id)
-        expect(result.blurb(p)).to eq("this reply has no quotes")
       end
     end
 

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -15,7 +15,7 @@ describe SearchController do
       expect(response).to be_success
       data = JSON.parse(response.body)
       expect(data['posts'][0]['id']).to eq(my_post.id)
-      expect(data['posts'][0]['blurb']).to eq('this is my really awesome post')
+      expect(data['posts'][0]['blurb']).to eq('this is my really <span class=search-highlight>awesome</span> post')
       expect(data['topics'][0]['id']).to eq(my_post.topic_id)
     end
   end

--- a/spec/services/search_indexer_spec.rb
+++ b/spec/services/search_indexer_spec.rb
@@ -10,7 +10,7 @@ describe SearchIndexer do
     SearchIndexer.update_posts_index(99, "你好世界", "", nil)
 
     raw_data = PostSearchData.where(post_id: 99).pluck(:raw_data)[0]
-    expect(raw_data.split(' ').length).to eq(2)
+    expect(raw_data.split(' ').length).to eq(1)
   end
 
   it 'correctly indexes a post' do


### PR DESCRIPTION
# Problem

Discourse _blurb_ does not correlate with the Postgres methods used to index and search data. 

# Solution

This PR does the following:

- Removes Ruby methods that build "blurbs" in search results. In place, harnessing powerful Postgres `ts_headline` to build better blurbs.
- Removes unnecessary index data from raw_data fields (topic title) in posts, and topic indexes leaving search_data fields in current format
- Improves result processing by using preprocessed raw_data
- Removes blurb-length search option due to irrelevance in blurb calculations 
