### PR TITLE
More accurate steps for preparing the database

### DIFF
--- a/docs/DEVELOPMENT-OSX-NATIVE.md
+++ b/docs/DEVELOPMENT-OSX-NATIVE.md
@@ -257,10 +257,13 @@ bundle install
 
 ### Prepare your database
 ```sh
-rake db:create
-rake db:migrate
-rake db:test:prepare
-rake db:seed_fu
+# run this if there was a pre-existing database
+bundle exec rake db:drop
+RAILS_ENV=test bundle exec rake db:drop
+
+# time to create the database and run migrations
+bundle exec rake db:create db:migrate
+RAILS_ENV=test bundle exec rake db:create db:migrate
 ```
 
 ## Now, test it out!


### PR DESCRIPTION
An improvement on the content of the document `docs/DEVELOPMENT-OSX-NATIVE.md` at the _prepare your database_ section.

The existing prepare database instructions were not correct. I have updated them according to what existed in the other document (docs/DEVELOPMENT-ADVANCED.md).