### PR TITLE
FIX: d-button should default type to button

### DIFF
--- a/app/assets/javascripts/discourse/components/d-button.js.es6
+++ b/app/assets/javascripts/discourse/components/d-button.js.es6
@@ -7,6 +7,8 @@ export default Ember.Component.extend({
 
   form: null,
 
+  type: "button",
+
   tagName: "button",
   classNameBindings: [":btn", "noText", "btnType"],
   attributeBindings: [


### PR DESCRIPTION
This will prevent unexpected behavior of  d-button being considerd as a submit button.