### PR TITLE
Twitter onebox improvements

### DIFF
--- a/lib/twitter_api.rb
+++ b/lib/twitter_api.rb
@@ -4,7 +4,7 @@ class TwitterApi
   class << self
 
     def prettify_tweet(tweet)
-      text = tweet["text"].dup
+      text = tweet["full_text"].dup
       if entities = tweet["entities"] and urls = entities["urls"]
         urls.each do |url|
           text.gsub!(url["url"], "<a target='_blank' href='#{url["expanded_url"]}'>#{url["display_url"]}</a>")
@@ -81,7 +81,7 @@ class TwitterApi
     end
 
     def tweet_uri_for(id)
-      URI.parse "#{BASE_URL}/1.1/statuses/show.json?id=#{id}"
+      URI.parse "#{BASE_URL}/1.1/statuses/show.json?id=#{id}&tweet_mode=extended"
     end
 
     unless defined? BASE_URL

--- a/lib/twitter_api.rb
+++ b/lib/twitter_api.rb
@@ -22,6 +22,10 @@ class TwitterApi
             if large = m['sizes']['large']
               result << "<img class='tweet-image' src='#{m['media_url_https']}' width='#{large['w']}' height='#{large['h']}'>"
             end
+          elsif m['type'] == 'video'
+            if large = m['sizes']['large']
+              result << "<iframe class='tweet-video' src='https://twitter.com/i/videos/#{tweet['id_str']}' width='#{large['w']}' height='#{large['h']}' frameborder='0'></iframe>"
+            end
           end
         end
         result << "</div>"


### PR DESCRIPTION
Add support for Twitter's new "extended tweets". See [here](https://meta.discourse.org/t/onebox-twitter-embedding/18943/25?u=david_taylor) for relevant issue report

Twitter documentation on the change is [here](https://dev.twitter.com/overview/api/upcoming-changes-to-tweets)

Have also added support for oneboxing twitter videos, in the same way that images are currently done.