### PR TITLE
FEATURE: Hide discourse version in page header

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -285,6 +285,15 @@ module ApplicationHelper
     content_tag(:script, MultiJson.dump(json).html_safe, type: 'application/ld+json'.freeze)
   end
 
+  def discourse_generator_tag
+    if SiteSetting.hide_discourse_version
+      version_content = "Discourse"
+    else
+      version_content = "Discourse #{Discourse::VERSION::STRING} - https://github.com/discourse/discourse version #{Discourse.git_version}"
+    end
+    tag(:meta, name: 'generator', content: version_content)
+  end
+
   def gsub_emoji_to_unicode(str)
     Emoji.gsub_emoji_to_unicode(str)
   end

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -1,4 +1,4 @@
-<meta name="generator" content="Discourse <%= Discourse::VERSION::STRING %> - https://github.com/discourse/discourse version <%= Discourse.git_version %>">
+<%= discourse_generator_tag %>
 <%- if SiteSetting.site_favicon_url.present? %>
 <link rel="icon" type="image/png" href="<%=SiteSetting.site_favicon_url%>">
 <%- end %>

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1517,6 +1517,7 @@ en:
     content_security_policy_collect_reports: "Enable CSP violation report collection at /csp_reports"
     content_security_policy_script_src: "Additional whitelisted script sources. The current host and CDN are included by default. See <a href='https://meta.discourse.org/t/mitigate-xss-attacks-with-content-security-policy/104243' target='_blank'>Mitigate XSS Attacks with Content Security Policy.</a>"
     invalidate_inactive_admin_email_after_days: "Admin accounts that have not visited the site in this number of days will need to re-validate their email address before logging in. Set to 0 to disable."
+    hide_discourse_version: "Don't include the Discourse version number in the page source."
     top_menu: "Determine which items appear in the homepage navigation, and in what order. Example latest|new|unread|categories|top|read|posted|bookmarks"
     post_menu: "Determine which items appear on the post menu, and in what order. Example like|edit|flag|delete|share|bookmark|reply"
     post_menu_hidden_items: "The menu items to hide by default in the post menu unless an expansion ellipsis is clicked on."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1393,6 +1393,7 @@ security:
     default: 365
     min: 0
     max: 2000
+  hide_discourse_version: false
 
 onebox:
   enable_flash_video_onebox: false

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -318,4 +318,19 @@ describe ApplicationHelper do
       end
     end
   end
+
+  describe 'discourse_generator_tag' do
+    context 'default' do
+      it 'includes version information' do
+        expect(helper.discourse_generator_tag).to match(/content="Discourse #{Discourse::VERSION::STRING}/)
+      end
+    end
+
+    context 'hide version information' do
+      it 'doesnt include version information' do
+        SiteSetting.hide_discourse_version = true
+        expect(helper.discourse_generator_tag).to match(/content="Discourse"/)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Added a new setting to the security tab of Discourse to hide the Discourse version in the 'generator' meta tag.

The default generator tag contains something like: `content="Discourse 2.3.0 - https://github.com/discourse/discourse version 0bcb62fc2d027ee031d2275112da7ac9e26d31bf"`

When you change this setting to true, it will just show `content="Discourse"`
