### PR TITLE
Support ruby 2.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,6 @@ addons:
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - rvm: 2.5.0
 
 rvm:
   - 2.5.0

--- a/app/jobs/regular/bulk_invite.rb
+++ b/app/jobs/regular/bulk_invite.rb
@@ -29,7 +29,8 @@ module Jobs
     end
 
     def read_csv_file(csv_path)
-      CSV.foreach(csv_path, encoding: "bom|utf-8") do |csv_info|
+      file = File.open(csv_path, encoding: 'bom|utf-8')
+      CSV.new(file).each do |csv_info|
         if csv_info[0]
           if (EmailValidator.email_regex =~ csv_info[0])
             # email is valid
@@ -45,6 +46,8 @@ module Jobs
     rescue Exception => e
       log "Bulk Invite Process Failed -- '#{e.message}'"
       @failed += 1
+    ensure
+      file.close
     end
 
     def get_group_ids(group_names, csv_line_number)

--- a/spec/jobs/bulk_invite_spec.rb
+++ b/spec/jobs/bulk_invite_spec.rb
@@ -12,7 +12,7 @@ describe Jobs::BulkInvite do
     context '.read_csv_file' do
       let(:user) { Fabricate(:user) }
       let(:bulk_invite) { Jobs::BulkInvite.new }
-      let(:csv_file) { File.new("#{Rails.root}/spec/fixtures/csv/discourse.csv") }
+      let(:csv_file) { "#{Rails.root}/spec/fixtures/csv/discourse.csv" }
 
       it 'reads csv file' do
         bulk_invite.current_user = user


### PR DESCRIPTION
Support for ruby 2.5.0

The BOM encoding behaviour somehow changed between ruby releases, so I had to change the logic of opening the csv file for import. 