### PR TITLE
FEAT: make s3_force_path_style shadowed_by_global

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1042,6 +1042,7 @@ files:
     regex: '^https?:\/\/.+[^\/]$'
   s3_force_path_style:
     default: false
+    shadowed_by_global: true
   s3_configure_tombstone_policy:
     default: true
     shadowed_by_global: true


### PR DESCRIPTION
Without this it's impossible to enable S3 backups to Minio (and Digital Ocean Spaces?) using only ENV variables in config.

@tgxworld 

https://meta.discourse.org/t/can-we-make-s3-force-path-style-be-shadowed-by-global/103571