### PR TITLE
DEV: removes dead code

### DIFF
--- a/app/assets/javascripts/discourse-common/mixins/focus-event.js.es6
+++ b/app/assets/javascripts/discourse-common/mixins/focus-event.js.es6
@@ -35,7 +35,7 @@ export default Ember.Mixin.create({
       }
     } else {
       if (!Discourse.hasFocus) {
-        Discourse.setProperties({ hasFocus: true, notify: false });
+        Discourse.set("hasFocus", true);
         appEvents.trigger("discourse:focus-changed", true);
       }
     }


### PR DESCRIPTION
As per sam:

https://github.com/discourse/discourse/blame/b9ccf4d09c62fd87a3be0bd42ecd3ed036dd6129/app/assets/javascripts/discourse.js 1

We used to put (*) topic title for certain cases, something that we totally stopped doing.