### PR TITLE
DEV: default to test env when running d/rspec

### DIFF
--- a/bin/docker/rspec
+++ b/bin/docker/rspec
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 PARAMS="$@"
-CMD="cd /src && USER=discourse RUBY_GLOBAL_METHOD_CACHE_SIZE=131072 LD_PRELOAD=/usr/lib/libjemalloc.so RAILS_ENV=${RAILS_ENV:=development} bin/rspec $PARAMS"
+CMD="cd /src && USER=discourse RUBY_GLOBAL_METHOD_CACHE_SIZE=131072 LD_PRELOAD=/usr/lib/libjemalloc.so RAILS_ENV=${RAILS_ENV:=test} bin/rspec $PARAMS"
 docker exec -it -u discourse:discourse discourse_dev /bin/bash -c "$CMD"


### PR DESCRIPTION
`RAILS_ENV` currently defaults to `developement` when running the `rspec` docker wrapper.

This changes the default to `test` so the tests are running with right setups.