### PR TITLE
FIX: Do not allow revoking the token of current session.

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1109,10 +1109,9 @@ class UsersController < ApplicationController
     guardian.ensure_can_edit!(user)
 
     if params[:token_id]
-      cookie = guardian.request.cookies[Auth::DefaultCurrentUserProvider::TOKEN_COOKIE]
       token = UserAuthToken.find_by(id: params[:token_id], user_id: user.id)
       # The user should not be able to revoke the auth token of current session.
-      raise Discourse::NotFound if UserAuthToken.hash_token(cookie) == token.auth_token
+      raise Discourse::NotFound if guardian.auth_token == token.auth_token
       UserAuthToken.where(id: params[:token_id], user_id: user.id).each(&:destroy!)
     else
       UserAuthToken.where(user_id: user.id).each(&:destroy!)

--- a/app/serializers/user_auth_token_serializer.rb
+++ b/app/serializers/user_auth_token_serializer.rb
@@ -9,9 +9,7 @@ class UserAuthTokenSerializer < ApplicationSerializer
   end
 
   def is_active
-    cookie = scope.request.cookies[Auth::DefaultCurrentUserProvider::TOKEN_COOKIE]
-
-    UserAuthToken.hash_token(cookie) == object.auth_token
+    scope.auth_token == object.auth_token
   end
 
   def seen_at

--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -381,6 +381,13 @@ class Guardian
       (components - Theme.components_for(parent)).empty?
   end
 
+  def auth_token
+    return nil if !request&.cookies[Auth::DefaultCurrentUserProvider::TOKEN_COOKIE]
+
+    cookie = request.cookies[Auth::DefaultCurrentUserProvider::TOKEN_COOKIE]
+    UserAuthToken.hash_token(cookie)
+  end
+
   private
 
   def is_my_own?(obj)

--- a/spec/components/guardian_spec.rb
+++ b/spec/components/guardian_spec.rb
@@ -2963,4 +2963,14 @@ describe Guardian do
       end
     end
   end
+
+  describe '#auth_token' do
+    it 'returns the correct auth token' do
+      token = UserAuthToken.generate!(user_id: user.id)
+      env = Rack::MockRequest.env_for("/", "HTTP_COOKIE" => "_t=#{token.unhashed_auth_token};")
+
+      guardian = Guardian.new(user, Rack::Request.new(env))
+      expect(guardian.auth_token).to eq(token.auth_token)
+    end
+  end
 end

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -3246,9 +3246,6 @@ describe UsersController do
       end
 
       it 'logs user out' do
-        SiteSetting.log_out_strict = false
-        expect(user.user_auth_tokens.count).to eq(2)
-
         ids = user.user_auth_tokens.map { |token| token.id }
         post "/u/#{user.username}/preferences/revoke-auth-token.json", params: { token_id: ids[0] }
 
@@ -3259,20 +3256,17 @@ describe UsersController do
         expect(user.user_auth_tokens.first.id).to eq(ids[1])
       end
 
-      it 'logs user out from everywhere if log_out_strict is enabled' do
-        SiteSetting.log_out_strict = true
-        expect(user.user_auth_tokens.count).to eq(2)
+      it 'does not let user log out of current session' do
+        token = UserAuthToken.generate!(user_id: user.id)
+        env = Rack::MockRequest.env_for("/", "HTTP_COOKIE" => "_t=#{token.unhashed_auth_token};")
+        Guardian.any_instance.stubs(:request).returns(Rack::Request.new(env))
 
-        ids = user.user_auth_tokens.map { |token| token.id }
-        post "/u/#{user.username}/preferences/revoke-auth-token.json", params: { token_id: ids[0] }
+        post "/u/#{user.username}/preferences/revoke-auth-token.json", params: { token_id: token.id }
 
-        expect(response.status).to eq(200)
-        expect(user.user_auth_tokens.count).to eq(0)
+        expect(response.status).to eq(404)
       end
 
       it 'logs user out from everywhere if token_id is not present' do
-        expect(user.user_auth_tokens.count).to eq(2)
-
         post "/u/#{user.username}/preferences/revoke-auth-token.json"
 
         expect(response.status).to eq(200)


### PR DESCRIPTION
Right now, if `log_out_strict` is enabled trying to revoke any token will result in revoking all the tokens.

This PR changes two things:
* it does not allow the current session to be terminated by any means;
* it does not take into account if `log_out_strict` is enabled anymore (because of the previous point).