### PR TITLE
FIX: safari desktop doesn't support input[time]

### DIFF
--- a/app/assets/javascripts/discourse/components/future-date-input.js.es6
+++ b/app/assets/javascripts/discourse/components/future-date-input.js.es6
@@ -36,6 +36,8 @@ export default Ember.Component.extend({
     }
   },
 
+  timeInputDisabled: Ember.computed.empty("date"),
+
   @observes("date", "time")
   _updateInput() {
     if (!this.date) {

--- a/app/assets/javascripts/discourse/templates/components/future-date-input.hbs
+++ b/app/assets/javascripts/discourse/templates/components/future-date-input.hbs
@@ -21,7 +21,7 @@
 
     <div class="control-group">
       {{d-icon "far-clock"}}
-      {{input type="time" value=time}}
+      {{input placeholder="--:--" type="time" value=time disabled=timeInputDisabled}}
     </div>
   {{/if}}
 

--- a/app/assets/stylesheets/common/base/edit-topic-status-update-modal.scss
+++ b/app/assets/stylesheets/common/base/edit-topic-status-update-modal.scss
@@ -49,6 +49,10 @@
         font-size: $font-up-1;
       }
     }
+
+    input[disabled] {
+      background: $primary-low;
+    }
   }
   .pika-single {
     position: absolute !important; /* inline JS styles */


### PR DESCRIPTION
This commit attempts to improve the experience by:
- showing time input as disabled on any platform if date hasn't been set
- showing a placeholder --:-- to emphasize the expected format