### PR TITLE
Revert "FIX: When mutating a string to build a diff. Dup it first"

### DIFF
--- a/lib/discourse_diff.rb
+++ b/lib/discourse_diff.rb
@@ -176,25 +176,24 @@ class DiscourseDiff
   end
 
   def add_class_or_wrap_in_tags(html_or_text, klass)
-    dupped_html_or_text = html_or_text.dup
-    index_of_next_chevron = dupped_html_or_text.index(">")
-    if dupped_html_or_text.length > 0 && dupped_html_or_text[0] == '<' && index_of_next_chevron
-      index_of_class = dupped_html_or_text.index("class=")
+    index_of_next_chevron = html_or_text.index(">")
+    if html_or_text.length > 0 && html_or_text[0] == '<' && index_of_next_chevron
+      index_of_class = html_or_text.index("class=")
       if index_of_class.nil? || index_of_class > index_of_next_chevron
         # we do not have a class for the current tag
         # add it right before the ">"
-        dupped_html_or_text.insert(index_of_next_chevron, " class=\"diff-#{klass}\"")
+        html_or_text.insert(index_of_next_chevron, " class=\"diff-#{klass}\"")
       else
         # we have a class, insert it at the beginning if not already present
-        classes = dupped_html_or_text[/class=(["'])([^\1]*)\1/, 2]
+        classes = html_or_text[/class=(["'])([^\1]*)\1/, 2]
         if classes.include?("diff-#{klass}")
-          dupped_html_or_text
+          html_or_text
         else
-          dupped_html_or_text.insert(index_of_class + "class=".length + 1, "diff-#{klass} ")
+          html_or_text.insert(index_of_class + "class=".length + 1, "diff-#{klass} ")
         end
       end
     else
-      "<#{klass}>#{dupped_html_or_text}</#{klass}>"
+      "<#{klass}>#{html_or_text}</#{klass}>"
     end
   end
 


### PR DESCRIPTION
Reverts discourse/discourse#7482

This change should have been applied to the `frozen_string_literal` branch.