### PR TITLE
DEV: Refactor 2FA authentication flows for sanity

### DIFF
--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -309,16 +309,6 @@ class SessionController < ApplicationController
     (user.active && user.email_confirmed?) ? login(user) : not_activated(user)
   end
 
-  def invalid_security_key(user, err_message = nil)
-    Webauthn.stage_challenge(user, secure_session) if !params[:security_key_credential]
-    render json: failed_json.merge(
-      error: err_message || I18n.t("login.invalid_security_key"),
-      reason: "invalid_security_key",
-      backup_enabled: user.backup_codes_enabled?,
-      multiple_second_factor_methods: user.has_multiple_second_factor_methods?
-    ).merge(Webauthn.allowed_credentials(user, secure_session))
-  end
-
   def email_login_info
     raise Discourse::NotFound if !SiteSetting.enable_local_logins_via_email
 

--- a/spec/components/concern/second_factor_manager_spec.rb
+++ b/spec/components/concern/second_factor_manager_spec.rb
@@ -3,8 +3,16 @@
 require 'rails_helper'
 
 RSpec.describe SecondFactorManager do
-  fab!(:user_second_factor_totp) { Fabricate(:user_second_factor_totp) }
-  let(:user) { user_second_factor_totp.user }
+  fab!(:user) { Fabricate(:user) }
+  fab!(:user_second_factor_totp) { Fabricate(:user_second_factor_totp, user: user) }
+  fab!(:user_security_key) do
+    Fabricate(
+      :user_security_key,
+      user: user,
+      public_key: valid_security_key_data[:public_key],
+      credential_id: valid_security_key_data[:credential_id]
+    )
+  end
   fab!(:another_user) { Fabricate(:user) }
 
   fab!(:user_second_factor_backup) { Fabricate(:user_second_factor_backup) }
@@ -78,7 +86,7 @@ RSpec.describe SecondFactorManager do
 
     describe "when user's second factor record is disabled" do
       it 'should return false' do
-        user.user_second_factors.totps.first.update!(enabled: false)
+        disable_totp
         expect(user.totp_enabled?).to eq(false)
       end
     end
@@ -103,6 +111,150 @@ RSpec.describe SecondFactorManager do
         SiteSetting.enable_local_logins = false
 
         expect(user.totp_enabled?).to eq(false)
+      end
+    end
+  end
+
+  describe "#has_multiple_second_factor_methods?" do
+    context "when security keys and totp are enabled" do
+      it "retrns true" do
+        expect(user.has_multiple_second_factor_methods?).to eq(true)
+      end
+    end
+
+    context "if the totp gets disabled" do
+      it "retrns false" do
+        disable_totp
+        expect(user.has_multiple_second_factor_methods?).to eq(false)
+      end
+    end
+
+    context "if the security key gets disabled" do
+      it "retrns false" do
+        disable_security_key
+        expect(user.has_multiple_second_factor_methods?).to eq(false)
+      end
+    end
+  end
+
+  describe "#only_security_keys_enabled?" do
+    it "returns true if totp disabled and security key enabled" do
+      disable_totp
+      expect(user.only_security_keys_enabled?).to eq(true)
+    end
+  end
+
+  describe "#only_totp_or_backup_codes_enabled?" do
+    it "returns true if totp enabled and security key disabled" do
+      disable_security_key
+      expect(user.only_totp_or_backup_codes_enabled?).to eq(true)
+    end
+  end
+
+  describe "#authenticate_second_factor_method" do
+    let(:params) { {} }
+    let(:secure_session) { {} }
+
+    context "when neither security keys nor totp/backup codes are enabled" do
+      before do
+        disable_security_key && disable_totp
+      end
+      it "returns OK, because it doesn't need to authenticate" do
+        expect(user.authenticate_second_factor_method(params, secure_session).ok?).to eq(true)
+      end
+    end
+
+    context "when only security key is enabled" do
+      before do
+        disable_totp
+        simulate_localhost_webauthn_challenge
+        Webauthn.stage_challenge(user, secure_session)
+      end
+
+      context "when security key params are valid" do
+        let(:params) { { security_key_credential: valid_security_key_auth_post_data, second_factor_method: UserSecondFactor.methods[:security_key] } }
+        it "returns OK" do
+          expect(user.authenticate_second_factor_method(params, secure_session).ok?).to eq(true)
+        end
+      end
+
+      context "when security key params are invalid" do
+        let(:params) do
+          {
+            security_key_credential: {
+              signature: 'bad',
+              clientData: 'bad',
+              authenticatorData: 'bad',
+              credentialId: 'bad'
+            },
+            second_factor_method: UserSecondFactor.methods[:security_key]
+          }
+        end
+        it "returns not OK" do
+          result = user.authenticate_second_factor_method(params, secure_session)
+          expect(result.ok?).to eq(false)
+          expect(result.error).to eq(I18n.t("webauthn.validation.not_found_error"))
+        end
+      end
+    end
+
+    context "when only totp is enabled" do
+      before do
+        disable_security_key
+      end
+
+      context "when totp is valid" do
+        let(:params) do
+          {
+            second_factor_token: user.user_second_factors.totps.first.totp_object.now,
+            second_factor_method: UserSecondFactor.methods[:totp]
+          }
+        end
+        it "returns OK" do
+          expect(user.authenticate_second_factor_method(params, secure_session).ok?).to eq(true)
+        end
+      end
+
+      context "when totp is invalid" do
+        let(:params) do
+          {
+            second_factor_token: "blah",
+            second_factor_method: UserSecondFactor.methods[:totp]
+          }
+        end
+        it "returns not OK" do
+          result = user.authenticate_second_factor_method(params, secure_session)
+          expect(result.ok?).to eq(false)
+          expect(result.error).to eq(I18n.t("login.invalid_second_factor_code"))
+        end
+      end
+    end
+
+    context "when both security keys and totp are enabled" do
+      before do
+        simulate_localhost_webauthn_challenge
+        Webauthn.stage_challenge(user, secure_session)
+      end
+
+      context "when no totp params are provided" do
+        let(:params) { { security_key_credential: valid_security_key_auth_post_data, second_factor_method: UserSecondFactor.methods[:security_key] } }
+
+        it "validates the security key OK" do
+          expect(user.authenticate_second_factor_method(params, secure_session).ok?).to eq(true)
+        end
+      end
+
+      context "when totp params are provided" do
+        let(:params) do
+          {
+            second_factor_token: user.user_second_factors.totps.first.totp_object.now,
+            second_factor_method: UserSecondFactor.methods[:totp]
+          }
+        end
+
+        it "validates totp OK" do
+          expect(user.authenticate_second_factor_method(params, secure_session).ok?).to eq(true)
+        end
       end
     end
   end
@@ -186,5 +338,13 @@ RSpec.describe SecondFactorManager do
         end
       end
     end
+  end
+
+  def disable_totp
+    user.user_second_factors.totps.first.update!(enabled: false)
+  end
+
+  def disable_security_key
+    user.security_keys.first.destroy!
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -160,7 +160,7 @@ RSpec.configure do |config|
   config.include MessageBus
   config.include RSpecHtmlMatchers
   config.include IntegrationHelpers, type: :request
-  config.include WebauthnIntegrationHelpers, type: :request
+  config.include WebauthnIntegrationHelpers
   config.include SiteSettingsHelpers
   config.mock_framework = :mocha
   config.order = 'random'

--- a/spec/requests/session_controller_spec.rb
+++ b/spec/requests/session_controller_spec.rb
@@ -316,7 +316,7 @@ RSpec.describe SessionController do
             expect(session[:current_user_id]).to eq(nil)
             response_body = JSON.parse(response.body)
             expect(response_body['error']).to eq(I18n.t(
-              'login.invalid_second_factor_code'
+              'login.invalid_security_key'
             ))
           end
         end
@@ -1173,7 +1173,7 @@ RSpec.describe SessionController do
             response_body = JSON.parse(response.body)
             expect(response_body["failed"]).to eq("FAILED")
             expect(response_body['error']).to eq(I18n.t(
-              'login.invalid_second_factor_code'
+              'login.invalid_security_key'
             ))
           end
         end


### PR DESCRIPTION
* Move confusing 2FA logic involving whether to authenticate with security key or totp to second factor manager and clean up, and move authenticate webauthn functionality to second factor manager.
* Replace confusing code in session controller with new calls to second factor manager
* Add specs for new manager code and ensure current session controller specs work fine