### PR TITLE
FIX: include topic/PM link & unsubscribe link in email footer

### DIFF
--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -569,7 +569,15 @@ class UserNotifications < ActionMailer::Base
         site_description: SiteSetting.site_description
       )
 
-      html = PrettyText.cook(message, sanitize: false).html_safe
+      unless translation_override_exists
+        html = UserNotificationRenderer.render(
+          template: 'email/invite',
+          format: :html,
+          locals: { message: PrettyText.cook(message, sanitize: false).html_safe,
+                    classes: Rtl.new(user).css_class
+          }
+        )
+      end
     else
       reached_limit = SiteSetting.max_emails_per_day_per_user > 0
       reached_limit &&= (EmailLog.where(user_id: user.id)

--- a/app/views/email/invite.html.erb
+++ b/app/views/email/invite.html.erb
@@ -1,0 +1,8 @@
+<div id='main' class=<%= classes %>>
+  <div class='header-instructions'>%{header_instructions}</div>
+  <% if message.present? %>
+    <div><%= message %></div>
+  <% end %>
+  <div class='footer'>%{respond_instructions}</div>
+  <div class='footer'>%{unsubscribe_instructions}</div>
+</div>

--- a/spec/mailers/user_notifications_spec.rb
+++ b/spec/mailers/user_notifications_spec.rb
@@ -862,6 +862,18 @@ describe UserNotifications do
       let(:user) { post.user }
       let(:mail_template) { "user_notifications.user_#{notification_type}_pm" }
 
+      it "should include message link & unsubscribe link in footer" do
+        mail = UserNotifications.user_invited_to_private_message(
+          user,
+          post: post,
+          notification_type: notification_type,
+          notification_data_hash: notification.data_hash
+        )
+        mail_html = mail.html_part.body.to_s
+        expect(mail_html.scan(/Visit Message/).count).to eq(1)
+        expect(mail_html.scan(/To unsubscribe/).count).to eq(1)
+      end
+
       include_examples "respect for private_email"
       include_examples "no reply by email"
       include_examples "sets user locale"
@@ -894,6 +906,21 @@ describe UserNotifications do
   describe "user invited to a topic" do
     include_examples "notification email building" do
       let(:notification_type) { :invited_to_topic }
+      let(:post) { Fabricate(:post) }
+      let(:user) { post.user }
+
+      it "should include topic link & unsubscribe link in footer" do
+        mail = UserNotifications.user_invited_to_private_message(
+          user,
+          post: post,
+          notification_type: notification_type,
+          notification_data_hash: notification.data_hash
+        )
+        mail_html = mail.html_part.body.to_s
+        expect(mail_html.scan(/Visit Topic/).count).to eq(1)
+        expect(mail_html.scan(/To unsubscribe/).count).to eq(1)
+      end
+
       include_examples "respect for private_email"
       include_examples "no reply by email"
       include_examples "sets user locale"


### PR DESCRIPTION
When existing users are invited to a topic or PM they are not seeing topic/PM link & unsubscribe link in email footer. This PR fixes that.

Message:
<img width="397" alt="Screen Shot 2019-10-15 at 11 25 37" src="https://user-images.githubusercontent.com/5732281/66805440-acf30b00-ef42-11e9-9515-ae9dfc3e1413.png">

Topic:
<img width="1404" alt="Screen Shot 2019-10-15 at 11 29 21" src="https://user-images.githubusercontent.com/5732281/66805442-acf30b00-ef42-11e9-8ae0-ff199b706895.png">
