### PR TITLE
FIX: force enable a user's email_private_messages option when user replies via email

### DIFF
--- a/lib/email/receiver.rb
+++ b/lib/email/receiver.rb
@@ -577,7 +577,6 @@ module Email
 
       case destination[:type]
       when :group
-        enable_email_pm_setting(user)
         group = destination[:obj]
         create_group_post(group, user, body, elided, hidden_reason_id)
 
@@ -601,8 +600,6 @@ module Email
         if post_reply_key.user_id != user.id && !forwarded_reply_key?(post_reply_key, user)
           raise ReplyUserNotMatchingError, "post_reply_key.user_id => #{post_reply_key.user_id.inspect}, user.id => #{user.id.inspect}"
         end
-
-        enable_email_pm_setting(user)
 
         post = Post.with_deleted.find(post_reply_key.post_id)
 
@@ -639,6 +636,8 @@ module Email
                      topic: post.topic,
                      skip_validations: true)
       else
+        enable_email_pm_setting(user)
+
         create_topic(user: user,
                      raw: body,
                      elided: elided,
@@ -845,6 +844,7 @@ module Email
     def create_reply(options = {})
       raise TopicNotFoundError if options[:topic].nil? || options[:topic].trashed?
       options[:post] = nil if options[:post]&.trashed?
+      enable_email_pm_setting(options[:user]) if options[:topic].archetype == Archetype.private_message
 
       if post_action_type = post_action_for(options[:raw])
         create_post_action(options[:user], options[:post], post_action_type)

--- a/lib/email/receiver.rb
+++ b/lib/email/receiver.rb
@@ -577,7 +577,7 @@ module Email
 
       case destination[:type]
       when :group
-        enable_email_PM_setting(user)
+        enable_email_pm_setting(user)
         group = destination[:obj]
         create_group_post(group, user, body, elided, hidden_reason_id)
 
@@ -602,7 +602,7 @@ module Email
           raise ReplyUserNotMatchingError, "post_reply_key.user_id => #{post_reply_key.user_id.inspect}, user.id => #{user.id.inspect}"
         end
 
-        enable_email_PM_setting(user)
+        enable_email_pm_setting(user)
 
         post = Post.with_deleted.find(post_reply_key.post_id)
 
@@ -1063,7 +1063,7 @@ module Email
       end
     end
 
-    def enable_email_PM_setting(user)
+    def enable_email_pm_setting(user)
       # ensure user PM emails are enabled (since user is posting via email)
       if !user.staged && !user.user_option.email_private_messages
         user.user_option.update!(email_private_messages: true)

--- a/lib/email/receiver.rb
+++ b/lib/email/receiver.rb
@@ -1068,7 +1068,6 @@ module Email
       if !user.staged && !user.user_option.email_private_messages
         user.user_option.update!(email_private_messages: true)
       end
-
     end
   end
 

--- a/spec/components/email/receiver_spec.rb
+++ b/spec/components/email/receiver_spec.rb
@@ -525,6 +525,14 @@ describe Email::Receiver do
 
       expect { process(:reply_user_not_matching_but_known) }.to change { topic.posts.count }
     end
+
+    it "re-enables user's email_private_messages setting when user replies" do
+      user.user_option.update_columns(email_private_messages: false)
+      expect { process(:reply_user_matching) }.to change { topic.posts.count }
+      user.reload
+      expect(user.user_option.email_private_messages).to eq(true)
+    end
+
   end
 
   context "new message to a group" do
@@ -623,7 +631,7 @@ describe Email::Receiver do
       expect(Post.last.raw).to match(/discourse\.rb/)
     end
 
-    it "enables user's email_private_messages option when user emails group" do
+    it "enables user's email_private_messages setting when user emails group" do
       user = Fabricate(:user, email: "existing@bar.com")
       user.user_option.update_columns(email_private_messages: false)
       expect { process(:group_existing_user) }.to change(Topic, :count)

--- a/spec/components/email/receiver_spec.rb
+++ b/spec/components/email/receiver_spec.rb
@@ -526,7 +526,11 @@ describe Email::Receiver do
       expect { process(:reply_user_not_matching_but_known) }.to change { topic.posts.count }
     end
 
-    it "re-enables user's email_private_messages setting when user replies" do
+    it "re-enables user's email_private_messages setting when user replies to a private topic" do
+      topic.update_columns(category_id: nil, archetype: Archetype.private_message)
+      topic.allowed_users << user
+      topic.save
+
       user.user_option.update_columns(email_private_messages: false)
       expect { process(:reply_user_matching) }.to change { topic.posts.count }
       user.reload
@@ -631,7 +635,7 @@ describe Email::Receiver do
       expect(Post.last.raw).to match(/discourse\.rb/)
     end
 
-    it "enables user's email_private_messages setting when user emails group" do
+    it "enables user's email_private_messages setting when user emails new topic to group" do
       user = Fabricate(:user, email: "existing@bar.com")
       user.user_option.update_columns(email_private_messages: false)
       expect { process(:group_existing_user) }.to change(Topic, :count)


### PR DESCRIPTION
Builds on: https://github.com/discourse/discourse/pull/6437