### PR TITLE
FIX: allow multiple secondary emails

### DIFF
--- a/app/models/user_email.rb
+++ b/app/models/user_email.rb
@@ -14,7 +14,7 @@ class UserEmail < ActiveRecord::Base
 
   validate :user_id_not_changed, if: :primary
 
-  validates :primary, uniqueness: { scope: [:user_id] }
+  validates :primary, uniqueness: { scope: [:user_id] }, if: :primary
 
   private
 

--- a/db/migrate/20171220181249_change_user_emails_primary_index.rb
+++ b/db/migrate/20171220181249_change_user_emails_primary_index.rb
@@ -1,0 +1,11 @@
+class ChangeUserEmailsPrimaryIndex < ActiveRecord::Migration[5.1]
+  def up
+    remove_index :user_emails, [:user_id, :primary]
+    add_index :user_emails, [:user_id, :primary], unique: true, where: '"primary"'
+  end
+
+  def down
+    remove_index :user_emails, [:user_id, :primary]
+    add_index :user_emails, [:user_id, :primary], unique: true
+  end
+end

--- a/spec/models/user_email_spec.rb
+++ b/spec/models/user_email_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+require_dependency 'user_email'
+
+describe UserEmail do
+  context "validation" do
+    it "allows only one primary email" do
+      user = Fabricate(:user_single_email)
+      expect {
+        Fabricate(:alternate_email, user: user, primary: true)
+      }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+
+    it "allows multiple secondary emails" do
+      user = Fabricate(:user_single_email)
+      Fabricate(:alternate_email, user: user, primary: false)
+      Fabricate(:alternate_email, user: user, primary: false)
+      expect(user.user_emails.count).to eq 3
+    end
+  end
+
+  context "indexes" do
+    it "allows only one primary email" do
+      user = Fabricate(:user_single_email)
+      expect {
+        Fabricate.build(:alternate_email, user: user, primary: true).save(validate: false)
+      }.to raise_error(ActiveRecord::RecordNotUnique)
+    end
+
+    it "allows multiple secondary emails" do
+      user = Fabricate(:user_single_email)
+      Fabricate.build(:alternate_email, user: user, primary: false).save(validate: false)
+      Fabricate.build(:alternate_email, user: user, primary: false).save(validate: false)
+      expect(user.user_emails.count).to eq 3
+    end
+  end
+end


### PR DESCRIPTION
While working on adding multiple email support to the email receiver (which, based on the tests I've been writing, seems to already exist... but that's a story for another PR) I was running into errors adding multiple secondary email addresses to a user.

This fixes up the validator, and replaces the index with a partial index, to allow that to happen.