### PR TITLE
FEATURE: add short_site_description setting to be included in title tag on homepage

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -33,7 +33,11 @@ class CategoriesController < ApplicationController
     )
     @category_list.draft = Draft.get(current_user, Draft::NEW_TOPIC, @category_list.draft_sequence) if current_user
 
-    @title = "#{I18n.t('js.filters.categories.title')} - #{SiteSetting.title}" unless category_options[:is_homepage]
+    if category_options[:is_homepage] && SiteSetting.short_site_description.present?
+      @title = "#{SiteSetting.title} - #{SiteSetting.short_site_description}"
+    elsif !category_options[:is_homepage]
+      @title = "#{I18n.t('js.filters.categories.title')} - #{SiteSetting.title}"
+    end
 
     respond_to do |format|
       format.html do

--- a/app/controllers/list_controller.rb
+++ b/app/controllers/list_controller.rb
@@ -107,6 +107,8 @@ class ListController < ApplicationController
             @title = I18n.t('js.filters.with_topics', filter: filter_title)
           end
           @title << " - #{SiteSetting.title}"
+        elsif (filter.to_s == current_homepage) && SiteSetting.short_site_description.present?
+          @title = "#{SiteSetting.title} - #{SiteSetting.short_site_description}"
         end
       end
 

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1193,6 +1193,7 @@ en:
     educate_until_posts: "When the user starts typing their first (n) new posts, show the pop-up new user education panel in the composer."
     title: "The name of this site, as used in the title tag."
     site_description: "Describe this site in one sentence, as used in the meta description tag."
+    short_site_description: "Short description, as used in the title tag on homepage."
     contact_email: "Email address of key contact responsible for this site. Used for critical notifications, as well as on the <a href='%{base_path}/about' target='_blank'>/about</a> contact form for urgent matters."
     contact_url: "Contact URL for this site. Used on the <a href='%{base_path}/about' target='_blank'>/about</a> contact form for urgent matters."
     crawl_images: "Retrieve images from remote URLs to insert the correct width and height dimensions."
@@ -4047,6 +4048,9 @@ en:
           site_description:
             label: "Describe your community in one short sentence"
             placeholder: "A place for Jane and her friends to discuss cool stuff"
+          short_site_description:
+            label: "Describe your community in few words"
+            placeholder: "Best community ever"
 
       introduction:
         title: "Introduction"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -31,6 +31,8 @@ required:
     default: 'Discourse'
   site_description:
     default: ''
+  short_site_description:
+    default: ''
   contact_email:
     client: true
     default: ''

--- a/lib/wizard/builder.rb
+++ b/lib/wizard/builder.rb
@@ -33,12 +33,13 @@ class Wizard
       @wizard.append_step('forum-title') do |step|
         step.add_field(id: 'title', type: 'text', required: true, value: SiteSetting.title)
         step.add_field(id: 'site_description', type: 'text', required: true, value: SiteSetting.site_description)
+        step.add_field(id: 'short_site_description', type: 'text', required: false, value: SiteSetting.short_site_description)
 
         step.on_update do |updater|
           updater.ensure_changed(:title)
 
           if updater.errors.blank?
-            updater.apply_settings(:title, :site_description)
+            updater.apply_settings(:title, :site_description, :short_site_description)
           end
         end
       end

--- a/spec/requests/categories_controller_spec.rb
+++ b/spec/requests/categories_controller_spec.rb
@@ -37,6 +37,18 @@ describe CategoriesController do
         expect(json['topic_list_latest']).to include(%{"more_topics_url":"/latest"})
       end
     end
+
+    it "Shows correct title if category list is set for homepage" do
+      SiteSetting.top_menu = "categories|latest"
+      get "/"
+
+      expect(response.body).to have_tag "title", text: "Discourse"
+
+      SiteSetting.short_site_description = "Official community"
+      get "/"
+
+      expect(response.body).to have_tag "title", text: "Discourse - Official community"
+    end
   end
 
   context 'extensibility event' do

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -5,8 +5,10 @@ RSpec.describe ListController do
   let(:group) { Fabricate(:group) }
   let(:user) { Fabricate(:user) }
   let(:post) { Fabricate(:post, user: user) }
+  let(:admin) { Fabricate(:admin) }
 
   before do
+    admin  # to skip welcome wizard at home page `/`
     SiteSetting.top_menu = 'latest|new|unread|categories'
   end
 
@@ -76,6 +78,17 @@ RSpec.describe ListController do
       expect(response.status).to eq(200)
       parsed = JSON.parse(response.body)
       expect(parsed["topic_list"]["topics"].length).to eq(1)
+    end
+
+    it "shows correct title if topic list is set for homepage" do
+      get "/"
+
+      expect(response.body).to have_tag "title", text: "Discourse"
+
+      SiteSetting.short_site_description = "Best community"
+      get "/"
+
+      expect(response.body).to have_tag "title", text: "Discourse - Best community"
     end
   end
 


### PR DESCRIPTION
https://meta.discourse.org/t/feature-request-enable-separate-title-for-start-page-and-the-rest-of-the-pages/103882