### PR TITLE
FIX: check default locale when rtl_enabled method called without a user

### DIFF
--- a/lib/rtl.rb
+++ b/lib/rtl.rb
@@ -13,7 +13,7 @@ class Rtl
   end
 
   def current_user_rtl?
-    SiteSetting.allow_user_locale && user.try(:locale).in?(rtl_locales)
+    SiteSetting.allow_user_locale && (user&.locale || SiteSetting.default_locale).in?(rtl_locales)
   end
 
   def site_locale_rtl?


### PR DESCRIPTION
Checks `SiteSetting.default_locale` if `user&.locale` returns a false value.