### PR TITLE
FIX: prevent minimum_required_tags on category being set to null

### DIFF
--- a/app/assets/javascripts/discourse/templates/components/edit-category-settings.hbs
+++ b/app/assets/javascripts/discourse/templates/components/edit-category-settings.hbs
@@ -169,7 +169,7 @@
     <label for="category-minimum-tags">
       {{i18n 'category.minimum_required_tags'}}
     </label>
-          {{text-field value=category.minimum_required_tags id="category-minimum-tags" type="number"}}
+          {{text-field value=category.minimum_required_tags id="category-minimum-tags" type="number" min="0"}}
 
   </section>
 {{/if}}

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -149,9 +149,8 @@ class CategoriesController < ApplicationController
       category_params.delete(:position)
 
       # properly null the value so the database constraint doesn't catch us
-      if category_params.has_key?(:email_in) && category_params[:email_in].blank?
-        category_params[:email_in] = nil
-      end
+      category_params[:email_in] = nil if category_params[:email_in]&.blank?
+      category_params[:minimum_required_tags] = 0 if category_params[:minimum_required_tags]&.blank?
 
       old_permissions = cat.permissions_params
 

--- a/db/migrate/20181129094518_add_not_null_minimum_required_tags_on_categories.rb
+++ b/db/migrate/20181129094518_add_not_null_minimum_required_tags_on_categories.rb
@@ -1,0 +1,5 @@
+class AddNotNullMinimumRequiredTagsOnCategories < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null :categories, :minimum_required_tags, false, 0
+  end
+end

--- a/spec/requests/categories_controller_spec.rb
+++ b/spec/requests/categories_controller_spec.rb
@@ -91,6 +91,7 @@ describe CategoriesController do
 
       it "raises an exception when the text color is missing" do
         post "/categories.json", params: { name: "hello", color: "ff0" }
+        expect(response.status).to eq(400)
       end
 
       describe "failure" do
@@ -299,6 +300,7 @@ describe CategoriesController do
             custom_fields: {
               "dancing" => "frogs"
             },
+            minimum_required_tags: ""
           }
 
           expect(response.status).to eq(200)
@@ -311,6 +313,7 @@ describe CategoriesController do
           expect(category.color).to eq("ff0")
           expect(category.auto_close_hours).to eq(72)
           expect(category.custom_fields).to eq("dancing" => "frogs")
+          expect(category.minimum_required_tags).to eq(0)
         end
 
         it 'logs the changes correctly' do


### PR DESCRIPTION
Fixes `NoMethodError (undefined method '>' for nil:NilClass) /var/www/discourse/lib/topic_creator.rb:161:in 'setup_tags'` from the logs