### PR TITLE
[FEATURE] Disallow ignoring self, admins or moderators users

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -997,10 +997,7 @@ class UsersController < ApplicationController
 
   def ignore
     raise Discourse::NotFound unless SiteSetting.ignore_user_enabled
-
-    unless current_user.id != params[:ignored_user_id] && User.where(id: params[:ignored_user_id], admin: false, moderator: false).exists?
-      return render json: failed_json, status: 422
-    end
+    ensure_can_ignore_user!(params[:ignored_user_id])
 
     IgnoredUser.find_or_create_by!(user: current_user, ignored_user_id: params[:ignored_user_id])
     render json: success_json

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -996,9 +996,7 @@ class UsersController < ApplicationController
   end
 
   def ignore
-    unless SiteSetting.ignore_user_enabled
-      raise Discourse::NotFound
-    end
+    raise Discourse::NotFound unless SiteSetting.ignore_user_enabled
 
     unless current_user.id != params[:ignored_user_id] && User.where(id: params[:ignored_user_id], admin: false, moderator: false).exists?
       return render json: failed_json, status: 422

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -996,11 +996,15 @@ class UsersController < ApplicationController
   end
 
   def ignore
-    raise Discourse::NotFound unless SiteSetting.ignore_user_enabled
+    unless SiteSetting.ignore_user_enabled
+      raise Discourse::NotFound
+    end
 
-    ::IgnoredUser.find_or_create_by!(
-      user: current_user,
-      ignored_user_id: params[:ignored_user_id])
+    unless current_user.id != params[:ignored_user_id] && User.where(id: params[:ignored_user_id], admin: false, moderator: false).exists?
+      return render json: failed_json, status: 422
+    end
+
+    IgnoredUser.find_or_create_by!(user: current_user, ignored_user_id: params[:ignored_user_id])
     render json: success_json
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -997,7 +997,7 @@ class UsersController < ApplicationController
 
   def ignore
     raise Discourse::NotFound unless SiteSetting.ignore_user_enabled
-    ensure_can_ignore_user!(params[:ignored_user_id])
+    guardian.ensure_can_ignore_user!(params[:ignored_user_id])
 
     IgnoredUser.find_or_create_by!(user: current_user, ignored_user_id: params[:ignored_user_id])
     render json: success_json

--- a/app/serializers/basic_post_serializer.rb
+++ b/app/serializers/basic_post_serializer.rb
@@ -46,7 +46,7 @@ class BasicPostSerializer < ApplicationSerializer
   def ignored
     object.is_first_post? &&
       scope.current_user&.id != object.user_id &&
-      !object.user.staff? &&
+      !object.user&.staff? &&
       IgnoredUser.where(user_id: scope.current_user&.id,
                         ignored_user_id: object.user_id).exists?
   end

--- a/app/serializers/basic_post_serializer.rb
+++ b/app/serializers/basic_post_serializer.rb
@@ -46,8 +46,7 @@ class BasicPostSerializer < ApplicationSerializer
   def ignored
     object.is_first_post? &&
       scope.current_user&.id != object.user_id &&
-      !object.user.admin? &&
-      !object.user.moderator? &&
+      !object.user.staff? &&
       IgnoredUser.where(user_id: scope.current_user&.id,
                         ignored_user_id: object.user_id).exists?
   end

--- a/app/serializers/basic_post_serializer.rb
+++ b/app/serializers/basic_post_serializer.rb
@@ -44,8 +44,12 @@ class BasicPostSerializer < ApplicationSerializer
   end
 
   def ignored
-    object.is_first_post? && IgnoredUser.where(user_id: scope.current_user&.id,
-                                               ignored_user_id: object.user_id).exists?
+    object.is_first_post? &&
+      !object.user.admin? &&
+      !object.user.moderator? &&
+      scope.current_user&.id != object.user_id &&
+      IgnoredUser.where(user_id: scope.current_user&.id,
+                        ignored_user_id: object.user_id).exists?
   end
 
   def include_name?

--- a/app/serializers/basic_post_serializer.rb
+++ b/app/serializers/basic_post_serializer.rb
@@ -45,9 +45,9 @@ class BasicPostSerializer < ApplicationSerializer
 
   def ignored
     object.is_first_post? &&
+      scope.current_user&.id != object.user_id &&
       !object.user.admin? &&
       !object.user.moderator? &&
-      scope.current_user&.id != object.user_id &&
       IgnoredUser.where(user_id: scope.current_user&.id,
                         ignored_user_id: object.user_id).exists?
   end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -282,7 +282,7 @@ class UserSerializer < BasicUserSerializer
   end
 
   def can_ignore_user
-    SiteSetting.ignore_user_enabled && !object.admin? && !object.moderator?
+    SiteSetting.ignore_user_enabled? && !object.staff?
   end
 
   # Needed because 'send_private_message_to_user' will always return false

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -282,7 +282,7 @@ class UserSerializer < BasicUserSerializer
   end
 
   def can_ignore_user
-    SiteSetting.ignore_user_enabled
+    SiteSetting.ignore_user_enabled && (scope.user&.admin? || scope.user&.moderator?)
   end
 
   # Needed because 'send_private_message_to_user' will always return false

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -282,7 +282,7 @@ class UserSerializer < BasicUserSerializer
   end
 
   def can_ignore_user
-    SiteSetting.ignore_user_enabled && (scope.user&.admin? || scope.user&.moderator?)
+    SiteSetting.ignore_user_enabled && !object.admin? && !object.moderator?
   end
 
   # Needed because 'send_private_message_to_user' will always return false

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -282,7 +282,7 @@ class UserSerializer < BasicUserSerializer
   end
 
   def can_ignore_user
-    SiteSetting.ignore_user_enabled? && !object.staff?
+    SiteSetting.ignore_user_enabled? && !object.staff? && scope.current_user != object
   end
 
   # Needed because 'send_private_message_to_user' will always return false

--- a/app/services/user_updater.rb
+++ b/app/services/user_updater.rb
@@ -149,7 +149,8 @@ class UserUpdater
 
   def update_muted_users(usernames)
     usernames ||= ""
-    desired_ids = User.where(username: usernames.split(",")).pluck(:id)
+    desired_usernames = usernames.split(",").reject { |username| user.username == username }
+    desired_ids = User.where(username: desired_usernames).pluck(:id)
     if desired_ids.empty?
       MutedUser.where(user_id: user.id).destroy_all
     else
@@ -168,7 +169,8 @@ class UserUpdater
 
   def update_ignored_users(usernames)
     usernames ||= ""
-    desired_ids = User.where(username: usernames.split(",")).pluck(:id)
+    desired_usernames = usernames.split(",").reject { |username| user.username == username }
+    desired_ids = User.where(username: desired_usernames).where(admin: false, moderator: false).pluck(:id)
     if desired_ids.empty?
       IgnoredUser.where(user_id: user.id).destroy_all
     else

--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -391,8 +391,7 @@ class Guardian
   end
 
   def can_ignore_user?(user_id)
-    return @user.id != user_id
-    User.where(id: user_id, admin: false, moderator: false).exists?
+    @user.id != user_id && User.where(id: user_id, admin: false, moderator: false).exists?
   end
 
   def allow_themes?(theme_ids, include_preview: false)

--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -390,6 +390,11 @@ class Guardian
     UserExport.where(user_id: @user.id, created_at: (Time.zone.now.beginning_of_day..Time.zone.now.end_of_day)).count == 0
   end
 
+  def can_ignore_user?(user_id)
+    return @user.id != user_id
+    User.where(id: user_id, admin: false, moderator: false).exists?
+  end
+
   def allow_themes?(theme_ids, include_preview: false)
     return true if theme_ids.blank?
 

--- a/lib/topic_view.rb
+++ b/lib/topic_view.rb
@@ -605,13 +605,13 @@ class TopicView
     if SiteSetting.ignore_user_enabled
 
       sql = <<~SQL
-            SELECT ignored_user_id
-            FROM ignored_users as ig
-            JOIN users as u ON u.id = ig.ignored_user_id
-            WHERE ig.user_id = :current_user_id
-              AND ig.ignored_user_id <> :current_user_id
-              AND u.admin = FALSE
-              AND u.moderator = FALSE
+          SELECT ignored_user_id
+          FROM ignored_users as ig
+          JOIN users as u ON u.id = ig.ignored_user_id
+          WHERE ig.user_id = :current_user_id
+            AND ig.ignored_user_id <> :current_user_id
+            AND NOT u.admin
+            AND NOT u.moderator
       SQL
 
       ignored_user_ids = DB.query_single(sql, current_user_id: @user&.id)

--- a/spec/components/guardian_spec.rb
+++ b/spec/components/guardian_spec.rb
@@ -2645,7 +2645,7 @@ describe Guardian do
 
     context "when ignored user is the same as guardian user" do
       it 'does not allow ignoring user' do
-        expect(guardian.can_ignore_user?(user.id)).to be_falsey
+        expect(guardian.can_ignore_user?(user.id)).to eq(false)
       end
     end
 
@@ -2653,7 +2653,7 @@ describe Guardian do
       let!(:admin) { Fabricate(:user, admin: true) }
 
       it 'does not allow ignoring user' do
-        expect(guardian.can_ignore_user?(admin.id)).to be_falsey
+        expect(guardian.can_ignore_user?(admin.id)).to eq(false)
       end
     end
 
@@ -2661,7 +2661,7 @@ describe Guardian do
       let!(:another_user) { Fabricate(:user) }
 
       it 'allows ignoring user' do
-        expect(guardian.can_ignore_user?(another_user.id)).to be_truthy
+        expect(guardian.can_ignore_user?(another_user.id)).to eq(true)
       end
     end
   end

--- a/spec/components/guardian_spec.rb
+++ b/spec/components/guardian_spec.rb
@@ -2640,6 +2640,32 @@ describe Guardian do
     end
   end
 
+  describe '#can_ignore_user?' do
+    let(:guardian) { Guardian.new(user) }
+
+    context "when ignored user is the same as guardian user" do
+      it 'does not allow ignoring user' do
+        expect(guardian.can_ignore_user?(user.id)).to be_falsey
+      end
+    end
+
+    context "when ignored user is a staff user" do
+      let!(:admin) { Fabricate(:user, admin: true) }
+
+      it 'does not allow ignoring user' do
+        expect(guardian.can_ignore_user?(admin.id)).to be_falsey
+      end
+    end
+
+    context "when ignored user is a normal user" do
+      let!(:another_user) { Fabricate(:user) }
+
+      it 'allows ignoring user' do
+        expect(guardian.can_ignore_user?(another_user.id)).to be_truthy
+      end
+    end
+  end
+
   describe "#allow_themes?" do
     let(:theme) { Fabricate(:theme) }
     let(:theme2) { Fabricate(:theme) }

--- a/spec/components/topic_view_spec.rb
+++ b/spec/components/topic_view_spec.rb
@@ -94,7 +94,7 @@ describe TopicView do
           let!(:post4) { Fabricate(:post, topic: topic, user: admin) }
 
           it "filters out ignored user excluding the staff user" do
-            tv = TopicView.new(topic.id, nil)
+            tv = TopicView.new(topic.id, evil_trout)
             expect(tv.filtered_post_ids).to eq([post.id, post2.id, post4.id])
           end
         end

--- a/spec/components/topic_view_spec.rb
+++ b/spec/components/topic_view_spec.rb
@@ -44,7 +44,7 @@ describe TopicView do
           SiteSetting.ignore_user_enabled = false
 
           tv = TopicView.new(topic.id, evil_trout)
-          expect(tv.filtered_post_ids).to match_array([post.id, post2.id, post3.id])
+          expect(tv.filtered_post_ids).to eq([post.id, post2.id, post3.id])
         end
       end
 
@@ -56,7 +56,7 @@ describe TopicView do
 
         it "filters out ignored user posts" do
           tv = TopicView.new(topic.id, evil_trout)
-          expect(tv.filtered_post_ids).to match_array([post.id, post2.id])
+          expect(tv.filtered_post_ids).to eq([post.id, post2.id])
         end
 
         describe "when an ignored user made the original post" do
@@ -64,7 +64,7 @@ describe TopicView do
 
           it "filters out ignored user posts only" do
             tv = TopicView.new(topic.id, evil_trout)
-            expect(tv.filtered_post_ids).to match_array([post.id, post2.id])
+            expect(tv.filtered_post_ids).to eq([post.id, post2.id])
           end
         end
 
@@ -74,7 +74,7 @@ describe TopicView do
 
           it "filters out ignored user posts only" do
             tv = TopicView.new(topic.id, evil_trout)
-            expect(tv.filtered_post_ids).to match_array([post.id, post2.id, post4.id])
+            expect(tv.filtered_post_ids).to eq([post.id, post2.id, post4.id])
           end
         end
 
@@ -84,18 +84,18 @@ describe TopicView do
 
           it "filters out ignored user posts only" do
             tv = TopicView.new(topic.id, nil)
-            expect(tv.filtered_post_ids).to match_array([post.id, post2.id, post3.id, post4.id])
+            expect(tv.filtered_post_ids).to eq([post.id, post2.id, post3.id, post4.id])
           end
         end
 
         describe "when a staff user is ignored" do
           let!(:admin) { Fabricate(:user, admin: true) }
           let!(:admin_ignored_user) { Fabricate(:ignored_user, user: evil_trout, ignored_user: admin) }
-          let!(:post4) { Fabricate(:post, topic: topic, user: admin_ignored_user) }
+          let!(:post4) { Fabricate(:post, topic: topic, user: admin) }
 
           it "filters out ignored user excluding the staff user" do
             tv = TopicView.new(topic.id, nil)
-            expect(tv.filtered_post_ids).to match_array([post.id, post2.id, post4.id])
+            expect(tv.filtered_post_ids).to eq([post.id, post2.id, post4.id])
           end
         end
       end

--- a/spec/components/topic_view_spec.rb
+++ b/spec/components/topic_view_spec.rb
@@ -92,6 +92,18 @@ describe TopicView do
             expect(tv.filtered_post_ids).to match_array([post.id, post2.id, post3.id, post4.id])
           end
         end
+
+        describe "when a staff user is ignored" do
+          let!(:admin) { Fabricate(:user, admin: true) }
+          let!(:admin_ignored_user) { Fabricate(:ignored_user, user: evil_trout, ignored_user: admin) }
+          let!(:post4) { Fabricate(:post, topic: topic, user: admin_ignored_user) }
+
+          it "filters out ignored user excluding the staff user" do
+            tv = TopicView.new(topic.id, nil)
+            expect(tv.filtered_post_ids.size).to eq(3)
+            expect(tv.filtered_post_ids).to match_array([post.id, post2.id, post4.id])
+          end
+        end
       end
     end
   end

--- a/spec/components/topic_view_spec.rb
+++ b/spec/components/topic_view_spec.rb
@@ -44,7 +44,6 @@ describe TopicView do
           SiteSetting.ignore_user_enabled = false
 
           tv = TopicView.new(topic.id, evil_trout)
-          expect(tv.filtered_post_ids.size).to eq(3)
           expect(tv.filtered_post_ids).to match_array([post.id, post2.id, post3.id])
         end
       end
@@ -57,7 +56,6 @@ describe TopicView do
 
         it "filters out ignored user posts" do
           tv = TopicView.new(topic.id, evil_trout)
-          expect(tv.filtered_post_ids.size).to eq(2)
           expect(tv.filtered_post_ids).to match_array([post.id, post2.id])
         end
 
@@ -66,7 +64,6 @@ describe TopicView do
 
           it "filters out ignored user posts only" do
             tv = TopicView.new(topic.id, evil_trout)
-            expect(tv.filtered_post_ids.size).to eq(2)
             expect(tv.filtered_post_ids).to match_array([post.id, post2.id])
           end
         end
@@ -77,7 +74,6 @@ describe TopicView do
 
           it "filters out ignored user posts only" do
             tv = TopicView.new(topic.id, evil_trout)
-            expect(tv.filtered_post_ids.size).to eq(3)
             expect(tv.filtered_post_ids).to match_array([post.id, post2.id, post4.id])
           end
         end
@@ -88,7 +84,6 @@ describe TopicView do
 
           it "filters out ignored user posts only" do
             tv = TopicView.new(topic.id, nil)
-            expect(tv.filtered_post_ids.size).to eq(4)
             expect(tv.filtered_post_ids).to match_array([post.id, post2.id, post3.id, post4.id])
           end
         end
@@ -100,7 +95,6 @@ describe TopicView do
 
           it "filters out ignored user excluding the staff user" do
             tv = TopicView.new(topic.id, nil)
-            expect(tv.filtered_post_ids.size).to eq(3)
             expect(tv.filtered_post_ids).to match_array([post.id, post2.id, post4.id])
           end
         end

--- a/spec/jobs/ignored_users_summary_spec.rb
+++ b/spec/jobs/ignored_users_summary_spec.rb
@@ -48,8 +48,8 @@ describe Jobs::IgnoredUsersSummary do
             subtype: TopicSubtype.system_message
           })
           expect(posts.count).to eq(2)
-          expect(posts[0].raw).to include(matt.username)
-          expect(posts[1].raw).to include(john.username)
+          expect(posts.find { |post| post.raw.include?(matt.username) }).to be_present
+          expect(posts.find { |post| post.raw.include?(john.username) }).to be_present
         end
       end
     end

--- a/spec/services/user_updater_spec.rb
+++ b/spec/services/user_updater_spec.rb
@@ -23,6 +23,15 @@ describe UserUpdater do
       expect(MutedUser.where(user_id: u1.id).count).to eq 2
       expect(MutedUser.where(user_id: u3.id).count).to eq 0
     end
+
+    it 'excludes acting user' do
+      u1 = Fabricate(:user)
+      u2 = Fabricate(:user)
+      updater = UserUpdater.new(u1, u1)
+      updater.update_muted_users("#{u1.username},#{u2.username}")
+
+      expect(MutedUser.where(user_id: u1.id).count).to eq 1
+    end
   end
 
   describe '#update_ignored_users' do
@@ -43,6 +52,15 @@ describe UserUpdater do
       expect(IgnoredUser.where(user_id: u2.id).count).to eq 2
       expect(IgnoredUser.where(user_id: u1.id).count).to eq 2
       expect(IgnoredUser.where(user_id: u3.id).count).to eq 0
+    end
+
+    it 'excludes acting user' do
+      u1 = Fabricate(:user)
+      u2 = Fabricate(:user)
+      updater = UserUpdater.new(u1, u1)
+      updater.update_ignored_users("#{u1.username},#{u2.username}")
+
+      expect(IgnoredUser.where(user_id: u1.id).count).to eq 1
     end
   end
 

--- a/spec/services/user_updater_spec.rb
+++ b/spec/services/user_updater_spec.rb
@@ -30,7 +30,7 @@ describe UserUpdater do
       updater = UserUpdater.new(u1, u1)
       updater.update_muted_users("#{u1.username},#{u2.username}")
 
-      expect(MutedUser.where(user_id: u1.id).count).to eq 1
+      expect(MutedUser.where(muted_user_id: u2.id).count).to eq 1
     end
   end
 
@@ -60,7 +60,7 @@ describe UserUpdater do
       updater = UserUpdater.new(u1, u1)
       updater.update_ignored_users("#{u1.username},#{u2.username}")
 
-      expect(IgnoredUser.where(user_id: u1.id).count).to eq 1
+      expect(IgnoredUser.where(ignored_user_id: u2.id).count).to eq 1
     end
   end
 


### PR DESCRIPTION
## Why?

This is part of the [Ability to ignore a user feature](https://meta.discourse.org/t/ability-to-ignore-a-user/110254/8).

We do not want to allow Users ignoring:

1. Themselves
2. Any Admins or Moderators