### PR TITLE
Fix frontend tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,6 @@ sudo: required
 dist: trusty
 
 cache:
-  apt: true
   yarn: true
   directories:
     - vendor/bundle

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ services:
   - redis-server
 
 sudo: required
-dist: trusty
+dist: xenial
 
 cache:
   yarn: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
 
 addons:
   chrome: stable
-  postgresql: 9.6
+  postgresql: "9.6"
   apt:
     update: true
     packages:


### PR DESCRIPTION
The only important change here is the distro update in Travis config (trusty to xenial).

This is required since the latest stable Chrome (77, released 2019-09-10) doesn't support trusty, its installation attempt fails, and we try to run tests on a pre-installed version of Chrome (62, from 2017-10-17).

There are no side effects to that upgrade so far in [my tests](https://travis-ci.org/discourse/discourse/builds/583871714), but if there are any objections to this bump, we probably could install Chrome 76 (i.e. the last one that supported trusty) manually.

---

Note: This PR doesn't fix the Travis build completely. Backend tests are failing too, see: https://github.com/discourse/discourse-assign/pull/47#issuecomment-530597959
