### PR TITLE
extract Google Analytics / Tag Manager inline JS

### DIFF
--- a/app/assets/javascripts/google-tag-manager.js
+++ b/app/assets/javascripts/google-tag-manager.js
@@ -1,0 +1,17 @@
+(function() {
+  const gtmDataElement = document.getElementById("data-google-tag-manager");
+  const dataLayerJson = JSON.parse(gtmDataElement.dataset.dataLayer);
+
+  // dataLayer declaration needs to precede the container snippet
+  // https://developers.google.com/tag-manager/devguide#adding-data-layer-variables-to-a-page
+  window.dataLayer = [dataLayerJson];
+
+  /* eslint-disable */
+  // prettier-ignore
+  (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer',gtmDataElement.dataset.containerId);
+  /* eslint-enable */
+})();

--- a/app/assets/javascripts/google-universal-analytics.js
+++ b/app/assets/javascripts/google-universal-analytics.js
@@ -1,0 +1,20 @@
+/* eslint-disable */
+// prettier-ignore
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+/* eslint-enable */
+
+(function() {
+  const gaDataElement = document.getElementById("data-ga-universal-analytics");
+  const gaJson = JSON.parse(gaDataElement.dataset.json);
+
+  window.ga("create", gaDataElement.dataset.trackingCode, gaJson);
+  if (gaDataElement.dataset.autoLinkDomains.length) {
+    const autoLinkDomains = gaDataElement.dataset.autoLinkDomains.split("|");
+
+    window.ga("require", "linker");
+    window.ga("linker:autoLink", autoLinkDomains);
+  }
+})();

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -31,7 +31,7 @@ module ApplicationHelper
     if SiteSetting.ga_universal_auto_link_domains.present?
       result[:allowLinker] = true
     end
-    result.to_json.html_safe
+    result.to_json
   end
 
   def ga_universal_json

--- a/app/views/common/_google_tag_manager_head.html.erb
+++ b/app/views/common/_google_tag_manager_head.html.erb
@@ -1,11 +1,5 @@
-<script>
-dataLayer = [<%= google_tag_manager_json %>];
-</script>
+<meta id="data-google-tag-manager"
+  data-data-layer="<%= google_tag_manager_json %>"
+  data-container-id="<%= SiteSetting.gtm_container_id %>" />
 
-<!-- Google Tag Manager -->
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','<%= SiteSetting.gtm_container_id %>');</script>
-<!-- End Google Tag Manager -->
+<%= preload_script 'google-tag-manager' %>

--- a/app/views/common/_google_universal_analytics.html.erb
+++ b/app/views/common/_google_universal_analytics.html.erb
@@ -1,14 +1,7 @@
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+<%= tag.meta id: 'data-ga-universal-analytics', data: {
+  tracking_code: SiteSetting.ga_universal_tracking_code,
+  json: ga_universal_json,
+  auto_link_domains: SiteSetting.ga_universal_auto_link_domains
+} %>
 
-  ga('create', '<%= SiteSetting.ga_universal_tracking_code %>', <%= ga_universal_json %>);
-
-  <% if SiteSetting.ga_universal_auto_link_domains.present? %>
-  ga('require', 'linker');
-  ga('linker:autoLink', <%= raw SiteSetting.ga_universal_auto_link_domains.split('|').to_json %>);
-  <% end %>
-
-</script>
+<%= preload_script "google-universal-analytics" %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -117,6 +117,8 @@ module Discourse
       plugin-third-party.js
       markdown-it-bundle.js
       service-worker.js
+      google-tag-manager.js
+      google-universal-analytics.js
     }
 
     # Precompile all available locales


### PR DESCRIPTION
Previously I shoved all the server-rendered data into a `div`:

```html
<div class="hidden" id="id" data-server-rendered="hello world"></div>
```

This works but @SamSaffron brought up a question about HTML semantics. After looking through the docs, I decided to try out the `meta` tag In this PR:

> Metadata contains information about the page. This includes information about styles, scripts and **data to help software use and render the page**.  -- [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element#Document_metadata)

```html
<meta id="id" data-server-rendered="hello world" />
```

The only limitation with `meta` is it has to live in `head`, but it's fine 99% of the time (we can always fallback to `div`s for the other 1%).

If we are good with using the `meta` tag, I will amend my previous/future PRs.