### PR TITLE
Added `ssl` parameter for action_mailer

### DIFF
--- a/config/discourse_defaults.conf
+++ b/config/discourse_defaults.conf
@@ -80,6 +80,9 @@ smtp_enable_start_tls = true
 # to disable, set to 'none'
 smtp_openssl_verify_mode =
 
+# mode for enable ssl in stmp settings
+smtp_enable_ssl = true
+
 # load MiniProfiler in production, to be used by developers
 load_mini_profiler = true
 

--- a/config/discourse_defaults.conf
+++ b/config/discourse_defaults.conf
@@ -81,7 +81,7 @@ smtp_enable_start_tls = true
 smtp_openssl_verify_mode =
 
 # mode for enable ssl in stmp settings
-smtp_enable_ssl = true
+smtp_enable_ssl = false
 
 # load MiniProfiler in production, to be used by developers
 load_mini_profiler = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -32,7 +32,8 @@ Discourse::Application.configure do
       user_name:            GlobalSetting.smtp_user_name,
       password:             GlobalSetting.smtp_password,
       authentication:       GlobalSetting.smtp_authentication,
-      enable_starttls_auto: GlobalSetting.smtp_enable_start_tls
+      enable_starttls_auto: GlobalSetting.smtp_enable_start_tls,
+      ssl:                  GlobalSetting.smtp_enable_ssl
     }
 
     settings[:openssl_verify_mode] = GlobalSetting.smtp_openssl_verify_mode if GlobalSetting.smtp_openssl_verify_mode


### PR DESCRIPTION
append `ssl` option for `action_mailer` to deal with the following error.
- http://stackoverflow.com/questions/6579865/in-rails-3-and-actionmailer-is-it-possible-to-send-email-using-tls-over-ssl-no