### PR TITLE
FIX: don't show dashboard warning when s3 settings are globally configured

### DIFF
--- a/config/discourse_defaults.conf
+++ b/config/discourse_defaults.conf
@@ -175,6 +175,10 @@ s3_access_key_id =
 s3_secret_access_key =
 s3_use_iam_profile = false
 s3_cdn_url =
+enable_s3_uploads =
+enable_s3_backups =
+s3_upload_bucket =
+s3_backup_bucket =
 
 
 ### rate limits apply to all sites

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -896,20 +896,29 @@ files:
   enable_s3_uploads:
     default: false
     client: true
-  s3_use_iam_profile: false
-  s3_access_key_id: ''
+    shadowed_by_global: true
+  s3_use_iam_profile:
+    default: false
+    shadowed_by_global: true
+  s3_access_key_id:
+    default: ''
+    shadowed_by_global: true
   s3_secret_access_key:
     default: ''
     secret: true
+    shadowed_by_global: true
   s3_region:
     default: 'us-east-1'
     enum: 'S3RegionSiteSetting'
+    shadowed_by_global: true
   s3_upload_bucket:
     default: ''
     regex: '^[a-z0-9\-\/]+$' # can't use '.' when using HTTPS
+    shadowed_by_global: true
   s3_cdn_url:
     default: ''
     regex: '^https?:\/\/.+[^\/]$'
+    shadowed_by_global: true
   allow_profile_backgrounds:
     client: true
     default: true


### PR DESCRIPTION
https://meta.discourse.org/t/dashboard-warning-when-s3-backups-are-globally-configured/88872?u=osama