### PR TITLE
UX: Show static page title.

### DIFF
--- a/app/assets/javascripts/discourse/lib/static-route-builder.js.es6
+++ b/app/assets/javascripts/discourse/lib/static-route-builder.js.es6
@@ -34,6 +34,13 @@ export default function(page) {
       this.controllerFor("static").set("model", model);
     },
 
+    titleToken() {
+      if (page === "tos") {
+        return I18n.t("terms_of_service");
+      }
+      return I18n.t(page);
+    },
+
     actions: {
       didTransition() {
         this.controllerFor("application").set("showFooter", true);


### PR DESCRIPTION
This is work in progress as I still have to find a nicer way for the title and also add it to meta description too.

Both "tos" and "terms_of_service" have been used as i18n keys and I could:
(a) add a new `tos` key that would be exactly the same with `terms_of_service`;
(b) use this ugly `if`.