### PR TITLE
FEATURE: add website field to SSO

### DIFF
--- a/app/models/discourse_single_sign_on.rb
+++ b/app/models/discourse_single_sign_on.rb
@@ -92,6 +92,11 @@ class DiscourseSingleSignOn < SingleSignOn
       user.user_profile.save!
     end
 
+    if website
+      user.user_profile.website = website
+      user.user_profile.save!
+    end
+
     unless admin.nil? && moderator.nil?
       Group.refresh_automatic_groups!(:admins, :moderators, :staff)
     end

--- a/lib/single_sign_on.rb
+++ b/lib/single_sign_on.rb
@@ -1,7 +1,7 @@
 class SingleSignOn
   ACCESSORS = [:nonce, :name, :username, :email, :avatar_url, :avatar_force_update, :require_activation,
                :bio, :external_id, :return_sso_url, :admin, :moderator, :suppress_welcome_message, :title,
-               :add_groups, :remove_groups, :groups, :profile_background_url, :card_background_url]
+               :add_groups, :remove_groups, :groups, :profile_background_url, :card_background_url, :website]
   FIXNUMS = []
   BOOLS = [:avatar_force_update, :admin, :moderator, :require_activation, :suppress_welcome_message]
   NONCE_EXPIRY_TIME = 10.minutes

--- a/spec/models/discourse_single_sign_on_spec.rb
+++ b/spec/models/discourse_single_sign_on_spec.rb
@@ -30,6 +30,7 @@ describe DiscourseSingleSignOn do
     sso.title = "user title"
     sso.custom_fields["a"] = "Aa"
     sso.custom_fields["b.b"] = "B.b"
+    sso.website = "https://www.discourse.org/"
     sso
   end
 
@@ -49,6 +50,7 @@ describe DiscourseSingleSignOn do
     expect(parsed.title).to eq sso.title
     expect(parsed.custom_fields["a"]).to eq "Aa"
     expect(parsed.custom_fields["b.b"]).to eq "B.b"
+    expect(parsed.website).to eq sso.website
   end
 
   it "can do round trip parsing correctly" do


### PR DESCRIPTION
Allows option of including a user website field with sso payload.

https://meta.discourse.org/t/passing-user-website-data-in-sso-payload/87470/2