### PR TITLE
FEATURE: Add users-top plugin outlet

### DIFF
--- a/app/assets/javascripts/discourse/templates/mobile/users.hbs
+++ b/app/assets/javascripts/discourse/templates/mobile/users.hbs
@@ -1,6 +1,7 @@
 {{#load-more selector=".directory .user" action="loadMore"}}
   <div class="container">
     <div class='directory'>
+      {{plugin-outlet name="users-top" connectorTagName='div' args=(hash model=model)}}
 
       <div class='clearfix user-controls'>
         {{period-chooser period=period}}

--- a/app/assets/javascripts/discourse/templates/users.hbs
+++ b/app/assets/javascripts/discourse/templates/users.hbs
@@ -2,7 +2,7 @@
   {{#load-more selector=".directory tbody tr" action="loadMore"}}
     <div class="container">
       <div class='directory'>
-
+        {{plugin-outlet name="users-top" connectorTagName='div' args=(hash model=model)}}
         <div class='clearfix'>
           {{period-chooser period=period}}
           {{text-field value=nameInput placeholderKey="directory.filter_name" class="filter-name no-blur"}}


### PR DESCRIPTION
This PR adds a plugin outlet on the top of the users page. I have been working on a extension for the Discourse-Locations plugin to show the locations of users with @erlend-sh and @angusmcleod . This plugin outlet is for adding a navigation between the users page and the map page which shows the locations of the users as shown below

![image](https://user-images.githubusercontent.com/15868287/38561256-3201e930-3cf5-11e8-9596-b3333e55d617.png)
