### PR TITLE
UX: discourse restore -- sort by date

### DIFF
--- a/script/discourse
+++ b/script/discourse
@@ -96,7 +96,7 @@ class DiscourseCLI < Thor
     if !filename
       puts "You must provide a filename to restore. Did you mean one of the following?\n\n"
 
-      Dir["public/backups/default/*"].each do |f|
+      Dir["public/backups/default/*"].sort_by { |filename| File.mtime(filename) }.reverse.each do |f|
         puts "#{discourse} restore #{File.basename(f)}"
       end
 


### PR DESCRIPTION
Now, if you do `./script/discourse restore` with no filename to restore, it sorts the suggested files in reverse chron, so the top file will most likely be the one you want.