### PR TITLE
Fix: RTL topic-admin-menu position

### DIFF
--- a/app/assets/javascripts/discourse/widgets/topic-admin-menu.js.es6
+++ b/app/assets/javascripts/discourse/widgets/topic-admin-menu.js.es6
@@ -63,8 +63,13 @@ createWidget('topic-admin-menu-button', {
 
     const $button = $(e.target).closest('button');
     const position = $button.position();
+    const rtl = $('html').hasClass('rtl');
     position.left = position.left;
     position.outerHeight = $button.outerHeight();
+
+    if (rtl) {
+        position.left -= 217 - $button.outerWidth();
+    }
 
     if (this.attrs.fixed) {
       position.left += $button.width() - 203;

--- a/app/assets/stylesheets/common/base/rtl.scss
+++ b/app/assets/stylesheets/common/base/rtl.scss
@@ -2,9 +2,9 @@
 // *** These styles are all going to be flipped by the r2 gem ***
 // Adding the !important declaration to a rule prevents it from being flipped.
 
-// Keep the topic admin menu on the page
-.rtl .popup-menu {
-  right: 0 !important;
+.rtl #topic-progress-wrapper .topic-admin-popup-menu.right-side,
+.rtl #topic-progress-wrapper.docked .topic-admin-popup-menu.right-side {
+  right: 80px;
 }
 
 // This is used to flip the .d-icon-caret-right


### PR DESCRIPTION
Checks if an RTL locale is being used to set the inline styles for the topic-admin-menu position. Fixes RTL css for `#topic-progress-wrapper .topic-admin-popup-menu.right-side`.

Before:
![screen shot 2018-01-13 at 10 49 16 am](https://user-images.githubusercontent.com/2975917/34909346-3e7125a4-f854-11e7-9959-17986230f256.png)
After:
![screen shot 2018-01-13 at 10 59 08 am](https://user-images.githubusercontent.com/2975917/34909358-631d3622-f854-11e7-90df-5ebfd0165c82.png)

Before (`.topic-admin-popup-menu.right-side`):
![screen shot 2018-01-13 at 10 51 08 am](https://user-images.githubusercontent.com/2975917/34909384-98e264bc-f854-11e7-9afe-ec6271a8772e.png)
After:
![screen shot 2018-01-13 at 10 59 30 am](https://user-images.githubusercontent.com/2975917/34909387-a6323c64-f854-11e7-98cc-7e186f18b009.png)


