### PR TITLE
allow CSP reports to be sent when header is set outside of Discourse

### DIFF
--- a/app/controllers/csp_reports_controller.rb
+++ b/app/controllers/csp_reports_controller.rb
@@ -30,6 +30,10 @@ class CspReportsController < ApplicationController
   end
 
   def report_collection_enabled?
-    ContentSecurityPolicy.enabled? && SiteSetting.content_security_policy_collect_reports
+    (
+      ContentSecurityPolicy.enabled? ||
+      SiteSetting.content_security_policy_collect_reports_no_header
+    ) &&
+    SiteSetting.content_security_policy_collect_reports
   end
 end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1286,6 +1286,7 @@ en:
     content_security_policy: EXPERIMENTAL - Turn on Content-Security-Policy
     content_security_policy_report_only: EXPERIMENTAL - Turn on Content-Security-Policy-Report-Only
     content_security_policy_collect_reports: Enable CSP violation report collection at /csp_reports
+    content_security_policy_collect_reports_no_header: Collect CSP violations even if no CSP header is set by Discourse (perhaps it's set by nginx instead)
     content_security_policy_script_src: Additional whitelisted script sources. The current host and CDN are included by default.
     top_menu: "Determine which items appear in the homepage navigation, and in what order. Example latest|new|unread|categories|top|read|posted|bookmarks"
     post_menu: "Determine which items appear on the post menu, and in what order. Example like|edit|flag|delete|share|bookmark|reply"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1190,6 +1190,8 @@ security:
     default: false
   content_security_policy_collect_reports:
     default: true
+  content_security_policy_collect_reports_no_header:
+    default: false
   content_security_policy_script_src:
     type: list
     default: ''

--- a/spec/requests/csp_reports_controller_spec.rb
+++ b/spec/requests/csp_reports_controller_spec.rb
@@ -36,6 +36,11 @@ describe CspReportsController do
       SiteSetting.content_security_policy = false
       SiteSetting.content_security_policy_report_only = false
       SiteSetting.content_security_policy_collect_reports = true
+      SiteSetting.content_security_policy_collect_reports_no_header = true
+      send_report
+      expect(response.status).to eq(200)
+
+      SiteSetting.content_security_policy_collect_reports_no_header = false
       send_report
       expect(response.status).to eq(404)
 


### PR DESCRIPTION
@xrav3nz one for you

[we set our CSP headers in nginx](https://github.com/mozilla/discourse.mozilla.org/blob/4fe534298e2ea9959b06c283f68887adc5599d3c/includes/headers.yml#L2-L14) (allowing us to set different policies for different directives, and ensuring we always fail-safe to a CSP policy even if Discourse isn't setting headers correctly), but currently `/csp_reports` 404s because Discourse doesn't think we have a CSP header set.

I've added another setting to override this behaviour, and force `/csp_reports` to accept reports, even if (from Discourse's perspective) a CSP header isn't being set