### PR TITLE
rename route `/javascripts` to `/theme-javascripts`

### DIFF
--- a/app/controllers/theme_javascripts_controller.rb
+++ b/app/controllers/theme_javascripts_controller.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class JavascriptsController < ApplicationController
+class ThemeJavascriptsController < ApplicationController
   DISK_CACHE_PATH = "#{Rails.root}/tmp/javascript-cache"
 
   skip_before_action(

--- a/app/models/javascript_cache.rb
+++ b/app/models/javascript_cache.rb
@@ -7,7 +7,7 @@ class JavascriptCache < ActiveRecord::Base
   before_save :update_digest
 
   def url
-    "#{GlobalSetting.cdn_url}#{GlobalSetting.relative_url_root}/javascripts/#{digest}.js"
+    "#{GlobalSetting.cdn_url}#{GlobalSetting.relative_url_root}/theme-javascripts/#{digest}.js"
   end
 
   private

--- a/config/nginx.sample.conf
+++ b/config/nginx.sample.conf
@@ -191,7 +191,7 @@ server {
     # This big block is needed so we can selectively enable
     # acceleration for backups and avatars
     # see note about repetition above
-    location ~ ^/(letter_avatar/|user_avatar|highlight-js|stylesheets|favicon/proxied|service-worker) {
+    location ~ ^/(letter_avatar/|user_avatar|highlight-js|stylesheets|theme-javascripts|favicon/proxied|service-worker) {
       proxy_set_header Host $http_host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Request-Start "t=${msec}";

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -450,7 +450,7 @@ Discourse::Application.routes.draw do
 
   get "stylesheets/:name.css.map" => "stylesheets#show_source_map", constraints: { name: /[-a-z0-9_]+/ }
   get "stylesheets/:name.css" => "stylesheets#show", constraints: { name: /[-a-z0-9_]+/ }
-  get "javascripts/:digest.js" => "javascripts#show", constraints: { digest: /\h{40}/ }
+  get "theme-javascripts/:digest.js" => "theme_javascripts#show", constraints: { digest: /\h{40}/ }
 
   post "uploads" => "uploads#create"
   post "uploads/lookup-urls" => "uploads#lookup_urls"

--- a/spec/requests/theme_javascripts_controller_spec.rb
+++ b/spec/requests/theme_javascripts_controller_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-describe JavascriptsController do
+describe ThemeJavascriptsController do
   let(:theme) { Fabricate(:theme) }
   let(:theme_field) { ThemeField.create!(theme: theme, target_id: 0, name: "header", value: "<a>html</a>") }
   let(:javascript_cache) { JavascriptCache.create!(content: 'console.log("hello");', theme_field: theme_field) }
@@ -11,7 +11,7 @@ describe JavascriptsController do
       # actually set digest to make sure 404 is raised by router
       javascript_cache.update_attributes(digest: digest)
 
-      get "/javascripts/#{digest}.js"
+      get "/theme-javascripts/#{digest}.js"
     end
 
     it 'only accepts 40-char hexdecimal digest name' do
@@ -37,18 +37,18 @@ describe JavascriptsController do
     it 'considers the database record as the source of truth' do
       clear_disk_cache
 
-      get "/javascripts/#{javascript_cache.digest}.js"
+      get "/theme-javascripts/#{javascript_cache.digest}.js"
       expect(response.status).to eq(200)
       expect(response.body).to eq(javascript_cache.content)
 
       javascript_cache.destroy!
 
-      get "/javascripts/#{javascript_cache.digest}.js"
+      get "/theme-javascripts/#{javascript_cache.digest}.js"
       expect(response.status).to eq(404)
     end
 
     def clear_disk_cache
-      `rm #{JavascriptsController::DISK_CACHE_PATH}/*`
+      `rm #{ThemeJavascriptsController::DISK_CACHE_PATH}/*`
     end
   end
 end


### PR DESCRIPTION
RE: https://github.com/discourse/discourse/pull/6447

I tried rebaking a small theme component to test the javascript extraction, but the resulting extracted javascript 404'ed `/javascripts/263e67c3f1569db61de1d05af93cc7efc73043d5.js`.

![image](https://user-images.githubusercontent.com/6376558/46955522-1d7df800-d061-11e8-8a89-a01445515431.png)

Looks like Nginx handled the request directly, so it didn't even get to the Rails controller.

This PR renames the route to `/theme-javascripts/...`