### PR TITLE
Expose limit for admin/users/list API

### DIFF
--- a/lib/admin_user_index_query.rb
+++ b/lib/admin_user_index_query.rb
@@ -24,7 +24,20 @@ class AdminUserIndexQuery
     'read_time' => 'user_stats.time_read'
   }
 
-  def find_users(limit=100)
+  # To keep backward compatibility, the default 'limit' value is 100 if neither
+  # an explicit limit argument or a param[:limit] value are available.  If an
+  # explicit argument is passed, that takes precedence over the param[:limit]
+  # value.  (We use zero as a sentinel value here, because a limit of zero
+  # never makes sense: "find the first 0 users that match"?)
+  def find_users(limit=0)
+    if limit == 0
+      limit = params[:limit].to_i
+    end
+
+    if limit <= 0
+      limit = 100
+    end
+
     find_users_query.limit(limit)
   end
 

--- a/spec/components/admin_user_index_query_spec.rb
+++ b/spec/components/admin_user_index_query_spec.rb
@@ -26,7 +26,7 @@ describe AdminUserIndexQuery do
       query = ::AdminUserIndexQuery.new({ order: "trust_level" })
       expect(query.find_users_query.to_sql).to match("trust_level DESC")
     end
-    
+
     it "allows custom ordering asc" do
       query = ::AdminUserIndexQuery.new({ order: "trust_level", ascending: true })
       expect(query.find_users_query.to_sql).to match("trust_level ASC" )
@@ -40,6 +40,30 @@ describe AdminUserIndexQuery do
     it "allows custom ordering and direction for stats" do
       query = ::AdminUserIndexQuery.new({ order: "topics_viewed", ascending: true })
       expect(query.find_users_query.to_sql).to match("topics_entered ASC")
+    end
+
+  end
+
+  describe "limit" do
+    it "allows custom limit via argument" do
+      query = ::AdminUserIndexQuery.new({})
+      expect(query.find_users(99).to_sql).to match("LIMIT 99")
+    end
+
+    it "allows custom limit via params" do
+      query = ::AdminUserIndexQuery.new({ limit: 99 })
+      expect(query.find_users().to_sql).to match("LIMIT 99")
+    end
+
+    it "prefers limit arg to param" do
+      query = ::AdminUserIndexQuery.new({ limit: 99 })
+      expect(query.find_users(50).to_sql).to match("LIMIT 50")
+    end
+
+    it "limit param can't be injected" do
+      query = ::AdminUserIndexQuery.new({ limit: "wat, no" })
+      expect(query.find_users_query.to_sql).not_to match("wat, no")
+      expect(query.find_users_query.to_sql).to match("LIMIT 100")
     end
   end
 


### PR DESCRIPTION
Expose querystring access to the "limit" parameter so that we're not restricted to only the first 100 users.  (See also the discussion at https://meta.discourse.org/t/using-the-api-for-user-management-the-100-user-limit/37562.)

Added tests to ensure that the parameter can't be used in a SQL injection attack, and that if anything is amiss it falls back to the previously-existing behavior.

_Do note that this PR is offered in advance of full agreement from folks that this is even a reasonable thing to do... but it gives a starting point for the discussion._