### PR TITLE
FEAT: Fix and improve migrate_to_s3 rake task

### DIFF
--- a/lib/tasks/uploads.rake
+++ b/lib/tasks/uploads.rake
@@ -239,9 +239,9 @@ def migrate_to_s3
 
   # Migrate all uploads
   file_uploads = Upload.where.not(sha1: nil).where("url NOT LIKE '#{s3.absolute_base_url}%'")
-  image_uploads = file_uploads.where("lower(extension) NOT IN (?)", FileHelper.supported_images.to_a)
+  non_image_uploads = file_uploads.where("lower(extension) NOT IN (?)", FileHelper.supported_images.to_a)
 
-  [image_uploads, file_uploads].each do |uploads|
+  [non_image_uploads, file_uploads].each do |uploads|
     uploads.find_in_batches(batch_size: 100) do |batch|
       batch.each do |upload|
         now = Process.clock_gettime(Process::CLOCK_MONOTONIC)

--- a/lib/tasks/uploads.rake
+++ b/lib/tasks/uploads.rake
@@ -274,6 +274,9 @@ def migrate_to_s3
 
           content_type = `file --mime-type -b #{path}`.strip
           to = s3.store_upload(file, upload, content_type)
+
+          file.close
+          File.unlink(path)
         rescue => e
           puts "Encountered an error while migrating #{upload.url}: #{e.class}: #{e.message}"
           next

--- a/lib/tasks/uploads.rake
+++ b/lib/tasks/uploads.rake
@@ -1,6 +1,7 @@
 require "db_helper"
 require "digest/sha1"
 require "base62"
+require "mini_mime"
 
 ################################################################################
 #                                    gather                                    #
@@ -272,7 +273,8 @@ def migrate_to_s3
             next
           end
 
-          content_type = `file --mime-type -b #{path}`.strip
+          content_type = MiniMime.lookup_by_filename(File.basename(path)).content_type
+
           to = s3.store_upload(file, upload, content_type)
 
           file.close


### PR DESCRIPTION
See individual commits for atomic changes:
* Ensure that upload migration to S3 works without a CDN enabled
  * An attempt at optimization in https://github.com/discourse/discourse/commit/7290145641e855c01a03ed505175cda79db3eb12 resulted in the migration task failing entirely when a CDN was not configured for use. This reverts part of https://github.com/discourse/discourse/commit/7290145641e855c01a03ed505175cda79db3eb12 , ensuring it is more reliable in all cases.
* Fix variable naming in migrate_to_s3
  * It's still unclear why prioritizing the migration of non-image uploads first results in any net performance improvement. @tgxworld Can you provide any rationale for this? Otherwise, it may be best to simplify the code and remove the sorting entirely.
* Include remote files in "uploads:migrate_to_s3" task
  * This adds a new feature to the task, allowing migration of existing remote files (for example, when renaming the upload bucket). This should also work across S3-compliant services, allowing migration in and out of AWS to other S3-compliant providers.
* Remove local upload files after moving them to S3
  * Once locally stored uploads are successfully migrated to S3, they should be removed, so they don't continue to consume disk space as 'leaked' resources.
* Use MiniMime to determine S3 upload content types
  * MiniMime is used in other parts of Discourse to determine MIME type from file extensions, and should be used instead of a subprocess call to the `file` utility.