### PR TITLE
FIX: don't strip eml attachments from received emails

### DIFF
--- a/lib/email/receiver.rb
+++ b/lib/email/receiver.rb
@@ -882,7 +882,7 @@ module Email
     def attachments
       # strip blacklisted attachments (mostly signatures)
       @attachments ||= begin
-        attachments =  @mail.attachments.select { |attachment| is_whitelisted_attachment?(attachment) }
+        attachments =  @mail.parts.select { |part| part.attachment? && is_whitelisted_attachment?(part) }
         attachments << @mail if @mail.attachment? && is_whitelisted_attachment?(@mail)
         attachments
       end

--- a/spec/components/email/receiver_spec.rb
+++ b/spec/components/email/receiver_spec.rb
@@ -470,31 +470,43 @@ describe Email::Receiver do
     it "supports attachments" do
       SiteSetting.authorized_extensions = "txt"
       expect { process(:attached_txt_file) }.to change { topic.posts.count }
-      expect(topic.posts.last.raw).to match(/text\.txt/)
+      expect(topic.posts.last.raw).to match(/<a\sclass='attachment'[^>]*>text\.txt<\/a>/)
+      expect(topic.posts.last.uploads.length).to eq 1
+    end
+
+    it "supports eml attachments" do
+      SiteSetting.authorized_extensions = "eml"
+      expect { process(:attached_eml_file) }.to change { topic.posts.count }
+      expect(topic.posts.last.raw).to match(/<a\sclass='attachment'[^>]*>sample\.eml<\/a>/)
+      expect(topic.posts.last.uploads.length).to eq 1
     end
 
     context "when attachment is rejected" do
       it "sends out the warning email" do
         expect { process(:attached_txt_file) }.to change { EmailLog.count }.by(1)
         expect(EmailLog.last.email_type).to eq("email_reject_attachment")
+        expect(topic.posts.last.uploads.length).to eq 0
       end
 
       it "doesn't send out the warning email if sender is staged user" do
         user.update_columns(staged: true)
         expect { process(:attached_txt_file) }.not_to change { EmailLog.count }
+        expect(topic.posts.last.uploads.length).to eq 0
       end
 
       it "creates the post with attachment missing message" do
         missing_attachment_regex = Regexp.escape(I18n.t('emails.incoming.missing_attachment', filename: "text.txt"))
         expect { process(:attached_txt_file) }.to change { topic.posts.count }
         expect(topic.posts.last.raw).to match(/#{missing_attachment_regex}/)
+        expect(topic.posts.last.uploads.length).to eq 0
       end
     end
 
     it "supports emails with just an attachment" do
       SiteSetting.authorized_extensions = "pdf"
       expect { process(:attached_pdf_file) }.to change { topic.posts.count }
-      expect(topic.posts.last.raw).to match(/discourse\.pdf/)
+      expect(topic.posts.last.raw).to match(/<a\sclass='attachment'[^>]*>discourse\.pdf<\/a>/)
+      expect(topic.posts.last.uploads.length).to eq 1
     end
 
     it "supports liking via email" do
@@ -638,7 +650,8 @@ describe Email::Receiver do
     it "supports any kind of attachments when 'allow_all_attachments_for_group_messages' is enabled" do
       SiteSetting.allow_all_attachments_for_group_messages = true
       expect { process(:attached_rb_file) }.to change(Topic, :count)
-      expect(Post.last.raw).to match(/discourse\.rb/)
+      expect(Post.last.raw).to match(/<a\sclass='attachment'[^>]*>discourse\.rb<\/a>/)
+      expect(Post.last.uploads.length).to eq 1
     end
 
     it "enables user's email_private_messages setting when user emails new topic to group" do

--- a/spec/fixtures/emails/attached_eml_file.eml
+++ b/spec/fixtures/emails/attached_eml_file.eml
@@ -1,0 +1,31 @@
+Return-Path: <discourse@bar.com>
+From: Foo Bar <discourse@bar.com>
+To: reply+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com
+Date: Sat, 30 Jan 2016 01:10:11 +0100
+Message-ID: <38@foo.bar.mail>
+Mime-Version: 1.0
+Content-Type: multipart/mixed;
+ boundary="--==_mimepart_56abff5d49749_ddf83fca6d033a28548ad";
+ charset=UTF-8
+Content-Transfer-Encoding: 7bit
+
+
+----==_mimepart_56abff5d49749_ddf83fca6d033a28548ad
+Content-Type: text/plain;
+ charset=UTF-8
+Content-Transfer-Encoding: 7bit
+
+Please find the eml file attached.
+
+----==_mimepart_56abff5d49749_ddf83fca6d033a28548ad
+Content-Type: message/rfc822; name="sample.eml"
+Content-Disposition: attachment; filename="sample.eml"
+Content-Transfer-Encoding: base64
+X-Attachment-Id: f_jnxo58s31
+Content-ID: <f_jnxo58s31>
+
+RGF0ZTogU3VuLCAxIEFwciAyMDEyIDE0OjI1OjI1IC0wNjAwDQpGcm9tOiBmaWxlQGZ5aWNlbnRl
+ci5jb20NClN1YmplY3Q6IFdlbGNvbWUNClRvOiBzb21lb25lQHNvbWV3aGVyZS5jb20NCg0KRGVh
+ciBGcmllbmQsDQoNCldlbGNvbWUgdG8gZmlsZS5meWljZW50ZXIuY29tIQ0KDQpTaW5jZXJlbHks
+DQpGWUljZW50ZXIuY29tIFRlYW0NCg==
+----==_mimepart_56abff5d49749_ddf83fca6d033a28548ad--


### PR DESCRIPTION
https://meta.discourse.org/t/outlook-email-files-attached-to-emails-sent-to-discourse-are-stripped-and-not-delivered/98703/8

When using attachments method from Mail gem on raw mail content, it's checking within the attached .eml for attachments instead of treating it as one (https://github.com/mikel/mail/blob/master/lib/mail/attachments_list.rb#L10). This is a way around it