### PR TITLE
Added plugin outlet near editor's preview.

### DIFF
--- a/app/assets/javascripts/discourse/templates/components/d-editor.hbs
+++ b/app/assets/javascripts/discourse/templates/components/d-editor.hbs
@@ -28,7 +28,8 @@
 
   <div class="d-editor-preview-wrapper {{if forcePreview 'force-preview'}}">
     <div class="d-editor-preview">
-      {{{preview}}}
+      <div class="d-editor-cooked">{{{preview}}}</div>
+      <div class="d-editor-plugin">{{plugin-outlet name="editor-preview"}}</div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
This is required for the updates I made to canned replies plugin from this [PR](https://github.com/discourse/discourse-canned-replies/pull/22).

This should help plugins display stuff using the preview pane.