### PR TITLE
converting mobile topic-map to icons

### DIFF
--- a/app/assets/javascripts/discourse/widgets/topic-map.js.es6
+++ b/app/assets/javascripts/discourse/widgets/topic-map.js.es6
@@ -62,8 +62,10 @@ createWidget('topic-map-summary', {
   },
 
   html(attrs, state) {
-    const contents = [];
-    contents.push(h('li',
+    const primary = [];
+    const secondary = [];
+    
+    primary.push(h('li',
       [
         h('h4', I18n.t('created_lowercase')),
         h('div.topic-map-post.created-at', [
@@ -72,7 +74,7 @@ createWidget('topic-map-summary', {
         ])
       ]
     ));
-    contents.push(h('li',
+    primary.push(h('li',
       h('a', { attributes: { href: attrs.lastPostUrl } }, [
         h('h4', I18n.t('last_reply_lowercase')),
         h('div.topic-map-post.last-reply', [
@@ -81,28 +83,33 @@ createWidget('topic-map-summary', {
         ])
       ])
     ));
-    contents.push(h('li', [
+    secondary.push(h('li', [
+      h('i.fa.fa-comment'),      
       numberNode(attrs.topicReplyCount),
       h('h4', I18n.t('replies_lowercase', { count: attrs.topicReplyCount }))
     ]));
-    contents.push(h('li.secondary', [
+    secondary.push(h('li', [
+      h('i.fa.fa-eye'),
       numberNode(attrs.topicViews, { className: attrs.topicViewsHeat }),
       h('h4', I18n.t('views_lowercase', { count: attrs.topicViews }))
     ]));
-    contents.push(h('li.secondary', [
+    secondary.push(h('li', [
+      h('i.fa.fa-user'),
       numberNode(attrs.participantCount),
       h('h4', I18n.t('users_lowercase', { count: attrs.participantCount }))
     ]));
 
     if (attrs.topicLikeCount) {
-      contents.push(h('li.secondary', [
+      secondary.push(h('li', [
+        h('i.fa.fa-heart'),        
         numberNode(attrs.topicLikeCount),
         h('h4', I18n.t('likes_lowercase', { count: attrs.topicLikeCount }))
       ]));
     }
 
     if (attrs.topicLinkLength > 0) {
-      contents.push(h('li.secondary', [
+      secondary.push(h('li', [
+        h('i.fa.fa-link'),              
         numberNode(attrs.topicLinkLength),
         h('h4', I18n.t('links_lowercase', { count: attrs.topicLinkLength }))
       ]));
@@ -110,7 +117,7 @@ createWidget('topic-map-summary', {
 
     if (state.collapsed && attrs.topicPostsCount > 2 && attrs.participants.length > 0) {
       const participants = renderParticipants.call(this, attrs.userFilters, attrs.participants.slice(0, 3));
-      contents.push(h('li.avatars', participants));
+      secondary.push(h('li.avatars', participants));
     }
 
     const nav = h('nav.buttons', this.attach('button', {
@@ -119,8 +126,8 @@ createWidget('topic-map-summary', {
       action: 'toggleMap',
       className: 'btn',
     }));
-
-    return [nav, h('ul.clearfix', contents)];
+    
+    return [nav, h('ul.clearfix', [h('li.primary', primary), h('li.secondary', secondary)])];
   }
 });
 

--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -284,7 +284,6 @@ a.star {
   background: blend-primary-secondary(5%);
   border: 1px solid $primary-low;
   border-top: none; // would cause double top border
-
   section {
     border-top: 1px solid $primary-low;
   }
@@ -339,7 +338,6 @@ a.star {
   }
 
   .map {
-    .secondary {text-align: center;}
     li {
       float: left;
       padding: 7px 10px;
@@ -347,6 +345,15 @@ a.star {
         border-right: 0;
       }
       &:nth-child(3) { text-align:center; }
+    }
+    .primary, .secondary {
+      padding: 0;
+    }
+    .secondary {
+      text-align: center;
+      i {
+        display: none;
+      }
     }
     a, .number {
       line-height: 20px;
@@ -397,7 +404,7 @@ a.star {
       color: dark-light-choose($primary-medium, $secondary-high);
       background: blend-primary-secondary(5%);
       border-left: 1px solid $primary-low;
-      border-top: 1px solid $primary-low;
+      border-top: 1px solid transparent;
       &:hover {
         color: $primary;
         background: $primary-low;

--- a/app/assets/stylesheets/mobile/topic-post.scss
+++ b/app/assets/stylesheets/mobile/topic-post.scss
@@ -168,12 +168,11 @@ a.star {
 }
 
 .topic-map {
-
   margin: 10px 0;
   background: blend-primary-secondary(5%);
   border: 1px solid $primary-low;
   border-top: none; // would cause double top border
-
+  
   section {
     border-top: 1px solid $primary-low;
   }
@@ -188,7 +187,7 @@ a.star {
   }
 
   h4 {
-    margin: 0 0 3px 0;
+    margin: 0 0 2px 0;
     color: dark-light-choose($primary-medium, $secondary-medium);
     font-weight: normal;
     font-size: 0.857em;
@@ -228,16 +227,57 @@ a.star {
     margin-right: 4px;
   }
 
-  .map-collapsed {
     .secondary {
-      display: none;
+      h4 {
+        display: none;
+      }
+      i {
+        margin-right: 2px;
+      }
     }
-  }
 
-  .map {
+
+  .map { 
+    display: flex;
+    .buttons {
+      order: 5;
+      border-left: 1px solid $primary-low;
+      .btn {
+        border: none;
+        padding: 0 10px;
+        height: 100%;
+      }
+    } 
+    ul {
+      display: flex;
+      flex-wrap: wrap;
+      flex-grow: 1;      
+      align-items: center;
+      padding: 5px 10px;
+    }
     li {
-      float: left;
-      padding: 7px 8px;
+      display: flex; 
+      &.primary {
+        flex-shrink: 0;
+        padding: 5px 0;
+        li {
+          flex-direction: column;
+          margin-right: 10px;
+        }
+      }
+      &.secondary {
+        flex-wrap: wrap;
+        flex-basis: 94px;
+        flex-grow: 1;
+        padding: 5px 0;  
+        li {
+          margin-right: 8px;
+        }
+        i, span {
+          align-self: center; 
+          font-size: 1em;
+        }
+      }
       &:last-of-type {
         border-right: 0;
       }
@@ -245,11 +285,12 @@ a.star {
     a, .number {
       line-height: 20px;
     }
-    .number, i {
-      color: dark-light-choose($primary-high, $secondary-low);
-      font-size: 110%;
+    .number {
+      color: dark-light-choose($primary, $secondary);
     }
-
+    i {
+      color: dark-light-choose($primary-medium, $secondary-medium);
+    }
     .avatar + a {
       float: left;
     }


### PR DESCRIPTION
Replacing the secondary stats in the topic-map with icons, so they fit better in mobile 

<img width="315" alt="screen shot 2017-10-31 at 11 40 53 am" src="https://user-images.githubusercontent.com/1681963/32234171-7cbed772-be32-11e7-9de3-d9d3b98e983e.png">


Discussion: https://meta.discourse.org/t/i-suggest-to-replace-the-words-on-the-mobile-version-with-icons/72491