### PR TITLE
FIX: Mark invited admins as 'approved'

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -503,6 +503,7 @@ class Admin::UsersController < Admin::AdminController
     end
 
     user.active = true
+    user.approved = true
     user.save!
     user.grant_admin!
     user.change_trust_level!(4)

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -794,6 +794,8 @@ RSpec.describe Admin::UsersController do
       expect(u.name).to eq("Bill")
       expect(u.username).to eq("bill22")
       expect(u.admin).to eq(true)
+      expect(u.active).to eq(true)
+      expect(u.approved).to eq(true)
     end
 
     it "doesn't send the email with send_email falsey" do


### PR DESCRIPTION
This prevents invited admins appearing as no-op reviewables in the queue when `invite_only` or `require_approval` is enabled.