### PR TITLE
FIX: PM participants listed inline

### DIFF
--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -445,7 +445,7 @@ class UserNotifications < ActionMailer::Base
           I18n.t('subject_pm')
         end
 
-      participants = "#{I18n.t("user_notifications.pm_participants")} "
+      participants = ""
       participant_list = []
       post.topic.allowed_groups.each do |group|
         participant_list.push "[#{group.name} (#{group.users.count})](#{Discourse.base_url}/groups/#{group.name})"
@@ -528,6 +528,11 @@ class UserNotifications < ActionMailer::Base
         message = email_post_markdown(post) + (reached_limit ? "\n\n#{I18n.t "user_notifications.reached_limit", count: SiteSetting.max_emails_per_day_per_user}" : "");
       end
 
+      first_footer_classes = "hilight"
+      if (allow_reply_by_email && user.staged) || (user.suspended? || user.staged?)
+        first_footer_classes = ""
+      end
+
       unless translation_override_exists
         html = UserNotificationRenderer.new(Rails.configuration.paths["app/views"]).render(
           template: 'email/notification',
@@ -536,7 +541,8 @@ class UserNotifications < ActionMailer::Base
                     reached_limit: reached_limit,
                     post: post,
                     in_reply_to_post: in_reply_to_post,
-                    classes: Rtl.new(user).css_class
+                    classes: Rtl.new(user).css_class,
+                    first_footer_classes: first_footer_classes
           }
         )
       end

--- a/app/views/email/notification.html.erb
+++ b/app/views/email/notification.html.erb
@@ -30,12 +30,7 @@
     <% end %>
   <% end %>
 
-  <div class='footer'>%{respond_instructions}</div>
-  <% if post.topic.private_message? %>
-    <div class='undecorated-link-footer footer'>
-      %{participants}
-    </div>
-  <% end %>
+  <div class='footer undecorated-link-footer <%= first_footer_classes %>'>%{respond_instructions}</div>
   <div class='footer'>%{unsubscribe_instructions}</div>
 
 </div>

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2625,14 +2625,15 @@ en:
 
     header_instructions: ''
     reply_by_email: "[Visit Topic](%{base_url}%{url}) or reply to this email to respond."
-    reply_by_email_pm: "[Visit Message](%{base_url}%{url}) or reply to this email to respond."
+    reply_by_email_pm: "[Visit Message](%{base_url}%{url}) or reply to this email to respond to %{participants}."
     only_reply_by_email: "Reply to this email to respond."
+    only_reply_by_email_pm: "Reply to this email to respond to %{participants}."
     visit_link_to_respond: "[Visit Topic](%{base_url}%{url}) to respond."
-    visit_link_to_respond_pm: "[Visit Message](%{base_url}%{url}) to respond."
+    visit_link_to_respond_pm: "[Visit Message](%{base_url}%{url}) to respond to %{participants}."
 
     posted_by: "Posted by %{username} on %{post_date}"
 
-    pm_participants: "Participants:"
+    pm_participants: "Participants: %{participants}"
 
     invited_group_to_private_message_body: |
       %{username} invited @%{group_name} to a message

--- a/lib/email/message_builder.rb
+++ b/lib/email/message_builder.rb
@@ -34,9 +34,11 @@ module Email
 
         if @opts[:include_respond_instructions] == false
           @template_args[:respond_instructions] = ''
+          @template_args[:respond_instructions] = I18n.t('user_notifications.pm_participants', @template_args) if @opts[:private_reply]
         else
           if @opts[:only_reply_by_email]
             string = "user_notifications.only_reply_by_email"
+            string << "_pm" if @opts[:private_reply]
           else
             string = allow_reply_by_email? ? "user_notifications.reply_by_email" : "user_notifications.visit_link_to_respond"
             string << "_pm" if @opts[:private_reply]
@@ -96,13 +98,6 @@ module Email
         html_override.gsub!("%{respond_instructions}", "")
       end
 
-      if @template_args[:participants].present?
-        participants = PrettyText.cook(@template_args[:participants], sanitize: false).html_safe
-        html_override.gsub!("%{participants}", participants)
-      else
-        html_override.gsub!("%{participants}", "")
-      end
-
       styled = Email::Styles.new(html_override, @opts)
       styled.format_basic
       if style = @opts[:style]
@@ -118,12 +113,6 @@ module Email
     def body
       body = @opts[:body]
       body = I18n.t("#{@opts[:template]}.text_body_template", template_args).dup if @opts[:template]
-
-      if @template_args[:participants].present?
-        body << "\n"
-        body << @template_args[:participants]
-        body << "\n"
-      end
 
       if @template_args[:unsubscribe_instructions].present?
         body << "\n"

--- a/lib/email/styles.rb
+++ b/lib/email/styles.rb
@@ -98,6 +98,7 @@ module Email
       correct_first_body_margin
       correct_footer_style
       style('div.undecorated-link-footer a', "font-weight: normal;")
+      correct_footer_style_hilight_first
       reset_tables
       onebox_styles
       plugin_styles
@@ -242,20 +243,26 @@ module Email
     end
 
     def correct_footer_style
-      footernum = 0
       @fragment.css('.footer').each do |element|
         element['style'] = "color:#666;"
+        element.css('a').each do |inner|
+          inner['style'] = "color:#666;"
+        end
+      end
+    end
+
+    def correct_footer_style_hilight_first
+      footernum = 0
+      @fragment.css('.footer.hilight').each do |element|
         linknum = 0
         element.css('a').each do |inner|
           # we want the first footer link to be specially highlighted as IMPORTANT
           if footernum == (0) && linknum == (0)
-            inner['style'] = "background-color: #006699; color:#ffffff; border-top: 4px solid #006699; border-right: 6px solid #006699; border-bottom: 4px solid #006699; border-left: 6px solid #006699; display: inline-block;"
-          else
-            inner['style'] = "color:#666;"
+            inner['style'] = "background-color: #006699; color:#ffffff; border-top: 4px solid #006699; border-right: 6px solid #006699; border-bottom: 4px solid #006699; border-left: 6px solid #006699; display: inline-block; font-weight: bold;"
           end
-          linknum += 1
+          return
         end
-        footernum += 1
+        return
       end
     end
 

--- a/spec/components/email/message_builder_spec.rb
+++ b/spec/components/email/message_builder_spec.rb
@@ -247,17 +247,6 @@ describe Email::MessageBuilder do
 
   end
 
-  context "PM multiple participants" do
-    let(:pm_multiple) { Email::MessageBuilder.new(to_address,
-                                                               body: 'hello world',
-                                                               private_reply: true,
-                                                               participants: "user1, user2") }
-
-    it "lists participants out" do
-      expect(pm_multiple.body).to match('hello world\nuser1, user2')
-    end
-  end
-
   context "from field" do
 
     it "has the default from" do

--- a/spec/mailers/user_notifications_spec.rb
+++ b/spec/mailers/user_notifications_spec.rb
@@ -440,7 +440,7 @@ describe UserNotifications do
         notification_data_hash: notification.data_hash
       )
 
-      expect(mail.body).to include("#{I18n.t("user_notifications.pm_participants")} [group1 (2)](http://test.localhost/groups/group1), [group2 (1)](http://test.localhost/groups/group2), [one](http://test.localhost/u/one), [two](http://test.localhost/u/two)")
+      expect(mail.body).to include("[group1 (2)](http://test.localhost/groups/group1), [group2 (1)](http://test.localhost/groups/group2), [one](http://test.localhost/u/one), [two](http://test.localhost/u/two)")
     end
 
     context "when SiteSetting.group_name_in_subject is true" do


### PR DESCRIPTION
List PM participants inline with the reply options.

The 'visit message' footer button is no longer the only link which means that I'm now conditionally adding a class to add the first footer to hilight the link, otherwise the first footer links will be undecorated.