### PR TITLE
FIX: do not allow creation of topic if there is no category available for posting

### DIFF
--- a/lib/guardian/topic_guardian.rb
+++ b/lib/guardian/topic_guardian.rb
@@ -39,7 +39,8 @@ module TopicGuardian
     is_staff? ||
     (user &&
       user.trust_level >= SiteSetting.min_trust_to_create_topic.to_i &&
-      can_create_post?(parent))
+      can_create_post?(parent) &&
+      Category.topic_create_allowed(self).limit(1).count == 1)
   end
 
   def can_create_topic_on_category?(category)


### PR DESCRIPTION
If posting in 'uncategorized' category is disabled and all other categories have security settings such that it requires group membership for posting then a regular user (who doesn't belong to any group permitted for creating topic) sees <kbd>+ New Topic</kbd> button but when the composer opens they aren't allowed to choose any category, rendering the button useless and confusing.

This commit adds a check in guardian verifying that there is at least one category available for creating a topic.
