### PR TITLE
UX: Make the edits indicator a real link for accessibility

### DIFF
--- a/app/assets/javascripts/discourse/widgets/post-edits-indicator.js.es6
+++ b/app/assets/javascripts/discourse/widgets/post-edits-indicator.js.es6
@@ -62,13 +62,14 @@ export default createWidget("post-edits-indicator", {
       "a",
       {
         className,
-        attributes: { title }
+        attributes: { title, href: "#" }
       },
       contents
     );
   },
 
-  click() {
+  click(e) {
+    e.preventDefault();
     if (this.attrs.wiki && this.attrs.version === 1) {
       this.sendWidgetAction("editPost");
     } else if (this.attrs.canViewEditHistory) {


### PR DESCRIPTION
This link didn't have an `href` attribute, so it wasn't in the tab
order. This commit fixes that, while adding a call to `preventDefault`
in the event handler to avoid any regression in event handling.