### PR TITLE
DEV: Remove handling of category top menu items

### DIFF
--- a/app/assets/javascripts/discourse/models/nav-item.js.es6
+++ b/app/assets/javascripts/discourse/models/nav-item.js.es6
@@ -1,25 +1,19 @@
 import discourseComputed from "discourse-common/utils/decorators";
-import { toTitleCase } from "discourse/lib/formatter";
 import { emojiUnescape } from "discourse/lib/text";
 import Category from "discourse/models/category";
 import EmberObject from "@ember/object";
 import deprecated from "discourse-common/lib/deprecated";
 
 const NavItem = EmberObject.extend({
-  @discourseComputed("categoryName", "name")
-  title(categoryName, name) {
+  @discourseComputed("name")
+  title(name) {
     const extra = {};
-
-    if (categoryName) {
-      name = "category";
-      extra.categoryName = categoryName;
-    }
 
     return I18n.t("filters." + name.replace("/", ".") + ".help", extra);
   },
 
-  @discourseComputed("categoryName", "name", "count")
-  displayName(categoryName, name, count) {
+  @discourseComputed("name", "count")
+  displayName(name, count) {
     count = count || 0;
 
     if (
@@ -32,33 +26,9 @@ const NavItem = EmberObject.extend({
     let extra = { count: count };
     const titleKey = count === 0 ? ".title" : ".title_with_count";
 
-    if (categoryName) {
-      name = "category";
-      extra.categoryName = toTitleCase(categoryName);
-    }
-
     return emojiUnescape(
       I18n.t(`filters.${name.replace("/", ".") + titleKey}`, extra)
     );
-  },
-
-  @discourseComputed("name")
-  categoryName(name) {
-    const split = name.split("/");
-    return split[0] === "category" ? split[1] : null;
-  },
-
-  @discourseComputed("name")
-  categorySlug(name) {
-    const split = name.split("/");
-    if (split[0] === "category" && split[1]) {
-      const cat = Discourse.Site.current().categories.findBy(
-        "nameLower",
-        split[1].toLowerCase()
-      );
-      return cat ? Category.slugFor(cat) : null;
-    }
-    return null;
   },
 
   @discourseComputed("filterMode")
@@ -79,22 +49,18 @@ const NavItem = EmberObject.extend({
     return Discourse.getURL("/") + filterMode;
   },
 
-  @discourseComputed("name", "category", "categorySlug", "noSubcategories")
-  filterMode(name, category, categorySlug, noSubcategories) {
-    if (name.split("/")[0] === "category") {
-      return "c/" + categorySlug;
-    } else {
-      let mode = "";
-      if (category) {
-        mode += "c/";
-        mode += Category.slugFor(category);
-        if (noSubcategories) {
-          mode += "/none";
-        }
-        mode += "/l/";
+  @discourseComputed("name", "category", "noSubcategories")
+  filterMode(name, category, noSubcategories) {
+    let mode = "";
+    if (category) {
+      mode += "c/";
+      mode += Category.slugFor(category);
+      if (noSubcategories) {
+        mode += "/none";
       }
-      return mode + name.replace(" ", "-");
+      mode += "/l/";
     }
+    return mode + name.replace(" ", "-");
   },
 
   @discourseComputed("name", "category", "topicTrackingState.messageCount")

--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -160,11 +160,11 @@ module Discourse
   end
 
   def self.top_menu_items
-    @top_menu_items ||= Discourse.filters + [:category, :categories, :top]
+    @top_menu_items ||= Discourse.filters + [:categories, :top]
   end
 
   def self.anonymous_top_menu_items
-    @anonymous_top_menu_items ||= Discourse.anonymous_filters + [:category, :categories, :top]
+    @anonymous_top_menu_items ||= Discourse.anonymous_filters + [:categories, :top]
   end
 
   PIXEL_RATIOS ||= [1, 1.5, 2, 3]

--- a/test/javascripts/fixtures/site-fixtures.js.es6
+++ b/test/javascripts/fixtures/site-fixtures.js.es6
@@ -41,7 +41,6 @@ export default {
         "starred",
         "read",
         "posted",
-        "category",
         "categories",
         "top"
       ],
@@ -49,7 +48,6 @@ export default {
         "latest",
         "top",
         "categories",
-        "category",
         "categories",
         "top"
       ],

--- a/test/javascripts/helpers/site.js.es6
+++ b/test/javascripts/helpers/site.js.es6
@@ -38,11 +38,10 @@ PreloadStore.store("site", {
     "starred",
     "read",
     "posted",
-    "category",
     "categories",
     "top"
   ],
-  anonymous_top_menu_items: ["latest", "category", "categories", "top"],
+  anonymous_top_menu_items: ["latest", "categories", "top"],
   uncategorized_category_id: 17,
   categories: [
     {

--- a/test/javascripts/models/nav-item-test.js.es6
+++ b/test/javascripts/models/nav-item-test.js.es6
@@ -16,7 +16,7 @@ QUnit.module("NavItem", {
 });
 
 QUnit.test("href", assert => {
-  assert.expect(4);
+  assert.expect(2);
 
   function href(text, expected, label) {
     assert.equal(NavItem.fromText(text, {}).get("href"), expected, label);
@@ -24,8 +24,6 @@ QUnit.test("href", assert => {
 
   href("latest", "/latest", "latest");
   href("categories", "/categories", "categories");
-  href("category/bug", "/c/bug", "English category name");
-  href("category/确实是这样", "/c/343434-category", "Chinese category name");
 });
 
 QUnit.test("count", assert => {


### PR DESCRIPTION
Support for these kinds of navigation items was dropped in 88f52514, but
the code for handling these menu items was never removed.