### PR TITLE
Serialize draft

### DIFF
--- a/app/assets/javascripts/discourse/controllers/composer.js.es6
+++ b/app/assets/javascripts/discourse/controllers/composer.js.es6
@@ -46,7 +46,7 @@ function loadDraft(store, opts) {
       draftSequence,
       draft: true,
       composerState: Composer.DRAFT
-    }
+    };
 
     serializedFields.forEach(f => {
       attrs[f] = draft[f] || opts[f];

--- a/app/assets/javascripts/discourse/controllers/composer.js.es6
+++ b/app/assets/javascripts/discourse/controllers/composer.js.es6
@@ -25,7 +25,7 @@ function loadDraft(store, opts) {
   let draft = opts.draft;
   const draftKey = opts.draftKey;
   const draftSequence = opts.draftSequence;
-  
+
   try {
     if (draft && typeof draft === "string") {
       draft = JSON.parse(draft);
@@ -47,13 +47,13 @@ function loadDraft(store, opts) {
       draft: true,
       composerState: Composer.DRAFT
     }
-    
+
     serializedFields.forEach(f => {
       attrs[f] = draft[f] || opts[f];
     });
 
     composer.open(attrs);
-    
+
     return composer;
   }
 }

--- a/app/assets/javascripts/discourse/controllers/composer.js.es6
+++ b/app/assets/javascripts/discourse/controllers/composer.js.es6
@@ -39,8 +39,13 @@ function loadDraft(store, opts) {
     ((draft.title && draft.title !== "") || (draft.reply && draft.reply !== ""))
   ) {
     const composer = store.createRecord("composer");
+    var serialized = Composer.serializedFieldsForDraft();
+    var serializedObject = {};
+    serialized.forEach( key=>{
+      serializedObject[key] = draft[key] ;
+    })
 
-    composer.open({
+    var attrs = {
       draftKey,
       draftSequence,
       action: draft.action,
@@ -57,8 +62,11 @@ function loadDraft(store, opts) {
       typingTime: draft.typingTime,
       whisper: draft.whisper,
       tags: draft.tags,
-      noBump: draft.noBump
-    });
+      noBump: draft.noBump,
+    }
+
+ attrs = Object.assign(attrs, serializedObject)
+    composer.open(attrs);
     return composer;
   }
 }
@@ -898,6 +906,14 @@ export default Ember.Controller.extend({
     composerModel.setProperties({
       composeState: Composer.OPEN,
       isWarning: false
+    });
+    var draftKeys = Composer.serializedFieldsForDraft();
+    var draftOpts = JSON.parse(opts.draft)
+    var currentModel = this.model;
+    draftKeys.forEach(function(k){
+          if(draftOpts[k]){
+            Ember.set(currentModel, k, draftOpts[k]);
+          }
     });
 
     if (opts.usernames && !this.get("model.targetUsernames")) {

--- a/app/assets/javascripts/discourse/controllers/composer.js.es6
+++ b/app/assets/javascripts/discourse/controllers/composer.js.es6
@@ -25,7 +25,7 @@ function loadDraft(store, opts) {
   let draft = opts.draft;
   const draftKey = opts.draftKey;
   const draftSequence = opts.draftSequence;
-
+  
   try {
     if (draft && typeof draft === "string") {
       draft = JSON.parse(draft);
@@ -39,34 +39,21 @@ function loadDraft(store, opts) {
     ((draft.title && draft.title !== "") || (draft.reply && draft.reply !== ""))
   ) {
     const composer = store.createRecord("composer");
-    var serialized = Composer.serializedFieldsForDraft();
-    var serializedObject = {};
-    serialized.forEach( key=>{
-      serializedObject[key] = draft[key] ;
-    })
+    const serializedFields = Composer.serializedFieldsForDraft();
 
-    var attrs = {
+    let attrs = {
       draftKey,
       draftSequence,
-      action: draft.action,
-      title: draft.title,
-      categoryId: draft.categoryId || opts.categoryId,
-      postId: draft.postId,
-      archetypeId: draft.archetypeId,
-      reply: draft.reply,
-      metaData: draft.metaData,
-      usernames: draft.usernames,
       draft: true,
-      composerState: Composer.DRAFT,
-      composerTime: draft.composerTime,
-      typingTime: draft.typingTime,
-      whisper: draft.whisper,
-      tags: draft.tags,
-      noBump: draft.noBump,
+      composerState: Composer.DRAFT
     }
+    
+    serializedFields.forEach(f => {
+      attrs[f] = draft[f] || opts[f];
+    });
 
- attrs = Object.assign(attrs, serializedObject)
     composer.open(attrs);
+    
     return composer;
   }
 }
@@ -906,14 +893,6 @@ export default Ember.Controller.extend({
     composerModel.setProperties({
       composeState: Composer.OPEN,
       isWarning: false
-    });
-    var draftKeys = Composer.serializedFieldsForDraft();
-    var draftOpts = JSON.parse(opts.draft)
-    var currentModel = this.model;
-    draftKeys.forEach(function(k){
-          if(draftOpts[k]){
-            Ember.set(currentModel, k, draftOpts[k]);
-          }
     });
 
     if (opts.usernames && !this.get("model.targetUsernames")) {

--- a/app/assets/javascripts/discourse/controllers/composer.js.es6
+++ b/app/assets/javascripts/discourse/controllers/composer.js.es6
@@ -748,15 +748,15 @@ export default Ember.Controller.extend({
   },
 
   /**
-    Open the composer view
+   Open the composer view
 
-    @method open
-    @param {Object} opts Options for creating a post
-      @param {String} opts.action The action we're performing: edit, reply or createTopic
-      @param {Discourse.Post} [opts.post] The post we're replying to
-      @param {Discourse.Topic} [opts.topic] The topic we're replying to
-      @param {String} [opts.quote] If we're opening a reply from a quote, the quote we're making
-  **/
+   @method open
+   @param {Object} opts Options for creating a post
+   @param {String} opts.action The action we're performing: edit, reply or createTopic
+   @param {Discourse.Post} [opts.post] The post we're replying to
+   @param {Discourse.Topic} [opts.topic] The topic we're replying to
+   @param {String} [opts.quote] If we're opening a reply from a quote, the quote we're making
+   **/
   open(opts) {
     opts = opts || {};
 

--- a/app/assets/javascripts/discourse/lib/plugin-api.js.es6
+++ b/app/assets/javascripts/discourse/lib/plugin-api.js.es6
@@ -43,6 +43,7 @@ import Sharing from "discourse/lib/sharing";
 import { addComposerUploadHandler } from "discourse/components/composer-editor";
 import { addCategorySortCriteria } from "discourse/components/edit-category-settings";
 import { queryRegistry } from "discourse/widgets/widget";
+import Composer from "discourse/models/composer";
 
 // If you add any methods to the API ensure you bump up this number
 const PLUGIN_API_VERSION = "0.8.32";
@@ -842,6 +843,21 @@ class PluginApi {
    */
   addComposerUploadHandler(extensions, method) {
     addComposerUploadHandler(extensions, method);
+  }
+
+  /**
+   * Adds a field to draft serializer
+   *
+   * Example:
+   *
+   * api.serializeToDraft('key_set_in_model', 'field_name_in_payload');
+   *
+   * to keep both of them same
+   * api.serializeToDraft('field_name');
+   *
+   */
+  serializeToDraft(fieldName, property){
+    Composer.serialzeToDraft(fieldName, property);
   }
 
   /**

--- a/app/assets/javascripts/discourse/lib/plugin-api.js.es6
+++ b/app/assets/javascripts/discourse/lib/plugin-api.js.es6
@@ -425,44 +425,44 @@ class PluginApi {
   }
 
   /**
-    Called whenever the "page" changes. This allows us to set up analytics
-    and other tracking.
+   Called whenever the "page" changes. This allows us to set up analytics
+   and other tracking.
 
-    To get notified when the page changes, you can install a hook like so:
+   To get notified when the page changes, you can install a hook like so:
 
-    ```javascript
-      api.onPageChange((url, title) => {
+   ```javascript
+   api.onPageChange((url, title) => {
         console.log('the page changed to: ' + url + ' and title ' + title);
       });
-    ```
-  **/
+   ```
+   **/
   onPageChange(fn) {
     this.onAppEvent("page:changed", data => fn(data.url, data.title));
   }
 
   /**
-    Listen for a triggered `AppEvent` from Discourse.
+   Listen for a triggered `AppEvent` from Discourse.
 
-    ```javascript
-      api.onAppEvent('inserted-custom-html', () => {
+   ```javascript
+   api.onAppEvent('inserted-custom-html', () => {
         console.log('a custom footer was rendered');
       });
-    ```
-  **/
+   ```
+   **/
   onAppEvent(name, fn) {
     const appEvents = this._lookupContainer("app-events:main");
     appEvents && appEvents.on(name, fn);
   }
 
   /**
-    Registers a function to generate custom avatar CSS classes
-    for a particular user.
+   Registers a function to generate custom avatar CSS classes
+   for a particular user.
 
-    Takes a function that will accept a user as a parameter
-    and return an array of CSS classes to apply.
+   Takes a function that will accept a user as a parameter
+   and return an array of CSS classes to apply.
 
-    ```javascript
-    api.customUserAvatarClasses(user => {
+   ```javascript
+   api.customUserAvatarClasses(user => {
       if (Ember.get(user, 'primary_group_name') === 'managers') {
         return ['managers'];
       }
@@ -856,7 +856,7 @@ class PluginApi {
    * api.serializeToDraft('field_name');
    *
    */
-  serializeToDraft(fieldName, property){
+  serializeToDraft(fieldName, property) {
     Composer.serialzeToDraft(fieldName, property);
   }
 

--- a/app/assets/javascripts/discourse/models/composer.js.es6
+++ b/app/assets/javascripts/discourse/models/composer.js.es6
@@ -58,17 +58,17 @@ const CLOSED = "closed",
     featuredLink: "topic.featured_link"
   },
   _draft_serializer = {
-    reply: 'reply',
-    action: 'action',
-    title: 'title',
-    categoryId: 'categoryId',
-    archetypeId: 'archetypeId',
-    whisper: 'whisper',
-    metaData: 'metaData',
-    composerTime: 'composerTime',
-    typingTime: 'typingTime',
-    postId: 'post.id',
-    usernames: 'targetUsernames',
+    reply: "reply",
+    action: "action",
+    title: "title",
+    categoryId: "categoryId",
+    archetypeId: "archetypeId",
+    whisper: "whisper",
+    metaData: "metaData",
+    composerTime: "composerTime",
+    typingTime: "typingTime",
+    postId: "post.id",
+    usernames: "targetUsernames",
   },
   _add_draft_fields = {},
   FAST_REPLY_LENGTH_THRESHOLD = 10000;
@@ -724,7 +724,7 @@ const Composer = RestModel.extend({
     if (!isEdit(opts.action) || !opts.post) {
       composer.appEvents.trigger("composer:reply-reloaded", composer);
     }
-    
+
     // Ensure additional draft fields are set
     Object.keys(_add_draft_fields).forEach(f => {
       this.set(_add_draft_fields[f], opts[f]);
@@ -1021,9 +1021,9 @@ const Composer = RestModel.extend({
       Ember.run.cancel(this._clearingStatus);
       this._clearingStatus = null;
     }
-        
+
     let data = this.serialize(_draft_serializer);
-    
+
     if (data.postId && !Ember.isEmpty(this.originalText)) {
       data.originalText = this.originalText;
     }

--- a/app/assets/javascripts/discourse/models/composer.js.es6
+++ b/app/assets/javascripts/discourse/models/composer.js.es6
@@ -68,7 +68,7 @@ const CLOSED = "closed",
     composerTime: "composerTime",
     typingTime: "typingTime",
     postId: "post.id",
-    usernames: "targetUsernames",
+    usernames: "targetUsernames"
   },
   _add_draft_fields = {},
   FAST_REPLY_LENGTH_THRESHOLD = 10000;
@@ -1099,7 +1099,7 @@ Composer.reopenClass({
     return Object.keys(_create_serializer);
   },
 
-  serializeToDraft(fieldName, property){
+  serializeToDraft(fieldName, property) {
     if (!property) {
       property = fieldName;
     }

--- a/app/assets/javascripts/discourse/models/composer.js.es6
+++ b/app/assets/javascripts/discourse/models/composer.js.es6
@@ -59,6 +59,10 @@ const CLOSED = "closed",
   },
   FAST_REPLY_LENGTH_THRESHOLD = 10000;
 
+const draft_serializer = {
+ 
+}
+
 export const SAVE_LABELS = {
   [EDIT]: "composer.save_edit",
   [REPLY]: "composer.reply",
@@ -1021,6 +1025,8 @@ const Composer = RestModel.extend({
       usernames: this.targetUsernames,
       postId: this.get("post.id")
     });
+    var serializedFields = this.serialize(draft_serializer);
+    Object.assign(data,serializedFields)
 
     if (data.postId && !Ember.isEmpty(this.originalText)) {
       data.originalText = this.originalText;
@@ -1095,6 +1101,18 @@ Composer.reopenClass({
 
   serializedFieldsForCreate() {
     return Object.keys(_create_serializer);
+  },
+
+ serializeToDraft(fieldName, property){
+    if (!property) {
+      property = fieldName;
+    }
+    draft_serializer[fieldName] = property;
+
+  },
+
+  serializedFieldsForDraft() {
+    return Object.keys(draft_serializer);
   },
 
   // The status the compose view can have


### PR DESCRIPTION
This PR adds a function `serializeToDraft` to the composer model to allow saving topic custom fields to draft and setting them back when the draft is reopened.

Here is the post on meta for this.
https://meta.discourse.org/t/including-composer-custom-fields-on-save-draft/126913/2