### PR TITLE
FIX: Escape $ in translations before interpolating

### DIFF
--- a/app/assets/javascripts/locales/i18n.js
+++ b/app/assets/javascripts/locales/i18n.js
@@ -116,7 +116,15 @@ I18n.interpolate = function(message, options) {
   for (var i = 0; placeholder = matches[i]; i++) {
     name = placeholder.replace(this.PLACEHOLDER, "$1");
 
-    value = options[name];
+    if (typeof options[name] === "string") {
+      // The dollar sign (`$`) is a special replace pattern, and `$&` inserts
+      // the matched string. Thus dollars signs need to be escaped with the
+      // special pattern `$$`, which inserts a single `$`.
+      // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_string_as_a_parameter
+      value = options[name].replace(/\$/g, "$$$$");
+    } else {
+      value = options[name];
+    }
 
     if (!this.isValidNode(options, name)) {
       value = "[missing " + placeholder + " value]";

--- a/test/javascripts/lib/i18n-test.js.es6
+++ b/test/javascripts/lib/i18n-test.js.es6
@@ -60,7 +60,8 @@ QUnit.module("lib:i18n", {
           days: {
             one: "%{count} day",
             other: "%{count} days"
-          }
+          },
+          dollar_sign: "Hi {{description}}"
         }
       }
     };
@@ -221,5 +222,14 @@ QUnit.test("fallback", assert => {
     I18n.t("topic.reply.help"),
     "begin composing a reply to this topic",
     "falls back to English translations"
+  );
+});
+
+QUnit.test("Dollar signs are properly escaped", assert => {
+  assert.equal(
+    I18n.t("dollar_sign", {
+      description: "$& $&"
+    }),
+    "Hi $& $&"
   );
 });


### PR DESCRIPTION
> Context: https://meta.discourse.org/t/notification-character-bug/128461/8

I was almost pulling my hairs out wondering why this would happen, then I took a closer look at [the `replace(pattern, replacement)` function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_string_as_a_parameter):

> The `replacement` string can include the following special replacement patterns:
>
> Pattern | Inserts
> -- | --
> $& | Inserts the matched substring.
> ... | ...


The dollar sign (`$`) is a special replace pattern, and `$&` inserts the matched string... 😅  Thus dollars signs need to be escaped with the special pattern `$$`, which inserts a single `$`.

Let me know what you think, thanks!