### PR TITLE
FIX: find tags with non-latin names

### DIFF
--- a/lib/search.rb
+++ b/lib/search.rb
@@ -369,7 +369,7 @@ class Search
     end
   end
 
-  advanced_filter(/^\#([a-zA-Z0-9\-:=]+)/) do |posts, match|
+  advanced_filter(/^\#([\p{L}0-9\-:=]+)/) do |posts, match|
 
     exact = true
 
@@ -465,11 +465,11 @@ class Search
     end
   end
 
-  advanced_filter(/^tags?:([a-zA-Z0-9,\-_+]+)/) do |posts, match|
+  advanced_filter(/^tags?:([\p{L}0-9,\-_+]+)/) do |posts, match|
     search_tags(posts, match, positive: true)
   end
 
-  advanced_filter(/\-tags?:([a-zA-Z0-9,\-_+]+)/) do |posts, match|
+  advanced_filter(/\-tags?:([\p{L}0-9,\-_+]+)/) do |posts, match|
     search_tags(posts, match, positive: false)
   end
 

--- a/spec/components/search_spec.rb
+++ b/spec/components/search_spec.rb
@@ -822,8 +822,9 @@ describe Search do
       expect(Search.execute("sams post #sub-category").posts.length).to eq(1)
 
       # tags
-      topic.tags = [Fabricate(:tag, name: 'alpha')]
+      topic.tags = [Fabricate(:tag, name: 'alpha'), Fabricate(:tag, name: 'привет')]
       expect(Search.execute('this is a test #alpha').posts.map(&:id)).to eq([post.id])
+      expect(Search.execute('this is a test #привет').posts.map(&:id)).to eq([post.id])
       expect(Search.execute('this is a test #beta').posts.size).to eq(0)
     end
 
@@ -862,6 +863,14 @@ describe Search do
 
         expect(Search.execute('green tags:eggs').posts.map(&:id)).to eq([post4.id])
         expect(Search.execute('tags:plants').posts.size).to eq(0)
+      end
+
+      it 'can find posts with non-latin tag' do
+        topic = Fabricate(:topic)
+        topic.tags = [Fabricate(:tag, name: 'さようなら')]
+        post = Fabricate(:post, raw: 'Testing post', topic: topic)
+
+        expect(Search.execute('tags:さようなら').posts.map(&:id)).to eq([post.id])
       end
 
       it 'can find posts with any tag from multiple tags' do


### PR DESCRIPTION
Meta: https://meta.discourse.org/t/search-by-tag-not-english-characters/92893