### PR TITLE
FIX: PM glyph in user-menu should always be shown to staff

### DIFF
--- a/app/assets/javascripts/discourse/widgets/user-menu.js.es6
+++ b/app/assets/javascripts/discourse/widgets/user-menu.js.es6
@@ -109,7 +109,7 @@ createWidget("user-menu-links", {
     glyphs.push(this.notificationsGlyph());
     glyphs.push(this.bookmarksGlyph());
 
-    if (this.siteSettings.enable_personal_messages) {
+    if (this.siteSettings.enable_personal_messages || this.currentUser.staff) {
       glyphs.push(this.messagesGlyph());
     }
 

--- a/app/assets/javascripts/discourse/widgets/user-menu.js.es6
+++ b/app/assets/javascripts/discourse/widgets/user-menu.js.es6
@@ -115,7 +115,10 @@ createWidget("user-menu-links", {
 
     return h("ul.menu-links-row", [
       links.map(l => h("li.user", this.linkHtml(l))),
-      h("li.glyphs", glyphs.map(l => this.glyphHtml(l)))
+      h(
+        "li.glyphs",
+        glyphs.map(l => this.glyphHtml(l))
+      )
     ]);
   },
 

--- a/app/assets/javascripts/discourse/widgets/user-menu.js.es6
+++ b/app/assets/javascripts/discourse/widgets/user-menu.js.es6
@@ -115,10 +115,7 @@ createWidget("user-menu-links", {
 
     return h("ul.menu-links-row", [
       links.map(l => h("li.user", this.linkHtml(l))),
-      h(
-        "li.glyphs",
-        glyphs.map(l => this.glyphHtml(l))
-      )
+      h("li.glyphs", glyphs.map(l => this.glyphHtml(l)))
     ]);
   },
 


### PR DESCRIPTION
History: https://meta.discourse.org/t//133518

<hr>

Some communities have the `enable_personal_messages` switched off. We currently show the PM icon in the user menu based on that. This is not correct as staff members can always send PMs, so it's handy for them to have that icon visible even if non-staff members are not allowed to use PMs.

This PR corrects that in that if the current user is a staff member, they'll get the icon regardless of what that setting it set to.