### PR TITLE
Copy `welcome_message` translation override to `welcome_message_invite_only`

### DIFF
--- a/db/migrate/20190125103246_copy_login_required_welcome_message.rb
+++ b/db/migrate/20190125103246_copy_login_required_welcome_message.rb
@@ -1,0 +1,11 @@
+class CopyLoginRequiredWelcomeMessage < ActiveRecord::Migration[5.2]
+  def change
+    execute <<~SQL
+      INSERT INTO translation_overrides (locale, translation_key, value, created_at, updated_at)
+      SELECT locale, 'login_required.welcome_message_invite_only', value, created_at, updated_at
+      FROM translation_overrides
+      WHERE translation_key = 'login_required.welcome_message'
+      AND NOT EXISTS (SELECT 1 FROM translation_overrides WHERE translation_key = 'login_required.welcome_message_invite_only');
+    SQL
+  end
+end


### PR DESCRIPTION
This commit copies `login_required.welcome_message` translation override to `login_required.welcome_message_invite_only` if the `login_required.welcome_message_invite_only` override is blank. This is done so as to ensure that login page customization remains same after [this commit](https://github.com/discourse/discourse/commit/93eb0a0690fc8972c857ac2d7472b5f8d95c7953).