### PR TITLE
FIX: allows mini-tag-chooser to fetch tags in background

### DIFF
--- a/app/assets/javascripts/select-kit/components/mini-tag-chooser.js.es6
+++ b/app/assets/javascripts/select-kit/components/mini-tag-chooser.js.es6
@@ -188,7 +188,7 @@ export default ComboBox.extend(TagsMixin, {
     return content;
   },
 
-  _prepareSearch(query) {
+  _prepareSearch(query, options) {
     const data = {
       q: query,
       limit: this.get("siteSettings.max_tag_search_results"),
@@ -203,7 +203,7 @@ export default ComboBox.extend(TagsMixin, {
 
     if (!this.everyTag) data.filterForInput = true;
 
-    this.searchTags("/tags/filter/search", data, this._transformJson);
+    this.searchTags("/tags/filter/search", data, this._transformJson, options);
   },
 
   _transformJson(context, json) {
@@ -243,6 +243,12 @@ export default ComboBox.extend(TagsMixin, {
 
   didDeselect(tags) {
     this.destroyTags(tags);
+  },
+
+  didUpdateAttrs() {
+    this._super(...arguments);
+
+    this._prepareSearch(this.filter, { background: true });
   },
 
   _tagsChanged() {

--- a/app/assets/javascripts/select-kit/mixins/tags.js.es6
+++ b/app/assets/javascripts/select-kit/mixins/tags.js.es6
@@ -10,8 +10,10 @@ export default Ember.Mixin.create({
     if (searchDebounce) run.cancel(searchDebounce);
   },
 
-  searchTags(url, data, callback) {
-    this.startLoading();
+  searchTags(url, data, callback, options) {
+    options = options || {};
+
+    if (!options.background) this.startLoading();
 
     return ajax(Discourse.getURL(url), {
       quietMillis: 200,
@@ -21,10 +23,12 @@ export default Ember.Mixin.create({
     })
       .then(json => {
         this.set("asyncContent", callback(this, json));
-        this.autoHighlight();
+        if (!options.background) this.autoHighlight();
       })
       .catch(error => popupAjaxError(error))
-      .finally(() => this.stopLoading());
+      .finally(() => {
+        if (!options.background) this.stopLoading();
+      });
   },
 
   validateCreate(term) {


### PR DESCRIPTION
This is useful when changing the category in the composer for example. When opening mini-tag-chooser after, tags will be correctly updated for the selected category.