### PR TITLE
bug: keep query params present in auth_redirect

### DIFF
--- a/app/controllers/user_api_keys_controller.rb
+++ b/app/controllers/user_api_keys_controller.rb
@@ -93,9 +93,12 @@ class UserApiKeysController < ApplicationController
     end
 
     if params[:auth_redirect]
-      redirect_path = +"#{params[:auth_redirect]}?payload=#{CGI.escape(@payload)}"
-      redirect_path << "&oneTimePassword=#{CGI.escape(otp_payload)}" if scopes.include?("one_time_password")
-      redirect_to(redirect_path)
+      uri = URI.parse(params[:auth_redirect])
+      query_attributes = [uri.query, "payload=#{CGI.escape(@payload)}"]
+      query_attributes << "oneTimePassword=#{CGI.escape(otp_payload)}" if scopes.include?("one_time_password")
+      uri.query = query_attributes.compact.join('&')
+
+      redirect_to(uri.to_s)
     else
       respond_to do |format|
         format.html { render :show }

--- a/spec/requests/user_api_keys_controller_spec.rb
+++ b/spec/requests/user_api_keys_controller_spec.rb
@@ -260,6 +260,23 @@ describe UserApiKeysController do
       post "/user-api-key.json", params: args
       expect(response.status).to eq(302)
     end
+
+    it 'will keep query_params added in auth_redirect' do
+      SiteSetting.min_trust_level_for_user_api_key = 0
+      SiteSetting.allowed_user_api_auth_redirects = args[:auth_redirect] + "/*"
+
+      user = Fabricate(:user, trust_level: 0)
+      sign_in(user)
+
+      query_str = "/?param1=val1"
+      args[:auth_redirect] = args[:auth_redirect] + query_str
+
+      post "/user-api-key.json", params: args
+      expect(response.status).to eq(302)
+
+      uri = URI.parse(response.redirect_url)
+      expect(uri.to_s).to include(query_str)
+    end
   end
 
   context '#create-one-time-password' do


### PR DESCRIPTION
https://meta.discourse.org/t/user-api-keys-payload-and-existing-query-string-leads-to-a-double-question-mark/123617