### PR TITLE
Make the login error message more informative if user tries to log in with cookies disabled.

### DIFF
--- a/app/assets/javascripts/discourse/controllers/login.js.es6
+++ b/app/assets/javascripts/discourse/controllers/login.js.es6
@@ -4,7 +4,7 @@ import showModal from "discourse/lib/show-modal";
 import { setting } from "discourse/lib/computed";
 import { findAll } from "discourse/models/login-method";
 import { escape } from "pretty-text/sanitizer";
-import { escapeExpression } from "discourse/lib/utilities";
+import { escapeExpression, areCookiesEnabled } from "discourse/lib/utilities";
 import { extractError } from "discourse/lib/ajax-error";
 import computed from "ember-addons/ember-computed-decorators";
 import { SECOND_FACTOR_METHODS } from "discourse/models/user";
@@ -180,6 +180,8 @@ export default Ember.Controller.extend(ModalFunctionality, {
           // Failed to login
           if (e.jqXHR && e.jqXHR.status === 429) {
             self.flash(I18n.t("login.rate_limit"), "error");
+          } else if (!areCookiesEnabled()) {
+            self.flash(I18n.t("login.cookies_error"), "error");
           } else {
             self.flash(I18n.t("login.error"), "error");
           }

--- a/app/assets/javascripts/discourse/lib/utilities.js.es6
+++ b/app/assets/javascripts/discourse/lib/utilities.js.es6
@@ -617,5 +617,17 @@ export function fillMissingDates(data, startDate, endDate) {
   return data;
 }
 
+export function areCookiesEnabled() {
+  // see: https://github.com/Modernizr/Modernizr/blob/400db4043c22af98d46e1d2b9cbc5cb062791192/feature-detects/cookies.js
+  try {
+    document.cookie = 'cookietest=1';
+    var ret = document.cookie.indexOf('cookietest=') !== -1;
+    document.cookie = 'cookietest=1; expires=Thu, 01-Jan-1970 00:00:01 GMT';
+    return ret;
+  } catch (e) {
+    return false;
+  }
+};
+
 // This prevents a mini racer crash
 export default {};

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1171,6 +1171,7 @@ en:
       email_placeholder: "email or username"
       caps_lock_warning: "Caps Lock is on"
       error: "Unknown error"
+      cookies_error: "Your browsers seems to have cookies disabled. You might not be able to log in without enabling them first."
       rate_limit: "Please wait before trying to log in again."
       blank_username: "Please enter your email or username."
       blank_username_or_password: "Please enter your email or username, and password."


### PR DESCRIPTION
Fixes [this issue](https://meta.discourse.org/t/unknown-error-when-trying-to-log-in-with-incorrect-credentials-with-cookies-disabled/79750).

The function which checks if cookies are enabled is a part of [Modernizr](https://github.com/Modernizr/Modernizr/blob/400db4043c22af98d46e1d2b9cbc5cb062791192/feature-detects/cookies.js).