### PR TITLE
DEV: Expose a way to extend a method that returns a list

### DIFF
--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -605,11 +605,15 @@ class Plugin::Instance
   end
 
   def register_reviewable_type(reviewable_type_class)
-    types = Reviewable.types
-    types << reviewable_type_class.name
+    extend_list_method Reviewable, :types, [reviewable_type_class.name]
+  end
+
+  def extend_list_method(klass, method, new_attributes)
+    current_list = klass.send(method)
+    current_list.concat(new_attributes)
 
     reloadable_patch do
-      Reviewable.send(:define_singleton_method, :types) { types }
+      klass.send(:define_singleton_method, method) { current_list }
     end
   end
 

--- a/spec/components/plugin/instance_spec.rb
+++ b/spec/components/plugin/instance_spec.rb
@@ -465,11 +465,22 @@ describe Plugin::Instance do
   describe '#register_reviewable_types' do
     it 'Overrides the existing Reviewable types adding new ones' do
       current_types = Reviewable.types
-      new_type_class = Class
+       new_type_class = Class
 
-      Plugin::Instance.new.register_reviewable_type new_type_class
+       Plugin::Instance.new.register_reviewable_type new_type_class
 
-      expect(Reviewable.types).to match_array(current_types << new_type_class.name)
+       expect(Reviewable.types).to match_array(current_types << new_type_class.name)
+    end
+  end
+
+  describe '#extend_list_method' do
+    it 'Overrides the existing list appending new elements' do
+      current_list = Reviewable.types
+      new_element = Class.name
+
+      Plugin::Instance.new.extend_list_method Reviewable, :types, [new_element]
+
+      expect(Reviewable.types).to match_array(current_list << new_element)
     end
   end
 end


### PR DESCRIPTION
This is the third time I find myself needing to use this pattern for a plugin (I'm going to need it again for `discourse-sift`) and thought it was a good idea to expose a method in the plugin instance API.

It's going to be used for:
 - Registering a `ReviewableAkismetPost` type
 - Registering a `ReviewableSiftPost` type
 - Extend `UserHistory#user_history_actions` with `discourse-akismet` custom actions.
 - Extend `UserHistory#user_history_actions` with `discourse-sift` custom actions.