### PR TITLE
FEATURE: Multisite support for S3 backup store

### DIFF
--- a/lib/backup_restore/backuper.rb
+++ b/lib/backup_restore/backuper.rb
@@ -83,7 +83,7 @@ module BackupRestore
       @timestamp = Time.now.strftime("%Y-%m-%d-%H%M%S")
       @tmp_directory = File.join(Rails.root, "tmp", "backups", @current_db, @timestamp)
       @dump_filename = File.join(@tmp_directory, BackupRestore::DUMP_FILE)
-      @archive_directory = BackupRestore::LocalBackupStore.base_directory(@current_db)
+      @archive_directory = BackupRestore::LocalBackupStore.base_directory(db: @current_db)
       filename = @filename_override || "#{SiteSetting.title.parameterize}-#{@timestamp}"
       @archive_basename = File.join(@archive_directory, "#{filename}-#{BackupRestore::VERSION_PREFIX}#{BackupRestore.current_version}")
 

--- a/lib/backup_restore/local_backup_store.rb
+++ b/lib/backup_restore/local_backup_store.rb
@@ -3,9 +3,11 @@ require_dependency "disk_space"
 
 module BackupRestore
   class LocalBackupStore < BackupStore
-    def self.base_directory(current_db = nil)
-      current_db ||= RailsMultisite::ConnectionManagement.current_db
-      base_directory = File.join(Rails.root, "public", "backups", current_db)
+    def self.base_directory(db: nil, root_directory: nil)
+      current_db = db || RailsMultisite::ConnectionManagement.current_db
+      root_directory ||= File.join(Rails.root, "public", "backups")
+
+      base_directory = File.join(root_directory, current_db)
       FileUtils.mkdir_p(base_directory) unless Dir.exists?(base_directory)
       base_directory
     end
@@ -15,7 +17,7 @@ module BackupRestore
     end
 
     def initialize(opts = {})
-      @base_directory = opts[:base_directory] || LocalBackupStore.base_directory
+      @base_directory = LocalBackupStore.base_directory(root_directory: opts[:root_directory])
     end
 
     def remote?

--- a/lib/backup_restore/s3_backup_store.rb
+++ b/lib/backup_restore/s3_backup_store.rb
@@ -5,11 +5,12 @@ module BackupRestore
   class S3BackupStore < BackupStore
     DOWNLOAD_URL_EXPIRES_AFTER_SECONDS ||= 15
     UPLOAD_URL_EXPIRES_AFTER_SECONDS ||= 21_600 # 6 hours
+    MULTISITE_PREFIX = "backups"
 
     def initialize(opts = {})
       s3_options = S3Helper.s3_options(SiteSetting)
       s3_options.merge!(opts[:s3_options]) if opts[:s3_options]
-      @s3_helper = S3Helper.new(SiteSetting.s3_backup_bucket, '', s3_options)
+      @s3_helper = S3Helper.new(s3_bucket_name_with_prefix, '', s3_options)
     end
 
     def remote?
@@ -90,6 +91,14 @@ module BackupRestore
 
     def cleanup_allowed?
       !SiteSetting.s3_disable_cleanup
+    end
+
+    def s3_bucket_name_with_prefix
+      if Rails.configuration.multisite
+        File.join(SiteSetting.s3_backup_bucket, MULTISITE_PREFIX, RailsMultisite::ConnectionManagement.current_db)
+      else
+        SiteSetting.s3_backup_bucket
+      end
     end
   end
 end

--- a/spec/lib/backup_restore/shared_examples_for_backup_store.rb
+++ b/spec/lib/backup_restore/shared_examples_for_backup_store.rb
@@ -2,9 +2,14 @@ shared_context "backups" do
   before { create_backups }
   after(:all) { remove_backups }
 
+  # default backup files
   let(:backup1) { BackupFile.new(filename: "b.tar.gz", size: 17, last_modified: Time.parse("2018-09-13T15:10:00Z")) }
   let(:backup2) { BackupFile.new(filename: "a.tgz", size: 29, last_modified: Time.parse("2018-02-11T09:27:00Z")) }
   let(:backup3) { BackupFile.new(filename: "r.sql.gz", size: 11, last_modified: Time.parse("2017-12-20T03:48:00Z")) }
+
+  # backup files on another multisite
+  let(:backup4) { BackupFile.new(filename: "multi-1.tar.gz", size: 22, last_modified: Time.parse("2018-11-26T03:17:09Z")) }
+  let(:backup5) { BackupFile.new(filename: "multi-2.tar.gz", size: 19, last_modified: Time.parse("2018-11-27T03:16:54Z")) }
 end
 
 shared_examples "backup store" do
@@ -39,6 +44,12 @@ shared_examples "backup store" do
         expect(files).to_not be_empty
         expect(files.map(&:filename)).to contain_exactly(backup1.filename, backup2.filename, backup3.filename)
       end
+
+      it "works with multisite", type: :multisite do
+        RailsMultisite::ConnectionManagement.with_connection("second") do
+          expect(store.files).to eq([backup5, backup4])
+        end
+      end
     end
 
     describe "#latest_file" do
@@ -49,6 +60,12 @@ shared_examples "backup store" do
       it "returns nil when there are no files" do
         store.files.each { |file| store.delete_file(file.filename) }
         expect(store.latest_file).to be_nil
+      end
+
+      it "works with multisite", type: :multisite do
+        RailsMultisite::ConnectionManagement.with_connection("second") do
+          expect(store.latest_file).to eq(backup5)
+        end
       end
     end
 
@@ -66,6 +83,15 @@ shared_examples "backup store" do
         store.delete_old
         expect(store.files).to eq([backup1])
       end
+
+      it "works with multisite", type: :multisite do
+        SiteSetting.maximum_backups = 1
+
+        RailsMultisite::ConnectionManagement.with_connection("second") do
+          store.delete_old
+          expect(store.files).to eq([backup5])
+        end
+      end
     end
 
     describe "#file" do
@@ -79,7 +105,14 @@ shared_examples "backup store" do
 
       it "includes the file's source location if it is requested" do
         file = store.file(backup1.filename, include_download_source: true)
-        expect(file.source).to match(source_regex(backup1.filename))
+        expect(file.source).to match(source_regex("default", backup1.filename, multisite: false))
+      end
+
+      it "works with multisite", type: :multisite do
+        RailsMultisite::ConnectionManagement.with_connection("second") do
+          file = store.file(backup4.filename, include_download_source: true)
+          expect(file.source).to match(source_regex("second", backup4.filename, multisite: true))
+        end
       end
     end
 
@@ -94,6 +127,14 @@ shared_examples "backup store" do
 
       it "does nothing when the file doesn't exist" do
         expect { store.delete_file("foo.gz") }.to_not change { store.files }
+      end
+
+      it "works with multisite", type: :multisite do
+        RailsMultisite::ConnectionManagement.with_connection("second") do
+          expect(store.files).to include(backup5)
+          store.delete_file(backup5.filename)
+          expect(store.files).to_not include(backup5)
+        end
       end
     end
 
@@ -116,6 +157,14 @@ shared_examples "backup store" do
 
         expect { store.download_file(filename, destination_path) }.to raise_exception(StandardError)
       end
+
+      it "works with multisite", type: :multisite do
+        RailsMultisite::ConnectionManagement.with_connection("second") do
+          expect(store.files).to include(backup5)
+          store.delete_file(backup5.filename)
+          expect(store.files).to_not include(backup5)
+        end
+      end
     end
   end
 end
@@ -129,7 +178,7 @@ shared_examples "remote backup store" do
     include_context "backups"
 
     describe "#upload_file" do
-      it "uploads file into store" do
+      def upload_file
         freeze_time
 
         backup = BackupFile.new(
@@ -151,6 +200,16 @@ shared_examples "remote backup store" do
         expect(store.file(backup.filename)).to eq(backup)
       end
 
+      it "uploads file into store" do
+        upload_file
+      end
+
+      it "works with multisite", type: :multisite do
+        RailsMultisite::ConnectionManagement.with_connection("second") do
+          upload_file
+        end
+      end
+
       it "raises an exception when a file with same filename exists" do
         Tempfile.create(backup1.filename) do |file|
           expect { store.upload_file(backup1.filename, file.path, "application/gzip") }
@@ -164,12 +223,21 @@ shared_examples "remote backup store" do
         filename = "foo.tar.gz"
         url = store.generate_upload_url(filename)
 
-        expect(url).to match(upload_url_regex(filename))
+        expect(url).to match(upload_url_regex("default", filename, multisite: false))
       end
 
       it "raises an exeption when a file with same filename exists" do
         expect { store.generate_upload_url(backup1.filename) }
           .to raise_exception(BackupRestore::BackupStore::BackupFileExists)
+      end
+
+      it "works with multisite", type: :multisite do
+        RailsMultisite::ConnectionManagement.with_connection("second") do
+          filename = "foo.tar.gz"
+          url = store.generate_upload_url(filename)
+
+          expect(url).to match(upload_url_regex("second", filename, multisite: true))
+        end
       end
     end
   end


### PR DESCRIPTION
There are some specs missing and there's no migration yet. Still, @tgxworld can you take a quick look and tell me if I'm on the right path? I didn't have to make any big changes to `LocalBackupStore` in order to get the shared specs working, so I'm confident that the specs make sense.

The S3 backup store assumes that backups always are under the `/default` prefix even when there is no multisite. Is there a method to detect if there are multiple sites in case we don't want that behavior?