### PR TITLE
install imagemagick@6 for OSX native development

### DIFF
--- a/docs/DEVELOPMENT-OSX-NATIVE.md
+++ b/docs/DEVELOPMENT-OSX-NATIVE.md
@@ -191,9 +191,11 @@ Homebrew loves you.
 
 ## ImageMagick
 
-ImageMagick is used for generating avatars (including for test fixtures).
+ImageMagick is used for generating avatars (including for test fixtures). Brew installs ImageMagick 7 by default, and this version
+doesn't work with Discourse.
 
-    brew install imagemagick
+    brew install imagemagick@6
+    brew link --force imagemagick@6
 
 ImageMagick is going to want to use the Helvetica font to generate the
 letter-avatars:


### PR DESCRIPTION
This PR fixes the documentation to install ImageMagick 6 instead of 7 (default version when running `brew install imagemagick`)

## Notes
The only place I found this information was in https://meta.discourse.org/t/beginners-guide-to-install-discourse-on-mac-os-x-macos-for-development/15772/112. Should we add this somewhere else, like we did with PostgreSQL 10?