### PR TITLE
FEATURE - Prevent unnecessary refreshes with overscroll-behavior-y

### DIFF
--- a/app/assets/stylesheets/mobile/discourse.scss
+++ b/app/assets/stylesheets/mobile/discourse.scss
@@ -11,6 +11,7 @@ html {
 
 body {
   background-color: $secondary;
+  overscroll-behavior-y: contain;
 }
 
 textarea {


### PR DESCRIPTION
There's a issue while navigating through a post having many replies. We have pull the page down to load previous replies and it sometimes refreshes the page unfortunately. This problem can be solved using a single line of CSS, which is now becoming popular in the PWA world. I have added `overscroll-behavior-y: contain;` to the mobile/discourse.scss and solved it.

This has no adverse effects because most want this behaviour and can have an alternative, if they actually want to refresh.