### PR TITLE
Ignore `min_trust_to_send_messages` setting when messaging groups

### DIFF
--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -407,7 +407,7 @@ class Guardian
     # User is authenticated
     authenticated? &&
     # Have to be a basic level at least
-    (@user.has_trust_level?(SiteSetting.min_trust_to_send_messages) || notify_moderators) &&
+    (is_group || @user.has_trust_level?(SiteSetting.min_trust_to_send_messages) || notify_moderators) &&
     # User disabled private message
     (is_staff? || is_group || target.user_option.allow_private_messages) &&
     # PMs are enabled


### PR DESCRIPTION
This means that TL0 users can message groups with "Who can message this group?" set to "Everyone".

It also means that members of a group with "Who can message this group?" set to "members, moderators and admins" can also message the group, even when their trust level is below min_trust_to_send_messages.