### PR TITLE
allow adding tags as a custom subject format for emails

### DIFF
--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -446,7 +446,7 @@ class UserNotifications < ActionMailer::Base
     # tag names
     if opts[:show_tags_in_subject] && post.topic_id
       tags = Topic.find_by(id: post.topic_id)&.tags.first(3)
-      show_tags_in_subject = tags.any? ? tags.map{ |t| "[#{t.name}]" }.join : nil
+      show_tags_in_subject = tags.any? ? tags.map { |t| "[#{t.name}]" }.join : nil
     end
 
     if post.topic.private_message?

--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -446,7 +446,7 @@ class UserNotifications < ActionMailer::Base
     # tag names
     if opts[:show_tags_in_subject] && post.topic_id
       tags = Topic.find_by(id: post.topic_id)&.tags.first(3)
-      show_tags_in_subject = tags.any? ? tags.map { |t| "[#{t.name}]" }.join : nil
+      show_tags_in_subject = tags.any? ? tags.map { |t| "[#{t.name}]" }.join(" ") : nil
     end
 
     if post.topic.private_message?

--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -223,6 +223,7 @@ class UserNotifications < ActionMailer::Base
     opts[:allow_reply_by_email] = true
     opts[:use_site_subject] = true
     opts[:show_category_in_subject] = true
+    opts[:show_tags_in_subject] = true
     notification_email(user, opts)
   end
 
@@ -230,6 +231,7 @@ class UserNotifications < ActionMailer::Base
     opts[:allow_reply_by_email] = true
     opts[:use_site_subject] = true
     opts[:show_category_in_subject] = true
+    opts[:show_tags_in_subject] = true
     notification_email(user, opts)
   end
 
@@ -237,6 +239,7 @@ class UserNotifications < ActionMailer::Base
     opts[:allow_reply_by_email] = true
     opts[:use_site_subject] = true
     opts[:show_category_in_subject] = true
+    opts[:show_tags_in_subject] = true
     notification_email(user, opts)
   end
 
@@ -244,6 +247,7 @@ class UserNotifications < ActionMailer::Base
     opts[:allow_reply_by_email] = true
     opts[:use_site_subject] = true
     opts[:show_category_in_subject] = true
+    opts[:show_tags_in_subject] = true
     notification_email(user, opts)
   end
 
@@ -251,6 +255,7 @@ class UserNotifications < ActionMailer::Base
     opts[:allow_reply_by_email] = true
     opts[:use_site_subject] = true
     opts[:show_category_in_subject] = true
+    opts[:show_tags_in_subject] = true
     notification_email(user, opts)
   end
 
@@ -259,6 +264,7 @@ class UserNotifications < ActionMailer::Base
     opts[:use_site_subject] = true
     opts[:add_re_to_subject] = true
     opts[:show_category_in_subject] = true
+    opts[:show_tags_in_subject] = true
     notification_email(user, opts)
   end
 
@@ -267,6 +273,7 @@ class UserNotifications < ActionMailer::Base
     opts[:use_site_subject] = true
     opts[:add_re_to_subject] = true
     opts[:show_category_in_subject] = false
+    opts[:show_tags_in_subject] = false
     opts[:show_group_in_subject] = true if SiteSetting.group_in_subject
 
     # We use the 'user_posted' event when you are emailed a post in a PM.
@@ -285,6 +292,7 @@ class UserNotifications < ActionMailer::Base
     opts[:allow_reply_by_email] = false
     opts[:use_invite_template] = true
     opts[:show_category_in_subject] = true
+    opts[:show_tags_in_subject] = true
     notification_email(user, opts)
   end
 
@@ -299,6 +307,7 @@ class UserNotifications < ActionMailer::Base
       use_site_subject: true,
       add_re_to_subject: true,
       show_category_in_subject: true,
+      show_tags_in_subject: true,
       notification_type: "posted",
       notification_data_hash: {
         original_username: post.user.username,
@@ -382,6 +391,7 @@ class UserNotifications < ActionMailer::Base
       use_site_subject: opts[:use_site_subject],
       add_re_to_subject: opts[:add_re_to_subject],
       show_category_in_subject: opts[:show_category_in_subject],
+      show_tags_in_subject: opts[:show_tags_in_subject],
       show_group_in_subject: opts[:show_group_in_subject],
       notification_type: notification_type,
       use_invite_template: opts[:use_invite_template],
@@ -431,6 +441,14 @@ class UserNotifications < ActionMailer::Base
       end
     else
       show_category_in_subject = nil
+    end
+
+    # tag names
+    tags = Topic.find_by(id: post.topic_id)&.tags
+    if opts[:show_tags_in_subject] && post.topic_id && tags
+      show_tags_in_subject = tags.map{ |t| "[#{t.name}]" }.join
+    else
+      show_tags_in_subject = nil
     end
 
     if post.topic.private_message?
@@ -560,6 +578,7 @@ class UserNotifications < ActionMailer::Base
       use_site_subject: use_site_subject,
       add_re_to_subject: add_re_to_subject,
       show_category_in_subject: show_category_in_subject,
+      show_tags_in_subject: show_tags_in_subject,
       private_reply: post.topic.private_message?,
       subject_pm: subject_pm,
       participants: participants,

--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -444,11 +444,9 @@ class UserNotifications < ActionMailer::Base
     end
 
     # tag names
-    tags = Topic.find_by(id: post.topic_id)&.tags
-    if opts[:show_tags_in_subject] && post.topic_id && tags
-      show_tags_in_subject = tags.map{ |t| "[#{t.name}]" }.join
-    else
-      show_tags_in_subject = nil
+    if opts[:show_tags_in_subject] && post.topic_id
+      tags = Topic.find_by(id: post.topic_id)&.tags.first(3)
+      show_tags_in_subject = tags.any? ? tags.map{ |t| "[#{t.name}]" }.join : nil
     end
 
     if post.topic.private_message?

--- a/lib/email/message_builder.rb
+++ b/lib/email/message_builder.rb
@@ -64,7 +64,7 @@ module Email
         subject.gsub!("%{optional_re}", @opts[:add_re_to_subject] ? I18n.t('subject_re', @template_args) : '')
         subject.gsub!("%{optional_pm}", @opts[:private_reply] ? @template_args[:subject_pm] : '')
         subject.gsub!("%{optional_cat}", @template_args[:show_category_in_subject] ? "[#{@template_args[:show_category_in_subject]}] " : '')
-        subject.gsub!("%{optional_tag}", @template_args[:show_tags_in_subject] ? "#{@template_args[:show_tags_in_subject]} " : '')
+        subject.gsub!("%{optional_tags}", @template_args[:show_tags_in_subject] ? "#{@template_args[:show_tags_in_subject]} " : '')
         subject.gsub!("%{topic_title}", @template_args[:topic_title]) if @template_args[:topic_title] # must be last for safety
       else
         subject = @opts[:subject]

--- a/lib/email/message_builder.rb
+++ b/lib/email/message_builder.rb
@@ -64,6 +64,7 @@ module Email
         subject.gsub!("%{optional_re}", @opts[:add_re_to_subject] ? I18n.t('subject_re', @template_args) : '')
         subject.gsub!("%{optional_pm}", @opts[:private_reply] ? @template_args[:subject_pm] : '')
         subject.gsub!("%{optional_cat}", @template_args[:show_category_in_subject] ? "[#{@template_args[:show_category_in_subject]}] " : '')
+        subject.gsub!("%{optional_tag}", @template_args[:show_tags_in_subject] ? "#{@template_args[:show_tags_in_subject]} " : '')
         subject.gsub!("%{topic_title}", @template_args[:topic_title]) if @template_args[:topic_title] # must be last for safety
       else
         subject = @opts[:subject]

--- a/spec/mailers/user_notifications_spec.rb
+++ b/spec/mailers/user_notifications_spec.rb
@@ -213,7 +213,9 @@ describe UserNotifications do
   describe '.user_replied' do
     let(:response_by_user) { Fabricate(:user, name: "John Doe") }
     let(:category) { Fabricate(:category, name: 'India') }
-    let(:topic) { Fabricate(:topic, category: category) }
+    let(:tag1) { Fabricate(:tag, name: 'Taggo') }
+    let(:tag2) { Fabricate(:tag, name: 'Taggie') }
+    let(:topic) { Fabricate(:topic, category: category, tags: [tag1, tag2]) }
     let(:post) { Fabricate(:post, topic: topic, raw: 'This is My super duper cool topic') }
     let(:response) { Fabricate(:post, reply_to_post_number: 1, topic: post.topic, user: response_by_user) }
     let(:user) { Fabricate(:user) }
@@ -222,6 +224,7 @@ describe UserNotifications do
     it 'generates a correct email' do
 
       # Fabricator is not fabricating this ...
+      SiteSetting.email_subject = "[%{site_name}] %{optional_pm}%{optional_cat}%{optional_tag}%{topic_title}"
       SiteSetting.enable_names = true
       SiteSetting.display_name_on_posts = true
       mail = UserNotifications.user_replied(response.user,
@@ -234,6 +237,10 @@ describe UserNotifications do
 
       # subject should include category name
       expect(mail.subject).to match(/India/)
+
+      # subject should include tag names
+      expect(mail.subject).to match(/Taggo/)
+      expect(mail.subject).to match(/Taggie/)
 
       mail_html = mail.html_part.to_s
 

--- a/spec/mailers/user_notifications_spec.rb
+++ b/spec/mailers/user_notifications_spec.rb
@@ -224,7 +224,7 @@ describe UserNotifications do
     it 'generates a correct email' do
 
       # Fabricator is not fabricating this ...
-      SiteSetting.email_subject = "[%{site_name}] %{optional_pm}%{optional_cat}%{optional_tag}%{topic_title}"
+      SiteSetting.email_subject = "[%{site_name}] %{optional_pm}%{optional_cat}%{optional_tags}%{topic_title}"
       SiteSetting.enable_names = true
       SiteSetting.display_name_on_posts = true
       mail = UserNotifications.user_replied(response.user,


### PR DESCRIPTION
Meta: https://meta.discourse.org/t/allow-adding-tags-as-a-custom-subject-format-for-emails/84424