### PR TITLE
FIX: list staff users within the last month

### DIFF
--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -174,7 +174,7 @@ end
 desc "List all users which have been staff in the last month"
 task "users:list_recent_staff" => :environment do
   current_staff_ids = User.human_users.where("admin OR moderator").pluck(:id)
-  recent_actions = UserHistory.where("created_at < ?", 1.month.ago)
+  recent_actions = UserHistory.where("created_at > ?", 1.month.ago)
   recent_admin_ids = recent_actions.where(action: UserHistory.actions[:revoke_admin]).pluck(:target_user_id)
   recent_moderator_ids = recent_actions.where(action: UserHistory.actions[:revoke_moderation]).pluck(:target_user_id)
 


### PR DESCRIPTION
I've noticed that the `users:list_recent_staff` rake task listed all staff user which are currently staff and all which were staff before but not within the last month.

This tiny fix lists all users which were staff within the last month.