### PR TITLE
FIX: Modify frozen String and profile_db_generator uses category id

### DIFF
--- a/script/profile_db_generator.rb
+++ b/script/profile_db_generator.rb
@@ -35,7 +35,7 @@ def sentence
     gabbler.learn(story)
   end
 
-  sentence = ""
+  sentence = +""
   until sentence.length > 800 do
     sentence << @gabbler.sentence
     sentence << "\n"
@@ -104,7 +104,7 @@ puts
 puts "Creating 100 topics"
 
 topic_ids = 100.times.map do
-  post = PostCreator.create(users.sample, raw: sentence, title: sentence[0..50].strip, category:  categories.sample.name, skip_validations: true)
+  post = PostCreator.create(users.sample, raw: sentence, title: sentence[0..50].strip, category:  categories.sample.id, skip_validations: true)
 
   putc "."
   post.topic_id


### PR DESCRIPTION
Hey,

I found two small bugs in profile_db_generator. 

First one is related to `script/profile_db_generator.rb:40:in sentence: can't modify frozen String (FrozenError)`. To solve that, I changed `<<` to `+=` to create a new String object.

The second one is related to that commit https://github.com/discourse/discourse/commit/373b8a213996a71ae49e78c4f969483b85c5d64c. Since that change, TopicCreator is expecting category param being Integer and don't have a fallback to use the name anymore. To solve that, I changed profile_db_generator to pass `id` instead of a name.