### PR TITLE
single quote password in restore command

### DIFF
--- a/lib/backup_restore/restorer.rb
+++ b/lib/backup_restore/restorer.rb
@@ -282,7 +282,7 @@ module BackupRestore
     def psql_command
       db_conf = BackupRestore.database_configuration
 
-      password_argument = "PGPASSWORD=#{db_conf.password}" if db_conf.password.present?
+      password_argument = "PGPASSWORD='#{db_conf.password}'" if db_conf.password.present?
       host_argument     = "--host=#{db_conf.host}"         if db_conf.host.present?
       port_argument     = "--port=#{db_conf.port}"         if db_conf.port.present?
       username_argument = "--username=#{db_conf.username}" if db_conf.username.present?


### PR DESCRIPTION
Followup to #3283. Quotes passwords passed to shell for backup restore.

The previous PR only fixed the `backup` process, this fixes the `restore` to match.