### PR TITLE
FIX: dir-span when null is passed as argument

### DIFF
--- a/app/assets/javascripts/discourse/helpers/dir-span.js.es6
+++ b/app/assets/javascripts/discourse/helpers/dir-span.js.es6
@@ -2,11 +2,12 @@ import { registerUnbound } from "discourse-common/lib/helpers";
 import { isRTL } from 'discourse/lib/text-direction';
 
 function setDir(text) {
-  if (Discourse.SiteSettings.support_mixed_text_direction) {
-    let textDir = isRTL(text) ? 'rtl' : 'ltr';
-    return `<span dir="${textDir}">${text}</span>`;
+  let content = text ? text : "";
+  if (content && Discourse.SiteSettings.support_mixed_text_direction) {
+    let textDir = isRTL(content) ? 'rtl' : 'ltr';
+    return `<span dir="${textDir}">${content}</span>`;
   }
-  return text;
+  return content;
 }
 
 export default registerUnbound('dir-span', function(str) {


### PR DESCRIPTION
The `dir-span` helper function is returning the string 'null' for the category description when no description is present. This affects sites that have not enabled the mixed-text-direction support setting.

This fix returns an empty string instead.