### PR TITLE
DEV: remove uploaded_meta_id column from category

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -280,7 +280,6 @@ class CategoriesController < ApplicationController
                       :auto_close_based_on_last_post,
                       :uploaded_logo_id,
                       :uploaded_background_id,
-                      :uploaded_meta_id,
                       :slug,
                       :allow_badges,
                       :topic_template,

--- a/app/jobs/scheduled/clean_up_uploads.rb
+++ b/app/jobs/scheduled/clean_up_uploads.rb
@@ -55,7 +55,7 @@ module Jobs
         .joins("LEFT JOIN users u ON u.uploaded_avatar_id = uploads.id")
         .joins("LEFT JOIN user_avatars ua ON ua.gravatar_upload_id = uploads.id OR ua.custom_upload_id = uploads.id")
         .joins("LEFT JOIN user_profiles up ON up.profile_background = uploads.url OR up.card_background = uploads.url")
-        .joins("LEFT JOIN categories c ON c.uploaded_logo_id = uploads.id OR c.uploaded_background_id = uploads.id OR c.uploaded_meta_id = uploads.id")
+        .joins("LEFT JOIN categories c ON c.uploaded_logo_id = uploads.id OR c.uploaded_background_id = uploads.id")
         .joins("LEFT JOIN custom_emojis ce ON ce.upload_id = uploads.id")
         .joins("LEFT JOIN theme_fields tf ON tf.upload_id = uploads.id")
         .joins("LEFT JOIN user_exports ue ON ue.upload_id = uploads.id")

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -28,7 +28,6 @@ class Category < ActiveRecord::Base
   belongs_to :latest_post, class_name: "Post"
   belongs_to :uploaded_logo, class_name: "Upload"
   belongs_to :uploaded_background, class_name: "Upload"
-  belongs_to :uploaded_meta, class_name: "Upload"
 
   has_many :topics
   has_many :category_users
@@ -666,7 +665,6 @@ end
 #  sort_ascending                    :boolean
 #  uploaded_logo_id                  :integer
 #  uploaded_background_id            :integer
-#  uploaded_meta_id                  :integer
 #  topic_featured_link_allowed       :boolean          default(TRUE)
 #  all_topics_wiki                   :boolean          default(FALSE), not null
 #  show_subcategory_list             :boolean          default(FALSE)

--- a/app/models/category_list.rb
+++ b/app/models/category_list.rb
@@ -69,7 +69,6 @@ class CategoryList
     @categories = Category.includes(
       :uploaded_background,
       :uploaded_logo,
-      :uploaded_meta,
       :topic_only_relative_url,
       subcategories: [:topic_only_relative_url]
     ).secured(@guardian)

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -28,7 +28,7 @@ class Site
   def categories
     @categories ||= begin
       categories = Category
-        .includes(:uploaded_logo, :uploaded_background, :uploaded_meta)
+        .includes(:uploaded_logo, :uploaded_background)
         .secured(@guardian)
         .joins('LEFT JOIN topics t on t.id = categories.topic_id')
         .select('categories.*, t.slug topic_slug')

--- a/app/serializers/basic_category_serializer.rb
+++ b/app/serializers/basic_category_serializer.rb
@@ -30,7 +30,6 @@ class BasicCategorySerializer < ApplicationSerializer
 
   has_one :uploaded_logo, embed: :object, serializer: CategoryUploadSerializer
   has_one :uploaded_background, embed: :object, serializer: CategoryUploadSerializer
-  has_one :uploaded_meta, embed: :object, serializer: CategoryUploadSerializer
 
   def include_parent_category_id?
     parent_category_id

--- a/app/views/list/list.erb
+++ b/app/views/list/list.erb
@@ -90,7 +90,7 @@
 <% if @category %>
   <% content_for :head do %>
     <%= auto_discovery_link_tag(:rss, { action: :category_feed }, title: t('rss_topics_in_category', category: @category.name)) %>
-    <%= raw crawlable_meta_data(title: @category.name, description: @category.description) %>
+    <%= raw crawlable_meta_data(title: @category.name, description: @category.description, image: @category.uploaded_logo&.url.presence) %>
   <% end %>
 <% elsif @tag_id %>
   <% content_for :head do %>

--- a/app/views/list/list.erb
+++ b/app/views/list/list.erb
@@ -90,7 +90,7 @@
 <% if @category %>
   <% content_for :head do %>
     <%= auto_discovery_link_tag(:rss, { action: :category_feed }, title: t('rss_topics_in_category', category: @category.name)) %>
-    <%= raw crawlable_meta_data(title: @category.name, description: @category.description, image: @category.uploaded_logo&.url.presence) %>
+    <%= raw crawlable_meta_data(title: @category.name, description: @category.description) %>
   <% end %>
 <% elsif @tag_id %>
   <% content_for :head do %>

--- a/db/post_migrate/20190103065652_remove_uploaded_meta_id_from_category.rb
+++ b/db/post_migrate/20190103065652_remove_uploaded_meta_id_from_category.rb
@@ -1,0 +1,9 @@
+class RemoveUploadedMetaIdFromCategory < ActiveRecord::Migration[5.2]
+  def up
+    Migration::ColumnDropper.execute_drop(:categories, %i{uploaded_meta_id})
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/requests/categories_controller_spec.rb
+++ b/spec/requests/categories_controller_spec.rb
@@ -144,8 +144,7 @@ describe CategoriesController do
             permissions: {
               "everyone" => readonly,
               "staff" => create_post
-            },
-            uploaded_meta_id: 2
+            }
           }
 
           expect(response.status).to eq(200)
@@ -158,7 +157,6 @@ describe CategoriesController do
           expect(category.color).to eq("ff0")
           expect(category.auto_close_hours).to eq(72)
           expect(UserHistory.count).to eq(4) # 1 + 3 (bootstrap mode)
-          expect(category.uploaded_meta_id).to eq(2)
         end
       end
     end


### PR DESCRIPTION
https://meta.discourse.org/t/custom-og-twitter-metadata-image-per-category/59313/8

This is to be pushed after https://github.com/discourse/discourse/pull/6724 since it needs to be rebased on top of it.

This contains front-end code for giving the option to add meta image and show meta image in the category.