### PR TITLE
DEV: Add `pry-remote` gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -137,6 +137,7 @@ group :test, :development do
   gem 'shoulda', require: false
   gem 'rspec-html-matchers'
   gem 'pry-nav'
+  gem 'pry-remote'
   gem 'byebug', require: ENV['RM_INFO'].nil?
   gem 'rubocop', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -287,6 +287,9 @@ GEM
       pry (>= 0.9.10, < 0.11.0)
     pry-rails (0.3.6)
       pry (>= 0.10.4)
+    pry-remote (0.1.8)
+      pry (~> 0.9)
+      slop (~> 3.0)
     public_suffix (3.0.3)
     puma (3.12.0)
     r2 (0.2.7)
@@ -520,6 +523,7 @@ DEPENDENCIES
   pg
   pry-nav
   pry-rails
+  pry-remote
   puma
   r2 (~> 0.2.5)
   rack-mini-profiler


### PR DESCRIPTION
## Why?

I find it easy to use `pry-remote` when I want to debug and not wanting to depend on `binding.pry` which gets overridden most of the times by the log lines in the terminal. I am not sure if there is a better way but I find this gem handy. 