### PR TITLE
FEATURE: regex matching for `rake posts:remap` and `rake posts:delete_word`

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -91,6 +91,16 @@ class Post < ActiveRecord::Base
 
     q.order('posts.created_at ASC')
   }
+  scope :raw_match, -> (pattern, type = 'string') {
+    type = type&.downcase
+
+    case type
+    when 'string'
+      where('raw ILIKE ?', "%#{pattern}%")
+    when 'regex'
+      where('raw ~ ?', pattern)
+    end
+  }
 
   delegate :username, to: :user
 

--- a/spec/tasks/posts_spec.rb
+++ b/spec/tasks/posts_spec.rb
@@ -1,18 +1,46 @@
 require 'rails_helper'
+require 'highline/import'
+require 'highline/simulate'
 
 RSpec.describe "Post rake tasks" do
   before do
+    Rake::Task.clear
     Discourse::Application.load_tasks
     IO.any_instance.stubs(:puts)
   end
 
   describe 'remap' do
+    let!(:tricky_post) { Fabricate(:post, raw: 'Today ^Today') }
+
     it 'should remap posts' do
       post = Fabricate(:post, raw: "The quick brown fox jumps over the lazy dog")
 
-      Rake::Task['posts:remap'].invoke("brown", "red")
+      HighLine::Simulate.with('y') do
+        Rake::Task['posts:remap'].invoke("brown", "red")
+      end
+
       post.reload
       expect(post.raw).to eq('The quick red fox jumps over the lazy dog')
+    end
+
+    context 'when type == string' do
+      it 'remaps input as string' do
+        HighLine::Simulate.with('y') do
+          Rake::Task['posts:remap'].invoke('^Today', 'Yesterday', 'string')
+        end
+
+        expect(tricky_post.reload.raw).to eq('Today Yesterday')
+      end
+    end
+
+    context 'when type == regex' do
+      it 'remaps input as regex' do
+        HighLine::Simulate.with('y') do
+          Rake::Task['posts:remap'].invoke('^Today', 'Yesterday', 'regex')
+        end
+
+        expect(tricky_post.reload.raw).to eq('Yesterday ^Today')
+      end
     end
   end
 end


### PR DESCRIPTION
> CONTEXT & DISCUSSION: https://meta.discourse.org/t/replace-a-string-in-all-posts/48729/45?u=xrav3nz

This PR adds regex pattern matching support for `rake posts:remap` and `rake posts:delete_word`.

```ruby
> rake posts:remap['pattern', 'replace', type]
> rake posts:delete_word['pattern', type]
```

where `type` defaults to `string` if omitted.

Cheers 💪 

----

EDIT: The failed test seems to be flaky and is not relevant to this change.