### PR TITLE
For rake plugin:spec, only load ruby files ending in _spec.rb

### DIFF
--- a/lib/tasks/plugin.rake
+++ b/lib/tasks/plugin.rake
@@ -47,7 +47,7 @@ desc 'run plugin specs'
 task 'plugin:spec', :plugin do |t, args|
   args.with_defaults(plugin: "*")
   ruby = `which ruby`.strip
-  files = Dir.glob("./plugins/#{args[:plugin]}/spec/**/*.rb")
+  files = Dir.glob("./plugins/#{args[:plugin]}/spec/**/*_spec.rb")
   if files.length > 0
     sh "LOAD_PLUGINS=1 #{ruby} -S rspec #{files.join(' ')}"
   else


### PR DESCRIPTION
This matches the default behaviour of rspec, as per

> When you run RSpec without giving it specific file names, it determines which
> files to load by applying a pattern to the provided directory arguments or
> spec (if no directories are provided). By default, RSpec uses the following
> pattern:
> 
> `"**{,/*/**}/*_spec.rb"`

[docs](https://relishapp.com/rspec/rspec-core/docs/command-line/pattern-option)