### PR TITLE
FIX: use new key for delete topic to make it lowercased as all other …

### DIFF
--- a/app/assets/javascripts/discourse/widgets/post-menu.js.es6
+++ b/app/assets/javascripts/discourse/widgets/post-menu.js.es6
@@ -267,7 +267,7 @@ registerButton("delete", attrs => {
     return {
       id: "delete_topic",
       action: "deletePost",
-      title: "topic.actions.delete",
+      title: "post.controls.delete_topic",
       icon: "trash-o",
       className: "delete"
     };

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2166,6 +2166,7 @@ en:
         unlock_post_description: "allow the poster to edit this post"
         delete_topic_disallowed_modal: "You don't have permission to delete this topic. If you really want it to be deleted, submit a flag for moderator attention together with reasoning."
         delete_topic_disallowed: "you don't have permission to delete this topic"
+        delete_topic: "delete topic"
 
       actions:
         flag: 'Flag'


### PR DESCRIPTION
…buttons label around it

https://meta.discourse.org/t/delete-topic-tooltip-is-capitalized-but-nothing-else-is/73252/6