### PR TITLE
DEV: Add debug lines for mystery no_user_selected error

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -777,6 +777,10 @@ class PostsController < ApplicationController
       result[:target_group_names] = groups.join(",")
     end
 
+    if recipients.blank? || result[:target_usernames].blank?
+      Rails.logger.debug("Missing recipients for PM! result: #{result.inspect} | params: #{params.inspect}")
+    end
+
     result.permit!
     result.to_h
   end

--- a/lib/topic_creator.rb
+++ b/lib/topic_creator.rb
@@ -171,6 +171,8 @@ class TopicCreator
     topic.subtype = TopicSubtype.user_to_user unless topic.subtype
 
     unless @opts[:target_usernames].present? || @opts[:target_emails].present? || @opts[:target_group_names].present?
+      Rails.logger.debug("Topic PM cannot be created without recipients! opts: #{@opts.inspect}")
+
       rollback_with!(topic, :no_user_selected)
     end
 

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -1110,6 +1110,22 @@ describe PostsController do
         expect(new_topic.allowed_users).to contain_exactly(user, user_2, user_3)
       end
 
+      context "when target_recipients not provided" do
+        it "errors when creating a private post" do
+          post "/posts.json", params: {
+            raw: 'this is the test content',
+            archetype: 'private_message',
+            title: "this is some post",
+            target_recipients: ""
+          }
+
+          expect(response.status).to eq(422)
+          expect(JSON.parse(response.body)["errors"]).to include(
+            I18n.t("activerecord.errors.models.topic.attributes.base.no_user_selected")
+          )
+        end
+      end
+
       context "errors" do
         it "does not succeed" do
           post "/posts.json", params: { raw: 'test' }


### PR DESCRIPTION
On some customer forums we are randomly getting a "You must select a valid user" error when sending a PM even when all parameters seem to be OK. This is an attempt to track it down with more data.

For example parameters like this will SOMETIMES randomly throw the "You must select a valid user" error even when the user is provided.

```
params: {
  raw: "this is another test to me",
  title: "this is another test to me",
  unlist_topic: false,
  category: nil,
  is_warning: false,
  archetype: "private_message",
  target_recipients: "martin",
  typing_duration_msecs: 5300,
  composer_open_duration_msecs: 16118,
  featured_link: nil,
  shared_draft: false,
  draft_key: "new_private_message",
  nested_post: true
}
```

Also just added a spec to expect the particular error that we are getting.