### PR TITLE
FIX: Fixed edit category description redirecting without saving

### DIFF
--- a/app/assets/javascripts/discourse/components/edit-category-general.js.es6
+++ b/app/assets/javascripts/discourse/components/edit-category-general.js.es6
@@ -94,7 +94,7 @@ export default buildCategoryPanel("general", {
 
   actions: {
     showCategoryTopic() {
-      DiscourseURL.routeTo(this.get("category.topic_url"));
+      window.open(this.get("category.topic_url"), "_blank").focus();
       return false;
     }
   }

--- a/app/assets/javascripts/discourse/templates/components/edit-category-general.hbs
+++ b/app/assets/javascripts/discourse/templates/components/edit-category-general.hbs
@@ -38,7 +38,7 @@
       {{/if}}
       {{#if category.topic_url}}
         <br>
-        {{d-button class="btn-default" action=(action "showCategoryTopic") icon="pencil-alt" label="category.change_in_category_topic"}}
+        {{d-button class="btn-default edit-category-description" action=(action "showCategoryTopic") icon="pencil-alt" label="category.change_in_category_topic"}}
       {{/if}}
     </section>
   {{/if}}

--- a/test/javascripts/acceptance/category-edit-test.js.es6
+++ b/test/javascripts/acceptance/category-edit-test.js.es6
@@ -46,7 +46,7 @@ QUnit.test("Change the topic template", async assert => {
 });
 
 QUnit.test("Edit the description without loosing progress", async assert => {
-  let win = { focus: function () {} };
+  let win = { focus: function() {} };
   let windowOpen = sandbox.stub(window, "open").returns(win);
   sandbox.stub(win, "focus");
 
@@ -55,10 +55,7 @@ QUnit.test("Edit the description without loosing progress", async assert => {
   await click(".edit-category");
   await click(".edit-category-description");
   assert.ok(
-    windowOpen.calledWith(
-      "/t/category-definition-for-bug/2",
-      "_blank"
-    ),
+    windowOpen.calledWith("/t/category-definition-for-bug/2", "_blank"),
     "opens the category topic in a new tab"
   );
 });

--- a/test/javascripts/acceptance/category-edit-test.js.es6
+++ b/test/javascripts/acceptance/category-edit-test.js.es6
@@ -45,6 +45,24 @@ QUnit.test("Change the topic template", async assert => {
   );
 });
 
+QUnit.test("Edit the description without loosing progress", async assert => {
+  let win = { focus: function () {} };
+  let windowOpen = sandbox.stub(window, "open").returns(win);
+  sandbox.stub(win, "focus");
+
+  await visit("/c/bug");
+
+  await click(".edit-category");
+  await click(".edit-category-description");
+  assert.ok(
+    windowOpen.calledWith(
+      "/t/category-definition-for-bug/2",
+      "_blank"
+    ),
+    "opens the category topic in a new tab"
+  );
+});
+
 QUnit.test("Error Saving", async assert => {
   await visit("/c/bug");
 


### PR DESCRIPTION
When a user clicks on `Edit Description` in the edit category modal, he got redirected to the post without saving the edit on the category. This fix will open up a new tab when the user clicks on `Edit Description` and the edit category modal will stay open on the first page.

Resolves: https://meta.discourse.org/t/when-editing-a-category-clicking-edit-description-redirects-without-saving/111797