### PR TITLE
FIX: first post true if user creates topic first

### DIFF
--- a/lib/new_post_manager.rb
+++ b/lib/new_post_manager.rb
@@ -40,7 +40,8 @@ class NewPostManager
 
     !!(
       args[:first_post_checks] &&
-      user.post_count == 0
+      user.post_count == 0 &&
+      user.topic_count == 0
     )
   end
 

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -859,6 +859,23 @@ describe PostsController do
           expect(user).not_to be_silenced
         end
 
+        it "doesn't enqueue posts when user first creates a topic" do
+          user.user_stat.update_column(:topic_count, 1)
+
+          post "/posts.json", params: {
+            raw: 'this is the test content',
+            title: 'this is the test title for the topic',
+            composer_open_duration_msecs: 204,
+            typing_duration_msecs: 100,
+            topic_id: topic.id
+          }
+
+          expect(response.status).to eq(200)
+          parsed = ::JSON.parse(response.body)
+
+          expect(parsed["action"]).not_to be_present
+        end
+
         it "doesn't enqueue replies when the topic is closed" do
           topic = Fabricate(:closed_topic)
 


### PR DESCRIPTION
Reported here: https://meta.discourse.org/t/user-was-banned-for-posting-a-reply-within-3-seconds/128823/12
The problem here is the user could create a topic, then reply and get
silenced on the second time (though technically their first post) for being below the
`min_first_post_typing_time` threshold.