### PR TITLE
FIX: Avoid the deleted_at scope when recovering a topic

### DIFF
--- a/lib/post_destroyer.rb
+++ b/lib/post_destroyer.rb
@@ -85,7 +85,7 @@ class PostDestroyer
     UserActionManager.post_created(@post)
     DiscourseEvent.trigger(:post_recovered, @post, @opts, @user)
     if @post.is_first_post?
-      UserActionManager.topic_created(@post.topic)
+      UserActionManager.topic_created(topic)
       DiscourseEvent.trigger(:topic_recovered, topic, @user)
       StaffActionLogger.new(@user).log_topic_delete_recover(topic, "recover_topic", @opts.slice(:context)) if @user.id != @post.user_id
     end

--- a/spec/components/post_destroyer_spec.rb
+++ b/spec/components/post_destroyer_spec.rb
@@ -177,6 +177,17 @@ describe PostDestroyer do
         expect(@user.user_stat.post_count).to eq(1)
       end
 
+      it 'Recovers the post correctly' do
+        PostDestroyer.new(admin, post).destroy
+
+        post.reload
+        PostDestroyer.new(admin, post).recover
+        recovered_topic = post.reload.topic
+
+        expect(recovered_topic.deleted_at).to be_nil
+        expect(recovered_topic.deleted_by_id).to be_nil
+      end
+
       context "recovered by user" do
         it "should increment the user's post count" do
           PostDestroyer.new(@user, @reply).destroy


### PR DESCRIPTION
Avoid the deleted_at scope when recovering a topic from a recently recovered post.