### PR TITLE
FIX: translate bootbox confirmation dialog

### DIFF
--- a/app/assets/javascripts/discourse/initializers/localization.js.es6
+++ b/app/assets/javascripts/discourse/initializers/localization.js.es6
@@ -55,7 +55,7 @@ export default {
     bootbox.addLocale(I18n.currentLocale(), {
       OK: I18n.t("composer.modal_ok"),
       CANCEL: I18n.t("composer.modal_cancel"),
-      CONFIRM: I18n.t("composer.modal_cancel")
+      CONFIRM: I18n.t("composer.modal_ok")
     });
     bootbox.setLocale(I18n.currentLocale());
   }

--- a/app/assets/javascripts/discourse/initializers/localization.js.es6
+++ b/app/assets/javascripts/discourse/initializers/localization.js.es6
@@ -51,5 +51,12 @@ export default {
         node[segs[segs.length - 1]] = v;
       }
     });
+
+    bootbox.addLocale(I18n.currentLocale(), {
+      OK: I18n.t("composer.modal_ok"),
+      CANCEL: I18n.t("composer.modal_cancel"),
+      CONFIRM: I18n.t("composer.modal_cancel")
+    });
+    bootbox.setLocale(I18n.currentLocale());
   }
 };


### PR DESCRIPTION
Localize bootbox confirmation buttons - pull from Discourse translation keys