### PR TITLE
PERF: Avoid front loading all gaps.

### DIFF
--- a/app/assets/javascripts/discourse/models/post-stream.js.es6
+++ b/app/assets/javascripts/discourse/models/post-stream.js.es6
@@ -853,6 +853,10 @@ export default RestModel.extend({
       if (posts) {
         posts.forEach(p => this.storePost(store.createRecord("post", p)));
       }
+
+      if (result.post_stream.gaps) {
+        this.set("gaps", _.merge(this.get("gaps"), result.post_stream.gaps));
+      }
     });
   },
 

--- a/app/assets/javascripts/discourse/widgets/post-gap.js.es6
+++ b/app/assets/javascripts/discourse/widgets/post-gap.js.es6
@@ -9,6 +9,9 @@ export default createWidget("post-gap", {
   },
 
   html(attrs, state) {
+    const gapLength = attrs.gap.length;
+    if (gapLength <= 0) return;
+
     return state.loading
       ? I18n.t("loading")
       : I18n.t("post.gap", { count: attrs.gap.length });

--- a/app/assets/javascripts/discourse/widgets/post-stream.js.es6
+++ b/app/assets/javascripts/discourse/widgets/post-stream.js.es6
@@ -24,6 +24,7 @@ const DAY = 1000 * 60 * 60 * 24;
 const _dontCloak = {};
 let _cloaked = {};
 let _heights = {};
+const insertedGaps = new Set([]);
 
 export function preventCloak(postId) {
   _dontCloak[postId] = true;
@@ -107,6 +108,8 @@ export default createWidget("post-stream", {
       // Post gap - before
       const beforeGap = before[post.id];
       if (beforeGap) {
+        beforeGap.forEach(postId => insertedGaps.add(postId));
+
         result.push(
           this.attach(
             "post-gap",
@@ -140,8 +143,17 @@ export default createWidget("post-stream", {
       }
 
       // Post gap - after
-      const afterGap = after[post.id];
+      let afterGap = after[post.id];
+
       if (afterGap) {
+        const toDelete = [];
+
+        afterGap.forEach(postId => {
+          if (insertedGaps.has(postId)) toDelete.push(postId);
+        });
+
+        afterGap = _.difference(afterGap, toDelete);
+
         result.push(
           this.attach(
             "post-gap",

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -355,7 +355,7 @@ class Post < ActiveRecord::Base
             SELECT posts.id
             FROM posts
             WHERE posts.topic_id = #{topic_id.to_i}
-            AND posts.post_number = 1
+            AND posts.sort_order = 1
           ) UNION
           (
             SELECT p1.id

--- a/db/migrate/20180629082500_add_index_topic_id_sort_order_on_posts.rb
+++ b/db/migrate/20180629082500_add_index_topic_id_sort_order_on_posts.rb
@@ -1,0 +1,5 @@
+class AddIndexTopicIdSortOrderOnPosts < ActiveRecord::Migration[5.2]
+  def change
+    add_index :posts, [:topic_id, :sort_order], order: { sort_order: :asc }
+  end
+end


### PR DESCRIPTION
On a mega topic with 70K posts, the following query to load all the gaps upfront is very expensive.

![screenshot from 2018-06-29 16-36-59](https://user-images.githubusercontent.com/4335742/42082484-ae1a4572-7bba-11e8-8933-e6a6abe09f3f.png)

Instead of plucking all the ids, I replaced it with a solution that uses 4 queries and only load the gaps as the client request for each chunk

![screenshot from 2018-06-29 16-38-39](https://user-images.githubusercontent.com/4335742/42082585-fb40a990-7bba-11e8-8aee-2561e83c496a.png)
