### PR TITLE
FIX: Return actual errors if PostCreator fails

### DIFF
--- a/script/import_scripts/base.rb
+++ b/script/import_scripts/base.rb
@@ -563,7 +563,7 @@ class ImportScripts::Base
     post_creator = PostCreator.new(user, opts)
     post = post_creator.create
     post_create_action.try(:call, post) if post
-    post_creator.errors.full_messages.empty? ? post : post_creator.errors.full_messages
+    if !post || post_creator.errors&.length > 0 ? post : post_creator.errors.full_messages
   end
 
   def create_upload(user_id, path, source_filename)

--- a/script/import_scripts/base.rb
+++ b/script/import_scripts/base.rb
@@ -563,7 +563,7 @@ class ImportScripts::Base
     post_creator = PostCreator.new(user, opts)
     post = post_creator.create
     post_create_action.try(:call, post) if post
-    post ? post : post_creator.errors.full_messages
+    post_creator.errors.full_messages.empty? ? post : post_creator.errors.full_messages
   end
 
   def create_upload(user_id, path, source_filename)


### PR DESCRIPTION
https://meta.discourse.org/t/insufficient-checking-of-postcreator-in-importer-base/110570
Extract:
It seems that if (for example) you mistakenly try and add
target_usernames to a post with user_ids rather than usernames,
create_post in scripts/import_scripts/base.rb won’t return an error.

This is because it returns: post ? post :
post_creator.errors.full_messages. However, post has already been
initialised as a Post type on line 564. Checking for the post_creator
errors instead returns the correct behaviour.