### PR TITLE
FEATURE: Add a preview to the poll builder

### DIFF
--- a/app/assets/stylesheets/common/base/modal.scss
+++ b/app/assets/stylesheets/common/base/modal.scss
@@ -142,7 +142,7 @@
   overflow: auto;
 
   &:not(.history-modal) {
-    .modal-body:not(.reorder-categories) {
+    .modal-body:not(.reorder-categories):not(.poll-ui-builder) {
       max-height: none !important;
     }
   }
@@ -475,10 +475,12 @@
   }
 }
 
+.change-timestamp {
+  max-width: 420px;
+}
+
 .change-timestamp,
 .poll-ui-builder {
-  max-width: 420px;
-
   #date-container {
     .pika-single {
       position: relative !important; // overriding another important

--- a/plugins/poll/assets/javascripts/discourse/templates/modal/poll-ui-builder.hbs
+++ b/plugins/poll/assets/javascripts/discourse/templates/modal/poll-ui-builder.hbs
@@ -1,83 +1,87 @@
 {{#d-modal-body title="poll.ui_builder.title" class="poll-ui-builder"}}
   <form class="poll-ui-builder-form form-horizontal">
-    <div class="input-group poll-select">
-      <label class="input-group-label">{{i18n 'poll.ui_builder.poll_type.label'}}</label>
-      {{combo-box content=pollTypes
-                  value=pollType
-                  allowInitialValueMutation=true
-                  valueAttribute="value"}}
-    </div>
-
-    <div class="input-group poll-select">
-      <label class="input-group-label">{{i18n 'poll.ui_builder.poll_result.label'}}</label>
-      {{combo-box content=pollResults
-                  value=pollResult
-                  allowInitialValueMutation=true
-                  valueAttribute="value"}}
-    </div>
-
-
-    {{#if showMinMax}}
-      <div class="input-group poll-number">
-        <label class="input-group-label">{{i18n 'poll.ui_builder.poll_config.min'}}</label>
-        {{input type='number'
-                value=pollMin
-                valueAttribute="value"
-                class="poll-options-min"}}
-      </div>
-      {{input-tip validation=minMaxValueValidation}}
-
-
-      <div class="input-group poll-number">
-        <label class="input-group-label">{{i18n 'poll.ui_builder.poll_config.max'}}</label>
-        {{input type='number'
-                value=pollMax
-                valueAttribute="value"
-                class="poll-options-max"}}
+    <div class="options">
+      <div class="input-group poll-select">
+        <label class="input-group-label">{{i18n 'poll.ui_builder.poll_type.label'}}</label>
+        {{combo-box content=pollTypes
+                    value=pollType
+                    allowInitialValueMutation=true
+                    valueAttribute="value"}}
       </div>
 
-      {{#if isNumber}}
+      <div class="input-group poll-select">
+        <label class="input-group-label">{{i18n 'poll.ui_builder.poll_result.label'}}</label>
+        {{combo-box content=pollResults
+                    value=pollResult
+                    allowInitialValueMutation=true
+                    valueAttribute="value"}}
+      </div>
+
+      {{#if showMinMax}}
         <div class="input-group poll-number">
-          <label class="input-group-label">{{i18n 'poll.ui_builder.poll_config.step'}}</label>
+          <label class="input-group-label">{{i18n 'poll.ui_builder.poll_config.min'}}</label>
           {{input type='number'
-                  value=pollStep
+                  value=pollMin
                   valueAttribute="value"
-                  min="1"
-                  class="poll-options-step"}}
+                  class="poll-options-min"}}
         </div>
-        {{input-tip validation=minStepValueValidation}}
+        {{input-tip validation=minMaxValueValidation}}
+
+        <div class="input-group poll-number">
+          <label class="input-group-label">{{i18n 'poll.ui_builder.poll_config.max'}}</label>
+          {{input type='number'
+                  value=pollMax
+                  valueAttribute="value"
+                  class="poll-options-max"}}
+        </div>
+
+        {{#if isNumber}}
+          <div class="input-group poll-number">
+            <label class="input-group-label">{{i18n 'poll.ui_builder.poll_config.step'}}</label>
+            {{input type='number'
+                    value=pollStep
+                    valueAttribute="value"
+                    min="1"
+                    class="poll-options-step"}}
+          </div>
+          {{input-tip validation=minStepValueValidation}}
+        {{/if}}
       {{/if}}
-    {{/if}}
 
-    {{#unless isNumber}}
-      <div class="input-group poll-textarea">
-        <label>{{i18n 'poll.ui_builder.poll_options.label'}}</label>
-        {{textarea value=pollOptions autocomplete="discourse"}}
+      {{#unless isNumber}}
+        <div class="input-group poll-textarea">
+          <label>{{i18n 'poll.ui_builder.poll_options.label'}}</label>
+          {{textarea value=pollOptions autocomplete="discourse"}}
+        </div>
+        {{input-tip validation=minNumOfOptionsValidation}}
+      {{/unless}}
+
+      <div class="input-group poll-checkbox">
+        <label>
+          {{input type='checkbox' checked=publicPoll}}
+          {{i18n "poll.ui_builder.poll_public.label"}}
+        </label>
       </div>
-      {{input-tip validation=minNumOfOptionsValidation}}
-    {{/unless}}
 
-    <div class="input-group poll-checkbox">
-      <label>
-        {{input type='checkbox' checked=publicPoll}}
-        {{i18n "poll.ui_builder.poll_public.label"}}
-      </label>
+      <div class="input-group poll-checkbox">
+        <label>
+          {{input type="checkbox" checked=autoClose}}
+          {{i18n "poll.ui_builder.automatic_close.label"}}
+        </label>
+      </div>
+
+      {{#if autoClose}}
+        <div class="input-group poll-date">
+          {{date-picker-future value=date containerId="date-container"}}
+          {{input type="time" value=time}}
+          <div id="date-container"></div>
+        </div>
+      {{/if}}
     </div>
 
-    <div class="input-group poll-checkbox">
-      <label>
-        {{input type="checkbox" checked=autoClose}}
-        {{i18n "poll.ui_builder.automatic_close.label"}}
-      </label>
+    <div class="d-editor-preview">
+      {{cook-text this.pollOutput}}
     </div>
-
-    {{#if autoClose}}
-      <div class="input-group">
-        {{date-picker-future value=date containerId="date-container"}}
-        {{input type="time" value=time}}
-        <div id="date-container"></div>
-      </div>
-    {{/if}}
   </form>
 {{/d-modal-body}}
 

--- a/plugins/poll/assets/stylesheets/common/poll-ui-builder.scss
+++ b/plugins/poll/assets/stylesheets/common/poll-ui-builder.scss
@@ -1,7 +1,18 @@
 $poll-margin: 10px;
 
 .poll-ui-builder-form {
+  display: flex;
   margin: 0;
+
+  .options {
+    flex-shrink: 0;
+    width: 280px;
+  }
+
+  .d-editor-preview {
+    margin-left: $poll-margin * 2;
+    width: 360px;
+  }
 
   label {
     font-weight: bold;
@@ -45,7 +56,8 @@ $poll-margin: 10px;
     margin-top: $poll-margin;
   }
 
-  .poll-checkbox {
+  .poll-checkbox,
+  .poll-date {
     margin-top: $poll-margin / 2;
   }
 }

--- a/plugins/poll/assets/stylesheets/common/poll.scss
+++ b/plugins/poll/assets/stylesheets/common/poll.scss
@@ -21,6 +21,7 @@ div.poll {
   li[data-poll-option-id] {
     color: $primary;
     padding: 0.5em 0;
+    word-break: break-word;
   }
 
   img {

--- a/plugins/poll/assets/stylesheets/mobile/poll-ui-builder.scss
+++ b/plugins/poll/assets/stylesheets/mobile/poll-ui-builder.scss
@@ -1,0 +1,5 @@
+.poll-ui-builder-form {
+  .d-editor-preview {
+    display: none;
+  }
+}

--- a/plugins/poll/assets/stylesheets/mobile/poll.scss
+++ b/plugins/poll/assets/stylesheets/mobile/poll.scss
@@ -27,9 +27,3 @@ div.poll {
     }
   }
 }
-
-.poll-ui-builder-form {
-  .d-editor-preview {
-    display: none;
-  }
-}

--- a/plugins/poll/assets/stylesheets/mobile/poll.scss
+++ b/plugins/poll/assets/stylesheets/mobile/poll.scss
@@ -27,3 +27,9 @@ div.poll {
     }
   }
 }
+
+.poll-ui-builder-form {
+  .d-editor-preview {
+    display: none;
+  }
+}

--- a/plugins/poll/plugin.rb
+++ b/plugins/poll/plugin.rb
@@ -10,6 +10,7 @@ register_asset "stylesheets/common/poll.scss"
 register_asset "stylesheets/common/poll-ui-builder.scss"
 register_asset "stylesheets/desktop/poll.scss", :desktop
 register_asset "stylesheets/mobile/poll.scss", :mobile
+register_asset "stylesheets/mobile/poll-ui-builder.scss", :mobile
 
 register_svg_icon "far fa-check-square"
 

--- a/plugins/poll/test/javascripts/acceptance/poll-builder-enabled-test.js.es6
+++ b/plugins/poll/test/javascripts/acceptance/poll-builder-enabled-test.js.es6
@@ -1,3 +1,4 @@
+import selectKit from "helpers/select-kit-helper";
 import { acceptance, updateCurrentUser } from "helpers/qunit-helpers";
 import { displayPollBuilderButton } from "discourse/plugins/poll/helpers/display-poll-builder-button";
 import { clearPopupMenuOptionsCallback } from "discourse/controllers/composer";
@@ -54,7 +55,10 @@ test("staff - with insufficient trust level", assert => {
 
 test("poll preview", async assert => {
   displayPollBuilderButton();
-  await click(".select-kit-row[title='Build Poll']");
+  const popupMenu = selectKit(".toolbar-popup-menu-options");
+  await popupMenu.expand();
+  await popupMenu.selectRowByValue("showPollBuilder");
+
   await fillIn(".poll-textarea textarea", "First option\nSecond option");
 
   assert.equal(find(".d-editor-preview li:first-child").text(), "First option");

--- a/plugins/poll/test/javascripts/acceptance/poll-builder-enabled-test.js.es6
+++ b/plugins/poll/test/javascripts/acceptance/poll-builder-enabled-test.js.es6
@@ -51,3 +51,12 @@ test("staff - with insufficient trust level", assert => {
     );
   });
 });
+
+test("poll preview", async assert => {
+  displayPollBuilderButton();
+  await click(".select-kit-row[title='Build Poll']");
+  await fillIn(".poll-textarea textarea", "First option\nSecond option");
+
+  assert.equal(find(".d-editor-preview li:first-child").text(), "First option");
+  assert.equal(find(".d-editor-preview li:last-child").text(), "Second option");
+});


### PR DESCRIPTION
Closes https://meta.discourse.org/t/show-preview-in-poll-builder/117323/6

<img src="https://user-images.githubusercontent.com/66961/62738030-8d66d000-ba31-11e9-817d-49ae6792cf1c.png" width=400 alt="poll builder preview">

Shout out to @pmusaraj for the recent poll [builder tweaks](https://github.com/discourse/discourse/commit/78500fb77017ae1defd9d1a77f26164493847624). Saved me some CSS tweaking! 😃

I've hardcoded both column widths, which isn't ideal, but modal's `max-width` means that it expands horizontally as you type (until it reaches that max width). As far as I know, there is no way to force a flex element to fill all the available space up to the `max-width`. I'm open to suggestions. 😉 

Oh, and the `poll-ui-builder.hbs` diff looks messy only because I've wrapped all the poll options in a `<div class="options">`.