### PR TITLE
PERF: do not carry post ids in memory when rebaking all posts

### DIFF
--- a/lib/tasks/posts.rake
+++ b/lib/tasks/posts.rake
@@ -87,10 +87,11 @@ def rebake_posts(opts = {})
 
     total = Post.count
     rebaked = 0
+    batch = 1000
+    Post.update_all('baked_version = NULL')
 
-    # TODO: make this resumable because carrying around 20 million ids in memory is not a great idea long term
-    Post.order(id: :desc).pluck(:id).in_groups_of(1000, false).each do |batched_post_ids|
-      Post.order(created_at: :desc).where(id: batched_post_ids).each do |post|
+    (0..(total - 1).abs).step(batch) do |i|
+      Post.order(id: :desc).offset(i).limit(batch).each do |post|
         rebake_post(post, opts)
         print_status(rebaked += 1, total)
       end


### PR DESCRIPTION
@tgxworld can you review this commit? Thanks!