### PR TITLE
FIX: Include user id in notification webhook

### DIFF
--- a/app/serializers/notification_serializer.rb
+++ b/app/serializers/notification_serializer.rb
@@ -3,6 +3,7 @@
 class NotificationSerializer < ApplicationSerializer
 
   attributes :id,
+             :user_id,
              :notification_type,
              :read,
              :created_at,

--- a/spec/serializers/notification_serializer_spec.rb
+++ b/spec/serializers/notification_serializer_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe NotificationSerializer do
+  describe '#as_json' do
+    fab!(:user) { Fabricate(:user) }
+    let(:notification) { Fabricate(:notification, user: user) }
+    let(:serializer) { NotificationSerializer.new(notification) }
+    let(:json) { serializer.as_json }
+
+    it "returns the user_id" do
+      expect(json[:notification][:user_id]).to eq(user.id)
+    end
+
+  end
+end


### PR DESCRIPTION
The payload when receiving a notification webhook is pointless without
knowing which user the notification is for. This fix adds the user_id to
the notification serializer so that when you receive a notification
webhook you can properly identify which user the notification is for.

See

https://meta.discourse.org/t/getting-the-target-user-for-notification-webhook-events/129052?u=blake

for more details.