### PR TITLE
UX: The "enable 2FA" string was hard to translate

### DIFF
--- a/app/assets/javascripts/discourse/components/discourse-linked-text.js.es6
+++ b/app/assets/javascripts/discourse/components/discourse-linked-text.js.es6
@@ -1,0 +1,18 @@
+import { default as computed } from 'ember-addons/ember-computed-decorators';
+
+export default Ember.Component.extend({
+  tagName: 'span',
+
+  @computed("text")
+  translatedText(text) {
+    if (text) return I18n.t(text);
+  },
+
+  click(event) {
+    if (event.target.tagName.toUpperCase() === 'A') {
+      this.sendAction("action", this.get("actionParam"));
+    }
+
+    return false;
+  }
+});

--- a/app/assets/javascripts/discourse/controllers/preferences/account.js.es6
+++ b/app/assets/javascripts/discourse/controllers/preferences/account.js.es6
@@ -4,6 +4,7 @@ import { default as computed } from "ember-addons/ember-computed-decorators";
 import PreferencesTabController from "discourse/mixins/preferences-tab-controller";
 import { setting } from 'discourse/lib/computed';
 import { popupAjaxError } from 'discourse/lib/ajax-error';
+import showModal from 'discourse/lib/show-modal';
 
 export default Ember.Controller.extend(CanCheckEmails, PreferencesTabController, {
 
@@ -39,11 +40,6 @@ export default Ember.Controller.extend(CanCheckEmails, PreferencesTabController,
   @computed()
   canChangePassword() {
     return !this.siteSettings.enable_sso && this.siteSettings.enable_local_logins;
-  },
-
-  @computed
-  showTwoFactorModalText() {
-    return I18n.t('user.second_factor.title').toLowerCase();
   },
 
   actions: {
@@ -105,6 +101,10 @@ export default Ember.Controller.extend(CanCheckEmails, PreferencesTabController,
           }
         ];
       bootbox.dialog(message, buttons, {"classes": "delete-account"});
+    },
+
+    showTwoFactorModal() {
+      showModal('second-factor-intro');
     }
   }
 });

--- a/app/assets/javascripts/discourse/routes/preferences.js.es6
+++ b/app/assets/javascripts/discourse/routes/preferences.js.es6
@@ -15,10 +15,6 @@ export default RestrictedUserRoute.extend({
   },
 
   actions: {
-    showTwoFactorModal() {
-      showModal('second-factor-intro');
-    },
-
     showAvatarSelector() {
       showModal('avatar-selector');
 

--- a/app/assets/javascripts/discourse/templates/components/discourse-linked-text.hbs
+++ b/app/assets/javascripts/discourse/templates/components/discourse-linked-text.hbs
@@ -1,0 +1,1 @@
+{{{translatedText}}}

--- a/app/assets/javascripts/discourse/templates/preferences/account.hbs
+++ b/app/assets/javascripts/discourse/templates/preferences/account.hbs
@@ -71,9 +71,7 @@
     {{#if model.second_factor_enabled}}
       {{i18n 'user.second_factor.disable'}}
     {{else}}
-      {{i18n 'enable'}}
-      <a href {{action "showTwoFactorModal"}}>{{showTwoFactorModalText}}</a>
-      {{i18n 'user.second_factor.enable'}}
+      {{discourse-linked-text action="showTwoFactorModal" text="user.second_factor.enable"}}
     {{/if}}
 
     {{#if isCurrentUser}}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -741,7 +741,7 @@ en:
       second_factor:
         title: "Two Factor Authentication"
         disable: "Disable two factor authentication"
-        enable: "for enhanced account security"
+        enable: "Enable <a href>two factor authentication</a> for enhanced account security"
         confirm_password_description: "Please confirm your password to continue"
         label: "Code"
         enable_description: |


### PR DESCRIPTION
The "Enable two factor authentication for enhanced account security" was split into 3 parts which made it really hard to translate.

I wanted to do something like `{{{i18n 'user.second_factor.enable' link=(action "showTwoFactorModal")}}}`, but that didn't work. So, this is the next best solution I could think of.