### PR TITLE
SECURITY: Don't send CSRF token in query string

### DIFF
--- a/app/assets/javascripts/discourse/components/composer-editor.js.es6
+++ b/app/assets/javascripts/discourse/components/composer-editor.js.es6
@@ -657,13 +657,10 @@ export default Ember.Component.extend({
     this._pasted = false;
 
     const $element = $(this.element);
-    const csrf = this.session.get("csrfToken");
 
     $element.fileupload({
       url: Discourse.getURL(
-        `/uploads.json?client_id=${
-          this.messageBus.clientId
-        }&authenticity_token=${encodeURIComponent(csrf)}`
+        `/uploads.json?client_id=${this.messageBus.clientId}`
       ),
       dataType: "json",
       pasteZone: $element

--- a/app/assets/javascripts/discourse/mixins/upload.js.es6
+++ b/app/assets/javascripts/discourse/mixins/upload.js.es6
@@ -23,8 +23,6 @@ export default Ember.Mixin.create({
       getUrl(this.getWithDefault("uploadUrl", "/uploads")) +
       ".json?client_id=" +
       (this.messageBus && this.messageBus.clientId) +
-      "&authenticity_token=" +
-      encodeURIComponent(Discourse.Session.currentProp("csrfToken")) +
       this.uploadUrlParams
     );
   },


### PR DESCRIPTION
The token is already present in the headers thanks to the csrf-token
initializer.