### PR TITLE
FIX: rescue ActiveRecord::RecordInvalid in find_or_create_by_safe!

### DIFF
--- a/lib/freedom_patches/active_record_base.rb
+++ b/lib/freedom_patches/active_record_base.rb
@@ -15,7 +15,7 @@ class ActiveRecord::Base
   def self.find_or_create_by_safe!(hash)
     begin
       find_or_create_by!(hash)
-    rescue PG::UniqueViolation, ActiveRecord::RecordNotUnique
+    rescue PG::UniqueViolation, ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid
       # try again cause another transaction could have passed by now
       find_or_create_by!(hash)
     end


### PR DESCRIPTION
Tracked this down from:

```text
Job exception: Validation failed: Post has already been taken

BT
/var/www/discourse/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.0/lib/active_record/validations.rb:80:in `raise_validation_error'
...
/var/www/discourse/lib/freedom_patches/active_record_base.rb:17:in `find_or_create_by_safe!'
/var/www/discourse/lib/email/sender.rb:269:in `set_reply_key'
/var/www/discourse/app/jobs/regular/user_email.rb:47:in `execute'
```

https://github.com/discourse/discourse/blob/1a01385e886b52e1d2e77c5d38d81846a736727b/lib/email/sender.rb#L268-L272

i.e. basically, the record is inserted between the `find_by` and the `create_by!`.

We already [rescue `PG::UniqueViolation` and `ActiveRecord::RecordNotUnique`](https://github.com/discourse/discourse/blob/3bb4f4c5efff46f3aa1607af53a0b0b3f7a02346/lib/freedom_patches/active_record_base.rb#L18), however, they are only raised if the error is picked up by the database constraint. In this case, our AR uniqueness validation raised `ActiveRecord::RecordInvalid` (before hitting the database).

I am still a bit torn if we should just catch all `ActiveRecord::RecordInvalid` within `find_or_create_by!`, **or deal with this individually in `Email::Sender#set_reply_key`** (in which we can easily check if it is a uniqueness validation error). Let me know what do you think! 