### PR TITLE
UX: Fix like and flag button-count alignment on mobile

### DIFF
--- a/app/assets/stylesheets/mobile/topic-post.scss
+++ b/app/assets/stylesheets/mobile/topic-post.scss
@@ -32,35 +32,30 @@ span.badge-posts {
     .actions {
       display: flex;
     }
-    .like-button {
+    // Handles the like and flag buttons in the post menu.
+    .double-button {
       display: flex;
       flex: 0 1 auto;
       button {
-        &.like {
+        &.like,
+        &.create-flag {
           flex: 1 1 auto;
         }
-        &.like-count {
-          padding: 8px 4px 8px 8px;
-          line-height: 1.2;
-          &.regular-likes {
-            margin-right: 0;
+        &.button-count {
+          padding: s(2 1 2 2);
+          + .toggle-like,
+          + .create-flag {
+            padding: s(2 2 2 1);
           }
           &.my-likes {
             display: flex;
             max-width: unset;
-            margin-right: 0;
-            padding: 8px 9px 8px 8px;
+            padding: s(2);
             .d-icon {
-              padding-left: 8px;
+              padding-left: s(2);
             }
           }
         }
-        .d-icon {
-          line-height: $line-height-medium;
-        }
-      }
-      button.like-count + button.toggle-like {
-        padding: 8px 9px 8px 4px;
       }
     }
     .d-icon {


### PR DESCRIPTION
The markup for the like button changed and this led to some styles not applying which results in alignment issues like this

<img width="300" src="https://user-images.githubusercontent.com/33972521/57276541-8c41a200-70d4-11e9-84a2-84cf271b9ea7.png">

This PR fixes these issues

<img width="300" src="https://user-images.githubusercontent.com/33972521/57276595-abd8ca80-70d4-11e9-8b83-e4a8602c29e4.png">
