### PR TITLE
FIX: Ensure that scheduled jobs are loaded.

### DIFF
--- a/config/initializers/100-sidekiq.rb
+++ b/config/initializers/100-sidekiq.rb
@@ -1,5 +1,13 @@
 # frozen_string_literal: true
 
+# Ensure that scheduled jobs are loaded before mini_scheduler is configured.
+if Rails.env == "development"
+  require "jobs/base"
+  Dir.glob("#{Rails.root}/app/jobs/scheduled/*.rb") do |f|
+    load(f)
+  end
+end
+
 require "sidekiq/pausable"
 
 Sidekiq.configure_client do |config|


### PR DESCRIPTION
In development, the scheduled jobs are loaded lazily and MiniScheduler
cannot discover them (/sidekiq/scheduler does not show any jobs).