### PR TITLE
Log to stdout when configured

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -21,6 +21,11 @@ Discourse::Application.configure do
   config.assets.digest = true
 
   config.log_level = :info
+  
+  # log to stdout when configured
+  if ENV['LOG_STDOUT']
+    config.logger = Logger.new(STDOUT)
+  end
 
   if GlobalSetting.smtp_address
     settings = {


### PR DESCRIPTION
First contribution here, thanks for your help!

The goal of the PR is to make rails log everything to stdout. This is desired in some environment and a good practice recommended by [12factorapp](https://12factor.net/) for instance.

I checked quickly the code, and there is another possibility, make it a lig provider, and put this logic in a separate initializer.

Please let me know, and I'll update the PR accordingly.