### PR TITLE
FIX: Enter key on forms submits rather than refresh

### DIFF
--- a/app/assets/javascripts/discourse/templates/modal/forgot-password.hbs
+++ b/app/assets/javascripts/discourse/templates/modal/forgot-password.hbs
@@ -1,4 +1,4 @@
-<form>
+<form {{action "resetPassword" on="submit"}}>
   {{#d-modal-body class="forgot-password-modal"}}
     {{#unless offerHelp}}
       <label for='username-or-email'>{{i18n 'forgot_password.invite'}}</label>

--- a/app/assets/javascripts/discourse/templates/preferences-second-factor.hbs
+++ b/app/assets/javascripts/discourse/templates/preferences-second-factor.hbs
@@ -1,6 +1,6 @@
 <section class='user-preferences solo-preference second-factor'>
   {{#conditional-loading-spinner condition=loading}}
-  <form class="form-horizontal">
+  <form class="form-horizontal" {{action "confirmPassword" on="submit"}}>
 
     {{#if showEnforcedNotice}}
       <div class="control-group">


### PR DESCRIPTION
These two forms have a single input, and pressing <kbd>Enter</kbd> currently refreshes the page, rather than submitting the form as expected. 