### PR TITLE
use description_text instead of description to show correct sanitized…

### DIFF
--- a/app/views/list/list.erb
+++ b/app/views/list/list.erb
@@ -31,7 +31,7 @@
         <span itemprop='name'><%= subcategory.name %></span>
       </a>
       <% if subcategory.description.present? %>
-        <span itemprop='description'><%= subcategory.description %></span>
+        <span itemprop='description'><%= subcategory.description_text %></span>
       <% end %>
     <% end %>
     <br/>


### PR DESCRIPTION
… description

This is to show the proper description of sub-categories at category page. Example: https://meta.discourse.org/c/plugin/?_escaped_fragment_ 
I wanted to use html_safe so that links can be included on that page but that comes with XSS risk. Is there any standard safe way to do it here for sub-categories description?