### PR TITLE
FIX: Adds a message when the passwords doesn't match in task admin:create

### DIFF
--- a/lib/tasks/admin.rake
+++ b/lib/tasks/admin.rake
@@ -48,7 +48,10 @@ task "admin:create" => :environment do
         begin
           password = ask("Password:  ") { |q| q.echo = false }
           password_confirmation = ask("Repeat password:  ") { |q| q.echo = false }
-        end while password != password_confirmation
+          passwords_match = password == password_confirmation
+
+          say("Passwords don't match, try again...") unless passwords_match
+        end while !passwords_match
         admin.password = password
       end
     else
@@ -62,17 +65,17 @@ task "admin:create" => :environment do
         else
           password = ask("Password:  ") { |q| q.echo = false }
           password_confirmation = ask("Repeat password:  ") { |q| q.echo = false }
+          passwords_match = password == password_confirmation
         end
-      end while password != password_confirmation
+
+        say("Passwords don't match, try again...") unless passwords_match
+      end while !passwords_match
       admin.password = password
     end
 
     # save/update user account
     saved = admin.save
-    if !saved
-      puts admin.errors.full_messages.join("\n")
-      next
-    end
+    say(admin.errors.full_messages.join("\n")) unless saved
   end while !saved
 
   say "\nEnsuring account is active!"


### PR DESCRIPTION
If the password and password confirmation doesn't match when using `rake admin:create` to create an admin user, it shows a message indicating that. Previously it didn't say anything and it was confusing.

<img width="612" alt="Screen Shot 2019-12-12 at 5 25 09 PM" src="https://user-images.githubusercontent.com/4307598/70759829-dfcc3c00-1d04-11ea-9e53-59201ea07532.png">
