### PR TITLE
FIX: Do not extract dates from quotes and Oneboxes

### DIFF
--- a/plugins/discourse-local-dates/plugin.rb
+++ b/plugins/discourse-local-dates/plugin.rb
@@ -26,19 +26,21 @@ after_initialize do
   register_post_custom_field_type(DiscourseLocalDates::POST_CUSTOM_FIELD, :json)
 
   on(:before_post_process_cooked) do |doc, post|
-    dates =
-      doc.css('span.discourse-local-date').map do |cooked_date|
-        date = {}
-        cooked_date.attributes.values.each do |attribute|
-          data_name = attribute.name&.gsub('data-', '')
-          if data_name && %w[date time timezone recurring].include?(data_name)
-            unless attribute.value == 'undefined'
-              date[data_name] = CGI.escapeHTML(attribute.value || '')
-            end
+    dates = []
+
+    doc.css('span.discourse-local-date').map do |cooked_date|
+      next if cooked_date.ancestors("aside").length > 0
+      date = {}
+      cooked_date.attributes.values.each do |attribute|
+        data_name = attribute.name&.gsub('data-', '')
+        if data_name && %w[date time timezone recurring].include?(data_name)
+          unless attribute.value == 'undefined'
+            date[data_name] = CGI.escapeHTML(attribute.value || '')
           end
         end
-        date
       end
+      dates << date
+    end
 
     if dates.present?
       post.custom_fields[DiscourseLocalDates::POST_CUSTOM_FIELD] = dates

--- a/plugins/discourse-local-dates/spec/models/post_spec.rb
+++ b/plugins/discourse-local-dates/spec/models/post_spec.rb
@@ -26,6 +26,29 @@ describe Post do
 
       expect(post.local_dates).to eq([])
     end
+
+    it "should not contain dates from quotes" do
+      post = Fabricate(:post, raw: <<~SQL)
+        [quote]
+          [date=2018-09-17 time=01:39:00 format="LLL" timezone="Europe/Paris" timezones="Europe/Paris|America/Los_Angeles"]
+        [/quote]
+      SQL
+      CookedPostProcessor.new(post).post_process
+
+      expect(post.local_dates.count).to eq(0)
+    end
+
+    it "should not contain dates from examples" do
+      Oneboxer.stubs(:cached_onebox).with('https://example.com').returns(<<-HTML)
+        <aside class="onebox githubcommit">
+          <span class="discourse-local-date" data-format="ll" data-date="2020-01-20" data-time="15:06:58" data-timezone="UTC">03:06PM - 20 Jan 20 UTC</span>
+        </aside>
+      HTML
+      post = Fabricate(:post, raw: "https://example.com")
+      CookedPostProcessor.new(post).post_process
+
+      expect(post.local_dates.count).to eq(0)
+    end
   end
 
 end


### PR DESCRIPTION
Post.local_dates used to contain dates from quotes and Oneboxes.