### PR TITLE
Feature - allow user and group specific cards styling

### DIFF
--- a/app/assets/javascripts/discourse/components/group-card-contents.js.es6
+++ b/app/assets/javascripts/discourse/components/group-card-contents.js.es6
@@ -9,7 +9,7 @@ export default Ember.Component.extend(CardContentsBase, CleansUp, {
   elementId: 'group-card',
   triggeringLinkClass: 'mention-group',
   classNames: ['no-bg'],
-  classNameBindings: ['visible:show', 'showBadges', 'hasCardBadgeImage', 'isFixed:fixed'],
+  classNameBindings: ['visible:show', 'showBadges', 'hasCardBadgeImage', 'isFixed:fixed', 'groupClass'],
   allowBackgrounds: setting('allow_profile_backgrounds'),
   showBadges: setting('enable_badges'),
 
@@ -22,6 +22,9 @@ export default Ember.Component.extend(CardContentsBase, CleansUp, {
 
   @computed('group.user_count', 'group.members.length')
   moreMembersCount: (memberCount, maxMemberDisplay) => memberCount - maxMemberDisplay,
+
+  @computed('group.name')
+  groupClass: (name) => name ? `group-card-${name}` : '',
 
   @computed('group')
   groupPath(group) {

--- a/app/assets/javascripts/discourse/components/user-card-contents.js.es6
+++ b/app/assets/javascripts/discourse/components/user-card-contents.js.es6
@@ -9,7 +9,7 @@ import CleansUp from 'discourse/mixins/cleans-up';
 export default Ember.Component.extend(CardContentsBase, CanCheckEmails, CleansUp, {
   elementId: 'user-card',
   triggeringLinkClass: 'mention',
-  classNameBindings: ['visible:show', 'showBadges', 'user.card_background::no-bg', 'isFixed:fixed'],
+  classNameBindings: ['visible:show', 'showBadges', 'user.card_background::no-bg', 'isFixed:fixed', 'usernameClass'],
   allowBackgrounds: setting('allow_profile_backgrounds'),
   showBadges: setting('enable_badges'),
 
@@ -33,6 +33,9 @@ export default Ember.Component.extend(CardContentsBase, CanCheckEmails, CleansUp
   nameFirst(name) {
     return !this.siteSettings.prioritize_username_in_ux && name && name.trim().length > 0;
   },
+
+  @computed('username')
+  usernameClass : (username) => username ? `user-card-${username}` : '',
 
   @computed('username', 'topicPostCount')
   togglePostsLabel(username, count) {


### PR DESCRIPTION
An idea from working on the user cards today is to expose the user or group name in the classnames so they can be styled individually.