### PR TITLE
FEATURE: search topics when adding a link in composer

### DIFF
--- a/app/assets/javascripts/discourse/controllers/insert-hyperlink.js.es6
+++ b/app/assets/javascripts/discourse/controllers/insert-hyperlink.js.es6
@@ -172,7 +172,7 @@ export default Ember.Controller.extend(ModalFunctionality, {
         this.selectLink(e.target);
       }
     },
-    search(value) {
+    search() {
       this._debounced = Ember.run.debounce(this, this.triggerSearch, 400);
     }
   }

--- a/app/assets/javascripts/discourse/controllers/insert-hyperlink.js.es6
+++ b/app/assets/javascripts/discourse/controllers/insert-hyperlink.js.es6
@@ -44,6 +44,13 @@ export default Ember.Controller.extend(ModalFunctionality, {
           e.stopPropagation();
         }
         break;
+      case 27:
+        if (this.searchResults.length) {
+          this.set("searchResults", []);
+          e.preventDefault();
+          e.stopPropagation();
+        }
+        break;
     }
   },
 

--- a/app/assets/javascripts/discourse/controllers/insert-hyperlink.js.es6
+++ b/app/assets/javascripts/discourse/controllers/insert-hyperlink.js.es6
@@ -1,15 +1,98 @@
 import ModalFunctionality from "discourse/mixins/modal-functionality";
+import { searchForTerm } from "discourse/lib/search";
+import { observes } from "ember-addons/ember-computed-decorators";
 
 export default Ember.Controller.extend(ModalFunctionality, {
-  linkUrl: "",
-  linkText: "",
-
   onShow() {
-    Ember.run.next(() =>
-      $(this)
-        .find("input.link-url")
-        .focus()
-    );
+    this.set("linkUrl", "");
+    this.set("linkText", "");
+    this.set("searchResults", []);
+    this.set("selectedRow", -1);
+
+    Ember.run.next(() => {
+      const element = document.querySelector(".insert-link");
+
+      element.addEventListener("keydown", e => {
+        switch (e.which) {
+          case 40:
+            this.selectRow(e, "down");
+            break;
+          case 38:
+            this.selectRow(e, "up");
+            break;
+          case 13:
+            // override Enter behaviour when a row is selected
+            if (this.selectedRow > -1) {
+              this.setUpdated(this.selectedRow);
+              element.querySelector("input.link-text").focus();
+              e.preventDefault();
+              e.stopPropagation();
+            }
+            break;
+        }
+      });
+
+      element
+        .closest(".modal-inner-container")
+        .addEventListener("mousedown", e => {
+          if (!e.target.closest(".inputs")) {
+            this.set("searchResults", []);
+          }
+        });
+
+      document.querySelector("input.link-url").focus();
+    });
+  },
+
+  selectRow(e, direction) {
+    const index =
+      direction === "down" ? this.selectedRow + 1 : this.selectedRow - 1;
+
+    if (index > -1 && index < this.searchResults.length) {
+      document
+        .querySelectorAll(".internal-link-results .search-link")
+        [index].focus();
+      this.set("selectedRow", index);
+    } else {
+      this.set("selectedRow", -1);
+      document.querySelector("input.link-text").focus();
+    }
+
+    e.preventDefault();
+  },
+
+  setUpdated(index) {
+    const topic = this.searchResults[index];
+    if (topic) {
+      this.set("linkUrl", Discourse.BaseUrl + topic.url);
+      if (!this.linkText) {
+        this.set("linkText", topic.title);
+      }
+    }
+    this.set("selectedRow", -1);
+  },
+
+  @observes("linkUrl")
+  triggerSearch() {
+    if (
+      this.linkUrl &&
+      this.linkUrl.length > 3 &&
+      !this.linkUrl.startsWith("http")
+    ) {
+      const searchTopics = function() {
+        searchForTerm(this.linkUrl, { typeFilter: "topic" }).then(results => {
+          if (results && results.topics && results.topics.length > 0) {
+            this.set("searchResults", results.topics);
+          } else {
+            this.set("searchResults", []);
+          }
+        });
+      };
+
+      Ember.run.debounce(this, searchTopics, 400);
+    } else {
+      this.set("searchResults", []);
+    }
   },
 
   actions: {
@@ -35,12 +118,13 @@ export default Ember.Controller.extend(ModalFunctionality, {
           this.toolbarEvent.selectText(sel.start + 1, origLink.length);
         }
       }
-      this.set("linkUrl", "");
-      this.set("linkText", "");
       this.send("closeModal");
     },
     cancel() {
       this.send("closeModal");
+    },
+    select(index) {
+      this.setUpdated(index);
     }
   }
 });

--- a/app/assets/javascripts/discourse/templates/modal/insert-hyperlink.hbs
+++ b/app/assets/javascripts/discourse/templates/modal/insert-hyperlink.hbs
@@ -1,6 +1,15 @@
 {{#d-modal-body title="composer.link_dialog_title" class="insert-link"}}
     <div class="inputs">
       {{text-field value=linkUrl placeholderKey="composer.link_url_placeholder" class="link-url"}}
+      {{#if searchResults}}
+        <div class="internal-link-results">
+          {{#each searchResults as |r index|}}
+            <a class="search-link" href="#" {{action "select" index}}>
+              {{r.fancy_title}}
+            </a>
+          {{/each}}
+        </div>
+      {{/if}}
     </div>
     <div class="inputs">
       {{text-field value=linkText placeholderKey="composer.link_optional_text" class="link-text"}}

--- a/app/assets/javascripts/discourse/templates/modal/insert-hyperlink.hbs
+++ b/app/assets/javascripts/discourse/templates/modal/insert-hyperlink.hbs
@@ -1,6 +1,9 @@
 {{#d-modal-body title="composer.link_dialog_title" class="insert-link"}}
     <div class="inputs">
       {{text-field value=linkUrl placeholderKey="composer.link_url_placeholder" class="link-url"}}
+      {{#if searchLoading}}
+        {{loading-spinner}}
+      {{/if}}
       {{#if searchResults}}
         <div class="internal-link-results">
           {{#each searchResults as |r index|}}

--- a/app/assets/javascripts/discourse/templates/modal/insert-hyperlink.hbs
+++ b/app/assets/javascripts/discourse/templates/modal/insert-hyperlink.hbs
@@ -5,7 +5,7 @@
         <div class="internal-link-results">
           {{#each searchResults as |r index|}}
             <a class="search-link" href="#" {{action "select" index}}>
-              {{r.fancy_title}}
+              {{replace-emoji r.fancy_title}}
             </a>
           {{/each}}
         </div>

--- a/app/assets/javascripts/discourse/templates/modal/insert-hyperlink.hbs
+++ b/app/assets/javascripts/discourse/templates/modal/insert-hyperlink.hbs
@@ -12,7 +12,11 @@
       {{#if searchResults}}
         <div class="internal-link-results">
           {{#each searchResults as |r index|}}
-            <a class="search-link" href="#" {{action "select" index}}>
+            <a
+              class="search-link"
+              href="{{r.url}}"
+              onclick={{action "linkClick"}}
+              data-title="{{r.title}}">
               {{replace-emoji r.fancy_title}}
             </a>
           {{/each}}

--- a/app/assets/javascripts/discourse/templates/modal/insert-hyperlink.hbs
+++ b/app/assets/javascripts/discourse/templates/modal/insert-hyperlink.hbs
@@ -1,6 +1,11 @@
 {{#d-modal-body title="composer.link_dialog_title" class="insert-link"}}
     <div class="inputs">
-      {{text-field value=linkUrl placeholderKey="composer.link_url_placeholder" class="link-url"}}
+      {{text-field
+        value=linkUrl
+        placeholderKey="composer.link_url_placeholder"
+        class="link-url"
+        key-up=(action "search")
+      }}
       {{#if searchLoading}}
         {{loading-spinner}}
       {{/if}}

--- a/app/assets/stylesheets/common/base/modal.scss
+++ b/app/assets/stylesheets/common/base/modal.scss
@@ -201,8 +201,34 @@
     }
 
     &.insert-link {
+      overflow-y: visible;
       input {
         min-width: 300px;
+      }
+
+      .inputs {
+        position: relative;
+        .internal-link-results {
+          position: absolute;
+          top: 70%;
+          padding: 5px 10px;
+          box-shadow: shadow("card");
+          z-index: 5;
+          background-color: $secondary;
+          max-height: 150px;
+          width: 90%;
+          overflow-y: auto;
+          > a {
+            padding: 6px;
+            border-bottom: 1px solid $primary-low;
+            cursor: pointer;
+            display: block;
+            &:hover,
+            &:focus {
+              background-color: $highlight-medium;
+            }
+          }
+        }
       }
     }
     textarea {

--- a/app/assets/stylesheets/common/base/modal.scss
+++ b/app/assets/stylesheets/common/base/modal.scss
@@ -208,6 +208,13 @@
 
       .inputs {
         position: relative;
+        .spinner {
+          position: absolute;
+          right: 8px;
+          top: -15px;
+          width: 10px;
+          height: 10px;
+        }
         .internal-link-results {
           position: absolute;
           top: 70%;

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1685,7 +1685,7 @@ en:
       link_description: "enter link description here"
       link_dialog_title: "Insert Hyperlink"
       link_optional_text: "optional title"
-      link_url_placeholder: "https://example.com"
+      link_url_placeholder: "Paste a URL or type to search topics"
       quote_title: "Blockquote"
       quote_text: "Blockquote"
       code_title: "Preformatted text"

--- a/test/javascripts/acceptance/composer-hyperlink-test.js.es6
+++ b/test/javascripts/acceptance/composer-hyperlink-test.js.es6
@@ -9,18 +9,13 @@ QUnit.test("add a hyperlink to a reply", async assert => {
   await click(".topic-post:first-child button.reply");
   await fillIn(".d-editor-input", "This is a link to ");
 
-  assert.equal(
-    find(".insert-link.modal-body").length,
-    0,
+  assert.ok(
+    !exists(".insert-link.modal-body"),
     "no hyperlink modal by default"
   );
 
   await click(".d-editor button.link");
-  assert.equal(
-    find(".insert-link.modal-body").length,
-    1,
-    "hyperlink modal visible"
-  );
+  assert.ok(exists(".insert-link.modal-body"), "hyperlink modal visible");
 
   await fillIn(".modal-body .link-url", "google.com");
   await fillIn(".modal-body .link-text", "Google");
@@ -32,9 +27,8 @@ QUnit.test("add a hyperlink to a reply", async assert => {
     "adds link with url and text, prepends 'http://'"
   );
 
-  assert.equal(
-    find(".insert-link.modal-body").length,
-    0,
+  assert.ok(
+    !exists(".insert-link.modal-body"),
     "modal dismissed after submitting link"
   );
 
@@ -51,9 +45,8 @@ QUnit.test("add a hyperlink to a reply", async assert => {
     "adds link with url and text, prepends 'http://'"
   );
 
-  assert.equal(
-    find(".insert-link.modal-body").length,
-    0,
+  assert.ok(
+    !exists(".insert-link.modal-body"),
     "modal dismissed after cancelling"
   );
 
@@ -75,26 +68,24 @@ QUnit.test("add a hyperlink to a reply", async assert => {
 
   await click(".d-editor button.link");
   await fillIn(".modal-body .link-url", "http://google.com");
-  assert.equal(
-    find(".internal-link-results").length,
-    0,
+  await keyEvent(".modal-body .link-url", "keyup", 32);
+  assert.ok(
+    !exists(".internal-link-results"),
     "does not show internal links search dropdown when inputting a url"
   );
 
   await fillIn(".modal-body .link-url", "local");
-
-  assert.equal(
-    find(".internal-link-results").length,
-    1,
+  await keyEvent(".modal-body .link-url", "keyup", 32);
+  assert.ok(
+    exists(".internal-link-results"),
     "shows internal links search dropdown when entering keywords"
   );
 
   await keyEvent(".insert-link", "keydown", 40);
   await keyEvent(".insert-link", "keydown", 13);
 
-  assert.equal(
-    find(".internal-link-results").length,
-    0,
+  assert.ok(
+    !exists(".internal-link-results"),
     "search dropdown dismissed after selecting an internal link"
   );
 

--- a/test/javascripts/acceptance/composer-hyperlink-test.js.es6
+++ b/test/javascripts/acceptance/composer-hyperlink-test.js.es6
@@ -70,4 +70,38 @@ QUnit.test("add a hyperlink to a reply", async assert => {
     "[Reset](http://somelink.com) textarea contents.",
     "adds link to a selected text"
   );
+
+  await fillIn(".d-editor-input", "");
+
+  await click(".d-editor button.link");
+  await fillIn(".modal-body .link-url", "http://google.com");
+  assert.equal(
+    find(".internal-link-results").length,
+    0,
+    "does not show internal links search dropdown when inputting a url"
+  );
+
+  await fillIn(".modal-body .link-url", "local");
+
+  assert.equal(
+    find(".internal-link-results").length,
+    1,
+    "shows internal links search dropdown when entering keywords"
+  );
+
+  await keyEvent(".insert-link", "keydown", 40);
+  await keyEvent(".insert-link", "keydown", 13);
+
+  assert.equal(
+    find(".internal-link-results").length,
+    0,
+    "search dropdown dismissed after selecting an internal link"
+  );
+
+  assert.ok(
+    find(".link-url")
+      .val()
+      .includes("http"),
+    "replaces link url field with internal link"
+  );
 });


### PR DESCRIPTION
When adding a hyperlink, typing something in the URL field that isn't a URL (i.e. doesn't start with `http`) will trigger a search of topics. 

<img width="694" alt="image" src="https://user-images.githubusercontent.com/368961/66584497-455c4a80-eb53-11e9-907f-3806e225ed81.png">

When selecting a topic from the results, the topic url and title will be added to the respective fields. 

Related: https://meta.discourse.org/t/search-existing-topics-when-hyperlinking/112922.