### PR TITLE
DEV: Remove `suspend` from Admin::UsersController responses

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -137,7 +137,6 @@ class Admin::UsersController < Admin::AdminController
 
     render_json_dump(
       suspension: {
-        suspended: true,
         suspend_reason: params[:reason],
         full_suspend_reason: user_history.try(:details),
         suspended_till: @user.suspended_till,
@@ -157,7 +156,8 @@ class Admin::UsersController < Admin::AdminController
 
     render_json_dump(
       suspension: {
-        suspended: false
+        suspended_till: nil,
+        suspended_at: nil
       }
     )
   end

--- a/test/javascripts/acceptance/admin-suspend-user-test.js.es6
+++ b/test/javascripts/acceptance/admin-suspend-user-test.js.es6
@@ -8,7 +8,7 @@ acceptance("Admin - Suspend User", {
     server.put("/admin/users/:user_id/suspend", () =>
       helper.response(200, {
         suspension: {
-          suspended: true
+          suspended_till: "2099-01-01T12:00:00.000Z"
         }
       })
     );
@@ -16,7 +16,7 @@ acceptance("Admin - Suspend User", {
     server.put("/admin/users/:user_id/unsuspend", () =>
       helper.response(200, {
         suspension: {
-          suspended: false
+          suspended_till: null
         }
       })
     );


### PR DESCRIPTION
`suspend` isn't a User attribute, but was being assigned to the frontend User model as if it was. The model has a computed property that depends on `suspended_till`, so instead of overriding this property, it's better to return relevant attributes.

Fixes a computed-property.override deprecation (https://emberjs.com/deprecations/v3.x#toc_computed-property-override)