### PR TITLE
Bump logster to 2.3.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -186,7 +186,7 @@ GEM
     logstash-event (1.2.02)
     logstash-logger (0.26.1)
       logstash-event (~> 1.2)
-    logster (2.2.0)
+    logster (2.3.0)
     loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)


### PR DESCRIPTION
Introduces a new feature that keeps track of number of logs that have been suppressed by each pattern. 

![image](https://user-images.githubusercontent.com/17474474/54972259-e3b00680-4f9b-11e9-96cd-e2c12d2c239f.png)

https://github.com/discourse/logster/commit/d3146c0fe11b6a277062b8e021550e617701fea5