### PR TITLE
FIX: Fixed editing whispers bumps topic

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -236,9 +236,6 @@ class PostsController < ApplicationController
       opts[:skip_validations] = true
     end
 
-    # Bypass bump for whisper edits
-    opts[:bypass_bump] = true if post.whisper?
-
     topic = post.topic
     topic = Topic.with_deleted.find(post.topic_id) if guardian.is_staff?
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -236,6 +236,9 @@ class PostsController < ApplicationController
       opts[:skip_validations] = true
     end
 
+    # Bypass bump for whisper edits
+    opts[:bypass_bump] = true if post.whisper?
+
     topic = post.topic
     topic = Topic.with_deleted.find(post.topic_id) if guardian.is_staff?
 

--- a/lib/post_revisor.rb
+++ b/lib/post_revisor.rb
@@ -512,7 +512,7 @@ class PostRevisor
   end
 
   def bypass_bump?
-    !@post_successfully_saved || @topic_changes.errored? || @opts[:bypass_bump] == true
+    !@post_successfully_saved || @topic_changes.errored? || @opts[:bypass_bump] == true || @post.whisper?
   end
 
   def is_last_post?

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -393,6 +393,15 @@ describe PostsController do
         post.reload
         expect(post.raw).to eq('edited body')
       end
+
+      it "won't update bump date if post is a whisper" do
+        post = Fabricate(:post, post_type: Post.types[:whisper], user: user)
+
+        put "/posts/#{post.id}.json", params: update_params
+        expect(response.status).to eq(200)
+
+        expect(post.topic.reload.bumped_at).to be < post.created_at
+      end
     end
 
     it 'can not change category to a disallowed category' do


### PR DESCRIPTION
Editing a whisper not longer changes the topic's bump date.

Resolves: https://meta.discourse.org/t/editing-whisper-bumps-topic/108890

This is also my first PR for discourse. Feedback is greatly appreciated!