### PR TITLE
FEATURE: make summary as first tab on user page

### DIFF
--- a/app/assets/javascripts/discourse/controllers/user.js.es6
+++ b/app/assets/javascripts/discourse/controllers/user.js.es6
@@ -1,11 +1,9 @@
 import CanCheckEmails from 'discourse/mixins/can-check-emails';
 import computed from 'ember-addons/ember-computed-decorators';
-import UserAction from 'discourse/models/user-action';
 import User from 'discourse/models/user';
 
 export default Ember.Controller.extend(CanCheckEmails, {
   indexStream: false,
-  userActionType: null,
   application: Ember.inject.controller(),
   userNotifications: Ember.inject.controller('user-notifications'),
   currentPath: Ember.computed.alias('application.currentPath'),
@@ -61,18 +59,6 @@ export default Ember.Controller.extend(CanCheckEmails, {
   showBadges(badgeCount) {
     return Discourse.SiteSettings.enable_badges && badgeCount > 0;
   },
-
-  @computed("userActionType")
-  privateMessageView(userActionType) {
-    return (userActionType === UserAction.TYPES.messages_sent) ||
-           (userActionType === UserAction.TYPES.messages_received);
-  },
-
-  @computed("indexStream", "userActionType")
-  showActionTypeSummary(indexStream,userActionType, showPMs) {
-    return (indexStream || userActionType) && !showPMs;
-  },
-
 
   @computed()
   canInviteToForum() {

--- a/app/assets/javascripts/discourse/routes/user-activity-index.js.es6
+++ b/app/assets/javascripts/discourse/routes/user-activity-index.js.es6
@@ -1,14 +1,5 @@
 import UserActivityStreamRoute from "discourse/routes/user-activity-stream";
 
 export default UserActivityStreamRoute.extend({
-  userActionType: undefined,
-
-  actions: {
-    didTransition() {
-      this._super();
-      this.controllerFor("user").set("indexStream", true);
-      return true;
-    }
-  }
-
+  userActionType: null
 });

--- a/app/assets/javascripts/discourse/routes/user-summary.js.es6
+++ b/app/assets/javascripts/discourse/routes/user-summary.js.es6
@@ -1,5 +1,11 @@
 export default Discourse.Route.extend({
   model() {
     return this.modelFor("user").summary();
+  },
+
+  actions: {
+    didTransition() {
+      this.controllerFor("user").set("indexStream", true);
+    }
   }
 });

--- a/app/assets/javascripts/discourse/routes/user.js.es6
+++ b/app/assets/javascripts/discourse/routes/user.js.es6
@@ -1,5 +1,3 @@
-const INDEX_STREAM_ROUTES = ["user.deletedPosts", "user.flaggedPosts", "userActivity.index"];
-
 import Draft from 'discourse/models/draft';
 
 export default Discourse.Route.extend({
@@ -16,7 +14,7 @@ export default Discourse.Route.extend({
     willTransition(transition) {
       // will reset the indexStream when transitioning to routes that aren't "indexStream"
       // otherwise the "header" will jump
-      const isIndexStream = INDEX_STREAM_ROUTES.indexOf(transition.targetName) !== -1;
+      const isIndexStream = transition.targetName === "user.summary";
       this.controllerFor('user').set('indexStream', isIndexStream);
       return true;
     },

--- a/app/assets/javascripts/discourse/templates/user.hbs
+++ b/app/assets/javascripts/discourse/templates/user.hbs
@@ -162,6 +162,7 @@
     </section>
 
     {{#mobile-nav class='main-nav' desktopClass="nav nav-pills user-nav" currentPath=currentPath}}
+      <li>{{#link-to 'user.summary'}}{{i18n 'user.summary.title'}}{{/link-to}}</li>
       <li>{{#link-to 'userActivity'}}{{i18n 'user.activity_stream'}}{{/link-to}}</li>
       {{#if showNotificationsTab}}
         <li>
@@ -180,7 +181,6 @@
         <li>{{#link-to 'user.badges'}}{{fa-icon "certificate"}}{{i18n 'badges.title'}}{{/link-to}}</li>
       {{/if}}
       {{plugin-outlet name="user-main-nav" connectorTagName='li' args=(hash model=model)}}
-      <li>{{#link-to 'user.summary'}}{{i18n 'user.summary.title'}}{{/link-to}}</li>
       {{#if model.can_edit}}
         <li>{{#link-to 'preferences'}}{{fa-icon "cog"}}{{i18n 'user.preferences'}}{{/link-to}}</li>
       {{/if}}

--- a/test/javascripts/acceptance/user-anonymous-test.js.es6
+++ b/test/javascripts/acceptance/user-anonymous-test.js.es6
@@ -18,6 +18,7 @@ function hasTopicList() {
 test("Root URL", () => {
   visit("/users/eviltrout");
   andThen(() => {
+    ok($('body.user-summary-page').length, "has the body class");
     equal(currentPath(), 'user.summary', "it defaults to summary");
   });
 });

--- a/test/javascripts/acceptance/user-test.js.es6
+++ b/test/javascripts/acceptance/user-test.js.es6
@@ -27,7 +27,7 @@ test("Root URL - Viewing Self", () => {
   visit("/users/eviltrout");
   andThen(() => {
     ok($('body.user-activity-page').length, "has the body class");
-    equal(currentPath(), 'user.userActivity.index', "it defaults to summary");
+    equal(currentPath(), 'user.userActivity.index', "it defaults to activity");
     ok(exists('.container.viewing-self'), "has the viewing-self class");
   });
 });


### PR DESCRIPTION
Requested here: https://meta.discourse.org/t/custom-user-fields-show-on-activity-but-not-summary-page/59196/3?u=techapj
