### PR TITLE
UX: better topic map top link title for links to categories

### DIFF
--- a/app/assets/javascripts/discourse/widgets/topic-map.js.es6
+++ b/app/assets/javascripts/discourse/widgets/topic-map.js.es6
@@ -148,7 +148,16 @@ createWidget('topic-map-link', {
       content = `${content.substr(0, truncateLength).trim()}...`;
     }
 
-    return attrs.title ? replaceEmoji(content) : content;
+    let categoriesRegexp = /\/c\/[0-9]*-(.*)/;
+    content = attrs.title ? replaceEmoji(content) : content;
+
+    let matches = categoriesRegexp.exec(content);
+    if(matches) {
+      return content.replace(categoriesRegexp, '$1 Category').replace(/-/g, ' ').replace(/(^| )(\w)/g, function (x) {
+        return x.toUpperCase();
+      });
+    }
+    return content;
   }
 });
 


### PR DESCRIPTION
Link to the issue: https://meta.discourse.org/t/better-topic-map-top-link-title-for-links-to-categories/66375