### PR TITLE
FIX: Blocked watched words should apply to staff

### DIFF
--- a/lib/validators/post_validator.rb
+++ b/lib/validators/post_validator.rb
@@ -60,7 +60,7 @@ class Validators::PostValidator < ActiveModel::Validator
   end
 
   def watched_words(post)
-    if !post.acting_user&.staff? && !post.acting_user&.staged && matches = WordWatcher.new(post.raw).should_block?
+    if !post.acting_user&.staged && matches = WordWatcher.new(post.raw).should_block?
       post.errors.add(:base, I18n.t('contains_blocked_words', word: matches[0]))
     end
   end

--- a/spec/integration/watched_words_spec.rb
+++ b/spec/integration/watched_words_spec.rb
@@ -37,18 +37,14 @@ describe WatchedWord do
       should_block_post(manager)
     end
 
-    it "should not block the post from admin" do
+    it "should block the post from admin" do
       manager = NewPostManager.new(admin, raw: "Want some #{block_word.word} for cheap?", topic_id: topic.id)
-      result = manager.perform
-      expect(result).to be_success
-      expect(result.action).to eq(:create_post)
+      should_block_post(manager)
     end
 
-    it "should not block the post from moderator" do
+    it "should block the post from moderator" do
       manager = NewPostManager.new(moderator, raw: "Want some #{block_word.word} for cheap?", topic_id: topic.id)
-      result = manager.perform
-      expect(result).to be_success
-      expect(result.action).to eq(:create_post)
+      should_block_post(manager)
     end
 
     it "should block in a private message too" do


### PR DESCRIPTION
Having different behavior for staff and regular users can make it confusing for admins to understand how their configuration changes affect regular users.

cc @SamSaffron