### PR TITLE
FEATURE: Add disable dashboard stats site setting

### DIFF
--- a/app/jobs/scheduled/dashboard_stats.rb
+++ b/app/jobs/scheduled/dashboard_stats.rb
@@ -8,7 +8,7 @@ module Jobs
 
     def execute(args)
       return if SiteSetting.disable_dashboard_stats == true
-      
+
       problems_started_at = AdminDashboardData.problems_started_at
       if problems_started_at && problems_started_at < 2.days.ago
         # If there have been problems reported on the dashboard for a while,

--- a/app/jobs/scheduled/dashboard_stats.rb
+++ b/app/jobs/scheduled/dashboard_stats.rb
@@ -7,6 +7,8 @@ module Jobs
     every 30.minutes
 
     def execute(args)
+      return if SiteSetting.disable_dashboard_stats == true
+      
       problems_started_at = AdminDashboardData.problems_started_at
       if problems_started_at && problems_started_at < 2.days.ago
         # If there have been problems reported on the dashboard for a while,

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1968,6 +1968,8 @@ en:
 
     default_text_size: "Text size which is selected by default"
 
+    disable_dashboard_stats: "Disable "New advice on your site dashboard" messages"
+
     retain_web_hook_events_period_days: "Number of days to retain web hook event records."
     retry_web_hook_events: "Automatically retry failed web hook events for 4 times. Time gaps between the retries are 1, 5, 25 and 125 minutes."
 

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1845,6 +1845,9 @@ uncategorized:
   always_include_topic_excerpts:
     default: false
     hidden: true
+    
+  disable_dashboard_stats:
+    default: false
 
 user_preferences:
   default_email_digest_frequency:


### PR DESCRIPTION
Some Discourse instances may want to disable the weekly dashboard PM called "New advice on your site dashboard". This PR adds a site setting (default off/false) that will cause the PM to not be sent if enabled by an admin.

See this link for some more context: https://meta.discourse.org/t/disable-new-advice-on-your-site-dashboard-inbox-spam/110981