### PR TITLE
UX: Separate section for 2FA settings, more consistent layout

### DIFF
--- a/app/assets/javascripts/discourse/templates/preferences/account.hbs
+++ b/app/assets/javascripts/discourse/templates/preferences/account.hbs
@@ -80,32 +80,38 @@
 
     {{passwordProgress}}
   </div>
+</div>
 
+<div class="control-group pref-second-factor">
+  <label class="control-label">{{i18n 'user.second_factor.title'}}</label>
+  {{#unless model.second_factor_enabled}}
+    <label>
+        {{i18n 'user.second_factor.short_description'}}
+    </label>
+  {{/unless}}
   <div class="controls pref-second-factor">
-    {{#if model.second_factor_enabled}}
-      {{i18n 'user.second_factor.disable'}}
-    {{else}}
-      {{i18n 'user.second_factor.enable'}}
-    {{/if}}
-
     {{#if isCurrentUser}}
-      {{#link-to "preferences.second-factor" class="btn btn-default btn-small btn-icon pad-left no-text"}}
-        {{d-icon "pencil-alt"}}
-      {{/link-to}}
+      {{#if model.second_factor_enabled}}
+        {{#link-to "preferences.second-factor" class="btn btn-default"}}
+          {{d-icon "unlock"}} {{i18n 'user.second_factor.disable'}}
+        {{/link-to}}
+      {{else}}
+        {{#link-to "preferences.second-factor" class="btn btn-default"}}
+          {{d-icon "lock"}} {{i18n 'user.second_factor.enable'}}
+        {{/link-to}}
+      {{/if}}
     {{/if}}
   </div>
 
   <div class="controls pref-second-factor-backup">
     {{#if model.second_factor_enabled}}
-      {{#if model.second_factor_backup_enabled}}
-        {{i18n 'user.second_factor_backup.manage'}}
-      {{else}}
-        {{i18n 'user.second_factor_backup.enable_long'}}
-      {{/if}}
-
       {{#if isCurrentUser}}
-        {{#link-to "preferences.second-factor-backup" class="btn btn-default btn-small btn-icon pad-left no-text"}}
-          {{d-icon "pencil-alt"}}
+        {{#link-to "preferences.second-factor-backup"}}
+        {{#if model.second_factor_backup_enabled}}
+          {{i18n 'user.second_factor_backup.manage'}}
+        {{else}}
+          {{i18n 'user.second_factor_backup.enable_long'}}
+        {{/if}}
         {{/link-to}}
       {{/if}}
     {{/if}}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -922,8 +922,8 @@ en:
 
       second_factor:
         title: "Two Factor Authentication"
-        disable: "Disable two factor authentication"
-        enable: "Enable two factor authentication for enhanced account security"
+        disable: "Disable Two Factor Authentication"
+        enable: "Enable Two Factor Authentication"
         confirm_password_description: "Please confirm your password to continue"
         label: "Code"
         rate_limit: "Please wait before trying another authentication code."
@@ -931,6 +931,8 @@ en:
           Scan this QR code in a supported app (<a href="https://www.google.com/search?q=authenticator+apps+for+android" target="_blank">Android</a> – <a href="https://www.google.com/search?q=authenticator+apps+for+ios" target="_blank">iOS</a>) and enter your authentication code.
         disable_description: "Please enter the authentication code from your app"
         show_key_description: "Enter manually"
+        short_description: |
+          Protect your account with one-time use security codes.
         extended_description: |
           Two factor authentication adds extra security to your account by requiring a one-time token in addition to your password. Tokens can be generated on <a href="https://www.google.com/search?q=authenticator+apps+for+android" target='_blank'>Android</a> and <a href="https://www.google.com/search?q=authenticator+apps+for+ios">iOS</a> devices.
         oauth_enabled_warning: "Please note that social logins will be disabled once two factor authentication has been enabled on your account."


### PR DESCRIPTION
@davidtaylorhq mentioned that a customer was having an issue where their users were clicking the "edit" button on 2FA thinking it would edit their password, illustrated here:

<img width="533" alt="Screenshot 2019-05-14 at 16 19 30" src="https://user-images.githubusercontent.com/1681963/57868433-f93df180-77d0-11e9-901c-14fd2698dd1f.png">

The edit buttons in all our 2FA settings feels odd to me in general, because you're enabling/disabling more than "editing." I propose making enable/disable a proper button and splitting it off into its own section.

Before:

<img width="487" alt="Screen Shot 2019-05-16 at 11 53 48 AM" src="https://user-images.githubusercontent.com/1681963/57868602-491cb880-77d1-11e9-900e-5d4da6aa8b7b.png">


<img width="367" alt="Screen Shot 2019-05-16 at 11 44 56 AM" src="https://user-images.githubusercontent.com/1681963/57868515-21c5eb80-77d1-11e9-969a-ced44c87ad64.png">



After:

<img width="548" alt="Screen Shot 2019-05-16 at 11 34 25 AM" src="https://user-images.githubusercontent.com/1681963/57868573-3b673300-77d1-11e9-8817-f9ab84cead3c.png">

<img width="355" alt="Screen Shot 2019-05-16 at 11 33 34 AM" src="https://user-images.githubusercontent.com/1681963/57868545-2ee2da80-77d1-11e9-8d9c-9a2f2756f1b3.png">


Any feelings about this, @coding-horror? I know you had requested some changes a while back to make this more subtle, but I feel like the division avoids confusion for someone who isn't familiar with 2FA... and I don't mind giving more attention to a security feature. 