### PR TITLE
Feature: Add unseen-topic and new-posts classnames to topic list items

### DIFF
--- a/app/assets/javascripts/discourse/components/topic-list-item.js.es6
+++ b/app/assets/javascripts/discourse/components/topic-list-item.js.es6
@@ -63,8 +63,15 @@ export default Ember.Component.extend(bufferedRender({
       classes.push('has-excerpt');
     }
 
+    if (topic.get('unseen')) {
+      classes.push("unseen-topic");
+    }
 
-    ['liked', 'archived', 'bookmarked', 'pinned'].forEach(name => {
+    if (topic.get('displayNewPosts')) {
+      classes.push("new-posts");
+    }
+
+    ['liked', 'archived', 'bookmarked', 'pinned', 'closed'].forEach(name => {
       if (topic.get(name)) {
         classes.push(name);
       }


### PR DESCRIPTION
Adds classname descriptions for new and unread posts on topic-list-items.

Allows for new/unread topic-list-items to be targeted with css directly, making the post list items easier to theme.

Ran into this when experimenting with some interesting theming ideas that requires css selection for new/unread post list rows themselves and thought it might be useful for other themes as well.