### PR TITLE
FIX: Check for category conflicts in SiteSetting validations

### DIFF
--- a/lib/site_settings/validations.rb
+++ b/lib/site_settings/validations.rb
@@ -24,7 +24,7 @@ module SiteSettings::Validations
       SiteSetting.default_categories_tracking.split("|"),
       SiteSetting.default_categories_muted.split("|"),
       SiteSetting.default_categories_watching_first_post.split("|")
-    ].flatten.to_set
+    ].flatten.map(&:to_i).to_set
 
     validate_default_categories(category_ids, default_categories_selected)
   end
@@ -36,7 +36,7 @@ module SiteSettings::Validations
       SiteSetting.default_categories_watching.split("|"),
       SiteSetting.default_categories_muted.split("|"),
       SiteSetting.default_categories_watching_first_post.split("|")
-    ].flatten.to_set
+    ].flatten.map(&:to_i).to_set
 
     validate_default_categories(category_ids, default_categories_selected)
   end
@@ -48,7 +48,7 @@ module SiteSettings::Validations
       SiteSetting.default_categories_watching.split("|"),
       SiteSetting.default_categories_tracking.split("|"),
       SiteSetting.default_categories_watching_first_post.split("|")
-    ].flatten.to_set
+    ].flatten.map(&:to_i).to_set
 
     validate_default_categories(category_ids, default_categories_selected)
   end
@@ -60,7 +60,7 @@ module SiteSettings::Validations
       SiteSetting.default_categories_watching.split("|"),
       SiteSetting.default_categories_tracking.split("|"),
       SiteSetting.default_categories_muted.split("|")
-    ].flatten.to_set
+    ].flatten.map(&:to_i).to_set
 
     validate_default_categories(category_ids, default_categories_selected)
   end

--- a/spec/lib/site_settings/validations_spec.rb
+++ b/spec/lib/site_settings/validations_spec.rb
@@ -22,6 +22,14 @@ describe SiteSettings::Validations do
         subject.validate_default_categories_watching("#{category.id}|12312323")
       }.to raise_error(Discourse::InvalidParameters)
     end
+
+    it "prevents using the same category in more than one default group" do
+      SiteSetting.default_categories_watching = "#{category.id}"
+
+      expect {
+        SiteSetting.default_categories_tracking = "#{category.id}"
+      }.to raise_error(Discourse::InvalidParameters)
+    end
   end
 
   context "s3 buckets reusage" do


### PR DESCRIPTION
It was possible to add a category to more than one default group, e.g. "default categories muted" and "default categories watching first post".

The bug was caused by category validations inadvertently comparing strings and numbers.