### PR TITLE
FEATURE: show login and signup button on no-ember layout

### DIFF
--- a/app/assets/stylesheets/common/base/header.scss
+++ b/app/assets/stylesheets/common/base/header.scss
@@ -15,6 +15,23 @@
       display: flex;
       align-items: center;
       height: 100%;
+
+      .header-row {
+        width: 100%;
+
+        .logo-wrapper {
+          float: left;
+        }
+        .auth-buttons {
+          float: right;
+          margin-top: 0.4em;
+
+          .login-button,
+          .signup-button {
+            padding: 8px 14px;
+          }
+        }
+      }
     }
   }
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -501,4 +501,10 @@ module ApplicationHelper
     end
     absolute_url
   end
+
+  def can_sign_up?
+    SiteSetting.allow_new_registrations &&
+    !SiteSetting.invite_only &&
+    !SiteSetting.enable_sso
+  end
 end

--- a/app/views/application/_header.html.erb
+++ b/app/views/application/_header.html.erb
@@ -2,7 +2,7 @@
   <header class="d-header">
     <div class="wrap">
       <div class="contents">
-        <div class="row">
+        <div class="header-row">
           <div class="logo-wrapper">
             <a href="<%= path "/" %>">
               <%- if application_logo_url.present? %>
@@ -12,6 +12,14 @@
               <%- end %>
             </a>
           </div>
+          <%- unless current_user %>
+            <div class='auth-buttons'>
+              <%- if can_sign_up? %>
+                <a href="<%= path "/signup"%>" class='btn btn-primary btn-small signup-button'><%= I18n.t('sign_up') %></a>
+              <%- end %>
+              <a href="<%= path "/login"%>" class='btn btn-primary btn-small login-button'><%= I18n.t('log_in') %></a>
+            </div>
+          <%- end %>
         </div>
       </div>
     </div>

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -64,6 +64,7 @@ en:
   posts: "posts"
   loading: "Loading"
   powered_by_html: 'Powered by <a href="https://www.discourse.org">Discourse</a>, best viewed with JavaScript enabled'
+  sign_up: "Sign Up"
   log_in: "Log In"
   submit: "Submit"
   purge_reason: "Automatically deleted as abandoned, deactivated account"


### PR DESCRIPTION
This PR adds signup and login button to no-ember layout pages for anonymous users.

Feature requested here:

- https://meta.discourse.org/t/how-can-users-sign-up-for-or-log-into-the-forum-when-they-encounter-page-not-found/120945/5?u=techapj
- https://meta.discourse.org/t/missing-log-in-button-on-error-pages/110659/5?u=techapj

Demo:

<img width="1203" alt="Screen Shot 2019-07-08 at 16 32 51" src="https://user-images.githubusercontent.com/5732281/60805549-0f977680-a19e-11e9-8e31-f5f891ada2ed.png">
