### PR TITLE
FIX: Muted tags are respected by TopicTrackingState

### DIFF
--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -27,6 +27,7 @@ class CurrentUserSerializer < BasicUserSerializer
              :redirected_to_top,
              :custom_fields,
              :muted_category_ids,
+             :muted_tag_ids,
              :dismissed_banner_key,
              :is_anonymous,
              :reviewable_count,
@@ -166,6 +167,10 @@ class CurrentUserSerializer < BasicUserSerializer
 
   def muted_category_ids
     CategoryUser.lookup(object, :muted).pluck(:category_id)
+  end
+
+  def muted_tag_ids
+    TagUser.lookup(object, :muted).pluck(:tag_id)
   end
 
   def ignored_users

--- a/spec/models/topic_tracking_state_spec.rb
+++ b/spec/models/topic_tracking_state_spec.rb
@@ -353,6 +353,77 @@ describe TopicTrackingState do
     expect(report.length).to eq(1)
   end
 
+  context 'muted tags' do
+    it "remove_muted_tags_from_latest is set to always" do
+      SiteSetting.remove_muted_tags_from_latest = 'always'
+      user = Fabricate(:user)
+      tag1 = Fabricate(:tag)
+      tag2 = Fabricate(:tag)
+      Fabricate(:topic_tag, tag: tag1, topic: topic)
+      Fabricate(:topic_tag, tag: tag2, topic: topic)
+      post
+
+      report = TopicTrackingState.report(user)
+      expect(report.length).to eq(1)
+
+      TagUser.create!(user_id: user.id,
+                      notification_level: TagUser.notification_levels[:muted],
+                      tag_id: tag1.id
+                     )
+
+      report = TopicTrackingState.report(user)
+      expect(report.length).to eq(0)
+    end
+
+    it "remove_muted_tags_from_latest is set to only_muted" do
+      SiteSetting.remove_muted_tags_from_latest = 'only_muted'
+      user = Fabricate(:user)
+      tag1 = Fabricate(:tag)
+      tag2 = Fabricate(:tag)
+      Fabricate(:topic_tag, tag: tag1, topic: topic)
+      Fabricate(:topic_tag, tag: tag2, topic: topic)
+      post
+
+      report = TopicTrackingState.report(user)
+      expect(report.length).to eq(1)
+
+      TagUser.create!(user_id: user.id,
+                      notification_level: TagUser.notification_levels[:muted],
+                      tag_id: tag1.id
+                     )
+
+      report = TopicTrackingState.report(user)
+      expect(report.length).to eq(1)
+
+      TagUser.create!(user_id: user.id,
+                      notification_level: TagUser.notification_levels[:muted],
+                      tag_id: tag2.id
+                     )
+
+      report = TopicTrackingState.report(user)
+      expect(report.length).to eq(0)
+    end
+
+    it "remove_muted_tags_from_latest is set to never" do
+      SiteSetting.remove_muted_tags_from_latest = 'never'
+      user = Fabricate(:user)
+      tag1 = Fabricate(:tag)
+      Fabricate(:topic_tag, tag: tag1, topic: topic)
+      post
+
+      report = TopicTrackingState.report(user)
+      expect(report.length).to eq(1)
+
+      TagUser.create!(user_id: user.id,
+                      notification_level: TagUser.notification_levels[:muted],
+                      tag_id: tag1.id
+                     )
+
+      report = TopicTrackingState.report(user)
+      expect(report.length).to eq(1)
+    end
+  end
+
   it "correctly handles seen categories" do
     user = Fabricate(:user)
     post

--- a/spec/serializers/current_user_serializer_spec.rb
+++ b/spec/serializers/current_user_serializer_spec.rb
@@ -68,6 +68,25 @@ RSpec.describe CurrentUserSerializer do
     end
   end
 
+  context "#muted_tag_ids" do
+    fab!(:user) { Fabricate(:user) }
+    fab!(:tag) { Fabricate(:tag) }
+    let!(:tag_user) do
+      TagUser.create!(user_id: user.id,
+                      notification_level: TagUser.notification_levels[:muted],
+                      tag_id: tag.id
+                     )
+    end
+    let :serializer do
+      CurrentUserSerializer.new(user, scope: Guardian.new, root: false)
+    end
+
+    it 'include muted tag ids' do
+      payload = serializer.as_json
+      expect(payload[:muted_tag_ids]).to eq([tag.id])
+    end
+  end
+
   context "#second_factor_enabled" do
     fab!(:user) { Fabricate(:user) }
     let :serializer do


### PR DESCRIPTION
When the tag is muted and topic contains that tag, we should not mark that message as NEW.

There are 3 possible settings which site admin can set.
remove_muted_tags_from_latest - always
It means that if the topic got at least one muted tag, we should not mark that topic as NEW

remove_muted_tags_from_latest - only muted
Similar to above, however, if at least one tag is not muted, the topic is still marked as NEW

remove_muted_tags_from_latest - never
Basically, mute tag setting is ignored and all topics are set as NEW