### PR TITLE
FIX: Use migrations path for post_migrate

### DIFF
--- a/config/initializers/000-post_migration.rb
+++ b/config/initializers/000-post_migration.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 unless Discourse.skip_post_deployment_migrations?
-  Rails.application.config.paths['db/migrate'] << Rails.root.join(
+  ActiveRecord::Migrator.migrations_paths << Rails.root.join(
     Discourse::DB_POST_MIGRATE_PATH
   ).to_s
 end


### PR DESCRIPTION
That is a problem after upgrade to Rails 6. It was partially fixed here: https://github.com/discourse/discourse/commit/025d4ee91f4727540c749e2162680e1042c34376