### PR TITLE
Mobile CSS for deleted topics is inconsistent with desktop CSS

### DIFF
--- a/app/assets/stylesheets/mobile/topic-post.scss
+++ b/app/assets/stylesheets/mobile/topic-post.scss
@@ -475,7 +475,9 @@ button.select-post {
 
 
 .deleted {
-  background-color: dark-light-diff(rgba($danger,.7), $secondary, 50%, -60%);
+  .topic-body {
+    background-color: dark-light-diff(rgba($danger,.7), $secondary, 50%, -60%);
+  }
 }
 
 .deleted-user-avatar {


### PR DESCRIPTION
mobile targets a less specific class (`.deleted`) while desktop targets `.deleted>.topic-body`