### PR TITLE
UX: Add link to Groups in admin dashboard.

### DIFF
--- a/app/assets/javascripts/admin/controllers/admin.js.es6
+++ b/app/assets/javascripts/admin/controllers/admin.js.es6
@@ -4,6 +4,11 @@ export default Ember.Controller.extend({
   application: Ember.inject.controller(),
 
   @computed
+  showGroups() {
+    return !this.siteSettings.enable_group_directory;
+  },
+
+  @computed
   showBadges() {
     return this.currentUser.get("admin") && this.siteSettings.enable_badges;
   },

--- a/app/assets/javascripts/admin/controllers/admin.js.es6
+++ b/app/assets/javascripts/admin/controllers/admin.js.es6
@@ -3,14 +3,14 @@ import computed from "ember-addons/ember-computed-decorators";
 export default Ember.Controller.extend({
   application: Ember.inject.controller(),
 
-  @computed
-  showGroups() {
-    return !this.siteSettings.enable_group_directory;
+  @computed("siteSettings.enable_group_directory")
+  showGroups(enableGroupDirectory) {
+    return !enableGroupDirectory;
   },
 
-  @computed
-  showBadges() {
-    return this.currentUser.get("admin") && this.siteSettings.enable_badges;
+  @computed("siteSettings.enable_badges")
+  showBadges(enableBadges) {
+    return this.currentUser.get("admin") && enableBadges;
   },
 
   @computed("application.currentPath")

--- a/app/assets/javascripts/admin/templates/admin.hbs
+++ b/app/assets/javascripts/admin/templates/admin.hbs
@@ -10,6 +10,9 @@
           {{nav-item route='adminSiteSettings' label='admin.site_settings.title'}}
         {{/if}}
         {{nav-item route='adminUsersList' label='admin.users.title'}}
+        {{#if showGroups}}
+          {{nav-item route='groups' label='admin.groups.title'}}
+        {{/if}}
         {{#if showBadges}}
           {{nav-item route='adminBadges' label='admin.badges.title'}}
         {{/if}}


### PR DESCRIPTION
The placement of the "Groups" link under "Users" is sometimes confusing.