### PR TITLE
Feature: only install service workers for android.

### DIFF
--- a/app/assets/javascripts/discourse/initializers/register-service-worker.js.es6
+++ b/app/assets/javascripts/discourse/initializers/register-service-worker.js.es6
@@ -7,9 +7,10 @@ export default {
 
     const isSupported= isSecured && ('serviceWorker' in navigator);
     const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+    const isAndroid = navigator.userAgent.indexOf('Android') !== -1;
 
     if (isSupported) {
-      if (Discourse.ServiceWorkerURL && !isSafari) {
+      if (Discourse.ServiceWorkerURL && !isSafari && isAndroid) {
         navigator.serviceWorker
           .register(`${Discourse.BaseUri}/${Discourse.ServiceWorkerURL}`)
           .catch(error => {

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -161,7 +161,7 @@ class StaticController < ApplicationController
         # https://github.com/w3c/ServiceWorker/blob/master/explainer.md#updating-a-service-worker
         # Maximum cache that the service worker will respect is 24 hours.
         # However, ensure that these may be cached and served for longer on servers.
-        immutable_for 1.year
+        immutable_for 24.hours
 
         if Rails.application.assets_manifest.assets['service-worker.js']
           path = File.expand_path(Rails.root + "public/assets/#{Rails.application.assets_manifest.assets['service-worker.js']}")

--- a/app/views/common/_discourse_javascript.html.erb
+++ b/app/views/common/_discourse_javascript.html.erb
@@ -45,7 +45,7 @@
     Discourse.ThemeSettings = ps.get('themeSettings');
     Discourse.LetterAvatarVersion = '<%= LetterAvatar.version %>';
     Discourse.MarkdownItURL = '<%= asset_url('markdown-it-bundle.js') %>';
-    Discourse.ServiceWorkerURL = Discourse.Environment != "development" ? '<%= Rails.application.assets_manifest.assets['service-worker.js'] %>' : 'service-worker.js';
+    Discourse.ServiceWorkerURL = 'service-worker2.js';
     I18n.defaultLocale = '<%= SiteSetting.default_locale %>';
     Discourse.start();
     Discourse.set('assetVersion','<%= Discourse.assets_digest %>');

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -733,10 +733,12 @@ Discourse::Application.routes.draw do
     # current site before updating to a new Service Worker.
     # Support the old Service Worker path to avoid routing error filling up the
     # logs.
-    get "/service-worker.js" => redirect(relative_url_root + service_worker_asset, status: 302), format: :js
+    get "/service-worker.js" => redirect(relative_url_root + "service-worker2.js", status: 302), format: :js
     get service_worker_asset => "static#service_worker_asset", format: :js
+    get "/service-worker2.js" => "static#service_worker_asset", format: :js
   elsif Rails.env.development?
     get "/service-worker.js" => "static#service_worker_asset", format: :js
+    get "/service-worker2.js" => "static#service_worker_asset", format: :js
   end
 
   get "cdn_asset/:site/*path" => "static#cdn_asset", format: false


### PR DESCRIPTION
canonical path - service-worker2.js
browsers might have a 301 cached on service-worker.js.