### PR TITLE
DEV: Update Bundler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
           architecture: 'x64'
 
       - name: Setup bundler
-        run: gem install bundler -v 1.17.3 --no-doc
+        run: gem install bundler -v 2.1.1 --no-doc
 
       - name: Bundler cache
         uses: actions/cache@v1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -556,4 +556,4 @@ DEPENDENCIES
   yaml-lint
 
 BUNDLED WITH
-   1.17.3
+   2.1.1


### PR DESCRIPTION
Latest RubyGems 3.1.1 vendors bundler 2.1.0 *again*. And our base
image build system even updates it to 2.1.1.

After that it is unable to run a simple `bundle install` because of
version mismatch.

Updating bundler to the one that comes with our enforced Ruby version
solves this.