### PR TITLE
DEV: Allow returning non-objects from addToolbarPopupMenuOptionsCallback

### DIFF
--- a/app/assets/javascripts/discourse/controllers/composer.js.es6
+++ b/app/assets/javascripts/discourse/controllers/composer.js.es6
@@ -247,6 +247,9 @@ export default Controller.extend({
 
   _setupPopupMenuOption(callback) {
     let option = callback();
+    if (typeof option === "undefined") {
+      return null;
+    }
 
     if (typeof option.condition === "undefined") {
       option.condition = true;
@@ -287,9 +290,9 @@ export default Controller.extend({
       );
 
       return options.concat(
-        _popupMenuOptionsCallbacks.map(callback =>
-          this._setupPopupMenuOption(callback)
-        )
+        _popupMenuOptionsCallbacks
+          .map(callback => this._setupPopupMenuOption(callback))
+          .filter(o => o)
       );
     }
   },

--- a/app/assets/javascripts/discourse/controllers/composer.js.es6
+++ b/app/assets/javascripts/discourse/controllers/composer.js.es6
@@ -246,7 +246,7 @@ export default Controller.extend({
   },
 
   _setupPopupMenuOption(callback) {
-    let option = callback();
+    let option = callback(this);
     if (typeof option === "undefined") {
       return null;
     }


### PR DESCRIPTION
This would currently break, because you currently MUST return a valid object in the `addToolbarPopupMenuOptionsCallback`. Here, if `composer.creatingTopic` is false, `undefined` will be returned and and error will occur when the option is being pushed onto the list of popups.
```

function initializeSomeButton(api) {
  api.modifyClass("controller:composer", {
    actions: {
      someActionDefinedHere() {
        showModal("webinar-picker", {
          model: this.model,
          title: "zoom.webinar_picker.title"
        });
      }
    }
  });

  api.addToolbarPopupMenuOptionsCallback(() => {
    const composer = api.container.lookup('controller:composer').model
    if (composer && composer.creatingTopic) {
      return {
        id: "X",
        icon: "far-X",
        action: "someActionDefinedHere",
        label: "X"
      };
    };
  });
}

export default {
  name: "add-some-button",

  initialize(container) {
      withPluginApi("0.5", initializeSomeButton);
  }
};
```

You may think, why not just add the conditional `if (api.container.lookup('something').isTrue)` before the `withPluginApi` call! That was my thought as well. The problem is the frailty of using `container.lookup`. In the `initialize` function I was looking up `controller:composer`. Simplying looking it up (just console.loging it) broke the class modification (`api.modifyClass("controller:composer"`) for some non-obvious reason.

This fix increases the robustness of the callback system without almost any sacrifice.
