### PR TITLE
Simplify user-nav styles to facilitate theming

### DIFF
--- a/app/assets/stylesheets/common/base/user.scss
+++ b/app/assets/stylesheets/common/base/user.scss
@@ -3,23 +3,6 @@
   .d-icon-heart {
     color: $love !important;
   }
-  .nav-pills {
-    a {
-      color: dark-light-choose(scale-color($primary, $lightness: 40%), scale-color($secondary, $lightness: 40%));
-    }
-
-    a:hover i {
-      color: $quaternary;
-    }
-
-    a.active i {
-      color: $secondary;
-    }
-
-    i {
-      color: dark-light-choose(scale-color($primary, $lightness: 55%), scale-color($secondary, $lightness: 55%));
-    }
-  }
 }
 
 .user-field {
@@ -161,11 +144,9 @@
 .user-nav {
   margin: 5px 0px;
   padding-top: 10px;
-  .d-icon {
-    margin-right: 5px;
-  }
-  .d-icon-comment {
-    margin-right: 2px;
+
+  li a {
+    color: dark-light-choose(scale-color($primary, $lightness: 40%), scale-color($secondary, $lightness: 40%));
   }
 }
 

--- a/app/assets/stylesheets/common/components/navs.scss
+++ b/app/assets/stylesheets/common/components/navs.scss
@@ -20,9 +20,11 @@
 .nav-pills {
   @extend %nav;
   @extend .clearfix;
+
   > li {
     float: left;
     margin-right: 5px;
+
     > a {
       border: none;
       padding: 5px 12px;
@@ -30,14 +32,26 @@
       font-size: 1.143em;
       line-height: 20px;
       transition: background .15s;
+
+      .d-icon {
+        margin-right: 5px;
+        opacity: .65;
+      }
+
       &:hover {
         color: $quaternary;
         background-color: $quaternary-low;
       }
     }
-    &.active > a, > a.active {
+
+    &.active > a,
+    > a.active {
       color: $secondary;
       background-color: $quaternary;
+
+      .d-icon {
+        opacity: 1;
+      }
     }
   }
 }


### PR DESCRIPTION
Icons will now inherit the text colour, which will make the thicker ones look a tad darker, but seems to me a reasonable compromise for removing code which ultimately [unnecessarily] complicates theming.

I'm also using the existing `.user-nav` class rather than the unnecessarily nested `.user-main .nav-pills` used before, which should further facilitate targeting the element for theming.