### PR TITLE
FIX: don't hide back button at the bottom of timeline

### DIFF
--- a/app/assets/javascripts/discourse/widgets/topic-timeline.js.es6
+++ b/app/assets/javascripts/discourse/widgets/topic-timeline.js.es6
@@ -216,11 +216,6 @@ createWidget("timeline-scrollarea", {
       );
       showButton =
         before + SCROLLER_HEIGHT - 5 < lastReadTop || before > lastReadTop + 25;
-
-      // Don't show if at the bottom of the timeline
-      if (lastReadTop > scrollareaHeight() - LAST_READ_HEIGHT / 2) {
-        showButton = false;
-      }
     }
 
     const result = [


### PR DESCRIPTION
Fixes: https://meta.discourse.org/t/what-does-the-timeline-back-button-do/111883