### PR TITLE
UX: Use '-' as default category slug

### DIFF
--- a/app/assets/javascripts/discourse/models/category.js.es6
+++ b/app/assets/javascripts/discourse/models/category.js.es6
@@ -261,12 +261,8 @@ Category.reopenClass({
       result = Category.slugFor(parentCategory) + separator;
     }
 
-    const id = get(category, "id"),
-      slug = get(category, "slug");
-
-    return !slug || slug.trim().length === 0
-      ? `${result}${id}-category`
-      : result + slug;
+    const slug = get(category, "slug");
+    return !slug || slug.trim().length === 0 ? `${result}-` : result + slug;
   },
 
   list() {

--- a/test/javascripts/models/category-test.js.es6
+++ b/test/javascripts/models/category-test.js.es6
@@ -17,13 +17,13 @@ QUnit.test("slugFor", assert => {
   );
   slugFor(
     store.createRecord("category", { id: 123, slug: "" }),
-    "123-category",
-    "It returns id-category for empty strings"
+    "-",
+    "It returns - for empty slugs"
   );
   slugFor(
     store.createRecord("category", { id: 456 }),
-    "456-category",
-    "It returns id-category for undefined slugs"
+    "-",
+    "It returns - for undefined slugs"
   );
   slugFor(
     store.createRecord("category", { slug: "熱帶風暴畫眉" }),
@@ -46,14 +46,14 @@ QUnit.test("slugFor", assert => {
 
   slugFor(
     store.createRecord("category", { id: 555, parentCategory: parentCategory }),
-    "darth/555-category",
+    "darth/-",
     "it uses the parent slug before the child and then uses id"
   );
 
   parentCategory.set("slug", null);
   slugFor(
     store.createRecord("category", { id: 555, parentCategory: parentCategory }),
-    "345-category/555-category",
+    "-/-",
     "it uses the parent before the child and uses ids for both"
   );
 });


### PR DESCRIPTION
This replaces the default slug from 'ID-category' to '-'.