### PR TITLE
DEV: Add plugin-outlet to allow SSO sites to put a message on the User Preferences page

### DIFF
--- a/app/assets/javascripts/discourse/templates/preferences.hbs
+++ b/app/assets/javascripts/discourse/templates/preferences.hbs
@@ -1,5 +1,7 @@
 {{#d-section pageClass="user-preferences" class="user-content user-preferences"}}
 
+  {{plugin-outlet name="above-user-preferences"}}
+
   <form class="form-horizontal">
 
     <div class="control-group save-button" id='save-button-top'>


### PR DESCRIPTION
Relevant Discussion:
https://meta.discourse.org/t/add-link-to-external-sso-profile-to-profile-page/59027/7?u=cpradio