### PR TITLE
DEV: Allow validity of lock to be customizable for `DistributedMutex`.

### DIFF
--- a/spec/components/distributed_mutex_spec.rb
+++ b/spec/components/distributed_mutex_spec.rb
@@ -2,9 +2,15 @@ require 'rails_helper'
 require_dependency 'distributed_mutex'
 
 describe DistributedMutex do
+  let(:key) { "test_mutex_key" }
+
+  after do
+    $redis.del(key)
+  end
+
   it "allows only one mutex object to have the lock at a time" do
     mutexes = (1..10).map do
-      DistributedMutex.new("test_mutex_key")
+      DistributedMutex.new(key)
     end
 
     x = 0
@@ -22,9 +28,9 @@ describe DistributedMutex do
   end
 
   it "handles auto cleanup correctly" do
-    m = DistributedMutex.new("test_mutex_key")
+    m = DistributedMutex.new(key)
 
-    $redis.setnx "test_mutex_key", Time.now.to_i - 1
+    $redis.setnx key, Time.now.to_i - 1
 
     start = Time.now.to_i
     m.synchronize do
@@ -35,8 +41,26 @@ describe DistributedMutex do
     expect(Time.now.to_i).to be <= start + 1
   end
 
+  it 'allows the validity of the lock to be configured' do
+    freeze_time
+
+    mutex = DistributedMutex.new(key)
+
+    mutex.synchronize(validity: 2) do
+      expect($redis.ttl(key)).to eq(2)
+      expect($redis.get(key).to_i).to eq(Time.now.to_i + 2)
+    end
+
+    mutex.synchronize do
+      expect($redis.ttl(key)).to eq(DistributedMutex::DEFAULT_VALIDITY)
+
+      expect($redis.get(key).to_i)
+        .to eq(Time.now.to_i + DistributedMutex::DEFAULT_VALIDITY)
+    end
+  end
+
   it "maintains mutex semantics" do
-    m = DistributedMutex.new("test_mutex_key")
+    m = DistributedMutex.new(key)
 
     expect {
       m.synchronize do
@@ -55,7 +79,7 @@ describe DistributedMutex do
     end
 
     it "works even if redis is in readonly" do
-      m = DistributedMutex.new("test_readonly")
+      m = DistributedMutex.new(key)
       start = Time.now
       done = false
 


### PR DESCRIPTION
- Allows a user to override the default lock validity of 60 seconds.
- Also clean up test which was leaking a redis key