### PR TITLE
FIX: when tag or category is added notify users that topic was modified

### DIFF
--- a/app/jobs/regular/notify_category_change.rb
+++ b/app/jobs/regular/notify_category_change.rb
@@ -7,7 +7,7 @@ module Jobs
 
       if post&.topic&.visible?
         post_alerter = PostAlerter.new
-        post_alerter.notify_post_users(post, User.where(id: args[:notified_user_ids]), include_tag_watchers: false)
+        post_alerter.notify_post_users(post, User.where(id: args[:notified_user_ids]), include_tag_watchers: false, new_record: false)
         post_alerter.notify_first_post_watchers(post, post_alerter.category_watchers(post.topic))
       end
     end

--- a/app/jobs/regular/notify_tag_change.rb
+++ b/app/jobs/regular/notify_tag_change.rb
@@ -7,7 +7,7 @@ module Jobs
 
       if post&.topic&.visible?
         post_alerter = PostAlerter.new
-        post_alerter.notify_post_users(post, User.where(id: args[:notified_user_ids]), include_category_watchers: false)
+        post_alerter.notify_post_users(post, User.where(id: args[:notified_user_ids]), include_category_watchers: false, new_record: false)
         post_alerter.notify_first_post_watchers(post, post_alerter.tag_watchers(post.topic))
       end
     end

--- a/spec/jobs/notify_tag_change_spec.rb
+++ b/spec/jobs/notify_tag_change_spec.rb
@@ -24,6 +24,7 @@ describe ::Jobs::NotifyTagChange do
     notification = Notification.last
     expect(notification.user_id).to eq(user.id)
     expect(notification.topic_id).to eq(post.topic_id)
+    expect(notification.notification_type).to eq(Notification.types[:edited])
   end
 
   it 'doesnt create notification for user watching category' do

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -1404,7 +1404,7 @@ describe Topic do
               user_id: user.id,
               topic_id: topic.id,
               post_number: 1,
-              notification_type: Notification.types[:posted]
+              notification_type: Notification.types[:edited]
             ).exists?).to eq(true)
 
             expect(Notification.where(


### PR DESCRIPTION
There is a feature, that when tag or category is added to the topic,
customers who are watching that category or tag are notified.

The problem is that it is using default notification type "new post"

It would be better to use "new post" only when there really is a new
post and "edited" when categories or tags were modified.