### PR TITLE
FIX: always show filtered site settings after navigation

### DIFF
--- a/app/assets/javascripts/admin/controllers/admin-site-settings-category.js.es6
+++ b/app/assets/javascripts/admin/controllers/admin-site-settings-category.js.es6
@@ -4,7 +4,7 @@ export default Ember.Controller.extend({
   categoryNameKey: null,
   adminSiteSettings: Ember.inject.controller(),
 
-  @computed("adminSiteSettings.visible", "categoryNameKey")
+  @computed("adminSiteSettings.visibleSiteSettings", "categoryNameKey")
   category(categories, nameKey) {
     return (categories || []).findBy("nameKey", nameKey);
   },

--- a/app/assets/javascripts/admin/controllers/admin-site-settings-category.js.es6
+++ b/app/assets/javascripts/admin/controllers/admin-site-settings-category.js.es6
@@ -4,7 +4,7 @@ export default Ember.Controller.extend({
   categoryNameKey: null,
   adminSiteSettings: Ember.inject.controller(),
 
-  @computed("adminSiteSettings.model", "categoryNameKey")
+  @computed("adminSiteSettings.visible", "categoryNameKey")
   category(categories, nameKey) {
     return (categories || []).findBy("nameKey", nameKey);
   },

--- a/app/assets/javascripts/admin/controllers/admin-site-settings.js.es6
+++ b/app/assets/javascripts/admin/controllers/admin-site-settings.js.es6
@@ -2,6 +2,8 @@ import debounce from "discourse/lib/debounce";
 
 export default Ember.Controller.extend({
   filter: null,
+  allSiteSettings: Ember.computed.alias("model"),
+  visible: null,
   onlyOverridden: false,
 
   filterContentNow(category) {
@@ -14,7 +16,7 @@ export default Ember.Controller.extend({
     }
 
     if ((!filter || 0 === filter.length) && !this.get("onlyOverridden")) {
-      this.set("model", this.get("allSiteSettings"));
+      this.set("visible", this.get("allSiteSettings"));
       this.transitionToRoute("adminSiteSettings");
       return;
     }
@@ -62,7 +64,7 @@ export default Ember.Controller.extend({
     all.hasMore = matches.length > 30;
     all.count = all.hasMore ? "30+" : matches.length;
 
-    this.set("model", matchesGroupedByCategory);
+    this.set("visible", matchesGroupedByCategory);
     this.transitionToRoute(
       "adminSiteSettingsCategory",
       category || "all_results"

--- a/app/assets/javascripts/admin/controllers/admin-site-settings.js.es6
+++ b/app/assets/javascripts/admin/controllers/admin-site-settings.js.es6
@@ -3,7 +3,7 @@ import debounce from "discourse/lib/debounce";
 export default Ember.Controller.extend({
   filter: null,
   allSiteSettings: Ember.computed.alias("model"),
-  visible: null,
+  visibleSiteSettings: null,
   onlyOverridden: false,
 
   filterContentNow(category) {
@@ -16,7 +16,7 @@ export default Ember.Controller.extend({
     }
 
     if ((!filter || 0 === filter.length) && !this.get("onlyOverridden")) {
-      this.set("visible", this.get("allSiteSettings"));
+      this.set("visibleSiteSettings", this.get("allSiteSettings"));
       this.transitionToRoute("adminSiteSettings");
       return;
     }
@@ -64,7 +64,7 @@ export default Ember.Controller.extend({
     all.hasMore = matches.length > 30;
     all.count = all.hasMore ? "30+" : matches.length;
 
-    this.set("visible", matchesGroupedByCategory);
+    this.set("visibleSiteSettings", matchesGroupedByCategory);
     this.transitionToRoute(
       "adminSiteSettingsCategory",
       category || "all_results"

--- a/app/assets/javascripts/admin/routes/admin-site-settings-index.js.es6
+++ b/app/assets/javascripts/admin/routes/admin-site-settings-index.js.es6
@@ -6,7 +6,8 @@ export default Discourse.Route.extend({
   beforeModel() {
     this.replaceWith(
       "adminSiteSettingsCategory",
-      this.controllerFor("adminSiteSettings").get("visible")[0].nameKey
+      this.controllerFor("adminSiteSettings").get("visibleSiteSettings")[0]
+        .nameKey
     );
   }
 });

--- a/app/assets/javascripts/admin/routes/admin-site-settings-index.js.es6
+++ b/app/assets/javascripts/admin/routes/admin-site-settings-index.js.es6
@@ -6,7 +6,7 @@ export default Discourse.Route.extend({
   beforeModel() {
     this.replaceWith(
       "adminSiteSettingsCategory",
-      this.modelFor("adminSiteSettings")[0].nameKey
+      this.controllerFor("adminSiteSettings").get("visible")[0].nameKey
     );
   }
 });

--- a/app/assets/javascripts/admin/routes/admin-site-settings.js.es6
+++ b/app/assets/javascripts/admin/routes/admin-site-settings.js.es6
@@ -10,9 +10,10 @@ export default Discourse.Route.extend({
   },
 
   afterModel(siteSettings) {
-    this.controllerFor("adminSiteSettings").set(
-      "allSiteSettings",
-      siteSettings
-    );
+    const controller = this.controllerFor("adminSiteSettings");
+
+    if (!controller.get("visible")) {
+      controller.set("visible", siteSettings);
+    }
   }
 });

--- a/app/assets/javascripts/admin/routes/admin-site-settings.js.es6
+++ b/app/assets/javascripts/admin/routes/admin-site-settings.js.es6
@@ -12,8 +12,8 @@ export default Discourse.Route.extend({
   afterModel(siteSettings) {
     const controller = this.controllerFor("adminSiteSettings");
 
-    if (!controller.get("visible")) {
-      controller.set("visible", siteSettings);
+    if (!controller.get("visibleSiteSettings")) {
+      controller.set("visibleSiteSettings", siteSettings);
     }
   }
 });

--- a/app/assets/javascripts/admin/templates/site-settings.hbs
+++ b/app/assets/javascripts/admin/templates/site-settings.hbs
@@ -15,7 +15,7 @@
 
 <div class="admin-nav pull-left">
   <ul class="nav nav-stacked">
-    {{#each visible as |category|}}
+    {{#each visibleSiteSettings as |category|}}
       <li class="{{category.nameKey}}">
         {{#link-to 'adminSiteSettingsCategory' category.nameKey class=category.nameKey}}
           {{category.name}}

--- a/app/assets/javascripts/admin/templates/site-settings.hbs
+++ b/app/assets/javascripts/admin/templates/site-settings.hbs
@@ -15,7 +15,7 @@
 
 <div class="admin-nav pull-left">
   <ul class="nav nav-stacked">
-    {{#each model as |category|}}
+    {{#each visible as |category|}}
       <li class="{{category.nameKey}}">
         {{#link-to 'adminSiteSettingsCategory' category.nameKey class=category.nameKey}}
           {{category.name}}

--- a/test/javascripts/acceptance/admin-site-settings-test.js.es6
+++ b/test/javascripts/acceptance/admin-site-settings-test.js.es6
@@ -54,3 +54,20 @@ QUnit.test("changing value updates dirty state", async assert => {
     "saving via Enter key marks setting as overriden"
   );
 });
+
+QUnit.test(
+  "always shows filtered site settings if a filter is set",
+  async assert => {
+    await visit("/admin/site_settings");
+    await fillIn("#setting-filter", "title");
+    assert.equal(count(".row.setting"), 1);
+
+    // navigate away to the "Dashboard" page
+    await click(".nav.nav-pills li:nth-child(1) a");
+    assert.equal(count(".row.setting"), 0);
+
+    // navigate back to the "Settings" page
+    await click(".nav.nav-pills li:nth-child(2) a");
+    assert.equal(count(".row.setting"), 1);
+  }
+);


### PR DESCRIPTION
This PR fixes a problem that, after filtering the site settings:

<img src="https://user-images.githubusercontent.com/6376558/49772522-8e393d80-fcbb-11e8-9f36-69236fe2c596.png" width="500" />

If you navigate away by, for example, going to the "Customize" tab, and come back to the "Settings" tab:

<img src="https://user-images.githubusercontent.com/6376558/49772513-8aa5b680-fcbb-11e8-8aae-c929a2f39101.png" width="500" />

You end up in a weird state that the filter is set, but the site settings aren't filtered.