### PR TITLE
FIX: downcase SSO external email before checking against Discourse email

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -908,7 +908,7 @@ class User < ActiveRecord::Base
   def email_confirmed?
     email_tokens.where(email: email, confirmed: true).present? ||
     email_tokens.empty? ||
-    single_sign_on_record&.external_email.downcase == email
+    single_sign_on_record&.external_email&.downcase == email
   end
 
   def activate

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -908,7 +908,7 @@ class User < ActiveRecord::Base
   def email_confirmed?
     email_tokens.where(email: email, confirmed: true).present? ||
     email_tokens.empty? ||
-    single_sign_on_record&.external_email == email
+    single_sign_on_record&.external_email.downcase == email
   end
 
   def activate


### PR DESCRIPTION
Automatic group membership based off email domains is failing for sites using SSO when the email address contains uppercase letters. This is because the `email_confirmed?` method is checking the SSO record's `external_email` against the user's normalized Discourse email.

If we don't want to make this change, another option would be to disable automatic group membership based off email domains for site's using SSO.

