### PR TITLE
FEATURE: Add rake task to disable secure media

### DIFF
--- a/lib/tasks/uploads.rake
+++ b/lib/tasks/uploads.rake
@@ -910,7 +910,6 @@ task "uploads:recover" => :environment do
 end
 
 task "uploads:disable_secure_media" => :environment do
-  # loc sec up  [-6, -5, 67, 69, 28, -4, -3, -2, -1, 1, 27, 26, 33, 38, 31, 34, 35, 65, 39, 29, 40, 30, 32, 36, 49, 66, 41, 52, 54]
   RailsMultisite::ConnectionManagement.each_connection do |db|
     unless Discourse.store.external?
       puts "This task only works for external storage."
@@ -922,7 +921,7 @@ task "uploads:disable_secure_media" => :environment do
     Upload.transaction do
       SiteSetting.secure_media = false
 
-      secure_uploads = Upload.where(id: [-6, -5, 67, 69, 28, -4, -3, -2, -1, 1, 27, 26, 33, 38, 31, 34, 35, 65, 39, 29, 40, 30, 32, 36, 49, 66, 41, 52, 54]) # Upload.where(secure: true)
+      secure_uploads = Upload.where(secure: true)
       secure_upload_ids = secure_uploads.pluck(:id)
 
       puts "Updating all uploads to secure: false."

--- a/lib/tasks/uploads.rake
+++ b/lib/tasks/uploads.rake
@@ -922,6 +922,7 @@ task "uploads:disable_secure_media" => :environment do
 
     secure_uploads = Upload.includes(:posts).where(secure: true)
     secure_upload_count = secure_uploads.count
+
     i = 0
     secure_uploads.find_each(batch_size: 20).each do |upload|
       Upload.transaction do

--- a/spec/requests/uploads_controller_spec.rb
+++ b/spec/requests/uploads_controller_spec.rb
@@ -431,6 +431,23 @@ describe UploadsController do
         result = JSON.parse(response.body)
         expect(result[0]["url"]).to match("secure-media-uploads")
       end
+
+      context "when secure media is disabled" do
+        before do
+          SiteSetting.secure_media = false
+        end
+
+        it "should redirect to the regular show route" do
+          secure_url = upload.url.sub(SiteSetting.Upload.absolute_base_url, "/secure-media-uploads")
+          sign_in(user)
+          stub_request(:head, "https://#{SiteSetting.s3_upload_bucket}.s3.amazonaws.com/")
+
+          get secure_url
+
+          expect(response.status).to eq(302)
+          expect(response.redirect_url).to eq(Discourse.store.cdn_url(upload.url))
+        end
+      end
     end
   end
 


### PR DESCRIPTION
* Add a rake task to disable secure media. This sets all uploads to `secure: false`, changes the upload ACL to public, and rebakes all the posts using the uploads to make sure they point to the correct URLs. This is in a transaction for each upload with the upload being updated the last step, so if the task fails it can be resumed.
* Also allow viewing media via the secure url if secure media is disabled, redirecting to the normal CDN url, because otherwise media links will be broken while we go and rebake all the posts + update ACLs