### PR TITLE
FIX: oneboxer.js infinitely retrying failed requests

### DIFF
--- a/app/assets/javascripts/pretty-text/oneboxer.js.es6
+++ b/app/assets/javascripts/pretty-text/oneboxer.js.es6
@@ -86,7 +86,7 @@ function loadNext(ajax) {
           removeLoading = false;
           loadingQueue.unshift({ url, refresh, $elem, categoryId, topicId });
         } else {
-          setFailedCache[normalize(url)] = true;
+          setFailedCache(normalize(url), true);
         }
       }
     )


### PR DESCRIPTION
When we encountered a 404 or other issue when oneboxing a URL, we kept retrying it ad infinitum which can cause DDOS issues. The fix in oneboxer.js was simple:

* setFailedCache was used like a variable object, when it was in fact a function

At some point the API must have changed and not all places were updated.