### PR TITLE
FIX: path whitelist for embedded comments didn't work with non-ASCII chars

### DIFF
--- a/app/models/embeddable_host.rb
+++ b/app/models/embeddable_host.rb
@@ -1,3 +1,5 @@
+require_dependency 'url_helper'
+
 class EmbeddableHost < ActiveRecord::Base
   validate :host_must_be_valid
   belongs_to :category
@@ -10,7 +12,7 @@ class EmbeddableHost < ActiveRecord::Base
   def self.record_for_url(uri)
 
     if uri.is_a?(String)
-      uri = URI(URI.encode(uri)) rescue nil
+      uri = URI(UrlHelper.escape_uri(uri)) rescue nil
     end
     return false unless uri.present?
 
@@ -25,7 +27,10 @@ class EmbeddableHost < ActiveRecord::Base
     path << "?" << uri.query if uri.query.present?
 
     where("lower(host) = ?", host).each do |eh|
-      return eh if eh.path_whitelist.blank? || !Regexp.new(eh.path_whitelist).match(path).nil?
+      return eh if eh.path_whitelist.blank?
+
+      path_regexp = Regexp.new(eh.path_whitelist)
+      return eh if path_regexp.match(path) || path_regexp.match(URI.unescape(path))
     end
 
     nil
@@ -35,7 +40,7 @@ class EmbeddableHost < ActiveRecord::Base
     # Work around IFRAME reload on WebKit where the referer will be set to the Forum URL
     return true if url&.starts_with?(Discourse.base_url)
 
-    uri = URI(URI.encode(url)) rescue nil
+    uri = URI(UrlHelper.escape_uri(url)) rescue nil
     uri.present? && record_for_url(uri).present?
   end
 

--- a/lib/final_destination.rb
+++ b/lib/final_destination.rb
@@ -2,6 +2,7 @@ require 'socket'
 require 'ipaddr'
 require 'excon'
 require 'rate_limiter'
+require 'url_helper'
 
 # Determine the final endpoint for a Web URI, following redirects
 class FinalDestination
@@ -237,7 +238,7 @@ class FinalDestination
   end
 
   def escape_url
-    TopicEmbed.escape_uri(
+    UrlHelper.escape_uri(
       CGI.unescapeHTML(@url),
       Regexp.new("[^#{URI::PATTERN::UNRESERVED}#{URI::PATTERN::RESERVED}#]")
     )

--- a/lib/url_helper.rb
+++ b/lib/url_helper.rb
@@ -21,4 +21,14 @@ class UrlHelper
     url.sub(/^http:/i, "")
   end
 
+  DOUBLE_ESCAPED_REGEXP ||= /%25([0-9a-f]{2})/i
+
+  # Prevents double URL encode
+  # https://stackoverflow.com/a/37599235
+  def self.escape_uri(uri, pattern = URI::UNSAFE)
+    encoded = URI.encode(uri, pattern)
+    encoded.gsub!(DOUBLE_ESCAPED_REGEXP, '%\1')
+    encoded
+  end
+
 end

--- a/spec/components/url_helper_spec.rb
+++ b/spec/components/url_helper_spec.rb
@@ -79,4 +79,26 @@ describe UrlHelper do
 
   end
 
+  describe "#escape_uri" do
+    it "doesn't escape simple URL" do
+      url = UrlHelper.escape_uri('http://example.com/foo/bar')
+      expect(url).to eq('http://example.com/foo/bar')
+    end
+
+    it "escapes unsafe chars" do
+      url = UrlHelper.escape_uri("http://example.com/?a=\11\15")
+      expect(url).to eq('http://example.com/?a=%09%0D')
+    end
+
+    it "escapes non-ascii chars" do
+      url = UrlHelper.escape_uri('http://example.com/ماهی')
+      expect(url).to eq('http://example.com/%D9%85%D8%A7%D9%87%DB%8C')
+    end
+
+    it "doesn't escape already escaped chars" do
+      url = UrlHelper.escape_uri('http://example.com/foo%20bar/foo bar/')
+      expect(url).to eq('http://example.com/foo%20bar/foo%20bar/')
+    end
+  end
+
 end

--- a/spec/models/embeddable_host_spec.rb
+++ b/spec/models/embeddable_host_spec.rb
@@ -103,6 +103,22 @@ describe EmbeddableHost do
       expect(EmbeddableHost.url_allowed?('http://eviltrout.com/rick/smith')).to eq(true)
       expect(EmbeddableHost.url_allowed?('http://eviltrout.com/morty/sanchez')).to eq(true)
     end
+
+    it "works with non-english paths" do
+      Fabricate(:embeddable_host, path_whitelist: '/انگلیسی/.*')
+      Fabricate(:embeddable_host, path_whitelist: '/definição/.*')
+      expect(EmbeddableHost.url_allowed?('http://eviltrout.com/انگلیسی/foo')).to eq(true)
+      expect(EmbeddableHost.url_allowed?('http://eviltrout.com/definição/foo')).to eq(true)
+      expect(EmbeddableHost.url_allowed?('http://eviltrout.com/bar/foo')).to eq(false)
+    end
+
+    it "works with URL encoded paths" do
+      Fabricate(:embeddable_host, path_whitelist: '/definição/.*')
+      Fabricate(:embeddable_host, path_whitelist: '/ingl%C3%A9s/.*')
+
+      expect(EmbeddableHost.url_allowed?('http://eviltrout.com/defini%C3%A7%C3%A3o/foo')).to eq(true)
+      expect(EmbeddableHost.url_allowed?('http://eviltrout.com/inglés/foo')).to eq(true)
+    end
   end
 
 end

--- a/spec/models/topic_embed_spec.rb
+++ b/spec/models/topic_embed_spec.rb
@@ -233,25 +233,4 @@ describe TopicEmbed do
     end
   end
 
-  context ".escape_uri" do
-    it "doesn't escape simple URL" do
-      url = TopicEmbed.escape_uri('http://example.com/foo/bar')
-      expect(url).to eq('http://example.com/foo/bar')
-    end
-
-    it "escapes unsafe chars" do
-      url = TopicEmbed.escape_uri("http://example.com/?a=\11\15")
-      expect(url).to eq('http://example.com/?a=%09%0D')
-    end
-
-    it "escapes non-ascii chars" do
-      url = TopicEmbed.escape_uri('http://example.com/ماهی')
-      expect(url).to eq('http://example.com/%D9%85%D8%A7%D9%87%DB%8C')
-    end
-
-    it "doesn't escape already escaped chars" do
-      url = TopicEmbed.escape_uri('http://example.com/foo%20bar/foo bar/')
-      expect(url).to eq('http://example.com/foo%20bar/foo%20bar/')
-    end
-  end
 end


### PR DESCRIPTION
https://meta.discourse.org/t/embedding-discourse-comments-via-javascript/31963/244