### PR TITLE
FEATURE: Allow plugins to whitelist user custom fields for public display

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -252,8 +252,20 @@ class User < ActiveRecord::Base
     plugin_staff_user_custom_fields[custom_field_name] = plugin
   end
 
+  def self.plugin_public_user_custom_fields
+    @plugin_public_user_custom_fields ||= {}
+  end
+
+  def self.register_plugin_public_custom_field(custom_field_name, plugin)
+    plugin_public_user_custom_fields[custom_field_name] = plugin
+  end
+
   def self.whitelisted_user_custom_fields(guardian)
     fields = []
+
+    plugin_public_user_custom_fields.each do |k, v|
+      fields << k if v.enabled?
+    end
 
     if SiteSetting.public_user_custom_fields.present?
       fields += SiteSetting.public_user_custom_fields.split('|')

--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -121,6 +121,12 @@ class Plugin::Instance
     end
   end
 
+  def whitelist_public_user_custom_field(field)
+    reloadable_patch do |plugin|
+      ::User.register_plugin_public_custom_field(field, plugin) # plugin.enabled? is checked at runtime
+    end
+  end
+
   def register_editable_user_custom_field(field)
     reloadable_patch do |plugin|
       ::User.register_plugin_editable_user_custom_field(field, plugin) # plugin.enabled? is checked at runtime

--- a/spec/serializers/user_serializer_spec.rb
+++ b/spec/serializers/user_serializer_spec.rb
@@ -195,6 +195,13 @@ describe UserSerializer do
       expect(json[:custom_fields]['public_field']).to eq(user.custom_fields['public_field'])
       expect(json[:custom_fields]['secret_field']).to eq(nil)
     end
+
+    it "serializes the fields listed in plugin_public_user_custom_fields" do
+      plugin = Plugin::Instance.new
+      plugin.whitelist_public_user_custom_field :public_field
+      expect(json[:custom_fields]['public_field']).to eq(user.custom_fields['public_field'])
+      expect(json[:custom_fields]['secret_field']).to eq(nil)
+    end
   end
 
   context "with user_api_keys" do


### PR DESCRIPTION
This works exactly the same as `whitelist_staff_user_custom_fields`, but is not limited to staff