### PR TITLE
FIX: Use all flag types in moderators activity query

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -885,7 +885,7 @@ class Report
         SELECT agreed_by_id,
         disagreed_by_id
         FROM post_actions
-        WHERE post_action_type_id IN (#{PostActionType.flag_types_without_custom.values.join(',')})
+        WHERE post_action_type_id IN (#{PostActionType.flag_types.values.join(',')})
         AND created_at >= '#{report.start_date}'
         AND created_at <= '#{report.end_date}'
         ),


### PR DESCRIPTION
Currently, the Moderators Activity report is excluding `notify_moderators` flag types. This is the type of flag that is created when a user selects 'Something Else' from the flagging modal.

Using `PostActionType.flag_types` instead of `PostActionType.flag_types_without_custom` in the `period_actions` query will allow these types of flags to be counted when a moderator agrees or disagrees with them.