### PR TITLE
DEV: Add vagrant directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,6 @@ vendor/bundle/*
 /package-lock.json
 
 /vendor/data/GeoLite2-City.mmdb
+
+# Vagrant
+.vagrant


### PR DESCRIPTION
This adds the vagrant directory to the gitignore. Currently I always have to watch to not commit it and probably other people use vagrant too. 