### PR TITLE
FIX: Rescue file not found hightlight.min.js

### DIFF
--- a/lib/highlight_js/highlight_js.rb
+++ b/lib/highlight_js/highlight_js.rb
@@ -12,7 +12,12 @@ module HighlightJs
   end
 
   def self.bundle(langs)
-    result = File.read(HIGHLIGHTJS_DIR + "highlight.min.js")
+    begin
+      result = File.read(HIGHLIGHTJS_DIR + "highlight.min.js")
+    rescue Errno::ENOENT
+      return ""
+    end
+
     langs.each do |lang|
       begin
         result << "\n" << File.read(HIGHLIGHTJS_DIR + "languages/#{lang}.min.js")


### PR DESCRIPTION
I had users suddenly report that they were unable to access my forum. I quick look at `/logs` returned me the following error:

```
ActionView::Template::Error (No such file or directory @ rb_sysopen - /home/tla/discourse/vendor/assets/javascripts/highlightjs/highlight.min.js)
lib/highlight_js/highlight_js.rb:15:in `read'
```

I don't know why that exactly happened but my highlight.min.js went missing. I fixed the error by downloading the js file from the git repo and re-adding it.

I think it would be best just to rescue this line so that Discourse can continue with "halfway" normal operations and not totally crash.