### PR TITLE
Improved email validation in user search module.

### DIFF
--- a/app/assets/javascripts/discourse/lib/user-search.js.es6
+++ b/app/assets/javascripts/discourse/lib/user-search.js.es6
@@ -1,5 +1,6 @@
 import { CANCELLED_STATUS } from 'discourse/lib/autocomplete';
 import { userPath } from 'discourse/lib/url';
+import { emailValid } from 'discourse/lib/utilities';
 
 var cache = {},
     cacheTopicId,
@@ -61,7 +62,7 @@ function organizeResults(r, options) {
     });
   }
 
-  if (!options.disallowEmails && options.term.match(/@/)) {
+  if (!options.disallowEmails && emailValid(options.term)) {
     let e = { username: options.term };
     emails = [ e ];
     results.push(e);


### PR DESCRIPTION
Fixes the bug described [here](https://meta.discourse.org/t/username-preceded-by-detected-as-email/71355/5).

Basically, the bug was caused by poorly validation of email addresses. Everything containing `@` was considered an email, which is not true.