### PR TITLE
DEV: adds teardownComponent hook to connector class

### DIFF
--- a/app/assets/javascripts/discourse/components/plugin-connector.js.es6
+++ b/app/assets/javascripts/discourse/components/plugin-connector.js.es6
@@ -16,6 +16,13 @@ export default Ember.Component.extend({
     this.set("actions", connectorClass.actions);
   },
 
+  willDestroyElement() {
+    this._super(...arguments);
+
+    const connectorClass = this.get("connector.connectorClass");
+    connectorClass.teardownComponent.call(this, this);
+  },
+
   @observes("args")
   _argsChanged() {
     const args = this.args || {};

--- a/app/assets/javascripts/discourse/lib/plugin-connectors.js.es6
+++ b/app/assets/javascripts/discourse/lib/plugin-connectors.js.es6
@@ -17,7 +17,8 @@ export function extraConnectorClass(name, obj) {
 const DefaultConnectorClass = {
   actions: {},
   shouldRender: () => true,
-  setupComponent() {}
+  setupComponent() {},
+  teardownComponent() {}
 };
 
 function findOutlets(collection, callback) {


### PR DESCRIPTION
This is the counterpart to setupComponent and allows you to clean any observers or state when the component is destroyed.