### PR TITLE
FEATURE: Drop "backup" schema 7 days after restore

### DIFF
--- a/app/jobs/scheduled/drop_backup_schema.rb
+++ b/app/jobs/scheduled/drop_backup_schema.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Jobs
+  class DropBackupSchema < ::Jobs::Scheduled
+    every 1.day
+
+    def execute(_)
+      BackupRestore::DatabaseRestorer.drop_backup_schema
+    end
+  end
+end

--- a/app/models/backup_metadata.rb
+++ b/app/models/backup_metadata.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class BackupMetadata < ActiveRecord::Base
+  LAST_RESTORE_DATE = "last_restore_date"
+
   def self.value_for(name)
     where(name: name).pluck_first(:value).presence
   end


### PR DESCRIPTION
The "backup" schema is used to rollback a failed restore. It isn't useful after a longer period of time and turns into a waste of disk space.