### PR TITLE
FIX: CDN_URL hostname should be in GlobalSetting.hostnames

### DIFF
--- a/app/models/global_setting.rb
+++ b/app/models/global_setting.rb
@@ -117,6 +117,8 @@ class GlobalSetting
     hostnames = [ hostname ]
     hostnames << backup_hostname if backup_hostname.present?
 
+    hostnames << URI.parse(cdn_url).host if cdn_url.present?
+
     hash["host_names"] = hostnames
     hash["database"] = db_name
 


### PR DESCRIPTION
This avoids the need to specify the CDN_URL hostname as a DISCOURSE_BACKUP_HOSTNAME in the container configuration.