### PR TITLE
FIX: When dismissing category inform via MessageBus

### DIFF
--- a/app/assets/javascripts/discourse/models/topic-tracking-state.js.es6
+++ b/app/assets/javascripts/discourse/models/topic-tracking-state.js.es6
@@ -28,7 +28,7 @@ function isUnread(topic) {
 }
 
 function isUnseen(topic) {
-  return !topic.last_seen_at || topic.last_seen_at < topic.created_at;
+  return !topic.is_seen;
 }
 
 const TopicTrackingState = EmberObject.extend({
@@ -73,7 +73,7 @@ const TopicTrackingState = EmberObject.extend({
         tracker.notify(data);
       }
 
-      if (["dismiss_category", "dismiss_new"].includes(data.message_type)) {
+      if (data.message_type === "dismiss_new") {
         Object.keys(tracker.states).forEach(k => {
           const topic = tracker.states[k];
           if (
@@ -81,7 +81,7 @@ const TopicTrackingState = EmberObject.extend({
             topic.category_id === parseInt(data.payload.category_id, 0)
           ) {
             tracker.states[k] = Object.assign({}, topic, {
-              last_seen_at: data.payload.last_seen_at
+              is_seen: true
             });
           }
         });
@@ -236,10 +236,10 @@ const TopicTrackingState = EmberObject.extend({
 
       if (state) {
         const lastRead = t.get("last_read_post_number");
-        const lastSeenAt = t.get("last_seen_at");
+        const isSeen = t.get("is_seen");
         if (
           lastRead !== state.last_read_post_number ||
-          lastSeenAt !== state.last_seen_at
+          isSeen !== state.is_seen
         ) {
           const postsCount = t.get("posts_count");
           let newPosts = postsCount - state.highest_post_number,
@@ -260,7 +260,7 @@ const TopicTrackingState = EmberObject.extend({
             last_read_post_number: state.last_read_post_number,
             new_posts: newPosts,
             unread: unread,
-            last_seen_at: state.last_seen_at,
+            is_seen: state.is_seen,
             unseen: !state.last_read_post_number && isUnseen(state)
           });
         }

--- a/app/assets/javascripts/discourse/models/topic-tracking-state.js.es6
+++ b/app/assets/javascripts/discourse/models/topic-tracking-state.js.es6
@@ -14,7 +14,8 @@ function isNew(topic) {
   return (
     topic.last_read_post_number === null &&
     ((topic.notification_level !== 0 && !topic.notification_level) ||
-      topic.notification_level >= NotificationLevels.TRACKING)
+      topic.notification_level >= NotificationLevels.TRACKING) &&
+    isUnseen(topic)
   );
 }
 
@@ -24,6 +25,10 @@ function isUnread(topic) {
     topic.last_read_post_number < topic.highest_post_number &&
     topic.notification_level >= NotificationLevels.TRACKING
   );
+}
+
+function isUnseen(topic) {
+  return !topic.last_seen_at || topic.last_seen_at < topic.created_at;
 }
 
 const TopicTrackingState = EmberObject.extend({
@@ -66,6 +71,22 @@ const TopicTrackingState = EmberObject.extend({
 
       if (data.message_type === "latest") {
         tracker.notify(data);
+      }
+
+      if (["dismiss_category", "dismiss_new"].includes(data.message_type)) {
+        Object.keys(tracker.states).forEach(k => {
+          const topic = tracker.states[k];
+          if (
+            !data.payload.category_id ||
+            topic.category_id === parseInt(data.payload.category_id, 0)
+          ) {
+            tracker.states[k] = Object.assign({}, topic, {
+              last_seen_at: data.payload.last_seen_at
+            });
+          }
+        });
+        tracker.notifyPropertyChange("states");
+        tracker.incrementMessageCount();
       }
 
       if (["new_topic", "unread", "read"].includes(data.message_type)) {
@@ -215,7 +236,11 @@ const TopicTrackingState = EmberObject.extend({
 
       if (state) {
         const lastRead = t.get("last_read_post_number");
-        if (lastRead !== state.last_read_post_number) {
+        const lastSeenAt = t.get("last_seen_at");
+        if (
+          lastRead !== state.last_read_post_number ||
+          lastSeenAt !== state.last_seen_at
+        ) {
           const postsCount = t.get("posts_count");
           let newPosts = postsCount - state.highest_post_number,
             unread = postsCount - state.last_read_post_number;
@@ -235,7 +260,8 @@ const TopicTrackingState = EmberObject.extend({
             last_read_post_number: state.last_read_post_number,
             new_posts: newPosts,
             unread: unread,
-            unseen: !state.last_read_post_number
+            last_seen_at: state.last_seen_at,
+            unseen: !state.last_read_post_number && isUnseen(state)
           });
         }
       }

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -847,7 +847,6 @@ class TopicsController < ApplicationController
   end
 
   def reset_new
-    last_seen_at = Time.zone.now
     if params[:category_id].present?
       category_ids = [params[:category_id]]
       if params[:include_subcategories] == 'true'
@@ -858,12 +857,12 @@ class TopicsController < ApplicationController
           .category_users
           .where(category_id: category_id)
           .first_or_initialize
-          .update!(last_seen_at: last_seen_at)
-        TopicTrackingState.publish_dismiss_category(category_id, last_seen_at, current_user.id)
+          .update!(last_seen_at: Time.zone.now)
+        TopicTrackingState.publish_dismiss_new(current_user.id, category_id)
       end
     else
-      current_user.user_stat.update_column(:new_since, last_seen_at)
-      TopicTrackingState.publish_dismiss_new(last_seen_at, current_user.id)
+      current_user.user_stat.update_column(:new_since, Time.zone.now)
+      TopicTrackingState.publish_dismiss_new(current_user.id)
     end
     render body: nil
   end

--- a/app/models/topic_tracking_state.rb
+++ b/app/models/topic_tracking_state.rb
@@ -144,6 +144,27 @@ class TopicTrackingState
     MessageBus.publish(self.unread_channel_key(user_id), message.as_json, user_ids: [user_id])
   end
 
+  def self.publish_dismiss_category(category_id, last_seen_at, user_id)
+    message = {
+      message_type: "dismiss_category",
+      payload: {
+        category_id: category_id,
+        last_seen_at: last_seen_at
+      }
+    }
+    MessageBus.publish(self.unread_channel_key(user_id), message.as_json, user_ids: [user_id])
+  end
+
+  def self.publish_dismiss_new(last_seen_at, user_id)
+    message = {
+      message_type: "dismiss_new",
+      payload: {
+        last_seen_at: last_seen_at
+      }
+    }
+    MessageBus.publish(self.unread_channel_key(user_id), message.as_json, user_ids: [user_id])
+  end
+
   def self.treat_as_new_topic_clause
     User.where("GREATEST(CASE
                   WHEN COALESCE(uo.new_topic_duration_minutes, :default_duration) = :always THEN u.created_at

--- a/app/models/topic_tracking_state.rb
+++ b/app/models/topic_tracking_state.rb
@@ -144,23 +144,11 @@ class TopicTrackingState
     MessageBus.publish(self.unread_channel_key(user_id), message.as_json, user_ids: [user_id])
   end
 
-  def self.publish_dismiss_category(category_id, last_seen_at, user_id)
-    message = {
-      message_type: "dismiss_category",
-      payload: {
-        category_id: category_id,
-        last_seen_at: last_seen_at
-      }
-    }
-    MessageBus.publish(self.unread_channel_key(user_id), message.as_json, user_ids: [user_id])
-  end
-
-  def self.publish_dismiss_new(last_seen_at, user_id)
+  def self.publish_dismiss_new(user_id, category_id = nil)
+    payload = category_id ? { category_id: category_id } : {}
     message = {
       message_type: "dismiss_new",
-      payload: {
-        last_seen_at: last_seen_at
-      }
+      payload: payload
     }
     MessageBus.publish(self.unread_channel_key(user_id), message.as_json, user_ids: [user_id])
   end

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -2342,6 +2342,8 @@ RSpec.describe TopicsController do
 
       user.user_stat.update_column(:new_since, old_date)
 
+      TopicTrackingState.expects(:publish_dismiss_new)
+
       put "/topics/reset-new.json"
       expect(response.status).to eq(200)
       user.reload
@@ -2356,6 +2358,9 @@ RSpec.describe TopicsController do
         sign_in(user)
         category_user = CategoryUser.create!(category_id: category.id, user_id: user.id)
         subcategory_user = CategoryUser.create!(category_id: subcategory.id, user_id: user.id)
+
+        TopicTrackingState.expects(:publish_dismiss_category)
+
         put "/topics/reset-new.json?category_id=#{category.id}"
 
         expect(category_user.reload.last_seen_at).not_to be_nil

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -2342,7 +2342,7 @@ RSpec.describe TopicsController do
 
       user.user_stat.update_column(:new_since, old_date)
 
-      TopicTrackingState.expects(:publish_dismiss_new)
+      TopicTrackingState.expects(:publish_dismiss_new).with(user.id)
 
       put "/topics/reset-new.json"
       expect(response.status).to eq(200)
@@ -2359,7 +2359,7 @@ RSpec.describe TopicsController do
         category_user = CategoryUser.create!(category_id: category.id, user_id: user.id)
         subcategory_user = CategoryUser.create!(category_id: subcategory.id, user_id: user.id)
 
-        TopicTrackingState.expects(:publish_dismiss_category)
+        TopicTrackingState.expects(:publish_dismiss_new).with(user.id, category.id.to_s)
 
         put "/topics/reset-new.json?category_id=#{category.id}"
 


### PR DESCRIPTION
When the category is dismissed, `dismiss_new` message is sent to fronted to clean state.

In addition, I noticed that when old dismiss new button is clicked, no message is sent so I decided to kill two birds with one stone.

![Screencast-from-19-11-19-02_49_03](https://user-images.githubusercontent.com/72780/69110973-77c76480-0a7c-11ea-8974-0837cb086f29.gif)
