### PR TITLE
FIX: Corrects typo to avoid error 500 on theme change

### DIFF
--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -301,7 +301,7 @@ class Guardian
     if is_staff?
       Theme.theme_keys.include?(theme_key)
     else
-      Theme.theme_user_keys.include?(theme_key)
+      Theme.user_theme_keys.include?(theme_key)
     end
   end
 


### PR DESCRIPTION
Simple typo by the looks of it 