### PR TITLE
Add base_url to config locales

### DIFF
--- a/config/locales/server.ar.yml
+++ b/config/locales/server.ar.yml
@@ -626,8 +626,8 @@ ar:
       email_body: "%{link}\n\n%{message}"
     inappropriate:
       title: 'غير مناسب'
-      description: 'محتوي هذا المنشور أي شخص عاقل سيعتبره عدواني، أو مسيئ، أو انتهاك لـ<a href="/guidelines">مبادئ مجتمعنا التوجيهية</a>.'
-      short_description: 'انتهاك <a href="/guidelines">للقواعد العامة للمجتمع</a>'
+      description: 'محتوي هذا المنشور أي شخص عاقل سيعتبره عدواني، أو مسيئ، أو انتهاك لـ<a href="%{base_url}/guidelines">مبادئ مجتمعنا التوجيهية</a>.'
+      short_description: 'انتهاك <a href="%{base_url}/guidelines">للقواعد العامة للمجتمع</a>'
       long_form: 'ترفع علم هذا عن صورة غير ملائمة'
     notify_user:
       title: 'أرسل رسالة إلى @{{username}}'
@@ -666,11 +666,11 @@ ar:
       long_form: 'ترفع علم هذا كدعاية'
     inappropriate:
       title: 'غير مناسب'
-      description: 'هذا الموضوع يشمل محتوى أي شخص عاقل سيعتبره عدواني، أو مسيئ، أو انتهاك لـ<a href="/guidelines">مبادئ مجتمعنا التوجيهية</a>.'
+      description: 'هذا الموضوع يشمل محتوى أي شخص عاقل سيعتبره عدواني، أو مسيئ، أو انتهاك لـ<a href="%{base_url}/guidelines">مبادئ مجتمعنا التوجيهية</a>.'
       long_form: 'ترفع علم هذا عن صورة غير ملائمة'
     notify_moderators:
       title: "شيء آخر "
-      description: 'هذا الموضوع يتطلب اهتمام الطاقم العام معتمداً على  <a href="/guidelines">التوجيهات</a>, <a href="%{tos_url}">شروط الخدمة</a>, أو لسبب آخر لم يذكر أعلاه.'
+      description: 'هذا الموضوع يتطلب اهتمام الطاقم العام معتمداً على  <a href="%{base_url}/guidelines">التوجيهات</a>, <a href="%{tos_url}">شروط الخدمة</a>, أو لسبب آخر لم يذكر أعلاه.'
       long_form: 'علم هذا لتنبيه المراقب'
       email_title: 'الموضوع "%{title}" يتطلب موافقة المشرف'
       email_body: "%{link}\n\n%{message}"
@@ -852,11 +852,11 @@ ar:
     sidekiq_warning: "\"Sidekiq\" لا يعمل! \nالعديد من المهام, كإرسال البريدوغيرها, يتم تنفيذها بشكل غير متزامن من قبل \"sidekiq\". الرجاء التحقيق من عمل احدى وضائف الـ\"Sidekiq\".  <a href=\"https://github.com/mperham/sidekiq\" target=\"_blank\">Learn about Sidekiq here</a>."
     queue_size_warning: 'عدد المهام في الطّابور هو %{queue_size}، وهذا رقم كبير. قد يكون هذا مؤشّرًا لوجود مشكلة بعمليّات Sidekiq، أو قد تحتاج إضافة عاملي Sidekiq أخرى.'
     memory_warning: 'خادمك يعمل بأقل من 1 جيجا بايت من الذاكرة الإجمالية. يتطلب على الأقل 1 جيجا بايت من الذاكرة.'
-    google_oauth2_config_warning: 'تم تكوين الخادم للسماح بالتسجيل وتسجيل الدخول مع Google OAuth2 (enable_google_oauth2_logins)، لكن معرف العميل وعميل القيم السرية لم يعين. أذهب إلى <a href="/admin/site_settings">إعدادات الموقع</a>وتحديث الإعدادات. <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">أنظر لهذا الدليل لمزيد من المعلومات</a>.'
-    facebook_config_warning: 'تم تكوين الخادم للسماح بالتسجيل وتسجيل الدخول مع Facebook (enable_facebook_logins), لكن معرف العميل وعميل القيم السرية لم يعين. أذهب إلى <a href="/admin/site_settings">إعدادات الموقع</a>وتحديث الإعدادات. <a href="https://meta.discourse.org/t/configuring-facebook-login-for-discourse/13394"  target="_blank">أنظر لهذا الدليل لمزيد من المعلومات</a>.'
-    twitter_config_warning: 'تم تكوين الخادم للسماح بالتسجيل وتسجيل الدخول مع Twitter (enable_twitter_logins),  لكن معرف العميل وعميل القيم السرية لم يعين. أذهب إلى  <a href="/admin/site_settings">إعدادات الموقع</a> وتحديث الإعدادات. <a href="https://meta.discourse.org/t/configuring-twitter-login-for-discourse/13395" target="_blank">أنظر لهذا الدليل لمزيد من المعلومات</a>.'
-    github_config_warning: 'تم تكوين الخادم للسماح بالتسجيل وتسجيل الدخول مع GitHub (enable_github_logins),  لكن معرف العميل وعميل القيم السرية لم يعين. أذهب إلى  <a href="/admin/site_settings">إعدادات الموقع</a> وتحديث الإعدادات. <a href="https://meta.discourse.org/t/configuring-github-login-for-discourse/13745" target="_blank">أنظر لهذا الدليل لمزيد من المعلومات</a>.'
-    failing_emails_warning: 'يوجد %{num_failed_jobs} مهام بريد إلكتروني فشلت. تحقق من app.yml الخاص بك وتأكد من إعدادات خادم البريد أنها صحيحة. <a href="/sidekiq/retries" target="_blank">أنظر للمهام الفاشلة في Sidekiq</a>.'
+    google_oauth2_config_warning: 'تم تكوين الخادم للسماح بالتسجيل وتسجيل الدخول مع Google OAuth2 (enable_google_oauth2_logins)، لكن معرف العميل وعميل القيم السرية لم يعين. أذهب إلى <a href="%{base_url}/admin/site_settings">إعدادات الموقع</a>وتحديث الإعدادات. <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">أنظر لهذا الدليل لمزيد من المعلومات</a>.'
+    facebook_config_warning: 'تم تكوين الخادم للسماح بالتسجيل وتسجيل الدخول مع Facebook (enable_facebook_logins), لكن معرف العميل وعميل القيم السرية لم يعين. أذهب إلى <a href="%{base_url}/admin/site_settings">إعدادات الموقع</a>وتحديث الإعدادات. <a href="https://meta.discourse.org/t/configuring-facebook-login-for-discourse/13394"  target="_blank">أنظر لهذا الدليل لمزيد من المعلومات</a>.'
+    twitter_config_warning: 'تم تكوين الخادم للسماح بالتسجيل وتسجيل الدخول مع Twitter (enable_twitter_logins),  لكن معرف العميل وعميل القيم السرية لم يعين. أذهب إلى  <a href="%{base_url}/admin/site_settings">إعدادات الموقع</a> وتحديث الإعدادات. <a href="https://meta.discourse.org/t/configuring-twitter-login-for-discourse/13395" target="_blank">أنظر لهذا الدليل لمزيد من المعلومات</a>.'
+    github_config_warning: 'تم تكوين الخادم للسماح بالتسجيل وتسجيل الدخول مع GitHub (enable_github_logins),  لكن معرف العميل وعميل القيم السرية لم يعين. أذهب إلى  <a href="%{base_url}/admin/site_settings">إعدادات الموقع</a> وتحديث الإعدادات. <a href="https://meta.discourse.org/t/configuring-github-login-for-discourse/13745" target="_blank">أنظر لهذا الدليل لمزيد من المعلومات</a>.'
+    failing_emails_warning: 'يوجد %{num_failed_jobs} مهام بريد إلكتروني فشلت. تحقق من app.yml الخاص بك وتأكد من إعدادات خادم البريد أنها صحيحة. <a href="%{base_url}/sidekiq/retries" target="_blank">أنظر للمهام الفاشلة في Sidekiq</a>.'
     subfolder_ends_in_slash: "إعدادات المجلدات الداخلية خاطئ;ال DISCOURSE_RELATIVE_URL_ROOT يجب ان تنتهي ب سلاش."
   site_settings:
     censored_words: "الكلمات التي ستُستبدل آليًّا ب‍ &#9632;&#9632;&#9632;&#9632;"
@@ -1488,7 +1488,7 @@ ar:
       من فضلك قم بتسجيل الدخول او انشاء حساب جديد للمتابعة.
   terms_of_service:
     title: "شروط الخدمة"
-    signup_form_message: 'لقد قرأت و أوافق على <a href="/tos" target="_blank">بنود الخدمة</a>.'
+    signup_form_message: 'لقد قرأت و أوافق على <a href="%{base_url}/tos" target="_blank">بنود الخدمة</a>.'
   deleted: 'حذف'
   upload:
     edit_reason: "تحميل نسخ محلية للصور"

--- a/config/locales/server.bg.yml
+++ b/config/locales/server.bg.yml
@@ -400,7 +400,7 @@ bg:
       email_body: "%{link}\n\n%{message}"
     inappropriate:
       title: 'Неприлично'
-      description: 'Този пост има съдържание, което всеки разумен човек би сметнал за обидно и оскърбително  of <a href="/guidelines">Правилата на Общността</a>.'
+      description: 'Този пост има съдържание, което всеки разумен човек би сметнал за обидно и оскърбително  of <a href="%{base_url}/guidelines">Правилата на Общността</a>.'
       long_form: 'Маркирахте това като неприлично'
     notify_user:
       title: 'Изпрати съобщение до @{{username}}'
@@ -427,7 +427,7 @@ bg:
       long_form: 'маркирахте това като спам'
     inappropriate:
       title: 'Неприлично'
-      description: 'Този пост има съдържание, което всеки разумен човек би сметнал за обидно и оскърбително , или нарушава of <a href="/guidelines">виж Правилата на Общността</a>.'
+      description: 'Този пост има съдържание, което всеки разумен човек би сметнал за обидно и оскърбително , или нарушава of <a href="%{base_url}/guidelines">виж Правилата на Общността</a>.'
       long_form: 'Маркирано като неприлично'
     notify_moderators:
       title: "Нещо друго"
@@ -574,10 +574,10 @@ bg:
     host_names_warning: "Вашият config/database.yml файл използва по подразбиране localhost за hostname. Обновете, за да използва името на вашия сайт за hostname. "
     sidekiq_warning: 'Sidekiq не работи. Много задачи, като изпращане на имейли, се изпълняват несинхронизирано от sidekiq.  Моля убедете се, че поне един процес sidekiq работи.  <a href="https://github.com/mperham/sidekiq" target="_blank">Научете повече за Sidekiq тук</a>.'
     memory_warning: 'Вашият сървър използва по-малко от 1 ГБ от общата памет. Препоръчва се най-малко 1 ГБ.'
-    google_oauth2_config_warning: 'Сървърът е конфигуриран да позволи регистрация и вписване с Google OAuth2 (enable_google_oauth2_logins), но client id и client secret values не са определени. Отидете на <a href="/admin/site_settings">Настройките на сайта</a> и актуализирайте настройките. <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank"">За повече информация вижте тук</a>.'
-    facebook_config_warning: 'Сървърът е конфигуриран да позволи регистрация и вписване с Facebook (enable_facebook_logins), app id и app secret values  не са изпратени. Отидете на  <a href="/admin/site_settings"> Настройките на сайта </a> и обновете настройките.<a href="https://meta.discourse.org/t/configuring-facebook-login-for-discourse/13394" target="_blank">За повече информация вижте тук</a>.'
-    twitter_config_warning: 'Сървърът е конфигуриран да позволи регистрация и вписване със Twitter (enable_twitter_logins),но the key and secret values не са изпратени. Отидете на <a href="/admin/site_settings">Настройките на сайта</a> и обновете настройките. <a href="https://meta.discourse.org/t/configuring-twitter-login-for-discourse/13395" target="_blank"> За повече информация вижте тук</a>.'
-    github_config_warning: 'Сървърът е конфигуриран да позволи регистрация и вписване с GitHub (enable_github_logins), но client id и secret values не са изпратени. Отидете на <a href="/admin/site_settings">Настройките на сайта</a> и обновете настройките<a href="https://meta.discourse.org/t/configuring-github-login-for-discourse/13745" target="_blank">За повече информация вижте тук</a>.'
+    google_oauth2_config_warning: 'Сървърът е конфигуриран да позволи регистрация и вписване с Google OAuth2 (enable_google_oauth2_logins), но client id и client secret values не са определени. Отидете на <a href="%{base_url}/admin/site_settings">Настройките на сайта</a> и актуализирайте настройките. <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank"">За повече информация вижте тук</a>.'
+    facebook_config_warning: 'Сървърът е конфигуриран да позволи регистрация и вписване с Facebook (enable_facebook_logins), app id и app secret values  не са изпратени. Отидете на  <a href="%{base_url}/admin/site_settings"> Настройките на сайта </a> и обновете настройките.<a href="https://meta.discourse.org/t/configuring-facebook-login-for-discourse/13394" target="_blank">За повече информация вижте тук</a>.'
+    twitter_config_warning: 'Сървърът е конфигуриран да позволи регистрация и вписване със Twitter (enable_twitter_logins),но the key and secret values не са изпратени. Отидете на <a href="%{base_url}/admin/site_settings">Настройките на сайта</a> и обновете настройките. <a href="https://meta.discourse.org/t/configuring-twitter-login-for-discourse/13395" target="_blank"> За повече информация вижте тук</a>.'
+    github_config_warning: 'Сървърът е конфигуриран да позволи регистрация и вписване с GitHub (enable_github_logins), но client id и secret values не са изпратени. Отидете на <a href="%{base_url}/admin/site_settings">Настройките на сайта</a> и обновете настройките<a href="https://meta.discourse.org/t/configuring-github-login-for-discourse/13745" target="_blank">За повече информация вижте тук</a>.'
     subfolder_ends_in_slash: "Вашата настройка за подпапка е неправилна; DISCOURSE_RELATIVE_URL_ROOT завършва с наклонена черта."
   site_settings:
     censored_words: "Думите които ще бъдат автоматично заменени с &#9632;&#9632;&#9632;&#9632;"
@@ -1062,7 +1062,7 @@ bg:
     search_title: "Търси този сайт"
   terms_of_service:
     title: "Правила за ползване"
-    signup_form_message: 'Аз прочетох и приемам  <a href="/tos" target="_blank">правилата за ползване</a>.'
+    signup_form_message: 'Аз прочетох и приемам  <a href="%{base_url}/tos" target="_blank">правилата за ползване</a>.'
   deleted: 'изтрит'
   upload:
     edit_reason: "изтеглено локално копие на изображенията"

--- a/config/locales/server.bs_BA.yml
+++ b/config/locales/server.bs_BA.yml
@@ -223,7 +223,7 @@ bs_BA:
       long_form: 'opomeni kao spam'
     inappropriate:
       title: 'Neprikladno'
-      description: 'Ovaj post sadrži tekst koji bi razumna osoba smatrala uvredljivim, pogrdnim i neprikladan prema <a href="/guidelines">pravilima naše zajednice</a>.'
+      description: 'Ovaj post sadrži tekst koji bi razumna osoba smatrala uvredljivim, pogrdnim i neprikladan prema <a href="%{base_url}/guidelines">pravilima naše zajednice</a>.'
       long_form: 'opomeni kao neprikladno'
     notify_user:
       long_form: 'korisnik obavješten'
@@ -247,7 +247,7 @@ bs_BA:
       long_form: 'opomenuo kao spam'
     inappropriate:
       title: 'Inappropriate'
-      description: 'Ova tema sadrži tekst koji bi razumna osoba smatrala uvredljivim, pogrdnim i neprikladan prema <a href="/guidelines">pravilima naše zajednice</a>.'
+      description: 'Ova tema sadrži tekst koji bi razumna osoba smatrala uvredljivim, pogrdnim i neprikladan prema <a href="%{base_url}/guidelines">pravilima naše zajednice</a>.'
       long_form: 'opomenuto kao neprikladno'
     notify_moderators:
       title: "Obavijesti Moderatore"
@@ -345,10 +345,10 @@ bs_BA:
     host_names_warning: "Your config/database.yml file is using the default localhost hostname. Update it to use your site's hostname."
     sidekiq_warning: 'Sidekiq is not running. Many tasks, like sending emails, are executed asynchronously by sidekiq. Please ensure at least one sidekiq process is running. <a href="https://github.com/mperham/sidekiq" target="_blank">Learn about Sidekiq here</a>.'
     memory_warning: 'Your server is running with less than 1 GB of total memory. At least 1 GB of memory is recommended.'
-    google_oauth2_config_warning: 'The server is configured to allow signup and log in with Google OAuth2 (enable_google_oauth2_logins), but the client id and client secret values are not set. Go to <a href="/admin/site_settings">the Site Settings</a> and update the settings. <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">See this guide to learn more</a>.'
-    facebook_config_warning: 'The server is configured to allow signup and log in with Facebook (enable_facebook_logins), but the app id and app secret values are not set. Go to <a href="/admin/site_settings">the Site Settings</a> and update the settings. <a href="https://meta.discourse.org/t/configuring-facebook-login-for-discourse/13394" target="_blank">See this guide to learn more</a>.'
-    twitter_config_warning: 'The server is configured to allow signup and log in with Twitter (enable_twitter_logins), but the key and secret values are not set. Go to <a href="/admin/site_settings">the Site Settings</a> and update the settings. <a href="https://meta.discourse.org/t/configuring-twitter-login-for-discourse/13395" target="_blank">See this guide to learn more</a>.'
-    github_config_warning: 'The server is configured to allow signup and log in with GitHub (enable_github_logins), but the client id and secret values are not set. Go to <a href="/admin/site_settings">the Site Settings</a> and update the settings. <a href="https://meta.discourse.org/t/configuring-github-login-for-discourse/13745" target="_blank">See this guide to learn more</a>.'
+    google_oauth2_config_warning: 'The server is configured to allow signup and log in with Google OAuth2 (enable_google_oauth2_logins), but the client id and client secret values are not set. Go to <a href="%{base_url}/admin/site_settings">the Site Settings</a> and update the settings. <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">See this guide to learn more</a>.'
+    facebook_config_warning: 'The server is configured to allow signup and log in with Facebook (enable_facebook_logins), but the app id and app secret values are not set. Go to <a href="%{base_url}/admin/site_settings">the Site Settings</a> and update the settings. <a href="https://meta.discourse.org/t/configuring-facebook-login-for-discourse/13394" target="_blank">See this guide to learn more</a>.'
+    twitter_config_warning: 'The server is configured to allow signup and log in with Twitter (enable_twitter_logins), but the key and secret values are not set. Go to <a href="%{base_url}/admin/site_settings">the Site Settings</a> and update the settings. <a href="https://meta.discourse.org/t/configuring-twitter-login-for-discourse/13395" target="_blank">See this guide to learn more</a>.'
+    github_config_warning: 'The server is configured to allow signup and log in with GitHub (enable_github_logins), but the client id and secret values are not set. Go to <a href="%{base_url}/admin/site_settings">the Site Settings</a> and update the settings. <a href="https://meta.discourse.org/t/configuring-github-login-for-discourse/13745" target="_blank">See this guide to learn more</a>.'
   site_settings:
     censored_words: "Words that will be automatically replaced with &#9632;&#9632;&#9632;&#9632;"
     delete_old_hidden_posts: "Auto-delete any hidden posts that stay hidden for more than 30 days."
@@ -664,7 +664,7 @@ bs_BA:
     search_title: "Pretraži stranicu"
   terms_of_service:
     title: "Terms of Service"
-    signup_form_message: 'I have read and accept the <a href="/tos" target="_blank">Terms of Service</a>.'
+    signup_form_message: 'I have read and accept the <a href="%{base_url}/tos" target="_blank">Terms of Service</a>.'
   deleted: 'obrisano'
   upload:
     edit_reason: "downloaded local copies of images"

--- a/config/locales/server.ca.yml
+++ b/config/locales/server.ca.yml
@@ -491,7 +491,7 @@ ca:
       email_body: "%{link}\n\n%{message}"
     inappropriate:
       title: 'Inapropiat'
-      description: 'Aquesta publicació té contingut que una persona raonable consideraria ofensiu, abusiu o una violació de les <a href="/guidelines">nostres normes de la comunitat</a>.'
+      description: 'Aquesta publicació té contingut que una persona raonable consideraria ofensiu, abusiu o una violació de les <a href="%{base_url}/guidelines">nostres normes de la comunitat</a>.'
       long_form: 'marcar amb bandera d''inapropiat'
     notify_user:
       title: 'Envia un missatge a @{{username}}'
@@ -525,11 +525,11 @@ ca:
       long_form: 'marcat amb bandera de brossa'
     inappropriate:
       title: 'Inapropiat'
-      description: 'Aquest tema té contingut que una persona raonable consideraria ofensiu, abusiu o una violació de les <a href="/guidelines">nostres normes de la comunitat</a>.'
+      description: 'Aquest tema té contingut que una persona raonable consideraria ofensiu, abusiu o una violació de les <a href="%{base_url}/guidelines">nostres normes de la comunitat</a>.'
       long_form: 'marcat amb bandera d''inapropiat'
     notify_moderators:
       title: "Alguna altra cosa"
-      description: 'Aquest tema necessita la supervisió general de l''equip basada en les <a href="/guidelines">normes</a>, <a href="%{tos_url}">TOS</a> o per un altre motiu abans no esmentat.'
+      description: 'Aquest tema necessita la supervisió general de l''equip basada en les <a href="%{base_url}/guidelines">normes</a>, <a href="%{tos_url}">TOS</a> o per un altre motiu abans no esmentat.'
       long_form: 'marcat per a la supervisió moderadora'
       email_title: 'El tema "%{title}" necessita la supervisió moderadora'
       email_body: "%{link}\n\n%{message}"
@@ -717,11 +717,11 @@ ca:
     sidekiq_warning: 'No s''està executant <i>Sidekiq</i>. Hi ha moltes tasques asincrònicament en execució per <i>Sidekiq</i>, com ara enviament de correus. Si us plau, assegura''t que com a mínim hi ha un procés <i>Sidekiq</i> en marxa.  <a href="https://github.com/mperham/sidekiq" target="_blank">Aprèn més aquí sobre <i>Sidekiq</i></a>.'
     queue_size_warning: 'La quantitat de tasques en cua és de %{queue_size}, que és elevada. Això podria indicar un problema amb un o més procesos o potser et cal afegir-hi més treballadors de <i>Sidekiq</i>.'
     memory_warning: 'El teu servidor s''està executant amb menys d''1 GB de memòria total. Se''n recomana com a mínim un 1 GB de memòria.'
-    google_oauth2_config_warning: 'El servidor està configurat per permetre el registre i inici de sessió amb Google OAuth2 (enable_google_oauth2_logins), però l''id de client i els valors secrets de client no estan configurats. Vés a <a href="/admin/site_settings">la Configuració del Lloc</a> i actualitza les configuracions. <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">Mira aquesta guia per saber-ne més</a>.'
-    facebook_config_warning: 'El servidor està configurat per permetre el registre i inici de sessió amb Facebook (enable_facebook_logins), però l''id de client i els valors secrets de client no estan configurats. Vés a <a href="/admin/site_settings">la Configuració del Lloc</a> i actualitza les configuracions. <a href="https://meta.discourse.org/t/configuring-facebook-login-for-discourse/13394" target="_blank">Mira aquesta guia per saber-ne més</a>.'
-    twitter_config_warning: 'El servidor està configurat per permetre el registre i inici de sessió amb Twitter (enable_twitter_logins), però l''id de client i els valors secrets de client no estan configurats. Vés a <a href="/admin/site_settings">la Configuració del Lloc</a> i actualitza les configuracions. <a href="https://meta.discourse.org/t/configuring-twitter-login-for-discourse/13395" target="_blank">Mira aquesta guia per saber-ne més</a>.'
-    github_config_warning: 'El servidor està configurat per permetre el registre i inici de sessió amb GitHub (enable_github_logins), però l''id de client i els valors secrets de client no estan configurats. Vés a <a href="/admin/site_settings">la Configuració del Lloc</a> i actualitza les configuracions. <a href="https://meta.discourse.org/t/configuring-github-login-for-discourse/13745" target="_blank">Mira aquesta guia per aprendre''n més</a>.'
-    failing_emails_warning: 'Hi ha %{num_failed_jobs} tasques de correu fallides. Revisa el teu app.yml i assegura''t que la configuració del servidor de correu és correcta. <a href="/sidekiq/retries" target="_blank">Mira les tasques fallides a <i>Sidekiq</i></a>.'
+    google_oauth2_config_warning: 'El servidor està configurat per permetre el registre i inici de sessió amb Google OAuth2 (enable_google_oauth2_logins), però l''id de client i els valors secrets de client no estan configurats. Vés a <a href="%{base_url}/admin/site_settings">la Configuració del Lloc</a> i actualitza les configuracions. <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">Mira aquesta guia per saber-ne més</a>.'
+    facebook_config_warning: 'El servidor està configurat per permetre el registre i inici de sessió amb Facebook (enable_facebook_logins), però l''id de client i els valors secrets de client no estan configurats. Vés a <a href="%{base_url}/admin/site_settings">la Configuració del Lloc</a> i actualitza les configuracions. <a href="https://meta.discourse.org/t/configuring-facebook-login-for-discourse/13394" target="_blank">Mira aquesta guia per saber-ne més</a>.'
+    twitter_config_warning: 'El servidor està configurat per permetre el registre i inici de sessió amb Twitter (enable_twitter_logins), però l''id de client i els valors secrets de client no estan configurats. Vés a <a href="%{base_url}/admin/site_settings">la Configuració del Lloc</a> i actualitza les configuracions. <a href="https://meta.discourse.org/t/configuring-twitter-login-for-discourse/13395" target="_blank">Mira aquesta guia per saber-ne més</a>.'
+    github_config_warning: 'El servidor està configurat per permetre el registre i inici de sessió amb GitHub (enable_github_logins), però l''id de client i els valors secrets de client no estan configurats. Vés a <a href="%{base_url}/admin/site_settings">la Configuració del Lloc</a> i actualitza les configuracions. <a href="https://meta.discourse.org/t/configuring-github-login-for-discourse/13745" target="_blank">Mira aquesta guia per aprendre''n més</a>.'
+    failing_emails_warning: 'Hi ha %{num_failed_jobs} tasques de correu fallides. Revisa el teu app.yml i assegura''t que la configuració del servidor de correu és correcta. <a href="%{base_url}/sidekiq/retries" target="_blank">Mira les tasques fallides a <i>Sidekiq</i></a>.'
     subfolder_ends_in_slash: "La teva configuració de subcarpeta no és correcta; DISCOURSE_RELATIVE_URL_ROOT acaba amb barra inclinada."
     email_polling_errored_recently:
       one: "L'enquesta per correu electrònic ha generat un error durant les darreres 24 hores. Fes un cop d'ull als <a href='/logs' target='_blank'>registres</a> per saber-ne més."
@@ -1668,7 +1668,7 @@ ca:
     search_title: "Busca aquest lloc"
   terms_of_service:
     title: "Condicions d'ús"
-    signup_form_message: 'He llegit i accepto les <a href="/tos" target="_blank">Condicions del servei</a>.'
+    signup_form_message: 'He llegit i accepto les <a href="%{base_url}/tos" target="_blank">Condicions del servei</a>.'
   deleted: 'esborrat'
   upload:
     edit_reason: "còpia local d'imatges descarregada"

--- a/config/locales/server.cs.yml
+++ b/config/locales/server.cs.yml
@@ -606,7 +606,7 @@ cs:
       long_form: 'označeno jako spam'
     inappropriate:
       title: 'Nevhodné'
-      description: 'Obsah tohoto příspěvku by rozumný člověk shledal urážlivý, hrubý nebo v rozporu s <a href="/guidelines">pravidly komunity</a>.'
+      description: 'Obsah tohoto příspěvku by rozumný člověk shledal urážlivý, hrubý nebo v rozporu s <a href="%{base_url}/guidelines">pravidly komunity</a>.'
       long_form: 'nahlášeno jako nevhodné'
     notify_moderators:
       title: "Něco jiného"
@@ -761,9 +761,9 @@ cs:
     host_names_warning: "Vaše konfigurace v souboru config/database.yml používá 'localhost' jako jméno hostitele. Změňte toto nastavení na doménu vašeho webu."
     sidekiq_warning: 'Sidekiq neběží. Řada úloh, jako je zasílání emailů, se provádí asynchronně na pozadí přes sidekiq. Prosím, ujistěte se, že alespoň jeden process sidekiq běží. <a href="https://github.com/mperham/sidekiq">Více o Sidekiq</a>.'
     memory_warning: 'Váš server má méně než 1 GB paměti. Doporučená konfigurace je alespoň 1 GB paměti.'
-    facebook_config_warning: 'Server je nakonfigurován, aby povoloval registraci a přihlášení přes Facebook (enable_facebook_logins), ale nejsou nastaveny hodnoty "app id" a "app secret". Navštivte <a href="/admin/site_settings">nastevení webu</a> a opravte nastavení. <a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide#enable-facebook-logins" target="_blank">Pro více informací si přečtěte tento návod</a>.'
-    twitter_config_warning: 'Server je nakonfigurován, aby povoloval registraci a přihlášení přes Twitter (enable_twitter_logins), ale nejsou nastaveny hodnoty "key" a "secret". Navštivte <a href="/admin/site_settings">nastevení webu</a> a opravte nastavení. <a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide#enable-twitter-logins" target="_blank">Pro více informací si přečtěte tento návod</a>.'
-    github_config_warning: 'Server je nakonfigurován, aby povoloval registraci a přihlášení přes GitHub (enable_github_logins), ale nejsou nastaveny hodnoty "client id" a "secret". Navštivte <a href="/admin/site_settings">nastevení webu</a> a opravte nastavení. <a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide" target="_blank">Pro více informací si přečtěte tento návod</a>.'
+    facebook_config_warning: 'Server je nakonfigurován, aby povoloval registraci a přihlášení přes Facebook (enable_facebook_logins), ale nejsou nastaveny hodnoty "app id" a "app secret". Navštivte <a href="%{base_url}/admin/site_settings">nastevení webu</a> a opravte nastavení. <a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide#enable-facebook-logins" target="_blank">Pro více informací si přečtěte tento návod</a>.'
+    twitter_config_warning: 'Server je nakonfigurován, aby povoloval registraci a přihlášení přes Twitter (enable_twitter_logins), ale nejsou nastaveny hodnoty "key" a "secret". Navštivte <a href="%{base_url}/admin/site_settings">nastevení webu</a> a opravte nastavení. <a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide#enable-twitter-logins" target="_blank">Pro více informací si přečtěte tento návod</a>.'
+    github_config_warning: 'Server je nakonfigurován, aby povoloval registraci a přihlášení přes GitHub (enable_github_logins), ale nejsou nastaveny hodnoty "client id" a "secret". Navštivte <a href="%{base_url}/admin/site_settings">nastevení webu</a> a opravte nastavení. <a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide" target="_blank">Pro více informací si přečtěte tento návod</a>.'
   site_settings:
     allow_user_locale: "Povolit uživatelům nastavit si jazyk fóra"
     min_search_term_length: "Minimální délka hledaného výrazu ve znacích"
@@ -916,7 +916,7 @@ cs:
     see_more: "Více"
   terms_of_service:
     title: "Podmínky používání"
-    signup_form_message: 'I have read and accept the <a href="/tos" target="_blank">Terms of Service</a>.'
+    signup_form_message: 'I have read and accept the <a href="%{base_url}/tos" target="_blank">Terms of Service</a>.'
   deleted: 'smazáno'
   upload:
     unauthorized: "Bohužel, soubor, který se snažíte nahrát, není povolený (povolené přípony: %{authorized_extensions})."

--- a/config/locales/server.da.yml
+++ b/config/locales/server.da.yml
@@ -516,7 +516,7 @@ da:
       email_body: "%{link}\n\n%{message}"
     inappropriate:
       title: 'Upassende'
-      description: 'Dette indlæg har indhold som en rimelig person ville opfatte som stødende, udtryk for misbrug eller som et brud på <a href="/guidelines">vores sammenholds retningslinjer</a>.'
+      description: 'Dette indlæg har indhold som en rimelig person ville opfatte som stødende, udtryk for misbrug eller som et brud på <a href="%{base_url}/guidelines">vores sammenholds retningslinjer</a>.'
       long_form: 'markerede dette som stødende'
     notify_user:
       title: 'Send @{{username}} en besked'
@@ -525,7 +525,7 @@ da:
       email_body: "%{link}\n\n%{message}"
     notify_moderators:
       title: "Noget andet"
-      description: 'Dette indlæg kræver moderatorernes opmærksomhed baseret på <a href="/faq">Den Gode Tone</a>, <a href="%{tos_url}">Brugerbetingelser</a> eller en anden grund, som ikke er nævnt ovenfor.'
+      description: 'Dette indlæg kræver moderatorernes opmærksomhed baseret på <a href="%{base_url}/faq">Den Gode Tone</a>, <a href="%{tos_url}">Brugerbetingelser</a> eller en anden grund, som ikke er nævnt ovenfor.'
       long_form: 'Har flagged dette overfor administrator'
       email_title: 'Et indlæg i "%{title}" afkræver stillingtagen hos administrator'
       email_body: "%{link}\n\n%{message}"
@@ -550,11 +550,11 @@ da:
       long_form: 'markerede dette som spam'
     inappropriate:
       title: 'Upassende'
-      description: 'Dette emne har indlæg som en fornuftig person finder stødende, krænkende, eller som er i modstrid med <a href="/guidelines">Den Gode Tone</a>.'
+      description: 'Dette emne har indlæg som en fornuftig person finder stødende, krænkende, eller som er i modstrid med <a href="%{base_url}/guidelines">Den Gode Tone</a>.'
       long_form: 'markeret upassende'
     notify_moderators:
       title: "Noget andet"
-      description: 'Dette emne kræver moderatorernes opmærksomhed baseret på <a href="/faq">Den Gode Tone</a>, <a href="%{tos_url}">Brugerbetingelser</a> eller en anden grund, som ikke er nævnt ovenfor.'
+      description: 'Dette emne kræver moderatorernes opmærksomhed baseret på <a href="%{base_url}/faq">Den Gode Tone</a>, <a href="%{tos_url}">Brugerbetingelser</a> eller en anden grund, som ikke er nævnt ovenfor.'
       long_form: 'markerede dette til gennemsyn'
       email_title: 'Emnet "%{title}" kræver moderator-opmærksomhed'
       email_body: "%{link}\n\n%{message}"
@@ -736,11 +736,11 @@ da:
     sidekiq_warning: 'Sidekiq kører ikke. Mange opgaver, som f.eks. udsendelse af e-mail, afvikles asynkront af sidekiq. Du skal sikre dig at der kører mindst én sidekiq-proces. <a href="https://github.com/mperham/sidekiq" target="_blank">Læs mere om Sidekiq her</a>.'
     queue_size_warning: 'Antallet af job i kø er %{queue_size}, hvilket er højt. Dette kunne indikere at der er et problem med Sidekiq processerne, eller du behøver at tilføre flere Sidekiq resurser.'
     memory_warning: 'Din server kører med mindre end 1 GB samlet hukommelse. Det anbefales at have mindst 1 GB hukommelse.'
-    google_oauth2_config_warning: 'Serveren er konfigureret til at tillade signup med Google OAuth2 (enable_google_oauth2_logins),men klient id og klientens skjulte værdier er ikke indstillet. Gå til<a href="/admin/site_settings">the Site Settings</a> og opdater! <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">Se denne guide for at lære mere</a>.'
-    facebook_config_warning: 'Serveren er konfigureret til at tillade tilmelding og login med Facebook (enable_facebook_logins), men app id og app secret værdierne er ikke angivet. Gå til <a href="/admin/site_settings">indstillinger</a> og opdatér indstillingerne. <a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide#enable-facebook-logins" target="_blank">Se denne vejledning for mere information</a>.'
-    twitter_config_warning: 'Serveren er konfigureret til at tillade tilmelding og login med Twitter (enable_twitter_logins), men key og secret værdierne er ikke angivet. Gå til <a href="/admin/site_settings">indstillinger</a> og opdatér indstillingerne. <a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide#enable-twitter-logins" target="_blank">Se denne vejledning for mere information</a>.'
-    github_config_warning: 'Serveren er konfigureret til at tillade tilmelding og login med GitHub (enable_github_logins), men client id og secret værdierne er ikke angivet. Gå til <a href="/admin/site_settings">indstillinger</a> og opdatér indstillingerne. <a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide" target="_blank">Se denne vejledning for mere information</a>.'
-    failing_emails_warning: 'Der er %{num_failed_jobs} email operationer der mislykkede. Tjek din app.yml for at sikre at din mail server indstillinger er korrekte. <a href="/sidekiq/retries" target="_blank">Se mislykkede operationer i Sidekiq</a>.'
+    google_oauth2_config_warning: 'Serveren er konfigureret til at tillade signup med Google OAuth2 (enable_google_oauth2_logins),men klient id og klientens skjulte værdier er ikke indstillet. Gå til<a href="%{base_url}/admin/site_settings">the Site Settings</a> og opdater! <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">Se denne guide for at lære mere</a>.'
+    facebook_config_warning: 'Serveren er konfigureret til at tillade tilmelding og login med Facebook (enable_facebook_logins), men app id og app secret værdierne er ikke angivet. Gå til <a href="%{base_url}/admin/site_settings">indstillinger</a> og opdatér indstillingerne. <a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide#enable-facebook-logins" target="_blank">Se denne vejledning for mere information</a>.'
+    twitter_config_warning: 'Serveren er konfigureret til at tillade tilmelding og login med Twitter (enable_twitter_logins), men key og secret værdierne er ikke angivet. Gå til <a href="%{base_url}/admin/site_settings">indstillinger</a> og opdatér indstillingerne. <a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide#enable-twitter-logins" target="_blank">Se denne vejledning for mere information</a>.'
+    github_config_warning: 'Serveren er konfigureret til at tillade tilmelding og login med GitHub (enable_github_logins), men client id og secret værdierne er ikke angivet. Gå til <a href="%{base_url}/admin/site_settings">indstillinger</a> og opdatér indstillingerne. <a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide" target="_blank">Se denne vejledning for mere information</a>.'
+    failing_emails_warning: 'Der er %{num_failed_jobs} email operationer der mislykkede. Tjek din app.yml for at sikre at din mail server indstillinger er korrekte. <a href="%{base_url}/sidekiq/retries" target="_blank">Se mislykkede operationer i Sidekiq</a>.'
     subfolder_ends_in_slash: "Din undermappe er ikke opsat korrekt; DISCOURSE_RELATIVE_URL_ROOT ender med en slash."
     email_polling_errored_recently:
       one: "Email afstemning har afstedkommet en fejl i de seneste 24 timer. Venligst se <a href='/logs' target='_blank'>the logs</a> for detaljer."
@@ -1344,7 +1344,7 @@ da:
     search_title: "Søg på denne side"
   terms_of_service:
     title: "Vilkår"
-    signup_form_message: 'Jeg har læst og accepterer  <a href="/tos" target="_blank">vilkårene</a>.'
+    signup_form_message: 'Jeg har læst og accepterer  <a href="%{base_url}/tos" target="_blank">vilkårene</a>.'
   deleted: 'slettet'
   upload:
     unauthorized: "Beklager, filen, som du forsøger at uploade er ikke autoriseret (autoriserede filendelser: %{authorized_extensions})."

--- a/config/locales/server.de.yml
+++ b/config/locales/server.de.yml
@@ -670,8 +670,8 @@ de:
       email_body: "%{link}\n\n%{message}"
     inappropriate:
       title: 'Unangemessen'
-      description: 'Dieser Beitrag enthält Inhalte, die eine vernünftige Person als anstößig, beleidigend oder <a href="/guidelines">unsere Richtlinien verletzend</a> auffassen würde.'
-      short_description: 'Ein Verstoß gegen <a href="/guidelines">unsere Community-Richtlinien</a>'
+      description: 'Dieser Beitrag enthält Inhalte, die eine vernünftige Person als anstößig, beleidigend oder <a href="%{base_url}/guidelines">unsere Richtlinien verletzend</a> auffassen würde.'
+      short_description: 'Ein Verstoß gegen <a href="%{base_url}/guidelines">unsere Community-Richtlinien</a>'
       long_form: 'dies als unangemessen gemeldet'
     notify_user:
       title: 'Schreibe @{{username}} eine Nachricht'
@@ -720,12 +720,12 @@ de:
       short_description: 'Dies ist ist Werbung'
     inappropriate:
       title: 'Unangemessen'
-      description: 'Dieses Thema enthält Inhalte, die eine vernünftige Person als anstößig, beleidigend oder <a href="/guidelines">unsere Richtlinien verletzend</a> auffassen würde.'
+      description: 'Dieses Thema enthält Inhalte, die eine vernünftige Person als anstößig, beleidigend oder <a href="%{base_url}/guidelines">unsere Richtlinien verletzend</a> auffassen würde.'
       long_form: 'als unangemessen gemeldet'
-      short_description: 'Ein Verstoß gegen <a href="/guidelines">unsere Community-Richtlinien</a>'
+      short_description: 'Ein Verstoß gegen <a href="%{base_url}/guidelines">unsere Community-Richtlinien</a>'
     notify_moderators:
       title: "Irgendetwas anderes"
-      description: 'Dieser Beitrag erfordert die allgemeine Aufmerksamkeit des Teams, da er entweder nicht mit den <a href="/guidelines">Richtlinien</a> oder den <a href="%{tos_url}">Nutzungsbedingungen</a> in Einklang zu bringen ist, oder aus anderen Gründen.'
+      description: 'Dieser Beitrag erfordert die allgemeine Aufmerksamkeit des Teams, da er entweder nicht mit den <a href="%{base_url}/guidelines">Richtlinien</a> oder den <a href="%{tos_url}">Nutzungsbedingungen</a> in Einklang zu bringen ist, oder aus anderen Gründen.'
       long_form: ' hast dies den Moderatoren gemeldet'
       short_description: 'Erfordert aus einem anderen Grund die Aufmerksamkeit des Teams'
       email_title: 'Das Thema "%{title}" benötigt die Aufmerksamkeit eines Moderators'
@@ -1007,10 +1007,10 @@ de:
     sidekiq_warning: 'Sidekiq läuft nicht. Viele Aufgaben, wie zum Beispiel das Versenden von E-Mails, werden asynchron durch Sidekiq ausgeführt. Bitte stell sicher, dass mindestens ein Sidekiq-Prozess läuft. <a href="https://github.com/mperham/sidekiq">Mehr über Sidekiq erfährst du hier (en)</a>.'
     queue_size_warning: 'Eine hohe Anzahl an Aufgaben (%{queue_size}) befindet sich in der Warteschlange. Dies könnte auf ein Problem mit Sidekiq hinweisen oder du musst zusätzliche Sidekiq Worker starten.'
     memory_warning: 'Dein Server läuft mit weniger als 1 GB Hauptspeicher. Mindestens 1 GB Hauptspeicher werden empfohlen.'
-    google_oauth2_config_warning: 'Der Server ist für Anmeldung und Login mit Google OAuth2 (enable_google_oauth2_logins)  konfiguriert, aber die Client-ID und das Client-Gemeheimnis sind nicht gesetzt. Trage diese in den <a href="/admin/site_settings">Einstellung</a> ein. <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">Eine Anleitung zu diesem Thema findest du hier</a>.'
-    facebook_config_warning: 'Der Server erlaubt die Anmeldung mit Facebook (enable_facebook_logins), aber die App ID und der Geheimcode sind nicht gesetzt. Besuche <a href="/admin/site_settings">die Einstellungen</a> um die fehlenden Einträge hinzuzufügen. <a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide#enable-facebook-logins" target="_blank">Besuche den Leitfaden um mehr zu erfahren</a>.'
-    twitter_config_warning: 'Der Server erlaubt die Anmeldung mit Twitter (enable_twitter_logins), aber der Schlüssel und der Geheimcode sind nicht gesetzt. Besuche <a href="/admin/site_settings">die Einstellungen</a> um die fehlenden Einträge hinzuzufügen. <a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide#enable-twitter-logins" target="_blank">Besuche den Leitfaden um mehr zu erfahren</a>.'
-    github_config_warning: 'Der Server erlaubt die Anmeldung mit Facebook GitHub (enable_github_logins), aber die Kunden-ID und der Geheimcode sind nicht gesetzt. Besuche <a href="/admin/site_settings">die Einstellungen</a> um die fehlenden Einträge hinzuzufügen. <a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide" target="_blank">Besuche den Leitfaden um mehr zu erfahren</a>.'
+    google_oauth2_config_warning: 'Der Server ist für Anmeldung und Login mit Google OAuth2 (enable_google_oauth2_logins)  konfiguriert, aber die Client-ID und das Client-Gemeheimnis sind nicht gesetzt. Trage diese in den <a href="%{base_url}/admin/site_settings">Einstellung</a> ein. <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">Eine Anleitung zu diesem Thema findest du hier</a>.'
+    facebook_config_warning: 'Der Server erlaubt die Anmeldung mit Facebook (enable_facebook_logins), aber die App ID und der Geheimcode sind nicht gesetzt. Besuche <a href="%{base_url}/admin/site_settings">die Einstellungen</a> um die fehlenden Einträge hinzuzufügen. <a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide#enable-facebook-logins" target="_blank">Besuche den Leitfaden um mehr zu erfahren</a>.'
+    twitter_config_warning: 'Der Server erlaubt die Anmeldung mit Twitter (enable_twitter_logins), aber der Schlüssel und der Geheimcode sind nicht gesetzt. Besuche <a href="%{base_url}/admin/site_settings">die Einstellungen</a> um die fehlenden Einträge hinzuzufügen. <a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide#enable-twitter-logins" target="_blank">Besuche den Leitfaden um mehr zu erfahren</a>.'
+    github_config_warning: 'Der Server erlaubt die Anmeldung mit Facebook GitHub (enable_github_logins), aber die Kunden-ID und der Geheimcode sind nicht gesetzt. Besuche <a href="%{base_url}/admin/site_settings">die Einstellungen</a> um die fehlenden Einträge hinzuzufügen. <a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide" target="_blank">Besuche den Leitfaden um mehr zu erfahren</a>.'
     failing_emails_warning: "%{num_failed_jobs} E-Mails konnten nicht versendet werden. Überprüfe deine app.yml und stelle sicher, dass die E-Mail Servereinstellungen korrekt gesetzt sind. \n<a href=\"/sidekiq/retries\" target=\"_blank\">Sieh dir hier die nicht versendeten E-Mails an.</a>"
     subfolder_ends_in_slash: "Deine Installation in einem Pfad ist nicht korrekt, DISCOURSE_RELATIVE_URL_ROOT endet mit einem Schrägstrich."
     email_polling_errored_recently:
@@ -2716,7 +2716,7 @@ de:
       Ein Konto ist erforderlich. Bitte erstelle ein Konto oder melde dich an.
   terms_of_service:
     title: "Nutzungsbedingungen"
-    signup_form_message: 'Ich habe die <a href="/tos" target="_blank">Nutzungsbedingungen</a> gelesen und akzeptiert.'
+    signup_form_message: 'Ich habe die <a href="%{base_url}/tos" target="_blank">Nutzungsbedingungen</a> gelesen und akzeptiert.'
   deleted: 'gelöscht'
   image: "Bild"
   upload:

--- a/config/locales/server.el.yml
+++ b/config/locales/server.el.yml
@@ -548,8 +548,8 @@ el:
       email_body: "%{link}\n\n%{message}"
     inappropriate:
       title: 'Ανάρμοστο'
-      description: 'Το περιεχόμενο αυτής της δημοσίευσης θα θεωρούνταν από κάθε λογικό άνθρωπο, προσβλητικό, καταχρηστικό ή αντίθετο με τις  <a href="/guidelines">οδηγίες χρήσης της κοινότητάς μας</a>'
-      short_description: 'Παράβαση των <a href="/guidelines">Οδηγιών της Κοινότητας</a>'
+      description: 'Το περιεχόμενο αυτής της δημοσίευσης θα θεωρούνταν από κάθε λογικό άνθρωπο, προσβλητικό, καταχρηστικό ή αντίθετο με τις  <a href="%{base_url}/guidelines">οδηγίες χρήσης της κοινότητάς μας</a>'
+      short_description: 'Παράβαση των <a href="%{base_url}/guidelines">Οδηγιών της Κοινότητας</a>'
       long_form: 'το επισήμαναν ως ανάρμοστο'
     notify_user:
       title: 'Αποστολή μηνύματος στον @{{username}} '
@@ -592,11 +592,11 @@ el:
       long_form: 'το επισήμαναν ως ανεπιθύμητο'
     inappropriate:
       title: 'Ανάρμοστο'
-      description: 'Αυτό το θέμα έχει περιεχόμενο το οποίο θα θεωρούνταν από κάθε λογικό άνθρωπο προσβλητικό, καταχρηστικό ή αντίθετο με τις  <a href="/guidelines">οδηγίες χρήσης της κοινότητας μας</a>.'
+      description: 'Αυτό το θέμα έχει περιεχόμενο το οποίο θα θεωρούνταν από κάθε λογικό άνθρωπο προσβλητικό, καταχρηστικό ή αντίθετο με τις  <a href="%{base_url}/guidelines">οδηγίες χρήσης της κοινότητας μας</a>.'
       long_form: 'το επισήμαναν ως ανάρμοστο'
     notify_moderators:
       title: "Κάτι άλλο"
-      description: 'Το θέμα απαιτεί την γενική προσοχή του προσωπικού, βασισμένη στις <a href="/guidelines">κατευθυντήριες γραμμές</a>, τους<a href="%{tos_url}">όρους χρήσης</a> ή για άλλο λόγο που δεν αναφέρεται πιο πάνω.'
+      description: 'Το θέμα απαιτεί την γενική προσοχή του προσωπικού, βασισμένη στις <a href="%{base_url}/guidelines">κατευθυντήριες γραμμές</a>, τους<a href="%{tos_url}">όρους χρήσης</a> ή για άλλο λόγο που δεν αναφέρεται πιο πάνω.'
       long_form: 'το επισήμαναν για έλεγχο από συντονιστή'
       email_title: 'Το θέμα "%{title}" χρειάζεται έλεγχο από συντονιστή'
       email_body: "%{link}\n\n%{message}"
@@ -782,11 +782,11 @@ el:
       <a href="https://github.com/mperham/sidekiq" target="_blank">Περισσότερα για το Sidekiq εδώ</a>.'
     queue_size_warning: 'Ο αριθμός των εργασιών που βρίσκονται σε λίστα αναμονής  είναι %{queue_size}, το οποίο είναι υψηλό. Αυτό θα μπορούσε να ενδείξει πρόβλημα με τις λειτουργία(ες) του Sidekiq ή θα πρέπει να προσθέσετε κι άλλους Sidekiq εργάτες. '
     memory_warning: 'Ο server σας έχει λιγότερο από 1 GB διαθέσιμης μνήμης. Προτείνεται η χρήση τουλάχιστον 1 GB μνήμης.'
-    google_oauth2_config_warning: 'Ο server είναι ρυθμισμένος να επιτρέπει την εγγραφή και την είσοδο με Google OAuth2 (enable_google_oauth2_logins), αλλά η ταυτότητα του πελάτη και οι μυστικές τιμές δεν έχουν οριστεί. Πηγαίνετε στις <a href="/admin/site_settings">Ρυθμίσεις Σελίδας</a> και ανανεώστε τις ρυθμίσεις. <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">Δείτε τον οδηγό για περισσότερα</a>.'
-    facebook_config_warning: 'Ο server είναι ρυθμισμένος να επιτρέπει την εγγραφή και την είσοδο με Facebook (enable_facebook_logins), αλλά η ταυτότητα του πελάτη και οι μυστικές τιμές δεν έχουν οριστεί. Πηγαίνετε στις <a href="/admin/site_settings">Ρυθμίσεις Σελίδας</a> και ανανεώστε τις ρυθμίσεις. <a href="https://meta.discourse.org/t/configuring-facebook-login-for-discourse/13394" target="_blank">Δείτε τον οδηγό για περισσότερα</a>.'
-    twitter_config_warning: 'Ο server είναι ρυθμισμένος να επιτρέπει την εγγραφή και την είσοδο με Twitter  (enable_twitter_logins), αλλά η ταυτότητα του πελάτη και οι μυστικές τιμές δεν έχουν οριστεί. Πηγαίνετε στις <a href="/admin/site_settings">Ρυθμίσεις Σελίδας</a> και ανανεώστε τις ρυθμίσεις. <a href="https://meta.discourse.org/t/configuring-twitter-login-for-discourse/13395" target="_blank">Δείτε τον οδηγό για περισσότερα</a>.'
-    github_config_warning: 'Ο server είναι ρυθμισμένος να επιτρέπει την εγγραφή και την είσοδο με GitHub  (enable_github_logins), αλλά η ταυτότητα του πελάτη και οι μυστικές τιμές δεν έχουν οριστεί. Πηγαίνετε στις <a href="/admin/site_settings">Ρυθμίσεις Σελίδας</a> και ανανεώστε τις ρυθμίσεις. <a href="https://meta.discourse.org/t/configuring-github-login-for-discourse/13745" target="_blank">Δείτε τον οδηγό για περισσότερα</a>.'
-    failing_emails_warning: 'Υπάρχουν %{num_failed_jobs} εργασίες email οι οποίες απέτυχαν. Ελέγξτε το app.yml  και βεβαιωθείτε πως οι ρυθμίσεις του mail server σας είναι σωστές.  <a href="/sidekiq/retries" target="_blank">Δείτε τις αποτυχημένες εργασίες στο Sidekiq</a>.'
+    google_oauth2_config_warning: 'Ο server είναι ρυθμισμένος να επιτρέπει την εγγραφή και την είσοδο με Google OAuth2 (enable_google_oauth2_logins), αλλά η ταυτότητα του πελάτη και οι μυστικές τιμές δεν έχουν οριστεί. Πηγαίνετε στις <a href="%{base_url}/admin/site_settings">Ρυθμίσεις Σελίδας</a> και ανανεώστε τις ρυθμίσεις. <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">Δείτε τον οδηγό για περισσότερα</a>.'
+    facebook_config_warning: 'Ο server είναι ρυθμισμένος να επιτρέπει την εγγραφή και την είσοδο με Facebook (enable_facebook_logins), αλλά η ταυτότητα του πελάτη και οι μυστικές τιμές δεν έχουν οριστεί. Πηγαίνετε στις <a href="%{base_url}/admin/site_settings">Ρυθμίσεις Σελίδας</a> και ανανεώστε τις ρυθμίσεις. <a href="https://meta.discourse.org/t/configuring-facebook-login-for-discourse/13394" target="_blank">Δείτε τον οδηγό για περισσότερα</a>.'
+    twitter_config_warning: 'Ο server είναι ρυθμισμένος να επιτρέπει την εγγραφή και την είσοδο με Twitter  (enable_twitter_logins), αλλά η ταυτότητα του πελάτη και οι μυστικές τιμές δεν έχουν οριστεί. Πηγαίνετε στις <a href="%{base_url}/admin/site_settings">Ρυθμίσεις Σελίδας</a> και ανανεώστε τις ρυθμίσεις. <a href="https://meta.discourse.org/t/configuring-twitter-login-for-discourse/13395" target="_blank">Δείτε τον οδηγό για περισσότερα</a>.'
+    github_config_warning: 'Ο server είναι ρυθμισμένος να επιτρέπει την εγγραφή και την είσοδο με GitHub  (enable_github_logins), αλλά η ταυτότητα του πελάτη και οι μυστικές τιμές δεν έχουν οριστεί. Πηγαίνετε στις <a href="%{base_url}/admin/site_settings">Ρυθμίσεις Σελίδας</a> και ανανεώστε τις ρυθμίσεις. <a href="https://meta.discourse.org/t/configuring-github-login-for-discourse/13745" target="_blank">Δείτε τον οδηγό για περισσότερα</a>.'
+    failing_emails_warning: 'Υπάρχουν %{num_failed_jobs} εργασίες email οι οποίες απέτυχαν. Ελέγξτε το app.yml  και βεβαιωθείτε πως οι ρυθμίσεις του mail server σας είναι σωστές.  <a href="%{base_url}/sidekiq/retries" target="_blank">Δείτε τις αποτυχημένες εργασίες στο Sidekiq</a>.'
     subfolder_ends_in_slash: "Οι ρυθμίσεις του υποφακέλου σας δεν είναι σωστές. Το DISCOURSE_RELATIVE_URL_ROOT τελειώνει με κάθετη.  "
     email_polling_errored_recently:
       one: "To Email polling έχει παράγει ένα σφάλμα τις τελευταίες 24 ώρες . Δείτε <a href='/logs' target='_blank'>τα αρχεία καταγραφής</a> για περισσότερες λεπτομέρειες.   "
@@ -2174,7 +2174,7 @@ el:
       Παρακαλούμε δημιουργήστε έναν λογαριασμό ή συνδεθείτε για να συνεχίσετε..
   terms_of_service:
     title: "Όροι Χρήσης"
-    signup_form_message: 'Έχω διαβάσει και αποδέχομαι τους <a href="/tos" target="_blank">Όρους Χρήσης</a>.'
+    signup_form_message: 'Έχω διαβάσει και αποδέχομαι τους <a href="%{base_url}/tos" target="_blank">Όρους Χρήσης</a>.'
   deleted: 'διεγράφη'
   image: "εικόνα"
   upload:

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -770,8 +770,8 @@ en:
       email_body: "%{link}\n\n%{message}"
     inappropriate:
       title: 'Inappropriate'
-      description: 'This post contains content that a reasonable person would consider offensive, abusive, or a violation of <a href="/guidelines">our community guidelines</a>.'
-      short_description: 'A violation of <a href="/guidelines">our community guidelines</a>'
+      description: 'This post contains content that a reasonable person would consider offensive, abusive, or a violation of <a href="%{base_url}/guidelines">our community guidelines</a>.'
+      short_description: 'A violation of <a href="%{base_url}/guidelines">our community guidelines</a>'
       long_form: 'flagged this as inappropriate'
     notify_user:
       title: 'Send @{{username}} a message'
@@ -822,12 +822,12 @@ en:
       short_description: 'This is an advertisement'
     inappropriate:
       title: 'Inappropriate'
-      description: 'This topic contains content that a reasonable person would consider offensive, abusive, or a violation of <a href="/guidelines">our community guidelines</a>.'
+      description: 'This topic contains content that a reasonable person would consider offensive, abusive, or a violation of <a href="%{base_url}/guidelines">our community guidelines</a>.'
       long_form: 'flagged this as inappropriate'
-      short_description: 'A violation of <a href="/guidelines">our community guidelines</a>'
+      short_description: 'A violation of <a href="%{base_url}/guidelines">our community guidelines</a>'
     notify_moderators:
       title: "Something Else"
-      description: 'This topic requires general staff attention based on the <a href="/guidelines">guidelines</a>, <a href="%{tos_url}">TOS</a>, or for another reason not listed above.'
+      description: 'This topic requires general staff attention based on the <a href="%{base_url}/guidelines">guidelines</a>, <a href="%{tos_url}">TOS</a>, or for another reason not listed above.'
       long_form: 'flagged this for moderator attention'
       short_description: 'Requires staff attention for another reason'
       email_title: 'The topic "%{title}" requires moderator attention'
@@ -1117,14 +1117,14 @@ en:
     sidekiq_warning: 'Sidekiq is not running. Many tasks, like sending emails, are executed asynchronously by sidekiq. Please ensure at least one sidekiq process is running. <a href="https://github.com/mperham/sidekiq" target="_blank">Learn about Sidekiq here</a>.'
     queue_size_warning: 'The number of queued jobs is %{queue_size}, which is high. This could indicate a problem with the Sidekiq process(es), or you may need to add more Sidekiq workers.'
     memory_warning: 'Your server is running with less than 1 GB of total memory. At least 1 GB of memory is recommended.'
-    google_oauth2_config_warning: 'The server is configured to allow signup and log in with Google OAuth2 (enable_google_oauth2_logins), but the client id and client secret values are not set. Go to <a href="/admin/site_settings">the Site Settings</a> and update the settings. <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">See this guide to learn more</a>.'
-    facebook_config_warning: 'The server is configured to allow signup and log in with Facebook (enable_facebook_logins), but the app id and app secret values are not set. Go to <a href="/admin/site_settings">the Site Settings</a> and update the settings. <a href="https://meta.discourse.org/t/configuring-facebook-login-for-discourse/13394" target="_blank">See this guide to learn more</a>.'
-    twitter_config_warning: 'The server is configured to allow signup and log in with Twitter (enable_twitter_logins), but the key and secret values are not set. Go to <a href="/admin/site_settings">the Site Settings</a> and update the settings. <a href="https://meta.discourse.org/t/configuring-twitter-login-for-discourse/13395" target="_blank">See this guide to learn more</a>.'
-    github_config_warning: 'The server is configured to allow signup and log in with GitHub (enable_github_logins), but the client id and secret values are not set. Go to <a href="/admin/site_settings">the Site Settings</a> and update the settings. <a href="https://meta.discourse.org/t/configuring-github-login-for-discourse/13745" target="_blank">See this guide to learn more</a>.'
-    s3_config_warning: 'The server is configured to upload files to s3, but at least one the following setting is not set: s3_access_key_id, s3_secret_access_key, s3_use_iam_profile, or s3_upload_bucket. Go to <a href="/admin/site_settings">the Site Settings</a> and update the settings. <a href="https://meta.discourse.org/t/how-to-set-up-image-uploads-to-s3/7229" target="_blank">See "How to set up image uploads to S3?" to learn more</a>.'
-    s3_backup_config_warning: 'The server is configured to upload backups to s3, but at least one the following setting is not set: s3_access_key_id, s3_secret_access_key, s3_use_iam_profile, or s3_backup_bucket. Go to <a href="/admin/site_settings">the Site Settings</a> and update the settings. <a href="https://meta.discourse.org/t/how-to-set-up-image-uploads-to-s3/7229" target="_blank">See "How to set up image uploads to S3?" to learn more</a>.'
+    google_oauth2_config_warning: 'The server is configured to allow signup and log in with Google OAuth2 (enable_google_oauth2_logins), but the client id and client secret values are not set. Go to <a href="%{base_url}/admin/site_settings">the Site Settings</a> and update the settings. <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">See this guide to learn more</a>.'
+    facebook_config_warning: 'The server is configured to allow signup and log in with Facebook (enable_facebook_logins), but the app id and app secret values are not set. Go to <a href="%{base_url}/admin/site_settings">the Site Settings</a> and update the settings. <a href="https://meta.discourse.org/t/configuring-facebook-login-for-discourse/13394" target="_blank">See this guide to learn more</a>.'
+    twitter_config_warning: 'The server is configured to allow signup and log in with Twitter (enable_twitter_logins), but the key and secret values are not set. Go to <a href="%{base_url}/admin/site_settings">the Site Settings</a> and update the settings. <a href="https://meta.discourse.org/t/configuring-twitter-login-for-discourse/13395" target="_blank">See this guide to learn more</a>.'
+    github_config_warning: 'The server is configured to allow signup and log in with GitHub (enable_github_logins), but the client id and secret values are not set. Go to <a href="%{base_url}/admin/site_settings">the Site Settings</a> and update the settings. <a href="https://meta.discourse.org/t/configuring-github-login-for-discourse/13745" target="_blank">See this guide to learn more</a>.'
+    s3_config_warning: 'The server is configured to upload files to s3, but at least one the following setting is not set: s3_access_key_id, s3_secret_access_key, s3_use_iam_profile, or s3_upload_bucket. Go to <a href="%{base_url}/admin/site_settings">the Site Settings</a> and update the settings. <a href="https://meta.discourse.org/t/how-to-set-up-image-uploads-to-s3/7229" target="_blank">See "How to set up image uploads to S3?" to learn more</a>.'
+    s3_backup_config_warning: 'The server is configured to upload backups to s3, but at least one the following setting is not set: s3_access_key_id, s3_secret_access_key, s3_use_iam_profile, or s3_backup_bucket. Go to <a href="%{base_url}/admin/site_settings">the Site Settings</a> and update the settings. <a href="https://meta.discourse.org/t/how-to-set-up-image-uploads-to-s3/7229" target="_blank">See "How to set up image uploads to S3?" to learn more</a>.'
     image_magick_warning: 'The server is configured to create thumbnails of large images, but ImageMagick is not installed. Install ImageMagick using your favorite package manager or <a href="https://www.imagemagick.org/script/download.php" target="_blank">download the latest release</a>.'
-    failing_emails_warning: 'There are %{num_failed_jobs} email jobs that failed. Check your app.yml and ensure that the mail server settings are correct. <a href="/sidekiq/retries" target="_blank">See the failed jobs in Sidekiq</a>.'
+    failing_emails_warning: 'There are %{num_failed_jobs} email jobs that failed. Check your app.yml and ensure that the mail server settings are correct. <a href="%{base_url}/sidekiq/retries" target="_blank">See the failed jobs in Sidekiq</a>.'
     subfolder_ends_in_slash: "Your subfolder setup is incorrect; the DISCOURSE_RELATIVE_URL_ROOT ends in a slash."
     email_polling_errored_recently:
       one: "Email polling has generated an error in the past 24 hours. Look at <a href='/logs' target='_blank'>the logs</a> for more details."
@@ -3238,7 +3238,7 @@ en:
 
   terms_of_service:
     title: "Terms of Service"
-    signup_form_message: 'I have read and accept the <a href="/tos" target="_blank">Terms of Service</a>.'
+    signup_form_message: 'I have read and accept the <a href="%{base_url}/tos" target="_blank">Terms of Service</a>.'
 
   deleted: 'deleted'
 

--- a/config/locales/server.es.yml
+++ b/config/locales/server.es.yml
@@ -644,8 +644,8 @@ es:
       email_body: "%{link}\n\n%{message}"
     inappropriate:
       title: 'Inapropiado'
-      description: 'Este post contiene contenido que una persona sensata podría considerar ofensivo, abusivo o que viola <a href="/guidelines">nuestras directrices de comunidad</a>.'
-      short_description: 'Una violación a las <a href="/guidelines">guías de nuestra comunidad</a>'
+      description: 'Este post contiene contenido que una persona sensata podría considerar ofensivo, abusivo o que viola <a href="%{base_url}/guidelines">nuestras directrices de comunidad</a>.'
+      short_description: 'Una violación a las <a href="%{base_url}/guidelines">guías de nuestra comunidad</a>'
       long_form: 'reportado como inapropiado'
     notify_user:
       title: 'Enviar un mensaje a @{{username}}'
@@ -694,12 +694,12 @@ es:
       short_description: 'Esto es un anuncio'
     inappropriate:
       title: 'Inapropiado'
-      description: 'Este tema contiene material que una persona sensata podría considerar ofensivo, abusivo, o que viola <a href="/guidelines">las directrices de nuestra comunidad</a>.'
+      description: 'Este tema contiene material que una persona sensata podría considerar ofensivo, abusivo, o que viola <a href="%{base_url}/guidelines">las directrices de nuestra comunidad</a>.'
       long_form: 'marcado como inapropiado'
-      short_description: 'Incumple <a href="/guidelines">nuestras directrices de la comunidad</a>'
+      short_description: 'Incumple <a href="%{base_url}/guidelines">nuestras directrices de la comunidad</a>'
     notify_moderators:
       title: "Notificar a los moderadores"
-      description: 'Este tema requiere atención del equipo de moderación basándose en las <a href="/guidelines">pautas de la comunidad</a> o los  <a href="%{tos_url}">Términos y condiciones</a>, o por otra razón no especificada arriba.'
+      description: 'Este tema requiere atención del equipo de moderación basándose en las <a href="%{base_url}/guidelines">pautas de la comunidad</a> o los  <a href="%{tos_url}">Términos y condiciones</a>, o por otra razón no especificada arriba.'
       long_form: 'reportado para atención de los moderadores'
       short_description: 'Requiere atención del staff por otro motivo'
       email_title: 'El tema "%{title}" requiere la atención de un moderador'
@@ -978,11 +978,11 @@ es:
     sidekiq_warning: 'Sidekiq no está funcionando. Muchas tareas, por ejemplo el envío de correos, están realizadas desincronizadamente por sidekiq. Por favor asegúrate de que por lo menos un proceso de sidekiq está funcionando. <a href="https://github.com/mperham/sidekiq" target="_blank">Learn about Sidekiq here</a>.'
     queue_size_warning: 'El número de jobs en cola es %{queue_size}, se trata de una cifra alta. Esto podría indicar un problema en el proceso (o procesos) de Sidekiq, o quizá se deba añadir más Sidekiq workers.'
     memory_warning: 'Tu servidor está funcionando con menos de 1 GB de memoria total. Por lo menos 1 GB de memoria es recomendado.'
-    google_oauth2_config_warning: 'El servidor está configurado para permitir el registro e inicio de sesión con Google OAuth2 (enable_google_oauth2_logins), pero los valores client id y client secret están vacíos. Ve a <a href="/admin/site_settings">Ajustes del sitio</a> y actualiza la configuración. <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">Mira esta guía para saber más</a>.'
-    facebook_config_warning: 'El servidor está configurado para permitir crear una cuenta e ingresar utilizando Facebook (enable_facebook_logins), pero los valores id y secreto de la app no están configurados. Ingresa a <a href="/admin/site_settings">la Configuración del Sitio</a> y actualiza la configuración. <a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide#enable-facebook-logins" target="_blank">Revisa la guía para aprender más</a>.'
-    twitter_config_warning: 'El servidor está configurado para permitir crear una cuenta e ingresar utilizando Twitter (enable_twitter_logins), pero los valores clave y secreto de la app no están configurados. Ingresa a <a href="/admin/site_settings">la Configuración del Sitio</a> y actualiza la configuración. <a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide#enable-twitter-logins" target="_blank">Revisa la guía para aprender más</a>.'
-    github_config_warning: 'El servidor está configurado para permitir crear una cuenta e ingresar utilizando GitHub (enable_github_logins), pero los valores de cliente clave y cliente secreto no están configurados. Ingresa a <a href="/admin/site_settings">la Configuración del Sitio</a> y actualiza la configuración. <a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide" target="_blank">Revisa la guía para aprender más</a>.'
-    failing_emails_warning: 'Hay %{num_failed_jobs} jobs de email que fallaron. Revisa tu app.yml y asegúrate que la configuración del servidor de mail es correcta. <a href="/sidekiq/retries" target="_blank">Mira los jobs fallados en Sidekiq</a>.'
+    google_oauth2_config_warning: 'El servidor está configurado para permitir el registro e inicio de sesión con Google OAuth2 (enable_google_oauth2_logins), pero los valores client id y client secret están vacíos. Ve a <a href="%{base_url}/admin/site_settings">Ajustes del sitio</a> y actualiza la configuración. <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">Mira esta guía para saber más</a>.'
+    facebook_config_warning: 'El servidor está configurado para permitir crear una cuenta e ingresar utilizando Facebook (enable_facebook_logins), pero los valores id y secreto de la app no están configurados. Ingresa a <a href="%{base_url}/admin/site_settings">la Configuración del Sitio</a> y actualiza la configuración. <a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide#enable-facebook-logins" target="_blank">Revisa la guía para aprender más</a>.'
+    twitter_config_warning: 'El servidor está configurado para permitir crear una cuenta e ingresar utilizando Twitter (enable_twitter_logins), pero los valores clave y secreto de la app no están configurados. Ingresa a <a href="%{base_url}/admin/site_settings">la Configuración del Sitio</a> y actualiza la configuración. <a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide#enable-twitter-logins" target="_blank">Revisa la guía para aprender más</a>.'
+    github_config_warning: 'El servidor está configurado para permitir crear una cuenta e ingresar utilizando GitHub (enable_github_logins), pero los valores de cliente clave y cliente secreto no están configurados. Ingresa a <a href="%{base_url}/admin/site_settings">la Configuración del Sitio</a> y actualiza la configuración. <a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide" target="_blank">Revisa la guía para aprender más</a>.'
+    failing_emails_warning: 'Hay %{num_failed_jobs} jobs de email que fallaron. Revisa tu app.yml y asegúrate que la configuración del servidor de mail es correcta. <a href="%{base_url}/sidekiq/retries" target="_blank">Mira los jobs fallados en Sidekiq</a>.'
     subfolder_ends_in_slash: "La configuación del subdirectorio no es correcta; el campo DISCOURSE_RELATIVE_URL_ROOT termina con una barra."
     email_polling_errored_recently:
       one: "El email polling ha generado un error en las pasadas 24 horas. Mira en <a href='/logs' target='_blank'>los logs</a> para más detalles."
@@ -2643,7 +2643,7 @@ es:
       Una cuenta es requerida. Por favor cree una cuenta o inicie sesión para continuar.
   terms_of_service:
     title: "Condiciones Generales de Uso"
-    signup_form_message: 'He leído y acepto las <a href="/tos" target="_blank">Condiciones de Servicio</a>.'
+    signup_form_message: 'He leído y acepto las <a href="%{base_url}/tos" target="_blank">Condiciones de Servicio</a>.'
   deleted: 'borrado'
   image: "imagen"
   upload:

--- a/config/locales/server.et.yml
+++ b/config/locales/server.et.yml
@@ -449,7 +449,7 @@ et:
       email_body: "%{link}\n\n%{message}"
     inappropriate:
       title: 'Ebasünnis'
-      description: 'Selle postituse sisu on iga mõistliku inimese hinnangul solvav, ahistav või rikub <a href="/guidelines">meie kommuuni reegleid</a>.'
+      description: 'Selle postituse sisu on iga mõistliku inimese hinnangul solvav, ahistav või rikub <a href="%{base_url}/guidelines">meie kommuuni reegleid</a>.'
       long_form: 'tähistasin selle kui sobimatu'
     notify_user:
       title: 'Saada kasutajale @{{username}} sõnum'
@@ -483,11 +483,11 @@ et:
       long_form: 'tähistasin selle kui spämmi'
     inappropriate:
       title: 'Ebasobiv'
-      description: 'Selle teema sisu on iga mõistliku inimese hinnangu järgi solvav, ahistav või rikub <a href="/guidelines">meie kommuuni reegleid</a>.'
+      description: 'Selle teema sisu on iga mõistliku inimese hinnangu järgi solvav, ahistav või rikub <a href="%{base_url}/guidelines">meie kommuuni reegleid</a>.'
       long_form: 'tähistasin selle kui sobimatu'
     notify_moderators:
       title: "Miski muu"
-      description: 'See teema vajab saidi meeskonna tähelepanu tulenevalt <a href="/guidelines">juhisest</a>, <a href="%{tos_url}">kasutustingimustest</a> või mõnest muust põhjusest, mida pole siin mainitud.'
+      description: 'See teema vajab saidi meeskonna tähelepanu tulenevalt <a href="%{base_url}/guidelines">juhisest</a>, <a href="%{tos_url}">kasutustingimustest</a> või mõnest muust põhjusest, mida pole siin mainitud.'
       long_form: 'tähistasin selle kui moderaatori tähelepanu vajava'
       email_title: 'Teema "%{title}" nõuab moderaatori tähelepanu'
       email_body: "%{link}\n\n%{message}"

--- a/config/locales/server.fa_IR.yml
+++ b/config/locales/server.fa_IR.yml
@@ -533,8 +533,8 @@ fa_IR:
       email_body: "%{link}\n\n%{message}"
     inappropriate:
       title: 'نامناسب'
-      description: 'محتوای این موضوع شامل مواردی میشود که یک شخص می تونه آن را  توهین آمیز، آزار دهنده، یا نقض کننده قوانین باشد <a href="/guidelines"> راهنمای انجمن</a>.'
-      short_description: 'نقض  <a href="/guidelines">راهنمای انجمن</a>'
+      description: 'محتوای این موضوع شامل مواردی میشود که یک شخص می تونه آن را  توهین آمیز، آزار دهنده، یا نقض کننده قوانین باشد <a href="%{base_url}/guidelines"> راهنمای انجمن</a>.'
+      short_description: 'نقض  <a href="%{base_url}/guidelines">راهنمای انجمن</a>'
       long_form: 'به عنوان نامناسب علامت گذاری شده'
     notify_user:
       title: 'فرستادن پیام به @{{username}}'
@@ -574,11 +574,11 @@ fa_IR:
       long_form: 'پرچم‌گذاری به عنوان یک هرزنامه'
     inappropriate:
       title: 'نامناسب'
-      description: 'محتوای این موضوع شامل مواردی میشود که یک شخص می‌تواند آن را  توهین آمیز، آزار دهنده، یا نقض  قوانین انجمن باشد. <a href="/guidelines">راهنمای انجمن</a>.'
+      description: 'محتوای این موضوع شامل مواردی میشود که یک شخص می‌تواند آن را  توهین آمیز، آزار دهنده، یا نقض  قوانین انجمن باشد. <a href="%{base_url}/guidelines">راهنمای انجمن</a>.'
       long_form: 'پرچم گذاری شده به عنوان نامناسب'
     notify_moderators:
       title: "یک چیز دیگر"
-      description: 'این موضوع نیاز به توجه همکاران بر اساس <a href="/guidelines">guidelines</a>, <a href="%{tos_url}">شرایط استفاده از خدمات</a>، دارد یا یک دلیل دیگر که در بالا ذکر نشده.'
+      description: 'این موضوع نیاز به توجه همکاران بر اساس <a href="%{base_url}/guidelines">guidelines</a>, <a href="%{tos_url}">شرایط استفاده از خدمات</a>، دارد یا یک دلیل دیگر که در بالا ذکر نشده.'
       long_form: 'این را برای توجه مدیر پرچم گذاری کن'
       email_title: 'موضوع "%{title}" نیاز به توجه مدیر دارد. '
       email_body: "%{link}\n\n%{message}"
@@ -761,11 +761,11 @@ fa_IR:
     sidekiq_warning: 'Sidekiq کار نمی کند. کار‌های زیادی مثل ارسال ایمیل ها، برای اجرا نیازمند sidekiq هستند. لطفا مطمئن شوید که حداقل یک پروسه sidekiq کار می‌کند.  <a href="https://github.com/mperham/sidekiq" target="_blank"> درباره Sidekiq  بیشتر بدانید.</a>'
     queue_size_warning: 'تعداد کار های زمانبندی شده %{queue_size}، که مقدار بالاییست. این مسئله می‌تواند باعث بروز مشکل در پردازش(های) Sidekiq شود، یا می‌توانید عامل‌های Sidekiq  بیشتری اضافه کنید.'
     memory_warning: 'سرور شما با کمتر از 1 گیگ رم راه اندازی شده است، برای دیسکورس حداقل 1 گیگ رم لازم است تا به درستی کار کند.'
-    google_oauth2_config_warning: 'سرور تنظیم شده تا اجازه دهد برای  ثبت نام و وارد شدن با Google OAuth2 (enable_google_oauth2_logins), ولی clientid و client secret تنظیم نشده است. به <a href="/admin/site_settings">تنظیمات سایت</a> بروید و تنظیمات را به‌روز کنید.  <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">اطلاعات بیشتر</a>.'
-    facebook_config_warning: 'سرور تنظیم شده تا اجازه ثبت نام و وارد شدن یا فیس بوک را بدهد. (enable_facebook_logins)، ولی app id و app secret تنظیم نشده است. به <a href="/admin/site_settings"> بروید و </a> و تنظیمات سایت را تغییر دهید.  <a href="https://meta.discourse.org/t/configuring-facebook-login-for-discourse/13394" target="_blank">اطلاعات بیشتر</a>.'
-    twitter_config_warning: 'سرور تنظیم شده تا اجازه ثبت نام و وارد شدن با توییتر را بدهد (enable_twitter_logins), مقدار key و secret تنظیم نشده است. به <a href="/admin/site_settings"> تنظیمات سایت </a>  رفته و مقادیر را بروز کنید. <a href="https://meta.discourse.org/t/configuring-twitter-login-for-discourse/13395" target="_blank">اطلاعات بیشتر</a>.'
-    github_config_warning: 'سرور تنظیم شده تا اجازه ثبت نام و وارد شدن با GitHub را بدهد (enable_github_logins), ولی مقادیر client id و secret وارد نشده اند. به <a href="/admin/site_settings"> تنظیمات سایت </a> رفته و مقادیر را تنظیم کنید.  <a href="https://meta.discourse.org/t/configuring-github-login-for-discourse/13745" target="_blank">توضیحات بیشتر</a>.'
-    failing_emails_warning: '%{num_failed_jobs} ایمیل زمانبندی شده نا‌موفق وجود دارد. فایل app.yml  را بررسی کنید و مطمئن شوید که تنظیمات سرور ایمیل درست است.  <a href="/sidekiq/retries" target="_blank"> نمایش زمابندی‌های ناموفق Sidekiq </a>.'
+    google_oauth2_config_warning: 'سرور تنظیم شده تا اجازه دهد برای  ثبت نام و وارد شدن با Google OAuth2 (enable_google_oauth2_logins), ولی clientid و client secret تنظیم نشده است. به <a href="%{base_url}/admin/site_settings">تنظیمات سایت</a> بروید و تنظیمات را به‌روز کنید.  <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">اطلاعات بیشتر</a>.'
+    facebook_config_warning: 'سرور تنظیم شده تا اجازه ثبت نام و وارد شدن یا فیس بوک را بدهد. (enable_facebook_logins)، ولی app id و app secret تنظیم نشده است. به <a href="%{base_url}/admin/site_settings"> بروید و </a> و تنظیمات سایت را تغییر دهید.  <a href="https://meta.discourse.org/t/configuring-facebook-login-for-discourse/13394" target="_blank">اطلاعات بیشتر</a>.'
+    twitter_config_warning: 'سرور تنظیم شده تا اجازه ثبت نام و وارد شدن با توییتر را بدهد (enable_twitter_logins), مقدار key و secret تنظیم نشده است. به <a href="%{base_url}/admin/site_settings"> تنظیمات سایت </a>  رفته و مقادیر را بروز کنید. <a href="https://meta.discourse.org/t/configuring-twitter-login-for-discourse/13395" target="_blank">اطلاعات بیشتر</a>.'
+    github_config_warning: 'سرور تنظیم شده تا اجازه ثبت نام و وارد شدن با GitHub را بدهد (enable_github_logins), ولی مقادیر client id و secret وارد نشده اند. به <a href="%{base_url}/admin/site_settings"> تنظیمات سایت </a> رفته و مقادیر را تنظیم کنید.  <a href="https://meta.discourse.org/t/configuring-github-login-for-discourse/13745" target="_blank">توضیحات بیشتر</a>.'
+    failing_emails_warning: '%{num_failed_jobs} ایمیل زمانبندی شده نا‌موفق وجود دارد. فایل app.yml  را بررسی کنید و مطمئن شوید که تنظیمات سرور ایمیل درست است.  <a href="%{base_url}/sidekiq/retries" target="_blank"> نمایش زمابندی‌های ناموفق Sidekiq </a>.'
     subfolder_ends_in_slash: "تنظیمات زیرپوشه نادرست است، مقدار DISCOURSE_RELATIVE_URL_ROOT با نویسه‌ی slash تمام می‌شود."
     email_polling_errored_recently:
       one: "رای‌گیری ایمیلی %{count} خطا در 24 ساعت گذشته ایجاد کرده. <a href='/logs' target='_blank'>گزارشات</a> را ببینید."
@@ -1944,7 +1944,7 @@ fa_IR:
       داشتن حساب کاربری الزامی است. لطفا یک حساب کاربری بسازید یا وارد شوید.
   terms_of_service:
     title: "شرایط استفاده از خدمات"
-    signup_form_message: 'من  <a href="/tos" target="_blank">شرایط استفاده از خدمات</a> را خواندم و قبول می‌کنم.'
+    signup_form_message: 'من  <a href="%{base_url}/tos" target="_blank">شرایط استفاده از خدمات</a> را خواندم و قبول می‌کنم.'
   deleted: 'حذف شد'
   image: "تصویر"
   upload:
@@ -2003,7 +2003,7 @@ fa_IR:
       description: یک پسند دریافت کرده‌اید
     autobiographer:
       name: نویسنده شرح‌حال
-      description: اطلاعات <a href="/my/preferences">صفحه شخصی</a>  خود را تکمیل کرده
+      description: اطلاعات <a href="%{base_url}/my/preferences">صفحه شخصی</a>  خود را تکمیل کرده
     anniversary:
       name: سالگرد
       description: برای یک سال کاربر فعال بوده، حداقل یک نوشته دارد.

--- a/config/locales/server.fi.yml
+++ b/config/locales/server.fi.yml
@@ -692,8 +692,8 @@ fi:
       email_body: "%{link}\n\n%{message}"
     inappropriate:
       title: 'Sopimaton'
-      description: 'Viestin sisältö on loukkaava, herjaava tai ristiriidassa <a href="/guidelines">palstan sääntöjen</a> kanssa.'
-      short_description: '<a href="/guidelines">Palstan sääntöjen</a> vastainen'
+      description: 'Viestin sisältö on loukkaava, herjaava tai ristiriidassa <a href="%{base_url}/guidelines">palstan sääntöjen</a> kanssa.'
+      short_description: '<a href="%{base_url}/guidelines">Palstan sääntöjen</a> vastainen'
       long_form: 'liputti tämän sopimattomaksi'
     notify_user:
       title: 'Lähetä käyttäjälle @{{username}} viesti.'
@@ -742,12 +742,12 @@ fi:
       short_description: 'Tämä on mainos'
     inappropriate:
       title: 'Sopimaton'
-      description: 'Ketjussa on loukkaavaa, herjaavaa tai <a href="/guidelines">palstan sääntöjen</a> kanssa ristiriitaista sisältöä.'
+      description: 'Ketjussa on loukkaavaa, herjaavaa tai <a href="%{base_url}/guidelines">palstan sääntöjen</a> kanssa ristiriitaista sisältöä.'
       long_form: 'liputti tämän sopimattomaksi'
-      short_description: '<a href="/guidelines">Palstan sääntöjen</a> vastainen'
+      short_description: '<a href="%{base_url}/guidelines">Palstan sääntöjen</a> vastainen'
     notify_moderators:
       title: "Jotain muuta"
-      description: 'Valvojan tulee huomioida tämä ketju <a href="/guidelines">palstan sääntöjen</a>, <a href="%{tos_url}">palveluehtojen</a> tai jonkun muun syyn vuoksi.'
+      description: 'Valvojan tulee huomioida tämä ketju <a href="%{base_url}/guidelines">palstan sääntöjen</a>, <a href="%{tos_url}">palveluehtojen</a> tai jonkun muun syyn vuoksi.'
       long_form: 'liputit tämän valvojille tiedoksi'
       short_description: 'Henkilökunnan tulisi huomioida muusta syystä'
       email_title: 'Ketju"%{title}" kaipaa valvojan huomiota'
@@ -1029,11 +1029,11 @@ fi:
     sidekiq_warning: 'Sidekiq ei ole käynnissä. Monet tehtävät, kuten sähköpostien lähettäminen, suoritetaan asynkronisesti sidekiqin avulla. Varmista, että vähintään yksi sidekiq prosessi on käynnissä. <a href="https://github.com/mperham/sidekiq" target="_blank">Opiskele lisää Sidekiqista täältä</a>.'
     queue_size_warning: 'Jonossa olevien tehtävien määrä on %{queue_size}, joka on korkea. Tämä voi olla merkki ongelmista Sidekiq prosess(e)issa tai sinun voi täytyä lisätä Sidekiq workerien määrää.'
     memory_warning: 'Palvelimella on alle 1GB muistia. Vähintään 1 GB muistia on suositeltavaa.'
-    google_oauth2_config_warning: 'Palvelin on konfiguroitu hyväksymään liittyminen Google OAuth2:n kautta (enable_google_oauth2_logins), mutta client id ja client secret arvoja ei ole asetettu. Päivitä arvot <a href="/admin/site_settings">sivuston asetuksissa</a>.Voit lukea lisätietoja <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">tästä oppaasta</a>.'
-    facebook_config_warning: 'Palvelin on konfiguroitu hyväksymään liittyminen Facebookin kautta (enable_facebook_logins), mutta app id ja app secret arvoja ei ole asetettu. Päivitä arvot <a href="/admin/site_settings">sivuston asetuksissa</a>.Voit lukea lisätietoja <a href="https://meta.discourse.org/t/configuring-facebook-login-for-discourse/13394" target="_blank">tästä oppaasta</a>.'
-    twitter_config_warning: 'Palvelin on konfiguroitu hyväksymään liittyminen Twitterin kautta (enable_twitter_logins), mutta salaisia arvoja ei ole asetettu. Päivitä arvot <a href="/admin/site_settings">sivuston asetuksissa</a>. Voit lukea lisätietoja <a href="https://meta.discourse.org/t/configuring-twitter-login-for-discourse/13395" target="_blank">tästä oppaasta</a>.'
-    github_config_warning: 'Palvelin on konfiguroitu hyväksymään liittyminen Githubin kautta (enable_github_logins), mutta client id ja app secret arvoja ei ole asetettu. Päivitä arvot <a href="/admin/site_settings">sivuston asetuksissa</a>.Voit lukea lisätietoja <a href="https://meta.discourse.org/t/configuring-github-login-for-discourse/13745" target="_blank">tästä oppaasta</a>.'
-    failing_emails_warning: 'Epäonnistuneiden sähköpostitehtävien määrä on %{num_failed_jobs}. Tarkista app.yml ja varmista, että palvelimen asetukset ovat kunnossa. <a href="/sidekiq/retries" target="_blank">Katsele epäonnistuneita tehtäviä Sidekiqissa</a>.'
+    google_oauth2_config_warning: 'Palvelin on konfiguroitu hyväksymään liittyminen Google OAuth2:n kautta (enable_google_oauth2_logins), mutta client id ja client secret arvoja ei ole asetettu. Päivitä arvot <a href="%{base_url}/admin/site_settings">sivuston asetuksissa</a>.Voit lukea lisätietoja <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">tästä oppaasta</a>.'
+    facebook_config_warning: 'Palvelin on konfiguroitu hyväksymään liittyminen Facebookin kautta (enable_facebook_logins), mutta app id ja app secret arvoja ei ole asetettu. Päivitä arvot <a href="%{base_url}/admin/site_settings">sivuston asetuksissa</a>.Voit lukea lisätietoja <a href="https://meta.discourse.org/t/configuring-facebook-login-for-discourse/13394" target="_blank">tästä oppaasta</a>.'
+    twitter_config_warning: 'Palvelin on konfiguroitu hyväksymään liittyminen Twitterin kautta (enable_twitter_logins), mutta salaisia arvoja ei ole asetettu. Päivitä arvot <a href="%{base_url}/admin/site_settings">sivuston asetuksissa</a>. Voit lukea lisätietoja <a href="https://meta.discourse.org/t/configuring-twitter-login-for-discourse/13395" target="_blank">tästä oppaasta</a>.'
+    github_config_warning: 'Palvelin on konfiguroitu hyväksymään liittyminen Githubin kautta (enable_github_logins), mutta client id ja app secret arvoja ei ole asetettu. Päivitä arvot <a href="%{base_url}/admin/site_settings">sivuston asetuksissa</a>.Voit lukea lisätietoja <a href="https://meta.discourse.org/t/configuring-github-login-for-discourse/13745" target="_blank">tästä oppaasta</a>.'
+    failing_emails_warning: 'Epäonnistuneiden sähköpostitehtävien määrä on %{num_failed_jobs}. Tarkista app.yml ja varmista, että palvelimen asetukset ovat kunnossa. <a href="%{base_url}/sidekiq/retries" target="_blank">Katsele epäonnistuneita tehtäviä Sidekiqissa</a>.'
     subfolder_ends_in_slash: "Alihakemiston asetuksesi ei kelpaa; DISCOURSE_RELATIVE_URL_ROOT päättyy vinoviivaan."
     email_polling_errored_recently:
       one: "Sähköpostin pollaus on aiheuttanut virheen edellisen 24 tunnin aikana. Tarkastele <a href='/logs' target='_blank'>lokeja</a> saadaksesi lisätietoja."
@@ -2711,7 +2711,7 @@ fi:
       Käyttäjätili tarvitaan. Luo tili tai kirjaudu sisään.
   terms_of_service:
     title: "Käyttöehdot"
-    signup_form_message: 'Olen lukenut ja ymmärtänyt <a href="/tos" target="_blank">Käyttöehdot</a>.'
+    signup_form_message: 'Olen lukenut ja ymmärtänyt <a href="%{base_url}/tos" target="_blank">Käyttöehdot</a>.'
   deleted: 'poistettu'
   image: "kuva"
   upload:

--- a/config/locales/server.fr.yml
+++ b/config/locales/server.fr.yml
@@ -644,8 +644,8 @@ fr:
       email_body: "%{link}\n\n%{message}"
     inappropriate:
       title: 'Inapproprié'
-      description: 'Ce message contient du contenu qu''une personne raisonnable jugerait offensant, abusif ou en violation de la <a href="/guidelines">charte de notre communauté</a>.'
-      short_description: 'Une violation de <a href="/guidelines">la charte de notre communauté</a>'
+      description: 'Ce message contient du contenu qu''une personne raisonnable jugerait offensant, abusif ou en violation de la <a href="%{base_url}/guidelines">charte de notre communauté</a>.'
+      short_description: 'Une violation de <a href="%{base_url}/guidelines">la charte de notre communauté</a>'
       long_form: 'signalé comme inapproprié'
     notify_user:
       title: 'Envoyer un message à @{{username}} '
@@ -694,9 +694,9 @@ fr:
       short_description: 'Ceci est une publicité'
     inappropriate:
       title: 'Inapproprié'
-      description: 'Ce message contient du contenu qu''une personne raisonnable jugerait offensant, abusif ou en violation de la <a href="/guidelines">charte de notre communauté</a>.'
+      description: 'Ce message contient du contenu qu''une personne raisonnable jugerait offensant, abusif ou en violation de la <a href="%{base_url}/guidelines">charte de notre communauté</a>.'
       long_form: 'signalé comme inapproprié'
-      short_description: 'Une transgression de <a href="/guidelines">notre charte communautaire'
+      short_description: 'Une transgression de <a href="%{base_url}/guidelines">notre charte communautaire'
     notify_moderators:
       title: "Autre chose"
       description: 'Ce sujet demande l''attention des responsables d''après la <a href=''/fguidelines''>charte de la communauté</a>, <a href=''%{tos_url}''>les conditions générales de service</a> ou pour une autre raison.'
@@ -978,11 +978,11 @@ fr:
     sidekiq_warning: 'Sidekiq n''est pas lancé. De nombreuses tâches, comme l''envoi des courriels, sont exécutées de manière asynchrone par sidekiq. Assurez-vous d''avoir au moins un processus sidekiq de lancé. <a href="https://github.com/mperham/sidekiq">En savoir plus sur sidekiq</a>.'
     queue_size_warning: 'Le nombre de jobs dans la file d''attente est de %{queue_size}, ce qui est assez élevé. Cela peut indiquer un problème avec le(s) process Sidekiq, ou la nécessité d''ajouter davantage de workers.'
     memory_warning: 'Votre serveur dispose de moins de 1 Go de mémoire vive. Au moins 1 Go de RAM est recommandé.'
-    google_oauth2_config_warning: 'Le serveur est configuré pour permettre l''authentification via Google Oauth2 (enable_google_oauth2_logins), mais les paramètres client id et client secret ne sont pas renseignés. Allez dans les <a href="/admin/site_settings">Paramètres du Site</a> et mettez les à jour. <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">Voir le guide pour en savoir plus</a>.'
-    facebook_config_warning: 'Le serveur est configuré pour permettre l''authentification par Facebook (enable_facebook_logins), mais les paramètres facebook_app_id et facebook_app_secret ne sont pas renseignés. Allez dans les <a href="/admin/site_settings">Paramètres</a> et mettez les à jour. <a href="https://meta.discourse.org/t/configuring-facebook-login-for-discourse/13394" target="_blank">Voir le guide pour en savoir plus</a>.'
-    twitter_config_warning: 'Le serveur est configuré pour permettre l''authentification par Twitter (enable_twitter_logins), mais les paramètres key et secret ne sont pas renseignés. Allez dans les <a href="/admin/site_settings">Paramétres</a> et mettez les à jour. <a href="https://meta.discourse.org/t/configuring-twitter-login-for-discourse/13395" target="_blank">Voir le guide pour en savoir plus</a>.'
+    google_oauth2_config_warning: 'Le serveur est configuré pour permettre l''authentification via Google Oauth2 (enable_google_oauth2_logins), mais les paramètres client id et client secret ne sont pas renseignés. Allez dans les <a href="%{base_url}/admin/site_settings">Paramètres du Site</a> et mettez les à jour. <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">Voir le guide pour en savoir plus</a>.'
+    facebook_config_warning: 'Le serveur est configuré pour permettre l''authentification par Facebook (enable_facebook_logins), mais les paramètres facebook_app_id et facebook_app_secret ne sont pas renseignés. Allez dans les <a href="%{base_url}/admin/site_settings">Paramètres</a> et mettez les à jour. <a href="https://meta.discourse.org/t/configuring-facebook-login-for-discourse/13394" target="_blank">Voir le guide pour en savoir plus</a>.'
+    twitter_config_warning: 'Le serveur est configuré pour permettre l''authentification par Twitter (enable_twitter_logins), mais les paramètres key et secret ne sont pas renseignés. Allez dans les <a href="%{base_url}/admin/site_settings">Paramétres</a> et mettez les à jour. <a href="https://meta.discourse.org/t/configuring-twitter-login-for-discourse/13395" target="_blank">Voir le guide pour en savoir plus</a>.'
     github_config_warning: 'Le serveur est configuré pour permettre l''authentification par GitHub (enable_github_logins), mais les paramètres github_client_id et github_client_secret ne sont pas renseignés. Allez dans les <a href=\"/admin/site_settings\">Paramètres</a> et mettez les à jour. <a href="https://meta.discourse.org/t/configuring-github-login-for-discourse/13745" target="_blank">Voir le guide pour en savoir plus</a>.'
-    failing_emails_warning: 'Il y a %{num_failed_jobs} tâches d''envois de courriel en erreur. Vérifiez votre fichier app.yml et assurez-vous de la conformité des paramètres du serveur de courriel. <a href="/sidekiq/retries" target="_blank">Voir aussi les processus en échec dans Sidekiq</a>.'
+    failing_emails_warning: 'Il y a %{num_failed_jobs} tâches d''envois de courriel en erreur. Vérifiez votre fichier app.yml et assurez-vous de la conformité des paramètres du serveur de courriel. <a href="%{base_url}/sidekiq/retries" target="_blank">Voir aussi les processus en échec dans Sidekiq</a>.'
     subfolder_ends_in_slash: "Votre configuration de sous-répertoire est erronée; DISCOURSE_RELATIVE_URL_ROOT se termine avec une barre oblique ."
     email_polling_errored_recently:
       one: "La vérification des courriels a généré une erreur au cours des 24 dernières heures. Vérifiez <a href='/logs' target='_blank'>le journal</a> pour plus de détails."
@@ -2668,7 +2668,7 @@ fr:
       Un compte est nécessaire. Veuillez en créer un ou connectez-vous pour continuer.
   terms_of_service:
     title: "Conditions générales d'utilisation"
-    signup_form_message: 'J''ai lu et j''accepte les <a href="/tos" target="_blank">conditions générales d''utilisation</ a>.'
+    signup_form_message: 'J''ai lu et j''accepte les <a href="%{base_url}/tos" target="_blank">conditions générales d''utilisation</ a>.'
   deleted: 'supprimé'
   image: "image"
   upload:

--- a/config/locales/server.he.yml
+++ b/config/locales/server.he.yml
@@ -613,8 +613,8 @@ he:
       email_body: "%{link}\n\n%{message}"
     inappropriate:
       title: 'לא ראוי'
-      description: 'פוסט זה מכיל תוכן שאדם סביר היה רואה כפוגעני, מתעלל או הפרה של <a href="/guidelines">כללי הקהילה</a>.'
-      short_description: 'הפרה של <a href="/guidelines">כללי הקהילה שלנו</a>'
+      description: 'פוסט זה מכיל תוכן שאדם סביר היה רואה כפוגעני, מתעלל או הפרה של <a href="%{base_url}/guidelines">כללי הקהילה</a>.'
+      short_description: 'הפרה של <a href="%{base_url}/guidelines">כללי הקהילה שלנו</a>'
       long_form: 'דוגלל כלא ראוי'
     notify_user:
       title: 'שלחו הודעה ל @{{username}}'
@@ -656,11 +656,11 @@ he:
       long_form: 'דיגלתם זאת כספאם'
     inappropriate:
       title: 'לא ראוי'
-      description: 'נושא זה מכיל תוכן שהאדם הסביר היה מחשיב פוגעני, מתעלל או הפרה של <a href="/guidelines">כללי ההתנהלות בקהילה שלנו</a>.'
+      description: 'נושא זה מכיל תוכן שהאדם הסביר היה מחשיב פוגעני, מתעלל או הפרה של <a href="%{base_url}/guidelines">כללי ההתנהלות בקהילה שלנו</a>.'
       long_form: 'דוגלל כלא ראוי'
     notify_moderators:
       title: "משהו אחר"
-      description: 'נושא זה דורש תשומת לב של הצוות בהתאם ל<a href="/guidelines">הנחיות הקהילה</a>, <a href="%{tos_url}">תנאי השירות</a>, או מסיבה אחרת שאינה רשומה למעלה.'
+      description: 'נושא זה דורש תשומת לב של הצוות בהתאם ל<a href="%{base_url}/guidelines">הנחיות הקהילה</a>, <a href="%{tos_url}">תנאי השירות</a>, או מסיבה אחרת שאינה רשומה למעלה.'
       long_form: 'זה סומן לתשומת הלב של מנחה'
       email_title: 'הנושא "%{title}" דורש תשומת לב של מנחה'
       email_body: "%{link}\n\n%{message}"
@@ -842,11 +842,11 @@ he:
     sidekiq_warning: 'Sidekiq לא רץ. משימות רבות, כמו שליחת מיילים, מבוצעות אסינכרונית באמצעות Sidekiq. אנא וודאו שלפחות תהליך אחד של Sidekiq רץ. <a href="https://github.com/mperham/sidekiq" target="_blank">לימדו על Sidekiq כאן</a>.'
     queue_size_warning: 'מספר העבודות בתור הוא %{queue_size}, שהוא גבוה. זה עלול להצביע על בעיה עם תהליך(י) Sidekiq, או שייתכן שאתם צריכים יותר Sidekiq workers.'
     memory_warning: 'בשרת שלכם יש פחות מ 1 גיגה זיכרון בסך הכל. מומלץ לפחות 1 גיגה זיכרון.'
-    google_oauth2_config_warning: 'השרת מכוון לאפשר הרשמות והתחברות עם OAuth2 של גוגל (enable_google_oauth2_logins), אבל ערכי זהות הלקוח (client id) וסיסמת הלקוח (client secret) אינם מוגדרים. לכו ל<a href="/admin/site_settings"> הגדרות האתר </a> ועדכנו את הגדרות האתר. <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank"> ראו מדריך זה כדי ללמוד עוד</a>.'
-    facebook_config_warning: 'השרת מכוון לאפשר הרשמה והתחברות עם פייסבוק (enable_facebook_logins), אבל ערכי מזהה האפליקציה וסוד האפליקציה אינם קבועים. לכו ל <a href="/admin/site_settings">הגדרות האתר</a> ועדכנו את ההגדרות האלו. <a href="https://meta.discourse.org/t/configuring-facebook-login-for-discourse/13394" target="_blank">ראו מדריך זה כדי ללמוד עוד</a>.'
-    twitter_config_warning: 'השרת מכוון לאפשר הרשמה והתחברות עם טוויטר (enable_twitter_logins), אבל ערכי המפתח והסוד אינם קבועים. לכו ל <a href="/admin/site_settings">הגדרות האתר</a> ועדכנו את ההגדרות האלו. <a href="https://meta.discourse.org/t/configuring-twitter-login-for-discourse/13395" target="_blank">ראו מדריך זה כדי ללמוד עוד</a>.'
-    github_config_warning: 'השרת מכוון לאפשר הרשמה והתחברות עם גיטהאב (enable_github_logins), אבל ערכי מזהה הלקוח והסוד אינם קבועים. לכו ל <a href="/admin/site_settings">הגדרות האתר</a> ועדכנו את ההגדרות האלו. <a href="https://meta.discourse.org/t/configuring-github-login-for-discourse/13745" target="_blank">ראו מדריך זה כדי ללמוד עוד</a>.'
-    failing_emails_warning: 'יש %{num_failed_jobs} עבודות מייל שנכשלו. בידקו את app.yml שלכם כדי לוודא ששרת המייל מוגדר כיאות. <a href="/sidekiq/retries" target="_blank">ראו את העבודות שנכשלו ב Sidekiq</a>.'
+    google_oauth2_config_warning: 'השרת מכוון לאפשר הרשמות והתחברות עם OAuth2 של גוגל (enable_google_oauth2_logins), אבל ערכי זהות הלקוח (client id) וסיסמת הלקוח (client secret) אינם מוגדרים. לכו ל<a href="%{base_url}/admin/site_settings"> הגדרות האתר </a> ועדכנו את הגדרות האתר. <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank"> ראו מדריך זה כדי ללמוד עוד</a>.'
+    facebook_config_warning: 'השרת מכוון לאפשר הרשמה והתחברות עם פייסבוק (enable_facebook_logins), אבל ערכי מזהה האפליקציה וסוד האפליקציה אינם קבועים. לכו ל <a href="%{base_url}/admin/site_settings">הגדרות האתר</a> ועדכנו את ההגדרות האלו. <a href="https://meta.discourse.org/t/configuring-facebook-login-for-discourse/13394" target="_blank">ראו מדריך זה כדי ללמוד עוד</a>.'
+    twitter_config_warning: 'השרת מכוון לאפשר הרשמה והתחברות עם טוויטר (enable_twitter_logins), אבל ערכי המפתח והסוד אינם קבועים. לכו ל <a href="%{base_url}/admin/site_settings">הגדרות האתר</a> ועדכנו את ההגדרות האלו. <a href="https://meta.discourse.org/t/configuring-twitter-login-for-discourse/13395" target="_blank">ראו מדריך זה כדי ללמוד עוד</a>.'
+    github_config_warning: 'השרת מכוון לאפשר הרשמה והתחברות עם גיטהאב (enable_github_logins), אבל ערכי מזהה הלקוח והסוד אינם קבועים. לכו ל <a href="%{base_url}/admin/site_settings">הגדרות האתר</a> ועדכנו את ההגדרות האלו. <a href="https://meta.discourse.org/t/configuring-github-login-for-discourse/13745" target="_blank">ראו מדריך זה כדי ללמוד עוד</a>.'
+    failing_emails_warning: 'יש %{num_failed_jobs} עבודות מייל שנכשלו. בידקו את app.yml שלכם כדי לוודא ששרת המייל מוגדר כיאות. <a href="%{base_url}/sidekiq/retries" target="_blank">ראו את העבודות שנכשלו ב Sidekiq</a>.'
     subfolder_ends_in_slash: "הגדרות תיקיית המשנה שלכם לא נכונות, הנתיב DISCOURSE_RELATIVE_URL_ROOT צריך להסתיים בלוכסן."
     email_polling_errored_recently:
       one: "ניסיונות שליחת מיילים יצרו תקלה ב 24 השעות האחרונות. צפו ב<a href='/logs' target='_blank'>יומנים</a> לפרטים נוספים."
@@ -2036,7 +2036,7 @@ he:
       נדרש חשבון. נא ליצור חשבון או להיכנס כדי להמשיך.
   terms_of_service:
     title: "תנאי השימוש"
-    signup_form_message: 'קראתי את ואני מסכים/מה עם <a href="/tos" target="_blank">תנאי השירות</a>.'
+    signup_form_message: 'קראתי את ואני מסכים/מה עם <a href="%{base_url}/tos" target="_blank">תנאי השירות</a>.'
   deleted: 'נמחק'
   image: "תמונה"
   upload:

--- a/config/locales/server.it.yml
+++ b/config/locales/server.it.yml
@@ -642,7 +642,7 @@ it:
       email_body: "%{link}\n\n%{message}"
     inappropriate:
       title: 'Inappropriato'
-      description: 'Questo messaggio ha dei contenuti che una persona ragionevole considererebbe offensivi, aggressivi o una violazione delle <a href="/guidelines">linee guida della comunità</a>.'
+      description: 'Questo messaggio ha dei contenuti che una persona ragionevole considererebbe offensivi, aggressivi o una violazione delle <a href="%{base_url}/guidelines">linee guida della comunità</a>.'
       short_description: 'Una violazione delle </a>linee guida della nostra comunità </a>'
       long_form: 'segnalato come inappropriato'
     notify_user:
@@ -688,11 +688,11 @@ it:
       long_form: 'segnalato come spam'
     inappropriate:
       title: 'Inappropriato'
-      description: 'Questo argomento ha dei contenuti che una persona ragionevole considererebbe offensivi, aggressivi o una violazione delle <a href="/guidelines">linee guida della comunità</a>.'
+      description: 'Questo argomento ha dei contenuti che una persona ragionevole considererebbe offensivi, aggressivi o una violazione delle <a href="%{base_url}/guidelines">linee guida della comunità</a>.'
       long_form: 'segnalato come inappropriato'
     notify_moderators:
       title: "Altro"
-      description: 'Questo argomento richiede attenzione da parte deilo staff in base alle <a href="/guidelines">linee guida</a>, ai <a href="%{tos_url}">TOS</a> o per altri motivi non elencati.'
+      description: 'Questo argomento richiede attenzione da parte deilo staff in base alle <a href="%{base_url}/guidelines">linee guida</a>, ai <a href="%{tos_url}">TOS</a> o per altri motivi non elencati.'
       long_form: 'segnalato all''attenzione dei moderatori'
       email_title: 'L''argomento "%{title}" richiede l''attenzione di un moderatore'
       email_body: "%{link}\n\n%{message}"
@@ -923,11 +923,11 @@ it:
     sidekiq_warning: 'Sidekiq non è in esecuzione. Molte attività, come l''invio di email, sono eseguite in maniera asincrona da sidekiq. Assicurati che almeno un processo sidekiq sia in esecuzione. <a href="https://github.com/mperham/sidekiq"  target="_blank">Leggi altro su sidekiq qui</a>.'
     queue_size_warning: 'Il numero di job in coda è %{queue_size}, il che è alto. Ciò potrebbe indicare un problema con i processi Sidekiq, oppure devi aggiungere altri worker Sidekiq.'
     memory_warning: 'Il tuo server gira con meno di 1 GB di memoria. Si raccomanda almeno 1 GB di memoria.'
-    google_oauth2_config_warning: 'Il server è configurato per permettere iscrizioni e login con Google Oauth2 (enable_google_oauth2_logins), ma il client id e il client secret non sono impostati. Vai nelle <a href="/admin/site_settings">Impostazioni del sito</a> e aggiorna le impostazioni. <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">Leggi questa guida per saperne di più</a>.'
-    facebook_config_warning: 'Il server è configurato per accettare iscrizioni e login con Facebook (enable_facebook_logins), tuttavia i parametri app id e secret non sono stati impostati. Vai alle <a href="/admin/site_settings">Impostazioni</a> e aggiorna i campi interessati. <a href="https://meta.discourse.org/t/configuring-facebook-login-for-discourse/13394" target="_blank">Leggi questa guida per saperne di più</a>.'
-    twitter_config_warning: 'Il server è configurato per accettare iscrizioni e login con Twitter (enable_twitter_logins), tuttavia i parametri key e secret non sono stati impostati. Vai alle <a href="/admin/site_settings">Impostazioni</a> e aggiorna i campi interessati. <a href="https://meta.discourse.org/t/configuring-twitter-login-for-discourse/13395" target="_blank">Leggi questa guida per saperne di più</a>.'
-    github_config_warning: 'Il server è configurato per accettare iscrizioni e login con GitHub (enable_github_logins), tuttavia i parametri client id e secret non sono stati impostati. Vai alle <a href="/admin/site_settings">Impostazioni</a> e aggiorna i campi interessati. <a href="https://meta.discourse.org/t/configuring-github-login-for-discourse/13745" target="_blank">Leggi questa guida per saperne di più</a>.'
-    failing_emails_warning: 'Ci sono %{num_failed_jobs} job di email falliti. Controlla il file app.yml e assicurati che le impostazioni del mail server siano corrette. <a href="/sidekiq/retries" target="_blank">Vedi i job falliti in Sidekiq</a>.'
+    google_oauth2_config_warning: 'Il server è configurato per permettere iscrizioni e login con Google Oauth2 (enable_google_oauth2_logins), ma il client id e il client secret non sono impostati. Vai nelle <a href="%{base_url}/admin/site_settings">Impostazioni del sito</a> e aggiorna le impostazioni. <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">Leggi questa guida per saperne di più</a>.'
+    facebook_config_warning: 'Il server è configurato per accettare iscrizioni e login con Facebook (enable_facebook_logins), tuttavia i parametri app id e secret non sono stati impostati. Vai alle <a href="%{base_url}/admin/site_settings">Impostazioni</a> e aggiorna i campi interessati. <a href="https://meta.discourse.org/t/configuring-facebook-login-for-discourse/13394" target="_blank">Leggi questa guida per saperne di più</a>.'
+    twitter_config_warning: 'Il server è configurato per accettare iscrizioni e login con Twitter (enable_twitter_logins), tuttavia i parametri key e secret non sono stati impostati. Vai alle <a href="%{base_url}/admin/site_settings">Impostazioni</a> e aggiorna i campi interessati. <a href="https://meta.discourse.org/t/configuring-twitter-login-for-discourse/13395" target="_blank">Leggi questa guida per saperne di più</a>.'
+    github_config_warning: 'Il server è configurato per accettare iscrizioni e login con GitHub (enable_github_logins), tuttavia i parametri client id e secret non sono stati impostati. Vai alle <a href="%{base_url}/admin/site_settings">Impostazioni</a> e aggiorna i campi interessati. <a href="https://meta.discourse.org/t/configuring-github-login-for-discourse/13745" target="_blank">Leggi questa guida per saperne di più</a>.'
+    failing_emails_warning: 'Ci sono %{num_failed_jobs} job di email falliti. Controlla il file app.yml e assicurati che le impostazioni del mail server siano corrette. <a href="%{base_url}/sidekiq/retries" target="_blank">Vedi i job falliti in Sidekiq</a>.'
     subfolder_ends_in_slash: "L'impostazione della sottocartella è errata; DISCOURSE_RELATIVE_URL_ROOT finisce con uno slash."
     email_polling_errored_recently:
       one: "Il polling delle email ha generato un errore nelle ultime 24 ore. Controlla <a href='/logs' target='_blank'>i log</a> per maggiori dettagli."
@@ -2335,7 +2335,7 @@ it:
       E' richiesto un account. Per continuare, crea un nuovo account oppure connettiti.
   terms_of_service:
     title: "Termini di Servizio"
-    signup_form_message: 'Ho letto e accetto i <a href="/tos" target="_blank">Termini del Servizio</a>.'
+    signup_form_message: 'Ho letto e accetto i <a href="%{base_url}/tos" target="_blank">Termini del Servizio</a>.'
   deleted: 'cancellati'
   image: "immagine"
   upload:

--- a/config/locales/server.ja.yml
+++ b/config/locales/server.ja.yml
@@ -375,7 +375,7 @@ ja:
       long_form: '不適切として通報する'
     notify_moderators:
       title: "その他"
-      description: 'このトピックは <a href="/guidelines">ガイドライン</a>, <a href="%{tos_url}">利用規約</a>の違反や、その他不適切な理由がある。'
+      description: 'このトピックは <a href="%{base_url}/guidelines">ガイドライン</a>, <a href="%{tos_url}">利用規約</a>の違反や、その他不適切な理由がある。'
       long_form: 'モデレーターへ知らせるために通報する'
       email_title: 'トピック"%{title}" は不適切な可能性があるため、管理人による確認を必要とする。'
       email_body: "%{link}\n\n%{message}"
@@ -537,10 +537,10 @@ ja:
     sidekiq_warning: 'Sidekiq が起動していません。メール送信等、多くのタスクが sidekiq により非同期に実行されます。少なくとも sidekiq のプロセスを1つは起動してください。<a href="https://github.com/mperham/sidekiq" target="_blank">Sidekiq についてはこちらを参考にしてください</a>。'
     queue_size_warning: 'キューイングされたジョブの数は %{queue_size} で、これは多いです。SIdekiqのプロセスに問題があるか、Sidekiqのworkerを増やす必要があります'
     memory_warning: '現在サーバが 1GB 未満の総メモリで起動しています。推奨メモリサイズは 1GB 以上です。'
-    google_oauth2_config_warning: 'サーバが Google OAuth2 アカウントによるサインアップ・ログイン可能な設定 (enable_google_oauth2_logins) になっていますが、client id と secret が設定されていません。<a href="/admin/site_settings">サイトの設定</a> にて設定を更新してください。<a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">詳しくはこちらを参考にしてください</a>。'
-    facebook_config_warning: 'サーバが Facebook アカウントによるサインアップ・ログイン可能な設定 (enable_facebook_logins) になっていますが、app id と app secret が設定されていません。<a href="/admin/site_settings">サイトの設定</a> にて設定を更新してください。<a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide#enable-facebook-logins" target="_blank">詳しくはこちらを参考にしてください</a>。'
-    twitter_config_warning: 'サーバが Twitter アカウントによるサインアップ・ログイン可能な設定 (enable_twitter_logins) になっていますが、key と secret が設定されていません。<a href="/admin/site_settings">サイトの設定</a> にて設定を更新してください。<a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide#enable-twitter-logins" target="_blank">詳しくはこちらを参考にしてください</a>。'
-    github_config_warning: 'サーバが Github アカウントによるサインアップ・ログイン可能な設定 (enable_github_logins) になっていますが、client id と secret が設定されていません。<a href="/admin/site_settings">サイトの設定</a> にて設定を更新してください。<a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide" target="_blank">詳しくはこちらを参考にしてください</a>。'
+    google_oauth2_config_warning: 'サーバが Google OAuth2 アカウントによるサインアップ・ログイン可能な設定 (enable_google_oauth2_logins) になっていますが、client id と secret が設定されていません。<a href="%{base_url}/admin/site_settings">サイトの設定</a> にて設定を更新してください。<a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">詳しくはこちらを参考にしてください</a>。'
+    facebook_config_warning: 'サーバが Facebook アカウントによるサインアップ・ログイン可能な設定 (enable_facebook_logins) になっていますが、app id と app secret が設定されていません。<a href="%{base_url}/admin/site_settings">サイトの設定</a> にて設定を更新してください。<a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide#enable-facebook-logins" target="_blank">詳しくはこちらを参考にしてください</a>。'
+    twitter_config_warning: 'サーバが Twitter アカウントによるサインアップ・ログイン可能な設定 (enable_twitter_logins) になっていますが、key と secret が設定されていません。<a href="%{base_url}/admin/site_settings">サイトの設定</a> にて設定を更新してください。<a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide#enable-twitter-logins" target="_blank">詳しくはこちらを参考にしてください</a>。'
+    github_config_warning: 'サーバが Github アカウントによるサインアップ・ログイン可能な設定 (enable_github_logins) になっていますが、client id と secret が設定されていません。<a href="%{base_url}/admin/site_settings">サイトの設定</a> にて設定を更新してください。<a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide" target="_blank">詳しくはこちらを参考にしてください</a>。'
     image_magick_warning: 'サーバが大きな画像のサムネイルを作成する設定になっていますが、ImageMagick がインストールされていません。お好きなパッケージマネージャを使って ImageMagick をインストールするか、<a href="http://www.imagemagick.org/script/binary-releases.php" target="_blank">最新のリリースをダウンロードしてください</a>。'
   site_settings:
     censored_words: "自動的に &#9632;&#9632;&#9632;&#9632; で置換されます"
@@ -986,7 +986,7 @@ ja:
     search_google: "Google"
   terms_of_service:
     title: "利用規約"
-    signup_form_message: '<a href="/tos" target="_blank">Terms of Service</a>を読んで同意しました'
+    signup_form_message: '<a href="%{base_url}/tos" target="_blank">Terms of Service</a>を読んで同意しました'
   deleted: '削除'
   upload:
     edit_reason: "ダウンロードされた画像のコピー"

--- a/config/locales/server.ko.yml
+++ b/config/locales/server.ko.yml
@@ -510,7 +510,7 @@ ko:
     inappropriate:
       title: '부적절함'
       description: '이 글은 다른 사용자들에게 공격적이나 모욕적 또는 침해적인 글을 담고 있습니다.'
-      short_description: '<a href="/guidelines">커뮤니티 가이드라인</a> 의 위반'
+      short_description: '<a href="%{base_url}/guidelines">커뮤니티 가이드라인</a> 의 위반'
       long_form: '부적절함으로 신고하기'
     notify_user:
       title: '@{{username}} 님에게 메시지를 보냅니다'
@@ -554,11 +554,11 @@ ko:
       title: '부적절함'
       description: '이 글은 평균적인 사람들의 관점에서 볼 때 공격적이나 모욕적인 글을 담고 있거나,
 
-        <a href="/guidelines">커뮤니티 가이드라인</a>에 맞지 않습니다.'
+        <a href="%{base_url}/guidelines">커뮤니티 가이드라인</a>에 맞지 않습니다.'
       long_form: '부적절함으로 신고하였습니다.'
     notify_moderators:
       title: "기타"
-      description: '이 주제는 <a href="/guidelines">가이드라인</a>, <a href="%{tos_url}">이용약관</a>, 위에서 언급되지 않은 기타 사유로 인해 운영진이 검토할 필요가 있습니다.'
+      description: '이 주제는 <a href="%{base_url}/guidelines">가이드라인</a>, <a href="%{tos_url}">이용약관</a>, 위에서 언급되지 않은 기타 사유로 인해 운영진이 검토할 필요가 있습니다.'
       long_form: '관리자의 주의를 위해 신고'
       email_title: '글타래 "%{title}" 은 운영자의 확인이 필요합니다'
       email_body: "%{link}\n\n%{message}"
@@ -741,11 +741,11 @@ ko:
     sidekiq_warning: 'Sidekiq 이 현재 실행되고 있지 않습니다. Sidekiq는 이메일 전송 같은 많은 작업들을 비동기식으로 처리합니다. 적어도 하나의 sidekiq 프로세서를 실행시켜 주세요. <a href="https://github.com/mperham/sidekiq">Sidekiq 배우기</a>.'
     queue_size_warning: '큐 작업의 수가 %{queue_size} 개 입니다. 작업의 수가 너무 많습니다. Sidekiq에 문제가 있을 수 있습니다. Sidekiq Worker를 더 추가하세요.'
     memory_warning: '당신의 서버는 1GB 이하 메모리로 실행되고 있습니다. 적어도 1GB 이상의 메모리를 사용하세요.'
-    google_oauth2_config_warning: 'Google OAuth2 인증을 통한 로그인과 회원가입(enable_google_oauth2_logins)을 설정하였습니다. 하지만, 아직 Client ID와 Client Secret을 입력하지 않았습니다. <a href="/admin/site_settings">the Site Settings</a> and update the settings. <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">자세히 알아보기</a>.'
-    facebook_config_warning: '당신의 서버는 페이스북을 통한 가입을 설정하였습니다(enable_facebook_logins), 그러나 app id와 app secret 값을 입력하지 않았습니다. <a href="/admin/site_settings">사이트 설정</a> 에서 업데이트 해주세요. <a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide#enable-facebook-logins" target="_blank">가이드 읽어보기</a>.'
-    twitter_config_warning: '당신의 서버는 트위터를 통한 가입을 설정하였습니다(enable_twitter_logins), 그러나 key 와 secret 값이 입력하지 않았습니다. <a href="/admin/site_settings">사이트 설정</a> 에서 업데이트 해주세요. <a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide#enable-twitter-logins" target="_blank">가이드 읽어보기</a>.'
-    github_config_warning: '당신의 서버는 Github를 통한 가입을 설정하였습니다(enable_github_logins), 그러나 client id 와 secret 값을 입력하지 않았습니다. <a href="/admin/site_settings">사이트 설정</a> 에서 업데이트 해주세요. <a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide" target="_blank">가이드 읽어보기</a>.'
-    failing_emails_warning: '실패한 이메일 작업이 %{num_failed_jobs} 개 있습니다. app.yml 을 열어서 메일 서버 설정이 정확한지 확인해보세요. <a href="/sidekiq/retries" target="_blank">Sidekiq에서 실패한 작업 보기</a>.'
+    google_oauth2_config_warning: 'Google OAuth2 인증을 통한 로그인과 회원가입(enable_google_oauth2_logins)을 설정하였습니다. 하지만, 아직 Client ID와 Client Secret을 입력하지 않았습니다. <a href="%{base_url}/admin/site_settings">the Site Settings</a> and update the settings. <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">자세히 알아보기</a>.'
+    facebook_config_warning: '당신의 서버는 페이스북을 통한 가입을 설정하였습니다(enable_facebook_logins), 그러나 app id와 app secret 값을 입력하지 않았습니다. <a href="%{base_url}/admin/site_settings">사이트 설정</a> 에서 업데이트 해주세요. <a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide#enable-facebook-logins" target="_blank">가이드 읽어보기</a>.'
+    twitter_config_warning: '당신의 서버는 트위터를 통한 가입을 설정하였습니다(enable_twitter_logins), 그러나 key 와 secret 값이 입력하지 않았습니다. <a href="%{base_url}/admin/site_settings">사이트 설정</a> 에서 업데이트 해주세요. <a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide#enable-twitter-logins" target="_blank">가이드 읽어보기</a>.'
+    github_config_warning: '당신의 서버는 Github를 통한 가입을 설정하였습니다(enable_github_logins), 그러나 client id 와 secret 값을 입력하지 않았습니다. <a href="%{base_url}/admin/site_settings">사이트 설정</a> 에서 업데이트 해주세요. <a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide" target="_blank">가이드 읽어보기</a>.'
+    failing_emails_warning: '실패한 이메일 작업이 %{num_failed_jobs} 개 있습니다. app.yml 을 열어서 메일 서버 설정이 정확한지 확인해보세요. <a href="%{base_url}/sidekiq/retries" target="_blank">Sidekiq에서 실패한 작업 보기</a>.'
     subfolder_ends_in_slash: "서브폴더 설정이 정확하지 않습니다. DISCOURSE_RELATIVE_URL_ROOT 다음에 슬래시가 있습니다."
     email_polling_errored_recently:
       other: "이메일 폴링에서 지난 24시간 동안%{count}개의 에러가 발생하였습니다. 세부 정보는 <a href='/logs' target='_blank'>로그</a>에서 확인하세요."
@@ -1363,7 +1363,7 @@ ko:
     search_title: "이 사이트 검색"
   terms_of_service:
     title: "서비스 이용약관"
-    signup_form_message: 'I have read and accept the <a href="/tos" target="_blank">Terms of Service</a>.'
+    signup_form_message: 'I have read and accept the <a href="%{base_url}/tos" target="_blank">Terms of Service</a>.'
   deleted: '삭제되었습니다'
   image: "이미지"
   upload:

--- a/config/locales/server.nb_NO.yml
+++ b/config/locales/server.nb_NO.yml
@@ -642,8 +642,8 @@ nb_NO:
       email_body: "%{link}\n\n%{message}"
     inappropriate:
       title: 'Upassende'
-      description: 'Dette innlegget har innhold som for en fornuftig person vil kunne være fornærmende, nedverdigende eller brudd på <a href="/guidelines">retningslinjene til denne gemenskapen</a>.'
-      short_description: 'Et brudd på <a href="/guidelines">retningslinjene for samfunnet</a>'
+      description: 'Dette innlegget har innhold som for en fornuftig person vil kunne være fornærmende, nedverdigende eller brudd på <a href="%{base_url}/guidelines">retningslinjene til denne gemenskapen</a>.'
+      short_description: 'Et brudd på <a href="%{base_url}/guidelines">retningslinjene for samfunnet</a>'
       long_form: 'markerte dette som upassende'
     notify_user:
       title: 'Send en melding til @{{username}}'
@@ -692,12 +692,12 @@ nb_NO:
       short_description: 'Dette er en reklame'
     inappropriate:
       title: 'Upassende'
-      description: 'Dette innlegget har innhold som en fornuftig person vil anslå å være fornærmende, nedverdigende eller brudd på <a href="/guidelines">retningslinjene til denne gemenskapen</a>.'
+      description: 'Dette innlegget har innhold som en fornuftig person vil anslå å være fornærmende, nedverdigende eller brudd på <a href="%{base_url}/guidelines">retningslinjene til denne gemenskapen</a>.'
       long_form: 'markerte dette som upassende'
-      short_description: 'Et brudd på <a href="/guidelines">retningslinjene for samfunnet</a>'
+      short_description: 'Et brudd på <a href="%{base_url}/guidelines">retningslinjene for samfunnet</a>'
     notify_moderators:
       title: "Noe annet"
-      description: 'Emnet krever oppfølging av staben basert på <a href="/guidelines">retningslinjene</a>, <a href="%{tos_url}">brukeravtale</a>, eller en annen grunn ikke i listen over.'
+      description: 'Emnet krever oppfølging av staben basert på <a href="%{base_url}/guidelines">retningslinjene</a>, <a href="%{tos_url}">brukeravtale</a>, eller en annen grunn ikke i listen over.'
       long_form: 'Markert for mederering'
       short_description: 'Krever handling fra staben av en annen grunn'
       email_title: 'Tråden "%{title}" krever oppmerksomhet fra en moderator'
@@ -976,11 +976,11 @@ nb_NO:
     sidekiq_warning: 'Sidekiq kjører ikke. Mange oppgaver, som å sende e-post, kjøres i bakgrunnen av sidekiq. Vennligst verifiser at minst én sidekiq-prosess kjører. <a href="https://github.com/mperham/sidekiq" target="_blank">Lær mer om Sidekiq her</a>.'
     queue_size_warning: 'Antallet jobber som står i kø er %{queue_size}, som er høyt. Dette kan være en indikasjon på at Sidekiq-prosessen(e) har et problem, eller det kan tenkes du bare trenger flere samtidige Sidekiq-arbeidere.'
     memory_warning: 'Serveren din kjører med mindre enn 1 GB med minne. Minst 1 GB RAM er anbefalt.'
-    google_oauth2_config_warning: 'Denne serveren er konfigurert for å tillate innmelding og innlogging med Google OAuth2 (enable_google_oauth2_logins), men verdiene for klientid og klienthemmelighet er ikke satt. Gå til <a href="/admin/site_settings">Instillingene for nettstedet</a> og oppdater dem. <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">Les denne guiden for å lære mer</a>.'
-    facebook_config_warning: 'Denne serveren er konfigurert for å tillate innmelding og innlogging med Facebook (enable_facebook_logins), men verdiene for app-id og app-hemmelighet er ikke satt. Gå til <a href="/admin/site_settings">Instillingene for nettstedet</a> og oppdater dem. <a href="https://meta.discourse.org/t/configuring-facebook-login-for-discourse/13394" target="_blank">Les denne guiden for å lære mer</a>.'
-    twitter_config_warning: 'Denne serveren er konfigurert for å tillate innmelding og innlogging med Twitter (enable_twitter_logins), men verdiene for nøkkel og hemmelighet er ikke satt. Gå til <a href="/admin/site_settings">Instillingene for nettstedet</a> og oppdater dem. <a href="https://meta.discourse.org/t/configuring-twitter-login-for-discourse/13395" target="_blank">Les denne guiden for å lære mer</a>.'
-    github_config_warning: 'Denne serveren er konfigurert for å tillate innmelding og innlogging med GitHub (enable_github_logins), men verdiene for klientid og hemmelighet er ikke satt. Gå til <a href="/admin/site_settings">Instillingene for nettstedet</a> og oppdater dem. <a href="https://meta.discourse.org/t/configuring-github-login-for-discourse/13745" target="_blank">Les denne guiden for å lære mer</a>.'
-    failing_emails_warning: 'Det er %{num_failed_jobs} e-postjobber som har feilet. Sjekk instillingene i app.yml og verifiser at serverinstillingene for e-post er riktige. <a href="/sidekiq/retries" target="_blank">Se de feilede jobbene i Sidekiq</a>.'
+    google_oauth2_config_warning: 'Denne serveren er konfigurert for å tillate innmelding og innlogging med Google OAuth2 (enable_google_oauth2_logins), men verdiene for klientid og klienthemmelighet er ikke satt. Gå til <a href="%{base_url}/admin/site_settings">Instillingene for nettstedet</a> og oppdater dem. <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">Les denne guiden for å lære mer</a>.'
+    facebook_config_warning: 'Denne serveren er konfigurert for å tillate innmelding og innlogging med Facebook (enable_facebook_logins), men verdiene for app-id og app-hemmelighet er ikke satt. Gå til <a href="%{base_url}/admin/site_settings">Instillingene for nettstedet</a> og oppdater dem. <a href="https://meta.discourse.org/t/configuring-facebook-login-for-discourse/13394" target="_blank">Les denne guiden for å lære mer</a>.'
+    twitter_config_warning: 'Denne serveren er konfigurert for å tillate innmelding og innlogging med Twitter (enable_twitter_logins), men verdiene for nøkkel og hemmelighet er ikke satt. Gå til <a href="%{base_url}/admin/site_settings">Instillingene for nettstedet</a> og oppdater dem. <a href="https://meta.discourse.org/t/configuring-twitter-login-for-discourse/13395" target="_blank">Les denne guiden for å lære mer</a>.'
+    github_config_warning: 'Denne serveren er konfigurert for å tillate innmelding og innlogging med GitHub (enable_github_logins), men verdiene for klientid og hemmelighet er ikke satt. Gå til <a href="%{base_url}/admin/site_settings">Instillingene for nettstedet</a> og oppdater dem. <a href="https://meta.discourse.org/t/configuring-github-login-for-discourse/13745" target="_blank">Les denne guiden for å lære mer</a>.'
+    failing_emails_warning: 'Det er %{num_failed_jobs} e-postjobber som har feilet. Sjekk instillingene i app.yml og verifiser at serverinstillingene for e-post er riktige. <a href="%{base_url}/sidekiq/retries" target="_blank">Se de feilede jobbene i Sidekiq</a>.'
     subfolder_ends_in_slash: "Oppsettet av undermappe er feil; variablen DISCOURSE_RELATIVE_URL_ROOT slutter med en skråstrek."
     email_polling_errored_recently:
       one: "Henting av e-post har generert en feil de siste 24 timene. Se i <a href='/logs' target='_blank'>loggene</a> for mer detaljer."
@@ -1263,7 +1263,7 @@ nb_NO:
     search_title: "Søk i denne siden"
   terms_of_service:
     title: "Bruksvilkår"
-    signup_form_message: 'Jeg har lest og akseptert <a href="/tos" target="_blank">Bruksvilkårene</a>.'
+    signup_form_message: 'Jeg har lest og akseptert <a href="%{base_url}/tos" target="_blank">Bruksvilkårene</a>.'
   deleted: 'slettet'
   upload:
     edit_reason: "Last ned lokal kopi av bilder"

--- a/config/locales/server.nl.yml
+++ b/config/locales/server.nl.yml
@@ -532,8 +532,8 @@ nl:
       email_body: "%{link}\n\n%{message}"
     inappropriate:
       title: 'Ongepast'
-      description: 'Dit bericht bevat inhoud die een redelijk persoon als beledigend, kwetsend of een overtreding van <a href="/guidelines">onze gemeenschapsrichtlijnen</a> zou beschouwen.'
-      short_description: 'Een overtreding van <a href="/guidelines">onze community richtlijnen</a>'
+      description: 'Dit bericht bevat inhoud die een redelijk persoon als beledigend, kwetsend of een overtreding van <a href="%{base_url}/guidelines">onze gemeenschapsrichtlijnen</a> zou beschouwen.'
+      short_description: 'Een overtreding van <a href="%{base_url}/guidelines">onze community richtlijnen</a>'
       long_form: 'heeft dit als ongepast gemarkeerd'
     notify_user:
       title: '@{{username}} een bericht sturen'
@@ -573,11 +573,11 @@ nl:
       long_form: 'heeft dit als spam gemarkeerd'
     inappropriate:
       title: 'Ongepast'
-      description: 'Dit topic bevat inhoud die een redelijk persoon als beledigend, kwetsend of een overtreding van <a href="/guidelines">onze gemeenschapsrichtlijnen</a> zou beschouwen.'
+      description: 'Dit topic bevat inhoud die een redelijk persoon als beledigend, kwetsend of een overtreding van <a href="%{base_url}/guidelines">onze gemeenschapsrichtlijnen</a> zou beschouwen.'
       long_form: 'heeft dit als ongepast gemarkeerd'
     notify_moderators:
       title: "Iets anders"
-      description: 'Dit topic vereist algemene aandacht van een staflid op basis van de <a href="/guidelines">richtlijnen</a>, <a href="%{tos_url}">voorwaarden</a>, of om een andere reden dan hierboven vermeld.'
+      description: 'Dit topic vereist algemene aandacht van een staflid op basis van de <a href="%{base_url}/guidelines">richtlijnen</a>, <a href="%{tos_url}">voorwaarden</a>, of om een andere reden dan hierboven vermeld.'
       long_form: 'heeft dit gemarkeerd voor aandacht van een moderator'
       email_title: 'Het topic ''%{title}'' vereist aandacht van een moderator'
       email_body: "%{link}\n\n%{message}"
@@ -759,11 +759,11 @@ nl:
     sidekiq_warning: 'Sidekiq is niet actief. Veel taken, zoals het verzenden van e-mail, worden door Sidekiq asynchroon uitgevoerd. Zorg ervoor dat er minstens één Sidekiq-proces actief is. <a href="https://github.com/mperham/sidekiq" target="_blank">Lees hier meer over Sidekiq</a>.'
     queue_size_warning: 'Het aantal taken in de wachtrij is %{queue_size}, wat hoog is. Dit zou op een probleem met Sidekiq-processen kunnen duiden, of mogelijk dient u meer Sidekiq-workers toe te voegen.'
     memory_warning: 'Uw server werkt met minder dan 1 GB aan totaal geheugen. Minstens 1 GB geheugen wordt aanbevolen.'
-    google_oauth2_config_warning: 'De server is geconfigureerd om registratie en aanmelding via Google OAuth2 (enable_google_oauth2_logins) toe te staan, maar de waarden voor client-ID en clientgeheim zijn niet ingesteld. Ga naar <a href="/admin/site_settings">de Website-instellingen</a> en werk de instellingen bij. <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">Bekijk deze handleiding voor meer info</a>.'
-    facebook_config_warning: 'De server is geconfigureerd om registratie en aanmelding via Facebook toe te staan (enable_facebook_logins), maar de waarden voor app-ID en app-geheim zijn niet ingesteld. Ga naar <a href="/admin/site_settings">de Website-instellingen</a> en werk de instellingen bij. <a href="https://meta.discourse.org/t/configuring-facebook-login-for-discourse/13394" target="_blank">Bekijk deze handleiding voor meer info</a>.'
-    twitter_config_warning: 'De server is geconfigureerd om registratie en aanmelding via Twitter toe te staan (enable_twitter_logins), maar de waarden voor sleutel en geheim zijn niet ingesteld. Ga naar <a href="/admin/site_settings">de Website-instellingen</a> en werk de instellingen bij. <a href="https://meta.discourse.org/t/configuring-twitter-login-for-discourse/13395" target="_blank">Bekijk deze handleiding voor meer info</a>.'
-    github_config_warning: 'De server is geconfigureerd om registratie en aanmelding via GitHub toe te staan (enable_github_logins), maar de waarden voor client-ID en -geheim zijn niet ingesteld. Ga naar <a href="/admin/site_settings">de Website-instellingen</a> en werk de instellingen bij. <a href="https://meta.discourse.org/t/configuring-github-login-for-discourse/13745" target="_blank">Bekijk deze handleiding voor meer info</a>.'
-    failing_emails_warning: 'Er zijn %{num_failed_jobs} mislukte e-mailtaken. Controleer uw bestand app.yml en zorg ervoor dat de mailserverinstellingen juist zijn. <a href="/sidekiq/retries" target="_blank">Bekijk de mislukte taken in Sidekiq</a>.'
+    google_oauth2_config_warning: 'De server is geconfigureerd om registratie en aanmelding via Google OAuth2 (enable_google_oauth2_logins) toe te staan, maar de waarden voor client-ID en clientgeheim zijn niet ingesteld. Ga naar <a href="%{base_url}/admin/site_settings">de Website-instellingen</a> en werk de instellingen bij. <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">Bekijk deze handleiding voor meer info</a>.'
+    facebook_config_warning: 'De server is geconfigureerd om registratie en aanmelding via Facebook toe te staan (enable_facebook_logins), maar de waarden voor app-ID en app-geheim zijn niet ingesteld. Ga naar <a href="%{base_url}/admin/site_settings">de Website-instellingen</a> en werk de instellingen bij. <a href="https://meta.discourse.org/t/configuring-facebook-login-for-discourse/13394" target="_blank">Bekijk deze handleiding voor meer info</a>.'
+    twitter_config_warning: 'De server is geconfigureerd om registratie en aanmelding via Twitter toe te staan (enable_twitter_logins), maar de waarden voor sleutel en geheim zijn niet ingesteld. Ga naar <a href="%{base_url}/admin/site_settings">de Website-instellingen</a> en werk de instellingen bij. <a href="https://meta.discourse.org/t/configuring-twitter-login-for-discourse/13395" target="_blank">Bekijk deze handleiding voor meer info</a>.'
+    github_config_warning: 'De server is geconfigureerd om registratie en aanmelding via GitHub toe te staan (enable_github_logins), maar de waarden voor client-ID en -geheim zijn niet ingesteld. Ga naar <a href="%{base_url}/admin/site_settings">de Website-instellingen</a> en werk de instellingen bij. <a href="https://meta.discourse.org/t/configuring-github-login-for-discourse/13745" target="_blank">Bekijk deze handleiding voor meer info</a>.'
+    failing_emails_warning: 'Er zijn %{num_failed_jobs} mislukte e-mailtaken. Controleer uw bestand app.yml en zorg ervoor dat de mailserverinstellingen juist zijn. <a href="%{base_url}/sidekiq/retries" target="_blank">Bekijk de mislukte taken in Sidekiq</a>.'
     subfolder_ends_in_slash: "Uw submapconfiguratie is onjuist; de DISCOURSE_RELATIVE_URL_ROOT eindigt met een schuine streep."
     email_polling_errored_recently:
       one: "E-mailpolling heeft de afgelopen 24 uur een fout gegenereerd. Bekijk <a href='/logs' target='_blank'>de logboeken</a> voor meer details."
@@ -1377,7 +1377,7 @@ nl:
     search_title: "Zoeken op deze website"
   terms_of_service:
     title: "Servicevoorwaarden"
-    signup_form_message: 'Ik heb de <a href="/tos" target="_blank">Servicevoorwaarden</a> gelezen en ga hiermee akkoord.'
+    signup_form_message: 'Ik heb de <a href="%{base_url}/tos" target="_blank">Servicevoorwaarden</a> gelezen en ga hiermee akkoord.'
   deleted: 'verwijderd'
   upload:
     edit_reason: "lokale kopieën van afbeeldingen gedownload"

--- a/config/locales/server.pl_PL.yml
+++ b/config/locales/server.pl_PL.yml
@@ -593,8 +593,8 @@ pl_PL:
       email_body: "%{link}\n\n%{message}"
     inappropriate:
       title: 'Niewłaściwe'
-      description: 'Ten wpis zawiera treści które umiarkowana osoba może uznać za wulgarne, obraźliwe lub naruszające <a href="/guidelines">wytyczne społeczności</a>.'
-      short_description: 'Naruszenie  <a href="/guidelines">naszych wytycznych dla społeczności </a>'
+      description: 'Ten wpis zawiera treści które umiarkowana osoba może uznać za wulgarne, obraźliwe lub naruszające <a href="%{base_url}/guidelines">wytyczne społeczności</a>.'
+      short_description: 'Naruszenie  <a href="%{base_url}/guidelines">naszych wytycznych dla społeczności </a>'
       long_form: 'oflagowano jako niewłaściwe'
     notify_user:
       title: 'Wyślij @{{username}} wiadomość'
@@ -637,11 +637,11 @@ pl_PL:
       long_form: 'oflagowano jako spam'
     inappropriate:
       title: 'Niewłaściwe'
-      description: 'Ten temat zawiera treści jakie rozsądna osoba może uznać za agresywne, obraźliwe,  lub sprzeczne z <a href="/guidelines">wytycznymi społeczności</a>.'
+      description: 'Ten temat zawiera treści jakie rozsądna osoba może uznać za agresywne, obraźliwe,  lub sprzeczne z <a href="%{base_url}/guidelines">wytycznymi społeczności</a>.'
       long_form: 'oflagowano jako niewłaściwe'
     notify_moderators:
       title: "Coś innego"
-      description: 'Ten wpis wymaga interwencji moderatora z uwagi na niezgodność z <a href="/guidelines">wytycznymi społeczności</a>, <a href="%{tos_url}">warunkami użytkowania</a> lub z innego, niewymienionego tu powodu.'
+      description: 'Ten wpis wymaga interwencji moderatora z uwagi na niezgodność z <a href="%{base_url}/guidelines">wytycznymi społeczności</a>, <a href="%{tos_url}">warunkami użytkowania</a> lub z innego, niewymienionego tu powodu.'
       long_form: 'oznaczył to dla uwagi moderatora'
       email_title: 'Temat "%{title}" wymaga uwagi moderatora'
       email_body: "%{link}\n\n%{message}"
@@ -824,11 +824,11 @@ pl_PL:
     sidekiq_warning: 'Sidekiq nie działa. Wiele zadań, takich jak wysyłanie emaili, jest wykonywane asynchronicznie przez sidekiqa. Zagwarantuj, że przynajmniej jeden proces sidekiqa działa. <a href="https://github.com/mperham/sidekiq" target="_blank">Dowiedz się więcej o Sidekiqu</a>.'
     queue_size_warning: 'Liczba oczekujących zadań wynosi %{queue_size}, to dużo. Może to wskazywać na problem z procesem (procesami) Sidekiq, lub możesz potrzebować więcej pracowników Sidekiq.'
     memory_warning: 'Twój serwer działa z mniej niż 1 GB pamięci całkowitej. Przynajmniej 1 GB pamięci jest zalecany.'
-    google_oauth2_config_warning: 'Serwer został skonfigurowany, aby umożliwić rejestracje i logowanie za pomocą Google OAuth2 (enable_google_oauth2_logins), ale id klienta oraz tajne wartości klienta nie są ustawione. Przejdź do <a href="/admin/site_settings">strony ustawień</a> i zaktualizuj ustawienia, <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank"> Zobacz przewodnik, aby dowiedzieć się więcej</a>.'
-    facebook_config_warning: 'Serwer jest skonfigurowany by pozwalać na rejestrację i logowanie za pomocą Facebooka (enable_facebook_logins), ale identyfikator i sekret aplikacji nie są ustawione. Przejdź do <a href="/admin/site_settings">ustawień serwisu</a> i zmień ustawienia. <a href="https://meta.discourse.org/t/configuring-facebook-login-for-discourse/13394" target="_blank">Zobacz ten poradnik by dowiedzieć się więcej</a>.'
-    twitter_config_warning: 'Serwer jest skonfigurowany by pozwalać na rejestrację i logowanie za pomocą Twittera (enable_twitter_logins), ale klucz i sekret nie są ustawione. Przejdź do <a href="/admin/site_settings">ustawień serwisu</a> i zmień ustawienia. <a href="https://meta.discourse.org/t/configuring-twitter-login-for-discourse/13395" target="_blank">Zobacz ten poradnik by dowiedzieć się więcej</a>.'
-    github_config_warning: 'Serwer jest skonfigurowany by pozwalać na rejestrację i logowanie za pomocą GitHuba (enable_github_logins), ale id klienta i sekret nie są ustawione. Przejdź do <a href="/admin/site_settings">ustawień serwisu</a> i zmień ustawienia. <a href="https://meta.discourse.org/t/configuring-github-login-for-discourse/13745" target="_blank">Zobacz ten poradnik by dowiedzieć się więcej</a>.'
-    failing_emails_warning: '%{num_failed_jobs} prac emailowych nie powiodło się. Sprawdź plik app.yml i upewnij się, że ustawienia serwera poczty są poprawne. <a href="/sidekiq/retries" target="_blank">Zobacz nieudane prace w Sidekiqu</a>.'
+    google_oauth2_config_warning: 'Serwer został skonfigurowany, aby umożliwić rejestracje i logowanie za pomocą Google OAuth2 (enable_google_oauth2_logins), ale id klienta oraz tajne wartości klienta nie są ustawione. Przejdź do <a href="%{base_url}/admin/site_settings">strony ustawień</a> i zaktualizuj ustawienia, <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank"> Zobacz przewodnik, aby dowiedzieć się więcej</a>.'
+    facebook_config_warning: 'Serwer jest skonfigurowany by pozwalać na rejestrację i logowanie za pomocą Facebooka (enable_facebook_logins), ale identyfikator i sekret aplikacji nie są ustawione. Przejdź do <a href="%{base_url}/admin/site_settings">ustawień serwisu</a> i zmień ustawienia. <a href="https://meta.discourse.org/t/configuring-facebook-login-for-discourse/13394" target="_blank">Zobacz ten poradnik by dowiedzieć się więcej</a>.'
+    twitter_config_warning: 'Serwer jest skonfigurowany by pozwalać na rejestrację i logowanie za pomocą Twittera (enable_twitter_logins), ale klucz i sekret nie są ustawione. Przejdź do <a href="%{base_url}/admin/site_settings">ustawień serwisu</a> i zmień ustawienia. <a href="https://meta.discourse.org/t/configuring-twitter-login-for-discourse/13395" target="_blank">Zobacz ten poradnik by dowiedzieć się więcej</a>.'
+    github_config_warning: 'Serwer jest skonfigurowany by pozwalać na rejestrację i logowanie za pomocą GitHuba (enable_github_logins), ale id klienta i sekret nie są ustawione. Przejdź do <a href="%{base_url}/admin/site_settings">ustawień serwisu</a> i zmień ustawienia. <a href="https://meta.discourse.org/t/configuring-github-login-for-discourse/13745" target="_blank">Zobacz ten poradnik by dowiedzieć się więcej</a>.'
+    failing_emails_warning: '%{num_failed_jobs} prac emailowych nie powiodło się. Sprawdź plik app.yml i upewnij się, że ustawienia serwera poczty są poprawne. <a href="%{base_url}/sidekiq/retries" target="_blank">Zobacz nieudane prace w Sidekiqu</a>.'
     subfolder_ends_in_slash: "Twoje ustawienie podfolderu jest niepoprawne; DISCOURSE_RELATIVE_URL_ROOT kończy się slashem."
     email_polling_errored_recently:
       one: "Email polling wygenerował 1 błąd w przeciągu ostatniej doby. Więcej szczegółów w <a href='/logs' target='_blank'>logach</a>."
@@ -2084,7 +2084,7 @@ pl_PL:
 
   terms_of_service:
     title: "Warunki użytkowania serwisu"
-    signup_form_message: 'Przeczytałem i zgadzam się z <a href="/tos" target="_blank">Regulaminem Serwisu</a>.'
+    signup_form_message: 'Przeczytałem i zgadzam się z <a href="%{base_url}/tos" target="_blank">Regulaminem Serwisu</a>.'
   deleted: 'usunięte'
   image: "obraz"
   upload:

--- a/config/locales/server.pt.yml
+++ b/config/locales/server.pt.yml
@@ -480,8 +480,8 @@ pt:
       email_body: "%{link}\n\n%{message}"
     inappropriate:
       title: 'Inapropriado'
-      description: 'Esta mensagem contém conteúdo que uma pessoa sensata iria considerar ofensivo, abusivo, ou como uma violação das <a href="/guidelines"> orientações da nossa comunidade</a>.'
-      short_description: 'Uma violação das <a href="/guidelines">nossas linhas diretrizes comunitárias</a>'
+      description: 'Esta mensagem contém conteúdo que uma pessoa sensata iria considerar ofensivo, abusivo, ou como uma violação das <a href="%{base_url}/guidelines"> orientações da nossa comunidade</a>.'
+      short_description: 'Uma violação das <a href="%{base_url}/guidelines">nossas linhas diretrizes comunitárias</a>'
       long_form: 'sinalizou isto como inapropriado'
     notify_user:
       title: 'Enviar uma mensagem a @{{username}}'
@@ -518,11 +518,11 @@ pt:
       long_form: 'sinalizou isto como spam'
     inappropriate:
       title: 'Inapropriado'
-      description: 'Este tópico contém conteúdo que uma pessoa sensata consideraria ofensivo, abusivo ou como uma violação das <a href="/guidelines">orientações da nossa comunidades</a>.'
+      description: 'Este tópico contém conteúdo que uma pessoa sensata consideraria ofensivo, abusivo ou como uma violação das <a href="%{base_url}/guidelines">orientações da nossa comunidades</a>.'
       long_form: 'sinalizou isto como inapropriado'
     notify_moderators:
       title: "Algo Mais"
-      description: 'Este tópico requer a atenção geral do pessoal baseado nas <a href="/guidelines">orientações</a>, <a href="%{tos_url}">Termos e Condições</a>, ou por outra razão não listada acima.'
+      description: 'Este tópico requer a atenção geral do pessoal baseado nas <a href="%{base_url}/guidelines">orientações</a>, <a href="%{tos_url}">Termos e Condições</a>, ou por outra razão não listada acima.'
       long_form: 'sinalizou isto para obter a atenção do moderador'
       email_title: 'O tópico "%{title}" requer a atenção do moderador'
       email_body: "%{link}\n\n%{message}"
@@ -704,11 +704,11 @@ pt:
     sidekiq_warning: 'Sidekiq não está em execução. Muitas tarefas, como envio de emails, são executadas de forma assíncrona pelo sidekiq. Por favor certifique-se de que pelo menos um processo sidekiq está em execução. <a href="https://github.com/mperham/sidekiq" target="_blank">Aprenda sobre Sidekiq aqui</a>.'
     queue_size_warning: 'O número de trabalhos na fila é %{queue_size}, o que é alto. Isto pode indicar um problema com o(s) processo(s) Sidekiq, ou pode necessitar de adicionar mais trabalhadores Sidekiq.'
     memory_warning: 'O seu servidor está a executar com menos de 1 GB de memória total. Pelo menos 1 GB é a quantidade de memória recomendada.'
-    google_oauth2_config_warning: 'O servidor está configurado para permitir inscrever-se e entrar com o Google OAuth2 (enable_google_oauth2_logins), mas o id e os valores privados do cliente não estão configurados. Vá   <a href="/admin/site_settings">às Configurações do Sítio</a> e atualize as definições. <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">Veja este guia para saber mais</a>.'
-    facebook_config_warning: 'O servidor está configurado para permitir inscrever-se e entrar com o Facebook (enable_facebook_logins), mas o id e os valores privados da aplicação não estão configurados. Vá  <a href="/admin/site_settings">às Configurações do Sítio</a> e atualize as definições. <a href="https://meta.discourse.org/t/configuring-facebook-login-for-discourse/13394" target="_blank">Veja este guia para saber mais</a>.'
-    twitter_config_warning: 'O servidor está configurado para permitir inscrever-se e entrar com o Twitter (enable_twitter_logins), mas a chave e os valores privados não estão configurados. Vá <a href="/admin/site_settings">às Configurações do Sítio</a> e atualize as definições. <a href="https://meta.discourse.org/t/configuring-twitter-login-for-discourse/13395" target="_blank">Veja este guia para saber mais</a>.'
-    github_config_warning: 'O servidor está configurado para permitir inscrever-se e entrar com o GitHub (enable_github_logins), mas o id e valores privados do cliente não estão configurados. Vá <a href="/admin/site_settings">às Configurações do Sítio</a> e atualize as definições. <a href="https://meta.discourse.org/t/configuring-github-login-for-discourse/13745" target="_blank">Veja este guia para saber mais</a>.'
-    failing_emails_warning: 'Há %{num_failed_jobs} tarefas de email que falharam. Verifique o seu app.yml e assegure-se que as configurações do servidor de email estão corretas. <a href="/sidekiq/retries" target="_blank"> Veja as tarefas que falharam no Sidekiq</a>.'
+    google_oauth2_config_warning: 'O servidor está configurado para permitir inscrever-se e entrar com o Google OAuth2 (enable_google_oauth2_logins), mas o id e os valores privados do cliente não estão configurados. Vá   <a href="%{base_url}/admin/site_settings">às Configurações do Sítio</a> e atualize as definições. <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">Veja este guia para saber mais</a>.'
+    facebook_config_warning: 'O servidor está configurado para permitir inscrever-se e entrar com o Facebook (enable_facebook_logins), mas o id e os valores privados da aplicação não estão configurados. Vá  <a href="%{base_url}/admin/site_settings">às Configurações do Sítio</a> e atualize as definições. <a href="https://meta.discourse.org/t/configuring-facebook-login-for-discourse/13394" target="_blank">Veja este guia para saber mais</a>.'
+    twitter_config_warning: 'O servidor está configurado para permitir inscrever-se e entrar com o Twitter (enable_twitter_logins), mas a chave e os valores privados não estão configurados. Vá <a href="%{base_url}/admin/site_settings">às Configurações do Sítio</a> e atualize as definições. <a href="https://meta.discourse.org/t/configuring-twitter-login-for-discourse/13395" target="_blank">Veja este guia para saber mais</a>.'
+    github_config_warning: 'O servidor está configurado para permitir inscrever-se e entrar com o GitHub (enable_github_logins), mas o id e valores privados do cliente não estão configurados. Vá <a href="%{base_url}/admin/site_settings">às Configurações do Sítio</a> e atualize as definições. <a href="https://meta.discourse.org/t/configuring-github-login-for-discourse/13745" target="_blank">Veja este guia para saber mais</a>.'
+    failing_emails_warning: 'Há %{num_failed_jobs} tarefas de email que falharam. Verifique o seu app.yml e assegure-se que as configurações do servidor de email estão corretas. <a href="%{base_url}/sidekiq/retries" target="_blank"> Veja as tarefas que falharam no Sidekiq</a>.'
     subfolder_ends_in_slash: "A configuração da sua sub-página está incorreta; o DISCOURSE_RELATIVE_URL_ROOT termina com um traço."
     email_polling_errored_recently:
       one: "A consulta automática de emails gerou um erro nas últimas 24 horas. Consulte em <a href='/logs' target='_blank'>os registos</a> para mais detalhes."
@@ -1585,7 +1585,7 @@ pt:
     search_title: "Pesquisar neste sítio"
   terms_of_service:
     title: "Termos de Serviço"
-    signup_form_message: 'Li e aceito os <a href="/tos" target="_blank">Termos de Serviço</a>.'
+    signup_form_message: 'Li e aceito os <a href="%{base_url}/tos" target="_blank">Termos de Serviço</a>.'
   deleted: 'eliminado'
   upload:
     edit_reason: "cópias locais de imagens transferidas"

--- a/config/locales/server.pt_BR.yml
+++ b/config/locales/server.pt_BR.yml
@@ -637,8 +637,8 @@ pt_BR:
       email_body: "%{link}\n\n%{message}"
     inappropriate:
       title: 'Inapropriado'
-      description: 'Este post contém conteúdo que uma pessoa razoável consideraria ofensivo, abusivo, ou uma violação das <a href="/guidelines">nossas diretrizes da comunidade</a>.'
-      short_description: 'Uma violação de <a href="/guidelines">nossas diretrizes da comunidade</a>'
+      description: 'Este post contém conteúdo que uma pessoa razoável consideraria ofensivo, abusivo, ou uma violação das <a href="%{base_url}/guidelines">nossas diretrizes da comunidade</a>.'
+      short_description: 'Uma violação de <a href="%{base_url}/guidelines">nossas diretrizes da comunidade</a>'
       long_form: 'sinalizado como inapropriado'
     notify_user:
       title: 'Envie ao(à) @ {{nome de usuário}} uma mensagem'
@@ -684,12 +684,12 @@ pt_BR:
       short_description: 'Este é um anúncio'
     inappropriate:
       title: 'Impróprio'
-      description: 'Este tópico contém um conteúdo que uma pessoa razoável consideraria ofensivo, abusivo, ou violação de <a href="/guidelines">nossas diretrizes da comunidade</a>.'
+      description: 'Este tópico contém um conteúdo que uma pessoa razoável consideraria ofensivo, abusivo, ou violação de <a href="%{base_url}/guidelines">nossas diretrizes da comunidade</a>.'
       long_form: 'sinalizar como impróprio'
-      short_description: 'Uma violação de <a href="/guidelines">nossas diretrizes da comunidade</a>'
+      short_description: 'Uma violação de <a href="%{base_url}/guidelines">nossas diretrizes da comunidade</a>'
     notify_moderators:
       title: "Algo mais"
-      description: 'Este tópico requer a atenção geral da equipe baseado nas <a href="/guidelines">diretrizes da comunidade</a>,  no <a href="%{tos_url}">Termos de Serviço</a>, ou em outra razão não listada acima.'
+      description: 'Este tópico requer a atenção geral da equipe baseado nas <a href="%{base_url}/guidelines">diretrizes da comunidade</a>,  no <a href="%{tos_url}">Termos de Serviço</a>, ou em outra razão não listada acima.'
       long_form: 'sinalizar isso para atenção da moderação'
       short_description: 'Requer atenção da equipe por outro motivo'
       email_title: 'O tópico "%{title}" requer atenção do moderador'
@@ -968,11 +968,11 @@ pt_BR:
     sidekiq_warning: 'Sidekiq não está em execução. Muitas tarefas, como envio de emails, são executadas de forma assíncrona pelo sidekiq. Por favor certifique-se de que ao menos um processo sidekiq esteja execução. <a href="https://github.com/mperham/sidekiq" target="_blank">Aprenda sobre Sidekiq aqui</a>.'
     queue_size_warning: 'O número de processos na fila é %{queue_size}, o que é alto. Isso pode ser indicação de um problema com o(s) processo(s) do Sidekiq, ou você pode ter que adicionar mais Sidekiq workers.'
     memory_warning: 'Seu servidor está rodando com menos de 1 GB de memória total. Pelo menos 1 GB é quantidade de memória recomendada.'
-    google_oauth2_config_warning: 'O servidor está configurado para permitir o signup e login com Google OAuth2 (enable_google_oauth2_logins), mas os valores de Cliend Id e Secret não estão configurados. Vá para <a href="/admin/site_settings">as Configurações do Site</a> e atualize as configurações. <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">Veja este guia e aprenda mais</a>.'
-    facebook_config_warning: 'O servidor está configurado para permitir o signup e login com Facebook (enable_facebook_logins), mas os valores do App Id e App Secret não estão configurados. Vá para <a href="/admin/site_settings">as Configurações do Site</a> e atualize as configurações. <a href="https://meta.discourse.org/t/configuring-facebook-login-for-discourse/13394" target="_blank">Veja este guia e aprenda mais</a>.'
-    twitter_config_warning: 'O servidor está configurado para permitir o signup e login com Twitter (enable_twitter_logins), mas os valores de Key e Secret não estão configurados. Vá para <a href="/admin/site_settings">as Configurações do Site</a> e atualize as configurações. <a href="https://meta.discourse.org/t/configuring-twitter-login-for-discourse/13395" target="_blank">Veja este guia e aprenda mais</a>.'
-    github_config_warning: 'O servidor está configurado para permitir o signup e login com GitHub (enable_twitter_logins), mas os valores de Cliend Id e Secret não estão configurados. Vá para <a href="/admin/site_settings">the Site Settings</a> e atualize as configurações. <a href="https://meta.discourse.org/t/configuring-github-login-for-discourse/13745" target="_blank">Veja este guia e aprenda mais</a>.'
-    failing_emails_warning: 'Existem %{num_failed_jobs} tarefas de email que falharam. Verifique seu app.yml e se assegure que as configurações do servidor de email estão corretas. <a href="/sidekiq/retries" target="_blank">Veja as tarefas que falharam no Sidekiq</a>.'
+    google_oauth2_config_warning: 'O servidor está configurado para permitir o signup e login com Google OAuth2 (enable_google_oauth2_logins), mas os valores de Cliend Id e Secret não estão configurados. Vá para <a href="%{base_url}/admin/site_settings">as Configurações do Site</a> e atualize as configurações. <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">Veja este guia e aprenda mais</a>.'
+    facebook_config_warning: 'O servidor está configurado para permitir o signup e login com Facebook (enable_facebook_logins), mas os valores do App Id e App Secret não estão configurados. Vá para <a href="%{base_url}/admin/site_settings">as Configurações do Site</a> e atualize as configurações. <a href="https://meta.discourse.org/t/configuring-facebook-login-for-discourse/13394" target="_blank">Veja este guia e aprenda mais</a>.'
+    twitter_config_warning: 'O servidor está configurado para permitir o signup e login com Twitter (enable_twitter_logins), mas os valores de Key e Secret não estão configurados. Vá para <a href="%{base_url}/admin/site_settings">as Configurações do Site</a> e atualize as configurações. <a href="https://meta.discourse.org/t/configuring-twitter-login-for-discourse/13395" target="_blank">Veja este guia e aprenda mais</a>.'
+    github_config_warning: 'O servidor está configurado para permitir o signup e login com GitHub (enable_twitter_logins), mas os valores de Cliend Id e Secret não estão configurados. Vá para <a href="%{base_url}/admin/site_settings">the Site Settings</a> e atualize as configurações. <a href="https://meta.discourse.org/t/configuring-github-login-for-discourse/13745" target="_blank">Veja este guia e aprenda mais</a>.'
+    failing_emails_warning: 'Existem %{num_failed_jobs} tarefas de email que falharam. Verifique seu app.yml e se assegure que as configurações do servidor de email estão corretas. <a href="%{base_url}/sidekiq/retries" target="_blank">Veja as tarefas que falharam no Sidekiq</a>.'
     subfolder_ends_in_slash: "Sua configuração de subdiretórios está incorreta; DISCOURSE_RELATIVE_URL_ROOT termina com uma barra."
     email_polling_errored_recently:
       one: "A apuração de email gerou um erro nas últimas 24 horas. Veja <a href='/logs' target='_blank'>os logs</a> para mais detalhes."
@@ -2603,7 +2603,7 @@ pt_BR:
       Uma conta é necessária. Por favor, crie uma conta ou faça o login para continuar.
   terms_of_service:
     title: "Termos de Serviço"
-    signup_form_message: 'Eu li e aceito os <a href="/tos" target="_blank">Termos de Serviço</ a>.'
+    signup_form_message: 'Eu li e aceito os <a href="%{base_url}/tos" target="_blank">Termos de Serviço</ a>.'
   deleted: 'removido'
   image: "imagem"
   upload:

--- a/config/locales/server.ro.yml
+++ b/config/locales/server.ro.yml
@@ -489,7 +489,7 @@ ro:
       email_body: "%{link}\n\n%{message}"
     inappropriate:
       title: 'Necorespunzător'
-      description: 'Această postare are un conținut pe care o persoană rezonabilă l-ar putea considera drept ofensator, abuziv, sau o violare a <a href="/guidelines"> ghidului comunității</a>.'
+      description: 'Această postare are un conținut pe care o persoană rezonabilă l-ar putea considera drept ofensator, abuziv, sau o violare a <a href="%{base_url}/guidelines"> ghidului comunității</a>.'
       long_form: 'marcat ca necorespunzător'
     notify_user:
       title: 'Trimite-i un mesaj lui @{{username}}'
@@ -523,11 +523,11 @@ ro:
       long_form: 'Marchează ca spam'
     inappropriate:
       title: 'Necorespunzător'
-      description: 'Acest subiect are conținut ce ar putea fi considerat drept ofensator, abuziv, sau o violare a <a href="/guidelines"> regulilor comunității</a>.'
+      description: 'Acest subiect are conținut ce ar putea fi considerat drept ofensator, abuziv, sau o violare a <a href="%{base_url}/guidelines"> regulilor comunității</a>.'
       long_form: 'marcat cu marcaj de avertizare ca inadecvat'
     notify_moderators:
       title: "Alt motiv"
-      description: 'Acest subiect necesită atenția generală a echipei pe  baza <a href="/guidelines">ghidului</a>, <a href="%{tos_url}">CGU</a>, sau pentru un alt motiv care nu este menționat anterior.'
+      description: 'Acest subiect necesită atenția generală a echipei pe  baza <a href="%{base_url}/guidelines">ghidului</a>, <a href="%{tos_url}">CGU</a>, sau pentru un alt motiv care nu este menționat anterior.'
       long_form: 'marcat cu marcaj de avertizare în atenția moderatorilor'
       email_title: 'Subiectul "%{title}" necesită atenția moderatorilor'
       email_body: "%{link}\n\n%{message}"
@@ -717,11 +717,11 @@ ro:
     sidekiq_warning: 'Sidekiq nu este pornit. Multe acțiuni, cum ar fi trimiterea de emailuri, sunt executate asincron de către sidekiq. Asigură-te că măcar un proces din sidekiq este pornit. <a href="https://github.com/mperham/sidekiq" target="_blank"> Citește despre Sidekiq aici</a>.'
     queue_size_warning: 'Numărul de sarcini aflate în lista de așteptare este de %{queue_size}, ceea ce e mult. Asta poate indica o problemă cu procesul(ele) Sidekiq, sau că e necesar să adaugi mai multi  Sidekiq workers.'
     memory_warning: 'Serverul tău lucrează cu mai puțin de 1 GB memorie. Se recomandă cel puțin 1 GB memorie.'
-    google_oauth2_config_warning: 'Serverul e configurat să permită autentificarea cu Google OAuth2 (enable_google_oauth2_logins), dar valorile secrete ale clientului precum și id-ul clientului nu sunt setate. Mergi la <a href="/admin/site_settings">Setările site-ului</a> și modifică setările. <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">Vizualizează ghidul pentru mai multe informații</a>.'
-    facebook_config_warning: 'Serverul e configurat să permită înscrierea și autentificarea cu Facebook (enable_facebook_logins), dar app id și valoarea app secret nu sunt setate. Mergi la <a href="/admin/site_settings">Setările site-ului</a> și modifică setările. <a href="https://meta.discourse.org/t/configuring-facebook-login-for-discourse/13394" target="_blank">Vizualizează ghidul pentru mai multe informații</a>.'
-    twitter_config_warning: 'Serverul e configurat să permită înscrierea și autentificarea cu Twitter (enable_twitter_logins),dar cheia și valoarea secretă nu sunt setate. Mergi la <a href="/admin/site_settings">Setările site-ului</a> și modifică setarea. <a href="https://meta.discourse.org/t/configuring-twitter-login-for-discourse/13395" target="_blank">Vizualizează ghidul pentru mai multe informații</a>.'
-    github_config_warning: 'Serverul e configurat să permită înscrierea și autentificarea cu GitHub (enable_github_logins), dar id-ul de client și valorile secrete nu sunt setate. Mergi la <a href="/admin/site_settings">Setările site-ului</a> și modifică setarea. <a href="https://meta.discourse.org/t/configuring-github-login-for-discourse/13745" target="_blank">Vizualizează ghidul pentru mai multe informații</a>.'
-    failing_emails_warning: 'Există %{num_failed_jobs} (de) sarcini email care au eșuat. Verifică app.yml și asigură-te că setările serverului de mail sunt corecte. <a href="/sidekiq/retries" target="_blank">Vizualizează sarcini eșuate în Sidekiq</a>.'
+    google_oauth2_config_warning: 'Serverul e configurat să permită autentificarea cu Google OAuth2 (enable_google_oauth2_logins), dar valorile secrete ale clientului precum și id-ul clientului nu sunt setate. Mergi la <a href="%{base_url}/admin/site_settings">Setările site-ului</a> și modifică setările. <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">Vizualizează ghidul pentru mai multe informații</a>.'
+    facebook_config_warning: 'Serverul e configurat să permită înscrierea și autentificarea cu Facebook (enable_facebook_logins), dar app id și valoarea app secret nu sunt setate. Mergi la <a href="%{base_url}/admin/site_settings">Setările site-ului</a> și modifică setările. <a href="https://meta.discourse.org/t/configuring-facebook-login-for-discourse/13394" target="_blank">Vizualizează ghidul pentru mai multe informații</a>.'
+    twitter_config_warning: 'Serverul e configurat să permită înscrierea și autentificarea cu Twitter (enable_twitter_logins),dar cheia și valoarea secretă nu sunt setate. Mergi la <a href="%{base_url}/admin/site_settings">Setările site-ului</a> și modifică setarea. <a href="https://meta.discourse.org/t/configuring-twitter-login-for-discourse/13395" target="_blank">Vizualizează ghidul pentru mai multe informații</a>.'
+    github_config_warning: 'Serverul e configurat să permită înscrierea și autentificarea cu GitHub (enable_github_logins), dar id-ul de client și valorile secrete nu sunt setate. Mergi la <a href="%{base_url}/admin/site_settings">Setările site-ului</a> și modifică setarea. <a href="https://meta.discourse.org/t/configuring-github-login-for-discourse/13745" target="_blank">Vizualizează ghidul pentru mai multe informații</a>.'
+    failing_emails_warning: 'Există %{num_failed_jobs} (de) sarcini email care au eșuat. Verifică app.yml și asigură-te că setările serverului de mail sunt corecte. <a href="%{base_url}/sidekiq/retries" target="_blank">Vizualizează sarcini eșuate în Sidekiq</a>.'
     subfolder_ends_in_slash: "Setările subfolderului sunt incorecte; DISCOURSE_RELATIVE_URL_ROOT se termină cu slash."
     email_polling_errored_recently:
       one: "Email polling a generat o eroare în ultimele 24 de ore. Vizualizează <a href='/logs' target='_blank'>rapoartele</a> pentru mai multe detalii."
@@ -1640,7 +1640,7 @@ ro:
     search_title: "Caută în site"
   terms_of_service:
     title: "Condițiile generale de utilizare"
-    signup_form_message: 'Am citit și accept <a href="/tos" target="_blank">Condițiile generale de utilizare</a>.'
+    signup_form_message: 'Am citit și accept <a href="%{base_url}/tos" target="_blank">Condițiile generale de utilizare</a>.'
   deleted: 'șters'
   upload:
     edit_reason: "copii locale ale imaginilor descărcate"

--- a/config/locales/server.ru.yml
+++ b/config/locales/server.ru.yml
@@ -540,7 +540,7 @@ ru:
       email_body: "%{link}\n\n%{message}"
     inappropriate:
       title: 'Неприемлемо'
-      description: 'Это сообщение может быть оскорбительным или нарушает <a href="/guidelines">правила поведения</a>.'
+      description: 'Это сообщение может быть оскорбительным или нарушает <a href="%{base_url}/guidelines">правила поведения</a>.'
       long_form: 'отметить как неуместное'
     notify_user:
       title: 'Отправить @{{username}} личное сообщение'
@@ -575,7 +575,7 @@ ru:
       long_form: 'отмечено как спам'
     inappropriate:
       title: 'Неуместно'
-      description: 'Эта тема может быть сочтена оскорбительной или нарушает <a href="/guidelines">правила поведения на сайте</a>.'
+      description: 'Эта тема может быть сочтена оскорбительной или нарушает <a href="%{base_url}/guidelines">правила поведения на сайте</a>.'
       long_form: 'отмеченно как неуместное'
     notify_moderators:
       title: "Другое"
@@ -756,10 +756,10 @@ ru:
     host_names_warning: "Ваш файл config/database.yml использует локальное имя хоста по умолчанию. Поменяйте его на имя хоста вашего сайта."
     sidekiq_warning: 'Sidekiq не запущен. Сейчас многие задачи, такие как отправка электронных писем, выполняются асинхронно.  Пожалуйста, убедитесь, что хотя бы один процесс sidekiq запущен. <a href="https://github.com/mperham/sidekiq">Узнайте больше о  Sidekiq здесь</a>.'
     memory_warning: 'Общее количество памяти, используемое вашим сервером, составляет менее 1 GB. Рекомендовано использовать минимум 1 GB.'
-    google_oauth2_config_warning: 'Сервер позволяет регистрацию и вход на сайт с использованием учетной записи Google OAuth2 (enable_google_oauth2_logins), но id и секретные значения не заданы. Пройдите в раздел <a href="/admin/site_settings">Настройки сайта</a> и обновите настройки. <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">Ознакомьтесь с данным руководством для получения дополнительной информации</a>.'
-    facebook_config_warning: 'Сервер позволяет регистрацию и вход на сайт с использованием учетной записи Facebook (enable_facebook_logins), но id и секретные значения не заданы. Пройдите в раздел <a href="/admin/site_settings">Настройки сайта</a> и обновите настройки. <a href="https://meta.discourse.org/t/configuring-facebook-login-for-discourse/13394" target="_blank">Ознакомьтесь с данным руководством для получения дополнительной информации</a>.'
-    twitter_config_warning: 'Сервер позволяет регистрацию и вход на сайт с использованием учетной записи Twitter (enable_twitter_logins), но id и секретные значения не заданы. Пройдите в раздел <a href="/admin/site_settings">Настройки сайта</a> и обновите настройки. <a href="https://meta.discourse.org/t/configuring-twitter-login-for-discourse/13395" target="_blank"> Ознакомьтесь с данным руководством для получения дополнительной информации</a>.'
-    github_config_warning: 'Сервер позволяет регистрацию и вход на сайт с использованием учетной записи GitHub (enable_github_logins), но id и секретные значения не заданы. Пройдите в раздел <a href="/admin/site_settings">Настройки сайта</a> и обновите настройки. <a href="https://meta.discourse.org/t/configuring-github-login-for-discourse/13745" target="_blank">Ознакомьтесь с данным руководством для получения дополнительной информации</a>.'
+    google_oauth2_config_warning: 'Сервер позволяет регистрацию и вход на сайт с использованием учетной записи Google OAuth2 (enable_google_oauth2_logins), но id и секретные значения не заданы. Пройдите в раздел <a href="%{base_url}/admin/site_settings">Настройки сайта</a> и обновите настройки. <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">Ознакомьтесь с данным руководством для получения дополнительной информации</a>.'
+    facebook_config_warning: 'Сервер позволяет регистрацию и вход на сайт с использованием учетной записи Facebook (enable_facebook_logins), но id и секретные значения не заданы. Пройдите в раздел <a href="%{base_url}/admin/site_settings">Настройки сайта</a> и обновите настройки. <a href="https://meta.discourse.org/t/configuring-facebook-login-for-discourse/13394" target="_blank">Ознакомьтесь с данным руководством для получения дополнительной информации</a>.'
+    twitter_config_warning: 'Сервер позволяет регистрацию и вход на сайт с использованием учетной записи Twitter (enable_twitter_logins), но id и секретные значения не заданы. Пройдите в раздел <a href="%{base_url}/admin/site_settings">Настройки сайта</a> и обновите настройки. <a href="https://meta.discourse.org/t/configuring-twitter-login-for-discourse/13395" target="_blank"> Ознакомьтесь с данным руководством для получения дополнительной информации</a>.'
+    github_config_warning: 'Сервер позволяет регистрацию и вход на сайт с использованием учетной записи GitHub (enable_github_logins), но id и секретные значения не заданы. Пройдите в раздел <a href="%{base_url}/admin/site_settings">Настройки сайта</a> и обновите настройки. <a href="https://meta.discourse.org/t/configuring-github-login-for-discourse/13745" target="_blank">Ознакомьтесь с данным руководством для получения дополнительной информации</a>.'
   site_settings:
     censored_words: "Слова, которые будут автоматически заменены на &#9632;&#9632;&#9632;&#9632;"
     delete_old_hidden_posts: "Автоматически удалять сообщения, скрытые дольше чем 30 дней."
@@ -1320,7 +1320,7 @@ ru:
     search_button: "Поиск"
   terms_of_service:
     title: "Условия предоставления услуг"
-    signup_form_message: 'Я прочитал(а) и согласен(а) с <a href="/tos" target="_blank">пользовательским соглашением</a>.'
+    signup_form_message: 'Я прочитал(а) и согласен(а) с <a href="%{base_url}/tos" target="_blank">пользовательским соглашением</a>.'
   deleted: 'удалено'
   upload:
     edit_reason: "загружены и сохранены локально использованные с других сайтов картинки"

--- a/config/locales/server.sk.yml
+++ b/config/locales/server.sk.yml
@@ -516,7 +516,7 @@ sk:
       email_body: "%{link}\n\n%{message}"
     inappropriate:
       title: 'Nevhodné'
-      description: 'Obsah tohto príspevku môže byť nektorými osobami považovaný za urážlivý, hanlivý, alebo  porušujúci  <a href="/guidelines">pravidlá slušného správania</a>.'
+      description: 'Obsah tohto príspevku môže byť nektorými osobami považovaný za urážlivý, hanlivý, alebo  porušujúci  <a href="%{base_url}/guidelines">pravidlá slušného správania</a>.'
       long_form: 'toto označ ako nevhodné'
     notify_user:
       title: 'Poslať @{{username}} správu'
@@ -547,11 +547,11 @@ sk:
       long_form: 'označiť toto ako spam'
     inappropriate:
       title: 'Nevhodné'
-      description: 'Táto téma môže byť nektorými osobami považovaná za urážlivú, hanlivú, alebo  porušujúcu  <a href="/guidelines">pravidlá slušného správania</a>.'
+      description: 'Táto téma môže byť nektorými osobami považovaná za urážlivú, hanlivú, alebo  porušujúcu  <a href="%{base_url}/guidelines">pravidlá slušného správania</a>.'
       long_form: 'toto označ ako nevhodné'
     notify_moderators:
       title: "Niečo iné"
-      description: 'Táto téma vyžaduje pozornosť obsluhy na základe <a href="/guidelines">pravidiel</a>, <a href="%{tos_url}">TOS</a>, alebo z iného dôvodu ako je uvedené vyššie.'
+      description: 'Táto téma vyžaduje pozornosť obsluhy na základe <a href="%{base_url}/guidelines">pravidiel</a>, <a href="%{tos_url}">TOS</a>, alebo z iného dôvodu ako je uvedené vyššie.'
       long_form: 'označené do pozornosti moderátora'
       email_title: 'Téma "%{title}" vyžaduje pozornosť moderátora'
       email_body: "%{link}\n\n%{message}"
@@ -715,11 +715,11 @@ sk:
     sidekiq_warning: 'Sidekiq neni spustený. Množstvo úloh, ako napríklad posielanie emailov, je vykonávaných asynchrónne prostrednictvom sidekiq. Prosim zabezpečte aby bol spustený aspoň jeden proces sidekiq <a href="https://github.com/mperham/sidekiq" target="_blank">Viac o Sidekiq</a>.'
     queue_size_warning: 'Počet úloh v zásobníku je %{queue_size}, čo je dosť veľa. To môže byť príznakom problému s procesom (procesmi) Sidekiq, alebo by ste mali spustiť viac Sidekiq procesov.'
     memory_warning: 'Váš server beží s menej než 1 GB pamäte. Odporúča sa minimálne 1GB. '
-    google_oauth2_config_warning: 'Server má nakonfigurovanú podporu registrácie a prihlásenia pomocou Google OAuth2 (enable_google_oauth2_logins), ale identifikačné údaje klienta a jeho tajné hodnoty nie sú nastavené. Navštívte <a href="/admin/site_settings">Nastavenia stránky</a> a aktualizujte nastavenia. <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">Chcete vedieť viac? Pozrite si tento návod</a>.'
-    facebook_config_warning: 'Server má nakonfigurovanú podporu registrácie a prihlásenia pomocou Facebooku (enable_facebook_logins), ale údaje "app Id" a tajné hodnoty nie sú nastavené. Navštívte <a href="/admin/site_settings">Nastavenia stránky</a> a aktualizujte nastavenia.  <a href="https://meta.discourse.org/t/configuring-facebook-login-for-discourse/13394" target="_blank">Chcete vedieť viac? Pozrite si tento návod</a>.'
-    twitter_config_warning: 'Server má nakonfigurovanú podporu registrácie a prihlásenia pomocou Twitteru (enable_twitter_logins), ale kľúč a tajné hodnoty nie sú nastavené. Navštívte  <a href="/admin/site_settings">Nastavenia stránky</a> a aktualizujte nastavenia. <a href="https://meta.discourse.org/t/configuring-twitter-login-for-discourse/13395" target="_blank">Chcete vedieť viac? Pozrite si tento návod</a>.'
-    github_config_warning: 'Server má nakonfigurovanú podporu registrácie a prihlásenia pomocou GitHub (enable_github_logins), ale identifikačné údaje klienta a jeho tajné hodnoty nie sú nastavené.. Navštívte <a href="/admin/site_settings">Nastavenia stránky</a> a aktualizujte nastavenia.<a href="https://meta.discourse.org/t/configuring-github-login-for-discourse/13745" target="_blank">Chcete vedieť viac? Pozrite si tento návod</a>.'
-    failing_emails_warning: 'Existuje %{num_failed_jobs} neuspešných emailých pokusov. Skontrolujte Váš app.yml a uistite sa, že nastavenia email serveru máte správne. <a href="/sidekiq/retries" target="_blank">Pozrieť neúspešné pokusy v Sidekiq</a>.'
+    google_oauth2_config_warning: 'Server má nakonfigurovanú podporu registrácie a prihlásenia pomocou Google OAuth2 (enable_google_oauth2_logins), ale identifikačné údaje klienta a jeho tajné hodnoty nie sú nastavené. Navštívte <a href="%{base_url}/admin/site_settings">Nastavenia stránky</a> a aktualizujte nastavenia. <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">Chcete vedieť viac? Pozrite si tento návod</a>.'
+    facebook_config_warning: 'Server má nakonfigurovanú podporu registrácie a prihlásenia pomocou Facebooku (enable_facebook_logins), ale údaje "app Id" a tajné hodnoty nie sú nastavené. Navštívte <a href="%{base_url}/admin/site_settings">Nastavenia stránky</a> a aktualizujte nastavenia.  <a href="https://meta.discourse.org/t/configuring-facebook-login-for-discourse/13394" target="_blank">Chcete vedieť viac? Pozrite si tento návod</a>.'
+    twitter_config_warning: 'Server má nakonfigurovanú podporu registrácie a prihlásenia pomocou Twitteru (enable_twitter_logins), ale kľúč a tajné hodnoty nie sú nastavené. Navštívte  <a href="%{base_url}/admin/site_settings">Nastavenia stránky</a> a aktualizujte nastavenia. <a href="https://meta.discourse.org/t/configuring-twitter-login-for-discourse/13395" target="_blank">Chcete vedieť viac? Pozrite si tento návod</a>.'
+    github_config_warning: 'Server má nakonfigurovanú podporu registrácie a prihlásenia pomocou GitHub (enable_github_logins), ale identifikačné údaje klienta a jeho tajné hodnoty nie sú nastavené.. Navštívte <a href="%{base_url}/admin/site_settings">Nastavenia stránky</a> a aktualizujte nastavenia.<a href="https://meta.discourse.org/t/configuring-github-login-for-discourse/13745" target="_blank">Chcete vedieť viac? Pozrite si tento návod</a>.'
+    failing_emails_warning: 'Existuje %{num_failed_jobs} neuspešných emailých pokusov. Skontrolujte Váš app.yml a uistite sa, že nastavenia email serveru máte správne. <a href="%{base_url}/sidekiq/retries" target="_blank">Pozrieť neúspešné pokusy v Sidekiq</a>.'
     subfolder_ends_in_slash: "Vaše nastavenie podadresára je chybné, DISCOURSE_RELATIVE_URL_ROOT je ukončené lomítkom."
   site_settings:
     censored_words: "Slová, ktoré budu automatický nahradené znakmi &#9632;&#9632;&#9632;&#9632;"
@@ -1248,7 +1248,7 @@ sk:
     search_title: "Prehľadať tieto stránky"
   terms_of_service:
     title: "Podmienky používania"
-    signup_form_message: 'Prečítal som si <a href="/tos" target="_blank">Podmienky používania</a> a súhlasím s nimi.'
+    signup_form_message: 'Prečítal som si <a href="%{base_url}/tos" target="_blank">Podmienky používania</a> a súhlasím s nimi.'
   deleted: 'vymazané'
   upload:
     edit_reason: "stiahnuté lokálne kópie obrázkov"

--- a/config/locales/server.sq.yml
+++ b/config/locales/server.sq.yml
@@ -305,7 +305,7 @@ sq:
       email_body: "%{link}\n\n%{message}"
     inappropriate:
       title: 'i papërshtatshëm'
-      description: 'Ky postim përmban pjesë që një person i arsyeshëm do ta quante ofenduese, fyese, ose kundër <a href="/guidelines">udhëzimeve të komunitetit tonë</a>.'
+      description: 'Ky postim përmban pjesë që një person i arsyeshëm do ta quante ofenduese, fyese, ose kundër <a href="%{base_url}/guidelines">udhëzimeve të komunitetit tonë</a>.'
       long_form: 'sinjalizoi këtë postim si të papërshtatshëm'
     notify_user:
       title: 'Dërgoji @{{username}} një mesazh'
@@ -331,7 +331,7 @@ sq:
       long_form: 'sinjalizoi këtë postim si spam'
     inappropriate:
       title: 'I papërshtatshëm'
-      description: 'Ky postim përmban pjesë që një person i arsyeshëm do ta quante ofenduese, fyese, ose kundër <a href="/guidelines">udhëzimeve të komunitetit tonë</a>.'
+      description: 'Ky postim përmban pjesë që një person i arsyeshëm do ta quante ofenduese, fyese, ose kundër <a href="%{base_url}/guidelines">udhëzimeve të komunitetit tonë</a>.'
       long_form: 'shënoje si të papërshtatshme'
     notify_moderators:
       title: "Diçka Tjetër"
@@ -492,10 +492,10 @@ sq:
     sidekiq_warning: 'Sidekiq is not running. Many tasks, like sending emails, are executed asynchronously by sidekiq. Please ensure at least one sidekiq process is running. <a href="https://github.com/mperham/sidekiq" target="_blank">Learn about Sidekiq here</a>.'
     queue_size_warning: 'The number of queued jobs is %{queue_size}, which is high. This could indicate a problem with the Sidekiq process(es), or you may need to add more Sidekiq workers.'
     memory_warning: 'Your server is running with less than 1 GB of total memory. At least 1 GB of memory is recommended.'
-    google_oauth2_config_warning: 'The server is configured to allow signup and log in with Google OAuth2 (enable_google_oauth2_logins), but the client id and client secret values are not set. Go to <a href="/admin/site_settings">the Site Settings</a> and update the settings. <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">See this guide to learn more</a>.'
-    facebook_config_warning: 'The server is configured to allow signup and log in with Facebook (enable_facebook_logins), but the app id and app secret values are not set. Go to <a href="/admin/site_settings">the Site Settings</a> and update the settings. <a href="https://meta.discourse.org/t/configuring-facebook-login-for-discourse/13394" target="_blank">See this guide to learn more</a>.'
-    twitter_config_warning: 'The server is configured to allow signup and log in with Twitter (enable_twitter_logins), but the key and secret values are not set. Go to <a href="/admin/site_settings">the Site Settings</a> and update the settings. <a href="https://meta.discourse.org/t/configuring-twitter-login-for-discourse/13395" target="_blank">See this guide to learn more</a>.'
-    github_config_warning: 'The server is configured to allow signup and log in with GitHub (enable_github_logins), but the client id and secret values are not set. Go to <a href="/admin/site_settings">the Site Settings</a> and update the settings. <a href="https://meta.discourse.org/t/configuring-github-login-for-discourse/13745" target="_blank">See this guide to learn more</a>.'
+    google_oauth2_config_warning: 'The server is configured to allow signup and log in with Google OAuth2 (enable_google_oauth2_logins), but the client id and client secret values are not set. Go to <a href="%{base_url}/admin/site_settings">the Site Settings</a> and update the settings. <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">See this guide to learn more</a>.'
+    facebook_config_warning: 'The server is configured to allow signup and log in with Facebook (enable_facebook_logins), but the app id and app secret values are not set. Go to <a href="%{base_url}/admin/site_settings">the Site Settings</a> and update the settings. <a href="https://meta.discourse.org/t/configuring-facebook-login-for-discourse/13394" target="_blank">See this guide to learn more</a>.'
+    twitter_config_warning: 'The server is configured to allow signup and log in with Twitter (enable_twitter_logins), but the key and secret values are not set. Go to <a href="%{base_url}/admin/site_settings">the Site Settings</a> and update the settings. <a href="https://meta.discourse.org/t/configuring-twitter-login-for-discourse/13395" target="_blank">See this guide to learn more</a>.'
+    github_config_warning: 'The server is configured to allow signup and log in with GitHub (enable_github_logins), but the client id and secret values are not set. Go to <a href="%{base_url}/admin/site_settings">the Site Settings</a> and update the settings. <a href="https://meta.discourse.org/t/configuring-github-login-for-discourse/13745" target="_blank">See this guide to learn more</a>.'
   site_settings:
     censored_words: "Fjalët do të zhvendosen automatikisht me &#9632;&#9632;&#9632;&#9632;"
     delete_old_hidden_posts: "Auto-delete any hidden posts that stay hidden for more than 30 days."
@@ -1069,7 +1069,7 @@ sq:
     search_title: "Kërko në këtë faqe"
   terms_of_service:
     title: "Kushtet e shërbimit"
-    signup_form_message: 'I have read and accept the <a href="/tos" target="_blank">Terms of Service</a>.'
+    signup_form_message: 'I have read and accept the <a href="%{base_url}/tos" target="_blank">Terms of Service</a>.'
   deleted: 'deleted'
   upload:
     edit_reason: "downloaded local copies of images"

--- a/config/locales/server.sv.yml
+++ b/config/locales/server.sv.yml
@@ -442,7 +442,7 @@ sv:
       email_body: "%{link}\n\n%{message}"
     inappropriate:
       title: 'Olämpligt'
-      description: 'Detta inläggs innehåll inkluderar saker som en förnuftig person skulle anse vara stötande, kränkande eller en överträdelse av <a href="/guidelines">våra riktlinjer</a>.'
+      description: 'Detta inläggs innehåll inkluderar saker som en förnuftig person skulle anse vara stötande, kränkande eller en överträdelse av <a href="%{base_url}/guidelines">våra riktlinjer</a>.'
       long_form: 'flagga detta som olämpligt'
     notify_user:
       title: 'Skicka ett meddelande till @{{username}} '
@@ -476,11 +476,11 @@ sv:
       long_form: 'flaggad som spam'
     inappropriate:
       title: 'Olämpligt'
-      description: 'Detta ämne har innehåll som en förnuftig person skulle anse vara stötande, kränkande eller en överträdelse av <a href="/guidelines">våra riktlinjer</a>.'
+      description: 'Detta ämne har innehåll som en förnuftig person skulle anse vara stötande, kränkande eller en överträdelse av <a href="%{base_url}/guidelines">våra riktlinjer</a>.'
       long_form: 'flaggad som olämplig'
     notify_moderators:
       title: "Annat"
-      description: 'Det här inlägget kräver generell uppmärksamhet från personalen baserat på  <a href="/guidelines">riktlinjerna</a>, <a href="%{tos_url}">användarvillkoren</a> eller på grund av en annan anledning som inte finns med ovan.'
+      description: 'Det här inlägget kräver generell uppmärksamhet från personalen baserat på  <a href="%{base_url}/guidelines">riktlinjerna</a>, <a href="%{tos_url}">användarvillkoren</a> eller på grund av en annan anledning som inte finns med ovan.'
       long_form: 'flaggade det här för granskning av moderator'
       email_title: 'Ämnet "%{title}" kräver moderators uppmärksamhet'
       email_body: "%{link}\n\n%{message}"
@@ -661,11 +661,11 @@ sv:
     sidekiq_warning: 'Sidekiq körs inte. Många uppgifter, sm att skicka e-post, utförs asynkront av sidekiq. Var vänlig se till att minst en sidekiqprocess körs. <a href="https://github.com/mperham/sidekiq">Läs mer om Sidekiq här</a>.'
     queue_size_warning: 'Antal köade jobb är %{queue_size}, vilket är ganska högt. Det kan indikera ett problem med Sidekiq process(er), eller så kanske du behöver lägga till fler Sidekiqarbetare.'
     memory_warning: 'Din server körs med mindre än 1 GB minne. Minne på minst 1 GB är rekommenderat.'
-    google_oauth2_config_warning: 'Servern är konfigurerad till att tillåta registrering och inloggning med Google OAuth2 (inställningen enable_google_oauth2). men klient-id och klienthemlighetsvärden är inte satta. Gå till <a href="/admin/site_settings">Webbplatsinställningarna</a> och uppdatera inställningarna. <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">Läs den här guiden för att lära dig mer</a>.'
-    facebook_config_warning: 'Servern är konfigurerad till att tillåta registrering och inloggning med Facebook (inställningen enable_facebook_logins). men app-id och appens hemlighetsvärden är inte satta. Gå till <a href="/admin/site_settings">Webbplatsinställningarna</a> och uppdatera inställningarna. <a href="https://meta.discourse.org/t/configuring-facebook-login-for-discourse/13394" target="_blank">Läs den här guiden för att lära dig mer</a>.'
-    twitter_config_warning: 'Servern är konfigurerad till att tillåta registrering och inloggning med Twitter (inställningen twitter_logins). men nyckel- och hemlighetsvärden är inte satta. Gå till <a href="/admin/site_settings">Webbplatsinställningarna</a> och uppdatera inställningarna. <a href="https://meta.discourse.org/t/configuring-twitter-login-for-discourse/13395" target="_blank">Läs den här guiden för att lära dig mer</a>.'
-    github_config_warning: 'Servern är konfigurerad till att tillåta registrering och inloggning med GitHub (inställningen twitter_logins). men klient-id och hemlighetsvärden är inte satta. Gå till <a href="/admin/site_settings">Webbplatsinställningarna</a> och uppdatera inställningarna. <a href="https://meta.discourse.org/t/configuring-github-login-for-discourse/13745" target="_blank">Läs den här guiden för att lära dig mer</a>.'
-    failing_emails_warning: 'Det finns %{num_failed_jobs} e-postutskick som har misslyckats. Kontrollera din app.yml-fil för att säkerställa att serverinställningarna för e-post är korrekta. <a href="/sidekiq/retries" target="_blank">Se alla misslyckade utskick i Sidekiq</a>.'
+    google_oauth2_config_warning: 'Servern är konfigurerad till att tillåta registrering och inloggning med Google OAuth2 (inställningen enable_google_oauth2). men klient-id och klienthemlighetsvärden är inte satta. Gå till <a href="%{base_url}/admin/site_settings">Webbplatsinställningarna</a> och uppdatera inställningarna. <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">Läs den här guiden för att lära dig mer</a>.'
+    facebook_config_warning: 'Servern är konfigurerad till att tillåta registrering och inloggning med Facebook (inställningen enable_facebook_logins). men app-id och appens hemlighetsvärden är inte satta. Gå till <a href="%{base_url}/admin/site_settings">Webbplatsinställningarna</a> och uppdatera inställningarna. <a href="https://meta.discourse.org/t/configuring-facebook-login-for-discourse/13394" target="_blank">Läs den här guiden för att lära dig mer</a>.'
+    twitter_config_warning: 'Servern är konfigurerad till att tillåta registrering och inloggning med Twitter (inställningen twitter_logins). men nyckel- och hemlighetsvärden är inte satta. Gå till <a href="%{base_url}/admin/site_settings">Webbplatsinställningarna</a> och uppdatera inställningarna. <a href="https://meta.discourse.org/t/configuring-twitter-login-for-discourse/13395" target="_blank">Läs den här guiden för att lära dig mer</a>.'
+    github_config_warning: 'Servern är konfigurerad till att tillåta registrering och inloggning med GitHub (inställningen twitter_logins). men klient-id och hemlighetsvärden är inte satta. Gå till <a href="%{base_url}/admin/site_settings">Webbplatsinställningarna</a> och uppdatera inställningarna. <a href="https://meta.discourse.org/t/configuring-github-login-for-discourse/13745" target="_blank">Läs den här guiden för att lära dig mer</a>.'
+    failing_emails_warning: 'Det finns %{num_failed_jobs} e-postutskick som har misslyckats. Kontrollera din app.yml-fil för att säkerställa att serverinställningarna för e-post är korrekta. <a href="%{base_url}/sidekiq/retries" target="_blank">Se alla misslyckade utskick i Sidekiq</a>.'
     subfolder_ends_in_slash: "Inställningarna för dina undermappar är inte korrekt; DISCOURSE_RELATIV_URL_ROOT slutar med ett snedstreck."
     email_polling_errored_recently:
       one: "E-postpolling har genererat ett fel de senaste 24 timmarna. Se <a href='/logs' target='_blank'>loggarna</a> för mer detaljer."
@@ -1548,7 +1548,7 @@ sv:
     search_title: "Sök på hemsidan"
   terms_of_service:
     title: "Användarvillkor"
-    signup_form_message: 'Jag har läst och accepterat <a href="/tos" target="_blank">Användarvillkoren</a>.'
+    signup_form_message: 'Jag har läst och accepterat <a href="%{base_url}/tos" target="_blank">Användarvillkoren</a>.'
   deleted: 'raderad'
   upload:
     edit_reason: "nedladdade lokala kopior av bilder"

--- a/config/locales/server.sw.yml
+++ b/config/locales/server.sw.yml
@@ -463,8 +463,8 @@ sw:
       email_body: "%{link}\n\n%{message}"
     inappropriate:
       title: 'Haifai'
-      description: 'Chapisho hili lina maandishi ambayo mtu mwenye akili timamu anaweza kuona ni matusi, ubaguzi, au kukiuka <a href="/guidelines">mwongozo wa jumuiya</a>.'
-      short_description: 'Ukiukaji wa <a href="/guidelines">miongozo ya jukwaa letu</a>'
+      description: 'Chapisho hili lina maandishi ambayo mtu mwenye akili timamu anaweza kuona ni matusi, ubaguzi, au kukiuka <a href="%{base_url}/guidelines">mwongozo wa jumuiya</a>.'
+      short_description: 'Ukiukaji wa <a href="%{base_url}/guidelines">miongozo ya jukwaa letu</a>'
       long_form: 'imeripotiwa kuwa haiko sawa'
     notify_user:
       title: 'Mtumie @{{username}} ujumbe'
@@ -509,11 +509,11 @@ sw:
       long_form: 'imeripotiwa kama barua taka'
     inappropriate:
       title: 'Haifai'
-      description: 'Mada hii ina maandishi ambayo mtu mwenye akili timamu anaweza kuona ni matusi, ubaguzi, au kukiuka <a href="/guidelines">mwongozo wa jumuiya</a>.'
+      description: 'Mada hii ina maandishi ambayo mtu mwenye akili timamu anaweza kuona ni matusi, ubaguzi, au kukiuka <a href="%{base_url}/guidelines">mwongozo wa jumuiya</a>.'
       long_form: 'imeripotiwa kuwa haiko sawa'
     notify_moderators:
       title: "Kitu Kingine"
-      description: 'Mada hii inahitaji kupitiwa na msaidizi kwa sababu za <a href="/guidelines">mwongozo</a>, <a href="%{tos_url}">TOS</a>, au kwa sababu nyingine ambayo haijaorodheshwa.'
+      description: 'Mada hii inahitaji kupitiwa na msaidizi kwa sababu za <a href="%{base_url}/guidelines">mwongozo</a>, <a href="%{tos_url}">TOS</a>, au kwa sababu nyingine ambayo haijaorodheshwa.'
       long_form: 'imeripotiwa na itapitiwa na msimamizi'
       email_title: 'Mada "%{title}" inahitaji kupitiwa na msimamizi'
       email_body: "%{link}\n\n%{message}"
@@ -715,11 +715,11 @@ sw:
     sidekiq_warning: 'Sidekiq haifanyi kazi. Shughuli nyingi kama kutuma barua pepe, zinashughulikiwa na sidekiq. Tafadhali hakikisha kuwa mfumo wa sidekiq unafanya kazi. <a href="https://github.com/mperham/sidekiq" target="_blank">Jifunza kuhusu Sidekiq hapa</a>.'
     queue_size_warning: 'Namba za kazi zilizopangwa ni %{queue_size}, ambazo ni nyingi. Hii inaweza kusababishwa na tatizo na m(i)fumo wa Sidekiq, au inabidi uongeze wafanyakazi wa Sidekiq.'
     memory_warning: 'Seva yako inatumia chini ya GB 1 ya kumbukumbu. Tunakushauri utumie kumbukumbu zaidi ya GB 1.'
-    google_oauth2_config_warning: 'Seva inaruhusu watu kujiunga au kuingia kwa kutumia  Google OAuth2 (enable_google_oauth2_logins), lakini taarifa za  client id and client secret hazijaandikwa. Nenda kwenye <a href="/admin/site_settings"> Mipangilio ya Tovuti </a> na sasisha mipangilio. <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank"> Tembelea mwongozo kwa taarifa zaidi</a>.'
-    facebook_config_warning: 'Seva inaruhusu watu kujiunga au kuingia kwa kutumia Facebook (enable_facebook_logins), lakini taarifa za client id and client secret hazijaandikwa. Nenda kwenye <a href="/admin/site_settings">Mipangilio ya Tovuti</a> na sasisha mipangilio. <a href="https://meta.discourse.org/t/configuring-facebook-login-for-discourse/13394" target="_blank">Tembelea mwongozo kwa taarifa zaidi</a>.'
-    twitter_config_warning: 'Seva inaruhusu watu kujiunga au kuingia kwa kutumia Twitter (enable_twitter_logins), lakini taarifa za client id and client secret hazijaandikwa. Nenda kwenye <a href="/admin/site_settings">Mipangilio ya Tovuti</a> na sasisha mipangilio. <a href="https://meta.discourse.org/t/configuring-twitter-login-for-discourse/13395" target="_blank">Tembelea mwongozo kwa taarifa zaidi</a>.'
-    github_config_warning: 'Seva inaruhusu watu kujiunga au kuingia kwa kutumia Github (enable_github_logins), lakini taarifa za client id and client secret hazijaandikwa. Nenda kwenye <a href="/admin/site_settings">Mipangilio ya Tovuti</a> na sasisha mipangilio. <a href="https://meta.discourse.org/t/configuring-github-login-for-discourse/13745" target="_blank">Tembelea mwongozo kwa taarifa zaidi</a>.'
-    failing_emails_warning: 'Kuna kazi %{num_failed_jobs} za barua pepe ambazo zimeshindwa. Angalia file la app.yml na hakikisha mipangilio ya seva za barua ziko sawa. <a href="/sidekiq/retries" target="_blank">Ona kazi zilizoshindwa ndani ya Sidekiq</a>.'
+    google_oauth2_config_warning: 'Seva inaruhusu watu kujiunga au kuingia kwa kutumia  Google OAuth2 (enable_google_oauth2_logins), lakini taarifa za  client id and client secret hazijaandikwa. Nenda kwenye <a href="%{base_url}/admin/site_settings"> Mipangilio ya Tovuti </a> na sasisha mipangilio. <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank"> Tembelea mwongozo kwa taarifa zaidi</a>.'
+    facebook_config_warning: 'Seva inaruhusu watu kujiunga au kuingia kwa kutumia Facebook (enable_facebook_logins), lakini taarifa za client id and client secret hazijaandikwa. Nenda kwenye <a href="%{base_url}/admin/site_settings">Mipangilio ya Tovuti</a> na sasisha mipangilio. <a href="https://meta.discourse.org/t/configuring-facebook-login-for-discourse/13394" target="_blank">Tembelea mwongozo kwa taarifa zaidi</a>.'
+    twitter_config_warning: 'Seva inaruhusu watu kujiunga au kuingia kwa kutumia Twitter (enable_twitter_logins), lakini taarifa za client id and client secret hazijaandikwa. Nenda kwenye <a href="%{base_url}/admin/site_settings">Mipangilio ya Tovuti</a> na sasisha mipangilio. <a href="https://meta.discourse.org/t/configuring-twitter-login-for-discourse/13395" target="_blank">Tembelea mwongozo kwa taarifa zaidi</a>.'
+    github_config_warning: 'Seva inaruhusu watu kujiunga au kuingia kwa kutumia Github (enable_github_logins), lakini taarifa za client id and client secret hazijaandikwa. Nenda kwenye <a href="%{base_url}/admin/site_settings">Mipangilio ya Tovuti</a> na sasisha mipangilio. <a href="https://meta.discourse.org/t/configuring-github-login-for-discourse/13745" target="_blank">Tembelea mwongozo kwa taarifa zaidi</a>.'
+    failing_emails_warning: 'Kuna kazi %{num_failed_jobs} za barua pepe ambazo zimeshindwa. Angalia file la app.yml na hakikisha mipangilio ya seva za barua ziko sawa. <a href="%{base_url}/sidekiq/retries" target="_blank">Ona kazi zilizoshindwa ndani ya Sidekiq</a>.'
     missing_mailgun_api_key: "Seva imesanidiwa kutuma barua pepe kwa kutumia Mailgun lakini haujaweka ufunguo wa Mailgun unaotumika kuthibitisha ujumbe."
     bad_favicon_url: "Ishara unayoipenda imeshindwa kuonekana. Angalia mipangilio ya favicon_url ndani ya <a href='/admin/site_settings'>Mipangilio ya Tovuti</a>."
     force_https_warning: "Tovuti yako inatumia SSL. Lakini `<a href='/admin/site_settings/category/all_results?filter=force_https'>force_https` haijaruhusiwa kwenye mipangilio ya tovuti yako."

--- a/config/locales/server.te.yml
+++ b/config/locales/server.te.yml
@@ -295,7 +295,7 @@ te:
       email_body: "%{link}\n\n%{message}"
     inappropriate:
       title: 'అసమంజసమైనది'
-      description: 'ఈ టపాలో విషయం కొంతమందికి అభ్యంతరకరమైనది, అగౌరవపరిచేది లేదా <a href="/guidelines">మా కమ్యునిటీ మార్గదర్శకాలకు</a> లోబడినది కాదు.'
+      description: 'ఈ టపాలో విషయం కొంతమందికి అభ్యంతరకరమైనది, అగౌరవపరిచేది లేదా <a href="%{base_url}/guidelines">మా కమ్యునిటీ మార్గదర్శకాలకు</a> లోబడినది కాదు.'
       long_form: 'దీన్ని అసమంజసమైనదిగా కేతనించాము'
     notify_user:
       email_title: '"%{title}" లో మీ టపా'
@@ -318,7 +318,7 @@ te:
       long_form: 'దీన్ని స్పాముగా కేతనించారు'
     inappropriate:
       title: 'అసమంజసం'
-      description: 'ఈ అంశంలో ఉన్న విషయం ద్వారా ఒక సహేతుకమైన వ్యక్తిని ప్రమాదకరమైన,అసంబధ్ధమైనవానిగా పరిగణిస్తారు,లేదా <a href="/guidelines"> మన వర్గ మార్గదర్శకాల ఉల్లంఘన జరుగుతుంది</a>.'
+      description: 'ఈ అంశంలో ఉన్న విషయం ద్వారా ఒక సహేతుకమైన వ్యక్తిని ప్రమాదకరమైన,అసంబధ్ధమైనవానిగా పరిగణిస్తారు,లేదా <a href="%{base_url}/guidelines"> మన వర్గ మార్గదర్శకాల ఉల్లంఘన జరుగుతుంది</a>.'
       long_form: 'దీన్ని అసమంజసమైనదిగా కేతనించారు'
     notify_moderators:
       title: "వేరే ఏదో"
@@ -532,7 +532,7 @@ te:
     search_title: "ఈ సైట్ వెదుకు"
   terms_of_service:
     title: "సేవా నియమాలు"
-    signup_form_message: 'నేను <a href="/tos" target="_blank">సేవా నియమాలను</a> చదివాను, వాటికి అంగీకరిస్తున్నాను.'
+    signup_form_message: 'నేను <a href="%{base_url}/tos" target="_blank">సేవా నియమాలను</a> చదివాను, వాటికి అంగీకరిస్తున్నాను.'
   deleted: 'తొలగించారు'
   upload:
     images:

--- a/config/locales/server.tr_TR.yml
+++ b/config/locales/server.tr_TR.yml
@@ -409,7 +409,7 @@ tr_TR:
       email_body: "%{link}\n\n%{message}"
     inappropriate:
       title: 'Uygunsuz'
-      description: 'Bu gönderi saldırgan, kötüleyici ya da <a href="/guidelines">topluluk yönergelerini</a> ihlal eden içerik barındırmaktadır. '
+      description: 'Bu gönderi saldırgan, kötüleyici ya da <a href="%{base_url}/guidelines">topluluk yönergelerini</a> ihlal eden içerik barındırmaktadır. '
       long_form: 'bunu uygunsuz olarak bildirdi'
     notify_user:
       title: '@{{username}} adlı kullanıcıya ileti gönder'
@@ -438,11 +438,11 @@ tr_TR:
       long_form: 'bunu istenmeyen olarak bildirdi'
     inappropriate:
       title: 'Uygunsuz'
-      description: 'Bu konu saldırgan, kötüleyici ya da <a href="/guidelines">topluluk yönergelerini</a> ihlal eden içerik barındırmaktadır. '
+      description: 'Bu konu saldırgan, kötüleyici ya da <a href="%{base_url}/guidelines">topluluk yönergelerini</a> ihlal eden içerik barındırmaktadır. '
       long_form: 'bunu uygunsuz olarak bildirdi'
     notify_moderators:
       title: "Başka Bir Şey"
-      description: 'Bu gönderi <a href="/guidelines">yönergeler</a>, <a href="%{tos_url}">hizmet şartları</a> veya başka herhangi bir nedenden dolayı görevli incelemesi gerektirmektedir.'
+      description: 'Bu gönderi <a href="%{base_url}/guidelines">yönergeler</a>, <a href="%{tos_url}">hizmet şartları</a> veya başka herhangi bir nedenden dolayı görevli incelemesi gerektirmektedir.'
       long_form: 'bunu moderatörün ilgisi için bildirdi'
       email_title: '"%{title}" konu başlığının moderatör tarafından kontrol edilmesi gerekiyor'
       email_body: "%{link}\n\n%{message}"
@@ -612,11 +612,11 @@ tr_TR:
     sidekiq_warning: 'Sidekiq çalışmıyor. E-posta yollamak gibi gibi birçok asenkron görev sidekiq''in işidir. En az bir tane sidekiq süreci çalıştırdığınızdan emin olun. <a href="https://github.com/mperham/sidekiq" target="_blank">Sidekiq ile ilgili bilgi burada</a>.'
     queue_size_warning: 'Kuyruğa eklenmiş işlerin sayısı fazla: %{queue_size}. Bu Sidekiq işlem(ler)indeki bir sorunu işaret ediyor olabilir, ya da daha fazla Sidekiq işçisi eklemeniz gerekiyor olabilir.'
     memory_warning: 'Sunucunuz toplam 1GB''tan az bellek ile çalışıyor. En az 1GB bellek tavsiye edilmektedir.'
-    google_oauth2_config_warning: 'Sunucu Google OAuth2 (enable_google_oauth2_logins) ile üyelik oluşturulması ve giriş yapılmasına elveriyor, fakat the kullanıcı IDsi and gizli kullanıcı değerleri henüz ayarlanmamış. <a href="/admin/site_settings">Site Ayarları</a> sayfasına gidin ve ayarları güncelleyin. <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">Daha fazla bilgi için bu yönetmeliğe bakın</a>.'
-    facebook_config_warning: 'Sunucu Facebook (enable_facebook_logins) ile üyelik oluşturulması ve giriş yapılmasına izin veriyor, fakat app ID ve gizli app değerleri henüz ayarlanmamış. <a href="/admin/site_settings">Site Ayarları</a> sayfasına gidin ve ayarları güncelleyin. <a href="https://meta.discourse.org/t/configuring-facebook-login-for-discourse/13394" target="_blank">Daha fazla bilgi için bu yönetmeliğe bakın</a>.'
-    twitter_config_warning: 'Sunucu Twitter (enable_twitter_logins) ile üyelik oluşturulması ve giriş yapılmasına izin veriyor, fakat anahtar ve gizli değerler henüz ayarlanmamış. <a href="/admin/site_settings">Site Ayarları</a> sayfasına gidin ve ayarları güncelleyin. <a href="https://meta.discourse.org/t/configuring-twitter-login-for-discourse/13395" target="_blank">Daha fazla bilgi için bu yönetmeliğe bakın</a>.'
-    github_config_warning: 'Sunucu GitHub (enable_github_logins) ile üyelik oluşturulması ve giriş yapılmasına izin veriyor, fakat kullanıcı IDsi ve gizli değerler henüz ayarlanmamış. <a href="/admin/site_settings">Site Ayarları</a> sayfasına gidin ayarları güncelleyin. <a href="https://meta.discourse.org/t/configuring-github-login-for-discourse/13745" target="_blank">Daha fazla bilgi için bu yönetmeliğe bakın</a>.'
-    failing_emails_warning: 'Başarısızlıkla sonuçlanmış %{num_failed_jobs} e-posta işlemi bulunuyor. app.yml dosyanızı kontrol edin ve e-posta sunucu ayarlarınızın doğru olduğundan emin olun. <a href="/sidekiq/retries" target="_blank">Sidekiq''deki başarısız işlemlere göz atın</a>.'
+    google_oauth2_config_warning: 'Sunucu Google OAuth2 (enable_google_oauth2_logins) ile üyelik oluşturulması ve giriş yapılmasına elveriyor, fakat the kullanıcı IDsi and gizli kullanıcı değerleri henüz ayarlanmamış. <a href="%{base_url}/admin/site_settings">Site Ayarları</a> sayfasına gidin ve ayarları güncelleyin. <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">Daha fazla bilgi için bu yönetmeliğe bakın</a>.'
+    facebook_config_warning: 'Sunucu Facebook (enable_facebook_logins) ile üyelik oluşturulması ve giriş yapılmasına izin veriyor, fakat app ID ve gizli app değerleri henüz ayarlanmamış. <a href="%{base_url}/admin/site_settings">Site Ayarları</a> sayfasına gidin ve ayarları güncelleyin. <a href="https://meta.discourse.org/t/configuring-facebook-login-for-discourse/13394" target="_blank">Daha fazla bilgi için bu yönetmeliğe bakın</a>.'
+    twitter_config_warning: 'Sunucu Twitter (enable_twitter_logins) ile üyelik oluşturulması ve giriş yapılmasına izin veriyor, fakat anahtar ve gizli değerler henüz ayarlanmamış. <a href="%{base_url}/admin/site_settings">Site Ayarları</a> sayfasına gidin ve ayarları güncelleyin. <a href="https://meta.discourse.org/t/configuring-twitter-login-for-discourse/13395" target="_blank">Daha fazla bilgi için bu yönetmeliğe bakın</a>.'
+    github_config_warning: 'Sunucu GitHub (enable_github_logins) ile üyelik oluşturulması ve giriş yapılmasına izin veriyor, fakat kullanıcı IDsi ve gizli değerler henüz ayarlanmamış. <a href="%{base_url}/admin/site_settings">Site Ayarları</a> sayfasına gidin ayarları güncelleyin. <a href="https://meta.discourse.org/t/configuring-github-login-for-discourse/13745" target="_blank">Daha fazla bilgi için bu yönetmeliğe bakın</a>.'
+    failing_emails_warning: 'Başarısızlıkla sonuçlanmış %{num_failed_jobs} e-posta işlemi bulunuyor. app.yml dosyanızı kontrol edin ve e-posta sunucu ayarlarınızın doğru olduğundan emin olun. <a href="%{base_url}/sidekiq/retries" target="_blank">Sidekiq''deki başarısız işlemlere göz atın</a>.'
     subfolder_ends_in_slash: "Alt dizin kurulumunuz hatalı, DISCOURSE_RELATIVE_URL_ROOT sonunda yan çizgi bulunmalı."
     bad_favicon_url: "Minik simge yüklemesi başarısız oldu. <a href='/admin/site_settings'>Site Ayarları</a>ndan favicon_url alanını kontrol edin."
   site_settings:
@@ -1334,7 +1334,7 @@ tr_TR:
     search_title: "Bu sitede ara"
   terms_of_service:
     title: "Üyelik Sözleşmesi"
-    signup_form_message: '<a href="/tos" target="_blank">Üyelik Sözleşmesini</a> okudum ve kabul ediyorum.'
+    signup_form_message: '<a href="%{base_url}/tos" target="_blank">Üyelik Sözleşmesini</a> okudum ve kabul ediyorum.'
   deleted: 'silindi'
   upload:
     edit_reason: "resimlerin yerel kopyaları indirildi"

--- a/config/locales/server.uk.yml
+++ b/config/locales/server.uk.yml
@@ -299,9 +299,9 @@ uk:
     host_names_warning: "Your config/database.yml file is using the default localhost hostname. Update it to use your site's hostname."
     sidekiq_warning: 'Sidekiq is not running. Many tasks, like sending emails, are executed asynchronously by sidekiq. Please ensure at least one sidekiq process is running. <a href="https://github.com/mperham/sidekiq" target="_blank">Learn about Sidekiq here</a>.'
     memory_warning: 'Your server is running with less than 1 GB of total memory. At least 1 GB of memory is recommended.'
-    facebook_config_warning: 'The server is configured to allow signup and log in with Facebook (enable_facebook_logins), but the app id and app secret values are not set. Go to <a href="/admin/site_settings">the Site Settings</a> and update the settings. <a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide#enable-facebook-logins" target="_blank">See this guide to learn more</a>.'
-    twitter_config_warning: 'The server is configured to allow signup and log in with Twitter (enable_twitter_logins), but the key and secret values are not set. Go to <a href="/admin/site_settings">the Site Settings</a> and update the settings. <a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide#enable-twitter-logins" target="_blank">See this guide to learn more</a>.'
-    github_config_warning: 'The server is configured to allow signup and log in with GitHub (enable_github_logins), but the client id and secret values are not set. Go to <a href="/admin/site_settings">the Site Settings</a> and update the settings. <a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide" target="_blank">See this guide to learn more</a>.'
+    facebook_config_warning: 'The server is configured to allow signup and log in with Facebook (enable_facebook_logins), but the app id and app secret values are not set. Go to <a href="%{base_url}/admin/site_settings">the Site Settings</a> and update the settings. <a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide#enable-facebook-logins" target="_blank">See this guide to learn more</a>.'
+    twitter_config_warning: 'The server is configured to allow signup and log in with Twitter (enable_twitter_logins), but the key and secret values are not set. Go to <a href="%{base_url}/admin/site_settings">the Site Settings</a> and update the settings. <a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide#enable-twitter-logins" target="_blank">See this guide to learn more</a>.'
+    github_config_warning: 'The server is configured to allow signup and log in with GitHub (enable_github_logins), but the client id and secret values are not set. Go to <a href="%{base_url}/admin/site_settings">the Site Settings</a> and update the settings. <a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide" target="_blank">See this guide to learn more</a>.'
   site_settings:
     allow_user_locale: "Allow users to choose their own language interface preference"
     min_search_term_length: "Мінімальна дозволена довжина пошукової фрази у символах"
@@ -413,7 +413,7 @@ uk:
     search_title: "Пошук на цьому сайті"
   terms_of_service:
     title: "Умови Використання"
-    signup_form_message: 'I have read and accept the <a href="/tos" target="_blank">Terms of Service</a>.'
+    signup_form_message: 'I have read and accept the <a href="%{base_url}/tos" target="_blank">Terms of Service</a>.'
   deleted: 'deleted'
   upload:
     edit_reason: "завантажені локальні копії забражень"

--- a/config/locales/server.ur.yml
+++ b/config/locales/server.ur.yml
@@ -611,8 +611,8 @@ ur:
       email_body: "%{link}\n\n%{message}"
     inappropriate:
       title: 'نامناسب'
-      description: 'اِس پوسٹ میں ایسا مواد شامل ہے جو ایک مناسب شخص جارحانہ، غیر مہذب، یا <a href="/guidelines">ہماری کمیونٹی کے قواعد و ضوابط</a> کے خلاف سمجھے گا۔'
-      short_description: '<a href="/guidelines">ہماری کمیونٹی کے قواعد و ضوابط</a> کی خلاف ورزی'
+      description: 'اِس پوسٹ میں ایسا مواد شامل ہے جو ایک مناسب شخص جارحانہ، غیر مہذب، یا <a href="%{base_url}/guidelines">ہماری کمیونٹی کے قواعد و ضوابط</a> کے خلاف سمجھے گا۔'
+      short_description: '<a href="%{base_url}/guidelines">ہماری کمیونٹی کے قواعد و ضوابط</a> کی خلاف ورزی'
       long_form: 'اِس کو نامناسب ہونے کے طور پر فلَیگ کیا گیا'
     notify_user:
       title: '@{{username}} کو ایک پیغام بھیجیں'
@@ -657,11 +657,11 @@ ur:
       long_form: 'اِس کو سپَیم کے طور پر فلَیگ کیا گیا'
     inappropriate:
       title: 'نامناسب'
-      description: 'اِس ٹاپک میں ایسا مواد شامل ہے جو ایک مناسب شخص جارحانہ، غیر مہذب، یا <a href="/guidelines">ہماری کمیونٹی کے قواعد و ضوابط</a> کے خلاف سمجھے گا۔'
+      description: 'اِس ٹاپک میں ایسا مواد شامل ہے جو ایک مناسب شخص جارحانہ، غیر مہذب، یا <a href="%{base_url}/guidelines">ہماری کمیونٹی کے قواعد و ضوابط</a> کے خلاف سمجھے گا۔'
       long_form: 'اِس کو نامناسب ہونے کے طور پر فلَیگ کیا گیا'
     notify_moderators:
       title: "کچھ اور"
-      description: 'اِس ٹاپک کو، <a href="/guidelines">قواعد و ضوابط</a>، <a href="%{tos_url}">سروس کی شرائط</a>، یا مندرجہ بالا درج وجوہات کے علاوہ، کے مطابق اسٹاف کی عام توجہ کی ضرورت ہے۔'
+      description: 'اِس ٹاپک کو، <a href="%{base_url}/guidelines">قواعد و ضوابط</a>، <a href="%{tos_url}">سروس کی شرائط</a>، یا مندرجہ بالا درج وجوہات کے علاوہ، کے مطابق اسٹاف کی عام توجہ کی ضرورت ہے۔'
       long_form: 'اِس کو ماڈریٹر کی توجہ کیلئے فلَیگ کیا گیا'
       email_title: 'ٹاپک "%{title}" پر اسٹاف کی توجہ درکار ہے'
       email_body: "%{link}\n\n%{message}"
@@ -850,10 +850,10 @@ ur:
     sidekiq_warning: 'Sidekiq نہیں چل رہا۔ بہت سے کام، جیسا کہ ای میل بھیجنا، sidekq کی طرف سے اےسِنکرونسلی مکمل کیے جاتے ہیں۔ براہ کرم یقینی بنائیں کہ کم ازکم ایک sidekq پراسیس چل رہا ہے۔ <a href="https://github.com/mperham/sidekiq" target="_blank">Sidekiq کے بارے میں یہاں سے جانیے</a>۔'
     queue_size_warning: 'قطار میں موجود جابز کی تعداد %{queue_size} ہے، جو کہ زیادہ ہے۔ یہ Sidekiq پراسیس کے ساتھ ایک مسئلہ کی نشاندہی کر سکتا ہے، یا آپ کو مزید Sidekiq کارکنوں کو شامل کرنے کی ضرورت ہوسکتی ہے۔'
     memory_warning: 'آپ کا سرور مجموعی طور پر 1 GB سے کم میموری کے ساتھ چل رہا ہے۔ کم ازکم 1 GB میموری تجویز کی گئی ہے۔'
-    google_oauth2_config_warning: 'سرور کو ترتیب دیا گیا ہے کہ گُوگل (OAuth2 (enable_google_oauth2_logins کے ساتھ سائن اپ اور لاگ اِن کی اجازت ہو، لیکن کلائنٹ آئی ڈی اور کلائنٹ سیکرٹ وَیلِیوز مقرر نہیں کیے گئے ہیں۔ <a href="/admin/site_settings">سائٹ ترتیبات</a> پر جائیں اور ترتیبات کو اَپ ڈیٹ کریں۔ <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">مزید جاننے کے لئے یہ گائیڈ ملاحظہ کریں</a>۔'
-    facebook_config_warning: 'سرور کو ترتیب دیا گیا ہے کہ فیس بُک (OAuth2 (enable_facebook_logins کے ساتھ سائن اپ اور لاگ اِن کی اجازت ہو، لیکن اَیپ آئی ڈی اور اَیپ سیکرٹ وَیلِیوز مقرر نہیں کیے گئے ہیں۔ <a href="/admin/site_settings">سائٹ ترتیبات</a> پر جائیں اور ترتیبات کو اَپ ڈیٹ کریں۔ <a href="https://meta.discourse.org/t/configuring-facebook-login-for-discourse/13394" target="_blank">مزید جاننے کے لئے یہ گائیڈ ملاحظہ کریں</a>۔'
-    twitter_config_warning: 'سرور کو ترتیب دیا گیا ہے کہ ٹَوِیٹر (enable_twitter_logins) کے ساتھ سائن اپ اور لاگ اِن کی اجازت ہو، لیکن قیی اور سیکرٹ وَیلِیوز مقرر نہیں کیے گئے ہیں۔ <a href="/admin/site_settings">سائٹ ترتیبات</a> پر جائیں اور ترتیبات کو اَپ ڈیٹ کریں۔ <a href="https://meta.discourse.org/t/configuring-twitter-login-for-discourse/13395" target="_blank">مزید جاننے کے لئے یہ گائیڈ ملاحظہ کریں</a>۔'
-    github_config_warning: 'سرور کو ترتیب دیا گیا ہے کہ گِٹ ہَب (enable_github_logins) کے ساتھ سائن اپ اور لاگ اِن کی اجازت ہو، لیکن کلائنٹ آئی ڈی اور سیکرٹ وَیلِیوز مقرر نہیں کیے گئے ہیں۔ <a href="/admin/site_settings">سائٹ ترتیبات</a> پر جائیں اور ترتیبات کو اَپ ڈیٹ کریں۔ <a href="https://meta.discourse.org/t/configuring-github-login-for-discourse/13745" target="_blank">مزید جاننے کے لئے یہ گائیڈ ملاحظہ کریں</a>۔'
+    google_oauth2_config_warning: 'سرور کو ترتیب دیا گیا ہے کہ گُوگل (OAuth2 (enable_google_oauth2_logins کے ساتھ سائن اپ اور لاگ اِن کی اجازت ہو، لیکن کلائنٹ آئی ڈی اور کلائنٹ سیکرٹ وَیلِیوز مقرر نہیں کیے گئے ہیں۔ <a href="%{base_url}/admin/site_settings">سائٹ ترتیبات</a> پر جائیں اور ترتیبات کو اَپ ڈیٹ کریں۔ <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">مزید جاننے کے لئے یہ گائیڈ ملاحظہ کریں</a>۔'
+    facebook_config_warning: 'سرور کو ترتیب دیا گیا ہے کہ فیس بُک (OAuth2 (enable_facebook_logins کے ساتھ سائن اپ اور لاگ اِن کی اجازت ہو، لیکن اَیپ آئی ڈی اور اَیپ سیکرٹ وَیلِیوز مقرر نہیں کیے گئے ہیں۔ <a href="%{base_url}/admin/site_settings">سائٹ ترتیبات</a> پر جائیں اور ترتیبات کو اَپ ڈیٹ کریں۔ <a href="https://meta.discourse.org/t/configuring-facebook-login-for-discourse/13394" target="_blank">مزید جاننے کے لئے یہ گائیڈ ملاحظہ کریں</a>۔'
+    twitter_config_warning: 'سرور کو ترتیب دیا گیا ہے کہ ٹَوِیٹر (enable_twitter_logins) کے ساتھ سائن اپ اور لاگ اِن کی اجازت ہو، لیکن قیی اور سیکرٹ وَیلِیوز مقرر نہیں کیے گئے ہیں۔ <a href="%{base_url}/admin/site_settings">سائٹ ترتیبات</a> پر جائیں اور ترتیبات کو اَپ ڈیٹ کریں۔ <a href="https://meta.discourse.org/t/configuring-twitter-login-for-discourse/13395" target="_blank">مزید جاننے کے لئے یہ گائیڈ ملاحظہ کریں</a>۔'
+    github_config_warning: 'سرور کو ترتیب دیا گیا ہے کہ گِٹ ہَب (enable_github_logins) کے ساتھ سائن اپ اور لاگ اِن کی اجازت ہو، لیکن کلائنٹ آئی ڈی اور سیکرٹ وَیلِیوز مقرر نہیں کیے گئے ہیں۔ <a href="%{base_url}/admin/site_settings">سائٹ ترتیبات</a> پر جائیں اور ترتیبات کو اَپ ڈیٹ کریں۔ <a href="https://meta.discourse.org/t/configuring-github-login-for-discourse/13745" target="_blank">مزید جاننے کے لئے یہ گائیڈ ملاحظہ کریں</a>۔'
     failing_emails_warning: 'ناکام ہونے والی %{num_failed_jobs} اِی مَیل جابز موجود ہیں۔ اپنا app.yml چیک کریں اور یہ یقینی بنائیں کہ میل سرور کی ترتیبات درست ہیں۔ Sidekiq میں ناکام جابز ملاحظہ کریں۔'
     subfolder_ends_in_slash: "آپ کا سب-فولڈر سیٹ اپ غلط ہے؛ DISCOURSE_RELATIVE_URL_ROOT ایک سلَیش میں ختم ہوتا ہے۔"
     email_polling_errored_recently:
@@ -2407,7 +2407,7 @@ ur:
       ایک اکاؤنٹ کی ضرورت ہے۔ برائے مہربانی جاری رکھنے کیلئے ایک اکاؤنٹ بنائیں یا لاگ اِن کریں۔
   terms_of_service:
     title: "سروس کی شرائط"
-    signup_form_message: 'میں نے <a href="/tos" target="_blank">سروس کی شرائط</a> کو پڑھا اور قبول کر لیا ہے۔'
+    signup_form_message: 'میں نے <a href="%{base_url}/tos" target="_blank">سروس کی شرائط</a> کو پڑھا اور قبول کر لیا ہے۔'
   deleted: 'حذف کردہ'
   image: "تصویر"
   upload:

--- a/config/locales/server.vi.yml
+++ b/config/locales/server.vi.yml
@@ -361,7 +361,7 @@ vi:
       email_body: "%{link}\n\n%{message}"
     inappropriate:
       title: 'Không thích hợp'
-      description: 'Chủ để này chứa nội dung mà bình thường được xem là xúc phạm, lạm dụng, hoặc vi phạm <a href="/guidelines">nguyên tắc cộng đồng</a>.'
+      description: 'Chủ để này chứa nội dung mà bình thường được xem là xúc phạm, lạm dụng, hoặc vi phạm <a href="%{base_url}/guidelines">nguyên tắc cộng đồng</a>.'
       long_form: 'đánh dấu cái này không thích hợp'
     notify_user:
       title: 'Gửi tin nhắn cho @{{username}}.'
@@ -389,11 +389,11 @@ vi:
       long_form: 'đã đánh dấu bài này dạng bài viết rác'
     inappropriate:
       title: 'Không phù hợp'
-      description: 'Chủ để này chứa nội dung mà với lý lẽ thường nhật được xem là xúc phạm, lạm dụng, hoặc  vi phạm <a href="/guidelines">chỉ dẫn chung của cộng đồng</a>.'
+      description: 'Chủ để này chứa nội dung mà với lý lẽ thường nhật được xem là xúc phạm, lạm dụng, hoặc  vi phạm <a href="%{base_url}/guidelines">chỉ dẫn chung của cộng đồng</a>.'
       long_form: 'đã đánh dấu bài này không phù hợp'
     notify_moderators:
       title: "Một cái khác"
-      description: 'Bài viết này cần Ban quản trị lưu ý theo dựa trên <a href="/guidelines">hướng dẫn</a> và <a href="%{tos_url}">điều khoản</a>  sử dụng.'
+      description: 'Bài viết này cần Ban quản trị lưu ý theo dựa trên <a href="%{base_url}/guidelines">hướng dẫn</a> và <a href="%{tos_url}">điều khoản</a>  sử dụng.'
       long_form: 'đã đánh dấu cho điều hành viên xem xét'
       email_title: 'Chủ đề "%{title}" cần được ban điều hành quan tâm'
       email_body: "%{link}\n\n%{message}"
@@ -544,11 +544,11 @@ vi:
     sidekiq_warning: ' Sidekiq đang không hoạt động. Rất nhiều tác vụ, như gửi email, là được thực thi không đồng bộ bởi sidekiq. Hãy chắc chắn rằng ít nhất một tiến trình sidekiq phải đang hoạt động. <a href="https://github.com/mperham/sidekiq" target="_blank">Đọc thêm về Sidekiq tại đây</a>.'
     queue_size_warning: 'Có %{queue_size} công việc đang chờ xử lý trong hàng đợi. Điều này chứng tỏ có vấn đề đã xảy ra với tiến trình Sidekiq, hoặc bạn cần tăng số lượng Sidekiq workers ().'
     memory_warning: 'Máy chủ của bạn có bộ nhớ ít hơn 1 GB. Khuyến cáo sử dụng bộ nhớ tối thiểu 1 GB .'
-    google_oauth2_config_warning: 'Máy chủ được cấu hình cho phép đăng ký và đăng nhập với Google OAuth2 (enable_google_oauth2_logins), tuy nhiên giá trị của client id và client secret thì không được thiết lập. Truy cập <a href="/admin/site_settings">Cấu hình Site</a> và bổ sung các thiết lập đó. <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">Xem hướng dẫn này để biết thêm chi tiết</a>.'
-    facebook_config_warning: 'Máy chủ được cấu hình cho phép đăng ký và đăng nhập với Facebook  (enable_facebook_logins), tuy nhiên giá trị của client id và client secret thì không được thiết lập. Truy cập <a href="/admin/site_settings">Cấu hình Site</a> và bổ sung các thiết lập đó. <a href="https://meta.discourse.org/t/configuring-facebook-login-for-discourse/13394" target="_blank">Xem hướng dẫn này để biết thêm chi tiết</a>.'
-    twitter_config_warning: 'Máy chủ được cấu hình cho phép đăng ký và đăng nhập với Twitter   (enable_twitter_logins), tuy nhiên giá trị của client id và client secret thì không được thiết lập. Truy cập <a href="/admin/site_settings">Cấu hình Site</a> và bổ sung các thiết lập đó. <a href="https://meta.discourse.org/t/configuring-twitter-login-for-discourse/13395" target="_blank">Xem hướng dẫn này để biết thêm chi tiết</a>.'
-    github_config_warning: 'Máy chủ được cấu hình cho phép đăng ký và đăng nhập với GitHub    (enable_github_logins), tuy nhiên giá trị của client id và client secret thì không được thiết lập. Truy cập <a href="/admin/site_settings">Cấu hình Site</a> và bổ sung các thiết lập đó. <a href="https://meta.discourse.org/t/configuring-github-login-for-discourse/13745" target="_blank">Xem hướng dẫn này để biết thêm chi tiết</a>.'
-    failing_emails_warning: 'Có %{num_failed_jobs} email jobs thấ bại. Kiểm tra app.yml và chắc chắn rằng cấu hình máy chủ email đúng. <a href="/sidekiq/retries" target="_blank">Xem jobs thất bại ở Sidekiq</a>.'
+    google_oauth2_config_warning: 'Máy chủ được cấu hình cho phép đăng ký và đăng nhập với Google OAuth2 (enable_google_oauth2_logins), tuy nhiên giá trị của client id và client secret thì không được thiết lập. Truy cập <a href="%{base_url}/admin/site_settings">Cấu hình Site</a> và bổ sung các thiết lập đó. <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">Xem hướng dẫn này để biết thêm chi tiết</a>.'
+    facebook_config_warning: 'Máy chủ được cấu hình cho phép đăng ký và đăng nhập với Facebook  (enable_facebook_logins), tuy nhiên giá trị của client id và client secret thì không được thiết lập. Truy cập <a href="%{base_url}/admin/site_settings">Cấu hình Site</a> và bổ sung các thiết lập đó. <a href="https://meta.discourse.org/t/configuring-facebook-login-for-discourse/13394" target="_blank">Xem hướng dẫn này để biết thêm chi tiết</a>.'
+    twitter_config_warning: 'Máy chủ được cấu hình cho phép đăng ký và đăng nhập với Twitter   (enable_twitter_logins), tuy nhiên giá trị của client id và client secret thì không được thiết lập. Truy cập <a href="%{base_url}/admin/site_settings">Cấu hình Site</a> và bổ sung các thiết lập đó. <a href="https://meta.discourse.org/t/configuring-twitter-login-for-discourse/13395" target="_blank">Xem hướng dẫn này để biết thêm chi tiết</a>.'
+    github_config_warning: 'Máy chủ được cấu hình cho phép đăng ký và đăng nhập với GitHub    (enable_github_logins), tuy nhiên giá trị của client id và client secret thì không được thiết lập. Truy cập <a href="%{base_url}/admin/site_settings">Cấu hình Site</a> và bổ sung các thiết lập đó. <a href="https://meta.discourse.org/t/configuring-github-login-for-discourse/13745" target="_blank">Xem hướng dẫn này để biết thêm chi tiết</a>.'
+    failing_emails_warning: 'Có %{num_failed_jobs} email jobs thấ bại. Kiểm tra app.yml và chắc chắn rằng cấu hình máy chủ email đúng. <a href="%{base_url}/sidekiq/retries" target="_blank">Xem jobs thất bại ở Sidekiq</a>.'
     subfolder_ends_in_slash: "Thư mục con của bạn được thiết lập không đúng, DISCOURSE_RELATIVE_URL_ROOT phải được kết thúc bằng dấu gạch chéo."
     email_polling_errored_recently:
       other: "Email đã tạo %{count} lỗi trong 24 giờ qua, xem <a href='/logs' target='_blank'>nhật ký</a> để biết thêm chi tiết."
@@ -1099,7 +1099,7 @@ vi:
     search_title: "Tìm trang này"
   terms_of_service:
     title: "Điều khoản Dịch vụ"
-    signup_form_message: 'Tôi đã đọc và đồng ý với <a href="/tos" target="_blank">Điều khoản dịch vụ</a>.'
+    signup_form_message: 'Tôi đã đọc và đồng ý với <a href="%{base_url}/tos" target="_blank">Điều khoản dịch vụ</a>.'
   deleted: 'đã bị xóa '
   upload:
     edit_reason: "tải về một bản sao của hình ảnh."

--- a/config/locales/server.zh_CN.yml
+++ b/config/locales/server.zh_CN.yml
@@ -514,8 +514,8 @@ zh_CN:
       email_body: "%{link}\n\n%{message}"
     inappropriate:
       title: '不当内容'
-      description: '此帖内容包含对他人的攻击、侮辱、仇视语言或违反了<a href="/guidelines">我们的社区准则</a>。'
-      short_description: '违反了<a href="/guidelines">我们的社群指引</a>'
+      description: '此帖内容包含对他人的攻击、侮辱、仇视语言或违反了<a href="%{base_url}/guidelines">我们的社区准则</a>。'
+      short_description: '违反了<a href="%{base_url}/guidelines">我们的社群指引</a>'
       long_form: '标记为不当内容'
     notify_user:
       title: '给@{{username}}发送一条私信'
@@ -558,11 +558,11 @@ zh_CN:
       long_form: '标记为垃圾'
     inappropriate:
       title: '不当内容'
-      description: '此主题内容包含对他人的攻击、侮辱、仇视语言或违反了<a href="/guidelines">我们的社区准则</a>。'
+      description: '此主题内容包含对他人的攻击、侮辱、仇视语言或违反了<a href="%{base_url}/guidelines">我们的社区准则</a>。'
       long_form: '标记为不当内容'
     notify_moderators:
       title: "其他内容"
-      description: '此帖需要版主依据<a href="/guidelines">社区准则</a>、<a href="/tos">服务条款（TOS）</a>或其它未列出的原因来给予关注。'
+      description: '此帖需要版主依据<a href="%{base_url}/guidelines">社区准则</a>、<a href="%{base_url}/tos">服务条款（TOS）</a>或其它未列出的原因来给予关注。'
       long_form: '标记为需版主注意'
       email_title: '“{title}”主题需要你的关注'
       email_body: "%{link}\n\n%{message}"
@@ -758,11 +758,11 @@ zh_CN:
     sidekiq_warning: 'Sidekiq 不在运行。很多任务，例如发送电子邮件，是异步的被 sidekiq 调度执行的。请确保至少运行一个 sidekiq 进程。<a href="https://github.com/mperham/sidekiq" target="_blank">了解 Sidekiq</a>。'
     queue_size_warning: '队列中有较多任务，为 %{queue_size} 个。这可能是因为 Sidekiq 进程的问题导致，或者需要更多的 Sidekiq 进程。'
     memory_warning: '你的服务器环境内存少于 1GB，我们建议至少要有 1GB 内存。'
-    google_oauth2_config_warning: '服务器允许使用 Google Oauth2 登录（enable_google_oauth2_logins），但是 client id 和 client secret 没有被设定。 到<a href="/admin/site_settings">站点设置</a>更新此设定。 <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">参考设定指南</a>。'
-    facebook_config_warning: '服务器允许使用 Facebook 帐号登录（enable_facebook_logins），但是 app id 和 app secret 没有被设定。 到<a href="/admin/site_settings">站点设置</a>更新此设定。<a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide#enable-facebook-logins" target="_blank">参考设定指南</a>。'
-    twitter_config_warning: '服务器允许使用 Twitter 账号登录（enable_twitter_logins），但是 key 和 secret 没有被设定。 到<a href="/admin/site_settings">站点设置</a>更新此设定。<a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide#enable-twitter-logins" target="_blank">参考设定指南</a>。'
-    github_config_warning: '服务器允许使用 GitHub 账号登录（enable_github_logins），但是 client id 和 secret 没有被设定。 到<a href="/admin/site_settings">站点设置</a>更新此设定。<a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide" target="_blank">参考设定指南</a>。'
-    failing_emails_warning: '有 %{num_failed_jobs} 个邮件任务失败。请检查 app.yml 文件是否正确配置了邮件服务器。<a href="/sidekiq/retries" target="_blank">查看 Sidekiq 中失败的任务</a>。'
+    google_oauth2_config_warning: '服务器允许使用 Google Oauth2 登录（enable_google_oauth2_logins），但是 client id 和 client secret 没有被设定。 到<a href="%{base_url}/admin/site_settings">站点设置</a>更新此设定。 <a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">参考设定指南</a>。'
+    facebook_config_warning: '服务器允许使用 Facebook 帐号登录（enable_facebook_logins），但是 app id 和 app secret 没有被设定。 到<a href="%{base_url}/admin/site_settings">站点设置</a>更新此设定。<a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide#enable-facebook-logins" target="_blank">参考设定指南</a>。'
+    twitter_config_warning: '服务器允许使用 Twitter 账号登录（enable_twitter_logins），但是 key 和 secret 没有被设定。 到<a href="%{base_url}/admin/site_settings">站点设置</a>更新此设定。<a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide#enable-twitter-logins" target="_blank">参考设定指南</a>。'
+    github_config_warning: '服务器允许使用 GitHub 账号登录（enable_github_logins），但是 client id 和 secret 没有被设定。 到<a href="%{base_url}/admin/site_settings">站点设置</a>更新此设定。<a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide" target="_blank">参考设定指南</a>。'
+    failing_emails_warning: '有 %{num_failed_jobs} 个邮件任务失败。请检查 app.yml 文件是否正确配置了邮件服务器。<a href="%{base_url}/sidekiq/retries" target="_blank">查看 Sidekiq 中失败的任务</a>。'
     subfolder_ends_in_slash: "你的子目录设置不正确；DISCOURSE_RELATIVE_URL_ROOT以斜杠结尾。"
     email_polling_errored_recently:
       other: "邮件轮询在过去的 24 小时内出现了 %{count} 个错误。看一看<a href='/logs' target='_blank'>日志</a>寻找详情。"
@@ -2202,7 +2202,7 @@ zh_CN:
       你需要一个账号。请创建一个账号或者登录以继续。
   terms_of_service:
     title: "服务条款"
-    signup_form_message: '我已经阅读并接受 <a href="/tos" target="_blank">服务条款</a>。'
+    signup_form_message: '我已经阅读并接受 <a href="%{base_url}/tos" target="_blank">服务条款</a>。'
   deleted: '已删除'
   image: "图片"
   upload:

--- a/config/locales/server.zh_TW.yml
+++ b/config/locales/server.zh_TW.yml
@@ -464,7 +464,7 @@ zh_TW:
       email_body: "%{link}\n\n%{message}"
     inappropriate:
       title: '不當內容'
-      description: '此帖內容包含對他人的攻擊、侮辱、仇視語言或違反了<a href="/guidelines">我們的社群守則</a>。'
+      description: '此帖內容包含對他人的攻擊、侮辱、仇視語言或違反了<a href="%{base_url}/guidelines">我們的社群守則</a>。'
       long_form: '投訴為不當內容'
     notify_user:
       title: '給 @{{username}} 送出一則訊息'
@@ -498,11 +498,11 @@ zh_TW:
       long_form: '投訴為垃圾內容'
     inappropriate:
       title: '不當內容'
-      description: '此主題內容包含對他人的攻擊、侮辱、仇視語言或違反了<a href="/guidelines">我們的社群守則</a>。'
+      description: '此主題內容包含對他人的攻擊、侮辱、仇視語言或違反了<a href="%{base_url}/guidelines">我們的社群守則</a>。'
       long_form: '投訴為不當內容'
     notify_moderators:
       title: "其他"
-      description: '此帖需要版主依據<a href="/guidelines">社群準則</a>、<a href="/tos">服務條款（TOS）</a>或其它未列出的原因來給予關注。'
+      description: '此帖需要版主依據<a href="%{base_url}/guidelines">社群準則</a>、<a href="%{base_url}/tos">服務條款（TOS）</a>或其它未列出的原因來給予關注。'
       long_form: '標記為需版主注意'
       email_title: '此討論話題 "%{title}" 需要板主注意'
       email_body: "%{link}\n\n%{message}"
@@ -685,11 +685,11 @@ zh_TW:
     sidekiq_warning: 'Sidekiq 未有執行。很多程序, 如發送電子郵件, 需要 sidekiq 非同步 (asynchronous) 執行的。請確保至少運行一個 sidekiq 程序。<a href="https://github.com/mperham/sidekiq">瞭解 Sidekiq</a>。'
     queue_size_warning: '隊列中有較多任務，為 %{queue_size} 個。這可能是因為 Sidekiq 進程的問題導致，或者需要更多的 Sidekiq 進程。'
     memory_warning: '伺服器記憶體少於 1GB，建議配置至少 1GB 記憶體'
-    google_oauth2_config_warning: '伺服器設定為允許使用 Google Oauth2 註冊以及登入 (enable_google_oauth2_logins)，但未設定客戶端 id 和客戶端 secret 值。請至<a href="/admin/site_settings">網站設定</a>裡更改設定。<a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">參閱教學指南</a>。'
-    facebook_config_warning: '伺服器允許使用 Facebook 帳號登入 (enable_facebook_logins), 但未有設定 app id 及 app secret values 。 請在 <a href="/admin/site_settings">網站設定</a> 裡更改設定。 <a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide#enable-facebook-logins" target="_blank">設定教學指南</a>。'
-    twitter_config_warning: '伺服器允許使用 Twitter 帳號登入 (enable_twitter_logins), 但未有設定 key 和 secret values 。 請在 <a href="/admin/site_settings">網站設定</a> 裡更改設定。 <a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide#enable-twitter-logins" target="_blank">設定教學指南</a>。'
-    github_config_warning: '伺服器允許使用 GitHub 帳號登入  (enable_github_logins), 但未有設定 client id 和 secret values。 請在 <a href="/admin/site_settings">網站設定</a> 裡更改設定。 <a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide" target="_blank">設定教學指南</a>。'
-    failing_emails_warning: '有 %{num_failed_jobs} 個郵件任務失敗。請檢查 app.yml 檔案是否正確配置了郵件伺服器。<a href="/sidekiq/retries" target="_blank">查看 Sidekiq 中失敗的任務</a>。'
+    google_oauth2_config_warning: '伺服器設定為允許使用 Google Oauth2 註冊以及登入 (enable_google_oauth2_logins)，但未設定客戶端 id 和客戶端 secret 值。請至<a href="%{base_url}/admin/site_settings">網站設定</a>裡更改設定。<a href="https://meta.discourse.org/t/configuring-google-login-for-discourse/15858" target="_blank">參閱教學指南</a>。'
+    facebook_config_warning: '伺服器允許使用 Facebook 帳號登入 (enable_facebook_logins), 但未有設定 app id 及 app secret values 。 請在 <a href="%{base_url}/admin/site_settings">網站設定</a> 裡更改設定。 <a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide#enable-facebook-logins" target="_blank">設定教學指南</a>。'
+    twitter_config_warning: '伺服器允許使用 Twitter 帳號登入 (enable_twitter_logins), 但未有設定 key 和 secret values 。 請在 <a href="%{base_url}/admin/site_settings">網站設定</a> 裡更改設定。 <a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide#enable-twitter-logins" target="_blank">設定教學指南</a>。'
+    github_config_warning: '伺服器允許使用 GitHub 帳號登入  (enable_github_logins), 但未有設定 client id 和 secret values。 請在 <a href="%{base_url}/admin/site_settings">網站設定</a> 裡更改設定。 <a href="https://github.com/discourse/discourse/wiki/The-Discourse-Admin-Quick-Start-Guide" target="_blank">設定教學指南</a>。'
+    failing_emails_warning: '有 %{num_failed_jobs} 個郵件任務失敗。請檢查 app.yml 檔案是否正確配置了郵件伺服器。<a href="%{base_url}/sidekiq/retries" target="_blank">查看 Sidekiq 中失敗的任務</a>。'
     subfolder_ends_in_slash: "你的子目錄設置不正確；DISCOURSE_RELATIVE_URL_ROOT以斜杠結尾。"
     email_polling_errored_recently:
       other: "郵件輪詢在過去的 24 小時內出現了 %{count} 個錯誤。看一看<a href='/logs' target='_blank'>日誌</a>尋找詳情。"
@@ -1761,7 +1761,7 @@ zh_TW:
       你需要一個帳號。請創設一個帳號，或者登入以繼續。
   terms_of_service:
     title: "服務條款"
-    signup_form_message: '我已閱讀並接受 <a href="/tos" target="_blank">服務條款</a>'
+    signup_form_message: '我已閱讀並接受 <a href="%{base_url}/tos" target="_blank">服務條款</a>'
   deleted: '已刪除'
   upload:
     edit_reason: "下載外部圖片留做存檔"


### PR DESCRIPTION
These links are broken for forums with a base URLs under a subdirectory. I used the following `sed` commands to fix them:

```
sed -i "s|href=\'/|href=\'\%\{base_url\}/|g" server.*
sed -i "s|href=\"/|href=\"\%\{base_url\}/|g" server.*
```