### PR TITLE
extract inline `onpopstate` handler on 404 page

### DIFF
--- a/app/assets/javascripts/onpopstate-handler.js.no-module.es6
+++ b/app/assets/javascripts/onpopstate-handler.js.no-module.es6
@@ -1,0 +1,6 @@
+window.onpopstate = function(event) {
+  // check if Discourse object exists if not take care of back navigation
+  if (event.state && !window.hasOwnProperty("Discourse")) {
+    window.location = document.location;
+  }
+};

--- a/app/views/exceptions/not_found.html.erb
+++ b/app/views/exceptions/not_found.html.erb
@@ -38,11 +38,5 @@
     </div>
   </div>
 
-  <script language="Javascript">
-    window.onpopstate = function(event) {
-      if (event.state && !window.hasOwnProperty("Discourse")) {  //check if Discourse object exists if not take care of back navigation
-        window.location = document.location;
-      }
-    };
-  </script>
+  <%= preload_script('onpopstate-handler') %>
 <%- end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -128,6 +128,7 @@ module Discourse
       activate-account.js
       auto-redirect.js
       wizard-start.js
+      onpopstate-handler.js
     }
 
     # Precompile all available locales


### PR DESCRIPTION
This scenario requires the `onpopstate` listener for back / forward in browser to work:

1. click on a 404 link in a post
2. **refresh** the 404 page
3. go back / forward no longer works