### PR TITLE
FIX: Show 'emails disabled' to staff users when disabled for non-staff

### DIFF
--- a/app/assets/javascripts/discourse/components/global-notice.js.es6
+++ b/app/assets/javascripts/discourse/components/global-notice.js.es6
@@ -25,8 +25,7 @@ export default Ember.Component.extend(
 
       if (
         this.siteSettings.disable_emails === "yes" ||
-        (this.siteSettings.disable_emails === "non-staff" &&
-          !(this.currentUser && this.currentUser.get("staff")))
+        this.siteSettings.disable_emails === "non-staff"
       ) {
         notices.push([I18n.t("emails_are_disabled"), "alert-emails-disabled"]);
       }

--- a/test/javascripts/acceptance/email-notice-test.js.es6
+++ b/test/javascripts/acceptance/email-notice-test.js.es6
@@ -1,0 +1,28 @@
+import { acceptance } from "helpers/qunit-helpers";
+
+acceptance("Email Disabled Banner", {
+  loggedIn: true
+});
+
+QUnit.test("shows banner when required", async assert => {
+  Discourse.SiteSettings.disable_email = "no";
+  await visit("/");
+  assert.notOk(
+    exists(".alert-emails-disabled"),
+    "alert is not displayed when email enabled"
+  );
+
+  Discourse.SiteSettings.disable_email = "yes";
+  await visit("/");
+  assert.notOk(
+    exists(".alert-emails-disabled"),
+    "alert is displayed when email disabled"
+  );
+
+  Discourse.SiteSettings.disable_email = "non-staff";
+  await visit("/");
+  assert.notOk(
+    exists(".alert-emails-disabled"),
+    "alert is displayed when email disabled for non-staff"
+  );
+});


### PR DESCRIPTION
At the moment, the "All outgoing email has been globally disabled by an administrator" banner doesn't show to staff users if SiteSetting.disable_emails === "non-staff". That means site admins might not realise emails are disabled until a user reports it.