### PR TITLE
FIX: define actions on connector class early

### DIFF
--- a/app/assets/javascripts/discourse/components/plugin-connector.js.es6
+++ b/app/assets/javascripts/discourse/components/plugin-connector.js.es6
@@ -12,6 +12,8 @@ export default Ember.Component.extend({
 
     const connectorClass = this.get("connector.connectorClass");
     connectorClass.setupComponent.call(this, args, this);
+
+    this.set("actions", connectorClass.actions);
   },
 
   @observes("args")


### PR DESCRIPTION
This would prevent failure with connectors templates defining actions as closures. In this case action existence is checked at compile time and not runtime.