### PR TITLE
FEATURE: Make auth_redirect param options on user_api_keys

### DIFF
--- a/app/controllers/user_api_keys_controller.rb
+++ b/app/controllers/user_api_keys_controller.rb
@@ -87,12 +87,15 @@ class UserApiKeysController < ApplicationController
     public_key = OpenSSL::PKey::RSA.new(params[:public_key])
     @payload = Base64.encode64(public_key.public_encrypt(@payload))
 
-    (redirect_to("#{params[:auth_redirect]}?payload=#{CGI.escape(@payload)}") && return) if params[:auth_redirect]
-    respond_to do |format|
-      format.html { render :show }
-      format.json do
-        instructions = I18n.t("user_api_key.instructions", application_name: @application_name)
-        render json: { payload: @payload, instructions: instructions }
+    if params[:auth_redirect]
+      redirect_to("#{params[:auth_redirect]}?payload=#{CGI.escape(@payload)}")
+    else
+      respond_to do |format|
+        format.html { render :show }
+        format.json do
+          instructions = I18n.t("user_api_key.instructions", application_name: @application_name)
+          render json: { payload: @payload, instructions: instructions }
+        end
       end
     end
   end

--- a/app/views/user_api_keys/new.html.erb
+++ b/app/views/user_api_keys/new.html.erb
@@ -24,7 +24,7 @@
   <%= hidden_field_tag 'access', @access %>
   <%= hidden_field_tag 'nonce', @nonce %>
   <%= hidden_field_tag 'client_id', @client_id %>
-  <%= hidden_field_tag 'auth_redirect', @auth_redirect %>
+  <%= hidden_field_tag('auth_redirect', @auth_redirect) if @auth_redirect %>
   <%= hidden_field_tag 'push_url', @push_url %>
   <%= hidden_field_tag 'public_key', @public_key%>
   <%= hidden_field_tag 'scopes', @scopes%>

--- a/app/views/user_api_keys/show.html.erb
+++ b/app/views/user_api_keys/show.html.erb
@@ -1,0 +1,2 @@
+<p><%= t("user_api_key.instructions", application_name: @application_name) %></p>
+<code><%= @payload %></code>

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -874,6 +874,7 @@ en:
     read: "read"
     read_write: "read/write"
     description: "\"%{application_name}\" is requesting the following access to your account:"
+    instructions: "We just generated a new user API key for you to use with \"%{application_name}\", please paste the following key into your application:"
     no_trust_level: "Sorry, you do not have the required trust level to access the user API"
     generic_error: "Sorry, we are unable to issue user API keys, this feature may be disabled by the site admin"
     scopes:

--- a/spec/requests/user_api_keys_controller_spec.rb
+++ b/spec/requests/user_api_keys_controller_spec.rb
@@ -213,10 +213,27 @@ describe UserApiKeysController do
       args.delete(:auth_redirect)
 
       SiteSetting.min_trust_level_for_user_api_key = 0
+      post "/user-api-key", params: args
+      expect(response.status).not_to eq(302)
+      payload = Nokogiri::HTML(response.body).at('code').content
+      encrypted = Base64.decode64(payload)
+      key = OpenSSL::PKey::RSA.new(private_key)
+      parsed = JSON.parse(key.private_decrypt(encrypted))
+      api_key = UserApiKey.find_by(key: parsed["key"])
+      expect(api_key.user_id).to eq(user.id)
+    end
+
+    it "will just show the JSON payload if no redirect" do
+      user = Fabricate(:user, trust_level: 0)
+      sign_in(user)
+
+      args.delete(:auth_redirect)
+
+      SiteSetting.min_trust_level_for_user_api_key = 0
       post "/user-api-key.json", params: args
       expect(response.status).not_to eq(302)
-
-      encrypted = Base64.decode64(response.body)
+      payload = JSON.parse(response.body)["payload"]
+      encrypted = Base64.decode64(payload)
       key = OpenSSL::PKey::RSA.new(private_key)
       parsed = JSON.parse(key.private_decrypt(encrypted))
       api_key = UserApiKey.find_by(key: parsed["key"])

--- a/spec/requests/user_api_keys_controller_spec.rb
+++ b/spec/requests/user_api_keys_controller_spec.rb
@@ -205,5 +205,23 @@ describe UserApiKeysController do
 
       expect(response.status).to eq(302)
     end
+
+    it "will just show the payload if no redirect" do
+      user = Fabricate(:user, trust_level: 0)
+      sign_in(user)
+
+      args.delete(:auth_redirect)
+
+      SiteSetting.min_trust_level_for_user_api_key = 0
+      post "/user-api-key.json", params: args
+      expect(response.status).not_to eq(302)
+
+      encrypted = Base64.decode64(response.body)
+      key = OpenSSL::PKey::RSA.new(private_key)
+      parsed = JSON.parse(key.private_decrypt(encrypted))
+      api_key = UserApiKey.find_by(key: parsed["key"])
+      expect(api_key.user_id).to eq(user.id)
+
+    end
   end
 end


### PR DESCRIPTION
This is a possible solution for https://meta.discourse.org/t/user-api-keys-specification/48536/19
This allows for user-api-key requests to not require a redirect url.
Instead, the encypted payload will just be displayed after creation  ( which can be copied
pasted into an env for a CLI, for example  )