### PR TITLE
Use the CategoryHashtag::SEPARATOR

### DIFF
--- a/spec/components/concern/category_hashtag_spec.rb
+++ b/spec/components/concern/category_hashtag_spec.rb
@@ -28,7 +28,7 @@ describe CategoryHashtag do
       child_category.update_attributes!(slug: "OraNGE")
 
       expect(Category.query_from_hashtag_slug("apple")).to eq(nil)
-      expect(Category.query_from_hashtag_slug("apple:orange")).to eq(nil)
+      expect(Category.query_from_hashtag_slug("apple#{CategoryHashtag::SEPARATOR}orange")).to eq(nil)
     end
   end
 end


### PR DESCRIPTION
This is a small enhancement on an existing test. Instead of hard coding the `:` symbol, use the `CategoryHashtag::SEPARATOR` constant, like we do in the previous examples in the same file.