### PR TITLE
Prevent robots from indexing uploads

### DIFF
--- a/app/views/robots_txt/index.erb
+++ b/app/views/robots_txt/index.erb
@@ -27,5 +27,6 @@ Disallow: /*?api_key*
 Disallow: /*?*api_key*
 Disallow: /groups
 Disallow: /groups/
+Disallow: /uploads/
 
 <%= server_plugin_outlet "robots_txt_index" %>


### PR DESCRIPTION
Although most user uploads are probably harmless, it's possible someone
has (either maliciously or not) uploaded sensitive information. Prevent
robots from indexing the uploads route.