### PR TITLE
FIX: 302 for all unknown service worker paths

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -733,8 +733,10 @@ Discourse::Application.routes.draw do
     # logs.
     get "/service-worker.js" => redirect(relative_url_root + service_worker_asset, status: 302), format: :js
     get service_worker_asset => "static#service_worker_asset", format: :js
+    get "/*service_worker_path" => redirect(relative_url_root + service_worker_asset, status: 302), format: :js, constraints: { service_worker_path: /service-worker-.*/ }
   elsif Rails.env.development?
     get "/service-worker.js" => "static#service_worker_asset", format: :js
+    get "/*service_worker_path" => redirect(relative_url_root + "service-worker.js", status: 302), format: :js, constraints: { service_worker_path: /service-worker-.*/ }
   end
 
   get "cdn_asset/:site/*path" => "static#cdn_asset", format: false


### PR DESCRIPTION
Not sure if this is a good idea, but older service workers should find *something*, right?

This is a little more heavy handed that previous attempts - in this case, any older service worker files will be 302'd to the newer one.