### PR TITLE
FIX: Only show topic timer to staff

### DIFF
--- a/app/assets/javascripts/discourse/widgets/topic-admin-menu.js.es6
+++ b/app/assets/javascripts/discourse/widgets/topic-admin-menu.js.es6
@@ -140,11 +140,12 @@ export default createWidget('topic-admin-menu', {
                      icon: 'lock',
                      label: 'actions.close' });
     }
-
-    buttons.push({ className: 'topic-admin-status-update',
+    if (this.currentUser.get('staff')) {
+      buttons.push({ className: 'topic-admin-status-update',
                    action: 'showTopicStatusUpdate',
                    icon: 'clock-o',
                    label: 'actions.timed_update' });
+    }
 
     const isPrivateMessage = topic.get('isPrivateMessage');
 


### PR DESCRIPTION
Resolves https://meta.discourse.org/t/how-to-create-a-timed-topic/60731/9