### PR TITLE
PERF: a faster way to count tags used per category

### DIFF
--- a/app/jobs/onceoff/init_category_tag_stats.rb
+++ b/app/jobs/onceoff/init_category_tag_stats.rb
@@ -1,0 +1,15 @@
+module Jobs
+  class InitCategoryTagStats < Jobs::Onceoff
+    def execute_onceoff(args)
+      CategoryTagStat.exec_sql <<~SQL
+    INSERT INTO category_tag_stats (category_id, tag_id, topic_count)
+         SELECT topics.category_id, tags.id, COUNT(topics.id)
+           FROM tags
+     INNER JOIN topic_tags ON tags.id = topic_tags.tag_id
+     INNER JOIN topics ON topics.id = topic_tags.topic_id
+            AND topics.deleted_at IS NULL
+       GROUP BY tags.id, topics.category_id
+      SQL
+    end
+  end
+end

--- a/app/jobs/scheduled/ensure_db_consistency.rb
+++ b/app/jobs/scheduled/ensure_db_consistency.rb
@@ -16,6 +16,7 @@ module Jobs
       CategoryUser.ensure_consistency!
       UserOption.ensure_consistency!
       Tag.ensure_consistency!
+      CategoryTagStat.ensure_consistency!
     end
   end
 end

--- a/app/models/category_tag_stat.rb
+++ b/app/models/category_tag_stat.rb
@@ -1,0 +1,61 @@
+class CategoryTagStat < ActiveRecord::Base
+  belongs_to :category
+  belongs_to :tag
+
+  def self.topic_moved(topic, from_category_id, to_category_id)
+    if from_category_id
+      self.where(tag_id: topic.tags.map(&:id), category_id: from_category_id)
+        .where('topic_count > 0')
+        .update_all('topic_count = topic_count - 1')
+    end
+
+    if to_category_id
+      sql = <<~SQL
+        UPDATE #{self.table_name}
+           SET topic_count = topic_count + 1
+         WHERE tag_id in (:tag_ids)
+           AND category_id = :category_id
+     RETURNING tag_id
+      SQL
+
+      tag_ids = topic.tags.map(&:id)
+      updated_tag_ids = self.exec_sql(sql, tag_ids: tag_ids, category_id: to_category_id).map { |row| row['tag_id'] }
+
+      (tag_ids - updated_tag_ids).each do |tag_id|
+        CategoryTagStat.create!(tag_id: tag_id, category_id: to_category_id, topic_count: 1)
+      end
+    end
+  end
+
+  def self.topic_deleted(topic)
+    topic_moved(topic, topic.category_id, nil)
+  end
+
+  def self.topic_recovered(topic)
+    topic_moved(topic, nil, topic.category_id)
+  end
+
+  def self.ensure_consistency!
+    self.update_topic_counts
+  end
+
+  # Recalculate all topic counts if they got out of sync
+  def self.update_topic_counts
+    CategoryTagStat.exec_sql <<~SQL
+      UPDATE category_tag_stats stats
+      SET topic_count = x.topic_count
+      FROM (
+        SELECT COUNT(topics.id) AS topic_count,
+               tags.id AS tag_id,
+               topics.category_id as category_id
+        FROM tags
+        INNER JOIN topic_tags ON tags.id = topic_tags.tag_id
+        INNER JOIN topics ON topics.id = topic_tags.topic_id AND topics.deleted_at IS NULL
+        GROUP BY tags.id, topics.category_id
+      ) x
+      WHERE stats.tag_id = x.tag_id
+        AND stats.category_id = x.category_id
+        AND x.topic_count <> stats.topic_count
+    SQL
+  end
+end

--- a/app/models/topic_tag.rb
+++ b/app/models/topic_tag.rb
@@ -1,6 +1,24 @@
 class TopicTag < ActiveRecord::Base
   belongs_to :topic
   belongs_to :tag, counter_cache: "topic_count"
+
+  after_create do
+    if topic.category_id
+      if stat = CategoryTagStat.where(tag_id: tag_id, category_id: topic.category_id).first
+        stat.increment!(:topic_count)
+      else
+        CategoryTagStat.create(tag_id: tag_id, category_id: topic.category_id, topic_count: 1)
+      end
+    end
+  end
+
+  after_destroy do
+    if topic.category_id
+      if stat = CategoryTagStat.where(tag_id: tag_id, category: topic.category_id).first
+        stat.topic_count == 1 ? stat.destroy : stat.decrement!(:topic_count)
+      end
+    end
+  end
 end
 
 # == Schema Information

--- a/db/migrate/20180207163946_create_category_tag_stats.rb
+++ b/db/migrate/20180207163946_create_category_tag_stats.rb
@@ -1,0 +1,12 @@
+class CreateCategoryTagStats < ActiveRecord::Migration[5.1]
+  def change
+    create_table :category_tag_stats do |t|
+      t.references :category, null: false
+      t.references :tag, null: false
+      t.integer :topic_count, default: 0, null: false
+    end
+
+    add_index :category_tag_stats, [:category_id, :topic_count]
+    add_index :category_tag_stats, [:category_id, :tag_id], unique: true
+  end
+end

--- a/spec/models/topic_list_spec.rb
+++ b/spec/models/topic_list_spec.rb
@@ -62,8 +62,8 @@ describe TopicList do
       let!(:other_tag) { Fabricate(:tag, topics: [topic], name: "use-anywhere") }
       let(:topic_list) { TopicList.new('latest', topic.user, [topic], category: category.id, category_id: category.id) }
 
-      it 'should only return tags allowed in the category' do
-        expect(topic_list.top_tags).to eq([tag.name])
+      it 'should return tags used in the category' do
+        expect(topic_list.top_tags).to eq([tag.name, other_tag.name].sort)
       end
 
       it "with no category, should return all tags" do


### PR DESCRIPTION
A fix for the problem described here:

https://meta.discourse.org/t/slow-tags-query-when-alphabetical-sort-is-disabled/78133

With the category_tag_stats table, we can quickly find most used tags for a given set of categories. The tricky part is keeping these counts correct.