### PR TITLE
Removed "shoulda" gem in favor of "shoulda-matchers" and update

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -135,7 +135,7 @@ group :test, :development do
   gem 'rb-fsevent', require: RUBY_PLATFORM =~ /darwin/i ? 'rb-fsevent' : false
   gem 'rb-inotify', '~> 0.9', require: RUBY_PLATFORM =~ /linux/i ? 'rb-inotify' : false
   gem 'rspec-rails', require: false
-  gem 'shoulda', '~> 3.6'
+  gem 'shoulda-matchers', '~> 3.1', '>= 3.1.3', require: false
   gem 'rspec-html-matchers'
   gem 'pry-nav'
   gem 'byebug', require: ENV['RM_INFO'].nil?

--- a/Gemfile
+++ b/Gemfile
@@ -135,7 +135,7 @@ group :test, :development do
   gem 'rb-fsevent', require: RUBY_PLATFORM =~ /darwin/i ? 'rb-fsevent' : false
   gem 'rb-inotify', '~> 0.9', require: RUBY_PLATFORM =~ /linux/i ? 'rb-inotify' : false
   gem 'rspec-rails', require: false
-  gem 'shoulda', require: false
+  gem 'shoulda', '~> 3.6'
   gem 'rspec-html-matchers'
   gem 'pry-nav'
   gem 'byebug', require: ENV['RM_INFO'].nil?

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -400,10 +400,6 @@ GEM
     seed-fu (2.3.9)
       activerecord (>= 3.1)
       activesupport (>= 3.1)
-    shoulda (3.6.0)
-      shoulda-context (~> 1.0, >= 1.0.1)
-      shoulda-matchers (~> 3.0)
-    shoulda-context (1.2.2)
     shoulda-matchers (3.1.3)
       activesupport (>= 4.0.0)
     sidekiq (5.2.5)
@@ -557,7 +553,7 @@ DEPENDENCIES
   sassc
   sassc-rails
   seed-fu
-  shoulda (~> 3.6)
+  shoulda-matchers (~> 3.1, >= 3.1.3)
   sidekiq
   simplecov
   sprockets-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,7 +86,7 @@ GEM
       open4 (~> 1.3)
     coderay (1.1.2)
     colored2 (3.1.2)
-    concurrent-ruby (1.1.4)
+    concurrent-ruby (1.1.5)
     connection_pool (2.2.2)
     cork (0.3.0)
       colored2 (~> 3.1)
@@ -161,7 +161,7 @@ GEM
     hkdf (0.3.0)
     htmlentities (4.3.4)
     http_accept_language (2.0.5)
-    i18n (1.5.3)
+    i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     image_size (1.5.0)
     in_threads (1.5.0)
@@ -400,12 +400,12 @@ GEM
     seed-fu (2.3.9)
       activerecord (>= 3.1)
       activesupport (>= 3.1)
-    shoulda (3.5.0)
+    shoulda (3.6.0)
       shoulda-context (~> 1.0, >= 1.0.1)
-      shoulda-matchers (>= 1.4.1, < 3.0)
+      shoulda-matchers (~> 3.0)
     shoulda-context (1.2.2)
-    shoulda-matchers (2.8.0)
-      activesupport (>= 3.0.0)
+    shoulda-matchers (3.1.3)
+      activesupport (>= 4.0.0)
     sidekiq (5.2.5)
       connection_pool (~> 2.2, >= 2.2.2)
       rack (>= 1.5.0)
@@ -557,7 +557,7 @@ DEPENDENCIES
   sassc
   sassc-rails
   seed-fu
-  shoulda
+  shoulda (~> 3.6)
   sidekiq
   simplecov
   sprockets-rails

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -11,7 +11,7 @@ describe Category do
 
   it 'validates uniqueness of name' do
     Fabricate(:category)
-    is_expected.to validate_uniqueness_of(:name).scoped_to(:parent_category_id)
+    is_expected.to validate_uniqueness_of(:name).scoped_to(:parent_category_id).case_insensitive
   end
 
   it 'validates inclusion of search_priority' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -42,7 +42,7 @@ end
 ENV["RAILS_ENV"] ||= 'test'
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
-require 'shoulda'
+require 'shoulda-matchers'
 require 'sidekiq/testing'
 
 # The shoulda-matchers gem no longer detects the test framework

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -45,6 +45,16 @@ require 'rspec/rails'
 require 'shoulda'
 require 'sidekiq/testing'
 
+# The shoulda-matchers gem no longer detects the test framework
+# you're using or mixes itself into that framework automatically.
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :active_record
+    with.library :active_model
+  end
+end
+
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
 Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }


### PR DESCRIPTION
Hi there, my first contribution here 👍.

I just saw a warning when running all tests while configuring the project for development and I thought that it will be cool to have the `shoulda` gem upgraded 🚀.

The warning:

```
warning: BigDecimal.new is deprecated; use BigDecimal() method instead.
```

`shoulda` gem upgraded to version [3.6.0](https://rubygems.org/gems/shoulda/versions/3.6.0)

`shoulda-matchers` gem upgraded to version [3.1.3](https://github.com/thoughtbot/shoulda-matchers/blob/master/NEWS.md#improvements-1) from version [2.8.0](https://github.com/thoughtbot/shoulda-matchers/blob/master/NEWS.md#280)

Please let me know if I need to add more info 👍 