### PR TITLE
FIX: Don't error CleanUpInactiveUserJob when user is missing

### DIFF
--- a/app/jobs/scheduled/clean_up_inactive_users.rb
+++ b/app/jobs/scheduled/clean_up_inactive_users.rb
@@ -30,7 +30,8 @@ module Jobs
       User.transaction do
         ids.each do |id|
           begin
-            user = User.find(id)
+            user = User.find_by(id: id)
+            next unless user
             destroyer.destroy(user, transaction: false, context: I18n.t("user.destroy_reasons.inactive_user"))
           rescue => e
             Discourse.handle_job_exception(e,


### PR DESCRIPTION
https://dev.discourse.org/t/bug-crushing-game-2019-edition/17547/68