### PR TITLE
FIX: don't send multiple requests when changing category notification

### DIFF
--- a/app/assets/javascripts/select-kit/components/category-notifications-button.js.es6
+++ b/app/assets/javascripts/select-kit/components/category-notifications-button.js.es6
@@ -11,5 +11,7 @@ export default NotificationOptionsComponent.extend({
 
   mutateValue(value) {
     this.get("category").setNotification(value);
-  }
+  },
+
+  deselect() {}
 });

--- a/app/models/category_user.rb
+++ b/app/models/category_user.rb
@@ -55,7 +55,11 @@ class CategoryUser < ActiveRecord::Base
       record.notification_level = level
       record.save!
     else
-      CategoryUser.create!(user: user, category_id: category_id, notification_level: level)
+      begin
+        CategoryUser.create!(user: user, category_id: category_id, notification_level: level)
+      rescue ActiveRecord::RecordNotUnique
+        # does not matter
+      end
     end
 
     auto_watch(user_id: user.id)


### PR DESCRIPTION
Fixes `ActiveRecord::RecordNotUnique (PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint "idx_category_users_u1"` in logs