### PR TITLE
UX: moves topic-list excerpts out of category / tag div

### DIFF
--- a/app/assets/javascripts/discourse/templates/list/topic-list-item.raw.hbs
+++ b/app/assets/javascripts/discourse/templates/list/topic-list-item.raw.hbs
@@ -31,11 +31,11 @@
       {{/unless}}
     {{/unless}}
     {{discourse-tags topic mode="list" tagsForUser=tagsForUser}}
-    {{#if expandPinned}}
-      {{raw "list/topic-excerpt" topic=topic}}
-    {{/if}}
     {{raw "list/action-list" topic=topic postNumbers=topic.liked_post_numbers className="likes" icon="heart"}}
   </div>
+  {{#if expandPinned}}
+    {{raw "list/topic-excerpt" topic=topic}}
+  {{/if}}
 </td>
 
 {{#if showPosters}}

--- a/app/assets/javascripts/discourse/templates/list/topic-list-item.raw.hbs
+++ b/app/assets/javascripts/discourse/templates/list/topic-list-item.raw.hbs
@@ -17,24 +17,24 @@
     {{~raw "topic-status" topic=topic}}
     {{~topic-link topic class="raw-link raw-topic-link"}}
     {{~#if topic.featured_link}}
-      {{~topic-featured-link topic}}
+    {{~topic-featured-link topic}}
     {{~/if}}
     {{~raw-plugin-outlet name="topic-list-after-title"}}
     {{~#if showTopicPostBadges}}
-      {{~raw "topic-post-badges" unread=topic.unread newPosts=topic.displayNewPosts unseen=topic.unseen url=topic.lastUnreadUrl newDotText=newDotText}}
+    {{~raw "topic-post-badges" unread=topic.unread newPosts=topic.displayNewPosts unseen=topic.unseen url=topic.lastUnreadUrl newDotText=newDotText}}
     {{~/if}}
   </span>
   <div class="link-bottom-line">
-  {{#unless hideCategory}}
-    {{#unless topic.isPinnedUncategorized}}
-      {{category-link topic.category}}
+    {{#unless hideCategory}}
+      {{#unless topic.isPinnedUncategorized}}
+        {{category-link topic.category}}
+      {{/unless}}
     {{/unless}}
-  {{/unless}}
-  {{discourse-tags topic mode="list" tagsForUser=tagsForUser}}
-  {{#if expandPinned}}
-    {{raw "list/topic-excerpt" topic=topic}}
-  {{/if}}
-  {{raw "list/action-list" topic=topic postNumbers=topic.liked_post_numbers className="likes" icon="heart"}}
+    {{discourse-tags topic mode="list" tagsForUser=tagsForUser}}
+    {{#if expandPinned}}
+      {{raw "list/topic-excerpt" topic=topic}}
+    {{/if}}
+    {{raw "list/action-list" topic=topic postNumbers=topic.liked_post_numbers className="likes" icon="heart"}}
   </div>
 </td>
 
@@ -49,21 +49,21 @@
 {{/if}}
 
 {{#if showLikes}}
-<td class="num likes">
-  {{#if hasLikes}}
-    <a href='{{topic.summaryUrl}}'>
-      {{number topic.like_count}} {{d-icon "heart"}}</td>
-    </a>
-  {{/if}}
+  <td class="num likes">
+    {{#if hasLikes}}
+      <a href='{{topic.summaryUrl}}'>
+        {{number topic.like_count}} {{d-icon "heart"}}</td>
+  </a>
+{{/if}}
 {{/if}}
 
 {{#if showOpLikes}}
-<td class="num likes">
-  {{#if hasOpLikes}}
-    <a href='{{topic.summaryUrl}}'>
-      {{number topic.op_like_count}} {{d-icon "heart"}}</td>
-    </a>
-  {{/if}}
+  <td class="num likes">
+    {{#if hasOpLikes}}
+      <a href='{{topic.summaryUrl}}'>
+        {{number topic.op_like_count}} {{d-icon "heart"}}</td>
+  </a>
+{{/if}}
 {{/if}}
 
 <td class="num views {{topic.viewsHeat}}">{{number topic.views numberKey="views_long"}}</td>

--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -144,9 +144,6 @@
     .discourse-tag.box {
       margin-right: 0.25em;
     }
-    .topic-excerpt {
-      flex: 1 1 0%; // IE11 fix - unit on flexbasis is required
-    }
   }
 
   .topic-featured-link {


### PR DESCRIPTION
History:

https://meta.discourse.org/t/category-showing-on-pinned-topics/105963

Note: 

This PR includes a code formatting commit for the template. There are no changes in that commit only formatting. 

All changes are in the subsequent commits