### PR TITLE
FIX: incorrect pending_users_reminder user count

### DIFF
--- a/app/jobs/scheduled/pending_users_reminder.rb
+++ b/app/jobs/scheduled/pending_users_reminder.rb
@@ -22,13 +22,13 @@ module Jobs
           target_usernames = Group[:moderators].users.map do |user|
             next if user.id < 0
 
-            count = user.notifications.joins(:topic)
+            unseen_count = user.notifications.joins(:topic)
               .where("notifications.id > ?", user.seen_notification_id)
               .where("notifications.read = false")
               .where("topics.subtype = ?", TopicSubtype.pending_users_reminder)
               .count
 
-            count == 0 ? user.username : nil
+            unseen_count == 0 ? user.username : nil
           end.compact
 
           unless target_usernames.empty?

--- a/spec/jobs/pending_users_reminder_spec.rb
+++ b/spec/jobs/pending_users_reminder_spec.rb
@@ -38,6 +38,13 @@ describe Jobs::PendingUsersReminder do
         PostCreator.expects(:create).never
         Jobs::PendingUsersReminder.new.execute({})
       end
+
+      it "sets the correct pending user count in the notification" do
+        SiteSetting.pending_users_reminder_delay = 8
+        Fabricate(:user, created_at: 9.hours.ago)
+        PostCreator.expects(:create).with(Discourse.system_user, has_entries(title: '1 user waiting for approval'))
+        Jobs::PendingUsersReminder.new.execute({})
+      end
     end
   end
 


### PR DESCRIPTION
In the pending_users_reminder job the pending users count is being overridden by the value of `count` set in the user.notifications query. It is resulting in notifications like this being sent:

<img width="888" alt="screen shot 2017-12-13 at 12 00 55 pm" src="https://user-images.githubusercontent.com/2975917/33973440-c0096f66-e037-11e7-8705-d5f4c3b5cdbe.png">


