### PR TITLE
Improve user anonymizing

### DIFF
--- a/app/jobs/regular/anonymize_user.rb
+++ b/app/jobs/regular/anonymize_user.rb
@@ -1,0 +1,50 @@
+module Jobs
+  class AnonymizeUser < Jobs::Base
+
+    sidekiq_options queue: 'low'
+
+    def execute(args)
+      @user_id = args[:user_id]
+      @prev_email = args[:prev_email]
+      @anonymize_ip = args[:anonymize_ip]
+
+      make_anonymous
+    end
+
+    def make_anonymous
+      anonymize_ips(@anonymize_ip) if @anonymize_ip
+
+      Invite.with_deleted.where(user_id: @user_id).destroy_all
+      EmailToken.where(user_id: @user_id).destroy_all
+      EmailLog.where(user_id: @user_id).delete_all
+      IncomingEmail.where("user_id = ? OR from_address = ?", @user_id, @prev_email).delete_all
+
+      Post.with_deleted
+        .where(user_id: @user_id)
+        .where.not(raw_email: nil)
+        .update_all(raw_email: nil)
+    end
+
+    def ip_where(column = 'user_id')
+      ["#{column} = :user_id AND ip_address IS NOT NULL", user_id: @user_id]
+    end
+
+    def anonymize_ips(new_ip)
+      IncomingLink.where(ip_where('current_user_id')).update_all(ip_address: new_ip)
+      ScreenedEmail.where(email: @prev_email).update_all(ip_address: new_ip)
+      SearchLog.where(ip_where).update_all(ip_address: new_ip)
+      TopicLinkClick.where(ip_where).update_all(ip_address: new_ip)
+      TopicViewItem.where(ip_where).update_all(ip_address: new_ip)
+      UserHistory.where(ip_where('acting_user_id')).update_all(ip_address: new_ip)
+      UserProfileView.where(ip_where).update_all(ip_address: new_ip)
+
+      # UserHistory for delete_user logs the user's IP. Note this is quite ugly but we don't
+      # have a better way of querying on details right now.
+      UserHistory.where(
+        "action = :action AND details LIKE 'id: #{@user_id}\n%'",
+        action: UserHistory.actions[:delete_user]
+      ).update_all(ip_address: new_ip)
+    end
+
+  end
+end

--- a/app/services/user_anonymizer.rb
+++ b/app/services/user_anonymizer.rb
@@ -47,9 +47,10 @@ class UserAnonymizer
       options.email_direct = false
       options.save
 
-      profile = @user.user_profile
-      profile.destroy if profile
-      @user.create_user_profile
+      if profile = @user.user_profile
+        profile.update(location: nil, website: nil, bio_raw: nil, bio_cooked: nil,
+                       profile_background: nil, card_background: nil)
+      end
 
       @user.user_avatar.try(:destroy)
       @user.twitter_user_info.try(:destroy)

--- a/app/services/user_merger.rb
+++ b/app/services/user_merger.rb
@@ -24,10 +24,11 @@ class UserMerger
   protected
 
   def update_username
-    Jobs::UpdateUsername.new.execute(user_id: @source_user.id,
-                                     old_username: @source_user.username,
-                                     new_username: @target_user.username,
-                                     avatar_template: @target_user.avatar_template)
+    UsernameChanger.update_username(user_id: @source_user.id,
+                                    old_username: @source_user.username,
+                                    new_username: @target_user.username,
+                                    avatar_template: @target_user.avatar_template,
+                                    asynchronous: false)
   end
 
   def move_posts

--- a/app/services/username_changer.rb
+++ b/app/services/username_changer.rb
@@ -13,31 +13,37 @@ class UsernameChanger
     self.new(user, new_username, actor).change
   end
 
-  def change(asynchronous: true)
+  def change(asynchronous: true, run_update_job: true)
     if @actor && @old_username != @new_username
       StaffActionLogger.new(@actor).log_username_change(@user, @old_username, @new_username)
     end
 
     @user.username = @new_username
+
     if @user.save
-
-      args = {
-        user_id: @user.id,
-        old_username: @old_username,
-        new_username: @new_username,
-        avatar_template: @user.avatar_template
-      }
-
-      if asynchronous
-        Jobs.enqueue(:update_username, args)
-      else
-        Jobs::UpdateUsername.new.execute(args)
-      end
-
+      UsernameChanger.update_username(user_id: @user.id,
+                                      old_username: @old_username,
+                                      new_username: @new_username,
+                                      avatar_template: @user.avatar_template,
+                                      asynchronous: asynchronous) if run_update_job
       return true
     end
 
     false
   end
 
+  def self.update_username(user_id:, old_username:, new_username:, avatar_template:, asynchronous: true)
+    args = {
+      user_id: user_id,
+      old_username: old_username,
+      new_username: new_username,
+      avatar_template: avatar_template
+    }
+
+    if asynchronous
+      Jobs.enqueue(:update_username, args)
+    else
+      Jobs::UpdateUsername.new.execute(args)
+    end
+  end
 end

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -73,11 +73,7 @@ task "users:update_posts", [:old_username, :current_username] => [:environment] 
   end
 
   user = find_user(current_username)
-  Jobs::UpdateUsername.new.execute(
-    user_id: user.id,
-    old_username: old_username,
-    new_username: user.username,
-    avatar_template: user.avatar_template)
+  UsernameChanger.update_username(user.id, old_username, user.username, user.avatar_template)
 
   puts "", "Username updated!", ""
 end

--- a/spec/services/user_anonymizer_spec.rb
+++ b/spec/services/user_anonymizer_spec.rb
@@ -23,7 +23,9 @@ describe UserAnonymizer do
   end
 
   describe "make_anonymous" do
-    let(:user) { Fabricate(:user, username: "edward") }
+    let(:original_email) { "edward@example.net" }
+    let(:user) { Fabricate(:user, username: "edward", email: original_email) }
+    let(:another_user) { Fabricate(:evil_trout) }
     subject(:make_anonymous) { described_class.make_anonymous(user, admin) }
 
     it "changes username" do
@@ -201,6 +203,49 @@ describe UserAnonymizer do
       expect(user.api_key).to eq(nil)
     end
 
+    it "removes invites" do
+      Fabricate(:invite, user: user)
+      Fabricate(:invite, user: another_user)
+
+      expect { make_anonymous }.to change { Invite.count }.by(-1)
+      expect(Invite.where(user_id: user.id).count).to eq(0)
+    end
+
+    it "removes email tokens" do
+      Fabricate(:email_token, user: user)
+      Fabricate(:email_token, user: another_user)
+
+      expect { make_anonymous }.to change { EmailToken.count }.by(-1)
+      expect(EmailToken.where(user_id: user.id).count).to eq(0)
+    end
+
+    it "removes email log entries" do
+      Fabricate(:email_log, user: user)
+      Fabricate(:email_log, user: another_user)
+
+      expect { make_anonymous }.to change { EmailLog.count }.by(-1)
+      expect(EmailLog.where(user_id: user.id).count).to eq(0)
+    end
+
+    it "removes incoming emails" do
+      Fabricate(:incoming_email, user: user, from_address: user.email)
+      Fabricate(:incoming_email, from_address: user.email, error: "Some error")
+      Fabricate(:incoming_email, user: another_user, from_address: another_user.email)
+
+      expect { make_anonymous }.to change { IncomingEmail.count }.by(-2)
+      expect(IncomingEmail.where(user_id: user.id).count).to eq(0)
+      expect(IncomingEmail.where(from_address: original_email).count).to eq(0)
+    end
+
+    it "removes raw email from posts" do
+      post1 = Fabricate(:post, user: user, via_email: true, raw_email: "raw email from user")
+      post2 = Fabricate(:post, user: another_user, via_email: true, raw_email: "raw email from another user")
+
+      make_anonymous
+
+      expect(post1.reload).to have_attributes(via_email: true, raw_email: nil)
+      expect(post2.reload).to have_attributes(via_email: true, raw_email: "raw email from another user")
+    end
   end
 
   describe "anonymize_ip" do


### PR DESCRIPTION
**Remove more PII during user anonymizing**
- [x] invite if the user was invited
- [x] email tokens
- [x] incoming emails
- [x] email log entries
- [x] raw emails from posts

**Other improvements**
- [x] Run in sidekiq job
- [x] Use `@anonymized.invalid` instead of `@example.com` as email domain
- [x] Enqueue the `update_username` job after successfully anonymizing the user instead of doing it during the anonymizing which might get rolled back on error.
- [x] Don't delete profile views, because it's not necessary and slows down the process.