### PR TITLE
Load plugins for qunit travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,4 +62,4 @@ install:
   - bash -c "if [ '$RAILS_MASTER' == '0' ]; then bundle install --without development --deployment --retry=3 --jobs=3; fi"
 
 script:
-  - bash -c "if [ '$QUNIT_RUN' == '0' ]; then bundle exec rspec && bundle exec rake plugin:spec; else bundle exec rake qunit:test['200000']; fi"
+  - bash -c "if [ '$QUNIT_RUN' == '0' ]; then bundle exec rspec && bundle exec rake plugin:spec; else LOAD_PLUGINS=1 bundle exec rake qunit:test['200000']; fi"


### PR DESCRIPTION
The tests will fail for this PR, because of all the broken qunit tests that are currently being ignored by travis.

See https://meta.discourse.org/t/plugin-qunit-tests-are-not-running-as-part-of-rake-qunit-test/59577/6?u=david_taylor