### PR TITLE
Remove use of `rescue nil`.

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -390,7 +390,13 @@ class Admin::UsersController < Admin::AdminController
     ip = params[:ip]
 
     # should we cache results in redis?
-    location = Excon.get("https://ipinfo.io/#{ip}/json", read_timeout: 10, connect_timeout: 10).body rescue nil
+    begin
+      location = Excon.get(
+        "https://ipinfo.io/#{ip}/json",
+        read_timeout: 10, connect_timeout: 10
+      ).body
+    rescue Excon::Error
+    end
 
     render json: location
   end
@@ -424,7 +430,7 @@ class Admin::UsersController < Admin::AdminController
     }
 
     AdminUserIndexQuery.new(params).find_users(50).each do |user|
-      user_destroyer.destroy(user, options) rescue nil
+      user_destroyer.destroy(user, options)
     end
 
     render json: success_json

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -127,7 +127,7 @@ class UploadsController < ApplicationController
 
     upload.errors.empty? ? upload : { errors: upload.errors.values.flatten }
   ensure
-    tempfile&.close! rescue nil
+    tempfile&.close!
   end
 
 end

--- a/app/controllers/user_badges_controller.rb
+++ b/app/controllers/user_badges_controller.rb
@@ -58,7 +58,11 @@ class UserBadgesController < ApplicationController
     post_id = nil
 
     if params[:reason].present?
-      path = URI.parse(params[:reason]).path rescue nil
+      path = begin
+        URI.parse(params[:reason]).path
+      rescue URI::InvalidURIError
+      end
+
       route = Rails.application.routes.recognize_path(path) if path
       if route
         topic_id = route[:topic_id].to_i

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -48,7 +48,11 @@ class Users::OmniauthCallbacksController < ApplicationController
     end
 
     if origin.present?
-      parsed = URI.parse(origin) rescue nil
+      parsed = begin
+        URI.parse(origin)
+      rescue URI::InvalidURIError
+      end
+
       if parsed
         @origin = "#{parsed.path}?#{parsed.query}"
       end

--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -77,8 +77,8 @@ class WebhooksController < ActionController::Base
   def mandrill
     events = params["mandrill_events"]
     events.each do |event|
-      message_id = event["msg"]["metadata"]["message_id"] rescue nil
-      to_address = event["msg"]["email"] rescue nil
+      message_id = event.dig("msg", "metadata", "message_id")
+      to_address = event.dig("msg", "email")
 
       case event["event"]
       when "hard_bounce"
@@ -94,12 +94,12 @@ class WebhooksController < ActionController::Base
   def sparkpost
     events = params["_json"] || [params]
     events.each do |event|
-      message_event = event["msys"]["message_event"] rescue nil
+      message_event = event.dig("msys", "message_event")
       next unless message_event
 
-      message_id   = message_event["rcpt_meta"]["message_id"] rescue nil
-      to_address   = message_event["rcpt_to"]                 rescue nil
-      bounce_class = message_event["bounce_class"]            rescue nil
+      message_id   = message_event.dig("rcpt_meta", "message_id")
+      to_address   = message_event["rcpt_to"]
+      bounce_class = message_event["bounce_class"]
       next unless bounce_class
 
       bounce_class = bounce_class.to_i

--- a/app/jobs/regular/bulk_invite.rb
+++ b/app/jobs/regular/bulk_invite.rb
@@ -25,7 +25,7 @@ module Jobs
       notify_user
 
       # since emails have already been sent out, delete the uploaded csv file
-      FileUtils.rm_rf(csv_path) rescue nil
+      FileUtils.rm_rf(csv_path)
     end
 
     def read_csv_file(csv_path)

--- a/app/jobs/regular/emit_web_hook_event.rb
+++ b/app/jobs/regular/emit_web_hook_event.rb
@@ -39,7 +39,7 @@ module Jobs
     end
 
     def setup_topic(args)
-      topic_view = (TopicView.new(args[:topic_id], Discourse.system_user) rescue nil)
+      topic_view = TopicView.new(args[:topic_id], Discourse.system_user)
       return if topic_view.blank?
       args[:payload] = WebHookTopicViewSerializer.new(topic_view, scope: guardian, root: false).as_json
     end

--- a/app/jobs/regular/pull_hotlinked_images.rb
+++ b/app/jobs/regular/pull_hotlinked_images.rb
@@ -47,9 +47,9 @@ module Jobs
 
       downloaded_urls = {}
 
-      large_images = JSON.parse(post.custom_fields[Post::LARGE_IMAGES].presence || "[]") rescue []
-      broken_images = JSON.parse(post.custom_fields[Post::BROKEN_IMAGES].presence || "[]") rescue []
-      downloaded_images = JSON.parse(post.custom_fields[Post::DOWNLOADED_IMAGES].presence || "{}") rescue {}
+      large_images = JSON.parse(post.custom_fields[Post::LARGE_IMAGES].presence || "[]")
+      broken_images = JSON.parse(post.custom_fields[Post::BROKEN_IMAGES].presence || "[]")
+      downloaded_images = JSON.parse(post.custom_fields[Post::DOWNLOADED_IMAGES].presence || "{}")
 
       has_new_large_image  = false
       has_new_broken_image = false

--- a/app/models/embeddable_host.rb
+++ b/app/models/embeddable_host.rb
@@ -12,7 +12,10 @@ class EmbeddableHost < ActiveRecord::Base
   def self.record_for_url(uri)
 
     if uri.is_a?(String)
-      uri = URI(UrlHelper.escape_uri(uri)) rescue nil
+      uri = begin
+        URI(UrlHelper.escape_uri(uri))
+      rescue URI::InvalidURIError
+      end
     end
     return false unless uri.present?
 
@@ -40,7 +43,11 @@ class EmbeddableHost < ActiveRecord::Base
     # Work around IFRAME reload on WebKit where the referer will be set to the Forum URL
     return true if url&.starts_with?(Discourse.base_url)
 
-    uri = URI(UrlHelper.escape_uri(url)) rescue nil
+    uri = begin
+      URI(UrlHelper.escape_uri(url))
+    rescue URI::InvalidURIError
+    end
+
     uri.present? && record_for_url(uri).present?
   end
 

--- a/app/models/optimized_image.rb
+++ b/app/models/optimized_image.rb
@@ -86,7 +86,7 @@ class OptimizedImage < ActiveRecord::Base
 
       # make sure we remove the cached copy from external stores
       if Discourse.store.external?
-        external_copy.try(:close!) rescue nil
+        external_copy&.close!
       end
 
       thumbnail
@@ -293,15 +293,15 @@ class OptimizedImage < ActiveRecord::Base
           DbHelper.remap(previous_url, optimized_image.url)
           # remove the old file (when local)
           unless external
-            FileUtils.rm(path, force: true) rescue nil
+            FileUtils.rm(path, force: true)
           end
         rescue => e
           problems << { optimized_image: optimized_image, ex: e }
           # just ditch the optimized image if there was any errors
           optimized_image.destroy
         ensure
-          file.try(:unlink) rescue nil
-          file.try(:close) rescue nil
+          file&.unlink
+          file&.close
         end
       end
     end

--- a/app/models/permalink.rb
+++ b/app/models/permalink.rb
@@ -37,7 +37,7 @@ class Permalink < ActiveRecord::Base
       end
 
       if regex.length > 1
-        [Regexp.new(regex[1..-1]), sub[1..-1] || ""] rescue nil
+        [Regexp.new(regex[1..-1]), sub[1..-1] || ""]
       end
 
     end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -527,9 +527,10 @@ class Post < ActiveRecord::Base
     return if user_id == new_user.id
 
     edit_reason = I18n.with_locale(SiteSetting.default_locale) do
-      I18n.t('change_owner.post_revision_text',
-             old_user: (self.user.username_lower rescue nil) || I18n.t('change_owner.deleted_user'),
-             new_user: new_user.username_lower
+      I18n.t(
+        'change_owner.post_revision_text',
+        old_user: self.user.username_lower || I18n.t('change_owner.deleted_user'),
+        new_user: new_user.username_lower
       )
     end
 

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1021,11 +1021,14 @@ SQL
     TopicUser.change(user.id, id, cleared_pinned_at: nil)
   end
 
-  def update_pinned(status, global = false, pinned_until = nil)
-    pinned_until = Time.parse(pinned_until) rescue nil
+  def update_pinned(status, global = false, pinned_until = "")
+    pinned_until = begin
+      Time.parse(pinned_until)
+    rescue ArgumentError
+    end
 
     update_columns(
-      pinned_at: status ? Time.now : nil,
+      pinned_at: status ? Time.zon.now : nil,
       pinned_globally: global,
       pinned_until: pinned_until
     )

--- a/app/models/topic_link.rb
+++ b/app/models/topic_link.rb
@@ -115,7 +115,14 @@ SQL
 
       PrettyText
         .extract_links(post.cooked)
-        .map { |u| [u, URI.parse(u.url)] rescue nil }
+        .map do |u|
+          uri = begin
+            URI.parse(u.url)
+          rescue URI::InvalidURIError
+          end
+
+          [u, uri]
+        end
         .reject { |_, p| p.nil? || "mailto".freeze == p.scheme }
         .uniq { |_, p| p }
         .each do |link, parsed|

--- a/app/models/topic_link_click.rb
+++ b/app/models/topic_link_click.rb
@@ -16,7 +16,10 @@ class TopicLinkClick < ActiveRecord::Base
     url = args[:url][0...TopicLink.max_url_length]
     return nil if url.blank?
 
-    uri = URI.parse(url) rescue nil
+    uri = begin
+      URI.parse(url)
+    rescue URI::InvalidURIError
+    end
 
     urls = Set.new
     urls << url
@@ -43,7 +46,11 @@ class TopicLinkClick < ActiveRecord::Base
     # add a cdn link
     if uri
       if Discourse.asset_host.present?
-        cdn_uri = URI.parse(Discourse.asset_host) rescue nil
+        cdn_uri = begin
+          URI.parse(Discourse.asset_host)
+        rescue URI::InvalidURIError
+        end
+
         if cdn_uri && cdn_uri.hostname == uri.hostname && uri.path.starts_with?(cdn_uri.path)
           is_cdn_link = true
           urls << uri.path[cdn_uri.path.length..-1]
@@ -51,7 +58,11 @@ class TopicLinkClick < ActiveRecord::Base
       end
 
       if SiteSetting.Upload.s3_cdn_url.present?
-        cdn_uri = URI.parse(SiteSetting.Upload.s3_cdn_url) rescue nil
+        cdn_uri = begin
+          URI.parse(SiteSetting.Upload.s3_cdn_url)
+        rescue URI::InvalidURIError
+        end
+
         if cdn_uri && cdn_uri.hostname == uri.hostname && uri.path.starts_with?(cdn_uri.path)
           is_cdn_link = true
           path = uri.path[cdn_uri.path.length..-1]

--- a/app/models/user_avatar.rb
+++ b/app/models/user_avatar.rb
@@ -35,7 +35,7 @@ class UserAvatar < ActiveRecord::Base
           upload = UploadCreator.new(tempfile, 'gravatar.png', origin: gravatar_url, type: "avatar").create_for(user_id)
 
           if gravatar_upload_id != upload.id
-            gravatar_upload.try(:destroy!) rescue nil
+            gravatar_upload&.destroy!
             self.gravatar_upload = upload
             save!
           end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -188,7 +188,11 @@ class UserSerializer < BasicUserSerializer
   end
 
   def website_name
-    uri = URI(website.to_s) rescue nil
+    uri = begin
+      URI(website.to_s)
+    rescue URI::InvalidURIError
+    end
+
     return if uri.nil? || uri.host.nil?
     uri.host.sub(/^www\./, '') + uri.path
   end

--- a/app/services/handle_chunk_upload.rb
+++ b/app/services/handle_chunk_upload.rb
@@ -42,8 +42,8 @@ class HandleChunkUpload
     tmp_directory   = @params[:tmp_directory]
 
     # delete destination files
-    File.delete(upload_path) rescue nil
-    File.delete(tmp_upload_path) rescue nil
+    File.delete(upload_path)
+    File.delete(tmp_upload_path)
 
     # merge all the chunks
     File.open(tmp_upload_path, "a") do |file|
@@ -59,7 +59,7 @@ class HandleChunkUpload
     FileUtils.mv(tmp_upload_path, upload_path, force: true)
 
     # remove tmp directory
-    FileUtils.rm_rf(tmp_directory) rescue nil
+    FileUtils.rm_rf(tmp_directory)
   end
 
 end

--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -405,8 +405,7 @@ class PostAlerter
     )
 
     if created.id && !existing_notification && NOTIFIABLE_TYPES.include?(type) && !user.suspended?
-      # we may have an invalid post somehow, dont blow up
-      post_url = original_post.url rescue nil
+      post_url = original_post.url
       if post_url
         payload = {
          notification_type: type,

--- a/lib/backup_restore/backuper.rb
+++ b/lib/backup_restore/backuper.rb
@@ -316,8 +316,8 @@ module BackupRestore
 
     def log(message)
       timestamp = Time.now.strftime("%Y-%m-%d %H:%M:%S")
-      puts(message) rescue nil
-      publish_log(message, timestamp) rescue nil
+      puts(message)
+      publish_log(message, timestamp)
       save_log(message, timestamp)
     end
 

--- a/lib/backup_restore/restorer.rb
+++ b/lib/backup_restore/restorer.rb
@@ -500,8 +500,8 @@ module BackupRestore
 
     def log(message)
       timestamp = Time.now.strftime("%Y-%m-%d %H:%M:%S")
-      puts(message) rescue nil
-      publish_log(message, timestamp) rescue nil
+      puts(message)
+      publish_log(message, timestamp)
       save_log(message, timestamp)
     end
 

--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -128,7 +128,11 @@ module Discourse
     if Rails.env.development?
       plugin_hash = Digest::SHA1.hexdigest(all_plugins.map { |p| p.path }.sort.join('|'))
       hash_file = "#{Rails.root}/tmp/plugin-hash"
-      old_hash = File.read(hash_file) rescue nil
+
+      old_hash = begin
+        File.read(hash_file)
+      rescue Errno::ENOENT
+      end
 
       if old_hash && old_hash != plugin_hash
         puts "WARNING: It looks like your discourse plugins have recently changed."
@@ -236,7 +240,13 @@ module Discourse
   end
 
   def self.route_for(uri)
-    uri = URI(uri) rescue nil unless uri.is_a?(URI)
+    unless uri.is_a?(URI)
+      uri = begin
+        URI(uri)
+      rescue URI::InvalidURIError
+      end
+    end
+
     return unless uri
 
     path = uri.path || ""

--- a/lib/email/receiver.rb
+++ b/lib/email/receiver.rb
@@ -823,7 +823,7 @@ module Email
             end
           end
         ensure
-          tmp.try(:close!) rescue nil
+          tmp&.close!
         end
       end
 

--- a/lib/import_export/importer.rb
+++ b/lib/import_export/importer.rb
@@ -161,7 +161,7 @@ module ImportExport
     end
 
     def new_category_id(external_category_id)
-      CategoryCustomField.where(name: "import_id", value: "#{external_category_id}#{import_source}").first.category_id rescue nil
+      CategoryCustomField.where(name: "import_id", value: "#{external_category_id}#{import_source}").first.category_id
     end
 
     def import_source

--- a/lib/inline_oneboxer.rb
+++ b/lib/inline_oneboxer.rb
@@ -32,7 +32,7 @@ class InlineOneboxer
     if route = Discourse.route_for(url)
       if route[:controller] == "topics" &&
         route[:action] == "show" &&
-        topic = (Topic.where(id: route[:topic_id].to_i).first rescue nil)
+        topic = Topic.where(id: route[:topic_id].to_i).first
 
         return onebox_for(url, topic.title, opts) if Guardian.new.can_see?(topic)
       end
@@ -42,7 +42,10 @@ class InlineOneboxer
     domains = SiteSetting.inline_onebox_domains_whitelist&.split('|') unless always_allow
 
     if always_allow || domains
-      uri = URI(url) rescue nil
+      uri = begin
+        URI(url)
+      rescue URI::InvalidURIError
+      end
 
       if uri.present? &&
         uri.hostname.present? &&

--- a/lib/site_setting_extension.rb
+++ b/lib/site_setting_extension.rb
@@ -339,10 +339,15 @@ module SiteSettingExtension
   end
 
   def get_hostname(url)
-    unless (URI.parse(url).scheme rescue nil).nil?
-      url = "http://#{url}" if URI.parse(url).scheme.nil?
-      url = URI.parse(url).host
+    uri = begin
+      URI.parse(url)
+    rescue URI::InvalidURIError
     end
+
+    unless uri.scheme.nil?
+      url = uri.host
+    end
+
     url
   end
 

--- a/lib/socket_server.rb
+++ b/lib/socket_server.rb
@@ -16,7 +16,7 @@ class SocketServer
   end
 
   def stop
-    @server&.close rescue nil
+    @server&.close
     FileUtils.rm_f(@socket_path)
     @server = nil
     @blk = nil
@@ -72,7 +72,7 @@ class SocketServer
   rescue => e
     Rails.logger.warn("Failed to handle connection in stats socket #{e}:\n#{e.backtrace.join("\n")}")
   ensure
-    socket&.close rescue nil
+    socket&.close
   end
 
   def get_response(command)

--- a/lib/stylesheet/manager.rb
+++ b/lib/stylesheet/manager.rb
@@ -110,7 +110,11 @@ class Stylesheet::Manager
       if File.exists?(stylesheet_fullpath)
         unless StylesheetCache.where(target: qualified_target, digest: digest).exists?
           begin
-            source_map = File.read(source_map_fullpath) rescue nil
+            source_map = begin
+              File.read(source_map_fullpath)
+            rescue Errno::ENOENT
+            end
+
             StylesheetCache.add(qualified_target, digest, File.read(stylesheet_fullpath), source_map)
           rescue => e
             Rails.logger.warn "Completely unexpected error adding contents of '#{stylesheet_fullpath}' to cache #{e}"

--- a/lib/upload_creator.rb
+++ b/lib/upload_creator.rb
@@ -105,7 +105,7 @@ class UploadCreator
       @upload
     end
   ensure
-    @file.close! rescue nil
+    @file&.close!
   end
 
   def extract_image_info!
@@ -149,7 +149,7 @@ class UploadCreator
       @opts[:content_type] = "image/jpeg"
       extract_image_info!
     else
-      jpeg_tempfile.close! rescue nil
+      jpeg_tempfile&.close!
     end
   end
 

--- a/lib/validators/upload_url_validator.rb
+++ b/lib/validators/upload_url_validator.rb
@@ -1,7 +1,11 @@
 class UploadUrlValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     if value.present?
-      uri = URI.parse(value) rescue nil
+      uri =
+        begin
+          URI.parse(value)
+        rescue URI::InvalidURIError
+        end
 
       unless uri && Upload.exists?(url: value)
         record.errors[attribute] << (options[:message] || I18n.t('errors.messages.invalid'))

--- a/spec/components/final_destination_spec.rb
+++ b/spec/components/final_destination_spec.rb
@@ -22,8 +22,7 @@ describe FinalDestination do
         when 'force.get.com' then '22.102.29.40'
         when 'wikipedia.com' then '1.2.3.4'
         else
-          as_ip = IPAddr.new(host) rescue nil
-          raise "couldn't lookup #{host}" if as_ip.nil?
+          as_ip = IPAddr.new(host)
           host
         end
       end

--- a/spec/services/user_destroyer_spec.rb
+++ b/spec/services/user_destroyer_spec.rb
@@ -125,17 +125,10 @@ describe UserDestroyer do
           @user.stubs(:first_post_created_at).returns(Time.zone.now)
         end
 
-        it 'should not delete the user' do
-          expect { destroy rescue nil }.to_not change { User.count }
-        end
-
-        it 'should raise an error' do
-          expect { destroy }.to raise_error(UserDestroyer::PostsExistError)
-        end
-
-        it 'should not log the action' do
+        it 'should raise the right error' do
           StaffActionLogger.any_instance.expects(:log_user_deletion).never
-          destroy rescue nil
+          expect { destroy }.to raise_error(UserDestroyer::PostsExistError)
+          expect(user.reload.id).to be_present
         end
       end
 


### PR DESCRIPTION
* `rescue nil` is a really bad pattern to use in our code base.
  We should rescue errors that we expect the code to throw and
  not rescue everything because we're unsure of what errors the
  code would throw. This would reduce the amount of pain we face
  when debugging why something isn't working as expected. I've
  been bitten countless of times by errors being swallowed as a
  result during debugging sessions.