### PR TITLE
FIX: Translation fallback was not using fallback's translation override.

### DIFF
--- a/lib/freedom_patches/translate_accelerator.rb
+++ b/lib/freedom_patches/translate_accelerator.rb
@@ -137,17 +137,25 @@ module I18n
       load_locale(locale) unless @loaded_locales.include?(locale)
 
       if @overrides_enabled
-        if by_locale = overrides_by_locale(locale)
+        overrides = {}
+
+        backend.fallbacks(locale).each do |l|
+          overrides[l] = overrides_by_locale(l)
+        end
+
+        if overrides.present?
           if options.present?
-            options[:overrides] = by_locale
+            options[:overrides] = overrides
 
             # I18n likes to use throw...
             catch(:exception) do
               return backend.translate(locale, key, options)
             end
           else
-            if result = by_locale[key]
-              return result
+            overrides.each do |_k, v|
+              if result = v[key]
+                return result
+              end
             end
           end
         end

--- a/lib/i18n/backend/discourse_i18n.rb
+++ b/lib/i18n/backend/discourse_i18n.rb
@@ -72,8 +72,9 @@ module I18n
         # the original translations before applying our overrides.
         def lookup(locale, key, scope = [], options = {})
           existing_translations = super(locale, key, scope, options)
+          overrides = options.dig(:overrides, locale)
 
-          if options[:overrides] && existing_translations
+          if overrides && existing_translations
             if options[:count]
 
               remapped_translations =
@@ -85,13 +86,13 @@ module I18n
 
               result = {}
 
-              remapped_translations.merge(options[:overrides]).each do |k, v|
+              remapped_translations.merge(overrides).each do |k, v|
                 result[k.split('.').last.to_sym] = v if k != key && k.start_with?(key.to_s)
               end
               return result if result.size > 0
             end
 
-            return options[:overrides][key] if options[:overrides][key]
+            return overrides[key] if overrides[key]
           end
 
           existing_translations

--- a/spec/components/discourse_i18n_spec.rb
+++ b/spec/components/discourse_i18n_spec.rb
@@ -147,6 +147,22 @@ describe I18n::Backend::DiscourseI18n do
       expect(I18n.translate('keys.magic', count: 2)).to eq("no magic keys")
     end
 
+    it "returns the overriden text when falling back" do
+      TranslationOverride.upsert!('en', 'got', "summer")
+      I18n.backend.store_translations(:en, got: 'winter')
+
+      expect(I18n.translate('got')).to eq('summer')
+      expect(I18n.with_locale(:zh_TW) { I18n.translate('got') }).to eq('summer')
+
+      TranslationOverride.upsert!('en', 'throne', "%{title} is the new queen")
+      I18n.backend.store_translations(:en, throne: "%{title} is the new king")
+
+      expect(I18n.t('throne', title: 'snow')).to eq('snow is the new queen')
+
+      expect(I18n.with_locale(:en) { I18n.t('throne', title: 'snow') })
+        .to eq('snow is the new queen')
+    end
+
     it 'supports ActiveModel::Naming#human' do
       Fish = Class.new(ActiveRecord::Base)
 


### PR DESCRIPTION
https://meta.discourse.org/t/discobot-falling-back-to-site-locale-is-not-using-customized-copies/65140