### PR TITLE
UX: Rename "Keep Post" to "Keep Post Hidden" when hidden

### DIFF
--- a/app/models/reviewable_flagged_post.rb
+++ b/app/models/reviewable_flagged_post.rb
@@ -40,7 +40,12 @@ class ReviewableFlaggedPost < Reviewable
       build_action(actions, :agree_and_hide, icon: 'far-eye-slash', bundle: agree)
     end
 
-    build_action(actions, :agree_and_keep, icon: 'thumbs-up', bundle: agree)
+    if post.hidden?
+      build_action(actions, :agree_and_keep_hidden, icon: 'thumbs-up', bundle: agree)
+    else
+      build_action(actions, :agree_and_keep, icon: 'thumbs-up', bundle: agree)
+    end
+
     if guardian.can_suspend?(target_created_by)
       build_action(actions, :agree_and_suspend, icon: 'ban', bundle: agree, client_action: 'suspend')
       build_action(actions, :agree_and_silence, icon: 'microphone-slash', bundle: agree, client_action: 'silence')
@@ -121,6 +126,10 @@ class ReviewableFlaggedPost < Reviewable
 
   # Penalties are handled by the modal after the action is performed
   def perform_agree_and_keep(performed_by, args)
+    agree(performed_by, args)
+  end
+
+  def perform_agree_and_keep_hidden(performed_by, args)
     agree(performed_by, args)
   end
 

--- a/app/models/reviewable_flagged_post.rb
+++ b/app/models/reviewable_flagged_post.rb
@@ -4,6 +4,14 @@ require_dependency 'reviewable'
 
 class ReviewableFlaggedPost < Reviewable
 
+  # Penalties are handled by the modal after the action is performed
+  def self.action_aliases
+    { agree_and_keep_hidden: :agree_and_keep,
+      agree_and_silence: :agree_and_keep,
+      agree_and_suspend: :agree_and_keep,
+      disagree_and_restore: :disagree }
+  end
+
   def self.counts_for(posts)
     result = {}
 
@@ -124,20 +132,7 @@ class ReviewableFlaggedPost < Reviewable
     end
   end
 
-  # Penalties are handled by the modal after the action is performed
   def perform_agree_and_keep(performed_by, args)
-    agree(performed_by, args)
-  end
-
-  def perform_agree_and_keep_hidden(performed_by, args)
-    agree(performed_by, args)
-  end
-
-  def perform_agree_and_suspend(performed_by, args)
-    agree(performed_by, args)
-  end
-
-  def perform_agree_and_silence(performed_by, args)
     agree(performed_by, args)
   end
 
@@ -166,10 +161,6 @@ class ReviewableFlaggedPost < Reviewable
     agree(performed_by, args) do
       PostDestroyer.new(performed_by, post).recover
     end
-  end
-
-  def perform_disagree_and_restore(performed_by, args)
-    perform_disagree(performed_by, args)
   end
 
   def perform_disagree(performed_by, args)

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -4492,6 +4492,9 @@ en:
       agree_and_keep:
         title: "Keep Post"
         description: "Agree with flag and keep the post unchanged."
+      agree_and_keep_hidden:
+        title: "Keep Post Hidden"
+        description: "Agree with flag and leave the post hidden."
       agree_and_suspend:
         title: "Suspend User"
         description: "Agree with flag and suspend the user."

--- a/spec/models/reviewable_flagged_post_spec.rb
+++ b/spec/models/reviewable_flagged_post_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe ReviewableFlaggedPost, type: :model do
         actions = reviewable.actions_for(guardian)
         expect(actions.has?(:agree_and_hide)).to eq(true)
         expect(actions.has?(:agree_and_keep)).to eq(true)
+        expect(actions.has?(:agree_and_keep_hidden)).to eq(false)
         expect(actions.has?(:agree_and_silence)).to eq(true)
         expect(actions.has?(:agree_and_suspend)).to eq(true)
         expect(actions.has?(:delete_spammer)).to eq(true)
@@ -52,6 +53,13 @@ RSpec.describe ReviewableFlaggedPost, type: :model do
         expect(actions.has?(:delete_and_ignore_replies)).to eq(false)
         expect(actions.has?(:delete_and_agree)).to eq(false)
         expect(actions.has?(:delete_and_replies)).to eq(false)
+      end
+
+      it "changes `agree_and_keep` to `agree_and_keep_hidden` if it's been hidden" do
+        post.hidden = true
+        actions = reviewable.actions_for(guardian)
+        expect(actions.has?(:agree_and_keep)).to eq(false)
+        expect(actions.has?(:agree_and_keep_hidden)).to eq(true)
       end
 
       it "returns `agree_and_restore` if the post is user deleted" do


### PR DESCRIPTION
This is based on this feedback:
https://meta.discourse.org/t/category-group-review-moderation/116478/19

When a post is hidden this makes the operation much more clear.

![image](https://user-images.githubusercontent.com/17538/59445262-54add000-8dcd-11e9-86e9-74ada84706bf.png)

@SamSaffron I made this a PR because I think translations are frozen now and this introduces a new one?
