### PR TITLE
FIX: Tracking Topic State know about category_seen_at

### DIFF
--- a/spec/models/topic_tracking_state_spec.rb
+++ b/spec/models/topic_tracking_state_spec.rb
@@ -353,6 +353,28 @@ describe TopicTrackingState do
     expect(report.length).to eq(1)
   end
 
+  it "correctly handles seen categories" do
+    user = Fabricate(:user)
+    post
+
+    report = TopicTrackingState.report(user)
+    expect(report.length).to eq(1)
+
+    CategoryUser.create!(user_id: user.id,
+                         notification_level: CategoryUser.notification_levels[:regular],
+                         category_id: post.topic.category_id,
+                         last_seen_at: post.topic.created_at
+                         )
+
+    report = TopicTrackingState.report(user)
+    expect(report.length).to eq(0)
+
+    post.topic.touch(:created_at)
+
+    report = TopicTrackingState.report(user)
+    expect(report.length).to eq(1)
+  end
+
   it "correctly handles capping" do
     user = Fabricate(:user)
 


### PR DESCRIPTION
If category got `last_seen_at` is set TrackingTopicState should know about it and exclude those topics from marking them as new.

@SamSaffron could you take a look on that? Logically it makes sense to me, however, I couldn't replicate bug from dev on my local