### PR TITLE
FEATURE: Whitelist the `allowfullscreen` iframe attribute

### DIFF
--- a/app/assets/javascripts/pretty-text/white-lister.js.es6
+++ b/app/assets/javascripts/pretty-text/white-lister.js.es6
@@ -167,6 +167,7 @@ const DEFAULT_LIST = [
   "iframe[marginheight]",
   "iframe[marginwidth]",
   "iframe[width]",
+  "iframe[allowfullscreen]",
   "img[alt]",
   "img[height]",
   "img[title]",


### PR DESCRIPTION
Adding this to core allows showing the fullscreen button on whitelisted, external iframe videos.

**Example from Vimeo**
_(Tested on Chrome + Firefox on Windows 10)_

![iframe](https://user-images.githubusercontent.com/5862206/64691589-a8a18100-d4b0-11e9-98a4-cc6677294c52.png)





