### PR TITLE
DEV: Refactor location string builders.

### DIFF
--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -35,7 +35,7 @@ class UserNotifications < ActionMailer::Base
 
   def suspicious_login(user, opts = {})
     ipinfo = DiscourseIpInfo.get(opts[:client_ip])
-    location = [ipinfo[:city], ipinfo[:region], ipinfo[:country]].reject(&:blank?).join(", ")
+    location = ipinfo[:location]
     browser = BrowserDetection.browser(opts[:user_agent])
     device = BrowserDetection.device(opts[:user_agent])
     os = BrowserDetection.os(opts[:user_agent])

--- a/app/serializers/concerns/user_auth_tokens_mixin.rb
+++ b/app/serializers/concerns/user_auth_tokens_mixin.rb
@@ -21,11 +21,7 @@ module UserAuthTokensMixin
 
   def location
     ipinfo = DiscourseIpInfo.get(client_ip, locale: I18n.locale)
-
-    location = [ipinfo[:city], ipinfo[:region], ipinfo[:country]].reject { |x| x.blank? }.join(", ")
-    return I18n.t('staff_action_logs.unknown') if location.blank?
-
-    location
+    ipinfo[:location].presence || I18n.t('staff_action_logs.unknown')
   end
 
   def browser


### PR DESCRIPTION
The [location](https://github.com/discourse/discourse/blob/master/lib/discourse_ip_info.rb#L45) is already provided by DiscourseIpInfo.