### PR TITLE
minor changes to default script-src

### DIFF
--- a/lib/content_security_policy/default.rb
+++ b/lib/content_security_policy/default.rb
@@ -44,13 +44,14 @@ class ContentSecurityPolicy
     def script_src
       [
         :unsafe_eval,
+        :report_sample,
         "#{base_url}/logs/",
         "#{base_url}/sidekiq/",
         "#{base_url}/mini-profiler-resources/",
         *script_assets
       ].tap do |sources|
-        sources << 'https://www.google-analytics.com' if SiteSetting.ga_universal_tracking_code.present?
-        sources << 'https://www.googletagmanager.com' if SiteSetting.gtm_container_id.present?
+        sources << 'https://www.google-analytics.com/analytics.js' if SiteSetting.ga_universal_tracking_code.present?
+        sources << 'https://www.googletagmanager.com/gtm.js' if SiteSetting.gtm_container_id.present?
       end
     end
 

--- a/spec/lib/content_security_policy_spec.rb
+++ b/spec/lib/content_security_policy_spec.rb
@@ -31,6 +31,7 @@ describe ContentSecurityPolicy do
       script_srcs = parse(policy)['script-src']
       expect(script_srcs).to include(*%w[
         'unsafe-eval'
+        'report-sample'
         http://test.localhost/logs/
         http://test.localhost/sidekiq/
         http://test.localhost/mini-profiler-resources/
@@ -50,8 +51,8 @@ describe ContentSecurityPolicy do
       SiteSetting.gtm_container_id = 'GTM-ABCDEF'
 
       script_srcs = parse(policy)['script-src']
-      expect(script_srcs).to include('https://www.google-analytics.com')
-      expect(script_srcs).to include('https://www.googletagmanager.com')
+      expect(script_srcs).to include('https://www.google-analytics.com/analytics.js')
+      expect(script_srcs).to include('https://www.googletagmanager.com/gtm.js')
     end
 
     it 'whitelists CDN assets when integrated' do


### PR DESCRIPTION
- add `'report-sample'` to force require a sample of the violating code
- do not whitelist GA/GTM's entire domain