### PR TITLE
display language name in user locale selector

### DIFF
--- a/app/assets/javascripts/discourse/controllers/preferences/interface.js.es6
+++ b/app/assets/javascripts/discourse/controllers/preferences/interface.js.es6
@@ -33,7 +33,7 @@ export default Ember.Controller.extend(PreferencesTabController, {
 
   @computed()
   availableLocales() {
-    return this.siteSettings.available_locales.split('|').map(s => ({ name: s, value: s }));
+    return JSON.parse(this.siteSettings.available_locales);
   },
 
   @computed()

--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -30,7 +30,7 @@ class SiteSetting < ActiveRecord::Base
   client_settings << :available_locales
 
   def self.available_locales
-    LocaleSiteSetting.values.map { |e| e[:value] }.join('|')
+    LocaleSiteSetting.values.to_json
   end
 
   def self.topic_title_length


### PR DESCRIPTION
Make user locale selector consistent with admin. Meta: https://meta.discourse.org/t/is-there-any-way-to-let-language-selector-display-english-instead-of-en/14518