### PR TITLE
FIX: Revert Demon::DemonBase back to Demon::Base

### DIFF
--- a/lib/demon/base.rb
+++ b/lib/demon/base.rb
@@ -3,7 +3,7 @@
 module Demon; end
 
 # intelligent fork based demonizer
-class Demon::DemonBase
+class Demon::Base
 
   def self.demons
     @demons
@@ -57,7 +57,7 @@ class Demon::DemonBase
   def alive?(pid = nil)
     pid ||= @pid
     if pid
-      Demon::DemonBase.alive?(pid)
+      Demon::Base.alive?(pid)
     else
       false
     end
@@ -143,7 +143,7 @@ class Demon::DemonBase
   def already_running?
     if File.exists? pid_file
       pid = File.read(pid_file).to_i
-      if Demon::DemonBase.alive?(pid)
+      if Demon::Base.alive?(pid)
         return pid
       end
     end

--- a/lib/demon/rails_autospec.rb
+++ b/lib/demon/rails_autospec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require "demon/demon_base"
+require "demon/base"
 
-class Demon::RailsAutospec < Demon::DemonBase
+class Demon::RailsAutospec < Demon::Base
 
   def self.prefix
     "rails-autospec"

--- a/lib/demon/sidekiq.rb
+++ b/lib/demon/sidekiq.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require "demon/demon_base"
+require "demon/base"
 
-class Demon::Sidekiq < ::Demon::DemonBase
+class Demon::Sidekiq < ::Demon::Base
 
   def self.prefix
     "sidekiq"

--- a/lib/freedom_patches/zeitwerk.rb
+++ b/lib/freedom_patches/zeitwerk.rb
@@ -2,7 +2,6 @@
 
 module ActiveSupport::Dependencies::ZeitwerkIntegration::Inflector
   CUSTOM_PATHS = {
-    'base' => 'Jobs',
     'canonical_url' => 'CanonicalURL',
     'clean_up_unmatched_ips' => 'CleanUpUnmatchedIPs',
     'homepage_constraint' => 'HomePageConstraint',
@@ -18,8 +17,9 @@ module ActiveSupport::Dependencies::ZeitwerkIntegration::Inflector
     'version' => 'Discourse',
   }
 
-  def self.camelize(basename, _abspath)
-    return basename.camelize if _abspath =~ /onceoff\.rb$/
+  def self.camelize(basename, abspath)
+    return basename.camelize if abspath =~ /onceoff\.rb$/
+    return 'Jobs' if abspath =~ /jobs\/base\.rb$/
     CUSTOM_PATHS.fetch(basename, basename.camelize)
   end
 end

--- a/script/demon_test/parent.rb
+++ b/script/demon_test/parent.rb
@@ -4,7 +4,7 @@ require File.expand_path("../../../config/environment", __FILE__)
 
 puts "Parent is now loaded"
 
-class ForkExecDemon < Demon::DemonBase
+class ForkExecDemon < Demon::Base
   def self.prefix
     "fork-exec-child"
   end


### PR DESCRIPTION
I introduced DemonBase because I had got some conflict between `demon/base.rb` and `jobs/base.rb`, however, to not rename base class, it is possible to use regex on absolute path in Zeitwerk custom inflector.