### PR TITLE
add user-preferences-emails-pref-email-settings outlet

### DIFF
--- a/app/assets/javascripts/discourse/templates/preferences/emails.hbs
+++ b/app/assets/javascripts/discourse/templates/preferences/emails.hbs
@@ -24,6 +24,7 @@
     {{/if}}
   </div>
   {{/unless}}
+  {{plugin-outlet name="user-preferences-emails-pref-email-settings" args=(hash model=model save=(action "save"))}}
 </div>
 
 {{#unless siteSettings.disable_digest_emails}}


### PR DESCRIPTION
Necessary to add preferences to the bottom of the Email section, like so:

![screenshot from 2018-06-08 15-02-29](https://user-images.githubusercontent.com/755354/41162182-0e6b7d40-6b2d-11e8-8eb5-3c4d0260fb45.png)

I'll be using it in the plugin I'm making described in this topic: https://meta.discourse.org/t/per-user-preference-mark-post-as-read-when-emailed/86256