### PR TITLE
FEATURE: Use translated name for 'your email has been authenticated by'

### DIFF
--- a/app/assets/javascripts/discourse/controllers/create-account.js.es6
+++ b/app/assets/javascripts/discourse/controllers/create-account.js.es6
@@ -147,13 +147,13 @@ export default Ember.Controller.extend(
       );
     }.property("accountEmail", "authOptions.email", "authOptions.email_valid"),
 
-    authProviderDisplayName(provider) {
-      switch (provider) {
-        case "Google_oauth2":
-          return "Google";
-        default:
-          return provider;
-      }
+    authProviderDisplayName(providerName) {
+      const matchingProvider = findAll().find(provider => {
+        return provider.name === providerName;
+      });
+      return matchingProvider !== undefined
+        ? matchingProvider.get("prettyName")
+        : providerName;
     },
 
     prefillUsername: function() {

--- a/app/assets/javascripts/discourse/controllers/create-account.js.es6
+++ b/app/assets/javascripts/discourse/controllers/create-account.js.es6
@@ -151,7 +151,7 @@ export default Ember.Controller.extend(
       const matchingProvider = findAll().find(provider => {
         return provider.name === providerName;
       });
-      return matchingProvider !== undefined
+      return matchingProvider
         ? matchingProvider.get("prettyName")
         : providerName;
     },

--- a/lib/auth/result.rb
+++ b/lib/auth/result.rb
@@ -64,8 +64,7 @@ class Auth::Result
     else
       result = { email: email,
                  username: UserNameSuggester.suggest(username || name || email),
-                 # this feels a tad wrong
-                 auth_provider: authenticator_name.capitalize,
+                 auth_provider: authenticator_name,
                  email_valid: !!email_valid,
                  omit_username: !!omit_username }
 

--- a/spec/requests/omniauth_callbacks_controller_spec.rb
+++ b/spec/requests/omniauth_callbacks_controller_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe Users::OmniauthCallbacksController do
 
         expect(response_body["email"]).to eq(email)
         expect(response_body["username"]).to eq("Some_name")
-        expect(response_body["auth_provider"]).to eq("Google_oauth2")
+        expect(response_body["auth_provider"]).to eq("google_oauth2")
         expect(response_body["email_valid"]).to eq(true)
         expect(response_body["omit_username"]).to eq(false)
         expect(response_body["name"]).to eq("Some Name")

--- a/spec/views/omniauth_callbacks/complete.html.erb_spec.rb
+++ b/spec/views/omniauth_callbacks/complete.html.erb_spec.rb
@@ -33,7 +33,7 @@ describe "users/omniauth_callbacks/complete.html.erb" do
     render
 
     expect(rendered_data["email"]).to eq(result.email)
-    expect(rendered_data["auth_provider"]).to eq("cas")
+    expect(rendered_data["auth_provider"]).to eq("CAS")
   end
 
 end

--- a/spec/views/omniauth_callbacks/complete.html.erb_spec.rb
+++ b/spec/views/omniauth_callbacks/complete.html.erb_spec.rb
@@ -35,7 +35,7 @@ describe "users/omniauth_callbacks/complete.html.erb" do
     expect(rendered_data["email"]).to eq(result.email)
     # TODO this is a bit weird, the upcasing is confusing,
     #  clean it up throughout
-    expect(rendered_data["auth_provider"]).to eq("Cas")
+    expect(rendered_data["auth_provider"]).to eq("cas")
   end
 
 end

--- a/spec/views/omniauth_callbacks/complete.html.erb_spec.rb
+++ b/spec/views/omniauth_callbacks/complete.html.erb_spec.rb
@@ -33,8 +33,6 @@ describe "users/omniauth_callbacks/complete.html.erb" do
     render
 
     expect(rendered_data["email"]).to eq(result.email)
-    # TODO this is a bit weird, the upcasing is confusing,
-    #  clean it up throughout
     expect(rendered_data["auth_provider"]).to eq("cas")
   end
 

--- a/test/javascripts/controllers/create-account-test.js.es6
+++ b/test/javascripts/controllers/create-account-test.js.es6
@@ -86,8 +86,7 @@ QUnit.test("passwordValidation", function(assert) {
 });
 
 QUnit.test("authProviderDisplayName", function(assert) {
-  const subject = this.subject;
-  const controller = subject({ siteSettings: Discourse.SiteSettings });
+  const controller = this.subject({ siteSettings: Discourse.SiteSettings });
 
   assert.equal(
     controller.authProviderDisplayName("facebook"),

--- a/test/javascripts/controllers/create-account-test.js.es6
+++ b/test/javascripts/controllers/create-account-test.js.es6
@@ -84,3 +84,19 @@ QUnit.test("passwordValidation", function(assert) {
   testInvalidPassword("porkchops", I18n.t("user.password.same_as_username"));
   testInvalidPassword("pork@chops.com", I18n.t("user.password.same_as_email"));
 });
+
+QUnit.test("authProviderDisplayName", function(assert) {
+  var subject = this.subject;
+  var controller = subject({ siteSettings: Discourse.SiteSettings });
+
+  assert.equal(
+    controller.authProviderDisplayName("facebook"),
+    I18n.t("login.facebook.name"),
+    "provider name is translated correctly"
+  );
+  assert.equal(
+    controller.authProviderDisplayName("idontexist"),
+    "idontexist",
+    "provider name falls back if not found"
+  );
+});

--- a/test/javascripts/controllers/create-account-test.js.es6
+++ b/test/javascripts/controllers/create-account-test.js.es6
@@ -86,8 +86,8 @@ QUnit.test("passwordValidation", function(assert) {
 });
 
 QUnit.test("authProviderDisplayName", function(assert) {
-  var subject = this.subject;
-  var controller = subject({ siteSettings: Discourse.SiteSettings });
+  const subject = this.subject;
+  const controller = subject({ siteSettings: Discourse.SiteSettings });
 
   assert.equal(
     controller.authProviderDisplayName("facebook"),


### PR DESCRIPTION
Right now we use the auth provider name from the url (e.g. meta.discourse.org/auth/**github**), and simply capitalise the first letter. To quote 2013 @SamSaffron "This feels a tad wrong" 😉.

This change means that we use the proper translated name, using the same method as the user preferences page.

For the case of GitHub, before:
<img width="494" alt="screenshot 2018-11-22 at 14 35 23" src="https://user-images.githubusercontent.com/6270921/48909138-5e3d0e00-ee64-11e8-93ce-ddbbe942c087.png">

After:
<img width="491" alt="screenshot 2018-11-22 at 14 35 39" src="https://user-images.githubusercontent.com/6270921/48909131-57160000-ee64-11e8-8ee6-e6123f178728.png">

The server-side changes are very minimal, and there are no changes to the plugin API.