### PR TITLE
Bump prettier to 1.19.1 and lock dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "install-peerdeps": "^1.10.2",
     "lodash-cli": "https://github.com/lodash-archive/lodash-cli.git",
     "pretender": "^1.6",
-    "prettier": "^1.18.2",
+    "prettier": "1.19.1",
     "puppeteer": "1.20",
     "qunit": "2.8.0",
     "route-recognizer": "^0.3.3",

--- a/test/javascripts/acceptance/group-requests-test.js.es6
+++ b/test/javascripts/acceptance/group-requests-test.js.es6
@@ -126,5 +126,8 @@ QUnit.test("Group Requests", async assert => {
       .trim(),
     "denied"
   );
-  assert.deepEqual(requests, [["19", "true"], ["20", undefined]]);
+  assert.deepEqual(requests, [
+    ["19", "true"],
+    ["20", undefined]
+  ]);
 });

--- a/test/javascripts/components/combo-box-test.js.es6
+++ b/test/javascripts/components/combo-box-test.js.es6
@@ -11,7 +11,10 @@ moduleForComponent("combo-box", {
 componentTest("default", {
   template: "{{combo-box content=items}}",
   beforeEach() {
-    this.set("items", [{ id: 1, name: "hello" }, { id: 2, name: "world" }]);
+    this.set("items", [
+      { id: 1, name: "hello" },
+      { id: 2, name: "world" }
+    ]);
   },
 
   async test(assert) {
@@ -43,7 +46,10 @@ componentTest("with valueAttribute", {
 componentTest("with nameProperty", {
   template: '{{combo-box content=items nameProperty="text"}}',
   beforeEach() {
-    this.set("items", [{ id: 0, text: "hello" }, { id: 1, text: "world" }]);
+    this.set("items", [
+      { id: 0, text: "hello" },
+      { id: 1, text: "world" }
+    ]);
   },
 
   async test(assert) {

--- a/test/javascripts/components/multi-select-test.js.es6
+++ b/test/javascripts/components/multi-select-test.js.es6
@@ -14,7 +14,10 @@ componentTest("with objects and values", {
   template: "{{multi-select content=items values=values}}",
 
   beforeEach() {
-    this.set("items", [{ id: 1, name: "hello" }, { id: 2, name: "world" }]);
+    this.set("items", [
+      { id: 1, name: "hello" },
+      { id: 2, name: "world" }
+    ]);
     this.set("values", [1, 2]);
   },
 

--- a/test/javascripts/components/single-select-test.js.es6
+++ b/test/javascripts/components/single-select-test.js.es6
@@ -33,7 +33,10 @@ componentTest("accepts a value by reference", {
 
   beforeEach() {
     this.set("value", 1);
-    this.set("content", [{ id: 1, name: "robin" }, { id: 2, name: "regis" }]);
+    this.set("content", [
+      { id: 1, name: "robin" },
+      { id: 2, name: "regis" }
+    ]);
   },
 
   async test(assert) {
@@ -148,7 +151,10 @@ componentTest("dynamic headerText", {
   template: "{{single-select value=1 content=content}}",
 
   beforeEach() {
-    this.set("content", [{ id: 1, name: "robin" }, { id: 2, name: "regis" }]);
+    this.set("content", [
+      { id: 1, name: "robin" },
+      { id: 2, name: "regis" }
+    ]);
   },
 
   async test(assert) {
@@ -246,7 +252,10 @@ componentTest("supports keyboard events", {
   template: "{{single-select content=content filterable=true}}",
 
   beforeEach() {
-    this.set("content", [{ id: 1, name: "robin" }, { id: 2, name: "regis" }]);
+    this.set("content", [
+      { id: 1, name: "robin" },
+      { id: 2, name: "regis" }
+    ]);
   },
 
   skip: true,

--- a/test/javascripts/controllers/topic-test.js.es6
+++ b/test/javascripts/controllers/topic-test.js.es6
@@ -324,7 +324,10 @@ QUnit.test("canChangeOwner", function(assert) {
   this.registry.injection("controller", "currentUser", "current-user:main");
 
   const postStream = {
-    posts: [{ id: 1, username: "gary" }, { id: 2, username: "lili" }],
+    posts: [
+      { id: 1, username: "gary" },
+      { id: 2, username: "lili" }
+    ],
     stream: [1, 2]
   };
 

--- a/test/javascripts/models/post-stream-test.js.es6
+++ b/test/javascripts/models/post-stream-test.js.es6
@@ -141,7 +141,11 @@ QUnit.test("closestPostNumberFor", assert => {
 
 QUnit.test("closestDaysAgoFor", assert => {
   const postStream = buildStream(1231);
-  postStream.set("timelineLookup", [[1, 10], [3, 8], [5, 1]]);
+  postStream.set("timelineLookup", [
+    [1, 10],
+    [3, 8],
+    [5, 1]
+  ]);
 
   assert.equal(postStream.closestDaysAgoFor(1), 10);
   assert.equal(postStream.closestDaysAgoFor(2), 10);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2287,10 +2287,10 @@ pretender@^1.6:
     fake-xml-http-request "^1.6.0"
     route-recognizer "^0.3.3"
 
-prettier@^1.18.2:
-  version "1.18.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
-  integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
+prettier@1.19.1:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
+  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
 process-nextick-args@~2.0.0:
   version "2.0.0"


### PR DESCRIPTION
There were issues that devs were encountering where their local prettier was on one version,  e.g. 1.18.2, and the jenkins version was the latest,  e.g. 1.19.1, which use different default rulesets.

This was causing lefthook to pass locally but fail in jenkins. Now we should have no surprises from  prettier when merging.