### PR TITLE
DEV: Add utf8-cleaner gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -215,3 +215,4 @@ end
 gem 'webpush', require: false
 gem 'colored2', require: false
 gem 'maxminddb'
+gem 'utf8-cleaner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -443,6 +443,8 @@ GEM
       kgio (~> 2.6)
       raindrops (~> 0.7)
     uniform_notifier (1.12.1)
+    utf8-cleaner (0.2.5)
+      activesupport
     webmock (3.4.2)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -568,6 +570,7 @@ DEPENDENCIES
   uglifier
   unf
   unicorn
+  utf8-cleaner
   webmock
   webpush
 

--- a/lib/middleware/discourse_public_exceptions.rb
+++ b/lib/middleware/discourse_public_exceptions.rb
@@ -16,10 +16,6 @@ module Middleware
       exception = env["action_dispatch.exception"]
       response = ActionDispatch::Response.new
 
-      # Special handling for invalid params, in this case we can not re-dispatch
-      # the Request object has a "broken" .params which can not be accessed
-      exception = nil if Rack::QueryParser::InvalidParameterError === exception
-
       # We also can not dispatch bad requests as no proper params
       exception = nil if ActionController::BadRequest === exception
 

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -88,33 +88,13 @@ RSpec.describe ApplicationController do
       Rails.logger = @old_logger
     end
 
-    it 'should not raise a 500 (nor should it log a warning) for bad params' do
+    it 'should clean bad params from request via utf8-cleaner gem' do
       bad_str = "d\xDE".force_encoding('utf-8')
       expect(bad_str.valid_encoding?).to eq(false)
 
       get "/latest.json", params: { test: bad_str }
 
-      expect(response.status).to eq(400)
-
-      log = @logs.string
-
-      if (log.include? 'exception app middleware')
-        # heisentest diagnostics
-        puts
-        puts "EXTRA DIAGNOSTICS FOR INTERMITENT TEST FAIL"
-        puts log
-        puts ">> action_dispatch.exception"
-        ex = request.env['action_dispatch.exception']
-        puts ">> exception class: #{ex.class} : #{ex}"
-      end
-
-      expect(log).not_to include('exception app middleware')
-
-      expect(JSON.parse(response.body)).to eq(
-        "status" => 400,
-        "error" => "Bad Request"
-      )
-
+      expect(response.status).to eq(200)
     end
   end
 


### PR DESCRIPTION
Removes invalid UTF-8 characters from environment, preventing errors and warnings in logs like: 

- Discourse::InvalidParameters (string contains null byte)
- Failed to handle exception in exception app middleware : Invalid query parameters: Invalid encoding for parameter: 1����%2527%2522
