### PR TITLE
FIX: invited users were not granted trust level based on their group

### DIFF
--- a/app/models/invite_redeemer.rb
+++ b/app/models/invite_redeemer.rb
@@ -28,11 +28,6 @@ InviteRedeemer = Struct.new(:invite, :username, :name, :password, :user_custom_f
 
     user = User.new(email: invite.email, username: available_username, name: available_name, active: true, trust_level: SiteSetting.default_invitee_trust_level)
 
-    if password
-      user.password_required!
-      user.password = password
-    end
-
     if !SiteSetting.must_approve_users? || (SiteSetting.must_approve_users? && invite.invited_by.staff?)
       user.approved = true
       user.approved_by_id = invite.invited_by_id
@@ -52,9 +47,14 @@ InviteRedeemer = Struct.new(:invite, :username, :name, :password, :user_custom_f
     end
 
     user.moderator = true if invite.moderator? && invite.invited_by.staff?
-    user.save!
 
-    user
+    if password
+      user.password = password
+      user.password_required!
+    end
+
+    user.save!
+    User.find(user.id)
   end
 
   private

--- a/spec/models/invite_redeemer_spec.rb
+++ b/spec/models/invite_redeemer_spec.rb
@@ -107,5 +107,14 @@ describe InviteRedeemer do
       expect(user.custom_fields["user_field_#{required_field.id}"]).to eq('value1')
       expect(user.custom_fields["user_field_#{optional_field.id}"]).to eq('value2')
     end
+
+    it "adds user to group" do
+      group = Fabricate(:group, grant_trust_level: 2)
+      InvitedGroup.create(group_id: group.id, invite_id: invite.id)
+      user = InviteRedeemer.new(invite, username, name, password).redeem
+
+      expect(user.group_users.count).to eq(4)
+      expect(user.trust_level).to eq(2)
+    end
   end
 end


### PR DESCRIPTION
https://meta.discourse.org/t/bulk-invites-and-trust-level/73535

If the user enters a password when accepting invite they were not granted trust level based on their group privileges. It was because `password_required` was set to `true` when creating user record and when the user was updated again when granting trust level the password validation was raising an error saying that the password is empty, this was because `password_required` was still set to `true`.

This commit fetches fresh user record after the user is created so that the user record can be updated successfully.