### PR TITLE
DEV: Revert parallel_tests bump

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -255,7 +255,7 @@ GEM
       ruby-openid
     optimist (3.0.0)
     parallel (1.19.1)
-    parallel_tests (2.30.0)
+    parallel_tests (2.29.2)
       parallel
     parser (2.6.5.0)
       ast (~> 2.4.0)


### PR DESCRIPTION
parallel_tests with this version uses `bin/rake`, which auto-loads plugins