### PR TITLE
FIX: Allow delete method in write scope

### DIFF
--- a/app/models/user_api_key.rb
+++ b/app/models/user_api_key.rb
@@ -2,7 +2,7 @@ class UserApiKey < ActiveRecord::Base
 
   SCOPES = {
     read: [:get],
-    write: [:get, :post, :patch],
+    write: [:get, :post, :patch, :delete],
     message_bus: [[:post, 'message_bus']],
     push: nil,
     notifications: [[:post, 'message_bus'], [:get, 'notifications#index'], [:put, 'notifications#mark_read']],


### PR DESCRIPTION
Simple use case: I want to delete a like in a post using the Discourse API and my User API Key.

