### PR TITLE
Prevent user custom fields new lines going under the user avatar on the profile page

### DIFF
--- a/app/assets/stylesheets/desktop/user.scss
+++ b/app/assets/stylesheets/desktop/user.scss
@@ -247,6 +247,10 @@
     }
   }
 
+  .public-user-fields {
+    overflow: hidden;
+  }
+
   .viewing-self & .about.collapsed-info {
     .secondary,
     .staff-counters {


### PR DESCRIPTION
Prevent user custom fields new lines going under the user avatar on the profile page when the user has no bio.

See https://meta.discourse.org/t/custom-fields-alignment-on-user-profile/91595