### PR TITLE
FEATURE: Add setting to enable inline emoji translation

### DIFF
--- a/app/assets/javascripts/discourse/components/d-editor.js.es6
+++ b/app/assets/javascripts/discourse/components/d-editor.js.es6
@@ -410,12 +410,17 @@ export default Ember.Component.extend({
       },
 
       onKeyUp(text, cp) {
+        // Regular expressions used to extract emoji name from text.
+        // The space version requires a ' ' (space) before the emoji name
+        // (i.e. ' :smile'), while the other one does not and is used
+        // when enable_inline_emoji_translation is true.
+        const noSpaceColonEmoji = /(:(?!:).?[\w-]*:?(?!:)(?:t\d?)?:?) ?$/gi;
+        const spaceColonEmoji = /(?:^|[^a-z])(:(?!:).?[\w-]*:?(?!:)(?:t\d?)?:?) ?$/gi;
+
         const regex = self.siteSettings.enable_inline_emoji_translation
-          ? /(:(?!:).?[\w-]*:?(?!:)(?:t\d?)?:?) ?$/gi
-          : /(?:^|[^a-z])(:(?!:).?[\w-]*:?(?!:)(?:t\d?)?:?) ?$/gi;
-
+          ? noSpaceColonEmoji
+          : spaceColonEmoji;
         const matches = regex.exec(text.substring(0, cp));
-
         if (matches && matches[1]) {
           return [matches[1]];
         }

--- a/app/assets/javascripts/discourse/components/d-editor.js.es6
+++ b/app/assets/javascripts/discourse/components/d-editor.js.es6
@@ -410,9 +410,11 @@ export default Ember.Component.extend({
       },
 
       onKeyUp(text, cp) {
-        const matches = /(?:^|[^a-z])(:(?!:).?[\w-]*:?(?!:)(?:t\d?)?:?) ?$/gi.exec(
-          text.substring(0, cp)
-        );
+        const regex = self.siteSettings.enable_inline_emoji_translation
+          ? /(:(?!:).?[\w-]*:?(?!:)(?:t\d?)?:?) ?$/gi
+          : /(?:^|[^a-z])(:(?!:).?[\w-]*:?(?!:)(?:t\d?)?:?) ?$/gi;
+
+        const matches = regex.exec(text.substring(0, cp));
 
         if (matches && matches[1]) {
           return [matches[1]];

--- a/app/assets/javascripts/pretty-text/engines/discourse-markdown/emoji.js.es6
+++ b/app/assets/javascripts/pretty-text/engines/discourse-markdown/emoji.js.es6
@@ -57,7 +57,7 @@ function imageFor(code, opts) {
   }
 }
 
-function getEmojiName(content, pos, state) {
+function getEmojiName(content, pos, state, inlineEmoji) {
   if (content.charCodeAt(pos) !== 58) {
     return;
   }
@@ -65,6 +65,7 @@ function getEmojiName(content, pos, state) {
   if (pos > 0) {
     let prev = content.charCodeAt(pos - 1);
     if (
+      !inlineEmoji &&
       !state.md.utils.isSpace(prev) &&
       !state.md.utils.isPunctChar(String.fromCharCode(prev))
     ) {
@@ -173,7 +174,13 @@ function getEmojiTokenByTranslation(content, pos, state) {
   }
 }
 
-function applyEmoji(content, state, emojiUnicodeReplacer, enableShortcuts) {
+function applyEmoji(
+  content,
+  state,
+  emojiUnicodeReplacer,
+  enableShortcuts,
+  inlineEmoji
+) {
   let i;
   let result = null;
   let contentToken = null;
@@ -188,7 +195,7 @@ function applyEmoji(content, state, emojiUnicodeReplacer, enableShortcuts) {
 
   for (i = 0; i < content.length - 1; i++) {
     let offset = 0;
-    let emojiName = getEmojiName(content, i, state);
+    let emojiName = getEmojiName(content, i, state, inlineEmoji);
     let token = null;
 
     if (emojiName) {
@@ -235,6 +242,7 @@ export function setup(helper) {
   helper.registerOptions((opts, siteSettings, state) => {
     opts.features.emoji = !!siteSettings.enable_emoji;
     opts.features.emojiShortcuts = !!siteSettings.enable_emoji_shortcuts;
+    opts.features.inlineEmoji = !!siteSettings.enable_inline_emoji_translation;
     opts.emojiSet = siteSettings.emoji_set || "";
     opts.customEmoji = state.customEmoji;
   });
@@ -246,7 +254,8 @@ export function setup(helper) {
           c,
           s,
           md.options.discourse.emojiUnicodeReplacer,
-          md.options.discourse.features.emojiShortcuts
+          md.options.discourse.features.emojiShortcuts,
+          md.options.discourse.features.inlineEmoji
         )
       )
     );

--- a/app/assets/javascripts/pretty-text/engines/discourse-markdown/emoji.js.es6
+++ b/app/assets/javascripts/pretty-text/engines/discourse-markdown/emoji.js.es6
@@ -195,7 +195,7 @@ function applyEmoji(
 
   for (i = 0; i < content.length - 1; i++) {
     let offset = 0;
-    let emojiName = getEmojiName(content, i, state, inlineEmoji);
+    const emojiName = getEmojiName(content, i, state, inlineEmoji);
     let token = null;
 
     if (emojiName) {

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1779,6 +1779,7 @@ en:
     enable_emoji_shortcuts: "Common smiley text such as :) :p :( will be converted to emojis"
     emoji_set: "How would you like your emoji?"
     emoji_autocomplete_min_chars: "Minimum number of characters required to trigger autocomplete emoji popup"
+    enable_inline_emoji_translation: "Enables translation for inline emojis (without any space or punctuation before)"
 
     approve_post_count: "The amount of posts from a new or basic user that must be approved"
     approve_unless_trust_level: "Posts for users below this trust level must be approved"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -746,6 +746,14 @@ posting:
     default: 0
     locale_default:
       fr: 1
+  enable_inline_emoji_translation:
+    client: true
+    default: false
+    locale_default:
+      zh_CN: true
+      zh_TW: true
+      ja: true
+      ko: true
   approve_post_count:
     default: 0
   approve_unless_trust_level:

--- a/test/javascripts/lib/pretty-text-test.js.es6
+++ b/test/javascripts/lib/pretty-text-test.js.es6
@@ -1364,7 +1364,7 @@ QUnit.test("emoji - enable_inline_emoji_translation", assert => {
   assert.cookedOptions(
     "test:smile:test",
     { siteSettings: { enable_inline_emoji_translation: true } },
-    `<p>test<img src="/images/emoji/twitter/smile.png?v=${v}" title=":smile:" class="emoji" alt=":smile:">test</p>`
+    `<p>test<img src="/images/emoji/emoji_one/smile.png?v=${v}" title=":smile:" class="emoji" alt=":smile:">test</p>`
   );
 });
 

--- a/test/javascripts/lib/pretty-text-test.js.es6
+++ b/test/javascripts/lib/pretty-text-test.js.es6
@@ -1354,6 +1354,20 @@ QUnit.test("emoji", assert => {
   );
 });
 
+QUnit.test("emoji - enable_inline_emoji_translation", assert => {
+  assert.cookedOptions(
+    "test:smile:test",
+    { siteSettings: { enable_inline_emoji_translation: false } },
+    `<p>test:smile:test</p>`
+  );
+
+  assert.cookedOptions(
+    "test:smile:test",
+    { siteSettings: { enable_inline_emoji_translation: true } },
+    `<p>test<img src="/images/emoji/twitter/smile.png?v=${v}" title=":smile:" class="emoji" alt=":smile:">test</p>`
+  );
+});
+
 QUnit.test("emoji - emojiSet", assert => {
   assert.cookedOptions(
     ":smile:",


### PR DESCRIPTION
There is a minor issue which prevents the autocomplete from showing up on just ":" (but works with ":s" for example).