### PR TITLE
Add a permalink normalization prefix setting for phpbb3

### DIFF
--- a/script/import_scripts/phpbb3/importers/permalink_importer.rb
+++ b/script/import_scripts/phpbb3/importers/permalink_importer.rb
@@ -47,6 +47,9 @@ module ImportScripts::PhpBB3
     protected
 
     def add_normalization(normalizations, normalization)
+      if @settings.normalization_prefix
+        normalization = "/" + @settings.normalization_prefix + "\\" + normalization
+      end
       normalizations << normalization unless normalizations.include?(normalization)
     end
 

--- a/script/import_scripts/phpbb3/settings.yml
+++ b/script/import_scripts/phpbb3/settings.yml
@@ -31,6 +31,9 @@ import:
     categories: true  # redirects   /viewforum.php?f=1            to  /c/category-name
     topics: true      # redirects   /viewtopic.php?f=6&t=43       to  /t/topic-name/81
     posts: false      # redirects   /viewtopic.php?p=2455#p2455   to  /t/topic-name/81/4
+    # Append a prefix to each type of link, ex. 'forum' to redirect /forum/viewtopic.php?f=6&t=43 to /t/topic-name/81
+    # Don't add an initial or final slash. If you have a multilevel prefix you will need to escape the forward slashes
+    prefix:
 
   avatars:
     uploaded: true  # import uploaded avatars

--- a/script/import_scripts/phpbb3/support/settings.rb
+++ b/script/import_scripts/phpbb3/support/settings.rb
@@ -84,11 +84,13 @@ module ImportScripts::PhpBB3
     attr_reader :create_category_links
     attr_reader :create_topic_links
     attr_reader :create_post_links
+    attr_reader :normalization_prefix
 
     def initialize(yaml)
       @create_category_links = yaml['categories']
       @create_topic_links = yaml['topics']
       @create_post_links = yaml['posts']
+      @normalization_prefix = yaml['prefix']
     end
   end
 end


### PR DESCRIPTION
[As discussed in the forum](https://meta.discourse.org/t/importing-from-phpbb3/30810/421), I used this in a test migration to enable you to set a prefix for the permalink normalisations.

It's not very rigorous though. Is there a good way to strip slashes from the beginning and end, and to escape any slashes found in the middle?

Edit: or considering all this does is add some text to the regexs, maybe it would be better to just add some docs, rather than trying to make the code foolproof.