### PR TITLE
Poll migration is not idempotent

### DIFF
--- a/plugins/poll/db/post_migrate/20180820080623_migrate_polls_data.rb
+++ b/plugins/poll/db/post_migrate/20180820080623_migrate_polls_data.rb
@@ -95,6 +95,8 @@ class MigratePollsData < ActiveRecord::Migration[5.2]
         step = poll["step"].to_i.clamp(0, max)
         anonymous_voters = poll["anonymous_voters"].to_i.clamp(0, PG_INTEGER_MAX)
 
+        next if Poll.exists?(post_id: r.post_id, name: escape(name))
+
         poll_id = execute(<<~SQL
           INSERT INTO polls (
             post_id,


### PR DESCRIPTION
The  poll migration script (for 2.3.0) is not idempotent due to database constrains on the
poll related objects, namely:
```
polls: index_polls_on_post_id_and_name (post_id,name) UNIQUE
poll_options: index_poll_options_on_poll_id_and_digest  (poll_id,digest) UNIQUE
poll_votes:  index_poll_votes_on_poll_id_and_poll_option_id_and_user_id  (poll_id,poll_option_id,user_id) UNIQUE
```
This change skips a particular poll migration if it's already found on
the db. We also wrap the poll migration in a transaction so that if the
script happens to fail mid-way while migrating a poll we rollback the
poll and all it's related records, thus preventing undesirable partial
states.