### PR TITLE
FEATURE: Add new group visibility option for "logged on users"

### DIFF
--- a/app/assets/javascripts/discourse/components/groups-form-interaction-fields.js.es6
+++ b/app/assets/javascripts/discourse/components/groups-form-interaction-fields.js.es6
@@ -13,6 +13,12 @@ export default Ember.Component.extend({
       },
       {
         name: I18n.t(
+          "admin.groups.manage.interaction.visibility_levels.logged_on_users"
+        ),
+        value: 4
+      },
+      {
+        name: I18n.t(
           "admin.groups.manage.interaction.visibility_levels.members"
         ),
         value: 1

--- a/app/assets/javascripts/discourse/components/groups-form-interaction-fields.js.es6
+++ b/app/assets/javascripts/discourse/components/groups-form-interaction-fields.js.es6
@@ -15,23 +15,23 @@ export default Ember.Component.extend({
         name: I18n.t(
           "admin.groups.manage.interaction.visibility_levels.logged_on_users"
         ),
-        value: 4
+        value: 1
       },
       {
         name: I18n.t(
           "admin.groups.manage.interaction.visibility_levels.members"
         ),
-        value: 1
+        value: 2
       },
       {
         name: I18n.t("admin.groups.manage.interaction.visibility_levels.staff"),
-        value: 2
+        value: 3
       },
       {
         name: I18n.t(
           "admin.groups.manage.interaction.visibility_levels.owners"
         ),
-        value: 3
+        value: 4
       }
     ];
 

--- a/app/assets/javascripts/discourse/templates/components/groups-form-interaction-fields.hbs
+++ b/app/assets/javascripts/discourse/templates/components/groups-form-interaction-fields.hbs
@@ -9,6 +9,10 @@
         content=visibilityLevelOptions
         castInteger=true
         class="groups-form-visibility-level"}}
+
+    <div class="control-instructions">
+      {{i18n 'admin.groups.manage.interaction.visibility_levels.description'}}
+    </div>
   </div>
 {{/if}}
 

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -91,7 +91,8 @@ class Group < ActiveRecord::Base
       public: 0,
       members: 1,
       staff: 2,
-      owners: 3
+      owners: 3,
+      logged_on_users: 4
     )
   end
 
@@ -109,6 +110,11 @@ class Group < ActiveRecord::Base
       sql = <<~SQL
         groups.id IN (
           SELECT g.id FROM groups g WHERE g.visibility_level = :public
+
+          UNION ALL
+
+          SELECT g.id FROM groups g
+          WHERE g.visibility_level = :logged_on_users AND :user_id IS NOT NULL
 
           UNION ALL
 
@@ -323,6 +329,8 @@ class Group < ActiveRecord::Base
     when :moderators
       group.update!(messageable_level: ALIAS_LEVELS[:everyone])
     end
+
+    group.update!(visibility_level: Group.visibility_levels[:logged_on_users]) if group.visibility_level == Group.visibility_levels[:public]
 
     # Remove people from groups they don't belong in.
     remove_subquery =

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -89,10 +89,10 @@ class Group < ActiveRecord::Base
   def self.visibility_levels
     @visibility_levels = Enum.new(
       public: 0,
-      members: 1,
-      staff: 2,
-      owners: 3,
-      logged_on_users: 4
+      logged_on_users: 1,
+      members: 2,
+      staff: 3,
+      owners: 4
     )
   end
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3172,6 +3172,7 @@ en:
             visibility_levels:
               title: "Who can see this group?"
               public: "Everyone"
+              logged_on_users: "Logged on users"
               members: "Group owners, members and admins"
               staff: "Group owners and staff"
               owners: "Group owners and admins"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3173,9 +3173,10 @@ en:
               title: "Who can see this group?"
               public: "Everyone"
               logged_on_users: "Logged on users"
-              members: "Group owners, members and admins"
+              members: "Group owners and members"
               staff: "Group owners and staff"
-              owners: "Group owners and admins"
+              owners: "Group owners"
+              description: "Admins can see all groups."
           membership:
             automatic: Automatic
             trust_level: Trust Level

--- a/db/fixtures/002_groups.rb
+++ b/db/fixtures/002_groups.rb
@@ -5,4 +5,4 @@ if g = Group.find_by(name: 'trust_level_5', id: 15)
   g.destroy!
 end
 
-Group.where(name: 'everyone').update_all(visibility_level: Group.visibility_levels[:owners])
+Group.where(name: 'everyone').update_all(visibility_level: Group.visibility_levels[:staff])

--- a/db/migrate/20190705173948_renumber_group_visibility_levels.rb
+++ b/db/migrate/20190705173948_renumber_group_visibility_levels.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class RenumberGroupVisibilityLevels < ActiveRecord::Migration[5.2]
+  def up
+    execute "UPDATE groups SET visibility_level = 4 WHERE visibility_level = 3"
+    execute "UPDATE groups SET visibility_level = 3 WHERE visibility_level = 2"
+    execute "UPDATE groups SET visibility_level = 2 WHERE visibility_level = 1"
+  end
+
+  def down
+    execute "UPDATE groups SET visibility_level = 0 WHERE visibility_level = 1"
+    execute "UPDATE groups SET visibility_level = 1 WHERE visibility_level = 2"
+    execute "UPDATE groups SET visibility_level = 2 WHERE visibility_level = 3"
+    execute "UPDATE groups SET visibility_level = 3 WHERE visibility_level = 4"
+  end
+end

--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -194,6 +194,7 @@ class Guardian
     return true if group.visibility_level == Group.visibility_levels[:public]
     return true if is_admin?
     return true if is_staff? && group.visibility_level == Group.visibility_levels[:staff]
+    return true if authenticated? && group.visibility_level == Group.visibility_levels[:logged_on_users]
     return false if user.blank?
 
     membership = GroupUser.find_by(group_id: group.id, user_id: user.id)
@@ -213,6 +214,7 @@ class Guardian
     return true if groups.all? { |g| g.visibility_level == Group.visibility_levels[:public] }
     return true if is_admin?
     return true if is_staff? && groups.all? { |g| g.visibility_level == Group.visibility_levels[:staff] }
+    return true if authenticated? && groups.all? { |g| g.visibility_level == Group.visibility_levels[:logged_on_users] }
     return false if user.blank?
 
     memberships = GroupUser.where(group: groups, user_id: user.id).pluck(:owner)

--- a/spec/components/guardian_spec.rb
+++ b/spec/components/guardian_spec.rb
@@ -3027,7 +3027,7 @@ describe Guardian do
   end
 
   describe(:can_see_group) do
-    it 'Correctly handles owner visibile groups' do
+    it 'Correctly handles owner visible groups' do
       group = Group.new(name: 'group', visibility_level: Group.visibility_levels[:owners])
 
       member = Fabricate(:user)
@@ -3039,13 +3039,14 @@ describe Guardian do
       group.reload
 
       expect(Guardian.new(admin).can_see_group?(group)).to eq(true)
+      expect(Guardian.new(another_user).can_see_group?(group)).to eq(false)
       expect(Guardian.new(moderator).can_see_group?(group)).to eq(false)
       expect(Guardian.new(member).can_see_group?(group)).to eq(false)
       expect(Guardian.new.can_see_group?(group)).to eq(false)
       expect(Guardian.new(owner).can_see_group?(group)).to eq(true)
     end
 
-    it 'Correctly handles staff visibile groups' do
+    it 'Correctly handles staff visible groups' do
       group = Group.new(name: 'group', visibility_level: Group.visibility_levels[:staff])
 
       member = Fabricate(:user)
@@ -3056,6 +3057,7 @@ describe Guardian do
       group.add_owner(owner)
       group.reload
 
+      expect(Guardian.new(another_user).can_see_group?(group)).to eq(false)
       expect(Guardian.new(member).can_see_group?(group)).to eq(false)
       expect(Guardian.new(admin).can_see_group?(group)).to eq(true)
       expect(Guardian.new(moderator).can_see_group?(group)).to eq(true)
@@ -3063,7 +3065,7 @@ describe Guardian do
       expect(Guardian.new.can_see_group?(group)).to eq(false)
     end
 
-    it 'Correctly handles member visibile groups' do
+    it 'Correctly handles member visible groups' do
       group = Group.new(name: 'group', visibility_level: Group.visibility_levels[:members])
 
       member = Fabricate(:user)
@@ -3076,9 +3078,28 @@ describe Guardian do
 
       expect(Guardian.new(moderator).can_see_group?(group)).to eq(false)
       expect(Guardian.new.can_see_group?(group)).to eq(false)
+      expect(Guardian.new(another_user).can_see_group?(group)).to eq(false)
       expect(Guardian.new(admin).can_see_group?(group)).to eq(true)
       expect(Guardian.new(member).can_see_group?(group)).to eq(true)
       expect(Guardian.new(owner).can_see_group?(group)).to eq(true)
+    end
+
+    it 'Correctly handles logged-on-user visible groups' do
+      group = Group.new(name: 'group', visibility_level: Group.visibility_levels[:logged_on_users])
+      member = Fabricate(:user)
+      group.add(member)
+      group.save!
+
+      owner = Fabricate(:user)
+      group.add_owner(owner)
+      group.reload
+
+      expect(Guardian.new.can_see_group?(group)).to eq(false)
+      expect(Guardian.new(moderator).can_see_group?(group)).to eq(true)
+      expect(Guardian.new(admin).can_see_group?(group)).to eq(true)
+      expect(Guardian.new(member).can_see_group?(group)).to eq(true)
+      expect(Guardian.new(owner).can_see_group?(group)).to eq(true)
+      expect(Guardian.new(another_user).can_see_group?(group)).to eq(true)
     end
 
     it 'Correctly handles public groups' do
@@ -3090,7 +3111,7 @@ describe Guardian do
   end
 
   describe '#can_see_groups?' do
-    it 'correctly handles owner visibile groups' do
+    it 'correctly handles owner visible groups' do
       group = Group.new(name: 'group', visibility_level: Group.visibility_levels[:owners])
 
       member = Fabricate(:user)
@@ -3102,6 +3123,7 @@ describe Guardian do
       group.reload
 
       expect(Guardian.new(admin).can_see_groups?([group])).to eq(true)
+      expect(Guardian.new(another_user).can_see_groups?([group])).to eq(false)
       expect(Guardian.new(moderator).can_see_groups?([group])).to eq(false)
       expect(Guardian.new(member).can_see_groups?([group])).to eq(false)
       expect(Guardian.new.can_see_groups?([group])).to eq(false)
@@ -3126,9 +3148,10 @@ describe Guardian do
       expect(Guardian.new(member).can_see_groups?([group, group2])).to eq(false)
       expect(Guardian.new.can_see_groups?([group, group2])).to eq(false)
       expect(Guardian.new(owner).can_see_groups?([group, group2])).to eq(false)
+      expect(Guardian.new(another_user).can_see_groups?([group, group2])).to eq(false)
     end
 
-    it 'correctly handles staff visibile groups' do
+    it 'correctly handles staff visible groups' do
       group = Group.new(name: 'group', visibility_level: Group.visibility_levels[:staff])
 
       member = Fabricate(:user)
@@ -3144,9 +3167,10 @@ describe Guardian do
       expect(Guardian.new(moderator).can_see_groups?([group])).to eq(true)
       expect(Guardian.new(owner).can_see_groups?([group])).to eq(true)
       expect(Guardian.new.can_see_groups?([group])).to eq(false)
+      expect(Guardian.new(another_user).can_see_groups?([group])).to eq(false)
     end
 
-    it 'correctly handles member visibile groups' do
+    it 'correctly handles member visible groups' do
       group = Group.new(name: 'group', visibility_level: Group.visibility_levels[:members])
 
       member = Fabricate(:user)
@@ -3157,11 +3181,31 @@ describe Guardian do
       group.add_owner(owner)
       group.reload
 
+      expect(Guardian.new(another_user).can_see_groups?([group])).to eq(false)
       expect(Guardian.new(moderator).can_see_groups?([group])).to eq(false)
       expect(Guardian.new.can_see_groups?([group])).to eq(false)
       expect(Guardian.new(admin).can_see_groups?([group])).to eq(true)
       expect(Guardian.new(member).can_see_groups?([group])).to eq(true)
       expect(Guardian.new(owner).can_see_groups?([group])).to eq(true)
+    end
+
+    it 'correctly handles logged-on-user visible groups' do
+      group = Group.new(name: 'group', visibility_level: Group.visibility_levels[:logged_on_users])
+
+      member = Fabricate(:user)
+      group.add(member)
+      group.save!
+
+      owner = Fabricate(:user)
+      group.add_owner(owner)
+      group.reload
+
+      expect(Guardian.new(member).can_see_groups?([group])).to eq(true)
+      expect(Guardian.new(admin).can_see_groups?([group])).to eq(true)
+      expect(Guardian.new(moderator).can_see_groups?([group])).to eq(true)
+      expect(Guardian.new(owner).can_see_groups?([group])).to eq(true)
+      expect(Guardian.new.can_see_groups?([group])).to eq(false)
+      expect(Guardian.new(another_user).can_see_groups?([group])).to eq(true)
     end
 
     it 'correctly handles the case where the user is not a member of every group' do
@@ -3190,7 +3234,7 @@ describe Guardian do
       expect(Guardian.new.can_see_groups?([group])).to eq(true)
     end
 
-    it 'correctly handles there case where not every group is public' do
+    it 'correctly handles case where not every group is public' do
       group1 = Group.new(name: 'group', visibility_level: Group.visibility_levels[:public])
       group2 = Group.new(name: 'group', visibility_level: Group.visibility_levels[:private])
 

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -1371,7 +1371,8 @@ describe GroupsController do
     before do
       group.update!(
         name: 'GOT',
-        full_name: 'Daenerys Targaryen'
+        full_name: 'Daenerys Targaryen',
+        visibility_level: Group.visibility_levels[:logged_on_users]
       )
 
       hidden_group

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -62,6 +62,10 @@ describe GroupsController do
     end
 
     context 'sortable' do
+      before do
+        sign_in(user)
+      end
+
       let!(:other_group) { Fabricate(:group, name: "zzzzzz", users: [user]) }
 
       %w{
@@ -126,7 +130,7 @@ describe GroupsController do
       expect(group_ids).to include(group.id)
       expect(group_ids).to_not include(staff_group.id)
       expect(response_body["load_more_groups"]).to eq("/groups?page=1")
-      expect(response_body["total_rows_groups"]).to eq(2)
+      expect(response_body["total_rows_groups"]).to eq(1)
 
       expect(response_body["extras"]["type_filters"].map(&:to_sym)).to eq(
         described_class::TYPE_FILTERS.keys - [:my, :owner, :automatic]

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -242,6 +242,16 @@ RSpec.describe ListController do
         end
       end
 
+      describe 'group restricted to logged-on-users' do
+        before { group.update!(visibility_level: Group.visibility_levels[:logged_on_users]) }
+
+        it 'should return the right response' do
+          get "/topics/groups/#{group.name}.json"
+
+          expect(response.status).to eq(403)
+        end
+      end
+
       describe 'restricted group' do
         before { group.update!(visibility_level: Group.visibility_levels[:staff]) }
 
@@ -263,6 +273,16 @@ RSpec.describe ListController do
           get "/topics/groups/#{group.name}.json"
 
           expect(response.status).to eq(403)
+        end
+      end
+
+      describe 'group restricted to logged-on-users' do
+        before { group.update!(visibility_level: Group.visibility_levels[:logged_on_users]) }
+
+        it 'should return the right response' do
+          get "/topics/groups/#{group.name}.json"
+
+          expect(response.status).to eq(200)
         end
       end
     end


### PR DESCRIPTION
In some cases it is useful to only allow logged on users to be able to view group membership. That's what this PR does. It also sets all automatic groups (except`everyone`) to be visible to "logged on users", previously they were marked as public but suppressed in the group page for non-staff.  

Admin UI screenshot: 
<img width="489" alt="image" src="https://user-images.githubusercontent.com/368961/60209925-ad4b8700-9829-11e9-8c5f-c010a0eb971f.png">
