### PR TITLE
FIX: make /new-topic redirect survive full screen login

### DIFF
--- a/app/assets/javascripts/discourse/controllers/login.js.es6
+++ b/app/assets/javascripts/discourse/controllers/login.js.es6
@@ -90,7 +90,6 @@ export default Ember.Controller.extend(ModalFunctionality, {
           // Trigger the browser's password manager using the hidden static login form:
           const $hidden_login_form = $('#hidden-login-form');
           const destinationUrl = $.cookie('destination_url');
-          const shouldRedirectToUrl = self.session.get("shouldRedirectToUrl");
           const ssoDestinationUrl = $.cookie('sso_destination_url');
           $hidden_login_form.find('input[name=username]').val(self.get('loginName'));
           $hidden_login_form.find('input[name=password]').val(self.get('loginPassword'));
@@ -103,9 +102,6 @@ export default Ember.Controller.extend(ModalFunctionality, {
             // redirect client to the original URL
             $.cookie('destination_url', null);
             $hidden_login_form.find('input[name=redirect]').val(destinationUrl);
-          } else if (shouldRedirectToUrl) {
-            self.session.set("shouldRedirectToUrl", null);
-            $hidden_login_form.find('input[name=redirect]').val(shouldRedirectToUrl);
           } else {
             $hidden_login_form.find('input[name=redirect]').val(window.location.href);
           }
@@ -222,14 +218,10 @@ export default Ember.Controller.extend(ModalFunctionality, {
     // Reload the page if we're authenticated
     if (options.authenticated) {
       const destinationUrl = $.cookie('destination_url');
-      const shouldRedirectToUrl = self.session.get("shouldRedirectToUrl");
-      if (self.get('loginRequired') && destinationUrl) {
+      if (destinationUrl) {
         // redirect client to the original URL
         $.cookie('destination_url', null);
         window.location.href = destinationUrl;
-      } else if (shouldRedirectToUrl) {
-        self.session.set("shouldRedirectToUrl", null);
-        window.location.href = shouldRedirectToUrl;
       } else if (window.location.pathname === Discourse.getURL('/login')) {
         window.location.pathname = Discourse.getURL('/');
       } else {

--- a/app/assets/javascripts/discourse/routes/new-message.js.es6
+++ b/app/assets/javascripts/discourse/routes/new-message.js.es6
@@ -33,7 +33,7 @@ export default Discourse.Route.extend({
         }
       });
     } else {
-      this.session.set("shouldRedirectToUrl", window.location.href);
+      $.cookie('destination_url', window.location.href);
       this.replaceWith('login');
     }
   }

--- a/app/assets/javascripts/discourse/routes/new-topic.js.es6
+++ b/app/assets/javascripts/discourse/routes/new-topic.js.es6
@@ -13,7 +13,7 @@ export default Discourse.Route.extend({
       });
     } else {
       // User is not logged in
-      self.session.set("shouldRedirectToUrl", window.location.href);
+      $.cookie('destination_url', window.location.href);
       self.replaceWith('login');
     }
   }


### PR DESCRIPTION
This is a reversion, of sorts, to #3555, because the change meant that the redirect didn't survive full screen login, making the /new-topic route rather useless for sites using fsl (like my own).

#3555 came after @SamSaffron's [comment](https://github.com/discourse/discourse/commit/d1632c1dbd256411bbb348f638bb7f5f61f05eae##commitcomment-11694599):
> $.cookie is odd usage, I would not like us to use this. we need a different way, we have sessions for this kind of stuff.

To respect this, I originally tried accessing `shouldRedirectToUrl` from the session in `app/controllers/users/omniauth_callbacks_controller.rb`, but it looks like the session didn't survive authentication, because it wasn't there.

I imagine for this reason the established principle, across the codebase, is to use a `destination_url` cookie for redirect:

[`app/controllers/application_controller.rb`](https://github.com/discourse/discourse/blob/master/app/controllers/application_controller.rb#L568-L570):
```ruby
# save original URL in a cookie (javascript redirects after login in this case)
cookies[:destination_url] = destination_url
redirect_to :login
```

[`app/controllers/users/omniauth_callbacks_controller.rb`](https://github.com/discourse/discourse/blob/master/app/controllers/users/omniauth_callbacks_controller.rb#L44-L47):
```ruby
if cookies[:destination_url].present?
  origin = cookies[:destination_url]
  cookies.delete(:destination_url)
end
```

I humbly propose if we don't want to use cookies for this, we later move to sessions in one fell swoop - rather than having multiple, some partially functional, post-authentication redirection methods.