### PR TITLE
DEV: `yarn prettier` in Danger

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -2,8 +2,9 @@ if github.pr_json && (github.pr_json["additions"] || 0) > 250 || (github.pr_json
   warn("This pull request is big! We prefer smaller PRs whenever possible, as they are easier to review. Can this be split into a few smaller PRs?")
 end
 
-prettier_offenses = `prettier --list-different "app/assets/stylesheets/**/*.scss" "app/assets/javascripts/**/*.es6" "test/javascripts/**/*.es6"`.split('\n')
-if !prettier_offenses.empty?
+prettier_offenses = `yarn --silent prettier --list-different "app/assets/stylesheets/**/*.scss" "app/assets/javascripts/**/*.es6" "test/javascripts/**/*.es6"`.split("\n")
+
+unless prettier_offenses.empty?
   fail(%{
 This PR doesn't match our required code formatting standards, as enforced by prettier.io. <a href='https://meta.discourse.org/t/prettier-code-formatting-tool/93212'>Here's how to set up prettier in your code editor.</a>\n
 #{prettier_offenses.map { |o| github.html_link(o) }.join("\n")}


### PR DESCRIPTION
In our Travis build logs:

```
sh: 1: prettier: not found
```

since we have moved prettier to yarn and [dropped it from our docker image](https://github.com/discourse/discourse_docker/commit/9a4dca18029a983cb1fce28010e7f1f44c7e1ac7).

---

🎉 Welcome back @discoursedangerbot 

![image](https://user-images.githubusercontent.com/6376558/45608613-7b311b80-ba86-11e8-99d3-9e1b748107f9.png)
