### PR TITLE
FIX: Do not send duplicate alerts for the same post

### DIFF
--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -326,19 +326,8 @@ class PostAlerter
         post_number: post.post_number
       ).limit(10)
 
+    # Don't notify the same user about the same type of notification on the same post
     existing_notification_of_same_type = existing_notifications.find { |n| n.notification_type == type }
-
-    # existing_notification = user.notifications
-    #   .order("notifications.id DESC")
-    #   .find_by(
-    #     topic_id: post.topic_id,
-    #     post_number: post.post_number
-    #   )
-
-    # # Don't notify the same user about the same type of notification on the same post
-    # existing_notification_of_same_type = existing_notification if existing_notification&.notification_type == type
-
-    puts existing_notification_of_same_type.inspect
 
     return if existing_notification_of_same_type && !should_notify_previous?(user, existing_notification_of_same_type, opts)
 
@@ -367,15 +356,6 @@ class PostAlerter
         return notification if notification
       end
     end
-
-    # Don't alert same user about the same post
-    # i.e. skip duplicate alerts on a revised post (when editing post triggers a new type of notification like a mention or a quote)
-    existing_alert = user.notifications
-      .order("notifications.id DESC")
-      .find_by(
-        topic_id: post.topic_id,
-        post_number: post.post_number
-      )
 
     collapsed = false
 

--- a/spec/services/post_alerter_spec.rb
+++ b/spec/services/post_alerter_spec.rb
@@ -544,12 +544,13 @@ describe PostAlerter do
   describe ".create_notification" do
     fab!(:topic) { Fabricate(:private_message_topic, user: user, created_at: 1.hour.ago) }
     fab!(:post) { Fabricate(:post, topic: topic, created_at: 1.hour.ago) }
+    let(:type) { Notification.types[:private_message] }
 
     it "creates a notification for PMs" do
       post.revise(user, { raw: 'This is the revised post' }, revised_at: Time.zone.now)
 
       expect {
-        PostAlerter.new.create_notification(user, Notification.types[:private_message], post)
+        PostAlerter.new.create_notification(user, type, post)
       }.to change { user.notifications.count }.by(1)
 
       expect(user.notifications.last.data_hash["topic_title"]).to eq(topic.title)
@@ -561,14 +562,50 @@ describe PostAlerter do
       post.revise(user, { title: "This is the revised title" }, revised_at: Time.now)
 
       expect {
-        PostAlerter.new.create_notification(user, Notification.types[:private_message], post)
+        PostAlerter.new.create_notification(user, type, post)
       }.to change { user.notifications.count }.by(1)
 
       expect(user.notifications.last.data_hash["topic_title"]).to eq(original_title)
     end
 
-    it "triggers :post_notification_alert" do
+    it "triggers :pre_notification_alert" do
+      events = DiscourseEvent.track_events do
+        PostAlerter.new.create_notification(user, type, post)
+      end
 
+      payload = {
+       notification_type: type,
+       post_number: post.post_number,
+       topic_title: post.topic.title,
+       topic_id: post.topic.id,
+       excerpt: post.excerpt(400, text_entities: true, strip_links: true, remap_emoji: true),
+       username: post.username,
+       post_url: post.url
+      }
+
+      expect(events).to include(event_name: :pre_notification_alert, params: [user, payload])
+    end
+
+    it "does not alert when revising and changing notification type" do
+      PostAlerter.new.create_notification(user, type, post)
+
+      post.revise(user, { raw: "Editing post to fake include a mention of @eviltrout" }, revised_at: Time.now)
+
+      events = DiscourseEvent.track_events do
+        PostAlerter.new.create_notification(user, Notification.types[:mentioned], post)
+      end
+
+      payload = {
+       notification_type: type,
+       post_number: post.post_number,
+       topic_title: post.topic.title,
+       topic_id: post.topic.id,
+       excerpt: post.excerpt(400, text_entities: true, strip_links: true, remap_emoji: true),
+       username: post.username,
+       post_url: post.url
+      }
+
+      expect(events).not_to include(event_name: :pre_notification_alert, params: [user, payload])
     end
 
     it "triggers :before_create_notification" do


### PR DESCRIPTION
This addresses a small part of duplicate alerts on the same post ([initial discussion on meta](https://meta.discourse.org/t/new-ios-mobile-app-beta-available-for-testing/115912/33?u=pmusaraj)).

Case scenario

- userA replies to a topic owned by userB
- userB receives an alert (push notification)
- userA revises her post and adds a mention of userB or quotes userB

Currently, userB receives a second alert upon being mentioned or quoted. 
This PR suppresses the second alert on the same post. 

