### PR TITLE
Fix: approve anonymous shadow users on creation 

### DIFF
--- a/app/services/anonymous_shadow_creator.rb
+++ b/app/services/anonymous_shadow_creator.rb
@@ -13,6 +13,7 @@ class AnonymousShadowCreator
     return unless user
     return unless SiteSetting.allow_anonymous_posting
     return if user.trust_level < SiteSetting.anonymous_posting_min_trust_level
+    return if SiteSetting.must_approve_users? && !user.approved?
 
     if (shadow_id = user.custom_fields["shadow_id"].to_i) > 0
       shadow = User.find_by(id: shadow_id)
@@ -40,6 +41,8 @@ class AnonymousShadowCreator
         active: true,
         trust_level: 1,
         manual_locked_trust_level: 1,
+        approved: true,
+        approved_at: 1.day.ago,
         created_at: 1.day.ago # bypass new user restrictions
       )
 

--- a/spec/services/anonymous_shadow_creator_spec.rb
+++ b/spec/services/anonymous_shadow_creator_spec.rb
@@ -16,6 +16,11 @@ describe AnonymousShadowCreator do
       expect(AnonymousShadowCreator.get(Fabricate.build(:user, trust_level: 0))).to eq(nil)
     end
 
+    it "returns no shadow if must_approve_users is true and user is not approved" do
+      SiteSetting.must_approve_users = true
+      expect(AnonymousShadowCreator.get(Fabricate.build(:user, approved: false))).to eq(nil)
+    end
+
     it "returns a new shadow once time expires" do
       SiteSetting.anonymous_account_duration_minutes = 1
 


### PR DESCRIPTION
This is a fix for: https://meta.discourse.org/t/hide-anonymous-users-from-users-pending-review/28670