### PR TITLE
PERF: Cache user badge count in user_stats table

### DIFF
--- a/app/models/badge.rb
+++ b/app/models/badge.rb
@@ -114,6 +114,7 @@ class Badge < ActiveRecord::Base
 
   after_commit do
     SvgSprite.expire_cache
+    UserStat.update_distinct_badge_count if saved_change_to_enabled?
   end
 
   # fields that can not be edited on system badges

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -945,7 +945,7 @@ class User < ActiveRecord::Base
   end
 
   def badge_count
-    user_stat.distinct_badge_count
+    user_stat&.distinct_badge_count
   end
 
   def featured_user_badges(limit = 3)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -945,7 +945,7 @@ class User < ActiveRecord::Base
   end
 
   def badge_count
-    user_badges.select('distinct badge_id').count
+    user_stat.distinct_badge_count
   end
 
   def featured_user_badges(limit = 3)

--- a/app/models/user_badge.rb
+++ b/app/models/user_badge.rb
@@ -18,11 +18,13 @@ class UserBadge < ActiveRecord::Base
 
   after_create do
     Badge.increment_counter 'grant_count', self.badge_id
+    UserStat.update_distinct_badge_count self.user_id
     DiscourseEvent.trigger(:user_badge_granted, self.badge_id, self.user_id)
   end
 
   after_destroy do
     Badge.decrement_counter 'grant_count', self.badge_id
+    UserStat.update_distinct_badge_count self.user_id
     DiscourseEvent.trigger(:user_badge_removed, self.badge_id, self.user_id)
   end
 

--- a/db/migrate/20191220134101_add_distinct_badge_count_to_user_stats.rb
+++ b/db/migrate/20191220134101_add_distinct_badge_count_to_user_stats.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+class AddDistinctBadgeCountToUserStats < ActiveRecord::Migration[6.0]
+  def change
+    add_column :user_stats, :distinct_badge_count, :integer, default: 0, null: false
+
+    execute <<~SQL
+      UPDATE user_stats
+      SET distinct_badge_count = x.distinct_badge_count
+      FROM (
+        SELECT users.id user_id, COUNT(distinct user_badges.badge_id) distinct_badge_count
+        FROM users
+        LEFT JOIN user_badges ON user_badges.user_id = users.id
+                              AND (user_badges.badge_id IN (SELECT id FROM badges WHERE enabled))
+        GROUP BY users.id
+      ) x
+      WHERE user_stats.user_id = x.user_id AND user_stats.distinct_badge_count <> x.distinct_badge_count
+    SQL
+  end
+end


### PR DESCRIPTION
This means that we no longer need to run a `count()` on the user_badges table when serializing a user