### PR TITLE
FIX: If a prettified slug is a number, return default

### DIFF
--- a/lib/slug.rb
+++ b/lib/slug.rb
@@ -20,7 +20,7 @@ module Slug
       when :none then self.none_generator(string)
       end
     slug = self.prettify_slug(slug, max_length: max_length)
-    slug.blank? ? default : slug
+    (slug.blank? || slug_is_only_numbers?(slug)) ? default : slug
   end
 
   def self.sanitize(string, downcase: false, max_length: MAX_LENGTH)
@@ -30,9 +30,13 @@ module Slug
 
   private
 
+  def self.slug_is_only_numbers?(slug)
+    (slug =~ /[^\d]/).blank?
+  end
+
   def self.prettify_slug(slug, max_length:)
     # Reject slugs that only contain numbers, because they would be indistinguishable from id's.
-    slug = (slug =~ /[^\d]/ ? slug : '')
+    slug = (slug_is_only_numbers?(slug) ? '' : slug)
 
     slug
       .tr("_", "-")

--- a/spec/components/slug_spec.rb
+++ b/spec/components/slug_spec.rb
@@ -17,6 +17,10 @@ describe Slug do
       expect(Slug.for('')).to eq default_slug
     end
 
+    it 'return topic by default if the string boils down to a number' do
+      expect(Slug.for('=213=-!(@#+@)(!*_(@#&(!)#')).to eq default_slug
+    end
+
     it 'accepts fallback' do
       expect(Slug.for('', 'king')).to eq 'king'
     end


### PR DESCRIPTION
Meta thread: https://meta.discourse.org/t/sending-a-pm-with-the-following-title-causes-an-error/135654/3

* We had an issue where if someone sent a PM with crazy
  characters that are stripped and we end up with only
  a number, the topic redirect errored because the slug was
  a number. so instead we return the default as well if
  the slug is a number after prettification