### PR TITLE
Added Access-Control-Allow-Methods to CORS configuration

### DIFF
--- a/config/initializers/008-rack-cors.rb
+++ b/config/initializers/008-rack-cors.rb
@@ -41,6 +41,7 @@ class Discourse::Cors
       headers['Access-Control-Allow-Origin'] = origin || cors_origins[0]
       headers['Access-Control-Allow-Headers'] = 'Content-Type, X-Requested-With, X-CSRF-Token, Discourse-Visible, User-Api-Key, User-Api-Client-Id'
       headers['Access-Control-Allow-Credentials'] = 'true'
+      headers['Access-Control-Allow-Methods'] = 'POST, PUT, GET, OPTIONS, DELETE'
     end
 
     headers


### PR DESCRIPTION
Browsers are not consistent about which HTTP methods are allowed via CORS requests by default. Particularly DELETE or PUT. See discussion here: https://stackoverflow.com/questions/20478312/default-value-for-access-control-allow-methods

This patch explicitly configures which methods are allowed: POST, PUT, GET, OPTIONS, DELETE