### PR TITLE
FIX: Remove ignore user feature from `user-card-contents` component

### DIFF
--- a/app/assets/javascripts/discourse/components/user-card-contents.js.es6
+++ b/app/assets/javascripts/discourse/components/user-card-contents.js.es6
@@ -195,11 +195,6 @@ export default Ember.Component.extend(
         this._close();
       },
 
-      ignoreUser() {
-        this.get("user").ignore();
-        this._close();
-      },
-
       watchUser() {
         this.get("user").watch();
         this._close();

--- a/app/assets/javascripts/discourse/templates/components/user-card-contents.hbs
+++ b/app/assets/javascripts/discourse/templates/components/user-card-contents.hbs
@@ -48,21 +48,6 @@
             icon="envelope"
             label="user.private_message"}}
         </li>
-        {{#if user.can_ignore_user}}
-          <li>
-            {{#if user.ignored}}
-              {{d-button class="btn-default"
-                         action=(action "watchUser")
-                         icon="far-eye"
-                         label="user.watch"}}
-            {{else}}
-              {{d-button class="btn-danger"
-                         action=(action "ignoreUser")
-                         icon="far-eye-slash"
-                         label="user.ignore"}}
-            {{/if}}
-          </li>
-        {{/if}}
       {{/if}}
 
       {{#if showFilter}}


### PR DESCRIPTION
## Why?

Based on our discussions, we want to have the `Ignore button will ONLY be on the User’s profile page`.

This is how the `user-card-contents` component looks like:

![image](https://user-images.githubusercontent.com/45508821/53741133-96a1ae80-3e8d-11e9-8616-b0baec048b9a.png)

We are removing the `Ignore` button from there.
