### PR TITLE
FIX: Update tags on change.

### DIFF
--- a/app/assets/javascripts/discourse/templates/components/topic-category.hbs
+++ b/app/assets/javascripts/discourse/templates/components/topic-category.hbs
@@ -7,7 +7,7 @@
 <div class="topic-header-extra">
   {{#if siteSettings.tagging_enabled}}
     <div class="list-tags">
-      {{discourse-tags topic mode="list"}}
+      {{discourse-tags topic mode="list" tags=topic.tags}}
     </div>
   {{/if}}
   {{#if siteSettings.topic_featured_link_enabled}}


### PR DESCRIPTION
With this change, tags are automatically updated in the topic header when they change. Also, it updates when the topic is assigned / unassigned.

@jjaffeux, can you please review this one? I find this problem weird because:

* adding an unused argument that directly references the tag array works
* `discourse-tags` is still an unbound helper, but it works?
* using a bound helper did not help either (i.e. `htmlHelper`)