### PR TITLE
FIX: Use all flag types in moderators activity report

### DIFF
--- a/app/models/reports/moderators_activity.rb
+++ b/app/models/reports/moderators_activity.rb
@@ -69,7 +69,7 @@ Report.add_report("moderators_activity") do |report|
       SELECT agreed_by_id,
       disagreed_by_id
       FROM post_actions
-      WHERE post_action_type_id IN (#{PostActionType.flag_types_without_custom.values.join(',')})
+      WHERE post_action_type_id IN (#{PostActionType.flag_types.values.join(',')})
       AND created_at >= '#{report.start_date}'
       AND created_at <= '#{report.end_date}'
       ),


### PR DESCRIPTION
The Flags Reviewed section of the moderators activity report is ignoring the `:notify_moderators` flag type. Changing `PostActionType.flag_types_without_custom` to `PostActionType.flag_types` fixes that.