### PR TITLE
REFACTOR: Quick refactor of the webhook event emitter job

### DIFF
--- a/app/jobs/regular/emit_web_hook_event.rb
+++ b/app/jobs/regular/emit_web_hook_event.rb
@@ -7,62 +7,43 @@ module Jobs
     RETRY_BACKOFF = 5
 
     def execute(args)
-      %i{
-        web_hook_id
-        event_type
-      }.each do |key|
-        raise Discourse::InvalidParameters.new(key) unless args[key].present?
+      memoize_arguments(args)
+      validate_arguments!
+
+      unless ping_event?(event_type)
+        validate_argument!(:payload)
+
+        return if webhook_inactive?
+        return if group_webhook_invalid?
+        return if category_webhook_invalid?
+        return if tag_webhook_invalid?
       end
 
-      @orig_args = args.dup
-
-      web_hook = WebHook.find_by(id: args[:web_hook_id])
-      raise Discourse::InvalidParameters.new(:web_hook_id) if web_hook.blank?
-
-      unless ping_event?(args[:event_type])
-        return unless web_hook.active?
-
-        return if web_hook.group_ids.present? && (args[:group_id].present? ||
-          !web_hook.group_ids.include?(args[:group_id]))
-
-        return if web_hook.category_ids.present? && (!args[:category_id].present? ||
-          !web_hook.category_ids.include?(args[:category_id]))
-
-        return if web_hook.tag_ids.present? && (args[:tag_ids].blank? ||
-          (web_hook.tag_ids & args[:tag_ids]).blank?)
-
-        raise Discourse::InvalidParameters.new(:payload) unless args[:payload].present?
-        args[:payload] = JSON.parse(args[:payload])
-      end
-
-      web_hook_request(args, web_hook)
+      send_webhook!
     end
 
     private
 
-    def guardian
-      Guardian.new(Discourse.system_user)
-    end
-
-    def ping_event?(event_type)
-      PING_EVENT == event_type.to_s
-    end
-
-    def build_web_hook_body(args, web_hook)
-      body = {}
-      event_type = args[:event_type].to_s
-
-      if ping_event?(event_type)
-        body[:ping] = 'OK'
-      else
-        body[event_type] = args[:payload]
+    def validate_arguments!
+      %i{
+        web_hook_id
+        event_type
+      }.each do |key|
+        raise Discourse::InvalidParameters.new(key) unless arguments[key].present?
       end
 
-      new_body = Plugin::Filter.apply(:after_build_web_hook_body, self, body)
-      MultiJson.dump(new_body)
+      raise Discourse::InvalidParameters.new(:web_hook_id) if web_hook.blank?
     end
 
-    def web_hook_request(args, web_hook)
+    def validate_argument!(key)
+      raise Discourse::InvalidParameters.new(key) unless arguments[key].present?
+    end
+
+    def memoize_arguments(args)
+      @arguments = args.dup
+    end
+
+    def send_webhook!
       uri = URI(web_hook.payload_url.strip)
 
       conn = Excon.new(
@@ -71,42 +52,17 @@ module Jobs
         retry_limit: 0
       )
 
-      body = build_web_hook_body(args, web_hook)
-      web_hook_event = WebHookEvent.create!(web_hook_id: web_hook.id, payload: body)
+      web_hook_body = build_webhook_body
+      web_hook_event = create_webhook_event(web_hook_body)
+      web_hook_headers = build_webhook_headers(uri, web_hook_body, web_hook_event)
+
       response = nil
 
       begin
-        content_type =
-          case web_hook.content_type
-          when WebHook.content_types['application/x-www-form-urlencoded']
-            'application/x-www-form-urlencoded'
-          else
-            'application/json'
-          end
-
-        headers = {
-          'Accept' => '*/*',
-          'Connection' => 'close',
-          'Content-Length' => body.bytesize,
-          'Content-Type' => content_type,
-          'Host' => uri.host,
-          'User-Agent' => "Discourse/#{Discourse::VERSION::STRING}",
-          'X-Discourse-Instance' => Discourse.base_url,
-          'X-Discourse-Event-Id' => web_hook_event.id,
-          'X-Discourse-Event-Type' => args[:event_type]
-        }
-
-        headers['X-Discourse-Event'] = args[:event_name].to_s if args[:event_name].present?
-
-        if web_hook.secret.present?
-          headers['X-Discourse-Event-Signature'] = "sha256=#{OpenSSL::HMAC.hexdigest("sha256", web_hook.secret, body)}"
-        end
-
         now = Time.zone.now
-        response = conn.post(headers: headers, body: body)
-
+        response = conn.post(headers: web_hook_headers, body: web_hook_body)
         web_hook_event.update!(
-          headers: MultiJson.dump(headers),
+          headers: MultiJson.dump(web_hook_headers),
           status: response.status,
           response_headers: MultiJson.dump(response.headers),
           response_body: response.body,
@@ -114,28 +70,146 @@ module Jobs
         )
       rescue => e
         web_hook_event.update!(
-          headers: MultiJson.dump(headers),
+          headers: MultiJson.dump(web_hook_headers),
           status: -1,
           response_headers: MultiJson.dump(error: e),
           duration: ((Time.zone.now - now) * 1000).to_i
         )
       end
 
-      MessageBus.publish("/web_hook_events/#{web_hook.id}", {
-        web_hook_event_id: web_hook_event.id,
-        event_type: args[:event_type]
-      }, user_ids: User.human_users.staff.pluck(:id))
-
+      publish_webhook_event(web_hook_event)
       retry_web_hook if response&.status != 200
     end
 
     def retry_web_hook
       if SiteSetting.retry_web_hook_events?
-        @orig_args[:retry_count] = (@orig_args[:retry_count] || 0) + 1
-        return if @orig_args[:retry_count] > MAX_RETRY_COUNT
-        delay = RETRY_BACKOFF**(@orig_args[:retry_count] - 1)
-        Jobs.enqueue_in(delay.minutes, :emit_web_hook_event, @orig_args)
+        arguments[:retry_count] = (arguments[:retry_count] || 0) + 1
+        return if arguments[:retry_count] > MAX_RETRY_COUNT
+        delay = RETRY_BACKOFF ** (arguments[:retry_count] - 1)
+        Jobs.enqueue_in(delay.minutes, :emit_web_hook_event, arguments)
       end
     end
+
+    def publish_webhook_event(web_hook_event)
+      MessageBus.publish("/web_hook_events/#{web_hook.id}", {
+        web_hook_event_id: web_hook_event.id,
+        event_type: event_type
+      }, user_ids: User.human_users.staff.pluck(:id))
+    end
+
+    def ping_event?(event_type)
+      PING_EVENT == event_type.to_s
+    end
+
+    def webhook_inactive?
+      !web_hook.active?
+    end
+
+    def group_webhook_invalid?
+      web_hook.group_ids.present? && (group_id.present? ||
+        !web_hook.group_ids.include?(group_id))
+    end
+
+    def category_webhook_invalid?
+      web_hook.category_ids.present? && (!category_id.present? ||
+        !web_hook.category_ids.include?(category_id))
+    end
+
+    def tag_webhook_invalid?
+      web_hook.tag_ids.present? && (tag_ids.blank? ||
+        (web_hook.tag_ids & tag_ids).blank?)
+    end
+
+    def arguments
+      @arguments
+    end
+
+    def event_type
+      @event_type ||= arguments[:event_type].to_s
+    end
+
+    def event_name
+      @event_name ||= arguments[:event_name].to_s
+    end
+
+    def retry_count
+      @retry_count ||= @arguments[:retry_count]
+    end
+
+    def webhook_id
+      @webhook_id ||= @arguments[:web_hook_id]
+    end
+
+    def group_id
+      @group_id ||= @arguments[:group_id]
+    end
+
+    def category_id
+      @category_id ||= @arguments[:category_id]
+    end
+
+    def tag_ids
+      @tag_ids ||= @arguments[:tag_ids]
+    end
+
+    def payload
+      @payload ||= @arguments[:payload]
+    end
+
+    def parsed_payload
+      @parsed_payload ||= JSON.parse(payload)
+    end
+
+    def web_hook
+      @web_hook ||= WebHook.find_by(id: webhook_id)
+    end
+
+    def build_webhook_headers(uri, web_hook_body, web_hook_event)
+      content_type =
+        case web_hook.content_type
+        when WebHook.content_types['application/x-www-form-urlencoded']
+          'application/x-www-form-urlencoded'
+        else
+          'application/json'
+        end
+
+      headers = {
+        'Accept' => '*/*',
+        'Connection' => 'close',
+        'Content-Length' => web_hook_body.bytesize,
+        'Content-Type' => content_type,
+        'Host' => uri.host,
+        'User-Agent' => "Discourse/#{Discourse::VERSION::STRING}",
+        'X-Discourse-Instance' => Discourse.base_url,
+        'X-Discourse-Event-Id' => web_hook_event.id,
+        'X-Discourse-Event-Type' => event_type
+      }
+
+      headers['X-Discourse-Event'] = event_name if event_name.present?
+
+      if web_hook.secret.present?
+        headers['X-Discourse-Event-Signature'] = "sha256=#{OpenSSL::HMAC.hexdigest("sha256", web_hook.secret, web_hook_body)}"
+      end
+
+      headers
+    end
+
+    def build_webhook_body
+      body = {}
+
+      if ping_event?(event_type)
+        body[:ping] = 'OK'
+      else
+        body[event_type] = parsed_payload
+      end
+
+      new_body = Plugin::Filter.apply(:after_build_web_hook_body, self, body)
+      MultiJson.dump(new_body)
+    end
+
+    def create_webhook_event(web_hook_body)
+      WebHookEvent.create!(web_hook_id: web_hook.id, payload: web_hook_body)
+    end
+
   end
 end


### PR DESCRIPTION
## Why?

While looking at some log errors for the bug crushing game, I noticed some Webhook related error.

```
Webhook event failed: connect_write timeout reached
```

There is more of why this could be happening, I can explain on a separate PR. I thought as a first step I would just do a quick refactor of this job to pave the way for a cleaner set of changes / experiments to this job.