### PR TITLE
FIX: response error when deleting non-existent tags

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -100,8 +100,11 @@ class TagsController < ::ApplicationController
   def destroy
     guardian.ensure_can_admin_tags!
     tag_name = params[:tag_id]
+    tag = Tag.find_by_name(tag_name)
+    raise Discourse::NotFound if tag.nil?
+
     TopicCustomField.transaction do
-      Tag.find_by_name(tag_name).destroy
+      tag.destroy
       StaffActionLogger.new(current_user).log_custom('deleted_tag', subject: tag_name)
     end
     render json: success_json

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -190,4 +190,30 @@ describe TagsController do
       end
     end
   end
+
+  describe 'destroy' do
+    context 'tagging enabled' do
+      before do
+        log_in(:admin)
+        SiteSetting.tagging_enabled = true
+      end
+
+      context 'with an existent tag name' do
+        it 'deletes the tag' do
+          tag = Fabricate(:tag)
+          delete :destroy, params: { tag_id: tag.name }, format: :json
+          expect(response).to be_success
+        end
+      end
+
+      context 'with a nonexistent tag name' do
+        it 'returns a tag not found message' do
+          delete :destroy, params: { tag_id: 'idontexist' }, format: :json
+          expect(response).not_to be_success
+          json = ::JSON.parse(response.body)
+          expect(json['error_type']).to eq('not_found')
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR is to address the [issue](https://meta.discourse.org/t/api-inconsistent-error-message-when-deleting-a-tag/70729) that arises when trying to delete a non-existent tag.  Updates the API to return 'not_found' instead of a general Rails error. 

First time contributing to this repo, so please let me know if there are any processes that I may have overlooked when creating this PR. Cheers!
