### PR TITLE
Removed omit_stats attribute from User

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -45,9 +45,6 @@ class UsersController < ApplicationController
 
     user_serializer = UserSerializer.new(@user, scope: guardian, root: 'user')
 
-    # TODO remove this options from serializer
-    user_serializer.omit_stats = true
-
     topic_id = params[:include_post_count_for].to_i
     if topic_id != 0
       user_serializer.topic_post_count = { topic_id => Post.secured(guardian).where(topic_id: topic_id, user_id: @user.id).count }

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,7 +1,6 @@
 class UserSerializer < BasicUserSerializer
 
-  attr_accessor :omit_stats,
-                :topic_post_count
+  attr_accessor :topic_post_count
 
   def self.staff_attributes(*attrs)
     attributes(*attrs)
@@ -228,10 +227,6 @@ class UserSerializer < BasicUserSerializer
     scope.can_edit_name?(object)
   end
 
-  def include_stats?
-    !omit_stats == true
-  end
-
   def stats
     UserAction.stats(object.id, scope)
   end
@@ -330,7 +325,7 @@ class UserSerializer < BasicUserSerializer
   end
 
   def include_private_messages_stats?
-    can_edit && !(omit_stats == true)
+    can_edit
   end
 
   def private_messages_stats


### PR DESCRIPTION
I saw the `user_controller` TODO to remove `omit_stats` from the `user_serializer`. I went ahead and removed occurrences of it. It also looks like `include_private_messages_stats?` in `user_serializer` isn't used so I could remove that as well. 

Looking forward to feedback and feel free to close the PR if I understood the TODO incorrectly. Thank you.