### PR TITLE
FIX: Cache short upload URL

### DIFF
--- a/app/assets/javascripts/discourse/components/composer-editor.js.es6
+++ b/app/assets/javascripts/discourse/components/composer-editor.js.es6
@@ -755,7 +755,7 @@ export default Component.extend({
           getUploadMarkdown(upload)
         );
 
-        cacheShortUploadUrl(upload.short_url, upload.url);
+        cacheShortUploadUrl(upload.short_url, upload);
         this.appEvents.trigger(
           "composer:replace-text",
           this.uploadPlaceholder.trim(),


### PR DESCRIPTION
The code for caching was already there, but it was caching invalid data,
which automatically invalidated the cache entry.