### PR TITLE
FIX: Make sure a post has replies before accessing the reply_id

### DIFF
--- a/app/views/embed/comments.html.erb
+++ b/app/views/embed/comments.html.erb
@@ -27,7 +27,7 @@
         </h3>
         <%= get_html(post.cooked) %>
 
-        <%- if post.reply_count > 0 %>
+        <%- if post.reply_count > 0 && post.replies.exists? %>
           <%- if post.reply_count == 1 %>
             <%= link_to I18n.t('embed.replies', count: post.reply_count), post.full_url, 'data-link-to-post' => post.replies.first.id.to_s, :class => 'post-replies button' %>
           <% else %>


### PR DESCRIPTION
If the reply to a post is moved to a new topic, embedded comments for the post will break, with the error `undefiled property ID for nil class`. This is because moving a post doesn't reset the reply_count for the post's parent. This PR just checks that the post has replies. It doesn't deal with resetting the reply_count.