### PR TITLE
DEV: Improve support for plugins creating topics / posts.

### DIFF
--- a/app/assets/javascripts/discourse/models/composer.js.es6
+++ b/app/assets/javascripts/discourse/models/composer.js.es6
@@ -724,6 +724,7 @@ const Composer = RestModel.extend({
     }
 
     const props = {
+      topic_id: this.topic.id,
       raw: this.reply,
       raw_old: this.editConflict ? null : this.originalText,
       edit_reason: opts.editReason,

--- a/app/assets/javascripts/discourse/widgets/notification-item.js.es6
+++ b/app/assets/javascripts/discourse/widgets/notification-item.js.es6
@@ -85,6 +85,11 @@ createWidget("notification-item", {
     }
 
     if (this.attrs.fancy_title) {
+      if (this.attrs.topic_id) {
+        return `<span data-topic-id="${this.attrs.topic_id}">${
+          this.attrs.fancy_title
+        }</span>`;
+      }
       return this.attrs.fancy_title;
     }
 

--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -169,7 +169,7 @@
         display: none;
       }
 
-      span {
+      span:first-child {
         color: $primary;
       }
 

--- a/app/assets/stylesheets/common/base/user.scss
+++ b/app/assets/stylesheets/common/base/user.scss
@@ -671,7 +671,7 @@
       margin-right: 0.5em;
     }
 
-    span {
+    span:first-child {
       color: $primary;
     }
 

--- a/app/assets/stylesheets/common/components/user-stream-item.scss
+++ b/app/assets/stylesheets/common/components/user-stream-item.scss
@@ -102,7 +102,7 @@
     p {
       display: inline-block;
 
-      span {
+      span:first-child {
         color: $primary;
       }
     }

--- a/lib/post_creator.rb
+++ b/lib/post_creator.rb
@@ -56,6 +56,7 @@ class PostCreator
   #     pinned_at             - Topic pinned time (optional)
   #     pinned_globally       - Is the topic pinned globally (optional)
   #     shared_draft          - Is the topic meant to be a shared draft
+  #     topic_opts            - Options to be overwritten for topic
   #
   def initialize(user, opts)
     # TODO: we should reload user in case it is tainted, should take in a user_id as opposed to user
@@ -410,7 +411,8 @@ class PostCreator
   def create_topic
     return if @topic
     begin
-      topic_creator = TopicCreator.new(@user, guardian, @opts)
+      opts = @opts[:topic_opts] ? @opts.merge(@opts[:topic_opts]) : @opts
+      topic_creator = TopicCreator.new(@user, guardian, opts)
       @topic = topic_creator.create
     rescue ActiveRecord::Rollback
       rollback_from_errors!(topic_creator)

--- a/lib/topic_creator.rb
+++ b/lib/topic_creator.rb
@@ -37,6 +37,9 @@ class TopicCreator
   def create
     topic = Topic.new(setup_topic_params)
     setup_tags(topic)
+    if fields = @opts[:custom_fields]
+      topic.custom_fields = fields
+    end
 
     DiscourseEvent.trigger(:before_create_topic, topic, self)
 

--- a/spec/components/new_post_manager_spec.rb
+++ b/spec/components/new_post_manager_spec.rb
@@ -212,7 +212,7 @@ describe NewPostManager do
       handler = -> { nil }
 
       NewPostManager.add_handler(&handler)
-      expect(NewPostManager.handlers).to eq([default_handler, handler])
+      expect(NewPostManager.handlers).to eq([handler])
     end
 
     it "can be added in high priority" do
@@ -223,7 +223,7 @@ describe NewPostManager do
       NewPostManager.add_handler(100, &a)
       NewPostManager.add_handler(50, &b)
       NewPostManager.add_handler(101, &c)
-      expect(NewPostManager.handlers).to eq([c, a, b, default_handler])
+      expect(NewPostManager.handlers).to eq([c, a, b])
     end
 
   end

--- a/spec/components/post_creator_spec.rb
+++ b/spec/components/post_creator_spec.rb
@@ -54,6 +54,11 @@ describe PostCreator do
       expect { creator.create }.to raise_error(Discourse::InvalidAccess)
     end
 
+    it "can be created with custom fields" do
+      post = PostCreator.create(user, basic_topic_params.merge(topic_opts: { custom_fields: { hello: "world" } }))
+      expect(post.topic.custom_fields).to eq("hello" => "world")
+    end
+
     context "reply to post number" do
       it "omits reply to post number if received on a new topic" do
         p = PostCreator.new(user, basic_topic_params.merge(reply_to_post_number: 3)).create


### PR DESCRIPTION
First improvement brought by this PR is the ability to register `NewPostManager` handlers for private messages. The other improvements are minor and basically add more options to `PostCreator` and `TopicCreator`.

These improvements are required for `discourse-encrypt`. Right now, the plugin makes two requests when creating a new topic - one is the "default" one that simply creates a topic and another one is supplying the title and keys and saving them in a `TopicCustomField` and `PluginStore`.

With these changes, I can simply do this:

```ruby
  add_permitted_post_create_param(:encryptedTitle)
  add_permitted_post_create_param(:encryptedRaw)
  add_permitted_post_create_param(:encryptedKeys)

  NewPostManager.add_handler do |manager|
    next if manager.args[:archetype] != Archetype.private_message || !manager.args[:encryptedRaw]

    manager.args[:raw] = manager.args[:encryptedRaw]
    manager.args[:skip_unique_check] = true
    if title = manager.args[:encryptedTitle]
      manager.args[:topic_opts] ||= {}
      manager.args[:topic_opts][:custom_fields] ||= {}
      manager.args[:topic_opts][:custom_fields][:encrypted_title] = manager.args[:encryptedTitle]
    end

    result = manager.perform_create_post
    if result.success?
      keys = JSON.parse(manager.args[:encryptedKeys])
      topic_id = result.post.topic_id
      users = Hash[User.where(username: keys.keys).map { |u| [u.username, u] }]

      keys.each { |u, k| PluginStore.set("discourse-encrypt", "key_#{topic_id}_#{users[u].id}", k) }
    end

    result
  end
```