### PR TITLE
FEATURE: provide more details when performing a bulk add to group

### DIFF
--- a/app/assets/javascripts/admin/controllers/admin-groups-bulk-complete.js.es6
+++ b/app/assets/javascripts/admin/controllers/admin-groups-bulk-complete.js.es6
@@ -1,0 +1,4 @@
+export default Ember.Controller.extend({
+  adminGroupsBulk: Ember.inject.controller(),
+  bulkAddResponse: Ember.computed.alias('adminGroupsBulk.bulkAddResponse')
+});

--- a/app/assets/javascripts/admin/controllers/admin-groups-bulk.js.es6
+++ b/app/assets/javascripts/admin/controllers/admin-groups-bulk.js.es6
@@ -6,6 +6,7 @@ export default Ember.Controller.extend({
   users: null,
   groupId: null,
   saving: false,
+  bulkAddResponse: null,
 
   @computed('saving', 'users', 'groupId')
   buttonDisabled(saving, users, groupId) {
@@ -24,7 +25,8 @@ export default Ember.Controller.extend({
       ajax('/admin/groups/bulk', {
         data: { users, group_id: this.get('groupId') },
         method: 'PUT'
-      }).then(() => {
+      }).then(result => {
+        this.set('bulkAddResponse', result);
         this.transitionToRoute('adminGroups.bulkComplete');
       }).catch(popupAjaxError).finally(() => {
         this.set('saving', false);

--- a/app/assets/javascripts/admin/templates/groups-bulk-complete.hbs
+++ b/app/assets/javascripts/admin/templates/groups-bulk-complete.hbs
@@ -1,1 +1,11 @@
-<p>{{i18n "admin.groups.bulk_complete"}}</p>
+{{#if bulkAddResponse}}
+  <p>{{{bulkAddResponse.message}}}</p>
+  {{#if bulkAddResponse.users_not_added}}
+    <p>{{i18n "admin.groups.bulk_complete_users_not_added"}}</p>
+    {{#each bulkAddResponse.users_not_added as |user|}}
+      {{user}}<br/>
+    {{/each}}
+  {{/if}}
+{{else}}
+  <p>{{i18n "admin.groups.bulk_complete"}}</p>
+{{/if}}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2600,6 +2600,7 @@ en:
         add_members: "Add members"
         custom: "Custom"
         bulk_complete: "The users have been added to the group."
+        bulk_complete_users_not_added: "These users were not added:"
         bulk: "Bulk Add to Group"
         bulk_paste: "Paste a list of usernames or emails, one per line:"
         bulk_select: "(select a group)"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -255,6 +255,8 @@ en:
     delete_reason: "Deleted via post moderation queue"
 
   groups:
+    success:
+      bulk_add: "%{users_added} users have been added to the group."
     errors:
       can_not_modify_automatic: "You cannot modify an automatic group"
       member_already_exist: "'%{username}' is already a member of this group."

--- a/spec/controllers/admin/groups_controller_spec.rb
+++ b/spec/controllers/admin/groups_controller_spec.rb
@@ -69,6 +69,11 @@ describe Admin::GroupsController do
       expect(user2.primary_group).to eq(group)
       expect(user2.title).to eq("WAT")
       expect(user2.trust_level).to eq(4)
+
+      # verify JSON response
+      json = ::JSON.parse(response.body)
+      expect(json['message']).to eq("2 users have been added to the group.")
+      expect(json['users_not_added'][0]).to eq("doesnt_exist")
     end
   end
 


### PR DESCRIPTION
https://meta.discourse.org/t/provide-more-details-when-performing-a-bulk-add-to-group/60665?u=techapj

This PR adds more information on success page.

![screen shot 2017-04-27 at 01 25 44](https://cloud.githubusercontent.com/assets/5732281/25454203/40dcac20-2ae9-11e7-8af3-8e9646a2dad4.png)
