### PR TITLE
FIX: do not escape already escaped chars in URL

### DIFF
--- a/spec/models/topic_embed_spec.rb
+++ b/spec/models/topic_embed_spec.rb
@@ -186,12 +186,31 @@ describe TopicEmbed do
 
       before do
         file.stubs(:read).returns contents
-        TopicEmbed.stubs(:open).returns file
+        TopicEmbed.stubs(:open)
+          .with('http://eviltrout.com/test/%D9%85%D8%A7%D9%87%DB%8C', allow_redirections: :safe).returns file
       end
 
       it "doesn't throw an error" do
         response = TopicEmbed.find_remote(url)
         expect(response.title).to eq("سلام")
+      end
+    end
+
+    context "encoded URL" do
+      let(:url) { 'http://example.com/hello%20world' }
+      let(:contents) { "<title>Hello World!</title><body></body>" }
+      let!(:embeddable_host) { Fabricate(:embeddable_host) }
+      let!(:file) { StringIO.new }
+
+      before do
+        file.stubs(:read).returns contents
+        TopicEmbed.stubs(:open)
+          .with('http://example.com/hello%20world', allow_redirections: :safe).returns file
+      end
+
+      it "doesn't throw an error" do
+        response = TopicEmbed.find_remote(url)
+        expect(response.title).to eq("Hello World!")
       end
     end
 
@@ -214,4 +233,25 @@ describe TopicEmbed do
     end
   end
 
+  context ".escape_uri" do
+    it "doesn't escape simple URL" do
+      url = TopicEmbed.escape_uri('http://example.com/foo/bar')
+      expect(url).to eq('http://example.com/foo/bar')
+    end
+
+    it "escapes unsafe chars" do
+      url = TopicEmbed.escape_uri("http://example.com/?a=\11\15")
+      expect(url).to eq('http://example.com/?a=%09%0D')
+    end
+
+    it "escapes non-ascii chars" do
+      url = TopicEmbed.escape_uri('http://example.com/ماهی')
+      expect(url).to eq('http://example.com/%D9%85%D8%A7%D9%87%DB%8C')
+    end
+
+    it "doesn't escape already escaped chars" do
+      url = TopicEmbed.escape_uri('http://example.com/foo%20bar/foo bar/')
+      expect(url).to eq('http://example.com/foo%20bar/foo%20bar/')
+    end
+  end
 end


### PR DESCRIPTION
Fix for `Job exception: undefined method `author' for nil:NilClass`
https://meta.discourse.org/logs/show/0e87a429023632664db4a78684170ac2

Escaping already escaped chars in URL produced invalid URL