### PR TITLE
20180323 Fix Mass Assignment Warning

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -668,9 +668,10 @@ class TopicsController < ApplicationController
       raise ActionController::ParameterMissing.new(:topic_ids)
     end
 
-    operation = params.require(:operation)
-    operation.permit!
-    operation = operation.to_h.symbolize_keys
+    operation = params
+      .require(:operation)
+      .permit(:type, :group, :category_id, :notification_level_id, :tags)
+      .to_h.symbolize_keys
 
     raise ActionController::ParameterMissing.new(:operation_type) if operation[:type].blank?
     operator = TopicsBulkAction.new(current_user, topic_ids, operation, group: operation[:group])


### PR DESCRIPTION
I'm not a regular discourse contributor, but I saw an increasing number of security warnings on Hakiri for discourse, so I decided to come help out a bit (maybe some low hanging fruit). Just a small thing.

This replaces a forceful `permit!` with an explicit list of permitted params, resolving a `Mass Assignment` (https://hakiri.io/github/discourse/discourse/master/5f19ad95074329bea3328a796f061de79db9c227/warnings?name=Mass+Assignment) warning.

I walked the codebase to see where this `operation` object was used, so I believe I captured all the possible attributes that are used (such as in `TopicsBulkAction`), but do let me know if I've overlooked something.

Also, a small cleanup on the assignment (better aligned, single assignment, more readable).