### PR TITLE
FIX: Don't rely on setting data type read from database

### DIFF
--- a/lib/site_settings/type_supervisor.rb
+++ b/lib/site_settings/type_supervisor.rb
@@ -100,7 +100,8 @@ class SiteSettings::TypeSupervisor
 
   def to_rb_value(name, value, override_type = nil)
     name = name.to_sym
-    type = @types[name] = (override_type || @types[name] || get_data_type(name, value))
+    @types[name] = (@types[name] || get_data_type(name, value))
+    type = (override_type || @types[name])
 
     case type
     when self.class.types[:float]

--- a/spec/components/site_setting_extension_spec.rb
+++ b/spec/components/site_setting_extension_spec.rb
@@ -124,6 +124,15 @@ describe SiteSettingExtension do
       expect(settings2.hello).to eq(99)
     end
 
+    it "does not override types in the type supervisor" do
+      settings.setting(:foo, "bar")
+      settings.provider.save(:foo, "bar", SiteSetting.types[:enum])
+      settings.refresh!
+      expect(settings.foo).to eq("bar")
+
+      settings.foo = "baz"
+      expect(settings.foo).to eq("baz")
+    end
   end
 
   describe "multisite" do

--- a/spec/components/site_settings/type_supervisor_spec.rb
+++ b/spec/components/site_settings/type_supervisor_spec.rb
@@ -275,6 +275,12 @@ describe SiteSettings::TypeSupervisor do
         expect(settings.type_supervisor.to_rb_value(:type_custom, 2)).to eq 2
         expect(settings.type_supervisor.to_rb_value(:type_custom, '2|3')).to eq '2|3'
       end
+
+      it 'should not modify the types of settings' do
+        types = SiteSettings::TypeSupervisor.types
+        settings.type_supervisor.to_rb_value(:default_locale, 'fr', types[:enum])
+        expect(settings.type_supervisor.to_db_value(:default_locale, 'en')).to eq(['en', types[:string]])
+      end
     end
   end
 


### PR DESCRIPTION
Editing a site setting could fail when the datatype of a setting was changed and that setting was saved to the DB before the the datatype was changed. E.g. this did prevent changing the `default_locale` when the DB contained 7 (`enum`) and the app expected 1 (`string`).

I changed it so that it uses the datatype from the DB when reading the value, but otherwise always lets the Ruby calculate the right datatype.

@tgxworld Could you please take a quick look since you wrote most of the code around site settings?