### PR TITLE
Bump logster to 2.0.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -183,7 +183,7 @@ GEM
     logstash-event (1.2.02)
     logstash-logger (0.26.1)
       logstash-event (~> 1.2)
-    logster (2.0.0.pre)
+    logster (2.0.1)
     loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)


### PR DESCRIPTION
Fixes a problem with env line-height on iOS: https://github.com/discourse/logster/commit/026b7a8317ad3c9583e1210746cc92217cb28659