### PR TITLE
Update discourse_tagging.rb

### DIFF
--- a/lib/discourse_tagging.rb
+++ b/lib/discourse_tagging.rb
@@ -65,7 +65,7 @@ module DiscourseTagging
     term = opts[:term]
     if term.present?
       term.downcase!
-      term.gsub!(/[^a-z0-9\.\-\_]*/, '')
+      term.gsub!(/[^a-z0-9а-я\.\-\_]*/, '')
       term.gsub!("_", "\\_")
       query = query.where('tags.name like ?', "%#{term}%")
     end


### PR DESCRIPTION
Tag search in tags dropdown box does not work for non-English characters