### PR TITLE
DEV: Clear caches between tests

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -563,7 +563,7 @@ class ApplicationController < ActionController::Base
   end
 
   def self.banner_json_cache
-    @banner_json_cache ||= DistributedCache.new("banner_json")
+    @banner_json_cache ||= DistributedCache.get("banner_json")
   end
 
   def banner_json

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -121,7 +121,7 @@ class Category < ActiveRecord::Base
   # Allows us to skip creating the category definition topic in tests.
   attr_accessor :skip_category_definition
 
-  @topic_id_cache = DistributedCache.new('category_topic_ids')
+  @topic_id_cache = DistributedCache.get('category_topic_ids')
 
   def self.topic_ids
     @topic_id_cache['ids'] || reset_topic_ids_cache
@@ -546,7 +546,7 @@ class Category < ActiveRecord::Base
     id == SiteSetting.uncategorized_category_id
   end
 
-  @@url_cache = DistributedCache.new('category_url')
+  @@url_cache = DistributedCache.get('category_url')
 
   def clear_url_cache
     @@url_cache.clear

--- a/app/models/color_scheme.rb
+++ b/app/models/color_scheme.rb
@@ -122,7 +122,7 @@ class ColorScheme < ActiveRecord::Base
   end
 
   def self.hex_cache
-    @hex_cache ||= DistributedCache.new("scheme_hex_for_name")
+    @hex_cache ||= DistributedCache.get("scheme_hex_for_name")
   end
 
   attr_accessor :is_base

--- a/app/models/developer.rb
+++ b/app/models/developer.rb
@@ -6,7 +6,7 @@ class Developer < ActiveRecord::Base
   after_save :rebuild_cache
   after_destroy :rebuild_cache
 
-  @id_cache = DistributedCache.new('developer_ids')
+  @id_cache = DistributedCache.get('developer_ids')
 
   def self.user_ids
     @id_cache["ids"] || rebuild_cache

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -10,7 +10,7 @@ require_dependency 'theme_translation_manager'
 
 class Theme < ActiveRecord::Base
 
-  @cache = DistributedCache.new('theme')
+  @cache = DistributedCache.get('theme')
 
   belongs_to :user
   belongs_to :color_scheme

--- a/app/serializers/application_serializer.rb
+++ b/app/serializers/application_serializer.rb
@@ -17,7 +17,7 @@ class ApplicationSerializer < ActiveModel::Serializer
   end
 
   def self.fragment_cache
-    @cache ||= DistributedCache.new("am_serializer_fragment_cache")
+    @cache ||= DistributedCache.get("am_serializer_fragment_cache")
   end
 
   protected

--- a/config/initializers/004-message_bus.rb
+++ b/config/initializers/004-message_bus.rb
@@ -93,7 +93,12 @@ MessageBus.on_disconnect do |site_id|
 end
 
 # Point at our redis
-MessageBus.redis_config = GlobalSetting.redis_config
+if Rails.env.test?
+  MessageBus.configure(backend: :memory)
+else
+  MessageBus.redis_config = GlobalSetting.redis_config
+end
+
 MessageBus.reliable_pub_sub.max_backlog_size = GlobalSetting.message_bus_max_backlog_size
 
 MessageBus.long_polling_enabled = SiteSetting.enable_long_polling

--- a/lib/active_record/connection_adapters/postgresql_fallback_adapter.rb
+++ b/lib/active_record/connection_adapters/postgresql_fallback_adapter.rb
@@ -12,7 +12,7 @@ class PostgreSQLFallbackHandler
   DATABASE_DOWN_CHANNEL = '/global/database_down'.freeze
 
   def initialize
-    @masters_down = DistributedCache.new('masters_down', namespace: false)
+    @masters_down = DistributedCache.get('masters_down', namespace: false)
     @mutex = Mutex.new
     @initialized = false
 

--- a/lib/content_security_policy/extension.rb
+++ b/lib/content_security_policy/extension.rb
@@ -29,7 +29,7 @@ class ContentSecurityPolicy
     private
 
     def cache
-      @cache ||= DistributedCache.new('csp_extensions')
+      @cache ||= DistributedCache.get('csp_extensions')
     end
 
     def find_theme_extensions(theme_ids)

--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -370,7 +370,7 @@ module Discourse
   end
 
   def self.last_read_only
-    @last_read_only ||= DistributedCache.new('last_read_only', namespace: false)
+    @last_read_only ||= DistributedCache.get('last_read_only', namespace: false)
   end
 
   def self.recently_readonly?

--- a/lib/distributed_cache.rb
+++ b/lib/distributed_cache.rb
@@ -3,6 +3,36 @@
 require 'message_bus/distributed_cache'
 
 class DistributedCache < MessageBus::DistributedCache
+  class << self
+    module Test
+      def caches
+        @caches ||= {}
+      end
+
+      def get(key, **opts)
+        caches[key] ||= new(key, **opts)
+      end
+
+      def clear_caches!
+        caches.each_value do |cache|
+          cache.hash.clear
+        end
+      end
+    end
+
+    module Real
+      def get(key, **opts)
+        new(key, **opts)
+      end
+    end
+
+    if Rails.env.test?
+      include Test
+    else
+      include Real
+    end
+  end
+
   def initialize(key, manager: nil, namespace: true)
     super(
       key,

--- a/lib/stylesheet/manager.rb
+++ b/lib/stylesheet/manager.rb
@@ -13,7 +13,7 @@ class Stylesheet::Manager
   @lock = Mutex.new
 
   def self.cache
-    @cache ||= DistributedCache.new("discourse_stylesheet")
+    @cache ||= DistributedCache.get("discourse_stylesheet")
   end
 
   def self.clear_theme_cache!

--- a/lib/svg_sprite/svg_sprite.rb
+++ b/lib/svg_sprite/svg_sprite.rb
@@ -389,6 +389,6 @@ License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL
   end
 
   def self.cache
-    @cache ||= DistributedCache.new('svg_sprite')
+    @cache ||= DistributedCache.get('svg_sprite')
   end
 end

--- a/spec/components/guardian_spec.rb
+++ b/spec/components/guardian_spec.rb
@@ -2788,8 +2788,8 @@ describe Guardian do
   end
 
   describe "#allow_themes?" do
-    let!(:theme) { Fabricate(:theme) }
-    let!(:theme2) { Fabricate(:theme) }
+    fab!(:theme) { Fabricate(:theme) }
+    fab!(:theme2) { Fabricate(:theme) }
 
     it "allows staff to use any themes" do
       expect(Guardian.new(moderator).allow_themes?([theme.id, theme2.id])).to eq(false)

--- a/spec/components/theme_settings_manager_spec.rb
+++ b/spec/components/theme_settings_manager_spec.rb
@@ -5,7 +5,7 @@ require 'theme_settings_manager'
 
 describe ThemeSettingsManager do
 
-  let!(:theme) { Fabricate(:theme) }
+  fab!(:theme) { Fabricate(:theme) }
   let(:theme_settings) do
     yaml = File.read("#{Rails.root}/spec/fixtures/theme_settings/valid_settings.yaml")
     theme.set_field(target: :settings, name: "yaml", value: yaml)

--- a/spec/components/theme_store/tgz_exporter_spec.rb
+++ b/spec/components/theme_store/tgz_exporter_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 require 'theme_store/tgz_exporter'
 
 describe ThemeStore::TgzExporter do
-  let!(:theme) do
+  fab!(:theme) do
     Fabricate(:theme, name: "Header Icons").tap do |theme|
       theme.set_field(target: :common, name: :body_tag, value: "<b>testtheme1</b>")
       theme.set_field(target: :settings, name: :yaml, value: "somesetting: test")

--- a/spec/models/javascript_cache_spec.rb
+++ b/spec/models/javascript_cache_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe JavascriptCache, type: :model do
-  let!(:theme) { Fabricate(:theme) }
+  fab!(:theme) { Fabricate(:theme) }
   let(:theme_field) { ThemeField.create!(theme: theme, target_id: 0, name: "header", value: "<a>html</a>") }
 
   describe '#save' do

--- a/spec/models/theme_field_spec.rb
+++ b/spec/models/theme_field_spec.rb
@@ -234,9 +234,9 @@ HTML
 
   describe "locale fields" do
 
-    let!(:theme) { Fabricate(:theme) }
-    let!(:theme2) { Fabricate(:theme) }
-    let!(:theme3) { Fabricate(:theme) }
+    fab!(:theme) { Fabricate(:theme) }
+    fab!(:theme2) { Fabricate(:theme) }
+    fab!(:theme3) { Fabricate(:theme) }
 
     let!(:en1) {
       ThemeField.create!(theme: theme, target_id: Theme.targets[:translations], name: "en",

--- a/spec/models/theme_spec.rb
+++ b/spec/models/theme_spec.rb
@@ -202,12 +202,12 @@ HTML
   end
 
   describe ".transform_ids" do
-    let!(:orphan1) { Fabricate(:theme, component: true) }
-    let!(:child) { Fabricate(:theme, component: true) }
-    let!(:child2) { Fabricate(:theme, component: true) }
-    let!(:orphan2) { Fabricate(:theme, component: true) }
-    let!(:orphan3) { Fabricate(:theme, component: true) }
-    let!(:orphan4) { Fabricate(:theme, component: true) }
+    fab!(:orphan1) { Fabricate(:theme, component: true) }
+    fab!(:child) { Fabricate(:theme, component: true) }
+    fab!(:child2) { Fabricate(:theme, component: true) }
+    fab!(:orphan2) { Fabricate(:theme, component: true) }
+    fab!(:orphan3) { Fabricate(:theme, component: true) }
+    fab!(:orphan4) { Fabricate(:theme, component: true) }
 
     before do
       theme.add_child_theme!(child)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -91,6 +91,7 @@ module TestSetup
     #
     # $redis = DiscourseMockRedis.new
 
+    DistributedCache.clear_caches!
     RateLimiter.disable
     PostActionNotifier.disable
     SearchIndexer.disable

--- a/spec/requests/admin/themes_controller_spec.rb
+++ b/spec/requests/admin/themes_controller_spec.rb
@@ -218,7 +218,7 @@ describe Admin::ThemesController do
   end
 
   describe '#update' do
-    let!(:theme) { Fabricate(:theme) }
+    fab!(:theme) { Fabricate(:theme) }
 
     it 'returns the right response when an invalid id is given' do
       put "/admin/themes/99999.json"
@@ -348,7 +348,7 @@ describe Admin::ThemesController do
   end
 
   describe '#destroy' do
-    let!(:theme) { Fabricate(:theme) }
+    fab!(:theme) { Fabricate(:theme) }
 
     it 'returns the right response when an invalid id is given' do
       delete "/admin/themes/9999.json"
@@ -380,7 +380,7 @@ describe Admin::ThemesController do
   end
 
   describe '#diff_local_changes' do
-    let(:theme) { Fabricate(:theme) }
+    fab!(:theme) { Fabricate(:theme) }
 
     it "should return empty for a default theme" do
       get "/admin/themes/#{theme.id}/diff_local_changes.json"

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -254,9 +254,9 @@ RSpec.describe ApplicationController do
   end
 
   describe "#handle_theme" do
-    let!(:theme) { Fabricate(:theme, user_selectable: true) }
-    let!(:theme2) { Fabricate(:theme, user_selectable: true) }
-    let!(:non_selectable_theme) { Fabricate(:theme, user_selectable: false) }
+    fab!(:theme) { Fabricate(:theme, user_selectable: true) }
+    fab!(:theme2) { Fabricate(:theme, user_selectable: true) }
+    fab!(:non_selectable_theme) { Fabricate(:theme, user_selectable: false) }
     fab!(:user) { Fabricate(:user) }
     fab!(:admin) { Fabricate(:admin) }
 

--- a/spec/requests/theme_javascripts_controller_spec.rb
+++ b/spec/requests/theme_javascripts_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 describe ThemeJavascriptsController do
-  let!(:theme) { Fabricate(:theme) }
+  fab!(:theme) { Fabricate(:theme) }
   let(:theme_field) { ThemeField.create!(theme: theme, target_id: 0, name: "header", value: "<a>html</a>") }
   let(:javascript_cache) { JavascriptCache.create!(content: 'console.log("hello");', theme_field: theme_field) }
 

--- a/spec/services/staff_action_logger_spec.rb
+++ b/spec/services/staff_action_logger_spec.rb
@@ -155,7 +155,7 @@ describe StaffActionLogger do
       expect { logger.log_theme_change(nil, nil) }.to raise_error(Discourse::InvalidParameters)
     end
 
-    let! :theme do
+    fab! :theme do
       Fabricate(:theme)
     end
 


### PR DESCRIPTION
This PR clears all `DistributedCache`s before every test and makes the caches use the memory backend during testing. This makes it possible to prefabricate themes.

I ran the tests before and after these changes, the time before was 11m 52s, the time afterwards was 11m 38s.