### PR TITLE
UX: Preview multiple color schemes in wizard.

### DIFF
--- a/app/assets/javascripts/wizard/components/theme-preview.js.es6
+++ b/app/assets/javascripts/wizard/components/theme-preview.js.es6
@@ -7,7 +7,7 @@ import {
   LOREM
 } from "wizard/lib/preview";
 
-export default createPreviewComponent(659, 320, {
+export default createPreviewComponent(300, 160, {
   logo: null,
   avatar: null,
 

--- a/app/assets/javascripts/wizard/components/theme-previews.js.es6
+++ b/app/assets/javascripts/wizard/components/theme-previews.js.es6
@@ -1,0 +1,8 @@
+export default Ember.Component.extend({
+    actions: {
+      changed(value) {
+        this.set("field.value", value);
+      }
+    }
+  });
+  

--- a/app/assets/javascripts/wizard/lib/preview.js.es6
+++ b/app/assets/javascripts/wizard/lib/preview.js.es6
@@ -75,7 +75,7 @@ export function createPreviewComponent(width, height, obj) {
           return false;
         }
 
-        const colors = this.get("wizard").getCurrentColors();
+        const colors = this.get("wizard").getCurrentColors(this.get("colors_id"));
         if (!colors) {
           return;
         }

--- a/app/assets/javascripts/wizard/models/wizard.js.es6
+++ b/app/assets/javascripts/wizard/models/wizard.js.es6
@@ -23,18 +23,18 @@ const Wizard = Ember.Object.extend({
   },
 
   // A bit clunky, but get the current colors from the appropriate step
-  getCurrentColors() {
+  getCurrentColors(schemeId) {
     const colorStep = this.get("steps").findBy("id", "colors");
     if (!colorStep) {
       return;
     }
 
-    const themeChoice = colorStep.get("fieldsById.base_scheme_id");
+    const themeChoice = colorStep.get("fieldsById.theme_previews");
     if (!themeChoice) {
       return;
     }
 
-    const themeId = themeChoice.get("value");
+    const themeId = schemeId ? schemeId : themeChoice.get("value");
     if (!themeId) {
       return;
     }

--- a/app/assets/javascripts/wizard/templates/components/theme-previews.hbs
+++ b/app/assets/javascripts/wizard/templates/components/theme-previews.hbs
@@ -1,0 +1,11 @@
+<ul class="grid">
+  {{#each field.choices as |choice|}}
+    <li>
+      {{theme-preview colors_id=choice.id wizard=wizard}}
+      {{radio-button radioValue=choice.id
+                     label=choice.id
+                     value=field.value
+                     onChange="changed"}}
+    </li>
+  {{/each}}
+</ul>

--- a/app/assets/stylesheets/wizard.scss
+++ b/app/assets/stylesheets/wizard.scss
@@ -106,6 +106,20 @@ body.wizard {
   }
 }
 
+.wizard-step-colors {
+  ul.grid {
+    margin: 0 auto;
+    text-align: left;
+    list-style-type: none;
+
+    li {
+        display: inline-block;
+        vertical-align: top;
+        text-align: center;
+    }
+  }
+}
+
 .wizard-column {
   position: relative;
   z-index: 11;

--- a/lib/wizard/builder.rb
+++ b/lib/wizard/builder.rb
@@ -120,37 +120,25 @@ class Wizard
         default_theme = Theme.find_by(key: SiteSetting.default_theme_key)
         scheme_id = default_theme&.color_scheme&.base_scheme_id || 'default'
 
-        themes = step.add_field(id: 'base_scheme_id', type: 'dropdown', required: true, value: scheme_id)
+        themes = step.add_field(id: 'theme_previews', type: 'component', required: true, value: scheme_id)
         ColorScheme.base_color_scheme_colors.each do |t|
           with_hash = t[:colors].dup
           with_hash.map { |k, v| with_hash[k] = "##{v}" }
           themes.add_choice(t[:id], data: { colors: with_hash })
         end
-        step.add_field(id: 'theme_preview', type: 'component')
 
         step.on_update do |updater|
-          scheme_name = updater.fields[:base_scheme_id]
+          scheme_name = updater.fields[:theme_previews]
+          name = scheme_name
 
           theme = nil
+          scheme = ColorScheme.find_by(base_scheme_id: scheme_name, via_wizard: true)
+          scheme ||= ColorScheme.create_from_base(name: name, via_wizard: true, base_scheme_id: scheme_name)
+          themes = Theme.where(color_scheme_id: scheme.id).order(:id).to_a
+          theme = themes.find(&:default?)
+          theme ||= themes.first
 
-          if scheme_name == "dark"
-            scheme = ColorScheme.find_by(base_scheme_id: 'dark', via_wizard: true)
-
-            name = I18n.t("wizard.step.colors.fields.theme_id.choices.dark.label")
-            scheme ||= ColorScheme.create_from_base(name: name, via_wizard: true, base_scheme_id: "dark")
-
-            theme = Theme.find_by(color_scheme_id: scheme.id)
-            name = I18n.t('color_schemes.dark_theme_name')
-            theme ||= Theme.create(name: name, color_scheme_id: scheme.id, user_id: @wizard.user.id)
-          else
-            themes = Theme.where(color_scheme_id: nil).order(:id).to_a
-            theme = themes.find(&:default?)
-            theme ||= themes.first
-
-            name = I18n.t('color_schemes.light_theme_name')
-            theme ||= Theme.create(name: name, user_id: @wizard.user.id)
-          end
-
+          theme ||= Theme.create(name: name, user_id: @wizard.user.id, color_scheme_id: scheme.id)
           theme.set_default!
         end
       end


### PR DESCRIPTION
It was a dropdown to provide choices of color schemes,
and only one scheme could be shown.
With this commit, multiple color scheme previews can be displayed on
one page at the same time, making admins choose color schemes more
easily.