### PR TITLE
PERF: Quit out of the email job quickly if disabled

### DIFF
--- a/app/jobs/regular/critical_user_email.rb
+++ b/app/jobs/regular/critical_user_email.rb
@@ -6,6 +6,10 @@ module Jobs
 
     sidekiq_options queue: 'critical'
 
+    def quit_email_early?
+      false
+    end
+
     def execute(args)
       super(args)
     end

--- a/spec/jobs/user_email_spec.rb
+++ b/spec/jobs/user_email_spec.rb
@@ -58,6 +58,26 @@ describe Jobs::UserEmail do
     end
   end
 
+  context "disable_emails setting" do
+    it "sends when no" do
+      SiteSetting.disable_emails = 'no'
+      Email::Sender.any_instance.expects(:send).once
+      Jobs::UserEmail.new.execute(type: :confirm_new_email, user_id: user.id)
+    end
+
+    it "does not send an email when yes" do
+      SiteSetting.disable_emails = 'yes'
+      Email::Sender.any_instance.expects(:send).never
+      Jobs::UserEmail.new.execute(type: :confirm_new_email, user_id: user.id)
+    end
+
+    it "sends when critical" do
+      SiteSetting.disable_emails = 'yes'
+      Email::Sender.any_instance.expects(:send)
+      Jobs::CriticalUserEmail.new.execute(type: :confirm_new_email, user_id: user.id)
+    end
+  end
+
   context "recently seen" do
     let(:post) { Fabricate(:post, user: user) }
 


### PR DESCRIPTION
This prevents sidekiq from doing a bunch of queries when email is
disabled.

Critical emails are a special case and will be sent.