### PR TITLE
FIX: do not agree flags by default when deleting posts

### DIFF
--- a/app/controllers/admin/flags_controller.rb
+++ b/app/controllers/admin/flags_controller.rb
@@ -86,8 +86,7 @@ class Admin::FlagsController < Admin::AdminController
     restore_post = params[:action_on_post] == "restore"
 
     if delete_post
-      # PostDestroy calls PostAction.agree_flags!
-      destroy_post(post)
+      destroy_post(post, agree_flags: true)
     elsif restore_post
       PostAction.agree_flags!(post, current_user, delete_post)
       PostDestroyer.new(current_user, post).recover
@@ -138,12 +137,12 @@ class Admin::FlagsController < Admin::AdminController
 
   private
 
-  def destroy_post(post)
+  def destroy_post(post, agree_flags: false)
     if post.is_first_post?
       topic = Topic.find_by(id: post.topic_id)
       guardian.ensure_can_delete!(topic) if topic.present?
     end
 
-    PostDestroyer.new(current_user, post).destroy
+    PostDestroyer.new(current_user, post, agree_flags: agree_flags).destroy
   end
 end

--- a/spec/components/post_destroyer_spec.rb
+++ b/spec/components/post_destroyer_spec.rb
@@ -632,13 +632,13 @@ describe PostDestroyer do
     let!(:flag) { PostAction.act(moderator, second_post, PostActionType.types[:off_topic]) }
 
     before do
-      SiteSetting.queue_jobs = false
+      Jobs::SendSystemMessage.clear
     end
 
     it "should delete public post actions and agree with flags" do
       second_post.expects(:update_flagged_posts_count)
 
-      PostDestroyer.new(moderator, second_post).destroy
+      PostDestroyer.new(moderator, second_post, agree_flags: true).destroy
 
       expect(PostAction.find_by(id: bookmark.id)).to eq(nil)
 
@@ -650,36 +650,39 @@ describe PostDestroyer do
       expect(second_post.bookmark_count).to eq(0)
       expect(second_post.off_topic_count).to eq(1)
 
-      notification = second_post.user.notifications.where(notification_type: Notification.types[:private_message]).last
-      expect(notification).to be_present
-      expect(notification.topic.title).to eq(I18n.t('system_messages.flags_agreed_and_post_deleted.subject_template'))
+      expect(Jobs::SendSystemMessage.jobs.size).to eq(1)
     end
 
     it "should not send the flags_agreed_and_post_deleted message if it was deleted by system" do
-      second_post.expects(:update_flagged_posts_count)
-      PostDestroyer.new(Discourse.system_user, second_post).destroy
-      expect(
-        Topic.where(title: I18n.t('system_messages.flags_agreed_and_post_deleted.subject_template')).exists?
-      ).to eq(false)
+      expect(PostAction.flagged_posts_count).to eq(1)
+      PostDestroyer.new(Discourse.system_user, second_post, agree_flags: true).destroy
+      expect(Jobs::SendSystemMessage.jobs.size).to eq(0)
+      expect(PostAction.flagged_posts_count).to eq(0)
     end
 
     it "should not send the flags_agreed_and_post_deleted message if it was deleted by author" do
       SiteSetting.delete_removed_posts_after = 0
-      second_post.expects(:update_flagged_posts_count)
-      PostDestroyer.new(second_post.user, second_post).destroy
-      expect(
-        Topic.where(title: I18n.t('system_messages.flags_agreed_and_post_deleted.subject_template')).exists?
-      ).to eq(false)
+      expect(PostAction.flagged_posts_count).to eq(1)
+      PostDestroyer.new(second_post.user, second_post, agree_flags: true).destroy
+      expect(Jobs::SendSystemMessage.jobs.size).to eq(0)
+      expect(PostAction.flagged_posts_count).to eq(0)
     end
 
     it "should not send the flags_agreed_and_post_deleted message if flags were deferred" do
-      second_post.expects(:update_flagged_posts_count)
+      expect(PostAction.flagged_posts_count).to eq(1)
       PostAction.defer_flags!(second_post, moderator)
       second_post.reload
-      PostDestroyer.new(moderator, second_post).destroy
-      expect(
-        Topic.where(title: I18n.t('system_messages.flags_agreed_and_post_deleted.subject_template')).exists?
-      ).to eq(false)
+      expect(PostAction.flagged_posts_count).to eq(0)
+
+      PostDestroyer.new(moderator, second_post, agree_flags: true).destroy
+      expect(Jobs::SendSystemMessage.jobs.size).to eq(0)
+    end
+
+    it "should not send the flags_agreed_and_post_deleted message if agree_flags is false" do
+      expect(PostAction.flagged_posts_count).to eq(1)
+      PostDestroyer.new(moderator, second_post, agree_flags: false).destroy
+      expect(Jobs::SendSystemMessage.jobs.size).to eq(0)
+      expect(PostAction.flagged_posts_count).to eq(0)
     end
 
     it "should set the deleted_public_actions custom field" do


### PR DESCRIPTION
When bulk deleting posts we were agreeing with flags on the deleted posts. Now by default we will defer flags, unless the flag is mark as agreed explicitly.