### PR TITLE
Advances search logical and by multiple tags 

### DIFF
--- a/app/assets/javascripts/discourse/components/search-advanced-options.js.es6
+++ b/app/assets/javascripts/discourse/components/search-advanced-options.js.es6
@@ -77,7 +77,8 @@ export default Em.Component.extend({
             likes: false,
             private: false,
             seen: false
-          }
+          },
+          all_tags: false
         },
         status: '',
         min_post_count: '',
@@ -230,13 +231,15 @@ export default Em.Component.extend({
 
     const match = this.filterBlocks(REGEXP_TAGS_PREFIX);
     const tags = this.get('searchedTerms.tags');
+    const contain_all_tags = this.get('searchedTerms.special.all_tags');
 
     if (match.length !== 0) {
-      const existingInput = _.isArray(tags) ? tags.join(',') : tags;
+      const join_char = contain_all_tags ? ',' : '|';
+      const existingInput = _.isArray(tags) ? tags.join(join_char) : tags;
       const userInput = match[0].replace(REGEXP_TAGS_REPLACE, '');
 
       if (existingInput !== userInput) {
-        this.set('searchedTerms.tags', (userInput.length !== 0) ? userInput.split(',') : []);
+        this.set('searchedTerms.tags', (userInput.length !== 0) ? userInput.split(join_char) : []);
       }
     } else if (tags.length !== 0) {
       this.set('searchedTerms.tags', []);
@@ -365,14 +368,16 @@ export default Em.Component.extend({
     }
   },
 
-  @observes('searchedTerms.tags')
+  @observes('searchedTerms.tags', 'searchedTerms.special.all_tags')
   updateSearchTermForTags() {
     const match = this.filterBlocks(REGEXP_TAGS_PREFIX);
     const tagFilter = this.get('searchedTerms.tags');
     let searchTerm = this.get('searchTerm') || '';
+    const contain_all_tags = this.get('searchedTerms.special.all_tags');
 
     if (tagFilter && tagFilter.length !== 0) {
-      const tags = tagFilter.join(',');
+      const join_char = contain_all_tags ? ',' : '|';
+      const tags = tagFilter.join(join_char);
 
       if (match.length !== 0) {
         searchTerm = searchTerm.replace(match[0], `tags:${tags}`);

--- a/app/assets/javascripts/discourse/components/search-advanced-options.js.es6
+++ b/app/assets/javascripts/discourse/components/search-advanced-options.js.es6
@@ -234,7 +234,7 @@ export default Em.Component.extend({
     const contain_all_tags = this.get('searchedTerms.special.all_tags');
 
     if (match.length !== 0) {
-      const join_char = contain_all_tags ? ',' : '|';
+      const join_char = contain_all_tags ? '+' : ',';
       const existingInput = _.isArray(tags) ? tags.join(join_char) : tags;
       const userInput = match[0].replace(REGEXP_TAGS_REPLACE, '');
 
@@ -376,7 +376,7 @@ export default Em.Component.extend({
     const contain_all_tags = this.get('searchedTerms.special.all_tags');
 
     if (tagFilter && tagFilter.length !== 0) {
-      const join_char = contain_all_tags ? ',' : '|';
+      const join_char = contain_all_tags ? '+' : ',';
       const tags = tagFilter.join(join_char);
 
       if (match.length !== 0) {

--- a/app/assets/javascripts/discourse/templates/components/search-advanced-options.hbs
+++ b/app/assets/javascripts/discourse/templates/components/search-advanced-options.hbs
@@ -41,12 +41,15 @@
       <label class="control-label" for="search-with-tags">{{i18n "search.advanced.with_tags.label"}}</label>
       <div class="controls">
         {{tag-chooser tags=searchedTerms.tags blacklist=searchedTerms.tags allowCreate=false placeholder="" everyTag="true" unlimitedTagCount="true" width="70%"}}
+      <section class="field">
+          <label>{{ input type="checkbox" class="all-tags" checked=searchedTerms.special.all_tags}} {{i18n "search.advanced.filters.all_tags"}} </label>
+      </section>
       </div>
     </div>
   </div>
 {{/if}}
 
-<div class="container">
+<div class="container">contain_all_tags
   <div class="control-group pull-left">
     <label class="control-label" for="search-in-options">{{i18n "search.advanced.filters.label"}}</label>
     <div class="controls">

--- a/app/assets/javascripts/discourse/templates/components/search-advanced-options.hbs
+++ b/app/assets/javascripts/discourse/templates/components/search-advanced-options.hbs
@@ -49,7 +49,7 @@
   </div>
 {{/if}}
 
-<div class="container">contain_all_tags
+<div class="container">
   <div class="control-group pull-left">
     <label class="control-label" for="search-in-options">{{i18n "search.advanced.filters.label"}}</label>
     <div class="controls">

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1340,6 +1340,7 @@ en:
           seen: I've read
           unseen: I've not read
           wiki: are wiki
+          all_tags: Contains all tags
         statuses:
           label: Where topics
           open: are open

--- a/lib/search.rb
+++ b/lib/search.rb
@@ -445,20 +445,19 @@ class Search
     end
   end
 
-  advanced_filter(/tags?:([a-zA-Z0-9,\-_|]+)/) do |posts, match|
-    if match.include?(',')
-      tags = match.split(",")
+  advanced_filter(/tags?:([a-zA-Z0-9,\-_+]+)/) do |posts, match|
+    if match.include?('+')
+      tags = match.split('+')
 
-      # TODO use ts_query function
       posts.where("topics.id IN (
-      SELECT DISTINCT(tt.topic_id)
+      SELECT tt.topic_id
       FROM topic_tags tt, tags
       WHERE tt.tag_id = tags.id
       GROUP BY tt.topic_id
-      HAVING to_tsvector('simple',array_to_string(array_agg(tags.name), ' ')) @@ to_tsquery('simple', ?)
+      HAVING to_tsvector(#{query_locale}, array_to_string(array_agg(tags.name), ' ')) @@ to_tsquery(#{query_locale}, ?)
       )", tags.join('&'))
     else
-      tags = match.split("|")
+      tags = match.split(",")
 
       posts.where("topics.id IN (
       SELECT DISTINCT(tt.topic_id)

--- a/lib/search.rb
+++ b/lib/search.rb
@@ -445,15 +445,28 @@ class Search
     end
   end
 
-  advanced_filter(/tags?:([a-zA-Z0-9,\-_]+)/) do |posts, match|
-    tags = match.split(",")
+  advanced_filter(/tags?:([a-zA-Z0-9,\-_|]+)/) do |posts, match|
+    if match.include?(',')
+      tags = match.split(",")
 
-    posts.where("topics.id IN (
+      # TODO use ts_query function
+      posts.where("topics.id IN (
+      SELECT DISTINCT(tt.topic_id)
+      FROM topic_tags tt, tags
+      WHERE tt.tag_id = tags.id
+      GROUP BY tt.topic_id
+      HAVING to_tsvector('simple',array_to_string(array_agg(tags.name), ' ')) @@ to_tsquery('simple', ?)
+      )", tags.join('&'))
+    else
+      tags = match.split("|")
+
+      posts.where("topics.id IN (
       SELECT DISTINCT(tt.topic_id)
       FROM topic_tags tt, tags
       WHERE tt.tag_id = tags.id
       AND tags.name in (?)
       )", tags)
+    end
   end
 
   private

--- a/spec/components/search_spec.rb
+++ b/spec/components/search_spec.rb
@@ -703,6 +703,28 @@ describe Search do
       expect(Search.execute('green tags:eggs').posts.map(&:id)).to eq([post2.id])
       expect(Search.execute('green tags:plants').posts.size).to eq(0)
     end
+
+    context 'tags' do
+      let(:tag1) { Fabricate(:tag, name: 'lunch') }
+      let(:tag2) { Fabricate(:tag, name: 'eggs') }
+      let(:topic1) { Fabricate(:topic, tags: [tag2, Fabricate(:tag)]) }
+      let(:topic2) { Fabricate(:topic, tags: [tag1]) }
+      let(:topic3) { Fabricate(:topic, tags: [tag1, tag2]) }
+      let!(:post1) { Fabricate(:post, topic: topic1)}
+      let!(:post2) { Fabricate(:post, topic: topic2)}
+      let!(:post3) { Fabricate(:post, topic: topic3)}
+
+      it 'can find posts with any tag from multiple tags' do
+        Fabricate(:post)
+
+        expect(Search.execute('tags:eggs|lunch').posts.map(&:id).sort).to eq([post1.id, post2.id, post3.id].sort)
+      end
+
+      it 'can find posts which contains all provided tags' do
+        expect(Search.execute('tags:lunch,eggs').posts.map(&:id)).to eq([post3.id])
+      end
+    end
+
   end
 
   it 'can parse complex strings using ts_query helper' do

--- a/spec/components/search_spec.rb
+++ b/spec/components/search_spec.rb
@@ -694,34 +694,32 @@ describe Search do
       expect(Search.execute('this is a test #beta').posts.size).to eq(0)
     end
 
-    it "can find with tag" do
-      topic1 = Fabricate(:topic, title: 'Could not, would not, on a boat')
-      topic1.tags = [Fabricate(:tag, name: 'eggs'), Fabricate(:tag, name: 'ham')]
-      Fabricate(:post, topic: topic1)
-      post2 = Fabricate(:post, topic: topic1, raw: "It probably doesn't help that they're green...")
-
-      expect(Search.execute('green tags:eggs').posts.map(&:id)).to eq([post2.id])
-      expect(Search.execute('green tags:plants').posts.size).to eq(0)
-    end
-
     context 'tags' do
       let(:tag1) { Fabricate(:tag, name: 'lunch') }
       let(:tag2) { Fabricate(:tag, name: 'eggs') }
       let(:topic1) { Fabricate(:topic, tags: [tag2, Fabricate(:tag)]) }
-      let(:topic2) { Fabricate(:topic, tags: [tag1]) }
+      let(:topic2) { Fabricate(:topic, tags: [tag2]) }
       let(:topic3) { Fabricate(:topic, tags: [tag1, tag2]) }
       let!(:post1) { Fabricate(:post, topic: topic1)}
       let!(:post2) { Fabricate(:post, topic: topic2)}
       let!(:post3) { Fabricate(:post, topic: topic3)}
 
+      it 'can find posts with tag' do
+        post4 = Fabricate(:post, topic: topic3, raw: "It probably doesn't help that they're green...")
+
+        expect(Search.execute('green tags:eggs').posts.map(&:id)).to eq([post4.id])
+        expect(Search.execute('tags:plants').posts.size).to eq(0)
+      end
+
       it 'can find posts with any tag from multiple tags' do
         Fabricate(:post)
 
-        expect(Search.execute('tags:eggs|lunch').posts.map(&:id).sort).to eq([post1.id, post2.id, post3.id].sort)
+        expect(Search.execute('tags:eggs,lunch').posts.map(&:id).sort).to eq([post1.id, post2.id, post3.id].sort)
       end
 
       it 'can find posts which contains all provided tags' do
-        expect(Search.execute('tags:lunch,eggs').posts.map(&:id)).to eq([post3.id])
+        expect(Search.execute('tags:lunch+eggs').posts.map(&:id)).to eq([post3.id])
+        expect(Search.execute('tags:eggs+lunch').posts.map(&:id)).to eq([post3.id])
       end
     end
 


### PR DESCRIPTION
**User story:** As a user, I want to search posts which contains all of the tags I entered in order to find posts in more detailed way.

Related discussions: 
https://meta.discourse.org/t/does-multiple-tag-search-support-and-vs-or/56041
https://meta.discourse.org/t/multiple-tags-search-query-takes-too-long-big-forum/56023/8

New checkbox _Contains all tags_ is added to advanced search. If checkbox is checked, separator between tags is '+' (represents logical AND) instead of ',' (represents logical OR, already in use). Backend for search is done in Postgre built-in full text and it has same performance (query plan is below doing only one sequential database scan on tags and topic_tags tables) for any number of tags. 

I added two new rspec tests into tags context and moved old test for logical or search into the same context.

![query-plan](https://cloud.githubusercontent.com/assets/5477556/26722745/a25a227e-4791-11e7-8bb2-93d0ac0a5536.png)

