### PR TITLE
FEATURE: record edit revisions on queued posts

### DIFF
--- a/app/assets/javascripts/discourse/templates/components/queued-post.hbs
+++ b/app/assets/javascripts/discourse/templates/components/queued-post.hbs
@@ -66,6 +66,14 @@
                    icon="times"
                    disabled=post.isSaving
                    class="btn-danger cancel"}}
+
+        {{#if showEditReason}}
+          {{text-field value=buffered.edit_reason
+                       maxlength="255"
+                       placeholderKey="composer.edit_reason_placeholder"}}
+        {{else}}
+          <a {{action "displayEditReason"}} class="display-edit-reason">{{i18n 'composer.show_edit_reason'}}</a>
+        {{/if}}
       {{else}}
         {{d-button action="approve"
                    disabled=post.isSaving

--- a/app/assets/stylesheets/desktop/queued-posts.scss
+++ b/app/assets/stylesheets/desktop/queued-posts.scss
@@ -14,6 +14,10 @@
        span {color: dark-light-choose($primary-medium, $secondary-medium); }
      }
 
+    .body {
+      margin: 0.5em 0;
+    }
+
     .cooked {
       width: $topic-body-width;
       float: left;
@@ -28,6 +32,10 @@
       button {
         float: left;
         margin-right: 0.5em;
+      }
+
+      .display-edit-reason {
+        line-height: 30px;
       }
     }
     .post-title {

--- a/app/models/queued_post.rb
+++ b/app/models/queued_post.rb
@@ -74,7 +74,7 @@ class QueuedPost < ActiveRecord::Base
     ) if revised?
 
     transaction do
-      UserBlocker.unsilence(user, approved_by) if user.silenced?
+      UserSilencer.unsilence(user, approved_by) if user.silenced?
       change_to!(:approved, approved_by)
     end
   rescue

--- a/app/models/queued_post.rb
+++ b/app/models/queued_post.rb
@@ -40,6 +40,10 @@ class QueuedPost < ActiveRecord::Base
     QueuedPost.visible_queues.include?(queue)
   end
 
+  def revised?
+    post_options['changes'].present?
+  end
+
   def self.broadcast_new!
     msg = { post_queue_new_count: QueuedPost.new_count }
     MessageBus.publish('/queue_counts', msg, user_ids: User.staff.pluck(:id))
@@ -63,6 +67,7 @@ class QueuedPost < ActiveRecord::Base
     created_post = nil
 
     creator = PostCreator.new(user, create_options.merge(skip_validations: true, skip_jobs: true))
+    revisor = nil
     QueuedPost.transaction do
       change_to!(:approved, approved_by)
 
@@ -73,10 +78,22 @@ class QueuedPost < ActiveRecord::Base
       unless created_post && creator.errors.blank?
         raise StandardError.new(creator.errors.full_messages.join(" "))
       end
+
+      if revised?
+        revisor = PostRevisor.new(created_post)
+        revisor.revise!(
+          User.find(post_options['changes']['editor_id']),
+          post_options['changes'],
+          skip_validations: true,
+          skip_jobs: true,
+          force_new_version: true
+        )
+      end
     end
 
     # Do sidekiq work outside of the transaction
     creator.enqueue_jobs
+    revisor.post_process_post if revised?
 
     DiscourseEvent.trigger(:approved_post, self, created_post)
     created_post

--- a/app/serializers/queued_post_serializer.rb
+++ b/app/serializers/queued_post_serializer.rb
@@ -11,7 +11,8 @@ class QueuedPostSerializer < ApplicationSerializer
              :post_options,
              :created_at,
              :category_id,
-             :can_delete_user
+             :can_delete_user,
+             :revised?
 
   has_one :user, serializer: AdminUserListSerializer
   has_one :topic, serializer: BasicTopicSerializer

--- a/lib/post_creator.rb
+++ b/lib/post_creator.rb
@@ -80,7 +80,7 @@ class PostCreator
   end
 
   def guardian
-    @guardian ||= Guardian.new(@user)
+    @guardian ||= Guardian.new(@opts[:acting_user] || @user)
   end
 
   def valid?

--- a/lib/post_revisor.rb
+++ b/lib/post_revisor.rb
@@ -111,12 +111,6 @@ class PostRevisor
   # - bypass_bump: do not bump the topic, even if last post
   # - skip_validations: ask ActiveRecord to skip validations
   # - skip_revision: do not create a new PostRevision record
-  # - skip_jobs: Don't enqueue jobs when revision succeeds. This is needed if you
-  #              wrap `PostRevisor` in a transaction, as the sidekiq jobs could
-  #              dequeue before the commit finishes which leads to corrupt state.
-  #              If you do this, be sure to call `post_process_post` after the
-  #              transaction is comitted.
-
   def revise!(editor, fields, opts = {})
     @editor = editor
     @fields = fields.with_indifferent_access
@@ -172,7 +166,7 @@ class PostRevisor
     # WARNING: do not pull this into the transaction
     # it can fire events in sidekiq before the post is done saving
     # leading to corrupt state
-    post_process_post unless @opts[:skip_jobs]
+    post_process_post
 
     update_topic_word_counts
     alert_users

--- a/lib/post_revisor.rb
+++ b/lib/post_revisor.rb
@@ -111,6 +111,12 @@ class PostRevisor
   # - bypass_bump: do not bump the topic, even if last post
   # - skip_validations: ask ActiveRecord to skip validations
   # - skip_revision: do not create a new PostRevision record
+  # - skip_jobs: Don't enqueue jobs when revision succeeds. This is needed if you
+  #              wrap `PostRevisor` in a transaction, as the sidekiq jobs could
+  #              dequeue before the commit finishes which leads to corrupt state.
+  #              If you do this, be sure to call `post_process_post` after the
+  #              transaction is comitted.
+
   def revise!(editor, fields, opts = {})
     @editor = editor
     @fields = fields.with_indifferent_access
@@ -166,7 +172,7 @@ class PostRevisor
     # WARNING: do not pull this into the transaction
     # it can fire events in sidekiq before the post is done saving
     # leading to corrupt state
-    post_process_post
+    post_process_post unless @opts[:skip_jobs]
 
     update_topic_word_counts
     alert_users

--- a/plugins/poll/spec/lib/new_post_manager_spec.rb
+++ b/plugins/poll/spec/lib/new_post_manager_spec.rb
@@ -28,7 +28,7 @@ describe NewPostManager do
       queued_post = QueuedPost.last
       queued_post.approve!(admin)
 
-      expect(Post.last.custom_fields[DiscoursePoll::POLLS_CUSTOM_FIELD])
+      expect(user.posts.last.custom_fields[DiscoursePoll::POLLS_CUSTOM_FIELD])
         .to_not eq(nil)
     end
   end

--- a/spec/models/queued_post_spec.rb
+++ b/spec/models/queued_post_spec.rb
@@ -192,15 +192,15 @@ describe QueuedPost do
     end
   end
 
-  context 'approving a post by a blocked user' do
-    let(:blocked_user) { Fabricate(:user, blocked: true) }
+  context 'approving a post by a silenced user' do
+    let(:silenced_user) { Fabricate(:user, silenced_till: 1.year.from_now) }
     let(:admin) { Fabricate(:admin) }
-    let(:qp) { Fabricate(:queued_post, user: blocked_user) }
+    let(:qp) { Fabricate(:queued_post, user: silenced_user) }
 
-    it 'unblocks a blocked user' do
+    it 'unsilence a silenced user' do
       expect {
         qp.approve!(admin)
-      }.to change { blocked_user.blocked? }.from(true).to(false)
+      }.to change { silenced_user.silenced? }.from(true).to(false)
     end
   end
   context "visibility" do

--- a/spec/models/queued_post_spec.rb
+++ b/spec/models/queued_post_spec.rb
@@ -192,6 +192,17 @@ describe QueuedPost do
     end
   end
 
+  context 'approving a post by a blocked user' do
+    let(:blocked_user) { Fabricate(:user, blocked: true) }
+    let(:admin) { Fabricate(:admin) }
+    let(:qp) { Fabricate(:queued_post, user: blocked_user) }
+
+    it 'unblocks a blocked user' do
+      expect {
+        qp.approve!(admin)
+      }.to change { blocked_user.blocked? }.from(true).to(false)
+    end
+  end
   context "visibility" do
     it "works as expected in the invisible queue" do
       qp = Fabricate(:queued_post, queue: 'invisible')

--- a/test/javascripts/acceptance/queued-posts-test.js.es6
+++ b/test/javascripts/acceptance/queued-posts-test.js.es6
@@ -25,7 +25,6 @@ QUnit.test("For topics: body of post, title, category and tags are all editbale"
   });
 });
 
-
 QUnit.test("For replies: only the body of post is editbale", assert => {
   server.get("/queued_posts", () => { //eslint-disable-line no-undef
     return [
@@ -43,5 +42,24 @@ QUnit.test("For replies: only the body of post is editbale", assert => {
     assert.notOk(exists(".edit-title .ember-text-field"), "title should not be editbale");
     assert.notOk(exists(".category-chooser"), "category should not be editable");
     assert.notOk(exists("div.tag-chooser"), "tags should not be editable");
+  });
+});
+
+QUnit.test("revised content should be shown if provided", assert => {
+  server.get("/queued_posts", () => { //eslint-disable-line no-undef
+    return [
+      200,
+      {"Content-Type": "application/json"},
+      {"users":[{"id":3,"username":"test_user","avatar_template":"/letter_avatar_proxy/v2/letter/t/eada6e/{size}.png","active":true,"admin":false,"moderator":false,"last_seen_at":"2017-08-15T19:11:58.078Z","last_emailed_at":null,"created_at":"2017-08-07T02:23:33.309Z","last_seen_age":"1m","last_emailed_age":null,"created_at_age":"9d","username_lower":"test_user","trust_level":0,"trust_level_locked":false,"flag_level":0,"title":null,"suspended_at":null,"suspended_till":null,"suspended":null,"blocked":false,"time_read":"33m","staged":false,"days_visited":5,"posts_read_count":26,"topics_entered":8,"post_count":14}],"topics":[],"queued_posts":[{"id":37,"queue":"default","user_id":3,"state":1,"topic_id":null,"approved_by_id":null,"rejected_by_id":null,"raw":"original content","post_options":{"archetype":"regular","category":"17","typing_duration_msecs":"3000","composer_open_duration_msecs":"18425","visible":true,"is_warning":false,"title":"original title","tags":["original"],"first_post_checks":true,"is_poll":true,"changes":{"raw":"new content","title":"new title","category_id":3,"tags":["edited"],"editor_id":1}},"created_at":"2017-08-15T19:12:24.310Z","category_id":1,"can_delete_user":true,"revised":true}],"__rest_serializer":"1","refresh_queued_posts":"/queued_posts?status=new"}
+    ];
+  });
+
+  visit("/queued-posts");
+
+  andThen(() => {
+    assert.ok(exists(".body:contains('new content')"), "the revised body of the post should be shown");
+    assert.ok(exists(".post-title:contains('new title')"), "the revised title should be shown");
+    assert.ok(exists(".badge-category:contains('meta')"), "the revised category should be shown");
+    assert.ok(exists(".tag-edited:contains('edited')"), "the revised tag should be shown");
   });
 });


### PR DESCRIPTION
> **Discussion & Screenshots:** https://meta.discourse.org/t/ability-to-change-the-category-of-a-post-before-approving/66754/8?u=xrav3nz

Since we already store complete revisions for regular post edits, why not for queued post edits as well? ;)

This PR utilizes `PostCreator` and `PostRevisor`:

- All edits by staff is recorded to `queued_post.post_options[:changes]`. 
- When approving a pending queued post, `PostCreator` creates a post with the original content, then `PostRevisor` revises the post to reflect the latest changes and creates a `PostRevision`. 
- ~~Post creation and revision are both wrapped in a transaction while relevant processing jobs are only queued upon success.~~ Post creation and revision are take out of the transaction block: 8813b4d.

----

This adds quite a bit of complexity to the current posts approval flow. Open to suggestions on possible ways to simplify the process and/or improve testing. Cheers 

