### PR TITLE
FIX: Re-download hotlinked optimized images

### DIFF
--- a/app/jobs/regular/pull_hotlinked_images.rb
+++ b/app/jobs/regular/pull_hotlinked_images.rb
@@ -35,8 +35,6 @@ module Jobs
     end
 
     def execute(args)
-      return unless SiteSetting.download_remote_images_to_local?
-
       post_id = args[:post_id]
       raise Discourse::InvalidParameters.new(:post_id) unless post_id.present?
 
@@ -148,6 +146,9 @@ module Jobs
         # Return true if we can't find the upload in the db
         return !Upload.get_from_url(src)
       end
+
+      # Don't download non-local images unless site setting enabled
+      return false unless SiteSetting.download_remote_images_to_local?
 
       # parse the src
       begin

--- a/app/jobs/regular/pull_hotlinked_images.rb
+++ b/app/jobs/regular/pull_hotlinked_images.rb
@@ -60,7 +60,7 @@ module Jobs
         src = original_src = image['src']
         src = "#{SiteSetting.force_https ? "https" : "http"}:#{src}" if src.start_with?("//")
 
-        if is_valid_image_url(src)
+        if should_download_image?(src)
           begin
             # have we already downloaded that file?
             schemeless_src = remove_scheme(original_src)
@@ -136,16 +136,18 @@ module Jobs
 
     def extract_images_from(html)
       doc = Nokogiri::HTML::fragment(html)
-      doc.css("img[src]") - doc.css("img.avatar")
+      doc.css("img[src]") - doc.css("img.avatar") - doc.css(".lightbox img[src]")
     end
 
-    def is_valid_image_url(src)
+    def should_download_image?(src)
       # make sure we actually have a url
       return false unless src.present?
-      # we don't want to pull uploaded images
-      return false if Discourse.store.has_been_uploaded?(src)
-      # we don't want to pull relative images
-      return false if src =~ /\A\/[^\/]/i
+
+      # If file is on the forum or CDN domain
+      if Discourse.store.has_been_uploaded?(src) || src =~ /\A\/[^\/]/i
+        # Return true if we can't find the upload in the db
+        return !Upload.get_from_url(src)
+      end
 
       # parse the src
       begin
@@ -157,11 +159,6 @@ module Jobs
       hostname = uri.hostname
       return false unless hostname
 
-      # we don't want to pull images hosted on the CDN (if we use one)
-      return false if Discourse.asset_host.present? && URI.parse(Discourse.asset_host).hostname == hostname
-      return false if SiteSetting.Upload.s3_cdn_url.present? && URI.parse(SiteSetting.Upload.s3_cdn_url).hostname == hostname
-      # we don't want to pull images hosted on the main domain
-      return false if URI.parse(Discourse.base_url_no_prefix).hostname == hostname
       # check the domains blacklist
       SiteSetting.should_download_images?(src)
     end

--- a/spec/jobs/pull_hotlinked_images_spec.rb
+++ b/spec/jobs/pull_hotlinked_images_spec.rb
@@ -151,6 +151,21 @@ describe Jobs::PullHotlinkedImages do
         expect(subject.should_download_image?(src)).to eq(true)
       end
     end
+
+    context "when download_remote_images_to_local? is false" do
+      before do
+        SiteSetting.download_remote_images_to_local = false
+      end
+
+      it "still returns true for optimized" do
+        src = Discourse.store.get_path_for_optimized_image(Fabricate(:optimized_image))
+        expect(subject.should_download_image?(src)).to eq(true)
+      end
+
+      it 'returns false for valid remote URLs' do
+        expect(subject.should_download_image?("http://meta.discourse.org")).to eq(false)
+      end
+    end
   end
 
   describe "with a lightboxed image" do


### PR DESCRIPTION
Previously, it would never try and download images from the forum/CDN domain. Now, it will download **any** images which are not found in the uploads table. That includes
- Optimized images which have been copied from elsewhere

- "Original" image URLs copied from another hosted site on the same CDN domain

- "Original" images which have somehow dissappeared from the database, but are still available on the CDN.