### PR TITLE
FIX: ensures spinner is showing on tags/show when loading more

### DIFF
--- a/app/assets/javascripts/discourse/templates/tags/show.hbs
+++ b/app/assets/javascripts/discourse/templates/tags/show.hbs
@@ -52,32 +52,32 @@
   <div class="row">
     <div class="full-width">
       <div id='list-area'>
-      {{conditional-loading-spinner condition=loading}}
+        {{#unless loading}}
+          {{#if list.topics}}
+            {{#discovery-topics-list model=list refresh=(action "refresh")}}
+            {{bulk-select-button selected=selected action=(action "refresh")}}
 
-      {{#unless loading}}
-        {{#if list.topics}}
-          {{#discovery-topics-list model=list refresh=(action "refresh")}}
-          {{bulk-select-button selected=selected action=(action "refresh")}}
+            {{topic-list topics=list.topics
+                        canBulkSelect=canBulkSelect
+                        toggleBulkSelect=(action "toggleBulkSelect")
+                        bulkSelectEnabled=bulkSelectEnabled
+                        selected=selected
+                        showPosters=true
+                        order=order
+                        ascending=ascending
+                        changeSort=(action "changeSort")}}
 
-          {{topic-list topics=list.topics
-                      canBulkSelect=canBulkSelect
-                      toggleBulkSelect=(action "toggleBulkSelect")
-                      bulkSelectEnabled=bulkSelectEnabled
-                      selected=selected
-                      showPosters=true
-                      order=order
-                      ascending=ascending
-                      changeSort=(action "changeSort")}}
+            {{/discovery-topics-list}}
+          {{else}}
+            <footer class='topic-list-bottom'>
+              <h3>
+                {{footerMessage}}{{#link-to "discovery.categories"}} {{i18n 'topic.browse_all_categories'}}{{/link-to}} {{i18n 'or'}} {{#link-to 'discovery.latest'}}{{i18n 'topic.view_latest_topics'}}{{/link-to}}.
+              </h3>
+            </footer>
+          {{/if}}
+        {{/unless}}
 
-          {{/discovery-topics-list}}
-        {{else}}
-          <footer class='topic-list-bottom'>
-            <h3>
-              {{footerMessage}}{{#link-to "discovery.categories"}} {{i18n 'topic.browse_all_categories'}}{{/link-to}} {{i18n 'or'}} {{#link-to 'discovery.latest'}}{{i18n 'topic.view_latest_topics'}}{{/link-to}}.
-            </h3>
-          </footer>
-        {{/if}}
-      {{/unless}}
+        {{conditional-loading-spinner condition=list.loadingMore}}
       </div>
     </div>
   </div>


### PR DESCRIPTION
Context: https://meta.discourse.org/t/issue-while-scrolling-down-after-selecting-a-tag-on-the-home-page/122542