### PR TITLE
FEATURE: Adds option to search only in titles

### DIFF
--- a/app/assets/javascripts/discourse/components/search-advanced-options.js.es6
+++ b/app/assets/javascripts/discourse/components/search-advanced-options.js.es6
@@ -444,19 +444,7 @@ export default Em.Component.extend({
 
   @observes('searchedTerms.special.in.likes')
   updateSearchTermForSpecialInLikes() {
-    const match = this.filterBlocks(REGEXP_SPECIAL_IN_LIKES_MATCH);
-    const inFilter = this.get('searchedTerms.special.in.likes');
-    let searchTerm = this.get('searchTerm') || '';
-
-    if (inFilter) {
-      if (match.length === 0) {
-        searchTerm += ` in:likes`;
-        this.set('searchTerm', searchTerm.trim());
-      }
-    } else if (match.length !== 0) {
-      searchTerm = searchTerm.replace(match, '');
-      this.set('searchTerm', searchTerm.trim());
-    }
+    this.updateSearchTermForSpecialIn('likes', REGEXP_SPECIAL_IN_LIKES_MATCH);
   },
 
   @observes('searchedTerms.special.in.title')
@@ -466,36 +454,12 @@ export default Em.Component.extend({
 
   @observes('searchedTerms.special.in.private')
   updateSearchTermForSpecialInPrivate() {
-    const match = this.filterBlocks(REGEXP_SPECIAL_IN_PRIVATE_MATCH);
-    const inFilter = this.get('searchedTerms.special.in.private');
-    let searchTerm = this.get('searchTerm') || '';
-
-    if (inFilter) {
-      if (match.length === 0) {
-        searchTerm += ` in:private`;
-        this.set('searchTerm', searchTerm.trim());
-      }
-    } else if (match.length !== 0) {
-      searchTerm = searchTerm.replace(match, '');
-      this.set('searchTerm', searchTerm.trim());
-    }
+    this.updateSearchTermForSpecialIn('private', REGEXP_SPECIAL_IN_PRIVATE_MATCH);
   },
 
   @observes('searchedTerms.special.in.seen')
   updateSearchTermForSpecialInSeen() {
-    const match = this.filterBlocks(REGEXP_SPECIAL_IN_SEEN_MATCH);
-    const inFilter = this.get('searchedTerms.special.in.seen');
-    let searchTerm = this.get('searchTerm') || '';
-
-    if (inFilter) {
-      if (match.length === 0) {
-        searchTerm += ` in:seen`;
-        this.set('searchTerm', searchTerm.trim());
-      }
-    } else if (match.length !== 0) {
-      searchTerm = searchTerm.replace(match, '');
-      this.set('searchTerm', searchTerm.trim());
-    }
+    this.updateSearchTermForSpecialIn('seen', REGEXP_SPECIAL_IN_SEEN_MATCH);
   },
 
   @observes('searchedTerms.status')

--- a/app/assets/javascripts/discourse/components/search-advanced-options.js.es6
+++ b/app/assets/javascripts/discourse/components/search-advanced-options.js.es6
@@ -18,6 +18,7 @@ const REGEXP_TAGS_REPLACE          = /(^(tags?:|#(?=[a-z0-9\-]+::tag))|::tag\s?$
 
 const REGEXP_IN_MATCH                 = /^(in|with):(posted|watching|tracking|bookmarks|first|pinned|unpinned|wiki|unseen|image)/ig;
 const REGEXP_SPECIAL_IN_LIKES_MATCH   = /^in:likes/ig;
+const REGEXP_SPECIAL_IN_TITLE_MATCH   = /^in:title/ig;
 const REGEXP_SPECIAL_IN_PRIVATE_MATCH = /^in:private/ig;
 const REGEXP_SPECIAL_IN_SEEN_MATCH    = /^in:seen/ig;
 
@@ -113,6 +114,7 @@ export default Em.Component.extend({
     this.setSearchedTermSpecialInValue('searchedTerms.special.in.likes', REGEXP_SPECIAL_IN_LIKES_MATCH);
     this.setSearchedTermSpecialInValue('searchedTerms.special.in.private', REGEXP_SPECIAL_IN_PRIVATE_MATCH);
     this.setSearchedTermSpecialInValue('searchedTerms.special.in.seen', REGEXP_SPECIAL_IN_SEEN_MATCH);
+    this.setSearchedTermSpecialInValue('searchedTerms.special.in.title', REGEXP_SPECIAL_IN_TITLE_MATCH);
     this.setSearchedTermValue('searchedTerms.status', REGEXP_STATUS_PREFIX);
     this.setSearchedTermValueForPostTime();
     this.setSearchedTermValue('searchedTerms.min_post_count', REGEXP_MIN_POST_COUNT_PREFIX);
@@ -424,6 +426,22 @@ export default Em.Component.extend({
     }
   },
 
+  updateSearchTermForSpecialIn(key, regexp){
+    const match = this.filterBlocks(regexp);
+    const inFilter = this.get(`searchedTerms.special.in.${key}`);
+    let searchTerm = this.get('searchTerm') || '';
+
+    if (inFilter) {
+      if (match.length === 0) {
+        searchTerm += ` in:${key}`;
+        this.set('searchTerm', searchTerm.trim());
+      }
+    } else if (match.length !== 0) {
+      searchTerm = searchTerm.replace(match, '');
+      this.set('searchTerm', searchTerm.trim());
+    }
+  },
+
   @observes('searchedTerms.special.in.likes')
   updateSearchTermForSpecialInLikes() {
     const match = this.filterBlocks(REGEXP_SPECIAL_IN_LIKES_MATCH);
@@ -439,6 +457,11 @@ export default Em.Component.extend({
       searchTerm = searchTerm.replace(match, '');
       this.set('searchTerm', searchTerm.trim());
     }
+  },
+
+  @observes('searchedTerms.special.in.title')
+  updateSearchTermForSpecialInTitle() {
+    this.updateSearchTermForSpecialIn('title', REGEXP_SPECIAL_IN_TITLE_MATCH);
   },
 
   @observes('searchedTerms.special.in.private')

--- a/app/assets/javascripts/discourse/templates/components/search-advanced-options.hbs
+++ b/app/assets/javascripts/discourse/templates/components/search-advanced-options.hbs
@@ -1,4 +1,7 @@
 <div class="container">
+  <div class="control-group">
+    <label>{{input type="checkbox" class="in-title" checked=searchedTerms.special.in.title}} {{i18n "search.advanced.filters.title"}}</label>
+  </div>
   <div class="control-group pull-left">
     <label class="control-label" for="search-posted-by">{{i18n "search.advanced.posted_by.label"}}</label>
     <div class="controls">

--- a/app/assets/javascripts/discourse/templates/components/search-advanced-options.hbs
+++ b/app/assets/javascripts/discourse/templates/components/search-advanced-options.hbs
@@ -1,7 +1,4 @@
 <div class="container">
-  <div class="control-group">
-    <label>{{input type="checkbox" class="in-title" checked=searchedTerms.special.in.title}} {{i18n "search.advanced.filters.title"}}</label>
-  </div>
   <div class="control-group pull-left">
     <label class="control-label" for="search-posted-by">{{i18n "search.advanced.posted_by.label"}}</label>
     <div class="controls">
@@ -88,4 +85,8 @@
       {{input type="number" value=searchedTerms.min_post_count class="input-small" id='search-min-post-count'}}
     </div>
   </div>
+  <div class="control-group">
+    <label>{{input type="checkbox" class="in-title" checked=searchedTerms.special.in.title}} {{i18n "search.advanced.filters.title"}}</label>
+  </div>
+
 </div>

--- a/app/services/search_indexer.rb
+++ b/app/services/search_indexer.rb
@@ -104,15 +104,16 @@ class SearchIndexer
   end
 
   def self.update_topics_index(topic_id, title, cooked)
-    indexable_title = title.dup
-    indexable_cooked = scrub_html_for_search(cooked)[0...Topic::MAX_SIMILAR_BODY_LENGTH]
-    update_index('topic', topic_id, indexable_title, indexable_cooked)
+    title_entry = title.dup
+    cooked_entry = scrub_html_for_search(cooked)[0...Topic::MAX_SIMILAR_BODY_LENGTH]
+    update_index('topic', topic_id, title_entry, cooked_entry)
   end
 
   def self.update_posts_index(post_id, cooked, title, category)
-    search_data = scrub_html_for_search(cooked) << " " << title.dup.force_encoding('UTF-8')
-    search_data << " " << category if category
-    update_index('post', post_id, search_data)
+    title_entry = title.dup.force_encoding('UTF-8')
+    cooked_entry = scrub_html_for_search(cooked)
+    entries = [title_entry, cooked_entry, (category if category)].compact
+    update_index('post', post_id, *entries)
   end
 
   def self.update_users_index(user_id, username, name)

--- a/app/services/search_indexer.rb
+++ b/app/services/search_indexer.rb
@@ -83,7 +83,7 @@ class SearchIndexer
   end
 
   def self.update_index_param_name_for(index)
-    "indexable_fragment_#{index}".to_sym
+    "indexable_entry_#{index}".to_sym
   end
 
   def self.build_ts_vector(stemmer, indexable_entries)

--- a/app/services/search_indexer.rb
+++ b/app/services/search_indexer.rb
@@ -24,7 +24,7 @@ class SearchIndexer
     foreign_key = "#{table}_id"
     stemmer = stemmer_from_table(table)
 
-    indexable_entries = raw_entries.collect{|raw_entry| prepare_entry_for_indexing(raw_entry)}
+    indexable_entries = raw_entries.collect { |raw_entry| prepare_entry_for_indexing(raw_entry) }
 
     # Would be nice to use AR here but not sure how to execut Postgres functions
     # when inserting data like this.

--- a/app/services/search_indexer.rb
+++ b/app/services/search_indexer.rb
@@ -14,6 +14,9 @@ class SearchIndexer
     HtmlScrubber.scrub(html)
   end
 
+  # @param raw_entries The list of entries to index. When more than one entry is provided, they will get a weight. The
+  # first one will have a priority A; he second one a priority B, etc.
+  # When only 1 entry is provided, no weights will be used.
   def self.update_index(table, id, *raw_entries)
     raw_data = Search.prepare_data(raw_entries.join(' '), :index)
 

--- a/app/services/search_indexer.rb
+++ b/app/services/search_indexer.rb
@@ -88,7 +88,7 @@ class SearchIndexer
   end
 
   def self.build_ts_vector(stemmer, indexable_entries)
-    raise ArgumentError, "The max number of entries to index is 4 to match the number of weights supported by PostgreSQL (A, B, C, D)" unless indexable_entries.length.between?(1, 4)
+    raise ArgumentError, "The max number of entries to index is 4 since the weights supported by PostgreSQL are A, B, C, D" unless indexable_entries.length.between?(1, 4)
 
     ts_vectors = indexable_entries.collect.with_index do |_, index|
       "TO_TSVECTOR('#{stemmer}', :#{update_index_param_name_for(index)})"

--- a/app/services/search_indexer.rb
+++ b/app/services/search_indexer.rb
@@ -15,8 +15,7 @@ class SearchIndexer
   end
 
   # @param raw_entries The list of entries to index. When more than one entry is provided, they will get a weight. The
-  # first one will have a priority A; he second one a priority B, etc.
-  # When only 1 entry is provided, no weights will be used.
+  # first one will have a priority A; he second one a priority B, etc. When only 1 entry is provided, no weights will be used.
   def self.update_index(table, id, *raw_entries)
     raw_data = Search.prepare_data(raw_entries.join(' '), :index)
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1423,6 +1423,7 @@ en:
           private: In my messages
           bookmarks: I bookmarked
           first: are the very first post
+          title: Only search in titles
           pinned: are pinned
           unpinned: are not pinned
           seen: I read

--- a/lib/search.rb
+++ b/lib/search.rb
@@ -773,7 +773,7 @@ class Search
   end
 
   def self.default_ts_config
-      "'#{Search.ts_config}'"
+    "'#{Search.ts_config}'"
     end
 
     def default_ts_config

--- a/lib/search.rb
+++ b/lib/search.rb
@@ -746,9 +746,8 @@ class Search
           posts = posts.order("posts.like_count DESC")
         end
       else
-        posts = posts.order("TS_RANK_CD(TO_TSVECTOR(#{default_ts_config}, topics.title), #{ts_query}) DESC")
-
-        data_ranking = "TS_RANK_CD(post_search_data.search_data, #{ts_query})"
+        # Making title's weight 10 times body's for bumping titles
+        data_ranking = "TS_RANK_CD('{0.025, 0.05, 0.1, 1.0}', post_search_data.search_data, #{ts_query})"
         if opts[:aggregate_search]
           posts = posts.order("SUM(#{data_ranking}) DESC")
         else

--- a/lib/search.rb
+++ b/lib/search.rb
@@ -1,7 +1,7 @@
 require_dependency 'search/grouped_search_results'
 
 class Search
-  INDEX_VERSION = 1.freeze
+  INDEX_VERSION = 2
 
   def self.per_facet
     5

--- a/lib/search.rb
+++ b/lib/search.rb
@@ -746,7 +746,7 @@ class Search
           posts = posts.order("posts.like_count DESC")
         end
       else
-        # Making title's weight 10 times body's for bumping titles
+        # Making title's weight much bigger than body's for really bumping titles in results
         data_ranking = "TS_RANK_CD('{0.025, 0.05, 0.1, 1.0}', post_search_data.search_data, #{ts_query})"
         if opts[:aggregate_search]
           posts = posts.order("SUM(#{data_ranking}) DESC")

--- a/lib/search.rb
+++ b/lib/search.rb
@@ -535,6 +535,9 @@ class Search
         elsif word == 'in:private'
           @search_pms = true
           nil
+        elsif word == 'in:title'
+          @search_only_in_title = true
+          nil
         elsif word =~ /^private_messages:(.+)$/
           @search_pms = true
           nil
@@ -681,7 +684,7 @@ class Search
           posts = posts.joins('JOIN users u ON u.id = posts.user_id')
           posts = posts.where("posts.raw  || ' ' || u.username || ' ' || COALESCE(u.name, '') ilike ?", "%#{term_without_quote}%")
         else
-          posts = posts.where("post_search_data.search_data @@ #{ts_query}")
+          posts = posts.where("post_search_data.search_data @@ #{ts_query(weight_filter: weight_filter_for_post_query)}")
           exact_terms = @term.scan(/"([^"]+)"/).flatten
           exact_terms.each do |exact|
             posts = posts.where("posts.raw ilike ?", "%#{exact}%")
@@ -764,7 +767,12 @@ class Search
       posts.limit(limit)
     end
 
-    def self.default_ts_config
+  def weight_filter_for_post_query
+    # 'A' because title is indexed first. @see SearchIndexer#update_posts_index
+    @search_only_in_title ? 'A' : nil
+  end
+
+  def self.default_ts_config
       "'#{Search.ts_config}'"
     end
 
@@ -772,8 +780,7 @@ class Search
       self.class.default_ts_config
     end
 
-    def self.ts_query(term, ts_config = nil, joiner = "&")
-
+    def self.ts_query(term, ts_config = nil, joiner = "&", weight_filter: nil)
       data = Post.exec_sql("SELECT TO_TSVECTOR(:config, :term)",
                            config: 'simple',
                            term: term).values[0][0]
@@ -786,16 +793,15 @@ class Search
 
       query = ActiveRecord::Base.connection.quote(
         all_terms
-          .map { |t| "'#{PG::Connection.escape_string(t)}':*" }
+          .map { |t| "'#{PG::Connection.escape_string(t)}':*#{weight_filter}" }
           .join(" #{joiner} ")
       )
-
       "TO_TSQUERY(#{ts_config || default_ts_config}, #{query})"
     end
 
-    def ts_query(ts_config = nil)
+    def ts_query(ts_config = nil, weight_filter: nil)
       @ts_query_cache ||= {}
-      @ts_query_cache["#{ts_config || default_ts_config} #{@term}"] ||= Search.ts_query(@term, ts_config)
+      @ts_query_cache["#{ts_config || default_ts_config} #{@term} #{weight_filter}"] ||= Search.ts_query(@term, ts_config, weight_filter: weight_filter)
     end
 
     def wrap_rows(query)

--- a/spec/components/search_spec.rb
+++ b/spec/components/search_spec.rb
@@ -643,6 +643,15 @@ describe Search do
       expect(Search.execute("@#{_post.user.username}").posts.length).to eq(1)
     end
 
+    it 'supports in:title' do
+      topic = Fabricate(:topic, title: 'omg this is the title')
+      _post = Fabricate(:post, raw: 'this is the boring body much less exciting', topic: topic)
+
+      expect(Search.execute('exciting').posts.length).to eq(1)
+      expect(Search.execute('exciting in:title').posts.length).to eq(0)
+      expect(Search.execute('omg in:title').posts.length).to eq(1)
+    end
+
     it 'supports group' do
       topic = Fabricate(:topic, created_at: 3.months.ago)
       post = Fabricate(:post, raw: 'hi this is a test 123 123', topic: topic)

--- a/test/javascripts/acceptance/search-test.js.es6
+++ b/test/javascripts/acceptance/search-test.js.es6
@@ -109,6 +109,7 @@ QUnit.test("Right filters are shown to anonymous users", assert => {
     assert.notOk(exists('.search-advanced-options .in-likes'));
     assert.notOk(exists('.search-advanced-options .in-private'));
     assert.notOk(exists('.search-advanced-options .in-seen'));
+    assert.ok(exists('.search-advanced-options .in-title'));
   });
 });
 
@@ -137,5 +138,6 @@ QUnit.test("Right filters are shown to logged-in users", assert => {
     assert.ok(exists('.search-advanced-options .in-likes'));
     assert.ok(exists('.search-advanced-options .in-private'));
     assert.ok(exists('.search-advanced-options .in-seen'));
+    assert.ok(exists('.search-advanced-options .in-title'));
   });
 });


### PR DESCRIPTION
It adds a new search option `in:title` that will make it search only in titles.

It also adds a new checkbox at the top of the advanced search UI:

![screen recording 2018-01-27 at 02 01 pm](https://user-images.githubusercontent.com/129938/35472184-a3760ad4-036a-11e8-846b-d01b83759e04.gif)

See: 

- https://meta.discourse.org/t/add-in-title-modifier-to-advanced-search/38546?source_topic_id=77463
- https://meta.discourse.org/t/search-only-within-topic-titles/27600?source_topic_id=77463

## Overview of changes

It changes the way posts and topics are indexed to use [PostgreSQL full-text search weights](https://www.postgresql.org/docs/9.1/static/textsearch-controls.html). Then, it uses the weight associated with `title` to filter by title when searching posts.

Before, it was concatenating `title + body + category` and storing the indexed result. Now, it will store the concatenation of weighted indexed parts.

This is my first experience with PostgreSQL full-text search. I think it is the proper way to do it after checking the docs. The weights system is a little bit bizarre with 4 values (A, B, C, D) but seems to work pretty well.

As a side effect, results will take weight into consideration when sorting. So `title` > `body` > `category`. From [12.3.3. Ranking Search Results](https://www.postgresql.org/docs/9.1/static/textsearch-controls.html):

> If no weights are provided, then these defaults are used:
> {0.1, 0.2, 0.4, 1.0}

So for posts, weights will be 1.0 for title `title`, 0.4 for `body` and 0.2 for `category`. I think this is ok, but it's definitely something good to check before merging the PR. I tested this locally with a database with 19k posts from a forum I used to run, and the sorting made sense to me.

I will add some comments in the code to explain the changes next.

## Reindexing required

`in:title` will only work after re-indexing all the posts. Not sure how to do it automatically when shipping this:

- Should it trigger a reindexing job as part of the deploy? Is there support in place for such tasks? I guess we could launch a job from a migration if not
- Should it just increase [the `INDEX_VERSION` ](https://github.com/jorgemanrubia/discourse/blob/258051809096598a7390cfbdbac3191d4cf865e3/lib/search.rb#L4) and rely on the [indexing job](https://github.com/jorgemanrubia/discourse/blob/2c56f8df7c1eba7ff81bc66eaafd1e27a8c4ff19/app/jobs/scheduled/reindex_search.rb#L3) that runs every day?

In development I have used `rake search:reindex` for testing this.