### PR TITLE
Bump logster version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -184,7 +184,7 @@ GEM
     logstash-event (1.2.02)
     logstash-logger (0.26.1)
       logstash-event (~> 1.2)
-    logster (1.2.11)
+    logster (1.3.0)
     loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)


### PR DESCRIPTION
[Logster](https://rubygems.org/gems/logster/) has been updated to version 1.3.0 that includes Ember upgrade to version 3.5.

Tested locally and everything seems to work perfectly fine 🎉 