### PR TITLE
mobile topic adjustments

### DIFF
--- a/app/assets/stylesheets/common/base/onebox.scss
+++ b/app/assets/stylesheets/common/base/onebox.scss
@@ -134,6 +134,9 @@ aside.onebox {
     img {
       max-height: 170px;
       max-width: 20%;
+      @media all and (max-width: 600px) {
+        max-width: 35%;
+      }
       height: auto;
       width: auto;
       float: left;

--- a/app/assets/stylesheets/mobile/topic-post.scss
+++ b/app/assets/stylesheets/mobile/topic-post.scss
@@ -47,8 +47,13 @@ span.badge-posts {
       &.expand-post {
         margin:10px 0 10px 0;
       }
-      &.has-like {color: $love;}
-
+      &.reply {
+        float: right;
+        color: $primary-high;        
+      }
+      &.has-like {
+        color: $love;
+      }
       &.bookmarked {
         color: $tertiary;
       }


### PR DESCRIPTION
moving the reply arrow back to the right & making it darker

<img width="411" alt="screen shot 2017-11-17 at 4 55 57 pm" src="https://user-images.githubusercontent.com/1681963/32970837-949ec706-cbb8-11e7-9036-8f2aab742bc2.png">

Also adjusting onebox max-image width from 20% to 35% on sub-600px devices only