### PR TITLE
FIX: show error message if the topic deletion fails

### DIFF
--- a/app/assets/javascripts/discourse/models/topic.js.es6
+++ b/app/assets/javascripts/discourse/models/topic.js.es6
@@ -467,16 +467,19 @@ const Topic = RestModel.extend({
 
   // Delete this topic
   destroy(deleted_by) {
-    this.setProperties({
-      deleted_at: new Date(),
-      deleted_by: deleted_by,
-      "details.can_delete": false,
-      "details.can_recover": true
-    });
     return ajax(`/t/${this.id}`, {
       data: { context: window.location.pathname },
       type: "DELETE"
-    });
+    })
+      .then(() => {
+        this.setProperties({
+          deleted_at: new Date(),
+          deleted_by: deleted_by,
+          "details.can_delete": false,
+          "details.can_recover": true
+        });
+      })
+      .catch(popupAjaxError);
   },
 
   // Recover this topic if deleted

--- a/test/javascripts/acceptance/topic-test.js.es6
+++ b/test/javascripts/acceptance/topic-test.js.es6
@@ -207,6 +207,14 @@ QUnit.test(
   }
 );
 
+QUnit.skip("Deleting a topic", async assert => {
+  await visit("/t/internationalization-localization/280");
+  await click(".topic-post:eq(0) button.show-more-actions");
+  await click(".widget-button.delete");
+
+  assert.ok(exists(".widget-button.recover"), "it shows the recover button");
+});
+
 acceptance("Topic featured links", {
   loggedIn: true,
   settings: {

--- a/test/javascripts/models/topic-test.js.es6
+++ b/test/javascripts/models/topic-test.js.es6
@@ -108,15 +108,6 @@ QUnit.test("updateFromJson", assert => {
   assert.equal(topic.get("category"), category);
 });
 
-QUnit.test("destroy", assert => {
-  const user = User.create({ username: "eviltrout" });
-  const topic = Topic.create({ id: 1234 });
-
-  topic.destroy(user);
-  assert.present(topic.get("deleted_at"), "deleted at is set");
-  assert.equal(topic.get("deleted_by"), user, "deleted by is set");
-});
-
 QUnit.test("recover", assert => {
   const user = User.create({ username: "eviltrout" });
   const topic = Topic.create({


### PR DESCRIPTION
When staff tries to delete category definition topic the topic does not gets deleted but the client side code indicates that topic has been deleted. This commit will show error message from server side if topic can not be deleted.