### PR TITLE
Adds functionality to let the user change the first of week.

### DIFF
--- a/app/assets/javascripts/discourse/components/date-picker.js.es6
+++ b/app/assets/javascripts/discourse/components/date-picker.js.es6
@@ -21,7 +21,7 @@ export default Ember.Component.extend({
           container: container || this.$()[0],
           bound: container === undefined,
           format: "YYYY-MM-DD",
-          firstDay: 1,
+          firstDay: Discourse.User.currentProp("first_day_of_week"),
           i18n: {
             previousMonth: I18n.t("dates.previous_month"),
             nextMonth: I18n.t("dates.next_month"),

--- a/app/assets/javascripts/discourse/controllers/preferences/interface.js.es6
+++ b/app/assets/javascripts/discourse/controllers/preferences/interface.js.es6
@@ -27,6 +27,7 @@ export default Ember.Controller.extend(PreferencesTabController, {
       "locale",
       "external_links_in_new_tab",
       "dynamic_favicon",
+      "first_day_of_week",
       "enable_quoting",
       "disable_jump_reply",
       "automatically_unpin_topics",
@@ -88,6 +89,19 @@ export default Ember.Controller.extend(PreferencesTabController, {
       }
     });
     return result;
+  },
+
+  @computed()
+  daysOfWeek() {
+    return [
+      { name: "Monday",    value: 1 },
+      { name: "Tuesday",   value: 2 },
+      { name: "Wednesday", value: 3 },
+      { name: "Thursday",  value: 4 },
+      { name: "Friday",    value: 5 },
+      { name: "Saturday",  value: 6 },
+      { name: "Sunday",    value: 7 }
+    ];
   },
 
   actions: {

--- a/app/assets/javascripts/discourse/models/user.js.es6
+++ b/app/assets/javascripts/discourse/models/user.js.es6
@@ -262,6 +262,7 @@ const User = RestModel.extend({
       "email_private_messages",
       "email_previous_replies",
       "dynamic_favicon",
+      "first_day_of_week",
       "enable_quoting",
       "disable_jump_reply",
       "automatically_unpin_topics",
@@ -329,7 +330,8 @@ const User = RestModel.extend({
           this.get("user_option"),
           "enable_quoting",
           "external_links_in_new_tab",
-          "dynamic_favicon"
+          "dynamic_favicon",
+          "first_day_of_week"
         );
         Discourse.User.current().setProperties(userProps);
         this.setProperties(updatedState);

--- a/app/assets/javascripts/discourse/templates/preferences/interface.hbs
+++ b/app/assets/javascripts/discourse/templates/preferences/interface.hbs
@@ -30,6 +30,13 @@
   </div>
 </div>
 
+<div class="control-group first-day-of-week">
+  <label class="control-label">{{i18n 'user.first_day_of_week'}}</label>
+  <div class="controls">
+    {{combo-box content=daysOfWeek valueAttribute="value" value=model.user_option.first_day_of_week}}
+  </div>
+</div>
+
 <div class="control-group other">
   <label class="control-label">{{i18n 'user.other_settings'}}</label>
 

--- a/app/models/user_option.rb
+++ b/app/models/user_option.rb
@@ -184,6 +184,7 @@ end
 #  allow_private_messages           :boolean          default(TRUE), not null
 #  homepage_id                      :integer
 #  theme_ids                        :integer          default([]), not null, is an Array
+#  first_day_of_week                :integer          default(1), not null
 #
 # Indexes
 #

--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -17,6 +17,7 @@ class CurrentUserSerializer < BasicUserSerializer
              :enable_quoting,
              :external_links_in_new_tab,
              :dynamic_favicon,
+             :first_day_of_week,
              :trust_level,
              :can_send_private_email_messages,
              :can_edit,
@@ -81,6 +82,10 @@ class CurrentUserSerializer < BasicUserSerializer
 
   def dynamic_favicon
     object.user_option.dynamic_favicon
+  end
+
+  def first_day_of_week
+    object.user_option.first_day_of_week
   end
 
   def automatically_unpin_topics

--- a/app/serializers/user_option_serializer.rb
+++ b/app/serializers/user_option_serializer.rb
@@ -8,6 +8,7 @@ class UserOptionSerializer < ApplicationSerializer
              :email_direct,
              :external_links_in_new_tab,
              :dynamic_favicon,
+             :first_day_of_week,
              :enable_quoting,
              :disable_jump_reply,
              :digest_after_minutes,

--- a/app/services/user_updater.rb
+++ b/app/services/user_updater.rb
@@ -24,6 +24,7 @@ class UserUpdater
     :external_links_in_new_tab,
     :enable_quoting,
     :dynamic_favicon,
+    :first_day_of_week,
     :disable_jump_reply,
     :automatically_unpin_topics,
     :digest_after_minutes,

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -699,6 +699,7 @@ en:
       api_approved: "Approved:"
       theme: "Theme"
       home: "Default Home Page"
+      first_day_of_week: "First day of week"
       staged: "Staged"
 
       staff_counters:

--- a/db/migrate/20180721191805_add_first_day_of_week.rb
+++ b/db/migrate/20180721191805_add_first_day_of_week.rb
@@ -1,0 +1,5 @@
+class AddFirstDayOfWeek < ActiveRecord::Migration[5.2]
+  def change
+    add_column :user_options, :first_day_of_week, :integer, null: false, default: 1
+  end
+end


### PR DESCRIPTION
Fixes [this issue](https://meta.discourse.org/t/set-calendar-start-day-in-personal-preferences/91473/14).

This is work in progress as the desired outcome was not clearly specified.