### PR TITLE
FIX: ensures slug and id are not arrays

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -783,6 +783,9 @@ class ApplicationController < ActionController::Base
     @title = opts[:title] || I18n.t("page_not_found.title")
     @group = opts[:group]
     @hide_search = true if SiteSetting.login_required
+
+    params[:slug] = params[:slug].first if params[:slug].kind_of?(Array)
+    params[:id] = params[:id].first if params[:id].kind_of?(Array)
     @slug = (params[:slug].presence || params[:id].presence || "").tr('-', ' ')
 
     render_to_string status: opts[:status], layout: opts[:layout], formats: [:html], template: '/exceptions/not_found'


### PR DESCRIPTION
If for some reason an URL was created in this format:

```
?slug[]=foo&slug[]=bar
```

This would have created an exception of this kind:

```
NoMethodError (undefined method `tr' for ["foo", "bar"]:Array
Did you mean?  try)
```