### PR TITLE
Reset widget decorators after each test

### DIFF
--- a/app/assets/javascripts/discourse/widgets/widget.js.es6
+++ b/app/assets/javascripts/discourse/widgets/widget.js.es6
@@ -32,6 +32,10 @@ export function applyDecorators(widget, type, attrs, state) {
   return [];
 }
 
+export function resetDecorators() {
+  Object.keys(_decorators).forEach(key => delete _decorators[key]);
+}
+
 const _customSettings = {};
 export function changeSetting(widgetName, settingName, newValue) {
   _customSettings[widgetName] = _customSettings[widgetName] || {};

--- a/test/javascripts/helpers/qunit-helpers.js.es6
+++ b/test/javascripts/helpers/qunit-helpers.js.es6
@@ -9,6 +9,7 @@ import { clearHTMLCache } from 'discourse/helpers/custom-html';
 import { flushMap } from 'discourse/models/store';
 import { clearRewrites } from 'discourse/lib/url';
 import { initSearchData } from 'discourse/widgets/search-menu';
+import { resetDecorators } from 'discourse/widgets/widget';
 
 export function currentUser() {
   return Discourse.User.create(sessionFixtures['/session/current.json'].current_user);
@@ -99,6 +100,7 @@ export function acceptance(name, options) {
       resetPluginApi();
       clearRewrites();
       initSearchData();
+      resetDecorators();
       Discourse.reset();
     }
   });


### PR DESCRIPTION
Resetting widget decorators after each test should prevent build errors like the one we are seeing on Travis right now with the Cakeday plugin.