### PR TITLE
UX: order categories based on latest activity for all page styles

### DIFF
--- a/app/models/category_list.rb
+++ b/app/models/category_list.rb
@@ -77,13 +77,8 @@ class CategoryList
 
     if SiteSetting.fixed_category_positions
       @categories = @categories.order(:position, :id)
-    elsif !SiteSetting.fixed_category_positions && SiteSetting.desktop_category_page_style == "categories_and_latest_topics"
-      @categories = @categories.includes(:latest_post).order("posts.created_at DESC NULLS LAST").order('categories.id ASC')
     else
-      @categories = @categories.order('COALESCE(categories.posts_week, 0) DESC')
-        .order('COALESCE(categories.posts_month, 0) DESC')
-        .order('COALESCE(categories.posts_year, 0) DESC')
-        .order('id ASC')
+      @categories = @categories.includes(:latest_post).order("posts.created_at DESC NULLS LAST").order('categories.id ASC')
     end
 
     @categories = @categories.to_a

--- a/spec/models/category_list_spec.rb
+++ b/spec/models/category_list_spec.rb
@@ -147,34 +147,21 @@ describe CategoryList do
     context 'fixed_category_positions is disabled' do
       before do
         SiteSetting.fixed_category_positions = false
-        SiteSetting.desktop_category_page_style = "categories_and_top_topics"
       end
 
       it "returns categories in order of activity" do
-        cat1 = Fabricate(:category, position: 0, posts_week: 1, posts_month: 1, posts_year: 1)
-        cat2 = Fabricate(:category, position: 1, posts_week: 2, posts_month: 1, posts_year: 1)
-        expect(category_ids).to eq([cat2.id, cat1.id])
+        post1 = Fabricate(:post, created_at: 1.hour.ago)
+        post2 = Fabricate(:post, created_at: 1.day.ago)
+        post3 = Fabricate(:post, created_at: 1.week.ago)
+        cat1 = Fabricate(:category, position: 0, latest_post_id: post2.id)
+        cat2 = Fabricate(:category, position: 1, latest_post_id: post3.id)
+        cat3 = Fabricate(:category, position: 1, latest_post_id: post1.id)
+        expect(category_ids).to eq([cat3.id, cat1.id, cat2.id])
       end
 
       it "returns categories in order of id when there's no activity" do
         cat1, cat2 = Fabricate(:category, position: 1), Fabricate(:category, position: 0)
         expect(category_ids).to eq([cat1.id, cat2.id])
-      end
-
-      context "when using categories_and_latest_topics layout" do
-        before do
-          SiteSetting.desktop_category_page_style = "categories_and_latest_topics"
-        end
-
-        it "returns categories in order of latest activity" do
-          post1 = Fabricate(:post, created_at: 1.hour.ago)
-          post2 = Fabricate(:post, created_at: 1.day.ago)
-          post3 = Fabricate(:post, created_at: 1.week.ago)
-          cat1 = Fabricate(:category, position: 0, latest_post_id: post2.id)
-          cat2 = Fabricate(:category, position: 1, latest_post_id: post3.id)
-          cat3 = Fabricate(:category, position: 1, latest_post_id: post1.id)
-          expect(category_ids).to eq([cat3.id, cat1.id, cat2.id])
-        end
       end
     end
   end


### PR DESCRIPTION
follow up for https://review.discourse.org/t/ux-order-categories-based-on-recent-activity-when-using-categories-and-latest-topics-layout-7166/2192