### PR TITLE
FIX: Allow theme translations to be accessed in initializers

### DIFF
--- a/app/assets/javascripts/discourse/lib/plugin-api.js.es6
+++ b/app/assets/javascripts/discourse/lib/plugin-api.js.es6
@@ -46,7 +46,7 @@ import { queryRegistry } from "discourse/widgets/widget";
 import Composer from "discourse/models/composer";
 
 // If you add any methods to the API ensure you bump up this number
-const PLUGIN_API_VERSION = "0.8.35";
+const PLUGIN_API_VERSION = "0.8.36";
 
 class PluginApi {
   constructor(version, container) {

--- a/lib/theme_javascript_compiler.rb
+++ b/lib/theme_javascript_compiler.rb
@@ -209,8 +209,8 @@ console.log(settingParts)
     @content << script + "\n"
   end
 
-  def append_module(script, name)
-    script.prepend theme_variables
+  def append_module(script, name, include_variables: true)
+    script = "#{theme_variables}#{script}" if include_variables
     template = Tilt::ES6ModuleTranspilerTemplate.new {}
     @content << template.module_transpile(script, "", name)
   rescue MiniRacer::RuntimeError => ex


### PR DESCRIPTION
Previously theme translations were loaded along with other plugin API scripts. These run after pre-initializers and initializers when the app boots. This commit moves theme translation loading into pre-initializers, so their behaviour matches core translations more closely.