### PR TITLE
FIX: create tmp if it doesn't exist when creating tmp/pids

### DIFF
--- a/config/unicorn.conf.rb
+++ b/config/unicorn.conf.rb
@@ -19,7 +19,7 @@ listen (ENV["UNICORN_PORT"] || 3000).to_i
 timeout 30
 
 if !File.exist?("#{discourse_path}/tmp/pids")
-  Dir.mkdir("#{discourse_path}/tmp/pids")
+  FileUtils.mkdir_p("#{discourse_path}/tmp/pids")
 end
 
 # feel free to point this anywhere accessible on the filesystem


### PR DESCRIPTION
After [this change](https://github.com/discourse/discourse/commit/f3549291a36157932ad015799aca6d39ccec083d#diff-26ac62db6c6a4582de3bbf2615790c23R22) I get this error if I stop a dev server, ``rm -rf tmp`` and start it again:
```
`mkdir': No such file or directory @ dir_s_mkdir - /Users/angusmcleod/discourse/discourse/tmp/pids (Errno::ENOENT)
```
This fixes it.