### PR TITLE
FIX: show only allowed tags on PM tags page and display correct count

### DIFF
--- a/app/assets/javascripts/discourse/controllers/user-private-messages-tags.js.es6
+++ b/app/assets/javascripts/discourse/controllers/user-private-messages-tags.js.es6
@@ -1,5 +1,6 @@
 export default Ember.Controller.extend({
   sortProperties: ['count:desc', 'id'],
+  tagsForUser: null,
 
   actions: {
     sortByCount() {

--- a/app/assets/javascripts/discourse/controllers/user-topics-list.js.es6
+++ b/app/assets/javascripts/discourse/controllers/user-topics-list.js.es6
@@ -9,6 +9,7 @@ export default Ember.Controller.extend({
   newIncoming: [],
   incomingCount: 0,
   channel: null,
+  tagsForUser: null,
 
   _showFooter: function() {
     this.set("application.showFooter", !this.get("model.canLoadMore"));

--- a/app/assets/javascripts/discourse/lib/render-tag.js.es6
+++ b/app/assets/javascripts/discourse/lib/render-tag.js.es6
@@ -5,8 +5,12 @@ export default function renderTag(tag, params) {
   const tagName = params.tagName || "a";
   let path;
   if (tagName === "a" && !params.noHref) {
-    const current_user = Discourse.User.current();
-    path = params.isPrivateMessage ? `/u/${current_user.username}/messages/tags/${tag}` : `/tags/${tag}`;
+    if (params.isPrivateMessage && Discourse.User.current()) {
+      const username = params.tagsForUser ? params.tagsForUser : Discourse.User.current().username;
+      path = `/u/${username}/messages/tags/${tag}`;
+    } else {
+      path = `/tags/${tag}`;
+    }
   }
   const href = path ? ` href='${Discourse.getURL(path)}' ` : "";
 

--- a/app/assets/javascripts/discourse/lib/render-tags.js.es6
+++ b/app/assets/javascripts/discourse/lib/render-tags.js.es6
@@ -20,10 +20,16 @@ export function addTagsHtmlCallback(callback, options) {
 export default function(topic, params){
   let tags = topic.tags;
   let buffer = "";
+  let tagsForUser = null;
   const isPrivateMessage = topic.get('isPrivateMessage');
 
-  if (params && params.mode === "list") {
-    tags = topic.get("visibleListTags");
+  if (params) {
+    if (params.mode === "list") {
+      tags = topic.get("visibleListTags");
+    }
+    if (params.tagsForUser) {
+      tagsForUser = params.tagsForUser;
+    }
   }
 
   let customHtml = null;
@@ -44,7 +50,7 @@ export default function(topic, params){
     buffer = "<div class='discourse-tags'>";
     if (tags) {
       for(let i=0; i<tags.length; i++){
-        buffer += renderTag(tags[i], { isPrivateMessage }) + ' ';
+        buffer += renderTag(tags[i], { isPrivateMessage, tagsForUser }) + ' ';
       }
     }
 

--- a/app/assets/javascripts/discourse/routes/build-private-messages-route.js.es6
+++ b/app/assets/javascripts/discourse/routes/build-private-messages-route.js.es6
@@ -32,6 +32,7 @@ export default (viewName, path, channel) => {
         hideCategory: true,
         showPosters: true,
         canBulkSelect: true,
+        tagsForUser: this.modelFor("user").get("username_lower"),
         selected: []
       });
 

--- a/app/assets/javascripts/discourse/routes/user-private-messages-tags.js.es6
+++ b/app/assets/javascripts/discourse/routes/user-private-messages-tags.js.es6
@@ -3,7 +3,8 @@ import { popupAjaxError } from 'discourse/lib/ajax-error';
 
 export default Discourse.Route.extend({
   model() {
-    return ajax('/tags/personal_messages').then(result => {
+    const username = this.modelFor("user").get("username_lower");
+    return ajax(`/tags/personal_messages/${username}`).then(result => {
       return result.tags.map(tag => Ember.Object.create(tag));
     }).catch(popupAjaxError);
   },
@@ -15,7 +16,8 @@ export default Discourse.Route.extend({
   setupController(controller, model) {
     this.controllerFor('user-private-messages-tags').setProperties({
       model,
-      sortProperties: this.siteSettings.tags_sort_alphabetically ? ['id'] : ['count:desc', 'id']
+      sortProperties: this.siteSettings.tags_sort_alphabetically ? ['id'] : ['count:desc', 'id'],
+      tagsForUser: this.modelFor("user").get("username_lower")
     });
     this.controllerFor('user-private-messages').setProperties({
       showToggleBulkSelect: false,

--- a/app/assets/javascripts/discourse/templates/components/basic-topic-list.hbs
+++ b/app/assets/javascripts/discourse/templates/components/basic-topic-list.hbs
@@ -17,7 +17,8 @@
                  bulkSelectEnabled=bulkSelectEnabled
                  canBulkSelect=canBulkSelect
                  selected=selected
-                 skipHeader=skipHeader}}
+                 skipHeader=skipHeader
+                 tagsForUser=tagsForUser}}
   {{else}}
     {{#unless loadingMore}}
     <div class='alert alert-info'>

--- a/app/assets/javascripts/discourse/templates/components/tag-list.hbs
+++ b/app/assets/javascripts/discourse/templates/components/tag-list.hbs
@@ -10,7 +10,7 @@
 {{#each sortedTags as |tag|}}
   <div class='tag-box'>
     {{#if tag.count}}
-      {{discourse-tag tag.id isPrivateMessage=isPrivateMessage}} <span class='tag-count'>x {{tag.count}}</span>
+      {{discourse-tag tag.id isPrivateMessage=isPrivateMessage tagsForUser=tagsForUser}} <span class='tag-count'>x {{tag.count}}</span>
     {{else}}
       {{discourse-tag tag.id}}
     {{/if}}

--- a/app/assets/javascripts/discourse/templates/components/topic-list.hbs
+++ b/app/assets/javascripts/discourse/templates/components/topic-list.hbs
@@ -40,7 +40,8 @@
                       expandGloballyPinned=expandGloballyPinned
                       expandAllPinned=expandAllPinned
                       lastVisitedTopic=lastVisitedTopic
-                      selected=selected}}
+                      selected=selected
+                      tagsForUser=tagsForUser}}
     {{raw "list/visited-line" lastVisitedTopic=lastVisitedTopic topic=topic}}
   {{/each}}
 </tbody>

--- a/app/assets/javascripts/discourse/templates/list/topic-list-item.raw.hbs
+++ b/app/assets/javascripts/discourse/templates/list/topic-list-item.raw.hbs
@@ -18,7 +18,7 @@
     {{/if}}
   </span>
 
-  {{discourse-tags topic mode="list"}}
+  {{discourse-tags topic mode="list" tagsForUser=tagsForUser}}
   {{#if expandPinned}}
     {{raw "list/topic-excerpt" topic=topic}}
   {{/if}}

--- a/app/assets/javascripts/discourse/templates/user-private-messages-tags.hbs
+++ b/app/assets/javascripts/discourse/templates/user-private-messages-tags.hbs
@@ -13,5 +13,5 @@
 <hr/>
 
 {{#if model}}
-  {{tag-list tags=model sortProperties=sortProperties titleKey="tagging.all_tags" isPrivateMessage=true}}
+  {{tag-list tags=model sortProperties=sortProperties titleKey="tagging.all_tags" isPrivateMessage=true tagsForUser=tagsForUser}}
 {{/if}}

--- a/app/assets/javascripts/discourse/templates/user-topics-list.hbs
+++ b/app/assets/javascripts/discourse/templates/user-topics-list.hbs
@@ -7,7 +7,8 @@
                      selected=selected
                      hasIncoming=hasIncoming
                      incomingCount=incomingCount
-                     showInserted="showInserted"}}
+                     showInserted="showInserted"
+                     tagsForUser=tagsForUser}}
 
   {{conditional-loading-spinner condition=model.loadingMore}}
 {{/load-more}}

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -193,7 +193,10 @@ class TagsController < ::ApplicationController
 
   def personal_messages
     guardian.ensure_can_tag_pms!
-    pm_tags = Tag.pm_tags(guardian: guardian)
+    allowed_user = fetch_user_from_params
+    raise Discourse::NotFound if allowed_user.blank?
+    raise Discourse::NotFound if current_user.id != allowed_user.id && !@guardian.is_admin?
+    pm_tags = Tag.pm_tags(guardian: guardian, allowed_user: allowed_user)
 
     render json: { tags: pm_tags }
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -739,7 +739,7 @@ Discourse::Application.routes.draw do
     get '/filter/list' => 'tags#index'
     get '/filter/search' => 'tags#search'
     get '/check' => 'tags#check_hashtag'
-    get '/personal_messages' => 'tags#personal_messages'
+    get '/personal_messages/:username' => 'tags#personal_messages'
     constraints(tag_id: /[^\/]+?/, format: /json|rss/) do
       get '/:tag_id.rss' => 'tags#tag_feed'
       get '/:tag_id' => 'tags#show', as: 'tag_show'


### PR DESCRIPTION
FIX: tags page should link to user profile we are browsing