### PR TITLE
PERF: Skip compressing locales for faster rebuilds

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -12,7 +12,8 @@ Discourse::Application.configure do
   # Disable Rails's static asset server (Apache or nginx will already do this)
   config.public_file_server.enabled = GlobalSetting.serve_static_assets || false
 
-  config.assets.js_compressor = :uglifier
+  require 'uglifier'
+  config.assets.js_compressor = Uglifier.new(harmony: true)
 
   # stuff should be pre-compiled
   config.assets.compile = false

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -205,7 +205,7 @@ task 'assets:precompile' => 'assets:precompile:before' do
 
               info["size"] = File.size(path)
               info["mtime"] = File.mtime(path).iso8601
-              gzip(path)
+              gzip(path) if should_brotli?(info["logical_path"])
               brotli(path) if should_brotli?(info["logical_path"])
 
               STDERR.puts "Done compressing #{file} : #{(Process.clock_gettime(Process::CLOCK_MONOTONIC) - start).round(2)} secs"

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -16,7 +16,7 @@ task 'assets:precompile:before' do
   # is recompiled
   Emoji.clear_cache
 
-  if Rails.configuration.assets.js_compressor == :uglifier && !`which uglifyjs`.empty? && !ENV['SKIP_NODE_UGLIFY']
+  if !`which uglifyjs`.empty? && !ENV['SKIP_NODE_UGLIFY']
     $node_uglify = true
   end
 

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -199,8 +199,8 @@ task 'assets:precompile' => 'assets:precompile:before' do
 
               # We can specify some files to never minify
               unless (ENV["DONT_MINIFY"] == "1") || to_skip.include?(info['logical_path'])
-                FileUtils.mv(path, _path)
-                compress(_file, file)
+                FileUtils.mv(path, _path) if should_brotli?(info["logical_path"])
+                compress(_file, file) if should_brotli?(info["logical_path"])
               end
 
               info["size"] = File.size(path)

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -79,7 +79,7 @@ def compress_node(from, to)
   source_map_root = assets + ((d = File.dirname(from)) == "." ? "" : "/#{d}")
   source_map_url = cdn_path "/assets/#{to}.map"
 
-  cmd = "uglifyjs '#{assets_path}/#{from}' -p relative -c -m -o '#{to_path}' --source-map-root '#{source_map_root}' --source-map '#{assets_path}/#{to}.map' --source-map-url '#{source_map_url}'"
+  cmd = "uglifyjs '#{assets_path}/#{from}' -p relative -m -o '#{to_path}' --source-map-root '#{source_map_root}' --source-map '#{assets_path}/#{to}.map' --source-map-url '#{source_map_url}'"
 
   STDERR.puts cmd
   result = `#{cmd} 2>&1`
@@ -205,7 +205,7 @@ task 'assets:precompile' => 'assets:precompile:before' do
 
               info["size"] = File.size(path)
               info["mtime"] = File.mtime(path).iso8601
-              gzip(path) if should_brotli?(info["logical_path"])
+              gzip(path)
               brotli(path) if should_brotli?(info["logical_path"])
 
               STDERR.puts "Done compressing #{file} : #{(Process.clock_gettime(Process::CLOCK_MONOTONIC) - start).round(2)} secs"


### PR DESCRIPTION
Several changes to asset precompilation to improve rebuild speeds: 

1. Use uglifier without the `-c (--compress)` option

This results in slightly larger file sizes (300k vs 296k for application.js for example) but it has a significant improvement in compilation speed (60s faster in my tests). Disabling compression is also mentioned in https://github.com/mishoo/UglifyJS2#uglify-fast-minify-mode as a way to speed up Uglify by 3-4 times. 

2. Skipping uglifier and brotli for non-default locales

Non-default locales take up a very large chunk of precompilation, skipping uglifier and brotli for them saves 1-2 minutes per build. These files are still gzipped, so their size now averages 120k per file (vs 80k with uglifier and brotli). 

### Performance tests

`time ./launcher rebuild app` on a fresh site on a basic Digital Ocean instance, no plugins
Benchmark (tests-passed): **7m25s**
This PR: **4m20s**

`time ./launcher bootstrap app` on an existing Discourse instance with a few plugins
Benchmark (current tests-passed): **12m0s**
This PR: **9m44s**

----

The PR also updates the Sprockets JS compression configuration to enable harmony support in the Uglifier gem. 