### PR TITLE
QR code display fix on dark backgrounds

### DIFF
--- a/app/assets/javascripts/discourse/templates/preferences-second-factor.hbs
+++ b/app/assets/javascripts/discourse/templates/preferences-second-factor.hbs
@@ -48,7 +48,11 @@
 
         <div class="control-group">
           <div class="controls">
-            {{{secondFactorImage}}}
+            <div class="qr-code-container">
+              <div class="qr-code">
+                {{{secondFactorImage}}}
+              </div>
+            </div>
 
             <p>
             {{#if showSecondFactorKey}}

--- a/app/assets/stylesheets/common/base/user.scss
+++ b/app/assets/stylesheets/common/base/user.scss
@@ -565,3 +565,10 @@
   }
 }
 
+.qr-code-container {
+    display: flex;
+    .qr-code {
+        padding: 5px 5px 0 5px;
+        background-color: white;
+    }
+}


### PR DESCRIPTION
https://meta.discourse.org/t/2fa-qr-code-not-visible-on-dark-theme/81152?u=awole20

This will put a white div with a padding of 5 around the QR code so that it's visible on a dark background.

Styles are currently inline - will gladly refactor all inline styles, but I'm not sure the best place for them in the scss.