### PR TITLE
FIX: crawler layout CSS adjustments

### DIFF
--- a/app/assets/stylesheets/common/base/crawler_layout.scss
+++ b/app/assets/stylesheets/common/base/crawler_layout.scss
@@ -18,6 +18,7 @@ body.crawler {
   }
   div#main-outlet {
     div.post {
+      word-break: break-word;
       img {
         max-width: 100%;
       }

--- a/app/assets/stylesheets/common/base/crawler_layout.scss
+++ b/app/assets/stylesheets/common/base/crawler_layout.scss
@@ -7,6 +7,7 @@ body.crawler {
     background-color: #fff;
     padding: 10px;
     box-shadow: shadow("header");
+    box-sizing: border-box;
   }
   div.topic-list div[itemprop="itemListElement"] {
     padding: 10px 0;


### PR DESCRIPTION
This PR makes two changes that improve the crawler layout. 

The first change is that it adjusts the header size to fit the viewport. We are currently not factoring in the padding we add to the header, this causes horizontal scrolling to occur.

<img width="300" src="https://user-images.githubusercontent.com/33972521/57055876-ec99a380-6cd0-11e9-976b-8e15bdcf76b8.png">

This is fixed by factoring in the padding in the width of the header. 

The second change is to wrap code in posts to prevent horizontal scrolling. There are two types of code that are affected by this:

* unformatted code 
* code posted in inline code blocks

<img width="300" src="https://user-images.githubusercontent.com/33972521/57055897-2074c900-6cd1-11e9-94ea-d3c7769bbe05.png">

This is fixed by forcing the code to wrap in order to prevent horizontal scrolling. 

<img width="300" src="https://user-images.githubusercontent.com/33972521/57055906-34202f80-6cd1-11e9-8172-cdfab5ed66e6.png">
