### PR TITLE
Feature: add jump to post modal on mobile

### DIFF
--- a/app/assets/javascripts/discourse/components/topic-navigation.js.es6
+++ b/app/assets/javascripts/discourse/components/topic-navigation.js.es6
@@ -63,6 +63,9 @@ export default Ember.Component.extend({
         if ( !$target.is('.widget-button') &&
              !$parents.is('.widget-button') &&
              !$parents.is('.dropdown-menu') &&
+             !$parents.is('#discourse-modal') &&
+             !$target.is('#discourse-modal') &&
+             !$parents.is('.modal-footer') &&
              (
               $target.is('.topic-timeline') ||
              !$parents.is('#topic-progress-wrapper')

--- a/app/assets/javascripts/discourse/controllers/jump-to-post.js.es6
+++ b/app/assets/javascripts/discourse/controllers/jump-to-post.js.es6
@@ -4,6 +4,10 @@ export default Ember.Controller.extend(ModalFunctionality, {
   model: null,
   postNumber: null,
 
+  onShow: () => {
+    Ember.run.next(() => $('#post-jump').focus());
+  },
+
   actions: {
     jump() {
       const max   = this.get("topic.postStream.filteredPostsCount");

--- a/app/assets/javascripts/discourse/controllers/topic.js.es6
+++ b/app/assets/javascripts/discourse/controllers/topic.js.es6
@@ -13,6 +13,7 @@ import { extractLinkMeta } from 'discourse/lib/render-topic-featured-link';
 import { popupAjaxError } from 'discourse/lib/ajax-error';
 import { spinnerHTML } from 'discourse/helpers/loading-spinner';
 import { userPath } from 'discourse/lib/url';
+import showModal from 'discourse/lib/show-modal';
 
 let customPostMessageCallbacks = {};
 
@@ -469,13 +470,15 @@ export default Ember.Controller.extend(BufferedContent, {
     },
 
     jumpToPostPrompt() {
-      const postText = prompt(I18n.t('topic.progress.jump_prompt_long'));
-      if (postText === null) { return; }
-
-      const postIndex = parseInt(postText, 10);
-      if (postIndex === 0) { return; }
-
-      this._jumpToIndex(postIndex);
+      const topic = this.get('model');
+      const controller = showModal('jump-to-post');
+      controller.setProperties({
+        topic: topic,
+        postNumber: null,
+        jumpToIndex: (index) => {
+          this.send('jumpToIndex', index);
+        }
+      });
     },
 
     jumpToPost(postNumber) {

--- a/app/assets/javascripts/discourse/templates/modal/jump-to-post.hbs
+++ b/app/assets/javascripts/discourse/templates/modal/jump-to-post.hbs
@@ -1,5 +1,5 @@
 {{#d-modal-body title="topic.progress.jump_prompt_long"}}
-  {{text-field value=postNumber insert-newline="jump"}}
+  {{input id="post-jump" type="number" value=postNumber insert-newline="jump"}}
   <span class='input-hint-text'>
     {{i18n "topic.progress.jump_prompt_of" count=topic.postStream.filteredPostsCount}}
   </span>

--- a/app/assets/stylesheets/common/foundation/variables.scss
+++ b/app/assets/stylesheets/common/foundation/variables.scss
@@ -67,7 +67,6 @@ $line-height-large: 1.4; // Normal or small text
 
 $z-layers: (
   "max": 9999,
-  "fullscreen": 1700,
   "modal": (
     "tooltip": 1600,
     "popover": 1500,
@@ -75,6 +74,7 @@ $z-layers: (
     "content": 1300,
     "overlay": 1200
   ),
+  "fullscreen": 1150,
   "mobile-composer": 1100,
   "header": 1000,
   "tooltip": 600,


### PR DESCRIPTION
...rather than using browser prompt(). Specify input as a number (easier for mobile soft keyboards), and auto-focus (one less click).

Rearranges "fullscreen" under the modal, and supports click-out to dismiss/cancel.

Gif is worth 1000 words:

![mobile-jump-to-post](https://user-images.githubusercontent.com/1322534/41387120-1c6e2f58-6f3a-11e8-92ac-44fefd4f2df1.gif)
