### PR TITLE
Password mail with IP addresses.

### DIFF
--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -248,7 +248,7 @@ class SessionController < ApplicationController
     user = User.find_by_username_or_email(params[:login])
     user_presence = user.present? && user.id > 0 && !user.staged
     if user_presence
-      user_agent = request.user_agent || '(unidentified browser)'
+      user_agent = ERB::Util.html_escape(request.user_agent) || '(unidentified browser)'
       email_token = user.email_tokens.create(email: user.email, remote_ip: request.remote_ip, user_agent: user_agent)
       Jobs.enqueue(:critical_user_email, type: :forgot_password, user_id: user.id, email_token: email_token.token)
     end

--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -248,7 +248,7 @@ class SessionController < ApplicationController
     user = User.find_by_username_or_email(params[:login])
     user_presence = user.present? && user.id > 0 && !user.staged
     if user_presence
-      user_agent = ERB::Util.html_escape(request.user_agent) || '(unidentified browser)'
+      user_agent = request.user_agent || '(unidentified browser)'
       email_token = user.email_tokens.create(email: user.email, remote_ip: request.remote_ip, user_agent: user_agent)
       Jobs.enqueue(:critical_user_email, type: :forgot_password, user_id: user.id, email_token: email_token.token)
     end

--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -248,7 +248,8 @@ class SessionController < ApplicationController
     user = User.find_by_username_or_email(params[:login])
     user_presence = user.present? && user.id > 0 && !user.staged
     if user_presence
-      email_token = user.email_tokens.create(email: user.email)
+      user_agent = request.user_agent || '(unidentified browser)'
+      email_token = user.email_tokens.create(email: user.email, remote_ip: request.remote_ip, user_agent: user_agent)
       Jobs.enqueue(:critical_user_email, type: :forgot_password, user_id: user.id, email_token: email_token.token)
     end
 

--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -248,7 +248,7 @@ class SessionController < ApplicationController
     user = User.find_by_username_or_email(params[:login])
     user_presence = user.present? && user.id > 0 && !user.staged
     if user_presence
-      user_agent = request.user_agent || '(unidentified browser)'
+      user_agent = request.user_agent || I18n.t('no_browser_user_agent')
       email_token = user.email_tokens.create(email: user.email, remote_ip: request.remote_ip, user_agent: user_agent)
       Jobs.enqueue(:critical_user_email, type: :forgot_password, user_id: user.id, email_token: email_token.token)
     end

--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -51,7 +51,8 @@ class UserNotifications < ActionMailer::Base
     token_data = EmailToken.where(token: opts[:email_token]).first
     # may not be set, if from before change
     remote_ip = token_data.remote_ip || ''
-    user_agent = token_data.user_agent || ''
+    # force UA not to ever be interpreted as HTML
+    user_agent = token_data.user_agent ? "`#{token_data.user_agent}`" : ''
 
     build_email(user.email,
                 template: user.has_password? ? "user_notifications.forgot_password" : "user_notifications.set_password",

--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -51,15 +51,16 @@ class UserNotifications < ActionMailer::Base
     token_data = EmailToken.where(token: opts[:email_token]).first
     # may not be set, if from before change
     remote_ip = token_data.remote_ip || ''
-    # force UA not to ever be interpreted as HTML
-    user_agent = token_data.user_agent ? "`#{token_data.user_agent}`" : ''
+    user_agent = token_data.user_agent || ''
+    # force UA not to ever be interpreted as HTML or to escape from backticks
+    user_agent.tr!('<>`', '')
 
     build_email(user.email,
                 template: user.has_password? ? "user_notifications.forgot_password" : "user_notifications.set_password",
                 locale: user_locale(user),
                 email_token: opts[:email_token],
 		remote_ip: remote_ip,
-		user_agent: user_agent)
+		user_agent: "`#{user_agent}`")
   end
 
   def admin_login(user, opts = {})

--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -48,12 +48,18 @@ class UserNotifications < ActionMailer::Base
   end
 
   def forgot_password(user, opts = {})
-    token_data = EmailToken.where(token: opts[:email_token]).first
-    # may not be set, if from before change
-    remote_ip = token_data.remote_ip || ''
-    user_agent = token_data.user_agent || ''
-    # force UA not to ever be interpreted as HTML or to escape from backticks
-    user_agent.tr!('<>`', '')
+    remote_ip = I18n.t('no_remote_ip')
+    user_agent = I18n.t('no_browser_user_agent')
+
+    if opts[:email_token] then
+      token_data = EmailToken.where(token: opts[:email_token]).first
+      # may not be set, if from before change
+      remote_ip = token_data.remote_ip if token_data.remote_ip
+      user_agent = token_data.user_agent if token_data.user_agent
+
+      # force UA not to ever be interpreted as HTML or to escape from backticks
+      user_agent.tr!('<>`', '')
+    end
 
     build_email(user.email,
                 template: user.has_password? ? "user_notifications.forgot_password" : "user_notifications.set_password",

--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -59,8 +59,8 @@ class UserNotifications < ActionMailer::Base
                 template: user.has_password? ? "user_notifications.forgot_password" : "user_notifications.set_password",
                 locale: user_locale(user),
                 email_token: opts[:email_token],
-		remote_ip: remote_ip,
-		user_agent: "`#{user_agent}`")
+                remote_ip: remote_ip,
+                user_agent: "`#{user_agent}`")
   end
 
   def admin_login(user, opts = {})

--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -48,10 +48,17 @@ class UserNotifications < ActionMailer::Base
   end
 
   def forgot_password(user, opts = {})
+    token_data = EmailToken.where(token: opts[:email_token]).first
+    # may not be set, if from before change
+    remote_ip = token_data.remote_ip || ''
+    user_agent = token_data.user_agent || ''
+
     build_email(user.email,
                 template: user.has_password? ? "user_notifications.forgot_password" : "user_notifications.set_password",
                 locale: user_locale(user),
-                email_token: opts[:email_token])
+                email_token: opts[:email_token],
+		remote_ip: remote_ip,
+		user_agent: user_agent)
   end
 
   def admin_login(user, opts = {})

--- a/app/models/email_token.rb
+++ b/app/models/email_token.rb
@@ -3,11 +3,10 @@ class EmailToken < ActiveRecord::Base
 
   validates :token, :user_id, :email, presence: true
 
-  attr_accessor :remote_ip, :user_agent
-
   before_validation(on: :create) do
     self.token = EmailToken.generate_token
     self.email = self.email.downcase if self.email
+    self.user_agent = self.user_agent.strip if self.user_agent
   end
 
   after_create do

--- a/app/models/email_token.rb
+++ b/app/models/email_token.rb
@@ -3,6 +3,8 @@ class EmailToken < ActiveRecord::Base
 
   validates :token, :user_id, :email, presence: true
 
+  attr_accessor :remote_ip, :user_agent
+
   before_validation(on: :create) do
     self.token = EmailToken.generate_token
     self.email = self.email.downcase if self.email
@@ -98,6 +100,8 @@ end
 #  token      :string           not null
 #  confirmed  :boolean          default(FALSE), not null
 #  expired    :boolean          default(FALSE), not null
+#  remote_ip  :inet
+#  user_agent :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -55,6 +55,9 @@ en:
   anonymous: "Anonymous"
   remove_posts_deleted_by_author: "Deleted by author"
 
+  no_browser_user_agent: "(unidentified browser)"
+  no_remote_ip: "(unidentified IP address)"
+
   themes:
     bad_color_scheme: "Can not update theme, invalid color scheme"
     other_error: "Something went wrong updating theme"
@@ -2657,7 +2660,7 @@ en:
       text_body_template: |
         Somebody asked to reset your password on [%{site_name}](%{base_url}).
 
-        The request came from %{remote_ip} using "%{user_agent}". If it was not you, you can safely ignore this email.
+        The request came from [%{remote_ip}](https://ipinfo.io/%{remote_ip}) using "%{user_agent}". If it was not you, you can safely ignore this email.
 
         Click the following link to choose a new password:
         %{base_url}/u/password-reset/%{email_token}

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2657,7 +2657,7 @@ en:
       text_body_template: |
         Somebody asked to reset your password on [%{site_name}](%{base_url}).
 
-	The request came from %{remote_ip} using "%{user_agent}". If it was not you, you can safely ignore this email.
+        The request came from %{remote_ip} using "%{user_agent}". If it was not you, you can safely ignore this email.
 
         Click the following link to choose a new password:
         %{base_url}/u/password-reset/%{email_token}
@@ -2668,7 +2668,7 @@ en:
       text_body_template: |
         Somebody asked to add a password to your account on [%{site_name}](%{base_url}). Alternatively, you can log in using any supported online service (Google, Facebook, etc) that is associated with this validated email address.
 
-	The request came from %{remote_ip} using "%{user_agent}". If it was not you, you can safely ignore this email.
+        The request came from %{remote_ip} using "%{user_agent}". If it was not you, you can safely ignore this email.
 
         Click the following link to choose a password:
         %{base_url}/u/password-reset/%{email_token}

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2657,7 +2657,7 @@ en:
       text_body_template: |
         Somebody asked to reset your password on [%{site_name}](%{base_url}).
 
-        If it was not you, you can safely ignore this email.
+	The request came from %{remote_ip} using "%{user_agent}". If it was not you, you can safely ignore this email.
 
         Click the following link to choose a new password:
         %{base_url}/u/password-reset/%{email_token}
@@ -2668,7 +2668,7 @@ en:
       text_body_template: |
         Somebody asked to add a password to your account on [%{site_name}](%{base_url}). Alternatively, you can log in using any supported online service (Google, Facebook, etc) that is associated with this validated email address.
 
-        If you did not make this request, you can safely ignore this email.
+	The request came from %{remote_ip} using "%{user_agent}". If it was not you, you can safely ignore this email.
 
         Click the following link to choose a password:
         %{base_url}/u/password-reset/%{email_token}

--- a/db/migrate/20170816343911_add_password_change_ip_to_email_tokens.rb
+++ b/db/migrate/20170816343911_add_password_change_ip_to_email_tokens.rb
@@ -1,0 +1,11 @@
+class AddPasswordChangeIpToEmailTokens < ActiveRecord::Migration
+  def up
+    add_column :email_tokens, :remote_ip, :inet
+    add_column :email_tokens, :user_agent, :string
+  end
+
+  def down
+    remove_column :email_tokens, :remote_ip
+    remove_column :email_tokens, :user_agent
+  end
+end


### PR DESCRIPTION
Save the user's IP address and browser `User-Agent:` when creating password reset tokens. Then when sending password reset email, include those in the message sent.