### PR TITLE
FIX: use UserBadgeSerializer::UserSerializer for user_badge.granted_by

### DIFF
--- a/app/serializers/detailed_user_badge_serializer.rb
+++ b/app/serializers/detailed_user_badge_serializer.rb
@@ -1,5 +1,5 @@
 class DetailedUserBadgeSerializer < BasicUserBadgeSerializer
-  has_one :granted_by
+  has_one :granted_by, serializer: UserBadgeSerializer::UserSerializer
 
   attributes :post_number, :topic_id, :topic_title
 


### PR DESCRIPTION
> DISCUSSION: https://meta.discourse.org/t/trouble-accessing-preferences-after-upgrade-to-discourse-2-1-0-beta4/94253/2?u=xrav3nz

`UserSerializer` is making tons of SQL queries on the fly when serializing `user_badge.granted_by`. Using `UserBadgeSerializer::UserSerializer` cuts down the number of queries from 81 to 8 locally for me.

From what I can see, `granted_by` is only used in:

https://github.com/discourse/discourse/blob/7f4ef3db9e1a2794083bf99f5f1f8e17b24de54c/app/assets/javascripts/admin/templates/user-badges.hbs#L42-L45

and `UserBadgeSerializer::UserSerializer` serializes enough information for it.