### PR TITLE
FIX: uses localized string for 429 in reports

### DIFF
--- a/app/assets/javascripts/admin/components/admin-report.js.es6
+++ b/app/assets/javascripts/admin/components/admin-report.js.es6
@@ -318,11 +318,10 @@ export default Ember.Component.extend({
       })
       .catch(data => {
         if (data.jqXHR && data.jqXHR.status === 429) {
-          const error = data.jqXHR.responseJSON
-            ? data.jqXHR.responseJSON.errors[0]
-            : data.jqXHR.responseText;
-
-          this.set("rateLimitationString", error);
+          this.set(
+            "rateLimitationString",
+            I18n.t("admin.dashboard.too_many_requests")
+          );
         }
       })
       .finally(() => {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2808,6 +2808,7 @@ en:
         disabled: Disabled
         timeout_error: Sorry, query is taking too long, please pick a shorter interval
         exception_error: Sorry, an error occurred while executing the query
+        too_many_requests: You’ve performed this action too many times. Please wait before trying again.
 
         reports:
           trend_title: "%{percent} change. Currently %{current}, was %{prev} in previous period."


### PR DESCRIPTION
NGINX was retuning an html page instead of single string for some users. Seems safer to not risk showing anything from server anyways.