### PR TITLE
FIX: use * when apply italics in the editor instead of _

### DIFF
--- a/app/assets/javascripts/discourse/components/d-editor.js.es6
+++ b/app/assets/javascripts/discourse/components/d-editor.js.es6
@@ -80,7 +80,7 @@ class Toolbar {
       icon: "italic",
       label: getButtonLabel("composer.italic_label", "I"),
       shortcut: "I",
-      perform: e => e.applySurround("_", "_", "italic_text")
+      perform: e => e.applySurround("*", "*", "italic_text")
     });
 
     if (opts.showLink) {

--- a/test/javascripts/components/d-editor-test.js.es6
+++ b/test/javascripts/components/d-editor-test.js.es6
@@ -157,7 +157,7 @@ testCase(`bold with a multiline selection`, async function(assert, textarea) {
 testCase(`italic button with no selection`, async function(assert, textarea) {
   await click(`button.italic`);
   const example = I18n.t(`composer.italic_text`);
-  assert.equal(this.get("value"), `hello world._${example}_`);
+  assert.equal(this.get("value"), `hello world.*${example}*`);
 
   assert.equal(textarea.selectionStart, 13);
   assert.equal(textarea.selectionEnd, 13 + example.length);
@@ -168,7 +168,7 @@ testCase(`italic button with a selection`, async function(assert, textarea) {
   textarea.selectionEnd = 11;
 
   await click(`button.italic`);
-  assert.equal(this.get("value"), `hello _world_.`);
+  assert.equal(this.get("value"), `hello *world*.`);
   assert.equal(textarea.selectionStart, 7);
   assert.equal(textarea.selectionEnd, 12);
 
@@ -185,7 +185,7 @@ testCase(`italic with a multiline selection`, async function(assert, textarea) {
   textarea.selectionEnd = 12;
 
   await click(`button.italic`);
-  assert.equal(this.get("value"), `_hello_\n\n_world_\n\ntest.`);
+  assert.equal(this.get("value"), `*hello*\n\n*world*\n\ntest.`);
   assert.equal(textarea.selectionStart, 0);
   assert.equal(textarea.selectionEnd, 16);
 


### PR DESCRIPTION
Per feature request: https://meta.discourse.org/t/when-using-the-italics-button-in-the-ui-you-can-not-properly-italicise-words-in-chinese/109957