### PR TITLE
Removing overridden settings label color

### DIFF
--- a/app/assets/stylesheets/common/admin/admin_base.scss
+++ b/app/assets/stylesheets/common/admin/admin_base.scss
@@ -537,12 +537,6 @@ $mobile-breakpoint: 700px;
     }
   }
 
-  .setting.overridden {
-    h3 {
-      color: scale-color($highlight, $lightness: -50%);
-    }
-  }
-
   .setting.overridden.string {
     input[type=text], textarea {
       background-color: $highlight-medium;


### PR DESCRIPTION
The label color can cause some readability issues depending on the theme, and doesn't seem necessary. 

As discussed here: https://meta.discourse.org/t/dark-theme-has-some-areas-where-text-is-dark/74992