### PR TITLE
fixing category delete modal background color

### DIFF
--- a/app/assets/stylesheets/common/base/modal.scss
+++ b/app/assets/stylesheets/common/base/modal.scss
@@ -331,8 +331,8 @@
 
     .cannot_delete_reason {
       position: absolute;
-      background: dark-light-choose($primary, $secondary);
-      color: dark-light-choose($secondary, $secondary);
+      background: $primary;
+      color: $secondary;
       text-align: center;
       border-radius: 2px;
       padding: 12px 8px;
@@ -343,13 +343,12 @@
         border: solid transparent;
         content: " ";
         position: absolute;
-        border-top-color: dark-light-choose($primary, $secondary);
+        border-top-color: $primary;
         border-width: 8px;
       }
     }
   }
 }
-
 
 .incoming-email-modal {
   .btn {


### PR DESCRIPTION
Should look like this 

<img width="379" alt="screen shot 2017-11-13 at 5 10 32 pm" src="https://user-images.githubusercontent.com/1681963/32751997-9bc2e420-c895-11e7-8cd7-a672806f6a5c.png">

not this 

![image](https://user-images.githubusercontent.com/1681963/32752013-a94667d4-c895-11e7-93c2-04fe69116926.png)

as reported here: https://meta.discourse.org/t/unable-to-delete-a-category/73983