### PR TITLE
remove Logster from CSP whitelist

### DIFF
--- a/lib/content_security_policy.rb
+++ b/lib/content_security_policy.rb
@@ -5,10 +5,6 @@ class ContentSecurityPolicy
   include GlobalPath
 
   class Middleware
-    WHITELISTED_PATHS = %w(
-      /logs
-    )
-
     def initialize(app)
       @app = app
     end
@@ -18,7 +14,6 @@ class ContentSecurityPolicy
       _, headers, _ = response = @app.call(env)
 
       return response unless html_response?(headers) && ContentSecurityPolicy.enabled?
-      return response if whitelisted?(request.path)
 
       policy = ContentSecurityPolicy.new.build
       headers['Content-Security-Policy'] = policy if SiteSetting.content_security_policy
@@ -31,14 +26,6 @@ class ContentSecurityPolicy
 
     def html_response?(headers)
       headers['Content-Type'] && headers['Content-Type'] =~ /html/
-    end
-
-    def whitelisted?(path)
-      if GlobalSetting.relative_url_root
-        path.slice!(/^#{Regexp.quote(GlobalSetting.relative_url_root)}/)
-      end
-
-      WHITELISTED_PATHS.any? { |whitelisted| path.start_with?(whitelisted) }
     end
   end
 

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -260,16 +260,6 @@ RSpec.describe ApplicationController do
       expect(response.headers).to_not include('Content-Security-Policy-Report-Only')
     end
 
-    it 'does not set CSP for /logs' do
-      sign_in(Fabricate(:admin))
-      SiteSetting.content_security_policy = true
-
-      get '/logs'
-
-      expect(response.status).to eq(200)
-      expect(response.headers).to_not include('Content-Security-Policy')
-    end
-
     def parse(csp_string)
       csp_string.split(';').map do |policy|
         directive, *sources = policy.split


### PR DESCRIPTION
Logster 1.3 no longer has inline JS and is now CSP compliant