### PR TITLE
UX: Add "Drafts" to quick access profile tab.

### DIFF
--- a/app/assets/javascripts/discourse/widgets/quick-access-profile.js.es6
+++ b/app/assets/javascripts/discourse/widgets/quick-access-profile.js.es6
@@ -46,6 +46,11 @@ createWidgetFrom(QuickAccessPanel, "quick-access-profile", {
         content: I18n.t("user.private_messages")
       },
       {
+        icon: "pencil",
+        href: `${this.attrs.path}/activity/drafts`,
+        content: I18n.t("user_action_groups.15")
+      },
+      {
         icon: "cog",
         href: `${this.attrs.path}/preferences`,
         content: I18n.t("user.preferences")


### PR DESCRIPTION
> CONTEXT: https://meta.discourse.org/t/please-add-drafts-to-user-menu/129840

I talked to @techAPJ and "stole" this from him 🙈.

<img src="https://user-images.githubusercontent.com/6376558/66183181-b61fd600-e62c-11e9-9e25-9c9b9f06f13b.png" width="300px">
