### PR TITLE
FIX: Hotlinked image not replaced with placeholder

### DIFF
--- a/lib/cooked_post_processor.rb
+++ b/lib/cooked_post_processor.rb
@@ -32,8 +32,8 @@ class CookedPostProcessor
     DistributedMutex.synchronize("post_process_#{@post.id}") do
       DiscourseEvent.trigger(:before_post_process_cooked, @doc, @post)
       keep_reverse_index_up_to_date
-      post_process_images
       post_process_oneboxes
+      post_process_images
       optimize_urls
       update_post_image
       enforce_nofollow

--- a/spec/components/cooked_post_processor_spec.rb
+++ b/spec/components/cooked_post_processor_spec.rb
@@ -11,8 +11,8 @@ describe CookedPostProcessor do
 
     it "post process in sequence" do
       cpp.expects(:keep_reverse_index_up_to_date).in_sequence(post_process)
-      cpp.expects(:post_process_images).in_sequence(post_process)
       cpp.expects(:post_process_oneboxes).in_sequence(post_process)
+      cpp.expects(:post_process_images).in_sequence(post_process)
       cpp.expects(:optimize_urls).in_sequence(post_process)
       cpp.expects(:pull_hotlinked_images).in_sequence(post_process)
       cpp.post_process


### PR DESCRIPTION
Hotlinked image links are not replaced with placeholder while clicking "Rebuild HTML" button.