### PR TITLE
FIX: TopicLink URLs should be case-insensitive

### DIFF
--- a/spec/models/topic_link_spec.rb
+++ b/spec/models/topic_link_spec.rb
@@ -29,6 +29,7 @@ describe TopicLink do
     before do
       post = Fabricate(:post, raw: "
 http://a.com/
+http://A.com/
 http://b.com/b
 http://#{'a' * 200}.com/invalid
 http://b.com/#{'a' * 500}


### PR DESCRIPTION
@SamSaffron Can you verify this commit? Will `validates_uniqueness_of :url, case_sensitive: false` create issues when the duplicate record (`google.com` vs `Google.com`) is updated? If yes, we might need to run a migration merging existing duplicated records.