### PR TITLE
FIX: use discourse route_for function to check url route

### DIFF
--- a/app/controllers/user_badges_controller.rb
+++ b/app/controllers/user_badges_controller.rb
@@ -61,12 +61,7 @@ class UserBadgesController < ApplicationController
         return render json: { failed: I18n.t('invalid_grant_badge_reason_link') }, status: 400
       end
 
-      path = begin
-        URI.parse(params[:reason]).path
-      rescue URI::Error
-      end
-
-      route = Rails.application.routes.recognize_path(path) if path
+      route = Discourse.route_for(params[:reason])
       if route
         topic_id = route[:topic_id].to_i
         post_number = route[:post_number] || 1


### PR DESCRIPTION
it takes care if there is a relative url root

https://meta.discourse.org/t/unable-to-grant-custom-badge-for-non-empty-reason-field/82299