### PR TITLE
FIX: Changed poll closing messages to upcase

### DIFF
--- a/plugins/poll/config/locales/client.bs_BA.yml
+++ b/plugins/poll/config/locales/client.bs_BA.yml
@@ -50,8 +50,8 @@ bs_BA:
         label: "Zatvori"
         confirm: "Da li ste sigurni da želite da zatvorite ovu anketu?"
       automatic_close:
-        closes_in: "zatvara se za<strong>%{timeLeft}</strong>"
-        age: "zatvoreno<strong>%{age}</strong>"
+        closes_in: "Zatvara se za<strong>%{timeLeft}</strong>"
+        age: "Zatvoreno<strong>%{age}</strong>"
       error_while_toggling_status: "Izvinjavamo se, pojavio se problem u prebacivanju statutusa ove ankete"
       error_while_casting_votes: "Izvinjavamo se, pojavila se greška prikazivanja vaših glasova"
       error_while_fetching_voters: "Izvinjavamo se, pojavila se greška pri prikazivanju glasača"

--- a/plugins/poll/config/locales/client.de.yml
+++ b/plugins/poll/config/locales/client.de.yml
@@ -52,8 +52,8 @@ de:
         label: "Beenden"
         confirm: "Möchtest du diese Umfrage wirklich beenden?"
       automatic_close:
-        closes_in: "schließt in <strong>%{timeLeft}</strong>"
-        age: "geschlossen <strong>%{age}</strong>"
+        closes_in: "Schließt in <strong>%{timeLeft}</strong>"
+        age: "Geschlossen <strong>%{age}</strong>"
       error_while_toggling_status: "Entschuldige, beim Wechseln des Status dieser Umfrage ist ein Fehler aufgetreten."
       error_while_casting_votes: "Entschuldige, beim Abgeben deiner Stimme ist ein Fehler aufgetreten."
       error_while_fetching_voters: "Entschuldige, beim Anzeigen der Teilnehmer ist ein Fehler aufgetreten."

--- a/plugins/poll/config/locales/client.en.yml
+++ b/plugins/poll/config/locales/client.en.yml
@@ -73,7 +73,7 @@ en:
 
       automatic_close:
         closes_in: "Closes in <strong>%{timeLeft}</strong>."
-        age: "closed <strong>%{age}</strong>"
+        age: "Closed <strong>%{age}</strong>"
 
       error_while_toggling_status: "Sorry, there was an error toggling the status of this poll."
       error_while_casting_votes: "Sorry, there was an error casting your votes."

--- a/plugins/poll/config/locales/client.es.yml
+++ b/plugins/poll/config/locales/client.es.yml
@@ -52,8 +52,8 @@ es:
         label: "Cerrar"
         confirm: "¿Seguro que quieres cerrar esta encuesta?"
       automatic_close:
-        closes_in: "cierra en <strong>%{timeLeft}</strong>"
-        age: "cerrado <strong>%{age}</strong>"
+        closes_in: "Cierra en <strong>%{timeLeft}</strong>"
+        age: "Cerrado <strong>%{age}</strong>"
       error_while_toggling_status: "Lo sentimos, hubo un error al cambiar el estado de esta encuesta."
       error_while_casting_votes: "Lo sentimos, hubo un error al registrar tus votos."
       error_while_fetching_voters: "Lo sentimos, hubo un error al mostrar los votantes."

--- a/plugins/poll/config/locales/client.fi.yml
+++ b/plugins/poll/config/locales/client.fi.yml
@@ -52,8 +52,8 @@ fi:
         label: "Sulje"
         confirm: "Suljetaanko äänestys?"
       automatic_close:
-        closes_in: "sulkeutuu <strong>%{timeLeft}</strong> kuluttua"
-        age: "sulkeutui <strong>%{age}</strong>"
+        closes_in: "Sulkeutuu <strong>%{timeLeft}</strong> kuluttua"
+        age: "Sulkeutui <strong>%{age}</strong>"
       error_while_toggling_status: "Pahoittelut, äänestyksen tilaa muutettaessa tapahtui virhe."
       error_while_casting_votes: "Pahoittelut, ääntä annettaessa tapahtui virhe."
       error_while_fetching_voters: "Pahoittelut, äänestäneiden näyttämisessä tapahtui virhe."

--- a/plugins/poll/config/locales/client.fr.yml
+++ b/plugins/poll/config/locales/client.fr.yml
@@ -52,8 +52,8 @@ fr:
         label: "Fermer"
         confirm: "Êtes-vous sûr de vouloir fermer ce sondage ?"
       automatic_close:
-        closes_in: "fermera dans <strong>%{timeLeft}</strong>"
-        age: "fermé <strong>%{age}</strong>"
+        closes_in: "Fermera dans <strong>%{timeLeft}</strong>"
+        age: "Fermé <strong>%{age}</strong>"
       error_while_toggling_status: "Désolé, il y a eu une erreur lors du changement de statut de ce sondage."
       error_while_casting_votes: "Désolé, il y a eu une erreur lors de l'envoi de vos votes."
       error_while_fetching_voters: "Désolé, il y a eu une erreur lors de l'affichage des votants."

--- a/plugins/poll/config/locales/client.hu.yml
+++ b/plugins/poll/config/locales/client.hu.yml
@@ -41,7 +41,7 @@ hu:
         label: "Bezárás"
         confirm: "Biztosan lezárod ezt a szavazást?"
       automatic_close:
-        closes_in: "le lesz zárva <strong>%{timeLeft}</strong>"
+        closes_in: "Le lesz zárva <strong>%{timeLeft}</strong>"
       error_while_toggling_status: "Elnézést, a szavazat állapotának vizsgálatakor hiba lépett fel."
       error_while_casting_votes: "Sajnáljuk, hiba történt a szavazatod elküldésekor."
       error_while_fetching_voters: "Elnézést, a szavazatok kiírásakor hiba lépett fel."

--- a/plugins/poll/config/locales/client.it.yml
+++ b/plugins/poll/config/locales/client.it.yml
@@ -47,8 +47,8 @@ it:
         label: "Chiudi"
         confirm: "Sicuro di voler chiudere questo sondaggio?"
       automatic_close:
-        closes_in: "termina in <strong>%{timeLeft}</strong>"
-        age: "terminato <strong>%{age}</strong>"
+        closes_in: "Termina in <strong>%{timeLeft}</strong>"
+        age: "Terminato <strong>%{age}</strong>"
       error_while_toggling_status: "Spiacenti, si è verificato un errore nel commutare lo stato di questo sondaggio."
       error_while_casting_votes: "Spiacenti, si è verificato un errore nella votazione."
       error_while_fetching_voters: "Spiacenti, si è verificato un errore nel visualizzare i votanti."

--- a/plugins/poll/config/locales/client.nb_NO.yml
+++ b/plugins/poll/config/locales/client.nb_NO.yml
@@ -45,8 +45,8 @@ nb_NO:
         label: "Lukk"
         confirm: "Er du sikker på at du vil lukke avstemningen?"
       automatic_close:
-        closes_in: "stenger om <strong>%{timeLeft}</strong>"
-        age: "stengt <strong>%{age}</strong>"
+        closes_in: "Stenger om <strong>%{timeLeft}</strong>"
+        age: "Stengt <strong>%{age}</strong>"
       error_while_toggling_status: "Beklager, det oppstod en feil ved endring av status på denne avstemningen."
       error_while_casting_votes: "Beklager, det oppstod en feil da du ga din stemme."
       error_while_fetching_voters: "Beklager, det oppstod en feil når stemmegivere skulle vises."

--- a/plugins/poll/config/locales/client.pl_PL.yml
+++ b/plugins/poll/config/locales/client.pl_PL.yml
@@ -55,8 +55,8 @@ pl_PL:
         label: "Zamknij"
         confirm: "Czy na pewno chcesz zamknąć tę ankietę?"
       automatic_close:
-        closes_in: "zostanie zamknięty w ciągu <strong>%{timeLeft}</strong>"
-        age: "zamknięty <strong>%{age}</strong>"
+        closes_in: "Zostanie zamknięty w ciągu <strong>%{timeLeft}</strong>"
+        age: "Zamknięty <strong>%{age}</strong>"
       error_while_toggling_status: "Przepraszamy, wystąpił błąd podczas przełączania statusu w tej ankiecie."
       error_while_casting_votes: "Przepraszamy, wystąpił błąd podczas oddawania głosów."
       error_while_fetching_voters: "Przepraszamy, wystąpił błąd podczas wyświetlania głosujących."

--- a/plugins/poll/config/locales/client.pt_BR.yml
+++ b/plugins/poll/config/locales/client.pt_BR.yml
@@ -47,8 +47,8 @@ pt_BR:
         label: "Fechar"
         confirm: "Você tem certeza que deseja fechar essa enquete?"
       automatic_close:
-        closes_in: "fecha em<strong>%{timeLeft}</strong>"
-        age: "fechado <strong>%{age}</strong>"
+        closes_in: "Fecha em<strong>%{timeLeft}</strong>"
+        age: "Fechado <strong>%{age}</strong>"
       error_while_toggling_status: "Desculpe, houve um erro ao mudar a situação da enquete.."
       error_while_casting_votes: "Desculpe, houve um erro ao votar."
       error_while_fetching_voters: "Desculpe, houve um erro ao mostrar os votantes."

--- a/plugins/poll/config/locales/client.ro.yml
+++ b/plugins/poll/config/locales/client.ro.yml
@@ -50,8 +50,8 @@ ro:
         label: "Închide sondajul"
         confirm: "Ești sigur că vrei să închizi acest sondaj?"
       automatic_close:
-        closes_in: "se închide în <strong>%{timeLeft}</strong>"
-        age: "închis <strong>%{age}</strong>"
+        closes_in: "Se închide în <strong>%{timeLeft}</strong>"
+        age: "Închis <strong>%{age}</strong>"
       error_while_toggling_status: "Ne pare rău, a apărut o eroare la schimbarea stării acestui sondaj."
       error_while_casting_votes: "Ne pare rău, a apărut o eroare la exercitarea voturilor tale."
       error_while_fetching_voters: "Ne pare rău, a apărut o eroare la afișarea votanților."

--- a/plugins/poll/config/locales/client.ru.yml
+++ b/plugins/poll/config/locales/client.ru.yml
@@ -55,8 +55,8 @@ ru:
         label: "Завершить"
         confirm: "Вы уверены, что хотите завершить этот опрос и больше не принимать голоса?"
       automatic_close:
-        closes_in: "закроется через <strong>%{timeLeft}</strong>"
-        age: "закрыто <strong>%{age}</strong>"
+        closes_in: "Закроется через <strong>%{timeLeft}</strong>"
+        age: "Закрыто <strong>%{age}</strong>"
       error_while_toggling_status: "Произошла ошибка при смене статуса опроса."
       error_while_casting_votes: "Произошла ошибка в процессе обработки вашего голоса."
       error_while_fetching_voters: "В процессе получения списка проголосовавших произошла ошибка."

--- a/plugins/poll/config/locales/client.sk.yml
+++ b/plugins/poll/config/locales/client.sk.yml
@@ -55,8 +55,8 @@ sk:
         label: "Zavrieť"
         confirm: "Ste si istý, že chcete uzavrieť toto hlasovanie?"
       automatic_close:
-        closes_in: "uzavrie sa za"
-        age: "uzavreté"
+        closes_in: "Uzavrie sa za"
+        age: "Uzavreté"
       error_while_toggling_status: "Ľutujeme, nastala chyba pri prepínaní stavu tohto hlasovania."
       error_while_casting_votes: "Ľutujeme, nastala chyba pri prideľovaní Vašich hlasov."
       error_while_fetching_voters: "Ľutujeme, nastala chyba pri zobrazení účastníkov."

--- a/plugins/poll/config/locales/client.sl.yml
+++ b/plugins/poll/config/locales/client.sl.yml
@@ -62,8 +62,8 @@ sl:
         label: "Zapri"
         confirm: "Ali ste prepričani da hočete zapreti to anketo?"
       automatic_close:
-        closes_in: "se zapre v <strong>%{timeLeft}</strong>"
-        age: "zaprta <strong>%{age}</strong>"
+        closes_in: "Se zapre v <strong>%{timeLeft}</strong>"
+        age: "Zaprta <strong>%{age}</strong>"
       error_while_toggling_status: "Prišlo je do napake med spreminjanjem statusa te ankete."
       error_while_casting_votes: "Prišlo je do napake med oddajo vašega glasu."
       error_while_fetching_voters: "Prišlo je do napake med prikazom glasovalcev."

--- a/plugins/poll/config/locales/client.sw.yml
+++ b/plugins/poll/config/locales/client.sw.yml
@@ -47,8 +47,8 @@ sw:
         label: "Funga"
         confirm: "Unauhakika unataka kufunga uchaguzi huu?"
       automatic_close:
-        closes_in: "karibu katika<strong>%{timeLeft}</strong>"
-        age: "imefungwa <strong>%{age}</strong>"
+        closes_in: "Karibu katika<strong>%{timeLeft}</strong>"
+        age: "Imefungwa <strong>%{age}</strong>"
       error_while_toggling_status: "Samahani kulikuwa na hitilafu kwenye kubadilisha hali ya uchaguzi huu."
       error_while_casting_votes: "Samahani kulikuwa na hitilafu kwenye kupiga kura."
       error_while_fetching_voters: "Samahani kulikuwa na hitilafu kwenye kuonyesha wapiga kura."


### PR DESCRIPTION
Both localized "closes_in" and "age" for polls needed to be capitalized.

Resolves: https://meta.discourse.org/t/poll-autoclosing-display-issue/110910

Locales that I wasn't able to change: "client.zh_CN.yml", "client.ja.yml"