### PR TITLE
FIX: Award 'First Onebox' badge just for Oneboxed URLs.

### DIFF
--- a/lib/cooked_post_processor.rb
+++ b/lib/cooked_post_processor.rb
@@ -28,7 +28,7 @@ class CookedPostProcessor
     @cooking_options = @cooking_options.symbolize_keys
 
     @doc = Nokogiri::HTML::fragment(post.cook(post.raw, @cooking_options))
-    @has_oneboxes = post.post_analyzer.found_oneboxes?
+    @has_oneboxes = @doc.css("aside.onebox").count > 0
     @size_cache = {}
 
     @disable_loading_image = !!opts[:disable_loading_image]
@@ -506,13 +506,14 @@ class CookedPostProcessor
       map[url] = true
 
       if is_onebox
-        @has_oneboxes = true
-
-        Oneboxer.onebox(url,
+        onebox = Oneboxer.onebox(url,
           invalidate_oneboxes: !!@opts[:invalidate_oneboxes],
           user_id: @post&.user_id,
           category_id: @post&.topic&.category_id
         )
+
+        @has_oneboxes = true if onebox.present?
+        onebox
       else
         process_inline_onebox(element)
         false


### PR DESCRIPTION
We are adding a `onebox` class when cooking the content to any link, but we are not sure it will be oneboxed until we actually try to onebox it. This commit ensures that.