### PR TITLE
FIX: Don't try to create an empty tag when updating a topic

### DIFF
--- a/app/assets/javascripts/discourse/models/topic.js.es6
+++ b/app/assets/javascripts/discourse/models/topic.js.es6
@@ -660,8 +660,6 @@ Topic.reopenClass({
   },
 
   update(topic, props) {
-    props = JSON.parse(JSON.stringify(props)) || {};
-
     // We support `category_id` and `categoryId` for compatibility
     if (typeof props.categoryId !== "undefined") {
       props.category_id = props.categoryId;
@@ -673,11 +671,11 @@ Topic.reopenClass({
       delete props.category_id;
     }
 
-    if (props.tags && props.tags.length === 0) {
-      props.tags = [""];
-    }
-
-    return ajax(topic.get("url"), { type: "PUT", data: props }).then(result => {
+    return ajax(topic.get("url"), {
+      type: "PUT",
+      data: JSON.stringify(props),
+      contentType: "application/json"
+    }).then(result => {
       // The title can be cleaned up server side
       props.title = result.basic_topic.title;
       props.fancy_title = result.basic_topic.fancy_title;

--- a/test/javascripts/helpers/create-pretender.js.es6
+++ b/test/javascripts/helpers/create-pretender.js.es6
@@ -397,7 +397,8 @@ export default function() {
     this.get("/t/500.json", () => response(502, {}));
 
     this.put("/t/:slug/:id", request => {
-      const data = parsePostData(request.requestBody);
+      const isJSON = request.requestHeaders["Content-Type"].includes("application/json");
+      const data = isJSON ? JSON.parse(request.requestBody) : parsePostData(request.requestBody);
 
       return response(200, {
         basic_topic: {

--- a/test/javascripts/helpers/create-pretender.js.es6
+++ b/test/javascripts/helpers/create-pretender.js.es6
@@ -397,8 +397,13 @@ export default function() {
     this.get("/t/500.json", () => response(502, {}));
 
     this.put("/t/:slug/:id", request => {
-      const isJSON = request.requestHeaders["Content-Type"].includes("application/json");
-      const data = isJSON ? JSON.parse(request.requestBody) : parsePostData(request.requestBody);
+      const isJSON = request.requestHeaders["Content-Type"].includes(
+        "application/json"
+      );
+
+      const data = isJSON
+        ? JSON.parse(request.requestBody)
+        : parsePostData(request.requestBody);
 
       return response(200, {
         basic_topic: {


### PR DESCRIPTION
Fixes an issue where updates to the first post in a topic would be visible only for staff.

Before, because the empty tag would find its way to `PostRevisor`, `TopicsController#update` would create a hidden revision, and later `PostsController#update` would only update that revision.

After this change, `TopicsController` doesn't create a revision at all (unless necessary), so `PostsController` can do that and correctly decide whether the revision should be hidden or not.