### PR TITLE
FEATURE: add profile_background and card_background support for Discourse SSO

### DIFF
--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -1,5 +1,6 @@
 require_dependency 'rate_limiter'
 require_dependency 'single_sign_on'
+require_dependency 'url_helper'
 
 class SessionController < ApplicationController
   class LocalLoginNotAllowed < StandardError; end
@@ -53,6 +54,26 @@ class SessionController < ApplicationController
         sso.admin = current_user.admin?
         sso.moderator = current_user.moderator?
         sso.groups = current_user.groups.pluck(:name).join(",")
+
+        sso.avatar_url = Discourse.store.cdn_url UrlHelper.absolute(
+          "#{Discourse.store.absolute_base_url}/#{Discourse.store.get_path_for_upload(current_user.uploaded_avatar)}"
+        ) unless current_user.uploaded_avatar.nil?
+        sso.profile_background_url = UrlHelper.absolute upload_cdn_path(
+          current_user.user_profile.profile_background
+        ) if current_user.user_profile.profile_background.present?
+        sso.card_background_url = UrlHelper.absolute upload_cdn_path(
+          current_user.user_profile.card_background
+        ) if current_user.user_profile.card_background.present?
+
+        sso.avatar_url = Discourse.store.cdn_url UrlHelper.absolute(
+          "#{Discourse.store.absolute_base_url}/#{Discourse.store.get_path_for_upload(current_user.uploaded_avatar)}"
+        ) unless current_user.uploaded_avatar.nil?
+        sso.profile_background_url = UrlHelper.absolute upload_cdn_path(
+          current_user.user_profile.profile_background
+        ) if current_user.user_profile.profile_background.present?
+        sso.card_background_url = UrlHelper.absolute upload_cdn_path(
+          current_user.user_profile.card_background
+        ) if current_user.user_profile.card_background.present?
 
         if sso.return_sso_url.blank?
           render plain: "return_sso_url is blank, it must be provided", status: 400

--- a/app/jobs/regular/download_profile_background_from_url.rb
+++ b/app/jobs/regular/download_profile_background_from_url.rb
@@ -1,0 +1,28 @@
+module Jobs
+
+  class DownloadProfileBackgroundFromUrl < Jobs::Base
+    sidekiq_options retry: false
+
+    def execute(args)
+      url = args[:url]
+      user_id = args[:user_id]
+
+      raise Discourse::InvalidParameters.new(:url) if url.blank?
+      raise Discourse::InvalidParameters.new(:user_id) if user_id.blank?
+
+      return unless user = User.find_by(id: user_id)
+
+      begin
+        UserProfile.import_url_for_user(
+          url,
+          user,
+          is_card_background: args[:is_card_background],
+        )
+      rescue Discourse::InvalidParameters => e
+        raise e unless e.message == 'url'
+      end
+    end
+
+  end
+
+end

--- a/app/models/discourse_single_sign_on.rb
+++ b/app/models/discourse_single_sign_on.rb
@@ -190,13 +190,31 @@ class DiscourseSingleSignOn < SingleSignOn
             )
           end
 
+          if profile_background_url.present?
+            Jobs.enqueue(:download_profile_background_from_url,
+              url: profile_background_url,
+              user_id: user.id,
+              is_card_background: false
+            )
+          end
+
+          if card_background_url.present?
+            Jobs.enqueue(:download_profile_background_from_url,
+              url: card_background_url,
+              user_id: user.id,
+              is_card_background: true
+            )
+          end
+
           user.create_single_sign_on_record!(
             last_payload: unsigned_payload,
             external_id: external_id,
             external_username: username,
             external_email: email,
             external_name: name,
-            external_avatar_url: avatar_url
+            external_avatar_url: avatar_url,
+            external_profile_background_url: profile_background_url,
+            external_card_background_url: card_background_url
           )
         end
       end
@@ -233,10 +251,36 @@ class DiscourseSingleSignOn < SingleSignOn
       end
     end
 
+    profile_background_missing = user.user_profile.profile_background.blank? || Upload.get_from_url(user.user_profile.profile_background).blank?
+    if (profile_background_missing || SiteSetting.sso_overrides_profile_background) && profile_background_url.present?
+      profile_background_changed = sso_record.external_profile_background_url != profile_background_url
+      if profile_background_changed || profile_background_missing
+        Jobs.enqueue(:download_profile_background_from_url,
+            url: profile_background_url,
+            user_id: user.id,
+            is_card_background: false
+        )
+      end
+    end
+
+    card_background_missing = user.user_profile.card_background.blank? || Upload.get_from_url(user.user_profile.card_background).blank?
+    if (card_background_missing || SiteSetting.sso_overrides_profile_background) && card_background_url.present?
+      card_background_changed = sso_record.external_card_background_url != card_background_url
+      if card_background_changed || card_background_missing
+        Jobs.enqueue(:download_profile_background_from_url,
+            url: card_background_url,
+            user_id: user.id,
+            is_card_background: true
+        )
+      end
+    end
+
     # change external attributes for sso record
     sso_record.external_username = username
     sso_record.external_email = email
     sso_record.external_name = name
     sso_record.external_avatar_url = avatar_url
+    sso_record.external_profile_background_url = profile_background_url
+    sso_record.external_card_background_url = card_background_url
   end
 end

--- a/app/models/single_sign_on_record.rb
+++ b/app/models/single_sign_on_record.rb
@@ -18,6 +18,8 @@ end
 #  external_email      :string
 #  external_name       :string
 #  external_avatar_url :string(1000)
+#  external_profile_background_url :string(1000)
+#  external_card_background_url :string(1000)
 #
 # Indexes
 #

--- a/app/serializers/single_sign_on_record_serializer.rb
+++ b/app/serializers/single_sign_on_record_serializer.rb
@@ -3,5 +3,7 @@ class SingleSignOnRecordSerializer < ApplicationSerializer
              :last_payload, :created_at,
              :updated_at, :external_username,
              :external_email, :external_name,
-             :external_avatar_url
+             :external_avatar_url,
+             :external_profile_background_url,
+             :external_card_background_url
 end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1231,6 +1231,8 @@ en:
     sso_overrides_username: "Overrides local username with external site username from SSO payload on every login, and prevent local changes. (WARNING: discrepancies can occur due to differences in username length/requirements)"
     sso_overrides_name: "Overrides local full name with external site full name from SSO payload on every login, and prevent local changes."
     sso_overrides_avatar: "Overrides user avatar with external site avatar from SSO payload. If enabled, disabling allow_uploaded_avatars is highly recommended"
+    sso_overrides_profile_background: "Overrides user profile background with external site avatar from SSO payload."
+    sso_overrides_card_background: "Overrides user card background with external site avatar from SSO payload."
     sso_not_approved_url: "Redirect unapproved SSO accounts to this URL"
     sso_allows_all_return_paths: "Do not restrict the domain for return_paths provided by SSO (by default return path must be on current site)"
 

--- a/config/locales/server.zh_CN.yml
+++ b/config/locales/server.zh_CN.yml
@@ -961,6 +961,8 @@ zh_CN:
     sso_overrides_username: "每一次登录时，用 SSO 信息中的外部站点的用户名覆盖本地用户名，并且阻止本地的用户名修改。（警告：因格本地用户名的长度和其他要求，用户名可能会有所差异）"
     sso_overrides_name: "每一次登录时，用 SSO 信息中的外部站点的全名覆盖本地全名，并且阻止本地的全名修改。"
     sso_overrides_avatar: "用单点登录信息中的外部站点头像覆盖用户头像。如果启用，强烈建议禁用 allow_uploaded_avatars"
+    sso_overrides_profile_background: "用单点登录信息中的外部站点个人档背景图片覆盖用户头像。"
+    sso_overrides_card_background: "用单点登录信息中的外部站点用户卡背景图片覆盖用户头像。"
     sso_not_approved_url: "重定向未受许可的单点登录账号至这个 URL"
     sso_allows_all_return_paths: "不限制 SSO 提供的 return_paths 中的域名（默认情况下返回地址必须位于当前站点）"
     allow_new_registrations: "允许新用户注册。取消选择将阻止任何人创建一个新账户。"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -348,6 +348,8 @@ login:
   sso_overrides_avatar:
     default: false
     client: true
+  sso_overrides_profile_background: false
+  sso_overrides_card_background: false
   sso_not_approved_url: ''
   email_domains_blacklist:
     default: 'mailinator.com'

--- a/db/migrate/20180316092939_add_external_profile_and_card_background_url_to_single_sign_on_record.rb
+++ b/db/migrate/20180316092939_add_external_profile_and_card_background_url_to_single_sign_on_record.rb
@@ -1,0 +1,6 @@
+class AddExternalProfileAndCardBackgroundUrlToSingleSignOnRecord < ActiveRecord::Migration[5.1]
+  def change
+    add_column :single_sign_on_records, :external_profile_background_url, :string
+    add_column :single_sign_on_records, :external_card_background_url, :string
+  end
+end

--- a/lib/single_sign_on.rb
+++ b/lib/single_sign_on.rb
@@ -1,7 +1,7 @@
 class SingleSignOn
   ACCESSORS = [:nonce, :name, :username, :email, :avatar_url, :avatar_force_update, :require_activation,
                :bio, :external_id, :return_sso_url, :admin, :moderator, :suppress_welcome_message, :title,
-               :add_groups, :remove_groups, :groups]
+               :add_groups, :remove_groups, :groups, :profile_background_url, :card_background_url]
   FIXNUMS = []
   BOOLS = [:avatar_force_update, :admin, :moderator, :require_activation, :suppress_welcome_message]
   NONCE_EXPIRY_TIME = 10.minutes

--- a/spec/jobs/download_profile_background_from_url_spec.rb
+++ b/spec/jobs/download_profile_background_from_url_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe Jobs::DownloadProfileBackgroundFromUrl do
+  let(:user) { Fabricate(:user) }
+
+  describe 'when url is invalid' do
+    it 'should not raise any error' do
+      expect do
+        described_class.new.execute(
+          url: '/assets/something/nice.jpg',
+          user_id: user.id
+        )
+      end.to_not raise_error
+    end
+  end
+end

--- a/spec/models/user_profile_spec.rb
+++ b/spec/models/user_profile_spec.rb
@@ -202,4 +202,39 @@ describe UserProfile do
       end
     end
   end
+
+  context '.import_url_for_user' do
+    let(:user) { Fabricate(:user) }
+
+    before do
+      stub_request(:any, "thisfakesomething.something.com")
+        .to_return(body: "abc", status: 404, headers: { 'Content-Length' => 3 })
+    end
+
+    describe 'when profile_background_url returns an invalid status code' do
+      it 'should not do anything' do
+        url = "http://thisfakesomething.something.com/"
+
+        UserProfile.import_url_for_user(url, user, is_card_background: false)
+
+        user.reload
+
+        expect(user.user_profile.profile_background).to eq(nil)
+      end
+    end
+
+    describe 'when card_background_url returns an invalid status code' do
+      it 'should not do anything' do
+        url = "http://thisfakesomething.something.com/"
+
+        UserProfile.import_url_for_user(url, user, is_card_background: true)
+
+        user.reload
+
+        expect(user.user_profile.card_background).to eq(nil)
+      end
+    end
+
+  end
+
 end


### PR DESCRIPTION
Synchronize `UserProfile.profile_background` and `UserProfile.card_background` against a remote site with Discourse SSO.