### PR TITLE
fixes overflowing div width on user activity page

### DIFF
--- a/app/assets/stylesheets/desktop/user.scss
+++ b/app/assets/stylesheets/desktop/user.scss
@@ -143,7 +143,6 @@
    }
 
   .user-right {
-    width: 900px;
     display: table-cell;
   }
 


### PR DESCRIPTION
My last PR (https://github.com/discourse/discourse/pull/5056) caused a regression:

> Hmm [#5056] regressed on iPad, now it is exceeding the available space and making everything tiny.
> -- @coding-horror, [on meta](https://meta.discourse.org/t/long-words-not-wrapping-in-user-activity-page/68181/7?u=xrav3nz).

Detailed explanation of the fix and why it works: https://meta.discourse.org/t/long-words-not-wrapping-in-user-activity-page/68181/8?u=xrav3nz