### PR TITLE
FEATURE: Update all seeded topics with translated content

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -574,6 +574,8 @@ en:
 
       [trust]: https://blog.discourse.org/2018/06/understanding-discourse-trust-levels/
 
+  admin_quick_start_title: "READ ME FIRST: Admin Quick Start Guide"
+
   category:
     topic_prefix: "About the %{category} category"
     replace_paragraph: "(Replace this first paragraph with a brief description of your new category. This guidance will appear in the category selection area, so try to keep it below 200 characters.)"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1734,6 +1734,15 @@ uncategorized:
   privacy_topic_id:
     default: -1
     hidden: true
+  welcome_topic_id:
+    default: -1
+    hidden: true
+  lounge_welcome_topic_id:
+    default: -1
+    hidden: true
+  admin_quick_start_topic_id:
+    default: -1
+    hidden: true
 
   bootstrap_mode_min_users:
     default: 50

--- a/db/fixtures/990_topics.rb
+++ b/db/fixtures/990_topics.rb
@@ -2,64 +2,14 @@ User.reset_column_information
 Topic.reset_column_information
 Post.reset_column_information
 
-staff = Category.find_by(id: SiteSetting.staff_category_id)
-seed_welcome_topics = (Topic.where('id NOT IN (SELECT topic_id from categories where topic_id is not null)').count == 0 && !Rails.env.test?)
+if !Rails.env.test?
+  seed_welcome_topics = !Topic.where(<<~SQL).exists?
+    id NOT IN (
+      SELECT topic_id
+      FROM categories
+      WHERE topic_id IS NOT NULL
+    )
+  SQL
 
-unless Rails.env.test?
-  def create_static_page_topic(site_setting_key, title_key, body_key, body_override, category, description, params = {})
-    unless SiteSetting.send(site_setting_key) > 0
-      creator = PostCreator.new(Discourse.system_user,
-                                 title: I18n.t(title_key, default: I18n.t(title_key, locale: :en)),
-                                 raw: body_override.present? ? body_override : I18n.t(body_key, params.merge(default: I18n.t(body_key, params.merge(locale: :en)))),
-                                 skip_validations: true,
-                                 category: category ? category.name : nil)
-      post = creator.create
-
-      raise "Failed to create the #{description} topic! #{creator.errors.full_messages.join('. ')}" if creator.errors.present?
-
-      SiteSetting.send("#{site_setting_key}=", post.topic_id)
-
-      _reply = PostCreator.create(Discourse.system_user,
-                                  raw: I18n.t('static_topic_first_reply', page_name: I18n.t(title_key, default: I18n.t(title_key, locale: :en))),
-                                  skip_validations: true,
-                                  topic_id: post.topic_id)
-    end
-  end
-
-  create_static_page_topic('tos_topic_id', 'tos_topic.title', "tos_topic.body", nil, staff, "terms of service",
-                           company_name: SiteSetting.company_name.presence || "company_name",
-                           base_url: Discourse.base_url,
-                           contact_email: SiteSetting.contact_email.presence || "contact_email",
-                           governing_law: SiteSetting.governing_law.presence || "governing_law",
-                           city_for_disputes: SiteSetting.city_for_disputes.presence || "city_for_disputes")
-
-  create_static_page_topic('guidelines_topic_id', 'guidelines_topic.title', "guidelines_topic.body", nil, staff, "guidelines", base_path: Discourse.base_path)
-
-  create_static_page_topic('privacy_topic_id', 'privacy_topic.title', "privacy_topic.body", nil, staff, "privacy policy")
-end
-
-if seed_welcome_topics
-  puts "Seeding welcome topics"
-
-  post = PostCreator.create(Discourse.system_user, raw: I18n.t('discourse_welcome_topic.body', base_path: Discourse.base_path), title: I18n.t('discourse_welcome_topic.title'), skip_validations: true)
-  post.topic.update_pinned(true, true)
-  TopicCustomField.create(topic_id: post.topic.id, name: "is_welcome_topic", value: "true")
-
-  lounge = Category.find_by(id: SiteSetting.lounge_category_id)
-  if lounge
-    post = PostCreator.create(Discourse.system_user, raw: I18n.t('lounge_welcome.body', base_path: Discourse.base_path), title: I18n.t('lounge_welcome.title'), skip_validations: true, category: lounge.name)
-    post.topic.update_pinned(true)
-  end
-
-  filename = DiscoursePluginRegistry.seed_data["admin_quick_start_filename"]
-  if filename.nil? || !File.exists?(filename)
-    filename = Rails.root + 'docs/ADMIN-QUICK-START-GUIDE.md'
-  end
-
-  welcome = File.read(filename)
-  PostCreator.create(Discourse.system_user,
-                      raw: welcome,
-                      title: DiscoursePluginRegistry.seed_data["admin_quick_start_title"] || "READ ME FIRST: Admin Quick Start Guide",
-                      skip_validations: true,
-                      category: staff ? staff.name : nil)
+  SeedData::Topics.with_default_locale.create(seed_welcome_topics)
 end

--- a/db/migrate/20190227210035_add_welcome_topic_id_site_setting.rb
+++ b/db/migrate/20190227210035_add_welcome_topic_id_site_setting.rb
@@ -1,0 +1,30 @@
+class AddWelcomeTopicIdSiteSetting < ActiveRecord::Migration[5.2]
+  def up
+    execute <<~SQL
+      INSERT INTO site_settings(name, data_type, value, created_at, updated_at)
+      SELECT 'welcome_topic_id', 3, topic_id, created_at, updated_at
+      FROM topic_custom_fields
+      WHERE name = 'is_welcome_topic' AND value = 'true'
+      LIMIT 1
+    SQL
+
+    execute <<~SQL
+      DELETE FROM topic_custom_fields
+      WHERE name = 'is_welcome_topic' AND value = 'true'
+    SQL
+  end
+
+  def down
+    execute <<~SQL
+      INSERT INTO topic_custom_fields(topic_id, name, value, created_at, updated_at)
+      SELECT value::INTEGER, 'is_welcome_topic', 'true', created_at, updated_at
+      FROM site_settings
+      WHERE name = 'welcome_topic_id'
+    SQL
+
+    execute <<~SQL
+      DELETE FROM site_settings
+      WHERE name = 'welcome_topic_id'
+    SQL
+  end
+end

--- a/lib/introduction_updater.rb
+++ b/lib/introduction_updater.rb
@@ -29,11 +29,9 @@ class IntroductionUpdater
   end
 
   def find_welcome_post
-    topic_id = TopicCustomField
-      .where(name: "is_welcome_topic", value: "true")
-      .pluck(:topic_id)
+    topic_id = SiteSetting.welcome_topic_id
 
-    if topic_id.blank?
+    if topic_id <= 0
       title = I18n.t("discourse_welcome_topic.title")
       topic_id = find_topic_id(title)
     end

--- a/lib/seed_data/topics.rb
+++ b/lib/seed_data/topics.rb
@@ -1,0 +1,172 @@
+module SeedData
+  class Topics
+    def self.with_default_locale
+      SeedData::Topics.new(SiteSetting.default_locale)
+    end
+
+    def initialize(locale)
+      @locale = locale
+    end
+
+    def create(include_welcome_topics)
+      I18n.with_locale(@locale) do
+        topics(include_welcome_topics).each { |topic| create_topic(topic) }
+      end
+    end
+
+    def update
+      I18n.with_locale(@locale) do
+        topics.each do |topic|
+          topic.except!(:category, :after_create)
+          update_topic(topic)
+        end
+      end
+    end
+
+    private
+
+    def topics(include_welcome_topics = true)
+      staff_category = Category.find_by(id: SiteSetting.staff_category_id)
+
+      topics = [
+        # Terms of Service
+        {
+          site_setting_name: 'tos_topic_id',
+          title: I18n.t('tos_topic.title'),
+          raw: I18n.t('tos_topic.body',
+                      company_name: setting_value('company_name'),
+                      base_url: Discourse.base_url,
+                      contact_email: setting_value('contact_email'),
+                      governing_law: setting_value('governing_law'),
+                      city_for_disputes: setting_value('city_for_disputes')
+          ),
+          category: staff_category,
+          static_first_reply: true
+        },
+
+        # FAQ/Guidelines
+        {
+          site_setting_name: 'guidelines_topic_id',
+          title: I18n.t('guidelines_topic.title'),
+          raw: I18n.t('guidelines_topic.body', base_path: Discourse.base_path),
+          category: staff_category,
+          static_first_reply: true
+        },
+
+        # Privacy Policy
+        {
+          site_setting_name: 'privacy_topic_id',
+          title: I18n.t('privacy_topic.title'),
+          raw: I18n.t('privacy_topic.body'),
+          category: staff_category,
+          static_first_reply: true
+        }
+      ]
+
+      if include_welcome_topics
+        # Welcome Topic
+        topics << {
+          site_setting_name: 'welcome_topic_id',
+          title: I18n.t('discourse_welcome_topic.title'),
+          raw: I18n.t('discourse_welcome_topic.body', base_path: Discourse.base_path),
+          after_create: proc do |post|
+            post.topic.update_pinned(true, true)
+          end
+        }
+
+        # Lounge Welcome Topic
+        if lounge_category = Category.find_by(id: SiteSetting.lounge_category_id)
+          topics << {
+            site_setting_name: 'lounge_welcome_topic_id',
+            title: I18n.t('lounge_welcome.title'),
+            raw: I18n.t('lounge_welcome.body', base_path: Discourse.base_path),
+            category: lounge_category,
+            after_create: proc do |post|
+              post.topic.update_pinned(true)
+            end
+          }
+        end
+
+        # Admin Quick Start Guide
+        topics << {
+          site_setting_name: 'admin_quick_start_topic_id',
+          title: DiscoursePluginRegistry.seed_data['admin_quick_start_title'] || I18n.t('admin_quick_start_title'),
+          raw: admin_quick_start_raw,
+          category: staff_category
+        }
+      end
+
+      topics
+    end
+
+    def create_topic(site_setting_name:, title:, raw:, category: nil, static_first_reply: false, after_create: nil)
+      topic_id = SiteSetting.send(site_setting_name)
+      return if topic_id > 0 || Topic.find_by(id: topic_id)
+
+      post = PostCreator.create!(
+        Discourse.system_user,
+        title: title,
+        raw: raw,
+        skip_validations: true,
+        category: category&.name
+      )
+
+      if static_first_reply
+        PostCreator.create!(
+          Discourse.system_user,
+          raw: first_reply_raw(title),
+          skip_validations: true,
+          topic_id: post.topic_id
+        )
+      end
+
+      after_create&.call(post)
+
+      SiteSetting.send("#{site_setting_name}=", post.topic_id)
+    end
+
+    def update_topic(site_setting_name:, title:, raw:, static_first_reply: false)
+      topic_id = SiteSetting.send(site_setting_name)
+      post = Post.find_by(topic_id: topic_id, post_number: 1)
+      return if !post
+
+      post.revise(
+        Discourse.system_user,
+        title: title,
+        raw: raw,
+        skip_validations: true
+      )
+
+      if static_first_reply && reply = first_reply(post)
+        reply.revise(
+          Discourse.system_user,
+          raw: first_reply_raw(title),
+          skip_validations: true
+        )
+      end
+    end
+
+    def setting_value(site_setting_key)
+      SiteSetting.send(site_setting_key).presence || "<ins>#{site_setting_key}</ins>"
+    end
+
+    def first_reply(post)
+      Post.find_by(topic_id: post.topic_id, post_number: 2, user_id: Discourse::SYSTEM_USER_ID)
+    end
+
+    def first_reply_raw(topic_title)
+      I18n.t('static_topic_first_reply', page_name: topic_title)
+    end
+
+    def admin_quick_start_raw
+      quick_start_filename = DiscoursePluginRegistry.seed_data["admin_quick_start_filename"]
+
+      if !quick_start_filename || !File.exist?(quick_start_filename)
+        # TODO Make the quick start guide translatable
+        quick_start_filename = File.join(Rails.root, 'docs', 'ADMIN-QUICK-START-GUIDE.md')
+      end
+
+      File.read(quick_start_filename)
+    end
+  end
+end

--- a/lib/tasks/topics.rake
+++ b/lib/tasks/topics.rake
@@ -65,20 +65,6 @@ task "topics:apply_autoclose" => :environment do
   puts "", "Done"
 end
 
-def update_static_page_topic(locale, site_setting_key, title_key, body_key, params = {})
-  topic = Topic.find(SiteSetting.send(site_setting_key))
-
-  if (topic && post = topic.first_post)
-    post.revise(Discourse.system_user,
-                title: I18n.t(title_key, locale: locale),
-                raw: I18n.t(body_key, params.merge(locale: locale)))
-
-    puts "", "Topic for #{site_setting_key} updated"
-  else
-    puts "", "Topic for #{site_setting_key} not found"
-  end
-end
-
 desc "Update static topics (ToS, Privacy, Guidelines) with latest translated content"
 task "topics:update_static", [:locale] => [:environment] do |_, args|
   locale = args[:locale]&.to_sym
@@ -88,15 +74,5 @@ task "topics:update_static", [:locale] => [:environment] do |_, args|
     exit 1
   end
 
-  update_static_page_topic(locale, "tos_topic_id", "tos_topic.title", "tos_topic.body",
-                           company_name: SiteSetting.company_name.presence || "company_name",
-                           base_url: Discourse.base_url,
-                           contact_email: SiteSetting.contact_email.presence || "contact_email",
-                           governing_law: SiteSetting.governing_law.presence || "governing_law",
-                           city_for_disputes: SiteSetting.city_for_disputes.presence || "city_for_disputes")
-
-  update_static_page_topic(locale, "guidelines_topic_id", "guidelines_topic.title", "guidelines_topic.body",
-                           base_path: Discourse.base_path)
-
-  update_static_page_topic(locale, "privacy_topic_id", "privacy_topic.title", "privacy_topic.body")
+  SeedData::Topics.with_default_locale.update
 end

--- a/spec/lib/introduction_updater_spec.rb
+++ b/spec/lib/introduction_updater_spec.rb
@@ -12,8 +12,8 @@ describe IntroductionUpdater do
       topic
     end
 
-    it "finds the welcome topic by custom field" do
-      TopicCustomField.create(topic_id: welcome_topic.id, name: "is_welcome_topic", value: "true")
+    it "finds the welcome topic by site setting" do
+      SiteSetting.welcome_topic_id = welcome_topic.id
       expect(subject.get_summary).to eq(welcome_post_raw)
     end
 


### PR DESCRIPTION
* Stores IDs of seeded topics as hidden site settings and converts the `is_welcome_topic` custom field into a site setting as well.

* Makes the topic title of the Admin Quick Start Guide translatable. The guide's content not yet.

* Allows the `topics:update_static` rake task to update all seeded topics with a given locale.
(Works only for newly created sites which have the new hidden site settings.)

* Deduplicates code used by `db/fixtures/990_topics.rb` and `topics.rake`