### PR TITLE
Feature: Add service worker registration method to plugin API

### DIFF
--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -4,7 +4,7 @@ require_dependency 'file_helper'
 class StaticController < ApplicationController
 
   skip_before_action :check_xhr, :redirect_to_login_if_required
-  skip_before_action :verify_authenticity_token, only: [:brotli_asset, :cdn_asset, :enter, :favicon]
+  skip_before_action :verify_authenticity_token, only: [:brotli_asset, :cdn_asset, :enter, :favicon, :service_worker_asset]
 
   PAGES_WITH_EMAIL_PARAM = ['login', 'password_reset', 'signup']
 
@@ -141,6 +141,12 @@ class StaticController < ApplicationController
 
   def cdn_asset
     serve_asset
+  end
+
+  def service_worker_asset
+    respond_to do |format|
+      format.js
+    end
   end
 
   protected

--- a/app/views/static/service_worker_asset.js.erb
+++ b/app/views/static/service_worker_asset.js.erb
@@ -88,3 +88,7 @@ self.addEventListener('fetch', event => {
   // event.respondWith(). If no fetch handlers call event.respondWith(), the request will be
   // handled by the browser as if there were no service worker involvement.
 });
+
+<% DiscoursePluginRegistry.service_workers.each do |js| %>
+<%=raw "#{File.read(js)}" %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -687,6 +687,8 @@ Discourse::Application.routes.draw do
   post "draft" => "draft#update"
   delete "draft" => "draft#destroy"
 
+  get "service-worker" => "static#service_worker_asset"
+
   get "cdn_asset/:site/*path" => "static#cdn_asset", format: false
   get "brotli_asset/*path" => "static#brotli_asset", format: false
 

--- a/lib/discourse_plugin_registry.rb
+++ b/lib/discourse_plugin_registry.rb
@@ -5,6 +5,7 @@ class DiscoursePluginRegistry
 
   class << self
     attr_writer :javascripts
+    attr_writer :service_workers
     attr_writer :admin_javascripts
     attr_writer :stylesheets
     attr_writer :mobile_stylesheets
@@ -22,6 +23,10 @@ class DiscoursePluginRegistry
     # Default accessor values
     def javascripts
       @javascripts ||= Set.new
+    end
+
+    def service_workers
+      @service_workers ||= Set.new
     end
 
     def asset_globs
@@ -77,6 +82,10 @@ class DiscoursePluginRegistry
   def register_js(filename, options = {})
     # If we have a server side option, add that too.
     self.class.javascripts << filename
+  end
+
+  def self.register_service_worker(filename, options = {})
+    self.service_workers << filename
   end
 
   def register_css(filename)
@@ -166,6 +175,10 @@ class DiscoursePluginRegistry
     self.class.javascripts
   end
 
+  def service_workers
+    self.class.service_workers
+  end
+
   def stylesheets
     self.class.stylesheets
   end
@@ -188,6 +201,7 @@ class DiscoursePluginRegistry
 
   def self.clear
     self.javascripts = nil
+    self.service_workers = nil
     self.stylesheets = nil
     self.mobile_stylesheets = nil
     self.desktop_stylesheets = nil
@@ -197,6 +211,7 @@ class DiscoursePluginRegistry
 
   def self.reset!
     javascripts.clear
+    service_workers.clear
     admin_javascripts.clear
     stylesheets.clear
     mobile_stylesheets.clear

--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -29,6 +29,7 @@ class Plugin::Instance
    :color_schemes,
    :initializers,
    :javascripts,
+   :service_workers,
    :styles,
    :themes].each do |att|
     class_eval %Q{
@@ -332,6 +333,11 @@ class Plugin::Instance
     assets << [full_path, opts]
   end
 
+  def register_service_worker(file, opts = nil)
+    full_path = File.dirname(path) << "/assets/" << file
+    service_workers << [full_path, opts]
+  end
+
   def register_color_scheme(name, colors)
     color_schemes << { name: name, colors: colors }
   end
@@ -419,6 +425,8 @@ JS
     end
 
     register_assets! unless assets.blank?
+
+    register_service_workers! unless service_workers.blank?
 
     seed_data.each do |key, value|
       DiscoursePluginRegistry.register_seed_data(key, value)
@@ -513,6 +521,12 @@ JS
   def register_assets!
     assets.each do |asset, opts|
       DiscoursePluginRegistry.register_asset(asset, opts)
+    end
+  end
+
+  def register_service_workers!
+    service_workers.each do |asset, opts|
+      DiscoursePluginRegistry.register_service_worker(asset, opts)
     end
   end
 

--- a/spec/components/discourse_plugin_registry_spec.rb
+++ b/spec/components/discourse_plugin_registry_spec.rb
@@ -92,6 +92,26 @@ describe DiscoursePluginRegistry do
     end
   end
 
+  context '.register_service_worker' do
+    let(:registry) { DiscoursePluginRegistry }
+
+    before do
+      registry.register_service_worker('hello.js')
+    end
+
+    after do
+      registry.reset!
+    end
+
+    it 'is returned by DiscoursePluginRegistry.service_workers' do
+      expect(registry.service_workers.include?('hello.js')).to eq(true)
+    end
+
+    it "won't add the same file twice" do
+      expect { registry.register_service_worker('hello.js') }.not_to change(registry.service_workers, :size)
+    end
+  end
+
   context '.register_archetype' do
     it "delegates archetypes to the Archetype component" do
       Archetype.expects(:register).with('threaded', hello: 123)

--- a/spec/components/plugin/instance_spec.rb
+++ b/spec/components/plugin/instance_spec.rb
@@ -95,6 +95,18 @@ describe Plugin::Instance do
     end
   end
 
+  context "register service worker" do
+    it "populates the DiscoursePluginRegistry" do
+      plugin = Plugin::Instance.new nil, "/tmp/test.rb"
+      plugin.register_service_worker("test.js")
+      plugin.register_service_worker("test2.js")
+
+      plugin.send :register_service_workers!
+
+      expect(DiscoursePluginRegistry.service_workers.count).to eq(2)
+    end
+  end
+
   context "activate!" do
     it "can activate plugins correctly" do
       plugin = Plugin::Instance.new


### PR DESCRIPTION
Adds a plugin hook to register service workers.

Adds registered service worker scripts to the /service-worker.js template.