### PR TITLE
Fix: Safari failing to download backups from email links

### DIFF
--- a/app/assets/javascripts/discourse/initializers/register-service-worker.js.es6
+++ b/app/assets/javascripts/discourse/initializers/register-service-worker.js.es6
@@ -6,9 +6,10 @@ export default {
           (location.hostname === "localhost");
 
     const isSupported= isSecured && ('serviceWorker' in navigator);
+    const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
 
     if (isSupported) {
-      if (Discourse.ServiceWorkerURL) {
+      if (Discourse.ServiceWorkerURL && !isSafari) {
         navigator.serviceWorker
           .register(`${Discourse.BaseUri}/${Discourse.ServiceWorkerURL}`)
           .catch(error => {

--- a/app/assets/javascripts/service-worker.js.erb
+++ b/app/assets/javascripts/service-worker.js.erb
@@ -65,6 +65,10 @@ self.addEventListener('activate', function(event) {
 });
 
 self.addEventListener('fetch', function(event) {
+  // Bypass service workers if this is a url with a token param
+  if(/\?.*token/i.test(event.request.url)) {
+    return;
+  }
   // We only want to call event.respondWith() if this is a navigation request
   // for an HTML page.
   // request.mode of 'navigate' is unfortunately not supported in Chrome


### PR DESCRIPTION
disable service workers on safari

bypass serviceworker network if this is a URL with a token param