### PR TITLE
FIX: trigger user_updated webhook when avatar changes

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -124,6 +124,8 @@ class User < ActiveRecord::Base
   after_create :ensure_in_trust_level_group
   after_create :set_default_categories_preferences
 
+  after_update :trigger_user_updated_event, if: :saved_change_to_uploaded_avatar_id?
+
   before_save :update_usernames
   before_save :ensure_password_is_hashed
   before_save :match_title_to_primary_group_changes
@@ -1410,6 +1412,11 @@ class User < ActiveRecord::Base
   end
 
   private
+
+  def trigger_user_updated_event
+    DiscourseEvent.trigger(:user_updated, self)
+    true
+  end
 
   def check_if_title_is_badged_granted
     if title_changed? && !new_record? && user_profile

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -1926,10 +1926,13 @@ describe UsersController do
       end
 
       it 'can successfully pick a custom avatar' do
-        put "/u/#{user.username}/preferences/avatar/pick.json", params: {
-          upload_id: upload.id, type: "custom"
-        }
+        events = DiscourseEvent.track_events do
+          put "/u/#{user.username}/preferences/avatar/pick.json", params: {
+            upload_id: upload.id, type: "custom"
+          }
+        end
 
+        expect(events.map { |event| event[:event_name] }).to include(:user_updated)
         expect(response.status).to eq(200)
         expect(user.reload.uploaded_avatar_id).to eq(upload.id)
         expect(user.user_avatar.reload.custom_upload_id).to eq(upload.id)
@@ -1981,8 +1984,11 @@ describe UsersController do
           end
 
           it 'can successfully select an avatar' do
-            put "/u/#{user.username}/preferences/avatar/select.json", params: { url: avatar1.url }
+            events = DiscourseEvent.track_events do
+              put "/u/#{user.username}/preferences/avatar/select.json", params: { url: avatar1.url }
+            end
 
+            expect(events.map { |event| event[:event_name] }).to include(:user_updated)
             expect(response.status).to eq(200)
             expect(user.reload.uploaded_avatar_id).to eq(avatar1.id)
             expect(user.user_avatar.reload.custom_upload_id).to eq(avatar1.id)


### PR DESCRIPTION
https://meta.discourse.org/t/user-profile-avatar-icon-not-triggering-webhook/117089