### PR TITLE
UX: Add subcategory class to hamburger menu items that are subcategories

### DIFF
--- a/app/assets/javascripts/discourse/widgets/hamburger-categories.js.es6
+++ b/app/assets/javascripts/discourse/widgets/hamburger-categories.js.es6
@@ -6,6 +6,12 @@ createWidget('hamburger-category', {
   tagName: 'li.category-link',
 
   html(c) {
+    if (c.parent_category_id) {
+      this.tagName += '.subcategory';
+    }
+
+    this.tagName += '.category-' + Discourse.Category.slugFor(c, '-');
+
     const results = [ this.attach('category-link', { category: c, allowUncategorized: true }) ];
 
     const unreadTotal = parseInt(c.get('unreadTopics'), 10) + parseInt(c.get('newTopics'), 10);


### PR DESCRIPTION
UX: Add data-category-url to make targetting a category li element in the hamburger menu easier

Relevant Discussions:
https://meta.discourse.org/t/is-there-any-way-to-remove-subcategories-from-the-hamburger-menu/57799/12
https://meta.discourse.org/t/hiding-specific-sub-category-from-hamburger-menu/58929
