### PR TITLE
Exclude bundle directory when running rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,9 @@ AllCops:
   TargetRubyVersion: 2.4
   DisabledByDefault: true
   Exclude:
-    - bundle/**/*
+    - 'bundle/**/*'
+    - 'vendor/**/*'
+    - 'node_modules/**/*'
 
 # Prefer &&/|| over and/or.
 Style/AndOr:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,8 @@
 AllCops:
   TargetRubyVersion: 2.4
   DisabledByDefault: true
+  Exclude:
+    - bundle/**/*
 
 # Prefer &&/|| over and/or.
 Style/AndOr:


### PR DESCRIPTION
If I run `bundle exec rubocop` in the root of discourse, it tries to lint many thousands of files from dependencies inside the `bundle` directory. This PR adds an exclude rule for anything inside the `bundle` directory, so we're just linting Discourse files.