### PR TITLE
FIX: remove delete option from admin wrench for non-admins/moderators when all posts are selected

### DIFF
--- a/app/assets/javascripts/discourse/controllers/topic.js.es6
+++ b/app/assets/javascripts/discourse/controllers/topic.js.es6
@@ -966,15 +966,21 @@ export default Ember.Controller.extend(BufferedContent, {
   canDeselectAll: Ember.computed.alias("selectedAllPosts"),
 
   @computed(
+    "currentUser.staff",
     "selectedPostsCount",
     "selectedAllPosts",
     "selectedPosts",
     "selectedPosts.[]"
   )
-  canDeleteSelected(selectedPostsCount, selectedAllPosts, selectedPosts) {
+  canDeleteSelected(
+    isStaff,
+    selectedPostsCount,
+    selectedAllPosts,
+    selectedPosts
+  ) {
     return (
       selectedPostsCount > 0 &&
-      (selectedAllPosts || selectedPosts.every(p => p.can_delete))
+      ((selectedAllPosts && isStaff) || selectedPosts.every(p => p.can_delete))
     );
   },
 

--- a/test/javascripts/controllers/topic-test.js.es6
+++ b/test/javascripts/controllers/topic-test.js.es6
@@ -209,7 +209,11 @@ QUnit.test("canDeleteSelected", function(assert) {
     ],
     stream: [1, 2, 3]
   };
-
+  const currentUser = Discourse.User.create({ admin: false });
+  this.registry.register("current-user:main", currentUser, {
+    instantiate: false
+  });
+  this.registry.injection("controller", "currentUser", "current-user:main");
   const model = Topic.create({ postStream });
   const controller = this.subject({ model });
   const selectedPostIds = controller.get("selectedPostIds");
@@ -235,9 +239,16 @@ QUnit.test("canDeleteSelected", function(assert) {
 
   selectedPostIds.pushObject(1);
 
+  assert.not(
+    controller.get("canDeleteSelected"),
+    "false when all posts are selected and user is staff"
+  );
+
+  currentUser.set("admin", true);
+
   assert.ok(
     controller.get("canDeleteSelected"),
-    "true when all posts are selected"
+    "true when all posts are selected and user is staff"
   );
 });
 


### PR DESCRIPTION
https://meta.discourse.org/t/tl4-users-can-see-delete-selected-option-when-selecting-all-posts-from-admin-wrench/59982