### PR TITLE
DEV: Make groups/new accessible by plugins

### DIFF
--- a/app/assets/javascripts/discourse/templates/components/groups-form-membership-fields.hbs
+++ b/app/assets/javascripts/discourse/templates/components/groups-form-membership-fields.hbs
@@ -27,6 +27,9 @@
     </label>
   </div>
 
+  {{plugin-outlet name="groups-form-membership-below-automatic"
+                  args=(hash model=model)}}
+
   <div class="control-group">
     <label class="control-label">{{i18n "admin.groups.manage.membership.trust_level"}}</label>
     <label for="grant_trust_level">{{i18n 'admin.groups.manage.membership.trust_levels_title'}}</label>

--- a/app/assets/javascripts/discourse/templates/group-index.hbs
+++ b/app/assets/javascripts/discourse/templates/group-index.hbs
@@ -64,7 +64,8 @@
                     removeMember=(action "removeMember")
                     makeOwner=(action "makeOwner")
                     removeOwner=(action "removeOwner")
-                    member=m}}
+                    member=m
+                    group=model}}
               {{/if}}
             </td>
           </tr>

--- a/app/assets/javascripts/discourse/templates/group-index.hbs
+++ b/app/assets/javascripts/discourse/templates/group-index.hbs
@@ -67,6 +67,7 @@
                     member=m
                     group=model}}
               {{/if}}
+              {{!-- group parameter is used by plugins --}}
             </td>
           </tr>
         {{/each}}

--- a/app/controllers/admin/groups_controller.rb
+++ b/app/controllers/admin/groups_controller.rb
@@ -130,7 +130,7 @@ class Admin::GroupsController < Admin::AdminController
   private
 
   def group_params
-    params.require(:group).permit(
+    permitted = [
       :name,
       :mentionable_level,
       :messageable_level,
@@ -153,6 +153,10 @@ class Admin::GroupsController < Admin::AdminController
       :membership_request_template,
       :owner_usernames,
       :usernames
-    )
+    ]
+    custom_fields = Group.editable_group_custom_fields
+    permitted << { custom_fields: custom_fields } unless custom_fields.blank?
+
+    params.require(:group).permit(permitted)
   end
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -545,6 +545,9 @@ class GroupsController < ApplicationController
             :automatic_membership_email_domains,
             :automatic_membership_retroactive
           ])
+
+          custom_fields = Group.editable_group_custom_fields
+          default_params << { custom_fields: custom_fields } unless custom_fields.blank?
         end
 
         default_params

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -189,6 +189,21 @@ class Group < ActiveRecord::Base
     levels
   end
 
+  def self.plugin_editable_group_custom_fields
+    @plugin_editable_group_custom_fields ||= {}
+  end
+
+  def self.register_plugin_editable_group_custom_field(custom_field_name, plugin)
+    plugin_editable_group_custom_fields[custom_field_name] = plugin
+  end
+
+  def self.editable_group_custom_fields
+    plugin_editable_group_custom_fields.reduce([]) do |fields, (k, v)|
+      next(fields) unless v.enabled?
+      fields << k
+    end.uniq
+  end
+
   def downcase_incoming_email
     self.incoming_email = (incoming_email || "").strip.downcase.presence
   end

--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -146,6 +146,12 @@ class Plugin::Instance
     end
   end
 
+  def register_editable_group_custom_field(field)
+    reloadable_patch do |plugin|
+      ::Group.register_plugin_editable_group_custom_field(field, plugin) # plugin.enabled? is checked at runtime
+    end
+  end
+
   def custom_avatar_column(column)
     reloadable_patch do |plugin|
       AvatarLookup.lookup_columns << column


### PR DESCRIPTION
- Expose a new plugin outlet. 
- Pass group model to the group-member-dropdown so it can be accessed by plugins
- Extend group permitted params from a plugin