### PR TITLE
FIX: Clear unsaved groups when switching user

### DIFF
--- a/app/assets/javascripts/admin/routes/admin-user-index.js.es6
+++ b/app/assets/javascripts/admin/routes/admin-user-index.js.es6
@@ -19,6 +19,7 @@ export default Discourse.Route.extend({
     controller.setProperties({
       originalPrimaryGroupId: model.get("primary_group_id"),
       availableGroups: this._availableGroups,
+      customGroupIdsBuffer: null,
       model
     });
   }

--- a/test/javascripts/helpers/create-pretender.js.es6
+++ b/test/javascripts/helpers/create-pretender.js.es6
@@ -528,6 +528,14 @@ export default function() {
       });
     });
 
+    this.get("/admin/users/1.json", () => {
+      return response(200, {
+        id: 1,
+        username: "eviltrout",
+        admin: true
+      });
+    });
+
     this.get("/admin/users/2.json", () => {
       return response(200, {
         id: 2,


### PR DESCRIPTION
This clears unsaved groups when admin switches to another user without saving.

Resolves: https://meta.discourse.org/t/admin-user-group-membership-edition-persists-between-users/112239

Didn't write a test for it since I didn't find any acceptance tests for custom groups. Just tell me when I should write some.