### PR TITLE
FIX: Changed poll age message to upcase

### DIFF
--- a/plugins/poll/config/locales/client.en.yml
+++ b/plugins/poll/config/locales/client.en.yml
@@ -73,7 +73,7 @@ en:
 
       automatic_close:
         closes_in: "Closes in <strong>%{timeLeft}</strong>."
-        age: "closed <strong>%{age}</strong>"
+        age: "Closed <strong>%{age}</strong>"
 
       error_while_toggling_status: "Sorry, there was an error toggling the status of this poll."
       error_while_casting_votes: "Sorry, there was an error casting your votes."


### PR DESCRIPTION
The age locale for polls also needed to be capitalized.

Resolves: https://meta.discourse.org/t/poll-autoclosing-display-issue/110910/3