### PR TITLE
FIX : proper error for creating topic with tag withour tag creation p…

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -3499,6 +3499,7 @@ en:
     title: "Tags"
     staff_tag_disallowed: "The tag \"%{tag}\" may only be applied by staff."
     staff_tag_remove_disallowed: "The tag \"%{tag}\" may only be removed by staff."
+    creation_not_allowed: "Tag creation not allowed."
   rss_by_tag: "Topics tagged %{tag}"
 
   finish_installation:

--- a/lib/topic_creator.rb
+++ b/lib/topic_creator.rb
@@ -29,6 +29,10 @@ class TopicCreator
       topic.errors[:base] << I18n.t("tags.staff_tag_disallowed", tag: staff_only.join(" "))
     end
 
+    unless @guardian.can_create_tag?
+      topic.errors[:base] << I18n.t("tags.creation_not_allowed")
+    end
+
     DiscourseEvent.trigger(:after_validate_topic, topic, self)
     valid &&= topic.errors.empty?
 


### PR DESCRIPTION
…ermission.

Creating a topic with a new tag without tag-creation permission fails silently.This
commit raises tag creation not allowed exception for the same.