### PR TITLE
FIX: disable_2fa fix method selection

### DIFF
--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -143,7 +143,7 @@ desc "Disable 2FA for user with the given username"
 task "users:disable_2fa", [:username] => [:environment] do |_, args|
   username = args[:username]
   user = find_user(username)
-  UserSecondFactor.totp.where(user_id: user.id).each(&:destroy!)
+  UserSecondFactor.where(user_id: user.id, method: UserSecondFactor.methods[:totp]).each(&:destroy!)
   puts "2FA disabled for #{username}"
 end
 


### PR DESCRIPTION
The previous code resulted in

    NameError: undefined local variable or method `totp' for main:Object

I now understand what @tgxworld meant about we should only disable totp when I submitted this before.

This is the kind of Ruby stuff that I still don't understand well,(perhaps this isn't the most Ruby way to do this?) but this does what I think is supposed to happen. And it worked just now.