### PR TITLE
FIX: keep emoji syntax for custom emojis in quotes

### DIFF
--- a/app/assets/javascripts/discourse/lib/to-markdown.js.es6
+++ b/app/assets/javascripts/discourse/lib/to-markdown.js.es6
@@ -227,7 +227,7 @@ export class Tag {
         const src = attr.src || pAttr.src;
         const cssClass = attr.class || pAttr.class;
 
-        if (cssClass === "emoji") {
+        if (cssClass && cssClass.includes("emoji")) {
           return attr.title || pAttr.title;
         }
 

--- a/test/javascripts/lib/to-markdown-test.js.es6
+++ b/test/javascripts/lib/to-markdown-test.js.es6
@@ -340,3 +340,15 @@ QUnit.test("keeps emoji and removes click count", assert => {
 
   assert.equal(toMarkdown(html), markdown);
 });
+
+QUnit.test("keeps emoji syntax for custom emoji", assert => {
+  const html = `
+    <p>
+      <img class="emoji emoji-custom" title=":custom_emoji:" src="https://d11a6trkgmumsb.cloudfront.net/images/emoji/custom_emoji" alt=":custom_emoji:" />
+    </p>
+  `;
+
+  const markdown = `:custom_emoji:`;
+
+  assert.equal(toMarkdown(html), markdown);
+});


### PR DESCRIPTION
fixes https://meta.discourse.org/t/custom-emoji-are-shown-in-wrong-size-when-quoted/98572