### PR TITLE
UX: Improve email testing admin tool.

### DIFF
--- a/app/assets/javascripts/admin/controllers/admin-email-index.js.es6
+++ b/app/assets/javascripts/admin/controllers/admin-email-index.js.es6
@@ -28,30 +28,25 @@ export default Ember.Controller.extend({
         sentTestEmail: false
       });
 
-      var self = this;
       ajax("/admin/email/test", {
         type: "POST",
         data: { email_address: this.get("testEmailAddress") }
       })
-        .then(
-          function() {
-            self.set("sentTestEmail", true);
-          },
-          function(e) {
-            if (e.responseJSON && e.responseJSON.errors) {
-              bootbox.alert(
-                I18n.t("admin.email.error", {
-                  server_error: e.responseJSON.errors[0]
-                })
-              );
-            } else {
-              bootbox.alert(I18n.t("admin.email.test_error"));
-            }
-          }
+        .then(response =>
+          this.set("sentTestEmailMessage", response.send_test_email_message)
         )
-        .finally(function() {
-          self.set("sendingEmail", false);
-        });
+        .catch(e => {
+          if (e.responseJSON && e.responseJSON.errors) {
+            bootbox.alert(
+              I18n.t("admin.email.error", {
+                server_error: e.responseJSON.errors[0]
+              })
+            );
+          } else {
+            bootbox.alert(I18n.t("admin.email.test_error"));
+          }
+        })
+        .finally(() => this.set("sendingEmail", false));
     }
   }
 });

--- a/app/assets/javascripts/admin/templates/email-index.hbs
+++ b/app/assets/javascripts/admin/templates/email-index.hbs
@@ -21,7 +21,7 @@
   </div>
   <div class='controls'>
     <button class='btn btn-primary' {{action "sendTestEmail"}} disabled={{sendTestEmailDisabled}}>{{i18n 'admin.email.send_test'}}</button>
-    {{#if sentTestEmail}}<span class='result-message'>{{i18n 'admin.email.sent_test'}}</span>{{/if}}
+    {{#if sentTestEmailMessage}}<span class='result-message'>{{sentTestEmailMessage}}</span>{{/if}}
   </div>
   {{/if}}
 </div>

--- a/app/controllers/admin/email_controller.rb
+++ b/app/controllers/admin/email_controller.rb
@@ -11,7 +11,13 @@ class Admin::EmailController < Admin::AdminController
     params.require(:email_address)
     begin
       Jobs::TestEmail.new.execute(to_address: params[:email_address])
-      render body: nil
+      if SiteSetting.disable_emails == "yes"
+        render json: { sent_test_email_message: I18n.t("admin.email.sent_test_disabled") }
+      elsif SiteSetting.disable_emails == "non-staff" && !User.find_by_email(params[:email_address])&.staff?
+        render json: { sent_test_email_message: I18n.t("admin.email.sent_test_disabled_for_non_staff") }
+      else
+        render json: { sent_test_email_message: I18n.t("admin.email.sent_test") }
+      end
     rescue => e
       render json: { errors: [e.message] }, status: 422
     end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1963,6 +1963,12 @@ en:
       totp: "Use an authenticator app instead"
       backup_code: "Use a backup code instead"
 
+  admin:
+    email:
+      sent_test: "sent!"
+      sent_test_disabled: "cannot send because emails are disabled"
+      sent_test_disabled_for_non_staff: "cannot send because emails are disabled for non-staff"
+
   user:
     deactivated: "Was deactivated due to too many bounced emails to '%{email}'."
     deactivated_by_staff: "Deactivated by staff"


### PR DESCRIPTION
Fixes [this](https://meta.discourse.org/t/email-test-area-should-warn-if-emails-are-disabled/95269).