### PR TITLE
BUGFIX: string in server_plugin_outlet needs to be mutable

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -329,7 +329,7 @@ module ApplicationHelper
     erbs = ApplicationHelper.all_connectors.select { |c| c =~ matcher }
     return "" if erbs.blank?
 
-    result = ""
+    result = +""
     erbs.each { |erb| result << render(file: erb) }
     result.html_safe
   end


### PR DESCRIPTION
Strings in application_helper are now implicitly frozen since the addition of the ``# frozen_string_literal: true`` flag. The string in question needs to be mutable however otherwise an error is thrown when you attempt to use a server plugin outlet.