### PR TITLE
FIX: error when rebaking posts

### DIFF
--- a/app/assets/javascripts/pretty-text/engines/discourse-markdown/bbcode-block.js.es6
+++ b/app/assets/javascripts/pretty-text/engines/discourse-markdown/bbcode-block.js.es6
@@ -176,8 +176,9 @@ function findInlineCloseTag(state, openTag, start, max) {
         closeTag = parseBBCodeTag(state.src, j, max);
         if (!closeTag || closeTag.tag !== openTag.tag || !closeTag.closing) {
           closeTag = null;
+        } else {
+          closeTag.start = j;
         }
-        closeTag.start = j;
         break;
       }
     }


### PR DESCRIPTION
When rebaking post with `raw` content:

```
[QUOTE=elementum]Lorem ipsum dolor sit amet, consectetur adipiscing elit.[/QUOTE]

Fusce porttitor convallis leo, non facilisis ante ultricies in.
```

I am getting this error:

```
Failed to rebake (topic_id: 12, post_id: 17)
TypeError: Cannot set property 'start' of null
JavaScript at findInlineCloseTag (<anonymous>:194:28)
JavaScript at applyBBCode (<anonymous>:241:20)
JavaScript at Array.md.block.ruler.after.alt (<anonymous>:352:16)
JavaScript at ParserBlock.tokenize (<anonymous>:1249:20)
JavaScript at ParserBlock.parse (<anonymous>:1285:8)
JavaScript at Array.block (<anonymous>:4136:20)
JavaScript at Core.process (<anonymous>:1345:13)
JavaScript at MarkdownIt.parse (<anonymous>:1110:13)
JavaScript at MarkdownIt.render (<anonymous>:1130:36)
JavaScript at cook (<anonymous>:357:32)
/home/techapj/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/mini_racer-0.1.11/lib/mini_racer.rb:176:in `eval_unsafe'
```

cc @ZogStriP @SamSaffron 