### PR TITLE
Add placeholder text to group member add field

### DIFF
--- a/app/assets/javascripts/discourse/templates/components/group-members-input.hbs
+++ b/app/assets/javascripts/discourse/templates/components/group-members-input.hbs
@@ -15,7 +15,9 @@
 
 {{#unless model.automatic}}
   <div class="group-members-input-selector">
-    {{user-selector usernames=model.usernames}}
+    {{user-selector usernames=model.usernames
+          placeholderKey="admin.groups.selector_placeholder"
+          id="member-selector"}}
 
     {{#if addButton}}
       {{d-button action="addMembers"


### PR DESCRIPTION
https://meta.discourse.org/t/no-placeholder-text-for-group-member-add-field/67137