### PR TITLE
UX: Cap likes under posts

### DIFF
--- a/app/assets/javascripts/discourse/widgets/actions-summary.js.es6
+++ b/app/assets/javascripts/discourse/widgets/actions-summary.js.es6
@@ -22,15 +22,10 @@ createWidget('small-user-list', {
   html(atts) {
     let users = atts.users;
     if (users) {
-      const currentUser = this.currentUser;
-      if (atts.addSelf && !users.some(u => u.username === currentUser.username)) {
-        users = users.concat(avatarAtts(currentUser));
-      }
-
       let description = null;
 
       if (atts.description) {
-        description = I18n.t(atts.description, { icons: '' });
+        description = I18n.t(atts.description, { count: atts.count });
       }
 
       // oddly post_url is on the user

--- a/app/controllers/post_action_users_controller.rb
+++ b/app/controllers/post_action_users_controller.rb
@@ -16,6 +16,10 @@ class PostActionUsersController < ApplicationController
       .includes(:user)
       .order('post_actions.created_at asc')
 
+    if post_action_type_id == PostActionType.types[:like] && params[:limit].present?
+      post_actions = post_actions.limit(params[:limit].to_i)
+    end
+
     if !guardian.can_see_post_actors?(post.topic, post_action_type_id)
       if !current_user
         raise Discourse::InvalidAccess

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1947,6 +1947,9 @@ en:
           notify_user: "sent a message"
           bookmark: "bookmarked this"
           like: "liked this"
+          likes_capped:
+            one: "and {{count}} other liked this"
+            other: "and {{count}} others liked this"
           vote: "voted for this"
         by_you:
           off_topic: "You flagged this as off-topic"


### PR DESCRIPTION
Meta topic: https://meta.discourse.org/t/the-most-liked-topic-of-any-discourse/59649/7?u=osama

Screenshot:

![capped_likes](https://user-images.githubusercontent.com/17474474/31308044-1acd3f3a-ab78-11e7-9918-1280fda5bd47.png)

Not sure what number to limit the likes at. Currently it's 25. Is that too high or too low? Should the number be configurable in site settings?