### PR TITLE
FIX: Mobile Safari composer improvements

### DIFF
--- a/app/assets/javascripts/discourse/lib/safari-hacks.js.es6
+++ b/app/assets/javascripts/discourse/lib/safari-hacks.js.es6
@@ -129,8 +129,21 @@ function positioningWorkaround($fixedElement) {
     if (fixedElement.style.top === "0px") {
       if (this !== document.activeElement) {
         evt.preventDefault();
+
+        // this tricks safari into assuming current input is at top of the viewport
+        // via https://stackoverflow.com/questions/38017771/mobile-safari-prevent-scroll-page-when-focus-on-input
+        this.style.transform = "translateY(-200px)";
         this.focus();
+        let _this = this;
+        setTimeout(function() {
+          _this.style.transform = "none";
+        }, 50);
       }
+      return;
+    }
+
+    // don't trigger keyboard on disabled input (input is disabled when a category is required)
+    if (evt.target.disabled) {
       return;
     }
 
@@ -153,9 +166,7 @@ function positioningWorkaround($fixedElement) {
 
     fixedElement.style.top = "0px";
 
-    composingTopic = $("#reply-control .category-chooser").length > 0;
-
-    const height = calcHeight(composingTopic);
+    const height = calcHeight();
     fixedElement.style.height = height + "px";
 
     $(fixedElement).addClass("no-transition");

--- a/app/assets/javascripts/discourse/lib/safari-hacks.js.es6
+++ b/app/assets/javascripts/discourse/lib/safari-hacks.js.es6
@@ -63,7 +63,6 @@ function calcHeight() {
 }
 
 let workaroundActive = false;
-let composingTopic = false;
 
 export function isWorkaroundActive() {
   return workaroundActive;

--- a/app/assets/javascripts/discourse/lib/safari-hacks.js.es6
+++ b/app/assets/javascripts/discourse/lib/safari-hacks.js.es6
@@ -142,8 +142,8 @@ function positioningWorkaround($fixedElement) {
       return;
     }
 
-    // don't trigger keyboard on disabled input (input is disabled when a category is required)
-    if (evt.target.disabled) {
+    // don't trigger keyboard on disabled element (happens when a category is required)
+    if (this.disabled) {
       return;
     }
 


### PR DESCRIPTION
This includes two fixes: 

- prevents keyboard from being invoked when textarea is disabled (this happens when a category selection is required when creating a new topic)
- avoids scrolling up when switching focus from title to textarea on new topic creation

See below videos for an illustration of the second fix. 

Before: 
https://monosnap.com/file/3ohWIJB8TcqvUYqnkypuBZVzq1tG2C 

After: 
https://monosnap.com/file/HngAVObO5gy3XUTnYP7mNDITC504zQ