### PR TITLE
FIX: Move default options that were in the bufferedRender function.

### DIFF
--- a/app/assets/javascripts/discourse/components/topic-list-item.js.es6
+++ b/app/assets/javascripts/discourse/components/topic-list-item.js.es6
@@ -31,6 +31,9 @@ export function navigateToTopic(topic, href) {
 
 export const ListItemDefaults = {
   tagName: "tr",
+  classNameBindings: [":topic-list-item", "unboundClassNames", "topic.visited"],
+  attributeBindings: ["data-topic-id"],
+  "data-topic-id": Ember.computed.alias("topic.id"),
 
   @computed
   newDotText() {
@@ -175,13 +178,6 @@ export default Ember.Component.extend(
   ListItemDefaults,
   bufferedRender({
     rerenderTriggers: ["bulkSelectEnabled", "topic.pinned"],
-    classNameBindings: [
-      ":topic-list-item",
-      "unboundClassNames",
-      "topic.visited"
-    ],
-    attributeBindings: ["data-topic-id"],
-    "data-topic-id": Ember.computed.alias("topic.id"),
 
     actions: {
       toggleBookmark() {


### PR DESCRIPTION
This will fix shortcut navigation for discourse-assign