### PR TITLE
FEATURE: Dismiss new per category

### DIFF
--- a/app/assets/javascripts/discourse/controllers/discovery/topics.js.es6
+++ b/app/assets/javascripts/discourse/controllers/discovery/topics.js.es6
@@ -84,7 +84,7 @@ const controllerOpts = {
 
     resetNew() {
       this.topicTrackingState.resetNew();
-      Topic.resetNew().then(() => this.send("refresh"));
+      Topic.resetNew(this.category, !this.noSubcategories).then(() => this.send("refresh"));
     },
 
     dismissReadPosts() {
@@ -106,7 +106,7 @@ const controllerOpts = {
 
   @discourseComputed("model.filter", "model.topics.length")
   showResetNew(filter, topicsLength) {
-    return filter === "new" && topicsLength > 0;
+    return this.isFilterPage(filter, "new") && topicsLength > 0;
   },
 
   @discourseComputed("model.filter", "model.topics.length")

--- a/app/assets/javascripts/discourse/models/topic.js.es6
+++ b/app/assets/javascripts/discourse/models/topic.js.es6
@@ -763,8 +763,9 @@ Topic.reopenClass({
     });
   },
 
-  resetNew() {
-    return ajax("/topics/reset-new", { type: "PUT" });
+  resetNew(category, include_subcategories) {
+    const data = category ? { category_id: category.id, include_subcategories } : {}
+    return ajax("/topics/reset-new", { type: "PUT", data });
   },
 
   idForSlug(slug) {

--- a/app/assets/javascripts/discourse/models/topic.js.es6
+++ b/app/assets/javascripts/discourse/models/topic.js.es6
@@ -764,7 +764,7 @@ Topic.reopenClass({
   },
 
   resetNew(category, include_subcategories) {
-    const data = category ? { category_id: category.id, include_subcategories } : {}
+    const data = category ? { category_id: category.id, include_subcategories } : {};
     return ajax("/topics/reset-new", { type: "PUT", data });
   },
 

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -848,7 +848,23 @@ class TopicsController < ApplicationController
   end
 
   def reset_new
-    current_user.user_stat.update_column(:new_since, Time.now)
+    if params[:category_id].present?
+      category_ids = [params[:category_id]]
+
+      if params[:include_subcategories] == 'true'
+        category_ids = category_ids.concat(Category.where(parent_category_id: params[:category_id]))
+      end
+
+      category_ids.each do |category_id|
+        current_user
+          .category_users
+          .where(category_id: category_id)
+          .first_or_initialize
+          .update!(last_seen_at: Time.zone.now)
+      end
+    else
+      current_user.user_stat.update_column(:new_since, Time.now)
+    end
     render body: nil
   end
 

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -852,7 +852,7 @@ class TopicsController < ApplicationController
       category_ids = [params[:category_id]]
 
       if params[:include_subcategories] == 'true'
-        category_ids = category_ids.concat(Category.where(parent_category_id: params[:category_id]))
+        category_ids = category_ids.concat(Category.where(parent_category_id: params[:category_id]).pluck(:id))
       end
 
       category_ids.each do |category_id|

--- a/app/models/category_user.rb
+++ b/app/models/category_user.rb
@@ -217,6 +217,16 @@ class CategoryUser < ActiveRecord::Base
     Hash[*notification_levels.flatten]
   end
 
+  def self.lookup_for(user, category_ids)
+    return {} if user.blank? || category_ids.blank?
+    create_lookup(CategoryUser.where(category_id: category_ids, user_id: user.id))
+  end
+
+  def self.create_lookup(category_users)
+    category_users.each_with_object({}) do |category_user, acc|
+      acc[category_user.category_id] = category_user
+    end
+  end
 end
 
 # == Schema Information

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -135,6 +135,7 @@ class Topic < ActiveRecord::Base
 
   # When we want to temporarily attach some data to a forum topic (usually before serialization)
   attr_accessor :user_data
+  attr_accessor :category_user_data
 
   attr_accessor :posters  # TODO: can replace with posters_summary once we remove old list code
   attr_accessor :participants

--- a/app/models/topic_list.rb
+++ b/app/models/topic_list.rb
@@ -83,6 +83,7 @@ class TopicList
 
     # Attach some data for serialization to each topic
     @topic_lookup = TopicUser.lookup_for(@current_user, @topics) if @current_user
+    @category_user_lookup = CategoryUser.lookup_for(@current_user, @topics.map(&:category_id).uniq) if @current_user
 
     post_action_type =
       if @current_user
@@ -114,6 +115,7 @@ class TopicList
 
     @topics.each do |ft|
       ft.user_data = @topic_lookup[ft.id] if @topic_lookup.present?
+      ft.category_user_data = @category_user_lookup[ft.category_id] if @category_user_lookup.present?
 
       if ft.user_data && post_action_lookup && actions = post_action_lookup[ft.id]
         ft.user_data.post_action_data = { post_action_type => actions }

--- a/app/serializers/listable_topic_serializer.rb
+++ b/app/serializers/listable_topic_serializer.rb
@@ -59,6 +59,7 @@ class ListableTopicSerializer < BasicTopicSerializer
   def seen
     return true if !scope || !scope.user
     return true if object.user_data && !object.user_data.last_read_post_number.nil?
+    return true if object.category_user_data&.last_seen_at && object.created_at < object.category_user_data.last_seen_at
     return true if object.created_at < scope.user.user_option.treat_as_new_topic_start_date
     false
   end

--- a/db/migrate/20191107025041_add_last_seen_to_category_users.rb
+++ b/db/migrate/20191107025041_add_last_seen_to_category_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddLastSeenToCategoryUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :category_users, :last_seen_at, :datetime
+  end
+end

--- a/db/migrate/20191107025140_add_index_to_last_seen_at_on_category_users.rb
+++ b/db/migrate/20191107025140_add_index_to_last_seen_at_on_category_users.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class AddIndexToLastSeenAtOnCategoryUsers < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
+  def up
+    if !index_exists?(:category_users, [:user_id, :last_seen_at])
+      add_index :category_users, [:user_id, :last_seen_at], algorithm: :concurrently
+    end
+
+    remove_index :category_users, name: 'idx_category_users_user_id_category_id'
+    remove_index :category_users, name: 'idx_category_users_category_id_user_id'
+
+    add_index :category_users, [:user_id, :category_id],
+        name: 'idx_category_users_user_id_category_id', unique: false
+    add_index :category_users, [:category_id, :user_id],
+        name: 'idx_category_users_category_id_user_id', unique: false
+  end
+
+  def down
+    remove_index :category_users, [:user_id, :last_seen_at]
+
+    remove_index :category_users, name: 'idx_category_users_user_id_category_id'
+    remove_index :category_users, name: 'idx_category_users_category_id_user_id'
+
+    add_index :category_users, [:user_id, :category_id],
+        name: 'idx_category_users_user_id_category_id', unique: true
+    add_index :category_users, [:category_id, :user_id],
+        name: 'idx_category_users_category_id_user_id', unique: true
+  end
+end

--- a/db/migrate/20191107025140_add_index_to_last_seen_at_on_category_users.rb
+++ b/db/migrate/20191107025140_add_index_to_last_seen_at_on_category_users.rb
@@ -7,25 +7,9 @@ class AddIndexToLastSeenAtOnCategoryUsers < ActiveRecord::Migration[6.0]
     if !index_exists?(:category_users, [:user_id, :last_seen_at])
       add_index :category_users, [:user_id, :last_seen_at], algorithm: :concurrently
     end
-
-    remove_index :category_users, name: 'idx_category_users_user_id_category_id'
-    remove_index :category_users, name: 'idx_category_users_category_id_user_id'
-
-    add_index :category_users, [:user_id, :category_id],
-        name: 'idx_category_users_user_id_category_id', unique: false
-    add_index :category_users, [:category_id, :user_id],
-        name: 'idx_category_users_category_id_user_id', unique: false
   end
 
   def down
     remove_index :category_users, [:user_id, :last_seen_at]
-
-    remove_index :category_users, name: 'idx_category_users_user_id_category_id'
-    remove_index :category_users, name: 'idx_category_users_category_id_user_id'
-
-    add_index :category_users, [:user_id, :category_id],
-        name: 'idx_category_users_user_id_category_id', unique: true
-    add_index :category_users, [:category_id, :user_id],
-        name: 'idx_category_users_category_id_user_id', unique: true
   end
 end

--- a/db/post_migrate/20191107032231_change_notification_level.rb
+++ b/db/post_migrate/20191107032231_change_notification_level.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ChangeNotificationLevel < ActiveRecord::Migration[6.0]
+  def up
+    change_column :category_users, :notification_level, :integer, null: true
+  end
+
+  def down
+    change_column :category_users, :notification_level, :integer, null: false
+  end
+end

--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -875,7 +875,7 @@ class TopicQuery
         list = list
           .references("cu")
           .joins("LEFT JOIN category_users ON category_users.category_id = topics.category_id")
-          .where("category_users.user_id IS NULL OR category_users.user_id = :user_id", user_id: user.id)
+          .where("COALESCE(category_users.user_id, :user_id) = :user_id", user_id: user.id)
           .where("topics.category_id = :category_id
                  OR COALESCE(category_users.notification_level, :muted) <> :muted
                  OR tu.notification_level > :regular",
@@ -896,7 +896,7 @@ class TopicQuery
       list = list
         .references("cu")
         .joins("LEFT JOIN category_users ON category_users.category_id = topics.category_id")
-        .where("category_users.user_id IS NULL OR category_users.user_id = :user_id", user_id: user.id)
+        .where("COALESCE(category_users.user_id, :user_id) = :user_id", user_id: user.id)
         .where("category_users.notification_level IS NULL
                OR category_users.notification_level <> :muted
                OR category_users.category_id = :category_id OR tu.notification_level >= :tracking",

--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -876,7 +876,9 @@ class TopicQuery
           .references("cu")
           .joins("LEFT JOIN category_users ON category_users.category_id = topics.category_id")
           .where("category_users.user_id IS NULL OR category_users.user_id = :user_id", user_id: user.id)
-          .where("topics.category_id = :category_id OR COALESCE(category_users.notification_level, :muted) <> :muted OR tu.notification_level > :regular",
+          .where("topics.category_id = :category_id
+                 OR COALESCE(category_users.notification_level, :muted) <> :muted
+                 OR tu.notification_level > :regular",
                  muted: CategoryUser.notification_levels[:muted],
                  regular: TopicUser.notification_levels[:regular],
                  category_id: category_id || -1)
@@ -895,7 +897,9 @@ class TopicQuery
         .references("cu")
         .joins("LEFT JOIN category_users ON category_users.category_id = topics.category_id")
         .where("category_users.user_id IS NULL OR category_users.user_id = :user_id", user_id: user.id)
-        .where("category_users.notification_level IS NULL OR category_users.notification_level <> :muted OR category_users.category_id = :category_id OR tu.notification_level >= :tracking",
+        .where("category_users.notification_level IS NULL
+               OR category_users.notification_level <> :muted
+               OR category_users.category_id = :category_id OR tu.notification_level >= :tracking",
                muted: CategoryUser.notification_levels[:muted],
                tracking: TopicUser.notification_levels[:tracking],
                category_id: category_id || -1)

--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -517,6 +517,7 @@ class TopicQuery
     result = remove_muted_topics(result, @user)
     result = remove_muted_categories(result, @user, exclude: options[:category])
     result = remove_muted_tags(result, @user, options)
+    result = remove_already_seen_for_category(result, @user)
 
     self.class.results_filter_callbacks.each do |filter_callback|
       result = filter_callback.call(:new, result, @user, options)
@@ -871,21 +872,14 @@ class TopicQuery
 
     if SiteSetting.mute_all_categories_by_default
       if user
-        list = list.references("cu")
-          .where("
-          NOT EXISTS (
-            SELECT 1
-              FROM categories c
-              LEFT OUTER JOIN category_users cu
-              ON c.id = cu.category_id AND cu.user_id = :user_id
-            WHERE c.id = topics.category_id
-              AND c.id <> :category_id
-              AND (COALESCE(cu.notification_level, :muted) = :muted)
-              AND (COALESCE(tu.notification_level, :regular) <= :regular)
-          )", user_id: user.id,
-              muted: CategoryUser.notification_levels[:muted],
-              regular: TopicUser.notification_levels[:regular],
-              category_id: category_id || -1)
+        list = list
+          .references("cu")
+          .joins("LEFT JOIN category_users ON category_users.category_id = topics.category_id")
+          .where("category_users.user_id IS NULL OR category_users.user_id = :user_id", user_id: user.id)
+          .where("topics.category_id = :category_id OR COALESCE(category_users.notification_level, :muted) <> :muted OR tu.notification_level > :regular",
+                 muted: CategoryUser.notification_levels[:muted],
+                 regular: TopicUser.notification_levels[:regular],
+                 category_id: category_id || -1)
       else
         category_ids = [
           SiteSetting.default_categories_watching.split("|"),
@@ -897,20 +891,14 @@ class TopicQuery
         list = list.where("topics.category_id IN (?)", category_ids) if category_ids.present?
       end
     elsif user
-      list = list.references("cu")
-        .where("
-        NOT EXISTS (
-          SELECT 1
-            FROM category_users cu
-           WHERE cu.user_id = :user_id
-             AND cu.category_id = topics.category_id
-             AND cu.notification_level = :muted
-             AND cu.category_id <> :category_id
-             AND (tu.notification_level IS NULL OR tu.notification_level < :tracking)
-        )", user_id: user.id,
-            muted: CategoryUser.notification_levels[:muted],
-            tracking: TopicUser.notification_levels[:tracking],
-            category_id: category_id || -1)
+      list = list
+        .references("cu")
+        .joins("LEFT JOIN category_users ON category_users.category_id = topics.category_id")
+        .where("category_users.user_id IS NULL OR category_users.user_id = :user_id", user_id: user.id)
+        .where("category_users.notification_level IS NULL OR category_users.notification_level <> :muted OR category_users.category_id = :category_id OR tu.notification_level >= :tracking",
+               muted: CategoryUser.notification_levels[:muted],
+               tracking: TopicUser.notification_levels[:tracking],
+               category_id: category_id || -1)
     end
 
     list
@@ -947,6 +935,16 @@ class TopicQuery
              AND tt.topic_id = topics.id
         ) OR NOT EXISTS (SELECT 1 FROM topic_tags tt WHERE tt.topic_id = topics.id)", tag_ids: muted_tag_ids)
     end
+  end
+
+  def remove_already_seen_for_category(list, user)
+    if user
+      list = list
+        .where("category_users.user_id IS NULL OR category_users.user_id = :user_id", user_id: user.id)
+        .where("category_users.last_seen_at IS NULL OR topics.created_at > category_users.last_seen_at")
+    end
+
+    list
   end
 
   def new_messages(params)

--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -874,8 +874,7 @@ class TopicQuery
       if user
         list = list
           .references("cu")
-          .joins("LEFT JOIN category_users ON category_users.category_id = topics.category_id")
-          .where("COALESCE(category_users.user_id, :user_id) = :user_id", user_id: user.id)
+          .joins("LEFT JOIN category_users ON category_users.category_id = topics.category_id AND category_users.user_id = #{user.id}")
           .where("topics.category_id = :category_id
                  OR COALESCE(category_users.notification_level, :muted) <> :muted
                  OR tu.notification_level > :regular",
@@ -895,8 +894,7 @@ class TopicQuery
     elsif user
       list = list
         .references("cu")
-        .joins("LEFT JOIN category_users ON category_users.category_id = topics.category_id")
-        .where("COALESCE(category_users.user_id, :user_id) = :user_id", user_id: user.id)
+        .joins("LEFT JOIN category_users ON category_users.category_id = topics.category_id AND category_users.user_id = #{user.id}")
         .where("category_users.notification_level IS NULL
                OR category_users.notification_level <> :muted
                OR category_users.category_id = :category_id OR tu.notification_level >= :tracking",
@@ -944,7 +942,6 @@ class TopicQuery
   def remove_already_seen_for_category(list, user)
     if user
       list = list
-        .where("category_users.user_id IS NULL OR category_users.user_id = :user_id", user_id: user.id)
         .where("category_users.last_seen_at IS NULL OR topics.created_at > category_users.last_seen_at")
     end
 

--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -895,10 +895,10 @@ class TopicQuery
       list = list
         .references("cu")
         .joins("LEFT JOIN category_users ON category_users.category_id = topics.category_id AND category_users.user_id = #{user.id}")
-        .where("category_users.notification_level IS NULL
-               OR category_users.notification_level <> :muted
+        .where("COALESCE(category_users.notification_level, :regular) <> :muted
                OR category_users.category_id = :category_id OR tu.notification_level >= :tracking",
                muted: CategoryUser.notification_levels[:muted],
+               regular: CategoryUser.notification_levels[:regular],
                tracking: TopicUser.notification_levels[:tracking],
                category_id: category_id || -1)
     end

--- a/spec/components/topic_query_spec.rb
+++ b/spec/components/topic_query_spec.rb
@@ -273,6 +273,19 @@ describe TopicQuery do
     end
   end
 
+  context 'already seen categories' do
+    it 'is removed from new and visible on latest lists' do
+      category = Fabricate(:category_with_definition)
+      topic = Fabricate(:topic, category: category)
+      CategoryUser.create!(user_id: user.id,
+                           category_id: category.id,
+                           last_seen_at: topic.created_at
+                          )
+      expect(topic_query.list_new.topics.map(&:id)).not_to include(topic.id)
+      expect(topic_query.list_latest.topics.map(&:id)).to include(topic.id)
+    end
+  end
+
   context 'muted tags' do
     it 'is removed from new and latest lists' do
       SiteSetting.tagging_enabled = true

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -2345,6 +2345,31 @@ RSpec.describe TopicsController do
       user.reload
       expect(user.user_stat.new_since.to_date).not_to eq(old_date.to_date)
     end
+
+    context 'category' do
+      fab!(:category) { Fabricate(:category) }
+      fab!(:subcategory) { Fabricate(:category, parent_category_id: category.id) }
+
+      it 'updates last_seen_at for main category' do
+        sign_in(user)
+        category_user = CategoryUser.create!(category_id: category.id, user_id: user.id)
+        subcategory_user = CategoryUser.create!(category_id: subcategory.id, user_id: user.id)
+        put "/topics/reset-new.json?category_id=#{category.id}"
+
+        expect(category_user.reload.last_seen_at).not_to be_nil
+        expect(subcategory_user.reload.last_seen_at).to be_nil
+      end
+
+      it 'updates last_seen_at for main category and subcategories' do
+        sign_in(user)
+        category_user = CategoryUser.create!(category_id: category.id, user_id: user.id)
+        subcategory_user = CategoryUser.create!(category_id: subcategory.id, user_id: user.id)
+        put "/topics/reset-new.json?category_id=#{category.id}&include_subcategories=true"
+
+        expect(category_user.reload.last_seen_at).not_to be_nil
+        expect(subcategory_user.reload.last_seen_at).not_to be_nil
+      end
+    end
   end
 
   describe '#feature_stats' do


### PR DESCRIPTION
Ability to dismiss new topics per category. I recorded a quick demo of how it is working

https://dev.discourse.org/t/add-per-category-dismiss-new/22865

![Screencast-from-11-11-19-16_00_28](https://user-images.githubusercontent.com/72780/68562585-760b0900-049e-11ea-88c4-fac623c3592b.gif)

@vinothkannans could you take a look? Especially on part related to `mute_all_categories_by_default` because I changed it to use join instead