### PR TITLE
UX: Show static page title.

### DIFF
--- a/app/assets/javascripts/discourse/lib/static-route-builder.js.es6
+++ b/app/assets/javascripts/discourse/lib/static-route-builder.js.es6
@@ -34,6 +34,10 @@ export default function(page) {
       this.controllerFor("static").set("model", model);
     },
 
+    titleToken() {
+      return I18n.t(page);
+    },
+
     actions: {
       didTransition() {
         this.controllerFor("application").set("showFooter", true);

--- a/app/assets/javascripts/discourse/templates/about.hbs
+++ b/app/assets/javascripts/discourse/templates/about.hbs
@@ -10,7 +10,7 @@
         {{else}}
           <li class="nav-item-faq">{{#link-to 'faq'}}{{i18n 'faq'}}{{/link-to}}</li>
         {{/if}}
-        <li class="nav-item-tos">{{#link-to 'tos'}}{{i18n 'terms_of_service'}}{{/link-to}}</li>
+        <li class="nav-item-tos">{{#link-to 'tos'}}{{i18n 'tos'}}{{/link-to}}</li>
         <li class="nav-item-privacy">{{#link-to 'privacy'}}{{i18n 'privacy'}}{{/link-to}}</li>
       </ul>
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -228,7 +228,7 @@ en:
     guidelines: "Guidelines"
     privacy_policy: "Privacy Policy"
     privacy: "Privacy"
-    terms_of_service: "Terms of Service"
+    tos: "Terms of Service"
     mobile_view: "Mobile View"
     desktop_view: "Desktop View"
     you: "You"


### PR DESCRIPTION
This is work in progress as I still have to find a nicer way for the title and also add it to meta description too.

Both "tos" and "terms_of_service" have been used as i18n keys and I could:
(a) add a new `tos` key that would be exactly the same with `terms_of_service`;
(b) use this ugly `if`.