### PR TITLE
FIX: fix notifications for flag PMs and show topics with moderator posts in inbox

### DIFF
--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -304,7 +304,7 @@ class TopicQuery
     list = private_messages_for(user, :user)
 
     list = not_archived(list, user)
-      .where('NOT (topics.participant_count = 1 AND topics.user_id = ?)', user.id)
+      .where('NOT (topics.participant_count = 1 AND topics.user_id = ? AND topics.moderator_posts_count = 0)', user.id)
 
     create_list(:private_messages, {}, list)
   end

--- a/spec/components/topic_query_spec.rb
+++ b/spec/components/topic_query_spec.rb
@@ -1042,4 +1042,16 @@ describe TopicQuery do
       end
     end
   end
+
+  describe '#list_private_messages' do
+    it "includes topics with moderator posts" do
+      private_message_topic = Fabricate(:private_message_post, user: user).topic
+
+      expect(TopicQuery.new(user).list_private_messages(user).topics).to be_empty
+
+      private_message_topic.add_moderator_post(admin, "Thank you for your flag")
+
+      expect(TopicQuery.new(user).list_private_messages(user).topics).to eq([private_message_topic])
+    end
+  end
 end


### PR DESCRIPTION
https://meta.discourse.org/t/not-seeing-replies-to-report-pms/101844/14

Some old moderator posts that were not correctly processed before this change and [993d8f34](https://github.com/discourse/discourse/commit/993d8f346e3030fd1ad148ce55fe468371215e03) are not listed under /u/username/messages