### PR TITLE
FEATURE: filter personal messages by tags

### DIFF
--- a/app/assets/javascripts/discourse/controllers/user-private-messages.js.es6
+++ b/app/assets/javascripts/discourse/controllers/user-private-messages.js.es6
@@ -12,6 +12,8 @@ export default Ember.Controller.extend({
   currentPath: Em.computed.alias('application.currentPath'),
   selected: Em.computed.alias('userTopicsList.selected'),
   bulkSelectEnabled: Em.computed.alias('userTopicsList.bulkSelectEnabled'),
+  pmTags: Em.computed.alias('userTopicsList.model.topic_list.pm_tags'),
+  pmTaggingEnabled: Ember.computed.alias('site.can_tag_pms'),
 
   showNewPM: function(){
     return this.get('user.viewingSelf') &&

--- a/app/assets/javascripts/discourse/templates/user/messages.hbs
+++ b/app/assets/javascripts/discourse/templates/user/messages.hbs
@@ -65,7 +65,6 @@
     </button>
     {{/if}}
 
-
     {{#if bulkSelectEnabled}}
     <button {{action "selectAll"}} class="btn btn-select-all">
       {{i18n "user.messages.select_all"}}
@@ -74,6 +73,10 @@
 
     {{#if isGroup}}
       {{group-notifications-button value=group.group_user.notification_level group=group user=model}}
+    {{/if}}
+
+    {{#if pmTaggingEnabled}}
+      {{pm-tag-drop pmTags=pmTags}}
     {{/if}}
 </div>
 

--- a/app/assets/javascripts/select-kit/components/pm-tag-drop.js.es6
+++ b/app/assets/javascripts/select-kit/components/pm-tag-drop.js.es6
@@ -1,0 +1,19 @@
+import TagDropComponent from "select-kit/components/tag-drop";
+import DiscourseURL from "discourse/lib/url";
+import { default as computed } from "ember-addons/ember-computed-decorators";
+
+export default TagDropComponent.extend({
+  @computed
+  allTagsUrl() {
+    return `/u/${this.currentUser.username}/messages/`;
+  },
+
+  content: Ember.computed.alias("pmTags"),
+
+  actions: {
+    onSelect(tagId) {
+      const url = `/u/${this.currentUser.username}/messages/tag/${tagId}`;
+      DiscourseURL.routeTo(url);
+    }
+  }
+});

--- a/app/controllers/list_controller.rb
+++ b/app/controllers/list_controller.rb
@@ -134,6 +134,7 @@ class ListController < ApplicationController
   def self.generate_message_route(action)
     define_method("#{action}") do
       list_opts = build_topic_list_options
+      list_opts[:show_pm_tags] = true if guardian.can_tag_pms?
       target_user = fetch_user_from_params({ include_inactive: current_user.try(:staff?) }, [:user_stat, :user_option])
       guardian.ensure_can_see_private_messages!(target_user.id)
       list = generate_list_for(action.to_s, target_user, list_opts)

--- a/app/models/topic_list.rb
+++ b/app/models/topic_list.rb
@@ -35,6 +35,7 @@ class TopicList
                 :for_period,
                 :per_page,
                 :top_tags,
+                :pm_tags,
                 :current_user,
                 :tags
 
@@ -57,6 +58,15 @@ class TopicList
     opts = @category ? { category: @category } : {}
     opts[:guardian] = Guardian.new(@current_user)
     Tag.top_tags(opts)
+  end
+
+  def pm_tags
+    guardian = Guardian.new(@current_user)
+    if @opts[:show_pm_tags] && guardian.can_tag_pms?
+      Tag.pm_tags(guardian: guardian)
+    else
+      []
+    end
   end
 
   def preload_key

--- a/app/serializers/topic_list_serializer.rb
+++ b/app/serializers/topic_list_serializer.rb
@@ -8,6 +8,7 @@ class TopicListSerializer < ApplicationSerializer
              :for_period,
              :per_page,
              :top_tags,
+             :pm_tags,
              :tags
 
   has_many :topics, serializer: TopicListItemSerializer, embed: :objects
@@ -27,6 +28,10 @@ class TopicListSerializer < ApplicationSerializer
 
   def include_top_tags?
     Tag.include_tags?
+  end
+
+  def include_pm_tags?
+    scope.can_tag_pms?
   end
 
   def include_tags?

--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -32,7 +32,8 @@ class TopicQuery
          match_all_tags
          no_subcategories
          slow_platform
-         no_tags)
+         no_tags
+         show_pm_tags)
   end
 
   def self.valid_options

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -96,6 +96,28 @@ describe Tag do
     end
   end
 
+  describe '#pm_tags' do
+    before do
+      @private_tags = []
+      personal_message = Fabricate(:private_message_topic)
+      2.times { |i| @private_tags << Fabricate(:tag, topics: [personal_message]) }
+    end
+
+    it "returns nothing if user is not a staff" do
+      expect(described_class.pm_tags.sort).to be_empty
+    end
+
+    it "returns nothing if allow_staff_to_tag_pms setting is disabled" do
+      SiteSetting.allow_staff_to_tag_pms = false
+      expect(described_class.pm_tags(guardian: Guardian.new(Fabricate(:admin))).sort).to be_empty
+    end
+
+    it "returns all pm tags if user is a staff and pm tagging is enabled" do
+      SiteSetting.allow_staff_to_tag_pms = true
+      expect(described_class.pm_tags(guardian: Guardian.new(Fabricate(:admin)))).to match_array(@private_tags.map(&:name))
+    end
+  end
+
   context "topic counts" do
     it "should exclude private message topics" do
       topic

--- a/spec/models/topic_list_spec.rb
+++ b/spec/models/topic_list_spec.rb
@@ -78,4 +78,28 @@ describe TopicList do
       end
     end
   end
+
+  describe '#pm_tags' do
+    let(:admin) { Fabricate(:admin) }
+    let(:personal_message) { Fabricate(:private_message_topic) }
+
+    before do
+      SiteSetting.tagging_enabled = true
+      SiteSetting.allow_staff_to_tag_pms = true
+      @private_tags = []
+      2.times { |i| @private_tags << Fabricate(:tag, topics: [personal_message]) }
+    end
+
+    context 'when viewed as normal user' do
+      it 'returns no tags' do
+        expect(TopicList.new('liked', personal_message.user, [personal_message], show_pm_tags: true).pm_tags).to be_empty
+      end
+    end
+
+    context 'when viewed as admin' do
+      it 'returns pm tags' do
+        expect(TopicList.new('liked', admin, [personal_message], show_pm_tags: true).pm_tags).to match_array(@private_tags.map(&:name))
+      end
+    end
+  end
 end

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -105,6 +105,8 @@ RSpec.describe ListController do
         sign_in(user)
         get "/topics/private-messages-tag/#{user.username}/#{tag.name}.json"
         expect(response).to be_success
+        data = JSON.parse(response.body)
+        expect(data["topic_list"]["pm_tags"].length).to eq(1)
       end
     end
   end


### PR DESCRIPTION
This PR adds a tag dropdown on user messages page to filter messages by tags.

<img width="557" alt="screen shot 2018-03-07 at 16 40 37" src="https://user-images.githubusercontent.com/5732281/37089371-4f76c344-2226-11e8-844f-3f5c694aac81.png">
