### PR TITLE
FIX: memoization in PostAnalyzer.raw_mentions

### DIFF
--- a/app/models/post_analyzer.rb
+++ b/app/models/post_analyzer.rb
@@ -60,7 +60,7 @@ class PostAnalyzer
 
     raw_mentions.compact!
     raw_mentions.uniq!
-    @raw_mention = raw_mentions
+    @raw_mentions = raw_mentions
   end
 
   # from rack ... compat with ruby 2.2


### PR DESCRIPTION
Due to a missing 's' when assigning the computed value to @raw_mentions, the raw_mentions function in PostAnalyzer would never retrieve a memoized value.

Meta topic: https://meta.discourse.org/t/broken-memoization-of-mentions-in-posts/69671