### PR TITLE
Add a nil check on the connection before attempting to exec it

### DIFF
--- a/script/import_scripts/base.rb
+++ b/script/import_scripts/base.rb
@@ -203,7 +203,7 @@ class ImportScripts::Base
       return true
     end
   ensure
-    connection.exec('DROP TABLE import_ids')
+    connection.exec('DROP TABLE import_ids') unless connection.nil?
   end
 
   def created_user(user)


### PR DESCRIPTION
Ran into an issue while trying to [import mbox files](https://meta.discourse.org/t/howto-import-mbox-mailing-list-files/51233) that I tracked back to this line. I'm not an avid rubyist so I'm not entirely sure this is the Right Solution™, but it got my import running after I made this change.

Figured that others would probably run into the same issue so I thought I'd submit a PR to call attention to the issue, if nothing else. =)

Cheers!