### PR TITLE
FIX: skip some checks for CJK locale in TextSentinel

### DIFF
--- a/lib/text_sentinel.rb
+++ b/lib/text_sentinel.rb
@@ -69,12 +69,18 @@ class TextSentinel
     @text.gsub(symbols_regex, '').size > 0
   end
 
+  def skipped_locale
+    %w(zh_CN zh_TW ko ja).freeze
+  end
+
   def seems_unpretentious?
+    return true if skipped_locale.include?(SiteSetting.default_locale)
     # Don't allow super long words if there is a word length maximum
     @opts[:max_word_length].blank? || @text.split(/\s|\/|-|\.|:/).map(&:size).max <= @opts[:max_word_length]
   end
 
   def seems_quiet?
+    return true if skipped_locale.include?(SiteSetting.default_locale)
     # We don't allow all upper case content
     SiteSetting.allow_uppercase_posts || @text == @text.mb_chars.downcase.to_s || @text != @text.mb_chars.upcase.to_s
   end

--- a/spec/components/text_sentinel_spec.rb
+++ b/spec/components/text_sentinel_spec.rb
@@ -95,6 +95,17 @@ describe TextSentinel do
       expect(TextSentinel.new("去年十二月，北韓不顧國際社會警告")).to be_valid
     end
 
+    it "skips uppercase text for CJK locale" do
+      SiteSetting.default_locale = 'zh_CN'
+      expect(TextSentinel.new("去年SHIER月，北韓不顧國際社會警告")).to be_valid
+    end
+
+    it "skips long words check (`seems_unpretentious`) for CJK locale" do
+      SiteSetting.default_locale = 'zh_CN'
+      expect(TextSentinel.title_sentinel("非常长的文字没有空格分割肯定会触发警告但这不应该是一个错误这个要超过五十个个字符"*2)).to be_valid
+    end
+
+
     it "doesn't allow a long alphanumeric string with no spaces" do
       expect(TextSentinel.new("jfewjfoejwfojeojfoejofjeo3" * 5, max_word_length: 30)).not_to be_valid
     end

--- a/spec/components/text_sentinel_spec.rb
+++ b/spec/components/text_sentinel_spec.rb
@@ -102,9 +102,8 @@ describe TextSentinel do
 
     it "skips long words check (`seems_unpretentious`) for CJK locale" do
       SiteSetting.default_locale = 'zh_CN'
-      expect(TextSentinel.title_sentinel("非常长的文字没有空格分割肯定会触发警告但这不应该是一个错误这个要超过五十个个字符"*2)).to be_valid
+      expect(TextSentinel.title_sentinel("非常长的文字没有空格分割肯定会触发警告但这不应该是一个错误这个要超过五十个个字符" * 2)).to be_valid
     end
-
 
     it "doesn't allow a long alphanumeric string with no spaces" do
       expect(TextSentinel.new("jfewjfoejwfojeojfoejofjeo3" * 5, max_word_length: 30)).not_to be_valid


### PR DESCRIPTION
continuation of #7045