### PR TITLE
[FIX] invalid byte sequence in UTF-8

### DIFF
--- a/script/bulk_import/base.rb
+++ b/script/bulk_import/base.rb
@@ -518,8 +518,8 @@ class BulkImport::Base
   end
 
   def fix_name(name)
-    return if name.blank?
     name.scrub!
+    return if name.blank?
     name = ActiveSupport::Inflector.transliterate(name)
     name.gsub!(/[^\w.-]+/, "_")
     name.gsub!(/^\W+/, "")


### PR DESCRIPTION
The name should be scrubbed before to avoid encoding issues when using ```name.blank?```.