### PR TITLE
UX: show group full name even when title is same.

### DIFF
--- a/app/assets/javascripts/discourse/components/groups-info.js.es6
+++ b/app/assets/javascripts/discourse/components/groups-info.js.es6
@@ -5,8 +5,8 @@ export default Component.extend({
   tagName: "span",
   classNames: ["group-info-details"],
 
-  @discourseComputed("group.full_name", "group.title")
-  showFullName(fullName, title) {
-    return fullName && fullName.length && fullName !== title;
+  @discourseComputed("group.full_name")
+  showFullName(fullName) {
+    return fullName && fullName.length;
   }
 });


### PR DESCRIPTION
https://meta.discourse.org/t/public-group-list-shows-inconsistent-name-or-full-name/133069/14?u=techapj