### PR TITLE
Lock down gem versions so bundle update can be run

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ gem 'onebox', '1.8.35'
 gem 'http_accept_language', '~>2.0.5', require: false
 
 gem 'ember-rails', '0.18.5'
-gem 'ember-source'
+gem 'ember-source', '2.13.3'
 gem 'ember-handlebars-template', '0.7.5'
 gem 'barber'
 
@@ -82,7 +82,7 @@ gem 'omniauth-oauth2', require: false
 
 gem 'omniauth-google-oauth2'
 gem 'oj'
-gem 'pg'
+gem 'pg', '~> 0.21.0'
 gem 'pry-rails', require: false
 gem 'r2', '~> 0.2.5', require: false
 gem 'rake'


### PR DESCRIPTION
New clean PR without Gemfile.lock update see #5491 

Note that Travis will complain and build will stop with:
```
You are trying to install in deployment mode after changing
your Gemfile. Run `bundle install` elsewhere and add the
updated Gemfile.lock to version control.
The dependencies in your gemfile changed
You have added to the Gemfile:
* ember-source (= 2.13.3)
* pg (~> 0.21.0)
You have deleted from the Gemfile:
* ember-source
* pg```