### PR TITLE
FIX: do not create duplicate topics

### DIFF
--- a/app/models/topic_embed.rb
+++ b/app/models/topic_embed.rb
@@ -182,8 +182,8 @@ class TopicEmbed < ActiveRecord::Base
   end
 
   def self.topic_id_for_embed(embed_url)
-    embed_url = normalize_url(embed_url)
-    TopicEmbed.where("lower(embed_url) = ?", embed_url).pluck(:topic_id).first
+    embed_url = normalize_url(embed_url).sub(/^https?\:\/\//, '')
+    TopicEmbed.where("embed_url ~* '^https?://#{embed_url}$'").pluck(:topic_id).first
   end
 
   def self.first_paragraph_from(html)

--- a/spec/models/topic_embed_spec.rb
+++ b/spec/models/topic_embed_spec.rb
@@ -60,6 +60,20 @@ describe TopicEmbed do
 
   end
 
+  context '.topic_id_for_embed' do
+    it "returns correct topic id irrespective of url protocol" do
+      topic_embed = Fabricate(:topic_embed, embed_url: "http://example.com/post/248")
+
+      expect(TopicEmbed.topic_id_for_embed('http://exAMPle.com/post/248')).to eq(topic_embed.topic_id)
+      expect(TopicEmbed.topic_id_for_embed('https://example.com/post/248/')).to eq(topic_embed.topic_id)
+
+      expect(TopicEmbed.topic_id_for_embed('http://example.com/post/248/2')).to eq(nil)
+      expect(TopicEmbed.topic_id_for_embed('http://examples.com/post/248')).to eq(nil)
+      expect(TopicEmbed.topic_id_for_embed('http://example.com/post/24')).to eq(nil)
+      expect(TopicEmbed.topic_id_for_embed('http://example.com/post')).to eq(nil)
+    end
+  end
+
   describe '.find_remote' do
 
     context ".title_scrub" do

--- a/spec/requests/embed_controller_spec.rb
+++ b/spec/requests/embed_controller_spec.rb
@@ -4,6 +4,7 @@ describe EmbedController do
 
   let(:host) { "eviltrout.com" }
   let(:embed_url) { "http://eviltrout.com/2013/02/10/why-discourse-uses-emberjs.html" }
+  let(:embed_url_secure) { "https://eviltrout.com/2013/02/10/why-discourse-uses-emberjs.html" }
   let(:discourse_username) { "eviltrout" }
 
   it "is 404 without an embed_url" do
@@ -95,7 +96,7 @@ describe EmbedController do
       it "displays the right view" do
         topic_embed = Fabricate(:topic_embed, embed_url: embed_url)
 
-        get '/embed/comments', params: { embed_url: embed_url }, headers: headers
+        get '/embed/comments', params: { embed_url: embed_url_secure }, headers: headers
 
         expect(response.body).to match(I18n.t('embed.start_discussion'))
       end


### PR DESCRIPTION
https://meta.discourse.org/t/duplicate-http-https-topics-are-randomly-created/77190