### PR TITLE
FEATURE: remove table wrapping posts in notification emails

### DIFF
--- a/app/views/email/_post.html.erb
+++ b/app/views/email/_post.html.erb
@@ -1,31 +1,23 @@
-<table class='post-wrapper <%= post.whisper? ? "whisper" : "" %> <%= use_excerpt ? "excerpt" : ""%>'>
-  <tbody>
+<div class='post-wrapper <%= post.whisper? ? "whisper" : "" %> <%= use_excerpt ? "excerpt" : ""%>'>
+  <table>
     <tr>
+      <td class='user-avatar'>
+        <img src="<%= post.user.small_avatar_url %>" title="<%= post.user.username%>">
+      </td>
       <td>
-        <table>
-          <tr>
-            <td class='user-avatar'>
-              <img src="<%= post.user.small_avatar_url %>" title="<%= post.user.username%>">
-            </td>
-            <td>
-              <%- if show_username_on_post(post) %>
-              <a class="username" href="<%=Discourse.base_url%>/u/<%= post.user.username_lower%>" target="_blank"><%= post.user.username %></a>
-              <% end %>
-              <%- if show_name_on_post(post) %>
-                <a class="user-name" href="<%=Discourse.base_url%>/u/<%= post.user.username_lower%>" target="_blank"><%= post.user.name %></a>
-              <% end %>
-              <%- if post.user.title.present? %>
-                <span class='user-title'><%= post.user.title %></span>
-              <% end %>
-              <br>
-              <span class='notification-date'><%= l post.created_at, format: :short_no_year %></span>
-            </td>
-          </tr>
-        </table>
+        <%- if show_username_on_post(post) %>
+        <a class="username" href="<%=Discourse.base_url%>/u/<%= post.user.username_lower%>" target="_blank"><%= post.user.username %></a>
+        <% end %>
+        <%- if show_name_on_post(post) %>
+          <a class="user-name" href="<%=Discourse.base_url%>/u/<%= post.user.username_lower%>" target="_blank"><%= post.user.name %></a>
+        <% end %>
+        <%- if post.user.title.present? %>
+          <span class='user-title'><%= post.user.title %></span>
+        <% end %>
+        <br>
+        <span class='notification-date'><%= l post.created_at, format: :short_no_year %></span>
       </td>
     </tr>
-    <tr>
-      <td class='body'><%= format_for_email(post, use_excerpt) %></td>
-    </tr>
-  </tbody>
-</table>
+  </table>
+  <div class='body'><%= format_for_email(post, use_excerpt) %></div>
+</div>

--- a/lib/email/styles.rb
+++ b/lib/email/styles.rb
@@ -92,8 +92,8 @@ module Email
       style('.user-avatar img', nil, width: '45', height: '45')
       style('hr', 'background-color: #ddd; height: 1px; border: 1px;')
       style('.rtl', 'direction: rtl;')
-      style('td.body', 'padding-top:5px;', colspan: "2")
-      style('.whisper td.body', 'font-style: italic; color: #9c9c9c;')
+      style('div.body', 'padding-top:5px;')
+      style('.whisper div.body', 'font-style: italic; color: #9c9c9c;')
       style('.lightbox-wrapper .meta', 'display: none')
       correct_first_body_margin
       correct_footer_style


### PR DESCRIPTION
Per: https://meta.discourse.org/t/simplified-html-emails/62600/12?u=leomca

This removes the table wrapping the post in notification emails, but keeps the table wrapping the user details.

I tested on litmus.com against the [10 most popular email clients](https://emailclientmarketshare.com/), with an email generated by this code, and with an email generated by the current code, to compare.

There were a couple of small regressions, I'll take advice on whether it's worth hunting down the reasons and fixing them:

In Outlook on Windows in versions from 2007 to 2016, and in Windows 10 Mail, there was a loss of padding under the user details header:

*With table:*

![ol2007-vertical-allowed-1366](https://cloud.githubusercontent.com/assets/755354/26078807/9617395c-39b8-11e7-92d3-2d4fdff05af6.png)

*Without table:*

![ol2007-vertical-allowed-1366](https://cloud.githubusercontent.com/assets/755354/26078830/a30785d6-39b8-11e7-8be0-a007de434b69.png)

And on all devices running iOS 10.2, a blue border appeared next to the avatar in the user details header:

*With table:*

![ipadpro13in-vertical-allowed-1366](https://cloud.githubusercontent.com/assets/755354/26078948/08f140da-39b9-11e7-93f7-f49e72b55ffe.png)

*Without table:*

![ipadpro13in-vertical-allowed-1366](https://cloud.githubusercontent.com/assets/755354/26078955/1341190c-39b9-11e7-8868-a25eb1a215a9.png)
