### PR TITLE
Feature: all filter for reviewables

### DIFF
--- a/app/assets/javascripts/discourse/controllers/review-index.js.es6
+++ b/app/assets/javascripts/discourse/controllers/review-index.js.es6
@@ -30,7 +30,7 @@ export default Ember.Controller.extend({
 
   @computed
   statuses() {
-    return ["pending", "approved", "rejected", "ignored", "reviewed"].map(
+    return ["pending", "approved", "rejected", "ignored", "reviewed", "all"].map(
       id => {
         return { id, name: I18n.t(`review.statuses.${id}.title`) };
       }

--- a/app/assets/javascripts/discourse/templates/user.hbs
+++ b/app/assets/javascripts/discourse/templates/user.hbs
@@ -10,7 +10,7 @@
           {{/if}}
           {{#if model.number_of_flagged_posts}}
             <div>
-              {{#link-to 'review' (query-params target_created_by_id=model.id status='reviewed')}}
+              {{#link-to 'review' (query-params target_created_by_id=model.id status='all' type='ReviewableFlaggedPost')}}
                 <span class="flagged-posts">{{model.number_of_flagged_posts}}</span>{{i18n 'user.staff_counters.flagged_posts'}}
               {{/link-to}} 
             </div>

--- a/app/controllers/reviewables_controller.rb
+++ b/app/controllers/reviewables_controller.rb
@@ -151,7 +151,7 @@ protected
   end
 
   def allowed_statuses
-    @allowed_statuses ||= ([:reviewed] + Reviewable.statuses.keys)
+    @allowed_statuses ||= (%i[reviewed all] + Reviewable.statuses.keys)
   end
 
   def version_required

--- a/app/models/reviewable.rb
+++ b/app/models/reviewable.rb
@@ -278,11 +278,7 @@ class Reviewable < ActiveRecord::Base
     return [] if user.blank?
     result = viewable_by(user, order: order)
 
-    if status == :reviewed
-      result = result.where(status: [statuses[:approved], statuses[:rejected], statuses[:ignored]])
-    else
-      result = result.where(status: statuses[status])
-    end
+    result = by_status(result, status)
     result = result.where(type: type) if type
     result = result.where(category_id: category_id) if category_id
     result = result.where(topic_id: topic_id) if topic_id
@@ -380,6 +376,16 @@ protected
       self.version = version_result[0]
     else
       raise UpdateConflict.new
+    end
+  end
+
+  def self.by_status(partial_result, status)
+    return partial_result if status == :all
+
+    if status == :reviewed
+      partial_result.where(status: [statuses[:approved], statuses[:rejected], statuses[:ignored]])
+    else
+      partial_result.where(status: statuses[status])
     end
   end
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -410,6 +410,8 @@ en:
           title: "Ignored"
         reviewed:
           title: "(All Reviewed)"
+        all:
+          title: "(Everything)"
 
       types:
         reviewable_flagged_post:

--- a/spec/models/reviewable_spec.rb
+++ b/spec/models/reviewable_spec.rb
@@ -107,29 +107,38 @@ RSpec.describe Reviewable, type: :model do
         expect(Reviewable.list_for(user, status: :pending)).to eq([reviewable])
       end
 
-      it 'Let us filter by the target_created_by_id attribute' do
-        user.update_columns(moderator: false, admin: true)
-        different_user_reviewable = Fabricate(:reviewable)
+      context 'Reviewing as an admin' do
+        before { user.update_columns(moderator: false, admin: true) }
 
-        reviewables = Reviewable.list_for(
-          user, target_created_by_id: different_user_reviewable.target_created_by_id
-        )
+        it 'Let us filter by the target_created_by_id attribute' do
+          different_user_reviewable = Fabricate(:reviewable)
 
-        expect(reviewables).to match_array [different_user_reviewable]
+          reviewables = Reviewable.list_for(
+            user, target_created_by_id: different_user_reviewable.target_created_by_id
+          )
+
+          expect(reviewables).to match_array [different_user_reviewable]
+        end
+
+        it 'Excludes reviewable that do not match with the created_by_id' do
+          unknown_target_created_by_id = -99
+          filtered_reviewable = reviewable
+
+          reviewables = Reviewable.list_for(
+            user, target_created_by_id: unknown_target_created_by_id
+          )
+
+          expect(reviewables).not_to include filtered_reviewable
+        end
+
+        it 'Does not filter by status when status parameter is set to all' do
+          rejected_reviewable = Fabricate(:reviewable, target: post, status: Reviewable.statuses[:rejected])
+
+          reviewables = Reviewable.list_for(user, status: :all)
+
+          expect(reviewables).to match_array [reviewable, rejected_reviewable]
+        end
       end
-
-      it 'Excludes reviewable that do not match with the created_by_id' do
-        user.update_columns(moderator: false, admin: true)
-        unknown_target_created_by_id = -99
-        filtered_reviewable = reviewable
-
-        reviewables = Reviewable.list_for(
-          user, target_created_by_id: unknown_target_created_by_id
-        )
-
-        expect(reviewables).not_to include filtered_reviewable
-      end
-
     end
 
     context "with a category restriction" do

--- a/spec/requests/reviewables_controller_spec.rb
+++ b/spec/requests/reviewables_controller_spec.rb
@@ -96,6 +96,10 @@ describe ReviewablesController do
         json = ::JSON.parse(response.body)
         expect(json['reviewables']).to be_present
 
+        get "/review.json?type=ReviewableUser&status=all"
+        expect(response.code).to eq("200")
+        json = ::JSON.parse(response.body)
+        expect(json['reviewables']).to be_present
       end
 
       it "raises an error with an invalid status" do


### PR DESCRIPTION
### Changes

- Added new `all` status filter to show everything.
- Clicking on user's flagged posts now uses the `all` filter.
- Clicking on user's flagged posts now only shows `ReviewableFlaggedPost`.