### PR TITLE
Fix for tag intersection not populating

### DIFF
--- a/app/assets/javascripts/discourse/routes/tags-show.js.es6
+++ b/app/assets/javascripts/discourse/routes/tags-show.js.es6
@@ -184,10 +184,10 @@ export default Discourse.Route.extend({
               var c = self.controllerFor("composer").get("model");
               c.set(
                 "tags",
-                _.flatten(
-                  [controller.get("model.id")],
+                _.compact(_.flatten([
+                  controller.get("model.id"),
                   controller.get("additionalTags")
-                )
+                ]))
               );
             }
           });


### PR DESCRIPTION
Ref https://meta.discourse.org/t/composer-in-intersection-page-tag-field-not-pre-filled/94780