### PR TITLE
FIX: Ensure sourcemap's source is correct

### DIFF
--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -75,11 +75,13 @@ end
 def compress_node(from, to)
   to_path = "#{assets_path}/#{to}"
   assets = cdn_relative_path("/assets")
-  source_map_root = assets + ((d = File.dirname(from)) == "." ? "" : "/#{d}")
+  assets_additional_path = (d = File.dirname(from)) == "." ? "" : "/#{d}"
+  source_map_root = assets + assets_additional_path
   source_map_url = cdn_path "/assets/#{to}.map"
+  base_source_map = 'public/assets' + assets_additional_path
 
   cmd = <<~EOS
-    uglifyjs '#{assets_path}/#{from}' -m -c -o '#{to_path}' --source-map "root='#{source_map_root}',url='#{source_map_url}'" --output '#{to_path}'
+    uglifyjs '#{assets_path}/#{from}' -m -c -o '#{to_path}' --source-map "base='#{base_source_map}',root='#{source_map_root}',url='#{source_map_url}'"
   EOS
 
   STDERR.puts cmd


### PR DESCRIPTION
This will ensure that only the asset filename appears in the source attribute.

