### PR TITLE
FIX: Show a correct diff when editing consecutive paragraphs

### DIFF
--- a/lib/discourse_diff.rb
+++ b/lib/discourse_diff.rb
@@ -12,7 +12,7 @@ class DiscourseDiff
     before_markdown = tokenize_line(CGI::escapeHTML(@before))
     after_markdown = tokenize_line(CGI::escapeHTML(@after))
 
-    @block_by_block_diff = ONPDiff.new(before_html, after_html).diff
+    @block_by_block_diff = ONPDiff.new(before_html, after_html).paragraph_diff
     @line_by_line_diff = ONPDiff.new(before_markdown, after_markdown).short_diff
   end
 

--- a/spec/components/discourse_diff_spec.rb
+++ b/spec/components/discourse_diff_spec.rb
@@ -76,6 +76,13 @@ describe DiscourseDiff do
       expect(DiscourseDiff.new(before, after).side_by_side_html).to eq("<div class=\"revision-content\"><p>this is a paragraph</p></div><div class=\"revision-content\"><p>this is a <ins>great </ins>paragraph</p></div>")
     end
 
+    it "adds <ins> and <del> tags on consecutive paragraphs", :focus do
+      before = "<p>this is one paragraph</p><p>here is yet another</p>"
+      after = "<p>this is one great paragraph</p><p>here is another</p>"
+      got = DiscourseDiff.new(before, after).side_by_side_html
+      expect(got).to eq("<div class=\"revision-content\"><p>this is one paragraph</p><p>here is <del>yet </del>another</p></div><div class=\"revision-content\"><p>this is one <ins>great </ins>paragraph</p><p>here is another</p></div>")
+    end
+
     it "adds <del> tags around removed text on the left div" do
       before = "<p>this is a great paragraph</p>"
       after = "<p>this is a paragraph</p>"

--- a/spec/components/onpdiff_spec.rb
+++ b/spec/components/onpdiff_spec.rb
@@ -39,4 +39,38 @@ describe ONPDiff do
 
   end
 
+  describe "paragraph_diff" do
+
+    it "returns an empty array when there is no content to diff" do
+      expect(ONPDiff.new("", "").paragraph_diff).to eq([])
+    end
+
+    it "returns an array with the operation code for each element" do
+      expect(ONPDiff.new("abc", "acd").paragraph_diff).to eq([["a", :common], ["b", :delete], ["c", :common], ["d", :add]])
+    end
+
+    it "pairs as many elements as possible", :focus do
+      expect(ONPDiff.new("abcd", "abef").paragraph_diff).to eq([
+        ["a", :common], ["b", :common],
+        ["e", :add], ["c", :delete],
+        ["f", :add], ["d", :delete]
+      ])
+
+      expect(ONPDiff.new("abcde", "abfg").paragraph_diff).to eq([
+        ["a", :common], ["b", :common],
+        ["c", :delete],
+        ["d", :delete], ["f", :add],
+        ["e", :delete], ["g", :add]
+      ])
+
+      expect(ONPDiff.new("abcd", "abefg").paragraph_diff).to eq([
+        ["a", :common], ["b", :common],
+        ["e", :add],
+        ["f", :add], ["c", :delete],
+        ["g", :add], ["d", :delete]
+      ])
+    end
+
+  end
+
 end


### PR DESCRIPTION
Currently, if two consecutive paragraphs are edited, their contents are not properly diffed:
![Screen Shot 2019-10-10 at 09 35 13](https://user-images.githubusercontent.com/27538/66567849-61b6b200-eb68-11e9-9c0b-b9f5c985a170.png)

The current algorithm performs a pairwise diff whenever a deletion follows an addition or vice versa. This happens here:

https://github.com/discourse/discourse/blob/c5326682d6346c13b495ece9f3ee4e82f1b13a72/lib/discourse_diff.rb#L38-L39

However, in the example above we have two additions followed by two deletions. This leads to:
- an added paragraph: `this is one great paragraph`
- a pairwise comparison: `this is one paragraph` vs. `this is another` 
- a deleted paragraph: `here is yet another`

The ideal approach would be to perform an alignment step before diffing (which is not trivial to implement, see [Gale-Church algorithm](https://en.wikipedia.org/wiki/Gale–Church_alignment_algorithm)), so a good compromise is to use one of the alternative edit sequences to the one returned by ONPDiff. 

In other words, `ONPDiff.paragraph_diff` transforms the edit sequence from `ONPDiff.diff` `Add1 Add2 Delete1 Delete2` into this one `Add1 Delete1 Add2 Delete2`. 

Current behavior using `ONPDiff.diff`:

![image](https://user-images.githubusercontent.com/27538/66569824-a2182f00-eb6c-11e9-9e69-416ef33f15a1.png)

Proposed behavior using `ONPDiff.paragraph_diff`:

![image](https://user-images.githubusercontent.com/27538/66569931-d55abe00-eb6c-11e9-8497-421b4d482835.png)

