### PR TITLE
use failed_to_login for SSO error

### DIFF
--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -144,7 +144,7 @@ class SessionController < ApplicationController
       if user = sso.lookup_or_create_user(request.remote_ip)
 
         if user.suspended?
-          render_sso_error(text: I18n.t("login.suspended", date: user.suspended_till), status: 403)
+          render_sso_error(text: failed_to_login(user)[:error], status: 403)
           return
         end
 


### PR DESCRIPTION
The error displayed when logging into suspended accounts via SSO never includes
the suspension reason, unlike non-SSO logins. By re-using the failed_to_login
method when generating the error message for SSO we can ensure the message is
consistent between the SSO and non-SSO paths.