### PR TITLE
REFACTOR: Proxy letter avatars in rails instead of nginx

### DIFF
--- a/app/controllers/user_avatars_controller.rb
+++ b/app/controllers/user_avatars_controller.rb
@@ -35,7 +35,7 @@ class UserAvatarsController < ApplicationController
   def show_proxy_letter
     is_asset_path
 
-    if SiteSetting.external_system_avatars_url !~ /^\/letter_avatar_proxy/
+    if SiteSetting.external_system_avatars_url !~ /^\/letter(_avatar)?_proxy/
       raise Discourse::NotFound
     end
 
@@ -43,17 +43,8 @@ class UserAvatarsController < ApplicationController
     params.require(:color)
     params.require(:version)
     params.require(:size)
-
     hijack do
-      identity = LetterAvatar::Identity.new
-      identity.letter = params[:letter].to_s[0].upcase
-      identity.color = params[:color].scan(/../).map(&:hex)
-      image = LetterAvatar.generate(params[:letter].to_s, params[:size].to_i, identity: identity)
-
-      response.headers["Last-Modified"] = File.ctime(image).httpdate
-      response.headers["Content-Length"] = File.size(image).to_s
-      immutable_for(1.year)
-      send_file image, disposition: nil
+      proxy_avatar("https://avatars.discourse.org/#{params[:version]}/letter/#{params[:letter]}/#{params[:color]}/#{params[:size]}.png", Time.new('1990-01-01'))
     end
   end
 

--- a/config/nginx.sample.conf
+++ b/config/nginx.sample.conf
@@ -191,7 +191,7 @@ server {
     # This big block is needed so we can selectively enable
     # acceleration for backups and avatars
     # see note about repetition above
-    location ~ ^/(svg-sprite/|letter_avatar/|user_avatar|highlight-js|stylesheets|theme-javascripts|favicon/proxied|service-worker) {
+    location ~ ^/(svg-sprite/|letter_avatar/|letter_avatar_proxy/|letter_proxy/|user_avatar|highlight-js|stylesheets|theme-javascripts|favicon/proxied|service-worker) {
       proxy_set_header Host $http_host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Request-Start "t=${msec}";
@@ -211,30 +211,6 @@ server {
       proxy_cache_valid 200 301 302 7d;
       proxy_cache_valid any 1m;
       proxy_pass http://discourse;
-      break;
-    }
-
-    location /letter_avatar_proxy/ {
-      # Don't send any client headers to the avatars service
-      proxy_method GET;
-      proxy_pass_request_headers off;
-      proxy_pass_request_body off;
-
-      # Don't let cookies interrupt caching, and don't pass them to the
-      # client
-      proxy_ignore_headers "Set-Cookie";
-      proxy_hide_header "Set-Cookie";
-      proxy_hide_header "X-Discourse-Username";
-      proxy_hide_header "X-Runtime";
-
-      proxy_cache one;
-      # shared in multisite
-      proxy_cache_key $request_uri;
-      proxy_cache_valid 200 7d;
-      proxy_cache_valid 404 1m;
-      proxy_set_header Connection "";
-
-      proxy_pass https://avatars.discourse.org/;
       break;
     }
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -451,8 +451,9 @@ Discourse::Application.routes.draw do
   get "letter_avatar/:username/:size/:version.png" => "user_avatars#show_letter", format: false, constraints: { hostname: /[\w\.-]+/, size: /\d+/, username: RouteFormat.username }
   get "user_avatar/:hostname/:username/:size/:version.png" => "user_avatars#show", format: false, constraints: { hostname: /[\w\.-]+/, size: /\d+/, username: RouteFormat.username }
 
-  # in most production settings this is bypassed
+  # letter_avatar_proxy is deprecated since Feb '19, and can be removed after a full rebake
   get "letter_avatar_proxy/:version/letter/:letter/:color/:size.png" => "user_avatars#show_proxy_letter"
+  get "letter_proxy/:version/letter/:letter/:color/:size.png" => "user_avatars#show_proxy_letter"
 
   get "svg-sprite/:hostname/svg-:theme_ids-:version.js" => "svg_sprite#show", format: false, constraints: { hostname: /[\w\.-]+/, version: /\h{40}/, theme_ids: /([0-9]+(,[0-9]+)*)?/ }
   get "svg-sprite/search/:keyword" => "svg_sprite#search", format: false, constraints: { keyword: /[-a-z0-9\s\%]+/ }

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1077,7 +1077,7 @@ files:
     client: true
     shadowed_by_global: true
   external_system_avatars_url:
-    default: "/letter_avatar_proxy/v2/letter/{first_letter}/{color}/{size}.png"
+    default: "/letter_proxy/v3/letter/{first_letter}/{color}/{size}.png"
     client: true
     regex: '^((https?:)?\/)?\/.+[^\/]'
     shadowed_by_global: true

--- a/plugins/discourse-narrative-bot/spec/requests/discobot_certificate_spec.rb
+++ b/plugins/discourse-narrative-bot/spec/requests/discobot_certificate_spec.rb
@@ -25,7 +25,7 @@ describe "Discobot Certificate" do
       end
 
       it 'should return the right text' do
-        stub_request(:get, /letter_avatar_proxy/).to_return(status: 200)
+        stub_request(:get, /letter_proxy/).to_return(status: 200)
 
         stub_request(:get, "http://test.localhost//images/d-logo-sketch-small.png")
           .to_return(status: 200)

--- a/spec/components/pretty_text_spec.rb
+++ b/spec/components/pretty_text_spec.rb
@@ -215,7 +215,7 @@ describe PrettyText do
             ddd
             [/quote]
           MD
-          expect(PrettyText.cook(md)).to include("/forum/letter_avatar_proxy")
+          expect(PrettyText.cook(md)).to include("/forum/letter_proxy")
         end
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1147,7 +1147,7 @@ describe User do
       expect(user.small_avatar_url).to eq("//test.localhost/letter_avatar/sam/45/#{LetterAvatar.version}.png")
 
       SiteSetting.external_system_avatars_enabled = true
-      expect(user.small_avatar_url).to eq("//test.localhost/letter_avatar_proxy/v2/letter/s/5f9b8f/45.png")
+      expect(user.small_avatar_url).to eq("//test.localhost/letter_proxy/v3/letter/s/5f9b8f/45.png")
     end
 
   end

--- a/spec/requests/user_avatars_controller_spec.rb
+++ b/spec/requests/user_avatars_controller_spec.rb
@@ -10,7 +10,8 @@ describe UserAvatarsController do
     end
 
     it 'returns an avatar if we are allowing the proxy' do
-      get "/letter_avatar_proxy/v2/letter/a/aaaaaa/360.png"
+      stub_request(:get, "https://avatars.discourse.org/v3/letter/a/aaaaaa/360.png").to_return(body: 'image')
+      get "/letter_avatar_proxy/v3/letter/a/aaaaaa/360.png"
       expect(response.status).to eq(200)
     end
   end


### PR DESCRIPTION
- This change gives us more control over the request. In particular we can easily lookup DNS dynamically, instead of only upon nginx startup.
- The proxy path has been renamed from `letter_avatar_proxy` to `letter_proxy`, so that existing nginx config doesn't prevent use. The old path remains functional.
- Nginx config has been updated to add caching for both paths. This change will require a container rebuild.
- The proxy will now function in development environments, so the patch for `letter_avatar_proxy` has been removed