### PR TITLE
FEATURE: Calculate CSP based on active themes

### DIFF
--- a/lib/content_security_policy.rb
+++ b/lib/content_security_policy.rb
@@ -4,8 +4,8 @@ require_dependency 'content_security_policy/extension'
 
 class ContentSecurityPolicy
   class << self
-    def policy
-      new.build
+    def policy(theme_ids = [])
+      new.build(theme_ids)
     end
 
     def base_url
@@ -14,10 +14,10 @@ class ContentSecurityPolicy
     attr_writer :base_url
   end
 
-  def build
+  def build(theme_ids)
     builder = Builder.new
 
-    Extension.theme_extensions.each { |extension| builder << extension }
+    Extension.theme_extensions(theme_ids).each { |extension| builder << extension }
     Extension.plugin_extensions.each { |extension| builder << extension }
     builder << Extension.site_setting_extension
 

--- a/lib/content_security_policy/extension.rb
+++ b/lib/content_security_policy/extension.rb
@@ -17,12 +17,13 @@ class ContentSecurityPolicy
 
     THEME_SETTING = 'extend_content_security_policy'
 
-    def theme_extensions
-      cache['theme_extensions'] ||= find_theme_extensions
+    def theme_extensions(theme_ids)
+      key = "theme_extensions_#{Theme.transform_ids(theme_ids).join(',')}"
+      cache[key] ||= find_theme_extensions(theme_ids)
     end
 
     def clear_theme_extensions_cache!
-      cache['theme_extensions'] = nil
+      cache.clear
     end
 
     private
@@ -31,10 +32,10 @@ class ContentSecurityPolicy
       @cache ||= DistributedCache.new('csp_extensions')
     end
 
-    def find_theme_extensions
+    def find_theme_extensions(theme_ids)
       extensions = []
 
-      Theme.find_each do |theme|
+      Theme.where(id: Theme.transform_ids(theme_ids)).find_each do |theme|
         theme.cached_settings.each do |setting, value|
           extensions << build_theme_extension(value) if setting.to_s == THEME_SETTING
         end

--- a/lib/content_security_policy/middleware.rb
+++ b/lib/content_security_policy/middleware.rb
@@ -12,11 +12,11 @@ class ContentSecurityPolicy
       _, headers, _ = response = @app.call(env)
 
       return response unless html_response?(headers)
-
       ContentSecurityPolicy.base_url = request.host_with_port if Rails.env.development?
 
-      headers['Content-Security-Policy'] = policy if SiteSetting.content_security_policy
-      headers['Content-Security-Policy-Report-Only'] = policy if SiteSetting.content_security_policy_report_only
+      theme_ids = env[:resolved_theme_ids]
+      headers['Content-Security-Policy'] = policy(theme_ids) if SiteSetting.content_security_policy
+      headers['Content-Security-Policy-Report-Only'] = policy(theme_ids) if SiteSetting.content_security_policy_report_only
 
       response
     end


### PR DESCRIPTION
Previously the CSP would include contributions from all installed themes, even if they weren't currently active. Now we calculate (and cache) the CSP based on the currently active themes.