### PR TITLE
Exit with an error if there are errors with settings import

### DIFF
--- a/lib/tasks/site_settings.rake
+++ b/lib/tasks/site_settings.rake
@@ -29,4 +29,8 @@ task "site_settings:import" => :environment do
   puts " Updated:   #{counts[:updated]}"
   puts " Not Found: #{counts[:not_found]}"
   puts " Errors:    #{counts[:errors]}"
+
+  if counts[:not_found] + counts[:errors] > 0
+    exit 1
+  end
 end


### PR DESCRIPTION
If the site_settings import has any errors or settings that are not found, this
will cause the task to exit with a non-zero exit code.

This is useful when using this task as part of automated configuration deployment,
where you may not want to continue with the process if a setting fails to
import.

My specific use-case is that I'm using Puppet to bootstrap and deploy Discourse, and using  site_settings:import to populate some of the settings in the DB. I want my Puppet runs to fail if there's an issue with the settings; at the moment I have to use a hack where I check the output of the rake task for the error/not found counts.