### PR TITLE
Slow down the "Screaming Frog SEO Spider"

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1372,7 +1372,7 @@ security:
     list_type: compact
   slow_down_crawler_user_agents:
     type: list
-    default: "bingbot"
+    default: "bingbot|seo spider"
     list_type: compact
   slow_down_crawler_rate: 60
   content_security_policy:


### PR DESCRIPTION
* adds 'seo spider' to the default slowdown list
* we're seeing obnoxious crawl rates (20+ requests/sec) hammering 
customer sites