### PR TITLE
Block enforce second factor if enable local logins is disabled

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -204,6 +204,8 @@ en:
       enable_s3_uploads_is_required: "You cannot enable inventory to S3 unless you've enabled the S3 uploads."
       s3_backup_requires_s3_settings: "You cannot use S3 as backup location unless you've provided the '%{setting_name}'."
       s3_bucket_reused: "You cannot use the same bucket for 's3_upload_bucket' and 's3_backup_bucket'. Choose a different bucket or use a different path for each bucket."
+      second_factor_cannot_be_enforced_with_disabled_local_login: "You cannot enforce 2FA if local logins are disabled."
+      local_login_cannot_be_disabled_if_second_factor_enforced: "You cannot disable local login if 2FA is enforced. Disable enforced 2FA before disabling local logins."
     conflicting_google_user_id: 'The Google Account ID for this account has changed; staff intervention is required for security reasons. Please contact staff and point them to <br><a href="https://meta.discourse.org/t/76575">https://meta.discourse.org/t/76575</a>'
 
   activemodel:

--- a/lib/site_settings/validations.rb
+++ b/lib/site_settings/validations.rb
@@ -143,6 +143,17 @@ module SiteSettings::Validations
     validate_bucket_setting("s3_backup_bucket", SiteSetting.s3_upload_bucket, new_val)
   end
 
+  def validate_enforce_second_factor(new_val)
+    return if SiteSetting.enable_local_logins
+    validate_error :second_factor_cannot_be_enforced_with_disabled_local_login
+  end
+
+  def validate_enable_local_logins(new_val)
+    return if new_val == "t"
+    return if SiteSetting.enforce_second_factor == "no"
+    validate_error :local_login_cannot_be_disabled_if_second_factor_enforced
+  end
+
   private
 
   def validate_bucket_setting(setting_name, upload_bucket, backup_bucket)


### PR DESCRIPTION
https://meta.discourse.org/t/block-enforce-second-factor-if-enable-local-logins-is-disabled/124216

* Disallows enforcing 2FA if local logins are disabled
* Disallows disabling local logins if enforce 2FA is enabled