### PR TITLE
FIX: Respect the full_screen_login parameter from plugin auth providers

### DIFF
--- a/app/assets/javascripts/discourse/models/login-method.js.es6
+++ b/app/assets/javascripts/discourse/models/login-method.js.es6
@@ -29,7 +29,7 @@ const LoginMethod = Ember.Object.extend({
         authUrl += "?reconnect=true";
       }
 
-      if (fullScreenLogin) {
+      if (fullScreenLogin || this.full_screen_login) {
         document.cookie = "fsl=true";
         window.location = authUrl;
       } else {


### PR DESCRIPTION
This behavior was regressed in 427979e7e51bb9bc858eb6ad2456ce0075fdc643

@techAPJ I'm not sure if this was intentional or not. Please can you review?