### PR TITLE
DEV: Allow plugins to whitelist specific user custom_fields for editing

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -104,7 +104,7 @@ class UsersController < ApplicationController
     attributes.delete(:username)
 
     if params[:user_fields].present?
-      attributes[:custom_fields] = {}
+      attributes[:custom_fields] ||= {}
 
       fields = UserField.all
       fields = fields.where(editable: true) unless current_user.staff?
@@ -1167,6 +1167,7 @@ class UsersController < ApplicationController
       :card_background
     ]
 
+    permitted << { custom_fields: User.editable_user_custom_fields } unless User.editable_user_custom_fields.blank?
     permitted.concat UserUpdater::OPTION_ATTR
     permitted.concat UserUpdater::CATEGORY_IDS.keys.map { |k| { k => [] } }
     permitted.concat UserUpdater::TAG_NAMES.keys

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -222,6 +222,24 @@ class User < ActiveRecord::Base
     end
   end
 
+  def self.plugin_editable_user_custom_fields
+    @plugin_editable_user_custom_fields ||= {}
+  end
+
+  def self.register_plugin_editable_user_custom_field(custom_field_name, plugin)
+    plugin_editable_user_custom_fields[custom_field_name] = plugin
+  end
+
+  def self.editable_user_custom_fields
+    fields = []
+
+    plugin_editable_user_custom_fields.each do |k, v|
+      fields << k if v.enabled?
+    end
+
+    fields.uniq
+  end
+
   def self.plugin_staff_user_custom_fields
     @plugin_staff_user_custom_fields ||= {}
   end

--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -121,6 +121,12 @@ class Plugin::Instance
     end
   end
 
+  def register_editable_user_custom_field(field)
+    reloadable_patch do |plugin|
+      ::User.register_plugin_editable_user_custom_field(field, plugin) # plugin.enabled? is checked at runtime
+    end
+  end
+
   def custom_avatar_column(column)
     reloadable_patch do |plugin|
       AvatarLookup.lookup_columns << column

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -1517,12 +1517,43 @@ describe UsersController do
           end
 
           context "custom_field" do
-            it "does not update the custom field" do
-              put "/u/#{user.username}.json", params: { custom_fields: { test: :it } }
+            before do
+              plugin = Plugin::Instance.new
+              plugin.register_editable_user_custom_field :test2
+            end
+
+            after do
+              User.plugin_editable_user_custom_fields.clear
+            end
+
+            it "only updates allowed user fields" do
+              put "/u/#{user.username}.json", params: { custom_fields: { test1: :hello1, test2: :hello2 } }
 
               expect(response.status).to eq(200)
-              expect(user.custom_fields["test"]).to be_blank
+              expect(user.custom_fields["test1"]).to be_blank
+              expect(user.custom_fields["test2"]).to eq("hello2")
             end
+
+            it "works alongside a user field" do
+              user_field = Fabricate(:user_field, editable: true)
+              put "/u/#{user.username}.json", params: { custom_fields: { test1: :hello1, test2: :hello2 }, user_fields: { user_field.id.to_s => 'happy' } }
+              expect(response.status).to eq(200)
+              expect(user.custom_fields["test1"]).to be_blank
+              expect(user.custom_fields["test2"]).to eq("hello2")
+              expect(user.user_fields[user_field.id.to_s]).to eq('happy')
+            end
+
+            it "is secure when there are no registered editable fields" do
+              User.plugin_editable_user_custom_fields.clear
+              put "/u/#{user.username}.json", params: { custom_fields: { test1: :hello1, test2: :hello2 } }
+              expect(response.status).to eq(200)
+              expect(user.custom_fields["test1"]).to be_blank
+              expect(user.custom_fields["test2"]).to be_blank
+
+              put "/u/#{user.username}.json", params: { custom_fields: ["arrayitem1", "arrayitem2"] }
+              expect(response.status).to eq(200)
+            end
+
           end
         end
 


### PR DESCRIPTION
Required due to recent custom_fields changes. This is presenting a few support issues on Meta for various broken plugins. Once this is merged I will make a few small pull requests to the most popular plugins that have been affected.