### PR TITLE
FIX: Lazy Loading: copy only present srcset

### DIFF
--- a/app/assets/javascripts/discourse/lib/lazy-load-images.js.es6
+++ b/app/assets/javascripts/discourse/lib/lazy-load-images.js.es6
@@ -45,7 +45,10 @@ function show(image) {
     };
 
     copyImg.src = imageData.src;
-    copyImg.srcset = imageData.srcset || copyImg.srcset;
+
+    if (imageData.srcset) {
+      copyImg.srcset = imageData.srcset;
+    }
 
     copyImg.style.position = "absolute";
     copyImg.style.top = `${image.offsetTop}px`;


### PR DESCRIPTION
When showing a lazy-loaded image, copy the `srcset` property only when it is actually set. `copyImg.srcset = copyImg.srcset` is not actually a noop but creates an empty `srcset`, changing content security rules on the image.