### PR TITLE
FIX: Notify staged users about private categories

### DIFF
--- a/lib/guardian/topic_guardian.rb
+++ b/lib/guardian/topic_guardian.rb
@@ -154,7 +154,7 @@ module TopicGuardian
 
     category = topic.category
     can_see_category?(category) &&
-      (!category.read_restricted || !is_staged? || topic.user == user)
+      (!category.read_restricted || !is_staged? || secure_category_ids.include?(category.id) || topic.user == user)
   end
 
   def can_get_access_to_topic?(topic)


### PR DESCRIPTION
Group membership and `CategoryUser` notification level should be
respected to determine whether to notify staged users about activity in
private categories, instead of only ever generating notifications for staged
users' own topics (which has been the behaviour since
0c4ac2a)