### PR TITLE
WIP: fix catogory text_color for box style category badge

### DIFF
--- a/lib/category_badge.rb
+++ b/lib/category_badge.rb
@@ -88,12 +88,14 @@ module CategoryBadge
         when :bar
           'color: #222222; padding: 3px; vertical-align: text-top; margin-top: -3px; display: inline-block;'
         when :box
-          "color: #{category.text_color}; #{show_parent ? 'margin-left: 5px; ' : ''} position: relative; padding: 0 5px; margin-top: 2px;"
+          "color: ##{category.text_color}; #{show_parent ? 'margin-left: 5px; ' : ''} position: relative; padding: 0 5px; margin-top: 2px;"
         when :bullet
           'color: #222222; vertical-align: text-top; line-height: 1; margin-left: 4px; padding-left: 2px; display: inline;'
         when :none
           ''
         end + 'max-width: 150px; overflow: hidden; text-overflow: ellipsis;'
+      elsif (SiteSetting.category_style).to_sym == :box
+        "color: ##{category.text_color}"
       else
         ''
       end


### PR DESCRIPTION
`category_badge.rb` is used to create category badges for the the Discourse topic onebox, the not-found page, and the email digest. It isn't setting the text color correctly for the box_style category badge.

![screen shot 2018-04-27 at 11 09 19 am](https://user-images.githubusercontent.com/2975917/39378044-1333482c-4a0c-11e8-9c6e-299e80a5e7ff.png)

This PR fixes that problem both for when the `inline_style` option is used and for when it isn't used.

There is a further issue that when there is an apostrophe in the category description the markup that is returned for the `.badge-category` span is broken due to the way the `title` attrubute is being set:

```
title="This is a category for learning about Discourse development. I" ll="" be="" using="" it="" wp-discourse="" sub-category="" for="" testing="" the="" wordpress="" discourse="" plugin.=""
```
I can look at this some more and either include a fix for it in this PR, or deal with it separately.