### PR TITLE
s3 relative routes need the relative routes on the final cdn path.

### DIFF
--- a/lib/file_store/s3_store.rb
+++ b/lib/file_store/s3_store.rb
@@ -119,7 +119,7 @@ module FileStore
       return url if SiteSetting.Upload.s3_cdn_url.blank?
       schema = url[/^(https?:)?\/\//, 1]
       folder = @s3_helper.s3_bucket_folder_path.nil? ? "" : "#{@s3_helper.s3_bucket_folder_path}/"
-      url.sub(File.join("#{schema}#{absolute_base_url}", folder), File.join(SiteSetting.Upload.s3_cdn_url, "/"))
+      url.sub(File.join("#{schema}#{absolute_base_url}", folder), File.join(SiteSetting.Upload.s3_cdn_url, Discourse.base_uri, "/"))
     end
 
     def cache_avatar(avatar, user_id)

--- a/lib/file_store/s3_store.rb
+++ b/lib/file_store/s3_store.rb
@@ -119,7 +119,7 @@ module FileStore
       return url if SiteSetting.Upload.s3_cdn_url.blank?
       schema = url[/^(https?:)?\/\//, 1]
       folder = @s3_helper.s3_bucket_folder_path.nil? ? "" : "#{@s3_helper.s3_bucket_folder_path}/"
-      url.sub(File.join("#{schema}#{absolute_base_url}", folder), File.join(SiteSetting.Upload.s3_cdn_url, Discourse.base_uri, "/"))
+      url.sub(File.join("#{schema}#{absolute_base_url}"), File.join(SiteSetting.Upload.s3_cdn_url))
     end
 
     def cache_avatar(avatar, user_id)

--- a/spec/components/file_store/s3_store_spec.rb
+++ b/spec/components/file_store/s3_store_spec.rb
@@ -391,7 +391,7 @@ describe FileStore::S3Store do
 
       url = "//s3-upload-bucket.s3.dualstack.us-east-1.amazonaws.com/livechat/original/gif.png"
 
-      expect(store.cdn_url(url)).to eq("https://rainbow.com/community/original/gif.png")
+      expect(store.cdn_url(url)).to eq("https://rainbow.com/livechat/original/gif.png")
     end
   end
 

--- a/spec/components/file_store/s3_store_spec.rb
+++ b/spec/components/file_store/s3_store_spec.rb
@@ -391,7 +391,7 @@ describe FileStore::S3Store do
 
       url = "//s3-upload-bucket.s3.dualstack.us-east-1.amazonaws.com/livechat/original/gif.png"
 
-      expect(store.cdn_url(url)).to eq("https://rainbow.com/original/gif.png")
+      expect(store.cdn_url(url)).to eq("https://rainbow.com/community/original/gif.png")
     end
   end
 


### PR DESCRIPTION
The tests seem to indicate this isn't true, but on a cloudfront install:
All other scripts are loaded with {cdn_url}/{s3_subfolder}/{file}

Images are unable to load via {cdn_url}/{file}
Images are able to load via {cdn_url}/{s3_subfolder}/{file}

So I'm assuming the test is incorrect in this case, and we *do* need the subfolder.

(This is assuming the config for the cdn_url should *not* include subfolder paths)