### PR TITLE
DEV: exposes getPluginApi

### DIFF
--- a/app/assets/javascripts/discourse/lib/plugin-api.js.es6
+++ b/app/assets/javascripts/discourse/lib/plugin-api.js.es6
@@ -39,7 +39,7 @@ import Sharing from "discourse/lib/sharing";
 import { addComposerUploadHandler } from "discourse/components/composer-editor";
 
 // If you add any methods to the API ensure you bump up this number
-const PLUGIN_API_VERSION = "0.8.25";
+const PLUGIN_API_VERSION = "0.8.26";
 
 class PluginApi {
   constructor(version, container) {
@@ -796,7 +796,7 @@ function cmpVersions(a, b) {
   return segmentsA.length - segmentsB.length;
 }
 
-function getPluginApi(version) {
+export function getPluginApi(version) {
   version = version.toString();
   if (cmpVersions(version, PLUGIN_API_VERSION) <= 0) {
     if (!_pluginv01) {


### PR DESCRIPTION
This allows to make this kind of check in plugin initializers:

```
    if (getPluginApi("0.8.26")) {
      withPluginApi("0.8.26", api => doNewThing(api, container));
    } else {
      withPluginApi("0.8.13", api => doOldThing(api, container));
    }
```