### PR TITLE
FEATURE: Show a blurry preview when lazy loading images

### DIFF
--- a/app/assets/javascripts/discourse/lib/lazy-load-images.js.es6
+++ b/app/assets/javascripts/discourse/lib/lazy-load-images.js.es6
@@ -2,24 +2,39 @@ const OBSERVER_OPTIONS = {
   rootMargin: "50%" // load images slightly before they're visible
 };
 
+const imageSources = new WeakMap();
+
+const LOADING_DATA =
+  "data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==";
+
 // We hide an image by replacing it with a transparent gif
 function hide(image) {
   image.classList.add("d-lazyload");
   image.classList.add("d-lazyload-hidden");
-  image.setAttribute("data-src", image.getAttribute("src"));
+
+  imageSources.set(image, {
+    src: image.getAttribute("src"),
+    srcSet: image.getAttribute("srcset")
+  });
+  image.removeAttribute("srcset");
+
   image.setAttribute(
     "src",
-    "data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
+    image.getAttribute("data-small-upload") || LOADING_DATA
   );
+  image.removeAttribute("data-small-upload");
 }
 
-// Restore an image from the `data-src` attribute
+// Restore an image when onscreen
 function show(image) {
-  let dataSrc = image.getAttribute("data-src");
-  if (dataSrc) {
-    image.setAttribute("src", dataSrc);
-    image.classList.remove("d-lazyload-hidden");
+  let sources = imageSources.get(image);
+  if (sources) {
+    image.setAttribute("src", sources.src);
+    if (sources.srcSet) {
+      image.setAttribute("srcset", sources.srcSet);
+    }
   }
+  image.classList.remove("d-lazyload-hidden");
 }
 
 export function setupLazyLoading(api) {

--- a/app/assets/stylesheets/common/base/lightbox.scss
+++ b/app/assets/stylesheets/common/base/lightbox.scss
@@ -1,6 +1,7 @@
 .lightbox-wrapper .lightbox {
   position: relative;
   display: inline-block;
+  overflow: hidden;
   background: $primary-low;
   &:hover .meta {
     opacity: 0.9;
@@ -9,7 +10,6 @@
 }
 
 .d-lazyload-hidden {
-  opacity: 0;
   box-sizing: border-box;
 }
 

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -65,7 +65,8 @@ class Upload < ActiveRecord::Base
     opts = opts.merge(raise_on_error: true)
     begin
       OptimizedImage.create_for(self, width, height, opts)
-    rescue
+    rescue => ex
+      Rails.logger.info ex if Rails.env.development?
       opts = opts.merge(raise_on_error: false)
       if fix_image_extension
         OptimizedImage.create_for(self, width, height, opts)

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -46,13 +46,10 @@ class Upload < ActiveRecord::Base
     thumbnail(width, height).present?
   end
 
-  def create_thumbnail!(width, height, crop = false)
+  def create_thumbnail!(width, height, opts = nil)
     return unless SiteSetting.create_thumbnails?
-
-    opts = {
-      allow_animation: SiteSetting.allow_animated_thumbnails,
-      crop: crop
-    }
+    opts ||= {}
+    opts[:allow_animation] = SiteSetting.allow_animated_thumbnails
 
     if get_optimized_image(width, height, opts)
       save(validate: false)

--- a/lib/cooked_post_processor.rb
+++ b/lib/cooked_post_processor.rb
@@ -322,14 +322,14 @@ class CookedPostProcessor
     end
 
     if upload = Upload.get_from_url(src)
-      upload.create_thumbnail!(width, height, crop)
+      upload.create_thumbnail!(width, height, crop: crop)
 
       each_responsive_ratio do |ratio|
         resized_w = (width * ratio).to_i
         resized_h = (height * ratio).to_i
 
         if upload.width && resized_w <= upload.width
-          upload.create_thumbnail!(resized_w, resized_h, crop)
+          upload.create_thumbnail!(resized_w, resized_h, crop: crop)
         end
       end
     end

--- a/spec/models/optimized_image_spec.rb
+++ b/spec/models/optimized_image_spec.rb
@@ -29,6 +29,21 @@ describe OptimizedImage do
       end
     end
 
+    describe ".resize_instructions" do
+      let(:image) { "#{Rails.root}/spec/fixtures/images/logo.png" }
+
+      it "doesn't return any color options by default" do
+        instructions = described_class.resize_instructions(image, image, "50x50")
+        expect(instructions).to_not include('-colors')
+      end
+
+      it "supports an optional color option" do
+        instructions = described_class.resize_instructions(image, image, "50x50", colors: 12)
+        expect(instructions).to include('-colors')
+      end
+
+    end
+
     describe '.resize' do
       it 'should work correctly when extension is bad' do
 
@@ -186,7 +201,6 @@ describe OptimizedImage do
   describe ".create_for" do
 
     it "is able to 'optimize' an svg" do
-
       # we don't really optimize anything, we simply copy
       # but at least this confirms this actually works
 
@@ -237,6 +251,11 @@ describe OptimizedImage do
           expect(oi.width).to eq(100)
           expect(oi.height).to eq(200)
           expect(oi.url).to eq("/internally/stored/optimized/image.png")
+        end
+
+        it "is able to change the format" do
+          oi = OptimizedImage.create_for(upload, 100, 200, format: 'gif')
+          expect(oi.url).to eq("/internally/stored/optimized/image.gif")
         end
 
       end


### PR DESCRIPTION
This generates a 10x10 PNG thumbnail for each lightboxed image.
If Image Lazy Loading is enabled (IntersectionObserver API) then
we'll load the low res version when offscreen. As the image scrolls
in we'll swap it for the high res version.
