### PR TITLE
FIX: composer full screen shortcut doesn't work if inputs have focus

### DIFF
--- a/app/assets/javascripts/discourse/components/composer-title.js.es6
+++ b/app/assets/javascripts/discourse/components/composer-title.js.es6
@@ -1,3 +1,4 @@
+/* global Mousetrap:true */
 import {
   default as computed,
   observes,

--- a/app/assets/javascripts/discourse/components/composer-title.js.es6
+++ b/app/assets/javascripts/discourse/components/composer-title.js.es6
@@ -1,11 +1,13 @@
 import {
   default as computed,
-  observes
+  observes,
+  on
 } from "ember-addons/ember-computed-decorators";
 import InputValidation from "discourse/models/input-validation";
 import { load, lookupCache } from "pretty-text/oneboxer";
 import { ajax } from "discourse/lib/ajax";
 import afterTransition from "discourse/lib/after-transition";
+import { getOwner } from "discourse-common/lib/get-owner";
 
 export default Ember.Component.extend({
   classNames: ["title-input"],
@@ -24,6 +26,20 @@ export default Ember.Component.extend({
     if (this.get("composer.titleLength") > 0) {
       Ember.run.debounce(this, this._titleChanged, 10);
     }
+    // We need to bind the full screen shortcut to the composer title in order
+    // for it to work even if the title has focus - see components/d-editor.js.es6
+    const mouseTrap = Mousetrap(this.$()[0]);
+    mouseTrap.bind(["shift+f11"], event => {
+      const composer = getOwner(this).lookup("controller:composer");
+      composer.toggleFullscreen();
+      return true;
+    });
+  },
+
+  @on("willDestroyElement")
+  _clearKeyboardShortcuts() {
+    const mouseTrap = Mousetrap(this.$()[0]);
+    mouseTrap.unbind("shift+f11");
   },
 
   @computed(

--- a/app/assets/javascripts/discourse/components/composer-title.js.es6
+++ b/app/assets/javascripts/discourse/components/composer-title.js.es6
@@ -29,16 +29,17 @@ export default Ember.Component.extend({
     // We need to bind the full screen shortcut to the composer title in order
     // for it to work even if the title has focus - see components/d-editor.js.es6
     const mouseTrap = Mousetrap(this.$()[0]);
-    mouseTrap.bind(["shift+f11"], event => {
+    mouseTrap.bind(["shift+f11"], () => {
       const composer = getOwner(this).lookup("controller:composer");
       composer.toggleFullscreen();
       return true;
     });
+    this._mouseTrap = mouseTrap;
   },
 
   @on("willDestroyElement")
   _clearKeyboardShortcuts() {
-    const mouseTrap = Mousetrap(this.$()[0]);
+    const mouseTrap = this._mouseTrap;
     mouseTrap.unbind("shift+f11");
   },
 

--- a/app/assets/javascripts/discourse/components/d-editor.js.es6
+++ b/app/assets/javascripts/discourse/components/d-editor.js.es6
@@ -267,7 +267,7 @@ export default Ember.Component.extend({
       return true;
     });
     // the full screen shortcut is also added in components/composer-title.js.es6
-    //  in order to work even if the title input has focus
+    // in order to work even if the title input has focus
     mouseTrap.bind(["shift+f11"], event => {
       const composer = getOwner(this).lookup("controller:composer");
       composer.toggleFullscreen();

--- a/app/assets/javascripts/discourse/components/d-editor.js.es6
+++ b/app/assets/javascripts/discourse/components/d-editor.js.es6
@@ -268,7 +268,7 @@ export default Ember.Component.extend({
     });
     // the full screen shortcut is also added in components/composer-title.js.es6
     // in order to work even if the title input has focus
-    mouseTrap.bind(["shift+f11"], event => {
+    mouseTrap.bind(["shift+f11"], () => {
       const composer = getOwner(this).lookup("controller:composer");
       composer.toggleFullscreen();
       return true;


### PR DESCRIPTION
History:

https://meta.discourse.org/t/fullscreen-composer-keyboard-shortcut-works-only-once/101920/3

The full screen shortcut in the composer does not work if either the title or body inputs have focus. Since we auto-focus the title field, this creates an extra step where the user has to click outside of that input to be able to trigger the shortcut and enter full screen mode.

In the transition between full screen mode and normal mode, the title field is removed and reinserted and it gets auto-focused every time. 

To avoid the extra step where the user has to click outside, we bind the shortcut to the inputs so that the user will be able to use it even if the inputs have focus.  