### PR TITLE
FIX: Image file names with dots were showing incorrectly in composer markdown

### DIFF
--- a/app/assets/javascripts/discourse/lib/uploads.js.es6
+++ b/app/assets/javascripts/discourse/lib/uploads.js.es6
@@ -7,8 +7,7 @@ function isGUID(value) {
 }
 
 function imageNameFromFileName(fileName) {
-  const split = fileName.split(".");
-  let name = split[split.length - 2];
+  let name = fileName.substr(0, fileName.lastIndexOf('.'));
 
   if (isAppleDevice() && isGUID(name)) {
     name = I18n.t("upload_selector.default_image_alt_text");

--- a/app/assets/javascripts/discourse/lib/uploads.js.es6
+++ b/app/assets/javascripts/discourse/lib/uploads.js.es6
@@ -7,7 +7,7 @@ function isGUID(value) {
 }
 
 function imageNameFromFileName(fileName) {
-  let name = fileName.substr(0, fileName.lastIndexOf('.'));
+  let name = fileName.substr(0, fileName.lastIndexOf("."));
 
   if (isAppleDevice() && isGUID(name)) {
     name = I18n.t("upload_selector.default_image_alt_text");

--- a/test/javascripts/lib/uploads-test.js.es6
+++ b/test/javascripts/lib/uploads-test.js.es6
@@ -218,15 +218,18 @@ QUnit.test("getUploadMarkdown", assert => {
   );
 });
 
-QUnit.test("getUploadMarkdown - replaces GUID in image alt text on iOS", assert => {
-  assert.equal(
-    testUploadMarkdown("8F2B469B-6B2C-4213-BC68-57B4876365A0.jpeg"),
-    "![8F2B469B-6B2C-4213-BC68-57B4876365A0|100x200](/uploads/123/abcdef.ext)"
-  );
+QUnit.test(
+  "getUploadMarkdown - replaces GUID in image alt text on iOS",
+  assert => {
+    assert.equal(
+      testUploadMarkdown("8F2B469B-6B2C-4213-BC68-57B4876365A0.jpeg"),
+      "![8F2B469B-6B2C-4213-BC68-57B4876365A0|100x200](/uploads/123/abcdef.ext)"
+    );
 
-  sandbox.stub(Utilities, "isAppleDevice").returns(true);
-  assert.equal(
-    testUploadMarkdown("8F2B469B-6B2C-4213-BC68-57B4876365A0.jpeg"),
-    "![image|100x200](/uploads/123/abcdef.ext)"
-  );
-});
+    sandbox.stub(Utilities, "isAppleDevice").returns(true);
+    assert.equal(
+      testUploadMarkdown("8F2B469B-6B2C-4213-BC68-57B4876365A0.jpeg"),
+      "![image|100x200](/uploads/123/abcdef.ext)"
+    );
+  }
+);

--- a/test/javascripts/lib/uploads-test.js.es6
+++ b/test/javascripts/lib/uploads-test.js.es6
@@ -205,6 +205,11 @@ QUnit.test("getUploadMarkdown", assert => {
     "![file name with space|100x200](/uploads/123/abcdef.ext)"
   );
 
+  assert.equal(
+    testUploadMarkdown("image.file.name.with.dots.png"),
+    "![image.file.name.with.dots|100x200](/uploads/123/abcdef.ext)"
+  );
+
   const short_url = "uploads://asdaasd.ext";
 
   assert.equal(
@@ -213,7 +218,7 @@ QUnit.test("getUploadMarkdown", assert => {
   );
 });
 
-QUnit.test("replaces GUID in image alt text on iOS", assert => {
+QUnit.test("getUploadMarkdown - replaces GUID in image alt text on iOS", assert => {
   assert.equal(
     testUploadMarkdown("8F2B469B-6B2C-4213-BC68-57B4876365A0.jpeg"),
     "![8F2B469B-6B2C-4213-BC68-57B4876365A0|100x200](/uploads/123/abcdef.ext)"


### PR DESCRIPTION
Meta: https://meta.discourse.org/t/inconsistent-png-and-pdf-upload-filenaming-conventions/135130/3

When uploading an image file with dots in the filename we were splitting the string on dots and getting the last of the split items as the extension-less filename. However this did not work with filenames that have dots. We now  just remove the extension using substr.