### PR TITLE
Feature: add topic posts count to webhook post serializer

### DIFF
--- a/app/serializers/web_hook_post_serializer.rb
+++ b/app/serializers/web_hook_post_serializer.rb
@@ -1,4 +1,7 @@
 class WebHookPostSerializer < PostSerializer
+
+  attributes :topic_posts_count
+
   def include_topic_title?
     true
   end
@@ -14,4 +17,9 @@ class WebHookPostSerializer < PostSerializer
       false
     end
   end
+
+  def topic_posts_count
+    object.topic && object.topic.posts_count
+  end
+
 end

--- a/app/serializers/web_hook_post_serializer.rb
+++ b/app/serializers/web_hook_post_serializer.rb
@@ -19,7 +19,7 @@ class WebHookPostSerializer < PostSerializer
   end
 
   def topic_posts_count
-    object.topic && object.topic.posts_count
+    object.topic ? object.topic.posts_count : 0
   end
 
 end

--- a/spec/serializers/web_hook_post_serializer_spec.rb
+++ b/spec/serializers/web_hook_post_serializer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe WebHookPostSerializer do
 
   it 'should only include the required keys' do
     count = serializer.as_json.keys.count
-    difference = count - 40
+    difference = count - 41
 
     expect(difference).to eq(0), lambda {
       message = ""


### PR DESCRIPTION
This change would make it possible for the WordPress plugin to get the correct number of Discourse comments on a topic when posts have been moved or deleted from the topic. 