### PR TITLE
Readme: Remove reference to old dev environment setup blog post

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,13 @@ Browse [lots more notable Discourse instances](https://www.discourse.org/custome
 
 ## Development
 
-1. If you're **brand new to Ruby and Rails**, please see [**Discourse as Your First Rails App**](http://blog.discourse.org/2013/04/discourse-as-your-first-rails-app/).
+To get your environment setup, follow the community setup guide for your operating system.
 
-2. If you're familiar with how Rails works and are comfortable setting up your own environment, use our [**Discourse Advanced Developer Guide**](docs/DEVELOPER-ADVANCED.md).
+1. If you're on macOS, try the [macOS development guide](https://meta.discourse.org/t/beginners-guide-to-install-discourse-on-macos-for-development/15772).
+1. If you're on Ubuntu, try the [Ubuntu development guide](https://meta.discourse.org/t/beginners-guide-to-install-discourse-on-ubuntu-for-development/14727).
+1. If you're on Windows, try the [Windows 10 development guide](https://meta.discourse.org/t/beginners-guide-to-install-discourse-on-windows-10-for-development/75149).
+
+If you're familiar with how Rails works and are comfortable setting up your own environment, you can also try out the [**Discourse Advanced Developer Guide**](docs/DEVELOPER-ADVANCED.md), which is aimed primarily at Ubuntu and macOS environments.
 
 Before you get started, ensure you have the following minimum versions: [Ruby 2.4+](http://www.ruby-lang.org/en/downloads/), [PostgreSQL 10+](http://www.postgresql.org/download/), [Redis 2.6+](http://redis.io/download). If you're having trouble, please see our [**TROUBLESHOOTING GUIDE**](docs/TROUBLESHOOTING.md) first!
 


### PR DESCRIPTION
The old "Discourse as your first rails app" blog post points people in
the direction of Vagrant, which is no longer maintained. That blog post
now points people in the direction of guides that have been wiki-fied on
Meta, which can also be replied to if there are questions. The existing
setup guides appear to be relevant still, but the community wikis are
probably better for new people to reference.

If you ask me, though, there's a great debate here about whether or not
setup documentation should live in this repo or on Meta -- but I don't
have the answer for that. It's more important to get the effectively
dead guide off the front page, since it's Hacktoberfest and I'm sure
people want to contribute, but need a clear starting point.