### PR TITLE
UX: removes unnecessary margin in header tag wrapper

### DIFF
--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -517,9 +517,6 @@ video {
     overflow: hidden;
     text-overflow: ellipsis;
   }
-  .topic-header-extra {
-    margin: 0 0 0 5px;
-  }
 }
 
 /* default docked header CSS for all topics, including those without categories */


### PR DESCRIPTION
This margin is not needed and doesn't exist in the mobile view. 

It causes a bit of a problem in desktop topics with no categories and more prominently in PMs with tags in the desktop view.

There's a small TODO here where the rest of the extra-info-wrapper styles should all be moved to header sylesheets.