### PR TITLE
FIX: :reject_user_delete action can only be handled by ReviewableUser

### DIFF
--- a/app/services/user_destroyer.rb
+++ b/app/services/user_destroyer.rb
@@ -116,7 +116,7 @@ class UserDestroyer
     end
 
     # After the user is deleted, remove the reviewable
-    if reviewable = Reviewable.pending.find_by(target: user)
+    if reviewable = ReviewableUser.pending.find_by(target: user)
       reviewable.perform(@actor, :reject_user_delete)
     end
 

--- a/spec/services/user_destroyer_spec.rb
+++ b/spec/services/user_destroyer_spec.rb
@@ -100,6 +100,16 @@ describe UserDestroyer do
       end
     end
 
+    context "with a reviewable user" do
+      let(:reviewable) { Fabricate(:reviewable, created_by: admin) }
+
+      it 'sets the reviewable user as rejected' do
+        UserDestroyer.new(admin).destroy(reviewable.target)
+
+        expect(reviewable.reload.status).to eq(Reviewable.statuses[:rejected])
+      end
+    end
+
     context "with a directory item record" do
 
       it "removes the directory item" do


### PR DESCRIPTION
This action can only be handled by the `ReviewableUser`. This is causing an error when there are different reviewable types involved (especially the ones we define in `discourse-akismet`)