### PR TITLE
Add topic and category context to post webhook payload

### DIFF
--- a/app/serializers/web_hook_post_serializer.rb
+++ b/app/serializers/web_hook_post_serializer.rb
@@ -2,7 +2,9 @@
 
 class WebHookPostSerializer < PostSerializer
 
-  attributes :topic_posts_count
+  attributes :topic_posts_count,
+             :topic_archetype,
+             :category_slug
 
   def include_topic_title?
     true
@@ -30,6 +32,18 @@ class WebHookPostSerializer < PostSerializer
 
   def topic_posts_count
     object.topic ? object.topic.posts_count : 0
+  end
+
+  def topic_archetype
+    object.topic ? object.topic.archetype : ''
+  end
+
+  def include_category_slug?
+    object.topic && object.topic.category
+  end
+
+  def category_slug
+    object.topic && object.topic.category ? object.topic.category.slug_for_url : ''
   end
 
   def include_readers_count?

--- a/spec/serializers/web_hook_post_serializer_spec.rb
+++ b/spec/serializers/web_hook_post_serializer_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe WebHookPostSerializer do
 
   it 'should only include the required keys' do
     count = serialized_for_user(admin).keys.count
-    difference = count - 36
+    difference = count - 38
 
     expect(difference).to eq(0), lambda {
       message = +""


### PR DESCRIPTION
Adds additional fields topic_archetype and category_slug to the post
webhook so that handlers have some context about the post event without
having to call back to the API.

Discussed [here](https://meta.discourse.org/t/webhooks-how-best-to-differentiate-a-pm-from-a-public-post/76363/13).