### PR TITLE
FIX: Hide old bookmark button on post-menu if SiteSetting.enable_bookmarks_with_reminders

### DIFF
--- a/app/assets/javascripts/discourse/widgets/post-menu.js.es6
+++ b/app/assets/javascripts/discourse/widgets/post-menu.js.es6
@@ -332,7 +332,7 @@ registerButton("bookmarkWithReminder", (attrs, state, siteSettings) => {
     title,
     titleOptions,
     className: classNames.join(" "),
-    icon: "book"
+    icon: "bookmark"
   };
 });
 
@@ -460,7 +460,16 @@ export default createWidget("post-menu", {
     const allButtons = [];
     let visibleButtons = [];
 
-    const orderedButtons = this.menuItems();
+    // filter menu items based on site settings
+    const orderedButtons = this.menuItems().filter(button => {
+      if (
+        this.siteSettings.enable_bookmarks_with_reminders &&
+        button === "bookmark"
+      ) {
+        return false;
+      }
+      return true;
+    });
 
     // If the post is a wiki, make Edit more prominent
     if (attrs.wiki && attrs.canEdit) {

--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -330,7 +330,7 @@ class PostSerializer < BasicPostSerializer
   end
 
   def post_bookmark
-    return nil if !SiteSetting.enable_bookmarks_with_reminders?
+    return nil if !SiteSetting.enable_bookmarks_with_reminders? || @topic_view.blank?
     @post_bookmark ||= @topic_view.user_post_bookmarks.find { |bookmark| bookmark.post_id == object.id }
   end
 

--- a/spec/serializers/post_serializer_spec.rb
+++ b/spec/serializers/post_serializer_spec.rb
@@ -227,10 +227,11 @@ describe PostSerializer do
 
   context "post with bookmarks" do
     let(:current_user) { Fabricate(:user) }
+    let(:topic_view) { TopicView.new(post.topic, current_user) }
     let(:serialized) do
       s = serialized_post(current_user)
       s.post_actions = PostAction.counts_for([post], current_user)[post.id]
-      s.topic_view = TopicView.new(post.topic, current_user)
+      s.topic_view = topic_view
       s
     end
 
@@ -265,10 +266,18 @@ describe PostSerializer do
         it "returns the reminder_at for the bookmark" do
           expect(serialized.as_json[:bookmark_reminder_at]).to eq(bookmark.reminder_at.iso8601)
         end
+
+        context "if topic_view is blank" do
+          let(:topic_view) { nil }
+
+          it "does not return the bookmarked_with_reminder attribute" do
+            expect(serialized.as_json.key?(:bookmarked_with_reminder)).to eq(false)
+          end
+        end
       end
 
       context "when the site setting for bookmarks with reminders is disabled" do
-        it "does not return the bookmarked attribute" do
+        it "does not return the bookmarked_with_reminder attribute" do
           expect(serialized.as_json.key?(:bookmarked_with_reminder)).to eq(false)
         end
 


### PR DESCRIPTION
* Hide old bookmark post-menu item if the site setting for the new bookmark reminders is enabled and change icon for the new bookmark functionality to the same as the old bookmark button
* Fix null `@topic_view` error in post serializer for post_bookmark, as new posts do not have a `@topic_view`