### PR TITLE
FEATURE: Add scheduled job to purge expired ignored users

### DIFF
--- a/app/jobs/scheduled/purge_expired_ignored_users.rb
+++ b/app/jobs/scheduled/purge_expired_ignored_users.rb
@@ -1,0 +1,9 @@
+module Jobs
+  class PurgeExpiredIgnoredUsers < Jobs::Scheduled
+    every 1.day
+
+    def execute(args)
+      IgnoredUser.where("created_at <= ?", 4.months.ago).delete_all
+    end
+  end
+end

--- a/spec/jobs/purge_expired_ignored_users_spec.rb
+++ b/spec/jobs/purge_expired_ignored_users_spec.rb
@@ -7,7 +7,6 @@ describe Jobs::PurgeExpiredIgnoredUsers do
 
   context "with no ignored users" do
     it "does nothing" do
-      subject
       expect { subject }.to_not change { IgnoredUser.count }
     end
   end
@@ -24,19 +23,20 @@ describe Jobs::PurgeExpiredIgnoredUsers do
 
     context "when no expired ignored users" do
       it "does nothing" do
-        subject
         expect { subject }.to_not change { IgnoredUser.count }
       end
     end
 
     context "when there are expired ignored users" do
+      let(:fred) { Fabricate(:user, username: "fred") }
+
       it "purges expired ignored users" do
         freeze_time(5.months.ago) do
-          fred = Fabricate(:user, username: "fred")
           Fabricate(:ignored_user, user: tarek, ignored_user: fred)
         end
 
-        expect { subject }.to change { IgnoredUser.count }.from(3).to(2)
+        subject
+        expect(IgnoredUser.find_by(ignored_user: fred)).to be_nil
       end
     end
   end

--- a/spec/jobs/purge_expired_ignored_users_spec.rb
+++ b/spec/jobs/purge_expired_ignored_users_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+require_dependency 'jobs/scheduled/purge_expired_ignored_users'
+
+describe Jobs::PurgeExpiredIgnoredUsers do
+  subject { Jobs::PurgeExpiredIgnoredUsers.new.execute({}) }
+
+  context "with no ignored users" do
+    it "does nothing" do
+      subject
+      expect { subject }.to_not change { IgnoredUser.count }
+    end
+  end
+
+  context "when some ignored users exist" do
+    let(:tarek) { Fabricate(:user, username: "tarek") }
+    let(:matt) { Fabricate(:user, username: "matt") }
+    let(:john) { Fabricate(:user, username: "john") }
+
+    before do
+      Fabricate(:ignored_user, user: tarek, ignored_user: matt)
+      Fabricate(:ignored_user, user: tarek, ignored_user: john)
+    end
+
+    context "when no expired ignored users" do
+      it "does nothing" do
+        subject
+        expect { subject }.to_not change { IgnoredUser.count }
+      end
+    end
+
+    context "when there are expired ignored users" do
+      it "purges expired ignored users" do
+        freeze_time(5.months.ago) do
+          fred = Fabricate(:user, username: "fred")
+          Fabricate(:ignored_user, user: tarek, ignored_user: fred)
+        end
+
+        expect { subject }.to change { IgnoredUser.count }.from(3).to(2)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Why?

This is part of the [Ability to ignore a user feature](https://meta.discourse.org/t/ability-to-ignore-a-user/110254/8).

> The maximum ignore duration will be 4 months, so let’s go ahead and set up a task to clear these ignores after 4 months, as we have to assume all beta ignores are “max duration”.
