### PR TITLE
FIX: save registration_ip_address for staged users logging in via social auth

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -117,6 +117,7 @@ class Users::OmniauthCallbacksController < ApplicationController
       # ensure there is an active email token
       user.email_tokens.create(email: user.email) unless EmailToken.where(email: user.email, confirmed: true).present? || user.email_tokens.active.where(email: user.email).exists?
       user.activate
+      user.update!(registration_ip_address: request.remote_ip) if user.registration_ip_address.blank?
     end
 
     if ScreenedIpAddress.should_block?(request.remote_ip)


### PR DESCRIPTION
Sets `registration_ip_address` for users overtaking their staged account via social login (e.g. Google login).