### PR TITLE
FIX: store records with ID 0 not working reliably

### DIFF
--- a/app/assets/javascripts/discourse/adapters/rest.js.es6
+++ b/app/assets/javascripts/discourse/adapters/rest.js.es6
@@ -42,7 +42,9 @@ export default Ember.Object.extend({
   },
 
   appendQueryParams(path, findArgs, extension) {
-    if (findArgs) {
+    // In the condition, checking for `findArgs` only is not sufficient because
+    // it might be `0`.
+    if (findArgs !== undefined) {
       if (typeof findArgs === "object") {
         const queryString = Object.keys(findArgs)
           .reject(k => !findArgs[k])

--- a/app/assets/javascripts/discourse/models/store.js.es6
+++ b/app/assets/javascripts/discourse/models/store.js.es6
@@ -10,13 +10,11 @@ function flushMap() {
   _identityMap = {};
 }
 
-function storeMap(type, id, obj) {
-  if (!id) {
-    return;
+function storeMap(type, id, record) {
+  if (id !== undefined) {
+    _identityMap[type] = _identityMap[type] || {};
+    _identityMap[type][id] = record;
   }
-
-  _identityMap[type] = _identityMap[type] || {};
-  _identityMap[type][id] = obj;
 }
 
 function fromMap(type, id) {
@@ -197,7 +195,20 @@ export default Ember.Object.extend({
 
   createRecord(type, attrs) {
     attrs = attrs || {};
-    return !!attrs.id ? this._hydrate(type, attrs) : this._build(type, attrs);
+
+    // Creating a record with an ID might conflict with existing records. Before building a new
+    // record, check for existing records.
+    if (attrs.hasOwnProperty("id")) {
+      if (typeof attrs.id !== "number") {
+        throw new TypeError(
+          `The id property has type ${typeof attrs.id} (must be number).`
+        );
+      }
+
+      return this._hydrate(type, attrs);
+    }
+
+    return this._build(type, attrs);
   },
 
   destroyRecord(type, record) {
@@ -240,20 +251,20 @@ export default Ember.Object.extend({
     return ResultSet.create(createArgs);
   },
 
-  _build(type, obj) {
-    obj.store = this;
-    obj.__type = type;
-    obj.__state = obj.id ? "created" : "new";
+  _build(type, attrs) {
+    attrs.store = this;
+    attrs.__type = type;
+    attrs.__state = attrs.id !== undefined ? "created" : "new";
 
     // TODO: Have injections be automatic
-    obj.topicTrackingState = this.register.lookup("topic-tracking-state:main");
-    obj.keyValueStore = this.register.lookup("key-value-store:main");
-    obj.siteSettings = this.register.lookup("site-settings:main");
+    attrs.topicTrackingState = this.register.lookup("topic-tracking-state:main");
+    attrs.keyValueStore = this.register.lookup("key-value-store:main");
+    attrs.siteSettings = this.register.lookup("site-settings:main");
 
     const klass = this.register.lookupFactory("model:" + type) || RestModel;
-    const model = klass.create(obj);
+    const model = klass.create(attrs);
 
-    storeMap(type, obj.id, model);
+    storeMap(type, attrs.id, model);
     return model;
   },
 
@@ -299,55 +310,51 @@ export default Ember.Object.extend({
     }
   },
 
-  _hydrateEmbedded(type, obj, root) {
+  _hydrateEmbedded(type, attrs, root) {
     const self = this;
-    Object.keys(obj).forEach(function(k) {
+    Object.keys(attrs).forEach(function(k) {
       const m = /(.+)\_id(s?)$/.exec(k);
       if (m) {
         const subType = m[1];
 
         if (m[2]) {
-          const hydrated = obj[k].map(function(id) {
+          const hydrated = attrs[k].map(function(id) {
             return self._lookupSubType(subType, type, id, root);
           });
-          obj[self.pluralize(subType)] = hydrated || [];
-          delete obj[k];
+          attrs[self.pluralize(subType)] = hydrated || [];
+          delete attrs[k];
         } else {
-          const hydrated = self._lookupSubType(subType, type, obj[k], root);
+          const hydrated = self._lookupSubType(subType, type, attrs[k], root);
           if (hydrated) {
-            obj[subType] = hydrated;
-            delete obj[k];
+            attrs[subType] = hydrated;
+            delete attrs[k];
           }
         }
       }
     });
   },
 
-  _hydrate(type, obj, root) {
-    if (!obj) {
+  _hydrate(type, attrs, root) {
+    if (!attrs) {
       throw new Error("Can't hydrate " + type + " of `null`");
     }
 
-    const id = obj.id;
-    if (!id) {
-      throw new Error("Can't hydrate " + type + " without an `id`");
-    }
-
-    root = root || obj;
+    root = root || attrs;
 
     // Experimental: If serialized with a certain option we'll wire up embedded objects
     // automatically.
     if (root.__rest_serializer === "1") {
-      this._hydrateEmbedded(type, obj, root);
+      this._hydrateEmbedded(type, attrs, root);
     }
 
-    const existing = fromMap(type, id);
-    if (existing === obj) {
+    const existing = fromMap(type, attrs.id);
+    if (existing === attrs) {
       return existing;
     }
 
     if (existing) {
-      delete obj.id;
+      const id = attrs.id;
+      delete attrs.id;
       let klass = this.register.lookupFactory("model:" + type);
 
       if (klass && klass.class) {
@@ -358,12 +365,12 @@ export default Ember.Object.extend({
         klass = RestModel;
       }
 
-      existing.setProperties(klass.munge(obj));
-      obj.id = id;
+      existing.setProperties(klass.munge(attrs));
+      attrs.id = id;
       return existing;
     }
 
-    return this._build(type, obj);
+    return this._build(type, attrs);
   }
 });
 

--- a/test/javascripts/models/store-test.js.es6
+++ b/test/javascripts/models/store-test.js.es6
@@ -6,27 +6,36 @@ QUnit.test("createRecord", assert => {
   const store = createStore();
   const widget = store.createRecord("widget", { id: 111, name: "hello" });
 
-  assert.ok(!widget.get("isNew"), "it is not a new record");
-  assert.equal(widget.get("name"), "hello");
-  assert.equal(widget.get("id"), 111);
+  assert.ok(!widget.get("isNew"), "record is not new");
+  assert.equal(widget.get("name"), "hello", "record name is correct");
+  assert.equal(widget.get("id"), 111, "record ID is correct");
 });
 
-QUnit.test("createRecord without an `id`", assert => {
+QUnit.test("createRecord with ID 0", assert => {
+  const store = createStore();
+  const widget = store.createRecord("widget", { id: 0, name: "" });
+
+  assert.ok(!widget.get("isNew"), "record is not new");
+  assert.equal(widget.get("name"), "", "record name is correct");
+  assert.equal(widget.get("id"), 0, "record ID is correct");
+});
+
+QUnit.test("createRecord without an ID", assert => {
   const store = createStore();
   const widget = store.createRecord("widget", { name: "hello" });
 
-  assert.ok(widget.get("isNew"), "it is a new record");
-  assert.ok(!widget.get("id"), "there is no id");
+  assert.ok(widget.get("isNew"), "record is new");
+  assert.ok(widget.get("id") === undefined, "record has no `id` property");
 });
 
-QUnit.test("createRecord doesn't modify the input `id` field", assert => {
+QUnit.test("createRecord doesn’t modify the input `id` field", assert => {
   const store = createStore();
   const widget = store.createRecord("widget", { id: 1, name: "hello" });
 
   const obj = { id: 1, name: "something" };
-
   const other = store.createRecord("widget", obj);
-  assert.equal(widget, other, "returns the same record");
+
+  assert.deepEqual(widget, other, "both records are the same");
   assert.equal(widget.name, "something", "it updates the properties");
   assert.equal(obj.id, 1, "it does not remove the id from the input");
 });
@@ -35,8 +44,9 @@ QUnit.test("createRecord without attributes", assert => {
   const store = createStore();
   const widget = store.createRecord("widget");
 
-  assert.ok(!widget.get("id"), "there is no id");
-  assert.ok(widget.get("isNew"), "it is a new record");
+  assert.ok(widget.get("id") === undefined, "record has no `id` property");
+  assert.ok(widget.get("isNew"), "record is new");
+  assert.ok(!widget.get("isCreated"), "record is not created");
 });
 
 QUnit.test(
@@ -44,40 +54,39 @@ QUnit.test(
   assert => {
     const store = createStore();
     const widget = store.createRecord("widget", { id: 33 });
-    const secondWidget = store.createRecord("widget", { id: 33 });
+    const other = store.createRecord("widget", { id: 33 });
 
-    assert.equal(widget, secondWidget, "they should be the same");
+    assert.deepEqual(widget, other, "both records are the same");
   }
 );
 
 QUnit.test("find", assert => {
   const store = createStore();
-
-  return store.find("widget", 123).then(function(w) {
-    assert.equal(w.get("name"), "Trout Lure");
-    assert.equal(w.get("id"), 123);
-    assert.ok(!w.get("isNew"), "found records are not new");
-    assert.equal(w.get("extras.hello"), "world", "extra attributes are set");
+  return store.find("widget", 123).then(result1 => {
+    assert.equal(result1.get("name"), "Trout Lure", "record name is correct");
+    assert.equal(result1.get("id"), 123, "record ID is correct");
+    assert.ok(!result1.get("isNew"), "record is not new");
+    assert.equal(result1.get("extras.hello"), "world", "extra attributes are set");
 
     // A second find by id returns the same object
-    store.find("widget", 123).then(function(w2) {
-      assert.equal(w, w2);
-      assert.equal(w.get("extras.hello"), "world", "extra attributes are set");
+    store.find("widget", 123).then(result2 => {
+      assert.deepEqual(result1, result2, "Second `find` returns the same object");
+      assert.equal(result1.get("extras.hello"), "world", "extra attributes are set");
     });
   });
 });
 
 QUnit.test("find with object id", assert => {
   const store = createStore();
-  return store.find("widget", { id: 123 }).then(function(w) {
-    assert.equal(w.get("firstObject.name"), "Trout Lure");
+  return store.find("widget", { id: 123 }).then(result => {
+    assert.equal(result.get("firstObject.name"), "Trout Lure", "record name is correct");
   });
 });
 
 QUnit.test("find with query param", assert => {
   const store = createStore();
-  return store.find("widget", { name: "Trout Lure" }).then(function(w) {
-    assert.equal(w.get("firstObject.id"), 123);
+  return store.find("widget", { name: "Trout Lure" }).then(result => {
+    assert.equal(result.get("firstObject.id"), 123, "record ID is correct");
   });
 });
 
@@ -85,11 +94,12 @@ QUnit.test("findStale with no stale results", assert => {
   const store = createStore();
   const stale = store.findStale("widget", { name: "Trout Lure" });
 
-  assert.ok(!stale.hasResults, "there are no stale results");
-  assert.ok(!stale.results, "results are present");
-  return stale.refresh().then(function(w) {
+  assert.ok(!stale.hasResults, "record has no stale results");
+  assert.ok(!stale.results, "record results are absent");
+
+  return stale.refresh().then(result => {
     assert.equal(
-      w.get("firstObject.id"),
+      result.get("firstObject.id"),
       123,
       "a `refresh()` method provides results for stale"
     );
@@ -98,93 +108,94 @@ QUnit.test("findStale with no stale results", assert => {
 
 QUnit.test("update", assert => {
   const store = createStore();
-  return store.update("widget", 123, { name: "hello" }).then(function(result) {
-    assert.ok(result);
+  return store.update("widget", 123, { name: "hello" }).then(result => {
+    assert.ok(result, "update returns a result");
   });
 });
 
-QUnit.test("update with a multi world name", function(assert) {
+QUnit.test("update with a multi-word store type", assert => {
   const store = createStore();
   return store
     .update("cool-thing", 123, { name: "hello" })
-    .then(function(result) {
-      assert.ok(result);
-      assert.equal(result.payload.name, "hello");
+    .then(result => {
+      assert.ok(result, "update returns a result");
+      assert.equal(result.payload.name, "hello", "record name is correct");
     });
 });
 
 QUnit.test("findAll", assert => {
   const store = createStore();
-  return store.findAll("widget").then(function(result) {
-    assert.equal(result.get("length"), 2);
-    const w = result.findBy("id", 124);
-    assert.ok(!w.get("isNew"), "found records are not new");
-    assert.equal(w.get("name"), "Evil Repellant");
+  return store.findAll("widget").then(findAllResult => {
+    assert.equal(findAllResult.get("length"), 2, "result length is correct");
+
+    const findByResult = findAllResult.findBy("id", 124);
+    assert.ok(!findByResult.get("isNew"), "found record is not new");
+    assert.equal(findByResult.get("name"), "Evil Repellant", "found record name is correct");
   });
 });
 
-QUnit.test("destroyRecord", function(assert) {
+QUnit.test("destroyRecord", assert => {
   const store = createStore();
-  return store.find("widget", 123).then(function(w) {
-    store.destroyRecord("widget", w).then(function(result) {
-      assert.ok(result);
+  return store.find("widget", 123).then(findResult => {
+    store.destroyRecord("widget", findResult).then(destroyResult => {
+      assert.ok(destroyResult, "destroyRecord returns a result");
     });
   });
 });
 
-QUnit.test("destroyRecord when new", function(assert) {
+QUnit.test("destroyRecord when new", assert => {
   const store = createStore();
-  const w = store.createRecord("widget", { name: "hello" });
-  store.destroyRecord("widget", w).then(function(result) {
-    assert.ok(result);
+  const widget = store.createRecord("widget", { name: "hello" });
+  store.destroyRecord("widget", widget).then(result => {
+    assert.ok(result, "destroyRecord returns a result");
   });
 });
 
-QUnit.test("find embedded", function(assert) {
+QUnit.test("find embedded", assert => {
   const store = createStore();
-  return store.find("fruit", 2).then(function(f) {
-    assert.ok(f.get("farmer"), "it has the embedded object");
+  return store.find("fruit", 2).then(result => {
+    assert.ok(result.get("farmer"), "result has the embedded object");
 
-    const fruitCols = f.get("colors");
-    assert.equal(fruitCols.length, 2);
-    assert.equal(fruitCols[0].get("id"), 1);
-    assert.equal(fruitCols[1].get("id"), 2);
+    const fruitColors = result.get("colors");
+    assert.equal(fruitColors.length, 2);
+    assert.equal(fruitColors[0].get("id"), 1);
+    assert.equal(fruitColors[1].get("id"), 2);
 
-    assert.ok(f.get("category"), "categories are found automatically");
+    assert.ok(result.get("category"), "categories are found automatically");
   });
 });
 
-QUnit.test("meta types", function(assert) {
+QUnit.test("meta types", assert => {
   const store = createStore();
-  return store.find("barn", 1).then(function(f) {
+  return store.find("barn", 1).then(result => {
     assert.equal(
-      f.get("owner.name"),
+      result.get("owner.name"),
       "Old MacDonald",
-      "it has the embedded farmer"
+      "result has the embedded farmer"
     );
   });
 });
 
-QUnit.test("findAll embedded", function(assert) {
+QUnit.test("findAll embedded", assert => {
   const store = createStore();
-  return store.findAll("fruit").then(function(fruits) {
-    assert.equal(fruits.objectAt(0).get("farmer.name"), "Old MacDonald");
+  return store.findAll("fruit").then(result => {
+    assert.equal(result.objectAt(0).get("farmer.name"), "Old MacDonald");
     assert.equal(
-      fruits.objectAt(0).get("farmer"),
-      fruits.objectAt(1).get("farmer"),
+      result.objectAt(0).get("farmer"),
+      result.objectAt(1).get("farmer"),
       "points at the same object"
     );
     assert.equal(
-      fruits.get("extras.hello"),
+      result.get("extras.hello"),
       "world",
       "it can supply extra information"
     );
 
-    const fruitCols = fruits.objectAt(0).get("colors");
-    assert.equal(fruitCols.length, 2);
-    assert.equal(fruitCols[0].get("id"), 1);
-    assert.equal(fruitCols[1].get("id"), 2);
+    const fruitColors = result.objectAt(0).get("colors");
+    assert.equal(fruitColors.length, 2);
+    assert.equal(fruitColors[0].get("id"), 1);
+    assert.equal(fruitColors[1].get("id"), 2);
 
-    assert.equal(fruits.objectAt(2).get("farmer.name"), "Luke Skywalker");
+    assert.equal(result.objectAt(2).get("farmer.name"), "Luke Skywalker");
   });
 });


### PR DESCRIPTION
*(This was brought up on meta.discourse.org: [Store: What’s the correct type of a record ID?](https://meta.discourse.org/t/store-what-s-the-correct-type-of-a-record-id/92605))*

---

This pull request addresses the inconsistent behavior of creating records in the store that have an ID property with the value `0`. Due to various checks like the following, records with ID 0 were treated like records without an ID.

```js
return !!attrs.id ? this._hydrate(type, attrs) : this._build(type, attrs);
```
I also renamed some instances of `obj` to `attrs`. If a method is called with an `attrs` parameter which the method doesn’t transform and then passes on to another method call, it should still be called `attrs`.