### PR TITLE
FIX: Prevent emoji-picker from not showing

### DIFF
--- a/app/assets/javascripts/discourse/components/emoji-picker.js.es6
+++ b/app/assets/javascripts/discourse/components/emoji-picker.js.es6
@@ -565,7 +565,7 @@ export default Ember.Component.extend({
         } else {
           const previewInputOffset = $(".d-editor-input").offset();
 
-          const pickerHeight = $(".emoji-picker").height();
+          const pickerHeight = $(".d-editor .emoji-picker").height();
           const editorHeight = $(".d-editor-input").height();
           const windowBottom = $(window).scrollTop() + $(window).height();
 


### PR DESCRIPTION
If an external plugin inserts an element with class "emoji-picker", something probable (and already happening) if they extend EmojiPicker, it could cause troubles as css is added depending on the emoji-picker height. Just by adding a class of a parent <div> as could be d-editor, we prevent this from happening.