### PR TITLE
FEATURE: Display trust level descriptions in site settings

### DIFF
--- a/app/models/trust_level_setting.rb
+++ b/app/models/trust_level_setting.rb
@@ -8,7 +8,8 @@ class TrustLevelSetting < EnumSiteSetting
   end
 
   def self.values
-    @values ||= valid_values.map { |x| { name: x.to_s, value: x } }
+    levels = TrustLevel.all
+    @values ||= valid_values.map { |x| { name: "#{x}: #{levels[x.to_i].name}", value: x } }
   end
 
   def self.valid_values


### PR DESCRIPTION
Adds the translated name of the trust level alongside the number

## Before:
<img width="628" alt="screen shot 2018-09-21 at 12 33 08" src="https://user-images.githubusercontent.com/6270921/45878867-85129180-bd9a-11e8-9804-9af803ae7aa4.png">

## After:
<img width="671" alt="screen shot 2018-09-21 at 12 21 07" src="https://user-images.githubusercontent.com/6270921/45878844-71672b00-bd9a-11e8-94e1-daa9d4661ef5.png">
