### PR TITLE
FIX: reset bump date resets bumped_at to the last regular post in topic

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1390,7 +1390,7 @@ class Topic < ActiveRecord::Base
     post = ordered_posts.where(
       user_deleted: false,
       hidden: false,
-      post_type: Topic.visible_post_types
+      post_type: Post.types[:regular]
     ).last
 
     update!(bumped_at: post.created_at)

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -2315,25 +2315,26 @@ describe Topic do
   end
 
   describe "#reset_bumped_at" do
-    it "ignores hidden and deleted posts when resetting the topic's bump date" do
-      post = create_post(created_at: 10.hours.ago)
-      topic = post.topic
+    it "ignores hidden, deleted, moderator and small action posts when resetting the topic's bump date" do
+      post1 = create_post(created_at: 10.hours.ago)
+      topic = post1.topic
 
       expect { topic.reset_bumped_at }.to_not change { topic.bumped_at }
 
-      post = Fabricate(:post, topic: topic, post_number: 2, created_at: 9.hours.ago)
+      post2 = Fabricate(:post, topic: topic, post_number: 2, created_at: 9.hours.ago)
       Fabricate(:post, topic: topic, post_number: 3, created_at: 8.hours.ago, deleted_at: 1.hour.ago)
       Fabricate(:post, topic: topic, post_number: 4, created_at: 7.hours.ago, hidden: true)
       Fabricate(:post, topic: topic, post_number: 5, created_at: 6.hours.ago, user_deleted: true)
       Fabricate(:post, topic: topic, post_number: 6, created_at: 5.hours.ago, post_type: Post.types[:whisper])
 
-      expect { topic.reset_bumped_at }.to change { topic.bumped_at }.to(post.reload.created_at)
+      expect { topic.reset_bumped_at }.to change { topic.bumped_at }.to(post2.reload.created_at)
 
-      post = Fabricate(:post, topic: topic, post_number: 7, created_at: 4.hours.ago, post_type: Post.types[:moderator_action])
-      expect { topic.reset_bumped_at }.to change { topic.bumped_at }.to(post.reload.created_at)
+      post3 = Fabricate(:post, topic: topic, post_number: 7, created_at: 4.hours.ago, post_type: Post.types[:regular])
+      expect { topic.reset_bumped_at }.to change { topic.bumped_at }.to(post3.reload.created_at)
 
-      post = Fabricate(:post, topic: topic, post_number: 8, created_at: 3.hours.ago, post_type: Post.types[:small_action])
-      expect { topic.reset_bumped_at }.to change { topic.bumped_at }.to(post.reload.created_at)
+      Fabricate(:post, topic: topic, post_number: 8, created_at: 3.hours.ago, post_type: Post.types[:small_action])
+      Fabricate(:post, topic: topic, post_number: 9, created_at: 2.hours.ago, post_type: Post.types[:moderator_action])
+      expect { topic.reset_bumped_at }.not_to change { topic.bumped_at }
     end
   end
 end


### PR DESCRIPTION
https://meta.discourse.org/t/reset-bump-date-doesnt-work-if-there-is-a-moderator-action-as-the-last-post/101637/4