### PR TITLE
FIX: validate YAML before save to avoid race condition

### DIFF
--- a/app/models/theme_field.rb
+++ b/app/models/theme_field.rb
@@ -171,10 +171,7 @@ COMPILED
       errors << e.message
     end
 
-    self.error = errors.join("\n").presence unless self.destroyed?
-    if will_save_change_to_error?
-      update_columns(error: self.error)
-    end
+    self.error = errors.join("\n").presence
   end
 
   def self.guess_type(name)
@@ -237,6 +234,8 @@ COMPILED
   end
 
   before_save do
+    validate_yaml!
+
     if will_save_change_to_value? && !will_save_change_to_value_baked?
       self.value_baked = nil
     end
@@ -245,7 +244,6 @@ COMPILED
   after_commit do
     ensure_baked!
     ensure_scss_compiles!
-    validate_yaml!
     theme.clear_cached_settings!
 
     Stylesheet::Manager.clear_theme_cache! if self.name.include?("scss")

--- a/spec/models/theme_spec.rb
+++ b/spec/models/theme_spec.rb
@@ -355,6 +355,12 @@ HTML
       expect(theme_field.javascript_cache.content).to eq(transpiled.strip)
     end
 
+    it 'is empty when the settings are invalid' do
+      theme.set_field(target: :settings, name: :yaml, value: 'nil_setting: ')
+      theme.save!
+
+      expect(theme.settings).to be_empty
+    end
   end
 
   it 'correctly caches theme ids' do


### PR DESCRIPTION
YAML setting `ThemeField`s are validated in an `after_commit` callback, which does not finish before the setting is used elsewhere, specifically:

https://github.com/discourse/discourse/blob/bb67ca9d21fc0871ea545e5ffb551cac4c20e4dd/app/models/theme.rb#L348-L357

where `Theme#settings` depends on the theme field being validated.

This PR moves the `validate_yaml!` call to `before_save` instead. This is okay because the validation process is not expensive.