### PR TITLE
FEATURE: Input for name when creating a new authenticator 

### DIFF
--- a/app/assets/javascripts/discourse/controllers/second-factor-add-totp.js.es6
+++ b/app/assets/javascripts/discourse/controllers/second-factor-add-totp.js.es6
@@ -11,7 +11,7 @@ export default Ember.Controller.extend(ModalFunctionality, {
     this.setProperties({
       errorMessage: null,
       secondFactorKey: null,
-      secondFactorName: I18n.t("user.second_factor.totp.default_name"),
+      secondFactorName: null,
       secondFactorToken: null,
       showSecondFactorKey: false,
       secondFactorImage: null,

--- a/app/assets/javascripts/discourse/controllers/second-factor-add-totp.js.es6
+++ b/app/assets/javascripts/discourse/controllers/second-factor-add-totp.js.es6
@@ -48,10 +48,7 @@ export default Ember.Controller.extend(ModalFunctionality, {
       this.set("loading", true);
 
       this.model
-        .enableSecondFactorTotp(
-          this.secondFactorToken,
-          this.secondFactorName
-        )
+        .enableSecondFactorTotp(this.secondFactorToken, this.secondFactorName)
         .then(response => {
           if (response.error) {
             this.set("errorMessage", response.error);

--- a/app/assets/javascripts/discourse/controllers/second-factor-add-totp.js.es6
+++ b/app/assets/javascripts/discourse/controllers/second-factor-add-totp.js.es6
@@ -11,6 +11,7 @@ export default Ember.Controller.extend(ModalFunctionality, {
     this.setProperties({
       errorMessage: null,
       secondFactorKey: null,
+      secondFactorName: I18n.t("user.second_factor.totp.default_name"),
       secondFactorToken: null,
       showSecondFactorKey: false,
       secondFactorImage: null,
@@ -49,7 +50,7 @@ export default Ember.Controller.extend(ModalFunctionality, {
       this.model
         .enableSecondFactorTotp(
           this.secondFactorToken,
-          I18n.t("user.second_factor.totp.default_name")
+          this.secondFactorName
         )
         .then(response => {
           if (response.error) {

--- a/app/assets/javascripts/discourse/templates/components/second-factor-input.hbs
+++ b/app/assets/javascripts/discourse/templates/components/second-factor-input.hbs
@@ -6,4 +6,5 @@
     id=inputId
     autocorrect="off"
     autocapitalize="off"
-    autofocus="autofocus"}}
+    autofocus="autofocus"
+    placeholder=placeholder}}

--- a/app/assets/javascripts/discourse/templates/modal/second-factor-add-totp.hbs
+++ b/app/assets/javascripts/discourse/templates/modal/second-factor-add-totp.hbs
@@ -33,8 +33,12 @@
     </div>
 
     <div class="control-group">
-      <label class="control-label input-prepend">{{i18n 'user.second_factor.label'}}</label>
+      <label class="control-label input-prepend">{{i18n 'user.second_factor.name'}}</label>
+      <div class="controls">
+        {{second-factor-input value=secondFactorName inputId='second-factor-name'}}
+      </div>
 
+      <label class="control-label input-prepend">{{i18n 'user.second_factor.label'}}</label>
       <div class="controls">
         {{second-factor-input maxlength=6 value=secondFactorToken inputId='second-factor-token'}}
       </div>

--- a/app/assets/javascripts/discourse/templates/modal/second-factor-add-totp.hbs
+++ b/app/assets/javascripts/discourse/templates/modal/second-factor-add-totp.hbs
@@ -35,12 +35,12 @@
     <div class="control-group">
       <label class="control-label input-prepend">{{i18n 'user.second_factor.name'}}</label>
       <div class="controls">
-        {{second-factor-input value=secondFactorName inputId='second-factor-name'}}
+        {{second-factor-input value=secondFactorName inputId='second-factor-name' placeholder=(i18n 'user.second_factor.totp.default_name')}}
       </div>
 
       <label class="control-label input-prepend">{{i18n 'user.second_factor.label'}}</label>
       <div class="controls">
-        {{second-factor-input maxlength=6 value=secondFactorToken inputId='second-factor-token'}}
+        {{second-factor-input maxlength=6 value=secondFactorToken inputId='second-factor-token' placeholder='123456'}}
       </div>
     </div>
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -971,6 +971,7 @@ en:
         enable: "Manage Two Factor Authentication"
         forgot_password: "Forgot password?"
         confirm_password_description: "Please confirm your password to continue"
+        name: "Name"
         label: "Code"
         rate_limit: "Please wait before trying another authentication code."
         enable_description: |


### PR DESCRIPTION
Added an input to name name a new authenticator. Initially, the value is set to `My Authenticator`, which is the default name currently.

![Screenshot from 2019-10-03 13-27-10](https://user-images.githubusercontent.com/16214023/66154067-5b618c80-e5e2-11e9-9de4-e6764e9eaee1.png)
