### PR TITLE
UX: Enabled sorting for more columns in admin user list

### DIFF
--- a/app/assets/javascripts/admin/controllers/admin-users-list-show.js.es6
+++ b/app/assets/javascripts/admin/controllers/admin-users-list-show.js.es6
@@ -8,7 +8,7 @@ export default Ember.Controller.extend(CanCheckEmails, {
   query: null,
   order: null,
   ascending: null,
-  showEmails: false,
+  showEmailsToggle: false,
   refreshing: false,
   listFilter: null,
   selectAll: false,
@@ -51,7 +51,7 @@ export default Ember.Controller.extend(CanCheckEmails, {
 
     AdminUser.findAll(this.get("query"), {
       filter: this.get("listFilter"),
-      show_emails: this.get("showEmails"),
+      show_emails: this.get("showEmailsToggle"),
       order: this.get("order"),
       ascending: this.get("ascending")
     })
@@ -88,7 +88,12 @@ export default Ember.Controller.extend(CanCheckEmails, {
     },
 
     showEmails: function() {
-      this.set("showEmails", true);
+      this.set("showEmailsToggle", true);
+      this._refreshUsers();
+    },
+
+    hideEmails: function() {
+      this.set("showEmailsToggle", false);
       this._refreshUsers();
     }
   }

--- a/app/assets/javascripts/admin/controllers/admin-users-list-show.js.es6
+++ b/app/assets/javascripts/admin/controllers/admin-users-list-show.js.es6
@@ -8,7 +8,7 @@ export default Ember.Controller.extend(CanCheckEmails, {
   query: null,
   order: null,
   ascending: null,
-  showEmailsToggle: false,
+  showEmails: false,
   refreshing: false,
   listFilter: null,
   selectAll: false,
@@ -51,7 +51,7 @@ export default Ember.Controller.extend(CanCheckEmails, {
 
     AdminUser.findAll(this.get("query"), {
       filter: this.get("listFilter"),
-      show_emails: this.get("showEmailsToggle"),
+      show_emails: this.get("showEmails"),
       order: this.get("order"),
       ascending: this.get("ascending")
     })
@@ -87,13 +87,8 @@ export default Ember.Controller.extend(CanCheckEmails, {
       );
     },
 
-    showEmails: function() {
-      this.set("showEmailsToggle", true);
-      this._refreshUsers();
-    },
-
-    hideEmails: function() {
-      this.set("showEmailsToggle", false);
+    toggleEmailVisibility: function() {
+      this.toggleProperty("showEmails");
       this._refreshUsers();
     }
   }

--- a/app/assets/javascripts/admin/routes/admin-users-list-show.js.es6
+++ b/app/assets/javascripts/admin/routes/admin-users-list-show.js.es6
@@ -17,7 +17,6 @@ export default Discourse.Route.extend({
           order: transition.queryParams.order,
           ascending: transition.queryParams.ascending,
           query: params.filter,
-          showEmails: false,
           refreshing: false
         });
 

--- a/app/assets/javascripts/admin/templates/users-list-show.hbs
+++ b/app/assets/javascripts/admin/templates/users-list-show.hbs
@@ -8,16 +8,16 @@
 <div class="admin-title">
   <h2>{{title}}</h2>
   {{#if canCheckEmails}}
-      {{#if showEmailsToggle}}
-        <button {{action "hideEmails"}} class="hide-emails btn btn-default">{{i18n 'admin.users.hide_emails'}}</button>
+      {{#if showEmails}}
+        <button {{action "toggleEmailVisibility"}} class="hide-emails btn btn-default">{{i18n 'admin.users.hide_emails'}}</button>
       {{else}}
-        <button {{action "showEmails"}} class="show-emails btn btn-default">{{i18n 'admin.users.show_emails'}}</button>
+        <button {{action "toggleEmailVisibility"}} class="show-emails btn btn-default">{{i18n 'admin.users.show_emails'}}</button>
       {{/if}}
   {{/if}}
 </div>
 <div class='username controls'>
   {{text-field value=listFilter placeholder=searchHint}}
-  
+
 </div>
 
 {{#conditional-loading-spinner condition=refreshing}}

--- a/app/assets/javascripts/admin/templates/users-list-show.hbs
+++ b/app/assets/javascripts/admin/templates/users-list-show.hbs
@@ -8,7 +8,11 @@
 <div class="admin-title">
   <h2>{{title}}</h2>
   {{#if canCheckEmails}}
-      <button {{action "showEmails"}} class="show-emails btn btn-default">{{i18n 'admin.users.show_emails'}}</button>
+      {{#if showEmailsToggle}}
+        <button {{action "hideEmails"}} class="hide-emails btn btn-default">{{i18n 'admin.users.hide_emails'}}</button>
+      {{else}}
+        <button {{action "showEmails"}} class="show-emails btn btn-default">{{i18n 'admin.users.show_emails'}}</button>
+      {{/if}}
   {{/if}}
 </div>
 <div class='username controls'>
@@ -23,9 +27,9 @@
         {{#if showApproval}}
           <th>{{input type="checkbox" checked=selectAll}}</th>
         {{/if}}
-        <th>{{i18n 'username'}}</th>
-        <th class='email-heading'>{{i18n 'email'}}</th>
-        <th>{{i18n 'admin.users.last_emailed'}}</th>
+        {{admin-directory-toggle field="username" i18nKey='username' order=order ascending=ascending}}
+        {{admin-directory-toggle field="email" i18nKey='email' order=order ascending=ascending}}
+        {{admin-directory-toggle field="last_emailed" i18nKey='admin.users.last_emailed' order=order ascending=ascending}}
         {{admin-directory-toggle field="seen" i18nKey='last_seen' order=order ascending=ascending}}
         {{admin-directory-toggle field="topics_viewed" i18nKey="admin.user.topics_entered" order=order ascending=ascending}}
         {{admin-directory-toggle field="posts_read" i18nKey="admin.user.posts_read_count" order=order ascending=ascending}}

--- a/app/assets/stylesheets/common/admin/admin_base.scss
+++ b/app/assets/stylesheets/common/admin/admin_base.scss
@@ -435,7 +435,7 @@ $mobile-breakpoint: 700px;
   display: flex;
   flex-wrap: wrap;
   align-items: flex-start;
-  .show-emails {
+  .show-emails, .hide-emails {
     margin-left: auto;
   }
 }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3788,6 +3788,7 @@ en:
         id_not_found: "Sorry, that user id doesn't exist in our system."
         active: "Activated"
         show_emails: "Show Emails"
+        hide_emails: "Hide Emails"
         nav:
           new: "New"
           active: "Active"

--- a/test/javascripts/acceptance/admin-users-list-test.js.es6
+++ b/test/javascripts/acceptance/admin-users-list-test.js.es6
@@ -19,7 +19,8 @@ QUnit.test("sorts users", async assert => {
   assert.ok(
     find(".users-list .user:nth-child(1) .username")
       .text()
-      .includes("eviltrout")
+      .includes("eviltrout"),
+    "list should be sorted by username"
   );
 
   await click(".users-list .sortable:nth-child(1)");
@@ -27,7 +28,8 @@ QUnit.test("sorts users", async assert => {
   assert.ok(
     find(".users-list .user:nth-child(1) .username")
       .text()
-      .includes("discobot")
+      .includes("discobot"),
+    "list should be sorted ascending by username"
   );
 });
 

--- a/test/javascripts/acceptance/admin-users-list-test.js.es6
+++ b/test/javascripts/acceptance/admin-users-list-test.js.es6
@@ -9,6 +9,50 @@ QUnit.test("lists users", async assert => {
   assert.ok(!exists(".user:eq(0) .email small"), "escapes email");
 });
 
+QUnit.test("sorts users", async assert => {
+  await visit("/admin/users/list/active");
+
+  assert.ok(exists(".users-list .user"));
+
+  await click(".users-list .sortable:nth-child(1)");
+
+  assert.ok(
+    find(".users-list .user:nth-child(1) .username")
+      .text()
+      .includes("eviltrout")
+  );
+
+  await click(".users-list .sortable:nth-child(1)");
+
+  assert.ok(
+    find(".users-list .user:nth-child(1) .username")
+      .text()
+      .includes("discobot")
+  );
+});
+
+QUnit.test("toggles email visibility", async assert => {
+  await visit("/admin/users/list/active");
+
+  assert.ok(exists(".users-list .user"));
+
+  await click(".show-emails");
+
+  assert.equal(
+    find(".users-list .user:nth-child(1) .email").text(),
+    "<small>eviltrout@example.com</small>",
+    "shows the emails"
+  );
+
+  await click(".hide-emails");
+
+  assert.equal(
+    find(".users-list .user:nth-child(1) .email").text(),
+    "",
+    "hides the emails"
+  );
+});
+
 QUnit.test("switching tabs", async assert => {
   const activeUser = "eviltrout@example.com";
   const suspectUser = "sam@example.com";

--- a/test/javascripts/helpers/create-pretender.js.es6
+++ b/test/javascripts/helpers/create-pretender.js.es6
@@ -448,8 +448,8 @@ export default function() {
       overridden: true
     };
 
-    this.get("/admin/users/list/active.json", () => {
-      return response(200, [
+    this.get("/admin/users/list/active.json", request => {
+      let store = [
         {
           id: 1,
           username: "eviltrout",
@@ -460,7 +460,20 @@ export default function() {
           username: "discobot",
           email: "<small>discobot_email</small>"
         }
-      ]);
+      ];
+      const ascending = request.queryParams.ascending;
+      const order = request.queryParams.order;
+
+      if (order) {
+        store = store.sort(function(a, b) {
+          return a[order] - b[order];
+        });
+      }
+      if (ascending) {
+        store = store.reverse();
+      }
+
+      return response(200, store);
     });
 
     this.get("/admin/users/list/suspect.json", () => {

--- a/test/javascripts/helpers/create-pretender.js.es6
+++ b/test/javascripts/helpers/create-pretender.js.es6
@@ -454,6 +454,11 @@ export default function() {
           id: 1,
           username: "eviltrout",
           email: "<small>eviltrout@example.com</small>"
+        },
+        {
+          id: 3,
+          username: "discobot",
+          email: "<small>discobot_email</small>"
         }
       ]);
     });


### PR DESCRIPTION
This enables sorting for `email`, `username` and `last emailed` in the admin user list.

Also changed the `showEmail` button to a permanent toggle since the old behavior felt like a bug.

### Before:
![Peek 2019-03-19 22-17](https://user-images.githubusercontent.com/13546486/54642375-b98ab000-4a94-11e9-9302-99ce8b857da5.gif)

### After:
![Peek 2019-03-19 22-16](https://user-images.githubusercontent.com/13546486/54642392-c6a79f00-4a94-11e9-833c-45395d6cf5ba.gif)

I also wanted to write Qunit tests for both the sorting and the show / hide email function but somehow both of these functions weren't working in Qunit. Sorting wasn't clickable and the show / hide email function somehow always showed the emails.

If someone knows why that is, I will happily add tests to this PR!