### PR TITLE
Clarify category tag settings text

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2008,8 +2008,8 @@ en:
       settings: 'Settings'
       topic_template: "Topic Template"
       tags: "Tags"
-      tags_allowed_tags: "Tags that can only be used in this category:"
-      tags_allowed_tag_groups: "Tag groups that can only be used in this category:"
+      tags_allowed_tags: "Only allow these tags to be used in this category:"
+      tags_allowed_tag_groups: "Only allow tags from these groups to be used in this category:"
       tags_placeholder: "(Optional) list of allowed tags"
       tag_groups_placeholder: "(Optional) list of allowed tag groups"
       topic_featured_link_allowed: "Allow featured links in this category"


### PR DESCRIPTION
https://meta.discourse.org/t/change-to-category-tag-settings-text/63926

This change eliminates the ambiguity in the previous copy, which suggested that the setting prevented the tags from being used in other categories, rather than the actual behaviour of constraining what can be used in the edited category.