### PR TITLE
UX: Primary button didn't have hover effect anymore

### DIFF
--- a/app/assets/stylesheets/common/components/buttons.scss
+++ b/app/assets/stylesheets/common/components/buttons.scss
@@ -88,13 +88,14 @@
   }
   &:hover,
   &.btn-hover {
-    color: #fff;
-    background: dark-light-choose($tertiary, $tertiary);
+    background: scale-color($tertiary, $lightness: -20%);
   }
   &:active,
   &.btn-active {
-    @include linear-gradient($tertiary, $tertiary);
-    color: $secondary;
+    @include linear-gradient(
+      scale-color($tertiary, $lightness: -20%),
+      $tertiary
+    );
   }
   &[disabled],
   &.disabled {


### PR DESCRIPTION
The hover effect for `btn-primary` got lost a year ago. This should fix it.

![](https://user-images.githubusercontent.com/473736/44907860-c4107280-ad19-11e8-8be1-6fdd7e606a8c.gif)

@awesomerobot Do my changes look OK to you? I more or less copied what we are doing for `btn-danger`.