### PR TITLE
FIX: Topics with muted tag didn't show up when filtering by category and tag

### DIFF
--- a/app/assets/javascripts/discourse/routes/tags-show.js.es6
+++ b/app/assets/javascripts/discourse/routes/tags-show.js.es6
@@ -73,8 +73,9 @@ export default Discourse.Route.extend({
     const params = filterQueryParams(transition.to.queryParams, {});
     const categorySlug = this.categorySlug;
     const parentCategorySlug = this.parentCategorySlug;
-    const filter = this.navMode;
+    const topicFilter = this.navMode;
     const tagId = tag ? tag.id.toLowerCase() : "none";
+    let filter;
 
     if (categorySlug) {
       const category = Discourse.Category.findBySlug(
@@ -82,31 +83,25 @@ export default Discourse.Route.extend({
         parentCategorySlug
       );
       if (parentCategorySlug) {
-        params.filter = `tags/c/${parentCategorySlug}/${categorySlug}/${tagId}/l/${filter}`;
+        filter = `tags/c/${parentCategorySlug}/${categorySlug}/${tagId}/l/${topicFilter}`;
       } else {
-        params.filter = `tags/c/${categorySlug}/${tagId}/l/${filter}`;
+        filter = `tags/c/${categorySlug}/${tagId}/l/${topicFilter}`;
       }
       if (category) {
         category.setupGroupsAndPermissions();
         this.set("category", category);
       }
     } else if (this.additionalTags) {
-      params.filter = `tags/intersection/${tagId}/${this.get(
-        "additionalTags"
-      ).join("/")}`;
+      filter = `tags/intersection/${tagId}/${this.additionalTags.join("/")}`;
       this.set("category", null);
     } else {
-      params.filter = `tags/${tagId}/l/${filter}`;
+      filter = `tags/${tagId}/l/${topicFilter}`;
       this.set("category", null);
     }
 
-    return findTopicList(
-      this.store,
-      this.topicTrackingState,
-      params.filter,
-      params,
-      { cached: true }
-    ).then(list => {
+    return findTopicList(this.store, this.topicTrackingState, filter, params, {
+      cached: true
+    }).then(list => {
       if (list.topic_list.tags && list.topic_list.tags.length === 1) {
         // Update name of tag (case might be different)
         tag.setProperties({

--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -863,6 +863,7 @@ class TopicQuery
 
     list
   end
+
   def remove_muted_categories(list, user, opts = nil)
     category_id = get_category_id(opts[:exclude]) if opts
 
@@ -885,6 +886,7 @@ class TopicQuery
 
     list
   end
+
   def remove_muted_tags(list, user, opts = nil)
     if user.nil? || !SiteSetting.tagging_enabled || SiteSetting.remove_muted_tags_from_latest == 'never'
       return list
@@ -895,16 +897,9 @@ class TopicQuery
       return list
     end
 
-    showing_tag = if opts[:filter]
-      f = opts[:filter].split('/')
-      f[0] == 'tags' ? f[1] : nil
-    else
-      nil
-    end
-
     # if viewing the topic list for a muted tag, show all the topics
-    if showing_tag.present? && TagUser.lookup(user, :muted).joins(:tag).where('tags.name = ?', showing_tag).exists?
-      return list
+    if !opts[:no_tags] && opts[:tags].present?
+      return list if TagUser.lookup(user, :muted).joins(:tag).where('tags.name = ?', opts[:tags].first).exists?
     end
 
     if SiteSetting.remove_muted_tags_from_latest == 'always'


### PR DESCRIPTION
It also removes the redundant `filter` parameter. Previously URLs looked like this:

```
http://example.com/tags/c/some-category/muted-tag/l/latest.json?filter=tags/c/some-category/muted-tag/l/latest
```

But it looks like the `filter` parameter was only used to find out if topics with a muted tag should be removed or not. But the same thing can be accomplished by using the first tag ID. The following URL looks a lot cleaner.

```
http://example.com/tags/c/some-category/muted-tag/l/latest.json
```