### PR TITLE
FIX: Order UserFields by position, by default

### DIFF
--- a/app/assets/javascripts/discourse/models/site.js.es6
+++ b/app/assets/javascripts/discourse/models/site.js.es6
@@ -204,9 +204,9 @@ Site.reopenClass(Singleton, {
     }
 
     if (result.user_fields) {
-      result.user_fields = result.user_fields.map(uf =>
-        Ember.Object.create(uf)
-      );
+      result.user_fields = result.user_fields
+        .sort((a, b) => (a.position > b.position ? 1 : -1))
+        .map(uf => Ember.Object.create(uf));
     }
 
     return result;

--- a/app/assets/javascripts/discourse/models/site.js.es6
+++ b/app/assets/javascripts/discourse/models/site.js.es6
@@ -204,9 +204,9 @@ Site.reopenClass(Singleton, {
     }
 
     if (result.user_fields) {
-      result.user_fields = result.user_fields
-        .sort((a, b) => (a.position > b.position ? 1 : -1))
-        .map(uf => Ember.Object.create(uf));
+      result.user_fields = result.user_fields.map(uf =>
+        Ember.Object.create(uf)
+      );
     }
 
     return result;

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -25,7 +25,7 @@ class Site
   end
 
   def user_fields
-    UserField.all
+    UserField.order(:position).all
   end
 
   def categories


### PR DESCRIPTION
This solves the issue brought up [in this topic](https://meta.discourse.org/t/onboarding-process-for-new-member/74837/8), and I don't see why we wouldn't always order the UserField by the position column.

The solution for the topic mentioned could be solved by sorting the user fields all over the place, but this works, and might even solve the same issue elsewhere that we are not aware of.