### PR TITLE
UX: prevent cooked dates from wrapping across multiple lines

### DIFF
--- a/plugins/discourse-local-dates/assets/stylesheets/common/discourse-local-dates.scss
+++ b/plugins/discourse-local-dates/assets/stylesheets/common/discourse-local-dates.scss
@@ -3,6 +3,7 @@
     color: $primary;
     cursor: pointer;
     border-bottom: 1px dashed $primary-medium;
+    white-space: nowrap;
 
     .d-icon {
       color: $primary;


### PR DESCRIPTION
History: https://meta.discourse.org/t/date-dropdown-broken-when-date-spans-multiple-lines/124279

This PR forces cooked dates to always be on one line to prevent positioning issues for the tooltip. 

**before** 

![dates001](https://user-images.githubusercontent.com/33972521/62103496-39d8e180-b2cf-11e9-8f35-5285b4e4ff4d.png)

**after**

![date002](https://user-images.githubusercontent.com/33972521/62103499-3f362c00-b2cf-11e9-8d0a-9959ab959b5f.png)
