### PR TITLE
Add ubuntu screen file

### DIFF
--- a/docs/ubuntu.screen
+++ b/docs/ubuntu.screen
@@ -1,0 +1,18 @@
+# GNU screen configuration file for Discourse Ubuntu development
+
+# Start up your development instance in detached mode:
+#   screen -d -m -c docs/ubuntu.screen
+
+# Start in attached mode:
+# screen -m -c docs/ubuntu.screen
+
+# commands that exit hang around until you hit 'k' to kill or 'r' to restart
+zombie kr
+
+screen -t rails_s 0 bash -c 'echo Starting rails server...;  cd ~/discourse; bundle exec rails s -b 0.0.0.0'
+screen -t rails_c 1 bash -c 'echo Starting rails console...; cd ~/discourse; bundle exec rails c'
+screen -t sidekiq 2 bash -c 'echo Starting sidekiq...;       cd ~/discourse; bundle exec sidekiq -l log/sidekiq.log'
+screen -t mail    3 bash -c 'echo Starting mailcatcher...;   cd ~/discourse; mailcatcher --http-ip 0.0.0.0'
+screen -t bash    4 bash
+
+scrollback 50000


### PR DESCRIPTION
The Discourse vagrant instance previously had a screen file (per [this comment](https://meta.discourse.org/t/how-to-use-screen-to-bootstrap-a-development-install-ubuntu/62678/2)).

This commit introduces a screen file for ubuntu that should work if the [ubuntu dev guide](https://meta.discourse.org/t/beginners-guide-to-install-discourse-on-ubuntu-for-development/14727) is followed.