### PR TITLE
UX: clear topic timer text when manually closing/opening

### DIFF
--- a/app/assets/javascripts/discourse/components/topic-timer-info.js.es6
+++ b/app/assets/javascripts/discourse/components/topic-timer-info.js.es6
@@ -8,6 +8,7 @@ export default Ember.Component.extend(
     _delayedRerender: null,
 
     rerenderTriggers: [
+      "topicClosed",
       "statusType",
       "executeAt",
       "basedOnLastPost",
@@ -17,6 +18,9 @@ export default Ember.Component.extend(
 
     buildBuffer(buffer) {
       if (!this.get("executeAt")) return;
+
+      const topicClosed = this.get("topicClosed");
+      if (topicClosed !== undefined && (topicClosed ? "close" : "open") === this.get("statusType")) return;
 
       let statusUpdateAt = moment(this.get("executeAt"));
 

--- a/app/assets/javascripts/discourse/components/topic-timer-info.js.es6
+++ b/app/assets/javascripts/discourse/components/topic-timer-info.js.es6
@@ -19,8 +19,9 @@ export default Ember.Component.extend(
     buildBuffer(buffer) {
       if (!this.get("executeAt")) return;
 
-      const topicClosed = this.get("topicClosed");
-      if (topicClosed !== undefined && (topicClosed ? "close" : "open") === this.get("statusType")) return;
+      const topicStatus = this.get("topicClosed") ? "close" : "open";
+      const topicStatusKnown = this.get("topicClosed") !== undefined;
+      if (topicStatusKnown && topicStatus === this.get("statusType")) return;
 
       let statusUpdateAt = moment(this.get("executeAt"));
 

--- a/app/assets/javascripts/discourse/templates/topic.hbs
+++ b/app/assets/javascripts/discourse/templates/topic.hbs
@@ -223,12 +223,14 @@
 
               {{#if model.private_topic_timer.execute_at}}
                 {{topic-timer-info
+                    topicClosed=model.closed
                     statusType=model.private_topic_timer.status_type
                     executeAt=model.private_topic_timer.execute_at
                     duration=model.private_topic_timer.duration}}
               {{/if}}
 
               {{topic-timer-info
+                  topicClosed=model.closed
                   statusType=model.topic_timer.status_type
                   executeAt=model.topic_timer.execute_at
                   basedOnLastPost=model.topic_timer.based_on_last_post


### PR DESCRIPTION
> CONTEXT & DISCUSSION: https://meta.discourse.org/t/closing-a-topic-manually-doesnt-clear-the-topic-timers-automatic-closure/86203

As per title, a (hopefully) minor UX change. [Here](https://meta.discourse.org/t/closing-a-topic-manually-doesnt-clear-the-topic-timers-automatic-closure/86203/4?u=xrav3nz) is a demo of the changes.