### PR TITLE
FEATURE: fallback to image alt before filename if there's no title in lightboxes

### DIFF
--- a/lib/cooked_post_processor.rb
+++ b/lib/cooked_post_processor.rb
@@ -426,7 +426,7 @@ class CookedPostProcessor
     informations = +"#{original_width}×#{original_height}"
     informations << " #{upload.human_filesize}" if upload
 
-    a["title"] = CGI.escapeHTML(img["title"] || filename)
+    a["title"] = CGI.escapeHTML(img["title"] || img["alt"] || filename)
 
     meta.add_child create_icon_node("far-image")
     meta.add_child create_span_node("filename", a["title"])

--- a/spec/components/cooked_post_processor_spec.rb
+++ b/spec/components/cooked_post_processor_spec.rb
@@ -597,7 +597,38 @@ describe CookedPostProcessor do
 
       end
 
-      context "with title" do
+      context "with title and alt" do
+        fab!(:post) do
+          Fabricate(:post, raw: <<~HTML)
+          <img src="#{upload.url}" title="WAT" alt="RED">
+          HTML
+        end
+
+        let(:cpp) { CookedPostProcessor.new(post, disable_loading_image: true) }
+
+        before do
+          SiteSetting.max_image_height = 2000
+          SiteSetting.create_thumbnails = true
+          FastImage.expects(:size).returns([1750, 2000])
+          OptimizedImage.expects(:resize).returns(true)
+          FileStore::BaseStore.any_instance.expects(:get_depth_for).returns(0)
+        end
+
+        it "generates overlay information using image title and ignores alt" do
+          cpp.post_process
+
+          expect(cpp.html).to match_html <<~HTML
+            <p><div class="lightbox-wrapper"><a class="lightbox" href="//test.localhost#{upload.url}" data-download-href="//test.localhost/uploads/default/#{upload.sha1}" title="WAT"><img src="//test.localhost/uploads/default/optimized/1X/#{upload.sha1}_#{OptimizedImage::VERSION}_690x788.png" title="WAT" alt="RED" width="690" height="788"><div class="meta">
+            <svg class="fa d-icon d-icon-far-image svg-icon" aria-hidden="true"><use xlink:href="#far-image"></use></svg><span class="filename">WAT</span><span class="informations">1750×2000 1.21 KB</span><svg class="fa d-icon d-icon-discourse-expand svg-icon" aria-hidden="true"><use xlink:href="#discourse-expand"></use></svg>
+            </div></a></div></p>
+          HTML
+
+          expect(cpp).to be_dirty
+        end
+
+      end
+
+      context "with title only" do
         fab!(:post) do
           Fabricate(:post, raw: <<~HTML)
           <img src="#{upload.url}" title="WAT">
@@ -614,12 +645,43 @@ describe CookedPostProcessor do
           FileStore::BaseStore.any_instance.expects(:get_depth_for).returns(0)
         end
 
-        it "generates overlay information" do
+        it "generates overlay information using image title" do
           cpp.post_process
 
           expect(cpp.html).to match_html <<~HTML
             <p><div class="lightbox-wrapper"><a class="lightbox" href="//test.localhost#{upload.url}" data-download-href="//test.localhost/uploads/default/#{upload.sha1}" title="WAT"><img src="//test.localhost/uploads/default/optimized/1X/#{upload.sha1}_#{OptimizedImage::VERSION}_690x788.png" title="WAT" width="690" height="788"><div class="meta">
             <svg class="fa d-icon d-icon-far-image svg-icon" aria-hidden="true"><use xlink:href="#far-image"></use></svg><span class="filename">WAT</span><span class="informations">1750×2000 1.21 KB</span><svg class="fa d-icon d-icon-discourse-expand svg-icon" aria-hidden="true"><use xlink:href="#discourse-expand"></use></svg>
+            </div></a></div></p>
+          HTML
+
+          expect(cpp).to be_dirty
+        end
+
+      end
+
+      context "with alt only" do
+        fab!(:post) do
+          Fabricate(:post, raw: <<~HTML)
+          <img src="#{upload.url}" alt="RED">
+          HTML
+        end
+
+        let(:cpp) { CookedPostProcessor.new(post, disable_loading_image: true) }
+
+        before do
+          SiteSetting.max_image_height = 2000
+          SiteSetting.create_thumbnails = true
+          FastImage.expects(:size).returns([1750, 2000])
+          OptimizedImage.expects(:resize).returns(true)
+          FileStore::BaseStore.any_instance.expects(:get_depth_for).returns(0)
+        end
+
+        it "generates overlay information using image alt" do
+          cpp.post_process
+
+          expect(cpp.html).to match_html <<~HTML
+            <p><div class="lightbox-wrapper"><a class="lightbox" href="//test.localhost#{upload.url}" data-download-href="//test.localhost/uploads/default/#{upload.sha1}" title="RED"><img src="//test.localhost/uploads/default/optimized/1X/#{upload.sha1}_#{OptimizedImage::VERSION}_690x788.png" alt="RED" width="690" height="788"><div class="meta">
+            <svg class="fa d-icon d-icon-far-image svg-icon" aria-hidden="true"><use xlink:href="#far-image"></use></svg><span class="filename">RED</span><span class="informations">1750×2000 1.21 KB</span><svg class="fa d-icon d-icon-discourse-expand svg-icon" aria-hidden="true"><use xlink:href="#discourse-expand"></use></svg>
             </div></a></div></p>
           HTML
 


### PR DESCRIPTION
some history / context: 

https://meta.discourse.org/t/display-an-images-alt-or-title-attribute-in-ligthbox-overlay/130579
https://meta.discourse.org/t/image-title-and-alt-tags-not-displaying/38918/5

This PR is also a prerequisite to some work being done here

https://meta.discourse.org/t/make-it-more-obvious-an-image-is-resizable-when-uploading-an-image/132030

<hr>

Right now, when you add an image and it's big enough to be lightboxed you get an overlay that looks like so

![image](https://user-images.githubusercontent.com/33972521/68066890-2334a180-fd7a-11e9-98d5-7d7ed09b50dc.png)

This overlay contains some useful information but notice that it also contains the filename. Why does this happen? it happens because we check if the image has a title and use that, but otherwise we fallback to the filename. 

https://github.com/hnb-ku/discourse/blob/master/lib/cooked_post_processor.rb#L427-L429

The issue here is that most image will not have a title because markdown does not add one unless you use a very particular syntax. 

the default syntax we use when a user uploads / copy-pastes an image looks like this

```
![pluginPage01|368x413](upload://zX6AuAdsNWYzcfIT08zVQPgaJbD.png) 
```

and will result in this markup after it's processed by markdown

```
<img src="/uploads/default/original/1X/fbfa85f19aae34a5f2d7fd9586d843daac895655.png" alt="pluginPage01" width="368" height="413">
```

So, there's no title and we therefore fallback to the filename in the overlay. 

Markdown supports adding a title but the syntax is different and looks like so 

```
![pluginPage01|368x413](upload://zX6AuAdsNWYzcfIT08zVQPgaJbD.png "image title") 
```

that would then generate 

```
<img src="/uploads/default/original/1X/fbfa85f19aae34a5f2d7fd9586d843daac895655.png" alt="pluginPage01" title="image title" width="368" height="413">
```

which would then be used in the overlay because the image has a title. 

What this PR does is add the image alt as a fallback before falling back to the file name. 

That means that we go

title > alt > filename

This allows us to leverage on the alt that markdown generates and allows users to control the text or image description used in the overlay. 

For example, let's say you have an image with the name `photo01.jpg` and you upload that image. you get this in the editor

```
![photo01|368x413](upload://zX6AuAdsNWYzcfIT08zVQPgaJbD.png) 
```

Prior to this PR, even if you edit `photo01` to `cute cats playing with water` the overlay for the lightbox in the cooked post will still display as `photo01` 

This PR makes it possible to change the overlay text in the editor by changing `photo01` to the desired text to be displayed in the lightbox overlay.

If an image has both a title and an alt, then the title is used and the alt is ignored, which ensures backwards compatibility for cases when a markdown title was added. 

This will only affect new posts and old posts would need to be rebaked. 

 
