### PR TITLE
Fix spelling error

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4231,7 +4231,7 @@ en:
       reseed:
         action:
           label: "Replace Text…"
-          title: "Replace text of catgegories and topics with translations"
+          title: "Replace text of categories and topics with translations"
 
         modal:
           title: "Replace Text"


### PR DESCRIPTION
This commit fixes an ii8n spelling error introduced by commit 41c74239852b2edfd50524a1bb98a052a054ecdb