### PR TITLE
Fix wizard

### DIFF
--- a/app/assets/javascripts/wizard-application.js
+++ b/app/assets/javascripts/wizard-application.js
@@ -3,6 +3,7 @@
 //= require ./ember-addons/macro-alias
 //= require ./ember-addons/ember-computed-decorators
 //= require_tree ./discourse-common
+//= require i18n-patches
 //= require_tree ./select-kit
 //= require wizard/router
 //= require wizard/wizard

--- a/app/assets/javascripts/wizard/components/wizard-field-dropdown.js.es6
+++ b/app/assets/javascripts/wizard/components/wizard-field-dropdown.js.es6
@@ -1,0 +1,5 @@
+export default Ember.Component.extend({
+  keyPress(e) {
+    e.stopPropagation();
+  }
+});

--- a/app/views/wizard/index.html.erb
+++ b/app/views/wizard/index.html.erb
@@ -2,11 +2,11 @@
   <head>
     <%= discourse_stylesheet_link_tag :wizard, theme_ids: nil %>
     <%= preload_script 'ember_jquery' %>
+    <%= preload_script "locales/#{I18n.locale}" %>
     <%= preload_script 'wizard-vendor' %>
     <%= preload_script 'wizard-application' %>
-    <%= preload_script "locales/#{I18n.locale}" %>
     <%= render partial: "common/special_font_face" %>
-    <script src="<%= Discourse.base_uri %>/extra-locales/wizard"></script>
+    <script src="<%= ExtraLocalesController.url("wizard") %>"></script>
     <%= csrf_meta_tags %>
 
     <meta name="discourse-base-uri" content="<%= Discourse.base_uri %>">


### PR DESCRIPTION
* Translations from the `js.*` namespace were not found, because `i18n-patches` were not loaded. I noticed because `select_kit.no_content` wasn't found.

* The extra-locales didn't use a hash in the URL.

* Using the <kbd>Enter</kbd> key to select a locale moved you to the next step without actually changing the locale.