### PR TITLE
FEATURE: Optional detailed performance logging for Sidekiq jobs

### DIFF
--- a/app/jobs/base.rb
+++ b/app/jobs/base.rb
@@ -87,9 +87,13 @@ module Jobs
         interval = ENV["DISCOURSE_LOG_SIDEKIQ_INTERVAL"]
         return if !interval
         @@interval_thread ||= Thread.new do
-          loop do
-            sleep interval.to_i
-            @@active_jobs.each { |j| j.write_to_log if j.current_duration > interval }
+          begin
+            loop do
+              sleep interval.to_i
+              @@active_jobs.each { |j| j.write_to_log if j.current_duration > interval }
+            end
+          rescue Exception => e
+            Discourse.warn_exception(e, message: "Sidekiq interval logging thread terminated unexpectedly")
           end
         end
       end

--- a/lib/method_profiler.rb
+++ b/lib/method_profiler.rb
@@ -61,4 +61,26 @@ class MethodProfiler
     end
     data
   end
+
+  def self.ensure_discourse_instrumentation!
+    @@instrumentation_setup ||= begin
+      MethodProfiler.patch(PG::Connection, [
+        :exec, :async_exec, :exec_prepared, :send_query_prepared, :query, :exec_params
+      ], :sql)
+
+      MethodProfiler.patch(Redis::Client, [
+        :call, :call_pipeline
+      ], :redis)
+
+      MethodProfiler.patch(Net::HTTP, [
+        :request
+      ], :net, no_recurse: true)
+
+      MethodProfiler.patch(Excon::Connection, [
+        :request
+      ], :net)
+      true
+    end
+  end
+
 end

--- a/lib/middleware/request_tracker.rb
+++ b/lib/middleware/request_tracker.rb
@@ -15,26 +15,7 @@ class Middleware::RequestTracker
   #   # do stuff with env and data
   # end
   def self.register_detailed_request_logger(callback)
-
-    unless @patched_instrumentation
-      MethodProfiler.patch(PG::Connection, [
-        :exec, :async_exec, :exec_prepared, :send_query_prepared, :query, :exec_params
-      ], :sql)
-
-      MethodProfiler.patch(Redis::Client, [
-        :call, :call_pipeline
-      ], :redis)
-
-      MethodProfiler.patch(Net::HTTP, [
-        :request
-      ], :net, no_recurse: true)
-
-      MethodProfiler.patch(Excon::Connection, [
-        :request
-      ], :net)
-      @patched_instrumentation = true
-    end
-
+    MethodProfiler.ensure_discourse_instrumentation!
     (@@detailed_request_loggers ||= []) << callback
   end
 


### PR DESCRIPTION
By default, this does nothing. Two environment variables are available:

- `DISCOURSE_LOG_SIDEKIQ`

  Set to `"1"` to enable logging. This will log all completed jobs to `log/rails/sidekiq.log`, along with various db/redis/network statistics. This is useful to track down poorly performing jobs.

- `DISCOURSE_LOG_SIDEKIQ_INTERVAL`

  (seconds) Check running jobs periodically, and log their current duration. They will appear in the logs with `status:pending`. This is useful to track down jobs which take a long time, then crash sidekiq before completing.