### PR TITLE
FIX: Staff action records now also accepts action_name as filter

### DIFF
--- a/app/models/user_history.rb
+++ b/app/models/user_history.rb
@@ -193,11 +193,12 @@ class UserHistory < ActiveRecord::Base
   end
 
   def self.staff_filters
-    [:action_id, :custom_type, :acting_user, :target_user, :subject]
+    [:action_id, :custom_type, :acting_user, :target_user, :subject, :action_name]
   end
 
   def self.staff_action_records(viewer, opts = nil)
     opts ||= {}
+    opts[:action_id] = self.actions[opts[:action_name].to_sym] if opts[:action_name]
     query = self.with_filters(opts.slice(*staff_filters)).only_staff_actions.limit(200).order('id DESC').includes(:acting_user, :target_user)
     query = query.where(admin_only: false) unless viewer && viewer.admin?
     query

--- a/spec/models/user_history_spec.rb
+++ b/spec/models/user_history_spec.rb
@@ -36,13 +36,13 @@ describe UserHistory do
       end
 
       it 'filters by action' do
-        records = described_class.staff_action_records(Fabricate(:admin), {action: @change_site_setting.id}).to_a
+        records = described_class.staff_action_records(Fabricate(:admin), action_id: @change_site_setting.action_before_type_cast).to_a
         expect(records.size).to eq(1)
         expect(records.first).to eq(@change_site_setting)
       end
 
       it 'filters by action_name' do
-        records = described_class.staff_action_records(Fabricate(:admin), {action_name: "change_site_setting"}).to_a
+        records = described_class.staff_action_records(Fabricate(:admin), action_name: "change_site_setting").to_a
         expect(records.size).to eq(1)
         expect(records.first).to eq(@change_site_setting)
       end

--- a/spec/models/user_history_spec.rb
+++ b/spec/models/user_history_spec.rb
@@ -34,6 +34,18 @@ describe UserHistory do
         records = described_class.staff_action_records(Fabricate(:moderator)).to_a
         expect(records).to eq([@change_trust_level])
       end
+
+      it 'filters by action' do
+        records = described_class.staff_action_records(Fabricate(:admin), {action: @change_site_setting.id}).to_a
+        expect(records.size).to eq(1)
+        expect(records.first).to eq(@change_site_setting)
+      end
+
+      it 'filters by action_name' do
+        records = described_class.staff_action_records(Fabricate(:admin), {action_name: "change_site_setting"}).to_a
+        expect(records.size).to eq(1)
+        expect(records.first).to eq(@change_site_setting)
+      end
     end
   end
 


### PR DESCRIPTION
Staff action records now also accepts action_name as filter, since this was necessary for pre-filled filters like

```
showSuspensions() {
  this.get("adminTools").showActionLogs(this, {
    target_user: this.get("model.username"),
    action_name: "suspend_user"
  });
},
```

where we want to filter by an `action_name` but don't know its associated enum id, which was required for the filters to work.

Resolves: https://meta.discourse.org/t/link-to-filtered-list-from-user-profile-suspensions-link/112568