### PR TITLE
FIX: Cached new topic data should not be deleted after dismiss new

### DIFF
--- a/app/assets/javascripts/discourse/controllers/discovery/topics.js.es6
+++ b/app/assets/javascripts/discourse/controllers/discovery/topics.js.es6
@@ -83,7 +83,6 @@ const controllerOpts = {
     },
 
     resetNew() {
-      this.topicTrackingState.resetNew();
       Topic.resetNew(this.category, !this.noSubcategories).then(() =>
         this.send("refresh")
       );

--- a/app/assets/javascripts/discourse/models/topic-tracking-state.js.es6
+++ b/app/assets/javascripts/discourse/models/topic-tracking-state.js.es6
@@ -381,14 +381,6 @@ const TopicTrackingState = EmberObject.extend({
       .value().length;
   },
 
-  resetNew() {
-    Object.keys(this.states).forEach(id => {
-      if (this.states[id].last_read_post_number === null) {
-        delete this.states[id];
-      }
-    });
-  },
-
   countUnread(category_id) {
     return _.chain(this.states)
       .filter(isUnread)


### PR DESCRIPTION
43ddf60cdf27a865b7b1aa0d54a144a3e46c74cf introduced a new method for dismissing new topics in topic-tracking-state, which works on a per-category basis.

This commit removes the old mechanism, which was to delete all 'new' topics from the local tracking state, regardless of category.