### PR TITLE
Added the required hooks for discourse-favorites plugin.

### DIFF
--- a/app/assets/javascripts/discourse/components/category-title-before.js.es6
+++ b/app/assets/javascripts/discourse/components/category-title-before.js.es6
@@ -1,0 +1,3 @@
+export default Ember.Component.extend({
+  tagName: ''
+});

--- a/app/assets/javascripts/discourse/templates/components/categories-boxes-with-topics.hbs
+++ b/app/assets/javascripts/discourse/templates/components/categories-boxes-with-topics.hbs
@@ -11,6 +11,7 @@
             {{#if c.read_restricted}}
               {{d-icon 'lock'}}
             {{/if}}
+            {{category-title-before category=c}}
             {{c.name}}
           </h3>
         </a>

--- a/app/assets/javascripts/discourse/templates/components/categories-only.hbs
+++ b/app/assets/javascripts/discourse/templates/components/categories-only.hbs
@@ -24,6 +24,7 @@
               <div class='subcategories'>
                 {{#each c.subcategories as |s|}}
                   <span class='subcategory'>
+                    {{category-title-before category=s}}
                     {{category-link s hideParent="true"}}
                     {{category-unread category=s}}
                   </span>

--- a/app/assets/javascripts/discourse/templates/components/category-title-before.hbs
+++ b/app/assets/javascripts/discourse/templates/components/category-title-before.hbs
@@ -1,0 +1,1 @@
+{{plugin-outlet name="category-title-before" noTags=true args=(hash category=category)}}

--- a/app/assets/javascripts/discourse/templates/components/category-title-link.hbs
+++ b/app/assets/javascripts/discourse/templates/components/category-title-link.hbs
@@ -1,3 +1,4 @@
+{{category-title-before category=category}}
 <a class="category-title-link" href={{category.url}}>
   {{#if category.read_restricted}}
     {{d-icon 'lock'}}


### PR DESCRIPTION
This PR adds `plugin-outlet`s before category titles so a star symbol can be added by the Favorites plugin.

Also, I had to make a small change to the top period extracting method because otherwise prefixes "top/" and "favorites/" were considered the same.