### PR TITLE
UX: Do not show the groups directory if disabled.

### DIFF
--- a/app/assets/javascripts/discourse/widgets/hamburger-menu.js.es6
+++ b/app/assets/javascripts/discourse/widgets/hamburger-menu.js.es6
@@ -155,10 +155,7 @@ export default createWidget("hamburger-menu", {
       });
     }
 
-    if (
-      this.siteSettings.enable_group_directory ||
-      (this.currentUser && this.currentUser.staff)
-    ) {
+    if (this.siteSettings.enable_group_directory) {
       links.push({
         route: "groups",
         className: "groups-link",


### PR DESCRIPTION
Staff could still see the groups directory before.

Fixes [this](https://meta.discourse.org/t/groups-link-in-hamburger-menu-still-there-after-turning-off-groups-directory/95597/2).