### PR TITLE
FEATURE: Add normal as a preference for topic subscription state when replying to a topic

### DIFF
--- a/app/assets/javascripts/discourse/controllers/preferences.js.es6
+++ b/app/assets/javascripts/discourse/controllers/preferences.js.es6
@@ -124,7 +124,8 @@ export default Ember.Controller.extend(CanCheckEmails, {
                        { name: I18n.t('user.auto_track_options.after_10_minutes'), value: 600000 }],
 
   notificationLevelsForReplying: [{ name: I18n.t('topic.notifications.watching.title'), value: NotificationLevels.WATCHING },
-                                  { name: I18n.t('topic.notifications.tracking.title'), value: NotificationLevels.TRACKING }],
+                                  { name: I18n.t('topic.notifications.tracking.title'), value: NotificationLevels.TRACKING },
+                                  { name: I18n.t('topic.notifications.regular.title'), value: NotificationLevels.REGULAR }],
 
 
   considerNewTopicOptions: [{ name: I18n.t('user.new_topic_duration.not_viewed'), value: -1 },

--- a/app/models/notification_level_when_replying_site_setting.rb
+++ b/app/models/notification_level_when_replying_site_setting.rb
@@ -15,7 +15,8 @@ class NotificationLevelWhenReplyingSiteSetting < EnumSiteSetting
   def self.values
     @values ||= [
       { name: 'topic.notifications.watching.title', value: notification_levels[:watching] },
-      { name: 'topic.notifications.tracking.title', value: notification_levels[:tracking] }
+      { name: 'topic.notifications.tracking.title', value: notification_levels[:tracking] },
+      { name: 'topic.notifications.regular.title', value: notification_levels[:regular] }
     ]
   end
 

--- a/lib/post_creator.rb
+++ b/lib/post_creator.rb
@@ -494,6 +494,8 @@ class PostCreator
       TopicUser.auto_notification_for_staging(@user.id, @topic.id, TopicUser.notification_reasons[:auto_watch])
     elsif @user.user_option.notification_level_when_replying === NotificationLevels.topic_levels[:watching]
       TopicUser.auto_notification(@user.id, @topic.id, TopicUser.notification_reasons[:created_post], NotificationLevels.topic_levels[:watching])
+    elsif @user.user_option.notification_level_when_replying === NotificationLevels.topic_levels[:regular]
+      TopicUser.auto_notification(@user.id, @topic.id, TopicUser.notification_reasons[:created_post], NotificationLevels.topic_levels[:regular])
     else
       TopicUser.auto_notification(@user.id, @topic.id, TopicUser.notification_reasons[:created_post], NotificationLevels.topic_levels[:tracking])
     end

--- a/spec/components/post_creator_spec.rb
+++ b/spec/components/post_creator_spec.rb
@@ -899,6 +899,23 @@ describe PostCreator do
       topic_user = TopicUser.find_by(user_id: user.id, topic_id: post.topic_id)
       expect(topic_user.notification_level).to eq(TopicUser.notification_levels[:tracking])
     end
+
+    it "topic notification level is normal based on preference" do
+      user.user_option.notification_level_when_replying = 1
+
+      admin = Fabricate(:admin)
+      topic = PostCreator.create(admin,
+                                 title: "this is the title of a topic created by an admin for tracking notification",
+                                 raw: "this is the content of a topic created by an admin for keeping a tracking notification state on a topic ;)"
+      )
+
+      post = PostCreator.create(user,
+                                topic_id: topic.topic_id,
+                                raw: "this is a reply to set the tracking state to normal ;)"
+      )
+      topic_user = TopicUser.find_by(user_id: user.id, topic_id: post.topic_id)
+      expect(topic_user.notification_level).to eq(TopicUser.notification_levels[:regular])
+    end
   end
 
   describe '#create!' do


### PR DESCRIPTION
Relevant Discussion
https://github.com/discourse/discourse/commit/4dc4c5bebcbc37c3ad38aad12ad5f00b95377471

Notes:
1. Tracking is still the default when the user preference is not set to anything
2. This still abides by the requested subscription must be higher than what is currently set and what is currently set must be higher than normal/regular. (see https://meta.discourse.org/t/change-category-tracking-subscription-to-watching-if-i-post-a-reply/60958/25?u=cpradio)
3. Admin Setting can be default to Normal as well now

Other Notes:
1. If the user's setting of `Automatically track topics I enter` is set to anything other than Never, and that time allotment passes, having the setting `When I post in a topic, set that topic to` Normal will do nothing, as the topic state was already set to Tracking.