### PR TITLE
FIX: Use Discourse.getURL for /clicks/track so clicks can be tracked

### DIFF
--- a/app/assets/javascripts/discourse/lib/ajax.js.es6
+++ b/app/assets/javascripts/discourse/lib/ajax.js.es6
@@ -159,7 +159,7 @@ export function ajax() {
   if (
     args.type &&
     args.type.toUpperCase() !== "GET" &&
-    url !== "/clicks/track" &&
+    url !== Discourse.getURL("/clicks/track") &&
     !Discourse.Session.currentProp("csrfToken")
   ) {
     promise = new Ember.RSVP.Promise((resolve, reject) => {

--- a/app/assets/javascripts/discourse/lib/click-track.js.es6
+++ b/app/assets/javascripts/discourse/lib/click-track.js.es6
@@ -102,9 +102,9 @@ export default {
         data.append("url", href);
         data.append("post_id", postId);
         data.append("topic_id", topicId);
-        navigator.sendBeacon("/clicks/track", data);
+        navigator.sendBeacon(Discourse.getURL("/clicks/track"), data);
       } else {
-        trackPromise = ajax("/clicks/track", {
+        trackPromise = ajax(Discourse.getURL("/clicks/track"), {
           type: "POST",
           data: {
             url: href,


### PR DESCRIPTION
Our install of Discourse @chatterbugapp was seeing requests for click tracking go through to our main app (we use a relative URL root) - I dug in a bit and it seems like this file was missing a call to `Discourse.getURL`. 

🙏 🙇 