### PR TITLE
FIX: attempts to use params from addDiscoveryQueryParam

### DIFF
--- a/app/assets/javascripts/discourse/components/d-navigation.js.es6
+++ b/app/assets/javascripts/discourse/components/d-navigation.js.es6
@@ -1,6 +1,9 @@
 import computed from "ember-addons/ember-computed-decorators";
 
 export default Ember.Component.extend({
+  router: Ember.inject.service(),
+  persistedQueryParams: null,
+
   tagName: "",
 
   @computed("category")
@@ -27,9 +30,25 @@ export default Ember.Component.extend({
     if (filterMode.indexOf("top/") === 0) {
       filterMode = filterMode.replace("top/", "");
     }
+
+    let params;
+    const currentRouteQueryParams = this.get("router.currentRoute.queryParams");
+    if (this.persistedQueryParams && currentRouteQueryParams) {
+      const currentKeys = Object.keys(currentRouteQueryParams);
+      const discoveryKeys = Object.keys(this.persistedQueryParams);
+      const supportedKeys = currentKeys.filter(
+        i => discoveryKeys.indexOf(i) > 0
+      );
+      params = supportedKeys.reduce((object, key) => {
+        object[key] = currentRouteQueryParams[key];
+        return object;
+      }, {});
+    }
+
     return Discourse.NavItem.buildList(category, {
       filterMode,
-      noSubcategories
+      noSubcategories,
+      persistedQueryParams: params
     });
   }
 });

--- a/app/assets/javascripts/discourse/components/navigation-item.js.es6
+++ b/app/assets/javascripts/discourse/components/navigation-item.js.es6
@@ -26,13 +26,26 @@ export default Ember.Component.extend(
       const content = this.content;
 
       let href = content.get("href");
+      let queryParams = [];
 
       // Include the category id if the option is present
       if (content.get("includeCategoryId")) {
         let categoryId = this.get("category.id");
         if (categoryId) {
-          href += `?category_id=${categoryId}`;
+          queryParams.push(`category_id=${categoryId}`);
         }
+      }
+
+      // ensures we keep discovery query params added through plugin api
+      if (content.persistedQueryParams) {
+        Object.keys(content.persistedQueryParams).forEach(key => {
+          const value = content.persistedQueryParams[key];
+          queryParams.push(`${key}=${value}`);
+        });
+      }
+
+      if (queryParams.length) {
+        href += `?${queryParams.join("&")}`;
       }
 
       if (

--- a/app/assets/javascripts/discourse/controllers/discovery-sortable.js.es6
+++ b/app/assets/javascripts/discourse/controllers/discovery-sortable.js.es6
@@ -1,3 +1,5 @@
+import DiscourseNavigation from "discourse/components/d-navigation";
+
 // Just add query params here to have them automatically passed to topic list filters.
 export const queryParams = {
   order: { replace: true, refreshModel: true },
@@ -31,6 +33,12 @@ export const addDiscoveryQueryParam = function(p, opts) {
   cOpts[p] = Ember.computed.alias(`discoveryTopics.${p}`);
   cOpts["queryParams"] = Object.keys(queryParams);
   Controller.reopen(cOpts);
+
+  if (opts && opts.persisted) {
+    DiscourseNavigation.reopen({
+      persistedQueryParams: queryParams
+    });
+  }
 };
 
 export default Controller;

--- a/app/assets/javascripts/discourse/models/nav-item.js.es6
+++ b/app/assets/javascripts/discourse/models/nav-item.js.es6
@@ -136,6 +136,9 @@ NavItem.reopenClass({
     if (opts.category) {
       args.category = opts.category;
     }
+    if (opts.persistedQueryParams) {
+      args.persistedQueryParams = opts.persistedQueryParams;
+    }
     if (opts.noSubcategories) {
       args.noSubcategories = true;
     }


### PR DESCRIPTION
This commit will for example allow this:

```
api.addDiscoveryQueryParam("my_param", { persist: true });
```

If you page is forum.foo.bar/?my_param=1, when clicking on an "unread" link for example this query string will be kept.