### PR TITLE
TEST ONLY: PollFeed integration test

### DIFF
--- a/app/jobs/scheduled/poll_feed.rb
+++ b/app/jobs/scheduled/poll_feed.rb
@@ -101,7 +101,9 @@ module Jobs
       end
 
       def content
-        @article_rss_item.content.try(:force_encoding, "UTF-8").try(:scrub) || @article_rss_item.description.try(:force_encoding, "UTF-8").try(:scrub)
+        @article_rss_item.content_encoded&.force_encoding("UTF-8")&.scrub ||
+          @article_rss_item.content&.force_encoding("UTF-8")&.scrub ||
+          @article_rss_item.description&.force_encoding("UTF-8")&.scrub
       end
 
       def title

--- a/spec/fixtures/feed/feed.rss
+++ b/spec/fixtures/feed/feed.rss
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?><rss version="2.0"
+  xmlns:content="http://purl.org/rss/1.0/modules/content/"
+  xmlns:wfw="http://wellformedweb.org/CommentAPI/"
+  xmlns:dc="http://purl.org/dc/elements/1.1/"
+  xmlns:atom="http://www.w3.org/2005/Atom"
+  xmlns:sy="http://purl.org/rss/1.0/modules/syndication/"
+  xmlns:slash="http://purl.org/rss/1.0/modules/slash/"
+  >
+<channel>
+  <title>Discourse</title>
+  <atom:link href="https://blog.discourse.org/feed/" rel="self" type="application/rss+xml" />
+  <link>https://blog.discourse.org</link>
+  <description>Official blog for the open source Discourse project</description>
+  <lastBuildDate>Thu, 14 Sep 2017 15:22:33 +0000</lastBuildDate>
+  <language>en-US</language>
+  <sy:updatePeriod>hourly</sy:updatePeriod>
+  <sy:updateFrequency>1</sy:updateFrequency>
+  <generator>https://wordpress.org/?v=4.8.1</generator>
+  <item>
+    <title>Poll Feed Spec Fixture</title>
+    <link>https://blog.discourse.org/2017/09/poll-feed-spec-fixture/</link>
+    <pubDate>Thu, 14 Sep 2017 15:22:33 +0000</pubDate>
+    <dc:creator><![CDATA[xrav3nz]]></dc:creator>
+    <category><![CDATA[spec]]></category>
+    <guid isPermaLink="false">https://blog.discourse.org/?p=pollfeedspec</guid>
+    <description><![CDATA[Here are some random descriptions... [&#8230;]]]></description>
+    <content:encoded><![CDATA[<p>This is the body &amp; content. </p>]]></content:encoded>
+  </item>
+  </channel>
+</rss>

--- a/spec/jobs/poll_feed_spec.rb
+++ b/spec/jobs/poll_feed_spec.rb
@@ -43,4 +43,73 @@ describe Jobs::PollFeed do
 
   end
 
+  describe '#poll_feed' do
+    let(:embed_by_username) { 'eviltrout' }
+    let(:embed_username_key_from_feed) { 'dc_creator' }
+    let!(:default_user) { Fabricate(:evil_trout) }
+    let!(:feed_author) { Fabricate(:user, username: 'xrav3nz', email: 'hi@bye.com') }
+
+    before do
+      SiteSetting.feed_polling_enabled = true
+      SiteSetting.feed_polling_url = 'https://blog.discourse.org/feed/'
+      SiteSetting.embed_by_username = embed_by_username
+
+      stub_request(:get, SiteSetting.feed_polling_url).to_return(
+        status: 200,
+        body: file_from_fixtures('feed.rss', 'feed').read,
+        headers: { "Content-Type" => "application/rss+xml" }
+      )
+    end
+
+    describe 'author username parsing' do
+      context 'when neither embed_by_username nor embed_username_key_from_feed is set' do
+        before do
+          SiteSetting.embed_by_username = ""
+          SiteSetting.embed_username_key_from_feed = ""
+        end
+
+        it 'does not import topics' do
+          expect { poller.poll_feed }.not_to change { Topic.count }
+        end
+      end
+
+      context 'when embed_by_username is set' do
+        before do
+          SiteSetting.embed_by_username = embed_by_username
+          SiteSetting.embed_username_key_from_feed = ""
+        end
+
+        it 'creates the new topics under embed_by_username' do
+          expect { poller.poll_feed }.to change { Topic.count }.by(1)
+          expect(Topic.last.user).to eq(default_user)
+        end
+      end
+
+      context 'when embed_username_key_from_feed is set' do
+        before do
+          SiteSetting.embed_username_key_from_feed = embed_username_key_from_feed
+        end
+
+        it 'creates the new topics under the username found' do
+          expect { poller.poll_feed }.to change { Topic.count }.by(1)
+          expect(Topic.last.user).to eq(feed_author)
+        end
+      end
+    end
+
+    it 'parses the title correctly' do
+      expect { poller.poll_feed }.to change { Topic.count }.by(1)
+      expect(Topic.last.title).to eq('Poll Feed Spec Fixture')
+    end
+
+    it 'parses the content correctly' do
+      expect { poller.poll_feed }.to change { Topic.count }.by(1)
+      expect(Topic.last.first_post.raw).to include('<p>This is the body &amp; content. </p>')
+    end
+
+    it 'parses the link correctly' do
+      expect { poller.poll_feed }.to change { Topic.count }.by(1)
+      expect(Topic.last.topic_embed.embed_url).to eq('https://blog.discourse.org/2017/09/poll-feed-spec-fixture')
+    end
+  end
 end


### PR DESCRIPTION
> CONTEXT: https://meta.discourse.org/t/simple-rss-is-buggy-and-should-be-forked-or-replaced/27529/23

This is _almost_ a spec-only PR that introduces integration tests for PollFeed (except for a tiny bug fix discovered by the new tests). There will be a follow-up PR to actually replace the SimpleRSS gem with the built-in Ruby RSS module.

The new tests focus on parsing and extracting the correct information out of the RSS/XML feed. Open to suggestions, and let me know if you think more cases should be covered (i.e. all logic in `PollFeed::Feed`).


