### PR TITLE
FIX: reset_db

### DIFF
--- a/bin/docker/reset_db
+++ b/bin/docker/reset_db
@@ -1,8 +1,11 @@
 #!/bin/bash
-SCRIPTPATH=$(cd "$(dirname "$0")"; pwd -P)
+SCRIPTPATH=$(cd "$(dirname "$0")" >/dev/null; pwd -P)
 SOURCE_DIR=$(cd "$SCRIPTPATH" && cd ../.. && pwd -P)
 DATA_DIR=$SOURCE_DIR/data/postgres
 
 # Should this also run /etc/runit/1.d/ensure_database, or will that
-# happen automatically?
+# happen automatically? -- It will happen, but restarting the container is required
 docker run -it -v $DATA_DIR:/shared/postgres_data discourse/dev /bin/bash -c "rm -fr /shared/postgres_data/*"
+docker restart discourse_dev
+echo "Creating admin user..."
+"${SCRIPTPATH}/rake" admin:create


### PR DESCRIPTION
To get the database rebuilt requires a restart of the container. 

I also added a rake admin:create, since it's useful, and it's what `boot_dev --init `does.