### PR TITLE
FIX: Bind value of excluded-usernames for user-selector

### DIFF
--- a/app/assets/javascripts/discourse/components/user-selector.js.es6
+++ b/app/assets/javascripts/discourse/components/user-selector.js.es6
@@ -60,8 +60,7 @@ export default TextField.extend({
       allowAny = bool("allowAny"),
       disabled = bool("disabled"),
       allowEmails = bool("allowEmails"),
-      fullWidthWrap = bool("fullWidthWrap"),
-      excludedUsernames = this.excludedUsernames || [];
+      fullWidthWrap = bool("fullWidthWrap");
 
     const allExcludedUsernames = () => {
       // hack works around some issues with allowAny eventing
@@ -71,7 +70,7 @@ export default TextField.extend({
         usernames.concat([currentUser.username]);
       }
 
-      return usernames.concat(excludedUsernames);
+      return usernames.concat(this.excludedUsernames || []);
     };
 
     this.element.addEventListener("paste", this._paste);


### PR DESCRIPTION
`excludedUsernames` was not being bound to the value passed in, because the value was being held at the value when the component was `inited`. 

Now `excludedUsernames` is properly bound!