### PR TITLE
FIX: allow focus of input on Android mobile devices

### DIFF
--- a/app/assets/javascripts/select-kit/mixins/dom-helpers.js.es6
+++ b/app/assets/javascripts/select-kit/mixins/dom-helpers.js.es6
@@ -111,11 +111,7 @@ export default Mixin.create({
             $(context.element).focus();
           }
         } else {
-          if (this.site && this.site.isMobileDevice) {
-            this.expand();
-          } else {
-            context.$filterInput().focus();
-          }
+          context.$filterInput().focus();
         }
       });
     });


### PR DESCRIPTION
This reverts commit bfcf8ed61bebba6be3082507dafa6766024ddf3a.

We shouldn't disable focus on select-kit inputs on mobile devices, I think it's a better user experience to allow focus. Unfortunately, iOS already blocks focusing on inputs via a JS call. This revert only affects Android devices. 
