### PR TITLE
Fix bench script 

### DIFF
--- a/script/profile_db_generator.rb
+++ b/script/profile_db_generator.rb
@@ -44,7 +44,7 @@ end
 
 def create_admin(seq)
   User.new.tap { |admin|
-    admin.email = "admin@localhost#{seq}"
+    admin.email = "admin@localhost#{seq}.fake"
     admin.username = "admin#{seq}"
     admin.password = "password"
     admin.save


### PR DESCRIPTION
I tried to clone Discourse so that I could work on some perf patches, but I couldn't get the bench script to work without a few tiny fixes. 

- 'facter' gem requires 'CFPropertyList` gem, but it's not installed automatically
- the `run` method called `Kernel::exit`, which silently exits instead of telling you why. Changed to `Kernel::abort`
- Email addresses created in profile_db_generator were invalid according to the User email validation regex. (Didn't allow `admin@localhost1` as a valid email)