### PR TITLE
FIX: everyone can see poll results when on_vote and closed

### DIFF
--- a/plugins/poll/app/models/poll.rb
+++ b/plugins/poll/app/models/poll.rb
@@ -46,10 +46,8 @@ class Poll < ActiveRecord::Base
   end
 
   def can_see_results?(user)
-    return true if always?
     return !!user&.staff? if staff_only?
-    return has_voted?(user) if on_vote?
-    is_closed?
+    !!(always? || (on_vote? && has_voted?(user)) || is_closed?)
   end
 
   def has_voted?(user)

--- a/plugins/poll/spec/models/poll_spec.rb
+++ b/plugins/poll/spec/models/poll_spec.rb
@@ -16,4 +16,46 @@ describe ::DiscoursePoll::Poll do
       expect(::DiscoursePoll::Poll.transform_for_user_field_override(user_field_name)).to eq(user_field_name)
     end
   end
+
+  describe "can see results?" do
+    it "everyone can see results when results setting is always" do
+      post = Fabricate(:post, raw: "[poll]\n- A\n- B\n[/poll]")
+      user = Fabricate(:user)
+      expect(post.polls.first.can_see_results?(user)).to eq(true)
+    end
+
+    it "users who voted can see results when results setting is on_vote" do
+      post = Fabricate(:post, raw: "[poll results=on_vote]\n- A\n- B\n[/poll]")
+      user = Fabricate(:user)
+      poll = post.polls.first
+      option = poll.poll_options.first
+
+      expect(poll.can_see_results?(user)).to eq(false)
+      poll.poll_votes.create!(poll_option_id: option.id , user_id: user.id)
+      expect(poll.can_see_results?(user)).to eq(true)
+    end
+
+    it "everyone can see results when results setting is on_vote and poll is closed" do
+      post = Fabricate(:post, raw: "[poll results=on_vote]\n- A\n- B\n[/poll]")
+      user = Fabricate(:user)
+      poll = post.polls.first
+
+      expect(poll.can_see_results?(user)).to eq(false)
+      poll.update(close_at: Date.yesterday)
+      expect(poll.can_see_results?(user)).to eq(true)
+    end
+
+    it "only staff memebers can see results when results setting is staff_only" do
+      post = Fabricate(:post, raw: "[poll results=staff_only]\n- A\n- B\n[/poll]")
+      user = Fabricate(:user)
+      poll = post.polls.first
+      option = poll.poll_options.first
+
+      expect(poll.can_see_results?(user)).to eq(false)
+      poll.poll_votes.create!(poll_option_id: option.id , user_id: user.id)
+      expect(poll.can_see_results?(user)).to eq(false)
+      user.update!(moderator: true)
+      expect(poll.can_see_results?(user)).to eq(true)
+    end
+  end
 end


### PR DESCRIPTION
The bug was mentioned here: https://meta.discourse.org/t/poll-name/136436

I added specs to cover existing behaviour and refactored can_see_results method.

Guard condition should apply only if the poll result setting is set to `staff_only`.

In other cases, user can see results when the poll result setting is set to `always` or user voted or poll is closed.