### PR TITLE
FIX: Top offset value of #main-outlet element is always 0

### DIFF
--- a/app/assets/javascripts/discourse/components/site-header.js.es6
+++ b/app/assets/javascripts/discourse/components/site-header.js.es6
@@ -24,7 +24,7 @@ const SiteHeaderComponent = MountWidget.extend(Docking, {
     if (this.docAt === null) {
       const outlet = $('#main-outlet');
       if (!(outlet && outlet.length === 1)) return;
-      this.docAt = outlet.offset().top;
+      this.docAt = outlet.children().offset().top;
     }
 
     const $body = $('body');


### PR DESCRIPTION
I believe behavior of offset method changed in jQuery and it is not respecting padding anymore. So now I am getting offset value for first child element of `#main-outlet`.