### PR TITLE
FEATURE: in:tagged search (srv side)

### DIFF
--- a/lib/search.rb
+++ b/lib/search.rb
@@ -267,15 +267,12 @@ class Search
 
   advanced_filter(/^in:tagged$/) do |posts|
     posts
-      .joins("JOIN topic_tags ON
-        topic_tags.topic_id = posts.topic_id")
+      .where('EXISTS (SELECT 1 FROM topic_tags WHERE topic_tags.topic_id = posts.topic_id)')
   end
 
   advanced_filter(/^in:untagged$/) do |posts|
     posts
-      .joins("LEFT JOIN topic_tags ON
-        topic_tags.topic_id = posts.topic_id")
-      .where("topic_tags.id IS NULL")
+      .where('NOT EXISTS (SELECT 1 FROM topic_tags WHERE topic_tags.topic_id = posts.topic_id)')
   end
 
   advanced_filter(/^status:open$/) do |posts|

--- a/lib/search.rb
+++ b/lib/search.rb
@@ -272,7 +272,9 @@ class Search
 
   advanced_filter(/^in:untagged$/) do |posts|
     posts
-      .where('NOT EXISTS (SELECT 1 FROM topic_tags WHERE topic_tags.topic_id = posts.topic_id)')
+      .joins("LEFT JOIN topic_tags ON
+        topic_tags.topic_id = posts.topic_id")
+      .where("topic_tags.id IS NULL")
   end
 
   advanced_filter(/^status:open$/) do |posts|

--- a/lib/search.rb
+++ b/lib/search.rb
@@ -265,6 +265,19 @@ class Search
     @advanced_filters
   end
 
+  advanced_filter(/^in:tagged$/) do |posts|
+    posts
+      .joins("JOIN topic_tags ON
+        topic_tags.topic_id = posts.topic_id")
+  end
+
+  advanced_filter(/^in:untagged$/) do |posts|
+    posts
+      .joins("LEFT JOIN topic_tags ON
+        topic_tags.topic_id = posts.topic_id")
+      .where("topic_tags.id IS NULL")
+  end
+
   advanced_filter(/^status:open$/) do |posts|
     posts.where('NOT topics.closed AND NOT topics.archived')
   end

--- a/spec/components/search_spec.rb
+++ b/spec/components/search_spec.rb
@@ -1339,4 +1339,32 @@ describe Search do
 
   end
 
+  context 'in:tagged' do
+    it 'allows for searching by presence of any tags' do
+      topic = Fabricate(:topic, title: 'I am testing a tagged search')
+      _post = Fabricate(:post, topic: topic, raw: 'this is the first post')
+      tag = Fabricate(:tag)
+      topic_tag = Fabricate(:topic_tag, topic: topic, tag: tag)
+
+      results = Search.execute('in:untagged')
+      expect(results.posts.length).to eq(0)
+
+      results = Search.execute('in:tagged')
+      expect(results.posts.length).to eq(1)
+    end
+  end
+
+  context 'in:untagged' do
+    it 'allows for searching by presence of no tags' do
+      topic = Fabricate(:topic, title: 'I am testing a untagged search')
+      _post = Fabricate(:post, topic: topic, raw: 'this is the first post')
+
+      results = Search.execute('in:untagged')
+      expect(results.posts.length).to eq(1)
+
+      results = Search.execute('in:tagged')
+      expect(results.posts.length).to eq(0)
+    end
+  end
+
 end


### PR DESCRIPTION
Similar to in:solved or in:unsolved, the filters check for an
existence of the topic_id in the topic_tags table:

 * `in:tagged` means that *at least one tag* exists for a topic
 * `in:untagged` means that *no tag* exists for a topic

see:
 * https://meta.discourse.org/t/how-to-search-filter-untagged-topics/119641/2
 * UI-related PR: https://github.com/discourse/discourse/pull/7721