### PR TITLE
FIX: `Hide Details` button generates multiple details blocks

### DIFF
--- a/plugins/discourse-details/assets/javascripts/initializers/apply-details.js.es6
+++ b/plugins/discourse-details/assets/javascripts/initializers/apply-details.js.es6
@@ -18,7 +18,7 @@ function initializeDetails(api) {
           "\n" + `[details="${I18n.t("composer.details_title")}"]` + "\n",
           "\n[/details]\n",
           "details_text",
-          { multiline: true }
+          { multiline: false }
         );
         this.set('optionsVisible', false);
       }

--- a/plugins/discourse-details/test/javascripts/acceptance/details-button-test.js.es6
+++ b/plugins/discourse-details/test/javascripts/acceptance/details-button-test.js.es6
@@ -90,3 +90,28 @@ test('details button', (assert) => {
     assert.equal(textarea.selectionEnd, 49, 'it should end highlighting at the right position');
   });
 });
+
+test('details button surrounds all selected text in a single details block', (assert) => {
+  const multilineInput = 'first line\n\nsecond line\n\nthird line';
+
+  visit("/");
+  click('#create-topic');
+  fillIn('.d-editor-input', multilineInput);
+
+  andThen(() => {
+    const textarea = findTextarea();
+    textarea.selectionStart = 0;
+    textarea.selectionEnd = textarea.value.length;
+  });
+
+  click('button.options');
+  click('.popup-menu .d-icon-caret-right');
+
+  andThen(() => {
+    assert.equal(
+      find(".d-editor-input").val(),
+      `\n[details="${I18n.t('composer.details_title')}"]\n${multilineInput}\n[/details]\n`,
+      'it should contain the right output'
+    );
+  });
+});


### PR DESCRIPTION
> BUG REPROT: https://meta.discourse.org/t/hide-details-button-not-functioning-splitting-text-into-multiple-details/73486


If the editor contained the following text:

```
first line
second line
```

Selecting them and clicking the `Hide Details` button would produce:

```
[details="Summary"]
first line
[/details]


[details="Summary"]
second line
[/details]
```

While the desired behaviour should be:

```
[details="Summary"]
first line
second line
[/details]
```