### PR TITLE
FEATURE: Log password changes in UserHistory

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -497,6 +497,11 @@ class UsersController < ApplicationController
           Invite.invalidate_for_email(@user.email) # invite link can't be used to log in anymore
           secure_session["password-#{token}"] = nil
           secure_session["second-factor-#{token}"] = nil
+          UserHistory.create!(
+            target_user: @user,
+            acting_user: @user,
+            action: UserHistory.actions[:change_password]
+          )
           logon_after_password_reset
         end
       end

--- a/app/models/user_history.rb
+++ b/app/models/user_history.rb
@@ -82,7 +82,8 @@ class UserHistory < ActiveRecord::Base
       removed_unsuspend_user: 63,
       post_rejected: 64,
       merge_user: 65,
-      entity_export: 66
+      entity_export: 66,
+      change_password: 67
     )
   end
 


### PR DESCRIPTION
Currently none of these "non-staff" UserHistory rows are used in the user interface, and can only be accessed through data-explorer. Nonetheless, I think we should be logging password changes. 

This will also be useful for the discourse-password-expiry plugin I am working on.