### PR TITLE
FIX: pluralization rules for Serbian language

### DIFF
--- a/config/locales/plurals.rb
+++ b/config/locales/plurals.rb
@@ -92,7 +92,7 @@
   sms: { i18n: { plural: { keys: [:one, :two, :other], rule: lambda { |n| n == 1 ? :one : n == 2 ? :two : :other } } } },
   so: { i18n: { plural: { keys: [:one, :other], rule: lambda { |n| n == 1 ? :one : :other } } } },
   sq: { i18n: { plural: { keys: [:one, :other], rule: lambda { |n| n == 1 ? :one : :other } } } },
-  sr: { i18n: { plural: { keys: [:one, :few, :many, :other], rule: lambda { |n| n % 10 == 1 && n % 100 != 11 ? :one : [2, 3, 4].include?(n % 10) && ![12, 13, 14].include?(n % 100) ? :few : n % 10 == 0 || [5, 6, 7, 8, 9].include?(n % 10) || [11, 12, 13, 14].include?(n % 100) ? :many : :other } } } },
+  sr: { i18n: { plural: { keys: [:one, :few, :other], rule: lambda { |n| n % 10 == 1 && n % 100 != 11 ? :one : [2, 3, 4].include?(n % 10) && ![12, 13, 14].include?(n % 100) ? :few : :other } } } },
   sv: { i18n: { plural: { keys: [:one, :other], rule: lambda { |n| n == 1 ? :one : :other } } } },
   sw: { i18n: { plural: { keys: [:one, :other], rule: lambda { |n| n == 1 ? :one : :other } } } },
   ta: { i18n: { plural: { keys: [:one, :other], rule: lambda { |n| n == 1 ? :one : :other } } } },

--- a/lib/javascripts/locale/sr.js
+++ b/lib/javascripts/locale/sr.js
@@ -1,14 +1,11 @@
 MessageFormat.locale.sr = function (n) {
-  if ((n % 10) == 1 && (n % 100) != 11) {
+  var r10 = n % 10, r100 = n % 100;
+
+  if (r10 == 1 && r100 != 11)
     return 'one';
-  }
-  if ((n % 10) >= 2 && (n % 10) <= 4 &&
-      ((n % 100) < 12 || (n % 100) > 14) && n == Math.floor(n)) {
+
+  if (r10 >= 2 && r10 <= 4 && (r100 < 12 || r100 > 14) && n == Math.floor(n))
     return 'few';
-  }
-  if ((n % 10) === 0 || ((n % 10) >= 5 && (n % 10) <= 9) ||
-      ((n % 100) >= 11 && (n % 100) <= 14) && n == Math.floor(n)) {
-    return 'many';
-  }
+
   return 'other';
 };


### PR DESCRIPTION
Updated SR pluralization to use 3 keys: one, few, other (as by Transifex)