### PR TITLE
FIX: do not verify group visibility when checking for mentionable/messageable

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -282,7 +282,7 @@ class GroupsController < ApplicationController
   end
 
   def mentionable
-    group = find_group(:name)
+    group = find_group(:name, ensure_can_see: false)
 
     if group
       render json: { mentionable: Group.mentionable(current_user).where(id: group.id).present? }
@@ -292,7 +292,7 @@ class GroupsController < ApplicationController
   end
 
   def messageable
-    group = find_group(:name)
+    group = find_group(:name, ensure_can_see: false)
 
     if group
       render json: { messageable: Group.messageable(current_user).where(id: group.id).present? }
@@ -468,12 +468,11 @@ class GroupsController < ApplicationController
     params.require(:group).permit(*permitted_params)
   end
 
-  def find_group(param_name)
+  def find_group(param_name, ensure_can_see: true)
     name = params.require(param_name)
     group = Group
     group = group.find_by("lower(name) = ?", name.downcase)
-    guardian.ensure_can_see!(group)
+    guardian.ensure_can_see!(group) if ensure_can_see
     group
   end
-
 end

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -383,19 +383,39 @@ describe GroupsController do
       group.update_attributes!(name: 'test')
 
       get "/groups/test/mentionable.json", params: { name: group.name }
-
       expect(response).to be_success
 
       response_body = JSON.parse(response.body)
       expect(response_body["mentionable"]).to eq(false)
 
-      group.update_attributes!(mentionable_level: Group::ALIAS_LEVELS[:everyone])
+      group.update_attributes!(mentionable_level: Group::ALIAS_LEVELS[:everyone], visibility_level: Group.visibility_levels[:staff])
 
       get "/groups/test/mentionable.json", params: { name: group.name }
       expect(response).to be_success
 
       response_body = JSON.parse(response.body)
       expect(response_body["mentionable"]).to eq(true)
+    end
+  end
+
+  describe '#messageable' do
+    it "should return the right response" do
+      sign_in(user)
+      group.update_attributes!(name: 'test')
+
+      get "/groups/test/messageable.json", params: { name: group.name }
+      expect(response).to be_success
+
+      response_body = JSON.parse(response.body)
+      expect(response_body["messageable"]).to eq(false)
+
+      group.update_attributes!(messageable_level: Group::ALIAS_LEVELS[:everyone], visibility_level: Group.visibility_levels[:staff])
+
+      get "/groups/test/messageable.json", params: { name: group.name }
+      expect(response).to be_success
+
+      response_body = JSON.parse(response.body)
+      expect(response_body["messageable"]).to eq(true)
     end
   end
 


### PR DESCRIPTION
Fixes https://meta.discourse.org/t/urls-for-group-message-error-for-private-groups/70631

@tgxworld Can you review this PR please? Thanks!