### PR TITLE
FEATURE: Create hidden posts for received spam emails

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -113,7 +113,8 @@ class Post < ActiveRecord::Base
     @hidden_reasons ||= Enum.new(flag_threshold_reached: 1,
                                  flag_threshold_reached_again: 2,
                                  new_user_spam_threshold_reached: 3,
-                                 flagged_by_tl3_user: 4)
+                                 flagged_by_tl3_user: 4,
+                                 email_spam_header_found: 5)
   end
 
   def self.types

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1532,6 +1532,7 @@ en:
     log_mail_processing_failures: "Log all email processing failures to http://yoursitename.com/logs"
     email_in: "Allow users to post new topics via email (requires manual or pop3 polling). Configure the addresses in the \"Settings\" tab of each category."
     email_in_min_trust: "The minimum trust level a user needs to have to be allowed to post new topics via email."
+    email_in_spam_header: "The email header to detect spam."
     email_prefix: "The [label] used in the subject of emails. It will default to 'title' if not set."
     email_site_title: "The title of the site used as the sender of emails from the site. Default to 'title' if not set. If your 'title' contains characters that are not allowed in email sender strings, use this setting."
 

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -783,6 +783,13 @@ email:
   email_in_min_trust:
     default: 2
     enum: 'TrustLevelSetting'
+  email_in_spam_header:
+    type: enum
+    default: 'none'
+    choices:
+     - none
+     - X-Spam-Flag
+     - X-Spam-Status
   email_prefix: ''
   email_site_title: ''
   disable_emails:

--- a/spec/components/post_creator_spec.rb
+++ b/spec/components/post_creator_spec.rb
@@ -38,6 +38,15 @@ describe PostCreator do
       expect(post.wiki).to eq(true)
     end
 
+    it "can be created with a hidden reason" do
+      hri = Post.hidden_reasons[:flag_threshold_reached]
+      post = PostCreator.create(user, basic_topic_params.merge(hidden_reason_id: hri))
+      expect(post.hidden).to eq(true)
+      expect(post.hidden_at).to be_present
+      expect(post.hidden_reason_id).to eq(hri)
+      expect(post.topic.visible).to eq(false)
+    end
+
     it "ensures the user can create the topic" do
       Guardian.any_instance.expects(:can_create?).with(Topic, nil).returns(false)
       expect { creator.create }.to raise_error(Discourse::InvalidAccess)
@@ -70,6 +79,14 @@ describe PostCreator do
 
     context "success" do
       before { creator }
+
+      it "is not hidden" do
+        p = creator.create
+        expect(p.hidden).to eq(false)
+        expect(p.hidden_at).not_to be_present
+        expect(p.hidden_reason_id).to eq(nil)
+        expect(p.topic.visible).to eq(true)
+      end
 
       it "doesn't return true for spam" do
         creator.create

--- a/spec/fixtures/emails/spam_x_spam_flag.eml
+++ b/spec/fixtures/emails/spam_x_spam_flag.eml
@@ -1,0 +1,12 @@
+Return-Path: <existing@bar.com>
+From: Foo Bar <existing@bar.com>
+To: category@bar.com
+Subject: This is a topic from an existing user
+Date: Fri, 15 Jan 2016 00:12:43 +0100
+Message-ID: <32@foo.bar.mail>
+Mime-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+X-Spam-Flag: YES
+
+Hey, this is a topic from an existing user ;)

--- a/spec/fixtures/emails/spam_x_spam_status.eml
+++ b/spec/fixtures/emails/spam_x_spam_status.eml
@@ -1,0 +1,12 @@
+Return-Path: <existing@bar.com>
+From: Foo Bar <existing@bar.com>
+To: category@bar.com
+Subject: This is a topic from an existing user
+Date: Fri, 15 Jan 2016 00:12:43 +0100
+Message-ID: <32@foo.bar.mail>
+Mime-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+X-Spam-Status: Yes, score=12.3 required=4.5
+
+Hey, this is a topic from an existing user ;)


### PR DESCRIPTION
Spamchecker usually have 3 results: HAM, SPAM and PROBABLY_SPAM
SPAM gets usually directly rejected and needs no further handling.
HAM is good message and usually gets passed unmodified.
PROBABLY_SPAM gets an additional header to allow further processing.
This change addes processing capabilities for such headers and marks
new posts created as hidden when received via email.