### PR TITLE
FIX: Ensure enforce 2FA satisfied by security keys

### DIFF
--- a/app/serializers/admin_detailed_user_serializer.rb
+++ b/app/serializers/admin_detailed_user_serializer.rb
@@ -39,7 +39,7 @@ class AdminDetailedUserSerializer < AdminUserSerializer
   has_many :groups, embed: :object, serializer: BasicGroupSerializer
 
   def second_factor_enabled
-    object.totp_enabled?
+    object.totp_enabled? || object.security_keys_enabled?
   end
 
   def can_disable_second_factor

--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -210,6 +210,6 @@ class CurrentUserSerializer < BasicUserSerializer
   end
 
   def second_factor_enabled
-    object.totp_enabled?
+    object.totp_enabled? || object.security_keys_enabled?
   end
 end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -164,7 +164,7 @@ class UserSerializer < BasicUserSerializer
   end
 
   def second_factor_enabled
-    object.totp_enabled?
+    object.totp_enabled? || object.security_keys_enabled?
   end
 
   def include_second_factor_backup_enabled?

--- a/spec/serializers/current_user_serializer_spec.rb
+++ b/spec/serializers/current_user_serializer_spec.rb
@@ -68,6 +68,38 @@ RSpec.describe CurrentUserSerializer do
     end
   end
 
+  context "#second_factor_enabled" do
+    fab!(:user) { Fabricate(:user) }
+    let :serializer do
+      CurrentUserSerializer.new(user, scope: Guardian.new(user), root: false)
+    end
+    let(:json) { serializer.as_json }
+
+    it "is false by default" do
+      expect(json[:second_factor_enabled]).to eq(false)
+    end
+
+    context "when totp enabled" do
+      before do
+        User.any_instance.stubs(:totp_enabled?).returns(true)
+      end
+
+      it "is true" do
+        expect(json[:second_factor_enabled]).to eq(true)
+      end
+    end
+
+    context "when security_keys enabled" do
+      before do
+        User.any_instance.stubs(:security_keys_enabled?).returns(true)
+      end
+
+      it "is true" do
+        expect(json[:second_factor_enabled]).to eq(true)
+      end
+    end
+  end
+
   context "#groups" do
     fab!(:member) { Fabricate(:user) }
     let :serializer do

--- a/spec/serializers/user_serializer_spec.rb
+++ b/spec/serializers/user_serializer_spec.rb
@@ -40,8 +40,9 @@ describe UserSerializer do
   end
 
   context "with a user" do
+    let(:scope) { Guardian.new }
     fab!(:user) { Fabricate(:user) }
-    let(:serializer) { UserSerializer.new(user, scope: Guardian.new, root: false) }
+    let(:serializer) { UserSerializer.new(user, scope: scope, root: false) }
     let(:json) { serializer.as_json }
     fab!(:upload) { Fabricate(:upload) }
     fab!(:upload2) { Fabricate(:upload) }
@@ -162,6 +163,33 @@ describe UserSerializer do
 
       it "has a cooked bio" do
         expect(json[:bio_cooked]).to eq 'my cooked bio'
+      end
+    end
+
+    describe "second_factor_enabled" do
+      let(:scope) { Guardian.new(user) }
+      it "is false by default" do
+        expect(json[:second_factor_enabled]).to eq(false)
+      end
+
+      context "when totp enabled" do
+        before do
+          User.any_instance.stubs(:totp_enabled?).returns(true)
+        end
+
+        it "is true" do
+          expect(json[:second_factor_enabled]).to eq(true)
+        end
+      end
+
+      context "when security_keys enabled" do
+        before do
+          User.any_instance.stubs(:security_keys_enabled?).returns(true)
+        end
+
+        it "is true" do
+          expect(json[:second_factor_enabled]).to eq(true)
+        end
       end
     end
   end


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/920448/68449401-a8b0c980-0232-11ea-967a-b61fea71f15f.png)

* If a staff user created only a security key as their single 2FA option. they continued to be prompted to create a 2FA option because we only considered this condition satisfied if a TOTP was added.
* The condition is now satisfied if TOTP OR security keys are enabled