### PR TITLE
Add search not operator

### DIFF
--- a/lib/search.rb
+++ b/lib/search.rb
@@ -458,20 +458,13 @@ class Search
     end
   end
 
-  advanced_filter(/tags?:([a-zA-Z0-9,\-_+!]+)/) do |posts, match|
-    if match.include?('!')
-      search_parts = match.split('!')
-      positive_part = search_parts[0]
-      negative_part = search_parts[1]
+  advanced_filter(/^tags?:(.*)/) do |posts, match|
+    search_tags(posts, match)
+  end
 
-      positive_tags = search_tags(posts, positive_part)
-      negative_tags = search_tags(posts, negative_part)
-
-      positive_tags.where(["posts.id NOT IN (?)",
-                           negative_tags.pluck("id")]).order("id")
-    else
-      search_tags(posts, match)
-    end
+  advanced_filter(/\-tags?:(.*)/) do |posts, match|
+    negative_tags = search_tags(posts, match)
+    posts.where(["posts.id NOT IN (?)", negative_tags.pluck("id")]).order("id")
   end
 
   advanced_filter(/filetypes?:([a-zA-Z0-9,\-_]+)/) do |posts, match|

--- a/lib/search.rb
+++ b/lib/search.rb
@@ -458,9 +458,9 @@ class Search
     end
   end
 
-  advanced_filter(/tags?:([a-zA-Z0-9,\-_+~]+)/) do |posts, match|
-    if match.include?('~')
-      search_parts = match.split('~')
+  advanced_filter(/tags?:([a-zA-Z0-9,\-_+!]+)/) do |posts, match|
+    if match.include?('!')
+      search_parts = match.split('!')
       positive_part = search_parts[0]
       negative_part = search_parts[1]
 

--- a/lib/search.rb
+++ b/lib/search.rb
@@ -468,7 +468,7 @@ class Search
       negative_tags = search_tags(posts, negative_part)
 
       positive_tags.where(["posts.id NOT IN (?)",
-                           negative_tags.pluck("id")])
+                           negative_tags.pluck("id")]).order("id")
     else
       search_tags(posts, match)
     end

--- a/lib/search.rb
+++ b/lib/search.rb
@@ -458,18 +458,16 @@ class Search
     end
   end
 
-  advanced_filter(/^tags?:(.*)/) do |posts, match|
-    search_tags(posts, match)
+  advanced_filter(/^tags?:([a-zA-Z0-9,\-_+]+)/) do |posts, match|
+    search_tags(posts, match, true)
   end
 
-  advanced_filter(/\-tags?:(.*)/) do |posts, match|
-    negative_tags = search_tags(posts, match)
-    posts.where(["posts.id NOT IN (?)", negative_tags.pluck("id")]).order("id")
+  advanced_filter(/\-tags?:([a-zA-Z0-9,\-_+]+)/) do |posts, match|
+    search_tags(posts, match, false)
   end
 
   advanced_filter(/filetypes?:([a-zA-Z0-9,\-_]+)/) do |posts, match|
     file_extensions = match.split(",").map(&:downcase)
-
     posts.where("posts.id IN (
       SELECT post_id FROM topic_links
       WHERE extension IN (:file_extensions)
@@ -482,27 +480,28 @@ class Search
 
   private
 
-    def search_tags(posts, match)
+    def search_tags(posts, match, is_positive)
       return if match.nil?
+
+      modifier = is_positive ? "" : "NOT"
 
       if match.include?('+')
         tags = match.split('+')
-        posts.where("topics.id IN (
-              SELECT tt.topic_id
-              FROM topic_tags tt, tags
-              WHERE tt.tag_id = tags.id
-              GROUP BY tt.topic_id
-              HAVING to_tsvector(#{default_ts_config}, array_to_string(array_agg(tags.name), ' ')) @@ to_tsquery(#{default_ts_config}, ?)
-              )", tags.join('&'))
+        posts.where("topics.id #{modifier} IN (
+          SELECT tt.topic_id
+          FROM topic_tags tt, tags
+          WHERE tt.tag_id = tags.id
+          GROUP BY tt.topic_id
+          HAVING to_tsvector(#{default_ts_config}, array_to_string(array_agg(tags.name), ' ')) @@ to_tsquery(#{default_ts_config}, ?)
+        )", tags.join('&')).order("id")
       else
         tags = match.split(",")
 
-        posts.where("topics.id IN (
-              SELECT DISTINCT(tt.topic_id)
-              FROM topic_tags tt, tags
-              WHERE tt.tag_id = tags.id
-              AND tags.name in (?)
-              )", tags)
+        posts.where("topics.id #{modifier} IN (
+          SELECT DISTINCT(tt.topic_id)
+          FROM topic_tags tt, tags
+          WHERE tt.tag_id = tags.id AND tags.name IN (?)
+        )", tags).order("id")
       end
     end
 

--- a/spec/components/search_spec.rb
+++ b/spec/components/search_spec.rb
@@ -807,12 +807,17 @@ describe Search do
     context 'tags' do
       let(:tag1) { Fabricate(:tag, name: 'lunch') }
       let(:tag2) { Fabricate(:tag, name: 'eggs') }
+      let(:tag3) { Fabricate(:tag, name: 'sandwiches') }
       let(:topic1) { Fabricate(:topic, tags: [tag2, Fabricate(:tag)]) }
       let(:topic2) { Fabricate(:topic, tags: [tag2]) }
       let(:topic3) { Fabricate(:topic, tags: [tag1, tag2]) }
+      let(:topic4) { Fabricate(:topic, tags: [tag1, tag2, tag3]) }
+      let(:topic5) { Fabricate(:topic, tags: [tag2, tag3]) }
       let!(:post1) { Fabricate(:post, topic: topic1) }
       let!(:post2) { Fabricate(:post, topic: topic2) }
       let!(:post3) { Fabricate(:post, topic: topic3) }
+      let!(:post4) { Fabricate(:post, topic: topic4) }
+      let!(:post5) { Fabricate(:post, topic: topic5) }
 
       it 'can find posts with tag' do
         post4 = Fabricate(:post, topic: topic3, raw: "It probably doesn't help that they're green...")
@@ -824,12 +829,17 @@ describe Search do
       it 'can find posts with any tag from multiple tags' do
         Fabricate(:post)
 
-        expect(Search.execute('tags:eggs,lunch').posts.map(&:id).sort).to eq([post1.id, post2.id, post3.id].sort)
+        expect(Search.execute('tags:eggs,lunch').posts.map(&:id).sort).to eq([post1.id, post2.id, post3.id, post4.id, post5.id].sort)
       end
 
       it 'can find posts which contains all provided tags' do
-        expect(Search.execute('tags:lunch+eggs').posts.map(&:id)).to eq([post3.id])
-        expect(Search.execute('tags:eggs+lunch').posts.map(&:id)).to eq([post3.id])
+        expect(Search.execute('tags:lunch+eggs+sandwiches').posts.map(&:id)).to eq([post4.id].sort)
+        expect(Search.execute('tags:eggs+lunch+sandwiches').posts.map(&:id)).to eq([post4.id].sort)
+      end
+      it 'can find posts which contains provided tags and does not contain selected ones' do
+        expect(Search.execute('tags:eggs~lunch').posts.map(&:id)).to eq([post1.id, post2.id, post5.id].sort)
+        expect(Search.execute('tags:eggs~lunch+sandwiches').posts.map(&:id)).to eq([post1.id, post2.id, post3.id, post5.id].sort)
+        expect(Search.execute('tags:eggs~lunch,sandwiches').posts.map(&:id)).to eq([post1.id, post2.id].sort)
       end
     end
 

--- a/spec/components/search_spec.rb
+++ b/spec/components/search_spec.rb
@@ -837,9 +837,9 @@ describe Search do
         expect(Search.execute('tags:eggs+lunch+sandwiches').posts.map(&:id)).to eq([post4.id].sort)
       end
       it 'can find posts which contains provided tags and does not contain selected ones' do
-        expect(Search.execute('tags:eggs~lunch').posts.map(&:id)).to eq([post1.id, post2.id, post5.id].sort)
-        expect(Search.execute('tags:eggs~lunch+sandwiches').posts.map(&:id)).to eq([post1.id, post2.id, post3.id, post5.id].sort)
-        expect(Search.execute('tags:eggs~lunch,sandwiches').posts.map(&:id)).to eq([post1.id, post2.id].sort)
+        expect(Search.execute('tags:eggs!lunch').posts.map(&:id)).to eq([post1.id, post2.id, post5.id].sort)
+        expect(Search.execute('tags:eggs!lunch+sandwiches').posts.map(&:id)).to eq([post1.id, post2.id, post3.id, post5.id].sort)
+        expect(Search.execute('tags:eggs!lunch,sandwiches').posts.map(&:id)).to eq([post1.id, post2.id].sort)
       end
     end
 

--- a/spec/components/search_spec.rb
+++ b/spec/components/search_spec.rb
@@ -836,10 +836,11 @@ describe Search do
         expect(Search.execute('tags:lunch+eggs+sandwiches').posts.map(&:id)).to eq([post4.id].sort)
         expect(Search.execute('tags:eggs+lunch+sandwiches').posts.map(&:id)).to eq([post4.id].sort)
       end
+
       it 'can find posts which contains provided tags and does not contain selected ones' do
-        expect(Search.execute('tags:eggs!lunch').posts.map(&:id)).to eq([post1.id, post2.id, post5.id].sort)
-        expect(Search.execute('tags:eggs!lunch+sandwiches').posts.map(&:id)).to eq([post1.id, post2.id, post3.id, post5.id].sort)
-        expect(Search.execute('tags:eggs!lunch,sandwiches').posts.map(&:id)).to eq([post1.id, post2.id].sort)
+        expect(Search.execute('tags:eggs -tags:lunch').posts.map(&:id)).to eq([post1.id, post2.id, post5.id].sort)
+        expect(Search.execute('tags:eggs -tags:lunch+sandwiches').posts.map(&:id)).to eq([post1.id, post2.id, post3.id, post5.id].sort)
+        expect(Search.execute('tags:eggs -tags:lunch,sandwiches').posts.map(&:id)).to eq([post1.id, post2.id].sort)
       end
     end
 


### PR DESCRIPTION
I added the simple version of search operator "not" (~) for tags. Currently it has the highest precedence.
Link to the issue: https://meta.discourse.org/t/new-search-operator-not/52087
  