### PR TITLE
FEATURE: add setting which adds group name to PM email subject

### DIFF
--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -245,6 +245,7 @@ class UserNotifications < ActionMailer::Base
     opts[:use_site_subject] = true
     opts[:add_re_to_subject] = true
     opts[:show_category_in_subject] = false
+    opts[:show_group_in_subject] = true if SiteSetting.group_in_subject
 
     # We use the 'user_posted' event when you are emailed a post in a PM.
     opts[:notification_type] = 'posted'
@@ -359,6 +360,7 @@ class UserNotifications < ActionMailer::Base
       use_site_subject: opts[:use_site_subject],
       add_re_to_subject: opts[:add_re_to_subject],
       show_category_in_subject: opts[:show_category_in_subject],
+      show_group_in_subject: opts[:show_group_in_subject],
       notification_type: notification_type,
       use_invite_template: opts[:use_invite_template],
       user: user
@@ -407,6 +409,21 @@ class UserNotifications < ActionMailer::Base
       end
     else
       show_category_in_subject = nil
+    end
+
+    if post.topic.private_message?
+      subject_pm =
+        if opts[:show_group_in_subject]
+          if group = post.topic.allowed_groups&.first
+            if group.full_name
+              "[#{group.full_name}] "
+            else
+              "[#{group.name}] "
+            end
+          end
+        else
+          I18n.t('subject_pm')
+        end
     end
 
     if SiteSetting.private_email?
@@ -510,6 +527,7 @@ class UserNotifications < ActionMailer::Base
       add_re_to_subject: add_re_to_subject,
       show_category_in_subject: show_category_in_subject,
       private_reply: post.topic.private_message?,
+      subject_pm: subject_pm,
       include_respond_instructions: !(user.suspended? || user.staged?),
       template: template,
       site_description: SiteSetting.site_description,

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1446,6 +1446,7 @@ en:
     staff_user_custom_fields: "A whitelist of custom fields for a user that can be shown to staff."
     enable_user_directory: "Provide a directory of users for browsing"
     enable_group_directory: "Provide a directory of groups for browsing"
+    group_in_subject: "Set %{optional_pm} in email subject to name of first group in PM, see: https://meta.discourse.org/t/customize-subject-format-for-standard-emails/20801"
     allow_anonymous_posting: "Allow users to switch to anonymous mode"
     anonymous_posting_min_trust_level: "Minimum trust level required to enable anonymous posting"
     anonymous_account_duration_minutes: "To protect anonymity create a new anonymous account every N minutes for each user. Example: if set to 600, as soon as 600 minutes elapse from last post AND user switches to anon, a new anonymous account is created."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -429,6 +429,8 @@ groups:
   enable_group_directory:
     client: true
     default: true
+  group_in_subject:
+    default: false
 
 posting:
   min_post_length:

--- a/lib/email/message_builder.rb
+++ b/lib/email/message_builder.rb
@@ -62,7 +62,7 @@ module Email
         subject = String.new(SiteSetting.email_subject)
         subject.gsub!("%{site_name}", @template_args[:email_prefix])
         subject.gsub!("%{optional_re}", @opts[:add_re_to_subject] ? I18n.t('subject_re', @template_args) : '')
-        subject.gsub!("%{optional_pm}", @opts[:private_reply] ? I18n.t('subject_pm', @template_args) : '')
+        subject.gsub!("%{optional_pm}", @opts[:private_reply] ? @template_args[:subject_pm] : '')
         subject.gsub!("%{optional_cat}", @template_args[:show_category_in_subject] ? "[#{@template_args[:show_category_in_subject]}] " : '')
         subject.gsub!("%{topic_title}", @template_args[:topic_title]) if @template_args[:topic_title] # must be last for safety
       else

--- a/spec/mailers/user_notifications_spec.rb
+++ b/spec/mailers/user_notifications_spec.rb
@@ -357,7 +357,7 @@ describe UserNotifications do
       expect(mail[:from].display_names).to eql(['john'])
 
       # subject should include "[PM]"
-      expect(mail.subject).to match("[PM]")
+      expect(mail.subject).to include("[PM] ")
 
       # 1 "visit message" link
       expect(mail.html_part.to_s.scan(/Visit Message/).count).to eq(1)
@@ -386,6 +386,65 @@ describe UserNotifications do
       expect(mail.html_part.to_s).to_not include(topic.url)
       expect(mail.text_part.to_s).to_not include(response.raw)
       expect(mail.text_part.to_s).to_not include(topic.url)
+    end
+
+    it "doesn't include group name in subject" do
+      group = Fabricate(:group)
+      topic.allowed_groups = [ group ]
+      mail = UserNotifications.user_private_message(
+        response.user,
+        post: response,
+        notification_type: notification.notification_type,
+        notification_data_hash: notification.data_hash
+      )
+
+      expect(mail.subject).to include("[PM] ")
+    end
+
+    context "when SiteSetting.group_name_in_subject is true" do
+      before do
+        SiteSetting.group_in_subject = true
+      end
+
+      let(:group) { Fabricate(:group, name: "my_group") }
+      let(:mail) { UserNotifications.user_private_message(
+        response.user,
+        post: response,
+        notification_type: notification.notification_type,
+        notification_data_hash: notification.data_hash
+      ) }
+
+      shared_examples "includes first group name" do
+        it "includes first group name in subject" do
+          expect(mail.subject).to include("[my_group] ")
+        end
+
+        context "when first group has full name" do
+          it "includes full name in subject" do
+            group.full_name = "My Group"
+            group.save
+            expect(mail.subject).to include("[My Group] ")
+          end
+        end
+      end
+
+      context "one group in pm" do
+        before do
+          topic.allowed_groups = [ group ]
+        end
+
+        include_examples "includes first group name"
+      end
+
+      context "multiple groups in pm" do
+        let(:group2) { Fabricate(:group) }
+
+        before do
+          topic.allowed_groups = [ group, group2 ]
+        end
+
+        include_examples "includes first group name"
+      end
     end
   end
 


### PR DESCRIPTION
From: https://meta.discourse.org/t/alternative-subject-for-group-pm-email-notifications/57158

I thought I'd KISS and just use the first group which receives the PM in the subject line. It's not perfect, and could cause some confusion, but it's behind a site setting and (I think) is still better than what currently exists.