### PR TITLE
FIX: Do not load plugin CSS/JS assets when disabled

### DIFF
--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -216,7 +216,7 @@ module Discourse
     plugins.select do |plugin|
       next if args[:include_official] == false && plugin.metadata.official?
       next if args[:include_unofficial] == false && !plugin.metadata.official?
-      next if args[:include_disabled] == false && !plugin.enabled?
+      next if !args[:include_disabled] && !plugin.enabled?
 
       true
     end

--- a/spec/components/discourse_spec.rb
+++ b/spec/components/discourse_spec.rb
@@ -65,6 +65,33 @@ describe Discourse do
     end
   end
 
+  context 'plugins' do
+    let(:plugin_class) do
+      Class.new(Plugin::Instance) do
+        attr_accessor :enabled
+        def enabled?
+          @enabled
+        end
+      end
+    end
+
+    let(:plugin1) { plugin_class.new.tap { |p| p.enabled = true } }
+    let(:plugin2) { plugin_class.new.tap { |p| p.enabled = false } }
+
+    before { Discourse.plugins.append(plugin1, plugin2) }
+    after { Discourse.plugins.clear }
+
+    it 'can find plugins correctly' do
+      expect(Discourse.plugins).to contain_exactly(plugin1, plugin2)
+
+      # Exclude disabled plugins by default
+      expect(Discourse.find_plugins({})).to contain_exactly(plugin1)
+
+      # Include disabled plugins when requested
+      expect(Discourse.find_plugins(include_disabled: true)).to contain_exactly(plugin1, plugin2)
+    end
+  end
+
   context 'authenticators' do
     it 'returns inbuilt authenticators' do
       expect(Discourse.authenticators).to match_array(Discourse::BUILTIN_AUTH.map(&:authenticator))


### PR DESCRIPTION
Follow-up to 839916aa4901ab62fb84bcaf7d91c4354091f506 and 5bd6b70d985e2736f56d2bec6cce56bee0227b1f