### PR TITLE
DEV: Disable better_errors when developing with more than one worker

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -40,6 +40,11 @@ Discourse::Application.configure do
 
   BetterErrors::Middleware.allow_ip! ENV['TRUSTED_IP'] if ENV['TRUSTED_IP']
 
+  if defined?(Unicorn) && ENV["UNICORN_WORKERS"].to_i != 1
+    # BetterErrors doesn't work with multiple unicorn workers. Disable it to avoid confusion
+    Rails.configuration.middleware.delete BetterErrors::Middleware
+  end
+
   config.load_mini_profiler = true
   if hosts = ENV['DISCOURSE_DEV_HOSTS']
     config.hosts.concat(hosts.split(","))


### PR DESCRIPTION
From the better_errors README:

> Better Errors works by leaving a lot of context in server process memory. If you're using a web server that runs multiple "workers" it's likely that a second request (as happens when you click on a stack frame) will hit a different worker. That worker won't have the necessary context in memory, and you'll see a Session Expired message.