### PR TITLE
phpBB3 importer: Disable file size validators during import

### DIFF
--- a/script/import_scripts/phpbb3/importer.rb
+++ b/script/import_scripts/phpbb3/importer.rb
@@ -34,9 +34,32 @@ module ImportScripts::PhpBB3
     end
 
     def change_site_settings
+      # let's make sure that we import all attachments no matter how big they are
+      setting_keys = [:max_image_size_kb, :max_attachment_size_kb]
+      original_validators = disable_setting_validators(setting_keys)
+
       super
 
       @importers.permalink_importer.change_site_settings
+
+      enable_setting_validators(original_validators)
+    end
+
+    def disable_setting_validators(setting_keys)
+      original_validators = {}
+
+      setting_keys.each do |key|
+        original_validators[key] = SiteSetting.validators[key]
+        SiteSetting.validators[key] = nil
+      end
+
+      original_validators
+    end
+
+    def enable_setting_validators(original_validators)
+      original_validators.each do |key, validator|
+        SiteSetting.validators[key] = validator
+      end
     end
 
     def get_site_settings_for_import


### PR DESCRIPTION
Let's make sure that we import all attachments no matter how big they are by disabling the site setting validators for `max_image_size_kb` and `max_attachment_size_kb` during the import.

This fixes problems like this one:
https://meta.discourse.org/t/importing-from-phpbb3/30810/200