### PR TITLE
Mark up the headers in the Categories page

### DIFF
--- a/app/assets/javascripts/discourse/templates/components/categories-only.hbs
+++ b/app/assets/javascripts/discourse/templates/components/categories-only.hbs
@@ -2,14 +2,14 @@
   <table class="category-list {{if showTopics 'with-topics'}}">
     <thead>
       <tr>
-        <th class="category">{{i18n 'categories.category'}}</th>
+        <th class="category"><span aria-role="heading" aria-level="2" id="categories-only-category">{{i18n 'categories.category'}}</span></th>
         <th class="topics">{{i18n 'categories.topics'}}</th>
         {{#if showTopics}}
           <th class="latest">{{i18n 'categories.latest'}}</th>
         {{/if}}
       </tr>
     </thead>
-    <tbody>
+    <tbody aria-labelledby="categories-only-category">
       {{#each categories as |c|}}
         <tr data-category-id={{c.id}} class="{{if c.description_excerpt 'has-description' 'no-description'}} {{if c.uploaded_logo.url 'has-logo' 'no-logo'}}">
           <td class="category" style={{border-color c.color}}>

--- a/app/assets/javascripts/discourse/templates/components/latest-topic-list.hbs
+++ b/app/assets/javascripts/discourse/templates/components/latest-topic-list.hbs
@@ -1,4 +1,4 @@
-<div class='table-heading'>
+<div class='table-heading' aria-role="heading" aria-level="2">
   {{i18n "filters.latest.title"}}
 </div>
 


### PR DESCRIPTION
This should cause them to show up in Table of Contents. Most screenreaders have a keyboard command to bring up a list of headers, allowing the user to skip to a section of the page that interests them without listening to Stephen Hawking recite Discourse-Search-Menu-User-All Categories-All Tags-Latest-New-... for the fiftieth time. Or, in this case, allowing the users to skip to the "Latest" section without listening to the categories first.