### PR TITLE
FEATURE: Allow Google Login to be enabled for multiple hosted domains.

### DIFF
--- a/lib/auth/google_oauth2_authenticator.rb
+++ b/lib/auth/google_oauth2_authenticator.rb
@@ -60,8 +60,9 @@ class Auth::GoogleOAuth2Authenticator < Auth::Authenticator
       options[:prompt] = google_oauth2_prompt.gsub("|", " ")
     end
 
+    # Multiple hosted domains can be specified. Delimit with spaces or commas.
     google_oauth2_hd = SiteSetting.google_oauth2_hd
-    options[:hd] = google_oauth2_hd if google_oauth2_hd.present?
+    options[:hd] = google_oauth2_hd.split(/ ,/) if google_oauth2_hd.present?
 
     # jwt encoding is causing auth to fail in quite a few conditions
     # skipping


### PR DESCRIPTION
The `omniauth-google-oauth2` gem allows for authentication to be limited to one or more "hosted domains" (aka GSuite domains): https://github.com/zquestz/omniauth-google-oauth2#configuration. In order to specify multiple hosted domains, the gem expects `hd` to be an array. A common way for specifying this when white-listing multiple hosted domains is to use spaces or commas as delimiters in the string. This commit allows a Discourse admin to specify an array that Google Login should allow by separating multiple domain names in the `google oauth2 hd` field (at `<discourse>/admin/site_settings/category/login`) with either spaces or commas. This string is parsed into the array format that the `omniauth-google-oauth2` gem expects. 