### PR TITLE
safely call html_safe on category description

### DIFF
--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -6,7 +6,7 @@
       <h2><a href='<%= c.url %>' itemprop='item'>
         <span itemprop='name'><%= c.name %></span>
       </a></h2>
-      <span itemprop='description'><%= c.description.html_safe %></span>
+      <span itemprop='description'><%= c.description&.html_safe %></span>
     </div>
   <% end %>
 </div>


### PR DESCRIPTION
The `categories.description` column is not modified as "not null", so it is possible for the description to be nil. This changes the code not call html_safe on nil.