### PR TITLE
Add functionality required by discourse-encrypt

### DIFF
--- a/app/assets/javascripts/discourse/components/composer-action-title.js.es6
+++ b/app/assets/javascripts/discourse/components/composer-action-title.js.es6
@@ -66,9 +66,9 @@ export default Ember.Component.extend({
   },
 
   _formatReplyToTopic(link) {
-    return `<a class="topic-link" href="${link.href}">${
-      link.anchor
-    }</a>`.htmlSafe();
+    return `<a class="topic-link" href="${link.href}" data-topic-id="${this.get(
+      "model.topic.id"
+    )}">${link.anchor}</a>`.htmlSafe();
   },
 
   _formatReplyToUserPost(avatar, link) {

--- a/app/assets/javascripts/discourse/helpers/topic-link.js.es6
+++ b/app/assets/javascripts/discourse/helpers/topic-link.js.es6
@@ -11,6 +11,6 @@ registerUnbound("topic-link", (topic, args) => {
     args.class.split(" ").forEach(c => classes.push(c));
   }
 
-  const result = `<a href='${url}' class='${classes.join(" ")}'>${title}</a>`;
+  const result = `<a href='${url}' class='${classes.join(" ")}' data-topic-id='${topic.id}'>${title}</a>`;
   return new Handlebars.SafeString(result);
 });

--- a/app/assets/javascripts/discourse/helpers/topic-link.js.es6
+++ b/app/assets/javascripts/discourse/helpers/topic-link.js.es6
@@ -11,6 +11,8 @@ registerUnbound("topic-link", (topic, args) => {
     args.class.split(" ").forEach(c => classes.push(c));
   }
 
-  const result = `<a href='${url}' class='${classes.join(" ")}' data-topic-id='${topic.id}'>${title}</a>`;
+  const result = `<a href='${url}'
+                     class='${classes.join(" ")}'
+                     data-topic-id='${topic.id}'>${title}</a>`;
   return new Handlebars.SafeString(result);
 });

--- a/app/assets/javascripts/discourse/lib/show-modal.js.es6
+++ b/app/assets/javascripts/discourse/lib/show-modal.js.es6
@@ -39,6 +39,7 @@ export default function(name, opts) {
   modalController.set("modalClass", opts.modalClass);
 
   const controllerName = opts.admin ? `modals/${name}` : name;
+  modalController.set("name", controllerName);
 
   let controller = container.lookup("controller:" + controllerName);
   const templateName = opts.templateName || Ember.String.dasherize(name);

--- a/app/assets/javascripts/discourse/models/composer.js.es6
+++ b/app/assets/javascripts/discourse/models/composer.js.es6
@@ -683,6 +683,8 @@ const Composer = RestModel.extend({
           originalText: post.get("raw"),
           loading: false
         });
+
+        composer.appEvents.trigger("composer:reply-reloaded", composer);
       });
     } else if (opts.action === REPLY && opts.quote) {
       this.setProperties({
@@ -696,6 +698,10 @@ const Composer = RestModel.extend({
     this.set("originalText", opts.draft ? "" : this.get("reply"));
     if (this.get("editingFirstPost")) {
       this.set("originalTitle", this.get("title"));
+    }
+
+    if (!isEdit(opts.action) || !opts.post) {
+      composer.appEvents.trigger("composer:reply-reloaded", composer);
     }
 
     return false;

--- a/app/assets/javascripts/discourse/routes/application.js.es6
+++ b/app/assets/javascripts/discourse/routes/application.js.es6
@@ -144,6 +144,13 @@ const ApplicationRoute = Discourse.Route.extend(OpenComposer, {
     // Close the current modal, and destroy its state.
     closeModal() {
       this.render("hide-modal", { into: "modal", outlet: "modalBody" });
+
+      const route = getOwner(this).lookup("route:application");
+      const name = route.controllerFor("modal").get("name");
+      const controller = getOwner(this).lookup(`controller:${name}`);
+      if (controller && controller.onClose) {
+        controller.onClose();
+      }
     },
 
     /**

--- a/app/assets/javascripts/discourse/templates/application.hbs
+++ b/app/assets/javascripts/discourse/templates/application.hbs
@@ -18,6 +18,7 @@
     {{notification-consent-banner}}
     {{global-notice}}
     {{create-topics-notice}}
+    {{plugin-outlet name="top-notices" args=(hash currentPath=currentPath)}}
   </div>
   {{outlet}}
   {{outlet "user-card"}}

--- a/app/assets/javascripts/discourse/templates/composer.hbs
+++ b/app/assets/javascripts/discourse/templates/composer.hbs
@@ -17,6 +17,7 @@
               {{#unless model.viewFullscreen}}
                 <div class="reply-details">
                   {{composer-action-title model=model canWhisper=canWhisper tabindex=8}}
+                  {{plugin-outlet name="composer-action-after" noTags=true args=(hash model=model)}}
 
                   {{#unless site.mobileView}}
                     {{#if whisperOrUnlistTopicText}}

--- a/app/assets/javascripts/discourse/templates/topic.hbs
+++ b/app/assets/javascripts/discourse/templates/topic.hbs
@@ -44,7 +44,7 @@
           </div>
 
         {{else}}
-          <h1>
+          <h1 data-topic-id="{{unbound model.id}}">
             {{#unless model.is_warning}}
               {{#if siteSettings.enable_personal_messages}}
                 <a href={{pmPath}}>

--- a/app/assets/javascripts/discourse/widgets/header-topic-info.js.es6
+++ b/app/assets/javascripts/discourse/widgets/header-topic-info.js.es6
@@ -40,6 +40,7 @@ export default createWidget("header-topic-info", {
           className: "topic-link",
           action: "jumpToTopPost",
           href,
+          attributes: { "data-topic-id": topic.get("id") },
           contents: () => titleHTML
         })
       );

--- a/app/assets/javascripts/discourse/widgets/link.js.es6
+++ b/app/assets/javascripts/discourse/widgets/link.js.es6
@@ -35,12 +35,18 @@ export default createWidget("link", {
   },
 
   buildAttributes(attrs) {
-    return {
+    const ret = {
       href: this.href(attrs),
       title: attrs.title
         ? I18n.t(attrs.title, attrs.titleOptions)
         : this.label(attrs)
     };
+    if (attrs.attributes) {
+      Object.keys(attrs.attributes).forEach(
+        k => (ret[k] = attrs.attributes[k])
+      );
+    }
+    return ret;
   },
 
   label(attrs) {

--- a/app/assets/javascripts/discourse/widgets/post.js.es6
+++ b/app/assets/javascripts/discourse/widgets/post.js.es6
@@ -464,7 +464,11 @@ createWidget("post-article", {
   },
 
   buildAttributes(attrs) {
-    return { "data-post-id": attrs.id, "data-user-id": attrs.user_id };
+    return {
+      "data-post-id": attrs.id,
+      "data-topic-id": attrs.topicId,
+      "data-user-id": attrs.user_id
+    };
   },
 
   html(attrs, state) {

--- a/test/javascripts/models/composer-test.js.es6
+++ b/test/javascripts/models/composer-test.js.es6
@@ -1,4 +1,5 @@
 import { currentUser } from "helpers/qunit-helpers";
+import AppEvents from "discourse/lib/app-events";
 import Composer from "discourse/models/composer";
 import createStore from "helpers/create-store";
 
@@ -7,6 +8,7 @@ QUnit.module("model:composer");
 function createComposer(opts) {
   opts = opts || {};
   opts.user = opts.user || currentUser();
+  opts.appEvents = AppEvents.create();
   return createStore().createRecord("composer", opts);
 }
 


### PR DESCRIPTION
These patches add or improve functionality exposed to plugins (especially to discourse-encrypt 💃 ).

- Added a plugin outlet to add top-side notices (such as "You did not activate encryption on this device...").
- Added `data-topic-id` on few elements containing topic titles (plugin needs to know what content belongs to which topic).
- Added `composer-action-after` to add an indicator whether the message is encrypted or not. There is another plugin outlet nearby (`composer-fields`), but that forces me to add a whole line just to show an icon.
- Modals are notified when closed. It is basically the opposite of `onShow`. Hmm... maybe I should have called it `onHide`? 🤔