### PR TITLE
If there is a specific poll error message it should be shown to the user

### DIFF
--- a/plugins/poll/assets/javascripts/widgets/discourse-poll.js.es6
+++ b/plugins/poll/assets/javascripts/widgets/discourse-poll.js.es6
@@ -3,6 +3,7 @@ import { h } from 'virtual-dom';
 import { iconNode } from 'discourse-common/lib/icon-library';
 import RawHtml from 'discourse/widgets/raw-html';
 import { ajax } from 'discourse/lib/ajax';
+import { popupAjaxError } from 'discourse/lib/ajax-error';
 import evenRound from "discourse/plugins/poll/lib/even-round";
 import { avatarFor } from 'discourse/widgets/post';
 import round from "discourse/lib/round";
@@ -15,8 +16,12 @@ function fetchVoters(payload) {
   return ajax("/polls/voters.json", {
     type: "get",
     data: payload
-  }).catch(() => {
-    bootbox.alert(I18n.t('poll.error_while_fetching_voters'));
+  }).catch((error) => {
+    if (error) {
+      popupAjaxError(error);
+    } else {
+      bootbox.alert(I18n.t('poll.error_while_fetching_voters'));
+    }
   });
 }
 
@@ -511,8 +516,12 @@ export default createWidget('discourse-poll', {
           }).then(() => {
             poll.set('status', status);
             this.scheduleRerender();
-          }).catch(() => {
-            bootbox.alert(I18n.t("poll.error_while_toggling_status"));
+          }).catch((error) => {
+            if (error) {
+              popupAjaxError(error);
+            } else {
+              bootbox.alert(I18n.t("poll.error_while_toggling_status"));
+            }
           }).finally(() => {
             state.loading = false;
           });
@@ -570,8 +579,12 @@ export default createWidget('discourse-poll', {
       }
     }).then(() => {
       state.showResults = true;
-    }).catch(() => {
-      bootbox.alert(I18n.t("poll.error_while_casting_votes"));
+    }).catch((error) => {
+      if (error) {
+        popupAjaxError(error);
+      } else {
+        bootbox.alert(I18n.t("poll.error_while_casting_votes"));
+      }
     }).finally(() => {
       state.loading = false;
     });


### PR DESCRIPTION
e.g. when voting error messages such as poll.post_is_deleted and poll.topic_must_be_open_to_vote are thrown from the server ([see here](https://github.com/discourse/discourse/blob/master/plugins/poll/plugin.rb#L42)), however the client only ever displays the generic error message.