### PR TITLE
DEV: Raise errors when cleaning the download cache, and fix for macOS

### DIFF
--- a/lib/file_store/base_store.rb
+++ b/lib/file_store/base_store.rb
@@ -139,7 +139,9 @@ module FileStore
       FileUtils.mkdir_p(dir) unless Dir.exist?(dir)
       FileUtils.cp(file.path, path)
       # keep latest 500 files
-      `ls -tr #{CACHE_DIR} | head -n -#{CACHE_MAXIMUM_SIZE} | awk '$0="#{CACHE_DIR}"$0' | xargs rm -f`
+      Discourse::Utils.execute_command <<~COMMAND
+        set -o pipefail; ls -t #{CACHE_DIR} | tail -n +#{CACHE_MAXIMUM_SIZE + 1} | awk '$0="#{CACHE_DIR}"$0' | xargs rm -f
+      COMMAND
     end
 
     private


### PR DESCRIPTION
POSIX's `head` specification states: "The application shall ensure that the number option-argument is a positive decimal integer"

Negative values are supported on GNU `head`, so this works in the discourse docker image. However, in some environments (e.g. macOS), the system `head` version fails with a negative n parameter.

This commit does two things

- Checks the status at each stage of the pipe, so it cannot fail silently
- Flip the `ls` command to list in descending time order, and use `tail -n +501` instead of `head -n -500`.

The visible result is that macOS users no longer see `head: illegal line count -- -500` printed throughout the test suite.