### PR TITLE
FEATURE: Display 'last updated' on dashboard, improve release notes link

### DIFF
--- a/app/assets/javascripts/admin/controllers/admin-dashboard-general.js.es6
+++ b/app/assets/javascripts/admin/controllers/admin-dashboard-general.js.es6
@@ -111,13 +111,6 @@ export default Ember.Controller.extend(PeriodComputationMixin, {
     return { startDate, endDate };
   },
 
-  @computed("model.attributes.updated_at")
-  updatedTimestamp(updatedAt) {
-    return moment(updatedAt)
-      .tz(moment.tz.guess())
-      .format("LLL");
-  },
-
   _reportsForPeriodURL(period) {
     return Discourse.getURL(`/admin?period=${period}`);
   }

--- a/app/assets/javascripts/admin/models/admin-dashboard.js.es6
+++ b/app/assets/javascripts/admin/models/admin-dashboard.js.es6
@@ -1,6 +1,10 @@
 import { ajax } from "discourse/lib/ajax";
 
-const GENERAL_ATTRIBUTES = ["updated_at"];
+const GENERAL_ATTRIBUTES = [
+  "updated_at",
+  "discourse_updated_at",
+  "release_notes_link"
+];
 
 const AdminDashboard = Discourse.Model.extend({});
 

--- a/app/assets/javascripts/admin/templates/dashboard_general.hbs
+++ b/app/assets/javascripts/admin/templates/dashboard_general.hbs
@@ -115,8 +115,12 @@
         <div class="last-dashboard-update">
           <div>
             <h4>{{i18n "admin.dashboard.last_updated"}} </h4>
-            <p>{{updatedTimestamp}}</p>
-            <a rel="noopener" target="_blank" href="https://meta.discourse.org/tags/release-notes" class="btn btn-default">
+            <p>{{format-date model.attributes.updated_at leaveAgo="true"}}</p>
+          </div>
+          <div>
+            <h4>{{i18n "admin.dashboard.discourse_last_updated"}} </h4>
+            <p>{{format-date model.attributes.discourse_updated_at leaveAgo="true"}}</p>
+            <a rel="noopener" target="_blank" href={{model.attributes.release_notes_link}} class="btn btn-default">
               {{i18n "admin.dashboard.whats_new_in_discourse"}}
             </a>
           </div>

--- a/app/assets/stylesheets/common/admin/dashboard.scss
+++ b/app/assets/stylesheets/common/admin/dashboard.scss
@@ -249,6 +249,7 @@
     .last-dashboard-update {
       text-align: center;
       display: flex;
+      flex-direction: column;
       justify-content: center;
       div {
         align-self: center;

--- a/app/models/admin_dashboard_general_data.rb
+++ b/app/models/admin_dashboard_general_data.rb
@@ -2,8 +2,11 @@
 
 class AdminDashboardGeneralData < AdminDashboardData
   def get_json
+    days_since_update = ((DateTime.now - Discourse.last_commit_date) / 1.day).to_i
     {
-      updated_at: Time.zone.now.as_json
+      updated_at: Time.zone.now.as_json,
+      discourse_updated_at: Discourse.last_commit_date,
+      release_notes_link: "https://meta.discourse.org/c/feature/announcements?tags=release-notes&before=#{days_since_update}"
     }
   end
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3008,7 +3008,8 @@ en:
 
       dashboard:
         title: "Dashboard"
-        last_updated: "Dashboard last updated:"
+        last_updated: "Dashboard updated:"
+        discourse_last_updated: "Discourse updated:"
         version: "Version"
         up_to_date: "You're up to date!"
         critical_available: "A critical update is available."

--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -437,6 +437,16 @@ module Discourse
       end
   end
 
+  def self.last_commit_date
+    ensure_version_file_loaded
+    $last_commit_date ||=
+      begin
+        git_cmd = 'git log -1 --format="%ct"'
+        seconds = self.try_git(git_cmd, nil)
+        seconds.nil? ? nil : DateTime.strptime(seconds, '%s')
+      end
+  end
+
   def self.try_git(git_cmd, default_value)
     version_value = false
 


### PR DESCRIPTION
Before: (link is generic)
<img width="567" alt="Screenshot 2019-05-16 at 15 12 34" src="https://user-images.githubusercontent.com/6270921/57861204-12a16680-77ee-11e9-98d3-9ac669035cf9.png">

After: (Link is specific to last_updated date)
<img width="576" alt="Screenshot 2019-05-16 at 15 06 47" src="https://user-images.githubusercontent.com/6270921/57861209-159c5700-77ee-11e9-9292-d8ef30dbb21c.png">
