### PR TITLE
FEATURE: Add button to delete unused tags

### DIFF
--- a/app/assets/javascripts/discourse/components/tags-admin-dropdown.js.es6
+++ b/app/assets/javascripts/discourse/components/tags-admin-dropdown.js.es6
@@ -22,6 +22,12 @@ export default DropdownSelectBoxComponent.extend({
         name: I18n.t("tagging.upload"),
         description: I18n.t("tagging.upload_description"),
         icon: "upload"
+      },
+      {
+        id: "deleteUnusedTags",
+        name: I18n.t("tagging.delete_unused"),
+        description: I18n.t("tagging.delete_unused_description"),
+        icon: "trash"
       }
     ];
 
@@ -30,7 +36,8 @@ export default DropdownSelectBoxComponent.extend({
 
   actionNames: {
     manageGroups: "showTagGroups",
-    uploadTags: "showUploader"
+    uploadTags: "showUploader",
+    deleteUnusedTags: "deleteUnused"
   },
 
   mutateValue(id) {

--- a/app/assets/javascripts/discourse/controllers/tags-index.js.es6
+++ b/app/assets/javascripts/discourse/controllers/tags-index.js.es6
@@ -1,5 +1,7 @@
 import computed from "ember-addons/ember-computed-decorators";
 import showModal from "discourse/lib/show-modal";
+import { ajax } from "discourse/lib/ajax";
+import { popupAjaxError } from "discourse/lib/ajax-error";
 
 export default Ember.Controller.extend({
   sortProperties: ["totalCount:desc", "id"],
@@ -38,6 +40,29 @@ export default Ember.Controller.extend({
 
     showUploader() {
       showModal("tag-upload");
+    },
+
+    deleteUnused() {
+      ajax("/tags/unused", { type: "GET" })
+        .then(result => {
+          bootbox.confirm(
+            I18n.t("tagging.delete_unused_confirmation", {
+              count: result.count
+            }),
+            I18n.t("tagging.cancel_delete_unused"),
+            I18n.t("tagging.delete_unused"),
+            proceed => {
+              if (proceed) {
+                ajax("/tags/unused", { type: "DELETE" })
+                  .then(() => {
+                    this.send("refresh");
+                  })
+                  .catch(popupAjaxError);
+              }
+            }
+          );
+        })
+        .catch(popupAjaxError);
     }
   }
 });

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -146,6 +146,17 @@ class TagsController < ::ApplicationController
     end
   end
 
+  def count_unused
+    guardian.ensure_can_admin_tags!
+    render json: { count: Tag.where(topic_count: 0, pm_topic_count: 0).count }
+  end
+
+  def destroy_unused
+    guardian.ensure_can_admin_tags!
+    Tag.where(topic_count: 0, pm_topic_count: 0).destroy_all
+    render json: success_json
+  end
+
   def destroy
     guardian.ensure_can_admin_tags!
     tag_name = params[:tag_id]

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2707,6 +2707,10 @@ en:
       upload_description: "Upload a text file to create tags in bulk"
       upload_instructions: "One per line, optionally with a tag group in the format 'tag_name,tag_group'."
       upload_successful: "Tags uploaded successfully"
+      delete_unused_confirmation: "Are you sure you want to delete %{count} unused tags?"
+      delete_unused: "Delete Unused Tags"
+      delete_unused_description: "Delete all tags which are not attached to any topics or personal messages"
+      cancel_delete_unused: "Cancel"
       filters:
         without_category: "%{filter} %{tag} topics"
         with_category: "%{filter} %{tag} topics in %{category}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -776,6 +776,8 @@ Discourse::Application.routes.draw do
     get '/check' => 'tags#check_hashtag'
     get '/personal_messages/:username' => 'tags#personal_messages'
     post '/upload' => 'tags#upload'
+    get '/unused' => 'tags#count_unused'
+    delete '/unused' => 'tags#destroy_unused'
     constraints(tag_id: /[^\/]+?/, format: /json|rss/) do
       get '/:tag_id.rss' => 'tags#tag_feed'
       get '/:tag_id' => 'tags#show', as: 'tag_show'

--- a/spec/requests/tags_controller_spec.rb
+++ b/spec/requests/tags_controller_spec.rb
@@ -389,6 +389,45 @@ describe TagsController do
     end
   end
 
+  describe '#unused' do
+    it "fails if you can't manage tags" do
+      sign_in(Fabricate(:user))
+      get "/tags/unused.json"
+      expect(response.status).to eq(403)
+      delete "/tags/unused.json"
+      expect(response.status).to eq(403)
+    end
+
+    context 'logged in' do
+      before do
+        sign_in(Fabricate(:admin))
+      end
+
+      context 'with some tags' do
+        let!(:tags) { [
+          Fabricate(:tag, name: "used_publically", topic_count: 2, pm_topic_count: 0),
+          Fabricate(:tag, name: "used_privately", topic_count: 0, pm_topic_count: 3),
+          Fabricate(:tag, name: "used_everywhere", topic_count: 0, pm_topic_count: 3),
+          Fabricate(:tag, name: "unused1", topic_count: 0, pm_topic_count: 0),
+          Fabricate(:tag, name: "unused2", topic_count: 0, pm_topic_count: 0)
+        ]}
+
+        it 'returns the correct number of unused tags' do
+          get "/tags/unused.json"
+          expect(response.status).to eq(200)
+          json = ::JSON.parse(response.body)
+          expect(json["count"]).to eq(2)
+        end
+
+        it 'deletes the correct tags' do
+          expect { delete "/tags/unused.json" }.to change { Tag.count }.by(-2)
+          expect(Tag.pluck(:name)).to contain_exactly("used_publically", "used_privately", "used_everywhere")
+        end
+      end
+
+    end
+  end
+
   context '#upload_csv' do
     it 'requires you to be logged in' do
       post "/tags/upload.json"


### PR DESCRIPTION
This is particularly useful if you have uploaded a CSV file, and wish to bulk-delete all of the tags that you uploaded.

Adds an option to the tag administration hamburger:
<img width="313" alt="screenshot 2018-11-09 at 16 58 41" src="https://user-images.githubusercontent.com/6270921/48276791-c50fff80-e440-11e8-996d-7e40d5b415dd.png">

Clicking the button presents a confirmation modal, including the number of tags which will be deleted:
<img width="623" alt="screenshot 2018-11-09 at 16 55 22" src="https://user-images.githubusercontent.com/6270921/48276719-9bef6f00-e440-11e8-876c-98f815996ef6.png">
