### PR TITLE
DEV: Trigger event when Middleware::RequestTracker is registered.

### DIFF
--- a/config/initializers/200-message_bus_request_tracker.rb
+++ b/config/initializers/200-message_bus_request_tracker.rb
@@ -16,6 +16,7 @@ Rails.configuration.middleware = Rails.configuration.middleware + session_operat
 if Rails.env != 'development' || ENV['TRACK_REQUESTS']
   require 'middleware/request_tracker'
   Rails.configuration.middleware.unshift Middleware::RequestTracker
+  DiscourseEvent.trigger(:request_tracker_registered)
 
   if GlobalSetting.enable_performance_http_headers
     MethodProfiler.ensure_discourse_instrumentation!


### PR DESCRIPTION
This is required to let plugins register middlewares before `Middleware::RequestTracker`. Doing it in the global scope is too early for `Middleware::RequestTracker` to exist and doing it in `after_initialize` is impossible because the middleware stack gets frozen.