### PR TITLE
latest.json: last topic from first page appears on the second page as well

### DIFF
--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -315,7 +315,7 @@ class TopicQuery
     if page == 0
       (pinned_topics + unpinned_topics)[0...limit] if limit
     else
-      offset = (page * per_page) - pinned_topics.count - 1
+      offset = (page * per_page) - pinned_topics.count
       offset = 0 unless offset > 0
       unpinned_topics.offset(offset).to_a
     end

--- a/spec/components/topic_query_spec.rb
+++ b/spec/components/topic_query_spec.rb
@@ -67,6 +67,35 @@ describe TopicQuery do
 
   end
 
+  context "prioritize_pinned_topics" do
+
+    it "does the pagination correctly" do
+
+      num_topics = 15
+      per_page = 3
+
+      topics = []
+      (num_topics - 1).downto(0).each do |i|
+         topics[i] = Fabricate(:topic)
+      end
+
+      topic_query = TopicQuery.new(user)
+      results = topic_query.send(:default_results)
+
+      expect(topic_query.prioritize_pinned_topics(results, {
+        :per_page => per_page,
+        :page => 0
+      })).to eq(topics[0...per_page])
+
+      expect(topic_query.prioritize_pinned_topics(results, {
+        :per_page => per_page,
+        :page => 1
+      })).to eq(topics[per_page...num_topics])
+
+    end
+
+  end
+
   context 'bookmarks' do
     it "filters and returns bookmarks correctly" do
       post = Fabricate(:post)


### PR DESCRIPTION
Fixes [this](https://meta.discourse.org/t/off-by-one-error-in-latest-json-page-1/58622/8).