### PR TITLE
FEATURE: New API to apply custom filters to the review queue

### DIFF
--- a/app/assets/javascripts/discourse/controllers/review-index.js.es6
+++ b/app/assets/javascripts/discourse/controllers/review-index.js.es6
@@ -11,7 +11,8 @@ export default Controller.extend({
     "username",
     "from_date",
     "to_date",
-    "sort_order"
+    "sort_order",
+    "additional_filters"
   ],
   type: null,
   status: "pending",
@@ -24,6 +25,7 @@ export default Controller.extend({
   from_date: null,
   to_date: null,
   sort_order: "priority",
+  additional_filters: null,
 
   init(...args) {
     this._super(...args);
@@ -118,8 +120,10 @@ export default Controller.extend({
         username: this.filterUsername,
         from_date: this.filterFromDate,
         to_date: this.filterToDate,
-        sort_order: this.filterSortOrder
+        sort_order: this.filterSortOrder,
+        additional_filters: JSON.stringify(this.additionalFilters)
       });
+
       this.send("refreshRoute");
     },
 

--- a/app/assets/javascripts/discourse/routes/review-index.js.es6
+++ b/app/assets/javascripts/discourse/routes/review-index.js.es6
@@ -25,7 +25,8 @@ export default DiscourseRoute.extend({
       filterUsername: meta.username,
       filterFromDate: meta.from_date,
       filterToDate: meta.to_date,
-      filterSortOrder: meta.sort_order
+      filterSortOrder: meta.sort_order,
+      additionalFilters: meta.additional_filters || {}
     });
   },
 

--- a/app/assets/javascripts/discourse/templates/review-index.hbs
+++ b/app/assets/javascripts/discourse/templates/review-index.hbs
@@ -24,7 +24,7 @@
 
     {{#if filtersExpanded}}
 
-      {{plugin-outlet name="above-review-filters" args=(hash model=model)}}
+      {{plugin-outlet name="above-review-filters" args=(hash model=model additionalFilters=additionalFilters)}}
 
       <div class='reviewable-filter'>
         <label class='filter-label'>{{i18n "review.filters.type.title"}}</label>

--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -663,6 +663,15 @@ class Plugin::Instance
     File.exists?(js_file_path)
   end
 
+  # Receives an array with two elements:
+  # 1. A symbol that represents the name of the value to filter.
+  # 2. A Proc that takes the existing ActiveRecord::Relation and the value received from the front-end.
+  def add_custom_reviewable_filter(filter)
+    reloadable_patch do
+      Reviewable.add_custom_filter(filter)
+    end
+  end
+
   protected
 
   def self.js_path

--- a/spec/models/reviewable_spec.rb
+++ b/spec/models/reviewable_spec.rb
@@ -435,4 +435,29 @@ RSpec.describe Reviewable, type: :model do
       expect(Reviewable.min_score_for_priority).to eq(45.6)
     end
   end
+
+  context "custom filters" do
+    after do
+      Reviewable.clear_custom_filters!
+    end
+
+    it 'correctly add a new filter' do
+      Reviewable.add_custom_filter([:assigned_to, Proc.new { |results, value| results }])
+
+      expect(Reviewable.custom_filters.size).to eq(1)
+    end
+
+    it 'applies the custom filter' do
+      admin = Fabricate(:admin)
+      first_reviewable = Fabricate(:reviewable)
+      second_reviewable = Fabricate(:reviewable)
+      custom_filter = [:target_id, Proc.new { |results, value| results.where(target_id: value) }]
+      Reviewable.add_custom_filter(custom_filter)
+
+      results = Reviewable.list_for(admin, additional_filters: { target_id: first_reviewable.target_id })
+
+      expect(results.size).to eq(1)
+      expect(results.first).to eq first_reviewable
+    end
+  end
 end


### PR DESCRIPTION
This PR adds a new API to include custom filters in the review queue. An example can be found [here](https://github.com/discourse/discourse-assign/pull/58).
