### PR TITLE
updating banner style, fixes banner on dark themes

### DIFF
--- a/app/assets/stylesheets/common/components/banner.scss
+++ b/app/assets/stylesheets/common/components/banner.scss
@@ -4,10 +4,9 @@
 
 #banner {
   padding: 10px;
-  border-radius: 5px;
   background: $tertiary-low;
-  box-shadow: 0 1px 2px $tertiary-medium;
-  color: darken($tertiary, 45%);
+  box-shadow: 0 2px 4px -1px rgba(0,0,0, .25);
+  color: $primary;
   z-index: 1001;
   overflow: auto;
 
@@ -18,7 +17,7 @@
   .close {
     font-size: 1.786em;
     margin-top: -5px;
-    color: $tertiary-medium;
+    color: dark-light-choose($primary-low-mid, $secondary-medium);
     padding-left: 5px;
     float: right;
   }


### PR DESCRIPTION
Color variables were off, so dark theme banner text was too dark. 

<img width="1144" alt="screen shot 2017-10-26 at 10 34 36 pm" src="https://user-images.githubusercontent.com/1681963/32085772-1096d554-ba9f-11e7-9450-bc2dab6779ef.png">
<img width="1129" alt="screen shot 2017-10-26 at 10 35 56 pm" src="https://user-images.githubusercontent.com/1681963/32085773-10a6547a-ba9f-11e7-8942-31dc987bc2b3.png">
