### PR TITLE
FIX: Frozen string error in `TopicEmbed.import`

### DIFF
--- a/app/models/topic_embed.rb
+++ b/app/models/topic_embed.rb
@@ -36,8 +36,8 @@ class TopicEmbed < ActiveRecord::Base
     if SiteSetting.embed_truncate
       contents = first_paragraph_from(contents)
     end
-    contents ||= +''
-    contents << imported_from_html(url)
+    contents ||= ''
+    contents = +contents << imported_from_html(url)
 
     url = normalize_url(url)
 

--- a/spec/models/topic_embed_spec.rb
+++ b/spec/models/topic_embed_spec.rb
@@ -86,6 +86,26 @@ describe TopicEmbed do
         expect(post.cook_method).to eq(Post.cook_methods[:regular])
       end
     end
+
+    describe 'embedded content truncation' do
+      MAX_LENGTH_BEFORE_TRUNCATION = 100
+
+      let(:long_content) { "<p>#{'a' * MAX_LENGTH_BEFORE_TRUNCATION}</p>\n<p>more</p>" }
+
+      it 'truncates the imported post when truncation is enabled' do
+        SiteSetting.embed_truncate = true
+        post = TopicEmbed.import(user, url, title, long_content)
+
+        expect(post.raw).not_to include(long_content)
+      end
+
+      it 'keeps everything in the imported post when truncation is disabled' do
+        SiteSetting.embed_truncate = false
+        post = TopicEmbed.import(user, url, title, long_content)
+
+        expect(post.raw).to include(long_content)
+      end
+    end
   end
 
   context '.topic_id_for_embed' do


### PR DESCRIPTION
When `SiteSetting.embed_truncate` is enabled (by default), the truncated
string is mutable and does not raise an error. :heavy_check_mark: 

However, when the setting is disabled, the `contents` string is frozen
and immutable, and will raise a `FrozenError`. :boom: 