### PR TITLE
FIX: Make 'findBySlugPathWithID' when URL ends with a slash

### DIFF
--- a/app/assets/javascripts/discourse/models/category.js.es6
+++ b/app/assets/javascripts/discourse/models/category.js.es6
@@ -334,7 +334,7 @@ Category.reopenClass({
   },
 
   findBySlugPathWithID(slugPathWithID) {
-    let parts = slugPathWithID.split("/");
+    let parts = slugPathWithID.split("/").filter(Boolean);
     // slugs found by star/glob pathing in emeber do not automatically url decode - ensure that these are decoded
     if (Discourse.SiteSettings.slug_generation_method === "encoded") {
       parts = parts.map(urlPart => decodeURI(urlPart));

--- a/test/javascripts/models/category-test.js.es6
+++ b/test/javascripts/models/category-test.js.es6
@@ -184,6 +184,30 @@ QUnit.test("findSingleBySlug", assert => {
   );
 });
 
+QUnit.test("findBySlugPathWithID", assert => {
+  const store = createStore();
+
+  const foo = store.createRecord("category", { id: 1, slug: "foo" });
+  const bar = store.createRecord("category", {
+    id: 2,
+    slug: "bar",
+    parentCategory: foo
+  });
+  const baz = store.createRecord("category", {
+    id: 3,
+    slug: "baz",
+    parentCategory: foo
+  });
+
+  const categoryList = [foo, bar, baz];
+  sandbox.stub(Category, "list").returns(categoryList);
+
+  assert.deepEqual(Category.findBySlugPathWithID("foo"), foo);
+  assert.deepEqual(Category.findBySlugPathWithID("foo/bar"), bar);
+  assert.deepEqual(Category.findBySlugPathWithID("foo/bar/"), bar);
+  assert.deepEqual(Category.findBySlugPathWithID("foo/baz/3"), baz);
+});
+
 QUnit.test("search with category name", assert => {
   const store = createStore(),
     category1 = store.createRecord("category", {


### PR DESCRIPTION
Make URLs such as 'https://discourse/c/foo/bar/' work the same way
'https://discourse/c/foo/bar' does.