### PR TITLE
FEATURE: auto grant an available title when removing old title

### DIFF
--- a/app/models/badge.rb
+++ b/app/models/badge.rb
@@ -159,6 +159,15 @@ class Badge < ActiveRecord::Base
     SQL
   end
 
+  def self.i18n_name(name)
+    name.downcase.tr(' ', '_')
+  end
+
+  def self.display_name(name)
+    key = "badges.#{i18n_name(name)}.name"
+    I18n.t(key, default: name)
+  end
+
   def awarded_for_trust_level?
     id <= 4
   end
@@ -191,8 +200,7 @@ class Badge < ActiveRecord::Base
   end
 
   def display_name
-    key = "badges.#{i18n_name}.name"
-    I18n.t(key, default: self.name)
+    self.class.display_name(name)
   end
 
   def long_description
@@ -230,9 +238,8 @@ class Badge < ActiveRecord::Base
   end
 
   def i18n_name
-    self.name.downcase.tr(' ', '_')
+    @i18n_name ||= self.class.i18n_name(name)
   end
-
 end
 
 # == Schema Information

--- a/app/models/group_user.rb
+++ b/app/models/group_user.rb
@@ -45,7 +45,7 @@ class GroupUser < ActiveRecord::Base
 
   def grant_other_available_title
     if group.title.present? && group.title == user.title
-      user.update(title: user.available_titles.first)
+      user.update!(title: user.next_best_title)
     end
   end
 
@@ -81,7 +81,6 @@ class GroupUser < ActiveRecord::Base
     user.update!(group_locked_trust_level: highest_level)
     Promotion.recalculate(user)
   end
-
 end
 
 # == Schema Information

--- a/app/models/group_user.rb
+++ b/app/models/group_user.rb
@@ -5,7 +5,7 @@ class GroupUser < ActiveRecord::Base
   belongs_to :user
 
   after_save :update_title
-  after_destroy :remove_title
+  after_destroy :grant_other_available_title
 
   after_save :set_primary_group
   after_destroy :remove_primary_group, :recalculate_trust_level
@@ -43,13 +43,9 @@ class GroupUser < ActiveRecord::Base
     )
   end
 
-  def remove_title
-    if group.title.present?
-      DB.exec("
-        UPDATE users SET title = NULL
-        WHERE title = :title AND id = :id",
-        id: user_id, title: group.title
-      )
+  def grant_other_available_title
+    if group.title.present? && group.title == user.title
+      user.update(title: user.available_titles.first)
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -109,6 +109,7 @@ class User < ActiveRecord::Base
   before_save :update_username_lower
   before_save :ensure_password_is_hashed
   before_save :match_title_to_primary_group_changes
+  before_save :check_if_title_is_badged_granted
 
   after_save :expire_tokens_if_password_changed
   after_save :clear_global_notice_if_needed
@@ -999,13 +1000,6 @@ class User < ActiveRecord::Base
     @user_fields
   end
 
-  def title=(val)
-    write_attribute(:title, val)
-    if !new_record? && user_profile
-      user_profile.update_column(:badge_granted_title, false)
-    end
-  end
-
   def number_of_deleted_posts
     Post.with_deleted
       .where(user_id: self.id)
@@ -1120,6 +1114,18 @@ class User < ActiveRecord::Base
 
   def mature_staged?
     from_staged? && self.created_at && self.created_at < 1.day.ago
+  end
+
+  def available_titles
+    group_titles_query = groups
+    group_titles_query = group_titles_query.order("groups.id = #{primary_group_id} DESC") if primary_group_id
+    group_titles_query = group_titles_query.order("groups.primary_group DESC")
+
+    group_titles = group_titles_query.pluck(:title).reject(&:blank?)
+    badge_titles = badges.where(allow_title: true).pluck(:name)
+      .map { |name| Badge.display_name(name) }
+
+    group_titles + badge_titles
   end
 
   protected
@@ -1283,6 +1289,13 @@ class User < ActiveRecord::Base
   end
 
   private
+
+  def check_if_title_is_badged_granted
+    if title_changed? && !new_record? && user_profile
+      badge_granted_title = title.present? && badges.where(allow_title: true, name: title).exists?
+      user_profile.update_column(:badge_granted_title, badge_granted_title)
+    end
+  end
 
   def previous_visit_at_update_required?(timestamp)
     seen_before? && (last_seen_at < (timestamp - SiteSetting.previous_visit_timeout_hours.hours))

--- a/app/services/user_updater.rb
+++ b/app/services/user_updater.rb
@@ -66,9 +66,6 @@ class UserUpdater
       attributes[:title] != user.title &&
       guardian.can_grant_title?(user, attributes[:title])
       user.title = attributes[:title]
-      if user.badges.where(name: user.title).exists?
-        user_profile.badge_granted_title = true
-      end
     end
 
     CATEGORY_IDS.each do |attribute, level|

--- a/spec/models/badge_spec.rb
+++ b/spec/models/badge_spec.rb
@@ -80,4 +80,21 @@ describe Badge do
       it { is_expected.to be true }
     end
   end
+
+  describe '.i18n_name' do
+    it 'transforms to lower case letters, and replaces spaces with underscores' do
+      expect(Badge.i18n_name('Basic User')).to eq('basic_user')
+    end
+  end
+
+  describe '.display_name' do
+    it 'fetches from translations when i18n_name key exists' do
+      expect(Badge.display_name('basic_user')).to eq('Basic')
+      expect(Badge.display_name('Basic User')).to eq('Basic')
+    end
+
+    it 'fallbacks to argument value when translation does not exist' do
+      expect(Badge.display_name('Not In Translations')).to eq('Not In Translations')
+    end
+  end
 end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -677,7 +677,7 @@ describe Group do
 
     context 'when stripping title' do
       it "only strips user's title if exact match" do
-        group.update(title: 'Awesome')
+        group.update!(title: 'Awesome')
         expect { group.remove(user) }.to change { user.reload.title }.from('Awesome').to(nil)
 
         group.add(user)
@@ -686,7 +686,7 @@ describe Group do
       end
 
       it "grants another title when the user has other available titles" do
-        group.update(title: 'Awesome')
+        group.update!(title: 'Awesome')
         Fabricate(:group, title: 'Super').add(user)
 
         expect { group.remove(user) }.to change { user.reload.title }.from('Awesome').to('Super')

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -675,13 +675,22 @@ describe Group do
   describe '#remove' do
     before { group.add(user) }
 
-    it "only strips user's title if exact match" do
-      group.update(title: 'Awesome')
-      expect { group.remove(user) }.to change { user.reload.title }.from('Awesome').to(nil)
+    context 'when stripping title' do
+      it "only strips user's title if exact match" do
+        group.update(title: 'Awesome')
+        expect { group.remove(user) }.to change { user.reload.title }.from('Awesome').to(nil)
 
-      group.add(user)
-      user.update_columns(title: 'Different')
-      expect { group.remove(user) }.to_not change { user.reload.title }
+        group.add(user)
+        user.update_columns(title: 'Different')
+        expect { group.remove(user) }.to_not change { user.reload.title }
+      end
+
+      it "grants another title when the user has other available titles" do
+        group.update(title: 'Awesome')
+        Fabricate(:group, title: 'Super').add(user)
+
+        expect { group.remove(user) }.to change { user.reload.title }.from('Awesome').to('Super')
+      end
     end
 
     it "unsets the user's primary group" do


### PR DESCRIPTION
> DISCUSSION: https://meta.discourse.org/t/user-in-multiple-groups-title-display-and-group-link-dont-match/96502/17?u=xrav3nz

When revoking an old title (due to leaving the group that grants the said title), this feature will grant one of the other available titles automatically.

We will pick the first available title in the following order:

1. user's current primary group title
2. title from a user's group that automatically set primary group
3. user's other group titles
4. user's badge titles