### PR TITLE
FEATURE: Add export poll button

### DIFF
--- a/plugins/poll/assets/javascripts/widgets/discourse-poll.js.es6
+++ b/plugins/poll/assets/javascripts/widgets/discourse-poll.js.es6
@@ -720,7 +720,7 @@ export default createWidget("discourse-poll", {
       const blob = new Blob([csvContent],{type: 'text/csv;charset=utf-8;'});
       const url = URL.createObjectURL(blob);
       pom.href = url;
-      pom.setAttribute('download', 'poll.csv');
+      pom.setAttribute("download", "poll.csv");
       pom.click();
     });
   },

--- a/plugins/poll/assets/javascripts/widgets/discourse-poll.js.es6
+++ b/plugins/poll/assets/javascripts/widgets/discourse-poll.js.es6
@@ -716,12 +716,13 @@ export default createWidget("discourse-poll", {
         download: 1
       }
     }).then(csvContent => {
-      const pom = document.createElement('a');
+      const downloadLink = document.createElement('a');
       const blob = new Blob([csvContent],{type: 'text/csv;charset=utf-8;'});
       const url = URL.createObjectURL(blob);
-      pom.href = url;
-      pom.setAttribute("download", "poll.csv");
-      pom.click();
+      downloadLink.href = url;
+      downloadLink.setAttribute("download", `poll-export-${attrs.poll.name}-${attrs.post.id}.csv`);
+      downloadLink.click();
+      downloadLink.remove();
     });
   },
 

--- a/plugins/poll/assets/javascripts/widgets/discourse-poll.js.es6
+++ b/plugins/poll/assets/javascripts/widgets/discourse-poll.js.es6
@@ -425,7 +425,7 @@ createWidget("discourse-poll-buttons", {
     const closed = attrs.isClosed;
     const staffOnly = poll.results === "staff_only";
     const isStaff = this.currentUser && this.currentUser.staff;
-    const dataExplorerEnabled = this.siteSettings.data_explorer_enabled === true;
+    const dataExplorerEnabled = this.siteSettings.data_explorer_enabled;
     const hideResultsDisabled = !staffOnly && (closed || topicArchived);
     const exportQueryID = this.siteSettings.poll_export_data_explorer_query_id;
 

--- a/plugins/poll/assets/javascripts/widgets/discourse-poll.js.es6
+++ b/plugins/poll/assets/javascripts/widgets/discourse-poll.js.es6
@@ -476,7 +476,7 @@ createWidget("discourse-poll-buttons", {
       }
     }
 
-    if (isStaff && dataExplorerEnabled && poll.get("voters") > 0) {
+    if (isStaff && dataExplorerEnabled && poll.voters > 0) {
       contents.push(
         this.attach("button", {
           className: "btn btn-default toggle-results",

--- a/plugins/poll/assets/javascripts/widgets/discourse-poll.js.es6
+++ b/plugins/poll/assets/javascripts/widgets/discourse-poll.js.es6
@@ -477,7 +477,7 @@ createWidget("discourse-poll-buttons", {
       }
     }
 
-    if (isStaff && dataExplorerEnabled && poll.voters > 0 && exportQueryID !== 0) {
+    if (isStaff && dataExplorerEnabled && poll.voters > 0 && exportQueryID) {
       contents.push(
         this.attach("button", {
           className: "btn btn-default export-results",

--- a/plugins/poll/assets/javascripts/widgets/discourse-poll.js.es6
+++ b/plugins/poll/assets/javascripts/widgets/discourse-poll.js.es6
@@ -709,7 +709,8 @@ export default createWidget("discourse-poll", {
     ajax(`/admin/plugins/explorer/queries/${queryID}/run.csv`, {
       type: "POST",
       data: {
-        params: JSON.stringify({ // needed for data-explorer route compatibility
+        // needed for data-explorer route compatibility
+        params: JSON.stringify({
           poll_name: attrs.poll.name,
           post_id: attrs.post.id.toString() // needed for data-explorer route compatibility
         }),
@@ -717,21 +718,27 @@ export default createWidget("discourse-poll", {
         limit: 1000000,
         download: 1
       }
-    }).then(csvContent => {
-      const downloadLink = document.createElement('a');
-      const blob = new Blob([csvContent],{type: 'text/csv;charset=utf-8;'});
-      const url = URL.createObjectURL(blob);
-      downloadLink.href = url;
-      downloadLink.setAttribute("download", `poll-export-${attrs.poll.name}-${attrs.post.id}.csv`);
-      downloadLink.click();
-      downloadLink.remove();
-    }).catch(error => {
-      if (error) {
-        popupAjaxError(error);
-      } else {
-        bootbox.alert(I18n.t("poll.error_while_exporting_results"));
-      }
-    });
+    })
+      .then(csvContent => {
+        const downloadLink = document.createElement("a");
+        const blob = new Blob([csvContent], {
+          type: "text/csv;charset=utf-8;"
+        });
+        downloadLink.href = URL.createObjectURL(blob);
+        downloadLink.setAttribute(
+          "download",
+          `poll-export-${attrs.poll.name}-${attrs.post.id}.csv`
+        );
+        downloadLink.click();
+        downloadLink.remove();
+      })
+      .catch(error => {
+        if (error) {
+          popupAjaxError(error);
+        } else {
+          bootbox.alert(I18n.t("poll.error_while_exporting_results"));
+        }
+      });
   },
 
   showLogin() {

--- a/plugins/poll/assets/javascripts/widgets/discourse-poll.js.es6
+++ b/plugins/poll/assets/javascripts/widgets/discourse-poll.js.es6
@@ -479,7 +479,7 @@ createWidget("discourse-poll-buttons", {
     if (isStaff && dataExplorerEnabled && poll.voters > 0) {
       contents.push(
         this.attach("button", {
-          className: "btn btn-default toggle-results",
+          className: "btn btn-default export-results",
           label: "poll.export-results.label",
           title: "poll.export-results.title",
           icon: "download",

--- a/plugins/poll/assets/javascripts/widgets/discourse-poll.js.es6
+++ b/plugins/poll/assets/javascripts/widgets/discourse-poll.js.es6
@@ -715,7 +715,7 @@ export default createWidget("discourse-poll", {
         limit: 1000000,
         download: 1
       }
-    }).then(( csvContent ) => {
+    }).then(csvContent => {
       const pom = document.createElement('a');
       const blob = new Blob([csvContent],{type: 'text/csv;charset=utf-8;'});
       const url = URL.createObjectURL(blob);

--- a/plugins/poll/assets/javascripts/widgets/discourse-poll.js.es6
+++ b/plugins/poll/assets/javascripts/widgets/discourse-poll.js.es6
@@ -483,7 +483,7 @@ createWidget("discourse-poll-buttons", {
           label: "poll.export-results.label",
           title: "poll.export-results.title",
           icon: "download",
-          disabled: poll.get("voters") === 0,
+          disabled: poll.voters === 0,
           action: "exportResults"
         })
       );

--- a/plugins/poll/assets/javascripts/widgets/discourse-poll.js.es6
+++ b/plugins/poll/assets/javascripts/widgets/discourse-poll.js.es6
@@ -708,7 +708,7 @@ export default createWidget("discourse-poll", {
       type: "POST",
       data: {
         params: JSON.stringify({ // needed for data-explorer route compatibility
-          poll_name: attrs.poll.get("name"),
+          poll_name: attrs.poll.name,
           post_id: attrs.post.id.toString() // needed for data-explorer route compatibility
         }),
         explain: false,

--- a/plugins/poll/assets/stylesheets/desktop/poll.scss
+++ b/plugins/poll/assets/stylesheets/desktop/poll.scss
@@ -36,6 +36,10 @@ div.poll {
       line-height: 2em;
     }
 
+    :not(:first-child):not(:last-child) {
+      margin-left: 1em;
+    }
+
     .toggle-status {
       float: right;
     }

--- a/plugins/poll/config/locales/client.en.yml
+++ b/plugins/poll/config/locales/client.en.yml
@@ -63,6 +63,10 @@ en:
         title: "Back to your votes"
         label: "Hide results"
 
+      export-results:
+        title: "Export the poll results"
+        label: "Export"
+
       open:
         title: "Open the poll"
         label: "Open"

--- a/plugins/poll/config/locales/client.en.yml
+++ b/plugins/poll/config/locales/client.en.yml
@@ -84,6 +84,7 @@ en:
       error_while_toggling_status: "Sorry, there was an error toggling the status of this poll."
       error_while_casting_votes: "Sorry, there was an error casting your votes."
       error_while_fetching_voters: "Sorry, there was an error displaying the voters."
+      error_while_exporting_results: "Sorry, there was an error exporting poll results."
 
       ui_builder:
         title: Build Poll

--- a/plugins/poll/config/locales/server.en.yml
+++ b/plugins/poll/config/locales/server.en.yml
@@ -20,6 +20,7 @@ en:
     poll_maximum_options: "Maximum number of options allowed in a poll."
     poll_edit_window_mins: "Number of minutes after post creation during which polls can be edited."
     poll_minimum_trust_level_to_create: "Define the minimum trust level needed to create polls."
+    poll_export_data_explorer_query_id: "ID of the Data Explorer Query to use for exporting poll results (0 to disable)."
 
   poll:
     poll: "poll"

--- a/plugins/poll/config/settings.yml
+++ b/plugins/poll/config/settings.yml
@@ -14,3 +14,7 @@ plugins:
     default: 1
     client: true
     enum: 'TrustLevelSetting'
+  poll_export_data_explorer_query_id:
+    default: -16
+    min: -9999
+    client: true


### PR DESCRIPTION
This PR aims to make poll results easily exportable to staff in a CSV format, so they can be analyzed in external software.

It also makes the export data easily customizable by allowing users to leverage any data explorer query to generate the report. By default, we use a query that ships with data explorer, but user can change the ID in settings or use `0` to disable this feature.

One potential upgrade is using the recent work that allows arbitrary group to run data explorer and allow all the groups with access to the configured query to also export polls, but that can be added later.