### PR TITLE
Feature: Add after-user-details plugin outlet

### DIFF
--- a/app/assets/javascripts/admin/templates/user-index.hbs
+++ b/app/assets/javascripts/admin/templates/user-index.hbs
@@ -538,6 +538,8 @@
 </section>
 {{/if}}
 
+{{plugin-outlet name="after-user-details" args=(hash model=model)}}
+
 <section>
   <hr>
   <div class="pull-right">

--- a/app/assets/javascripts/discourse/templates/mobile/users.hbs
+++ b/app/assets/javascripts/discourse/templates/mobile/users.hbs
@@ -1,6 +1,7 @@
 {{#load-more selector=".directory .user" action="loadMore"}}
   <div class="container">
     <div class='directory'>
+      {{plugin-outlet name="users-top" connectorTagName='div' args=(hash model=model)}}
 
       <div class='clearfix user-controls'>
         {{period-chooser period=period}}

--- a/app/assets/javascripts/discourse/templates/users.hbs
+++ b/app/assets/javascripts/discourse/templates/users.hbs
@@ -2,7 +2,7 @@
   {{#load-more selector=".directory tbody tr" action="loadMore"}}
     <div class="container">
       <div class='directory'>
-
+        {{plugin-outlet name="users-top" connectorTagName='div' args=(hash model=model)}}
         <div class='clearfix'>
           {{period-chooser period=period}}
           {{text-field value=nameInput placeholderKey="directory.filter_name" class="filter-name no-blur"}}


### PR DESCRIPTION
This is for the development of a plugin to replace the Sitepoint discourse fork.
https://github.com/sitepoint/discourse/blob/4f22f7f36bd4ad4ffaf85067161b5e2e8eaeea75/app/assets/javascripts/admin/templates/user-index.hbs#L466