### PR TITLE
FIX: Move read state when moving posts

### DIFF
--- a/app/jobs/onceoff/clean_up_post_timings.rb
+++ b/app/jobs/onceoff/clean_up_post_timings.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Jobs
+  class CleanUpPostTimings < Jobs::Onceoff
+
+    # Remove post timings that are remnants of previous post moves
+    # or other shenanigans and don't reference a valid user or post anymore.
+    def execute_onceoff(args)
+      DB.exec <<~SQL
+        DELETE
+        FROM post_timings pt
+        WHERE NOT EXISTS(
+                SELECT 1
+                FROM posts p
+                WHERE p.topic_id = pt.topic_id
+                  AND p.post_number = pt.post_number
+            )
+      SQL
+
+      DB.exec <<~SQL
+        DELETE
+        FROM post_timings pt
+        WHERE NOT EXISTS(
+                SELECT 1
+                FROM users u
+                WHERE pt.user_id = u.id
+            )
+      SQL
+    end
+  end
+end

--- a/spec/fabricators/post_fabricator.rb
+++ b/spec/fabricators/post_fabricator.rb
@@ -162,3 +162,7 @@ Fabricator(:post_via_email, from: :post) do
     incoming_email.user = post.user
   end
 end
+
+Fabricator(:whisper, from: :post) do
+  post_type Post.types[:whisper]
+end


### PR DESCRIPTION
* Moves / copies post timings
* Moves / copies topic users
* Fixes a small bug in the calculation of post numbers

---

A couple of notes:
* Notification levels
  * Moving posts to a new topic copies the notification level of the original topic. There's no fancy logic to calculate the correct notification level yet.

  * Moving posts to an existing topic keeps the notification level of the destination topic.

* Users who haven't read all posts in the destination topic will see all moved posts as unread even though they might have already read them. There's no way to fix this.

* When the destination topic is marked as "new" for a user and that same user has already read some of the moved posts, then the topic will lose the "new" status and show all posts in that topic as unread.

* The new once-off clean-up job removes incorrect records from the `post_timings` table. Otherwise moving posts into a topic from which posts were moved in the past will fail.

* I decided to always bump the destination topic after moving posts. That felt like the right thing to do in order to decrease the chance of missing any moves even though you have already read all moved posts and all posts in the destination topic.