### PR TITLE
UX: Allow the contact url setting to be an email

### DIFF
--- a/app/assets/javascripts/discourse/controllers/about.js.es6
+++ b/app/assets/javascripts/discourse/controllers/about.js.es6
@@ -1,15 +1,20 @@
+import { emailValid } from "discourse/lib/utilities";
+
 export default Ember.Controller.extend({
   faqOverriden: Ember.computed.gt("siteSettings.faq_url.length", 0),
 
   contactInfo: function() {
-    if (this.siteSettings.contact_url) {
+    const contact_url = this.siteSettings.contact_url;
+    if (contact_url) {
       return I18n.t("about.contact_info", {
         contact_info:
-          "<a href='" +
-          this.siteSettings.contact_url +
-          "' target='_blank'>" +
-          this.siteSettings.contact_url +
-          "</a>"
+          emailValid(contact_url)
+            ? contact_url
+            : ("<a href='" +
+              contact_url +
+              "' target='_blank'>" +
+              contact_url +
+              "</a>")
       });
     } else if (this.siteSettings.contact_email) {
       return I18n.t("about.contact_info", {


### PR DESCRIPTION
A small change to fix what happens if you set the contact url setting to an email address (no longer makes a link to domain.com/emailaddress).