### PR TITLE
feat(field): allow custom fields to have a FA icon

### DIFF
--- a/app/assets/javascripts/admin/components/admin-user-field-item.js.es6
+++ b/app/assets/javascripts/admin/components/admin-user-field-item.js.es6
@@ -75,7 +75,8 @@ export default Ember.Component.extend(bufferedProperty("userField"), {
         "required",
         "show_on_profile",
         "show_on_user_card",
-        "options"
+        "options",
+        "icon"
       );
 
       this.userField

--- a/app/assets/javascripts/admin/templates/components/admin-user-field-item.hbs
+++ b/app/assets/javascripts/admin/templates/components/admin-user-field-item.hbs
@@ -11,6 +11,10 @@
     {{input value=buffered.description class="user-field-desc" maxlength="255"}}
   {{/admin-form-row}}
 
+  {{#admin-form-row label="admin.user_fields.icon"}}
+    {{input value=buffered.icon class="user-field-icon" maxlength="255"}}
+  {{/admin-form-row}}
+
   {{#if bufferedFieldType.hasOptions}}
     {{#admin-form-row label="admin.user_fields.options"}}
       {{value-list values=buffered.options inputType="array"}}
@@ -53,5 +57,10 @@
     </div>
   </div>
   <div class="row">{{flags}}</div>
+  {{#if userField.icon}}
+  <div class="row">
+    <span>{{ d-icon userField.icon }}</span>
+  </div>
+  {{/if}}
 {{/if}}
 <div class="clearfix"></div>

--- a/app/assets/javascripts/discourse/templates/components/user-fields/text.hbs
+++ b/app/assets/javascripts/discourse/templates/components/user-fields/text.hbs
@@ -1,4 +1,5 @@
 <label class="control-label" for="{{concat 'user-' elementId}}">{{{field.name}}} {{#if field.required}}<span class='required'>*</span>{{/if}}
+{{#if field.icon}} <span>{{ d-icon field.icon }}</span>{{/if}}
 </label>
 <div class='controls'>
   {{input id=(concat 'user-' elementId) value=value maxlength=site.user_field_max_length}}

--- a/app/controllers/admin/user_fields_controller.rb
+++ b/app/controllers/admin/user_fields_controller.rb
@@ -3,7 +3,7 @@
 class Admin::UserFieldsController < Admin::AdminController
 
   def self.columns
-    [:name, :field_type, :editable, :description, :required, :show_on_profile, :show_on_user_card, :position]
+    [:name, :field_type, :editable, :description, :required, :show_on_profile, :show_on_user_card, :position, :icon]
   end
 
   def create

--- a/app/models/user_field.rb
+++ b/app/models/user_field.rb
@@ -31,4 +31,5 @@ end
 #  show_on_user_card :boolean          default(FALSE), not null
 #  external_name     :string
 #  external_type     :string
+#  icon              :string
 #

--- a/app/serializers/user_field_serializer.rb
+++ b/app/serializers/user_field_serializer.rb
@@ -10,7 +10,8 @@ class UserFieldSerializer < ApplicationSerializer
              :show_on_profile,
              :show_on_user_card,
              :position,
-             :options
+             :options,
+             :icon
 
   def options
     object.user_field_options.pluck(:value)

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4079,6 +4079,7 @@ en:
         name: "Field Name"
         type: "Field Type"
         description: "Field Description"
+        icon: "Field Icon"
         save: "Save"
         edit: "Edit"
         delete: "Delete"

--- a/db/migrate/20190618225659_add_icon_to_user_fields.rb
+++ b/db/migrate/20190618225659_add_icon_to_user_fields.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddIconToUserFields < ActiveRecord::Migration[5.2]
+  def change
+    add_column :user_fields, :icon, :string, null: true
+  end
+end


### PR DESCRIPTION
I would beeing able to put a font awesome icon near my custom fields (ie: Steam ID, Battle Tag, etc...).

To do so, I think about adding an extra column to the table which will store the font awesome class.
If an icon has been set, it will be displayed on both admin list and user profile.

I'm not quite familiar with RoR environment, so I hope it's done properly.
At least, it seams to work on by dev environment ^^'