### PR TITLE
postprocessing ignored cook method

### DIFF
--- a/lib/cooked_post_processor.rb
+++ b/lib/cooked_post_processor.rb
@@ -20,6 +20,7 @@ class CookedPostProcessor
     @cooking_options[:topic_id] = post.topic_id
     @cooking_options = @cooking_options.symbolize_keys
     @cooking_options[:omit_nofollow] = true if post.omit_nofollow?
+    @cooking_options[:cook_method] = post.cook_method
 
     analyzer = post.post_analyzer
     @doc = Nokogiri::HTML::fragment(analyzer.cook(post.raw, @cooking_options))

--- a/lib/email_cook.rb
+++ b/lib/email_cook.rb
@@ -21,12 +21,11 @@ class EmailCook
     str.scan(EmailCook.url_regexp).each do |m|
       url = m[0]
 
-      val = "<a href='#{url}'>#{url}</a>"
-
-      # Onebox consideration
       if str.strip == url
-        oneboxed = Oneboxer.onebox(url)
-        val = oneboxed if oneboxed.present?
+        # this could be oneboxed
+        val = %|<a href="#{url}" class="onebox" target="_blank">#{url}</a>|
+      else
+        val = %|<a href="#{url}">#{url}</a>|
       end
 
       str.gsub!(url, val)

--- a/spec/components/email_cook_spec.rb
+++ b/spec/components/email_cook_spec.rb
@@ -27,17 +27,19 @@ LONG_COOKED
     expect(EmailCook.new(long).cook).to eq(long_cooked.strip)
   end
 
-  it 'autolinks' do
-    stub_request(:get, "https://www.eviltrout.com").to_return(body: "")
-    stub_request(:head, "https://www.eviltrout.com").to_return(body: "")
-    expect(EmailCook.new("https://www.eviltrout.com").cook).to eq("<a href='https://www.eviltrout.com'>https://www.eviltrout.com</a><br>")
+  it 'creates oneboxed link when the line contains only a link' do
+    expect(EmailCook.new("https://www.eviltrout.com").cook).to eq('<a href="https://www.eviltrout.com" class="onebox" target="_blank">https://www.eviltrout.com</a><br>')
   end
 
   it 'autolinks without the beginning of a line' do
-    expect(EmailCook.new("my site: https://www.eviltrout.com").cook).to eq("my site: <a href='https://www.eviltrout.com'>https://www.eviltrout.com</a><br>")
+    expect(EmailCook.new("my site: https://www.eviltrout.com").cook).to eq('my site: <a href="https://www.eviltrout.com">https://www.eviltrout.com</a><br>')
+  end
+
+  it 'autolinks without the end of a line' do
+    expect(EmailCook.new("https://www.eviltrout.com is my site").cook).to eq('<a href="https://www.eviltrout.com">https://www.eviltrout.com</a> is my site<br>')
   end
 
   it 'links even within a quote' do
-    expect(EmailCook.new("> https://www.eviltrout.com").cook).to eq("<blockquote><a href='https://www.eviltrout.com'>https://www.eviltrout.com</a><br></blockquote>")
+    expect(EmailCook.new("> https://www.eviltrout.com").cook).to eq('<blockquote><a href="https://www.eviltrout.com">https://www.eviltrout.com</a><br></blockquote>')
   end
 end

--- a/spec/models/post_analyzer_spec.rb
+++ b/spec/models/post_analyzer_spec.rb
@@ -10,19 +10,18 @@ describe PostAnalyzer do
 
     let(:raw) { "Here's a tweet:\n#{url}" }
     let(:options) { {} }
-    let(:args) { [raw, options] }
 
     before { Oneboxer.stubs(:onebox) }
 
     it 'fetches the cached onebox for any urls in the post' do
       Oneboxer.expects(:cached_onebox).with url
-      post_analyzer.cook(*args)
+      post_analyzer.cook(raw, options)
       expect(post_analyzer.found_oneboxes?).to be(true)
     end
 
     it 'does not invalidate the onebox cache' do
       Oneboxer.expects(:invalidate).with(url).never
-      post_analyzer.cook(*args)
+      post_analyzer.cook(raw, options)
     end
 
     context 'when invalidating oneboxes' do
@@ -30,8 +29,28 @@ describe PostAnalyzer do
 
       it 'invalidates the oneboxes for urls in the post' do
         Oneboxer.expects(:invalidate).with url
-        post_analyzer.cook(*args)
+        post_analyzer.cook(raw, options)
       end
+    end
+
+    it "does nothing when the cook_method is 'raw_html'" do
+      cooked = post_analyzer.cook('Hello <div/> world', cook_method: Post.cook_methods[:raw_html])
+      expect(cooked).to eq('Hello <div/> world')
+    end
+
+    it "does not interpret Markdown when cook_method is 'email'" do
+      cooked = post_analyzer.cook('*this is not italic* and here is a link: https://www.example.com', cook_method: Post.cook_methods[:email])
+      expect(cooked).to eq('*this is not italic* and here is a link: <a href="https://www.example.com">https://www.example.com</a>')
+    end
+
+    it "does interpret Markdown when cook_method is 'regular'" do
+      cooked = post_analyzer.cook('*this is italic*', cook_method: Post.cook_methods[:regular])
+      expect(cooked).to eq('<p><em>this is italic</em></p>')
+    end
+
+    it "does interpret Markdown when not cook_method is set" do
+      cooked = post_analyzer.cook('*this is italic*')
+      expect(cooked).to eq('<p><em>this is italic</em></p>')
     end
   end
 


### PR DESCRIPTION
Postprocessing of posts ignored the `cook_method`.
When a post had a `cook_method` of `email` it looked fine at first, but it didn't after Sidekiq ran the `ProcessPost` job.

![image](https://user-images.githubusercontent.com/473736/31676276-5e495f2c-b367-11e7-8172-a008a99b7945.png)

This PR moves the logic into `PostAnalyzer`. The example from above looks now correct.

![image](https://user-images.githubusercontent.com/473736/31676261-52b68270-b367-11e7-9b73-46dc1489a6ab.png)

There are two more changes in this PR:
* `EmailCook` doesn't use the oneboxer anymore. It was slowing down mbox imports and is now handled by the `ProcessPost` job.
* I replaced the `def cook(*args)` with `def cook(raw, opts = {})` because I find the splat extremely confusing and hard to read.