### PR TITLE
Fix typo in client.en.yml and server.en.yml.

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3220,7 +3220,7 @@ en:
               owners: "Group owners"
               description: "Admins can see all groups."
             members_visibility_levels:
-              title: "Who can see this group members?"
+              title: "Who can see this group's members?"
               description: "Admins can see members of all groups."
             publish_read_state: "On group messages publish group read state"
 

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2244,7 +2244,7 @@ en:
     omniauth_error:
       generic: "Sorry, there was an error authorizing your account. Please try again."
       csrf_detected: "Authorization timed out, or you have switched browsers. Please try again."
-      request_error: "An error occured when starting authorization. Please try again."
+      request_error: "An error occurred when starting authorization. Please try again."
       invalid_iat: "Unable to verify authorization token due to server clock differences. Please try again."
     omniauth_error_unknown: "Something went wrong processing your log in, please try again."
     omniauth_confirm_title: "Log in using %{provider}"


### PR DESCRIPTION
"Occured" [misspelling](https://en.wiktionary.org/wiki/occured) of "occurred".