### PR TITLE
FIX: Do not show User Cannot See Mention dialog when crafting a new topic or a new message

### DIFF
--- a/app/assets/javascripts/discourse/components/composer-editor.js.es6
+++ b/app/assets/javascripts/discourse/components/composer-editor.js.es6
@@ -3,6 +3,7 @@ import { default as computed, on } from 'ember-addons/ember-computed-decorators'
 import { linkSeenMentions, fetchUnseenMentions } from 'discourse/lib/link-mentions';
 import { linkSeenCategoryHashtags, fetchUnseenCategoryHashtags } from 'discourse/lib/link-category-hashtags';
 import { linkSeenTagHashtags, fetchUnseenTagHashtags } from 'discourse/lib/link-tag-hashtag';
+import Composer from 'discourse/models/composer';
 import { load } from 'pretty-text/oneboxer';
 import { ajax } from 'discourse/lib/ajax';
 import InputValidation from 'discourse/models/input-validation';
@@ -138,7 +139,7 @@ export default Ember.Component.extend({
   _renderUnseenMentions($preview, unseen) {
     // 'Create a New Topic' scenario is not supported (per conversation with codinghorror)
     // https://meta.discourse.org/t/taking-another-1-7-release-task/51986/7
-    fetchUnseenMentions(unseen, this.get('topic.id')).then(() => {
+    fetchUnseenMentions(unseen, this.get('composer.topic.id')).then(() => {
       linkSeenMentions($preview, this.siteSettings);
       this._warnMentionedGroups($preview);
       this._warnCannotSeeMention($preview);
@@ -187,6 +188,11 @@ export default Ember.Component.extend({
   },
 
   _warnCannotSeeMention($preview) {
+    const composerDraftKey = this.get('composer.draftKey');
+    if (composerDraftKey === Composer.CREATE_TOPIC || composerDraftKey === Composer.NEW_PRIVATE_MESSAGE_KEY
+        || composerDraftKey === Composer.REPLY_AS_NEW_TOPIC_KEY || composerDraftKey === Composer.REPLY_AS_NEW_PRIVATE_MESSAGE_KEY)
+      return;
+
     Ember.run.scheduleOnce('afterRender', () => {
       var found = this.get('warnedCannotSeeMentions') || [];
       $preview.find('.mention.cannot-see').each((idx,e) => {

--- a/app/assets/javascripts/discourse/controllers/composer.js.es6
+++ b/app/assets/javascripts/discourse/controllers/composer.js.es6
@@ -367,7 +367,7 @@ export default Ember.Controller.extend({
 
     cannotSeeMention(mentions) {
       mentions.forEach(mention => {
-        const translation = (this.get('topic.isPrivateMessage')) ?
+        const translation = (this.get('model.topic.isPrivateMessage')) ?
           'composer.cannot_see_mention.private' :
           'composer.cannot_see_mention.category';
         const body = I18n.t(translation, {

--- a/app/assets/javascripts/discourse/mixins/open-composer.js.es6
+++ b/app/assets/javascripts/discourse/mixins/open-composer.js.es6
@@ -32,7 +32,7 @@ export default Ember.Mixin.create({
       topicTitle,
       topicBody,
       archetypeId: 'private_message',
-      draftKey: 'new_private_message'
+      draftKey: Composer.NEW_PRIVATE_MESSAGE_KEY
     });
   }
 

--- a/app/assets/javascripts/discourse/models/composer.js.es6
+++ b/app/assets/javascripts/discourse/models/composer.js.es6
@@ -15,6 +15,7 @@ const CLOSED = 'closed',
       // The actions the composer can take
       CREATE_TOPIC = 'createTopic',
       PRIVATE_MESSAGE = 'privateMessage',
+      NEW_PRIVATE_MESSAGE_KEY = 'new_private_message',
       REPLY = 'reply',
       EDIT = 'edit',
       REPLY_AS_NEW_TOPIC_KEY = "reply_as_new_topic",
@@ -815,6 +816,7 @@ Composer.reopenClass({
   EDIT,
 
   // Draft key
+  NEW_PRIVATE_MESSAGE_KEY,
   REPLY_AS_NEW_TOPIC_KEY,
   REPLY_AS_NEW_PRIVATE_MESSAGE_KEY
 });


### PR DESCRIPTION
Use the model/composer topic.id to determine what users cannot be mentioned and what message to show as a warning.

Relevant Discussion:
https://meta.discourse.org/t/bug-when-composing-topic-while-viewing-pm-incorrect-mentioned-user-will-not-be-notified-warning/59270