### PR TITLE
UX: Rename 'Hide results' to 'Show vote' in polls

### DIFF
--- a/plugins/poll/config/locales/client.en.yml
+++ b/plugins/poll/config/locales/client.en.yml
@@ -61,7 +61,7 @@ en:
 
       hide-results:
         title: "Back to your votes"
-        label: "Hide results"
+        label: "Show vote"
 
       export-results:
         title: "Export the poll results"


### PR DESCRIPTION
For various reasons, users may want to change their response to a poll.
Currently they have permission to do so, however it is hidden behind the 'Hide
results' button. Since what this button does is take the user back to the vote
panel, it seems more appropriate to name it 'Show vote', where it becomes
obvious that it can be modified and re-submitted.

As discussed here [1], there are mulitple users, myself included, who assumed
that editing a misclick response was impossible. This improves the label to make
it more descriptive of the action actually being taken.

[1] https://meta.discourse.org/t/ability-to-remove-my-choice-in-a-poll/53642/6