### PR TITLE
Add plugin outlet create-account-after-password

### DIFF
--- a/app/assets/javascripts/discourse/templates/modal/create-account.hbs
+++ b/app/assets/javascripts/discourse/templates/modal/create-account.hbs
@@ -53,6 +53,7 @@
           {{/if}}
 
           {{plugin-outlet name="create-account-before-password"
+                          noTags=true
                           args=(hash accountName=accountName
                                      accountUsername=accountUsername
                                      accountPassword=accountPassword
@@ -83,6 +84,13 @@
               {{input value=accountChallenge id="new-account-challenge"}}
             </td>
           </tr>
+
+          {{plugin-outlet name="create-account-after-password"
+                          noTags=true
+                          args=(hash accountName=accountName
+                                     accountUsername=accountUsername
+                                     accountPassword=accountPassword
+                                     userFields=userFields)}}
 
           </table>
 


### PR DESCRIPTION
There's a plugin outlet called `create-account-before-password`, so I added `create-account-after-password` (which I needed for a plugin I'm developing). I also added `noTags=true` to both outlets. Since both outlets are inside a `table` element, wrapping them in the default `span` isn't valid html.

(Also https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/components/plugin-outlet.js.es6#L39)