### PR TITLE
FIX: Always return secure_proxy_without_cdn url for secure media

### DIFF
--- a/lib/url_helper.rb
+++ b/lib/url_helper.rb
@@ -64,6 +64,11 @@ class UrlHelper
 
     url = secure ? secure_proxy_without_cdn(url) : absolute_without_cdn(url)
 
+    # we always want secure media to come from
+    # Discourse.base_url_no_prefix/secure-media-uploads
+    # to avoid asset_host mixups
+    return schemaless(url) if secure
+
     unless is_attachment && no_cdn
       url = Discourse.store.cdn_url(url)
       url = local_cdn_url(url) if Discourse.store.external?

--- a/spec/components/url_helper_spec.rb
+++ b/spec/components/url_helper_spec.rb
@@ -167,6 +167,10 @@ describe UrlHelper do
         )
       end
     end
+
+    after do
+      Rails.configuration.action_controller.asset_host = nil
+    end
   end
 
 end

--- a/spec/components/url_helper_spec.rb
+++ b/spec/components/url_helper_spec.rb
@@ -131,4 +131,42 @@ describe UrlHelper do
     end
   end
 
+  describe "#cook_url" do
+    let(:url) { "//s3bucket.s3.dualstack.us-east-1.amazonaws.com/dev/original/3X/2/e/2e6f2ef81b6910ea592cd6d21ee897cd51cf72e4.jpeg" }
+
+    before do
+      FileStore::S3Store.any_instance.stubs(:has_been_uploaded?).returns(true)
+      Rails.configuration.action_controller.asset_host = "https://test.some-cdn.com/dev"
+      SiteSetting.enable_s3_uploads = true
+      SiteSetting.s3_upload_bucket = "s3bucket"
+      SiteSetting.s3_access_key_id = "s3_access_key_id"
+      SiteSetting.s3_secret_access_key = "s3_secret_access_key"
+      SiteSetting.login_required = true
+    end
+
+    def cooked
+      UrlHelper.cook_url(url, secure: secure)
+    end
+
+    context "when the upload for the url is secure" do
+      let(:secure) { true }
+
+      it "returns the secure_proxy_without_cdn url, with no asset host URL change" do
+        expect(cooked).to eq(
+          "//test.localhost/secure-media-uploads/dev/original/3X/2/e/2e6f2ef81b6910ea592cd6d21ee897cd51cf72e4.jpeg"
+        )
+      end
+    end
+
+    context "when the upload for the url is not secure" do
+      let(:secure) { false }
+
+      it "returns the local_cdn_url" do
+        expect(cooked).to eq(
+          "//s3bucket.s3.dualstack.us-east-1.amazonaws.com/dev/original/3X/2/e/2e6f2ef81b6910ea592cd6d21ee897cd51cf72e4.jpeg"
+        )
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
There was an issue on dev where when uploading secure media, the href of the media was correctly being replaced in the `CookedPostProcessor`, but the srcset urls were not being replaced correctly. This is because UrlHelper.cook_url was returning the asset host URL for the media for secure media instead of returning early with the proxied secure proxy url.