### PR TITLE
FIX: revert to using _.each

### DIFF
--- a/app/assets/javascripts/discourse/models/topic-tracking-state.js.es6
+++ b/app/assets/javascripts/discourse/models/topic-tracking-state.js.es6
@@ -373,7 +373,7 @@ const TopicTrackingState = Discourse.Model.extend({
 
   countCategory(category_id) {
     let sum = 0;
-    this.states.forEach(topic => {
+    _.each(this.states, topic => {
       if (topic.category_id === category_id && !topic.deleted) {
         sum +=
           topic.last_read_post_number === null ||


### PR DESCRIPTION
Should be replaced with Object.keys variation when reproducible