### PR TITLE
Remove Yahoo login support from core and deprecate OpenID2.0

### DIFF
--- a/app/assets/javascripts/admin/controllers/modals/admin-add-upload.js.es6
+++ b/app/assets/javascripts/admin/controllers/modals/admin-add-upload.js.es6
@@ -34,7 +34,6 @@ const SCSS_VARIABLE_NAMES = [
   "facebook",
   "cas",
   "twitter",
-  "yahoo",
   "github",
   "base-font-size",
   "base-line-height",

--- a/app/assets/stylesheets/common/components/buttons.scss
+++ b/app/assets/stylesheets/common/components/buttons.scss
@@ -225,12 +225,6 @@
       background: darken($twitter, 10%);
     }
   }
-  &.yahoo {
-    background: $yahoo;
-    &:hover {
-      background: darken($yahoo, 10%);
-    }
-  }
   &.github {
     background: $github;
     &:hover {

--- a/app/assets/stylesheets/common/foundation/variables.scss
+++ b/app/assets/stylesheets/common/foundation/variables.scss
@@ -22,7 +22,6 @@ $instagram: #e1306c !default;
 $facebook: #4267b2 !default;
 $cas: #70ba61 !default;
 $twitter: #1da1f2 !default;
-$yahoo: #810293 !default;
 $github: #100e0f !default;
 
 // Badge color variables

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1381,10 +1381,6 @@ en:
         name: "Facebook"
         title: "with Facebook"
         message: "Authenticating with Facebook (make sure pop up blockers are not enabled)"
-      yahoo:
-        name: "Yahoo"
-        title: "with Yahoo"
-        message: "Authenticating with Yahoo (make sure pop up blockers are not enabled)"
       github:
         name: "GitHub"
         title: "with GitHub"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1485,7 +1485,6 @@ en:
     enable_local_logins_via_email: "Allow users to request a one-click login link to be sent to them via email."
     allow_new_registrations: "Allow new user registrations. Uncheck this to prevent anyone from creating a new account."
     enable_signup_cta: "Show a notice to returning anonymous users prompting them to sign up for an account."
-    enable_yahoo_logins: "Enable Yahoo authentication"
 
     enable_google_oauth2_logins: "Enable Google Oauth2 authentication. This is the method of authentication that Google currently supports. Requires key and secret. See <a href='https://meta.discourse.org/t/15858' target='_blank'>Configuring Google login for Discourse</a>."
     google_oauth2_client_id: "Client ID of your Google application."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -341,8 +341,6 @@ login:
       - "select_account"
   google_oauth2_hd:
     default: ""
-  enable_yahoo_logins:
-    default: false
   enable_twitter_logins:
     default: false
   twitter_consumer_key:

--- a/lib/auth/open_id_authenticator.rb
+++ b/lib/auth/open_id_authenticator.rb
@@ -35,6 +35,7 @@ class Auth::OpenIdAuthenticator < Auth::Authenticator
   end
 
   def after_authenticate(auth_token, existing_account: nil)
+    Discourse.deprecate("OpenID Authentication has been deprecated, please migrate to OAuth2 or OpenID Connect", since: "2.3.0beta4", drop_from: "2.4")
     result = Auth::Result.new
 
     data = auth_token[:info]

--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -217,7 +217,6 @@ module Discourse
   BUILTIN_AUTH ||= [
     Auth::AuthProvider.new(authenticator: Auth::FacebookAuthenticator.new, frame_width: 580, frame_height: 400, icon: "fab-facebook"),
     Auth::AuthProvider.new(authenticator: Auth::GoogleOAuth2Authenticator.new, frame_width: 850, frame_height: 500), # Custom icon implemented in client
-    Auth::AuthProvider.new(authenticator: Auth::OpenIdAuthenticator.new("yahoo", "https://me.yahoo.com", 'enable_yahoo_logins', trusted: true), icon: "fab-yahoo"),
     Auth::AuthProvider.new(authenticator: Auth::GithubAuthenticator.new, icon: "fab-github"),
     Auth::AuthProvider.new(authenticator: Auth::TwitterAuthenticator.new, icon: "fab-twitter"),
     Auth::AuthProvider.new(authenticator: Auth::InstagramAuthenticator.new, icon: "fab-instagram")

--- a/lib/svg_sprite/svg_sprite.rb
+++ b/lib/svg_sprite/svg_sprite.rb
@@ -77,7 +77,6 @@ module SvgSprite
     "fab-twitter",
     "fab-twitter-square",
     "fab-windows",
-    "fab-yahoo",
     "far-bell",
     "far-bell-slash",
     "far-calendar-plus",

--- a/spec/jobs/invalidate_inactive_admins_spec.rb
+++ b/spec/jobs/invalidate_inactive_admins_spec.rb
@@ -37,7 +37,6 @@ describe Jobs::InvalidateInactiveAdmins do
       context 'with social logins' do
         before do
           GithubUserInfo.create!(user_id: not_seen_admin.id, screen_name: 'bob', github_user_id: 100)
-          UserOpenId.create!(url: 'https://me.yahoo.com/id/123' , user_id: not_seen_admin.id, email: 'bob@example.com', active: true)
           UserAssociatedAccount.create!(provider_name: "google_oauth2", user_id: not_seen_admin.id, provider_uid: 100, info: { email: "bob@google.account.com" })
         end
 
@@ -45,7 +44,6 @@ describe Jobs::InvalidateInactiveAdmins do
           subject
           expect(GithubUserInfo.where(user_id: not_seen_admin.id).exists?).to eq(false)
           expect(UserAssociatedAccount.where(user_id: not_seen_admin.id).exists?).to eq(false)
-          expect(UserOpenId.where(user_id: not_seen_admin.id).exists?).to eq(false)
         end
       end
     end

--- a/test/javascripts/helpers/site-settings.js
+++ b/test/javascripts/helpers/site-settings.js
@@ -28,7 +28,6 @@ Discourse.SiteSettingsOriginal = {
   allow_new_registrations: true,
   enable_google_logins: true,
   enable_google_oauth2_logins: false,
-  enable_yahoo_logins: true,
   enable_twitter_logins: true,
   enable_facebook_logins: true,
   enable_github_logins: true,


### PR DESCRIPTION
The OpenID2.0 protocol has been declared obsolete by the OpenID Foundation: https://openid.net/developers/specs/

- Plugin developers using OpenID2.0 should migrate to OAuth2 or OIDC. OpenID2.0 APIs will be removed in v2.4.0

- For sites requiring Yahoo login, it can be implemented using the OpenID Connect plugin: https://meta.discourse.org/t/103632