### PR TITLE
DEV: HTML Builders should respect if a plugin is enabled or not

### DIFF
--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -418,7 +418,10 @@ class Plugin::Instance
   end
 
   def register_html_builder(name, &block)
-    DiscoursePluginRegistry.register_html_builder(name, &block)
+    plugin = self
+    DiscoursePluginRegistry.register_html_builder(name) do |*args|
+      block.call(*args) if plugin.enabled?
+    end
   end
 
   def register_asset(file, opts = nil)

--- a/spec/components/plugin/instance_spec.rb
+++ b/spec/components/plugin/instance_spec.rb
@@ -32,7 +32,10 @@ describe Plugin::Instance do
 
     context "with a plugin that extends things" do
 
-      class Trout; end
+      class Trout
+        attr_accessor :data
+      end
+
       class TroutSerializer < ApplicationSerializer
         attribute :name
 
@@ -90,7 +93,6 @@ describe Plugin::Instance do
       end
 
       it "checks enabled/disabled functionality for extensions" do
-
         # with an enabled plugin
         @plugin.enabled = true
         expect(@trout.status?).to eq("evil")
@@ -113,6 +115,17 @@ describe Plugin::Instance do
         expect(@child_serializer.scales).to eq(1024)
         expect(@child_serializer.include_scales?).to eq(false)
         expect(@child_serializer.name).to eq("a trout jr")
+      end
+
+      it "only returns HTML if enabled" do
+        ctx = Trout.new
+        ctx.data = "hello"
+
+        @plugin.register_html_builder('test:html') { |c| "<div>#{c.data}</div>" }
+        @plugin.enabled = false
+        expect(DiscoursePluginRegistry.build_html('test:html', ctx)).to eq("")
+        @plugin.enabled = true
+        expect(DiscoursePluginRegistry.build_html('test:html', ctx)).to eq("<div>hello</div>")
       end
     end
   end


### PR DESCRIPTION
Previously they would return the HTML regardless of whether the plugin
was enabled or not.