### PR TITLE
FIX: frozen string exception

### DIFF
--- a/app/models/incoming_domain.rb
+++ b/app/models/incoming_domain.rb
@@ -24,7 +24,7 @@ class IncomingDomain < ActiveRecord::Base
     url = "http#{https ? "s" : ""}://#{name}"
 
     if https && port != 443 || !https && port != 80
-      url << ":#{port}"
+      url += ":#{port}"
     end
 
     url


### PR DESCRIPTION
Initial backtrace:

```
/var/www/discourse/app/models/incoming_domain.rb:29:in `to_url'
/var/www/discourse/app/models/incoming_link.rb:83:in `referer'
/var/www/discourse/app/models/incoming_link.rb:106:in `referer_valid'
```