### PR TITLE
FIX: Use multiple multisite databases in parallel tests

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -34,11 +34,10 @@ end
 # Parallel spec system
 if ENV['RAILS_ENV'] == "test" && ENV['TEST_ENV_NUMBER']
   if ENV['TEST_ENV_NUMBER'] == ''
-    n = 1
-  else
-    n = ENV['TEST_ENV_NUMBER'].to_i
+    ENV['TEST_ENV_NUMBER'] = '1'
   end
 
+  n = ENV['TEST_ENV_NUMBER'].to_i
   port = 10000 + n
 
   STDERR.puts "Setting up parallel test mode - starting Redis #{n} on port #{port}"
@@ -47,7 +46,16 @@ if ENV['RAILS_ENV'] == "test" && ENV['TEST_ENV_NUMBER']
   pid = Process.spawn("redis-server --dir tmp/test_data_#{n}/redis --port #{port}", out: "/dev/null")
 
   ENV["DISCOURSE_REDIS_PORT"] = port.to_s
-  ENV["RAILS_DB"] = "discourse_test_#{n}"
+
+  db = ['discourse_test']
+
+  if ENV['USE_MULTISITE_DB']
+    db << "multisite"
+  end
+
+  db << n.to_s
+
+  ENV["RAILS_DB"] = db.join('_')
 
   at_exit do
     Process.kill("SIGTERM", pid)

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -42,9 +42,21 @@ begin
   Rake::Task['db:create'].enhance(["db:force_skip_persist"] + reqs)
 end
 
+task 'parallel:create' do |_, args|
+  if !ENV.include?('USE_MULTISITE_DB')
+    system("RAILS_ENV=test USE_MULTISITE_DB=1 rake parallel:create")
+  end
+end
+
 task 'db:drop' => [:load_config] do |_, args|
   if MultisiteTestHelpers.create_multisite?
     system("RAILS_DB=discourse_test_multisite RAILS_ENV=test rake db:drop")
+  end
+end
+
+task 'parallel:drop' do |_, args|
+  if !ENV.include?('USE_MULTISITE_DB')
+    system("RAILS_ENV=test USE_MULTISITE_DB=1 rake parallel:drop")
   end
 end
 
@@ -63,6 +75,12 @@ task 'db:migrate' => ['environment', 'set_locale'] do |_, args|
     system("rake db:schema:dump")
     system("RAILS_DB=discourse_test_multisite rake db:schema:load")
     system("RAILS_DB=discourse_test_multisite rake db:migrate")
+  end
+end
+
+task 'parallel:migrate' do |_, args|
+  if !ENV.include?('USE_MULTISITE_DB')
+    system("RAILS_ENV=test USE_MULTISITE_DB=1 rake parallel:migrate")
   end
 end
 


### PR DESCRIPTION
These new databases can be managed using the `parallel:*` commands.