### PR TITLE
FEATURE: Admin wrench action to change topic bump date and disable bumping

### DIFF
--- a/app/assets/javascripts/discourse/controllers/bump-topic.js.es6
+++ b/app/assets/javascripts/discourse/controllers/bump-topic.js.es6
@@ -1,0 +1,79 @@
+import ModalFunctionality from "discourse/mixins/modal-functionality";
+import computed from "ember-addons/ember-computed-decorators";
+import DiscourseURL from "discourse/lib/url";
+import Topic from "discourse/models/topic";
+
+// Modal for enabling/disabling bumping of topics and changing the bump date
+export default Ember.Controller.extend(ModalFunctionality, {
+  topicController: Ember.inject.controller("topic"),
+  saving: false,
+  date: "",
+  time: "",
+  skipBump: false,
+  updateDate: false,
+
+  @computed("saving")
+  buttonTitle(saving) {
+    return saving ? I18n.t("saving") : I18n.t("topic.bump.action");
+  },
+
+  @computed("date", "time")
+  bumpedAt(date, time) {
+    return moment(date + " " + time, "YYYY-MM-DD HH:mm:ss");
+  },
+
+  @computed("bumpedAt")
+  validBumpDate(bumpedAt) {
+    return moment().diff(bumpedAt, "minutes") < 0;
+  },
+
+  @computed("saving", "date", "validBumpDate", "skipBump", "updateDate")
+  buttonDisabled() {
+    if (this.get("saving")) return true;
+
+    if (this.get("updateDate")) {
+      return this.get("validBumpDate") || Ember.isEmpty(this.get("date"));
+    }
+
+    const topic = this.get("topicController.model");
+    return this.get("skipBump") === Boolean(topic.skip_bump);
+  },
+
+  onShow() {
+    const topic = this.get("topicController.model");
+    const bumpedAt = moment(topic.bumped_at);
+
+    this.setProperties({
+      saving: false,
+      skipBump: Boolean(topic.skip_bump),
+      updateDate: false,
+      date: bumpedAt.format("YYYY-MM-DD"),
+      time: bumpedAt.format("HH:mm")
+    });
+  },
+
+  actions: {
+    save: function() {
+      this.set("saving", true);
+      const self = this,
+        topic = this.get("topicController.model");
+
+      Topic.updateBump(
+        topic.get("id"),
+        this.get("skipBump"),
+        this.get("updateDate") ? this.get("bumpedAt").unix() : null
+      )
+        .then(function() {
+          self.send("closeModal");
+          Em.run.next(() => {
+            DiscourseURL.routeTo(topic.get("url"));
+          });
+        })
+        .catch(function() {
+          self.flash(I18n.t("topic.bump.error"), "alert-error");
+          self.set("saving", false);
+        });
+      return false;
+    }
+  }
+});

--- a/app/assets/javascripts/discourse/models/topic.js.es6
+++ b/app/assets/javascripts/discourse/models/topic.js.es6
@@ -687,6 +687,17 @@ Topic.reopenClass({
     return promise;
   },
 
+  updateBump(topicId, skipBump, bumpedAt) {
+    const promise = ajax("/t/" + topicId + "/update-bump", {
+      type: "PUT",
+      data: { skip_bump: skipBump, bumped_at: bumpedAt }
+    }).then(function(result) {
+      if (result.success) return result;
+      promise.reject(new Error("error updating bump date of topic"));
+    });
+    return promise;
+  },
+
   bulkOperation(topics, operation) {
     return ajax("/topics/bulk", {
       type: "PUT",

--- a/app/assets/javascripts/discourse/routes/topic.js.es6
+++ b/app/assets/javascripts/discourse/routes/topic.js.es6
@@ -77,6 +77,13 @@ const TopicRoute = Discourse.Route.extend({
       });
     },
 
+    showBumpTopic() {
+      showModal("bump-topic", {
+        model: this.modelFor("topic"),
+        title: "topic.bump.title"
+      });
+    },
+
     showFeatureTopic() {
       showModal("featureTopic", {
         model: this.modelFor("topic"),

--- a/app/assets/javascripts/discourse/templates/components/topic-footer-buttons.hbs
+++ b/app/assets/javascripts/discourse/templates/components/topic-footer-buttons.hbs
@@ -13,6 +13,7 @@
       showTopicStatusUpdate=showTopicStatusUpdate
       showFeatureTopic=showFeatureTopic
       showChangeTimestamp=showChangeTimestamp
+      showBumpTopic=showBumpTopic
       convertToPublicTopic=convertToPublicTopic
       convertToPrivateMessage=convertToPrivateMessage}}
   {{/if}}

--- a/app/assets/javascripts/discourse/templates/modal/bump-topic.hbs
+++ b/app/assets/javascripts/discourse/templates/modal/bump-topic.hbs
@@ -1,0 +1,26 @@
+{{#d-modal-body class="bump-topic"}}
+  <form>
+    <label class='checkbox-label'>
+      {{input type="checkbox" checked=skipBump}}
+      {{i18n "topic.bump.disable"}}
+    </label>
+
+    <p class="alert alert-error {{unless validBumpDate 'hidden'}}">
+      {{i18n 'topic.bump.invalid_date'}}
+    </p>
+
+    <label class='checkbox-label'>
+      {{input type="checkbox" checked=updateDate}}
+      {{i18n "topic.bump.update_date"}}
+    </label>
+
+    {{date-picker-past value=date defaultDate=date containerId="date-container"}}
+    {{input type="time" value=time}}
+
+    <div id="date-container"/>
+  </form>
+{{/d-modal-body}}
+
+<div class="modal-footer">
+  <button class="btn btn-primary" disabled={{buttonDisabled}} {{action "save"}}>{{i18n 'topic.bump.action'}}</button>
+</div>

--- a/app/assets/javascripts/discourse/templates/topic.hbs
+++ b/app/assets/javascripts/discourse/templates/topic.hbs
@@ -94,6 +94,7 @@
               showTopicStatusUpdate=(action "topicRouteAction" "showTopicStatusUpdate")
               showFeatureTopic=(action "topicRouteAction" "showFeatureTopic")
               showChangeTimestamp=(action "topicRouteAction" "showChangeTimestamp")
+              showBumpTopic=(action "topicRouteAction" "showBumpTopic")
               convertToPublicTopic=(action "convertToPublicTopic")
               convertToPrivateMessage=(action "convertToPrivateMessage")}}
           {{/if}}
@@ -121,6 +122,7 @@
             showTopicStatusUpdate=(action "topicRouteAction" "showTopicStatusUpdate")
             showFeatureTopic=(action "topicRouteAction" "showFeatureTopic")
             showChangeTimestamp=(action "topicRouteAction" "showChangeTimestamp")
+            showBumpTopic=(action "topicRouteAction" "showBumpTopic")
             convertToPublicTopic=(action "convertToPublicTopic")
             convertToPrivateMessage=(action "convertToPrivateMessage")}}
         {{else}}
@@ -144,6 +146,7 @@
                 showTopicStatusUpdate=(action "topicRouteAction" "showTopicStatusUpdate")
                 showFeatureTopic=(action "topicRouteAction" "showFeatureTopic")
                 showChangeTimestamp=(action "topicRouteAction" "showChangeTimestamp")
+                showBumpTopic=(action "topicRouteAction" "showBumpTopic")
                 convertToPublicTopic=(action "convertToPublicTopic")
                 convertToPrivateMessage=(action "convertToPrivateMessage")}}
             {{/if}}
@@ -256,6 +259,7 @@
                     showTopicStatusUpdate=(action "topicRouteAction" "showTopicStatusUpdate")
                     showFeatureTopic=(action "topicRouteAction" "showFeatureTopic")
                     showChangeTimestamp=(action "topicRouteAction" "showChangeTimestamp")
+                    showBumpTopic=(action "topicRouteAction" "showBumpTopic")
                     convertToPublicTopic=(action "convertToPublicTopic")
                     convertToPrivateMessage=(action "convertToPrivateMessage")
                     toggleBookmark=(action "toggleBookmark")

--- a/app/assets/javascripts/discourse/widgets/topic-admin-menu.js.es6
+++ b/app/assets/javascripts/discourse/widgets/topic-admin-menu.js.es6
@@ -201,6 +201,13 @@ export default createWidget("topic-admin-menu", {
         icon: "calendar",
         label: "change_timestamp.title"
       });
+
+      buttons.push({
+        className: "topic-admin-bump",
+        action: "showBumpTopic",
+        icon: "level-up",
+        label: "actions.bump"
+      });
     }
 
     if (!isPrivateMessage) {

--- a/app/assets/stylesheets/common/base/modal.scss
+++ b/app/assets/stylesheets/common/base/modal.scss
@@ -466,7 +466,8 @@
 }
 
 .change-timestamp,
-.poll-ui-builder {
+.poll-ui-builder,
+.bump-topic {
   .date-picker {
     width: 9em;
   }

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -429,6 +429,7 @@ class Category < ActiveRecord::Base
       .where(category_id: self.id)
       .where('id <> ?', self.topic_id)
       .where('bumped_at < ?', 1.day.ago)
+      .where('skip_bump IS NULL OR skip_bump = FALSE')
       .where('pinned_at IS NULL AND NOT closed AND NOT archived')
       .order('bumped_at ASC')
       .limit(1)

--- a/app/models/post_mover.rb
+++ b/app/models/post_mover.rb
@@ -220,7 +220,7 @@ class PostMover
       attrs = {}
       attrs[:last_posted_at] = post.created_at
       attrs[:last_post_user_id] = post.user_id
-      attrs[:bumped_at] = post.created_at unless post.no_bump
+      attrs[:bumped_at] = post.created_at unless post.no_bump || destination_topic.skip_bump
       attrs[:updated_at] = Time.now
       destination_topic.update_columns(attrs)
     end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1457,6 +1457,7 @@ end
 #  fancy_title               :string(400)
 #  highest_staff_post_number :integer          default(0), not null
 #  featured_link             :string
+#  skip_bump                 :boolean
 #
 # Indexes
 #

--- a/app/serializers/topic_view_serializer.rb
+++ b/app/serializers/topic_view_serializer.rb
@@ -40,7 +40,9 @@ class TopicViewSerializer < ApplicationSerializer
                         :featured_link_root_domain,
                         :pinned_globally,
                         :pinned_at,
-                        :pinned_until
+                        :pinned_until,
+                        :skip_bump,
+                        :bumped_at
 
   attributes :draft,
              :draft_key,
@@ -295,6 +297,14 @@ class TopicViewSerializer < ApplicationSerializer
     scope.can_create_shared_draft? &&
       object.topic.category_id == SiteSetting.shared_drafts_category.to_i &&
       object.topic.shared_draft.present?
+  end
+
+  def include_skip_bump?
+    scope.can_update_bump?
+  end
+
+  def include_bumped_at?
+    scope.can_update_bump?
   end
 
   private

--- a/app/serializers/web_hook_topic_view_serializer.rb
+++ b/app/serializers/web_hook_topic_view_serializer.rb
@@ -20,6 +20,8 @@ class WebHookTopicViewSerializer < TopicViewSerializer
     topic_timer
     private_topic_timer
     details
+    bumped_at
+    skip_bump
   }.each do |attr|
     define_method("include_#{attr}?") do
       false

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1857,6 +1857,7 @@ en:
         reset_read: "Reset Read Data"
         make_public: "Make Public Topic"
         make_private: "Make Personal Message"
+        bump: "Bump Topic…"
 
       feature:
         pin: "Pin Topic"
@@ -1993,6 +1994,14 @@ en:
         invalid_timestamp: "Timestamp cannot be in the future."
         error: "There was an error changing the timestamp of the topic."
         instructions: "Please select the new timestamp of the topic. Posts in the topic will be updated to have the same time difference."
+
+      bump:
+        title: "Bump Topic…"
+        disable: "Disable bumping for this topic"
+        update_date: "Update bump date"
+        invalid_date: "Bump date cannot be in the future."
+        error: "There was an error changing the bump date of the topic."
+        action: "Save"
 
       multi_select:
         select: 'select'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -698,6 +698,7 @@ Discourse::Application.routes.draw do
   post "t/:topic_id/merge-topic" => "topics#merge_topic", constraints: { topic_id: /\d+/ }
   post "t/:topic_id/change-owner" => "topics#change_post_owners", constraints: { topic_id: /\d+/ }
   put "t/:topic_id/change-timestamp" => "topics#change_timestamps", constraints: { topic_id: /\d+/ }
+  put "t/:topic_id/update-bump" => "topics#update_bump", constraints: { topic_id: /\d+/ }
   delete "t/:topic_id/timings" => "topics#destroy_timings", constraints: { topic_id: /\d+/ }
   put "t/:topic_id/bookmark" => "topics#bookmark", constraints: { topic_id: /\d+/ }
   put "t/:topic_id/remove_bookmarks" => "topics#remove_bookmarks", constraints: { topic_id: /\d+/ }

--- a/db/migrate/20180801123455_add_skip_bump_to_topics.rb
+++ b/db/migrate/20180801123455_add_skip_bump_to_topics.rb
@@ -1,0 +1,5 @@
+class AddSkipBumpToTopics < ActiveRecord::Migration[5.2]
+  def change
+    add_column :topics, :skip_bump, :boolean
+  end
+end

--- a/lib/guardian/topic_guardian.rb
+++ b/lib/guardian/topic_guardian.rb
@@ -146,4 +146,8 @@ module TopicGuardian
     return false unless SiteSetting.topic_featured_link_enabled
     Category.where(id: category_id || SiteSetting.uncategorized_category_id, topic_featured_link_allowed: true).exists?
   end
+
+  def can_update_bump?
+    is_admin?
+  end
 end

--- a/lib/post_creator.rb
+++ b/lib/post_creator.rb
@@ -412,7 +412,7 @@ class PostCreator
       attrs[:last_post_user_id] = @post.user_id
       attrs[:word_count] = (@topic.word_count || 0) + @post.word_count
       attrs[:excerpt] = @post.excerpt_for_topic if new_topic?
-      attrs[:bumped_at] = @post.created_at unless @post.no_bump
+      attrs[:bumped_at] = @post.created_at unless @post.no_bump || @topic.skip_bump
       attrs[:updated_at] = Time.now
       @topic.update_columns(attrs)
     end

--- a/lib/post_revisor.rb
+++ b/lib/post_revisor.rb
@@ -511,7 +511,7 @@ class PostRevisor
   end
 
   def bypass_bump?
-    !@post_successfully_saved || @topic_changes.errored? || @opts[:bypass_bump] == true
+    !@post_successfully_saved || @topic_changes.errored? || @opts[:bypass_bump] == true || @topic.skip_bump
   end
 
   def is_last_post?

--- a/spec/models/post_mover_spec.rb
+++ b/spec/models/post_mover_spec.rb
@@ -353,6 +353,16 @@ describe PostMover do
           moderator_post = topic.posts.find_by(post_number: 2)
           expect(moderator_post.raw).to include("4 posts were merged")
         end
+
+        it "doesn't bump the topic when bumping is disabled" do
+          destination_topic.update_attribute(:skip_bump, true)
+          destination_topic.reload
+
+          expect {
+            topic.move_posts(user, [p2.id], destination_topic_id: destination_topic.id)
+            destination_topic.reload
+          }.to_not change(destination_topic, :bumped_at)
+        end
       end
 
       shared_examples "moves email related stuff" do

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -784,6 +784,33 @@ describe Topic do
         }.not_to change(@topic, :bumped_at)
       end
     end
+
+    context "bumping disabled" do
+      before do
+        @last_post = Fabricate(:post, topic: @topic, user: @topic.user)
+        @topic.update_attribute(:skip_bump, true)
+        @topic.reload
+      end
+
+      after do
+        @topic.update_attribute(:skip_bump, false)
+      end
+
+      it "editing the last post doesn't bump the topic" do
+        expect {
+          @last_post.revise(Fabricate(:moderator), raw: 'updated contents')
+          @topic.reload
+        }.to_not change(@topic, :bumped_at)
+      end
+
+      it "creating a post doesn't bump the topic" do
+        @topic.update_attribute(:skip_bump, true)
+        expect {
+          create_post(topic: @topic, user: @topic.user)
+          @topic.reload
+        }.to_not change(@topic, :bumped_at)
+      end
+    end
   end
 
   context 'moderator posts' do

--- a/spec/serializers/topic_view_serializer_spec.rb
+++ b/spec/serializers/topic_view_serializer_spec.rb
@@ -130,4 +130,20 @@ describe TopicViewSerializer do
       expect(json[:tags]).to eq([])
     end
   end
+
+  context "bump date" do
+    let(:moderator) { Fabricate(:moderator) }
+
+    it "should not include bumped_at and skip_bump for users and moderators" do
+      [user, moderator].each do |user|
+        json = serialize_topic(topic, user)
+        expect(json).to_not include(:bumped_at, :skip_bump)
+      end
+    end
+
+    it "should include bumped_at and skip_bump for admins" do
+      json = serialize_topic(topic, admin)
+      expect(json).to include(:bumped_at, :skip_bump)
+    end
+  end
 end


### PR DESCRIPTION
Adds a new action to the admin wrench of topics.

![image](https://user-images.githubusercontent.com/473736/43680639-361d1a30-983f-11e8-9cd3-fc90f2684911.png)

The dialog allows disabling bumping of the selected topic which prevents bumps by replying to the topic, editing the topic's last post or autobumping within the category.
In addition to that it allows changing the topic's bump date to an arbitrary value <= now. The date picker defaults to the current bump date.

![image](https://user-images.githubusercontent.com/473736/43680655-57e38816-983f-11e8-9ae3-16b7143c5407.png)

* Adds a new column (`skip_bump`) to the `topics` table. It doesn't set a default value in order to prevent long locks on the table during the migration. `NULL` is considered to be `false`.
* Adds `bumped_at` and `skip_bump` to the topic serializer if the current user is an admin.