### PR TITLE
Added events to show and hide the preview pane.

### DIFF
--- a/app/assets/javascripts/discourse/components/composer-editor.js.es6
+++ b/app/assets/javascripts/discourse/components/composer-editor.js.es6
@@ -33,12 +33,10 @@ export default Ember.Component.extend({
 
     this.appEvents.on('composer:show-preview', () => {
       this.set('showPreview', true);
-      this.keyValueStore.set({ key: 'composer.showPreview', value: true });
     });
 
     this.appEvents.on('composer:hide-preview', () => {
       this.set('showPreview', false);
-      this.keyValueStore.set({ key: 'composer.showPreview', value: false });
     });
   },
 
@@ -50,6 +48,11 @@ export default Ember.Component.extend({
   @computed('showPreview')
   toggleText: function(showPreview) {
     return showPreview ? I18n.t('composer.hide_preview') : I18n.t('composer.show_preview');
+  },
+
+  @observes('showPreview')
+  showPreviewChanged() {
+      this.keyValueStore.set({ key: 'composer.showPreview', value: this.get('showPreview') });
   },
 
   @computed
@@ -498,7 +501,6 @@ export default Ember.Component.extend({
 
     togglePreview() {
       this.toggleProperty('showPreview');
-      this.keyValueStore.set({ key: 'composer.showPreview', value: this.get('showPreview') });
     },
 
     extraButtons(toolbar) {

--- a/app/assets/javascripts/discourse/components/composer-editor.js.es6
+++ b/app/assets/javascripts/discourse/components/composer-editor.js.es6
@@ -30,6 +30,16 @@ export default Ember.Component.extend({
   _setupPreview() {
     const val = (this.site.mobileView ? false : (this.keyValueStore.get('composer.showPreview') || 'true'));
     this.set('showPreview', val === 'true');
+
+    this.appEvents.on('composer:show-preview', () => {
+      this.set('showPreview', true);
+      this.keyValueStore.set({ key: 'composer.showPreview', value: true });
+    });
+
+    this.appEvents.on('composer:hide-preview', () => {
+      this.set('showPreview', false);
+      this.keyValueStore.set({ key: 'composer.showPreview', value: false });
+    });
   },
 
   @computed('site.mobileView', 'showPreview')
@@ -445,6 +455,8 @@ export default Ember.Component.extend({
   @on('willDestroyElement')
   _composerClosed() {
     this.appEvents.trigger('composer:will-close');
+    this.appEvents.off('composer:show-preview');
+    this.appEvents.off('composer:hide-preview');
     Ember.run.next(() => {
       $('#main-outlet').css('padding-bottom', 0);
       // need to wait a bit for the "slide down" transition of the composer


### PR DESCRIPTION
The plugin-outlet defined in the preview is useless if the preview pane is hidden.

I consider that plugins should may be able to show and hide the preview pane.