### PR TITLE
Add dotenv-rails gem to have .env loaded in rake tasks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,8 @@ gem 'mime-types', require: 'mime/types/columnar'
 gem 'mini_mime'
 gem 'mini_suffix'
 
+gem 'dotenv-rails'
+
 gem 'hiredis'
 gem 'redis', require:  ["redis", "redis/connection/hiredis"]
 gem 'redis-namespace'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,10 @@ GEM
       image_size (~> 1.5)
       in_threads (~> 1.3)
       progress (~> 3.0, >= 3.0.1)
+    dotenv (2.2.1)
+    dotenv-rails (2.2.1)
+      dotenv (= 2.2.1)
+      railties (>= 3.2, < 5.2)
     email_reply_trimmer (0.1.8)
     ember-data-source (2.2.1)
       ember-source (>= 1.8, < 3.0)
@@ -421,6 +425,7 @@ DEPENDENCIES
   cppjieba_rb
   discourse-qunit-rails
   discourse_image_optim
+  dotenv-rails
   email_reply_trimmer (= 0.1.8)
   ember-handlebars-template (= 0.7.5)
   ember-rails (= 0.18.5)


### PR DESCRIPTION
Otherwise I couldn't get the `GlobalSetting.developer_emails` to have the value from `.env` loaded when doing a `rake admin:create`.

If there is some sort of `require 'foreman/dotenv'` that exists, I think it could be placed in `Rakefile` to have the same result.