### PR TITLE
FIX: set default for theme.key, if it has not yet been dropped

### DIFF
--- a/db/migrate/20180716200103_add_theme_key_default.rb
+++ b/db/migrate/20180716200103_add_theme_key_default.rb
@@ -1,0 +1,11 @@
+class AddThemeKeyDefault < ActiveRecord::Migration[5.2]
+  def up
+    if column_exists?(:themes, :key)
+      execute("ALTER TABLE themes ALTER COLUMN key SET DEFAULT 'deprecated'")
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
<s>Need to use `Migration::SafeMigrate.disable!`, because the SQL query that gets generated contains the word "DROP"

```
ALTER TABLE "themes" ALTER "key" DROP NOT NULL
```

`column_exists?` is used to make sure this doesn't run if the `key` column has already been dropped.</s>

Set a default value, so that we don't hit issues with the NOT_NULL constraint while waiting for the column to be dropped