### PR TITLE
DEV: Plugin scss errors should break precompile

### DIFF
--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -105,6 +105,8 @@ module Discourse
 
   class Deprecation < StandardError; end
 
+  class ScssError < StandardError; end
+
   def self.filters
     @filters ||= [:latest, :unread, :new, :read, :posted, :bookmarks]
   end

--- a/lib/stylesheet/compiler.rb
+++ b/lib/stylesheet/compiler.rb
@@ -6,16 +6,6 @@ module Stylesheet
 
   class Compiler
 
-    def self.error_as_css(error, label)
-      error = error.message
-      error.gsub!("\n", '\A ')
-      error.gsub!("'", '\27 ')
-
-      "#main { display: none; }
-      body { white-space: pre; }
-      body:before { font-family: monospace; content: '#{error}' }"
-    end
-
     def self.compile_asset(asset, options = {})
 
       if Importer.special_imports[asset.to_s]

--- a/lib/stylesheet/manager.rb
+++ b/lib/stylesheet/manager.rb
@@ -166,15 +166,11 @@ class Stylesheet::Manager
          source_map_file: source_map_filename
       )
     rescue SassC::SyntaxError => e
-
-      # we do not need this reported as we will report it in the UI anyway
-      Rails.logger.info "Failed to compile #{@target} stylesheet: #{e.message}"
-
       if %w{embedded_theme mobile_theme desktop_theme}.include?(@target.to_s)
         # no special errors for theme, handled in theme editor
         ["", nil]
       else
-        [Stylesheet::Compiler.error_as_css(e, "#{@target} stylesheet"), nil]
+        raise Discourse::ScssError, e.message
       end
     end
 

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -58,7 +58,8 @@ task 'assets:precompile:css' => 'environment' do
         STDERR.puts "Compiling css for #{db} #{Time.zone.now}"
         begin
           Stylesheet::Manager.precompile_css
-        rescue => PG::UndefinedColumn
+        rescue PG::UndefinedColumn => e
+          STDERR.puts "#{e.class} #{e.message}: #{e.backtrace.join("\n")}"
           STDERR.puts "Skipping precompilation of CSS cause schema is old, you are precompiling prior to running migrations."
         end
       end


### PR DESCRIPTION
Previously, if a plugin had a SCSS syntax error, the app would rebuild and the error would be displayed in the browser when loading the app post-rebuild. 

This PR changes the behaviour by raising an error immediately on SCSS syntax errors, thus triggering a rebuild failure. 

Note that while testing these changes in several environments, the `rescue => PG::UndefinedColumn` line would trigger skipping CSS precompilation due to a `already initialized constant PG::UndefinedColumn` warning (the updated `raise` syntax no longer triggers the warning). 