### PR TITLE
Add shadowed_by_global for S3 uploads

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -932,6 +932,7 @@ files:
   enable_s3_uploads:
     default: false
     client: true
+    shadowed_by_global: true
   s3_use_iam_profile: false
   s3_access_key_id: 
     default: ''
@@ -947,6 +948,7 @@ files:
   s3_upload_bucket:
     default: ''
     regex: '^[a-z0-9\-\/]+$' # can't use '.' when using HTTPS
+    shadowed_by_global: true
   s3_endpoint:
     default: 'https://s3.amazonaws.com'
     regex: '^https?:\/\/.+[^\/]$'
@@ -954,6 +956,7 @@ files:
   s3_cdn_url:
     default: ''
     regex: '^https?:\/\/.+[^\/]$'
+    shadowed_by_global: true
   s3_force_path_style:
     default: false
   allow_profile_backgrounds:


### PR DESCRIPTION
I'm still not clear why these need to be added (or aren't there already?), but without these changes these variables seem not to matter if they're in `config/discourse.conf`.