### PR TITLE
FEATURE: Allow import of hidden site settings

### DIFF
--- a/app/services/site_settings_task.rb
+++ b/app/services/site_settings_task.rb
@@ -11,8 +11,8 @@ class SiteSettingsTask
     h
   end
 
-  def self.import(yml, import_hidden: false)
-    h = SiteSettingsTask.export_to_hash(include_defaults: true, include_hidden: import_hidden)
+  def self.import(yml)
+    h = SiteSettingsTask.export_to_hash(include_defaults: true, include_hidden: true)
     counts = { updated: 0, not_found: 0, errors: 0 }
     log = []
 

--- a/app/services/site_settings_task.rb
+++ b/app/services/site_settings_task.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class SiteSettingsTask
-  def self.export_to_hash(include_defaults: false)
-    site_settings = SiteSetting.all_settings
+  def self.export_to_hash(include_defaults: false, include_hidden: false)
+    site_settings = SiteSetting.all_settings(include_hidden)
     h = {}
     site_settings.each do |site_setting|
       next if site_setting[:default] == site_setting[:value] if !include_defaults
@@ -11,8 +11,8 @@ class SiteSettingsTask
     h
   end
 
-  def self.import(yml)
-    h = SiteSettingsTask.export_to_hash(include_defaults: true)
+  def self.import(yml, import_hidden: false)
+    h = SiteSettingsTask.export_to_hash(include_defaults: true, include_hidden: import_hidden)
     counts = { updated: 0, not_found: 0, errors: 0 }
     log = []
 

--- a/lib/tasks/site_settings.rake
+++ b/lib/tasks/site_settings.rake
@@ -9,9 +9,7 @@ task "site_settings:export" => :environment do
 end
 
 desc "Imports site settings"
-task "site_settings:import", [:import_hidden] => :environment do |t, args|
-  args.with_defaults(import_hidden: false)
-
+task "site_settings:import" => :environment do
   yml = (STDIN.tty?) ? '' : STDIN.read
   if yml == ''
     puts
@@ -24,7 +22,7 @@ task "site_settings:import", [:import_hidden] => :environment do |t, args|
   puts "starting import..."
   puts
 
-  log, counts = SiteSettingsTask.import(yml, import_hidden: args.import_hidden)
+  log, counts = SiteSettingsTask.import(yml)
 
   puts log
 

--- a/lib/tasks/site_settings.rake
+++ b/lib/tasks/site_settings.rake
@@ -9,7 +9,9 @@ task "site_settings:export" => :environment do
 end
 
 desc "Imports site settings"
-task "site_settings:import" => :environment do
+task "site_settings:import", [:import_hidden] => :environment do |t, args|
+  args.with_defaults(import_hidden: false)
+
   yml = (STDIN.tty?) ? '' : STDIN.read
   if yml == ''
     puts
@@ -22,7 +24,7 @@ task "site_settings:import" => :environment do
   puts "starting import..."
   puts
 
-  log, counts = SiteSettingsTask.import(yml)
+  log, counts = SiteSettingsTask.import(yml, import_hidden: args.import_hidden)
 
   puts log
 

--- a/spec/services/site_settings_spec.rb
+++ b/spec/services/site_settings_spec.rb
@@ -31,6 +31,21 @@ describe SiteSettingsTask do
       expect(SiteSetting.title).to eq "Test"
     end
 
+    it "won't update a hidden setting by default" do
+      yml = "logo_url: /logo.png"
+      log, counts = SiteSettingsTask.import(yml)
+      expect(log[0]).to eq "NOT FOUND: existing site setting not found for logo_url"
+      expect(counts[:not_found]).to eq 1
+    end
+
+    it "allows for updating hidden settings" do
+      yml = "logo_url: /logo.png"
+      log, counts = SiteSettingsTask.import(yml, import_hidden: true)
+      expect(log[0]).to eq "Changed logo_url FROM: /images/d-logo-sketch.png TO: /logo.png"
+      expect(counts[:updated]).to eq 1
+      expect(SiteSetting.logo_url).to eq "/logo.png"
+    end
+
     it "won't update a setting that doesn't exist" do
       yml = "fake_setting: foo"
       log, counts = SiteSettingsTask.import(yml)

--- a/spec/services/site_settings_spec.rb
+++ b/spec/services/site_settings_spec.rb
@@ -31,16 +31,9 @@ describe SiteSettingsTask do
       expect(SiteSetting.title).to eq "Test"
     end
 
-    it "won't update a hidden setting by default" do
+    it "updates hidden settings" do
       yml = "logo_url: /logo.png"
       log, counts = SiteSettingsTask.import(yml)
-      expect(log[0]).to eq "NOT FOUND: existing site setting not found for logo_url"
-      expect(counts[:not_found]).to eq 1
-    end
-
-    it "allows for updating hidden settings" do
-      yml = "logo_url: /logo.png"
-      log, counts = SiteSettingsTask.import(yml, import_hidden: true)
       expect(log[0]).to eq "Changed logo_url FROM: /images/d-logo-sketch.png TO: /logo.png"
       expect(counts[:updated]).to eq 1
       expect(SiteSetting.logo_url).to eq "/logo.png"


### PR DESCRIPTION
**Updated**: Hidden site settings are now also imported using the rake site_settings:import task

**Old**:
~~The site_settings:import rake task is updated to accept an optional import_hidden parameter. The default behaviour stays the same.~~

~~When passing in the import_hidden parameter, the rake task will also import hidden site settings.~~