### PR TITLE
UX: Unified emoji escape regex

### DIFF
--- a/app/assets/javascripts/pretty-text/emoji.js.es6
+++ b/app/assets/javascripts/pretty-text/emoji.js.es6
@@ -21,6 +21,14 @@ export function extendedEmojiList() {
 
 const emojiHash = {};
 
+const unicodeRegexp = new RegExp(
+  Object.keys(replacements)
+    .sort()
+    .reverse()
+    .join("|") + "|\\B:[^\\s:]+(?::t\\d)?:?\\B",
+  "g"
+);
+
 // add all default emojis
 emojis.forEach(code => (emojiHash[code] = true));
 
@@ -35,7 +43,7 @@ export function performEmojiUnescape(string, opts) {
     return;
   }
 
-  return string.replace(/[\u1000-\uFFFF]+|\B:[^\s:]+(?::t\d)?:?\B/g, m => {
+  return string.replace(unicodeRegexp, m => {
     const isEmoticon = !!translations[m];
     const isUnicodeEmoticon = !!replacements[m];
     let emojiVal;
@@ -63,7 +71,7 @@ export function performEmojiUnescape(string, opts) {
 }
 
 export function performEmojiEscape(string) {
-  return string.replace(/[\u1000-\uFFFF]+|\B:[^\s:]+(?::t\d)?:?\B/g, m => {
+  return string.replace(unicodeRegexp, m => {
     if (!!translations[m]) {
       return ":" + translations[m] + ":";
     } else if (!!replacements[m]) {

--- a/test/javascripts/acceptance/topic-test.js.es6
+++ b/test/javascripts/acceptance/topic-test.js.es6
@@ -188,7 +188,7 @@ QUnit.test("Updating the topic title with unicode emojis", async assert => {
   await visit("/t/internationalization-localization/280");
   await click("#topic-title .d-icon-pencil-alt");
 
-  await fillIn("#edit-title", "emojis title 👨‍🌾");
+  await fillIn("#edit-title", "emojis title 👨‍🌾🙏");
 
   await click("#topic-title .submit-edit");
 
@@ -196,7 +196,7 @@ QUnit.test("Updating the topic title with unicode emojis", async assert => {
     find(".fancy-title")
       .html()
       .trim(),
-    `emojis title <img src="/images/emoji/emoji_one/man_farmer.png?v=${v}" title="man_farmer" alt="man_farmer" class="emoji">`,
+    `emojis title <img src="/images/emoji/emoji_one/man_farmer.png?v=${v}" title="man_farmer" alt="man_farmer" class="emoji"><img src="/images/emoji/emoji_one/pray.png?v=${v}" title="pray" alt="pray" class="emoji">`,
     "it displays the new title with escaped unicode emojis"
   );
 });


### PR DESCRIPTION
This sets a unified regex for `emojiUnescape` which is also used in `lib/pretty-text/shims.js`

Related: https://meta.discourse.org/t/unicode-emoji-modifiers-are-handled-differently-in-titles-and-post-content/111328