### PR TITLE
FIX: allow upto three url redirects in onebox

### DIFF
--- a/config/initializers/100-onebox_options.rb
+++ b/config/initializers/100-onebox_options.rb
@@ -2,6 +2,6 @@ require_dependency 'twitter_api'
 
 Onebox.options = {
   twitter_client: TwitterApi,
-  redirect_limit: 1,
+  redirect_limit: 3,
   user_agent: "Discourse Forum Onebox v#{Discourse::VERSION::STRING}"
 }


### PR DESCRIPTION
This PR fixes Medium oneboxes. Issue originally reported here: https://meta.discourse.org/t/onebox-for-subdomains/73893

Even after going through `FinalDestination` library Medium performs following redirects in Onebox:

1. https://hackernoon.com/practical-functional-programming-6d7932abc58b?gi=9262906b7e6c 
2. https://medium.com/m/global-identity?redirectUrl=https%3A%2F%2Fhackernoon.com%2Fpractical-functional-programming-6d7932abc58b 
3. https://hackernoon.com/practical-functional-programming-6d7932abc58b?gi=4b490916fb4b

Currently since onebox is limited to one redirect, the oneboxing is failing.