### PR TITLE
Bump onebox version.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,7 @@ gem 'redis-namespace'
 
 gem 'active_model_serializers', '~> 0.8.3'
 
-gem 'onebox', '1.8.91'
+gem 'onebox', '1.8.92'
 
 gem 'http_accept_language', '~>2.0.5', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -237,7 +237,7 @@ GEM
     omniauth-twitter (1.4.0)
       omniauth-oauth (~> 1.1)
       rack
-    onebox (1.8.91)
+    onebox (1.8.92)
       htmlentities (~> 4.3)
       moneta (~> 1.0)
       multi_json (~> 1.11)
@@ -484,7 +484,7 @@ DEPENDENCIES
   omniauth-oauth2
   omniauth-openid
   omniauth-twitter
-  onebox (= 1.8.91)
+  onebox (= 1.8.92)
   openid-redis-store
   parallel_tests
   pg


### PR DESCRIPTION
Fixes multiple possible sources of exceptions due to frozen strings. Wikipedia onebox was definitely failing before this patch.