### PR TITLE
FIX: Don't return error 500 when invalid date param is given to admin reports

### DIFF
--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -88,8 +88,12 @@ class Admin::ReportsController < Admin::AdminController
   private
 
   def parse_params(report_params)
-    start_date = (report_params[:start_date].present? ? Time.parse(report_params[:start_date]).to_date : 1.days.ago).beginning_of_day
-    end_date = (report_params[:end_date].present? ? Time.parse(report_params[:end_date]).to_date : start_date + 30.days).end_of_day
+    begin
+      start_date = (report_params[:start_date].present? ? Time.parse(report_params[:start_date]).to_date : 1.days.ago).beginning_of_day
+      end_date = (report_params[:end_date].present? ? Time.parse(report_params[:end_date]).to_date : start_date + 30.days).end_of_day
+    rescue ArgumentError => e
+      raise Discourse::InvalidParameters.new(e.message)
+    end
 
     facets = nil
     if Array === report_params[:facets]

--- a/spec/requests/admin/reports_controller_spec.rb
+++ b/spec/requests/admin/reports_controller_spec.rb
@@ -47,6 +47,24 @@ describe Admin::ReportsController do
             expect(JSON.parse(response.body)["reports"][1]["type"]).to eq("not_found")
           end
         end
+
+        context "invalid start or end dates" do
+          it "doesn't return 500 error" do
+            get "/admin/reports/bulk.json", params: {
+              reports: {
+                topics: { limit: 10, start_date: "2015-0-1" }
+              }
+            }
+            expect(response.status).to eq(400)
+
+            get "/admin/reports/bulk.json", params: {
+              reports: {
+                topics: { limit: 10, end_date: "2015-0-1" }
+              }
+            }
+            expect(response.status).to eq(400)
+          end
+        end
       end
     end
 


### PR DESCRIPTION
Error 500 creates noise in the logs, this changes the response to 400 when `start_date` or `end_date` are are invalid (e.g. month 0).