### PR TITLE
Add onceoff job to remap bot images link.

### DIFF
--- a/plugins/discourse-narrative-bot/jobs/onceoff/remap_old_bot_images.rb
+++ b/plugins/discourse-narrative-bot/jobs/onceoff/remap_old_bot_images.rb
@@ -1,0 +1,36 @@
+module Jobs
+  module DiscourseNarrativeBot
+    class RemapOldBotImages < ::Jobs::Onceoff
+      def execute_onceoff(args)
+        paths = [
+          "/images/font-awesome-link.png",
+          "/images/unicorn.png",
+          "/images/font-awesome-ellipsis.png",
+          "/images/font-awesome-bookmark.png",
+          "/images/font-awesome-smile.png",
+          "/images/font-awesome-flag.png",
+          "/images/font-awesome-search.png",
+          "/images/capybara-eating.gif",
+          "/images/font-awesome-pencil.png",
+          "/images/font-awesome-trash.png",
+          "/images/font-awesome-rotate-left.png",
+          "/images/font-awesome-gear.png",
+        ]
+
+        Post.raw_match("/images/").where(user_id: -2).find_each do |post|
+          if (matches = post.raw.scan(/(?<!\/plugins\/discourse-narrative-bot)(#{paths.join("|")})/)).present?
+            new_raw = post.raw
+
+            matches.each do |match|
+              path = match.first
+              new_raw = new_raw.gsub(path, "/plugins/discourse-narrative-bot#{path}")
+            end
+
+            post.update_columns(raw: new_raw)
+            post.rebake!
+          end
+        end
+      end
+    end
+  end
+end

--- a/plugins/discourse-narrative-bot/plugin.rb
+++ b/plugins/discourse-narrative-bot/plugin.rb
@@ -19,6 +19,7 @@ after_initialize do
     '../jobs/narrative_init.rb',
     '../jobs/send_default_welcome_message.rb',
     '../jobs/onceoff/grant_badges.rb',
+    '../jobs/onceoff/remap_old_bot_images.rb',
     '../lib/discourse_narrative_bot/actions.rb',
     '../lib/discourse_narrative_bot/base.rb',
     '../lib/discourse_narrative_bot/new_user_narrative.rb',

--- a/plugins/discourse-narrative-bot/spec/jobs/onceoff/remap_old_bot_iamges_spec.rb
+++ b/plugins/discourse-narrative-bot/spec/jobs/onceoff/remap_old_bot_iamges_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe Jobs::DiscourseNarrativeBot::RemapOldBotImages do
+  context "when bot's post contains an old link" do
+    let(:post) do
+      Fabricate(:post,
+        user_id: -2,
+        raw: 'If you’d like to learn more, select <img src="/images/font-awesome-gear.png" width="16" height="16"> <img src="/images/font-awesome-ellipsis.png" width="16" height="16"> below  and <img src="/images/font-awesome-bookmark.png" width="16" height="16"> **bookmark this private message**.  If you do, there may be a :gift: in your future!'
+      )
+    end
+
+    before do
+      post
+    end
+
+    it 'should remap the links correctly' do
+      expected_raw = 'If you’d like to learn more, select <img src="/plugins/discourse-narrative-bot/images/font-awesome-gear.png" width="16" height="16"> <img src="/plugins/discourse-narrative-bot/images/font-awesome-ellipsis.png" width="16" height="16"> below  and <img src="/plugins/discourse-narrative-bot/images/font-awesome-bookmark.png" width="16" height="16"> **bookmark this private message**.  If you do, there may be a :gift: in your future!'
+
+      2.times do
+        described_class.new.execute_onceoff({})
+        expect(post.reload.raw).to eq(expected_raw)
+      end
+    end
+
+    context 'subfolder' do
+      let(:post) do
+        Fabricate(:post,
+          user_id: -2,
+          raw: 'If you’d like to learn more, select <img src="/community/images/font-awesome-ellipsis.png" width="16" height="16"> below  and <img src="/community/images/font-awesome-bookmark.png" width="16" height="16"> **bookmark this private message**.  If you do, there may be a :gift: in your future!'
+        )
+      end
+
+      it 'should remap the links correctly' do
+        described_class.new.execute_onceoff({})
+
+        expect(post.reload.raw).to eq(
+          'If you’d like to learn more, select <img src="/community/plugins/discourse-narrative-bot/images/font-awesome-ellipsis.png" width="16" height="16"> below  and <img src="/community/plugins/discourse-narrative-bot/images/font-awesome-bookmark.png" width="16" height="16"> **bookmark this private message**.  If you do, there may be a :gift: in your future!'
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://meta.discourse.org/t/discobot-tutorial-broken-elipsis-and-bookmark-png-images-appear-to-be-missing-on-my-site/73294/12