### PR TITLE
show read more from category link in crawler view of topic

### DIFF
--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -98,6 +98,12 @@
   </div>
 <% end %>
 
+<% if @topic_view.topic && @topic_view.topic.category %>
+  <div class="clearfix topic-body">
+    <%= t('js.topic.read_more_in_category', catLink: "<a href=\"#{@topic_view.topic.category.url}\">#{CGI.escapeHTML(@topic_view.topic.category.name)}</a>", latestLink: "<a href=\"/latest\">#{t("js.topic.view_latest_topics")}</a>") %>
+  </div>
+<% end %>
+
 <% end %>
 
 <% content_for :head do %>

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1893,7 +1893,7 @@ en:
       options: "Topic Options"
       show_links: "show links within this topic"
       toggle_information: "toggle topic details"
-      read_more_in_category: "Want to read more? Browse other topics in {{catLink}} or {{latestLink}}."
+      read_more_in_category: "Want to read more? Browse other topics in %{catLink} or %{latestLink}."
       read_more: "Want to read more? {{catLink}} or {{latestLink}}."
 
       # keys ending with _MF use message format, see https://meta.discourse.org/t/message-format-support-for-localization/7035 for details


### PR DESCRIPTION
I tested it on my local but link gets rendered at the text. Is it due to some set-up issue on local or am I doing something wrong here
![Screenshot from 2019-04-23 19-49-19](https://user-images.githubusercontent.com/6376157/56588355-cef97980-6600-11e9-9222-f6a4acc81bb0.png)

This is a part of https://meta.discourse.org/t/improving-discourse-static-html-archive/112497/6, it will improve the user's interactivity on the static website when the user scrolls at the end of a topic.

Also, should I change `{{}}` to `%{}` in all locales file or just `en` one is fine?
