### PR TITLE
import_scripts: add fluxbb prefix to missing query

### DIFF
--- a/script/import_scripts/fluxbb.rb
+++ b/script/import_scripts/fluxbb.rb
@@ -63,7 +63,7 @@ class ImportScripts::FluxBB < ImportScripts::Base
   def import_users
     puts '', "creating users"
 
-    total_count = mysql_query("SELECT count(*) count FROM users;").first['count']
+    total_count = mysql_query(`SELECT count(*) count FROM #{FLUXBB_PREFIX}users;`).first['count']
 
     batches(BATCH_SIZE) do |offset|
       results = mysql_query(


### PR DESCRIPTION
Signed-off-by: Jelle van der Waa <jelle@archlinux.org>