### PR TITLE
FIX: correctly retrieve 'login required' setting value on wizard

### DIFF
--- a/app/assets/javascripts/wizard/templates/components/wizard-field-checkbox.hbs
+++ b/app/assets/javascripts/wizard/templates/components/wizard-field-checkbox.hbs
@@ -1,0 +1,7 @@
+<label>
+{{input type="checkbox"
+        class="wizard-checkbox"
+        checked=field.value}}
+
+{{field.placeholder}}
+</label>

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -4261,10 +4261,12 @@ en:
             choices:
               open:
                 label: "Public"
-                description: "Anyone can access this community and sign up for an account"
+                description: "Anyone can access this community"
               restricted:
                 label: "Private"
-                description: "Only people I have invited or approved can access this community"
+                description: "Only logged in users can access this community"
+          invite_only:
+              placeholder: "Account can be created by invitation only, sign ups are disabled."
 
       contact:
         title: "Contact"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -4266,7 +4266,7 @@ en:
                 label: "Private"
                 description: "Only logged in users can access this community"
           invite_only:
-              placeholder: "Account can be created by invitation only, sign ups are disabled."
+              placeholder: "People must be explicitly invited. Public registration is disabled."
 
       contact:
         title: "Contact"

--- a/lib/wizard/builder.rb
+++ b/lib/wizard/builder.rb
@@ -76,17 +76,22 @@ class Wizard
       end
 
       @wizard.append_step('privacy') do |step|
-        locked = SiteSetting.login_required? && SiteSetting.invite_only?
         privacy = step.add_field(id: 'privacy',
                                  type: 'radio',
                                  required: true,
-                                 value: locked ? 'restricted' : 'open')
+                                 value: SiteSetting.login_required? ? 'restricted' : 'open')
         privacy.add_choice('open', icon: 'unlock')
         privacy.add_choice('restricted', icon: 'lock')
 
+        invite_only = step.add_field(id: 'invite_only',
+                                     type: 'checkbox',
+                                     required: false,
+                                     placeholder: 'wizard.invites.add_user',
+                                     value: SiteSetting.invite_only?)
+
         step.on_update do |updater|
           updater.update_setting(:login_required, updater.fields[:privacy] == 'restricted')
-          updater.update_setting(:invite_only, updater.fields[:privacy] == 'restricted')
+          updater.update_setting(:invite_only, updater.fields[:invite_only])
         end
       end
 

--- a/spec/components/wizard/step_updater_spec.rb
+++ b/spec/components/wizard/step_updater_spec.rb
@@ -63,7 +63,7 @@ describe Wizard::StepUpdater do
 
   context "privacy settings" do
     it "updates to open correctly" do
-      updater = wizard.create_updater('privacy', privacy: 'open')
+      updater = wizard.create_updater('privacy', privacy: 'open', invite_only: false)
       updater.update
       expect(updater.success?).to eq(true)
       expect(SiteSetting.login_required?).to eq(false)
@@ -72,7 +72,7 @@ describe Wizard::StepUpdater do
     end
 
     it "updates to private correctly" do
-      updater = wizard.create_updater('privacy', privacy: 'restricted')
+      updater = wizard.create_updater('privacy', privacy: 'restricted', invite_only: true)
       updater.update
       expect(updater.success?).to eq(true)
       expect(SiteSetting.login_required?).to eq(true)

--- a/spec/components/wizard/wizard_builder_spec.rb
+++ b/spec/components/wizard/wizard_builder_spec.rb
@@ -113,4 +113,22 @@ describe Wizard::Builder do
       end
     end
   end
+
+  context 'privacy step' do
+    let(:privacy_step) { wizard.steps.find { |s| s.id == 'privacy' } }
+
+    it 'should set the right default value for the fields' do
+      SiteSetting.login_required = true
+      SiteSetting.invite_only = false
+
+      fields = privacy_step.fields
+      login_required_field = fields.first
+      invite_only_field = fields.last
+
+      expect(login_required_field.id).to eq('privacy')
+      expect(login_required_field.value).to eq("restricted")
+      expect(invite_only_field.id).to eq('invite_only')
+      expect(invite_only_field.value).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
FEATURE: extract 'invite only' setting in a separate checkbox control

![Screenshot from 2019-04-11 10-25-47](https://user-images.githubusercontent.com/5732281/55931709-34825900-5c44-11e9-8869-3702ef9c7156.png)
