### PR TITLE
FEATURE: Keyboard shortcut to refocus composer

### DIFF
--- a/app/assets/javascripts/discourse/components/d-editor.js.es6
+++ b/app/assets/javascripts/discourse/components/d-editor.js.es6
@@ -254,6 +254,7 @@ export default Ember.Component.extend({
   @on('willDestroyElement')
   _shutDown() {
     if (this.get('composerEvents')) {
+      this.appEvents.off('composer:insert-block');
       this.appEvents.off('composer:insert-text');
       this.appEvents.off('composer:replace-text');
     }

--- a/app/assets/javascripts/discourse/lib/keyboard-shortcuts.js.es6
+++ b/app/assets/javascripts/discourse/lib/keyboard-shortcuts.js.es6
@@ -12,6 +12,7 @@ const bindings = {
   '.':               {click: '.alert.alert-info.clickable', anonymous: true}, // show incoming/updated topics
   'b':               {handler: 'toggleBookmark'},
   'c':               {handler: 'createTopic'},
+  'C':               {handler: 'focusComposer'},
   'ctrl+f':          {handler: 'showPageSearch', anonymous: true},
   'command+f':       {handler: 'showPageSearch', anonymous: true},
   'ctrl+p':          {handler: 'printTopic', anonymous: true},
@@ -171,6 +172,15 @@ export default {
   createTopic() {
     if (this.currentUser && this.currentUser.can_create_topic) {
       this.container.lookup('controller:composer').open({action: Composer.CREATE_TOPIC, draftKey: Composer.CREATE_TOPIC});
+    }
+  },
+
+  focusComposer() {
+    const composer = this.container.lookup('controller:composer');
+    if (composer.get('model.viewOpen')) {
+      setTimeout(() => $('textarea.d-editor-input').focus(), 0);
+    } else {
+      composer.send('openIfDraft');
     }
   },
 

--- a/app/assets/javascripts/discourse/templates/modal/keyboard-shortcuts-help.hbs
+++ b/app/assets/javascripts/discourse/templates/modal/keyboard-shortcuts-help.hbs
@@ -25,7 +25,6 @@
     <div class="span6">
       <h4>{{i18n 'keyboard_shortcuts_help.application.title'}}</h4>
       <ul>
-        <li>{{{i18n 'keyboard_shortcuts_help.application.create'}}}</li>
         <li>{{{i18n 'keyboard_shortcuts_help.application.hamburger_menu'}}}</li>
         <li>{{{i18n 'keyboard_shortcuts_help.application.user_profile_menu'}}}</li>
         <li>{{{i18n 'keyboard_shortcuts_help.application.show_incoming_updated_topics'}}}</li>
@@ -35,6 +34,15 @@
         <li>{{{i18n 'keyboard_shortcuts_help.application.dismiss_topics'}}}</li>
         <li>{{{i18n 'keyboard_shortcuts_help.application.log_out'}}}</li>
       </ul>
+      <h4>{{i18n 'keyboard_shortcuts_help.composing.title'}}</h4>
+      <ul>
+        <li>{{{i18n 'keyboard_shortcuts_help.composing.return'}}}</li>
+        <li>{{{i18n 'keyboard_shortcuts_help.application.create'}}}</li>
+        <li>{{{i18n 'keyboard_shortcuts_help.actions.reply_as_new_topic'}}}</li>
+        <li>{{{i18n 'keyboard_shortcuts_help.actions.reply_topic'}}}</li>
+        <li>{{{i18n 'keyboard_shortcuts_help.actions.reply_post'}}}</li>
+        <li>{{{i18n 'keyboard_shortcuts_help.actions.quote_post'}}}</li>
+      </ul>
     </div>
     <div class="span6">
       <h4>{{i18n 'keyboard_shortcuts_help.actions.title'}}</h4>
@@ -43,10 +51,6 @@
         <li>{{{i18n 'keyboard_shortcuts_help.actions.pin_unpin_topic'}}}</li>
         <li>{{{i18n 'keyboard_shortcuts_help.actions.share_topic'}}}</li>
         <li>{{{i18n 'keyboard_shortcuts_help.actions.share_post'}}}</li>
-        <li>{{{i18n 'keyboard_shortcuts_help.actions.reply_as_new_topic'}}}</li>
-        <li>{{{i18n 'keyboard_shortcuts_help.actions.reply_topic'}}}</li>
-        <li>{{{i18n 'keyboard_shortcuts_help.actions.reply_post'}}}</li>
-        <li>{{{i18n 'keyboard_shortcuts_help.actions.quote_post'}}}</li>
         <li>{{{i18n 'keyboard_shortcuts_help.actions.like'}}}</li>
         <li>{{{i18n 'keyboard_shortcuts_help.actions.flag'}}}</li>
         <li>{{{i18n 'keyboard_shortcuts_help.actions.bookmark'}}}</li>

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2442,6 +2442,9 @@ en:
         dismiss_new_posts: '<b>x</b>, <b>r</b> Dismiss New/Posts'
         dismiss_topics: '<b>x</b>, <b>t</b> Dismiss Topics'
         log_out: '<b>shift</b>+<b>z</b> <b>shift</b>+<b>z</b> Log Out'
+      composing:
+        title: 'Composing'
+        return: '<b>shift</b>+<b>C</b> Return to composer'
       actions:
         title: 'Actions'
         bookmark_topic: '<b>f</b> Toggle bookmark topic'


### PR DESCRIPTION
https://meta.discourse.org/t/accessibility-focus-management-in-topics/78109/3?u=riking

It was very annoying to get back to the composer after losing it!

Added to the keyboard shortcuts help dialog, and reshuffled it a bit. Translation keys were intentionally kept so our translators don't have to copy paste to update.

The setTimeout(0) is necessary because otherwise, the `C` actually gets inserted!

This commit also fixes an incidental listener leak.

![image](https://user-images.githubusercontent.com/627891/35024756-2afdb6fa-faf6-11e7-80e9-4e53f65f7a4a.png)
