### PR TITLE
FIX: show user avatar on User summary page

### DIFF
--- a/app/serializers/user_summary_serializer.rb
+++ b/app/serializers/user_summary_serializer.rb
@@ -18,8 +18,12 @@ class UserSummarySerializer < ApplicationSerializer
     end
   end
 
-  class UserWithCountSerializer < BasicUserSerializer
-    attributes :count, :name
+  class UserWithCountSerializer < ApplicationSerializer
+    attributes :id, :username, :name, :count, :avatar_template
+
+    def avatar_template
+      User.avatar_template(object[:username], object[:uploaded_avatar_id])
+    end
   end
 
   class CategoryWithCountsSerializer < ApplicationSerializer

--- a/spec/serializers/basic_user_serializer_spec.rb
+++ b/spec/serializers/basic_user_serializer_spec.rb
@@ -22,6 +22,8 @@ describe BasicUserSerializer do
       expect(json[:name]).to be_blank
     end
 
+    it "returns the avatar_template" do
+      expect(json[:avatar_template]).to be_present
+    end
   end
-
 end

--- a/spec/serializers/user_summary_serializer_spec.rb
+++ b/spec/serializers/user_summary_serializer_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe UserSummarySerializer do
+  it "returns expected data" do
+    UserActionCreator.enable
+    user = Fabricate(:user)
+    liked_post = create_post
+    PostAction.act(user, liked_post, PostActionType.types[:like])
+
+    guardian = Guardian.new(user)
+    summary = UserSummary.new(user, guardian)
+    serializer = UserSummarySerializer.new(summary, scope: guardian, root: false)
+    json = serializer.as_json
+
+    expect(json[:likes_given]).to be_present
+    expect(json[:likes_received]).to be_present
+    expect(json[:posts_read_count]).to be_present
+    expect(json[:topic_count]).to be_present
+    expect(json[:time_read]).to be_present
+    expect(json[:most_liked_users][0][:count]).to be_present
+    expect(json[:most_liked_users][0][:username]).to be_present
+    expect(json[:most_liked_users][0][:avatar_template]).to be_present
+  end
+end


### PR DESCRIPTION
Fixes the issue where user avatar is not showing up on "Most replied to", "Most liked by", "Most liked" section on [user summary page](https://meta.discourse.org/u/techAPJ/summary).

The UX was regressed in [this commit](https://github.com/discourse/discourse/commit/f0af61da415d0bbb4a49cb0eb461bd7bbeb7ea12#diff-6cc61be7ac2ff6a06ffe7dcc9dccee8d).

Basically the existing condition was just checking for an object and in case of user summary page the object was `UserSummary::UserWithCount` which does not have `avatar_template` method anymore. This commit ensures that we check for `User` object explicitly and if that's not the case fetch the `avatar_template` from User model.