### PR TITLE
REFACTOR: Do not use `[nil]` as a list of theme_ids when in safe mode

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -380,7 +380,10 @@ class ApplicationController < ActionController::Base
     return if request.method != "GET"
 
     resolve_safe_mode
-    return if request.env[NO_CUSTOM]
+
+    if request.env[NO_CUSTOM]
+      return @theme_ids = request.env[:resolved_theme_ids] = []
+    end
 
     theme_ids = []
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -381,11 +381,7 @@ module ApplicationHelper
   end
 
   def theme_ids
-    if customization_disabled?
-      [nil]
-    else
-      request.env[:resolved_theme_ids]
-    end
+    request.env[:resolved_theme_ids]
   end
 
   def scheme_id

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -135,10 +135,10 @@ class Theme < ActiveRecord::Base
 
       all_ids = [parent, *components]
 
-      disabled_ids = Theme.where(id: all_ids).includes(:remote_theme)
-        .reject(&:enabled?).pluck(:id)
+      enabled_ids = Theme.where(id: all_ids).includes(:remote_theme)
+        .select(&:enabled?).pluck(:id)
 
-      all_ids - disabled_ids
+      all_ids & enabled_ids # Maintain ordering using intersection
     end
   end
 

--- a/lib/stylesheet/manager.rb
+++ b/lib/stylesheet/manager.rb
@@ -44,6 +44,7 @@ class Stylesheet::Manager
     theme_ids = [theme_ids] unless Array === theme_ids
     theme_ids = [theme_ids.first] unless target =~ THEME_REGEX
     theme_ids = Theme.transform_ids(theme_ids, extend: false)
+    theme_ids = [nil] if theme_ids.empty? # Build at least one stylesheet without any theme
 
     current_hostname = Discourse.current_hostname
 

--- a/spec/components/svg_sprite/svg_sprite_spec.rb
+++ b/spec/components/svg_sprite/svg_sprite_spec.rb
@@ -18,7 +18,7 @@ describe SvgSprite do
     expect(SvgSprite.path([1, 2])).to eq("/svg-sprite/#{Discourse.current_hostname}/svg-1,2-#{version}.js")
 
     # Safe mode
-    expect(SvgSprite.path([nil])).to eq("/svg-sprite/#{Discourse.current_hostname}/svg--#{version}.js")
+    expect(SvgSprite.path(nil)).to eq("/svg-sprite/#{Discourse.current_hostname}/svg--#{version}.js")
   end
 
   it 'can search for a specific FA icon' do

--- a/spec/models/theme_spec.rb
+++ b/spec/models/theme_spec.rb
@@ -65,9 +65,8 @@ describe Theme do
     expect(Theme.transform_ids([theme.id])).to be_empty
   end
 
-  it "#transform_ids works with nil values" do
-    # Used in safe mode
-    expect(Theme.transform_ids([nil])).to eq([nil])
+  it "#transform_ids only passes valid themes" do
+    expect(Theme.transform_ids([nil])).to eq([])
   end
 
   it "doesn't allow multi-level theme components" do


### PR DESCRIPTION
I've removed this unusual behaviour, so now `[nil]` is only used inside a specific function of the stylesheet compiler.

cc @eviltrout 

