### PR TITLE
UX: Mobile card buttons should truncate if there isn't enough space

### DIFF
--- a/app/assets/stylesheets/mobile/components/user-card.scss
+++ b/app/assets/stylesheets/mobile/components/user-card.scss
@@ -20,13 +20,17 @@ $avatar_width: 120px;
       display: flex;
       flex: 1;
       margin-top: 1em;
-      button {
-        white-space: nowrap;
-      }
+      max-width: 100%;
       li {
         flex: 1;
-        & + li {
-          margin-left: 0.5em;
+        min-width: 0;
+        &:nth-child(2) {
+          border-left: 0.5em solid transparent;
+        }
+        button {
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
         }
       }
     }


### PR DESCRIPTION
History: https://meta.discourse.org/t/mobile-user-card-text-overflow-issue/112870

This mostly occurs with non-english locales that have long strings. 

**before:**
![cardButtonsBefore](https://user-images.githubusercontent.com/33972521/55284525-f74bda80-53aa-11e9-808f-f15cab76b625.png)

**after:** 
![cardButtonsAfter](https://user-images.githubusercontent.com/33972521/55284537-9bce1c80-53ab-11e9-8779-d9e4e0a37073.png)


