### PR TITLE
move large blobs out of `<head>`

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -55,9 +55,6 @@
     <%= render partial: "common/discourse_stylesheet" %>
     <%= render partial: "common/special_font_face" %>
 
-    <meta id="data-preloaded" data-preloaded="<%= preloaded_json %>">
-    <%= preload_script "preload-application-data" %>
-
     <%= yield :head %>
 
     <%= build_plugin_html 'server:before-head-close' %>
@@ -106,6 +103,9 @@
         <input type="submit" id="signin-button" value="<%= t 'log_in' %>">
       </form>
     <% end %>
+
+    <div class="hidden" id="data-preloaded" data-preloaded="<%= preloaded_json %>">
+    <%= preload_script "preload-application-data" %>
 
     <%= yield :data %>
 

--- a/spec/requests/categories_controller_spec.rb
+++ b/spec/requests/categories_controller_spec.rb
@@ -32,7 +32,7 @@ describe CategoriesController do
       SiteSetting.categories_topics.times { Fabricate(:topic) }
       get "/categories"
 
-      expect(response.body).to have_tag("meta#data-preloaded") do |element|
+      expect(response.body).to have_tag("div#data-preloaded") do |element|
         json = JSON.parse(element.current_scope.attribute('data-preloaded').value)
         expect(json['topic_list_latest']).to include(%{"more_topics_url":"/latest"})
       end

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -190,7 +190,7 @@ describe UsersController do
         )
 
         expect(response.status).to eq(200)
-        expect(response.body).to have_tag("meta#data-preloaded") do |element|
+        expect(response.body).to have_tag("div#data-preloaded") do |element|
           json = JSON.parse(element.current_scope.attribute('data-preloaded').value)
           expect(json['password_reset']).to include('{"is_developer":false,"admin":false,"second_factor_required":false,"backup_enabled":false}')
         end
@@ -258,7 +258,7 @@ describe UsersController do
 
           get "/u/password-reset/#{token}"
 
-          expect(response.body).to have_tag("meta#data-preloaded") do |element|
+          expect(response.body).to have_tag("div#data-preloaded") do |element|
             json = JSON.parse(element.current_scope.attribute('data-preloaded').value)
             expect(json['password_reset']).to include('{"is_developer":false,"admin":false,"second_factor_required":true,"backup_enabled":false}')
           end
@@ -2615,7 +2615,7 @@ describe UsersController do
 
         expect(response.status).to eq(200)
 
-        expect(response.body).to have_tag("meta#data-preloaded") do |element|
+        expect(response.body).to have_tag("div#data-preloaded") do |element|
           json = JSON.parse(element.current_scope.attribute('data-preloaded').value)
           expect(json['accountCreated']).to include(
             "{\"message\":\"#{I18n.t("login.activate_email", email: user.email).gsub!("</", "<\\/")}\",\"show_controls\":true,\"username\":\"#{user.username}\",\"email\":\"#{user.email}\"}"


### PR DESCRIPTION
Thanks @SamSaffron for bringing this up: the `data-preloaded` JSON unnecessarily bloats the `<head>` section, and increases the payload dramatically for reading open graph tags, so moving this and future large blobs of data out of `<head>`.

Sanity check that everything still works:

![image](https://user-images.githubusercontent.com/6376558/46089936-32920480-c1e2-11e8-8bb3-d770d4345027.png)
