### PR TITLE
Ruby version update

### DIFF
--- a/docs/DEVELOPER-ADVANCED.md
+++ b/docs/DEVELOPER-ADVANCED.md
@@ -21,8 +21,8 @@ To get your Ubuntu 16.04 or 18.04 LTS install up and running to develop Discours
 
     # exit the terminal and open it again to activate RVM
 
-    rvm install 2.5.3
-    rvm --default use 2.5.3 # If this error out check https://rvm.io/integration/gnome-terminal
+    rvm install 2.6.1
+    rvm --default use 2.6.1 # If this error out check https://rvm.io/integration/gnome-terminal
     gem install bundler mailcatcher rake
 
     # Download and install postgresql-10 from https://wiki.postgresql.org/wiki/Apt

--- a/docs/DEVELOPMENT-OSX-NATIVE.md
+++ b/docs/DEVELOPMENT-OSX-NATIVE.md
@@ -4,7 +4,7 @@ These instructions assume you have read and understood the **[Discourse Advanced
 
 OS X has become a popular platform for developing Ruby on Rails applications; as such, if you run OS X, you might find it more congenial to work on **[Discourse](https://www.discourse.org)** in your native environment. These instructions should get you there.
 
-Obviously, if you **already** develop Ruby on OS X, a lot of this will be redundant, because you'll have already done it, or something like it. If that's the case, you may well be able to just install Ruby 2.5+ using RVM and get started! Discourse has enough dependencies, however (note: not a criticism!) that there's a good chance you'll find **something** else in this document that's useful for getting your Discourse development started!
+Obviously, if you **already** develop Ruby on OS X, a lot of this will be redundant, because you'll have already done it, or something like it. If that's the case, you may well be able to just install Ruby 2.6+ using RVM and get started! Discourse has enough dependencies, however (note: not a criticism!) that there's a good chance you'll find **something** else in this document that's useful for getting your Discourse development started!
 
 ## Quick Setup
 
@@ -76,11 +76,11 @@ If you do already have RVM installed, this should make sure everything is up to 
     # If autolibs is set to 0-2, it will give an error for things that are missing, instead.
     rvm requirements
 
-Either way, you'll now want to install Ruby 2.5+ (we recommend 2.5.2 or higher).
+Either way, you'll now want to install Ruby 2.6+ (we recommend 2.6.1 or higher).
 
     # Now, install Ruby
-    rvm install 2.5.3
-    rvm use 2.5.3 --default # Careful with this if you're already developing Ruby
+    rvm install 2.6.1
+    rvm use 2.6.1 --default # Careful with this if you're already developing Ruby
 
 ## Git
 


### PR DESCRIPTION
Commit 8745f78277f80250032352343bde59f7bba12bec stated that Ruby 2.6.1 and above should be used for development operations.

Per that commit bump all references to Ruby 2.5 to Ruby version 2.6.