### PR TITLE
FIX: Unread topics not clearing when whisper is last post

### DIFF
--- a/lib/topics_bulk_action.rb
+++ b/lib/topics_bulk_action.rb
@@ -68,9 +68,10 @@ class TopicsBulkAction
   end
 
   def dismiss_posts
+    highest_number_source_column = @user.staff? ? 'highest_staff_post_number' : 'highest_post_number'
     sql = <<~SQL
       UPDATE topic_users tu
-      SET highest_seen_post_number = t.highest_post_number , last_read_post_number = highest_post_number
+      SET highest_seen_post_number = t.#{highest_number_source_column} , last_read_post_number = t.#{highest_number_source_column}
       FROM topics t
       WHERE t.id = tu.topic_id AND tu.user_id = :user_id AND t.id IN (:topic_ids)
     SQL

--- a/spec/components/topics_bulk_action_spec.rb
+++ b/spec/components/topics_bulk_action_spec.rb
@@ -20,6 +20,32 @@ describe TopicsBulkAction do
       expect(tu.last_read_post_number).to eq(3)
       expect(tu.highest_seen_post_number).to eq(3)
     end
+
+    context "when the user is staff" do
+      fab!(:user) { Fabricate(:admin) }
+
+      context "when the highest_staff_post_number is > highest_post_number for a topic (e.g. whisper is last post)" do
+        it "dismisses posts" do
+          post1 = create_post(user: user)
+          p = create_post(topic_id: post1.topic_id)
+          create_post(topic_id: post1.topic_id)
+
+          whisper = PostCreator.new(
+            user,
+            topic_id: post1.topic.id,
+            post_type: Post.types[:whisper],
+            raw: 'this is a whispered reply'
+          ).create
+
+          TopicsBulkAction.new(user, [post1.topic_id], type: 'dismiss_posts').perform!
+
+          tu = TopicUser.find_by(user_id: user.id, topic_id: post1.topic_id)
+
+          expect(tu.last_read_post_number).to eq(4)
+          expect(tu.highest_seen_post_number).to eq(4)
+        end
+      end
+    end
   end
 
   describe "invalid operation" do


### PR DESCRIPTION
### Fix

Meta thread: https://meta.discourse.org/t/cant-dismiss-unread-if-last-post-is-an-assign-or-whisper/131823/7

* when sending a whisper, the `highest_staff_post_number` is set
  in the `next_post_number` method for a `Topic`, but the
  `highest_post_number` is left alone. this leaves a situation
  where `highest_staff_post_number` is > `highest_post_number`
* when `TopicsBulkAction#dismiss_posts` was run, it was only setting the topic_user
  `highest_seen_post_number` using the `highest_post_number` from the topic, so if
  the user was staff and the last post in a topic was a whisper
  their highest seen number was not set, and the topic stayed unread

Found through testing that the bug wasn't to do with Assign/Unassign as they do not affect the post numbers, only whispering does.

### Reproduction

1. Create 2 staff users locally
2. Create a topic as the first user
3. Login as the second user in incognito and watch the topic
4. Post a whisper in the topic as the first user
5. Visit the Unread tab as the second user
6. The topic should show as unread
7. Click on Dismiss and accept the modal. The topic should no longer appear unread (currently the bug is that the topic stays unread)

Step 4:

![image](https://user-images.githubusercontent.com/920448/67911123-17f24200-fbd1-11e9-894a-37dd74353085.png)

Step 5:

![image](https://user-images.githubusercontent.com/920448/67911180-630c5500-fbd1-11e9-99e9-d2a83e28dc5f.png)
