### PR TITLE
UX: Disable system edit notifications by default

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1835,7 +1835,7 @@ uncategorized:
     hidden: true
     default: true
 
-  disable_edit_notifications: false
+  disable_edit_notifications: true
 
   likes_notification_consolidation_threshold:
     default: 3


### PR DESCRIPTION
Enabling this setting prevents notifications when the system downloads hotlinked images. This stops an onslaught of notifications when old posts are rebaked. It does not affect regular edit notifications