### PR TITLE
FEATURE: Allow wildcard in allowed_user_api_auth_redirects setting

### DIFF
--- a/app/controllers/user_api_keys_controller.rb
+++ b/app/controllers/user_api_keys_controller.rb
@@ -53,7 +53,7 @@ class UserApiKeysController < ApplicationController
 
     if params.key?(:auth_redirect) && SiteSetting.allowed_user_api_auth_redirects
         .split('|')
-        .none? { |u| params[:auth_redirect] == u }
+        .none? { |u| WildcardUrlChecker.check_url(u, params[:auth_redirect]) }
 
       raise Discourse::InvalidAccess
     end

--- a/app/services/wildcard_url_checker.rb
+++ b/app/services/wildcard_url_checker.rb
@@ -1,8 +1,6 @@
 module WildcardUrlChecker
 
   def self.check_url(url, url_to_check)
-    puts "url: " + url
-    puts "url_to_check: " + url_to_check
     escaped_url = Regexp.escape(url).sub("\\*", '\S*')
     url_regex = Regexp.new("^#{escaped_url}$", 'i')
 

--- a/app/services/wildcard_url_checker.rb
+++ b/app/services/wildcard_url_checker.rb
@@ -1,0 +1,12 @@
+module WildcardUrlChecker
+
+  def self.check_url(url, url_to_check)
+    puts "url: " + url
+    puts "url_to_check: " + url_to_check
+    escaped_url = Regexp.escape(url).sub("\\*", '\S*')
+    url_regex = Regexp.new("^#{escaped_url}$", 'i')
+
+    url_to_check.match(url_regex)
+  end
+
+end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1881,7 +1881,7 @@ en:
     allow_user_api_key_scopes: "List of scopes allowed for user API keys"
     max_api_keys_per_user: "Maximum number of user API keys per user"
     min_trust_level_for_user_api_key: "Trust level required for generation of user API keys"
-    allowed_user_api_auth_redirects: "Allowed URL for authentication redirect for user API keys"
+    allowed_user_api_auth_redirects: "Allowed URL for authentication redirect for user API keys. Wildcard symbol * can be used to match any part of it (e.g. www.example.com/*)."
     allowed_user_api_push_urls: "Allowed URLs for server push to user API"
     expire_user_api_keys_days: "Number of days before an user API key automatically expires (0 for never)"
 

--- a/spec/requests/user_api_keys_controller_spec.rb
+++ b/spec/requests/user_api_keys_controller_spec.rb
@@ -240,5 +240,15 @@ describe UserApiKeysController do
       expect(api_key.user_id).to eq(user.id)
 
     end
+
+    it "will allow redirect to wildcard urls" do
+      SiteSetting.allowed_user_api_auth_redirects = args[:auth_redirect] + '/*'
+      args[:auth_redirect] = args[:auth_redirect] + '/bluebirds/fly'
+
+      sign_in(Fabricate(:user))
+
+      post "/user-api-key.json", params: args
+      expect(response.status).to eq(302)
+    end
   end
 end


### PR DESCRIPTION
### Use case
I need to consume the Discourse APIs using User API Keys from JS in some pages reachable in a different location than the domain root. Instead of listing all the locations in the `allowed_user_api_auth_redirects` (which will be impossibile if I generate pages dynamically), I can use a wildcard to allow redirect to multiple pages: i.e. `www.example.com/site/*`.
