### PR TITLE
FIX: Abort CensoredWordsValidator early if censored_words_regexp nil

### DIFF
--- a/lib/validators/censored_words_validator.rb
+++ b/lib/validators/censored_words_validator.rb
@@ -2,8 +2,10 @@
 
 class CensoredWordsValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    if WordWatcher.words_for_action(:censor).present? && censored_words_regexp.present?
-      return if (censored_words = censor_words(value, censored_words_regexp)).blank?
+    words_regexp = censored_words_regexp
+    if WordWatcher.words_for_action(:censor).present? && !words_regexp.nil?
+      censored_words = censor_words(value, words_regexp)
+      return if censored_words.blank?
       record.errors.add(
         attribute,
         :contains_censored_words,
@@ -31,6 +33,6 @@ class CensoredWordsValidator < ActiveModel::EachValidator
   end
 
   def censored_words_regexp
-    @censored_words_regexp ||= WordWatcher.word_matcher_regexp :censor
+    WordWatcher.word_matcher_regexp :censor
   end
 end

--- a/lib/validators/censored_words_validator.rb
+++ b/lib/validators/censored_words_validator.rb
@@ -2,9 +2,11 @@
 
 class CensoredWordsValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    if WordWatcher.words_for_action(:censor).present? && (censored_words = censor_words(value, censored_words_regexp)).present?
+    if WordWatcher.words_for_action(:censor).present? && censored_words_regexp.present?
+      return if (censored_words = censor_words(value, censored_words_regexp)).blank?
       record.errors.add(
-        attribute, :contains_censored_words,
+        attribute,
+        :contains_censored_words,
         censored_words: join_censored_words(censored_words)
       )
     end
@@ -29,6 +31,6 @@ class CensoredWordsValidator < ActiveModel::EachValidator
   end
 
   def censored_words_regexp
-    WordWatcher.word_matcher_regexp :censor
+    @censored_words_regexp ||= WordWatcher.word_matcher_regexp :censor
   end
 end

--- a/spec/lib/validators/censored_words_validator_spec.rb
+++ b/spec/lib/validators/censored_words_validator_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe CensoredWordsValidator do
+  let(:value) { 'some new bad text' }
+  let(:record) { Fabricate(:post, raw: 'this is a test') }
+  let(:attribute) { :raw }
+
+  describe "#validate_each" do
+    context "when there are censored words for action" do
+      let!(:watched_word) { Fabricate(:watched_word, action: WatchedWord.actions[:censor], word: 'bad') }
+
+      context "when there is a nil word_matcher_regexp" do
+        before do
+          WordWatcher.stubs(:word_matcher_regexp).returns(nil)
+        end
+
+        it "adds no errors to the record" do
+          validate
+          expect(record.errors.empty?).to eq(true)
+        end
+      end
+
+      context "when there is word_matcher_regexp" do
+        context "when the new value does not contain the watched word" do
+          let(:value) { 'some new good text' }
+
+          it "adds no errors to the record" do
+            validate
+            expect(record.errors.empty?).to eq(true)
+          end
+        end
+
+        context "when the new value does contain the watched word" do
+          let(:value) { 'some new bad text' }
+
+          it "adds errors to the record" do
+            validate
+            expect(record.errors.empty?).to eq(false)
+          end
+        end
+      end
+    end
+  end
+
+  def validate
+    described_class.new(attributes: :test).validate_each(record, attribute, value)
+  end
+end


### PR DESCRIPTION
* Sometimes censored_words_regex can end up nil, erroring the validator. this handles the nil condition and also adds a spec for the validator