### PR TITLE
Add plugin outlet in admin theme list

### DIFF
--- a/app/assets/javascripts/admin/templates/customize-themes.hbs
+++ b/app/assets/javascripts/admin/templates/customize-themes.hbs
@@ -5,6 +5,7 @@
     {{#each sortedThemes as |theme|}}
       <li>
         {{#link-to 'adminCustomizeThemes.show' theme replace=true}}
+          {{plugin-outlet name="admin-customize-themes-list-item" connectorTagName='span' args=(hash theme=theme)}}
           {{theme.name}}
           {{#if theme.user_selectable}}
             {{d-icon "user"}}

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -8,6 +8,7 @@ class Theme < ActiveRecord::Base
 
   @cache = DistributedCache.new('theme')
 
+  belongs_to :user
   belongs_to :color_scheme
   has_many :theme_fields, dependent: :destroy
   has_many :theme_settings, dependent: :destroy

--- a/app/serializers/theme_serializer.rb
+++ b/app/serializers/theme_serializer.rb
@@ -58,6 +58,8 @@ end
 class ThemeSerializer < ChildThemeSerializer
   attributes :color_scheme, :color_scheme_id, :user_selectable, :remote_theme_id, :settings
 
+  has_one :user, serializer: UserNameSerializer, embed: :object
+
   has_many :theme_fields, serializer: ThemeFieldSerializer, embed: :objects
   has_many :child_themes, serializer: ChildThemeSerializer, embed: :objects
   has_one :remote_theme, serializer: RemoteThemeSerializer, embed: :objects


### PR DESCRIPTION
This will be used by discourse-theme-creator to add avatars next to each theme.

Also adds `belongs_to :user` to the theme model, and adds the theme owner to the serializer