### PR TITLE
FIX: Minimum username length must be less than any group name.

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -162,9 +162,9 @@ en:
       invalid_choice:
         one: 'You specified the invalid choice %{name}'
         other: 'You specified the invalid choices %{name}'
-      min_username_length_exists: "You cannot set the minimum username length above the shortest username."
+      min_username_length_exists: "You cannot set the minimum username length above the shortest username or group name."
       min_username_length_range: "You cannot set the minimum above the maximum."
-      max_username_length_exists: "You cannot set the maximum username length below the longest username."
+      max_username_length_exists: "You cannot set the maximum username length below the longest username or group name."
       max_username_length_range: "You cannot set the maximum below the minimum."
       default_categories_already_selected: "You cannot select a category used in another list."
       s3_upload_bucket_is_required: "You cannot enable uploads to S3 unless you've provided the 's3_upload_bucket'."

--- a/lib/site_settings/validations.rb
+++ b/lib/site_settings/validations.rb
@@ -8,11 +8,13 @@ module SiteSettings::Validations
   def validate_min_username_length(new_val)
     validate_error :min_username_length_range if new_val > SiteSetting.max_username_length
     validate_error :min_username_length_exists if User.where('length(username) < ?', new_val).exists?
+    validate_error :min_username_length_exists if Group.where('length(name) < ?', new_val).exists?
   end
 
   def validate_max_username_length(new_val)
     validate_error :min_username_length_range if new_val < SiteSetting.min_username_length
     validate_error :max_username_length_exists if User.where('length(username) > ?', new_val).exists?
+    validate_error :max_username_length_exists if Group.where('length(name) > ?', new_val).exists?
   end
 
   def validate_default_categories(new_val, default_categories_selected)

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -388,7 +388,7 @@ describe Group do
       u.save!
     end
 
-    SiteSetting.min_username_length = 6
+    SiteSetting.min_username_length = 5
     Group.refresh_automatic_groups!(:staff)
     # should not explode here
   end


### PR DESCRIPTION
Fixes [this](https://meta.discourse.org/t/setting-min-username-length-greater-than-5-breaks-granting-and-revoking-admin-moderator-permissions/57079/9).