### PR TITLE
FEATURE: Fetch email from auth provider if current user email is invalid

### DIFF
--- a/spec/components/auth/managed_authenticator_spec.rb
+++ b/spec/components/auth/managed_authenticator_spec.rb
@@ -180,6 +180,35 @@ describe Auth::ManagedAuthenticator do
       end
     end
 
+    describe "email update" do
+      let(:user) { Fabricate(:user) }
+      let!(:associated) { UserAssociatedAccount.create!(user: user, provider_name: 'myauth', provider_uid: "1234") }
+
+      it "updates the user's email if currently invalid" do
+        user.update!(email: "someemail@discourse.org")
+        # Existing email is valid, do not change
+        expect { result = authenticator.after_authenticate(hash) }
+          .not_to change { user.reload.email }
+
+        user.update!(email: "someemail@discourse.invalid")
+        # Existing email is invalid, expect change
+        expect { result = authenticator.after_authenticate(hash) }
+          .to change { user.reload.email }
+
+        expect(user.email).to eq("awesome@example.com")
+      end
+
+      it "doesn't raise error if email is taken" do
+        other_user = Fabricate(:user, email: "awesome@example.com")
+        user.update!(email: "someemail@discourse.invalid")
+
+        expect { result = authenticator.after_authenticate(hash) }
+          .not_to change { user.reload.email }
+
+        expect(user.email).to eq("someemail@discourse.invalid")
+      end
+    end
+
     describe "avatar on create" do
       let(:user) { Fabricate(:user) }
       let!(:association) { UserAssociatedAccount.create!(provider_name: 'myauth', provider_uid: "1234") }


### PR DESCRIPTION
If the existing email address for a user ends in `.invalid`, we should take the email address from an authentication payload, and replace the invalid address.

This commit also adds some extensibility so that plugin authenticators can define `always_update_user_email?`