### PR TITLE
DEV: Don't define `_super` when modifying widgets unless the property is a function

### DIFF
--- a/app/assets/javascripts/discourse/widgets/widget.js.es6
+++ b/app/assets/javascripts/discourse/widgets/widget.js.es6
@@ -79,7 +79,7 @@ export function reopenWidget(name, opts) {
   Object.keys(opts).forEach(k => {
     let old = existing.prototype[k];
 
-    if (old) {
+    if (old instanceof Function) {
       // Add support for `this._super()` to reopened widgets if the prototype exists in the
       // base object
       existing.prototype[k] = function(...args) {


### PR DESCRIPTION
I was trying to override a core widget's `tagName` property in a theme and I was seeing a very weird behavior where the widget would render in the DOM as `<function>` element with weird classes such as `_super apply args`. I tracked it down to this bug here where we always define `_super` regardless if whether the old property as a function.