### PR TITLE
wiki/documentation update - jhead is now in brew

### DIFF
--- a/docs/DEVELOPMENT-OSX-NATIVE.md
+++ b/docs/DEVELOPMENT-OSX-NATIVE.md
@@ -229,23 +229,14 @@ config.action_mailer.smtp_settings = { address: "localhost", port: 1025 }
 Set up [MailCatcher](https://github.com/sj26/mailcatcher) so the app can intercept
 outbound email and you can verify what is being sent.
 
-## Additional Setup Tasks
+## Additional Image Tooling
 
 In addition to ImageMagick we also need to install some other image related
 software:
 
 ```sh
-brew install gifsicle jpegoptim optipng
+brew install gifsicle jpegoptim optipng jhead
 npm install -g svgo
-```
-
-Install jhead
-
-```sh
-curl "http://www.sentex.net/~mwandel/jhead/jhead-2.97.tar.gz" | tar xzf -
-cd jhead-2.97
-make
-make install
 ```
 
 ## Setting up your Discourse


### PR DESCRIPTION
This is a minor update to the OSX specific dev file. 
I've signed the CLA and read the [contribution guidelines](https://meta.discourse.org/t/discourse-development-contribution-guidelines/3823), but couldn't find any notes on documentation updates. 
