### PR TITLE
FIX: Do not start the login flow when logging out from SSO/Authenticator

### DIFF
--- a/app/assets/javascripts/discourse/lib/logout.js.es6
+++ b/app/assets/javascripts/discourse/lib/logout.js.es6
@@ -1,4 +1,6 @@
 import { isEmpty } from "@ember/utils";
+import { findAll } from "discourse/models/login-method";
+
 export default function logout(siteSettings, keyValueStore) {
   if (!siteSettings || !keyValueStore) {
     const container = Discourse.__container__;
@@ -9,9 +11,21 @@ export default function logout(siteSettings, keyValueStore) {
   keyValueStore.abandonLocal();
 
   const redirect = siteSettings.logout_redirect;
-  if (isEmpty(redirect)) {
-    window.location = Discourse.getURL("/");
-  } else {
+  if (!isEmpty(redirect)) {
     window.location.href = redirect;
+    return;
   }
+
+  const isSso = siteSettings.enable_sso;
+  const isOneAuthenticator =
+    !siteSettings.enable_local_logins && findAll().length === 1;
+
+  if (siteSettings.login_required && (isSso || isOneAuthenticator)) {
+    // In this situation visiting most URLs will start the auth process again
+    // Go to the `/login` page to avoid an immediate redirect
+    window.location.href = Discourse.getURL("/login");
+    return;
+  }
+
+  window.location.href = Discourse.getURL("/");
 }

--- a/app/assets/javascripts/discourse/lib/logout.js.es6
+++ b/app/assets/javascripts/discourse/lib/logout.js.es6
@@ -16,11 +16,11 @@ export default function logout(siteSettings, keyValueStore) {
     return;
   }
 
-  const isSso = siteSettings.enable_sso;
-  const isOneAuthenticator =
+  const sso = siteSettings.enable_sso;
+  const oneAuthenticator =
     !siteSettings.enable_local_logins && findAll().length === 1;
 
-  if (siteSettings.login_required && (isSso || isOneAuthenticator)) {
+  if (siteSettings.login_required && (sso || oneAuthenticator)) {
     // In this situation visiting most URLs will start the auth process again
     // Go to the `/login` page to avoid an immediate redirect
     window.location.href = Discourse.getURL("/login");


### PR DESCRIPTION
This affects login_required sites which use SSO or have only one authenticator enabled. Previously, logging out would redirect to the homepage, which would then redirect to the identity provider. Now, users will be redirected to the Discourse login page. This avoids the confusing situation where a user appears to remain logged in after clicking logout.

Sites which have explicitly defined a logout_redirect url are not affected by this change.

For context, see https://meta.discourse.org/t/134138/2