### PR TITLE
Add avatar-flair plugin outlet for user card

### DIFF
--- a/app/assets/javascripts/discourse/templates/components/user-card-contents.hbs
+++ b/app/assets/javascripts/discourse/templates/components/user-card-contents.hbs
@@ -10,6 +10,7 @@
           flairColor=user.primary_group_flair_color
           groupName=user.primary_group_name}}
       {{/if}}
+      {{plugin-outlet name="user-card-avatar-flair" args=(hash user=user) tagName='div'}}
     </div>
 
     <div class="names">


### PR DESCRIPTION
This allows plugins to add content next to the avatar in a user card. I'd like to use this in discourse-whos-online to add a 'presence' icon.

<img width="422" alt="screen shot 2017-08-26 at 23 17 28" src="https://user-images.githubusercontent.com/6270921/29745525-e566910e-8ab4-11e7-9649-4e5be6c7abea.png">
 