### PR TITLE
UX: truncate long topic tiles to prevent badges and date from wrapping

### DIFF
--- a/app/assets/stylesheets/desktop/category-list.scss
+++ b/app/assets/stylesheets/desktop/category-list.scss
@@ -62,22 +62,23 @@
     margin: 10px 0 0;
     display: flex;
     align-items: center;
-    flex-wrap: wrap;
-
     &:first-of-type {
       margin-top: 13px;
     }
-
     a.last-posted-at,
     a.last-posted-at:visited {
       font-size: $font-down-1;
       color: dark-light-choose($primary-medium, $secondary-high);
     }
-
     .topic-statuses .fa {
       color: dark-light-choose($primary-medium, $secondary-high);
     }
-
+    .title {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      flex: 0 1 auto;
+    }
     .topic-post-badges .badge.new-posts,
     .title {
       margin-right: 5px;


### PR DESCRIPTION
Forces long featured-topic titles to truncate while on categories-with-featured-topics.

If titles are not truncated, some unwanted display issues can occur, like the new-post badge and topic date being on separate lines, as well as the lock icon in the case of closed topics. 

Before
![1325](https://user-images.githubusercontent.com/33972521/49424416-7b170100-f7d5-11e8-9a9d-aa58d1c1fb3b.png)
After
![1326](https://user-images.githubusercontent.com/33972521/49424421-836f3c00-f7d5-11e8-8d6a-7afbf6fcdff8.png)

This can also be fixed by moving the elements around in the template but one-line titles across the board is more visually consistent so I'm trying that first.