### PR TITLE
FIX: correct user serializer user method for extended serializer

### DIFF
--- a/app/serializers/basic_user_serializer.rb
+++ b/app/serializers/basic_user_serializer.rb
@@ -20,6 +20,6 @@ class BasicUserSerializer < ApplicationSerializer
   end
 
   def user
-    object[:user] || object
+    object[:user] || object.try(:user) || object
   end
 end

--- a/spec/fabricators/post_action_fabricator.rb
+++ b/spec/fabricators/post_action_fabricator.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+Fabricator(:post_action) do
+  post
+  user
+  post_action_type_id PostActionType.types[:like]
+end

--- a/spec/serializers/basic_user_serializer_spec.rb
+++ b/spec/serializers/basic_user_serializer_spec.rb
@@ -15,8 +15,7 @@ describe BasicUserSerializer do
     end
 
     describe 'extended serializers' do
-      Fabricator(:post_action)
-      let(:post_action) { Fabricate.build(:post_action, user: user) }
+      let(:post_action) { Fabricate(:post_action, user: user) }
       let(:serializer) { PostActionUserSerializer.new(post_action, scope: Guardian.new(user), root: false) }
       it "returns the user correctly" do
         expect(serializer.user.username).to eq(user.username)

--- a/spec/serializers/basic_user_serializer_spec.rb
+++ b/spec/serializers/basic_user_serializer_spec.rb
@@ -14,6 +14,16 @@ describe BasicUserSerializer do
       expect(json[:avatar_template]).to eq(user.avatar_template)
     end
 
+    describe 'extended serializers' do
+      Fabricator(:post_action) do
+      end
+      let(:post_action) { Fabricate.build(:post_action, user: user) }
+      let(:serializer) { PostActionUserSerializer.new(post_action, scope: Guardian.new(user), root: false) }
+      it "returns the user correctly" do
+        expect(serializer.user.username).to eq(user.username)
+      end
+    end
+
     it "doesn't return the name it when `enable_names` is false" do
       SiteSetting.enable_names = false
       expect(json[:name]).to eq(nil)

--- a/spec/serializers/basic_user_serializer_spec.rb
+++ b/spec/serializers/basic_user_serializer_spec.rb
@@ -15,8 +15,7 @@ describe BasicUserSerializer do
     end
 
     describe 'extended serializers' do
-      Fabricator(:post_action) do
-      end
+      Fabricator(:post_action)
       let(:post_action) { Fabricate.build(:post_action, user: user) }
       let(:serializer) { PostActionUserSerializer.new(post_action, scope: Guardian.new(user), root: false) }
       it "returns the user correctly" do


### PR DESCRIPTION
A small fix for Basic User Serializers where some downstream serializers do not correctly set user objects. This causes some issues in certain plugins that depend on the user method to return a user.

Submitting as a PR so I don't break anything in an end-of-day push-to-master rush. I will merge this tomorrow if this looks OK.