### PR TITLE
add no_subcategories query param in url only if its true

### DIFF
--- a/app/controllers/list_controller.rb
+++ b/app/controllers/list_controller.rb
@@ -382,7 +382,9 @@ class ListController < ApplicationController
 
     # hacky columns get special handling
     options[:topic_ids] = param_to_integer_list(:topic_ids)
-    options[:no_subcategories] = options[:no_subcategories] == 'true'
+    if options[:no_subcategories] == 'true'
+      options[:no_subcategories] = true
+    end
 
     options
   end


### PR DESCRIPTION
@coding-horror mentioned to me that the “next link” from the latest is built like so https://meta.discourse.org/latest?no_definitions=true&no_subcategories=false&page=2 which is super nasty. So, his suggestion was to remove queryParams to https://meta.discourse.org/latest?page=2

This is related to it. I haven't removed `no_definitions` since we use it as a filter. It is used as below:
```   
 if options[:no_definitions]
      result = result.where('COALESCE(categories.topic_id, 0) <> topics.id')
 end
```
This adds `no_subcategories` param only if it's true otherwise it will be assumed as false anyways.
