### PR TITLE
INSTALL-cloud: you can re-run discourse-setup

### DIFF
--- a/docs/INSTALL-cloud.md
+++ b/docs/INSTALL-cloud.md
@@ -68,7 +68,7 @@ Answer the following questions when prompted:
     SMTP port [587]:
     SMTP password? []: 
 
-This will generate an `app.yml` configuration file on your behalf, and then kicks off bootstrap. Bootstrapping takes between **2-8 minutes** to set up your Discourse. If you need to change or fix these settings after bootstrapping, edit your `/containers/app.yml` file and `./launcher rebuild app`, otherwise your changes will not take effect.
+This will generate an `app.yml` configuration file on your behalf, and then kicks off bootstrap. Bootstrapping takes between **2-8 minutes** to set up your Discourse. If you need to change these settings after bootstrapping, you can run `./discourse-setup` again (it will read your old values from the file) or edit `/containers/app.yml` with `nano` and then `./launcher rebuild app`, otherwise your changes will not take effect.
 
 ### Start Discourse
 


### PR DESCRIPTION
Make it a bit more clear that you can run discourse-setup again to change settings if you get them wrong the first time.