### PR TITLE
UX: hide post is unread tooltip after the post is read

### DIFF
--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -865,8 +865,9 @@ span.highlighted {
 }
 
 .read-state.read {
+  visibility: hidden;
   opacity: 0;
-  transition: opacity ease-out 1s;
+  transition: visibility 1s, opacity ease-out 1s;
 }
 
 .signup-cta {


### PR DESCRIPTION
Note we can't use `display: none` here because it doesn't work with animations.