### PR TITLE
Remove stray reference to additionalPanels

### DIFF
--- a/app/assets/javascripts/discourse/widgets/header.js.es6
+++ b/app/assets/javascripts/discourse/widgets/header.js.es6
@@ -174,7 +174,6 @@ export function attachAdditionalPanel(name, toggle, transformAttrs) {
 export default createWidget('header', {
   tagName: 'header.d-header.clearfix',
   buildKey: () => `header`,
-  additionalPanels: [],
 
   defaultState() {
     let states =  {


### PR DESCRIPTION
Oops, I left a stray reference to `this.additionalPanels` in the header, which shouldn't be there now that this is using a local variable.