### PR TITLE
Added an API to ask if an incoming email should be dropped at the SMTP level.

### DIFF
--- a/app/controllers/admin/email_controller.rb
+++ b/app/controllers/admin/email_controller.rb
@@ -73,7 +73,7 @@ class Admin::EmailController < Admin::AdminController
     params.require(:from)
     params.require(:to)
     # These strings aren't localized; they are sent to an anonymous SMTP user.
-    if User.find_by_email(params[:from]).nil? && !SiteSetting.enable_staged_users
+    if !User.exists?(email: Email.downcase(params[:from])) && !SiteSetting.enable_staged_users
         render json: { reject: true, reason: "Mail from your address is not accepted. Do you have an account here?" }
     elsif Email::Receiver.check_address(Email.downcase(params[:to])).nil?
         render json: { reject: true, reason: "Mail to this address is not accepted. Check the address and try to send again?" }

--- a/app/controllers/admin/email_controller.rb
+++ b/app/controllers/admin/email_controller.rb
@@ -75,7 +75,7 @@ class Admin::EmailController < Admin::AdminController
     # These strings aren't localized; they are sent to an anonymous SMTP user.
     if User.find_by_email(params[:from]).nil? && !SiteSetting.enable_staged_users
         render json: { reject: true, reason: "Mail from your address is not accepted. Do you have an account here?" }
-    elsif Email::Receiver.new(params[:from]).check_address(params[:to]).nil?
+    elsif Email::Receiver.check_address(Email.downcase(params[:to])).nil?
         render json: { reject: true, reason: "Mail to this address is not accepted. Check the address and try to send again?" }
     else
         render json: { reject: false }

--- a/app/controllers/admin/email_controller.rb
+++ b/app/controllers/admin/email_controller.rb
@@ -74,11 +74,11 @@ class Admin::EmailController < Admin::AdminController
     params.require(:to)
     # These strings aren't localized; they are sent to an anonymous SMTP user.
     if !User.exists?(email: Email.downcase(params[:from])) && !SiteSetting.enable_staged_users
-        render json: { reject: true, reason: "Mail from your address is not accepted. Do you have an account here?" }
+      render json: { reject: true, reason: "Mail from your address is not accepted. Do you have an account here?" }
     elsif Email::Receiver.check_address(Email.downcase(params[:to])).nil?
-        render json: { reject: true, reason: "Mail to this address is not accepted. Check the address and try to send again?" }
+      render json: { reject: true, reason: "Mail to this address is not accepted. Check the address and try to send again?" }
     else
-        render json: { reject: false }
+      render json: { reject: false }
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -155,6 +155,7 @@ Discourse::Application.routes.draw do
         get "/incoming_from_bounced/:id" => "email#incoming_from_bounced"
         get "preview-digest" => "email#preview_digest"
         get "send-digest" => "email#send_digest"
+        get "smtp_should_reject"
         post "handle_mail"
       end
     end

--- a/lib/email/receiver.rb
+++ b/lib/email/receiver.rb
@@ -302,11 +302,11 @@ module Email
 
     def destinations
       all_destinations
-        .map { |d| check_address(d) }
+        .map { |d| Email::Receiver.check_address(d) }
         .drop_while(&:blank?)
     end
 
-    def check_address(address)
+    def self.check_address(address)
       # only check for a group/category when 'email_in' is enabled
       if SiteSetting.email_in
         group = Group.find_by_email(address)
@@ -317,7 +317,7 @@ module Email
       end
 
       # reply
-      match = reply_by_email_address_regex.match(address)
+      match = Email::Receiver.reply_by_email_address_regex.match(address)
       if match && match.captures
         match.captures.each do |c|
           next if c.blank?
@@ -443,7 +443,7 @@ module Email
       true
     end
 
-    def reply_by_email_address_regex
+    def self.reply_by_email_address_regex
       @reply_by_email_address_regex ||= begin
         reply_addresses = [
            SiteSetting.reply_by_email_address,
@@ -652,7 +652,7 @@ module Email
     end
 
     def should_invite?(email)
-      email !~ reply_by_email_address_regex &&
+      email !~ Email::Receiver.reply_by_email_address_regex &&
       email !~ group_incoming_emails_regex &&
       email !~ category_email_in_regex
     end


### PR DESCRIPTION
This lets an SMTP server optionally decide if it should reject a mail without
passing it on to Discourse at all, possibly before even reading the
email's payload, to prevent spam-induced backscatter and save resources.

This just does the bare minimum sanity checking that could prevent obvious
backscatter. For legit errors from legit users, Discourse will still send a
much more pleasant reply email.