### PR TITLE
UX: Improve error handling for common OmniAuth exceptions

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -91,7 +91,7 @@ class Users::OmniauthCallbacksController < ApplicationController
   end
 
   def failure
-    error_key = params[:message].to_s.gsub(/[^a-z0-9_-]/, "") || "generic"
+    error_key = params[:message].to_s.gsub(/[^\w-]/, "") || "generic"
     flash[:error] = I18n.t("login.omniauth_error.#{error_key}", default: I18n.t("login.omniauth_error.generic"))
     render 'failure'
   end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -91,7 +91,8 @@ class Users::OmniauthCallbacksController < ApplicationController
   end
 
   def failure
-    flash[:error] = I18n.t("login.omniauth_error")
+    error_key = params[:message].to_s.gsub(/[^a-z0-9_-]/, "") || "generic"
+    flash[:error] = I18n.t("login.omniauth_error.#{error_key}", default: I18n.t("login.omniauth_error.generic"))
     render 'failure'
   end
 

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2224,7 +2224,11 @@ en:
     errors: "%{errors}"
     not_available: "Not available. Try %{suggestion}?"
     something_already_taken: "Something went wrong, perhaps the username or email is already registered. Try the forgot password link."
-    omniauth_error: "Sorry, there was an error authorizing your account. Perhaps you did not approve authorization?"
+    omniauth_error: 
+      generic: "Sorry, there was an error authorizing your account. Please try again."
+      csrf_detected: "Authorization timed out, or you have switched browsers. Please try again."
+      request_error: "An error occured when starting authorization. Please try again."
+      invalid_iat: "Unable to verify authorization token due to server clock differences. Please try again."
     omniauth_error_unknown: "Something went wrong processing your log in, please try again."
     omniauth_confirm_title: "Log in using %{provider}"
     omniauth_confirm_button: "Continue"

--- a/lib/csrf_token_verifier.rb
+++ b/lib/csrf_token_verifier.rb
@@ -2,6 +2,8 @@
 
 # Provides a way to check a CSRF token outside of a controller
 class CSRFTokenVerifier
+  class InvalidCSRFToken < StandardError; end
+
   include ActiveSupport::Configurable
   include ActionController::RequestForgeryProtection
 
@@ -17,7 +19,7 @@ class CSRFTokenVerifier
     @request = ActionDispatch::Request.new(env.dup)
 
     unless verified_request?
-      raise ActionController::InvalidAuthenticityToken
+      raise InvalidCSRFToken
     end
   end
 

--- a/spec/requests/omniauth_callbacks_controller_spec.rb
+++ b/spec/requests/omniauth_callbacks_controller_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe Users::OmniauthCallbacksController do
 
       it "should error for disabled authenticators" do
         SiteSetting.enable_google_oauth2_logins = false
-        post "/auth/fake_auth"
+        post "/auth/google_oauth2"
         expect(response.status).to eq(404)
         get "/auth/google_oauth2"
         expect(response.status).to eq(403)

--- a/spec/requests/omniauth_callbacks_controller_spec.rb
+++ b/spec/requests/omniauth_callbacks_controller_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Users::OmniauthCallbacksController do
     it "should display the failure message if needed" do
       get "/auth/failure"
       expect(response.status).to eq(200)
-      expect(response.body).to include(I18n.t("login.omniauth_error"))
+      expect(response.body).to include(I18n.t("login.omniauth_error.generic"))
     end
 
     describe "request" do
@@ -96,6 +96,28 @@ RSpec.describe Users::OmniauthCallbacksController do
         expect(response.status).to eq(404)
         get "/auth/fake_auth"
         expect(response.status).to eq(403)
+      end
+
+      it "should error for disabled authenticators" do
+        SiteSetting.enable_google_oauth2_logins = false
+        post "/auth/fake_auth"
+        expect(response.status).to eq(404)
+        get "/auth/google_oauth2"
+        expect(response.status).to eq(403)
+      end
+
+      it "should handle common errors" do
+        OmniAuth::Strategies::GoogleOauth2.any_instance.stubs(:mock_request_call).raises(
+          OAuth::Unauthorized.new(mock().tap { |m| m.stubs(:code).returns(403); m.stubs(:message).returns("Message") })
+        )
+        post "/auth/google_oauth2"
+        expect(response.status).to eq(302)
+        expect(response.location).to end_with("/auth/failure?message=request_error")
+
+        OmniAuth::Strategies::GoogleOauth2.any_instance.stubs(:mock_request_call).raises(JWT::InvalidIatError.new)
+        post "/auth/google_oauth2"
+        expect(response.status).to eq(302)
+        expect(response.location).to end_with("/auth/failure?message=invalid_iat")
       end
 
       it "should only start auth with a POST request" do
@@ -111,10 +133,12 @@ RSpec.describe Users::OmniauthCallbacksController do
 
         it "should be CSRF protected" do
           post "/auth/google_oauth2"
-          expect(response.status).to eq(422)
+          expect(response.status).to eq(302)
+          expect(response.location).to include("/auth/failure?message=csrf_detected")
 
           post "/auth/google_oauth2", params: { authenticity_token: "faketoken" }
-          expect(response.status).to eq(422)
+          expect(response.status).to eq(302)
+          expect(response.location).to include("/auth/failure?message=csrf_detected")
 
           get "/session/csrf.json"
           token = JSON.parse(response.body)["csrf"]

--- a/spec/requests/omniauth_callbacks_controller_spec.rb
+++ b/spec/requests/omniauth_callbacks_controller_spec.rb
@@ -112,12 +112,12 @@ RSpec.describe Users::OmniauthCallbacksController do
         )
         post "/auth/google_oauth2"
         expect(response.status).to eq(302)
-        expect(response.location).to end_with("/auth/failure?message=request_error")
+        expect(response.location).to include("/auth/failure?message=request_error")
 
         OmniAuth::Strategies::GoogleOauth2.any_instance.stubs(:mock_request_call).raises(JWT::InvalidIatError.new)
         post "/auth/google_oauth2"
         expect(response.status).to eq(302)
-        expect(response.location).to end_with("/auth/failure?message=invalid_iat")
+        expect(response.location).to include("/auth/failure?message=invalid_iat")
       end
 
       it "should only start auth with a POST request" do

--- a/spec/views/omniauth_callbacks/failure.html.erb_spec.rb
+++ b/spec/views/omniauth_callbacks/failure.html.erb_spec.rb
@@ -8,7 +8,7 @@ describe "users/omniauth_callbacks/failure.html.erb" do
     flash[:error] = I18n.t("login.omniauth_error", strategy: 'test')
       render
 
-      expect(rendered.match(I18n.t("login.omniauth_error", strategy: 'test'))).not_to eq(nil)
+      expect(rendered.match(I18n.t("login.omniauth_error.generic", strategy: 'test'))).not_to eq(nil)
   end
 
 end


### PR DESCRIPTION
This displays more useful messages for the most common issues we see:
- CSRF (when the user switches browser)
- Invalid IAT (when the server clock is wrong)
- OAuth::Unauthorized for OAuth1 providers (e.g. Twitter), when the credentials are incorrect

This commit also stops earlier for disabled authenticators. Now we stop at the request phase, rather than the callback phase.