### PR TITLE
Docker lint SINGLE_PLUGIN

### DIFF
--- a/lib/tasks/docker.rake
+++ b/lib/tasks/docker.rake
@@ -35,11 +35,18 @@ end
 
 desc 'Run JS and Ruby linters'
 task 'docker:lint' do
-  success = run_or_fail("bundle exec rubocop --parallel")
-  success = run_or_fail("eslint app/assets/javascripts test/javascripts")
-  success = run_or_fail("eslint --ext .es6 app/assets/javascripts test/javascripts plugins")
+  success = true
 
-  exit 1 if !success
+  if ENV["SINGLE_PLUGIN"]
+    success &&= run_or_fail("bundle exec rubocop --parallel plugins/#{ENV["SINGLE_PLUGIN"]}")
+    success &&= run_or_fail("eslint --ext .es6 plugins/#{ENV['SINGLE_PLUGIN']}")
+  else
+    success &&= run_or_fail("bundle exec rubocop --parallel") unless ENV["SKIP_CORE"]
+    success &&= run_or_fail("eslint app/assets/javascripts test/javascripts") unless ENV["SKIP_CORE"]
+    success &&= run_or_fail("eslint --ext .es6 app/assets/javascripts test/javascripts plugins") unless ENV["SKIP_PLUGINS"]
+  end
+
+  exit 1 unless success
 end
 
 desc 'Run all tests (JS and code in a standalone environment)'

--- a/lib/tasks/docker.rake
+++ b/lib/tasks/docker.rake
@@ -2,6 +2,8 @@
 # running it anywhere else will likely fail
 #
 # Environment Variables (specific to this rake task)
+# => SKIP_LINT                 set to 1 to skip linting (eslint and rubocop)
+# => SKIP_TESTS                set to 1 to skip all tests
 # => SKIP_CORE                 set to 1 to skip core tests (rspec and qunit)
 # => SKIP_PLUGINS              set to 1 to skip plugin tests (rspec and qunit)
 # => INSTALL_OFFICIAL_PLUGINS  set to 1 to install all core plugins before running tests
@@ -14,8 +16,6 @@
 # Other useful environment variables (not specific to this rake task)
 # => COMMIT_HASH    used by the discourse_test docker image to load a specific commit of discourse
 #                   this can also be set to a branch, e.g. "origin/tests-passed"
-# => SKIP_LINT      if using the discourse_test docker image, this will skip the docker:test task, and only run the docker:lint task
-# => LINT_ONLY      if using the discourse_test docker image, this will skip the docker:lint task, and only run the docker:test task
 #
 # Example usage:
 #   Run all core and plugin tests:
@@ -33,97 +33,95 @@ def run_or_fail(command)
   $?.exitstatus == 0
 end
 
-desc 'Run JS and Ruby linters'
-task 'docker:lint' do
-  success = true
-
-  if ENV["SINGLE_PLUGIN"]
-    success &&= run_or_fail("bundle exec rubocop --parallel plugins/#{ENV["SINGLE_PLUGIN"]}")
-    success &&= run_or_fail("eslint --ext .es6 plugins/#{ENV['SINGLE_PLUGIN']}")
-  else
-    success &&= run_or_fail("bundle exec rubocop --parallel") unless ENV["SKIP_CORE"]
-    success &&= run_or_fail("eslint app/assets/javascripts test/javascripts") unless ENV["SKIP_CORE"]
-    success &&= run_or_fail("eslint --ext .es6 app/assets/javascripts test/javascripts plugins") unless ENV["SKIP_PLUGINS"]
-  end
-
-  exit 1 if !success
-end
-
 desc 'Run all tests (JS and code in a standalone environment)'
 task 'docker:test' do
   begin
-
-    puts "Cleaning up old test tmp data in tmp/test_data"
-    `rm -fr tmp/test_data && mkdir -p tmp/test_data/redis && mkdir tmp/test_data/pg`
-
-    puts "Starting background redis"
-    @redis_pid = Process.spawn('redis-server --dir tmp/test_data/redis')
-
-    @postgres_bin = "/usr/lib/postgresql/9.5/bin/"
-    `#{@postgres_bin}initdb -D tmp/test_data/pg`
-
-    # speed up db, never do this in production mmmmk
-    `echo fsync = off >> tmp/test_data/pg/postgresql.conf`
-    `echo full_page_writes = off >> tmp/test_data/pg/postgresql.conf`
-    `echo shared_buffers = 500MB >> tmp/test_data/pg/postgresql.conf`
-
-    puts "Starting postgres"
-    @pg_pid = Process.spawn("#{@postgres_bin}postmaster -D tmp/test_data/pg")
-
-    ENV["RAILS_ENV"] = "test"
-
-    @good = run_or_fail("bundle exec rake db:create db:migrate")
-
-    if ENV["INSTALL_OFFICIAL_PLUGINS"]
-      @good &&= run_or_fail("bundle exec rake plugin:install_all_official")
+    @good = true
+    unless ENV['SKIP_LINT']
+      puts "Running linters"
+      if ENV["SINGLE_PLUGIN"]
+        @good &&= run_or_fail("bundle exec rubocop --parallel plugins/#{ENV["SINGLE_PLUGIN"]}")
+        @good &&= run_or_fail("eslint --ext .es6 plugins/#{ENV['SINGLE_PLUGIN']}")
+      else
+        @good &&= run_or_fail("bundle exec rubocop --parallel") unless ENV["SKIP_CORE"]
+        @good &&= run_or_fail("eslint app/assets/javascripts test/javascripts") unless ENV["SKIP_CORE"]
+        @good &&= run_or_fail("eslint --ext .es6 app/assets/javascripts test/javascripts plugins") unless ENV["SKIP_PLUGINS"]
+      end
     end
 
-    unless ENV["JS_ONLY"]
+    unless ENV['SKIP_TESTS']
+      puts "Cleaning up old test tmp data in tmp/test_data"
+      `rm -fr tmp/test_data && mkdir -p tmp/test_data/redis && mkdir tmp/test_data/pg`
 
-      unless ENV["SKIP_CORE"]
-        params = []
-        if ENV["BISECT"]
-          params << "--bisect"
-        end
-        if ENV["RSPEC_SEED"]
-          params << "--seed #{ENV["RSPEC_SEED"]}"
-        end
-        @good &&= run_or_fail("bundle exec rspec #{params.join(' ')}".strip)
+      puts "Starting background redis"
+      @redis_pid = Process.spawn('redis-server --dir tmp/test_data/redis')
+
+      @postgres_bin = "/usr/lib/postgresql/9.5/bin/"
+      `#{@postgres_bin}initdb -D tmp/test_data/pg`
+
+      # speed up db, never do this in production mmmmk
+      `echo fsync = off >> tmp/test_data/pg/postgresql.conf`
+      `echo full_page_writes = off >> tmp/test_data/pg/postgresql.conf`
+      `echo shared_buffers = 500MB >> tmp/test_data/pg/postgresql.conf`
+
+      puts "Starting postgres"
+      @pg_pid = Process.spawn("#{@postgres_bin}postmaster -D tmp/test_data/pg")
+
+      ENV["RAILS_ENV"] = "test"
+
+      @good &&= run_or_fail("bundle exec rake db:create db:migrate")
+
+      if ENV["INSTALL_OFFICIAL_PLUGINS"]
+        @good &&= run_or_fail("bundle exec rake plugin:install_all_official")
       end
 
-      unless ENV["SKIP_PLUGINS"]
-        if ENV["SINGLE_PLUGIN"]
-          @good &&= run_or_fail("bundle exec rake plugin:spec['#{ENV["SINGLE_PLUGIN"]}']")
-        else
-          @good &&= run_or_fail("bundle exec rake plugin:spec")
+      unless ENV["JS_ONLY"]
+
+        unless ENV["SKIP_CORE"]
+          params = []
+          if ENV["BISECT"]
+            params << "--bisect"
+          end
+          if ENV["RSPEC_SEED"]
+            params << "--seed #{ENV["RSPEC_SEED"]}"
+          end
+          @good &&= run_or_fail("bundle exec rspec #{params.join(' ')}".strip)
         end
-      end
 
-    end
-
-    unless ENV["RUBY_ONLY"]
-      unless ENV["SKIP_CORE"]
-        @good &&= run_or_fail("bundle exec rake qunit:test['600000']")
-        @good &&= run_or_fail("bundle exec rake qunit:test['600000','/wizard/qunit']")
-      end
-
-      unless ENV["SKIP_PLUGINS"]
-        if ENV["SINGLE_PLUGIN"]
-          @good &&= run_or_fail("bundle exec rake plugin:qunit['#{ENV['SINGLE_PLUGIN']}','600000']")
-        else
-          @good &&= run_or_fail("bundle exec rake plugin:qunit['*','600000']")
+        unless ENV["SKIP_PLUGINS"]
+          if ENV["SINGLE_PLUGIN"]
+            @good &&= run_or_fail("bundle exec rake plugin:spec['#{ENV["SINGLE_PLUGIN"]}']")
+          else
+            @good &&= run_or_fail("bundle exec rake plugin:spec")
+          end
         end
+
       end
 
+      unless ENV["RUBY_ONLY"]
+        unless ENV["SKIP_CORE"]
+          @good &&= run_or_fail("bundle exec rake qunit:test['600000']")
+          @good &&= run_or_fail("bundle exec rake qunit:test['600000','/wizard/qunit']")
+        end
+
+        unless ENV["SKIP_PLUGINS"]
+          if ENV["SINGLE_PLUGIN"]
+            @good &&= run_or_fail("bundle exec rake plugin:qunit['#{ENV['SINGLE_PLUGIN']}','600000']")
+          else
+            @good &&= run_or_fail("bundle exec rake plugin:qunit['*','600000']")
+          end
+        end
+
+      end
     end
 
   ensure
     puts "Terminating"
 
-    Process.kill("TERM", @redis_pid)
-    Process.kill("TERM", @pg_pid)
-    Process.wait @redis_pid
-    Process.wait @pg_pid
+    Process.kill("TERM", @redis_pid) if @redis_pid
+    Process.kill("TERM", @pg_pid) if @pg_pid
+    Process.wait @redis_pid if @redis_pid
+    Process.wait @pg_pid if @pg_pid
   end
 
   if !@good

--- a/lib/tasks/docker.rake
+++ b/lib/tasks/docker.rake
@@ -46,7 +46,7 @@ task 'docker:lint' do
     success &&= run_or_fail("eslint --ext .es6 app/assets/javascripts test/javascripts plugins") unless ENV["SKIP_PLUGINS"]
   end
 
-  exit 1 unless success
+  exit 1 if !success
 end
 
 desc 'Run all tests (JS and code in a standalone environment)'

--- a/lib/tasks/docker.rake
+++ b/lib/tasks/docker.rake
@@ -14,6 +14,8 @@
 # Other useful environment variables (not specific to this rake task)
 # => COMMIT_HASH    used by the discourse_test docker image to load a specific commit of discourse
 #                   this can also be set to a branch, e.g. "origin/tests-passed"
+# => SKIP_LINT      if using the discourse_test docker image, this will skip the docker:test task, and only run the docker:lint task
+# => LINT_ONLY      if using the discourse_test docker image, this will skip the docker:lint task, and only run the docker:test task
 #
 # Example usage:
 #   Run all core and plugin tests:

--- a/script/docker_test.rb
+++ b/script/docker_test.rb
@@ -1,3 +1,12 @@
+# This script is run in the discourse_test docker image
+# Available environment variables:
+# => COMMIT_HASH    used by the discourse_test docker image to load a specific commit of discourse
+#                   this can also be set to a branch, e.g. "origin/tests-passed"
+# => SKIP_LINT      if using the discourse_test docker image, this will skip the docker:test task, and only run the docker:lint task
+# => LINT_ONLY      if using the discourse_test docker image, this will skip the docker:lint task, and only run the docker:test task
+#
+# See lib/tasks/docker.rake for other available environment variables
+
 def run_or_fail(command)
   pid = Process.spawn(command)
   Process.wait(pid)

--- a/script/docker_test.rb
+++ b/script/docker_test.rb
@@ -2,10 +2,7 @@
 # Available environment variables:
 # => COMMIT_HASH    used by the discourse_test docker image to load a specific commit of discourse
 #                   this can also be set to a branch, e.g. "origin/tests-passed"
-# => SKIP_LINT      if using the discourse_test docker image, this will skip the docker:test task, and only run the docker:lint task
-# => LINT_ONLY      if using the discourse_test docker image, this will skip the docker:lint task, and only run the docker:test task
-#
-# See lib/tasks/docker.rake for other available environment variables
+# See lib/tasks/docker.rake for more information
 
 def run_or_fail(command)
   pid = Process.spawn(command)
@@ -21,5 +18,4 @@ unless ENV['NO_UPDATE']
   run_or_fail("bundle")
 end
 
-run_or_fail("bundle exec rake docker:lint") if !ENV["SKIP_LINT"]
-run_or_fail("bundle exec rake docker:test") if !ENV["LINT_ONLY"]
+run_or_fail("bundle exec rake docker:test")


### PR DESCRIPTION
@tgxworld this restores `SINGLE_PLUGIN` functionality to the discourse_test docker image linting after https://github.com/discourse/discourse/commit/8ecf383c557d2ff7dbcd22b4faa942c235d44f2a - I use it for testing plugins on travis and don't really want to be linting the entirety of discourse core every time.

Hope it's ok 😃
