### PR TITLE
FIX: prevents duplicate error on instagam migration

### DIFF
--- a/db/migrate/20190227150413_migrate_instagram_user_info.rb
+++ b/db/migrate/20190227150413_migrate_instagram_user_info.rb
@@ -9,15 +9,19 @@ class MigrateInstagramUserInfo < ActiveRecord::Migration[5.2]
       last_used,
       created_at,
       updated_at
-    ) SELECT
-      'instagram',
-      instagram_user_id,
-      user_id,
-      json_build_object('nickname', screen_name),
-      updated_at,
-      created_at,
-      updated_at
-    FROM instagram_user_infos
+    )
+      SELECT
+        'instagram',
+        instagram_user_id,
+        user_id,
+        json_build_object('nickname', screen_name),
+        updated_at,
+        created_at,
+        updated_at
+      FROM instagram_user_infos
+      ORDER BY updated_at DESC
+    ON CONFLICT (provider_name, provider_uid)
+    DO NOTHING
     SQL
   end
 


### PR DESCRIPTION
Previous instagram records didn’t have unique index, as a result it's seems like in some cases we have duplicate ids, which is causing issues with the associated_accounts which does have unique index.

It's sorted by `updated_at DESC` on the thought that the most recent one is more likely to be the one we want to keep.