### PR TITLE
FIX: tag and category watchers regression

### DIFF
--- a/app/jobs/regular/notify_category_change.rb
+++ b/app/jobs/regular/notify_category_change.rb
@@ -7,7 +7,7 @@ module Jobs
 
       if post&.topic&.visible?
         post_alerter = PostAlerter.new
-        post_alerter.notify_post_users(post, User.where(id: args[:notified_user_ids]))
+        post_alerter.notify_post_users(post, User.where(id: args[:notified_user_ids]), include_tag_watchers: false)
         post_alerter.notify_first_post_watchers(post, post_alerter.category_watchers(post.topic))
       end
     end

--- a/app/jobs/regular/notify_tag_change.rb
+++ b/app/jobs/regular/notify_tag_change.rb
@@ -7,7 +7,7 @@ module Jobs
 
       if post&.topic&.visible?
         post_alerter = PostAlerter.new
-        post_alerter.notify_post_users(post, User.where(id: args[:notified_user_ids]))
+        post_alerter.notify_post_users(post, User.where(id: args[:notified_user_ids]), include_category_watchers: false)
         post_alerter.notify_first_post_watchers(post, post_alerter.tag_watchers(post.topic))
       end
     end

--- a/spec/jobs/notify_tag_change_spec.rb
+++ b/spec/jobs/notify_tag_change_spec.rb
@@ -25,4 +25,13 @@ describe ::Jobs::NotifyTagChange do
     expect(notification.user_id).to eq(user.id)
     expect(notification.topic_id).to eq(post.topic_id)
   end
+
+  it 'doesnt create notification for user watching category' do
+    CategoryUser.create!(
+      user_id: user.id,
+      category_id: post.topic.category_id,
+      notification_level: TopicUser.notification_levels[:watching]
+    )
+    expect { described_class.new.execute(post_id: post.id, notified_user_ids: [regular_user.id]) }.not_to change { Notification.count }
+  end
 end


### PR DESCRIPTION
I made a regression here https://github.com/discourse/discourse/commit/17366d3bcc8ac27980e4fb3b7cfdc1ed86c6ab02#diff-ddeebb36d131f89ca91be9d04c2baefaR10

When the tag is added, people watching specific tag are notified but also people watching specific category.

Therefore, `notify_post_users` should accept options who should be notified.

So when `category` is added to the topic, users watching topic and users watching category are notified.

When `tag` is added to the topic, users watching topic and users watching tag are notified

Finally, when a new post is created, everybody is notified, topic watchers, category watchers, tag watchers.