### PR TITLE
UX: Consistent placement of category-title-before plugin outlet

### DIFF
--- a/app/assets/javascripts/discourse/templates/components/categories-boxes-with-topics.hbs
+++ b/app/assets/javascripts/discourse/templates/components/categories-boxes-with-topics.hbs
@@ -11,10 +11,10 @@
           {{/if}}
 
           <h3>
+            {{category-title-before category=c}}
             {{#if c.read_restricted}}
               {{d-icon 'lock'}}
             {{/if}}
-            {{category-title-before category=c}}
             {{c.name}}
           </h3>
         </a>

--- a/app/assets/javascripts/discourse/templates/components/category-title-link.hbs
+++ b/app/assets/javascripts/discourse/templates/components/category-title-link.hbs
@@ -1,10 +1,9 @@
-{{category-title-before category=category}}
 <a class="category-title-link" href={{category.url}}>
   <div class="category-text-title">
+    {{category-title-before category=category}}
     {{#if category.read_restricted}}
       {{d-icon 'lock'}}
     {{/if}}
-
     <span class="category-name">{{dir-span category.name}}</span>
   </div>
   {{#if category.uploaded_logo.url}}

--- a/app/assets/stylesheets/mobile/topic-list.scss
+++ b/app/assets/stylesheets/mobile/topic-list.scss
@@ -278,7 +278,6 @@ tr.category-topic-link {
 
   h3 {
     max-width: 100%;
-    display: inline-block;
     font-size: $font-up-2;
     padding: 0 0 0 10px;
     .d-icon {


### PR DESCRIPTION
The following changes are included in this PR:

- Provide more consistent placement of the `category-title-before` plugin outlet.
- Remove unnecessary `inline-block` styling on the mobile category list item heading

Note that I'm leaving out the "Boxes with subcategories" category style for now. I feel like the boxes in this style are too small to facilitate extra icons. Also, I'm not sure what we'd want to do about the listed subcategories. Currently, they are just standard links that don't even include the lock icon if they are a restricted category.

@pmusaraj if you could take a look at this and make sure there isn't anything else you think should be included, that would be great! I'll be creating a PR for the Category Icons component that adjusts for these changes (assuming they are accepted!)