### PR TITLE
DEV: Remove inline styles from upload buttons

### DIFF
--- a/app/assets/javascripts/admin/templates/components/watched-word-uploader.hbs
+++ b/app/assets/javascripts/admin/templates/components/watched-word-uploader.hbs
@@ -1,7 +1,7 @@
 <label class="btn {{if addDisabled 'disabled'}}">
   {{d-icon "upload"}}
   {{i18n 'admin.watched_words.form.upload'}}
-  <input disabled={{addDisabled}} type="file" accept="text/plain,text/csv" style="visibility: hidden; position: absolute;" />
+  <input disabled={{addDisabled}} type="file" accept="text/plain,text/csv"/>
 </label>
 <br/>
 <span class="instructions">One word per line</span>

--- a/app/assets/javascripts/discourse/templates/components/avatar-uploader.hbs
+++ b/app/assets/javascripts/discourse/templates/components/avatar-uploader.hbs
@@ -1,6 +1,6 @@
 <label class="btn" disabled={{uploading}} title="{{i18n 'user.change_avatar.upload_title'}}">
   {{d-icon "picture-o"}}&nbsp;{{uploadButtonText}}
-  <input disabled={{uploading}} type="file" accept="image/*" style="visibility: hidden; position: absolute;" />
+  <input disabled={{uploading}} type="file" accept="image/*" />
 </label>
 {{#if uploading}}
   <span>{{i18n 'upload_selector.uploading'}} {{uploadProgress}}%</span>

--- a/app/assets/javascripts/discourse/templates/components/csv-uploader.hbs
+++ b/app/assets/javascripts/discourse/templates/components/csv-uploader.hbs
@@ -1,6 +1,6 @@
 <label class="btn" disabled={{uploadButtonDisabled}}>
   {{d-icon "upload"}}&nbsp;{{uploadButtonText}}
-  <input disabled={{uploading}} type="file" accept=".csv" style="visibility: hidden; position: absolute;" />
+  <input disabled={{uploading}} type="file" accept=".csv"/>
 </label>
 {{#if uploading}}
   <span>{{i18n 'upload_selector.uploading'}} {{uploadProgress}}%</span>

--- a/app/assets/javascripts/discourse/templates/components/emoji-uploader.hbs
+++ b/app/assets/javascripts/discourse/templates/components/emoji-uploader.hbs
@@ -2,5 +2,5 @@
 <label class="btn btn-primary {{if addDisabled 'disabled'}}">
   {{d-icon "plus"}}
   {{i18n 'admin.emoji.add'}}
-  <input disabled={{addDisabled}} type="file" accept=".png,.gif" style="visibility: hidden; position: absolute;" />
+  <input disabled={{addDisabled}} type="file" accept=".png,.gif" />
 </label>

--- a/app/assets/javascripts/discourse/templates/components/image-uploader.hbs
+++ b/app/assets/javascripts/discourse/templates/components/image-uploader.hbs
@@ -2,7 +2,7 @@
   <div class="image-upload-controls">
     <label class="btn pad-left no-text {{if uploading 'disabled'}}">
       {{d-icon "picture-o"}}
-      <input disabled={{uploading}} type="file" accept="image/*" style="visibility: hidden; position: absolute;" />
+      <input disabled={{uploading}} type="file" accept="image/*" />
     </label>
     {{#if backgroundStyle}}
       <button {{action "trash"}} class="btn btn-danger pad-left no-text">{{d-icon "trash-o"}}</button>

--- a/app/assets/javascripts/discourse/templates/components/images-uploader.hbs
+++ b/app/assets/javascripts/discourse/templates/components/images-uploader.hbs
@@ -1,6 +1,6 @@
 <label class="btn" disabled={{uploading}} title="{{i18n "admin.site_settings.uploaded_image_list.upload.title"}}">
   {{d-icon "picture-o"}}&nbsp;{{uploadButtonText}}
-  <input disabled={{uploading}} type="file" accept="image/*" multiple style="visibility: hidden; position: absolute;" />
+  <input disabled={{uploading}} type="file" accept="image/*" multiple />
 </label>
 {{#if uploading}}
   <span>{{i18n 'upload_selector.uploading'}} {{uploadProgress}}%</span>

--- a/app/assets/javascripts/wizard/templates/components/wizard-field-image.hbs
+++ b/app/assets/javascripts/wizard/templates/components/wizard-field-image.hbs
@@ -10,5 +10,5 @@
     {{d-icon "picture-o"}}
   {{/if}}
 
-  <input disabled={{uploading}} type="file" accept="image/*" style="visibility: hidden; position: absolute;" />
+  <input disabled={{uploading}} type="file" accept="image/*"/>
 </label>

--- a/app/assets/stylesheets/common/components/buttons.scss
+++ b/app/assets/stylesheets/common/components/buttons.scss
@@ -203,6 +203,14 @@
   }
 }
 
+// File upload buttons
+// --------------------------------------------------
+
+.btn input[type="file"] {
+  visibility: hidden;
+  position: absolute;
+}
+
 // Button Sizes
 // --------------------------------------------------
 

--- a/app/assets/stylesheets/wizard.scss
+++ b/app/assets/stylesheets/wizard.scss
@@ -326,6 +326,11 @@ body.wizard {
     .fa {
       margin-left: 0.5em;
     }
+
+    input[type="file"] {
+      visibility: hidden;
+      position: absolute;
+    }
   }
 
   .wizard-step-footer {


### PR DESCRIPTION
@tgxworld [pointed out](https://github.com/discourse/discourse/pull/6484#discussion_r224695970) that we use inline styles for file inputs, and that it would be better to move into CSS files. @awesomerobot would you mind having a look at this to check it doesn't interfere with your button-cleanup work?