### PR TITLE
FIX: Fixed changing composer mode escaping title

### DIFF
--- a/app/assets/javascripts/discourse/controllers/composer.js.es6
+++ b/app/assets/javascripts/discourse/controllers/composer.js.es6
@@ -910,7 +910,7 @@ export default Ember.Controller.extend({
       opts.topicTitle &&
       opts.topicTitle.length <= this.siteSettings.max_topic_title_length
     ) {
-      this.set("model.title", escapeExpression(opts.topicTitle));
+      this.set("model.title", opts.topicTitle);
     }
 
     if (opts.topicCategoryId) {

--- a/test/javascripts/acceptance/composer-actions-test.js.es6
+++ b/test/javascripts/acceptance/composer-actions-test.js.es6
@@ -139,7 +139,10 @@ QUnit.test("shared draft", async assert => {
   await visit("/");
   await click("#create-topic");
 
-  await fillIn("#reply-title", "This is the new text for the title");
+  await fillIn(
+    "#reply-title",
+    "This is the new text for the title using 'quotes'"
+  );
   await fillIn(".d-editor-input", "This is the new text for the post");
   await tags.expand();
   await tags.selectRowByValue("monkey");
@@ -148,6 +151,11 @@ QUnit.test("shared draft", async assert => {
   await composerActions.selectRowByValue("shared_draft");
 
   assert.equal(tags.header().value(), "monkey", "tags are not reset");
+
+  assert.equal(
+    find("#reply-title").val(),
+    "This is the new text for the title using 'quotes'"
+  );
 
   assert.equal(
     find("#reply-control .btn-primary.create .d-button-label").text(),


### PR DESCRIPTION
This fixes changing composer mode escaping the title.

Resolves: https://meta.discourse.org/t/toggling-shared-draft-causes-encoding-issue-when-title-has-quotes/111798

I removed the `escapeExpression` function from the `topicTitle` which was originally added by @techAPJ in commit c28c5083e0e7db96ec27f27c0107292e7469b214 to sanitize tags when the topic is created from url.

But similar to what tgxworld commented under the commit, I was also not able to inject html or js into the title using the url method. Tried a lot of variations and from my point of view its safe to remove the escape function.