### PR TITLE
Fix report specs on Ruby 2.3

### DIFF
--- a/lib/freedom_patches/ceil.rb
+++ b/lib/freedom_patches/ceil.rb
@@ -1,0 +1,36 @@
+# precision was added to ceil in Ruby 2.4
+class Float
+  if (1.5).method(:ceil).arity == 0
+    old_ceil = instance_method(:ceil)
+
+    define_method(:ceil) do |ndigits = 0|
+      if ndigits == 0
+        old_ceil.bind(self).()
+      else
+        precision = 10**ndigits
+        result = old_ceil.bind(self * precision).() / precision.to_f
+        ndigits.negative? ? result.round : result
+      end
+    end
+  end
+end
+
+class Integer
+  if 1.method(:ceil).arity == 0
+    old_ceil = instance_method(:ceil)
+
+    define_method(:ceil) do |ndigits = 0|
+      if ndigits == 0
+        old_ceil.bind(self).()
+      else
+        precision = 10**ndigits
+
+        if ndigits.negative?
+          ((self * precision).ceil / precision).to_i
+        else
+          old_ceil.bind(self * precision).() / precision.to_f
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/freedom_patches/ceil_spec.rb
+++ b/spec/lib/freedom_patches/ceil_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+describe Float do
+  describe '#ceil' do
+    it 'works correctly' do
+      expect(1.2.ceil).to eq(2)
+      expect(2.0.ceil).to eq(2)
+      expect((-1.2).ceil).to eq(-1)
+      expect((-2.0).ceil).to eq(-2)
+
+      expect(1.234567.ceil(2)).to eq(1.24)
+      expect(1.234567.ceil(3)).to eq(1.235)
+      expect(1.234567.ceil(4)).to eq(1.2346)
+      expect(1.234567.ceil(5)).to eq(1.23457)
+
+      expect(34567.89.ceil(-5)).to eq(100000)
+      expect(34567.89.ceil(-4)).to eq(40000)
+      expect(34567.89.ceil(-3)).to eq(35000)
+      expect(34567.89.ceil(-2)).to eq(34600)
+      expect(34567.89.ceil(-1)).to eq(34570)
+      expect(34567.89.ceil(0)).to eq(34568)
+      expect(34567.89.ceil(1)).to eq(34567.9)
+      expect(34567.89.ceil(2)).to eq(34567.89)
+      expect(34567.89.ceil(3)).to eq(34567.89)
+    end
+  end
+end
+
+describe Integer do
+  describe '#ceil' do
+    it 'works correctly' do
+      expect(1.ceil).to eq(1)
+      expect(1.ceil(2)).to eq(1.0)
+      expect(15.ceil(-1)).to eq(20)
+    end
+  end
+end


### PR DESCRIPTION
Our Travis build is broken on Ruby 2.3 because `ceil` doesn't support `precision` as argument. This adds a patch for old Ruby versions.

@SamSaffron Does that look OK to you?