### PR TITLE
FIX: don't raise an error on integer usernames in user_name_suggester

### DIFF
--- a/lib/user_name_suggester.rb
+++ b/lib/user_name_suggester.rb
@@ -39,7 +39,7 @@ module UserNameSuggester
   end
 
   def self.sanitize_username(name)
-    name = ActiveSupport::Inflector.transliterate(name)
+    name = ActiveSupport::Inflector.transliterate(name.to_s)
     # 1. replace characters that aren't allowed with '_'
     name.gsub!(UsernameValidator::CONFUSING_EXTENSIONS, "_")
     name.gsub!(/[^\w.-]/, "_")

--- a/spec/components/user_name_suggester_spec.rb
+++ b/spec/components/user_name_suggester_spec.rb
@@ -18,6 +18,10 @@ describe UserNameSuggester do
       expect(UserNameSuggester.suggest(nil)).to eq(nil)
     end
 
+    it "doesn't raise an error on integer username" do
+      expect(UserNameSuggester.suggest(999)).to eq('999')
+    end
+
     it 'corrects weird characters' do
       expect(UserNameSuggester.suggest("Darth%^Vader")).to eq('Darth_Vader')
     end


### PR DESCRIPTION
**Error:** ArgumentError (Can only transliterate strings. Received Integer)

```ruby
/var/www/discourse/vendor/bundle/ruby/2.5.0/gems/activesupport-5.2.0/lib/active_support/inflector/transliterate.rb:62:in `transliterate'
/var/www/discourse/lib/user_name_suggester.rb:42:in `sanitize_username'
/var/www/discourse/lib/user_name_suggester.rb:38:in `fix_username'
/var/www/discourse/lib/user_name_suggester.rb:21:in `find_available_username_based_on'
/var/www/discourse/lib/user_name_suggester.rb:7:in `suggest'
/var/www/discourse/lib/auth/result.rb:66:in `to_client_hash'
/var/www/discourse/app/views/users/omniauth_callbacks/complete.html.erb:28:in `_app_views_users_omniauth_callbacks_complete_html_erb__18618
```
