### PR TITLE
Add JSONB `data` field to PluginStoreRow

### DIFF
--- a/app/models/plugin_store_row.rb
+++ b/app/models/plugin_store_row.rb
@@ -10,6 +10,7 @@ end
 #  key         :string           not null
 #  type_name   :string           not null
 #  value       :text
+#  data        :jsonb
 #
 # Indexes
 #

--- a/db/migrate/20180814190139_add_data_to_plugin_store_rows.rb
+++ b/db/migrate/20180814190139_add_data_to_plugin_store_rows.rb
@@ -1,0 +1,5 @@
+class AddDataToPluginStoreRows < ActiveRecord::Migration[5.2]
+  def change
+    add_column :plugin_store_rows, :data, :jsonb
+  end
+end


### PR DESCRIPTION
Following discussion here: https://meta.discourse.org/t/adding-jsonb-columns-for-custom-fields/93418/3

This provides a reasonably efficient method for plugin developers to store and lookup json in the database.

`store_accessor` makes this a very powerful tool for plugin developers. Example use:

```ruby
class Video < PluginStoreRow
  KEY_PREFIX = "video_"
  PLUGIN_NAME = Video::PLUGIN_NAME

  after_initialize :init_model

  store_accessor :data, :field1, :field2, :field3

  default_scope do
    where(plugin_name: PLUGIN_NAME, type_name: "JSONB")
    .where("key LIKE ?", "#{KEY_PREFIX}%")
  end

  def video_id=(video_id)
    self.key = "#{KEY_PREFIX}#{video_id}"
  end

  def init_model
    self.type_name ||= 'JSONB'
    self.plugin_name ||= PLUGIN_NAME
  end
end
```
This can then be used almost exactly like a normal activerecord model, without the need for any database migrations:
```ruby
Video.all # returns only the relevent PluginStoreRows

Video.where("data->>'field1' = ?", "somevalue") # Lookup based on JSON value

# Can be used like any activerecord model
video = Video.create!(video_id: 42, key: "someuniquekey", field1: "somevalue", field2: true)
video.destroy!
```
