### PR TITLE
UX: Do not use avatars as fallback opengraph images for replies

### DIFF
--- a/lib/topic_view.rb
+++ b/lib/topic_view.rb
@@ -236,11 +236,8 @@ class TopicView
   end
 
   def image_url
-    if @post_number > 1 && @desired_post.present?
-      @desired_post.image_url
-    else
-      @topic.image_url
-    end
+    url = @desired_post&.image_url if @post_number > 1
+    url || @topic.image_url
   end
 
   def filter_posts(opts = {})

--- a/lib/topic_view.rb
+++ b/lib/topic_view.rb
@@ -236,7 +236,7 @@ class TopicView
   end
 
   def image_url
-    url = @desired_post&.image_url if @post_number > 1
+    url = desired_post&.image_url if @post_number > 1
     url || @topic.image_url
   end
 

--- a/lib/topic_view.rb
+++ b/lib/topic_view.rb
@@ -237,12 +237,7 @@ class TopicView
 
   def image_url
     if @post_number > 1 && @desired_post.present?
-      if @desired_post.image_url.present?
-        @desired_post.image_url
-      elsif @desired_post.user
-        # show poster avatar
-        @desired_post.user.avatar_template_url.gsub("{size}", "200")
-      end
+      @desired_post.image_url
     else
       @topic.image_url
     end

--- a/spec/components/topic_view_spec.rb
+++ b/spec/components/topic_view_spec.rb
@@ -706,4 +706,35 @@ describe TopicView do
       expect(topic_view.read_time).to eq(nil)
     end
   end
+
+  describe '#image_url' do
+    let!(:post1) { Fabricate(:post, topic: topic) }
+    let!(:post2) { Fabricate(:post, topic: topic) }
+    let!(:post3) { Fabricate(:post, topic: topic).tap { |p| p.update_column(:image_url, "post3_image.png") }.reload }
+
+    def topic_view_for_post(post_number)
+      TopicView.new(topic.id, evil_trout, post_number: post_number)
+    end
+
+    context "when op has an image" do
+      before do
+        topic.update_column(:image_url, "op_image.png")
+        post1.update_column(:image_url, "op_image.png")
+      end
+
+      it "uses the topic image as a fallback when posts have no image" do
+        expect(topic_view_for_post(1).image_url).to eq("op_image.png")
+        expect(topic_view_for_post(2).image_url).to eq("op_image.png")
+        expect(topic_view_for_post(3).image_url).to eq("post3_image.png")
+      end
+    end
+
+    context "when op has no image" do
+      it "returns nil when posts have no image" do
+        expect(topic_view_for_post(1).image_url).to eq(nil)
+        expect(topic_view_for_post(2).image_url).to eq(nil)
+        expect(topic_view_for_post(3).image_url).to eq("post3_image.png")
+      end
+    end
+  end
 end


### PR DESCRIPTION
People rarely want to have their avatars show up as the preview image on social media platforms. Instead, we should fall back to the site opengraph image.