### PR TITLE
Fake reads option on PostCreator

### DIFF
--- a/app/models/topic_user.rb
+++ b/app/models/topic_user.rb
@@ -362,6 +362,22 @@ class TopicUser < ActiveRecord::Base
       end
     end
 
+    # Causes user reads on `post_number` if they have read `post_number - 1`
+    def fake_user_reads(topic_id, post_number)
+      DB.exec(
+        "
+          UPDATE topic_users
+            SET
+              last_read_post_number = :post_number,
+              highest_seen_post_number = GREATEST(highest_seen_post_number, :post_number)
+            WHERE
+              topic_id = :topic_id AND
+              last_read_post_number = :post_number - 1
+        ",
+        topic_id: topic_id,
+        post_number: post_number
+      )
+    end
   end
 
   def self.update_post_action_cache(opts = {})

--- a/lib/post_creator.rb
+++ b/lib/post_creator.rb
@@ -39,6 +39,8 @@ class PostCreator
   #                             dequeue before the commit finishes. If you do this, be sure to
   #                             call `enqueue_jobs` after the transaction is comitted.
   #   hidden_reason_id        - Reason for hiding the post (optional)
+  #   fake_reads              - If a user has read the previous post, should we pretend they read
+  #                             this one too? (default false)
   #
   #   When replying to a topic:
   #     topic_id              - topic we're replying to
@@ -83,6 +85,10 @@ class PostCreator
 
   def skip_validations?
     @opts[:skip_validations]
+  end
+
+  def fake_reads?
+    @opts.fetch(:fake_reads, false)
   end
 
   def guardian
@@ -224,7 +230,8 @@ class PostCreator
 
     PostJobsEnqueuer.new(@post, @topic, new_topic?,
       import_mode: @opts[:import_mode],
-      post_alert_options: @opts[:post_alert_options]
+      post_alert_options: @opts[:post_alert_options],
+      fake_reads: fake_reads?
     ).enqueue_jobs
   end
 


### PR DESCRIPTION
When creating a post, you can now pretend that a user has read `post_number` if they have already read `post_number - 1`.