### PR TITLE
FIX: Always add username span in quick access item

### DIFF
--- a/app/assets/javascripts/discourse/widgets/quick-access-item.js.es6
+++ b/app/assets/javascripts/discourse/widgets/quick-access-item.js.es6
@@ -67,6 +67,8 @@ createWidget("quick-access-item", {
   },
 
   _usernameHtml() {
-    return this.attrs.username ? `<span>${this.attrs.username}</span> ` : "";
+    // Generate an empty `<span>` even if there is no username, because the
+    // first `<span>` is styled differently.
+    return this.attrs.username ? `<span>${this.attrs.username}</span> ` : "<span></span>";
   }
 });


### PR DESCRIPTION
> CONTEXT: https://meta.discourse.org/t/quick-access-to-bookmarks-and-messages-on-user-menu/32787/59

Generate an empty `<span>` even if there is no username, because the
first `<span>` is styled differently:

https://github.com/discourse/discourse/blob/505b8b76bce2023da6869a80d3d4c5a9ae340931/app/assets/stylesheets/common/base/menu-panel.scss#L178-L180

I am not sure if it would be better to add a CSS class instead. Open to suggestions, thanks!

**Before**

<img width="354" alt="Screen Shot 2019-12-10 at 2 09 11 PM" src="https://user-images.githubusercontent.com/6376558/70574321-b8387080-1b58-11ea-8113-f5de85eb087f.png">

**After**

<img width="346" alt="Screen Shot 2019-12-10 at 2 10 20 PM" src="https://user-images.githubusercontent.com/6376558/70574324-b8387080-1b58-11ea-992b-36e8065ccf33.png">

---


