### PR TITLE
Fix 'asscoiated' typo

### DIFF
--- a/app/models/concerns/has_search_data.rb
+++ b/app/models/concerns/has_search_data.rb
@@ -2,9 +2,9 @@ module HasSearchData
   extend ActiveSupport::Concern
 
   included do
-    _asscoiated_record_name = self.name.sub('SearchData', '').underscore
-    self.primary_key = "#{_asscoiated_record_name}_id"
-    belongs_to _asscoiated_record_name.to_sym
+    _associated_record_name = self.name.sub('SearchData', '').underscore
+    self.primary_key = "#{_associated_record_name}_id"
+    belongs_to _associated_record_name.to_sym
     validates_presence_of :search_data
   end
 end

--- a/spec/components/concern/has_search_data_spec.rb
+++ b/spec/components/concern/has_search_data_spec.rb
@@ -35,7 +35,7 @@ describe HasSearchData do
       item
     end
 
-    it 'sets its primary key into asscoiated model' do
+    it 'sets its primary key into associated model' do
       expect(ModelItemSearchData.primary_key).to eq 'model_item_id'
     end
 


### PR DESCRIPTION
I know that **Naming is CRITICAL** and that **Refactoring only NOT welcome**.

But since I spotted this (consistent) typo and the change does not affect any
functionality -- I checked the presence of "asscoiated" in the code base, I
guess the first rule trumps the second one.

It also gave me a false pretext to bypass my reluctance to use Google forms and
sign de CLA. Typos hurt the eye.