### PR TITLE
FIX: async reload of locales could result in missing translations

### DIFF
--- a/app/models/translation_override.rb
+++ b/app/models/translation_override.rb
@@ -17,21 +17,16 @@ class TranslationOverride < ActiveRecord::Base
 
     translation_override = find_or_initialize_by(params)
     params.merge!(data) if translation_override.new_record?
-    i18n_changed if translation_override.update(data)
+    I18n.reload! if translation_override.update(data)
     translation_override
   end
 
   def self.revert!(locale, *keys)
     TranslationOverride.where(locale: locale, translation_key: keys).delete_all
-    i18n_changed
+    I18n.reload!
   end
 
   private
-
-    def self.i18n_changed
-      I18n.reload!
-      MessageBus.publish('/i18n-flush', refresh: true)
-    end
 
     def check_interpolation_keys
       original_text = I18n.overrides_disabled do

--- a/config/initializers/100-i18n.rb
+++ b/config/initializers/100-i18n.rb
@@ -4,7 +4,3 @@ require 'i18n/backend/discourse_i18n'
 I18n.backend = I18n::Backend::DiscourseI18n.new
 I18n.config.missing_interpolation_argument_handler = proc { throw(:exception) }
 I18n.init_accelerator!
-
-unless Rails.env.test?
-  MessageBus.subscribe("/i18n-flush") { I18n.reload! }
-end


### PR DESCRIPTION
Reloading of locales via MessageBus could result in missing translations when `I18n.reload!` was called by `MessageBus` while `I18n.t()` was used.

![image](https://user-images.githubusercontent.com/473736/30912210-0efe4bc0-a38c-11e7-8f91-806f9c6653ed.png)

I think this can be removed because
* I couldn't find any other reference to `i18n-flush`
* `I18n.reload!` is executed by the same method that published `i18n-flush` which resulted in duplicate reloads