### PR TITLE
Adding space before URL click-counter for improved copy & paste-ability

### DIFF
--- a/app/assets/javascripts/discourse/widgets/post-cooked.js.es6
+++ b/app/assets/javascripts/discourse/widgets/post-cooked.js.es6
@@ -101,7 +101,7 @@ export default class PostCooked {
         // don't display badge counts on category badge & oneboxes (unless when explicitely stated)
         if (valid && isValidLink($link)) {
           const title = I18n.t("topic_map.clicks", {count: lc.clicks});
-          $link.append(`<span class='badge badge-notification clicks' title='${title}'>${number(lc.clicks)}</span>`);
+          $link.append(`<span class='badge badge-notification clicks' title='${title}'>${' ' + number(lc.clicks)}</span>`);
         }
       });
     });

--- a/app/assets/javascripts/discourse/widgets/post-cooked.js.es6
+++ b/app/assets/javascripts/discourse/widgets/post-cooked.js.es6
@@ -101,7 +101,7 @@ export default class PostCooked {
         // don't display badge counts on category badge & oneboxes (unless when explicitely stated)
         if (valid && isValidLink($link)) {
           const title = I18n.t("topic_map.clicks", {count: lc.clicks});
-          $link.append(`<span class='badge badge-notification clicks' title='${title}'>${' ' + number(lc.clicks)}</span>`);
+          $link.append(` <span class='badge badge-notification clicks' title='${title}'>${number(lc.clicks)}</span>`);
         }
       });
     });

--- a/app/assets/stylesheets/common/components/badges.scss
+++ b/app/assets/stylesheets/common/components/badges.scss
@@ -197,7 +197,6 @@
     top: -1px;
     color: $primary-medium;
     position: relative;
-    margin-left: 2px;
     border: none;
   }
 }


### PR DESCRIPTION
Adding a space to click counts in posts so when a user copies text they don't paste a broken URL

See discussion: https://meta.discourse.org/t/copying-a-link-includes-the-click-count/83531