### PR TITLE
FEATURE: set CSP base-uri and object-src to none

### DIFF
--- a/lib/content_security_policy/default.rb
+++ b/lib/content_security_policy/default.rb
@@ -7,6 +7,8 @@ class ContentSecurityPolicy
 
     def initialize
       @directives = {}.tap do |directives|
+        directives[:base_uri] = [:none]
+        directives[:object_src] = [:none]
         directives[:script_src] = script_src
         directives[:worker_src] = worker_src
         directives[:report_uri] = report_uri if SiteSetting.content_security_policy_collect_reports

--- a/spec/lib/content_security_policy_spec.rb
+++ b/spec/lib/content_security_policy_spec.rb
@@ -16,6 +16,20 @@ describe ContentSecurityPolicy do
     end
   end
 
+  describe 'base-uri' do
+    it 'is set to none' do
+      base_uri = parse(policy)['base-uri']
+      expect(base_uri).to eq(["'none'"])
+    end
+  end
+
+  describe 'object-src' do
+    it 'is set to none' do
+      object_srcs = parse(policy)['object-src']
+      expect(object_srcs).to eq(["'none'"])
+    end
+  end
+
   describe 'worker-src' do
     it 'always has self and blob' do
       worker_srcs = parse(policy)['worker-src']


### PR DESCRIPTION
`object-src`: 
- For `<object>` , `<embed>` , and `<applet>` elements
- This is for Flash and family, so default to `'none'`

`base-uri` :

- Prevents the `<base>` of the page to be set to another domain which changes relative urls
- Discourse does not use `<base>` , so default to `'none'`

Setting them can prevent trivial bypasses to our CSP, and they are should quite safe. 