### PR TITLE
FIX: Race-condition in fallback handlers

### DIFF
--- a/lib/active_record/connection_adapters/postgresql_fallback_adapter.rb
+++ b/lib/active_record/connection_adapters/postgresql_fallback_adapter.rb
@@ -32,19 +32,21 @@ class PostgreSQLFallbackHandler
   end
 
   def verify_master
-    synchronize { return if @thread && @thread.alive? }
+    synchronize do
+      return if @thread && @thread.alive?
 
-    @thread = Thread.new do
-      while true do
-        thread = Thread.new { initiate_fallback_to_master }
-        thread.abort_on_exception = true
-        thread.join
-        break if synchronize { @masters_down.hash.empty? }
-        sleep 5
+      @thread = Thread.new do
+        while true do
+          thread = Thread.new { initiate_fallback_to_master }
+          thread.abort_on_exception = true
+          thread.join
+          break if synchronize { @masters_down.hash.empty? }
+          sleep 5
+        end
       end
-    end
 
-    @thread.abort_on_exception = true
+      @thread.abort_on_exception = true
+    end
   end
 
   def master_down?

--- a/lib/discourse_redis.rb
+++ b/lib/discourse_redis.rb
@@ -23,17 +23,19 @@ class DiscourseRedis
     end
 
     def verify_master
-      synchronize { return if @thread && @thread.alive? }
+      synchronize do
+        return if @thread && @thread.alive?
 
-      @thread = Thread.new do
-        loop do
-          begin
-            thread = Thread.new { initiate_fallback_to_master }
-            thread.join
-            break if synchronize { @master }
-            sleep 5
-          ensure
-            thread.kill
+        @thread = Thread.new do
+          loop do
+            begin
+              thread = Thread.new { initiate_fallback_to_master }
+              thread.join
+              break if synchronize { @master }
+              sleep 5
+            ensure
+              thread.kill
+            end
           end
         end
       end


### PR DESCRIPTION
Calling `verify_master` in multiple threads simultaneously would cause
multiple threads to be spawned.