### PR TITLE
UX: Changed error draft status to icon

### DIFF
--- a/app/assets/javascripts/discourse/templates/composer.hbs
+++ b/app/assets/javascripts/discourse/templates/composer.hbs
@@ -164,7 +164,9 @@
                 {{/if}}
                 {{#if model.draftSaving}}<div class="spinner small"></div>{{/if}}
                 {{#if model.draftSaved}}{{d-icon 'check' class='save-animation'}}{{/if}}
-                {{model.draftStatus}}
+                {{#if model.draftStatus}}
+                  <span title="{{model.draftStatus}}">{{d-icon 'times'}}</span>
+                {{/if}}
               </div>
             </div>
 

--- a/app/assets/javascripts/discourse/templates/composer.hbs
+++ b/app/assets/javascripts/discourse/templates/composer.hbs
@@ -165,7 +165,7 @@
                 {{#if model.draftSaving}}<div class="spinner small"></div>{{/if}}
                 {{#if model.draftSaved}}{{d-icon 'check' class='save-animation'}}{{/if}}
                 {{#if model.draftStatus}}
-                  <span title="{{model.draftStatus}}">{{d-icon 'times'}}</span>
+                  <span title="{{model.draftStatus}}">{{d-icon 'user-edit'}}</span>
                 {{/if}}
               </div>
             </div>

--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -307,6 +307,11 @@
         margin-right: 5px;
       }
     }
+    #draft-status .d-icon-user-edit {
+      color: $danger;
+      font-size: 20px;
+      vertical-align: -5.5px;
+    }
   }
 
   .composer-bottom-right {

--- a/lib/svg_sprite/svg_sprite.rb
+++ b/lib/svg_sprite/svg_sprite.rb
@@ -181,6 +181,7 @@ module SvgSprite
     "unlock-alt",
     "upload",
     "user",
+    "user-edit",
     "user-plus",
     "user-secret",
     "user-times",

--- a/test/javascripts/acceptance/composer-edit-conflict-test.js.es6
+++ b/test/javascripts/acceptance/composer-edit-conflict-test.js.es6
@@ -4,7 +4,7 @@ acceptance("Composer - Edit conflict", {
   loggedIn: true
 });
 
-QUnit.skip("Edit a post that causes an edit conflict", async assert => {
+QUnit.test("Edit a post that causes an edit conflict", async assert => {
   // prettier-ignore
   server.put("/posts/398", () => [ // eslint-disable-line no-undef
     409, { "Content-Type": "application/json" }, { errors: ["edit conflict"] }
@@ -21,6 +21,8 @@ QUnit.skip("Edit a post that causes an edit conflict", async assert => {
     I18n.t("composer.overwrite_edit"),
     "it shows the overwrite button"
   );
+  assert.ok(find("#draft-status .d-icon-times"), "error icon should be there");
+  await click(".modal .btn-primary");
 });
 
 QUnit.test(

--- a/test/javascripts/acceptance/composer-edit-conflict-test.js.es6
+++ b/test/javascripts/acceptance/composer-edit-conflict-test.js.es6
@@ -21,7 +21,10 @@ QUnit.test("Edit a post that causes an edit conflict", async assert => {
     I18n.t("composer.overwrite_edit"),
     "it shows the overwrite button"
   );
-  assert.ok(find("#draft-status .d-icon-times"), "error icon should be there");
+  assert.ok(
+    find("#draft-status .d-icon-user-edit"),
+    "error icon should be there"
+  );
   await click(".modal .btn-primary");
 });
 


### PR DESCRIPTION
This changes the error draft text to an icon which can be hovered to get the error message.

![Screenshot 2019-04-12 at 08 37 31 (2)](https://user-images.githubusercontent.com/13546486/56018024-40802080-5d01-11e9-8daf-d182e7b7b101.png)

cc @awesomerobot it currently doesn't have any animations since it's unclear on if we should keep them (2fea29a). If we are going to keep the scaling animation I will also enhance the error icon 🙂