### PR TITLE
FIX: Rename deprecated icons, allow custom icons in badges

### DIFF
--- a/app/assets/javascripts/admin/components/admin-web-hook-status.js.es6
+++ b/app/assets/javascripts/admin/components/admin-web-hook-status.js.es6
@@ -5,7 +5,7 @@ import { bufferedRender } from "discourse-common/lib/buffered-render";
 export default Ember.Component.extend(
   bufferedRender({
     classes: ["text-muted", "text-danger", "text-successful", "text-muted"],
-    icons: ["circle-o", "times-circle", "circle", "circle"],
+    icons: ["far-circle", "times-circle", "circle", "circle"],
 
     @computed("deliveryStatuses", "model.last_delivery_status")
     status(deliveryStatuses, lastDeliveryStatus) {

--- a/app/assets/javascripts/admin/templates/customize-colors-show.hbs
+++ b/app/assets/javascripts/admin/templates/customize-colors-show.hbs
@@ -6,7 +6,7 @@
       <button {{action "save"}} disabled={{model.disableSave}} class='btn btn-primary'>{{i18n 'admin.customize.save'}}</button>
       {{/unless}}
       <button {{action "copy" model}} class='btn btn-default'>{{d-icon "copy"}} {{i18n 'admin.customize.copy'}}</button>
-      <button {{action "copyToClipboard" model}} class='btn btn-default'>{{d-icon "clipboard"}} {{i18n 'admin.customize.copy_to_clipboard'}}</button>
+      <button {{action "copyToClipboard" model}} class='btn btn-default'>{{d-icon "far-clipboard"}} {{i18n 'admin.customize.copy_to_clipboard'}}</button>
       {{#if model.theme_id}}
       {{i18n "admin.customize.theme_owner"}}
       {{#link-to "adminCustomizeThemes.show" model.theme_id}}{{model.theme_name}}{{/link-to}}

--- a/app/assets/javascripts/admin/templates/web-hooks.hbs
+++ b/app/assets/javascripts/admin/templates/web-hooks.hbs
@@ -25,7 +25,7 @@
             <td class='description'>{{webHook.description}}</td>
             <td class='controls'>
               {{#link-to 'adminWebHooks.show' webHook tagName='button' classNames='btn btn-default no-text'}}{{d-icon 'far-edit'}}{{/link-to}}
-              {{d-button class="destroy btn-danger" action=(action "destroy") actionParam=webHook icon="remove"}}
+              {{d-button class="destroy btn-danger" action=(action "destroy") actionParam=webHook icon="times"}}
             </td>
           </tr>
         {{/each}}

--- a/app/assets/javascripts/discourse/helpers/icon-or-image.js.es6
+++ b/app/assets/javascripts/discourse/helpers/icon-or-image.js.es6
@@ -6,7 +6,7 @@ export default htmlHelper(function({ icon, image }) {
     return `<img src='${image}'>`;
   }
 
-  if (Ember.isEmpty(icon) || icon.indexOf("fa-") < 0) {
+  if (Ember.isEmpty(icon)) {
     return "";
   }
 

--- a/app/assets/javascripts/discourse/models/composer.js.es6
+++ b/app/assets/javascripts/discourse/models/composer.js.es6
@@ -69,11 +69,11 @@ export const SAVE_LABELS = {
 
 export const SAVE_ICONS = {
   [EDIT]: "pencil-alt",
-  [EDIT_SHARED_DRAFT]: "clipboard",
+  [EDIT_SHARED_DRAFT]: "far-clipboard",
   [REPLY]: "reply",
   [CREATE_TOPIC]: "plus",
   [PRIVATE_MESSAGE]: "envelope",
-  [CREATE_SHARED_DRAFT]: "clipboard"
+  [CREATE_SHARED_DRAFT]: "far-clipboard"
 };
 
 const Composer = RestModel.extend({

--- a/app/assets/javascripts/discourse/templates/about.hbs
+++ b/app/assets/javascripts/discourse/templates/about.hbs
@@ -58,7 +58,7 @@
                     args=(hash model=model)}}
 
       <section class='about stats'>
-        <h3>{{d-icon "bar-chart"}}  {{i18n 'about.stats'}}</h3>
+        <h3>{{d-icon "far-chart-bar"}}  {{i18n 'about.stats'}}</h3>
 
         <table class='table'>
           <tr>

--- a/app/assets/javascripts/discourse/templates/components/shared-draft-controls.hbs
+++ b/app/assets/javascripts/discourse/templates/components/shared-draft-controls.hbs
@@ -17,7 +17,7 @@
           action=(action "publish")
           label="shared_drafts.publish"
           class="btn-primary publish-shared-draft"
-          icon="clipboard"}}
+          icon="far-clipboard"}}
       {{/if}}
     </div>
   {{/if}}

--- a/app/assets/javascripts/discourse/widgets/post-admin-menu.js.es6
+++ b/app/assets/javascripts/discourse/widgets/post-admin-menu.js.es6
@@ -107,14 +107,14 @@ export function buildManageButtons(attrs, currentUser, siteSettings) {
       contents.push({
         action: "toggleWiki",
         label: "post.controls.unwiki",
-        icon: "pencil-square-o",
+        icon: "far-edit",
         className: "btn-default wiki wikied"
       });
     } else {
       contents.push({
         action: "toggleWiki",
         label: "post.controls.wiki",
-        icon: "pencil-square-o",
+        icon: "far-edit",
         className: "btn-default wiki"
       });
     }

--- a/app/assets/javascripts/discourse/widgets/post-edits-indicator.js.es6
+++ b/app/assets/javascripts/discourse/widgets/post-edits-indicator.js.es6
@@ -40,7 +40,7 @@ export default createWidget("post-edits-indicator", {
     let title;
 
     if (attrs.wiki) {
-      icon = "pencil-square-o";
+      icon = "far-edit";
       className = `${className || ""} wiki`.trim();
 
       if (attrs.version > 1) {

--- a/app/assets/javascripts/discourse/widgets/post-menu.js.es6
+++ b/app/assets/javascripts/discourse/widgets/post-menu.js.es6
@@ -178,7 +178,7 @@ registerButton("wiki-edit", attrs => {
       action: "editPost",
       className: "edit create",
       title: "post.controls.edit",
-      icon: "pencil-square-o",
+      icon: "far-edit",
       alwaysShowYours: true
     };
     if (!attrs.mobileView) {

--- a/app/assets/javascripts/select-kit/components/composer-actions.js.es6
+++ b/app/assets/javascripts/select-kit/components/composer-actions.js.es6
@@ -67,7 +67,7 @@ export default DropdownSelectBoxComponent.extend({
         content.title = I18n.t("composer.composer_actions.edit");
         break;
       case CREATE_SHARED_DRAFT:
-        content.icon = "clipboard";
+        content.icon = "far-clipboard";
         content.title = I18n.t("composer.composer_actions.draft");
         break;
     }
@@ -167,7 +167,7 @@ export default DropdownSelectBoxComponent.extend({
         items.push({
           name: I18n.t("composer.composer_actions.shared_draft.label"),
           description: I18n.t("composer.composer_actions.shared_draft.desc"),
-          icon: "clipboard",
+          icon: "far-clipboard",
           id: "shared_draft"
         });
       }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4240,7 +4240,7 @@ en:
         enabled: Enable badge
         icon: Icon
         image: Image
-        icon_help: "Use a Font Awesome class"
+        icon_help: "Enter a Font Awesome icon name (use prefix 'far-' for regular icons and 'fab-' for brand icons)"
         image_help: "Enter the URL of the image (overrides icon field if both are set)"
         query: Badge Query (SQL)
         target_posts: Query targets posts

--- a/db/fixtures/006_badges.rb
+++ b/db/fixtures/006_badges.rb
@@ -270,7 +270,7 @@ end
 Badge.seed do |b|
   b.id = Badge::Anniversary
   b.name = "Anniversary"
-  b.default_icon = "fa-clock-o"
+  b.default_icon = "far-clock"
   b.badge_type_id = BadgeType::Silver
   b.default_badge_grouping_id = BadgeGrouping::Community
   b.query = nil
@@ -427,7 +427,7 @@ end
   Badge.seed do |b|
     b.id = id
     b.name = name
-    b.default_icon = "fa-eye"
+    b.default_icon = "far-eye"
     b.badge_type_id = level
     b.query = BadgeQueries.consecutive_visits(days)
     b.default_badge_grouping_id = BadgeGrouping::Community

--- a/db/migrate/20190716014949_rename_deprecated_badge_icons.rb
+++ b/db/migrate/20190716014949_rename_deprecated_badge_icons.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class RenameDeprecatedBadgeIcons < ActiveRecord::Migration[5.2]
+  def up
+    execute "UPDATE badges SET icon = 'far-clock' WHERE icon = 'fa-clock-o'"
+    execute "UPDATE badges SET icon = 'far-eye' WHERE icon = 'fa-eye'"
+  end
+
+  def down
+  end
+end

--- a/test/javascripts/fixtures/user_fixtures.js.es6
+++ b/test/javascripts/fixtures/user_fixtures.js.es6
@@ -246,7 +246,7 @@ export default {
           browser: "Google Chrome",
           device: "Linux Computer",
           os: "Linux",
-          icon: "linux",
+          icon: "fab-linux",
           created_at: "2018-09-08T21:22:56.225Z",
           seen_at: "2018-09-08T21:22:56.512Z",
           is_active: false
@@ -258,7 +258,7 @@ export default {
           browser: "Google Chrome",
           device: "Linux Computer",
           os: "Linux",
-          icon: "linux",
+          icon: "fab-linux",
           created_at: "2018-09-08T21:33:41.616Z",
           seen_at: "2018-09-08T21:33:42.209Z",
           is_active: true
@@ -270,7 +270,7 @@ export default {
           browser: "Internet Explorer",
           device: "Windows Computer",
           os: "Windows",
-          icon: "windows",
+          icon: "fab-windows",
           created_at: "2018-09-07T21:44:41.616Z",
           seen_at: "2018-09-08T21:44:42.209Z",
           is_active: false

--- a/test/javascripts/widgets/topic-status-test.js.es6
+++ b/test/javascripts/widgets/topic-status-test.js.es6
@@ -21,7 +21,7 @@ widgetTest("extendability", {
   beforeEach(store) {
     TopicStatusIcons.addObject([
       "has_accepted_answer",
-      "check-square-o",
+      "far-check-square",
       "solved"
     ]);
     this.set("args", {
@@ -32,6 +32,6 @@ widgetTest("extendability", {
     });
   },
   test(assert) {
-    assert.ok(find(".topic-status .d-icon-check-square-o").length);
+    assert.ok(find(".topic-status .d-icon-far-check-square").length);
   }
 });


### PR DESCRIPTION
- adds a migration renaming FA4 icon names in badges
- allows all icons to be used in badges (previously was limited to icons prefixed with `fa-`)
- renames remaining FA 4.7 icons to FA5 equivalents