### PR TITLE
FIX: use current user color scheme when filling `theme-color` attribute

### DIFF
--- a/app/controllers/metadata_controller.rb
+++ b/app/controllers/metadata_controller.rb
@@ -27,8 +27,8 @@ class MetadataController < ApplicationController
       display: display,
       orientation: 'any',
       start_url: Discourse.base_uri.present? ? "#{Discourse.base_uri}/" : '.',
-      background_color: "##{ColorScheme.hex_for_name('secondary')}",
-      theme_color: "##{ColorScheme.hex_for_name('header_background')}",
+      background_color: "##{ColorScheme.hex_for_name('secondary', view_context.scheme_id)}",
+      theme_color: "##{ColorScheme.hex_for_name('header_background', view_context.scheme_id)}",
       icons: [
         {
           src: logo,

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -362,6 +362,12 @@ module ApplicationHelper
     end
   end
 
+  def scheme_id
+    return if theme_ids.blank?
+    theme = Theme.find_by(id: theme_ids.first)
+    theme&.color_scheme_id
+  end
+
   def current_homepage
     current_user&.user_option&.homepage || SiteSetting.anonymous_homepage
   end

--- a/app/models/color_scheme.rb
+++ b/app/models/color_scheme.rb
@@ -186,14 +186,16 @@ class ColorScheme < ActiveRecord::Base
     new_color_scheme
   end
 
-  def self.lookup_hex_for_name(name)
-    enabled_color_scheme = Theme.where(id: SiteSetting.default_theme_id).first&.color_scheme
+  def self.lookup_hex_for_name(name, scheme_id = nil)
+    enabled_color_scheme = find_by(id: scheme_id) if scheme_id
+    enabled_color_scheme ||= Theme.where(id: SiteSetting.default_theme_id).first&.color_scheme
     (enabled_color_scheme || base).colors.find { |c| c.name == name }.try(:hex) || "nil"
   end
 
-  def self.hex_for_name(name)
-    hex_cache[name] ||= lookup_hex_for_name(name)
-    hex_cache[name] == "nil" ? nil : hex_cache[name]
+  def self.hex_for_name(name, scheme_id = nil)
+    cache_key = scheme_id ? name + "_#{scheme_id}" : name
+    hex_cache[cache_key] ||= lookup_hex_for_name(name, scheme_id)
+    hex_cache[cache_key] == "nil" ? nil : hex_cache[cache_key]
   end
 
   def colors=(arr)

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -51,6 +51,7 @@ class Theme < ActiveRecord::Base
 
     remove_from_cache!
     clear_cached_settings!
+    ColorScheme.hex_cache.clear
   end
 
   after_destroy do
@@ -72,6 +73,7 @@ class Theme < ActiveRecord::Base
     end
 
     Theme.expire_site_cache!
+    ColorScheme.hex_cache.clear
   end
 
   after_commit ->(theme) do

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -9,7 +9,7 @@
 <%- if (SiteSetting.apple_touch_icon_url != "/images/default-apple-touch-icon.png") && SiteSetting.apple_touch_icon_url.present? %>
 <link rel="icon" type="image/png" sizes="144x144" href="<%=SiteSetting.apple_touch_icon_url%>">
 <%- end %>
-<meta name="theme-color" content="#<%= ColorScheme.hex_for_name('header_background') %>">
+<meta name="theme-color" content="#<%= ColorScheme.hex_for_name('header_background', scheme_id) %>">
 <% if mobile_view? %>
 <meta name="viewport" content="width=device-width, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">
 <% else %>

--- a/spec/models/color_scheme_spec.rb
+++ b/spec/models/color_scheme_spec.rb
@@ -65,6 +65,13 @@ describe ColorScheme do
         expect(ColorScheme.hex_for_name('undefined')).to eq nil
       end
 
+      it "returns the base color for an attribute of a specified scheme" do
+        scheme = ColorScheme.create_from_base(name: "test scheme")
+        ColorSchemeRevisor.revise(scheme, colors: [{ name: "header_background", hex: "9dc927", default_hex: "949493" }])
+        scheme.reload
+        expect(ColorScheme.hex_for_name("header_background", scheme.id)).to eq("9dc927")
+      end
+
       it "returns the base color for an attribute" do
         expect(ColorScheme.hex_for_name('second_one')).to eq base_colors[:second_one]
       end


### PR DESCRIPTION
https://meta.discourse.org/t/meta-attribute-theme-color-uses-the-default-header-background-color-not-the-active-one/96727?u=osama