### PR TITLE
UX: disables all time col in activity metrics new dashboard

### DIFF
--- a/app/assets/javascripts/admin/components/admin-report-counts.js.es6
+++ b/app/assets/javascripts/admin/components/admin-report-counts.js.es6
@@ -1,4 +1,5 @@
 export default Ember.Component.extend({
+  allTime: true,
   tagName: 'tr',
   reverseColors: Ember.computed.match('report.type', /^(time_to_first_response|topics_with_no_response)$/),
   classNameBindings: ['reverseColors']

--- a/app/assets/javascripts/admin/templates/components/admin-report-counts.hbs
+++ b/app/assets/javascripts/admin/templates/components/admin-report-counts.hbs
@@ -19,4 +19,6 @@
   {{number report.lastThirtyDaysCount}} {{d-icon "caret-up" class="up"}} {{d-icon "caret-down" class="down"}}
 </td>
 
-<td class="value">{{number report.total}}</td>
+{{#if allTime}}
+  <td class="value">{{number report.total}}</td>
+{{/if}}

--- a/app/assets/javascripts/admin/templates/dashboard_next.hbs
+++ b/app/assets/javascripts/admin/templates/dashboard_next.hbs
@@ -72,12 +72,11 @@
                 <th>{{i18n 'admin.dashboard.reports.yesterday'}}</th>
                 <th>{{i18n 'admin.dashboard.reports.last_7_days'}}</th>
                 <th>{{i18n 'admin.dashboard.reports.last_30_days'}}</th>
-                <th>{{i18n 'admin.dashboard.reports.all'}}</th>
               </tr>
             </thead>
             <tbody>
               {{#each reports as |report|}}
-                {{admin-report-counts report=report}}
+                {{admin-report-counts report=report allTime=false}}
               {{/each}}
             </tbody>
           </table>


### PR DESCRIPTION
This commit also makes it work for old dashboard.