### PR TITLE
UX: replace lightbox loading text with spinner

### DIFF
--- a/app/assets/javascripts/discourse/lib/lightbox.js.es6
+++ b/app/assets/javascripts/discourse/lib/lightbox.js.es6
@@ -2,6 +2,7 @@ import loadScript from "discourse/lib/load-script";
 import { escapeExpression } from "discourse/lib/utilities";
 import { renderIcon } from "discourse-common/lib/icon-library";
 import { isAppWebview, postRNWebviewMessage } from "discourse/lib/utilities";
+import { spinnerHTML } from "discourse/helpers/loading-spinner";
 
 export default function($elem) {
   if (!$elem) {
@@ -10,6 +11,7 @@ export default function($elem) {
 
   loadScript("/javascripts/jquery.magnific-popup.min.js").then(function() {
     const spoilers = $elem.find(".spoiler a.lightbox, .spoiled a.lightbox");
+
     $elem
       .find("a.lightbox")
       .not(spoilers)
@@ -18,6 +20,8 @@ export default function($elem) {
         closeOnContentClick: false,
         removalDelay: 300,
         mainClass: "mfp-zoom-in",
+        tClose: I18n.t("lightbox.close"),
+        tLoading: spinnerHTML,
 
         gallery: {
           enabled: true,
@@ -26,8 +30,6 @@ export default function($elem) {
           tCounter: I18n.t("lightbox.counter")
         },
 
-        tClose: I18n.t("lightbox.close"),
-        tLoading: I18n.t("lightbox.loading"),
         ajax: {
           tError: I18n.t("lightbox.content_load_error")
         },

--- a/app/assets/stylesheets/common/base/lightbox.scss
+++ b/app/assets/stylesheets/common/base/lightbox.scss
@@ -100,3 +100,7 @@ $meta-element-margin: 6px;
     }
   }
 }
+
+.mfp-preloader .spinner {
+  margin: auto;
+}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2806,7 +2806,6 @@ en:
       next: "Next (Right arrow key)"
       counter: "%curr% of %total%"
       close: "Close (Esc)"
-      loading: "Loading…"
       content_load_error: '<a href="%url%">The content</a> could not be loaded.'
       image_load_error: '<a href="%url%">The image</a> could not be loaded.'
 


### PR DESCRIPTION
Right now, if you open a lightbox and the image in the lightbox is not yet loaded, you'll see something like this:

![spinnerBefore](https://user-images.githubusercontent.com/33972521/56288836-28b9f980-6152-11e9-8483-bc3cbcd05541.png)

This PR removes that string and adds our loading spinner instead

![spinner](https://user-images.githubusercontent.com/33972521/56288723-ed1f2f80-6151-11e9-9b1d-544bab8ab911.png)
