### PR TITLE
DEV: improve creation of custom notifications

### DIFF
--- a/app/assets/javascripts/discourse/widgets/custom-notification-item.js.es6
+++ b/app/assets/javascripts/discourse/widgets/custom-notification-item.js.es6
@@ -5,17 +5,29 @@ import { iconNode } from "discourse-common/lib/icon-library";
 
 createWidgetFrom(DefaultNotificationItem, "custom-notification-item", {
   notificationTitle(notificationName, data) {
+    if (data.customTitle) return I18n.t(data.customTitle);
+    if (data.customTranslatedTitle) return data.customTranslatedTitle;
+
     return data.title ? I18n.t(data.title) : "";
   },
 
+  url(data) {
+    if (data.customUrl) return data.customUrl;
+
+    return this._super(...arguments);
+  },
+
   text(notificationName, data) {
+    if (data.customMessage) return data.customMessage;
+
     const username = formatUsername(data.display_username);
     const description = this.description(data);
-
     return I18n.t(data.message, { description, username });
   },
 
   icon(notificationName, data) {
-    return iconNode(`notification.${data.message}`);
+    return iconNode(
+      data.customIcon ? data.customIcon : `notification.${data.message}`
+    );
   }
 });


### PR DESCRIPTION
It now allows to write this:

```ruby
    Notification.create!(
      notification_type: Notification.types[:custom],
      user_id: 3,
      data: {
        customMessage: 'This is going well',
        customTranslatedTitle: 'Status of the day', # could also be customTitle which would be wrapped in an I18n.t call
        customIcon: 'heart',
        customUrl: 'https://www.google.fr'
      }.to_json
    )
```