### PR TITLE
remove JS no longer needed on 404 page

### DIFF
--- a/app/views/exceptions/not_found.html.erb
+++ b/app/views/exceptions/not_found.html.erb
@@ -37,12 +37,4 @@
       </p>
     </div>
   </div>
-
-  <script language="Javascript">
-    window.onpopstate = function(event) {
-      if (event.state && !window.hasOwnProperty("Discourse")) {  //check if Discourse object exists if not take care of back navigation
-        window.location = document.location;
-      }
-    };
-  </script>
 <%- end %>


### PR DESCRIPTION
I have tried this on a few pages:

- `/404`
- `/random-nonexistent-path`
- `/t/not-found/12312313123`
- Link to the URLs above in a post and click on them

Removing the listener does not seem to break go-back or other navigation functionalities.

The original commit from 2014: https://github.com/discourse/discourse/commit/a967d4dfba292ee15f5a490e98495e35f27b1ffb. /cc @eviltrout do you happen to remember what else the listener is used for?