### PR TITLE
Edit maxlength categories longer

### DIFF
--- a/app/assets/javascripts/discourse/templates/components/edit-category-general.hbs
+++ b/app/assets/javascripts/discourse/templates/components/edit-category-general.hbs
@@ -2,7 +2,7 @@
   <section class='field'>
     <section class="field-item">
       <label>{{i18n 'category.name'}}</label>
-      {{text-field value=category.name placeholderKey="category.name_placeholder" maxlength="50"}}
+      {{text-field value=category.name placeholderKey="category.name_placeholder" maxlength="60"}}
     </section>
     <section class="field-item">
       <label>{{i18n 'category.slug'}}</label>


### PR DESCRIPTION
I change maxlength categories from 50 to 60. Maxlength="50" so short for some website. Please accept my pull. Thank you!