### PR TITLE
FEATURE: Show diff of local changes before updating remote theme

### DIFF
--- a/app/assets/stylesheets/common/base/modal.scss
+++ b/app/assets/stylesheets/common/base/modal.scss
@@ -265,6 +265,15 @@
         }
       }
     }
+
+    pre {
+      background-color: blend-primary-secondary(5%);
+      max-height: 300px;
+      padding: 0.5em;
+      code {
+        max-height: none;
+      }
+    }
   }
   .password-confirmation {
     display: none;

--- a/app/controllers/admin/themes_controller.rb
+++ b/app/controllers/admin/themes_controller.rb
@@ -250,6 +250,15 @@ class Admin::ThemesController < Admin::AdminController
     exporter.cleanup!
   end
 
+  def diff_local_changes
+    theme = Theme.find_by(id: params[:id])
+    raise Discourse::InvalidParameters.new(:id) unless theme
+    changes = theme.remote_theme&.diff_local_changes
+    respond_to do |format|
+      format.json { render json: changes || {} }
+    end
+  end
+
   private
 
   def update_default_theme

--- a/app/models/remote_theme.rb
+++ b/app/models/remote_theme.rb
@@ -170,6 +170,21 @@ class RemoteTheme < ActiveRecord::Base
     end
   end
 
+  def diff_local_changes
+    return unless is_git?
+    importer = ThemeStore::GitImporter.new(remote_url, private_key: private_key, branch: branch)
+    begin
+      importer.import!
+    rescue RemoteTheme::ImportError => err
+      { error: err.message }
+    else
+      changes = importer.diff_local_changes(self.id)
+      return nil if changes.blank?
+
+      { diff: changes }
+    end
+  end
+
   def normalize_override(hex)
     return unless hex
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3415,6 +3415,8 @@ en:
           long_title: "Amend colors, CSS and HTML contents of your site"
           edit: "Edit"
           edit_confirm: "This is a remote theme, if you edit CSS/HTML your changes will be erased next time you update the theme."
+          update_confirm: "These local changes will be erased by the update. Are you sure you want to continue?"
+          update_confirm_yes: "Yes, continue with the update"
           common: "Common"
           desktop: "Desktop"
           mobile: "Mobile"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -206,6 +206,7 @@ Discourse::Application.routes.draw do
     post "themes/upload_asset" => "themes#upload_asset"
     post "themes/generate_key_pair" => "themes#generate_key_pair"
     get "themes/:id/preview" => "themes#preview"
+    get "themes/:id/diff_local_changes" => "themes#diff_local_changes"
 
     scope "/customize", constraints: AdminConstraint.new do
       resources :user_fields, constraints: AdminConstraint.new

--- a/lib/theme_store/tgz_exporter.rb
+++ b/lib/theme_store/tgz_exporter.rb
@@ -9,6 +9,10 @@ class ThemeStore::TgzExporter
     @export_name = "discourse-#{@export_name}" unless @export_name.starts_with?("discourse")
   end
 
+  def export_name
+    @export_name
+  end
+
   def package_filename
     export_package
   end
@@ -17,7 +21,6 @@ class ThemeStore::TgzExporter
     FileUtils.rm_rf(@temp_folder)
   end
 
-  private
   def export_to_folder
     FileUtils.mkdir(@temp_folder)
 
@@ -50,6 +53,7 @@ class ThemeStore::TgzExporter
     @temp_folder
   end
 
+  private
   def export_package
     export_to_folder
     Dir.chdir(@temp_folder) do

--- a/spec/models/remote_theme_spec.rb
+++ b/spec/models/remote_theme_spec.rb
@@ -27,7 +27,7 @@ describe RemoteTheme do
           "theme_version": "1.0",
           "minimum_discourse_version": "1.0.0",
           "assets": {
-            "font": "assets/awesome.woff2"
+            "font": "assets/font.woff2"
           },
           "color_schemes": {
             "#{color_scheme_name}": {
@@ -51,7 +51,7 @@ describe RemoteTheme do
         "common/header.html" => "I AM HEADER",
         "common/random.html" => "I AM SILLY",
         "common/embedded.scss" => "EMBED",
-        "assets/awesome.woff2" => "FAKE FONT",
+        "assets/font.woff2" => "FAKE FONT",
         "settings.yaml" => "boolean_setting: true",
         "locales/en.yml" => "sometranslations"
       )
@@ -82,7 +82,6 @@ describe RemoteTheme do
       expect(@theme.theme_fields.length).to eq(7)
 
       mapped = Hash[*@theme.theme_fields.map { |f| ["#{f.target_id}-#{f.name}", f.value] }.flatten]
-
       expect(mapped["0-header"]).to eq("I AM HEADER")
       expect(mapped["1-scss"]).to eq(scss_data)
       expect(mapped["0-embedded_scss"]).to eq("EMBED")
@@ -115,7 +114,6 @@ describe RemoteTheme do
 
       File.delete("#{initial_repo}/settings.yaml")
       File.delete("#{initial_repo}/scss/file.scss")
-
       `cd #{initial_repo} && git commit -am "update"`
 
       time = Time.new('2001')
@@ -158,6 +156,14 @@ describe RemoteTheme do
 
       scheme_count = ColorScheme.where(theme_id: @theme.id).count
       expect(scheme_count).to eq(1)
+
+      # It should detect local changes
+      expect(remote.diff_local_changes.blank?).to eq(true)
+      @theme.set_field(target: :common, name: :scss, value: 'body {background-color: blue};')
+      @theme.save
+      @theme.reload
+
+      expect(remote.diff_local_changes[:diff]).to include("background-color: blue")
     end
   end
 

--- a/spec/models/remote_theme_spec.rb
+++ b/spec/models/remote_theme_spec.rb
@@ -158,7 +158,6 @@ describe RemoteTheme do
       expect(scheme_count).to eq(1)
 
       # It should detect local changes
-      expect(remote.diff_local_changes.blank?).to eq(true)
       @theme.set_field(target: :common, name: :scss, value: 'body {background-color: blue};')
       @theme.save
       @theme.reload

--- a/spec/requests/admin/themes_controller_spec.rb
+++ b/spec/requests/admin/themes_controller_spec.rb
@@ -376,4 +376,13 @@ describe Admin::ThemesController do
       expect(response.status).to eq(400)
     end
   end
+
+  describe '#diff_local_changes' do
+    let(:theme) { Fabricate(:theme) }
+
+    it "should return empty for a default theme" do
+      get "/admin/themes/#{theme.id}/diff_local_changes.json"
+      expect(response.body).to eq("{}")
+    end
+  end
 end


### PR DESCRIPTION
<img width="828" alt="image" src="https://user-images.githubusercontent.com/368961/56761602-c2456480-676b-11e9-899d-5f84575dcad1.png">

When updating a remote theme, this checks whether there are any local changes, and if so, it displays a diff of the changes to the user, as in screenshot above.  

Changes to SCSS, HTML (JS) and uploaded assets will trigger the warning. Deleted theme assets will not trigger it. 