### PR TITLE
DEV: User email test optimization

### DIFF
--- a/spec/fabricators/user_fabricator.rb
+++ b/spec/fabricators/user_fabricator.rb
@@ -1,7 +1,7 @@
 Fabricator(:user_stat) do
 end
 
-Fabricator(:user_single_email, class_name: :user) do
+Fabricator(:user, class_name: :user) do
   name 'Bruce Wayne'
   username { sequence(:username) { |i| "bruce#{i}" } }
   email { sequence(:email) { |i| "bruce#{i}@wayne.com" } }
@@ -11,7 +11,7 @@ Fabricator(:user_single_email, class_name: :user) do
   active true
 end
 
-Fabricator(:user, from: :user_single_email) do
+Fabricator(:user_with_secondary_email, from: :user) do
   after_create { |user| Fabricate(:secondary_email, user: user) }
 end
 

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -272,7 +272,7 @@ describe Group do
         group = Group.refresh_automatic_group!(:staff)
         expect(group.name).to eq('staff')
 
-        Fabricate(:user_single_email, username: I18n.t('groups.default_names.moderators').upcase)
+        Fabricate(:user, username: I18n.t('groups.default_names.moderators').upcase)
         group = Group.refresh_automatic_group!(:moderators)
         expect(group.name).to eq('moderators')
       end

--- a/spec/models/user_email_spec.rb
+++ b/spec/models/user_email_spec.rb
@@ -4,14 +4,14 @@ require_dependency 'user_email'
 describe UserEmail do
   context "validation" do
     it "allows only one primary email" do
-      user = Fabricate(:user_single_email)
+      user = Fabricate(:user)
       expect {
         Fabricate(:secondary_email, user: user, primary: true)
       }.to raise_error(ActiveRecord::RecordInvalid)
     end
 
     it "allows multiple secondary emails" do
-      user = Fabricate(:user_single_email)
+      user = Fabricate(:user)
       Fabricate(:secondary_email, user: user, primary: false)
       Fabricate(:secondary_email, user: user, primary: false)
       expect(user.user_emails.count).to eq 3
@@ -20,14 +20,14 @@ describe UserEmail do
 
   context "indexes" do
     it "allows only one primary email" do
-      user = Fabricate(:user_single_email)
+      user = Fabricate(:user)
       expect {
         Fabricate.build(:secondary_email, user: user, primary: true).save(validate: false)
       }.to raise_error(ActiveRecord::RecordNotUnique)
     end
 
     it "allows multiple secondary emails" do
-      user = Fabricate(:user_single_email)
+      user = Fabricate(:user)
       Fabricate.build(:secondary_email, user: user, primary: false).save(validate: false)
       Fabricate.build(:secondary_email, user: user, primary: false).save(validate: false)
       expect(user.user_emails.count).to eq 3

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -713,7 +713,7 @@ describe User do
 
     it 'email whitelist should be used when email is being changed' do
       SiteSetting.email_domains_whitelist = 'vaynermedia.com'
-      u = Fabricate(:user_single_email, email: 'good@vaynermedia.com')
+      u = Fabricate(:user, email: 'good@vaynermedia.com')
       u.email = 'nope@mailinator.com'
       expect(u).not_to be_valid
     end
@@ -1812,7 +1812,7 @@ describe User do
   end
 
   describe "#secondary_emails" do
-    let(:user) { Fabricate(:user_single_email) }
+    let(:user) { Fabricate(:user) }
 
     it "only contains secondary emails" do
       expect(user.user_emails.secondary).to eq([])

--- a/spec/serializers/admin_user_list_serializer_spec.rb
+++ b/spec/serializers/admin_user_list_serializer_spec.rb
@@ -17,9 +17,9 @@ describe AdminUserListSerializer do
   end
 
   context "emails" do
-    let(:admin) { Fabricate(:user_single_email, admin: true, email: "admin@email.com") }
-    let(:moderator) { Fabricate(:user_single_email, moderator: true, email: "moderator@email.com") }
-    let(:user) { Fabricate(:user_single_email, email: "user@email.com") }
+    let(:admin) { Fabricate(:user, admin: true, email: "admin@email.com") }
+    let(:moderator) { Fabricate(:user, moderator: true, email: "moderator@email.com") }
+    let(:user) { Fabricate(:user, email: "user@email.com") }
 
     def serialize(user, viewed_by, opts = nil)
       AdminUserListSerializer.new(

--- a/spec/services/anonymous_shadow_creator_spec.rb
+++ b/spec/services/anonymous_shadow_creator_spec.rb
@@ -10,7 +10,7 @@ describe AnonymousShadowCreator do
 
     before { SiteSetting.allow_anonymous_posting = true }
 
-    let(:user) { Fabricate(:user_single_email, trust_level: 3) }
+    let(:user) { Fabricate(:user, trust_level: 3) }
 
     it "returns no shadow if trust level is not met" do
       expect(AnonymousShadowCreator.get(Fabricate.build(:user, trust_level: 0))).to eq(nil)

--- a/spec/services/user_anonymizer_spec.rb
+++ b/spec/services/user_anonymizer_spec.rb
@@ -24,7 +24,7 @@ describe UserAnonymizer do
 
   describe "make_anonymous" do
     let(:original_email) { "edward@example.net" }
-    let(:user) { Fabricate(:user_single_email, username: "edward", email: original_email) }
+    let(:user) { Fabricate(:user, username: "edward", email: original_email) }
     let(:another_user) { Fabricate(:evil_trout) }
     subject(:make_anonymous) { described_class.make_anonymous(user, admin) }
 

--- a/spec/services/user_destroyer_spec.rb
+++ b/spec/services/user_destroyer_spec.rb
@@ -19,7 +19,7 @@ describe UserDestroyer do
   describe 'destroy' do
     before do
       @admin = Fabricate(:admin)
-      @user = Fabricate(:user)
+      @user = Fabricate(:user_with_secondary_email)
     end
 
     it 'raises an error when user is nil' do

--- a/spec/services/user_merger_spec.rb
+++ b/spec/services/user_merger_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 describe UserMerger do
-  let!(:target_user) { Fabricate(:user_single_email, username: 'alice', email: 'alice@example.com') }
-  let!(:source_user) { Fabricate(:user_single_email, username: 'alice1', email: 'alice@work.com') }
+  let!(:target_user) { Fabricate(:user, username: 'alice', email: 'alice@example.com') }
+  let!(:source_user) { Fabricate(:user, username: 'alice1', email: 'alice@work.com') }
   let(:walter) { Fabricate(:walter_white) }
 
   def merge_users!(source = nil, target =  nil)
@@ -838,7 +838,7 @@ describe UserMerger do
   it "skips merging email adresses when a secondary email address exists" do
     merge_users!(source_user, target_user)
 
-    alice2 = Fabricate(:user_single_email, username: 'alice2', email: 'alice@foo.com')
+    alice2 = Fabricate(:user, username: 'alice2', email: 'alice@foo.com')
     merge_users!(alice2, target_user)
 
     emails = UserEmail.where(user_id: target_user.id).pluck(:email, :primary)


### PR DESCRIPTION
This PR removes unnecessary fabrications of user emails. It wasn't quite the speed boost I was hoping for, but it does reduce the number of fabricated objects by ~7,000 and speeds up the tests by ~20s.

This PR makes the default `:user` fabricator create a user with a single email address. When you need a user with a secondary email, you can use the old `:user` fabricator which has been renamed to `:user_with_secondary_email`.