### PR TITLE
Differentiate one/other in I18n for select-kit’s hasReached(Max|Min)imum

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1251,8 +1251,12 @@ en:
       no_content: No matches found
       filter_placeholder: Search...
       create: "Create: '{{content}}'"
-      max_content_reached: "You can only select {{count}} item(s)."
-      min_content_not_reached: "Select at least {{count}} item(s)."
+      max_content_reached:
+        one: "You can only select {{count}} item."
+        other: "You can only select {{count}} item(s)."
+      min_content_not_reached:
+        one: "Select at least {{count}} item."
+        other: "Select at least {{count}} item(s)."
 
     emoji_picker:
       filter_placeholder: Search for emoji

--- a/test/javascripts/components/multi-select-test.js.es6
+++ b/test/javascripts/components/multi-select-test.js.es6
@@ -171,7 +171,7 @@ componentTest('with minimum', {
   test(assert) {
     this.get('subject').expand();
 
-    andThen(() => assert.equal(this.get('subject').validationMessage(), 'Select at least 1 item(s).'));
+    andThen(() => assert.equal(this.get('subject').validationMessage(), 'Select at least 1 item.'));
 
     this.get('subject').selectRowByValue('sam');
 

--- a/test/javascripts/components/single-select-test.js.es6
+++ b/test/javascripts/components/single-select-test.js.es6
@@ -512,7 +512,7 @@ componentTest('with minimum', {
   test(assert) {
     this.get('subject').expand();
 
-    andThen(() => assert.equal(this.get('subject').validationMessage(), 'Select at least 1 item(s).'));
+    andThen(() => assert.equal(this.get('subject').validationMessage(), 'Select at least 1 item.'));
 
     this.get('subject').selectRowByValue('sam');
 


### PR DESCRIPTION
The I18n keys `js.select_kit.min_content_not_reached` and
`js.select_kit.max_content_reached` did not differentiate between
one or more `item(s)`, which can be difficult to translate.

While it works in English: `You can only select {{count}} item(s).`
It doesn't work e.g. in German: `Du kannst nur {{count}} Eintrag/Einträge auswählen.`