### PR TITLE
FIX: When running the wizard and using a custom theme, fallback to the color_scheme name if the base_scheme_id is nil

### DIFF
--- a/app/models/color_scheme.rb
+++ b/app/models/color_scheme.rb
@@ -187,6 +187,10 @@ class ColorScheme < ActiveRecord::Base
     @base_color_scheme
   end
 
+  def self.is_base?(scheme_name)
+    base_color_scheme_colors.map { |c| c[:id] }.include?(scheme_name)
+  end
+
   # create_from_base will create a new ColorScheme that overrides Discourse's base color scheme with the given colors.
   def self.create_from_base(params)
     new_color_scheme = new(name: params[:name])

--- a/spec/components/wizard/wizard_builder_spec.rb
+++ b/spec/components/wizard/wizard_builder_spec.rb
@@ -162,7 +162,21 @@ describe Wizard::Builder do
       end
     end
 
-    describe "when the default them hass been override" do
+    describe "when the default theme has been override and the color scheme doesn't have a base scheme" do
+      let(:color_scheme) { Fabricate(:color_scheme, base_scheme_id: nil) }
+
+      before do
+        SiteSetting.default_theme_id = theme.id
+        theme.update(color_scheme: color_scheme)
+      end
+
+      it 'fallbacks to the color scheme name' do
+        expect(field.required).to eq(false)
+        expect(field.value).to eq(color_scheme.name)
+      end
+    end
+
+    describe "when the default theme has been override" do
       before do
         theme.set_default!
       end


### PR DESCRIPTION
When re-running the wizard and using a custom theme, the logo step canvas is not working. This is caused by the `base_scheme_id` of the `color_scheme` being nil for some custom themes.

To fix this, this PR proposes to add the custom theme (set as the default) to the list of themes previewed in the `colors` step. Here, I'm using the hibiscus theme as my default:

![Screen Shot 2019-10-23 at 18 29 07](https://user-images.githubusercontent.com/5025816/67435687-0bfbf400-f5c3-11e9-883d-7f4146b5ffd5.png)

When jumping to the logo step, the canvas is using the custom theme colors:

![Screen Shot 2019-10-23 at 18 52 03](https://user-images.githubusercontent.com/5025816/67437040-503cc380-f5c6-11e9-949b-fec346d4b1c7.png)

