### PR TITLE
Add default Spanish quotation mark style and TLD

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -706,7 +706,7 @@ posting:
   markdown_linkify_tlds:
     client: true
     type: list
-    default: "com|net|org|io|co|tv|ru|cn|us|uk|me|de|fr|fi|gov"
+    default: "com|net|org|io|co|tv|ru|cn|us|uk|me|de|fr|fi|gov|es"
     list_type: compact
   markdown_typographer_quotation_marks:
     client: true
@@ -717,6 +717,7 @@ posting:
     locale_default:
       de: "„|“|‚|‘"
       fr: "«\xA0|\xA0»|‹\xA0|\xA0›"
+      es: "«|»|“|”"
   enable_rich_text_paste:
     client: true
     default: true


### PR DESCRIPTION
In Spanish it's recommended to use latin (« »), then English (“ ”) quotation marks.

Source: http://lema.rae.es/dpd/srv/search?id=SSTAZ5sDyD6h59vijX

Also adds .es TLD to be automatically recognized by Markdown by default.