### PR TITLE
add limit to custom field ordering

### DIFF
--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -631,7 +631,7 @@ class TopicQuery
 
     if sort_column.start_with?('custom_fields')
       field = sort_column.split('.')[1]
-      return result.order("(SELECT CASE WHEN EXISTS (SELECT true FROM topic_custom_fields tcf WHERE tcf.topic_id::integer = topics.id::integer AND tcf.name = '#{field}') THEN (SELECT value::integer FROM topic_custom_fields tcf WHERE tcf.topic_id::integer = topics.id::integer AND tcf.name = '#{field}') ELSE 0 END) #{sort_dir}")
+      return result.order("(SELECT CASE WHEN EXISTS (SELECT true FROM topic_custom_fields tcf WHERE tcf.topic_id::integer = topics.id::integer AND tcf.name = '#{field}' LIMIT 1) THEN (SELECT value::integer FROM topic_custom_fields tcf WHERE tcf.topic_id::integer = topics.id::integer AND tcf.name = '#{field}' LIMIT 1) ELSE 0 END) #{sort_dir}")
     end
 
     result.order("topics.#{sort_column} #{sort_dir}")


### PR DESCRIPTION
While not likely, it is possible to end up with two rows in a custom field table with the same related id.

See further: https://meta.discourse.org/t/custom-field-casting-affected-by-recent-update/122746

For example: https://discourse.angusmcleod.com.au/t/events-code-error-500/1254/4

The data will look something like this.

``topic_custom_fields``

| id  | topic_id | name | value |
| ------------- | ------------- | ------------- | ------------- |
| 9180 | 62 | event_start | 1563100201 |
| 9179  | 62  | event_start | 1563100201 |

In most respects this eventuality can be handled in a plugin, however there is one place where this causes a cardinality issue that can't be handled in a plugin: ordering by the custom field in a ``TopicQuery``.

This PR adds a LIMIT to the custom field ordering statement in ``TopicQuery`` to handle that eventuality. 

