### PR TITLE
FIX: ensure we clear emoji cache before recompilation

### DIFF
--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -11,6 +11,10 @@ task 'assets:precompile:before' do
   puts "Purging temp files"
   `rm -fr #{Rails.root}/tmp/cache`
 
+  # Ensure we clear emoji cache before pretty-text/emoji/data.js.es6.erb
+  # is recompiled
+  Emoji.clear_cache
+
   if Rails.configuration.assets.js_compressor == :uglifier && !`which uglifyjs`.empty? && !ENV['SKIP_NODE_UGLIFY']
     $node_uglify = true
   end


### PR DESCRIPTION
I'm not 100% sure it's the root cause, but in my tests it seems to fix the issue.