### PR TITLE
UX: exclude irrelevant search filters for anonymous users

### DIFF
--- a/app/assets/javascripts/discourse/components/search-advanced-options.js.es6
+++ b/app/assets/javascripts/discourse/components/search-advanced-options.js.es6
@@ -30,12 +30,14 @@ const IN_OPTIONS_MAPPING = {'images': 'with'};
 export default Em.Component.extend({
   classNames: ['search-advanced-options'],
 
-  inOptions: [
+  inOptionsForUsers: [
     {name: I18n.t('search.advanced.filters.unseen'),  value: "unseen"},
     {name: I18n.t('search.advanced.filters.posted'),    value: "posted"},
     {name: I18n.t('search.advanced.filters.watching'),  value: "watching"},
     {name: I18n.t('search.advanced.filters.tracking'),  value: "tracking"},
     {name: I18n.t('search.advanced.filters.bookmarks'), value: "bookmarks"},
+  ],
+  inOptionsForAll: [
     {name: I18n.t('search.advanced.filters.first'),     value: "first"},
     {name: I18n.t('search.advanced.filters.pinned'),    value: "pinned"},
     {name: I18n.t('search.advanced.filters.unpinned'),  value: "unpinned"},
@@ -91,7 +93,8 @@ export default Em.Component.extend({
           when: 'before',
           days: ''
         }
-      }
+      },
+      inOptions: this.currentUser ? this.inOptionsForUsers.concat(this.inOptionsForAll) : this.inOptionsForAll
     });
   },
 

--- a/app/assets/javascripts/discourse/templates/components/search-advanced-options.hbs
+++ b/app/assets/javascripts/discourse/templates/components/search-advanced-options.hbs
@@ -53,11 +53,13 @@
   <div class="control-group pull-left">
     <label class="control-label" for="search-in-options">{{i18n "search.advanced.filters.label"}}</label>
     <div class="controls">
-      <section class='field'>
-        <label>{{input type="checkbox" class="in-likes" checked=searchedTerms.special.in.likes}} {{i18n "search.advanced.filters.likes"}}</label>
-        <label>{{input type="checkbox" class="in-private" checked=searchedTerms.special.in.private}} {{i18n "search.advanced.filters.private"}}</label>
-        <label>{{input type="checkbox" class="in-seen" checked=searchedTerms.special.in.seen}} {{i18n "search.advanced.filters.seen"}}</label>
-      </section>
+      {{#if currentUser}}
+        <section class='field'>
+          <label>{{input type="checkbox" class="in-likes" checked=searchedTerms.special.in.likes}} {{i18n "search.advanced.filters.likes"}}</label>
+          <label>{{input type="checkbox" class="in-private" checked=searchedTerms.special.in.private}} {{i18n "search.advanced.filters.private"}}</label>
+          <label>{{input type="checkbox" class="in-seen" checked=searchedTerms.special.in.seen}} {{i18n "search.advanced.filters.seen"}}</label>
+        </section>
+      {{/if}}
       {{combo-box id="in" valueAttribute="value" content=inOptions value=searchedTerms.in none="user.locale.any"}}
     </div>
   </div>

--- a/test/javascripts/acceptance/search-full-test.js.es6
+++ b/test/javascripts/acceptance/search-full-test.js.es6
@@ -1,6 +1,7 @@
 import { acceptance, waitFor } from "helpers/qunit-helpers";
 acceptance("Search - Full Page", {
   settings: {tagging_enabled: true},
+  loggedIn: true,
   beforeEach() {
     const response = (object) => {
       return [

--- a/test/javascripts/acceptance/search-test.js.es6
+++ b/test/javascripts/acceptance/search-test.js.es6
@@ -74,52 +74,48 @@ QUnit.test("Search with context", assert => {
   });
 });
 
-QUnit.test("in:likes, in:private, and in:seen filters are hidden to anonymous users", assert => {
+QUnit.test("Right filters are shown to anonymous users", assert => {
   visit("/search?expanded=true");
 
   andThen(() => {
+    assert.ok(exists('select#in option[value=first]'));
+    assert.ok(exists('select#in option[value=pinned]'));
+    assert.ok(exists('select#in option[value=unpinned]'));
+    assert.ok(exists('select#in option[value=wiki]'));
+    assert.ok(exists('select#in option[value=images]'));
+
+    assert.notOk(exists('select#in option[value=unseen]'));
+    assert.notOk(exists('select#in option[value=posted]'));
+    assert.notOk(exists('select#in option[value=watching]'));
+    assert.notOk(exists('select#in option[value=tracking]'));
+    assert.notOk(exists('select#in option[value=bookmarks]'));
+
     assert.notOk(exists('.search-advanced-options .in-likes'));
     assert.notOk(exists('.search-advanced-options .in-private'));
     assert.notOk(exists('.search-advanced-options .in-seen'));
   });
 });
 
-QUnit.test("in:likes, in:private, and in:seen filters are available to logged in users", assert => {
+QUnit.test("Right filters are shown to logged-in users", assert => {
   logIn();
   Discourse.reset();
   visit("/search?expanded=true");
 
   andThen(() => {
-    assert.ok(exists('.search-advanced-options .in-likes'));
-    assert.ok(exists('.search-advanced-options .in-private'));
-    assert.ok(exists('.search-advanced-options .in-seen'));
-  });
-});
+    assert.ok(exists('select#in option[value=first]'));
+    assert.ok(exists('select#in option[value=pinned]'));
+    assert.ok(exists('select#in option[value=unpinned]'));
+    assert.ok(exists('select#in option[value=wiki]'));
+    assert.ok(exists('select#in option[value=images]'));
 
-QUnit.test(`"I've not read", "I posted in", "I'm watching", "I'm tracking",
-            "I've bookmarked" filters are hidden to anonymous users from the dropdown`, assert => {
-  visit("/search?expanded=true");
-
-  andThen(() => {
-    assert.notOk(exists('select#in option[value=unseen]'));
-    assert.notOk(exists('select#in option[value=posted]'));
-    assert.notOk(exists('select#in option[value=watching]'));
-    assert.notOk(exists('select#in option[value=tracking]'));
-    assert.notOk(exists('select#in option[value=bookmarks]'));
-  });
-});
-
-QUnit.test(`"I've not read", "I posted in", "I'm watching", "I'm tracking",
-            "I've bookmarked" filters are available to logged in users in the dropdown`, assert => {
-  logIn();
-  Discourse.reset();
-  visit("/search?expanded=true");
-
-  andThen(() => {
     assert.ok(exists('select#in option[value=unseen]'));
     assert.ok(exists('select#in option[value=posted]'));
     assert.ok(exists('select#in option[value=watching]'));
     assert.ok(exists('select#in option[value=tracking]'));
     assert.ok(exists('select#in option[value=bookmarks]'));
+
+    assert.ok(exists('.search-advanced-options .in-likes'));
+    assert.ok(exists('.search-advanced-options .in-private'));
+    assert.ok(exists('.search-advanced-options .in-seen'));
   });
 });

--- a/test/javascripts/acceptance/search-test.js.es6
+++ b/test/javascripts/acceptance/search-test.js.es6
@@ -1,4 +1,4 @@
-import { acceptance } from "helpers/qunit-helpers";
+import { acceptance, logIn } from "helpers/qunit-helpers";
 acceptance("Search");
 
 QUnit.test("search", (assert) => {
@@ -71,5 +71,55 @@ QUnit.test("Search with context", assert => {
 
   andThen(() => {
     assert.ok(!$('.search-context input[type=checkbox]').is(":checked"));
+  });
+});
+
+QUnit.test("in:likes, in:private, and in:seen filters are hidden to anonymous users", assert => {
+  visit("/search?expanded=true");
+
+  andThen(() => {
+    assert.notOk(exists('.search-advanced-options .in-likes'));
+    assert.notOk(exists('.search-advanced-options .in-private'));
+    assert.notOk(exists('.search-advanced-options .in-seen'));
+  });
+});
+
+QUnit.test("in:likes, in:private, and in:seen filters are available to logged in users", assert => {
+  logIn();
+  Discourse.reset();
+  visit("/search?expanded=true");
+
+  andThen(() => {
+    assert.ok(exists('.search-advanced-options .in-likes'));
+    assert.ok(exists('.search-advanced-options .in-private'));
+    assert.ok(exists('.search-advanced-options .in-seen'));
+  });
+});
+
+QUnit.test(`"I've not read", "I posted in", "I'm watching", "I'm tracking",
+            "I've bookmarked" filters are hidden to anonymous users from the dropdown`, assert => {
+  visit("/search?expanded=true");
+
+  andThen(() => {
+    assert.notOk(exists('select#in option[value=unseen]'));
+    assert.notOk(exists('select#in option[value=posted]'));
+    assert.notOk(exists('select#in option[value=watching]'));
+    assert.notOk(exists('select#in option[value=tracking]'));
+    assert.notOk(exists('select#in option[value=bookmarks]'));
+  });
+});
+
+QUnit.test(`"I've not read", "I posted in", "I'm watching", "I'm tracking",
+            "I've bookmarked" filters are available to logged in users in the dropdown`, assert => {
+  logIn();
+  Discourse.reset();
+  visit("/search?expanded=true");
+
+  andThen(() => {
+    assert.ok(exists('select#in option[value=unseen]'));
+    assert.ok(exists('select#in option[value=posted]'));
+    assert.ok(exists('select#in option[value=watching]'));
+    assert.ok(exists('select#in option[value=tracking]'));
+    assert.ok(exists('select#in option[value=bookmarks]'));
   });
 });


### PR DESCRIPTION
> This PR tries to resolve https://meta.discourse.org/t/hide-i-liked-ive-read-etc-from-advanced-search-for-anonymous-users/64816.

---

On the advanced search page, filters like "I've read", "I'm watching", etc, are irrelevant to anonymous users and should be hidden.

Open to suggestions, cheers!

---

**For authorized users:**
<img width="600" alt="authorized_user" src="https://user-images.githubusercontent.com/6376558/29064882-6acb5fee-7bf8-11e7-9951-5227c22b8158.png">

**For anonymous users:**
<img width="600" alt="anonymous_user" src="https://user-images.githubusercontent.com/6376558/29064888-6f9cfc8a-7bf8-11e7-9a9a-e2f92cb7ee04.png">
