### PR TITLE
fix css of prev and next page links, move them to bottom of page

### DIFF
--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -88,7 +88,7 @@
 <% end %>
 
 <% if @topic_view.prev_page || @topic_view.next_page %>
-  <div role='navigation' itemscope itemtype='http://schema.org/SiteNavigationElement'>
+  <div role='navigation' itemscope itemtype='http://schema.org/SiteNavigationElement' class="topic-body crawler-post">
     <% if @topic_view.prev_page %>
       <span itemprop='name'><%= link_to t(:prev_page), @topic_view.prev_page_path, rel: 'prev', itemprop: 'url' %></span>
     <% end %>


### PR DESCRIPTION
Previously it used to be shown like this: https://d11a6trkgmumsb.cloudfront.net/original/3X/5/7/57d818420f83aed4984a7218337fcb0d8b4fad3c.png, I have just moved them to the bottom of page

Attaching screenshot for the same:
![Screenshot from 2019-04-30 20-06-47](https://user-images.githubusercontent.com/6376157/56969684-52781500-6b83-11e9-9f42-589452c7b1d4.png)
