### PR TITLE
DEV: skip discourse-chat-integration tests

### DIFF
--- a/lib/tasks/plugin.rake
+++ b/lib/tasks/plugin.rake
@@ -7,7 +7,8 @@ task 'plugin:install_all_official' do
     'discourse-nginx-performance-report',
     'lazyYT',
     'poll',
-    'discourse-calendar'
+    'discourse-calendar',
+    'discourse-chat-integration'
   ])
 
   map = {


### PR DESCRIPTION
Suspected of causing timeout issues in our test suite with Ember 3.7