### PR TITLE
Add "further reading for themes" step to wizard

### DIFF
--- a/app/assets/stylesheets/wizard.scss
+++ b/app/assets/stylesheets/wizard.scss
@@ -188,6 +188,10 @@ body.wizard {
 
   .wizard-step-contents {
     height: 550px;
+    a {
+      text-decoration: none;
+      color: #6699ff;
+    }
   }
 
   .wizard-column-contents {

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -4330,6 +4330,17 @@ en:
       colors:
         title: "Theme"
 
+      themes_further_reading:
+        title: "Further reading for themes"
+        description:
+          "You can customize many aspects of your community's look-and-feel in just a few clicks (for example by adding a header or footer). Here is a useful list of resources to learn more about themes and theme components in Discourse:
+          <ul>
+          <li><a href='https://meta.discourse.org/t/91966' target='_blank'>Beginner's guide to creating themes and theme components</a></li>
+          <li><a href='https://meta.discourse.org/t/63682' target='_blank'>How do I install a theme or theme component?</a></li>
+          <li><a href='https://meta.discourse.org/t/110448' target='_blank'>Theme Developer Quick Reference Guide</a></li>
+          </ul>
+          And remember to visit the <a href='https://meta.discourse.org/c/theme' target='_blank'>#themes</a> category on <a href='https://meta.discourse.org' target='_blank'>meta.discourse.org</a> regularly to see the newest themes and components posted by staff and contributors."
+
       logos:
         title: "Logos"
         fields:

--- a/lib/wizard/builder.rb
+++ b/lib/wizard/builder.rb
@@ -198,6 +198,8 @@ class Wizard
         end
       end
 
+      @wizard.append_step('themes-further-reading')
+
       @wizard.append_step('logos') do |step|
         step.add_field(id: 'logo', type: 'image', value: SiteSetting.site_logo_url)
         step.add_field(id: 'logo_small', type: 'image', value: SiteSetting.site_logo_small_url)


### PR DESCRIPTION
Adds the following screen to the wizard, after the "Theme" step. 

<img width="832" alt="image" src="https://user-images.githubusercontent.com/368961/58432591-22883880-8081-11e9-8ebf-0963d8abcf22.png">
