### PR TITLE
DEV: Move some autocomplete input styling to SCSS

### DIFF
--- a/app/assets/javascripts/discourse/lib/autocomplete.js.es6
+++ b/app/assets/javascripts/discourse/lib/autocomplete.js.es6
@@ -212,11 +212,9 @@ export default function(options) {
     }
 
     if (options.single && !options.width) {
-      this.css("width", "100%");
+      this.attr("class", `${this.attr("class")} fullwidth-input`);
     } else if (options.width) {
       this.css("width", options.width);
-    } else {
-      this.width(150);
     }
 
     this.attr(

--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -437,6 +437,9 @@ div.ac-wrap {
     margin: 0;
     background: transparent;
     min-height: unset;
+    &.fullwidth-input {
+      width: 100%;
+    }
   }
 }
 

--- a/app/assets/stylesheets/desktop/compose.scss
+++ b/app/assets/stylesheets/desktop/compose.scss
@@ -15,6 +15,10 @@
     width: 404px;
   }
 
+  .item + #private-message-users {
+    width: 150px;
+  }
+
   .select-kit.is-expanded {
     z-index: z("composer", "dropdown") + 1;
   }


### PR DESCRIPTION
This small refactor serves two purposes: 1) to have the composer "Add a user" autocomplete default to 100% of its container by default and shrink to 150px only after a user has been added and 2) to simplify overriding styling in themes. 