### PR TITLE
extract client side `Discourse` setup inline JS

### DIFF
--- a/app/assets/javascripts/preload-application-data.js
+++ b/app/assets/javascripts/preload-application-data.js
@@ -1,12 +1,42 @@
 (function() {
+  var ps = require("preload-store").default;
   var preloadedDataElement = document.getElementById("data-preloaded");
 
   if (preloadedDataElement) {
-    var ps = require("preload-store").default;
     var preloaded = JSON.parse(preloadedDataElement.dataset.preloaded);
 
     Object.keys(preloaded).forEach(function(key) {
       ps.store(key, JSON.parse(preloaded[key]));
     });
+  }
+
+  var setupData = document.getElementById("data-discourse-setup").dataset;
+
+  Discourse.CDN = setupData.cdn;
+  Discourse.BaseUrl = setupData.baseUrl;
+  Discourse.BaseUri = setupData.baseUri;
+  Discourse.Environment = setupData.environment;
+  Discourse.SiteSettings = ps.get("siteSettings");
+  Discourse.ThemeSettings = ps.get("themeSettings");
+  Discourse.LetterAvatarVersion = setupData.letterAvatarVersion;
+  Discourse.MarkdownItURL = setupData.markdownItUrl;
+  Discourse.ServiceWorkerURL = setupData.serviceWorkerUrl;
+  I18n.defaultLocale = setupData.defaultLocale;
+  Discourse.start();
+  Discourse.set("assetVersion", setupData.assetVersion);
+  Discourse.Session.currentProp(
+    "disableCustomCSS",
+    setupData.disableCustomCss === "true"
+  );
+
+  if (setupData.safeMode) {
+    Discourse.Session.currentProp("safe_mode", setupData.safeMode);
+  }
+
+  Discourse.HighlightJSPath = setupData.highlightJsPath;
+
+  if (setupData.S3BaseUrl) {
+    Discourse.S3CDN = setupData.s3Cdn;
+    Discourse.S3BaseUrl = setupData.s3BaseUrl;
   }
 })();

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -307,13 +307,13 @@ module ApplicationHelper
   end
 
   def normalized_safe_mode
-    safe_mode = nil
-    (safe_mode ||= []) << ApplicationController::NO_CUSTOM if customization_disabled?
-    (safe_mode ||= []) << ApplicationController::NO_PLUGINS if !allow_plugins?
-    (safe_mode ||= []) << ApplicationController::ONLY_OFFICIAL if !allow_third_party_plugins?
-    if safe_mode
-      safe_mode.join(",").html_safe
-    end
+    safe_mode = []
+
+    safe_mode << ApplicationController::NO_CUSTOM if customization_disabled?
+    safe_mode << ApplicationController::NO_PLUGINS if !allow_plugins?
+    safe_mode << ApplicationController::ONLY_OFFICIAL if !allow_third_party_plugins?
+
+    safe_mode.join(",")
   end
 
   def loading_admin?
@@ -405,5 +405,35 @@ module ApplicationHelper
   def preloaded_json
     return '{}' if @preloaded.blank?
     @preloaded.transform_values { |value| escape_unicode(value) }.to_json
+  end
+
+  def client_side_setup_data
+    service_worker_url = Rails.env.development? ? 'service-worker.js' : Rails.application.assets_manifest.assets['service-worker.js']
+    current_hostname_without_port = RailsMultisite::ConnectionManagement.current_hostname.sub(/:[\d]*$/, '')
+
+    setup_data = {
+      cdn: Rails.configuration.action_controller.asset_host,
+      base_url: current_hostname_without_port,
+      base_uri: Discourse::base_uri,
+      environment: Rails.env,
+      letter_avatar_version: LetterAvatar.version,
+      markdown_it_url: asset_url('markdown-it-bundle.js'),
+      service_worker_url: service_worker_url,
+      default_locale: SiteSetting.default_locale,
+      asset_version: Discourse.assets_digest,
+      disable_custom_css: loading_admin?,
+      highlight_js_path: HighlightJs.path,
+    }
+
+    if guardian.can_enable_safe_mode? && params["safe_mode"]
+      setup_data[:safe_mode] = normalized_safe_mode
+    end
+
+    if SiteSetting.Upload.enable_s3_uploads
+      setup_data[:s3_cdn] = SiteSetting.Upload.s3_cdn_url.presence
+      setup_data[:s3_base_url] = SiteSetting.Upload.s3_base_url
+    end
+
+    setup_data
   end
 end

--- a/app/views/common/_discourse_javascript.html.erb
+++ b/app/views/common/_discourse_javascript.html.erb
@@ -33,34 +33,6 @@
       }
     });
   <%- end %>
-
-  (function() {
-    var ps = require('preload-store').default;
-
-    Discourse.CDN = '<%= Rails.configuration.action_controller.asset_host %>';
-    Discourse.BaseUrl = '<%= RailsMultisite::ConnectionManagement.current_hostname %>'.replace(/:[\d]*$/,"");
-    Discourse.BaseUri = '<%= Discourse::base_uri %>';
-    Discourse.Environment = '<%= Rails.env %>';
-    Discourse.SiteSettings = ps.get('siteSettings');
-    Discourse.ThemeSettings = ps.get('themeSettings');
-    Discourse.LetterAvatarVersion = '<%= LetterAvatar.version %>';
-    Discourse.MarkdownItURL = '<%= asset_url('markdown-it-bundle.js') %>';
-    Discourse.ServiceWorkerURL = Discourse.Environment != "development" ? '<%= Rails.application.assets_manifest.assets['service-worker.js'] %>' : 'service-worker.js';
-    I18n.defaultLocale = '<%= SiteSetting.default_locale %>';
-    Discourse.start();
-    Discourse.set('assetVersion','<%= Discourse.assets_digest %>');
-    Discourse.Session.currentProp("disableCustomCSS", <%= loading_admin? %>);
-    <%- if guardian.can_enable_safe_mode? && params["safe_mode"] %>
-    Discourse.Session.currentProp("safe_mode", <%= normalized_safe_mode.inspect.html_safe %>);
-    <%- end %>
-    Discourse.HighlightJSPath = <%= HighlightJs.path.inspect.html_safe %>;
-    <%- if SiteSetting.Upload.enable_s3_uploads %>
-      <%- if SiteSetting.Upload.s3_cdn_url.present? %>
-    Discourse.S3CDN = '<%= SiteSetting.Upload.s3_cdn_url %>';
-      <%- end %>
-    Discourse.S3BaseUrl = '<%= SiteSetting.Upload.s3_base_url %>';
-    <%- end %>
-  })();
 </script>
 
 <%= preload_script 'browser-update' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,11 +17,6 @@
       <meta name="shared_session_key" content="<%= shared_session_key %>">
     <%- end %>
 
-    <script>
-      window.EmberENV = window.EmberENV || {};
-      window.EmberENV['FORCE_JQUERY'] = true;
-    </script>
-
     <%= preload_script "locales/#{I18n.locale}" %>
     <%= preload_script "ember_jquery" %>
     <%= preload_script "preload-store" %>
@@ -58,6 +53,8 @@
     <%= yield :head %>
 
     <%= build_plugin_html 'server:before-head-close' %>
+
+    <%= tag.meta id: 'data-discourse-setup', data: client_side_setup_data %>
   </head>
 
   <body class="<%= body_classes %>">


### PR DESCRIPTION
Manually tested in <kbd>F12</kbd> that all the `Discourse` vars are set up properly 😅

Will be able to ✂️ `common/_discourse_javascript.html.erb` in the next PR.