### PR TITLE
Set individual future-date-input components as clearable

### DIFF
--- a/app/assets/javascripts/admin/templates/modal/admin-silence-user.hbs
+++ b/app/assets/javascripts/admin/templates/modal/admin-silence-user.hbs
@@ -7,6 +7,7 @@
           class="silence-until"
           label="admin.user.silence_duration"
           includeFarFuture=true
+          clearable=false
           input=silenceUntil}}
       </label>
     </div>

--- a/app/assets/javascripts/admin/templates/modal/admin-suspend-user.hbs
+++ b/app/assets/javascripts/admin/templates/modal/admin-suspend-user.hbs
@@ -8,6 +8,7 @@
             class="suspend-until"
             label="admin.user.suspend_duration"
             includeFarFuture=true
+            clearable=false
             input=suspendUntil}}
         </label>
       </div>

--- a/app/assets/javascripts/discourse/templates/components/future-date-input.hbs
+++ b/app/assets/javascripts/discourse/templates/components/future-date-input.hbs
@@ -8,6 +8,7 @@
         input=input
         includeWeekend=includeWeekend
         includeFarFuture=includeFarFuture
+        clearable=clearable
         none="topic.auto_update_input.none"}}
   </div>
 

--- a/app/assets/javascripts/discourse/templates/modal/feature-topic.hbs
+++ b/app/assets/javascripts/discourse/templates/modal/feature-topic.hbs
@@ -44,6 +44,7 @@
             {{future-date-input
               class="pin-until"
               includeFarFuture=true
+              clearable=true
               input=model.pinnedInCategoryUntil}}
             {{popup-input-tip validation=pinInCategoryValidation shownAt=pinInCategoryTipShownAt}}
           </p>
@@ -54,6 +55,7 @@
             {{future-date-input
               class="pin-until"
               includeFarFuture=true
+              clearable=true
               input=model.pinnedInCategoryUntil}}
             {{popup-input-tip validation=pinInCategoryValidation shownAt=pinInCategoryTipShownAt}}
           </p>
@@ -86,6 +88,7 @@
             {{future-date-input
               class="pin-until"
               includeFarFuture=true
+              clearable=true
               input=model.pinnedGloballyUntil}}
             {{popup-input-tip validation=pinGloballyValidation shownAt=pinGloballyTipShownAt}}
           </p>
@@ -96,6 +99,7 @@
             {{future-date-input
               class="pin-until"
               includeFarFuture=true
+              clearable=true
               input=model.pinnedGloballyUntil}}
             {{popup-input-tip validation=pinGloballyValidation shownAt=pinGloballyTipShownAt}}
           </p>

--- a/app/assets/javascripts/select-kit/components/future-date-input-selector.js.es6
+++ b/app/assets/javascripts/select-kit/components/future-date-input-selector.js.es6
@@ -164,7 +164,6 @@ export default ComboBoxComponent.extend(DatetimeMixin, {
   classNames: ["future-date-input-selector"],
   isCustom: Ember.computed.equal("value", "pick_date_and_time"),
   isBasedOnLastPost: Ember.computed.equal("value", "set_based_on_last_post"),
-  clearable: true,
   rowComponent: "future-date-input-selector/future-date-input-selector-row",
   headerComponent:
     "future-date-input-selector/future-date-input-selector-header",


### PR DESCRIPTION
This avoids a strange Safari bug in admin interface, when suspending or silencing a user, selecting "Pick date and time", the date or time inputs are unfocusable. The bug only happens when the inputs are clearable, so this PR makes those inputs unclearable (they shouldn't be clearable, anyway).