### PR TITLE
FIX: ensures reports can't modify records

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -83,6 +83,9 @@ class Report
 
   def self.wrap_slow_query(timeout = 20000)
     ActiveRecord::Base.connection.transaction do
+      # Setting transaction to read only prevents shoot-in-foot actions like SELECT FOR UPDATE
+      # see test 'doesn't allow you to modify the database #1'
+      DB.exec "SET TRANSACTION READ ONLY"
       # Set a statement timeout so we can't tie up the server
       DB.exec "SET LOCAL statement_timeout = #{timeout}"
       yield

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -83,8 +83,7 @@ class Report
 
   def self.wrap_slow_query(timeout = 20000)
     ActiveRecord::Base.connection.transaction do
-      # Setting transaction to read only prevents shoot-in-foot actions like SELECT FOR UPDATE
-      # see test 'doesn't allow you to modify the database #1'
+      # Allows only read only transactions
       DB.exec "SET TRANSACTION READ ONLY"
       # Set a statement timeout so we can't tie up the server
       DB.exec "SET LOCAL statement_timeout = #{timeout}"


### PR DESCRIPTION
We do this in discourse-data-explorer and I think it totally makes sense to have the same guard in our reports to prevent any mistake and future usage.