### PR TITLE
FIX: Onebox discourse user not respecting enable names

### DIFF
--- a/lib/oneboxer.rb
+++ b/lib/oneboxer.rb
@@ -234,11 +234,14 @@ module Oneboxer
     username = route[:username] || ""
 
     if user = User.find_by(username_lower: username.downcase)
+
+      name = user.name if SiteSetting.enable_names
+
       args = {
         user_id: user.id,
         username: user.username,
         avatar: PrettyText.avatar_img(user.avatar_template, "extra_large"),
-        name: user.name,
+        name: name,
         bio: user.user_profile.bio_excerpt(230),
         location: user.user_profile.location,
         joined: I18n.t('joined'),

--- a/spec/components/oneboxer_spec.rb
+++ b/spec/components/oneboxer_spec.rb
@@ -94,6 +94,15 @@ describe Oneboxer do
       expect(preview("/u/#{user.username}")).to include(user.name)
     end
 
+    it "should respect enable_names site setting" do
+      user = Fabricate(:user)
+
+      SiteSetting.enable_names = true
+      expect(preview("/u/#{user.username}")).to include(user.name)
+      SiteSetting.enable_names = false
+      expect(preview("/u/#{user.username}")).not_to include(user.name)
+    end
+
     it "links to an upload" do
       path = "/uploads/default/original/3X/e/8/e8fcfa624e4fb6623eea57f54941a58ba797f14d"
 


### PR DESCRIPTION
This fixes a bug in which the onebox preview of a discourse user displays the user's real name even if the `enable names` site setting is set to false.

Resolves: https://meta.discourse.org/t/users-full-name-are-shown-in-preview-even-with-enable-names-off/112386