### PR TITLE
FIX: Remote theme record not saved when checking for updates

### DIFF
--- a/app/controllers/admin/themes_controller.rb
+++ b/app/controllers/admin/themes_controller.rb
@@ -186,22 +186,16 @@ class Admin::ThemesController < Admin::AdminController
     update_translations
     handle_switch
 
-    save_remote = false
     if params[:theme][:remote_check]
       @theme.remote_theme.update_remote_version
-      save_remote = true
     end
 
     if params[:theme][:remote_update]
       @theme.remote_theme.update_from_remote
-      save_remote = true
     end
 
     respond_to do |format|
       if @theme.save
-
-        @theme.remote_theme.save! if save_remote
-
         update_default_theme
 
         @theme.reload

--- a/app/models/remote_theme.rb
+++ b/app/models/remote_theme.rb
@@ -106,6 +106,8 @@ class RemoteTheme < ActiveRecord::Base
       self.updated_at = Time.zone.now
       self.remote_version, self.commits_behind = importer.commits_since(local_version)
       self.last_error_text = nil
+    ensure
+      self.save!
     end
   end
 
@@ -119,6 +121,7 @@ class RemoteTheme < ActiveRecord::Base
         importer.import!
       rescue RemoteTheme::ImportError => err
         self.last_error_text = err.message
+        self.save!
         return self
       else
         self.last_error_text = nil
@@ -163,6 +166,7 @@ class RemoteTheme < ActiveRecord::Base
 
     update_theme_color_schemes(theme, theme_info["color_schemes"]) unless theme.component
 
+    self.save!
     self
   ensure
     begin


### PR DESCRIPTION
Right now if you check for updates on remote theme, the "last checked" time doesn't change and the number of new commits remains 0 because the record wasn't saved. This makes it impossible to update remote theme via the UI.
It seems this regression is a side effect of this commit: https://github.com/discourse/discourse/commit/98fbc019a3578950f40c86a923a3c2155929cc1b.