### PR TITLE
FIX: still suggest allowed usernames

### DIFF
--- a/lib/user_name_suggester.rb
+++ b/lib/user_name_suggester.rb
@@ -57,11 +57,16 @@ module UserNameSuggester
         else
           offset = 0
         end
+
+        if allowed_username && offset > 0
+          (0...offset).each do |x|
+            attempt = create_attempt(name, i, x)
+            return attempt if attempt == allowed_username
+          end
+        end
       end
 
-      suffix = (i + offset).to_s
-      max_length = User.username_length.end - suffix.length
-      attempt = "#{truncate(name, max_length)}#{suffix}"
+      attempt = create_attempt(name, i, offset)
       i += 1
     end
 
@@ -70,6 +75,12 @@ module UserNameSuggester
       i += 1
     end
     attempt
+  end
+
+  def self.create_attempt(name, i, offset)
+    suffix = (i + offset).to_s
+    max_length = User.username_length.end - suffix.length
+    attempt = "#{truncate(name, max_length)}#{suffix}"
   end
 
   def self.fix_username(name)

--- a/spec/components/user_name_suggester_spec.rb
+++ b/spec/components/user_name_suggester_spec.rb
@@ -19,6 +19,14 @@ describe UserNameSuggester do
       expect(UserNameSuggester.suggest('saM')).to eq('saM3')
     end
 
+    it "doesn't skip over allowed username" do
+      Fabricate(:user, username: 'sam')
+      Fabricate(:user, username: 'sAm1')
+      Fabricate(:user, username: 'sam2')
+
+      expect(UserNameSuggester.suggest('saM', 'saM2')).to eq('saM2')
+    end
+
     it "doesn't raise an error on nil username" do
       expect(UserNameSuggester.suggest(nil)).to eq(nil)
     end


### PR DESCRIPTION
@SamSaffron your recent [performance fix](https://github.com/discourse/discourse/commit/a8fbb19e7c728f5f33d2b784530635791ea959e3#diff-514902a839d0144b93caa26b61419c01) unintentionally broke behaviour I was relying on for updating usernames from an external user directory.

I've added the behaviour I was relying on back. I think my spec does a better job of explaining it, but I'll attempt to with words:

* If I want a suggestion based off "user", but "user" is taken I'll get "user1".
* If I then set a user's username to "user1", but I want to periodically check if I can update it to "user" by using the username suggester, I set "user1" as the `allowed_username` so once it's reached in the iteration of alternative usernames it's suggested.
* Unfortunately the optimisation skips past "user1" and suggests "user2" immediately.
* This wouldn't be a *huge* problem, if it then didn't return "user1" on the next call of the username suggester. Meaning on every external-profile refresh this poor user will have their username ping-pong between "user1" and "user2".

This **is** something I can fix in my plugin, but the fix seems a lot simpler here than there, and seems relatively inoffensive. If you disagree with that assessment let me know, and I'm happy to make the change downstream. :smile: 