### PR TITLE
FEATURE: Add external_id to User Serializer

### DIFF
--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -73,7 +73,9 @@ class UserSerializer < BasicUserSerializer
              :primary_group_flair_bg_color,
              :primary_group_flair_color,
              :staged,
-             :second_factor_enabled
+             :second_factor_enabled,
+             :external_id
+
 
   has_one :invited_by, embed: :object, serializer: BasicUserSerializer
   has_many :groups, embed: :object, serializer: BasicGroupSerializer
@@ -285,6 +287,14 @@ class UserSerializer < BasicUserSerializer
 
   def primary_group_flair_color
     object.try(:primary_group).try(:flair_color)
+  end
+
+  def external_id
+    object&.single_sign_on_record&.external_id
+  end
+
+  def include_external_id?
+    SiteSetting.enable_sso
   end
 
   ###

--- a/spec/serializers/user_serializer_spec.rb
+++ b/spec/serializers/user_serializer_spec.rb
@@ -196,4 +196,28 @@ describe UserSerializer do
       expect(json[:custom_fields]['secret_field']).to eq(nil)
     end
   end
+
+  context "when SSO is enabled" do
+    it "sets the external_id field" do
+      SiteSetting.sso_url = "http://example.com/discourse_sso"
+      SiteSetting.sso_secret = "abcdefghijklmnop"
+      SiteSetting.enable_sso = true
+      sso = DiscourseSingleSignOn.new
+      sso.username = "test"
+      sso.email = "test@example.com"
+      sso.external_id = "1"
+      user = sso.lookup_or_create_user
+      json = UserSerializer.new(user, scope: Guardian.new, root: false).as_json
+      expect(json[:external_id]).to eq("1")
+    end
+  end
+
+  context "when SSO is not enabled" do
+    let(:user) { Fabricate(:user) }
+    let(:json) { UserSerializer.new(user, scope: Guardian.new, root: false).as_json }
+    it "doesn't include the external_id field" do
+      SiteSetting.enable_sso = false
+      expect(json).not_to have_key(:external_id)
+    end
+  end
 end


### PR DESCRIPTION
Adds the `external_id` to UserSerializer if SSO is enabled.