### PR TITLE
remove safari check from isAppleDevice

### DIFF
--- a/app/assets/javascripts/discourse/lib/utilities.js.es6
+++ b/app/assets/javascripts/discourse/lib/utilities.js.es6
@@ -546,7 +546,6 @@ export function isAppleDevice() {
   // This will apply hack on all iDevices
   return (
     navigator.userAgent.match(/(iPad|iPhone|iPod)/g) &&
-    navigator.userAgent.match(/Safari/g) &&
     !navigator.userAgent.match(/Trident/g)
   );
 }


### PR DESCRIPTION
When running Discourse in WebView within React Native, "Safari" is not included in the ``userAgent``: 

iOS Safari User Agent:

```
Mozilla/5.0 (iPhone; CPU iPhone OS 11_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/11.0 Mobile/15E148 Safari/604.1
```

React Native iOS User Agent:
```
Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/16B91
```

This means ``isAppleDevice`` (in lib/utilities) returns null. However React Native WebView still requires the various apple hacks, such as ``positioningWorkaround`` (see lib/safari-hacks), which are not applied if ``isAppleDevice`` is null.

If we could remove the requirement of Safari from this check, that would fix it. The check still requires an iDevice.

cc @pmusaraj 