### PR TITLE
Fix issue for custom image badges urls

### DIFF
--- a/app/assets/javascripts/discourse/helpers/icon-or-image.js.es6
+++ b/app/assets/javascripts/discourse/helpers/icon-or-image.js.es6
@@ -1,7 +1,14 @@
 import { htmlHelper } from 'discourse-common/lib/helpers';
 import { iconHTML } from 'discourse-common/lib/icon-library';
 
-export default htmlHelper(function(str) {
-  if (Ember.isEmpty(str)) { return ""; }
-  return (str.indexOf('fa-') === 0) ? iconHTML(str.replace('fa-', '')) : `<img src='${str}'>`;
+export default htmlHelper(function({ icon, image }) {
+  if (!Ember.isEmpty(image)) {
+    return `<img src='${image}'>`;
+  }
+
+  if (Ember.isEmpty(icon) || icon.indexOf('fa-') !== 0) {
+    return '';
+  }
+
+  return iconHTML(icon.replace('fa-', ''));
 });

--- a/app/assets/javascripts/discourse/templates/components/badge-button.hbs
+++ b/app/assets/javascripts/discourse/templates/components/badge-button.hbs
@@ -1,3 +1,3 @@
-{{icon-or-image badge.icon}}
+{{icon-or-image badge}}
 <span class="badge-display-name">{{badge.name}}</span>
 {{yield}}

--- a/app/assets/javascripts/discourse/templates/components/badge-card.hbs
+++ b/app/assets/javascripts/discourse/templates/components/badge-card.hbs
@@ -7,7 +7,7 @@
 <div class='badge-contents'>
   <a href={{url}} class="badge-link">
     <div class='badge-icon {{badge.badgeTypeClassName}}'>
-      {{icon-or-image badge.icon}}
+      {{icon-or-image badge}}
     </div>
     <div class='badge-info'>
       <div class='badge-info-item'>


### PR DESCRIPTION
# Description

Whenever the user tries to add a custom image URL in order to change the image of a badge that value won't work as the method only takes into count the `icon` property, this code refactor the method for `icon-or-image` in order to accept the whole object and verify both properties (image and icon) and retrieving the image if it is set or the icon if the image is not set and the icon is a valid font-awesome icon type format.
