### PR TITLE
Load service worker on Apple platforms again

### DIFF
--- a/app/assets/javascripts/discourse/initializers/register-service-worker.js.es6
+++ b/app/assets/javascripts/discourse/initializers/register-service-worker.js.es6
@@ -9,9 +9,7 @@ export default {
     const isSupported = isSecured && "serviceWorker" in navigator;
 
     if (isSupported) {
-      const isApple = !!navigator.platform.match(/(Mac|iPhone|iPod|iPad)/i);
-
-      if (Discourse.ServiceWorkerURL && !isApple) {
+      if (Discourse.ServiceWorkerURL) {
         navigator.serviceWorker.getRegistrations().then(registrations => {
           for (let registration of registrations) {
             if (


### PR DESCRIPTION
Service workers were disabled on Apple platforms just under a year ago in commit https://github.com/discourse/discourse/commit/6d0732f7b4fedcbf744896d4f629c0337fc313d0 because no features on Apple platforms required it and there were vague "issues" stemming from use of service workers on at least iOS (see linked commit for a GitHub linkback to a 404 post on the meta forums).

We need to re-enable the service worker again so that [Push Notifications](https://github.com/discourse/discourse-push-notifications) begin working on Mac.

I chronicled my journey to get to this point on the [meta forum](https://meta.discourse.org/t/discourse-push-notifications-for-desktop/86941/48).