### PR TITLE
FIX: Use unescaped title as combo-box id

### DIFF
--- a/app/assets/javascripts/discourse/models/user.js.es6
+++ b/app/assets/javascripts/discourse/models/user.js.es6
@@ -759,7 +759,12 @@ const User = RestModel.extend({
 
     return _.uniq(titles)
       .sort()
-      .map(Ember.Handlebars.Utils.escapeExpression);
+      .map(title => {
+        return {
+          name: Ember.Handlebars.Utils.escapeExpression(title),
+          id: title
+        };
+      });
   },
 
   @computed("user_option.text_size_seq", "user_option.text_size")


### PR DESCRIPTION
User title options are escaped using `Ember.Handlebars.Utils.escapeExpression` for security reasons. We don't want to send the escaped version to the back-end.