### PR TITLE
SPEC: reworked specs of existing group behavior

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -355,8 +355,6 @@ class GroupsController < ApplicationController
       end
     end
 
-    user.primary_group_id = nil if user.primary_group_id == group.id
-
     group.remove(user)
     GroupActionLogger.new(current_user, group).log_remove_user_from_group(user)
 


### PR DESCRIPTION
> DISCUSSION: https://meta.discourse.org/t/user-in-multiple-groups-title-display-and-group-link-dont-match/96502/17?u=xrav3nz

This only re-organizes and adds some specs about our **current** group behaviour around joining, leaving, title granting, and primary group changes. 

---

- [x] More specs on existing `Group` behavior (this PR)
- [x] Switch title if exact match and primary changes (https://github.com/discourse/discourse/pull/6404)
- [ ] When stripping a title, we should check if there is another title we can grant the user