### PR TITLE
FIX: Rename deprecated "refresh" icon to "sync"

### DIFF
--- a/app/assets/javascripts/discourse/controllers/exception.js.es6
+++ b/app/assets/javascripts/discourse/controllers/exception.js.es6
@@ -17,7 +17,7 @@ const ButtonBackBright = {
     classes: "btn-primary",
     action: "tryLoading",
     key: "errors.buttons.again",
-    icon: "refresh"
+    icon: "sync"
   },
   ButtonLoadPage = {
     classes: "btn-primary",


### PR DESCRIPTION
I picked this up in the console:

> Deprecation notice: Please replace all occurrences of "refresh" with "sync". FontAwesome 4.7 icon names are now deprecated and will be removed in the next release.

Fixed this in the exception page, and tested that it's working as intended. I also did a quick grep through the codebase, this seems to be the only occurrence of "refresh".

cc/ @pmusaraj Thanks!