### PR TITLE
Delete disabled Category button: remove tooltip on hover on desktop

### DIFF
--- a/app/assets/javascripts/discourse/controllers/edit-category.js.es6
+++ b/app/assets/javascripts/discourse/controllers/edit-category.js.es6
@@ -106,10 +106,7 @@ export default Ember.Controller.extend(ModalFunctionality, {
     },
 
     toggleDeleteTooltip() {
-      // check if is touch device
-      if ( $('html').hasClass('discourse-touch') ) {
-        this.toggleProperty('hiddenTooltip');
-      }
+      this.toggleProperty('hiddenTooltip');
     }
   }
 

--- a/app/assets/stylesheets/desktop/modal.scss
+++ b/app/assets/stylesheets/desktop/modal.scss
@@ -129,13 +129,6 @@
       right: 4px;
       max-width: 380px;
       min-width: 300px;
-      display: none;
-    }
-
-    @include hover {
-      .cannot_delete_reason {
-        display: block;
-      }
     }
   }
 }


### PR DESCRIPTION
Remove hover effect on desktop for tooltip. 
Fix requets after testing and discovering not smooth behavour of tooltip.

Issue: https://meta.discourse.org/t/show-disabled-delete-button-when-category-cant-be-deleted/58199

Fix Requested:
https://meta.discourse.org/t/show-disabled-delete-button-when-category-cant-be-deleted/58199/5 