### PR TITLE
FIX: update group.has_messages field weekly

### DIFF
--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -577,4 +577,21 @@ describe Group do
       expect(group.group_users.map(&:user_id)).to contain_exactly(user.id, admin.id)
     end
   end
+
+  it "Correctly updates has_messages" do
+    group = Fabricate(:group, has_messages: true)
+    topic = Fabricate(:private_message_topic)
+
+    # when group message is not present
+    Group.refresh_has_messages!
+    group.reload
+    expect(group.has_messages?).to eq false
+
+    # when group message is present
+    group.update!(has_messages: true)
+    TopicAllowedGroup.create!(topic_id: topic.id, group_id: group.id)
+    Group.refresh_has_messages!
+    group.reload
+    expect(group.has_messages?).to eq true
+  end
 end


### PR DESCRIPTION
Fixes this issue: https://meta.discourse.org/t/messaging-group-inboxes-and-archives-show-even-after-all-messages-deleted/48467

@SamSaffron: `has_messages` field was added to `groups` table in [this commit](https://github.com/discourse/discourse/commit/a8b5192efd43bcbf64ffe7ae44e5c5b7f3be0b51#diff-34c506df3814d6196b4857679170c2b4), it is supposed to keep track of if there are any messages in groups. It gets updated to `true` when a topic is created but does not reverts to `false` when the topic is deleted.

This PR adds a weekly check to make sure that `has_messages` field is up-to-date for all the groups.

Review please? :)