### PR TITLE
FIX: Fixed custom emoji circumventing "max emojis in topic title" set…

### DIFF
--- a/lib/pretty_text.rb
+++ b/lib/pretty_text.rb
@@ -230,7 +230,7 @@ module PrettyText
     return title unless SiteSetting.enable_emoji?
 
     set = SiteSetting.emoji_set.inspect
-    custom = Emoji.custom.map{ |e| [e.name, e.url] }.to_h.to_json
+    custom = Emoji.custom.map { |e| [e.name, e.url] }.to_h.to_json
     protect do
       v8.eval(<<~JS)
         __paths = #{paths_json};

--- a/lib/pretty_text.rb
+++ b/lib/pretty_text.rb
@@ -230,10 +230,11 @@ module PrettyText
     return title unless SiteSetting.enable_emoji?
 
     set = SiteSetting.emoji_set.inspect
+    custom = Emoji.custom.map{ |e| [e.name, e.url] }.to_h.to_json
     protect do
       v8.eval(<<~JS)
         __paths = #{paths_json};
-        __performEmojiUnescape(#{title.inspect}, { getURL: __getURL, emojiSet: #{set} });
+        __performEmojiUnescape(#{title.inspect}, { getURL: __getURL, emojiSet: #{set}, customEmoji: #{custom} });
       JS
     end
   end

--- a/spec/components/validators/max_emojis_validator_spec.rb
+++ b/spec/components/validators/max_emojis_validator_spec.rb
@@ -14,7 +14,9 @@ describe MaxEmojisValidator do
   shared_examples "validating any topic title" do
     it 'adds an error when emoji count is greater than SiteSetting.max_emojis_in_title' do
       SiteSetting.max_emojis_in_title = 3
-      record.title = '🧐 Lots of emojis here 🎃 :joy: :)'
+      CustomEmoji.create!(name: 'trout', upload: Fabricate(:upload))
+      Emoji.clear_cache
+      record.title = '🧐 Lots of emojis here 🎃 :trout: :)'
       validate
       expect(record.errors[:title][0]).to eq(I18n.t("errors.messages.max_emojis", max_emojis_count: 3))
 


### PR DESCRIPTION
This addresses the issue reported in the link below, where custom emojis weren't counted in the "max emojis" validation.

Resolves: https://meta.discourse.org/t/custom-emoji-circumvent-max-emojis-in-topic-title-setting/109425