### PR TITLE
UX: Added leading whitespace to emoji picker & inline translation for…

### DIFF
--- a/app/assets/javascripts/discourse/components/d-editor.js.es6
+++ b/app/assets/javascripts/discourse/components/d-editor.js.es6
@@ -866,7 +866,9 @@ export default Ember.Component.extend({
       const captures = selected.pre.match(/\B:(\w*)$/);
 
       if (_.isEmpty(captures)) {
-        this._addText(selected, `:${code}:`);
+        selected.pre.match(/\S$/)
+          ? this._addText(selected, ` :${code}:`)
+          : this._addText(selected, `:${code}:`);
       } else {
         let numOfRemovedChars = selected.pre.length - captures[1].length;
         selected.pre = selected.pre.slice(

--- a/app/assets/javascripts/pretty-text/emoji.js.es6
+++ b/app/assets/javascripts/pretty-text/emoji.js.es6
@@ -68,8 +68,8 @@ export function performEmojiUnescape(string, opts) {
       : "emoji";
     const isAllowed =
       (!inlineEmojiEnabled &&
-        (/\s|[.,\/#!$%^&*;:{}=\-_`~()]/.test(before) || m.index === 0)) ||
-      inlineEmojiEnabled;
+        (/\s|[>.,\/#!$%^&*;:{}=\-_`~()]/.test(before) || m.index === 0)) ||
+      !!inlineEmojiEnabled;
 
     const replacement =
       url && (isEmoticon || hasEndingColon || isUnicodeEmoticon) && isAllowed
@@ -101,11 +101,9 @@ export function performEmojiEscape(string, opts) {
       replacement = m[0];
     }
     const before = string.charAt(m.index - 1);
-    if (!/\B/.test(before)) {
-      replacement = "\u200b" + replacement;
-    }
     if (
-      (!inlineEmojiEnabled && (/\s/.test(before) || /\./.test(before))) ||
+      (!inlineEmojiEnabled &&
+        (/\s|[>.,\/#!$%^&*;:{}=\-_`~()]/.test(before) || m.index === 0)) ||
       !!inlineEmojiEnabled
     ) {
       string = string.replace(m[0], replacement);

--- a/lib/pretty_text.rb
+++ b/lib/pretty_text.rb
@@ -230,10 +230,11 @@ module PrettyText
 
     set = SiteSetting.emoji_set.inspect
     custom = Emoji.custom.map { |e| [e.name, e.url] }.to_h.to_json
+    inline_emoji = SiteSetting.enable_inline_emoji_translation
     protect do
       v8.eval(<<~JS)
         __paths = #{paths_json};
-        __performEmojiUnescape(#{title.inspect}, { getURL: __getURL, emojiSet: #{set}, customEmoji: #{custom} });
+        __performEmojiUnescape(#{title.inspect}, { getURL: __getURL, emojiSet: #{set}, customEmoji: #{custom}, inlineEmojiEnabled: #{inline_emoji} });
       JS
     end
   end
@@ -241,9 +242,10 @@ module PrettyText
   def self.escape_emoji(title)
     return unless title
 
+    inline_emoji = SiteSetting.enable_inline_emoji_translation
     protect do
       v8.eval(<<~JS)
-        __performEmojiEscape(#{title.inspect});
+        __performEmojiEscape(#{title.inspect}, { inlineEmojiEnabled: #{inline_emoji} });
       JS
     end
   end

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -280,6 +280,7 @@ describe Topic do
     let(:topic_script) { build_topic_with_title("Topic with <script>alert('title')</script> script in its title") }
     let(:topic_emoji) { build_topic_with_title("I 💖 candy alot") }
     let(:topic_modifier_emoji) { build_topic_with_title("I 👨‍🌾 candy alot") }
+    let(:topic_inline_emoji) { build_topic_with_title("Hello😊World") }
 
     it "escapes script contents" do
       expect(topic_script.fancy_title).to eq("Topic with &lt;script&gt;alert(&lsquo;title&rsquo;)&lt;/script&gt; script in its title")
@@ -291,6 +292,16 @@ describe Topic do
 
     it "keeps combined emojis" do
       expect(topic_modifier_emoji.fancy_title).to eq("I :man_farmer: candy alot")
+    end
+
+    it "keeps inline emojis if inline emoji setting disabled" do
+      SiteSetting.enable_inline_emoji_translation = false
+      expect(topic_inline_emoji.fancy_title).to eq("Hello😊World")
+    end
+
+    it "expands inline emojis if inline emoji setting enabled" do
+      SiteSetting.enable_inline_emoji_translation = true
+      expect(topic_inline_emoji.fancy_title).to eq("Hello:blush:World")
     end
 
     it "escapes bold contents" do

--- a/test/javascripts/acceptance/emoji-picker-test.js.es6
+++ b/test/javascripts/acceptance/emoji-picker-test.js.es6
@@ -60,6 +60,33 @@ QUnit.test("emoji picker triggers event when picking emoji", async assert => {
   );
 });
 
+QUnit.test("emoji picker add leading whitespace before emoji", async assert => {
+  await visit("/t/internationalization-localization/280");
+  await click("#topic-footer-buttons .btn.create");
+
+  // Whitespace should be added on text
+  await fillIn(".d-editor-input", "This is a test input");
+  await click("button.emoji.btn");
+  await click(".emoji-picker button[title='grinning']");
+  assert.equal(
+    find(".d-editor-input").val(),
+    "This is a test input :grinning:",
+    "it adds the emoji code and a leading whitespace when there is text"
+  );
+  await click("button.emoji.btn");
+
+  // Whitespace should not be added on whitespace
+  await fillIn(".d-editor-input", "This is a test input ");
+  await click("button.emoji.btn");
+  await click(".emoji-picker button[title='grinning']");
+  assert.equal(
+    find(".d-editor-input").val(),
+    "This is a test input :grinning:",
+    "it adds the emoji code and no leading whitespace when user already entered whitespace"
+  );
+  await click("button.emoji.btn");
+});
+
 QUnit.test("emoji picker has a list of recently used emojis", async assert => {
   await visit("/t/internationalization-localization/280");
   await click("#topic-footer-buttons .btn.create");

--- a/test/javascripts/acceptance/topic-test.js.es6
+++ b/test/javascripts/acceptance/topic-test.js.es6
@@ -201,6 +201,26 @@ QUnit.test("Updating the topic title with unicode emojis", async assert => {
   );
 });
 
+QUnit.test(
+  "Updating the topic title with unicode emojis without whitespaces",
+  async assert => {
+    await visit("/t/internationalization-localization/280");
+    await click("#topic-title .d-icon-pencil-alt");
+
+    await fillIn("#edit-title", "Test🙂Title");
+
+    await click("#topic-title .submit-edit");
+
+    assert.equal(
+      find(".fancy-title")
+        .html()
+        .trim(),
+      `Test<img src="/images/emoji/emoji_one/slightly_smiling_face.png?v=${v}" title="slightly_smiling_face" alt="slightly_smiling_face" class="emoji">Title`,
+      "it displays the new title with escaped unicode emojis"
+    );
+  }
+);
+
 acceptance("Topic featured links", {
   loggedIn: true,
   settings: {

--- a/test/javascripts/acceptance/topic-test.js.es6
+++ b/test/javascripts/acceptance/topic-test.js.es6
@@ -204,6 +204,7 @@ QUnit.test("Updating the topic title with unicode emojis", async assert => {
 QUnit.test(
   "Updating the topic title with unicode emojis without whitespaces",
   async assert => {
+    Discourse.SiteSettings.enable_inline_emoji_translation = true;
     await visit("/t/internationalization-localization/280");
     await click("#topic-title .d-icon-pencil-alt");
 

--- a/test/javascripts/components/d-editor-test.js.es6
+++ b/test/javascripts/components/d-editor-test.js.es6
@@ -699,7 +699,7 @@ componentTest("emoji", {
     await click(
       '.emoji-picker .section[data-section="smileys_&_emotion"] button.emoji[title="grinning"]'
     );
-    assert.equal(this.get("value"), "hello world.:grinning:");
+    assert.equal(this.get("value"), "hello world. :grinning:");
   }
 });
 

--- a/test/javascripts/lib/emoji-test.js.es6
+++ b/test/javascripts/lib/emoji-test.js.es6
@@ -64,6 +64,15 @@ QUnit.test("emojiUnescape", assert => {
     "hi :blonde_man:t6",
     "end colon not optional for skin tones"
   );
+  Discourse.SiteSettings.enable_inline_emoji_translation = false;
+  testUnescape("hi:smile:", `hi:smile:`, "inline translations disabled");
+  Discourse.SiteSettings.enable_inline_emoji_translation = true;
+  testUnescape(
+    "hi:smile:",
+    `hi<img src='/images/emoji/emoji_one/smile.png?v=${v}' title='smile' alt='smile' class='emoji'>`,
+    "inline translations enabled"
+  );
+  Discourse.SiteSettings.enable_inline_emoji_translation = false;
 });
 
 QUnit.test("Emoji search", assert => {


### PR DESCRIPTION
… emoji escape

This enhances the emoji picker to now automatically append a whitespace in front of the "about to insert" emoji, in order to get the emojis to escape correctly.

Also `emojiUnescape` and `emojiEscape` now support the `enable_inline_emoji_translation` site setting.

Resolves: https://meta.discourse.org/t/emoji-not-recognized-after-cyrillic-symbols/72091/17