### PR TITLE
Feature: Include participants at the bottom of PM emails

### DIFF
--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -447,15 +447,15 @@ class UserNotifications < ActionMailer::Base
 
       participants = "#{I18n.t("user_notifications.pm_participants")} "
       participant_list = []
+      post.topic.allowed_groups.each do |group|
+        participant_list.push "[#{group.name} (#{I18n.t("groups.member_count", count: group.users.count)})](#{Discourse.base_url}/groups/#{group.name})"
+      end
       post.topic.allowed_users.each do |user|
         if SiteSetting.prioritize_username_in_ux?
           participant_list.push "[#{user.username}](#{Discourse.base_url}/u/#{user.username_lower})"
         else
           participant_list.push "[#{user.name.blank? ? user.username : user.name}](#{Discourse.base_url}/u/#{user.username_lower})"
         end
-      end
-      post.topic.allowed_groups.each do |group|
-        participant_list.push "[#{group.name}](#{Discourse.base_url}/groups/#{group.name})"
       end
       participants += participant_list.join(", ")
     end

--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -448,10 +448,14 @@ class UserNotifications < ActionMailer::Base
       participants = "#{I18n.t("user_notifications.pm_participants")} "
       participant_list = []
       post.topic.allowed_users.each do |user|
-        participant_list.push user.username
+        if SiteSetting.prioritize_username_in_ux?
+          participant_list.push "[#{user.username}](#{Discourse.base_url}/u/#{user.username_lower})"
+        else
+          participant_list.push "[#{user.name.blank? ? user.username : user.name}](#{Discourse.base_url}/u/#{user.username_lower})"
+        end
       end
       post.topic.allowed_groups.each do |group|
-        participant_list.push group.name
+        participant_list.push "[#{group.name}](#{Discourse.base_url}/groups/#{group.name})"
       end
       participants += participant_list.join(", ")
     end

--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -444,6 +444,16 @@ class UserNotifications < ActionMailer::Base
         else
           I18n.t('subject_pm')
         end
+
+      participants = "#{I18n.t("user_notifications.pm_participants")} "
+      participant_list = []
+      post.topic.allowed_users.each do |user|
+        participant_list.push user.username
+      end
+      post.topic.allowed_groups.each do |group|
+        participant_list.push group.name
+      end
+      participants += participant_list.join(", ")
     end
 
     if SiteSetting.private_email?
@@ -548,6 +558,7 @@ class UserNotifications < ActionMailer::Base
       show_category_in_subject: show_category_in_subject,
       private_reply: post.topic.private_message?,
       subject_pm: subject_pm,
+      participants: participants,
       include_respond_instructions: !(user.suspended? || user.staged?),
       template: template,
       site_description: SiteSetting.site_description,

--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -448,7 +448,7 @@ class UserNotifications < ActionMailer::Base
       participants = "#{I18n.t("user_notifications.pm_participants")} "
       participant_list = []
       post.topic.allowed_groups.each do |group|
-        participant_list.push "[#{group.name} (#{I18n.t("groups.member_count", count: group.users.count)})](#{Discourse.base_url}/groups/#{group.name})"
+        participant_list.push "[#{group.name} (#{group.users.count})](#{Discourse.base_url}/groups/#{group.name})"
       end
       post.topic.allowed_users.each do |user|
         if SiteSetting.prioritize_username_in_ux?

--- a/app/views/email/notification.html.erb
+++ b/app/views/email/notification.html.erb
@@ -32,7 +32,7 @@
 
   <div class='footer'>%{respond_instructions}</div>
   <% if post.topic.private_message? %>
-    <div class='footer'>
+    <div class='undecorated-link-footer footer'>
       %{participants}
     </div>
   <% end %>

--- a/app/views/email/notification.html.erb
+++ b/app/views/email/notification.html.erb
@@ -31,6 +31,11 @@
   <% end %>
 
   <div class='footer'>%{respond_instructions}</div>
+  <% if post.topic.private_message? %>
+    <div class='footer'>
+      %{participants}
+    </div>
+  <% end %>
   <div class='footer'>%{unsubscribe_instructions}</div>
 
 </div>

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -323,6 +323,10 @@ en:
     request_membership_pm:
       title: "Membership Request for @%{group_name}"
 
+    member_count:
+      one: "1 member"
+      other: "%{count} members"
+
   education:
     until_posts:
       one: "1 post"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2599,6 +2599,8 @@ en:
 
     posted_by: "Posted by %{username} on %{post_date}"
 
+    pm_participants: "This is PM between"
+
     invited_group_to_private_message_body: |
       %{username} invited @%{group_name} to a message
 
@@ -2723,6 +2725,18 @@ en:
     user_mentioned:
       title: "User Mentioned"
       subject_template: "[%{email_prefix}] %{topic_title}"
+      text_body_template: |
+        %{header_instructions}
+
+        %{message}
+
+        %{context}
+
+        %{respond_instructions}
+
+    user_mentioned_pm:
+      title: "User Mentioned PM"
+      subject_template: "[%{email_prefix}] [PM] %{topic_title}"
       text_body_template: |
         %{header_instructions}
 

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -323,10 +323,6 @@ en:
     request_membership_pm:
       title: "Membership Request for @%{group_name}"
 
-    member_count:
-      one: "1 member"
-      other: "%{count} members"
-
   education:
     until_posts:
       one: "1 post"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2603,7 +2603,7 @@ en:
 
     posted_by: "Posted by %{username} on %{post_date}"
 
-    pm_participants: "This is PM between"
+    pm_participants: "Participants:"
 
     invited_group_to_private_message_body: |
       %{username} invited @%{group_name} to a message

--- a/lib/email/message_builder.rb
+++ b/lib/email/message_builder.rb
@@ -96,6 +96,13 @@ module Email
         html_override.gsub!("%{respond_instructions}", "")
       end
 
+      if @template_args[:participants].present?
+        participants = PrettyText.cook(@template_args[:participants], sanitize: false).html_safe
+        html_override.gsub!("%{participants}", participants)
+      else
+        html_override.gsub!("%{participants}", "")
+      end
+
       styled = Email::Styles.new(html_override, @opts)
       styled.format_basic
       if style = @opts[:style]
@@ -111,6 +118,12 @@ module Email
     def body
       body = @opts[:body]
       body = I18n.t("#{@opts[:template]}.text_body_template", template_args).dup if @opts[:template]
+
+      if @template_args[:participants].present?
+        body << "\n"
+        body << @template_args[:participants]
+        body << "\n"
+      end
 
       if @template_args[:unsubscribe_instructions].present?
         body << "\n"

--- a/lib/email/styles.rb
+++ b/lib/email/styles.rb
@@ -97,6 +97,7 @@ module Email
       style('.lightbox-wrapper .meta', 'display: none')
       correct_first_body_margin
       correct_footer_style
+      style('div.undecorated-link-footer a', "font-weight: normal;")
       reset_tables
       onebox_styles
       plugin_styles

--- a/spec/components/email/message_builder_spec.rb
+++ b/spec/components/email/message_builder_spec.rb
@@ -247,6 +247,17 @@ describe Email::MessageBuilder do
 
   end
 
+  context "PM multiple participants" do
+    let(:pm_multiple) { Email::MessageBuilder.new(to_address,
+                                                               body: 'hello world',
+                                                               private_reply: true,
+                                                               participants: "user1, user2") }
+
+    it "lists participants out" do
+      expect(pm_multiple.body).to match('hello world\nuser1, user2')
+    end
+  end
+
   context "from field" do
 
     it "has the default from" do

--- a/spec/mailers/user_notifications_spec.rb
+++ b/spec/mailers/user_notifications_spec.rb
@@ -436,7 +436,7 @@ describe UserNotifications do
         notification_data_hash: notification.data_hash
       )
 
-      expect(mail.body).to include("#{I18n.t("user_notifications.pm_participants")} one, two")
+      expect(mail.body).to include("#{I18n.t("user_notifications.pm_participants")} [one](http://test.localhost/u/one), [two](http://test.localhost/u/two)")
     end
 
     context "when SiteSetting.group_name_in_subject is true" do

--- a/spec/mailers/user_notifications_spec.rb
+++ b/spec/mailers/user_notifications_spec.rb
@@ -443,7 +443,7 @@ describe UserNotifications do
         notification_data_hash: notification.data_hash
       )
 
-      expect(mail.body).to include("#{I18n.t("user_notifications.pm_participants")} [group1 (2 members)](http://test.localhost/groups/group1), [group2 (1 member)](http://test.localhost/groups/group2), [one](http://test.localhost/u/one), [two](http://test.localhost/u/two)")
+      expect(mail.body).to include("#{I18n.t("user_notifications.pm_participants")} [group1 (2)](http://test.localhost/groups/group1), [group2 (1)](http://test.localhost/groups/group2), [one](http://test.localhost/u/one), [two](http://test.localhost/u/two)")
     end
 
     context "when SiteSetting.group_name_in_subject is true" do

--- a/spec/mailers/user_notifications_spec.rb
+++ b/spec/mailers/user_notifications_spec.rb
@@ -423,12 +423,19 @@ describe UserNotifications do
       expect(mail.subject).to include("[PM] ")
     end
 
-    it "includes a list of participants" do
+    it "includes a list of participants, groups first with member lists" do
+      group1 = Fabricate(:group)
+      group2 = Fabricate(:group)
+      group1.name = "group1"
+      group2.name = "group2"
       user1 = Fabricate(:user)
       user2 = Fabricate(:user)
       user1.username = "one"
       user2.username = "two"
+      user1.groups = [ group1, group2 ]
+      user2.groups = [ group1 ]
       topic.allowed_users = [ user1, user2 ]
+      topic.allowed_groups = [ group1, group2 ]
       mail = UserNotifications.user_private_message(
         response.user,
         post: response,
@@ -436,7 +443,7 @@ describe UserNotifications do
         notification_data_hash: notification.data_hash
       )
 
-      expect(mail.body).to include("#{I18n.t("user_notifications.pm_participants")} [one](http://test.localhost/u/one), [two](http://test.localhost/u/two)")
+      expect(mail.body).to include("#{I18n.t("user_notifications.pm_participants")} [group1 (2 members)](http://test.localhost/groups/group1), [group2 (1 member)](http://test.localhost/groups/group2), [one](http://test.localhost/u/one), [two](http://test.localhost/u/two)")
     end
 
     context "when SiteSetting.group_name_in_subject is true" do

--- a/spec/mailers/user_notifications_spec.rb
+++ b/spec/mailers/user_notifications_spec.rb
@@ -423,6 +423,22 @@ describe UserNotifications do
       expect(mail.subject).to include("[PM] ")
     end
 
+    it "includes a list of participants" do
+      user1 = Fabricate(:user)
+      user2 = Fabricate(:user)
+      user1.username = "one"
+      user2.username = "two"
+      topic.allowed_users = [ user1, user2 ]
+      mail = UserNotifications.user_private_message(
+        response.user,
+        post: response,
+        notification_type: notification.notification_type,
+        notification_data_hash: notification.data_hash
+      )
+
+      expect(mail.body).to include("#{I18n.t("user_notifications.pm_participants")} one, two")
+    end
+
     context "when SiteSetting.group_name_in_subject is true" do
       before do
         SiteSetting.group_in_subject = true


### PR DESCRIPTION
https://meta.discourse.org/t/email-notification-recipients-unclear-when-pm-is-sent-to-multiple-users/26934/13?u=featheredtoast

Includes a comma separated list in email footers: "This is a PM between..." under the response footer

Lists users first, followed by groups.

Fix: added missing translation for PM mentions