### PR TITLE
DEV: Support custom server-side names in rest models

### DIFF
--- a/app/assets/javascripts/discourse/adapters/rest.js.es6
+++ b/app/assets/javascripts/discourse/adapters/rest.js.es6
@@ -65,8 +65,12 @@ export default Ember.Object.extend({
   pathFor(store, type, findArgs) {
     let path =
       this.basePath(store, type, findArgs) +
-      Ember.String.underscore(store.pluralize(type));
+      Ember.String.underscore(store.pluralize(this.apiNameFor(type)));
     return this.appendQueryParams(path, findArgs);
+  },
+
+  apiNameFor(type) {
+    return type;
   },
 
   findAll(store, type, findArgs) {
@@ -103,7 +107,7 @@ export default Ember.Object.extend({
 
   update(store, type, id, attrs) {
     const data = {};
-    const typeField = Ember.String.underscore(type);
+    const typeField = Ember.String.underscore(this.apiNameFor(type));
     data[typeField] = attrs;
 
     return ajax(
@@ -116,7 +120,7 @@ export default Ember.Object.extend({
 
   createRecord(store, type, attrs) {
     const data = {};
-    const typeField = Ember.String.underscore(type);
+    const typeField = Ember.String.underscore(this.apiNameFor(type));
     data[typeField] = attrs;
     return ajax(this.pathFor(store, type), this.getPayload("POST", data)).then(
       function(json) {

--- a/app/assets/javascripts/discourse/models/store.js.es6
+++ b/app/assets/javascripts/discourse/models/store.js.es6
@@ -92,7 +92,12 @@ export default Ember.Object.extend({
     if (typeof findArgs === "object") {
       return this._resultSet(type, result, findArgs);
     } else {
-      return this._hydrate(type, result[Ember.String.underscore(type)], result);
+      const apiName = this.adapterFor(type).apiNameFor(type);
+      return this._hydrate(
+        type,
+        result[Ember.String.underscore(apiName)],
+        result
+      );
     }
   },
 
@@ -146,8 +151,11 @@ export default Ember.Object.extend({
   },
 
   refreshResults(resultSet, type, url) {
+    const adapter = this.adapterFor(type);
     return ajax(url).then(result => {
-      const typeName = Ember.String.underscore(this.pluralize(type));
+      const typeName = Ember.String.underscore(
+        this.pluralize(adapter.apiNameFor(type))
+      );
       const content = result[typeName].map(obj =>
         this._hydrate(type, obj, result)
       );
@@ -156,8 +164,11 @@ export default Ember.Object.extend({
   },
 
   appendResults(resultSet, type, url) {
+    const adapter = this.adapterFor(type);
     return ajax(url).then(result => {
-      let typeName = Ember.String.underscore(this.pluralize(type));
+      const typeName = Ember.String.underscore(
+        this.pluralize(adapter.apiNameFor(type))
+      );
 
       let pageTarget = result.meta || result;
       let totalRows =
@@ -210,7 +221,10 @@ export default Ember.Object.extend({
   },
 
   _resultSet(type, result, findArgs) {
-    const typeName = Ember.String.underscore(this.pluralize(type));
+    const adapter = this.adapterFor(type);
+    const typeName = Ember.String.underscore(
+      this.pluralize(adapter.apiNameFor(type))
+    );
     const content = result[typeName].map(obj =>
       this._hydrate(type, obj, result)
     );

--- a/test/javascripts/helpers/create-store.js.es6
+++ b/test/javascripts/helpers/create-store.js.es6
@@ -5,7 +5,7 @@ import TopicListAdapter from "discourse/adapters/topic-list";
 import TopicTrackingState from "discourse/models/topic-tracking-state";
 import { buildResolver } from "discourse-common/resolver";
 
-export default function() {
+export default function(customLookup = () => {}) {
   const resolver = buildResolver("discourse").create();
 
   return Store.create({
@@ -34,6 +34,7 @@ export default function() {
           this._settings = this._settings || Discourse.SiteSettings;
           return this._settings;
         }
+        return customLookup(type);
       },
 
       lookupFactory(type) {

--- a/test/javascripts/models/rest-model-test.js.es6
+++ b/test/javascripts/models/rest-model-test.js.es6
@@ -2,6 +2,7 @@ QUnit.module("rest-model");
 
 import createStore from "helpers/create-store";
 import RestModel from "discourse/models/rest";
+import RestAdapter from "discourse/adapters/rest";
 
 QUnit.test("munging", assert => {
   const store = createStore();
@@ -100,4 +101,38 @@ QUnit.test("destroyRecord", assert => {
       assert.ok(result);
     });
   });
+});
+
+QUnit.test("custom api name", async assert => {
+  const store = createStore(type => {
+    if (type === "adapter:my-widget") {
+      return RestAdapter.extend({
+        // An adapter like this is used when the server-side key/url
+        // do not match the name of the es6 class
+        apiNameFor() {
+          return "widget";
+        }
+      }).create();
+    }
+  });
+
+  // The pretenders only respond to requests for `widget`
+  // If these basic tests, the name override worked correctly
+
+  //Create
+  const widget = store.createRecord("my-widget");
+  await widget.save({ name: "Evil Widget" });
+  assert.equal(widget.id, 100, "it saved a new record successully");
+  assert.equal(widget.get("name"), "Evil Widget");
+
+  // Update
+  await widget.update({ name: "new name" });
+  assert.equal(widget.get("name"), "new name");
+
+  // Destroy
+  await widget.destroyRecord();
+
+  // Lookup
+  const foundWidget = await store.find("my-widget", 123);
+  assert.equal(foundWidget.name, "Trout Lure");
 });

--- a/test/javascripts/models/rest-model-test.js.es6
+++ b/test/javascripts/models/rest-model-test.js.es6
@@ -117,7 +117,7 @@ QUnit.test("custom api name", async assert => {
   });
 
   // The pretenders only respond to requests for `widget`
-  // If these basic tests, the name override worked correctly
+  // If these basic tests pass, the name override worked correctly
 
   //Create
   const widget = store.createRecord("my-widget");


### PR DESCRIPTION
There are a couple of places I would like to use this:

- Upgrading `api-key.js.es6` to use rest model. We can't use `api_key` as a key when POSTing, because Discourse tries to use it for authentication
- In discourse-theme-creator, we have a new model `user-theme`, which connects to core routes which serve content on the `theme` key. At the moment, this requires [a lot of overrides](https://github.com/discourse/discourse-theme-creator/blob/master/assets/javascripts/discourse/adapters/user-theme.js.es6)