### PR TITLE
IncomingLink: do not store IP of logged-in users

### DIFF
--- a/app/models/incoming_link.rb
+++ b/app/models/incoming_link.rb
@@ -20,6 +20,7 @@ class IncomingLink < ActiveRecord::Base
       u = User.select(:id).find_by(username_lower: username.downcase)
       user_id = u.id if u
     end
+    ip_address = opts[:ip_address]
 
     if opts[:referer].present?
       begin
@@ -38,6 +39,7 @@ class IncomingLink < ActiveRecord::Base
         .pluck(:id).first
 
       cid = current_user ? (current_user.id) : (nil)
+      ip_address = nil if cid
 
       unless cid && cid == user_id
 
@@ -45,7 +47,7 @@ class IncomingLink < ActiveRecord::Base
                user_id: user_id,
                post_id: post_id,
                current_user_id: cid,
-               ip_address: opts[:ip_address]) if post_id
+               ip_address: ip_address) if post_id
 
       end
     end

--- a/spec/models/incoming_link_spec.rb
+++ b/spec/models/incoming_link_spec.rb
@@ -2,6 +2,8 @@ require 'rails_helper'
 
 describe IncomingLink do
 
+  let(:sharing_user) { Fabricate(:user, name: 'Alice') }
+  let(:current_user) { Fabricate(:user, name: 'Bob') }
   let(:post) { Fabricate(:post) }
   let(:topic) { post.topic }
 
@@ -82,11 +84,42 @@ describe IncomingLink do
     end
 
     it "is able to look up user_id and log it from the GET params" do
-      user = Fabricate(:user, username: "Bob")
-      add(host: 'test.com', username: "bob", post_id: 1)
+      add(host: 'test.com', username: sharing_user.username, post_id: 1)
 
       first = IncomingLink.first
-      expect(first.user_id).to eq user.id
+      expect(first.user_id).to eq sharing_user.id
+    end
+
+    it "logs an incoming and stores IP with no current user" do
+      add(referer: 'https://example.social/@alice/1234',
+          post_id: post.id,
+          username: sharing_user.username,
+          current_user: nil,
+          ip_address: '100.64.1.1')
+      expect(IncomingLink.count).to eq 1
+      il = IncomingLink.last
+      expect(il.ip_address).to eq '100.64.1.1'
+    end
+
+    it "does not log when the sharing user clicks their own link" do
+      add(referer: 'https://example.social/@alice/1234',
+          post_id: post.id,
+          username: sharing_user.username,
+          current_user: sharing_user,
+          ip_address: '100.64.1.2')
+      expect(IncomingLink.count).to eq 0
+    end
+
+    it "does not store ip address when a logged-in user clicks" do
+      add(referer: 'https://example.social/@alice/1234',
+          post_id: post.id,
+          username: sharing_user.username,
+          current_user: current_user,
+          ip_address: '100.64.1.3')
+      expect(IncomingLink.count).to eq 1
+      il = IncomingLink.last
+      expect(il.ip_address).to eq nil
+      expect(il.current_user_id).to eq current_user.id
     end
   end
 


### PR DESCRIPTION
Code is pretty simple - just don't store the IP if we have a current user.

Console output on development instance showing this working:

```
 #<IncomingLink:0x000000000b16d1d0
  id: 3,
  created_at: Mon, 14 May 2018 21:46:56 UTC +00:00,
  user_id: 1,
  ip_address: #<IPAddr: IPv4:127.0.0.1/255.255.255.255>,
  current_user_id: nil,  ## <==
  post_id: 18,
  incoming_referer_id: nil>,
 #<IncomingLink:0x000000000b16ceb0
  id: 4,
  created_at: Mon, 14 May 2018 21:55:45 UTC +00:00,
  user_id: 1,
  ip_address: nil,       ## <== ip_address is nil for logged-in users
  current_user_id: 2,    ## <==
  post_id: 19,
  incoming_referer_id: nil>]
```