### PR TITLE
FIX: Improved performance of report spec

### DIFF
--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -217,11 +217,14 @@ describe Report do
       context "with #{request_type}" do
         before(:each) do
           freeze_time DateTime.parse('2017-03-01 12:00')
-          ApplicationRequest.create(date: 35.days.ago.to_time, req_type: ApplicationRequest.req_types[request_type.to_s], count: 35)
-          ApplicationRequest.create(date: 7.days.ago.to_time, req_type: ApplicationRequest.req_types[request_type.to_s], count: 8)
-          ApplicationRequest.create(date: Time.now, req_type: ApplicationRequest.req_types[request_type.to_s], count: 1)
-          ApplicationRequest.create(date: 1.day.ago.to_time, req_type: ApplicationRequest.req_types[request_type.to_s], count: 2)
-          ApplicationRequest.create(date: 2.days.ago.to_time, req_type: ApplicationRequest.req_types[request_type.to_s], count: 3)
+          application_requests = [
+            { date: 35.days.ago.to_time, req_type: ApplicationRequest.req_types[request_type.to_s], count: 35 },
+            { date: 7.days.ago.to_time, req_type: ApplicationRequest.req_types[request_type.to_s], count: 8 },
+            { date: Time.now, req_type: ApplicationRequest.req_types[request_type.to_s], count: 1 },
+            { date: 1.day.ago.to_time, req_type: ApplicationRequest.req_types[request_type.to_s], count: 2 },
+            { date: 2.days.ago.to_time, req_type: ApplicationRequest.req_types[request_type.to_s], count: 3 }
+          ]
+          ApplicationRequest.insert_all(application_requests)
         end
 
         context 'returns a report with data' do
@@ -237,7 +240,7 @@ describe Report do
           end
 
           it "returns today's data" do
-            expect(report.data.select { |value| value[:x] == Date.today }).to be_present
+            expect(report.data.find { |value| value[:x] == Date.today }).to be_present
           end
 
           it 'returns total data' do

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -51,15 +51,17 @@ describe Report do
         freeze_time DateTime.parse('2017-03-01 12:00')
 
         # today, an incomplete day:
-        ApplicationRequest.create(date: 0.days.ago.to_time, req_type: ApplicationRequest.req_types['http_total'], count: 1)
+        application_requests = [{ date: 0.days.ago.to_time, req_type: ApplicationRequest.req_types['http_total'], count: 1 }]
 
         # 60 complete days:
-        30.times do |i|
-          ApplicationRequest.create(date: (i + 1).days.ago.to_time, req_type: ApplicationRequest.req_types['http_total'], count: 10)
+        30.times.each_with_object(application_requests) do |i|
+          application_requests.concat([{ date: (i + 1).days.ago.to_time, req_type: ApplicationRequest.req_types['http_total'], count: 10  }])
         end
-        30.times do |i|
-          ApplicationRequest.create(date: (31 + i).days.ago.to_time, req_type: ApplicationRequest.req_types['http_total'], count: 100)
+        30.times.each_with_object(application_requests) do |i|
+          application_requests.concat([{ date: (31 + i).days.ago.to_time, req_type: ApplicationRequest.req_types['http_total'], count: 100 }])
         end
+
+        ApplicationRequest.insert_all(application_requests)
       end
 
       subject(:json) { Report.find("http_total_reqs").as_json }

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -133,7 +133,6 @@ describe Report do
         expect(report.data.select { |v| v[:x].today? }).to be_present
         expect(report.prev30Days).to eq(2)
       end
-
     end
   end
 
@@ -179,9 +178,12 @@ describe Report do
           if arg == :flag
             user = Fabricate(:user)
             builder = -> (dt) { PostActionCreator.create(user, Fabricate(:post), :spam, created_at: dt) }
+          elsif arg == :signup
+            builder = -> (dt) { Fabricate(:user, created_at: dt) }
           else
-            factories = { signup: :user, email: :email_log }
-            builder = -> (dt) { Fabricate(factories[arg] || arg, created_at: dt) }
+            user = Fabricate(:user)
+            factories = { email: :email_log }
+            builder = -> (dt) { Fabricate(factories[arg] || arg, created_at: dt, user: user) }
           end
 
           [DateTime.now, 1.hour.ago, 1.hour.ago, 1.day.ago, 2.days.ago, 30.days.ago, 35.days.ago].each(&builder)

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -191,15 +191,9 @@ describe Report do
           [DateTime.now, 1.hour.ago, 1.hour.ago, 1.day.ago, 2.days.ago, 30.days.ago, 35.days.ago].each(&builder)
         end
 
-        it "returns today's data" do
+        it "returns today's, total and previous 30 day's data" do
           expect(report.data.select { |v| v[:x].today? }).to be_present
-        end
-
-        it 'returns total data' do
           expect(report.total).to eq 7
-        end
-
-        it "returns previous 30 day's data" do
           expect(report.prev30Days).to be_present
         end
       end
@@ -229,29 +223,24 @@ describe Report do
           ApplicationRequest.insert_all(application_requests)
         end
 
-        context 'returns a report with data' do
-          it "returns expected number of recoords" do
-            expect(report.data.count).to eq 4
-          end
+        it 'returns a report with data' do
+          # expected number of recoords
+          expect(report.data.count).to eq 4
 
-          it 'sorts the data from oldest to latest dates' do
-            expect(report.data[0][:y]).to eq(8) # 7 days ago
-            expect(report.data[1][:y]).to eq(3) # 2 days ago
-            expect(report.data[2][:y]).to eq(2) # 1 day ago
-            expect(report.data[3][:y]).to eq(1) # today
-          end
+          # sorts the data from oldest to latest dates
+          expect(report.data[0][:y]).to eq(8) # 7 days ago
+          expect(report.data[1][:y]).to eq(3) # 2 days ago
+          expect(report.data[2][:y]).to eq(2) # 1 day ago
+          expect(report.data[3][:y]).to eq(1) # today
 
-          it "returns today's data" do
-            expect(report.data.find { |value| value[:x] == Date.today }).to be_present
-          end
+          # today's data
+          expect(report.data.find { |value| value[:x] == Date.today }).to be_present
 
-          it 'returns total data' do
-            expect(report.total).to eq 49
-          end
+          # total data
+          expect(report.total).to eq 49
 
-          it 'returns previous 30 days of data' do
-            expect(report.prev30Days).to eq 35
-          end
+          #previous 30 days of data
+          expect(report.prev30Days).to eq 35
         end
       end
     end

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -77,10 +77,20 @@ describe Report do
       before do
         Report.clear_cache
         freeze_time DateTime.parse('2017-03-01 12:00')
-
-        ((0..32).to_a + [60, 61, 62, 63]).each do |i|
-          Fabricate(:topic, created_at: i.days.ago)
+        user = Fabricate(:user)
+        topics = ((0..32).to_a + [60, 61, 62, 63]).map do |i|
+          date = i.days.ago
+          {
+            user_id: user.id,
+            last_post_user_id: user.id,
+            title: "topic #{i}",
+            category_id: SiteSetting.uncategorized_category_id,
+            bumped_at: date,
+            created_at: date,
+            updated_at: date
+          }
         end
+        Topic.insert_all(topics)
       end
 
       it "counts the correct records" do


### PR DESCRIPTION
Before it was around 18 seconds and now it is around 10 seconds. 

For review, I would recommend going commit by commit because each improvement is in a separate commit.

The biggest improvement was by not creating not necessary database entities. For example `topic` fabricator is creating a user if none is passed. If we create topics in a loop, we are creating a bunch of not relevant users. 

Also when setup in before(:each) is expensive, I merged examples to one, to avoid that calculation.

There are significantly fewer tests because of that (that merged examples from the last commit was defined in the loop) 
```
 [:signup, :topic, :post, :flag, :like, :email].each
```

Before
<img width="554" alt="WindowsTerminal_DrZ72IwKvh" src="https://user-images.githubusercontent.com/72780/71610170-f6b6cd80-2be2-11ea-8f99-e8538273cc92.png">

After
<img width="535" alt="WindowsTerminal_tC6Do3ATEF" src="https://user-images.githubusercontent.com/72780/71610173-fae2eb00-2be2-11ea-9fe1-fd8945c8300d.png">
