### PR TITLE
Improve source code linting for continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ before_install:
   - eslint --ext .es6 app/assets/javascripts
   - eslint --ext .es6 test/javascripts
   - eslint --ext .es6 plugins/**/assets/javascripts
+  - eslint --ext .es6 plugins/**/test/javascripts
   - eslint test/javascripts
   - rubocop --parallel
 

--- a/lib/tasks/docker.rake
+++ b/lib/tasks/docker.rake
@@ -7,6 +7,7 @@
 # => INSTALL_OFFICIAL_PLUGINS  set to 1 to install all core plugins before running tests
 # => RUBY_ONLY                 set to 1 to skip all qunit tests
 # => JS_ONLY                   set to 1 to skip all rspec tests
+# => SKIP_LINT                 set to 1 to skip rubocop and eslint checks
 # => SINGLE_PLUGIN             set to plugin name to only run plugin-specific rspec tests (you'll probably want to SKIP_CORE as well)
 # => BISECT                    set to 1 to run rspec --bisect (applies to core rspec tests only)
 # => RSPEC_SEED                set to seed to use for rspec tests (applies to core rspec tests only)
@@ -89,18 +90,20 @@ task 'docker:test' do
 
     unless ENV["RUBY_ONLY"]
       unless ENV["SKIP_CORE"]
-        @good &&= run_or_fail("eslint app/assets/javascripts")
-        @good &&= run_or_fail("eslint --ext .es6 app/assets/javascripts")
-        @good &&= run_or_fail("eslint --ext .es6 test/javascripts")
-        @good &&= run_or_fail("eslint test/javascripts")
+        @good &&= run_or_fail("eslint app/assets/javascripts") unless ENV["SKIP_LINT"]
+        @good &&= run_or_fail("eslint --ext .es6 app/assets/javascripts") unless ENV["SKIP_LINT"]
+        @good &&= run_or_fail("eslint --ext .es6 test/javascripts") unless ENV["SKIP_LINT"]
+        @good &&= run_or_fail("eslint test/javascripts") unless ENV["SKIP_LINT"]
         @good &&= run_or_fail("bundle exec rake qunit:test['600000']")
         @good &&= run_or_fail("bundle exec rake qunit:test['600000','/wizard/qunit']")
       end
 
       unless ENV["SKIP_PLUGINS"]
         if ENV["SINGLE_PLUGIN"]
+          @good &&= run_or_fail("eslint --ext .es6 plugins/#{ENV['SINGLE_PLUGIN']}") unless ENV["SKIP_LINT"]
           @good &&= run_or_fail("bundle exec rake plugin:qunit['#{ENV['SINGLE_PLUGIN']}','600000']")
         else
+          @good &&= run_or_fail("eslint --ext .es6 plugins") unless ENV["SKIP_LINT"]
           @good &&= run_or_fail("bundle exec rake plugin:qunit['*','600000']")
         end
       end

--- a/lib/tasks/docker.rake
+++ b/lib/tasks/docker.rake
@@ -90,10 +90,8 @@ task 'docker:test' do
 
     unless ENV["RUBY_ONLY"]
       unless ENV["SKIP_CORE"]
-        @good &&= run_or_fail("eslint app/assets/javascripts") unless ENV["SKIP_LINT"]
-        @good &&= run_or_fail("eslint --ext .es6 app/assets/javascripts") unless ENV["SKIP_LINT"]
-        @good &&= run_or_fail("eslint --ext .es6 test/javascripts") unless ENV["SKIP_LINT"]
-        @good &&= run_or_fail("eslint test/javascripts") unless ENV["SKIP_LINT"]
+        @good &&= run_or_fail("eslint app/assets/javascripts test/javascripts") unless ENV["SKIP_LINT"]
+        @good &&= run_or_fail("eslint --ext .es6 app/assets/javascripts test/javascripts") unless ENV["SKIP_LINT"]
         @good &&= run_or_fail("bundle exec rake qunit:test['600000']")
         @good &&= run_or_fail("bundle exec rake qunit:test['600000','/wizard/qunit']")
       end

--- a/lib/tasks/docker.rake
+++ b/lib/tasks/docker.rake
@@ -63,6 +63,8 @@ task 'docker:test' do
     unless ENV["JS_ONLY"]
 
       unless ENV["SKIP_CORE"]
+        @good &&= run_or_fail("bundle exec rubocop --parallel") unless ENV["SKIP_LINT"]
+
         params = []
         if ENV["BISECT"]
           params << "--bisect"
@@ -75,8 +77,10 @@ task 'docker:test' do
 
       unless ENV["SKIP_PLUGINS"]
         if ENV["SINGLE_PLUGIN"]
+          @good &&= run_or_fail("bundle exec rubocop --parallel plugins/#{ENV["SINGLE_PLUGIN"]}") unless ENV["SKIP_LINT"]
           @good &&= run_or_fail("bundle exec rake plugin:spec['#{ENV["SINGLE_PLUGIN"]}']")
         else
+          @good &&= run_or_fail("bundle exec rubocop --parallel plugins") unless ENV["SKIP_LINT"]
           @good &&= run_or_fail("bundle exec rake plugin:spec")
         end
       end

--- a/plugins/poll/test/javascripts/acceptance/polls-test.js.es6
+++ b/plugins/poll/test/javascripts/acceptance/polls-test.js.es6
@@ -6,7 +6,7 @@ acceptance("Rendering polls", {
 });
 
 test("Single Poll", (assert) => {
-  server.get('/t/13.json', () => {
+  server.get('/t/13.json', () => { // eslint-disable-line no-undef
     return [
       200,
       { "Content-Type": "application/json" },
@@ -26,7 +26,7 @@ test("Single Poll", (assert) => {
 });
 
 test("Public poll", assert => {
-  server.get('/t/12.json', () => {
+  server.get('/t/12.json', () => { // eslint-disable-line no-undef
     return [
       200,
       { "Content-Type": "application/json" },
@@ -34,7 +34,7 @@ test("Public poll", assert => {
     ];
   });
 
-  server.get('/polls/voters.json', request => {
+  server.get('/polls/voters.json', request => { // eslint-disable-line no-undef
     let body = {};
 
     if (_.isEqual(request.queryParams, { post_id: "15", poll_name: "poll" })) {
@@ -73,7 +73,7 @@ test("Public poll", assert => {
 });
 
 test("Public number poll", assert => {
-  server.get('/t/13.json', () => {
+  server.get('/t/13.json', () => { // eslint-disable-line no-undef
     return [
       200,
       { "Content-Type": "application/json" },
@@ -81,7 +81,7 @@ test("Public number poll", assert => {
     ];
   });
 
-  server.get('/polls/voters.json', request => {
+  server.get('/polls/voters.json', request => { // eslint-disable-line no-undef
     let body = {};
 
     if (_.isEqual(request.queryParams, { post_id: "16", poll_name: "poll" })) {


### PR DESCRIPTION
This PR does a number of things related to source code linting:

- Add rubocop linting to `docker:test` rake task
- Add eslint JS linting for plugin files in the `docker:test` rake task
- Add optional SKIP_LINT variable to the `docker:test` rake task
- Get travis to run eslint on plugin test files (currently only runs on `plugins/**/assets/javascripts`)
- Fix the failing "polls" plugin eslint using the same `eslint-disable-line` technique as used in core (see `acceptance/group-logs-test.js.es6` for an example)


