### PR TITLE
Add missing fields to Upload Fabricator

### DIFF
--- a/spec/fabricators/upload_fabricator.rb
+++ b/spec/fabricators/upload_fabricator.rb
@@ -5,6 +5,8 @@ Fabricator(:upload) do
   filesize 1234
   width 100
   height 200
+  thumbnail_width 30
+  thumbnail_height 60
 
   url do |attrs|
     sequence(:url) do |n|

--- a/spec/serializers/upload_serializer_spec.rb
+++ b/spec/serializers/upload_serializer_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe UploadSerializer do
+  let(:upload) { Fabricate(:upload) }
+  let(:subject) { UploadSerializer.new(upload, root: false) }
+
+  it 'should render without errors' do
+    json_data = JSON.load(subject.to_json)
+
+    expect(json_data['id']).to eql upload.id
+    expect(json_data['width']).to eql upload.width
+    expect(json_data['height']).to eql upload.height
+    expect(json_data['thumbnail_width']).to eql upload.thumbnail_width
+    expect(json_data['thumbnail_height']).to eql upload.thumbnail_height
+  end
+end


### PR DESCRIPTION
Now that https://github.com/discourse/discourse/commit/9ab1fb7dfc349293e433d4d3e78518d7d2ba1b06 saves the thumbnail_width and height the fabricator needs updating to prevent fix_dimensions attempting to fetch the image to populate the missing fields.

Test added for sanity, output prior to change to fabricator is below.

```
Failures:

  1) UploadSerializer should render without errors
     Failure/Error:
         def self.resize(width, height, opts = {})
           return if width.blank? || height.blank?

           max_width = (opts[:max_width] || SiteSetting.max_image_width).to_f
           max_height = (opts[:max_height] || SiteSetting.max_image_height).to_f

           w = width.to_f
           h = height.to_f

           return [w.floor, h.floor] if w <= max_width && h <= max_height

     ArgumentError:
       wrong number of arguments (given 0, expected 2..3)
```