### PR TITLE
DEV: makes hidepassed default when running qunit

### DIFF
--- a/lib/tasks/qunit.rake
+++ b/lib/tasks/qunit.rake
@@ -56,7 +56,7 @@ task "qunit:test", [:timeout, :qunit_path] => :environment do |_, args|
     test_path = "#{Rails.root}/test"
     qunit_path = args[:qunit_path] || "/qunit"
     cmd = "node #{test_path}/run-qunit.js http://localhost:#{port}#{qunit_path}"
-    options = { seed: (ENV["QUNIT_SEED"] || Random.new.seed) }
+    options = { seed: (ENV["QUNIT_SEED"] || Random.new.seed), hidepassed: 1 }
 
     %w{module filter qunit_skip_core qunit_single_plugin}.each do |arg|
       options[arg] = ENV[arg.upcase] if ENV[arg.upcase].present?


### PR DESCRIPTION
Mostly useful when not running headless, but I endup doing it a lot when debugging, one less thing to check.