### PR TITLE
FEATURE: Include muted users count within the ignored users report

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -1612,7 +1612,7 @@ class Report
           WHERE created_at >= '#{report.start_date}' AND created_at <= '#{report.end_date}'
           GROUP BY ignored_user_id
           ORDER BY COUNT(*) DESC
-          LIMIT #{report.limit || 250}
+          LIMIT :limit
         ),
         muted_users AS (
           SELECT
@@ -1622,7 +1622,7 @@ class Report
           WHERE created_at >= '#{report.start_date}' AND created_at <= '#{report.end_date}'
           GROUP BY muted_user_id
           ORDER BY COUNT(*) DESC
-          LIMIT #{report.limit || 250}
+          LIMIT :limit
         )
 
         SELECT u.id as user_id,
@@ -1637,7 +1637,7 @@ class Report
         ORDER BY total DESC
     SQL
 
-    DB.query(sql).each do |row|
+    DB.query(sql, limit: report.limit || 250).each do |row|
       report.data << {
         ignored_user_id: row.user_id,
         ignored_username: row.username,

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1234,6 +1234,7 @@ en:
       labels:
         ignored_user: Ignored User
         ignores_count: Ignores count
+        mutes_count: Mutes count
       description: "List top ignored users."
 
   dashboard:

--- a/spec/fabricators/muted_user.rb
+++ b/spec/fabricators/muted_user.rb
@@ -1,0 +1,3 @@
+Fabricator(:muted_user) do
+  user
+end

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -1108,15 +1108,29 @@ describe Report do
 
       it "works" do
         expect(report.data.length).to eq(2)
-        expect_row_to_be_equal(report.data[0], john)
-        expect_row_to_be_equal(report.data[1], matt)
+        expect_row_to_be_equal(report.data[0], john, 1, 0)
+        expect_row_to_be_equal(report.data[1], matt, 1, 0)
       end
 
-      def expect_row_to_be_equal(row, user)
+      def expect_row_to_be_equal(row, user, ignores, mutes)
         expect(row[:ignored_user_id]).to eq(user.id)
         expect(row[:ignored_username]).to eq(user.username)
         expect(row[:ignored_user_avatar_template]).to eq(User.avatar_template(user.username, user.uploaded_avatar_id))
-        expect(row[:ignores_count]).to eq(1)
+        expect(row[:ignores_count]).to eq(ignores)
+        expect(row[:mutes_count]).to eq(mutes)
+      end
+
+      context "when muted users exist" do
+        before do
+          Fabricate(:muted_user, user: tarek, muted_user: john)
+          Fabricate(:muted_user, user: tarek, muted_user: matt)
+        end
+
+        it "works" do
+          expect(report.data.length).to eq(2)
+          expect_row_to_be_equal(report.data[0], john, 1, 1)
+          expect_row_to_be_equal(report.data[1], matt, 1, 1)
+        end
       end
     end
 


### PR DESCRIPTION
## Why?

This is part of the [Ability to ignore a user feature](https://meta.discourse.org/t/ability-to-ignore-a-user/110254/8).

We want to add include the muted users count in the ignored users report.
We will also order by the `SUM(Ignored Users + Muted Users)`.

## UI

![Admin_-_Discourse](https://user-images.githubusercontent.com/45508821/54746932-62d0c380-4bc5-11e9-8eb9-6f82fe861ca7.png)
