### PR TITLE
Add prompt and HD settings to the Google OAuth2 plugin.

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -247,6 +247,12 @@ login:
     default: false
   google_oauth2_client_id: ''
   google_oauth2_client_secret: ''
+  google_oauth2_prompt:
+    client: true
+    default: 'none'
+  google_oauth2_hd:
+    client: true
+    default: ''
   enable_yahoo_logins:
     client: true
     default: false

--- a/lib/auth/google_oauth2_authenticator.rb
+++ b/lib/auth/google_oauth2_authenticator.rb
@@ -59,7 +59,9 @@ class Auth::GoogleOAuth2Authenticator < Auth::Authenticator
               strategy.options[:client_id] = SiteSetting.google_oauth2_client_id
               strategy.options[:client_secret] = SiteSetting.google_oauth2_client_secret
            },
-           skip_jwt: true
+           skip_jwt: true,
+           prompt: SiteSetting.google_oauth2_prompt,
+           hd: SiteSetting.google_oauth2_hd
   end
 
   protected


### PR DESCRIPTION
Discussed here: https://meta.discourse.org/t/improve-google-login-with-multiple-accounts/75964.

As suggested, this patch adds the prompt and hd options supported by the omniauth-google-oauth2 Gem to the Discourse settings menu.

I'm not great at Ruby, so this patch could still use a bit of love. Specifically:

* It would be great to validate that the prompt setting was an allowed value, specifically none, consent, or select_account
* Translations are needed

If someone could help drag this one across the finish line, I'd appreciate it. Thanks in advance! This is really going to help us with our installation.