### PR TITLE
Revert "FIX: User website allows new TLDs"

### DIFF
--- a/app/models/user_profile.rb
+++ b/app/models/user_profile.rb
@@ -1,7 +1,10 @@
 class UserProfile < ActiveRecord::Base
   belongs_to :user, inverse_of: :user_profile
 
+  WEBSITE_REGEXP = /(^$)|(^(http|https):\/\/[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,10}(([0-9]{1,5})?\/.*)?$)/ix
+
   validates :bio_raw, length: { maximum: 3000 }
+  validates :website, format: { with: WEBSITE_REGEXP }, allow_blank: true, if: Proc.new { |c| c.new_record? || c.website_changed? }
   validates :user, presence: true
   before_save :cook
   after_save :trigger_badges
@@ -102,13 +105,11 @@ class UserProfile < ActiveRecord::Base
   end
 
   def website_domain_validator
-    return if self.website.blank?
-    domain = Addressable::URI.parse(self.website).host
-    self.errors.add :website, :invalid unless PublicSuffix.valid?(domain, default_rule: nil)
+    allowed_domains = SiteSetting.user_website_domains_whitelist
+    return if (allowed_domains.blank? || self.website.blank?)
 
-    allowed_domains = SiteSetting.user_website_domains_whitelist.split('|')
-    return if allowed_domains.empty?
-    self.errors.add :base, (I18n.t('user.website.domain_not_allowed', domains: allowed_domains.join(", "))) unless allowed_domains.include?(domain)
+    domain = URI.parse(self.website).host
+    self.errors.add :base, (I18n.t('user.website.domain_not_allowed', domains: allowed_domains.split('|').join(", "))) unless allowed_domains.split('|').include?(domain)
   end
 
 end

--- a/spec/models/user_profile_spec.rb
+++ b/spec/models/user_profile_spec.rb
@@ -62,12 +62,6 @@ describe UserProfile do
         expect(Fabricate.build(:user_profile, user: user, website: "https://google.com")).to be_valid
       end
 
-      it "recognizes new TLDs" do
-        expect(Fabricate.build(:user_profile, user: user, website: "http://discourse.productions")).to be_valid
-        expect(Fabricate.build(:user_profile, user: user, website: "https://website.vermögensberatung")).to be_valid
-        expect(Fabricate.build(:user_profile, user: user, website: "http://site.notavalidtld")).not_to be_valid
-      end
-
       it "validates website domain if user_website_domains_whitelist setting is present" do
         SiteSetting.user_website_domains_whitelist = "discourse.org"
         expect(Fabricate.build(:user_profile, user: user, website: "https://google.com")).not_to be_valid


### PR DESCRIPTION
Reverts discourse/discourse#4819

@xfalcox reverting this because `addressable` gem is not installed in production. It's a dependency for `webmock` which is only installed in the test environment.