### PR TITLE
FIX: correct translations for logs error rate notice

### DIFF
--- a/app/assets/javascripts/discourse/services/logs-notice.js.es6
+++ b/app/assets/javascripts/discourse/services/logs-notice.js.es6
@@ -20,7 +20,7 @@ const LogsNotice = Ember.Object.extend({
     this.messageBus.subscribe("/logs_error_rate_exceeded", data => {
       const duration = data.duration;
       const rate = data.rate;
-      var siteSettingLimit = 0;
+      let siteSettingLimit = 0;
 
       if (duration === "minute") {
         siteSettingLimit = this.siteSettings.alert_admins_if_errors_per_minute;
@@ -28,22 +28,17 @@ const LogsNotice = Ember.Object.extend({
         siteSettingLimit = this.siteSettings.alert_admins_if_errors_per_hour;
       }
 
-      var translationKey = rate === siteSettingLimit ? "reached" : "exceeded";
+      let translationKey = rate === siteSettingLimit ? "reached" : "exceeded";
+      translationKey += `_${duration}_MF`;
 
       this.set(
         "text",
-        I18n.t(`logs_error_rate_notice.${translationKey}`, {
+        I18n.messageFormat(`logs_error_rate_notice.${translationKey}`, {
           relativeAge: autoUpdatingRelativeAge(
             new Date(data.publish_at * 1000)
           ),
-          siteSettingRate: I18n.t("logs_error_rate_notice.rate", {
-            count: siteSettingLimit,
-            duration: duration
-          }),
-          rate: I18n.t("logs_error_rate_notice.rate", {
-            count: rate,
-            duration: duration
-          }),
+          rate,
+          limit: siteSettingLimit,
           url: Discourse.getURL("/logs")
         })
       );

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1273,11 +1273,10 @@ en:
     too_few_topics_notice: "Let's <a href='https://blog.discourse.org/2014/08/building-a-discourse-community/'>get this discussion started!</a> There are currently <strong>%{currentTopics} / %{requiredTopics}</strong> topics. New visitors need some conversations to read and respond to."
     too_few_posts_notice: "Let's <a href='https://blog.discourse.org/2014/08/building-a-discourse-community/'>get this discussion started!</a> There are currently <strong>%{currentPosts} / %{requiredPosts}</strong> posts. New visitors need some conversations to read and respond to."
     logs_error_rate_notice:
-      reached: "<b>%{relativeAge}</b> – <a href='%{url}' target='_blank'>%{rate}</a> reached site setting limit of %{siteSettingRate}."
-      exceeded: "<b>%{relativeAge}</b> – <a href='%{url}' target='_blank'>%{rate}</a> exceeds site setting limit of %{siteSettingRate}."
-      rate:
-        one: "%{count} error/%{duration}"
-        other: "%{count} errors/%{duration}"
+      reached_hour_MF: "<b>{relativeAge}</b> – <a href='{url}' target='_blank'>{rate, plural, one {# error/hour} other {# errors/hour}}</a> reached site setting limit of {limit, plural, one {# error/hour} other {# errors/hour}}."
+      reached_minute_MF: "<b>{relativeAge}</b> – <a href='{url}' target='_blank'>{rate, plural, one {# error/minute} other {# errors/minute}}</a> reached site setting limit of {limit, plural, one {# error/minute} other {# errors/minute}}."
+      exceeded_hour_MF: "<b>{relativeAge}</b> – <a href='{url}' target='_blank'>{rate, plural, one {# error/hour} other {# errors/hour}}</a> exceeded site setting limit of {limit, plural, one {# error/hour} other {# errors/hour}}."
+      exceeded_minute_MF: "<b>{relativeAge}</b> – <a href='{url}' target='_blank'>{rate, plural, one {# error/minute} other {# errors/minute}}</a> exceeded site setting limit of {limit, plural, one {# error/minute} other {# errors/minute}}."
 
     learn_more: "learn more..."
 


### PR DESCRIPTION
The problem here is that `hour` and `minute` were passed to the `%{duration}` variable which made them impossible to translate in other languages.

I wonder if it's worth having 2 almost identical translations just for "reached" and "exceeded"? Perhaps we could combine them in one copy?