### PR TITLE
FEATURE: topic is validated for blocked words

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -74,6 +74,7 @@ class Topic < ActiveRecord::Base
                     presence: true,
                     topic_title_length: true,
                     censored_words: true,
+                    watched_words: true,
                     quality_title: { unless: :private_message? },
                     max_emojis: true,
                     unique_among: { unless: Proc.new { |t| (SiteSetting.allow_duplicate_topic_titles? || t.private_message?) },

--- a/lib/validators/watched_words_validator.rb
+++ b/lib/validators/watched_words_validator.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class WatchedWordsValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    if matches = WordWatcher.new(value).should_block?.presence
+      if matches.size == 1
+        key = 'contains_blocked_word'
+        translation_args = { word: matches[0] }
+      else
+        key = 'contains_blocked_words'
+        translation_args = { words: matches.join(', ') }
+      end
+      record.errors.add(:base, I18n.t(key, translation_args))
+    end
+  end
+end

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -86,6 +86,22 @@ describe Topic do
           end
         end
       end
+
+      describe 'blocked words' do
+        describe 'when title contains watched words' do
+          it 'should not be valid' do
+            Fabricate(:watched_word, word: 'pineapple', action: WatchedWord.actions[:block])
+
+            topic.title = 'pen PinEapple apple pen is a complete sentence'
+
+            expect(topic).to_not be_valid
+
+            expect(topic.errors.full_messages.first).to include(I18n.t(
+              'contains_blocked_word', word: 'PinEapple'
+            ))
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Currently, the topic is only validated for censored words and should be validated for blocked words as well.

Blocked words validation is now used by both `Post` and `Topic`. To avoid code duplication, I extracted blocked words validation code into separate Validator, and use it in both places.

The only downside is that even if the topic contains blocked words validation message is saying "Your post contains a word that's not allowed: tomato" but I think this is descriptive enough.

![Screenshot from 2019-10-02 09-51-33](https://user-images.githubusercontent.com/72780/66009711-09940600-e4ff-11e9-9b42-55e0970d2d11.png)
