### PR TITLE
UX: Create 32x32 thumbnail for favicons.

### DIFF
--- a/app/assets/javascripts/discourse.js.es6
+++ b/app/assets/javascripts/discourse.js.es6
@@ -62,10 +62,7 @@ const Discourse = Ember.Application.extend({
   @observes("notifyCount")
   faviconChanged() {
     if (Discourse.User.currentProp("dynamic_favicon")) {
-      let url = Discourse.SiteSettings.site_favicon_url;
-      if (/^http/.test(url)) {
-        url = Discourse.getURL("/favicon/proxied?" + encodeURIComponent(url));
-      }
+      const url = Discourse.getURL("/favicon/proxied");
       new window.Favcount(url).set(this.get("notifyCount"));
     }
   },

--- a/app/models/admin_dashboard_data.rb
+++ b/app/models/admin_dashboard_data.rb
@@ -90,7 +90,6 @@ class AdminDashboardData
     @problem_blocks = []
 
     @problem_messages = [
-      'dashboard.bad_favicon_url',
       'dashboard.poll_pop3_timeout',
       'dashboard.poll_pop3_auth_error'
     ]

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -53,8 +53,8 @@ class Upload < ActiveRecord::Base
     opts ||= {}
     opts[:allow_animation] = SiteSetting.allow_animated_thumbnails
 
-    if get_optimized_image(width, height, opts)
-      save(validate: false)
+    if optimized_image = get_optimized_image(width, height, opts)
+      optimized_image if save(validate: false)
     end
   end
 

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1242,7 +1242,6 @@ en:
       one: "Email polling has generated an error in the past 24 hours. Look at <a href='%{base_path}/logs' target='_blank'>the logs</a> for more details."
       other: "Email polling has generated %{count} errors in the past 24 hours. Look at <a href='%{base_path}/logs' target='_blank'>the logs</a> for more details."
     missing_mailgun_api_key: "The server is configured to send emails via Mailgun but you haven't provided an API key used to verify the webhook messages."
-    bad_favicon_url: "The favicon is failing to load. Check your favicon setting in <a href='%{base_path}/admin/site_settings'>Site Settings</a>."
     poll_pop3_timeout: "Connection to the POP3 server is timing out. Incoming email could not be retrieved. Please check your <a href='%{base_path}/admin/site_settings/category/email'>POP3 settings</a> and service provider."
     poll_pop3_auth_error: "Connection to the POP3 server is failing with an authentication error. Please check your <a href='%{base_path}/admin/site_settings/category/email'>POP3 settings</a>."
     force_https_warning: "Your website is using SSL. But `<a href='%{base_path}/admin/site_settings/category/all_results?filter=force_https'>force_https</a>` is not yet enabled in your site settings."


### PR DESCRIPTION
- Also read file directly from disk for local store instead of having to
download the file over the network.

- External stores will still have to be downloaded.