### PR TITLE
FIX: 'read' filter in top menu showing new topics

### DIFF
--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -165,7 +165,7 @@ class TopicQuery
 
   def list_read
     create_list(:read, unordered: true) do |topics|
-      topics.order('COALESCE(tu.last_visited_at, topics.bumped_at) DESC')
+      topics.where('tu.last_visited_at IS NOT NULL').order('tu.last_visited_at DESC')
     end
   end
 

--- a/spec/components/topic_query_spec.rb
+++ b/spec/components/topic_query_spec.rb
@@ -458,6 +458,8 @@ describe TopicQuery do
 
       context 'list_unread' do
         it 'lists topics correctly' do
+          new_topic = Fabricate(:post, user: creator).topic
+
           expect(topic_query.list_unread.topics).to eq([])
           expect(topic_query.list_read.topics).to match_array([fully_read, partially_read])
         end


### PR DESCRIPTION
https://meta.discourse.org/t/read-filter-in-top-menu-showing-new-topics/61654