### PR TITLE
Secondary emails next phase

### DIFF
--- a/app/assets/javascripts/admin/templates/user-index.hbs
+++ b/app/assets/javascripts/admin/templates/user-index.hbs
@@ -60,13 +60,32 @@
 
   {{#if canCheckEmails}}
     <div class='display-row email'>
-      <div class='field'>{{i18n 'user.email.title'}}</div>
+      <div class='field'>{{i18n 'user.email.primary'}}</div>
       <div class='value'>
         {{#unless model.active}}
           <div class='controls'>{{i18n 'admin.users.not_verified'}}</div>
         {{/unless}}
         {{#if model.email}}
           <a href="mailto:{{unbound model.email}}">{{model.email}}</a>
+        {{else}}
+          {{d-button action="checkEmail" actionParam=model icon="envelope-o" label="admin.users.check_email.text" title="admin.users.check_email.title"}}
+        {{/if}}
+      </div>
+    </div>
+
+    <div class='display-row secondary-emails'>
+      <div class='field'>{{i18n 'user.email.secondary'}}</div>
+      <div class='value'>
+        {{#if model.email}}
+          {{#if model.secondary_emails}}
+            <ul>
+              {{#each model.secondary_emails as |email| }}
+                <li><a href="mailto:{{unbound email}}">{{email}}</a></li>
+              {{/each}}
+            </ul>
+          {{else}}
+            {{i18n 'user.email.no_secondary'}}
+          {{/if}}
         {{else}}
           {{d-button action="checkEmail" actionParam=model icon="envelope-o" label="admin.users.check_email.text" title="admin.users.check_email.title"}}
         {{/if}}

--- a/app/assets/javascripts/discourse/models/user.js.es6
+++ b/app/assets/javascripts/discourse/models/user.js.es6
@@ -604,6 +604,7 @@ const User = RestModel.extend({
       if (result) {
         this.setProperties({
           email: result.email,
+          secondary_emails: result.secondary_emails,
           associated_accounts: result.associated_accounts
         });
       }

--- a/app/assets/javascripts/discourse/templates/preferences/account.hbs
+++ b/app/assets/javascripts/discourse/templates/preferences/account.hbs
@@ -49,6 +49,8 @@
       </div>
     {{/if}}
   </div>
+
+  {{plugin-outlet name="user-preferences-account-email" args=(hash model=model)}}
 {{/if}}
 
 {{#if canChangePassword}}

--- a/app/assets/stylesheets/common/admin/users.scss
+++ b/app/assets/stylesheets/common/admin/users.scss
@@ -29,6 +29,10 @@
   &:after {
     clear: both;
   }
+  &.secondary-emails ul {
+    margin: 0;
+    list-style: none;
+  }
   .field {
     font-weight: bold;
     width: 17.65765%;

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -148,6 +148,7 @@ class UsersController < ApplicationController
 
     render json: {
       email: user.email,
+      secondary_emails: user.secondary_emails,
       associated_accounts: user.associated_accounts
     }
   rescue Discourse::InvalidAccess

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1069,6 +1069,10 @@ class User < ActiveRecord::Base
     end
   end
 
+  def secondary_emails
+    user_emails.where(primary: false).pluck(:email)
+  end
+
   def recent_time_read
     self.created_at && self.created_at < 60.days.ago ?
       self.user_visits.where('visited_at >= ?', 60.days.ago).sum(:time_read) :

--- a/app/serializers/admin_user_list_serializer.rb
+++ b/app/serializers/admin_user_list_serializer.rb
@@ -1,6 +1,7 @@
 class AdminUserListSerializer < BasicUserSerializer
 
   attributes :email,
+             :secondary_emails,
              :active,
              :admin,
              :moderator,
@@ -40,6 +41,8 @@ class AdminUserListSerializer < BasicUserSerializer
     (scope.is_staff? && object.id == scope.user.id) || scope.can_see_emails? ||
       (scope.is_staff? && object.staged?)
   end
+
+  alias_method :include_secondary_emails?, :include_email?
 
   alias_method :include_associated_accounts?, :include_email?
 

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -34,6 +34,7 @@ class UserSerializer < BasicUserSerializer
 
   attributes :name,
              :email,
+             :secondary_emails,
              :last_posted_at,
              :last_seen_at,
              :bio_raw,
@@ -144,6 +145,8 @@ class UserSerializer < BasicUserSerializer
     (object.id && object.id == scope.user.try(:id)) ||
       (scope.is_staff? && object.staged?)
   end
+
+  alias_method :include_secondary_emails?, :include_email?
 
   def include_second_factor_enabled?
     (object&.id == scope.user&.id) || scope.is_staff?

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -807,6 +807,9 @@ en:
 
       email:
         title: "Email"
+        primary: "Primary Email"
+        secondary: "Secondary Emails"
+        no_secondary: "No secondary emails"
         instructions: "never shown to the public"
         ok: "We will email you to confirm"
         invalid: "Please enter a valid email address"

--- a/spec/fabricators/user_email_fabricator.rb
+++ b/spec/fabricators/user_email_fabricator.rb
@@ -3,7 +3,7 @@ Fabricator(:user_email) do
   primary true
 end
 
-Fabricator(:alternate_email, from: :user_email) do
+Fabricator(:secondary_email, from: :user_email) do
   email { sequence(:email) { |i| "bwayne#{i}@wayne.com" } }
   primary false
 end

--- a/spec/fabricators/user_fabricator.rb
+++ b/spec/fabricators/user_fabricator.rb
@@ -12,7 +12,7 @@ Fabricator(:user_single_email, class_name: :user) do
 end
 
 Fabricator(:user, from: :user_single_email) do
-  after_create { |user| Fabricate(:alternate_email, user: user)  }
+  after_create { |user| Fabricate(:secondary_email, user: user)  }
 end
 
 Fabricator(:coding_horror, from: :user) do

--- a/spec/models/user_email_spec.rb
+++ b/spec/models/user_email_spec.rb
@@ -6,14 +6,14 @@ describe UserEmail do
     it "allows only one primary email" do
       user = Fabricate(:user_single_email)
       expect {
-        Fabricate(:alternate_email, user: user, primary: true)
+        Fabricate(:secondary_email, user: user, primary: true)
       }.to raise_error(ActiveRecord::RecordInvalid)
     end
 
     it "allows multiple secondary emails" do
       user = Fabricate(:user_single_email)
-      Fabricate(:alternate_email, user: user, primary: false)
-      Fabricate(:alternate_email, user: user, primary: false)
+      Fabricate(:secondary_email, user: user, primary: false)
+      Fabricate(:secondary_email, user: user, primary: false)
       expect(user.user_emails.count).to eq 3
     end
   end
@@ -22,14 +22,14 @@ describe UserEmail do
     it "allows only one primary email" do
       user = Fabricate(:user_single_email)
       expect {
-        Fabricate.build(:alternate_email, user: user, primary: true).save(validate: false)
+        Fabricate.build(:secondary_email, user: user, primary: true).save(validate: false)
       }.to raise_error(ActiveRecord::RecordNotUnique)
     end
 
     it "allows multiple secondary emails" do
       user = Fabricate(:user_single_email)
-      Fabricate.build(:alternate_email, user: user, primary: false).save(validate: false)
-      Fabricate.build(:alternate_email, user: user, primary: false).save(validate: false)
+      Fabricate.build(:secondary_email, user: user, primary: false).save(validate: false)
+      Fabricate.build(:secondary_email, user: user, primary: false).save(validate: false)
       expect(user.user_emails.count).to eq 3
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1758,4 +1758,18 @@ describe User do
       filter_by(:filter_by_username_or_email)
     end
   end
+
+  describe "#secondary_emails" do
+    let!(:user) { Fabricate(:user_single_email) }
+
+    it "is empty when user has one email" do
+      expect(user.secondary_emails).to be_empty
+    end
+
+    it "only contains secondary emails" do
+      secondary_email = Fabricate(:secondary_email, user: user)
+      expect(user.secondary_emails).to contain_exactly(secondary_email.email)
+    end
+  end
+
 end

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -1900,14 +1900,16 @@ describe UsersController do
         expect(response).to be_forbidden
       end
 
-      it "returns both email and associated_accounts when you're allowed to see them" do
+      it "returns emails and associated_accounts when you're allowed to see them" do
+        user = Fabricate(:user)
         sign_in_admin
 
-        get "/u/#{Fabricate(:user).username}/emails.json"
+        get "/u/#{user.username}/emails.json"
 
         expect(response.status).to eq(200)
         json = JSON.parse(response.body)
-        expect(json["email"]).to be_present
+        expect(json["email"]).to eq(user.email)
+        expect(json["secondary_emails"]).to match_array(user.secondary_emails)
         expect(json["associated_accounts"]).to be_present
       end
 
@@ -1919,7 +1921,8 @@ describe UsersController do
 
         expect(response.status).to eq(200)
         json = JSON.parse(response.body)
-        expect(json["email"]).to be_present
+        expect(json["email"]).to eq(inactive_user.email)
+        expect(json["secondary_emails"]).to match_array(inactive_user.secondary_emails)
         expect(json["associated_accounts"]).to be_present
       end
     end

--- a/spec/serializers/admin_user_list_serializer_spec.rb
+++ b/spec/serializers/admin_user_list_serializer_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+require_dependency 'user'
+
+describe AdminUserListSerializer do
+
+  context "emails" do
+    let(:admin) { Fabricate(:user_single_email, admin: true, email: "admin@email.com") }
+    let(:user) { Fabricate(:user_single_email, email: "user@email.com") }
+
+    def fabricate_secondary_emails_for(u)
+      ["first", "second"].each do |name|
+        Fabricate(:secondary_email, user: u, email: "#{name}@email.com")
+      end
+    end
+
+    shared_examples "shown" do |email|
+      it "contains emails" do
+        expect(json[:email]).to eq(email)
+        expect(json[:secondary_emails]).to contain_exactly(
+          "first@email.com",
+          "second@email.com"
+        )
+      end
+    end
+
+    shared_examples "not shown" do
+      it "doesn't contain emails" do
+        expect(json[:email]).to be_nil
+        expect(json[:secondary_emails]).to be_nil
+      end
+    end
+
+    context "with myself" do
+      let(:json) { AdminUserListSerializer.new(admin, scope: Guardian.new(admin), root: false).as_json }
+
+      before do
+        fabricate_secondary_emails_for(admin)
+      end
+
+      include_examples "shown", "admin@email.com"
+    end
+
+    context "with a normal user" do
+      let(:json) { AdminUserListSerializer.new(user, scope: Guardian.new(admin), root: false).as_json }
+
+      before do
+        fabricate_secondary_emails_for(user)
+      end
+
+      include_examples "not shown"
+    end
+
+    context "with a normal user after clicking 'show emails'" do
+      let(:guardian) { Guardian.new(admin) }
+      let(:json) { AdminUserListSerializer.new(user, scope: guardian, root: false).as_json }
+
+      before do
+        guardian.can_see_emails = true
+        fabricate_secondary_emails_for(user)
+      end
+
+      include_examples "shown", "user@email.com"
+    end
+
+    context "with a staged user" do
+      let(:json) { AdminUserListSerializer.new(user, scope: Guardian.new(admin), root: false).as_json }
+
+      before do
+        user.staged = true
+        fabricate_secondary_emails_for(user)
+      end
+
+      include_examples "shown", "user@email.com"
+    end
+  end
+end

--- a/spec/serializers/user_serializer_spec.rb
+++ b/spec/serializers/user_serializer_spec.rb
@@ -196,4 +196,70 @@ describe UserSerializer do
       expect(json[:custom_fields]['secret_field']).to eq(nil)
     end
   end
+
+  context "with secondary emails" do
+    let(:user) { Fabricate(:user_single_email) }
+
+    before do
+      ["first", "second"].each do |name|
+        Fabricate(:secondary_email, user: user, email: "#{name}@email.com")
+      end
+    end
+
+    shared_examples "shown" do
+      it "contains the user's secondary emails" do
+        expect(json[:secondary_emails]).to contain_exactly(
+          "first@email.com",
+          "second@email.com"
+        )
+      end
+    end
+
+    shared_examples "not shown" do
+      it "doesn't contain the user's secondary emails" do
+        secondary_emails = json[:secondary_emails]
+        expect(secondary_emails).to be_nil
+      end
+    end
+
+    shared_examples "staged shown" do
+      context "with a staged user" do
+        before do
+          user.staged = true
+        end
+
+        include_examples "shown"
+      end
+    end
+
+    context "as the user" do
+      let(:json) { UserSerializer.new(user, scope: Guardian.new(user), root: false).as_json }
+      include_examples "shown"
+    end
+
+    context "as an admin" do
+      let(:admin) { Fabricate(:admin) }
+      let(:json) { UserSerializer.new(user, scope: Guardian.new(admin), root: false).as_json }
+      include_examples "not shown"
+      include_examples "staged shown"
+    end
+
+    context "as a moderator" do
+      let(:moderator) { Fabricate(:moderator) }
+      let(:json) { UserSerializer.new(user, scope: Guardian.new(moderator), root: false).as_json }
+      include_examples "not shown"
+      include_examples "staged shown"
+    end
+
+    context "as another user" do
+      let(:user2) { Fabricate(:user) }
+      let(:json) { UserSerializer.new(user, scope: Guardian.new(user2), root: false).as_json }
+      include_examples "not shown"
+    end
+
+    context "as an anonymous user" do
+      let(:json) { UserSerializer.new(user, scope: Guardian.new, root: false).as_json }
+      include_examples "not shown"
+    end
+  end
 end

--- a/test/javascripts/acceptance/admin-user-emails-test.js.es6
+++ b/test/javascripts/acceptance/admin-user-emails-test.js.es6
@@ -1,0 +1,124 @@
+import { acceptance } from "helpers/qunit-helpers";
+
+acceptance("Admin - User Emails", { loggedIn: true });
+
+const responseWithSecondary = secondary_emails => {
+  return [200, { "Content-Type": "application/json" }, {
+    id: 1,
+    username: "eviltrout",
+    email: "eviltrout@example.com",
+    secondary_emails: secondary_emails
+  }];
+};
+
+const assertNoSecondary = assert => {
+  assert.equal(
+    find(".display-row.email .value a").text(),
+    "eviltrout@example.com",
+    "displays primary email"
+  );
+  assert.equal(
+    find(".display-row.secondary-emails .value").text().trim(),
+    "No secondary emails",
+    "displays no secondary emails"
+  );
+};
+
+QUnit.test("my account has no secondary emails", assert => {
+  server.get("/admin/users/1.json", () => { // eslint-disable-line no-undef
+    return responseWithSecondary([]);
+  });
+  visit("/admin/users/1/eviltrout");
+
+  andThen(() => {
+    assertNoSecondary(assert);
+  });
+});
+
+QUnit.test("my account has one secondary email", assert => {
+  server.get("/admin/users/1.json", () => { // eslint-disable-line no-undef
+    return responseWithSecondary(["eviltrout1@example.com"]);
+  });
+  visit("/admin/users/1/eviltrout");
+
+  andThen(() => {
+    assert.equal(
+      find(".display-row.email .value a").text(),
+      "eviltrout@example.com",
+      "displays primary email"
+    );
+    assert.equal(
+      find(".display-row.secondary-emails .value a").text(),
+      "eviltrout1@example.com",
+      "displays secondary email"
+    );
+  });
+});
+
+const assertMultipleSecondary = assert => {
+  assert.equal(
+    find(".display-row.secondary-emails .value li:first-of-type a").text(),
+    "eviltrout1@example.com",
+    "displays first secondary email"
+  );
+  assert.equal(
+    find(".display-row.secondary-emails .value li:last-of-type a").text(),
+    "eviltrout2@example.com",
+    "displays second secondary email"
+  );
+};
+
+QUnit.test("my account has multiple secondary emails", assert => {
+  server.get("/admin/users/1.json", () => { // eslint-disable-line no-undef
+    return responseWithSecondary([
+      "eviltrout1@example.com",
+      "eviltrout2@example.com"
+    ]);
+  });
+  visit("/admin/users/1/eviltrout");
+
+  andThen(() => {
+    assertMultipleSecondary(assert);
+  });
+});
+
+const otherNoSecondaryShared = (assert, button) => {
+  visit("/admin/users/1234/regular");
+  click(`.display-row.${button} button`);
+
+  andThen(() => {
+    assertNoSecondary(assert);
+  });
+};
+
+QUnit.test("another account has no secondary emails - clicking primary button", assert => {
+  otherNoSecondaryShared(assert, "email");
+});
+
+QUnit.test("another account has no secondary emails - clicking secondary button", assert => {
+  otherNoSecondaryShared(assert, "secondary-emails");
+});
+
+const otherMultipleSecondaryShared = (assert, button) => {
+  server.get("/u/regular/emails.json", () => { // eslint-disable-line no-undef
+    return [200, { "Content-Type": "application/json" }, {
+      email: "eviltrout@example.com",
+      secondary_emails: ["eviltrout1@example.com", "eviltrout2@example.com"]
+    }];
+  });
+
+  visit("/admin/users/1234/regular");
+  click(`.display-row.${button} button`);
+
+  andThen(() => {
+    assertMultipleSecondary(assert);
+  });
+};
+
+QUnit.test("another account has multiple secondary emails - clicking primary button", assert => {
+  otherMultipleSecondaryShared(assert, "email");
+});
+
+QUnit.test("another account has multiple secondary emails - clicking secondary button", assert => {
+  otherMultipleSecondaryShared(assert, "secondary-emails");
+});


### PR DESCRIPTION
Hope I'm not stomping all over proper PR etiquette by including a number of commits in this.

These should bring functionality in line with my post: https://meta.discourse.org/t/additional-email-address-per-user-account-support/59847/13?u=leomca