### PR TITLE
UX: fixes onebox favicon vertical alignment

### DIFF
--- a/app/assets/stylesheets/common/base/onebox.scss
+++ b/app/assets/stylesheets/common/base/onebox.scss
@@ -87,7 +87,7 @@ a.loading-onebox {
 
 @mixin onebox-favicon($class, $image) {
   &.#{$class} .source {
-    background: image-url("favicons/#{$image}.png") no-repeat;
+    background: image-url("favicons/#{$image}.png") no-repeat 0% 50%;
     background-size: 16px 16px;
     padding-left: 20px;
   }


### PR DESCRIPTION
Before:
<img width="722" alt="Screenshot 2019-07-24 at 09 38 01" src="https://user-images.githubusercontent.com/339945/61774254-c6c6fb00-adf6-11e9-841d-f005bd04b313.png">

After:
<img width="721" alt="Screenshot 2019-07-24 at 09 37 46" src="https://user-images.githubusercontent.com/339945/61774245-c0d11a00-adf6-11e9-9cdf-2186215fefe6.png">
