### PR TITLE
FIX: Incorrect locale in badge granter

### DIFF
--- a/app/services/badge_granter.rb
+++ b/app/services/badge_granter.rb
@@ -380,11 +380,13 @@ class BadgeGranter
     SQL
   end
 
-  def self.send_notification(user_id, username, locale, badge)
-    use_default_locale = !SiteSetting.allow_user_locale && locale.blank?
-    notification_locale = use_default_locale ? SiteSetting.default_locale : locale
+  def self.notification_locale(locale)
+    use_default_locale = !SiteSetting.allow_user_locale || locale.blank?
+    use_default_locale ? SiteSetting.default_locale : locale
+  end
 
-    I18n.with_locale(notification_locale) do
+  def self.send_notification(user_id, username, locale, badge)
+    I18n.with_locale(notification_locale(locale)) do
       Notification.create!(
         user_id: user_id,
         notification_type: Notification.types[:granted_badge],

--- a/spec/services/badge_granter_spec.rb
+++ b/spec/services/badge_granter_spec.rb
@@ -322,4 +322,20 @@ describe BadgeGranter do
     end
   end
 
+  context 'notification locales' do
+    it 'is using default locales when user locales are not set' do
+      SiteSetting.allow_user_locale = true
+      expect(BadgeGranter.notification_locale('')).to eq(SiteSetting.default_locale)
+    end
+
+    it 'is using default locales when user locales are set but is not allowed' do
+      SiteSetting.allow_user_locale = false
+      expect(BadgeGranter.notification_locale('pl_PL')).to eq(SiteSetting.default_locale)
+    end
+
+    it 'is using user locales when set and allowed' do
+      SiteSetting.allow_user_locale = true
+      expect(BadgeGranter.notification_locale('pl_PL')).to eq('pl_PL')
+    end
+  end
 end


### PR DESCRIPTION
We want to use default locale when:
a) Site settings are not allowing for user locale
OR
b) User locale are blank