### PR TITLE
Improve protection against accidental drops and renames

### DIFF
--- a/lib/migration/base_dropper.rb
+++ b/lib/migration/base_dropper.rb
@@ -33,7 +33,12 @@ module Migration
             SELECT 1
             FROM schema_migration_details
             WHERE name = :after_migration AND
-                  created_at <= (current_timestamp AT TIME ZONE 'UTC' - INTERVAL :delay)
+                  (created_at <= (current_timestamp AT TIME ZONE 'UTC' - INTERVAL :delay) OR
+                   (SELECT created_at
+                    FROM schema_migration_details
+                    ORDER BY id ASC
+                    LIMIT 1) > (current_timestamp AT TIME ZONE 'UTC' - INTERVAL '10 minutes')
+                  )
         )
       SQL
     end

--- a/lib/migration/safe_migrate.rb
+++ b/lib/migration/safe_migrate.rb
@@ -84,26 +84,26 @@ class Migration::SafeMigrate
   end
 
   def self.protect!(sql)
-    if sql =~ /^\s*drop\s+table/i
+    if sql =~ /^\s*(?:drop\s+table|alter\s+table.*rename\s+to)\s+/i
       $stdout.puts("", <<~STR)
         WARNING
         -------------------------------------------------------------------------------------
-        An attempt was made to drop a table in a migration
+        An attempt was made to drop or rename a table in a migration
         SQL used was: '#{sql}'
-        Please use the deferred pattrn using Migration::TableDropper in db/seeds to drop
-        the table.
+        Please use the deferred pattern using Migration::TableDropper in db/seeds to drop
+        or rename the table.
 
         This protection is in place to protect us against dropping tables that are currently
         in use by live applications.
       STR
       raise Discourse::InvalidMigration, "Attempt was made to drop a table"
-    elsif sql =~ /^\s*alter\s+table.*(rename|drop)/i
+    elsif sql =~ /^\s*alter\s+table.*(?:rename|drop)\s+/i
       $stdout.puts("", <<~STR)
         WARNING
         -------------------------------------------------------------------------------------
         An attempt was made to drop or rename a column in a migration
         SQL used was: '#{sql}'
-        Please use the deferred pattrn using Migration::ColumnDropper in db/seeds to drop
+        Please use the deferred pattern using Migration::ColumnDropper in db/seeds to drop
         or rename columns.
 
         Note, to minimize disruption use self.ignored_columns = ["column name"] on your

--- a/lib/migration/table_dropper.rb
+++ b/lib/migration/table_dropper.rb
@@ -44,9 +44,10 @@ module Migration
         LIMIT 1
       SQL
 
-      builder.where(new_table_exists) if @new_name.present?
+      builder.where(table_exists(":new_name")) if @new_name.present?
 
       builder.where("table_schema = 'public'")
+        .where(table_exists(":old_name"))
         .where(previous_migration_done)
         .exec(old_name: @old_name,
               new_name: @new_name,
@@ -54,13 +55,13 @@ module Migration
               after_migration: @after_migration).to_a.length > 0
     end
 
-    def new_table_exists
+    def table_exists(table_name_placeholder)
       <<~SQL
         EXISTS(
             SELECT 1
             FROM INFORMATION_SCHEMA.TABLES
             WHERE table_schema = 'public' AND
-                  table_name = :new_name
+                  table_name = #{table_name_placeholder}
         )
       SQL
     end

--- a/spec/components/migration/column_dropper_spec.rb
+++ b/spec/components/migration/column_dropper_spec.rb
@@ -65,6 +65,19 @@ RSpec.describe Migration::ColumnDropper do
 
       expect(has_column?('topics', 'junk')).to eq(false)
       expect(dropped_proc_called).to eq(true)
+
+      dropped_proc_called = false
+
+      Migration::ColumnDropper.drop(
+        table: 'topics',
+        after_migration: migration_name,
+        columns: ['junk'],
+        delay: 10.minutes,
+        on_drop: ->() { dropped_proc_called = true }
+      )
+
+      # it should call "on_drop" only when there are columns to drop
+      expect(dropped_proc_called).to eq(false)
     end
 
     it "drops the columns immediately if the first migration was less than 10 minutes ago" do

--- a/spec/components/migration/safe_migrate_spec.rb
+++ b/spec/components/migration/safe_migrate_spec.rb
@@ -34,6 +34,7 @@ describe Migration::SafeMigrate do
 
     expect(output).to include("TableDropper")
 
+    expect { User.first }.not_to raise_error
     expect(User.first).not_to eq(nil)
   end
 
@@ -50,6 +51,7 @@ describe Migration::SafeMigrate do
 
     expect(output).to include("TableDropper")
 
+    expect { User.first }.not_to raise_error
     expect(User.first).not_to eq(nil)
   end
 
@@ -67,6 +69,7 @@ describe Migration::SafeMigrate do
     expect(output).to include("ColumnDropper")
 
     expect(User.first).not_to eq(nil)
+    expect { User.first.username }.not_to raise_error
   end
 
   it "bans all column renames" do
@@ -83,6 +86,7 @@ describe Migration::SafeMigrate do
     expect(output).to include("ColumnDropper")
 
     expect(User.first).not_to eq(nil)
+    expect { User.first.username }.not_to raise_error
   end
 
   it "supports being disabled" do

--- a/spec/components/migration/safe_migrate_spec.rb
+++ b/spec/components/migration/safe_migrate_spec.rb
@@ -37,6 +37,22 @@ describe Migration::SafeMigrate do
     expect(User.first).not_to eq(nil)
   end
 
+  it "bans all table renames" do
+    Migration::SafeMigrate.enable!
+
+    path = File.expand_path "#{Rails.root}/spec/fixtures/migrate/rename_table"
+
+    output = capture_stdout do
+      expect(lambda do
+        ActiveRecord::Migrator.up([path])
+      end).to raise_error(StandardError)
+    end
+
+    expect(output).to include("TableDropper")
+
+    expect(User.first).not_to eq(nil)
+  end
+
   it "bans all column removal" do
     Migration::SafeMigrate.enable!
 

--- a/spec/components/migration/table_dropper_spec.rb
+++ b/spec/components/migration/table_dropper_spec.rb
@@ -86,6 +86,19 @@ describe Migration::TableDropper do
 
         expect(table_exists?('table_with_old_name')).to eq(false)
         expect(dropped_proc_called).to eq(true)
+
+        dropped_proc_called = false
+
+        described_class.delayed_rename(
+          old_name: 'table_with_old_name',
+          new_name: 'table_with_new_name',
+          after_migration: migration_name,
+          delay: 10.minutes,
+          on_drop: ->() { dropped_proc_called = true }
+        )
+
+        # it should call "on_drop" only when there is a table to drop
+        expect(dropped_proc_called).to eq(false)
       end
     end
 
@@ -112,6 +125,18 @@ describe Migration::TableDropper do
 
         expect(table_exists?('table_with_old_name')).to eq(false)
         expect(dropped_proc_called).to eq(true)
+
+        dropped_proc_called = false
+
+        described_class.delayed_drop(
+          table_name: 'table_with_old_name',
+          after_migration: migration_name,
+          delay: 10.minutes,
+          on_drop: ->() { dropped_proc_called = true }
+        )
+
+        # it should call "on_drop" only when there is a table to drop
+        expect(dropped_proc_called).to eq(false)
       end
     end
   end

--- a/spec/fixtures/migrate/rename_table/20990309014014_rename_table.rb
+++ b/spec/fixtures/migrate/rename_table/20990309014014_rename_table.rb
@@ -1,0 +1,9 @@
+class RenameTable < ActiveRecord::Migration[5.1]
+  def up
+    rename_table :users, :persons
+  end
+
+  def down
+    raise "not tested"
+  end
+end


### PR DESCRIPTION
Most of the changes are improvements of and additions to the specs.

* Protects against table renames and show the correct error message.
* Improves the specs. Some of them were always green, no matter if the drops were actually prevented or not.
* Immediately run delayed migrations if the first migration was run < 10 minutes ago.
* Drop tables only if they actually exist. Dropping columns already had that check.