### PR TITLE
FEATURE: Warning when component is added and not assigned

### DIFF
--- a/app/assets/javascripts/admin/controllers/admin-customize-themes-show.js.es6
+++ b/app/assets/javascripts/admin/controllers/admin-customize-themes-show.js.es6
@@ -324,6 +324,7 @@ export default Controller.extend({
         result => {
           if (result) {
             const model = this.model;
+            model.setProperties({ recentlyInstalled: false });
             model.destroyRecord().then(() => {
               this.allThemes.removeObject(model);
               this.transitionToRoute("adminCustomizeThemes");

--- a/app/assets/javascripts/admin/routes/admin-customize-themes-show.js.es6
+++ b/app/assets/javascripts/admin/routes/admin-customize-themes-show.js.es6
@@ -51,6 +51,23 @@ export default Route.extend({
   actions: {
     didTransition() {
       scrollTop();
+    },
+    willTransition(transition) {
+      const model = this.controller.model;
+      if (model.recentlyInstalled && !model.hasParents && model.component) {
+        transition.abort();
+        bootbox.confirm(
+          I18n.t("admin.customize.theme.unsaved_parent_themes"),
+          I18n.t("admin.customize.theme.discard"),
+          I18n.t("admin.customize.theme.stay"),
+          result => {
+            if (!result) {
+              this.controller.model.setProperties({ recentlyInstalled: false });
+              transition.retry();
+            }
+          }
+        );
+      }
     }
   }
 });

--- a/app/assets/javascripts/admin/routes/admin-customize-themes.js.es6
+++ b/app/assets/javascripts/admin/routes/admin-customize-themes.js.es6
@@ -18,6 +18,7 @@ export default Route.extend({
 
     addTheme(theme) {
       this.refresh();
+      theme.setProperties({ recentlyInstalled: true });
       this.transitionTo("adminCustomizeThemes.show", theme.get("id"));
     }
   }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3636,6 +3636,7 @@ en:
           upload: "Upload"
           select_component: "Select a component..."
           unsaved_changes_alert: "You haven't saved your changes yet, do you want to discard them and move on?"
+          unsaved_parent_themes: "You haven't assigned the component to themes, do you want to move on?"
           discard: "Discard"
           stay: "Stay"
           css_html: "Custom CSS/HTML"


### PR DESCRIPTION
When a component is installed and not assigned to any theme and the user is changing page, we should display a warning.

If the user decides to skip warning or come back later, a warning should not be shown anymore.

Also, when the user clicks "delete" button right after installation, warning about forgotten themes should not be shown.

![leave-confirmation](https://user-images.githubusercontent.com/72780/70410304-bc09bb80-1aa2-11ea-83b7-36baab5f0d92.gif)
