### PR TITLE
bringing mobile topic statuses to parity with desktop

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -321,6 +321,8 @@ blockquote > *:last-child {
 }
 
 .small-action {
+  max-width: 755px;
+  border-top: 1px solid $primary-low;
   .topic-avatar {
     padding: 5px 0 3px;
     border-top: none;
@@ -332,10 +334,15 @@ blockquote > *:last-child {
       color: dark-light-choose($primary-low-mid, $secondary-high);
     }
   }
+  
+  .small-action.deleted {
+    background-color: dark-light-diff(rgba($danger,.7), $secondary, 50%, -60%);
+  }
 
   .small-action-desc.timegap {
       color: dark-light-choose($primary-medium, $secondary-high);
   }
+
   .small-action-desc {
     padding: 0.25em 0 0.5em 4.3em;
     margin-top: 6px;

--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -660,15 +660,6 @@ $topic-avatar-width: 45px;
   width: calc(#{$topic-avatar-width} + #{$topic-body-width} + 2 * #{$topic-body-width-padding});
 }
 
-.small-action {
-  max-width: 755px;
-  border-top: 1px solid $primary-low;
-}
-
-.small-action.deleted {
-  background-color: dark-light-diff(rgba($danger,.7), $secondary, 50%, -60%);
-}
-
 /* hide the reply border above the time gap notices */
 .time-gap + .topic-post .topic-body,
 .time-gap + .topic-post .topic-avatar {

--- a/app/assets/stylesheets/mobile/topic-post.scss
+++ b/app/assets/stylesheets/mobile/topic-post.scss
@@ -1,27 +1,3 @@
-.gap {
-  /* may not need this */
-}
-
-.small-action {
-  border-top: 1px solid $primary-low;
-  color: lighten($primary, 50%);
-  padding-bottom: 3px;
-  text-transform: uppercase;
-  font-weight: bold;
-
-  .topic-avatar {
-    margin-top: 5px;
-  }
-
-  .small-action-desc {
-    padding-top: 1em;
-
-    button {
-      padding-top: 0px;
-    }
-  }
-}
-
 /* hide the reply border above the time gap notices */
 .time-gap + .topic-post article {
   border-top: none;
@@ -35,7 +11,6 @@
 .post-stream {
   padding-bottom: 30px;
 }
-
 
 span.badge-posts {
   margin-right: 5px;


### PR DESCRIPTION
The small topic stuff can still be rewritten in flexbox for even better alignment, but this at least brings mobile up to speed with desktop in terms of alignment issues.

**Before**
![image uploaded from ios](https://user-images.githubusercontent.com/1681963/32680181-804b86bc-c637-11e7-806b-2e8b572468e5.jpg)

**After**
<img width="412" alt="screen shot 2017-11-10 at 3 23 26 pm" src="https://user-images.githubusercontent.com/1681963/32680107-2e4cccc2-c637-11e7-8369-7211b1de28aa.png">
