### PR TITLE
FEATURE: send message when a user reaches tl1

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -313,6 +313,11 @@ class User < ActiveRecord::Base
     Jobs.enqueue(:send_system_message, user_id: id, message_type: message_type)
   end
 
+  def enqueue_member_welcome_message
+    return unless SiteSetting.send_tl1_welcome_message?
+    Jobs.enqueue(:send_system_message, user_id: id, message_type: "welcome_tl1_user")
+  end
+
   def change_username(new_username, actor = nil)
     UsernameChanger.change(self, new_username, actor)
   end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1183,6 +1183,7 @@ en:
     track_external_right_clicks: "Track external links that are right clicked (eg: open in new tab) disabled by default because it rewrites URLs"
     site_contact_username: "A valid staff username to send all automated messages from. If left blank the default System account will be used."
     send_welcome_message: "Send all new users a welcome message with a quick start guide."
+    send_tl1_welcome_message: "Send new trust level 1 users a welcome message."
     suppress_reply_directly_below: "Don't show the expandable reply count on a post when there is only a single reply directly below this post."
     suppress_reply_directly_above: "Don't show the expandable in-reply-to on a post when there is only a single reply directly above this post."
     suppress_reply_when_quoting: "Don't show the expandable in-reply-to on a post when post quotes reply."
@@ -2195,6 +2196,14 @@ en:
         We believe in [civilized community behavior](%{base_url}/guidelines) at all times.
 
         Enjoy your stay!
+
+    welcome_tl1_user:
+      title: "Welcome TL1 User"
+      subject_template: "Introduce Yourself"
+      text_body_template: |
+        Hey there. We see you’ve been busy reading, which is fantastic, so we’ve promoted you up a [trust level!]
+        
+        We’re really glad you’re spending time with us and we’d love to know more about you. Take a moment to [fill out your profile], or feel free to [start a new topic].
 
     welcome_invite:
       title: "Welcome Invite"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -990,6 +990,7 @@ trust:
     default: 0
     enum: 'TrustLevelSetting'
   allow_flagging_staff: true
+  send_tl1_welcome_message: true
   tl1_requires_topics_entered: 5
   tl1_requires_read_posts:
     default: 30

--- a/lib/promotion.rb
+++ b/lib/promotion.rb
@@ -23,7 +23,11 @@ class Promotion
   end
 
   def review_tl0
-    Promotion.tl1_met?(@user) && change_trust_level!(TrustLevel[1])
+    if Promotion.tl1_met?(@user) && change_trust_level!(TrustLevel[1])
+      @user.enqueue_member_welcome_message
+      return true
+    end
+    false
   end
 
   def review_tl1

--- a/spec/components/promotion_spec.rb
+++ b/spec/components/promotion_spec.rb
@@ -53,7 +53,7 @@ describe Promotion do
       end
     end
 
-    context "that has done the requisite things" do
+    context "that has not done the requisite things" do
       it "does not promote the user" do
         user.created_at = 1.minute.ago
         stat = user.user_stat
@@ -63,6 +63,32 @@ describe Promotion do
         @result = promotion.review
         expect(@result).to eq(false)
         expect(user.trust_level).to eq(TrustLevel[0])
+      end
+    end
+
+    context "may send tl1 promotion messages" do
+      before do
+        stat = user.user_stat
+        stat.topics_entered = SiteSetting.tl1_requires_topics_entered
+        stat.posts_read_count = SiteSetting.tl1_requires_read_posts
+        stat.time_read = SiteSetting.tl1_requires_time_spent_mins * 60
+      end
+      it "sends promotion message by default" do
+        SiteSetting.send_tl1_welcome_message = true
+        Jobs.expects(:enqueue).with(
+          :send_system_message,
+          user_id: user.id, message_type: "welcome_tl1_user"
+        ).once
+        @result = promotion.review
+      end
+
+      it "can be turned off" do
+        SiteSetting.send_tl1_welcome_message = false
+        Jobs.expects(:enqueue).with(
+          :send_system_message,
+          user_id: user.id, message_type: "welcome_tl1_user"
+        ).never
+        @result = promotion.review
       end
     end
 


### PR DESCRIPTION
Sends a welcome message when a user hits tl1

Can be disabled via the `send_tl1_welcome_message` site setting.