### PR TITLE
UX: prevent scrollbars on initial panel load

### DIFF
--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -221,8 +221,8 @@
     .none {
       padding-top: 5px;
     }
-    .spinner-container.visible {
-      min-height: 30px;
+    .spinner-container {
+      min-height: 2em;
     }
     .spinner {
       width: 20px;


### PR DESCRIPTION
On initial page view, clicking the user-menu gives you a panel with a loading spinner while we fetch the notifications. As the spinner spins, it causes its parent container height to change. This leads to scrollbars. 

This PR gives that parent a fixed height to prevent its height from changing and thus prevent the scrollbars from showing. 