### PR TITLE
FIX: Hide muted subcategories for mobile

### DIFF
--- a/app/assets/javascripts/discourse/templates/mobile/components/categories-only.hbs
+++ b/app/assets/javascripts/discourse/templates/mobile/components/categories-only.hbs
@@ -28,7 +28,9 @@
               <td>
                 <div class='subcategories'>
                   {{#each c.subcategories as |subcategory|}}
-                    {{category-link subcategory}}
+                    {{#unless subcategory.isMuted}}
+                      {{category-link subcategory}}
+                    {{/unless}}
                   {{/each}}
                 </div>
               </td>


### PR DESCRIPTION
That bug was mentioned in [meta](https://meta.discourse.org/t/muting-categories-hides-them-muting-subcategories-should-too/131316)

Fix was done in that PR https://github.com/discourse/discourse/pull/8239
however I forgot about mobile template