### PR TITLE
FIX: don't activate un-confirmed email on omniauth authentication

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -115,7 +115,7 @@ class Users::OmniauthCallbacksController < ApplicationController
     if @auth_result.email_valid && @auth_result.email == user.email
       user.update!(staged: false)
       # ensure there is an active email token
-      user.email_tokens.create(email: user.email) unless user.email_tokens.active.exists?
+      user.email_tokens.create(email: user.email) unless user.email_tokens.active.where(email: user.email).exists?
       user.activate
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -690,7 +690,7 @@ class User < ActiveRecord::Base
   end
 
   def activate
-    if email_token = self.email_tokens.active.first
+    if email_token = self.email_tokens.active.where(email: self.email).first
       EmailToken.confirm(email_token.token)
     else
       self.active = true


### PR DESCRIPTION
Description of the problem here: https://meta.discourse.org/t/email-change-despite-not-confirming-it/69891?u=leomca

/cc @ZogStriP 