### PR TITLE
UX: Render wizard previews for high-DPI displays

### DIFF
--- a/app/assets/javascripts/wizard/lib/preview.js.es6
+++ b/app/assets/javascripts/wizard/lib/preview.js.es6
@@ -17,24 +17,27 @@ function canvasFor(image, w, h) {
   w = Math.ceil(w);
   h = Math.ceil(h);
 
+  const scale = window.devicePixelRatio;
+
   const can = document.createElement("canvas");
-  can.width = w * 2;
-  can.height = h * 2;
+  can.width = w * scale;
+  can.height = h * scale;
 
   const ctx = can.getContext("2d");
-  ctx.scale(2, 2);
+  ctx.scale(scale, scale);
   ctx.drawImage(image, 0, 0, w, h);
   return can;
 }
 
 export function createPreviewComponent(width, height, obj) {
+  const scale = window.devicePixelRatio;
   return Ember.Component.extend(
     {
       layoutName: "components/theme-preview",
       width,
       height,
-      elementWidth: width * 2,
-      elementHeight: height * 2,
+      elementWidth: width * scale,
+      elementHeight: height * scale,
       ctx: null,
       loaded: false,
 

--- a/app/assets/javascripts/wizard/lib/preview.js.es6
+++ b/app/assets/javascripts/wizard/lib/preview.js.es6
@@ -18,10 +18,11 @@ function canvasFor(image, w, h) {
   h = Math.ceil(h);
 
   const can = document.createElement("canvas");
-  can.width = w;
-  can.height = h;
+  can.width = w * 2;
+  can.height = h * 2;
 
   const ctx = can.getContext("2d");
+  ctx.scale(2, 2);
   ctx.drawImage(image, 0, 0, w, h);
   return can;
 }
@@ -32,6 +33,8 @@ export function createPreviewComponent(width, height, obj) {
       layoutName: "components/theme-preview",
       width,
       height,
+      elementWidth: width * 2,
+      elementHeight: height * 2,
       ctx: null,
       loaded: false,
 
@@ -39,6 +42,7 @@ export function createPreviewComponent(width, height, obj) {
         this._super(...arguments);
         const c = this.$("canvas")[0];
         this.ctx = c.getContext("2d");
+        this.ctx.scale(2, 2);
         this.reload();
       },
 

--- a/app/assets/javascripts/wizard/templates/components/theme-preview.hbs
+++ b/app/assets/javascripts/wizard/templates/components/theme-preview.hbs
@@ -1,4 +1,4 @@
 <div class='preview-area'>
-  <canvas width={{width}} height={{height}}>
+  <canvas width={{elementWidth}} height={{elementHeight}} style={{concat "width:" width "; height:" height ";"}}>
   </canvas>
 </div>


### PR DESCRIPTION
Sets up a canvas element of twice the required dimensions, scales the coordinate system by 2x, then shrinks the display in css.

Before:
<img width="713" alt="Screenshot 2019-04-12 at 15 29 02" src="https://user-images.githubusercontent.com/6270921/56044734-bef7b500-5d37-11e9-8908-317100deeadf.png">

After:
<img width="716" alt="Screenshot 2019-04-12 at 15 28 53" src="https://user-images.githubusercontent.com/6270921/56044753-c323d280-5d37-11e9-9120-feee19056607.png">
