### PR TITLE
FIX: Ignore OneBox blacklisted domains.

### DIFF
--- a/lib/oneboxer.rb
+++ b/lib/oneboxer.rb
@@ -250,9 +250,11 @@ module Oneboxer
 
   def self.external_onebox(url)
     Rails.cache.fetch(onebox_cache_key(url), expires_in: 1.day) do
-      fd = FinalDestination.new(url, ignore_redirects: ignore_redirects, force_get_hosts: force_get_hosts)
+      ignored = SiteSetting.onebox_domains_blacklist.split("|")
+
+      fd = FinalDestination.new(url, ignore_redirects: ignore_redirects, ignore_hostnames: ignored, force_get_hosts: force_get_hosts)
       uri = fd.resolve
-      return blank_onebox if uri.blank? || SiteSetting.onebox_domains_blacklist.include?(uri.hostname)
+      return blank_onebox if uri.blank? || ignored.map { |hostname| uri.hostname.match?(hostname) }.any?
 
       options = {
         cache: {},

--- a/spec/components/final_destination_spec.rb
+++ b/spec/components/final_destination_spec.rb
@@ -47,6 +47,14 @@ describe FinalDestination do
     FinalDestination.new(url, opts)
   end
 
+  it 'correctly parses ignored hostnames' do
+    fd = FinalDestination.new('https://meta.discourse.org',
+      ignore_redirects: ['http://google.com', 'youtube.com', 'https://meta.discourse.org', '://bing.com']
+    )
+
+    expect(fd.ignored).to eq(['test.localhost', 'google.com', 'meta.discourse.org'])
+  end
+
   describe '.resolve' do
 
     it "has a ready status code before anything happens" do

--- a/spec/components/oneboxer_spec.rb
+++ b/spec/components/oneboxer_spec.rb
@@ -107,4 +107,13 @@ describe Oneboxer do
     end
   end
 
+  it "does not crawl blacklisted URLs" do
+    SiteSetting.onebox_domains_blacklist = "git.*.com|bitbucket.com"
+    url = 'https://github.com/discourse/discourse/commit/21b562852885f883be43032e03c709241e8e6d4f'
+    stub_request(:head, 'https://discourse.org/').to_return(status: 302, body: "", headers: { location: url })
+
+    expect(Oneboxer.external_onebox(url)[:onebox]).to be_empty
+    expect(Oneboxer.external_onebox('https://discourse.org/')[:onebox]).to be_empty
+  end
+
 end


### PR DESCRIPTION
Fixes [this](https://meta.discourse.org/t/disable-discourse-from-crawling-links/69778/9).