### PR TITLE
FIX: Changing tag name class to data attribute

### DIFF
--- a/app/assets/javascripts/discourse/lib/render-tag.js.es6
+++ b/app/assets/javascripts/discourse/lib/render-tag.js.es6
@@ -1,7 +1,7 @@
 export default function renderTag(tag, params) {
   params = params || {};
   tag = Handlebars.Utils.escapeExpression(tag);
-  const classes = ["tag-" + tag, "discourse-tag"];
+  const classes = ["discourse-tag"];
   const tagName = params.tagName || "a";
   let path;
   if (tagName === "a" && !params.noHref) {
@@ -24,6 +24,8 @@ export default function renderTag(tag, params) {
     "<" +
     tagName +
     href +
+    " data-tag-name=" + 
+    tag + 
     " class='" +
     classes.join(" ") +
     "'>" +


### PR DESCRIPTION
See: https://meta.discourse.org/t/tags-with-title-box-displaying-as-a-big-box/95779

