### PR TITLE
DEV: add site setting type group_list for a list of groups

### DIFF
--- a/app/assets/javascripts/admin/components/site-settings/group-list.js.es6
+++ b/app/assets/javascripts/admin/components/site-settings/group-list.js.es6
@@ -1,0 +1,8 @@
+import computed from "ember-addons/ember-computed-decorators";
+
+export default Ember.Component.extend({
+  @computed()
+  groupChoices() {
+    return this.site.get('groups').map(g => g.name);
+  }
+});

--- a/app/assets/javascripts/admin/mixins/setting-component.js.es6
+++ b/app/assets/javascripts/admin/mixins/setting-component.js.es6
@@ -13,7 +13,8 @@ const CUSTOM_TYPES = [
   "uploaded_image_list",
   "compact_list",
   "secret_list",
-  "upload"
+  "upload",
+  "group_list"
 ];
 
 export default Ember.Mixin.create({

--- a/app/assets/javascripts/admin/templates/components/site-settings/group-list.hbs
+++ b/app/assets/javascripts/admin/templates/components/site-settings/group-list.hbs
@@ -1,0 +1,3 @@
+{{list-setting settingValue=value choices=groupChoices settingName=setting.setting}}
+{{setting-validation-message message=validationMessage}}
+<div class='desc'>{{{unbound setting.description}}}</div>

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4094,6 +4094,7 @@ en:
         clear_filter: "Clear"
         add_url: "add URL"
         add_host: "add host"
+        add_group: "add group"
         uploaded_image_list:
           label: "Edit list"
           empty: "There are no pictures yet. Please upload one."

--- a/lib/site_settings/type_supervisor.rb
+++ b/lib/site_settings/type_supervisor.rb
@@ -33,6 +33,7 @@ class SiteSettings::TypeSupervisor
       uploaded_image_list: 17,
       upload: 18,
       group: 19,
+      group_list: 20,
     )
   end
 

--- a/spec/components/site_settings/type_supervisor_spec.rb
+++ b/spec/components/site_settings/type_supervisor_spec.rb
@@ -72,9 +72,14 @@ describe SiteSettings::TypeSupervisor do
       it "'uploaded_image_list' should be at 17th position" do
         expect(SiteSettings::TypeSupervisor.types[:uploaded_image_list]).to eq(17)
       end
-
       it "'upload' should be at the right position" do
         expect(SiteSettings::TypeSupervisor.types[:upload]).to eq(18)
+      end
+      it "'group' should be at the right position" do
+        expect(SiteSettings::TypeSupervisor.types[:group]).to eq(19)
+      end
+      it "'group_list' should be at the right position" do
+        expect(SiteSettings::TypeSupervisor.types[:group_list]).to eq(20)
       end
     end
   end


### PR DESCRIPTION
I want to add a new setting to the ad plugin which takes a list of groups, so I'm adding this new setting type.

It would be nice to have a js test for this since there are no core settings that are using it, but didn't have success writing one. Something like this?

```
import componentTest from "helpers/component-test";
moduleForComponent("group-list", { integration: true });

componentTest("site-setting-group-list", {
  template: '{{site-settings/group-list value=values}}',

  beforeEach() {
    this.setProperties({
      ???
    });
  },

  async test(assert) {
    
  }
});

```