### PR TITLE
FIX: tags added while editing a pending approval topic do not show up

### DIFF
--- a/app/models/queued_post.rb
+++ b/app/models/queued_post.rb
@@ -91,6 +91,12 @@ class QueuedPost < ActiveRecord::Base
       end
     end
 
+    if create_options[:tags].present? &&
+      created_post.post_number == 1 &&
+      created_post.topic.tags.blank?
+      DiscourseTagging.tag_topic_by_names(created_post.topic, Guardian.new(approved_by), create_options[:tags])
+    end
+
     # Do sidekiq work outside of the transaction
     creator.enqueue_jobs
     creator.trigger_after_events

--- a/spec/models/queued_post_spec.rb
+++ b/spec/models/queued_post_spec.rb
@@ -110,6 +110,7 @@ describe QueuedPost do
                                      title: 'This is the topic title to queue up',
                                      archetype: 'regular',
                                      category: category.id,
+                                     tags: ['evil', 'trout'],
                                      meta_data: { evil: 'trout' }
                                    }) }
 
@@ -122,6 +123,8 @@ describe QueuedPost do
       end
 
       it "creates the post and topic" do
+        SiteSetting.tagging_enabled = true
+        SiteSetting.min_trust_level_to_tag_topics = 4
         topic_count, post_count = Topic.count, Post.count
         post = qp.approve!(admin)
 
@@ -134,6 +137,7 @@ describe QueuedPost do
         topic = post.topic
         expect(topic).to be_present
         expect(topic.category).to eq(category)
+        expect(topic.tags.map(&:name)).to contain_exactly('evil', 'trout')
 
         expect(UserHistory.where(action: UserHistory.actions[:post_approved]).count).to eq(1)
       end


### PR DESCRIPTION
https://meta.discourse.org/t/tags-added-while-editing-a-pending-approval-topic-do-not-show-up/106349