### PR TITLE
FIX: Use correct MIME type for theme exports

### DIFF
--- a/app/controllers/admin/themes_controller.rb
+++ b/app/controllers/admin/themes_controller.rb
@@ -248,7 +248,7 @@ class Admin::ThemesController < Admin::AdminController
     headers['Content-Length'] = File.size(file_path).to_s
     send_data File.read(file_path),
       filename: File.basename(file_path),
-      content_type: "application/x-gzip"
+      content_type: "application/zip"
   ensure
     exporter.cleanup!
   end


### PR DESCRIPTION
We use `ThemeStore::ZipExporter` which always exports a `.zip` archive. This fix is for some download managers that will change the file extension based on the `Content-Type`.