### PR TITLE
last attempt at fixing user page layout

### DIFF
--- a/app/assets/stylesheets/desktop/user.scss
+++ b/app/assets/stylesheets/desktop/user.scss
@@ -19,7 +19,15 @@
 }
 
 .user-preferences {
+  display: table-cell;
+  vertical-align: top;
   padding-top: 10px;
+  padding-left: 30px;
+
+  h3 {
+    color: $primary;
+    margin: 20px 0 10px 0;
+  }
 
   input.category-selector, input.user-selector, input.tag-chooser {
     width: 530px;
@@ -106,7 +114,7 @@
   // position: static;
 }
 
-.user-navigation, .user-preferences {
+.user-navigation {
   display: table-cell;
   vertical-align: top;
   width: 170px;
@@ -143,7 +151,6 @@
    }
 
   .user-right {
-    width: 900px;
     display: table-cell;
   }
 


### PR DESCRIPTION
> CONTEXT: https://meta.discourse.org/t/long-words-not-wrapping-in-user-activity-page/68181

drop the width setting on the right column *completely* so it can adjust on it own.

---

_Yet again_, my last PR broke the user preference page layout... 😢 

**What happened?**

The right column is a `div.user-right.user-preferences`:

<img src="https://user-images.githubusercontent.com/6376558/29482122-35c8fdc4-8459-11e7-9678-1cc3ff26035f.png" width="200px"/>

Turns out it has _two_ different CSS width properties. After dropping `width: 900px` with my last PR, `width: 170px` was secretly applied. This led to the layout problem eviltrout discovered.

---

Many thanks to @davidtaylorhq, who kindly helped me to test the change in various browsers / devices / widths. ❤️ 