### PR TITLE
FIX: Remove null bytes from search terms to prevent ArgumentError(s)

### DIFF
--- a/lib/search.rb
+++ b/lib/search.rb
@@ -138,6 +138,8 @@ class Search
     term.gsub!(/[\u200B-\u200D\uFEFF]/, '')
     # Replace curly quotes to regular quotes
     term.gsub!(/[\u201c\u201d]/, '"')
+    # Removes any null bytes from search terms
+    term.gsub!("\u0000", '')
 
     @clean_term = term
 

--- a/spec/components/search_spec.rb
+++ b/spec/components/search_spec.rb
@@ -71,6 +71,17 @@ describe Search do
     expect(search.clean_term).to eq('capybara')
   end
 
+  it 'strips null bytes (u0000) from search terms' do
+    term = "\u0063\u0061\u0070\u0079\u0000\u200c\u200d\ufeff\u0062\u0061\u0072\u0061".encode("UTF-8")
+
+    expect(term == 'capybara').to eq(false)
+
+    search = Search.new(term)
+    expect(search.valid?).to eq(true)
+    expect(search.term).to eq('capybara')
+    expect(search.clean_term).to eq('capybara')
+  end
+
   it 'replaces curly quotes to regular quotes in search terms' do
     term = '“discourse”'
 


### PR DESCRIPTION
**Error log**
```ruby
ArgumentError (string contains null byte) /var/www/discourse/lib/search.rb:148:in `escape_string' 
/var/www/discourse/lib/search.rb:148:in `escape_string'
/var/www/discourse/lib/search.rb:148:in `initialize'
/var/www/discourse/app/controllers/search_controller.rb:33:in `new'
/var/www/discourse/app/controllers/search_controller.rb:33:in `show'
```