### PR TITLE
Use `PostDestroyer` to delete topics when performing bulk operation

### DIFF
--- a/lib/topics_bulk_action.rb
+++ b/lib/topics_bulk_action.rb
@@ -135,7 +135,9 @@ class TopicsBulkAction
 
     def delete
       topics.each do |t|
-        t.trash! if guardian.can_delete?(t)
+        if guardian.can_delete?(t)
+          PostDestroyer.new(@user, t.ordered_posts.first).destroy
+        end
       end
     end
 

--- a/spec/components/topics_bulk_action_spec.rb
+++ b/spec/components/topics_bulk_action_spec.rb
@@ -66,7 +66,7 @@ describe TopicsBulkAction do
   end
 
   describe "delete" do
-    let(:topic) { Fabricate(:topic) }
+    let(:topic) { Fabricate(:post).topic }
     let(:moderator) { Fabricate(:moderator) }
 
     it "deletes the topic" do


### PR DESCRIPTION
This PR fixes this [bug](https://meta.discourse.org/t/bulk-deletion-of-topics-not-logged/50407?u=osama). Also it fixes a related problem (quite an edge case) where staff users couldn't undelete topics that were bulk deleted (for some reasons undelete would just fail silently).

Let me know what you think :)