### PR TITLE
Add image to whitelisted SVG elements

### DIFF
--- a/lib/upload_creator.rb
+++ b/lib/upload_creator.rb
@@ -8,8 +8,8 @@ class UploadCreator
   TYPES_TO_CROP ||= %w{avatar card_background custom_emoji profile_background}.each(&:freeze)
 
   WHITELISTED_SVG_ELEMENTS ||= %w{
-    circle clippath defs ellipse g line linearGradient path polygon polyline
-    radialGradient rect stop svg text textpath tref tspan use
+    circle clippath defs ellipse g image line linearGradient path polygon
+    polyline radialGradient rect stop svg text textpath tref tspan use
   }.each(&:freeze)
 
   # Available options


### PR DESCRIPTION
This allows SVG images containing embedded images to be rendered correctly.