### PR TITLE
FEATURE: Add plugin outlets to login/create-account modals

### DIFF
--- a/app/assets/javascripts/discourse/templates/modal/create-account.hbs
+++ b/app/assets/javascripts/discourse/templates/modal/create-account.hbs
@@ -1,5 +1,6 @@
 {{#create-account email=accountEmail disabled=submitDisabled action=(action "createAccount")}}
   {{#unless complete}}
+    {{plugin-outlet name="create-account-before-modal-body"}}
     {{#d-modal-body title="create_account.title" class=(concat (if hasAtLeastOneLoginButton "has-alt-auth") " " (if userFields "has-user-fields"))}}
 
       {{#unless hasAuthOptions}}

--- a/app/assets/javascripts/discourse/templates/modal/login.hbs
+++ b/app/assets/javascripts/discourse/templates/modal/login.hbs
@@ -1,4 +1,5 @@
 {{#login-modal screenX=lastX screenY=lastY loginName=loginName loginPassword=loginPassword secondFactorToken=secondFactorToken action=(action "login")}}
+  {{plugin-outlet name="login-before-modal-body"}}
   {{#d-modal-body title="login.title" class=modalBodyClasses}}
 
     {{#if canLoginLocal}}


### PR DESCRIPTION
This will add basic plugin outlets just above the modal-body of the login and create-account modals.