### PR TITLE
FEATURE: Multi-file javascript support for themes

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -431,6 +431,11 @@ module ApplicationHelper
       &.html_safe
   end
 
+  def theme_js_lookup
+    Theme.lookup_field(theme_ids, :extra_js, nil)
+      &.html_safe
+  end
+
   def discourse_stylesheet_link_tag(name, opts = {})
     if opts.key?(:theme_ids)
       ids = opts[:theme_ids] unless customization_disabled?

--- a/app/models/javascript_cache.rb
+++ b/app/models/javascript_cache.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 class JavascriptCache < ActiveRecord::Base
   belongs_to :theme_field
+  belongs_to :theme
 
   validate :content_cannot_be_nil
 
@@ -26,14 +27,21 @@ end
 # Table name: javascript_caches
 #
 #  id             :bigint           not null, primary key
-#  theme_field_id :bigint           not null
+#  theme_field_id :bigint
 #  digest         :string
 #  content        :text             not null
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
+#  theme_id       :bigint
 #
 # Indexes
 #
 #  index_javascript_caches_on_digest          (digest)
 #  index_javascript_caches_on_theme_field_id  (theme_field_id)
+#  index_javascript_caches_on_theme_id        (theme_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (theme_field_id => theme_fields.id) ON DELETE => cascade
+#  fk_rails_...  (theme_id => themes.id) ON DELETE => cascade
 #

--- a/app/models/theme_field.rb
+++ b/app/models/theme_field.rb
@@ -46,7 +46,8 @@ class ThemeField < ActiveRecord::Base
                         theme_upload_var: 2,
                         theme_color_var: 3, # No longer used
                         theme_var: 4, # No longer used
-                        yaml: 5)
+                        yaml: 5,
+                        js: 6)
   end
 
   def self.theme_var_type_ids
@@ -120,6 +121,29 @@ class ThemeField < ActiveRecord::Base
 
     doc.add_child("<script src='#{javascript_cache.url}'></script>") if javascript_cache.content.present?
     [doc.to_s, errors&.join("\n")]
+  end
+
+  def process_extra_js(content)
+    errors = []
+
+    js_compiler = ThemeJavascriptCompiler.new(theme_id, theme.name)
+    filename, extension = name.split(".", 2)
+    begin
+      case extension
+      when "js.es6"
+        js_compiler.append_module(content, filename)
+      when "hbs"
+        js_compiler.append_ember_template(filename.sub("discourse/templates/", ""), content)
+      when "raw.hbs"
+        js_compiler.append_raw_template(filename, content)
+      else
+        raise ThemeJavascriptCompiler::CompileError.new(I18n.t("themes.compile_error.unrecognized_extension", extension: extension))
+      end
+    rescue ThemeJavascriptCompiler::CompileError => ex
+      errors << ex.message
+    end
+
+    [js_compiler.content, errors&.join("\n")]
   end
 
   def raw_translation_data(internal: false)
@@ -227,6 +251,8 @@ class ThemeField < ActiveRecord::Base
       types[:scss]
     elsif target.to_s == "extra_scss"
       types[:scss]
+    elsif target.to_s == "extra_js"
+      types[:js]
     elsif target.to_s == "settings" || target.to_s == "translations"
       types[:yaml]
     end
@@ -247,6 +273,10 @@ class ThemeField < ActiveRecord::Base
   def basic_html_field?
     ThemeField.basic_targets.include?(Theme.targets[self.target_id].to_s) &&
       ThemeField.html_fields.include?(self.name)
+  end
+
+  def extra_js_field?
+    Theme.targets[self.target_id] == :extra_js
   end
 
   def basic_scss_field?
@@ -276,6 +306,10 @@ class ThemeField < ActiveRecord::Base
 
     if basic_html_field? || translation_field?
       self.value_baked, self.error = translation_field? ? process_translation : process_html(self.value)
+      self.error = nil unless self.error.present?
+      self.compiler_version = COMPILER_VERSION
+    elsif extra_js_field?
+      self.value_baked, self.error = process_extra_js(self.value)
       self.error = nil unless self.error.present?
       self.compiler_version = COMPILER_VERSION
     elsif basic_scss_field?
@@ -382,6 +416,9 @@ class ThemeField < ActiveRecord::Base
     ThemeFileMatcher.new(regex: /^(?:scss|stylesheets)\/(?<name>.+)\.scss$/,
                          targets: :extra_scss, names: nil, types: :scss,
                          canonical: -> (h) { "stylesheets/#{h[:name]}.scss" }),
+    ThemeFileMatcher.new(regex: /^javascripts\/(?<name>.+)$/,
+                         targets: :extra_js, names: nil, types: :js,
+                         canonical: -> (h) { "javascripts/#{h[:name]}" }),
     ThemeFileMatcher.new(regex: /^settings\.ya?ml$/,
                          names: "yaml", types: :yaml, targets: :settings,
                          canonical: -> (h) { "settings.yml" }),

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -39,6 +39,7 @@
 
     <%- unless customization_disabled? %>
       <%= raw theme_translations_lookup %>
+      <%= raw theme_js_lookup %>
       <%= raw theme_lookup("head_tag") %>
     <%- end %>
 

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -76,6 +76,8 @@ en:
   themes:
     bad_color_scheme: "Can not update theme, invalid color palette"
     other_error: "Something went wrong updating theme"
+    compile_error:
+      unrecognized_extension: "Unrecognized file extension: %{extension}"
     import_error:
       generic: An error occured while importing that theme
       about_json: "Import Error: about.json does not exist, or is invalid"

--- a/db/migrate/20190513143015_add_theme_id_to_javascript_cache.rb
+++ b/db/migrate/20190513143015_add_theme_id_to_javascript_cache.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class AddThemeIdToJavascriptCache < ActiveRecord::Migration[5.2]
+  def up
+    make_changes
+    execute "ALTER TABLE javascript_caches ADD CONSTRAINT enforce_theme_or_theme_field CHECK ((theme_id IS NOT NULL AND theme_field_id IS NULL) OR (theme_id IS NULL AND theme_field_id IS NOT NULL))"
+  end
+  def down
+    execute "ALTER TABLE javascript_caches DROP CONSTRAINT enforce_theme_or_theme_field"
+    revert { make_changes }
+  end
+
+  private
+
+  def make_changes
+    add_reference :javascript_caches, :theme, foreign_key: { on_delete: :cascade }
+    add_foreign_key :javascript_caches, :theme_fields, on_delete: :cascade
+
+    begin
+      Migration::SafeMigrate.disable!
+      change_column_null :javascript_caches, :theme_field_id, true
+    ensure
+      Migration::SafeMigrate.enable!
+    end
+  end
+end

--- a/lib/theme_javascript_compiler.rb
+++ b/lib/theme_javascript_compiler.rb
@@ -202,22 +202,36 @@ class ThemeJavascriptCompiler
     @content << script + "\n"
   end
 
+  def append_module(script, name)
+    script.prepend theme_variables
+    template = Tilt::ES6ModuleTranspilerTemplate.new {}
+    @content << template.module_transpile(script, "", name)
+  rescue MiniRacer::RuntimeError => ex
+    raise CompileError.new ex.message
+  end
+
   def append_js_error(message)
     @content << "console.error('Theme Transpilation Error:', #{message.inspect});"
   end
 
   private
 
+  def theme_variables
+    <<~JS
+      const __theme_name__ = "#{@theme_name.gsub('"', "\\\"")}";
+      const settings = Discourse.__container__
+        .lookup("service:theme-settings")
+        .getObjectForTheme(#{@theme_id});
+      const themePrefix = (key) => `theme_translations.#{@theme_id}.${key}`;
+    JS
+  end
+
   def transpile(es6_source, version)
     template = Tilt::ES6ModuleTranspilerTemplate.new {}
     wrapped = <<~PLUGIN_API_JS
       (function() {
         if ('Discourse' in window && typeof Discourse._registerPluginCode === 'function') {
-          const __theme_name__ = "#{@theme_name.gsub('"', "\\\"")}";
-          const settings = Discourse.__container__
-            .lookup("service:theme-settings")
-            .getObjectForTheme(#{@theme_id});
-          const themePrefix = (key) => `theme_translations.#{@theme_id}.${key}`;
+          #{theme_variables}
           Discourse._registerPluginCode('#{version}', api => {
             try {
             #{es6_source}

--- a/spec/models/theme_field_spec.rb
+++ b/spec/models/theme_field_spec.rb
@@ -172,7 +172,7 @@ HTML
     expect(hbs_field.reload.value_baked).to include('Ember.TEMPLATES["discovery"]')
     expect(raw_hbs_field.reload.value_baked).to include('Discourse.RAW_TEMPLATES["discourse/templates/discovery"]')
     expect(unknown_field.reload.value_baked).to eq("")
-    expect(unknown_field.reload.error).to eq("Unrecognized file extension: blah")
+    expect(unknown_field.reload.error).to eq(I18n.t("themes.compile_error.unrecognized_extension", extension: "blah"))
 
     # All together
     expect(theme.javascript_cache.content).to include('Ember.TEMPLATES["discovery"]')

--- a/spec/models/theme_field_spec.rb
+++ b/spec/models/theme_field_spec.rb
@@ -147,6 +147,40 @@ HTML
     expect(result).to include(".class5")
   end
 
+  it "correctly handles extra JS fields" do
+    theme = Fabricate(:theme)
+    js_field = theme.set_field(target: :extra_js, name: "discourse/controllers/discovery.js.es6", value: "import 'discourse/lib/ajax'; console.log('hello');")
+    hbs_field = theme.set_field(target: :extra_js, name: "discourse/templates/discovery.hbs", value: "{{hello-world}}")
+    raw_hbs_field = theme.set_field(target: :extra_js, name: "discourse/templates/discovery.raw.hbs", value: "{{hello-world}}")
+    unknown_field = theme.set_field(target: :extra_js, name: "discourse/controllers/discovery.blah", value: "this wont work")
+    theme.save!
+
+    expected_js = <<~JS
+      define("discourse/controllers/discovery", ["discourse/lib/ajax"], function () {
+        "use strict";
+
+        var __theme_name__ = "#{theme.name}";
+        var settings = Discourse.__container__.lookup("service:theme-settings").getObjectForTheme(#{theme.id});
+        var themePrefix = function themePrefix(key) {
+          return "theme_translations.#{theme.id}." + key;
+        };
+        console.log('hello');
+      });
+    JS
+    expect(js_field.reload.value_baked).to eq(expected_js.strip)
+
+    expect(hbs_field.reload.value_baked).to include('Ember.TEMPLATES["discovery"]')
+    expect(raw_hbs_field.reload.value_baked).to include('Discourse.RAW_TEMPLATES["discourse/templates/discovery"]')
+    expect(unknown_field.reload.value_baked).to eq("")
+    expect(unknown_field.reload.error).to eq("Unrecognized file extension: blah")
+
+    # All together
+    expect(theme.javascript_cache.content).to include('Ember.TEMPLATES["discovery"]')
+    expect(theme.javascript_cache.content).to include('Discourse.RAW_TEMPLATES["discourse/templates/discovery"]')
+    expect(theme.javascript_cache.content).to include('define("discourse/controllers/discovery"')
+    expect(theme.javascript_cache.content).to include("var settings =")
+  end
+
   def create_upload_theme_field!(name)
     ThemeField.create!(
       theme_id: 1,

--- a/spec/models/theme_spec.rb
+++ b/spec/models/theme_spec.rb
@@ -367,6 +367,7 @@ HTML
           var themePrefix = function themePrefix(key) {
             return 'theme_translations.#{theme.id}.' + key;
           };
+
           Discourse._registerPluginCode('1.0', function (api) {
             try {
               alert(settings.name);var a = function a() {};
@@ -402,6 +403,7 @@ HTML
           var themePrefix = function themePrefix(key) {
             return 'theme_translations.#{theme.id}.' + key;
           };
+
           Discourse._registerPluginCode('1.0', function (api) {
             try {
               alert(settings.name);var a = function a() {};


### PR DESCRIPTION
You can now add javascript files under `/js/*` in a theme, and they will be loaded as if they were included in core, or a plugin. If you give something the same name as a core/plugin file, it will be overridden. Support file extensions are `.js.es6`, `.hbs` and `.raw.hbs`.