### PR TITLE
FIX: Allow restore when latest migration is a post_migration

### DIFF
--- a/lib/backup_restore/restorer.rb
+++ b/lib/backup_restore/restorer.rb
@@ -377,6 +377,14 @@ module BackupRestore
 
     def migrate_database
       log "Migrating the database..."
+
+      if Discourse.skip_post_deployment_migrations?
+        ENV["SKIP_POST_DEPLOYMENT_MIGRATIONS"] = "0"
+        Rails.application.config.paths['db/migrate'] << Rails.root.join(
+          Discourse::DB_POST_MIGRATE_PATH
+        ).to_s
+      end
+
       Discourse::Application.load_tasks
       ENV["VERSION"] = @current_version.to_s
       DB.exec("SET search_path = public, pg_catalog;")


### PR DESCRIPTION
Restoring a backup failed when the environment variable `SKIP_POST_DEPLOYMENT_MIGRATIONS` was set to `1` and the latest migration was a post_migration.