### PR TITLE
Fix: let mailgun_api_key also support their "HTTP webhook signing key"

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1012,7 +1012,7 @@ email:
     default: ""
   mailgun_api_key:
     default: ""
-    regex: '^(key-\h{32}|\h{32}-\h{8}-\h{8})$'
+    regex: '^((key-)?\h{32}|\h{32}-\h{8}-\h{8})$'
     secret: true
   bounce_score_threshold:
     client: true


### PR DESCRIPTION
Mailgun now have a new API key format for webhooks which wasn't matching the setting regex.

Follow on to https://meta.discourse.org/t/handling-bouncing-e-mails/45343/131?u=dannii