### PR TITLE
UX: Make group membership UI clearer

### DIFF
--- a/app/assets/javascripts/discourse/templates/components/groups-form-membership-fields.hbs
+++ b/app/assets/javascripts/discourse/templates/components/groups-form-membership-fields.hbs
@@ -17,6 +17,20 @@
 
       {{i18n 'admin.groups.manage.membership.automatic_membership_retroactive'}}
     </label>
+  </div>
+
+  {{plugin-outlet name="groups-form-membership-below-automatic"
+                  args=(hash model=model)}}
+
+  <div class="control-group">
+    <label class="control-label">{{i18n "admin.groups.manage.membership.effects"}}</label>
+    <label for="grant_trust_level">{{i18n 'admin.groups.manage.membership.trust_levels_title'}}</label>
+
+    {{combo-box name="grant_trust_level"
+        valueAttribute="value"
+        value=model.grant_trust_level
+        content=trustLevelOptions
+        class="groups-form-grant-trust-level"}}
 
     <label>
       {{input type="checkbox"
@@ -25,20 +39,7 @@
 
       {{i18n 'admin.groups.manage.membership.primary_group'}}
     </label>
-  </div>
 
-  {{plugin-outlet name="groups-form-membership-below-automatic"
-                  args=(hash model=model)}}
-
-  <div class="control-group">
-    <label class="control-label">{{i18n "admin.groups.manage.membership.trust_level"}}</label>
-    <label for="grant_trust_level">{{i18n 'admin.groups.manage.membership.trust_levels_title'}}</label>
-
-    {{combo-box name="grant_trust_level"
-        valueAttribute="value"
-        value=model.grant_trust_level
-        content=trustLevelOptions
-        class="groups-form-grant-trust-level"}}
   </div>
 {{/if}}
 

--- a/app/assets/stylesheets/common/components/groups-form-membership-fields.scss
+++ b/app/assets/stylesheets/common/components/groups-form-membership-fields.scss
@@ -1,3 +1,4 @@
-.group-form-automatic-membership-automatic {
+.group-form-automatic-membership-automatic,
+.groups-form-grant-trust-level {
   margin-bottom: 10px;
 }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3268,8 +3268,8 @@ en:
 
           membership:
             automatic: Automatic
-            trust_level: Trust Level
             trust_levels_title: "Trust level automatically granted to members when they're added:"
+            effects: Effects
             trust_levels_none: "None"
             automatic_membership_email_domains: "Users who register with an email domain that exactly matches one in this list will be automatically added to this group:"
             automatic_membership_retroactive: "Apply the same email domain rule to add existing registered users"


### PR DESCRIPTION
The 'automatically set primary group' checkbox looked like it was associated with the email membership. In fact, it applies to all members who join the group. This commit moves it next to the 'automatic trust level' setting, and puts them both under an 'Effects' heading.

Before:

<img width="1162" alt="Screenshot 2019-10-17 at 16 56 15" src="https://user-images.githubusercontent.com/6270921/67026095-0c961580-f0ff-11e9-9ddf-acb476d10cc3.png">


After:

<img width="1143" alt="Screenshot 2019-10-17 at 16 53 10" src="https://user-images.githubusercontent.com/6270921/67026047-f9834580-f0fe-11e9-939d-de67f461abb7.png">
