### PR TITLE
Fix infinite loading of group posts

### DIFF
--- a/app/assets/javascripts/discourse/controllers/group-activity-posts.js.es6
+++ b/app/assets/javascripts/discourse/controllers/group-activity-posts.js.es6
@@ -1,13 +1,17 @@
+import { default as computed, observes } from 'ember-addons/ember-computed-decorators';
 import { fmt } from 'discourse/lib/computed';
 
 export default Ember.Controller.extend({
   group: Ember.inject.controller(),
   groupActivity: Ember.inject.controller(),
+  application: Ember.inject.controller(),
+  canLoadMore: true,
   loading: false,
   emptyText: fmt('type', 'groups.empty.%@'),
 
   actions: {
     loadMore() {
+      if (!this.get('canLoadMore')) { return; }
       if (this.get('loading')) { return; }
       this.set('loading', true);
       const posts = this.get('model');
@@ -20,9 +24,18 @@ export default Ember.Controller.extend({
 
         group.findPosts(opts).then(newPosts => {
           posts.addObjects(newPosts);
+          if(newPosts.length === 0) {
+            this.set('canLoadMore', false);
+          }
+        }).finally(() => {
           this.set('loading', false);
         });
       }
     }
+  },
+
+  @observes('canLoadMore')
+  _showFooter() {
+    this.set("application.showFooter", !this.get("canLoadMore"));
   }
 });

--- a/app/assets/javascripts/discourse/routes/group-activity-posts.js.es6
+++ b/app/assets/javascripts/discourse/routes/group-activity-posts.js.es6
@@ -12,7 +12,7 @@ export function buildGroupPage(type) {
     },
 
     setupController(controller, model) {
-      this.controllerFor('group-activity-posts').setProperties({ model, type });
+      this.controllerFor('group-activity-posts').setProperties({ model, type, canLoadMore: true });
       this.controllerFor("group").set("showing", type);
     },
 


### PR DESCRIPTION
Currently a bug on the groups posts view, posts will infinity load with zero length results. This addresses that bug.