### PR TITLE
FIX: Reset email preferences controller.

### DIFF
--- a/app/assets/javascripts/discourse/controllers/preferences/email.js.es6
+++ b/app/assets/javascripts/discourse/controllers/preferences/email.js.es6
@@ -20,6 +20,16 @@ export default Ember.Controller.extend({
   ),
   unchanged: propertyEqual("newEmailLower", "currentUser.email"),
 
+  reset: function() {
+    this.setProperties({
+      taken: false,
+      saving: false,
+      error: false,
+      success: false,
+      newEmail: null
+    });
+  },
+
   newEmailLower: function() {
     return this.get("newEmail")
       .toLowerCase()

--- a/app/assets/javascripts/discourse/routes/preferences-email.js.es6
+++ b/app/assets/javascripts/discourse/routes/preferences-email.js.es6
@@ -12,6 +12,7 @@ export default RestrictedUserRoute.extend({
   },
 
   setupController: function(controller, model) {
+    controller.reset();
     controller.setProperties({ model: model, newEmail: model.get("email") });
   },
 

--- a/test/javascripts/acceptance/preferences-test.js.es6
+++ b/test/javascripts/acceptance/preferences-test.js.es6
@@ -27,6 +27,12 @@ acceptance("User Preferences", {
       });
     });
 
+    server.put("/u/eviltrout/preferences/email", () => {
+      return helper.response({
+        success: true
+      });
+    });
+
     server.post("/user_avatar/eviltrout/refresh_gravatar.json", () => {
       return helper.response({
         gravatar_upload_id: 6543,
@@ -117,6 +123,20 @@ QUnit.test("email", async assert => {
     I18n.t("user.email.invalid"),
     "it should display invalid email tip"
   );
+});
+
+QUnit.test("email field always shows up", async assert => {
+  await visit("/u/eviltrout/preferences/email");
+
+  assert.ok(exists("#change-email"), "it has the input element");
+
+  await fillIn("#change-email", "eviltrout@discourse.org");
+  await click(".user-preferences button.btn-primary");
+
+  await visit("/u/eviltrout/preferences");
+  await visit("/u/eviltrout/preferences/email");
+
+  assert.ok(exists("#change-email"), "it has the input element");
 });
 
 QUnit.test("connected accounts", async assert => {


### PR DESCRIPTION
Fixes [this](https://meta.discourse.org/t/cant-change-multiple-users-emails-any-more/95180).