### PR TITLE
FIX: label helpers on sign up form are not hidden

### DIFF
--- a/app/assets/javascripts/discourse/components/input-tip.js.es6
+++ b/app/assets/javascripts/discourse/components/input-tip.js.es6
@@ -4,7 +4,6 @@ import { iconHTML } from "discourse-common/lib/icon-library";
 
 export default Component.extend({
   classNameBindings: [":tip", "good", "bad"],
-  rerenderTriggers: ["validation"],
   tipIcon: null,
   tipReason: null,
 

--- a/app/assets/javascripts/discourse/templates/components/input-tip.hbs
+++ b/app/assets/javascripts/discourse/templates/components/input-tip.hbs
@@ -1,1 +1,3 @@
-{{tipIcon}} {{tipReason}}
+{{#if tipReason}}
+  {{tipIcon}} {{tipReason}}
+{{/if}}


### PR DESCRIPTION
This commit https://github.com/discourse/discourse/commit/fe9293b8b554ab79636faa61a4756d5ff514a233 created a regression.

The problem is that dom changed a little bit.
Before it was
```
<tr class="instructions create-account-email">
  <td></td>
  <div id="account-email-validation" class="tip bad ember-view"></div>
  <td><label>Never shown to the public.</label></td>
</tr>
```

And after we got
```
<tr class="instructions create-account-email">
  <td></td>
  <div id="account-email-validation" class="tip bad ember-view"> </div>
  <td><label>Never shown to the public.</label></td>
</tr>
```
That small space may look like not important change.

However, now helpers are hitting that CSS rule:

```
.login-form {
  .tip {
    &:not(:empty) + td {
      display: none;
    }
}
```

To fix it, we should render template only if there is a reason - like it was before

```
if (reason) {
  buffer.push(iconHTML(this.good ? "check" : "times") + " " + reason);
}
```

This commit from @awesomerobot is fixing that issue https://github.com/discourse/discourse/commit/d449834a28b0c53257f7d6cbec5212847309ca08 so I closed that PR