### PR TITLE
FIX: Do not set destination_url cookie after deleting own account.

### DIFF
--- a/app/services/user_destroyer.rb
+++ b/app/services/user_destroyer.rb
@@ -111,7 +111,7 @@ class UserDestroyer
           end
           StaffActionLogger.new(deleted_by).log_user_deletion(user, opts.slice(:context))
         end
-        MessageBus.publish "/file-change", ["refresh"], user_ids: [result.id]
+        MessageBus.publish "/logout", result.id, user_ids: [result.id]
       end
     end
 


### PR DESCRIPTION
destination_url cookie is used to redirect the user to the a private
page after they have logged in. After deleting own account, a user's
pages would be refreshed which would set the destination_url, cookie
that can cause a redirect to an invalid page after logging in again.

Reproduction steps:

1. User is at `/u/:username/preferences/account` and deletes account by
requesting DELETE `/u/:username.json`.

2. User is being destroyed and a MessageBus message (`file-change`,
`['refresh']`) is published.

3. User receives response to DELETE request, but page may be or not
refreshed. Anyway, since they can no longer see the preferences page,
they are redirected to `/login` and `destination_url` cookie is set,
that will redirect on next login (but to the previous preferences page).