### PR TITLE
Revert "UX: Better emoji escaping for topic title"

### DIFF
--- a/app/assets/javascripts/pretty-text/emoji.js.es6
+++ b/app/assets/javascripts/pretty-text/emoji.js.es6
@@ -3,8 +3,7 @@ import {
   aliases,
   searchAliases,
   translations,
-  tonableEmojis,
-  replacements
+  tonableEmojis
 } from "pretty-text/emoji/data";
 import { IMAGE_VERSION } from "pretty-text/emoji/version";
 
@@ -35,47 +34,24 @@ export function performEmojiUnescape(string, opts) {
     return;
   }
 
-  return string.replace(/[\u1000-\uFFFF]+|\B:[^\s:]+(?::t\d)?:?\B/g, m => {
-    const isEmoticon = !!translations[m];
-    const isUnicodeEmoticon = !!replacements[m];
-    let emojiVal;
-    if (isEmoticon) {
-      emojiVal = translations[m];
-    } else if (isUnicodeEmoticon) {
-      emojiVal = replacements[m];
-    } else {
-      emojiVal = m.slice(1, m.length - 1);
-    }
-    const hasEndingColon = m.lastIndexOf(":") === m.length - 1;
-    const url = buildEmojiUrl(emojiVal, opts);
-    const classes = isCustomEmoji(emojiVal, opts)
-      ? "emoji emoji-custom"
-      : "emoji";
+  // this can be further improved by supporting matches of emoticons that don't begin with a colon
+  if (string.indexOf(":") >= 0) {
+    return string.replace(/\B:[^\s:]+(?::t\d)?:?\B/g, m => {
+      const isEmoticon = !!translations[m];
+      const emojiVal = isEmoticon ? translations[m] : m.slice(1, m.length - 1);
+      const hasEndingColon = m.lastIndexOf(":") === m.length - 1;
+      const url = buildEmojiUrl(emojiVal, opts);
+      const classes = isCustomEmoji(emojiVal, opts)
+        ? "emoji emoji-custom"
+        : "emoji";
 
-    return url && (isEmoticon || hasEndingColon || isUnicodeEmoticon)
-      ? `<img src='${url}' ${
-          opts.skipTitle ? "" : `title='${emojiVal}'`
-        } alt='${emojiVal}' class='${classes}'>`
-      : m;
-  });
-
-  return string;
-}
-
-export function performEmojiEscape(string) {
-  if (!string) {
-    return;
+      return url && (isEmoticon || hasEndingColon)
+        ? `<img src='${url}' ${
+            opts.skipTitle ? "" : `title='${emojiVal}'`
+          } alt='${emojiVal}' class='${classes}'>`
+        : m;
+    });
   }
-
-  return string.replace(/[\u1000-\uFFFF]+|\B:[^\s:]+(?::t\d)?:?\B/g, m => {
-    if (!!translations[m]) {
-      return ":" + translations[m] + ":";
-    } else if (!!replacements[m]) {
-      return ":" + replacements[m] + ":";
-    } else {
-      return m;
-    }
-  });
 
   return string;
 }

--- a/app/assets/javascripts/pretty-text/emoji/data.js.es6.erb
+++ b/app/assets/javascripts/pretty-text/emoji/data.js.es6.erb
@@ -3,4 +3,3 @@ export const tonableEmojis = <%= Emoji.tonable_emojis.flatten.inspect %>;
 export const aliases = <%= Emoji.aliases.inspect.gsub("=>", ":") %>;
 export const searchAliases = <%= Emoji.search_aliases.inspect.gsub("=>", ":") %>;
 export const translations = <%= Emoji.translations.inspect.gsub("=>", ":") %>;
-export const replacements = <%= Emoji.unicode_replacements_json %>;

--- a/app/models/emoji.rb
+++ b/app/models/emoji.rb
@@ -157,7 +157,13 @@ class Emoji
   end
 
   def self.unicode_unescape(string)
-    PrettyText.escape_emoji(string)
+    string.each_char.map do |c|
+      if str = unicode_replacements[c]
+        ":#{str}:"
+      else
+        c
+      end
+    end.join
   end
 
   def self.gsub_emoji_to_unicode(str)

--- a/lib/pretty_text.rb
+++ b/lib/pretty_text.rb
@@ -227,7 +227,7 @@ module PrettyText
   end
 
   def self.unescape_emoji(title)
-    return title unless SiteSetting.enable_emoji? && title
+    return title unless SiteSetting.enable_emoji?
 
     set = SiteSetting.emoji_set.inspect
     custom = Emoji.custom.map { |e| [e.name, e.url] }.to_h.to_json
@@ -235,16 +235,6 @@ module PrettyText
       v8.eval(<<~JS)
         __paths = #{paths_json};
         __performEmojiUnescape(#{title.inspect}, { getURL: __getURL, emojiSet: #{set}, customEmoji: #{custom} });
-      JS
-    end
-  end
-
-  def self.escape_emoji(title)
-    return unless title
-
-    protect do
-      v8.eval(<<~JS)
-        __performEmojiEscape(#{title.inspect});
       JS
     end
   end

--- a/lib/pretty_text/shims.js
+++ b/lib/pretty_text/shims.js
@@ -1,7 +1,6 @@
 __PrettyText = require("pretty-text/pretty-text").default;
 __buildOptions = require("pretty-text/pretty-text").buildOptions;
 __performEmojiUnescape = require("pretty-text/emoji").performEmojiUnescape;
-__performEmojiEscape = require("pretty-text/emoji").performEmojiEscape;
 
 __utils = require("discourse/lib/utilities");
 

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -279,7 +279,6 @@ describe Topic do
     let(:topic_image) { build_topic_with_title("Topic with <img src='something'> image in its title") }
     let(:topic_script) { build_topic_with_title("Topic with <script>alert('title')</script> script in its title") }
     let(:topic_emoji) { build_topic_with_title("I 💖 candy alot") }
-    let(:topic_modifier_emoji) { build_topic_with_title("I 👨‍🌾 candy alot") }
 
     it "escapes script contents" do
       expect(topic_script.fancy_title).to eq("Topic with &lt;script&gt;alert(&lsquo;title&rsquo;)&lt;/script&gt; script in its title")
@@ -287,10 +286,6 @@ describe Topic do
 
     it "expands emojis" do
       expect(topic_emoji.fancy_title).to eq("I :sparkling_heart: candy alot")
-    end
-
-    it "keeps combined emojis" do
-      expect(topic_modifier_emoji.fancy_title).to eq("I :man_farmer: candy alot")
     end
 
     it "escapes bold contents" do

--- a/test/javascripts/acceptance/topic-test.js.es6
+++ b/test/javascripts/acceptance/topic-test.js.es6
@@ -184,23 +184,6 @@ QUnit.test("Updating the topic title with emojis", async assert => {
   );
 });
 
-QUnit.test("Updating the topic title with unicode emojis", async assert => {
-  await visit("/t/internationalization-localization/280");
-  await click("#topic-title .d-icon-pencil-alt");
-
-  await fillIn("#edit-title", "emojis title 👨‍🌾");
-
-  await click("#topic-title .submit-edit");
-
-  assert.equal(
-    find(".fancy-title")
-      .html()
-      .trim(),
-    `emojis title <img src="/images/emoji/emoji_one/man_farmer.png?v=${v}" title="man_farmer" alt="man_farmer" class="emoji">`,
-    "it displays the new title with escaped unicode emojis"
-  );
-});
-
 acceptance("Topic featured links", {
   loggedIn: true,
   settings: {


### PR DESCRIPTION
Reverts discourse/discourse#7176 as this is breaking the https://github.com/discourse/discourse-prometheus-alert-receiver plugin (specs are failing)