### PR TITLE
List dots as a valid character in usernames

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2283,7 +2283,7 @@ en:
       short: "must be at least %{min} characters"
       long: "must be no more than %{max} characters"
       too_long: "is too long"
-      characters: "must only include numbers, letters, dashes, and underscores"
+      characters: "must only include numbers, letters, dashes, dots, and underscores"
       unique: "must be unique"
       blank: "must be present"
       must_begin_with_alphanumeric_or_underscore: "must begin with a letter, a number or an underscore"


### PR DESCRIPTION
They are already allowed, just an error doesn't list them as allowed.