### PR TITLE
DEV: prevents populate task to crash

### DIFF
--- a/lib/tasks/populate.thor
+++ b/lib/tasks/populate.thor
@@ -102,11 +102,13 @@ class Populate < Thor
   end
 
   def generate_sentence(num_words)
-    hipster_words.sample(num_words).join(' ').capitalize + '.'
+    sentence = hipster_words.sample(num_words).join(' ').capitalize + '.'
+    sentence.force_encoding('UTF-8')
   end
 
   def generate_email
-    hipster_words.sample.delete(' ') + '@' + hipster_words.sample.delete(' ') + '.com'
+    email = hipster_words.sample.delete(' ') + '@' + hipster_words.sample.delete(' ') + '.com'
+    email.delete("'").force_encoding('UTF-8')
   end
 
   def image_posts


### PR DESCRIPTION
Generated emails/names/sentences were crashing with the following error:

```
Can not transliterate strings with ASCII-8BIT encoding
```