### PR TITLE
FEATURE: New site setting `min_flags_staff_visibility`

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1473,6 +1473,7 @@ en:
     auto_silence_fast_typers_max_trust_level: "Maximum trust level to auto silence fast typers"
     auto_silence_first_post_regex: "Case insensitive regex that if passed will cause first post by user to be silenced and sent to approval queue. Example: raging|a[bc]a , will cause all posts containing raging or aba or aca to be silenced on first. Only applies to first post."
     flags_default_topics: "Show flagged topics by default in the admin section"
+    min_flags_staff_visibility: "The minimum amount of flags on a post must have before staff can see it in the admin section"
 
     reply_by_email_enabled: "Enable replying to topics via email."
     reply_by_email_address: "Template for reply by email incoming email address, for example: %{reply_key}@reply.example.com or replies+%{reply_key}@example.com"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1096,6 +1096,7 @@ spam:
   flags_default_topics:
     default: false
     client: true
+  min_flags_staff_visibility: 1
 
 rate_limits:
   unique_posts_mins: 5

--- a/spec/models/post_action_spec.rb
+++ b/spec/models/post_action_spec.rb
@@ -141,6 +141,17 @@ describe PostAction do
       expect(PostAction.flagged_posts_count).to eq(0)
     end
 
+    it "respects min_flags_staff_visibility" do
+      SiteSetting.min_flags_staff_visibility = 2
+      expect(PostAction.flagged_posts_count).to eq(0)
+
+      PostAction.act(codinghorror, post, PostActionType.types[:off_topic])
+      expect(PostAction.flagged_posts_count).to eq(0)
+
+      PostAction.act(eviltrout, post, PostActionType.types[:off_topic])
+      expect(PostAction.flagged_posts_count).to eq(1)
+    end
+
     it "should reset counts when a topic is deleted" do
       PostAction.act(codinghorror, post, PostActionType.types[:off_topic])
       post.topic.trash!


### PR DESCRIPTION
When set higher than 1, flags won't show up for staff in the admin
section unless the minimum threshold of flags on a post is reached.

The idea is for high traffic forums, moderators might not be concerned
with posts unless they have at least `min_flags_staff_visibility` flags.