### PR TITLE
Tweak error messages for restore

### DIFF
--- a/script/discourse
+++ b/script/discourse
@@ -87,11 +87,17 @@ class DiscourseCLI < Thor
   desc "restore", "Restore a Discourse backup"
   def restore(filename = nil)
 
+    if File.exist?('/usr/local/bin/discourse')
+      discourse = 'discourse'
+    else
+      discourse = './script/discourse'
+    end
+
     if !filename
       puts "You must provide a filename to restore. Did you mean one of the following?\n\n"
 
       Dir["public/backups/default/*"].each do |f|
-        puts "discourse restore #{File.basename(f)}"
+        puts "#{discourse} restore #{File.basename(f)}"
       end
 
       return
@@ -110,7 +116,8 @@ class DiscourseCLI < Thor
       puts '', 'The filename argument was missing.', ''
       usage
     rescue BackupRestore::RestoreDisabledError
-      puts '', 'Restores are not allowed.', 'An admin needs to set allow_restore to true in the site settings before restores can be run.', ''
+      puts '', 'Restores are not allowed.', 'An admin needs to set allow_restore to true in the site settings before restores can be run.'
+      puts "Enable now with", '', "#{discourse} enable_restore", ''
       puts 'Restore cancelled.', ''
     end
 


### PR DESCRIPTION
`discourse restore` recommends filenames if you call it with no filename.

Now it offers `./script/discourse` if `/usr/local/bin/discourse` doesn't exist so it'll offer the correct script name both in a container and in a development environment.

Also recommends calling `discourse enable_restore` if restore is not enabled (rather than suggesting that an admin needs to do it).