### PR TITLE
FIX: searching email logs by reply key

### DIFF
--- a/app/controllers/admin/email_controller.rb
+++ b/app/controllers/admin/email_controller.rb
@@ -32,7 +32,7 @@ class Admin::EmailController < Admin::AdminController
 
     if params[:reply_key].present?
       email_logs = email_logs.where(
-        "post_reply_keys.reply_key ILIKE ?", "%#{params[:reply_key]}%"
+        "CAST (post_reply_keys.reply_key AS VARCHAR) ILIKE ?", "%#{params[:reply_key]}%"
       )
     end
 


### PR DESCRIPTION
* you can't use LIKE or ILIKE on a UUID