### PR TITLE
FIX: version check

### DIFF
--- a/lib/discourse_hub.rb
+++ b/lib/discourse_hub.rb
@@ -42,8 +42,9 @@ module DiscourseHub
   def self.singular_action(action, rel_url, params={})
     JSON.parse(Excon.send(action,
       "#{hub_base_url}#{rel_url}",
-      body: params.to_query,
-      headers: { 'Referer' => referer, 'Accept' => accepts.join(', ') }
+      headers: { 'Referer' => referer, 'Accept' => accepts.join(', ') },
+      :query => params,
+      :omit_default_port => true
     ).body)
   end
 

--- a/spec/components/discourse_hub_spec.rb
+++ b/spec/components/discourse_hub_spec.rb
@@ -7,6 +7,7 @@ describe DiscourseHub do
       hub_response = {'success' => 'OK', 'latest_version' => '0.8.1', 'critical_updates' => false}
 
       stub_request(:get, (ENV['HUB_BASE_URL'] || "http://local.hub:3000/api") + "/version_check").
+        with(query: DiscourseHub.version_check_payload).
         to_return(status: 200, body: hub_response.to_json)
 
       expect(DiscourseHub.discourse_version_check).to eq(hub_response)


### PR DESCRIPTION
The api.discourse.org server apparently does not like GET
requests that have a port number in the headers Host entry.

Additionally fix the actual GET query; it should use query parameters not a body.