### PR TITLE
FEATURE: Add "Show tracked topics" link to User Prefs

### DIFF
--- a/app/assets/javascripts/discourse/models/user.js.es6
+++ b/app/assets/javascripts/discourse/models/user.js.es6
@@ -145,6 +145,11 @@ const User = RestModel.extend({
   watchingTopicsPath() {
     return defaultHomepage() === "latest" ? Discourse.getURL('/?state=watching') : Discourse.getURL('/latest?state=watching');
   },
+    
+  @computer()
+  trackingTopicsPath() {
+    return defaultHomepage() === "latest" ? Discourse.getURL('/?state=tracking') : Discourse.getURL('/latest?state=tracking');
+  },
 
   @computed("username")
   username_lower(username) {

--- a/app/assets/javascripts/discourse/models/user.js.es6
+++ b/app/assets/javascripts/discourse/models/user.js.es6
@@ -146,7 +146,7 @@ const User = RestModel.extend({
     return defaultHomepage() === "latest" ? Discourse.getURL('/?state=watching') : Discourse.getURL('/latest?state=watching');
   },
     
-  @computer()
+  @computed()
   trackingTopicsPath() {
     return defaultHomepage() === "latest" ? Discourse.getURL('/?state=tracking') : Discourse.getURL('/latest?state=tracking');
   },

--- a/app/assets/javascripts/discourse/templates/preferences.hbs
+++ b/app/assets/javascripts/discourse/templates/preferences.hbs
@@ -267,7 +267,7 @@
       </div>
       <div class="instructions">{{i18n 'user.tracked_categories_instructions'}}</div>
       <div class="controls category-controls">
-      <a href="{{unbound model.trackingTopicsPath}}">{{i18n 'user.tracking_topics_link'}}</a>
+      <a href="{{unbound model.trackingTopicsPath}}">{{i18n 'user.tracked_topics_link'}}</a>
       </div>
       <div class="controls category-controls">
         <label><span class="icon fa fa-dot-circle-o watching-first-post"></span> {{i18n 'user.watched_first_post_categories'}}</label>

--- a/app/assets/javascripts/discourse/templates/preferences.hbs
+++ b/app/assets/javascripts/discourse/templates/preferences.hbs
@@ -261,12 +261,14 @@
       <div class="controls category-controls">
       <a href="{{unbound model.watchingTopicsPath}}">{{i18n 'user.watched_topics_link'}}</a>
       </div>
-      <div class="instructions"></div>
       <div class="controls category-controls">
         <label><span class="icon fa fa-circle tracking"></span> {{i18n 'user.tracked_categories'}}</label>
         {{category-selector categories=model.trackedCategories blacklist=selectedCategories}}
       </div>
       <div class="instructions">{{i18n 'user.tracked_categories_instructions'}}</div>
+      <div class="controls category-controls">
+      <a href="{{unbound model.trackingTopicsPath}}">{{i18n 'user.tracking_topics_link'}}</a>
+      </div>
       <div class="controls category-controls">
         <label><span class="icon fa fa-dot-circle-o watching-first-post"></span> {{i18n 'user.watched_first_post_categories'}}</label>
         {{category-selector categories=model.watchedFirstPostCategories}}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -624,6 +624,7 @@ en:
       muted_users_instructions: "Suppress all notifications from these users."
       muted_topics_link: "Show muted topics"
       watched_topics_link: "Show watched topics"
+      tracked_topics_link: "Show tracked topics"
       automatically_unpin_topics: "Automatically unpin topics when I reach the bottom."
       apps: "Apps"
       revoke_access: "Revoke Access"


### PR DESCRIPTION
All this pull request does is what it says on the tin. ?state=tracking is already supported in Discourse, and all this will do is add a link to the user preferences page that lets people click to see the topics they're currently tracking (as opposed to the ones they're watching or have muted).

Mostly I'm just testing the waters a little since I'd like to see if I can figure out a good, lightweight way to track unread posts by topic creators/owners only, and set that up.