### PR TITLE
fixing some button issues on mobile posts

### DIFF
--- a/app/assets/stylesheets/mobile/topic-post.scss
+++ b/app/assets/stylesheets/mobile/topic-post.scss
@@ -20,45 +20,44 @@ span.badge-posts {
   display: none;
 }
 
-nav.post-controls {
-  clear: both;
-  .d-icon {
-    opacity: 1.0;
-  }
-}
-
 .who-liked {
   margin-left: 10px;
 }
 
 .topic-post {
-  button {
-    border: none;
-    font-size: 1.214em;
-    padding: 8px 10px;
-    vertical-align: top;
-    background: transparent;
-    color: dark-light-choose($primary-low-mid, $secondary-high);
-    float: left;
-    &.hidden {
-      display: none;
+  nav.post-controls {
+    clear: both;
+    .d-icon {
+      opacity: 1.0;
     }
-    &.admin {
-      position: relative;
-    }
-    &.expand-post {
-      margin:10px 0 10px 0;
-    }
-    &.has-like {color: $love;}
+    button {
+      border: none;
+      font-size: 1.214em;
+      padding: 8px 10px;
+      vertical-align: top;
+      background: transparent;
+      color: dark-light-choose($primary-low-mid, $secondary-high);
+      float: left;
+      &.hidden {
+        display: none;
+      }
+      &.admin {
+        position: relative;
+      }
+      &.expand-post {
+        margin:10px 0 10px 0;
+      }
+      &.has-like {color: $love;}
 
-    &.bookmarked {
-      color: $tertiary;
+      &.bookmarked {
+        color: $tertiary;
+      }
     }
-  }
 
-  button.like-count {
-    font-size: 1em;
-    padding: 8px 4px;
+    button.like-count {
+      font-size: 1em;
+      padding: 8px 4px;
+    }
   }
 }
 


### PR DESCRIPTION
Mobile nav control button styles were being applied too broadly, and were overriding buttons within post bodies (expansions, polls). 

Before 
<img width="303" alt="screen shot 2017-11-15 at 2 54 12 pm" src="https://user-images.githubusercontent.com/1681963/32857240-23e36ea8-ca15-11e7-8562-6b4c949e7c07.png">
After
<img width="331" alt="screen shot 2017-11-15 at 2 54 22 pm" src="https://user-images.githubusercontent.com/1681963/32857241-23f55712-ca15-11e7-875c-aa9ea6f95364.png">
Before
<img width="221" alt="screen shot 2017-11-15 at 2 55 57 pm" src="https://user-images.githubusercontent.com/1681963/32857242-2403abfa-ca15-11e7-8d80-1fc7a3132d17.png">
After
<img width="216" alt="screen shot 2017-11-15 at 2 56 03 pm" src="https://user-images.githubusercontent.com/1681963/32857243-24122842-ca15-11e7-8e65-ef6454d56650.png">
