### PR TITLE
PERF: remove total unread notifications from message bus

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -538,7 +538,6 @@ class User < ActiveRecord::Base
     payload = {
       unread_notifications: unread_notifications,
       unread_private_messages: unread_private_messages,
-      total_unread_notifications: total_unread_notifications,
       read_first_notification: read_first_notification?,
       last_notification: json,
       recent: recent,

--- a/test/javascripts/fixtures/session-fixtures.js.es6
+++ b/test/javascripts/fixtures/session-fixtures.js.es6
@@ -6,7 +6,6 @@ export default {
       uploaded_avatar_id: 5275,
       avatar_template: "/user_avatar/localhost/eviltrout/{size}/5275.png",
       name: "Robin Ward",
-      total_unread_notifications: 205,
       unread_notifications: 0,
       unread_private_messages: 0,
       admin: true,


### PR DESCRIPTION
User notifications queries and publishes total_unread_notifications on the message bus, but does not appear to use it.