### PR TITLE
UX: Large image placeholder style changed in cooked html

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -407,6 +407,40 @@ a.mention, a.mention-group {
   }
 }
 
+.large-image-placeholder {
+  > a {
+
+    &.link {
+      margin-right: 10px;
+    }
+
+    > * { overflow: hidden; }
+
+    > i.fa {
+      color: dark-light-choose($primary-medium, $secondary-medium);
+      margin-right: 6px;
+      font-size: $base-font-size;
+      line-height: $base-line-height;
+    }
+
+    > span.url {
+      display: inline-block;
+      max-width: 300px;
+      margin-right: 6px;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    > span.help {
+      display: inline-block;
+      color: dark-light-choose($primary-medium, $secondary-medium);
+      font-size: 0.929em;
+      font-style: italic;
+      line-height: $base-line-height;
+    }
+  }
+}
+
 .broken-image, .large-image {
   color: dark-light-choose($primary-low-mid, $secondary-high);
   border: 1px solid $primary-low;

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -524,7 +524,6 @@ en:
   post:
     image_placeholder:
       broken: "This image is broken"
-      large: "This image is too large to display here; click to view"
 
   rate_limiter:
     slow_down: "You have performed this action too many times, try again later."
@@ -2856,6 +2855,8 @@ en:
       too_large: "Sorry, the image you are trying to upload is too big (maximum size is %{max_size_kb}KB), please resize it and try again."
       larger_than_x_megapixels: "Sorry, the image you are trying to upload is too large (maximum dimension is %{max_image_megapixels}-megapixels), please resize it and try again."
       size_not_found: "Sorry, but we couldn't determine the size of the image. Maybe your image is corrupted?"
+    placeholders:
+      too_large: "(image larger than %{max_size_kb}KB)"
 
   avatar:
     missing: "Sorry, we can't find any avatar associated with that email address. Can you try uploading it again?"

--- a/lib/cooked_post_processor.rb
+++ b/lib/cooked_post_processor.rb
@@ -81,9 +81,51 @@ class CookedPostProcessor
     return if images.blank?
 
     images.each do |img|
+      next if large_images.include?(img["src"]) && add_large_image_placeholder!(img)
+
       limit_size!(img)
       convert_to_link!(img)
     end
+  end
+
+  def add_large_image_placeholder!(img)
+    url = img["src"]
+
+    is_hyperlinked = is_a_hyperlink?(img)
+
+    placeholder = create_node("div", "large-image-placeholder")
+    img.add_next_sibling(placeholder)
+    placeholder.add_child(img)
+
+    a = create_link_node(nil, url, true)
+    img.add_next_sibling(a)
+
+    span = create_span_node("url", url)
+    a.add_child(span)
+    span.add_previous_sibling(create_icon_node("image"))
+    span.add_next_sibling(create_span_node("help", I18n.t("upload.placeholders.too_large", max_size_kb: SiteSetting.max_image_size_kb)))
+
+    # Only if the image is already linked
+    if is_hyperlinked
+      parent = placeholder.parent
+      parent.add_next_sibling(placeholder)
+
+      if parent.name == 'a' && parent["href"].present? && url != parent["href"]
+        parent["class"] = "link"
+        a.add_previous_sibling(parent)
+
+        lspan = create_span_node("url", parent["href"])
+        parent.add_child(lspan)
+        lspan.add_previous_sibling(create_icon_node("link"))
+      end
+    end
+
+    img.remove
+    true
+  end
+
+  def large_images
+    @large_images ||= @post.custom_fields[Jobs::PullHotlinkedImages::LARGE_IMAGES].presence || []
   end
 
   def extract_images
@@ -243,21 +285,18 @@ class CookedPostProcessor
 
   def add_lightbox!(img, original_width, original_height, upload = nil)
     # first, create a div to hold our lightbox
-    lightbox = Nokogiri::XML::Node.new("div", @doc)
-    lightbox["class"] = "lightbox-wrapper"
+    lightbox = create_node("div", "lightbox-wrapper")
     img.add_next_sibling(lightbox)
     lightbox.add_child(img)
 
     # then, the link to our larger image
-    a = Nokogiri::XML::Node.new("a", @doc)
+    a = create_link_node("lightbox", img["src"])
     img.add_next_sibling(a)
 
     if upload && Discourse.store.internal?
       a["data-download-href"] = Discourse.store.download_url(upload)
     end
 
-    a["href"] = img["src"]
-    a["class"] = "lightbox"
     a.add_child(img)
 
     # replace the image by its thumbnail
@@ -265,8 +304,7 @@ class CookedPostProcessor
     img["src"] = upload.thumbnail(w, h).url if upload && upload.has_thumbnail?(w, h)
 
     # then, some overlay informations
-    meta = Nokogiri::XML::Node.new("div", @doc)
-    meta["class"] = "meta"
+    meta = create_node("div", "meta")
     img.add_next_sibling(meta)
 
     filename = get_filename(upload, img["src"])
@@ -286,11 +324,30 @@ class CookedPostProcessor
     return I18n.t("upload.pasted_image_filename")
   end
 
+  def create_node(tag_name, klass)
+    node = Nokogiri::XML::Node.new(tag_name, @doc)
+    node["class"] = klass if klass.present?
+    node
+  end
+
   def create_span_node(klass, content = nil)
-    span = Nokogiri::XML::Node.new("span", @doc)
+    span = create_node("span", klass)
     span.content = content if content
-    span["class"] = klass
     span
+  end
+
+  def create_icon_node(klass)
+    create_node("i", "fa fa-fw fa-#{klass}")
+  end
+
+  def create_link_node(klass, url, external = false)
+    a = create_node("a", klass)
+    a["href"] = url
+    if external
+      a["target"] = "_blank"
+      a["rel"] = "nofollow noopener"
+    end
+    a
   end
 
   def update_post_image
@@ -317,14 +374,17 @@ class CookedPostProcessor
 
     uploads = oneboxed_image_uploads.select(:url, :origin)
     oneboxed_images.each do |img|
+      if large_images.include?(img["src"])
+        img.remove
+        next
+      end
+
       url = img["src"].sub(/^https?:/i, "")
       upload = uploads.find { |u| u.origin.sub(/^https?:/i, "") == url }
       img["src"] = upload.url if upload.present?
-    end
 
-    # make sure we grab dimensions for oneboxed images
-    # and wrap in a div
-    oneboxed_images.each do |img|
+      # make sure we grab dimensions for oneboxed images
+      # and wrap in a div
       limit_size!(img)
       if img.parent["class"].include?("onebox-body") && (width = img["width"].to_i) > 0 && (height = img["height"].to_i) > 0
         img.delete('width')

--- a/spec/components/cooked_post_processor_spec.rb
+++ b/spec/components/cooked_post_processor_spec.rb
@@ -162,7 +162,7 @@ describe CookedPostProcessor do
 
       it "generates overlay information" do
         cpp.post_process_images
-        expect(cpp.html).to match_html "<p><div class=\"lightbox-wrapper\"><a data-download-href=\"/uploads/default/#{upload.sha1}\" href=\"/uploads/default/1/1234567890123456.jpg\" class=\"lightbox\" title=\"logo.png\"><img src=\"/uploads/default/optimized/1X/#{upload.sha1}_1_690x788.png\" width=\"690\" height=\"788\"><div class=\"meta\">
+        expect(cpp.html).to match_html "<p><div class=\"lightbox-wrapper\"><a class=\"lightbox\" href=\"/uploads/default/1/1234567890123456.jpg\" data-download-href=\"/uploads/default/#{upload.sha1}\" title=\"logo.png\"><img src=\"/uploads/default/optimized/1X/#{upload.sha1}_1_690x788.png\" width=\"690\" height=\"788\"><div class=\"meta\">
 <span class=\"filename\">logo.png</span><span class=\"informations\">1750x2000 1.21 KB</span><span class=\"expand\"></span>
 </div></a></div></p>"
         expect(cpp).to be_dirty
@@ -193,7 +193,7 @@ describe CookedPostProcessor do
 
       it "generates overlay information" do
         cpp.post_process_images
-        expect(cpp.html).to match_html "<p><div class=\"lightbox-wrapper\"><a data-download-href=\"/subfolder/uploads/default/#{upload.sha1}\" href=\"/subfolder/uploads/default/1/1234567890123456.jpg\" class=\"lightbox\" title=\"logo.png\"><img src=\"/subfolder/uploads/default/optimized/1X/#{upload.sha1}_1_690x788.png\" width=\"690\" height=\"788\"><div class=\"meta\">
+        expect(cpp.html).to match_html "<p><div class=\"lightbox-wrapper\"><a class=\"lightbox\" href=\"/subfolder/uploads/default/1/1234567890123456.jpg\" data-download-href=\"/subfolder/uploads/default/#{upload.sha1}\" title=\"logo.png\"><img src=\"/subfolder/uploads/default/optimized/1X/#{upload.sha1}_1_690x788.png\" width=\"690\" height=\"788\"><div class=\"meta\">
 <span class=\"filename\">logo.png</span><span class=\"informations\">1750x2000 1.21 KB</span><span class=\"expand\"></span>
 </div></a></div></p>"
         expect(cpp).to be_dirty
@@ -202,7 +202,7 @@ describe CookedPostProcessor do
       it "should escape the filename" do
         upload.update_attributes!(original_filename: "><img src=x onerror=alert('haha')>.png")
         cpp.post_process_images
-        expect(cpp.html).to match_html "<p><div class=\"lightbox-wrapper\"><a data-download-href=\"/subfolder/uploads/default/#{upload.sha1}\" href=\"/subfolder/uploads/default/1/1234567890123456.jpg\" class=\"lightbox\" title=\"&amp;gt;&amp;lt;img src=x onerror=alert(&amp;#39;haha&amp;#39;)&amp;gt;.png\"><img src=\"/subfolder/uploads/default/optimized/1X/#{upload.sha1}_1_690x788.png\" width=\"690\" height=\"788\"><div class=\"meta\">
+        expect(cpp.html).to match_html "<p><div class=\"lightbox-wrapper\"><a class=\"lightbox\" href=\"/subfolder/uploads/default/1/1234567890123456.jpg\" data-download-href=\"/subfolder/uploads/default/#{upload.sha1}\" title=\"&amp;gt;&amp;lt;img src=x onerror=alert(&amp;#39;haha&amp;#39;)&amp;gt;.png\"><img src=\"/subfolder/uploads/default/optimized/1X/#{upload.sha1}_1_690x788.png\" width=\"690\" height=\"788\"><div class=\"meta\">
 <span class=\"filename\">&amp;gt;&amp;lt;img src=x onerror=alert(&amp;#39;haha&amp;#39;)&amp;gt;.png</span><span class=\"informations\">1750x2000 1.21 KB</span><span class=\"expand\"></span>
 </div></a></div></p>"
       end
@@ -228,7 +228,7 @@ describe CookedPostProcessor do
 
       it "generates overlay information" do
         cpp.post_process_images
-        expect(cpp.html).to match_html "<p><div class=\"lightbox-wrapper\"><a data-download-href=\"/uploads/default/#{upload.sha1}\" href=\"/uploads/default/1/1234567890123456.jpg\" class=\"lightbox\" title=\"WAT\"><img src=\"/uploads/default/optimized/1X/#{upload.sha1}_1_690x788.png\" title=\"WAT\" width=\"690\" height=\"788\"><div class=\"meta\">
+        expect(cpp.html).to match_html "<p><div class=\"lightbox-wrapper\"><a class=\"lightbox\" href=\"/uploads/default/1/1234567890123456.jpg\" data-download-href=\"/uploads/default/#{upload.sha1}\" title=\"WAT\"><img src=\"/uploads/default/optimized/1X/#{upload.sha1}_1_690x788.png\" title=\"WAT\" width=\"690\" height=\"788\"><div class=\"meta\">
        <span class=\"filename\">WAT</span><span class=\"informations\">1750x2000 1.21 KB</span><span class=\"expand\"></span>
        </div></a></div></p>"
         expect(cpp).to be_dirty

--- a/spec/jobs/pull_hotlinked_images_spec.rb
+++ b/spec/jobs/pull_hotlinked_images_spec.rb
@@ -111,7 +111,7 @@ describe Jobs::PullHotlinkedImages do
         expect(post.cooked).to match(/<p><img src=.*\/uploads/)
         expect(post.cooked).to match(/<img src=.*\/uploads.*\ class="thumbnail"/)
         expect(post.cooked).to match(/<span class="broken-image fa fa-chain-broken/)
-        expect(post.cooked).to match(/<\/a><br><a href=.*\ target="_blank" .*\><span class="large-image fa fa-picture-o"><\/span><\/a>/)
+        expect(post.cooked).to match(/<div class="large-image-placeholder">/)
       end
     end
   end
@@ -132,9 +132,10 @@ describe Jobs::PullHotlinkedImages do
 
       Jobs::ProcessPost.new.execute(post_id: post.id)
       Jobs::PullHotlinkedImages.new.execute(post_id: post.id)
+      Jobs::ProcessPost.new.execute(post_id: post.id)
       post.reload
 
-      expect(post.cooked).to match(/<a href=.*\ target="_blank" .*\><span class="large-image fa fa-picture-o"><\/span><\/a>/)
+      expect(post.cooked).to match(/<div class="large-image-placeholder"><a href=.*\ target="_blank" .*\>/)
     end
   end
 


### PR DESCRIPTION
Large image placeholder UI changed as inline in cooked html. **And totally removed the large images inside onebox**.