### PR TITLE
FIX: Reload the ReviewableScore types when extending flags

### DIFF
--- a/app/models/reviewable_score.rb
+++ b/app/models/reviewable_score.rb
@@ -14,6 +14,13 @@ class ReviewableScore < ActiveRecord::Base
     )
   end
 
+  # When extending post action flags, we need to call this method in order to
+  # get the latests flags.
+  def self.reload_types
+    @types = nil
+    types
+  end
+
   def self.statuses
     @statuses ||= Enum.new(
       pending: 0,

--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -128,10 +128,13 @@ class Plugin::Instance
 
   # Applies to all sites in a multisite environment. Ignores plugin.enabled?
   def replace_flags(settings: ::FlagSettings.new)
-    yield settings
+    next_flag_id = ReviewableScore.types.values.max + 1
+
+    yield(settings, next_flag_id)
 
     reloadable_patch do |plugin|
       ::PostActionType.replace_flag_settings(settings)
+      ::ReviewableScore.reload_types
     end
   end
 


### PR DESCRIPTION
ReviewableScore#types extend the PostActionTypes with their own, storing the result inside a class variable. To avoid overwriting an existing flag, we need to calculate the next flag ID using these types instead of the PostAction ones. Since we first call the score types to calculate the id, this list gets memoized, leaving us with an outdated list.

To fix this, we now reload ReviewableScore#types after replacing flags.