### PR TITLE
FIX: reenable restore spec

### DIFF
--- a/spec/lib/backup_restore/restorer_spec.rb
+++ b/spec/lib/backup_restore/restorer_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 # This causes flakiness
-xdescribe BackupRestore::Restorer do
+describe BackupRestore::Restorer do
   it 'detects which pg_dump output is restorable to different schemas' do
     {
       "9.6.7" => true,


### PR DESCRIPTION
I think that restorer spec will not affect other specs anymore. Let's wait for buildkite and maybe retry 2-3 times to be sure