### PR TITLE
Feature/Fix: Flagged posts user notifications

### DIFF
--- a/app/models/reviewable_flagged_post.rb
+++ b/app/models/reviewable_flagged_post.rb
@@ -291,11 +291,11 @@ private
 
     Jobs.enqueue(
       :send_system_message,
-      user_id: @post.user_id,
+      user_id: post.user_id,
       message_type: :flags_disagreed,
       message_options: {
-        flagged_post_raw_content: @post.raw,
-        url: @post.url
+        flagged_post_raw_content: post.raw,
+        url: post.url
       }
     )
   end

--- a/app/models/reviewable_flagged_post.rb
+++ b/app/models/reviewable_flagged_post.rb
@@ -210,30 +210,26 @@ class ReviewableFlaggedPost < Reviewable
 
   def perform_delete_and_ignore(performed_by, args)
     result = perform_ignore(performed_by, args)
-    PostDestroyer.new(performed_by, post).destroy
+    destroyer(performed_by, post).destroy
     result
   end
 
   def perform_delete_and_ignore_replies(performed_by, args)
     result = perform_ignore(performed_by, args)
-
-    reply_ids = post.reply_ids(Guardian.new(performed_by), only_replies_to_single_post: false)
-    replies = Post.where(id: reply_ids.map { |r| r[:id] })
-    PostDestroyer.new(performed_by, post).destroy
-    replies.each { |reply| PostDestroyer.new(performed_by, reply).destroy }
+    PostDestroyer.delete_with_replies(performed_by, post, self)
 
     result
   end
 
   def perform_delete_and_agree(performed_by, args)
     result = agree(performed_by, args)
-    PostDestroyer.new(performed_by, post).destroy
+    destroyer(performed_by, post).destroy
     result
   end
 
   def perform_delete_and_agree_replies(performed_by, args)
     result = agree(performed_by, args)
-    PostDestroyer.delete_with_replies(performed_by, post)
+    PostDestroyer.delete_with_replies(performed_by, post, self)
     result
   end
 
@@ -283,6 +279,11 @@ protected
     end
   end
 
+private
+
+  def destroyer(performed_by, post)
+    PostDestroyer.new(performed_by, post, reviewable: self)
+  end
 end
 
 # == Schema Information

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2547,7 +2547,23 @@ en:
         The community flagged this post and now it is hidden. **Because this post has been hidden more than once, your post will now remain hidden until it is handled by a staff member.**
 
         For additional guidance, please refer to our [community guidelines](%{base_url}/guidelines).
+    
+    flags_disagreed:
+      title: "Flagged port restored by staff"
+      subject_template: "Flagged post restored by staff"
+      text_body_template: |
+        Hello,
 
+        This is an automated message from %{site_name} to let you know that [your post](%{base_url}%{url}) was restored.
+
+        This post was flagged by the community and a staff member opted to restore it.
+
+        [details="Click to expand restored post"]
+        ``` markdown
+        %{flagged_post_raw_content}
+        ```
+        [/details]
+  
     flags_agreed_and_post_deleted:
       title: "Flagged post removed by staff"
       subject_template: "Flagged post removed by staff"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2549,7 +2549,7 @@ en:
         For additional guidance, please refer to our [community guidelines](%{base_url}/guidelines).
     
     flags_disagreed:
-      title: "Flagged port restored by staff"
+      title: "Flagged post restored by staff"
       subject_template: "Flagged post restored by staff"
       text_body_template: |
         Hello,

--- a/spec/models/reviewable_flagged_post_spec.rb
+++ b/spec/models/reviewable_flagged_post_spec.rb
@@ -287,4 +287,15 @@ RSpec.describe ReviewableFlaggedPost, type: :model do
     end
   end
 
+  describe "#perform_disagree" do
+    it "notifies the user about the flagged post being restored" do
+      reviewable = Fabricate(:reviewable_flagged_post)
+      reviewable.post.hide!(PostActionType.types[:spam])
+
+      expect do
+        reviewable.perform(moderator, :disagree)
+      end.to change(Jobs::SendSystemMessage.jobs, :size).by(1)
+    end
+  end
+
 end

--- a/spec/models/reviewable_flagged_post_spec.rb
+++ b/spec/models/reviewable_flagged_post_spec.rb
@@ -273,4 +273,18 @@ RSpec.describe ReviewableFlaggedPost, type: :model do
 
   end
 
+  describe "#perform_delete_and_agree" do
+    it "notifies the user about the flagged post deletion" do
+      reviewable = Fabricate(:reviewable_flagged_post)
+      reviewable.add_score(
+        moderator, PostActionType.types[:spam],
+        created_at: reviewable.created_at
+      )
+
+      expect do
+        reviewable.perform(moderator, :delete_and_agree)
+      end.to change(Jobs::SendSystemMessage.jobs, :size).by(1)
+    end
+  end
+
 end


### PR DESCRIPTION
### Changes:

- FIX: User should get notified when a post is deleted 
- FEATURE: Notify posters when restoring flagged posts 

### Description:

The `PostDestroyer` looks for pending reviewables associated with the post (It'll never find one in this case) and tries to act on them. This logic is correct when manually deleting a post that was flagged, but it won't work when calling the destroyer from a reviewable action.

The destroyer now receives the reviewable object to get some context and directly notify the poster without trying to act again on the reviewable.

Also, a new PM will be created when disagreeing with the reviewable.
