### PR TITLE
FIX: Notify on Reviewable update.

### DIFF
--- a/app/models/reviewable.rb
+++ b/app/models/reviewable.rb
@@ -38,6 +38,9 @@ class Reviewable < ActiveRecord::Base
 
   after_commit(on: :create) do
     DiscourseEvent.trigger(:reviewable_created, self)
+  end
+
+  after_commit(on: [:create, :update]) do
     Jobs.enqueue(:notify_reviewable, reviewable_id: self.id) if pending?
   end
 


### PR DESCRIPTION
If a post is flagged after an action was already performed on it, it
will update the previous Reviable instance and not create a new one.
The notification logic was implemented in the :create callback which was
completely skipped in this case.