### PR TITLE
FIX: adds data-topic-id to quick-access-item

### DIFF
--- a/app/assets/javascripts/discourse/widgets/quick-access-item.js.es6
+++ b/app/assets/javascripts/discourse/widgets/quick-access-item.js.es6
@@ -33,11 +33,19 @@ createWidget("quick-access-item", {
     return result;
   },
 
-  html({ icon, href }) {
+  html({ href, icon }) {
+    let content = this._contentHtml();
+
+    let topicId = href.match(/\/t\/.*?\/(\d+)/);
+    if (topicId && topicId[1]) {
+      topicId = escapeExpression(topicId[1]);
+      content = `<span data-topic-id="${topicId}">${content}</span>`;
+    }
+
     return h("a", { attributes: { href } }, [
       iconNode(icon),
       new RawHtml({
-        html: `<div>${this._usernameHtml()}${this._contentHtml()}</div>`
+        html: `<div>${this._usernameHtml()}${content}</div>`
       })
     ]);
   },


### PR DESCRIPTION
This fix will allow discourse-encrypt to decrypt messages titles of the quick-access-pannel for PMs