### PR TITLE
FIX: don't trigger notifications when changing category/tags of unlisted topics

### DIFF
--- a/app/jobs/regular/notify_category_change.rb
+++ b/app/jobs/regular/notify_category_change.rb
@@ -5,7 +5,7 @@ module Jobs
     def execute(args)
       post = Post.find_by(id: args[:post_id])
 
-      if post&.topic
+      if post&.topic&.visible?
         post_alerter = PostAlerter.new
         post_alerter.notify_post_users(post, User.where(id: args[:notified_user_ids]))
         post_alerter.notify_first_post_watchers(post, post_alerter.category_watchers(post.topic))

--- a/app/jobs/regular/notify_tag_change.rb
+++ b/app/jobs/regular/notify_tag_change.rb
@@ -5,7 +5,7 @@ module Jobs
     def execute(args)
       post = Post.find_by(id: args[:post_id])
 
-      if post&.topic
+      if post&.topic&.visible?
         post_alerter = PostAlerter.new
         post_alerter.notify_post_users(post, User.where(id: args[:notified_user_ids]))
         post_alerter.notify_first_post_watchers(post, post_alerter.tag_watchers(post.topic))

--- a/spec/services/post_alerter_spec.rb
+++ b/spec/services/post_alerter_spec.rb
@@ -945,10 +945,10 @@ describe PostAlerter do
       before do
         SiteSetting.tagging_enabled = true
         Jobs.run_immediately!
+        TagUser.change(user.id, watched_tag.id, TagUser.notification_levels[:watching_first_post])
       end
 
       it "triggers a notification" do
-        TagUser.change(user.id, watched_tag.id, TagUser.notification_levels[:watching_first_post])
         expect(user.notifications.where(notification_type: Notification.types[:watching_first_post]).count).to eq(0)
 
         PostRevisor.new(post).revise!(Fabricate(:user), tags: [other_tag.name, watched_tag.name])
@@ -956,6 +956,15 @@ describe PostAlerter do
 
         PostRevisor.new(post).revise!(Fabricate(:user), tags: [watched_tag.name, other_tag.name])
         expect(user.notifications.where(notification_type: Notification.types[:watching_first_post]).count).to eq(1)
+      end
+
+      it "doesn't trigger a notification if topic is unlisted" do
+        post.topic.update_column(:visible, false)
+
+        expect(user.notifications.where(notification_type: Notification.types[:watching_first_post]).count).to eq(0)
+
+        PostRevisor.new(post).revise!(Fabricate(:user), tags: [other_tag.name, watched_tag.name])
+        expect(user.notifications.where(notification_type: Notification.types[:watching_first_post]).count).to eq(0)
       end
     end
   end


### PR DESCRIPTION
https://meta.discourse.org/t/any-way-to-not-send-emails-when-a-topic-category-is-changed/112845/13