### PR TITLE
FIX: Do not display broken image on crawler/print view

### DIFF
--- a/app/views/layouts/crawler.html.erb
+++ b/app/views/layouts/crawler.html.erb
@@ -22,7 +22,13 @@
   <body class="crawler">
     <%= theme_lookup("header") %>
     <header>
-      <a href="<%= path "/" %>"><img src="<%=SiteSetting.logo_url%>" alt="<%=SiteSetting.title%>" id="site-logo" style="max-width: 150px;"></a>
+      <a href="<%= path "/" %>">
+        <%- if SiteSetting.logo_url.present? %>
+          <img src="<%=SiteSetting.logo_url%>" alt="<%=SiteSetting.title%>" id="site-logo" style="max-width: 150px;">
+        <%- else %>
+          <h1><%=SiteSetting.title%></h1>
+        <% end %>
+      </a>
     </header>
     <div id="main-outlet" class="wrap">
       <%= yield %>


### PR DESCRIPTION
Before:
<img width="864" alt="screenshot 2018-11-07 at 13 21 46" src="https://user-images.githubusercontent.com/6270921/48133883-26dd3780-e290-11e8-8545-60bf6aa6348e.png">
After:
<img width="863" alt="screenshot 2018-11-07 at 13 22 46" src="https://user-images.githubusercontent.com/6270921/48133907-3eb4bb80-e290-11e8-9624-4e7270212389.png">
