### PR TITLE
Allow for no positioning on emoji picker

### DIFF
--- a/app/assets/javascripts/discourse/components/emoji-picker.js.es6
+++ b/app/assets/javascripts/discourse/components/emoji-picker.js.es6
@@ -448,7 +448,7 @@ export default Ember.Component.extend({
       $picker.css(_.merge(attributes, options));
     };
 
-    if(Ember.testing) {
+    if(Ember.testing || this.get('noPositioning')) {
       desktopPositioning();
       return;
     }

--- a/app/assets/javascripts/discourse/components/emoji-picker.js.es6
+++ b/app/assets/javascripts/discourse/components/emoji-picker.js.es6
@@ -21,6 +21,8 @@ export function resetCache() {
 let $picker, $filter, $results, $list, scrollPosition, $visibleSections, _checkTimeout;
 
 export default Ember.Component.extend({
+  automaticPositioning: true,
+
   willDestroyElement() {
     this._super();
 
@@ -448,7 +450,7 @@ export default Ember.Component.extend({
       $picker.css(_.merge(attributes, options));
     };
 
-    if(Ember.testing || this.get('noPositioning')) {
+    if(!this.get('automaticPositioning')) {
       desktopPositioning();
       return;
     }


### PR DESCRIPTION
Right now the emoji picker relies on there being a '#reply-control' element present (amongst several other elements specific to the discourse composer). This allows passing a 'noPositioning' argument to the component which gives the default positioning all the time.