### PR TITLE
Filter out hidden posts from TopicViewWordpressSerializer

### DIFF
--- a/app/serializers/topic_view_wordpress_serializer.rb
+++ b/app/serializers/topic_view_wordpress_serializer.rb
@@ -28,7 +28,7 @@ class TopicViewWordpressSerializer < ApplicationSerializer
   end
 
   def posts
-    object.posts
+    object.posts.select { |post| post.hidden === false }
   end
 
 end


### PR DESCRIPTION
We never need to send hidden posts to WordPress.