### PR TITLE
DEV: Have overcommit use local ESLint package

### DIFF
--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -19,5 +19,7 @@ PreCommit:
     command: ['bundle', 'exec', 'rubocop']
   EsLint:
     enabled: true
-    command: ['eslint', '--ext', '.es6', '-f', 'compact']
+    required_executable: './node_modules/.bin/eslint'
+    install_command: 'yarn install'
+    command: ['yarn', 'eslint', '--ext', '.es6', '-f', 'compact']
     include: '**/*.es6'


### PR DESCRIPTION
This replaces `eslint` with `yarn eslint` in overcommit, and brings it in line with our tests.