### PR TITLE
UX: better alignment for tags in the header

### DIFF
--- a/app/assets/javascripts/discourse/widgets/header-topic-info.js.es6
+++ b/app/assets/javascripts/discourse/widgets/header-topic-info.js.es6
@@ -94,7 +94,7 @@ export default createWidget("header-topic-info", {
       );
     }
 
-    const title = [h("h1", heading)];
+    const title = [h("h1.header-title", heading)];
     const category = topic.get("category");
 
     if (loaded || category) {

--- a/app/assets/stylesheets/common/base/header.scss
+++ b/app/assets/stylesheets/common/base/header.scss
@@ -258,10 +258,10 @@
     }
   }
   .header-title {
-    margin: 0 0 0.25em 0;
+    margin: 0 0 0.15em 0;
     .archetype-private_message & {
       // PMs might have participant avatars in the header
-      margin: 0 0 0.1em 0;
+      margin: 0;
     }
     font-size: $font-up-3;
     width: 100%;

--- a/app/assets/stylesheets/common/base/header.scss
+++ b/app/assets/stylesheets/common/base/header.scss
@@ -277,9 +277,6 @@
   }
   .badge-wrapper {
     margin-right: 8px;
-    &.bullet {
-      padding-top: 2px; // alignment hack
-    }
   }
   .badge-wrapper.bullet {
     .badge-category-parent-bg,

--- a/app/assets/stylesheets/common/base/header.scss
+++ b/app/assets/stylesheets/common/base/header.scss
@@ -258,7 +258,7 @@
     }
   }
   .header-title {
-    margin: 0 0 0.25em 0;
+    margin: 0 0 0.2em 0;
     font-size: $font-up-3;
     width: 100%;
   }

--- a/app/assets/stylesheets/common/base/header.scss
+++ b/app/assets/stylesheets/common/base/header.scss
@@ -258,7 +258,11 @@
     }
   }
   .header-title {
-    margin: 0 0 0.2em 0;
+    margin: 0 0 0.25em 0;
+    .archetype-private_message & {
+      // PMs might have participant avatars in the header
+      margin: 0 0 0.1em 0;
+    }
     font-size: $font-up-3;
     width: 100%;
   }

--- a/app/assets/stylesheets/common/base/header.scss
+++ b/app/assets/stylesheets/common/base/header.scss
@@ -257,7 +257,7 @@
       color: $danger;
     }
   }
-  h1 {
+  .header-title {
     margin: 0 0 0.25em 0;
     font-size: $font-up-3;
     width: 100%;

--- a/app/assets/stylesheets/desktop/header.scss
+++ b/app/assets/stylesheets/desktop/header.scss
@@ -18,7 +18,7 @@
     &:not(.two-rows) {
       min-height: 2.75em;
     }
-    h1 {
+    .header-title {
       margin: 0 0 0.125em 0;
     }
   }

--- a/app/assets/stylesheets/desktop/header.scss
+++ b/app/assets/stylesheets/desktop/header.scss
@@ -18,9 +18,6 @@
     &:not(.two-rows) {
       min-height: 2.75em;
     }
-    .header-title {
-      margin: 0 0 0.125em 0;
-    }
   }
 }
 

--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -513,52 +513,6 @@ video {
   }
 }
 
-.extra-info-wrapper {
-  overflow: hidden;
-  .badge-wrapper,
-  i,
-  .topic-link {
-    -webkit-animation: fadein 0.7s;
-    animation: fadein 0.7s;
-  }
-  .topic-statuses {
-    .d-icon {
-      color: $header_primary-medium;
-    }
-    .d-icon-envelope {
-      color: $danger;
-    }
-  }
-  .topic-link {
-    color: $header_primary;
-    display: block;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-}
-
-/* default docked header CSS for all topics, including those without categories */
-
-.extra-info {
-  h1 {
-    margin: 5px 0 0 0;
-    font-size: $font-up-3;
-    line-height: $line-height-large;
-    width: 100%;
-  }
-}
-
-/* override docked header CSS for topics with categories */
-
-.extra-info.two-rows {
-  h1 {
-    line-height: $line-height-medium;
-    margin: 0;
-    width: 100%;
-  }
-}
-
 .open > .dropdown-menu {
   display: block;
 }

--- a/app/assets/stylesheets/mobile/header.scss
+++ b/app/assets/stylesheets/mobile/header.scss
@@ -40,6 +40,7 @@
       }
       .header-title {
         font-size: $font-0;
+        margin: 0 0 0.35em 0;
       }
       .private-message-glyph-wrapper {
         float: left;

--- a/app/assets/stylesheets/mobile/header.scss
+++ b/app/assets/stylesheets/mobile/header.scss
@@ -38,7 +38,7 @@
       &:not(.two-rows) {
         min-height: 2.25em;
       }
-      h1 {
+      .header-title {
         font-size: $font-0;
       }
       .private-message-glyph-wrapper {

--- a/app/assets/stylesheets/mobile/header.scss
+++ b/app/assets/stylesheets/mobile/header.scss
@@ -41,6 +41,10 @@
       .header-title {
         font-size: $font-0;
         margin: 0 0 0.35em 0;
+        .archetype-private_message & {
+          // PMs might have participant avatars in the header
+          margin: 0 0 0.15em 0;
+        }
       }
       .private-message-glyph-wrapper {
         float: left;


### PR DESCRIPTION
This PR improves the alignment of tags in the header. 

Before:

![before0001](https://user-images.githubusercontent.com/33972521/63837677-85ee7300-c9ae-11e9-8309-f9191b33d835.png)

Note how misaligned the tag community is.

After 

![after0001](https://user-images.githubusercontent.com/33972521/63837400-ffd22c80-c9ad-11e9-9f01-288c54c77ee6.png)

This is essentially the only notable visual change in the PR. 

The PR also includes a few commits that do not cause any visual changes, namely

1. removal of a number of duplicate / unused styles
2. the addition of a class to the `<h1>` tag inside `extra-info-wrapper` to avoid using a tag-name selector in CSS


