### PR TITLE
Serialise 'nil' custom fields as empty dictionary, not null

### DIFF
--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -135,7 +135,7 @@ class CurrentUserSerializer < BasicUserSerializer
     end
 
     if fields.present?
-      User.custom_fields_for_ids([object.id], fields)[object.id]
+      User.custom_fields_for_ids([object.id], fields)[object.id] || {}
     else
       {}
     end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -387,7 +387,7 @@ class UserSerializer < BasicUserSerializer
     end
 
     if fields.present?
-      User.custom_fields_for_ids([object.id], fields)[object.id]
+      User.custom_fields_for_ids([object.id], fields)[object.id] || {}
     else
       {}
     end


### PR DESCRIPTION
At the moment, if a user has no custom fields, it gets serialized as a JSON "null". This can cause a lot of weird errors when trying to get/set them in javascript.

A number of plugins have been working around this by overriding the serialiser method with something like this:
```
add_to_serializer(:user, :custom_fields, false) {
    if object.custom_fields == nil then
      {}
    else
      object.custom_fields
    end
  }
```

E.g.:
https://github.com/xfalcox/discourse-signatures/blob/master/plugin.rb#L28-L36
https://github.com/Ebsy/discourse-nationalflags/blob/master/plugin.rb#L31-L38
https://github.com/davidtaylorhq/discourse-telegram-notifications/blob/master/plugin.rb#L184-L190