### PR TITLE
UX: adds theme body tab contents to no-ember pages

### DIFF
--- a/app/views/layouts/crawler.html.erb
+++ b/app/views/layouts/crawler.html.erb
@@ -45,6 +45,7 @@
       </nav>
       <p class='powered-by-link'><%= t 'powered_by_html' %></p>
     </footer>
+    <%= theme_lookup("footer") %>
     <%= theme_lookup("body_tag") %>
   </body>
   <%= yield :after_body %>

--- a/app/views/layouts/no_ember.html.erb
+++ b/app/views/layouts/no_ember.html.erb
@@ -22,6 +22,7 @@
     </div>
   </section>
   <%= theme_lookup("footer") %>
+  <%= raw theme_lookup("body_tag") %>
   <%= build_plugin_html 'no-client:footer' %>
   <%= build_plugin_html 'server:before-body-close' %>
 </body>


### PR DESCRIPTION
Context: https://meta.discourse.org/t/customization-in-body-tag-wont-appear-in-some-pages/105167

If a theme contains some html in the `</body>` tab, this html is not loaded on no-ember pages like `/404`

This is not consistent with fact that the contents of the theme's `footer` tab are actually loaded on those pages.

**Before** 

Normal pages:

![no-ember01](https://user-images.githubusercontent.com/33972521/61456336-5c4a3100-a998-11e9-9ecc-49e57a818acf.png)

No-ember pages 

![no-ember02](https://user-images.githubusercontent.com/33972521/61456484-c531a900-a998-11e9-9a80-499b5870c61c.png)

Notice how the body tab contents are not loaded.

After:

Normal pages (no change)

![no-ember01](https://user-images.githubusercontent.com/33972521/61456336-5c4a3100-a998-11e9-9ecc-49e57a818acf.png)

No-ember pages

![no-ember03](https://user-images.githubusercontent.com/33972521/61456564-fdd18280-a998-11e9-8a46-e4f58e57014f.png)

The body tab contents are loaded on the page.


Here's a sample theme that contains the markup added in the screenshots for testing:

[discourse-light.tar.gz](https://github.com/discourse/discourse/files/3406449/discourse-light.tar.gz)

