### PR TITLE
FIX: Skip gsub for normalizing whitespaces when text is nil

### DIFF
--- a/lib/text_cleaner.rb
+++ b/lib/text_cleaner.rb
@@ -57,7 +57,7 @@ class TextCleaner
   @@whitespaces_regexp = Regexp.new("(\u00A0|\u1680|\u180E|[\u2000-\u200A]|\u2028|\u2029|\u202F|\u205F|\u3000)", "u").freeze
 
   def self.normalize_whitespaces(text)
-    text.gsub(@@whitespaces_regexp, ' ')
+    text&.gsub(@@whitespaces_regexp, ' ')
   end
 
 end

--- a/spec/components/text_cleaner_spec.rb
+++ b/spec/components/text_cleaner_spec.rb
@@ -218,6 +218,7 @@ describe TextCleaner do
       whitespaces = "\u0020\u00A0\u1680\u180E\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u2028\u2029\u202F\u205F\u3000"
       expect(whitespaces.strip).not_to eq("")
       expect(TextCleaner.normalize_whitespaces(whitespaces).strip).to eq("")
+      expect(TextCleaner.normalize_whitespaces(nil)).to be_nil
     end
 
     it "does not muck with zero width white space" do


### PR DESCRIPTION
```ruby
NoMethodError (undefined method `gsub' for nil:NilClass)
/var/www/discourse/lib/text_cleaner.rb:60:in `normalize_whitespaces'
```
