### PR TITLE
FIX: allow tar to finish if files change during backup

### DIFF
--- a/lib/backup_restore/backuper.rb
+++ b/lib/backup_restore/backuper.rb
@@ -230,7 +230,7 @@ module BackupRestore
       FileUtils.cd(File.join(Rails.root, "public")) do
         if File.directory?(upload_directory)
           Discourse::Utils.execute_command(
-            'tar', '--append', '--dereference', '--file', tar_filename, upload_directory,
+            'tar', '--append', '--dereference', '--warning=no-file-changed', '--file', tar_filename, upload_directory,
             failure_message: "Failed to archive uploads."
           )
         else


### PR DESCRIPTION
This makes tar not fail if a file is changed during backup.

I tested by making a backup and restoring (albeit to the same instance).