### PR TITLE
DEV: See if the store is external before checking disk space

### DIFF
--- a/lib/cooked_post_processor.rb
+++ b/lib/cooked_post_processor.rb
@@ -642,9 +642,9 @@ class CookedPostProcessor
   end
 
   def disable_if_low_on_disk_space
+    return false if Discourse.store.external?
     return false if !SiteSetting.download_remote_images_to_local
     return false if available_disk_space >= SiteSetting.download_remote_images_threshold
-    return false if Discourse.store.external?
 
     SiteSetting.download_remote_images_to_local = false
     # log the site setting change


### PR DESCRIPTION
`available_disk_space` calls `df` which exits with an error if the `uploads` path doesn't exist. That's often the case when the `Discourse.store.external?` is true.

By doing the `external?` check first the `disable_if_low_on_disk_space` does less work and doesn't output any errors to the console.