### PR TITLE
Compose PM Button Class Fix

### DIFF
--- a/app/assets/javascripts/discourse/templates/user.hbs
+++ b/app/assets/javascripts/discourse/templates/user.hbs
@@ -44,10 +44,10 @@
             <ul>
               {{#if model.can_send_private_message_to_user}}
               <li>
-                {{#d-button class="btn btn-primary compose-pm" action=(route-action "composePrivateMessage" model)}}
-                  {{d-icon "envelope"}}
-                  {{i18n "user.private_message"}}
-                {{/d-button}}
+                {{d-button class="btn btn-primary compose-pm"
+                  action=(route-action "composePrivateMessage" model)
+                  icon="envelope"
+                  label="user.private_message"}}
               </li>
               {{/if}}
               {{#if currentUser.staff}}


### PR DESCRIPTION
The compose-pm button in user profiles was inserted as an inline component, wrapping the icon and the label. This meant that the discourse button class system was not being applied correctly, i.e. this button has the class "no-text" when it has text. This converts the button to a standard component.

<img width="400" alt="screenshot at jan 24 17-18-10" src="https://user-images.githubusercontent.com/5931623/51658767-410bf380-1ffd-11e9-9ebe-2f8f5fe47f3a.png">
