### PR TITLE
FEATURE: import Github profile picture

### DIFF
--- a/lib/auth/github_authenticator.rb
+++ b/lib/auth/github_authenticator.rb
@@ -118,14 +118,11 @@ class Auth::GithubAuthenticator < Auth::Authenticator
            scope: "user:email"
   end
 
-  protected
+  private
 
   def retrieve_avatar(user, data)
-    return unless user
-    return if user.user_avatar&.custom_upload_id.present?
+    return unless data[:image].present? && user && user.user_avatar&.custom_upload_id.blank?
 
-    if (avatar_url = data[:image]).present?
-      Jobs.enqueue(:download_avatar_from_url, url: avatar_url, user_id: user.id, override_gravatar: false)
-    end
+    Jobs.enqueue(:download_avatar_from_url, url: data[:image], user_id: user.id, override_gravatar: false)
   end
 end


### PR DESCRIPTION
> DISCUSSION: https://meta.discourse.org/t/import-github-image-as-profile-image-when-authenticating-with-github/49132

Bumped into the discussion topic when I was looking into some omniauth-related stuff.

The behaviour is consistent with the existing Facebook/TwitterAuthenticator:

- if the user had uploaded a custom avatar: Nothing happens
- if not: Retrieve and upload the avatar. Select this as the avatar unless the user had selected gravatar.