### PR TITLE
FEATURE: add topic list before status plugin outlet for mobile

### DIFF
--- a/app/assets/javascripts/discourse/templates/mobile/list/topic-list-item.raw.hbs
+++ b/app/assets/javascripts/discourse/templates/mobile/list/topic-list-item.raw.hbs
@@ -8,6 +8,7 @@
   <div>
   {{/unless~}}
     <div class='main-link'>
+      {{~raw-plugin-outlet name="topic-list-before-status"}}
       {{~raw "topic-status" topic=topic~}}
       {{~topic-link topic~}}
       {{~#if topic.featured_link~}}


### PR DESCRIPTION
Not sure if this was intentional to leave the plugin outlet out of the mobile view - this adds it.