### PR TITLE
FIX: 'guidelines_topic.body' in Brazillian Portuguese

### DIFF
--- a/config/locales/server.pt_BR.yml
+++ b/config/locales/server.pt_BR.yml
@@ -2532,7 +2532,7 @@ pt_BR:
     body: | 
       <a name="civilized"></a>
       
-      ## [Este é um lugar civilizado para discussão pública] (#civilized)
+      ## [Este é um lugar civilizado para discussão pública](#civilized)
       
       Por favor, trate este fórum de discussão com o mesmo respeito que você faria com um parque público. Nós também somos um recurso da comunidade compartilhada & mdash; um lugar para compartilhar habilidades, conhecimento e interesses por meio de conversas contínuas.
 
@@ -2540,7 +2540,7 @@ pt_BR:
 
       <a name="improve"></a>
 
-      ## [Melhore a discussão] (#improve) 
+      ## [Melhore a discussão](#improve) 
 
       Ajude-nos a fazer deste um ótimo lugar para discussão, sempre trabalhando para melhorar a discussão de alguma forma, por menor que seja. Se você não tiver certeza de que sua postagem será adicionada à conversa, pense no que deseja dizer e tente novamente mais tarde.
 
@@ -2550,7 +2550,7 @@ pt_BR:
 
       <a name="agreeable"></a>
 
-      ## [Seja agradável, mesmo quando você discordar] (#agreeable)
+      ## [Seja agradável, mesmo quando você discordar](#agreeable)
 
       Você pode querer responder a algo discordando dele. Isso é bom. Mas lembre-se de _criticizar idéias, não pessoas_. Por favor, evite:
 
@@ -2573,7 +2573,7 @@ pt_BR:
 
       <a name="flag-problems"></a>
 
-      ## [Se você ver um problema, sinalize-o] (#flag-problems)
+      ## [Se você ver um problema, sinalize-o](#flag-problems)
 
       Moderadores têm autoridade especial; eles são responsáveis ​​por este fórum. Mas você também. Com a sua ajuda, os moderadores podem ser facilitadores da comunidade, não apenas zeladores ou policiais.
 
@@ -2583,7 +2583,7 @@ pt_BR:
 
       <a name="be-civil"></a>
 
-      ## [Seja sempre civil] (#be-civil)
+      ## [Seja sempre civil](#be-civil)
 
       Nada sabota uma conversa saudável como grosseria:
 
@@ -2598,7 +2598,7 @@ pt_BR:
 
       <a name="keep-tidy"></a>
 
-      ## [Mantenha-o arrumado] (#keep-tidy)
+      ## [Mantenha-o arrumado](#keep-tidy)
 
       Faça o esforço para colocar as coisas no lugar certo, para que possamos passar mais tempo discutindo e menos limpando, assim:
 
@@ -2612,19 +2612,19 @@ pt_BR:
 
       <a name="stealing"></a>
 
-      ## [Post apenas seu próprio material] (#stealing)
+      ## [Post apenas seu próprio material](#stealing)
 
       Você não pode postar nada digital que pertença a outra pessoa sem permissão. Você não pode postar descrições, links ou métodos para roubar propriedade intelectual de alguém (software, vídeo, áudio, imagens) ou violar qualquer outra lei.
 
       <a name="power"></a>
 
-      ## [Empoderado por você] (#power)
+      ## [Empoderado por você](#power)
 
       Este site é operado por sua [equipe local amigável] (/ sobre) e * você *, a comunidade. Se você tiver outras dúvidas sobre como as coisas devem funcionar aqui, abra um novo tópico na [categoria de feedback do site] (/ c / feedback do site) e vamos discutir! Se houver um problema crítico ou urgente que não possa ser tratado por um meta tópico ou sinalizador, entre em contato conosco através da [página pessoal] (/ about).
 
       <a name="tos"></a>
 
-      ## [Termos de Serviço] (#tos)
+      ## [Termos de Serviço](#tos)
 
       Sim, legalês é chato, mas devemos nos proteger & ndash; e por extensão, você e seus dados & ndash; contra pessoas hostis. Temos um [Termos de Serviço] (/ tos) descrevendo seu (e nosso) comportamento e direitos relacionados a conteúdo, privacidade e leis. Para usar este serviço, você deve concordar em cumprir nossos [TOS] (/ tos).
 

--- a/config/locales/server.pt_BR.yml
+++ b/config/locales/server.pt_BR.yml
@@ -2532,7 +2532,7 @@ pt_BR:
     body: | 
       <a name="civilized"></a>
       
-      ## [Este é um lugar civilizado para discussão pública] (#civilizado)
+      ## [Este é um lugar civilizado para discussão pública] (#civilized)
       
       Por favor, trate este fórum de discussão com o mesmo respeito que você faria com um parque público. Nós também somos um recurso da comunidade compartilhada & mdash; um lugar para compartilhar habilidades, conhecimento e interesses por meio de conversas contínuas.
 
@@ -2540,7 +2540,7 @@ pt_BR:
 
       <a name="improve"></a>
 
-      ## [Melhore a discussão] (#melhorar) 
+      ## [Melhore a discussão] (#improve) 
 
       Ajude-nos a fazer deste um ótimo lugar para discussão, sempre trabalhando para melhorar a discussão de alguma forma, por menor que seja. Se você não tiver certeza de que sua postagem será adicionada à conversa, pense no que deseja dizer e tente novamente mais tarde.
 
@@ -2550,7 +2550,7 @@ pt_BR:
 
       <a name="agreeable"></a>
 
-      ## [Seja agradável, mesmo quando você discordar] (#agradável)
+      ## [Seja agradável, mesmo quando você discordar] (#agreeable)
 
       Você pode querer responder a algo discordando dele. Isso é bom. Mas lembre-se de _criticizar idéias, não pessoas_. Por favor, evite:
 
@@ -2563,7 +2563,7 @@ pt_BR:
 
       <a name="participate"></a>
 
-      ## [Sua participação conta](#participe)
+      ## [Sua participação conta](#participate)
 
       As conversas que temos aqui dão o tom para cada nova chegada. Ajude-nos a influenciar o futuro desta comunidade escolhendo participar de discussões que tornem este fórum um lugar interessante para ser & mdash; e evitando aqueles que não o fazem.
 
@@ -2573,7 +2573,7 @@ pt_BR:
 
       <a name="flag-problems"></a>
 
-      ## [Se você ver um problema, sinalize-o] (#SinalizçãoDeProblemas)
+      ## [Se você ver um problema, sinalize-o] (#flag-problems)
 
       Moderadores têm autoridade especial; eles são responsáveis ​​por este fórum. Mas você também. Com a sua ajuda, os moderadores podem ser facilitadores da comunidade, não apenas zeladores ou policiais.
 
@@ -2583,7 +2583,7 @@ pt_BR:
 
       <a name="be-civil"></a>
 
-      ## [Seja sempre civil] (#seja civil)
+      ## [Seja sempre civil] (#be-civil)
 
       Nada sabota uma conversa saudável como grosseria:
 
@@ -2598,7 +2598,7 @@ pt_BR:
 
       <a name="keep-tidy"></a>
 
-      ## [Mantenha-o arrumado] (#manter-arrumado)
+      ## [Mantenha-o arrumado] (#keep-tidy)
 
       Faça o esforço para colocar as coisas no lugar certo, para que possamos passar mais tempo discutindo e menos limpando, assim:
 
@@ -2612,19 +2612,19 @@ pt_BR:
 
       <a name="stealing"></a>
 
-      ## [Post apenas seu próprio material] (#roubar)
+      ## [Post apenas seu próprio material] (#stealing)
 
       Você não pode postar nada digital que pertença a outra pessoa sem permissão. Você não pode postar descrições, links ou métodos para roubar propriedade intelectual de alguém (software, vídeo, áudio, imagens) ou violar qualquer outra lei.
 
       <a name="power"></a>
 
-      ## [Empoderado por você] (#poder)
+      ## [Empoderado por você] (#power)
 
       Este site é operado por sua [equipe local amigável] (/ sobre) e * você *, a comunidade. Se você tiver outras dúvidas sobre como as coisas devem funcionar aqui, abra um novo tópico na [categoria de feedback do site] (/ c / feedback do site) e vamos discutir! Se houver um problema crítico ou urgente que não possa ser tratado por um meta tópico ou sinalizador, entre em contato conosco através da [página pessoal] (/ about).
 
       <a name="tos"></a>
 
-      ## [Termos de Serviço] (#tds)
+      ## [Termos de Serviço] (#tos)
 
       Sim, legalês é chato, mas devemos nos proteger & ndash; e por extensão, você e seus dados & ndash; contra pessoas hostis. Temos um [Termos de Serviço] (/ tos) descrevendo seu (e nosso) comportamento e direitos relacionados a conteúdo, privacidade e leis. Para usar este serviço, você deve concordar em cumprir nossos [TOS] (/ tos).
 

--- a/config/locales/server.pt_BR.yml
+++ b/config/locales/server.pt_BR.yml
@@ -2534,7 +2534,7 @@ pt_BR:
       
       ## [Este é um lugar civilizado para discussão pública](#civilized)
       
-      Por favor, trate este fórum de discussão com o mesmo respeito que você faria com um parque público. Nós também somos um recurso da comunidade compartilhada & mdash; um lugar para compartilhar habilidades, conhecimento e interesses por meio de conversas contínuas.
+      Por favor, trate este fórum de discussão com o mesmo respeito que você faria com um parque público. Nós também somos um recurso da comunidade compartilhada &mdash; um lugar para compartilhar habilidades, conhecimento e interesses por meio de conversas contínuas.
 
       Essas não são regras rígidas e rápidas, meras diretrizes para ajudar o julgamento humano de nossa comunidade e manter esse lugar limpo e bem iluminado para o discurso público civilizado.
 
@@ -2565,7 +2565,7 @@ pt_BR:
 
       ## [Sua participação conta](#participate)
 
-      As conversas que temos aqui dão o tom para cada nova chegada. Ajude-nos a influenciar o futuro desta comunidade escolhendo participar de discussões que tornem este fórum um lugar interessante para ser & mdash; e evitando aqueles que não o fazem.
+      As conversas que temos aqui dão o tom para cada nova chegada. Ajude-nos a influenciar o futuro desta comunidade escolhendo participar de discussões que tornem este fórum um lugar interessante para ser &mdash; e evitando aqueles que não o fazem.
 
       O discurso fornece ferramentas que permitem à comunidade identificar coletivamente as melhores (e piores) contribuições: favoritos, marcações, sinalizações, respostas, edições e assim por diante. Use essas ferramentas para melhorar sua própria experiência e a das outras pessoas também.
 
@@ -2575,7 +2575,7 @@ pt_BR:
 
       ## [Se você ver um problema, sinalize-o](#flag-problems)
 
-      Moderadores têm autoridade especial; eles são responsáveis ​​por este fórum. Mas você também. Com a sua ajuda, os moderadores podem ser facilitadores da comunidade, não apenas zeladores ou policiais.
+      Moderadores têm autoridade especial; eles são responsáveis por este fórum. Mas você também. Com a sua ajuda, os moderadores podem ser facilitadores da comunidade, não apenas zeladores ou policiais.
 
       Quando você vir um mau comportamento, não responda. Ele encoraja o mau comportamento reconhecendo-o, consome sua energia e desperdiça o tempo de todos. _Apenas sinalize_ Se houver sinalizadores suficientes, ações serão tomadas, automaticamente ou por intervenção do moderador.
 
@@ -2592,7 +2592,7 @@ pt_BR:
       *   Respeitar-se mutuamente. Não assedie nem lamente ninguém, personifique pessoas ou exponha suas informações pessoais.
       *   Respeite o nosso fórum. Não publique spam nem ofusque o fórum.
 
-      Estes não são termos concretos com definições precisas & mdash; evite até mesmo a aparência de qualquer uma dessas coisas. Se você não tiver certeza, pergunte-se como se sentiria se sua publicação fosse publicada na primeira página do New York Times..
+      Estes não são termos concretos com definições precisas &mdash; evite até mesmo a aparência de qualquer uma dessas coisas. Se você não tiver certeza, pergunte-se como se sentiria se sua publicação fosse publicada na primeira página do New York Times..
 
       Este é um fórum público e os mecanismos de pesquisa indexam essas discussões. Mantenha o idioma, links e imagens seguros para familiares e amigos.
 
@@ -2606,7 +2606,7 @@ pt_BR:
       *   Não publique a mesma coisa em vários tópicos.
       *   Não publique respostas sem conteúdo.
       *   Não desvie um tópico alterando-o no meio do caminho.
-      *   Não assine suas postagens & mdash; cada post tem suas informações de perfil anexadas.
+      *   Não assine suas postagens &mdash; cada post tem suas informações de perfil anexadas.
 
       Em vez de postar "+1" ou "Concordo", use o botão Curtir. Em vez de usar um tópico existente em uma direção radicalmente diferente, use Responder como um tópico vinculado.
 
@@ -2626,7 +2626,7 @@ pt_BR:
 
       ## [Termos de Serviço](#tos)
 
-      Sim, legalês é chato, mas devemos nos proteger & ndash; e por extensão, você e seus dados & ndash; contra pessoas hostis. Temos um [Termos de Serviço] (/ tos) descrevendo seu (e nosso) comportamento e direitos relacionados a conteúdo, privacidade e leis. Para usar este serviço, você deve concordar em cumprir nossos [TOS] (/ tos).
+      Sim, legalês é chato, mas devemos nos proteger &ndash; e por extensão, você e seus dados &ndash; contra pessoas hostis. Temos um [Termos de Serviço] (/ tos) descrevendo seu (e nosso) comportamento e direitos relacionados a conteúdo, privacidade e leis. Para usar este serviço, você deve concordar em cumprir nossos [TOS] (/ tos).
 
 tos_topic:
     title: "Termos de Serviço"

--- a/config/locales/server.pt_BR.yml
+++ b/config/locales/server.pt_BR.yml
@@ -2529,8 +2529,106 @@ pt_BR:
     Altere o primeiro post desse tópico para mudar seu conteúdo na página de %{page_name}
   guidelines_topic:
     title: "Perguntas frequentes/Diretrizes"
-    body: "<a name=\"civilized\"></a>\n\n## [Este é um lugar civilizado para discussão pública] (#civilizado)\n\nPor favor, trate este fórum de discussão com o mesmo respeito que você faria com um parque público. Nós também somos um recurso da comunidade compartilhada & mdash; um lugar para compartilhar habilidades, conhecimento e interesses por meio de conversas contínuas.\n\nEssas não são regras rígidas e rápidas, meras diretrizes para ajudar o julgamento humano de nossa comunidade e manter esse lugar limpo e bem iluminado para o discurso público civilizado.\n\n<a name=\"improve\"></a>\n\n## [Melhore a discussão] (#melhorar) \n\nAjude-nos a fazer deste um ótimo lugar para discussão, sempre trabalhando para melhorar a discussão de alguma forma, por menor que seja. Se você não tiver certeza de que sua postagem será adicionada à conversa, pense no que deseja dizer e tente novamente mais tarde.\n\nOs tópicos discutidos aqui são importantes para nós e queremos que você aja como se eles também fossem importantes para você. Seja respeitoso com os tópicos e as pessoas que os discutem, mesmo que você discorde de algo do que está sendo dito.\n\nUma maneira de melhorar a discussão é descobrindo aquelas que já estão acontecendo. Passe algum tempo navegando pelos tópicos aqui antes de responder ou iniciar o seu, e você terá mais chances de conhecer outras pessoas que compartilham seus interesses.\n\n<a name=\"agreeable\"></a>\n\n## [Seja agradável, mesmo quando você discordar] (#agradável)\n\nVocê pode querer responder a algo discordando dele. Isso é bom. Mas lembre-se de _criticizar idéias, não pessoas_. Por favor, evite:\n\n*   Xingamento\n*   Ataques ad hominem\n*   Respondendo ao tom de uma postagem em vez de seu conteúdo real\n*   Contradição do joelho-empurrão\n\nEm vez disso, forneça contra-argumentos fundamentados que melhorem a conversa.\n\n<a name=\"participate\"></a>\n\n## [Sua participação conta](#participe)\n\nAs conversas que temos aqui dão o tom para cada nova chegada. Ajude-nos a influenciar o futuro desta comunidade escolhendo participar de discussões que tornem este fórum um lugar interessante para ser & mdash; e evitando aqueles que não o fazem.\n\nO discurso fornece ferramentas que permitem à comunidade identificar coletivamente as melhores (e piores) contribuições: favoritos, marcações, sinalizações, respostas, edições e assim por diante. Use essas ferramentas para melhorar sua própria experiência e a das outras pessoas também.\n\nVamos deixar nossa comunidade melhor do que a encontramos.\n\n<a name=\"flag-problems\"></a>\n\n## [Se você ver um problema, sinalize-o] (#SinalizçãoDeProblemas)\n\nModeradores têm autoridade especial; eles são responsáveis ​​por este fórum. Mas você também. Com a sua ajuda, os moderadores podem ser facilitadores da comunidade, não apenas zeladores ou policiais.\n\nQuando você vir um mau comportamento, não responda. Ele encoraja o mau comportamento reconhecendo-o, consome sua energia e desperdiça o tempo de todos. _Apenas sinalize_ Se houver sinalizadores suficientes, ações serão tomadas, automaticamente ou por intervenção do moderador.\n\nPara manter nossa comunidade, os moderadores reservam-se o direito de remover qualquer conteúdo e qualquer conta de usuário por qualquer motivo a qualquer momento. Os moderadores não visualizam novas postagens; os moderadores e os operadores do site não se responsabilizam por nenhum conteúdo postado pela comunidade.\n\n<a name=\"be-civil\"></a>\n\n## [Seja sempre civil] (#seja civil)\n\nNada sabota uma conversa saudável como grosseria:\n\n*   Seja civilizado. Não poste nada que uma pessoa razoável consideraria ofensiva, abusiva ou de incitação ao ódio.\n*   Mantenha-se limpo. Não publique nada de obsceno ou sexualmente explícito.\n*   Respeitar-se mutuamente. Não assedie nem lamente ninguém, personifique pessoas ou exponha suas informações pessoais.\n*   Respeite o nosso fórum. Não publique spam nem ofusque o fórum.\n\nEstes não são termos concretos com definições precisas & mdash; evite até mesmo a aparência de qualquer uma dessas coisas. Se você não tiver certeza, pergunte-se como se sentiria se sua publicação fosse publicada na primeira página do New York Times..\n\nEste é um fórum público e os mecanismos de pesquisa indexam essas discussões. Mantenha o idioma, links e imagens seguros para familiares e amigos.\n\n<a name=\"keep-tidy\"></a>\n\n## [Mantenha-o arrumado] (#manter-arrumado)\n\nFaça o esforço para colocar as coisas no lugar certo, para que possamos passar mais tempo discutindo e menos limpando, assim:\n\n*   Não comece um tópico na categoria errada.\n*   Não publique a mesma coisa em vários tópicos.\n*   Não publique respostas sem conteúdo.\n*   Não desvie um tópico alterando-o no meio do caminho.\n*   Não assine suas postagens & mdash; cada post tem suas informações de perfil anexadas.\n\nEm vez de postar \"+1\" ou \"Concordo\", use o botão Curtir. Em vez de usar um tópico existente em uma direção radicalmente diferente, use Responder como um tópico vinculado.\n\n<a name=\"stealing\"></a>\n\n## [Post apenas seu próprio material] (#roubar)\n\nVocê não pode postar nada digital que pertença a outra pessoa sem permissão. Você não pode postar descrições, links ou métodos para roubar propriedade intelectual de alguém (software, vídeo, áudio, imagens) ou violar qualquer outra lei.\n\n<a name=\"power\"></a>\n\n## [Empoderado por você] (#poder)\n\nEste site é operado por sua [equipe local amigável] (/ sobre) e * você *, a comunidade. Se você tiver outras dúvidas sobre como as coisas devem funcionar aqui, abra um novo tópico na [categoria de feedback do site] (/ c / feedback do site) e vamos discutir! Se houver um problema crítico ou urgente que não possa ser tratado por um meta tópico ou sinalizador, entre em contato conosco através da [página pessoal] (/ about).\n\n<a name=\"tos\"></a>\n\n## [Termos de Serviço] (#tds)\n\nSim, legalês é chato, mas devemos nos proteger & ndash; e por extensão, você e seus dados & ndash; contra pessoas hostis. Temos um [Termos de Serviço] (/ tos) descrevendo seu (e nosso) comportamento e direitos relacionados a conteúdo, privacidade e leis. Para usar este serviço, você deve concordar em cumprir nossos [TOS] (/ tos).\n"
-  tos_topic:
+    body: | 
+      <a name="civilized"></a>
+      
+      ## [Este é um lugar civilizado para discussão pública] (#civilizado)
+      
+      Por favor, trate este fórum de discussão com o mesmo respeito que você faria com um parque público. Nós também somos um recurso da comunidade compartilhada & mdash; um lugar para compartilhar habilidades, conhecimento e interesses por meio de conversas contínuas.
+
+      Essas não são regras rígidas e rápidas, meras diretrizes para ajudar o julgamento humano de nossa comunidade e manter esse lugar limpo e bem iluminado para o discurso público civilizado.
+
+      <a name="improve"></a>
+
+      ## [Melhore a discussão] (#melhorar) 
+
+      Ajude-nos a fazer deste um ótimo lugar para discussão, sempre trabalhando para melhorar a discussão de alguma forma, por menor que seja. Se você não tiver certeza de que sua postagem será adicionada à conversa, pense no que deseja dizer e tente novamente mais tarde.
+
+      Os tópicos discutidos aqui são importantes para nós e queremos que você aja como se eles também fossem importantes para você. Seja respeitoso com os tópicos e as pessoas que os discutem, mesmo que você discorde de algo do que está sendo dito.
+
+      Uma maneira de melhorar a discussão é descobrindo aquelas que já estão acontecendo. Passe algum tempo navegando pelos tópicos aqui antes de responder ou iniciar o seu, e você terá mais chances de conhecer outras pessoas que compartilham seus interesses.
+
+      <a name="agreeable"></a>
+
+      ## [Seja agradável, mesmo quando você discordar] (#agradável)
+
+      Você pode querer responder a algo discordando dele. Isso é bom. Mas lembre-se de _criticizar idéias, não pessoas_. Por favor, evite:
+
+      *   Xingamento
+      *   Ataques ad hominem
+      *   Respondendo ao tom de uma postagem em vez de seu conteúdo real
+      *   Contradição do joelho-empurrão
+
+      Em vez disso, forneça contra-argumentos fundamentados que melhorem a conversa.
+
+      <a name="participate"></a>
+
+      ## [Sua participação conta](#participe)
+
+      As conversas que temos aqui dão o tom para cada nova chegada. Ajude-nos a influenciar o futuro desta comunidade escolhendo participar de discussões que tornem este fórum um lugar interessante para ser & mdash; e evitando aqueles que não o fazem.
+
+      O discurso fornece ferramentas que permitem à comunidade identificar coletivamente as melhores (e piores) contribuições: favoritos, marcações, sinalizações, respostas, edições e assim por diante. Use essas ferramentas para melhorar sua própria experiência e a das outras pessoas também.
+
+      Vamos deixar nossa comunidade melhor do que a encontramos.
+
+      <a name="flag-problems"></a>
+
+      ## [Se você ver um problema, sinalize-o] (#SinalizçãoDeProblemas)
+
+      Moderadores têm autoridade especial; eles são responsáveis ​​por este fórum. Mas você também. Com a sua ajuda, os moderadores podem ser facilitadores da comunidade, não apenas zeladores ou policiais.
+
+      Quando você vir um mau comportamento, não responda. Ele encoraja o mau comportamento reconhecendo-o, consome sua energia e desperdiça o tempo de todos. _Apenas sinalize_ Se houver sinalizadores suficientes, ações serão tomadas, automaticamente ou por intervenção do moderador.
+
+      Para manter nossa comunidade, os moderadores reservam-se o direito de remover qualquer conteúdo e qualquer conta de usuário por qualquer motivo a qualquer momento. Os moderadores não visualizam novas postagens; os moderadores e os operadores do site não se responsabilizam por nenhum conteúdo postado pela comunidade.
+
+      <a name="be-civil"></a>
+
+      ## [Seja sempre civil] (#seja civil)
+
+      Nada sabota uma conversa saudável como grosseria:
+
+      *   Seja civilizado. Não poste nada que uma pessoa razoável consideraria ofensiva, abusiva ou de incitação ao ódio.
+      *   Mantenha-se limpo. Não publique nada de obsceno ou sexualmente explícito.
+      *   Respeitar-se mutuamente. Não assedie nem lamente ninguém, personifique pessoas ou exponha suas informações pessoais.
+      *   Respeite o nosso fórum. Não publique spam nem ofusque o fórum.
+
+      Estes não são termos concretos com definições precisas & mdash; evite até mesmo a aparência de qualquer uma dessas coisas. Se você não tiver certeza, pergunte-se como se sentiria se sua publicação fosse publicada na primeira página do New York Times..
+
+      Este é um fórum público e os mecanismos de pesquisa indexam essas discussões. Mantenha o idioma, links e imagens seguros para familiares e amigos.
+
+      <a name="keep-tidy"></a>
+
+      ## [Mantenha-o arrumado] (#manter-arrumado)
+
+      Faça o esforço para colocar as coisas no lugar certo, para que possamos passar mais tempo discutindo e menos limpando, assim:
+
+      *   Não comece um tópico na categoria errada.
+      *   Não publique a mesma coisa em vários tópicos.
+      *   Não publique respostas sem conteúdo.
+      *   Não desvie um tópico alterando-o no meio do caminho.
+      *   Não assine suas postagens & mdash; cada post tem suas informações de perfil anexadas.
+
+      Em vez de postar "+1" ou "Concordo", use o botão Curtir. Em vez de usar um tópico existente em uma direção radicalmente diferente, use Responder como um tópico vinculado.
+
+      <a name="stealing"></a>
+
+      ## [Post apenas seu próprio material] (#roubar)
+
+      Você não pode postar nada digital que pertença a outra pessoa sem permissão. Você não pode postar descrições, links ou métodos para roubar propriedade intelectual de alguém (software, vídeo, áudio, imagens) ou violar qualquer outra lei.
+
+      <a name="power"></a>
+
+      ## [Empoderado por você] (#poder)
+
+      Este site é operado por sua [equipe local amigável] (/ sobre) e * você *, a comunidade. Se você tiver outras dúvidas sobre como as coisas devem funcionar aqui, abra um novo tópico na [categoria de feedback do site] (/ c / feedback do site) e vamos discutir! Se houver um problema crítico ou urgente que não possa ser tratado por um meta tópico ou sinalizador, entre em contato conosco através da [página pessoal] (/ about).
+
+      <a name="tos"></a>
+
+      ## [Termos de Serviço] (#tds)
+
+      Sim, legalês é chato, mas devemos nos proteger & ndash; e por extensão, você e seus dados & ndash; contra pessoas hostis. Temos um [Termos de Serviço] (/ tos) descrevendo seu (e nosso) comportamento e direitos relacionados a conteúdo, privacidade e leis. Para usar este serviço, você deve concordar em cumprir nossos [TOS] (/ tos).
+
+tos_topic:
     title: "Termos de Serviço"
   privacy_topic:
     title: "Política de Privacidade"

--- a/config/locales/server.pt_BR.yml
+++ b/config/locales/server.pt_BR.yml
@@ -2620,13 +2620,13 @@ pt_BR:
 
       ## [Empoderado por você](#power)
 
-      Este site é operado por sua [equipe local amigável] (/ sobre) e * você *, a comunidade. Se você tiver outras dúvidas sobre como as coisas devem funcionar aqui, abra um novo tópico na [categoria de feedback do site] (/ c / feedback do site) e vamos discutir! Se houver um problema crítico ou urgente que não possa ser tratado por um meta tópico ou sinalizador, entre em contato conosco através da [página pessoal] (/ about).
+      Este site é operado por sua [equipe local amigável] (/about) e *você*, a comunidade. Se você tiver outras dúvidas sobre como as coisas devem funcionar aqui, abra um novo tópico na [categoria de feedback do site] (/c/site-feedback) e vamos discutir! Se houver um problema crítico ou urgente que não possa ser tratado por um meta tópico ou sinalizador, entre em contato conosco através da [página pessoal] (/about).
 
       <a name="tos"></a>
 
       ## [Termos de Serviço](#tos)
 
-      Sim, legalês é chato, mas devemos nos proteger &ndash; e por extensão, você e seus dados &ndash; contra pessoas hostis. Temos um [Termos de Serviço] (/ tos) descrevendo seu (e nosso) comportamento e direitos relacionados a conteúdo, privacidade e leis. Para usar este serviço, você deve concordar em cumprir nossos [TOS] (/ tos).
+      Sim, legalês é chato, mas devemos nos proteger &ndash; e por extensão, você e seus dados &ndash; contra pessoas hostis. Temos um [Termos de Serviço] (/tos) descrevendo seu (e nosso) comportamento e direitos relacionados a conteúdo, privacidade e leis. Para usar este serviço, você deve concordar em cumprir nossos [TOS] (/tos).
 
 tos_topic:
     title: "Termos de Serviço"


### PR DESCRIPTION
Hi everyone, I'm building a community in Brazil, and when I was making the community setup, I saw some wrong things in `guidelines_topic.body` in Brazilian Portuguese translation.

To make the review and my explanation easier,  I splitted this PR in the follow parts/commit:

### Commit d5053cd 

I moved `guidelines_topic.body` to multi line version, looking others translation like [zh_TW](https://github.com/discourse/discourse/blob/55cc5ab4b8fb52bfea05659149fdcf6437d33a3c/config/locales/server.zh_TW.yml), [sk](https://github.com/discourse/discourse/blob/55cc5ab4b8fb52bfea05659149fdcf6437d33a3c/config/locales/server.sk.yml), [zh_CN](https://github.com/discourse/discourse/blob/55cc5ab4b8fb52bfea05659149fdcf6437d33a3c/config/locales/server.zh_CN.yml) and many others, I believe it's better to maintenance keep this long html/markdown content in multi line version instead of one line, will be easy see the next changes in the multi line version too .
  
### Commit 11174172eed5ef6d5f8cab0416f1c8833b22ec8b 

The first wrong thing is the links in titles, I don't know why, but it's was translated, but the anchors was not, of course it'll not work. Again, looking the others translations, I keep the links as the anchors.

### Commit  96591ebf0b8704ec60d7a54fc1c7d31272f0df4b

Maybe you notice, in last commit, we don't have a real link in markdown to the titles, because there is a space between `]`(square brackets) and `(`(round brackets), this commit fix it.

### Commit 36072a8f52534d244363cdafd05bb30b0a103fe0

Looking the text a bit closer, I found some htmlentities with a space between the `&`(amp) and the next letter, the result is the  htmlentities will not be rendered. Fixed!

### Commit b37ea70fe567a82aab85dcdad6d58812992d175e

Fixing the htmlentities, I found some links with space between the `/`, I don't know why, but it's wrong and I fixed it.

--- 

The final result was something like it:

![screenshot from 2019-02-24 20-48-09](https://user-images.githubusercontent.com/91538/53307830-0c4cbf80-387b-11e9-845e-c3074e076d42.png)

![screenshot from 2019-02-24 20-48-24](https://user-images.githubusercontent.com/91538/53307832-0fe04680-387b-11e9-98e6-19252c7902fd.png)

