### PR TITLE
Set result.target for update (matching _saveNew)

### DIFF
--- a/app/assets/javascripts/discourse/models/rest.js.es6
+++ b/app/assets/javascripts/discourse/models/rest.js.es6
@@ -30,6 +30,7 @@ const RestModel = Ember.Object.extend({
 
         self.setProperties(payload);
         self.afterUpdate(res);
+        res.target = self;
         return res;
       })
       .finally(() => this.set("isSaving", false));

--- a/test/javascripts/models/rest-model-test.js.es6
+++ b/test/javascripts/models/rest-model-test.js.es6
@@ -21,13 +21,17 @@ QUnit.test("update", assert => {
   const store = createStore();
   return store.find("widget", 123).then(function(widget) {
     assert.equal(widget.get("name"), "Trout Lure");
+    assert.ok(!widget.get("isSaving"), "it is not saving");
 
-    assert.ok(!widget.get("isSaving"));
     const promise = widget.update({ name: "new name" });
-    assert.ok(widget.get("isSaving"));
-    promise.then(function() {
-      assert.ok(!widget.get("isSaving"));
+    assert.ok(widget.get("isSaving"), "it is saving");
+
+    promise.then(function(result) {
+      assert.ok(!widget.get("isSaving"), "it is no longer saving");
       assert.equal(widget.get("name"), "new name");
+
+      assert.ok(result.target, "it has a reference to the record");
+      assert.equal(result.target.name, widget.get("name"));
     });
   });
 });
@@ -55,17 +59,20 @@ QUnit.test("save new", assert => {
 
   assert.ok(widget.get("isNew"), "it is a new record");
   assert.ok(!widget.get("isCreated"), "it is not created");
-  assert.ok(!widget.get("isSaving"));
+  assert.ok(!widget.get("isSaving"), "it is not saving");
 
   const promise = widget.save({ name: "Evil Widget" });
-  assert.ok(widget.get("isSaving"));
+  assert.ok(widget.get("isSaving"), "it is not saving");
 
-  return promise.then(function() {
-    assert.ok(!widget.get("isSaving"));
+  return promise.then(function(result) {
+    assert.ok(!widget.get("isSaving"), "it is no longer saving");
     assert.ok(widget.get("id"), "it has an id");
     assert.ok(widget.get("name"), "Evil Widget");
     assert.ok(widget.get("isCreated"), "it is created");
     assert.ok(!widget.get("isNew"), "it is no longer new");
+
+    assert.ok(result.target, "it has a reference to the record");
+    assert.equal(result.target.name, widget.get("name"));
   });
 });
 


### PR DESCRIPTION
Saving a new record (with `save()`) or updating a record (with `update()`) currently behave differently in that only `save()` will return a result object with a reference to the record object (i.e. `result.target` is set). Using `update()` will always miss that reference.

This pull request adds the reference to the result object for `update()` to match how `_saveNew()` works.

**Further notes**:

One reason why this is problematic is the ability to rely solely on *updating* records even for creating them in the first place. This happens when one provides the `id` property for the `attrs` object when calling `this.store.createRecord()`. The application logic treats records with an `id` property as existing and will always lead to a PUT request (whether this logic is desirable is an entirely different matter). With that, one never gets a response containing a reference to the record object from the server. Although `createRecord` already returns that object, one can’t be sure that the server-side representation is exactly identical. I wish to rely on the server-side representation.