### PR TITLE
FIX: make composer full screen shortcut work when inputs have focus

### DIFF
--- a/app/assets/javascripts/discourse/components/composer-editor.js.es6
+++ b/app/assets/javascripts/discourse/components/composer-editor.js.es6
@@ -108,6 +108,13 @@ export default Ember.Component.extend({
     this._resetUpload(true);
   },
 
+  @observes("focusTarget")
+  setFocus() {
+    if (this.get("focusTarget") === "editor") {
+      this.$("textarea").putCursorAtEnd();
+    }
+  },
+
   @computed
   markdownOptions() {
     return {

--- a/app/assets/javascripts/discourse/components/d-editor.js.es6
+++ b/app/assets/javascripts/discourse/components/d-editor.js.es6
@@ -256,15 +256,6 @@ export default Ember.Component.extend({
     const mouseTrap = Mousetrap(this.$(".d-editor-input")[0]);
     const shortcuts = this.get("toolbar.shortcuts");
 
-    // for some reason I am having trouble bubbling this so hack it in
-    mouseTrap.bind(["ctrl+alt+f"], event => {
-      this.appEvents.trigger("header:keyboard-trigger", {
-        type: "search",
-        event
-      });
-      return true;
-    });
-
     Object.keys(shortcuts).forEach(sc => {
       const button = shortcuts[sc];
       mouseTrap.bind(sc, () => {

--- a/app/assets/javascripts/discourse/components/d-editor.js.es6
+++ b/app/assets/javascripts/discourse/components/d-editor.js.es6
@@ -314,7 +314,6 @@ export default Ember.Component.extend({
     Object.keys(this.get("toolbar.shortcuts")).forEach(sc =>
       mouseTrap.unbind(sc)
     );
-    mouseTrap.unbind("ctrl+/", "command+/");
     this.$(".d-editor-preview").off("click.preview");
   },
 

--- a/app/assets/javascripts/discourse/controllers/composer.js.es6
+++ b/app/assets/javascripts/discourse/controllers/composer.js.es6
@@ -133,9 +133,10 @@ export default Ember.Controller.extend({
   @computed(
     "model.replyingToTopic",
     "model.creatingPrivateMessage",
-    "model.targetUsernames"
+    "model.targetUsernames",
+    "model.composeState"
   )
-  focusTarget(replyingToTopic, creatingPM, usernames) {
+  focusTarget(replyingToTopic, creatingPM, usernames, composeState) {
     if (this.capabilities.isIOS) {
       return "none";
     }
@@ -151,6 +152,10 @@ export default Ember.Controller.extend({
 
     if (replyingToTopic) {
       return "reply";
+    }
+
+    if (composeState === Composer.FULLSCREEN) {
+      return "editor";
     }
 
     return "title";

--- a/app/assets/javascripts/discourse/lib/keyboard-shortcuts.js.es6
+++ b/app/assets/javascripts/discourse/lib/keyboard-shortcuts.js.es6
@@ -7,7 +7,7 @@ const bindings = {
   "!": { postAction: "showFlags" },
   "#": { handler: "goToPost", anonymous: true },
   "/": { handler: "toggleSearch", anonymous: true },
-  "ctrl+alt+f": { handler: "toggleSearch", anonymous: true },
+  "ctrl+alt+f": { handler: "toggleSearch", anonymous: true, global: true },
   "=": { handler: "toggleHamburgerMenu", anonymous: true },
   "?": { handler: "showHelpModal", anonymous: true },
   ".": { click: ".alert.alert-info.clickable", anonymous: true }, // show incoming/updated topics
@@ -16,7 +16,7 @@ const bindings = {
   C: { handler: "focusComposer" },
   "ctrl+f": { handler: "showPageSearch", anonymous: true },
   "command+f": { handler: "showPageSearch", anonymous: true },
-  "ctrl+p": { handler: "printTopic", anonymous: true },
+  "ctrl+p": { handler: "printTopic", anonymous: true, global: true },
   "command+p": { handler: "printTopic", anonymous: true },
   d: { postAction: "deletePost" },
   e: { postAction: "editPost" },
@@ -67,7 +67,7 @@ const bindings = {
   "shift+s": { click: "#topic-footer-buttons button.share", anonymous: true }, // share topic
   "shift+u": { handler: "goToUnreadPost" },
   "shift+z shift+z": { handler: "logout" },
-  "shift+f11": { handler: "fullscreenComposer" },
+  "shift+f11": { handler: "fullscreenComposer", global: true },
   t: { postAction: "replyAsNewTopic" },
   u: { handler: "goBack", anonymous: true },
   "x r": {
@@ -101,7 +101,12 @@ export default {
       if (binding.path) {
         this._bindToPath(binding.path, key);
       } else if (binding.handler) {
-        this._bindToFunction(binding.handler, key);
+        if (binding.global) {
+          // global shortcuts will trigger even while focusing on input/textarea
+          this._globalBindToFunction(binding.handler, key);
+        } else {
+          this._bindToFunction(binding.handler, key);
+        }
       } else if (binding.postAction) {
         this._bindToSelectedPost(binding.postAction, key);
       } else if (binding.click) {
@@ -397,6 +402,12 @@ export default {
       }
       $sel.click();
     });
+  },
+
+  _globalBindToFunction(func, binding) {
+    if (typeof this[func] === "function") {
+      this.keyTrapper.bindGlobal(binding, _.bind(this[func], this));
+    }
   },
 
   _bindToFunction(func, binding) {

--- a/app/assets/javascripts/discourse/lib/keyboard-shortcuts.js.es6
+++ b/app/assets/javascripts/discourse/lib/keyboard-shortcuts.js.es6
@@ -16,7 +16,7 @@ const bindings = {
   C: { handler: "focusComposer" },
   "ctrl+f": { handler: "showPageSearch", anonymous: true },
   "command+f": { handler: "showPageSearch", anonymous: true },
-  "ctrl+p": { handler: "printTopic", anonymous: true, global: true },
+  "ctrl+p": { handler: "printTopic", anonymous: true },
   "command+p": { handler: "printTopic", anonymous: true },
   d: { postAction: "deletePost" },
   e: { postAction: "editPost" },

--- a/app/assets/javascripts/discourse/templates/composer.hbs
+++ b/app/assets/javascripts/discourse/templates/composer.hbs
@@ -111,7 +111,8 @@
                             importQuote=(action "importQuote")
                             togglePreview=(action "togglePreview")
                             showToolbar=showToolbar
-                            afterRefresh=(action "afterRefresh")}}
+                            afterRefresh=(action "afterRefresh")
+                            focusTarget=focusTarget}}
 
           <div class='submit-panel'>
             {{plugin-outlet name="composer-fields-below" args=(hash model=model)}}

--- a/app/assets/javascripts/vendor.js
+++ b/app/assets/javascripts/vendor.js
@@ -22,6 +22,7 @@
 //= require jquery.sortable.js
 //= require lodash.js
 //= require mousetrap.js
+//= require mousetrap-global-bind.js
 //= require rsvp.js
 //= require show-html.js
 //= require break_string

--- a/lib/tasks/javascript.rake
+++ b/lib/tasks/javascript.rake
@@ -74,6 +74,8 @@ task 'javascript:update' do
     }, {
       source: 'moment-timezone/builds/moment-timezone-with-data.js'
     }, {
+      source: 'mousetrap/plugins/global-bind/mousetrap-global-bind.js'
+    }, {
       source: 'resumablejs/resumable.js'
     }, {
       # TODO: drop when we eventually drop IE11, this will land in iOS in version 13

--- a/vendor/assets/javascripts/mousetrap-global-bind.js
+++ b/vendor/assets/javascripts/mousetrap-global-bind.js
@@ -1,0 +1,43 @@
+/**
+ * adds a bindGlobal method to Mousetrap that allows you to
+ * bind specific keyboard shortcuts that will still work
+ * inside a text input field
+ *
+ * usage:
+ * Mousetrap.bindGlobal('ctrl+s', _saveChanges);
+ */
+/* global Mousetrap:true */
+(function(Mousetrap) {
+    var _globalCallbacks = {};
+    var _originalStopCallback = Mousetrap.prototype.stopCallback;
+
+    Mousetrap.prototype.stopCallback = function(e, element, combo, sequence) {
+        var self = this;
+
+        if (self.paused) {
+            return true;
+        }
+
+        if (_globalCallbacks[combo] || _globalCallbacks[sequence]) {
+            return false;
+        }
+
+        return _originalStopCallback.call(self, e, element, combo);
+    };
+
+    Mousetrap.prototype.bindGlobal = function(keys, callback, action) {
+        var self = this;
+        self.bind(keys, callback, action);
+
+        if (keys instanceof Array) {
+            for (var i = 0; i < keys.length; i++) {
+                _globalCallbacks[keys[i]] = true;
+            }
+            return;
+        }
+
+        _globalCallbacks[keys] = true;
+    };
+
+    Mousetrap.init();
+}) (Mousetrap);


### PR DESCRIPTION
This is a fix for https://github.com/discourse/discourse/pull/6839 using a mousetrap.js plugin that allows binding keyboard shortcuts globally. 

* adds `global` parameter to keyboard shortcut definitions for `shift+f11` (composer full screen) and `ctrl+alt+f` (toggle search)
* sets focus on composer editor when going fullscreen