### PR TITLE
Bump logster to 2.1.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -183,7 +183,7 @@ GEM
     logstash-event (1.2.02)
     logstash-logger (0.26.1)
       logstash-event (~> 1.2)
-    logster (2.0.1)
+    logster (2.1.0)
     loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)


### PR DESCRIPTION
Includes improvements when running in development mode. See https://github.com/discourse/logster/commit/e73cbbb010e7d9429dcf3a6b8fc341c6b2148387