### PR TITLE
FEATURE: send max 200 emails every minute for bulk invites

### DIFF
--- a/app/jobs/regular/invite_email.rb
+++ b/app/jobs/regular/invite_email.rb
@@ -15,8 +15,10 @@ module Jobs
 
       message = InviteMailer.send_invite(invite)
       Email::Sender.new(message, :invite).send
+
+      if invite.emailed_status != Invite.emailed_status_types[:not_required]
+        invite.update_column(:emailed_status, Invite.emailed_status_types[:sent])
+      end
     end
-
   end
-
 end

--- a/app/jobs/regular/process_bulk_invite_emails.rb
+++ b/app/jobs/regular/process_bulk_invite_emails.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require_dependency 'email/sender'
+
+module Jobs
+
+  class ProcessBulkInviteEmails < Jobs::Base
+
+    def execute(args)
+      pending_invite_ids = Invite.where(emailed_status: Invite.emailed_status_types[:bulk_pending]).limit(Invite::BULK_INVITE_EMAIL_LIMIT).pluck(:id)
+
+      if pending_invite_ids.length > 0
+        Invite.where(id: pending_invite_ids).update_all(emailed_status: Invite.emailed_status_types[:sending])
+        pending_invite_ids.each do |invite_id|
+          Jobs.enqueue(:invite_email, invite_id: invite_id)
+        end
+        Jobs.enqueue_in(1.minute, :process_bulk_invite_emails)
+      end
+    end
+  end
+end

--- a/app/models/invite_redeemer.rb
+++ b/app/models/invite_redeemer.rb
@@ -60,7 +60,7 @@ InviteRedeemer = Struct.new(:invite, :username, :name, :password, :user_custom_f
 
     user.save!
 
-    if invite.via_email
+    if invite.emailed_status != Invite.emailed_status_types[:not_required]
       user.email_tokens.create!(email: user.email)
       user.activate
     end

--- a/app/models/user_second_factor.rb
+++ b/app/models/user_second_factor.rb
@@ -44,6 +44,7 @@ end
 #  last_used  :datetime
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  name       :string
 #
 # Indexes
 #

--- a/db/migrate/20190711154946_add_emailed_status_to_invite.rb
+++ b/db/migrate/20190711154946_add_emailed_status_to_invite.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class AddEmailedStatusToInvite < ActiveRecord::Migration[5.2]
+  def change
+    add_column :invites, :emailed_status, :integer
+    add_index :invites, :emailed_status
+
+    DB.exec <<~SQL
+      UPDATE invites
+      SET emailed_status = 0
+      WHERE via_email = false
+    SQL
+  end
+end

--- a/db/post_migrate/20190716124050_remove_via_email_from_invite.rb
+++ b/db/post_migrate/20190716124050_remove_via_email_from_invite.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'migration/column_dropper'
+
+class RemoveViaEmailFromInvite < ActiveRecord::Migration[5.2]
+  def up
+    Migration::ColumnDropper.execute_drop(:invites, %i{via_email})
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/fabricators/invite_fabricator.rb
+++ b/spec/fabricators/invite_fabricator.rb
@@ -3,5 +3,4 @@
 Fabricator(:invite) do
   invited_by(fabricator: :user)
   email 'iceking@ADVENTURETIME.ooo'
-  via_email true
 end

--- a/spec/jobs/invite_email_spec.rb
+++ b/spec/jobs/invite_email_spec.rb
@@ -27,8 +27,15 @@ describe Jobs::InviteEmail do
         InviteMailer.expects(:send_invite).never
         Jobs::InviteEmail.new.execute(invite_id: invite.id)
       end
+
+      it "updates invite emailed_status" do
+        invite.emailed_status = Invite.emailed_status_types[:pending]
+        invite.save!
+        Jobs::InviteEmail.new.execute(invite_id: invite.id)
+
+        invite.reload
+        expect(invite.emailed_status).to eq(Invite.emailed_status_types[:sent])
+      end
     end
-
   end
-
 end

--- a/spec/jobs/process_bulk_invite_emails_spec.rb
+++ b/spec/jobs/process_bulk_invite_emails_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Jobs::ProcessBulkInviteEmails do
+  describe '#execute' do
+    it 'processes pending invites' do
+      invite = Fabricate(:invite, emailed_status: Invite.emailed_status_types[:bulk_pending])
+
+      described_class.new.execute({})
+
+      invite.reload
+      expect(invite.emailed_status).to eq(Invite.emailed_status_types[:sending])
+      expect(Jobs::InviteEmail.jobs.size).to eq(1)
+      expect(Jobs::ProcessBulkInviteEmails.jobs.size).to eq(1)
+    end
+  end
+end

--- a/spec/models/invite_redeemer_spec.rb
+++ b/spec/models/invite_redeemer_spec.rb
@@ -47,6 +47,15 @@ describe InviteRedeemer do
       expect(user.email).to eq('staged@account.com')
       expect(user.approved).to eq(true)
     end
+
+    it "should not activate user invited via links" do
+      user = InviteRedeemer.create_user_from_invite(Fabricate(:invite, email: 'walter.white@email.com', emailed_status: Invite.emailed_status_types[:not_required]), 'walter', 'Walter White')
+      expect(user.username).to eq('walter')
+      expect(user.name).to eq('Walter White')
+      expect(user.email).to eq('walter.white@email.com')
+      expect(user.approved).to eq(true)
+      expect(user.active).to eq(false)
+    end
   end
 
   describe "#redeem" do

--- a/spec/requests/invites_controller_spec.rb
+++ b/spec/requests/invites_controller_spec.rb
@@ -353,7 +353,7 @@ describe InvitesController do
 
           context "with password" do
             context "user was invited via email" do
-              before { invite.update_column(:via_email, true) }
+              before { invite.update_column(:emailed_status, Invite.emailed_status_types[:pending]) }
 
               it "doesn't send an activation email and activates the user" do
                 expect do
@@ -373,7 +373,7 @@ describe InvitesController do
             end
 
             context "user was invited via link" do
-              before { invite.update_column(:via_email, false) }
+              before { invite.update_column(:emailed_status, Invite.emailed_status_types[:not_required]) }
 
               it "sends an activation email and doesn't activate the user" do
                 expect do


### PR DESCRIPTION
DEV: deprecate `invite.via_email` in favor of `invite.emailed_status`

This commit adds a new column `emailed_status` in `invites` table for
 tracking email sending status.
 0 - not required
 1 - pending
 2 - bulk pending
 3 - sending
 4 - sent

For normal email invites, invite record is created with emailed_status
 set to 'pending'.

When bulk invites are sent invite record is created with emailed_status
 set to 'bulk pending'.

For invites that generates link, invite record is created with
 emailed_status set to 'not required'.

When invite email is in queue emailed_status is updated to 'sending'

Once the email is sent via `InviteEmail` job the invite emailed_status
 is updated to 'sent'.