### PR TITLE
REFACTOR: Pass down `currentUser` to `post-cooked` widget

### DIFF
--- a/app/assets/javascripts/discourse/widgets/embedded-post.js.es6
+++ b/app/assets/javascripts/discourse/widgets/embedded-post.js.es6
@@ -41,7 +41,7 @@ export default createWidget("embedded-post", {
                 shareUrl: attrs.shareUrl
               })
             ]),
-            new PostCooked(attrs, new DecoratorHelper(this))
+            new PostCooked(attrs, new DecoratorHelper(this), this.currentUser)
           ])
         ])
       ])

--- a/app/assets/javascripts/discourse/widgets/post-cooked.js.es6
+++ b/app/assets/javascripts/discourse/widgets/post-cooked.js.es6
@@ -12,18 +12,11 @@ export function addDecorator(cb) {
 }
 
 export default class PostCooked {
-  constructor(attrs, decoratorHelper) {
+  constructor(attrs, decoratorHelper, currentUser) {
     this.attrs = attrs;
     this.expanding = false;
     this._highlighted = false;
-
-    if (decoratorHelper) {
-      this.decoratorHelper = decoratorHelper;
-      if (decoratorHelper.widget && decoratorHelper.widget.currentUser) {
-        this.currentUser = decoratorHelper.widget.currentUser;
-      }
-    }
-
+    this.currentUser = currentUser;
     this.ignoredUsers = this.currentUser
       ? this.currentUser.ignored_users
       : null;

--- a/app/assets/javascripts/discourse/widgets/post.js.es6
+++ b/app/assets/javascripts/discourse/widgets/post.js.es6
@@ -355,7 +355,7 @@ createWidget("post-contents", {
   },
 
   html(attrs, state) {
-    let result = [new PostCooked(attrs, new DecoratorHelper(this))];
+    let result = [new PostCooked(attrs, new DecoratorHelper(this), this.currentUser)];
     result = result.concat(applyDecorators(this, "after-cooked", attrs, state));
 
     if (attrs.cooked_hidden) {

--- a/app/assets/javascripts/discourse/widgets/post.js.es6
+++ b/app/assets/javascripts/discourse/widgets/post.js.es6
@@ -355,7 +355,9 @@ createWidget("post-contents", {
   },
 
   html(attrs, state) {
-    let result = [new PostCooked(attrs, new DecoratorHelper(this), this.currentUser)];
+    let result = [
+      new PostCooked(attrs, new DecoratorHelper(this), this.currentUser)
+    ];
     result = result.concat(applyDecorators(this, "after-cooked", attrs, state));
 
     if (attrs.cooked_hidden) {


### PR DESCRIPTION
## Why?

This is part of the [Ability to ignore a user feature](https://meta.discourse.org/t/ability-to-ignore-a-user/110254/8).

Instead of evaluating the `currentUser` from the `DecoratorHelper`, we are passing it down from the `post` widget to the `post-cooked` widget.