### PR TITLE
FIX: Sidekiq job has wrong data when post owner changes within transaction

### DIFF
--- a/app/services/post_owner_changer.rb
+++ b/app/services/post_owner_changer.rb
@@ -11,19 +11,17 @@ class PostOwnerChanger
   end
 
   def change_owner!
-    ActiveRecord::Base.transaction do
-      @post_ids.each do |post_id|
-        post = Post.with_deleted.where(id: post_id, topic_id: @topic.id).first
-        next if post.blank?
-        @topic.user = @new_owner if post.is_first_post?
+    @post_ids.each do |post_id|
+      post = Post.with_deleted.where(id: post_id, topic_id: @topic.id).first
+      next if post.blank?
+      @topic.user = @new_owner if post.is_first_post?
 
-        if post.user == nil
-          @topic.recover! if post.is_first_post?
-        end
-        post.topic = @topic
-        post.set_owner(@new_owner, @acting_user, @skip_revision)
-        PostAction.remove_act(@new_owner, post, PostActionType.types[:like])
+      if post.user == nil
+        @topic.recover! if post.is_first_post?
       end
+      post.topic = @topic
+      post.set_owner(@new_owner, @acting_user, @skip_revision)
+      PostAction.remove_act(@new_owner, post, PostActionType.types[:like])
 
       @topic.update_statistics
 


### PR DESCRIPTION
`PostOwnerChanger.change_owner!` leads to a call to `PostRevisor.revise!` which contains the [following warning](https://github.com/discourse/discourse/blob/master/lib/post_revisor.rb#L174-L177).

```ruby
# WARNING: do not pull this into the transaction
# it can fire events in sidekiq before the post is done saving
# leading to corrupt state
post_process_post
```

So, for example, it grants badges to the wrong user when the post owner is changed within a transaction.