### PR TITLE
SearchLog: Do not store IP of logged in users, add retention policy

### DIFF
--- a/app/models/search_log.rb
+++ b/app/models/search_log.rb
@@ -41,6 +41,7 @@ class SearchLog < ActiveRecord::Base
     search_type = search_types[search_type]
     return [:error] unless search_type.present? && ip_address.present?
 
+    ip_address = nil if user_id
     key = redis_key(user_id: user_id, ip_address: ip_address)
 
     result = nil
@@ -143,7 +144,7 @@ end
 #  id                 :integer          not null, primary key
 #  term               :string           not null
 #  user_id            :integer
-#  ip_address         :inet             not null
+#  ip_address         :inet
 #  search_result_id   :integer
 #  search_type        :integer          not null
 #  created_at         :datetime         not null

--- a/app/models/search_log.rb
+++ b/app/models/search_log.rb
@@ -1,7 +1,7 @@
 require_dependency 'enum'
 
 class SearchLog < ActiveRecord::Base
-  validates_presence_of :term, :ip_address
+  validates_presence_of :term
 
   def self.search_types
     @search_types ||= Enum.new(

--- a/app/models/search_log.rb
+++ b/app/models/search_log.rb
@@ -134,6 +134,7 @@ class SearchLog < ActiveRecord::Base
     if search_id.present?
       SearchLog.where('id < ?', search_id[0]).delete_all
     end
+    SearchLog.where('created_at < TIMESTAMP ?', SiteSetting.search_query_log_max_retention_days.days.ago).delete_all
   end
 end
 

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1067,6 +1067,7 @@ en:
     search_recent_posts_size: "How many recent posts to keep in the index"
     log_search_queries: "Log search queries performed by users"
     search_query_log_max_size: "Maximum amount of search queries to keep"
+    search_query_log_max_retention_days: "Maximum amount of time to keep search queries, in days. Default is 3 years (1095 days)."
     allow_uncategorized_topics: "Allow topics to be created without a category. WARNING: If there are any uncategorized topics, you must recategorize them before turning this off."
     allow_duplicate_topic_titles: "Allow topics with identical, duplicate titles."
     unique_posts_mins: "How many minutes before a user can make a post with the same content again"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1329,6 +1329,9 @@ search:
   search_query_log_max_size:
     default: 1000000
     max: 1000000
+  search_query_log_max_retention_days:
+    default: 1095 # 3 years
+    max: 1825 # 5 years
 
 uncategorized:
   version_checks:

--- a/db/migrate/20180521184439_allow_null_ip_search_log.rb
+++ b/db/migrate/20180521184439_allow_null_ip_search_log.rb
@@ -1,0 +1,13 @@
+class AllowNullIpSearchLog < ActiveRecord::Migration[5.1]
+  def up
+    begin
+      Migration::SafeMigrate.disable!
+      change_column :search_logs, :ip_address, :inet, null: true
+    ensure
+      Migration::SafeMigrate.enable!
+    end
+  end
+
+  def down
+  end
+end

--- a/spec/models/search_log_spec.rb
+++ b/spec/models/search_log_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe SearchLog, type: :model do
         log = SearchLog.find(log_id)
         expect(log.term).to eq('hello')
         expect(log.search_type).to eq(SearchLog.search_types[:full_page])
-        expect(log.ip_address).to eq('192.168.0.1')
+        expect(log.ip_address).to eq(nil)
         expect(log.user_id).to eq(user.id)
 
         action, updated_log_id = SearchLog.log(
@@ -183,11 +183,12 @@ RSpec.describe SearchLog, type: :model do
   end
 
   context "trending" do
+    let(:user) { Fabricate(:user) }
     before do
       SearchLog.log(term: 'ruby', search_type: :header, ip_address: '127.0.0.1')
       SearchLog.log(term: 'php', search_type: :header, ip_address: '127.0.0.1')
       SearchLog.log(term: 'java', search_type: :header, ip_address: '127.0.0.1')
-      SearchLog.log(term: 'ruby', search_type: :header, ip_address: '127.0.0.1', user_id: Fabricate(:user).id)
+      SearchLog.log(term: 'ruby', search_type: :header, ip_address: '127.0.0.1', user_id: user.id)
       SearchLog.log(term: 'swift', search_type: :header, ip_address: '127.0.0.1')
       SearchLog.log(term: 'ruby', search_type: :header, ip_address: '127.0.0.2')
     end
@@ -207,6 +208,7 @@ RSpec.describe SearchLog, type: :model do
       expect(top_trending.click_through).to eq(0)
 
       SearchLog.where(term: 'ruby', ip_address: '127.0.0.1').update_all(search_result_id: 12)
+      SearchLog.where(term: 'ruby', user_id: user.id).update_all(search_result_id: 12)
       SearchLog.where(term: 'ruby', ip_address: '127.0.0.2').update_all(search_result_id: 24)
       top_trending = SearchLog.trending.first
       expect(top_trending.click_through).to eq(3)


### PR DESCRIPTION
Also set a time-based retention policy on search logs, in addition to the size-based retention policy.