### PR TITLE
FIX: allow an admin to click on blank errors

### DIFF
--- a/app/serializers/incoming_email_details_serializer.rb
+++ b/app/serializers/incoming_email_details_serializer.rb
@@ -17,7 +17,7 @@ class IncomingEmailDetailsSerializer < ApplicationSerializer
 
   def error
     if @error_string.blank?
-      "Unrecognized Error"
+      I18n.t("emails.incoming.unrecognized_error")
     else
       @error_string
     end

--- a/app/serializers/incoming_email_details_serializer.rb
+++ b/app/serializers/incoming_email_details_serializer.rb
@@ -16,11 +16,7 @@ class IncomingEmailDetailsSerializer < ApplicationSerializer
   EMAIL_RECEIVER_ERROR_PREFIX = "Email::Receiver::".freeze
 
   def error
-    if @error_string.blank?
-      I18n.t("emails.incoming.unrecognized_error")
-    else
-      @error_string
-    end
+    @error_string.presence || I18n.t("emails.incoming.unrecognized_error")
   end
 
   def error_description

--- a/app/serializers/incoming_email_details_serializer.rb
+++ b/app/serializers/incoming_email_details_serializer.rb
@@ -16,7 +16,11 @@ class IncomingEmailDetailsSerializer < ApplicationSerializer
   EMAIL_RECEIVER_ERROR_PREFIX = "Email::Receiver::".freeze
 
   def error
-    @error_string
+    if @error_string.blank?
+      "Unrecognized Error"
+    else
+      @error_string
+    end
   end
 
   def error_description

--- a/app/serializers/incoming_email_serializer.rb
+++ b/app/serializers/incoming_email_serializer.rb
@@ -30,11 +30,7 @@ class IncomingEmailSerializer < ApplicationSerializer
   end
 
   def error
-    if @object.error.blank?
-      I18n.t("emails.incoming.unrecognized_error")
-    else
-      @object.error
-    end
+    @object.error.presence || I18n.t("emails.incoming.unrecognized_error")
   end
 
 end

--- a/app/serializers/incoming_email_serializer.rb
+++ b/app/serializers/incoming_email_serializer.rb
@@ -31,7 +31,7 @@ class IncomingEmailSerializer < ApplicationSerializer
 
   def error
     if @object.error.blank?
-      "Unrecognized Error"
+      I18n.t("emails.incoming.unrecognized_error")
     else
       @object.error
     end

--- a/app/serializers/incoming_email_serializer.rb
+++ b/app/serializers/incoming_email_serializer.rb
@@ -29,4 +29,12 @@ class IncomingEmailSerializer < ApplicationSerializer
     object.cc_addresses.split(";")
   end
 
+  def error
+    if @object.error.blank?
+      "Unrecognized Error"
+    else
+      @object.error
+    end
+  end
+
 end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -78,6 +78,7 @@ en:
         topic_closed_error: "Happens when a reply came in but the related topic has been closed."
         bounced_email_error: "Email is a bounced email report."
         screened_email_error: "Happens when the sender's email address was already screened."
+      unrecognized_error: "Unrecognized Error"
 
   errors: &errors
     format: ! '%{attribute} %{message}'

--- a/spec/components/email/processor_spec.rb
+++ b/spec/components/email/processor_spec.rb
@@ -66,9 +66,9 @@ describe Email::Processor do
       Rails.logger.expects(:error)
 
       Email::Processor.process!(mail)
-      expect(IncomingEmail.first.error).to             eq("boom")
-      expect(IncomingEmail.first.rejection_message).to be_present
-      expect(EmailLog.first.email_type).to             eq("email_reject_unrecognized_error")
+      expect(IncomingEmail.last.error).to             eq("boom")
+      expect(IncomingEmail.last.rejection_message).to be_present
+      expect(EmailLog.last.email_type).to             eq("email_reject_unrecognized_error")
     end
 
     it "sends more than one rejection email per day" do

--- a/spec/controllers/admin/email_controller_spec.rb
+++ b/spec/controllers/admin/email_controller_spec.rb
@@ -86,7 +86,7 @@ describe Admin::EmailController do
       Fabricate(:incoming_email, error: "")
       xhr :get, :rejected
       rejected = JSON.parse(response.body)
-      expect(rejected.first['error']).to eq('Unrecognized Error')
+      expect(rejected.first['error']).to eq(I18n.t("emails.incoming.unrecognized_error"))
     end
   end
 
@@ -95,7 +95,7 @@ describe Admin::EmailController do
       incoming_email = Fabricate(:incoming_email, error: "")
       xhr :get, :incoming, id: incoming_email.id
       incoming = JSON.parse(response.body)
-      expect(incoming['error']).to eq('Unrecognized Error')
+      expect(incoming['error']).to eq(I18n.t("emails.incoming.unrecognized_error"))
     end
   end
 

--- a/spec/controllers/admin/email_controller_spec.rb
+++ b/spec/controllers/admin/email_controller_spec.rb
@@ -81,4 +81,22 @@ describe Admin::EmailController do
     end
   end
 
+  context '.rejected' do
+    it 'should provide a string for a blank error' do
+      Fabricate(:incoming_email, error: "")
+      xhr :get, :rejected
+      rejected = JSON.parse(response.body)
+      expect(rejected.first['error']).to eq('Unrecognized Error')
+    end
+  end
+
+  context '.incoming' do
+    it 'should provide a string for a blank error' do
+      incoming_email = Fabricate(:incoming_email, error: "")
+      xhr :get, :incoming, id: incoming_email.id
+      incoming = JSON.parse(response.body)
+      expect(incoming['error']).to eq('Unrecognized Error')
+    end
+  end
+
 end

--- a/spec/fabricators/incoming_email_fabricator.rb
+++ b/spec/fabricators/incoming_email_fabricator.rb
@@ -1,0 +1,1 @@
+Fabricator(:incoming_email)


### PR DESCRIPTION
Oops, in https://github.com/discourse/discourse/pull/5026 I forgot to show a string in the admin interface for blank errors so they can actually be clicked on and investigated:

![screenshot from 2017-08-04 17-35-12](https://user-images.githubusercontent.com/755354/28977769-4d7a6bb6-793b-11e7-9414-1e557d518956.png)

This fixes that!