### PR TITLE
UX: user-card adjustments for users with hidden profiles

### DIFF
--- a/app/assets/javascripts/discourse/templates/components/user-card-contents.hbs
+++ b/app/assets/javascripts/discourse/templates/components/user-card-contents.hbs
@@ -3,7 +3,11 @@
 
     <div class="card-row first-row">
       <div class="user-card-avatar">
-        <a href {{action "showUser" user}} class="card-huge-avatar">{{bound-avatar user "huge"}}</a>
+        {{#if user.profile_hidden}}
+          <span class="card-huge-avatar">{{bound-avatar user "huge"}}</span>
+        {{else}}
+          <a href {{action "showUser" user}} class="card-huge-avatar">{{bound-avatar user "huge"}}</a>
+        {{/if}}
         {{#if user.primary_group_name}}
           {{avatar-flair
           flairURL=user.primary_group_flair_url
@@ -16,10 +20,17 @@
       <div class="names">
         <span>
           <h1 class="{{staff}} {{newUser}} {{if nameFirst "full-name" "username"}}">
-            <a href {{action "showUser" user}} class='user-profile-link'>
-              {{if nameFirst user.name (format-username username)}}
-              {{user-status user currentUser=currentUser}}
-            </a>
+            {{#if user.profile_hidden}}
+              <span>
+                {{if nameFirst user.name (format-username username)}}
+                {{user-status user currentUser=currentUser}}
+              </span>
+            {{else}}
+              <a href {{action "showUser" user}} class='user-profile-link'>
+                {{if nameFirst user.name (format-username username)}}
+                {{user-status user currentUser=currentUser}}
+              </a>
+            {{/if}}
           </h1>
           {{plugin-outlet name="user-card-after-username" args=(hash user=user showUser=(action "showUser" user)) tagName=''}}
           {{#unless nameFirst}}
@@ -82,6 +93,14 @@
       tagName=""}}
     </div>
 
+    {{#if user.profile_hidden}}
+      <div class="card-row second-row">
+        <div class='profile-hidden'>
+          <span>{{i18n "user.profile_hidden"}}</span>
+        </div>
+      </div>
+    {{/if}}
+
     {{#if isSuspendedOrHasBio}}
       <div class="card-row second-row">
         {{#if user.suspend_reason}}
@@ -126,7 +145,7 @@
       </div>
     {{/if}}
 
-    {{#if user}}
+    {{#if user.time_read}}
       <div class="card-row fourth-row">
         {{#unless user.profile_hidden}}
           <div class="metadata">

--- a/app/assets/stylesheets/common/components/user-card.scss
+++ b/app/assets/stylesheets/common/components/user-card.scss
@@ -136,6 +136,10 @@ $avatar_margin: -50px; // negative margin makes avatars extend above cards
         font-weight: bold;
       }
     }
+    .profile-hidden {
+      font-size: $font-up-1;
+      margin-top: 0.5em;
+    }
   }
   // location and website
   .third-row {


### PR DESCRIPTION
Right now, if you request the user-card for a user who set their profile to be hidden you get this on desktop

![desktopHiddenBefore](https://user-images.githubusercontent.com/33972521/55304187-d6ec5080-547c-11e9-946c-594019e5a93b.png)

and this on mobile

![hiddenProfileBeforeMobile](https://user-images.githubusercontent.com/33972521/55304248-1b77ec00-547d-11e9-9a83-753bfb764898.png)

Both the avatar and username are clickable links that take you to the user's profile. Since the profile is hidden, the only thing you get to see there is a message that says 

"This user's public profile is hidden"

This PR addresses this issue by making two changes:

1- The username and avatar will no longer be links. This means that no matter how much you click them, you won't be navigated to the profile of the hidden user. This change only affects normal users. Admins / moderators / staff will still be able to click the links and view the profile - since it's not hidden for them.

2- A message indicating that the profile is hidden is added to the user card for the user who has hidden their profile. It looks like this on desktop

![hiddenProfileAfterDesktop](https://user-images.githubusercontent.com/33972521/55304636-e9678980-547e-11e9-87bb-35b2c8a22ab4.png)

and like this on mobile

![hiddenProfileAfterMobile](https://user-images.githubusercontent.com/33972521/55304579-968dd200-547e-11e9-82f8-553003768581.png)

The string used is the same localized string we use on hidden profile pages so no extra strings are added.

