### PR TITLE
FEATURE: Watched Word Improvements

### DIFF
--- a/app/assets/javascripts/admin/controllers/admin-watched-words-action.js.es6
+++ b/app/assets/javascripts/admin/controllers/admin-watched-words-action.js.es6
@@ -2,6 +2,7 @@ import computed from "ember-addons/ember-computed-decorators";
 import WatchedWord from "admin/models/watched-word";
 import { ajax } from "discourse/lib/ajax";
 import { fmt } from "discourse/lib/computed";
+import showModal from "discourse/lib/show-modal";
 
 export default Ember.Controller.extend({
   actionNameKey: null,
@@ -101,6 +102,16 @@ export default Ember.Controller.extend({
           }
         }
       );
+    },
+
+    test() {
+      WatchedWord.findAll().then(data => {
+        this.set("adminWatchedWords.model", data);
+        showModal("admin-watched-word-test", {
+          admin: true,
+          model: this.currentAction
+        });
+      });
     }
   }
 });

--- a/app/assets/javascripts/admin/controllers/modals/admin-watched-word-test.js.es6
+++ b/app/assets/javascripts/admin/controllers/modals/admin-watched-word-test.js.es6
@@ -1,0 +1,11 @@
+import { default as computed } from "ember-addons/ember-computed-decorators";
+import ModalFunctionality from "discourse/mixins/modal-functionality";
+
+export default Ember.Controller.extend(ModalFunctionality, {
+  @computed("value", "model.compiledRegularExpression")
+  matches(value, regexpString) {
+    if (!value || !regexpString) return;
+    let censorRegexp = new RegExp(regexpString, "ig");
+    return value.match(censorRegexp);
+  }
+});

--- a/app/assets/javascripts/admin/models/watched-word.js.es6
+++ b/app/assets/javascripts/admin/models/watched-word.js.es6
@@ -42,7 +42,8 @@ WatchedWord.reopenClass({
           name: I18n.t("admin.watched_words.actions." + n),
           words: actions[n],
           count: actions[n].length,
-          regularExpressions: list.regular_expressions
+          regularExpressions: list.regular_expressions,
+          compiledRegularExpression: list.compiled_regular_expressions[n]
         });
       });
     });

--- a/app/assets/javascripts/admin/templates/modal/admin-watched-word-test.hbs
+++ b/app/assets/javascripts/admin/templates/modal/admin-watched-word-test.hbs
@@ -1,0 +1,16 @@
+{{#d-modal-body rawTitle=(i18n "admin.watched_words.test.modal_title" action=model.name) class="watched-words-test-modal"}}
+    <p>{{i18n "admin.watched_words.test.description"}}</p>
+    {{textarea name="test_value" value=value autofocus="autofocus"}}
+    {{#if matches}}
+        <p>
+            {{i18n "admin.watched_words.test.found_matches"}}
+            <ul>
+                {{#each matches as |match|}}
+                    <li>{{match}}</li>
+                {{/each}}
+            </ul>
+        </p>
+    {{else}}
+        <p>{{i18n "admin.watched_words.test.no_matches"}}</p>
+    {{/if}}
+{{/d-modal-body}}

--- a/app/assets/javascripts/admin/templates/watched-words-action.hbs
+++ b/app/assets/javascripts/admin/templates/watched-words-action.hbs
@@ -39,6 +39,10 @@
 
 <div class="clear-all-row">
   {{d-button
+    label="admin.watched_words.test.button_label"
+    icon="far-eye"
+    action=(action "test")}}
+  {{d-button
     class="btn-danger clear-all"
     label="admin.watched_words.clear_all"
     icon="trash-alt"

--- a/app/assets/javascripts/discourse/lib/text.js.es6
+++ b/app/assets/javascripts/discourse/lib/text.js.es6
@@ -13,7 +13,7 @@ function getOpts(opts) {
     {
       getURL: Discourse.getURLWithCDN,
       currentUser: Discourse.__container__.lookup("current-user:main"),
-      censoredWords: site.censored_words,
+      censoredRegexp: site.censored_regexp,
       siteSettings,
       formatUsername
     },

--- a/app/assets/javascripts/discourse/models/topic.js.es6
+++ b/app/assets/javascripts/discourse/models/topic.js.es6
@@ -97,7 +97,7 @@ const Topic = RestModel.extend({
   fancyTitle(title) {
     let fancyTitle = censor(
       emojiUnescape(title || ""),
-      Discourse.Site.currentProp("censored_words")
+      Discourse.Site.currentProp("censored_regexp")
     );
 
     if (Discourse.SiteSettings.support_mixed_text_direction) {

--- a/app/assets/javascripts/pretty-text/censored-words.js.es6
+++ b/app/assets/javascripts/pretty-text/censored-words.js.es6
@@ -1,75 +1,19 @@
-function escapeRegexp(text) {
-  return text.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&").replace(/\*/g, "S*");
-}
+export function censorFn(regexpString, replacementLetter) {
+  if (regexpString) {
+    let censorRegexp = new RegExp(regexpString, "ig");
+    replacementLetter = replacementLetter || "&#9632;";
 
-function createCensorRegexp(patterns) {
-  return new RegExp(`((?<!\\w)(?:${patterns.join("|")}))(?!\\w)`, "ig");
-}
-
-export function censorFn(
-  censoredWords,
-  replacementLetter,
-  watchedWordsRegularExpressions
-) {
-  let patterns = [];
-
-  replacementLetter = replacementLetter || "&#9632;";
-
-  if (censoredWords && censoredWords.length) {
-    patterns = censoredWords.split("|");
-    if (!watchedWordsRegularExpressions) {
-      patterns = patterns.map(t => `(${escapeRegexp(t)})`);
-    }
-  }
-
-  if (patterns.length) {
-    let censorRegexp;
-
-    try {
-      if (watchedWordsRegularExpressions) {
-        censorRegexp = new RegExp(
-          "((?:" + patterns.join("|") + "))(?![^\\(]*\\))",
-          "ig"
+    return function(text) {
+      text = text.replace(censorRegexp, (fullMatch, ...groupMatches) => {
+        const stringMatch = groupMatches.find(g => typeof g === "string");
+        return fullMatch.replace(
+          stringMatch,
+          new Array(stringMatch.length + 1).join(replacementLetter)
         );
-      } else {
-        censorRegexp = createCensorRegexp(patterns);
-      }
+      });
 
-      if (censorRegexp) {
-        return function(text) {
-          let original = text;
-
-          try {
-            let m = censorRegexp.exec(text);
-            const fourCharReplacement = new Array(5).join(replacementLetter);
-
-            while (m && m[0]) {
-              if (m[0].length > original.length) {
-                return original;
-              } // regex is dangerous
-              if (watchedWordsRegularExpressions) {
-                text = text.replace(censorRegexp, fourCharReplacement);
-              } else {
-                const replacement = new Array(m[0].length + 1).join(
-                  replacementLetter
-                );
-                text = text.replace(
-                  createCensorRegexp([escapeRegexp(m[0])]),
-                  replacement
-                );
-              }
-              m = censorRegexp.exec(text);
-            }
-
-            return text;
-          } catch (e) {
-            return original;
-          }
-        };
-      }
-    } catch (e) {
-      // fall through
-    }
+      return text;
+    };
   }
 
   return function(t) {
@@ -77,6 +21,6 @@ export function censorFn(
   };
 }
 
-export function censor(text, censoredWords, replacementLetter) {
-  return censorFn(censoredWords, replacementLetter)(text);
+export function censor(text, censoredRegexp, replacementLetter) {
+  return censorFn(censoredRegexp, replacementLetter)(text);
 }

--- a/app/assets/javascripts/pretty-text/engines/discourse-markdown/censored.js.es6
+++ b/app/assets/javascripts/pretty-text/engines/discourse-markdown/censored.js.es6
@@ -29,15 +29,11 @@ export function setup(helper) {
   });
 
   helper.registerPlugin(md => {
-    const words = md.options.discourse.censoredWords;
+    const censoredRegexp = md.options.discourse.censoredRegexp;
 
-    if (words && words.length > 0) {
+    if (censoredRegexp) {
       const replacement = String.fromCharCode(9632);
-      const censor = censorFn(
-        words,
-        replacement,
-        md.options.discourse.watchedWordsRegularExpressions
-      );
+      const censor = censorFn(censoredRegexp, replacement);
       md.core.ruler.push("censored", state => censorTree(state, censor));
     }
   });

--- a/app/assets/javascripts/pretty-text/pretty-text.js.es6
+++ b/app/assets/javascripts/pretty-text/pretty-text.js.es6
@@ -29,7 +29,7 @@ export function buildOptions(state) {
     lookupUploadUrls,
     previewing,
     linkify,
-    censoredWords,
+    censoredRegexp,
     disableEmojis
   } = state;
 
@@ -67,7 +67,7 @@ export function buildOptions(state) {
     formatUsername,
     emojiUnicodeReplacer,
     lookupUploadUrls,
-    censoredWords,
+    censoredRegexp,
     allowedHrefSchemes: siteSettings.allowed_href_schemes
       ? siteSettings.allowed_href_schemes.split("|")
       : null,

--- a/app/assets/stylesheets/common/admin/staff_logs.scss
+++ b/app/assets/stylesheets/common/admin/staff_logs.scss
@@ -370,6 +370,9 @@ table.screened-ip-addresses {
     display: flex;
     margin-top: 10px;
     justify-content: flex-end;
+    .clear-all {
+      margin-left: 5px;
+    }
   }
 }
 
@@ -429,6 +432,10 @@ table.screened-ip-addresses {
   .about {
     margin: 0.5em 0 1em 0;
   }
+}
+
+.watched-words-test-modal p {
+  margin-top: 0;
 }
 
 // Search logs

--- a/app/models/admin_dashboard_data.rb
+++ b/app/models/admin_dashboard_data.rb
@@ -96,7 +96,7 @@ class AdminDashboardData
                       :image_magick_check, :failing_emails_check,
                       :subfolder_ends_in_slash_check,
                       :pop3_polling_configuration, :email_polling_errored_recently,
-                      :out_of_date_themes, :unreachable_themes
+                      :out_of_date_themes, :unreachable_themes, :watched_words_check
 
     add_problem_check do
       sidekiq_check || queue_size_check
@@ -222,6 +222,17 @@ class AdminDashboardData
   def force_https_check
     return unless @opts[:check_force_https]
     I18n.t('dashboard.force_https_warning', base_path: Discourse.base_path) unless SiteSetting.force_https
+  end
+
+  def watched_words_check
+    WatchedWord.actions.keys.each do |action|
+      begin
+        WordWatcher.word_matcher_regexp(action, raise_errors: true)
+      rescue RegexpError => e
+        return I18n.t('dashboard.watched_word_regexp_error', base_path: Discourse.base_path, action: action)
+      end
+    end
+    nil
   end
 
   def out_of_date_themes

--- a/app/serializers/site_serializer.rb
+++ b/app/serializers/site_serializer.rb
@@ -30,7 +30,7 @@ class SiteSerializer < ApplicationSerializer
     :wizard_required,
     :topic_featured_link_allowed_category_ids,
     :user_themes,
-    :censored_words,
+    :censored_regexp,
     :shared_drafts_category_id
   )
 
@@ -156,8 +156,8 @@ class SiteSerializer < ApplicationSerializer
     scope.topic_featured_link_allowed_category_ids
   end
 
-  def censored_words
-    WordWatcher.words_for_action(:censor).join('|')
+  def censored_regexp
+    WordWatcher.word_matcher_regexp(:censor)&.source
   end
 
   def shared_drafts_category_id

--- a/app/serializers/watched_word_list_serializer.rb
+++ b/app/serializers/watched_word_list_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class WatchedWordListSerializer < ApplicationSerializer
-  attributes :actions, :words, :regular_expressions
+  attributes :actions, :words, :regular_expressions, :compiled_regular_expressions
 
   def actions
     WatchedWord.actions.keys
@@ -17,5 +17,13 @@ class WatchedWordListSerializer < ApplicationSerializer
   # in the admin section
   def regular_expressions
     SiteSetting.watched_words_regular_expressions?
+  end
+
+  def compiled_regular_expressions
+    expressions = {}
+    WatchedWord.actions.keys.each do |action|
+      expressions[action] = WordWatcher.word_matcher_regexp(action)&.source
+    end
+    expressions
   end
 end

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3920,6 +3920,12 @@ en:
           exists: "Already exists"
           upload: "Add from file"
           upload_successful: "Upload successful. Words have been added."
+        test:
+          button_label: "Test"
+          modal_title: "Test '%{action}' Watched Words"
+          description: "Enter text below to check for matches with watched words"
+          found_matches: "Found matches:"
+          no_matches: "No matches found"
 
       impersonate:
         title: "Impersonate"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1303,6 +1303,7 @@ en:
     force_https_warning: "Your website is using SSL. But `<a href='%{base_path}/admin/site_settings/category/all_results?filter=force_https'>force_https</a>` is not yet enabled in your site settings."
     out_of_date_themes: "Updates are available for the following themes:"
     unreachable_themes: "We were unable to check for updates on the following themes:"
+    watched_word_regexp_error: "The regular expression for %{action} watched words is invalid. Please check your <a href='%{base_path}/admin/logs/watched_words'>Watched Word settings</a>, or disable the 'watched words regular expressions' site setting."
 
   site_settings:
     censored_words: "Words that will be automatically replaced with &#9632;&#9632;&#9632;&#9632;"

--- a/lib/pretty_text.rb
+++ b/lib/pretty_text.rb
@@ -162,7 +162,7 @@ module PrettyText
         __optInput.customEmoji = #{custom_emoji.to_json};
         __optInput.emojiUnicodeReplacer = __emojiUnicodeReplacer;
         __optInput.lookupUploadUrls = __lookupUploadUrls;
-        __optInput.censoredWords = #{WordWatcher.words_for_action(:censor).join('|').to_json};
+        __optInput.censoredRegexp = #{WordWatcher.word_matcher_regexp(:censor)&.source.to_json};
       JS
 
       if opts[:topicId]

--- a/spec/services/word_watcher_spec.rb
+++ b/spec/services/word_watcher_spec.rb
@@ -24,7 +24,7 @@ describe WordWatcher do
       it "is correct when watched_words_regular_expressions = false" do
         SiteSetting.watched_words_regular_expressions = false
         regexp = WordWatcher.word_matcher_regexp(:block)
-        expect(regexp.inspect).to eq("/(?<!\\w)((#{word1}|#{word2}))(?!\\w)/i")
+        expect(regexp.inspect).to eq("/(?:\\W|^)(#{word1}|#{word2})(?=\\W|$)/i")
       end
     end
   end

--- a/test/javascripts/fixtures/watched-words-fixtures.js.es6
+++ b/test/javascripts/fixtures/watched-words-fixtures.js.es6
@@ -8,6 +8,7 @@ export default {
       { id: 4, word: "scheme", action: "flag" },
       { id: 5, word: "coupon", action: "require_approval" },
       { id: 6, word: '<img src="x">', action: "block" }
-    ]
+    ],
+    compiled_regular_expressions: {}
   }
 };

--- a/test/javascripts/lib/pretty-text-test.js.es6
+++ b/test/javascripts/lib/pretty-text-test.js.es6
@@ -21,7 +21,6 @@ const rawOpts = {
     enable_markdown_linkify: true,
     markdown_linkify_tlds: "com"
   },
-  censoredWords: "shucks|whiz|whizzer|a**le|badword*|shuck$|café|$uper",
   getURL: url => url
 };
 
@@ -974,89 +973,15 @@ QUnit.test("images", assert => {
 });
 
 QUnit.test("censoring", assert => {
-  assert.cooked(
-    "aw shucks, golly gee whiz.",
-    "<p>aw ■■■■■■, golly gee ■■■■.</p>",
-    "it censors words in the Site Settings"
-  );
-
-  assert.cooked(
-    "you are a whizzard! I love cheesewhiz. Whiz.",
-    "<p>you are a whizzard! I love cheesewhiz. ■■■■.</p>",
-    "it doesn't censor words unless they have boundaries."
-  );
-
-  assert.cooked(
-    "you are a whizzer! I love cheesewhiz. Whiz.",
-    "<p>you are a ■■■■■■■! I love cheesewhiz. ■■■■.</p>",
-    "it censors words even if previous partial matches exist."
-  );
-
-  assert.cooked(
-    "The link still works. [whiz](http://www.whiz.com)",
-    '<p>The link still works. <a href="http://www.whiz.com">■■■■</a></p>',
-    "it won't break links by censoring them."
-  );
-
-  assert.cooked(
-    "Call techapj the computer whiz at 555-555-1234 for free help.",
-    "<p>Call techapj the computer ■■■■ at 555-555-1234 for free help.</p>",
-    "uses both censored words and patterns from site settings"
-  );
-
-  assert.cooked(
-    "I have a pen, I have an a**le",
-    "<p>I have a pen, I have an ■■■■■</p>",
-    "it escapes regexp chars"
-  );
-
-  assert.cooked(
-    "Aw shuck$, I can't fix the problem with money",
-    "<p>Aw ■■■■■■, I can't fix the problem with money</p>",
-    "it works for words ending in non-word characters"
-  );
-
-  assert.cooked(
-    "Let's go to a café today",
-    "<p>Let's go to a ■■■■ today</p>",
-    "it works for words ending in accented characters"
-  );
-
-  assert.cooked(
-    "Discourse is $uper amazing",
-    "<p>Discourse is ■■■■■ amazing</p>",
-    "it works for words starting with non-word characters"
-  );
-
-  assert.cooked(
-    "No badword or apple here plz.",
-    "<p>No ■■■■■■■ or ■■■■■ here plz.</p>",
-    "it handles * as wildcard"
-  );
-
   assert.cookedOptions(
     "Pleased to meet you, but pleeeease call me later, xyz123",
     {
-      siteSettings: {
-        watched_words_regular_expressions: true
-      },
-      censoredWords: "xyz*|plee+ase"
+      censoredRegexp: "(xyz*|plee+ase)"
     },
-    "<p>Pleased to meet you, but ■■■■ call me later, ■■■■123</p>",
-    "supports words as regular expressions"
+    "<p>Pleased to meet you, but ■■■■■■■■■ call me later, ■■■123</p>",
+    "supports censoring"
   );
-
-  assert.cookedOptions(
-    "Meet downtown in your town at the townhouse on Main St.",
-    {
-      siteSettings: {
-        watched_words_regular_expressions: true
-      },
-      censoredWords: "\\btown\\b"
-    },
-    "<p>Meet downtown in your ■■■■ at the townhouse on Main St.</p>",
-    "supports words as regular expressions"
-  );
+  // More tests in pretty_text_spec.rb
 });
 
 QUnit.test("code blocks/spans hoisting", assert => {


### PR DESCRIPTION
- Client-side censoring fixed for non-chrome browsers. (Regular expression adapted to avoid lookback)
- Regex generation is now done on the server, to reduce repeated logic, and make it easier to extend in plugins
- Censor tests are moved to ruby, to ensure everything works end-to-end
- If "watched words regular expressions" is enabled, warn the admin when the generated regex is invalid

- Added a "test" button to the admin UI, so that it is easy to test for matches:

<img width="496" alt="Screenshot 2019-08-02 at 11 00 20" src="https://user-images.githubusercontent.com/6270921/62362403-c0323500-b514-11e9-8e6c-730c9abc0633.png">
