### PR TITLE
FIX: Move upload secure ACL change to CookedPostProcessor

### DIFF
--- a/lib/cooked_post_processor.rb
+++ b/lib/cooked_post_processor.rb
@@ -38,6 +38,7 @@ class CookedPostProcessor
       post_process_oneboxes
       post_process_images
       post_process_quotes
+      update_uploads_secure_status
       optimize_urls
       remove_user_ids
       update_post_image
@@ -47,6 +48,12 @@ class CookedPostProcessor
       @post.link_post_uploads(fragments: @doc)
       DiscourseEvent.trigger(:post_process_cooked, @doc, @post)
       nil
+    end
+  end
+
+  def update_uploads_secure_status
+    if SiteSetting.secure_media? || SiteSetting.prevent_anons_from_downloading_files?
+      @post.update_uploads_secure_status
     end
   end
 

--- a/lib/post_creator.rb
+++ b/lib/post_creator.rb
@@ -178,7 +178,6 @@ class PostCreator
         update_user_counts
         create_embedded_topic
         link_post_uploads
-        update_uploads_secure_status
         ensure_in_allowed_users if guardian.is_staff?
         unarchive_message
         if !@opts[:import_mode]
@@ -377,12 +376,6 @@ class PostCreator
     if disallowed_uploads.is_a? Array
       @post.errors.add(:base, I18n.t('secure_upload_not_allowed_in_public_topic', upload_filenames: disallowed_uploads.join(", ")))
       rollback_from_errors!(@post)
-    end
-  end
-
-  def update_uploads_secure_status
-    if SiteSetting.secure_media? || SiteSetting.prevent_anons_from_downloading_files?
-      @post.update_uploads_secure_status
     end
   end
 


### PR DESCRIPTION
This is to avoid a race condition which caused log message errors when we were trying to set the ACL for the optimized images to private before the files were even created in S3