### PR TITLE
Add an optional category-specific [slug] for email subject lines.

### DIFF
--- a/app/assets/javascripts/discourse/models/category.js.es6
+++ b/app/assets/javascripts/discourse/models/category.js.es6
@@ -81,6 +81,7 @@ const Category = RestModel.extend({
       data: {
         name: this.get('name'),
         slug: this.get('slug'),
+        email_subject_slug: this.get('email_subject_slug'),
         color: this.get('color'),
         text_color: this.get('text_color'),
         secure: this.get('secure'),

--- a/app/assets/javascripts/discourse/templates/components/edit-category-settings.hbs
+++ b/app/assets/javascripts/discourse/templates/components/edit-category-settings.hbs
@@ -97,6 +97,14 @@
   </section>
 {{/if}}
 
+<section class='field'>
+  <label>
+    {{fa-icon "envelope-o"}}
+    {{i18n 'category.email_subject_slug'}}
+    {{text-field class="email-in" value=category.email_subject_slug}}
+  </label>
+</section>
+
 {{#if emailInEnabled}}
     <section class='field'>
       <label>

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -177,6 +177,19 @@ class CategoriesController < ApplicationController
     end
   end
 
+  def update_email_subject_slug
+    @category = Category.find(params[:category_id].to_i)
+    guardian.ensure_can_edit!(@category)
+
+    custom_slug = params[:email_subject_slug].to_s
+
+    if custom_slug.present? && @category.update_attributes(email_subject_slug: custom_slug)
+      render json: success_json
+    else
+      render_json_error(@category)
+    end
+  end
+
   def set_notifications
     category_id = params[:category_id].to_i
     notification_level = params[:notification_level].to_i
@@ -240,6 +253,7 @@ class CategoriesController < ApplicationController
                         :uploaded_logo_id,
                         :uploaded_background_id,
                         :slug,
+                        :email_subject_slug,
                         :allow_badges,
                         :topic_template,
                         :sort_order,

--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -371,6 +371,7 @@ class UserNotifications < ActionMailer::Base
     category = Topic.find_by(id: post.topic_id).category
     if opts[:show_category_in_subject] && post.topic_id && category && !category.uncategorized?
       show_category_in_subject = category.name
+      show_category_slug_in_subject = category.email_subject_slug
 
       # subcategory case
       if !category.parent_category_id.nil?
@@ -378,6 +379,7 @@ class UserNotifications < ActionMailer::Base
       end
     else
       show_category_in_subject = nil
+      show_category_slug_in_subject = nil
     end
 
     if SiteSetting.private_email?
@@ -464,6 +466,7 @@ class UserNotifications < ActionMailer::Base
       use_site_subject: use_site_subject,
       add_re_to_subject: add_re_to_subject,
       show_category_in_subject: show_category_in_subject,
+      show_category_slug_in_subject: show_category_slug_in_subject,
       private_reply: post.topic.private_message?,
       include_respond_instructions: !(user.suspended? || user.staged?),
       template: template,

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -528,6 +528,7 @@ end
 #  topics_month                  :integer          default(0)
 #  topics_week                   :integer          default(0)
 #  slug                          :string           not null
+#  email_subject_slug            :string
 #  description                   :text
 #  text_color                    :string(6)        default("FFFFFF"), not null
 #  read_restricted               :boolean          default(FALSE), not null

--- a/app/serializers/basic_category_serializer.rb
+++ b/app/serializers/basic_category_serializer.rb
@@ -24,7 +24,8 @@ class BasicCategorySerializer < ApplicationSerializer
              :num_featured_topics,
              :default_view,
              :subcategory_list_style,
-             :default_top_period
+             :default_top_period,
+             :email_subject_slug
 
   has_one :uploaded_logo, embed: :object, serializer: CategoryUploadSerializer
   has_one :uploaded_background, embed: :object, serializer: CategoryUploadSerializer

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1995,6 +1995,7 @@ en:
       save: 'Save Category'
       slug: 'Category Slug'
       slug_placeholder: '(Optional) dashed-words for url'
+      email_subject_slug: 'Email Subject Slug'
       creation_error: There has been an error during the creation of the category.
       save_error: There was an error saving the category.
       name: "Category Name"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -494,6 +494,7 @@ Discourse::Application.routes.draw do
   post "categories/reorder" => "categories#reorder"
   post "category/:category_id/notifications" => "categories#set_notifications"
   put "category/:category_id/slug" => "categories#update_slug"
+  put "category/:category_id/email_subject_slug" => "categories#update_email_slug"
 
   get "categories_and_latest" => "categories#categories_and_latest"
 

--- a/lib/email/message_builder.rb
+++ b/lib/email/message_builder.rb
@@ -65,6 +65,7 @@ module Email
         subject.gsub!("%{optional_re}", @opts[:add_re_to_subject] ? I18n.t('subject_re', @template_args) : '')
         subject.gsub!("%{optional_pm}", @opts[:private_reply] ? I18n.t('subject_pm', @template_args) : '')
         subject.gsub!("%{optional_cat}", @template_args[:show_category_in_subject] ? "[#{@template_args[:show_category_in_subject]}] " : '')
+        subject.gsub!("%{optional_cat_slug}", @template_args[:show_category_slug_in_subject] ? "[#{@template_args[:show_category_slug_in_subject]}] " : '')
         subject.gsub!("%{topic_title}", @template_args[:topic_title]) if @template_args[:topic_title] # must be last for safety
       else
         subject = @opts[:subject]


### PR DESCRIPTION
This lets us turn "[Game Development] actual subject..." emails into
"[GAMEDEV] actual subject" without resorting to making the official name of
the category ugly (or breaking URLs and/or uglifying the usual category slug). We need this as we add more things that were mailing lists, so Mailing List Mode people continue on with the subject slug people expected.

A lot of this was built by looking at revision control to see what had to be touched for other fields in the Category Settings UI, but I was basically stumbling around in the dark, so if something looks obviously wrong, it probably is.

This needs a field added to the Categories table, so there's a db/migrate entry. The UI needs a new string translated; I filled in English only.