### PR TITLE
Allow users to resend/update email from confirmation page

### DIFF
--- a/app/assets/javascripts/discourse-common/resolver.js.es6
+++ b/app/assets/javascripts/discourse-common/resolver.js.es6
@@ -134,7 +134,6 @@ export function buildResolver(baseName) {
       if (full.indexOf('connectors') === 0) {
         return Ember.TEMPLATES[`javascripts/${full}`];
       }
-
     },
 
     resolveTemplate(parsedName) {

--- a/app/assets/javascripts/discourse/components/activation-controls.js.es6
+++ b/app/assets/javascripts/discourse/components/activation-controls.js.es6
@@ -1,0 +1,3 @@
+export default Ember.Component.extend({
+  classNames: 'activation-controls'
+});

--- a/app/assets/javascripts/discourse/controllers/account-created-edit-email.js.es6
+++ b/app/assets/javascripts/discourse/controllers/account-created-edit-email.js.es6
@@ -1,0 +1,27 @@
+import { changeEmail } from 'discourse/lib/user-activation';
+import computed from 'ember-addons/ember-computed-decorators';
+import { popupAjaxError } from 'discourse/lib/ajax-error';
+
+export default Ember.Controller.extend({
+  accountCreated: null,
+  newEmail: null,
+
+  @computed('newEmail', 'accountCreated.email')
+  submitDisabled(newEmail, currentEmail) {
+    return newEmail === currentEmail;
+  },
+
+  actions: {
+    changeEmail() {
+      const email = this.get('newEmail');
+      changeEmail({ email }).then(() => {
+        this.set('accountCreated.email', email);
+        this.transitionToRoute('account-created.resent');
+      }).catch(popupAjaxError);
+    },
+
+    cancel() {
+      this.transitionToRoute('account-created.index');
+    }
+  }
+});

--- a/app/assets/javascripts/discourse/controllers/account-created-index.js.es6
+++ b/app/assets/javascripts/discourse/controllers/account-created-index.js.es6
@@ -1,0 +1,15 @@
+import { resendActivationEmail } from 'discourse/lib/user-activation';
+
+export default Ember.Controller.extend({
+  actions: {
+    sendActivationEmail() {
+      resendActivationEmail(this.get('accountCreated.username')).then(() => {
+        this.transitionToRoute('account-created.resent');
+      });
+    },
+    editActivationEmail() {
+      this.transitionToRoute('account-created.edit-email');
+    }
+  }
+});
+

--- a/app/assets/javascripts/discourse/controllers/activation-edit.js.es6
+++ b/app/assets/javascripts/discourse/controllers/activation-edit.js.es6
@@ -1,8 +1,7 @@
 import computed from 'ember-addons/ember-computed-decorators';
 import ModalFunctionality from 'discourse/mixins/modal-functionality';
-import { ajax } from 'discourse/lib/ajax';
 import { extractError } from 'discourse/lib/ajax-error';
-import { userPath } from 'discourse/lib/url';
+import { changeEmail } from 'discourse/lib/user-activation';
 
 export default Ember.Controller.extend(ModalFunctionality, {
   login: Ember.inject.controller(),
@@ -20,13 +19,10 @@ export default Ember.Controller.extend(ModalFunctionality, {
     changeEmail() {
       const login = this.get('login');
 
-      ajax(userPath('update-activation-email'), {
-        data: {
-          username: login.get('loginName'),
-          password: login.get('loginPassword'),
-          email: this.get('newEmail')
-        },
-        type: 'PUT'
+      changeEmail({
+        username: login.get('loginName'),
+        password: login.get('loginPassword'),
+        email: this.get('newEmail')
       }).then(() => {
         const modal = this.showModal('activation-resent', {title: 'log_in'});
         modal.set('currentEmail', this.get('newEmail'));

--- a/app/assets/javascripts/discourse/controllers/not-activated.js.es6
+++ b/app/assets/javascripts/discourse/controllers/not-activated.js.es6
@@ -1,18 +1,13 @@
-import { ajax } from 'discourse/lib/ajax';
-import { popupAjaxError } from 'discourse/lib/ajax-error';
 import ModalFunctionality from 'discourse/mixins/modal-functionality';
-import { userPath } from 'discourse/lib/url';
+import { resendActivationEmail } from 'discourse/lib/user-activation';
 
 export default Ember.Controller.extend(ModalFunctionality, {
   actions: {
     sendActivationEmail() {
-      ajax(userPath('action/send_activation_email'), {
-        data: { username: this.get('username') },
-        type: 'POST'
-      }).then(() => {
+      resendActivationEmail(this.get('username')).then(() => {
         const modal = this.showModal('activation-resent', {title: 'log_in'});
         modal.set('currentEmail', this.get('currentEmail'));
-      }).catch(popupAjaxError);
+      });
     },
 
     editActivationEmail() {

--- a/app/assets/javascripts/discourse/initializers/url-redirects.js.es6
+++ b/app/assets/javascripts/discourse/initializers/url-redirects.js.es6
@@ -20,6 +20,8 @@ export default {
       DiscourseURL.rewrite(new RegExp(`^/u/${username}/?$`, "i"), `/u/${username}/activity`);
     }
 
-    DiscourseURL.rewrite(/^\/u\/([^\/]+)\/?$/, "/u/$1/summary");
+    DiscourseURL.rewrite(/^\/u\/([^\/]+)\/?$/, "/u/$1/summary", {
+      exceptions: ['/u/account-created']
+    });
   }
 };

--- a/app/assets/javascripts/discourse/lib/url.js.es6
+++ b/app/assets/javascripts/discourse/lib/url.js.es6
@@ -22,7 +22,12 @@ export function rewritePath(path) {
   const params = path.split("?");
 
   let result = params[0];
-  rewrites.forEach(rw => result = result.replace(rw.regexp, rw.replacement));
+  rewrites.forEach(rw => {
+    if (((rw.opts.exceptions || []).some(ex => path.indexOf(ex) === 0))) {
+      return;
+    }
+    result = result.replace(rw.regexp, rw.replacement);
+  });
 
   if (params.length > 1) {
     result += `?${params[1]}`;
@@ -219,8 +224,8 @@ const DiscourseURL = Ember.Object.extend({
     return this.handleURL(path, opts);
   },
 
-  rewrite(regexp, replacement) {
-    rewrites.push({ regexp, replacement });
+  rewrite(regexp, replacement, opts) {
+    rewrites.push({ regexp, replacement, opts: opts || {} });
   },
 
   redirectTo(url) {

--- a/app/assets/javascripts/discourse/lib/user-activation.js.es6
+++ b/app/assets/javascripts/discourse/lib/user-activation.js.es6
@@ -1,0 +1,15 @@
+import { ajax } from 'discourse/lib/ajax';
+import { popupAjaxError } from 'discourse/lib/ajax-error';
+import { userPath } from 'discourse/lib/url';
+
+export function resendActivationEmail(username) {
+  return ajax(userPath('action/send_activation_email'), {
+    type: 'POST',
+    data: { username }
+  }).catch(popupAjaxError);
+}
+
+export function changeEmail(data) {
+  return ajax(userPath('update-activation-email'), { data, type: 'PUT' });
+}
+

--- a/app/assets/javascripts/discourse/routes/account-created-edit-email.js.es6
+++ b/app/assets/javascripts/discourse/routes/account-created-edit-email.js.es6
@@ -1,0 +1,7 @@
+export default Ember.Route.extend({
+  setupController(controller) {
+    const accountCreated = this.controllerFor('account-created').get('accountCreated');
+    controller.set('accountCreated', accountCreated);
+    controller.set('newEmail', accountCreated.email);
+  }
+});

--- a/app/assets/javascripts/discourse/routes/account-created-index.js.es6
+++ b/app/assets/javascripts/discourse/routes/account-created-index.js.es6
@@ -1,0 +1,9 @@
+export default Ember.Route.extend({
+  setupController(controller) {
+    controller.set(
+      'accountCreated',
+      this.controllerFor('account-created').get('accountCreated')
+    );
+  }
+});
+

--- a/app/assets/javascripts/discourse/routes/account-created-resent.js.es6
+++ b/app/assets/javascripts/discourse/routes/account-created-resent.js.es6
@@ -1,0 +1,8 @@
+export default Ember.Route.extend({
+  setupController(controller) {
+    controller.set(
+      'email',
+      this.controllerFor('account-created').get('accountCreated.email')
+    );
+  }
+});

--- a/app/assets/javascripts/discourse/routes/account-created.js.es6
+++ b/app/assets/javascripts/discourse/routes/account-created.js.es6
@@ -1,0 +1,7 @@
+import PreloadStore from 'preload-store';
+
+export default Ember.Route.extend({
+  setupController(controller) {
+    controller.set('accountCreated', PreloadStore.get('accountCreated'));
+  }
+});

--- a/app/assets/javascripts/discourse/routes/app-route-map.js.es6
+++ b/app/assets/javascripts/discourse/routes/app-route-map.js.es6
@@ -64,7 +64,10 @@ export default function() {
   // User routes
   this.route('users', { resetNamespace: true, path: '/u' });
   this.route('password-reset', { path: '/u/password-reset/:token' });
-  this.route('account-created', { path: '/u/account-created' });
+  this.route('account-created', { path: '/u/account-created' }, function() {
+    this.route('resent');
+    this.route('edit-email');
+  });
   this.route('user', { path: '/u/:username', resetNamespace: true }, function() {
     this.route('summary');
     this.route('userActivity', { path: '/activity', resetNamespace: true }, function() {

--- a/app/assets/javascripts/discourse/routes/app-route-map.js.es6
+++ b/app/assets/javascripts/discourse/routes/app-route-map.js.es6
@@ -64,6 +64,7 @@ export default function() {
   // User routes
   this.route('users', { resetNamespace: true, path: '/u' });
   this.route('password-reset', { path: '/u/password-reset/:token' });
+  this.route('account-created', { path: '/u/account-created' });
   this.route('user', { path: '/u/:username', resetNamespace: true }, function() {
     this.route('summary');
     this.route('userActivity', { path: '/activity', resetNamespace: true }, function() {

--- a/app/assets/javascripts/discourse/templates/account-created.hbs
+++ b/app/assets/javascripts/discourse/templates/account-created.hbs
@@ -1,3 +1,5 @@
 <div id='simple-container'>
-  <div class='account-created'>{{{accountCreated.message}}}</div>
+  <div class='account-created'>
+    {{outlet}}
+  </div>
 </div>

--- a/app/assets/javascripts/discourse/templates/account-created.hbs
+++ b/app/assets/javascripts/discourse/templates/account-created.hbs
@@ -1,0 +1,3 @@
+<div id='simple-container'>
+  <div class='account-created'>{{{accountCreated.message}}}</div>
+</div>

--- a/app/assets/javascripts/discourse/templates/account-created/edit-email.hbs
+++ b/app/assets/javascripts/discourse/templates/account-created/edit-email.hbs
@@ -1,11 +1,11 @@
-{{#d-modal-body}}
+<div class='ac-message'>
   {{activation-email-form email=newEmail}}
-{{/d-modal-body}}
+</div>
 
-<div class="modal-footer">
+<div class='activation-controls'>
   {{d-button action="changeEmail"
              label="login.submit_new_email"
              disabled=submitDisabled
              class="btn-primary"}}
-  {{d-button action="closeModal" label="close"}}
+  {{d-button action=(action "cancel") label="cancel" class="edit-cancel"}}
 </div>

--- a/app/assets/javascripts/discourse/templates/account-created/index.hbs
+++ b/app/assets/javascripts/discourse/templates/account-created/index.hbs
@@ -1,8 +1,7 @@
-{{#d-modal-body}}
-  {{{i18n 'login.not_activated' sentTo=sentTo}}}
-{{/d-modal-body}}
-
-<div class="modal-footer">
+<div class='ac-message'>
+  {{{accountCreated.message}}}
+</div>
+{{#if accountCreated.username}}
   {{activation-controls sendActivationEmail=(action "sendActivationEmail")
                         editActivationEmail=(action "editActivationEmail")}}
-</div>
+{{/if}}

--- a/app/assets/javascripts/discourse/templates/account-created/resent.hbs
+++ b/app/assets/javascripts/discourse/templates/account-created/resent.hbs
@@ -1,0 +1,3 @@
+<div class='ac-message'>
+  {{{i18n 'login.sent_activation_email_again' currentEmail=email}}}
+</div>

--- a/app/assets/javascripts/discourse/templates/components/activation-controls.hbs
+++ b/app/assets/javascripts/discourse/templates/components/activation-controls.hbs
@@ -1,0 +1,8 @@
+{{d-button action=sendActivationEmail
+           label="login.resend_title"
+           icon="envelope"
+           class="btn-primary resend"}}
+{{d-button action=editActivationEmail
+           label="login.change_email"
+           icon="pencil"
+           class="edit-email"}}

--- a/app/assets/javascripts/discourse/templates/components/activation-email-form.hbs
+++ b/app/assets/javascripts/discourse/templates/components/activation-email-form.hbs
@@ -1,0 +1,2 @@
+<p>{{i18n "login.provide_new_email"}}</p>
+{{input value=email class="activate-new-email"}}

--- a/app/assets/stylesheets/common/base/activation.scss
+++ b/app/assets/stylesheets/common/base/activation.scss
@@ -9,7 +9,15 @@
   margin: 0 auto;
 
   .account-created {
-    font-size: 16px;
-    line-height: 24px;
+    .ac-message {
+      font-size: 16px;
+      line-height: 24px;
+    }
+
+    .activation-controls {
+      button {
+        margin-right: 0.5em;
+      }
+    }
   }
 }

--- a/app/assets/stylesheets/common/base/activation.scss
+++ b/app/assets/stylesheets/common/base/activation.scss
@@ -7,4 +7,9 @@
   padding: 20px;
   width: 550px;
   margin: 0 auto;
+
+  .account-created {
+    font-size: 16px;
+    line-height: 24px;
+  }
 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,6 +10,7 @@ require_dependency 'letter_avatar'
 require_dependency 'distributed_cache'
 require_dependency 'global_path'
 require_dependency 'secure_session'
+require_dependency 'topic_query'
 
 class ApplicationController < ActionController::Base
   include CurrentUser

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -534,8 +534,10 @@ class UsersController < ApplicationController
   def account_created
     @custom_body_class = "static-account-created"
     @message = session['user_created_message'] || I18n.t('activation.missing_session')
+    store_preloaded("accountCreated", MultiJson.dump(message: @message))
+
     expires_now
-    render layout: 'no_ember'
+    render "default/empty"
   end
 
   def activate_account

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -533,6 +533,8 @@ class UsersController < ApplicationController
   end
 
   def account_created
+    return redirect_to("/") if current_user.present?
+
     @custom_body_class = "static-account-created"
     @message = session['user_created_message'] || I18n.t('activation.missing_session')
     @account_created = { message: @message }

--- a/app/views/users/account_created.html.erb
+++ b/app/views/users/account_created.html.erb
@@ -1,9 +1,0 @@
-<div id='simple-container'>
-  <span style="font-size: 16px; line-height: 24px;"><%= @message.html_safe %></span>
-</div>
-
-<%- content_for(:no_ember_head) do %>
-  <%= render_google_universal_analytics_code %>
-<%- end %>
-
-<%= render_google_analytics_code %>

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1661,7 +1661,7 @@ en:
     incorrect_username_email_or_password: "Incorrect username, email or password"
     wait_approval: "Thanks for signing up. We will notify you when your account has been approved."
     active: "Your account is activated and ready to use."
-    activate_email: "<p>You're almost done! We sent an activation mail to <b>%{email}</b>. Please follow the instructions in the email to activate your account.</p><p>If it doesn't arrive, check your spam folder, or try to log in again to send another activation mail or to input a new email address.</p>"
+    activate_email: "<p>You're almost done! We sent an activation mail to <b>%{email}</b>. Please follow the instructions in the email to activate your account.</p><p>If it doesn't arrive, check your spam folder, send another activation mail or input a new email address.</p>"
     not_activated: "You can't log in yet. We sent an activation email to you. Please follow the instructions in the email to activate your account."
     not_allowed_from_ip_address: "You can't log in as %{username} from that IP address."
     admin_not_allowed_from_ip_address: "You can't log in as admin from that IP address."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -324,6 +324,8 @@ Discourse::Application.routes.draw do
     post "#{root_path}/read-faq" => "users#read_faq"
     get "#{root_path}/search/users" => "users#search_users"
     get "#{root_path}/account-created/" => "users#account_created"
+    get "#{root_path}/account-created/resent" => "users#account_created"
+    get "#{root_path}/account-created/edit-email" => "users#account_created"
     get({ "#{root_path}/password-reset/:token" => "users#password_reset" }.merge(index == 1 ? { as: :password_reset_token } : {}))
     get "#{root_path}/confirm-email-token/:token" => "users#confirm_email_token", constraints: { format: 'json' }
     put "#{root_path}/password-reset/:token" => "users#password_reset"

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -2008,6 +2008,12 @@ describe UsersController do
       expect(created[:username]).to be_blank
     end
 
+    it "redirects when the user is logged in" do
+      log_in(:user)
+      get :account_created
+      expect(response).to be_redirect
+    end
+
     context "when the user account is created" do
       before do
         session['user_created_message'] = "Donuts"

--- a/test/javascripts/acceptance/account-created-test.js.es6
+++ b/test/javascripts/acceptance/account-created-test.js.es6
@@ -1,0 +1,17 @@
+import { acceptance } from "helpers/qunit-helpers";
+import PreloadStore from 'preload-store';
+
+acceptance("Account Created");
+
+test("account created", () => {
+  visit("/u/account-created");
+  PreloadStore.store('accountCreated', {
+    message: "Hello World"
+  });
+
+  andThen(() => {
+    ok(exists('.account-created'));
+    equal(find('.account-created').text(), "Hello World", "it displays the message");
+  });
+});
+

--- a/test/javascripts/acceptance/account-created-test.js.es6
+++ b/test/javascripts/acceptance/account-created-test.js.es6
@@ -3,15 +3,92 @@ import PreloadStore from 'preload-store';
 
 acceptance("Account Created");
 
-test("account created", () => {
-  visit("/u/account-created");
+test("account created - message", assert => {
   PreloadStore.store('accountCreated', {
     message: "Hello World"
   });
+  visit("/u/account-created");
 
   andThen(() => {
-    ok(exists('.account-created'));
-    equal(find('.account-created').text(), "Hello World", "it displays the message");
+    assert.ok(exists('.account-created'));
+    assert.equal(
+      find('.account-created .ac-message').text().trim(),
+      "Hello World",
+      "it displays the message"
+    );
+    assert.notOk(exists('.activation-controls'));
   });
 });
 
+test("account created - resend email", assert => {
+  PreloadStore.store('accountCreated', {
+    message: "Hello World",
+    username: 'eviltrout',
+    email: 'eviltrout@example.com'
+  });
+  visit("/u/account-created");
+
+  andThen(() => {
+    assert.ok(exists('.account-created'));
+    assert.equal(
+      find('.account-created .ac-message').text().trim(),
+      "Hello World",
+      "it displays the message"
+    );
+  });
+
+  click('.activation-controls .resend');
+  andThen(() => {
+    assert.equal(currentPath(), "account-created.resent");
+    const email = find('.account-created .ac-message b').text();
+    assert.equal(email, 'eviltrout@example.com');
+  });
+
+});
+
+test("account created - update email - cancel", assert => {
+  PreloadStore.store('accountCreated', {
+    message: "Hello World",
+    username: 'eviltrout',
+    email: 'eviltrout@example.com'
+  });
+  visit("/u/account-created");
+
+  click('.activation-controls .edit-email');
+  andThen(() => {
+    assert.equal(currentPath(), "account-created.edit-email");
+    assert.ok(find('.activation-controls .btn-primary:disabled').length);
+  });
+
+  click('.activation-controls .edit-cancel');
+  andThen(() => {
+    assert.equal(currentPath(), "account-created.index");
+  });
+});
+
+test("account created - update email - submit", assert => {
+  PreloadStore.store('accountCreated', {
+    message: "Hello World",
+    username: 'eviltrout',
+    email: 'eviltrout@example.com'
+  });
+  visit("/u/account-created");
+
+  click('.activation-controls .edit-email');
+  andThen(() => {
+    assert.ok(find('.activation-controls .btn-primary:disabled').length);
+  });
+
+  fillIn('.activate-new-email', 'newemail@example.com');
+  andThen(() => {
+    assert.notOk(find('.activation-controls .btn-primary:disabled').length);
+  });
+
+  click('.activation-controls .btn-primary');
+  andThen(() => {
+    assert.equal(currentPath(), "account-created.resent");
+    const email = find('.account-created .ac-message b').text();
+    assert.equal(email, 'newemail@example.com');
+  });
+
+});


### PR DESCRIPTION
Previously, you had to try logging in again before presented with the options. Now they are present on the confirmation screen.