### PR TITLE
FIX: category routes model params should decode their URL parts

### DIFF
--- a/app/assets/javascripts/discourse/models/category.js.es6
+++ b/app/assets/javascripts/discourse/models/category.js.es6
@@ -334,7 +334,11 @@ Category.reopenClass({
   },
 
   findBySlugPathWithID(slugPathWithID) {
-    const parts = slugPathWithID.split("/");
+    let parts = slugPathWithID.split("/");
+    // slugs found by star/glob pathing in emeber do not automatically url decode - ensure that these are decoded
+    if (Discourse.SiteSettings.slug_generation_method === "encoded") {
+      parts = parts.map(urlPart => decodeURI(urlPart));
+    }
     let category = null;
 
     if (parts.length > 0 && parts[parts.length - 1].match(/^\d+$/)) {

--- a/app/assets/javascripts/discourse/routes/build-category-route.js.es6
+++ b/app/assets/javascripts/discourse/routes/build-category-route.js.es6
@@ -39,6 +39,12 @@ export default (filterArg, params) => {
             .filter(x => x)
             .join("/");
         }
+      } else if (Discourse.SiteSettings.slug_generation_method === "encoded") {
+        let separator = "/";
+        modelParams.category_slug_path_with_id = modelParams.category_slug_path_with_id
+          .split(separator)
+          .map(urlPart => decodeURI(urlPart))
+          .join(separator);
       }
 
       return modelParams;

--- a/app/assets/javascripts/discourse/routes/build-category-route.js.es6
+++ b/app/assets/javascripts/discourse/routes/build-category-route.js.es6
@@ -39,12 +39,6 @@ export default (filterArg, params) => {
             .filter(x => x)
             .join("/");
         }
-      } else if (Discourse.SiteSettings.slug_generation_method === "encoded") {
-        let separator = "/";
-        modelParams.category_slug_path_with_id = modelParams.category_slug_path_with_id
-          .split(separator)
-          .map(urlPart => decodeURI(urlPart))
-          .join(separator);
       }
 
       return modelParams;


### PR DESCRIPTION
Ember's route star globbing does not uri decode by default. This is
problematic for subcategory globs with encoded URL site settings enabled.

Subcategories with encoded URLs will 404 without this decode.

I found this https://github.com/tildeio/route-recognizer/pull/91
which explicitly explains that globbing does not decode automatically.