### PR TITLE
FIX: correctly resets user_themes template

### DIFF
--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -28,7 +28,7 @@ class Theme < ActiveRecord::Base
     changed_fields.each(&:save!)
     changed_fields.clear
 
-    Theme.expire_site_cache! if user_selectable_changed?
+    Theme.expire_site_cache! if user_selectable_changed? || name_changed?
 
     @dependant_themes = nil
     @included_themes = nil
@@ -46,7 +46,6 @@ class Theme < ActiveRecord::Base
     end
 
     if self.id
-
       ColorScheme
         .where(theme_id: self.id)
         .where("id NOT IN (SELECT color_scheme_id FROM themes where color_scheme_id IS NOT NULL)")
@@ -56,6 +55,8 @@ class Theme < ActiveRecord::Base
         .where(theme_id: self.id)
         .update_all(theme_id: nil)
     end
+
+    Theme.expire_site_cache!
   end
 
   after_commit ->(theme) do


### PR DESCRIPTION
This commit adds tests for this behaviour and also adds support for
reseting cache when updating a theme name and destroying a theme.