### PR TITLE
FEATURE: notify tag watchers when tag was added to post

### DIFF
--- a/app/jobs/regular/notify_tag_change.rb
+++ b/app/jobs/regular/notify_tag_change.rb
@@ -7,6 +7,7 @@ module Jobs
 
       if post&.topic&.visible?
         post_alerter = PostAlerter.new
+        post_alerter.notify_post_users(post, User.where(id: args[:notified_user_ids]))
         post_alerter.notify_first_post_watchers(post, post_alerter.tag_watchers(post.topic))
       end
     end

--- a/lib/post_revisor.rb
+++ b/lib/post_revisor.rb
@@ -94,7 +94,8 @@ class PostRevisor
         tc.record_change('tags', prev_tags, tags)
         DB.after_commit do
           post = tc.topic.ordered_posts.first
-          Jobs.enqueue(:notify_tag_change, post_id: post.id)
+          notified_user_ids = [post.user_id, post.last_editor_id].uniq
+          Jobs.enqueue(:notify_tag_change, post_id: post.id, notified_user_ids: notified_user_ids)
         end
       end
     end

--- a/spec/jobs/notify_tag_change_spec.rb
+++ b/spec/jobs/notify_tag_change_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe ::Jobs::NotifyTagChange do
+
+  fab!(:user) { Fabricate(:user) }
+  fab!(:regular_user) { Fabricate(:trust_level_4) }
+  fab!(:post) { Fabricate(:post, user: regular_user) }
+  fab!(:tag) { Fabricate(:tag, name: 'test') }
+
+  it "creates notification for watched tag" do
+    TagUser.create!(
+      user_id: user.id,
+      tag_id: tag.id,
+      notification_level: NotificationLevels.topic_levels[:watching]
+    )
+    TopicTag.create!(
+      topic_id: post.topic.id,
+      tag_id: tag.id
+    )
+
+    expect { described_class.new.execute(post_id: post.id, notified_user_ids: [regular_user.id]) }.to change { Notification.count }
+    notification = Notification.last
+    expect(notification.user_id).to eq(user.id)
+    expect(notification.topic_id).to eq(post.topic_id)
+  end
+end

--- a/spec/services/post_alerter_spec.rb
+++ b/spec/services/post_alerter_spec.rb
@@ -1003,7 +1003,7 @@ describe PostAlerter do
       it "triggers a notification" do
         expect(user.notifications.where(notification_type: Notification.types[:watching_first_post]).count).to eq(0)
 
-        expect { PostRevisor.new(post).revise!(Fabricate(:user), tags: [other_tag.name, watched_tag.name]) }.to change { Notification.count }.by(1)
+        expect { PostRevisor.new(post).revise!(Fabricate(:user), tags: [other_tag.name, watched_tag.name]) }.to change { Notification.where(user_id: user.id).count }.by(1)
         expect(user.notifications.where(notification_type: Notification.types[:watching_first_post]).count).to eq(1)
 
         expect { PostRevisor.new(post).revise!(Fabricate(:user), tags: [watched_tag.name, other_tag.name]) }.to change { Notification.count }.by(0)


### PR DESCRIPTION
Issue was mentioned in this [meta topic](https://meta.discourse.org/t/send-a-notification-to-watching-users-when-adding-tag/125314)

It is working well when category is changed because NotifyCategoryChange job already got that code:
```
if post&.topic&.visible?
  post_alerter = PostAlerter.new
  post_alerter.notify_post_users(post, User.where(id: args[:notified_user_ids]))
  post_alerter.notify_first_post_watchers(post, post_alerter.category_watchers(post.topic))
end
```

For NotifyTagChange job notify post users were missing so it worked only when your notification was set to `watching first post`