### PR TITLE
FEATURE: Multisite support for S3 image stores

### DIFF
--- a/lib/file_store/base_store.rb
+++ b/lib/file_store/base_store.rb
@@ -28,6 +28,10 @@ module FileStore
       not_implemented
     end
 
+    def upload_path
+      "uploads/#{RailsMultisite::ConnectionManagement.current_db}"
+    end
+
     def has_been_uploaded?(url)
       not_implemented
     end

--- a/lib/file_store/base_store.rb
+++ b/lib/file_store/base_store.rb
@@ -29,7 +29,7 @@ module FileStore
     end
 
     def upload_path
-      "uploads/#{RailsMultisite::ConnectionManagement.current_db}"
+      File.join("uploads", RailsMultisite::ConnectionManagement.current_db)
     end
 
     def has_been_uploaded?(url)

--- a/lib/file_store/local_store.rb
+++ b/lib/file_store/local_store.rb
@@ -32,12 +32,8 @@ module FileStore
       "#{Discourse.asset_host}#{relative_base_url}"
     end
 
-    def upload_path
-      "/uploads/#{RailsMultisite::ConnectionManagement.current_db}"
-    end
-
     def relative_base_url
-      "#{Discourse.base_uri}#{upload_path}"
+      "#{Discourse.base_uri}/#{upload_path}"
     end
 
     def external?
@@ -68,7 +64,7 @@ module FileStore
     end
 
     def get_path_for(type, upload_id, sha, extension)
-      "#{upload_path}/#{super(type, upload_id, sha, extension)}"
+      "/#{upload_path}/#{super(type, upload_id, sha, extension)}"
     end
 
     def copy_file(file, path)

--- a/lib/file_store/local_store.rb
+++ b/lib/file_store/local_store.rb
@@ -33,7 +33,7 @@ module FileStore
     end
 
     def relative_base_url
-      "#{Discourse.base_uri}/#{upload_path}"
+      "#{Discourse.base_uri}#{upload_path}"
     end
 
     def external?
@@ -42,7 +42,7 @@ module FileStore
 
     def download_url(upload)
       return unless upload
-      "#{relative_base_url}/#{upload.sha1}"
+      File.join(relative_base_url, upload.sha1)
     end
 
     def cdn_url(url)
@@ -64,7 +64,7 @@ module FileStore
     end
 
     def get_path_for(type, upload_id, sha, extension)
-      "/#{upload_path}/#{super(type, upload_id, sha, extension)}"
+      File.join("/", upload_path, super(type, upload_id, sha, extension))
     end
 
     def copy_file(file, path)
@@ -86,7 +86,7 @@ module FileStore
     end
 
     def public_dir
-      "#{Rails.root}/public"
+      File.join(Rails.root, "public")
     end
 
     def tombstone_dir
@@ -101,15 +101,13 @@ module FileStore
     private
 
     def list_missing(model)
-      public_directory = "#{Rails.root}/public"
-
       count = 0
       model.find_each do |upload|
 
         # could be a remote image
         next unless upload.url =~ /^\/[^\/]/
 
-        path = "#{public_directory}#{upload.url}"
+        path = "#{public_dir}#{upload.url}"
         bad = true
         begin
           bad = false if File.size(path) != 0

--- a/lib/file_store/s3_store.rb
+++ b/lib/file_store/s3_store.rb
@@ -42,11 +42,11 @@ module FileStore
       options[:content_disposition] = "attachment; filename=\"#{filename}\"" unless FileHelper.is_supported_image?(filename)
       # if this fails, it will throw an exception
 
-      path.prepend("#{upload_path}/") if RailsMultisite::ConnectionManagement.current_db != "default"
+      path.prepend(File.join(upload_path, "/")) if RailsMultisite::ConnectionManagement.current_db != "default"
       path = @s3_helper.upload(file, path, options)
 
       # return the upload url
-      "#{absolute_base_url}/#{path}"
+      File.join(absolute_base_url, path)
     end
 
     def remove_file(url, path)
@@ -96,7 +96,7 @@ module FileStore
       return url if SiteSetting.Upload.s3_cdn_url.blank?
       schema = url[/^(https?:)?\/\//, 1]
       folder = @s3_helper.s3_bucket_folder_path.nil? ? "" : "#{@s3_helper.s3_bucket_folder_path}/"
-      url.sub("#{schema}#{absolute_base_url}/#{folder}", "#{SiteSetting.Upload.s3_cdn_url}/")
+      url.sub(File.join("#{schema}#{absolute_base_url}", folder), File.join(SiteSetting.Upload.s3_cdn_url, "/"))
     end
 
     def cache_avatar(avatar, user_id)

--- a/lib/file_store/s3_store.rb
+++ b/lib/file_store/s3_store.rb
@@ -41,7 +41,10 @@ module FileStore
       # add a "content disposition" header for "attachments"
       options[:content_disposition] = "attachment; filename=\"#{filename}\"" unless FileHelper.is_supported_image?(filename)
       # if this fails, it will throw an exception
+
+      path.prepend("#{upload_path}/") if RailsMultisite::ConnectionManagement.current_db != "default"
       path = @s3_helper.upload(file, path, options)
+
       # return the upload url
       "#{absolute_base_url}/#{path}"
     end

--- a/spec/multisite/s3_store_spec.rb
+++ b/spec/multisite/s3_store_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+require 'file_store/s3_store'
+
+RSpec.describe 'Multisite s3 uploads', type: :multisite do
+  let(:conn) { RailsMultisite::ConnectionManagement }
+  let(:store) { FileStore::S3Store.new }
+  let(:s3_helper) { store.instance_variable_get(:@s3_helper) }
+  let(:uploaded_file) { file_from_fixtures("logo.png") }
+
+  before(:each) do
+    SiteSetting.s3_upload_bucket = "s3-upload-bucket"
+    SiteSetting.s3_access_key_id = "s3-access-key-id"
+    SiteSetting.s3_secret_access_key = "s3-secret-access-key"
+    SiteSetting.enable_s3_uploads = true
+  end
+
+  shared_context 's3 helpers' do
+    let(:store) { FileStore::S3Store.new }
+    let(:client) { Aws::S3::Client.new(stub_responses: true) }
+    let(:resource) { Aws::S3::Resource.new(client: client) }
+    let(:s3_bucket) { resource.bucket("s3-upload-bucket") }
+    let(:s3_helper) { store.instance_variable_get(:@s3_helper) }
+  end
+
+  context 'uploading to s3' do
+    include_context "s3 helpers"
+
+    describe "#store_upload" do
+      it "returns the correct url for default multisite db" do
+        s3_helper.expects(:s3_bucket).returns(s3_bucket).at_least_once
+        s3_object = stub
+        upload = Fabricate(:upload, sha1: Digest::SHA1.hexdigest('secreet image string'))
+
+        conn.with_connection('default') do
+          s3_bucket.expects(:object).with("original/1X/#{upload.sha1}.png").returns(s3_object)
+          s3_object.expects(:upload_file)
+
+          expect(store.store_upload(uploaded_file, upload)).to eq(
+          "//s3-upload-bucket.s3.dualstack.us-east-1.amazonaws.com/original/1X/#{upload.sha1}.png"
+          )
+        end
+      end
+
+      it "returns the correct url for second multisite db" do
+        s3_helper.expects(:s3_bucket).returns(s3_bucket).at_least_once
+        s3_object = stub
+        upload = Fabricate(:upload, sha1: Digest::SHA1.hexdigest('secreet second string'))
+
+        conn.with_connection('second') do
+          s3_bucket.expects(:object).with("uploads/second/original/1X/#{upload.sha1}.png").returns(s3_object)
+          s3_object.expects(:upload_file)
+
+          expect(store.store_upload(uploaded_file, upload)).to eq(
+          "//s3-upload-bucket.s3.dualstack.us-east-1.amazonaws.com/uploads/second/original/1X/#{upload.sha1}.png"
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/multisite/s3_store_spec.rb
+++ b/spec/multisite/s3_store_spec.rb
@@ -3,55 +3,37 @@ require 'file_store/s3_store'
 
 RSpec.describe 'Multisite s3 uploads', type: :multisite do
   let(:conn) { RailsMultisite::ConnectionManagement }
-  let(:store) { FileStore::S3Store.new }
-  let(:s3_helper) { store.instance_variable_get(:@s3_helper) }
-  let(:uploaded_file) { file_from_fixtures("logo.png") }
+  let(:uploaded_file) { file_from_fixtures("smallest.png") }
 
-  before(:each) do
-    SiteSetting.s3_upload_bucket = "s3-upload-bucket"
-    SiteSetting.s3_access_key_id = "s3-access-key-id"
-    SiteSetting.s3_secret_access_key = "s3-secret-access-key"
-    SiteSetting.enable_s3_uploads = true
+  let(:upload) do
+    Fabricate(:upload, sha1: Digest::SHA1.hexdigest(File.read(uploaded_file)))
   end
 
-  shared_context 's3 helpers' do
-    let(:store) { FileStore::S3Store.new }
-    let(:client) { Aws::S3::Client.new(stub_responses: true) }
-    let(:resource) { Aws::S3::Resource.new(client: client) }
-    let(:s3_bucket) { resource.bucket("s3-upload-bucket") }
-    let(:s3_helper) { store.instance_variable_get(:@s3_helper) }
+  let(:s3_client) { Aws::S3::Client.new(stub_responses: true) }
+
+  let(:s3_helper) do
+    S3Helper.new(SiteSetting.s3_upload_bucket, '', client: s3_client)
   end
+
+  let(:store) { FileStore::S3Store.new(s3_helper) }
 
   context 'uploading to s3' do
-    include_context "s3 helpers"
+    before(:each) do
+      SiteSetting.s3_upload_bucket = "some-really-cool-bucket"
+      SiteSetting.s3_access_key_id = "s3-access-key-id"
+      SiteSetting.s3_secret_access_key = "s3-secret-access-key"
+      SiteSetting.enable_s3_uploads = true
+    end
 
     describe "#store_upload" do
-      it "returns the correct url for default multisite db" do
-        s3_helper.expects(:s3_bucket).returns(s3_bucket).at_least_once
-        s3_object = stub
-        upload = Fabricate(:upload, sha1: Digest::SHA1.hexdigest('secreet image string'))
-
-        conn.with_connection('default') do
-          s3_bucket.expects(:object).with("original/1X/#{upload.sha1}.png").returns(s3_object)
-          s3_object.expects(:upload_file)
-
-          expect(store.store_upload(uploaded_file, upload)).to eq(
-          "//s3-upload-bucket.s3.dualstack.us-east-1.amazonaws.com/original/1X/#{upload.sha1}.png"
-          )
-        end
-      end
-
-      it "returns the correct url for second multisite db" do
-        s3_helper.expects(:s3_bucket).returns(s3_bucket).at_least_once
-        s3_object = stub
-        upload = Fabricate(:upload, sha1: Digest::SHA1.hexdigest('secreet second string'))
+      it "returns the correct url for default and second multisite db" do
+        expect(store.store_upload(uploaded_file, upload)).to eq(
+          "//#{SiteSetting.s3_upload_bucket}.s3.dualstack.us-east-1.amazonaws.com/original/1X/c530c06cf89c410c0355d7852644a73fc3ec8c04.png"
+        )
 
         conn.with_connection('second') do
-          s3_bucket.expects(:object).with("uploads/second/original/1X/#{upload.sha1}.png").returns(s3_object)
-          s3_object.expects(:upload_file)
-
           expect(store.store_upload(uploaded_file, upload)).to eq(
-          "//s3-upload-bucket.s3.dualstack.us-east-1.amazonaws.com/uploads/second/original/1X/#{upload.sha1}.png"
+            "//#{SiteSetting.s3_upload_bucket}.s3.dualstack.us-east-1.amazonaws.com/uploads/second/original/1X/c530c06cf89c410c0355d7852644a73fc3ec8c04.png"
           )
         end
       end


### PR DESCRIPTION
- [x] Update the stores to store uploads ONLY for multisite sites into the right folders. 
- [x] Leave uploads and backups for the default site as it is.