### PR TITLE
UX: for numbers greater than 100k allow 0 precision

### DIFF
--- a/app/assets/javascripts/discourse/lib/formatter.js.es6
+++ b/app/assets/javascripts/discourse/lib/formatter.js.es6
@@ -310,8 +310,10 @@ export function number(val) {
   if (val > 999999) {
     formattedNumber = I18n.toNumber(val / 1000000, {precision: 1});
     return I18n.t("number.short.millions", {number: formattedNumber});
-  }
-  if (val > 999) {
+  } else if (val > 99999) {
+    formattedNumber = I18n.toNumber(val / 1000, {precision: 0});
+    return I18n.t("number.short.thousands", {number: formattedNumber});
+  } else if (val > 999) {
     formattedNumber = I18n.toNumber(val / 1000, {precision: 1});
     return I18n.t("number.short.thousands", {number: formattedNumber});
   }


### PR DESCRIPTION
Numbers like `365178` will display as `365k`, instead of `365.1k`.