### PR TITLE
add style to show admin/users header as clickable

### DIFF
--- a/app/assets/stylesheets/common/admin/admin_base.scss
+++ b/app/assets/stylesheets/common/admin/admin_base.scss
@@ -29,12 +29,32 @@ $mobile-breakpoint: 700px;
 
 .admin-contents table {
   width: 100%;
+  margin-top: 10px;
+
   tr {text-align: left;}
   td, th {padding: 8px;}
-  th {border-top: 1px solid dark-light-diff($primary, $secondary, 90%, -60%); text-align: left;}
-  td {border-bottom: 1px solid dark-light-diff($primary, $secondary, 90%, -60%); border-top: 1px solid dark-light-diff($primary, $secondary, 90%, -60%);}
-  th.sortable i.fa-chevron-down,
-  th.sortable i.fa-chevron-up {margin-left: 0.5em;}
+  td {
+    border-bottom: 1px solid dark-light-diff($primary, $secondary, 90%, -60%);
+    border-top: 1px solid dark-light-diff($primary, $secondary, 90%, -60%);
+  }
+  th {
+    text-align: left;
+
+    &.sortable {
+      cursor: pointer;
+      white-space: nowrap;
+
+      &:hover {
+        background-color: #e9e9e9;
+        background-color: lighten($primary, 80%);
+      }
+
+      i.fa-chevron-down,
+      i.fa-chevron-up {
+        margin-left: 0.5em;
+      }
+    }
+  }
   tr:hover { background-color: darken($secondary, 2.5%); }
   tr.selected { background-color: lighten($primary, 80%); }
   .filters input { margin-bottom: 0; }


### PR DESCRIPTION
Adding style to admin/users/list/active to look like the one in /users
- add pointer to mouse on hover to sortable columns
-  add grey background on hover to sortable columns
- remove top border on title's columns to replicate /users look
- give some top margin to the table to replicate /users look

Issue: https://meta.discourse.org/t/admin-users-list-does-not-indicate-which-columns-are-sortable/59268