### PR TITLE
UX: expand-post button alignment fix

### DIFF
--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -482,6 +482,7 @@ span.post-count {
 
 button.expand-post {
   margin-top: 10px;
+  margin-left: $topic-body-width-padding;
 }
 
 .quote-button.visible {


### PR DESCRIPTION
This PR improves the alignment of the "expand-post" button. 

The cooked content has some padding on desktop. The button does not have that, so we get something like this:

![expand-fix-0](https://user-images.githubusercontent.com/33972521/60786666-ee2c8f80-a189-11e9-89cc-513c636d3f1e.png)

The fix is to add the same amount of cooked padding (set via a variable) as margins to the button

![expand-fix-1](https://user-images.githubusercontent.com/33972521/60786691-06041380-a18a-11e9-9992-5664d49602c3.png)

This is a desktop only change since we don't add the padding on mobile. 


