### PR TITLE
Change condition when displaying URLs for S3 a/v uploads in the editor

### DIFF
--- a/app/assets/javascripts/discourse/lib/utilities.js.es6
+++ b/app/assets/javascripts/discourse/lib/utilities.js.es6
@@ -348,7 +348,7 @@ export function uploadLocation(url) {
   if (Discourse.CDN) {
     url = Discourse.getURLWithCDN(url);
     return /^\/\//.test(url) ? 'http:' + url : url;
-  } else if (Discourse.SiteSettings.enable_s3_uploads) {
+  } else if (Discourse.S3BaseUrl) {
     return 'https:' + url;
   } else {
     var protocol = window.location.protocol + '//',


### PR DESCRIPTION
This is a minor replacement that doesn't change any behaviour. 

Instead of checking whether S3 uploads are enabled directly with the site settings, it checks it via the helper which I also used for overriding the settings for Azure Blob Storage plugin (it fixes the bug that appeared when uploading audio/video files onto Azure Blob https://meta.discourse.org/t/azure-blob-storage-plugin/79392/13).
