### PR TITLE
Add different trigger for the emoji popup of French users.

### DIFF
--- a/app/assets/javascripts/discourse/components/d-editor.js.es6
+++ b/app/assets/javascripts/discourse/components/d-editor.js.es6
@@ -434,6 +434,10 @@ export default Ember.Component.extend({
           const full = `:${term}`;
           term = term.toLowerCase();
 
+          if (term.length < self.siteSettings.emoji_autocomplete_min_chars) {
+            return resolve([]);
+          }
+
           if (term === "") {
             return resolve(["slight_smile", "smile", "wink", "sunny", "blush"]);
           }

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1706,6 +1706,7 @@ en:
     enable_emoji_shortcuts: "Common smiley text such as :) :p :( will be converted to emojis"
     emoji_set: "How would you like your emoji?"
     enforce_square_emoji: "Force a square aspect ratio to all emojis."
+    emoji_autocomplete_min_chars: "Minimum number of characters required to trigger autocomplete emoji popup"
 
     approve_post_count: "The amount of posts from a new or basic user that must be approved"
     approve_unless_trust_level: "Posts for users below this trust level must be approved"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -676,6 +676,11 @@ posting:
     enum: 'EmojiSetSiteSetting'
   enforce_square_emoji:
     default: true
+  emoji_autocomplete_min_chars:
+    client: true
+    default: 0
+    locale_default:
+      fr: 1
   approve_post_count:
     default: 0
   approve_unless_trust_level:


### PR DESCRIPTION
Fixes [this issue](https://meta.discourse.org/t/default-emoji-plugin-how-to-disable/3415/71).