### PR TITLE
FEATURE: SKIP_DB_AND_REDIS env to enable bootstrapping without a DB

### DIFF
--- a/app/models/emoji.rb
+++ b/app/models/emoji.rb
@@ -89,10 +89,12 @@ class Emoji
   def self.load_custom
     result = []
 
-    CustomEmoji.includes(:upload).order(:name).each do |emoji|
-      result << Emoji.new.tap do |e|
-        e.name = emoji.name
-        e.url = emoji.upload&.url
+    if !GlobalSetting.skip_db?
+      CustomEmoji.includes(:upload).order(:name).each do |emoji|
+        result << Emoji.new.tap do |e|
+          e.name = emoji.name
+          e.url = emoji.upload&.url
+        end
       end
     end
 

--- a/app/models/global_setting.rb
+++ b/app/models/global_setting.rb
@@ -77,6 +77,22 @@ class GlobalSetting
     end
   end
 
+  def self.skip_db=(v)
+    @skip_db = v
+  end
+
+  def self.skip_db?
+    @skip_db
+  end
+
+  def self.skip_redis=(v)
+    @skip_redis = v
+  end
+
+  def self.skip_redis?
+    @skip_redis
+  end
+
   def self.use_s3?
     (@use_s3 ||=
       begin

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,6 +35,11 @@ unless Rails.env.test? && ENV['LOAD_PLUGINS'] != "1"
 end
 GlobalSetting.load_defaults
 
+if ENV['SKIP_DB_AND_REDIS'] == '1'
+  GlobalSetting.skip_db = true
+  GlobalSetting.skip_redis = true
+end
+
 require 'pry-rails' if Rails.env.development?
 
 if defined?(Bundler)

--- a/config/initializers/004-message_bus.rb
+++ b/config/initializers/004-message_bus.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
+if GlobalSetting.skip_redis?
+  MessageBus.configure(backend: :memory)
+  return
+end
+
 MessageBus.site_id_lookup do |env = nil|
   if env
     setup_message_bus_env(env)

--- a/config/initializers/005-site_settings.rb
+++ b/config/initializers/005-site_settings.rb
@@ -5,6 +5,13 @@
 # the original version
 Discourse.git_version
 
+if GlobalSetting.skip_redis?
+  require 'site_settings/local_process_provider'
+  Rails.cache = Discourse.cache
+  SiteSetting.provider = SiteSettings::LocalProcessProvider.new
+  return
+end
+
 reload_settings = lambda {
   RailsMultisite::ConnectionManagement.safe_each_connection do
     begin

--- a/config/initializers/006-ensure_login_hint.rb
+++ b/config/initializers/006-ensure_login_hint.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+return if GlobalSetting.skip_db?
+
 # Some sanity checking so we don't count on an unindexed column on boot
 begin
   if ActiveRecord::Base.connection.table_exists?(:users) &&

--- a/config/initializers/100-logster.rb
+++ b/config/initializers/100-logster.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
+if GlobalSetting.skip_redis?
+  Rails.logger = Rails.logger.chained.first
+  return
+end
+
 if Rails.env.development? && RUBY_VERSION.match?(/^2\.5\.[23]/)
   STDERR.puts "WARNING: Discourse development environment runs slower on Ruby 2.5.3 or below"
   STDERR.puts "We recommend you upgrade to Ruby 2.6.1 for the optimal development performance"

--- a/config/initializers/100-push-notifications.rb
+++ b/config/initializers/100-push-notifications.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+return if GlobalSetting.skip_db?
+
 require_dependency 'webpush'
 
 if SiteSetting.vapid_public_key.blank? || SiteSetting.vapid_private_key.blank? || SiteSetting.vapid_public_key_bytes.blank?

--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -245,7 +245,13 @@ module Discourse
   end
 
   def self.cache
-    @cache ||= Cache.new
+    @cache ||= begin
+      if GlobalSetting.skip_redis?
+        ActiveSupport::Cache::MemoryStore.new
+      else
+        Cache.new
+      end
+    end
   end
 
   # Get the current base URL for the current site

--- a/lib/freedom_patches/translate_accelerator.rb
+++ b/lib/freedom_patches/translate_accelerator.rb
@@ -138,6 +138,8 @@ module I18n
     def overrides_by_locale(locale)
       return unless @overrides_enabled
 
+      return {} if GlobalSetting.skip_db?
+
       site = RailsMultisite::ConnectionManagement.current_db
 
       by_site = @overrides_by_site[site]


### PR DESCRIPTION
Sometimes we would like to create a base image without any DB access, this
assists in creating custom base images with custom plugins that already
includes `public/assets`

Following this change set you can run:

```
SPROCKETS_CONCURRENT=1 DONT_PRECOMPILE_CSS=1 SKIP_DB_AND_REDIS=1 RAILS_ENV=production bin/rake assets:precompile
```

Then it is straight forward to create a base image without needing a DB or
Redis.