### PR TITLE
FIX: Add route for user TL3 requirements page

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -134,6 +134,7 @@ Discourse::Application.routes.draw do
     get "users/:id.json" => 'users#show', defaults: {format: 'json'}
     get 'users/:id/:username' => 'users#show', constraints: {username: USERNAME_ROUTE_FORMAT}
     get 'users/:id/:username/badges' => 'users#show'
+    get 'users/:id/:username/tl3_requirements' => 'users#show'
 
 
     post "users/sync_sso" => "users#sync_sso", constraints: AdminConstraint.new


### PR DESCRIPTION
For reference: https://meta.discourse.org/t/user-tl3-requirements-page-missing-on-refresh/59261