### PR TITLE
UX: prevent images and lightboxes from extending outside blockquotes

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -203,6 +203,15 @@ aside.quote {
   }
 }
 
+blockquote {
+  // due to #image-sizing-hack large images and lightboxes extend past the
+  // limits blockquotes. Since #image-sizing-hack is inline, we need to use
+  // !important here otherwise it won't work.
+  img {
+    max-width: 100% !important;
+  }
+}
+
 .quote-controls,
 .quote-controls .d-icon {
   color: dark-light-choose($primary-low-mid, $secondary-high);


### PR DESCRIPTION
Large images and lightboxes in blockquotes sometimes extend outside of the boundaries of their parent element.

![images1](https://user-images.githubusercontent.com/33972521/55017876-a47dc600-502c-11e9-9581-696ba8e0eb61.png)

This occurs because we set the `max-width` on these images in 

https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/initializers/ensure-max-image-dimensions.js.es6

While that works for images that are direct children of `.cooked` the added padding and margins for blockquotes are not factored in that calcualtion. So the `max-width` we set ends up being wider than the blockquote. 

Since the calculated width for images - added by the initializer above - is added inline, we need to use `!important` here to override it for image in blockquotes.

![images2](https://user-images.githubusercontent.com/33972521/55018111-2241d180-502d-11e9-8851-b3ef32a3330f.png)
  