### PR TITLE
The "Groups" section's heading on user admin page was visible to mods

### DIFF
--- a/app/assets/javascripts/admin/templates/user-index.hbs
+++ b/app/assets/javascripts/admin/templates/user-index.hbs
@@ -343,32 +343,31 @@
   </div>
 </section>
 
-<section class='details'>
-  <h1>{{i18n 'admin.groups.title'}}</h1>
-
-  {{#if currentUser.admin}}
-    <div class='display-row'>
-      <div class='field'>{{i18n 'admin.groups.automatic'}}</div>
-      <div class='value'>{{automaticGroups}}</div>
-    </div>
-    <div class='display-row'>
-      <div class='field'>{{i18n 'admin.groups.custom'}}</div>
-      <div class='value'>
-        {{admin-group-selector selected=model.customGroups available=availableGroups}}
+{{#if currentUser.admin}}
+  <section class='details'>
+    <h1>{{i18n 'admin.groups.title'}}</h1>
+      <div class='display-row'>
+        <div class='field'>{{i18n 'admin.groups.automatic'}}</div>
+        <div class='value'>{{automaticGroups}}</div>
       </div>
-      <div class='controls'>
-        {{#if model.customGroups}}
-          {{i18n 'admin.groups.primary'}}
-          {{combo-box content=model.customGroups value=model.primary_group_id nameProperty="name" none="admin.groups.no_primary"}}
-        {{/if}}
-        {{#if primaryGroupDirty}}
-          {{d-button icon="check" class="ok" action="savePrimaryGroup"}}
-          {{d-button icon="times" class="cancel" action="resetPrimaryGroup"}}
-        {{/if}}
+      <div class='display-row'>
+        <div class='field'>{{i18n 'admin.groups.custom'}}</div>
+        <div class='value'>
+          {{admin-group-selector selected=model.customGroups available=availableGroups}}
+        </div>
+        <div class='controls'>
+          {{#if model.customGroups}}
+            {{i18n 'admin.groups.primary'}}
+            {{combo-box content=model.customGroups value=model.primary_group_id nameProperty="name" none="admin.groups.no_primary"}}
+          {{/if}}
+          {{#if primaryGroupDirty}}
+            {{d-button icon="check" class="ok" action="savePrimaryGroup"}}
+            {{d-button icon="times" class="cancel" action="resetPrimaryGroup"}}
+          {{/if}}
+        </div>
       </div>
-    </div>
-  {{/if}}
-</section>
+  </section>
+{{/if}}
 
 <section class='details'>
   <h1>{{i18n 'admin.user.activity'}}</h1>


### PR DESCRIPTION
Has been bothering me for a while so I thought I'd submit a PR :)

Here is a before and after:
Before:

![before](https://cloud.githubusercontent.com/assets/17474474/25099135/c0e1d5a4-23b3-11e7-95d1-8036bff057d4.png)

After:

![after](https://cloud.githubusercontent.com/assets/17474474/25099130/c060a538-23b3-11e7-8428-602fc523e9e8.png)