### PR TITLE
DEV: Optionally allow autospec without auto-running the whole suite

### DIFF
--- a/lib/autospec/manager.rb
+++ b/lib/autospec/manager.rb
@@ -18,6 +18,7 @@ class Autospec::Manager
   def initialize(opts = {})
     @opts = opts
     @debug = opts[:debug]
+    @auto_run_all = ENV["AUTO_RUN_ALL"] != "0"
     @queue = []
     @mutex = Mutex.new
     @signal = ConditionVariable.new
@@ -42,12 +43,13 @@ class Autospec::Manager
       exit
     end
 
-    ensure_all_specs_will_run
+    ensure_all_specs_will_run if @auto_run_all
     start_runners
     start_service_queue
     listen_for_changes
 
     puts "Press [ENTER] to stop the current run"
+    puts "Press [ENTER] while stopped to run all specs" unless @auto_run_all
     while @runners.any?(&:running?)
       STDIN.gets
       process_queue
@@ -138,7 +140,7 @@ class Autospec::Manager
       has_failed = true
       if result > 0
         focus_on_failed_tests(current)
-        ensure_all_specs_will_run(runner)
+        ensure_all_specs_will_run(runner) if @auto_run_all
       end
     end
 
@@ -343,7 +345,7 @@ class Autospec::Manager
         end
 
         # push run all specs to end of queue in correct order
-        ensure_all_specs_will_run(runner)
+        ensure_all_specs_will_run(runner) if @auto_run_all
       end
       puts "@@@@@@@@@@@@ specs queued" if @debug
       puts "@@@@@@@@@@@@ #{@queue}" if @debug


### PR DESCRIPTION
I want to use autospec while working on a single spec file. At the moment, it will start running all specs once it completes the file I'm working on. With parallel mode enabled, this causes CPU usage to spike dramatically, affecting IDE performance, battery life, and fan noise. I would prefer that it only runs all specs when I explicitly press [ENTER]

This commit adds a new ENV variable `AUTO_RUN_ALL`. To prevent auto-running all specs, set it to 0. The default behavior remains unchanged.