### PR TITLE
Fix - service worker registrations

### DIFF
--- a/app/assets/javascripts/discourse/initializers/register-service-worker.js.es6
+++ b/app/assets/javascripts/discourse/initializers/register-service-worker.js.es6
@@ -2,27 +2,25 @@ export default {
   name: 'register-service-worker',
 
   initialize() {
-    window.addEventListener('load', () => {
-      const isSecured = (document.location.protocol === 'https:') ||
-        (location.hostname === "localhost");
+    const isSecured = (document.location.protocol === 'https:') ||
+          (location.hostname === "localhost");
 
-      const isSupported= isSecured && ('serviceWorker' in navigator);
+    const isSupported= isSecured && ('serviceWorker' in navigator);
 
-      if (isSupported) {
-        if (Discourse.ServiceWorkerURL) {
-          navigator.serviceWorker
-            .register(`${Discourse.BaseUri}/${Discourse.ServiceWorkerURL}`)
-            .catch(error => {
-              Ember.Logger.info(`Failed to register Service Worker: ${error}`);
-            });
-        } else {
-          navigator.serviceWorker.getRegistrations().then(registrations => {
-            for(let registration of registrations) {
-              registration.unregister();
-            };
+    if (isSupported) {
+      if (Discourse.ServiceWorkerURL) {
+        navigator.serviceWorker
+          .register(`${Discourse.BaseUri}/${Discourse.ServiceWorkerURL}`)
+          .catch(error => {
+            Ember.Logger.info(`Failed to register Service Worker: ${error}`);
           });
-        }
+      } else {
+        navigator.serviceWorker.getRegistrations().then(registrations => {
+          for(let registration of registrations) {
+            registration.unregister();
+          };
+        });
       }
-    });
+    }
   }
 };

--- a/app/views/common/_discourse_javascript.html.erb
+++ b/app/views/common/_discourse_javascript.html.erb
@@ -45,7 +45,7 @@
     Discourse.ThemeSettings = ps.get('themeSettings');
     Discourse.LetterAvatarVersion = '<%= LetterAvatar.version %>';
     Discourse.MarkdownItURL = '<%= asset_url('markdown-it-bundle.js') %>';
-    Discourse.ServiceWorkerURL = '<%= Rails.application.assets_manifest.assets['service-worker.js'] %>'
+    Discourse.ServiceWorkerURL = Discourse.Environment != "development" ? '<%= Rails.application.assets_manifest.assets['service-worker.js'] %>' : 'service-worker.js';
     I18n.defaultLocale = '<%= SiteSetting.default_locale %>';
     Discourse.start();
     Discourse.set('assetVersion','<%= Discourse.assets_digest %>');

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -734,6 +734,8 @@ Discourse::Application.routes.draw do
     # logs.
     get "/service-worker.js" => redirect(relative_url_root + service_worker_asset), format: :js
     get service_worker_asset => "static#service_worker_asset", format: :js
+  elsif Rails.env.development?
+    get "/service-worker.js" => "static#service_worker_asset", format: :js
   end
 
   get "cdn_asset/:site/*path" => "static#cdn_asset", format: false


### PR DESCRIPTION
* register service workers in a development env

* reliably register service worker from ember initialize fn: https://meta.discourse.org/t/android-chrome-not-registering-service-workers/84759