### PR TITLE
Add spec to cover "Badge Type has many Badges" relation

### DIFF
--- a/spec/models/badge_type_spec.rb
+++ b/spec/models/badge_type_spec.rb
@@ -3,7 +3,7 @@ require_dependency 'badge_type'
 
 describe BadgeType do
 
+  it { is_expected.to have_many :badges }
   it { is_expected.to validate_presence_of :name }
   it { is_expected.to validate_uniqueness_of :name }
-
 end


### PR DESCRIPTION
Relation was not being covered in specs. This PR adds this expectation.

Also: fix filename.
`_spec` suffix was missing. By default, RSpec ignores files in this situation.
Ref: https://github.com/rspec/rspec-core/issues/642