### PR TITLE
UX: better way to hide header icons if title is visible on mobile

### DIFF
--- a/app/assets/stylesheets/mobile/header.scss
+++ b/app/assets/stylesheets/mobile/header.scss
@@ -52,10 +52,8 @@
 
   // Hide header avatar + icons while topic title is visible in mobile header
   .extra-info-wrapper + .panel {
-    flex: 0;
-    min-width: 0;
     .header-buttons,
-    .badge-notification {
+    .d-header-icons {
       display: none;
     }
   }


### PR DESCRIPTION
This is a followup to the following commits

6d7c0c8f137bf1c4968e8777c7694fd2c1b7b392
533fb0019ab7c0520a57dbd8055a4b323b4be026
ac4470cd561bfc42869690a91e819149fa9c0fff

When the mobile header title is visible, we want to hide icons, buttons and avatar in the header to give more space for the title to expand.

If we use `display: none` on `.panel` an issue will occur since both the hamburger and user menus are children of `.panel` - this means the would inherit that property.

That causes a problem on android if the user swipes right / left to bring these menus. The menus would be hidden and the user would be stuck.

CSS does not allow for visible children under a hidden parent - at least when using the display property.

The previous implementation relied on the flex property to "shrink" the panel if the the title is visible. This worked but was not ideal. Sometimes the notification badges would still be visible at the very edge of the screen. Other times the login button would be visible.

<img src="https://user-images.githubusercontent.com/33972521/54613578-e4293880-4a95-11e9-812b-19bfb257abde.png" width="250">

<img src="https://user-images.githubusercontent.com/33972521/54625429-43914380-4aaa-11e9-9788-c4068bd139d0.png" width="250">

This PR addresses this issue by targeting `.d-header-icons` and `.header-buttons` instead of targeting the `.panel` div. This ensures that the icons, buttons and avatar are hidden whilst not affecting the hamburger / user menus. 