### PR TITLE
FIX: make TopicEmbed trashable

### DIFF
--- a/app/models/topic_embed.rb
+++ b/app/models/topic_embed.rb
@@ -1,10 +1,18 @@
 require_dependency 'nokogiri'
 
 class TopicEmbed < ActiveRecord::Base
+  include Trashable
+
   belongs_to :topic
   belongs_to :post
   validates_presence_of :embed_url
   validates_uniqueness_of :embed_url
+
+  before_validation(on: :create) do
+    unless (topic_embed = TopicEmbed.with_deleted.where('deleted_at IS NOT NULL AND embed_url = ?', embed_url).first).nil?
+      topic_embed.destroy!
+    end
+  end
 
   class FetchResponse
     attr_accessor :title, :body, :author
@@ -203,13 +211,15 @@ end
 #
 # Table name: topic_embeds
 #
-#  id           :integer          not null, primary key
-#  topic_id     :integer          not null
-#  post_id      :integer          not null
-#  embed_url    :string(1000)     not null
-#  content_sha1 :string(40)
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
+#  id            :integer          not null, primary key
+#  topic_id      :integer          not null
+#  post_id       :integer          not null
+#  embed_url     :string(1000)     not null
+#  content_sha1  :string(40)
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  deleted_at    :datetime
+#  deleted_by_id :integer
 #
 # Indexes
 #

--- a/db/migrate/20170425083011_add_deleted_at_to_topic_embeds.rb
+++ b/db/migrate/20170425083011_add_deleted_at_to_topic_embeds.rb
@@ -1,0 +1,6 @@
+class AddDeletedAtToTopicEmbeds < ActiveRecord::Migration
+  def change
+    add_column :topic_embeds, :deleted_at, :datetime
+    add_column :topic_embeds, :deleted_by_id, :integer, null: true
+  end
+end

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -1493,6 +1493,15 @@ describe Topic do
         expect { topic.trash!(moderator) }.to_not change { category.reload.topic_count }
       end
     end
+
+    it "trashes topic embed record" do
+      topic = Fabricate(:topic)
+      post = Fabricate(:post, topic: topic, post_number: 1)
+      topic_embed = TopicEmbed.create!(topic_id: topic.id, embed_url: "https://blog.codinghorror.com/password-rules-are-bullshit", post_id: post.id)
+      topic.trash!
+      topic_embed.reload
+      expect(topic_embed.deleted_at).not_to eq(nil)
+    end
   end
 
   describe 'recover!' do
@@ -1508,6 +1517,15 @@ describe Topic do
         topic = Fabricate(:topic, category: category)
         expect { topic.recover! }.to_not change { category.reload.topic_count }
       end
+    end
+
+    it "recovers topic embed record" do
+      topic = Fabricate(:topic, deleted_at: 1.day.ago)
+      post = Fabricate(:post, topic: topic, post_number: 1)
+      topic_embed = TopicEmbed.create!(topic_id: topic.id, embed_url: "https://blog.codinghorror.com/password-rules-are-bullshit", post_id: post.id, deleted_at: 1.day.ago)
+      topic.recover!
+      topic_embed.reload
+      expect(topic_embed.deleted_at).to eq(nil)
     end
   end
 


### PR DESCRIPTION
Requested here: https://meta.discourse.org/t/a-posts-topicembed-isnt-destroyed-when-the-post-is-deleted/60904?u=techapj

This PR allows `TopicEmbed` to be trashed when topic is deleted. Essentially four things is added in this PR:

1) If the topic is trashed, trash associated topic_embed record as well. Thus allowing new topic_embed record to be created for same `embed_url` (more info about this in point 3).

2) If the topic is recovered, recover associated topic_embed record as well.

3) If a new topic_embed record is created that has same `embed_url` which was trashed earlier, then that old (trashed) record will be permanently destroyed thus preventing accidental recovery of that old (trashed) record.

4) When the topic is permanently destroyed, destroy associated topic_embed record as well.

@eviltrout can you please review this PR? Thanks!