### PR TITLE
UX: Make shared drafts behaviour consistent for non-staff users

### DIFF
--- a/spec/components/topic_query_spec.rb
+++ b/spec/components/topic_query_spec.rb
@@ -1014,6 +1014,17 @@ describe TopicQuery do
         list = TopicQuery.new(moderator).list_latest
         expect(list.topics).not_to include(topic)
       end
+
+      it "doesn't include shared draft topics for regular users" do
+        group.add(user)
+        SiteSetting.shared_drafts_category = nil
+        list = TopicQuery.new(user).list_latest
+        expect(list.topics).to include(topic)
+
+        SiteSetting.shared_drafts_category = shared_drafts_category.id
+        list = TopicQuery.new(user).list_latest
+        expect(list.topics).not_to include(topic)
+      end
     end
   end
 end


### PR DESCRIPTION
This makes it easier to diagnose the problem when a public category
is set as the 'shared drafts category'. Doing this is not recommended.