### PR TITLE
FIX: Catch error when unknown COSE algorithm is supplied for Security Key

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -943,6 +943,7 @@ en:
       public_key_error: "The public key verification for the credential failed."
       ownership_error: "The security key is not owned by the user."
       not_found_error: "A security key with the provided credential ID could not be found."
+      unknown_cose_algorithm_error: "The algorithm used for the security key is not recognized."
 
   topic_flag_types:
     spam:

--- a/lib/webauthn.rb
+++ b/lib/webauthn.rb
@@ -26,4 +26,5 @@ module Webauthn
   class NotFoundError < SecurityKeyError; end
   class OwnershipError < SecurityKeyError; end
   class PublicKeyError < SecurityKeyError; end
+  class UnknownCOSEAlgorithmError < SecurityKeyError; end
 end

--- a/spec/lib/webauthn/security_key_authentication_service_spec.rb
+++ b/spec/lib/webauthn/security_key_authentication_service_spec.rb
@@ -131,4 +131,16 @@ describe Webauthn::SecurityKeyAuthenticationService do
       )
     end
   end
+
+  context 'when the COSE algorithm used cannot be found' do
+    before do
+      COSE::Algorithm.expects(:find).returns(nil)
+    end
+
+    it 'raises a UnknownCOSEAlgorithmError' do
+      expect { subject.authenticate_security_key }.to raise_error(
+        Webauthn::UnknownCOSEAlgorithmError, I18n.t('webauthn.validation.unknown_cose_algorithm_error')
+      )
+    end
+  end
 end


### PR DESCRIPTION
Added a fix to gracefully error with a Webauthn::SecurityKeyError if somehow a user provides an unkown COSE algorithm when logging in with a security key. From this error in the dev logs:

```
Message (2 copies reported)
NoMethodError (undefined method `hash_function' for nil:NilClass)
/var/www/discourse/lib/webauthn/security_key_authentication_service.rb:67:in `authenticate_security_key'

Backtrace
/var/www/discourse/lib/webauthn/security_key_authentication_service.rb:67:in `authenticate_security_key'
/var/www/discourse/app/controllers/session_controller.rb:303:in `create'
```

If `COSE::Algorithm.find` returns nil we now fail gracefully and log the algorithm used along with the user ID and the security key params for debugging, as this will help us find other common algorithms to implement for webauthn
