### PR TITLE
Order moderators_activity report by moderator username

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -635,7 +635,7 @@ class Report
     report.data = []
     mod_data = {}
 
-    User.real.where(moderator: true).find_each do |u|
+    User.real.where(moderator: true).order(:username_lower).each do |u|
       mod_data[u.id] = {
         user_id: u.id,
         username: u.username,


### PR DESCRIPTION
To get this to work, I've had to change `User.real.where(moderator: true).find_each` to `User.real.where(moderator: true).order(:username_lower).each`. 

If this is a problem, the query that sets up the `mod_data` hash could be left as it is and then ordered with  `mod_data = mod_data.sort_by{ |k, v| v[:username].downcase }.to_h`