### PR TITLE
Try extracting time period only when the filter is 'top'.

### DIFF
--- a/app/assets/javascripts/discourse/routes/build-topic-route.js.es6
+++ b/app/assets/javascripts/discourse/routes/build-topic-route.js.es6
@@ -91,7 +91,7 @@ export default function(filter, extras) {
       const topicOpts = {
         model,
         category: null,
-        period: model.get('for_period') || (filter.indexOf('/') > 0 ? filter.split('/')[1] : ''),
+        period: model.get('for_period') || (filter.indexOf('top/') >= 0 ? filter.split('/')[1] : ''),
         selected: [],
         expandGloballyPinned: true
       };


### PR DESCRIPTION
When developing [discourse-favorites](https://github.com/nbianca/discourse-favorites) I had to add a few new topic lists: favorites/latest, favorites/new, favorites/unread. When I added these, the filter would be misparsed and consider 'latest', 'new' or 'unread' as period which was wrong. The timeperiod should only be extracted when the filter is a 'top' filter (it contains 'top/').