### PR TITLE
FIX: only extract script tags with certain types

### DIFF
--- a/app/models/theme_field.rb
+++ b/app/models/theme_field.rb
@@ -123,9 +123,10 @@ COMPILED
     end
 
     doc.css('script').each do |node|
-      next if node['src'].present?
+      next unless inline_javascript?(node)
 
-      javascript_cache.content << "(function() { #{node.inner_html} })();"
+      javascript_cache.content << node.inner_html
+      javascript_cache.content << "\n"
       node.remove
     end
 
@@ -252,6 +253,24 @@ COMPILED
     # TODO message for mobile vs desktop
     MessageBus.publish "/header-change/#{theme.id}", self.value if theme && self.name == "header"
     MessageBus.publish "/footer-change/#{theme.id}", self.value if theme && self.name == "footer"
+  end
+
+  private
+
+  JAVASCRIPT_TYPES = %w(
+    text/javascript
+    application/javascript
+    application/ecmascript
+  )
+
+  def inline_javascript?(node)
+    if node['src'].present?
+      false
+    elsif node['type'].present?
+      JAVASCRIPT_TYPES.include?(node['type'])
+    else
+      true
+    end
   end
 end
 

--- a/app/models/theme_field.rb
+++ b/app/models/theme_field.rb
@@ -267,7 +267,7 @@ COMPILED
     if node['src'].present?
       false
     elsif node['type'].present?
-      JAVASCRIPT_TYPES.include?(node['type'])
+      JAVASCRIPT_TYPES.include?(node['type'].downcase)
     else
       true
     end

--- a/spec/models/theme_field_spec.rb
+++ b/spec/models/theme_field_spec.rb
@@ -37,8 +37,17 @@ describe ThemeField do
     <script type="text/discourse-plugin" version="0.8">
       var a = "inline discourse plugin";
     </script>
+    <script type="text/template" data-template="custom-template">
+      <div>custom script type</div>
+    </script>
     <script>
       var b = "inline raw script";
+    </script>
+    <script type="text/javascript">
+      var c = "text/javascript";
+    </script>
+    <script type="application/javascript">
+      var d = "application/javascript";
     </script>
     <script src="/external-script.js"></script>
     HTML
@@ -47,8 +56,27 @@ describe ThemeField do
 
     expect(theme_field.value_baked).to include("<script src=\"#{theme_field.javascript_cache.url}\"></script>")
     expect(theme_field.value_baked).to include("external-script.js")
-    expect(theme_field.javascript_cache.content).to include('inline discourse plugin')
-    expect(theme_field.javascript_cache.content).to include('inline raw script')
+    expect(theme_field.value_baked).to include('<script type="text/template"')
+    expect(theme_field.javascript_cache.content).to include('a = "inline discourse plugin"')
+    expect(theme_field.javascript_cache.content).to include('b = "inline raw script"')
+    expect(theme_field.javascript_cache.content).to include('c = "text/javascript"')
+    expect(theme_field.javascript_cache.content).to include('d = "application/javascript"')
+  end
+
+  it 'adds newlines between the extracted javascripts' do
+    html = <<~HTML
+    <script>var a = 10</script>
+    <script>var b = 10</script>
+    HTML
+
+    extracted = <<~JavaScript
+    var a = 10
+    var b = 10
+    JavaScript
+
+    theme_field = ThemeField.create!(theme_id: 1, target_id: 0, name: "header", value: html)
+
+    expect(theme_field.javascript_cache.content).to eq(extracted)
   end
 
   it "correctly extracts and generates errors for transpiled js" do

--- a/spec/models/theme_field_spec.rb
+++ b/spec/models/theme_field_spec.rb
@@ -43,7 +43,7 @@ describe ThemeField do
     <script>
       var b = "inline raw script";
     </script>
-    <script type="text/javascript">
+    <script type="texT/jAvasCripT">
       var c = "text/javascript";
     </script>
     <script type="application/javascript">


### PR DESCRIPTION
`script` tags with custom types (e.g. `text/template`) will not be executed by the browser, and should not be extracted into an external theme JavaScript.