### PR TITLE
Update Ruby requirements in docs/INSTALL.md

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -23,7 +23,7 @@ Hosting Rails applications is complicated. Even if you already have Postgres, Re
 
 - [Postgres 9.5+](http://www.postgresql.org/download/)
 - [Redis 2.6+](http://redis.io/download)
-- [Ruby 2.3+](http://www.ruby-lang.org/en/downloads/) (we recommend 2.3.1 or higher)
+- [Ruby 2.4+](http://www.ruby-lang.org/en/downloads/) (we recommend 2.4.4 or higher)
 
 ## Security
 


### PR DESCRIPTION
Discourse 2.0 using Ruby 2.3 fails because of
```
Discourse requires Ruby 2.4.0 or up
```

Although in the [software requirements](https://github.com/discourse/discourse/blob/master/docs/INSTALL.md#software-requirements) specify: 

> Ruby 2.3+ (we recommend 2.3.1 or higher)

Discourse has a test to check the ruby version, according to the output obtained trying to run the container using Ruby 2.3, this test [config/application.rb](https://github.com/discourse/discourse/commit/39bfd836c6d97e8c9768b386c188169ceccbf1ff) was included in this new version:
```
begin
  if !RUBY_VERSION.match?(/^2\.[456]/)
    STDERR.puts "Discourse requires Ruby 2.4.0 or up"
    exit 1
  end
rescue
  # no String#match?
  STDERR.puts "Discourse requires Ruby 2.4.0 or up"
  exit 1
end
```

Also, according to the [troubleshooting guide](https://github.com/discourse/discourse/blob/35a645c71f677790514a3863e43ab90b438a3bcc/docs/TROUBLESHOOTING.md#troubleshooting-issues-with-discourse-environments):
> Are you running Ruby 2.4 or later?
Discourse is designed for Ruby 2.4 or later. We recommend 2.4.4 p296 or later. You can check your version by typing `ruby -v` and checking the response.