### PR TITLE
FIX: don't apply crawler blocking if user agent is missing

### DIFF
--- a/lib/crawler_detection.rb
+++ b/lib/crawler_detection.rb
@@ -12,7 +12,7 @@ module CrawlerDetection
   end
 
   def self.crawler?(user_agent)
-    return true if user_agent.nil?
+    return false if !user_agent.present?
 
     # this is done to avoid regenerating regexes
     @non_crawler_matchers ||= {}

--- a/spec/components/crawler_detection_spec.rb
+++ b/spec/components/crawler_detection_spec.rb
@@ -147,10 +147,10 @@ describe CrawlerDetection do
       expect(CrawlerDetection.is_blocked_crawler?('Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36')).to eq(false)
     end
 
-    it 'is true if user agent is missing and whitelist is defined' do
+    it 'is false if user agent is missing and whitelist is defined' do
       SiteSetting.whitelisted_crawler_user_agents = 'Googlebot'
-      expect(CrawlerDetection.is_blocked_crawler?('')).to eq(true)
-      expect(CrawlerDetection.is_blocked_crawler?(nil)).to eq(true)
+      expect(CrawlerDetection.is_blocked_crawler?('')).to eq(false)
+      expect(CrawlerDetection.is_blocked_crawler?(nil)).to eq(false)
     end
 
     it 'is false if user agent is missing and blacklist is defined' do


### PR DESCRIPTION
We were applying web crawler blocking logic to requests that had no user agent. Stats have shown that crawlers are good at providing user agents, so I think we should stop trying to block requests with missing user agent. Some tooling (like site monitoring) could unintentionally be blocked because they don't provide user agent.