### PR TITLE
FIX: Narration Bot now gets site setting for automatic post deletion

### DIFF
--- a/plugins/discourse-narrative-bot/config/locales/server.en.yml
+++ b/plugins/discourse-narrative-bot/config/locales/server.en.yml
@@ -366,7 +366,7 @@ en:
         reply: |-
           Phew, that was a close one! Thanks for fixing that :wink:
 
-          Do note that you only have 24 hours to undelete a post.
+          Do note that you only have %{deletion_after} hour(s) to undelete a post.
 
       category_hashtag:
         instructions: |-

--- a/plugins/discourse-narrative-bot/lib/discourse_narrative_bot/advanced_user_narrative.rb
+++ b/plugins/discourse-narrative-bot/lib/discourse_narrative_bot/advanced_user_narrative.rb
@@ -249,7 +249,7 @@ module DiscourseNarrativeBot
       fake_delay
 
       raw = <<~RAW
-      #{I18n.t("#{I18N_KEY}.recover.reply", i18n_post_args)}
+      #{I18n.t("#{I18N_KEY}.recover.reply", i18n_post_args(deletion_after: SiteSetting.delete_removed_posts_after))}
 
       #{instance_eval(&@next_instructions)}
       RAW

--- a/plugins/discourse-narrative-bot/spec/discourse_narrative_bot/advanced_user_narrative_spec.rb
+++ b/plugins/discourse-narrative-bot/spec/discourse_narrative_bot/advanced_user_narrative_spec.rb
@@ -390,7 +390,7 @@ RSpec.describe DiscourseNarrativeBot::AdvancedUserNarrative do
             .to change { Post.count }.by(1)
 
           expected_raw = <<~RAW
-          #{I18n.t('discourse_narrative_bot.advanced_user_narrative.recover.reply', base_uri: '')}
+          #{I18n.t('discourse_narrative_bot.advanced_user_narrative.recover.reply', base_uri: '', deletion_after: SiteSetting.delete_removed_posts_after)}
 
           #{I18n.t('discourse_narrative_bot.advanced_user_narrative.category_hashtag.instructions', category: "#a:b", base_uri: '')}
           RAW


### PR DESCRIPTION
This fixes the narration bot always displaying that posts get automatically deleted after 24 hours even if the site setting `delete_removed_posts_after` is set to another value.

Resolves: https://meta.discourse.org/t/discobot-does-not-properly-update-to-automatic-post-deletion-time/115844