### PR TITLE
removes rubocop from dangerfile for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,6 @@ install:
   - bash -c "if [ '$RAILS_MASTER' == '1' ]; then bundle update --retry=3 --jobs=3 arel rails seed-fu > /dev/null; fi"
   - bash -c "if [ '$RAILS_MASTER' == '0' ]; then bundle install --without development --deployment --retry=3 --jobs=3 > /dev/null; fi"
   - bash -c "if [ '$RUN_LINT' == '1' ]; then yarn global add eslint babel-eslint prettier > /dev/null; fi"
-  - bash -c "if [ '$RUN_LINT' == '1' ]; then gem install rubocop > /dev/null; fi"
   - bash -c "if [ '$QUNIT_RUN' == '1' ]; then yarn install --dev > /dev/null; fi"
   - bash -c "if [ '$RUN_LINT' != '1' ]; then bundle exec rake db:create db:migrate > /dev/null; fi"
 
@@ -73,6 +72,7 @@ script:
   - |
     bash -c "
       if [ '$RUN_LINT' == '1' ]; then
+        bundle exec rubocop --parallel && \
         bundle exec danger && \
         eslint --ext .es6 app/assets/javascripts && \
         eslint --ext .es6 test/javascripts && \

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,31 +1,5 @@
-require 'json'
-require 'shellwords'
-
 if git.lines_of_code > 500
   warn("This PR seems big, we prefer smaller PR. Please be sure this is needed and can't be split in smaller PRs.")
-end
-
-to_lint = git.modified_files + git.added_files
-files_to_lint = Shellwords.join(to_lint)
-rubocop_output = `bundle exec rubocop -f json --parallel #{files_to_lint}`
-if !rubocop_output.empty?
-  offenses = JSON.parse(rubocop_output)['files']
-    .select { |f| f['offenses'].any? }
-
-  def format_offense(offense)
-    output = "file: #{offense['path']}\n"
-    offense['offenses'].each do |o|
-      output << "#{o['message']} (line:#{o['location']['start_line']}, col:#{o['location']['start_column']})\n"
-    end
-    output << "\n"
-  end
-
-  if !offenses.empty?
-    fail(%{
-This PR has multiple rubocop offenses. We recommend configuring prettier linting in your editor:\n
-#{offenses.map { |o| format_offense(o) }.join('\n') }
-    })
-  end
 end
 
 prettier_offenses = `prettier --list-different "app/assets/stylesheets/**/*.scss" "app/assets/javascripts/**/*.es6" "test/javascripts/**/*.es6"`.split('\n')


### PR DESCRIPTION
This will be re-enabled once I can reproduce and fix errors using travis local docker build.