### PR TITLE
Improve docker performance with `delegated` mount flag

### DIFF
--- a/bin/docker/boot_dev
+++ b/bin/docker/boot_dev
@@ -38,7 +38,7 @@ echo "Using data in:   ${DATA_DIR}"
 
 mkdir -p "${DATA_DIR}"
 
-docker run -d -p 1080:1080 -p 3000:3000 -v "$DATA_DIR:/shared/postgres_data" -v "$SOURCE_DIR:/src" --hostname=discourse --name=discourse_dev --restart=always discourse/discourse_dev:release /sbin/boot
+docker run -d -p 1080:1080 -p 3000:3000 -v "$DATA_DIR:/shared/postgres_data:delegated" -v "$SOURCE_DIR:/src:delegated" --hostname=discourse --name=discourse_dev --restart=always discourse/discourse_dev:release /sbin/boot
 
 if [ "${initialize}" = "initialize" ]; then
     echo "Installing gems..."

--- a/bin/docker/shutdown_dev
+++ b/bin/docker/shutdown_dev
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker rm -f discourse_dev
+docker stop discourse_dev && docker rm discourse_dev


### PR DESCRIPTION
> BACKGROUND & CONTEXT: https://meta.discourse.org/t/running-discourse-on-docker-for-mac/49682/39?u=xrav3nz

### What's the `delegated` flag?

> - `consistent` (default): perfect consistency (host and container have an identical view of the mount at all times)
> - `cached`: the host’s view is authoritative (permit delays before updates on the host appear in the container)
> - `delegated`: the container’s view is authoritative (permit delays before updates on the container appear in the host)

I am still a bit torn between `delegated` and `cached`, let me know what you think! More information at https://docs.docker.com/docker-for-mac/osxfs-caching/#delegated.

### Benchmarks

  - default (`consistent`) i.e. `-v "$SOURCE_DIR:/src"`

    ``` text
    ❯ /usr/bin/time d/rails r 'puts'
    13.74 real         0.06 user         0.01 sys
    13.73 real         0.06 user         0.01 sys
    14.44 real         0.06 user         0.01 sys
    ```

  - `delegated` i.e. `-v "$SOURCE_DIR:/src:delegated"`

    ``` text
    ❯ /usr/bin/time d/rails r 'puts'
    4.77 real         0.07 user         0.01 sys
    5.39 real         0.06 user         0.07 sys
    4.86 real         0.06 user         0.01 sys
    ```

---

This has significantly improved my development experience for the past two weeks. I am not sure if I've missed anything that could backfire, some 👀 would be great, thanks!