### PR TITLE
Switch ids in References-Header field of mails.

### DIFF
--- a/lib/email/sender.rb
+++ b/lib/email/sender.rb
@@ -109,7 +109,7 @@ module Email
         else
           @message.header['Message-ID']  = post_message_id
           @message.header['In-Reply-To'] = referenced_post_message_ids[0] || topic_message_id
-          @message.header['References']  = [referenced_post_message_ids, topic_message_id].flatten.compact.uniq
+          @message.header['References']  = [topic_message_id, referenced_post_message_ids].flatten.compact.uniq
         end
 
         # https://www.ietf.org/rfc/rfc2919.txt


### PR DESCRIPTION
This change allows email-clients to show threaded views of mails as
expected.  Apparently most algorithms expect the message ids of mails
in the Reference-header-field to be sorted such that they build a
traversal through the thread, so the oldest (original) message being
first, then its child, grandchild and so on until it arrives at the
message id that the "new" mail (that is to be sent) is the reply to.

MSGA [1]
+- Re: MSGA [1-1]
|  +- Re: Re: MSGA [1-2-1]
|  +- Re: Re: MSGA [1-2-2]
+- Re: MSGA [1-1]

If the stuff in brackets would be the message ID, the References-Header
field of a message that is a reply to [1-2-1] should look like:

References: 1, 1-1, 1-2-1

Discussion took place in:
https://meta.discourse.org/t/e-mail-threading-in-ml-mode-does-not-work-in-thunderbird

Main information taken from:
https://www.jwz.org/doc/threading.html