### PR TITLE
FIX: generated class names for tags with colon

### DIFF
--- a/app/assets/javascripts/discourse/components/topic-list-item.js.es6
+++ b/app/assets/javascripts/discourse/components/topic-list-item.js.es6
@@ -51,7 +51,9 @@ export const ListItemDefaults = {
     }
 
     if (topic.get("tags")) {
-      topic.get("tags").forEach(tagName => classes.push("tag-" + tagName));
+      topic.get("tags").forEach(tagName => {
+        classes.push("tag-" + tagName.replace(/:/g, '-'));
+      });
     }
 
     if (topic.get("hasExcerpt")) {


### PR DESCRIPTION
In the topic list, the tag name is automatically converted to a css class name. We are using tags that contain a colon in the tag name like `threat:high`. This was converted incorrectly into the css class name `tag-threat:high`. This fixes the class name generation to be `tag-threat-high`. See attached screenshots.

before:
<img width="807" alt="before" src="https://user-images.githubusercontent.com/6006/60039675-94bb5f80-96b7-11e9-8413-6b9872131855.png">
after:
<img width="815" alt="after" src="https://user-images.githubusercontent.com/6006/60039687-984ee680-96b7-11e9-963a-a8e137065482.png">
