### PR TITLE
FIX: Properly render server side plugin outlets

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -384,7 +384,7 @@ module ApplicationHelper
     return "" if erbs.blank?
 
     result = +""
-    erbs.each { |erb| result << render(file: erb) }
+    erbs.each { |erb| result << render(inline: File.read(erb)) }
     result.html_safe
   end
 


### PR DESCRIPTION
The behavior of the `render` helper method changed in Rails 6 so now the method doesn't render the template and return the output, instead it just returns the file content as-is. Context: https://meta.discourse.org/t/discourse-sitemap-plugin/40348/134?u=osama