### PR TITLE
Scroll is tracked on search page.

### DIFF
--- a/app/assets/javascripts/discourse/components/scroll-tracker.js.es6
+++ b/app/assets/javascripts/discourse/components/scroll-tracker.js.es6
@@ -1,0 +1,41 @@
+import Scrolling from 'discourse/mixins/scrolling';
+
+export default Ember.Component.extend(Scrolling, {
+
+  didReceiveAttrs() {
+    this._super();
+
+    this.set('trackerName', `scroll-tracker-${this.get('name')}`);
+  },
+
+  didInsertElement() {
+    this._super();
+
+    this.bindScrolling({ name: this.get('name') });
+  },
+
+  didRender() {
+    this._super();
+
+    const data = this.session.get(this.get('trackerName'));
+    if (data && data.position >= 0 && data.tag === this.get('tag')) {
+      Ember.run.next(() => $(window).scrollTop(data.position + 1));
+    }
+  },
+
+  willDestroyElement() {
+    this._super();
+
+    this.unbindScrolling(this.get('name'));
+  },
+
+  scrolled() {
+    this._super();
+
+    this.session.set(this.get('trackerName'), {
+      position: $(window).scrollTop(),
+      tag: this.get('tag'),
+    });
+  },
+
+});

--- a/app/assets/javascripts/discourse/templates/full-page-search.hbs
+++ b/app/assets/javascripts/discourse/templates/full-page-search.hbs
@@ -1,4 +1,5 @@
 {{#d-section pageClass="search" class="search-container"}}
+  {{scroll-tracker name="full-page-search" tag=searchTerm}}
   <div class="search row clearfix">
     {{search-text-field value=searchTerm class="full-page-search input-xxlarge search no-blur" action="search" hasAutofocus=hasAutofocus}}
     {{d-button action="search" icon="search" class="btn-primary" disabled=searching}}


### PR DESCRIPTION
Hello,

I implemented a new component "scroll-tracker" that is meant to be used to track position on a page. This component has two attributes: the name - which is mandatory and is a unique key; a tag - which is a value that is used to validate previous scrolling value.

In my case, the search term is going to be tag. Let's say I search for 'A' and I navigate until the middle of the page. After that, I search for 'B' and it will set the scroll position to the previous one, something that should not happen.

Many thanks to @jjaffeux for his help.