### PR TITLE
FIX: unicode group names encoded for url

### DIFF
--- a/app/controllers/list_controller.rb
+++ b/app/controllers/list_controller.rb
@@ -385,7 +385,9 @@ class ListController < ApplicationController
       end
 
     opts = opts.dup
-    opts[:group_name] = URI.encode(opts[:group_name]) if opts[:group_name]
+    if SiteSetting.unicode_usernames && opts[:group_name]
+      opts[:group_name] = URI.encode(opts[:group_name])
+    end
     opts.delete(:category) if page_params.include?(:category_slug_path_with_id)
 
     public_send(method, opts.merge(page_params)).sub('.json?', '?')

--- a/app/controllers/list_controller.rb
+++ b/app/controllers/list_controller.rb
@@ -385,6 +385,7 @@ class ListController < ApplicationController
       end
 
     opts = opts.dup
+    opts[:group_name] = URI.encode(opts[:group_name]) if opts[:group_name]
     opts.delete(:category) if page_params.include?(:category_slug_path_with_id)
 
     public_send(method, opts.merge(page_params)).sub('.json?', '?')


### PR DESCRIPTION
Fixes this issue - [unicode group name break group messages](https://meta.discourse.org/t/unicode-group-name-break-the-group-message/132493)

@eviltrout What do you think of the placement of this fix? The method `construct_url_with` is used in many routes, so I figure it would be a good spot.