### PR TITLE
Update instructions to use correct ruby version

### DIFF
--- a/docs/DEVELOPMENT-OSX-NATIVE.md
+++ b/docs/DEVELOPMENT-OSX-NATIVE.md
@@ -4,7 +4,7 @@ These instructions assume you have read and understood the **[Discourse Advanced
 
 OS X has become a popular platform for developing Ruby on Rails applications; as such, if you run OS X, you might find it more congenial to work on **[Discourse](http://discourse.org)** in your native environment. These instructions should get you there.
 
-Obviously, if you **already** develop Ruby on OS X, a lot of this will be redundant, because you'll have already done it, or something like it. If that's the case, you may well be able to just install Ruby 2.0 using RVM and get started! Discourse has enough dependencies, however (note: not a criticism!) that there's a good chance you'll find **something** else in this document that's useful for getting your Discourse development started!
+Obviously, if you **already** develop Ruby on OS X, a lot of this will be redundant, because you'll have already done it, or something like it. If that's the case, you may well be able to just install Ruby 2.3 using RVM and get started! Discourse has enough dependencies, however (note: not a criticism!) that there's a good chance you'll find **something** else in this document that's useful for getting your Discourse development started!
 
 ## Quick Setup
 
@@ -79,8 +79,8 @@ If you do already have RVM installed, this should make sure everything is up to 
 Either way, you'll now want to install the 'turbo' version of Ruby 2.0.
 
     # Now, install Ruby
-    rvm install 2.0.0-turbo
-    rvm use 2.0.0-turbo --default # Careful with this if you're already developing Ruby
+    rvm install 2.3.4-turbo
+    rvm use 2.3.4 --default # Careful with this if you're already developing Ruby
 
 ## Git
 


### PR DESCRIPTION
Bundler will not finish installing gems under Ruby 2.0.0. The instructions should maybe use the minimum ruby version in the travis.yml file.