### PR TITLE
FIX: Consistently handle category param

### DIFF
--- a/lib/seed_data/topics.rb
+++ b/lib/seed_data/topics.rb
@@ -132,7 +132,7 @@ module SeedData
         title: title,
         raw: raw,
         skip_validations: true,
-        category: category&.name
+        category: category&.id
       )
 
       if static_first_reply

--- a/lib/topic_creator.rb
+++ b/lib/topic_creator.rb
@@ -150,13 +150,8 @@ class TopicCreator
         return Category.find(SiteSetting.shared_drafts_category)
       end
 
-      # Temporary fix to allow older clients to create topics.
-      # When all clients are updated the category variable should
-      # be set directly to the contents of the if statement.
       if (@opts[:category].is_a? Integer) || (@opts[:category] =~ /^\d+$/)
         Category.find_by(id: @opts[:category])
-      else
-        Category.find_by(name_lower: @opts[:category].try(:downcase))
       end
     end
   end

--- a/spec/components/topic_creator_spec.rb
+++ b/spec/components/topic_creator_spec.rb
@@ -53,9 +53,9 @@ describe TopicCreator do
           expect(topic.public_topic_timer).to eq(nil)
         end
 
-        it "category name is case insensitive" do
+        it "can create a topic in a category" do
           category = Fabricate(:category, name: "Neil's Blog")
-          topic = TopicCreator.create(user, Guardian.new(user), valid_attrs.merge(category: "neil's blog"))
+          topic = TopicCreator.create(user, Guardian.new(user), valid_attrs.merge(category: category.id))
           expect(topic).to be_valid
           expect(topic.category).to eq(category)
         end
@@ -103,18 +103,18 @@ describe TopicCreator do
 
         it "fails for regular user if minimum_required_tags is not satisfied" do
           expect do
-            TopicCreator.create(user, Guardian.new(user), valid_attrs.merge(category: "beta"))
+            TopicCreator.create(user, Guardian.new(user), valid_attrs.merge(category: category.id))
           end.to raise_error(ActiveRecord::Rollback)
         end
 
         it "lets admin create a topic regardless of minimum_required_tags" do
-          topic = TopicCreator.create(admin, Guardian.new(admin), valid_attrs.merge(tags: [tag1.name], category: "beta"))
+          topic = TopicCreator.create(admin, Guardian.new(admin), valid_attrs.merge(tags: [tag1.name], category: category.id))
           expect(topic).to be_valid
           expect(topic.tags.length).to eq(1)
         end
 
         it "works for regular user if minimum_required_tags is satisfied" do
-          topic = TopicCreator.create(user, Guardian.new(user), valid_attrs.merge(tags: [tag1.name, tag2.name], category: "beta"))
+          topic = TopicCreator.create(user, Guardian.new(user), valid_attrs.merge(tags: [tag1.name, tag2.name], category: category.id))
           expect(topic).to be_valid
           expect(topic.tags.length).to eq(2)
         end
@@ -122,7 +122,7 @@ describe TopicCreator do
         it "lets new user create a topic if they don't have sufficient trust level to tag topics" do
           SiteSetting.min_trust_level_to_tag_topics = 1
           new_user = Fabricate(:newuser)
-          topic = TopicCreator.create(new_user, Guardian.new(new_user), valid_attrs.merge(category: "beta"))
+          topic = TopicCreator.create(new_user, Guardian.new(new_user), valid_attrs.merge(category: category.id))
           expect(topic).to be_valid
         end
       end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -580,7 +580,7 @@ describe Category do
     context 'for uncategorized category' do
       before do
         @uncategorized = Category.find(SiteSetting.uncategorized_category_id)
-        create_post(user: Fabricate(:user), category: @uncategorized.name)
+        create_post(user: Fabricate(:user), category: @uncategorized.id)
         Category.update_stats
         @uncategorized.reload
       end


### PR DESCRIPTION
See https://meta.discourse.org/t/api-post-to-posts-json-inconsistent-between-users/118571
for more info.

This commit removes a 5 year old temporary fix that is no longer needed.

https://github.com/discourse/discourse/commit/bc1824a6ed28bc9d5b75a561a00acde17fed6b7b#diff-d8c648926664f849aec050757bfcb6f9R72

The web interface uses category_id when creating a topic so I think we
should unify on category_id when using the api.