### PR TITLE
DEV: Remove buffered rendering from topic-list-item

### DIFF
--- a/app/assets/javascripts/discourse/components/topic-list-item.js.es6
+++ b/app/assets/javascripts/discourse/components/topic-list-item.js.es6
@@ -37,7 +37,7 @@ export default Component.extend({
   attributeBindings: ["data-topic-id"],
   "data-topic-id": alias("topic.id"),
 
-  init() {
+  didReceiveAttrs() {
     this._super(...arguments);
     this.renderTopicListItem();
   },
@@ -75,13 +75,8 @@ export default Component.extend({
     }
   },
 
-  @observes("bulkSelectEnabled", "topic.{pinned,tags}")
+  @observes("topic.pinned")
   rerenderTriggers() {
-    this.renderTopicListItem();
-  },
-
-  @discourseComputed("topic.{archived,visible,closed,category}")
-  rerenderComputedTriggers() {
     this.renderTopicListItem();
   },
 

--- a/app/assets/javascripts/discourse/components/topic-list-item.js.es6
+++ b/app/assets/javascripts/discourse/components/topic-list-item.js.es6
@@ -42,6 +42,7 @@ export default Component.extend({
     this.renderTopicListItem();
   },
 
+  @observes("topic.pinned")
   renderTopicListItem() {
     const template = findRawTemplate("list/topic-list-item");
     if (template) {
@@ -73,11 +74,6 @@ export default Component.extend({
     if (this.includeUnreadIndicator) {
       this.messageBus.unsubscribe(this.unreadIndicatorChannel);
     }
-  },
-
-  @observes("topic.pinned")
-  rerenderTriggers() {
-    this.renderTopicListItem();
   },
 
   @discourseComputed("topic.id")

--- a/app/assets/javascripts/discourse/components/topic-list-item.js.es6
+++ b/app/assets/javascripts/discourse/components/topic-list-item.js.es6
@@ -75,11 +75,13 @@ export default Component.extend({
     }
   },
 
-  @observes(
-    "bulkSelectEnabled",
-    "topic.{pinned,visible,archived,closed,category,tags}"
-  )
+  @observes("bulkSelectEnabled", "topic.{pinned,tags}")
   rerenderTriggers() {
+    this.renderTopicListItem();
+  },
+
+  @discourseComputed("topic.{archived,visible,closed,category}")
+  rerenderComputedTriggers() {
     this.renderTopicListItem();
   },
 

--- a/app/assets/javascripts/discourse/components/topic-list-item.js.es6
+++ b/app/assets/javascripts/discourse/components/topic-list-item.js.es6
@@ -77,12 +77,7 @@ export default Component.extend({
 
   @observes(
     "bulkSelectEnabled",
-    "topic.pinned",
-    "topic.visible",
-    "topic.archived",
-    "topic.closed",
-    "topic.category",
-    "topic.tags"
+    "topic.{pinned,visible,archived,closed,category,tags}"
   )
   rerenderTriggers() {
     this.renderTopicListItem();

--- a/app/assets/javascripts/discourse/components/topic-list-item.js.es6
+++ b/app/assets/javascripts/discourse/components/topic-list-item.js.es6
@@ -249,4 +249,3 @@ export default Component.extend({
     }
   })
 });
-

--- a/app/assets/javascripts/discourse/templates/components/topic-list-item.hbs
+++ b/app/assets/javascripts/discourse/templates/components/topic-list-item.hbs
@@ -1,0 +1,1 @@
+{{topicListItemContents}}


### PR DESCRIPTION
This is another refactoring in the multi-step process to remove all uses
of our custom Render Buffer.

Previous commit: 1c7305c0f1b26444dbd12918efb50e55a1231e73 in this
series.

This is just a refactor and should not change any functionality.