### PR TITLE
UX: Keyboard shortcuts will automatically select hovered post.

### DIFF
--- a/app/assets/javascripts/discourse/lib/keyboard-shortcuts.js.es6
+++ b/app/assets/javascripts/discourse/lib/keyboard-shortcuts.js.es6
@@ -297,10 +297,14 @@ export default {
   sendToSelectedPost(action) {
     const container = this.container;
     // TODO: We should keep track of the post without a CSS class
-    const selectedPostId = parseInt(
+    let selectedPostId = parseInt(
       $(".topic-post.selected article.boxed").data("post-id"),
       10
     );
+    if (!selectedPostId) {
+      // If no post was selected, automatically select the hovered post.
+      selectedPostId = parseInt($("article.boxed:hover").data("post-id"), 10);
+    }
     if (selectedPostId) {
       const topicController = container.lookup("controller:topic");
       const post = topicController


### PR DESCRIPTION
Fixes [this](https://meta.discourse.org/t/intructions-on-right-and-feedback-on-wrong-keyboard-shortcut-usage/65794/8).