### PR TITLE
Add og tags to metadata in individual badges page

### DIFF
--- a/app/controllers/badges_controller.rb
+++ b/app/controllers/badges_controller.rb
@@ -38,20 +38,20 @@ class BadgesController < ApplicationController
     raise Discourse::NotFound unless SiteSetting.enable_badges
 
     params.require(:id)
-    badge = Badge.enabled.find(params[:id])
+    @badge = Badge.enabled.find(params[:id])
 
     if current_user
-      user_badge = UserBadge.find_by(user_id: current_user.id, badge_id: badge.id)
+      user_badge = UserBadge.find_by(user_id: current_user.id, badge_id: @badge.id)
       if user_badge && user_badge.notification
         user_badge.notification.update_attributes read: true
       end
     end
 
-    serialized = MultiJson.dump(serialize_data(badge, BadgeSerializer, root: "badge", include_long_description: true))
+    serialized = MultiJson.dump(serialize_data(@badge, BadgeSerializer, root: "badge", include_long_description: true))
     respond_to do |format|
       format.html do
         store_preloaded "badge", serialized
-        render "default/empty"
+        render
       end
       format.json { render json: serialized }
     end

--- a/app/views/badges/show.html.erb
+++ b/app/views/badges/show.html.erb
@@ -1,0 +1,3 @@
+<% content_for :head do %>
+  <%= raw crawlable_meta_data(title: @badge.display_name + ' Badge in ' + SiteSetting.title, description: @badge.long_description) %>
+<% end %>


### PR DESCRIPTION
Created new view file for badges and allowed its rendering from
badges_controller. First step to implementing feature for sharing badges
on social media (https://meta.discourse.org/t/share-badges-on-social-media/51998)