### PR TITLE
FIX: Make sure the suspended status is up to date

### DIFF
--- a/app/serializers/admin_user_list_serializer.rb
+++ b/app/serializers/admin_user_list_serializer.rb
@@ -23,7 +23,6 @@ class AdminUserListSerializer < BasicUserSerializer
              :approved,
              :suspended_at,
              :suspended_till,
-             :suspended,
              :silenced,
              :silenced_till,
              :time_read,
@@ -60,10 +59,6 @@ class AdminUserListSerializer < BasicUserSerializer
 
   def include_silenced_till?
     object.silenced_till?
-  end
-
-  def suspended
-    object.suspended?
   end
 
   def include_suspended_at?


### PR DESCRIPTION
Continuation of #8206

The returned `suspend` attribute was overwriting a computed property, which made the user admin page go out of sync.

Fixes a computed-property.override deprecation (https://emberjs.com/deprecations/v3.x#toc_computed-property-override)