### PR TITLE
FIX: redirect loop for new users visiting /new-topic using full screen login

### DIFF
--- a/app/assets/javascripts/discourse.js.es6
+++ b/app/assets/javascripts/discourse.js.es6
@@ -8,6 +8,7 @@ const Discourse = Ember.Application.extend({
   _docTitle: document.title,
   RAW_TEMPLATES: {},
   __widget_helpers: {},
+  showingSignup: false,
 
   getURL(url) {
     if (!url) return url;

--- a/app/assets/javascripts/discourse/routes/new-message.js.es6
+++ b/app/assets/javascripts/discourse/routes/new-message.js.es6
@@ -34,7 +34,11 @@ export default Discourse.Route.extend({
       });
     } else {
       $.cookie('destination_url', window.location.href);
-      this.replaceWith('login');
+      if (Discourse.showingSignup) {
+        Discourse.showingSignup = false;
+      } else {
+        self.replaceWith('login');
+      }
     }
   }
 

--- a/app/assets/javascripts/discourse/routes/new-topic.js.es6
+++ b/app/assets/javascripts/discourse/routes/new-topic.js.es6
@@ -14,7 +14,12 @@ export default Discourse.Route.extend({
     } else {
       // User is not logged in
       $.cookie('destination_url', window.location.href);
-      self.replaceWith('login');
+      if (Discourse.showingSignup) {
+        // We're showing the sign up modal
+        Discourse.showingSignup = false;
+      } else {
+        self.replaceWith('login');
+      }
     }
   }
 });

--- a/app/views/common/_discourse_javascript.html.erb
+++ b/app/views/common/_discourse_javascript.html.erb
@@ -21,6 +21,7 @@
 
 <script>
   <%- if !current_user && flash[:authentication_data] %>
+    Discourse.showingSignup = true
     require('discourse/routes/application').default.reopen({
       actions: {
         didTransition: function() {


### PR DESCRIPTION
#5105 exposed a new problem where users who were required to complete the sign up modal would get redirected back to the full screen login before being able to do so. This fixes that.

Wasn't sure whether `Discourse.showing_signup` was the best place to store that variable, happy to move it elsewhere.