### PR TITLE
FIX: prevent anonymous users from changing their email/username/name

### DIFF
--- a/app/assets/javascripts/discourse/controllers/preferences/account.js.es6
+++ b/app/assets/javascripts/discourse/controllers/preferences/account.js.es6
@@ -55,11 +55,15 @@ export default Ember.Controller.extend(
       return availableTitles.length > 0;
     },
 
-    @computed()
-    canChangePassword() {
-      return (
-        !this.siteSettings.enable_sso && this.siteSettings.enable_local_logins
-      );
+    @computed("model.is_anonymous")
+    canChangePassword(isAnonymous) {
+      if (isAnonymous) {
+        return false;
+      } else {
+        return (
+          !this.siteSettings.enable_sso && this.siteSettings.enable_local_logins
+        );
+      }
     },
 
     @computed("model.associated_accounts")
@@ -92,9 +96,17 @@ export default Ember.Controller.extend(
       return userId !== this.get("currentUser.id");
     },
 
-    @computed("model.second_factor_enabled", "canCheckEmails")
-    canUpdateAssociatedAccounts(secondFactorEnabled, canCheckEmails) {
-      if (secondFactorEnabled || !canCheckEmails) {
+    @computed(
+      "model.second_factor_enabled",
+      "canCheckEmails",
+      "model.is_anonymous"
+    )
+    canUpdateAssociatedAccounts(
+      secondFactorEnabled,
+      canCheckEmails,
+      isAnonymous
+    ) {
+      if (secondFactorEnabled || !canCheckEmails || isAnonymous) {
         return false;
       }
 

--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -31,6 +31,9 @@ class Guardian
     def moderator?
       false
     end
+    def anonymous?
+      true
+    end
     def approved?
       false
     end
@@ -105,6 +108,10 @@ class Guardian
 
   def is_staged?
     @user.staged?
+  end
+
+  def is_anonymous?
+    @user.anonymous?
   end
 
   # Can the user see the object?

--- a/lib/guardian/user_guardian.rb
+++ b/lib/guardian/user_guardian.rb
@@ -17,23 +17,26 @@ module UserGuardian
   end
 
   def can_edit_username?(user)
-    return false if (SiteSetting.sso_overrides_username? && SiteSetting.enable_sso?)
+    return false if SiteSetting.sso_overrides_username? && SiteSetting.enable_sso?
     return true if is_staff?
     return false if SiteSetting.username_change_period <= 0
+    return false if is_anonymous?
     is_me?(user) && ((user.post_count + user.topic_count) == 0 || user.created_at > SiteSetting.username_change_period.days.ago)
   end
 
   def can_edit_email?(user)
-    return false if (SiteSetting.sso_overrides_email? && SiteSetting.enable_sso?)
+    return false if SiteSetting.sso_overrides_email? && SiteSetting.enable_sso?
     return false unless SiteSetting.email_editable?
     return true if is_staff?
+    return false if is_anonymous?
     can_edit?(user)
   end
 
   def can_edit_name?(user)
-    return false if not(SiteSetting.enable_names?)
-    return false if (SiteSetting.sso_overrides_name? && SiteSetting.enable_sso?)
+    return false unless SiteSetting.enable_names?
+    return false if SiteSetting.sso_overrides_name? && SiteSetting.enable_sso?
     return true if is_staff?
+    return false if is_anonymous?
     can_edit?(user)
   end
 

--- a/spec/components/guardian_spec.rb
+++ b/spec/components/guardian_spec.rb
@@ -9,6 +9,7 @@ describe Guardian do
   let(:user) { Fabricate(:user) }
   let(:moderator) { Fabricate(:moderator) }
   let(:admin) { Fabricate(:admin) }
+  let(:anonymous_user) { Fabricate(:anonymous) }
   let(:trust_level_1) { build(:user, trust_level: 1) }
   let(:trust_level_2) { build(:user, trust_level: 2) }
   let(:trust_level_3) { build(:user, trust_level: 3) }
@@ -2403,6 +2404,20 @@ describe Guardian do
       it "is true for admins" do
         expect(Guardian.new(admin).can_edit_username?(user)).to be_truthy
       end
+
+      it "is true for admins when changing anonymous username" do
+        expect(Guardian.new(admin).can_edit_username?(anonymous_user)).to be_truthy
+      end
+    end
+
+    context "for anonymous user" do
+      before do
+        SiteSetting.allow_anonymous_posting = true
+      end
+
+      it "is false" do
+        expect(Guardian.new(anonymous_user).can_edit_username?(anonymous_user)).to be_falsey
+      end
     end
 
     context 'for a new user' do
@@ -2474,6 +2489,16 @@ describe Guardian do
     context 'when allowed in settings' do
       before do
         SiteSetting.email_editable = true
+      end
+
+      context "for anonymous user" do
+        before do
+          SiteSetting.allow_anonymous_posting = true
+        end
+
+        it "is false" do
+          expect(Guardian.new(anonymous_user).can_edit_email?(anonymous_user)).to be_falsey
+        end
       end
 
       it "is false when not logged in" do
@@ -2552,6 +2577,16 @@ describe Guardian do
 
     it "is false for regular users to edit another user's name" do
       expect(Guardian.new(build(:user)).can_edit_name?(build(:user, created_at: 1.minute.ago))).to be_falsey
+    end
+
+    context "for anonymous user" do
+      before do
+        SiteSetting.allow_anonymous_posting = true
+      end
+
+      it "is false" do
+        expect(Guardian.new(anonymous_user).can_edit_name?(anonymous_user)).to be_falsey
+      end
     end
 
     context 'for a new user' do

--- a/test/javascripts/controllers/preferences-account-test.js.es6
+++ b/test/javascripts/controllers/preferences-account-test.js.es6
@@ -1,12 +1,13 @@
 moduleFor("controller:preferences/account");
 
-QUnit.skip("updating of associated accounts", function(assert) {
+QUnit.test("updating of associated accounts", function(assert) {
   const controller = this.subject({
     siteSettings: {
       enable_google_oauth2_logins: true
     },
     model: Ember.Object.create({
-      second_factor_enabled: true
+      second_factor_enabled: true,
+      is_anonymous: true
     }),
     site: Ember.Object.create({
       isMobileDevice: false
@@ -18,6 +19,10 @@ QUnit.skip("updating of associated accounts", function(assert) {
   assert.equal(controller.get("canUpdateAssociatedAccounts"), false);
 
   controller.set("model.second_factor_enabled", false);
+
+  assert.equal(controller.get("canUpdateAssociatedAccounts"), false);
+
+  controller.set("model.is_anonymous", false);
 
   assert.equal(controller.get("canUpdateAssociatedAccounts"), false);
 


### PR DESCRIPTION
https://meta.discourse.org/t/suspect-account-anonymous-account/112813