### PR TITLE
FIX: wrongful redirections when topic starts with BaseUri

### DIFF
--- a/app/assets/javascripts/discourse/lib/discourse-location.js.es6
+++ b/app/assets/javascripts/discourse/lib/discourse-location.js.es6
@@ -66,7 +66,10 @@ const DiscourseLocation = Ember.Object.extend({
   getURL() {
     const location = get(this, "location");
     let url = location.pathname;
-    url = url.replace(Discourse.BaseUri, "");
+
+    if (Discourse.BaseUri.length() > 0 && url.startsWith(Discourse.BaseUri)) {
+      url = url.substring(Discourse.BaseUri.length);
+    }
 
     const search = location.search || "";
     url += search;


### PR DESCRIPTION
Fixes https://meta.discourse.org/t/discourse-rewriting-url-path-behaviour-failing/94120