### PR TITLE
FIX: Topic links onebox differently if end in /

### DIFF
--- a/lib/onebox/engine/discourse_local_onebox.rb
+++ b/lib/onebox/engine/discourse_local_onebox.rb
@@ -12,8 +12,7 @@ module Onebox
         url = other.to_s
         return false unless url[Discourse.base_url]
 
-        path = url.sub(Discourse.base_url, "")
-        route = Rails.application.routes.recognize_path(path)
+        route = Discourse.route_for(url)
 
         !!(route[:controller] =~ /topics|uploads/)
       rescue ActionController::RoutingError
@@ -21,8 +20,9 @@ module Onebox
       end
 
       def to_html
-        path = @url.sub(Discourse.base_url, "")
-        route = Rails.application.routes.recognize_path(path)
+        uri = URI(@url)
+        path = uri.path || ""
+        route = Discourse.route_for(uri)
 
         case route[:controller]
         when "uploads" then upload_html(path)

--- a/spec/components/onebox/engine/discourse_local_onebox_spec.rb
+++ b/spec/components/onebox/engine/discourse_local_onebox_spec.rb
@@ -35,6 +35,11 @@ describe Onebox::Engine::DiscourseLocalOnebox do
       expect(html).to include(post2.excerpt)
       expect(html).to include(post2.topic.title)
 
+      url = "#{Discourse.base_url}#{post2.url}/?source_topic_id=#{post2.topic_id + 1}"
+      html = Onebox.preview(url).to_s
+      expect(html).to include(post2.excerpt)
+      expect(html).to include(post2.topic.title)
+
       html = Onebox.preview("#{Discourse.base_url}#{post2.url}").to_s
       expect(html).to include(post2.user.username)
       expect(html).to include(post2.excerpt)
@@ -63,6 +68,10 @@ describe Onebox::Engine::DiscourseLocalOnebox do
 
     it "returns some onebox goodness if topic exists and can be seen" do
       html = Onebox.preview(topic.url).to_s
+      expect(html).to include(topic.ordered_posts.first.user.username)
+      expect(html).to include("<blockquote>")
+
+      html = Onebox.preview("#{topic.url}/?u=codinghorror").to_s
       expect(html).to include(topic.ordered_posts.first.user.username)
       expect(html).to include("<blockquote>")
     end


### PR DESCRIPTION
Links to the internal topics are oneboxed differently if there’s a / in the end.