### PR TITLE
Second phase of renaming User.group_locked_trust_level.

### DIFF
--- a/app/jobs/scheduled/tl3_promotions.rb
+++ b/app/jobs/scheduled/tl3_promotions.rb
@@ -6,10 +6,14 @@ module Jobs
     def execute(args)
       # Demotions
       demoted_user_ids = []
-      User.real.where(
-        trust_level: TrustLevel[3],
-        manual_locked_trust_level: nil
-      ).where("group_locked_trust_level IS NULL OR group_locked_trust_level < ?", TrustLevel[3]).find_each do |u|
+      User.real
+        .joins("LEFT JOIN (SELECT gu.user_id, MAX(g.grant_trust_level) AS group_min_trust_level FROM groups g, group_users gu WHERE g.id = gu.group_id GROUP BY gu.user_id) tl ON users.id = tl.user_id")
+        .where(
+          trust_level: TrustLevel[3],
+          manual_locked_trust_level: nil
+        )
+        .where("group_min_trust_level IS NULL OR group_min_trust_level < ?", TrustLevel[3])
+        .find_each do |u|
         # Don't demote too soon after being promoted
         next if u.on_tl3_grace_period?
 

--- a/app/models/group_user.rb
+++ b/app/models/group_user.rb
@@ -66,23 +66,12 @@ class GroupUser < ActiveRecord::Base
   def grant_trust_level
     return if group.grant_trust_level.nil?
 
-    if (user.group_locked_trust_level || 0) < group.grant_trust_level
-      user.update!(group_locked_trust_level: group.grant_trust_level)
-    end
-
     TrustLevelGranter.grant(group.grant_trust_level, user)
   end
 
   def recalculate_trust_level
     return if group.grant_trust_level.nil?
 
-    # Find the highest level of the user's remaining groups
-    highest_level = GroupUser
-      .where(user_id: user.id)
-      .includes(:group)
-      .maximum("groups.grant_trust_level")
-
-    user.update!(group_locked_trust_level: highest_level)
     Promotion.recalculate(user)
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1345,7 +1345,6 @@ end
 #  staged                    :boolean          default(FALSE), not null
 #  first_seen_at             :datetime
 #  silenced_till             :datetime
-#  group_locked_trust_level  :integer
 #  manual_locked_trust_level :integer
 #
 # Indexes

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -308,6 +308,13 @@ class User < ActiveRecord::Base
     find_by(username_lower: username.downcase)
   end
 
+  def group_min_trust_level
+    GroupUser
+      .where(user_id: id)
+      .includes(:group)
+      .maximum("groups.grant_trust_level")
+  end
+
   def enqueue_welcome_message(message_type)
     return unless SiteSetting.send_welcome_message?
     Jobs.enqueue(:send_system_message, user_id: id, message_type: message_type)

--- a/app/services/user_merger.rb
+++ b/app/services/user_merger.rb
@@ -209,7 +209,6 @@ class UserMerger
         primary_group_id          = COALESCE(t.primary_group_id, s.primary_group_id),
         registration_ip_address   = COALESCE(t.registration_ip_address, s.registration_ip_address),
         first_seen_at             = LEAST(t.first_seen_at, s.first_seen_at),
-        group_locked_trust_level  = GREATEST(t.group_locked_trust_level, s.group_locked_trust_level),
         manual_locked_trust_level = GREATEST(t.manual_locked_trust_level, s.manual_locked_trust_level)
       FROM users AS s
       WHERE t.id = :target_user_id AND s.id = :source_user_id

--- a/db/migrate/20180817175248_remove_group_locked_trust_level.rb
+++ b/db/migrate/20180817175248_remove_group_locked_trust_level.rb
@@ -1,0 +1,5 @@
+class RemoveGroupLockedTrustLevel < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :users, :group_locked_trust_level
+  end
+end

--- a/lib/promotion.rb
+++ b/lib/promotion.rb
@@ -121,9 +121,9 @@ class Promotion
     end
 
     # Then consider the group locked level
-    if user.group_locked_trust_level
+    if user.group_min_trust_level
       return user.update!(
-        trust_level: user.group_locked_trust_level
+        trust_level: user.group_min_trust_level
       )
     end
 

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -605,28 +605,28 @@ describe Group do
 
       # Add a group without one to consider `NULL` check
       g2.add(user)
-      expect(user.group_locked_trust_level).to be_nil
+      expect(user.group_min_trust_level).to be_nil
       expect(user.manual_locked_trust_level).to be_nil
 
       g0.add(user)
       expect(user.reload.trust_level).to eq(2)
-      expect(user.group_locked_trust_level).to eq(2)
+      expect(user.group_min_trust_level).to eq(2)
       expect(user.manual_locked_trust_level).to be_nil
 
       g1.add(user)
       expect(user.reload.trust_level).to eq(3)
-      expect(user.group_locked_trust_level).to eq(3)
+      expect(user.group_min_trust_level).to eq(3)
       expect(user.manual_locked_trust_level).to be_nil
 
       g1.remove(user)
       expect(user.reload.trust_level).to eq(2)
-      expect(user.group_locked_trust_level).to eq(2)
+      expect(user.group_min_trust_level).to eq(2)
       expect(user.manual_locked_trust_level).to be_nil
 
       g0.remove(user)
       user.reload
       expect(user.manual_locked_trust_level).to be_nil
-      expect(user.group_locked_trust_level).to be_nil
+      expect(user.group_min_trust_level).to be_nil
       expect(user.trust_level).to eq(0)
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1378,7 +1378,7 @@ describe User do
       expect(user.title).to eq("bars and wats")
       expect(user.trust_level).to eq(1)
       expect(user.manual_locked_trust_level).to be_nil
-      expect(user.group_locked_trust_level).to eq(1)
+      expect(user.group_min_trust_level).to eq(1)
     end
   end
 


### PR DESCRIPTION
To be merged after #6279.