### PR TITLE
FIX: clean up cooked group bio when bio is removed

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -209,8 +209,10 @@ class Group < ActiveRecord::Base
   end
 
   def cook_bio
-    if !self.bio_raw.blank?
+    if self.bio_raw.present?
       self.bio_cooked = PrettyText.cook(self.bio_raw)
+    else
+      self.bio_cooked = nil
     end
   end
 


### PR DESCRIPTION
https://meta.discourse.org/t/group-bio-cant-be-deleted/119777