### PR TITLE
Revert "FIX: public_file_server.enabled is false in test"

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -10,7 +10,7 @@ Discourse::Application.configure do
   config.cache_classes = true
 
   # Configure static asset server for tests with Cache-Control for performance
-  config.public_file_server.enabled = false
+  config.public_file_server.enabled = true
 
   # don't consider reqs local so we can properly handle exceptions like we do in prd
   config.consider_all_requests_local       = false

--- a/spec/requests/uploads_controller_spec.rb
+++ b/spec/requests/uploads_controller_spec.rb
@@ -266,6 +266,7 @@ describe UploadsController do
     end
 
     it 'returns 200 when js file' do
+      ActionDispatch::FileHandler.any_instance.stubs(:match?).returns(false)
       upload = upload_file("test.js", "themes")
       get upload.url
       expect(response.status).to eq(200)


### PR DESCRIPTION
Reverts discourse/discourse#8192

I think we should revert it, I only checked `rspec` and that change is failing qunit test but also make them terribly slow 218s vs 11s