### PR TITLE
FIX: Correct behavior of auto-notification state updating to exclude …

### DIFF
--- a/app/models/topic_user.rb
+++ b/app/models/topic_user.rb
@@ -38,8 +38,9 @@ class TopicUser < ActiveRecord::Base
     end
 
     def auto_notification(user_id, topic_id, reason, notification_level)
-      if TopicUser.where("user_id = ? AND topic_id = ? AND (notifications_reason_id IS NULL OR notification_level < ?)",
-                           user_id, topic_id, notification_level).exists?
+      if TopicUser.where("user_id = :user_id AND topic_id = :topic_id AND (notifications_reason_id IS NULL OR
+        (notification_level < :notification_level AND notification_level > 1))",
+                           user_id: user_id, topic_id: topic_id, notification_level: notification_level).exists?
         change(user_id, topic_id,
           notification_level: notification_level,
           notifications_reason_id: reason

--- a/spec/models/topic_user_spec.rb
+++ b/spec/models/topic_user_spec.rb
@@ -272,6 +272,28 @@ describe TopicUser do
         expect(tu.notification_level).to eq(TopicUser.notification_levels[:watching])
       end
 
+      it 'should not update tracking state when state manually set to normal you reply' do
+        new_user.user_option.update_column(:notification_level_when_replying, 3)
+        post_creator.create
+        TopicUser.exec_sql("UPDATE topic_users set notification_level=1
+                       WHERE topic_id = :topic_id AND user_id = :user_id", topic_id: topic_new_user.topic_id, user_id: topic_new_user.user_id)
+        TopicUser.auto_notification(topic_new_user.user_id, topic_new_user.topic_id, TopicUser.notification_reasons[:created_post], TopicUser.notification_levels[:tracking])
+
+        tu = TopicUser.find_by(user_id: topic_new_user.user_id, topic_id: topic_new_user.topic_id)
+        expect(tu.notification_level).to eq(TopicUser.notification_levels[:regular])
+      end
+
+      it 'should not update tracking state when state manually set to muted you reply' do
+        new_user.user_option.update_column(:notification_level_when_replying, 3)
+        post_creator.create
+        TopicUser.exec_sql("UPDATE topic_users set notification_level=0
+                       WHERE topic_id = :topic_id AND user_id = :user_id", topic_id: topic_new_user.topic_id, user_id: topic_new_user.user_id)
+        TopicUser.auto_notification(topic_new_user.user_id, topic_new_user.topic_id, TopicUser.notification_reasons[:created_post], TopicUser.notification_levels[:tracking])
+
+        tu = TopicUser.find_by(user_id: topic_new_user.user_id, topic_id: topic_new_user.topic_id)
+        expect(tu.notification_level).to eq(TopicUser.notification_levels[:muted])
+      end
+
       it 'should not automatically track topics you reply to and have set state manually' do
         post_creator.create
         TopicUser.change(new_user, topic, notification_level: TopicUser.notification_levels[:regular])


### PR DESCRIPTION
…when the topic already has a state of normal/muted