### PR TITLE
Proof-of-concept: Data loss on update of single user_field

### DIFF
--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1533,6 +1533,34 @@ describe UsersController do
 
               expect(user.user_fields[user_field.id.to_s].size).to eq(UserField.max_length)
             end
+
+            it "override required field" do
+              put :update, params: {
+                username: user.username, name: 'Jim Tom', user_fields: { user_field.id.to_s => 'happy', optional_field.id.to_s => 'feet' }
+              }, format: :json
+
+              put :update, params: {
+                username: user.username, name: 'Jim Tom', user_fields: { optional_field.id.to_s => 'day' }
+              }, format: :json
+
+              expect(response).to be_success
+              expect(user.user_fields[user_field.id.to_s]).to eq 'happy'
+              expect(user.user_fields[optional_field.id.to_s]).to eq 'day'
+            end
+
+            it "override optional field" do
+              put :update, params: {
+                username: user.username, name: 'Jim Tom', user_fields: { user_field.id.to_s => 'happy', optional_field.id.to_s => 'feet' }
+              }, format: :json
+
+              put :update, params: {
+                username: user.username, name: 'Jim Tom', user_fields: { user_field.id.to_s => 'sad' }
+              }, format: :json
+
+              expect(response).to be_success
+              expect(user.user_fields[user_field.id.to_s]).to eq 'sad'
+              expect(user.user_fields[optional_field.id.to_s]).to eq 'feet'
+            end
           end
 
           context "uneditable field" do


### PR DESCRIPTION
Tests to proof a changed behaviour of user_field update.
The current update needs a list of all user_fields. When only a single user_field is submitted, the content of all other user_fields will be set to nil (data loss).
In the past it was possible to change the content of a single user_field without side effects to other user_fields.
The changed behaviour is probably introduced on the following commit (Line 102, 105, 115, 121):

https://github.com/discourse/discourse/blob/77d4c4d8dc00491b99aa15dfd78eb22a47ffe663/app/controllers/users_controller.rb#L99-L123