### PR TITLE
Remove unnecessary code in d-editor CSS

### DIFF
--- a/app/assets/stylesheets/common/d-editor.scss
+++ b/app/assets/stylesheets/common/d-editor.scss
@@ -75,7 +75,6 @@
 .d-editor-button-bar {
   display: flex;
   align-items: center;
-  border-bottom: none;
   min-height: 30px;
   padding-left: 3px;
   border-bottom: 1px solid $primary-low;


### PR DESCRIPTION
Just a quick one-line edit of the d-editor CSS. There was a `border-bottom: none;` that gets overridden a few lines below by `border-bottom: 1px solid $primary-low;` making it unnecessary.