### PR TITLE
Watched words improvements

### DIFF
--- a/app/assets/javascripts/admin/components/watched-word-uploader.js.es6
+++ b/app/assets/javascripts/admin/components/watched-word-uploader.js.es6
@@ -2,13 +2,13 @@ import computed from "ember-addons/ember-computed-decorators";
 import UploadMixin from "discourse/mixins/upload";
 
 export default Ember.Component.extend(UploadMixin, {
-  type: "csv",
+  type: "txt",
   classNames: "watched-words-uploader",
   uploadUrl: "/admin/logs/watched_words/upload",
   addDisabled: Ember.computed.alias("uploading"),
 
   validateUploadedFilesOptions() {
-    return { csvOnly: true };
+    return { skipValidation: true };
   },
 
   @computed("actionKey")

--- a/app/assets/javascripts/admin/controllers/admin-watched-words-action.js.es6
+++ b/app/assets/javascripts/admin/controllers/admin-watched-words-action.js.es6
@@ -37,6 +37,11 @@ export default Ember.Controller.extend({
     return a ? a.words.length : 0;
   },
 
+  @computed("actionNameKey")
+  downloadLink(type) {
+    return `/admin/logs/watched_words/action/${type}/download`;
+  },
+
   actions: {
     recordAdded(arg) {
       const a = this.findAction(this.actionNameKey);

--- a/app/assets/javascripts/admin/controllers/admin-watched-words-action.js.es6
+++ b/app/assets/javascripts/admin/controllers/admin-watched-words-action.js.es6
@@ -87,12 +87,9 @@ export default Ember.Controller.extend({
         I18n.t("yes_value"),
         result => {
           if (result) {
-            ajax(
-              `/admin/logs/watched_words/action/${actionKey}.json`,
-              {
-                method: "DELETE"
-              }
-            ).then(() => {
+            ajax(`/admin/logs/watched_words/action/${actionKey}.json`, {
+              method: "DELETE"
+            }).then(() => {
               const action = this.findAction(actionKey);
               if (action) {
                 action.setProperties({

--- a/app/assets/javascripts/admin/controllers/admin-watched-words-action.js.es6
+++ b/app/assets/javascripts/admin/controllers/admin-watched-words-action.js.es6
@@ -1,6 +1,7 @@
 import computed from "ember-addons/ember-computed-decorators";
 import WatchedWord from "admin/models/watched-word";
 import { ajax } from "discourse/lib/ajax";
+import { fmt } from "discourse/lib/computed";
 
 export default Ember.Controller.extend({
   actionNameKey: null,
@@ -8,6 +9,10 @@ export default Ember.Controller.extend({
   showWordsList: Ember.computed.or(
     "adminWatchedWords.filtered",
     "adminWatchedWords.showWords"
+  ),
+  downloadLink: fmt(
+    "actionNameKey",
+    "/admin/logs/watched_words/action/%@/download"
   ),
 
   findAction(actionName) {
@@ -35,11 +40,6 @@ export default Ember.Controller.extend({
   @computed("currentAction.count")
   wordCount(count) {
     return count || 0;
-  },
-
-  @computed("actionNameKey")
-  downloadLink(type) {
-    return `/admin/logs/watched_words/action/${type}/download`;
   },
 
   actions: {

--- a/app/assets/javascripts/admin/controllers/admin-watched-words-action.js.es6
+++ b/app/assets/javascripts/admin/controllers/admin-watched-words-action.js.es6
@@ -88,7 +88,7 @@ export default Ember.Controller.extend({
         result => {
           if (result) {
             ajax(
-              `/admin/logs/watched_words/action/${actionKey}/clear_all.json`,
+              `/admin/logs/watched_words/action/${actionKey}.json`,
               {
                 method: "DELETE"
               }

--- a/app/assets/javascripts/admin/templates/components/watched-word-uploader.hbs
+++ b/app/assets/javascripts/admin/templates/components/watched-word-uploader.hbs
@@ -1,7 +1,7 @@
 <label class="btn btn-default {{if addDisabled 'disabled'}}">
   {{d-icon "upload"}}
   {{i18n 'admin.watched_words.form.upload'}}
-  <input class="hidden-upload-field" disabled={{addDisabled}} type="file" accept="text/plain,text/csv" />
+  <input class="hidden-upload-field" disabled={{addDisabled}} type="file" accept=".csv" />
 </label>
 <br/>
 <span class="instructions">{{i18n 'admin.watched_words.one_word_per_line'}}</span>

--- a/app/assets/javascripts/admin/templates/components/watched-word-uploader.hbs
+++ b/app/assets/javascripts/admin/templates/components/watched-word-uploader.hbs
@@ -3,5 +3,4 @@
   {{i18n 'admin.watched_words.form.upload'}}
   <input class="hidden-upload-field" disabled={{addDisabled}} type="file" accept=".csv" />
 </label>
-<br/>
 <span class="instructions">{{i18n 'admin.watched_words.one_word_per_line'}}</span>

--- a/app/assets/javascripts/admin/templates/components/watched-word-uploader.hbs
+++ b/app/assets/javascripts/admin/templates/components/watched-word-uploader.hbs
@@ -1,6 +1,6 @@
 <label class="btn btn-default {{if addDisabled 'disabled'}}">
   {{d-icon "upload"}}
   {{i18n 'admin.watched_words.form.upload'}}
-  <input class="hidden-upload-field" disabled={{addDisabled}} type="file" accept=".csv" />
+  <input class="hidden-upload-field" disabled={{addDisabled}} type="file" accept="text/plain" />
 </label>
 <span class="instructions">{{i18n 'admin.watched_words.one_word_per_line'}}</span>

--- a/app/assets/javascripts/admin/templates/watched-words-action.hbs
+++ b/app/assets/javascripts/admin/templates/watched-words-action.hbs
@@ -16,8 +16,8 @@
   </a>
 </div>
 {{watched-word-uploader uploading=uploading actionKey=actionNameKey done=(action "uploadComplete")}}
-
 </div>
+
 <div>
   <label class="show-words-checkbox">
     {{input type="checkbox" checked=adminWatchedWords.showWords disabled=adminWatchedWords.disableShowWords}}
@@ -32,4 +32,12 @@
   {{else}}
     {{i18n 'admin.watched_words.word_count' count=wordCount}}
   {{/if}}
+</div>
+
+<div class="clear-all-row">
+  {{d-button
+    class="btn btn-danger clear-all"
+    label="admin.watched_words.clear_all"
+    icon="trash"
+    action=(action "clearAll")}}
 </div>

--- a/app/assets/javascripts/admin/templates/watched-words-action.hbs
+++ b/app/assets/javascripts/admin/templates/watched-words-action.hbs
@@ -11,10 +11,11 @@
 
   <div class="download-upload-controls">
     <div class="download">
-      <a class="btn btn-default download-link" target="_blank" href={{downloadLink}}>
-        {{d-icon "download"}}
-        {{i18n "admin.watched_words.download"}}
-      </a>
+      {{d-button
+        class="btn-default download-link"
+        href=downloadLink
+        icon="download"
+        label="admin.watched_words.download"}}
     </div>
     {{watched-word-uploader uploading=uploading actionKey=actionNameKey done=(action "uploadComplete")}}
   </div>

--- a/app/assets/javascripts/admin/templates/watched-words-action.hbs
+++ b/app/assets/javascripts/admin/templates/watched-words-action.hbs
@@ -36,8 +36,8 @@
 
 <div class="clear-all-row">
   {{d-button
-    class="btn btn-danger clear-all"
+    class="btn-danger clear-all"
     label="admin.watched_words.clear_all"
-    icon="trash"
+    icon="trash-alt"
     action=(action "clearAll")}}
 </div>

--- a/app/assets/javascripts/admin/templates/watched-words-action.hbs
+++ b/app/assets/javascripts/admin/templates/watched-words-action.hbs
@@ -3,19 +3,21 @@
 <p class="about">{{actionDescription}}</p>
 
 <div class="watched-word-controls">
-{{watched-word-form
-  actionKey=actionNameKey
-  action=(action "recordAdded")
-  filteredContent=filteredContent
-  regularExpressions=adminWatchedWords.regularExpressions}}
+  {{watched-word-form
+    actionKey=actionNameKey
+    action=(action "recordAdded")
+    filteredContent=filteredContent
+    regularExpressions=adminWatchedWords.regularExpressions}}
 
-<div class="download">
-  <a class="btn btn-default download-link" target="_blank" href={{downloadLink}}>
-    {{d-icon "download"}}
-    {{i18n "admin.watched_words.download"}}
-  </a>
-</div>
-{{watched-word-uploader uploading=uploading actionKey=actionNameKey done=(action "uploadComplete")}}
+  <div class="download-upload-controls">
+    <div class="download">
+      <a class="btn btn-default download-link" target="_blank" href={{downloadLink}}>
+        {{d-icon "download"}}
+        {{i18n "admin.watched_words.download"}}
+      </a>
+    </div>
+    {{watched-word-uploader uploading=uploading actionKey=actionNameKey done=(action "uploadComplete")}}
+  </div>
 </div>
 
 <div>

--- a/app/assets/javascripts/admin/templates/watched-words-action.hbs
+++ b/app/assets/javascripts/admin/templates/watched-words-action.hbs
@@ -9,7 +9,14 @@
   filteredContent=filteredContent
   regularExpressions=adminWatchedWords.regularExpressions}}
 
+<div class="download">
+  <a class="btn btn-default download-link" target="_blank" href={{downloadLink}}>
+    {{d-icon "download"}}
+    {{i18n "admin.watched_words.download"}}
+  </a>
+</div>
 {{watched-word-uploader uploading=uploading actionKey=actionNameKey done=(action "uploadComplete")}}
+
 </div>
 <div>
   <label class="show-words-checkbox">

--- a/app/assets/javascripts/discourse/lib/url.js.es6
+++ b/app/assets/javascripts/discourse/lib/url.js.es6
@@ -23,7 +23,8 @@ const SERVER_SIDE_ONLY = [
   /\.rss$/,
   /\.json$/,
   /^\/admin\/upgrade$/,
-  /^\/logs($|\/)/
+  /^\/logs($|\/)/,
+  /^\/admin\/logs\/watched_words\/action\/[^\/]+\/download$/
 ];
 
 export function rewritePath(path) {

--- a/app/assets/stylesheets/common/admin/staff_logs.scss
+++ b/app/assets/stylesheets/common/admin/staff_logs.scss
@@ -369,6 +369,12 @@ table.screened-ip-addresses {
   display: flex;
   flex-wrap: wrap;
   margin-bottom: 1em;
+  .download {
+    margin-left: auto;
+    .download-link {
+      min-height: 30px;
+    }
+  }
 }
 
 .watched-words-list {
@@ -395,13 +401,18 @@ table.screened-ip-addresses {
 }
 
 .watched-words-uploader {
-  margin-left: auto;
+  margin-left: 7px;
   @media screen and (max-width: 500px) {
     flex: 1 1 100%;
     margin-top: 0.5em;
   }
+  label.btn {
+    float: right;
+  }
   .instructions {
     font-size: $font-down-1;
+    margin-top: 5px;
+    float: right;
   }
 }
 

--- a/app/assets/stylesheets/common/admin/staff_logs.scss
+++ b/app/assets/stylesheets/common/admin/staff_logs.scss
@@ -383,9 +383,6 @@ table.screened-ip-addresses {
   }
   .download {
     justify-content: flex-end;
-    .download-link {
-      min-height: 30px;
-    }
   }
 }
 

--- a/app/assets/stylesheets/common/admin/staff_logs.scss
+++ b/app/assets/stylesheets/common/admin/staff_logs.scss
@@ -362,17 +362,13 @@ table.screened-ip-addresses {
   display: inline-block;
   width: 250px;
   margin-bottom: 1em;
-  float: left;
 }
 
 .admin-watched-words {
   .clear-all-row {
     display: flex;
     margin-top: 10px;
-
-    .btn.clear-all {
-      margin-left: auto;
-    }
+    justify-content: flex-end;
   }
 }
 
@@ -380,8 +376,12 @@ table.screened-ip-addresses {
   display: flex;
   flex-wrap: wrap;
   margin-bottom: 1em;
+  justify-content: space-between;
+  .download-upload-controls {
+    display: flex;
+  }
   .download {
-    margin-left: auto;
+    justify-content: flex-end;
     .download-link {
       min-height: 30px;
     }
@@ -414,17 +414,16 @@ table.screened-ip-addresses {
 
 .watched-words-uploader {
   margin-left: 5px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
   @media screen and (max-width: 500px) {
     flex: 1 1 100%;
     margin-top: 0.5em;
   }
-  label.btn {
-    float: right;
-  }
   .instructions {
     font-size: $font-down-1;
     margin-top: 5px;
-    float: right;
   }
 }
 

--- a/app/assets/stylesheets/common/admin/staff_logs.scss
+++ b/app/assets/stylesheets/common/admin/staff_logs.scss
@@ -362,6 +362,7 @@ table.screened-ip-addresses {
   display: inline-block;
   width: 250px;
   margin-bottom: 1em;
+  vertical-align: top;
 }
 
 .admin-watched-words {

--- a/app/assets/stylesheets/common/admin/staff_logs.scss
+++ b/app/assets/stylesheets/common/admin/staff_logs.scss
@@ -413,7 +413,7 @@ table.screened-ip-addresses {
 }
 
 .watched-words-uploader {
-  margin-left: 7px;
+  margin-left: 5px;
   @media screen and (max-width: 500px) {
     flex: 1 1 100%;
     margin-top: 0.5em;

--- a/app/assets/stylesheets/common/admin/staff_logs.scss
+++ b/app/assets/stylesheets/common/admin/staff_logs.scss
@@ -365,6 +365,17 @@ table.screened-ip-addresses {
   float: left;
 }
 
+.admin-watched-words {
+  .clear-all-row {
+    display: flex;
+    margin-top: 10px;
+
+    .btn.clear-all {
+      margin-left: auto;
+    }
+  }
+}
+
 .watched-word-controls {
   display: flex;
   flex-wrap: wrap;
@@ -379,6 +390,7 @@ table.screened-ip-addresses {
 
 .watched-words-list {
   margin-top: 20px;
+  display: inline-block;
 }
 
 .watched-word {

--- a/app/controllers/admin/watched_words_controller.rb
+++ b/app/controllers/admin/watched_words_controller.rb
@@ -62,6 +62,7 @@ class Admin::WatchedWordsController < Admin::AdminController
     raise Discourse::NotFound if !action
 
     WatchedWord.where(action: action).delete_all
+    WordWatcher.clear_cache!
     render json: success_json
   end
 

--- a/app/controllers/admin/watched_words_controller.rb
+++ b/app/controllers/admin/watched_words_controller.rb
@@ -36,7 +36,7 @@ class Admin::WatchedWordsController < Admin::AdminController
       rescue => e
         data = failed_json.merge(errors: [e.message])
       end
-      MessageBus.publish("/uploads/csv", data.as_json, client_ids: [params[:client_id]])
+      MessageBus.publish("/uploads/txt", data.as_json, client_ids: [params[:client_id]])
     end
 
     render json: success_json

--- a/app/controllers/admin/watched_words_controller.rb
+++ b/app/controllers/admin/watched_words_controller.rb
@@ -51,8 +51,8 @@ class Admin::WatchedWordsController < Admin::AdminController
     content = WatchedWord.where(action: action).pluck(:word).join("\n")
     headers['Content-Length'] = content.bytesize.to_s
     send_data content,
-      filename: "#{Discourse.current_hostname}-watched-words-#{name}.csv",
-      content_type: "text/csv"
+      filename: "#{Discourse.current_hostname}-watched-words-#{name}.txt",
+      content_type: "text/plain"
   end
 
   def clear_all

--- a/app/controllers/admin/watched_words_controller.rb
+++ b/app/controllers/admin/watched_words_controller.rb
@@ -51,8 +51,18 @@ class Admin::WatchedWordsController < Admin::AdminController
     content = WatchedWord.where(action: action).pluck(:word).join("\n")
     headers['Content-Length'] = content.bytesize.to_s
     send_data content,
-      filename: "#{Discourse.current_hostname}-watched-words-#{name}.txt",
-      content_type: "text/plain"
+      filename: "#{Discourse.current_hostname}-watched-words-#{name}.csv",
+      content_type: "text/csv"
+  end
+
+  def clear_all
+    params.require(:id)
+    name = watched_words_params[:id].to_sym
+    action = WatchedWord.actions[name]
+    raise Discourse::NotFound if !action
+
+    WatchedWord.where(action: action).delete_all
+    render json: success_json
   end
 
   private

--- a/app/controllers/export_csv_controller.rb
+++ b/app/controllers/export_csv_controller.rb
@@ -12,6 +12,7 @@ class ExportCsvController < ApplicationController
   end
 
   private
+
   def export_params
     @_export_params ||= begin
       params.require(:entity)

--- a/app/services/word_watcher.rb
+++ b/app/services/word_watcher.rb
@@ -74,21 +74,22 @@ class WordWatcher
       match = regexp.match(@raw)
       return match if !all_matches || !match
 
-      matches = []
       if SiteSetting.watched_words_regular_expressions?
+        set = Set.new
         @raw.scan(regexp).each do |m|
           if Array === m
-            matches << m.find(&:present?)
+            set.add(m.find(&:present?))
           elsif String === m
-            matches << m
+            set.add(m)
           end
         end
+        matches = set.to_a
       else
         matches = @raw.scan(regexp)
+        matches.flatten!
+        matches.uniq!
       end
-      matches.flatten!
       matches.compact!
-      matches.uniq!
       matches.sort!
       matches
     else

--- a/app/services/word_watcher.rb
+++ b/app/services/word_watcher.rb
@@ -14,17 +14,20 @@ class WordWatcher
     WatchedWord.where(action: WatchedWord.actions[action.to_sym]).exists?
   end
 
-  def self.word_matcher_regexp(action)
-    s = Discourse.cache.fetch(word_matcher_regexp_key(action), expires_in: 1.day) do
-      words = words_for_action(action)
-      if words.empty?
-        nil
-      else
-        regexp = '(' + words.map { |w| word_to_regexp(w) }.join('|'.freeze) + ')'
-        SiteSetting.watched_words_regular_expressions? ? regexp : "(?<!\\w)(#{regexp})(?!\\w)"
-      end
+  def self.get_cached_words(action)
+    Discourse.cache.fetch(word_matcher_regexp_key(action), expires_in: 1.day) do
+      words_for_action(action).presence
     end
-    s.present? ? Regexp.new(s, Regexp::IGNORECASE) : nil
+  end
+
+  def self.word_matcher_regexp(action)
+    words = get_cached_words(action)
+    if words
+      words = words.map { |w| word_to_regexp(w) }
+      regexp = "(#{words.join('|')})"
+      regexp = "(?<!\\w)(#{regexp})(?!\\w)" if !SiteSetting.watched_words_regular_expressions?
+      Regexp.new(regexp, Regexp::IGNORECASE)
+    end
   end
 
   def self.word_to_regexp(word)
@@ -37,7 +40,7 @@ class WordWatcher
   end
 
   def self.word_matcher_regexp_key(action)
-    "watched-words-regexp:#{action}"
+    "watched-words-list:#{action}"
   end
 
   def self.clear_cache!
@@ -54,13 +57,29 @@ class WordWatcher
     word_matches_for_action?(:flag)
   end
 
-  def should_block?
-    word_matches_for_action?(:block)
+  def should_block?(all_matches: false)
+    word_matches_for_action?(:block, all_matches: all_matches)
   end
 
-  def word_matches_for_action?(action)
-    r = self.class.word_matcher_regexp(action)
-    r ? r.match(@raw) : false
+  def word_matches_for_action?(action, all_matches: false)
+    regexp = self.class.word_matcher_regexp(action)
+    if regexp
+      match = regexp.match(@raw)
+      return match if !all_matches || !match
+      matches = []
+      regexps = self.class.get_cached_words(action).map do |w|
+        word = self.class.word_to_regexp(w)
+        word = "(?<!\\w)(#{word})(?!\\w)" if !SiteSetting.watched_words_regular_expressions?
+        Regexp.new(word, Regexp::IGNORECASE)
+      end
+      regexps.each do |reg|
+        if result = reg.match(@raw)
+          matches << result[0] if matches.exclude?(result[0])
+        end
+      end
+      matches.sort
+    else
+      false
+    end
   end
-
 end

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3900,7 +3900,6 @@ en:
           exists: "Already exists"
           upload: "Add from file"
           upload_successful: "Upload successful. Words have been added."
-          one_word_per_line: One word per line
 
       impersonate:
         title: "Impersonate"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3873,6 +3873,11 @@ en:
         show_words: "show words"
         one_word_per_line: "One word per line"
         download: Download
+        clear_all: Clear All
+        clear_all_confirm_block: "Are you sure you want to clear all watched words for the Block action?"
+        clear_all_confirm_censor: "Are you sure you want to clear all watched words for the Censor action?"
+        clear_all_confirm_flag: "Are you sure you want to clear all watched words for the Flag action?"
+        clear_all_confirm_require_approval: "Are you sure you want to clear all watched words for the Require Approval action?"
         word_count:
           one: "%{count} word"
           other: "%{count} words"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3892,7 +3892,7 @@ en:
           add: "Add"
           success: "Success"
           exists: "Already exists"
-          upload: "Upload"
+          upload: "Add from file"
           upload_successful: "Upload successful. Words have been added."
 
       impersonate:

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3872,6 +3872,7 @@ en:
         clear_filter: "Clear"
         show_words: "show words"
         one_word_per_line: "One word per line"
+        download: Download
         word_count:
           one: "%{count} word"
           other: "%{count} words"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3894,6 +3894,7 @@ en:
           exists: "Already exists"
           upload: "Add from file"
           upload_successful: "Upload successful. Words have been added."
+          one_word_per_line: One word per line
 
       impersonate:
         title: "Impersonate"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -303,7 +303,8 @@ en:
   too_many_links:
     one: "Sorry, new users can only put one link in a post."
     other: "Sorry, new users can only put %{count} links in a post."
-  contains_blocked_words: "Your post contains a word that's not allowed: %{word}"
+  contains_blocked_word: "Your post contains a word that's not allowed: %{word}"
+  contains_blocked_words: "Your post contains multiple words that aren't allowed: %{words}"
 
   spamming_host: "Sorry you cannot post a link to that host."
   user_is_suspended: "Suspended users are not allowed to post."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -178,7 +178,7 @@ Discourse::Application.routes.draw do
         collection do
           get "action/:id" => "watched_words#index"
           get "action/:id/download" => "watched_words#download"
-          delete "action/:id/clear_all" => "watched_words#clear_all"
+          delete "action/:id" => "watched_words#clear_all"
         end
       end
       post "watched_words/upload" => "watched_words#upload"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -177,6 +177,7 @@ Discourse::Application.routes.draw do
       resources :watched_words, only: [:index, :create, :update, :destroy] do
         collection do
           get "action/:id" => "watched_words#index"
+          get "action/:id/download" => "watched_words#download"
         end
       end
       post "watched_words/upload" => "watched_words#upload"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -178,6 +178,7 @@ Discourse::Application.routes.draw do
         collection do
           get "action/:id" => "watched_words#index"
           get "action/:id/download" => "watched_words#download"
+          delete "action/:id/clear_all" => "watched_words#clear_all"
         end
       end
       post "watched_words/upload" => "watched_words#upload"

--- a/lib/new_post_manager.rb
+++ b/lib/new_post_manager.rb
@@ -172,9 +172,16 @@ class NewPostManager
   end
 
   def perform
-    if !self.class.exempt_user?(@user) && matches = WordWatcher.new("#{@args[:title]} #{@args[:raw]}").should_block?
+    if !self.class.exempt_user?(@user) && matches = WordWatcher.new("#{@args[:title]} #{@args[:raw]}").should_block?(all_matches: true).presence
       result = NewPostResult.new(:created_post, false)
-      result.errors.add(:base, I18n.t('contains_blocked_words', word: matches[0]))
+      if matches.size == 1
+        key = 'contains_blocked_word'
+        translation_args = { word: matches[0] }
+      else
+        key = 'contains_blocked_words'
+        translation_args = { words: matches.join(', ') }
+      end
+      result.errors.add(:base, I18n.t(key, translation_args))
       return result
     end
 

--- a/lib/new_post_manager.rb
+++ b/lib/new_post_manager.rb
@@ -172,7 +172,7 @@ class NewPostManager
   end
 
   def perform
-    if !self.class.exempt_user?(@user) && matches = WordWatcher.new("#{@args[:title]} #{@args[:raw]}").should_block?(all_matches: true).presence
+    if !self.class.exempt_user?(@user) && matches = WordWatcher.new("#{@args[:title]} #{@args[:raw]}").should_block?.presence
       result = NewPostResult.new(:created_post, false)
       if matches.size == 1
         key = 'contains_blocked_word'

--- a/lib/validators/post_validator.rb
+++ b/lib/validators/post_validator.rb
@@ -60,8 +60,15 @@ class Validators::PostValidator < ActiveModel::Validator
   end
 
   def watched_words(post)
-    if !post.acting_user&.staged && matches = WordWatcher.new(post.raw).should_block?
-      post.errors.add(:base, I18n.t('contains_blocked_words', word: matches[0]))
+    if !post.acting_user&.staged && matches = WordWatcher.new(post.raw).should_block?(all_matches: true).presence
+      if matches.size == 1
+        key = 'contains_blocked_word'
+        translation_args = { word: matches[0] }
+      else
+        key = 'contains_blocked_words'
+        translation_args = { words: matches.join(', ') }
+      end
+      post.errors.add(:base, I18n.t(key, translation_args))
     end
   end
 

--- a/lib/validators/post_validator.rb
+++ b/lib/validators/post_validator.rb
@@ -60,7 +60,7 @@ class Validators::PostValidator < ActiveModel::Validator
   end
 
   def watched_words(post)
-    if !post.acting_user&.staged && matches = WordWatcher.new(post.raw).should_block?(all_matches: true).presence
+    if !post.acting_user&.staged && matches = WordWatcher.new(post.raw).should_block?.presence
       if matches.size == 1
         key = 'contains_blocked_word'
         translation_args = { word: matches[0] }

--- a/spec/integration/watched_words_spec.rb
+++ b/spec/integration/watched_words_spec.rb
@@ -13,6 +13,7 @@ describe WatchedWord do
   let(:require_approval_word) { Fabricate(:watched_word, action: WatchedWord.actions[:require_approval]) }
   let(:flag_word) { Fabricate(:watched_word, action: WatchedWord.actions[:flag]) }
   let(:block_word) { Fabricate(:watched_word, action: WatchedWord.actions[:block]) }
+  let(:another_block_word) { Fabricate(:watched_word, action: WatchedWord.actions[:block]) }
 
   before_all do
     WordWatcher.clear_cache!
@@ -27,7 +28,7 @@ describe WatchedWord do
       expect {
         result = manager.perform
         expect(result).to_not be_success
-        expect(result.errors[:base]&.first).to eq(I18n.t('contains_blocked_words', word: block_word.word))
+        expect(result.errors[:base]&.first).to eq(I18n.t('contains_blocked_word', word: block_word.word))
       }.to_not change { Post.count }
     end
 
@@ -49,6 +50,15 @@ describe WatchedWord do
     it "should block the post from moderator" do
       manager = NewPostManager.new(moderator, raw: "Want some #{block_word.word} for cheap?", topic_id: topic.id)
       should_block_post(manager)
+    end
+
+    it "should block the post if it contains multiple blocked words" do
+      manager = NewPostManager.new(moderator, raw: "Want some #{block_word.word} #{another_block_word.word} for cheap?", topic_id: topic.id)
+      expect {
+        result = manager.perform
+        expect(result).to_not be_success
+        expect(result.errors[:base]&.first).to eq(I18n.t('contains_blocked_words', words: [block_word.word, another_block_word.word].join(', ')))
+      }.to_not change { Post.count }
     end
 
     it "should block in a private message too" do

--- a/spec/requests/admin/watched_words_controller_spec.rb
+++ b/spec/requests/admin/watched_words_controller_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Admin::WatchedWordsController do
     context 'non admins' do
       it "doesn't allow them to perform #clear_all" do
         word = Fabricate(:watched_word, action: WatchedWord.actions[:block])
-        delete "/admin/logs/watched_words/action/block/clear_all"
+        delete "/admin/logs/watched_words/action/block"
         expect(response.status).to eq(404)
         expect(WatchedWord.pluck(:word)).to include(word.word)
       end
@@ -98,7 +98,7 @@ RSpec.describe Admin::WatchedWordsController do
 
       it "allows them to perform #clear_all" do
         word = Fabricate(:watched_word, action: WatchedWord.actions[:block])
-        delete "/admin/logs/watched_words/action/block/clear_all.json"
+        delete "/admin/logs/watched_words/action/block.json"
         expect(response.status).to eq(200)
         expect(WatchedWord.pluck(:word)).not_to include(word.word)
       end
@@ -107,7 +107,7 @@ RSpec.describe Admin::WatchedWordsController do
         block_word = Fabricate(:watched_word, action: WatchedWord.actions[:block])
         flag_word = Fabricate(:watched_word, action: WatchedWord.actions[:flag])
 
-        delete "/admin/logs/watched_words/action/flag/clear_all.json"
+        delete "/admin/logs/watched_words/action/flag.json"
         expect(response.status).to eq(200)
         all_words = WatchedWord.pluck(:word)
         expect(all_words).to include(block_word.word)

--- a/spec/services/word_watcher_spec.rb
+++ b/spec/services/word_watcher_spec.rb
@@ -62,6 +62,30 @@ describe WordWatcher do
         end
       end
 
+      context 'multiple matches' do
+        context 'non regexp words' do
+          it 'lists all matching words' do
+            Fabricate(:watched_word, word: "bananas", action: WatchedWord.actions[:block])
+            Fabricate(:watched_word, word: "hate", action: WatchedWord.actions[:block])
+            matches = WordWatcher.new("I hate bananas.").word_matches_for_action?(:block, all_matches: true)
+            expect(matches).to contain_exactly('hate', 'bananas')
+          end
+        end
+
+        context 'regexp words' do
+          before do
+            SiteSetting.watched_words_regular_expressions = true
+          end
+
+          it 'lists all matching patterns' do
+            Fabricate(:watched_word, word: "ban[a]+nas", action: WatchedWord.actions[:block])
+            Fabricate(:watched_word, word: "hates?", action: WatchedWord.actions[:block])
+            matches = WordWatcher.new("I hate banaaanas ").word_matches_for_action?(:block, all_matches: true)
+            expect(matches).to contain_exactly('banaaanas', 'hate')
+          end
+        end
+      end
+
       context "emojis" do
         it "handles emoji" do
           Fabricate(:watched_word, word: ":joy:", action: WatchedWord.actions[:require_approval])

--- a/spec/services/word_watcher_spec.rb
+++ b/spec/services/word_watcher_spec.rb
@@ -10,6 +10,25 @@ describe WordWatcher do
     $redis.flushall
   end
 
+  describe '.word_matcher_regexp' do
+    let!(:word1) { Fabricate(:watched_word, action: WatchedWord.actions[:block]).word }
+    let!(:word2) { Fabricate(:watched_word, action: WatchedWord.actions[:block]).word }
+
+    context 'format of the result regexp' do
+      it "is correct when watched_words_regular_expressions = true" do
+        SiteSetting.watched_words_regular_expressions = true
+        regexp = WordWatcher.word_matcher_regexp(:block)
+        expect(regexp.inspect).to eq("/(#{word1})|(#{word2})/i")
+      end
+
+      it "is correct when watched_words_regular_expressions = false" do
+        SiteSetting.watched_words_regular_expressions = false
+        regexp = WordWatcher.word_matcher_regexp(:block)
+        expect(regexp.inspect).to eq("/(?<!\\w)((#{word1}|#{word2}))(?!\\w)/i")
+      end
+    end
+  end
+
   describe "word_matches_for_action?" do
     it "is falsey when there are no watched words" do
       expect(WordWatcher.new(raw).word_matches_for_action?(:require_approval)).to be_falsey
@@ -65,10 +84,13 @@ describe WordWatcher do
       context 'multiple matches' do
         context 'non regexp words' do
           it 'lists all matching words' do
-            Fabricate(:watched_word, word: "bananas", action: WatchedWord.actions[:block])
-            Fabricate(:watched_word, word: "hate", action: WatchedWord.actions[:block])
-            matches = WordWatcher.new("I hate bananas.").word_matches_for_action?(:block, all_matches: true)
+            %w{bananas hate hates}.each do |word|
+              Fabricate(:watched_word, word: word, action: WatchedWord.actions[:block])
+            end
+            matches = WordWatcher.new("I hate bananas").word_matches_for_action?(:block, all_matches: true)
             expect(matches).to contain_exactly('hate', 'bananas')
+            matches = WordWatcher.new("She hates bananas too").word_matches_for_action?(:block, all_matches: true)
+            expect(matches).to contain_exactly('hates', 'bananas')
           end
         end
 
@@ -78,10 +100,14 @@ describe WordWatcher do
           end
 
           it 'lists all matching patterns' do
-            Fabricate(:watched_word, word: "ban[a]+nas", action: WatchedWord.actions[:block])
-            Fabricate(:watched_word, word: "hates?", action: WatchedWord.actions[:block])
-            matches = WordWatcher.new("I hate banaaanas ").word_matches_for_action?(:block, all_matches: true)
-            expect(matches).to contain_exactly('banaaanas', 'hate')
+            Fabricate(:watched_word, word: "(pine)?apples", action: WatchedWord.actions[:block])
+            Fabricate(:watched_word, word: "((move|store)(d)?)|((watch|listen)(ed|ing)?)", action: WatchedWord.actions[:block])
+
+            matches = WordWatcher.new("pine pineapples apples").word_matches_for_action?(:block, all_matches: true)
+            expect(matches).to contain_exactly('pineapples', 'apples')
+
+            matches = WordWatcher.new("go watched watch ed ing move d moveed moved moving").word_matches_for_action?(:block, all_matches: true)
+            expect(matches).to contain_exactly(*%w{watched watch move moved})
           end
         end
       end
@@ -118,7 +144,7 @@ describe WordWatcher do
             action: WatchedWord.actions[:block]
           )
           m = WordWatcher.new("this is not a test.").word_matches_for_action?(:block)
-          expect(m[1]).to eq("test")
+          expect(m[0]).to eq("test")
         end
 
         it "supports regular expressions as a site setting" do
@@ -128,11 +154,11 @@ describe WordWatcher do
             action: WatchedWord.actions[:require_approval]
           )
           m = WordWatcher.new("Evil Trout is cool").word_matches_for_action?(:require_approval)
-          expect(m[1]).to eq("Trout")
+          expect(m[0]).to eq("Trout")
           m = WordWatcher.new("Evil Troot is cool").word_matches_for_action?(:require_approval)
-          expect(m[1]).to eq("Troot")
+          expect(m[0]).to eq("Troot")
           m = WordWatcher.new("trooooooooot").word_matches_for_action?(:require_approval)
-          expect(m[1]).to eq("trooooooooot")
+          expect(m[0]).to eq("trooooooooot")
         end
 
         it "support uppercase" do
@@ -145,9 +171,9 @@ describe WordWatcher do
           m = WordWatcher.new('Amazing place').word_matches_for_action?(:require_approval)
           expect(m).to be_nil
           m = WordWatcher.new('Amazing applesauce').word_matches_for_action?(:require_approval)
-          expect(m[1]).to eq('applesauce')
+          expect(m[0]).to eq('applesauce')
           m = WordWatcher.new('Amazing AppleSauce').word_matches_for_action?(:require_approval)
-          expect(m[1]).to eq('AppleSauce')
+          expect(m[0]).to eq('AppleSauce')
         end
       end
 


### PR DESCRIPTION
This PR has 3 main changes:

1. It adds a button that allows downloading all words of an action (e.g. block, flag etc.) in a CSV file which will have each word on a line by itself.

2. It adds a button that clears all words of an action.

3. The error message that shows up when a post contains blocked words is now improved to show all blocked words contained in the post rather than just the first one.

Screenshot:

![image](https://user-images.githubusercontent.com/17474474/61360422-12bdf100-a887-11e9-8909-fca3f9397777.png)
