### PR TITLE
FIX: category id in filterCategory

### DIFF
--- a/app/assets/javascripts/discourse/models/topic-tracking-state.js.es6
+++ b/app/assets/javascripts/discourse/models/topic-tracking-state.js.es6
@@ -221,9 +221,9 @@ const TopicTrackingState = EmberObject.extend({
 
     if (split.length >= 4) {
       filter = split[split.length - 1];
-      // c/cat/subcat/l/latest
+      // c/cat/subcat/6/l/latest
       var category = Category.findSingleBySlug(
-        split.splice(1, split.length - 3).join("/")
+        split.splice(1, split.length - 4).join("/")
       );
       this.set("filterCategory", category);
     } else {

--- a/test/javascripts/models/topic-tracking-state-test.js.es6
+++ b/test/javascripts/models/topic-tracking-state-test.js.es6
@@ -42,7 +42,7 @@ QUnit.test("subscribe to category", function(assert) {
 
   const state = TopicTrackingState.create();
 
-  state.trackIncoming("c/darth/l/latest");
+  state.trackIncoming("c/darth/1/l/latest");
 
   state.notify({
     message_type: "new_topic",
@@ -67,7 +67,7 @@ QUnit.test("subscribe to category", function(assert) {
   );
 
   state.resetTracking();
-  state.trackIncoming("c/darth/luke/l/latest");
+  state.trackIncoming("c/darth/luke/2/l/latest");
 
   state.notify({
     message_type: "new_topic",


### PR DESCRIPTION
Small regression was created here: https://github.com/discourse/discourse/commit/374534f00ee#diff-4af46675500edc092f9224ca5835a7ddR106

After that change `listFilter` is including `categoryId` like `c/cat/subcat/6/l/latest` instead of `c/cat/subcat/l/latest`

Therefore, `trackIncoming` function in topic-tracking-state couldn't properly filter new messages