### PR TITLE
FIX: Ensure revisions are made to store edit reasons and no reasons get wiped

### DIFF
--- a/lib/post_revisor.rb
+++ b/lib/post_revisor.rb
@@ -130,8 +130,9 @@ class PostRevisor
     @fields[:user_id] = @fields[:user_id].to_i if @fields.has_key?(:user_id)
     @fields[:category_id] = @fields[:category_id].to_i if @fields.has_key?(:category_id)
 
-    # always reset edit_reason unless provided
-    @fields[:edit_reason] = nil unless @fields[:edit_reason].present?
+    # always reset edit_reason unless provided, do not set to nil else
+    # previous reasons are lost
+    @fields.delete(:edit_reason) unless @fields[:edit_reason].present?
 
     return false unless should_revise?
 
@@ -244,7 +245,11 @@ class PostRevisor
 
   def should_create_new_version?
     return false if @skip_revision
-    edited_by_another_user? || !ninja_edit? || owner_changed? || force_new_version?
+    edited_by_another_user? || !ninja_edit? || owner_changed? || force_new_version? || edit_reason_specified?
+  end
+
+  def edit_reason_specified?
+    @fields[:edit_reason].present? && @fields[:edit_reason] != @post.edit_reason
   end
 
   def edited_by_another_user?

--- a/lib/post_revisor.rb
+++ b/lib/post_revisor.rb
@@ -132,7 +132,7 @@ class PostRevisor
 
     # always reset edit_reason unless provided, do not set to nil else
     # previous reasons are lost
-    @fields.delete(:edit_reason) unless @fields[:edit_reason].present?
+    @fields.delete(:edit_reason) if @fields[:edit_reason].blank?
 
     return false unless should_revise?
 


### PR DESCRIPTION
Meta: https://meta.discourse.org/t/merged-edits-will-clobber-the-first-edit-reason/123475

* Fix an issue where if an edit was made to a post with a reason provided, and then another edit was made with no reason, the original edit reason got wiped out
* We now always make a post revision (even with ninja edits) if an edit reason has been provided and it is different from the current edit reason