### PR TITLE
FIX: Migrate post_edit_time_limit to tl2_post_edit_time_limit

### DIFF
--- a/db/migrate/20190908234054_migrate_post_edit_time_limit.rb
+++ b/db/migrate/20190908234054_migrate_post_edit_time_limit.rb
@@ -19,8 +19,6 @@ class MigratePostEditTimeLimit < ActiveRecord::Migration[5.2]
       FROM site_settings
       WHERE
         name = 'post_edit_time_limit'
-      AND
-        CAST(value AS INTEGER) > 43200
     ON CONFLICT
     DO NOTHING
     SQL

--- a/db/migrate/20190908234054_migrate_post_edit_time_limit.rb
+++ b/db/migrate/20190908234054_migrate_post_edit_time_limit.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class MigratePostEditTimeLimit < ActiveRecord::Migration[5.2]
+  def up
+    execute <<~SQL
+    INSERT INTO site_settings (
+      name,
+      value,
+      data_type,
+      created_at,
+      updated_at
+    )
+      SELECT
+        'tl2_post_edit_time_limit',
+        value,
+        data_type,
+        CURRENT_TIMESTAMP,
+        CURRENT_TIMESTAMP
+      FROM site_settings
+      WHERE
+        name = 'post_edit_time_limit'
+      AND
+        CAST(value AS INTEGER) > 43200
+    ON CONFLICT
+    DO NOTHING
+    SQL
+  end
+end


### PR DESCRIPTION
Insert new value into `tl2_post_edit_time_limit` if:
* tl2 setting does not exist
* tl0 setting is larger than default tl2
Also:
* Uses current timestamp
* No rollback

This doesn't set the new tl0 value.