### PR TITLE
FIX: brewfile was out of date

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,11 +1,5 @@
 # Install development dependencies on Mac OS X using Homebrew (http://mxcl.github.com/homebrew)
 
-# add this repo to Homebrew's sources
-tap 'homebrew/dupes'
-
-# install the gcc compiler required for ruby
-brew 'apple-gcc42'
-
 # you probably already have git installed; ensure that it is the latest version
 brew 'git'
 


### PR DESCRIPTION
* 'homebrew/dupes' has been deprecated
* 'apple-gcc42' is not available on Sierra