### PR TITLE
DEV: Test query volume policing

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -240,6 +240,32 @@ RSpec.configure do |config|
     end
   end
 
+  # Let's make tests that do too many queries more visible.
+  max_queries = 2000
+  num_queries = 0
+
+  config.before(:suite) do
+    ActiveSupport::Notifications
+      .subscribe('sql.active_record') do |name, start, finish, id, event|
+
+      num_queries += 1
+    end
+  end
+
+  config.before(:each) do
+    num_queries = 0
+  end
+
+  config.after(:each) do |example|
+    unless example.metadata[:allow_many_queries]
+      if num_queries > max_queries
+        raise "too many queries, "\
+          "#{num_queries} > #{max_queries}, "\
+          "add the allow_many_queries tag to ignore"
+      end
+    end
+  end
+
 end
 
 class TrackTimeStub


### PR DESCRIPTION
There are tests that do >1,900 queries and I think this is far too many.

As things stand, it's very easy for the number of queries per test to creep upwards over time. The goal of this PR is make this creep visible.

It works by counting the number of queries that are executed per test. When this exceeds the threshold, it raises an exception.

There are two ways to deal with this exception (asides from reducing the number of queries). You can tag the test with `allow_many_queries`, for example:

    it "should ...", allow_many_queries: true do
      ...
    end

Or, you can increase the threshold. Either way, it creates a place in the codebase where a discussion around test performance can happen during code review.