### PR TITLE
[FIX] Only include added fields if object responds to them

### DIFF
--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -83,7 +83,7 @@ class Plugin::Instance
 
         if define_include_method
           # Don't include serialized methods if the plugin is disabled
-          klass.send(:define_method, "include_#{attr}?") { plugin.enabled? }
+          klass.send(:define_method, "include_#{attr}?") { plugin.enabled? && object.respond_to?(attr) }
         end
       end
 


### PR DESCRIPTION
Per the discussion here:
https://meta.discourse.org/t/babble-a-chat-plugin/31753/760

The data-explorer plugin (and perhaps others), can leave a serializer in a state where it's unable to correctly serialize custom fields added by a plugin.

This fixes that by ensuring that the object can receive the message before sending it.