### PR TITLE
UX: Adjusts wizard step margins

### DIFF
--- a/app/assets/stylesheets/wizard.scss
+++ b/app/assets/stylesheets/wizard.scss
@@ -130,7 +130,6 @@ body.wizard {
 
 .wizard-step-colors {
   max-height: 465px;
-  margin-bottom: 20px;
   overflow-y: auto;
   .grid {
     box-sizing: border-box;
@@ -189,6 +188,7 @@ body.wizard {
 
   .wizard-step-contents {
     height: 550px;
+    margin-bottom: 2em;
     a {
       text-decoration: none;
       color: #6699ff;
@@ -516,7 +516,7 @@ body.wizard {
 }
 
 .radio-field-choice {
-  margin-bottom: 1.5em;
+  margin-bottom: 1.25em;
 
   input {
     outline: 0;
@@ -601,9 +601,6 @@ body.wizard {
   }
   .wizard-footer {
     display: none !important;
-  }
-  .wizard-field {
-    margin-bottom: 1em !important;
   }
   .wizard-step-description {
     margin-bottom: 1em !important;


### PR DESCRIPTION
This PR adjusts the margins in the wizard steps since we have some overlap in the emoji step

Before: 

![Screenshot from 2019-12-03 21-58-16](https://user-images.githubusercontent.com/33972521/70057512-399f7880-1618-11ea-83c8-b264b29f37cd.png)

After:

![Screenshot from 2019-12-03 21-37-02](https://user-images.githubusercontent.com/33972521/70057537-4623d100-1618-11ea-95d6-92c5fe7517dc.png)
