### PR TITLE
FIX: handles boolean with popupMenuOption

### DIFF
--- a/app/assets/javascripts/discourse/controllers/composer.js.es6
+++ b/app/assets/javascripts/discourse/controllers/composer.js.es6
@@ -255,10 +255,12 @@ export default Ember.Controller.extend({
   _setupPopupMenuOption(callback) {
     let option = callback();
 
-    if (option.condition) {
-      option.condition = this.get(option.condition);
-    } else {
+    if (typeof option.condition === "undefined") {
       option.condition = true;
+    } else if (typeof option.condition === "boolean") {
+      // uses existing value
+    } else {
+      option.condition = this.get(option.condition);
     }
 
     return option;


### PR DESCRIPTION
Handle the case of https://github.com/discourse/DiscoTOC doing this kind of setup:

```
return {
    action: "insertDtoc",
    icon: "align-left",
    label: themePrefix("insert_table_of_contents"),
    condition: !composerController.get("model.canCategorize")
  };
```

In this case there's no function to call, it's already set.