### PR TITLE
FIX: method names incorrect

### DIFF
--- a/app/assets/javascripts/select-kit/components/multi-select/multi-select-filter.js.es6
+++ b/app/assets/javascripts/select-kit/components/multi-select/multi-select-filter.js.es6
@@ -7,7 +7,7 @@ export default SelectKitFilterComponent.extend({
   classNames: ["multi-select-filter"],
 
   @discourseComputed("placeholder", "hasSelection")
-  discourseComputedPlaceholder(placeholder, hasSelection) {
+  computedPlaceholder(placeholder, hasSelection) {
     if (hasSelection) return "";
     return isEmpty(placeholder) ? "" : I18n.t(placeholder);
   }

--- a/app/assets/javascripts/select-kit/components/select-kit/select-kit-filter.js.es6
+++ b/app/assets/javascripts/select-kit/components/select-kit/select-kit-filter.js.es6
@@ -11,7 +11,7 @@ export default Component.extend({
   isHidden: not("shouldDisplayFilter"),
 
   @discourseComputed("placeholder")
-  discourseComputedPlaceholder(placeholder) {
+  computedPlaceholder(placeholder) {
     return isEmpty(placeholder) ? "" : I18n.t(placeholder);
   }
 });


### PR DESCRIPTION
The placeholder computed property is ``computedPlaceholder`` (see: https://github.com/discourse/discourse/blob/master/app/assets/javascripts/select-kit/templates/components/select-kit/select-kit-filter.hbs#L4). These methods may have been incorrectly named in a "replace all" of ``computed`` with ``discourseComputed``.