### PR TITLE
FIX: attempts to improve screen-tracker logic

### DIFF
--- a/app/assets/javascripts/discourse/components/discourse-topic.js.es6
+++ b/app/assets/javascripts/discourse/components/discourse-topic.js.es6
@@ -1,3 +1,4 @@
+import { getOwner } from "discourse-common/lib/get-owner";
 import DiscourseURL from "discourse/lib/url";
 import AddArchetypeClass from "discourse/mixins/add-archetype-class";
 import ClickTrack from "discourse/lib/click-track";
@@ -110,6 +111,7 @@ export default Ember.Component.extend(
         }
       );
 
+      this.appEvents.on("discourse:focus-changed", this, "focusChanged");
       this.appEvents.on("post:highlight", this, "_highlightPost");
       this.appEvents.on("header:update-topic", this, "_updateTopic");
     },
@@ -129,14 +131,20 @@ export default Ember.Component.extend(
 
       // this happens after route exit, stuff could have trickled in
       this._hideTopicInHeader();
+      this.appEvents.off("discourse:focus-changed", this, "focusChanged");
       this.appEvents.off("post:highlight", this, "_highlightPost");
       this.appEvents.off("header:update-topic", this, "_updateTopic");
     },
 
-    @observes("Discourse.hasFocus")
-    gotFocus() {
-      if (Discourse.get("hasFocus")) {
+    focusChanged(hasFocus) {
+      const screenTrack = getOwner(this).lookup("screen-track:main");
+
+      if (hasFocus) {
+        screenTrack.start();
+
         this.scrolled();
+      } else {
+        screenTrack.stop();
       }
     },
 

--- a/app/assets/javascripts/discourse/components/discourse-topic.js.es6
+++ b/app/assets/javascripts/discourse/components/discourse-topic.js.es6
@@ -140,11 +140,11 @@ export default Ember.Component.extend(
       const screenTrack = getOwner(this).lookup("screen-track:main");
 
       if (hasFocus) {
-        screenTrack.start();
+        screenTrack.resume();
 
         this.scrolled();
       } else {
-        screenTrack.stop();
+        screenTrack.pause();
       }
     },
 

--- a/app/assets/javascripts/discourse/lib/screen-track.js.es6
+++ b/app/assets/javascripts/discourse/lib/screen-track.js.es6
@@ -186,7 +186,10 @@ export default class {
         // Save unique topic IDs up to a max
         let topicIds = storage.get("anon-topic-ids");
         if (topicIds) {
-          topicIds = topicIds.split(",").map(e => parseInt(e));
+          topicIds = topicIds
+            .split(",")
+            .filter(Boolean)
+            .map(tid => parseInt(tid, 10));
         } else {
           topicIds = [];
         }
@@ -239,16 +242,14 @@ export default class {
       this.flush();
     }
 
-    if (Discourse.get("hasFocus")) {
-      this._topicTime += diff;
+    this._topicTime += diff;
 
-      this._onscreen.forEach(
-        postNumber => (timings[postNumber] = (timings[postNumber] || 0) + diff)
-      );
+    this._onscreen.forEach(
+      postNumber => (timings[postNumber] = (timings[postNumber] || 0) + diff)
+    );
 
-      this._readOnscreen.forEach(postNumber => {
-        this._readPosts[postNumber] = true;
-      });
-    }
+    this._readOnscreen.forEach(postNumber => {
+      this._readPosts[postNumber] = true;
+    });
   }
 }

--- a/app/assets/javascripts/discourse/lib/screen-track.js.es6
+++ b/app/assets/javascripts/discourse/lib/screen-track.js.es6
@@ -25,19 +25,21 @@ export default class {
     this.reset();
 
     this._setupScrollListener();
+    this._boundScrolled = Ember.run.bind(this, this.scrolled);
+    $(window).on("scroll.screentrack", this._boundScrolled);
 
     this._topicId = topicId;
     this._topicController = topicController;
   }
 
   pause() {
-    this._destroyScrollListener();
+    this._destroyTickListener();
     this.tick();
     this.flush();
   }
 
   resume() {
-    this._setupScrollListener();
+    this._setupTickListener();
   }
 
   stop() {
@@ -48,6 +50,7 @@ export default class {
 
     if (this._boundScrolled) {
       $(window).off("scroll.screentrack", this._boundScrolled);
+      this._boundScrolled = null;
     }
 
     this.tick();
@@ -261,16 +264,14 @@ export default class {
     }
   }
 
-  _setupScrollListener() {
+  _setupTickListener() {
     // Create an interval timer if we don't have one.
     if (!this._interval) {
       this._interval = setInterval(() => this.tick(), 1000);
-      this._boundScrolled = Ember.run.bind(this, this.scrolled);
-      $(window).on("scroll.screentrack", this._boundScrolled);
     }
   }
 
-  _destroyScrollListener() {
+  _destroyTickListener() {
     if (this._interval) {
       clearInterval(this._interval);
       this._interval = null;

--- a/app/assets/javascripts/discourse/lib/screen-track.js.es6
+++ b/app/assets/javascripts/discourse/lib/screen-track.js.es6
@@ -267,7 +267,7 @@ export default class {
   _setupTickListener() {
     // Create an interval timer if we don't have one.
     if (!this._interval) {
-      this._interval = setInterval(() => this.tick(), 1000);
+      this._interval = setInterval(() => Ember.run(() => this.tick()), 1000);
     }
   }
 

--- a/app/assets/javascripts/discourse/lib/screen-track.js.es6
+++ b/app/assets/javascripts/discourse/lib/screen-track.js.es6
@@ -24,7 +24,7 @@ export default class {
 
     this.reset();
 
-    this._setupScrollListener();
+    this._setupTickListener();
     this._boundScrolled = Ember.run.bind(this, this.scrolled);
     $(window).on("scroll.screentrack", this._boundScrolled);
 

--- a/test/javascripts/lib/screen-track-test.js.es6
+++ b/test/javascripts/lib/screen-track-test.js.es6
@@ -16,7 +16,7 @@ QUnit.module("lib:screen-track", {
 });
 
 // skip for now test leaks state
-QUnit.skip("Correctly flushes posts as needed", assert => {
+QUnit.test("Correctly flushes posts as needed", assert => {
   const timings = [];
 
   // prettier-ignore

--- a/test/javascripts/lib/screen-track-test.js.es6
+++ b/test/javascripts/lib/screen-track-test.js.es6
@@ -1,3 +1,4 @@
+import { currentUser } from "helpers/qunit-helpers";
 import TopicTrackingState from "discourse/models/topic-tracking-state";
 import Session from "discourse/models/session";
 import ScreenTrack from "discourse/lib/screen-track";
@@ -15,7 +16,7 @@ QUnit.module("lib:screen-track", {
 });
 
 // skip for now test leaks state
-QUnit.skip("Correctly flushes posts as needed", assert => {
+QUnit.test("Correctly flushes posts as needed", assert => {
   const timings = [];
 
   // prettier-ignore
@@ -29,13 +30,11 @@ QUnit.skip("Correctly flushes posts as needed", assert => {
     flush_timings_secs: 60
   };
 
-  const currentUser = { id: 1, username: "sam" };
-
   const tracker = new ScreenTrack(
     trackingState,
     siteSettings,
     Session.current(),
-    currentUser
+    currentUser()
   );
 
   const topicController = null;

--- a/test/javascripts/lib/screen-track-test.js.es6
+++ b/test/javascripts/lib/screen-track-test.js.es6
@@ -16,7 +16,7 @@ QUnit.module("lib:screen-track", {
 });
 
 // skip for now test leaks state
-QUnit.test("Correctly flushes posts as needed", assert => {
+QUnit.skip("Correctly flushes posts as needed", assert => {
   const timings = [];
 
   // prettier-ignore


### PR DESCRIPTION
This commit includes multiple fixes to make screen-tracker more reliable, especially in the context of long running sessions.

- do not rely on an observed Discourse.hasFocus
- defines a new appEvent when focus is changed
- stop tracking when tab loses focus