### PR TITLE
fixing an inconsistency that was causing some theming issues

### DIFF
--- a/app/assets/javascripts/discourse/templates/components/edit-category-settings.hbs
+++ b/app/assets/javascripts/discourse/templates/components/edit-category-settings.hbs
@@ -47,15 +47,19 @@
 <section class="field default-view-field">
   <label>
     {{i18n "category.default_view"}}
-    {{combo-box valueAttribute="value" content=availableViews value=category.default_view}}
   </label>
+  <div class="controls">
+    {{combo-box valueAttribute="value" content=availableViews value=category.default_view}}
+  </div>
 </section>
 
 <section class="field default-top-period-field">
   <label>
     {{i18n "category.default_top_period"}}
-    {{combo-box valueAttribute="value" content=availableTopPeriods value=category.default_top_period}}
   </label>
+  <div class="controls">
+    {{combo-box valueAttribute="value" content=availableTopPeriods value=category.default_top_period}}
+  </div>
 </section>
 
 <section class="field">


### PR DESCRIPTION
These dropdown menus were children of the label tag (typically we've kept them as siblings); this was inconsistent with other dropdowns within this modal, which caused some theming issues. 

**before**
<img width="416" alt="screen shot 2017-11-16 at 12 20 30 pm" src="https://user-images.githubusercontent.com/1681963/32905707-c1be63f4-cac8-11e7-9e4b-5c7ff0f632d6.png">

**after**
<img width="442" alt="screen shot 2017-11-16 at 12 21 51 pm" src="https://user-images.githubusercontent.com/1681963/32905708-c1ca4fac-cac8-11e7-8331-7bb3015abd2e.png">

