### PR TITLE
Full height swipe-able menus

### DIFF
--- a/app/assets/javascripts/discourse/components/site-header.js.es6
+++ b/app/assets/javascripts/discourse/components/site-header.js.es6
@@ -18,6 +18,8 @@ const SiteHeaderComponent = MountWidget.extend(Docking, PanEvents, {
   _isPanning: false,
   _panMenuOrigin: "right",
   _panMenuOffset: 0,
+  _scheduledMovingAnimation: null,
+  _scheduledRemoveAnimate: null,
   _topic: null,
 
   @observes(
@@ -62,7 +64,9 @@ const SiteHeaderComponent = MountWidget.extend(Docking, PanEvents, {
         this._animateOpening($panel);
       } else {
         //continue to open or close menu
-        window.requestAnimationFrame(() => this._handlePanDone(offset, event));
+        this._scheduledMovingAnimation = window.requestAnimationFrame(() =>
+          this._handlePanDone(offset, event)
+        );
       }
     });
   },
@@ -244,6 +248,8 @@ const SiteHeaderComponent = MountWidget.extend(Docking, PanEvents, {
         .off("pointermove")
         .off("pointercancel");
     }
+    Ember.run.cancel(this._scheduledRemoveAnimate);
+    window.cancelAnimationFrame(this._scheduledMovingAnimation);
   },
 
   buildArgs() {
@@ -361,7 +367,7 @@ const SiteHeaderComponent = MountWidget.extend(Docking, PanEvents, {
       if (this._animate) {
         $panel.addClass("animate");
         $headerCloak.addClass("animate");
-        Ember.run.later(() => {
+        this._scheduledRemoveAnimate = Ember.run.later(() => {
           $panel.removeClass("animate");
           $headerCloak.removeClass("animate");
         }, 200);

--- a/app/assets/javascripts/discourse/components/site-header.js.es6
+++ b/app/assets/javascripts/discourse/components/site-header.js.es6
@@ -61,13 +61,13 @@ const SiteHeaderComponent = MountWidget.extend(Docking, PanEvents, {
     const panMenuOrigin = this.get("panMenuOrigin");
     const panMenuOffset = this.get("panMenuOffset");
     if (panMenuOrigin === "right" && panMenuOffset === 0) {
-      return (e.deltaX > 200 && e.velocityX > -0.15) || e.velocityX > 0.15;
+      return (e.deltaX > 200 && e.velocityX > -0.10) || e.velocityX > 0.10;
     } else if (panMenuOrigin === "left" && panMenuOffset === 0) {
-      return (e.deltaX < -200 && e.velocityX < 0.15) || e.velocityX < -0.15;
+      return (e.deltaX < -200 && e.velocityX < 0.10) || e.velocityX < -0.10;
     } else if (panMenuOrigin === "right" && panMenuOffset !== 0) {
-      return (e.deltaX > 200 && e.velocityX > -0.15) || e.velocityX > 0.15;
+      return (e.deltaX > 200 && e.velocityX > -0.10) || e.velocityX > 0.10;
     } else if (panMenuOrigin === "left" && panMenuOffset !== 0) {
-      return (e.deltaX < -200 && e.velocityX < 0.15) || e.velocityX < -0.15;
+      return (e.deltaX < -200 && e.velocityX < 0.10) || e.velocityX < -0.10;
     }
   },
 

--- a/app/assets/javascripts/discourse/components/site-header.js.es6
+++ b/app/assets/javascripts/discourse/components/site-header.js.es6
@@ -180,6 +180,7 @@ const SiteHeaderComponent = MountWidget.extend(Docking, PanEvents, {
   },
 
   setTopic(topic) {
+    this.eventDispatched("dom:clean", "header");
     this._topic = topic;
     this.queueRerender();
   },

--- a/app/assets/javascripts/discourse/components/site-header.js.es6
+++ b/app/assets/javascripts/discourse/components/site-header.js.es6
@@ -138,7 +138,6 @@ const SiteHeaderComponent = MountWidget.extend(Docking, PanEvents, {
     if (!this.get("isPanning")) {
       return;
     }
-    e.originalEvent.preventDefault();
     const $menuPanels = $(".menu-panel");
     const panMenuOffset = this.get("panMenuOffset");
     $menuPanels.each((idx, panel) => {

--- a/app/assets/javascripts/discourse/components/site-header.js.es6
+++ b/app/assets/javascripts/discourse/components/site-header.js.es6
@@ -82,6 +82,7 @@ const SiteHeaderComponent = MountWidget.extend(Docking, PanEvents, {
         $centeredElement.parents(".panel-body").length) &&
       (e.direction === "left" || e.direction === "right")
     ) {
+      e.originalEvent.preventDefault();
       this.set("isPanning", true);
     } else if (
       center.x < 30 &&
@@ -137,6 +138,7 @@ const SiteHeaderComponent = MountWidget.extend(Docking, PanEvents, {
     if (!this.get("isPanning")) {
       return;
     }
+    e.originalEvent.preventDefault();
     const $menuPanels = $(".menu-panel");
     const panMenuOffset = this.get("panMenuOffset");
     $menuPanels.each((idx, panel) => {
@@ -334,8 +336,10 @@ const SiteHeaderComponent = MountWidget.extend(Docking, PanEvents, {
 
         const menuTop = this.site.mobileView ? 0 : headerHeight();
 
-        let height;
-        const winHeight = $(window).height() - 16;
+        let height = window.innerHeight
+          ? window.innerHeight
+          : $(window).height();
+        const winHeight = height - 16;
         height = winHeight - menuTop;
 
         if ($panelBody.prop("style").height !== "100%") {

--- a/app/assets/javascripts/discourse/components/site-header.js.es6
+++ b/app/assets/javascripts/discourse/components/site-header.js.es6
@@ -47,8 +47,8 @@ const SiteHeaderComponent = MountWidget.extend(Docking, PanEvents, {
     const $window = $(window);
     const windowWidth = parseInt($window.width());
     const $menuPanels = $(".menu-panel");
-    this._shouldPanClose(event) ? (offset += velocity) : (offset -= velocity);
     const menuOrigin = this.get("panMenuOrigin");
+    this._shouldMenuClose(event, menuOrigin) ? (offset += velocity) : (offset -= velocity);
     $menuPanels.each((idx, panel) => {
       const $panel = $(panel);
       const $headerCloak = $(".header-cloak");
@@ -65,23 +65,13 @@ const SiteHeaderComponent = MountWidget.extend(Docking, PanEvents, {
     });
   },
 
-  _shouldPanClose(e) {
-    const panMenuOrigin = this.get("panMenuOrigin");
-    const panMenuOffset = this.get("panMenuOffset");
-    //already opened, swiping from the right
-    //TODO: separate functions, add parameters
-    if(panMenuOrigin === "right") {
-      
+  _shouldMenuClose(e, menuOrigin) {
+    // menu should close after a pan either:
+    // if a user moved the panel closed past a threshold and away and is NOT swiping back open
+    // if a user swiped to close fast enough regardless of distance
+    if (menuOrigin === "right") {
+      return (e.deltaX > 200 && e.velocityX > -0.10) || e.velocityX > 0.10;
     } else {
-      
-    }
-    if (panMenuOrigin === "right" && panMenuOffset === 0) {
-      return (e.deltaX > 200 && e.velocityX > -0.10) || e.velocityX > 0.10;
-    } else if (panMenuOrigin === "left" && panMenuOffset === 0) {
-      return (e.deltaX < -200 && e.velocityX < 0.10) || e.velocityX < -0.10;
-    } else if (panMenuOrigin === "right" && panMenuOffset !== 0) {
-      return (e.deltaX > 200 && e.velocityX > -0.10) || e.velocityX > 0.10;
-    } else if (panMenuOrigin === "left" && panMenuOffset !== 0) {
       return (e.deltaX < -200 && e.velocityX < 0.10) || e.velocityX < -0.10;
     }
   },

--- a/app/assets/javascripts/discourse/components/site-header.js.es6
+++ b/app/assets/javascripts/discourse/components/site-header.js.es6
@@ -86,13 +86,13 @@ const SiteHeaderComponent = MountWidget.extend(Docking, PanEvents, {
       return (
         (e.deltaX > SWIPE_DISTANCE_THRESHOLD &&
           e.velocityX > -SWIPE_VELOCITY_THRESHOLD) ||
-        e.velocityX > SWIPE_VELOCITY_THRESHOLD
+        e.velocityX > 0
       );
     } else {
       return (
         (e.deltaX < -SWIPE_DISTANCE_THRESHOLD &&
           e.velocityX < SWIPE_VELOCITY_THRESHOLD) ||
-        e.velocityX < -SWIPE_VELOCITY_THRESHOLD
+        e.velocityX < 0
       );
     }
   },
@@ -269,7 +269,9 @@ const SiteHeaderComponent = MountWidget.extend(Docking, PanEvents, {
   afterRender() {
     const $menuPanels = $(".menu-panel");
     if ($menuPanels.length === 0) {
-      this._animate = true;
+      if (this.site.mobileView) {
+        this._animate = true;
+      }
       return;
     }
 
@@ -351,11 +353,17 @@ const SiteHeaderComponent = MountWidget.extend(Docking, PanEvents, {
 
         const menuTop = this.site.mobileView ? 0 : headerHeight();
 
-        let height = window.innerHeight
+        let height;
+        const winHeightOffset = 16;
+        let initialWinHeight = window.innerHeight
           ? window.innerHeight
           : $(window).height();
-        const winHeight = height - 16;
-        height = winHeight - menuTop;
+        const winHeight = initialWinHeight - winHeightOffset;
+        if (menuTop + contentHeight < winHeight && !this.site.mobileView) {
+          height = contentHeight + "px";
+        } else {
+          height = winHeight - menuTop;
+        }
 
         if ($panelBody.prop("style").height !== "100%") {
           $panelBody.height("100%");

--- a/app/assets/javascripts/discourse/components/site-header.js.es6
+++ b/app/assets/javascripts/discourse/components/site-header.js.es6
@@ -95,6 +95,7 @@ const SiteHeaderComponent = MountWidget.extend(Docking, PanEvents, {
         panMenuOffset: -300,
         isPanning: true
       });
+      $("header.d-header").removeClass("scroll-down scroll-up");
       this.eventDispatched("toggleHamburger", "header");
     } else if (
       windowWidth - center.x < 30 &&
@@ -107,6 +108,7 @@ const SiteHeaderComponent = MountWidget.extend(Docking, PanEvents, {
         panMenuOffset: -300,
         isPanning: true
       });
+      $("header.d-header").removeClass("scroll-down scroll-up");
       this.eventDispatched("toggleUserMenu", "header");
     } else {
       this.set("isPanning", false);

--- a/app/assets/javascripts/discourse/components/site-header.js.es6
+++ b/app/assets/javascripts/discourse/components/site-header.js.es6
@@ -275,7 +275,7 @@ const SiteHeaderComponent = MountWidget.extend(Docking, PanEvents, {
         width = windowWidth - 50;
       }
       if (this._panMenuOffset) {
-        this.set("panMenuOffset", -width);
+        this._panMenuOffset = -width;
       }
 
       $panel.removeClass("drop-down slide-in").addClass(viewMode);

--- a/app/assets/javascripts/discourse/components/site-header.js.es6
+++ b/app/assets/javascripts/discourse/components/site-header.js.es6
@@ -87,6 +87,10 @@ const SiteHeaderComponent = MountWidget.extend(Docking, PanEvents, {
   },
 
   panStart(e) {
+    //android supports pulling in from the screen edges
+    const screenEdgeMargin = 30;
+    const screenOffset = 300;
+
     const center = e.center;
     const $centeredElement = $(document.elementFromPoint(center.x, center.y));
     const $window = $(window);
@@ -100,24 +104,24 @@ const SiteHeaderComponent = MountWidget.extend(Docking, PanEvents, {
       e.originalEvent.preventDefault();
       this._isPanning = true;
     } else if (
-      center.x < 30 &&
+      center.x < screenEdgeMargin &&
       !this.$(".menu-panel").length &&
       e.direction === "right"
     ) {
       this._animate = false;
       this._panMenuOrigin = "left";
-      this._panMenuOffset = -300;
+      this._panMenuOffset = -screenOffset;
       this._isPanning = true;
       $("header.d-header").removeClass("scroll-down scroll-up");
       this.eventDispatched("toggleHamburger", "header");
     } else if (
-      windowWidth - center.x < 30 &&
+      windowWidth - center.x < screenEdgeMargin &&
       !this.$(".menu-panel").length &&
       e.direction === "left"
     ) {
       this._animate = false;
       this._panMenuOrigin = "right";
-      this._panMenuOffset = -300;
+      this._panMenuOffset = -screenOffset;
       this._isPanning = true;
       $("header.d-header").removeClass("scroll-down scroll-up");
       this.eventDispatched("toggleUserMenu", "header");

--- a/app/assets/javascripts/discourse/components/site-header.js.es6
+++ b/app/assets/javascripts/discourse/components/site-header.js.es6
@@ -14,10 +14,10 @@ const SiteHeaderComponent = MountWidget.extend(Docking, PanEvents, {
   widget: "header",
   docAt: null,
   dockedHeader: null,
-  animate: false,
-  isPanning: false,
-  panMenuOrigin: "right",
-  panMenuOffset: 0,
+  _animate: false,
+  _isPanning: false,
+  _panMenuOrigin: "right",
+  _panMenuOffset: 0,
   _topic: null,
 
   @observes(
@@ -30,15 +30,15 @@ const SiteHeaderComponent = MountWidget.extend(Docking, PanEvents, {
 
   _animateOpening($panel) {
     $panel.css({ right: "", left: "" });
-    this.panMenuOffset = 0;
+    this._panMenuOffset = 0;
   },
 
   _animateClosing($panel, menuOrigin, windowWidth) {
     $panel.css(menuOrigin, -windowWidth);
-    this.animate = true;
+    this._animate = true;
     Ember.run.schedule("afterRender", () => {
       this.eventDispatched("dom:clean", "header");
-      this.panMenuOffset = 0;
+      this._panMenuOffset = 0;
     });
   },
 
@@ -47,7 +47,7 @@ const SiteHeaderComponent = MountWidget.extend(Docking, PanEvents, {
     const $window = $(window);
     const windowWidth = parseInt($window.width());
     const $menuPanels = $(".menu-panel");
-    const menuOrigin = this.panMenuOrigin;
+    const menuOrigin = this._panMenuOrigin;
     this._shouldMenuClose(event, menuOrigin)
       ? (offset += velocity)
       : (offset -= velocity);
@@ -98,16 +98,16 @@ const SiteHeaderComponent = MountWidget.extend(Docking, PanEvents, {
       (e.direction === "left" || e.direction === "right")
     ) {
       e.originalEvent.preventDefault();
-      this.isPanning = true;
+      this._isPanning = true;
     } else if (
       center.x < 30 &&
       !this.$(".menu-panel").length &&
       e.direction === "right"
     ) {
-      this.animate = false;
-      this.panMenuOrigin = "left";
-      this.panMenuOffset = -300;
-      this.isPanning = true;
+      this._animate = false;
+      this._panMenuOrigin = "left";
+      this._panMenuOffset = -300;
+      this._isPanning = true;
       $("header.d-header").removeClass("scroll-down scroll-up");
       this.eventDispatched("toggleHamburger", "header");
     } else if (
@@ -115,26 +115,26 @@ const SiteHeaderComponent = MountWidget.extend(Docking, PanEvents, {
       !this.$(".menu-panel").length &&
       e.direction === "left"
     ) {
-      this.animate = false;
-      this.panMenuOrigin = "right";
-      this.panMenuOffset = -300;
-      this.isPanning = true;
+      this._animate = false;
+      this._panMenuOrigin = "right";
+      this._panMenuOffset = -300;
+      this._isPanning = true;
       $("header.d-header").removeClass("scroll-down scroll-up");
       this.eventDispatched("toggleUserMenu", "header");
     } else {
-      this.isPanning = false;
+      this._isPanning = false;
     }
   },
 
   panEnd(e) {
-    if (!this.isPanning) {
+    if (!this._isPanning) {
       return;
     }
-    this.isPanning = false;
+    this._isPanning = false;
     $(".menu-panel").each((idx, panel) => {
       const $panel = $(panel);
       let offset = $panel.css("right");
-      if (this.panMenuOrigin === "left") {
+      if (this._panMenuOrigin === "left") {
         offset = $panel.css("left");
       }
       offset = Math.abs(parseInt(offset, 10));
@@ -143,19 +143,19 @@ const SiteHeaderComponent = MountWidget.extend(Docking, PanEvents, {
   },
 
   panMove(e) {
-    if (!this.isPanning) {
+    if (!this._isPanning) {
       return;
     }
     const $menuPanels = $(".menu-panel");
     $menuPanels.each((idx, panel) => {
       const $panel = $(panel);
       const $headerCloak = $(".header-cloak");
-      if (this.panMenuOrigin === "right") {
-        const pxClosed = Math.min(0, -e.deltaX + this.panMenuOffset);
+      if (this._panMenuOrigin === "right") {
+        const pxClosed = Math.min(0, -e.deltaX + this._panMenuOffset);
         $panel.css("right", pxClosed);
         $headerCloak.css("opacity", Math.min(0.5, (300 + pxClosed) / 600));
       } else {
-        const pxClosed = Math.min(0, e.deltaX + this.panMenuOffset);
+        const pxClosed = Math.min(0, e.deltaX + this._panMenuOffset);
         $panel.css("left", pxClosed);
         $headerCloak.css("opacity", Math.min(0.5, (300 + pxClosed) / 600));
       }
@@ -256,7 +256,7 @@ const SiteHeaderComponent = MountWidget.extend(Docking, PanEvents, {
   afterRender() {
     const $menuPanels = $(".menu-panel");
     if ($menuPanels.length === 0) {
-      this.animate = true;
+      this._animate = true;
       return;
     }
 
@@ -274,21 +274,21 @@ const SiteHeaderComponent = MountWidget.extend(Docking, PanEvents, {
       if (windowWidth - width < 50) {
         width = windowWidth - 50;
       }
-      if (this.panMenuOffset) {
+      if (this._panMenuOffset) {
         this.set("panMenuOffset", -width);
       }
 
       $panel.removeClass("drop-down slide-in").addClass(viewMode);
-      if (this.animate || this.panMenuOffset !== 0) {
+      if (this._animate || this._panMenuOffset !== 0) {
         $headerCloak.css("opacity", 0);
         if (
           this.site.mobileView &&
           $panel.parent(".hamburger-panel").length > 0
         ) {
-          this.panMenuOrigin = "left";
+          this._panMenuOrigin = "left";
           $panel.css("left", -windowWidth);
         } else {
-          this.panMenuOrigin = "right";
+          this._panMenuOrigin = "right";
           $panel.css("right", -windowWidth);
         }
       }
@@ -354,7 +354,7 @@ const SiteHeaderComponent = MountWidget.extend(Docking, PanEvents, {
       }
 
       $panel.width(width);
-      if (this.animate) {
+      if (this._animate) {
         $panel.addClass("animate");
         $headerCloak.addClass("animate");
         Ember.run.later(() => {
@@ -364,7 +364,7 @@ const SiteHeaderComponent = MountWidget.extend(Docking, PanEvents, {
       }
       $panel.css({ right: "", left: "" });
       $headerCloak.css("opacity", 0.5);
-      this.animate = false;
+      this._animate = false;
     });
   }
 });

--- a/app/assets/javascripts/discourse/components/topic-navigation.js.es6
+++ b/app/assets/javascripts/discourse/components/topic-navigation.js.es6
@@ -140,6 +140,7 @@ export default Ember.Component.extend(PanEvents, {
   },
 
   panStart(e) {
+    e.originalEvent.preventDefault();
     const center = e.center;
     const $centeredElement = $(document.elementFromPoint(center.x, center.y));
     if ($centeredElement.parents(".timeline-scrollarea-wrapper").length) {
@@ -153,6 +154,7 @@ export default Ember.Component.extend(PanEvents, {
     if (!this.get("isPanning")) {
       return;
     }
+    e.originalEvent.preventDefault();
     this.set("isPanning", false);
     if (this._shouldPanClose(e)) {
       this._panOpenClose(e.deltaY, 40, "close");
@@ -165,6 +167,7 @@ export default Ember.Component.extend(PanEvents, {
     if (!this.get("isPanning")) {
       return;
     }
+    e.originalEvent.preventDefault();
     $(".timeline-container").css("bottom", Math.min(0, -e.deltaY));
   },
 

--- a/app/assets/javascripts/discourse/components/topic-navigation.js.es6
+++ b/app/assets/javascripts/discourse/components/topic-navigation.js.es6
@@ -1,6 +1,10 @@
 import { observes } from "ember-addons/ember-computed-decorators";
 import showModal from "discourse/lib/show-modal";
-import PanEvents from "discourse/mixins/pan-events";
+import PanEvents, {
+  SWIPE_VELOCITY,
+  SWIPE_DISTANCE_THRESHOLD,
+  SWIPE_VELOCITY_THRESHOLD
+} from "discourse/mixins/pan-events";
 
 export default Ember.Component.extend(PanEvents, {
   composerOpen: null,
@@ -117,10 +121,11 @@ export default Ember.Component.extend(PanEvents, {
     }
   },
 
-  _panOpenClose(offset, velocity, direction) {
+  _handlePanDone(offset, event) {
     const $timelineContainer = $(".timeline-container");
-    const maxOffset = parseInt($timelineContainer.css("height"));
-    direction === "close" ? (offset += velocity) : (offset -= velocity);
+    const maxOffset = parseInt($timelineContainer.css("height"), 10);
+
+    this._shouldPanClose(event) ? (offset += SWIPE_VELOCITY) : (offset -= SWIPE_VELOCITY);
 
     $timelineContainer.css("bottom", -offset);
     if (offset > maxOffset) {
@@ -129,14 +134,14 @@ export default Ember.Component.extend(PanEvents, {
       $timelineContainer.css("bottom", "");
     } else {
       Ember.run.later(
-        () => this._panOpenClose(offset, velocity, direction),
+        () => this._handlePanDone(offset, event),
         20
       );
     }
   },
 
   _shouldPanClose(e) {
-    return (e.deltaY > 200 && e.velocityY > -0.10) || e.velocityY > 0.10;
+    return (e.deltaY > SWIPE_DISTANCE_THRESHOLD && e.velocityY > -SWIPE_VELOCITY_THRESHOLD) || e.velocityY > SWIPE_VELOCITY_THRESHOLD;
   },
 
   panStart(e) {
@@ -144,27 +149,23 @@ export default Ember.Component.extend(PanEvents, {
     const center = e.center;
     const $centeredElement = $(document.elementFromPoint(center.x, center.y));
     if ($centeredElement.parents(".timeline-scrollarea-wrapper").length) {
-      this.set("isPanning", false);
+      this.isPanning = false;
     } else if (e.direction === "up" || e.direction === "down") {
-      this.set("isPanning", true);
+      this.isPanning = true;
     }
   },
 
   panEnd(e) {
-    if (!this.get("isPanning")) {
+    if (!this.isPanning) {
       return;
     }
     e.originalEvent.preventDefault();
-    this.set("isPanning", false);
-    if (this._shouldPanClose(e)) {
-      this._panOpenClose(e.deltaY, 40, "close");
-    } else {
-      this._panOpenClose(e.deltaY, 40, "open");
-    }
+    this.isPanning = false;
+    this._handlePanDone(e.deltaY, e);
   },
 
   panMove(e) {
-    if (!this.get("isPanning")) {
+    if (!this.isPanning) {
       return;
     }
     e.originalEvent.preventDefault();

--- a/app/assets/javascripts/discourse/components/topic-navigation.js.es6
+++ b/app/assets/javascripts/discourse/components/topic-navigation.js.es6
@@ -136,7 +136,7 @@ export default Ember.Component.extend(PanEvents, {
   },
 
   _shouldPanClose(e) {
-    return (e.deltaY > 200 && e.velocityY > -0.15) || e.velocityY > 0.15;
+    return (e.deltaY > 200 && e.velocityY > -0.10) || e.velocityY > 0.10;
   },
 
   panStart(e) {

--- a/app/assets/javascripts/discourse/mixins/pan-events.js.es6
+++ b/app/assets/javascripts/discourse/mixins/pan-events.js.es6
@@ -6,7 +6,6 @@ export default Ember.Mixin.create({
   //velocity is pixels per ms
 
   _panState: null,
-  panDisableVerticalScroll: false,
 
   didInsertElement() {
     this._super();

--- a/app/assets/javascripts/discourse/mixins/pan-events.js.es6
+++ b/app/assets/javascripts/discourse/mixins/pan-events.js.es6
@@ -2,6 +2,9 @@
    Pan events is a mixin that allows components to detect and respond to swipe gestures
    It fires callbacks for panStart, panEnd, panMove with the pan state, and the original event.
  **/
+export const SWIPE_VELOCITY = 40;
+export const SWIPE_DISTANCE_THRESHOLD = 200;
+export const SWIPE_VELOCITY_THRESHOLD = 0.1;
 export default Ember.Mixin.create({
   //velocity is pixels per ms
 

--- a/app/assets/javascripts/discourse/mixins/pan-events.js.es6
+++ b/app/assets/javascripts/discourse/mixins/pan-events.js.es6
@@ -3,7 +3,7 @@
    It fires callbacks for panStart, panEnd, panMove with the pan state, and the original event.
  **/
 export const SWIPE_VELOCITY = 40;
-export const SWIPE_DISTANCE_THRESHOLD = 200;
+export const SWIPE_DISTANCE_THRESHOLD = 50;
 export const SWIPE_VELOCITY_THRESHOLD = 0.1;
 export default Ember.Mixin.create({
   //velocity is pixels per ms

--- a/app/assets/javascripts/discourse/widgets/hamburger-menu.js.es6
+++ b/app/assets/javascripts/discourse/widgets/hamburger-menu.js.es6
@@ -323,7 +323,24 @@ export default createWidget("hamburger-menu", {
     });
   },
 
-  clickOutside() {
-    this.sendWidgetAction("toggleHamburger");
+  clickOutside(e) {
+    const $centeredElement = $(document.elementFromPoint(e.clientX, e.clientY));
+    if (
+      $centeredElement.parents(".panel").length &&
+      !$centeredElement.hasClass("header-cloak")
+    ) {
+      this.sendWidgetAction("toggleHamburger");
+    } else {
+      const $window = $(window);
+      const windowWidth = parseInt($window.width());
+      const $panel = $(".menu-panel");
+      $panel.addClass("animate");
+      const panelOffsetDirection = this.site.mobileView ? "left" : "right";
+      $panel.css(panelOffsetDirection, -windowWidth);
+      const $headerCloak = $(".header-cloak");
+      $headerCloak.addClass("animate");
+      $headerCloak.css("opacity", 0);
+      Ember.run.later(() => this.sendWidgetAction("toggleHamburger"), 200);
+    }
   }
 });

--- a/app/assets/javascripts/discourse/widgets/hamburger-menu.js.es6
+++ b/app/assets/javascripts/discourse/widgets/hamburger-menu.js.es6
@@ -332,7 +332,7 @@ export default createWidget("hamburger-menu", {
       this.sendWidgetAction("toggleHamburger");
     } else {
       const $window = $(window);
-      const windowWidth = parseInt($window.width());
+      const windowWidth = parseInt($window.width(), 10);
       const $panel = $(".menu-panel");
       $panel.addClass("animate");
       const panelOffsetDirection = this.site.mobileView ? "left" : "right";

--- a/app/assets/javascripts/discourse/widgets/hamburger-menu.js.es6
+++ b/app/assets/javascripts/discourse/widgets/hamburger-menu.js.es6
@@ -323,11 +323,11 @@ export default createWidget("hamburger-menu", {
     });
   },
 
-  clickOutside(e) {
+  clickOutsideMobile(e) {
     const $centeredElement = $(document.elementFromPoint(e.clientX, e.clientY));
     if (
       $centeredElement.parents(".panel").length &&
-      !$centeredElement.hasClass("header-cloak")
+        !$centeredElement.hasClass("header-cloak")
     ) {
       this.sendWidgetAction("toggleHamburger");
     } else {
@@ -341,6 +341,14 @@ export default createWidget("hamburger-menu", {
       $headerCloak.addClass("animate");
       $headerCloak.css("opacity", 0);
       Ember.run.later(() => this.sendWidgetAction("toggleHamburger"), 200);
+    }
+  },
+
+  clickOutside(e) {
+    if (this.site.mobileView) {
+      this.clickOutsideMobile(e);
+    } else {
+      this.sendWidgetAction("toggleHamburger");
     }
   }
 });

--- a/app/assets/javascripts/discourse/widgets/header.js.es6
+++ b/app/assets/javascripts/discourse/widgets/header.js.es6
@@ -360,6 +360,7 @@ export default createWidget("header", {
     this.state.userVisible = false;
     this.state.hamburgerVisible = false;
     this.state.searchVisible = false;
+    this.toggleBodyScrolling(false);
   },
 
   linkClickedEvent(attrs) {
@@ -509,7 +510,6 @@ export default createWidget("header", {
     if (state.searchVisible || state.hamburgerVisible || state.userVisible) {
       this.closeAll();
     }
-    this.toggleBodyScrolling(false);
   },
 
   headerKeyboardTrigger(msg) {

--- a/app/assets/javascripts/discourse/widgets/header.js.es6
+++ b/app/assets/javascripts/discourse/widgets/header.js.es6
@@ -253,6 +253,15 @@ createWidget("header-buttons", {
   }
 });
 
+createWidget("header-cloak", {
+  tagName: "div.header-cloak",
+  html() {
+    return "";
+  },
+  click() {},
+  scheduleRerender() {}
+});
+
 const forceContextEnabled = ["category", "user", "private_messages"];
 
 let additionalPanels = [];
@@ -314,6 +323,9 @@ export default createWidget("header", {
         panels.push(this.attach("hamburger-menu"));
       } else if (state.userVisible) {
         panels.push(this.attach("user-menu"));
+      }
+      if (this.site.mobileView) {
+        panels.push(this.attach("header-cloak"));
       }
 
       additionalPanels.map(panel => {

--- a/app/assets/javascripts/discourse/widgets/header.js.es6
+++ b/app/assets/javascripts/discourse/widgets/header.js.es6
@@ -446,7 +446,12 @@ export default createWidget("header", {
   },
 
   preventDefault(e) {
-    if (!$(e.target).parents('.menu-panel').length) {
+    // prevent all scrollin on menu panels, except on overflow
+    let height = window.innerHeight
+        ? window.innerHeight
+        : $(window).height();
+    if (!$(e.target).parents('.menu-panel').length ||
+        $('.menu-panel .panel-body-contents').height() <= height) {
       e.preventDefault();
     }
   },

--- a/app/assets/javascripts/discourse/widgets/header.js.es6
+++ b/app/assets/javascripts/discourse/widgets/header.js.es6
@@ -428,10 +428,27 @@ export default createWidget("header", {
     }
 
     this.state.userVisible = !this.state.userVisible;
+    this.toggleBodyScrolling(this.state.userVisible);
   },
 
   toggleHamburger() {
     this.state.hamburgerVisible = !this.state.hamburgerVisible;
+    this.toggleBodyScrolling(this.state.hamburgerVisible);
+  },
+
+  toggleBodyScrolling(bool) {
+    if (!this.site.mobileView) return;
+    if (bool) {
+      document.body.addEventListener('touchmove', this.preventDefault, { passive: false });
+    } else {
+      document.body.removeEventListener('touchmove', this.preventDefault, { passive: false });
+    }
+  },
+
+  preventDefault(e) {
+    if (!$(e.target).parents('.menu-panel').length) {
+      e.preventDefault();
+    }
   },
 
   togglePageSearch() {
@@ -487,6 +504,7 @@ export default createWidget("header", {
     if (state.searchVisible || state.hamburgerVisible || state.userVisible) {
       this.closeAll();
     }
+    this.toggleBodyScrolling(false);
   },
 
   headerKeyboardTrigger(msg) {

--- a/app/assets/javascripts/discourse/widgets/header.js.es6
+++ b/app/assets/javascripts/discourse/widgets/header.js.es6
@@ -439,19 +439,19 @@ export default createWidget("header", {
   toggleBodyScrolling(bool) {
     if (!this.site.mobileView) return;
     if (bool) {
-      document.body.addEventListener('touchmove', this.preventDefault, { passive: false });
+      document.body.addEventListener("touchmove", this.preventDefault, { passive: false });
     } else {
-      document.body.removeEventListener('touchmove', this.preventDefault, { passive: false });
+      document.body.removeEventListener("touchmove", this.preventDefault, { passive: false });
     }
   },
 
   preventDefault(e) {
     // prevent all scrollin on menu panels, except on overflow
-    let height = window.innerHeight
+    const height = window.innerHeight
         ? window.innerHeight
         : $(window).height();
-    if (!$(e.target).parents('.menu-panel').length ||
-        $('.menu-panel .panel-body-contents').height() <= height) {
+    if (!$(e.target).parents(".menu-panel").length ||
+        $(".menu-panel .panel-body-contents").height() <= height) {
       e.preventDefault();
     }
   },

--- a/app/assets/javascripts/discourse/widgets/user-menu.js.es6
+++ b/app/assets/javascripts/discourse/widgets/user-menu.js.es6
@@ -194,7 +194,23 @@ export default createWidget("user-menu", {
     });
   },
 
-  clickOutside() {
-    this.sendWidgetAction("toggleUserMenu");
+  clickOutside(e) {
+    const $centeredElement = $(document.elementFromPoint(e.clientX, e.clientY));
+    if (
+      $centeredElement.parents(".panel").length &&
+      !$centeredElement.hasClass("header-cloak")
+    ) {
+      this.sendWidgetAction("toggleUserMenu");
+    } else {
+      const $window = $(window);
+      const windowWidth = parseInt($window.width());
+      const $panel = $(".menu-panel");
+      $panel.addClass("animate");
+      $panel.css("right", -windowWidth);
+      const $headerCloak = $(".header-cloak");
+      $headerCloak.addClass("animate");
+      $headerCloak.css("opacity", 0);
+      Ember.run.later(() => this.sendWidgetAction("toggleUserMenu"), 200);
+    }
   }
 });

--- a/app/assets/javascripts/discourse/widgets/user-menu.js.es6
+++ b/app/assets/javascripts/discourse/widgets/user-menu.js.es6
@@ -194,11 +194,11 @@ export default createWidget("user-menu", {
     });
   },
 
-  clickOutside(e) {
+  clickOutsideMobile(e) {
     const $centeredElement = $(document.elementFromPoint(e.clientX, e.clientY));
     if (
       $centeredElement.parents(".panel").length &&
-      !$centeredElement.hasClass("header-cloak")
+        !$centeredElement.hasClass("header-cloak")
     ) {
       this.sendWidgetAction("toggleUserMenu");
     } else {
@@ -211,6 +211,14 @@ export default createWidget("user-menu", {
       $headerCloak.addClass("animate");
       $headerCloak.css("opacity", 0);
       Ember.run.later(() => this.sendWidgetAction("toggleUserMenu"), 200);
+    }
+  },
+
+  clickOutside(e) {
+    if (this.site.mobileView) {
+      this.clickOutsideMobile(e);
+    } else {
+      this.sendWidgetAction("toggleUserMenu");
     }
   }
 });

--- a/app/assets/javascripts/discourse/widgets/user-menu.js.es6
+++ b/app/assets/javascripts/discourse/widgets/user-menu.js.es6
@@ -203,7 +203,7 @@ export default createWidget("user-menu", {
       this.sendWidgetAction("toggleUserMenu");
     } else {
       const $window = $(window);
-      const windowWidth = parseInt($window.width());
+      const windowWidth = parseInt($window.width(), 10);
       const $panel = $(".menu-panel");
       $panel.addClass("animate");
       $panel.css("right", -windowWidth);

--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -2,6 +2,9 @@
   position: fixed;
   right: 0;
   box-shadow: shadow("header");
+  &.animate {
+    transition: right 0.2s ease-out, left 0.2s ease-out;
+  }
 
   .panel-body {
     position: absolute;
@@ -9,6 +12,9 @@
     bottom: 37px;
     width: 97%;
   }
+}
+.header-cloak {
+  display: none;
 }
 
 .menu-panel.drop-down {
@@ -42,6 +48,7 @@
   }
 
   .panel-body {
+    touch-action: pan-y pinch-zoom;
     overflow-y: auto;
     overflow-x: hidden;
   }

--- a/app/assets/stylesheets/mobile.scss
+++ b/app/assets/stylesheets/mobile.scss
@@ -29,6 +29,7 @@
 @import "mobile/admin_report";
 @import "mobile/admin_report_table";
 @import "mobile/admin_report_counters";
+@import "mobile/menu-panel";
 
 // Import all component-specific files
 @import "mobile/components/*";

--- a/app/assets/stylesheets/mobile/menu-panel.scss
+++ b/app/assets/stylesheets/mobile/menu-panel.scss
@@ -1,0 +1,21 @@
+.hamburger-panel .menu-panel.slide-in {
+  left: 0;
+}
+.header-cloak {
+  height: 100vh;
+  width: 100vw;
+  position: fixed;
+  background-color: black;
+  opacity: 0.5;
+  top: 0;
+  left: 0;
+  display: none;
+  touch-action: pan-y pinch-zoom;
+  &.animate {
+    transition: opacity 0.2s ease-out;
+  }
+}
+
+body {
+  touch-action: pan-y pinch-zoom;
+}

--- a/app/assets/stylesheets/mobile/menu-panel.scss
+++ b/app/assets/stylesheets/mobile/menu-panel.scss
@@ -16,6 +16,3 @@
   }
 }
 
-body {
-  touch-action: pan-y pinch-zoom;
-}


### PR DESCRIPTION
Add full height menu on mobile, animated slide in menus, and swipe-to-dismiss menu gestures. Android additionally gets swipe-to-slide-in gestures for menus. (iOS does not respond to this as it's reserved for forward/back motions. Dismissal swipes still work from the center of the screen).

Adds swipe support for iOS.