### PR TITLE
FEATURE: unhide the embed_whitelist_selector setting

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1870,6 +1870,7 @@ en:
 
     embed_truncate: "Truncate the embedded posts."
     embed_support_markdown: "Support Markdown formatting for embedded posts."
+    embed_whitelist_selector: "A comma separated list of CSS elements that are allowed in embeds."
     allowed_href_schemes: "Schemes allowed in links in addition to http and https."
     embed_post_limit: "Maximum number of posts to embed."
     embed_username_required: "The username for topic creation is required."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -790,6 +790,8 @@ posting:
     default: true
   embed_support_markdown:
     default: false
+  embed_whitelist_selector:
+    default: ""
   allowed_href_schemes:
     client: true
     default: ""
@@ -1471,9 +1473,6 @@ embedding:
     default: 100
     hidden: true
   embed_title_scrubber:
-    default: ""
-    hidden: true
-  embed_whitelist_selector:
     default: ""
     hidden: true
   embed_blacklist_selector:


### PR DESCRIPTION
This unhides the `embed_whitelist_selector` Site Setting and moves it to the Setting's 'posting' section.

This is mainly intended to be used by WordPress sites. Since the recent update to WordPress, markup is added to images that is preventing them from displaying when a post is expanded on Discourse.