### PR TITLE
FEATURE: Display notification count in title for logged in users

### DIFF
--- a/app/assets/javascripts/discourse/components/discovery-topics-list.js.es6
+++ b/app/assets/javascripts/discourse/components/discovery-topics-list.js.es6
@@ -24,7 +24,7 @@ const DiscoveryTopicsListComponent = Ember.Component.extend(
 
     @observes("incomingCount")
     _updateTitle() {
-      Discourse.notifyTitle(this.get("incomingCount"));
+      Discourse.updateContextCount(this.get("incomingCount"));
     },
 
     saveScrollPosition() {
@@ -38,7 +38,7 @@ const DiscoveryTopicsListComponent = Ember.Component.extend(
 
     actions: {
       loadMore() {
-        Discourse.notifyTitle(0);
+        Discourse.updateContextCount(0);
         this.get("model")
           .loadMore()
           .then(hasMoreResults => {

--- a/app/assets/javascripts/discourse/controllers/topic.js.es6
+++ b/app/assets/javascripts/discourse/controllers/topic.js.es6
@@ -1226,7 +1226,7 @@ export default Ember.Controller.extend(bufferedProperty("model"), {
           case "created": {
             postStream.triggerNewPostInStream(data.id).then(() => refresh());
             if (this.get("currentUser.id") !== data.user_id) {
-              Discourse.notifyBackgroundCountIncrement();
+              Discourse.incrementBackgroundContextCount();
             }
             break;
           }

--- a/app/assets/javascripts/discourse/initializers/title-notifications.js.es6
+++ b/app/assets/javascripts/discourse/initializers/title-notifications.js.es6
@@ -1,0 +1,18 @@
+export default {
+  name: "title-notifications",
+  after: "message-bus",
+
+  initialize(container) {
+    const appEvents = container.lookup("app-events:main");
+    const user = container.lookup("current-user:main");
+
+    if (!user) return; // must be logged in
+
+    appEvents.on("notifications:changed", () => {
+      let notifications =
+        user.get("unread_notifications") + user.get("unread_private_messages");
+
+      Discourse.updateNotificationCount(notifications);
+    });
+  }
+};

--- a/app/assets/javascripts/discourse/lib/clean-dom.js.es6
+++ b/app/assets/javascripts/discourse/lib/clean-dom.js.es6
@@ -22,7 +22,7 @@ function _clean() {
     .not(".no-blur")
     .blur();
 
-  Discourse.set("notifyCount", 0);
+  Discourse.set("contextCount", 0);
   Discourse.__container__.lookup("route:application").send("closeModal");
   const hideDropDownFunction = $("html").data("hide-dropdown");
   if (hideDropDownFunction) {

--- a/test/javascripts/lib/discourse-test.js.es6
+++ b/test/javascripts/lib/discourse-test.js.es6
@@ -1,3 +1,5 @@
+import { logIn, replaceCurrentUser } from "helpers/qunit-helpers";
+
 QUnit.module("lib:discourse");
 
 QUnit.test("getURL on subfolder install", assert => {
@@ -23,4 +25,65 @@ QUnit.test("getURLWithCDN on subfolder install with S3", assert => {
 
   Discourse.S3CDN = null;
   Discourse.S3BaseUrl = null;
+});
+
+QUnit.test("title counts are updated correctly", assert => {
+  Discourse.set("hasFocus", true);
+  Discourse.set("contextCount", 0);
+  Discourse.set("notificationCount", 0);
+
+  Discourse.set("_docTitle", "Test Title");
+
+  assert.equal(document.title, "Test Title", "title is correct");
+
+  Discourse.updateNotificationCount(5);
+  assert.equal(document.title, "Test Title", "title doesn't change with focus");
+
+  Discourse.incrementBackgroundContextCount();
+  assert.equal(document.title, "Test Title", "title doesn't change with focus");
+
+  Discourse.set("hasFocus", false);
+
+  Discourse.updateNotificationCount(5);
+  assert.equal(
+    document.title,
+    "Test Title",
+    "notification count ignored for anon"
+  );
+
+  Discourse.incrementBackgroundContextCount();
+  assert.equal(
+    document.title,
+    "(1) Test Title",
+    "title changes when incremented for anon"
+  );
+
+  logIn();
+  replaceCurrentUser({ dynamic_favicon: false });
+
+  Discourse.set("hasFocus", true);
+  Discourse.set("hasFocus", false);
+
+  Discourse.incrementBackgroundContextCount();
+  assert.equal(
+    document.title,
+    "Test Title",
+    "title doesn't change when incremented for logged in"
+  );
+
+  Discourse.updateNotificationCount(3);
+  assert.equal(
+    document.title,
+    "(3) Test Title",
+    "title includes notification count for logged in user"
+  );
+
+  Discourse.set("hasFocus", false);
+  Discourse.set("hasFocus", true);
+
+  assert.equal(
+    document.title,
+    "Test Title",
+    "counter dissappears after focus, and doesn't reappear until another notification arrives"
+  );
 });


### PR DESCRIPTION
This replaces the 'contextual' counters which we still use for anon user

### Existing behavior:

On topic list:
- Regardless of focus, browser title shows the count of topics waiting to be loaded (matches the "See N new or updated topic" banner)

On topic:
- IF tab is in the background, then increment the counter for each new post that arrives
- When focus is restored, reset the counter


### New behavior

For anon, same as above

For logged in users:
- If tab is in the background, **and** a new notification arrives while the tab is in the background, display the total notification count in the title
- Hide the count when the tab is in the foreground

cc @coding-horror 