### PR TITLE
UX: tone down user card email color

### DIFF
--- a/app/assets/stylesheets/common/components/user-card.scss
+++ b/app/assets/stylesheets/common/components/user-card.scss
@@ -68,6 +68,7 @@ $avatar_margin: -50px; // negative margin makes avatars extend above cards
     display: inline;
     margin-right: 0.5em;
     color: $primary;
+    &.email,
     .desc,
     a {
       color: $primary-high;


### PR DESCRIPTION
A small change to the color of emails for staged users in user-cards.

**Before:**
![beforeEmails](https://user-images.githubusercontent.com/33972521/56034040-afd52f00-5d58-11e9-93b2-34b65c735a55.png)

**After:**
![afterEmail](https://user-images.githubusercontent.com/33972521/56034027-a5b33080-5d58-11e9-9b9f-5b4be6ef9b08.png)

