### PR TITLE
Make onbox headers RTL compliant

### DIFF
--- a/app/assets/stylesheets/common/base/onebox.scss
+++ b/app/assets/stylesheets/common/base/onebox.scss
@@ -90,6 +90,7 @@ a.loading-onebox {
     background: image-url("favicons/#{$image}.png") no-repeat;
     background-size: 16px 16px;
     padding-left: 20px;
+    padding-right: 20px;
   }
 }
 


### PR DESCRIPTION
Makes onebox title link to be compliant with RTL (Right To Left) languages.
The issue is also displayed here: https://meta.discourse.org/t/rtl-onebox-suffers-from-overlapping/120518