### PR TITLE
FIX: invite approval `StaffActionLogger` bug

### DIFF
--- a/app/models/invite_redeemer.rb
+++ b/app/models/invite_redeemer.rb
@@ -133,7 +133,7 @@ InviteRedeemer = Struct.new(:invite, :username, :name, :password, :user_custom_f
 
   def approve_account_if_needed
     if get_existing_user
-      invited_user.approve(invite.invited_by_id, false)
+      invited_user.approve(invite.invited_by, false)
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -410,6 +410,7 @@ class User < ActiveRecord::Base
 
     if approved_by.is_a?(Integer)
       self.approved_by_id = approved_by
+      self.approved_by = User.find(approved_by)
     else
       self.approved_by = approved_by
     end
@@ -421,7 +422,7 @@ class User < ActiveRecord::Base
       DiscourseEvent.trigger(:user_approved, self)
     end
 
-    StaffActionLogger.new(approved_by).log_user_approve(self)
+    StaffActionLogger.new(self.approved_by).log_user_approve(self)
 
     result
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -405,24 +405,17 @@ class User < ActiveRecord::Base
   end
 
   # Approve this user
-  def approve(approved_by, send_mail = true)
+  def approve(approver, send_mail = true)
     self.approved = true
-
-    if approved_by.is_a?(Integer)
-      self.approved_by_id = approved_by
-      self.approved_by = User.find(approved_by)
-    else
-      self.approved_by = approved_by
-    end
-
     self.approved_at = Time.zone.now
+    self.approved_by = approver
 
     if result = save
       send_approval_email if send_mail
       DiscourseEvent.trigger(:user_approved, self)
     end
 
-    StaffActionLogger.new(self.approved_by).log_user_approve(self)
+    StaffActionLogger.new(approver).log_user_approve(self)
 
     result
   end


### PR DESCRIPTION
## Why?

We send `approved_by` to the `StaffActionLogger` which sometimes can be an integer, and that blows it up during its construction.