### PR TITLE
FIX: Decrement posts read count when destroying post timings

### DIFF
--- a/app/models/post_timing.rb
+++ b/app/models/post_timing.rb
@@ -71,6 +71,8 @@ class PostTiming < ActiveRecord::Base
         last_read_post_number: last_read
       )
 
+      topic.posts.find_by(post_number: post_number).decrement!(:reads)
+
       if !topic.private_message?
         set_minimum_first_unread!(user_id: user.id, date: topic.updated_at)
       end
@@ -86,6 +88,8 @@ class PostTiming < ActiveRecord::Base
       TopicUser
         .where('user_id = ? and topic_id in (?)', user_id, topic_ids)
         .delete_all
+
+      Post.where(topic_id: topic_ids).update_all('reads = reads - 1')
 
       date = Topic.listable_topics.where(id: topic_ids).minimum(:updated_at)
 

--- a/spec/models/post_timing_spec.rb
+++ b/spec/models/post_timing_spec.rb
@@ -164,4 +164,24 @@ describe PostTiming do
 
   end
 
+  describe 'decrementing posts read count when destroying post timings' do
+    let(:initial_read_count) { 0 }
+    let(:post) { Fabricate(:post, reads: initial_read_count) }
+
+    before do
+      PostTiming.process_timings(post.user, post.topic_id, 1, [[post.post_number, 100]])
+    end
+
+    it '#destroy_last_for decrements the reads count for a post' do
+      PostTiming.destroy_last_for(post.user, post.topic_id)
+
+      expect(post.reload.reads).to eq initial_read_count
+    end
+
+    it '#destroy_for decrements the reads count for a post' do
+      PostTiming.destroy_for(post.user, [post.topic_id])
+
+      expect(post.reload.reads).to eq initial_read_count
+    end
+  end
 end


### PR DESCRIPTION
When a topic is deferred, a `topic_timings` row gets deleted, and the topic_user information gets updated. 

The deferred posts read count needs to be decremented since this value will be incremented again when the user reads the deferred topic.