### PR TITLE
UX: completely hide notification badges if title is visible on mobile

### DIFF
--- a/app/assets/stylesheets/mobile/header.scss
+++ b/app/assets/stylesheets/mobile/header.scss
@@ -54,7 +54,8 @@
   .extra-info-wrapper + .panel {
     flex: 0;
     min-width: 0;
-    .header-buttons {
+    .header-buttons,
+    .badge-notification {
       display: none;
     }
   }


### PR DESCRIPTION
There are some cases where the notification badges are still visible even if the mobile header title is visible - in PMs.

![2](https://user-images.githubusercontent.com/33972521/54625429-43914380-4aaa-11e9-9788-c4068bd139d0.png)

We cannot use `display: none` on `.panel` because that would be inherited by the user and hamburger menus - which would mean users can't swipe to open those menus. 

So, we explicitly hide the notification badges if the title is visible just like the login button.

This has no effect if the title is not visible. 