### PR TITLE
Fix SMTP connection test

### DIFF
--- a/lib/tasks/emails.rake
+++ b/lib/tasks/emails.rake
@@ -84,8 +84,7 @@ task 'emails:test', [:email] => [:environment] do |_, args|
     #  s.auth_login(smtp[:user_name], smtp[:password])
     #end
 
-    Net::SMTP.start(smtp[:address], smtp[:port])
-      .auth_login(smtp[:user_name], smtp[:password])
+    Net::SMTP.start(smtp[:address], smtp[:port], 'localhost', smtp[:user_name], smtp[:password])
   rescue Exception => e
 
     if e.to_s.match(/execution expired/)


### PR DESCRIPTION
This test did not support 'no auth' use case and other auth methods except 'login'. I fixed it by simply making the call to start() in the right way. 
As shown in the source code of Net::SMTP (https://github.com/ruby/ruby/blob/ruby_2_5/lib/net/smtp.rb#L452), the start() function does accept the 'user' and 'secret' arguments. Also, in do_start() function (https://github.com/ruby/ruby/blob/ruby_2_5/lib/net/smtp.rb#L542), it automatically checks the auth method and args, skips the authentication if 'user' is not provided, and selects the right auth method from 'plain', 'login' or 'cram_md5'. This is exactly all of what we should do in a connection test and the odd 'auth_login' call in the previous code makes problems. 
BTW, I am using 'localhost' as the third argument, which is the same as the default value in start(). This parameter is the domain address sent along with the 'ehlo' command in SMTP protocol. I have seen some documents, e.g. https://github.com/tpn/msmtp/blob/master/doc/msmtp.1#L455, saying that 'localhost' is fine. It works for me.