### PR TITLE
DEV: attempts to make load-script more reliable

### DIFF
--- a/test/javascripts/lib/load-script-test.js.es6
+++ b/test/javascripts/lib/load-script-test.js.es6
@@ -5,19 +5,17 @@ QUnit.module("lib:load-script");
 QUnit.test(
   "load with a script tag, and callbacks are only executed after script is loaded",
   async assert => {
+    assert.ok(
+      typeof window.ace === "undefined",
+      "ensures ace is not previously loaded"
+    );
+
     const src = "/javascripts/ace/ace.js";
 
     await loadScript(src).then(() => {
       assert.ok(
-        typeof ace !== "undefined",
+        typeof window.ace !== "undefined",
         "callbacks should only be executed after the script has fully loaded"
-      );
-
-      // cannot use the `find` test helper here because the script tag is injected outside of the test sandbox frame
-      const scriptTags = Array.from(document.getElementsByTagName("script"));
-      assert.ok(
-        scriptTags.some(scriptTag => scriptTag.src.includes(src)),
-        "the script should be loaded with a script tag"
       );
     });
   }


### PR DESCRIPTION
We don't check on script anymore, but we still check on window.ace making very unlikely to regress.