### PR TITLE
PERF: Store `EmailLog#bounce_key` as `uuid` data type.

### DIFF
--- a/app/models/email_log.rb
+++ b/app/models/email_log.rb
@@ -67,6 +67,10 @@ class EmailLog < ActiveRecord::Base
       .try(:to_address)
   end
 
+  def bounce_key
+    super&.delete('-')
+  end
+
 end
 
 # == Schema Information

--- a/db/migrate/20180716072125_alter_bounce_key_on_email_logs.rb
+++ b/db/migrate/20180716072125_alter_bounce_key_on_email_logs.rb
@@ -1,0 +1,9 @@
+class AlterBounceKeyOnEmailLogs < ActiveRecord::Migration[5.2]
+  def up
+    change_column :email_logs, :bounce_key, 'uuid USING bounce_key::uuid'
+  end
+
+  def down
+    change_column :email_logs, :bounce_key, :string
+  end
+end

--- a/spec/models/email_log_spec.rb
+++ b/spec/models/email_log_spec.rb
@@ -101,4 +101,19 @@ describe EmailLog do
     end
   end
 
+  describe '#bounce_key' do
+    it 'should format the bounce key correctly' do
+      bounce_key = SecureRandom.hex
+      email_log = Fabricate(:email_log, user: user, bounce_key: bounce_key)
+
+      raw_bounce_key = EmailLog.where(id: email_log.id)
+        .pluck("bounce_key::text")
+        .first
+
+      expect(raw_bounce_key).to_not eq(bounce_key)
+      expect(raw_bounce_key.delete('-')).to eq(bounce_key)
+      expect(EmailLog.find(email_log.id).bounce_key).to eq(bounce_key)
+    end
+  end
+
 end


### PR DESCRIPTION
Storing the hexdecimal string as a uuid datatype results
in a column size that is 55% smaller than storing as
a string datatype.

```
discourse_development=# SELECT pg_column_size('8ff53b90af5b354bbe1bec8030764832'::VARCHAR);
 pg_column_size
----------------
             36
(1 row)

discourse_development=# SELECT pg_column_size('8ff53b90af5b354bbe1bec8030764832'::UUID);
 pg_column_size
----------------
             16
(1 row)
```