### PR TITLE
extract inline JS that's used to store preloaded data

### DIFF
--- a/app/assets/javascripts/preload-application-data.js
+++ b/app/assets/javascripts/preload-application-data.js
@@ -1,0 +1,12 @@
+(function() {
+  var preloadedDataElement = document.getElementById("data-preloaded");
+
+  if (preloadedDataElement) {
+    var ps = require("preload-store").default;
+    var preloaded = JSON.parse(preloadedDataElement.dataset.preloaded);
+
+    Object.keys(preloaded).forEach(function(key) {
+      ps.store(key, JSON.parse(preloaded[key]));
+    });
+  }
+})();

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -129,7 +129,7 @@ module ApplicationHelper
       javascript = javascript.scrub
       javascript.gsub!(/\342\200\250/u, '&#x2028;')
       javascript.gsub!(/(<\/)/u, '\u003C/')
-      javascript.html_safe
+      javascript
     else
       ''
     end
@@ -400,5 +400,10 @@ module ApplicationHelper
     end
 
     Stylesheet::Manager.stylesheet_link_tag(name, 'all', ids)
+  end
+
+  def preloaded_json
+    return '{}' if @preloaded.blank?
+    @preloaded.transform_values { |value| escape_unicode(value) }.to_json
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -55,6 +55,9 @@
     <%= render partial: "common/discourse_stylesheet" %>
     <%= render partial: "common/special_font_face" %>
 
+    <meta id="data-preloaded" data-preloaded="<%= preloaded_json %>">
+    <%= preload_script "preload-application-data" %>
+
     <%= yield :head %>
 
     <%= build_plugin_html 'server:before-head-close' %>
@@ -103,17 +106,6 @@
         <input type="submit" id="signin-button" value="<%= t 'log_in' %>">
       </form>
     <% end %>
-
-    <%- if @preloaded.present? %>
-      <script>
-      (function() {
-        var ps = require('preload-store').default;
-        <%- @preloaded.each do |key, json| %>
-          ps.store("<%= key %>", <%= escape_unicode(json) %>);
-        <% end %>
-      })();
-      </script>
-    <%- end %>
 
     <%= yield :data %>
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -119,6 +119,7 @@ module Discourse
       service-worker.js
       google-tag-manager.js
       google-universal-analytics.js
+      preload-application-data.js
     }
 
     # Precompile all available locales

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -165,4 +165,15 @@ describe ApplicationHelper do
     end
   end
 
+  describe 'preloaded_json' do
+    it 'returns empty JSON if preloaded is empty' do
+      @preloaded = nil
+      expect(helper.preloaded_json).to eq('{}')
+    end
+
+    it 'escapes and strips invalid unicode and strips in json body' do
+      @preloaded = { test: %{["< \x80"]} }
+      expect(helper.preloaded_json).to eq(%{{"test":"[\\"\\u003c \uFFFD\\"]"}})
+    end
+  end
 end

--- a/spec/requests/categories_controller_spec.rb
+++ b/spec/requests/categories_controller_spec.rb
@@ -31,7 +31,11 @@ describe CategoriesController do
       SiteSetting.categories_topics = 5
       SiteSetting.categories_topics.times { Fabricate(:topic) }
       get "/categories"
-      expect(response.body).to include(%{"more_topics_url":"/latest"})
+
+      expect(response.body).to have_tag("meta#data-preloaded") do |element|
+        json = JSON.parse(element.current_scope.attribute('data-preloaded').value)
+        expect(json['topic_list_latest']).to include(%{"more_topics_url":"/latest"})
+      end
     end
   end
 

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -190,7 +190,10 @@ describe UsersController do
         )
 
         expect(response.status).to eq(200)
-        expect(response.body).to include('{"is_developer":false,"admin":false,"second_factor_required":false,"backup_enabled":false}')
+        expect(response.body).to have_tag("meta#data-preloaded") do |element|
+          json = JSON.parse(element.current_scope.attribute('data-preloaded').value)
+          expect(json['password_reset']).to include('{"is_developer":false,"admin":false,"second_factor_required":false,"backup_enabled":false}')
+        end
 
         expect(session["password-#{token}"]).to be_blank
         expect(UserAuthToken.where(id: user_auth_token.id).count).to eq(0)
@@ -255,7 +258,10 @@ describe UsersController do
 
           get "/u/password-reset/#{token}"
 
-          expect(response.body).to include('{"is_developer":false,"admin":false,"second_factor_required":true,"backup_enabled":false}')
+          expect(response.body).to have_tag("meta#data-preloaded") do |element|
+            json = JSON.parse(element.current_scope.attribute('data-preloaded').value)
+            expect(json['password_reset']).to include('{"is_developer":false,"admin":false,"second_factor_required":true,"backup_enabled":false}')
+          end
 
           put "/u/password-reset/#{token}", params: {
             password: 'hg9ow8yHG32O',
@@ -2592,9 +2598,12 @@ describe UsersController do
 
         expect(response.status).to eq(200)
 
-        expect(response.body).to include(
-          "{\"message\":\"#{I18n.t("login.activate_email", email: user.email).gsub!("</", "<\\/")}\",\"show_controls\":true,\"username\":\"#{user.username}\",\"email\":\"#{user.email}\"}"
-        )
+        expect(response.body).to have_tag("meta#data-preloaded") do |element|
+          json = JSON.parse(element.current_scope.attribute('data-preloaded').value)
+          expect(json['accountCreated']).to include(
+            "{\"message\":\"#{I18n.t("login.activate_email", email: user.email).gsub!("</", "<\\/")}\",\"show_controls\":true,\"username\":\"#{user.username}\",\"email\":\"#{user.email}\"}"
+          )
+        end
       end
     end
   end


### PR DESCRIPTION
I'm extracting inline JS in `application.html.erb` (and its includes) bits by bits to prepare for CSP. 

I'd love a fresh pair of 👀  on the approach; once this initial PR is OK'd, the rest of the inline JS changes should fall in pretty easily.