### PR TITLE
fixes word wrap issue on user activity page

### DIFF
--- a/app/assets/stylesheets/desktop/user.scss
+++ b/app/assets/stylesheets/desktop/user.scss
@@ -92,6 +92,11 @@
 .user-table {
   margin-top: 30px;
   width: 100%;
+  display: table;
+  table-layout: fixed;
+  .wrapper {
+    display: table-row;
+  }
 }
 
 .user-navigation .nav-stacked .glyph {


### PR DESCRIPTION
> DISCUSSION & SCREENSHOTS: https://meta.discourse.org/t/long-words-not-wrapping-in-user-activity-page/68181

By default, the width of a table and its cells are adjusted to fit the content. Thus, longer words are not wrapped and lead to a wider width.