### PR TITLE
FIX: Guarantee order to correctly defer replies

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -335,7 +335,7 @@ class PostsController < ApplicationController
     params.require(:post_ids)
     agree_with_first_reply_flag = (params[:agree_with_first_reply_flag] || true).to_s == "true"
 
-    posts = Post.where(id: post_ids_including_replies)
+    posts = Post.where(id: post_ids_including_replies).order(:id)
     raise Discourse::InvalidParameters.new(:post_ids) if posts.blank?
 
     # Make sure we can delete the posts


### PR DESCRIPTION
From the [Postgres docs](https://www.postgresql.org/docs/current/queries-order.html):

> After a query has produced an output table (after the select list has been processed) it can optionally be sorted. If sorting is not chosen, the rows will be returned in an unspecified order. The actual order in that case will depend on the scan and join plan types and the order on disk, but it must not be relied on. A particular output ordering can only be guaranteed if the sort step is explicitly chosen.

The query produced before this change was:

```sql
SELECT "posts".* FROM "posts" WHERE ("posts"."deleted_at" IS NULL) AND "posts"."id" IN (10, 12)
```

Our code will approve the first flagged post and ignore the rest. Since the order is not guaranteed, sometimes a child is approved instead of the father.