### PR TITLE
FIX: throw error when link in reason for grant badge is an external link

### DIFF
--- a/app/controllers/user_badges_controller.rb
+++ b/app/controllers/user_badges_controller.rb
@@ -50,8 +50,7 @@ class UserBadgesController < ApplicationController
     user = fetch_user_from_params
 
     unless can_assign_badge_to_user?(user)
-      render json: failed_json, status: 403
-      return
+      return render json: failed_json, status: 403
     end
 
     badge = fetch_badge_from_params
@@ -59,8 +58,7 @@ class UserBadgesController < ApplicationController
 
     if params[:reason].present?
       unless is_badge_reason_valid? params[:reason]
-        render json: { failed: 'External link not allowed in reason' }, status: 400
-        return
+        return render json: { failed: I18n.t('invalid_grant_badge_reason_link') }, status: 400
       end
 
       path = begin
@@ -123,12 +121,6 @@ class UserBadgesController < ApplicationController
   end
 
   def is_badge_reason_valid?(reason)
-    uri = URI.parse(reason)
-
-    if uri && uri.scheme && uri.host
-      return Discourse.base_url == "#{uri.scheme}://#{uri.host}"
-    else
-      return false
-    end
+    return Discourse.route_for(reason)
   end
 end

--- a/app/controllers/user_badges_controller.rb
+++ b/app/controllers/user_badges_controller.rb
@@ -58,6 +58,11 @@ class UserBadgesController < ApplicationController
     post_id = nil
 
     if params[:reason].present?
+      unless is_badge_reason_valid? params[:reason]
+        render json: { failed: 'External link not allowed in reason' }, status: 400
+        return
+      end
+
       path = begin
         URI.parse(params[:reason]).path
       rescue URI::Error
@@ -115,5 +120,15 @@ class UserBadgesController < ApplicationController
 
   def ensure_badges_enabled
     raise Discourse::NotFound unless SiteSetting.enable_badges?
+  end
+
+  def is_badge_reason_valid?(reason)
+    uri = URI.parse(reason)
+
+    if uri && uri.scheme && uri.host
+      return Discourse.base_url == "#{uri.scheme}://#{uri.host}"
+    else
+      return false
+    end
   end
 end

--- a/app/controllers/user_badges_controller.rb
+++ b/app/controllers/user_badges_controller.rb
@@ -121,6 +121,7 @@ class UserBadgesController < ApplicationController
   end
 
   def is_badge_reason_valid?(reason)
-    return Discourse.route_for(reason)
+    route = Discourse.route_for(reason)
+    route && (route[:controller] == 'posts' || route[:controller] == 'topics')
   end
 end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -210,6 +210,7 @@ en:
   provider_not_enabled: "You are not permitted to view the requested resource. The authentication provider is not enabled."
   provider_not_found: "You are not permitted to view the requested resource. The authentication provider does not exist."
   read_only_mode_enabled: "The site is in read only mode. Interactions are disabled."
+  invalid_grant_badge_reason_link: "External or invalid discourse link is not allowed in badge reason"
 
   reading_time: "Reading time"
   likes: "Likes"

--- a/spec/requests/user_badges_controller_spec.rb
+++ b/spec/requests/user_badges_controller_spec.rb
@@ -158,6 +158,21 @@ describe UserBadgesController do
 
       expect(response.status).to eq(400)
     end
+
+    it 'does not grant badge if invalid discourse link is used in reason' do
+      admin = Fabricate(:admin)
+      post_1 = create_post
+
+      sign_in(admin)
+
+      post "/user_badges.json", params: {
+        badge_id: badge.id,
+        username: user.username,
+        reason: Discourse.base_url + "/random_url/" + post_1.url
+      }
+
+      expect(response.status).to eq(400)
+    end
   end
 
   context 'destroy' do

--- a/spec/requests/user_badges_controller_spec.rb
+++ b/spec/requests/user_badges_controller_spec.rb
@@ -146,14 +146,14 @@ describe UserBadgesController do
 
     it 'does not grant badge when external link is used in reason' do
       admin = Fabricate(:admin)
-      post_1 = create_post
+      post = create_post
 
       sign_in(admin)
 
       post "/user_badges.json", params: {
         badge_id: badge.id,
         username: user.username,
-        reason: "http://example.com/" + post_1.url
+        reason: "http://example.com/" + post.url
       }
 
       expect(response.status).to eq(400)
@@ -161,14 +161,14 @@ describe UserBadgesController do
 
     it 'does not grant badge if invalid discourse post/topic link is used in reason' do
       admin = Fabricate(:admin)
-      post_1 = create_post
+      post = create_post
 
       sign_in(admin)
 
       post "/user_badges.json", params: {
         badge_id: badge.id,
         username: user.username,
-        reason: Discourse.base_url + "/random_url/" + post_1.url
+        reason: Discourse.base_url + "/random_url/" + post.url
       }
 
       expect(response.status).to eq(400)
@@ -176,14 +176,14 @@ describe UserBadgesController do
 
     it 'grants badge when valid post/topic link is given in reason' do
       admin = Fabricate(:admin)
-      post_1 = create_post
+      post = create_post
 
       sign_in(admin)
 
       post "/user_badges.json", params: {
         badge_id: badge.id,
         username: user.username,
-        reason: Discourse.base_url + '/t/incorrect-usage-of-week-month-year-units-in-a-translated-string/98931'
+        reason: Discourse.base_url + post.url
       }
 
       expect(response.status).to eq(200)

--- a/spec/requests/user_badges_controller_spec.rb
+++ b/spec/requests/user_badges_controller_spec.rb
@@ -143,6 +143,21 @@ describe UserBadgesController do
 
       expect(events).to include(:user_badge_granted)
     end
+
+    it 'does not grant badge when external link is used in reason' do
+      admin = Fabricate(:admin)
+      post_1 = create_post
+
+      sign_in(admin)
+
+      post "/user_badges.json", params: {
+        badge_id: badge.id,
+        username: user.username,
+        reason: "http://example.com/" + post_1.url
+      }
+
+      expect(response.status).to eq(400)
+    end
   end
 
   context 'destroy' do

--- a/spec/requests/user_badges_controller_spec.rb
+++ b/spec/requests/user_badges_controller_spec.rb
@@ -159,7 +159,7 @@ describe UserBadgesController do
       expect(response.status).to eq(400)
     end
 
-    it 'does not grant badge if invalid discourse link is used in reason' do
+    it 'does not grant badge if invalid discourse post/topic link is used in reason' do
       admin = Fabricate(:admin)
       post_1 = create_post
 
@@ -172,6 +172,21 @@ describe UserBadgesController do
       }
 
       expect(response.status).to eq(400)
+    end
+
+    it 'grants badge when valid post/topic link is given in reason' do
+      admin = Fabricate(:admin)
+      post_1 = create_post
+
+      sign_in(admin)
+
+      post "/user_badges.json", params: {
+        badge_id: badge.id,
+        username: user.username,
+        reason: Discourse.base_url + '/t/incorrect-usage-of-week-month-year-units-in-a-translated-string/98931'
+      }
+
+      expect(response.status).to eq(200)
     end
   end
 


### PR DESCRIPTION
https://meta.discourse.org/t/adding-an-external-link-to-the-reason-field-badge-fails-silently/95847