### PR TITLE
FIX: datepicker will now default to monday as first day

### DIFF
--- a/app/assets/javascripts/discourse/components/date-picker.js.es6
+++ b/app/assets/javascripts/discourse/components/date-picker.js.es6
@@ -21,7 +21,7 @@ export default Ember.Component.extend({
           container: container || this.$()[0],
           bound: container === undefined,
           format: "YYYY-MM-DD",
-          firstDay: moment.localeData().firstDayOfWeek(),
+          firstDay: 1,
           i18n: {
             previousMonth: I18n.t("dates.previous_month"),
             nextMonth: I18n.t("dates.next_month"),


### PR DESCRIPTION
This will be regardless of the user locale. Many users use english forums even if not from the US and would end up having sunday as the first day of the week in the calendar. This commit follows the international standard.