### PR TITLE
FIX: Store custom attributes that are needed by plugins

### DIFF
--- a/lib/new_post_manager.rb
+++ b/lib/new_post_manager.rb
@@ -21,6 +21,14 @@ class NewPostManager
     sorted_handlers.map { |h| h[:proc] }
   end
 
+  def self.plugin_payload_attributes
+    @payload_attributes ||= []
+  end
+
+  def self.add_plugin_payload_attribute(attribute)
+    plugin_payload_attributes << attribute
+  end
+
   def self.clear_handlers!
     @sorted_handlers = []
   end
@@ -208,6 +216,9 @@ class NewPostManager
     %w(typing_duration_msecs composer_open_duration_msecs reply_to_post_number).each do |a|
       payload[a] = @args[a].to_i if @args[a]
     end
+
+    self.class.plugin_payload_attributes.each { |a| payload[a] = @args[a] if @args[a].present? }
+
     payload[:via_email] = true if !!@args[:via_email]
     payload[:raw_email] = @args[:raw_email] if @args[:raw_email].present?
 

--- a/plugins/poll/plugin.rb
+++ b/plugins/poll/plugin.rb
@@ -402,6 +402,8 @@ after_initialize do
     true
   end
 
+  NewPostManager.add_plugin_payload_attribute("is_poll")
+
   NewPostManager.add_handler(1) do |manager|
     post = Post.new(raw: manager.args[:raw])
 


### PR DESCRIPTION
The "is_poll" attribute is not being stored in the reviewable payload. This causes the callback defined by the Poll plugin to be useless.

To fix this, plugins are now able to extend the list of allowed payload attributes.