### PR TITLE
FIX: Do not move hidden post actions.

### DIFF
--- a/app/models/post_mover.rb
+++ b/app/models/post_mover.rb
@@ -224,6 +224,7 @@ class PostMover
     @posts ||= begin
       Post.where(topic: @original_topic, id: post_ids)
         .where.not(post_type: Post.types[:small_action])
+        .where.not(raw: '')
         .order(:created_at).tap do |posts|
 
         raise Discourse::InvalidParameters.new(:post_ids) if posts.empty?

--- a/spec/models/post_mover_spec.rb
+++ b/spec/models/post_mover_spec.rb
@@ -256,10 +256,13 @@ describe PostMover do
 
           it "does not try to move small action posts" do
             small_action = Fabricate(:post, topic: topic, raw: "A small action", post_type: Post.types[:small_action])
-            new_topic = topic.move_posts(user, [p2.id, p4.id, small_action.id], title: "new testing topic name", category_id: category.id)
+            hidden_small_action = Fabricate(:post, topic: topic, post_type: Post.types[:whisper])
+            hidden_small_action.update_attribute(:raw, "")
+            new_topic = topic.move_posts(user, [p2.id, p4.id, small_action.id, hidden_small_action.id], title: "new testing topic name", category_id: category.id)
 
             expect(new_topic.posts_count).to eq(2)
             expect(small_action.topic_id).to eq(topic.id)
+            expect(hidden_small_action.topic_id).to eq(topic.id)
 
             moderator_post = topic.posts.last
             expect(moderator_post.raw).to include("2 posts were split")


### PR DESCRIPTION
Hidden (staff-only) post actions are whisper posts with no content, that
are later transformed by the client into post actions (discourse-assign
uses this).