### PR TITLE
FIX: use `logo_url` settign when present for mobile layout instead of site name

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -263,7 +263,7 @@ module ApplicationHelper
   end
 
   def application_logo_url
-    @application_logo_url ||= (mobile_view? && SiteSetting.mobile_logo_url) || SiteSetting.logo_url
+    @application_logo_url ||= (mobile_view? && SiteSetting.mobile_logo_url).presence || SiteSetting.logo_url
   end
 
   def login_path


### PR DESCRIPTION
https://meta.discourse.org/t/header-css-not-applied-to-user-api-access-key-confirm-page/90906?u=osama