### PR TITLE
FEATURE: allows to define a dissmiss duration on global notices

### DIFF
--- a/app/assets/javascripts/discourse/components/global-notice.js.es6
+++ b/app/assets/javascripts/discourse/components/global-notice.js.es6
@@ -9,7 +9,7 @@ export function addGlobalNotice(text, id, options = {}) {
   _pluginNotices.push(Notice.create({ text, id, options }));
 }
 
-const GLOBAL_NOTICE_DISMISSED_PROMPT_KEY = "dismissed-global-notice";
+const GLOBAL_NOTICE_DISMISSED_PROMPT_KEY = "dismissed-global-notice-v2";
 
 const Notice = EmberObject.extend({
   text: null,
@@ -20,12 +20,20 @@ const Notice = EmberObject.extend({
     this._super(...arguments);
 
     const defaults = {
+      // can this banner be hidden
       dismissable: false,
+      // prepend html content
       html: null,
+      // will define the style of the banner, follows alerts styling
       level: "info",
+      // should the banner be permanently hidden?
       persistentDismiss: true,
+      // callback function when dismissing a banner
       onDismiss: null,
-      visibility: null
+      // show/hide banner function, will take precedence over everything
+      visibility: null,
+      // how long before banner should show again, eg: moment.duration(1, "week")
+      dismissDuration: null
     };
 
     this.options = this.set(
@@ -145,7 +153,24 @@ export default Component.extend({
           return notice.options.visibility(notice);
         } else {
           const key = `${GLOBAL_NOTICE_DISMISSED_PROMPT_KEY}-${notice.id}`;
-          return !this.keyValueStore.get(key);
+          const value = this.keyValueStore.get(key);
+
+          // banner has never been dismissed
+          if (!value) {
+            return true;
+          }
+
+          // banner has no persisten dismiss and should always show on load
+          if (!notice.options.persistentDismiss) {
+            return true;
+          }
+
+          if (notice.options.dismissDuration) {
+            const resetAt = moment(value).add(notice.options.dismissDuration);
+            return moment().isAfter(resetAt);
+          } else {
+            return false;
+          }
         }
       });
     }
@@ -160,7 +185,7 @@ export default Component.extend({
       if (notice.options.persistentDismiss) {
         this.keyValueStore.set({
           key: `${GLOBAL_NOTICE_DISMISSED_PROMPT_KEY}-${notice.id}`,
-          value: true
+          value: moment().toISOString(true)
         });
       }
 

--- a/app/assets/javascripts/discourse/components/global-notice.js.es6
+++ b/app/assets/javascripts/discourse/components/global-notice.js.es6
@@ -160,7 +160,7 @@ export default Component.extend({
             return true;
           }
 
-          // banner has no persisten dismiss and should always show on load
+          // banner has no persistent dismiss and should always show on load
           if (!notice.options.persistentDismiss) {
             return true;
           }

--- a/plugins/discourse-internet-explorer/assets/javascripts/initializers/discourse-internet-explorer.js.es6
+++ b/plugins/discourse-internet-explorer/assets/javascripts/initializers/discourse-internet-explorer.js.es6
@@ -8,7 +8,7 @@ function initializeInternetExplorerDeprecation(api) {
       api.addGlobalNotice(
         I18n.t("discourse_internet_explorer.deprecation_warning"),
         "deprecate-internet-explorer",
-        { dismissable: true }
+        { dismissable: true, dismissDuration: moment.duration(1, "week") }
       );
     }
   }


### PR DESCRIPTION
This commit also adds more documentation to various options and defines a 1 week duration for IE global notice dismiss duration.