### PR TITLE
FIX: update cache times for service workers

### DIFF
--- a/app/assets/javascripts/service-worker.js.erb
+++ b/app/assets/javascripts/service-worker.js.erb
@@ -37,6 +37,8 @@ self.addEventListener('install', function(event) {
       return caches.open(CURRENT_CACHES.offline).then(function(cache) {
         return cache.put(OFFLINE_URL, response);
       });
+    }).then(function(cache) {
+      self.skipWaiting();
     })
   );
 });
@@ -60,6 +62,8 @@ self.addEventListener('activate', function(event) {
           }
         })
       );
+    }).then(function() {
+      self.clients.claim()
     })
   );
 });

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -160,8 +160,11 @@ class StaticController < ApplicationController
       format.js do
         # https://github.com/w3c/ServiceWorker/blob/master/explainer.md#updating-a-service-worker
         # Maximum cache that the service worker will respect is 24 hours.
-        immutable_for 24.hours
+        # However, ensure that these may be cached and served for longer on servers.
+        immutable_for 1.year
 
+        path = File.expand_path(Rails.root + "public/assets/#{Rails.application.assets_manifest.assets['service-worker.js']}")
+        response.headers["Last-Modified"] = File.ctime(path).httpdate
         render(
           plain: Rails.application.assets_manifest.find_sources('service-worker.js').first,
           content_type: 'application/javascript'


### PR DESCRIPTION
Add a last modified time.

Register newer service workers and claim clients more quickly.