### PR TITLE
DEV: include TopicQueryParams in TagsController

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -357,7 +357,7 @@ class TagsController < ::ApplicationController
   end
 
   def build_topic_list_options
-    options = super.merge({
+    options = super.merge(
       page: params[:page],
       topic_ids: param_to_integer_list(:topic_ids),
       exclude_category_ids: params[:exclude_category_ids],
@@ -371,7 +371,7 @@ class TagsController < ::ApplicationController
       state: params[:state],
       search: params[:search],
       q: params[:q]
-    })
+    )
     options[:no_subcategories] = true if params[:no_subcategories] == 'true'
 
     if params[:tag_id] == 'none'

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 require_dependency 'topic_list_responder'
+require_dependency 'topic_query_params'
 require_dependency 'topics_bulk_action'
 require_dependency 'topic_query'
 
 class TagsController < ::ApplicationController
   include TopicListResponder
+  include TopicQueryParams
 
   before_action :ensure_tags_enabled
 
@@ -355,7 +357,7 @@ class TagsController < ::ApplicationController
   end
 
   def build_topic_list_options
-    options = {
+    options = super.merge({
       page: params[:page],
       topic_ids: param_to_integer_list(:topic_ids),
       exclude_category_ids: params[:exclude_category_ids],
@@ -369,7 +371,7 @@ class TagsController < ::ApplicationController
       state: params[:state],
       search: params[:search],
       q: params[:q]
-    }
+    })
     options[:no_subcategories] = true if params[:no_subcategories] == 'true'
 
     if params[:tag_id] == 'none'


### PR DESCRIPTION
I'm working on a plugin where I have something like this:

```ruby
TopicQuery.add_custom_filter :my_custom_filter do |topics, topic_query|
  if topic_query.options[:my_custom_filter] == "1"
    topics.where(...)
  end
end
```
which allows me to filter topics in latest, top etc. if `my_custom_filter` is included as a query param to the latest, top etc. endpoints. However, the `TagsController` doesn't extract the custom filters I added from `params` so `topic_query.options[:custom_filter]` is always missing in `TagsController`. `ListController` includes the `TopicQueryParams` module so I did the same thing for `TagsController`.