### PR TITLE
DEV: Add test-prof as a dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -122,6 +122,7 @@ group :test do
   gem 'minitest', require: false
   gem 'danger'
   gem 'simplecov', require: false
+  gem "test-prof"
 end
 
 group :test, :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -424,6 +424,7 @@ GEM
     stackprof (0.2.12)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
+    test-prof (0.8.0)
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.8)
@@ -559,6 +560,7 @@ DEPENDENCIES
   sprockets-rails
   sshkey
   stackprof
+  test-prof
   thor
   tilt
   uglifier


### PR DESCRIPTION
This is the first PR in a series that I'll be making to improve the rails tests.

test-prof is a useful tool for profiling test code. You can read more about it here: https://evilmartians.com/chronicles/testprof-a-good-doctor-for-slow-ruby-tests