### PR TITLE
FIX: corrects selector for move-to modal styles

### DIFF
--- a/app/assets/stylesheets/common/base/modal.scss
+++ b/app/assets/stylesheets/common/base/modal.scss
@@ -578,8 +578,8 @@
   }
 }
 
-// split topic modal
-.split-modal {
+// move-to topic modal
+.move-to-modal {
   // move to existing topic
   .existing-topic {
     .radio {
@@ -590,7 +590,6 @@
     }
     .topic-categories {
       width: 100%;
-      margin-left: 5px;
     }
   }
 }

--- a/app/assets/stylesheets/desktop/modal.scss
+++ b/app/assets/stylesheets/desktop/modal.scss
@@ -123,7 +123,9 @@
   }
 
   #move-selected {
-    width: 475px;
+    // prevents content from moving when user selects differnt move options 525px
+    // is the same width we set on category edit modal
+    width: 525px;
 
     p {
       margin-top: 0;


### PR DESCRIPTION
The markup for the modal changed in #6802 and so the styles from #6626 stopped working. This PR corrects the selector.

It also increases the width of the modal a bit to give content more space to expand.

