### PR TITLE
FIX: Update the review page whenever the reviewable count changes.

### DIFF
--- a/app/assets/javascripts/discourse/routes/review-index.js.es6
+++ b/app/assets/javascripts/discourse/routes/review-index.js.es6
@@ -25,6 +25,14 @@ export default Discourse.Route.extend({
     });
   },
 
+  activate() {
+    this.messageBus.subscribe("/reviewable_counts", () => this.refresh());
+  },
+
+  deactivate() {
+    this.messageBus.unsubscribe("/reviewable_counts");
+  },
+
   actions: {
     refreshRoute() {
       this.refresh();


### PR DESCRIPTION
As mentioned [here](https://meta.discourse.org/t/admin-mod-clicking-on-review-notification-doesnt-load-the-latest-to-be-reviewed-post/125503), the `/reviewable` page is not being refreshed properly.

The `/reviewable_counts` message gets sent every time a reviewable gets created or updated. We now listen for this message and refresh the page to keep it updated.