### PR TITLE
FEATURE: Use amazon s3 inventory to manage upload stats

### DIFF
--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -8,6 +8,7 @@ class SiteSetting < ActiveRecord::Base
   validates_presence_of :data_type
 
   after_save do |site_setting|
+    SiteSetting.refresh!
     DiscourseEvent.trigger(:site_setting_saved, site_setting)
     true
   end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -167,6 +167,7 @@ en:
         other: 'You specified the invalid choices %{name}'
       default_categories_already_selected: "You cannot select a category used in another list."
       s3_upload_bucket_is_required: "You cannot enable uploads to S3 unless you've provided the 's3_upload_bucket'."
+      s3_inventory_bucket_is_required: "You cannot enable inventory to S3 unless you've provided the 's3_inventory_bucket' and 's3_upload_bucket'."
       s3_backup_requires_s3_settings: "You cannot use S3 as backup location unless you've provided the '%{setting_name}'."
     conflicting_google_user_id: 'The Google Account ID for this account has changed; staff intervention is required for security reasons. Please contact staff and point them to <br><a href="https://meta.discourse.org/t/76575">https://meta.discourse.org/t/76575</a>'
 

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1037,6 +1037,11 @@ files:
   s3_configure_tombstone_policy:
     default: true
     shadowed_by_global: true
+  enable_s3_inventory:
+    default: false
+  s3_inventory_bucket:
+    default: ''
+    regex: '^[a-z0-9\-\/]+$' # can't use '.' when using HTTPS
   allow_profile_backgrounds:
     client: true
     default: true

--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -455,6 +455,13 @@ module Discourse
     end
   end
 
+  DiscourseEvent.on(:site_setting_saved) do |site_setting|
+    name = site_setting.name.to_s
+    if SiteSetting.enable_s3_uploads && (name.include?("s3_inventory") || name == "s3_upload_bucket")
+      store.inventory.update!
+    end
+  end
+
   def self.current_user_provider
     @current_user_provider || Auth::DefaultCurrentUserProvider
   end

--- a/lib/file_store/s3_store.rb
+++ b/lib/file_store/s3_store.rb
@@ -2,6 +2,7 @@ require "uri"
 require "mini_mime"
 require_dependency "file_store/base_store"
 require_dependency "s3_helper"
+require_dependency "s3_inventory"
 require_dependency "file_helper"
 
 module FileStore
@@ -114,6 +115,13 @@ module FileStore
     def list_missing_uploads(skip_optimized: false)
       list_missing(Upload, "original/")
       list_missing(OptimizedImage, "optimized/") unless skip_optimized
+    end
+
+    def inventory
+      @inventory ||= begin
+        require 's3_inventory'
+        S3Inventory.new(@s3_helper.s3_client, s3_bucket_name, @s3_helper.s3_bucket_folder_path)
+      end
     end
 
     private

--- a/lib/s3_helper.rb
+++ b/lib/s3_helper.rb
@@ -175,6 +175,10 @@ class S3Helper
     opts
   end
 
+  def s3_client
+    s3_resource.client
+  end
+
   private
 
   def default_s3_options

--- a/lib/s3_inventory.rb
+++ b/lib/s3_inventory.rb
@@ -1,0 +1,86 @@
+require "aws-sdk-s3"
+
+class S3Inventory
+
+  attr_reader :inventory_id, :s3_client, :source_bucket_name, :source_bucket_path, :destination_bucket_name, :destination_bucket_path
+
+  def initialize(s3_client, source_bucket_name, source_bucket_path, inventory_id = "discourse-uploads")
+    @s3_client = s3_client
+    @source_bucket_name = source_bucket_name
+    @source_bucket_path = source_bucket_path
+    @inventory_id = inventory_id
+  end
+
+  def update!
+    if SiteSetting.enable_s3_inventory
+      raise Discourse::InvalidParameters.new("s3_upload_bucket_name") if SiteSetting.s3_upload_bucket.blank?
+      raise Discourse::InvalidParameters.new("s3_inventory_bucket_name") if SiteSetting.s3_inventory_bucket.blank?
+    elsif SiteSetting.s3_upload_bucket.blank? || SiteSetting.s3_inventory_bucket.blank?
+      return
+    end
+
+    @destination_bucket_name, @destination_bucket_path = begin
+      SiteSetting.s3_inventory_bucket.downcase.split("/".freeze, 2)
+    end
+
+    update_policy
+    update_configuration
+  end
+
+  def update_policy
+    s3_client.put_bucket_policy(
+      bucket: destination_bucket_name,
+      policy: {
+        "Version" => "2012-10-17",
+        "Statement":[
+          {
+            "Sid": "InventoryAndAnalyticsExamplePolicy",
+            "Effect": "Allow",
+            "Principal": {"Service": "s3.amazonaws.com"},
+            "Action": ["s3:PutObject"],
+            "Resource": ["arn:aws:s3:::#{destination_bucket_name}/*"],
+            "Condition": {
+              "ArnLike": {
+                "aws:SourceArn": "arn:aws:s3:::#{source_bucket_name}"
+              },
+              "StringEquals": {
+                "s3:x-amz-acl": "bucket-owner-full-control"
+              }
+            }
+          }
+        ]
+      }.to_json
+    )
+  end
+
+  def update_configuration
+    s3_client.put_bucket_inventory_configuration({
+      bucket: source_bucket_name,
+      id: inventory_id,
+      inventory_configuration: inventory_configuration,
+      use_accelerate_endpoint: false
+    })
+  end
+
+  def inventory_configuration
+    config = {
+      destination: {
+        s3_bucket_destination: {
+          bucket: "arn:aws:s3:::#{destination_bucket_name}",
+          format: "CSV"
+        }
+      },
+      is_enabled: SiteSetting.enable_s3_inventory,
+      id: inventory_id,
+      included_object_versions: "Current",
+      optional_fields: ["Size", "LastModifiedDate", "ETag"],
+      schedule: {
+        frequency: "Daily"
+      }
+    }
+    config[:filter] = { prefix: source_bucket_path } if source_bucket_path.present?
+    config[:destination][:s3_bucket_destination][:prefix] = destination_bucket_path if destination_bucket_path.present?
+    config
+  end
+
+end

--- a/lib/site_settings/validations.rb
+++ b/lib/site_settings/validations.rb
@@ -53,6 +53,10 @@ module SiteSettings::Validations
     validate_error :s3_upload_bucket_is_required if new_val == "t" && SiteSetting.s3_upload_bucket.blank?
   end
 
+  def validate_enable_s3_inventory(new_val)
+    validate_error :s3_inventory_bucket_is_required if new_val == "t" && (SiteSetting.s3_inventory_bucket.blank? || SiteSetting.s3_upload_bucket.blank?)
+  end
+
   def validate_backup_location(new_val)
     return unless new_val == BackupLocationSiteSetting::S3
     validate_error(:s3_backup_requires_s3_settings, setting_name: "s3_backup_bucket") if SiteSetting.s3_backup_bucket.blank?

--- a/lib/tasks/uploads.rake
+++ b/lib/tasks/uploads.rake
@@ -720,3 +720,7 @@ task "uploads:recover" => :environment do
     end
   end
 end
+
+task "uploads:create_inventory" => :environment do
+  Discourse.store.inventory.update!
+end


### PR DESCRIPTION
TODO

- [ ] Fetch inventory .csv file to get upload stats.
- [ ] Update `uploads:missing` rake task with s3 inventory.
- [ ] Create rspec test cases.
- [ ] Add locale for inventory site settings.