### PR TITLE
Clear old text and URL when showing up the "Insert Hyperink" modal.

### DIFF
--- a/app/assets/javascripts/discourse/components/d-editor.js.es6
+++ b/app/assets/javascripts/discourse/components/d-editor.js.es6
@@ -870,6 +870,9 @@ export default Ember.Component.extend({
         return;
       }
 
+      this.set("linkUrl", "");
+      this.set("linkText", "");
+
       this._lastSel = this._getSelected();
 
       if (this._lastSel) {
@@ -943,9 +946,6 @@ export default Ember.Component.extend({
           this._selectText(sel.start + 1, origLink.length);
         }
       }
-
-      this.set("linkUrl", "");
-      this.set("linkText", "");
     },
 
     emoji() {

--- a/test/javascripts/components/d-editor-test.js.es6
+++ b/test/javascripts/components/d-editor-test.js.es6
@@ -241,6 +241,17 @@ testCase("link modal (cancel)", function(assert) {
   });
 });
 
+testCase("link modal (cancel clears inputs)", async function(assert) {
+  await click("button.link");
+  await fillIn(".insert-link input.link-url", "https://meta.discourse.org/");
+  await fillIn(".insert-link input.link-text", "Discourse Meta");
+  await click(".insert-link button.btn-danger");
+
+  await click("button.link");
+  assert.equal(this.$(".insert-link input.link-url")[0].value, "");
+  assert.equal(this.$(".insert-link input.link-text")[0].value, "");
+});
+
 testCase("link modal (simple link)", function(assert, textarea) {
   click("button.link");
 


### PR DESCRIPTION
Fixes [this issue](https://meta.discourse.org/t/hyperlink-modal-retains-text-on-cancel/75477).

Instead of clearing the text before showing the modal, it was cleared after a successful insert which caused the modal to retain data if the Cancel button was used.