### PR TITLE
single_sign_on: encode the payload with strict_encode64 which doesn't add extraneous newlines

### DIFF
--- a/lib/single_sign_on.rb
+++ b/lib/single_sign_on.rb
@@ -78,7 +78,7 @@ class SingleSignOn
   end
 
   def payload
-    payload = Base64.encode64(unsigned_payload)
+    payload = Base64.strict_encode64(unsigned_payload)
     "sso=#{CGI::escape(payload)}&sig=#{sign(payload)}"
   end
 


### PR DESCRIPTION
The extra newlines were bothering me.

Also fixes https://meta.discourse.org/t/official-single-sign-on-for-discourse-sso/13045/308?u=supermathie