### PR TITLE
FIX: Do not skip some emails in user search

### DIFF
--- a/app/assets/javascripts/discourse/lib/user-search.js.es6
+++ b/app/assets/javascripts/discourse/lib/user-search.js.es6
@@ -136,7 +136,7 @@ function organizeResults(r, options) {
 // will not find me, which is a reasonable compromise
 //
 // we also ignore if we notice a double space or a string that is only a space
-const ignoreRegex = /([\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,\/:;<=>?\[\]^`{|}~])|\s\s|^\s$/;
+const ignoreRegex = /([\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*,\/:;<=>?\[\]^`{|}~])|\s\s|^\s$|^[^+]*\+[^@]*$/;
 
 function skipSearch(term, allowEmails) {
   if (term.indexOf("@") > -1 && !allowEmails) {

--- a/test/javascripts/lib/user-search-test.js.es6
+++ b/test/javascripts/lib/user-search-test.js.es6
@@ -169,6 +169,9 @@ QUnit.test("it skips a search depending on punctuations", async assert => {
   // 6 + email
   assert.equal(results.length, 7);
 
+  results = await userSearch({ term: "sam+test@sam.com", allowEmails: true });
+  assert.equal(results.length, 7);
+
   results = await userSearch({ term: "sam@sam.com" });
   assert.equal(results.length, 0);
 


### PR DESCRIPTION
It used to avoid the email addresses containing the plus sign.