### PR TITLE
FEATURE: Skip sending emails to domains on the `.invalid` TLD

### DIFF
--- a/app/models/skipped_email_log.rb
+++ b/app/models/skipped_email_log.rb
@@ -32,7 +32,8 @@ class SkippedEmailLog < ActiveRecord::Base
       sender_message_to_blank: 17,
       sender_text_part_body_blank: 18,
       sender_body_blank: 19,
-      sender_post_deleted: 20
+      sender_post_deleted: 20,
+      sender_message_to_invalid: 21
       # you need to add the reason in server.en.yml below the "skipped_email_log" key
       # when you add a new enum value
     )

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -3465,6 +3465,7 @@ en:
     sender_text_part_body_blank: "text_part.body is blank"
     sender_body_blank: "body is blank"
     sender_post_deleted: "post has been deleted"
+    sender_message_to_invalid: "recipient has invalid email address"
 
   color_schemes:
     base_theme_name: "Base"

--- a/lib/email/sender.rb
+++ b/lib/email/sender.rb
@@ -35,6 +35,8 @@ module Email
       return skip(SkippedEmailLog.reason_types[:sender_message_blank])    if @message.blank?
       return skip(SkippedEmailLog.reason_types[:sender_message_to_blank]) if @message.to.blank?
 
+      return skip(SkippedEmailLog.reason_types[:sender_message_to_invalid]) if to_address.end_with?(".invalid")
+
       if @message.text_part
         if @message.text_part.body.to_s.blank?
           return skip(SkippedEmailLog.reason_types[:sender_text_part_body_blank])

--- a/spec/components/email/sender_spec.rb
+++ b/spec/components/email/sender_spec.rb
@@ -58,6 +58,13 @@ describe Email::Sender do
     Email::Sender.new(message, :hello).send
   end
 
+  it "doesn't deliver when the to address uses the .invalid tld" do
+    message = Mail::Message.new(body: 'hello', to: 'myemail@example.invalid')
+    message.expects(:deliver_now).never
+    expect { Email::Sender.new(message, :hello).send }.
+      to change { SkippedEmailLog.where(reason_type: SkippedEmailLog.reason_types[:sender_message_to_invalid]).count }.by(1)
+  end
+
   it "doesn't deliver when the body is nil" do
     message = Mail::Message.new(to: 'eviltrout@test.domain')
     message.expects(:deliver_now).never


### PR DESCRIPTION
This is a reserved TLD which we use when importing users without an email address. https://tools.ietf.org/html/rfc2606