### PR TITLE
Typo in Thai language admin page

### DIFF
--- a/config/locales/client.th.yml
+++ b/config/locales/client.th.yml
@@ -496,7 +496,7 @@ th:
         failed_to_move: "เกิดความผิดพลาดในการย้ายหัวข้อที่เลือก (อาจเกิดจาดเครือข่ายของคุณล่ม)"
         select_all: "เลือกทั้งหมด"
       preferences_nav:
-        profile: "ข้อมูลผู้ใช้<br><div><br data-mce-bogus=\"1\"></div>"
+        profile: "ข้อมูลผู้ใช้"
         emails: "อีเมล"
         tags: "ป้าย"
       change_password:


### PR DESCRIPTION
Typo in Thai language admin page

![image](https://user-images.githubusercontent.com/2979072/46942324-47521180-d097-11e8-981a-6a5277fb40d7.png)

