### PR TITLE
FIX: return 400 for missing required params

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -219,6 +219,10 @@ class ApplicationController < ActionController::Base
     render_json_error I18n.t('read_only_mode_enabled'), type: :read_only, status: 503
   end
 
+  rescue_from ActionController::ParameterMissing do |e|
+    render_json_error e.message, status: 400
+  end
+
   def redirect_with_client_support(url, options)
     if request.xhr?
       response.headers['Discourse-Xhr-Redirect'] = 'true'

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -42,6 +42,17 @@ RSpec.describe ApplicationController do
     end
   end
 
+  describe 'missing required param' do
+    it 'should return a 400' do
+      get "/search/query.json", params: { trem: "misspelled term" }
+
+      expect(response.status).to eq(400)
+      expect(JSON.parse(response.body)).to eq(
+        "errors" => ["param is missing or the value is empty: term"]
+      )
+    end
+  end
+
   describe 'build_not_found_page' do
     describe 'topic not found' do
 


### PR DESCRIPTION
If a required param is missing return a 400 and show a message
displaying which param was missing. Added this to the application
controller so that we don't have to add this logic to every controller
action.