### PR TITLE
PERF: Cache ranks for featured badges, to simplify user serialization

### DIFF
--- a/app/jobs/scheduled/badge_grant.rb
+++ b/app/jobs/scheduled/badge_grant.rb
@@ -22,6 +22,7 @@ module Jobs
       end
 
       BadgeGranter.revoke_ungranted_titles!
+      UserBadge.ensure_consistency! # Badge granter sometimes uses raw SQL, so hooks do not run. Clean up data
     end
 
   end

--- a/app/models/badge.rb
+++ b/app/models/badge.rb
@@ -115,6 +115,7 @@ class Badge < ActiveRecord::Base
   after_commit do
     SvgSprite.expire_cache
     UserStat.update_distinct_badge_count if saved_change_to_enabled?
+    UserBadge.ensure_consistency! if saved_change_to_enabled?
   end
 
   # fields that can not be edited on system badges

--- a/app/models/user_badge.rb
+++ b/app/models/user_badge.rb
@@ -100,6 +100,7 @@ end
 #  post_id         :integer
 #  notification_id :integer
 #  seq             :integer          default(0), not null
+#  featured_rank   :integer
 #
 # Indexes
 #

--- a/app/models/user_badge.rb
+++ b/app/models/user_badge.rb
@@ -75,7 +75,7 @@ class UserBadge < ActiveRecord::Base
       )
       -- Now use that data to update the featured_rank column
       UPDATE user_badges SET featured_rank = rank_number
-      FROM ranks WHERE ranks.badge_id = user_badges.badge_id AND ranks.user_id = user_badges.user_id
+      FROM ranks WHERE ranks.badge_id = user_badges.badge_id AND ranks.user_id = user_badges.user_id AND featured_rank IS DISTINCT FROM rank_number
     SQL
 
     DB.exec query

--- a/app/models/user_badge.rb
+++ b/app/models/user_badge.rb
@@ -10,13 +10,12 @@ class UserBadge < ActiveRecord::Base
   scope :grouped_with_count, -> {
     group(:badge_id, :user_id)
       .select(UserBadge.attribute_names.map { |x| "MAX(user_badges.#{x}) AS #{x}" },
-                  'COUNT(*) AS "count"',
-                  'MAX(badges.badge_type_id) AS badges_badge_type_id',
-                  'MAX(badges.grant_count) AS badges_grant_count')
-      .joins(:badge)
-      .order('max(featured_rank) ASC')
+              'COUNT(*) AS "count"')
+      .order('MAX(featured_rank) ASC')
       .includes(:user, :granted_by, { badge: :badge_type }, post: :topic)
   }
+
+  scope :for_enabled_badges, -> { where('user_badges.badge_id IN (SELECT id FROM badges WHERE enabled)') }
 
   validates :badge_id,
     presence: true,

--- a/app/models/user_badge.rb
+++ b/app/models/user_badge.rb
@@ -7,6 +7,17 @@ class UserBadge < ActiveRecord::Base
   belongs_to :notification, dependent: :destroy
   belongs_to :post
 
+  scope :grouped_with_count, -> {
+    group(:badge_id, :user_id)
+      .select(UserBadge.attribute_names.map { |x| "MAX(user_badges.#{x}) AS #{x}" },
+                  'COUNT(*) AS "count"',
+                  'MAX(badges.badge_type_id) AS badges_badge_type_id',
+                  'MAX(badges.grant_count) AS badges_grant_count')
+      .joins(:badge)
+      .order('max(featured_rank) ASC')
+      .includes(:user, :granted_by, { badge: :badge_type }, post: :topic)
+  }
+
   validates :badge_id,
     presence: true,
     uniqueness: { scope: :user_id },
@@ -19,13 +30,55 @@ class UserBadge < ActiveRecord::Base
   after_create do
     Badge.increment_counter 'grant_count', self.badge_id
     UserStat.update_distinct_badge_count self.user_id
+    UserBadge.update_featured_ranks! self.user_id
     DiscourseEvent.trigger(:user_badge_granted, self.badge_id, self.user_id)
   end
 
   after_destroy do
     Badge.decrement_counter 'grant_count', self.badge_id
     UserStat.update_distinct_badge_count self.user_id
+    UserBadge.update_featured_ranks! self.user_id
     DiscourseEvent.trigger(:user_badge_removed, self.badge_id, self.user_id)
+  end
+
+  def self.ensure_consistency!
+    self.update_featured_ranks!
+  end
+
+  def self.update_featured_ranks!(user_id = nil)
+    query = <<~SQL
+      WITH featured_tl_badge AS -- Find the best trust level badge for each user
+      (
+        SELECT user_id, max(badge_id) as badge_id
+        FROM user_badges
+        WHERE badge_id IN (1,2,3,4)
+        #{"AND user_id = #{user_id}" if user_id}
+        GROUP BY user_id
+      ),
+      ranks AS ( -- Take all user badges, group by user_id and badge_id, and calculate a rank for each one
+        SELECT
+          user_badges.user_id,
+          user_badges.badge_id,
+          RANK() OVER (
+            PARTITION BY user_badges.user_id -- Do a separate rank for each user
+            ORDER BY MAX(featured_tl_badge.user_id) NULLS LAST, -- Best tl badge first
+                    CASE WHEN user_badges.badge_id IN (1,2,3,4) THEN 1 ELSE 0 END ASC, -- Non-featured tl badges last
+                    MAX(badges.badge_type_id) ASC,
+                    MAX(badges.grant_count) ASC,
+                    user_badges.badge_id DESC
+          ) rank_number
+        FROM user_badges
+        INNER JOIN badges ON badges.id = user_badges.badge_id
+        LEFT JOIN featured_tl_badge ON featured_tl_badge.user_id = user_badges.user_id AND featured_tl_badge.badge_id = user_badges.badge_id
+        #{"WHERE user_badges.user_id = #{user_id}" if user_id}
+        GROUP BY user_badges.user_id, user_badges.badge_id
+      )
+      -- Now use that data to update the featured_rank column
+      UPDATE user_badges SET featured_rank = rank_number
+      FROM ranks WHERE ranks.badge_id = user_badges.badge_id AND ranks.user_id = user_badges.user_id
+    SQL
+
+    DB.exec query
   end
 
   private

--- a/app/models/user_badge.rb
+++ b/app/models/user_badge.rb
@@ -51,7 +51,7 @@ class UserBadge < ActiveRecord::Base
         SELECT user_id, max(badge_id) as badge_id
         FROM user_badges
         WHERE badge_id IN (1,2,3,4)
-        #{"AND user_id = #{user_id}" if user_id}
+        #{"AND user_id = #{user_id.to_i}" if user_id}
         GROUP BY user_id
       ),
       ranks AS ( -- Take all user badges, group by user_id and badge_id, and calculate a rank for each one
@@ -70,7 +70,7 @@ class UserBadge < ActiveRecord::Base
         FROM user_badges
         INNER JOIN badges ON badges.id = user_badges.badge_id
         LEFT JOIN featured_tl_badge ON featured_tl_badge.user_id = user_badges.user_id AND featured_tl_badge.badge_id = user_badges.badge_id
-        #{"WHERE user_badges.user_id = #{user_id}" if user_id}
+        #{"WHERE user_badges.user_id = #{user_id.to_i}" if user_id}
         GROUP BY user_badges.user_id, user_badges.badge_id
       )
       -- Now use that data to update the featured_rank column

--- a/app/models/user_badge.rb
+++ b/app/models/user_badge.rb
@@ -61,7 +61,8 @@ class UserBadge < ActiveRecord::Base
           user_badges.badge_id,
           RANK() OVER (
             PARTITION BY user_badges.user_id -- Do a separate rank for each user
-            ORDER BY MAX(featured_tl_badge.user_id) NULLS LAST, -- Best tl badge first
+            ORDER BY BOOL_OR(badges.enabled) DESC, -- Disabled badges last
+                    MAX(featured_tl_badge.user_id) NULLS LAST, -- Best tl badge first
                     CASE WHEN user_badges.badge_id IN (1,2,3,4) THEN 1 ELSE 0 END ASC, -- Non-featured tl badges last
                     MAX(badges.badge_type_id) ASC,
                     MAX(badges.grant_count) ASC,

--- a/db/migrate/20200107161405_add_featured_rank_to_user_badges.rb
+++ b/db/migrate/20200107161405_add_featured_rank_to_user_badges.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+class AddFeaturedRankToUserBadges < ActiveRecord::Migration[6.0]
+  def change
+    add_column :user_badges, :featured_rank, :integer, null: true
+
+    # execute <<~SQL
+    #   UPDATE user_badges
+    #   SET featured_rank = x.featured_rank
+    #   FROM (
+    #     SELECT users.id user_id, COUNT(distinct user_badges.badge_id) distinct_badge_count
+    #     FROM users
+    #     LEFT JOIN user_badges ON user_badges.user_id = users.id
+    #                           AND (user_badges.badge_id IN (SELECT id FROM badges WHERE enabled))
+    #     GROUP BY users.id
+    #   ) x
+    #   WHERE user_stats.user_id = x.user_id AND user_stats.distinct_badge_count <> x.distinct_badge_count
+    # SQL
+  end
+end

--- a/db/migrate/20200107161405_add_featured_rank_to_user_badges.rb
+++ b/db/migrate/20200107161405_add_featured_rank_to_user_badges.rb
@@ -3,17 +3,35 @@ class AddFeaturedRankToUserBadges < ActiveRecord::Migration[6.0]
   def change
     add_column :user_badges, :featured_rank, :integer, null: true
 
-    # execute <<~SQL
-    #   UPDATE user_badges
-    #   SET featured_rank = x.featured_rank
-    #   FROM (
-    #     SELECT users.id user_id, COUNT(distinct user_badges.badge_id) distinct_badge_count
-    #     FROM users
-    #     LEFT JOIN user_badges ON user_badges.user_id = users.id
-    #                           AND (user_badges.badge_id IN (SELECT id FROM badges WHERE enabled))
-    #     GROUP BY users.id
-    #   ) x
-    #   WHERE user_stats.user_id = x.user_id AND user_stats.distinct_badge_count <> x.distinct_badge_count
-    # SQL
+    execute <<~SQL
+      WITH featured_tl_badge AS -- Find the best trust level badge for each user
+      (
+        SELECT user_id, max(badge_id) as badge_id
+        FROM user_badges
+        WHERE badge_id IN (1,2,3,4)
+        GROUP BY user_id
+      ),
+      ranks AS ( -- Take all user badges, group by user_id and badge_id, and calculate a rank for each one
+        SELECT
+          user_badges.user_id,
+          user_badges.badge_id,
+          RANK() OVER (
+            PARTITION BY user_badges.user_id -- Do a separate rank for each user
+            ORDER BY BOOL_OR(badges.enabled) DESC, -- Disabled badges last
+                    MAX(featured_tl_badge.user_id) NULLS LAST, -- Best tl badge first
+                    CASE WHEN user_badges.badge_id IN (1,2,3,4) THEN 1 ELSE 0 END ASC, -- Non-featured tl badges last
+                    MAX(badges.badge_type_id) ASC,
+                    MAX(badges.grant_count) ASC,
+                    user_badges.badge_id DESC
+          ) rank_number
+        FROM user_badges
+        INNER JOIN badges ON badges.id = user_badges.badge_id
+        LEFT JOIN featured_tl_badge ON featured_tl_badge.user_id = user_badges.user_id AND featured_tl_badge.badge_id = user_badges.badge_id
+        GROUP BY user_badges.user_id, user_badges.badge_id
+      )
+      -- Now use that data to update the featured_rank column
+      UPDATE user_badges SET featured_rank = rank_number
+      FROM ranks WHERE ranks.badge_id = user_badges.badge_id AND ranks.user_id = user_badges.user_id
+    SQL
   end
 end

--- a/spec/models/user_badge_spec.rb
+++ b/spec/models/user_badge_spec.rb
@@ -16,4 +16,50 @@ describe UserBadge do
     it { is_expected.to validate_uniqueness_of(:badge_id).scoped_to(:user_id) }
   end
 
+  describe "featured rank" do
+    fab!(:user) { Fabricate(:user) }
+    fab!(:user_badge_tl1) { UserBadge.create!(badge_id: Badge::BasicUser, user: user, granted_by: Discourse.system_user, granted_at: Time.now) }
+    fab!(:user_badge_tl2) { UserBadge.create!(badge_id: Badge::Member, user: user, granted_by: Discourse.system_user, granted_at: Time.now) }
+    fab!(:user_badge_wiki) { UserBadge.create!(badge_id: Badge::WikiEditor, user: user, granted_by: Discourse.system_user, granted_at: Time.now) }
+    fab!(:user_badge_like) { UserBadge.create!(badge_id: Badge::FirstLike, user: user, granted_by: Discourse.system_user, granted_at: Time.now) }
+
+    it "gives user badges the correct rank" do
+      expect(user_badge_tl2.reload.featured_rank).to eq(1)
+      expect(user_badge_wiki.reload.featured_rank).to eq(2)
+      expect(user_badge_like.reload.featured_rank).to eq(3)
+      expect(user_badge_tl1.reload.featured_rank).to eq(4) # Previous trust level badges last
+    end
+
+    it "gives duplicate user_badges the same rank" do
+      ub1 = UserBadge.create!(badge_id: Badge::GreatTopic, user: user, granted_by: Discourse.system_user, granted_at: Time.now)
+      ub2 = UserBadge.create!(badge_id: Badge::GreatTopic, user: user, granted_by: Discourse.system_user, granted_at: Time.now, seq: 1)
+
+      expect(ub1.reload.featured_rank).to eq(2)
+      expect(ub2.reload.featured_rank).to eq(2)
+    end
+
+    it "skips disabled badges" do
+      user_badge_wiki.badge.update(enabled: false)
+      expect(user_badge_tl2.reload.featured_rank).to eq(1)
+      expect(user_badge_like.reload.featured_rank).to eq(2)
+      expect(user_badge_tl1.reload.featured_rank).to eq(3) # Previous trust level badges last
+      expect(user_badge_wiki.reload.featured_rank).to eq(4) # Disabled
+    end
+
+    it "can ensure consistency per user" do
+      user_badge_tl2.update_column(:featured_rank, 20) # Update without hooks
+      expect(user_badge_tl2.reload.featured_rank).to eq(20) # Double check
+      UserBadge.update_featured_ranks! user.id
+      expect(user_badge_tl2.reload.featured_rank).to eq(1)
+    end
+
+    it "can ensure consistency for all users" do
+      user_badge_tl2.update_column(:featured_rank, 20) # Update without hooks
+      expect(user_badge_tl2.reload.featured_rank).to eq(20) # Double check
+      UserBadge.update_featured_ranks!
+      expect(user_badge_tl2.reload.featured_rank).to eq(1)
+    end
+
+  end
+
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1706,15 +1706,12 @@ describe User do
 
   describe "#featured_user_badges" do
     fab!(:user) { Fabricate(:user) }
-    let!(:user_badge_tl1) { UserBadge.create(badge_id: 1, user: user, granted_by: Discourse.system_user, granted_at: Time.now) }
-    let!(:user_badge_tl2) { UserBadge.create(badge_id: 2, user: user, granted_by: Discourse.system_user, granted_at: Time.now) }
+    let!(:user_badge_tl1) { UserBadge.create(badge_id: Badge::BasicUser, user: user, granted_by: Discourse.system_user, granted_at: Time.now) }
+    let!(:user_badge_tl2) { UserBadge.create(badge_id: Badge::Member, user: user, granted_by: Discourse.system_user, granted_at: Time.now) }
+    let!(:user_badge_like) { UserBadge.create(badge_id: Badge::FirstLike, user: user, granted_by: Discourse.system_user, granted_at: Time.now) }
 
-    it 'should display highest trust level badge first' do
-      expect(user.featured_user_badges[0].badge_id).to eq(2)
-    end
-
-    it 'should display only 1 trust level badge' do
-      expect(user.featured_user_badges.length).to eq(1)
+    it 'should display badges in the correct order' do
+      expect(user.featured_user_badges.map(&:badge_id)).to eq([Badge::Member, Badge::FirstLike, Badge::BasicUser])
     end
   end
 


### PR DESCRIPTION
This introduces a new `featured_rank` column on the `user_badges` table. This is kept up-to-date automatically, and makes it much easier to load badges for user profiles and user cards.