### PR TITLE
FIX: Outsourced erb part from emoji.js.es6

### DIFF
--- a/app/assets/javascripts/pretty-text-bundle.js
+++ b/app/assets/javascripts/pretty-text-bundle.js
@@ -2,6 +2,7 @@
 //= require ./pretty-text/guid
 //= require ./pretty-text/censored-words
 //= require ./pretty-text/emoji/data
+//= require ./pretty-text/emoji/version
 //= require ./pretty-text/emoji
 //= require ./pretty-text/engines/discourse-markdown-it
 //= require xss.min

--- a/app/assets/javascripts/pretty-text/emoji.js.es6
+++ b/app/assets/javascripts/pretty-text/emoji.js.es6
@@ -1,7 +1,11 @@
-import { emojis, aliases, searchAliases, translations, tonableEmojis } from 'pretty-text/emoji/data';
-
-// bump up this number to expire all emojis
-export const IMAGE_VERSION = "<%= Emoji::EMOJI_VERSION %>";
+import {
+  emojis,
+  aliases,
+  searchAliases,
+  translations,
+  tonableEmojis
+} from "pretty-text/emoji/data";
+import { IMAGE_VERSION } from "pretty-text/emoji/version";
 
 const extendedEmoji = {};
 
@@ -17,16 +21,18 @@ export function extendedEmojiList() {
 const emojiHash = {};
 
 // add all default emojis
-emojis.forEach(code => emojiHash[code] = true);
+emojis.forEach(code => (emojiHash[code] = true));
 
 // and their aliases
 const aliasHash = {};
 Object.keys(aliases).forEach(name => {
-  aliases[name].forEach(alias => aliasHash[alias] = name);
+  aliases[name].forEach(alias => (aliasHash[alias] = name));
 });
 
 export function performEmojiUnescape(string, opts) {
-  if (!string) { return; }
+  if (!string) {
+    return;
+  }
 
   // this can be further improved by supporting matches of emoticons that don't begin with a colon
   if (string.indexOf(":") >= 0) {
@@ -35,10 +41,15 @@ export function performEmojiUnescape(string, opts) {
       const emojiVal = isEmoticon ? translations[m] : m.slice(1, m.length - 1);
       const hasEndingColon = m.lastIndexOf(":") === m.length - 1;
       const url = buildEmojiUrl(emojiVal, opts);
-      const classes = isCustomEmoji(emojiVal, opts) ? "emoji emoji-custom" : "emoji";
+      const classes = isCustomEmoji(emojiVal, opts)
+        ? "emoji emoji-custom"
+        : "emoji";
 
-      return url && (isEmoticon || hasEndingColon) ?
-             `<img src='${url}' ${opts.skipTitle ? '' : `title='${emojiVal}'`} alt='${emojiVal}' class='${classes}'>` : m;
+      return url && (isEmoticon || hasEndingColon)
+        ? `<img src='${url}' ${
+            opts.skipTitle ? "" : `title='${emojiVal}'`
+          } alt='${emojiVal}' class='${classes}'>`
+        : m;
     });
   }
 
@@ -48,7 +59,8 @@ export function performEmojiUnescape(string, opts) {
 export function isCustomEmoji(code, opts) {
   code = code.toLowerCase();
   if (extendedEmoji.hasOwnProperty(code)) return true;
-  if (opts && opts.customEmoji && opts.customEmoji.hasOwnProperty(code)) return true;
+  if (opts && opts.customEmoji && opts.customEmoji.hasOwnProperty(code))
+    return true;
   return false;
 }
 
@@ -64,8 +76,15 @@ export function buildEmojiUrl(code, opts) {
   }
 
   const noToneMatch = code.match(/([^:]+):?/);
-  if (noToneMatch && !url && (emojiHash.hasOwnProperty(noToneMatch[1]) || aliasHash.hasOwnProperty(noToneMatch[1]))) {
-    url = opts.getURL(`/images/emoji/${opts.emojiSet}/${code.replace(/:t/, '/')}.png`);
+  if (
+    noToneMatch &&
+    !url &&
+    (emojiHash.hasOwnProperty(noToneMatch[1]) ||
+      aliasHash.hasOwnProperty(noToneMatch[1]))
+  ) {
+    url = opts.getURL(
+      `/images/emoji/${opts.emojiSet}/${code.replace(/:t/, "/")}.png`
+    );
   }
 
   if (url) {
@@ -77,15 +96,23 @@ export function buildEmojiUrl(code, opts) {
 
 export function emojiExists(code) {
   code = code.toLowerCase();
-  return !!(extendedEmoji.hasOwnProperty(code) || emojiHash.hasOwnProperty(code) || aliasHash.hasOwnProperty(code));
-};
+  return !!(
+    extendedEmoji.hasOwnProperty(code) ||
+    emojiHash.hasOwnProperty(code) ||
+    aliasHash.hasOwnProperty(code)
+  );
+}
 
 let toSearch;
 export function emojiSearch(term, options) {
   const maxResults = (options && options["maxResults"]) || -1;
-  if (maxResults === 0) { return []; }
+  if (maxResults === 0) {
+    return [];
+  }
 
-  toSearch = toSearch || _.union(_.keys(emojiHash), _.keys(extendedEmoji), _.keys(aliasHash)).sort();
+  toSearch =
+    toSearch ||
+    _.union(_.keys(emojiHash), _.keys(extendedEmoji), _.keys(aliasHash)).sort();
 
   const results = [];
 
@@ -97,7 +124,7 @@ export function emojiSearch(term, options) {
   }
 
   // if term matches from beginning
-  for (let i=0; i<toSearch.length; i++) {
+  for (let i = 0; i < toSearch.length; i++) {
     const item = toSearch[i];
     if (item.indexOf(term) === 0) addResult(item);
   }
@@ -106,7 +133,7 @@ export function emojiSearch(term, options) {
     results.push.apply(results, searchAliases[term]);
   }
 
-  for (let i=0; i<toSearch.length; i++) {
+  for (let i = 0; i < toSearch.length; i++) {
     const item = toSearch[i];
     if (item.indexOf(term) > 0) addResult(item);
   }
@@ -116,7 +143,7 @@ export function emojiSearch(term, options) {
   } else {
     return results.slice(0, maxResults);
   }
-};
+}
 
 export function isSkinTonableEmoji(term) {
   const match = _.compact(term.split(":"))[0];

--- a/app/assets/javascripts/pretty-text/emoji/version.js.es6.erb
+++ b/app/assets/javascripts/pretty-text/emoji/version.js.es6.erb
@@ -1,0 +1,2 @@
+// bump up this number to expire all emojis
+export const IMAGE_VERSION = "<%= Emoji::EMOJI_VERSION %>";

--- a/test/javascripts/acceptance/emoji-picker-test.js.es6
+++ b/test/javascripts/acceptance/emoji-picker-test.js.es6
@@ -1,5 +1,5 @@
 import { acceptance } from "helpers/qunit-helpers";
-import { IMAGE_VERSION as v } from "pretty-text/emoji";
+import { IMAGE_VERSION as v } from "pretty-text/emoji/version";
 import { resetCache } from "discourse/components/emoji-picker";
 
 acceptance("EmojiPicker", {

--- a/test/javascripts/acceptance/emoji-test.js.es6
+++ b/test/javascripts/acceptance/emoji-test.js.es6
@@ -1,4 +1,4 @@
-import { IMAGE_VERSION as v } from "pretty-text/emoji";
+import { IMAGE_VERSION as v } from "pretty-text/emoji/version";
 import { acceptance } from "helpers/qunit-helpers";
 
 acceptance("Emoji", { loggedIn: true });

--- a/test/javascripts/acceptance/topic-test.js.es6
+++ b/test/javascripts/acceptance/topic-test.js.es6
@@ -1,5 +1,5 @@
 import { acceptance } from "helpers/qunit-helpers";
-import { IMAGE_VERSION as v } from "pretty-text/emoji";
+import { IMAGE_VERSION as v } from "pretty-text/emoji/version";
 
 acceptance("Topic", {
   loggedIn: true,

--- a/test/javascripts/lib/emoji-test.js.es6
+++ b/test/javascripts/lib/emoji-test.js.es6
@@ -1,4 +1,5 @@
-import { emojiSearch, IMAGE_VERSION as v } from "pretty-text/emoji";
+import { emojiSearch } from "pretty-text/emoji";
+import { IMAGE_VERSION as v } from "pretty-text/emoji/version";
 import { emojiUnescape } from "discourse/lib/text";
 
 QUnit.module("lib:emoji");

--- a/test/javascripts/lib/pretty-text-test.js.es6
+++ b/test/javascripts/lib/pretty-text-test.js.es6
@@ -1,7 +1,7 @@
 import Quote from "discourse/lib/quote";
 import Post from "discourse/models/post";
 import { default as PrettyText, buildOptions } from "pretty-text/pretty-text";
-import { IMAGE_VERSION as v } from "pretty-text/emoji";
+import { IMAGE_VERSION as v } from "pretty-text/emoji/version";
 import { INLINE_ONEBOX_LOADING_CSS_CLASS } from "pretty-text/inline-oneboxer";
 
 QUnit.module("lib:pretty-text");

--- a/test/javascripts/models/topic-test.js.es6
+++ b/test/javascripts/models/topic-test.js.es6
@@ -1,4 +1,4 @@
-import { IMAGE_VERSION as v } from "pretty-text/emoji";
+import { IMAGE_VERSION as v } from "pretty-text/emoji/version";
 
 QUnit.module("model:topic");
 


### PR DESCRIPTION
This is the first part of the "FIX: Better emoji escaping for topic title" in which the erb part is split from emoji.js.es6

More Information: https://github.com/discourse/discourse/commit/d32557ea326735c33a420dee7cc3de856c683dc7