### PR TITLE
FEATURE: Load translation overrides without JS `eval`

### DIFF
--- a/app/assets/javascripts/discourse/initializers/localization.js.es6
+++ b/app/assets/javascripts/discourse/initializers/localization.js.es6
@@ -1,5 +1,3 @@
-import PreloadStore from "preload-store";
-
 export default {
   name: "localization",
   after: "inject-objects",
@@ -21,20 +19,9 @@ export default {
     }
 
     // Merge any overrides into our object
-    const overrides = PreloadStore.get("translationOverrides") || {};
+    const overrides = I18n._overrides || {};
     Object.keys(overrides).forEach(k => {
       const v = overrides[k];
-
-      // Special case: Message format keys are functions
-      if (/_MF$/.test(k)) {
-        k = k.replace(/^[a-z_]*js\./, "");
-        I18n._compiledMFs[k] = new Function(
-          "transKey",
-          `return (${v})(transKey);`
-        );
-        return;
-      }
-
       k = k.replace("admin_js", "js");
 
       const segs = k.split(".");
@@ -50,6 +37,14 @@ export default {
       if (typeof node === "object") {
         node[segs[segs.length - 1]] = v;
       }
+    });
+
+    const mfOverrides = I18n._mfOverrides || {};
+    Object.keys(mfOverrides).forEach(k => {
+      const v = mfOverrides[k];
+
+      k = k.replace(/^[a-z_]*js\./, "");
+      I18n._compiledMFs[k] = v;
     });
 
     bootbox.addLocale(I18n.currentLocale(), {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -520,7 +520,6 @@ class ApplicationController < ActionController::Base
     store_preloaded("customHTML", custom_html_json)
     store_preloaded("banner", banner_json)
     store_preloaded("customEmoji", custom_emoji)
-    store_preloaded("translationOverrides", I18n.client_overrides_json(I18n.locale))
   end
 
   def preload_current_user_data

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -93,9 +93,14 @@ module ApplicationHelper
 
   def preload_script(script)
     path = script_asset_path(script)
+    preload_script_url(path)
+  end
 
-"<link rel='preload' href='#{path}' as='script'/>
-<script src='#{path}'></script>".html_safe
+  def preload_script_url(url)
+    <<~HTML.html_safe
+      <link rel="preload" href="#{url}" as="script">
+      <script src="#{url}"></script>
+    HTML
   end
 
   def discourse_csrf_tags

--- a/app/models/translation_override.rb
+++ b/app/models/translation_override.rb
@@ -39,6 +39,7 @@ class TranslationOverride < ActiveRecord::Base
 
   def self.i18n_changed(keys)
     I18n.reload!
+    ExtraLocalesController.clear_cache!
     MessageBus.publish('/i18n-flush', refresh: true)
 
     keys.flatten.each do |key|

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,6 +20,9 @@
     <%= build_plugin_html 'server:before-script-load' %>
 
     <%= preload_script "locales/#{I18n.locale}" %>
+    <%- if ExtraLocalesController.client_overrides_exist? %>
+      <%= preload_script_url ExtraLocalesController.url('overrides') %>
+    <%- end %>
     <%= preload_script "ember_jquery" %>
     <%= preload_script "preload-store" %>
     <%= preload_script "vendor" %>
@@ -29,7 +32,7 @@
       <%= preload_script file %>
     <%- end %>
     <%- if staff? %>
-      <script src="<%= ExtraLocalesController.url('admin') %>"></script>
+      <%= preload_script_url ExtraLocalesController.url('admin') %>
       <%= preload_script "admin" %>
     <%- end %>
 

--- a/app/views/wizard/index.html.erb
+++ b/app/views/wizard/index.html.erb
@@ -3,9 +3,12 @@
     <%= discourse_stylesheet_link_tag :wizard, theme_ids: nil %>
     <%= preload_script 'ember_jquery' %>
     <%= preload_script "locales/#{I18n.locale}" %>
+    <%- if ExtraLocalesController.client_overrides_exist? %>
+      <%= preload_script_url ExtraLocalesController.url('overrides') %>
+    <%- end %>
     <%= preload_script 'wizard-vendor' %>
     <%= preload_script 'wizard-application' %>
-    <script src="<%= ExtraLocalesController.url("wizard") %>"></script>
+    <%= preload_script_url ExtraLocalesController.url('wizard') %>
     <%= csrf_meta_tags %>
 
     <%= render partial: "layouts/head" %>

--- a/config/initializers/100-i18n.rb
+++ b/config/initializers/100-i18n.rb
@@ -12,5 +12,8 @@ I18n.reload!
 I18n.init_accelerator!
 
 unless Rails.env.test?
-  MessageBus.subscribe("/i18n-flush") { I18n.reload! }
+  MessageBus.subscribe("/i18n-flush") do
+    I18n.reload!
+    ExtraLocalesController.clear_cache!
+  end
 end

--- a/lib/freedom_patches/translate_accelerator.rb
+++ b/lib/freedom_patches/translate_accelerator.rb
@@ -137,8 +137,9 @@ module I18n
 
     def overrides_by_locale(locale)
       return unless @overrides_enabled
-
       return {} if GlobalSetting.skip_db?
+
+      execute_reload if @requires_reload
 
       site = RailsMultisite::ConnectionManagement.current_db
 
@@ -168,11 +169,6 @@ module I18n
       else
         raise
       end
-    end
-
-    def client_overrides_json(locale)
-      client_json = (overrides_by_locale(locale) || {}).select { |k, _| k[/^(admin_js|js)\./] }
-      MultiJson.dump(client_json)
     end
 
     def translate(*args)

--- a/spec/components/freedom_patches/translate_accelerator_spec.rb
+++ b/spec/components/freedom_patches/translate_accelerator_spec.rb
@@ -204,26 +204,5 @@ describe "translate accelerator" do
       override_translation('en', 'fish', 'fake fish')
       expect(Fish.model_name.human).to eq('Fish')
     end
-
-    describe "client json" do
-      it "is empty by default" do
-        expect(I18n.client_overrides_json('en')).to eq('{}')
-      end
-
-      it "doesn't return server overrides" do
-        override_translation('en', 'foo', 'bar')
-        expect(I18n.client_overrides_json('en')).to eq('{}')
-      end
-
-      it "returns client overrides" do
-        override_translation('en', 'js.foo', 'bar')
-        override_translation('en', 'admin_js.beep', 'boop')
-        json = ::JSON.parse(I18n.client_overrides_json('en'))
-
-        expect(json).to be_present
-        expect(json['js.foo']).to eq('bar')
-        expect(json['admin_js.beep']).to eq('boop')
-      end
-    end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -6,13 +6,20 @@ require 'rails_helper'
 describe ApplicationHelper do
 
   describe "preload_script" do
+    def preload_link(url)
+      <<~HTML
+          <link rel="preload" href="#{url}" as="script">
+          <script src="#{url}"></script>
+      HTML
+    end
+
     it "provides brotli links to brotli cdn" do
       set_cdn_url "https://awesome.com"
 
       helper.request.env["HTTP_ACCEPT_ENCODING"] = 'br'
       link = helper.preload_script('application')
 
-      expect(link).to eq("<link rel='preload' href='https://awesome.com/brotli_asset/application.js' as='script'/>\n<script src='https://awesome.com/brotli_asset/application.js'></script>")
+      expect(link).to eq(preload_link("https://awesome.com/brotli_asset/application.js"))
     end
 
     context "with s3 CDN" do
@@ -45,26 +52,26 @@ describe ApplicationHelper do
         helper.request.env["HTTP_ACCEPT_ENCODING"] = 'br'
         link = helper.preload_script('application')
 
-        expect(link).to eq("<link rel='preload' href='https://s3cdn.com/assets/application.br.js' as='script'/>\n<script src='https://s3cdn.com/assets/application.br.js'></script>")
+        expect(link).to eq(preload_link("https://s3cdn.com/assets/application.br.js"))
       end
 
       it "gives s3 cdn if asset host is not set" do
         link = helper.preload_script('application')
 
-        expect(link).to eq("<link rel='preload' href='https://s3cdn.com/assets/application.js' as='script'/>\n<script src='https://s3cdn.com/assets/application.js'></script>")
+        expect(link).to eq(preload_link("https://s3cdn.com/assets/application.js"))
       end
 
       it "can fall back to gzip compression" do
         helper.request.env["HTTP_ACCEPT_ENCODING"] = 'gzip'
         link = helper.preload_script('application')
-        expect(link).to eq("<link rel='preload' href='https://s3cdn.com/assets/application.gz.js' as='script'/>\n<script src='https://s3cdn.com/assets/application.gz.js'></script>")
+        expect(link).to eq(preload_link("https://s3cdn.com/assets/application.gz.js"))
       end
 
       it "gives s3 cdn even if asset host is set" do
         set_cdn_url "https://awesome.com"
         link = helper.preload_script('application')
 
-        expect(link).to eq("<link rel='preload' href='https://s3cdn.com/assets/application.js' as='script'/>\n<script src='https://s3cdn.com/assets/application.js'></script>")
+        expect(link).to eq(preload_link("https://s3cdn.com/assets/application.js"))
       end
     end
   end

--- a/test/javascripts/initializers/localization-test.js.es6
+++ b/test/javascripts/initializers/localization-test.js.es6
@@ -1,9 +1,9 @@
-import PreloadStore from "preload-store";
 import LocalizationInitializer from "discourse/initializers/localization";
 
 QUnit.module("initializer:localization", {
   _locale: I18n.locale,
   _translations: I18n.translations,
+  _overrides: I18n._overrides,
 
   beforeEach() {
     I18n.locale = "fr";
@@ -31,14 +31,15 @@ QUnit.module("initializer:localization", {
   afterEach() {
     I18n.locale = this._locale;
     I18n.translations = this._translations;
+    I18n._overrides = this._overrides;
   }
 });
 
 QUnit.test("translation overrides", function(assert) {
-  PreloadStore.store("translationOverrides", {
+  I18n._overrides = {
     "js.composer.reply": "WAT",
     "js.topic.reply.help": "foobar"
-  });
+  };
   LocalizationInitializer.initialize(this.registry);
 
   assert.equal(
@@ -56,10 +57,10 @@ QUnit.test("translation overrides", function(assert) {
 QUnit.test(
   "skip translation override if parent node is not an object",
   function(assert) {
-    PreloadStore.store("translationOverrides", {
+    I18n._overrides = {
       "js.composer.reply": "WAT",
       "js.composer.reply.help": "foobar"
-    });
+    };
     LocalizationInitializer.initialize(this.registry);
 
     assert.equal(I18n.t("composer.reply.help"), "[fr.composer.reply.help]");


### PR DESCRIPTION
Removes translation overrides from the `PreloadStore` and loads them via `ExtraLocalesController` instead.

* There's no need for using `eval` for MessageFormat strings on the client anymore, because they are already compiled on the server.
* It's multisite aware, so `ExtraLocalesController` caches the hashes for the `overrides` bundle by site.
* The `<script>` tag for the `overrides` bundle is only included when there are client-side overrides.

Other notable changes:
* Bundles are cached for 1 year instead of just 24 hours. When the content of a bundle changes, its hash (and the `v` parameter) change as well, so we should be good.
* I removed the distinction between development and production mode. Bundles are always served with the `v` parameter which makes debugging easier.