### PR TITLE
Add shadows to enable S3 backups to Digital Ocean

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -933,10 +933,14 @@ files:
     default: false
     client: true
   s3_use_iam_profile: false
-  s3_access_key_id: ''
+  s3_access_key_id: 
+    default: ''
+    secret: true
+    shadowed_by_global: true
   s3_secret_access_key:
     default: ''
     secret: true
+    shadowed_by_global: true
   s3_region:
     default: 'us-east-1'
     enum: 'S3RegionSiteSetting'
@@ -946,6 +950,7 @@ files:
   s3_endpoint:
     default: 'https://s3.amazonaws.com'
     regex: '^https?:\/\/.+[^\/]$'
+    shadowed_by_global: true
   s3_cdn_url:
     default: ''
     regex: '^https?:\/\/.+[^\/]$'


### PR DESCRIPTION
With these changes, backups to Digital Ocean spaces can be configured with the following variables:

  DISCOURSE_S3_ACCESS_KEY_ID: 'XXX'
  DISCOURSE_S3_SECRET_ACCESS_KEY: 'YYY'
  DISCOURSE_S3_UPLOAD_BUCKET: 'backups-bucket'
  DISCOURSE_S3_ENDPOINT: 'https://nyc3.digitaloceanspaces.com'
  DISCOURSE_ENABLE_S3_BACKUPS: true