### PR TITLE
FIX: ensures routing with hash doesn't stuck history

### DIFF
--- a/app/assets/javascripts/discourse/lib/discourse-location.js.es6
+++ b/app/assets/javascripts/discourse/lib/discourse-location.js.es6
@@ -101,7 +101,7 @@ const DiscourseLocation = Ember.Object.extend({
     const state = this.getState();
     path = this.formatURL(path);
 
-    if (state && state.path !== path) {
+    if (!state || (state && state.path !== path)) {
       this.replaceState(path);
     }
   },

--- a/app/assets/javascripts/discourse/lib/discourse-location.js.es6
+++ b/app/assets/javascripts/discourse/lib/discourse-location.js.es6
@@ -101,7 +101,7 @@ const DiscourseLocation = Ember.Object.extend({
     const state = this.getState();
     path = this.formatURL(path);
 
-    if (!state || (state && state.path !== path)) {
+    if (!state || state.path !== path) {
       this.replaceState(path);
     }
   },


### PR DESCRIPTION
Original issue: https://meta.discourse.org/t/hash-anchor-in-url-prevents-further-url-updates/122068/4

Basically when the path has a hash, state would be null, and nothing would happen.