### PR TITLE
FEATURE: Scroll-based logo on mobile 

### DIFF
--- a/app/assets/javascripts/discourse/components/discourse-topic.js.es6
+++ b/app/assets/javascripts/discourse/components/discourse-topic.js.es6
@@ -145,7 +145,7 @@ export default Ember.Component.extend(AddArchetypeClass, Scrolling, {
     // conditions for showing topic title in the header for mobile
     if (
       this.site.mobileView &&
-      scrollDirection != "up" &&
+      scrollDirection !== "up" &&
       offset > this.dockAt
     ) {
       return true;
@@ -199,10 +199,10 @@ export default Ember.Component.extend(AddArchetypeClass, Scrolling, {
 
     delta = offset - lastScroll;
     // 3px buffer so that the switch doesn't happen with tiny scrolls
-    if (delta > 3 && scrollDirection != "down") {
+    if (delta > 3 && scrollDirection !== "down") {
       scrollDirection = "down";
       this.appEvents.trigger("header:show-topic", this.topic);
-    } else if (delta < -3 && scrollDirection != "up") {
+    } else if (delta < -3 && scrollDirection !== "up") {
       scrollDirection = "up";
       this.appEvents.trigger("header:hide-topic");
     }

--- a/app/assets/javascripts/discourse/components/discourse-topic.js.es6
+++ b/app/assets/javascripts/discourse/components/discourse-topic.js.es6
@@ -102,11 +102,16 @@ export default Ember.Component.extend(AddArchetypeClass, Scrolling, {
       this.appEvents.on("topic:scrolled", offset =>
         this.mobileScrollGaurd(offset)
       );
+      // used to animate header contents on scroll
       this.appEvents.on("header:show-topic", () => {
-        $("header.d-header").addClass("scroll-logo");
+        $("header.d-header")
+          .removeClass("scroll-up")
+          .addClass("scroll-down");
       });
       this.appEvents.on("header:hide-topic", () => {
-        $("header.d-header").removeClass("scroll-logo");
+        $("header.d-header")
+          .removeClass("scroll-down")
+          .addClass("scroll-up");
       });
     }
   },
@@ -127,6 +132,7 @@ export default Ember.Component.extend(AddArchetypeClass, Scrolling, {
     // mobile scroll logo clean up.
     if (this.site.mobileView) {
       this.appEvents.off("topic:scrolled");
+      $("header.d-header").removeClass("scroll-down scroll-up");
     }
   },
 

--- a/app/assets/javascripts/discourse/components/topic-progress.js.es6
+++ b/app/assets/javascripts/discourse/components/topic-progress.js.es6
@@ -1,3 +1,4 @@
+import { getOwner } from "discourse-common/lib/get-owner";
 import {
   default as computed,
   observes
@@ -154,15 +155,14 @@ export default Ember.Component.extend({
     const $wrapper = this.$();
     if (!$wrapper || $wrapper.length === 0) return;
 
-    const offset = window.pageYOffset || $("html").scrollTop();
-    const progressHeight = this.site.mobileView
-      ? 0
-      : $("#topic-progress").height();
-    const maximumOffset = $("#topic-bottom").offset().top + progressHeight;
-    const windowHeight = $(window).height();
-    const composerHeight = $("#reply-control").height() || 0;
-    const isDocked = offset >= maximumOffset - windowHeight + composerHeight;
-    const bottom = $("body").height() - maximumOffset;
+    const offset = window.pageYOffset || $("html").scrollTop(),
+      progressHeight = this.site.mobileView ? 0 : $("#topic-progress").height(),
+      maximumOffset = $("#topic-bottom").offset().top + progressHeight,
+      windowHeight = $(window).height(),
+      bodyHeight = $("body").height(),
+      composerHeight = $("#reply-control").height() || 0,
+      isDocked = offset >= maximumOffset - windowHeight + composerHeight,
+      bottom = bodyHeight - maximumOffset;
 
     if (composerHeight > 0) {
       $wrapper.css("bottom", isDocked ? bottom : composerHeight);
@@ -177,6 +177,23 @@ export default Ember.Component.extend({
       $wrapper.css("right", `${$replyArea.offset().left}px`);
     } else {
       $wrapper.css("right", "1em");
+    }
+
+    // switch mobile scroll logo at the very bottom of topics
+    const isIOS = this.capabilities.isIOS,
+      switchHeight = bodyHeight - offset - windowHeight,
+      appEvents = getOwner(this).lookup("app-events:main");
+
+    if (isIOS && switchHeight < -10) {
+      // match elastic-scroll behaviour in iOS
+      setTimeout(function() {
+        appEvents.trigger("header:hide-topic");
+      }, 300);
+    } else if (!isIOS && switchHeight < 5) {
+      // normal switch for everyone else
+      setTimeout(function() {
+        appEvents.trigger("header:hide-topic");
+      }, 300);
     }
   },
 

--- a/app/assets/javascripts/discourse/widgets/header-contents.js.es6
+++ b/app/assets/javascripts/discourse/widgets/header-contents.js.es6
@@ -5,9 +5,9 @@ createWidget("header-contents", {
   tagName: "div.contents.clearfix",
   template: hbs`
     {{attach widget="home-logo" attrs=attrs}}
-    <div class="panel clearfix">{{yield}}</div>
     {{#if attrs.topic}}
       {{attach widget="header-topic-info" attrs=attrs}}
     {{/if}}
+    <div class="panel clearfix">{{yield}}</div>
   `
 });

--- a/app/assets/javascripts/discourse/widgets/header-topic-info.js.es6
+++ b/app/assets/javascripts/discourse/widgets/header-topic-info.js.es6
@@ -20,7 +20,7 @@ export default createWidget("header-topic-info", {
       if (href) {
         heading.push(
           h(
-            "a",
+            "a.private-message-glyph-wrapper",
             { attributes: { href } },
             h("span.private-message-glyph", iconNode("envelope"))
           )

--- a/app/assets/javascripts/discourse/widgets/header-topic-info.js.es6
+++ b/app/assets/javascripts/discourse/widgets/header-topic-info.js.es6
@@ -47,6 +47,7 @@ export default createWidget("header-topic-info", {
 
     const title = [h("h1", heading)];
     const category = topic.get("category");
+
     if (loaded || category) {
       if (
         category &&
@@ -54,12 +55,15 @@ export default createWidget("header-topic-info", {
           !this.siteSettings.suppress_uncategorized_badge)
       ) {
         const parentCategory = category.get("parentCategory");
+        const categories = [];
         if (parentCategory) {
-          title.push(
+          categories.push(
             this.attach("category-link", { category: parentCategory })
           );
         }
-        title.push(this.attach("category-link", { category }));
+        categories.push(this.attach("category-link", { category }));
+
+        title.push(h("div.categories-wrapper", categories));
       }
 
       let extra = [];

--- a/app/assets/javascripts/discourse/widgets/home-logo.js.es6
+++ b/app/assets/javascripts/discourse/widgets/home-logo.js.es6
@@ -26,15 +26,15 @@ export default createWidget("home-logo", {
     const logoUrl = siteSettings.site_logo_url || "";
     const title = siteSettings.title;
 
-    if (!mobileView && this.attrs.minimized) {
+    if (this.attrs.minimized) {
       const logoSmallUrl = siteSettings.site_logo_small_url || "";
       if (logoSmallUrl.length) {
         return h("img#site-logo.logo-small", {
           key: "logo-small",
           attributes: {
             src: Discourse.getURL(logoSmallUrl),
-            width: 33,
-            height: 33,
+            width: 36,
+            height: 36,
             alt: title
           }
         });
@@ -49,7 +49,7 @@ export default createWidget("home-logo", {
     } else if (logoUrl.length) {
       return h("img#site-logo.logo-big", {
         key: "logo-big",
-        attributes: { src: Discourse.getURL(logoUrl), alt: title }
+        attributes: { src: Discourse.getURL(logoUrl), height: 36, alt: title }
       });
     } else {
       return h("h1#site-text-logo.text-logo", { key: "logo-text" }, title);

--- a/app/assets/stylesheets/common/base/header.scss
+++ b/app/assets/stylesheets/common/base/header.scss
@@ -257,7 +257,7 @@
   .categories-wrapper {
     display: inline-flex;
     max-width: 100%;
-    // only truncate the last category name. One full width category
+    // only truncate the last category name.
     > a:last-of-type {
       overflow: hidden;
       white-space: nowrap;

--- a/app/assets/stylesheets/common/base/header.scss
+++ b/app/assets/stylesheets/common/base/header.scss
@@ -282,6 +282,9 @@
       overflow: hidden;
       white-space: nowrap;
       text-overflow: ellipsis;
+      .discourse-tag {
+        display: inline;
+      }
     }
   }
   // if a topic has both categories and tags, the tag container should shrink

--- a/app/assets/stylesheets/common/base/header.scss
+++ b/app/assets/stylesheets/common/base/header.scss
@@ -213,28 +213,17 @@
 .extra-info-wrapper {
   display: flex;
   align-items: center;
-  flex: 1;
+  flex: 1 1 0%; // unit on flex-basis is required for IE11
   height: 100%;
   line-height: $line-height-medium;
   padding: 0 1.5em 0 0.5em;
-  -webkit-animation: fadein 0.4s;
-  animation: fadein 0.4s;
-  // we need to hide overflow in both to turnicate the title in a flexbox
+  // we need to hide overflow in both to truncate the title in a flexbox
   overflow: hidden;
   .extra-info {
     overflow: hidden;
     width: 100%;
-  }
-  h1 {
-    margin: 0 0 0.25em 0;
-    font-size: $font-up-3;
-    width: 100%;
-  }
-  .topic-header-extra {
-    display: inline-flex;
-  }
-  .badge-wrapper {
-    margin-right: 8px;
+    -webkit-animation: fadein 0.5s;
+    animation: fadein 0.5s;
   }
   .topic-link {
     color: $header_primary;
@@ -259,5 +248,45 @@
     .unpinned {
       color: $header_primary;
     }
+  }
+  h1 {
+    margin: 0 0 0.25em 0;
+    font-size: $font-up-3;
+    width: 100%;
+  }
+  .categories-wrapper {
+    display: inline-flex;
+    max-width: 100%;
+    // only truncate the last category name. One full width category
+    > a:last-of-type {
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+    }
+  }
+  .badge-wrapper {
+    margin-right: 8px;
+  }
+  .badge-wrapper.bullet {
+    .badge-category-parent-bg,
+    .badge-category-bg {
+      min-width: 5px;
+    }
+  }
+  .topic-header-extra {
+    display: inline-flex;
+    align-items: center;
+    max-width: 100%;
+    flex: 1 0 0%; // unit on flex-basis is required for IE11
+    .discourse-tags {
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+    }
+  }
+  // if a topic has both categories and tags, the tag container should shrink
+  // instead of wrapping to the next line.
+  .categories-wrapper + .topic-header-extra {
+    min-width: 0;
   }
 }

--- a/app/assets/stylesheets/common/base/header.scss
+++ b/app/assets/stylesheets/common/base/header.scss
@@ -1,4 +1,6 @@
 .d-header {
+  display: flex;
+  align-items: center;
   width: 100%;
   position: absolute;
   top: 0;
@@ -6,35 +8,46 @@
   background-color: $header_background;
   box-shadow: shadow("header");
 
+  > .wrap {
+    width: 100%;
+    height: 100%;
+    .contents {
+      display: flex;
+      align-items: center;
+      height: 100%;
+    }
+  }
+
   .docked & {
     position: fixed;
     backface-visibility: hidden; /** do magic for scrolling performance **/
   }
 
-  .contents {
-    margin: 8px 0;
-  }
-
   .title {
-    float: left;
+    display: flex;
+    align-items: center;
+    height: 100%;
     a,
     a:visited {
       color: $header_primary;
     }
   }
 
+  // the logo height is set in the home-logo widget. This ensures we get a scaled
+  // width that respects the aspect ratio of the image
   #site-logo {
-    max-height: 2.8571em;
+    width: auto;
   }
 
   .d-icon-home {
-    font-size: 1.643em;
+    font-size: $font-up-5;
   }
 
   .panel {
-    float: right;
     position: relative;
     display: flex;
+    flex: 0 0 auto;
+    margin-left: auto;
     align-items: center;
   }
 
@@ -194,4 +207,57 @@
 // we don't need this X to clear field
 #search-term::-ms-clear {
   display: none;
+}
+
+// topic info in the header
+.extra-info-wrapper {
+  display: flex;
+  align-items: center;
+  flex: 1;
+  height: 100%;
+  line-height: $line-height-medium;
+  padding: 0 1.5em 0 0.5em;
+  -webkit-animation: fadein 0.4s;
+  animation: fadein 0.4s;
+  // we need to hide overflow in both to turnicate the title in a flexbox
+  overflow: hidden;
+  .extra-info {
+    overflow: hidden;
+    width: 100%;
+  }
+  h1 {
+    margin: 0 0 0.25em 0;
+    font-size: $font-up-3;
+    width: 100%;
+  }
+  .topic-header-extra {
+    display: inline-flex;
+  }
+  .badge-wrapper {
+    margin-right: 8px;
+  }
+  .topic-link {
+    color: $header_primary;
+    display: block;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .topic-statuses {
+    margin-top: -2px;
+    float: left;
+    padding: 0;
+    i {
+      color: $header_primary;
+    }
+    .d-icon-envelope {
+      color: $danger;
+    }
+    .d-icon-lock {
+      padding-top: 0.15em;
+    }
+    .unpinned {
+      color: $header_primary;
+    }
+  }
 }

--- a/app/assets/stylesheets/common/base/tagging.scss
+++ b/app/assets/stylesheets/common/base/tagging.scss
@@ -37,19 +37,6 @@
   }
 }
 
-.topic-header-extra .discourse-tag {
-  -webkit-animation: fadein 0.7s;
-  animation: fadein 0.7s;
-}
-
-.bullet + .topic-header-extra {
-  display: block;
-}
-
-.box + .topic-header-extra {
-  display: inline-block;
-}
-
 .topic-category {
   display: flex;
   flex-wrap: wrap;

--- a/app/assets/stylesheets/common/base/topic.scss
+++ b/app/assets/stylesheets/common/base/topic.scss
@@ -60,8 +60,6 @@
 .title-wrapper {
   display: flex;
   flex-wrap: wrap;
-  width: 90%;
-  align-items: flex-end;
   .btn-small {
     margin: 0 6px 0 0;
   }
@@ -149,12 +147,6 @@ a.badge-category {
 
 .topic-title-outlet {
   clear: both;
-}
-
-.extra-info-wrapper {
-  .badge-wrapper {
-    float: left;
-  }
 }
 
 .has-pending-posts {

--- a/app/assets/stylesheets/desktop/discourse.scss
+++ b/app/assets/stylesheets/desktop/discourse.scss
@@ -8,10 +8,6 @@ body.widget-dragging {
   cursor: ns-resize;
 }
 
-header {
-  margin-bottom: 15px;
-}
-
 // Common classes
 .boxed {
   height: 100%;

--- a/app/assets/stylesheets/desktop/header.scss
+++ b/app/assets/stylesheets/desktop/header.scss
@@ -4,16 +4,21 @@
 
 .d-header {
   left: 0;
-  padding-top: 3px;
-  height: 4.2857em;
-  .d-icon-home {
-    padding: 8px;
-    font-size: $font-up-5;
-  }
+  height: 4.2858em;
+  margin-bottom: 15px;
 
-  .site-text-logo {
-    position: relative;
-    top: 10px;
+  #site-text-logo {
+    font-size: $font-up-3;
+    margin: 0;
+  }
+  .extra-info {
+    // header title should not be centered if there's no tags / categories
+    &:not(.two-rows) {
+      min-height: 2.75em;
+    }
+    h1 {
+      margin: 0 0 0.125em 0;
+    }
   }
 }
 
@@ -39,13 +44,5 @@
   line-height: $line-height-large;
   .search-highlight {
     color: dark-light-choose($primary-high, $secondary-low);
-  }
-}
-
-header {
-  #site-text-logo {
-    font-size: $font-up-3;
-    margin-top: 0.4em;
-    line-height: $line-height-medium;
   }
 }

--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -11,14 +11,6 @@ h1 .topic-statuses .topic-status i {
   vertical-align: middle;
 }
 
-.logo-small {
-  margin-right: 8px;
-  width: auto;
-  max-width: 80px;
-  height: auto;
-  max-height: 40px;
-}
-
 .topic-body {
   padding: 0;
   &:first-of-type {
@@ -503,64 +495,6 @@ video {
   }
   to {
     opacity: 1;
-  }
-}
-
-.extra-info-wrapper {
-  overflow: hidden;
-  .badge-wrapper,
-  i,
-  .topic-link {
-    -webkit-animation: fadein 0.7s;
-    animation: fadein 0.7s;
-  }
-  .topic-statuses {
-    i {
-      color: $header_primary;
-    }
-    .d-icon-envelope {
-      color: $danger;
-    }
-    .d-icon-lock {
-      padding-top: 0.15em;
-    }
-    .unpinned {
-      color: $header_primary;
-    }
-  }
-  .topic-link {
-    color: $header_primary;
-    display: block;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-  .topic-header-extra {
-    margin: 0 0 0 5px;
-  }
-}
-
-/* default docked header CSS for all topics, including those without categories */
-
-.extra-info {
-  h1 {
-    margin: 5px 0 0 0;
-    font-size: $font-up-3;
-    line-height: $line-height-large;
-    width: 100%;
-  }
-  .topic-statuses {
-    margin-top: -2px;
-  }
-}
-
-/* override docked header CSS for topics with categories */
-
-.extra-info.two-rows {
-  h1 {
-    line-height: $line-height-medium;
-    margin: 0;
-    width: 100%;
   }
 }
 

--- a/app/assets/stylesheets/mobile/discourse.scss
+++ b/app/assets/stylesheets/mobile/discourse.scss
@@ -149,9 +149,3 @@ blockquote {
 #simple-container {
   width: 90%;
 }
-
-// somehow the image logo assumption inherits margins from earlier in the CSS
-// stack we must remove margins for text site titles
-h1#site-text-logo {
-  margin: 0 0 0 10px;
-}

--- a/app/assets/stylesheets/mobile/header.scss
+++ b/app/assets/stylesheets/mobile/header.scss
@@ -11,6 +11,8 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    -webkit-animation: fadein 0.5s;
+    animation: fadein 0.5s;
     a {
       display: block;
     }
@@ -33,14 +35,15 @@
       }
     }
   }
-  // styles for mobile scroll logo / topic
-  .panel {
-    animation: fadein 0.7s;
-  }
-  &.scroll-logo .panel {
+  button.sign-up-button {
     display: none;
   }
-  button.sign-up-button {
+  // styles for mobile scroll logo / topic
+  .panel {
+    -webkit-animation: fadein 0.5s;
+    animation: fadein 0.5s;
+  }
+  &.scroll-down .panel {
     display: none;
   }
 }

--- a/app/assets/stylesheets/mobile/header.scss
+++ b/app/assets/stylesheets/mobile/header.scss
@@ -2,34 +2,44 @@
 // Discourse header
 // --------------------------------------------------
 
-#site-text-logo {
-  font-size: $font-up-3;
-}
-@include breakpoint(mobile-small) {
-  #site-text-logo {
-    font-size: $font-up-2;
-  }
-}
-
 .d-header {
-  #site-logo {
-    max-width: 8.8em;
-  }
+  height: 3.66em;
 
   // some protection for text-only site titles
   .title {
-    max-width: 50%;
-    height: 39px;
+    max-width: 75%;
+    white-space: nowrap;
     overflow: hidden;
-    padding: 0;
-    text-overflow: clip;
-    display: table;
+    text-overflow: ellipsis;
     a {
-      display: table-cell;
-      vertical-align: middle;
+      display: block;
     }
   }
-
+  #site-text-logo {
+    margin: 0;
+    font-size: $font-up-1;
+  }
+  .extra-info-wrapper {
+    .extra-info {
+      // header title should not be centered if there's no tags / categories
+      &:not(.two-rows) {
+        min-height: 2.25em;
+      }
+      h1 {
+        font-size: $font-0;
+      }
+      .private-message-glyph-wrapper {
+        float: left;
+      }
+    }
+  }
+  // styles for mobile scroll logo / topic
+  .panel {
+    animation: fadein 0.7s;
+  }
+  &.scroll-logo .panel {
+    display: none;
+  }
   button.sign-up-button {
     display: none;
   }

--- a/app/assets/stylesheets/mobile/topic-post.scss
+++ b/app/assets/stylesheets/mobile/topic-post.scss
@@ -1,5 +1,4 @@
 /* hide the reply border above the time gap notices */
-
 .time-gap + .topic-post article {
   border-top: none;
 }
@@ -317,10 +316,6 @@ span.post-count {
 
 iframe {
   max-width: 100%;
-}
-
-.extra-info {
-  display: none;
 }
 
 .open > .dropdown-menu {


### PR DESCRIPTION
This PR adds the ability to show the small logo and topic information in the header on mobile while the user is scrolling down.

Previous related discussions can be found here https://meta.discourse.org/t/smart-mobile-header/99846

Re-ordering the elements in the header-contents widget came up while working on this. So, this PR also re-orders those elements and converts the header to flexbox 