### PR TITLE
Stop seeding assets for site design topic.

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -501,9 +501,6 @@ en:
   staff_category_name: "Staff"
   staff_category_description: "Private category for staff discussions. Topics are only visible to admins and moderators."
 
-  assets_topic_title: "Assets for the site design"
-  assets_topic_body: "This topic, visible only to staff, is for storing images and files used in the site design. Don't delete it!\n\n\nHere's how:\n\n\n1. Reply to this topic.\n2. Upload all the images you wish to use for logos, favicons, and so forth here. (Use the upload toolbar icon in the post editor, or drag-and-drop or paste images.)\n3. Submit your reply to post it.\n4. Right click the images in your new post to get the path to the uploaded images, or click the edit icon to edit your post and retrieve the path to the images. Copy the image paths.\n5. Paste those image paths into [basic settings](%{base_path}/admin/site_settings/category/required).\n\n\nIf you need to enable different file type uploads, edit `authorized_extensions` in the [file settings](%{base_path}/admin/site_settings/category/files)."
-
   discourse_welcome_topic:
     title: "Welcome to Discourse"
     body: |

--- a/db/fixtures/990_topics.rb
+++ b/db/fixtures/990_topics.rb
@@ -39,8 +39,6 @@ end
 if seed_welcome_topics
   puts "Seeding welcome topics"
 
-  PostCreator.create(Discourse.system_user, raw: I18n.t('assets_topic_body', base_path: Discourse.base_path), title: I18n.t('assets_topic_title'), skip_validations: true, category: staff ? staff.name : nil)
-
   post = PostCreator.create(Discourse.system_user, raw: I18n.t('discourse_welcome_topic.body', base_path: Discourse.base_path), title: I18n.t('discourse_welcome_topic.title'), skip_validations: true)
   post.topic.update_pinned(true, true)
   TopicCustomField.create(topic_id: post.topic.id, name: "is_welcome_topic", value: "true")


### PR DESCRIPTION
cc @SamSaffron @coding-horror  Any objections? We don't require this topic now that images can be directly uploaded into the site settings.