### PR TITLE
Unicode usernames

### DIFF
--- a/app/assets/javascripts/discourse/components/user-card-contents.js.es6
+++ b/app/assets/javascripts/discourse/components/user-card-contents.js.es6
@@ -115,8 +115,7 @@ export default Ember.Component.extend(CleansUp, CanCheckEmails, {
       return false;
     }
 
-    // XSS protection (should be encapsulated)
-    username = username.toString().replace(/[^A-Za-z0-9_\.\-]/g, "");
+    username = Ember.Handlebars.Utils.escapeExpression(username.toString());
 
     // Don't show on mobile
     if (this.site.mobileView) {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ require_dependency "permalink_constraint"
 
 # This used to be User#username_format, but that causes a preload of the User object
 # and makes Guard not work properly.
-USERNAME_ROUTE_FORMAT = /[\w.\-]+?/ unless defined? USERNAME_ROUTE_FORMAT
+USERNAME_ROUTE_FORMAT = /[%\w.\-]+?/ unless defined? USERNAME_ROUTE_FORMAT
 
 BACKUP_ROUTE_FORMAT = /.+\.(sql\.gz|tar\.gz|tgz)/i unless defined? BACKUP_ROUTE_FORMAT
 


### PR DESCRIPTION
Initial implementation to support unicode usernames (eg: Анатолий), ATM this PR won‘t work for unicode usernames without a custom username validation logic.

* route for % encoded:
allows router to understand url encoded usernames

* escape username instead of replacing chars:
make sure the username is escaped to avoid xss but is still readable by the backend