### PR TITLE
FIX: Add check for blank params in Webauthn::SecurityKeyBaseValidationService

### DIFF
--- a/lib/webauthn.rb
+++ b/lib/webauthn.rb
@@ -14,6 +14,7 @@ module Webauthn
 
   class SecurityKeyError < StandardError; end
 
+  class InvalidArgumentError < SecurityKeyError; end
   class InvalidOriginError < SecurityKeyError; end
   class InvalidRelyingPartyIdError < SecurityKeyError; end
   class UserVerificationError < SecurityKeyError; end

--- a/lib/webauthn/security_key_base_validation_service.rb
+++ b/lib/webauthn/security_key_base_validation_service.rb
@@ -6,6 +6,10 @@ module Webauthn
       @current_user = current_user
       @params = params
       @challenge_params = challenge_params
+
+      raise Webauthn::InvalidArgumentError if [
+        @params, @challenge_params, @current_user
+      ].any?(&:blank?)
     end
 
     def validate_webauthn_type(type_to_check)

--- a/spec/lib/webauthn/security_key_authentication_service_spec.rb
+++ b/spec/lib/webauthn/security_key_authentication_service_spec.rb
@@ -62,6 +62,13 @@ describe Webauthn::SecurityKeyAuthenticationService do
     expect(security_key.reload.last_used).not_to eq(nil)
   end
 
+  context "when the credential params are nil" do
+    let(:params) { nil }
+    it "raises a Webauthn::InvalidArgumentError error" do
+      expect { subject.authenticate_security_key }.to raise_error(Webauthn::InvalidArgumentError)
+    end
+  end
+
   context 'when the credential ID does not match any user security key in the database' do
     let(:credential_id) { 'badid' }
 


### PR DESCRIPTION
Added a fix to gracefully error with a Webauthn::SecurityKeyError if somehow a user provides blank params when validating a security key, e.g. on login. From this error in the dev logs:

```
Message (2 copies reported)
NoMethodError (undefined method `hash_function' for nil:NilClass)
/var/www/discourse/lib/webauthn/security_key_authentication_service.rb:67:in `authenticate_security_key'

Backtrace
/var/www/discourse/lib/webauthn/security_key_authentication_service.rb:67:in `authenticate_security_key'
/var/www/discourse/app/controllers/session_controller.rb:303:in `create'
```