### PR TITLE
HTTPSify links

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ accepts contributions from the public &ndash; including you!
 Before contributing to Discourse:
 
 1. Please read the complete mission statements on [**discourse.org**](https://www.discourse.org). Yes we actually believe this stuff; you should too.
-2. Read and sign the [**Electronic Discourse Forums Contribution License Agreement**](https://discourse.org/cla).
+2. Read and sign the [**Electronic Discourse Forums Contribution License Agreement**](https://www.discourse.org/cla).
 3. Dig into [**CONTRIBUTING.MD**](CONTRIBUTING.md), which covers submitting bugs, requesting new features, preparing your code for a pull request, etc.
 4. Always strive to collaborate [with mutual respect](https://github.com/discourse/discourse/blob/master/docs/code-of-conduct.md).
 5. Not sure what to work on? [**We've got some ideas.**](https://meta.discourse.org/t/so-you-want-to-help-out-with-discourse/3823)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<a href="http://www.discourse.org/"><img src=
+<a href="https://www.discourse.org/"><img src=
 "https://user-images.githubusercontent.com/1681963/52239617-e2683480-289c-11e9-922b-5da55472e5b4.png"
  width="300px"></a>
 
@@ -10,14 +10,14 @@ Discourse is the 100% open source discussion platform built for the next decade 
 - discussion forum
 - long-form chat room
 
-To learn more about the philosophy and goals of the project, [visit **discourse.org**](http://www.discourse.org).
+To learn more about the philosophy and goals of the project, [visit **discourse.org**](https://www.discourse.org).
 
 ## Screenshots
 
 
 <a href="https://bbs.boingboing.net"><img alt="Boing Boing" src="https://user-images.githubusercontent.com/1681963/52239245-04ad8280-289c-11e9-9c88-8c173d4a0422.png" width="720px"></a>
 <a href="https://twittercommunity.com/"><img src="https://user-images.githubusercontent.com/1681963/52239250-04ad8280-289c-11e9-9e42-574f6eaab9d7.png" width="720px"></a>
-<a href="http://discuss.howtogeek.com"><img src="https://user-images.githubusercontent.com/1681963/52239247-04ad8280-289c-11e9-9706-fd66bc0749dc.png" width="720px"></a>
+<a href="https://discuss.howtogeek.com"><img src="https://user-images.githubusercontent.com/1681963/52239247-04ad8280-289c-11e9-9706-fd66bc0749dc.png" width="720px"></a>
 <a href="https://talk.turtlerockstudios.com/"><img src="https://user-images.githubusercontent.com/1681963/52239249-04ad8280-289c-11e9-9155-f0ccc5decc50.png" width="720px"></a>
 
 <img src="https://user-images.githubusercontent.com/1681963/52239118-b304f800-289b-11e9-9904-16450680d9ec.jpg" alt="Mobile" width="414">
@@ -34,7 +34,7 @@ To get your environment setup, follow the community setup guide for your operati
 
 If you're familiar with how Rails works and are comfortable setting up your own environment, you can also try out the [**Discourse Advanced Developer Guide**](docs/DEVELOPER-ADVANCED.md), which is aimed primarily at Ubuntu and macOS environments.
 
-Before you get started, ensure you have the following minimum versions: [Ruby 2.5+](http://www.ruby-lang.org/en/downloads/), [PostgreSQL 10+](http://www.postgresql.org/download/), [Redis 2.6+](http://redis.io/download). If you're having trouble, please see our [**TROUBLESHOOTING GUIDE**](docs/TROUBLESHOOTING.md) first!
+Before you get started, ensure you have the following minimum versions: [Ruby 2.5+](https://www.ruby-lang.org/en/downloads/), [PostgreSQL 10+](https://www.postgresql.org/download/), [Redis 2.6+](https://redis.io/download). If you're having trouble, please see our [**TROUBLESHOOTING GUIDE**](docs/TROUBLESHOOTING.md) first!
 
 ## Setting up Discourse
 
@@ -57,8 +57,8 @@ Discourse is built for the *next* 10 years of the Internet, so our requirements 
 
 - [Ruby on Rails](https://github.com/rails/rails) &mdash; Our back end API is a Rails app. It responds to requests RESTfully in JSON.
 - [Ember.js](https://github.com/emberjs/ember.js) &mdash; Our front end is an Ember.js app that communicates with the Rails API.
-- [PostgreSQL](http://www.postgresql.org/) &mdash; Our main data store is in Postgres.
-- [Redis](http://redis.io/) &mdash; We use Redis as a cache and for transient data.
+- [PostgreSQL](https://www.postgresql.org/) &mdash; Our main data store is in Postgres.
+- [Redis](https://redis.io/) &mdash; We use Redis as a cache and for transient data.
 
 Plus *lots* of Ruby Gems, a complete list of which is at [/master/Gemfile](https://github.com/discourse/discourse/blob/master/Gemfile).
 
@@ -71,11 +71,11 @@ accepts contributions from the public &ndash; including you!
 
 Before contributing to Discourse:
 
-1. Please read the complete mission statements on [**discourse.org**](http://www.discourse.org). Yes we actually believe this stuff; you should too.
-2. Read and sign the [**Electronic Discourse Forums Contribution License Agreement**](http://discourse.org/cla).
+1. Please read the complete mission statements on [**discourse.org**](https://www.discourse.org). Yes we actually believe this stuff; you should too.
+2. Read and sign the [**Electronic Discourse Forums Contribution License Agreement**](https://discourse.org/cla).
 3. Dig into [**CONTRIBUTING.MD**](CONTRIBUTING.md), which covers submitting bugs, requesting new features, preparing your code for a pull request, etc.
 4. Always strive to collaborate [with mutual respect](https://github.com/discourse/discourse/blob/master/docs/code-of-conduct.md).
-5. Not sure what to work on? [**We've got some ideas.**](http://meta.discourse.org/t/so-you-want-to-help-out-with-discourse/3823)
+5. Not sure what to work on? [**We've got some ideas.**](https://meta.discourse.org/t/so-you-want-to-help-out-with-discourse/3823)
 
 
 We look forward to seeing your pull requests!
@@ -86,7 +86,7 @@ We take security very seriously at Discourse; all our code is 100% open source a
 
 ## The Discourse Team
 
-The original Discourse code contributors can be found in [**AUTHORS.MD**](docs/AUTHORS.md). For a complete list of the many individuals that contributed to the design and implementation of Discourse, please refer to [the official Discourse blog](http://blog.discourse.org/2013/02/the-discourse-team/) and [GitHub's list of contributors](https://github.com/discourse/discourse/contributors).
+The original Discourse code contributors can be found in [**AUTHORS.MD**](docs/AUTHORS.md). For a complete list of the many individuals that contributed to the design and implementation of Discourse, please refer to [the official Discourse blog](https://blog.discourse.org/2013/02/the-discourse-team/) and [GitHub's list of contributors](https://github.com/discourse/discourse/contributors).
 
 
 ## Copyright / License
@@ -97,7 +97,7 @@ Licensed under the GNU General Public License Version 2.0 (or later);
 you may not use this work except in compliance with the License.
 You may obtain a copy of the License in the LICENSE file, or at:
 
-   http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt
+   https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -109,4 +109,4 @@ Discourse logo and “Discourse Forum” ®, Civilized Discourse Construction Ki
 
 ## Dedication
 
-Discourse is built with [love, Internet style.](http://www.youtube.com/watch?v=Xe1TZaElTAs)
+Discourse is built with [love, Internet style.](https://www.youtube.com/watch?v=Xe1TZaElTAs)

--- a/docs/ADMIN-QUICK-START-GUIDE.md
+++ b/docs/ADMIN-QUICK-START-GUIDE.md
@@ -1,4 +1,4 @@
-Congratulations, you are now the proud owner of your very own [Civilized Discourse Construction Kit](http://www.discourse.org). :hatching_chick:
+Congratulations, you are now the proud owner of your very own [Civilized Discourse Construction Kit](https://www.discourse.org). :hatching_chick:
 
 ### Getting Started
 
@@ -101,7 +101,7 @@ Be patient; building communities is hard. Before launching, be sure to:
 3. Commit to visiting and participating regularly.
 4. Link your community everywhere and promote it so people can find it.
 
-There's more advice at [Building a Discourse Community](http://blog.discourse.org/2014/08/building-a-discourse-community/).
+There's more advice at [Building a Discourse Community](https://blog.discourse.org/2014/08/building-a-discourse-community/).
 
 ### Sending Invitations
 
@@ -135,7 +135,7 @@ The invite area on your profile page also includes advanced Staff methods of [se
 
 ### Need more Help?
 
-For more assistance on configuring and running your Discourse forum, see [meta.discourse.org](http://meta.discourse.org).
+For more assistance on configuring and running your Discourse forum, see [meta.discourse.org](https://meta.discourse.org).
 
 ----
 

--- a/docs/AUTHORS.md
+++ b/docs/AUTHORS.md
@@ -1,4 +1,4 @@
-> ⚠ This document _only_ reflects the team at the time of the original release in February 2013. For a more detailed and up to date list of the many individuals that contributed to the design and development of Discourse since then, please refer to [the official Discourse website](http://www.discourse.org). For a list of people who have contributed to the codebase, see [GitHub's list of contributors](https://github.com/discourse/discourse/contributors).
+> ⚠ This document _only_ reflects the team at the time of the original release in February 2013. For a more detailed and up to date list of the many individuals that contributed to the design and development of Discourse since then, please refer to [the official Discourse website](https://www.discourse.org). For a list of people who have contributed to the codebase, see [GitHub's list of contributors](https://github.com/discourse/discourse/contributors).
 
 # The Core Discourse Team
 

--- a/docs/DEVELOPMENT-OSX-NATIVE.md
+++ b/docs/DEVELOPMENT-OSX-NATIVE.md
@@ -2,7 +2,7 @@
 
 These instructions assume you have read and understood the **[Discourse Advanced Developer Install Guide](DEVELOPER-ADVANCED.md)**.
 
-OS X has become a popular platform for developing Ruby on Rails applications; as such, if you run OS X, you might find it more congenial to work on **[Discourse](http://discourse.org)** in your native environment. These instructions should get you there.
+OS X has become a popular platform for developing Ruby on Rails applications; as such, if you run OS X, you might find it more congenial to work on **[Discourse](https://www.discourse.org)** in your native environment. These instructions should get you there.
 
 Obviously, if you **already** develop Ruby on OS X, a lot of this will be redundant, because you'll have already done it, or something like it. If that's the case, you may well be able to just install Ruby 2.5+ using RVM and get started! Discourse has enough dependencies, however (note: not a criticism!) that there's a good chance you'll find **something** else in this document that's useful for getting your Discourse development started!
 
@@ -31,7 +31,7 @@ en_US.UTF-8
 
 ## OS X Development Tools
 
-As the [RVM website](http://rvm.io) makes clear, there are some serious issues between MRI Ruby and the modern Xcode command line tools, which are based on CLANG and LLVM, rather than classic GCC.
+As the [RVM website](https://rvm.io) makes clear, there are some serious issues between MRI Ruby and the modern Xcode command line tools, which are based on CLANG and LLVM, rather than classic GCC.
 
 This means that you need to do a little bit of groundwork if you do not already have an environment that you know for certain yields working rubies and gems.
 
@@ -41,7 +41,7 @@ You will then need the old GCC-4.2 compilers, which leads us to...
 
 ## Homebrew
 
-**[Homebrew](http://mxcl.github.com/homebrew)** is a package manager for ports of various Open Source packages that Apple doesn't already include (or newer versions of the ones they do), and competes in that space with MacPorts and a few others. Brew is very different from Apt, in that it often installs from source, and almost always installs development files as well as binaries, especially for libraries, so there are no special "-dev" packages.
+**[Homebrew](https://brew.sh)** is a package manager for ports of various Open Source packages that Apple doesn't already include (or newer versions of the ones they do), and competes in that space with MacPorts and a few others. Brew is very different from Apt, in that it often installs from source, and almost always installs development files as well as binaries, especially for libraries, so there are no special "-dev" packages.
 
 RVM (below) can automatically install homebrew for you with the autolibs setting, but doesn't install the GCC-4.2 compiler package when it does so, possibly because that package is not part of the mainstream homebrew repository.
 
@@ -94,15 +94,15 @@ You should now be able to check out a clone of Discourse.
 
 ### SourceTree
 
-Atlassian has a free Git client for OS X called [SourceTree](http://www.sourcetreeapp.com/download/) which can be extremely useful for keeping visual track of what's going on in Git-land. While it's arguably not a full substitute for command-line git (especially if you know the command line well), it's extremely powerful for a GUI version-control client.
+Atlassian has a free Git client for OS X called [SourceTree](https://www.sourcetreeapp.com/download/) which can be extremely useful for keeping visual track of what's going on in Git-land. While it's arguably not a full substitute for command-line git (especially if you know the command line well), it's extremely powerful for a GUI version-control client.
 
 ## Postgres 10
 
-OS X might ship with Postgres 9.x, but you're better off going with 10 and above from Homebrew or [Postgres.app](http://postgresapp.com).
+OS X might ship with Postgres 9.x, but you're better off going with 10 and above from Homebrew or [Postgres.app](https://postgresapp.com).
 
 ### Using Postgres.app
 
-After installing [Postgres.app](http://postgresapp.com/), there are some additional setup steps that are necessary for discourse to create a database on your machine.
+After installing [Postgres.app](https://postgresapp.com/), there are some additional setup steps that are necessary for discourse to create a database on your machine.
 
 Open this file:
 ```
@@ -203,7 +203,7 @@ cd ~/Library/Fonts
 fondu /System/Library/Fonts/Helvetica.dfont
 mkdir ~/.magick
 cd ~/.magick
-curl http://www.imagemagick.org/Usage/scripts/imagick_type_gen > type_gen
+curl https://www.imagemagick.org/Usage/scripts/imagick_type_gen > type_gen
 find /System/Library/Fonts /Library/Fonts ~/Library/Fonts -name "*.[to]tf" | perl type_gen -f - > type.xml
 cd /usr/local/Cellar/imagemagick/<version>/etc/ImageMagick-6
 ```
@@ -281,4 +281,4 @@ These commands assume an empty Discourse database, and an otherwise empty redis 
     redis-cli flushall
     bundle exec rspec # re-running to see if tests pass
 
-Search http://meta.discourse.org for solutions to other problems.
+Search https://meta.discourse.org for solutions to other problems.

--- a/docs/INSTALL-email.md
+++ b/docs/INSTALL-email.md
@@ -37,7 +37,7 @@ NOTE: Elastic Email policy insists on an additional UNSUBSCRIBE link at the bott
 
    [ee]: https://elasticemail.com
   [jet]: https://www.mailjet.com/pricing
-  [gun]: http://www.mailgun.com/
+  [gun]: https://www.mailgun.com/
    [sg]: https://sendgrid.com/
   [sg2]: https://sendgrid.com/docs/Classroom/Send/How_Emails_Are_Sent/api_keys.html
   

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -21,9 +21,9 @@ Hosting Rails applications is complicated. Even if you already have Postgres, Re
 
 ### Software Requirements
 
-- [Postgres 10+](http://www.postgresql.org/download/)
-- [Redis 2.6+](http://redis.io/download)
-- [Ruby 2.5+](http://www.ruby-lang.org/en/downloads/) (we recommend 2.5.2 or higher)
+- [Postgres 10+](https://www.postgresql.org/download/)
+- [Redis 2.6+](https://redis.io/download)
+- [Ruby 2.5+](https://www.ruby-lang.org/en/downloads/) (we recommend 2.5.2 or higher)
 
 ## Security
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -10,7 +10,7 @@ For a list of recent security commits, check [our GitHub commits prefixed with S
 
 ### Password Storage
 
-Discourse uses the PBKDF2 algorithm to encrypt salted passwords. This algorithm is blessed by NIST. Security experts on the web [tend to agree that PBKDF2 is a secure choice](http://security.stackexchange.com/questions/4781/do-any-security-experts-recommend-bcrypt-for-password-storage).
+Discourse uses the PBKDF2 algorithm to encrypt salted passwords. This algorithm is blessed by NIST. Security experts on the web [tend to agree that PBKDF2 is a secure choice](https://security.stackexchange.com/questions/4781/do-any-security-experts-recommend-bcrypt-for-password-storage).
 
 **options you can customise in your production.rb file**
 
@@ -35,7 +35,7 @@ In addition, titles and all other places where non-admins can enter code are pro
 
 ### CSRF
 
-[CSRF](http://en.wikipedia.org/wiki/Cross-site_request_forgery) allows malicious sites to perform HTTP requests in the context of a forum user without their knowledge -- mostly by getting users who already hold a valid forum login cookie to click a specific link in their web browser.
+[CSRF](https://en.wikipedia.org/wiki/Cross-site_request_forgery) allows malicious sites to perform HTTP requests in the context of a forum user without their knowledge -- mostly by getting users who already hold a valid forum login cookie to click a specific link in their web browser.
 
 Discourse extends the built-in Rails CSRF protection in the following ways:
 
@@ -47,7 +47,7 @@ Discourse extends the built-in Rails CSRF protection in the following ways:
 
 ### DDOS
 
-If you install via our recommended Docker image in our [install guide][ig], nginx is the front end web server. For additional DDOS protection we recommend placing [HAProxy](http://haproxy.1wt.eu/) in front.
+If you install via our recommended Docker image in our [install guide][ig], nginx is the front end web server. For additional DDOS protection we recommend placing [HAProxy](https://www.haproxy.org/) in front.
 
 ### Deployment concerns
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -4,7 +4,7 @@ Some notes about testing Discourse:
 
 ## MailCatcher
 
-Discourse depends heavily on (sending) email for notifications. We use [MailCatcher](http://mailcatcher.me/) 
+Discourse depends heavily on (sending) email for notifications. We use [MailCatcher](https://mailcatcher.me/) 
 to test emails. It's super convenient!
 
 > MailCatcher runs a super simple SMTP server which catches any message sent to it to display in a web interface. Run mailcatcher, set your favourite app to deliver to smtp://127.0.0.1:1025 instead of your default SMTP server, then check out http://127.0.0.1:1080 to see the mail that's arrived so far.

--- a/docs/code-of-conduct.md
+++ b/docs/code-of-conduct.md
@@ -68,7 +68,7 @@ members of the project's leadership.
 ## Attribution
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at [http://contributor-covenant.org/version/1/4][version]
+available at [https://contributor-covenant.org/version/1/4][version]
 
-[homepage]: http://contributor-covenant.org
-[version]: http://contributor-covenant.org/version/1/4/
+[homepage]: https://contributor-covenant.org
+[version]: https://contributor-covenant.org/version/1/4/

--- a/lib/freedom_patches/open_uri_redirections.rb
+++ b/lib/freedom_patches/open_uri_redirections.rb
@@ -6,7 +6,7 @@
 # https://gist.github.com/1271420
 #
 # Relevant issue:
-# http://redmine.ruby-lang.org/issues/3719
+# https://redmine.ruby-lang.org/issues/3719
 #
 # Source here:
 # https://github.com/ruby/ruby/blob/trunk/lib/open-uri.rb


### PR DESCRIPTION
Upgrade all links to HTTPS in Discourse's documentation.

Note to Discourse team: Diff for the whole PR lives at [https://github.com/discourse/discourse/pull/7046.patch](https://github.com/discourse/discourse/pull/7046.patch) or at [https://github.com/discourse/discourse/pull/7046/files](https://github.com/discourse/discourse/pull/7046/files).

You might want to squash merge this with a custom commit message and commit body since there are a lot of commits.