### PR TITLE
Allow plugins to modify class methods/properties

### DIFF
--- a/app/assets/javascripts/discourse/lib/plugin-api.js.es6
+++ b/app/assets/javascripts/discourse/lib/plugin-api.js.es6
@@ -45,11 +45,19 @@ class PluginApi {
   }
 
   /**
-   * Allows you to overwrite or extend methods in a class.
+   * Allows you to overwrite or extend methods and properties in a class.
+   *
+   * To modify class methods and properties, add `classMethods` to `opts` with a truthy value.
+   *
+   * If you need to modify both class methods and instance methods, you must call this twice.
    *
    * For example:
    *
    * ```
+   * api.modifyClass('model:user', {
+   *     createAccount(attrs) { }
+   * }, { classMethods: true });
+   *
    * api.modifyClass('controller:composer', {
    *   actions: {
    *     newActionHere() { }
@@ -72,7 +80,8 @@ class PluginApi {
       return;
     }
 
-    klass.class.reopen(changes);
+    opts.classMethods ? klass.class.reopenClass(changes) : klass.class.reopen(changes);
+
     return klass;
   }
 


### PR DESCRIPTION
`plugin-api.modifyClass` allows plugin authors to overwrite instance methods of existing classes, but there is no analogous way to overwrite class methods.... until now.

context here: https://meta.discourse.org/t/allow-modifying-class-methods-properties-in-plugin-api/84270