### PR TITLE
UX: Add +n indicator in topic list for PMs with > 5 participants

### DIFF
--- a/app/assets/javascripts/discourse/models/topic.js.es6
+++ b/app/assets/javascripts/discourse/models/topic.js.es6
@@ -70,8 +70,8 @@ const Topic = RestModel.extend({
     return user || this.creator;
   },
 
-  @discourseComputed("posters.[]", "participants.[]")
-  featuredUsers(posters, participants) {
+  @discourseComputed("posters.[]", "participants.[]", "allowed_user_count")
+  featuredUsers(posters, participants, allowedUserCount) {
     let users = posters;
     const maxUserCount = 5;
     const posterCount = users.length;
@@ -94,6 +94,13 @@ const Topic = RestModel.extend({
           }
         }
         return false;
+      });
+    }
+
+    if (this.isPrivateMessage && allowedUserCount > maxUserCount) {
+      users.splice(maxUserCount - 2, 1); // remove second-last avatar
+      users.push({
+        moreCount: `+${allowedUserCount - maxUserCount + 1}`
       });
     }
 

--- a/app/assets/javascripts/discourse/templates/list/posters-column.raw.hbs
+++ b/app/assets/javascripts/discourse/templates/list/posters-column.raw.hbs
@@ -1,5 +1,9 @@
 <td class='posters'>
 {{#each posters as |poster|}}
-<a href="{{poster.user.path}}" data-user-card="{{poster.user.username}}" class="{{poster.extraClasses}}">{{avatar poster avatarTemplatePath="user.avatar_template" usernamePath="user.username" namePath="user.name" imageSize="small"}}</a>
+  {{#if poster.moreCount}}
+    <a class="posters-more-count">{{poster.moreCount}}</a>
+  {{else}}
+    <a href="{{poster.user.path}}" data-user-card="{{poster.user.username}}" class="{{poster.extraClasses}}">{{avatar poster avatarTemplatePath="user.avatar_template" usernamePath="user.username" namePath="user.name" imageSize="small"}}</a>
+  {{/if}}
 {{/each}}
 </td>

--- a/app/assets/stylesheets/desktop/topic-list.scss
+++ b/app/assets/stylesheets/desktop/topic-list.scss
@@ -88,6 +88,9 @@
     }
   }
 
+  $td-posters-height: 29px; // min-height of td with avatar glow
+  $td-posters-more-lh: $td-posters-height - 4;
+
   .posters {
     // we know there are up to 5 avatars of fixed size
     // will be overridden by media width queries on narrow displays to 1 avatar's width
@@ -98,10 +101,17 @@
       &:last-of-type {
         margin-right: 0;
       }
+
+      &.posters-more-count {
+        cursor: default;
+        color: dark-light-choose($primary-medium, $secondary-medium);
+        line-height: $td-posters-more-lh;
+        font-size: $font-down-1;
+      }
     }
   }
   td.posters {
-    height: 29px; // min-height of td with avatar glow
+    height: $td-posters-height;
   }
   .posters a:first-child .avatar.latest:not(.single) {
     box-shadow: 0 0 3px 1px desaturate($tertiary-medium, 35%);

--- a/app/serializers/topic_list_item_serializer.rb
+++ b/app/serializers/topic_list_item_serializer.rb
@@ -14,7 +14,8 @@ class TopicListItemSerializer < ListableTopicSerializer
              :bookmarked_post_numbers,
              :liked_post_numbers,
              :featured_link,
-             :featured_link_root_domain
+             :featured_link_root_domain,
+             :allowed_user_count
 
   has_many :posters, serializer: TopicPosterSerializer, embed: :objects
   has_many :participants, serializer: TopicPosterSerializer, embed: :objects
@@ -84,6 +85,14 @@ class TopicListItemSerializer < ListableTopicSerializer
 
   def include_featured_link_root_domain?
     SiteSetting.topic_featured_link_enabled && object.featured_link.present?
+  end
+
+  def allowed_user_count
+    return object.allowed_users.count
+  end
+
+  def include_allowed_user_count?
+    object.private_message?
   end
 
 end


### PR DESCRIPTION
Screenshot: 

<img width="852" alt="image" src="https://user-images.githubusercontent.com/368961/68884027-39c6eb00-06e0-11ea-9065-8f623c0f7ab0.png">

The fourth avatar is dropped in order to make room for the +n element but also to keep the last avatar visible, since it is an indicator of the last poster. 