### PR TITLE
FIX: Fixed vanishing select boxes on full search as new content loads

### DIFF
--- a/app/assets/javascripts/discourse/controllers/full-page-search.js.es6
+++ b/app/assets/javascripts/discourse/controllers/full-page-search.js.es6
@@ -216,7 +216,7 @@ export default Ember.Controller.extend({
       return;
     }
 
-    var args = { q: searchTerm, page: this.get("page") };
+    let args = { q: searchTerm, page: this.get("page") };
 
     this.set("searching", true);
     this.set("loading", true);

--- a/app/assets/javascripts/discourse/controllers/full-page-search.js.es6
+++ b/app/assets/javascripts/discourse/controllers/full-page-search.js.es6
@@ -216,12 +216,14 @@ export default Ember.Controller.extend({
       return;
     }
 
+    var args = { q: searchTerm, page: this.get("page") };
+
     this.set("searching", true);
     this.set("loading", true);
-    this.set("bulkSelectEnabled", false);
-    this.get("selected").clear();
-
-    var args = { q: searchTerm, page: this.get("page") };
+    if (args.page === 1) {
+      this.set("bulkSelectEnabled", false);
+      this.get("selected").clear();
+    }
 
     const sortOrder = this.get("sortOrder");
     if (sortOrder && SortOrders[sortOrder].term) {


### PR DESCRIPTION
When more than 50 results were found on full page search and more results were loaded while in bulk select mode, the checkboxes would vanish and bulk select mode would turn off. This has been fixed.

Resolves: https://meta.discourse.org/t/bulk-actions-in-search-results-checkboxes-vanish-as-new-content-loads/111235