### PR TITLE
Discobot Localisation: Fix missing backtick

### DIFF
--- a/plugins/discourse-narrative-bot/config/locales/server.de.yml
+++ b/plugins/discourse-narrative-bot/config/locales/server.de.yml
@@ -116,7 +116,7 @@ de:
         tracks: |-
           Ich weiß derzeit, wie man die folgenden Dinge macht:
 
-          `@%{discobot_username} %{reset_trigger} %{default_track}
+          `@%{discobot_username} %{reset_trigger} %{default_track}`
           > Startet eine der folgenden interaktiven Tutorials: %{tracks}.
         bot_actions: |-
           `@%{discobot_username} %{dice_trigger} 2d6`


### PR DESCRIPTION
Discobot's German localisation had a minor formatting error when printing it's capabilities because of a missing backtick.