### PR TITLE
FEATURE: Only allow TL2 Users to ignore other users

### DIFF
--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -282,7 +282,10 @@ class UserSerializer < BasicUserSerializer
   end
 
   def can_ignore_user
-    SiteSetting.ignore_user_enabled? && !object.staff? && scope.current_user != object && (scope.current_user.staff? || scope.current_user.trust_level >= 2)
+    SiteSetting.ignore_user_enabled? &&
+      !object.staff? &&
+      scope.current_user != object &&
+      (scope.current_user.staff? || scope.current_user.trust_level >= TrustLevel.levels[:member])
   end
 
   # Needed because 'send_private_message_to_user' will always return false

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -282,7 +282,7 @@ class UserSerializer < BasicUserSerializer
   end
 
   def can_ignore_user
-    SiteSetting.ignore_user_enabled? && !object.staff? && scope.current_user != object
+    SiteSetting.ignore_user_enabled? && !object.staff? && scope.current_user != object && (scope.current_user.staff? || scope.current_user.trust_level >= 2)
   end
 
   # Needed because 'send_private_message_to_user' will always return false

--- a/app/services/user_updater.rb
+++ b/app/services/user_updater.rb
@@ -168,6 +168,8 @@ class UserUpdater
   end
 
   def update_ignored_users(usernames)
+    return if user.trust_level < 2
+
     usernames ||= ""
     desired_usernames = usernames.split(",").reject { |username| user.username == username }
     desired_ids = User.where(username: desired_usernames).where(admin: false, moderator: false).pluck(:id)

--- a/app/services/user_updater.rb
+++ b/app/services/user_updater.rb
@@ -168,7 +168,7 @@ class UserUpdater
   end
 
   def update_ignored_users(usernames)
-    return if user.trust_level < 2
+    return if user.trust_level < TrustLevel.levels[:member]
 
     usernames ||= ""
     desired_usernames = usernames.split(",").reject { |username| user.username == username }

--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -391,7 +391,9 @@ class Guardian
   end
 
   def can_ignore_user?(user_id)
-    @user.id != user_id && @user.trust_level >= 2 && User.where(id: user_id, admin: false, moderator: false).exists?
+    @user.id != user_id &&
+      @user.trust_level >= TrustLevel.levels[:member] &&
+      User.where(id: user_id, admin: false, moderator: false).exists?
   end
 
   def allow_themes?(theme_ids, include_preview: false)

--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -391,7 +391,7 @@ class Guardian
   end
 
   def can_ignore_user?(user_id)
-    @user.id != user_id && User.where(id: user_id, admin: false, moderator: false).exists?
+    @user.id != user_id && @user.trust_level >= 2 && User.where(id: user_id, admin: false, moderator: false).exists?
   end
 
   def allow_themes?(theme_ids, include_preview: false)

--- a/spec/components/guardian_spec.rb
+++ b/spec/components/guardian_spec.rb
@@ -2664,6 +2664,25 @@ describe Guardian do
         expect(guardian.can_ignore_user?(another_user.id)).to eq(true)
       end
     end
+
+    context "when ignorer's trust level is below tl2" do
+      let(:guardian) { Guardian.new(trust_level_1) }
+      let!(:another_user) { Fabricate(:user) }
+      let!(:trust_level_1) { build(:user, trust_level: 1) }
+
+      it 'does not allow ignoring user' do
+        expect(guardian.can_ignore_user?(another_user.id)).to eq(false)
+      end
+    end
+
+    context "when ignorer's trust level is tl2" do
+      let(:guardian) { Guardian.new(trust_level_2) }
+      let!(:another_user) { Fabricate(:user) }
+
+      it 'allows ignoring user' do
+        expect(guardian.can_ignore_user?(another_user.id)).to eq(true)
+      end
+    end
   end
 
   describe "#allow_themes?" do

--- a/spec/components/guardian_spec.rb
+++ b/spec/components/guardian_spec.rb
@@ -2641,11 +2641,11 @@ describe Guardian do
   end
 
   describe '#can_ignore_user?' do
-    let(:guardian) { Guardian.new(user) }
+    let(:guardian) { Guardian.new(trust_level_2) }
 
     context "when ignored user is the same as guardian user" do
       it 'does not allow ignoring user' do
-        expect(guardian.can_ignore_user?(user.id)).to eq(false)
+        expect(guardian.can_ignore_user?(trust_level_2.id)).to eq(false)
       end
     end
 

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -2027,7 +2027,7 @@ describe UsersController do
     end
 
     context 'while logged in' do
-      let(:user) { Fabricate(:user) }
+      let(:user) { Fabricate(:user, trust_level: 2) }
       let(:another_user) { Fabricate(:user) }
       before do
         sign_in(user)

--- a/spec/services/user_updater_spec.rb
+++ b/spec/services/user_updater_spec.rb
@@ -36,9 +36,9 @@ describe UserUpdater do
 
   describe '#update_ignored_users' do
     it 'updates ignored users' do
-      u1 = Fabricate(:user)
-      u2 = Fabricate(:user)
-      u3 = Fabricate(:user)
+      u1 = Fabricate(:user, trust_level: 2)
+      u2 = Fabricate(:user, trust_level: 2)
+      u3 = Fabricate(:user, trust_level: 2)
 
       updater = UserUpdater.new(u1, u1)
       updater.update_ignored_users("#{u2.username},#{u3.username}")
@@ -55,12 +55,23 @@ describe UserUpdater do
     end
 
     it 'excludes acting user' do
-      u1 = Fabricate(:user)
+      u1 = Fabricate(:user, trust_level: 2)
       u2 = Fabricate(:user)
       updater = UserUpdater.new(u1, u1)
       updater.update_ignored_users("#{u1.username},#{u2.username}")
 
       expect(IgnoredUser.where(ignored_user_id: u2.id).count).to eq 1
+    end
+
+    context 'when acting user\'s trust level is below tl2' do
+      it 'excludes acting user' do
+        u1 = Fabricate(:user, trust_level: 1)
+        u2 = Fabricate(:user)
+        updater = UserUpdater.new(u1, u1)
+        updater.update_ignored_users("#{u2.username}")
+
+        expect(IgnoredUser.where(ignored_user_id: u2.id).count).to eq 0
+      end
     end
   end
 


### PR DESCRIPTION
## Why?

This is part of the [Ability to ignore a user feature](https://meta.discourse.org/t/ability-to-ignore-a-user/110254/8).

We do not want to allow Users with trust level below TL2 to ignore other users.