### PR TITLE
Changed order of flags_given_received_count in de translation

### DIFF
--- a/config/locales/client.de.yml
+++ b/config/locales/client.de.yml
@@ -3825,7 +3825,7 @@ de:
         flags_given_count: Gemachte Meldungen
         flags_received_count: Erhaltene Meldungen
         warnings_received_count: Warnungen erhalten
-        flags_given_received_count: "Erhaltene / gemachte Meldungen"
+        flags_given_received_count: "Gemachte / erhaltene Meldungen"
         approve: "Genehmigen"
         approved_by: "genehmigt von"
         approve_success: "Benutzer wurde genehmigt und eine E-Mail mit Anweisungen zur Aktivierung wurde gesendet."


### PR DESCRIPTION
The translation is shown alongside the counter. In English it is translated as "given / received", so the words correspond to the order of the numbers. The order of the German words is swapped.