### PR TITLE
FIX: prevents events on toolbar when in form

### DIFF
--- a/app/assets/javascripts/discourse/components/d-button.js.es6
+++ b/app/assets/javascripts/discourse/components/d-button.js.es6
@@ -13,7 +13,8 @@ export default Ember.Component.extend({
     "disabled",
     "translatedTitle:title",
     "translatedLabel:aria-label",
-    "tabindex"
+    "tabindex",
+    "type"
   ],
 
   btnIcon: Ember.computed.notEmpty("icon"),

--- a/app/assets/javascripts/discourse/templates/components/d-editor-modal.hbs
+++ b/app/assets/javascripts/discourse/templates/components/d-editor-modal.hbs
@@ -1,7 +1,8 @@
+{{#unless hidden}}
+  {{yield}}
 
-{{yield}}
-
-<div class='controls'>
-  {{d-button class="btn-primary" label="composer.modal_ok" action=(action "ok")}}
-  {{d-button class="btn-danger" label="composer.modal_cancel" action=(action "cancel")}}
-</div>
+  <div class="controls">
+    {{d-button class="btn-primary" label="composer.modal_ok" action=(action "ok")}}
+    {{d-button class="btn-danger" label="composer.modal_cancel" action=(action "cancel")}}
+  </div>
+{{/unless}}

--- a/app/assets/javascripts/discourse/templates/components/d-editor.hbs
+++ b/app/assets/javascripts/discourse/templates/components/d-editor.hbs
@@ -24,6 +24,7 @@
           {{else}}
             {{d-button
               action=b.action
+              type="button"
               actionParam=b
               translatedTitle=b.title
               label=b.label


### PR DESCRIPTION
If a button is not of type button, pressing enter inside an `<input>` inside a `<form>` without the action attribute will trigger the first available `<button>` as most browsers default the type of an unspecified button to submit.

This commit also prevents d-editor-modal to be filled when it's hidden.