### PR TITLE
FEATURE: Normalize the service worker route

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -456,8 +456,6 @@ module ApplicationHelper
   end
 
   def client_side_setup_data
-    service_worker_url = 'service-worker.js'
-
     setup_data = {
       cdn: Rails.configuration.action_controller.asset_host,
       base_url: Discourse.base_url,
@@ -465,7 +463,7 @@ module ApplicationHelper
       environment: Rails.env,
       letter_avatar_version: LetterAvatar.version,
       markdown_it_url: script_asset_path('markdown-it-bundle'),
-      service_worker_url: service_worker_url,
+      service_worker_url: 'service-worker.js',
       default_locale: SiteSetting.default_locale,
       asset_version: Discourse.assets_digest,
       disable_custom_css: loading_admin?,

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -456,7 +456,7 @@ module ApplicationHelper
   end
 
   def client_side_setup_data
-    service_worker_url = Rails.env.development? ? 'service-worker.js' : Rails.application.assets_manifest.assets['service-worker.js']
+    service_worker_url = 'service-worker.js'
 
     setup_data = {
       cdn: Rails.configuration.action_controller.asset_host,

--- a/config/nginx.sample.conf
+++ b/config/nginx.sample.conf
@@ -33,6 +33,13 @@ map $http_x_forwarded_proto $thescheme {
 
 log_format log_discourse '[$time_local] "$http_host" $remote_addr "$request" "$http_user_agent" "$sent_http_x_discourse_route" $status $bytes_sent "$http_referer" $upstream_response_time $request_time "$sent_http_x_discourse_username"';
 
+# Allow bypass cache from localhost
+geo $bypass_cache {
+  default         0;
+  127.0.0.1       1;
+  ::1             1;
+}
+
 server {
 
   access_log /var/log/nginx/access.log log_discourse;
@@ -224,6 +231,15 @@ server {
       proxy_cache_valid 200 301 302 7d;
       proxy_cache_valid any 1m;
       proxy_pass http://discourse;
+
+      # Allow service worker cache to be re-cached by localhost requests only
+      # Forward public cache control
+      location ~ ^/service-worker {
+        proxy_cache_bypass $bypass_cache;
+        proxy_hide_header "Cache-Control";
+        add_header Cache-Control max-age=31556952,public;
+        proxy_pass http://discourse;
+      }
       break;
     }
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -807,7 +807,7 @@ Discourse::Application.routes.draw do
     # current site before updating to a new Service Worker.
     # Support the old Service Worker path to avoid routing error filling up the
     # logs.
-    get "/service-worker.js" => redirect(relative_url_root + service_worker_asset, status: 302), format: :js
+    get "/service-worker.js" =>  "static#service_worker_asset", format: :js
     get service_worker_asset => "static#service_worker_asset", format: :js
   elsif Rails.env.development?
     get "/service-worker.js" => "static#service_worker_asset", format: :js

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -68,6 +68,19 @@ task 'assets:precompile:css' => 'environment' do
   end
 end
 
+task 'assets:flush_sw' => 'environment' do
+  begin
+    hostname = Discourse.current_hostname
+    default_port = SiteSetting.force_https? ? 443 : 80
+    port = SiteSetting.port.to_i > 0 ? SiteSetting.port : default_port
+    STDERR.puts "Flushing service worker script"
+    `curl -s -m 1 --resolve '#{hostname}:#{port}:127.0.0.1' #{Discourse.base_url}/service-worker.js > /dev/null`
+    STDERR.puts "done"
+  rescue
+    STDERR.puts "Warning: unable to flush service worker script"
+  end
+end
+
 def assets_path
   "#{Rails.root}/public/assets"
 end


### PR DESCRIPTION
Update cache headers so they are not immutable outside of the rails app

Add the ability to purge the service worker cache from localhost

Rails -> nginx will pass immutable flags so the file is cached until reloaded.
In most cases, nginx will have its cache flushed on rebuild (new image)

For those needing dynamic re-caching (such as upgrading via the UI),
a rake task for flushing the service worker script is provided
through `assets:flush_sw`