### PR TITLE
UX: Show only the expand icon in lightboxes on mobile.

### DIFF
--- a/app/assets/stylesheets/mobile.scss
+++ b/app/assets/stylesheets/mobile.scss
@@ -16,6 +16,7 @@
 @import "mobile/upload";
 @import "mobile/user";
 @import "mobile/history";
+@import "mobile/lightbox";
 @import "mobile/directory";
 @import "mobile/search";
 @import "mobile/emoji";

--- a/app/assets/stylesheets/mobile/lightbox.scss
+++ b/app/assets/stylesheets/mobile/lightbox.scss
@@ -1,0 +1,21 @@
+.lightbox .meta,
+.lightbox:hover .meta {
+  opacity: 0.8;
+}
+
+.meta {
+  height: 25px;
+  width: 25px;
+  bottom: 0;
+  left: 0;
+
+  .filename,
+  .informations {
+    display: none;
+  }
+
+  .expand {
+    bottom: 1px;
+    right: 6px;
+  }
+}


### PR DESCRIPTION
Fixes [this](https://meta.discourse.org/t/black-bar-appearing-on-images/81608).