### PR TITLE
UX: Update time-based strings to be SI-compliant

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -71,37 +71,37 @@ en:
       wrap_ago: "%{date} ago"
 
       tiny:
-        half_a_minute: "< 1m"
+        half_a_minute: "< 1&nbsp;min"
         less_than_x_seconds:
-          one: "< %{count}s"
-          other: "< %{count}s"
+          one: "< %{count}&nbsp;s"
+          other: "< %{count}&nbsp;s"
         x_seconds:
-          one: "%{count}s"
-          other: "%{count}s"
+          one: "%{count}&nbsp;s"
+          other: "%{count}&nbsp;s"
         less_than_x_minutes:
-          one: "< %{count}m"
-          other: "< %{count}m"
+          one: "< %{count}&nbsp;min"
+          other: "< %{count}&nbsp;min"
         x_minutes:
-          one: "%{count}m"
-          other: "%{count}m"
+          one: "%{count}&nbsp;min"
+          other: "%{count}&nbsp;min"
         about_x_hours:
-          one: "%{count}h"
-          other: "%{count}h"
+          one: "%{count}&nbsp;h"
+          other: "%{count}&nbsp;h"
         x_days:
-          one: "%{count}d"
-          other: "%{count}d"
+          one: "%{count}&nbsp;d"
+          other: "%{count}&nbsp;d"
         x_months:
-          one: "%{count}mon"
-          other: "%{count}mon"
+          one: "%{count}&nbsp;mo"
+          other: "%{count}&nbsp;mo"
         about_x_years:
-          one: "%{count}y"
-          other: "%{count}y"
+          one: "%{count}&nbsp;y"
+          other: "%{count}&nbsp;y"
         over_x_years:
-          one: "> %{count}y"
-          other: "> %{count}y"
+          one: "> %{count}&nbsp;y"
+          other: "> %{count}&nbsp;y"
         almost_x_years:
-          one: "%{count}y"
-          other: "%{count}y"
+          one: "%{count}&nbsp;y"
+          other: "%{count}&nbsp;y"
         # Use Moment.js format string: https://momentjs.com/docs/#/displaying/format/
         date_month: "D MMM"
         # Use Moment.js format string: https://momentjs.com/docs/#/displaying/format/

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -575,7 +575,7 @@ en:
           attributes:
             word:
               too_many: "Too many words for that action"
-              
+
 
   uncategorized_category_name: "Uncategorized"
 
@@ -707,40 +707,40 @@ en:
 
   datetime:
     distance_in_words:
-      half_a_minute: "< 1m"
+      half_a_minute: "< 1&nbsp;min"
       less_than_x_seconds:
-        one: "< %{count}s"
-        other: "< %{count}s"
+        one: "< %{count}&nbsp;s"
+        other: "< %{count}&nbsp;s"
       x_seconds:
-        one: "%{count}s"
-        other: "%{count}s"
+        one: "%{count}&nbsp;s"
+        other: "%{count}&nbsp;s"
       less_than_x_minutes:
-        one: "< %{count}m"
-        other: "< %{count}m"
+        one: "< %{count}&nbsp;min"
+        other: "< %{count}&nbsp;min"
       x_minutes:
-        one: "%{count}m"
-        other: "%{count}m"
+        one: "%{count}&nbsp;min"
+        other: "%{count}&nbsp;min"
       about_x_hours:
-        one: "%{count}h"
-        other: "%{count}h"
+        one: "%{count}&nbsp;h"
+        other: "%{count}&nbsp;h"
       x_days:
-        one: "%{count}d"
-        other: "%{count}d"
+        one: "%{count}&nbsp;d"
+        other: "%{count}&nbsp;d"
       about_x_months:
-        one: "%{count}mon"
-        other: "%{count}mon"
+        one: "%{count}&nbsp;mo"
+        other: "%{count}&nbsp;mo"
       x_months:
-        one: "%{count}mon"
-        other: "%{count}mon"
+        one: "%{count}&nbsp;mo"
+        other: "%{count}&nbsp;mo"
       about_x_years:
-        one: "%{count}y"
-        other: "%{count}y"
+        one: "%{count}&nbsp;y"
+        other: "%{count}&nbsp;y"
       over_x_years:
-        one: "> %{count}y"
-        other: "> %{count}y"
+        one: "> %{count}&nbsp;y"
+        other: "> %{count}&nbsp;y"
       almost_x_years:
-        one: "%{count}y"
-        other: "%{count}y"
+        one: "%{count}&nbsp;y"
+        other: "%{count}&nbsp;y"
 
     distance_in_words_verbose:
       half_a_minute: "just now"

--- a/test/javascripts/lib/formatter-test.js.es6
+++ b/test/javascripts/lib/formatter-test.js.es6
@@ -93,7 +93,7 @@ QUnit.test("formating medium length dates", assert => {
   assert.equal(strip(formatDays(10)), shortDateYear(10));
 });
 
-QUnit.test("formating tiny dates", assert => {
+QUnit.test("formatting tiny dates", assert => {
   var shortDateYear = function(days) {
     return moment()
       .subtract(days, "days")
@@ -101,15 +101,15 @@ QUnit.test("formating tiny dates", assert => {
   };
 
   format = "tiny";
-  assert.equal(formatMins(0), "1m");
-  assert.equal(formatMins(1), "1m");
-  assert.equal(formatMins(2), "2m");
-  assert.equal(formatMins(60), "1h");
-  assert.equal(formatHours(4), "4h");
-  assert.equal(formatHours(23), "23h");
-  assert.equal(formatHours(23.5), "1d");
-  assert.equal(formatDays(1), "1d");
-  assert.equal(formatDays(14), "14d");
+  assert.equal(formatMins(0), "1&nbsp;min");
+  assert.equal(formatMins(1), "1&nbsp;min");
+  assert.equal(formatMins(2), "2&nbsp;min");
+  assert.equal(formatMins(60), "1&nbsp;h");
+  assert.equal(formatHours(4), "4&nbsp;h");
+  assert.equal(formatHours(23), "23&nbsp;h");
+  assert.equal(formatHours(23.5), "1&nbsp;d");
+  assert.equal(formatDays(1), "1&nbsp;d");
+  assert.equal(formatDays(14), "14&nbsp;d");
   assert.equal(formatDays(15), shortDate(15));
   assert.equal(formatDays(92), shortDate(92));
   assert.equal(formatDays(364), shortDate(364));
@@ -120,25 +120,25 @@ QUnit.test("formating tiny dates", assert => {
 
   var originalValue = Discourse.SiteSettings.relative_date_duration;
   Discourse.SiteSettings.relative_date_duration = 7;
-  assert.equal(formatDays(7), "7d");
+  assert.equal(formatDays(7), "7&nbsp;d");
   assert.equal(formatDays(8), shortDate(8));
 
   Discourse.SiteSettings.relative_date_duration = 1;
-  assert.equal(formatDays(1), "1d");
+  assert.equal(formatDays(1), "1&nbsp;d");
   assert.equal(formatDays(2), shortDate(2));
 
   Discourse.SiteSettings.relative_date_duration = 0;
-  assert.equal(formatMins(0), "1m");
-  assert.equal(formatMins(1), "1m");
-  assert.equal(formatMins(2), "2m");
-  assert.equal(formatMins(60), "1h");
+  assert.equal(formatMins(0), "1&nbsp;min");
+  assert.equal(formatMins(1), "1&nbsp;min");
+  assert.equal(formatMins(2), "2&nbsp;min");
+  assert.equal(formatMins(60), "1&nbsp;h");
   assert.equal(formatDays(1), shortDate(1));
   assert.equal(formatDays(2), shortDate(2));
   assert.equal(formatDays(366), shortDateYear(366));
 
   Discourse.SiteSettings.relative_date_duration = null;
-  assert.equal(formatDays(1), "1d");
-  assert.equal(formatDays(14), "14d");
+  assert.equal(formatDays(1), "1&nbsp;d");
+  assert.equal(formatDays(14), "14&nbsp;d");
   assert.equal(formatDays(15), shortDate(15));
 
   Discourse.SiteSettings.relative_date_duration = 14;
@@ -146,15 +146,15 @@ QUnit.test("formating tiny dates", assert => {
   clock.restore();
   clock = sinon.useFakeTimers(new Date(2012, 0, 12, 12, 0).getTime()); // Jan 12, 2012
 
-  assert.equal(formatDays(11), "11d");
-  assert.equal(formatDays(14), "14d");
+  assert.equal(formatDays(11), "11&nbsp;d");
+  assert.equal(formatDays(14), "14&nbsp;d");
   assert.equal(formatDays(15), shortDateYear(15));
   assert.equal(formatDays(366), shortDateYear(366));
 
   clock.restore();
   clock = sinon.useFakeTimers(new Date(2012, 0, 20, 12, 0).getTime()); // Jan 20, 2012
 
-  assert.equal(formatDays(14), "14d");
+  assert.equal(formatDays(14), "14&nbsp;d");
   assert.equal(formatDays(15), shortDate(15));
   assert.equal(formatDays(20), shortDateYear(20));
 
@@ -200,7 +200,7 @@ QUnit.test("updateRelativeAge", assert => {
 
   updateRelativeAge($elem);
 
-  assert.equal($elem.html(), "2m");
+  assert.equal($elem.html(), "2&nbsp;min");
 
   d = new Date();
   $elem = $(autoUpdatingRelativeAge(d, { format: "medium", leaveAgo: true }));
@@ -262,31 +262,47 @@ QUnit.test("number", assert => {
 QUnit.test("durationTiny", assert => {
   assert.equal(durationTiny(), "&mdash;", "undefined is a dash");
   assert.equal(durationTiny(null), "&mdash;", "null is a dash");
-  assert.equal(durationTiny(0), "< 1m", "0 seconds shows as < 1m");
-  assert.equal(durationTiny(59), "< 1m", "59 seconds shows as < 1m");
-  assert.equal(durationTiny(60), "1m", "60 seconds shows as 1m");
-  assert.equal(durationTiny(90), "2m", "90 seconds shows as 2m");
-  assert.equal(durationTiny(120), "2m", "120 seconds shows as 2m");
-  assert.equal(durationTiny(60 * 45), "1h", "45 minutes shows as 1h");
-  assert.equal(durationTiny(60 * 60), "1h", "60 minutes shows as 1h");
-  assert.equal(durationTiny(60 * 90), "2h", "90 minutes shows as 2h");
-  assert.equal(durationTiny(3600 * 23), "23h", "23 hours shows as 23h");
+  assert.equal(durationTiny(0), "< 1&nbsp;min", "0 seconds shows as < 1 min");
+  assert.equal(durationTiny(59), "< 1&nbsp;min", "59 seconds shows as < 1 min");
+  assert.equal(durationTiny(60), "1&nbsp;min", "60 seconds shows as 1 min");
+  assert.equal(durationTiny(90), "2&nbsp;min", "90 seconds shows as 2 min");
+  assert.equal(durationTiny(120), "2&nbsp;min", "120 seconds shows as 2 min");
+  assert.equal(durationTiny(60 * 45), "1&nbsp;h", "45 minutes shows as 1 h");
+  assert.equal(durationTiny(60 * 60), "1&nbsp;h", "60 minutes shows as 1 h");
+  assert.equal(durationTiny(60 * 90), "2&nbsp;h", "90 minutes shows as 2 h");
+  assert.equal(durationTiny(3600 * 23), "23&nbsp;h", "23 hours shows as 23 h");
   assert.equal(
     durationTiny(3600 * 24 - 29),
-    "1d",
-    "23 hours 31 mins shows as 1d"
+    "1&nbsp;d",
+    "23 hours 31 mins shows as 1 d"
   );
-  assert.equal(durationTiny(3600 * 24 * 89), "89d", "89 days shows as 89d");
+  assert.equal(
+    durationTiny(3600 * 24 * 89),
+    "89&nbsp;d",
+    "89 days shows as 89 d"
+  );
   assert.equal(
     durationTiny(60 * (525600 - 1)),
-    "12mon",
-    "364 days shows as 12mon"
+    "12&nbsp;mo",
+    "364 days shows as 12 mo"
   );
-  assert.equal(durationTiny(60 * 525600), "1y", "365 days shows as 1y");
-  assert.equal(durationTiny(86400 * 456), "1y", "456 days shows as 1y");
-  assert.equal(durationTiny(86400 * 457), "> 1y", "457 days shows as > 1y");
-  assert.equal(durationTiny(86400 * 638), "> 1y", "638 days shows as > 1y");
-  assert.equal(durationTiny(86400 * 639), "2y", "639 days shows as 2y");
-  assert.equal(durationTiny(86400 * 821), "2y", "821 days shows as 2y");
-  assert.equal(durationTiny(86400 * 822), "> 2y", "822 days shows as > 2y");
+  assert.equal(durationTiny(60 * 525600), "1&nbsp;y", "365 days shows as 1 y");
+  assert.equal(durationTiny(86400 * 456), "1&nbsp;y", "456 days shows as 1 y");
+  assert.equal(
+    durationTiny(86400 * 457),
+    "> 1&nbsp;y",
+    "457 days shows as > 1 y"
+  );
+  assert.equal(
+    durationTiny(86400 * 638),
+    "> 1&nbsp;y",
+    "638 days shows as > 1 y"
+  );
+  assert.equal(durationTiny(86400 * 639), "2&nbsp;y", "639 days shows as 2 y");
+  assert.equal(durationTiny(86400 * 821), "2&nbsp;y", "821 days shows as 2 y");
+  assert.equal(
+    durationTiny(86400 * 822),
+    "> 2&nbsp;y",
+    "822 days shows as > 2 y"
+  );
 });

--- a/test/javascripts/models/report-test.js.es6
+++ b/test/javascripts/models/report-test.js.es6
@@ -482,7 +482,7 @@ QUnit.test("computed labels", assert => {
   assert.equal(timeReadLabel.title, "Time read");
   assert.equal(timeReadLabel.type, "seconds");
   const computedTimeReadLabel = timeReadLabel.compute(row);
-  assert.equal(computedTimeReadLabel.formatedValue, "3d");
+  assert.equal(computedTimeReadLabel.formatedValue, "3&nbsp;d");
   assert.equal(computedTimeReadLabel.value, 287362);
 
   const noteLabel = computedLabels[3];


### PR DESCRIPTION
The units of second, minute, hour, and day are all SI units or are
associated with the SI, and therefore have symbols and not
abbreviations. The month is not an SI unit nor associated with it,
but is almost universally abbreviated as "mo". Finally, all units
should have a (non-breaking) space between the quantity and the
symbol/abbreviation. This commit addresses all these issues.