### PR TITLE
FIX: increase host_must_be_valid regex for .technology TLD

### DIFF
--- a/app/models/embeddable_host.rb
+++ b/app/models/embeddable_host.rb
@@ -39,7 +39,7 @@ class EmbeddableHost < ActiveRecord::Base
   private
 
     def host_must_be_valid
-      if host !~ /\A[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,7}(:[0-9]{1,5})?(\/.*)?\Z/i &&
+      if host !~ /\A[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,10}(:[0-9]{1,5})?(\/.*)?\Z/i &&
          host !~ /\A(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})(:[0-9]{1,5})?(\/.*)?\Z/ &&
          host !~ /\A([a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.)?localhost(\:[0-9]{1,5})?(\/.*)?\Z/i
         errors.add(:host, I18n.t('errors.messages.invalid'))


### PR DESCRIPTION
The `.technology` is 10 chars long and wasn't being matched previously. This you couldn't add it  as an embeddable host for comments.