### PR TITLE
FIX: escape sso_secret string when migrating to sso_provider_secret

### DIFF
--- a/db/migrate/20181005084357_add_sso_provider_secrets_to_site_settings.rb
+++ b/db/migrate/20181005084357_add_sso_provider_secrets_to_site_settings.rb
@@ -2,8 +2,10 @@ class AddSsoProviderSecretsToSiteSettings < ActiveRecord::Migration[5.2]
   def up
     return unless SiteSetting.enable_sso_provider && SiteSetting.sso_secret.present?
     sso_secret = SiteSetting.sso_secret
+    sso_secret_insert = ActiveRecord::Base.connection.quote("*|#{sso_secret}")
+
     execute "INSERT INTO site_settings(name, data_type, value, created_at, updated_at)
-             VALUES ('sso_provider_secrets', 8, '*|#{sso_secret}', now(), now())"
+             VALUES ('sso_provider_secrets', 8, #{sso_secret_insert}, now(), now())"
   end
 
   def down


### PR DESCRIPTION
https://meta.discourse.org/t/our-discourse-instance-failed-to-manually-upgrade/102372