### PR TITLE
Suppress tar(1)'s output

### DIFF
--- a/spec/components/theme_store/tgz_importer_spec.rb
+++ b/spec/components/theme_store/tgz_importer_spec.rb
@@ -23,7 +23,7 @@ describe ThemeStore::TgzImporter do
       FileUtils.mkdir('test/a')
       File.write("test/a/inner", "hello world inner")
 
-      `tar -cvzf test.tar.gz test/*`
+      `tar -cvzf test.tar.gz test/* 2> /dev/null`
     end
 
     importer = ThemeStore::TgzImporter.new("#{@temp_folder}/test.tar.gz")


### PR DESCRIPTION
The `tar` command in this test produces output when running; send that to /dev/null instead.