### PR TITLE
UX: add shortcut for deferring topics

### DIFF
--- a/app/assets/javascripts/discourse/controllers/keyboard-shortcuts-help.js.es6
+++ b/app/assets/javascripts/discourse/controllers/keyboard-shortcuts-help.js.es6
@@ -77,6 +77,10 @@ export default Ember.Controller.extend(ModalFunctionality, {
         keys2: [SHIFT, "k"],
         keysDelimiter: PLUS,
         shortcutsDelimiter: "slash"
+      }),
+      go_to_unread_post: buildShortcut("navigation.go_to_unread_post", {
+        keys1: [SHIFT, "l"],
+        keysDelimiter: PLUS
       })
     },
     application: {
@@ -157,6 +161,10 @@ export default Ember.Controller.extend(ModalFunctionality, {
       }),
       print: buildShortcut("actions.print", {
         keys1: [CTRL, "p"],
+        keysDelimiter: PLUS
+      }),
+      defer: buildShortcut("actions.defer", {
+        keys1: [SHIFT, "u"],
         keysDelimiter: PLUS
       })
     }

--- a/app/assets/javascripts/discourse/lib/keyboard-shortcuts.js.es6
+++ b/app/assets/javascripts/discourse/lib/keyboard-shortcuts.js.es6
@@ -65,9 +65,10 @@ const bindings = {
   "shift+p": { handler: "pinUnpinTopic" },
   "shift+r": { handler: "replyToTopic" },
   "shift+s": { click: "#topic-footer-buttons button.share", anonymous: true }, // share topic
-  "shift+u": { handler: "goToUnreadPost" },
+  "shift+l": { handler: "goToUnreadPost" },
   "shift+z shift+z": { handler: "logout" },
   "shift+f11": { handler: "fullscreenComposer", global: true },
+  "shift+u": { handler: "deferTopic" },
   t: { postAction: "replyAsNewTopic" },
   u: { handler: "goBack", anonymous: true },
   "x r": {
@@ -618,5 +619,9 @@ export default {
 
   _replyToPost() {
     this.container.lookup("controller:topic").send("replyToPost");
+  },
+
+  deferTopic() {
+    this.container.lookup("controller:topic").send("deferTopic");
   }
 };

--- a/app/assets/javascripts/discourse/templates/modal/keyboard-shortcuts-help.hbs
+++ b/app/assets/javascripts/discourse/templates/modal/keyboard-shortcuts-help.hbs
@@ -23,6 +23,7 @@
         <li>{{{shortcuts.navigation.up_down}}}</li>
         <li>{{{shortcuts.navigation.open}}}</li>
         <li>{{{shortcuts.navigation.next_prev}}}</li>
+        <li>{{{shortcuts.navigation.go_to_unread_post}}}</li>
       </ul>
     </div>
     <div>
@@ -64,6 +65,7 @@
         <li>{{{shortcuts.actions.mark_regular}}}</li>
         <li>{{{shortcuts.actions.mark_tracking}}}</li>
         <li>{{{shortcuts.actions.mark_watching}}}</li>
+        <li>{{{shortcuts.actions.defer}}}</li>
         <li>{{{shortcuts.actions.print}}}</li>
       </ul>
     </div>

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2853,6 +2853,7 @@ en:
         up_down: "%{shortcut} Move selection &uarr; &darr;"
         open: "%{shortcut} Open selected topic"
         next_prev: "%{shortcut} Next/previous section"
+        go_to_unread_post: "%{shortcut} Go to the first unread post"
       application:
         title: "Application"
         create: "%{shortcut} Create a new topic"
@@ -2889,6 +2890,7 @@ en:
         mark_tracking: "%{shortcut} Track topic"
         mark_watching: "%{shortcut} Watch topic"
         print: "%{shortcut} Print topic"
+        defer: "%{shortcut} Defer topic"
 
     badges:
       earned_n_times:


### PR DESCRIPTION
Shift+U is what Gmail uses for making emails unread, so we changed
Shift+U to be the shortcut for deferring topics (i.e. making them
unread). Shift+L is now the shortcut for going to the first unread post.