### PR TITLE
introduces wrap and changesDOM decorators

### DIFF
--- a/app/assets/javascripts/discourse-common/lib/buffered-render.js.es6
+++ b/app/assets/javascripts/discourse-common/lib/buffered-render.js.es6
@@ -1,10 +1,10 @@
+import changesDOM from "discourse-common/lib/changes-dom";
+
 // Ember 2.0 removes buffered rendering, but we can still implement it ourselves.
 // In the long term we'll want to remove this.
-
 const Mixin = {
+  @changesDOM
   _customRender() {
-    if (!this.element || this.isDestroying || this.isDestroyed) { return; }
-
     const buffer = [];
     this.buildBuffer(buffer);
     this.element.innerHTML = buffer.join('');

--- a/app/assets/javascripts/discourse-common/lib/changes-dom.js.es6
+++ b/app/assets/javascripts/discourse-common/lib/changes-dom.js.es6
@@ -1,0 +1,14 @@
+import wrap from "discourse-common/lib/wrap";
+
+export function DOMNotReadyError() { }
+DOMNotReadyError.prototype = new Error();
+
+export default function changesDOM(target, key, descriptor) {
+  const checkForDOM = function() {
+    if (!this.element || this.isDestroying || this.isDestroyed) {
+      throw new DOMNotReadyError();
+    }
+  };
+
+  return wrap(checkForDOM, DOMNotReadyError).call(this, target, key, descriptor);
+}

--- a/app/assets/javascripts/discourse-common/lib/wrap.js.es6
+++ b/app/assets/javascripts/discourse-common/lib/wrap.js.es6
@@ -1,0 +1,19 @@
+export default function wrap(wrapperFunction, exceptionClass) {
+  return function (target, key, descriptor) {
+    const originalFunction = descriptor.value;
+    if (typeof wrapperFunction === "function") {
+      descriptor.value = function(...args) {
+        try {
+          wrapperFunction.apply(this, ...args);
+          return originalFunction.apply(this, ...args);
+        } catch (exception) {
+          if (!exceptionClass || exceptionClass && !exception instanceof exceptionClass) {
+            throw exception;
+          }
+        }
+      };
+    }
+
+    return descriptor;
+  };
+}

--- a/app/assets/javascripts/discourse/components/add-category-class.js.es6
+++ b/app/assets/javascripts/discourse/components/add-category-class.js.es6
@@ -1,4 +1,5 @@
 import { observes } from 'ember-addons/ember-computed-decorators';
+import changesDOM from "discourse-common/lib/changes-dom";
 
 export default Ember.Component.extend({
   _slug: null,
@@ -8,8 +9,8 @@ export default Ember.Component.extend({
     this.refreshClass();
   },
 
+  @changesDOM
   _updateClass() {
-    if (this.isDestroying || this.isDestroyed) { return; }
     const slug = this.get('category.fullSlug');
     this._removeClass();
     if (slug) {

--- a/app/assets/javascripts/discourse/components/composer-messages.js.es6
+++ b/app/assets/javascripts/discourse/components/composer-messages.js.es6
@@ -1,4 +1,5 @@
 import LinkLookup from 'discourse/lib/link-lookup';
+import changesDOM from "discourse-common/lib/changes-dom";
 
 let _messagesCache = {};
 
@@ -71,8 +72,8 @@ export default Ember.Component.extend({
 
   // Resets all active messages.
   // For example if composing a new post.
+  @changesDOM
   reset() {
-    if (this.isDestroying || this.isDestroyed) { return; }
     this.setProperties({
       messages: [],
       messagesByTemplate: {},
@@ -84,9 +85,8 @@ export default Ember.Component.extend({
 
   // Called after the user has typed a reply.
   // Some messages only get shown after being typed.
+  @changesDOM
   _typedReply() {
-    if (this.isDestroying || this.isDestroyed) { return; }
-
     const composer = this.get('composer');
     if (composer.get('privateMessage')) {
       let usernames = composer.get('targetUsernames');

--- a/app/assets/javascripts/discourse/components/composer-title.js.es6
+++ b/app/assets/javascripts/discourse/components/composer-title.js.es6
@@ -3,6 +3,7 @@ import InputValidation from 'discourse/models/input-validation';
 import { load, lookupCache } from 'pretty-text/oneboxer';
 import { ajax } from 'discourse/lib/ajax';
 import afterTransition from 'discourse/lib/after-transition';
+import changesDOM from "discourse-common/lib/changes-dom";
 
 export default Ember.Component.extend({
   classNames: ['title-input'],
@@ -70,9 +71,8 @@ export default Ember.Component.extend({
     }
   },
 
+  @changesDOM
   _checkForUrl() {
-    if (!this.element || this.isDestroying || this.isDestroyed) { return; }
-
     if (this.get('isAbsoluteUrl') && this.bodyIsDefault()) {
 
       // only feature links to external sites

--- a/app/assets/javascripts/discourse/components/discourse-topic.js.es6
+++ b/app/assets/javascripts/discourse/components/discourse-topic.js.es6
@@ -4,6 +4,7 @@ import ClickTrack from 'discourse/lib/click-track';
 import Scrolling from 'discourse/mixins/scrolling';
 import { selectedText } from 'discourse/lib/utilities';
 import { observes } from 'ember-addons/ember-computed-decorators';
+import changesDOM from "discourse-common/lib/changes-dom";
 
 function highlight(postNumber) {
   const $contents = $(`#post_${postNumber} .topic-body`);
@@ -117,8 +118,9 @@ export default Ember.Component.extend(AddArchetypeClass, Scrolling, {
   },
 
   // The user has scrolled the window, or it is finished rendering and ready for processing.
+  @changesDOM
   scrolled() {
-    if (this.isDestroyed || this.isDestroying || this._state !== 'inDOM') {
+    if (this._state !== 'inDOM') {
       return;
     }
 

--- a/app/assets/javascripts/discourse/components/scrolling-post-stream.js.es6
+++ b/app/assets/javascripts/discourse/components/scrolling-post-stream.js.es6
@@ -4,6 +4,7 @@ import { cloak, uncloak } from 'discourse/widgets/post-stream';
 import { isWorkaroundActive } from 'discourse/lib/safari-hacks';
 import offsetCalculator from 'discourse/lib/offset-calculator';
 import optionalService from 'discourse/lib/optional-service';
+import changesDOM from "discourse-common/lib/changes-dom";
 
 function findTopView($posts, viewportTop, postsWrapperTop, min, max) {
   if (max < min) { return min; }
@@ -60,8 +61,8 @@ export default MountWidget.extend({
     }
   },
 
+  @changesDOM
   scrolled() {
-    if (this.isDestroyed || this.isDestroying) { return; }
     if (isWorkaroundActive()) { return; }
 
     // We use this because watching videos fullscreen in Chrome was super buggy

--- a/app/assets/javascripts/discourse/components/topic-navigation.js.es6
+++ b/app/assets/javascripts/discourse/components/topic-navigation.js.es6
@@ -1,5 +1,6 @@
 import { observes } from 'ember-addons/ember-computed-decorators';
 import showModal from 'discourse/lib/show-modal';
+import changesDOM from "discourse-common/lib/changes-dom";
 
 export default Ember.Component.extend({
   composerOpen: null,
@@ -10,9 +11,8 @@ export default Ember.Component.extend({
     this.set('info', Ember.Object.create());
   },
 
+  @changesDOM
   _performCheckSize() {
-    if (!this.element || this.isDestroying || this.isDestroyed) { return; }
-
     let info = this.get('info');
 
     if (info.get('topicProgressExpanded')) {

--- a/app/assets/javascripts/discourse/components/topic-progress.js.es6
+++ b/app/assets/javascripts/discourse/components/topic-progress.js.es6
@@ -1,4 +1,5 @@
 import { default as computed, observes } from 'ember-addons/ember-computed-decorators';
+import changesDOM from "discourse-common/lib/changes-dom";
 
 export default Ember.Component.extend({
   elementId: 'topic-progress-wrapper',
@@ -90,9 +91,8 @@ export default Ember.Component.extend({
                   .off('topic:current-post-scrolled', this, this._topicScrolled);
   },
 
+  @changesDOM
   _updateProgressBar() {
-    if (this.isDestroyed || this.isDestroying) { return; }
-
     const $topicProgress = this.$('#topic-progress');
     // speeds up stuff, bypass jquery slowness and extra checks
     if (!this._totalWidth) {

--- a/app/assets/javascripts/discourse/mixins/docking.js.es6
+++ b/app/assets/javascripts/discourse/mixins/docking.js.es6
@@ -1,3 +1,5 @@
+import changesDOM from "discourse-common/lib/changes-dom";
+
 const helper = {
   offset() {
     const mainOffset = $('#main').offset();
@@ -16,8 +18,8 @@ export default Ember.Mixin.create({
     };
   },
 
+  @changesDOM
   safeDockCheck() {
-    if (this.isDestroyed || this.isDestroying) { return; }
     this.dockCheck(helper);
   },
 

--- a/app/assets/javascripts/wizard/components/wizard-canvas.js.es6
+++ b/app/assets/javascripts/wizard/components/wizard-canvas.js.es6
@@ -1,3 +1,5 @@
+import changesDOM from "discourse-common/lib/changes-dom";
+
 const MAX_PARTICLES = 150;
 
 const SIZE = 144;
@@ -79,8 +81,9 @@ export default Ember.Component.extend({
     canvas.height = height;
   },
 
+  @changesDOM
   paint() {
-    if (this.isDestroying || this.isDestroyed || !this.ready) { return; }
+    if (!this.ready) { return; }
 
     const { ctx } = this;
     ctx.clearRect(0, 0, width, height);


### PR DESCRIPTION
Wrap lets you prepend a function:

```
@wrap(doSomething)
callSomeone() {
}
```

changesDOM is a utility decorator relying on wrap which will check there's actually a DOM element and it's not getting destroyed:

```
@changesDOM
needsDOM() {
  this.$().html("xxx");
}
```