### PR TITLE
FEATURE: Support referrerPolicy on embed iframe

### DIFF
--- a/public/javascripts/embed.js
+++ b/public/javascripts/embed.js
@@ -4,7 +4,7 @@
   var comments = document.getElementById('discourse-comments');
   var iframe = document.createElement('iframe');
 
-  ['discourseUrl', 'discourseEmbedUrl', 'discourseUserName'].forEach(function(i) {
+  ['discourseUrl', 'discourseEmbedUrl', 'discourseUserName', 'discourseReferrerPolicy'].forEach(function(i) {
     if (window[i]) { DE[i] = DE[i] || window[i]; }
   });
 
@@ -44,6 +44,10 @@
   iframe.width = "100%";
   iframe.frameBorder = "0";
   iframe.scrolling = "no";
+  if (DE.discourseReferrerPolicy) {
+    // See https://www.w3.org/TR/html5/semantics-embedded-content.html#the-iframe-element
+    iframe.referrerPolicy = DE.discourseReferrerPolicy;
+  }
   comments.appendChild(iframe);
 
   // Thanks http://amendsoft-javascript.blogspot.ca/2010/04/find-x-and-y-coordinate-of-html-control.html


### PR DESCRIPTION
This commit adds a new property "discourseReferrerPolicy" to the
set of supported configuration properties for the comment embed
script. If provided the value will be used to set the "referrerPolicy"
attribute on the iframe created to display the comments. This in turn
will allow embedding pages to define a more lenient referer policy on
the embed iframe for pages whose default policy is so strict it
keeps the comment embed from working.

Example:

  * Setup:
    * Discourse hosted at discourse.example.com
    * Comments embedded at example.com
    * Referrer-Policy at example.com set to 'same-origin'
  * Without this commit:
    * Loading the comments fails due to the referer being empty
  * With this commit and no adjusted configuration:
    * Loading the comments fails due to the referer being empty
      (= same behaviour as without the commit)
  * With this commit and DiscourseEmbed.discourseReferrerPolicy =
    'no-referrer-when-downgrade' as additional configuration:
    * Loading the comments succeeds

Note that this change is of special interest for embedding pages
wanting to restrict data flows under the terms of the GDPR since
it allows selectively whitelisting comment embeds while preventing
referer leaking by default.