### PR TITLE
FIX: All multisite upload paths should start with /uploads/default/..

### DIFF
--- a/lib/file_store/s3_store.rb
+++ b/lib/file_store/s3_store.rb
@@ -42,7 +42,7 @@ module FileStore
       options[:content_disposition] = "attachment; filename=\"#{filename}\"" unless FileHelper.is_supported_image?(filename)
       # if this fails, it will throw an exception
 
-      path.prepend(File.join(upload_path, "/")) if RailsMultisite::ConnectionManagement.current_db != "default"
+      path.prepend(File.join(upload_path, "/")) if Rails.configuration.multisite
       path = @s3_helper.upload(file, path, options)
 
       # return the upload url

--- a/spec/multisite/s3_store_spec.rb
+++ b/spec/multisite/s3_store_spec.rb
@@ -27,9 +27,11 @@ RSpec.describe 'Multisite s3 uploads', type: :multisite do
 
     describe "#store_upload" do
       it "returns the correct url for default and second multisite db" do
-        expect(store.store_upload(uploaded_file, upload)).to eq(
-          "//#{SiteSetting.s3_upload_bucket}.s3.dualstack.us-east-1.amazonaws.com/original/1X/c530c06cf89c410c0355d7852644a73fc3ec8c04.png"
-        )
+        conn.with_connection('default') do
+          expect(store.store_upload(uploaded_file, upload)).to eq(
+            "//#{SiteSetting.s3_upload_bucket}.s3.dualstack.us-east-1.amazonaws.com/uploads/default/original/1X/c530c06cf89c410c0355d7852644a73fc3ec8c04.png"
+          )
+        end
 
         conn.with_connection('second') do
           expect(store.store_upload(uploaded_file, upload)).to eq(

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -180,11 +180,13 @@ RSpec.configure do |config|
   end
 
   config.before(:each, type: :multisite) do
+    Rails.configuration.multisite = true
     RailsMultisite::ConnectionManagement.config_filename =
       "spec/fixtures/multisite/two_dbs.yml"
   end
 
   config.after(:each, type: :multisite) do
+    Rails.configuration.multisite = false
     RailsMultisite::ConnectionManagement.clear_settings!
     ActiveRecord::Base.clear_active_connections!
     ActiveRecord::Base.establish_connection


### PR DESCRIPTION
Ensures that non-multisite upload url structure is left untouched.