### PR TITLE
FEATURE: Allow viewing of raw emails for reviewable queued posts

### DIFF
--- a/app/assets/javascripts/discourse/components/reviewable-queued-post.js.es6
+++ b/app/assets/javascripts/discourse/components/reviewable-queued-post.js.es6
@@ -1,0 +1,9 @@
+import showModal from "discourse/lib/show-modal";
+
+export default Ember.Component.extend({
+  actions: {
+    showRawEmail() {
+      showModal("raw-email").set("rawEmail", this.reviewable.payload.raw_email);
+    }
+  }
+});

--- a/app/assets/javascripts/discourse/templates/components/reviewable-queued-post.hbs
+++ b/app/assets/javascripts/discourse/templates/components/reviewable-queued-post.hbs
@@ -5,6 +5,11 @@
   </div>
   {{category-badge reviewable.category}}
   {{reviewable-tags tags=reviewable.payload.tags tagName=''}}
+  {{#if reviewable.payload.via_email}}
+    <a href {{action "showRawEmail"}} class='show-raw-email'>
+      {{d-icon "far-envelope" title="post.via_email"}}
+    </a>
+  {{/if}}
 {{/reviewable-topic-link}}
 
 <div class='post-contents-wrapper'>

--- a/app/assets/stylesheets/common/base/reviewables.scss
+++ b/app/assets/stylesheets/common/base/reviewables.scss
@@ -366,7 +366,7 @@
 .reviewable-item {
   .show-raw-email {
     color: $primary-medium;
-    font-size: 0.8em;
+    font-size: $font-down-2;
   }
   .post-title {
     background-color: yellow;

--- a/app/assets/stylesheets/common/base/reviewables.scss
+++ b/app/assets/stylesheets/common/base/reviewables.scss
@@ -364,6 +364,10 @@
 }
 
 .reviewable-item {
+  .show-raw-email {
+    color: $primary-medium;
+    font-size: 0.8em;
+  }
   .post-title {
     background-color: yellow;
   }

--- a/app/serializers/reviewable_queued_post_serializer.rb
+++ b/app/serializers/reviewable_queued_post_serializer.rb
@@ -16,7 +16,9 @@ class ReviewableQueuedPostSerializer < ReviewableSerializer
     :is_poll,
     :typing_duration_msecs,
     :composer_open_duration_msecs,
-    :tags
+    :tags,
+    :via_email,
+    :raw_email
   )
 
   def reply_to_post_number

--- a/lib/new_post_manager.rb
+++ b/lib/new_post_manager.rb
@@ -201,6 +201,8 @@ class NewPostManager
     %w(typing_duration_msecs composer_open_duration_msecs reply_to_post_number).each do |a|
       payload[a] = @args[a].to_i if @args[a]
     end
+    payload[:via_email] = true if !!@args[:via_email]
+    payload[:raw_email] = @args[:raw_email] if @args[:raw_email].present?
 
     reviewable = ReviewableQueuedPost.new(
       created_by: @user,

--- a/spec/serializers/reviewable_queued_post_serializer_spec.rb
+++ b/spec/serializers/reviewable_queued_post_serializer_spec.rb
@@ -49,6 +49,8 @@ describe ReviewableQueuedPostSerializer do
 
       expect(payload['raw']).to eq('hello world post contents.')
       expect(payload['title']).to be_blank
+      expect(payload['via_email']).to eq(true)
+      expect(payload['raw_email']).to eq('store_me')
       expect(json[:topic_id]).to eq(reviewable.topic_id)
       expect(json[:topic_url]).to eq(reviewable.topic.url)
       expect(json[:can_edit]).to eq(true)


### PR DESCRIPTION
If a post arrives via email but must be reviewed, we now show an
icon that can be clicked to view the raw contents of the email.

This is useful if Discourse's email parser is acting odd and the user
reviewing the post wants to know what the original contents were before
approving/rejecting the post.