### PR TITLE
FIX: mixed-text-direction list padding

### DIFF
--- a/app/assets/stylesheets/common/base/rtl.scss
+++ b/app/assets/stylesheets/common/base/rtl.scss
@@ -56,3 +56,10 @@
 .rtl .dashboard-right {
   float: left !important;
 }
+
+// This is for the support_mixed_text_direction setting
+.cooked ul[dir="ltr"], .d-editor-preview ul[dir="ltr"],
+.cooked ul[dir="rtl"], .d-editor-preview ul[dir="rtl"] {
+  padding-right: 40px;
+  padding-left: 40px;
+}


### PR DESCRIPTION
When the support_mixed_text_direction setting is enabled, the text direction of cooked posts may be set in the opposite direction of the loaded stylesheet. The only way I can see to guarantee that the correct padding will be added to a list is to add the padding to both the left and the right of the list.

We don't have the same issue with ordered lists. In that case, the padding is being added by the user-agent stylesheet. On Chrome, that is `-webkit-padding-start: 40px;`. This works correctly for both ltr and rtl lists.