### PR TITLE
FIX: Presence bug

### DIFF
--- a/plugins/discourse-presence/plugin.rb
+++ b/plugins/discourse-presence/plugin.rb
@@ -122,9 +122,9 @@ after_initialize do
         if topic
           guardian.ensure_can_see!(topic)
 
-          any_changes = false
-          any_changes ||= Presence::PresenceManager.remove(type, id, current_user.id)
-          any_changes ||= Presence::PresenceManager.cleanup(type, id)
+          removed = Presence::PresenceManager.remove(type, id, current_user.id)
+          any_removed = Presence::PresenceManager.cleanup(type, id)
+          any_changes = removed || any_removed
 
           users = Presence::PresenceManager.publish(type, id) if any_changes
         end
@@ -144,9 +144,9 @@ after_initialize do
         if topic
           guardian.ensure_can_see!(topic)
 
-          any_changes = false
-          any_changes ||= Presence::PresenceManager.add(type, id, current_user.id)
-          any_changes ||= Presence::PresenceManager.cleanup(type, id)
+          added = Presence::PresenceManager.add(type, id, current_user.id)
+          any_removed = Presence::PresenceManager.cleanup(type, id)
+          any_changes = added || any_removed
 
           users = Presence::PresenceManager.publish(type, id) if any_changes
 


### PR DESCRIPTION
**Repro steps:**
- User 1 starts writing reply, then closes browser window
- Some time later, User 2 starts writing a reply. It looks like User 1 is still writing. 20 seconds later, User 1 drops off the "replying" indicator

**Expected behavior:**
User 1 drops off the "replying" indicator as soon as User 2 opens the composer

**Cause:**
I mis-used Ruby's `||=` operator, which meant that sometimes the logic on the right hand side wouldn't get triggered if the left hand side was already true.

**Fix:**
I added a test case for this situation, and have fixed the logic
