### PR TITLE
FIX: Do not show an empty modal when an IP address is allowed or blocked.

### DIFF
--- a/app/assets/javascripts/admin/components/screened-ip-address-form.js.es6
+++ b/app/assets/javascripts/admin/components/screened-ip-address-form.js.es6
@@ -59,18 +59,14 @@ export default Ember.Component.extend({
         screenedIpAddress
           .save()
           .then(result => {
-            if (result.success) {
-              this.setProperties({ ip_address: "", formSubmitted: false });
-              this.sendAction(
-                "action",
-                ScreenedIpAddress.create(result.screened_ip_address)
-              );
-              Ember.run.schedule("afterRender", () =>
-                this.$(".ip-address-input").focus()
-              );
-            } else {
-              bootbox.alert(result.errors);
-            }
+            this.setProperties({ ip_address: "", formSubmitted: false });
+            this.sendAction(
+              "action",
+              ScreenedIpAddress.create(result.screened_ip_address)
+            );
+            Ember.run.schedule("afterRender", () =>
+              this.$(".ip-address-input").focus()
+            );
           })
           .catch(e => {
             this.set("formSubmitted", false);

--- a/app/assets/javascripts/admin/controllers/admin-logs-screened-ip-addresses.js.es6
+++ b/app/assets/javascripts/admin/controllers/admin-logs-screened-ip-addresses.js.es6
@@ -46,19 +46,14 @@ export default Ember.Controller.extend({
       record.set("editing", false);
       record
         .save()
-        .then(saved => {
-          if (saved.success) {
-            this.set("savedIpAddress", null);
-          } else {
-            bootbox.alert(saved.errors);
-            if (wasEditing) record.set("editing", true);
-          }
+        .then(() => {
+          this.set("savedIpAddress", null);
         })
         .catch(e => {
-          if (e.responseJSON && e.responseJSON.errors) {
+          if (e.jqXHR.responseJSON && e.jqXHR.responseJSON.errors) {
             bootbox.alert(
               I18n.t("generic_error_with_reason", {
-                error: e.responseJSON.errors.join(". ")
+                error: e.jqXHR.responseJSON.errors.join(". ")
               })
             );
           } else {

--- a/app/controllers/admin/screened_ip_addresses_controller.rb
+++ b/app/controllers/admin/screened_ip_addresses_controller.rb
@@ -33,7 +33,7 @@ class Admin::ScreenedIpAddressesController < Admin::AdminController
 
   def update
     if @screened_ip_address.update_attributes(allowed_params)
-      render json: success_json
+      render_serialized(@screened_ip_address, ScreenedIpAddressSerializer)
     else
       render_json_error(@screened_ip_address)
     end


### PR DESCRIPTION
Fixes [this](https://meta.discourse.org/t/blacklisting-ip-has-no-feedback/94513).