### PR TITLE
FIX: Secure Upload URLs in lightbox

### DIFF
--- a/lib/cooked_post_processor.rb
+++ b/lib/cooked_post_processor.rb
@@ -375,9 +375,10 @@ class CookedPostProcessor
   def optimize_image!(img, upload, cropped: false)
     w, h = img["width"].to_i, img["height"].to_i
 
+    # note: optimize_urls cooks the src and data-small-upload further after this
     thumbnail = upload.thumbnail(w, h)
     if thumbnail && thumbnail.filesize.to_i < upload.filesize
-      img["src"] = UrlHelper.cook_url(thumbnail.url, secure: upload.secure?)
+      img["src"] = thumbnail.url
 
       srcset = +""
 
@@ -396,11 +397,11 @@ class CookedPostProcessor
         img["srcset"] = "#{UrlHelper.cook_url(img["src"], secure: upload.secure?)}#{srcset}" if srcset.present?
       end
     else
-      img["src"] = UrlHelper.cook_url(upload.url, secure: upload.secure?)
+      img["src"] = upload.url
     end
 
     if small_upload = loading_image(upload)
-      img["data-small-upload"] = UrlHelper.cook_url(small_upload.url, secure: upload.secure?)
+      img["data-small-upload"] = small_upload.url
     end
   end
 

--- a/lib/cooked_post_processor.rb
+++ b/lib/cooked_post_processor.rb
@@ -387,14 +387,14 @@ class CookedPostProcessor
         resized_h = (h * ratio).to_i
 
         if !cropped && upload.width && resized_w > upload.width
-          cooked_url = UrlHelper.cook_url(upload.url, secure: upload.secure?)
+          cooked_url = UrlHelper.cook_url(upload.url, secure: @post.with_secure_media?)
           srcset << ", #{cooked_url} #{ratio.to_s.sub(/\.0$/, "")}x"
         elsif t = upload.thumbnail(resized_w, resized_h)
-          cooked_url = UrlHelper.cook_url(t.url, secure: upload.secure?)
+          cooked_url = UrlHelper.cook_url(t.url, secure: @post.with_secure_media?)
           srcset << ", #{cooked_url} #{ratio.to_s.sub(/\.0$/, "")}x"
         end
 
-        img["srcset"] = "#{UrlHelper.cook_url(img["src"], secure: upload.secure?)}#{srcset}" if srcset.present?
+        img["srcset"] = "#{UrlHelper.cook_url(img["src"], secure: @post.with_secure_media?)}#{srcset}" if srcset.present?
       end
     else
       img["src"] = upload.url
@@ -412,7 +412,7 @@ class CookedPostProcessor
     lightbox.add_child(img)
 
     # then, the link to our larger image
-    src = UrlHelper.cook_url(img["src"], secure: upload&.secure?)
+    src = UrlHelper.cook_url(img["src"], secure: @post.with_secure_media?)
     a = create_link_node("lightbox", src)
     img.add_next_sibling(a)
 

--- a/lib/cooked_post_processor.rb
+++ b/lib/cooked_post_processor.rb
@@ -411,7 +411,7 @@ class CookedPostProcessor
     lightbox.add_child(img)
 
     # then, the link to our larger image
-    src = UrlHelper.cook_url(upload.url, secure: upload.secure?)
+    src = UrlHelper.cook_url(img["src"], secure: upload.secure?)
     a = create_link_node("lightbox", src)
     img.add_next_sibling(a)
 

--- a/lib/cooked_post_processor.rb
+++ b/lib/cooked_post_processor.rb
@@ -377,8 +377,7 @@ class CookedPostProcessor
 
     thumbnail = upload.thumbnail(w, h)
     if thumbnail && thumbnail.filesize.to_i < upload.filesize
-      cooked_url = UrlHelper.cook_url(thumbnail.url, secure: upload.secure?)
-      img["src"] = cooked_url
+      img["src"] = UrlHelper.cook_url(thumbnail.url, secure: upload.secure?)
 
       srcset = +""
 
@@ -397,13 +396,11 @@ class CookedPostProcessor
         img["srcset"] = "#{UrlHelper.cook_url(img["src"], secure: upload.secure?)}#{srcset}" if srcset.present?
       end
     else
-      cooked_url = UrlHelper.cook_url(upload.url, secure: upload.secure?)
-      img["src"] = cooked_url
+      img["src"] = UrlHelper.cook_url(upload.url, secure: upload.secure?)
     end
 
     if small_upload = loading_image(upload)
-      cooked_url = UrlHelper.cook_url(small_upload.url, secure: upload.secure?)
-      img["data-small-upload"] = cook_url
+      img["data-small-upload"] = UrlHelper.cook_url(small_upload.url, secure: upload.secure?)
     end
   end
 

--- a/lib/cooked_post_processor.rb
+++ b/lib/cooked_post_processor.rb
@@ -377,7 +377,8 @@ class CookedPostProcessor
 
     thumbnail = upload.thumbnail(w, h)
     if thumbnail && thumbnail.filesize.to_i < upload.filesize
-      img["src"] = thumbnail.url
+      cooked_url = UrlHelper.cook_url(thumbnail.url, secure: upload.secure?)
+      img["src"] = cooked_url
 
       srcset = +""
 

--- a/lib/cooked_post_processor.rb
+++ b/lib/cooked_post_processor.rb
@@ -396,11 +396,13 @@ class CookedPostProcessor
         img["srcset"] = "#{UrlHelper.cook_url(img["src"], secure: upload.secure?)}#{srcset}" if srcset.present?
       end
     else
-      img["src"] = upload.url
+      cooked_url = UrlHelper.cook_url(upload.url, secure: upload.secure?)
+      img["src"] = cooked_url
     end
 
     if small_upload = loading_image(upload)
-      img["data-small-upload"] = small_upload.url
+      cooked_url = UrlHelper.cook_url(small_upload.url, secure: upload.secure?)
+      img["data-small-upload"] = cook_url
     end
   end
 

--- a/lib/cooked_post_processor.rb
+++ b/lib/cooked_post_processor.rb
@@ -411,7 +411,7 @@ class CookedPostProcessor
     lightbox.add_child(img)
 
     # then, the link to our larger image
-    src = UrlHelper.cook_url(img["src"], secure: upload.secure?)
+    src = UrlHelper.cook_url(img["src"], secure: upload&.secure?)
     a = create_link_node("lightbox", src)
     img.add_next_sibling(a)
 

--- a/lib/cooked_post_processor.rb
+++ b/lib/cooked_post_processor.rb
@@ -346,8 +346,10 @@ class CookedPostProcessor
       end
     end
 
-    add_lightbox!(img, original_width, original_height, upload, cropped: crop) if img.ancestors('.quote').blank?
-    optimize_image!(img, upload, cropped: crop) if upload
+    cooked_upload_url = UrlHelper.cook_url(upload.url, secure: upload.secure?)
+
+    add_lightbox!(img, original_width, original_height, upload, cooked_upload_url, cropped: crop) if img.ancestors('.quote').blank?
+    optimize_image!(img, upload, cooked_upload_url, cropped: crop) if upload
   end
 
   def loading_image(upload)
@@ -372,7 +374,7 @@ class CookedPostProcessor
       .each { |r| yield r if r > 1 }
   end
 
-  def optimize_image!(img, upload, cropped: false)
+  def optimize_image!(img, upload, cooked_upload_url, cropped: false)
     w, h = img["width"].to_i, img["height"].to_i
 
     thumbnail = upload.thumbnail(w, h)
@@ -386,8 +388,7 @@ class CookedPostProcessor
         resized_h = (h * ratio).to_i
 
         if !cropped && upload.width && resized_w > upload.width
-          cooked_url = UrlHelper.cook_url(upload.url, secure: upload.secure?)
-          srcset << ", #{cooked_url} #{ratio.to_s.sub(/\.0$/, "")}x"
+          srcset << ", #{cooked_upload_url} #{ratio.to_s.sub(/\.0$/, "")}x"
         elsif t = upload.thumbnail(resized_w, resized_h)
           cooked_url = UrlHelper.cook_url(t.url, secure: upload.secure?)
           srcset << ", #{cooked_url} #{ratio.to_s.sub(/\.0$/, "")}x"
@@ -396,7 +397,7 @@ class CookedPostProcessor
         img["srcset"] = "#{UrlHelper.cook_url(img["src"], secure: upload.secure?)}#{srcset}" if srcset.present?
       end
     else
-      img["src"] = UrlHelper.cook_url(upload.url, secure: upload.secure?)
+      img["src"] = cooked_upload_url
     end
 
     if small_upload = loading_image(upload)
@@ -404,15 +405,14 @@ class CookedPostProcessor
     end
   end
 
-  def add_lightbox!(img, original_width, original_height, upload, cropped: false)
+  def add_lightbox!(img, original_width, original_height, upload, cooked_upload_url, cropped: false)
     # first, create a div to hold our lightbox
     lightbox = create_node("div", LIGHTBOX_WRAPPER_CSS_CLASS)
     img.add_next_sibling(lightbox)
     lightbox.add_child(img)
 
     # then, the link to our larger image
-    src = UrlHelper.cook_url(upload.url, secure: upload.secure?)
-    a = create_link_node("lightbox", src)
+    a = create_link_node("lightbox", cooked_upload_url)
     img.add_next_sibling(a)
 
     if upload

--- a/lib/cooked_post_processor.rb
+++ b/lib/cooked_post_processor.rb
@@ -411,7 +411,8 @@ class CookedPostProcessor
     lightbox.add_child(img)
 
     # then, the link to our larger image
-    a = create_link_node("lightbox", img["src"])
+    src = UrlHelper.cook_url(upload.url, secure: upload.secure?)
+    a = create_link_node("lightbox", src)
     img.add_next_sibling(a)
 
     if upload

--- a/lib/file_store/s3_store.rb
+++ b/lib/file_store/s3_store.rb
@@ -72,6 +72,8 @@ module FileStore
     def has_been_uploaded?(url)
       return false if url.blank?
 
+      return true if url.starts_with?("/secure-media-uploads/")
+
       base_hostname = URI.parse(absolute_base_url).hostname
       return true if url[base_hostname]
 

--- a/lib/file_store/s3_store.rb
+++ b/lib/file_store/s3_store.rb
@@ -72,8 +72,6 @@ module FileStore
     def has_been_uploaded?(url)
       return false if url.blank?
 
-      return true if url.starts_with?("/secure-media-uploads/")
-
       base_hostname = URI.parse(absolute_base_url).hostname
       return true if url[base_hostname]
 

--- a/spec/components/cooked_post_processor_spec.rb
+++ b/spec/components/cooked_post_processor_spec.rb
@@ -512,6 +512,7 @@ describe CookedPostProcessor do
 
             OptimizedImage.expects(:resize).returns(true)
             FileStore::BaseStore.any_instance.expects(:get_depth_for).returns(0)
+            Discourse.store.class.any_instance.expects(:has_been_uploaded?).at_least_once.returns(true)
 
             SiteSetting.secure_media = true
             upload.update_column(:secure, true)
@@ -521,11 +522,13 @@ describe CookedPostProcessor do
             Fabricate(:post, raw: "![large.png|600x500](#{upload.short_url})")
           end
 
-          pending "handles secure images" do
+          it "handles secure images with the correct lightbox link href" do
             cpp.post_process
 
             expect(cpp.html).to match_html <<~HTML
-              TODO
+            <p><div class="lightbox-wrapper"><a class="lightbox" href="//test.localhost/secure-media-uploads/original/1X/b6589fc6ab0dc82cf12099d1c2d40ab994e8410c.png" data-download-href="https://local.cdn.com/uploads/short-url/q16M6GR110R47Z9p9Dk3PMXOJoE.unknown?dl=1" title="large.png"><img src="" alt="large.png" data-base62-sha1="q16M6GR110R47Z9p9Dk3PMXOJoE" width="600" height="500"><div class="meta">
+            <svg class="fa d-icon d-icon-far-image svg-icon" aria-hidden="true"><use xlink:href="#far-image"></use></svg><span class="filename">large.png</span><span class="informations">1750×2000 1.21 KB</span><svg class="fa d-icon d-icon-discourse-expand svg-icon" aria-hidden="true"><use xlink:href="#discourse-expand"></use></svg>
+            </div></a></div></p>
             HTML
           end
         end

--- a/spec/components/cooked_post_processor_spec.rb
+++ b/spec/components/cooked_post_processor_spec.rb
@@ -527,7 +527,7 @@ describe CookedPostProcessor do
             cpp.post_process
 
             expect(cpp.html).to match_html <<~HTML
-            <p><div class="lightbox-wrapper"><a class="lightbox" href="//test.localhost/secure-media-uploads/original/1X/b6589fc6ab0dc82cf12099d1c2d40ab994e8410c.png" data-download-href="//test.localhost/uploads/short-url/q16M6GR110R47Z9p9Dk3PMXOJoE.unknown?dl=1" title="large.png"><img src="" alt="large.png" data-base62-sha1="q16M6GR110R47Z9p9Dk3PMXOJoE" width="600" height="500"><div class="meta">
+            <p><div class="lightbox-wrapper"><a class="lightbox" href="//test.localhost/secure-media-uploads/original/1X/#{upload.sha1}.png" data-download-href="//test.localhost/uploads/short-url/q16M6GR110R47Z9p9Dk3PMXOJoE.unknown?dl=1" title="large.png"><img src="" alt="large.png" data-base62-sha1="#{upload.base62_sha1}" width="600" height="500"><div class="meta">
             <svg class="fa d-icon d-icon-far-image svg-icon" aria-hidden="true"><use xlink:href="#far-image"></use></svg><span class="filename">large.png</span><span class="informations">1750×2000 1.21 KB</span><svg class="fa d-icon d-icon-discourse-expand svg-icon" aria-hidden="true"><use xlink:href="#discourse-expand"></use></svg>
             </div></a></div></p>
             HTML

--- a/spec/components/cooked_post_processor_spec.rb
+++ b/spec/components/cooked_post_processor_spec.rb
@@ -527,7 +527,7 @@ describe CookedPostProcessor do
             cpp.post_process
 
             expect(cpp.html).to match_html <<~HTML
-            <p><div class="lightbox-wrapper"><a class="lightbox" href="//test.localhost/secure-media-uploads/original/1X/#{upload.sha1}.png" data-download-href="//test.localhost/uploads/short-url/q16M6GR110R47Z9p9Dk3PMXOJoE.unknown?dl=1" title="large.png"><img src="" alt="large.png" data-base62-sha1="#{upload.base62_sha1}" width="600" height="500"><div class="meta">
+            <p><div class="lightbox-wrapper"><a class="lightbox" href="//test.localhost/secure-media-uploads/original/1X/#{upload.sha1}.png" data-download-href="//test.localhost/uploads/short-url/#{upload.base62_sha1}.unknown?dl=1" title="large.png"><img src="" alt="large.png" data-base62-sha1="#{upload.base62_sha1}" width="600" height="500"><div class="meta">
             <svg class="fa d-icon d-icon-far-image svg-icon" aria-hidden="true"><use xlink:href="#far-image"></use></svg><span class="filename">large.png</span><span class="informations">1750×2000 1.21 KB</span><svg class="fa d-icon d-icon-discourse-expand svg-icon" aria-hidden="true"><use xlink:href="#discourse-expand"></use></svg>
             </div></a></div></p>
             HTML

--- a/spec/components/cooked_post_processor_spec.rb
+++ b/spec/components/cooked_post_processor_spec.rb
@@ -514,6 +514,7 @@ describe CookedPostProcessor do
             FileStore::BaseStore.any_instance.expects(:get_depth_for).returns(0)
             Discourse.store.class.any_instance.expects(:has_been_uploaded?).at_least_once.returns(true)
 
+            SiteSetting.login_required = true
             SiteSetting.secure_media = true
             upload.update_column(:secure, true)
           end
@@ -526,7 +527,7 @@ describe CookedPostProcessor do
             cpp.post_process
 
             expect(cpp.html).to match_html <<~HTML
-            <p><div class="lightbox-wrapper"><a class="lightbox" href="//test.localhost/secure-media-uploads/original/1X/b6589fc6ab0dc82cf12099d1c2d40ab994e8410c.png" data-download-href="https://local.cdn.com/uploads/short-url/q16M6GR110R47Z9p9Dk3PMXOJoE.unknown?dl=1" title="large.png"><img src="" alt="large.png" data-base62-sha1="q16M6GR110R47Z9p9Dk3PMXOJoE" width="600" height="500"><div class="meta">
+            <p><div class="lightbox-wrapper"><a class="lightbox" href="//test.localhost/secure-media-uploads/original/1X/b6589fc6ab0dc82cf12099d1c2d40ab994e8410c.png" data-download-href="//test.localhost/uploads/short-url/q16M6GR110R47Z9p9Dk3PMXOJoE.unknown?dl=1" title="large.png"><img src="" alt="large.png" data-base62-sha1="q16M6GR110R47Z9p9Dk3PMXOJoE" width="600" height="500"><div class="meta">
             <svg class="fa d-icon d-icon-far-image svg-icon" aria-hidden="true"><use xlink:href="#far-image"></use></svg><span class="filename">large.png</span><span class="informations">1750×2000 1.21 KB</span><svg class="fa d-icon d-icon-discourse-expand svg-icon" aria-hidden="true"><use xlink:href="#discourse-expand"></use></svg>
             </div></a></div></p>
             HTML


### PR DESCRIPTION
This fixes the following issues:

* The link element on the lightbox which pops open the lightbox was linking to the S3 URL with a private ACL instead of the secure media URL for the image
* Change to use `@post.with_secure_media?` in `CookedPostProcessor` for URL cooking, as in some cases, like when a post is edited and an upload is added, `upload.secure?` can be false which resulted in `srcset` URLs not being cooked correctly to secure media upload urls.

**NOTE: these notes were modified by @martin-brennan**