### PR TITLE
FIX: TopicEmbed.import should update title and author

### DIFF
--- a/app/models/topic_embed.rb
+++ b/app/models/topic_embed.rb
@@ -73,7 +73,13 @@ class TopicEmbed < ActiveRecord::Base
       post = embed.post
       # Update the topic if it changed
       if post && post.topic && content_sha1 != embed.content_sha1
-        post.revise(user, { raw: absolutize_urls(url, contents) }, skip_validations: true, bypass_rate_limiter: true)
+        post_revision_args = {
+          raw: absolutize_urls(url, contents),
+          user_id: user.id,
+          title: title,
+        }
+
+        post.revise(user, post_revision_args, skip_validations: true, bypass_rate_limiter: true)
         embed.update_column(:content_sha1, content_sha1)
       end
     end

--- a/spec/jobs/poll_feed_spec.rb
+++ b/spec/jobs/poll_feed_spec.rb
@@ -82,6 +82,18 @@ describe Jobs::PollFeed do
             expect { poller.poll_feed }.to change { Topic.count }.by(1)
             expect(Topic.last.user).to eq(feed_author)
           end
+
+          it "updates the post if it had been polled" do
+            embed_url = 'https://blog.discourse.org/2017/09/poll-feed-spec-fixture'
+            post = TopicEmbed.import(Fabricate(:user), embed_url, 'old title', 'old content')
+
+            expect { poller.poll_feed }.to_not change { Topic.count }
+
+            post.reload
+            expect(post.topic.title).to eq('Poll Feed Spec Fixture')
+            expect(post.raw).to include('<p>This is the body &amp; content. </p>')
+            expect(post.user).to eq(feed_author)
+          end
         end
       end
 

--- a/spec/models/topic_embed_spec.rb
+++ b/spec/models/topic_embed_spec.rb
@@ -41,8 +41,12 @@ describe TopicEmbed do
       end
 
       it "Supports updating the post" do
-        post = TopicEmbed.import(user, url, title, "muhahaha new contents!")
+        new_user = Fabricate(:user)
+
+        post = TopicEmbed.import(new_user, url, title, "muhahaha new contents!")
+
         expect(post.cooked).to match(/new contents/)
+        expect(post.user).to eq(new_user)
       end
 
       it "Should leave uppercase Feed Entry URL untouched in content" do


### PR DESCRIPTION
We ran into a problem where `PollFeed` job didn't update the post author with the one found in the RSS feed.

Then I found out `TopicEmbed.import` only updates the post body and neglects new title or author, when a post with the same `embed_url` already exists.

---

Consider the scenario:

1. A blog page with Discourse embedded comment hits `embed_controller#comments`
2. The topic doesn't exist yet, so it tries to fetch the content from RSS feed, but it didn't because feed polling is rate limited
4. It then crawls the webpage and creates a topic with [the default `embed_by_username`](https://github.com/discourse/discourse/blob/ab80986184a498f68d99541c63558ea2089f49d3/lib/topic_retriever.rb#L48)
5. `PollFeed` is schedule to run at a later time, and it fetches the title, content, and author from the RSS feed with [`embed_username_key_from_feed`](https://github.com/discourse/discourse/blob/ab80986184a498f68d99541c63558ea2089f49d3/app/jobs/scheduled/poll_feed.rb#L156).
6. The post should be updated with the title, content and author from the feed.

---

Let me know what you think, cheers! 💪 