### PR TITLE
UX: adds href to category box titles

### DIFF
--- a/app/assets/javascripts/discourse/templates/components/categories-boxes.hbs
+++ b/app/assets/javascripts/discourse/templates/components/categories-boxes.hbs
@@ -1,5 +1,6 @@
 {{#each categories as |c|}}
-  <div class='category category-box category-box-{{unbound c.slug}}' style={{border-color c.color}} data-url={{c.url}}>
+  <div class='category category-box category-box-{{unbound c.slug}}' style={{border-color c.color}}
+   data-url={{c.url}}>
     <div class='category-box-inner'>
       <div class="category-logo">
         {{#if c.uploaded_logo.url}}

--- a/app/assets/javascripts/discourse/templates/components/categories-boxes.hbs
+++ b/app/assets/javascripts/discourse/templates/components/categories-boxes.hbs
@@ -13,12 +13,14 @@
       </div>
       <div class="category-details">
         <div class='category-box-heading'>
-          <h3>
-            {{#if c.read_restricted}}
-              {{d-icon 'lock'}}
-            {{/if}}
-            {{c.name}}
-          </h3>
+          <a href={{c.url}}>
+            <h3>
+              {{#if c.read_restricted}}
+                {{d-icon 'lock'}}
+              {{/if}}
+              {{c.name}}
+            </h3>
+          </a>
         </div>
 
         <div class='description'>


### PR DESCRIPTION
context: https://meta.discourse.org/t/subcategory-boxes-view-boxes-not-working-properly-as-links/117840

Currently, when a user left-clicks a category name (note: category and not subcategory) in the `categories-boxes` it works just fine.

However, if the user middle-clicks or right-clicks with the intention of opening it in a new tab, it doesn't work.

This occurs because there is no `<a>` tag in this template like there is in the `categories-boxes-with-topics` template.

This issue is present in both subcategories displayed as boxes (without topics) on a parent category's page as well as parent categories if the admin selects `boxes with subcategories` under the `desktop category page style` setting.

This PR adds that `<a>` tag so that the user can right-click or middle-click the category name and be able to open it in a new tab. 

This PR does not introduce any visual changes. 