### PR TITLE
FIX: Only do plain text table detection if outside code

### DIFF
--- a/app/assets/javascripts/discourse/components/d-editor.js.es6
+++ b/app/assets/javascripts/discourse/components/d-editor.js.es6
@@ -802,15 +802,6 @@ export default Ember.Component.extend({
     let html = clipboard.getData("text/html");
     let handled = false;
 
-    if (plainText) {
-      plainText = plainText.trim().replace(/\r/g, "");
-      const table = this._extractTable(plainText);
-      if (table) {
-        this.appEvents.trigger("composer:insert-text", table);
-        handled = true;
-      }
-    }
-
     const { pre, lineVal } = this._getSelected(null, { lineVal: true });
     const isInlinePasting = pre.match(/[^\n]$/);
 
@@ -837,6 +828,13 @@ export default Ember.Component.extend({
 
         this.appEvents.trigger("composer:insert-text", markdown);
         handled = true;
+      } else if (plainText) {
+        plainText = plainText.trim().replace(/\r/g, "");
+        const table = this._extractTable(plainText);
+        if (table) {
+          this.appEvents.trigger("composer:insert-text", table);
+          handled = true;
+        }
       }
     }
 

--- a/test/javascripts/lib/pretty-text-test.js.es6
+++ b/test/javascripts/lib/pretty-text-test.js.es6
@@ -1387,6 +1387,13 @@ QUnit.test("enable/disable features", assert => {
   );
 });
 
+QUnit.test("table inside code block", assert => {
+  assert.cooked(
+    "```|a|\n--\n|a|```",
+    '<pre><code class="lang-auto">--\n|a|```</code></pre>'
+  );
+});
+
 QUnit.test("emoji", assert => {
   assert.cooked(
     ":smile:",


### PR DESCRIPTION
Plain text table detection now only happens outside of code fence blocks.

Resolves: https://meta.discourse.org/t/plain-text-table-detection-should-respect-code-fences/115894