### PR TITLE
FIX: show new/unread button when a new topic or post is created

### DIFF
--- a/app/assets/javascripts/discourse/components/navigation-item.js.es6
+++ b/app/assets/javascripts/discourse/components/navigation-item.js.es6
@@ -8,7 +8,7 @@ export default Component.extend(FilterModeMixin, {
     "active",
     "content.hasIcon:has-icon",
     "content.classNames",
-    "hidden"
+    "isHidden:hidden"
   ],
   attributeBindings: ["content.title:title"],
   hidden: false,
@@ -22,6 +22,18 @@ export default Component.extend(FilterModeMixin, {
       return active;
     }
     return contentFilterType === filterType;
+  },
+
+  @discourseComputed("content.count")
+  isHidden(count) {
+    return (
+      !this.active &&
+      this.currentUser &&
+      this.currentUser.trust_level > 0 &&
+      (this.content.get("name") === "new" ||
+        this.content.get("name") === "unread") &&
+      count < 1
+    );
   },
 
   didReceiveAttrs() {
@@ -53,17 +65,5 @@ export default Component.extend(FilterModeMixin, {
     this.set("hrefLink", href);
 
     this.set("activeClass", this.active ? "active" : "");
-
-    if (
-      !this.active &&
-      this.currentUser &&
-      this.currentUser.trust_level > 0 &&
-      (content.get("name") === "new" || content.get("name") === "unread") &&
-      content.get("count") < 1
-    ) {
-      this.set("hidden", true);
-    } else {
-      this.set("hidden", false);
-    }
   }
 });


### PR DESCRIPTION
There is a problem that if you read all messages, even when a new one
arrives, the button on the top is not showing.

This is because once the button got `hidden` class, a label under is
properly updated, however, the class is not removed.

Therefore, I added computed isHidden function which is recalculated when
`count` change.

![unread gif](https://user-images.githubusercontent.com/72780/71054767-43dc7d80-21a7-11ea-8fac-9d0dad9e4565.gif)
