### PR TITLE
FEATURE: Allow customization of robots.txt

### DIFF
--- a/app/assets/javascripts/admin/controllers/admin-customize-robots-txt.js.es6
+++ b/app/assets/javascripts/admin/controllers/admin-customize-robots-txt.js.es6
@@ -1,4 +1,3 @@
-import computed from "ember-addons/ember-computed-decorators";
 import { ajax } from "discourse/lib/ajax";
 import { bufferedProperty } from "discourse/mixins/buffered-content";
 import { propertyEqual } from "discourse/lib/computed";

--- a/app/assets/javascripts/admin/controllers/admin-customize-robots-txt.js.es6
+++ b/app/assets/javascripts/admin/controllers/admin-customize-robots-txt.js.es6
@@ -1,0 +1,47 @@
+import computed from "ember-addons/ember-computed-decorators";
+import { ajax } from "discourse/lib/ajax";
+import { popupAjaxError } from "discourse/lib/ajax-error";
+
+export default Ember.Controller.extend({
+  saved: false,
+  isSaving: false,
+  buffer: null,
+
+  @computed("buffer", "model.content")
+  saveDisabled(buffer, orig) {
+    return buffer === orig;
+  },
+
+  @computed("model.overridden")
+  revertDisbaled(overridden) {
+    return !overridden;
+  },
+
+  actions: {
+    save(content = this.buffer) {
+      this.setProperties({
+        isSaving: true,
+        saved: false
+      });
+
+      ajax("robots.json", {
+        method: "PUT",
+        data: { content }
+      })
+        .then(model => {
+          this.setProperties({
+            saved: true,
+            model: model,
+            buffer: model.content
+          });
+        })
+        .finally(() => {
+          this.set("isSaving", false);
+        });
+    },
+
+    revert() {
+      this.send("save", "");
+    }
+  }
+});

--- a/app/assets/javascripts/admin/controllers/admin-customize-robots-txt.js.es6
+++ b/app/assets/javascripts/admin/controllers/admin-customize-robots-txt.js.es6
@@ -1,6 +1,5 @@
 import computed from "ember-addons/ember-computed-decorators";
 import { ajax } from "discourse/lib/ajax";
-import { popupAjaxError } from "discourse/lib/ajax-error";
 
 export default Ember.Controller.extend({
   saved: false,
@@ -12,7 +11,7 @@ export default Ember.Controller.extend({
     return buffer === orig;
   },
 
-  revertDisbaled: Ember.computed.not("model.overridden"),
+  resetDisbaled: Ember.computed.not("model.overridden"),
 
   actions: {
     save(content = this.buffer) {
@@ -37,7 +36,7 @@ export default Ember.Controller.extend({
         });
     },
 
-    revert() {
+    reset() {
       this.send("save", "");
     }
   }

--- a/app/assets/javascripts/admin/controllers/admin-customize-robots-txt.js.es6
+++ b/app/assets/javascripts/admin/controllers/admin-customize-robots-txt.js.es6
@@ -12,10 +12,7 @@ export default Ember.Controller.extend({
     return buffer === orig;
   },
 
-  @computed("model.overridden")
-  revertDisbaled(overridden) {
-    return !overridden;
-  },
+  revertDisbaled: Ember.computed.not("model.overridden"),
 
   actions: {
     save(content = this.buffer) {

--- a/app/assets/javascripts/admin/routes/admin-customize-robots-txt.js.es6
+++ b/app/assets/javascripts/admin/routes/admin-customize-robots-txt.js.es6
@@ -1,0 +1,12 @@
+import { ajax } from "discourse/lib/ajax";
+
+export default Ember.Route.extend({
+  model() {
+    return ajax("/admin/customize/robots");
+  },
+
+  setupController(controller, model) {
+    this._super(...arguments);
+    controller.set("buffer", model.content);
+  }
+});

--- a/app/assets/javascripts/admin/routes/admin-customize-robots-txt.js.es6
+++ b/app/assets/javascripts/admin/routes/admin-customize-robots-txt.js.es6
@@ -3,10 +3,5 @@ import { ajax } from "discourse/lib/ajax";
 export default Ember.Route.extend({
   model() {
     return ajax("/admin/customize/robots");
-  },
-
-  setupController(controller, model) {
-    this._super(...arguments);
-    controller.set("buffer", model.content);
   }
 });

--- a/app/assets/javascripts/admin/routes/admin-route-map.js.es6
+++ b/app/assets/javascripts/admin/routes/admin-route-map.js.es6
@@ -86,6 +86,10 @@ export default function() {
             this.route("edit", { path: "/:id" });
           }
         );
+        this.route("adminCustomizeRobotsTxt", {
+          path: "/robots",
+          resetNamespace: true
+        });
       }
     );
 

--- a/app/assets/javascripts/admin/templates/customize-robots-txt.hbs
+++ b/app/assets/javascripts/admin/templates/customize-robots-txt.hbs
@@ -1,5 +1,6 @@
 <div class="robots-txt-edit">
   <h3>{{i18n "admin.customize.robots.title"}}</h3>
+  <p>{{i18n "admin.customize.robots.warning"}}</p>
   {{#if model.overridden}}
     <div class="overridden">
       {{i18n "admin.customize.robots.overridden"}}
@@ -11,9 +12,10 @@
     rows=30}}
   {{#save-controls model=this action=(action "save") saved=saved saveDisabled=saveDisabled}}
     {{d-button
-      class="btn-normal"
-      disabled=revertDisbaled
-      action=(action "revert")
-      label="admin.customize.robots.revert"}}
+      class="btn-default"
+      disabled=resetDisbaled
+      icon="undo"
+      action=(action "reset")
+      label="admin.settings.reset"}}
   {{/save-controls}}
 </div>

--- a/app/assets/javascripts/admin/templates/customize-robots-txt.hbs
+++ b/app/assets/javascripts/admin/templates/customize-robots-txt.hbs
@@ -7,9 +7,8 @@
     </div>
   {{/if}}
   {{textarea
-    value=buffer
-    class="robots-txt-input"
-    rows=30}}
+    value=buffered.robots_txt
+    class="robots-txt-input"}}
   {{#save-controls model=this action=(action "save") saved=saved saveDisabled=saveDisabled}}
     {{d-button
       class="btn-default"

--- a/app/assets/javascripts/admin/templates/customize-robots-txt.hbs
+++ b/app/assets/javascripts/admin/templates/customize-robots-txt.hbs
@@ -1,0 +1,19 @@
+<div class="robots-txt-edit">
+  <h3>{{i18n "admin.customize.robots.title"}}</h3>
+  {{#if model.overridden}}
+    <div class="overridden">
+      {{i18n "admin.customize.robots.overridden"}}
+    </div>
+  {{/if}}
+  {{textarea
+    value=buffer
+    class="robots-txt-input"
+    rows=30}}
+  {{#save-controls model=this action=(action "save") saved=saved saveDisabled=saveDisabled}}
+    {{d-button
+      class="btn-normal"
+      disabled=revertDisbaled
+      action=(action "revert")
+      label="admin.customize.robots.revert"}}
+  {{/save-controls}}
+</div>

--- a/app/assets/stylesheets/common/admin/customize.scss
+++ b/app/assets/stylesheets/common/admin/customize.scss
@@ -787,5 +787,6 @@
   .robots-txt-input {
     width: 100%;
     box-sizing: border-box;
+    height: 600px;
   }
 }

--- a/app/assets/stylesheets/common/admin/customize.scss
+++ b/app/assets/stylesheets/common/admin/customize.scss
@@ -777,3 +777,15 @@
     margin-left: 1em;
   }
 }
+
+.robots-txt-edit {
+  div.overridden {
+    background: $highlight-medium;
+    padding: 7px;
+    margin-bottom: 7px;
+  }
+  .robots-txt-input {
+    width: 100%;
+    box-sizing: border-box;
+  }
+}

--- a/app/controllers/admin/robots_txt_controller.rb
+++ b/app/controllers/admin/robots_txt_controller.rb
@@ -3,27 +3,33 @@
 class Admin::RobotsTxtController < Admin::AdminController
 
   def show
-    render json: { content: current_robots_txt, overridden: @overridden }
+    render json: { robots_txt: current_robots_txt, overridden: @overridden }
   end
 
   def update
-    SiteSetting.overridden_robots_txt = params[:content]&.strip
+    params.require(:robots_txt)
+    SiteSetting.overridden_robots_txt = params[:robots_txt]
 
-    render json: { content: current_robots_txt, overridden: @overridden }
+    render json: { robots_txt: current_robots_txt, overridden: @overridden }
+  end
+
+  def reset
+    SiteSetting.overridden_robots_txt = ""
+    render json: { robots_txt: original_robots_txt, overridden: false }
   end
 
   private
 
   def current_robots_txt
-    content = SiteSetting.overridden_robots_txt.presence
-    @overridden = content.present?
-    content ||= original_robots_txt
-    content
+    robots_txt = SiteSetting.overridden_robots_txt.presence
+    @overridden = robots_txt.present?
+    robots_txt ||= original_robots_txt
+    robots_txt
   end
 
   def original_robots_txt
     if SiteSetting.allow_index_in_robots_txt?
-      @robots_info = ::RobotsTxtController.fetch_robots_info
+      @robots_info = ::RobotsTxtController.fetch_default_robots_info
       render_to_string "robots_txt/index"
     else
       render_to_string "robots_txt/no_index"

--- a/app/controllers/admin/robots_txt_controller.rb
+++ b/app/controllers/admin/robots_txt_controller.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class Admin::RobotsTxtController < Admin::AdminController
+
+  def show
+    render json: { content: current_robots_txt, overridden: @overridden }
+  end
+
+  def update
+    SiteSetting.overridden_robots_txt = params[:content]&.strip
+
+    render json: { content: current_robots_txt, overridden: @overridden }
+  end
+
+  private
+
+  def current_robots_txt
+    content = SiteSetting.overridden_robots_txt.presence
+    @overridden = content.present?
+    content ||= original_robots_txt
+    content
+  end
+
+  def original_robots_txt
+    if SiteSetting.allow_index_in_robots_txt?
+      @robots_info = ::RobotsTxtController.fetch_robots_info
+      render_to_string "robots_txt/index"
+    else
+      render_to_string "robots_txt/no_index"
+    end
+  end
+end

--- a/app/controllers/robots_txt_controller.rb
+++ b/app/controllers/robots_txt_controller.rb
@@ -4,6 +4,8 @@ class RobotsTxtController < ApplicationController
   layout false
   skip_before_action :preload_json, :check_xhr, :redirect_to_login_if_required
 
+  OVERRIDDEN_HEADER = "# This robots.txt file has been customized at /admin/customize/robots\n"
+
   # NOTE: order is important!
   DISALLOWED_PATHS ||= %w{
     /auth/
@@ -33,12 +35,13 @@ class RobotsTxtController < ApplicationController
   }
 
   def index
-    if SiteSetting.overridden_robots_txt.present?
-      render plain: SiteSetting.overridden_robots_txt
+    if (overridden = SiteSetting.overridden_robots_txt.dup).present?
+      overridden.prepend(OVERRIDDEN_HEADER) if guardian.is_admin? && !is_api?
+      render plain: overridden
       return
     end
     if SiteSetting.allow_index_in_robots_txt?
-      @robots_info = self.class.fetch_robots_info
+      @robots_info = self.class.fetch_default_robots_info
       render :index, content_type: 'text/plain'
     else
       render :no_index, content_type: 'text/plain'
@@ -50,13 +53,13 @@ class RobotsTxtController < ApplicationController
   # JSON that can be used by a script to create a robots.txt that works well with your
   # existing site.
   def builder
-    result = self.class.fetch_robots_info
+    result = self.class.fetch_default_robots_info
     overridden = SiteSetting.overridden_robots_txt
     result[:overridden] = overridden if overridden.present?
     render json: result
   end
 
-  def self.fetch_robots_info
+  def self.fetch_default_robots_info
     deny_paths = DISALLOWED_PATHS.map { |p| Discourse.base_uri + p }
     deny_all = [ "#{Discourse.base_uri}/" ]
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3622,7 +3622,10 @@ en:
           love:
             name: "love"
             description: "The like button's color."
-
+        robots:
+          title: "Customize your site's robots.txt file:"
+          overridden: Your site's robots.txt file has been modified.
+          revert: Revert Changes
       email:
         title: "Emails"
         settings: "Settings"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3623,9 +3623,9 @@ en:
             name: "love"
             description: "The like button's color."
         robots:
-          title: "Customize your site's robots.txt file:"
-          overridden: Your site's robots.txt file has been modified.
-          revert: Revert Changes
+          title: "Override your site's robots.txt file:"
+          warning: "Warning: overriding the robots.txt file will prevent all future changes to the site settings that modify robots.txt from being applied."
+          overridden: Your site's robots.txt file is overridden.
       email:
         title: "Emails"
         settings: "Settings"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3625,7 +3625,7 @@ en:
         robots:
           title: "Override your site's robots.txt file:"
           warning: "Warning: overriding the robots.txt file will prevent all future changes to the site settings that modify robots.txt from being applied."
-          overridden: Your site's robots.txt file is overridden.
+          overridden: Your site's default robots.txt file is overridden.
       email:
         title: "Emails"
         settings: "Settings"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -238,6 +238,7 @@ Discourse::Application.routes.draw do
 
       get 'robots' => 'robots_txt#show'
       put 'robots.json' => 'robots_txt#update'
+      delete 'robots.json' => 'robots_txt#reset'
     end
 
     resources :embeddable_hosts, constraints: AdminConstraint.new

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -235,6 +235,9 @@ Discourse::Application.routes.draw do
       get 'email_templates/(:id)'    => 'email_templates#show',   constraints: { id: /[0-9a-z_.]+/ }
       put 'email_templates/(:id)'    => 'email_templates#update', constraints: { id: /[0-9a-z_.]+/ }
       delete 'email_templates/(:id)' => 'email_templates#revert', constraints: { id: /[0-9a-z_.]+/ }
+
+      get 'robots' => 'robots_txt#show'
+      put 'robots.json' => 'robots_txt#update'
     end
 
     resources :embeddable_hosts, constraints: AdminConstraint.new

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1920,6 +1920,10 @@ uncategorized:
     default: 50000
     hidden: true
 
+  overridden_robots_txt:
+    default: ""
+    hidden: true
+
 user_preferences:
   default_email_digest_frequency:
     enum: "DigestEmailSiteSetting"

--- a/spec/requests/admin/robots_txt_controller_spec.rb
+++ b/spec/requests/admin/robots_txt_controller_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Admin::RobotsTxtController do
+  it "is a subclass of AdminController" do
+    expect(described_class < Admin::AdminController).to eq(true)
+  end
+
+  fab!(:admin) { Fabricate(:admin) }
+  fab!(:user) { Fabricate(:user) }
+
+  describe "non-admin users" do
+    before { sign_in(user) }
+
+    it "can't see #show" do
+      get "/admin/customize/robots.json"
+      expect(response.status).to eq(404)
+    end
+
+    it "can't see #update" do
+      put "/admin/customize/robots.json", params: { content: "adasdasd" }
+      expect(response.status).to eq(404)
+      expect(SiteSetting.overridden_robots_txt).to eq("")
+    end
+  end
+
+  describe "#show" do
+    before { sign_in(admin) }
+
+    it "returns default content is there are no overrides" do
+      get "/admin/customize/robots.json"
+      expect(response.status).to eq(200)
+      json = JSON.parse(response.body)
+      expect(json["content"]).to be_present
+      expect(json["overridden"]).to eq(false)
+    end
+
+    it "returns overridden content if there are overrides" do
+      SiteSetting.overridden_robots_txt = "something"
+      get "/admin/customize/robots.json"
+      expect(response.status).to eq(200)
+      json = JSON.parse(response.body)
+      expect(json["content"]).to eq("something")
+      expect(json["overridden"]).to eq(true)
+    end
+  end
+
+  describe "#update" do
+    before { sign_in(admin) }
+
+    it "overrides the site's default robots.txt" do
+      put "/admin/customize/robots.json", params: { content: "new_content" }
+      expect(response.status).to eq(200)
+      json = JSON.parse(response.body)
+      expect(json["content"]).to eq("new_content")
+      expect(json["overridden"]).to eq(true)
+      expect(SiteSetting.overridden_robots_txt).to eq("new_content")
+
+      get "/robots.txt"
+      expect(response.body).to eq("new_content")
+    end
+
+    it "allows reverting changes" do
+      SiteSetting.overridden_robots_txt = "overridden_content"
+      put "/admin/customize/robots.json", params: { content: "" }
+      expect(response.status).to eq(200)
+      json = JSON.parse(response.body)
+      expect(json["content"]).not_to eq("overridden_content")
+      expect(json["overridden"]).to eq(false)
+      expect(SiteSetting.overridden_robots_txt).to eq("")
+
+      get "/robots.txt"
+      expect(response.body).not_to eq("overridden_content")
+    end
+  end
+end

--- a/spec/requests/admin/robots_txt_controller_spec.rb
+++ b/spec/requests/admin/robots_txt_controller_spec.rb
@@ -18,21 +18,28 @@ describe Admin::RobotsTxtController do
       expect(response.status).to eq(404)
     end
 
-    it "can't see #update" do
-      put "/admin/customize/robots.json", params: { content: "adasdasd" }
+    it "can't perform #update" do
+      put "/admin/customize/robots.json", params: { robots_txt: "adasdasd" }
       expect(response.status).to eq(404)
       expect(SiteSetting.overridden_robots_txt).to eq("")
+    end
+
+    it "can't perform #reset" do
+      SiteSetting.overridden_robots_txt = "overridden_content"
+      delete "/admin/customize/robots.json"
+      expect(response.status).to eq(404)
+      expect(SiteSetting.overridden_robots_txt).to eq("overridden_content")
     end
   end
 
   describe "#show" do
     before { sign_in(admin) }
 
-    it "returns default content is there are no overrides" do
+    it "returns default content if there are no overrides" do
       get "/admin/customize/robots.json"
       expect(response.status).to eq(200)
       json = JSON.parse(response.body)
-      expect(json["content"]).to be_present
+      expect(json["robots_txt"]).to be_present
       expect(json["overridden"]).to eq(false)
     end
 
@@ -41,7 +48,7 @@ describe Admin::RobotsTxtController do
       get "/admin/customize/robots.json"
       expect(response.status).to eq(200)
       json = JSON.parse(response.body)
-      expect(json["content"]).to eq("something")
+      expect(json["robots_txt"]).to eq("something")
       expect(json["overridden"]).to eq(true)
     end
   end
@@ -50,28 +57,35 @@ describe Admin::RobotsTxtController do
     before { sign_in(admin) }
 
     it "overrides the site's default robots.txt" do
-      put "/admin/customize/robots.json", params: { content: "new_content" }
+      put "/admin/customize/robots.json", params: { robots_txt: "new_content" }
       expect(response.status).to eq(200)
       json = JSON.parse(response.body)
-      expect(json["content"]).to eq("new_content")
+      expect(json["robots_txt"]).to eq("new_content")
       expect(json["overridden"]).to eq(true)
       expect(SiteSetting.overridden_robots_txt).to eq("new_content")
 
       get "/robots.txt"
-      expect(response.body).to eq("new_content")
+      expect(response.body).to include("new_content")
     end
 
-    it "allows reverting changes" do
+    it "requires `robots_txt` param to be present" do
       SiteSetting.overridden_robots_txt = "overridden_content"
-      put "/admin/customize/robots.json", params: { content: "" }
+      put "/admin/customize/robots.json", params: { robots_txt: "" }
+      expect(response.status).to eq(400)
+    end
+  end
+
+  describe "#reset" do
+    before { sign_in(admin) }
+
+    it "resets robots.txt file to the default version" do
+      SiteSetting.overridden_robots_txt = "overridden_content"
+      delete "/admin/customize/robots.json"
       expect(response.status).to eq(200)
       json = JSON.parse(response.body)
-      expect(json["content"]).not_to eq("overridden_content")
+      expect(json["robots_txt"]).not_to include("overridden_content")
       expect(json["overridden"]).to eq(false)
       expect(SiteSetting.overridden_robots_txt).to eq("")
-
-      get "/robots.txt"
-      expect(response.body).not_to eq("overridden_content")
     end
   end
 end

--- a/spec/requests/robots_txt_controller_spec.rb
+++ b/spec/requests/robots_txt_controller_spec.rb
@@ -26,6 +26,27 @@ RSpec.describe RobotsTxtController do
 
   describe '#index' do
 
+    context "header for when the content is overridden" do
+      it "is not prepended if there are no overrides" do
+        sign_in(Fabricate(:admin))
+        get '/robots.txt'
+        expect(response.body).not_to start_with(RobotsTxtController::OVERRIDDEN_HEADER)
+      end
+
+      it "is prepended if there are overrides and the user is admin" do
+        SiteSetting.overridden_robots_txt = "overridden_content"
+        sign_in(Fabricate(:admin))
+        get '/robots.txt'
+        expect(response.body).to start_with(RobotsTxtController::OVERRIDDEN_HEADER)
+      end
+
+      it "is not prepended if the user is not admin" do
+        SiteSetting.overridden_robots_txt = "overridden_content"
+        get '/robots.txt'
+        expect(response.body).not_to start_with(RobotsTxtController::OVERRIDDEN_HEADER)
+      end
+    end
+
     context 'subfolder' do
       it 'prefixes the rules with the directory' do
         Discourse.stubs(:base_uri).returns('/forum')

--- a/spec/requests/robots_txt_controller_spec.rb
+++ b/spec/requests/robots_txt_controller_spec.rb
@@ -11,6 +11,17 @@ RSpec.describe RobotsTxtController do
       expect(json['header']).to be_present
       expect(json['agents']).to be_present
     end
+
+    it "includes overridden content if robots.txt is is overridden" do
+      SiteSetting.overridden_robots_txt = "something"
+
+      get "/robots-builder.json"
+      expect(response.status).to eq(200)
+      json = ::JSON.parse(response.body)
+      expect(json['header']).to be_present
+      expect(json['agents']).to be_present
+      expect(json['overridden']).to eq("something")
+    end
   end
 
   describe '#index' do
@@ -100,6 +111,13 @@ RSpec.describe RobotsTxtController do
       get '/robots.txt'
 
       expect(response.body).to_not include("Disallow: /u/")
+    end
+
+    it "returns overridden robots.txt if the file is overridden" do
+      SiteSetting.overridden_robots_txt = "blah whatever"
+      get '/robots.txt'
+      expect(response.status).to eq(200)
+      expect(response.body).to eq(SiteSetting.overridden_robots_txt)
     end
   end
 end


### PR DESCRIPTION
This allows admins to customize/override the content of the robots.txt
file at /admin/customize/robots. That page is not linked to anywhere in
the UI -- admins have to manually type the URL to access that page.

Meta topic: https://meta.discourse.org/t/needing-to-edit-robots-txt-file-where-is-it/93879?u=osama

Screenshots:

![image](https://user-images.githubusercontent.com/17474474/61083151-b5174800-a433-11e9-890e-283221046b2b.png)

![image](https://user-images.githubusercontent.com/17474474/61083312-16d7b200-a434-11e9-9cae-dc3a9982c049.png)

@eviltrout does it make sense to prepend a comment to robots.txt that says something along the lines of "this robots.txt file has been customized at /admin/customize/robots" **if** the file is customized? It might help with figuring out why certain things are in the file and how to remove/change them?