### PR TITLE
Cleanup crawler styles, improve schema.org markup 

### DIFF
--- a/app/assets/stylesheets/common/base/crawler_layout.scss
+++ b/app/assets/stylesheets/common/base/crawler_layout.scss
@@ -7,7 +7,7 @@ body.crawler {
     background-color: #fff;
     padding: 10px;
     box-shadow: none;
-    border-bottom: 1px solid $primary-medium;
+    border-bottom: 1px solid $primary-low-mid;
     box-sizing: border-box;
   }
 
@@ -19,6 +19,16 @@ body.crawler {
         height: auto;
       }
     }
+  }
+
+  .raw-topic-link {
+    display: block;
+    font-weight: bold;
+    margin-bottom: 0.25em;
+  }
+
+  .topic-list {
+    margin-bottom: 1em;
   }
 }
 
@@ -33,14 +43,16 @@ body.crawler {
   border-top: 1px solid $primary-low;
 }
 
-.creator {
-  word-break: break-all;
-  a {
-    font-weight: bold;
-  }
-  @include breakpoint(tablet) {
-    display: inline-block;
-    margin-bottom: 0.25em;
+.crawler-post-meta {
+  .creator {
+    word-break: break-all;
+    a {
+      font-weight: bold;
+    }
+    @include breakpoint(tablet) {
+      display: inline-block;
+      margin-bottom: 0.25em;
+    }
   }
 }
 
@@ -77,9 +89,18 @@ body.crawler {
   }
 }
 
+.crawler-linkback-list {
+  margin-top: 1em;
+  a {
+    display: block;
+    padding: 0.5em 0;
+    border-top: 1px solid $primary-low;
+  }
+}
+
 footer {
   margin-top: 3em;
-  border-top: 1px solid $primary-low;
+  border-top: 1px solid $primary-low-mid;
 }
 
 .crawler-nav {

--- a/app/assets/stylesheets/common/base/crawler_layout.scss
+++ b/app/assets/stylesheets/common/base/crawler_layout.scss
@@ -44,6 +44,7 @@ body.crawler {
 }
 
 .crawler-post-meta {
+  margin-bottom: 1em;
   .creator {
     word-break: break-all;
     a {

--- a/app/assets/stylesheets/common/base/crawler_layout.scss
+++ b/app/assets/stylesheets/common/base/crawler_layout.scss
@@ -6,28 +6,93 @@ body.crawler {
     z-index: z("max");
     background-color: #fff;
     padding: 10px;
-    box-shadow: shadow("header");
+    box-shadow: none;
+    border-bottom: 1px solid $primary-medium;
     box-sizing: border-box;
   }
-  div.topic-list div[itemprop="itemListElement"] {
-    padding: 10px 0;
-    border-bottom: 1px solid #e9e9e9;
-    .page-links a {
-      padding: 0 4px;
-    }
-  }
+
   div#main-outlet {
     div.post {
       word-break: break-word;
       img {
         max-width: 100%;
+        height: auto;
       }
     }
   }
-  footer nav {
-    margin: 50px 0;
-    a {
-      padding: 15px;
-    }
+}
+
+.crawler-topic-title {
+  margin-top: 0.5em;
+}
+
+.crawler-post {
+  margin-top: 1em;
+  margin-bottom: 2em;
+  padding-top: 1.5em;
+  border-top: 1px solid $primary-low;
+}
+
+.creator {
+  word-break: break-all;
+  a {
+    font-weight: bold;
+  }
+  @include breakpoint(tablet) {
+    display: inline-block;
+    margin-bottom: 0.25em;
+  }
+}
+
+.crawler-post-infos {
+  color: $primary-high;
+  display: inline-block;
+  @include breakpoint(tablet, min-width) {
+    float: right;
+  }
+  [itemprop="position"] {
+    float: left;
+    margin-right: 0.5em;
+  }
+}
+
+#breadcrumbs {
+  margin-bottom: 0.5em;
+  font-size: $font-up-1;
+  > div {
+    margin-bottom: 0.15em;
+  }
+  .badge-category-bg {
+    background-color: $secondary-high;
+  }
+  .category-title {
+    color: $primary;
+  }
+}
+
+.crawler-tags-list {
+  span {
+    display: block;
+    margin-bottom: 0.15em;
+  }
+}
+
+footer {
+  margin-top: 3em;
+  border-top: 1px solid $primary-low;
+}
+
+.crawler-nav {
+  margin: 1em 0;
+  ul {
+    margin: 0;
+    list-style-type: none;
+  }
+  li {
+    display: inline-block;
+  }
+  a {
+    display: inline-block;
+    padding: 0.5em 1em 0.5em 0;
   }
 }

--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -892,22 +892,3 @@ span.highlighted {
     }
   }
 }
-
-.crawler-post {
-  .post-time {
-    float: right;
-  }
-  .post-likes {
-    float: right;
-  }
-  margin-top: 5px;
-}
-
-#breadcrumbs {
-  .badge-category-bg {
-    background-color: $secondary-high;
-  }
-  .category-title {
-    color: $primary;
-  }
-}

--- a/app/views/layouts/crawler.html.erb
+++ b/app/views/layouts/crawler.html.erb
@@ -35,11 +35,13 @@
     </div>
     <footer class="container wrap">
       <nav class='crawler-nav' itemscope itemtype='http://schema.org/SiteNavigationElement'>
-        <a href='<%= path "/" %>'><%= t 'home_title' %></a>
-        <%= link_to t('js.filters.categories.title'), path("/categories") %>
-        <%= link_to t('guidelines_topic.title'), path("/guidelines") %>
-        <%= link_to t('tos_topic.title'), path("/tos") %>
-        <%= link_to t('privacy_topic.title'), path("/privacy") %>
+        <ul>
+        <li itemprop="name"><a href='<%= path "/" %>' itemprop="url"><%= t 'home_title' %> </a></li>
+        <li itemprop="name"><a href='<%= path "/categories" %>' itemprop="url"><%= t 'js.filters.categories.title' %> </a></li>
+        <li itemprop="name"><a href='<%= path "/guidelines" %>' itemprop="url"><%= t 'guidelines_topic.title' %> </a></li>
+        <li itemprop="name"><a href='<%= path "/tos" %>' itemprop="url"><%= t 'tos_topic.title' %> </a></li>
+        <li itemprop="name"><a href='<%= path "/privacy" %>' itemprop="url"><%= t 'privacy_topic.title' %> </a></li>
+        </ul>
       </nav>
       <p class='powered-by-link'><%= t 'powered_by_html' %></p>
     </footer>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -1,4 +1,4 @@
-<h1>
+<h1 class="crawler-topic-title">
   <%= render_topic_title(@topic_view.topic) %>
 </h1>
 
@@ -22,19 +22,17 @@
 <% if SiteSetting.tagging_enabled %>
   <% @tags = @topic_view.topic.tags %>
   <% if @tags.present? %>
-    <div class='tags-list' itemscope itemtype='http://schema.org/ItemList'>
-      <% @tags.each do |tag| %>
-        <div itemprop='itemListElement' itemscope itemtype='http://schema.org/ListItem'>
-          <meta itemprop='url' content='<%= "#{Discourse.base_url}/tags/#{tag.name}" %>'>
-          <a href='<%= "#{Discourse.base_url}/tags/#{tag.name}" %>' itemprop='item'>
-            <span itemprop='name'><%= tag.name -%></span>
+    <div class='crawler-tags-list' itemscope itemtype='http://schema.org/DiscussionForumPosting'>
+      <% @tags.each_with_index do |tag, i| %>
+        <div itemprop='keywords'>
+          <a  href='<%= "#{Discourse.base_url}/tags/#{tag.name}" %>' rel="tag">
+            <span itemprop='headline'><%= tag.name -%></span>
           </a>
         </div>
       <% end %>
     </div>
   <% end %>
 <% end %>
-
 
 <%= server_plugin_outlet "topic_header" %>
 
@@ -43,9 +41,9 @@
 <% @topic_view.posts.each do |post| %>
   <div itemscope itemtype='http://schema.org/DiscussionForumPosting' class='topic-body crawler-post'>
     <% if (u = post.user) %>
-      <div class='creator'>
-        <span>
-          <a href='<%= Discourse.base_uri %>/u/<%= u.username %>'><b itemprop='author'><%= u.username %></b></a>
+      <div class='crawler-post-meta'>
+        <span class="creator" itemprop="author" itemscope itemtype="http://schema.org/Person">
+          <a itemprop="url" href='<%= Discourse.base_uri %>/u/<%= u.username %>'><span itemprop='name'><%= u.username %></span></a>
           <%= "(#{u.name})" if (SiteSetting.display_name_on_posts && SiteSetting.enable_names? && !u.name.blank?) %>
           <%
             who_username = post.custom_fields["action_code_who"] || ""
@@ -53,6 +51,9 @@
           %>
             <%= t("js.action_codes.#{post.action_code}", when: "", who: who_username).html_safe %>
           <% end %>
+        </span>
+
+        <span class="crawler-post-infos">
           <% if post.updated_at > post.created_at %>
             <meta itemprop='datePublished' content='<%= post.created_at.to_formatted_s(:iso8601) %>'>
             <time itemprop='dateModified' datetime='<%= post.updated_at.to_formatted_s(:iso8601) %>' class='post-time'>
@@ -63,26 +64,42 @@
               <%= l post.created_at, format: :long %>
             </time>
           <% end %>
-        </span>
         <span itemprop='position'>#<%= post.post_number %></span>
+        </span>
       </div>
       <div class='post' itemprop='articleBody'>
         <%= post.hidden ? t('flagging.user_must_edit').html_safe : post.cooked.html_safe %>
       </div>
-      <meta itemprop='interactionCount' content='UserLikes:<%= post.like_count %>'>
-      <meta itemprop='interactionCount' content='UserComments:<%= post.reply_count %>'>
+
       <meta itemprop='headline' content='<%= @topic_view.title %>'>
-      <div class='clearfix'>
-        <span class='post-likes'><%= post.like_count > 0 ? t('post.has_likes', count: post.like_count) : '' %></span>
-      </div>
-      <% if @topic_view.link_counts[post.id] && @topic_view.link_counts[post.id].length > 0 %>
-        <% @topic_view.link_counts[post.id].each do |link| %>
-          <% if link[:reflection] && link[:title].present? %>
-            <a href="<%=link[:url]%>"><%=link[:title]%></a>
-            <hr>
-          <% end %>
-        <% end %>
-      <% end %>
+
+      <div itemprop="interactionStatistic" itemscope itemtype="http://schema.org/InteractionCounter">
+         <meta itemprop="interactionType" content="http://schema.org/LikeAction"/>
+         <meta itemprop="userInteractionCount" content="<%= post.like_count %>" />
+         <span class='post-likes'><%= post.like_count > 0 ? t('post.has_likes', count: post.like_count) : '' %></span>
+       </div>
+
+       <div itemprop="interactionStatistic" itemscope itemtype="http://schema.org/InteractionCounter">
+          <meta itemprop="interactionType" content="http://schema.org/CommentAction"/>
+          <meta itemprop="userInteractionCount" content="<%= post.reply_count %>" />
+        </div>
+
+        <% if @topic_view.link_counts[post.id] && @topic_view.link_counts[post.id].length > 0 %>
+          <div class='crawler-linkback-list' itemscope itemtype='http://schema.org/ItemList'>
+            <% @topic_view.link_counts[post.id].each_with_index do |link, i| %>
+              <% if link[:reflection] && link[:title].present? %>
+                <div itemprop='itemListElement' itemscope itemtype='http://schema.org/ListItem'>
+                  <a href="<%=link[:url]%>" itemprop='item'>
+                    <meta itemprop='url' content='<%=link[:url]%>'>
+                    <meta itemprop='position' content='<%= i+1 %>'>
+                    <span itemprop='name'><%=link[:title]%></span>
+                  </a>
+                </div>
+              <% end %>
+            <% end %>
+          </div>
+       <% end %>
+
     <% end %>
   </div>
 <% end %>

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -63,7 +63,7 @@ en:
   topics: "Topics"
   posts: "posts"
   loading: "Loading"
-  powered_by_html: 'Powered by <a href="https://www.discourse.org">Discourse</a>, best viewed with JavaScript enabled'
+  powered_by_html: 'Powered by <a rel="nofollow" href="https://www.discourse.org">Discourse</a>, best viewed with JavaScript enabled'
   log_in: "Log In"
   submit: "Submit"
   purge_reason: "Automatically deleted as abandoned, deactivated account"


### PR DESCRIPTION
* Added some more spacing to various links for easier tapping
* Added clearer divisions between posts on mobile 
* Updated schema.org markup for likes and reply count
* Updated schema.org markup for tags in topics – previously we used https://schema.org/ItemList, but https://schema.org/keywords seems more appropriate to me... also resolved an error we had with ItemList
* Now that https://schema.org/ItemList is freed up (can only be used once per page) I updated the list of links under OP to use it   
* Added schema for crawler nav
* Validated schema via https://search.google.com/structured-data/testing-tool/u/0/ - we still get one error with itemlist (cancel	
All values provided for url must have the same domain.), but after some googling it looks like an error with the validator 