### PR TITLE
FEATURE: Include "via <site_name>" in email From header

### DIFF
--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -412,7 +412,7 @@ class UserNotifications < ActionMailer::Base
       title: notification_data[:topic_title],
       post: post,
       username: original_username,
-      from_alias: user_name,
+      from_alias: I18n.t('email_from', user_name: user_name, site_name: Email.site_title),
       allow_reply_by_email: allow_reply_by_email,
       use_site_subject: opts[:use_site_subject],
       add_re_to_subject: opts[:add_re_to_subject],

--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -235,7 +235,7 @@ class UserNotifications < ActionMailer::Base
       @preheader_text = I18n.t('user_notifications.digest.preheader', last_seen_at: @last_seen_at)
 
       opts = {
-        from_alias: I18n.t('user_notifications.digest.from', site_name: SiteSetting.title),
+        from_alias: I18n.t('user_notifications.digest.from', site_name: Email.site_title),
         subject: I18n.t('user_notifications.digest.subject_template', email_prefix: @email_prefix, date: short_date(Time.now)),
         add_unsubscribe_link: true,
         unsubscribe_url: "#{Discourse.base_url}/email/unsubscribe/#{@unsubscribe_key}",

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2884,6 +2884,7 @@ en:
 
   subject_re: "Re: "
   subject_pm: "[PM] "
+  email_from: "%{user_name} via %{site_name}"
 
   user_notifications:
     previous_discussion: "Previous Replies"

--- a/lib/email.rb
+++ b/lib/email.rb
@@ -37,4 +37,8 @@ module Email
     [text&.decoded, html&.decoded]
   end
 
+  def self.site_title
+    SiteSetting.email_site_title.presence || SiteSetting.title
+  end
+
 end

--- a/lib/email/message_builder.rb
+++ b/lib/email/message_builder.rb
@@ -208,8 +208,8 @@ module Email
         SiteSetting.email_site_title.blank? &&
         SiteSetting.title.blank?
 
-      if !@opts[:from_alias].blank?
-        "\"#{Email.cleanup_alias(@opts[:from_alias])}\" <#{source}>"
+      if @opts[:from_alias].present?
+        %Q|"#{Email.cleanup_alias(@opts[:from_alias])}" <#{source}>|
       elsif source == SiteSetting.notification_email || source == SiteSetting.reply_by_email_address
         site_alias_email(source)
       else
@@ -218,8 +218,8 @@ module Email
     end
 
     def site_alias_email(source)
-      from_alias = SiteSetting.email_site_title.presence || SiteSetting.title
-      "\"#{Email.cleanup_alias(from_alias)}\" <#{source}>"
+      from_alias = Email.site_title
+      %Q|"#{Email.cleanup_alias(from_alias)}" <#{source}>|
     end
 
   end

--- a/spec/mailers/user_notifications_spec.rb
+++ b/spec/mailers/user_notifications_spec.rb
@@ -247,7 +247,7 @@ describe UserNotifications do
                                              notification_data_hash: notification.data_hash
                                            )
       # from should include full user name
-      expect(mail[:from].display_names).to eql(['John Doe'])
+      expect(mail[:from].display_names).to eql(['John Doe via Discourse'])
 
       # subject should include category name
       expect(mail.subject).to match(/India/)
@@ -350,7 +350,7 @@ describe UserNotifications do
       expect(mail[:from].display_names).to_not eql(['John Doe'])
 
       # from should include username if "show user full names" is disabled
-      expect(mail[:from].display_names).to eql(['john'])
+      expect(mail[:from].display_names).to eql(['john via Discourse'])
 
       # subject should not include category name
       expect(mail.subject).not_to match(/Uncategorized/)
@@ -397,7 +397,7 @@ describe UserNotifications do
       )
 
       # from should include username if full user name is not provided
-      expect(mail[:from].display_names).to eql(['john'])
+      expect(mail[:from].display_names).to eql(['john via Discourse'])
 
       # subject should include "[PM]"
       expect(mail.subject).to include("[PM] ")
@@ -656,13 +656,13 @@ describe UserNotifications do
       it "should have user name as from_alias" do
         SiteSetting.enable_names = true
         SiteSetting.display_name_on_posts = true
-        expects_build_with(has_entry(:from_alias, "#{user.name}"))
+        expects_build_with(has_entry(:from_alias, "#{user.name} via Discourse"))
       end
 
       it "should not have user name as from_alias if display_name_on_posts is disabled" do
         SiteSetting.enable_names = false
         SiteSetting.display_name_on_posts = false
-        expects_build_with(has_entry(:from_alias, "walterwhite"))
+        expects_build_with(has_entry(:from_alias, "walterwhite via Discourse"))
       end
 
       it "should explain how to respond" do


### PR DESCRIPTION
This changes the `From` header of emails from "Jane Doe" to "Jane Doe via <site_name>" as requested in https://meta.discourse.org/t/change-send-as-in-email-notifications/31881. For Meta it will look like "Jane Doe via Discourse Meta". That should also prevent mistakes by users as described in https://meta.discourse.org/t/the-mailing-list-mode-email-address-book-trap/103838

It uses the value of the `email site title` site setting or, if it isn't set, the `title` setting as `<site_name>`.
The format of the `From` header can be customized with the `email_from` site text.

There's another change included in this PR: The `From` header of digest emails will now also use the `email site title` site setting before it falls back to the `title` setting.