### PR TITLE
FIX: Mark secure media upload insecure automatically if used for theme component

### DIFF
--- a/app/assets/javascripts/admin/controllers/modals/admin-add-upload.js.es6
+++ b/app/assets/javascripts/admin/controllers/modals/admin-add-upload.js.es6
@@ -4,7 +4,6 @@ import { inject } from "@ember/controller";
 import Controller from "@ember/controller";
 import ModalFunctionality from "discourse/mixins/modal-functionality";
 import { ajax } from "discourse/lib/ajax";
-import showModal from "discourse/lib/show-modal";
 import {
   default as discourseComputed,
   observes
@@ -127,24 +126,13 @@ export default Controller.extend(ModalFunctionality, {
       };
 
       options.data.append("file", file);
-      this.send("postUpload", options);
-    },
-
-    postUpload(options, markUploadInsecure = false) {
-      if (markUploadInsecure) {
-        options.data.append("mark_upload_insecure", true);
-      }
 
       ajax(this.uploadUrl, options)
         .then(result => {
-          if (result.prompt_mark_insecure) {
-            return this.send("promptMarkUploadInsecure", options);
-          }
-
           const upload = {
             upload_id: result.upload_id,
             name: this.name,
-            original_filename: options.data.get("file").name
+            original_filename: file.name
           };
           this.adminCustomizeThemesShow.send("addUpload", upload);
           this.send("closeModal");
@@ -152,21 +140,6 @@ export default Controller.extend(ModalFunctionality, {
         .catch(e => {
           popupAjaxError(e);
         });
-    },
-
-    promptMarkUploadInsecure(uploadAjaxOptions) {
-      this.send("closeModal");
-      return bootbox.confirm(
-        I18n.t("uploads.prompt_mark_insecure"),
-        I18n.t("uploads.no_leave_secure"),
-        I18n.t("uploads.yes_mark_insecure"),
-        result => {
-          if (result) {
-            return this.send("postUpload", uploadAjaxOptions, true);
-          }
-          showModal("admin-add-upload", { admin: true, name: "" });
-        }
-      );
     }
   }
 });

--- a/app/assets/javascripts/admin/controllers/modals/admin-add-upload.js.es6
+++ b/app/assets/javascripts/admin/controllers/modals/admin-add-upload.js.es6
@@ -4,6 +4,7 @@ import { inject } from "@ember/controller";
 import Controller from "@ember/controller";
 import ModalFunctionality from "discourse/mixins/modal-functionality";
 import { ajax } from "discourse/lib/ajax";
+import showModal from "discourse/lib/show-modal";
 import {
   default as discourseComputed,
   observes
@@ -126,13 +127,24 @@ export default Controller.extend(ModalFunctionality, {
       };
 
       options.data.append("file", file);
+      this.send("postUpload", options);
+    },
+
+    postUpload(options, markUploadInsecure = false) {
+      if (markUploadInsecure) {
+        options.data.append("mark_upload_insecure", true);
+      }
 
       ajax(this.uploadUrl, options)
         .then(result => {
+          if (result.prompt_mark_insecure) {
+            return this.send("promptMarkUploadInsecure", options);
+          }
+
           const upload = {
             upload_id: result.upload_id,
             name: this.name,
-            original_filename: file.name
+            original_filename: options.data.get("file").name
           };
           this.adminCustomizeThemesShow.send("addUpload", upload);
           this.send("closeModal");
@@ -140,6 +152,21 @@ export default Controller.extend(ModalFunctionality, {
         .catch(e => {
           popupAjaxError(e);
         });
+    },
+
+    promptMarkUploadInsecure(uploadAjaxOptions) {
+      this.send("closeModal");
+      return bootbox.confirm(
+        I18n.t("uploads.prompt_mark_insecure"),
+        I18n.t("uploads.no_leave_secure"),
+        I18n.t("uploads.yes_mark_insecure"),
+        result => {
+          if (result) {
+            return this.send("postUpload", uploadAjaxOptions, true);
+          }
+          showModal("admin-add-upload", { admin: true, name: "" });
+        }
+      );
     }
   }
 });

--- a/app/controllers/admin/themes_controller.rb
+++ b/app/controllers/admin/themes_controller.rb
@@ -42,6 +42,7 @@ class Admin::ThemesController < Admin::AdminController
       upload_id: upload.id,
       new_value: false
     )
+    Jobs.enqueue(:rebake_posts_for_upload, id: upload.id)
   end
 
   def generate_key_pair

--- a/app/controllers/admin/themes_controller.rb
+++ b/app/controllers/admin/themes_controller.rb
@@ -33,7 +33,7 @@ class Admin::ThemesController < Admin::AdminController
   end
 
   def mark_upload_insecure(upload)
-    upload.update_secure_status(secure_override: false)
+    upload.update_secure_status(secure_override_value: false)
     StaffActionLogger.new(current_user).log_change_upload_secure_status(
       upload_id: upload.id,
       new_value: false

--- a/app/controllers/admin/themes_controller.rb
+++ b/app/controllers/admin/themes_controller.rb
@@ -23,13 +23,9 @@ class Admin::ThemesController < Admin::AdminController
         if upload.errors.count > 0
           render_json_error upload
         else
-          if upload.secure?
-            if params[:mark_upload_insecure].blank?
-              return render json: { upload_id: upload.id, prompt_mark_insecure: true }, status: :accepted
-            else
-              mark_upload_insecure(upload)
-            end
-          end
+          # we assume a user intends to make some media public
+          # if they are uploading it to a theme component
+          mark_upload_insecure(upload) if upload.secure?
           render json: { upload_id: upload.id }, status: :created
         end
       end

--- a/app/jobs/regular/rebake_posts_for_upload.rb
+++ b/app/jobs/regular/rebake_posts_for_upload.rb
@@ -3,7 +3,9 @@
 module Jobs
   class RebakePostsForUpload < ::Jobs::Base
     def execute(args)
-      Upload.find(args[:id]).posts.find_each(&:rebake!)
+      upload = Upload.find_by(id: args[:id])
+      return if upload.blank?
+      upload.posts.find_each(&:rebake!)
     end
   end
 end

--- a/app/jobs/regular/rebake_posts_for_upload.rb
+++ b/app/jobs/regular/rebake_posts_for_upload.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Jobs
+  class RebakePostsForUpload < ::Jobs::Base
+    def execute(args)
+      Upload.find(args[:id]).posts.find_each(&:rebake!)
+    end
+  end
+end

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -230,9 +230,9 @@ class Upload < ActiveRecord::Base
     self.posts.where("cooked LIKE '%/_optimized/%'").find_each(&:rebake!)
   end
 
-  def update_secure_status
+  def update_secure_status(secure_override: nil)
     return false if self.for_theme || self.for_site_setting
-    mark_secure = should_be_secure?
+    mark_secure = secure_override.nil? ? should_be_secure? : secure_override
 
     self.update_column("secure", mark_secure)
     Discourse.store.update_upload_ACL(self) if Discourse.store.external?

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -230,9 +230,9 @@ class Upload < ActiveRecord::Base
     self.posts.where("cooked LIKE '%/_optimized/%'").find_each(&:rebake!)
   end
 
-  def update_secure_status(secure_override: nil)
+  def update_secure_status(secure_override_value: nil)
     return false if self.for_theme || self.for_site_setting
-    mark_secure = secure_override.nil? ? should_be_secure? : secure_override
+    mark_secure = secure_override_value.nil? ? should_be_secure? : secure_override_value
 
     self.update_column("secure", mark_secure)
     Discourse.store.update_upload_ACL(self) if Discourse.store.external?

--- a/app/models/user_history.rb
+++ b/app/models/user_history.rb
@@ -102,7 +102,8 @@ class UserHistory < ActiveRecord::Base
       api_key_update: 81,
       api_key_destroy: 82,
       revoke_title: 83,
-      change_title: 84
+      change_title: 84,
+      override_upload_secure_status: 85
     )
   end
 
@@ -181,7 +182,8 @@ class UserHistory < ActiveRecord::Base
       :change_title,
       :api_key_create,
       :api_key_update,
-      :api_key_destroy
+      :api_key_destroy,
+      :override_upload_secure_status
     ]
   end
 

--- a/app/services/staff_action_logger.rb
+++ b/app/services/staff_action_logger.rb
@@ -373,6 +373,17 @@ class StaffActionLogger
     ))
   end
 
+  def log_change_upload_secure_status(opts = {})
+    UserHistory.create!(params(opts).merge(
+      action: UserHistory.actions[:override_upload_secure_status],
+      details: [
+        "upload_id: #{opts[:upload_id]}",
+        "reason: #{I18n.t("uploads.marked_insecure_from_theme_component_reason")}"
+      ].join("\n"),
+      new_value: opts[:new_value]
+    ))
+  end
+
   def log_check_email(user, opts = {})
     raise Discourse::InvalidParameters.new(:user) unless user
     UserHistory.create!(params(opts).merge(

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2396,11 +2396,6 @@ en:
         one: "(topic withdrawn by author, will be automatically deleted in %{count} hour unless flagged)"
         other: "(topic withdrawn by author, will be automatically deleted in %{count} hours unless flagged)"
 
-    uploads:
-      prompt_mark_insecure: "This media file was already uploaded in a secure context. Would you like to mark the media as not secure? This will enable public access to the file if the URL for the file is known."
-      yes_mark_insecure: "Yes, mark upload as not secure"
-      no_leave_secure: "No, leave upload secure"
-
     post:
       quote_reply: "Quote"
       edit_reason: "Reason: "

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2396,6 +2396,11 @@ en:
         one: "(topic withdrawn by author, will be automatically deleted in %{count} hour unless flagged)"
         other: "(topic withdrawn by author, will be automatically deleted in %{count} hours unless flagged)"
 
+    uploads:
+      prompt_mark_insecure: "This media file was already uploaded in a secure context. Would you like to mark the media as not secure? This will enable public access to the file if the URL for the file is known."
+      yes_mark_insecure: "Yes, mark upload as not secure"
+      no_leave_secure: "No, leave upload secure"
+
     post:
       quote_reply: "Quote"
       edit_reason: "Reason: "
@@ -3936,6 +3941,7 @@ en:
             api_key_create: "api key create"
             api_key_update: "api key update"
             api_key_destroy: "api key destroy"
+            override_upload_secure_status: "override upload secure status"
         screened_emails:
           title: "Screened Emails"
           description: "When someone tries to create a new account, the following email addresses will be checked and the registration will be blocked, or some other action performed."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -971,6 +971,9 @@ en:
     topic_description: "To re-subscribe to %{link}, use the notification control at the bottom or right of the topic."
     private_topic_description: "To re-subscribe, use the notification control at the bottom or right of the topic."
 
+  uploads:
+    marked_insecure_from_theme_component_reason: "upload used in theme component"
+
   unsubscribe:
     title: "Unsubscribe"
     stop_watching_topic: "Stop watching this topic, %{link}"

--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -289,14 +289,14 @@ describe Upload do
   end
 
   describe '.update_secure_status' do
-    it "respects the secure_override parameter if provided" do
+    it "respects the secure_override_value parameter if provided" do
       upload.update!(secure: true)
 
-      upload.update_secure_status(secure_override: true)
+      upload.update_secure_status(secure_override_value: true)
 
       expect(upload.secure).to eq(true)
 
-      upload.update_secure_status(secure_override: false)
+      upload.update_secure_status(secure_override_value: false)
 
       expect(upload.secure).to eq(false)
     end

--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -289,6 +289,18 @@ describe Upload do
   end
 
   describe '.update_secure_status' do
+    it "respects the secure_override parameter if provided" do
+      upload.update!(secure: true)
+
+      upload.update_secure_status(secure_override: true)
+
+      expect(upload.secure).to eq(true)
+
+      upload.update_secure_status(secure_override: false)
+
+      expect(upload.secure).to eq(false)
+    end
+
     it 'marks a local upload as not secure with default settings' do
       upload.update!(secure: true)
       expect { upload.update_secure_status }

--- a/spec/requests/admin/themes_controller_spec.rb
+++ b/spec/requests/admin/themes_controller_spec.rb
@@ -53,29 +53,18 @@ describe Admin::ThemesController do
           upload.rewind
         end
 
-        context "when mark_upload_insecure param is blank" do
-          it "returns a response with prompt_mark_insecure" do
-            post "/admin/themes/upload_asset.json", params: { file: upload }
-            expect(response.status).to eq(202)
-            expect(response_json["upload_id"]).to eq(uploaded_file.id)
-            expect(response_json["prompt_mark_insecure"]).to eq(true)
-          end
+        it "marks the upload as not secure" do
+          post "/admin/themes/upload_asset.json", params: { file: upload }
+          expect(response.status).to eq(201)
+          expect(response_json["upload_id"]).to eq(uploaded_file.id)
+          uploaded_file.reload
+          expect(uploaded_file.secure).to eq(false)
         end
 
-        context "when mark_upload_insecure param is true" do
-          it "marks the upload as not secure" do
-            post "/admin/themes/upload_asset.json", params: { file: upload, mark_upload_insecure: true }
-            expect(response.status).to eq(201)
-            expect(response_json["upload_id"]).to eq(uploaded_file.id)
-            uploaded_file.reload
-            expect(uploaded_file.secure).to eq(false)
-          end
-
-          it "enqueues a job to rebake the posts for the upload" do
-            Jobs.expects(:enqueue).with(:rebake_posts_for_upload, id: uploaded_file.id)
-            post "/admin/themes/upload_asset.json", params: { file: upload, mark_upload_insecure: true }
-            expect(response.status).to eq(201)
-          end
+        it "enqueues a job to rebake the posts for the upload" do
+          Jobs.expects(:enqueue).with(:rebake_posts_for_upload, id: uploaded_file.id)
+          post "/admin/themes/upload_asset.json", params: { file: upload }
+          expect(response.status).to eq(201)
         end
       end
     end

--- a/spec/requests/admin/themes_controller_spec.rb
+++ b/spec/requests/admin/themes_controller_spec.rb
@@ -49,7 +49,7 @@ describe Admin::ThemesController do
 
       context "if the file is secure media" do
         before do
-          uploaded_file.update_secure_status(secure_override: true)
+          uploaded_file.update_secure_status(secure_override_value: true)
           upload.rewind
         end
 

--- a/spec/requests/admin/themes_controller_spec.rb
+++ b/spec/requests/admin/themes_controller_spec.rb
@@ -70,6 +70,12 @@ describe Admin::ThemesController do
             uploaded_file.reload
             expect(uploaded_file.secure).to eq(false)
           end
+
+          it "enqueues a job to rebake the posts for the upload" do
+            Jobs.expects(:enqueue).with(:rebake_posts_for_upload, id: uploaded_file.id)
+            post "/admin/themes/upload_asset.json", params: { file: upload, mark_upload_insecure: true }
+            expect(response.status).to eq(201)
+          end
         end
       end
     end


### PR DESCRIPTION
When uploading a file to a theme component, and that file is existing and has already been marked as secure, we now automatically mark the file as `secure: false`, change the ACL, and log the action as the user.