### PR TITLE
FEATURE: Create New Topic button on embed with params

### DIFF
--- a/app/assets/stylesheets/embed.scss
+++ b/app/assets/stylesheets/embed.scss
@@ -195,8 +195,8 @@ div.lightbox-wrapper {
     height: 16px;
     margin-right: 2px;
     background-image: svg-uri(
-          '<svg xmlns="http://www.w3.org/2000/svg" width="32px" height="32px" viewBox="0 0 448 512" fill="white"><path d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"></path></svg>'
-        );
+      '<svg xmlns="http://www.w3.org/2000/svg" width="32px" height="32px" viewBox="0 0 448 512" fill="white"><path d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"></path></svg>'
+    );
     background-repeat: no-repeat;
     background-size: 100%;
     background-position: top center;

--- a/app/assets/stylesheets/embed.scss
+++ b/app/assets/stylesheets/embed.scss
@@ -176,6 +176,20 @@ div.lightbox-wrapper {
   margin-bottom: 20px;
 }
 
+.new-topic-btn {
+  display: block;
+  width: 100%;
+  line-height: 34px;
+  border: none;
+  border-bottom: 1px solid $primary-low;
+  color: $primary;
+  background: transparent;
+}
+
+.new-topic-btn.complete {
+  line-height: 60px;
+}
+
 .topics-list {
   width: 100%;
 

--- a/app/assets/stylesheets/embed.scss
+++ b/app/assets/stylesheets/embed.scss
@@ -178,8 +178,7 @@ div.lightbox-wrapper {
 }
 
 .new-topic-btn {
-  margin-left: 0.5rem;
-  margin-top: 0.5rem;
+  margin: 0.5rem;
 
   &:hover {
     background: #006da3;

--- a/app/assets/stylesheets/embed.scss
+++ b/app/assets/stylesheets/embed.scss
@@ -3,6 +3,7 @@
 @import "./common/foundation/variables";
 @import "./common/foundation/colors";
 @import "./common/foundation/mixins";
+@import "./common/components/buttons";
 
 article.post {
   border-bottom: 1px solid #ddd;
@@ -177,17 +178,30 @@ div.lightbox-wrapper {
 }
 
 .new-topic-btn {
-  display: block;
-  width: 100%;
-  line-height: 34px;
-  border: none;
-  border-bottom: 1px solid $primary-low;
-  color: $primary;
-  background: transparent;
-}
+  margin-left: 0.5rem;
+  margin-top: 0.5rem;
 
-.new-topic-btn.complete {
-  line-height: 60px;
+  &:hover {
+    background: #006da3;
+  }
+
+  span {
+    display: inline-block;
+    vertical-align: middle;
+    padding-bottom: 2px;
+  }
+
+  .new-topic-btn__icon {
+    width: 16px;
+    height: 16px;
+    margin-right: 2px;
+    background-image: svg-uri(
+          '<svg xmlns="http://www.w3.org/2000/svg" width="32px" height="32px" viewBox="0 0 448 512" fill="white"><path d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"></path></svg>'
+        );
+    background-repeat: no-repeat;
+    background-size: 100%;
+    background-position: top center;
+  }
 }
 
 .topics-list {

--- a/app/controllers/embed_controller.rb
+++ b/app/controllers/embed_controller.rb
@@ -42,6 +42,15 @@ class EmbedController < ApplicationController
 
     list_options = build_topic_list_options
     list_options[:per_page] = params[:per_page].to_i if params.has_key?(:per_page)
+
+    if params[:allow_create]
+      @allow_create = true
+      create_url_params = {}
+      create_url_params[:category_id] = params[:category] if params[:category].present?
+      create_url_params[:tags] = params[:tags] if params[:tags].present?
+      @create_url = "#{Discourse.base_url}/new-topic?#{create_url_params.to_query}"
+    end
+
     topic_query = TopicQuery.new(current_user, list_options)
     @list = topic_query.list_latest
   end

--- a/app/views/embed/topics.html.erb
+++ b/app/views/embed/topics.html.erb
@@ -1,4 +1,12 @@
 <%- if @list && @list.topics.present? %>
+  <%- if @allow_create %>
+    <%= link_to @create_url, target: "_blank" do |link| %>
+      <button class="new-topic-btn">
+        <span class="new-topic-btn__icon"></span>
+        <span class="new-topic-btn__text">Create New Topic!</span>
+    </button>
+    <%- end %>
+  <%- end %>
   <div class='topics-list' data-embed-state='loaded' <%- if @embed_id %>data-embed-id="<%= @embed_id %>"<%- end %>>
     <%- @list.topics.each do |t| %>
       <div class='topic-list-item'>

--- a/app/views/embed/topics.html.erb
+++ b/app/views/embed/topics.html.erb
@@ -1,10 +1,10 @@
 <%- if @list && @list.topics.present? %>
   <%- if @allow_create %>
     <%= link_to @create_url, target: "_blank" do |link| %>
-      <button class="new-topic-btn">
-        <span class="new-topic-btn__icon"></span>
-        <span class="new-topic-btn__text">Create New Topic!</span>
-    </button>
+      <button class=<%="new-topic-btn" + (@template == "complete" ? " complete" : "") %>>
+        <span class=<%="new-topic-btn__text" if @template == "complete" %>></span>
+        <span class=<%="new-topic-btn__icon" if @template == "complete" %>>Create New Topic!</span>
+      </button>
     <%- end %>
   <%- end %>
   <div class='topics-list' data-embed-state='loaded' <%- if @embed_id %>data-embed-id="<%= @embed_id %>"<%- end %>>

--- a/app/views/embed/topics.html.erb
+++ b/app/views/embed/topics.html.erb
@@ -2,8 +2,8 @@
   <%- if @allow_create %>
     <%= link_to @create_url, target: "_blank" do |link| %>
       <button class=<%="new-topic-btn" + (@template == "complete" ? " complete" : "") %>>
-        <span class=<%="new-topic-btn__text" if @template == "complete" %>></span>
-        <span class=<%="new-topic-btn__icon" if @template == "complete" %>>Create New Topic!</span>
+        <span class=<%="new-topic-btn__icon" if @template == "complete" %>></span>
+        <span class=<%="new-topic-btn__text" if @template == "complete" %>>Create New Topic!</span>
       </button>
     <%- end %>
   <%- end %>

--- a/app/views/embed/topics.html.erb
+++ b/app/views/embed/topics.html.erb
@@ -1,9 +1,9 @@
 <%- if @list && @list.topics.present? %>
   <%- if @allow_create %>
     <%= link_to @create_url, target: "_blank" do |link| %>
-      <button class=<%="new-topic-btn" + (@template == "complete" ? " complete" : "") %>>
-        <span class=<%="new-topic-btn__icon" if @template == "complete" %>></span>
-        <span class=<%="new-topic-btn__text" if @template == "complete" %>>Create New Topic!</span>
+      <button class="new-topic-btn btn btn-primary">
+        <span class="new-topic-btn__icon"></span>
+        <span class="new-topic-btn__text"><%= I18n.t('embed.new_topic') %></span>
       </button>
     <%- end %>
   <%- end %>

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -295,6 +295,7 @@ en:
       other: "%{count} likes"
     last_reply: "Last reply"
     created: "Created"
+    new_topic: "Create new topic"
 
   no_mentions_allowed: "Sorry, you can't mention other users."
   too_many_mentions:


### PR DESCRIPTION
This allows embed urls to take the `allow_create` param, and add a `Create New Topic` button, that will open the composer in a new tab with category, and tags passed into the composer.

You will notice that this transforms the `category` param into `category_id` for the link to the composer. This is just how the params are accepted by each endpoint.

![Screenshot from 2019-11-01 13-27-41](https://user-images.githubusercontent.com/16214023/68047056-755ac180-fcab-11e9-927b-836bda68f582.png)
