### PR TITLE
FIX: only profile owner can see links to watched/tracked/muted topics

### DIFF
--- a/app/assets/javascripts/discourse/controllers/preferences/categories.js.es6
+++ b/app/assets/javascripts/discourse/controllers/preferences/categories.js.es6
@@ -20,12 +20,12 @@ export default Ember.Controller.extend(PreferencesTabController, {
     return [].concat(watched, watchedFirst, tracked, muted).filter(t => t);
   },
 
-  canSave: function() {
-    return (
-      this.get("currentUser.id") === this.get("model.id") ||
-      this.get("currentUser.admin")
-    );
-  }.property(),
+  @computed
+  canSee() {
+    return this.get("currentUser.id") === this.get("model.id");
+  },
+
+  canSave: Ember.computed.or("canSee", "currentUser.admin"),
 
   actions: {
     save() {

--- a/app/assets/javascripts/discourse/templates/preferences/categories.hbs
+++ b/app/assets/javascripts/discourse/templates/preferences/categories.hbs
@@ -6,18 +6,22 @@
     {{category-selector categories=model.watchedCategories blacklist=selectedCategories}}
   </div>
   <div class="instructions">{{i18n 'user.watched_categories_instructions'}}</div>
-  <div class="controls">
-    <a href="{{unbound model.watchingTopicsPath}}">{{i18n 'user.watched_topics_link'}}</a>
-  </div>
+  {{#if canSee}}
+    <div class="controls">
+      <a href="{{unbound model.watchingTopicsPath}}">{{i18n 'user.watched_topics_link'}}</a>
+    </div>
+  {{/if}}
 
   <div class="controls category-controls">
     <label>{{d-icon "d-tracking"}} {{i18n 'user.tracked_categories'}}</label>
     {{category-selector categories=model.trackedCategories blacklist=selectedCategories}}
   </div>
   <div class="instructions">{{i18n 'user.tracked_categories_instructions'}}</div>
-  <div class="controls">
-    <a href="{{unbound model.trackingTopicsPath}}">{{i18n 'user.tracked_topics_link'}}</a>
-  </div>
+  {{#if canSee}}
+    <div class="controls">
+      <a href="{{unbound model.trackingTopicsPath}}">{{i18n 'user.tracked_topics_link'}}</a>
+    </div>
+  {{/if}}
 
   <div class="controls category-controls">
     <label>{{d-icon "d-watching-first"}} {{i18n 'user.watched_first_post_categories'}}</label>
@@ -30,10 +34,11 @@
     {{category-selector categories=model.mutedCategories blacklist=selectedCategories}}
   </div>
   <div class="instructions">{{i18n 'user.muted_categories_instructions'}}</div>
-  <div class="controls">
-    <a href="{{unbound model.mutedTopicsPath}}">{{i18n 'user.muted_topics_link'}}</a>
-  </div>
-
+  {{#if canSee}}
+    <div class="controls">
+      <a href="{{unbound model.mutedTopicsPath}}">{{i18n 'user.muted_topics_link'}}</a>
+    </div>
+  {{/if}}
 </div>
 
 {{plugin-outlet name="user-preferences-categories" args=(hash model=model save=(action "save"))}}


### PR DESCRIPTION
https://meta.discourse.org/t/see-and-set-user-notification-level-for-topics-and-messages/108838/4