### PR TITLE
Support for importing `@ember/component` and `@ember/routing/route`

### DIFF
--- a/app/assets/javascripts/discourse-loader.js
+++ b/app/assets/javascripts/discourse-loader.js
@@ -1,6 +1,15 @@
 var define, requirejs;
 
 (function() {
+  // In future versions of ember we don't need this
+  var EMBER_MODULES = {};
+  if (typeof Ember !== "undefined") {
+    EMBER_MODULES = {
+      "@ember/component": { default: Ember.Component },
+      "@ember/routing/route": { default: Ember.Route }
+    };
+  }
+
   var _isArray;
   if (!Array.isArray) {
     _isArray = function(x) {
@@ -111,7 +120,7 @@ var define, requirejs;
   }
 
   function requireFrom(name, origin) {
-    var mod = registry[name];
+    var mod = EMBER_MODULES[name] || registry[name];
     if (!mod) {
       throw new Error(
         "Could not find module `" + name + "` imported from `" + origin + "`"
@@ -125,6 +134,10 @@ var define, requirejs;
   }
 
   requirejs = require = function(name) {
+    if (EMBER_MODULES[name]) {
+      return EMBER_MODULES[name];
+    }
+
     var mod = registry[name];
 
     if (mod && mod.callback instanceof Alias) {

--- a/app/assets/javascripts/discourse/components/d-modal.js.es6
+++ b/app/assets/javascripts/discourse/components/d-modal.js.es6
@@ -1,6 +1,7 @@
 import { on } from "ember-addons/ember-computed-decorators";
+import Component from "@ember/component";
 
-export default Ember.Component.extend({
+export default Component.extend({
   classNameBindings: [
     ":modal",
     ":d-modal",

--- a/app/assets/javascripts/discourse/routes/discourse.js.es6
+++ b/app/assets/javascripts/discourse/routes/discourse.js.es6
@@ -1,7 +1,8 @@
 import Composer from "discourse/models/composer";
 import { getOwner } from "discourse-common/lib/get-owner";
+import Route from "@ember/routing/route";
 
-const DiscourseRoute = Ember.Route.extend({
+const DiscourseRoute = Route.extend({
   showFooter: false,
 
   // Set to true to refresh a model without a transition if a query param

--- a/app/assets/javascripts/discourse/routes/group-activity-index.js.es6
+++ b/app/assets/javascripts/discourse/routes/group-activity-index.js.es6
@@ -1,4 +1,6 @@
-export default Ember.Route.extend({
+import Route from "@ember/routing/route";
+
+export default Route.extend({
   beforeModel() {
     const group = this.modelFor("group");
     if (group.can_see_members) {


### PR DESCRIPTION
This will allow us to take the first step in updating our modules to be consistent with example Ember code and to align with Ember CLI