### PR TITLE
Trigger DiscourseEvent when topic category is changed

### DIFF
--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -1054,6 +1054,10 @@ describe Topic do
 
     end
 
+    it 'trigger :topic_category_changed discourse event' do
+      DiscourseEvent.expects(:trigger).with(:topic_category_changed, @topic, @topic.category, @category)
+      @topic.changed_to_category(@category)
+    end
   end
 
   describe 'scopes' do


### PR DESCRIPTION
Required in order to fix
https://meta.discourse.org/t/when-moving-a-solved-topic-to-a-category-that-disallows-solutions-remove-solved/58385

I've been checked the DiscourseEvent to trigger such cases, can't found one.
There is also no trigger for `:topic_changed`.

Added `:topic_category_changed` instead of `:topic_changed` is to limit the scope.