### PR TITLE
FIX: Create `BaseDropper` functions in a different schema.

### DIFF
--- a/lib/backup_restore/restorer.rb
+++ b/lib/backup_restore/restorer.rb
@@ -65,24 +65,6 @@ module BackupRestore
 
         BackupRestore.move_tables_between_schemas("public", "backup")
 
-        # This is a temp fix to allow restores to work again.
-        # @tgxworld is currently working on a fix that namespaces functions
-        # created by Discourse so that we can alter the schema of those
-        # functions before restoring.
-        %w{
-          raise_email_logs_reply_key_readonly
-          raise_email_logs_skipped_reason_readonly
-        }.each do |function|
-          begin
-            DB.exec(<<~SQL)
-              DROP FUNCTION IF EXISTS backup.#{function};
-              ALTER FUNCTION public.#{function} SET SCHEMA "backup";
-            SQL
-          rescue PG::UndefinedFunction
-            # the function does not exist, no need to worry about this
-          end
-        end
-
         @db_was_changed = true
         restore_dump
         migrate_database

--- a/lib/migration/base_dropper.rb
+++ b/lib/migration/base_dropper.rb
@@ -1,5 +1,7 @@
 module Migration
   class BaseDropper
+    FUNCTION_SCHEMA_NAME = "discourse_functions".freeze
+
     def initialize(after_migration, delay, on_drop, after_drop)
       @after_migration = after_migration
       @on_drop = on_drop
@@ -46,6 +48,10 @@ module Migration
     end
 
     def self.create_readonly_function(table_name, column_name = nil)
+      DB.exec <<~SQL
+        CREATE SCHEMA IF NOT EXISTS #{FUNCTION_SCHEMA_NAME};
+      SQL
+
       message = column_name ?
                   "Discourse: #{column_name} in #{table_name} is readonly" :
                   "Discourse: #{table_name} is read only"
@@ -69,7 +75,14 @@ module Migration
     end
 
     def self.readonly_function_name(table_name, column_name = nil)
-      ["raise", table_name, column_name, "readonly()"].compact.join("_")
+      function_name = [
+        "raise",
+        table_name,
+        column_name,
+        "readonly()"
+      ].compact.join("_")
+
+      "#{FUNCTION_SCHEMA_NAME}.#{function_name}"
     end
 
     def self.readonly_trigger_name(table_name, column_name = nil)


### PR DESCRIPTION
https://meta.discourse.org/t/error-when-restore-db-backup/93145/25?u=tgxworld