### PR TITLE
FIX: Correct path to ImportExport module

### DIFF
--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -2,7 +2,7 @@
 
 desc 'Export all the categories'
 task 'export:categories', [:category_ids] => [:environment] do |_, args|
-  require "import_export/import_export"
+  require "import_export"
   ids = args[:category_ids].split(" ")
 
   ImportExport.export_categories(ids)
@@ -11,7 +11,7 @@ end
 
 desc 'Export only the structure of all categories'
 task 'export:category_structure', [:include_group_users, :file_name] => [:environment] do |_, args|
-  require "import_export/import_export"
+  require "import_export"
 
   ImportExport.export_category_structure(args[:include_group_users], args[:file_name])
   puts "", "Done", ""

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -507,7 +507,7 @@ end
 
 desc 'Import existing exported file'
 task 'import:file', [:file_name] => [:environment] do |_, args|
-  require "import_export/import_export"
+  require "import_export"
 
   ImportExport.import(args[:file_name])
   puts "", "Done", ""

--- a/script/discourse
+++ b/script/discourse
@@ -264,7 +264,7 @@ class DiscourseCLI < Thor
   end
 
   def load_import_export
-    require File.expand_path(File.dirname(__FILE__) + "/../lib/import_export/import_export")
+    require File.expand_path(File.dirname(__FILE__) + "/../lib/import_export")
   end
 
   def do_remap(from, to, regex = false)


### PR DESCRIPTION
During the move from Classic autoloader to Zeitwerk import_export module was moved to correct file name convention.
https://github.com/discourse/discourse/commit/427d54b2b00fa94474c0522eaed750452c4e7f43#diff-d896ec33b95afb7fae9f8bfe73d0580b

Problem is that export/import is still using old path to require that module

Meta: https://meta.discourse.org/t/topic-and-category-export-import/38930/40