### PR TITLE
FIX: exception with triggerRefresh and subcat listing

### DIFF
--- a/app/assets/javascripts/discourse/routes/build-category-route.js.es6
+++ b/app/assets/javascripts/discourse/routes/build-category-route.js.es6
@@ -200,6 +200,10 @@ export default (filterArg, params) => {
     actions: {
       setNotification(notification_level) {
         this.currentModel.setNotification(notification_level);
+      },
+
+      triggerRefresh() {
+        this.refresh();
       }
     }
   });


### PR DESCRIPTION
Clicking fast on the "top", "unread", or "latest" button  when browsing a parent category page with subcategories and the setting `Show subcategory list above topics in this category` enabled would cause an exception:

```
Uncaught Error: Nothing handled the action 'triggerRefresh'. If you did handle the action, this error can be caused by returning true from an action handler in a controller, causing the action to bubble.
```