### PR TITLE
FEATURE: per-category approval settings

### DIFF
--- a/app/assets/javascripts/discourse/routes/discovery-categories.js.es6
+++ b/app/assets/javascripts/discourse/routes/discovery-categories.js.es6
@@ -124,7 +124,8 @@ const DiscoveryCategoriesRoute = Discourse.Route.extend(OpenComposer, {
         group_permissions: [{ group_name: everyoneName, permission_type: 1 }],
         available_groups: groups.map(g => g.name),
         allow_badges: true,
-        topic_featured_link_allowed: true
+        topic_featured_link_allowed: true,
+        custom_fields: {}
       });
 
       showModal("edit-category", { model });

--- a/app/assets/javascripts/discourse/templates/components/edit-category-settings.hbs
+++ b/app/assets/javascripts/discourse/templates/components/edit-category-settings.hbs
@@ -161,4 +161,18 @@
   </section>
 {{/if}}
 
+<section class="field">
+  <label>
+    {{input type="checkbox" checked=category.custom_fields.require_topic_approval}}
+    {{i18n 'category.require_topic_approval'}}
+  </label>
+</section>
+
+<section class="field">
+  <label>
+    {{input type="checkbox" checked=category.custom_fields.require_reply_approval}}
+    {{i18n 'category.require_reply_approval'}}
+  </label>
+</section>
+
 {{plugin-outlet name="category-custom-settings" args=(hash category=category)}}

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -204,7 +204,7 @@ class PostsController < ApplicationController
       if changes[:category_id] && changes[:category_id].to_i != post.topic.category_id.to_i
         category = Category.find_by(id: changes[:category_id])
         if category || (changes[:category_id].to_i == 0)
-          guardian.ensure_can_create_topic_on_category!(category)
+          guardian.ensure_can_move_topic_to_category!(category)
         else
           return render_json_error(I18n.t('category.errors.not_found'))
         end

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -243,7 +243,7 @@ class TopicsController < ApplicationController
     if params[:category_id] && (params[:category_id].to_i != topic.category_id.to_i)
       category = Category.find_by(id: params[:category_id])
       if category || (params[:category_id].to_i == 0)
-        guardian.ensure_can_create_topic_on_category!(category)
+        guardian.ensure_can_move_topic_to_category!(category)
       else
         return render_json_error(I18n.t('category.errors.not_found'))
       end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -7,6 +7,12 @@ class Category < ActiveRecord::Base
   include CategoryHashtag
   include AnonCacheInvalidator
 
+  REQUIRE_TOPIC_APPROVAL = 'require_topic_approval'
+  REQUIRE_REPLY_APPROVAL = 'require_reply_approval'
+
+  register_custom_field_type(REQUIRE_TOPIC_APPROVAL, :boolean)
+  register_custom_field_type(REQUIRE_REPLY_APPROVAL, :boolean)
+
   belongs_to :topic, dependent: :destroy
   belongs_to :topic_only_relative_url,
               -> { select "id, title, slug" },
@@ -349,6 +355,14 @@ class Category < ActiveRecord::Base
     end
 
     [read_restricted, mapped]
+  end
+
+  def require_topic_approval?
+    custom_fields[REQUIRE_TOPIC_APPROVAL]
+  end
+
+  def require_reply_approval?
+    custom_fields[REQUIRE_REPLY_APPROVAL]
   end
 
   def allowed_tags=(tag_names_arg)

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2270,6 +2270,8 @@ en:
       allow_badges_label: "Allow badges to be awarded in this category"
       edit_permissions: "Edit Permissions"
       add_permission: "Add Permission"
+      require_topic_approval: "Require moderator approval of all new topics"
+      require_reply_approval: "Require moderator approval of all new replies"
       this_year: "this year"
       position: "position"
       default_position: "Default Position"

--- a/lib/guardian/topic_guardian.rb
+++ b/lib/guardian/topic_guardian.rb
@@ -34,6 +34,12 @@ module TopicGuardian
     (!category || Category.topic_create_allowed(self).where(id: category_id).count == 1)
   end
 
+  def can_move_topic_to_category?(category)
+    category = Category === category ? category : Category.find(category || SiteSetting.uncategorized_category_id)
+
+    is_staff? || (can_create_topic_on_category?(category) && !category.require_topic_approval?)
+  end
+
   def can_create_post_on_topic?(topic)
     # No users can create posts on deleted topics
     return false if topic.blank?

--- a/lib/new_post_manager.rb
+++ b/lib/new_post_manager.rb
@@ -82,7 +82,18 @@ class NewPostManager
     is_fast_typer?(manager) ||
     matches_auto_silence_regex?(manager) ||
     WordWatcher.new("#{manager.args[:title]} #{manager.args[:raw]}").requires_approval? ||
-    (SiteSetting.approve_unless_staged && user.staged)
+    (SiteSetting.approve_unless_staged && user.staged) ||
+    post_needs_approval_in_its_category?(manager)
+  end
+
+  def self.post_needs_approval_in_its_category?(manager)
+    if manager.args[:topic_id].present?
+      Category.joins(:topics).find_by(topics: { id: manager.args[:topic_id] }).require_reply_approval?
+    elsif manager.args[:category].present?
+      Category.find(manager.args[:category]).require_topic_approval?
+    else
+      false
+    end
   end
 
   def self.default_handler(manager)

--- a/lib/new_post_manager.rb
+++ b/lib/new_post_manager.rb
@@ -88,7 +88,9 @@ class NewPostManager
 
   def self.post_needs_approval_in_its_category?(manager)
     if manager.args[:topic_id].present?
-      Category.joins(:topics).find_by(topics: { id: manager.args[:topic_id] }).require_reply_approval?
+      cat = Category.joins(:topics).find_by(topics: { id: manager.args[:topic_id] })
+      return false unless cat
+      cat.require_reply_approval?
     elsif manager.args[:category].present?
       Category.find(manager.args[:category]).require_topic_approval?
     else

--- a/lib/post_revisor.rb
+++ b/lib/post_revisor.rb
@@ -69,7 +69,7 @@ class PostRevisor
   end
 
   track_topic_field(:category_id) do |tc, category_id|
-    if category_id == 0 || tc.guardian.can_create_topic_on_category?(category_id)
+    if category_id == 0 || tc.guardian.can_move_topic_to_category?(category_id)
       tc.record_change('category_id', tc.topic.category_id, category_id)
       tc.check_result(tc.topic.change_category_to_id(category_id))
     end

--- a/spec/components/new_post_manager_spec.rb
+++ b/spec/components/new_post_manager_spec.rb
@@ -315,6 +315,17 @@ describe NewPostManager do
         manager = NewPostManager.new(user, raw: 'this is a new post', topic_id: topic.id)
         expect(manager.perform.action).to eq(:enqueued)
       end
+
+      it "doesn't blow up with invalid topic_id" do
+        expect do
+          manager = NewPostManager.new(
+            user,
+            raw: 'this is a new topic',
+            topic_id: 97546
+          )
+          expect(manager.perform.action).to eq(:create_post)
+        end.not_to raise_error
+      end
     end
   end
 end

--- a/spec/components/post_revisor_spec.rb
+++ b/spec/components/post_revisor_spec.rb
@@ -62,6 +62,23 @@ describe PostRevisor do
       expect(post.topic.category_id).to eq(category.id)
     end
 
+    it 'does not revise category when the destination category requires topic approval' do
+      new_category = Fabricate(:category)
+      new_category.custom_fields[Category::REQUIRE_TOPIC_APPROVAL] = true
+      new_category.save!
+
+      post = create_post
+      old_category_id = post.topic.category_id
+
+      post.revise(post.user, category_id: new_category.id)
+      expect(post.reload.topic.category_id).to eq(old_category_id)
+
+      new_category.custom_fields[Category::REQUIRE_TOPIC_APPROVAL] = false
+      new_category.save!
+
+      post.revise(post.user, category_id: new_category.id)
+      expect(post.reload.topic.category_id).to eq(new_category.id)
+    end
   end
 
   context 'revise wiki' do

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -663,4 +663,25 @@ describe Category do
 
   end
 
+  describe 'require topic/post approval' do
+    let(:category) { Fabricate(:category) }
+
+    describe '#require_topic_approval?' do
+      before do
+        category.custom_fields[Category::REQUIRE_TOPIC_APPROVAL] = true
+        category.save
+      end
+
+      it { expect(category.reload.require_topic_approval?).to eq(true) }
+    end
+
+    describe '#require_reply_approval?' do
+      before do
+        category.custom_fields[Category::REQUIRE_REPLY_APPROVAL] = true
+        category.save
+      end
+
+      it { expect(category.reload.require_reply_approval?).to eq(true) }
+    end
+  end
 end

--- a/spec/requests/categories_controller_spec.rb
+++ b/spec/requests/categories_controller_spec.rb
@@ -296,6 +296,26 @@ describe CategoriesController do
           expect(response.status).to eq(200)
           expect(UserHistory.count).to eq(5) # 2 + 3 (bootstrap mode)
         end
+
+        it 'updates per-category approval settings correctly' do
+          category.custom_fields[Category::REQUIRE_TOPIC_APPROVAL] = false
+          category.custom_fields[Category::REQUIRE_REPLY_APPROVAL] = false
+          category.save!
+
+          put "/categories/#{category.id}.json", params: {
+            name: category.name,
+            color: category.color,
+            text_color: category.text_color,
+            custom_fields: {
+              require_reply_approval: true,
+              require_topic_approval: true,
+            }
+          }
+
+          category.reload
+          expect(category.require_topic_approval?).to eq(true)
+          expect(category.require_reply_approval?).to eq(true)
+        end
       end
     end
   end

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -352,6 +352,20 @@ describe PostsController do
       expect(response.status).not_to eq(200)
       expect(post.topic.category_id).not_to eq(category.id)
     end
+
+    it 'can not move to a category that requires topic approval' do
+      post = create_post
+      sign_in(post.user)
+
+      category = Fabricate(:category)
+      category.custom_fields[Category::REQUIRE_TOPIC_APPROVAL] = true
+      category.save!
+
+      put "/posts/#{post.id}.json", params: { post: { category_id: category.id, raw: "this is a test edit to post" } }
+
+      expect(response.status).to eq(403)
+      expect(post.topic.reload.category_id).not_to eq(category.id)
+    end
   end
 
   describe '#bookmark' do
@@ -487,19 +501,6 @@ describe PostsController do
 
         expect(response.status).to eq(403)
       end
-
-    it 'can not move to a category that requires topic approval' do
-      post = create_post
-      sign_in(post.user)
-
-      category = Fabricate(:category)
-      category.custom_fields[Category::REQUIRE_TOPIC_APPROVAL] = true
-      category.save!
-
-      put "/posts/#{post.id}.json", params: { post: { category_id: category.id } }
-
-      expect(response.status).to eq(403)
-      expect(post.topic.reload.category_id).not_to eq(category.id)
     end
   end
 

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -487,6 +487,19 @@ describe PostsController do
 
         expect(response.status).to eq(403)
       end
+
+    it 'can not move to a category that requires topic approval' do
+      post = create_post
+      sign_in(post.user)
+
+      category = Fabricate(:category)
+      category.custom_fields[Category::REQUIRE_TOPIC_APPROVAL] = true
+      category.save!
+
+      put "/posts/#{post.id}.json", params: { post: { category_id: category.id } }
+
+      expect(response.status).to eq(403)
+      expect(post.topic.reload.category_id).not_to eq(category.id)
     end
   end
 

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -644,8 +644,19 @@ RSpec.describe TopicsController do
 
         put "/t/#{topic.id}.json", params: { category_id: category.id }
 
-        expect(response.status).not_to eq(200)
-        expect(topic.category_id).not_to eq(category.id)
+        expect(response.status).to eq(403)
+        expect(topic.reload.category_id).not_to eq(category.id)
+      end
+
+      it 'can not move to a category that requires topic approval' do
+        category = Fabricate(:category)
+        category.custom_fields[Category::REQUIRE_TOPIC_APPROVAL] = true
+        category.save!
+
+        put "/t/#{topic.id}.json", params: { category_id: category.id }
+
+        expect(response.status).to eq(403)
+        expect(topic.reload.category_id).not_to eq(category.id)
       end
 
       describe 'without permission' do


### PR DESCRIPTION
> CONTEXT & DISCUSSION: https://meta.discourse.org/t/all-topics-in-a-category-should-be-confirmed-before-publication/66800?u=xrav3nz

I _was_ going to add new [`CategoryGroup.permission_types`](https://github.com/discourse/discourse/blob/4997ede16c24d2bc5d0e723fd68a745fdb26b27d/app/models/category_group.rb#L7-L10), for easy extensibility in case we want to support requiring approval for specific user groups only. However:

1. We assume everyone has full access when there are no specific permissions set ([serializer](https://github.com/discourse/discourse/blob/4997ede16c24d2bc5d0e723fd68a745fdb26b27d/app/controllers/categories_controller.rb#L110-L112), [SQL](https://github.com/discourse/discourse/blob/4997ede16c24d2bc5d0e723fd68a745fdb26b27d/app/models/category.rb#L124)).
2. The logic for checking posting permissions are pretty uncoupled from checking if a post needs approval (`Guardian` vs `NewPostManager`) anyway.

I wasn't sure if this warrants two new columns, so I ended up creating [two custom fields on `Category`](https://github.com/xrav3nz/discourse/blob/087e2d3af244c63bc2087e23216e1d180a9c4d5a/app/models/category.rb#L10-L14).

Let me know what you think 💪 