### PR TITLE
DEV: Introduce parallel rspec testing

### DIFF
--- a/.rspec_parallel
+++ b/.rspec_parallel
@@ -1,0 +1,4 @@
+--format progress
+--format ParallelTests::RSpec::RuntimeLogger --out tmp/parallel_runtime_rspec.log
+--format ParallelTests::RSpec::SummaryLogger --out tmp/spec_summary.log
+--format ParallelTests::RSpec::FailuresLogger --out tmp/failing_specs.log

--- a/Gemfile
+++ b/Gemfile
@@ -139,6 +139,7 @@ group :test, :development do
   gem 'pry-nav'
   gem 'byebug', require: ENV['RM_INFO'].nil?
   gem 'rubocop', require: false
+  gem 'parallel_tests'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -274,6 +274,8 @@ GEM
       ruby-openid
     optimist (3.0.0)
     parallel (1.13.0)
+    parallel_tests (2.28.0)
+      parallel
     parser (2.6.0.0)
       ast (~> 2.4.0)
     pg (1.1.4)
@@ -517,6 +519,7 @@ DEPENDENCIES
   omniauth-twitter
   onebox (= 1.8.82)
   openid-redis-store
+  parallel_tests
   pg
   pry-nav
   pry-rails

--- a/app/models/global_setting.rb
+++ b/app/models/global_setting.rb
@@ -236,6 +236,10 @@ class GlobalSetting
 
   class BlankProvider < BaseProvider
     def lookup(key, default)
+
+      if key == :redis_port
+        return ENV["DISCOURSE_REDIS_PORT"] if ENV["DISCOURSE_REDIS_PORT"]
+      end
       default
     end
 


### PR DESCRIPTION
Adds the parallel_tests gem, and redis/postgres configuration for running rspec tests in parallel. To use:

```
rake parallel:rake[db:create]
rake parallel:rake[db:migrate]
rake parallel:spec
```

This brings the test suite from 12m20s to 3m11s on my macOS machine