### PR TITLE
FIX: do not add a moderator post when post is flagged via direct message

### DIFF
--- a/app/models/post_action.rb
+++ b/app/models/post_action.rb
@@ -152,7 +152,7 @@ class PostAction < ActiveRecord::Base
   def self.agree_flags!(post, moderator, delete_post = false)
     actions = PostAction.active
       .where(post_id: post.id)
-      .where(post_action_type_id: PostActionType.flag_types.values)
+      .where(post_action_type_id: PostActionType.notify_flag_types.values)
 
     trigger_spam = false
     actions.each do |action|

--- a/spec/models/post_action_spec.rb
+++ b/spec/models/post_action_spec.rb
@@ -672,6 +672,20 @@ describe PostAction do
       expect(user_notifications.last.topic).to eq(topic)
     end
 
+    it "should not add a moderator post when post is flagged via private message" do
+      SiteSetting.queue_jobs = false
+      post = Fabricate(:post)
+      user = Fabricate(:user)
+      action = PostAction.act(user, post, PostActionType.types[:notify_user], message: "WAT")
+      topic = action.reload.related_post.topic
+      expect(user.notifications.count).to eq(0)
+
+      SiteSetting.auto_respond_to_flag_actions = true
+      PostAction.agree_flags!(post, admin)
+
+      user_notifications = user.notifications
+      expect(user_notifications.count).to eq(0)
+    end
   end
 
   describe "rate limiting" do


### PR DESCRIPTION
related:
https://meta.discourse.org/t/when-a-notify-author-flagged-post-is-deleted-system-says-thanks/92323
https://meta.discourse.org/t/flag-action-messages-sent-out-where-they-shouldnt-be/74536