### PR TITLE
FIX: Ensure load-more considers current position

### DIFF
--- a/app/assets/javascripts/discourse/mixins/load-more.js.es6
+++ b/app/assets/javascripts/discourse/mixins/load-more.js.es6
@@ -21,6 +21,7 @@ export default Mixin.create(Scrolling, {
     const eyeline = new Eyeline(this.eyelineSelector + ":last");
     this.set("eyeline", eyeline);
     eyeline.on("sawBottom", () => this.send("loadMore"));
+    eyeline.update(); // update once to consider current position
     this.bindScrolling();
   },
 


### PR DESCRIPTION
If user is already at the bottom of the page, the loadMore action will
not be called.