### PR TITLE
FIX: Change rootNone behavior in category-chooser

### DIFF
--- a/app/assets/javascripts/discourse/templates/components/edit-category-general.hbs
+++ b/app/assets/javascripts/discourse/templates/components/edit-category-general.hbs
@@ -12,7 +12,7 @@
     <section class='field'>
       <label>{{i18n 'category.parent'}}</label>
       {{category-chooser
-        none="category.none"
+        rootNone=true
         value=category.parent_category_id
         excludeCategoryId=category.id
         categories=parentCategories

--- a/app/assets/javascripts/select-kit/components/category-chooser.js.es6
+++ b/app/assets/javascripts/select-kit/components/category-chooser.js.es6
@@ -3,7 +3,7 @@ import discourseComputed from "discourse-common/utils/decorators";
 import PermissionType from "discourse/models/permission-type";
 import Category from "discourse/models/category";
 import { categoryBadgeHTML } from "discourse/helpers/category-link";
-const { get, isNone, isEmpty } = Ember;
+const { get, isPresent, isEmpty } = Ember;
 
 export default ComboBoxComponent.extend({
   pluginApiIdentifiers: ["category-chooser"],
@@ -55,15 +55,13 @@ export default ComboBoxComponent.extend({
 
   @discourseComputed("rootNone", "rootNoneLabel")
   none(rootNone, rootNoneLabel) {
-    if (
+    if (isPresent(rootNone)) {
+      return rootNoneLabel || "category.none";
+    } else if (
       this.siteSettings.allow_uncategorized_topics ||
       this.allowUncategorized
     ) {
-      if (!isNone(rootNone)) {
-        return rootNoneLabel || "category.none";
-      } else {
-        return Category.findUncategorized();
-      }
+      return Category.findUncategorized();
     } else {
       return "category.choose";
     }

--- a/test/javascripts/components/category-chooser-test.js.es6
+++ b/test/javascripts/components/category-chooser-test.js.es6
@@ -73,7 +73,7 @@ componentTest("with allowUncategorized=null rootNone=true", {
 
   test(assert) {
     assert.equal(this.subject.header().value(), null);
-    assert.equal(this.subject.header().title(), "category");
+    assert.equal(this.subject.header().title(), "(no category)");
   }
 });
 
@@ -88,7 +88,7 @@ componentTest("with disallowed uncategorized, rootNone and rootNoneLabel", {
 
   test(assert) {
     assert.equal(this.subject.header().value(), null);
-    assert.equal(this.subject.header().title(), "category");
+    assert.equal(this.subject.header().title(), "root none label");
   }
 });
 


### PR DESCRIPTION
This breaking change was originally a deprecation fix for overriding a computed property `none`.

There are 4 uses of `rootNone` in core and "all-the-plugins":

1. in **discourse-chat-integration**, admin-plugins-chat-edit-rule.hbs - changed behavior, that I'd consider a fix - `rootNoneLabel` is now used regardless of `siteSettings.allow_uncategorized_topics` value, which I believe was an originally intended behavior (i.e. it most likely hasn't been tested with disabled uncategorized topics)
2. in **discourse-slack-official**, plugins-slack.hbs - the same as 1.
3. in **core**, edit-category-general.hbs (in this PR) - no change in behavior
4. in **discourse-googlebooks**, edit-category-general.hbs - no change in behavior (since `allowUncategorized="true"` is also passed as an argument)

@jjaffeux what do you think about this bugfix?