### PR TITLE
FIX: Alias modules that are required rather than imported

### DIFF
--- a/app/assets/javascripts/discourse-loader.js
+++ b/app/assets/javascripts/discourse-loader.js
@@ -188,7 +188,7 @@ var define, requirejs;
   };
 
   function reify(mod, name, rseen) {
-    name = checkForAlias(name);
+    name = transformForAliases(name);
     var deps = mod.deps;
     var length = deps.length;
     var reified = new Array(length);
@@ -231,7 +231,7 @@ var define, requirejs;
     throw new Error("Could not find module " + name);
   }
 
-  function checkForAlias(name) {
+  function transformForAliases(name) {
     return ALIASES[name] ? ALIASES[name] : name;
   }
 

--- a/app/assets/javascripts/discourse-loader.js
+++ b/app/assets/javascripts/discourse-loader.js
@@ -188,6 +188,7 @@ var define, requirejs;
   };
 
   function reify(mod, name, rseen) {
+    name = checkForAlias(name);
     var deps = mod.deps;
     var length = deps.length;
     var reified = new Array(length);
@@ -217,7 +218,6 @@ var define, requirejs;
   }
 
   function requireFrom(name, origin) {
-    name = checkForAlias(name);
     var mod = EMBER_MODULES[name] || registry[name];
     if (!mod) {
       throw new Error(

--- a/app/assets/javascripts/discourse-loader.js
+++ b/app/assets/javascripts/discourse-loader.js
@@ -151,7 +151,7 @@ var define, requirejs;
   }
 
   Module.prototype.makeRequire = function() {
-    var name = this.name;
+    var name = transformForAliases(this.name);
 
     return (
       this._require ||
@@ -188,7 +188,6 @@ var define, requirejs;
   };
 
   function reify(mod, name, rseen) {
-    name = transformForAliases(name);
     var deps = mod.deps;
     var length = deps.length;
     var reified = new Array(length);
@@ -218,6 +217,7 @@ var define, requirejs;
   }
 
   function requireFrom(name, origin) {
+    name = transformForAliases(name);
     var mod = EMBER_MODULES[name] || registry[name];
     if (!mod) {
       throw new Error(


### PR DESCRIPTION
Simply moving `checkForAlias` to occur for all methods of importing/requiring modules