### PR TITLE
Adding clarification about install directory

### DIFF
--- a/docs/INSTALL-cloud.md
+++ b/docs/INSTALL-cloud.md
@@ -34,7 +34,8 @@ This command installs the latest versions of Docker and Git on your server. Alte
 
 ### Install Discourse
 
-Create a `/var/discourse` folder, clone the [Official Discourse Docker Image][dd] into it:
+Create a `/var/discourse` folder, clone the [Official Discourse Docker Image][dd] into it:  
+_Note: this is not a recommended install directory. Discourse must live in `/var/discourse` to work properly._
 
     sudo -s
     mkdir /var/discourse


### PR DESCRIPTION
I recently was setting up a (luckily) sandbox instance of Discourse to demonstrate it to a group. 

I have a Mac Mini and rather than paying for the DigitalOcean box, I decided to set it up on the Mac Mini. 

I decided to store it in `/Applications/discourse` rather than `/var/discourse`. 

This actually worked fine, until I restarted the machine and the discourse instance reset to the initial on-boarding register page. 

My understanding is this happened because:
```
## The Docker container is stateless; all data is stored in /shared
volumes:
  - volume:
      host: /var/discourse/shared/standalone
      guest: /shared
  - volume:
      host: /var/discourse/shared/standalone/log/var-log
      guest: /var/log
```

I figured to prevent anyone else from making the same mistake, I would add a friendly note letting the user know this is **not** a recommended install directory, but in fact, required for Discourse to work properly. 

Let me know if you think it’s worth it and if I should clean up or revise the copy at all. 
