### PR TITLE
FIX: add additional email to tests and clean up resulting mess

### DIFF
--- a/app/controllers/admin/groups_controller.rb
+++ b/app/controllers/admin/groups_controller.rb
@@ -23,6 +23,7 @@ class Admin::GroupsController < Admin::AdminController
         valid_emails[email] = valid_usernames[username_lower] = id
         id
       end
+      valid_users.uniq!
       invalid_users = users.reject! { |u| valid_emails[u] || valid_usernames[u] }
       group.bulk_add(valid_users) if valid_users.present?
       users_added = valid_users.count

--- a/app/jobs/scheduled/pending_users_reminder.rb
+++ b/app/jobs/scheduled/pending_users_reminder.rb
@@ -12,7 +12,7 @@ module Jobs
           query = query.where('users.created_at < ?', SiteSetting.pending_users_reminder_delay.hours.ago)
         end
 
-        newest_username = query.limit(1).pluck(:username).first
+        newest_username = query.limit(1).select(:username).first&.username
 
         return true if newest_username == previous_newest_username # already notified
 

--- a/lib/admin_user_index_query.rb
+++ b/lib/admin_user_index_query.rb
@@ -4,7 +4,8 @@ class AdminUserIndexQuery
 
   def initialize(params = {}, klass = User, trust_levels = TrustLevel.levels)
     @params = params
-    @query = initialize_query_with_order(klass).joins(:user_emails)
+    @outer_query = initialize_query_with_order(klass)
+    @query = klass.joins(:user_emails).distinct
     @trust_levels = trust_levels
   end
 
@@ -134,7 +135,7 @@ class AdminUserIndexQuery
     append filter_by_ip
     append filter_exclude
     append filter_by_search
-    @query
+    @outer_query.from(@query, 'users')
   end
 
 end

--- a/spec/fabricators/user_email_fabricator.rb
+++ b/spec/fabricators/user_email_fabricator.rb
@@ -2,3 +2,8 @@ Fabricator(:user_email) do
   email { sequence(:email) { |i| "bruce#{i}@wayne.com" } }
   primary true
 end
+
+Fabricator(:alternate_email, from: :user_email) do
+  email { sequence(:email) { |i| "bwayne#{i}@wayne.com" } }
+  primary false
+end

--- a/spec/fabricators/user_fabricator.rb
+++ b/spec/fabricators/user_fabricator.rb
@@ -1,7 +1,7 @@
 Fabricator(:user_stat) do
 end
 
-Fabricator(:user) do
+Fabricator(:user_single_email, class_name: :user) do
   name 'Bruce Wayne'
   username { sequence(:username) { |i| "bruce#{i}" } }
   email { sequence(:email) { |i| "bruce#{i}@wayne.com" } }
@@ -9,6 +9,10 @@ Fabricator(:user) do
   trust_level TrustLevel[1]
   ip_address { sequence(:ip_address) { |i| "99.232.23.#{i % 254}" } }
   active true
+end
+
+Fabricator(:user, from: :user_single_email) do
+  after_create { |user| Fabricate(:alternate_email, user: user)  }
 end
 
 Fabricator(:coding_horror, from: :user) do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -612,7 +612,7 @@ describe User do
 
     it 'email whitelist should be used when email is being changed' do
       SiteSetting.email_domains_whitelist = 'vaynermedia.com'
-      u = Fabricate(:user, email: 'good@vaynermedia.com')
+      u = Fabricate(:user_single_email, email: 'good@vaynermedia.com')
       u.email = 'nope@mailinator.com'
       expect(u).not_to be_valid
     end

--- a/spec/services/user_destroyer_spec.rb
+++ b/spec/services/user_destroyer_spec.rb
@@ -53,10 +53,10 @@ describe UserDestroyer do
         destroy
       end
 
-      it "adds email to block list if block_email is true" do
+      it "adds emails to block list if block_email is true" do
         expect {
           UserDestroyer.new(@admin).destroy(@user, destroy_opts.merge(block_email: true))
-        }.to change { ScreenedEmail.count }.by(1)
+        }.to change { ScreenedEmail.count }.by(2)
       end
     end
 


### PR DESCRIPTION
As a first step to [making use of additional emails](https://meta.discourse.org/t/additional-email-support/59847/9?u=leomca) I've added a secondary email to `Fabricate(:user)` to ensure that a user actually having multiple emails doesn't break everything.

Thankfully, it only broke a few things, which I fixed. However, I want to highlight what I've done to `AdminUserIndexQuery` because I'm concerned it's _deeply_ immoral.

With the `.joins` where it was we had the problem of duplicate users in the result. Adding a `.distinct` after solved that problem, but created a new one when the query contained `ORDER BY COALESCE(...)` because `for SELECT DISTINCT, ORDER BY expressions must appear in select list`.

So, my ultimate solution is to do all the filtering and making distinct in a subquery, which is then ordered in the outer query. However I know for sure this breaks `.pluck`, and who knows what else. Is there a better way?