### PR TITLE
FIX: Add presentation role to topic map headings, for accessibility

### DIFF
--- a/app/assets/javascripts/discourse/widgets/topic-map.js.es6
+++ b/app/assets/javascripts/discourse/widgets/topic-map.js.es6
@@ -86,7 +86,7 @@ createWidget("topic-map-summary", {
     const contents = [];
     contents.push(
       h("li", [
-        h("h4", I18n.t("created_lowercase")),
+        h("h4", { attributes: { role: "presentation" } }, I18n.t("created_lowercase")),
         h("div.topic-map-post.created-at", [
           avatarFor("tiny", {
             username: attrs.createdByUsername,
@@ -101,7 +101,7 @@ createWidget("topic-map-summary", {
       h(
         "li",
         h("a", { attributes: { href: attrs.lastPostUrl } }, [
-          h("h4", I18n.t("last_reply_lowercase")),
+          h("h4", { attributes: { role: "presentation" } }, I18n.t("last_reply_lowercase")),
           h("div.topic-map-post.last-reply", [
             avatarFor("tiny", {
               username: attrs.lastPostUsername,
@@ -116,13 +116,13 @@ createWidget("topic-map-summary", {
     contents.push(
       h("li", [
         numberNode(attrs.topicReplyCount),
-        h("h4", I18n.t("replies_lowercase", { count: attrs.topicReplyCount }))
+        h("h4", { attributes: { role: "presentation" } }, I18n.t("replies_lowercase", { count: attrs.topicReplyCount }))
       ])
     );
     contents.push(
       h("li.secondary", [
         numberNode(attrs.topicViews, { className: attrs.topicViewsHeat }),
-        h("h4", I18n.t("views_lowercase", { count: attrs.topicViews }))
+        h("h4", { attributes: { role: "presentation" } }, I18n.t("views_lowercase", { count: attrs.topicViews }))
       ])
     );
 
@@ -130,7 +130,7 @@ createWidget("topic-map-summary", {
       contents.push(
         h("li.secondary", [
           numberNode(attrs.participantCount),
-          h("h4", I18n.t("users_lowercase", { count: attrs.participantCount }))
+          h("h4", { attributes: { role: "presentation" } }, I18n.t("users_lowercase", { count: attrs.participantCount }))
         ])
       );
     }
@@ -139,7 +139,7 @@ createWidget("topic-map-summary", {
       contents.push(
         h("li.secondary", [
           numberNode(attrs.topicLikeCount),
-          h("h4", I18n.t("likes_lowercase", { count: attrs.topicLikeCount }))
+          h("h4", { attributes: { role: "presentation" } }, I18n.t("likes_lowercase", { count: attrs.topicLikeCount }))
         ])
       );
     }
@@ -148,7 +148,7 @@ createWidget("topic-map-summary", {
       contents.push(
         h("li.secondary", [
           numberNode(attrs.topicLinkLength),
-          h("h4", I18n.t("links_lowercase", { count: attrs.topicLinkLength }))
+          h("h4", { attributes: { role: "presentation" } }, I18n.t("links_lowercase", { count: attrs.topicLinkLength }))
         ])
       );
     }

--- a/app/assets/javascripts/discourse/widgets/topic-map.js.es6
+++ b/app/assets/javascripts/discourse/widgets/topic-map.js.es6
@@ -86,7 +86,11 @@ createWidget("topic-map-summary", {
     const contents = [];
     contents.push(
       h("li", [
-        h("h4", { attributes: { role: "presentation" } }, I18n.t("created_lowercase")),
+        h(
+          "h4",
+          { attributes: { role: "presentation" } },
+          I18n.t("created_lowercase")
+        ),
         h("div.topic-map-post.created-at", [
           avatarFor("tiny", {
             username: attrs.createdByUsername,
@@ -101,7 +105,11 @@ createWidget("topic-map-summary", {
       h(
         "li",
         h("a", { attributes: { href: attrs.lastPostUrl } }, [
-          h("h4", { attributes: { role: "presentation" } }, I18n.t("last_reply_lowercase")),
+          h(
+            "h4",
+            { attributes: { role: "presentation" } },
+            I18n.t("last_reply_lowercase")
+          ),
           h("div.topic-map-post.last-reply", [
             avatarFor("tiny", {
               username: attrs.lastPostUsername,
@@ -116,13 +124,21 @@ createWidget("topic-map-summary", {
     contents.push(
       h("li", [
         numberNode(attrs.topicReplyCount),
-        h("h4", { attributes: { role: "presentation" } }, I18n.t("replies_lowercase", { count: attrs.topicReplyCount }))
+        h(
+          "h4",
+          { attributes: { role: "presentation" } },
+          I18n.t("replies_lowercase", { count: attrs.topicReplyCount })
+        )
       ])
     );
     contents.push(
       h("li.secondary", [
         numberNode(attrs.topicViews, { className: attrs.topicViewsHeat }),
-        h("h4", { attributes: { role: "presentation" } }, I18n.t("views_lowercase", { count: attrs.topicViews }))
+        h(
+          "h4",
+          { attributes: { role: "presentation" } },
+          I18n.t("views_lowercase", { count: attrs.topicViews })
+        )
       ])
     );
 
@@ -130,7 +146,11 @@ createWidget("topic-map-summary", {
       contents.push(
         h("li.secondary", [
           numberNode(attrs.participantCount),
-          h("h4", { attributes: { role: "presentation" } }, I18n.t("users_lowercase", { count: attrs.participantCount }))
+          h(
+            "h4",
+            { attributes: { role: "presentation" } },
+            I18n.t("users_lowercase", { count: attrs.participantCount })
+          )
         ])
       );
     }
@@ -139,7 +159,11 @@ createWidget("topic-map-summary", {
       contents.push(
         h("li.secondary", [
           numberNode(attrs.topicLikeCount),
-          h("h4", { attributes: { role: "presentation" } }, I18n.t("likes_lowercase", { count: attrs.topicLikeCount }))
+          h(
+            "h4",
+            { attributes: { role: "presentation" } },
+            I18n.t("likes_lowercase", { count: attrs.topicLikeCount })
+          )
         ])
       );
     }
@@ -148,7 +172,11 @@ createWidget("topic-map-summary", {
       contents.push(
         h("li.secondary", [
           numberNode(attrs.topicLinkLength),
-          h("h4", { attributes: { role: "presentation" } }, I18n.t("links_lowercase", { count: attrs.topicLinkLength }))
+          h(
+            "h4",
+            { attributes: { role: "presentation" } },
+            I18n.t("links_lowercase", { count: attrs.topicLinkLength })
+          )
         ])
       );
     }


### PR DESCRIPTION
The `h4` elements in the topic map are not true headings; that tag is only
used to achieve a particular presentation. The use of a heading tag here
confuses screen reader users, who use headings for quick navigation. To
fix this without breaking any CSS, especially for third-party themes, we
add `role="presentation"` to these elements. That tells screen readers,
and other assistive technologies, to ignore the normal semantics of
these elements.