### PR TITLE
FEATURE: change layout when default page is category to tabular for _…

### DIFF
--- a/app/assets/stylesheets/desktop/category-list.scss
+++ b/app/assets/stylesheets/desktop/category-list.scss
@@ -109,6 +109,14 @@
     .latest {
       padding: 0 0 10px 10px;
     }
+
+    .blue-border {
+      border-color: #0088cc;
+    }
+
+    .grey-border {
+      border-color: #808281;
+    }
   }
 }
 

--- a/app/assets/stylesheets/desktop/category-list.scss
+++ b/app/assets/stylesheets/desktop/category-list.scss
@@ -110,12 +110,12 @@
       padding: 0 0 10px 10px;
     }
 
-    .blue-border {
-      border-color: #0088cc;
+    .secondary-border {
+      border-color: $secondary-high;
     }
 
-    .grey-border {
-      border-color: #808281;
+    .primary-border {
+      border-color: $primary-high;
     }
   }
 }

--- a/app/assets/stylesheets/desktop/category-list.scss
+++ b/app/assets/stylesheets/desktop/category-list.scss
@@ -109,14 +109,6 @@
     .latest {
       padding: 0 0 10px 10px;
     }
-
-    tr:nth-child(odd) {
-      border-color: $secondary-high;
-    }
-
-    tr:nth-child(even) {
-      border-color: $primary-high;
-    }
   }
 }
 

--- a/app/assets/stylesheets/desktop/category-list.scss
+++ b/app/assets/stylesheets/desktop/category-list.scss
@@ -110,11 +110,11 @@
       padding: 0 0 10px 10px;
     }
 
-    .secondary-border {
+    tr:nth-child(odd) {
       border-color: $secondary-high;
     }
 
-    .primary-border {
+    tr:nth-child(even) {
       border-color: $primary-high;
     }
   }

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -9,8 +9,8 @@
     <tbody>
       <meta itemprop='itemListOrder' content='http://schema.org/ItemListOrderDescending'>
       <% @category_list.categories.each_with_index do |c, index| %>
-        <tr>
-          <td class='category <%= index % 2 == 0 ? 'secondary-border' : 'primary-border' %>'>
+        <tr class='category'>
+          <td>
             <div itemprop='itemListElement' itemscope itemtype='http://schema.org/ListItem'>
               <meta itemprop='position' content='<%= index %>'>
               <meta itemprop='url' content='<%= "#{c.url}" %>'>

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -10,7 +10,7 @@
       <meta itemprop='itemListOrder' content='http://schema.org/ItemListOrderDescending'>
       <% @category_list.categories.each_with_index do |c, index| %>
         <tr>
-          <td class='category <%= index % 2 == 0 ? 'blue-border' : 'grey-border' %>'>
+          <td class='category <%= index % 2 == 0 ? 'secondary-border' : 'primary-border' %>'>
             <div itemprop='itemListElement' itemscope itemtype='http://schema.org/ListItem'>
               <meta itemprop='position' content='<%= index %>'>
               <meta itemprop='url' content='<%= "#{c.url}" %>'>

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -10,7 +10,7 @@
       <meta itemprop='itemListOrder' content='http://schema.org/ItemListOrderDescending'>
       <% @category_list.categories.each_with_index do |c, index| %>
         <tr>
-          <td class='category' style='border-color:<%= index % 2 == 0 ? '#0088CC' : '#808281' %>'>
+          <td class='category <%= index % 2 == 0 ? 'blue-border' : 'grey-border' %>'>
             <div itemprop='itemListElement' itemscope itemtype='http://schema.org/ListItem'>
               <meta itemprop='position' content='<%= index %>'>
               <meta itemprop='url' content='<%= "#{c.url}" %>'>

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -9,8 +9,8 @@
     <tbody>
       <meta itemprop='itemListOrder' content='http://schema.org/ItemListOrderDescending'>
       <% @category_list.categories.each_with_index do |c, index| %>
-        <tr class='category'>
-          <td>
+        <tr>
+          <td class='category' style='border-color: #<%= c.color %>;'>
             <div itemprop='itemListElement' itemscope itemtype='http://schema.org/ListItem'>
               <meta itemprop='position' content='<%= index %>'>
               <meta itemprop='url' content='<%= "#{c.url}" %>'>

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -1,17 +1,34 @@
-<div class='category-list' itemscope itemtype='http://schema.org/ItemList'>
-  <meta itemprop='itemListOrder' content='http://schema.org/ItemListOrderDescending'>
-  <% @category_list.categories.each_with_index do |c, index| %>
-    <div class='category' itemprop='itemListElement' itemscope itemtype='http://schema.org/ListItem'>
-      <meta itemprop='position' content='<%= index %>'>
-      <meta itemprop='url' content='<%= "#{c.url}" %>'>
-      <h2>
-        <a href='<%= "#{c.url}" %>' itemprop='item'>
-          <span itemprop='name'><%= c.name %></span>
-        </a>
-      </h2>
-      <span itemprop='description'><%= c.description&.html_safe %></span>
-    </div>
-  <% end %>
+<div itemscope itemtype='http://schema.org/ItemList'>
+  <table class='category-list'>
+    <thead>
+      <tr>
+        <th class='category'><%= t 'js.categories.category' %></th>
+        <th class='topics'><%= t 'js.topic.list' %></th>
+      </tr>
+    </thead>
+    <tbody>
+      <meta itemprop='itemListOrder' content='http://schema.org/ItemListOrderDescending'>
+      <% @category_list.categories.each_with_index do |c, index| %>
+        <tr>
+          <td class='category' style='border-color:<%= index % 2 == 0 ? '#0088CC' : '#808281' %>'>
+            <div itemprop='itemListElement' itemscope itemtype='http://schema.org/ListItem'>
+              <meta itemprop='position' content='<%= index %>'>
+              <meta itemprop='url' content='<%= "#{c.url}" %>'>
+              <h3>
+                <a href='<%= "#{c.url}" %>'>
+                  <span itemprop='name'><%= c.name %></span>
+                </a>
+              </h3>
+              <div itemprop='description'><%= c.description&.html_safe %></div>
+            </div>
+          </td>
+          <td class='topics'>
+            <div title='<%= "#{c.topic_count}" %> <%= t 'js.topic.list' %>'><%= c.topic_count %></div>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
 </div>
 
 <% content_for :title do %><%= @title %><% end %>

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -13,9 +13,9 @@
           <td class='category' style='border-color: #<%= c.color %>;'>
             <div itemprop='itemListElement' itemscope itemtype='http://schema.org/ListItem'>
               <meta itemprop='position' content='<%= index %>'>
-              <meta itemprop='url' content='<%= "#{c.url}" %>'>
+              <meta itemprop='url' content='<%= c.url %>'>
               <h3>
-                <a href='<%= "#{c.url}" %>'>
+                <a href='<%= c.url %>'>
                   <span itemprop='name'><%= c.name %></span>
                 </a>
               </h3>
@@ -23,7 +23,7 @@
             </div>
           </td>
           <td class='topics'>
-            <div title='<%= "#{c.topic_count}" %> <%= t 'js.topic.list' %>'><%= c.topic_count %></div>
+            <div title='<%= c.topic_count %> <%= t 'js.topic.list' %>'><%= c.topic_count %></div>
           </td>
         </tr>
       <% end %>


### PR DESCRIPTION
…escaped_fragment_ page

This is a part of https://meta.discourse.org/t/improving-discourse-static-html-archive/112497

The old layout can be viewed at https://meta.discourse.org/categories/?_escaped_fragment_

I have removed `itemprop='item'` since it was not needed (all information is provided in ListItem already) and was showing up as an error here: https://search.google.com/structured-data/testing-tool/u/0/#url=https%3A%2F%2Fmeta.discourse.org%2Fcategories%2F%3F_escaped_fragment_

Attaching screenshot with the new layout.

![Screenshot from 2019-03-27 22-24-51](https://user-images.githubusercontent.com/6376157/55096479-064b3800-50e0-11e9-9e15-efbcea45d14c.png)
