### PR TITLE
FIX: topic owner should watch the new topic when moving posts to a new topic

### DIFF
--- a/app/models/post_mover.rb
+++ b/app/models/post_mover.rb
@@ -34,6 +34,8 @@ class PostMover
       )
       DiscourseTagging.tag_topic_by_names(new_topic, Guardian.new(user), tags)
       move_posts_to new_topic
+      force_user_to_watch_new_topic
+      new_topic
     end
   end
 
@@ -222,5 +224,14 @@ class PostMover
       attrs[:updated_at] = Time.now
       destination_topic.update_columns(attrs)
     end
+  end
+
+  def force_user_to_watch_new_topic
+    TopicUser.change(
+      destination_topic.user,
+      destination_topic.id,
+      notification_level: TopicUser.notification_levels[:watching],
+      notifications_reason_id: TopicUser.notification_reasons[:created_topic]
+    )
   end
 end

--- a/app/models/post_mover.rb
+++ b/app/models/post_mover.rb
@@ -34,7 +34,7 @@ class PostMover
       )
       DiscourseTagging.tag_topic_by_names(new_topic, Guardian.new(user), tags)
       move_posts_to new_topic
-      force_user_to_watch_new_topic
+      watch_new_topic
       new_topic
     end
   end
@@ -226,7 +226,7 @@ class PostMover
     end
   end
 
-  def force_user_to_watch_new_topic
+  def watch_new_topic
     TopicUser.change(
       destination_topic.user,
       destination_topic.id,

--- a/spec/models/post_mover_spec.rb
+++ b/spec/models/post_mover_spec.rb
@@ -264,6 +264,19 @@ describe PostMover do
           moderator_post = topic.posts.last
           expect(moderator_post.raw).to include("2 posts were split")
         end
+
+        it "forces resulting topic owner to watch the new topic" do
+          new_topic = topic.move_posts(user, [p2.id, p4.id], title: "new testing topic name", category_id: category.id)
+
+          expect(new_topic.posts_count).to eq(2)
+
+          expect(TopicUser.exists?(
+            user_id: another_user,
+            topic_id: new_topic.id,
+            notification_level: TopicUser.notification_levels[:watching],
+            notifications_reason_id: TopicUser.notification_reasons[:created_topic]
+          )).to eq(true)
+        end
       end
 
       context "to an existing topic" do

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -58,12 +58,9 @@ RSpec.describe TopicsController do
 
     describe 'moving to a new topic' do
       let(:user) { Fabricate(:user) }
-      let(:user2) { Fabricate(:user) }
       let(:moderator) { Fabricate(:moderator) }
       let(:p1) { Fabricate(:post, user: user, post_number: 1) }
       let(:p2) { Fabricate(:post, user: user, post_number: 2, topic: p1.topic) }
-      let(:p3) { Fabricate(:post, user: user2, post_number: 3, topic: p1.topic) }
-      let(:p4) { Fabricate(:post, user: user2, post_number: 4, topic: p1.topic) }
       let!(:topic) { p1.topic }
 
       it "raises an error without post_ids" do
@@ -117,30 +114,6 @@ RSpec.describe TopicsController do
           expect(result['success']).to eq(true)
           expect(result['url']).to eq(Topic.last.relative_url)
           expect(Tag.all.pluck(:name)).to contain_exactly("tag1", "tag2")
-        end
-
-        it "forces resulting topic owner to watch the new topic" do
-          expect do
-            post "/t/#{topic.id}/move-posts.json", params: {
-              title: 'Logan is a good movie',
-              post_ids: [p3.id, p4.id],
-            }
-          end.to change { Topic.count }.by(1)
-
-          expect(response.status).to eq(200)
-
-          result = ::JSON.parse(response.body)
-
-          expect(result['success']).to eq(true)
-          new_topic = p3.reload.topic
-          expect(result['url']).to eq(new_topic.relative_url)
-
-          expect(TopicUser.exists?(
-            user_id: user2.id,
-            topic_id: new_topic.id,
-            notification_level: TopicUser.notification_levels[:watching],
-            notifications_reason_id: TopicUser.notification_reasons[:created_topic]
-          )).to eq(true)
         end
 
         describe 'when topic has been deleted' do


### PR DESCRIPTION
https://meta.discourse.org/t/when-a-post-is-moved-to-a-new-topic-by-a-moderator-the-moved-posts-author-is-not-watching/51779/3?u=osama