### PR TITLE
FIX: topic-map spec with VDOM and i18n plural

### DIFF
--- a/app/assets/javascripts/discourse/widgets/topic-map.js.es6
+++ b/app/assets/javascripts/discourse/widgets/topic-map.js.es6
@@ -88,7 +88,9 @@ createWidget("topic-map-summary", {
       h("li", [
         h(
           "h4",
-          { attributes: { role: "presentation" } },
+          {
+            attributes: { role: "presentation" }
+          },
           I18n.t("created_lowercase")
         ),
         h("div.topic-map-post.created-at", [
@@ -107,7 +109,9 @@ createWidget("topic-map-summary", {
         h("a", { attributes: { href: attrs.lastPostUrl } }, [
           h(
             "h4",
-            { attributes: { role: "presentation" } },
+            {
+              attributes: { role: "presentation" }
+            },
             I18n.t("last_reply_lowercase")
           ),
           h("div.topic-map-post.last-reply", [
@@ -126,8 +130,12 @@ createWidget("topic-map-summary", {
         numberNode(attrs.topicReplyCount),
         h(
           "h4",
-          { attributes: { role: "presentation" } },
-          I18n.t("replies_lowercase", { count: attrs.topicReplyCount })
+          {
+            attributes: { role: "presentation" }
+          },
+          I18n.t("replies_lowercase", {
+            count: attrs.topicReplyCount
+          }).toString()
         )
       ])
     );
@@ -136,8 +144,10 @@ createWidget("topic-map-summary", {
         numberNode(attrs.topicViews, { className: attrs.topicViewsHeat }),
         h(
           "h4",
-          { attributes: { role: "presentation" } },
-          I18n.t("views_lowercase", { count: attrs.topicViews })
+          {
+            attributes: { role: "presentation" }
+          },
+          I18n.t("views_lowercase", { count: attrs.topicViews }).toString()
         )
       ])
     );
@@ -148,8 +158,12 @@ createWidget("topic-map-summary", {
           numberNode(attrs.participantCount),
           h(
             "h4",
-            { attributes: { role: "presentation" } },
-            I18n.t("users_lowercase", { count: attrs.participantCount })
+            {
+              attributes: { role: "presentation" }
+            },
+            I18n.t("users_lowercase", {
+              count: attrs.participantCount
+            }).toString()
           )
         ])
       );
@@ -161,8 +175,12 @@ createWidget("topic-map-summary", {
           numberNode(attrs.topicLikeCount),
           h(
             "h4",
-            { attributes: { role: "presentation" } },
-            I18n.t("likes_lowercase", { count: attrs.topicLikeCount })
+            {
+              attributes: { role: "presentation" }
+            },
+            I18n.t("likes_lowercase", {
+              count: attrs.topicLikeCount
+            }).toString()
           )
         ])
       );
@@ -174,8 +192,12 @@ createWidget("topic-map-summary", {
           numberNode(attrs.topicLinkLength),
           h(
             "h4",
-            { attributes: { role: "presentation" } },
-            I18n.t("links_lowercase", { count: attrs.topicLinkLength })
+            {
+              attributes: { role: "presentation" }
+            },
+            I18n.t("links_lowercase", {
+              count: attrs.topicLinkLength
+            }).toString()
           )
         ])
       );


### PR DESCRIPTION
It appears that in vdom nodes, pluralized i18n strings are not compiled into a string before widget is compiled and result in an error as VDOM is expecting a string and not an object.