### PR TITLE
FIX: Require q param in /tags/filter/search route

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -193,6 +193,8 @@ class TagsController < ::ApplicationController
   end
 
   def search
+    params.require(:q)
+
     clean_name = DiscourseTagging.clean_tag(params[:q])
     category = params[:categoryId] ? Category.find_by_id(params[:categoryId]) : nil
 

--- a/spec/requests/tags_controller_spec.rb
+++ b/spec/requests/tags_controller_spec.rb
@@ -428,6 +428,16 @@ describe TagsController do
         json = ::JSON.parse(response.body)
         expect(json["results"].map { |j| j["id"] }).to eq(['тема-в-разработке'])
       end
+
+      context 'when tag query parameter is not provided' do
+        it 'does not cause a 500 error, returns a param required message' do
+          get "/tags/filter/search.json", params: {}
+          expect(response.status).not_to eq(500)
+          expect(response.status).to eq(400)
+          json = ::JSON.parse(response.body)
+          expect(json['errors'].first).to eq('param is missing or the value is empty: q')
+        end
+      end
     end
   end
 

--- a/spec/requests/tags_controller_spec.rb
+++ b/spec/requests/tags_controller_spec.rb
@@ -432,10 +432,9 @@ describe TagsController do
       context 'when tag query parameter is not provided' do
         it 'does not cause a 500 error, returns a param required message' do
           get "/tags/filter/search.json", params: {}
-          expect(response.status).not_to eq(500)
           expect(response.status).to eq(400)
           json = ::JSON.parse(response.body)
-          expect(json['errors'].first).to eq('param is missing or the value is empty: q')
+          expect(json['errors']).to include('param is missing or the value is empty: q')
         end
       end
     end


### PR DESCRIPTION
Fixes this log error: https://dev.discourse.org/logs/show/4e66b724b8133292a3f94e4a59a3caa4

* if not provided this route was causing a 500 error when
  DiscourseTagging.clean_tag was called, because .downcase
  was being called on the param (which was nil)
* this was detected in the logs, and upon further investigation
  all instances were occurring via community.nash.io
* nowhere in the frontend appeared to allow this behaviour; all
  calls to the tag search always provided the q param, so suspected
  direct call to the endpoint. now return a 400 error instead