### PR TITLE
Make 1gb warning a little less than 1gb

### DIFF
--- a/app/models/admin_dashboard_data.rb
+++ b/app/models/admin_dashboard_data.rb
@@ -145,7 +145,7 @@ class AdminDashboardData
   end
 
   def ram_check
-    I18n.t('dashboard.memory_warning') if MemInfo.new.mem_total && MemInfo.new.mem_total < 1_000_000
+    I18n.t('dashboard.memory_warning') if MemInfo.new.mem_total && MemInfo.new.mem_total < 950_000
   end
 
   def google_oauth2_config_check


### PR DESCRIPTION
When you have '1gb' RAM, this might be a little less than 1,000,000.
Let's not warn unless it's well under 1gb.