### PR TITLE
FIX: Split migration into two steps in developer guide

### DIFF
--- a/docs/DEVELOPER-ADVANCED.md
+++ b/docs/DEVELOPER-ADVANCED.md
@@ -54,7 +54,8 @@ If everything goes alright, let's clone Discourse and start hacking:
     RAILS_ENV=test bundle exec rake db:drop
 
     # time to create the database and run migrations
-    bundle exec rake db:create db:migrate
+    bundle exec rake db:create
+    bundle exec rake db:migrate
     RAILS_ENV=test bundle exec rake db:create db:migrate
 
     # run the specs (optional)

--- a/docs/DEVELOPMENT-OSX-NATIVE.md
+++ b/docs/DEVELOPMENT-OSX-NATIVE.md
@@ -250,7 +250,8 @@ bundle exec rake db:drop
 RAILS_ENV=test bundle exec rake db:drop
 
 # time to create the database and run migrations
-bundle exec rake db:create db:migrate
+bundle exec rake db:create
+bundle exec rake db:migrate
 RAILS_ENV=test bundle exec rake db:create db:migrate
 ```
 


### PR DESCRIPTION
To temporary mitigate the problem, we need to split rake `db:create` and rake `db:migrate` into two commands. 

It was discussed here: https://meta.discourse.org/t/hello-from-gitpod-installing-on-google-cloud-automated-dev-setup/128783/
