### PR TITLE
FIX: Text content search warning if more than 50 results

### DIFF
--- a/app/assets/javascripts/admin/templates/site-text-index.hbs
+++ b/app/assets/javascripts/admin/templates/site-text-index.hbs
@@ -23,4 +23,8 @@
   {{#each siteTexts as |siteText|}}
     {{site-text-summary siteText=siteText editAction=(action "edit") term=q searchRegex=siteTexts.extras.regex}}
   {{/each}}
+
+  {{#if siteTexts.extras.has_more}}
+    <p class="warning">{{i18n 'admin.site_text.more_than_50_results'}}</p>
+  {{/if}}
 {{/conditional-loading-spinner}}

--- a/app/assets/stylesheets/common/admin/admin_base.scss
+++ b/app/assets/stylesheets/common/admin/admin_base.scss
@@ -260,8 +260,8 @@ $mobile-breakpoint: 700px;
       margin-top: 1em;
     }
   }
-  .warning {
-    color: #e45735;
+  p.warning {
+    color: $danger;
   }
 }
 

--- a/app/assets/stylesheets/common/admin/admin_base.scss
+++ b/app/assets/stylesheets/common/admin/admin_base.scss
@@ -260,6 +260,9 @@ $mobile-breakpoint: 700px;
       margin-top: 1em;
     }
   }
+  .warning {
+    color: #e45735;
+  }
 }
 
 .content-list {

--- a/app/controllers/admin/site_texts_controller.rb
+++ b/app/controllers/admin/site_texts_controller.rb
@@ -43,7 +43,8 @@ class Admin::SiteTextsController < Admin::AdminController
       end
     end
 
-    render_serialized(results[0..50], SiteTextSerializer, root: 'site_texts', rest_serializer: true, extras: extras)
+    extras[:has_more] = true if results.size > 50
+    render_serialized(results[0..49], SiteTextSerializer, root: 'site_texts', rest_serializer: true, extras: extras)
   end
 
   def show

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4033,6 +4033,7 @@ en:
         go_back: "Back to Search"
         recommended: "We recommend customizing the following text to suit your needs:"
         show_overriden: "Only show overridden"
+        more_than_50_results: "There are more than 50 results. Please refine your search."
 
       settings: # used by theme and site settings
         show_overriden: "Only show overridden"

--- a/spec/requests/admin/site_texts_controller_spec.rb
+++ b/spec/requests/admin/site_texts_controller_spec.rb
@@ -45,6 +45,13 @@ RSpec.describe Admin::SiteTextsController do
         expect(JSON.parse(response.body)['site_texts']).to include(include("id" => "title"))
       end
 
+      it 'sets has_more to true if more than 50 results were found' do
+        get "/admin/customize/site_texts.json", params: { q: 'e' }
+        expect(response.status).to eq(200)
+        expect(JSON.parse(response.body)['site_texts'].size).to eq(50)
+        expect(JSON.parse(response.body)['extras']['has_more']).to be_truthy
+      end
+
       it 'normalizes quotes during search' do
         value = %q|“That’s a ‘magic’ sock.”|
         put "/admin/customize/site_texts/title.json", params: { site_text: { value: value } }


### PR DESCRIPTION
This adds a warning to site texts search if more than 50 results were found.

Resolves: https://meta.discourse.org/t/customize-text-content-search-results-missing/65327