### PR TITLE
FIX: Prevent from creation of duplicated TopicAllowedUsers

### DIFF
--- a/app/models/topic_converter.rb
+++ b/app/models/topic_converter.rb
@@ -81,6 +81,7 @@ class TopicConverter
       user.user_stat.save!
     end
     @topic.topic_allowed_users.build(user_id: @user.id) unless @topic.topic_allowed_users.where(user_id: @user.id).exists?
+    @topic.topic_allowed_users = @topic.topic_allowed_users.uniq(&:user_id)
     # update topics count
     @topic.user.user_stat.topic_count -= 1
     @topic.user.user_stat.save!

--- a/spec/models/topic_converter_spec.rb
+++ b/spec/models/topic_converter_spec.rb
@@ -114,7 +114,7 @@ describe TopicConverter do
 
     context 'success' do
       it "converts regular topic to private message" do
-        private_message = topic.convert_to_private_message(admin)
+        private_message = topic.convert_to_private_message(post.user)
         expect(private_message).to be_valid
         expect(topic.archetype).to eq("private_message")
         expect(topic.category_id).to eq(nil)


### PR DESCRIPTION
Something changed in Rails6 and now it behaves correctly. When we try to build a collection object with the same params it creates duplication which later we try to save.

Ensure that we don't try to create duplicated TopicAllowedUsers

Related to https://meta.discourse.org/t/error-message-topic-allowed-users-is-invalid/130382/5

![Screenshot from 2019-10-08 15-42-00](https://user-images.githubusercontent.com/72780/66368329-92211380-e9e3-11e9-9bf6-a98bd4a1dda2.png)