### PR TITLE
FEATURE: Option to link embed button to the top of the page

### DIFF
--- a/app/controllers/embed_controller.rb
+++ b/app/controllers/embed_controller.rb
@@ -46,10 +46,10 @@ class EmbedController < ApplicationController
         @reply_count = @topic_view.topic.posts_count - 1
         @reply_count = 0 if @reply_count < 0
 
-        if SiteSetting.embed_post_limit > 0 && !SiteSetting.embed_link_to_top
-          @topic_view_continue_url = @topic_view.posts.last.full_url
-        else
+        if SiteSetting.embed_link_to_top || SiteSetting.embed_post_limit == 0
           @topic_view_continue_url = @topic_view.absolute_url
+        else
+          @topic_view_continue_url = @topic_view.posts.last.full_url
         end
       end
 

--- a/app/controllers/embed_controller.rb
+++ b/app/controllers/embed_controller.rb
@@ -32,7 +32,7 @@ class EmbedController < ApplicationController
       @topic_view = TopicView.new(topic_id,
                                   current_user,
                                   limit: SiteSetting.embed_post_limit,
-                                  exclude_first: (SiteSetting.embed_post_limit > 0),
+                                  exclude_first: !SiteSetting.embed_link_to_top,
                                   exclude_deleted_users: true,
                                   exclude_hidden: true)
 
@@ -45,6 +45,12 @@ class EmbedController < ApplicationController
       if @topic_view
         @reply_count = @topic_view.topic.posts_count - 1
         @reply_count = 0 if @reply_count < 0
+
+        if SiteSetting.embed_link_to_top
+          @topic_view_continue_url = @topic_view.absolute_url
+        else
+          @topic_view_continue_url = @topic_view.posts.last.full_url
+        end
       end
 
     elsif embed_url.present?

--- a/app/controllers/embed_controller.rb
+++ b/app/controllers/embed_controller.rb
@@ -32,7 +32,7 @@ class EmbedController < ApplicationController
       @topic_view = TopicView.new(topic_id,
                                   current_user,
                                   limit: SiteSetting.embed_post_limit,
-                                  exclude_first: true,
+                                  exclude_first: (SiteSetting.embed_post_limit > 0),
                                   exclude_deleted_users: true,
                                   exclude_hidden: true)
 

--- a/app/controllers/embed_controller.rb
+++ b/app/controllers/embed_controller.rb
@@ -46,10 +46,10 @@ class EmbedController < ApplicationController
         @reply_count = @topic_view.topic.posts_count - 1
         @reply_count = 0 if @reply_count < 0
 
-        if SiteSetting.embed_link_to_top
-          @topic_view_continue_url = @topic_view.absolute_url
-        else
+        if SiteSetting.embed_post_limit > 0 && !SiteSetting.embed_link_to_top
           @topic_view_continue_url = @topic_view.posts.last.full_url
+        else
+          @topic_view_continue_url = @topic_view.absolute_url
         end
       end
 

--- a/app/views/embed/comments.html.erb
+++ b/app/views/embed/comments.html.erb
@@ -41,7 +41,7 @@
   <% if @topic_view.topic.posts_count > 0 %>
     <footer class="clearfix">
       <%= link_to(image_tag(SiteSetting.logo_url, class: 'logo'), Discourse.base_url, target: '_blank') %>
-      <%= link_to(I18n.t('embed.continue'), @topic_view.posts.last.full_url, class: 'button', target: '_blank') %>
+      <%= link_to(I18n.t('embed.continue'), @topic_view_continue_url, class: 'button', target: '_blank') %>
       <%- if @posts_left > 0 %>
         <span class='replies'><%= I18n.t('embed.more_replies', count: @posts_left) %></span>
       <%- end %>

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3492,7 +3492,7 @@ en:
 
         embed_by_username: "Username for topic creation"
         embed_post_limit: "Maximum number of posts to embed"
-        embed_link_to_top: "Link to the top of the page"
+        embed_link_to_top: "When embedding, the continue button links to the top of the topic instead of the bottom"
         embed_username_key_from_feed: "Key to pull discourse username from feed"
         embed_title_scrubber: "Regular expression used to scrub the title of posts"
         embed_truncate: "Truncate the embedded posts"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3492,6 +3492,7 @@ en:
 
         embed_by_username: "Username for topic creation"
         embed_post_limit: "Maximum number of posts to embed"
+        embed_link_to_top: "Link to the top of the page"
         embed_username_key_from_feed: "Key to pull discourse username from feed"
         embed_title_scrubber: "Regular expression used to scrub the title of posts"
         embed_truncate: "Truncate the embedded posts"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1071,7 +1071,7 @@ embedding:
     hidden: true
   embed_link_to_top:
     default: false
-    hidden: true
+    hidden: false
   embed_title_scrubber:
     default: ''
     hidden: true

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1069,6 +1069,9 @@ embedding:
   embed_post_limit:
     default: 100
     hidden: true
+  embed_link_to_top:
+    default: false
+    hidden: true
   embed_title_scrubber:
     default: ''
     hidden: true

--- a/spec/controllers/embed_controller_spec.rb
+++ b/spec/controllers/embed_controller_spec.rb
@@ -20,11 +20,20 @@ describe EmbedController do
 
     before do
       Fabricate(:embeddable_host)
-      SiteSetting.embed_link_to_top = true
       controller.request.stubs(:referer).returns('http://eviltrout.com/some-page')
     end
 
+    it "is successful if limit the setting is zero" do
+      SiteSetting.embed_link_to_top = false
+      topic = Fabricate(:topic)
+      SiteSetting.embed_post_limit = 0
+
+      get :comments, topic_id: topic.id
+      expect(response).to be_success
+    end
+
     it "allows a topic to be embedded by id" do
+      SiteSetting.embed_link_to_top = true
       topic = Fabricate(:topic)
       topic.posts << Fabricate(:post)
 

--- a/spec/controllers/embed_controller_spec.rb
+++ b/spec/controllers/embed_controller_spec.rb
@@ -20,14 +20,13 @@ describe EmbedController do
 
     before do
       Fabricate(:embeddable_host)
-      SiteSetting.stubs(:embed_link_to_top).returns(true)
+      SiteSetting.embed_link_to_top = true
       controller.request.stubs(:referer).returns('http://eviltrout.com/some-page')
     end
 
     it "allows a topic to be embedded by id" do
-      topic = Fabricate(:topic) do
-        posts { [Fabricate(:post)] }
-      end
+      topic = Fabricate(:topic)
+      topic.posts << Fabricate(:post)
 
       get :comments, topic_id: topic.id
       expect(response).to be_success

--- a/spec/controllers/embed_controller_spec.rb
+++ b/spec/controllers/embed_controller_spec.rb
@@ -20,11 +20,15 @@ describe EmbedController do
 
     before do
       Fabricate(:embeddable_host)
+      SiteSetting.stubs(:embed_link_to_top).returns(true)
       controller.request.stubs(:referer).returns('http://eviltrout.com/some-page')
     end
 
     it "allows a topic to be embedded by id" do
-      topic = Fabricate(:topic)
+      topic = Fabricate(:topic) do
+        posts { [Fabricate(:post)] }
+      end
+
       get :comments, topic_id: topic.id
       expect(response).to be_success
     end


### PR DESCRIPTION
This allows an embedded post to link back to the topic (the top of the page) instead of the last comment. In my case: this is useful for branding and stuff. 

I'm not sure if I need to create empty translations for the settings.

My branch name is not really relevant.

Fixed: The post limit can be zero. 

