### PR TITLE
FIX: scroll to top when accessing admin dashboard

### DIFF
--- a/app/assets/javascripts/admin/routes/admin-dashboard-next.js.es6
+++ b/app/assets/javascripts/admin/routes/admin-dashboard-next.js.es6
@@ -1,5 +1,8 @@
+import { scrollTop } from "discourse/mixins/scroll-top";
+
 export default Discourse.Route.extend({
   activate() {
     this.controllerFor("admin-dashboard-next").fetchDashboard();
+    scrollTop();
   }
 });


### PR DESCRIPTION
https://meta.discourse.org/t/scrollbar-doesnt-go-to-the-top-when-opening-the-admin-panel/90119?u=osama