### PR TITLE
improve posts layout for crawler - add like count to view too

### DIFF
--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -888,3 +888,22 @@ span.highlighted {
     }
   }
 }
+
+.crawler-post {
+  .post-time {
+    float: right;
+  }
+  .post-likes {
+    float: right;
+  }
+  margin-top: 5px;
+}
+
+#breadcrumbs {
+  .badge-category-bg {
+    background-color: #cea9a9;
+  }
+  .category-title {
+    color: #646464;
+  }
+}

--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -901,9 +901,9 @@ span.highlighted {
 
 #breadcrumbs {
   .badge-category-bg {
-    background-color: #cea9a9;
+    background-color: $secondary-high;
   }
   .category-title {
-    color: #646464;
+    color: $primary;
   }
 }

--- a/app/views/layouts/crawler.html.erb
+++ b/app/views/layouts/crawler.html.erb
@@ -33,7 +33,7 @@
     <div id="main-outlet" class="wrap">
       <%= yield %>
     </div>
-    <footer class="container">
+    <footer class="container wrap">
       <nav class='crawler-nav' itemscope itemtype='http://schema.org/SiteNavigationElement'>
         <a href='<%= path "/" %>'><%= t 'home_title' %></a>
         <%= link_to t('js.filters.categories.title'), path("/categories") %>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -10,8 +10,9 @@
       <%-if (i+1) < @breadcrumbs.length%>
         itemref="breadcrumb-<%=(i+1)%>"
       <%-end%>>
-      <a href="<%=c[:url]%>" itemprop="url">
-        <span itemprop="title"><%=c[:name]%></span>
+      <a href="<%=c[:url]%>" itemprop="url" class='badge-wrapper bullet'>
+        <span class="badge-category-bg" style='background-color: #CEA9A9;'> </span>
+        <span itemprop="title" style='color: #646464;'><%=c[:name]%></span>
       </a>
     </div>
   <% end %>
@@ -37,12 +38,10 @@
 
 <%= server_plugin_outlet "topic_header" %>
 
-<hr>
-
 <%- if include_crawler_content? %>
 
 <% @topic_view.posts.each do |post| %>
-  <div itemscope itemtype='http://schema.org/DiscussionForumPosting'>
+  <div itemscope itemtype='http://schema.org/DiscussionForumPosting' class='topic-body' style='margin-top: 5px;'>
     <% if (u = post.user) %>
       <div class='creator'>
         <span>
@@ -56,12 +55,12 @@
           <% end %>
           <% if post.updated_at > post.created_at %>
             <meta itemprop='datePublished' content='<%= post.created_at.to_formatted_s(:iso8601) %>'>
-            <time itemprop='dateModified' datetime='<%= post.updated_at.to_formatted_s(:iso8601) %>'>
-              <%= post.updated_at %>
+            <time itemprop='dateModified' datetime='<%= post.updated_at.to_formatted_s(:iso8601) %>' style='float: right;'>
+              <%= post.updated_at.strftime('%e %b %Y %H:%M:%S %Z') %>
             </time>
           <% else %>
-            <time itemprop='datePublished' datetime='<%= post.created_at.to_formatted_s(:iso8601) %>'>
-              <%= post.created_at %>
+            <time itemprop='datePublished' datetime='<%= post.created_at.to_formatted_s(:iso8601) %>' style='float: right;'>
+              <%= post.created_at.strftime('%e %b %Y %H:%M:%S %Z') %>
             </time>
           <% end %>
         </span>
@@ -73,6 +72,9 @@
       <meta itemprop='interactionCount' content='UserLikes:<%= post.like_count %>'>
       <meta itemprop='interactionCount' content='UserComments:<%= post.reply_count %>'>
       <meta itemprop='headline' content='<%= @topic_view.title %>'>
+      <div class='clearfix'>
+        <span style='float: right;'>Likes: <%= post.like_count %></span>
+      </div>
       <hr>
       <% if @topic_view.link_counts[post.id] && @topic_view.link_counts[post.id].length > 0 %>
         <% @topic_view.link_counts[post.id].each do |link| %>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -56,11 +56,11 @@
           <% if post.updated_at > post.created_at %>
             <meta itemprop='datePublished' content='<%= post.created_at.to_formatted_s(:iso8601) %>'>
             <time itemprop='dateModified' datetime='<%= post.updated_at.to_formatted_s(:iso8601) %>' class='post-time'>
-              <%= post.updated_at.strftime('%e %b %Y %H:%M:%S %Z') %>
+              <%= l post.updated_at, format: :long %>
             </time>
           <% else %>
             <time itemprop='datePublished' datetime='<%= post.created_at.to_formatted_s(:iso8601) %>' class='post-time'>
-              <%= post.created_at.strftime('%e %b %Y %H:%M:%S %Z') %>
+              <%= l post.created_at, format: :long %>
             </time>
           <% end %>
         </span>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -11,8 +11,8 @@
         itemref="breadcrumb-<%=(i+1)%>"
       <%-end%>>
       <a href="<%=c[:url]%>" itemprop="url" class='badge-wrapper bullet'>
-        <span class="badge-category-bg" style='background-color: #CEA9A9;'> </span>
-        <span itemprop="title" style='color: #646464;'><%=c[:name]%></span>
+        <span class="badge-category-bg"></span>
+        <span itemprop="title" class='category-title'><%=c[:name]%></span>
       </a>
     </div>
   <% end %>
@@ -41,7 +41,7 @@
 <%- if include_crawler_content? %>
 
 <% @topic_view.posts.each do |post| %>
-  <div itemscope itemtype='http://schema.org/DiscussionForumPosting' class='topic-body' style='margin-top: 5px;'>
+  <div itemscope itemtype='http://schema.org/DiscussionForumPosting' class='topic-body crawler-post'>
     <% if (u = post.user) %>
       <div class='creator'>
         <span>
@@ -55,11 +55,11 @@
           <% end %>
           <% if post.updated_at > post.created_at %>
             <meta itemprop='datePublished' content='<%= post.created_at.to_formatted_s(:iso8601) %>'>
-            <time itemprop='dateModified' datetime='<%= post.updated_at.to_formatted_s(:iso8601) %>' style='float: right;'>
+            <time itemprop='dateModified' datetime='<%= post.updated_at.to_formatted_s(:iso8601) %>' class='post-time'>
               <%= post.updated_at.strftime('%e %b %Y %H:%M:%S %Z') %>
             </time>
           <% else %>
-            <time itemprop='datePublished' datetime='<%= post.created_at.to_formatted_s(:iso8601) %>' style='float: right;'>
+            <time itemprop='datePublished' datetime='<%= post.created_at.to_formatted_s(:iso8601) %>' class='post-time'>
               <%= post.created_at.strftime('%e %b %Y %H:%M:%S %Z') %>
             </time>
           <% end %>
@@ -73,7 +73,7 @@
       <meta itemprop='interactionCount' content='UserComments:<%= post.reply_count %>'>
       <meta itemprop='headline' content='<%= @topic_view.title %>'>
       <div class='clearfix'>
-        <span style='float: right;'>Likes: <%= post.like_count %></span>
+        <span class='post-likes'>Likes: <%= post.like_count %></span>
       </div>
       <hr>
       <% if @topic_view.link_counts[post.id] && @topic_view.link_counts[post.id].length > 0 %>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -73,7 +73,7 @@
       <meta itemprop='interactionCount' content='UserComments:<%= post.reply_count %>'>
       <meta itemprop='headline' content='<%= @topic_view.title %>'>
       <div class='clearfix'>
-        <span class='post-likes'>Likes: <%= post.like_count %></span>
+        <span class='post-likes'><%= t('post.has_likes', count: post.like_count) %></span>
       </div>
       <hr>
       <% if @topic_view.link_counts[post.id] && @topic_view.link_counts[post.id].length > 0 %>

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -617,6 +617,9 @@ en:
   post:
     image_placeholder:
       broken: "This image is broken"
+    has_likes:
+      one: "%{count} Like"
+      other: "%{count} Likes"
 
   rate_limiter:
     slow_down: "You’ve performed this action too many times, please try again later."


### PR DESCRIPTION
This is a part of https://meta.discourse.org/t/improving-discourse-static-html-archive/112497

Attaching a screenshot of the new layout. I think there should be a better way to display likes, let me know if you have any suggestions.

The old layout can be seen here: https://meta.discourse.org/t/suspect-account-anonymous-account/112813/?_escaped_fragment_

![Screenshot from 2019-03-29 14-59-21](https://user-images.githubusercontent.com/6376157/55223066-63a3ce00-5233-11e9-9e8c-03febcb9361a.png)
