### PR TITLE
FIX: Fixed category reordering using arrow icons

### DIFF
--- a/test/javascripts/controllers/reorder-categories-test.js.es6
+++ b/test/javascripts/controllers/reorder-categories-test.js.es6
@@ -157,3 +157,51 @@ QUnit.test(
     );
   }
 );
+
+QUnit.test(
+  "changing the position through click on arrow of a category should place it at given position and respect children",
+  function(assert) {
+    const store = createStore();
+
+    const elem1 = store.createRecord("category", {
+      id: 1,
+      position: 0,
+      slug: "foo"
+    });
+
+    const child1 = store.createRecord("category", {
+      id: 4,
+      position: 1,
+      slug: "foochild",
+      parent_category_id: 1
+    });
+
+    const elem2 = store.createRecord("category", {
+      id: 2,
+      position: 2,
+      slug: "bar"
+    });
+
+    const elem3 = store.createRecord("category", {
+      id: 3,
+      position: 3,
+      slug: "test"
+    });
+
+    const categories = [elem1, child1, elem2, elem3];
+    const site = Ember.Object.create({ categories: categories });
+    const reorderCategoriesController = this.subject({ site });
+
+    reorderCategoriesController.fixIndices();
+
+    reorderCategoriesController.actions.moveDown.call(
+      reorderCategoriesController,
+      elem1
+    );
+
+    assert.deepEqual(
+      reorderCategoriesController.get("categoriesOrdered").mapBy("slug"),
+      ["bar", "foo", "foochild", "test"]
+    );
+  }
+);


### PR DESCRIPTION
This fixes not being able to reorder categories with childs using the arrow icons.

### Before
![Peek 2019-04-12 20-13](https://user-images.githubusercontent.com/13546486/56057810-1578e980-5d60-11e9-950d-5b3a16590c31.gif)

### After
![Peek 2019-04-12 20-14](https://user-images.githubusercontent.com/13546486/56057816-190c7080-5d60-11e9-9332-095a87057e3a.gif)

Resolves: https://meta.discourse.org/t/reorder-categories-behaving-strangely/104190/13