### PR TITLE
Add wizard_js to translations that can be overridden from a plugin

### DIFF
--- a/lib/js_locale_helper.rb
+++ b/lib/js_locale_helper.rb
@@ -47,7 +47,8 @@ module JsLocaleHelper
         translations = {
           locale_str => {
             'js' => {},
-            'admin_js' => {}
+            'admin_js' => {},
+            'wizard_js' => {}
           }
         }
       end
@@ -56,6 +57,7 @@ module JsLocaleHelper
       if translations[locale_str] && plugin_translations(locale_str)
         translations[locale_str]['js'].deep_merge!(plugin_translations(locale_str)['js']) if plugin_translations(locale_str)['js']
         translations[locale_str]['admin_js'].deep_merge!(plugin_translations(locale_str)['admin_js']) if plugin_translations(locale_str)['admin_js']
+        translations[locale_str]['wizard_js'].deep_merge!(plugin_translations(locale_str)['wizard_js']) if plugin_translations(locale_str)['wizard_js']
       end
 
       translations


### PR DESCRIPTION
Aside from making it possible to override ``wizard_js`` translations from a plugin, this change will also make the default locale fallback to English work for ``wizard_js`` translations added in a plugin.

See further: https://meta.discourse.org/t/custom-wizard-plugin/73345/78?u=angus