### PR TITLE
FEATURE: Don't delete email from server on pop3 polling

### DIFF
--- a/app/jobs/scheduled/poll_mailbox.rb
+++ b/app/jobs/scheduled/poll_mailbox.rb
@@ -39,8 +39,9 @@ module Jobs
       end
 
       pop3.start(SiteSetting.pop3_polling_username, SiteSetting.pop3_polling_password) do |pop|
-        pop.delete_all do |p|
+        pop.each_mail do |p|
           process_popmail(p)
+          p.delete if SiteSetting.pop3_polling_delete_from_server?
         end
       end
     rescue Net::OpenTimeout => e

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1405,6 +1405,7 @@ en:
     pop3_polling_host: "The host to poll for email via POP3."
     pop3_polling_username: "The username for the POP3 account to poll for email."
     pop3_polling_password: "The password for the POP3 account to poll for email."
+    pop3_polling_delete_from_server: "Delete emails from server"
     log_mail_processing_failures: "Log all email processing failures to http://yoursitename.com/logs"
     email_in: "Allow users to post new topics via email (requires manual or pop3 polling). Configure the addresses in the \"Settings\" tab of each category."
     email_in_min_trust: "The minimum trust level a user needs to have to be allowed to post new topics via email."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1405,7 +1405,7 @@ en:
     pop3_polling_host: "The host to poll for email via POP3."
     pop3_polling_username: "The username for the POP3 account to poll for email."
     pop3_polling_password: "The password for the POP3 account to poll for email."
-    pop3_polling_delete_from_server: "Delete emails from server"
+    pop3_polling_delete_from_server: "Delete emails from server. NOTE: If you disable this you should manually clean your mail inbox"
     log_mail_processing_failures: "Log all email processing failures to http://yoursitename.com/logs"
     email_in: "Allow users to post new topics via email (requires manual or pop3 polling). Configure the addresses in the \"Settings\" tab of each category."
     email_in_min_trust: "The minimum trust level a user needs to have to be allowed to post new topics via email."

--- a/config/locales/server.es.yml
+++ b/config/locales/server.es.yml
@@ -1236,6 +1236,7 @@ es:
     pop3_polling_host: "El host utilizado para hacer polling de e-mails vía POP3."
     pop3_polling_username: "El nombre de usuario de la cuenta POP3 para hacer polling de e-mails."
     pop3_polling_password: "La contraseña de la cuenta POP3 para hacer polling de correos."
+    pop3_polling_delete_from_server: "Eliminar los e-mails del servidor"
     log_mail_processing_failures: "Registra todos los fallos de procesamiento de email a http://yoursitename.com/logs"
     email_in: "Permitir a los usuarios crear nuevos temas por email (requiere el polling pop3). Configura las direcciones en la pestaña \"Ajustes\" de cada categoría."
     email_in_min_trust: "El mínimo nivel de confianza requerido para poder publicar nuevos temas por email."

--- a/config/locales/server.es.yml
+++ b/config/locales/server.es.yml
@@ -1236,7 +1236,6 @@ es:
     pop3_polling_host: "El host utilizado para hacer polling de e-mails vía POP3."
     pop3_polling_username: "El nombre de usuario de la cuenta POP3 para hacer polling de e-mails."
     pop3_polling_password: "La contraseña de la cuenta POP3 para hacer polling de correos."
-    pop3_polling_delete_from_server: "Eliminar los e-mails del servidor"
     log_mail_processing_failures: "Registra todos los fallos de procesamiento de email a http://yoursitename.com/logs"
     email_in: "Permitir a los usuarios crear nuevos temas por email (requiere el polling pop3). Configura las direcciones en la pestaña \"Ajustes\" de cada categoría."
     email_in_min_trust: "El mínimo nivel de confianza requerido para poder publicar nuevos temas por email."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -691,6 +691,7 @@ email:
   pop3_polling_port: 995
   pop3_polling_username: ''
   pop3_polling_password: ''
+  pop3_polling_delete_from_server: true
   log_mail_processing_failures: false
   incoming_email_prefer_html: false
   email_in:

--- a/spec/jobs/poll_mailbox_spec.rb
+++ b/spec/jobs/poll_mailbox_spec.rb
@@ -71,6 +71,13 @@ describe Jobs::PollMailbox do
       Net::POP3.any_instance.expects(:enable_ssl).never
       poller.poll_pop3
     end
+
+    it "delete emails from inbox when the setting is enabled" do
+      SiteSetting.pop3_polling_delete_from_server = true
+      Net::POP3.any_instance.stubs(:start)
+      Net::POP3.any_instance.expects(:empty?).to eq(true)
+      poller.poll_pop3
+    end
   end
 
   describe "#process_popmail" do


### PR DESCRIPTION
Added an option for avoiding deletion of emails from server, this allows reusing the reply mail account for other uses