### PR TITLE
add image to user's crawler page

### DIFF
--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -900,9 +900,6 @@ span.highlighted {
 }
 
 #breadcrumbs {
-  .badge-category-bg {
-    background-color: $secondary-high;
-  }
   .category-title {
     color: $primary;
   }

--- a/app/assets/stylesheets/desktop/user.scss
+++ b/app/assets/stylesheets/desktop/user.scss
@@ -246,3 +246,10 @@
     margin-top: s(1);
   }
 }
+
+.user-crawler {
+  .username {
+    margin-left: 5px;
+    display: inline-block;
+  }
+}

--- a/app/helpers/topics_helper.rb
+++ b/app/helpers/topics_helper.rb
@@ -11,9 +11,9 @@ module TopicsHelper
     category = topic.category
     if category && !category.uncategorized?
       if (parent = category.parent_category)
-        breadcrumb.push url: parent.url, name: parent.name
+        breadcrumb.push url: parent.url, name: parent.name, color: parent.color
       end
-      breadcrumb.push url: category.url, name: category.name
+      breadcrumb.push url: category.url, name: category.name, color: category.color
     end
 
     Plugin::Filter.apply(:topic_categories_breadcrumb, topic, breadcrumb)

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -11,7 +11,7 @@
         itemref="breadcrumb-<%=(i+1)%>"
       <%-end%>>
       <a href="<%=c[:url]%>" itemprop="url" class='badge-wrapper bullet'>
-        <span class="badge-category-bg"></span>
+        <span class="badge-category-bg" style='background-color: #<%= c[:color] %>'></span>
         <span itemprop="title" class='category-title'><%=c[:name]%></span>
       </a>
     </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,4 +1,7 @@
-<h2><%= @user.username %></h2>
+<div class='user-crawler'>
+	<img src='<%= get_absolute_image_url(@user.small_avatar_url) %>' alt='Image of <%= @user.username %>' title='<%= @user.username %>' />
+	<h2 class='username'><%= @user.username %></h2>
+</div>
 
 <% unless @restrict_fields %>
 <p><%= raw @user.user_profile.bio_processed %></p>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,5 +1,5 @@
 <div class='user-crawler'>
-	<img src='<%= get_absolute_image_url(@user.small_avatar_url) %>' alt='<%= t('user.image_alt', username: @user.username) %>' title='<%= @user.username %>' />
+	<img src='<%= UrlHelper.local_cdn_url(get_absolute_image_url(@user.small_avatar_url)) %>' alt='<%= @user.username %>' title='<%= @user.username %>' />
 	<h2 class='username'><%= @user.username %></h2>
 </div>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,5 +1,5 @@
 <div class='user-crawler'>
-	<img src='<%= get_absolute_image_url(@user.small_avatar_url) %>' alt='Image of <%= @user.username %>' title='<%= @user.username %>' />
+	<img src='<%= get_absolute_image_url(@user.small_avatar_url) %>' alt='<%= t('user.image_alt', username: @user.username) %>' title='<%= @user.username %>' />
 	<h2 class='username'><%= @user.username %></h2>
 </div>
 

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2222,7 +2222,6 @@ en:
       fixed_primary_email: "Fixed primary email for staged user"
       same_ip_address: "Same IP address (%{ip_address}) as other users"
       inactive_user: "Inactive user"
-    image_alt: "Image of %{username}"
 
   reviewables_reminder:
     submitted:

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2222,6 +2222,7 @@ en:
       fixed_primary_email: "Fixed primary email for staged user"
       same_ip_address: "Same IP address (%{ip_address}) as other users"
       inactive_user: "Inactive user"
+    image_alt: "Image of %{username}"
 
   reviewables_reminder:
     submitted:


### PR DESCRIPTION
use category-colour instead of static colour in post layout's breadcrumbs

Related to https://meta.discourse.org/t/improving-discourse-static-html-archive/112497

Let me know if you have any suggestions on what we can add to this page. Any other information we can show to the unauthenticated user? An image was already used in meta information for crawler so I have added in UI too.

![Screenshot from 2019-04-06 10-54-40](https://user-images.githubusercontent.com/6376157/55665461-b0a02980-585d-11e9-9228-14778b67364f.png)
