### PR TITLE
FIX: flaky jobs_base_spec.rb

### DIFF
--- a/spec/lib/backup_restore/restorer_spec.rb
+++ b/spec/lib/backup_restore/restorer_spec.rb
@@ -110,6 +110,7 @@ describe BackupRestore::Restorer do
       described_class.any_instance.stubs(initialize_state: true)
     end
     after do
+      RailsMultisite::ConnectionManagement.clear_settings!
       conn.establish_connection(db: 'default')
     end
     let(:conn) { RailsMultisite::ConnectionManagement }


### PR DESCRIPTION
I was searching for a reason for randomly failing jobs_base_spec.rb. The reason was that after restorer_spec, the database is not restored to default.
After restorer spec RailsMultisite::ConnectionManagement.all_dbs is rstill eturning array of `['default', 'second']`

Then base job execution is evaluated twice
```
dbs = RailsMultisite::ConnectionManagement.all_dbs
dbs.each do |db|
  execute(opts)
end
```