### PR TITLE
Show disable delete btn cat

### DIFF
--- a/app/assets/javascripts/discourse/components/d-button.js.es6
+++ b/app/assets/javascripts/discourse/components/d-button.js.es6
@@ -8,14 +8,14 @@ export default Ember.Component.extend({
   classNameBindings: [':btn', 'noText'],
   attributeBindings: ['disabled', 'translatedTitle:title'],
 
-  noText: Ember.computed.empty('translatedLabel'),
+  noText: Ember.computed.empty('translatedLabel'), //if translatedLable = null/empty then noText = true
 
-  @computed("title")
+  @computed("title") //this.get('title')
   translatedTitle(title) {
     if (title) return I18n.t(title);
   },
 
-  @computed("label")
+  @computed("label")//this.get('label')
   translatedLabel(label) {
     if (label) return I18n.t(label);
   },

--- a/app/assets/javascripts/discourse/components/d-button.js.es6
+++ b/app/assets/javascripts/discourse/components/d-button.js.es6
@@ -8,14 +8,14 @@ export default Ember.Component.extend({
   classNameBindings: [':btn', 'noText'],
   attributeBindings: ['disabled', 'translatedTitle:title'],
 
-  noText: Ember.computed.empty('translatedLabel'), //if translatedLable = null/empty then noText = true
+  noText: Ember.computed.empty('translatedLabel'),
 
-  @computed("title") //this.get('title')
+  @computed("title")
   translatedTitle(title) {
     if (title) return I18n.t(title);
   },
 
-  @computed("label")//this.get('label')
+  @computed("label")
   translatedLabel(label) {
     if (label) return I18n.t(label);
   },

--- a/app/assets/javascripts/discourse/controllers/edit-category.js.es6
+++ b/app/assets/javascripts/discourse/controllers/edit-category.js.es6
@@ -8,6 +8,7 @@ export default Ember.Controller.extend(ModalFunctionality, {
   saving: false,
   deleting: false,
   panels: null,
+  hiddenTooltip: true,
 
   _initPanels: function() {
     this.set('panels', []);
@@ -16,6 +17,7 @@ export default Ember.Controller.extend(ModalFunctionality, {
   onShow() {
     this.changeSize();
     this.titleChanged();
+    this.set('hiddenTooltip', true);
   },
 
   changeSize: function() {
@@ -101,6 +103,13 @@ export default Ember.Controller.extend(ModalFunctionality, {
           self.set('deleting', false);
         }
       });
+    },
+
+    toggleDeleteTooltip() {
+      // check if is touch device
+      if ( $('html').hasClass('discourse-touch') ) {
+        this.toggleProperty('hiddenTooltip');
+      }
     }
   }
 

--- a/app/assets/javascripts/discourse/templates/modal/edit-category.hbs
+++ b/app/assets/javascripts/discourse/templates/modal/edit-category.hbs
@@ -28,8 +28,14 @@
                  icon="trash-o"
                  label="category.delete"}}
     {{else}}
-      <div class="cannot_delete_reason">
-        {{{model.cannot_delete_reason}}}
+      <div class="disable_info_wrap">
+        {{d-button disabled=deleteDisabled
+                   icon="question-circle"
+                   label="category.delete"}}
+
+        <div class="cannot_delete_reason">
+          {{{model.cannot_delete_reason}}}
+        </div>
       </div>
     {{/if}}
   </div>

--- a/app/assets/javascripts/discourse/templates/modal/edit-category.hbs
+++ b/app/assets/javascripts/discourse/templates/modal/edit-category.hbs
@@ -30,10 +30,12 @@
     {{else}}
       <div class="disable_info_wrap">
         {{d-button disabled=deleteDisabled
+                   class="disable-no-hover"
+                   action="toggleDeleteTooltip"
                    icon="question-circle"
                    label="category.delete"}}
 
-        <div class="cannot_delete_reason">
+        <div class="cannot_delete_reason {{if hiddenTooltip "hidden" ""}}">
           {{{model.cannot_delete_reason}}}
         </div>
       </div>

--- a/app/assets/stylesheets/common/base/modal.scss
+++ b/app/assets/stylesheets/common/base/modal.scss
@@ -332,7 +332,33 @@
       margin-bottom: 10px;
     }
   }
+
+  .disable_info_wrap {
+    position: relative;
+    display: inline-block;
+    float: right;
+
+    .cannot_delete_reason {
+      position: absolute;
+      background: dark-light-choose(scale-color($primary, $lightness: 10%), scale-color($secondary, $lightness: 10%));
+      color: dark-light-choose(scale-color($primary, $lightness: 100%), scale-color($secondary, $lightness: 0%));
+      text-align: center;
+      border-radius: 2px;
+      padding: 12px 8px;
+
+      &::after {
+        top: 100%;
+        left: 57%;
+        border: solid transparent;
+        content: " ";
+        position: absolute;
+        border-top-color: dark-light-choose(scale-color($primary, $lightness: 10%), scale-color($secondary, $lightness: 10%));
+        border-width: 8px;
+      }
+    }
+  }
 }
+
 
 .incoming-email-modal {
   .btn {

--- a/app/assets/stylesheets/common/foundation/helpers.scss
+++ b/app/assets/stylesheets/common/foundation/helpers.scss
@@ -76,3 +76,11 @@
 .clickable {
   cursor: pointer;
 }
+
+
+// Buttons
+// ---------------------------------------------------
+.disable-no-hover:hover {
+  background: dark-light-choose(scale-color($primary, $lightness: 90%), scale-color($secondary, $lightness: 60%));;
+  color: $primary;
+}

--- a/app/assets/stylesheets/desktop/modal.scss
+++ b/app/assets/stylesheets/desktop/modal.scss
@@ -116,36 +116,20 @@
       }
     }
   }
+
   .disable_info_wrap {
-    position: relative;
-    display: inline-block;
-    float: right;
     margin-top: -70px;
     padding-top: 70px;
-    padding-left: 170px;
+    @media all and (min-width: 550px) {
+      padding-left: 170px;
+    }
 
     .cannot_delete_reason {
-      position: absolute;
       top: 4px;
       right: 4px;
       max-width: 380px;
       min-width: 300px;
-      background: dark-light-choose(scale-color($primary, $lightness: 10%), scale-color($secondary, $lightness: 10%));
-      color: dark-light-choose(scale-color($primary, $lightness: 100%), scale-color($secondary, $lightness: 0%));
-      text-align: center;
-      border-radius: 2px;
-      padding: 12px 8px;
       display: none;
-
-      &::after {
-        top: 100%;
-        left: 57%;
-        border: solid transparent;
-        content: " ";
-        position: absolute;
-        border-top-color: dark-light-choose(scale-color($primary, $lightness: 10%), scale-color($secondary, $lightness: 10%));
-        border-width: 8px;
-      }
     }
 
     @include hover {

--- a/app/assets/stylesheets/desktop/modal.scss
+++ b/app/assets/stylesheets/desktop/modal.scss
@@ -116,12 +116,43 @@
       }
     }
   }
-
-  .cannot_delete_reason {
+  .disable_info_wrap {
+    position: relative;
+    display: inline-block;
     float: right;
-    text-align: right;
-    max-width: 380px;
-    color: dark-light-choose(scale-color($primary, $lightness: 60%), scale-color($secondary, $lightness: 40%));
+    margin-top: -70px;
+    padding-top: 70px;
+    padding-left: 170px;
+
+    .cannot_delete_reason {
+      position: absolute;
+      top: 4px;
+      right: 4px;
+      max-width: 380px;
+      min-width: 300px;
+      background: dark-light-choose(scale-color($primary, $lightness: 10%), scale-color($secondary, $lightness: 10%));
+      color: dark-light-choose(scale-color($primary, $lightness: 100%), scale-color($secondary, $lightness: 0%));
+      text-align: center;
+      border-radius: 2px;
+      padding: 12px 8px;
+      display: none;
+
+      &::after {
+        top: 100%;
+        left: 57%;
+        border: solid transparent;
+        content: " ";
+        position: absolute;
+        border-top-color: dark-light-choose(scale-color($primary, $lightness: 10%), scale-color($secondary, $lightness: 10%));
+        border-width: 8px;
+      }
+    }
+
+    @include hover {
+      .cannot_delete_reason {
+        display: block;
+      }
+    }
   }
 }
 

--- a/app/assets/stylesheets/mobile/modal.scss
+++ b/app/assets/stylesheets/mobile/modal.scss
@@ -38,7 +38,7 @@
   width: 95%;
 }
 
-// we need a little extra room on mobile for the 
+// we need a little extra room on mobile for the
 // stuff inside the footer to fit
 .modal-footer {
   padding-right: 0;
@@ -132,6 +132,12 @@
         }
       }
     }
+  }
+
+  .disable_info_wrap .cannot_delete_reason {
+    top: -114px;
+    right: 8px;
+    min-width: 200px;
   }
 }
 


### PR DESCRIPTION
It show disabled button when category cannot be deleted.
On hover or on tap of the button, it will show explanatory tooltip.
 Steps to reproduce:
- go to a category main page. Category must have some old posts inside
- Edit the category
- Corner right of the modal edit-category, you should now see a buttons instead of text.
- Hover or tap on this button to see more info.

Reference isssue: https://meta.discourse.org/t/show-disabled-delete-button-when-category-cant-be-deleted/58199/2

![screen shot 2017-03-10 at 14 02 39](https://cloud.githubusercontent.com/assets/1055531/23804971/564f7d32-05bc-11e7-9aa3-acc16a0c5946.png)
