### PR TITLE
FEATURE: Staff only poll results

### DIFF
--- a/plugins/poll/app/models/poll.rb
+++ b/plugins/poll/app/models/poll.rb
@@ -42,7 +42,7 @@ class Poll < ActiveRecord::Base
 
   def can_see_results?(user)
     return true if always?
-    return user&.staff? if staff_only?
+    return !!user&.staff? if staff_only?
     return has_voted?(user) if on_vote?
     is_closed?
   end

--- a/plugins/poll/app/models/poll.rb
+++ b/plugins/poll/app/models/poll.rb
@@ -24,6 +24,7 @@ class Poll < ActiveRecord::Base
     always: 0,
     on_vote: 1,
     on_close: 2,
+    staff_only: 3,
   }
 
   enum visibility: {
@@ -40,7 +41,7 @@ class Poll < ActiveRecord::Base
   end
 
   def can_see_results?(user)
-    always? || is_closed? || (on_vote? && has_voted?(user))
+    always? || is_closed? || (on_vote? && has_voted?(user)) || (staff_only? && user&.staff?)
   end
 
   def has_voted?(user)

--- a/plugins/poll/app/models/poll.rb
+++ b/plugins/poll/app/models/poll.rb
@@ -41,7 +41,10 @@ class Poll < ActiveRecord::Base
   end
 
   def can_see_results?(user)
-    always? || is_closed? || (on_vote? && has_voted?(user)) || (staff_only? && user&.staff?)
+    return true if always?
+    return user&.staff? if staff_only?
+    return has_voted?(user) if on_vote?
+    is_closed?
   end
 
   def has_voted?(user)

--- a/plugins/poll/assets/javascripts/controllers/poll-ui-builder.js.es6
+++ b/plugins/poll/assets/javascripts/controllers/poll-ui-builder.js.es6
@@ -12,6 +12,7 @@ export default Ember.Controller.extend({
   alwaysPollResult: "always",
   votePollResult: "on_vote",
   closedPollResult: "on_close",
+  staffPollResult: "staff_only",
 
   init() {
     this._super(...arguments);
@@ -36,8 +37,8 @@ export default Ember.Controller.extend({
     ];
   },
 
-  @computed("alwaysPollResult", "votePollResult", "closedPollResult")
-  pollResults(alwaysPollResult, votePollResult, closedPollResult) {
+  @computed("alwaysPollResult", "votePollResult", "closedPollResult", "staffPollResult")
+  pollResults(alwaysPollResult, votePollResult, closedPollResult, staffPollResult) {
     return [
       {
         name: I18n.t("poll.ui_builder.poll_result.always"),
@@ -50,6 +51,10 @@ export default Ember.Controller.extend({
       {
         name: I18n.t("poll.ui_builder.poll_result.closed"),
         value: closedPollResult
+      },
+      {
+        name: I18n.t("poll.ui_builder.poll_result.staff"),
+        value: staffPollResult
       }
     ];
   },

--- a/plugins/poll/config/locales/client.en.yml
+++ b/plugins/poll/config/locales/client.en.yml
@@ -36,7 +36,7 @@ en:
         closed:
           title: "Results will be shown once <strong>closed</strong>."
         staff:
-          title: "Results will be shown once <strong>staff</strong>."
+          title: "Results are only shown to <strong>staff</strong> members."
 
       multiple:
         help:

--- a/plugins/poll/config/locales/client.en.yml
+++ b/plugins/poll/config/locales/client.en.yml
@@ -35,6 +35,8 @@ en:
           title: "Results will be shown on <strong>vote</strong>."
         closed:
           title: "Results will be shown once <strong>closed</strong>."
+        staff:
+          title: "Results will be shown once <strong>staff</strong>."
 
       multiple:
         help:
@@ -96,6 +98,7 @@ en:
           always: Always visible
           vote: On vote
           closed: When closed
+          staff: Staff only
         poll_config:
           max: Max
           min: Min


### PR DESCRIPTION
These changes allow only staff to see the results of a poll.

Non-staff users will be shown a screen like this:

https://review.discourse.org/uploads/default/original/1X/1b8bd76013363860f2bc455049cf35e69ef44e0a.png

The "Votes are public" message has been removed from the info section,
and the button to show the votes has been replaced with a message
stating the results will only be shown to staff.