### PR TITLE
Add discourseEmbedClass option and apply classname to iframe html

### DIFF
--- a/app/views/layouts/embed.html.erb
+++ b/app/views/layouts/embed.html.erb
@@ -63,6 +63,19 @@
             }
           }
 
+          // Set html class
+          var params = location.href.split('?');
+          if ( params.length > 1 ) {
+            params = params[1].split('&');
+            for ( p in params ) {
+              var param = params[p].split('=');
+              if( param[0] == 'embed_class' ){
+                document.documentElement.className = param[1];
+              }
+            }
+          }
+
+
         };
 
       })();

--- a/public/javascripts/embed.js
+++ b/public/javascripts/embed.js
@@ -4,7 +4,7 @@
   var comments = document.getElementById('discourse-comments');
   var iframe = document.createElement('iframe');
 
-  ['discourseUrl', 'discourseEmbedUrl', 'discourseUserName'].forEach(function(i) {
+  ['discourseUrl', 'discourseEmbedUrl', 'discourseUserName', 'discourseEmbedClass'].forEach(function(i) {
     if (window[i]) { DE[i] = DE[i] || window[i]; }
   });
 
@@ -24,6 +24,10 @@
 
   if (DE.topicId) {
     queryParams.topic_id = DE.topicId;
+  }
+
+  if (DE.discourseEmbedClass) {
+      queryParams.embed_class = DE.discourseEmbedClass;
   }
 
   var src = DE.discourseUrl + 'embed/comments';


### PR DESCRIPTION
This will allow the embed javascript to include a parameter
`discourseEmbedClass` that will be passed to the iframe page
where it will be parsed and applied to the iframe <html> element
as a class.

This allows targeting of CSS for different embeds.