### PR TITLE
FIX: Keep highlighted text for quoted replies by ignored users

### DIFF
--- a/app/assets/javascripts/discourse/widgets/post-cooked.js.es6
+++ b/app/assets/javascripts/discourse/widgets/post-cooked.js.es6
@@ -145,7 +145,7 @@ export default class PostCooked {
       const $blockQuote = $("> blockquote", $aside);
       $aside.data("original-contents", $blockQuote.html());
 
-      const originalText = $blockQuote.text().trim();
+      const originalText = $blockQuote.text().trim() || $("> blockquote", this.attrs.cooked).text().trim();
       $blockQuote.html(I18n.t("loading"));
       let topicId = this.attrs.topicId;
       if ($aside.data("topic")) {

--- a/app/assets/javascripts/discourse/widgets/post-cooked.js.es6
+++ b/app/assets/javascripts/discourse/widgets/post-cooked.js.es6
@@ -145,7 +145,11 @@ export default class PostCooked {
       const $blockQuote = $("> blockquote", $aside);
       $aside.data("original-contents", $blockQuote.html());
 
-      const originalText = $blockQuote.text().trim() || $("> blockquote", this.attrs.cooked).text().trim();
+      const originalText =
+        $blockQuote.text().trim() ||
+        $("> blockquote", this.attrs.cooked)
+          .text()
+          .trim();
       $blockQuote.html(I18n.t("loading"));
       let topicId = this.attrs.topicId;
       if ($aside.data("topic")) {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2243,7 +2243,7 @@ en:
       quote_reply: "Quote"
       edit_reason: "Reason: "
       post_number: "post {{number}}"
-      ignored: "Hidden content"
+      ignored: "Ignored content"
       wiki_last_edited_on: "wiki last edited on"
       last_edited_on: "post last edited on"
       reply_as_new_topic: "Reply as linked Topic"
@@ -2251,7 +2251,7 @@ en:
       continue_discussion: "Continuing the discussion from {{postLink}}:"
       follow_quote: "go to the quoted post"
       show_full: "Show Full Post"
-      show_hidden: "View hidden content."
+      show_hidden: "View ignored content."
       deleted_by_author:
         one: "(post withdrawn by author, will be automatically deleted in %{count} hour unless flagged)"
         other: "(post withdrawn by author, will be automatically deleted in %{count} hours unless flagged)"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -880,7 +880,7 @@ en:
     user_must_edit: "<p>This post was flagged by the community and is temporarily hidden.</p>"
 
   ignored:
-    hidden_content: "<p>Hidden content</p>"
+    hidden_content: "<p>Ignored content</p>"
 
   archetypes:
     regular:


### PR DESCRIPTION
## Why?

This is part of the [Ability to ignore a user feature](https://meta.discourse.org/t/ability-to-ignore-a-user/110254/8).

We hide/remove any ignored user quoted text in any of the posts for a certain topic. Users can **expand** the ignored user quoted text, and as a result, the **highlighting** logic wasn't working. This PR is to fix this behaviour.

### UI

#### Before
![GIF 1](https://user-images.githubusercontent.com/45508821/55800870-9cae2f00-5acc-11e9-9ae8-6cdfaf675911.gif)

#### After

![GIF 2 with hightlights](https://user-images.githubusercontent.com/45508821/55800879-a0da4c80-5acc-11e9-92be-6b99b483283a.gif)

 