### PR TITLE
enqueue spam/dmarc failing emails instead of hiding

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -4655,7 +4655,7 @@ en:
       category: "Posts in this category require manual approval by staff. See the category settings."
       must_approve_users: "All new users must be approved by staff. See `must_approve_users`."
       invite_only: "All new users should be invited. See `invite_only`."
-      email_auth_res_enqueue: "This email failed a DMARC check, it most likely isn\'t from whom it seems to be from. Check the raw email headers for more information."
+      email_auth_res_enqueue: "This email failed a DMARC check, it most likely isn't from whom it seems to be from. Check the raw email headers for more information."
       email_spam: "This email was flagged as spam by the header defined in `email_in_spam_header`."
 
     actions:

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2402,6 +2402,7 @@ en:
       fixed_primary_email: "Fixed primary email for staged user"
       same_ip_address: "Same IP address (%{ip_address}) as other users"
       inactive_user: "Inactive user"
+    email_in_spam_header: "User's first email was flagged as spam"
 
   reviewables_reminder:
     submitted:

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -4655,6 +4655,8 @@ en:
       category: "Posts in this category require manual approval by staff. See the category settings."
       must_approve_users: "All new users must be approved by staff. See `must_approve_users`."
       invite_only: "All new users should be invited. See `invite_only`."
+      email_auth_res_enqueue: "This email failed a DMARC check, it most likely isn\'t from whom it seems to be from. Check the raw email headers for more information."
+      email_spam: "This email was flagged as spam by the header defined in `email_in_spam_header`."
 
     actions:
       agree:

--- a/lib/email/authentication_results.rb
+++ b/lib/email/authentication_results.rb
@@ -2,8 +2,6 @@
 
 module Email
   class AuthenticationResults
-    attr_reader :results
-
     VERDICT = Enum.new(
       :gray,
       :pass,
@@ -12,11 +10,16 @@ module Email
     )
 
     def initialize(headers)
-      authserv_id = SiteSetting.email_in_authserv_id
-      @results = Array(headers).map do |header|
+      @authserv_id = SiteSetting.email_in_authserv_id
+      @headers = headers
+      @verdict = :gray if @authserv_id.blank?
+    end
+
+    def results
+      @results ||= Array(@headers).map do |header|
         parse_header(header.to_s)
       end.filter do |result|
-        authserv_id.blank? || authserv_id == result[:authserv_id]
+        @authserv_id.blank? || @authserv_id == result[:authserv_id]
       end
     end
 
@@ -44,7 +47,7 @@ module Email
 
     def calc_dmarc
       verdict = VERDICT[:gray]
-      @results.each do |result|
+      results.each do |result|
         result[:resinfo].each do |resinfo|
           if resinfo[:method] == "dmarc"
             v = VERDICT[resinfo[:result].to_sym].to_i

--- a/lib/email/authentication_results.rb
+++ b/lib/email/authentication_results.rb
@@ -32,7 +32,7 @@ module Email
 
     def calc_action
       if verdict == :fail
-        :hide
+        :enqueue
       else
         :accept
       end

--- a/spec/components/email/authentication_results_spec.rb
+++ b/spec/components/email/authentication_results_spec.rb
@@ -239,7 +239,7 @@ describe Email::AuthenticationResults do
 
         context "with a fail" do
           let(:headers) { "foobar.com; dmarc=fail" }
-          include_examples "is verdict", :fail
+          include_examples "is verdict", :gray
         end
 
         context "with a pass" do

--- a/spec/components/email/authentication_results_spec.rb
+++ b/spec/components/email/authentication_results_spec.rb
@@ -277,10 +277,10 @@ describe Email::AuthenticationResults do
   end
 
   describe "#action" do
-    it "hides a fail verdict" do
+    it "enqueues a fail verdict" do
       results = described_class.new("")
       results.expects(:verdict).returns(:fail)
-      expect(results.action).to eq (:hide)
+      expect(results.action).to eq (:enqueue)
     end
 
     it "accepts a pass verdict" do

--- a/spec/components/email/receiver_spec.rb
+++ b/spec/components/email/receiver_spec.rb
@@ -1001,6 +1001,8 @@ describe Email::Receiver do
     end
 
     it "creates hidden topic for failed Authentication-Results header" do
+      SiteSetting.email_in_authserv_id = 'example.com'
+
       user = Fabricate(:user, email: "existing@bar.com", trust_level: SiteSetting.email_in_min_trust)
       expect { process(:dmarc_fail) }.to change { ReviewableQueuedPost.count }.by(1)
       expect(user.reload.silenced?).to be(false)

--- a/spec/components/email/receiver_spec.rb
+++ b/spec/components/email/receiver_spec.rb
@@ -979,59 +979,31 @@ describe Email::Receiver do
     it "creates hidden topic for X-Spam-Flag" do
       SiteSetting.email_in_spam_header = 'X-Spam-Flag'
 
-      Fabricate(:user, email: "existing@bar.com", trust_level: SiteSetting.email_in_min_trust)
-      expect { process(:spam_x_spam_flag) }.to change { Topic.count }.by(1) # Topic created
-
-      topic = Topic.last
-      expect(topic.visible).to eq(false)
-
-      post = Post.last
-      expect(post.hidden).to eq(true)
-      expect(post.hidden_at).not_to eq(nil)
-      expect(post.hidden_reason_id).to eq(Post.hidden_reasons[:email_spam_header_found])
+      user = Fabricate(:user, email: "existing@bar.com", trust_level: SiteSetting.email_in_min_trust)
+      expect { process(:spam_x_spam_flag) }.to change { ReviewableQueuedPost.count }.by(1)
+      expect(user.reload.silenced?).to be(true)
     end
 
     it "creates hidden topic for X-Spam-Status" do
       SiteSetting.email_in_spam_header = 'X-Spam-Status'
 
-      Fabricate(:user, email: "existing@bar.com", trust_level: SiteSetting.email_in_min_trust)
-      expect { process(:spam_x_spam_status) }.to change { Topic.count }.by(1) # Topic created
-
-      topic = Topic.last
-      expect(topic.visible).to eq(false)
-
-      post = Post.last
-      expect(post.hidden).to eq(true)
-      expect(post.hidden_at).not_to eq(nil)
-      expect(post.hidden_reason_id).to eq(Post.hidden_reasons[:email_spam_header_found])
+      user = Fabricate(:user, email: "existing@bar.com", trust_level: SiteSetting.email_in_min_trust)
+      expect { process(:spam_x_spam_status) }.to change { ReviewableQueuedPost.count }.by(1)
+      expect(user.reload.silenced?).to be(true)
     end
 
     it "creates hidden topic for X-SES-Spam-Verdict" do
       SiteSetting.email_in_spam_header = 'X-SES-Spam-Verdict'
 
-      Fabricate(:user, email: "existing@bar.com", trust_level: SiteSetting.email_in_min_trust)
-      expect { process(:spam_x_ses_spam_verdict) }.to change { Topic.count }.by(1) # Topic created
-
-      topic = Topic.last
-      expect(topic.visible).to eq(false)
-
-      post = Post.last
-      expect(post.hidden).to eq(true)
-      expect(post.hidden_at).not_to eq(nil)
-      expect(post.hidden_reason_id).to eq(Post.hidden_reasons[:email_spam_header_found])
+      user = Fabricate(:user, email: "existing@bar.com", trust_level: SiteSetting.email_in_min_trust)
+      expect { process(:spam_x_ses_spam_verdict) }.to change { ReviewableQueuedPost.count }.by(1)
+      expect(user.reload.silenced?).to be(true)
     end
 
     it "creates hidden topic for failed Authentication-Results header" do
-      Fabricate(:user, email: "existing@bar.com", trust_level: SiteSetting.email_in_min_trust)
-      expect { process(:dmarc_fail) }.to change { Topic.count }.by(1) # Topic created
-
-      topic = Topic.last
-      expect(topic.visible).to eq(false)
-
-      post = Post.last
-      expect(post.hidden).to eq(true)
-      expect(post.hidden_at).not_to eq(nil)
-      expect(post.hidden_reason_id).to eq(Post.hidden_reasons[:email_authentication_result_header])
+      user = Fabricate(:user, email: "existing@bar.com", trust_level: SiteSetting.email_in_min_trust)
+      expect { process(:dmarc_fail) }.to change { ReviewableQueuedPost.count }.by(1)
+      expect(user.reload.silenced?).to be(false)
     end
 
     it "adds the 'elided' part of the original message when always_show_trimmed_content is enabled" do


### PR DESCRIPTION
This is how an email which fails DMARC, for instance, appears (mostly through previous work from @eviltrout):

![Screenshot from 2020-01-07 14-54-12](https://user-images.githubusercontent.com/755354/71904199-99c89380-315d-11ea-824f-5f7317cc0b68.png)

At the moment this doesn't show the reason that this topic needs approval, and I think in the DMARC case at least, this is important (otherwise you'll be left wondering why a post from an admin, for instance, is in the reviewable queue). But this reason is already stored in the reviewable score, so @eviltrout I wondered if you'd already had thoughts about exposing this.