### PR TITLE
FIX: a temporary fix when CJK user tries to add a long title

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -688,7 +688,13 @@ posting:
   max_users_notified_per_group_mention: 100
   newuser_max_replies_per_topic: 3
   newuser_max_mentions_per_post: 2
-  title_max_word_length: 30
+  title_max_word_length:
+    default: 30
+    locale_default:
+      ja: 50
+      ko: 50
+      zh_CN: 50
+      zh_TW: 50
   whitelisted_link_domains:
     default: ""
     type: list


### PR DESCRIPTION
Discourse doesn't analyze the sentence components. So it counts the whole sentence as a word for CJK.

https://meta.discoursecn.org/t/topic/3033