### PR TITLE
Remove assumption that social login is enabled

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1178,7 +1178,7 @@ en:
       accept_title: "Invitation"
       welcome_to: "Welcome to %{site_name}!"
       invited_by: "You were invited by:"
-      social_login_available: "You'll also be able to sign in with any social login using that email."
+      social_login_available: "If you are using this email address in a social login service enabled in this site, you will be able to sign in with it as well."
       your_email: "Your account email address is <b>%{email}</b>."
       accept_invite: "Accept Invitation"
       success: "Your account has been created and you're now logged in."


### PR DESCRIPTION
In the text of an invite we shouldn't assume that the instance has social logins enabled. Got a report from a user confused that was not finding the social logins (we don't have any).