### PR TITLE
FEATURE: Do encodeURI on share links if needed.

### DIFF
--- a/app/assets/javascripts/discourse/components/share-popup.js.es6
+++ b/app/assets/javascripts/discourse/components/share-popup.js.es6
@@ -81,7 +81,7 @@ export default Ember.Component.extend({
     if (!this.site.mobileView) {
       $this.css({ left: "" + x + "px" });
     }
-    this.set("link", url);
+    this.set("link", encodeURI(url));
     this.set("visible", true);
 
     Ember.run.scheduleOnce("afterRender", this, this._focusUrl);


### PR DESCRIPTION
Some Discourse-supported sharing platforms such as Twitter are unable to determine the end of a unicode URL. If you post a URL "https://example.org/t/测试/1" on Twitter, it will be a link of `href="https://example.org/t/"`

If the URL contains any unicode character (usually in the slug part) , it must be urlencoded with `encodeURI(url)` before being passed to `source.generateUrl(link, title)`, or it will be a malformed URL in the sharing tweet.