### PR TITLE
FIX: hide Delete Category button while creating a new category

### DIFF
--- a/app/assets/javascripts/discourse/templates/modal/edit-category.hbs
+++ b/app/assets/javascripts/discourse/templates/modal/edit-category.hbs
@@ -27,7 +27,7 @@
                  action="deleteCategory"
                  icon="trash-o"
                  label="category.delete"}}
-    {{else}}
+    {{else if model.id}}
       <div class="disable_info_wrap">
         {{d-button disabled=deleteDisabled
                    class="disable-no-hover"


### PR DESCRIPTION
![screen shot 2018-09-28 at 6 09 42 pm](https://user-images.githubusercontent.com/19775888/46209020-35a80480-c34a-11e8-89d5-5728801a0b02.png)