### PR TITLE
Make `email_excerpt` method take an optional `post` param

### DIFF
--- a/app/helpers/user_notifications_helper.rb
+++ b/app/helpers/user_notifications_helper.rb
@@ -51,9 +51,9 @@ module UserNotificationsHelper
     doc.css('div').first
   end
 
-  def email_excerpt(html_arg)
+  def email_excerpt(html_arg, post = nil)
     html = (first_paragraphs_from(html_arg) || html_arg).to_s
-    PrettyText.format_for_email(html).html_safe
+    PrettyText.format_for_email(html, post).html_safe
   end
 
   def normalize_name(name)

--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -205,7 +205,7 @@ class UserNotifications < ActionMailer::Base
       @excerpts = {}
 
       @popular_topics.map do |t|
-        @excerpts[t.first_post.id] = email_excerpt(t.first_post.cooked) if t.first_post.present?
+        @excerpts[t.first_post.id] = email_excerpt(t.first_post.cooked, t.first_post) if t.first_post.present?
       end
 
       # Try to find 3 interesting stats for the top of the digest

--- a/app/views/user_notifications/digest.html.erb
+++ b/app/views/user_notifications/digest.html.erb
@@ -248,7 +248,7 @@ body, table, td, th, h1, h2, h3 {font-family: Helvetica, Arial, sans-serif !impo
   <tbody>
     <tr>
       <td class="post-excerpt" style="color:#0a0a0a;font-size:14px;font-weight:normal;padding:16px;text-align:<%= rtl? ? 'right' : 'left' %>;width:100%;">
-        <%= email_excerpt(post.cooked) %>
+        <%= email_excerpt(post.cooked, post) %>
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
The spoiler alert plugin replaces spoiler text found in email excerpts with posts URL, which means it needs to have a reference to the post it's processing.

Follow up to this commit https://github.com/discourse/discourse-spoiler-alert/commit/a1ce55b78437473fda5308249e9fd3ff4a67f061