### PR TITLE
FIX: mini-tag-chooser was not returning a correct list of tags

### DIFF
--- a/app/assets/javascripts/select-kit/components/mini-tag-chooser.js.es6
+++ b/app/assets/javascripts/select-kit/components/mini-tag-chooser.js.es6
@@ -184,7 +184,6 @@ export default ComboBox.extend(Tags, {
       categoryId: this.get("categoryId")
     };
     if (this.get("selectedTags")) data.selected_tags = this.get("selectedTags").slice(0, 100);
-    if (!this.get("everyTag")) data.filterForInput = true;
 
     this.searchTags("/tags/filter/search", data, this._transformJson);
   },


### PR DESCRIPTION
Should also fix an issue where it validates the creation of an existing tag.