### PR TITLE
FIX: Use new tag routes

### DIFF
--- a/app/assets/javascripts/discourse/adapters/tag-info.js.es6
+++ b/app/assets/javascripts/discourse/adapters/tag-info.js.es6
@@ -2,6 +2,6 @@ import RESTAdapter from "discourse/adapters/rest";
 
 export default RESTAdapter.extend({
   pathFor(store, type, id) {
-    return "/tags/" + id + "/info";
+    return "/tag/" + id + "/info";
   }
 });

--- a/app/assets/javascripts/discourse/adapters/tag-notification.js.es6
+++ b/app/assets/javascripts/discourse/adapters/tag-notification.js.es6
@@ -2,6 +2,6 @@ import RESTAdapter from "discourse/adapters/rest";
 
 export default RESTAdapter.extend({
   pathFor(store, type, id) {
-    return "/tags/" + id + "/notifications";
+    return "/tag/" + id + "/notifications";
   }
 });

--- a/app/assets/javascripts/discourse/components/discourse-tag-bound.js.es6
+++ b/app/assets/javascripts/discourse/components/discourse-tag-bound.js.es6
@@ -13,6 +13,6 @@ export default Component.extend({
 
   @discourseComputed("tagRecord.id")
   href(tagRecordId) {
-    return Discourse.getURL("/tags/" + tagRecordId);
+    return Discourse.getURL("/tag/" + tagRecordId);
   }
 });

--- a/app/assets/javascripts/discourse/components/tag-drop-link.js.es6
+++ b/app/assets/javascripts/discourse/components/tag-drop-link.js.es6
@@ -14,11 +14,11 @@ export default Component.extend({
 
   @discourseComputed("tagId", "category")
   href(tagId, category) {
-    var url = "/tags";
     if (category) {
-      url += category.url;
+      return "/tags" + category.url + "/" + tagId;
+    } else {
+      return "/tag/" + tagId;
     }
-    return url + "/" + tagId;
   },
 
   @discourseComputed("tagId")

--- a/app/assets/javascripts/discourse/components/tag-info.js.es6
+++ b/app/assets/javascripts/discourse/components/tag-info.js.es6
@@ -76,7 +76,7 @@ export default Component.extend({
     },
 
     unlinkSynonym(tag) {
-      ajax(`/tags/${this.tagInfo.name}/synonyms/${tag.id}`, {
+      ajax(`/tag/${this.tagInfo.name}/synonyms/${tag.id}`, {
         type: "DELETE"
       })
         .then(() => this.tagInfo.synonyms.removeObject(tag))
@@ -98,7 +98,7 @@ export default Component.extend({
     },
 
     addSynonyms() {
-      ajax(`/tags/${this.tagInfo.name}/synonyms`, {
+      ajax(`/tag/${this.tagInfo.name}/synonyms`, {
         type: "POST",
         data: {
           synonyms: this.newSynonyms

--- a/app/assets/javascripts/discourse/lib/render-tag.js.es6
+++ b/app/assets/javascripts/discourse/lib/render-tag.js.es6
@@ -20,7 +20,7 @@ function defaultRenderTag(tag, params) {
         : User.current().username;
       path = `/u/${username}/messages/tags/${tag}`;
     } else {
-      path = `/tags/${tag}`;
+      path = `/tag/${tag}`;
     }
   }
   const href = path ? ` href='${Discourse.getURL(path)}' ` : "";

--- a/app/assets/javascripts/discourse/lib/search.js.es6
+++ b/app/assets/javascripts/discourse/lib/search.js.es6
@@ -79,7 +79,7 @@ export function translateResults(results, opts) {
       const tagName = Handlebars.Utils.escapeExpression(tag.name);
       return EmberObject.create({
         id: tagName,
-        url: Discourse.getURL("/tags/" + tagName)
+        url: Discourse.getURL("/tag/" + tagName)
       });
     })
     .compact();

--- a/app/assets/javascripts/discourse/routes/app-route-map.js.es6
+++ b/app/assets/javascripts/discourse/routes/app-route-map.js.es6
@@ -238,6 +238,14 @@ export default function() {
     this.route("intersection", {
       path: "intersection/:tag_id/*additional_tags"
     });
+
+    // legacy routes
+    this.route("show", { path: "/:tag_id" });
+    Site.currentProp("filters").forEach(filter => {
+      this.route("show" + filter.capitalize(), {
+        path: "/:tag_id/l/" + filter
+      });
+    });
   });
 
   this.route(

--- a/app/assets/javascripts/discourse/routes/app-route-map.js.es6
+++ b/app/assets/javascripts/discourse/routes/app-route-map.js.es6
@@ -238,14 +238,6 @@ export default function() {
     this.route("intersection", {
       path: "intersection/:tag_id/*additional_tags"
     });
-
-    // legacy routes
-    this.route("show", { path: "/:tag_id" });
-    Site.currentProp("filters").forEach(filter => {
-      this.route("show" + filter.capitalize(), {
-        path: "/:tag_id/l/" + filter
-      });
-    });
   });
 
   this.route(

--- a/app/assets/javascripts/discourse/routes/tags-show.js.es6
+++ b/app/assets/javascripts/discourse/routes/tags-show.js.es6
@@ -84,7 +84,7 @@ export default DiscourseRoute.extend(FilterModeMixin, {
       filter = `tags/intersection/${tagId}/${this.additionalTags.join("/")}`;
     } else {
       this.set("category", null);
-      filter = `tags/${tagId}/l/${topicFilter}`;
+      filter = `tag/${tagId}/l/${topicFilter}`;
     }
 
     return findTopicList(this.store, this.topicTrackingState, filter, params, {

--- a/app/assets/javascripts/select-kit/components/tag-drop.js.es6
+++ b/app/assets/javascripts/select-kit/components/tag-drop.js.es6
@@ -185,12 +185,12 @@ export default ComboBoxComponent.extend(TagsMixin, {
       } else if (tagId === "no-tags") {
         url = Discourse.getURL(this.noTagsUrl);
       } else {
-        url = "/tags";
-
         if (this.currentCategory) {
-          url += `/c/${Category.slugFor(this.currentCategory)}/${
+          url = `/tags/c/${Category.slugFor(this.currentCategory)}/${
             this.currentCategory.id
           }`;
+        } else {
+          url = "/tag";
         }
 
         if (tag && tag.targetTagId) {

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -191,10 +191,10 @@ class TagsController < ::ApplicationController
     discourse_expires_in 1.minute
 
     tag_id = params[:tag_id]
-    @link = "#{Discourse.base_url}/tags/#{tag_id}"
+    @link = "#{Discourse.base_url}/tag/#{tag_id}"
     @description = I18n.t("rss_by_tag", tag: tag_id)
     @title = "#{SiteSetting.title} - #{@description}"
-    @atom_link = "#{Discourse.base_url}/tags/#{tag_id}.rss"
+    @atom_link = "#{Discourse.base_url}/tag/#{tag_id}.rss"
 
     query = TopicQuery.new(current_user, tags: [tag_id])
     latest_results = query.latest_results

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -144,7 +144,7 @@ class Tag < ActiveRecord::Base
   end
 
   def full_url
-    "#{Discourse.base_url}/tags/#{self.name}"
+    "#{Discourse.base_url}/tag/#{self.name}"
   end
 
   def index_search

--- a/app/views/list/list.erb
+++ b/app/views/list/list.erb
@@ -4,7 +4,7 @@
 
 <%- if SiteSetting.tagging_enabled && @tag_id %>
   <h1>
-    <%= link_to "#{Discourse.base_url}/tags/#{@tag_id}", itemprop: 'item' do %>
+    <%= link_to "#{Discourse.base_url}/tag/#{@tag_id}", itemprop: 'item' do %>
       <span itemprop='name'><%= @tag_id %></span>
     <% end %>
   </h1>

--- a/app/views/tags/_tag.html.erb
+++ b/app/views/tags/_tag.html.erb
@@ -1,5 +1,5 @@
 <div class="tag-box">
-  <a href="<%= Discourse.base_url %>/tags/<%= tag[:id] %>" class="discourse-tag simple"><%= tag[:text] %></a>
+  <a href="<%= Discourse.base_url %>/tag/<%= tag[:id] %>" class="discourse-tag simple"><%= tag[:text] %></a>
   <% if tag[:count] && tag[:count] > 0 %>
     <span class="tag-count">x <%= tag[:count] %></span>
   <% end %>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -26,7 +26,7 @@
       <div class='crawler-tags-list' itemscope itemtype='http://schema.org/DiscussionForumPosting'>
         <% @tags.each_with_index do |tag, i| %>
           <div itemprop='keywords'>
-            <a  href='<%= "#{Discourse.base_url}/tags/#{tag.name}" %>' rel="tag">
+            <a  href='<%= "#{Discourse.base_url}/tag/#{tag.name}" %>' rel="tag">
               <span itemprop='headline'><%= tag.name -%></span>
             </a>
           </div>

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2582,7 +2582,7 @@ en:
 
       - Upgrade using our easy **[one-click browser upgrade](%{base_url}/admin/upgrade)**
 
-      - See what's new in the [release notes](https://meta.discourse.org/tags/release-notes) or view the [raw GitHub changelog](https://github.com/discourse/discourse/commits/master)
+      - See what's new in the [release notes](https://meta.discourse.org/tag/release-notes) or view the [raw GitHub changelog](https://github.com/discourse/discourse/commits/master)
 
       - Visit [meta.discourse.org](https://meta.discourse.org) for news, discussion, and support for Discourse
 
@@ -2597,7 +2597,7 @@ en:
 
       - Upgrade using our easy **[one-click browser upgrade](%{base_url}/admin/upgrade)**
 
-      - See what's new in the [release notes](https://meta.discourse.org/tags/release-notes) or view the [raw GitHub changelog](https://github.com/discourse/discourse/commits/master)
+      - See what's new in the [release notes](https://meta.discourse.org/tag/release-notes) or view the [raw GitHub changelog](https://github.com/discourse/discourse/commits/master)
 
       - Visit [meta.discourse.org](https://meta.discourse.org) for news, discussion, and support for Discourse
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -893,6 +893,23 @@ Discourse::Application.routes.draw do
 
       get '/intersection/:tag_id/*additional_tag_ids' => 'tags#show', as: 'tag_intersection'
     end
+
+    # legacy routes
+    constraints(tag_id: /[^\/]+?/, format: /json|rss/) do
+      get '/:tag_id.rss' => 'tags#tag_feed'
+      get '/:tag_id' => 'tags#show'
+      get '/:tag_id/info' => 'tags#info'
+      get '/:tag_id/notifications' => 'tags#notifications'
+      put '/:tag_id/notifications' => 'tags#update_notifications'
+      put '/:tag_id' => 'tags#update'
+      delete '/:tag_id' => 'tags#destroy'
+      post '/:tag_id/synonyms' => 'tags#create_synonyms'
+      delete '/:tag_id/synonyms/:synonym_id' => 'tags#destroy_synonym'
+
+      Discourse.filters.each do |filter|
+        get "/:tag_id/l/#{filter}" => "tags#show_#{filter}"
+      end
+    end
   end
 
   resources :tag_groups, constraints: StaffConstraint.new, except: [:edit] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -847,7 +847,7 @@ Discourse::Application.routes.draw do
 
   scope '/tag/:tag_id' do
     constraints format: :json do
-      get '/' => 'tags#show'
+      get '/' => 'tags#show', as: 'tag_show'
       get '/info' => 'tags#info'
       get '/notifications' => 'tags#notifications'
       put '/notifications' => 'tags#update_notifications'
@@ -857,7 +857,7 @@ Discourse::Application.routes.draw do
       delete '/synonyms/:synonym_id' => 'tags#destroy_synonym'
 
       Discourse.filters.each do |filter|
-        get "/l/#{filter}" => "tags#show_#{filter}"
+        get "/l/#{filter}" => "tags#show_#{filter}", as: "tag_show_#{filter}"
       end
     end
 
@@ -892,23 +892,6 @@ Discourse::Application.routes.draw do
       end
 
       get '/intersection/:tag_id/*additional_tag_ids' => 'tags#show', as: 'tag_intersection'
-    end
-
-    # legacy routes
-    constraints(tag_id: /[^\/]+?/, format: /json|rss/) do
-      get '/:tag_id.rss' => 'tags#tag_feed'
-      get '/:tag_id' => 'tags#show', as: 'tag_show'
-      get '/:tag_id/info' => 'tags#info'
-      get '/:tag_id/notifications' => 'tags#notifications'
-      put '/:tag_id/notifications' => 'tags#update_notifications'
-      put '/:tag_id' => 'tags#update'
-      delete '/:tag_id' => 'tags#destroy'
-      post '/:tag_id/synonyms' => 'tags#create_synonyms'
-      delete '/:tag_id/synonyms/:synonym_id' => 'tags#destroy_synonym'
-
-      Discourse.filters.each do |filter|
-        get "/:tag_id/l/#{filter}" => "tags#show_#{filter}", as: "tag_show_#{filter}"
-      end
     end
   end
 

--- a/lib/pretty_text/helpers.rb
+++ b/lib/pretty_text/helpers.rb
@@ -113,7 +113,7 @@ module PrettyText
         [category.url_with_id, text]
       elsif (!is_tag && tag = Tag.find_by(name: text)) ||
             (is_tag && tag = Tag.find_by(name: text.gsub!("#{tag_postfix}", '')))
-        ["#{Discourse.base_url}/tags/#{tag.name}", text]
+        ["#{Discourse.base_url}/tag/#{tag.name}", text]
       else
         nil
       end

--- a/spec/components/pretty_text_spec.rb
+++ b/spec/components/pretty_text_spec.rb
@@ -1014,7 +1014,7 @@ describe PrettyText do
     [
       "<span class=\"hashtag\">#unknown::tag</span>",
       "<a class=\"hashtag\" href=\"#{category2.url_with_id}\">#<span>known</span></a>",
-      "<a class=\"hashtag\" href=\"http://test.localhost/tags/known\">#<span>known</span></a>",
+      "<a class=\"hashtag\" href=\"http://test.localhost/tag/known\">#<span>known</span></a>",
       "<a class=\"hashtag\" href=\"#{category.url_with_id}\">#<span>testing</span></a>"
     ].each do |element|
 
@@ -1035,7 +1035,7 @@ describe PrettyText do
 
     cooked = PrettyText.cook("<A href='/a'>test</A> #known::tag")
     html = <<~HTML
-      <p><a href="/a">test</a> <a class="hashtag" href="http://test.localhost/tags/known">#<span>known</span></a></p>
+      <p><a href="/a">test</a> <a class="hashtag" href="http://test.localhost/tag/known">#<span>known</span></a></p>
     HTML
 
     expect(cooked).to eq(html.strip)

--- a/spec/requests/tags_controller_spec.rb
+++ b/spec/requests/tags_controller_spec.rb
@@ -82,30 +82,30 @@ describe TagsController do
     fab!(:tag) { Fabricate(:tag, name: 'test') }
 
     it "should return the right response" do
-      get "/tags/test"
+      get "/tag/test"
       expect(response.status).to eq(200)
     end
 
     it "should handle invalid tags" do
-      get "/tags/%2ftest%2f"
+      get "/tag/%2ftest%2f"
       expect(response.status).to eq(404)
     end
 
     it "should handle synonyms" do
       synonym = Fabricate(:tag, target_tag: tag)
-      get "/tags/#{synonym.name}"
+      get "/tag/#{synonym.name}"
       expect(response.status).to eq(200)
     end
 
     it "does not show staff-only tags" do
       tag_group = Fabricate(:tag_group, permissions: { "staff" => 1 }, tag_names: ["test"])
 
-      get "/tags/test"
+      get "/tag/test"
       expect(response.status).to eq(404)
 
       sign_in(admin)
 
-      get "/tags/test"
+      get "/tag/test"
       expect(response.status).to eq(200)
     end
 
@@ -181,12 +181,12 @@ describe TagsController do
     let(:synonym) { Fabricate(:tag, name: 'synonym', target_tag: tag) }
 
     it "returns 404 if tag not found" do
-      get "/tags/nope/info.json"
+      get "/tag/nope/info.json"
       expect(response.status).to eq(404)
     end
 
     it "can handle tag with no synonyms" do
-      get "/tags/#{tag.name}/info.json"
+      get "/tag/#{tag.name}/info.json"
       expect(response.status).to eq(200)
       expect(json.dig('tag_info', 'name')).to eq(tag.name)
       expect(json.dig('tag_info', 'synonyms')).to be_empty
@@ -194,7 +194,7 @@ describe TagsController do
     end
 
     it "can handle a synonym" do
-      get "/tags/#{synonym.name}/info.json"
+      get "/tag/#{synonym.name}/info.json"
       expect(response.status).to eq(200)
       expect(json.dig('tag_info', 'name')).to eq(synonym.name)
       expect(json.dig('tag_info', 'synonyms')).to be_empty
@@ -203,21 +203,21 @@ describe TagsController do
 
     it "can return a tag's synonyms" do
       synonym
-      get "/tags/#{tag.name}/info.json"
+      get "/tag/#{tag.name}/info.json"
       expect(response.status).to eq(200)
       expect(json.dig('tag_info', 'synonyms').map { |t| t['text'] }).to eq([synonym.name])
     end
 
     it "returns 404 if tag is staff-only" do
       tag_group = Fabricate(:tag_group, permissions: { "staff" => 1 }, tag_names: ["test"])
-      get "/tags/test/info.json"
+      get "/tag/test/info.json"
       expect(response.status).to eq(404)
     end
 
     it "staff-only tags can be retrieved for staff user" do
       sign_in(admin)
       tag_group = Fabricate(:tag_group, permissions: { "staff" => 1 }, tag_names: ["test"])
-      get "/tags/test/info.json"
+      get "/tag/test/info.json"
       expect(response.status).to eq(200)
     end
 
@@ -227,7 +227,7 @@ describe TagsController do
       tag_group = Fabricate(:tag_group, tags: [tag])
       category2.update!(tag_groups: [tag_group])
       staff_category = Fabricate(:private_category, group: Fabricate(:group), tags: [tag])
-      get "/tags/#{tag.name}/info.json"
+      get "/tag/#{tag.name}/info.json"
       expect(json.dig('tag_info', 'category_ids')).to contain_exactly(category.id, category2.id)
       expect(json['categories']).to be_present
     end
@@ -237,13 +237,13 @@ describe TagsController do
 
       it "returns tag groups if tag groups are visible" do
         SiteSetting.tags_listed_by_group = true
-        get "/tags/#{tag.name}/info.json"
+        get "/tag/#{tag.name}/info.json"
         expect(json.dig('tag_info', 'tag_group_names')).to eq([tag_group.name])
       end
 
       it "doesn't return tag groups if tag groups aren't visible" do
         SiteSetting.tags_listed_by_group = false
-        get "/tags/#{tag.name}/info.json"
+        get "/tag/#{tag.name}/info.json"
         expect(json['tag_info'].has_key?('tag_group_names')).to eq(false)
       end
     end
@@ -272,7 +272,7 @@ describe TagsController do
 
     it "triggers a extensibility event" do
       event = DiscourseEvent.track_events {
-        put "/tags/#{tag.name}.json", params: {
+        put "/tag/#{tag.name}.json", params: {
           tag: {
             id: 'hello'
           }
@@ -365,7 +365,7 @@ describe TagsController do
     context 'tagging disabled' do
       it "returns 404" do
         SiteSetting.tagging_enabled = false
-        get "/tags/#{tag.name}/l/latest.json"
+        get "/tag/#{tag.name}/l/latest.json"
         expect(response.status).to eq(404)
       end
     end
@@ -377,14 +377,14 @@ describe TagsController do
       end
 
       it "can filter by tag" do
-        get "/tags/#{tag.name}/l/latest.json"
+        get "/tag/#{tag.name}/l/latest.json"
         expect(response.status).to eq(200)
       end
 
       it "can filter by two tags" do
         single_tag_topic; multi_tag_topic; all_tag_topic
 
-        get "/tags/#{tag.name}/l/latest.json", params: {
+        get "/tag/#{tag.name}/l/latest.json", params: {
           additional_tag_ids: other_tag.name
         }
 
@@ -399,7 +399,7 @@ describe TagsController do
       it "can filter by multiple tags" do
         single_tag_topic; multi_tag_topic; all_tag_topic
 
-        get "/tags/#{tag.name}/l/latest.json", params: {
+        get "/tag/#{tag.name}/l/latest.json", params: {
           additional_tag_ids: "#{other_tag.name}/#{third_tag.name}"
         }
 
@@ -414,7 +414,7 @@ describe TagsController do
       it "does not find any tags when a tag which doesn't exist is passed" do
         single_tag_topic
 
-        get "/tags/#{tag.name}/l/latest.json", params: {
+        get "/tag/#{tag.name}/l/latest.json", params: {
           additional_tag_ids: "notatag"
         }
 
@@ -462,7 +462,7 @@ describe TagsController do
         end
 
         it "can filter by bookmarked" do
-          get "/tags/#{tag.name}/l/bookmarks.json"
+          get "/tag/#{tag.name}/l/bookmarks.json"
 
           expect(response.status).to eq(200)
         end
@@ -479,7 +479,7 @@ describe TagsController do
           it "includes topics when filtered by muted tag" do
             single_tag_topic
 
-            get "/tags/#{tag.name}/l/latest.json"
+            get "/tag/#{tag.name}/l/latest.json"
             expect(response.status).to eq(200)
 
             topic_ids = parse_topic_ids
@@ -642,7 +642,7 @@ describe TagsController do
       context 'with an existent tag name' do
         it 'deletes the tag' do
           tag = Fabricate(:tag)
-          delete "/tags/#{tag.name}.json"
+          delete "/tag/#{tag.name}.json"
           expect(response.status).to eq(200)
           expect(Tag.where(id: tag.id)).to be_empty
         end
@@ -650,7 +650,7 @@ describe TagsController do
 
       context 'with a nonexistent tag name' do
         it 'returns a tag not found message' do
-          delete "/tags/doesntexists.json"
+          delete "/tag/doesntexists.json"
           expect(response).not_to be_successful
           expect(json['error_type']).to eq('not_found')
         end
@@ -746,13 +746,13 @@ describe TagsController do
     fab!(:tag) { Fabricate(:tag) }
 
     it 'fails if not logged in' do
-      post "/tags/#{tag.name}/synonyms.json", params: { synonyms: ['synonym1'] }
+      post "/tag/#{tag.name}/synonyms.json", params: { synonyms: ['synonym1'] }
       expect(response.status).to eq(403)
     end
 
     it 'fails if not staff user' do
       sign_in(user)
-      post "/tags/#{tag.name}/synonyms.json", params: { synonyms: ['synonym1'] }
+      post "/tag/#{tag.name}/synonyms.json", params: { synonyms: ['synonym1'] }
       expect(response.status).to eq(403)
     end
 
@@ -762,7 +762,7 @@ describe TagsController do
       it 'can make a tag a synonym of another tag' do
         tag2 = Fabricate(:tag)
         expect {
-          post "/tags/#{tag.name}/synonyms.json", params: { synonyms: [tag2.name] }
+          post "/tag/#{tag.name}/synonyms.json", params: { synonyms: [tag2.name] }
         }.to_not change { Tag.count }
         expect(response.status).to eq(200)
         expect(tag2.reload.target_tag).to eq(tag)
@@ -770,7 +770,7 @@ describe TagsController do
 
       it 'can create new tags at the same time' do
         expect {
-          post "/tags/#{tag.name}/synonyms.json", params: { synonyms: ['synonym'] }
+          post "/tag/#{tag.name}/synonyms.json", params: { synonyms: ['synonym'] }
         }.to change { Tag.count }.by(1)
         expect(response.status).to eq(200)
         expect(Tag.find_by_name('synonym')&.target_tag).to eq(tag)
@@ -779,7 +779,7 @@ describe TagsController do
       it 'can return errors' do
         tag2 = Fabricate(:tag, target_tag: tag)
         tag3 = Fabricate(:tag)
-        post "/tags/#{tag3.name}/synonyms.json", params: { synonyms: [tag.name] }
+        post "/tag/#{tag3.name}/synonyms.json", params: { synonyms: [tag.name] }
         expect(response.status).to eq(200)
         json = JSON.parse(response.body)
         expect(json['failed']).to be_present
@@ -791,7 +791,7 @@ describe TagsController do
   describe '#destroy_synonym' do
     fab!(:tag) { Fabricate(:tag) }
     fab!(:synonym) { Fabricate(:tag, target_tag: tag, name: 'synonym') }
-    subject { delete("/tags/#{tag.name}/synonyms/#{synonym.name}.json") }
+    subject { delete("/tag/#{tag.name}/synonyms/#{synonym.name}.json") }
 
     it 'fails if not logged in' do
       subject
@@ -815,13 +815,13 @@ describe TagsController do
       end
 
       it "returns error if tag isn't a synonym" do
-        delete "/tags/#{Fabricate(:tag).name}/synonyms/#{synonym.name}.json"
+        delete "/tag/#{Fabricate(:tag).name}/synonyms/#{synonym.name}.json"
         expect(response.status).to eq(400)
         expect_same_tag_names(tag.reload.synonyms, [synonym])
       end
 
       it "returns error if synonym not found" do
-        delete "/tags/#{Fabricate(:tag).name}/synonyms/nope.json"
+        delete "/tag/#{Fabricate(:tag).name}/synonyms/nope.json"
         expect(response.status).to eq(404)
         expect_same_tag_names(tag.reload.synonyms, [synonym])
       end

--- a/test/javascripts/acceptance/search-test.js.es6
+++ b/test/javascripts/acceptance/search-test.js.es6
@@ -50,7 +50,7 @@ QUnit.test("search for a tag", async assert => {
 });
 
 QUnit.test("search scope checkbox", async assert => {
-  await visit("/tags/important");
+  await visit("/tag/important");
   await click("#search-button");
   assert.ok(
     exists(".search-context input:checked"),

--- a/test/javascripts/acceptance/tag-hashtag-test.js.es6
+++ b/test/javascripts/acceptance/tag-hashtag-test.js.es6
@@ -6,7 +6,7 @@ acceptance("Tag Hashtag", {
   pretend(server, helper) {
     server.get("/tags/check", () => {
       return helper.response({
-        valid: [{ value: "monkey", url: "/tags/monkey" }]
+        valid: [{ value: "monkey", url: "/tag/monkey" }]
       });
     });
   }
@@ -22,6 +22,6 @@ QUnit.test("tag is cooked properly", async assert => {
     find(".d-editor-preview:visible")
       .html()
       .trim(),
-    '<p>this is a tag hashtag <a href="/tags/monkey" class="hashtag">#<span>monkey</span></a></p>'
+    '<p>this is a tag hashtag <a href="/tag/monkey" class="hashtag">#<span>monkey</span></a></p>'
   );
 });

--- a/test/javascripts/acceptance/tags-intersection-test.js.es6
+++ b/test/javascripts/acceptance/tags-intersection-test.js.es6
@@ -5,7 +5,7 @@ acceptance("Tags intersection", {
   site: { can_tag_topics: true },
   settings: { tagging_enabled: true },
   pretend(server, helper) {
-    server.get("/tags/first/notifications", () => {
+    server.get("/tag/first/notifications", () => {
       return helper.response({
         tag_notification: { id: "first", notification_level: 1 }
       });

--- a/test/javascripts/acceptance/tags-test.js.es6
+++ b/test/javascripts/acceptance/tags-test.js.es6
@@ -91,7 +91,7 @@ QUnit.test("list the tags in groups", async assert => {
       .map(i => {
         return $(i).attr("href");
       }),
-    ["/tags/focus", "/tags/escort"],
+    ["/tag/focus", "/tag/escort"],
     "always uses lowercase URLs for mixed case tags"
   );
   assert.equal(
@@ -103,13 +103,13 @@ QUnit.test("list the tags in groups", async assert => {
 
 test("new topic button is not available for staff-only tags", async assert => {
   /* global server */
-  server.get("/tags/regular-tag/notifications", () => [
+  server.get("/tag/regular-tag/notifications", () => [
     200,
     { "Content-Type": "application/json" },
     { tag_notification: { id: "regular-tag", notification_level: 1 } }
   ]);
 
-  server.get("/tags/regular-tag/l/latest.json", () => [
+  server.get("/tag/regular-tag/l/latest.json", () => [
     200,
     { "Content-Type": "application/json" },
     {
@@ -133,13 +133,13 @@ test("new topic button is not available for staff-only tags", async assert => {
     }
   ]);
 
-  server.get("/tags/staff-only-tag/notifications", () => [
+  server.get("/tag/staff-only-tag/notifications", () => [
     200,
     { "Content-Type": "application/json" },
     { tag_notification: { id: "staff-only-tag", notification_level: 1 } }
   ]);
 
-  server.get("/tags/staff-only-tag/l/latest.json", () => [
+  server.get("/tag/staff-only-tag/l/latest.json", () => [
     200,
     { "Content-Type": "application/json" },
     {
@@ -166,18 +166,18 @@ test("new topic button is not available for staff-only tags", async assert => {
 
   updateCurrentUser({ moderator: false, admin: false });
 
-  await visit("/tags/regular-tag");
+  await visit("/tag/regular-tag");
   assert.ok(find("#create-topic:disabled").length === 0);
 
-  await visit("/tags/staff-only-tag");
+  await visit("/tag/staff-only-tag");
   assert.ok(find("#create-topic:disabled").length === 1);
 
   updateCurrentUser({ moderator: true });
 
-  await visit("/tags/regular-tag");
+  await visit("/tag/regular-tag");
   assert.ok(find("#create-topic:disabled").length === 0);
 
-  await visit("/tags/staff-only-tag");
+  await visit("/tag/staff-only-tag");
   assert.ok(find("#create-topic:disabled").length === 0);
 });
 
@@ -187,13 +187,13 @@ acceptance("Tag info", {
     tags_listed_by_group: true
   },
   pretend(server, helper) {
-    server.get("/tags/planters/notifications", () => {
+    server.get("/tag/planters/notifications", () => {
       return helper.response({
         tag_notification: { id: "planters", notification_level: 1 }
       });
     });
 
-    server.get("/tags/planters/l/latest.json", () => {
+    server.get("/tag/planters/l/latest.json", () => {
       return helper.response({
         users: [],
         primary_groups: [],
@@ -215,7 +215,7 @@ acceptance("Tag info", {
       });
     });
 
-    server.get("/tags/planters/info", () => {
+    server.get("/tag/planters/info", () => {
       return helper.response({
         __rest_serializer: "1",
         tag_info: {
@@ -261,7 +261,7 @@ acceptance("Tag info", {
 test("tag info can show synonyms", async assert => {
   updateCurrentUser({ moderator: false, admin: false });
 
-  await visit("/tags/planters");
+  await visit("/tag/planters");
   assert.ok(find("#show-tag-info").length === 1);
 
   await click("#show-tag-info");
@@ -286,7 +286,7 @@ test("tag info can show synonyms", async assert => {
 });
 
 test("admin can manage tags", async assert => {
-  server.delete("/tags/planters/synonyms/containers", () => [
+  server.delete("/tag/planters/synonyms/containers", () => [
     200,
     { "Content-Type": "application/json" },
     { success: true }
@@ -294,7 +294,7 @@ test("admin can manage tags", async assert => {
 
   updateCurrentUser({ moderator: false, admin: true });
 
-  await visit("/tags/planters");
+  await visit("/tag/planters");
   assert.ok(find("#show-tag-info").length === 1);
 
   await click("#show-tag-info");

--- a/test/javascripts/components/tag-drop-test.js.es6
+++ b/test/javascripts/components/tag-drop-test.js.es6
@@ -71,7 +71,7 @@ componentTest("default", {
     await this.subject.fillInFilter("dav");
     await this.subject.keyboard("enter");
     assert.ok(
-      DiscourseURL.routeTo.calledWith("/tags/david"),
+      DiscourseURL.routeTo.calledWith("/tag/david"),
       "it uses lowercase URLs for tags"
     );
   }
@@ -107,7 +107,7 @@ componentTest("synonym", {
     await this.subject.fillInFilter("robin");
     await this.subject.keyboard("enter");
     assert.ok(
-      DiscourseURL.routeTo.calledWith("/tags/eviltrout"),
+      DiscourseURL.routeTo.calledWith("/tag/eviltrout"),
       "it routes to the target tag"
     );
   }

--- a/test/javascripts/fixtures/discovery_fixtures.js.es6
+++ b/test/javascripts/fixtures/discovery_fixtures.js.es6
@@ -3756,7 +3756,7 @@ export default {
       ]
     }
   },
-  "/tags/important/l/latest.json": {
+  "/tag/important/l/latest.json": {
     users: [{ id: 1, username: "sam", avatar_template: "/images/avatar.png" }],
     primary_groups: [],
     topic_list: {


### PR DESCRIPTION
Daniel added unambiguous routes for tags in 1fb7a6297c7b5ebcd8433cdecd8bd41ec9fc4f3e. This PR ensures that the new routes are used.