### PR TITLE
FEATURE: new site setting to limit message recipients

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -213,6 +213,7 @@ en:
   user_is_suspended: "Suspended users are not allowed to post."
   topic_not_found: "Something has gone wrong. Perhaps this topic was closed or deleted while you were looking at it?"
   not_accepting_pms: "Sorry, %{username} is not accepting messages at the moment."
+  max_pm_recepients: "Sorry, you can send a message to maximum %{recipients_limit} recipients."
 
   just_posted_that: "is too similar to what you recently posted"
   invalid_characters: "contains invalid characters"
@@ -1497,6 +1498,8 @@ en:
     auto_close_topics_post_count: "Maximum number of posts allowed in a topic before it is automatically closed (0 to disable)"
 
     code_formatting_style: "Code button in composer will default to this code formatting style"
+
+    max_allowed_message_recipients: "Maximum recipients allowed in a message."
 
     default_email_digest_frequency: "How often users receive summary emails by default."
     default_include_tl0_in_digests: "Include posts from new users in summary emails by default. Users can change this in their preferences."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -600,6 +600,9 @@ posting:
     client: true
     default: ''
     type: list
+  max_allowed_message_recipients:
+    default: 30
+    min: 1
 
 email:
   email_time_window_mins:

--- a/lib/post_creator.rb
+++ b/lib/post_creator.rb
@@ -92,6 +92,12 @@ class PostCreator
       return false
     end
 
+    # Make sure max_allowed_message_recipients setting is respected
+    if @opts[:target_usernames].present? && !skip_validations? && !@user.staff?
+      errors[:base] << I18n.t(:max_pm_recepients, recipients_limit: SiteSetting.max_allowed_message_recipients) if @opts[:target_usernames].split(',').length > SiteSetting.max_allowed_message_recipients
+      return false if errors[:base].present?
+    end
+
     # Make sure none of the users have muted the creator
     names = @opts[:target_usernames]
     if names.present? && !skip_validations? && !@user.staff?


### PR DESCRIPTION
New site setting `max_allowed_message_recipients` to limit message recipients.

https://meta.discourse.org/t/one-of-my-users-just-group-messaged-100-other-user-with-a-spam-offer/65612/7?u=techapj