### PR TITLE
move /tags/ topic list out of footer

### DIFF
--- a/app/assets/javascripts/discourse/templates/tags/show.hbs
+++ b/app/assets/javascripts/discourse/templates/tags/show.hbs
@@ -41,29 +41,30 @@
 
 {{plugin-outlet name="discovery-list-container-top"}}
 
-<footer class='topic-list-bottom'>
-  {{conditional-loading-spinner condition=loading}}
+{{conditional-loading-spinner condition=loading}}
 
-  {{#unless loading}}
-    {{#if list.topics}}
-      {{#discovery-topics-list model=list refresh="refresh"}}
-      {{bulk-select-button selected=selected action="refresh"}}
+{{#unless loading}}
+  {{#if list.topics}}
+    {{#discovery-topics-list model=list refresh="refresh"}}
+    {{bulk-select-button selected=selected action="refresh"}}
 
-      {{topic-list topics=list.topics
-                   canBulkSelect=canBulkSelect
-                   toggleBulkSelect="toggleBulkSelect"
-                   bulkSelectEnabled=bulkSelectEnabled
-                   selected=selected
-                   showPosters=true
-                   order=order
-                   ascending=ascending
-                   changeSort="changeSort"}}
+    {{topic-list topics=list.topics
+                 canBulkSelect=canBulkSelect
+                 toggleBulkSelect="toggleBulkSelect"
+                 bulkSelectEnabled=bulkSelectEnabled
+                 selected=selected
+                 showPosters=true
+                 order=order
+                 ascending=ascending
+                 changeSort="changeSort"}}
 
-      {{/discovery-topics-list}}
-    {{else}}
+    {{/discovery-topics-list}}
+  {{else}}
+    <footer class='topic-list-bottom'>
       <h3>
         {{footerMessage}}{{#link-to "discovery.categories"}} {{i18n 'topic.browse_all_categories'}}{{/link-to}} {{i18n 'or'}} {{#link-to 'discovery.latest'}}{{i18n 'topic.view_latest_topics'}}{{/link-to}}
       </h3>
-    {{/if}}
-  {{/unless}}
-</footer>
+    </footer>
+  {{/if}}
+{{/unless}}
+


### PR DESCRIPTION
makes html more consistent with other topic lists 
https://meta.discourse.org/t/is-the-html-for-tags-topic-list-supposed-have-a-different-structure/74828