### PR TITLE
FEAT: show tags in crawler view of tags page for static site

### DIFF
--- a/app/views/tags/_tag.html.erb
+++ b/app/views/tags/_tag.html.erb
@@ -1,5 +1,5 @@
 <div class="tag-box">
-  <a href="/tags/<%= tag[:id] %>" class="discourse-tag simple"><%= tag[:text] %></a>
+  <a href="<%= Discourse.base_url %>/tags/<%= tag[:id] %>" class="discourse-tag simple"><%= tag[:text] %></a>
   <% if tag[:count] && tag[:count] > 0 %>
     <span class="tag-count">x <%= tag[:count] %></span>
   <% end %>

--- a/app/views/tags/_tag.html.erb
+++ b/app/views/tags/_tag.html.erb
@@ -1,0 +1,6 @@
+<div class="tag-box">
+  <a href="/tags/<%= tag[:id] %>" class="discourse-tag simple"><%= tag[:text] %></a>
+  <% if tag[:count] && tag[:count] > 0 %>
+    <span class="tag-count">x <%= tag[:count] %></span>
+  <% end %>
+</div>

--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -32,7 +32,7 @@
     <% end %>
   <% end %>
 
-  <% if @tags && !@tags.empty? %>
+  <% if @tags.present? %>
     <div class="tag-list">
       <h3><%= t 'js.tagging.other_tags' %></h3>
       <% @tags.each do |tag| %>

--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -34,7 +34,7 @@
 
   <% if @tags && !@tags.empty? %>
     <div class="tag-list">
-      <h3>Others</h3>
+      <h3><%= t 'js.tagging.other_tags' %></h3>
       <% @tags.each do |tag| %>
         <%= render "tag", tag: tag %>
       <% end %>

--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -1,3 +1,45 @@
 <% content_for :head do %>
   <%= raw crawlable_meta_data(title: @title, description: @description_meta) %>
 <% end %>
+
+<div class="tag-crawler">
+
+  <% if @extras[:categories] %>
+    <% @extras[:categories].each do |category| %>
+      <div class="tag-list">
+        <% if category[:name] %>
+          <h3><%= category[:name] %></h3>
+        <% end %>
+        <% category[:tags].each do |tag| %>
+          <%= render "tag", tag: tag %>
+        <% end %>
+      </div>
+      <div class="clearfix"></div>
+    <% end %>
+  <% end %>
+
+  <% if @extras[:tag_groups] %>
+    <% @extras[:tag_groups].each do |tag_group| %>
+      <div class="tag-list">
+        <% if tag_group[:name] %>
+          <h3><%= tag_group[:name] %></h3>
+        <% end %>
+        <% tag_group[:tags].each do |tag| %>
+          <%= render "tag", tag: tag %>
+        <% end %>
+      </div>
+      <div class="clearfix"></div>
+    <% end %>
+  <% end %>
+
+  <% if @tags && !@tags.empty? %>
+    <div class="tag-list">
+      <h3>Others</h3>
+      <% @tags.each do |tag| %>
+        <%= render "tag", tag: tag %>
+      <% end %>
+    </div>
+    <div class="clearfix"></div>
+  <% end %>
+
+</div>


### PR DESCRIPTION
This adds tags layout in crawler view for a static site. Attaching screenshot for the same below.
This is a part of https://meta.discourse.org/t/improving-discourse-static-html-archive/112497

![Screenshot from 2019-04-24 21-58-00](https://user-images.githubusercontent.com/6376157/56676462-f96c3500-66db-11e9-8f40-e5eaf4845f85.png)
