### PR TITLE
FIX: don't steal focus when text in editor is replaced

### DIFF
--- a/app/assets/javascripts/discourse/components/d-editor.js.es6
+++ b/app/assets/javascripts/discourse/components/d-editor.js.es6
@@ -676,8 +676,13 @@ export default Ember.Component.extend({
     // Replace value (side effect: cursor at the end).
     this.set("value", val.replace(oldVal, newVal));
 
-    // Restore cursor.
-    this._selectText(newSelection.start, newSelection.end - newSelection.start);
+    if ($("textarea.d-editor-input").is(":focus")) {
+      // Restore cursor.
+      this._selectText(
+        newSelection.start,
+        newSelection.end - newSelection.start
+      );
+    }
   },
 
   _addBlock(sel, text) {

--- a/test/javascripts/components/d-editor-test.js.es6
+++ b/test/javascripts/components/d-editor-test.js.es6
@@ -804,6 +804,10 @@ composerTestCase("replace-text event for composer", async function(assert) {
       assert,
       textarea
     ) {
+      const focusEvent = $.Event("focus");
+      const $input = $('textarea.d-editor-input');
+      $input.trigger(focusEvent);
+
       this.set("value", BEFORE);
       await setSelection(textarea, CASE.before);
 


### PR DESCRIPTION
https://meta.discourse.org/t/topic-title-input-should-not-lose-focus-after-image-upload-succeeds/103050