### PR TITLE
JSON API parsing error on CSRF exception: single quotes in ['BAD CSRF'] is invalid JSON

### DIFF
--- a/app/assets/javascripts/discourse/lib/ajax.js.es6
+++ b/app/assets/javascripts/discourse/lib/ajax.js.es6
@@ -69,7 +69,7 @@ export function ajax() {
     args.error = (xhr, textStatus, errorThrown) => {
       // note: for bad CSRF we don't loop an extra request right away.
       //  this allows us to eliminate the possibility of having a loop.
-      if (xhr.status === 403 && xhr.responseText === "['BAD CSRF']") {
+      if (xhr.status === 403 && xhr.responseText === "[\"BAD CSRF\"]") {
         Discourse.Session.current().set('csrfToken', null);
       }
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,7 +29,7 @@ class ApplicationController < ActionController::Base
     unless is_api? || is_user_api?
       super
       clear_current_user
-      render text: "['BAD CSRF']", status: 403
+      render text: "[\"BAD CSRF\"]", status: 403
     end
   end
 


### PR DESCRIPTION
https://meta.discourse.org/t/json-api-parsing-error-single-quotes-used-for-errors-like-bad-csrf/58869