### PR TITLE
FIX: Remove full nested quotes on direct reply

### DIFF
--- a/lib/cooked_post_processor.rb
+++ b/lib/cooked_post_processor.rb
@@ -83,7 +83,7 @@ class CookedPostProcessor
   def remove_full_quote_on_direct_reply
     return if !SiteSetting.remove_full_quote
     return if @post.post_number == 1
-    return if @doc.css("aside.quote").size != 1
+    return if @doc.xpath("aside[contains(@class, 'quote')]").size != 1
 
     previous = Post
       .where("post_number < ? AND topic_id = ? AND post_type = ? AND NOT hidden", @post.post_number, @post.topic_id, Post.types[:regular])
@@ -99,7 +99,7 @@ class CookedPostProcessor
 
     return if previous_text.gsub(/(\s){2,}/, '\1') != quoted_text.gsub(/(\s){2,}/, '\1')
 
-    quote_regexp = /\A\s*\[quote.+?\[\/quote\]/im
+    quote_regexp = /\A\s*\[quote.+\[\/quote\]/im
     quoteless_raw = @post.raw.sub(quote_regexp, "").strip
 
     return if @post.raw.strip == quoteless_raw

--- a/spec/components/cooked_post_processor_spec.rb
+++ b/spec/components/cooked_post_processor_spec.rb
@@ -1661,6 +1661,24 @@ describe CookedPostProcessor do
       RAW
     end
 
+    let(:raw3) do
+      <<~RAW.strip
+      [quote="#{post.user.username}, post:#{post.post_number}, topic:#{topic.id}"]
+
+      this is the “first” post
+
+      [/quote]
+
+      [quote="#{post.user.username}, post:#{post.post_number}, topic:#{topic.id}"]
+
+      this is the “first” post
+
+      [/quote]
+
+      and this is the third reply
+      RAW
+    end
+
     before do
       SiteSetting.remove_full_quote = true
     end
@@ -1683,6 +1701,13 @@ describe CookedPostProcessor do
         expect(reply.revisions.first.modifications["raw"]).to eq([raw, reply.raw])
         expect(reply.revisions.first.modifications["edit_reason"][1]).to eq(I18n.t(:removed_direct_reply_full_quotes))
       end
+    end
+
+    it 'does nothing if there are multiple quotes' do
+      reply = Fabricate(:post, topic: topic, raw: raw3)
+      CookedPostProcessor.new(reply).remove_full_quote_on_direct_reply
+      expect(topic.ordered_posts.pluck(:id)).to eq([post.id, reply.id])
+      expect(reply.raw).to eq(raw3)
     end
 
     it 'does not delete quote if not first paragraph' do
@@ -1714,6 +1739,19 @@ describe CookedPostProcessor do
       expect(reply.raw).to eq("and this is the third reply")
     end
 
+    it "works with nested quotes" do
+      reply1 = Fabricate(:post, topic: topic, raw: raw)
+      reply2 = Fabricate(:post, topic: topic, raw: <<~RAW.strip)
+        [quote="#{reply1.user.username}, post:#{reply1.post_number}, topic:#{topic.id}"]
+        #{raw}
+        [/quote]
+
+        quoting a post with a quote
+      RAW
+
+      CookedPostProcessor.new(reply2).remove_full_quote_on_direct_reply
+      expect(reply2.raw).to eq('quoting a post with a quote')
+    end
   end
 
 end


### PR DESCRIPTION
It used to check how many quotes were inside a post, without taking
considering that some quotes can contain other quotes. This commit
selects only top level quotes.

I had to use XPath because I could not find an equivalent CSS
selector.