### PR TITLE
FEATURE: setting to only use the key when finding the related post of…

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1377,6 +1377,8 @@ en:
     email_prefix: "The [label] used in the subject of emails. It will default to 'title' if not set."
     email_site_title: "The title of the site used as the sender of emails from the site. Default to 'title' if not set. If your 'title' contains characters that are not allowed in email sender strings, use this setting."
 
+    find_related_post_with_key: "Only use the reply key to find the replied-to post. (Recommended if using Amazon SES)"
+
     minimum_topics_similar: "How many topics need to exist before similar topics are presented when composing new topics."
 
     relative_date_duration: "Number of days after posting where post dates will be shown as relative (7d) instead of absolute (20 Feb)."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -629,6 +629,8 @@ email:
   alternative_reply_by_email_addresses:
     default: ''
     validator: "AlternativeReplyByEmailAddressesValidator"
+  find_related_post_with_key:
+    default: false
   manual_polling_enabled:
     default: false
   pop3_polling_enabled:

--- a/lib/email/receiver.rb
+++ b/lib/email/receiver.rb
@@ -486,6 +486,8 @@ module Email
     end
 
     def find_related_post
+      return if SiteSetting.find_related_post_with_key
+
       message_ids = [@mail.in_reply_to, Email::Receiver.extract_references(@mail.references)]
       message_ids.flatten!
       message_ids.select!(&:present?)


### PR DESCRIPTION
… an email reply

this fixes email-in threading problems when using a SMTP server which modifies the message_id
header, like Amazon SES

https://meta.discourse.org/t/email-in-replies-thread-wrongly/59365/17?u=leomca