### PR TITLE
Add facebook auth_token for plugins to use 

### DIFF
--- a/lib/auth/facebook_authenticator.rb
+++ b/lib/auth/facebook_authenticator.rb
@@ -1,4 +1,4 @@
-class Auth::FacebookAuthenticator < Auth::Authenticator
+﻿class Auth::FacebookAuthenticator < Auth::Authenticator
 
   AVATAR_SIZE = 480
 
@@ -72,6 +72,8 @@ class Auth::FacebookAuthenticator < Auth::Authenticator
 
       email = auth_token["info"][:email]
 
+      access_token = auth_token["credentials"][:token]
+
       website = (info["urls"] && info["urls"]["Website"]) || nil
 
       {
@@ -87,7 +89,8 @@ class Auth::FacebookAuthenticator < Auth::Authenticator
           avatar_url: info["image"],
           location: info["location"],
           website: website,
-          about_me: info["description"]
+          about_me: info["description"],
+          token: access_token
         },
         email: email,
         email_valid: true

--- a/spec/components/auth/facebook_authenticator_spec.rb
+++ b/spec/components/auth/facebook_authenticator_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+﻿require 'rails_helper'
 
 # In the ghetto ... getting the spec to run in autospec
 #  thing is we need to load up all auth really early pre-fork
@@ -27,7 +27,10 @@ describe Auth::FacebookAuthenticator do
             "Website" => "https://awesome.com"
           }
         },
-        "uid" => "100"
+        "uid" => "100",
+        "credentials" => {
+            :token => "abcdefghi123"
+        }
       }
 
       result = authenticator.after_authenticate(hash)
@@ -50,7 +53,10 @@ describe Auth::FacebookAuthenticator do
         "info" => {
           :email => "bob@bob.com"
         },
-        "uid" => "100"
+        "uid" => "100",
+        "credentials" => {
+            :token => "abcdefghi123"
+        }
       }
 
       authenticator = Auth::FacebookAuthenticator.new


### PR DESCRIPTION
As above, attempting to get the auth_token changes in for plugin use; originating PR #2406 did not have spec updates.  This includes those.

Original changes by @rl7greg 