### PR TITLE
DEV: consistent theme lookup in application / crawler / no-ember views

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -34,9 +34,9 @@
     <%- end %>
 
     <%- unless customization_disabled? %>
-      <%= raw theme_translations_lookup %>
-      <%= raw theme_js_lookup %>
-      <%= raw theme_lookup("head_tag") %>
+      <%= theme_translations_lookup %>
+      <%= theme_js_lookup %>
+      <%= theme_lookup("head_tag") %>
     <%- end %>
 
     <%= render_google_tag_manager_head_code %>
@@ -112,7 +112,7 @@
     <%= preload_script 'browser-update' %>
 
     <%- unless customization_disabled? %>
-      <%= raw theme_lookup("body_tag") %>
+      <%= theme_lookup("body_tag") %>
     <%- end %>
     <%= build_plugin_html 'server:before-body-close' %>
   </body>

--- a/app/views/layouts/crawler.html.erb
+++ b/app/views/layouts/crawler.html.erb
@@ -45,6 +45,7 @@
       </nav>
       <p class='powered-by-link'><%= t 'powered_by_html' %></p>
     </footer>
+    <%= theme_lookup("footer") %>
     <%= theme_lookup("body_tag") %>
   </body>
   <%= yield :after_body %>

--- a/app/views/layouts/no_ember.html.erb
+++ b/app/views/layouts/no_ember.html.erb
@@ -22,6 +22,7 @@
     </div>
   </section>
   <%= theme_lookup("footer") %>
+  <%= theme_lookup("body_tag") %>
   <%= build_plugin_html 'no-client:footer' %>
   <%= build_plugin_html 'server:before-body-close' %>
 </body>


### PR DESCRIPTION
history: https://meta.discourse.org/t/customization-in-body-tag-wont-appear-in-some-pages/105167

This PR ensures that theme fields are consistently injected in the different relevant views. Those views are 

1. `application`
2. `crawler`
3. `no-ember`

The application view currently contains all the required theme fields.
1. `head_tag`
2. `header`
3. `footer` (this is actually added in the [application.hbs](https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/templates/application.hbs#L29) template and not in the view file)
4. `body_tag`

The crawler view contains three fields
1. `head_tag` 
2. `header`
3. `body_tag` 

_the `footer` field is missing from this view_

The no-ember view contains three fields
1. `head_tag` 
2. `header`
3. `footer` 

_the `body_tag`  field is missing in this view_

This PR adds those missing fields. 

Before (no-ember view)

![image](https://user-images.githubusercontent.com/33972521/62115111-71a15280-b2ea-11e9-8f98-0649a96cf908.png)

after (no-ember view)

![image](https://user-images.githubusercontent.com/33972521/62115149-841b8c00-b2ea-11e9-8bbc-a24e8e9ffcb0.png)


Before (crawler view)

![theme001](https://user-images.githubusercontent.com/33972521/62115499-220f5680-b2eb-11e9-9b91-253a0063713f.png)

after (crawler view)

![theme002](https://user-images.githubusercontent.com/33972521/62115512-25a2dd80-b2eb-11e9-9c1e-b825b36114a6.png)

<hr> 

This PR also removes the `raw` helper that was used in some places where we lookup theme html, JS, and translations. 

The reason is that it wasn't used consistently (used in some places but not others) and because it's actually not needed.  

We already use `html_safe` in `theme_lookup` / `theme_js_lookup` and `theme_translations_lookup` to mark them as safe. So the `raw` helper is not really doing anything here.

https://github.com/discourse/discourse/blob/eff1c19e3be473b609c7f585337fd9dd1af968d1/app/helpers/application_helper.rb#L432-L445

I tested to confirm that removing the `raw` helpers wouldn't cause any issues in all the theme fields we lookup. 

This is a simple theme that contains the markup used in the screenshots above.

[discourse_light .tar.gz](https://github.com/discourse/discourse/files/3446014/discourse_light.tar.gz)
