### PR TITLE
FIX: Update topic/post counter correctly when category has zero topics

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -180,26 +180,6 @@ class Category < ActiveRecord::Base
   end
 
   def self.update_stats
-    topics_with_post_count = Topic
-      .select("topics.category_id, COUNT(*) topic_count, SUM(topics.posts_count) post_count")
-      .where("topics.id NOT IN (select cc.topic_id from categories cc WHERE topic_id IS NOT NULL)")
-      .group("topics.category_id")
-      .visible.to_sql
-
-    DB.exec <<~SQL
-      UPDATE categories c
-         SET topic_count = COALESCE(x.topic_count, 0),
-             post_count = COALESCE(x.post_count, 0)
-        FROM (
-              SELECT ccc.id as category_id, stats.topic_count, stats.post_count
-              FROM categories ccc
-              LEFT JOIN (#{topics_with_post_count}) stats
-              ON stats.category_id = ccc.id
-             ) x
-       WHERE x.category_id = c.id
-         AND (c.topic_count <> COALESCE(x.topic_count, 0) OR c.post_count <> COALESCE(x.post_count, 0))
-    SQL
-
     # Yes, there are a lot of queries happening below.
     # Performing a lot of queries is actually faster than using one big update
     # statement with sub-selects on large databases with many categories,
@@ -213,12 +193,14 @@ class Category < ActiveRecord::Base
     Category.all.each do |c|
       topics = c.topics.visible
       topics = topics.where(['topics.id <> ?', c.topic_id]) if c.topic_id
+      c.topic_count = topics.count
       c.topics_year  = topics.created_since(1.year.ago).count
       c.topics_month = topics.created_since(1.month.ago).count
       c.topics_week  = topics.created_since(1.week.ago).count
       c.topics_day   = topics.created_since(1.day.ago).count
 
       posts = c.visible_posts
+      c.post_count  = posts.count
       c.posts_year  = posts.created_since(1.year.ago).count
       c.posts_month = posts.created_since(1.month.ago).count
       c.posts_week  = posts.created_since(1.week.ago).count

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -642,6 +642,22 @@ describe Category do
         expect(@uncategorized.posts_week).to eq(1)
       end
     end
+
+    context 'when there are no topics left' do
+      let!(:topic) { create_post(user: @category.user, category: @category.id).reload.topic }
+
+      it 'can update the topic count to zero' do
+        @category.reload
+        expect(@category.topic_count).to eq(1)
+        expect(@category.topics.count).to eq(2)
+        topic.delete # Delete so the post trash/destroy hook doesn't fire
+
+        Category.update_stats
+        @category.reload
+        expect(@category.topics.count).to eq(1)
+        expect(@category.topic_count).to eq(0)
+      end
+    end
   end
 
   describe "#url" do


### PR DESCRIPTION
Previously, categories without any topics were being excluded from the UPDATE query. This means the counter gets stuck, and the category cannot be deleted. This change ensures that the counters get correctly set to zero.