### PR TITLE
Updates api_test_seeds for multiple auth_token support

### DIFF
--- a/db/api_test_seeds.rb
+++ b/db/api_test_seeds.rb
@@ -1,2 +1,3 @@
-User.create(name: "Test User", email: "test_user@example.com", password: "password", username: "test_user", approved: true, active: true, auth_token: "39a925803ddc658a68a7e276e558ed62", admin: true)
-ApiKey.create(key: 'test_d7fd0429940', user_id: 1, created_by_id: 1)
+user = User.where(username: "test_user").first_or_create(name: "Test User", email: "test_user@example.com", password: SecureRandom.hex, username: "test_user", approved: true, active: true, admin: true)
+UserAuthToken.generate!(user_id: user.id)
+ApiKey.create(key: 'test_d7fd0429940', user_id: user.id, created_by_id: user.id)


### PR DESCRIPTION
See https://meta.discourse.org/t/discourse-ruby-api-testing-unknown-attribute-auth-token-for-user/75704 for reasoning. 

I'm not super familiar with Discourse, but this seems right-ish. Happy to make adjustments. In summary, this seed hadn't been updated since auth token's were moved to a separate model and not a field on `User` (this was my understanding in any case).