### PR TITLE
FEATURE: Improve avatar education link

### DIFF
--- a/app/assets/javascripts/discourse/templates/preferences/account.hbs
+++ b/app/assets/javascripts/discourse/templates/preferences/account.hbs
@@ -143,7 +143,7 @@
 
 {{#unless siteSettings.sso_overrides_avatar}}
   <div class="control-group pref-avatar">
-    <label class="control-label">{{i18n 'user.avatar.title'}}</label>
+    <label class="control-label" id="profile-picture">{{i18n 'user.avatar.title'}}</label>
     <div class="controls">
       {{! we want the "huge" version even though we're downsizing it in CSS }}
       {{bound-avatar model "huge"}}

--- a/lib/composer_messages_finder.rb
+++ b/lib/composer_messages_finder.rb
@@ -85,7 +85,7 @@ class ComposerMessagesFinder
     {
       id: 'avatar',
       templateName: 'education',
-      body: PrettyText.cook(I18n.t('education.avatar', profile_path: "/u/#{@user.username_lower}"))
+      body: PrettyText.cook(I18n.t('education.avatar', profile_path: "/u/#{@user.username_lower}/preferences/account#profile-picture"))
     }
   end
 


### PR DESCRIPTION
The avatar education message currently links to the base user user profile. Given this would be presented to a new user, it seems like it would be better to point them closer to the actual setting.