### PR TITLE
FIX: Restore for non-multisite is not raising an error on reconnect step

### DIFF
--- a/lib/backup_restore/restorer.rb
+++ b/lib/backup_restore/restorer.rb
@@ -404,7 +404,7 @@ module BackupRestore
 
     def reconnect_database
       log "Reconnecting to the database..."
-      RailsMultisite::ConnectionManagement::reload
+      RailsMultisite::ConnectionManagement::reload if RailsMultisite::ConnectionManagement::instance
       RailsMultisite::ConnectionManagement::establish_connection(db: @current_db)
     end
 

--- a/spec/lib/backup_restore/restorer_spec.rb
+++ b/spec/lib/backup_restore/restorer_spec.rb
@@ -124,5 +124,10 @@ describe BackupRestore::Restorer do
       restorer.send(:reconnect_database)
       expect(RailsMultisite::ConnectionManagement.current_db).to eq('second')
     end
+
+    it 'it is not erroring for non multisite' do
+      RailsMultisite::ConnectionManagement::clear_settings!
+      expect{ restorer.send(:reconnect_database) }.not_to raise_error
+    end
   end
 end


### PR DESCRIPTION
That commit introduced a bug to the system: https://github.com/discourse/discourse/commit/f69dacf979317946ed4a3e81e85fcca1b45bedf0

Restore works fine for multisite, however, stopped working for non-multisite.

Reason for that was that `establish_connection` method got a check if the multisite instance is available:
```
    def self.instance
      @instance
    end

    def self.establish_connection(opts)
      @instance.establish_connection(opts) if @instance
    end
```
However, the reload method don't have that check
```
    def self.reload
      @instance = new(instance.config_filename)
    end
```

To solve it, let's ensure we are in a multisite environment before call reload