### PR TITLE
FIX: Use dynamic name resolution for the nginx letter avatar proxy

### DIFF
--- a/config/nginx.sample.conf
+++ b/config/nginx.sample.conf
@@ -214,7 +214,7 @@ server {
       break;
     }
 
-    location /letter_avatar_proxy/ {
+    location ~ ^/letter_avatar_proxy/(.*)$ {
       # Don't send any client headers to the avatars service
       proxy_method GET;
       proxy_pass_request_headers off;
@@ -234,7 +234,10 @@ server {
       proxy_cache_valid 404 1m;
       proxy_set_header Connection "";
 
-      proxy_pass https://avatars.discourse.org/;
+      # Note: This requires the nginx runtime resolver to be configured.
+      # The official Docker-based Discourse configuration does this.
+      set $dynamic_upstream https://avatars.discourse.org;
+      proxy_pass $dynamic_upstream/$1;
       break;
     }
 


### PR DESCRIPTION
This is desirable for two reasons:

1. As reported in a [bug
topic](https://meta.discourse.org/t/restarting-container-when-internet-is-down-causes-discourse-to-fail/42615/4),
if nginx resolves Internet hostnames on startup, then the container
won't run if the host is disconnected from the Internet at startup.

2. If the IP address of the avatars.discourse.org hostname ever changes,
then nginx will end p using an old IP address until the administrator
restarts the container, unless we use dynamic resolution.

This commit depends on [a corresponding PR in the discourse_docker
repository](https://github.com/discourse/discourse_docker/pull/413).