### PR TITLE
Add 'topicTags' attribute to structure that is passed to callbacks re…

### DIFF
--- a/app/assets/javascripts/discourse/lib/transform-post.js.es6
+++ b/app/assets/javascripts/discourse/lib/transform-post.js.es6
@@ -121,6 +121,7 @@ export default function transformPost(currentUser, site, post, prevPost, nextPos
   postAtts.userCustomFields = post.user_custom_fields;
   postAtts.topicUrl = topic.get('url');
   postAtts.isSaving = post.isSaving;
+  postAtts.topicTags = topic.tags;
 
   const showPMMap = topic.archetype === 'private_message' && post.post_number === 1;
   if (showPMMap) {


### PR DESCRIPTION
…gistered with the 'api.addPostTransformCallback(...)' function so they are available there.

Making these available allows you to do special formatting of posts based on tags applied to the topic without having to resort to hacks (e.g. checking for `.tag-<tagname>` styles in the page, or including the entire `topic` object through a `api.includePostAttributes('topic')` call).
