### PR TITLE
DEV: Allow specifying button class in reviewable action definitions

### DIFF
--- a/app/assets/javascripts/discourse/templates/components/reviewable-bundled-action.hbs
+++ b/app/assets/javascripts/discourse/templates/components/reviewable-bundled-action.hbs
@@ -9,7 +9,7 @@
     disabled=reviewableUpdating}}
 {{else}}
   {{d-button
-    class=(concat "reviewable-action " (dasherize first.id))
+    class=(concat "reviewable-action " (dasherize first.id) " " first.button_class)
     icon=first.icon
     action=(action "perform" first)
     translatedLabel=first.label

--- a/app/assets/stylesheets/common/base/reviewables.scss
+++ b/app/assets/stylesheets/common/base/reviewables.scss
@@ -262,10 +262,6 @@
     .reviewable-action,
     .reviewable-action-dropdown {
       margin-right: 0.5em;
-
-      &.delete-user {
-        @extend .btn-danger;
-      }
     }
   }
   padding-bottom: 1em;

--- a/app/models/reviewable_flagged_post.rb
+++ b/app/models/reviewable_flagged_post.rb
@@ -269,10 +269,11 @@ protected
     end
   end
 
-  def build_action(actions, id, icon:, bundle: nil, client_action: nil, confirm: false)
+  def build_action(actions, id, icon:, button_class: nil, bundle: nil, client_action: nil, confirm: false)
     actions.add(id, bundle: bundle) do |action|
       prefix = "reviewables.actions.#{id}"
       action.icon = icon
+      action.button_class = button_class
       action.label = "#{prefix}.title"
       action.description = "#{prefix}.description"
       action.client_action = client_action

--- a/app/models/reviewable_queued_post.rb
+++ b/app/models/reviewable_queued_post.rb
@@ -38,6 +38,7 @@ class ReviewableQueuedPost < Reviewable
     if pending? && guardian.can_delete_user?(created_by)
       actions.add(:delete_user) do |action|
         action.icon = 'trash-alt'
+        action.button_class = 'btn-danger'
         action.label = 'reviewables.actions.delete_user.title'
         action.confirm_message = 'reviewables.actions.delete_user.confirm'
       end

--- a/app/serializers/reviewable_action_serializer.rb
+++ b/app/serializers/reviewable_action_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ReviewableActionSerializer < ApplicationSerializer
-  attributes :id, :icon, :label, :confirm_message, :description, :client_action
+  attributes :id, :icon, :button_class, :label, :confirm_message, :description, :client_action
 
   def label
     I18n.t(object.label)

--- a/lib/reviewable/actions.rb
+++ b/lib/reviewable/actions.rb
@@ -33,11 +33,11 @@ class Reviewable < ActiveRecord::Base
     end
 
     class Action < Item
-      attr_accessor :icon, :label, :description, :confirm_message, :client_action
+      attr_accessor :icon, :button_class, :label, :description, :confirm_message, :client_action
 
-      def initialize(id, icon = nil, label = nil)
+      def initialize(id, icon = nil, button_class = nil, label = nil)
         super(id)
-        @icon, @label = icon, label
+        @icon, @button_class, @label = icon, button_class, label
       end
     end
 

--- a/spec/models/reviewable_queued_post_spec.rb
+++ b/spec/models/reviewable_queued_post_spec.rb
@@ -118,6 +118,12 @@ RSpec.describe ReviewableQueuedPost, type: :model do
       end
 
       context "delete_user" do
+        it "has the correct button class" do
+          expect(reviewable.actions_for(Guardian.new(moderator)).to_a.
+            find { |a| a.id == :delete_user }.button_class).
+            to eq("btn-danger")
+        end
+
         it "deletes the user and rejects the post" do
           other_reviewable = Fabricate(:reviewable_queued_post, created_by: reviewable.created_by)
 


### PR DESCRIPTION
This avoids the need for using `@extend` in SCSS, which can be problematic in plugins

See https://review.discourse.org/t/fix-make-compatible-with-debundled-plugin-css-assets-feature/5297/7 for context.