### PR TITLE
Prefer throwing a new Error object instead of just a string expression

### DIFF
--- a/app/assets/javascripts/admin/services/admin-tools.js.es6
+++ b/app/assets/javascripts/admin/services/admin-tools.js.es6
@@ -127,7 +127,7 @@ export default Ember.Service.extend({
                 if (result.deleted) {
                   resolve();
                 } else {
-                  throw 'failed to delete';
+                  throw new Error('failed to delete');
                 }
               }).catch(() => {
                 bootbox.alert(I18n.t("admin.user.delete_failed"));

--- a/app/assets/javascripts/discourse/adapters/rest.js.es6
+++ b/app/assets/javascripts/discourse/adapters/rest.js.es6
@@ -20,7 +20,7 @@ export function Result(payload, responseJson) {
 // We use this to make sure 404s are caught
 function rethrow(error) {
   if (error.status === 404) {
-    throw "404: " + error.responseText;
+    throw new Error("404: " + error.responseText);
   }
   throw(error);
 }

--- a/app/assets/javascripts/discourse/components/d-editor.js.es6
+++ b/app/assets/javascripts/discourse/components/d-editor.js.es6
@@ -138,7 +138,7 @@ class Toolbar {
   addButton(button) {
     const g = this.groups.findBy('group', button.group);
     if (!g) {
-      throw `Couldn't find toolbar group ${button.group}`;
+      throw new Error(`Couldn't find toolbar group ${button.group}`);
     }
 
     const createdButton = {

--- a/app/assets/javascripts/discourse/controllers/composer.js.es6
+++ b/app/assets/javascripts/discourse/controllers/composer.js.es6
@@ -590,7 +590,7 @@ export default Ember.Controller.extend({
 
     if (!opts.draftKey) {
       alert("composer was opened without a draft key");
-      throw "composer opened without a proper draft key";
+      throw new Error("composer opened without a proper draft key");
     }
     const self = this;
     let composerModel = this.get('model');

--- a/app/assets/javascripts/discourse/controllers/invites-show.js.es6
+++ b/app/assets/javascripts/discourse/controllers/invites-show.js.es6
@@ -77,8 +77,8 @@ export default Ember.Controller.extend(PasswordValidation, UsernameValidation, N
             this.set('errorMessage', result.message);
           }
         }
-      }).catch(response => {
-        throw response;
+      }).catch(error => {
+        throw new Error(error);
       });
     }
   }

--- a/app/assets/javascripts/discourse/controllers/password-reset.js.es6
+++ b/app/assets/javascripts/discourse/controllers/password-reset.js.es6
@@ -67,8 +67,8 @@ export default Ember.Controller.extend(PasswordValidation, {
             this.set('errorMessage', result.message);
           }
         }
-      }).catch(response => {
-        throw response;
+      }).catch(error => {
+        throw new Error(error);
       });
     },
 

--- a/app/assets/javascripts/discourse/controllers/topic.js.es6
+++ b/app/assets/javascripts/discourse/controllers/topic.js.es6
@@ -22,7 +22,7 @@ export function resetCustomPostMessageCallbacks() {
 
 export function registerCustomPostMessageCallback(type, callback) {
   if (customPostMessageCallbacks[type]) {
-    throw `Error ${type} is an already registered post message!`;
+    throw new Error(`Error ${type} is an already registered post message!`);
   }
 
   customPostMessageCallbacks[type] = callback;

--- a/app/assets/javascripts/discourse/lib/load-script.js.es6
+++ b/app/assets/javascripts/discourse/lib/load-script.js.es6
@@ -82,7 +82,7 @@ export default function loadScript(url, opts) {
     // option.
     if (opts.scriptTag) {
       if (Ember.testing) {
-        throw `In test mode scripts cannot be loaded async ${cdnUrl}`;
+        throw new Error(`In test mode scripts cannot be loaded async ${cdnUrl}`);
       }
       loadWithTag(cdnUrl, cb);
     } else {

--- a/app/assets/javascripts/discourse/models/badge.js.es6
+++ b/app/assets/javascripts/discourse/models/badge.js.es6
@@ -61,7 +61,7 @@ const Badge = RestModel.extend({
       self.updateFromJson(json);
       return self;
     }).catch(function(error) {
-      throw error;
+      throw new Error(error);
     });
   },
 

--- a/app/assets/javascripts/discourse/models/composer.js.es6
+++ b/app/assets/javascripts/discourse/models/composer.js.es6
@@ -506,8 +506,8 @@ const Composer = RestModel.extend({
     }
 
     if (opts.action === REPLY && isEdit(this.get('action'))) this.set('reply', '');
-    if (!opts.draftKey) throw 'draft key is required';
-    if (opts.draftSequence === null) throw 'draft sequence is required';
+    if (!opts.draftKey) throw new Error('draft key is required');
+    if (opts.draftSequence === null) throw new Error('draft sequence is required');
 
     this.setProperties({
       draftKey: opts.draftKey,
@@ -668,7 +668,7 @@ const Composer = RestModel.extend({
         this.clearState();
         return result;
       }).catch(error => {
-        throw error;
+        throw new Error(error);
       });
     }).catch(rollback);
   },

--- a/app/assets/javascripts/discourse/models/post-stream.js.es6
+++ b/app/assets/javascripts/discourse/models/post-stream.js.es6
@@ -217,7 +217,7 @@ export default RestModel.extend({
       this.setProperties({ loadingFilter: false, timelineLookup: json.timeline_lookup, loaded: true });
     }).catch(result => {
       this.errorLoading(result);
-      throw result;
+      throw new Error(result);
     }).finally(() => {
       this.set('loadingNearPost', null);
     });

--- a/app/assets/javascripts/discourse/models/post.js.es6
+++ b/app/assets/javascripts/discourse/models/post.js.es6
@@ -273,10 +273,10 @@ const Post = RestModel.extend({
       .then(function(result){
         self.set("topic.bookmarked", result.topic_bookmarked);
       })
-      .catch(function(e) {
+      .catch(function(error) {
         self.toggleProperty("bookmarked");
         if (bookmarkedTopic) {self.set("topic.bookmarked", false); }
-        throw e;
+        throw new Error(error);
       });
   },
 

--- a/app/assets/javascripts/discourse/models/rest.js.es6
+++ b/app/assets/javascripts/discourse/models/rest.js.es6
@@ -44,7 +44,9 @@ const RestModel = Ember.Object.extend({
     const self = this;
     self.set('isSaving', true);
     return adapter.createRecord(store, type, props).then(function(res) {
-      if (!res) { throw "Received no data back from createRecord"; }
+      if (!res) {
+        throw new Error("Received no data back from createRecord");
+      }
 
       // We can get a response back without properties, for example
       // when a post is queued.
@@ -59,7 +61,7 @@ const RestModel = Ember.Object.extend({
   },
 
   createProperties() {
-    throw "You must overwrite `createProperties()` before saving a record";
+    throw new Error("You must overwrite `createProperties()` before saving a record");
   },
 
   save(props) {

--- a/app/assets/javascripts/discourse/models/store.js.es6
+++ b/app/assets/javascripts/discourse/models/store.js.es6
@@ -302,10 +302,14 @@ export default Ember.Object.extend({
   },
 
   _hydrate(type, obj, root) {
-    if (!obj) { throw "Can't hydrate " + type + " of `null`"; }
+    if (!obj) {
+      throw new Error("Can't hydrate " + type + " of `null`");
+    }
 
     const id = obj.id;
-    if (!id) { throw "Can't hydrate " + type + " without an `id`"; }
+    if (!id) {
+      throw new Error("Can't hydrate " + type + " without an `id`");
+    }
 
     root = root || obj;
 

--- a/app/assets/javascripts/discourse/models/topic.js.es6
+++ b/app/assets/javascripts/discourse/models/topic.js.es6
@@ -652,7 +652,7 @@ function moveResult(result) {
     flushMap();
     return result;
   }
-  throw "error moving posts topic";
+  throw new Error("error moving posts topic");
 }
 
 export function movePosts(topicId, data) {

--- a/app/assets/javascripts/discourse/widgets/widget.js.es6
+++ b/app/assets/javascripts/discourse/widgets/widget.js.es6
@@ -179,9 +179,9 @@ export default class Widget {
     if (Discourse.Environment === "development" || Ember.testing) {
       const ds = this.defaultState(attrs);
       if (typeof ds !== "object") {
-        throw `defaultState must return an object`;
+        throw new Error(`defaultState must return an object`);
       } else if (Object.keys(ds).length > 0 && !this.key) {
-        throw `you need a key when using state in ${this.name}`;
+        throw new Error(`you need a key when using state in ${this.name}`);
       }
     }
 
@@ -279,7 +279,7 @@ export default class Widget {
       result.dirtyKeys = this.dirtyKeys;
       return result;
     } else {
-      throw `Couldn't find ${widgetName} factory`;
+      throw new Error(`Couldn't find ${widgetName} factory`);
     }
   }
 

--- a/app/assets/javascripts/service-worker.js.erb
+++ b/app/assets/javascripts/service-worker.js.erb
@@ -91,7 +91,7 @@ self.addEventListener('fetch', function(event) {
         if (!navigator.onLine) {
           return caches.match(OFFLINE_URL);
         } else {
-          throw error;
+          throw new Error(error);
         }
       })
     );

--- a/app/assets/javascripts/wizard/models/step.js.es6
+++ b/app/assets/javascripts/wizard/models/step.js.es6
@@ -49,7 +49,7 @@ export default Ember.Object.extend(ValidState, {
       data: { fields }
     }).catch(response => {
       response.responseJSON.errors.forEach(err => this.fieldError(err.field, err.description));
-      throw response;
+      throw new Error(response);
     });
   }
 });

--- a/test/javascripts/helpers/select-kit-helper.js
+++ b/test/javascripts/helpers/select-kit-helper.js
@@ -1,12 +1,12 @@
 function checkSelectKitIsNotExpanded(selector) {
   if (find(selector).hasClass('is-expanded')) {
-    throw 'You expected select-kit to be collapsed but it is expanded.';
+    throw new Error('You expected select-kit to be collapsed but it is expanded.');
   }
 }
 
 function checkSelectKitIsNotCollapsed(selector) {
   if (!find(selector).hasClass('is-expanded')) {
-    throw 'You expected select-kit to be expanded but it is collapsed.';
+    throw new Error('You expected select-kit to be expanded but it is collapsed.');
   }
 }
 


### PR DESCRIPTION
In Discourse’s JavaScript code, a lot of error reporting is done in the form `throw 'message'`. In some cases, this hides the error message completely and instead generates a console output that looks like this.

When [discourse/app/assets/javascripts/discourse/models/rest.js.es6: **createProperties**](https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/models/rest.js.es6#L62) throws:

```
undefined              ember:19818:7
defaultDispatch        ember:19818:7
dispatchError          ember:19797:7
run                    ember:2560:9
run                    ember:24451:12
handler                ember:13785:7
setupHandler/<         ember:44352:15
dispatch               jquery:5183:16
add/elemData.handle    jquery:4992:6
```

Note that the top-level error message will be displayed as `undefined`. Instead, the error should be reported as `throw new Error('message')`, generating a way more useful console output:

```
You must overwrite `createProperties()` before saving a record
createProperties@discourse/models/rest:79:13
_saveNew@discourse/models/rest:50:24
save@discourse/models/rest:82:34
createRoute@javascripts/discourse/controllers/admin-plugins-name:23:9
send@ember:34220:28
handler/</<@ember:13806:13
flaggedInstrument@ember:20589:14
handler/<@ember:13805:11
run@ember:2558:16
run@ember:24451:12
handler@ember:13785:7
setupHandler/<@ember:44352:15
dispatch@jquery:5183:16
add/elemData.handle@jquery:4992:6
```

I looked through the source code and changed most occurrences that didn’t follow the pattern `throw new Error(...)`. Note that I didn’t attempt to be more specific about the type of error (e.g. ReferenceError, TypeError, etc.) to throw as I’m not very familiar with the code base. Such a decision should be done by someone else.

Furthermore, I don’t know if these kinds of changes need tests and if so, how the would look like. If this is required, let me know.

*(I’m unsure whether this requires the prefix `FIX` or another prefix, so I left it out.)*