### PR TITLE
UX: prevents non-lightboxed images from stretching in quotes

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -235,6 +235,8 @@ blockquote {
   // !important here otherwise it won't work.
   img {
     max-width: 100% !important;
+    object-fit: cover;
+    object-position: top;
   }
 }
 


### PR DESCRIPTION
This PR adds protection for super-long non-lightboxed in images quotes so that they don't stretch.

Close approximation of the issue:

Before

![106](https://user-images.githubusercontent.com/33972521/63339828-5325f880-c378-11e9-8d59-8b9c5733575c.png)

After

![107](https://user-images.githubusercontent.com/33972521/63339838-57eaac80-c378-11e9-9585-ed3a23823701.png)
