### PR TITLE
REFACTOR: searchData constant included in search-menu widget

### DIFF
--- a/app/assets/javascripts/discourse/widgets/search-menu.js.es6
+++ b/app/assets/javascripts/discourse/widgets/search-menu.js.es6
@@ -71,6 +71,7 @@ const SearchHelper = {
 
 export default createWidget('search-menu', {
   tagName: 'div.search-menu',
+  searchData,
 
   fullSearchUrl(opts) {
     const contextEnabled = searchData.contextEnabled;


### PR DESCRIPTION
To access `searchData` constant while reopening widgets through plugin API it included in `search-menu` widget also.