### PR TITLE
UX: Removes avatar animation for mobile-user cards

### DIFF
--- a/app/assets/stylesheets/mobile/discourse.scss
+++ b/app/assets/stylesheets/mobile/discourse.scss
@@ -147,17 +147,3 @@ blockquote {
 #simple-container {
   width: 90%;
 }
-
-// this is used to provide visual feedback that indicates that the user / group
-// cards are loading after the user clicks on an avatar. It's mostly for very slow
-// connections. Users on good connections won't notice it.
-[data-user-card]:focus {
-  .avatar,
-  + .avatar-flair {
-    animation: wave 0.75s infinite;
-    animation-delay: 0.5s;
-  }
-  .avatar {
-    position: relative;
-  }
-}


### PR DESCRIPTION
Mobile user-cards predate https://github.com/discourse/discourse/pull/7404

Back then, we used to animate the avatar for the user you clicked on as an indicator that your click was registered while the server responded.

You can see that animation here

https://d11a6trkgmumsb.cloudfront.net/original/3X/e/6/e671ca13fc217e8122ad1465700922e77e961a1b.mp4

With the quick loading of cards added in https://github.com/discourse/discourse/pull/7404 this animation is no longer necessary since the cards load instantly.

This PR removes that animation 