### PR TITLE
UX: show like icon next to count on archived posts

### DIFF
--- a/app/assets/javascripts/discourse/widgets/post-menu.js.es6
+++ b/app/assets/javascripts/discourse/widgets/post-menu.js.es6
@@ -61,8 +61,14 @@ function likeCount(attrs) {
         ? "post.has_likes_title_only_you"
         : "post.has_likes_title_you"
       : "post.has_likes_title";
-    const icon = attrs.yours ? "d-liked" : "";
+    let icon = attrs.yours ? "d-liked" : "";
+    let addContainer = attrs.yours;
     const additionalClass = attrs.yours ? "my-likes" : "regular-likes";
+
+    if (!attrs.showLike) {
+      icon = attrs.yours ? "d-liked" : "d-unliked";
+      addContainer = true;
+    }
 
     return {
       action: "toggleWhoLiked",
@@ -71,7 +77,7 @@ function likeCount(attrs) {
       contents: count,
       icon,
       iconRight: true,
-      addContainer: attrs.yours,
+      addContainer,
       titleOptions: { count: attrs.liked ? count - 1 : count }
     };
   }

--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -65,8 +65,9 @@ nav.post-controls {
       }
       margin-left: 0;
       margin-right: 0;
-      &.my-likes {
-        // Like count on my posts
+      &.my-likes,
+      &.regular-likes {
+        // Like count on posts
         .d-icon {
           color: $primary-low-mid;
           padding-left: 0.45em;

--- a/app/assets/stylesheets/mobile/topic-post.scss
+++ b/app/assets/stylesheets/mobile/topic-post.scss
@@ -47,7 +47,8 @@ span.badge-posts {
           + .create-flag {
             padding: s(2 2 2 1);
           }
-          &.my-likes {
+          &.my-likes,
+          &.regular-likes {
             display: flex;
             max-width: unset;
             padding: s(2);


### PR DESCRIPTION
https://meta.discourse.org/t/missing-icon-for-likes-on-archived-topics/120452/