### PR TITLE
FIX: Prevent scientific notation in free space check

### DIFF
--- a/app/controllers/admin/backups_controller.rb
+++ b/app/controllers/admin/backups_controller.rb
@@ -215,7 +215,7 @@ class Admin::BackupsController < Admin::AdminController
   private
 
   def has_enough_space_on_disk?(size)
-    `df -Pk #{Rails.root}/public/backups | awk 'NR==2 {print $4 * 1024;}'`.to_i > size
+    `df -Pk #{Rails.root}/public/backups | awk 'NR==2 {printf "%.0f", $4 * 1024;}'`.to_i > size
   end
 
   def ensure_backups_enabled


### PR DESCRIPTION
It's possibly that when trying to upload a backup the free space check
will output scientific notation resulting in an incorrect "There is not
enough space on disk" error.

The free space check uses the Linux `print` command which could return a
number using scientific notation like `1.60459e+10` and when ruby
converts it to an integer it will have the value of `1` instead of
`16045879296`. Which means even though you have 16GB of free space you
could not upload a 1GB backup file.

This commit uses the `printf` command instead which allows you to
specify that you do not want scientific notation.

I'm not sure why this hasn't been an issue before, but I was
experiencing it locally in development.