### PR TITLE
Allow optional import_mode param for posts in api

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -571,6 +571,9 @@ class PostsController < ApplicationController
       params[:skip_validations] = params[:skip_validations].to_s == "true"
       permitted << :skip_validations
 
+      params[:import_mode] = params[:import_mode].to_s == "true"
+      permitted << :import_mode
+
       # We allow `embed_url` via the API
       permitted << :embed_url
 


### PR DESCRIPTION
This should allow a new post to be created in import mode, which will be useful for creating topics in bulk without notifying users and all such sort of things.

relevant discussion:
https://meta.discourse.org/t/disable-count-pop-up-notifications/65543