### PR TITLE
DEV: Pass editor to plugin hook handling composer uploads.

### DIFF
--- a/app/assets/javascripts/discourse/components/composer-editor.js.es6
+++ b/app/assets/javascripts/discourse/components/composer-editor.js.es6
@@ -694,7 +694,7 @@ export default Ember.Component.extend({
 
       const matchingHandler = uploadHandlers.find(matcher);
       if (data.files.length === 1 && matchingHandler) {
-        if (!matchingHandler.method(data.files[0])) {
+        if (!matchingHandler.method(data.files[0], this)) {
           return false;
         }
       }

--- a/app/assets/javascripts/discourse/lib/plugin-api.js.es6
+++ b/app/assets/javascripts/discourse/lib/plugin-api.js.es6
@@ -44,7 +44,7 @@ import { addComposerUploadHandler } from "discourse/components/composer-editor";
 import { addCategorySortCriteria } from "discourse/components/edit-category-settings";
 
 // If you add any methods to the API ensure you bump up this number
-const PLUGIN_API_VERSION = "0.8.30";
+const PLUGIN_API_VERSION = "0.8.31";
 
 class PluginApi {
   constructor(version, container) {
@@ -809,7 +809,7 @@ class PluginApi {
    *
    * Example:
    *
-   * addComposerUploadHandler(["mp4", "mov"], (file) => {
+   * addComposerUploadHandler(["mp4", "mov"], (file, editor) => {
    *    console.log("Handling upload for", file.name);
    * })
    */


### PR DESCRIPTION
Passing the `composer-editor` component instance makes it easier for plugins to access jQuery-File-Upload widget (i.e. `editor.$().fileupload(...)`).