### PR TITLE
Allow plugins to intercept uploads in composer

### DIFF
--- a/app/assets/javascripts/discourse/components/composer-editor.js.es6
+++ b/app/assets/javascripts/discourse/components/composer-editor.js.es6
@@ -38,6 +38,14 @@ import {
 
 const REBUILD_SCROLL_MAP_EVENTS = ["composer:resized", "composer:typed-reply"];
 
+const uploadHandlers = [];
+export function addComposerUploadHandler(extensions, method) {
+  uploadHandlers.push({
+    extensions,
+    method
+  });
+}
+
 export default Ember.Component.extend({
   classNameBindings: ["showToolbar:toolbar-visible", ":wmd-controls"],
 
@@ -587,6 +595,19 @@ export default Ember.Component.extend({
     });
 
     $element.on("fileuploadsubmit", (e, data) => {
+      // Look for a matching file upload handler contributed from a plugin
+      const matcher = handler => {
+        const ext = handler.extensions.join("|");
+        const regex = new RegExp(`\\.(${ext})$`, "i");
+        return regex.test(data.files[0].name);
+      };
+      const matchingHandler = uploadHandlers.find(matcher);
+      if (data.files.length === 1 && matchingHandler) {
+        matchingHandler.method(data.files[0]);
+        return false;
+      }
+
+      // If no plugin, continue as normal
       const isPrivateMessage = this.get("composer.privateMessage");
 
       data.formData = { type: "composer" };

--- a/app/assets/javascripts/discourse/lib/plugin-api.js.es6
+++ b/app/assets/javascripts/discourse/lib/plugin-api.js.es6
@@ -35,9 +35,10 @@ import { registerCustomAvatarHelper } from "discourse/helpers/user-avatar";
 import { disableNameSuppression } from "discourse/widgets/poster-name";
 import { registerCustomPostMessageCallback as registerCustomPostMessageCallback1 } from "discourse/controllers/topic";
 import Sharing from "discourse/lib/sharing";
+import { addComposerUploadHandler } from "discourse/components/composer-editor";
 
 // If you add any methods to the API ensure you bump up this number
-const PLUGIN_API_VERSION = "0.8.23";
+const PLUGIN_API_VERSION = "0.8.24";
 
 class PluginApi {
   constructor(version, container) {
@@ -752,6 +753,22 @@ class PluginApi {
   addSharingSource(options) {
     Sharing.addSharingId(options.id);
     Sharing.addSource(options);
+  }
+
+  /**
+   *
+   * Registers a function to handle uploads for specified file types
+   * The normal uploading functionality will be bypassed
+   * This only for uploads of individual files
+   *
+   * Example:
+   *
+   * addComposerUploadHandler(["mp4", "mov"], (file) => {
+   *    console.log("Handling upload for", file.name);
+   * })
+   */
+  addComposerUploadHandler(extensions, method) {
+    addComposerUploadHandler(extensions, method);
   }
 }
 


### PR DESCRIPTION
Allow plugins to handle uploads in the composer for specific file types. 

For example, if you wanted to integrate with a video hosting provider, and send all video files directly to them instead of Discourse.

```js
api.addComposerUploadHandler(["mp4", "mov"], (file) => {
    console.log("Handling upload for", file.name);
    // Do uploading
})
```