### PR TITLE
FEATURE: Replace SimpleRSS with Ruby RSS module

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -165,7 +165,6 @@ gem 'gc_tracer', require: false, platform: :mri
 
 # required for feed importing and embedding
 gem 'ruby-readability', require: false
-gem 'simple-rss', require: false
 
 gem 'stackprof', require: false, platform: :mri
 gem 'memory_profiler', require: false, platform: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -364,7 +364,6 @@ GEM
       connection_pool (~> 2.2, >= 2.2.0)
       rack-protection (>= 1.5.0)
       redis (>= 3.3.4, < 5)
-    simple-rss (1.3.1)
     slop (3.6.0)
     sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
@@ -494,7 +493,6 @@ DEPENDENCIES
   seed-fu (~> 2.3.5)
   shoulda
   sidekiq
-  simple-rss
   sprockets-rails
   stackprof
   thor

--- a/app/jobs/scheduled/poll_feed.rb
+++ b/app/jobs/scheduled/poll_feed.rb
@@ -81,12 +81,11 @@ module Jobs
         return nil if raw_feed.blank?
 
         if SiteSetting.embed_username_key_from_feed.present?
-          FeedElementInstaller.install_rss_element(SiteSetting.embed_username_key_from_feed)
-          FeedElementInstaller.install_atom_element(SiteSetting.embed_username_key_from_feed)
+          FeedElementInstaller.install(SiteSetting.embed_username_key_from_feed, raw_feed)
         end
 
-        RSS::Parser.parse(raw_feed, false)
-      rescue RSS::NotWellFormedError
+        RSS::Parser.parse(raw_feed)
+      rescue RSS::NotWellFormedError, RSS::InvalidRSSError
         nil
       end
 
@@ -144,7 +143,7 @@ module Jobs
       end
 
       def author_username
-        @accessor.element_content(SiteSetting.embed_username_key_from_feed.to_sym)
+        @accessor.element_content(SiteSetting.embed_username_key_from_feed.sub(':', '_'))
       end
 
       def default_user

--- a/app/jobs/scheduled/poll_feed.rb
+++ b/app/jobs/scheduled/poll_feed.rb
@@ -53,10 +53,6 @@ module Jobs
     class Feed
       require 'simple-rss'
 
-      if SiteSetting.embed_username_key_from_feed.present?
-        SimpleRSS.item_tags << SiteSetting.embed_username_key_from_feed.to_sym
-      end
-
       def initialize
         @feed_url = SiteSetting.feed_polling_url
         @feed_url = "http://#{@feed_url}" if @feed_url !~ /^https?\:\/\//
@@ -79,6 +75,10 @@ module Jobs
       private
 
       def fetch_rss
+        if SiteSetting.embed_username_key_from_feed.present?
+          SimpleRSS.item_tags |= [SiteSetting.embed_username_key_from_feed.to_sym]
+        end
+
         SimpleRSS.parse open(@feed_url, allow_redirections: :all)
       rescue OpenURI::HTTPError, SimpleRSSError
         nil

--- a/lib/feed_element_installer.rb
+++ b/lib/feed_element_installer.rb
@@ -1,0 +1,21 @@
+require 'rss'
+
+module FeedElementInstaller
+  module_function
+
+  def install_rss_element(element_name)
+    return if RSS::Rss::Channel::Item.method_defined?(element_name)
+
+    RSS::Rss::Channel::Item.install_text_element(element_name, '', '?', element_name)
+    RSS::BaseListener.install_get_text_element("", element_name, element_name)
+  end
+
+  def install_atom_element(element_name)
+    return if RSS::Atom::Entry.method_defined?(element_name) ||
+              RSS::Atom::Feed::Entry.method_defined?(element_name)
+
+    RSS::Atom::Entry.install_text_element(element_name, '', '?', element_name)
+    RSS::Atom::Feed::Entry.install_text_element(element_name, '', '?', element_name)
+    RSS::BaseListener.install_get_text_element(RSS::Atom::URI, element_name, element_name)
+  end
+end

--- a/lib/feed_element_installer.rb
+++ b/lib/feed_element_installer.rb
@@ -1,21 +1,52 @@
+require 'rexml/document'
 require 'rss'
 
-module FeedElementInstaller
-  module_function
+class FeedElementInstaller
+  private_class_method :new
 
-  def install_rss_element(element_name)
-    return if RSS::Rss::Channel::Item.method_defined?(element_name)
+  def self.install(element_name, feed)
+    # RSS Specification at http://cyber.harvard.edu/rss/rss.html#extendingRss
+    # > A RSS feed may contain [non-standard elements], only if those elements are *defined in a namespace*
 
-    RSS::Rss::Channel::Item.install_text_element(element_name, '', '?', element_name)
-    RSS::BaseListener.install_get_text_element("", element_name, element_name)
+    new(element_name, feed).install if element_name.include?(':')
   end
 
-  def install_atom_element(element_name)
-    return if RSS::Atom::Entry.method_defined?(element_name) ||
-              RSS::Atom::Feed::Entry.method_defined?(element_name)
+  attr_reader :feed, :original_name, :element_namespace, :element_name, :element_accessor
 
-    RSS::Atom::Entry.install_text_element(element_name, '', '?', element_name)
-    RSS::Atom::Feed::Entry.install_text_element(element_name, '', '?', element_name)
-    RSS::BaseListener.install_get_text_element(RSS::Atom::URI, element_name, element_name)
+  def initialize(element_name, feed)
+    @feed = feed
+    @original_name = element_name
+    @element_namespace, @element_name = *element_name.split(':')
+    @element_accessor = "#{@element_namespace}_#{@element_name}"
+  end
+
+  def element_uri
+    @element_uri ||= REXML::Document.new(feed).root&.attributes&.namespaces&.fetch(@element_namespace, '') || ''
+  end
+
+  def install
+    install_in_rss unless installed_in_rss?
+    install_in_atom unless installed_in_atom?
+  end
+
+  private
+
+  def install_in_rss
+    RSS::Rss::Channel::Item.install_text_element(element_name, element_uri, '?', element_accessor, nil, original_name)
+    RSS::BaseListener.install_get_text_element(element_uri, element_name, element_accessor)
+  end
+
+  def install_in_atom
+    RSS::Atom::Entry.install_text_element(element_name, element_uri, '?', element_accessor, nil, original_name)
+    RSS::Atom::Feed::Entry.install_text_element(element_name, element_uri, '?', element_accessor, nil, original_name)
+    RSS::BaseListener.install_get_text_element(element_uri, element_name, element_accessor)
+  end
+
+  def installed_in_rss?
+    RSS::Rss::Channel::Item.method_defined?(element_accessor)
+  end
+
+  def installed_in_atom?
+    RSS::Atom::Entry.method_defined?(element_accessor) || RSS::Atom::Feed::Entry.method_defined?(element_accessor)
   end
 end

--- a/lib/feed_item_accessor.rb
+++ b/lib/feed_item_accessor.rb
@@ -1,0 +1,25 @@
+class FeedItemAccessor
+  attr_accessor :rss_item
+
+  def initialize(rss_item)
+    @rss_item = rss_item
+  end
+
+  def element_content(element_name)
+    try_attribute_or_self(element(element_name), :content)
+  end
+
+  def link
+    try_attribute_or_self(element(:link), :href)
+  end
+
+  private
+
+  def element(element_name)
+    rss_item.respond_to?(element_name) ? rss_item.send(element_name) : nil
+  end
+
+  def try_attribute_or_self(element, attribute_name)
+    element.respond_to?(attribute_name) ? element.send(attribute_name) : element
+  end
+end

--- a/spec/components/feed_element_installer_spec.rb
+++ b/spec/components/feed_element_installer_spec.rb
@@ -1,0 +1,28 @@
+require 'feed_element_installer'
+require 'rails_helper'
+
+describe FeedElementInstaller do
+  describe '#install_rss_element' do
+    let(:rss_feed_file) { file_from_fixtures('feed.rss', 'feed') }
+
+    it 'creates parsing for a non-standard, non-namespaced element' do
+      FeedElementInstaller.install_rss_element('username')
+
+      feed = RSS::Parser.parse(rss_feed_file, false)
+
+      expect(feed.items.first.username).to eq('xrav3nz')
+    end
+  end
+
+  describe '#install_atom_element' do
+    let(:atom_feed_file) { file_from_fixtures('feed.atom', 'feed') }
+
+    it 'creates parsing for a non-standard, non-namespaced element' do
+      FeedElementInstaller.install_atom_element('username')
+
+      feed = RSS::Parser.parse(atom_feed_file, false)
+
+      expect(feed.items.first.username).to eq('xrav3nz')
+    end
+  end
+end

--- a/spec/components/feed_element_installer_spec.rb
+++ b/spec/components/feed_element_installer_spec.rb
@@ -3,26 +3,38 @@ require 'rails_helper'
 
 describe FeedElementInstaller do
   describe '#install_rss_element' do
-    let(:rss_feed_file) { file_from_fixtures('feed.rss', 'feed') }
+    let(:raw_feed) { file_from_fixtures('feed.rss', 'feed').read }
 
-    it 'creates parsing for a non-standard, non-namespaced element' do
-      FeedElementInstaller.install_rss_element('username')
+    it 'creates parsing for a non-standard, namespaced element' do
+      FeedElementInstaller.install('discourse:username', raw_feed)
+      feed = RSS::Parser.parse(raw_feed)
 
-      feed = RSS::Parser.parse(rss_feed_file, false)
+      expect(feed.items.first.discourse_username).to eq('xrav3nz')
+    end
 
-      expect(feed.items.first.username).to eq('xrav3nz')
+    it 'does not create parsing for a non-standard, non-namespaced element' do
+      FeedElementInstaller.install('username', raw_feed)
+      feed = RSS::Parser.parse(raw_feed)
+
+      expect { feed.items.first.username }.to raise_error(NoMethodError)
     end
   end
 
   describe '#install_atom_element' do
-    let(:atom_feed_file) { file_from_fixtures('feed.atom', 'feed') }
+    let(:raw_feed) { file_from_fixtures('feed.atom', 'feed').read }
 
-    it 'creates parsing for a non-standard, non-namespaced element' do
-      FeedElementInstaller.install_atom_element('username')
+    it 'creates parsing for a non-standard, namespaced element' do
+      FeedElementInstaller.install('discourse:username', raw_feed)
+      feed = RSS::Parser.parse(raw_feed)
 
-      feed = RSS::Parser.parse(atom_feed_file, false)
+      expect(feed.items.first.discourse_username).to eq('xrav3nz')
+    end
 
-      expect(feed.items.first.username).to eq('xrav3nz')
+    it 'does not create parsing for a non-standard, non-namespaced element' do
+      FeedElementInstaller.install('username', raw_feed)
+      feed = RSS::Parser.parse(raw_feed)
+
+      expect { feed.items.first.username }.to raise_error(NoMethodError)
     end
   end
 end

--- a/spec/components/feed_item_accessor_spec.rb
+++ b/spec/components/feed_item_accessor_spec.rb
@@ -1,0 +1,33 @@
+require 'rss'
+require 'feed_item_accessor'
+require 'rails_helper'
+
+describe FeedItemAccessor do
+  context 'for ATOM feed' do
+    let(:atom_feed) { RSS::Parser.parse(file_from_fixtures('feed.atom', 'feed'), false) }
+    let(:atom_feed_item) { atom_feed.items.first }
+    let(:item_accessor) { FeedItemAccessor.new(atom_feed_item) }
+
+    describe '#element_content' do
+      it { expect(item_accessor.element_content('title')).to eq(atom_feed_item.title.content) }
+    end
+
+    describe '#link' do
+      it { expect(item_accessor.link).to eq(atom_feed_item.link.href) }
+    end
+  end
+
+  context 'for RSS feed' do
+    let(:rss_feed) { RSS::Parser.parse(file_from_fixtures('feed.rss', 'feed'), false) }
+    let(:rss_feed_item) { rss_feed.items.first }
+    let(:item_accessor) { FeedItemAccessor.new(rss_feed_item) }
+
+    describe '#element_content' do
+      it { expect(item_accessor.element_content('title')).to eq(rss_feed_item.title) }
+    end
+
+    describe '#link' do
+      it { expect(item_accessor.link).to eq(rss_feed_item.link) }
+    end
+  end
+end

--- a/spec/fixtures/feed/feed.atom
+++ b/spec/fixtures/feed/feed.atom
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed
+  xmlns="http://www.w3.org/2005/Atom"
+  xmlns:thr="http://purl.org/syndication/thread/1.0"
+  xml:lang="en-US"
+  xml:base="https://blog.discourse.org/wp-atom.php"
+   >
+  <title type="text">Discourse</title>
+  <subtitle type="text">Official blog for the open source Discourse project</subtitle>
+  <updated>2017-10-23T23:45:37Z</updated>
+  <link rel="alternate" type="text/html" href="https://blog.discourse.org" />
+  <id>https://blog.discourse.org/feed/atom/</id>
+  <link rel="self" type="application/atom+xml" href="https://blog.discourse.org/feed/atom/" />
+  <generator uri="https://wordpress.org/" version="4.8.2">WordPress</generator>
+  <entry>
+    <username>xrav3nz</username>
+    <author>
+      <name>xrav3nz</name>
+    </author>
+    <title type="html"><![CDATA[Poll Feed Spec Fixture]]></title>
+    <link rel="alternate" type="text/html" href="https://blog.discourse.org/2017/09/poll-feed-spec-fixture/" />
+    <id>https://blog.discourse.org/?p=pollfeedspec</id>
+    <updated>2017-09-14T15:22:33Z</updated>
+    <published>2017-09-14T15:22:33Z</published>
+    <category scheme="https://blog.discourse.org" term="design" />
+    <summary type="html"><![CDATA[Here are some random descriptions... [&#8230;]]]></summary>
+    <content type="html" xml:base="https://blog.discourse.org/2017/09/poll-feed-spec-fixture/"><![CDATA[<p>This is the body &amp; content. </p>]]></content>
+  </entry>
+</feed>

--- a/spec/fixtures/feed/feed.atom
+++ b/spec/fixtures/feed/feed.atom
@@ -2,6 +2,7 @@
 <feed
   xmlns="http://www.w3.org/2005/Atom"
   xmlns:thr="http://purl.org/syndication/thread/1.0"
+  xmlns:discourse="http://discourse.org/rss/modules/discourse/"
   xml:lang="en-US"
   xml:base="https://blog.discourse.org/wp-atom.php"
    >
@@ -13,7 +14,7 @@
   <link rel="self" type="application/atom+xml" href="https://blog.discourse.org/feed/atom/" />
   <generator uri="https://wordpress.org/" version="4.8.2">WordPress</generator>
   <entry>
-    <username>xrav3nz</username>
+    <discourse:username><![CDATA[xrav3nz]]></discourse:username>
     <author>
       <name>xrav3nz</name>
     </author>

--- a/spec/fixtures/feed/feed.rss
+++ b/spec/fixtures/feed/feed.rss
@@ -5,6 +5,7 @@
   xmlns:atom="http://www.w3.org/2005/Atom"
   xmlns:sy="http://purl.org/rss/1.0/modules/syndication/"
   xmlns:slash="http://purl.org/rss/1.0/modules/slash/"
+  xmlns:discourse="http://discourse.org/rss/modules/discourse/"
   >
 <channel>
   <title>Discourse</title>
@@ -21,7 +22,7 @@
     <link>https://blog.discourse.org/2017/09/poll-feed-spec-fixture/</link>
     <pubDate>Thu, 14 Sep 2017 15:22:33 +0000</pubDate>
     <dc:creator><![CDATA[xrav3nz]]></dc:creator>
-    <username><![CDATA[xrav3nz]]></username>
+    <discourse:username><![CDATA[xrav3nz]]></discourse:username>
     <category><![CDATA[spec]]></category>
     <guid isPermaLink="false">https://blog.discourse.org/?p=pollfeedspec</guid>
     <description><![CDATA[Here are some random descriptions... [&#8230;]]]></description>

--- a/spec/fixtures/feed/feed.rss
+++ b/spec/fixtures/feed/feed.rss
@@ -21,6 +21,7 @@
     <link>https://blog.discourse.org/2017/09/poll-feed-spec-fixture/</link>
     <pubDate>Thu, 14 Sep 2017 15:22:33 +0000</pubDate>
     <dc:creator><![CDATA[xrav3nz]]></dc:creator>
+    <username><![CDATA[xrav3nz]]></username>
     <category><![CDATA[spec]]></category>
     <guid isPermaLink="false">https://blog.discourse.org/?p=pollfeedspec</guid>
     <description><![CDATA[Here are some random descriptions... [&#8230;]]]></description>

--- a/spec/jobs/poll_feed_spec.rb
+++ b/spec/jobs/poll_feed_spec.rb
@@ -44,7 +44,7 @@ describe Jobs::PollFeed do
 
   describe '#poll_feed' do
     let(:embed_by_username) { 'eviltrout' }
-    let(:embed_username_key_from_feed) { 'username' }
+    let(:embed_username_key_from_feed) { 'discourse:username' }
     let!(:default_user) { Fabricate(:evil_trout) }
     let!(:feed_author) { Fabricate(:user, username: 'xrav3nz', email: 'hi@bye.com') }
 

--- a/spec/jobs/poll_feed_spec.rb
+++ b/spec/jobs/poll_feed_spec.rb
@@ -99,6 +99,7 @@ describe Jobs::PollFeed do
         SiteSetting.feed_polling_url = 'https://blog.discourse.org/feed/'
         SiteSetting.embed_by_username = embed_by_username
 
+        stub_request(:head, SiteSetting.feed_polling_url).to_return(status: 200)
         stub_request(:get, SiteSetting.feed_polling_url).to_return(
           status: 200,
           body: file_from_fixtures('feed.rss', 'feed').read,
@@ -115,6 +116,7 @@ describe Jobs::PollFeed do
         SiteSetting.feed_polling_url = 'https://blog.discourse.org/feed/atom/'
         SiteSetting.embed_by_username = embed_by_username
 
+        stub_request(:head, SiteSetting.feed_polling_url).to_return(status: 200)
         stub_request(:get, SiteSetting.feed_polling_url).to_return(
           status: 200,
           body: file_from_fixtures('feed.atom', 'feed').read,

--- a/spec/jobs/poll_feed_spec.rb
+++ b/spec/jobs/poll_feed_spec.rb
@@ -40,76 +40,89 @@ describe Jobs::PollFeed do
       poller.execute({})
       poller.execute({})
     end
-
   end
 
   describe '#poll_feed' do
     let(:embed_by_username) { 'eviltrout' }
-    let(:embed_username_key_from_feed) { 'dc_creator' }
+    let(:embed_username_key_from_feed) { 'username' }
     let!(:default_user) { Fabricate(:evil_trout) }
     let!(:feed_author) { Fabricate(:user, username: 'xrav3nz', email: 'hi@bye.com') }
 
-    before do
-      SiteSetting.feed_polling_enabled = true
-      SiteSetting.feed_polling_url = 'https://blog.discourse.org/feed/'
-      SiteSetting.embed_by_username = embed_by_username
+    shared_examples 'topic creation based on the the feed' do
+      describe 'author username parsing' do
+        context 'when neither embed_by_username nor embed_username_key_from_feed is set' do
+          before do
+            SiteSetting.embed_by_username = ""
+            SiteSetting.embed_username_key_from_feed = ""
+          end
 
-      stub_request(:get, SiteSetting.feed_polling_url).to_return(
-        status: 200,
-        body: file_from_fixtures('feed.rss', 'feed').read,
-        headers: { "Content-Type" => "application/rss+xml" }
-      )
-    end
-
-    describe 'author username parsing' do
-      context 'when neither embed_by_username nor embed_username_key_from_feed is set' do
-        before do
-          SiteSetting.embed_by_username = ""
-          SiteSetting.embed_username_key_from_feed = ""
+          it 'does not import topics' do
+            expect { poller.poll_feed }.not_to change { Topic.count }
+          end
         end
 
-        it 'does not import topics' do
-          expect { poller.poll_feed }.not_to change { Topic.count }
+        context 'when embed_by_username is set' do
+          before do
+            SiteSetting.embed_by_username = embed_by_username
+            SiteSetting.embed_username_key_from_feed = ""
+          end
+
+          it 'creates the new topics under embed_by_username' do
+            expect { poller.poll_feed }.to change { Topic.count }.by(1)
+            expect(Topic.last.user).to eq(default_user)
+          end
+        end
+
+        context 'when embed_username_key_from_feed is set' do
+          before do
+            SiteSetting.embed_username_key_from_feed = embed_username_key_from_feed
+          end
+
+          it 'creates the new topics under the username found' do
+            expect { poller.poll_feed }.to change { Topic.count }.by(1)
+            expect(Topic.last.user).to eq(feed_author)
+          end
         end
       end
 
-      context 'when embed_by_username is set' do
-        before do
-          SiteSetting.embed_by_username = embed_by_username
-          SiteSetting.embed_username_key_from_feed = ""
-        end
-
-        it 'creates the new topics under embed_by_username' do
-          expect { poller.poll_feed }.to change { Topic.count }.by(1)
-          expect(Topic.last.user).to eq(default_user)
-        end
-      end
-
-      context 'when embed_username_key_from_feed is set' do
-        before do
-          SiteSetting.embed_username_key_from_feed = embed_username_key_from_feed
-        end
-
-        it 'creates the new topics under the username found' do
-          expect { poller.poll_feed }.to change { Topic.count }.by(1)
-          expect(Topic.last.user).to eq(feed_author)
-        end
+      it 'parses creates a new post correctly' do
+        expect { poller.poll_feed }.to change { Topic.count }.by(1)
+        expect(Topic.last.title).to eq('Poll Feed Spec Fixture')
+        expect(Topic.last.first_post.raw).to include('<p>This is the body &amp; content. </p>')
+        expect(Topic.last.topic_embed.embed_url).to eq('https://blog.discourse.org/2017/09/poll-feed-spec-fixture')
       end
     end
 
-    it 'parses the title correctly' do
-      expect { poller.poll_feed }.to change { Topic.count }.by(1)
-      expect(Topic.last.title).to eq('Poll Feed Spec Fixture')
+    context 'when parsing RSS feed' do
+      before do
+        SiteSetting.feed_polling_enabled = true
+        SiteSetting.feed_polling_url = 'https://blog.discourse.org/feed/'
+        SiteSetting.embed_by_username = embed_by_username
+
+        stub_request(:get, SiteSetting.feed_polling_url).to_return(
+          status: 200,
+          body: file_from_fixtures('feed.rss', 'feed').read,
+          headers: { "Content-Type" => "application/rss+xml" }
+        )
+      end
+
+      include_examples 'topic creation based on the the feed'
     end
 
-    it 'parses the content correctly' do
-      expect { poller.poll_feed }.to change { Topic.count }.by(1)
-      expect(Topic.last.first_post.raw).to include('<p>This is the body &amp; content. </p>')
-    end
+    context 'when parsing ATOM feed' do
+      before do
+        SiteSetting.feed_polling_enabled = true
+        SiteSetting.feed_polling_url = 'https://blog.discourse.org/feed/atom/'
+        SiteSetting.embed_by_username = embed_by_username
 
-    it 'parses the link correctly' do
-      expect { poller.poll_feed }.to change { Topic.count }.by(1)
-      expect(Topic.last.topic_embed.embed_url).to eq('https://blog.discourse.org/2017/09/poll-feed-spec-fixture')
+        stub_request(:get, SiteSetting.feed_polling_url).to_return(
+          status: 200,
+          body: file_from_fixtures('feed.atom', 'feed').read,
+          headers: { "Content-Type" => "application/atom+xml" }
+        )
+      end
+
+      include_examples 'topic creation based on the the feed'
     end
   end
 end


### PR DESCRIPTION
> DISCUSSION: https://meta.discourse.org/t/simple-rss-is-buggy-and-should-be-forked-or-replaced/27529/23?u=xrav3nz

This PR got a bit chubby, so here's a brief breakdown:

1. More tests: `PollFeedJob` should correctly parse ATOM feeds
  
    #5199 adds the integration tests for parsing and creating topics from RSS feed, this adds the tests for ATOM feed

2. `FeedItemAccessor` 

    <details>
    <summary>  
     TL;DR this provides a consistent interface for accessing the content of a feed item element.
    </summary>

    <br/>

    Say we have a `rss_item` and an `atom_entry`, both parsed by the built-in Ruby RSS module. The interface for accessing the `title` are quite different: `rss_item.title` and `atom_entry.title.content` respectively.

    `FeedItemAccessor` acts as a general wrapper that provides a consistent interface: `accessor.element_content(:title)` will extract the content of the `title` element, and thus saves the pain from dealing with two different type of feed elements.
    </details>

3. `FeedElementInstaller`

    It 'installs' new elements so that `RSS::Parser` will accept and parses non-standard RSS/ATOM elements. EDIT: See https://github.com/discourse/discourse/pull/5311#issuecomment-345152707.

4. replace `SimpleRSS` with Ruby RSS module

    Having the aforementioned points already in-place, this is actually the easier part. 🕶 

---

Open to suggestions 💪 Cheers