### PR TITLE
FIX: Restricted site text better error

### DIFF
--- a/app/controllers/admin/site_texts_controller.rb
+++ b/app/controllers/admin/site_texts_controller.rb
@@ -119,7 +119,8 @@ class Admin::SiteTextsController < Admin::AdminController
   end
 
   def find_site_text
-    raise Discourse::NotFound unless I18n.exists?(params[:id]) && !self.class.restricted_keys.include?(params[:id])
+    raise Discourse::NotFound unless I18n.exists?(params[:id])
+    raise Discourse::InvalidAccess.new(nil, nil, custom_message: 'email_template_cant_be_modified') if self.class.restricted_keys.include?(params[:id])
     record_for(params[:id])
   end
 

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -242,6 +242,7 @@ en:
   provider_not_found: "You are not permitted to view the requested resource. The authentication provider does not exist."
   read_only_mode_enabled: "The site is in read only mode. Interactions are disabled."
   invalid_grant_badge_reason_link: "External or invalid discourse link is not allowed in badge reason"
+  email_template_cant_be_modified: "This email template can't be modified"
 
   reading_time: "Reading time"
   likes: "Likes"

--- a/spec/requests/admin/site_texts_controller_spec.rb
+++ b/spec/requests/admin/site_texts_controller_spec.rb
@@ -141,10 +141,12 @@ RSpec.describe Admin::SiteTextsController do
           site_text: { value: 'foo' }
         }
 
-        expect(response.status).to eq(404)
+        expect(response.status).to eq(403)
 
         json = ::JSON.parse(response.body)
-        expect(json['error_type']).to eq('not_found')
+        expect(json['error_type']).to eq('invalid_access')
+        expect(json['errors'].size).to eq(1)
+        expect(json['errors'].first).to eq(I18n.t('email_template_cant_be_modified'))
       end
 
       it "returns the right error message" do


### PR DESCRIPTION
This returns a better error message to the user if the site text is restricted.

Resolves: https://meta.discourse.org/t/better-error-message-for-uneditable-user-notifications-confirm-old-email-texts/111853