### PR TITLE
FIX: popular posts font weight in summary email

### DIFF
--- a/app/views/user_notifications/digest.html.erb
+++ b/app/views/user_notifications/digest.html.erb
@@ -247,7 +247,7 @@ body, table, td, th, h1, h2, h3 {font-family: Helvetica, Arial, sans-serif !impo
 <table dir="<%= rtl? ? 'rtl' : 'ltr' %>" style="width:100%;background:#fefefe;border-spacing:0;padding:0;text-align:<%= rtl? ? 'right' : 'left' %>;vertical-align:top;">
   <tbody>
     <tr>
-      <td class="post-excerpt" style="color:#0a0a0a;font-size:14px;font-weight:200;padding:16px;text-align:<%= rtl? ? 'right' : 'left' %>;width:100%;">
+      <td class="post-excerpt" style="color:#0a0a0a;font-size:14px;font-weight:normal;padding:16px;text-align:<%= rtl? ? 'right' : 'left' %>;width:100%;">
         <%= email_excerpt(post.cooked) %>
       </td>
     </tr>


### PR DESCRIPTION
https://meta.discourse.org/t/how-do-i-change-the-font-color-of-summary-e-mail-popular-post-excerpts-on-mobile/102727