### PR TITLE
FEATURE: defer flags when deleting child replies

### DIFF
--- a/app/assets/javascripts/admin/models/flagged-post.js.es6
+++ b/app/assets/javascripts/admin/models/flagged-post.js.es6
@@ -136,7 +136,9 @@ export default Post.extend({
             label: I18n.t("yes_value"),
             class: "btn-danger",
             callback() {
-              Post.deleteMany(replies.map(r => r.id), { deferFlags: true })
+              Post.deleteMany(replies.map(r => r.id), {
+                agreeWithFirstReplyFlag: false
+              })
                 .then(action)
                 .then(resolve)
                 .catch(error => {

--- a/app/assets/javascripts/discourse/models/post.js.es6
+++ b/app/assets/javascripts/discourse/models/post.js.es6
@@ -378,10 +378,10 @@ Post.reopenClass({
     });
   },
 
-  deleteMany(post_ids, { deferFlags = false } = {}) {
+  deleteMany(post_ids, { agreeWithFirstReplyFlag = true } = {}) {
     return ajax("/posts/destroy_many", {
       type: "DELETE",
-      data: { post_ids, defer_flags: deferFlags }
+      data: { post_ids, agree_with_first_reply_flag: agreeWithFirstReplyFlag }
     });
   },
 

--- a/lib/post_destroyer.rb
+++ b/lib/post_destroyer.rb
@@ -147,7 +147,7 @@ class PostDestroyer
       update_user_counts
       TopicUser.update_post_action_cache(post_id: @post.id)
       DB.after_commit do
-        if @opts[:defer_flags].to_s == "true"
+        if @opts[:defer_flags]
           defer_flags
         else
           agree_with_flags

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -248,15 +248,22 @@ describe PostsController do
         let(:moderator) { Fabricate(:moderator) }
 
         before do
+          sign_in(moderator)
           PostAction.act(moderator, post1, PostActionType.types[:off_topic])
           PostAction.act(moderator, post2, PostActionType.types[:off_topic])
           Jobs::SendSystemMessage.clear
         end
 
-        it "defers the posts" do
-          sign_in(moderator)
+        it "defers the child posts by default" do
           expect(PostAction.flagged_posts_count).to eq(2)
-          delete "/posts/destroy_many.json", params: { post_ids: [post1.id, post2.id], defer_flags: true }
+          delete "/posts/destroy_many.json", params: { post_ids: [post1.id, post2.id] }
+          expect(Jobs::SendSystemMessage.jobs.size).to eq(1)
+          expect(PostAction.flagged_posts_count).to eq(0)
+        end
+
+        it "can defer all posts based on `agree_with_first_reply_flag` param" do
+          expect(PostAction.flagged_posts_count).to eq(2)
+          delete "/posts/destroy_many.json", params: { post_ids: [post1.id, post2.id], agree_with_first_reply_flag: false }
           expect(Jobs::SendSystemMessage.jobs.size).to eq(0)
           expect(PostAction.flagged_posts_count).to eq(0)
         end


### PR DESCRIPTION
When deleting multiple posts in a topic only auto-agree with the flag on the actual post you pressed delete on and ignore all other flags in child deletes.