### PR TITLE
Add `WebHook` event triggers outside of class.

### DIFF
--- a/app/models/web_hook.rb
+++ b/app/models/web_hook.rb
@@ -47,35 +47,35 @@ class WebHook < ActiveRecord::Base
   def self.enqueue_post_hooks(event, post, user=nil)
     WebHook.enqueue_hooks(:post, post_id: post.id, category_id: post&.topic&.category_id, event_name: event.to_s)
   end
+end
 
-  %i(topic_destroyed topic_recovered).each do |event|
-    DiscourseEvent.on(event) do |topic, user|
-      WebHook.enqueue_topic_hooks(event, topic, user)
-    end
+%i(topic_destroyed topic_recovered).each do |event|
+  DiscourseEvent.on(event) do |topic, user|
+    WebHook.enqueue_topic_hooks(event, topic, user)
   end
+end
 
-  DiscourseEvent.on(:topic_created) do |topic, _, user|
-    WebHook.enqueue_topic_hooks(:topic_created, topic, user)
+DiscourseEvent.on(:topic_created) do |topic, _, user|
+  WebHook.enqueue_topic_hooks(:topic_created, topic, user)
+end
+
+%i(post_created
+   post_destroyed
+   post_recovered).each do |event|
+
+  DiscourseEvent.on(event) do |post, _, user|
+    WebHook.enqueue_post_hooks(event, post, user)
   end
+end
 
-  %i(post_created
-     post_destroyed
-     post_recovered).each do |event|
+DiscourseEvent.on(:post_edited) do |post, topic_changed|
+  WebHook.enqueue_post_hooks(:post_edited, post)
+  WebHook.enqueue_topic_hooks(:topic_edited, post.topic) if post.is_first_post? && topic_changed
+end
 
-    DiscourseEvent.on(event) do |post, _, user|
-      WebHook.enqueue_post_hooks(event, post, user)
-    end
-  end
-
-  DiscourseEvent.on(:post_edited) do |post, topic_changed|
-    WebHook.enqueue_post_hooks(:post_edited, post)
-    WebHook.enqueue_topic_hooks(:topic_edited, post.topic) if post.is_first_post? && topic_changed
-  end
-
-  %i(user_created user_approved user_updated).each do |event|
-    DiscourseEvent.on(event) do |user|
-      WebHook.enqueue_hooks(:user, user_id: user.id, event_name: event.to_s)
-    end
+%i(user_created user_approved user_updated).each do |event|
+  DiscourseEvent.on(event) do |user|
+    WebHook.enqueue_hooks(:user, user_id: user.id, event_name: event.to_s)
   end
 end
 


### PR DESCRIPTION
* In production, the classes are cached but in development
  reloading classes would not have reloaded the constant
  being referenced in the event triggers. Either way, we
  only want to enqueue the event triggers once.