### PR TITLE
FEATURE: support data-explorer outlet in group navigation

### DIFF
--- a/app/assets/javascripts/discourse/templates/components/group-navigation.hbs
+++ b/app/assets/javascripts/discourse/templates/components/group-navigation.hbs
@@ -18,4 +18,5 @@
       {{/link-to}}
     </li>
   {{/each}}
+  {{plugin-outlet name="group-reports-nav-item" args=(hash group=group)}}
 {{/mobile-nav}}


### PR DESCRIPTION
This is dependent on [this data-explorer plugin PR](https://github.com/discourse/discourse-data-explorer/pull/36/files) being merged in.

This adds the `Reports` tab to the group navigation, if the data explorer plugin is installed (and if user is a part of the group, and the group has access to at least 1 report).