### PR TITLE
FIX: don't require auth providers to set full_screen_login_setting

### DIFF
--- a/app/serializers/auth_provider_serializer.rb
+++ b/app/serializers/auth_provider_serializer.rb
@@ -15,6 +15,7 @@ class AuthProviderSerializer < ApplicationSerializer
 
   def full_screen_login
     return SiteSetting.send(object.full_screen_login_setting) if object.full_screen_login_setting
+    return object.full_screen_login if object.full_screen_login
     false
   end
 


### PR DESCRIPTION
@davidtaylorhq not sure if this was your intention, but https://github.com/discourse/discourse/commit/812add18bdb071d757a6faff4358f0252122f946 forced non-fsl on authentication providers which set `full_screen_login` but don't set `full_screen_login_setting`. This fixes that.