### PR TITLE
discourse-details: Add German locale

### DIFF
--- a/plugins/discourse-details/config/locales/client.de.yml
+++ b/plugins/discourse-details/config/locales/client.de.yml
@@ -1,0 +1,7 @@
+en:
+  js:
+    details:
+      title: Details ausblenden
+    composer:
+      details_title: Zusammenfassung
+      details_text: "Dieser Text wird versteckt"

--- a/plugins/discourse-details/config/locales/client.de.yml
+++ b/plugins/discourse-details/config/locales/client.de.yml
@@ -1,4 +1,4 @@
-en:
+de:
   js:
     details:
       title: Details ausblenden

--- a/plugins/discourse-details/config/locales/server.de.yml
+++ b/plugins/discourse-details/config/locales/server.de.yml
@@ -1,0 +1,3 @@
+en:
+  site_settings:
+    details_enabled: "Aktiviert das Details-Plugin. Wenn du dies änderst, musst du alle Beiträge neu „backen“ mit: \"rake posts:rebake\"."

--- a/plugins/discourse-details/config/locales/server.en.yml
+++ b/plugins/discourse-details/config/locales/server.en.yml
@@ -1,3 +1,3 @@
-en:
+de:
   site_settings:
     details_enabled: "Enable the details plugin. If you change this, you must rebake all posts with: \"rake posts:rebake\"."


### PR DESCRIPTION
Adds the German locale for the standard plugin *discourse-details*.