### PR TITLE
Update mention of default Digital Ocean distro

### DIFF
--- a/docs/INSTALL-cloud.md
+++ b/docs/INSTALL-cloud.md
@@ -6,7 +6,7 @@
 
 [Sign up for DigitalOcean][do], update billing info, then create your new cloud server.
 
-- The default of **Ubuntu 16.04 LTS x64** works fine. At minimum, a 64-bit Linux OS with a kernel version of 3.10+ is required.
+- The default of **Ubuntu 18.04 LTS x64** works fine. At minimum, a 64-bit Linux OS with a kernel version of 3.10+ is required.
 
 - The default of **1 GB** RAM works fine for small Discourse communities. We recommend 2 GB RAM for larger communities.
 


### PR DESCRIPTION
When I last exercised this procedure, the Digital Ocean UI defaulted to
'Ubuntu 18.04 x64', not 16.04 as it once did.  18.04 -- Bionic Beaver --
is the latest Ubuntu LTS release.

https://wiki.ubuntu.com/Releases