### PR TITLE
Add Updated Vagrantfile and screen file

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,48 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+# See https://github.com/discourse/discourse/blob/master/docs/VAGRANT.md
+#
+Vagrant.configure("2") do |config|
+  config.vm.box     = 'discourse-18.04'
+  config.vm.box_url = "https://www.dropbox.com/s/2132770g1e05c6d/discourse.box?dl=1"
+
+  # Make this VM reachable on the host network as well, so that other
+  # VM's running other browsers can access our dev server.
+  config.vm.network :private_network, ip: "192.168.10.200"
+
+  # Make it so that network access from the vagrant guest is able to
+  # use SSH private keys that are present on the host without copying
+  # them into the VM.
+  config.ssh.forward_agent = true
+
+  config.vm.provider :virtualbox do |v|
+    # This setting gives the VM 1024MB of RAM instead of the default 384.
+    v.customize ["modifyvm", :id, "--memory", [ENV['DISCOURSE_VM_MEM'].to_i, 1024].max]
+
+    # Who has a single core cpu these days anyways?
+    cpu_count = 2
+
+    # Determine the available cores in host system.
+    # This mostly helps on linux, but it couldn't hurt on MacOSX.
+    if RUBY_PLATFORM =~ /linux/
+      cpu_count = `nproc`.to_i
+    elsif RUBY_PLATFORM =~ /darwin/
+      cpu_count = `sysctl -n hw.ncpu`.to_i
+    end
+
+    # Assign additional cores to the guest OS.
+    v.customize ["modifyvm", :id, "--cpus", cpu_count]
+    v.customize ["modifyvm", :id, "--ioapic", "on"]
+
+    # This setting makes it so that network access from inside the vagrant guest
+    # is able to resolve DNS using the hosts VPN connection.
+    v.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+  end
+
+  config.vm.network :forwarded_port, guest: 3000, host: 4000
+  config.vm.network :forwarded_port, guest: 1080, host: 4080 # Mailcatcher
+
+  nfs_setting = RUBY_PLATFORM =~ /darwin/ || RUBY_PLATFORM =~ /linux/
+  config.vm.synced_folder ".", "/vagrant", id: "vagrant-root"
+
+end

--- a/docs/vagrant.screen
+++ b/docs/vagrant.screen
@@ -1,0 +1,18 @@
+# GNU screen configuration file for Discourse vagrant image
+
+# Start up development support commands in detached mode:
+#   screen -d -m -c docs/vagrant.screen
+
+# Start in attached mode:
+# screen -m -c docs/vagrant.screen
+
+# commands that exit hang around until you hit 'k' to kill or 'r' to restart
+zombie kr
+
+screen -t rails_s 0 bash -c 'echo Starting rails server...;  cd /vagrant; bundle exec rails s -b 0.0.0.0'
+screen -t rails_c 1 bash -c 'echo Starting rails console...; cd /vagrant; bundle exec rails c'
+screen -t sidekiq 2 bash -c 'echo Starting sidekiq...;       cd /vagrant; bundle exec sidekiq -l log/sidekiq.log'
+screen -t mail    3 bash -c 'echo Starting mailcatcher...;   cd /; mailcatcher --ip 0.0.0.0'
+screen -t bash    4 bash
+
+scrollback 50000


### PR DESCRIPTION
The Vagrantfile was previously removed as it was considered abandoned. This made the use of a Vagrant setup for development much more difficult. A new Vagrantfile that points to a new vagrant box (available publicly via dropbox) is now included. It uses an Ubuntu 18.04 server and the most recent Discourse