### PR TITLE
FIX: Better detection of Apple browsers

### DIFF
--- a/app/assets/javascripts/discourse/initializers/register-service-worker.js.es6
+++ b/app/assets/javascripts/discourse/initializers/register-service-worker.js.es6
@@ -9,7 +9,8 @@ export default {
     const isSupported = isSecured && "serviceWorker" in navigator;
 
     if (isSupported) {
-      const isApple = !!navigator.platform.match(/(Mac|iPhone|iPod|iPad)/i);
+      const caps = Discourse.__container__.lookup("capabilities:main");
+      const isApple = caps.isSafari || caps.isIOS || caps.isIpadOS;
 
       if (Discourse.ServiceWorkerURL && !isApple) {
         navigator.serviceWorker.getRegistrations().then(registrations => {

--- a/app/assets/javascripts/discourse/pre-initializers/sniff-capabilities.js.es6
+++ b/app/assets/javascripts/discourse/pre-initializers/sniff-capabilities.js.es6
@@ -37,6 +37,8 @@ export default {
 
       caps.isIOS =
         /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
+
+      caps.isIpadOS = ua.indexOf("Mac OS") !== -1 && touch;
     }
 
     // We consider high res a device with 1280 horizontal pixels. High DPI tablets like


### PR DESCRIPTION
Introduces isIpadOS to our capabilities sniffer, which is currently
compatible with latest iPad beta OS. Older iPad versions will match our
isIOS detection.

Using this new feature, fixes the service worker being blocked in Google
Chrome, Firefox and other browsers while running on Mac OS, where they
work just fine. This enables Desktop PWA install in Mac OS.