### PR TITLE
FIX for bucket name in GlobalSetting with folder

### DIFF
--- a/app/models/global_setting.rb
+++ b/app/models/global_setting.rb
@@ -85,6 +85,10 @@ class GlobalSetting
       end) == :true
   end
 
+  def self.s3_bucket_name
+    @s3_bucket_name ||= s3_bucket.downcase.split("/")[0]
+  end
+
   # for testing
   def self.reset_s3_cache!
     @use_s3 = nil

--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -133,7 +133,7 @@ class SiteSetting < ActiveRecord::Base
     end
 
     def self.absolute_base_url
-      bucket = SiteSetting.enable_s3_uploads ? Discourse.store.s3_bucket_name : GlobalSetting.s3_bucket
+      bucket = SiteSetting.enable_s3_uploads ? Discourse.store.s3_bucket_name : GlobalSetting.s3_bucket_name
 
       # cf. http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
       if SiteSetting.Upload.s3_region == "us-east-1"


### PR DESCRIPTION
When `s3_bucket="bucket/folder` in discourse.conf, absolute_base_url
was bucket/folder.s3-region.amazonaws.com

These names are bad, but this mirrors the s3_bucket/s3_bucket_name in
S3Store

N.B. that nearby s3_upload_bucket _should_ include the folder