### PR TITLE
fixed a small typo in the function's doc comment

### DIFF
--- a/app/assets/javascripts/discourse/lib/plugin-api.js.es6
+++ b/app/assets/javascripts/discourse/lib/plugin-api.js.es6
@@ -529,7 +529,7 @@ class PluginApi {
 
   /**
    * Exposes the widget creating ability to plugins. Plugins can
-   * register their own plugins and attach them with decorators.
+   * register their own widgets and attach them with decorators.
    * See `createWidget` in `discourse/widgets/widget` for more info.
    **/
   createWidget(name, args) {


### PR DESCRIPTION
Fixed a typo in the plugin-api file. Plugins can create their own ~~plugins~~ widgets