### PR TITLE
FIX: Use username in bot's certificate.

### DIFF
--- a/plugins/discourse-narrative-bot/lib/discourse_narrative_bot/certificate_generator.rb
+++ b/plugins/discourse-narrative-bot/lib/discourse_narrative_bot/certificate_generator.rb
@@ -552,7 +552,7 @@ module DiscourseNarrativeBot
     private
 
       def name
-        (@user.name && !@user.name.blank? ? @user.name : @user.username).titleize
+        @user.username.titleize
       end
 
       def logo_group(size, width, height)


### PR DESCRIPTION
* The default name generated can be weird sometimes.

@coding-horror Does this look OK to you?