### PR TITLE
DEV: rake qunit:test was crashing on macOS due to a flag

### DIFF
--- a/test/run-qunit.js
+++ b/test/run-qunit.js
@@ -43,7 +43,6 @@ async function runAllTests() {
         "--headless",
         "--no-sandbox",
         "--disable-dev-shm-usage",
-        "--disable-software-rasterizer",
         "--mute-audio",
         "--window-size=1440,900"
       ]


### PR DESCRIPTION
flag: --disable-software-rasterizer