### PR TITLE
Remove wrapper `<span>` from user nav plugin outlet

### DIFF
--- a/app/assets/javascripts/discourse/templates/user.hbs
+++ b/app/assets/javascripts/discourse/templates/user.hbs
@@ -191,7 +191,7 @@
       {{#if showBadges}}
         <li>{{#link-to 'user.badges'}}{{d-icon "certificate"}}{{i18n 'badges.title'}}{{/link-to}}</li>
       {{/if}}
-      {{plugin-outlet name="user-main-nav" connectorTagName='li' args=(hash model=model)}}
+      {{plugin-outlet name="user-main-nav" tagName='' connectorTagName='li' args=(hash model=model)}}
       {{#if model.can_edit}}
         <li>{{#link-to 'preferences'}}{{d-icon "cog"}}{{i18n 'user.preferences'}}{{/link-to}}</li>
       {{/if}}


### PR DESCRIPTION
As-per https://meta.discourse.org/t/plugin-outlet-incorrectly-handles-multiple-plugins-at-the-same-outlet/32206/24

I did a search of all-the-plugins, and it looks like the only one currently using the user-main-nav outlet is `dl-license-keys`

```
$ find . -name user-main-nav
./plugins/dl-license-keys/assets/javascripts/discourse/templates/connectors/user-main-nav
```