### PR TITLE
DEV: Add a plugin incompatibility message

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -21,6 +21,7 @@ require 'action_mailer/railtie'
 require 'sprockets/railtie'
 
 # Plugin related stuff
+require_relative '../lib/plugin_initialization_guard'
 require_relative '../lib/discourse_event'
 require_relative '../lib/discourse_plugin'
 require_relative '../lib/discourse_plugin_registry'
@@ -52,43 +53,6 @@ if defined?(Bundler)
   end
 
   Bundler.require(*bundler_groups)
-end
-
-def with_plugin_guard(&block)
-  begin
-    block.call
-  rescue => error
-    plugins_directory = Rails.root + 'plugins'
-
-    plugin_path = error.backtrace_locations.lazy.map do |location|
-      Pathname.new(location.absolute_path)
-        .ascend
-        .lazy
-        .find { |path| path.parent == plugins_directory }
-    end.next
-
-    raise unless plugin_path
-
-    stack_trace = error.backtrace.each_with_index.inject([]) do |messages, (line, index)|
-      if index == 0
-        messages << "#{line}: #{error} (#{error.class})"
-      else
-        messages << "\t#{index}: from #{line}"
-      end
-    end.reverse.join("\n")
-
-    STDERR.puts <<~MESSAGE
-      #{stack_trace}
-
-      ** INCOMPATIBLE PLUGIN **
-
-      You are unable to build Discourse due to errors in the plugin at
-      #{plugin_path}
-
-      Please try removing this plugin and rebuilding again!
-    MESSAGE
-    exit 1
-  end
 end
 
 module Discourse
@@ -303,7 +267,7 @@ module Discourse
         Discourse.activate_plugins!
       end
     else
-      with_plugin_guard do
+      plugin_initialization_guard do
         Discourse.activate_plugins!
       end
     end
@@ -340,7 +304,7 @@ module Discourse
       OpenID::Util.logger = Rails.logger
 
       # Load plugins
-      with_plugin_guard do
+      plugin_initialization_guard do
         Discourse.plugins.each(&:notify_after_initialize)
       end
 

--- a/lib/plugin_initialization_guard.rb
+++ b/lib/plugin_initialization_guard.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+def plugin_initialization_guard(&block)
+  begin
+    block.call
+  rescue => error
+    plugins_directory = Rails.root + 'plugins'
+
+    plugin_path = error.backtrace_locations.lazy.map do |location|
+      Pathname.new(location.absolute_path)
+        .ascend
+        .lazy
+        .find { |path| path.parent == plugins_directory }
+    end.next
+
+    raise unless plugin_path
+
+    stack_trace = error.backtrace.each_with_index.inject([]) do |messages, (line, index)|
+      if index == 0
+        messages << "#{line}: #{error} (#{error.class})"
+      else
+        messages << "\t#{index}: from #{line}"
+      end
+    end.reverse.join("\n")
+
+    STDERR.puts <<~MESSAGE
+      #{stack_trace}
+
+      ** INCOMPATIBLE PLUGIN **
+
+      You are unable to build Discourse due to errors in the plugin at
+      #{plugin_path}
+
+      Please try removing this plugin and rebuilding again!
+    MESSAGE
+    exit 1
+  end
+end


### PR DESCRIPTION
Example:

```
(…)
	11: from /Users/cvx/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bootsnap-1.4.4/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22:in `require'
	10: from /Users/cvx/discourse/discourse/config/application.rb:94:in `<main>'
	9: from /Users/cvx/discourse/discourse/config/application.rb:95:in `<module:Discourse>'
	8: from /Users/cvx/discourse/discourse/config/application.rb:306:in `<class:Application>'
	7: from /Users/cvx/discourse/discourse/config/application.rb:59:in `with_plugin_guard'
	6: from /Users/cvx/discourse/discourse/config/application.rb:307:in `block in <class:Application>'
	5: from lib/discourse.rb:168:in `activate_plugins!'
	4: from lib/discourse.rb:168:in `each'
	3: from lib/discourse.rb:171:in `block in activate_plugins!'
	2: from /Users/cvx/discourse/discourse/lib/plugin/instance.rb:494:in `activate!'
	1: from /Users/cvx/discourse/discourse/lib/plugin/instance.rb:494:in `instance_eval'
/Users/cvx/discourse/discourse/plugins/discourse-checklist/plugin.rb:13:in `activate!': undefined method `responds_to?' for #<Plugin::Instance:0x00007f7f3b908708>
Did you mean?  respond_to? (NoMethodError)

** INCOMPATIBLE PLUGIN **

You are unable to build Discourse due to errors in the plugin at
/Users/cvx/discourse/discourse/plugins/discourse-checklist

Please try removing this plugin and rebuilding again!
```

cc: @coding-horror

If anyone has a better for `with_plugin_guard()` please come forward. 😉
I'll rename it and extract into `/lib`.
