### PR TITLE
FIX: Use title attribute for notification items.

### DIFF
--- a/app/assets/javascripts/discourse/widgets/custom-notification-item.js.es6
+++ b/app/assets/javascripts/discourse/widgets/custom-notification-item.js.es6
@@ -4,7 +4,7 @@ import { formatUsername } from "discourse/lib/utilities";
 import { iconNode } from "discourse-common/lib/icon-library";
 
 createWidgetFrom(DefaultNotificationItem, "custom-notification-item", {
-  title(notificationName, data) {
+  notificationTitle(notificationName, data) {
     return data.title ? I18n.t(data.title) : "";
   },
 

--- a/app/assets/javascripts/discourse/widgets/default-notification-item.js.es6
+++ b/app/assets/javascripts/discourse/widgets/default-notification-item.js.es6
@@ -91,7 +91,7 @@ export const DefaultNotificationItem = createWidget(
       return iconNode(`notification.${notificationName}`);
     },
 
-    title(notificationName) {
+    notificationTitle(notificationName) {
       if (notificationName) {
         return I18n.t(`notifications.titles.${notificationName}`);
       } else {
@@ -108,7 +108,7 @@ export const DefaultNotificationItem = createWidget(
       let text = emojiUnescape(this.text(notificationName, data));
       let icon = this.icon(notificationName, data);
 
-      const title = this.title(notificationName, data);
+      const title = this.notificationTitle(notificationName, data);
 
       // We can use a `<p>` tag here once other languages have fixed their HTML
       // translations.


### PR DESCRIPTION
`title` function was also used by the `Widget` class to build the attributes of `li` element. The `title` attribute should only appear on the `a` element.