### PR TITLE
Time variable used to be created with users timezone

### DIFF
--- a/spec/models/search_log_spec.rb
+++ b/spec/models/search_log_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe SearchLog, type: :model do
 
   describe ".term_details" do
     it "should only use the date for the period" do
-      time = Time.new(2019, 5, 23, 18, 15, 30)
+      time = Time.utc(2019, 5, 23, 18, 15, 30)
       freeze_time(time)
 
       search_log = Fabricate(:search_log, created_at: time - 1.hour)


### PR DESCRIPTION
When I ran this test I had a problem because my TimeZone is UTC -5, so I was creating search_log on the correct day but search_log2 in the next day. The test expected to have two logs on the same day but I only had one. I changed the method to create a new time variable because it has to be UTC in order to pass the test.

Another user also had the same problem:
https://meta.discourse.org/t/beginners-guide-to-install-discourse-on-macos-for-development/15772/208
