### PR TITLE
add in plugin outlet and pass model to above-review-filters

### DIFF
--- a/app/assets/javascripts/discourse/templates/review-index.hbs
+++ b/app/assets/javascripts/discourse/templates/review-index.hbs
@@ -23,6 +23,9 @@
     </div>
 
     {{#if filtersExpanded}}
+
+      {{plugin-outlet name="above-review-filters" args=(hash model=model)}}
+
       <div class='reviewable-filter'>
         <label class='filter-label'>{{i18n "review.filters.type.title"}}</label>
         {{combo-box value=filterType content=allTypes none="review.filters.type.all"}}


### PR DESCRIPTION
this is needed to add filters to the review page in plugins.