### PR TITLE
FIX: prevents timezone to show duplicated zones in preview

### DIFF
--- a/plugins/discourse-local-dates/assets/javascripts/discourse-local-dates.js.no-module.es6
+++ b/plugins/discourse-local-dates/assets/javascripts/discourse-local-dates.js.no-module.es6
@@ -125,6 +125,10 @@
   }
 
   function _isEqualZones(timezoneA, timezoneB) {
+    if (timezoneA.includes(timezoneB) || timezoneB.includes(timezoneA)) {
+      return true;
+    }
+
     return (
       moment.tz(timezoneA).utcOffset() === moment.tz(timezoneB).utcOffset()
     );
@@ -222,7 +226,9 @@
     const previewedTimezones = [];
     const watchingUserTimezone = moment.tz.guess();
     const timezones = options.timezones.filter(
-      timezone => timezone !== watchingUserTimezone
+      timezone =>
+        !_isEqualZones(timezone, watchingUserTimezone) &&
+        !_isEqualZones(timezone, options.timezone)
     );
 
     previewedTimezones.push({
@@ -244,26 +250,24 @@
       timezones.unshift(options.timezone);
     }
 
-    timezones
-      .filter(z => z)
-      .forEach(timezone => {
-        if (_isEqualZones(timezone, displayedTimezone)) {
-          return;
-        }
+    timezones.filter(Boolean).forEach(timezone => {
+      if (_isEqualZones(timezone, displayedTimezone)) {
+        return;
+      }
 
-        if (_isEqualZones(timezone, watchingUserTimezone)) {
-          timezone = watchingUserTimezone;
-        }
+      if (_isEqualZones(timezone, watchingUserTimezone)) {
+        timezone = watchingUserTimezone;
+      }
 
-        previewedTimezones.push({
-          timezone,
-          dateTime: options.time
-            ? moment(dateTime)
-                .tz(timezone)
-                .format("LLL")
-            : _createDateTimeRange(dateTime, timezone)
-        });
+      previewedTimezones.push({
+        timezone,
+        dateTime: options.time
+          ? moment(dateTime)
+              .tz(timezone)
+              .format("LLL")
+          : _createDateTimeRange(dateTime, timezone)
       });
+    });
 
     if (!previewedTimezones.length) {
       previewedTimezones.push({


### PR DESCRIPTION
It could happen if you have Etc/UTC in default settings, and timezone="UTC" on date, the equality check is now more strict.