### PR TITLE
add admin-user-details plugin outlet

### DIFF
--- a/app/assets/javascripts/admin/templates/user-index.hbs
+++ b/app/assets/javascripts/admin/templates/user-index.hbs
@@ -174,6 +174,8 @@
   </section>
 {{/if}}
 
+{{plugin-outlet name="admin-user-details" args=(hash model=model)}}
+
 <section class='details'>
   <h1>{{i18n 'admin.user.permissions'}}</h1>
 


### PR DESCRIPTION
Enables useful additions to the admin user details page:

![screen shot 2017-09-07 at 14 57 44](https://user-images.githubusercontent.com/755354/30167011-f4a2e33a-93dc-11e7-93d2-e732d7a83b03.png)
