### PR TITLE
FIX: 500 error for missing badge grouping

### DIFF
--- a/app/serializers/basic_user_badge_serializer.rb
+++ b/app/serializers/basic_user_badge_serializer.rb
@@ -10,6 +10,6 @@ class BasicUserBadgeSerializer < ApplicationSerializer
   end
 
   def grouping_position
-    object.badge.badge_grouping.position
+    object.badge&.badge_grouping&.position
   end
 end


### PR DESCRIPTION
If a badge grouping happens to have been deleted a 500 error will be
thrown when looking a user's badges.

This fix allows the badge page to still be shown without any errors. The
badge with the missing badge grouping is still displayed.

I'll follow up with a separate pr/commit that will ensure if a badge
grouping is deleted, all badges with that badge_grouping_id will also be
updated.