### PR TITLE
FIX: changing tag group privacy setting was not consistent

### DIFF
--- a/app/assets/javascripts/discourse/components/radio-button.js.es6
+++ b/app/assets/javascripts/discourse/components/radio-button.js.es6
@@ -5,8 +5,12 @@ export default Ember.Component.extend({
   type : "radio",
   attributeBindings : ["name", "type", "value", "checked:checked", "disabled:disabled"],
 
-  click: function() {
-    this.set("selection", this.$().val());
+  click() {
+    const value = this.$().val();
+    if (this.get("selection") === value) {
+      this.set("selection", undefined);
+    }
+    this.set("selection", value);
   },
 
   @computed('value', 'selection')


### PR DESCRIPTION
https://meta.discourse.org/t/tags-can-be-used-by-everyone-causes-tag-to-be-usable-only-by-staff/86953