### PR TITLE
UX: invites#show can't be requested with json and is not configured p…

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -787,7 +787,9 @@ Discourse::Application.routes.draw do
   get "/posts/:id/raw-email" => "posts#raw_email"
   get "raw/:topic_id(/:post_number)" => "posts#markdown_num"
 
-  resources :invites
+  resources :invites, except: [:show]
+  get "/invites/:id" => "invites#show", constraints: { format: :html }
+
   post "invites/upload_csv" => "invites#upload_csv"
   post "invites/rescind-all" => "invites#rescind_all_invites"
   post "invites/reinvite" => "invites#resend_invite"


### PR DESCRIPTION
…roperly

Currently at
tempting to access an invite via json will result in the following error:

```
HTTP_ACCEPT	application/json, text/javascript, */*; q=0.01
GET /invites/xxxxxxx

ActionView::MissingTemplate (Missing template invites/show, application/show with {:locale=>[:en_US, :en], :formats=>[:json], :variants=>[], :handlers=>[:raw, :erb, :html, :builder, :ruby]}. Searched in:
  * "/var/www/discourse/app/views"
)
```