### PR TITLE
FEATURE: Allow running message_bus in a different redis instance

### DIFF
--- a/app/models/global_setting.rb
+++ b/app/models/global_setting.rb
@@ -136,6 +136,7 @@ class GlobalSetting
   # For testing purposes
   def self.reset_redis_config!
     @config = nil
+    @message_bus_config = nil
   end
 
   def self.redis_config
@@ -155,6 +156,29 @@ class GlobalSetting
         c[:db] = redis_db if redis_db != 0
         c[:db] = 1 if Rails.env == "test"
         c[:id] = nil if redis_skip_client_commands
+
+        c.freeze
+      end
+  end
+
+  def self.message_bus_redis_config
+    return redis_config unless message_bus_redis_enabled
+    @message_bus_config ||=
+      begin
+        c = {}
+        c[:host] = message_bus_redis_host if message_bus_redis_host
+        c[:port] = message_bus_redis_port if message_bus_redis_port
+
+        if message_bus_redis_slave_host && message_bus_redis_slave_port
+          c[:slave_host] = message_bus_redis_slave_host
+          c[:slave_port] = message_bus_redis_slave_port
+          c[:connector] = DiscourseRedis::Connector
+        end
+
+        c[:password] = message_bus_redis_password if message_bus_redis_password.present?
+        c[:db] = message_bus_redis_db if message_bus_redis_db != 0
+        c[:db] = 1 if Rails.env == "test"
+        c[:id] = nil if message_bus_redis_skip_client_commands
 
         c.freeze
       end

--- a/config/discourse_defaults.conf
+++ b/config/discourse_defaults.conf
@@ -120,6 +120,30 @@ redis_password =
 # skip configuring client id for cloud providers who support no client commands
 redis_skip_client_commands = false
 
+# message bus redis server switch
+message_bus_redis_enabled = false
+
+# message bus redis server address
+message_bus_redis_host = localhost
+
+# message bus redis server port
+message_bus_redis_port = 6379
+
+# message bus redis slave server address
+message_bus_redis_slave_host =
+
+# message bus redis slave server port
+message_bus_redis_slave_port = 6379
+
+# message bus redis database
+message_bus_redis_db = 0
+
+# message bus redis password
+message_bus_redis_password =
+
+# skip configuring client id for cloud providers who support no client commands
+message_bus_redis_skip_client_commands = false
+
 # enable Cross-origin Resource Sharing (CORS) directly at the application level
 enable_cors = false
 cors_origin = ''

--- a/config/initializers/004-message_bus.rb
+++ b/config/initializers/004-message_bus.rb
@@ -95,7 +95,7 @@ MessageBus.on_disconnect do |site_id|
 end
 
 # Point at our redis
-MessageBus.redis_config = GlobalSetting.redis_config
+MessageBus.redis_config = GlobalSetting.message_bus_redis_config
 MessageBus.reliable_pub_sub.max_backlog_size = GlobalSetting.message_bus_max_backlog_size
 
 MessageBus.long_polling_enabled = SiteSetting.enable_long_polling


### PR DESCRIPTION
Adds `DISCOURSE_MESSAGE_BUS_REDIS_ENABLED` env var, that when set
to true, will allow Discourse to connect to a different redis
instance for MessageBus needs.

When enabled you can configure the same env vars user for redis,
but prefixed by `MESSAGE_BUS`, eg:

`DISCOURSE_MESSAGE_BUS_REDIS_HOST`