### PR TITLE
FIX: quotes are not needed and might be the source of a bug

### DIFF
--- a/plugins/discourse-local-dates/assets/javascripts/lib/discourse-markdown/discourse-local-dates.js.es6
+++ b/plugins/discourse-local-dates/assets/javascripts/lib/discourse-markdown/discourse-local-dates.js.es6
@@ -13,10 +13,12 @@ function addLocalDate(buffer, matches, state) {
     countdown: null
   };
 
+  const matchString = matches[1].replace(/„|“/g, '"');
+
   let parsed = parseBBCodeTag(
-    "[date date" + matches[1] + "]",
+    "[date date" + matchString + "]",
     0,
-    matches[1].length + 11
+    matchString.length + 11
   );
 
   config.date = parsed.attrs.date;

--- a/plugins/discourse-local-dates/spec/lib/pretty_text_spec.rb
+++ b/plugins/discourse-local-dates/spec/lib/pretty_text_spec.rb
@@ -80,4 +80,13 @@ describe PrettyText do
       expect(excerpt).to eq("Wednesday, October 16, 2019 6:00 PM (UTC)")
     end
   end
+
+  context 'german quotes' do
+    let(:post) { Fabricate(:post, raw: '[date=2019-10-16 time=14:00:00 format="LLLL" timezone=„America/New_York“]') }
+
+    it 'converts german quotes to regular quotes' do
+      excerpt = PrettyText.excerpt(post.cooked, 200)
+      expect(excerpt).to eq('Wednesday, October 16, 2019 6:00 PM (UTC)')
+    end
+  end
 end


### PR DESCRIPTION
https://meta.discourse.org/t/insert-date-timezone-is-always-utc-my-timezone-is-ignored/126307