### PR TITLE
FIX: prevents ruby warning with circular reference

### DIFF
--- a/app/models/topic_tracking_state.rb
+++ b/app/models/topic_tracking_state.rb
@@ -246,7 +246,7 @@ SQL
     sql
   end
 
-  def self.publish_private_message(topic, archive_user_id: archive_user_id,
+  def self.publish_private_message(topic, archive_user_id: nil,
                                           post: nil,
                                           group_archive: false)
 


### PR DESCRIPTION
@tgxworld can you look at this please ? I see no reason for `archive_user_id: archive_user_id` (and it's not valid) but maybe it was on purpose.