### PR TITLE
Fix the padding on the login and register buttons.

### DIFF
--- a/app/assets/stylesheets/common/base/login.scss
+++ b/app/assets/stylesheets/common/base/login.scss
@@ -103,7 +103,5 @@ $input-width: 220px;
 button#login-link, button#new-account-link
 {
   background: transparent;
-  padding-left: 0;
-  margin-left: 20px;
   color: dark-light-choose(scale-color($primary, $lightness: 35%), scale-color($secondary, $lightness: 65%));
 }


### PR DESCRIPTION
Currently the register and login buttons have their left padding set to 0. In combination with the background of the buttons being set to non-transparent on hover this results in a very odd looking button.

Before this patch:

![image](https://cloud.githubusercontent.com/assets/5584439/25990596/32f121b6-36f8-11e7-8d86-26fedaf7a953.png)

After this patch:

![image](https://cloud.githubusercontent.com/assets/5584439/25990751/c7eb6efc-36f8-11e7-90c9-778136d808ad.png)

