### PR TITLE
FIX: Allow `rake destroy:topics` to delete topics in sub-categories

### DIFF
--- a/app/services/destroy_task.rb
+++ b/app/services/destroy_task.rb
@@ -2,12 +2,13 @@
 #   we are capturing all log output into a log array to return
 #   to the rake task rather than using `puts` statements.
 class DestroyTask
-  def self.destroy_topics(category)
-    c = Category.find_by_slug(category)
+  def self.destroy_topics(category, parent_category = nil)
+    c = Category.find_by_slug(category, parent_category)
     log = []
-    return "A category with the slug: #{category} could not be found" if c.nil?
+    descriptive_slug = parent_category ? "#{parent_category}/#{category}" : category
+    return "A category with the slug: #{descriptive_slug} could not be found" if c.nil?
     topics = Topic.where(category_id: c.id, pinned_at: nil).where.not(user_id: -1)
-    log << "There are #{topics.count} topics to delete in #{category} category"
+    log << "There are #{topics.count} topics to delete in #{descriptive_slug} category"
     topics.each do |topic|
       log << "Deleting #{topic.slug}..."
       first_post = topic.ordered_posts.first
@@ -24,7 +25,7 @@ class DestroyTask
     categories = Category.all
     log = []
     categories.each do |c|
-      log << destroy_topics(c.slug)
+      log << destroy_topics(c.slug, c.parent_category&.slug)
     end
     log
   end

--- a/lib/tasks/destroy.rake
+++ b/lib/tasks/destroy.rake
@@ -2,10 +2,12 @@
 #   content and users from your site, but keeping your site settings,
 #   theme, and category structure.
 desc "Remove all topics in a category"
-task "destroy:topics", [:category] => :environment do |t, args|
+task "destroy:topics", [:category, :parent_category] => :environment do |t, args|
   category = args[:category]
-  puts "Going to delete all topics in the #{category} category"
-  puts log = DestroyTask.destroy_topics(category)
+  parent_category = args[:parent_category]
+  descriptive_slug = parent_category ? "#{parent_category}/#{category}" : category
+  puts "Going to delete all topics in the #{descriptive_slug} category"
+  puts log = DestroyTask.destroy_topics(category, parent_category)
 end
 
 desc "Remove all topics in all categories"

--- a/spec/services/destroy_task_spec.rb
+++ b/spec/services/destroy_task_spec.rb
@@ -9,11 +9,18 @@ describe DestroyTask do
     let!(:c2) { Fabricate(:category) }
     let!(:t2) { Fabricate(:topic, category: c2) }
     let!(:p2) { Fabricate(:post, topic: t2) }
+    let!(:sc) { Fabricate(:category, parent_category: c) }
+    let!(:t3) { Fabricate(:topic, category: sc) }
+    let!(:p3) { Fabricate(:post, topic: t3) }
 
     it 'destroys all topics in a category' do
-      before_count = Topic.where(category_id: c.id).count
-      DestroyTask.destroy_topics(c.slug)
-      expect(Topic.where(category_id: c.id).count).to eq before_count - 1
+      expect { DestroyTask.destroy_topics(c.slug) }
+        .to change { Topic.where(category_id: c.id).count }.by (-1)
+    end
+
+    it 'destroys all topics in a sub category' do
+      expect { DestroyTask.destroy_topics(sc.slug, c.slug) }
+        .to change { Topic.where(category_id: sc.id).count }.by(-1)
     end
 
     it "doesn't destroy system topics" do
@@ -23,7 +30,7 @@ describe DestroyTask do
 
     it 'destroys topics in all categories' do
       DestroyTask.destroy_topics_all_categories
-      expect(Post.where(topic_id: [t.id, t2.id]).count).to eq 0
+      expect(Post.where(topic_id: [t.id, t2.id, t3.id]).count).to eq 0
     end
   end
 


### PR DESCRIPTION
Minor improvement so that the rake task can deal with sub categories