### PR TITLE
FIX: Skip pasting files if plain text available in clipboard

### DIFF
--- a/app/assets/javascripts/discourse.js.es6
+++ b/app/assets/javascripts/discourse.js.es6
@@ -9,6 +9,9 @@ const Discourse = Ember.Application.extend({
   RAW_TEMPLATES: {},
   __widget_helpers: {},
   showingSignup: false,
+  customEvents: {
+    paste: 'paste'
+  },
 
   getURL(url) {
     if (!url) return url;

--- a/app/assets/javascripts/discourse/components/composer-editor.js.es6
+++ b/app/assets/javascripts/discourse/components/composer-editor.js.es6
@@ -13,7 +13,8 @@ import { tinyAvatar,
          displayErrorForUpload,
          getUploadMarkdown,
          validateUploadedFiles,
-         formatUsername
+         formatUsername,
+         clipboardData
 } from 'discourse/lib/utilities';
 import { cacheShortUploadUrl, resolveAllShortUrls } from 'pretty-text/image-short-url';
 
@@ -394,7 +395,14 @@ export default Ember.Component.extend({
       pasteZone: $element,
     });
 
-    $element.on('fileuploadpaste', () => this._pasted = true);
+    $element.on('fileuploadpaste', (e) => {
+      let {types} = clipboardData(e);
+      this._pasted = true;
+
+      if (types.some(t => t === "text/plain")) {
+        e.preventDefault();
+      }
+    });
 
     $element.on('fileuploadsubmit', (e, data) => {
       const isPrivateMessage = this.get("composer.privateMessage");

--- a/app/assets/javascripts/discourse/components/d-editor.js.es6
+++ b/app/assets/javascripts/discourse/components/d-editor.js.es6
@@ -8,7 +8,7 @@ import { emojiSearch, isSkinTonableEmoji } from 'pretty-text/emoji';
 import { emojiUrlFor } from 'discourse/lib/text';
 import { getRegister } from 'discourse-common/lib/get-owner';
 import { findRawTemplate } from 'discourse/lib/raw-templates';
-import { determinePostReplaceSelection } from 'discourse/lib/utilities';
+import { determinePostReplaceSelection, clipboardData } from 'discourse/lib/utilities';
 import deprecated from 'discourse-common/lib/deprecated';
 
 // Our head can be a static string or a function that returns a string
@@ -614,6 +614,14 @@ export default Ember.Component.extend({
     $textarea.prop("selectionStart", insert.length);
     $textarea.prop("selectionEnd", insert.length);
     Ember.run.scheduleOnce("afterRender", () => $textarea.focus());
+  },
+
+  paste(e) {
+    let {types} = clipboardData(e);
+
+    if (types.some(t => t === "Files") && !types.some(t => t === "text/plain")) {
+      e.preventDefault();
+    }
   },
 
   actions: {

--- a/app/assets/javascripts/discourse/lib/utilities.js.es6
+++ b/app/assets/javascripts/discourse/lib/utilities.js.es6
@@ -421,5 +421,14 @@ export function isAppleDevice() {
     !navigator.userAgent.match(/Trident/g);
 }
 
+export function clipboardData(e) {
+  let data = e.clipboardData ||
+                e.originalEvent.clipboardData ||
+                e.delegatedEvent.originalEvent.clipboardData ||
+                event.clipboardData;
+
+  return { items: data.items, types: data.types };
+}
+
 // This prevents a mini racer crash
 export default {};


### PR DESCRIPTION
Problem : "If you paste into the composer and the clipboard has data available in both an image and text format, then they both appear."