### PR TITLE
FEATURE: Use Message-ID for detecting email replies to group

### DIFF
--- a/app/models/incoming_email.rb
+++ b/app/models/incoming_email.rb
@@ -5,7 +5,24 @@ class IncomingEmail < ActiveRecord::Base
 
   scope :errored,  -> { where("NOT is_bounce AND error IS NOT NULL") }
 
-  scope :addressed_to, -> (email) { where('incoming_emails.to_addresses ILIKE :email OR incoming_emails.cc_addresses ILIKE :email', email: "%#{email}%") }
+  scope :addressed_to, -> (email) do
+    where(<<~SQL, email: "%#{email}%")
+      incoming_emails.to_addresses ILIKE :email OR
+      incoming_emails.cc_addresses ILIKE :email
+    SQL
+  end
+
+  scope :addressed_to_user, ->(user) do
+    where(<<~SQL, user_id: user.id)
+      EXISTS(
+          SELECT 1
+          FROM user_emails
+          WHERE user_emails.user_id = :user_id AND
+                (incoming_emails.to_addresses ILIKE '%' || user_emails.email || '%' OR
+                 incoming_emails.cc_addresses ILIKE '%' || user_emails.email || '%')
+      )
+    SQL
+  end
 end
 
 # == Schema Information

--- a/script/import_scripts/mbox/support/indexer.rb
+++ b/script/import_scripts/mbox/support/indexer.rb
@@ -197,11 +197,7 @@ module ImportScripts::Mbox
     end
 
     def extract_reply_message_ids(mail)
-      message_ids = [mail.in_reply_to, Email::Receiver.extract_references(mail.references)]
-      message_ids.flatten!
-      message_ids.select!(&:present?)
-      message_ids.uniq!
-      message_ids.first(20)
+      Email::Receiver.extract_reply_message_ids(mail, max_message_id_count: 20)
     end
 
     def extract_subject(receiver, list_name)


### PR DESCRIPTION
Ignores the site setting "find_related_post_with_key" and always tries to honor the `In-Reply-To` and `References` header for emails sent to a group.

The senders email address must be included in the `To` or `CC` header of a previous email sent to the group and the `Message-ID` of that email must be included in the current email's `In-Reply-To` or `References` header.