### PR TITLE
fix get from url for external uploads without CDN

### DIFF
--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -79,6 +79,8 @@ class Upload < ActiveRecord::Base
     return if url.blank?
     # we store relative urls, so we need to remove any host/cdn
     url = url.sub(Discourse.asset_host, "") if Discourse.asset_host.present? && Discourse.asset_host != SiteSetting.Upload.s3_cdn_url
+    # when using s3 without CDN
+    url = url.sub(/^https?\:/, "") if url.include?(Discourse.store.absolute_base_url) && Discourse.store.external?
     # when using s3, we need to replace with the absolute base url
     url = url.sub(SiteSetting.Upload.s3_cdn_url, Discourse.store.absolute_base_url) if SiteSetting.Upload.s3_cdn_url.present?
 

--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -106,6 +106,13 @@ describe Upload do
         SiteSetting.enable_s3_uploads = false
       end
 
+      it "should return the right upload when using base url (not CDN) for s3" do
+        upload
+        url = "https://#{SiteSetting.s3_upload_bucket}.s3.amazonaws.com#{path}"
+
+        expect(Upload.get_from_url(url)).to eq(upload)
+      end
+
       it "should return the right upload when using a CDN for s3" do
         upload
         s3_cdn_url = 'https://mycdn.slowly.net'


### PR DESCRIPTION
This PR fixes the problem that appears when using S3 for storing uploads (or Azure Blob plugin) without CDN - get_from_url misses video uploads with absolute_base_url, causing them to get orphaned and thombstoned (post_upload record doesn't get created)

Related to this: https://meta.discourse.org/t/azure-blob-storage-plugin/79392/26?u=maja
