### PR TITLE
FEATURE: Incorporate PWA install prompt into Discourse UI

### DIFF
--- a/app/assets/javascripts/discourse/components/pwa-install-banner.js.es6
+++ b/app/assets/javascripts/discourse/components/pwa-install-banner.js.es6
@@ -24,14 +24,19 @@ export default Ember.Component.extend({
     window.addEventListener("beforeinstallprompt", this._promptEventHandler);
   },
 
+  @on("willDestroyElement")
+  _unregisterListener() {
+    window.removeEventListener("beforeinstallprompt", this._promptEventHandler);
+  },
+
   @computed
   bannerDismissed: {
     set(value) {
-      localStorage.setItem(USER_DISMISSED_PROMPT_KEY, value);
-      return localStorage.getItem(USER_DISMISSED_PROMPT_KEY);
+      this.keyValueStore.set({key: USER_DISMISSED_PROMPT_KEY, value: value});
+      return this.keyValueStore.get(USER_DISMISSED_PROMPT_KEY);
     },
     get() {
-      return localStorage.getItem(USER_DISMISSED_PROMPT_KEY);
+      return this.keyValueStore.get(USER_DISMISSED_PROMPT_KEY);
     }
   },
 
@@ -49,13 +54,11 @@ export default Ember.Component.extend({
     turnOn() {
       this.set("bannerDismissed", true);
       this.deferredInstallPromptEvent.prompt();
-      window.removeEventListener(
-        "beforeinstallprompt",
-        this._promptEventHandler
-      );
+      this._unregisterListener();
     },
     dismiss() {
       this.set("bannerDismissed", true);
+      this._unregisterListener();
     }
   }
 });

--- a/app/assets/javascripts/discourse/components/pwa-install-banner.js.es6
+++ b/app/assets/javascripts/discourse/components/pwa-install-banner.js.es6
@@ -32,7 +32,7 @@ export default Ember.Component.extend({
   @computed
   bannerDismissed: {
     set(value) {
-      this.keyValueStore.set({key: USER_DISMISSED_PROMPT_KEY, value: value});
+      this.keyValueStore.set({ key: USER_DISMISSED_PROMPT_KEY, value: value });
       return this.keyValueStore.get(USER_DISMISSED_PROMPT_KEY);
     },
     get() {

--- a/app/assets/javascripts/discourse/components/pwa-install-banner.js.es6
+++ b/app/assets/javascripts/discourse/components/pwa-install-banner.js.es6
@@ -15,7 +15,7 @@ export default Ember.Component.extend({
     this.set("deferredInstallPromptEvent", event);
   },
 
-  @on("init")
+  @on("didInsertElement")
   _registerListener() {
     this._promptEventHandler = Ember.run.bind(
       this,
@@ -54,11 +54,9 @@ export default Ember.Component.extend({
     turnOn() {
       this.set("bannerDismissed", true);
       this.deferredInstallPromptEvent.prompt();
-      this._unregisterListener();
     },
     dismiss() {
       this.set("bannerDismissed", true);
-      this._unregisterListener();
     }
   }
 });

--- a/app/assets/javascripts/discourse/components/pwa-install-banner.js.es6
+++ b/app/assets/javascripts/discourse/components/pwa-install-banner.js.es6
@@ -32,7 +32,7 @@ export default Ember.Component.extend({
   @computed
   bannerDismissed: {
     set(value) {
-      this.keyValueStore.set({ key: USER_DISMISSED_PROMPT_KEY, value: value });
+      this.keyValueStore.set({ key: USER_DISMISSED_PROMPT_KEY, value });
       return this.keyValueStore.get(USER_DISMISSED_PROMPT_KEY);
     },
     get() {

--- a/app/assets/javascripts/discourse/components/pwa-install-banner.js.es6
+++ b/app/assets/javascripts/discourse/components/pwa-install-banner.js.es6
@@ -1,0 +1,53 @@
+import {
+  default as computed,
+  on
+} from "ember-addons/ember-computed-decorators";
+
+const userDismissedPromptKey = "dismissed-pwa-install-banner";
+
+export default Ember.Component.extend({
+  deferredInstallPromptEvent: null,
+
+  @on("init")
+  _registerListener() {
+    var that = this;
+    window.addEventListener("beforeinstallprompt", e => {
+      // Prevent Chrome 76+ from automatically showing the prompt
+      e.preventDefault();
+      // Stash the event so it can be triggered later
+      that.set("deferredInstallPromptEvent", e);
+    });
+  },
+
+  @computed
+  bannerDismissed: {
+    set(value) {
+      localStorage.setItem(userDismissedPromptKey, value);
+      return localStorage.getItem(userDismissedPromptKey);
+    },
+    get() {
+      return localStorage.getItem(userDismissedPromptKey);
+    }
+  },
+
+  @computed("deferredInstallPromptEvent", "bannerDismissed")
+  showPWAInstallBanner() {
+    return (
+      this.currentUser && // User must be logged in
+      this.currentUser.trust_level > 0 && // Be at least trust_level 1
+      this.deferredInstallPromptEvent && // Pass the browser engagement checks
+      !window.matchMedia("(display-mode: standalone)").matches && // Not be in the installed PWA already
+      !this.bannerDismissed // Have not a previously dismissed install banner
+    );
+  },
+
+  actions: {
+    turnon() {
+      this.set("bannerDismissed", true);
+      this.deferredInstallPromptEvent.prompt();
+    },
+    dismiss() {
+      this.set("bannerDismissed", true);
+    }
+  }
+});

--- a/app/assets/javascripts/discourse/templates/application.hbs
+++ b/app/assets/javascripts/discourse/templates/application.hbs
@@ -16,6 +16,7 @@
       {{custom-html name="top"}}
     {{/if}}
     {{notification-consent-banner}}
+    {{pwa-install-banner}}
     {{global-notice}}
     {{create-topics-notice}}
     {{plugin-outlet name="top-notices" args=(hash currentPath=router._router.currentPath)}}

--- a/app/assets/javascripts/discourse/templates/components/pwa-install-banner.hbs
+++ b/app/assets/javascripts/discourse/templates/components/pwa-install-banner.hbs
@@ -5,7 +5,7 @@
         {{d-icon 'times'}}
       </div>
       <span>
-        {{i18n 'pwa.install_banner.question'}} <a {{action "turnOn"}}>{{i18n 'pwa.install_banner.link' title=siteSettings.title}}</a>
+        {{discourse-linked-text action=(action "turnOn") translatedText=(i18n "pwa.install_banner" title=siteSettings.title)}}</a>
       </span>
     </div>
   </div>

--- a/app/assets/javascripts/discourse/templates/components/pwa-install-banner.hbs
+++ b/app/assets/javascripts/discourse/templates/components/pwa-install-banner.hbs
@@ -5,7 +5,7 @@
         {{d-icon 'times'}}
       </div>
       <span>
-        {{discourse-linked-text action=(action "turnOn") translatedText=(i18n "pwa.install_banner" title=siteSettings.title)}}</a>
+        {{discourse-linked-text action=(action "turnOn") translatedText=(i18n "pwa.install_banner" title=siteSettings.title)}}
       </span>
     </div>
   </div>

--- a/app/assets/javascripts/discourse/templates/components/pwa-install-banner.hbs
+++ b/app/assets/javascripts/discourse/templates/components/pwa-install-banner.hbs
@@ -4,7 +4,7 @@
       <div class="close" {{action "dismiss"}}>
         {{d-icon 'times'}}
       </div>
-      {{i18n 'pwa.install_banner.prompt' title=siteSettings.title}} <a {{action "turnon"}}>{{i18n 'pwa.install_banner.install'}}</a>.
+      {{i18n 'pwa.install_banner.question'}} <a {{action "turnon"}}>{{i18n 'pwa.install_banner.link' title=siteSettings.title}}</a>.
     </div>
   </div>
 {{/if}}

--- a/app/assets/javascripts/discourse/templates/components/pwa-install-banner.hbs
+++ b/app/assets/javascripts/discourse/templates/components/pwa-install-banner.hbs
@@ -1,0 +1,10 @@
+{{#if showPWAInstallBanner}}
+  <div class="row">
+    <div class="pwa-install-banner alert alert-info">
+      <div class="close" {{action "dismiss"}}>
+        {{d-icon 'times'}}
+      </div>
+      {{i18n 'pwa.install_banner.prompt' title=siteSettings.title}} <a {{action "turnon"}}>{{i18n 'pwa.install_banner.install'}}</a>.
+    </div>
+  </div>
+{{/if}}

--- a/app/assets/javascripts/discourse/templates/components/pwa-install-banner.hbs
+++ b/app/assets/javascripts/discourse/templates/components/pwa-install-banner.hbs
@@ -4,7 +4,9 @@
       <div class="close" {{action "dismiss"}}>
         {{d-icon 'times'}}
       </div>
-      {{i18n 'pwa.install_banner.question'}} <a {{action "turnon"}}>{{i18n 'pwa.install_banner.link' title=siteSettings.title}}</a>.
+      <span>
+        {{i18n 'pwa.install_banner.question'}} <a {{action "turnOn"}}>{{i18n 'pwa.install_banner.link' title=siteSettings.title}}</a>
+      </span>
     </div>
   </div>
 {{/if}}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -353,7 +353,7 @@ en:
       edit: "Edit this banner >>"
 
     pwa:
-      install_banner:
+      install_banner: "Do you want to <a href>install %{title} on this device?</a>"
         question: "Do you want to"
         link: "install %{title} on this device?"
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -352,6 +352,11 @@ en:
       close: "Dismiss this banner."
       edit: "Edit this banner >>"
 
+    pwa:
+      install_banner:
+        prompt: "Do you want to install %{title} on this device?"
+        install: "Install"
+
     choose_topic:
       none_found: "No topics found."
       title:

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -354,8 +354,8 @@ en:
 
     pwa:
       install_banner:
-        prompt: "Do you want to install %{title} on this device?"
-        install: "Install"
+        question: "Do you want to"
+        link: "install %{title} on this device?"
 
     choose_topic:
       none_found: "No topics found."

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -354,8 +354,6 @@ en:
 
     pwa:
       install_banner: "Do you want to <a href>install %{title} on this device?</a>"
-        question: "Do you want to"
-        link: "install %{title} on this device?"
 
     choose_topic:
       none_found: "No topics found."


### PR DESCRIPTION
This is mainly done so Discourse forums stop nagging people to install
on the very first visits to a website.

We will prevent the native install "mini-info" bar from ever appearing,
capture the event that pops with it, and delay it until the user meets
our criteria, which currently is trust_level 1.

If the event happens and the user meets our criteria we show a Discourse
alert banner proposing the install to the user. Dismissal of the banner
is recorded so the user ins't bothered anymore on the same device.