### PR TITLE
DEV: Display a warning when themes hard-code optimized image links

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -92,6 +92,7 @@ en:
       component_no_default: "Theme components can't be default theme"
       component_no_color_scheme: "Theme components can't have color palettes"
       no_multilevels_components: "Themes with child themes can't be child themes themselves"
+      optimized_link: Optimized image links are ephemeral and should not be included in theme source code.
     settings_errors:
       invalid_yaml: "Provided YAML is invalid."
       data_type_not_a_number: "Setting `%{name}` type is unsupported. Supported types are `integer`, `bool`, `list` and `enum`"

--- a/spec/models/theme_field_spec.rb
+++ b/spec/models/theme_field_spec.rb
@@ -34,6 +34,30 @@ describe ThemeField do
     expect(theme_field.value_baked).to_not include('<script')
   end
 
+  it 'adds an error when optimized image links are included' do
+    theme_field = ThemeField.create!(theme_id: 1, target_id: 0, name: "body_tag", value: <<~HTML)
+      <img src="http://mysite.invalid/uploads/default/optimized/1X/6d749a141f513f88f167e750e528515002043da1_2_1282x1000.png"/>
+    HTML
+    theme_field.ensure_baked!
+    expect(theme_field.error).to include(I18n.t("themes.errors.optimized_link"))
+
+    theme_field = ThemeField.create!(theme_id: 1, target_id: 0, name: "scss", value: <<~SCSS)
+      body {
+        background: url(http://mysite.invalid/uploads/default/optimized/1X/6d749a141f513f88f167e750e528515002043da1_2_1282x1000.png);
+      }
+    SCSS
+    theme_field.ensure_baked!
+    expect(theme_field.error).to include(I18n.t("themes.errors.optimized_link"))
+
+    theme_field = ThemeField.create!(theme_id: 1, target_id: 0, name: "scss", value: <<~SCSS)
+      body {
+        background: url(http://notdiscourse.invalid/optimized/my_image.png);
+      }
+    SCSS
+    theme_field.ensure_baked!
+    expect(theme_field.error).to eq(nil)
+  end
+
   it 'only extracts inline javascript to an external file' do
     html = <<~HTML
     <script type="text/discourse-plugin" version="0.8">

--- a/spec/models/theme_field_spec.rb
+++ b/spec/models/theme_field_spec.rb
@@ -49,7 +49,7 @@ describe ThemeField do
     theme_field.ensure_baked!
     expect(theme_field.error).to include(I18n.t("themes.errors.optimized_link"))
 
-    theme_field = ThemeField.create!(theme_id: 1, target_id: 0, name: "scss", value: <<~SCSS)
+    theme_field.update(value: <<~SCSS)
       body {
         background: url(http://notdiscourse.invalid/optimized/my_image.png);
       }


### PR DESCRIPTION
This doesn't break the theme, it just shows a warning so that an administrator can resolve the issue:

<img width="1141" alt="Screenshot 2019-11-06 at 19 09 26" src="https://user-images.githubusercontent.com/6270921/68329379-05907080-00c9-11ea-9496-a5989ef56d5d.png">
