### PR TITLE
FEATURE: Add `Top Uploads` report

### DIFF
--- a/app/assets/javascripts/admin/components/admin-report-table.js.es6
+++ b/app/assets/javascripts/admin/components/admin-report-table.js.es6
@@ -79,7 +79,7 @@ export default Ember.Component.extend({
     if (sortLabel) {
       const compare = (label, direction) => {
         return (a, b) => {
-          let aValue = label.compute(a, { useSortProperty: true }).value;
+           const aValue = label.compute(a, { useSortProperty: true }).value;
           let bValue = label.compute(b, { useSortProperty: true }).value;
           const result = aValue < bValue ? -1 : aValue > bValue ? 1 : 0;
           return result * direction;

--- a/app/assets/javascripts/admin/components/admin-report-table.js.es6
+++ b/app/assets/javascripts/admin/components/admin-report-table.js.es6
@@ -79,8 +79,8 @@ export default Ember.Component.extend({
     if (sortLabel) {
       const compare = (label, direction) => {
         return (a, b) => {
-          const aValue = label.compute(a).value;
-          const bValue = label.compute(b).value;
+          let aValue = label.compute(a).value;
+          let bValue = label.compute(b).value;
           const result = aValue < bValue ? -1 : aValue > bValue ? 1 : 0;
           return result * direction;
         };

--- a/app/assets/javascripts/admin/components/admin-report-table.js.es6
+++ b/app/assets/javascripts/admin/components/admin-report-table.js.es6
@@ -79,8 +79,8 @@ export default Ember.Component.extend({
     if (sortLabel) {
       const compare = (label, direction) => {
         return (a, b) => {
-          let aValue = label.compute(a).value;
-          let bValue = label.compute(b).value;
+          let aValue = label.compute(a, { useSortProperty: true }).value;
+          let bValue = label.compute(b, { useSortProperty: true }).value;
           const result = aValue < bValue ? -1 : aValue > bValue ? 1 : 0;
           return result * direction;
         };

--- a/app/assets/javascripts/admin/components/admin-report-table.js.es6
+++ b/app/assets/javascripts/admin/components/admin-report-table.js.es6
@@ -79,8 +79,8 @@ export default Ember.Component.extend({
     if (sortLabel) {
       const compare = (label, direction) => {
         return (a, b) => {
-          const aValue = label.compute(a, {useSortProperty: true}).value;
-          const bValue = label.compute(b, {useSortProperty: true}).value;
+          const aValue = label.compute(a).value;
+          const bValue = label.compute(b).value;
           const result = aValue < bValue ? -1 : aValue > bValue ? 1 : 0;
           return result * direction;
         };

--- a/app/assets/javascripts/admin/components/admin-report-table.js.es6
+++ b/app/assets/javascripts/admin/components/admin-report-table.js.es6
@@ -79,8 +79,8 @@ export default Ember.Component.extend({
     if (sortLabel) {
       const compare = (label, direction) => {
         return (a, b) => {
-           const aValue = label.compute(a, { useSortProperty: true }).value;
-           const bValue = label.compute(b, { useSortProperty: true }).value;
+          const aValue = label.compute(a, {useSortProperty: true}).value;
+          const bValue = label.compute(b, {useSortProperty: true}).value;
           const result = aValue < bValue ? -1 : aValue > bValue ? 1 : 0;
           return result * direction;
         };

--- a/app/assets/javascripts/admin/components/admin-report-table.js.es6
+++ b/app/assets/javascripts/admin/components/admin-report-table.js.es6
@@ -80,7 +80,7 @@ export default Ember.Component.extend({
       const compare = (label, direction) => {
         return (a, b) => {
            const aValue = label.compute(a, { useSortProperty: true }).value;
-          let bValue = label.compute(b, { useSortProperty: true }).value;
+           const bValue = label.compute(b, { useSortProperty: true }).value;
           const result = aValue < bValue ? -1 : aValue > bValue ? 1 : 0;
           return result * direction;
         };

--- a/app/assets/javascripts/admin/models/report.js.es6
+++ b/app/assets/javascripts/admin/models/report.js.es6
@@ -266,7 +266,7 @@ const Report = Discourse.Model.extend({
         compute: (row, opts = {}) => {
           let value = null;
 
-          if(opts.useSortProperty) {
+          if (opts.useSortProperty) {
             value = row[label.sort_property || mainProperty];
           } else {
             value = row[mainProperty];

--- a/app/assets/javascripts/admin/models/report.js.es6
+++ b/app/assets/javascripts/admin/models/report.js.es6
@@ -272,6 +272,7 @@ const Report = Discourse.Model.extend({
           if (type === "seconds") return this._secondsLabel(value);
           if (type === "link") return this._linkLabel(label.properties, row);
           if (type === "percent") return this._percentLabel(value);
+          if (type === "bytes") return this._bytesLabel(value);
           if (type === "number") {
             return this._numberLabel(value, opts);
           }
@@ -378,6 +379,13 @@ const Report = Discourse.Model.extend({
     return {
       value,
       formatedValue: value ? formatedValue() : "—"
+    };
+  },
+
+  _bytesLabel(value) {
+    return {
+      value,
+      formatedValue: I18n.toHumanSize(value),
     };
   },
 

--- a/app/assets/javascripts/admin/models/report.js.es6
+++ b/app/assets/javascripts/admin/models/report.js.es6
@@ -264,7 +264,7 @@ const Report = Discourse.Model.extend({
         mainProperty,
         type,
         compute: (row, opts = {}) => {
-          let value = null;
+           let value;
 
           if (opts.useSortProperty) {
             value = row[label.sort_property || mainProperty];

--- a/app/assets/javascripts/admin/models/report.js.es6
+++ b/app/assets/javascripts/admin/models/report.js.es6
@@ -264,7 +264,13 @@ const Report = Discourse.Model.extend({
         mainProperty,
         type,
         compute: (row, opts = {}) => {
-          const value = row[mainProperty];
+          let value = null;
+
+          if(opts.useSortProperty) {
+            value = row[label.sort_property || mainProperty];
+          } else {
+            value = row[mainProperty];
+          }
 
           if (type === "user") return this._userLabel(label.properties, row);
           if (type === "post") return this._postLabel(label.properties, row);

--- a/app/assets/javascripts/admin/models/report.js.es6
+++ b/app/assets/javascripts/admin/models/report.js.es6
@@ -264,7 +264,7 @@ const Report = Discourse.Model.extend({
         mainProperty,
         type,
         compute: (row, opts = {}) => {
-           let value;
+          let value;
 
           if (opts.useSortProperty) {
             value = row[label.sort_property || mainProperty];

--- a/app/assets/javascripts/admin/models/report.js.es6
+++ b/app/assets/javascripts/admin/models/report.js.es6
@@ -264,13 +264,7 @@ const Report = Discourse.Model.extend({
         mainProperty,
         type,
         compute: (row, opts = {}) => {
-          let value;
-
-          if (opts.useSortProperty) {
-            value = row[label.sort_property || mainProperty];
-          } else {
-            value = row[mainProperty];
-          }
+          const value = row[mainProperty];
 
           if (type === "user") return this._userLabel(label.properties, row);
           if (type === "post") return this._postLabel(label.properties, row);

--- a/app/assets/javascripts/admin/models/report.js.es6
+++ b/app/assets/javascripts/admin/models/report.js.es6
@@ -385,7 +385,7 @@ const Report = Discourse.Model.extend({
   _bytesLabel(value) {
     return {
       value,
-      formatedValue: I18n.toHumanSize(value),
+      formatedValue: I18n.toHumanSize(value)
     };
   },
 

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -1456,11 +1456,11 @@ class Report
     report.data = []
 
     sql = <<~SQL
-    SELECT 
+    SELECT
     u.id as user_id,
-    u.username, 
-    u.uploaded_avatar_id, 
-    up.filesize, 
+    u.username,
+    u.uploaded_avatar_id,
+    up.filesize,
     up.original_filename,
     up.extension,
     up.url

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -1,8 +1,6 @@
 require_dependency 'topic_subtype'
 
 class Report
-  extend ActionView::Helpers::NumberHelper
-
   # Change this line each time report format change
   # and you want to ensure cache is reset
   SCHEMA_VERSION = 3
@@ -1446,9 +1444,8 @@ class Report
         title: I18n.t("reports.top_uploads.labels.extension")
       },
       {
-        type: :text,
-        property: :filesize_label,
-        sort_property: :filesize,
+        type: :bytes,
+        property: :filesize,
         title: I18n.t("reports.top_uploads.labels.filesize")
       },
     ]
@@ -1477,10 +1474,10 @@ class Report
       data[:author_id] = row.user_id
       data[:author_username] = row.username
       data[:author_avatar_template] = User.avatar_template(row.username, row.uploaded_avatar_id)
-      data[:filesize_label] = number_to_human_size(row.filesize)
+      data[:filesize_label] = row.filesize
       data[:filesize] = row.filesize
       data[:extension] = row.extension
-      data[:file_url] = "#{Discourse.base_url}/#{row.url}"
+      data[:file_url] = Discourse.store.cdn_url(row.url)
       data[:file_name] = row.original_filename.truncate(25)
 
       report.data << data

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1171,6 +1171,14 @@ en:
         location: Location
         login_at: Login at
       description: "List of admin and moderator login times with locations."
+    top_uploads:
+      title: "Top Uploads"
+      labels:
+        filename: Filename
+        extension: Extension
+        author: Author
+        filesize: File size
+      description: "Gain understanding of file uploads usage."
 
   dashboard:
     rails_env_warning: "Your server is running in %{env} mode."

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -1028,4 +1028,54 @@ describe Report do
       end
     end
   end
+
+  describe "report_top_uploads" do
+    let(:report) { Report.find("top_uploads") }
+    let(:tarek) { Fabricate(:admin, username: "tarek") }
+    let(:khalil) { Fabricate(:admin, username: "khalil") }
+
+    context "when has Upload records" do
+      let!(:tarek_upload) do
+        Fabricate(:upload, user: tarek,
+                  url: "/uploads/default/original/1X/tarek.jpg",
+                  extension: "jpg",
+                  original_filename: "tarek.jpg",
+                  filesize: 1000)
+      end
+      let!(:khalil_upload) do
+        Fabricate(:upload, user: khalil,
+                  url: "/uploads/default/original/1X/khalil.png",
+                  extension: "png",
+                  original_filename: "khalil.png",
+                  filesize: 2000)
+      end
+
+      it "works" do
+        expect(report.data.length).to eq(2)
+        expect_row_to_be_equal(report.data.first, khalil, khalil_upload)
+        expect_row_to_be_equal(report.data.second, tarek, tarek_upload)
+      end
+
+      def expect_row_to_be_equal(row, user, upload)
+        helper = Class.new do
+          include ActionView::Helpers::NumberHelper
+        end
+        helper = helper.new
+
+        expect(row[:author_id]).to eq(user.id)
+        expect(row[:author_username]).to eq(user.username)
+        expect(row[:author_avatar_template]).to eq(User.avatar_template(user.username, user.uploaded_avatar_id))
+        expect(row[:filesize_label]).to eq(helper.number_to_human_size(upload.filesize))
+        expect(row[:filesize]).to eq(upload.filesize)
+        expect(row[:extension]).to eq(upload.extension)
+        expect(row[:file_url]).to eq("#{Discourse.base_url}/#{upload.url}")
+        expect(row[:file_name]).to eq(upload.original_filename.truncate(25))
+      end
+    end
+
+    context "when has NO Upload records" do
+
+      include_examples "no data"
+    end
+  end
 end

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -1037,17 +1037,17 @@ describe Report do
     context "when has Upload records" do
       let!(:tarek_upload) do
         Fabricate(:upload, user: tarek,
-                  url: "/uploads/default/original/1X/tarek.jpg",
-                  extension: "jpg",
-                  original_filename: "tarek.jpg",
-                  filesize: 1000)
+                           url: "/uploads/default/original/1X/tarek.jpg",
+                           extension: "jpg",
+                           original_filename: "tarek.jpg",
+                           filesize: 1000)
       end
       let!(:khalil_upload) do
         Fabricate(:upload, user: khalil,
-                  url: "/uploads/default/original/1X/khalil.png",
-                  extension: "png",
-                  original_filename: "khalil.png",
-                  filesize: 2000)
+                           url: "/uploads/default/original/1X/khalil.png",
+                           extension: "png",
+                           original_filename: "khalil.png",
+                           filesize: 2000)
       end
 
       it "works" do

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -1057,18 +1057,12 @@ describe Report do
       end
 
       def expect_row_to_be_equal(row, user, upload)
-        helper = Class.new do
-          include ActionView::Helpers::NumberHelper
-        end
-        helper = helper.new
-
         expect(row[:author_id]).to eq(user.id)
         expect(row[:author_username]).to eq(user.username)
         expect(row[:author_avatar_template]).to eq(User.avatar_template(user.username, user.uploaded_avatar_id))
-        expect(row[:filesize_label]).to eq(helper.number_to_human_size(upload.filesize))
         expect(row[:filesize]).to eq(upload.filesize)
         expect(row[:extension]).to eq(upload.extension)
-        expect(row[:file_url]).to eq("#{Discourse.base_url}/#{upload.url}")
+        expect(row[:file_url]).to eq(Discourse.store.cdn_url(upload.url))
         expect(row[:file_name]).to eq(upload.original_filename.truncate(25))
       end
     end

--- a/test/javascripts/models/report-test.js.es6
+++ b/test/javascripts/models/report-test.js.es6
@@ -523,7 +523,7 @@ QUnit.test("computed labels", assert => {
   assert.equal(filesizeLabel.sortProperty, "filesize");
   assert.equal(filesizeLabel.title, "Filesize");
   assert.equal(filesizeLabel.type, "bytes");
-  const computedFilesizeLabel  = filesizeLabel.compute(row);
+  const computedFilesizeLabel = filesizeLabel.compute(row);
   assert.equal(computedFilesizeLabel.formatedValue, "569.0 KB");
   assert.equal(computedFilesizeLabel.value, 582641);
 

--- a/test/javascripts/models/report-test.js.es6
+++ b/test/javascripts/models/report-test.js.es6
@@ -404,7 +404,8 @@ QUnit.test("computed labels", assert => {
       topic_id: 2,
       topic_title: "Test topic",
       post_number: 3,
-      post_raw: "This is the beginning of"
+      post_raw: "This is the beginning of",
+      filesize: 582641
     }
   ];
 
@@ -437,7 +438,8 @@ QUnit.test("computed labels", assert => {
         truncated_raw: "post_raw"
       },
       title: "Post"
-    }
+    },
+    { type: "bytes", property: "filesize", title: "Filesize" }
   ];
 
   const report = Report.create({
@@ -515,6 +517,15 @@ QUnit.test("computed labels", assert => {
     "<a href='/t/-/2/3'>This is the beginning of</a>"
   );
   assert.equal(computedPostLabel.value, "This is the beginning of");
+
+  const filesizeLabel = computedLabels[6];
+  assert.equal(filesizeLabel.mainProperty, "filesize");
+  assert.equal(filesizeLabel.sortProperty, "filesize");
+  assert.equal(filesizeLabel.title, "Filesize");
+  assert.equal(filesizeLabel.type, "bytes");
+  const computedFilesizeLabel  = filesizeLabel.compute(row);
+  assert.equal(computedFilesizeLabel.formatedValue, "569.0 KB");
+  assert.equal(computedFilesizeLabel.value, 582641);
 
   // subfolder support
   Discourse.BaseUri = "/forum";


### PR DESCRIPTION
## Why do we need this feature?

This is part of: https://meta.discourse.org/t/gain-understanding-of-file-uploads-usage/104994

I am introducing a new report: `Top Uploads` to take a first step in solving the problem of: `an Admin wants to gain understanding of their forum file uploads usage`.

## How does this work?

1. This is building on top of the `report.rb` class by providing a new method: `report_top_uploads` which in turn will be automatically detected as a new report by the `Admin::ReportsController#index` ...

2. The report will show the largest (by filesize) N (default: 250) uploads, and it will show by which user is the upload created.

## How does it look like?

![top uploads](https://user-images.githubusercontent.com/45508821/50401903-158db300-078a-11e9-907e-5c73f958ed99.gif)

