### PR TITLE
Improve URL validation to check for a valid host.

### DIFF
--- a/app/models/user_profile.rb
+++ b/app/models/user_profile.rb
@@ -1,13 +1,8 @@
 class UserProfile < ActiveRecord::Base
   belongs_to :user, inverse_of: :user_profile
 
-  # This is not very picky about most DNS labels (the bits between the
-  # periods), but isn't taking much guff from the TLD. No leading
-  # digit, and no hyphens unless IDN.
-  WEBSITE_REGEXP = /(^$)|(^(https?:\/\/)?([a-z0-9][a-z0-9-]*\.)+([a-z][a-z0-9]+|xn--[a-z0-9-]+)(\/.*)?$)/i
-
   validates :bio_raw, length: { maximum: 3000 }
-  validates :website, format: { with: WEBSITE_REGEXP }, allow_blank: true, if: Proc.new { |c| c.new_record? || c.website_changed? }
+  validates :website, url: true, allow_blank: true, if: Proc.new { |c| c.new_record? || c.website_changed? }
   validates :user, presence: true
   before_save :cook
   after_save :trigger_badges

--- a/lib/validators/url_validator.rb
+++ b/lib/validators/url_validator.rb
@@ -1,9 +1,15 @@
 class UrlValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     if value.present?
-      uri = URI.parse(value) rescue nil
+      valid =
+        begin
+          uri = URI.parse(value)
+          uri.is_a?(URI::HTTP) && !uri.host.nil? && MiniSuffix.domain(uri.host).present?
+        rescue
+          nil
+        end
 
-      unless uri
+      unless valid
         record.errors[attribute] << (options[:message] || I18n.t('errors.messages.invalid'))
       end
     end

--- a/spec/models/user_profile_spec.rb
+++ b/spec/models/user_profile_spec.rb
@@ -55,18 +55,35 @@ describe UserProfile do
     end
 
     context "website validation" do
-      let(:user) { Fabricate(:user) }
+      let(:user_profile) { Fabricate.build(:user_profile, user: Fabricate(:user)) }
 
-      it "ensures website is valid" do
-        expect(Fabricate.build(:user_profile, user: user, website: "http://https://google.com")).not_to be_valid
-        expect(Fabricate.build(:user_profile, user: user, website: "http://discourse.productions")).to be_valid
-        expect(Fabricate.build(:user_profile, user: user, website: "https://google.com")).to be_valid
+      [
+        "http://https://google.com",
+      ].each do |invalid_url|
+        it "#{invalid_url} should not be valid" do
+          user_profile.website = invalid_url
+          expect(user_profile).to_not be_valid
+        end
+      end
+
+      [
+        "http://discourse.productions",
+        "https://google.com",
+      ].each do |valid_url|
+        it "#{valid_url} should be valid" do
+          user_profile.website = valid_url
+          expect(user_profile).to be_valid
+        end
       end
 
       it "validates website domain if user_website_domains_whitelist setting is present" do
         SiteSetting.user_website_domains_whitelist = "discourse.org"
-        expect(Fabricate.build(:user_profile, user: user, website: "https://google.com")).not_to be_valid
-        expect(Fabricate.build(:user_profile, user: user, website: "http://discourse.org")).to be_valid
+
+        user_profile.website = "https://google.com"
+        expect(user_profile).not_to be_valid
+
+        user_profile.website = "http://discourse.org"
+        expect(user_profile).to be_valid
       end
     end
 


### PR DESCRIPTION
Parsing a URL with `URI` is not sufficient as the following cases
are considered valid:

URI.parse("http://https://google.com")
=> #<URI::HTTP http://https//google.com>