### PR TITLE
FIX: Remove duplicate FORCE_JQUERY script code

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,10 +16,7 @@
       <meta name="shared_session_key" content="<%= shared_session_key %>">
     <%- end %>
 
-    <script>
-      window.EmberENV = window.EmberENV || {};
-      window.EmberENV['FORCE_JQUERY'] = true;
-    </script>
+    <script type="text/javascript" src="assets/javascripts/env.js"></script>
 
     <%= preload_script "locales/#{I18n.locale}" %>
     <%= preload_script "ember_jquery" %>


### PR DESCRIPTION
This code snippet was living in two places...

1.) app/views/layouts/application.html.erb
2.) app/assets/javascripts/env.js

All this does is makes #1 reference the common code in #2.  Not only does this reduce the chance of those two getting out of sync, but it also moves us a little bit closer to being able to drop unsafe-inline in the CSP policy for Discourse.

**WARNING:** This is my first time writing a patch for discourse and although I believe the concept is sound to simply reference this external link, I would appreciate someone validating that this actually works and that my paths are pointing to the right location in the context of a running app before merging this.