### PR TITLE
Emoji fixes

### DIFF
--- a/app/assets/javascripts/discourse/components/d-editor.js.es6
+++ b/app/assets/javascripts/discourse/components/d-editor.js.es6
@@ -912,7 +912,11 @@ export default Component.extend({
       const captures = selected.pre.match(/\B:(\w*)$/);
 
       if (_.isEmpty(captures)) {
-        this._addText(selected, `:${code}:`);
+        if (selected.pre.match(/\S$/)) {
+          this._addText(selected, ` :${code}:`);
+        } else {
+          this._addText(selected, `:${code}:`);
+        }
       } else {
         let numOfRemovedChars = selected.pre.length - captures[1].length;
         selected.pre = selected.pre.slice(

--- a/app/assets/javascripts/discourse/lib/text.js.es6
+++ b/app/assets/javascripts/discourse/lib/text.js.es6
@@ -68,7 +68,8 @@ function emojiOptions() {
   return {
     getURL: Discourse.getURLWithCDN,
     emojiSet: Discourse.SiteSettings.emoji_set,
-    enableEmojiShortcuts: Discourse.SiteSettings.enable_emoji_shortcuts
+    enableEmojiShortcuts: Discourse.SiteSettings.enable_emoji_shortcuts,
+    inlineEmoji: Discourse.SiteSettings.enable_inline_emoji_translation
   };
 }
 

--- a/app/assets/javascripts/pretty-text/emoji.js.es6
+++ b/app/assets/javascripts/pretty-text/emoji.js.es6
@@ -42,10 +42,31 @@ export function buildReplacementsList(emojiReplacements) {
     .join("|");
 }
 
-const unicodeRegexp = new RegExp(
-  buildReplacementsList(replacements) + "|\\B:[^\\s:]+(?::t\\d)?:?\\B",
-  "g"
-);
+let replacementListCache;
+const unicodeRegexpCache = {};
+
+function replacementList() {
+  if (replacementListCache === undefined) {
+    replacementListCache = buildReplacementsList(replacements);
+  }
+
+  return replacementListCache;
+}
+
+function unicodeRegexp(inlineEmoji) {
+  if (unicodeRegexpCache[inlineEmoji] === undefined) {
+    const emojiExpression = inlineEmoji
+      ? "|:[^\\s:]+(?::t\\d)?:?"
+      : "|\\B:[^\\s:]+(?::t\\d)?:?\\B";
+
+    unicodeRegexpCache[inlineEmoji] = new RegExp(
+      replacementList() + emojiExpression,
+      "g"
+    );
+  }
+
+  return unicodeRegexpCache[inlineEmoji];
+}
 
 // add all default emojis
 emojis.forEach(code => (emojiHash[code] = true));
@@ -56,12 +77,29 @@ Object.keys(aliases).forEach(name => {
   aliases[name].forEach(alias => (aliasHash[alias] = name));
 });
 
+function isReplacableInlineEmoji(string, index, inlineEmoji) {
+  if (inlineEmoji) return true;
+
+  // index depends on regex; when `inlineEmoji` is false, the regex starts
+  // with a `\B` character, so there's no need to subtract from the index
+  const beforeEmoji = string.slice(0, index - (inlineEmoji ? 1 : 0));
+
+  return (
+    beforeEmoji.length === 0 ||
+    /(?:\s|[>.,\/#!$%^&*;:{}=\-_`~()])$/.test(beforeEmoji) ||
+    new RegExp(`(?:${replacementList()})$`).test(beforeEmoji)
+  );
+}
+
 export function performEmojiUnescape(string, opts) {
   if (!string) {
     return;
   }
 
-  return string.replace(unicodeRegexp, m => {
+  const inlineEmoji = opts.inlineEmoji;
+  const regexp = unicodeRegexp(inlineEmoji);
+
+  return string.replace(regexp, (m, index) => {
     const isEmoticon = opts.enableEmojiShortcuts && !!translations[m];
     const isUnicodeEmoticon = !!replacements[m];
     let emojiVal;
@@ -78,7 +116,11 @@ export function performEmojiUnescape(string, opts) {
       ? "emoji emoji-custom"
       : "emoji";
 
-    return url && (isEmoticon || hasEndingColon || isUnicodeEmoticon)
+    const isReplacable =
+      (isEmoticon || hasEndingColon || isUnicodeEmoticon) &&
+      isReplacableInlineEmoji(string, index, inlineEmoji);
+
+    return url && isReplacable
       ? `<img src='${url}' ${
           opts.skipTitle ? "" : `title='${emojiVal}'`
         } alt='${emojiVal}' class='${classes}'>`
@@ -89,14 +131,19 @@ export function performEmojiUnescape(string, opts) {
 }
 
 export function performEmojiEscape(string, opts) {
-  return string.replace(unicodeRegexp, m => {
-    if (!!translations[m]) {
-      return opts.emojiShortcuts ? `:${translations[m]}:` : m;
-    } else if (!!replacements[m]) {
-      return `:${replacements[m]}:`;
-    } else {
-      return m;
+  const inlineEmoji = opts.inlineEmoji;
+  const regexp = unicodeRegexp(inlineEmoji);
+
+  return string.replace(regexp, (m, index) => {
+    if (isReplacableInlineEmoji(string, index, inlineEmoji)) {
+      if (!!translations[m]) {
+        return opts.emojiShortcuts ? `:${translations[m]}:` : m;
+      } else if (!!replacements[m]) {
+        return `:${replacements[m]}:`;
+      }
     }
+
+    return m;
   });
 
   return string;

--- a/app/assets/javascripts/pretty-text/engines/discourse-markdown/quotes.js.es6
+++ b/app/assets/javascripts/pretty-text/engines/discourse-markdown/quotes.js.es6
@@ -120,7 +120,8 @@ const rule = {
             title = performEmojiUnescape(topicInfo.title, {
               getURL: options.getURL,
               emojiSet: options.emojiSet,
-              enableEmojiShortcuts: options.enableEmojiShortcuts
+              enableEmojiShortcuts: options.enableEmojiShortcuts,
+              inlineEmoji: options.inlineEmoji
             });
           }
 
@@ -156,6 +157,7 @@ export function setup(helper) {
     opts.enableEmoji = siteSettings.enable_emoji;
     opts.emojiSet = siteSettings.emoji_set;
     opts.enableEmojiShortcuts = siteSettings.enable_emoji_shortcuts;
+    opts.inlineEmoji = siteSettings.enable_inline_emoji_translation;
   });
 
   helper.registerPlugin(md => {

--- a/lib/pretty_text.rb
+++ b/lib/pretty_text.rb
@@ -218,6 +218,7 @@ module PrettyText
 
     set = SiteSetting.emoji_set.inspect
     custom = Emoji.custom.map { |e| [e.name, e.url] }.to_h.to_json
+
     protect do
       v8.eval(<<~JS)
         __paths = #{paths_json};
@@ -225,7 +226,8 @@ module PrettyText
           getURL: __getURL,
           emojiSet: #{set},
           customEmoji: #{custom},
-          enableEmojiShortcuts: #{SiteSetting.enable_emoji_shortcuts}
+          enableEmojiShortcuts: #{SiteSetting.enable_emoji_shortcuts},
+          inlineEmoji: #{SiteSetting.enable_inline_emoji_translation}
         });
       JS
     end
@@ -238,7 +240,10 @@ module PrettyText
 
     protect do
       v8.eval(<<~JS)
-        __performEmojiEscape(#{title.inspect}, { emojiShortcuts: #{replace_emoji_shortcuts} });
+        __performEmojiEscape(#{title.inspect}, {
+          emojiShortcuts: #{replace_emoji_shortcuts},
+          inlineEmoji: #{SiteSetting.enable_inline_emoji_translation}
+        });
       JS
     end
   end

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -308,6 +308,7 @@ describe Topic do
     let(:topic_emoji) { build_topic_with_title("I 💖 candy alot") }
     let(:topic_modifier_emoji) { build_topic_with_title("I 👨‍🌾 candy alot") }
     let(:topic_shortcut_emoji) { build_topic_with_title("I love candy :)") }
+    let(:topic_inline_emoji) { build_topic_with_title("Hello😊World") }
 
     it "escapes script contents" do
       expect(topic_script.fancy_title).to eq("Topic with &lt;script&gt;alert(&lsquo;title&rsquo;)&lt;/script&gt; script in its title")
@@ -358,6 +359,16 @@ describe Topic do
       it "does not convert emoji shortcuts" do
         expect(topic_shortcut_emoji.fancy_title).to eq("I love candy :)")
       end
+    end
+
+    it "keeps inline emojis if inline emoji setting disabled" do
+      SiteSetting.enable_inline_emoji_translation = false
+      expect(topic_inline_emoji.fancy_title).to eq("Hello😊World")
+    end
+
+    it "expands inline emojis if inline emoji setting enabled" do
+      SiteSetting.enable_inline_emoji_translation = true
+      expect(topic_inline_emoji.fancy_title).to eq("Hello:blush:World")
     end
   end
 

--- a/test/javascripts/acceptance/emoji-picker-test.js.es6
+++ b/test/javascripts/acceptance/emoji-picker-test.js.es6
@@ -9,7 +9,7 @@ acceptance("EmojiPicker", {
   }
 });
 
-QUnit.skip("emoji picker can be opened/closed", async assert => {
+QUnit.test("emoji picker can be opened/closed", async assert => {
   await visit("/t/internationalization-localization/280");
   await click("#topic-footer-buttons .btn.create");
 
@@ -32,7 +32,7 @@ QUnit.skip("emoji picker can be opened/closed", async assert => {
   );
 });
 
-QUnit.skip("emojis can be hovered to display info", async assert => {
+QUnit.test("emojis can be hovered to display info", async assert => {
   await visit("/t/internationalization-localization/280");
   await click("#topic-footer-buttons .btn.create");
 
@@ -47,7 +47,7 @@ QUnit.skip("emojis can be hovered to display info", async assert => {
   );
 });
 
-QUnit.skip("emoji picker triggers event when picking emoji", async assert => {
+QUnit.test("emoji picker triggers event when picking emoji", async assert => {
   await visit("/t/internationalization-localization/280");
   await click("#topic-footer-buttons .btn.create");
   await click("button.emoji.btn");
@@ -90,7 +90,7 @@ QUnit.test(
   }
 );
 
-QUnit.skip("emoji picker has a list of recently used emojis", async assert => {
+QUnit.test("emoji picker has a list of recently used emojis", async assert => {
   await visit("/t/internationalization-localization/280");
   await click("#topic-footer-buttons .btn.create");
   await click("button.emoji.btn");
@@ -136,7 +136,7 @@ QUnit.skip("emoji picker has a list of recently used emojis", async assert => {
   );
 });
 
-QUnit.skip(
+QUnit.test(
   "emoji picker correctly orders recently used emojis",
   async assert => {
     await visit("/t/internationalization-localization/280");
@@ -164,7 +164,7 @@ QUnit.skip(
   }
 );
 
-QUnit.skip("emoji picker lazy loads emojis", async assert => {
+QUnit.test("emoji picker lazy loads emojis", async assert => {
   await visit("/t/internationalization-localization/280");
   await click("#topic-footer-buttons .btn.create");
 
@@ -177,7 +177,7 @@ QUnit.skip("emoji picker lazy loads emojis", async assert => {
   );
 });
 
-QUnit.skip("emoji picker persists state", async assert => {
+QUnit.test("emoji picker persists state", async assert => {
   await visit("/t/internationalization-localization/280");
   await click("#topic-footer-buttons .btn.create");
 

--- a/test/javascripts/acceptance/emoji-picker-test.js.es6
+++ b/test/javascripts/acceptance/emoji-picker-test.js.es6
@@ -4,7 +4,7 @@ import { IMAGE_VERSION as v } from "pretty-text/emoji/version";
 acceptance("EmojiPicker", {
   loggedIn: true,
   beforeEach() {
-    const store = Discourse.__container__.lookup("service:emojis-store");
+    const store = Discourse.__container__.lookup("service:emoji-store");
     store.reset();
   }
 });
@@ -59,6 +59,36 @@ QUnit.skip("emoji picker triggers event when picking emoji", async assert => {
     "it adds the emoji code in the editor when selected"
   );
 });
+
+QUnit.test(
+  "emoji picker adds leading whitespace before emoji",
+  async assert => {
+    await visit("/t/internationalization-localization/280");
+    await click("#topic-footer-buttons .btn.create");
+
+    // Whitespace should be added on text
+    await fillIn(".d-editor-input", "This is a test input");
+    await click("button.emoji.btn");
+    await click(".emoji-picker button[title='grinning']");
+    assert.equal(
+      find(".d-editor-input").val(),
+      "This is a test input :grinning:",
+      "it adds the emoji code and a leading whitespace when there is text"
+    );
+    await click("button.emoji.btn");
+
+    // Whitespace should not be added on whitespace
+    await fillIn(".d-editor-input", "This is a test input ");
+    await click("button.emoji.btn");
+    await click(".emoji-picker button[title='grinning']");
+    assert.equal(
+      find(".d-editor-input").val(),
+      "This is a test input :grinning:",
+      "it adds the emoji code and no leading whitespace when user already entered whitespace"
+    );
+    await click("button.emoji.btn");
+  }
+);
 
 QUnit.skip("emoji picker has a list of recently used emojis", async assert => {
   await visit("/t/internationalization-localization/280");

--- a/test/javascripts/acceptance/topic-test.js.es6
+++ b/test/javascripts/acceptance/topic-test.js.es6
@@ -186,6 +186,27 @@ QUnit.test("Updating the topic title with unicode emojis", async assert => {
   );
 });
 
+QUnit.test(
+  "Updating the topic title with unicode emojis without whitespaces",
+  async assert => {
+    Discourse.SiteSettings.enable_inline_emoji_translation = true;
+    await visit("/t/internationalization-localization/280");
+    await click("#topic-title .d-icon-pencil-alt");
+
+    await fillIn("#edit-title", "Test🙂Title");
+
+    await click("#topic-title .submit-edit");
+
+    assert.equal(
+      find(".fancy-title")
+        .html()
+        .trim(),
+      `Test<img src="/images/emoji/emoji_one/slightly_smiling_face.png?v=${v}" title="slightly_smiling_face" alt="slightly_smiling_face" class="emoji">Title`,
+      "it displays the new title with escaped unicode emojis"
+    );
+  }
+);
+
 acceptance("Topic featured links", {
   loggedIn: true,
   settings: {

--- a/test/javascripts/components/d-editor-test.js.es6
+++ b/test/javascripts/components/d-editor-test.js.es6
@@ -618,7 +618,6 @@ testCase(`doesn't jump to bottom with long text`, async function(
 });
 
 componentTest("emoji", {
-  skip: true,
   template: "{{d-editor value=value}}",
   beforeEach() {
     // Test adding a custom button
@@ -641,7 +640,7 @@ componentTest("emoji", {
     await click(
       '.emoji-picker .section[data-section="smileys_&_emotion"] button.emoji[title="grinning"]'
     );
-    assert.equal(this.value, "hello world.:grinning:");
+    assert.equal(this.value, "hello world. :grinning:");
   }
 });
 

--- a/test/javascripts/helpers/site-settings.js
+++ b/test/javascripts/helpers/site-settings.js
@@ -93,6 +93,8 @@ Discourse.SiteSettingsOriginal = {
   enable_emoji: true,
   enable_emoji_shortcuts: true,
   emoji_set: "emoji_one",
+  enable_emoji_shortcuts: true,
+  enable_inline_emoji_translation: false,
   desktop_category_page_style: "categories_and_latest_topics",
   enable_mentions: true,
   enable_personal_messages: true,

--- a/test/javascripts/lib/emoji-test.js.es6
+++ b/test/javascripts/lib/emoji-test.js.es6
@@ -92,6 +92,41 @@ QUnit.test("emojiUnescape", assert => {
     "no emoticons when emoji shortcuts are disabled",
     { enable_emoji_shortcuts: false }
   );
+  testUnescape(
+    "Hello 😊 World",
+    `Hello <img src='/images/emoji/emoji_one/blush.png?v=${v}' title='blush' alt='blush' class='emoji'> World`,
+    "emoji from Unicode emoji"
+  );
+  testUnescape(
+    "Hello😊World",
+    "Hello😊World",
+    "keeps Unicode emoji when inline translation disabled",
+    {
+      enable_inline_emoji_translation: false
+    }
+  );
+  testUnescape(
+    "Hello😊World",
+    `Hello<img src='/images/emoji/emoji_one/blush.png?v=${v}' title='blush' alt='blush' class='emoji'>World`,
+    "emoji from Unicode emoji when inline translation enabled",
+    {
+      enable_inline_emoji_translation: true
+    }
+  );
+  testUnescape(
+    "hi:smile:",
+    "hi:smile:",
+    "no emojis when inline translation disabled",
+    {
+      enable_inline_emoji_translation: false
+    }
+  );
+  testUnescape(
+    "hi:smile:",
+    `hi<img src='/images/emoji/emoji_one/smile.png?v=${v}' title='smile' alt='smile' class='emoji'>`,
+    "emoji when inline translation enabled",
+    { enable_inline_emoji_translation: true }
+  );
 });
 
 QUnit.test("Emoji search", assert => {


### PR DESCRIPTION
This replaces PR https://github.com/discourse/discourse/pull/7429
See also https://meta.discourse.org/t/emoji-not-recognized-after-cyrillic-symbols/72091

* FIX: Prepends whitespace when inserting via emoji picker
* FIX: Respect `enable_inline_emoji_translation` setting in titles
* DEV: Reenable Emoji Picker tests

@jjaffeux Is it okay to reenable the emoji picker tests? I fixed them and they work in my dev environment, but I saw that you disabled them due to timeout errors this summer.