### PR TITLE
FIX: updates discourse-ember-source gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,7 +97,7 @@ GEM
     debug_inspector (0.0.3)
     diff-lcs (1.3)
     diffy (3.3.0)
-    discourse-ember-source (3.10.0.1)
+    discourse-ember-source (3.10.0.2)
     discourse_image_optim (0.26.2)
       exifr (~> 1.2, >= 1.2.2)
       fspath (~> 3.0)


### PR DESCRIPTION
This is related to fix made to prevent a crash in iOS 9.5