### PR TITLE
"Watched Words" tab should only be visible to admins

### DIFF
--- a/app/assets/javascripts/admin/templates/admin.hbs
+++ b/app/assets/javascripts/admin/templates/admin.hbs
@@ -21,8 +21,8 @@
           {{nav-item route='adminCustomize' label='admin.customize.title'}}
           {{nav-item route='adminApi' label='admin.api.title'}}
           {{nav-item route='admin.backups' label='admin.backups.title'}}
+          {{nav-item route='adminWatchedWords' label='admin.watched_words.title'}}
         {{/if}}
-        {{nav-item route='adminWatchedWords' label='admin.watched_words.title'}}
         {{nav-item route='adminPlugins' label='admin.plugins.title'}}
         {{plugin-outlet name="admin-menu" connectorTagName="li"}}
       </ul>


### PR DESCRIPTION
Meta topic: https://meta.discourse.org/t/automatic-actions-based-on-words-found-in-posts/66878/5