### PR TITLE
FIX: progress bar position when theme has header

### DIFF
--- a/app/assets/javascripts/discourse/components/topic-progress.js.es6
+++ b/app/assets/javascripts/discourse/components/topic-progress.js.es6
@@ -162,7 +162,7 @@ export default Ember.Component.extend({
     const windowHeight = $(window).height();
     const composerHeight = $("#reply-control").height() || 0;
     const isDocked = offset >= maximumOffset - windowHeight + composerHeight;
-    const bottom = $("#main").height() - maximumOffset;
+    const bottom = $("body").height() - maximumOffset;
 
     if (composerHeight > 0) {
       $wrapper.css("bottom", isDocked ? bottom : composerHeight);


### PR DESCRIPTION
When there is content in the theme's header, the position of the topic progress bar on screens below 975px wide is off by the header's height. 

This happens because when calculating the docked topic progress bar's position, we use `#topic-bottom`'s top offset (which relates to the document), and `#main`'s height (which matches document height only if there are no elements between it and the body). We should use the `body` height instead. 

See this meta topic for a longer discussion with screenshots: https://meta.discourse.org/t/adding-header-in-theme-messes-up-topic-progress-bar-when-docked/97393/6 
