### PR TITLE
DEV: Allow execute_command to receive a block

### DIFF
--- a/spec/components/discourse_spec.rb
+++ b/spec/components/discourse_spec.rb
@@ -391,4 +391,25 @@ describe Discourse do
     end
   end
 
+  describe "Utils.execute_command" do
+    it "works for individual commands" do
+      expect(Discourse::Utils.execute_command("pwd").strip).to eq(Rails.root.to_s)
+      expect(Discourse::Utils.execute_command("pwd", chdir: "plugins").strip).to eq("#{Rails.root.to_s}/plugins")
+    end
+
+    it "works with a block" do
+      Discourse::Utils.execute_command do |runner|
+        expect(runner.exec("pwd").strip).to eq(Rails.root.to_s)
+      end
+
+      result = Discourse::Utils.execute_command(chdir: "plugins") do |runner|
+        expect(runner.exec("pwd").strip).to eq("#{Rails.root.to_s}/plugins")
+        runner.exec("pwd")
+      end
+
+      # Should return output of block
+      expect(result.strip).to eq("#{Rails.root.to_s}/plugins")
+    end
+  end
+
 end


### PR DESCRIPTION
This makes it easy to run multiple commands with the same keyword arguments. The main use is for using `chdir` across multiple commands. The `Dir.chdir` method is not concurrency safe, as it switches the working directory of the entire process.