### PR TITLE
FEATURE: match user title when primary group changes

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -108,6 +108,7 @@ class User < ActiveRecord::Base
 
   before_save :update_username_lower
   before_save :ensure_password_is_hashed
+  before_save :match_title_to_primary_group_changes
 
   after_save :expire_tokens_if_password_changed
   after_save :clear_global_notice_if_needed
@@ -1270,6 +1271,14 @@ class User < ActiveRecord::Base
       rescue Discourse::InvalidAccess, UserDestroyer::PostsExistError
         # keep going
       end
+    end
+  end
+
+  def match_title_to_primary_group_changes
+    return unless primary_group_id_changed?
+
+    if title == Group.where(id: primary_group_id_was).pluck(:title).first
+      self.title = primary_group&.title
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1815,28 +1815,15 @@ describe User do
   end
 
   describe '#match_title_to_primary_group_changes' do
-    let(:previous_primary_group) { Fabricate(:group, title: 'Previous', users: [user]) }
-    let(:new_primary_group) { Fabricate(:group, title: 'New', users: [user]) }
+    let(:primary_group_a) { Fabricate(:group, title: 'A', users: [user]) }
+    let(:primary_group_b) { Fabricate(:group, title: 'B', users: [user]) }
 
-    before { user.update(primary_group: previous_primary_group) }
+    it "updates user's title only when it is blank or matches the previous primary group" do
+      expect { user.update(primary_group: primary_group_a) }.to change { user.reload.title }.from(nil).to('A')
+      expect { user.update(primary_group: primary_group_b) }.to change { user.reload.title }.from('A').to('B')
 
-    def change_primary_group
-      user.update(primary_group: new_primary_group)
-    end
-
-    it "updates user's title when it matches the previous primary group" do
-      user.update(title: 'Previous')
-      expect { change_primary_group }.to change { user.reload.title }.from('Previous').to('New')
-    end
-
-    it "doesn't update user's title when it does not match the previous primary group" do
       user.update(title: 'Different')
-      expect { change_primary_group }.to_not change { user.reload.title }
-    end
-
-    it "update user's title when the user has a blank title" do
-      user.update(title: nil)
-      expect { change_primary_group }.to change { user.reload.title }.from(nil).to('New')
+      expect { user.update(primary_group: primary_group_a) }.to_not change { user.reload.title }
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1814,4 +1814,29 @@ describe User do
 
   end
 
+  describe '#match_title_to_primary_group_changes' do
+    let(:previous_primary_group) { Fabricate(:group, title: 'Previous', users: [user]) }
+    let(:new_primary_group) { Fabricate(:group, title: 'New', users: [user]) }
+
+    before { user.update(primary_group: previous_primary_group) }
+
+    def change_primary_group
+      user.update(primary_group: new_primary_group)
+    end
+
+    it "updates user's title when it matches the previous primary group" do
+      user.update(title: 'Previous')
+      expect { change_primary_group }.to change { user.reload.title }.from('Previous').to('New')
+    end
+
+    it "doesn't update user's title when it does not match the previous primary group" do
+      user.update(title: 'Different')
+      expect { change_primary_group }.to_not change { user.reload.title }
+    end
+
+    it "update user's title when the user has a blank title" do
+      user.update(title: nil)
+      expect { change_primary_group }.to change { user.reload.title }.from(nil).to('New')
+    end
+  end
 end


### PR DESCRIPTION
> DISCUSSION: https://meta.discourse.org/t/user-in-multiple-groups-title-display-and-group-link-dont-match/96502/17?u=xrav3nz

When primary group changes and the user's title is the previous primary group's title, change the title to the new primary group's title

---

- [x] More specs on existing `Group` behavior (https://github.com/discourse/discourse/pull/6403)
- [x] Switch title if exact match and primary changes (this PR)
- [ ] When stripping a title, we should check if there is another title we can grant the user