### PR TITLE
DEV: Allow CSP to be enabled during QUnit tests

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -224,8 +224,9 @@ module Discourse
     # supports etags (post 1.7)
     config.middleware.delete Rack::ETag
 
-    if Rails.env.production?
+    if !(Rails.env.development? || ENV['SKIP_ENFORCE_HOSTNAME'] == "1")
       require 'middleware/enforce_hostname'
+      puts "enforcing hostname"
       config.middleware.insert_after Rack::MethodOverride, Middleware::EnforceHostname
     end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -226,7 +226,6 @@ module Discourse
 
     if !(Rails.env.development? || ENV['SKIP_ENFORCE_HOSTNAME'] == "1")
       require 'middleware/enforce_hostname'
-      puts "enforcing hostname"
       config.middleware.insert_after Rack::MethodOverride, Middleware::EnforceHostname
     end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -224,7 +224,7 @@ module Discourse
     # supports etags (post 1.7)
     config.middleware.delete Rack::ETag
 
-    unless Rails.env.development?
+    if Rails.env.production?
       require 'middleware/enforce_hostname'
       config.middleware.insert_after Rack::MethodOverride, Middleware::EnforceHostname
     end

--- a/lib/content_security_policy/middleware.rb
+++ b/lib/content_security_policy/middleware.rb
@@ -12,7 +12,7 @@ class ContentSecurityPolicy
       _, headers, _ = response = @app.call(env)
 
       return response unless html_response?(headers)
-      ContentSecurityPolicy.base_url = request.host_with_port if Rails.env.development?
+      ContentSecurityPolicy.base_url = request.host_with_port if !Rails.env.production?
 
       theme_ids = env[:resolved_theme_ids]
 

--- a/lib/tasks/qunit.rake
+++ b/lib/tasks/qunit.rake
@@ -7,9 +7,6 @@ task "qunit:test", [:timeout, :qunit_path] => :environment do |_, args|
   require "socket"
   require 'rbconfig'
 
-  puts "Turning off CSP to allow qunit to run"
-  SiteSetting.content_security_policy = false
-
   if RbConfig::CONFIG['host_os'][/darwin|mac os/]
     google_chrome_cli = "/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome"
   else

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -252,10 +252,6 @@ RSpec.configure do |config|
     ActiveRecord::Base.establish_connection
   end
 
-  config.before(:each, type: :request) do
-    host! "test.localhost"
-  end
-
   class TestCurrentUserProvider < Auth::DefaultCurrentUserProvider
     def log_on_user(user, session, cookies, opts = {})
       session[:current_user_id] = user.id

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -252,6 +252,10 @@ RSpec.configure do |config|
     ActiveRecord::Base.establish_connection
   end
 
+  config.before(:each, type: :request) do
+    host! "test.localhost"
+  end
+
   class TestCurrentUserProvider < Auth::DefaultCurrentUserProvider
     def log_on_user(user, session, cookies, opts = {})
       session[:current_user_id] = user.id


### PR DESCRIPTION
The QUnit rake task starts a server in test mode. Therefore we need some tweaks to allow dynamic hostnames and dynamic CSP hostnames in test mode. These tweaks are already present in development mode.