### PR TITLE
DEV: adds --help --no-help options to plugin generator

### DIFF
--- a/lib/generators/plugin/plugin_generator.rb
+++ b/lib/generators/plugin/plugin_generator.rb
@@ -10,6 +10,7 @@ class PluginGenerator < Rails::Generators::NamedBase
   class_option :stylesheet, type: :boolean, desc: "Generate Stylesheet", default: true
   class_option :javascript, type: :boolean, desc: "Generate Javascript initializer", default: true
   class_option :scheduled_job, type: :boolean, desc: "Generate scheduled job", default: false
+  class_option :help, type: :boolean, desc: "Adds help comments in generated files", default: true
 
   def create_scheduled_job_file
     return unless @options['scheduled_job']

--- a/lib/generators/plugin/templates/javascript.es6.erb
+++ b/lib/generators/plugin/templates/javascript.es6.erb
@@ -1,6 +1,10 @@
 import { withPluginApi } from "discourse/lib/plugin-api";
 
 function initialize<%= classified_name %>(api) {
+  <% if @options['help'] %>
+  // see app/assets/javascripts/discourse/lib/plugin-api
+  // for the functions available via the api object
+  <% end %>
 }
 
 export default {

--- a/lib/generators/plugin/templates/plugin.rb.erb
+++ b/lib/generators/plugin/templates/plugin.rb.erb
@@ -13,6 +13,10 @@ enabled_site_setting :<%= underscored_name %>_enabled
 PLUGIN_NAME ||= "<%= name %>".freeze
 
 after_initialize do
+  <% if @options['help'] %>
+  # see lib/plugin/instance.rb for the methods available in this context
+  <% end %>
+
   module ::<%= classified_name %>
     class Engine < ::Rails::Engine
       engine_name PLUGIN_NAME


### PR DESCRIPTION
help will add helpful comments in the various generated files