### PR TITLE
FIX: oneboxer.js infinitely retrying failed requests (#8414)

### DIFF
--- a/app/assets/javascripts/pretty-text/oneboxer.js.es6
+++ b/app/assets/javascripts/pretty-text/oneboxer.js.es6
@@ -77,7 +77,7 @@ function loadNext(ajax) {
           removeLoading = false;
           loadingQueue.unshift({ url, refresh, $elem, categoryId, topicId });
         } else {
-          failedCache[normalize(url)] = true;
+          setFailedCache(normalize(url), true);
         }
       }
     )


### PR DESCRIPTION
* setFailedCache was used like a variable object, when it was in fact a function