### PR TITLE
Allow plugins to add panels to header more easily

### DIFF
--- a/app/assets/javascripts/discourse/lib/plugin-api.js.es6
+++ b/app/assets/javascripts/discourse/lib/plugin-api.js.es6
@@ -347,7 +347,7 @@ class PluginApi {
    * and returns a hash of attrs to pass to the widget
    **/
    addHeaderPanel(name, toggle, attrFn) {
-     queryRegistry('header').prototype.attachAdditionalPanel(name, toggle, attrFn)
+     queryRegistry('header').prototype.attachAdditionalPanel(name, toggle, attrFn);
    }
 
   /**

--- a/app/assets/javascripts/discourse/lib/plugin-api.js.es6
+++ b/app/assets/javascripts/discourse/lib/plugin-api.js.es6
@@ -18,9 +18,10 @@ import { addTagsHtmlCallback } from 'discourse/lib/render-tags';
 import { addUserMenuGlyph } from 'discourse/widgets/user-menu';
 import { addPostClassesCallback } from 'discourse/widgets/post';
 import { addPostTransformCallback } from 'discourse/widgets/post-stream';
+import { queryRegistry } from 'discourse/widgets/widget';
 
 // If you add any methods to the API ensure you bump up this number
-const PLUGIN_API_VERSION = '0.8.5';
+const PLUGIN_API_VERSION = '0.8.6';
 
 class PluginApi {
   constructor(version, container) {
@@ -332,6 +333,22 @@ class PluginApi {
   addFlagProperty(property) {
     return addFlagProperty(property);
   }
+
+  /**
+   * Adds a panel to the header
+   *
+   * takes a widget name, a value to toggle on, and a function which returns the attrs for the widget
+   * Example:
+   * ```javascript
+   * api.addHeaderPanel('widget-name', 'widgetVisible', function(attrs, state) { return {}; });
+   * ```
+   * note that 'toggle' is an attribute on the state of the header widget,
+   * and the attrFn receives the current attrs and state of the header as arguments,
+   * and returns a hash of attrs to pass to the widget
+   **/
+   addHeaderPanel(name, toggle, attrFn) {
+     queryRegistry('header').prototype.attachAdditionalPanel(name, toggle, attrFn)
+   }
 
   /**
    * Adds a pluralization to the store

--- a/app/assets/javascripts/discourse/lib/plugin-api.js.es6
+++ b/app/assets/javascripts/discourse/lib/plugin-api.js.es6
@@ -18,7 +18,8 @@ import { addTagsHtmlCallback } from 'discourse/lib/render-tags';
 import { addUserMenuGlyph } from 'discourse/widgets/user-menu';
 import { addPostClassesCallback } from 'discourse/widgets/post';
 import { addPostTransformCallback } from 'discourse/widgets/post-stream';
-import { queryRegistry } from 'discourse/widgets/widget';
+import { attachAdditionalPanel } from 'discourse/widgets/header';
+
 
 // If you add any methods to the API ensure you bump up this number
 const PLUGIN_API_VERSION = '0.8.6';
@@ -340,14 +341,18 @@ class PluginApi {
    * takes a widget name, a value to toggle on, and a function which returns the attrs for the widget
    * Example:
    * ```javascript
-   * api.addHeaderPanel('widget-name', 'widgetVisible', function(attrs, state) { return {}; });
+   * api.addHeaderPanel('widget-name', 'widgetVisible', function(attrs, state) {
+   *   return { name: attrs.name, description: state.description };
+   * });
    * ```
-   * note that 'toggle' is an attribute on the state of the header widget,
-   * and the attrFn receives the current attrs and state of the header as arguments,
-   * and returns a hash of attrs to pass to the widget
+   * 'toggle' is an attribute on the state of the header widget,
+   *
+   * 'transformAttrs' is a function which is passed the current attrs and state of the widget,
+   * and returns a hash of values to pass to attach
+   *
    **/
-   addHeaderPanel(name, toggle, attrFn) {
-     queryRegistry('header').prototype.attachAdditionalPanel(name, toggle, attrFn);
+   addHeaderPanel(name, toggle, transformAttrs) {
+     attachAdditionalPanel(name, toggle, transformAttrs);
    }
 
   /**

--- a/app/assets/javascripts/discourse/widgets/header.js.es6
+++ b/app/assets/javascripts/discourse/widgets/header.js.es6
@@ -169,6 +169,7 @@ const forceContextEnabled = ['category', 'user', 'private_messages'];
 export default createWidget('header', {
   tagName: 'header.d-header.clearfix',
   buildKey: () => `header`,
+  additionalPanels: [],
 
   defaultState() {
     let states =  {
@@ -183,6 +184,10 @@ export default createWidget('header', {
     }
 
     return states;
+  },
+
+  attachAdditionalPanel(name, toggle, attrFn) {
+    this.additionalPanels.push({ name, toggle, attrFn })
   },
 
   html(attrs, state) {
@@ -214,7 +219,11 @@ export default createWidget('header', {
       panels.push(this.attach('user-menu'));
     }
 
-    this.additionalPanels(attrs, state).map(function(panel) { panels.push(panel); });
+    this.additionalPanels.map((panel) => {
+      if (this.state[panel.toggle]) {
+        panels.push(this.attach(panel.name, panel.attrFn.call(this, attrs, state)));
+      }
+    });
 
     const contents = [ this.attach('home-logo', { minimized: !!attrs.topic }),
                        h('div.panel.clearfix', panels) ];
@@ -224,11 +233,6 @@ export default createWidget('header', {
     }
 
     return h('div.wrap', h('div.contents.clearfix', contents));
-  },
-
-  // override to allow plugins to append additional panels
-  additionalPanels() {
-    return [];
   },
 
   updateHighlight() {

--- a/app/assets/javascripts/discourse/widgets/header.js.es6
+++ b/app/assets/javascripts/discourse/widgets/header.js.es6
@@ -214,7 +214,7 @@ export default createWidget('header', {
       panels.push(this.attach('user-menu'));
     }
 
-    this.additionalPanels(attrs, state).map(function(panel) { panels.push(panel) });
+    this.additionalPanels(attrs, state).map(function(panel) { panels.push(panel); });
 
     const contents = [ this.attach('home-logo', { minimized: !!attrs.topic }),
                        h('div.panel.clearfix', panels) ];
@@ -227,8 +227,8 @@ export default createWidget('header', {
   },
 
   // override to allow plugins to append additional panels
-  additionalPanels(attrs, state) {
-    return []
+  additionalPanels() {
+    return [];
   },
 
   updateHighlight() {

--- a/app/assets/javascripts/discourse/widgets/header.js.es6
+++ b/app/assets/javascripts/discourse/widgets/header.js.es6
@@ -166,6 +166,11 @@ createWidget('header-buttons', {
 
 const forceContextEnabled = ['category', 'user', 'private_messages'];
 
+let additionalPanels = []
+export function attachAdditionalPanel(name, toggle, transformAttrs) {
+  additionalPanels.push({ name, toggle, transformAttrs });
+}
+
 export default createWidget('header', {
   tagName: 'header.d-header.clearfix',
   buildKey: () => `header`,
@@ -184,10 +189,6 @@ export default createWidget('header', {
     }
 
     return states;
-  },
-
-  attachAdditionalPanel(name, toggle, attrFn) {
-    this.additionalPanels.push({ name, toggle, attrFn });
   },
 
   html(attrs, state) {
@@ -219,9 +220,9 @@ export default createWidget('header', {
       panels.push(this.attach('user-menu'));
     }
 
-    this.additionalPanels.map((panel) => {
+    additionalPanels.map((panel) => {
       if (this.state[panel.toggle]) {
-        panels.push(this.attach(panel.name, panel.attrFn.call(this, attrs, state)));
+        panels.push(this.attach(panel.name, panel.transformAttrs.call(this, attrs, state)));
       }
     });
 

--- a/app/assets/javascripts/discourse/widgets/header.js.es6
+++ b/app/assets/javascripts/discourse/widgets/header.js.es6
@@ -187,7 +187,7 @@ export default createWidget('header', {
   },
 
   attachAdditionalPanel(name, toggle, attrFn) {
-    this.additionalPanels.push({ name, toggle, attrFn })
+    this.additionalPanels.push({ name, toggle, attrFn });
   },
 
   html(attrs, state) {

--- a/app/assets/javascripts/discourse/widgets/header.js.es6
+++ b/app/assets/javascripts/discourse/widgets/header.js.es6
@@ -214,7 +214,7 @@ export default createWidget('header', {
       panels.push(this.attach('user-menu'));
     }
 
-    this.additionalPanels(attrs, state).map(function(panel) { panels.push(panel) })
+    this.additionalPanels(attrs, state).map(function(panel) { panels.push(panel) });
 
     const contents = [ this.attach('home-logo', { minimized: !!attrs.topic }),
                        h('div.panel.clearfix', panels) ];

--- a/app/assets/javascripts/discourse/widgets/header.js.es6
+++ b/app/assets/javascripts/discourse/widgets/header.js.es6
@@ -214,6 +214,8 @@ export default createWidget('header', {
       panels.push(this.attach('user-menu'));
     }
 
+    this.additionalPanels(attrs, state).map(function(panel) { panels.push(panel) })
+
     const contents = [ this.attach('home-logo', { minimized: !!attrs.topic }),
                        h('div.panel.clearfix', panels) ];
 
@@ -222,6 +224,11 @@ export default createWidget('header', {
     }
 
     return h('div.wrap', h('div.contents.clearfix', contents));
+  },
+
+  // override to allow plugins to append additional panels
+  additionalPanels(attrs, state) {
+    return []
   },
 
   updateHighlight() {


### PR DESCRIPTION
Hey Discourse!

I'm looking to add an additional icon & panel to the header widget. Discourse has a very nice way of adding icons:

```
api.decorateWidget('header-icons:before', function(helper) {
  helper.attach('header-dropdown', { icon: 'smiley' })
})
```

but adding panels along with those icons has proven a challenge. (Maybe I'm missing something obvious?) Before, I was doing this by (very nastily) traversing through the resultant vDom result from the `html` method:

```
const _html = queryRegistry('header').prototype.html
const _super  = _html.call(this, attrs, state)
let panels = _super.children[0].children[1].children
panels.push(this.attach(myWidget))
// ^^ this is really hard and bad!
```

Predictably, this was fragile and has broken. It would be much easier for me to hook into the html method where the panels are being added, so that I could append them there, rather than trying to dig for them afterwards. :D 