### PR TITLE
DEV: removes dead code

### DIFF
--- a/app/assets/javascripts/discourse.js.es6
+++ b/app/assets/javascripts/discourse.js.es6
@@ -92,14 +92,6 @@ const Discourse = Ember.Application.extend(FocusEvent, {
     }
   },
 
-  // The classes of buttons to show on a post
-  @computed
-  postButtons() {
-    return Discourse.SiteSettings.post_menu.split("|").map(function(i) {
-      return i.replace(/\+/, "").capitalize();
-    });
-  },
-
   updateContextCount(count) {
     this.set("contextCount", count);
   },

--- a/app/assets/javascripts/discourse/widgets/post-menu.js.es6
+++ b/app/assets/javascripts/discourse/widgets/post-menu.js.es6
@@ -396,8 +396,7 @@ export default createWidget("post-menu", {
   },
 
   menuItems() {
-    let result = this.siteSettings.post_menu.split("|");
-    return result;
+    return this.siteSettings.post_menu.split("|").filter(Boolean);
   },
 
   html(attrs, state) {


### PR DESCRIPTION
Couldn't find where this code is being used. So far it seems that this has been superseed by:

https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/widgets/post-menu.js.es6#L399

Which I also quickly refactor in this PR

