### PR TITLE
FIX: correct docker image name

### DIFF
--- a/bin/docker/reset_db
+++ b/bin/docker/reset_db
@@ -5,7 +5,7 @@ DATA_DIR=$SOURCE_DIR/data/postgres
 
 # Should this also run /etc/runit/1.d/ensure_database, or will that
 # happen automatically? -- It will happen, but restarting the container is required
-docker run -it -v $DATA_DIR:/shared/postgres_data discourse/dev /bin/bash -c "rm -fr /shared/postgres_data/*"
+docker run -it -v $DATA_DIR:/shared/postgres_data discourse/discourse_dev:release /bin/bash -c "rm -fr /shared/postgres_data/*"
 docker restart discourse_dev
 echo "Creating admin user..."
 "${SCRIPTPATH}/rake" admin:create


### PR DESCRIPTION
`discourse/dev` is no more using and correct to the image is using