### PR TITLE
FIX: defer flags (only) when handling a flag and deleting replies

### DIFF
--- a/app/assets/javascripts/admin/models/flagged-post.js.es6
+++ b/app/assets/javascripts/admin/models/flagged-post.js.es6
@@ -136,7 +136,7 @@ export default Post.extend({
             label: I18n.t("yes_value"),
             class: "btn-danger",
             callback() {
-              Post.deleteMany(replies.map(r => r.id))
+              Post.deleteMany(replies.map(r => r.id), { deferFlags: true })
                 .then(action)
                 .then(resolve)
                 .catch(error => {

--- a/app/assets/javascripts/discourse/models/post.js.es6
+++ b/app/assets/javascripts/discourse/models/post.js.es6
@@ -369,10 +369,10 @@ Post.reopenClass({
     });
   },
 
-  deleteMany(post_ids) {
+  deleteMany(post_ids, { deferFlags = false } = {}) {
     return ajax("/posts/destroy_many", {
       type: "DELETE",
-      data: { post_ids }
+      data: { post_ids, defer_flags: deferFlags }
     });
   },
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -336,6 +336,7 @@ class PostsController < ApplicationController
 
   def destroy_many
     params.require(:post_ids)
+    defer_flags = params[:defer_flags] || false
 
     posts = Post.where(id: post_ids_including_replies)
     raise Discourse::InvalidParameters.new(:post_ids) if posts.blank?
@@ -344,7 +345,7 @@ class PostsController < ApplicationController
     posts.each { |p| guardian.ensure_can_delete!(p) }
 
     Post.transaction do
-      posts.each { |p| PostDestroyer.new(current_user, p).destroy }
+      posts.each { |p| PostDestroyer.new(current_user, p, defer_flags: defer_flags).destroy }
     end
 
     render body: nil

--- a/lib/post_destroyer.rb
+++ b/lib/post_destroyer.rb
@@ -147,7 +147,11 @@ class PostDestroyer
       update_user_counts
       TopicUser.update_post_action_cache(post_id: @post.id)
       DB.after_commit do
-        agree_with_flags
+        if @opts[:defer_flags].to_s == "true"
+          defer_flags
+        else
+          agree_with_flags
+        end
       end
     end
 
@@ -225,7 +229,7 @@ class PostDestroyer
     if @post.has_active_flag? && @user.id > 0 && @user.staff?
       Jobs.enqueue(
         :send_system_message,
-        user_id: @post.user.id,
+        user_id: @post.user_id,
         message_type: :flags_agreed_and_post_deleted,
         message_options: {
           url: @post.url,
@@ -239,6 +243,10 @@ class PostDestroyer
     end
 
     PostAction.agree_flags!(@post, @user, delete_post: true)
+  end
+
+  def defer_flags
+    PostAction.defer_flags!(@post, @user, delete_post: true)
   end
 
   def trash_user_actions


### PR DESCRIPTION
When deleting a flagged post and all child replies if the reply has a flag it will be deferred instead of being agreed with. All the other behaviour will remain same.