### PR TITLE
Show link to the original topic when it was deleted

### DIFF
--- a/app/assets/javascripts/discourse/templates/components/reviewable-topic-link.hbs
+++ b/app/assets/javascripts/discourse/templates/components/reviewable-topic-link.hbs
@@ -7,6 +7,9 @@
   {{else if (has-block)}}
     {{yield}}
   {{else}}
-    <span class="title-text">{{i18n "topic.deleted"}}</span>
+    <span class="title-text">
+      {{i18n "review.topics.deleted"}}
+      <a href={{get-url (concat '/t/' reviewable.removed_topic_id)}}>{{i18n "review.topics.original"}}</a>
+    </span>
   {{/if}}
 </div>

--- a/app/assets/javascripts/discourse/templates/components/reviewable-topic-link.hbs
+++ b/app/assets/javascripts/discourse/templates/components/reviewable-topic-link.hbs
@@ -9,7 +9,7 @@
   {{else}}
     <span class="title-text">
       {{i18n "review.topics.deleted"}}
-      <a href={{get-url (concat '/t/' reviewable.removed_topic_id)}}>{{i18n "review.topics.original"}}</a>
+      {{link-to (i18n "review.topics.original") "topic" "-" reviewable.removed_topic_id}}
     </span>
   {{/if}}
 </div>

--- a/app/serializers/reviewable_serializer.rb
+++ b/app/serializers/reviewable_serializer.rb
@@ -73,19 +73,19 @@ class ReviewableSerializer < ApplicationSerializer
   end
 
   def attributes
-    data = super
+    super.tap do |data|
+      data[:removed_topic_id] = object.topic_id unless object.topic
 
-    if object.target.present?
-      # Automatically add the target id as a "good name" for example a target_type of `User`
-      # becomes `user_id`
-      data[:"#{object.target_type.downcase}_id"] = object.target_id
+      if object.target.present?
+        # Automatically add the target id as a "good name" for example a target_type of `User`
+        # becomes `user_id`
+        data[:"#{object.target_type.downcase}_id"] = object.target_id
+      end
+
+      if self.class._payload_for_serialization.present?
+        data[:payload] = (object.payload || {}).slice(*self.class._payload_for_serialization)
+      end
     end
-
-    if self.class._payload_for_serialization.present?
-      data[:payload] = (object.payload || {}).slice(*self.class._payload_for_serialization)
-    end
-
-    data
   end
 
   def topic_tags

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -404,6 +404,8 @@ en:
         topic: "Topic"
         reviewable_count: "Count"
         reported_by: "Reported by"
+        deleted: "[Topic Deleted]"
+        original: '(original topic)'
         details: "details"
         unique_users:
           one: "1 user"

--- a/spec/serializers/reviewable_serializer_spec.rb
+++ b/spec/serializers/reviewable_serializer_spec.rb
@@ -6,7 +6,7 @@ describe ReviewableSerializer do
   let(:admin) { Fabricate(:admin) }
 
   it "serializes all the fields" do
-    json = ReviewableSerializer.new(reviewable, scope: Guardian.new(admin), root: nil).as_json
+    json = described_class.new(reviewable, scope: Guardian.new(admin), root: nil).as_json
 
     expect(json[:id]).to eq(reviewable.id)
     expect(json[:status]).to eq(reviewable.status)
@@ -15,6 +15,15 @@ describe ReviewableSerializer do
     expect(json[:category_id]).to eq(reviewable.category_id)
     expect(json[:can_edit]).to eq(true)
     expect(json[:version]).to eq(0)
+    expect(json[:removed_topic_id]).to be_nil
+  end
+
+  it 'Includes the removed topic id when the topis was deleted' do
+    reviewable.topic.trash!(admin)
+
+    json = described_class.new(reviewable.reload, scope: Guardian.new(admin), root: nil).as_json
+
+    expect(json[:removed_topic_id]).to eq reviewable.topic_id
   end
 
   it "will not throw an error when the payload is `nil`" do
@@ -22,5 +31,4 @@ describe ReviewableSerializer do
     json = ReviewableQueuedPostSerializer.new(reviewable, scope: Guardian.new(admin), root: nil).as_json
     expect(json['payload']).to be_blank
   end
-
 end


### PR DESCRIPTION
![otopic](https://user-images.githubusercontent.com/5025816/55506440-cfb77500-562b-11e9-9674-00cb9119e307.png)

### Changes
- i18n keys were moved into core since they're being used and not on the Akismet plugin.
- Added `removed_topic_id` to the serializer when the topic was deleted.