### PR TITLE
allow auth plugins to have a site setting for full screen login

### DIFF
--- a/app/assets/javascripts/discourse/models/login-method.js.es6
+++ b/app/assets/javascripts/discourse/models/login-method.js.es6
@@ -47,7 +47,17 @@ const LoginMethod = Ember.Object.extend({
       customLogin();
     } else {
       let authUrl = this.get("customUrl") || Discourse.getURL("/auth/" + name);
-      if (this.get("fullScreenLogin")) {
+
+      // first check if this plugin has a site setting for full screen login before using the static setting
+      let fullScreenLogin = false;
+      const fullScreenLoginSetting = this.get("fullScreenLoginSetting");
+      if (!Ember.isEmpty(fullScreenLoginSetting)) {
+        fullScreenLogin = this.siteSettings[fullScreenLoginSetting];
+      } else {
+        fullScreenLogin = this.get("fullScreenLogin")
+      }
+
+      if (fullScreenLogin) {
         document.cookie = "fsl=true";
         window.location = authUrl;
       } else {

--- a/app/assets/javascripts/discourse/models/login-method.js.es6
+++ b/app/assets/javascripts/discourse/models/login-method.js.es6
@@ -54,7 +54,7 @@ const LoginMethod = Ember.Object.extend({
       if (!Ember.isEmpty(fullScreenLoginSetting)) {
         fullScreenLogin = this.siteSettings[fullScreenLoginSetting];
       } else {
-        fullScreenLogin = this.get("fullScreenLogin")
+        fullScreenLogin = this.get("fullScreenLogin");
       }
 
       if (fullScreenLogin) {

--- a/lib/plugin/auth_provider.rb
+++ b/lib/plugin/auth_provider.rb
@@ -2,7 +2,8 @@ class Plugin::AuthProvider
 
   def self.auth_attributes
     [:glyph, :background_color, :pretty_name, :title, :message, :frame_width, :frame_height, :authenticator,
-     :pretty_name_setting, :title_setting, :enabled_setting, :full_screen_login, :custom_url]
+     :pretty_name_setting, :title_setting, :enabled_setting, :full_screen_login, :full_screen_login_setting,
+     :custom_url]
   end
 
   attr_accessor(*auth_attributes)
@@ -23,6 +24,7 @@ class Plugin::AuthProvider
     result['frameWidth'] = frame_width if frame_width
     result['frameHeight'] = frame_height if frame_height
     result['fullScreenLogin'] = full_screen_login if full_screen_login
+    result['fullScreenLoginSetting'] = full_screen_login_setting if full_screen_login_setting
     result.to_json
   end
 


### PR DESCRIPTION
this doesn't seem ideal but it doesn't appear there is any way for an auth plugin to use site settings to set full_screen_login otherwise.