### PR TITLE
FIX: Fix URL to user profile.

### DIFF
--- a/plugins/poll/assets/javascripts/widgets/discourse-poll.js.es6
+++ b/plugins/poll/assets/javascripts/widgets/discourse-poll.js.es6
@@ -8,7 +8,6 @@ import evenRound from "discourse/plugins/poll/lib/even-round";
 import { avatarFor } from "discourse/widgets/post";
 import round from "discourse/lib/round";
 import { relativeAge } from "discourse/lib/formatter";
-import { userPath } from "discourse/lib/url";
 
 function optionHtml(option) {
   return new RawHtml({ html: `<span>${option.html}</span>` });
@@ -145,7 +144,6 @@ createWidget("discourse-poll-voters", {
       return h("li", [
         avatarFor("tiny", {
           username: user.username,
-          url: this.site.mobileView ? userPath(user.username) : undefined,
           template: user.avatar_template
         }),
         " "

--- a/plugins/poll/test/javascripts/acceptance/polls-test-mobile.js.es6
+++ b/plugins/poll/test/javascripts/acceptance/polls-test-mobile.js.es6
@@ -24,9 +24,9 @@ test("Public number poll", async assert => {
     "it should display the right number of voters"
   );
 
-  assert.ok(
+  assert.notOk(
     find(".poll-voters:first li:first a").attr("href"),
-    "user URL exists"
+    "user URL does not exist"
   );
 
   // eslint-disable-next-line


### PR DESCRIPTION
After latest changes to user cards, they would not work anymore when clicking on user avatars from poll results. Instead of showing the card, the user would be routed to the user profile page.

This fixes the issue reported [here](https://meta.discourse.org/t/can-i-enable-the-user-popovers-on-mobile/110296/4).