### PR TITLE
Add Content-Type header to CORS

### DIFF
--- a/config/initializers/008-rack-cors.rb
+++ b/config/initializers/008-rack-cors.rb
@@ -39,7 +39,7 @@ class Discourse::Cors
       end
 
       headers['Access-Control-Allow-Origin'] = origin || cors_origins[0]
-      headers['Access-Control-Allow-Headers'] = 'X-Requested-With, X-CSRF-Token, Discourse-Visible, User-Api-Key, User-Api-Client-Id'
+      headers['Access-Control-Allow-Headers'] = 'Content-Type, X-Requested-With, X-CSRF-Token, Discourse-Visible, User-Api-Key, User-Api-Client-Id'
       headers['Access-Control-Allow-Credentials'] = 'true'
     end
 

--- a/spec/components/hijack_spec.rb
+++ b/spec/components/hijack_spec.rb
@@ -107,7 +107,7 @@ describe Hijack do
 
     expected = {
       "Access-Control-Allow-Origin" => "www.rainbows.com",
-      "Access-Control-Allow-Headers" => "X-Requested-With, X-CSRF-Token, Discourse-Visible, User-Api-Key, User-Api-Client-Id",
+      "Access-Control-Allow-Headers" => "Content-Type, X-Requested-With, X-CSRF-Token, Discourse-Visible, User-Api-Key, User-Api-Client-Id",
       "Access-Control-Allow-Credentials" => "true"
     }
 


### PR DESCRIPTION
When trying to add a new post using the [User API key](https://meta.discourse.org/t/user-api-keys-specification/48536) feature, I get `Request header field Content-Type is not allowed by Access-Control-Allow-Headers` error in the browser console.
This PR updates the Access-Control-Allow-Headers array to allow the use of the `Content-Type` header.