### PR TITLE
FEATURE: add indication if incoming email attachment was rejected and inform sender about it

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -88,6 +88,7 @@ en:
       maximum_staged_user_per_email_reached: "Reached maximum number of staged users created per email."
       no_subject: "(no subject)"
       no_body: "(no body)"
+      missing_attachment: '(Attachment %{filename} is missing)'
       errors:
         empty_email_error: "Happens when the raw mail we received was blank."
         no_message_id_error: "Happens when the mail has no 'Message-Id' header."
@@ -2604,6 +2605,16 @@ en:
         We're sorry, but your email message to %{destination} (titled %{former_title}) didn't work.
 
         There was an unrecognized error while processing your email and it wasn't posted. You should try again, or [contact a staff member](%{base_url}/about).
+
+    email_reject_attachment:
+      title: "Email Attachment Rejected"
+      subject_template: "[%{email_prefix}] Email issue -- Attachment Rejected"
+      text_body_template:  |
+        We're sorry, but the following attachments in your email message to %{destination} (titled %{former_title}) were rejected: %{rejected_attachments}
+
+        This can be caused by the attached file being too large or by an unauthorised file extension.
+
+        If you believe this is an error, [contact a staff member](%{base_url}/about).
 
     email_error_notification:
       title: "Email Error Notification"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2610,9 +2610,10 @@ en:
       title: "Email Attachment Rejected"
       subject_template: "[%{email_prefix}] Email issue -- Attachment Rejected"
       text_body_template:  |
-        We're sorry, but the following attachments in your email message to %{destination} (titled %{former_title}) were rejected: %{rejected_attachments}
+        Unfortunately some attachments in your email message to %{destination} (titled %{former_title}) were rejected.
 
-        This can be caused by the attached file being too large or by an unauthorised file extension.
+        Details:
+        %{rejected_errors}
 
         If you believe this is an error, [contact a staff member](%{base_url}/about).
 

--- a/lib/email/receiver.rb
+++ b/lib/email/receiver.rb
@@ -909,7 +909,7 @@ module Email
           tmp&.close!
         end
       end
-      notify_about_rejected_attachment(rejected_attachments) if rejected_attachments.present?
+      notify_about_rejected_attachment(rejected_attachments) if rejected_attachments.present? && !User.find(user_id).staged?
 
       raw
     end

--- a/lib/email/receiver.rb
+++ b/lib/email/receiver.rb
@@ -873,12 +873,12 @@ module Email
 
     def create_post_with_attachments(options = {})
       # deal with attachments
-      options[:raw] = add_attachments(options[:raw], options[:user].id, options)
+      options[:raw] = add_attachments(options[:raw], options[:user], options)
 
       create_post(options)
     end
 
-    def add_attachments(raw, user_id, options = {})
+    def add_attachments(raw, user, options = {})
       rejected_attachments = []
       attachments.each do |attachment|
         tmp = Tempfile.new(["discourse-email-attachment", File.extname(attachment.filename)])
@@ -887,7 +887,7 @@ module Email
           File.open(tmp.path, "w+b") { |f| f.write attachment.body.decoded }
           # create the upload for the user
           opts = { for_group_message: options[:is_group_message] }
-          upload = UploadCreator.new(tmp, attachment.filename, opts).create_for(user_id)
+          upload = UploadCreator.new(tmp, attachment.filename, opts).create_for(user.id)
           if upload&.valid?
             # try to inline images
             if attachment.content_type&.start_with?("image/")
@@ -909,7 +909,7 @@ module Email
           tmp&.close!
         end
       end
-      notify_about_rejected_attachment(rejected_attachments) if rejected_attachments.present? && !User.find(user_id).staged?
+      notify_about_rejected_attachment(rejected_attachments) if rejected_attachments.present? && !user.staged?
 
       raw
     end

--- a/spec/components/email/receiver_spec.rb
+++ b/spec/components/email/receiver_spec.rb
@@ -465,10 +465,20 @@ describe Email::Receiver do
       SiteSetting.authorized_extensions = "txt"
       expect { process(:attached_txt_file) }.to change { topic.posts.count }
       expect(topic.posts.last.raw).to match(/text\.txt/)
+    end
 
-      SiteSetting.authorized_extensions = "csv"
-      expect { process(:attached_txt_file_2) }.to change { topic.posts.count }
-      expect(topic.posts.last.raw).to_not match(/text\.txt/)
+    context "when attachment is rejected" do
+      it "sends out the warning email" do
+        expect { process(:attached_txt_file) }.to change { EmailLog.count }.by(1)
+        expect(EmailLog.last.email_type).to eq("email_reject_attachment")
+      end
+
+      it "creates the post with attachment missing message" do
+        missing_attachment_regex = Regexp.escape(I18n.t('emails.incoming.missing_attachment', filename: "text.txt"))
+        expect { process(:attached_txt_file) }.to change { topic.posts.count }
+        expect(topic.posts.last.raw).to match(/#{missing_attachment_regex}/)
+      end
+
     end
 
     it "supports emails with just an attachment" do

--- a/spec/components/email/receiver_spec.rb
+++ b/spec/components/email/receiver_spec.rb
@@ -473,12 +473,16 @@ describe Email::Receiver do
         expect(EmailLog.last.email_type).to eq("email_reject_attachment")
       end
 
+      it "doesn't send out the warning email if sender is staged user" do
+        user.update_columns(staged: true)
+        expect { process(:attached_txt_file) }.not_to change { EmailLog.count }
+      end
+
       it "creates the post with attachment missing message" do
         missing_attachment_regex = Regexp.escape(I18n.t('emails.incoming.missing_attachment', filename: "text.txt"))
         expect { process(:attached_txt_file) }.to change { topic.posts.count }
         expect(topic.posts.last.raw).to match(/#{missing_attachment_regex}/)
       end
-
     end
 
     it "supports emails with just an attachment" do


### PR DESCRIPTION
https://meta.discourse.org/t/e-mail-reject-attachment-template-or-add-note-to-topic-indicating-attachment-rejected-reason-for-rejection/47781/