### PR TITLE
Use In-Reply-To instead of Return-Path when the domains don't match

### DIFF
--- a/lib/email/sender.rb
+++ b/lib/email/sender.rb
@@ -165,7 +165,7 @@ module Email
         # however Rails has special handling for this header and ends up using this value
         # as the Envelope From address. Ideally it is supposed to be set by the mail server and the message can get flagged
         # by antispam filters if the From address domain doesn't match the senders address domain due to DKIM and SPF failures
-        if SiteSetting.reply_by_email_address.split("@").last == @message.from.split("@").last
+        if SiteSetting.reply_by_email_address.split("@").last == @message.from&.split("@").last
           @message.header[:return_path] = SiteSetting.reply_by_email_address.sub("%{reply_key}", "verp-#{email_log.bounce_key}")
         end
       end

--- a/lib/email/sender.rb
+++ b/lib/email/sender.rb
@@ -163,8 +163,11 @@ module Email
 
         # WARNING: RFC claims you can not set the Return Path header, this is 100% correct
         # however Rails has special handling for this header and ends up using this value
-        # as the Envelope From address so stuff works as expected
-        @message.header[:return_path] = SiteSetting.reply_by_email_address.sub("%{reply_key}", "verp-#{email_log.bounce_key}")
+        # as the Envelope From address. Ideally it is supposed to be set by the mail server and the message can get flagged
+        # by antispam filters if the From address domain doesn't match the senders address domain due to DKIM and SPF failures
+        if SiteSetting.reply_by_email_address.split("@").last == @message.from.split("@").last
+          @message.header[:return_path] = SiteSetting.reply_by_email_address.sub("%{reply_key}", "verp-#{email_log.bounce_key}")
+        end
       end
 
       email_log.post_id = post_id if post_id.present?


### PR DESCRIPTION
Setting the Return-Path header causes Rails to use it in the From header which can cause antispam filters to flag the message as a spam/phishing message if the From domain doesn't match the sender domain due to DKIM and SPF matching failures.

The Reply-To header is used to set the reply to address.
Set the Return-Path only if the domain are identical (sub domain changes can also cause a DKIM/SPF failure)

Ticket:
https://meta.discourse.org/t/discourse-setting-reply-to-value-in-from-header-field-when-using-reply-by-email-feature/103303

References:
https://api.rubyonrails.org/v5.1.6/classes/ActionMailer/Base.html