### PR TITLE
FIX: show rejected emails with unrecognized errors

### DIFF
--- a/app/models/incoming_email.rb
+++ b/app/models/incoming_email.rb
@@ -3,7 +3,7 @@ class IncomingEmail < ActiveRecord::Base
   belongs_to :topic
   belongs_to :post
 
-  scope :errored,  -> { where("NOT is_bounce AND LENGTH(COALESCE(error,'')) > 0") }
+  scope :errored,  -> { where("NOT is_bounce AND error IS NOT NULL") }
 end
 
 # == Schema Information

--- a/lib/email/receiver.rb
+++ b/lib/email/receiver.rb
@@ -49,7 +49,9 @@ module Email
           @incoming_email = create_incoming_email
           process_internal
         rescue => e
-          @incoming_email.update_columns(error: e.to_s) if @incoming_email
+          error = e.to_s
+          error = e.class.name if error.blank?
+          @incoming_email.update_columns(error: error) if @incoming_email
           raise
         end
       end

--- a/spec/components/email/receiver_spec.rb
+++ b/spec/components/email/receiver_spec.rb
@@ -69,6 +69,12 @@ describe Email::Receiver do
     expect(IncomingEmail.last.is_bounce).to eq(true)
   end
 
+  it "logs a blank error" do
+    Email::Receiver.any_instance.stubs(:process_internal).raises(RuntimeError, "")
+    process(:existing_user) rescue RuntimeError
+    expect(IncomingEmail.last.error).to eq("RuntimeError")
+  end
+
   context "bounces to VERP" do
 
     let(:bounce_key) { "14b08c855160d67f2e0c2f8ef36e251e" }


### PR DESCRIPTION
Although 407a23663df6c8e66c5c3b8e5cbf21a609de4109 will send rejection
messages for unrecognized errors, sometimes processing the email will
raise an error which has a blank message.

This commit:

1. Shows rejected emails which have already been processed and contain
   a blank error in /admin/email/rejected

2. Replaces new blank error messages with the error type