### PR TITLE
DEV: d-editor helper should be synchronous

### DIFF
--- a/test/javascripts/components/d-editor-test.js.es6
+++ b/test/javascripts/components/d-editor-test.js.es6
@@ -1,5 +1,6 @@
 import componentTest from "helpers/component-test";
 import { withPluginApi } from "discourse/lib/plugin-api";
+import formatTextWithSelection from "helpers/d-editor-helper";
 
 moduleForComponent("d-editor", { integration: true });
 
@@ -797,12 +798,14 @@ composerTestCase("replace-text event for composer", async function(assert) {
         .lookup("app-events:main")
         .trigger("composer:replace-text", "green", "yellow", { forceFocus: true });
 
-      let expect = await formatTextWithSelection(AFTER, CASE.after); // eslint-disable-line no-undef
-      let actual = await formatTextWithSelection( // eslint-disable-line no-undef
-        this.value,
-        getTextareaSelection(textarea)
-      );
-      assert.equal(actual, expect);
+      Ember.run.next(() => {
+        let expect = formatTextWithSelection(AFTER, CASE.after);
+        let actual = formatTextWithSelection(
+          this.value,
+          getTextareaSelection(textarea)
+        );
+        assert.equal(actual, expect);
+      });
     });
   }
 })();

--- a/test/javascripts/helpers/d-editor-helper.js.es6
+++ b/test/javascripts/helpers/d-editor-helper.js.es6
@@ -1,8 +1,4 @@
-Ember.Test.registerAsyncHelper("formatTextWithSelection", function(
-  app,
-  text,
-  [start, len]
-) {
+export default function formatTextWithSelection(text, [start, len]) {
   return [
     '"',
     text.substr(0, start),
@@ -12,4 +8,4 @@ Ember.Test.registerAsyncHelper("formatTextWithSelection", function(
     text.substr(start + len),
     '"'
   ].join("");
-});
+}

--- a/test/javascripts/test_helper.js
+++ b/test/javascripts/test_helper.js
@@ -32,7 +32,6 @@
 //= require helpers/assertions
 //= require helpers/textarea-selection
 //= require helpers/select-kit-helper
-//= require helpers/d-editor-helper
 
 //= require helpers/qunit-helpers
 //= require_tree ./fixtures


### PR DESCRIPTION
Also ensures trigger has happened before assertion and prevents leaking formatTextWithSelection into global context