### PR TITLE
FIX: Don't cause exceptions due to rename of `reply_id` column

### DIFF
--- a/db/migrate/20200116140132_rename_reply_id_column.rb
+++ b/db/migrate/20200116140132_rename_reply_id_column.rb
@@ -2,8 +2,6 @@
 
 class RenameReplyIdColumn < ActiveRecord::Migration[6.0]
   def up
-    Migration::ColumnDropper.mark_readonly(:post_replies, :reply_id)
-
     add_column :post_replies, :reply_post_id, :integer
 
     execute <<~SQL

--- a/db/migrate/20200117172135_add_trigger_to_sync_post_replies.rb
+++ b/db/migrate/20200117172135_add_trigger_to_sync_post_replies.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class AddTriggerToSyncPostReplies < ActiveRecord::Migration[6.0]
+  def up
+    # we don't want this column to be readonly yet
+    Migration::ColumnDropper.drop_readonly(:post_replies, :reply_id)
+
+    DB.exec <<~SQL
+      CREATE OR REPLACE FUNCTION post_replies_sync_reply_id()
+      RETURNS trigger AS $rcr$
+      BEGIN
+        NEW.reply_post_id := NEW.reply_id;
+        RETURN NEW;
+      END
+      $rcr$ LANGUAGE plpgsql;
+    SQL
+
+    DB.exec <<~SQL
+      CREATE TRIGGER post_replies_reply_id_sync
+      BEFORE INSERT OR UPDATE OF reply_id ON post_replies
+      FOR EACH ROW
+      WHEN (NEW.reply_id IS NOT NULL)
+      EXECUTE PROCEDURE post_replies_sync_reply_id();
+    SQL
+
+    # one more sync because we could be missing some data from the time between the
+    # "20200116140132_rename_reply_id_column" migration and now
+    execute <<~SQL
+      UPDATE post_replies
+      SET reply_post_id = reply_id
+      WHERE reply_post_id IS NULL
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/post_migrate/20200117174646_make_post_reply_id_column_read_only.rb
+++ b/db/post_migrate/20200117174646_make_post_reply_id_column_read_only.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class MakePostReplyIdColumnReadOnly < ActiveRecord::Migration[6.0]
+  def up
+    Migration::ColumnDropper.mark_readonly(:post_replies, :reply_id)
+    DB.exec("DROP FUNCTION IF EXISTS post_replies_sync_reply_id() CASCADE")
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
This syncs the value of the `reply_id` column into the `reply_post_id` column until all servers have been deployed and the post migrations ran.

Follow-up to ab07b945c28682ce58c5149003d65e6f3fd26dff

I tested it by executing the new `20200117172135_add_trigger_to_sync_post_replies` migration and running old code with the migrated database. Works fine. The trigger intercepts writes into the `reply_id` column and saves the value into the `reply_post_id` column. That way new code and old code will work until the deploy has finished. Then the post migration kicks in, deletes the trigger that does all the syncing and creates a new trigger to make the `reply_id` column read-only.