### PR TITLE
Update default linkify TLDs to top 15

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -540,7 +540,7 @@ posting:
   markdown_linkify_tlds:
     client: true
     type: list
-    default: 'com|gov|net|org'
+    default: 'com|net|org|io|co|tv|ru|cn|us|uk|me|de|fr|fi|gov'
   enable_rich_text_paste:
     client: true
     default: false


### PR DESCRIPTION
Also kept gov, but moved it to the end because it was in the previous version.

Based on Cisco Umbrella stats. http://s3-us-west-1.amazonaws.com/umbrella-static/index.html

https://meta.discourse.org/t/restrict-domain-name-autolinking-so-m-sc-and-b-sc-are-not-auto-linked/75837/25?u=riking

