### PR TITLE
FIX: Use updated_at date to denote expired invites

### DIFF
--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -55,7 +55,7 @@ class Invite < ActiveRecord::Base
   end
 
   def expired?
-    created_at < SiteSetting.invite_expiry_days.days.ago
+    updated_at < SiteSetting.invite_expiry_days.days.ago
   end
 
   # link_valid? indicates whether the invite link can be used to log in to the site
@@ -191,7 +191,7 @@ class Invite < ActiveRecord::Base
   end
 
   def self.find_pending_invites_from(inviter, offset = 0)
-    find_all_invites_from(inviter, offset).where('invites.user_id IS NULL').order('invites.created_at DESC')
+    find_all_invites_from(inviter, offset).where('invites.user_id IS NULL').order('invites.updated_at DESC')
   end
 
   def self.find_redeemed_invites_from(inviter, offset = 0)
@@ -244,7 +244,7 @@ class Invite < ActiveRecord::Base
   end
 
   def self.rescind_all_expired_invites_from(user)
-    Invite.where('invites.user_id IS NULL AND invites.email IS NOT NULL AND invited_by_id = ? AND invites.created_at < ?',
+    Invite.where('invites.user_id IS NULL AND invites.email IS NOT NULL AND invited_by_id = ? AND invites.updated_at < ?',
                 user.id, SiteSetting.invite_expiry_days.days.ago).find_each do |invite|
       invite.trash!(user)
     end

--- a/app/models/invite_redeemer.rb
+++ b/app/models/invite_redeemer.rb
@@ -88,7 +88,7 @@ InviteRedeemer = Struct.new(:invite, :username, :name, :password, :user_custom_f
   end
 
   def mark_invite_redeemed
-    count = Invite.where('id = ? AND redeemed_at IS NULL AND created_at >= ?',
+    count = Invite.where('id = ? AND redeemed_at IS NULL AND updated_at >= ?',
                  invite.id, SiteSetting.invite_expiry_days.days.ago)
       .update_all('redeemed_at = CURRENT_TIMESTAMP')
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1200,7 +1200,7 @@ en:
         search: "type to search invites..."
         title: "Invites"
         user: "Invited User"
-        sent: "Sent"
+        sent: "Last Sent"
         none: "No invites to display."
         truncated:
           one: "Showing the first invite."

--- a/db/migrate/20191211152404_add_index_to_invites.rb
+++ b/db/migrate/20191211152404_add_index_to_invites.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddIndexToInvites < ActiveRecord::Migration[6.0]
+  def change
+    add_index :invites, [:invited_by_id]
+  end
+end

--- a/spec/models/invite_redeemer_spec.rb
+++ b/spec/models/invite_redeemer_spec.rb
@@ -70,6 +70,7 @@ describe InviteRedeemer do
       inviter = invite.invited_by
       inviter.admin = true
       user = invite_redeemer.redeem
+      invite.reload
 
       expect(user.name).to eq(name)
       expect(user.username).to eq(username)
@@ -153,5 +154,20 @@ describe InviteRedeemer do
       another_user = another_invite_redeemer.redeem
       expect(another_user).to eq(nil)
     end
+
+    it "should correctly update the invite redeemed_at date" do
+      SiteSetting.invite_expiry_days = 2
+      invite.update!(created_at: 10.days.ago)
+
+      inviter = invite.invited_by
+      inviter.admin = true
+      user = invite_redeemer.redeem
+      invite.reload
+
+      expect(user.invited_by).to eq(inviter)
+      expect(inviter.notifications.count).to eq(1)
+      expect(invite.redeemed_at).not_to eq(nil)
+    end
+
   end
 end


### PR DESCRIPTION
Fixes an issue where resending invites did not reset the expired state of invites in the admin UI.