### PR TITLE
DEV: Log to STDOUT if RAILS_ENABLE_TEST_LOG

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -50,6 +50,9 @@ Discourse::Application.configure do
   unless ENV['RAILS_ENABLE_TEST_LOG']
     config.logger = Logger.new(nil)
     config.log_level = :fatal
+  else
+    config.logger = Logger.new(STDOUT)
+    config.log_level = ENV['RAILS_TEST_LOG_LEVEL'].present? ? ENV['RAILS_TEST_LOG_LEVEL'].to_sym : :info
   end
 
   if defined? RspecErrorTracker

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -47,12 +47,12 @@ Discourse::Application.configure do
 
   config.eager_load = false
 
-  unless ENV['RAILS_ENABLE_TEST_LOG']
-    config.logger = Logger.new(nil)
-    config.log_level = :fatal
-  else
+  if ENV['RAILS_ENABLE_TEST_LOG']
     config.logger = Logger.new(STDOUT)
     config.log_level = ENV['RAILS_TEST_LOG_LEVEL'].present? ? ENV['RAILS_TEST_LOG_LEVEL'].to_sym : :info
+  else
+    config.logger = Logger.new(nil)
+    config.log_level = :fatal
   end
 
   if defined? RspecErrorTracker


### PR DESCRIPTION
The env var `RAILS_ENABLE_TEST_LOG` didn't seem to do anything if enabled. This now sets the logger to STDOUT if `RAILS_ENABLE_TEST_LOG` is enabled and also introduces `RAILS_TEST_LOG_LEVEL` so the level of the logging in the console can be provided (default info).

Note: I am not sure if the original behaviour is expected. I can add an additional env var to enable the STDOUT logging if required