### PR TITLE
FIX: category list order using category featured topics

### DIFF
--- a/app/models/category_list.rb
+++ b/app/models/category_list.rb
@@ -43,6 +43,19 @@ class CategoryList
     "categories_list".freeze
   end
 
+  def self.order_categories(categories)
+    if SiteSetting.fixed_category_positions
+      categories.order(:position, :id)
+    else
+      allowed_category_ids = categories.pluck(:id) << nil # `nil` is necessary to include categories without any associated topics
+      categories.left_outer_joins(:featured_topics)
+        .where(topics: { category_id: allowed_category_ids })
+        .group('categories.id')
+        .order("max(topics.bumped_at) DESC NULLS LAST")
+        .order('categories.id ASC')
+    end
+  end
+
   private
 
   def find_relevant_topics
@@ -75,16 +88,7 @@ class CategoryList
 
     @categories = @categories.where("categories.parent_category_id = ?", @options[:parent_category_id].to_i) if @options[:parent_category_id].present?
 
-    if SiteSetting.fixed_category_positions
-      @categories = @categories.order(:position, :id)
-    else
-      allowed_category_ids = @categories.pluck(:id) << nil # `nil` is necessary to include categories without any associated topics
-      @categories = @categories.left_outer_joins(:featured_topics)
-        .where(topics: { category_id: allowed_category_ids })
-        .group('categories.id')
-        .order("max(topics.bumped_at) DESC NULLS LAST")
-        .order('categories.id ASC')
-    end
+    @categories = self.class.order_categories(@categories)
 
     @categories = @categories.to_a
 


### PR DESCRIPTION
follow up on https://review.discourse.org/t/ux-order-categories-based-on-latest-activity-for-all-page-styles-7196/2271