### PR TITLE
FIX: Add additional HTML5 media extensions to onebox audio and video tags

### DIFF
--- a/lib/oneboxer.rb
+++ b/lib/oneboxer.rb
@@ -171,9 +171,9 @@ module Oneboxer
 
   def self.local_upload_html(url)
     case File.extname(URI(url).path || "")
-    when /^\.(mov|mp4|webm|ogv)$/i
+    when /^\.(mov|mp4|m4v|webm|ogv|3gp)$/i
       "<video width='100%' height='100%' controls><source src='#{url}'><a href='#{url}'>#{url}</a></video>"
-    when /^\.(mp3|ogg|wav|m4a)$/i
+    when /^\.(mp3|og[ga]|opus|wav|m4[abpr]|aac|flac)$/i
       "<audio controls><source src='#{url}'><a href='#{url}'>#{url}</a></audio>"
     end
   end


### PR DESCRIPTION
Modern browsers support more file extensions than the ones we're currently specifying ([source](https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Video_codecs#Common_codecs)). 

For example, Ogg files usually have the `.ogg` extension, but can also have `.ogv` (for video) and `.oga` (for audio). 

Including these additional extensions ensures that valid media files will appear with an HTML audio/video player.