### PR TITLE
DEV: improve design of site setting default provider

### DIFF
--- a/lib/site_setting_extension.rb
+++ b/lib/site_setting_extension.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_dependency 'site_settings/deprecated_settings'
 require_dependency 'site_settings/type_supervisor'
 require_dependency 'site_settings/defaults_provider'
@@ -5,12 +7,54 @@ require_dependency 'site_settings/db_provider'
 
 module SiteSettingExtension
   include SiteSettings::DeprecatedSettings
-  extend Forwardable
 
-  def_delegator :defaults, :site_locale, :default_locale
-  def_delegator :defaults, :site_locale=, :default_locale=
-  def_delegator :defaults, :has_setting?
-  def_delegators 'SiteSettings::TypeSupervisor', :types, :supported_types
+  # support default_locale being set via global settings
+  # this also adds support for testing the extension and global settings
+  # for site locale
+  def self.extended(klass)
+    if GlobalSetting.respond_to?(:default_locale) && GlobalSetting.default_locale.present?
+      klass.send :setup_shadowed_methods, :default_locale, GlobalSetting.default_locale
+    end
+  end
+
+  # we need a default here to support defaults per locale
+  def default_locale=(val)
+    val = val.to_s
+    raise Discourse::InvalidParameters.new(:value) unless LocaleSiteSetting.valid_value?(val)
+    if val != self.default_locale
+      add_override!(:default_locale, val)
+      refresh!
+      Discourse.request_refresh!
+    end
+  end
+
+  def default_locale?
+    true
+  end
+
+  # set up some sort of default so we can look stuff up
+  def default_locale
+    # note optimised cause this is called a lot so avoiding .presence which
+    # adds 2 method calls
+    locale = current[:default_locale]
+    if locale && !locale.blank?
+      locale
+    else
+      SiteSettings::DefaultsProvider::DEFAULT_LOCALE
+    end
+  end
+
+  def has_setting?(v)
+    defaults.has_setting?(v)
+  end
+
+  def supported_types
+    SiteSettings::TypeSupervisor.supported_types
+  end
+
+  def types
+    SiteSettings::TypeSupervisor.types
+  end
 
   def listen_for_changes=(val)
     @listen_for_changes = val
@@ -55,11 +99,11 @@ module SiteSettingExtension
   end
 
   def refresh_settings
-    @refresh_settings ||= []
+    @refresh_settings ||= [:default_locale]
   end
 
   def client_settings
-    @client_settings ||= []
+    @client_settings ||= [:default_locale]
   end
 
   def previews
@@ -69,13 +113,17 @@ module SiteSettingExtension
   def setting(name_arg, default = nil, opts = {})
     name = name_arg.to_sym
 
+    if name == :default_locale
+      raise ArgumentError.new("Other settings depend on default locale, you can not configure it like this")
+    end
+
     shadowed_val = nil
 
     mutex.synchronize do
       defaults.load_setting(
         name,
         default,
-        opts.extract!(*SiteSettings::DefaultsProvider::CONSUMED_OPTS)
+        opts.delete(:locale_default)
       )
 
       categories[name] = opts[:category] || :uncategorized
@@ -121,7 +169,7 @@ module SiteSettingExtension
 
   def settings_hash
     result = {}
-    defaults.each_key do |s|
+    defaults.all.keys.each do |s|
       result[s] = send(s).to_s
     end
     result
@@ -139,21 +187,35 @@ module SiteSettingExtension
 
   # Retrieve all settings
   def all_settings(include_hidden = false)
-    defaults
+
+    locale_setting_hash =
+    {
+      setting: 'default_locale',
+      default: SiteSettings::DefaultsProvider::DEFAULT_LOCALE,
+      category: 'required',
+      description: description('default_locale'),
+      type: SiteSetting.types[SiteSetting.types[:enum]],
+      preview: nil,
+      value: self.default_locale,
+      valid_values: LocaleSiteSetting.values,
+      translate_names: LocaleSiteSetting.translate_names?
+    }
+
+    defaults.all(default_locale)
       .reject { |s, _| !include_hidden && hidden_settings.include?(s) }
       .map do |s, v|
       value = send(s)
       opts = {
         setting: s,
         description: description(s),
-        default: defaults[s].to_s,
+        default: defaults.get(s, default_locale).to_s,
         value: value.to_s,
         category: categories[s],
         preview: previews[s]
       }.merge(type_supervisor.type_hash(s))
 
       opts
-    end.unshift(defaults.locale_setting_hash)
+    end.unshift(locale_setting_hash)
   end
 
   def description(setting)
@@ -176,7 +238,7 @@ module SiteSettingExtension
         [s.name.to_sym, type_supervisor.to_rb_value(s.name, s.value, s.data_type)]
       }.to_a.flatten)]
 
-      defaults_view = defaults.all
+      defaults_view = defaults.all(new_hash[:default_locale])
 
       # add locale default and defaults based on default_locale, cause they are cached
       new_hash = defaults_view.merge!(new_hash)
@@ -233,7 +295,7 @@ module SiteSettingExtension
 
   def remove_override!(name)
     provider.destroy(name)
-    current[name] = defaults[name]
+    current[name] = defaults.get(name, default_locale)
     clear_cache!
   end
 

--- a/lib/site_settings/defaults_provider.rb
+++ b/lib/site_settings/defaults_provider.rb
@@ -1,31 +1,23 @@
+# frozen_string_literal: true
+
 module SiteSettings; end
 
 # A cache for providing default value based on site locale
 class SiteSettings::DefaultsProvider
-  include Enumerable
-
-  CONSUMED_OPTS = %i[default locale_default].freeze
-  DEFAULT_LOCALE_KEY = :default_locale
-  DEFAULT_LOCALE = 'en'.freeze
-  DEFAULT_CATEGORY = 'required'.freeze
-
-  @@site_locales ||= DistributedCache.new('site_locales')
+  DEFAULT_LOCALE = 'en'
 
   def initialize(site_setting)
     @site_setting = site_setting
-    @site_setting.refresh_settings << DEFAULT_LOCALE_KEY
     @defaults = {}
     @defaults[DEFAULT_LOCALE.to_sym] = {}
-
-    refresh_site_locale!
   end
 
-  def load_setting(name_arg, value, opts = {})
+  def load_setting(name_arg, value, locale_defaults)
     name = name_arg.to_sym
     @defaults[DEFAULT_LOCALE.to_sym][name] = value
 
-    if (locale_default = opts[:locale_default])
-      locale_default.each do |locale, v|
+    if (locale_defaults)
+      locale_defaults.each do |locale, v|
         locale = locale.to_sym
         @defaults[locale] ||= {}
         @defaults[locale][name] = v
@@ -34,15 +26,19 @@ class SiteSettings::DefaultsProvider
   end
 
   def db_all
-    @site_setting.provider.all.delete_if { |s| s.name.to_sym == DEFAULT_LOCALE_KEY }
+    @site_setting.provider.all
   end
 
-  def all
-    @defaults[DEFAULT_LOCALE.to_sym].merge(@defaults[self.site_locale.to_sym] || {})
+  def all(locale = nil)
+    if locale
+      @defaults[DEFAULT_LOCALE.to_sym].merge(@defaults[locale.to_sym] || {})
+    else
+      @defaults[DEFAULT_LOCALE.to_sym].dup
+    end
   end
 
-  def get(name)
-    @defaults.dig(self.site_locale.to_sym, name.to_sym) ||
+  def get(name, locale = DEFAULT_LOCALE)
+    @defaults.dig(locale.to_sym, name.to_sym) ||
       @defaults.dig(DEFAULT_LOCALE.to_sym, name.to_sym)
   end
   alias [] get
@@ -50,81 +46,25 @@ class SiteSettings::DefaultsProvider
   # Used to override site settings in dev/test env
   def set_regardless_of_locale(name, value)
     name = name.to_sym
-    if @site_setting.has_setting?(name)
+    if name == :default_locale || @site_setting.has_setting?(name)
       @defaults.each { |_, hash| hash.delete(name) }
       @defaults[DEFAULT_LOCALE.to_sym][name] = value
       value, type = @site_setting.type_supervisor.to_db_value(name, value)
-      @defaults[self.site_locale.to_sym] ||= {}
-      @defaults[self.site_locale.to_sym][name] = @site_setting.type_supervisor.to_rb_value(name, value, type)
+      @defaults[SiteSetting.default_locale.to_sym] ||= {}
+      @defaults[SiteSetting.default_locale.to_sym][name] = @site_setting.type_supervisor.to_rb_value(name, value, type)
     else
       raise ArgumentError.new("No setting named '#{name}' exists")
     end
   end
 
-  def site_locale
-    @@site_locales[current_db]
-  end
-
-  def site_locale=(val)
-    val = val.to_s
-    raise Discourse::InvalidParameters.new(:value) unless LocaleSiteSetting.valid_value?(val)
-
-    if val != @@site_locales[current_db]
-      @site_setting.provider.save(DEFAULT_LOCALE_KEY, val, SiteSetting.types[:string])
-      refresh_site_locale!
-      @site_setting.refresh!
-      Discourse.request_refresh!
-    end
-
-    @@site_locales[current_db]
-  end
-
-  def each(&block)
-    self.all.each do |key, value|
-      block.call(key.to_sym, value)
-    end
-  end
-
-  def locale_setting_hash
-    {
-      setting: DEFAULT_LOCALE_KEY,
-      default: DEFAULT_LOCALE,
-      category: DEFAULT_CATEGORY,
-      description: @site_setting.description(DEFAULT_LOCALE_KEY),
-      type: SiteSetting.types[SiteSetting.types[:enum]],
-      preview: nil,
-      value: @@site_locales[current_db],
-      valid_values: LocaleSiteSetting.values,
-      translate_names: LocaleSiteSetting.translate_names?
-    }
-  end
-
-  def refresh_site_locale!
-    RailsMultisite::ConnectionManagement.each_connection do |db|
-      @@site_locales[db] =
-        if GlobalSetting.respond_to?(DEFAULT_LOCALE_KEY) &&
-            (global_val = GlobalSetting.send(DEFAULT_LOCALE_KEY)) &&
-            !global_val.blank?
-          global_val
-        elsif (db_val = @site_setting.provider.find(DEFAULT_LOCALE_KEY))
-          db_val.value.to_s
-        else
-          DEFAULT_LOCALE
-        end
-
-      @@site_locales[db]
-    end
-  end
-
   def has_setting?(name)
-    has_key?(name.to_sym) || has_key?("#{name.to_s}?".to_sym)
+    has_key?(name.to_sym) || has_key?("#{name.to_s}?".to_sym) || name.to_sym == :default_locale
   end
 
   private
 
   def has_key?(name)
-    @defaults[self.site_locale.to_sym]&.key?(name) ||
-      @defaults[DEFAULT_LOCALE.to_sym].key?(name) || name == DEFAULT_LOCALE_KEY
+    @defaults[DEFAULT_LOCALE.to_sym].key?(name)
   end
 
   def current_db

--- a/spec/components/site_setting_extension_spec.rb
+++ b/spec/components/site_setting_extension_spec.rb
@@ -505,6 +505,15 @@ describe SiteSettingExtension do
   end
 
   describe "shadowed_by_global" do
+
+    context "default_locale" do
+      it "supports adding a default locale via a global" do
+        global_setting :default_locale, 'zh_CN'
+        settings.default_locale = 'en'
+        expect(settings.default_locale).to eq('zh_CN')
+      end
+    end
+
     context "without global setting" do
       before do
         settings.setting(:trout_api_key, 'evil', shadowed_by_global: true)

--- a/spec/controllers/admin/site_settings_controller_spec.rb
+++ b/spec/controllers/admin/site_settings_controller_spec.rb
@@ -12,14 +12,19 @@ describe Admin::SiteSettingsController do
     end
 
     context 'index' do
-      it 'returns success' do
+      it 'returns valid info' do
         get :index, format: :json
+        json = ::JSON.parse(response.body)
+        expect(json).to be_present
         expect(response).to be_success
-      end
 
-      it 'returns JSON' do
-        get :index, format: :json
-        expect(::JSON.parse(response.body)).to be_present
+        expect(json["site_settings"].length).to be > 100
+
+        locale = json["site_settings"].select do |s|
+          s["setting"] == "default_locale"
+        end
+
+        expect(locale.length).to eq(1)
       end
     end
 

--- a/spec/multisite/jobs_spec.rb
+++ b/spec/multisite/jobs_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe "Running Sidekiq Jobs in Multisite" do
 
   before do
     conn.config_filename = "spec/fixtures/multisite/two_dbs.yml"
-    SiteSetting.defaults.refresh_site_locale!
   end
 
   after do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -153,7 +153,6 @@ RSpec.configure do |config|
     SiteSetting.provider.all.each do |setting|
       SiteSetting.remove_override!(setting.name)
     end
-    SiteSetting.defaults.site_locale = SiteSettings::DefaultsProvider::DEFAULT_LOCALE
 
     # very expensive IO operations
     SiteSetting.automatically_download_gravatars = false


### PR DESCRIPTION
This refactors it so "Defaults provider" is only responsible for "defaults"

Locale handling and management of locale settings is moved back into
SiteSettingExtension

This eliminates complex state management using DistributedCache and makes
it way easier to test SiteSettingExtension