### PR TITLE
FIX: Detect SNS notifications for SES correctly

### DIFF
--- a/app/jobs/regular/process_sns_notification.rb
+++ b/app/jobs/regular/process_sns_notification.rb
@@ -22,7 +22,7 @@ module Jobs
       return unless Aws::SNS::MessageVerifier.new.authentic?(raw)
 
       message.dig("bounce", "bouncedRecipients").each do |r|
-        if email_log = EmailLog.order("created_at DESC").where(to_address: r["emailAddress"])[0]
+        if email_log = EmailLog.order("created_at DESC").where(to_address: r["emailAddress"]).first
           email_log.update_columns(bounced: true)
 
           if email_log.user&.email.present?

--- a/app/jobs/regular/process_sns_notification.rb
+++ b/app/jobs/regular/process_sns_notification.rb
@@ -22,7 +22,6 @@ module Jobs
       return unless Aws::SNS::MessageVerifier.new.authentic?(raw)
 
       message.dig("bounce", "bouncedRecipients").each do |r|
-        
         if email_log = EmailLog.order("created_at DESC").where(to_address: r["emailAddress"])[0]
           email_log.update_columns(bounced: true)
 


### PR DESCRIPTION
This fixes detection of email bounce by:
- removing hard requirement for email msg ID, msg ID in webhook msg never equals to ID in email_log
- gets bounce_score from user stats instead of nonexistent field in webhook msg

It's a bit better patch than shown in this post:
https://meta.discourse.org/t/handling-bouncing-e-mails/45343/100?u=systemz