### PR TITLE
FIX: make theme import's public key field `readonly`

### DIFF
--- a/app/assets/javascripts/admin/templates/modal/admin-import-theme.hbs
+++ b/app/assets/javascripts/admin/templates/modal/admin-import-theme.hbs
@@ -26,7 +26,7 @@
           {{#if publicKey}}
           <div class='public-key'>
             {{i18n 'admin.customize.theme.public_key'}}
-            {{textarea disabled=true value=publicKey}}
+            {{textarea readonly=true value=publicKey}}
           </div>
           {{/if}}
           {{/if}}


### PR DESCRIPTION
> CONTEXT & DISCUSSION: https://meta.discourse.org/t/unable-to-copy-public-key-when-installing-theme-from-private-repository-using-firefox/97849?u=xrav3nz

`disabled` attribute prevents the user from clicking or selecting in the control, whereas `readonly` does not.