### PR TITLE
FIX: properly log webhook errors in UI on rescue

### DIFF
--- a/app/jobs/regular/emit_web_hook_event.rb
+++ b/app/jobs/regular/emit_web_hook_event.rb
@@ -113,8 +113,12 @@ module Jobs
           duration: ((Time.zone.now - now) * 1000).to_i
         )
       rescue => e
-        web_hook_event.update!(headers: MultiJson.dump(headers))
-        Rails.logger.error("Webhook event failed: #{e}")
+        web_hook_event.update!(
+          headers: MultiJson.dump(headers),
+          status: -1,
+          response_headers: MultiJson.dump(error: e),
+          duration: ((Time.zone.now - now) * 1000).to_i
+        )
       end
 
       MessageBus.publish("/web_hook_events/#{web_hook.id}", {

--- a/app/models/web_hook_event.rb
+++ b/app/models/web_hook_event.rb
@@ -19,7 +19,6 @@ class WebHookEvent < ActiveRecord::Base
       else
         WebHook.last_delivery_statuses[:failed]
       end
-
     web_hook.save!
   end
 end


### PR DESCRIPTION
Currently when the site is unreachable we are not showing the failing webhook status in Admin UX, nor the error is logged in database. Instead we are generating noise in Rails error logs.

After this change there will be clear indication that the webhook is failing and the error will be logged in database.

<img width="448" alt="Screen Shot 2019-04-13 at 17 17 59" src="https://user-images.githubusercontent.com/5732281/56080123-a2807900-5e1a-11e9-977a-05d8683eb790.png">

<img width="739" alt="Screen Shot 2019-04-13 at 17 17 15" src="https://user-images.githubusercontent.com/5732281/56080124-a8765a00-5e1a-11e9-8583-c0461cb9a9f4.png">
