### PR TITLE
FIX: move external_id from UserSerializer to CurrentUserSerializer

### DIFF
--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -40,7 +40,8 @@ class CurrentUserSerializer < BasicUserSerializer
              :primary_group_id,
              :primary_group_name,
              :can_create_topic,
-             :can_post_link
+             :can_post_link,
+             :external_id
 
   def can_post_link
     scope.can_post_link?
@@ -197,4 +198,11 @@ class CurrentUserSerializer < BasicUserSerializer
     object.primary_group&.name.present?
   end
 
+  def external_id
+    object&.single_sign_on_record&.external_id
+  end
+
+  def include_external_id?
+    SiteSetting.enable_sso
+  end
 end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -73,8 +73,7 @@ class UserSerializer < BasicUserSerializer
              :primary_group_flair_bg_color,
              :primary_group_flair_color,
              :staged,
-             :second_factor_enabled,
-             :external_id
+             :second_factor_enabled
 
   has_one :invited_by, embed: :object, serializer: BasicUserSerializer
   has_many :groups, embed: :object, serializer: BasicGroupSerializer
@@ -286,14 +285,6 @@ class UserSerializer < BasicUserSerializer
 
   def primary_group_flair_color
     object.try(:primary_group).try(:flair_color)
-  end
-
-  def external_id
-    object&.single_sign_on_record&.external_id
-  end
-
-  def include_external_id?
-    SiteSetting.enable_sso
   end
 
   ###

--- a/spec/serializers/current_user_serializer_spec.rb
+++ b/spec/serializers/current_user_serializer_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe CurrentUserSerializer do
+  context "when SSO is not enabled" do
+    let(:user) { Fabricate(:user) }
+    let :serializer do
+      CurrentUserSerializer.new(user, scope: Guardian.new, root: false)
+    end
+
+    it "should not include the external_id field" do
+      payload = serializer.as_json
+      expect(payload).not_to have_key(:external_id)
+    end
+  end
+
+  context "when SSO is enabled" do
+    let :user do
+      user = Fabricate(:user)
+      SingleSignOnRecord.create!(user_id: user.id, external_id: '12345', last_payload: '')
+      user
+    end
+
+    let :serializer do
+      CurrentUserSerializer.new(user, scope: Guardian.new, root: false)
+    end
+
+    it "should include the external_id" do
+      SiteSetting.sso_url = "http://example.com/discourse_sso"
+      SiteSetting.sso_secret = "12345678910"
+      SiteSetting.enable_sso = true
+      payload = serializer.as_json
+      expect(payload[:external_id]).to eq("12345")
+    end
+  end
+end

--- a/spec/serializers/user_serializer_spec.rb
+++ b/spec/serializers/user_serializer_spec.rb
@@ -196,28 +196,4 @@ describe UserSerializer do
       expect(json[:custom_fields]['secret_field']).to eq(nil)
     end
   end
-
-  context "when SSO is enabled" do
-    it "sets the external_id field" do
-      SiteSetting.sso_url = "http://example.com/discourse_sso"
-      SiteSetting.sso_secret = "abcdefghijklmnop"
-      SiteSetting.enable_sso = true
-      sso = DiscourseSingleSignOn.new
-      sso.username = "test"
-      sso.email = "test@example.com"
-      sso.external_id = "1"
-      user = sso.lookup_or_create_user
-      json = UserSerializer.new(user, scope: Guardian.new, root: false).as_json
-      expect(json[:external_id]).to eq("1")
-    end
-  end
-
-  context "when SSO is not enabled" do
-    let(:user) { Fabricate(:user) }
-    let(:json) { UserSerializer.new(user, scope: Guardian.new, root: false).as_json }
-    it "doesn't include the external_id field" do
-      SiteSetting.enable_sso = false
-      expect(json).not_to have_key(:external_id)
-    end
-  end
 end


### PR DESCRIPTION
Moves the external_id from `UserSerializer` to `CurrentUserSerializer`.