### PR TITLE
DEV: Improve support for extending flags.

### DIFF
--- a/app/assets/javascripts/discourse/templates/components/flag-action-type.hbs
+++ b/app/assets/javascripts/discourse/templates/components/flag-action-type.hbs
@@ -18,7 +18,7 @@
     <h3>{{i18n 'flagging.notify_staff'}}</h3>
   {{/if}}
 {{else}}
-  <div class='controls'>
+  <div class="controls {{flag.name_key}}">
     <label class='radio'>
       <input type='radio' id="radio_{{unbound flag.name_key}}" {{action "changePostActionType" flag}} name='post_action_type_index'>
       <div class='flag-action-type-details'>

--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -127,8 +127,7 @@ class Plugin::Instance
   end
 
   # Applies to all sites in a multisite environment. Ignores plugin.enabled?
-  def replace_flags
-    settings = ::FlagSettings.new
+  def replace_flags(settings: ::FlagSettings.new)
     yield settings
 
     reloadable_patch do |plugin|


### PR DESCRIPTION
- Ensure that the 'notify_moderators' flag is always the last flag when using custom flags.
- Support passing a custom FlagSettings object when replacing flags to reuse existing ones.
