### PR TITLE
FIX: extracted theme JavaScripts for multisite

### DIFF
--- a/app/jobs/onceoff/rebake_all_html_theme_fields.rb
+++ b/app/jobs/onceoff/rebake_all_html_theme_fields.rb
@@ -1,0 +1,11 @@
+module Jobs
+  class RebakeAllHtmlThemeFields < Jobs::Onceoff
+    def execute_onceoff(args)
+      ThemeField.where(type_id: ThemeField.types[:html]).find_each do |theme_field|
+        theme_field.update(value_baked: nil)
+      end
+
+      Theme.clear_cache!
+    end
+  end
+end

--- a/app/models/javascript_cache.rb
+++ b/app/models/javascript_cache.rb
@@ -7,7 +7,7 @@ class JavascriptCache < ActiveRecord::Base
   before_save :update_digest
 
   def url
-    "#{GlobalSetting.cdn_url}#{GlobalSetting.relative_url_root}/theme-javascripts/#{digest}.js"
+    "#{GlobalSetting.cdn_url}#{GlobalSetting.relative_url_root}/theme-javascripts/#{digest}.js?__ws=#{Discourse.current_hostname}"
   end
 
   private

--- a/spec/jobs/rebake_all_html_theme_fields_spec.rb
+++ b/spec/jobs/rebake_all_html_theme_fields_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe Jobs::RebakeAllHtmlThemeFields do
+  let(:theme) { Fabricate(:theme) }
+  let(:theme_field) { ThemeField.create!(theme: theme, target_id: 0, name: "header", value: "<script>console.log(123)</script>") }
+
+  it 'extracts inline javascripts' do
+    theme_field.update_attributes(value_baked: 'need to be rebaked')
+
+    described_class.new.execute_onceoff({})
+
+    theme_field.reload
+    expect(theme_field.value_baked).to include('theme-javascripts')
+  end
+end

--- a/spec/models/javascript_cache_spec.rb
+++ b/spec/models/javascript_cache_spec.rb
@@ -29,4 +29,11 @@ RSpec.describe JavascriptCache, type: :model do
       expect(javascript_cache.errors.details[:content]).to include(error: :empty)
     end
   end
+
+  describe 'url' do
+    it 'works with multisite' do
+      javascript_cache = JavascriptCache.create!(content: 'console.log("hello");', theme_field: theme_field)
+      expect(javascript_cache.url).to include("?__ws=test.localhost")
+    end
+  end
 end


### PR DESCRIPTION
NOTE: this includes a onceoff job to rebake all HTML theme fields, which will

1. extract inline javascripts in themes, and
2. correct the wrong `theme-javascript` url for multisite 