### PR TITLE
FEATURE: automatically hide non-TL4 posts when flagged by a TL4 user

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -117,7 +117,8 @@ class Post < ActiveRecord::Base
                                  flag_threshold_reached_again: 2,
                                  new_user_spam_threshold_reached: 3,
                                  flagged_by_tl3_user: 4,
-                                 email_spam_header_found: 5)
+                                 email_spam_header_found: 5,
+                                 flagged_by_tl4_user: 6)
   end
 
   def self.types

--- a/app/models/post_action.rb
+++ b/app/models/post_action.rb
@@ -583,13 +583,19 @@ class PostAction < ActiveRecord::Base
 
       hide_post!(post, post_action_type, Post.hidden_reasons[:flagged_by_tl3_user])
 
-    elsif PostActionType.auto_action_flag_types.include?(post_action_type) &&
-          SiteSetting.flags_required_to_hide_post > 0
+    elsif PostActionType.auto_action_flag_types.include?(post_action_type)
 
-      _old_flags, new_flags = PostAction.flag_counts_for(post.id)
+      if acting_user.has_trust_level?(TrustLevel[4]) &&
+         post.user&.trust_level != TrustLevel[4]
 
-      if new_flags >= SiteSetting.flags_required_to_hide_post
-        hide_post!(post, post_action_type, guess_hide_reason(post))
+        hide_post!(post, post_action_type, Post.hidden_reasons[:flagged_by_tl4_user])
+      elsif SiteSetting.flags_required_to_hide_post > 0
+
+        _old_flags, new_flags = PostAction.flag_counts_for(post.id)
+
+        if new_flags >= SiteSetting.flags_required_to_hide_post
+          hide_post!(post, post_action_type, guess_hide_reason(post))
+        end
       end
     end
   end

--- a/plugins/discourse-narrative-bot/lib/discourse_narrative_bot/advanced_user_narrative.rb
+++ b/plugins/discourse-narrative-bot/lib/discourse_narrative_bot/advanced_user_narrative.rb
@@ -153,7 +153,7 @@ module DiscourseNarrativeBot
         flag = PostAction.create!(
           user: self.discobot_user,
           post: post, post_action_type_id:
-          PostActionType.types[:off_topic]
+          PostActionType.types[:notify_moderators]
         )
 
         PostAction.defer_flags!(post, self.discobot_user)


### PR DESCRIPTION
`advanced_user_narrative.rb` file change is required because discobot/TL4 user's `:off_topic` flag will auto hide the post.