### PR TITLE
Display "Replace Tags" and "Append Tags" buttons only if tagging is enabled.

### DIFF
--- a/app/assets/javascripts/discourse/controllers/topic-bulk-actions.js.es6
+++ b/app/assets/javascripts/discourse/controllers/topic-bulk-actions.js.es6
@@ -36,8 +36,10 @@ addBulkButton("relistTopics", "relist_topics", {
   icon: "eye",
   buttonVisible: topics => topics.some(t => !t.visible)
 });
-addBulkButton("showTagTopics", "change_tags", { icon: "tag" });
-addBulkButton("showAppendTagTopics", "append_tags", { icon: "tag" });
+if (Discourse.SiteSettings.tagging_enabled) {
+  addBulkButton("showTagTopics", "change_tags", { icon: "tag" });
+  addBulkButton("showAppendTagTopics", "append_tags", { icon: "tag" });
+}
 addBulkButton("deleteTopics", "delete", { icon: "trash", class: "btn-danger" });
 
 // Modal for performing bulk actions on topics


### PR DESCRIPTION
Fixes [this issue](https://meta.discourse.org/t/bulk-tag-buttons-appear-when-tagging-is-disabled/70092).