### PR TITLE
FIX: Reload plugin translations in development

### DIFF
--- a/lib/js_locale_helper.rb
+++ b/lib/js_locale_helper.rb
@@ -6,10 +6,12 @@ module JsLocaleHelper
     Dir["#{Rails.root}/plugins/*/config/locales/client.#{locale_str}.yml"]
   end
 
-  def self.reloadable_plugins(locale, ctx)
+  def self.reloadable_plugins(locale_sym, ctx)
     return unless Rails.env.development?
-    plugin_client_files(locale.to_s).each do |file|
-      ctx.depend_on(file)
+    I18n.fallbacks[locale_sym].each do |locale|
+      plugin_client_files(locale.to_s).each do |file|
+        ctx.depend_on(file)
+      end
     end
   end
 


### PR DESCRIPTION
The default locale is :en_US, which is just a thin layer over :en. In
other words, :en_US has the :en locale as a fallback. When "en.yml" is
edited, only the :en locale is refreshed and :en_US becomes stale.

This commit ensures that there is a dependency on the fallback locales
too.