### PR TITLE
FIX: allows forcing timezone displayed in local-dates

### DIFF
--- a/plugins/discourse-local-dates/assets/javascripts/discourse-local-dates.js
+++ b/plugins/discourse-local-dates/assets/javascripts/discourse-local-dates.js
@@ -45,7 +45,10 @@
         }
       });
 
-      var relativeTime = relativeTime.tz(moment.tz.guess());
+      var relativeTime = relativeTime.tz(
+        options.forceTimezone || moment.tz.guess()
+      );
+
       if (
         options.format !== "YYYY-MM-DD HH:mm:ss" &&
         relativeTime.isBetween(
@@ -65,18 +68,18 @@
 
       var joinedPreviews = previews.join("\n");
 
+      var displayedTime = relativeTime.replace(
+        "TZ",
+        _formatTimezone(options.forceTimezone || moment.tz.guess()).join(": ")
+      );
+
       $element
         .html(html)
         .attr("title", joinedPreviews)
         .attr("data-tooltip", joinedPreviews)
         .addClass("cooked")
         .find(".relative-time")
-        .text(
-          relativeTime.replace(
-            "TZ",
-            _formatTimezone(moment.tz.guess()).join(": ")
-          )
-        );
+        .text(displayedTime);
 
       if (repeat) {
         this.timeout = setTimeout(function() {
@@ -94,6 +97,7 @@
       options.time = $this.attr("data-time");
       options.recurring = $this.attr("data-recurring");
       options.timezones = $this.attr("data-timezones") || "Etc/UTC";
+      options.forceTimezone = $this.attr("data-force-timezone");
 
       processElement($this, options);
     });

--- a/plugins/discourse-local-dates/assets/javascripts/lib/discourse-markdown/discourse-local-dates.js.es6
+++ b/plugins/discourse-local-dates/assets/javascripts/lib/discourse-markdown/discourse-local-dates.js.es6
@@ -18,6 +18,7 @@ function addLocalDate(buffer, matches, state) {
 
   config.date = parsed.attrs.date;
   config.time = parsed.attrs.time;
+  config.forceTimezone = parsed.attrs.forceTimezone;
   config.recurring = parsed.attrs.recurring;
   config.format = parsed.attrs.format || config.format;
   config.timezones = parsed.attrs.timezones || config.timezones;
@@ -28,7 +29,8 @@ function addLocalDate(buffer, matches, state) {
     ["data-date", state.md.utils.escapeHtml(config.date)],
     ["data-time", state.md.utils.escapeHtml(config.time)],
     ["data-format", state.md.utils.escapeHtml(config.format)],
-    ["data-timezones", state.md.utils.escapeHtml(config.timezones)]
+    ["data-timezones", state.md.utils.escapeHtml(config.timezones)],
+    ["data-force-timezone", state.md.utils.escapeHtml(config.forceTimezone)]
   ];
 
   if (config.recurring) {


### PR DESCRIPTION
Use case being you might want to always display a specific timezone, but still have the possibility to show the tooltip with various timezones.