### PR TITLE
FIX: mods should be able to grant badges in post wrench

### DIFF
--- a/app/assets/javascripts/discourse/widgets/post-admin-menu.js.es6
+++ b/app/assets/javascripts/discourse/widgets/post-admin-menu.js.es6
@@ -64,7 +64,9 @@ export function buildManageButtons(attrs, currentUser) {
       action: 'changePostOwner',
       className: 'change-owner'
     });
+  }
 
+  if (currentUser.staff) {
     contents.push({
       icon: 'certificate',
       label: 'post.controls.grant_badge',


### PR DESCRIPTION
> CONTEXT: https://meta.discourse.org/t/feature-proposal-improved-badge-granting-workflow/58631/32?u=xrav3nz

A follow-up to https://github.com/discourse/discourse/pull/5498; moderators should be able to grant badges in post wrench too:

<img src='https://user-images.githubusercontent.com/6376558/35305379-1ad64ea6-0067-11e8-92bf-6d4ccfc2af4e.png' width='200px'/>

###### and plz do hate me for not having a test, considered it but didn't...