### PR TITLE
fix error "extension "hstore" already exists"

### DIFF
--- a/script/osx_dev
+++ b/script/osx_dev
@@ -74,8 +74,8 @@ echo "Creating PostgreSQL databases..."
 psql -d postgres -c "ALTER USER vagrant WITH PASSWORD 'password';"
 psql -d postgres -c "create database discourse_development owner vagrant encoding 'UTF8' TEMPLATE template0;"
 psql -d postgres -c "create database discourse_test        owner vagrant encoding 'UTF8' TEMPLATE template0;"
-psql -d discourse_development -c "CREATE EXTENSION hstore;"
-psql -d discourse_development -c "CREATE EXTENSION pg_trgm;"
+psql -d discourse_development -c "CREATE EXTENSION IF NOT EXISTS hstore;"
+psql -d discourse_development -c "CREATE EXTENSION IF NOT EXISTS pg_trgm;"
 
 ## Start Redis (Redis was installed by Homebrew using `brew bundle`) ##
 echo "Loading Redis..."


### PR DESCRIPTION
Error executing 'postInstallation': ERROR:  extension "hstore" already exists

I just saw that error from console, hope this can fix that error.