### PR TITLE
UX: confirmation before changing group membership in admin

### DIFF
--- a/app/assets/javascripts/admin/templates/user-index.hbs
+++ b/app/assets/javascripts/admin/templates/user-index.hbs
@@ -459,19 +459,29 @@
       <div class='display-row'>
         <div class='field'>{{i18n 'admin.groups.custom'}}</div>
         <div class='value'>
-          {{admin-group-selector selected=model.customGroups available=availableGroups}}
+          {{admin-group-selector selected=model.customGroups available=availableGroups buffer=customGroupIdsBuffer}}
         </div>
-        <div class='controls'>
-          {{#if model.customGroups}}
-            {{i18n 'admin.groups.primary'}}
-            {{combo-box content=model.customGroups value=model.primary_group_id none="admin.groups.no_primary"}}
-          {{/if}}
-          {{#if primaryGroupDirty}}
-            {{d-button icon="check" class="ok" action="savePrimaryGroup"}}
-            {{d-button icon="times" class="cancel" action="resetPrimaryGroup"}}
-          {{/if}}
-        </div>
+        {{#if customGroupsDirty}}
+          <div class='controls'>
+            {{d-button icon="check" class="ok" action="saveCustomGroups"}}
+            {{d-button icon="times" class="cancel" action="resetCustomGroups"}}
+          </div>
+        {{/if}}
       </div>
+      {{#if model.customGroups}}
+        <div class='display-row'>
+          <div class='field'>{{i18n 'admin.groups.primary'}}</div>
+          <div class='value'>
+            {{combo-box content=model.customGroups value=model.primary_group_id none="admin.groups.no_primary"}}
+          </div>
+          {{#if primaryGroupDirty}}
+            <div class='controls'>
+              {{d-button icon="check" class="ok" action="savePrimaryGroup"}}
+              {{d-button icon="times" class="cancel" action="resetPrimaryGroup"}}
+            </div>
+          {{/if}}
+        </div>
+      {{/if}}
   </section>
 {{/if}}
 

--- a/app/assets/javascripts/select-kit/components/admin-group-selector.js.es6
+++ b/app/assets/javascripts/select-kit/components/admin-group-selector.js.es6
@@ -1,4 +1,5 @@
 import MultiSelectComponent from "select-kit/components/multi-select";
+import computed from "ember-addons/ember-computed-decorators";
 const { makeArray } = Ember;
 
 export default MultiSelectComponent.extend({
@@ -7,11 +8,13 @@ export default MultiSelectComponent.extend({
   selected: null,
   available: null,
   allowAny: false,
+  buffer: null,
 
-  computeValues() {
-    return makeArray(this.get("selected")).map(s =>
-      this.valueForContentItem(s)
-    );
+  @computed("buffer")
+  values(buffer) {
+    return buffer === null
+      ? makeArray(this.get("selected")).map(s => this.valueForContentItem(s))
+      : buffer;
   },
 
   computeContent() {
@@ -25,33 +28,6 @@ export default MultiSelectComponent.extend({
   },
 
   mutateValues(values) {
-    if (values.length > this.get("selected").length) {
-      const newValues = values.filter(
-        v =>
-          !this.get("selected")
-            .map(s => this.valueForContentItem(s))
-            .includes(v)
-      );
-
-      newValues.forEach(value => {
-        const actionContext = this.get("available").findBy(
-          this.get("valueAttribute"),
-          parseInt(value, 10)
-        );
-
-        this.triggerAction({ action: "groupAdded", actionContext });
-      });
-    } else if (values.length < this.get("selected").length) {
-      const selected = this.get("selected").filter(
-        s => !values.includes(this.valueForContentItem(s))
-      );
-
-      selected.forEach(s => {
-        this.triggerAction({
-          action: "groupRemoved",
-          actionContext: this.valueForContentItem(s)
-        });
-      });
-    }
+    this.set("buffer", values);
   }
 });


### PR DESCRIPTION
[Video demo](https://www.youtube.com/watch?v=a9v-7SZE1ok) of the change.

---

<img src="https://user-images.githubusercontent.com/6376558/46082624-15553a00-c1d2-11e8-93ac-8228501a7d76.png" width="400px"/>

Currently, group memberships are granted/revoked automatically when selecting/deselecting a custom group, this is inconsistent with the other fields where the  ✔️ ❌ buttons are available.