### PR TITLE
Accessibility: focus management in topics

### DIFF
--- a/app/assets/javascripts/discourse/components/topic-list-item.js.es6
+++ b/app/assets/javascripts/discourse/components/topic-list-item.js.es6
@@ -30,8 +30,9 @@ export default Ember.Component.extend(bufferedRender({
   rerenderTriggers: ['bulkSelectEnabled', 'topic.pinned'],
   tagName: 'tr',
   classNameBindings: [':topic-list-item', 'unboundClassNames', 'topic.visited'],
-  attributeBindings: ['data-topic-id'],
+  attributeBindings: ['data-topic-id', 'tabindex'],
   'data-topic-id': Em.computed.alias('topic.id'),
+  'tabindex': 0,
 
   actions: {
     toggleBookmark() {

--- a/app/assets/javascripts/discourse/lib/keyboard-shortcuts.js.es6
+++ b/app/assets/javascripts/discourse/lib/keyboard-shortcuts.js.es6
@@ -299,9 +299,15 @@ export default {
       return;
     }
 
-    const $selected = ($articles.filter('.selected').length !== 0)
-      ? $articles.filter('.selected')
-      : $articles.filter('[data-islastviewedtopic=true]');
+    let $selected = $articles.filter(function(_, el) {
+      return el.contains(document.activeElement); // :focus
+    });
+    if ($selected.length === 0) {
+      $selected = $articles.filter('.selected');
+    }
+    if ($selected.length === 0) {
+      $selected = $articles.filter('[data-islastviewedtopic=true]');
+    }
     let index = $articles.index($selected);
 
     if ($selected.length !== 0) { //boundries check
@@ -338,10 +344,11 @@ export default {
       $article.addClass('selected');
 
       if ($article.is('.topic-post')) {
-        $('a.tabLoc', $article).focus();
+        $('article', $article).focus();
         this._scrollToPost($article);
 
       } else {
+        $article.focus();
         this._scrollList($article, direction);
       }
     }

--- a/app/assets/javascripts/discourse/lib/keyboard-shortcuts.js.es6
+++ b/app/assets/javascripts/discourse/lib/keyboard-shortcuts.js.es6
@@ -82,6 +82,8 @@ export default {
         this._bindToClick(binding.click, key);
       }
     });
+
+    this._bindFocus();
   },
 
   toggleBookmark() {
@@ -290,6 +292,24 @@ export default {
     if (typeof this[func] === 'function') {
       this.keyTrapper.bind(binding, _.bind(this[func], this));
     }
+  },
+
+  _bindFocus() {
+    $(document).on('focusin.topic-post', e => {
+      const $wrapper = $(e.target).closest('.topic-post, .topic-list-item, .topic-list tbody tr');
+      const $srcWrapper = $(e.relatedTarget).closest('.topic-post, .topic-list-item, .topic-list tbody tr');
+      if (!$wrapper.is($srcWrapper)) {
+        $wrapper.addClass('selected');
+      }
+    });
+
+    $(document).on('focusout.topic-post', e => {
+      const $wrapper = $(e.target).closest('.topic-post, .topic-list-item, .topic-list tbody tr');
+      const $srcWrapper = $(e.relatedTarget).closest('.topic-post, .topic-list-item, .topic-list tbody tr');
+      if (!$wrapper.is($srcWrapper)) {
+        $wrapper.removeClass('selected');
+      }
+    });
   },
 
   _moveSelection(direction) {

--- a/app/assets/javascripts/discourse/widgets/post.js.es6
+++ b/app/assets/javascripts/discourse/widgets/post.js.es6
@@ -366,11 +366,11 @@ createWidget('post-article', {
   },
 
   buildAttributes(attrs) {
-    return { 'data-post-id': attrs.id, 'data-user-id': attrs.user_id };
+    return { 'data-post-id': attrs.id, 'data-user-id': attrs.user_id, 'tabindex': '0' };
   },
 
   html(attrs, state) {
-    const rows = [h('a.tabLoc', { attributes: { href: ''} })];
+    const rows = [];
     if (state.repliesAbove.length) {
       const replies = state.repliesAbove.map(p => {
         return this.attach('embedded-post', p, { model: this.store.createRecord('post', p), state: { above: true } });

--- a/app/assets/stylesheets/common/components/keyboard_shortcuts.scss
+++ b/app/assets/stylesheets/common/components/keyboard_shortcuts.scss
@@ -6,8 +6,16 @@
   box-shadow: -3px 0 0 $danger;
 }
 
+.mobile-view .topic-list tr.selected td:first-child, .topic-list-item.selected td:first-child, .topic-post.selected {
+  box-shadow: none;
+}
+
 .topic-list-item.selected {
   background-color: inherit;
+}
+
+.topic-post article:focus, .topic-list tr:focus, .topic-list-item:focus {
+  outline: 0;
 }
 
 .keyboard-shortcuts-modal .modal-body {

--- a/app/assets/stylesheets/common/components/keyboard_shortcuts.scss
+++ b/app/assets/stylesheets/common/components/keyboard_shortcuts.scss
@@ -6,8 +6,10 @@
   box-shadow: -3px 0 0 $danger;
 }
 
-.mobile-view .topic-list tr.selected td:first-child, .topic-list-item.selected td:first-child, .topic-post.selected {
-  box-shadow: none;
+.mobile-view {
+  .topic-list tr.selected td:first-child, .topic-list-item.selected td:first-child, .topic-post.selected {
+    box-shadow: none;
+  }
 }
 
 .topic-list-item.selected {

--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -126,7 +126,7 @@ nav.post-controls {
     border: none;
     margin-left: 3px;
 
-    &.d-hover {
+    &.d-hover, &:focus {
       background: $primary-low;
       color: $primary;
     }
@@ -142,12 +142,12 @@ nav.post-controls {
       position: relative;
     }
 
-    &.delete.d-hover {
+    &.delete.d-hover, &.delete:focus {
       background: $danger;
       color: $secondary;
     }
 
-    &.like.d-hover {
+    &.like.d-hover, &.like:focus {
       color: $love;
       background: $love-low;
     }


### PR DESCRIPTION
This work is a prerequisite to pointing screen readers at the right spot when you enter in the middle of a topic.

 - Applied hover styling to post actions when focused - this way, you can actually see that the button is tabbed to instead of being entirely invisible.
 - Made topic posts, and topic list items, valid tab targets.
    - Removed the `<a class=tabLoc>` at the start of every post, because the post itself is now a valid target.
 - Made the J/K keyboard navigation focus each post / topic list item, and use focus as the first test for what's currently selected.
 - The obvious complement to that is to use the existing `.selected` styling for when the element is focused. *Edge does not support the `:focus-within` selector*, so we need to use JS to track this.
 - A final cleanup commit to set `outline: 0` on our newly focusable elements, since they have custom styling.