### PR TITLE
DEV: apply plugin migrations when testing in Travis and Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ install:
   - bash -c "if [ '$RAILS_MASTER' == '1' ]; then bundle update --retry=3 --jobs=3 arel rails seed-fu > /dev/null; fi"
   - bash -c "if [ '$RAILS_MASTER' == '0' ]; then bundle install --without development --deployment --retry=3 --jobs=3 > /dev/null; fi"
   - bash -c "if [ '$QUNIT_RUN' == '1' ] || [ '$RUN_LINT' == '1' ]; then yarn install --dev > /dev/null; fi"
-  - bash -c "if [ '$RUN_LINT' != '1' ]; then bundle exec rake db:create db:migrate > /dev/null; fi"
+  - bash -c "if [ '$RUN_LINT' != '1' ]; then LOAD_PLUGINS=1 bundle exec rake db:create db:migrate > /dev/null; fi"
 
 script:
   - |

--- a/lib/tasks/docker.rake
+++ b/lib/tasks/docker.rake
@@ -95,7 +95,11 @@ task 'docker:test' do
         @good &&= run_or_fail("bundle exec rake plugin:install_all_official")
       end
 
-      @good &&= run_or_fail("bundle exec rake db:migrate")
+      if ENV["SKIP_PLUGINS"]
+        @good &&= run_or_fail("bundle exec rake db:migrate")
+      else
+        @good &&= run_or_fail("LOAD_PLUGINS=1 bundle exec rake db:migrate")
+      end
 
       puts "travis_fold:end:prepare_tests" if ENV["TRAVIS"]
 


### PR DESCRIPTION
In `RAILS_ENV=test`, plugins are not loaded by default. Therefore we need to explicitly specify `LOAD_PLUGINS=1` when we want to apply plugin migrations.

This will become essential once @ZogStriP's poll changes are merged (note that travis is currently failing on #6359). It will also be useful for `discourse-anonymous-user` and `discourse-brightcove` (and any other plugins that may want to apply migrations in future).

This PR makes the changes for Travis, and for `docker.rake` (used by our internal test system, and plugins that use Travis)