### PR TITLE
FIX: Use `saved_change_to_value?` in site_setting_saved event

### DIFF
--- a/config/initializers/014-track-setting-changes.rb
+++ b/config/initializers/014-track-setting-changes.rb
@@ -2,7 +2,7 @@
 # existing users are approved.
 DiscourseEvent.on(:site_setting_saved) do |site_setting|
   name = site_setting.name.to_sym
-  next unless site_setting.value_changed?
+  next unless site_setting.saved_change_to_value?
 
   if name == :must_approve_users && site_setting.value == 't'
     User.where(approved: false).update_all(approved: true)

--- a/lib/site_settings/local_process_provider.rb
+++ b/lib/site_settings/local_process_provider.rb
@@ -8,7 +8,7 @@ class SiteSettings::LocalProcessProvider
     attr_accessor :name, :data_type, :value
 
     def value_changed?
-      true
+      false
     end
 
     def saved_change_to_value?


### PR DESCRIPTION
Since Rails 5.2, the behavior of `attribute_changed?` inside `after_save` callbacks has changed, so we need to use `saved_change_to_attribute` instead. The site setting local_process_provider in test mode was covering up the issue.

Followup to ba6d4b2a8db791ed85239e3a90de73786f219a0a