### PR TITLE
DEV: Don't run the PLUGINS-LINT stage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,14 @@ on:
     
 jobs:
   build:
-    name: "${{ matrix.target }}-${{ matrix.build_types }}"
+    name: "${{ matrix.target }}-${{ matrix.build_type }}"
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
 
     env:
       DISCOURSE_HOSTNAME: www.example.com
       RUBY_GLOBAL_METHOD_CACHE_SIZE: 131072
-      BUILD_TYPE: ${{ matrix.build_types }}
+      BUILD_TYPE: ${{ matrix.build_type }}
       TARGET: ${{ matrix.target }}
       RAILS_ENV: test
       PGHOST: localhost
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
 
       matrix:
-        build_types: [ 'BACKEND', 'FRONTEND', 'LINT' ]
+        build_type: [ 'BACKEND', 'FRONTEND', 'LINT' ]
         target: [ 'PLUGINS', 'CORE' ]
         os: [ ubuntu-latest ]
         ruby: [ '2.6.3' ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: CI
-   
+
 on:
   push:
     branches:
@@ -7,7 +7,7 @@ on:
   pull_request:
     branches-ignore:
       - 'tests-passed'
-    
+
 jobs:
   build:
     name: "${{ matrix.target }}-${{ matrix.build_type }}"
@@ -41,7 +41,7 @@ jobs:
     services:
       postgres:
         image: postgres:${{ matrix.postgres }}
-        ports: 
+        ports:
           - 5432:5432
         env:
           POSTGRES_USER: discourse
@@ -91,14 +91,14 @@ jobs:
           key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-gem-
-      
+
       - name: Setup gems
         run: bundle install --without development --deployment --jobs 4 --retry 3
 
       - name: Get yarn cache directory
         id: yarn-cache-dir
         run: echo "::set-output name=dir::$(yarn cache dir)"
-    
+
       - name: Yarn cache
         uses: actions/cache@v1
         id: yarn-cache
@@ -116,7 +116,7 @@ jobs:
         run: bin/rake plugin:install_all_official
 
       - name: Create database
-        if: env.BUILD_TYPE != 'LINT'    
+        if: env.BUILD_TYPE != 'LINT'
         run: bin/rake db:create && bin/rake db:migrate
 
       - name: Create parallel databases
@@ -126,7 +126,7 @@ jobs:
       - name: Rubocop
         if: env.BUILD_TYPE == 'LINT'
         run: bundle exec rubocop .
-      
+
       - name: ESLint
         if: env.BUILD_TYPE == 'LINT'
         run: yarn eslint app/assets/javascripts test/javascripts && yarn eslint --ext .es6 app/assets/javascripts test/javascripts plugins
@@ -136,7 +136,7 @@ jobs:
         run: |
           yarn prettier -v
           yarn prettier --list-different "app/assets/stylesheets/**/*.scss" "app/assets/javascripts/**/*.es6" "test/javascripts/**/*.es6" "plugins/**/*.scss" "plugins/**/*.es6"
-        
+
       - name: Core RSpec
         if: env.BUILD_TYPE == 'BACKEND' && env.TARGET == 'CORE'
         run: bin/turbo_rspec && bin/rake plugin:spec
@@ -149,14 +149,14 @@ jobs:
         if: env.BUILD_TYPE == 'FRONTEND' && env.TARGET == 'CORE'
         run: bundle exec rake qunit:test['1200000']
         timeout-minutes: 30
-      
+
       - name: Wizard QUnit
         if: env.BUILD_TYPE == 'FRONTEND' && env.TARGET == 'CORE'
         run: bundle exec rake qunit:test['1200000','/wizard/qunit']
         timeout-minutes: 30
-          
+
       - name: Plugin QUnit # Tests core plugins in TARGET=CORE, and all plugins in TARGET=PLUGINS
         if: env.BUILD_TYPE == 'FRONTEND'
         run: bundle exec rake plugin:qunit
         timeout-minutes: 30
-        
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         redis: [ '4.x' ]
         exclude:
           - build_type: 'LINT'
-          - target: 'PLUGINS'
+            target: 'PLUGINS'
 
     services:
       postgres:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
         ruby: [ '2.6.3' ]
         postgres: [ '10' ]
         redis: [ '4.x' ]
+        exclude:
+          - build_type: 'LINT'
+          - target: 'PLUGINS'
 
     services:
       postgres:


### PR DESCRIPTION
It's unlikely that changes introduced in a PR would trigger lint errors in non-default official plugins.
What might happen though (and did at least once) is that an unrelated lint error in a plugin can fail the master build and all PR builds.

@davidtaylorhq, @jjaffeux?