### PR TITLE
FIX: Mobile topic-timeline not closing on scrolling past last post

### DIFF
--- a/app/assets/javascripts/discourse/controllers/topic.js.es6
+++ b/app/assets/javascripts/discourse/controllers/topic.js.es6
@@ -727,6 +727,10 @@ export default Controller.extend(bufferedProperty("model"), {
     },
 
     jumpEnd() {
+      this.appEvents.trigger(
+        "topic:jump-to-post",
+        this.get("model.highest_post_number")
+      );
       DiscourseURL.routeTo(this.get("model.lastPostUrl"), {
         jumpEnd: true
       });

--- a/app/assets/javascripts/discourse/lib/url.js.es6
+++ b/app/assets/javascripts/discourse/lib/url.js.es6
@@ -103,11 +103,14 @@ const DiscourseURL = EmberObject.extend({
         let holderHeight = $holder.height();
         let windowHeight = $(window).height() - offsetCalculator();
 
-        // scroll to the bottom of the post and stop any further action if the
-        // post is yuge, otherwise just jump to the top of the post
-        // using the lock & holder method
+        // scroll to the bottom of the post and if the post is yuge we go back up the
+        // timeline by a small % of the post height so we can see the bottom of the text.
+        //
+        // otherwise just jump to the top of the post using the lock & holder method.
         if (holderHeight > windowHeight) {
-          $(window).scrollTop($holder.offset().top + holderHeight);
+          $(window).scrollTop(
+            $holder.offset().top + (holderHeight - holderHeight / 10)
+          );
           _transitioning = false;
           return;
         }


### PR DESCRIPTION
See https://meta.discourse.org/t/post-excerpts-are-missing-from-the-expanded-mobile-timeline/132768/4.

* When we dragged the topic-timeline handle past the last post
  in a topic we were not closing the timeline as we would if
  scrolling to a specific post
* This also fixes the issue where when scrolling past the end of
  the topic with a massive last post, none of the post could be
  seen