### PR TITLE
Fix link to GitHub oauth registration page

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1381,8 +1381,8 @@ en:
     facebook_app_secret: "App secret for Facebook authentication, registered at <a href='https://developers.facebook.com/apps/' target='_blank'>https://developers.facebook.com/apps</a>"
 
     enable_github_logins: "Enable Github authentication, requires github_client_id and github_client_secret. See <a href='https://meta.discourse.org/t/13745' target='_blank'>Configuring GitHub login for Discourse</a>."
-    github_client_id: "Client id for Github authentication, registered at <a href='https://github.com/settings/applications/' target='_blank'>https://github.com/settings/applications</a>"
-    github_client_secret: "Client secret for Github authentication, registered at <a href='https://github.com/settings/applications/' target='_blank'>https://github.com/settings/applications</a>"
+    github_client_id: "Client id for Github authentication, registered at <a href='https://github.com/settings/developers/' target='_blank'>https://github.com/settings/developers</a>"
+    github_client_secret: "Client secret for Github authentication, registered at <a href='https://github.com/settings/applications/' target='_blank'>https://github.com/settings/developers</a>"
 
     readonly_mode_during_backup: "Enable read only mode while taking a backup"
     enable_backups: "Allow administrators to create backups of the forum"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1382,7 +1382,7 @@ en:
 
     enable_github_logins: "Enable Github authentication, requires github_client_id and github_client_secret. See <a href='https://meta.discourse.org/t/13745' target='_blank'>Configuring GitHub login for Discourse</a>."
     github_client_id: "Client id for Github authentication, registered at <a href='https://github.com/settings/developers/' target='_blank'>https://github.com/settings/developers</a>"
-    github_client_secret: "Client secret for Github authentication, registered at <a href='https://github.com/settings/applications/' target='_blank'>https://github.com/settings/developers</a>"
+    github_client_secret: "Client secret for Github authentication, registered at <a href='https://github.com/settings/developers/' target='_blank'>https://github.com/settings/developers</a>"
 
     readonly_mode_during_backup: "Enable read only mode while taking a backup"
     enable_backups: "Allow administrators to create backups of the forum"


### PR DESCRIPTION
The old link lead only to the list of authorised apps for a particular user.