### PR TITLE
Feature: unconditionally consider TL0 users as "first day" users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -537,7 +537,7 @@ class User < ActiveRecord::Base
   def new_user_posting_on_first_day?
     !staff? &&
     trust_level < TrustLevel[2] &&
-    (self.first_post_created_at.nil? || self.first_post_created_at >= 24.hours.ago)
+    (trust_level == TrustLevel[0] || self.first_post_created_at.nil? || self.first_post_created_at >= 24.hours.ago)
   end
 
   def new_user?

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -990,6 +990,12 @@ describe User do
       u.user_stat.first_post_created_at = 25.hours.ago
       expect(u.new_user_posting_on_first_day?).to eq(false)
     end
+
+    it "considers trust level 0 users as new users unconditionally" do
+      u = Fabricate(:user, created_at: 28.hours.ago, trust_level: TrustLevel[0])
+      u.user_stat.first_post_created_at = 25.hours.ago
+      expect(u.new_user_posting_on_first_day?).to eq(true)
+    end
   end
 
   describe 'api keys' do


### PR DESCRIPTION
Applies max_topics_in_first_day / max_replies_in_first_day site settings towards tl0 users as well.

I'd argue that TL0 users haven't really completed their "first day" with the community so the semantics still work :)