### PR TITLE
FEATURE: offer help on forgot password modal

### DIFF
--- a/app/assets/javascripts/discourse/controllers/forgot-password.js.es6
+++ b/app/assets/javascripts/discourse/controllers/forgot-password.js.es6
@@ -5,6 +5,7 @@ import { extractError } from 'discourse/lib/ajax-error';
 import computed from 'ember-addons/ember-computed-decorators';
 
 export default Ember.Controller.extend(ModalFunctionality, {
+  offerHelp: null,
 
   @computed('accountEmailOrUsername', 'disabled')
   submitDisabled(accountEmailOrUsername, disabled) {
@@ -35,8 +36,7 @@ export default Ember.Controller.extend(ModalFunctionality, {
         if (data.user_found === true) {
           key += '_found';
           this.set('accountEmailOrUsername', '');
-          bootbox.alert(I18n.t(key, {email: escaped, username: escaped}));
-          this.send("closeModal");
+          this.set('offerHelp', I18n.t(key, {email: escaped, username: escaped}));
         } else {
           if (data.user_found === false) {
             key += '_not_found';
@@ -52,6 +52,14 @@ export default Ember.Controller.extend(ModalFunctionality, {
       });
 
       return false;
+    },
+
+    ok() {
+      this.send('closeModal');
+    },
+
+    help() {
+      this.set('offerHelp', I18n.t('forgot_password.help'));
     }
   }
 

--- a/app/assets/javascripts/discourse/routes/application.js.es6
+++ b/app/assets/javascripts/discourse/routes/application.js.es6
@@ -94,6 +94,7 @@ const ApplicationRoute = Discourse.Route.extend(OpenComposer, {
     showCreateAccount: unlessReadOnly('handleShowCreateAccount', I18n.t("read_only_mode.login_disabled")),
 
     showForgotPassword() {
+      this.controllerFor('forgot-password').set('offerHelp', null);
       showModal('forgotPassword', { title: 'forgot_password.title' });
     },
 

--- a/app/assets/javascripts/discourse/templates/modal/forgot-password.hbs
+++ b/app/assets/javascripts/discourse/templates/modal/forgot-password.hbs
@@ -1,9 +1,25 @@
 <form>
   {{#d-modal-body}}
-    <label for='username-or-email'>{{i18n 'forgot_password.invite'}}</label>
-    {{text-field value=accountEmailOrUsername placeholderKey="login.email_placeholder" id="username-or-email" autocorrect="off" autocapitalize="off"}}
+    {{#unless offerHelp}}
+      <label for='username-or-email'>{{i18n 'forgot_password.invite'}}</label>
+      {{text-field value=accountEmailOrUsername placeholderKey="login.email_placeholder" id="username-or-email" autocorrect="off" autocapitalize="off"}}
+    {{else}}
+      {{{offerHelp}}}
+    {{/unless}}
   {{/d-modal-body}}
   <div class="modal-footer">
-    <button class='btn btn-large btn-primary' disabled={{submitDisabled}} {{action "submit"}}>{{i18n 'forgot_password.reset'}}</button>
+    {{#unless offerHelp}}
+      {{d-button action="submit"
+	               label="forgot_password.reset"
+	               disabled=submitDisabled
+	               class="btn-primary"}}
+    {{else}}
+      {{d-button class="btn-large btn-primary"
+                 label="forgot_password.button_ok"
+                 action="ok"}}
+      {{d-button class="btn-large"
+                 label="forgot_password.button_help"
+                 action="help"}}
+    {{/unless}}
   </div>
 </form>

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1036,6 +1036,9 @@ en:
 
       complete_username_not_found: "No account matches the username <b>%{username}</b>"
       complete_email_not_found: "No account matches <b>%{email}</b>"
+      help: "Please contact site administrator."
+      button_ok: "OK"
+      button_help: "Help"
     login:
       title: "Log In"
       username: "User"


### PR DESCRIPTION
https://meta.discourse.org/t/handling-old-accounts-that-have-changed-emails/64649?u=techapj

![screen shot 2017-06-19 at 14 19 20](https://user-images.githubusercontent.com/5732281/27276941-52caa1b8-54fa-11e7-8e89-4e141f7d7c22.png)

on clicking help:

![screen shot 2017-06-19 at 14 17 59](https://user-images.githubusercontent.com/5732281/27276878-29c98478-54fa-11e7-901c-733f697c5578.png)

Help text can be edited by editing `forgot_password.help` locale key.