### PR TITLE
Replace embed on site link

### DIFF
--- a/docs/ADMIN-QUICK-START-GUIDE.md
+++ b/docs/ADMIN-QUICK-START-GUIDE.md
@@ -131,7 +131,7 @@ The invite area on your profile page also includes advanced Staff methods of [se
    - [Import old content from vBulletin, PHPbb, Vanilla, Drupal, BBPress, etc](https://github.com/discourse/discourse/tree/master/script/import_scripts)
    - A firewall on your server? [Configure firewall](https://meta.discourse.org/t/configure-a-firewall-for-discourse/20584).
    - A user friendly [offline page when rebuilding or upgrading?](https://meta.discourse.org/t/adding-an-offline-page-when-rebuilding/45238)
-   - Embed Discourse [in your WordPress install](https://github.com/discourse/wp-discourse), or [on your static HTML site](http://eviltrout.com/2014/01/22/embedding-discourse.html)
+   - Embed Discourse [in your WordPress install](https://github.com/discourse/wp-discourse), or [on your static HTML site](https://meta.discourse.org/t/embedding-discourse-comments-via-javascript/31963)
 
 ### Need more Help?
 


### PR DESCRIPTION
Move embed on site link to meta.discourse per the blog that was previously used (users are redirected to this meta.discourse link now).