### PR TITLE
Fix "duplicate method" issue

### DIFF
--- a/lib/single_sign_on.rb
+++ b/lib/single_sign_on.rb
@@ -8,7 +8,7 @@ class SingleSignOn
   NONCE_EXPIRY_TIME = 10.minutes
 
   attr_accessor(*ACCESSORS)
-  attr_accessor :sso_secret, :sso_url
+  attr_writer :sso_secret, :sso_url
 
   def self.sso_secret
     raise RuntimeError, "sso_secret not implemented on class, be sure to set it on instance"


### PR DESCRIPTION
Fixing http://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/DuplicateMethods

Readers are defined (https://github.com/discourse/discourse/blob/master/lib/single_sign_on.rb#L61), so only writers have to be generated.