### PR TITLE
FIX: Turn off search logging when read-only

### DIFF
--- a/lib/search.rb
+++ b/lib/search.rb
@@ -213,7 +213,7 @@ class Search
 
   # Query a term
   def execute
-    if SiteSetting.log_search_queries? && @opts[:search_type].present?
+    if SiteSetting.log_search_queries? && @opts[:search_type].present? && !Discourse.readonly_mode?
       status, search_log_id = SearchLog.log(
         term: @term,
         search_type: @opts[:search_type],


### PR DESCRIPTION
If `SiteSetting.log_search_queries` is enabled 500 errors will occur
when searching if the master db is down. This fix allows searching to
still work under these conditions.