### PR TITLE
Fix notifications of staged users after sign-up

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -235,6 +235,8 @@ class User < ActiveRecord::Base
       user.staged = false
       user.active = false
       user.custom_fields[FROM_STAGED] = true
+
+      DiscourseEvent.trigger(:user_unstaged, user)
     end
     user
   end
@@ -383,7 +385,7 @@ class User < ActiveRecord::Base
 
   def read_first_notification?
     if (trust_level > TrustLevel[1] ||
-        created_at < TRACK_FIRST_NOTIFICATION_READ_DURATION.seconds.ago)
+        (first_seen_at.present? && first_seen_at < TRACK_FIRST_NOTIFICATION_READ_DURATION.seconds.ago))
 
       return true
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -235,6 +235,7 @@ class User < ActiveRecord::Base
       user.staged = false
       user.active = false
       user.custom_fields[FROM_STAGED] = true
+      user.notifications.destroy_all
 
       DiscourseEvent.trigger(:user_unstaged, user)
     end

--- a/plugins/discourse-narrative-bot/plugin.rb
+++ b/plugins/discourse-narrative-bot/plugin.rb
@@ -112,6 +112,10 @@ after_initialize do
     end
   end
 
+  self.on(:user_unstaged) do |user|
+    user.enqueue_bot_welcome_post
+  end
+
   self.add_to_class(:user, :enqueue_bot_welcome_post) do
     return if SiteSetting.disable_discourse_narrative_bot_welcome_post
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1600,6 +1600,16 @@ describe User do
       expect(User.unstage(email: 'no@account.com')).to be_nil
     end
 
+    it "removes all previous notifications during unstaging" do
+      Fabricate(:notification, user: user)
+      Fabricate(:private_message_notification, user: user)
+      user.reload
+
+      expect(user.total_unread_notifications).to eq(2)
+      user = User.unstage(params)
+      expect(user.total_unread_notifications).to eq(0)
+    end
+
     it "triggers an event" do
       unstaged_user = nil
       event = DiscourseEvent.track_events { unstaged_user = User.unstage(params) }.first


### PR DESCRIPTION
* Deletes old notifications when a staged users signs up. Otherwise their can be quite a lot of notifications and when the user change the username during sign-up, none of the notification links will work.

* Makes sure that discobot messages staged users after they sign up.