### PR TITLE
FIX: Bots accuracy should be zero

### DIFF
--- a/app/models/reviewable_score.rb
+++ b/app/models/reviewable_score.rb
@@ -62,7 +62,7 @@ class ReviewableScore < ActiveRecord::Base
   #   if > 5 flags => (agreed flags / total flags) * 5.0
   def self.user_accuracy_bonus(user)
     user_stat = user&.user_stat
-    return 0.0 if user_stat.blank?
+    return 0.0 if user_stat.blank? || user.bot?
 
     calc_user_accuracy_bonus(user_stat.flags_agreed, user_stat.flags_disagreed)
   end

--- a/spec/models/reviewable_score_spec.rb
+++ b/spec/models/reviewable_score_spec.rb
@@ -96,6 +96,16 @@ RSpec.describe ReviewableScore, type: :model do
       expect(ReviewableScore.user_accuracy_bonus(user)).to eq(0.0)
     end
 
+    it "returns 0 for a user with no flags" do
+      system_user = Discourse.system_user
+      stats = system_user.user_stat
+
+      stats.flags_agreed = 10
+      stats.flags_disagreed = 42
+
+      expect(ReviewableScore.user_accuracy_bonus(system_user)).to eq(0.0)
+    end
+
     it "returns 0 until the user has made more than 5 flags" do
       user_stat.flags_agreed = 4
       user_stat.flags_disagreed = 1


### PR DESCRIPTION
Reviewables generated by automated systems (Akismet) should not lose weight due to poor accuracy.