### PR TITLE
FIX: Add a blank poll options validation

### DIFF
--- a/plugins/poll/config/locales/server.en.yml
+++ b/plugins/poll/config/locales/server.en.yml
@@ -43,6 +43,9 @@ en:
     default_poll_must_have_different_options: "Poll must have different options."
     named_poll_must_have_different_options: "Poll named <strong>%{name}</strong> must have different options."
 
+    default_poll_must_not_have_any_empty_options: "Poll must not have any empty options."
+    named_poll_must_not_have_any_empty_options: "Poll named <strong>%{name}</strong> must not have any empty options."
+
     default_poll_with_multiple_choices_has_invalid_parameters: "Poll with multiple choices has invalid parameters."
     named_poll_with_multiple_choices_has_invalid_parameters: "Poll named <strong>%{name}</strong> with multiple choice has invalid parameters."
 

--- a/plugins/poll/lib/polls_validator.rb
+++ b/plugins/poll/lib/polls_validator.rb
@@ -17,6 +17,7 @@ module DiscoursePoll
         return false unless valid_numbers?(poll)
         return false unless unique_poll_name?(polls, poll)
         return false unless unique_options?(poll)
+        return false unless any_blank_options?(poll)
         return false unless at_least_two_options?(poll)
         return false unless valid_number_of_options?(poll)
         return false unless valid_multiple_choice_settings?(poll)
@@ -69,6 +70,20 @@ module DiscoursePoll
           @post.errors.add(:base, I18n.t("poll.default_poll_must_have_different_options"))
         else
           @post.errors.add(:base, I18n.t("poll.named_poll_must_have_different_options", name: poll["name"]))
+        end
+
+        return false
+      end
+
+      true
+    end
+
+    def any_blank_options?(poll)
+      if poll["options"].any? { |o| o["html"].blank? }
+        if poll["name"] == ::DiscoursePoll::DEFAULT_POLL_NAME
+          @post.errors.add(:base, I18n.t("poll.default_poll_must_not_have_any_empty_options"))
+        else
+          @post.errors.add(:base, I18n.t("poll.named_poll_must_not_have_any_empty_options", name: poll["name"]))
         end
 
         return false

--- a/plugins/poll/spec/lib/polls_validator_spec.rb
+++ b/plugins/poll/spec/lib/polls_validator_spec.rb
@@ -124,6 +124,36 @@ describe ::DiscoursePoll::PollsValidator do
       )
     end
 
+    it "ensures that polls do not have any blank options" do
+      raw = <<~RAW
+      [poll]
+      * 1
+      *
+      [/poll]
+      RAW
+
+      post.raw = raw
+      expect(post.valid?).to eq(false)
+
+      expect(post.errors[:base]).to include(
+        I18n.t("poll.default_poll_must_not_have_any_empty_options")
+      )
+
+      raw = <<~RAW
+      [poll name=test]
+      *
+      * 1
+      [/poll]
+      RAW
+
+      post.raw = raw
+      expect(post.valid?).to eq(false)
+
+      expect(post.errors[:base]).to include(
+        I18n.t("poll.named_poll_must_not_have_any_empty_options", name: "test")
+      )
+    end
+
     it "ensure that polls have at least 2 options" do
       raw = <<~RAW
       [poll]


### PR DESCRIPTION
Before, saving a post with a blank poll option resulted in error 500.