### PR TITLE
FEATURE: Hide quoted replies for ignored users

### DIFF
--- a/app/assets/javascripts/discourse/components/scrolling-post-stream.js.es6
+++ b/app/assets/javascripts/discourse/components/scrolling-post-stream.js.es6
@@ -35,6 +35,7 @@ export default MountWidget.extend({
   buildArgs() {
     return this.getProperties(
       "posts",
+      "topic",
       "canCreatePost",
       "multiSelect",
       "gaps",

--- a/app/assets/javascripts/discourse/lib/transform-post.js.es6
+++ b/app/assets/javascripts/discourse/lib/transform-post.js.es6
@@ -81,7 +81,8 @@ export function transformBasicPost(post) {
     replyCount: post.reply_count,
     locked: post.locked,
     ignored: post.ignored,
-    userCustomFields: post.user_custom_fields
+    userCustomFields: post.user_custom_fields,
+    topic: post.topic,
   };
 
   _additionalAttributes.forEach(a => (postAtts[a] = post[a]));
@@ -133,6 +134,7 @@ export default function transformPost(
   postAtts.actionCodeWho = post.action_code_who;
   postAtts.topicUrl = topic.get("url");
   postAtts.isSaving = post.isSaving;
+  postAtts.topic = topic
 
   if (post.post_notice_type) {
     postAtts.postNoticeType = post.post_notice_type;

--- a/app/assets/javascripts/discourse/widgets/post-cooked.js.es6
+++ b/app/assets/javascripts/discourse/widgets/post-cooked.js.es6
@@ -192,7 +192,7 @@ export default class PostCooked {
       : this.attrs.topicUrl;
   }
 
-  _updateQuoteElements($html, $aside, desc) {
+  _updateQuoteElements($aside, desc) {
     let navLink = "";
     const quoteTitle = I18n.t("post.follow_quote");
     let postNumber = $aside.data("post");
@@ -227,7 +227,7 @@ export default class PostCooked {
     $quotes.each((i, e) => {
       const $aside = $(e);
       if ($aside.data("post")) {
-        this._updateQuoteElements($html, $aside, "chevron-down");
+        this._updateQuoteElements($aside, "chevron-down");
         const $title = $(".title", $aside);
 
         // Unless it's a full quote, allow click to expand

--- a/app/assets/javascripts/discourse/widgets/post-cooked.js.es6
+++ b/app/assets/javascripts/discourse/widgets/post-cooked.js.es6
@@ -192,7 +192,7 @@ export default class PostCooked {
       : this.attrs.topicUrl;
   }
 
-  _updateQuoteElements($aside, desc) {
+  _updateQuoteElements($html, $aside, desc) {
     let navLink = "";
     const quoteTitle = I18n.t("post.follow_quote");
     let postNumber = $aside.data("post");
@@ -212,6 +212,9 @@ export default class PostCooked {
       expandContract = iconHTML(desc, { title: "post.expand_collapse" });
       $(".title", $aside).css("cursor", "pointer");
     }
+    if(this.attrs.topic.ignored_usernames.includes($($aside).find('.title').text().trim().slice(0, -1))) {
+      $($aside).find("p").replaceWith("<i>Hidden content</i>");
+    }
     $(".quote-controls", $aside).html(expandContract + navLink);
   }
 
@@ -224,7 +227,7 @@ export default class PostCooked {
     $quotes.each((i, e) => {
       const $aside = $(e);
       if ($aside.data("post")) {
-        this._updateQuoteElements($aside, "chevron-down");
+        this._updateQuoteElements($html, $aside, "chevron-down");
         const $title = $(".title", $aside);
 
         // Unless it's a full quote, allow click to expand

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1013,7 +1013,7 @@ class UsersController < ApplicationController
       MutedUser.where(user: current_user, muted_user: user).delete_all
       IgnoredUser.where(user: current_user, ignored_user: user).delete_all
     end
-
+    ReadThroughCache.invalidate(current_user.id, "ignored_users")
     render json: success_json
   end
 

--- a/app/serializers/topic_view_serializer.rb
+++ b/app/serializers/topic_view_serializer.rb
@@ -215,7 +215,9 @@ class TopicViewSerializer < ApplicationSerializer
   end
 
   def ignored_usernames
-    IgnoredUser.where(user: topic.user).joins(:ignored_user).pluck(:username)
+    ReadThroughCache.fetch(topic.user.id, "ignored_users") do
+      IgnoredUser.where(user: topic.user).joins(:ignored_user).pluck(:username)
+    end
   end
 
   def actions_summary

--- a/app/serializers/topic_view_serializer.rb
+++ b/app/serializers/topic_view_serializer.rb
@@ -70,7 +70,8 @@ class TopicViewSerializer < ApplicationSerializer
     :participant_count,
     :destination_category_id,
     :pm_with_non_human_user,
-    :pending_posts_count
+    :pending_posts_count,
+    :ignored_usernames
   )
 
   # TODO: Split off into proper object / serializer
@@ -211,6 +212,10 @@ class TopicViewSerializer < ApplicationSerializer
 
   def unpinned
     PinnedCheck.unpinned?(object.topic, object.topic_user)
+  end
+
+  def ignored_usernames
+    IgnoredUser.where(user: topic.user).joins(:ignored_user).pluck(:username)
   end
 
   def actions_summary

--- a/app/serializers/web_hook_topic_view_serializer.rb
+++ b/app/serializers/web_hook_topic_view_serializer.rb
@@ -20,6 +20,7 @@ class WebHookTopicViewSerializer < TopicViewSerializer
     topic_timer
     private_topic_timer
     details
+    ignored_usernames
   }.each do |attr|
     define_method("include_#{attr}?") do
       false

--- a/app/services/user_updater.rb
+++ b/app/services/user_updater.rb
@@ -187,6 +187,8 @@ class UserUpdater
         ON CONFLICT DO NOTHING
       SQL
     end
+
+    ReadThroughCache.invalidate(user.id, "ignored_users")
   end
 
   private

--- a/lib/read_through_cache.rb
+++ b/lib/read_through_cache.rb
@@ -1,0 +1,13 @@
+class ReadThroughCache
+
+  def self.fetch(scope, key, expires_in = 1.hour)
+    Rails.cache.fetch("#{scope}/#{key}", expires_in: expires_in) do
+      yield
+    end
+  end
+
+  def self.invalidate(scope, key)
+    Rails.cache.delete("#{scope}/#{key}")
+  end
+
+end


### PR DESCRIPTION
## Why?

This is part of the [Ability to ignore a user feature](https://meta.discourse.org/t/ability-to-ignore-a-user/110254/8).

## UI

![What_is_the_best_time_to_hike_Mt__Fuji__⛰_-_Discourse](https://user-images.githubusercontent.com/45508821/55479506-1e5a1480-5616-11e9-8dab-78016952fa79.png)

## Current approach

1. **Hiding a quote** is happening by returning a list of `ignored usernames` (for the current User) from the backend, and on the front-end, we are using the `ignored usernames` value to do a `find & replace` in the already cooked post HTML for the Quoted text if it matches any of the `ignored usernames` array.

Cons:

- It doesn't feel natural to hack around HTML on the front-end this way, it is unreliable as well, since we are `$($aside).find('.title').text().trim() ....` to extract the Quoted text's username, and then comparing it with **ignored usernames**.

2. **Avoiding the N+1** is important, we are returning `ignored usernames` in the `TopicViewSerializer` for each Topic load, scoped to the current User. I have wrapped this around a read-through cache to ensure it is only called once within an 1 hour of expiry time.

Cons:

- The read-through cache itself isn't terrible, but it can be fragile because we need to make sure cache invalidation works, in this case it is _manual_. Other considerations, Redis round-trip, and how efficient is the expiry period.

## Different approach

1. **Hiding a quote** method can be improved by changing the way we are cooking the post and be more explicit by adding a `data-user-id` attribute, which makes it a lot easier and more reliable for us to hide the Quoted text on the front-end. 

Cons:

- It can be time consuming since we are probably going to have to write some migration to re-bake existing quoted posts?

2. **The ignored usernames N+1** can be avoided by tweaking the way we load the current User's connected data. The relationship is: `User -> IgnoredUsers`, that means, on the front-end, we can potentially be side-loading the `IgnoredUsers` models one time only and let Ember keep the current User state stored temporarily.