### PR TITLE
FIX: Cache `Discourse.system_user` separately for each multisite tenant

### DIFF
--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -536,7 +536,9 @@ module Discourse
   SYSTEM_USER_ID ||= -1
 
   def self.system_user
-    @system_user ||= User.find_by(id: SYSTEM_USER_ID)
+    @system_users ||= {}
+    current_db = RailsMultisite::ConnectionManagement.current_db
+    @system_users[current_db] ||= User.find_by(id: SYSTEM_USER_ID)
   end
 
   def self.store

--- a/spec/components/discourse_spec.rb
+++ b/spec/components/discourse_spec.rb
@@ -130,6 +130,12 @@ describe Discourse do
 
   end
 
+  context '#system_user' do
+    it 'returns the system user' do
+      expect(Discourse.system_user.id).to eq(-1)
+    end
+  end
+
   context "#store" do
 
     it "returns LocalStore by default" do


### PR DESCRIPTION
This was not causing any known issue, because the system user ID is always the same across all sites. However, we should cache this on a per-site basis to be safe.