### PR TITLE
UX: Move the admin dashboard trend icons inside the tooltip span

### DIFF
--- a/app/assets/javascripts/admin/templates/components/admin-report.hbs
+++ b/app/assets/javascripts/admin/templates/components/admin-report.hbs
@@ -40,11 +40,11 @@
             {{else}}
               {{number model.currentTotal noTitle="true"}}{{#if model.percent}}%{{/if}}
             {{/if}}
-          </span>
 
-          {{#if model.trendIcon}}
-            {{d-icon model.trendIcon class="icon"}}
-          {{/if}}
+            {{#if model.trendIcon}}
+              {{d-icon model.trendIcon class="icon"}}
+            {{/if}}
+          </span>
         </div>
       {{/if}}
     </div>


### PR DESCRIPTION
Just a small change to move the admin dashboard trend icons inside the `<span>` which has the tooltip.