### PR TITLE
Edit: add link to official plugins list

### DIFF
--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -3,6 +3,8 @@
 
 If you just want to get some plugins for your Discourse instance, check out [the plugin category](https://meta.discourse.org/c/plugin) at meta. This is the most up to date place for plugin discussion and listing.
 
+IF you want to be safe, use only plugins on this list of [Official Plugins](https://github.com/discourse/discourse/blob/master/lib/plugin/metadata.rb): 
+
 ### Discourse Plugin Tutorials
 
 * [Part One: Getting Started](https://meta.discourse.org/t/beginners-guide-to-creating-discourse-plugins/30515)

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -3,7 +3,7 @@
 
 If you just want to get some plugins for your Discourse instance, check out [the plugin category](https://meta.discourse.org/c/plugin) at meta. This is the most up to date place for plugin discussion and listing.
 
-IF you want to be safe, use only plugins on this list of [Official Plugins](https://github.com/discourse/discourse/blob/master/lib/plugin/metadata.rb): 
+If you want to be safe, use only plugins on this list of [Official Plugins](https://github.com/discourse/discourse/blob/master/lib/plugin/metadata.rb): 
 
 ### Discourse Plugin Tutorials
 


### PR DESCRIPTION
It took me a while to find that https://github.com/discourse/discourse/blob/master/lib/plugin/metadata.rb is where the green-checked plugins get determined.