### PR TITLE
FIX: Allow sending test e-mails to any email address when disable_ema…

### DIFF
--- a/app/controllers/admin/email_controller.rb
+++ b/app/controllers/admin/email_controller.rb
@@ -13,8 +13,6 @@ class Admin::EmailController < Admin::AdminController
       Jobs::TestEmail.new.execute(to_address: params[:email_address])
       if SiteSetting.disable_emails == "yes"
         render json: { sent_test_email_message: I18n.t("admin.email.sent_test_disabled") }
-      elsif SiteSetting.disable_emails == "non-staff" && !User.find_by_email(params[:email_address])&.staff?
-        render json: { sent_test_email_message: I18n.t("admin.email.sent_test_disabled_for_non_staff") }
       else
         render json: { sent_test_email_message: I18n.t("admin.email.sent_test") }
       end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2055,7 +2055,6 @@ en:
     email:
       sent_test: "sent!"
       sent_test_disabled: "cannot send because emails are disabled"
-      sent_test_disabled_for_non_staff: "cannot send because emails are disabled for non-staff"
 
   user:
     deactivated: "Was deactivated due to too many bounced emails to '%{email}'."

--- a/lib/email/sender.rb
+++ b/lib/email/sender.rb
@@ -30,10 +30,6 @@ module Email
       return skip(SkippedEmailLog.reason_types[:sender_message_blank])    if @message.blank?
       return skip(SkippedEmailLog.reason_types[:sender_message_to_blank]) if @message.to.blank?
 
-      if SiteSetting.disable_emails == "non-staff"
-        return unless User.find_by_email(to_address)&.staff?
-      end
-
       if @message.text_part
         if @message.text_part.body.to_s.blank?
           return skip(SkippedEmailLog.reason_types[:sender_text_part_body_blank])

--- a/spec/components/email/sender_spec.rb
+++ b/spec/components/email/sender_spec.rb
@@ -27,10 +27,10 @@ describe Email::Sender do
     context "disable_emails is enabled for non-staff users" do
       before { SiteSetting.disable_emails = "non-staff" }
 
-      it "doesn't deliver mail to normal user" do
-        Mail::Message.any_instance.expects(:deliver_now).never
+      it "delivers mail to normal user" do
+        Mail::Message.any_instance.expects(:deliver_now).once
         message = Mail::Message.new(to: user.email, body: "hello")
-        expect(Email::Sender.new(message, :hello).send).to eq(nil)
+        Email::Sender.new(message, :hello).send
       end
 
       it "delivers mail to staff user" do

--- a/spec/requests/admin/email_controller_spec.rb
+++ b/spec/requests/admin/email_controller_spec.rb
@@ -120,7 +120,7 @@ describe Admin::EmailController do
         expect(incoming['sent_test_email_message']).to eq(I18n.t("admin.email.sent_test_disabled"))
       end
 
-      it 'sends mail to staff only when setting is "non-staff"' do
+      it 'sends mail to everyone when setting is "non-staff"' do
         SiteSetting.disable_emails = 'non-staff'
 
         post "/admin/email/test.json", params: { email_address: admin.email }
@@ -129,7 +129,7 @@ describe Admin::EmailController do
 
         post "/admin/email/test.json", params: { email_address: eviltrout.email }
         incoming = JSON.parse(response.body)
-        expect(incoming['sent_test_email_message']).to eq(I18n.t("admin.email.sent_test_disabled_for_non_staff"))
+        expect(incoming['sent_test_email_message']).to eq(I18n.t("admin.email.sent_test"))
       end
 
       it 'sends mail to everyone when setting is "no"' do


### PR DESCRIPTION
…il is set to non-staff

When  `disable_email` is set to `non-staff`, this PR will allow test emails to be sent to any email address (not just staff) from `admin/email`.

Ref: https://meta.discourse.org/t/allow-sending-test-emails-when-mail-is-disabled/103931/4

