### PR TITLE
Extend config/version.rb with more informations

### DIFF
--- a/lib/discourse_updates.rb
+++ b/lib/discourse_updates.rb
@@ -7,7 +7,7 @@ module DiscourseUpdates
         DiscourseVersionCheck.new(
           installed_version: Discourse::VERSION::STRING,
           installed_sha: (Discourse.git_version == 'unknown' ? nil : Discourse.git_version),
-          installed_describe: `git describe --dirty --match "v[0-9]*"`,
+          installed_describe: Discourse.full_version,
           git_branch: Discourse.git_branch,
           updated_at: nil
         )
@@ -17,7 +17,7 @@ module DiscourseUpdates
           critical_updates: critical_updates_available?,
           installed_version: Discourse::VERSION::STRING,
           installed_sha: (Discourse.git_version == 'unknown' ? nil : Discourse.git_version),
-          installed_describe: `git describe --dirty --match "v[0-9]*"`,
+          installed_describe: Discourse.full_version,
           missing_versions_count: missing_versions_count,
           git_branch: Discourse.git_branch,
           updated_at: updated_at

--- a/lib/tasks/build.rake
+++ b/lib/tasks/build.rake
@@ -1,8 +1,13 @@
 desc "stamp the current build with the git hash placed in version.rb"
 task "build:stamp" => :environment do
-  git_version = `git rev-parse HEAD`.strip
+  git_version  = `git rev-parse HEAD`.strip
+  git_branch   = `git rev-parse --abbrev-ref HEAD`
+  full_version = `git describe --dirty --match "v[0-9]*"`
+
   File.open(Rails.root.to_s + '/config/version.rb', 'w') do |f|
-    f.write("$git_version = #{git_version.inspect}\n")
+    f.write("$git_version  = #{git_version.inspect}\n")
+    f.write("$git_branch   = #{git_branch.inspect}\n")
+    f.write("$full_version = #{full_version.inspect}\n")
   end
-  puts "Stamped current build with #{git_version}"
+  puts "Stamped current build with #{git_version} #{git_branch} #{full_version}"
 end


### PR DESCRIPTION
This gives installations not using git checkouts
to provide all the informations needed for the
internal version checks and version display in
the dashboard.

The build:stamp rake task was extended to also
add the new informations.