### PR TITLE
FIX: Ensure lightbox image download has correct content disposition in S3

### DIFF
--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -104,7 +104,11 @@ class UploadsController < ApplicationController
       if Discourse.store.internal?
         send_file_local_upload(upload)
       else
-        redirect_to Discourse.store.url_for(upload, params)
+        if params[:dl] == "1"
+          redirect_to Discourse.store.url_for(upload, force_download: true)
+        else
+          redirect_to Discourse.store.url_for(upload)
+        end
       end
     else
       render_404

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -104,7 +104,7 @@ class UploadsController < ApplicationController
       if Discourse.store.internal?
         send_file_local_upload(upload)
       else
-        redirect_to Discourse.store.url_for(upload)
+        redirect_to Discourse.store.url_for(upload, params)
       end
     else
       render_404

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -104,11 +104,7 @@ class UploadsController < ApplicationController
       if Discourse.store.internal?
         send_file_local_upload(upload)
       else
-        if params[:dl] == "1"
-          redirect_to Discourse.store.url_for(upload, force_download: true)
-        else
-          redirect_to Discourse.store.url_for(upload)
-        end
+        redirect_to Discourse.store.url_for(upload, force_download: params[:dl] == "1")
       end
     else
       render_404

--- a/lib/cooked_post_processor.rb
+++ b/lib/cooked_post_processor.rb
@@ -383,11 +383,7 @@ class CookedPostProcessor
     img.add_next_sibling(a)
 
     if upload
-      if Discourse.store.internal?
-        a["data-download-href"] = Discourse.store.download_url(upload)
-      else
-        a["data-download-href"] = "#{upload.short_path}?dl=1"
-      end
+      a["data-download-href"] = Discourse.store.download_url(upload)
     end
 
     a.add_child(img)

--- a/lib/cooked_post_processor.rb
+++ b/lib/cooked_post_processor.rb
@@ -382,8 +382,12 @@ class CookedPostProcessor
     a = create_link_node("lightbox", img["src"])
     img.add_next_sibling(a)
 
-    if upload && Discourse.store.internal?
-      a["data-download-href"] = Discourse.store.download_url(upload)
+    if upload
+      if Discourse.store.internal?
+        a["data-download-href"] = Discourse.store.download_url(upload)
+      else
+        a["data-download-href"] = "#{upload.short_path}?dl=1"
+      end
     end
 
     a.add_child(img)

--- a/lib/file_store/s3_store.rb
+++ b/lib/file_store/s3_store.rb
@@ -104,9 +104,7 @@ module FileStore
       FileStore::LocalStore.new.path_for(upload) if url && url[/^\/[^\/]/]
     end
 
-    def url_for(upload, params = {})
-      force_download = params[:dl] == "1" ? true : false
-
+    def url_for(upload, force_download: false)
       if upload.private? || force_download
         opts = { expires_in: S3Helper::DOWNLOAD_URL_EXPIRES_AFTER_SECONDS }
         opts[:response_content_disposition] = "attachment; filename=\"#{upload.original_filename}\"" if force_download

--- a/lib/file_store/s3_store.rb
+++ b/lib/file_store/s3_store.rb
@@ -99,6 +99,11 @@ module FileStore
       File.join("uploads", "tombstone", RailsMultisite::ConnectionManagement.current_db, "/")
     end
 
+    def download_url(upload)
+      return unless upload
+      "#{upload.short_path}?dl=1"
+    end
+
     def path_for(upload)
       url = upload&.url
       FileStore::LocalStore.new.path_for(upload) if url && url[/^\/[^\/]/]

--- a/lib/file_store/s3_store.rb
+++ b/lib/file_store/s3_store.rb
@@ -104,10 +104,15 @@ module FileStore
       FileStore::LocalStore.new.path_for(upload) if url && url[/^\/[^\/]/]
     end
 
-    def url_for(upload)
-      if upload.private?
+    def url_for(upload, params = {})
+      force_download = params[:dl] == "1" ? true : false
+
+      if upload.private? || force_download
+        opts = { expires_in: S3Helper::DOWNLOAD_URL_EXPIRES_AFTER_SECONDS }
+        opts[:response_content_disposition] = "attachment; filename=\"#{upload.original_filename}\"" if force_download
+
         obj = @s3_helper.object(get_upload_key(upload))
-        url = obj.presigned_url(:get, expires_in: S3Helper::DOWNLOAD_URL_EXPIRES_AFTER_SECONDS)
+        url = obj.presigned_url(:get, opts)
       else
         url = upload.url
       end

--- a/spec/components/file_store/s3_store_spec.rb
+++ b/spec/components/file_store/s3_store_spec.rb
@@ -395,4 +395,22 @@ describe FileStore::S3Store do
     end
   end
 
+  describe ".url_for" do
+    include_context "s3 helpers"
+    let(:s3_object) { stub }
+
+    it "returns signed URL with content disposition when requesting to download image" do
+      s3_helper.expects(:s3_bucket).returns(s3_bucket).at_least_once
+      s3_bucket.expects(:object).with("original/1X/#{upload.sha1}.png").returns(s3_object)
+      opts = {
+        expires_in: S3Helper::DOWNLOAD_URL_EXPIRES_AFTER_SECONDS,
+        response_content_disposition: "attachment; filename=\"#{upload.original_filename}\""
+      }
+
+      s3_object.expects(:presigned_url).with(:get, opts)
+
+      expect(store.url_for(upload, dl: "1")).not_to eq(upload.url)
+    end
+  end
+
 end

--- a/spec/components/file_store/s3_store_spec.rb
+++ b/spec/components/file_store/s3_store_spec.rb
@@ -395,6 +395,15 @@ describe FileStore::S3Store do
     end
   end
 
+  describe ".download_url" do
+    include_context "s3 helpers"
+    let(:s3_object) { stub }
+
+    it "returns correct short URL with dl=1 param" do
+      expect(store.download_url(upload)).to eq("#{upload.short_path}?dl=1")
+    end
+  end
+
   describe ".url_for" do
     include_context "s3 helpers"
     let(:s3_object) { stub }

--- a/spec/components/file_store/s3_store_spec.rb
+++ b/spec/components/file_store/s3_store_spec.rb
@@ -409,7 +409,7 @@ describe FileStore::S3Store do
 
       s3_object.expects(:presigned_url).with(:get, opts)
 
-      expect(store.url_for(upload, dl: "1")).not_to eq(upload.url)
+      expect(store.url_for(upload, force_download: true)).not_to eq(upload.url)
     end
   end
 


### PR DESCRIPTION
Fixes an inconsistency where clicking on the "Download" button of a lightboxed image opens the image in the browser when the site is configured to use S3 (instead of downloading the image directly, which is the default behaviour for local uploads). 

To fix, we need to use a presigned URL in S3 and pass it a content-disposition parameter ("attachment; filename="something.png") to encore a download as well as use the original filename.

See https://meta.discourse.org/t/viewing-images-at-full-size/121359 for more discussion. 