### PR TITLE
FIX: Clarify revert text

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2561,7 +2561,7 @@ en:
           last: "Last revision"
           hide: "Hide revision"
           show: "Show revision"
-          revert: "Revert to this revision"
+          revert: "Revert to last revision"
           edit_wiki: "Edit Wiki"
           edit_post: "Edit Post"
           comparing_previous_to_current_out_of_total: "<strong>{{previous}}</strong> {{icon}} <strong>{{current}}</strong> / {{total}}"


### PR DESCRIPTION
When you open the revision history of a post a button is shown on the bottom right labelled “Revert to this revision”. It is shown under the later revision on the right, but it actually refers to the older revision on the left.
![](https://d11a6trkgmumsb.cloudfront.net/original/3X/1/8/18d90278b4e6f3c998154759e9ac5c327d01da14.png)

It might be less confusing if it were renamed. 

