### PR TITLE
Fix github oneboxes for RTL locales

### DIFF
--- a/app/assets/stylesheets/common/base/rtl.scss
+++ b/app/assets/stylesheets/common/base/rtl.scss
@@ -60,3 +60,33 @@
   padding-right: 40px;
   padding-left: 40px;
 }
+
+// Fixes github oneboxes for RTL sites
+.rtl aside.onebox.githubblob {
+  padding: 12px 25px 12px 12px !important;
+  direction: ltr !important;
+}
+
+.rtl aside.onebox.githubblob .source {
+  background-position: 0 50% !important;
+  padding-right: 20px;
+}
+
+.rtl pre.onebox code ol.lines {
+  margin: 0 0 0 40px !important;
+}
+
+.rtl pre.onebox code ol.lines li:before {
+  right: -40px;
+  padding-left: 5px;
+  padding-right: 0;
+  text-align: right !important;
+}
+
+.rtl pre.onebox code ol.lines li {
+  padding-right: 5px;
+  padding-left: 0;
+  margin-right: 0;
+  border-right: 1px solid #cfcfcf;
+  border-left: none !important;
+}


### PR DESCRIPTION
This issue came up on meta: https://meta.discourse.org/t/ui-bug-github-preview-url-when-discourse-is-rtl/131725.

All rules are targeting the  `.rtl`  class that gets added to the  `head`  tag for RTL sites.

When we have rules like  `padding: 12px 25px 12px 12px;`  in the main stylesheet, the r2 gem automatically converts the rule to  `padding: 12px 12px 12px 25px;` . Adding  `!important`  prevents the rule from being flipped.

When we have a rule like  `padding-right: 5px;`  in the main style sheet, the r2 gem converts the rule to  `padding-left: 5px;` . I haven't found any way to prevent this. If we don't want the rule to be flipped, we need to add the opposite rule to what we want to happen to the rtl stylesheet. This is awkward, but there aren't many places this needs to be done.