### PR TITLE
Include HTTP Host header in nginx logs

### DIFF
--- a/config/nginx.sample.conf
+++ b/config/nginx.sample.conf
@@ -25,7 +25,7 @@ map $http_x_forwarded_proto $thescheme {
   https https;
 }
 
-log_format log_discourse '[$time_local] $remote_addr "$request" "$http_user_agent" "$sent_http_x_discourse_route" $status $bytes_sent "$http_referer" $upstream_response_time $request_time "$sent_http_x_discourse_username"';
+log_format log_discourse '[$time_local] "$http_host" $remote_addr "$request" "$http_user_agent" "$sent_http_x_discourse_route" $status $bytes_sent "$http_referer" $upstream_response_time $request_time "$sent_http_x_discourse_username"';
 
 server {
 

--- a/plugins/discourse-nginx-performance-report/lib/log_analyzer.rb
+++ b/plugins/discourse-nginx-performance-report/lib/log_analyzer.rb
@@ -3,12 +3,12 @@ class LogAnalyzer
   class LineParser
 
 
-    # log_format log_discourse '[$time_local] $remote_addr "$request" "$http_user_agent" "$sent_http_x_discourse_route" $status $bytes_sent "$http_referer" $upstream_response_time $request_time "$sent_http_x_discourse_username"';
+    # log_format log_discourse '[$time_local] "$http_host" $remote_addr "$request" "$http_user_agent" "$sent_http_x_discourse_route" $status $bytes_sent "$http_referer" $upstream_response_time $request_time "$sent_http_x_discourse_username"';
 
     attr_accessor :time, :ip_address, :url, :route, :user_agent, :rails_duration, :total_duration,
                   :username, :status, :bytes_sent, :referer
 
-    PATTERN = /\[(.*)\] (\S+) \"(.*)\" \"(.*)\" \"(.*)\" ([0-9]+) ([0-9]+) \"(.*)\" ([0-9.]+) ([0-9.]+) "(.*)"/
+    PATTERN = /\[(.*)\](?: ".*")? (\S+) \"(.*)\" \"(.*)\" \"(.*)\" ([0-9]+) ([0-9]+) \"(.*)\" ([0-9.]+) ([0-9.]+) "(.*)"/
 
     TIME_FORMAT = "%d/%b/%Y:%H:%M:%S %Z"
 


### PR DESCRIPTION
This is crucial in multisite installations, because otherwise the nginx logs
are fairly useless, however it can also be quite handy to know what
hostnames are being sent to your site.  The variable is quoted, because it
is untrusted input (it is taken directly from the HTTP request), but nginx
helpfully escapes the quoting character automagically, so we don't have to
worry about that.

For now, the log analysis plugin *recognises* the new log format
(and continues to recognise the previous format, for backwards
compatibility), but doesn't do anything with the new log entry field.  This
means your multisite performance plugin data is still broken, but it's no
worse than it was before.