### PR TITLE
FIX: hide topic admin menu button for regular users

### DIFF
--- a/app/assets/javascripts/discourse/widgets/topic-admin-menu.js.es6
+++ b/app/assets/javascripts/discourse/widgets/topic-admin-menu.js.es6
@@ -45,9 +45,8 @@ createWidget("topic-admin-menu-button", {
 
     // We don't show the button when expanded on the right side on desktop
     if (
-      (menu.attrs.actionButtons.length &&
-        !(attrs.rightSide && state.expanded)) ||
-      this.site.mobileView
+      menu.attrs.actionButtons.length &&
+      (!(attrs.rightSide && state.expanded) || this.site.mobileView)
     ) {
       result.push(
         this.attach("button", {


### PR DESCRIPTION
This bug was introduced here https://github.com/discourse/discourse/commit/b725252cd0c60d17521499d70f021cfde2114ccf#diff-a75b5e5a8561229e772a6c8e14804786R49

Wrench button is displayed on mobile for all users, not just admins with no actions available

![image](https://user-images.githubusercontent.com/72780/71617733-8626a580-2c10-11ea-8a25-1a0ffe42e1b4.png)
