### PR TITLE
FEATURE: Require spec helpers for plugins

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -31,9 +31,8 @@ Spork.prefork do
 
   # Require plugin helpers at plugin/[plugin]/spec/plugin_helper.rb (includes symlinked plugins).
   if ENV['LOAD_PLUGINS'] == "1"
-    Dir[Rails.root.join("plugins/**")].each do |plugin|
-      helper = "#{plugin}/spec/plugin_helper.rb"
-      require helper if File.exists?(helper)
+    Dir[Rails.root.join("plugins/*/spec/plugin_helper.rb")].each do |f|
+      require f
     end
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -29,6 +29,14 @@ Spork.prefork do
   Dir[Rails.root.join("spec/support/**/*.rb")].each {|f| require f}
   Dir[Rails.root.join("spec/fabricators/*.rb")].each {|f| require f}
 
+  # Require plugin helpers at plugin/[plugin]/spec/plugin_helper.rb (includes symlinked plugins).
+  if ENV['LOAD_PLUGINS'] == "1"
+    Dir[Rails.root.join("plugins/**")].each do |plugin|
+      helper = "#{plugin}/spec/plugin_helper.rb"
+      require helper if File.exists?(helper)
+    end
+  end
+
   # let's not run seed_fu every test
   SeedFu.quiet = true if SeedFu.respond_to? :quiet
 


### PR DESCRIPTION
This will allow plugin developers to load fixtures and helpers in specs.  

  * Follows any symlinked plugins