### PR TITLE
FIX: Only enqueue topic_edited hook when a post has a topic

### DIFF
--- a/config/initializers/012-web_hook_events.rb
+++ b/config/initializers/012-web_hook_events.rb
@@ -19,7 +19,7 @@ end
 
 DiscourseEvent.on(:post_edited) do |post, topic_changed|
   WebHook.enqueue_post_hooks(:post_edited, post)
-  WebHook.enqueue_topic_hooks(:topic_edited, post.topic) if post.is_first_post? && topic_changed
+  WebHook.enqueue_topic_hooks(:topic_edited, post.topic) if post.is_first_post? && topic_changed && post.topic
 end
 
 %i(


### PR DESCRIPTION
When the first post in a topic has been deleted and is then updated through the API, using an admin API key, it currently returns a 500 error: `undefined method 'id' for nil:NilClass` called from `app/models/web_hook.rb:48`.

This PR adds a check to make sure the post has an associated topic before enqueueing the topic_edited webhook.