### PR TITLE
FIX: GlobalPath#upload_cdn_path when S3 bucket has a folder

### DIFF
--- a/lib/global_path.rb
+++ b/lib/global_path.rb
@@ -9,7 +9,7 @@ module GlobalPath
 
   def upload_cdn_path(p)
     if SiteSetting.Upload.s3_cdn_url.present?
-      p = p.sub(Discourse.store.absolute_base_url, SiteSetting.Upload.s3_cdn_url)
+      p = Discourse.store.cdn_url(p)
     end
     p =~ /^http/ ? p : cdn_path(p)
   end

--- a/spec/components/global_path_spec.rb
+++ b/spec/components/global_path_spec.rb
@@ -25,6 +25,18 @@ describe GlobalPath do
       GlobalSetting.expects(:cdn_url).returns("https://something.com:221/foo")
       expect(cdn_relative_path("/test")).to eq("/foo/test")
     end
+  end
 
+  describe '#upload_cdn_path' do
+    it 'generates correctly when S3 bucket has a folder' do
+      global_setting :s3_access_key_id, 's3_access_key_id'
+      global_setting :s3_secret_access_key, 's3_secret_access_key'
+      global_setting :s3_bucket, 'file-uploads/folder'
+      global_setting :s3_region, 'us-west-2'
+      global_setting :s3_cdn_url, 'https://cdn-aws.com/folder'
+
+      expect(GlobalPathInstance.upload_cdn_path("#{Discourse.store.absolute_base_url}/folder/upload.jpg"))
+        .to eq("https://cdn-aws.com/folder/upload.jpg")
+    end
   end
 end


### PR DESCRIPTION
`GlobalPath#upload_cdn_path` does not consider S3 bucket "folder" path, and results in a repeated folder path in the generated URL, e.g. `https://cdn-aws.com/subfolder/subfolder/original/1X/e57963.jpg`