### PR TITLE
FIX: bug when revoking badge as title

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -215,12 +215,13 @@ class UsersController < ApplicationController
       user.save!
 
       log_params = {
-        revoke_reason: 'user title was same as revoked badge name or custom badge name',
         previous_value: previous_title
       }
 
       if current_user.staff? && current_user != user
-        StaffActionLogger.new(current_user).log_title_revoke(user, log_params)
+        StaffActionLogger
+          .new(current_user)
+          .log_title_revoke(user, log_params.merge(revoke_reason: 'user title was same as revoked badge name or custom badge name'))
       else
         UserHistory.create!(log_params.merge(target_user_id: user.id, action: UserHistory.actions[:revoke_title]))
       end

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -1943,6 +1943,14 @@ describe UsersController do
       expect(user.user_profile.granted_title_badge_id).to eq(nil)
     end
 
+    it "is not raising an erroring when user revokes title" do
+      sign_in(user)
+      badge.update allow_title: true
+      put "/u/#{user.username}/preferences/badge_title.json", params: { user_badge_id: user_badge.id }
+      put "/u/#{user.username}/preferences/badge_title.json", params: { user_badge_id: 0 }
+      expect(response.status).to eq(200)
+    end
+
     context "with overrided name" do
       fab!(:badge) { Fabricate(:badge, name: 'Demogorgon', allow_title: true) }
       let(:user_badge) { BadgeGranter.grant(badge, user) }


### PR DESCRIPTION
When user revokes badge as title, UserHistory item is created. However,
that object is not accepting revoke_reson parameter.