### PR TITLE
REFACTOR: Move redundant ignored user check into guardian

### DIFF
--- a/app/serializers/basic_post_serializer.rb
+++ b/app/serializers/basic_post_serializer.rb
@@ -44,6 +44,7 @@ class BasicPostSerializer < ApplicationSerializer
   end
 
   def ignored
+    return false if SiteSetting.ignore_user_enabled?
     object.is_first_post? &&
       scope.current_user&.id != object.user_id &&
       IgnoredUser.where(user_id: scope.current_user&.id,

--- a/app/serializers/basic_post_serializer.rb
+++ b/app/serializers/basic_post_serializer.rb
@@ -44,7 +44,7 @@ class BasicPostSerializer < ApplicationSerializer
   end
 
   def ignored
-    return false if SiteSetting.ignore_user_enabled?
+    return false unless SiteSetting.ignore_user_enabled?
     object.is_first_post? &&
       scope.current_user&.id != object.user_id &&
       IgnoredUser.where(user_id: scope.current_user&.id,

--- a/app/serializers/basic_post_serializer.rb
+++ b/app/serializers/basic_post_serializer.rb
@@ -46,7 +46,6 @@ class BasicPostSerializer < ApplicationSerializer
   def ignored
     object.is_first_post? &&
       scope.current_user&.id != object.user_id &&
-      !object.user&.staff? &&
       IgnoredUser.where(user_id: scope.current_user&.id,
                         ignored_user_id: object.user_id).exists?
   end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -282,10 +282,7 @@ class UserSerializer < BasicUserSerializer
   end
 
   def can_ignore_user
-    SiteSetting.ignore_user_enabled? &&
-      !object.staff? &&
-      scope.current_user != object &&
-      (scope.current_user.staff? || scope.current_user.trust_level >= TrustLevel.levels[:member])
+    SiteSetting.ignore_user_enabled? && scope.can_ignore_user?(object.id)
   end
 
   # Needed because 'send_private_message_to_user' will always return false

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -282,7 +282,7 @@ class UserSerializer < BasicUserSerializer
   end
 
   def can_ignore_user
-    SiteSetting.ignore_user_enabled? && scope.can_ignore_user?(object.id)
+    scope.can_ignore_user?(object.id)
   end
 
   # Needed because 'send_private_message_to_user' will always return false

--- a/app/services/user_updater.rb
+++ b/app/services/user_updater.rb
@@ -168,7 +168,7 @@ class UserUpdater
   end
 
   def update_ignored_users(usernames)
-    return if user.trust_level < TrustLevel.levels[:member]
+    return unless guardian.can_ignore_users?
 
     usernames ||= ""
     desired_usernames = usernames.split(",").reject { |username| user.username == username }

--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -395,6 +395,7 @@ class Guardian
   end
 
   def can_ignore_users?
+    return false if anonymous?
     SiteSetting.ignore_user_enabled? && (@user.staff? || @user.trust_level >= TrustLevel.levels[:member])
   end
 

--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -391,7 +391,8 @@ class Guardian
   end
 
   def can_ignore_user?(user_id)
-    @user.id != user_id &&
+    SiteSetting.ignore_user_enabled? &&
+      @user.id != user_id &&
       (@user.staff? || @user.trust_level >= TrustLevel.levels[:member]) &&
       User.where(id: user_id, admin: false, moderator: false).exists?
   end

--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -396,6 +396,10 @@ class Guardian
       User.where(id: user_id, admin: false, moderator: false).exists?
   end
 
+  def can_ignore_users?
+    @user.id != user_id && (@user.staff? || @user.trust_level >= TrustLevel.levels[:member])
+  end
+
   def allow_themes?(theme_ids, include_preview: false)
     return true if theme_ids.blank?
 

--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -397,7 +397,7 @@ class Guardian
   end
 
   def can_ignore_users?
-    @user.id != user_id && (@user.staff? || @user.trust_level >= TrustLevel.levels[:member])
+    @user.staff? || @user.trust_level >= TrustLevel.levels[:member]
   end
 
   def allow_themes?(theme_ids, include_preview: false)

--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -391,14 +391,11 @@ class Guardian
   end
 
   def can_ignore_user?(user_id)
-    SiteSetting.ignore_user_enabled? &&
-      @user.id != user_id &&
-      (@user.staff? || @user.trust_level >= TrustLevel.levels[:member]) &&
-      User.where(id: user_id, admin: false, moderator: false).exists?
+    can_ignore_users? && @user.id != user_id && User.where(id: user_id, admin: false, moderator: false).exists?
   end
 
   def can_ignore_users?
-    @user.staff? || @user.trust_level >= TrustLevel.levels[:member]
+    SiteSetting.ignore_user_enabled? && (@user.staff? || @user.trust_level >= TrustLevel.levels[:member])
   end
 
   def allow_themes?(theme_ids, include_preview: false)

--- a/spec/components/guardian_spec.rb
+++ b/spec/components/guardian_spec.rb
@@ -2641,6 +2641,10 @@ describe Guardian do
   end
 
   describe '#can_ignore_user?' do
+    before do
+      SiteSetting.ignore_user_enabled = true
+    end
+
     let(:guardian) { Guardian.new(trust_level_2) }
 
     context "when ignored user is the same as guardian user" do

--- a/spec/services/user_updater_spec.rb
+++ b/spec/services/user_updater_spec.rb
@@ -19,9 +19,9 @@ describe UserUpdater do
       updater = UserUpdater.new(u3, u3)
       updater.update_muted_users("")
 
-      expect(MutedUser.where(user_id: u2.id).count).to eq 2
-      expect(MutedUser.where(user_id: u1.id).count).to eq 2
-      expect(MutedUser.where(user_id: u3.id).count).to eq 0
+      expect(MutedUser.where(user_id: u2.id).pluck(:muted_user_id)).to match_array([u3.id, u1.id])
+      expect(MutedUser.where(user_id: u1.id).pluck(:muted_user_id)).to match_array([u2.id, u3.id])
+      expect(MutedUser.where(user_id: u3.id).count).to eq(0)
     end
 
     it 'excludes acting user' do
@@ -30,7 +30,7 @@ describe UserUpdater do
       updater = UserUpdater.new(u1, u1)
       updater.update_muted_users("#{u1.username},#{u2.username}")
 
-      expect(MutedUser.where(muted_user_id: u2.id).count).to eq 1
+      expect(MutedUser.where(muted_user_id: u2.id).pluck(:muted_user_id)).to match_array([u2.id])
     end
   end
 
@@ -49,9 +49,9 @@ describe UserUpdater do
       updater = UserUpdater.new(u3, u3)
       updater.update_ignored_users("")
 
-      expect(IgnoredUser.where(user_id: u2.id).count).to eq 2
-      expect(IgnoredUser.where(user_id: u1.id).count).to eq 2
-      expect(IgnoredUser.where(user_id: u3.id).count).to eq 0
+      expect(IgnoredUser.where(user_id: u2.id).pluck(:ignored_user_id)).to match_array([u3.id, u1.id])
+      expect(IgnoredUser.where(user_id: u1.id).pluck(:ignored_user_id)).to match_array([u2.id, u3.id])
+      expect(IgnoredUser.where(user_id: u3.id).count).to eq(0)
     end
 
     it 'excludes acting user' do
@@ -60,7 +60,7 @@ describe UserUpdater do
       updater = UserUpdater.new(u1, u1)
       updater.update_ignored_users("#{u1.username},#{u2.username}")
 
-      expect(IgnoredUser.where(ignored_user_id: u2.id).count).to eq 1
+      expect(IgnoredUser.where(user_id: u1.id).pluck(:ignored_user_id)).to match_array([u2.id])
     end
 
     context 'when acting user\'s trust level is below tl2' do
@@ -70,7 +70,18 @@ describe UserUpdater do
         updater = UserUpdater.new(u1, u1)
         updater.update_ignored_users("#{u2.username}")
 
-        expect(IgnoredUser.where(ignored_user_id: u2.id).count).to eq 0
+        expect(IgnoredUser.where(ignored_user_id: u2.id).count).to eq(0)
+      end
+    end
+
+    context 'when acting user is admin' do
+      it 'excludes acting user' do
+        u1 = Fabricate(:admin)
+        u2 = Fabricate(:user)
+        updater = UserUpdater.new(u1, u1)
+        updater.update_ignored_users("#{u1.username},#{u2.username}")
+
+        expect(IgnoredUser.where(user_id: u1.id).pluck(:ignored_user_id)).to match_array([u2.id])
       end
     end
   end

--- a/spec/services/user_updater_spec.rb
+++ b/spec/services/user_updater_spec.rb
@@ -35,6 +35,10 @@ describe UserUpdater do
   end
 
   describe '#update_ignored_users' do
+    before do
+      SiteSetting.ignore_user_enabled = true
+    end
+
     it 'updates ignored users' do
       u1 = Fabricate(:user, trust_level: 2)
       u2 = Fabricate(:user, trust_level: 2)


### PR DESCRIPTION
Both: [basic_post_serializer.rb](https://github.com/discourse/discourse/blob/master/app/serializers/basic_post_serializer.rb#L48-L51) and [user_serializer.rb](https://github.com/discourse/discourse/blob/master/app/serializers/user_serializer.rb#L286-L288) can re-use the logic in guardian.

Are we happy to instantiate guardian in those serializers? and refactor accordingly?