### PR TITLE
FIX: phpbb3 import - Display Post Id while importing

### DIFF
--- a/script/import_scripts/phpbb3/importers/post_importer.rb
+++ b/script/import_scripts/phpbb3/importers/post_importer.rb
@@ -25,6 +25,8 @@ module ImportScripts::PhpBB3
       is_first_post = row[:post_id] == row[:topic_first_post_id]
 
       attachments = import_attachments(row, user_id)
+      
+      puts "Processing post id: #{row[:post_id]}"
 
       mapped = {
         id: row[:post_id],


### PR DESCRIPTION
Displays posts id while importing for better error reference. At the moment it displays only table row which is not the same as post_id and it is harder for user to track.