### PR TITLE
DEV: Remove SiteSetting.default_categories_selected

### DIFF
--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -85,15 +85,6 @@ class SiteSetting < ActiveRecord::Base
     force_https? ? "https" : "http"
   end
 
-  def self.default_categories_selected
-    [
-      SiteSetting.default_categories_watching.split("|"),
-      SiteSetting.default_categories_tracking.split("|"),
-      SiteSetting.default_categories_muted.split("|"),
-      SiteSetting.default_categories_watching_first_post.split("|")
-    ].flatten.to_set
-  end
-
   def self.min_redirected_to_top_period(duration)
     ListController.best_period_with_topics_for(duration)
   end


### PR DESCRIPTION
Added on Aug 21, 2015 in bef80633b1b58189a732a3959d3a59da44aa55e9
The only usage removed on Aug 26, 2015 in 4ba89eec2799390feea4fae5ae5032013106f092

As far I can tell it isn't used by core or any official plugins.