### PR TITLE
Drop the fork usage of fastimage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,8 +53,7 @@ gem 'fast_xs'
 
 gem 'fast_xor'
 
-# Forked until https://github.com/sdsykes/fastimage/pull/93 is merged
-gem 'discourse_fastimage', require: 'fastimage'
+gem 'fastimage'
 
 gem 'aws-sdk-s3', require: false
 gem 'excon', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,7 +85,6 @@ GEM
     diff-lcs (1.3)
     discourse-qunit-rails (0.0.11)
       railties
-    discourse_fastimage (2.1.0)
     discourse_image_optim (0.24.5)
       exifr (~> 1.2, >= 1.2.2)
       fspath (~> 3.0)
@@ -120,6 +119,7 @@ GEM
       rake
       rake-compiler
     fast_xs (0.8.0)
+    fastimage (2.1.1)
     ffi (1.9.18)
     flamegraph (0.9.5)
     foreman (0.84.0)
@@ -420,7 +420,6 @@ DEPENDENCIES
   certified
   cppjieba_rb
   discourse-qunit-rails
-  discourse_fastimage
   discourse_image_optim
   email_reply_trimmer (= 0.1.8)
   ember-handlebars-template (= 0.7.5)
@@ -433,6 +432,7 @@ DEPENDENCIES
   fast_blank
   fast_xor
   fast_xs
+  fastimage
   flamegraph
   foreman
   gc_tracer
@@ -509,4 +509,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.16.0
+   1.16.1


### PR DESCRIPTION
Fork is not needed anymore since fastimage 2.1.1 has been released with the needed PR merged in.