### PR TITLE
DEV: Support running Ruby tests in parallel

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,3 @@
 --colour
+--profile
+--fail-fast

--- a/lib/tasks/docker.rake
+++ b/lib/tasks/docker.rake
@@ -127,9 +127,13 @@ task 'docker:test' do
 
           if ENV['PARALLEL']
             parts = ENV['PARALLEL'].split("/")
+            total = parts[1].to_i
+            subset = parts[0].to_i - 1
 
-            spec_partials = Dir["spec/**/*_spec.rb"].sort.in_groups(parts[1].to_i, false)
-            params << spec_partials[parts[0].to_i].join(' ')
+            spec_partials = Dir["spec/**/*_spec.rb"].sort.in_groups(total, false)
+            params << spec_partials[subset].join(' ')
+
+            puts "Running spec subset #{subset} of #{total}"
           end
 
           @good &&= run_or_fail("bundle exec rspec #{params.join(' ')}".strip)

--- a/lib/tasks/docker.rake
+++ b/lib/tasks/docker.rake
@@ -133,7 +133,7 @@ task 'docker:test' do
             spec_partials = Dir["spec/**/*_spec.rb"].sort.in_groups(total, false)
             params << spec_partials[subset].join(' ')
 
-            puts "Running spec subset #{subset} of #{total}"
+            puts "Running spec subset #{subset + 1} of #{total}"
           end
 
           @good &&= run_or_fail("bundle exec rspec #{params.join(' ')}".strip)

--- a/lib/tasks/docker.rake
+++ b/lib/tasks/docker.rake
@@ -124,6 +124,14 @@ task 'docker:test' do
           if ENV["RSPEC_SEED"]
             params << "--seed #{ENV["RSPEC_SEED"]}"
           end
+
+          if ENV['PARALLEL']
+            parts = ENV['PARALLEL'].split("/")
+
+            spec_partials = Dir["spec/**/*_spec.rb"].sort.in_groups(parts[1].to_i, false)
+            params << spec_partials[parts[0].to_i].join(' ')
+          end
+
           @good &&= run_or_fail("bundle exec rspec #{params.join(' ')}".strip)
         end
 


### PR DESCRIPTION
To speed up our Ruby tests, this PR introduces a new ENV variable that allows splitting the test suite into parts, which would allow us to run each part in parallel. 

Example: 
```
docker run -it --rm -e PARALLEL="1/4" discourse/discourse_test:release
docker run -it --rm -e PARALLEL="2/4" discourse/discourse_test:release
docker run -it --rm -e PARALLEL="3/4" discourse/discourse_test:release
docker run -it --rm -e PARALLEL="4/4" discourse/discourse_test:release
```

The PR also adds two parameters to Ruby specs: 
* `--profile` to display a summary of the slowest tests
* `--fail-fast` to fail the process immediately when a test fails
