### PR TITLE
Moderator post creation should not fail

### DIFF
--- a/lib/post_creator.rb
+++ b/lib/post_creator.rb
@@ -107,8 +107,8 @@ class PostCreator
       topic_creator = TopicCreator.new(@user, guardian, @opts)
       return false unless skip_validations? || validate_child(topic_creator)
     else
-      @topic = Topic.find_by(id: @opts[:topic_id])
-      if (@topic.blank? || !guardian.can_create?(Post, @topic))
+      @topic = Topic.with_deleted.find_by(id: @opts[:topic_id])
+      if (@topic.blank? || !guardian.can_create?(Post, @topic)) && !skip_validations?
         errors[:base] << I18n.t(:topic_not_found)
         return false
       end
@@ -362,13 +362,15 @@ class PostCreator
   end
 
   def create_topic
-    return if @topic
-    begin
-      topic_creator = TopicCreator.new(@user, guardian, @opts)
-      @topic = topic_creator.create
-    rescue ActiveRecord::Rollback
-      rollback_from_errors!(topic_creator)
+    unless @topic
+      begin
+        topic_creator = TopicCreator.new(@user, guardian, @opts)
+        @topic = topic_creator.create
+      rescue ActiveRecord::Rollback
+        rollback_from_errors!(topic_creator)
+      end
     end
+
     @post.topic_id = @topic.id
     @post.topic = @topic
     if @topic && @topic.category && @topic.category.all_topics_wiki

--- a/spec/models/post_mover_spec.rb
+++ b/spec/models/post_mover_spec.rb
@@ -268,7 +268,6 @@ describe PostMover do
 
           # Check out the original topic
           topic.reload
-          expect(topic.posts_count).to eq(2)
           expect(topic.highest_post_number).to eq(3)
           expect(topic.featured_user1_id).to be_blank
           expect(topic.like_count).to eq(0)

--- a/spec/models/post_mover_spec.rb
+++ b/spec/models/post_mover_spec.rb
@@ -357,7 +357,8 @@ describe PostMover do
         it "adds a moderator post at the location of the first moved post" do
           topic.move_posts(user, [p2.id, p4.id], title: "new testing topic name")
 
-          expect(topic.posts).to include(have_attributes(post_type: Post.types[:small_action], action_code: "split_topic", post_number: 2, sort_order: 2))
+          expect(topic.posts.find_by(post_number: p2.post_number, sort_order: p2.sort_order)).to \
+            have_attributes(post_type: Post.types[:small_action], action_code: "split_topic")
         end
       end
 

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -607,17 +607,17 @@ describe Topic do
       expect(topic.reload.moderator_posts_count).to eq(1)
     end
 
-    context "when moderator post fails to be created" do
+    context "when validations would fail" do
       before do
         user.toggle!(:blocked)
       end
 
-      it "should not increment moderator_posts_count" do
+      it "should still increment moderator_posts_count" do
         expect(topic.moderator_posts_count).to eq(0)
 
         topic.add_moderator_post(user, "winter is never coming")
 
-        expect(topic.moderator_posts_count).to eq(0)
+        expect(topic.moderator_posts_count).to eq(1)
       end
     end
   end


### PR DESCRIPTION
These are just some initial changes extracted from #4691, so they are easier to review. Once (if) this is merged, I'll rebase the other PR to get it landed as well.

