### PR TITLE
Show the select badge button only once.

### DIFF
--- a/app/assets/javascripts/discourse/templates/badges/show.hbs
+++ b/app/assets/javascripts/discourse/templates/badges/show.hbs
@@ -13,14 +13,12 @@
           <div class='grant-info-item'>
             {{i18n 'badges.allow_title'}}
             {{#if userBadges}}
-              {{#each userBadges as |ub|}}
-                {{#if model.allow_title}}
-                  {{d-button
-                      class='btn btn-small pad-left no-text'
-                      action='toggleSetUserTitle'
-                      icon='pencil'}}
-                {{/if}}
-              {{/each}}
+              {{#if model.allow_title}}
+                {{d-button
+                    class='btn btn-small pad-left no-text'
+                    action='toggleSetUserTitle'
+                    icon='pencil'}}
+              {{/if}}
             {{/if}}
           </div>
         {{/if}}


### PR DESCRIPTION
This was a pretty stupid mistake.