### PR TITLE
UX: style fixes for admin digest email preview page 

### DIFF
--- a/app/assets/javascripts/admin/templates/email-preview-digest.hbs
+++ b/app/assets/javascripts/admin/templates/email-preview-digest.hbs
@@ -10,9 +10,11 @@
     <div class="toggle">
       <label>{{i18n 'admin.email.format'}}</label>
       {{#if showHtml}}
-        <span>{{i18n 'admin.email.html'}}</span> | <a href {{action "toggleShowHtml"}}>{{i18n 'admin.email.text'}}</a>
+        <span>{{i18n 'admin.email.html'}}</span> | <a href
+         {{action "toggleShowHtml"}}>{{i18n 'admin.email.text'}}</a>
       {{else}}
-        <a href {{action "toggleShowHtml"}}>{{i18n 'admin.email.html'}}</a> | <span>{{i18n 'admin.email.text'}}</span>
+        <a href {{action "toggleShowHtml"}}>{{i18n 'admin.email.html'}}</a> |
+        <span>{{i18n 'admin.email.text'}}</span>
       {{/if}}
     </div>
   </div>
@@ -20,35 +22,35 @@
 
 {{#conditional-loading-spinner condition=loading}}
 
-<div class="email-preview-digest">
-  {{#if showSendEmailForm}}
-    <br/>
-    <div class="controls">
-      {{#if sendingEmail}}
-        {{i18n 'admin.email.sending_test'}}
-      {{else}}
-        <label>{{i18n 'admin.email.send_digest_label'}}</label>
-        {{text-field value=email placeholderKey="admin.email.test_email_address"}}
-        <button class='btn btn-default' {{action "sendEmail"}} disabled={{sendEmailDisabled}}>{{i18n 'admin.email.send_digest'}}</button>
-        {{#if sentEmail}}
-          <span class='result-message'>{{i18n 'admin.email.sent_test'}}</span>
+  <div class="email-preview-digest">
+    {{#if showSendEmailForm}}
+      <br />
+      <div class="controls">
+        {{#if sendingEmail}}
+          {{i18n 'admin.email.sending_test'}}
+        {{else}}
+          <label>{{i18n 'admin.email.send_digest_label'}}</label>
+          {{text-field value=email placeholderKey="admin.email.test_email_address"}}
+          <button class='btn btn-default' {{action "sendEmail"}} disabled={{sendEmailDisabled}}>{{i18n 'admin.email.send_digest'}}</button>
+          {{#if sentEmail}}
+            <span class='result-message'>{{i18n 'admin.email.sent_test'}}</span>
+          {{/if}}
         {{/if}}
+      </div>
+      <br />
+    {{/if}}
+
+    <div class="preview-output">
+      {{#if showHtml}}
+        {{#if htmlEmpty}}
+          <p>{{i18n 'admin.email.no_result'}}</p>
+        {{else}}
+          <iframe srcdoc={{model.html_content}} />
+        {{/if}}
+      {{else}}
+        <pre>{{{model.text_content}}}</pre>
       {{/if}}
     </div>
-    <br/>
-  {{/if}}
-
-  <div class="preview-output">
-    {{#if showHtml}}
-      {{#if htmlEmpty}}
-        <p>{{i18n 'admin.email.no_result'}}</p>
-      {{else}}
-        <iframe srcdoc={{model.html_content}} />
-      {{/if}}
-    {{else}}
-      <pre>{{{model.text_content}}}</pre>
-    {{/if}}
   </div>
-</div>
 
 {{/conditional-loading-spinner}}

--- a/app/assets/javascripts/admin/templates/email-preview-digest.hbs
+++ b/app/assets/javascripts/admin/templates/email-preview-digest.hbs
@@ -6,7 +6,7 @@
     {{date-picker-past value=lastSeen id="last-seen"}}
     <label>{{i18n 'admin.email.user'}}:</label>
     {{user-selector single="true" usernames=username canReceiveUpdates="true"}}
-    <button class='btn' {{action "refresh"}}>{{i18n 'admin.email.refresh'}}</button>
+    <button class='btn btn-primary digest-refresh-button' {{action "refresh"}}>{{i18n 'admin.email.refresh'}}</button>
     <div class="toggle">
       <label>{{i18n 'admin.email.format'}}</label>
       {{#if showHtml}}

--- a/app/assets/javascripts/admin/templates/email-preview-digest.hbs
+++ b/app/assets/javascripts/admin/templates/email-preview-digest.hbs
@@ -24,7 +24,6 @@
 
   <div class="email-preview-digest">
     {{#if showSendEmailForm}}
-      <br />
       <div class="controls">
         {{#if sendingEmail}}
           {{i18n 'admin.email.sending_test'}}
@@ -37,7 +36,6 @@
           {{/if}}
         {{/if}}
       </div>
-      <br />
     {{/if}}
 
     <div class="preview-output">

--- a/app/assets/stylesheets/common/admin/emails.scss
+++ b/app/assets/stylesheets/common/admin/emails.scss
@@ -78,7 +78,10 @@
 
 .email-preview-digest {
   .controls {
-    margin-left: 20px;
+    margin: 1em 0.5em;
+    input[type="text"] {
+      margin-bottom: 0;
+    }
     label {
       display: inline;
     }

--- a/app/assets/stylesheets/common/admin/emails.scss
+++ b/app/assets/stylesheets/common/admin/emails.scss
@@ -70,6 +70,12 @@
   padding: 0.25em 0;
 }
 
+.email-preview {
+  .digest-refresh-button {
+    margin: 0 0.5em;
+  }
+}
+
 .email-preview-digest {
   .controls {
     margin-left: 20px;


### PR DESCRIPTION
This PR makes a few minor style adjustments to the digest preview page in the admin.

Changes: 
1. adds `btn-primary` class to refresh button to make it more distinct
2. adds margins to the refresh button
3. replaces some `<br>` tags with CSS margins

before

![digest0002](https://user-images.githubusercontent.com/33972521/62213189-efda2380-b3d4-11e9-8646-d1761c3f1124.png)

After

![digest001](https://user-images.githubusercontent.com/33972521/62213199-f5d00480-b3d4-11e9-96e1-0a5a3bee44a4.png)

There's still more work to be done in refactoring the styles for this page, but the main goal of this PR is to highlight the refresh button a bit more. 
