### PR TITLE
DEV: Add missing indexes to user_profiles

### DIFF
--- a/app/models/user_custom_field.rb
+++ b/app/models/user_custom_field.rb
@@ -17,5 +17,7 @@ end
 #
 # Indexes
 #
-#  index_user_custom_fields_on_user_id_and_name  (user_id,name)
+#  idx_user_custom_fields_last_reminded_at          (name,user_id) UNIQUE WHERE ((name)::text = 'last_reminded_at'::text)
+#  idx_user_custom_fields_remind_assigns_frequency  (name,user_id) UNIQUE WHERE ((name)::text = 'remind_assigns_frequency'::text)
+#  index_user_custom_fields_on_user_id_and_name     (user_id,name)
 #

--- a/app/models/user_profile.rb
+++ b/app/models/user_profile.rb
@@ -171,10 +171,10 @@ end
 #
 # Indexes
 #
-#  index_user_profiles_on_bio_cooked_version      (bio_cooked_version)
-#  index_user_profiles_on_card_background         (card_background)
-#  index_user_profiles_on_granted_title_badge_id  (granted_title_badge_id)
-#  index_user_profiles_on_profile_background      (profile_background)
+#  index_user_profiles_on_bio_cooked_version            (bio_cooked_version)
+#  index_user_profiles_on_card_background_upload_id     (card_background_upload_id)
+#  index_user_profiles_on_granted_title_badge_id        (granted_title_badge_id)
+#  index_user_profiles_on_profile_background_upload_id  (profile_background_upload_id)
 #
 # Foreign Keys
 #

--- a/app/models/user_stat.rb
+++ b/app/models/user_stat.rb
@@ -224,4 +224,5 @@ end
 #  flags_disagreed          :integer          default(0), not null
 #  flags_ignored            :integer          default(0), not null
 #  first_unread_at          :datetime         not null
+#  distinct_badge_count     :integer          default(0), not null
 #

--- a/db/migrate/20200109130028_update_user_profiles_indexes.rb
+++ b/db/migrate/20200109130028_update_user_profiles_indexes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class UpdateUserProfilesIndexes < ActiveRecord::Migration[6.0]
   def change
     remove_index :user_profiles, :card_background

--- a/db/migrate/20200109130028_update_user_profiles_indexes.rb
+++ b/db/migrate/20200109130028_update_user_profiles_indexes.rb
@@ -1,0 +1,9 @@
+class UpdateUserProfilesIndexes < ActiveRecord::Migration[6.0]
+  def change
+    remove_index :user_profiles, :card_background
+    add_index :user_profiles, :card_background_upload_id
+
+    remove_index :user_profiles, :profile_background
+    add_index :user_profiles, :profile_background_upload_id
+  end
+end


### PR DESCRIPTION
The `card_background` and `profile_background` columns in `user_profiles` were changed in https://github.com/discourse/discourse/commit/24347ace10ad54f7f3bbc687bc7bc37734f558e4#diff-baa5914c0c7cddf3c8b5cd9139e0d091. This PR updates indexes for these columns.