### PR TITLE
FIX: Ensure page is reloaded when logging out

### DIFF
--- a/app/assets/javascripts/admin/models/backup.js.es6
+++ b/app/assets/javascripts/admin/models/backup.js.es6
@@ -63,7 +63,7 @@ Backup.reopenClass({
         bootbox.alert(result.message);
       } else {
         // redirect to homepage (session might be lost)
-        window.location.pathname = Discourse.getURL("/");
+        window.location = Discourse.getURL("/");
       }
     });
   }

--- a/app/assets/javascripts/admin/routes/admin-backups.js.es6
+++ b/app/assets/javascripts/admin/routes/admin-backups.js.es6
@@ -36,7 +36,7 @@ export default Discourse.Route.extend({
         );
         if (log.operation === "restore") {
           // redirect to homepage when the restore is done (session might be lost)
-          window.location.pathname = Discourse.getURL("/");
+          window.location = Discourse.getURL("/");
         }
       } else {
         this.controllerFor("adminBackupsLogs")

--- a/app/assets/javascripts/discourse/controllers/login.js.es6
+++ b/app/assets/javascripts/discourse/controllers/login.js.es6
@@ -349,7 +349,7 @@ export default Ember.Controller.extend(ModalFunctionality, {
         $.removeCookie("destination_url");
         window.location.href = destinationUrl;
       } else if (window.location.pathname === Discourse.getURL("/login")) {
-        window.location.pathname = Discourse.getURL("/");
+        window.location = Discourse.getURL("/");
       } else {
         window.location.reload();
       }

--- a/app/assets/javascripts/discourse/controllers/preferences/account.js.es6
+++ b/app/assets/javascripts/discourse/controllers/preferences/account.js.es6
@@ -190,7 +190,7 @@ export default Ember.Controller.extend(
                   () => {
                     bootbox.alert(
                       I18n.t("user.deleted_yourself"),
-                      () => (window.location.pathname = Discourse.getURL("/"))
+                      () => (window.location = Discourse.getURL("/"))
                     );
                   },
                   () => {
@@ -238,7 +238,7 @@ export default Ember.Controller.extend(
             if (!token) {
               const redirect = this.siteSettings.logout_redirect;
               if (Ember.isEmpty(redirect)) {
-                window.location.pathname = Discourse.getURL("/");
+                window.location = Discourse.getURL("/");
               } else {
                 window.location.href = redirect;
               }

--- a/app/assets/javascripts/discourse/lib/logout.js.es6
+++ b/app/assets/javascripts/discourse/lib/logout.js.es6
@@ -9,7 +9,7 @@ export default function logout(siteSettings, keyValueStore) {
 
   const redirect = siteSettings.logout_redirect;
   if (Ember.isEmpty(redirect)) {
-    window.location.pathname = Discourse.getURL("/");
+    window.location = Discourse.getURL("/");
   } else {
     window.location.href = redirect;
   }


### PR DESCRIPTION
To demonstrate the issue:
- Visit https://meta.discourse.org/#somethingHere while logged in
- Click "log out"
- You will be logged out, but the page will not be reloaded

Setting `window.location.pathname = "/"` will not reload the page if there is a hash present. Using `window.location = "/"` gives us the desired behavior.