### PR TITLE
DEV: replaces DOMNodeInserted by the better MutationObserver

### DIFF
--- a/app/assets/javascripts/discourse/lib/safari-hacks.js.es6
+++ b/app/assets/javascripts/discourse/lib/safari-hacks.js.es6
@@ -191,7 +191,14 @@ function positioningWorkaround($fixedElement) {
     });
   }, 100);
 
-  fixedElement.addEventListener("DOMNodeInserted", checkForInputs);
+  const config = {
+    childList: true,
+    subtree: true,
+    attributes: false,
+    characterData: false
+  };
+  const observer = new MutationObserver(checkForInputs);
+  observer.observe(fixedElement, config);
 }
 
 export default positioningWorkaround;


### PR DESCRIPTION
@eviltrout I noticed we had this violation in chrome console on mobile:

```
discourse/lib/safari-hacks:196
[Violation] Added synchronous DOM mutation listener to a 'DOMNodeInserted' event. Consider using MutationObserver to make the page more responsive.
```

So I went ahead and did this. It seems rather safe https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver

Could you have a look at some point please ?