### PR TITLE
FIX: Do not replace text of collapsed ignore posts

### DIFF
--- a/app/assets/javascripts/discourse/widgets/embedded-post.js.es6
+++ b/app/assets/javascripts/discourse/widgets/embedded-post.js.es6
@@ -29,6 +29,7 @@ export default createWidget("embedded-post", {
   buildKey: attrs => `embedded-post-${attrs.id}`,
 
   html(attrs, state) {
+    attrs.embeddedPost = true;
     return [
       h("div.reply", { attributes: { "data-post-id": attrs.id } }, [
         h("div.row", [

--- a/app/assets/javascripts/discourse/widgets/post-cooked.js.es6
+++ b/app/assets/javascripts/discourse/widgets/post-cooked.js.es6
@@ -262,6 +262,7 @@ export default class PostCooked {
 
   _computeCooked() {
     if (
+      this.attrs.embeddedPost &&
       this.ignoredUsers &&
       this.ignoredUsers.length > 0 &&
       this.ignoredUsers.includes(this.attrs.username)


### PR DESCRIPTION
## Why?

Right now, for collapsed posts of an ignored user, if the posts are expanded, we replace the text with `Ignored content`. We don't think this should be the case.

![GIF](https://user-images.githubusercontent.com/45508821/56652202-bc278900-6682-11e9-869f-d616032d2615.gif)
