### PR TITLE
FIX: Reconnect in restore process connects to correct DB

### DIFF
--- a/lib/backup_restore/restorer.rb
+++ b/lib/backup_restore/restorer.rb
@@ -404,6 +404,7 @@ module BackupRestore
 
     def reconnect_database
       log "Reconnecting to the database..."
+      RailsMultisite::ConnectionManagement::reload
       RailsMultisite::ConnectionManagement::establish_connection(db: @current_db)
     end
 


### PR DESCRIPTION
Simplified flow of restore is like that
```
migrate_database
reconnect
extract_uploads
```

Problem with incorrect current database started with this fix https://github.com/discourse/discourse/commit/025d4ee91f4

Dump task is reconnecting to default database https://github.com/rails/rails/blob/master/activerecord/lib/active_record/railties/databases.rake#L429

And then, we are trying to reconnect to the original database with that code:
```
def reconnect_database
  log "Reconnecting to the database..."
  RailsMultisite::ConnectionManagement::establish_connection(db: @current_db)
end
```

This reconnect is not switching us back to correct database because of that check
https://github.com/discourse/rails_multisite/blob/master/lib/rails_multisite/connection_management.rb#L181
Basically, it finds existing handler and it thinks that we are connected to correct DB and this step can be skipped.

To solve it, we can reload RailsMultisite::ConnectionManagement which creates a new instance of that class
https://github.com/discourse/rails_multisite/blob/master/lib/rails_multisite/connection_management.rb#L38

Meta: https://meta.discourse.org/t/multisite-restores-uploads-to-default-instead-of-actual-db-name/130778