### PR TITLE
UX: changes CSS class added to local dates

### DIFF
--- a/plugins/discourse-local-dates/assets/javascripts/discourse-local-dates.js
+++ b/plugins/discourse-local-dates/assets/javascripts/discourse-local-dates.js
@@ -77,7 +77,7 @@
         .html(html)
         .attr("title", joinedPreviews)
         .attr("data-tooltip", joinedPreviews)
-        .addClass("cooked")
+        .addClass("cooked-date")
         .find(".relative-time")
         .text(displayedTime);
 

--- a/plugins/discourse-local-dates/assets/stylesheets/common/discourse-local-dates.scss
+++ b/plugins/discourse-local-dates/assets/stylesheets/common/discourse-local-dates.scss
@@ -2,7 +2,7 @@
   display: inline-block;
   vertical-align: top;
 
-  &.cooked {
+  &.cooked-date {
     color: $primary;
     font-weight: bold;
     cursor: pointer;


### PR DESCRIPTION
Changing the class from `cooked` to `cooked-date` ensures that styles meant for the cooked content of a post don't apply to cooked dates. 