### PR TITLE
FIX: Replace %20 with space in markdown file name for uploads

### DIFF
--- a/app/assets/javascripts/discourse/lib/uploads.js.es6
+++ b/app/assets/javascripts/discourse/lib/uploads.js.es6
@@ -14,7 +14,7 @@ function imageNameFromFileName(fileName) {
     name = I18n.t("upload_selector.default_image_alt_text");
   }
 
-  return encodeURIComponent(name);
+  return encodeURIComponent(name).replace(/%20/g, " ");
 }
 
 export function validateUploadedFiles(files, opts) {

--- a/test/javascripts/lib/uploads-test.js.es6
+++ b/test/javascripts/lib/uploads-test.js.es6
@@ -200,6 +200,10 @@ QUnit.test("getUploadMarkdown", assert => {
     testUploadMarkdown("[foo|bar].png"),
     "![%5Bfoo%7Cbar%5D|100x200](/uploads/123/abcdef.ext)"
   );
+  assert.equal(
+    testUploadMarkdown("file name with space.png"),
+    "![file name with space|100x200](/uploads/123/abcdef.ext)"
+  );
 
   const short_url = "uploads://asdaasd.ext";
 


### PR DESCRIPTION
Meta: https://meta.discourse.org/t/image-name-has-20-in-file-name/134136

We were ending up with `[file%20name](url)` in the markdown preview, which looked weird and 
affected the alt text. this is because we were calling encodeURIComponent, which has been left in place because this is a valid thing to do for some cases. (e.g. https://github.com/discourse/discourse/commit/f674b9e86ee609cef538168661f8719e8572ca13)