### PR TITLE
rm period

### DIFF
--- a/app/assets/javascripts/discourse/templates/discovery/topics.hbs
+++ b/app/assets/javascripts/discourse/templates/discovery/topics.hbs
@@ -78,7 +78,7 @@
 
     {{#footer-message education=footerEducation message=footerMessage}}
       {{#if latest}}
-        {{#if canCreateTopicOnCategory}}<a href {{action "createTopic"}}>{{i18n 'topic.suggest_create_topic'}}</a>.{{/if}}
+        {{#if canCreateTopicOnCategory}}<a href {{action "createTopic"}}>{{i18n 'topic.suggest_create_topic'}}</a>{{/if}}
       {{else if top}}
         {{#link-to "discovery.categories"}}{{i18n 'topic.browse_all_categories'}}{{/link-to}}, {{#link-to 'discovery.latest'}}{{i18n 'topic.view_latest_topics'}}{{/link-to}} {{i18n 'or'}} {{i18n 'filters.top.other_periods'}}.
         {{top-period-buttons period=period action=(action "changePeriod")}}


### PR DESCRIPTION
``topic.suggest_create_topic`` ends in a question mark:

```
Why not create a topic?
```

Meaning that this sentence has double punctuation if the period is included in the template.

