### PR TITLE
PERF: Queries on `user_emails.email` column not using the index.

### DIFF
--- a/db/migrate/20180316072756_alter_index_email_on_user_emails.rb
+++ b/db/migrate/20180316072756_alter_index_email_on_user_emails.rb
@@ -1,0 +1,11 @@
+class AlterIndexEmailOnUserEmails < ActiveRecord::Migration[5.1]
+  def up
+    execute("DROP INDEX index_user_emails_on_email")
+    execute "CREATE UNIQUE INDEX index_user_emails_on_email ON user_emails (email);"
+  end
+
+  def down
+    execute("DROP INDEX index_user_emails_on_email")
+    execute "CREATE UNIQUE INDEX index_user_emails_on_email ON user_emails (lower(email));"
+  end
+end


### PR DESCRIPTION
The index was migrated from the `users` table which created an index based on `(lower(email)::text)`. However, the index would only be used if the query on the `user_emails.email` column was `lower(user_emails.email)::text`. That means a query like `UserEmail.exists?(email: 'tgx@discourse.org')` would end up doing a seq scan instead of using the index. We'll have to end up doing something like `UserEmail.exists?("lower(user_emails.emai)::text = ?", "tgx@discourse.org")` if we do not want to sacrifice performance.

```
## Normal index
discourse_development=# EXPLAIN ANALYZE SELECT "user_emails".* FROM "user_emails" WHERE "user_emails"."email" = 'tgx@discourse.org';
                                                               QUERY PLAN                                                                
-----------------------------------------------------------------------------------------------------------------------------------------
 Index Scan using index_user_emails_on_email on user_emails  (cost=0.41..8.43 rows=1 width=47) (actual time=0.055..0.056 rows=1 loops=1)
   Index Cond: ((email)::text = 'tgx@discourse.org'::text)
 Planning time: 1.138 ms
 Execution time: 0.109 ms
(4 rows)

## With old index.

discourse_development=# EXPLAIN ANALYZE SELECT "user_emails".* FROM "user_emails" WHERE "user_emails"."email" = 'tgx@discourse.org';
                                               QUERY PLAN                                                
---------------------------------------------------------------------------------------------------------
 Seq Scan on user_emails  (cost=0.00..747.16 rows=1 width=47) (actual time=7.035..10.305 rows=1 loops=1)
   Filter: ((email)::text = 'tgx@discourse.org'::text)
   Rows Removed by Filter: 33692
 Planning time: 0.402 ms
 Execution time: 10.339 ms
(5 rows)
```

cc @SamSaffron  @nlalonde @xfalcox 