### PR TITLE
FEATURE: admin can set a timer to remind them of a topic

### DIFF
--- a/app/assets/javascripts/discourse/controllers/edit-topic-status-update.js.es6
+++ b/app/assets/javascripts/discourse/controllers/edit-topic-status-update.js.es6
@@ -6,6 +6,7 @@ import { popupAjaxError } from 'discourse/lib/ajax-error';
 export const CLOSE_STATUS_TYPE = 'close';
 const OPEN_STATUS_TYPE = 'open';
 const PUBLISH_TO_CATEGORY_STATUS_TYPE = 'publish_to_category';
+const REMINDER_TYPE = 'reminder';
 
 export default Ember.Controller.extend(ModalFunctionality, {
   loading: false,
@@ -14,14 +15,18 @@ export default Ember.Controller.extend(ModalFunctionality, {
   selection: Ember.computed.alias('model.topic_status_update.status_type'),
   autoOpen: Ember.computed.equal('selection', OPEN_STATUS_TYPE),
   autoClose: Ember.computed.equal('selection', CLOSE_STATUS_TYPE),
+  remindMe: Ember.computed.equal('selection', REMINDER_TYPE),
   publishToCategory: Ember.computed.equal('selection', PUBLISH_TO_CATEGORY_STATUS_TYPE),
+
+  showTimeOnly: Ember.computed.or('autoOpen', 'remindMe'),
 
   @computed("model.closed")
   statusUpdates(closed) {
     return [
       { id: CLOSE_STATUS_TYPE, name: I18n.t(closed ? 'topic.temp_open.title' : 'topic.auto_close.title'), },
       { id: OPEN_STATUS_TYPE, name: I18n.t(closed ? 'topic.auto_reopen.title' : 'topic.temp_close.title') },
-      { id: PUBLISH_TO_CATEGORY_STATUS_TYPE, name: I18n.t('topic.publish_to_category.title') }
+      { id: PUBLISH_TO_CATEGORY_STATUS_TYPE, name: I18n.t('topic.publish_to_category.title') },
+      { id: REMINDER_TYPE, name: I18n.t('topic.reminder.title') }
     ];
   },
 

--- a/app/assets/javascripts/discourse/templates/modal/edit-topic-status-update.hbs
+++ b/app/assets/javascripts/discourse/templates/modal/edit-topic-status-update.hbs
@@ -5,7 +5,7 @@
     </div>
 
     <div>
-      {{#if autoOpen}}
+      {{#if showTimeOnly}}
         {{auto-update-input
             input=updateTime
             statusType=selection

--- a/app/jobs/regular/topic_reminder.rb
+++ b/app/jobs/regular/topic_reminder.rb
@@ -1,0 +1,28 @@
+module Jobs
+  class TopicReminder < Jobs::Base
+
+    def execute(args)
+      topic_status_update = TopicStatusUpdate.find_by(id: args[:topic_status_update_id])
+
+      topic = topic_status_update&.topic
+      user = topic_status_update&.user
+
+      if topic_status_update.blank? || topic.blank? || user.blank? ||
+          topic_status_update.execute_at > Time.zone.now
+        return
+      end
+
+      user.notifications.create(
+        notification_type: Notification.types[:topic_reminder],
+        topic_id: topic.id,
+        post_number: 1,
+        data: { topic_title: topic.title, display_username: user.username }.to_json
+      )
+
+      topic_status_update.trash!(Discourse.system_user)
+
+      true
+    end
+
+  end
+end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -52,7 +52,8 @@ class Notification < ActiveRecord::Base
                         custom: 14,
                         group_mentioned: 15,
                         group_message_summary: 16,
-                        watching_first_post: 17
+                        watching_first_post: 17,
+                        topic_reminder: 18
                        )
   end
 

--- a/app/serializers/topic_view_serializer.rb
+++ b/app/serializers/topic_view_serializer.rb
@@ -251,7 +251,7 @@ class TopicViewSerializer < ApplicationSerializer
 
   def topic_status_update
     TopicStatusUpdateSerializer.new(
-      object.topic.topic_status_update, root: false
+      object.topic.topic_status_update(object.guardian.user), root: false
     )
   end
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1238,6 +1238,7 @@ en:
       moved_post: "<i title='moved post' class='fa fa-sign-out'></i><p><span>{{username}}</span> moved {{description}}</p>"
       linked: "<i title='linked post' class='fa fa-link'></i><p><span>{{username}}</span> {{description}}</p>"
       granted_badge: "<i title='badge granted' class='fa fa-certificate'></i><p>Earned '{{description}}'</p>"
+      topic_reminder: "<i title='topic reminder' class='fa fa-hand-o-right'></i><p><span>{{username}}</span> {{description}}</p>"
 
       watching_first_post: "<i title='new topic' class='fa fa-dot-circle-o'></i><p><span>New Topic</span> {{description}}</p>"
 
@@ -1522,12 +1523,15 @@ en:
         label: "Auto-close topic hours:"
         error: "Please enter a valid value."
         based_on_last_post: "Don't close until the last post in the topic is at least this old."
+      reminder:
+        title: "Remind Me"
 
       status_update_notice:
         auto_open: "This topic will automatically open %{timeLeft}."
         auto_close: "This topic will automatically close %{timeLeft}."
         auto_publish_to_category: "This topic will be published to <a href=%{categoryUrl}>#%{categoryName}</a> %{timeLeft}."
         auto_close_based_on_last_post: "This topic will close %{duration} after the last reply."
+        auto_reminder: "You will be reminded about this topic %{timeLeft}."
       auto_close_title: 'Auto-Close Settings'
       auto_close_immediate:
         one: "The last post in the topic is already 1 hour old, so the topic will be closed immediately."

--- a/db/migrate/20170509202157_change_uniqueness_index_on_topic_status_updates.rb
+++ b/db/migrate/20170509202157_change_uniqueness_index_on_topic_status_updates.rb
@@ -1,0 +1,21 @@
+class ChangeUniquenessIndexOnTopicStatusUpdates < ActiveRecord::Migration
+  def up
+    execute "DROP INDEX idx_topic_id_status_type_deleted_at"
+
+    execute <<~SQL
+    CREATE UNIQUE INDEX idx_topic_id_status_type_user_id_deleted_at
+    ON topic_status_updates(topic_id, status_type, user_id)
+    WHERE deleted_at IS NULL
+    SQL
+  end
+
+  def down
+    execute "DROP INDEX idx_topic_id_status_type_user_id_deleted_at"
+
+    execute <<~SQL
+    CREATE UNIQUE INDEX idx_topic_id_status_type_deleted_at
+    ON topic_status_updates(topic_id, status_type)
+    WHERE deleted_at IS NULL
+    SQL
+  end
+end

--- a/spec/jobs/topic_reminder_spec.rb
+++ b/spec/jobs/topic_reminder_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+describe Jobs::TopicReminder do
+  let(:admin) { Fabricate(:admin) }
+  let(:topic) { Fabricate(:topic, topic_status_updates: [
+    Fabricate(:topic_status_update, user: admin, status_type: TopicStatusUpdate.types[:reminder])
+  ]) }
+
+  before do
+    SiteSetting.queue_jobs = true
+  end
+
+  it "should be able to create a reminder" do
+    topic
+    topic_status_update = topic.topic_status_update(admin)
+    Timecop.freeze(1.day.from_now) do
+      expect {
+        described_class.new.execute(topic_status_update_id: topic_status_update.id)
+      }.to change { Notification.count }.by(1)
+      expect( admin.notifications.where(notification_type: Notification.types[:topic_reminder]).first&.topic_id ).to eq(topic.id)
+      expect( TopicStatusUpdate.where(id: topic_status_update.id).first ).to be_nil
+    end
+  end
+
+  it "does nothing if it was trashed before the scheduled time" do
+    topic
+    topic_status_update = topic.topic_status_update(admin)
+    topic_status_update.trash!(Discourse.system_user)
+    Timecop.freeze(1.day.from_now) do
+      expect {
+        described_class.new.execute(topic_status_update_id: topic_status_update.id)
+      }.to_not change { Notification.count }
+    end
+  end
+
+  it "does nothing if job runs too early" do
+    topic
+    topic_status_update = topic.topic_status_update(admin)
+    topic_status_update.update_attribute(:execute_at, 8.hours.from_now)
+    Timecop.freeze(6.hours.from_now) do
+      expect {
+        described_class.new.execute(topic_status_update_id: topic_status_update.id)
+      }.to_not change { Notification.count }
+    end
+  end
+
+  it "does nothing if topic was deleted" do
+    topic
+    topic_status_update = topic.topic_status_update(admin)
+    topic.trash!
+    Timecop.freeze(1.day.from_now) do
+      expect {
+        described_class.new.execute(topic_status_update_id: topic_status_update.id)
+      }.to_not change { Notification.count }
+    end
+  end
+
+end


### PR DESCRIPTION
Inspired by "publish topic to category", I've re-used the TopicStatusUpdate code again. This adds the idea that each user can have their own topic timer. We probably need a new name for this model.