### PR TITLE
FEATURE: adds an updateComponent hook to plugin-connector

### DIFF
--- a/app/assets/javascripts/discourse/components/plugin-connector.js.es6
+++ b/app/assets/javascripts/discourse/components/plugin-connector.js.es6
@@ -20,6 +20,9 @@ export default Ember.Component.extend({
   _argsChanged() {
     const args = this.get("args") || {};
     Object.keys(args).forEach(key => this.set(key, args[key]));
+
+    const connectorClass = this.get("connector.connectorClass");
+    connectorClass.updateComponent.call(this, args, this);
   },
 
   send(name, ...args) {

--- a/app/assets/javascripts/discourse/lib/plugin-connectors.js.es6
+++ b/app/assets/javascripts/discourse/lib/plugin-connectors.js.es6
@@ -17,7 +17,8 @@ export function extraConnectorClass(name, obj) {
 const DefaultConnectorClass = {
   actions: {},
   shouldRender: () => true,
-  setupComponent() {}
+  setupComponent() {},
+  updateComponent() {}
 };
 
 function findOutlets(collection, callback) {


### PR DESCRIPTION
This commit allows plugin authors to hook into args mutations. setupComponent is called a the beginning and then you had no way to hook into this.