### PR TITLE
UX: Make profile views consistent with other elements

### DIFF
--- a/app/assets/javascripts/discourse/templates/user.hbs
+++ b/app/assets/javascripts/discourse/templates/user.hbs
@@ -160,7 +160,7 @@
               <div><dt>{{i18n 'user.last_seen'}}</dt><dd>{{bound-date model.last_seen_at}}</dd></div>
             {{/if}}
             {{#if model.profile_view_count}}
-            	<div><dt>{{i18n 'views'}}</dt><dd>{{model.profile_view_count}}</dd></div>
+              <div><dt>{{i18n 'views'}}</dt><dd>{{model.profile_view_count}}</dd></div>
             {{/if}}
             {{#if model.invited_by}}
               <div><dt class="invited-by">{{i18n 'user.invited_by'}}</dt><dd class="invited-by">{{#link-to 'user' model.invited_by}}{{model.invited_by.username}}{{/link-to}}</dd></div>

--- a/app/assets/javascripts/discourse/templates/user.hbs
+++ b/app/assets/javascripts/discourse/templates/user.hbs
@@ -159,7 +159,9 @@
             {{#if model.last_seen_at}}
               <div><dt>{{i18n 'user.last_seen'}}</dt><dd>{{bound-date model.last_seen_at}}</dd></div>
             {{/if}}
-            <div><dt>{{i18n 'views'}}</dt><dd>{{model.profile_view_count}}</dd></div>
+            {{#if model.profile_view_count}}
+            	<div><dt>{{i18n 'views'}}</dt><dd>{{model.profile_view_count}}</dd></div>
+            {{/if}}
             {{#if model.invited_by}}
               <div><dt class="invited-by">{{i18n 'user.invited_by'}}</dt><dd class="invited-by">{{#link-to 'user' model.invited_by}}{{model.invited_by.username}}{{/link-to}}</dd></div>
             {{/if}}


### PR DESCRIPTION
This is just a little consistency fix. It makes it so that a hidden profile won't show an empty "Views" element.

<img width="343" alt="Screen Shot 2019-07-30 at 2 32 42 AM" src="https://user-images.githubusercontent.com/22733864/62118361-66aadb80-b272-11e9-9b98-ef28a1abfdf8.png">
