### PR TITLE
FIX: Uncategorized pm not allowing edit

### DIFF
--- a/app/assets/javascripts/discourse/models/composer.js.es6
+++ b/app/assets/javascripts/discourse/models/composer.js.es6
@@ -121,6 +121,7 @@ const Composer = RestModel.extend({
   creatingSharedDraft: Ember.computed.equal("action", CREATE_SHARED_DRAFT),
   creatingPrivateMessage: Ember.computed.equal("action", PRIVATE_MESSAGE),
   notCreatingPrivateMessage: Ember.computed.not("creatingPrivateMessage"),
+  notPrivateMessage: Ember.computed.not("privateMessage"),
 
   @computed("privateMessage", "archetype.hasOptions")
   showCategoryChooser(isPrivateMessage, hasOptions) {
@@ -210,7 +211,8 @@ const Composer = RestModel.extend({
 
   canCategorize: Ember.computed.and(
     "canEditTitle",
-    "notCreatingPrivateMessage"
+    "notCreatingPrivateMessage",
+    "notPrivateMessage"
   ),
 
   @computed("canEditTitle", "creatingPrivateMessage", "categoryId")

--- a/test/javascripts/acceptance/composer-test.js.es6
+++ b/test/javascripts/acceptance/composer-test.js.es6
@@ -674,7 +674,7 @@ QUnit.test(
 
     assert.equal(
       find(".d-editor-container textarea").attr("placeholder"),
-      "Type here. Use Markdown, BBCode, or HTML to format. Drag or paste images.",
+      I18n.t("composer.reply_placeholder"),
       "it should not block because of missing category"
     );
   }

--- a/test/javascripts/acceptance/composer-test.js.es6
+++ b/test/javascripts/acceptance/composer-test.js.es6
@@ -659,6 +659,27 @@ QUnit.test("Loading draft also replaces the recipients", async assert => {
   assert.equal(find(".users-input .item:eq(0)").text(), "codinghorror");
 });
 
+QUnit.test(
+  "Deleting the text content of the first post in a private message",
+  async assert => {
+    Discourse.SiteSettings.allow_uncategorized_topics = false;
+
+    await visit("/t/34");
+
+    await click("#post_1 .d-icon-ellipsis-h");
+
+    await click("#post_1 .d-icon-pencil-alt");
+
+    await fillIn(".d-editor-input", "");
+
+    assert.equal(
+      find(".d-editor-container textarea").attr("placeholder"),
+      "Type here. Use Markdown, BBCode, or HTML to format. Drag or paste images.",
+      "it should not block because of missing category"
+    );
+  }
+);
+
 const assertImageResized = (assert, uploads) => {
   assert.equal(
     find(".d-editor-input").val(),

--- a/test/javascripts/fixtures/topic.js.es6
+++ b/test/javascripts/fixtures/topic.js.es6
@@ -4873,5 +4873,260 @@ export default {
     ],
     chunk_size: 20,
     bookmarked: false
+  },
+  "/t/34/1.json": {
+    post_stream: {
+      posts: [
+        {
+          id: 398,
+          name: null,
+          username: "tim.lange",
+          avatar_template: "/images/avatar.png",
+          created_at: "2019-03-28T07:57:50.527Z",
+          cooked: "<p>I am writing this private message to you</p>",
+          ignored: false,
+          post_number: 1,
+          post_type: 1,
+          updated_at: "2019-03-28T07:57:50.527Z",
+          reply_count: 0,
+          reply_to_post_number: null,
+          quote_count: 0,
+          avg_time: 15,
+          incoming_link_count: 0,
+          reads: 2,
+          score: 1.15,
+          yours: true,
+          topic_id: 34,
+          topic_slug: "test-pm",
+          display_username: null,
+          primary_group_name: null,
+          primary_group_flair_url: null,
+          primary_group_flair_bg_color: null,
+          primary_group_flair_color: null,
+          version: 1,
+          can_edit: true,
+          can_delete: false,
+          can_recover: null,
+          can_wiki: true,
+          read: true,
+          user_title: null,
+          actions_summary: [
+            {
+              id: 3,
+              can_act: true
+            },
+            {
+              id: 4,
+              can_act: true
+            },
+            {
+              id: 8,
+              can_act: true
+            },
+            {
+              id: 7,
+              can_act: true
+            }
+          ],
+          moderator: false,
+          admin: true,
+          staff: true,
+          user_id: 1,
+          hidden: false,
+          trust_level: 1,
+          deleted_at: null,
+          user_deleted: false,
+          edit_reason: null,
+          can_view_edit_history: true,
+          wiki: false
+        },
+        {
+          id: 419,
+          name: "Tim Lange",
+          username: "vox",
+          avatar_template: "/images/avatar.png",
+          created_at: "2019-03-28T08:04:16.790Z",
+          cooked: "<p>Have a reply for your pm</p>",
+          ignored: false,
+          post_number: 3,
+          post_type: 1,
+          updated_at: "2019-03-28T08:04:16.790Z",
+          reply_count: 0,
+          reply_to_post_number: null,
+          quote_count: 0,
+          avg_time: 16,
+          incoming_link_count: 0,
+          reads: 2,
+          score: 1.2,
+          yours: false,
+          topic_id: 34,
+          topic_slug: "test-pm",
+          display_username: "Tim Lange",
+          primary_group_name: null,
+          primary_group_flair_url: null,
+          primary_group_flair_bg_color: null,
+          primary_group_flair_color: null,
+          version: 1,
+          can_edit: true,
+          can_delete: true,
+          can_recover: null,
+          can_wiki: true,
+          read: true,
+          user_title: null,
+          actions_summary: [
+            {
+              id: 3,
+              can_act: true
+            },
+            {
+              id: 4,
+              can_act: true
+            },
+            {
+              id: 8,
+              can_act: true
+            },
+            {
+              id: 7,
+              can_act: true
+            }
+          ],
+          moderator: false,
+          admin: false,
+          staff: false,
+          user_id: 2,
+          hidden: false,
+          trust_level: 1,
+          deleted_at: null,
+          user_deleted: false,
+          edit_reason: null,
+          can_view_edit_history: true,
+          wiki: false,
+          post_notice_type: "first"
+        }
+      ],
+      stream: [25, 26, 27]
+    },
+    timeline_lookup: [[1, 0]],
+    id: 34,
+    title: "Test PM",
+    fancy_title: "Test PM",
+    posts_count: 3,
+    created_at: "2019-03-28T07:57:50.266Z",
+    views: 2,
+    reply_count: 0,
+    like_count: 0,
+    last_posted_at: "2019-03-28T08:04:16.790Z",
+    visible: true,
+    closed: false,
+    archived: false,
+    has_summary: false,
+    archetype: "private_message",
+    slug: "test-pm",
+    category_id: null,
+    word_count: 23,
+    deleted_at: null,
+    pending_posts_count: 0,
+    user_id: 1,
+    featured_link: null,
+    pinned_globally: false,
+    pinned_at: null,
+    pinned_until: null,
+    draft: null,
+    draft_key: "topic_34",
+    draft_sequence: 2,
+    posted: true,
+    unpinned: null,
+    pinned: false,
+    details: {
+      created_by: {
+        id: 1,
+        username: "tim.lange",
+        name: null,
+        avatar_template: "/images/avatar.png"
+      },
+      last_poster: {
+        id: 2,
+        username: "vox",
+        name: "Tim Lange",
+        avatar_template: "/images/avatar.png"
+      },
+      allowed_groups: [],
+      allowed_users: [
+        {
+          id: 2,
+          username: "vox",
+          name: "Tim Lange",
+          avatar_template: "/images/avatar.png"
+        },
+        {
+          id: 1,
+          username: "tim.lange",
+          name: null,
+          avatar_template: "/images/avatar.png"
+        }
+      ],
+      participants: [
+        {
+          id: 1,
+          username: "tim.lange",
+          name: null,
+          avatar_template: "/images/avatar.png",
+          post_count: 2,
+          primary_group_name: null,
+          primary_group_flair_url: null,
+          primary_group_flair_color: null,
+          primary_group_flair_bg_color: null
+        },
+        {
+          id: 2,
+          username: "vox",
+          name: "Tim Lange",
+          avatar_template: "/images/avatar.png",
+          post_count: 1,
+          primary_group_name: null,
+          primary_group_flair_url: null,
+          primary_group_flair_color: null,
+          primary_group_flair_bg_color: null
+        }
+      ],
+      notification_level: 3,
+      notifications_reason_id: 1,
+      can_move_posts: true,
+      can_edit: true,
+      can_delete: true,
+      can_remove_allowed_users: true,
+      can_remove_self_id: 1,
+      can_invite_to: true,
+      can_invite_via_email: true,
+      can_create_post: true,
+      can_reply_as_new_topic: true,
+      can_flag_topic: true,
+      can_convert_topic: true
+    },
+    current_post_number: 1,
+    highest_post_number: 3,
+    last_read_post_number: 3,
+    last_read_post_id: 27,
+    deleted_by: null,
+    has_deleted: false,
+    actions_summary: [
+      { id: 4, count: 0, hidden: false, can_act: true },
+      {
+        id: 8,
+        count: 0,
+        hidden: false,
+        can_act: true
+      },
+      { id: 7, count: 0, hidden: false, can_act: true }
+    ],
+    chunk_size: 20,
+    bookmarked: false,
+    message_archived: false,
+    topic_timer: null,
+    private_topic_timer: null,
+    message_bus_last_id: 7,
+    participant_count: 2,
+    pm_with_non_human_user: false
   }
 };

--- a/test/javascripts/helpers/create-pretender.js.es6
+++ b/test/javascripts/helpers/create-pretender.js.es6
@@ -155,6 +155,7 @@ export default function() {
     this.put("/u/eviltrout.json", () => response({ user: {} }));
 
     this.get("/t/280.json", () => response(fixturesByUrl["/t/280/1.json"]));
+    this.get("/t/34.json", () => response(fixturesByUrl["/t/34/1.json"]));
     this.get("/t/280/20.json", () => response(fixturesByUrl["/t/280/1.json"]));
     this.get("/t/28830.json", () => response(fixturesByUrl["/t/28830/1.json"]));
     this.get("/t/9.json", () => response(fixturesByUrl["/t/9/1.json"]));


### PR DESCRIPTION
When your Site Settings disallowed uncategorized posts and you edit the first post of a private message and removed all the text, Composer would then block input from happening because of "You must select a category before typing here". This has been fixed.

Resolves: https://meta.discourse.org/t/you-must-select-category-notice-when-editing-pm-op/112741