### PR TITLE
FIX: Create post notices only for public posts

### DIFF
--- a/lib/post_creator.rb
+++ b/lib/post_creator.rb
@@ -550,8 +550,12 @@ class PostCreator
 
   def create_post_notice
     return if @opts[:import_mode] || @user.anonymous? || @user.bot? || @user.staged
+    return if @post.topic.archetype != Archetype.default
 
-    last_post_time = Post.where(user_id: @user.id)
+    last_post_time = Post
+      .joins("JOIN topics ON topics.id = posts.topic_id")
+      .where(user_id: @user.id)
+      .where(topics: { archetype: Archetype.default })
       .order(created_at: :desc)
       .limit(1)
       .pluck(:created_at)

--- a/spec/components/post_creator_spec.rb
+++ b/spec/components/post_creator_spec.rb
@@ -1357,6 +1357,9 @@ describe PostCreator do
     fab!(:anonymous) { Fabricate(:anonymous) }
 
     it "generates post notices for new users" do
+      post = PostCreator.create!(user, title: "private message topic", raw: "private message post", archetype: Archetype.private_message, target_usernames: user.username)
+      expect(post.custom_fields[Post::NOTICE_TYPE]).to eq(nil)
+
       post = PostCreator.create!(user, title: "one of my first topics", raw: "one of my first posts")
       expect(post.custom_fields[Post::NOTICE_TYPE]).to eq(Post.notices[:new_user])
 
@@ -1367,6 +1370,9 @@ describe PostCreator do
     it "generates post notices for returning users" do
       SiteSetting.returning_users_days = 30
       old_post = Fabricate(:post, user: user, created_at: 31.days.ago)
+
+      post = PostCreator.create!(user, title: "private message topic", raw: "private message post", archetype: Archetype.private_message, target_usernames: user.username)
+      expect(post.custom_fields[Post::NOTICE_TYPE]).to eq(nil)
 
       post = PostCreator.create!(user, title: "this is a returning topic", raw: "this is a post")
       expect(post.custom_fields[Post::NOTICE_TYPE]).to eq(Post.notices[:returning_user])


### PR DESCRIPTION
This also ensures only public posts are considered when creating post
notices for new and returning users.