### PR TITLE
FEATURE: allow group to be invited to topics

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -467,13 +467,9 @@ class TopicsController < ApplicationController
 
     topic = Topic.find_by(id: params[:topic_id])
 
-    if topic.private_message?
-      guardian.ensure_can_invite_group_to_private_message!(group, topic)
-      topic.invite_group(current_user, group)
-      render_json_dump BasicGroupSerializer.new(group, scope: guardian, root: 'group')
-    else
-      render json: failed_json, status: 422
-    end
+    guardian.ensure_can_invite_group_to_private_message_or_topic!(group, topic)
+    topic.invite_group(current_user, group)
+    render_json_dump BasicGroupSerializer.new(group, scope: guardian, root: 'group')
   end
 
   def invite

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -769,9 +769,10 @@ SQL
       group.users.where(
         "group_users.notification_level > ?", NotificationLevels.all[:muted]
       ).find_each do |u|
+        notification_type = private_message? ? :invited_to_private_message : :invited_to_topic
 
         u.notifications.create!(
-          notification_type: Notification.types[:invited_to_private_message],
+          notification_type: Notification.types[notification_type],
           topic_id: self.id,
           post_number: 1,
           data: {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1828,11 +1828,11 @@ en:
         action: 'Send Invite'
         help: 'invite others to this topic via email or notifications'
         to_forum: "We'll send a brief email allowing your friend to immediately join by clicking a link, no login required."
-        sso_enabled: "Enter the username of the person you'd like to invite to this topic."
-        to_topic_blank: "Enter the username or email address of the person you'd like to invite to this topic."
+        sso_enabled: "Enter the username of the person or the name of the group you'd like to invite to this topic."
+        to_topic_blank: "Enter the username or email address of the person, or the name of the group you'd like to invite to this topic."
         to_topic_email: "You've entered an email address. We'll email an invitation that allows your friend to immediately reply to this topic."
-        to_topic_username: "You've entered a username. We'll send a notification with a link inviting them to this topic."
-        to_username: "Enter the username of the person you'd like to invite. We'll send a notification with a link inviting them to this topic."
+        to_topic_username: "You've entered a username or a group name. We'll send a notification with a link inviting them to this topic."
+        to_username: "Enter the username of the person or the name of the group you'd like to invite. We'll send a notification with a link inviting them to this topic."
 
         email_placeholder: 'name@example.com'
         success_email: "We mailed out an invitation to <b>{{emailOrUsername}}</b>. We'll notify you when the invitation is redeemed. Check the invitations tab on your user page to keep track of your invites."

--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -286,7 +286,7 @@ class Guardian
     is_admin? || (authenticated? && @user.id == user_id)
   end
 
-  def can_invite_group_to_private_message?(group, topic)
+  def can_invite_group_to_private_message_or_topic?(group, topic)
     can_see_topic?(topic) &&
     can_send_private_message?(group)
   end

--- a/spec/controllers/topics_controller_spec.rb
+++ b/spec/controllers/topics_controller_spec.rb
@@ -1240,13 +1240,14 @@ describe TopicsController do
       admins.save!
     end
 
-    it "disallows inviting a group to a topic" do
+    it "allows inviting a group to a topic" do
       topic = Fabricate(:topic)
       post :invite_group, params: {
         topic_id: topic.id, group: 'admins'
       }, format: :json
 
-      expect(response.status).to eq(422)
+      expect(response.status).to eq(200)
+      expect(topic.allowed_groups.first.id).to eq(admins.id)
     end
 
     it "allows inviting a group to a PM" do

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -199,9 +199,9 @@ RSpec.describe TopicsController do
     describe 'as an admin user' do
       let!(:admin) { sign_in(Fabricate(:admin)) }
 
-      it "disallows inviting a group to a topic" do
+      it "allows inviting a group to a topic" do
         topic = Fabricate(:topic)
-        invite_group(topic, 422)
+        invite_group(topic, 200)
       end
 
       it "allows inviting a group to a PM" do


### PR DESCRIPTION
> CONTEXT & DISCUSSION: https://meta.discourse.org/t/rate-limiting-blocking-group-invitations-to-topics/73954/11?u=xrav3nz

Uploaded a quick video of the changes in the discussion topic linked above.

It'd be great if someone familiar with the invitation flow could take a look; there are also some copy changes to reflect the new behaviour.

Cheers 💪 