### PR TITLE
FEATURE: Upload tags from CSV

### DIFF
--- a/app/assets/javascripts/admin/components/tags-uploader.js.es6
+++ b/app/assets/javascripts/admin/components/tags-uploader.js.es6
@@ -1,0 +1,19 @@
+import UploadMixin from "discourse/mixins/upload";
+
+export default Em.Component.extend(UploadMixin, {
+  type: "csv",
+  uploadUrl: "/tags/upload",
+  addDisabled: Em.computed.alias("uploading"),
+  elementId: "tag-uploader",
+
+  validateUploadedFilesOptions() {
+    return { csvOnly: true };
+  },
+
+  uploadDone() {
+    bootbox.alert(I18n.t("tagging.upload_successful"), () => {
+      this.sendAction("refresh");
+      this.sendAction("closeModal");
+    });
+  }
+});

--- a/app/assets/javascripts/admin/templates/components/tags-uploader.hbs
+++ b/app/assets/javascripts/admin/templates/components/tags-uploader.hbs
@@ -1,0 +1,6 @@
+  <label class="btn {{if addDisabled 'disabled'}}">
+    {{d-icon "upload"}}
+    {{i18n 'admin.watched_words.form.upload'}}
+    <input disabled={{addDisabled}} type="file" accept="text/plain,text/csv" style="visibility: hidden; position: absolute;" />
+  </label>
+  <span class="instructions">{{i18n 'tagging.upload_instructions'}}</span>

--- a/app/assets/javascripts/discourse/components/tags-admin-dropdown.js.es6
+++ b/app/assets/javascripts/discourse/components/tags-admin-dropdown.js.es6
@@ -16,6 +16,12 @@ export default DropdownSelectBoxComponent.extend({
         name: I18n.t("tagging.manage_groups"),
         description: I18n.t("tagging.manage_groups_description"),
         icon: "wrench"
+      },
+      {
+        id: "uploadTags",
+        name: I18n.t("tagging.upload"),
+        description: I18n.t("tagging.upload_description"),
+        icon: "upload"
       }
     ];
 
@@ -23,7 +29,8 @@ export default DropdownSelectBoxComponent.extend({
   },
 
   actionNames: {
-    manageGroups: "showTagGroups"
+    manageGroups: "showTagGroups",
+    uploadTags: "showUploader"
   },
 
   mutateValue(id) {

--- a/app/assets/javascripts/discourse/controllers/tags-index.js.es6
+++ b/app/assets/javascripts/discourse/controllers/tags-index.js.es6
@@ -1,4 +1,5 @@
 import computed from "ember-addons/ember-computed-decorators";
+import showModal from "discourse/lib/show-modal";
 
 export default Ember.Controller.extend({
   sortProperties: ["totalCount:desc", "id"],
@@ -33,6 +34,10 @@ export default Ember.Controller.extend({
         sortedByCount: false,
         sortedByName: true
       });
+    },
+
+    showUploader() {
+      showModal("tag-upload");
     }
   }
 });

--- a/app/assets/javascripts/discourse/routes/tags-index.js.es6
+++ b/app/assets/javascripts/discourse/routes/tags-index.js.es6
@@ -41,6 +41,10 @@ export default Discourse.Route.extend({
     showTagGroups() {
       this.transitionTo("tagGroups");
       return true;
+    },
+
+    refresh() {
+      this.refresh();
     }
   }
 });

--- a/app/assets/javascripts/discourse/templates/modal/tag-upload.hbs
+++ b/app/assets/javascripts/discourse/templates/modal/tag-upload.hbs
@@ -1,0 +1,3 @@
+{{#d-modal-body title='tagging.upload'}}
+    {{tags-uploader closeModal=(action "closeModal") refresh=(route-action "refresh")}}
+{{/d-modal-body}}

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -117,6 +117,35 @@ class TagsController < ::ApplicationController
     end
   end
 
+  def upload
+    guardian.ensure_can_admin_tags!
+
+    file = params[:file] || params[:files].first
+
+    hijack do
+      begin
+        Tag.transaction do
+          CSV.foreach(file.tempfile) do |row|
+            raise Discourse::InvalidParameters.new(I18n.t("tags.upload_row_too_long")) if row.length > 2
+
+            tag_name = DiscourseTagging.clean_tag(row[0])
+            tag_group_name = row[1] || nil
+
+            tag = Tag.find_by_name(tag_name) || Tag.create!(name: tag_name)
+
+            if tag_group_name
+              tag_group = TagGroup.find_by(name: tag_group_name) || TagGroup.create!(name: tag_group_name)
+              tag.tag_groups << tag_group unless tag.tag_groups.include?(tag_group)
+            end
+          end
+        end
+        render json: success_json
+      rescue Discourse::InvalidParameters => e
+        render json: failed_json.merge(errors: [e.message]), status: 422
+      end
+    end
+  end
+
   def destroy
     guardian.ensure_can_admin_tags!
     tag_name = params[:tag_id]

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2697,7 +2697,10 @@ en:
       sort_by_name: "name"
       manage_groups: "Manage Tag Groups"
       manage_groups_description: "Define groups to organize tags"
-
+      upload: "Upload Tags"
+      upload_description: "Upload a text file to create tags in bulk"
+      upload_instructions: "One per line, optionally with a tag group in the format 'tag_name,tag_group'."
+      upload_successful: "Tags uploaded successfully"
       filters:
         without_category: "%{filter} %{tag} topics"
         with_category: "%{filter} %{tag} topics in %{category}"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -3892,6 +3892,7 @@ en:
     staff_tag_disallowed: "The tag \"%{tag}\" may only be applied by staff."
     staff_tag_remove_disallowed: "The tag \"%{tag}\" may only be removed by staff."
     minimum_required_tags: "You must select at least %{count} tags."
+    upload_row_too_long: "The CSV file should have one tag per line. Optionally the tag can be followed by a comma, then the tag group name."
   rss_by_tag: "Topics tagged %{tag}"
 
   finish_installation:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -773,6 +773,7 @@ Discourse::Application.routes.draw do
     get '/filter/search' => 'tags#search'
     get '/check' => 'tags#check_hashtag'
     get '/personal_messages/:username' => 'tags#personal_messages'
+    post '/upload' => 'tags#upload'
     constraints(tag_id: /[^\/]+?/, format: /json|rss/) do
       get '/:tag_id.rss' => 'tags#tag_feed'
       get '/:tag_id' => 'tags#show', as: 'tag_show'

--- a/spec/fixtures/csv/tags.csv
+++ b/spec/fixtures/csv/tags.csv
@@ -1,0 +1,6 @@
+tag1
+Capitaltag2
+spaced tag
+tag1
+tag3,taggroup1
+tag4,taggroup1

--- a/spec/fixtures/csv/tags_invalid.csv
+++ b/spec/fixtures/csv/tags_invalid.csv
@@ -1,0 +1,5 @@
+tag1
+tag2
+tag3,taggroup1
+tag4,taggroup2
+tag5,with,too,many,columns


### PR DESCRIPTION
Adds an option to the `/tags` menu:

<img width="376" alt="screenshot 2018-10-11 at 15 18 16" src="https://user-images.githubusercontent.com/6270921/46810627-fb3a6080-cd68-11e8-88e0-2c34c0c0e603.png">

Supports one tag per line, and can optionally add the tag to a tag group. Import is 'hijacked' to prevent performance issues, and runs in a transaction. Restricted access in the same way as `/tag_groups` (admins & moderators).