### PR TITLE
Bump logster to -v 2.1.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -186,7 +186,7 @@ GEM
     logstash-event (1.2.02)
     logstash-logger (0.26.1)
       logstash-event (~> 1.2)
-    logster (2.1.1)
+    logster (2.1.2)
     loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)

--- a/config/initializers/100-logster.rb
+++ b/config/initializers/100-logster.rb
@@ -69,6 +69,7 @@ if Rails.env.production?
     # scopes for the enums
     /^Creating scope :open\. Overwriting existing method Poll\.open\./,
   ]
+  Logster.config.env_expandable_keys.push(:hostname, :problem_db)
 end
 
 # middleware that logs errors sits before multisite


### PR DESCRIPTION
Adds support for env expandable keys. See details here: https://github.com/discourse/logster/commit/00cbbf78a85eb86e2e06066ed80815b5fabfe1e2