### PR TITLE
Adding a setting for redis client id

### DIFF
--- a/app/models/global_setting.rb
+++ b/app/models/global_setting.rb
@@ -142,6 +142,7 @@ class GlobalSetting
         c = {}
         c[:host] = redis_host if redis_host
         c[:port] = redis_port if redis_port
+        c[:id] = redis_client_id if redis_client_id || "*"
 
         if redis_slave_host && redis_slave_port
           c[:slave_host] = redis_slave_host

--- a/config/discourse_defaults.conf
+++ b/config/discourse_defaults.conf
@@ -121,6 +121,10 @@ redis_password =
 # redis_sentinels = 10.0.0.1:26381,10.0.0.2:26381
 redis_sentinels =
 
+# redis client id might need to be set to nil to connect to some
+# cloud hosted redis instances (eg Google MemoryStore)
+redis_client_id =
+
 # enable Cross-origin Resource Sharing (CORS) directly at the application level
 enable_cors = false
 cors_origin = ''


### PR DESCRIPTION
Some redis providers, such as Google Memorystore do not allow the CLIENT
command.

https://github.com/mperham/sidekiq/wiki/Using-Redis#disabled-client-command

Discussion: https://meta.discourse.org/t/is-there-a-way-to-change-the-redis-connection-timeout/104476/11