### PR TITLE
FIX: Show all parent categories on topic page

### DIFF
--- a/app/assets/javascripts/discourse/helpers/category-link.js.es6
+++ b/app/assets/javascripts/discourse/helpers/category-link.js.es6
@@ -75,6 +75,9 @@ export function categoryLinkHTML(category, options) {
     if (options.categoryStyle) {
       categoryOptions.categoryStyle = options.categoryStyle;
     }
+    if (options.recursive) {
+      categoryOptions.recursive = true;
+    }
   }
   return new Handlebars.SafeString(
     categoryBadgeHTML(category, categoryOptions)

--- a/app/assets/javascripts/discourse/templates/components/topic-category.hbs
+++ b/app/assets/javascripts/discourse/templates/components/topic-category.hbs
@@ -1,8 +1,5 @@
 {{#unless topic.isPrivateMessage}}
-  {{#if topic.category.parentCategory}}
-    {{bound-category-link topic.category.parentCategory}}
-  {{/if}}
-  {{bound-category-link topic.category hideParent=true}}
+  {{bound-category-link topic.category recursive=true hideParent=true}}
 {{/unless}}
 <div class="topic-header-extra">
   {{#if siteSettings.tagging_enabled}}


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/4147664/72904623-dbe5fd80-3d37-11ea-8175-65eff9a04fd1.png)

After:

![image](https://user-images.githubusercontent.com/4147664/72904567-ca045a80-3d37-11ea-9662-572da4fa3318.png)
