### PR TITLE
DEV: prevents staff computed property to be overridden

### DIFF
--- a/app/assets/javascripts/discourse/controllers/composer.js.es6
+++ b/app/assets/javascripts/discourse/controllers/composer.js.es6
@@ -199,11 +199,7 @@ export default Ember.Controller.extend({
     );
   },
 
-  @computed
-  isStaffUser() {
-    const currentUser = this.currentUser;
-    return currentUser && currentUser.get("staff");
-  },
+  isStaffUser: Ember.computed.reads("currentUser.staff"),
 
   canUnlistTopic: Ember.computed.and("model.creatingTopic", "isStaffUser"),
 

--- a/app/assets/javascripts/discourse/models/user.js.es6
+++ b/app/assets/javascripts/discourse/models/user.js.es6
@@ -54,7 +54,19 @@ const User = RestModel.extend({
     return UserDraftsStream.create({ user: this });
   },
 
-  staff: Ember.computed.or("admin", "moderator"),
+  staff: Ember.computed("admin", "moderator", {
+    get() {
+      if (this._staff) {
+        return this._staff;
+      }
+
+      return this.admin || this.moderator;
+    },
+
+    set(_, value) {
+      return (this._staff = value);
+    }
+  }),
 
   destroySession() {
     return ajax(`/session/${this.username}`, { type: "DELETE" });

--- a/app/assets/javascripts/discourse/models/user.js.es6
+++ b/app/assets/javascripts/discourse/models/user.js.es6
@@ -60,7 +60,9 @@ const User = RestModel.extend({
     },
 
     // prevents staff property to be overridden
-    set() {}
+    set() {
+      return this.admin || this.moderator;
+    }
   }),
 
   destroySession() {

--- a/app/assets/javascripts/discourse/models/user.js.es6
+++ b/app/assets/javascripts/discourse/models/user.js.es6
@@ -56,16 +56,11 @@ const User = RestModel.extend({
 
   staff: Ember.computed("admin", "moderator", {
     get() {
-      if (this._staff) {
-        return this._staff;
-      }
-
       return this.admin || this.moderator;
     },
 
-    set(_, value) {
-      return (this._staff = value);
-    }
+    // prevents staff property to be overridden
+    set() {}
   }),
 
   destroySession() {

--- a/plugins/poll/test/javascripts/acceptance/poll-builder-disabled-test.js.es6
+++ b/plugins/poll/test/javascripts/acceptance/poll-builder-disabled-test.js.es6
@@ -14,7 +14,7 @@ acceptance("Poll Builder - polls are disabled", {
 });
 
 test("regular user - sufficient trust level", assert => {
-  updateCurrentUser({ staff: false, trust_level: 3 });
+  updateCurrentUser({ moderator: false, admin: false, trust_level: 3 });
 
   displayPollBuilderButton();
 
@@ -27,7 +27,7 @@ test("regular user - sufficient trust level", assert => {
 });
 
 test("regular user - insufficient trust level", assert => {
-  updateCurrentUser({ staff: false, trust_level: 1 });
+  updateCurrentUser({ moderator: false, admin: false, trust_level: 1 });
 
   displayPollBuilderButton();
 
@@ -40,7 +40,7 @@ test("regular user - insufficient trust level", assert => {
 });
 
 test("staff", assert => {
-  updateCurrentUser({ staff: true });
+  updateCurrentUser({ moderator: true });
 
   displayPollBuilderButton();
 

--- a/plugins/poll/test/javascripts/acceptance/poll-builder-enabled-test.js.es6
+++ b/plugins/poll/test/javascripts/acceptance/poll-builder-enabled-test.js.es6
@@ -14,7 +14,7 @@ acceptance("Poll Builder - polls are enabled", {
 });
 
 test("regular user - sufficient trust level", assert => {
-  updateCurrentUser({ staff: false, trust_level: 1 });
+  updateCurrentUser({ moderator: false, admin: false, trust_level: 1 });
 
   displayPollBuilderButton();
 
@@ -27,7 +27,7 @@ test("regular user - sufficient trust level", assert => {
 });
 
 test("regular user - insufficient trust level", assert => {
-  updateCurrentUser({ staff: false, trust_level: 0 });
+  updateCurrentUser({ moderator: false, admin: false, trust_level: 0 });
 
   displayPollBuilderButton();
 
@@ -40,7 +40,7 @@ test("regular user - insufficient trust level", assert => {
 });
 
 test("staff - with insufficient trust level", assert => {
-  updateCurrentUser({ staff: true, trust_level: 0 });
+  updateCurrentUser({ moderator: true, trust_level: 0 });
 
   displayPollBuilderButton();
 

--- a/test/javascripts/acceptance/composer-actions-test.js.es6
+++ b/test/javascripts/acceptance/composer-actions-test.js.es6
@@ -305,7 +305,7 @@ QUnit.test("replying to post - toggle_topic_bump", async assert => {
 QUnit.test("replying to post as staff", async assert => {
   const composerActions = selectKit(".composer-actions");
 
-  updateCurrentUser({ staff: true, admin: false });
+  updateCurrentUser({ admin: true });
   await visit("/t/internationalization-localization/280");
   await click("article#post_3 button.reply");
   await composerActions.expand();
@@ -317,7 +317,7 @@ QUnit.test("replying to post as staff", async assert => {
 QUnit.test("replying to post as TL3 user", async assert => {
   const composerActions = selectKit(".composer-actions");
 
-  updateCurrentUser({ staff: false, admin: false, trust_level: 3 });
+  updateCurrentUser({ moderator: false, admin: false, trust_level: 3 });
   await visit("/t/internationalization-localization/280");
   await click("article#post_3 button.reply");
   await composerActions.expand();
@@ -335,7 +335,7 @@ QUnit.test("replying to post as TL3 user", async assert => {
 QUnit.test("replying to post as TL4 user", async assert => {
   const composerActions = selectKit(".composer-actions");
 
-  updateCurrentUser({ staff: false, admin: false, trust_level: 4 });
+  updateCurrentUser({ moderator: false, admin: false, trust_level: 4 });
   await visit("/t/internationalization-localization/280");
   await click("article#post_3 button.reply");
   await composerActions.expand();

--- a/test/javascripts/acceptance/composer-topic-links-test.js.es6
+++ b/test/javascripts/acceptance/composer-topic-links-test.js.es6
@@ -156,7 +156,7 @@ acceptance("Composer topic featured links when uncategorized is not allowed", {
 });
 
 QUnit.test("Pasting a link enables the text input area", async assert => {
-  updateCurrentUser({ admin: false, staff: false, trust_level: 1 });
+  updateCurrentUser({ moderator: false, admin: false, trust_level: 1 });
 
   await visit("/");
   await click("#create-topic");

--- a/test/javascripts/acceptance/composer-uncategorized-test.js.es6
+++ b/test/javascripts/acceptance/composer-uncategorized-test.js.es6
@@ -18,7 +18,7 @@ acceptance("Composer and uncategorized is not allowed", {
 });
 
 QUnit.test("Disable body until category is selected", async assert => {
-  updateCurrentUser({ admin: false, staff: false, trust_level: 1 });
+  updateCurrentUser({ moderator: false, admin: false, trust_level: 1 });
 
   await visit("/");
   await click("#create-topic");

--- a/test/javascripts/acceptance/email-notice-test.js.es6
+++ b/test/javascripts/acceptance/email-notice-test.js.es6
@@ -26,7 +26,7 @@ QUnit.test("shows banner when required", async assert => {
     "alert is displayed when email disabled for non-staff"
   );
 
-  updateCurrentUser({ staff: true, moderator: true });
+  updateCurrentUser({ moderator: true });
   await visit("/");
   assert.ok(
     exists(".alert-emails-disabled"),

--- a/test/javascripts/acceptance/enforce-second-factor-test.js.es6
+++ b/test/javascripts/acceptance/enforce-second-factor-test.js.es6
@@ -35,7 +35,7 @@ QUnit.test("as an admin", async assert => {
 });
 
 QUnit.test("as a user", async assert => {
-  updateCurrentUser({ staff: false, admin: false });
+  updateCurrentUser({ moderator: false, admin: false });
 
   await visit("/u/eviltrout/preferences/second-factor");
   Discourse.SiteSettings.enforce_second_factor = "all";
@@ -59,7 +59,7 @@ QUnit.test("as a user", async assert => {
 });
 
 QUnit.test("as an anonymous user", async assert => {
-  updateCurrentUser({ staff: false, admin: false, is_anonymous: true });
+  updateCurrentUser({ moderator: false, admin: false, is_anonymous: true });
 
   await visit("/u/eviltrout/preferences/second-factor");
   Discourse.SiteSettings.enforce_second_factor = "all";

--- a/test/javascripts/acceptance/group-index-test.js.es6
+++ b/test/javascripts/acceptance/group-index-test.js.es6
@@ -26,7 +26,7 @@ QUnit.test("Viewing Members as anon user", async assert => {
 acceptance("Group Members", { loggedIn: true });
 
 QUnit.test("Viewing Members as a group owner", async assert => {
-  updateCurrentUser({ admin: false, staff: false });
+  updateCurrentUser({ moderator: false, admin: false });
 
   await visit("/g/discourse");
   await click(".group-members-add");

--- a/test/javascripts/acceptance/group-manage-interaction-test.js.es6
+++ b/test/javascripts/acceptance/group-manage-interaction-test.js.es6
@@ -42,7 +42,7 @@ QUnit.test("As an admin", async assert => {
 });
 
 QUnit.test("As a group owner", async assert => {
-  updateCurrentUser({ admin: false, staff: false });
+  updateCurrentUser({ moderator: false, admin: false });
   await visit("/g/discourse/manage/interaction");
 
   assert.equal(

--- a/test/javascripts/acceptance/group-manage-membership-test.js.es6
+++ b/test/javascripts/acceptance/group-manage-membership-test.js.es6
@@ -68,7 +68,7 @@ QUnit.test("As an admin", async assert => {
 });
 
 QUnit.test("As a group owner", async assert => {
-  updateCurrentUser({ staff: false, admin: false });
+  updateCurrentUser({ moderator: false, admin: false });
 
   await visit("/g/discourse/manage/membership");
 

--- a/test/javascripts/acceptance/group-manage-profile-test.js.es6
+++ b/test/javascripts/acceptance/group-manage-profile-test.js.es6
@@ -34,7 +34,7 @@ QUnit.test("As an admin", async assert => {
 });
 
 QUnit.test("As a group owner", async assert => {
-  updateCurrentUser({ staff: false, admin: false });
+  updateCurrentUser({ moderator: false, admin: false });
 
   await visit("/g/discourse/manage/profile");
 

--- a/test/javascripts/acceptance/tags-test.js.es6
+++ b/test/javascripts/acceptance/tags-test.js.es6
@@ -156,7 +156,7 @@ test("new topic button is not available for staff-only tags", async assert => {
     }
   ]);
 
-  updateCurrentUser({ staff: false });
+  updateCurrentUser({ moderator: false, admin: false });
 
   await visit("/tags/regular-tag");
   assert.ok(find("#create-topic:disabled").length === 0);
@@ -164,7 +164,7 @@ test("new topic button is not available for staff-only tags", async assert => {
   await visit("/tags/staff-only-tag");
   assert.ok(find("#create-topic:disabled").length === 1);
 
-  updateCurrentUser({ staff: true });
+  updateCurrentUser({ moderator: true });
 
   await visit("/tags/regular-tag");
   assert.ok(find("#create-topic:disabled").length === 0);

--- a/test/javascripts/acceptance/topic-edit-timer-test.js.es6
+++ b/test/javascripts/acceptance/topic-edit-timer-test.js.es6
@@ -20,7 +20,7 @@ acceptance("Topic - Edit timer", {
 });
 
 QUnit.test("default", async assert => {
-  updateCurrentUser({ admin: true, staff: true, canManageTopic: true });
+  updateCurrentUser({ moderator: true, canManageTopic: true });
   const timerType = selectKit(".select-kit.timer-type");
   const futureDateInputSelector = selectKit(".future-date-input-selector");
 
@@ -41,7 +41,7 @@ QUnit.test("default", async assert => {
 });
 
 QUnit.test("autoclose - specific time", async assert => {
-  updateCurrentUser({ admin: true, staff: true, canManageTopic: true });
+  updateCurrentUser({ moderator: true, canManageTopic: true });
   const futureDateInputSelector = selectKit(".future-date-input-selector");
 
   await visit("/t/internationalization-localization");
@@ -62,7 +62,7 @@ QUnit.test("autoclose - specific time", async assert => {
 });
 
 QUnit.test("autoclose", async assert => {
-  updateCurrentUser({ admin: true, staff: true, canManageTopic: true });
+  updateCurrentUser({ moderator: true, canManageTopic: true });
   const futureDateInputSelector = selectKit(".future-date-input-selector");
 
   await visit("/t/internationalization-localization");
@@ -117,7 +117,7 @@ QUnit.test("autoclose", async assert => {
 });
 
 QUnit.test("close temporarily", async assert => {
-  updateCurrentUser({ admin: true, staff: true, canManageTopic: true });
+  updateCurrentUser({ moderator: true, canManageTopic: true });
   const timerType = selectKit(".select-kit.timer-type");
   const futureDateInputSelector = selectKit(".future-date-input-selector");
 
@@ -159,7 +159,7 @@ QUnit.test("close temporarily", async assert => {
 });
 
 QUnit.test("schedule", async assert => {
-  updateCurrentUser({ admin: true, staff: true, canManageTopic: true });
+  updateCurrentUser({ moderator: true, canManageTopic: true });
   const timerType = selectKit(".select-kit.timer-type");
   const categoryChooser = selectKit(".modal-body .category-chooser");
   const futureDateInputSelector = selectKit(".future-date-input-selector");
@@ -194,7 +194,7 @@ QUnit.test("schedule", async assert => {
 });
 
 QUnit.test("TL4 can't auto-delete", async assert => {
-  updateCurrentUser({ staff: false, trust_level: 4 });
+  updateCurrentUser({ moderator: false, admin: false, trust_level: 4 });
 
   await visit("/t/internationalization-localization");
   await click(".toggle-admin-menu");
@@ -208,7 +208,7 @@ QUnit.test("TL4 can't auto-delete", async assert => {
 });
 
 QUnit.test("auto delete", async assert => {
-  updateCurrentUser({ admin: true, staff: true, canManageTopic: true });
+  updateCurrentUser({ moderator: true, canManageTopic: true });
   const timerType = selectKit(".select-kit.timer-type");
   const futureDateInputSelector = selectKit(".future-date-input-selector");
 
@@ -238,7 +238,7 @@ QUnit.test("auto delete", async assert => {
 QUnit.test(
   "Manually closing before the timer will clear the status text",
   async assert => {
-    updateCurrentUser({ admin: true, staff: true, canManageTopic: true });
+    updateCurrentUser({ moderator: true, canManageTopic: true });
     const futureDateInputSelector = selectKit(".future-date-input-selector");
 
     await visit("/t/internationalization-localization");
@@ -265,7 +265,7 @@ QUnit.test(
 );
 
 QUnit.test("Inline delete timer", async assert => {
-  updateCurrentUser({ admin: true, staff: true, canManageTopic: true });
+  updateCurrentUser({ moderator: true, canManageTopic: true });
   const futureDateInputSelector = selectKit(".future-date-input-selector");
 
   await visit("/t/internationalization-localization");

--- a/test/javascripts/controllers/topic-test.js.es6
+++ b/test/javascripts/controllers/topic-test.js.es6
@@ -537,7 +537,7 @@ QUnit.test(
       posts: [post, { id: 3 }, { id: 4 }]
     });
 
-    const currentUser = Ember.Object.create({ staff: true });
+    const currentUser = Ember.Object.create({ moderator: true });
     const model = Topic.create({ postStream });
     const controller = this.subject({ model, currentUser });
 

--- a/test/javascripts/models/post-test.js.es6
+++ b/test/javascripts/models/post-test.js.es6
@@ -54,7 +54,7 @@ QUnit.test("updateFromPost", assert => {
 });
 
 QUnit.test("destroy by staff", assert => {
-  var user = Discourse.User.create({ username: "staff", staff: true }),
+  var user = Discourse.User.create({ username: "staff", moderator: true }),
     post = buildPost({ user: user });
 
   post.destroy(user);

--- a/test/javascripts/widgets/hamburger-menu-test.js.es6
+++ b/test/javascripts/widgets/hamburger-menu-test.js.es6
@@ -53,7 +53,7 @@ widgetTest("staff menu", {
 
   beforeEach() {
     this.currentUser.setProperties({
-      staff: true,
+      moderator: true,
       reviewable_count: 3
     });
   },
@@ -70,7 +70,7 @@ widgetTest("staff menu - admin", {
   template: '{{mount-widget widget="hamburger-menu"}}',
 
   beforeEach() {
-    this.currentUser.setProperties({ staff: true, admin: true });
+    this.currentUser.setProperties({ admin: true });
   },
 
   test(assert) {
@@ -83,7 +83,7 @@ widgetTest("reviewable content", {
 
   beforeEach() {
     this.currentUser.setProperties({
-      staff: true,
+      moderator: true,
       reviewable_count: 5
     });
   },

--- a/test/javascripts/widgets/post-test.js.es6
+++ b/test/javascripts/widgets/post-test.js.es6
@@ -579,7 +579,7 @@ widgetTest("toggle moderator post", {
   template:
     '{{mount-widget widget="post" args=args togglePostType=(action "togglePostType")}}',
   beforeEach() {
-    this.currentUser.set("staff", true);
+    this.currentUser.set("moderator", true);
     this.set("args", { canManage: true });
     this.on("togglePostType", () => (this.toggled = true));
   },
@@ -595,7 +595,7 @@ widgetTest("toggle moderator post", {
   template:
     '{{mount-widget widget="post" args=args togglePostType=(action "togglePostType")}}',
   beforeEach() {
-    this.currentUser.set("staff", true);
+    this.currentUser.set("moderator", true);
     this.set("args", { canManage: true });
     this.on("togglePostType", () => (this.toggled = true));
   },

--- a/test/javascripts/widgets/poster-name-test.js.es6
+++ b/test/javascripts/widgets/poster-name-test.js.es6
@@ -28,7 +28,7 @@ widgetTest("extra classes and glyphs", {
     this.set("args", {
       username: "eviltrout",
       usernameUrl: "/u/eviltrout",
-      staff: true,
+      modeator: true,
       admin: true,
       moderator: true,
       new_user: true,

--- a/test/javascripts/widgets/poster-name-test.js.es6
+++ b/test/javascripts/widgets/poster-name-test.js.es6
@@ -28,7 +28,7 @@ widgetTest("extra classes and glyphs", {
     this.set("args", {
       username: "eviltrout",
       usernameUrl: "/u/eviltrout",
-      modeator: true,
+      staff: true,
       admin: true,
       moderator: true,
       new_user: true,


### PR DESCRIPTION
As we create user from json and staff is already set in the json answer, this is triggering https://deprecations.emberjs.com/v3.x/#toc_computed-property-override and is doing twice the work.