### PR TITLE
UX: adds hover effect on lightboxed images

### DIFF
--- a/app/assets/stylesheets/common/base/lightbox.scss
+++ b/app/assets/stylesheets/common/base/lightbox.scss
@@ -72,3 +72,15 @@ $meta-element-margin: 6px;
 .mfp-preloader .spinner {
   margin: auto;
 }
+
+@if is-light-color-scheme() {
+  a.lightbox {
+    -webkit-transition: all 0.6s cubic-bezier(0.165, 0.84, 0.44, 1);
+    transition: all 0.6s cubic-bezier(0.165, 0.84, 0.44, 1);
+  }
+
+  a.lightbox:hover {
+    border-radius: 5px;
+    box-shadow: 0 2px 5px 0 rgba($primary, 0.2), 0 2px 10px 0 rgba($primary, 0.2);
+  }
+}

--- a/app/assets/stylesheets/common/base/lightbox.scss
+++ b/app/assets/stylesheets/common/base/lightbox.scss
@@ -81,6 +81,7 @@ $meta-element-margin: 6px;
 
   a.lightbox:hover {
     border-radius: 5px;
-    box-shadow: 0 2px 5px 0 rgba($primary, 0.2), 0 2px 10px 0 rgba($primary, 0.2);
+    box-shadow: 0 2px 5px 0 rgba($primary, 0.2),
+      0 2px 10px 0 rgba($primary, 0.2);
   }
 }

--- a/app/assets/stylesheets/common/foundation/variables.scss
+++ b/app/assets/stylesheets/common/foundation/variables.scss
@@ -198,11 +198,23 @@ $box-shadow: (
   }
 }
 @function dark-light-choose($light-theme-result, $dark-theme-result) {
-  @if dc-color-brightness($primary) < dc-color-brightness($secondary) {
+  @if is-light-color-scheme() {
     @return $light-theme-result;
   } @else {
     @return $dark-theme-result;
   }
+}
+
+@function is-light-color-scheme() {
+  @if dc-color-brightness($primary) < dc-color-brightness($secondary) {
+    @return true;
+  } @else {
+    @return false;
+  }
+}
+
+@function is-dark-color-scheme() {
+  @return not is-light-color-scheme();
 }
 
 @import "color_transformations";


### PR DESCRIPTION
This commits also adds two scss functions:

- is-light-color-scheme()
- is-dark-color-scheme()

This hover effect won't be added on dark color schemes, as images already standout nicely on dark backgrounds.

Co-Authored-By: David Taylor <david@taylorhq.com>