### PR TITLE
REFACTOR: Remove context from filterMode

### DIFF
--- a/app/assets/javascripts/discourse/components/navigation-bar.js.es6
+++ b/app/assets/javascripts/discourse/components/navigation-bar.js.es6
@@ -25,7 +25,7 @@ export default Component.extend({
     let item = navItems.find(i => i.active === true);
 
     item =
-      item || navItems.find(i => i.get("filterMode").indexOf(filterMode) === 0);
+      item || navItems.find(i => i.get("filterMode") === filterMode);
 
     if (!item) {
       let connectors = this.connectors;

--- a/app/assets/javascripts/discourse/components/navigation-item.js.es6
+++ b/app/assets/javascripts/discourse/components/navigation-item.js.es6
@@ -20,10 +20,7 @@ export default Component.extend(
       if (active !== undefined) {
         return active;
       }
-      return (
-        contentFilterMode === filterMode ||
-        filterMode.indexOf(contentFilterMode) === 0
-      );
+      return contentFilterMode === filterMode;
     },
 
     buildBuffer(buffer) {

--- a/app/assets/javascripts/discourse/models/nav-item.js.es6
+++ b/app/assets/javascripts/discourse/models/nav-item.js.es6
@@ -31,8 +31,8 @@ const NavItem = EmberObject.extend({
     );
   },
 
-  @discourseComputed("filterMode")
-  href(filterMode) {
+  @discourseComputed("filterMode", "category", "noSubcategories")
+  href(filterMode, category, noSubcategories) {
     let customHref = null;
 
     NavItem.customNavItemHrefs.forEach(function(cb) {
@@ -46,21 +46,25 @@ const NavItem = EmberObject.extend({
       return customHref;
     }
 
-    return Discourse.getURL("/") + filterMode;
+    let url = Discourse.getURL("/");
+
+    if (category) {
+      url += "c/";
+      url += Category.slugFor(category);
+      if (noSubcategories) {
+        url += "/none";
+      }
+      url += "/l/";
+    }
+
+    url += this.filterMode;
+
+    return url;
   },
 
-  @discourseComputed("name", "category", "noSubcategories")
-  filterMode(name, category, noSubcategories) {
-    let mode = "";
-    if (category) {
-      mode += "c/";
-      mode += Category.slugFor(category);
-      if (noSubcategories) {
-        mode += "/none";
-      }
-      mode += "/l/";
-    }
-    return mode + name.replace(" ", "-");
+  @discourseComputed("name")
+  filterMode(name) {
+    return name.replace(" ", "-");
   },
 
   @discourseComputed("name", "category", "topicTrackingState.messageCount")
@@ -151,7 +155,7 @@ NavItem.reopenClass({
 
     if (
       args.filterMode &&
-      !items.some(i => i.indexOf(args.filterMode) !== -1)
+      !items.some(i => args.filterMode === i)
     ) {
       items.push(args.filterMode);
     }

--- a/app/assets/javascripts/discourse/routes/build-category-route.js.es6
+++ b/app/assets/javascripts/discourse/routes/build-category-route.js.es6
@@ -65,14 +65,9 @@ export default (filterArg, params) => {
     },
 
     _setupNavigation(category) {
-      const noSubcategories = params && !!params.no_subcategories,
-        filterMode = `c/${Category.slugFor(category)}${
-          noSubcategories ? "/none" : ""
-        }/l/${this.filter(category)}`;
-
       this.controllerFor("navigation/category").setProperties({
         category,
-        filterMode: filterMode,
+        filterMode: this.filter(category),
         noSubcategories: params && params.no_subcategories
       });
     },

--- a/app/assets/javascripts/discourse/routes/tags-show.js.es6
+++ b/app/assets/javascripts/discourse/routes/tags-show.js.es6
@@ -23,7 +23,6 @@ export default DiscourseRoute.extend({
     const tag = this.store.createRecord("tag", {
       id: Handlebars.Utils.escapeExpression(params.tag_id)
     });
-    let f = "";
 
     if (params.additional_tags) {
       this.set(
@@ -38,15 +37,7 @@ export default DiscourseRoute.extend({
       this.set("additionalTags", null);
     }
 
-    if (params.category) {
-      f = "c/";
-      if (params.parent_category) {
-        f += `${params.parent_category}/`;
-      }
-      f += `${params.category}/l/`;
-    }
-    f += this.navMode;
-    this.set("filterMode", f);
+    this.set("filterMode", this.navMode);
 
     if (params.category) {
       this.set("categorySlug", params.category);


### PR DESCRIPTION
The context is already provided via: category, noSubcategories and
tagId. Let's not duplicate that information in the filterMode.