### PR TITLE
Don't allow spans to disrupt plugin nav pill styling

### DIFF
--- a/app/assets/stylesheets/common/components/navs.scss
+++ b/app/assets/stylesheets/common/components/navs.scss
@@ -17,7 +17,7 @@
 // Pill nav
 // --------------------------------------------------
 
-.nav-pills {
+@mixin navPill {
   @extend %nav;
   @extend .clearfix;
 
@@ -54,6 +54,11 @@
       }
     }
   }
+}
+
+.nav-pills {
+  @include navPill;
+  > span { @include navPill; }
 }
 
 // Stacked nav


### PR DESCRIPTION
Currently there's an issue with the nav pill plugin outlet, in that it has to support potentially multiple component injections and thus has to have a `<span>` wrapper around any content it injects. So we end up with markup like this:
```
<ul class="nav-pills">
  <li>Normal pill</li>
  <li>Normal pill</li>
  <li>Normal pill</li>
  <span>
    <li>Plugin pill</li>
  </span>
</ul>
```
Because the nav-pill css is so strict, it means that it's impossible to style these pills without duplicating the existing styles (which are fairly complicated in their own right) within the plugin (which is suuuper prone to breakage)
![screen shot 2018-03-20 at 2 55 14 pm](https://user-images.githubusercontent.com/750477/37631472-bca11b68-2c4e-11e8-9453-6f632e2ec76e.png)

This is a 'smallest of a few evils' kind of solution which wraps up the existing styles into a mixin, and applies that mixin to any nested <span> tags within the nav-pills ul.