### PR TITLE
FIX: Hide muted subcategories

### DIFF
--- a/app/assets/javascripts/discourse/models/category.js.es6
+++ b/app/assets/javascripts/discourse/models/category.js.es6
@@ -3,6 +3,7 @@ import RestModel from "discourse/models/rest";
 import computed from "ember-addons/ember-computed-decorators";
 import { on } from "ember-addons/ember-computed-decorators";
 import PermissionType from "discourse/models/permission-type";
+import { NotificationLevels } from "discourse/lib/notification-levels";
 
 const Category = RestModel.extend({
   permissions: null,
@@ -42,6 +43,11 @@ const Category = RestModel.extend({
   @computed("id")
   searchContext(id) {
     return { type: "category", id, category: this };
+  },
+
+  @computed("notification_level")
+  isMuted(notificationLevel) {
+    return notificationLevel === NotificationLevels.MUTED;
   },
 
   @computed("name")

--- a/app/assets/javascripts/discourse/templates/components/categories-only.hbs
+++ b/app/assets/javascripts/discourse/templates/components/categories-only.hbs
@@ -20,12 +20,14 @@
               </div>
                    {{#if c.subcategories}}
               <div class='subcategories'>
-                {{#each c.subcategories as |s|}}
-                  <span class='subcategory'>
-                    {{category-title-before category=s}}
-                    {{category-link s hideParent="true"}}
-                    {{category-unread category=s}}
-                  </span>
+                {{#each c.subcategories as |subcategory|}}
+                  {{#unless subcategory.isMuted}}
+                    <span class='subcategory'>
+                      {{category-title-before category=subcategory}}
+                      {{category-link subcategory hideParent="true"}}
+                      {{category-unread category=subcategory}}
+                    </span>
+                  {{/unless}}
                 {{/each}}
               </div>
             {{/if}}


### PR DESCRIPTION
That bug was mentioned in [meta](https://meta.discourse.org/t/muting-categories-hides-them-muting-subcategories-should-too/131316)

Problem is that subcategories are always visible in `/categories` path even if muted.

Categories/subcategories are loaded in at least two places
https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/models/site.js.es6#L146
https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/routes/discovery-categories.js.es6#L46

I discussed that with @jjaffeux and we thought that maybe it would be a good idea to filter that on frontend level