### PR TITLE
UX: completely hide header-buttons on mobile if topic is visible 

### DIFF
--- a/app/assets/stylesheets/mobile/header.scss
+++ b/app/assets/stylesheets/mobile/header.scss
@@ -54,6 +54,9 @@
   .extra-info-wrapper + .panel {
     flex: 0;
     min-width: 0;
+    .header-buttons {
+      display: none;
+    }
   }
   // Fade in header avatar + icons if topic title is not visible in mobile header
   .panel {


### PR DESCRIPTION
This ensures that the login button on mobile is not displayed if the user - anon - is scrolling down in a topic and the title is visible. 

Right now, an anon user might see this depending on what mobile device they're on

![1](https://user-images.githubusercontent.com/33972521/54613578-e4293880-4a95-11e9-812b-19bfb257abde.png)

That's the login button. 

We can't use `display: none` on `.panel` since that would be inherited by the user / hamburger menus and would need to be overridden. 

So, I'm using flex-shrink to hide the panel. However, that leaves a little bit of the button visible. 

This PR adds `display: none` to the `.header-buttons` to ensure that it's completely hidden if the topic is visible. 

It has no effect if the topic is not visible.  
