### PR TITLE
bbcode find close tag loop end condition

### DIFF
--- a/app/assets/javascripts/pretty-text/engines/discourse-markdown/bbcode-block.js.es6
+++ b/app/assets/javascripts/pretty-text/engines/discourse-markdown/bbcode-block.js.es6
@@ -178,8 +178,8 @@ function findInlineCloseTag(state, openTag, start, max) {
           closeTag = null;
         } else {
           closeTag.start = j;
+          break;
         }
-        break;
       }
     }
   }


### PR DESCRIPTION
Only break loop when close tag has been found. Otherwise, keep searching until the end of string.