### PR TITLE
Add a user_seen DiscourseEvent for plugins to hook into

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -521,6 +521,8 @@ class User < ActiveRecord::Base
     # using update_column to avoid the AR transaction
     update_column(:last_seen_at, now)
     update_column(:first_seen_at, now) unless self.first_seen_at
+
+    DiscourseEvent.trigger(:user_seen, self)
   end
 
   def self.gravatar_template(email)


### PR DESCRIPTION
This would allow plugins to run logic whenever user activity occurs. I'd like to use this to make my whos_online plugin more responsive to users coming 'online'.

An example of how I plan to use this hook can be found [here](https://github.com/davidtaylorhq/discourse-whos-online/blob/beta/plugin.rb#L53). Clearly it is important that plugins don't run any time-consuming code here, as it will be hit every minute for all active users. I use it to update some redis keys, and then queue a sidekiq job.

ActiveRecord callbacks are not an alternative solution here, since `update_column` is being used for performance reasons.
