### PR TITLE
FIX: drop title updates through RSS feeds

### DIFF
--- a/app/models/topic_embed.rb
+++ b/app/models/topic_embed.rb
@@ -74,8 +74,6 @@ class TopicEmbed < ActiveRecord::Base
 
       # Update the topic if it changed
       if post&.topic
-        revision = {}
-
         if post.user != user
           PostOwnerChanger.new(
             post_ids: [post.id],
@@ -89,19 +87,14 @@ class TopicEmbed < ActiveRecord::Base
         end
 
         if content_sha1 != embed.content_sha1
-          revision[:raw] = absolutize_urls(url, contents)
-        end
-
-        revision[:title] = title if title != post.topic.title
-
-        unless revision.empty?
-          post.revise(user, revision,
+          post.revise(
+            user,
+            { raw: absolutize_urls(url, contents) },
             skip_validations: true,
             bypass_rate_limiter: true
           )
+          embed.update!(content_sha1: content_sha1)
         end
-
-        embed.update!(content_sha1: content_sha1) if revision[:raw]
       end
     end
 

--- a/spec/jobs/poll_feed_spec.rb
+++ b/spec/jobs/poll_feed_spec.rb
@@ -90,7 +90,6 @@ describe Jobs::PollFeed do
             expect { poller.poll_feed }.to_not change { Topic.count }
 
             post.reload
-            expect(post.topic.title).to eq('Poll Feed Spec Fixture')
             expect(post.raw).to include('<p>This is the body &amp; content. </p>')
             expect(post.user).to eq(feed_author)
           end

--- a/spec/models/topic_embed_spec.rb
+++ b/spec/models/topic_embed_spec.rb
@@ -41,13 +41,6 @@ describe TopicEmbed do
         expect(post.topic.category).to eq(embeddable_host.category)
       end
 
-      it "Supports updating the post title" do
-        TopicEmbed.import(user, url, "I am a new title", contents)
-
-        topic_embed.reload
-        expect(topic_embed.post.topic.title).to eq("I am a new title")
-      end
-
       it "Supports updating the post content" do
         expect do
           TopicEmbed.import(user, url, title, "muhahaha new contents!")


### PR DESCRIPTION
> CONTEXT: https://meta.discourse.org/t/posts-from-rss-bumped-on-each-run/95766/4?u=xrav3nz

TL;DR: this will create an edit loop if the title is sanitized when saving, so let's drop it

