### PR TITLE
FEATURE: support search click through tracking for user, category and tags

### DIFF
--- a/app/assets/javascripts/admin/controllers/admin-logs-search-logs.js.es6
+++ b/app/assets/javascripts/admin/controllers/admin-logs-search-logs.js.es6
@@ -1,4 +1,11 @@
 export default Ember.Controller.extend({
   loading: false,
-  period: "all"
+  period: "all",
+  searchType: "all",
+
+  searchTypeOptions: [
+                      {id: 'all',       name: I18n.t('admin.logs.search_logs.types.all_search_types')},
+                      {id: 'header',    name: I18n.t('admin.logs.search_logs.types.header')},
+                      {id: 'full_page', name: I18n.t('admin.logs.search_logs.types.full_page')}
+                    ]
 });

--- a/app/assets/javascripts/admin/routes/admin-logs-search-logs.js.es6
+++ b/app/assets/javascripts/admin/routes/admin-logs-search-logs.js.es6
@@ -6,20 +6,19 @@ export default Discourse.Route.extend({
   },
 
   queryParams: {
-    period: {
-      refreshModel: true
-    }
+    period: { refreshModel: true },
+    searchType: { refreshModel: true }
   },
 
   model(params) {
     this._params = params;
-    return ajax('/admin/logs/search_logs.json', { data: { period: params.period } }).then(search_logs => {
+    return ajax('/admin/logs/search_logs.json', { data: { period: params.period, search_type: params.searchType } }).then(search_logs => {
       return search_logs.map(sl => Ember.Object.create(sl));
     });
   },
 
   setupController(controller, model) {
     const params = this._params;
-    controller.setProperties({ model, period: params.period });
+    controller.setProperties({ model, period: params.period, searchType: params.searchType });
   }
 });

--- a/app/assets/javascripts/admin/templates/logs/search-logs.hbs
+++ b/app/assets/javascripts/admin/templates/logs/search-logs.hbs
@@ -1,5 +1,6 @@
 <p>
   {{period-chooser period=period}}
+  {{combo-box content=searchTypeOptions value=searchType class='search-logs-filter'}}
 </p>
 <br>
 
@@ -11,7 +12,6 @@
         <div class="col heading term">{{i18n 'admin.logs.search_logs.term'}}</div>
         <div class="col heading">{{i18n 'admin.logs.search_logs.searches'}}</div>
         <div class="col heading">{{i18n 'admin.logs.search_logs.click_through'}}</div>
-        <div class="col heading topic">{{i18n 'admin.logs.search_logs.most_viewed_topic'}}</div>
         <div class="col heading" title="{{i18n 'admin.logs.search_logs.unique_title'}}">{{i18n 'admin.logs.search_logs.unique'}}</div>
       </div>
 
@@ -20,11 +20,6 @@
           <div class="col term">{{item.term}}</div>
           <div class="col">{{item.searches}}</div>
           <div class="col">{{item.click_through}}</div>
-          <div class="col topic">
-            {{#if item.clicked_topic_id}}
-              <a href='{{unbound item.topic_url}}'>{{item.topic_title}}</a>
-            {{/if}}
-          </div>
           <div class="col">{{item.unique}}</div>
         </div>
       {{/each}}

--- a/app/assets/javascripts/discourse/widgets/search-menu-results.js.es6
+++ b/app/assets/javascripts/discourse/widgets/search-menu-results.js.es6
@@ -24,9 +24,13 @@ function createSearchResult({ type, linkField, builder }) {
 
       return attrs.results.map(r => {
         let searchResultId;
+
         if (type === "topic") {
           searchResultId = r.get('topic_id');
+        } else {
+          searchResultId = r.get('id');
         }
+
         return h('li', this.attach('link', {
           href: r.get(linkField),
           contents: () => builder.call(this, r, attrs.term),

--- a/app/assets/stylesheets/common/admin/admin_base.scss
+++ b/app/assets/stylesheets/common/admin/admin_base.scss
@@ -227,6 +227,11 @@ $mobile-breakpoint: 700px;
   .select-box-kit.dropdown-select-box {
     width: auto;
   }
+
+  .search-logs-filter {
+    width: 200px;
+    float: right;
+  }
 }
 
 .admin-container .controls {
@@ -1267,19 +1272,12 @@ table.api-keys {
 .search-logs-list{
   .col {
     text-align: center;
-    width: 10%;
+    width: 15%;
   }
 
   .col.term {
-    width: 30%;
+    width: 45%;
     text-align: left;
-  }
-
-  .col.topic {
-    width: 35%;
-    text-align: left;
-    text-overflow: ellipsis;
-    white-space: nowrap;
   }
 }
 

--- a/app/controllers/admin/search_logs_controller.rb
+++ b/app/controllers/admin/search_logs_controller.rb
@@ -2,7 +2,8 @@ class Admin::SearchLogsController < Admin::AdminController
 
   def index
     period = params[:period] || "all"
-    render_serialized(SearchLog.trending(period.to_sym), SearchLogsSerializer)
+    search_type = params[:search_type] || "all"
+    render_serialized(SearchLog.trending(period&.to_sym, search_type&.to_sym), SearchLogsSerializer)
   end
 
 end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -77,7 +77,8 @@ class SearchController < ApplicationController
     params.require(:search_result_type)
     params.require(:search_result_id)
 
-    if params[:search_result_type] == 'topic'
+    search_result_type = params[:search_result_type].downcase.to_sym
+    if SearchLog.search_result_types.has_key?(search_result_type)
       attributes = { id: params[:search_log_id] }
       if current_user.present?
         attributes[:user_id] = current_user.id
@@ -85,8 +86,15 @@ class SearchController < ApplicationController
         attributes[:ip_address] = request.remote_ip
       end
 
+      if search_result_type == :tag
+        search_result_id = Tag.find_by_name(params[:search_result_id])&.id
+      else
+        search_result_id = params[:search_result_id]
+      end
+
       SearchLog.where(attributes).update_all(
-        clicked_topic_id: params[:search_result_id]
+        search_result_type: SearchLog.search_result_types[search_result_type],
+        search_result_id: search_result_id
       )
     end
 

--- a/app/serializers/search_logs_serializer.rb
+++ b/app/serializers/search_logs_serializer.rb
@@ -2,16 +2,5 @@ class SearchLogsSerializer < ApplicationSerializer
   attributes :term,
              :searches,
              :click_through,
-             :clicked_topic_id,
-             :topic_title,
-             :topic_url,
              :unique
-
-  def topic_title
-    object&.topic&.title
-  end
-
-  def topic_url
-    object&.topic&.url
-  end
 end

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3209,9 +3209,12 @@ en:
           term: "Term"
           searches: "Searches"
           click_through: "Click Through"
-          most_viewed_topic: "Most Viewed Topic"
           unique: "Unique"
           unique_title: "unique users performing the search"
+          types:
+            all_search_types: "All search types"
+            header: "Header"
+            full_page: "Full Page"
         logster:
           title: "Error Logs"
 

--- a/db/migrate/20171128172835_rename_clicked_topic_id_to_search_result_id.rb
+++ b/db/migrate/20171128172835_rename_clicked_topic_id_to_search_result_id.rb
@@ -1,0 +1,13 @@
+class RenameClickedTopicIdToSearchResultId < ActiveRecord::Migration[5.1]
+  def up
+    rename_column :search_logs, :clicked_topic_id, :search_result_id
+    add_column :search_logs, :search_result_type, :integer, null: true
+
+    execute "UPDATE search_logs SET search_result_type = 1 WHERE search_result_id is NOT NULL"
+  end
+
+  def down
+    rename_column :search_logs, :search_result_id, :clicked_topic_id
+    remove_column :search_logs, :search_result_type
+  end
+end

--- a/spec/models/search_log_spec.rb
+++ b/spec/models/search_log_spec.rb
@@ -179,15 +179,11 @@ RSpec.describe SearchLog, type: :model do
       expect(top_trending.searches).to eq(3)
       expect(top_trending.unique).to eq(2)
       expect(top_trending.click_through).to eq(0)
-      expect(top_trending.clicked_topic_id).to eq(nil)
 
-      popular_topic = Fabricate(:topic)
-      not_so_popular_topic = Fabricate(:topic)
-      SearchLog.where(term: 'ruby', ip_address: '127.0.0.1').update_all(clicked_topic_id: popular_topic.id)
-      SearchLog.where(term: 'ruby', ip_address: '127.0.0.2').update_all(clicked_topic_id: not_so_popular_topic.id)
+      SearchLog.where(term: 'ruby', ip_address: '127.0.0.1').update_all(search_result_id: 12)
+      SearchLog.where(term: 'ruby', ip_address: '127.0.0.2').update_all(search_result_id: 24)
       top_trending = SearchLog.trending.first
       expect(top_trending.click_through).to eq(3)
-      expect(top_trending.clicked_topic_id).to eq(popular_topic.id)
     end
   end
 

--- a/test/javascripts/helpers/create-pretender.js.es6
+++ b/test/javascripts/helpers/create-pretender.js.es6
@@ -393,7 +393,7 @@ export default function() {
 
     this.get('/admin/logs/search_logs.json', () => {
       return response(200, [
-        {"term":"foobar","searches":35,"click_through":6,"clicked_topic_id":1550,"topic_title":"Foo Bar Topic Title","topic_url":"http://discourse.example.com/t/foo-bar-topic-title/1550","unique":16}
+        {"term":"foobar","searches":35,"click_through":6,"unique":16}
       ]);
     });
 


### PR DESCRIPTION
https://meta.discourse.org/t/search-logs-page/73281/11?u=techapj

This commit adds following features:

- support for tracking click through to user, tag and category
- new filter for search result type (topic, user, tag and category)
- new filter for search type (header, full page)

This commit also removes "most viewed topic" column from search logs page because we are now tracking multiple click through entities, so topic is not a special entity anymore. This also improves query perf. The query now takes `20.5ms` to run, as opposed to `655.9ms` previously.

![2017-11-30 16 55 45](https://user-images.githubusercontent.com/5732281/33428602-6c90ec1c-d5ef-11e7-993e-67199b42c635.gif)
