### PR TITLE
UX: Add expanded/collapsed class to post-controls

### DIFF
--- a/app/assets/javascripts/discourse/widgets/post-menu.js.es6
+++ b/app/assets/javascripts/discourse/widgets/post-menu.js.es6
@@ -484,7 +484,14 @@ export default createWidget("post-menu", {
       postControls.push(this.attach("post-admin-menu", attrs));
     }
 
-    const contents = [h("nav.post-controls.clearfix", postControls)];
+    const contents = [
+      h(
+        "nav.post-controls.clearfix" +
+          (this.state.collapsed ? ".collapsed" : ".expanded"),
+        postControls
+      )
+    ];
+
     if (state.likedUsers.length) {
       const remaining = state.total - state.likedUsers.length;
       contents.push(


### PR DESCRIPTION
This adds a .collapsed/.expanded class to the post-controls. 

The initial reason for this is so I can treat the solved button differently based on the space available on mobile. 