### PR TITLE
FIX: Fixed reorder categories by number not working correctly

### DIFF
--- a/app/assets/javascripts/discourse/controllers/reorder-categories.js.es6
+++ b/app/assets/javascripts/discourse/controllers/reorder-categories.js.es6
@@ -85,8 +85,7 @@ export default Ember.Controller.extend(ModalFunctionality, Ember.Evented, {
   actions: {
     change(cat, e) {
       let position = parseInt($(e.target).val());
-      cat.set("position", position);
-      this.fixIndices();
+      this.moveDir(cat, position - this.get("categoriesOrdered").indexOf(cat));
     },
 
     moveUp(cat) {

--- a/app/assets/javascripts/discourse/controllers/reorder-categories.js.es6
+++ b/app/assets/javascripts/discourse/controllers/reorder-categories.js.es6
@@ -85,7 +85,8 @@ export default Ember.Controller.extend(ModalFunctionality, Ember.Evented, {
   actions: {
     change(cat, e) {
       let position = parseInt($(e.target).val());
-      this.moveDir(cat, position - this.get("categoriesOrdered").indexOf(cat));
+      let amount = Math.min(Math.max(position, 0), this.get("categoriesOrdered").length - 1);
+      this.moveDir(cat, amount - this.get("categoriesOrdered").indexOf(cat));
     },
 
     moveUp(cat) {

--- a/app/assets/javascripts/discourse/controllers/reorder-categories.js.es6
+++ b/app/assets/javascripts/discourse/controllers/reorder-categories.js.es6
@@ -85,7 +85,10 @@ export default Ember.Controller.extend(ModalFunctionality, Ember.Evented, {
   actions: {
     change(cat, e) {
       let position = parseInt($(e.target).val());
-      let amount = Math.min(Math.max(position, 0), this.get("categoriesOrdered").length - 1);
+      let amount = Math.min(
+        Math.max(position, 0),
+        this.get("categoriesOrdered").length - 1
+      );
       this.moveDir(cat, amount - this.get("categoriesOrdered").indexOf(cat));
     },
 

--- a/test/javascripts/controllers/reorder-categories-test.js.es6
+++ b/test/javascripts/controllers/reorder-categories-test.js.es6
@@ -70,3 +70,90 @@ QUnit.test(
     );
   }
 );
+
+QUnit.test(
+  "changing the position number of a category should place it at given position",
+  function(assert) {
+    const store = createStore();
+
+    const elem1 = store.createRecord("category", {
+      id: 1,
+      position: 0,
+      slug: "foo"
+    });
+
+    const elem2 = store.createRecord("category", {
+      id: 2,
+      position: 1,
+      slug: "bar"
+    });
+
+    const elem3 = store.createRecord("category", {
+      id: 3,
+      position: 2,
+      slug: "test"
+    });
+
+    const categories = [elem1, elem2, elem3];
+    const site = Ember.Object.create({ categories: categories });
+    const reorderCategoriesController = this.subject({ site });
+
+    reorderCategoriesController.actions.change.call(
+      reorderCategoriesController,
+      elem1,
+      { target: "<input value='2'>" }
+    );
+
+    assert.deepEqual(
+      reorderCategoriesController.get("categoriesOrdered").mapBy("slug"),
+      ["test", "bar", "foo"]
+    );
+  }
+);
+
+QUnit.test(
+  "changing the position number of a category should place it at given position and respect children",
+  function(assert) {
+    const store = createStore();
+
+    const elem1 = store.createRecord("category", {
+      id: 1,
+      position: 0,
+      slug: "foo"
+    });
+
+    const child1 = store.createRecord("category", {
+      id: 4,
+      position: 1,
+      slug: "foochild",
+      parent_category_id: 1
+    });
+
+    const elem2 = store.createRecord("category", {
+      id: 2,
+      position: 2,
+      slug: "bar"
+    });
+
+    const elem3 = store.createRecord("category", {
+      id: 3,
+      position: 3,
+      slug: "test"
+    });
+
+    const categories = [elem1, child1, elem2, elem3];
+    const site = Ember.Object.create({ categories: categories });
+    const reorderCategoriesController = this.subject({ site });
+
+    reorderCategoriesController.actions.change.call(
+      reorderCategoriesController,
+      elem1,
+      { target: "<input value='3'>" }
+    );
+
+    assert.deepEqual(
+      reorderCategoriesController.get("categoriesOrdered").mapBy("slug"),
+      ["test", "bar", "foo", "foochild"]
+    );
+  }
+);


### PR DESCRIPTION
Current Behavior:
![Peek 2019-03-16 22-12](https://user-images.githubusercontent.com/13546486/54482760-de8ae300-4848-11e9-8ad0-80c7699b4aa5.gif)

How it should be:
![Peek 2019-03-16 22-13](https://user-images.githubusercontent.com/13546486/54482770-ef3b5900-4848-11e9-9efd-1a5b01cf2d14.gif)

Resolves: https://meta.discourse.org/t/reorder-categories-behaving-strangely/104190