### PR TITLE
Cast the numeric keys of `USER_HOMES` to numbers

### DIFF
--- a/app/assets/javascripts/discourse/controllers/preferences/interface.js.es6
+++ b/app/assets/javascripts/discourse/controllers/preferences/interface.js.es6
@@ -65,7 +65,7 @@ export default Ember.Controller.extend(PreferencesTabController, {
   @computed()
   userSelectableHome() {
     return _.map(USER_HOMES, (name, num) => {
-      return {name: I18n.t('filters.' + name + '.title'), value: num};
+      return {name: I18n.t('filters.' + name + '.title'), value: Number(num)};
     });
   },
 


### PR DESCRIPTION
When converting from hard-coded functions to a map,
the key `1` got converted to `"1"`.
This broke the user-customizable homepage dropdown menu.