### PR TITLE
do not overwrite hostname in development

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -198,8 +198,10 @@ module Discourse
     # supports etags (post 1.7)
     config.middleware.delete Rack::ETag
 
-    require 'middleware/enforce_hostname'
-    config.middleware.insert_after Rack::MethodOverride, Middleware::EnforceHostname
+    unless Rails.env.development?
+      require 'middleware/enforce_hostname'
+      config.middleware.insert_after Rack::MethodOverride, Middleware::EnforceHostname
+    end
 
     require 'content_security_policy'
     config.middleware.swap ActionDispatch::ContentSecurityPolicy::Middleware, ContentSecurityPolicy::Middleware


### PR DESCRIPTION
https://github.com/discourse/discourse/blob/10723ba1c259a559ad085bb96109e6fe7ddfdac7/lib/content_security_policy.rb#L103

Otherwise, `port` information is lost and leads to incorrect CSP generated on `localhost`:

> Refused to load the script `http://localhost:3000/assets/locales/en.js` because it violates the following Content Security Policy directive: `"script-src 'unsafe-eval' localhost/logs/ localhost/sidekiq/ localhost/mini-profiler-resources/ localhost/assets/ localhost/brotli_asset/ localhost/extra-locales/ localhost/highlight-js/ localhost/javascripts/ localhost/theme-javascripts/"`.

