### PR TITLE
Add category link renderer to plugin API

### DIFF
--- a/app/assets/javascripts/discourse/helpers/category-link.js.es6
+++ b/app/assets/javascripts/discourse/helpers/category-link.js.es6
@@ -5,6 +5,12 @@ import { iconHTML } from "discourse-common/lib/icon-library";
 var get = Em.get,
   escapeExpression = Handlebars.Utils.escapeExpression;
 
+let _renderers = [];
+
+export function registerCategoryLinkRenderer(renderer) {
+  _renderers.unshift(renderer);
+}
+
 function categoryStripe(color, classes) {
   var style = color ? "style='background-color: #" + color + ";'" : "";
   return "<span class='" + classes + "' " + style + "></span>";
@@ -32,76 +38,12 @@ export function categoryBadgeHTML(category, opts) {
   )
     return "";
 
-  let description = get(category, "description_text");
-  let restricted = get(category, "read_restricted");
-  let url = opts.url
-    ? opts.url
-    : Discourse.getURL("/c/") + Discourse.Category.slugFor(category);
-  let href = opts.link === false ? "" : url;
-  let tagName = opts.link === false || opts.link === "false" ? "span" : "a";
-  let extraClasses = opts.extraClasses ? " " + opts.extraClasses : "";
-  let color = get(category, "color");
-  let html = "";
-  let parentCat = null;
-  let categoryDir = "";
-
-  if (!opts.hideParent) {
-    parentCat = Discourse.Category.findById(
-      get(category, "parent_category_id")
-    );
-  }
-
-  const categoryStyle =
-    opts.categoryStyle || Discourse.SiteSettings.category_style;
-  if (categoryStyle !== "none") {
-    if (parentCat && parentCat !== category) {
-      html += categoryStripe(
-        get(parentCat, "color"),
-        "badge-category-parent-bg"
-      );
+  for (let i = 0; i < _renderers.length; i++) {
+    let result = _renderers[i].render(category, opts);
+    if (result) {
+      return result;
     }
-    html += categoryStripe(color, "badge-category-bg");
   }
-
-  let classNames = "badge-category clear-badge";
-  if (restricted) {
-    classNames += " restricted";
-  }
-
-  let style = "";
-  if (categoryStyle === "box") {
-    style = `style="color: #${get(category, "text_color")};"`;
-  }
-
-  html +=
-    `<span ${style} ` +
-    'data-drop-close="true" class="' +
-    classNames +
-    '"' +
-    (description ? 'title="' + escapeExpression(description) + '" ' : "") +
-    ">";
-
-  let categoryName = escapeExpression(get(category, "name"));
-
-  if (Discourse.SiteSettings.support_mixed_text_direction) {
-    categoryDir = isRTL(categoryName) ? 'dir="rtl"' : 'dir="ltr"';
-  }
-
-  if (restricted) {
-    html += `${iconHTML(
-      "lock"
-    )}<span class="category-name" ${categoryDir}>${categoryName}</span>`;
-  } else {
-    html += `<span class="category-name" ${categoryDir}>${categoryName}</span>`;
-  }
-  html += "</span>";
-
-  if (href) {
-    href = ` href="${href}" `;
-  }
-
-  extraClasses = categoryStyle ? categoryStyle + extraClasses : extraClasses;
-  return `<${tagName} class="badge-wrapper ${extraClasses}" ${href}>${html}</${tagName}>`;
 }
 
 export function categoryLinkHTML(category, options) {
@@ -136,3 +78,79 @@ export function categoryLinkHTML(category, options) {
 }
 
 registerUnbound("category-link", categoryLinkHTML);
+
+registerCategoryLinkRenderer({
+  name: "default",
+  render(category, opts) {
+    let description = get(category, "description_text");
+    let restricted = get(category, "read_restricted");
+    let url = opts.url
+      ? opts.url
+      : Discourse.getURL("/c/") + Discourse.Category.slugFor(category);
+    let href = opts.link === false ? "" : url;
+    let tagName = opts.link === false || opts.link === "false" ? "span" : "a";
+    let extraClasses = opts.extraClasses ? " " + opts.extraClasses : "";
+    let color = get(category, "color");
+    let html = "";
+    let parentCat = null;
+    let categoryDir = "";
+
+    if (!opts.hideParent) {
+      parentCat = Discourse.Category.findById(
+        get(category, "parent_category_id")
+      );
+    }
+
+    const categoryStyle =
+      opts.categoryStyle || Discourse.SiteSettings.category_style;
+    if (categoryStyle !== "none") {
+      if (parentCat && parentCat !== category) {
+        html += categoryStripe(
+          get(parentCat, "color"),
+          "badge-category-parent-bg"
+        );
+      }
+      html += categoryStripe(color, "badge-category-bg");
+    }
+
+    let classNames = "badge-category clear-badge";
+    if (restricted) {
+      classNames += " restricted";
+    }
+
+    let style = "";
+    if (categoryStyle === "box") {
+      style = `style="color: #${get(category, "text_color")};"`;
+    }
+
+    html +=
+      `<span ${style} ` +
+      'data-drop-close="true" class="' +
+      classNames +
+      '"' +
+      (description ? 'title="' + escapeExpression(description) + '" ' : "") +
+      ">";
+
+    let categoryName = escapeExpression(get(category, "name"));
+
+    if (Discourse.SiteSettings.support_mixed_text_direction) {
+      categoryDir = isRTL(categoryName) ? 'dir="rtl"' : 'dir="ltr"';
+    }
+
+    if (restricted) {
+      html += `${iconHTML(
+        "lock"
+      )}<span class="category-name" ${categoryDir}>${categoryName}</span>`;
+    } else {
+      html += `<span class="category-name" ${categoryDir}>${categoryName}</span>`;
+    }
+    html += "</span>";
+
+    if (href) {
+      href = ` href="${href}" `;
+    }
+
+    extraClasses = categoryStyle ? categoryStyle + extraClasses : extraClasses;
+    return `<${tagName} class="badge-wrapper ${extraClasses}" ${href}>${html}</${tagName}>`;
+  }
+});

--- a/app/assets/javascripts/discourse/lib/plugin-api.js.es6
+++ b/app/assets/javascripts/discourse/lib/plugin-api.js.es6
@@ -28,6 +28,7 @@ import {
   registerIconRenderer,
   replaceIcon
 } from "discourse-common/lib/icon-library";
+import { registerCategoryLinkRenderer } from "discourse/helpers/category-link";
 import { addNavItem } from "discourse/models/nav-item";
 import { replaceFormatter } from "discourse/lib/utilities";
 import { modifySelectKit } from "select-kit/mixins/plugin-api";
@@ -39,7 +40,7 @@ import Sharing from "discourse/lib/sharing";
 import { addComposerUploadHandler } from "discourse/components/composer-editor";
 
 // If you add any methods to the API ensure you bump up this number
-const PLUGIN_API_VERSION = "0.8.25";
+const PLUGIN_API_VERSION = "0.8.26";
 
 class PluginApi {
   constructor(version, container) {
@@ -774,6 +775,24 @@ class PluginApi {
    */
   addComposerUploadHandler(extensions, method) {
     addComposerUploadHandler(extensions, method);
+  }
+
+  /**
+   * Registers a renderer that overrides the display of category links.
+   * For example, to render an icon instead of any category name:
+   *
+   * import { iconHTML } from "discourse-common/lib/icon-library";
+   *
+   * api.registerCategoryLinkRenderer({
+   *   name: 'rocket',
+   *
+   *   render(category, opts) {
+   *     return `<span>${iconHTML('rocket')}</span>`;
+   *   },
+   * });
+   **/
+  registerCategoryLinkRenderer(fn) {
+    registerCategoryLinkRenderer(fn);
   }
 }
 


### PR DESCRIPTION
This lets themes/plugins override the category link display. I am working on a theme component that would use this plugin function to add its own renderer with icons in category badges. 