### PR TITLE
DEV: Abort autospec on [ENTER], even if no specs have failed

### DIFF
--- a/lib/autospec/manager.rb
+++ b/lib/autospec/manager.rb
@@ -364,8 +364,9 @@ class Autospec::Manager
       puts
       puts
       if specs.length == 0
-        puts "No specs have failed yet! "
+        puts "No specs have failed yet! Aborting anyway"
         puts
+        abort_runners
       else
         puts "The following specs have failed:"
         specs.each { |s| puts s }


### PR DESCRIPTION
When starting autospec, it says

> Press [ENTER] to stop the current run

However, [ENTER] does nothing unless a spec has failed. Sometimes I want to abort anyway, so that the run is restarted.