### PR TITLE
handle both name formats in managed authenticator

### DIFF
--- a/lib/auth/managed_authenticator.rb
+++ b/lib/auth/managed_authenticator.rb
@@ -85,7 +85,7 @@ class Auth::ManagedAuthenticator < Auth::Authenticator
     result = Auth::Result.new
     info = auth_token[:info]
     result.email = info[:email]
-    result.name = "#{info[:first_name]} #{info[:last_name]}"
+    result.name = info[:first_name] && info[:last_name] ? "#{info[:first_name]} #{info[:last_name]}" : info[:name] 
     result.username = info[:nickname]
     result.email_valid = primary_email_verified?(auth_token) if result.email
     result.extra_data = {


### PR DESCRIPTION
@davidtaylorhq In the course of working on the [migration of the oauth2-basic plugin to the managed_authenticator](https://meta.discourse.org/t/oauth2-basic-support/33879/188?u=angus) I've encountered an issue with the handling of names in the managed_authenticator.

The [OmniAuth AuthHash Schema](https://github.com/omniauth/omniauth/wiki/Auth-Hash-Schema) provides:
```
- name (required) - The best display name known to the strategy. Usually a concatenation of first and last name, but may also be an arbitrary designator or nickname for some strategies
```
and
```
- first_name
- last_name
```
The managed_authenticator currently combines the first_name and last_name properties.

This commit follows the current approach if there are first_name and last_name properties, but also falls back on the name property.