### PR TITLE
DEV: remove span from inside <tr> and move meta info to a td

### DIFF
--- a/app/views/list/list.erb
+++ b/app/views/list/list.erb
@@ -53,32 +53,30 @@
       <meta itemprop='itemListOrder' content='http://schema.org/ItemListOrderDescending'>
       <% @list.topics.each_with_index do |t,i| %>
         <tr>
-          <span itemprop='itemListElement' itemscope itemtype='http://schema.org/ListItem'>
+          <td itemprop='itemListElement' itemscope itemtype='http://schema.org/ListItem'>
             <meta itemprop='position' content='<%= i %>'>
             <meta itemprop='url' content='<%= t.url %>'>
             <meta itemprop='name' content='<%= t.title %>'>
-            <td>
-              <a href='<%= t.url %>' class='title raw-link raw-topic-link'>
-                <span><%= t.title %></span>
-              </a>
-              <% if (!@category || @category.has_children?) && t.category %>
-                <div>
-                  <a href='<%= t.category.url %>'><span class='category-name'><%= t.category.name %></span></a>
-                </div>
-              <% end %>
-              <% if t.pinned_until && (t.pinned_until > Time.zone.now) && (t.pinned_globally || @list.category) && t.excerpt %>
-                <p class='excerpt'>
-                  <%= t.excerpt.html_safe %>
-                </p>
-              <% end %>
-            </td>
-            <td>
-              <span class='posts' title='<%= t 'posts' %>'><%= t.posts_count %></span>
-            </td>
-            <td>
-              <%= I18n.l(t.created_at, format: :date_only) %>
-            </td>
-          </span>
+            <a href='<%= t.url %>' class='title raw-link raw-topic-link'>
+              <span><%= t.title %></span>
+            </a>
+            <% if (!@category || @category.has_children?) && t.category %>
+              <div>
+                <a href='<%= t.category.url %>'><span class='category-name'><%= t.category.name %></span></a>
+              </div>
+            <% end %>
+            <% if t.pinned_until && (t.pinned_until > Time.zone.now) && (t.pinned_globally || @list.category) && t.excerpt %>
+              <p class='excerpt'>
+                <%= t.excerpt.html_safe %>
+              </p>
+            <% end %>
+          </td>
+          <td>
+            <span class='posts' title='<%= t 'posts' %>'><%= t.posts_count %></span>
+          </td>
+          <td>
+            <%= I18n.l(t.created_at, format: :date_only) %>
+          </td>
         </tr>
       <% end %>
     </tbody>


### PR DESCRIPTION
https://review.discourse.org/t/feature-change-layout-of-escaped-fragment-topic-page-to-table-one-like-live-discourse-7250/2427/3
I have moved it out of span to <td>. I have tested that parsing for crawler works as expected. Moving meta info to <tr> threw errors when testing its parsing so have moved it to <td>