### PR TITLE
UX: Enabled pinch to zoom for lightbox

### DIFF
--- a/app/assets/javascripts/discourse/lib/lightbox.js.es6
+++ b/app/assets/javascripts/discourse/lib/lightbox.js.es6
@@ -6,7 +6,7 @@ export default function($elem) {
   if (!$elem) {
     return;
   }
-  const original_meta = $("meta[name=viewport]");
+  const originalMeta = $("meta[name=viewport]").attr("content");
   loadScript("/javascripts/jquery.magnific-popup.min.js").then(function() {
     const spoilers = $elem.find(".spoiler a.lightbox, .spoiled a.lightbox");
     $elem
@@ -24,8 +24,9 @@ export default function($elem) {
 
         callbacks: {
           open() {
-            original_meta.replaceWith(
-              '<meta name="viewport" content="width=device-width, initial-scale=1.0">'
+            $("meta[name=viewport]").attr(
+              "content",
+              "width=device-width, initial-scale=1.0"
             );
             const wrap = this.wrap,
               img = this.currItem.img,
@@ -40,7 +41,7 @@ export default function($elem) {
             });
           },
           beforeClose() {
-            $("meta[name=viewport]").replaceWith(original_meta);
+            $("meta[name=viewport]").attr("content", originalMeta);
             this.wrap.off("click.pinhandler");
             this.wrap.removeClass("mfp-force-scrollbars");
           }

--- a/app/assets/javascripts/discourse/lib/lightbox.js.es6
+++ b/app/assets/javascripts/discourse/lib/lightbox.js.es6
@@ -6,6 +6,7 @@ export default function($elem) {
   if (!$elem) {
     return;
   }
+  const original_meta = $('meta[name=viewport]');
   loadScript("/javascripts/jquery.magnific-popup.min.js").then(function() {
     const spoilers = $elem.find(".spoiler a.lightbox, .spoiled a.lightbox");
     $elem
@@ -23,6 +24,7 @@ export default function($elem) {
 
         callbacks: {
           open() {
+            original_meta.replaceWith( '<meta name="viewport" content="width=device-width, initial-scale=1.0">' );
             const wrap = this.wrap,
               img = this.currItem.img,
               maxHeight = img.css("max-height");
@@ -36,6 +38,7 @@ export default function($elem) {
             });
           },
           beforeClose() {
+            $('meta[name=viewport]').replaceWith( original_meta );
             this.wrap.off("click.pinhandler");
             this.wrap.removeClass("mfp-force-scrollbars");
           }

--- a/app/assets/javascripts/discourse/lib/lightbox.js.es6
+++ b/app/assets/javascripts/discourse/lib/lightbox.js.es6
@@ -6,7 +6,7 @@ export default function($elem) {
   if (!$elem) {
     return;
   }
-  const original_meta = $('meta[name=viewport]');
+  const original_meta = $("meta[name=viewport]");
   loadScript("/javascripts/jquery.magnific-popup.min.js").then(function() {
     const spoilers = $elem.find(".spoiler a.lightbox, .spoiled a.lightbox");
     $elem
@@ -24,7 +24,9 @@ export default function($elem) {
 
         callbacks: {
           open() {
-            original_meta.replaceWith( '<meta name="viewport" content="width=device-width, initial-scale=1.0">' );
+            original_meta.replaceWith(
+              '<meta name="viewport" content="width=device-width, initial-scale=1.0">'
+            );
             const wrap = this.wrap,
               img = this.currItem.img,
               maxHeight = img.css("max-height");
@@ -38,7 +40,7 @@ export default function($elem) {
             });
           },
           beforeClose() {
-            $('meta[name=viewport]').replaceWith( original_meta );
+            $("meta[name=viewport]").replaceWith(original_meta);
             this.wrap.off("click.pinhandler");
             this.wrap.removeClass("mfp-force-scrollbars");
           }


### PR DESCRIPTION
This replaces the meta viewport tag while looking at a lightbox. This enables pinch to zoom on various devices.

Resolves: https://meta.discourse.org/t/adjusting-image-zoom-level-on-mobile-devices/111440

Wanted to write Qunit tests for it but the box for component tests has no meta tags.