### PR TITLE
WIP: When a category is muted, subcategory is as well

### DIFF
--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -868,8 +868,9 @@ class TopicQuery
         NOT EXISTS (
           SELECT 1
             FROM category_users cu
+            LEFT JOIN categories ON categories.id = topics.category_id
            WHERE cu.user_id = :user_id
-             AND cu.category_id = topics.category_id
+             AND (cu.category_id = categories.id OR cu.category_id = categories.parent_category_id)
              AND cu.notification_level = :muted
              AND cu.category_id <> :category_id
              AND (tu.notification_level IS NULL OR tu.notification_level < :tracking)
@@ -878,7 +879,6 @@ class TopicQuery
             tracking: TopicUser.notification_levels[:tracking],
             category_id: category_id || -1)
     end
-
     list
   end
 

--- a/spec/components/topic_query_spec.rb
+++ b/spec/components/topic_query_spec.rb
@@ -238,6 +238,18 @@ describe TopicQuery do
       expect(topic_query.list_new.topics.map(&:id)).not_to include(topic.id)
       expect(topic_query.list_latest.topics.map(&:id)).not_to include(topic.id)
     end
+
+    it 'subcategory is removed from new and latest lists' do
+      category = Fabricate(:category_with_definition)
+      subcategory = Fabricate(:category, parent_category_id: category.id)
+
+      topic = Fabricate(:topic, category: subcategory)
+      CategoryUser.create!(user_id: user.id,
+                           category_id: category.id,
+                           notification_level: CategoryUser.notification_levels[:muted])
+      expect(topic_query.list_new.topics.map(&:id)).not_to include(topic.id)
+      expect(topic_query.list_latest.topics.map(&:id)).not_to include(topic.id)
+    end
   end
 
   context 'muted tags' do


### PR DESCRIPTION
That bug was mentioned in [meta](https://meta.discourse.org/t/muting-categories-hides-them-muting-subcategories-should-too/131316)

Let's say we got parent category with id 1 and subcategory with id 2. When parent category is muted topics linked to subcategory are not hidden because we are only looking for CategoryUser rows with subcategory id and mute notification level.

We should ensure if both, subcategory and parent category are not muted.