### PR TITLE
FIX: solution for pending migrations for bin/turbo_rspec

### DIFF
--- a/lib/turbo_tests/runner.rb
+++ b/lib/turbo_tests/runner.rb
@@ -80,6 +80,8 @@ module TurboTests
           .configurations["test"]
           .merge("database" => "discourse_test_1")
 
+      ActiveRecord::Migrator.migrations_paths = ['db/migrate', 'db/post_migrate']
+
       conn = ActiveRecord::Base.establish_connection(config).connection
       begin
         ActiveRecord::Migration.check_pending!(conn)


### PR DESCRIPTION
Currently, if you try to run `./bin/turbo_rspec` you will got that error `There are pending migrations, run rake parallel:migrate`

Reason for that is that command is running in `development` mode which includes plugins migration files in ActiveRecord::Migrator.migrations_paths:
```
["db/migrate",
 "/home/lis2/projects/discourse/plugins/discourse-details/db/migrate",
 "/home/lis2/projects/discourse/plugins/discourse-details/db/post_migrate",
 "/home/lis2/projects/discourse/plugins/discourse-local-dates/db/migrate",
 "/home/lis2/projects/discourse/plugins/discourse-local-dates/db/post_migrate",
...
]
```

A workaround solution would be to run the command with the TEST environment like `RAILS_ENV=test ./bin/turbo_rspec`

I want to propose in this PR to override migration_paths to check only Discourse core migrations.