### PR TITLE
Fix super-wide tables in Firefox

### DIFF
--- a/app/assets/stylesheets/common/admin/dashboard_next.scss
+++ b/app/assets/stylesheets/common/admin/dashboard_next.scss
@@ -17,6 +17,7 @@
 
     .section-column {
       min-width: calc(50% - .5em);
+      max-width: 100%;
 
       @include small-width  {
         min-width: 100%;


### PR DESCRIPTION
In Firefox (tested in Fx61), the "activity metrics" and related tables can become stupendously wide. Adding a `max-width` resolves this issue.