### PR TITLE
UX: Mobile editor style fixes

### DIFF
--- a/app/assets/stylesheets/common/admin/admin_base.scss
+++ b/app/assets/stylesheets/common/admin/admin_base.scss
@@ -221,7 +221,7 @@ $mobile-breakpoint: 700px;
     h3 {
       font-weight: normal;
       font-size: $font-0;
-      @include breakpoint(mobile) {
+      @include breakpoint(mobile-extra-large) {
         word-wrap: break-word;
       }
     }
@@ -233,7 +233,7 @@ $mobile-breakpoint: 700px;
       @include breakpoint(medium, min-width) {
         max-height: 100px;
       }
-      @include breakpoint(mobile) {
+      @include breakpoint(mobile-extra-large) {
         word-wrap: break-word;
       }
       color: $primary-medium;
@@ -248,7 +248,7 @@ $mobile-breakpoint: 700px;
     .title {
       margin-bottom: 1em;
     }
-    @include breakpoint(mobile) {
+    @include breakpoint(mobile-extra-large) {
       .title {
         word-wrap: break-word;
       }
@@ -535,7 +535,7 @@ $mobile-breakpoint: 700px;
     padding: 10px;
     display: flex;
     align-items: center;
-    @include breakpoint(mobile) {
+    @include breakpoint(mobile-extra-large) {
       margin: 0 -10px;
     }
     label {

--- a/app/assets/stylesheets/common/admin/admin_intro.scss
+++ b/app/assets/stylesheets/common/admin/admin_intro.scss
@@ -31,7 +31,7 @@
     margin-bottom: 5px;
   }
 
-  @include breakpoint(mobile) {
+  @include breakpoint(mobile-extra-large) {
     width: 100%;
     margin: 2em 0;
     .content-wrapper {

--- a/app/assets/stylesheets/common/admin/api.scss
+++ b/app/assets/stylesheets/common/admin/api.scss
@@ -31,7 +31,7 @@ table.web-hooks.grid {
       }
     }
   }
-  @include breakpoint(mobile) {
+  @include breakpoint(mobile-extra-large) {
     tbody {
       tr {
         grid-template-columns: 0.5fr 1fr;
@@ -159,7 +159,7 @@ table.api-keys {
 
     .hook-event {
       margin-bottom: 0.5em;
-      @include breakpoint(mobile) {
+      @include breakpoint(mobile-extra-large) {
         width: 100%;
       }
     }

--- a/app/assets/stylesheets/common/admin/backups.scss
+++ b/app/assets/stylesheets/common/admin/backups.scss
@@ -45,7 +45,7 @@ $rollback-darker: darken($rollback, 20%) !default;
         }
       }
     }
-    @include breakpoint(mobile) {
+    @include breakpoint(mobile-extra-large) {
       td.backup-filename {
         grid-column-start: 1;
         grid-column-end: 3;

--- a/app/assets/stylesheets/common/admin/plugins.scss
+++ b/app/assets/stylesheets/common/admin/plugins.scss
@@ -12,7 +12,7 @@
         grid-template-columns: 0.25fr repeat(4, 1fr);
       }
     }
-    @include breakpoint(mobile) {
+    @include breakpoint(mobile-extra-large) {
       tr {
         grid-template-columns: 0.25fr repeat(3, 1fr);
       }

--- a/app/assets/stylesheets/common/admin/staff_logs.scss
+++ b/app/assets/stylesheets/common/admin/staff_logs.scss
@@ -116,7 +116,7 @@
     }
   }
 
-  @include breakpoint(mobile) {
+  @include breakpoint(mobile-extra-large) {
     table.staff-logs tr {
       grid-template-columns: 1fr 1fr 0.5fr;
       td.staff-users {
@@ -433,7 +433,7 @@ table.search-logs-list {
       }
     }
   }
-  @include breakpoint(mobile) {
+  @include breakpoint(mobile-extra-large) {
     tr {
       td.term {
         grid-column-start: 1;

--- a/app/assets/stylesheets/common/base/cat_reorder.scss
+++ b/app/assets/stylesheets/common/base/cat_reorder.scss
@@ -6,7 +6,7 @@
   }
   input {
     width: 4em;
-    @include breakpoint(mobile) {
+    @include breakpoint(mobile-extra-large) {
       width: 2em;
     }
   }
@@ -22,7 +22,7 @@
   }
   .badge-wrapper span.badge-category {
     max-width: 20em;
-    @include breakpoint(mobile) {
+    @include breakpoint(mobile-extra-large) {
       max-width: 30vw;
     }
   }

--- a/app/assets/stylesheets/common/base/user-badges.scss
+++ b/app/assets/stylesheets/common/base/user-badges.scss
@@ -218,7 +218,7 @@
         margin-right: 0;
       }
     }
-    @include breakpoint(mobile) {
+    @include breakpoint(mobile-extra-large) {
       flex: 0 0 100%;
     }
     &:hover {

--- a/app/assets/stylesheets/common/base/user.scss
+++ b/app/assets/stylesheets/common/base/user.scss
@@ -552,7 +552,7 @@
       }
     }
     .select-kit.multi-select {
-      @include breakpoint(mobile) {
+      @include breakpoint(mobile-extra-large) {
         width: 100%;
       }
     }

--- a/app/assets/stylesheets/common/d-editor.scss
+++ b/app/assets/stylesheets/common/d-editor.scss
@@ -117,7 +117,7 @@
     margin: 0 5px;
     display: inline-block;
     border-left: 1px solid $primary-low-mid;
-    @include breakpoint(mobile) {
+    @include breakpoint(mobile-extra-large) {
       margin: 0 4px;
     }
   }

--- a/app/assets/stylesheets/common/d-editor.scss
+++ b/app/assets/stylesheets/common/d-editor.scss
@@ -265,41 +265,18 @@
 // everything in one place
 .d-editor-button-bar {
   margin: 0.25em;
-  // normal text size
-  .text-size-normal & {
-    .btn,
-    .btn-default {
-      padding: 0 0.5em;
-    }
 
-    .d-editor-spacer {
-      margin: 0 0.5em;
-    }
-
-    @include breakpoint(mobile-large) {
-      .btn,
-      .btn-default {
-        padding: 0 0.35em;
-        font-size: 0.96em;
-      }
-    }
-    @include breakpoint(mobile-medium) {
-      .d-editor-spacer {
-        margin: 0 0.25em;
-      }
-    }
+  // shared styles for all font sizes
+  .btn,
+  .btn-default {
+    padding: 0 0.5em;
   }
+  .d-editor-spacer {
+    margin: 0 0.25em;
+  }
+
   // small text size
   .text-size-smaller & {
-    .btn,
-    .btn-default {
-      padding: 0 0.5em;
-    }
-
-    .d-editor-spacer {
-      margin: 0 0.5em;
-    }
-
     @include breakpoint(mobile-large) {
       .btn,
       .btn-default {
@@ -316,22 +293,13 @@
       }
     }
   }
-  // larger text size
-  .text-size-larger & {
-    .btn,
-    .btn-default {
-      padding: 0 0.5em;
-      font-size: $font-down-1;
-    }
 
-    .d-editor-spacer {
-      margin: 0 0.25em;
-    }
-
+  // normal text size
+  .text-size-normal & {
     @include breakpoint(mobile-large) {
       .btn,
       .btn-default {
-        padding: 0 0.3em;
+        padding: 0 0.35em;
       }
     }
     @include breakpoint(mobile-medium) {
@@ -342,22 +310,33 @@
     }
   }
 
+  // larger text size
+  .text-size-larger & {
+    @include breakpoint(mobile-large) {
+      .btn,
+      .btn-default {
+        padding: 0 0.3em;
+      }
+    }
+    @include breakpoint(mobile-medium) {
+      .btn,
+      .btn-default {
+        padding: 0 0.2em;
+      }
+    }
+  }
+
   // largest text size
   .text-size-largest & {
     .btn,
     .btn-default {
-      padding: 0 0.5em;
       font-size: $font-down-1;
-    }
-
-    .d-editor-spacer {
-      margin: 0 0.2em;
     }
 
     @include breakpoint(mobile-large) {
       .btn,
       .btn-default {
-        padding: 0 0.25em;
+        padding: 0 0.3em;
       }
     }
     @include breakpoint(mobile-medium) {

--- a/app/assets/stylesheets/common/d-editor.scss
+++ b/app/assets/stylesheets/common/d-editor.scss
@@ -90,6 +90,17 @@
     @media all and (max-width: 800px) {
       padding: 5px;
     }
+    @include breakpoint(mobile-medium) {
+      padding: 4px;
+      font-size: 0.96em;
+    }
+    svg {
+      -webkit-transform: translate3d(
+        0,
+        0,
+        0
+      ); // Hack: Reduces composer icon jitter while scrolling in Safari on iOS12
+    }
   }
 
   .btn:not(.no-text) {

--- a/app/assets/stylesheets/common/d-editor.scss
+++ b/app/assets/stylesheets/common/d-editor.scss
@@ -87,12 +87,9 @@
     .d-icon {
       color: $primary-medium;
     }
-    @media all and (max-width: 800px) {
-      padding: 5px;
-    }
+
     @include breakpoint(mobile-medium) {
       padding: 4px;
-      font-size: 0.96em;
     }
     svg {
       -webkit-transform: translate3d(
@@ -114,13 +111,16 @@
   .btn.italic {
     font-style: italic;
   }
-}
 
-.d-editor-spacer {
-  height: 16px;
-  margin: 0 5px;
-  display: inline-block;
-  border-left: 1px solid $primary-low-mid;
+  .d-editor-spacer {
+    height: 1em;
+    margin: 0 5px;
+    display: inline-block;
+    border-left: 1px solid $primary-low-mid;
+    @include breakpoint(mobile) {
+      margin: 0 4px;
+    }
+  }
 }
 
 .d-editor-preview-wrapper {

--- a/app/assets/stylesheets/common/d-editor.scss
+++ b/app/assets/stylesheets/common/d-editor.scss
@@ -76,21 +76,16 @@
   display: flex;
   align-items: center;
   min-height: 30px;
-  padding-left: 3px;
   border-bottom: 1px solid $primary-low;
 
   .btn,
   .btn-default {
     background-color: transparent;
-    padding: 4px 8px;
     display: inline-block;
     .d-icon {
       color: $primary-medium;
     }
 
-    @include breakpoint(mobile-medium) {
-      padding: 4px;
-    }
     svg {
       -webkit-transform: translate3d(
         0,
@@ -98,6 +93,12 @@
         0
       ); // Hack: Reduces composer icon jitter while scrolling in Safari on iOS12
     }
+  }
+
+  .d-editor-spacer {
+    height: 1em;
+    display: inline-block;
+    border-left: 1px solid $primary-low-mid;
   }
 
   .btn:not(.no-text) {
@@ -110,16 +111,6 @@
 
   .btn.italic {
     font-style: italic;
-  }
-
-  .d-editor-spacer {
-    height: 1em;
-    margin: 0 5px;
-    display: inline-block;
-    border-left: 1px solid $primary-low-mid;
-    @include breakpoint(mobile-extra-large) {
-      margin: 0 4px;
-    }
   }
 }
 
@@ -191,9 +182,6 @@
   }
   .d-editor-textarea-wrapper {
     border: 1px solid $primary-low;
-  }
-  .d-editor-button-bar .btn {
-    padding: 6px 8px;
   }
   .d-editor-preview-wrapper {
     max-width: 100%;
@@ -271,4 +259,112 @@
 
 .mobile-view .d-editor-preview .image-wrapper .button-wrapper {
   opacity: 1;
+}
+
+// d-editor bar button sizing for all editors - this is kept seprate to keep
+// everything in one place
+.d-editor-button-bar {
+  margin: 0.25em;
+  // normal text size
+  .text-size-normal & {
+    .btn,
+    .btn-default {
+      padding: 0 0.5em;
+    }
+
+    .d-editor-spacer {
+      margin: 0 0.5em;
+    }
+
+    @include breakpoint(mobile-large) {
+      .btn,
+      .btn-default {
+        padding: 0 0.35em;
+        font-size: 0.96em;
+      }
+    }
+    @include breakpoint(mobile-medium) {
+      .d-editor-spacer {
+        margin: 0 0.25em;
+      }
+    }
+  }
+  // small text size
+  .text-size-smaller & {
+    .btn,
+    .btn-default {
+      padding: 0 0.5em;
+    }
+
+    .d-editor-spacer {
+      margin: 0 0.5em;
+    }
+
+    @include breakpoint(mobile-large) {
+      .btn,
+      .btn-default {
+        padding: 0 0.4em;
+      }
+    }
+    @include breakpoint(mobile-medium) {
+      .btn,
+      .btn-default {
+        padding: 0 0.3em;
+      }
+      .d-editor-spacer {
+        margin: 0 0.25em;
+      }
+    }
+  }
+  // larger text size
+  .text-size-larger & {
+    .btn,
+    .btn-default {
+      padding: 0 0.5em;
+      font-size: $font-down-1;
+    }
+
+    .d-editor-spacer {
+      margin: 0 0.25em;
+    }
+
+    @include breakpoint(mobile-large) {
+      .btn,
+      .btn-default {
+        padding: 0 0.3em;
+      }
+    }
+    @include breakpoint(mobile-medium) {
+      .btn,
+      .btn-default {
+        padding: 0 0.25em;
+      }
+    }
+  }
+
+  // largest text size
+  .text-size-largest & {
+    .btn,
+    .btn-default {
+      padding: 0 0.5em;
+      font-size: $font-down-1;
+    }
+
+    .d-editor-spacer {
+      margin: 0 0.2em;
+    }
+
+    @include breakpoint(mobile-large) {
+      .btn,
+      .btn-default {
+        padding: 0 0.25em;
+      }
+    }
+    @include breakpoint(mobile-medium) {
+      .btn,
+      .btn-default {
+        padding: 0 0.2em;
+      }
+    }
+  }
 }

--- a/app/assets/stylesheets/common/foundation/mixins.scss
+++ b/app/assets/stylesheets/common/foundation/mixins.scss
@@ -8,7 +8,8 @@
 $breakpoints: (
   mobile-small: 320px,
   mobile-medium: 350px,
-  mobile: 550px,
+  mobile-large: 450px,
+  mobile-extra-large: 550px,
   tablet: 768px,
   medium: 850px,
   large: 1000px,

--- a/app/assets/stylesheets/desktop/modal.scss
+++ b/app/assets/stylesheets/desktop/modal.scss
@@ -89,7 +89,7 @@
         max-width: 48%;
       }
 
-      @include breakpoint(mobile) {
+      @include breakpoint(mobile-extra-large) {
         flex: 1 1 auto;
         min-width: 49%;
         max-width: unset;

--- a/app/assets/stylesheets/mobile/compose.scss
+++ b/app/assets/stylesheets/mobile/compose.scss
@@ -29,6 +29,23 @@
     .reply-details {
       max-width: calc(100% - 75px);
     }
+
+    // Protection for languages with long strings on very small screens. This
+    // has no effect on most users but we need it for some cases. If this is
+    // not added, "add edit reason" will overlap with the composer controls
+    @include breakpoint(mobile-small) {
+      .reply-details {
+        flex-wrap: wrap;
+      }
+
+      .display-edit-reason {
+        margin-top: 0.5em;
+      }
+
+      .composer-controls {
+        align-self: flex-start;
+      }
+    }
   }
 
   .toggler {

--- a/app/assets/stylesheets/mobile/compose.scss
+++ b/app/assets/stylesheets/mobile/compose.scss
@@ -141,17 +141,6 @@
   }
 
   .d-editor-button-bar .btn {
-    svg {
-      -webkit-transform: translate3d(
-        0,
-        0,
-        0
-      ); // Hack: Reduces composer icon jitter while scrolling in Safari on iOS12
-    }
-    @include breakpoint(mobile-medium) {
-      padding: 4px;
-      font-size: 0.96em;
-    }
     &.preview {
       margin: 0;
     }


### PR DESCRIPTION
Context: https://meta.discourse.org/t/interface-problems-portugues-brazil/122511

(there's more than one issue reported in the topic, this PR only deals with the composer issues)

This PR fixes the following issues:
1. editor toolbar buttons overflowing in the group / bio about editor on small screens

2. adds protection for languages with long string to prevent `add edit reason` from overlapping with the composer controls on very narrow screens.

Notable changes: 
1. moves some of the styles for the composer toolbar to a more general stylesheet. The reason why we had overflow in the group / bio composer but not in the topic / post composer is because issue is fixed in the topic / post composer but the selector specificity prevented the fix from applying to the group / bio composer.

2. improves the responsiveness of the toolbar buttons for all types of composers for all the different font sizes we support (smaller, normal, larger, largest) on all screen sizes all the way to `320px` wide.

3. adds a new mobile breakpoint `mobile-large: 450px` that respects our naming conventions. This required updating the old `mobile: 550px` breakpoint and renaming it to `mobile-extra-large`. The PR updates all the occurrences where we used this old breakpoint to the new name - **no visual changes at all**. I've also made sure this won't effect any of the official plugins

    Before and after screenshots are not the most ideal way to illustrate the changes (4 sets of font sizes 
    with 3 breakpoints) so here's a couple of tables that indicate the click target for the toolbar buttons 
    before and after the changes - all units are in `px`. The left column represents the screen size. The top 
    row represents the font-size selected in the user's preferences. The data in between is the respective 
    touch target size for each toolbar button. 

    Before (Note that there was overflow issues in some cases here)

    |      	| smaller 	| normal 	| larger 	| largest 	|
    |:----:	|:-------:	|:------:	|:------:	|:-------:	|
    | >450 	|  24*30  	|  25*30 	|  27*30 	|  29*30  	|
    | <350 	|  21*30  	|  22*30 	|  24*30 	|  29*30  	|

    After (no overflow in any of the samples - also note the new breakpoint)

    |      	| smaller 	| normal 	| larger 	| largest 	|
    |:----:	|:-------:	|:------:	|:------:	|:-------:	|
    | >450 	|  28*30  	|  30*30 	|  34*30 	|  33*30  	|
    | <450 	|  25*30  	|  25*30 	|  27*30 	|  26*30  	|
    | <350 	|  22*30  	|  22*30 	|  24*30 	|  23*30  	|

    _A quick note about the discrepancy where the click target for the largest font-size is slightly smaller             
    than the larger font: This occurs because the we use `font-down-1` on the icons for the largest font     
    since the icons would be huge otherwise._

    There's still a few cases where the click target is less than 25px wide, which is not ideal. However, this             
    is as far as we can go with button sizing / padding while continuing to support iOS 10. The only way to increase the click targets any 
    further is to remove some of the buttons on mobile and add them to the composer popup menu. 

    **Note:** The samples above were taken with the `mixed-text-direction` setting enabled, that means 
    there's an additional button that's added to the toolbar that wouldn't be there on a default install. 
    However, we don't have any option but to factor that in, otherwise the toolbar will have overflow issues 
    for anyone with the setting enabled.

4. Finally, this PR moves all the toolbar button sizing styles to one place to make changing them a bit easier in the future. 

I can include screenshots of all the different states if needed. I'm skipping those because there's a lot of different cases and because this PR doesn't really introduced any notable visual changes to the buttons. 




