### PR TITLE
UX: Show user card on load

### DIFF
--- a/app/assets/javascripts/discourse/components/user-card-contents.js.es6
+++ b/app/assets/javascripts/discourse/components/user-card-contents.js.es6
@@ -152,7 +152,7 @@ export default Ember.Component.extend(
 
     _showCallback(username, $target) {
       this._positionCard($target);
-      this.setProperties({visible: true, loading: true});
+      this.setProperties({ visible: true, loading: true });
 
       const args = { stats: false };
       args.include_post_count_for = this.get("topic.id");

--- a/app/assets/javascripts/discourse/components/user-card-contents.js.es6
+++ b/app/assets/javascripts/discourse/components/user-card-contents.js.es6
@@ -53,6 +53,7 @@ export default Ember.Component.extend(
     showCheckEmail: Ember.computed.and("user.staged", "canCheckEmails"),
 
     user: null,
+    loading: false,
 
     // If inside a topic
     topicPostCount: null,
@@ -150,6 +151,9 @@ export default Ember.Component.extend(
     },
 
     _showCallback(username, $target) {
+      this._positionCard($target);
+      this.setProperties({visible: true, loading: true});
+
       const args = { stats: false };
       args.include_post_count_for = this.get("topic.id");
       User.findByUsername(username, args)
@@ -160,8 +164,7 @@ export default Ember.Component.extend(
               user.topic_post_count[args.include_post_count_for]
             );
           }
-          this._positionCard($target);
-          this.setProperties({ user, visible: true });
+          this.setProperties({ user, loading: false });
         })
         .catch(() => this._close())
         .finally(() => this.set("loading", null));

--- a/app/assets/javascripts/discourse/components/user-card-contents.js.es6
+++ b/app/assets/javascripts/discourse/components/user-card-contents.js.es6
@@ -152,7 +152,8 @@ export default Ember.Component.extend(
 
     _showCallback(username, $target) {
       this._positionCard($target);
-      this.setProperties({ visible: true, loading: true });
+      const currentUser = Discourse.__container__.lookup("current-user:main");
+      this.setProperties({ visible: true, loading: true, user: currentUser });
 
       const args = { stats: false };
       args.include_post_count_for = this.get("topic.id");

--- a/app/assets/javascripts/discourse/templates/components/user-card-contents.hbs
+++ b/app/assets/javascripts/discourse/templates/components/user-card-contents.hbs
@@ -46,6 +46,7 @@
           {{#if user.staged}}
             <h2 class="staged">{{i18n 'user.staged'}}</h2>
           {{/if}}
+          {{conditional-loading-spinner condition=loading}}
           {{plugin-outlet name="user-card-post-names" args=(hash user=user) tagName='div'}}
         </span>
       </div>

--- a/app/assets/javascripts/discourse/templates/components/user-card-contents.hbs
+++ b/app/assets/javascripts/discourse/templates/components/user-card-contents.hbs
@@ -46,7 +46,6 @@
           {{#if user.staged}}
             <h2 class="staged">{{i18n 'user.staged'}}</h2>
           {{/if}}
-          {{conditional-loading-spinner condition=loading}}
           {{plugin-outlet name="user-card-post-names" args=(hash user=user) tagName='div'}}
         </span>
       </div>
@@ -93,6 +92,21 @@
       args=(hash user=user close=(action "close"))
       tagName=""}}
     </div>
+
+    {{#if loading}}
+      <div class="card-row second-row">
+        <div class="animated-placeholder"></div>
+      </div>
+      <div class="card-row third-row">
+        <div class="animated-placeholder"></div>
+      </div>
+      <div class="card-row fourth-row">
+        <div class="animated-placeholder"></div>
+      </div>
+      <div class="card-row sixth-row">
+        <div class="animated-placeholder"></div>
+      </div>
+    {{/if}}
 
     {{#if user.profile_hidden}}
       <div class="card-row second-row">
@@ -146,44 +160,46 @@
       </div>
     {{/if}}
 
-    <div class="card-row fourth-row">
-      {{#unless user.profile_hidden}}
-        <div class="metadata">
-          {{#if user.last_posted_at}}
-            <h3><span class='desc'>{{i18n 'last_post'}}</span>
-              {{format-date user.last_posted_at leaveAgo="true"}}</h3>
-          {{/if}}
-          <h3><span class='desc'>{{i18n 'joined'}}</span>
-            {{format-date user.created_at leaveAgo="true"}}</h3>
-          {{#if user.time_read}}
-            <h3 title="{{timeReadTooltip}}">
-              <span class='desc'>{{i18n 'time_read'}}</span>
-              {{format-duration user.time_read}}
-              {{#if showRecentTimeRead}}
-                <span>({{i18n 'time_read_recently' time_read=recentTimeRead}})</span>
-              {{/if}}
-            </h3>
-          {{/if}}
-          {{#if showCheckEmail}}
-            <h3 class="email">
-              {{d-icon "far-envelope" title="user.email.title"}}
-              {{#if user.email}}
-                {{user.email}}
-              {{else}}
-                {{d-button
-                action=(action "checkEmail")
-                actionParam=user
-                icon="far-envelope"
-                label="admin.users.check_email.text"
-                class="btn-primary"}}
-              {{/if}}
-            </h3>
-          {{/if}}
-          {{plugin-outlet name="user-card-metadata" args=(hash user=user)}}
-        </div>
-      {{/unless}}
-      {{plugin-outlet name="user-card-after-metadata" args=(hash user=user)}}
-    </div>
+    {{#unless loading}}
+      <div class="card-row fourth-row">
+        {{#unless user.profile_hidden}}
+          <div class="metadata">
+            {{#if user.last_posted_at}}
+              <h3><span class='desc'>{{i18n 'last_post'}}</span>
+                {{format-date user.last_posted_at leaveAgo="true"}}</h3>
+            {{/if}}
+            <h3><span class='desc'>{{i18n 'joined'}}</span>
+              {{format-date user.created_at leaveAgo="true"}}</h3>
+            {{#if user.time_read}}
+              <h3 title="{{timeReadTooltip}}">
+                <span class='desc'>{{i18n 'time_read'}}</span>
+                {{format-duration user.time_read}}
+                {{#if showRecentTimeRead}}
+                  <span>({{i18n 'time_read_recently' time_read=recentTimeRead}})</span>
+                {{/if}}
+              </h3>
+            {{/if}}
+            {{#if showCheckEmail}}
+              <h3 class="email">
+                {{d-icon "far-envelope" title="user.email.title"}}
+                {{#if user.email}}
+                  {{user.email}}
+                {{else}}
+                  {{d-button
+                    action=(action "checkEmail")
+                    actionParam=user
+                    icon="far-envelope"
+                    label="admin.users.check_email.text"
+                    class="btn-primary"}}
+                {{/if}}
+              </h3>
+            {{/if}}
+            {{plugin-outlet name="user-card-metadata" args=(hash user=user)}}
+          </div>
+        {{/unless}}
+        {{plugin-outlet name="user-card-after-metadata" args=(hash user=user)}}
+      </div>
+    {{/unless}}
 
     {{#if publicUserFields}}
       <div class="card-row fifth-row">

--- a/app/assets/stylesheets/common/components/user-card.scss
+++ b/app/assets/stylesheets/common/components/user-card.scss
@@ -2,6 +2,27 @@ $card_width: 580px;
 $avatar_width: 120px;
 $avatar_margin: -50px; // negative margin makes avatars extend above cards
 
+// placeholder
+@keyframes placeHolderShimmer {
+  0% {
+    background-position: -468px 0;
+  }
+  100% {
+    background-position: 468px 0;
+  }
+}
+.animated-placeholder {
+  animation-duration: 1.25s;
+  animation-fill-mode: forwards;
+  animation-iteration-count: infinite;
+  animation-name: placeHolderShimmer;
+  animation-timing-function: linear;
+  background: darkgray;
+  background: linear-gradient(to right, #eeeeee 10%, #dddddd 18%, #eeeeee 33%);
+  height: 20px;
+  position: relative;
+}
+
 // shared styles for user and group cards
 #user-card,
 #group-card {
@@ -29,9 +50,6 @@ $avatar_margin: -50px; // negative margin makes avatars extend above cards
     }
     a.card-huge-avatar {
       outline: none;
-    }
-    .spinner {
-      float: left;
     }
   }
   &.no-bg {

--- a/app/assets/stylesheets/common/components/user-card.scss
+++ b/app/assets/stylesheets/common/components/user-card.scss
@@ -30,6 +30,9 @@ $avatar_margin: -50px; // negative margin makes avatars extend above cards
     a.card-huge-avatar {
       outline: none;
     }
+    .spinner {
+      float: left;
+    }
   }
   &.no-bg {
     .card-content {


### PR DESCRIPTION
This shows the user card even before it finished loading.

### Before
![Peek 2019-04-15 19-31](https://user-images.githubusercontent.com/13546486/56156650-fa0b1a00-5fbd-11e9-9807-4669d3a7252c.gif)

### After
![Peek 2019-04-15 20-10](https://user-images.githubusercontent.com/13546486/56156663-ff686480-5fbd-11e9-87f0-8d3abd63f929.gif)

&nbsp;
&nbsp;
This is a first mockup I made for this 🙂 I fiddled a lot around with different animations and even slower opacity fading of the modal but everything felt bad to me. That's why I kept it that way.

Also as far as I know the avatar can't be shown during load, because all the modal knows from the user is his username.

For: https://meta.discourse.org/t/user-more-info-cache-results-and-render-optimization/17578