### PR TITLE
FIX:  ambiguous column references in update_users task

### DIFF
--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -391,8 +391,8 @@ def update_users
              , MAX(p.created_at) max_created_at
           FROM posts p
           JOIN topics t ON t.id = p.topic_id AND t.archetype <> ?
-         WHERE deleted_at IS NULL
-      GROUP BY user_id
+         WHERE p.deleted_at IS NULL
+      GROUP BY p.user_id
     )
     UPDATE users
        SET first_seen_at  = X.min_created_at


### PR DESCRIPTION
`rake import:ensure_consistency` is currently failing because of ambiguous references to the `deleted_at` and `user_id` columns in the `update_users` task.