### PR TITLE
FEATURE: Add hidden attribute to PostWordpressSerializer

### DIFF
--- a/app/serializers/post_wordpress_serializer.rb
+++ b/app/serializers/post_wordpress_serializer.rb
@@ -2,7 +2,7 @@
 
 # The most basic attributes of a topic that we need to create a link for it.
 class PostWordpressSerializer < BasicPostSerializer
-  attributes :post_number
+  attributes :post_number, :hidden
 
   def avatar_template
     if object.user


### PR DESCRIPTION
Adds the `hidden` attribute to the `PostWordpressSerializer` so that hidden posts can be handled on WordPress.

Related topic on meta: https://meta.discourse.org/t/flagged-and-hidden-posts-whisper-authors-showing-up-in-wordpress/126409