### PR TITLE
FIX: allowed href scheme link can start with a +

### DIFF
--- a/app/assets/javascripts/pretty-text/sanitizer.js.es6
+++ b/app/assets/javascripts/pretty-text/sanitizer.js.es6
@@ -72,7 +72,10 @@ export function sanitize(text, whiteLister) {
   let extraHrefMatchers = null;
 
   if (allowedHrefSchemes && allowedHrefSchemes.length > 0) {
-    extraHrefMatchers = [new RegExp('^(' + allowedHrefSchemes.join('|') + '):\/\/\\+?[\\w\\.\\-]+','i')];
+    extraHrefMatchers = [new RegExp('^(' + allowedHrefSchemes.join('|') + '):\/\/[\\w\\.\\-]+','i')];
+    if (allowedHrefSchemes.includes('tel')) {
+      extraHrefMatchers.push(new RegExp('^tel:\/\/\\+?[\\w\\.\\-]+','i'))
+    }
   }
 
   let result = xss(text, {

--- a/app/assets/javascripts/pretty-text/sanitizer.js.es6
+++ b/app/assets/javascripts/pretty-text/sanitizer.js.es6
@@ -74,7 +74,7 @@ export function sanitize(text, whiteLister) {
   if (allowedHrefSchemes && allowedHrefSchemes.length > 0) {
     extraHrefMatchers = [new RegExp('^(' + allowedHrefSchemes.join('|') + '):\/\/[\\w\\.\\-]+','i')];
     if (allowedHrefSchemes.includes('tel')) {
-      extraHrefMatchers.push(new RegExp('^tel:\/\/\\+?[\\w\\.\\-]+','i'))
+      extraHrefMatchers.push(new RegExp('^tel:\/\/\\+?[\\w\\.\\-]+','i'));
     }
   }
 

--- a/app/assets/javascripts/pretty-text/sanitizer.js.es6
+++ b/app/assets/javascripts/pretty-text/sanitizer.js.es6
@@ -72,7 +72,7 @@ export function sanitize(text, whiteLister) {
   let extraHrefMatchers = null;
 
   if (allowedHrefSchemes && allowedHrefSchemes.length > 0) {
-    extraHrefMatchers = [new RegExp('^(' + allowedHrefSchemes.join('|') + '):\/\/[\\w\\.\\-]+','i')];
+    extraHrefMatchers = [new RegExp('^(' + allowedHrefSchemes.join('|') + '):\/\/\\+?[\\w\\.\\-]+','i')];
   }
 
   let result = xss(text, {

--- a/spec/components/pretty_text_spec.rb
+++ b/spec/components/pretty_text_spec.rb
@@ -811,6 +811,17 @@ describe PrettyText do
     expect(cooked).to eq(n expected)
   end
 
+  it 'allows only tel URL scheme to start with a plus character' do
+    SiteSetting.allowed_href_schemes = "tel|steam"
+    cooked = cook("[Tel URL Scheme](tel://+452530579785)")
+    expected = '<p><a href="tel://+452530579785" rel="nofollow noopener">Tel URL Scheme</a></p>'
+    expect(cooked).to eq(n expected)
+
+    cooked2 = cook("[Steam URL Scheme](steam://+store/452530)")
+    expected2 = '<p><a>Steam URL Scheme</a></p>'
+    expect(cooked2).to eq(n expected2)
+  end
+
   it "produces hashtag links" do
     category = Fabricate(:category, name: 'testing')
     category2 = Fabricate(:category, name: 'known')


### PR DESCRIPTION
It makes it possible to add links for international phone numbers that start with a plus sign
meta: https://meta.discourse.org/t/tel-links-not-working-with-plus-sign/76483