### PR TITLE
FEATURE: Show change name of user in staff logs

### DIFF
--- a/app/models/user_history.rb
+++ b/app/models/user_history.rb
@@ -144,7 +144,8 @@ class UserHistory < ActiveRecord::Base
       :delete_badge,
       :post_rejected,
       :merge_user,
-      :entity_export
+      :entity_export,
+      :change_name
     ]
   end
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3569,6 +3569,7 @@ en:
             delete_badge: "delete badge"
             merge_user: "merge user"
             entity_export: "export entity"
+            change_name: "change name"
         screened_emails:
           title: "Screened Emails"
           description: "When someone tries to create a new account, the following email addresses will be checked and the registration will be blocked, or some other action performed."


### PR DESCRIPTION
https://meta.discourse.org/t/admins-changing-users-name-not-username-should-be-logged/99511

This is how it looks:
![screenshot from 2018-11-22 06-27-03](https://user-images.githubusercontent.com/6376157/48875608-f06ef300-ee1f-11e8-805b-ea570970e658.png)
