### PR TITLE
FIX: Do not create a double like notification.

### DIFF
--- a/lib/post_action_creator.rb
+++ b/lib/post_action_creator.rb
@@ -205,7 +205,6 @@ private
       post_action.recover!
       action_attrs.each { |attr, val| post_action.public_send("#{attr}=", val) }
       post_action.save
-      PostActionNotifier.post_action_created(post_action)
     else
       post_action = PostAction.create(where_attrs.merge(action_attrs))
       if post_action && post_action.errors.count == 0


### PR DESCRIPTION
When a user liked, unliked and liked again the same post, the poster
would receive a notification such as "X and X liked ...". This happened
because PostActionNotifier.post_action_created was called twice.