### PR TITLE
FEATURE: Ignored user notification behaviour should be as a muted user

### DIFF
--- a/app/jobs/regular/notify_mailing_list_subscribers.rb
+++ b/app/jobs/regular/notify_mailing_list_subscribers.rb
@@ -39,6 +39,11 @@ module Jobs
                   )', post.user_id)
             .where('NOT EXISTS (
                       SELECT 1
+                      FROM ignored_users iu
+                      WHERE iu.ignored_user_id = ? AND iu.user_id = users.id
+                  )', post.user_id)
+            .where('NOT EXISTS (
+                      SELECT 1
                       FROM topic_users tu
                       WHERE tu.topic_id = ? AND tu.user_id = users.id AND tu.notification_level = ?
                   )', post.topic_id, TopicUser.notification_levels[:muted])

--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -13,8 +13,8 @@ class PostAlerter
 
   def not_allowed?(user, post)
     user.blank? ||
-      user.bot? ||
-      user.id == post.user_id
+    user.bot? ||
+    user.id == post.user_id
   end
 
   def all_allowed_users(post)
@@ -160,7 +160,7 @@ class PostAlerter
       .where('post_number > COALESCE((
                SELECT last_read_post_number FROM topic_users tu
                WHERE tu.user_id = ? AND tu.topic_id = ? ),0)',
-             user.id, topic.id)
+                user.id, topic.id)
       .where('reply_to_user_id = ? OR exists(
             SELECT 1 from topic_users tu
             WHERE tu.user_id = ? AND
@@ -220,9 +220,9 @@ class PostAlerter
     return unless stats
 
     group_id = post.topic
-                 .topic_allowed_groups
-                 .where(group_id: user.groups.pluck(:id))
-                 .pluck(:group_id).first
+      .topic_allowed_groups
+      .where(group_id: user.groups.pluck(:id))
+      .pluck(:group_id).first
 
     stat = stats.find { |s| s[:group_id] == group_id }
     return unless stat && stat[:inbox_count] > 0
@@ -293,15 +293,15 @@ class PostAlerter
 
     # apply muting here
     return if notifier_id && MutedUser.where(user_id: user.id, muted_user_id: notifier_id)
-                               .joins(:muted_user)
-                               .where('NOT admin AND NOT moderator')
-                               .exists?
+      .joins(:muted_user)
+      .where('NOT admin AND NOT moderator')
+      .exists?
 
     # apply ignored here
     return if notifier_id && IgnoredUser.where(user_id: user.id, ignored_user_id: notifier_id)
-                               .joins(:ignored_user)
-                               .where('NOT admin AND NOT moderator')
-                               .exists?
+      .joins(:ignored_user)
+      .where('NOT admin AND NOT moderator')
+      .exists?
 
     # skip if muted on the topic
     return if TopicUser.where(
@@ -321,12 +321,12 @@ class PostAlerter
 
     # Don't notify the same user about the same notification on the same post
     existing_notification = user.notifications
-                              .order("notifications.id DESC")
-                              .find_by(
-                                topic_id: post.topic_id,
-                                post_number: post.post_number,
-                                notification_type: type
-                              )
+      .order("notifications.id DESC")
+      .find_by(
+        topic_id: post.topic_id,
+        post_number: post.post_number,
+        notification_type: type
+      )
 
     return if existing_notification && !should_notify_previous?(user, existing_notification, opts)
 
@@ -336,7 +336,7 @@ class PostAlerter
       if existing_notification &&
         existing_notification.created_at > 1.day.ago &&
         (
-        user.user_option.like_notification_frequency ==
+          user.user_option.like_notification_frequency ==
           UserOption.like_notification_frequency_type[:always]
         )
 
@@ -425,13 +425,13 @@ class PostAlerter
   def create_notification_alert(user:, post:, notification_type:, excerpt: nil, username: nil)
     if post_url = post.url
       payload = {
-        notification_type: notification_type,
-        post_number: post.post_number,
-        topic_title: post.topic.title,
-        topic_id: post.topic.id,
-        excerpt: excerpt || post.excerpt(400, text_entities: true, strip_links: true, remap_emoji: true),
-        username: username || post.username,
-        post_url: post_url
+       notification_type: notification_type,
+       post_number: post.post_number,
+       topic_title: post.topic.title,
+       topic_id: post.topic.id,
+       excerpt: excerpt || post.excerpt(400, text_entities: true, strip_links: true, remap_emoji: true),
+       username: username || post.username,
+       post_url: post_url
       }
 
       MessageBus.publish("/notification-alert/#{user.id}", payload, user_ids: [user.id])
@@ -452,11 +452,11 @@ class PostAlerter
 
     if SiteSetting.allow_user_api_key_scopes.split("|").include?("push") && SiteSetting.allowed_user_api_push_urls.present?
       clients = user.user_api_keys
-                  .where("('push' = ANY(scopes) OR 'notifications' = ANY(scopes))")
-                  .where("push_url IS NOT NULL")
-                  .where("position(push_url IN ?) > 0", SiteSetting.allowed_user_api_push_urls)
-                  .where("revoked_at IS NULL")
-                  .pluck(:client_id, :push_url)
+        .where("('push' = ANY(scopes) OR 'notifications' = ANY(scopes))")
+        .where("push_url IS NOT NULL")
+        .where("position(push_url IN ?) > 0", SiteSetting.allowed_user_api_push_urls)
+        .where("revoked_at IS NULL")
+        .pluck(:client_id, :push_url)
 
       if clients.length > 0
         Jobs.enqueue(:push_notification, clients: clients, payload: payload, user_id: user.id)
@@ -602,10 +602,10 @@ class PostAlerter
     end
 
     notify = User.where(condition,
-                        watching: TopicUser.notification_levels[:watching],
-                        topic_id: post.topic_id,
-                        category_id: post.topic.category_id,
-                        tag_ids: tag_ids
+      watching: TopicUser.notification_levels[:watching],
+      topic_id: post.topic_id,
+      category_id: post.topic.category_id,
+      tag_ids: tag_ids
     )
 
     exclude_user_ids = notified.map(&:id)
@@ -653,7 +653,7 @@ class PostAlerter
         user_liked_consolidated_notification
       )
     elsif (
-    liked_by_user_notifications.count >=
+      liked_by_user_notifications.count >=
       SiteSetting.likes_notification_consolidation_threshold
     )
       return create_consolidated_liked_notification!(

--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -13,8 +13,8 @@ class PostAlerter
 
   def not_allowed?(user, post)
     user.blank? ||
-    user.bot? ||
-    user.id == post.user_id
+      user.bot? ||
+      user.id == post.user_id
   end
 
   def all_allowed_users(post)
@@ -160,7 +160,7 @@ class PostAlerter
       .where('post_number > COALESCE((
                SELECT last_read_post_number FROM topic_users tu
                WHERE tu.user_id = ? AND tu.topic_id = ? ),0)',
-                user.id, topic.id)
+             user.id, topic.id)
       .where('reply_to_user_id = ? OR exists(
             SELECT 1 from topic_users tu
             WHERE tu.user_id = ? AND
@@ -220,9 +220,9 @@ class PostAlerter
     return unless stats
 
     group_id = post.topic
-      .topic_allowed_groups
-      .where(group_id: user.groups.pluck(:id))
-      .pluck(:group_id).first
+                 .topic_allowed_groups
+                 .where(group_id: user.groups.pluck(:id))
+                 .pluck(:group_id).first
 
     stat = stats.find { |s| s[:group_id] == group_id }
     return unless stat && stat[:inbox_count] > 0
@@ -293,15 +293,15 @@ class PostAlerter
 
     # apply muting here
     return if notifier_id && MutedUser.where(user_id: user.id, muted_user_id: notifier_id)
-      .joins(:muted_user)
-      .where('NOT admin AND NOT moderator')
-      .exists?
+                               .joins(:muted_user)
+                               .where('NOT admin AND NOT moderator')
+                               .exists?
 
     # apply ignored here
     return if notifier_id && IgnoredUser.where(user_id: user.id, ignored_user_id: notifier_id)
-      .joins(:ignored_user)
-      .where('NOT admin AND NOT moderator')
-      .exists?
+                               .joins(:ignored_user)
+                               .where('NOT admin AND NOT moderator')
+                               .exists?
 
     # skip if muted on the topic
     return if TopicUser.where(
@@ -321,12 +321,12 @@ class PostAlerter
 
     # Don't notify the same user about the same notification on the same post
     existing_notification = user.notifications
-      .order("notifications.id DESC")
-      .find_by(
-        topic_id: post.topic_id,
-        post_number: post.post_number,
-        notification_type: type
-      )
+                              .order("notifications.id DESC")
+                              .find_by(
+                                topic_id: post.topic_id,
+                                post_number: post.post_number,
+                                notification_type: type
+                              )
 
     return if existing_notification && !should_notify_previous?(user, existing_notification, opts)
 
@@ -336,7 +336,7 @@ class PostAlerter
       if existing_notification &&
         existing_notification.created_at > 1.day.ago &&
         (
-          user.user_option.like_notification_frequency ==
+        user.user_option.like_notification_frequency ==
           UserOption.like_notification_frequency_type[:always]
         )
 
@@ -425,13 +425,13 @@ class PostAlerter
   def create_notification_alert(user:, post:, notification_type:, excerpt: nil, username: nil)
     if post_url = post.url
       payload = {
-       notification_type: notification_type,
-       post_number: post.post_number,
-       topic_title: post.topic.title,
-       topic_id: post.topic.id,
-       excerpt: excerpt || post.excerpt(400, text_entities: true, strip_links: true, remap_emoji: true),
-       username: username || post.username,
-       post_url: post_url
+        notification_type: notification_type,
+        post_number: post.post_number,
+        topic_title: post.topic.title,
+        topic_id: post.topic.id,
+        excerpt: excerpt || post.excerpt(400, text_entities: true, strip_links: true, remap_emoji: true),
+        username: username || post.username,
+        post_url: post_url
       }
 
       MessageBus.publish("/notification-alert/#{user.id}", payload, user_ids: [user.id])
@@ -452,11 +452,11 @@ class PostAlerter
 
     if SiteSetting.allow_user_api_key_scopes.split("|").include?("push") && SiteSetting.allowed_user_api_push_urls.present?
       clients = user.user_api_keys
-        .where("('push' = ANY(scopes) OR 'notifications' = ANY(scopes))")
-        .where("push_url IS NOT NULL")
-        .where("position(push_url IN ?) > 0", SiteSetting.allowed_user_api_push_urls)
-        .where("revoked_at IS NULL")
-        .pluck(:client_id, :push_url)
+                  .where("('push' = ANY(scopes) OR 'notifications' = ANY(scopes))")
+                  .where("push_url IS NOT NULL")
+                  .where("position(push_url IN ?) > 0", SiteSetting.allowed_user_api_push_urls)
+                  .where("revoked_at IS NULL")
+                  .pluck(:client_id, :push_url)
 
       if clients.length > 0
         Jobs.enqueue(:push_notification, clients: clients, payload: payload, user_id: user.id)
@@ -565,47 +565,47 @@ class PostAlerter
     warn_if_not_sidekiq
 
     condition = <<~SQL
-       id IN (
-         SELECT user_id
-           FROM topic_users
-          WHERE notification_level = :watching
-            AND topic_id = :topic_id
+      id IN (
+        SELECT user_id
+          FROM topic_users
+         WHERE notification_level = :watching
+           AND topic_id = :topic_id
 
-          UNION
+         UNION
 
-         SELECT cu.user_id
-           FROM category_users cu
-      LEFT JOIN topic_users tu ON tu.user_id = cu.user_id
-                              AND tu.topic_id = :topic_id
-          WHERE cu.notification_level = :watching
-            AND cu.category_id = :category_id
-            AND tu.user_id IS NULL
+        SELECT cu.user_id
+          FROM category_users cu
+     LEFT JOIN topic_users tu ON tu.user_id = cu.user_id
+                             AND tu.topic_id = :topic_id
+         WHERE cu.notification_level = :watching
+           AND cu.category_id = :category_id
+           AND tu.user_id IS NULL
 
-         /*tags*/
-       )
+        /*tags*/
+      )
     SQL
 
     tag_ids = post.topic.topic_tags.pluck('topic_tags.tag_id')
 
     if tag_ids.present?
       condition.sub! "/*tags*/", <<~SQL
-           UNION
+        UNION
 
-           SELECT tag_users.user_id
-             FROM tag_users
-        LEFT JOIN topic_users tu ON tu.user_id = tag_users.user_id
-                                AND tu.topic_id = :topic_id
-            WHERE tag_users.notification_level = :watching
-              AND tag_users.tag_id IN (:tag_ids)
-              AND tu.user_id IS NULL
+        SELECT tag_users.user_id
+          FROM tag_users
+     LEFT JOIN topic_users tu ON tu.user_id = tag_users.user_id
+                             AND tu.topic_id = :topic_id
+         WHERE tag_users.notification_level = :watching
+           AND tag_users.tag_id IN (:tag_ids)
+           AND tu.user_id IS NULL
       SQL
     end
 
     notify = User.where(condition,
-      watching: TopicUser.notification_levels[:watching],
-      topic_id: post.topic_id,
-      category_id: post.topic.category_id,
-      tag_ids: tag_ids
+                        watching: TopicUser.notification_levels[:watching],
+                        topic_id: post.topic_id,
+                        category_id: post.topic.category_id,
+                        tag_ids: tag_ids
     )
 
     exclude_user_ids = notified.map(&:id)
@@ -653,7 +653,7 @@ class PostAlerter
         user_liked_consolidated_notification
       )
     elsif (
-      liked_by_user_notifications.count >=
+    liked_by_user_notifications.count >=
       SiteSetting.likes_notification_consolidation_threshold
     )
       return create_consolidated_liked_notification!(

--- a/lib/post_creator.rb
+++ b/lib/post_creator.rb
@@ -115,10 +115,12 @@ class PostCreator
       User
         .joins("LEFT JOIN user_options ON user_options.user_id = users.id")
         .joins("LEFT JOIN muted_users ON muted_users.user_id = users.id AND muted_users.muted_user_id = #{@user.id.to_i}")
+        .joins("LEFT JOIN ignored_users ON ignored_users.user_id = users.id AND ignored_users.ignored_user_id = #{@user.id.to_i}")
         .where("user_options.user_id IS NOT NULL")
         .where("
           (user_options.user_id IN (:user_ids) AND NOT user_options.allow_private_messages) OR
-          muted_users.user_id IN (:user_ids)
+          muted_users.user_id IN (:user_ids) OR
+          ignored_users.user_id IN (:user_ids)
         ", user_ids: users.keys)
         .pluck(:id).each do |m|
 

--- a/spec/jobs/notify_mailing_list_subscribers_spec.rb
+++ b/spec/jobs/notify_mailing_list_subscribers_spec.rb
@@ -108,6 +108,12 @@ describe Jobs::NotifyMailingListSubscribers do
         include_examples "no emails"
       end
 
+      context "from an ignored user" do
+        before { Fabricate(:ignored_user, user: mailing_list_user, ignored_user: user) }
+        include_examples "no emails"
+      end
+
+
       context "from a muted topic" do
         before { TopicUser.create(user: mailing_list_user, topic: post.topic, notification_level: TopicUser.notification_levels[:muted]) }
         include_examples "no emails"

--- a/spec/jobs/notify_mailing_list_subscribers_spec.rb
+++ b/spec/jobs/notify_mailing_list_subscribers_spec.rb
@@ -113,7 +113,6 @@ describe Jobs::NotifyMailingListSubscribers do
         include_examples "no emails"
       end
 
-
       context "from a muted topic" do
         before { TopicUser.create(user: mailing_list_user, topic: post.topic, notification_level: TopicUser.notification_levels[:muted]) }
         include_examples "no emails"

--- a/spec/services/post_alerter_spec.rb
+++ b/spec/services/post_alerter_spec.rb
@@ -171,6 +171,15 @@ describe PostAlerter do
       }.to change(evil_trout.notifications, :count).by(0)
     end
 
+    it 'does not notify for ignored users' do
+      post = Fabricate(:post, raw: '[quote="EvilTrout, post:1"]whatup[/quote]')
+      IgnoredUser.create!(user_id: evil_trout.id, ignored_user_id: post.user_id)
+
+      expect {
+        PostAlerter.post_created(post)
+      }.to change(evil_trout.notifications, :count).by(0)
+    end
+
     it 'notifies a user by username' do
       topic = Fabricate(:topic)
 


### PR DESCRIPTION
## Why?

This is part of the [Ability to ignore a user feature](https://meta.discourse.org/t/ability-to-ignore-a-user/110254/8).

If we ignore a user, either from the preferences or user summary or API , the ignored user notification rules should be the same as a muted user.

## UI

Teddy (current user) was ignored by Tarek, and therefore Teddy can NOT send a message to Tarek.

![65ZrFt9LAD](https://user-images.githubusercontent.com/45508821/54742625-d8cf2d80-4bb9-11e9-80b8-e0798bb52f94.gif)
