### PR TITLE
FIX: broken select badge as user title

### DIFF
--- a/app/assets/javascripts/discourse/templates/components/badge-title.hbs
+++ b/app/assets/javascripts/discourse/templates/components/badge-title.hbs
@@ -10,7 +10,10 @@
     <div class="control-group">
       <label class="control-label"></label>
       <div class="controls">
-        {{combo-box value=selectedUserBadgeId nameProperty="badge.name" content=selectableUserBadges}}
+        {{combo-box
+          value=selectedUserBadgeId
+          nameProperty="badge.name"
+          content=selectableUserBadges}}
       </div>
     </div>
 

--- a/app/assets/javascripts/discourse/templates/user/badge-title.hbs
+++ b/app/assets/javascripts/discourse/templates/user/badge-title.hbs
@@ -1,1 +1,4 @@
-{{badge-title selectableUserBadges=selectableUserBadges user=user}}
+{{badge-title
+  selectedUserBadgeId=selectedUserBadgeId
+  selectableUserBadges=selectableUserBadges
+  user=user}}

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -178,7 +178,7 @@ class UsersController < ApplicationController
 
     user_badge = UserBadge.find_by(id: params[:user_badge_id])
     if user_badge && user_badge.user == user && user_badge.badge.allow_title?
-      user.title = user_badge.badge.name
+      user.title = user_badge.badge.display_name
       user.user_profile.badge_granted_title = true
       user.save!
       user.user_profile.save!

--- a/config/locales/client.ca.yml
+++ b/config/locales/client.ca.yml
@@ -2021,7 +2021,7 @@ ca:
         one: "1 concedit"
         other: "%{count} concedits"
       select_badge_for_title: Tria un distintiu per fer-lo servir com al teu títol
-      none: "<none>"
+      none: "(none)"
       badge_grouping:
         getting_started:
           name: Començant

--- a/config/locales/client.cs.yml
+++ b/config/locales/client.cs.yml
@@ -2065,7 +2065,7 @@ cs:
         few: "%{count} přidělen"
         other: "%{count} přidělen"
       select_badge_for_title: Vyberte odznak, který chcete použít jako svůj titul
-      none: "<none>"
+      none: "(none)"
       badge_grouping:
         getting_started:
           name: Jak začít?

--- a/config/locales/client.da.yml
+++ b/config/locales/client.da.yml
@@ -2085,7 +2085,7 @@ da:
         one: "1 tildelt"
         other: "%{count} tildelt"
       select_badge_for_title: Vælg en badge, du vil bruge som din titel
-      none: "<ingen>"
+      none: "(ingen)"
       badge_grouping:
         getting_started:
           name: Sådan kommer du i gang

--- a/config/locales/client.de.yml
+++ b/config/locales/client.de.yml
@@ -2267,7 +2267,7 @@ de:
         one: "1-mal verliehen"
         other: "%{count}-mal verliehen"
       select_badge_for_title: Wähle ein Abzeichen als deinen Titel aus
-      none: "<keines>"
+      none: "(keines)"
       badge_grouping:
         getting_started:
           name: Erste Schritte

--- a/config/locales/client.el.yml
+++ b/config/locales/client.el.yml
@@ -2214,7 +2214,7 @@ el:
         one: "1 χορηγήθηκε"
         other: "%{count} χορηγήθηκε"
       select_badge_for_title: Επίλεξε ένα παράσημο για να χρησιμοποιήσεις ως τίτλο
-      none: "<none>"
+      none: "(none)"
       badge_grouping:
         getting_started:
           name: Ξεκινώντας

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2482,7 +2482,7 @@ en:
         one:   "1 granted"
         other: "%{count} granted"
       select_badge_for_title: Select a badge to use as your title
-      none: "<none>"
+      none: "(none)"
       badge_grouping:
         getting_started:
           name: Getting Started

--- a/config/locales/client.es.yml
+++ b/config/locales/client.es.yml
@@ -2271,7 +2271,7 @@ es:
         one: "1 concedido"
         other: "%{count} concedidos"
       select_badge_for_title: Seleccionar una distinción para utilizar como tu título
-      none: "<none>"
+      none: "(none)"
       badge_grouping:
         getting_started:
           name: Primeros pasos

--- a/config/locales/client.et.yml
+++ b/config/locales/client.et.yml
@@ -1971,7 +1971,7 @@ et:
         one: "1 lubatud"
         other: "%{count} lubatud"
       select_badge_for_title: Vali märgis, mida kasutada oma pealkirjana
-      none: "<pole ühtegi>"
+      none: "(pole ühtegi)"
       badge_grouping:
         getting_started:
           name: Alustamine

--- a/config/locales/client.fa_IR.yml
+++ b/config/locales/client.fa_IR.yml
@@ -2009,7 +2009,7 @@ fa_IR:
       granted:
         other: "%{count} اعطا شده"
       select_badge_for_title: انتخاب یک نشان برای استفاده در عنوان خود
-      none: "<none>"
+      none: "(none)"
       badge_grouping:
         getting_started:
           name: شروع

--- a/config/locales/client.fi.yml
+++ b/config/locales/client.fi.yml
@@ -2268,7 +2268,7 @@ fi:
         one: "1 myönnetty"
         other: "%{count} myönnettyä"
       select_badge_for_title: Valitse tittelisi ansiomerkeistä
-      none: "<ei mitään>"
+      none: "(ei mitään)"
       badge_grouping:
         getting_started:
           name: Ensiaskeleet

--- a/config/locales/client.fr.yml
+++ b/config/locales/client.fr.yml
@@ -2271,7 +2271,7 @@ fr:
         one: "1 décerné"
         other: "%{count} décernés"
       select_badge_for_title: Sélectionner un badge comme titre
-      none: "<aucun>"
+      none: "(aucun)"
       badge_grouping:
         getting_started:
           name: Initiation

--- a/config/locales/client.he.yml
+++ b/config/locales/client.he.yml
@@ -2113,7 +2113,7 @@ he:
         one: "הוענק"
         other: "%{count} הוענקו"
       select_badge_for_title: בחרו בעיטור לשימוש בכותרת שלכם
-      none: "<none>"
+      none: "(none)"
       badge_grouping:
         getting_started:
           name: מתחילים

--- a/config/locales/client.it.yml
+++ b/config/locales/client.it.yml
@@ -2211,7 +2211,7 @@ it:
         one: "1 assegnato"
         other: "%{count} assegnati"
       select_badge_for_title: Seleziona un distintivo da usare come tuo titolo
-      none: "<nessuno>"
+      none: "(nessuno)"
       badge_grouping:
         getting_started:
           name: Iniziali

--- a/config/locales/client.ko.yml
+++ b/config/locales/client.ko.yml
@@ -2091,7 +2091,7 @@ ko:
       granted:
         other: "%{count}개 수여됨"
       select_badge_for_title: 타이틀로 사용할 배지 선택하기
-      none: "<none>"
+      none: "(none)"
       badge_grouping:
         getting_started:
           name: 시작하기

--- a/config/locales/client.lv.yml
+++ b/config/locales/client.lv.yml
@@ -2199,7 +2199,7 @@ lv:
         one: "1 piešķirts"
         other: "%{count} piešķirti"
       select_badge_for_title: Izvēlieties žetonu, ko lietot kā jūsu titulu
-      none: "<none>"
+      none: "(none)"
       badge_grouping:
         getting_started:
           name: Uzsākt darbu

--- a/config/locales/client.nb_NO.yml
+++ b/config/locales/client.nb_NO.yml
@@ -2268,7 +2268,7 @@ nb_NO:
         one: "ett tildelt"
         other: "%{count} tildelt"
       select_badge_for_title: Velg et merke å bruke som din tittel
-      none: "<none>"
+      none: "(none)"
       badge_grouping:
         getting_started:
           name: Kom i gang

--- a/config/locales/client.nl.yml
+++ b/config/locales/client.nl.yml
@@ -2175,7 +2175,7 @@ nl:
         one: "1 toegekend"
         other: "%{count} toegekend"
       select_badge_for_title: Kies een badge om als uw titel te gebruiken
-      none: "<geen>"
+      none: "(geen)"
       badge_grouping:
         getting_started:
           name: Aan de slag

--- a/config/locales/client.pl_PL.yml
+++ b/config/locales/client.pl_PL.yml
@@ -2430,7 +2430,7 @@ pl_PL:
         many: "%{count} przyznanych"
         other: "%{count} przyznanych"
       select_badge_for_title: Wybierz odznakę do użycia jako twój tytuł
-      none: "<brak>"
+      none: "(brak)"
       badge_grouping:
         getting_started:
           name: Pierwsze kroki

--- a/config/locales/client.pt.yml
+++ b/config/locales/client.pt.yml
@@ -2024,7 +2024,7 @@ pt:
         one: "1 concedido"
         other: "%{count} concedidos"
       select_badge_for_title: Selecionar um distintivo para usar como seu título
-      none: "<none>"
+      none: "(none)"
       badge_grouping:
         getting_started:
           name: Começar

--- a/config/locales/client.pt_BR.yml
+++ b/config/locales/client.pt_BR.yml
@@ -2126,7 +2126,7 @@ pt_BR:
         one: "1 concedido"
         other: "%{count} concedidos"
       select_badge_for_title: Selecione um emblema para usar como o seu título
-      none: "<nenhum>"
+      none: "(nenhum)"
       badge_grouping:
         getting_started:
           name: Primeiros Passos

--- a/config/locales/client.ro.yml
+++ b/config/locales/client.ro.yml
@@ -2034,7 +2034,7 @@ ro:
         few: "%{count} acordate"
         other: "%{count} acordate"
       select_badge_for_title: Selectați un ecuson pentru a-l folosi ca titlu
-      none: "<niciunul>"
+      none: "(niciunul)"
       badge_grouping:
         getting_started:
           name: Cum începem

--- a/config/locales/client.ru.yml
+++ b/config/locales/client.ru.yml
@@ -2294,7 +2294,7 @@ ru:
         many: "выдано %{count}"
         other: "выдано %{count}"
       select_badge_for_title: Использовать награду в качестве Вашего титула
-      none: "<отсутствует>"
+      none: "(отсутствует)"
       badge_grouping:
         getting_started:
           name: Начало работы

--- a/config/locales/client.sk.yml
+++ b/config/locales/client.sk.yml
@@ -1915,7 +1915,7 @@ sk:
         one: "1 udelený"
         few: "%{count} udelené"
         other: "%{count} udelených"
-      none: "<žiadne>"
+      none: "(žiadne)"
       badge_grouping:
         getting_started:
           name: Začíname

--- a/config/locales/client.sq.yml
+++ b/config/locales/client.sq.yml
@@ -1883,7 +1883,7 @@ sq:
         one: "1 e akorduar"
         other: "%{count} të akorduara"
       select_badge_for_title: Zgjidhni një stemë për ta përdorur si titullin tuaj
-      none: "<asnjë>"
+      none: "(asnjë)"
       badge_grouping:
         getting_started:
           name: Fillestar

--- a/config/locales/client.sv.yml
+++ b/config/locales/client.sv.yml
@@ -2022,7 +2022,7 @@ sv:
         one: "1 utfärdad"
         other: "%{count} utfärdade"
       select_badge_for_title: Välj en utmärkelse att använda som din titel
-      none: "<none>"
+      none: "(none)"
       badge_grouping:
         getting_started:
           name: Komma igång

--- a/config/locales/client.tr_TR.yml
+++ b/config/locales/client.tr_TR.yml
@@ -1986,7 +1986,7 @@ tr_TR:
       granted:
         other: "%{count} izin verildi"
       select_badge_for_title: Başlık yazısı olarak kullanılacak bir rozet seçin
-      none: "<none>"
+      none: "(none)"
       badge_grouping:
         getting_started:
           name: Başlangıç

--- a/config/locales/client.ur.yml
+++ b/config/locales/client.ur.yml
@@ -1980,7 +1980,7 @@ ur:
         one: "1 عطا کیا گیا"
         other: "%{count} عطا کیے گئے"
       select_badge_for_title: اپنے عنوان کے طور پر استعمال کرنے کے لئے ایک بیج منتخب کریں
-      none: "<none>"
+      none: "(none)"
       badge_grouping:
         getting_started:
           name: شروعات

--- a/config/locales/client.vi.yml
+++ b/config/locales/client.vi.yml
@@ -1834,7 +1834,7 @@ vi:
       title: Huy hiệu
       badge_count:
         other: "%{count} huy hiệu"
-      none: "<none>"
+      none: "(none)"
       badge_grouping:
         getting_started:
           name: Bắt đầu

--- a/config/locales/client.zh_CN.yml
+++ b/config/locales/client.zh_CN.yml
@@ -2142,7 +2142,7 @@ zh_CN:
       granted:
         other: "%{count} 授予"
       select_badge_for_title: 选择一个徽章作为你的头衔使用
-      none: "<none>"
+      none: "(none)"
       badge_grouping:
         getting_started:
           name: 开始

--- a/config/locales/client.zh_TW.yml
+++ b/config/locales/client.zh_TW.yml
@@ -1884,7 +1884,7 @@ zh_TW:
       granted:
         other: "%{count} 授予"
       select_badge_for_title: 選擇一個徽章作為你的頭銜使用
-      none: "<none>"
+      none: "(none)"
       badge_grouping:
         getting_started:
           name: 開始

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1640,14 +1640,14 @@ describe UsersController do
         user_badge_id: user_badge.id, username: user.username
       }, format: :json
 
-      expect(user.reload.title).not_to eq(badge.name)
+      expect(user.reload.title).not_to eq(badge.display_name)
       badge.update_attributes allow_title: true
 
       put :badge_title, params: {
         user_badge_id: user_badge.id, username: user.username
       }, format: :json
 
-      expect(user.reload.title).to eq(badge.name)
+      expect(user.reload.title).to eq(badge.display_name)
       expect(user.user_profile.badge_granted_title).to eq(true)
 
       user.title = "testing"
@@ -1655,6 +1655,24 @@ describe UsersController do
       user.user_profile.reload
       expect(user.user_profile.badge_granted_title).to eq(false)
 
+    end
+  end
+
+  describe "badge_title with overrided name" do
+    let(:user) { Fabricate(:user) }
+    let(:badge) { Fabricate(:badge, name: 'Demogorgon', allow_title: true) }
+    let(:user_badge) { BadgeGranter.grant(badge, user) }
+
+    TranslationOverride.upsert!('en', 'badges.demogorgon.name', 'Boss')
+
+    it "uses the badge display name as user title" do
+      log_in_user user
+
+      put :badge_title, params: {
+        user_badge_id: user_badge.id, username: user.username
+      }, format: :json
+
+      expect(user.reload.title).to eq(badge.display_name)
     end
   end
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1663,7 +1663,13 @@ describe UsersController do
     let(:badge) { Fabricate(:badge, name: 'Demogorgon', allow_title: true) }
     let(:user_badge) { BadgeGranter.grant(badge, user) }
 
-    TranslationOverride.upsert!('en', 'badges.demogorgon.name', 'Boss')
+    before do
+      TranslationOverride.upsert!('en', 'badges.demogorgon.name', 'Boss')
+    end
+
+    after do
+      TranslationOverride.revert!('en', ['badges.demogorgon.name'])
+    end
 
     it "uses the badge display name as user title" do
       log_in_user user


### PR DESCRIPTION
* selected id wasn’t pass to underlying component
* <none> was rendered as an html tag <none></none> and not consistent with what we do in other places, eg: (no category)
* overriding a badge name wouldn’t work as it was using badge.name and not badge.display_name
* adds a spec to ensure this behavior is correct