### PR TITLE
FEATURE: add enpoint to check password of user

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -164,6 +164,15 @@ class Admin::UsersController < Admin::AdminController
     )
   end
 
+  def check_password
+    user = User.find_by_username_or_email(params[:username])
+    if user && user.confirm_password?(params[:password])
+      render json: success_json
+    else
+      render json: failed_json
+    end
+  end
+
   def log_out
     if @user
       @user.user_auth_tokens.destroy_all

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -100,6 +100,7 @@ Discourse::Application.routes.draw do
         get "list" => "users#index"
         get "list/:query" => "users#index"
         get "ip-info" => "users#ip_info"
+        post "check-password" => "users#check_password"
         delete "delete-others-with-same-ip" => "users#delete_other_accounts_with_same_ip"
         get "total-others-with-same-ip" => "users#total_other_accounts_with_same_ip"
         put "approve-bulk" => "users#approve_bulk"

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -527,6 +527,50 @@ RSpec.describe Admin::UsersController do
     end
   end
 
+  describe '#check_password' do
+    let(:reg_user) { Fabricate(:user, password: "ilovepasta") }
+
+    it "returns success with username and the correct password" do
+      post "/admin/users/check-password.json", params: {
+        username: reg_user.username,
+        password: "ilovepasta"
+      }
+      expect(response.status).to eq(200)
+      json = ::JSON.parse(response.body)
+      expect(json['success']).to eq("OK")
+    end
+
+    it "returns success with email and the correct password" do
+      post "/admin/users/check-password.json", params: {
+        username: reg_user.email,
+        password: "ilovepasta"
+      }
+      expect(response.status).to eq(200)
+      json = ::JSON.parse(response.body)
+      expect(json['success']).to eq("OK")
+    end
+
+    it "returns failed with a wrong password" do
+      post "/admin/users/check-password.json", params: {
+        username: reg_user.username,
+        password: "ihatepasta"
+      }
+      expect(response.status).to eq(200)
+      json = ::JSON.parse(response.body)
+      expect(json['failed']).to eq("FAILED")
+    end
+
+    it "returns failed with invalid username" do
+      post "/admin/users/check-password.json", params: {
+        username: "123123",
+        password: "ilovepasta"
+      }
+      expect(response.status).to eq(200)
+      json = ::JSON.parse(response.body)
+      expect(json['failed']).to eq("FAILED")
+    end
+  end
+
   describe '#log_out' do
     let(:reg_user) { Fabricate(:user) }
 


### PR DESCRIPTION
When other services should use Discourse for user authentification it is
not always possible to do this via a browser. Add an endpoint to check
the password of an existion user, which can be used e.g. by a mail server
to verify the user credentials via a simple API call.