### PR TITLE
FIX: improves icon alignment

### DIFF
--- a/app/assets/stylesheets/common/admin/customize.scss
+++ b/app/assets/stylesheets/common/admin/customize.scss
@@ -88,21 +88,27 @@
     }
 
     .nav.target {
+      margin-top: 15px;
+
       li {
         position: relative;
+
+        a {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+        }
       }
-      margin-top: 15px;
+
       .fa {
-        margin-left: 3px;
+        margin-left: 8px;
       }
-      li.mobile a {
-        padding-right: 25px;
-      }
+
       .d-icon-mobile {
-        position: absolute;
-        right: 10px;
-        top: 3px;
+        position: relative;
+        top: -3px;
         font-size: 1.5em;
+        max-height: 20px;
       }
     }
 


### PR DESCRIPTION
the mobile icon has a higher height than other icons, given we want a total 30px height and we apply a 5px top and bottom padding, the icon can be at most 20px height