### PR TITLE
PERF: Reduce number of database queries for `DbHelper.remap`

### DIFF
--- a/lib/db_helper.rb
+++ b/lib/db_helper.rb
@@ -9,14 +9,30 @@ class DbHelper
   ORDER BY table_name, column_name"
 
   def self.remap(from, to, anchor_left = false, anchor_right = false)
-    connection = ActiveRecord::Base.connection.raw_connection
-    remappable_columns = connection.async_exec(REMAP_SQL).to_a
-    args = [from, to, "#{anchor_left ? '' : "%"}#{from}#{anchor_right ? '' : "%"}"]
+    results = DB.query(REMAP_SQL).to_a
+    like = "#{anchor_left ? '' : "%"}#{from}#{anchor_right ? '' : "%"}"
 
-    remappable_columns.each do |rc|
-      table_name = rc["table_name"]
-      column_name = rc["column_name"]
-      connection.async_exec("UPDATE #{table_name} SET #{column_name} = REPLACE(#{column_name}, $1, $2) WHERE #{column_name} LIKE $3", args) rescue nil
+    remappable_columns = {}
+
+    results.each do |result|
+      remappable_columns[result.table_name] ||= []
+      remappable_columns[result.table_name] << result.column_name
+    end
+
+    remappable_columns.each do |table_name, column_names|
+      set_clause = column_names.map do |column_name|
+        "#{column_name} = REPLACE(#{column_name}, :from, :to)"
+      end.join(", ")
+
+      where_clause = column_names.map do |column_name|
+        "#{column_name} LIKE :like"
+      end.join(" OR ")
+
+      DB.exec(<<~SQL, from: from, to: to, like: like)
+        UPDATE #{table_name}
+        SET #{set_clause}
+        WHERE #{where_clause}
+      SQL
     end
 
     SiteSetting.refresh!

--- a/spec/lib/db_helper_spec.rb
+++ b/spec/lib/db_helper_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+require_dependency 'db_helper'
+
+RSpec.describe DbHelper do
+  describe '.remap' do
+    it 'should remap columns properly' do
+      post = Fabricate(:post, cooked: "this is a specialcode that I included")
+      post_attributes = post.reload.attributes
+      post2 = Fabricate(:post, image_url: "/testing/specialcode")
+      post2_attributes = post2.reload.attributes
+
+      badge = Fabricate(:badge, query: "specialcode")
+      badge_attributes = badge.reload.attributes
+
+      DbHelper.remap("specialcode", "codespecial")
+
+      post.reload
+
+      expect(post.cooked).to include("codespecial")
+
+      post2.reload
+
+      expect(post2.image_url).to eq("/testing/codespecial")
+
+      expect(post2_attributes.except("image_url"))
+        .to eq(post2.attributes.except("image_url"))
+
+      badge.reload
+
+      expect(badge.query).to eq("codespecial")
+
+      expect(badge_attributes.except("query"))
+        .to eq(badge.attributes.except("query"))
+    end
+  end
+end


### PR DESCRIPTION
* Cuts number of queries from 273 to 89
* Add some specs
* For a table with 500 posts, benchmarks locally shows a runtime
  reduction from 0.046929135 to 0.032694705.