### PR TITLE
FIX: Show category list on subcategory page if it has subcategories too

### DIFF
--- a/app/assets/javascripts/discourse/components/edit-category-settings.js.es6
+++ b/app/assets/javascripts/discourse/components/edit-category-settings.js.es6
@@ -1,5 +1,5 @@
 import discourseComputed from "discourse-common/utils/decorators";
-import { empty, and } from "@ember/object/computed";
+import { empty, alias, and } from "@ember/object/computed";
 import { setting } from "discourse/lib/computed";
 import { buildCategoryPanel } from "discourse/components/edit-category-panel";
 import { searchPriorities } from "discourse/components/concerns/category-search-priorities";
@@ -13,7 +13,7 @@ export function addCategorySortCriteria(criteria) {
 export default buildCategoryPanel("settings", {
   emailInEnabled: setting("email_in"),
   showPositionInput: setting("fixed_category_positions"),
-  isParentCategory: empty("category.parent_category_id"),
+  isParentCategory: alias("category.isParent"),
   showSubcategoryListStyle: and(
     "category.show_subcategory_list",
     "isParentCategory"

--- a/app/assets/javascripts/discourse/components/edit-category-settings.js.es6
+++ b/app/assets/javascripts/discourse/components/edit-category-settings.js.es6
@@ -1,5 +1,5 @@
 import discourseComputed from "discourse-common/utils/decorators";
-import { empty, alias, and } from "@ember/object/computed";
+import { empty, and } from "@ember/object/computed";
 import { setting } from "discourse/lib/computed";
 import { buildCategoryPanel } from "discourse/components/edit-category-panel";
 import { searchPriorities } from "discourse/components/concerns/category-search-priorities";
@@ -13,7 +13,10 @@ export function addCategorySortCriteria(criteria) {
 export default buildCategoryPanel("settings", {
   emailInEnabled: setting("email_in"),
   showPositionInput: setting("fixed_category_positions"),
-  isParentCategory: alias("category.isParent"),
+  @discourseComputed("category.isParent", "category.parent_category_id")
+  isParentCategory(isParent, parentCategoryId) {
+    return isParent || !parentCategoryId;
+  },
   showSubcategoryListStyle: and(
     "category.show_subcategory_list",
     "isParentCategory"

--- a/app/assets/javascripts/discourse/models/category.js.es6
+++ b/app/assets/javascripts/discourse/models/category.js.es6
@@ -66,6 +66,11 @@ const Category = RestModel.extend({
   },
 
   @discourseComputed("subcategories")
+  isParent(subcategories) {
+    return subcategories && subcategories.length > 0;
+  },
+
+  @discourseComputed("subcategories")
   isGrandParent(subcategories) {
     return (
       subcategories &&

--- a/app/assets/javascripts/discourse/routes/build-category-route.js.es6
+++ b/app/assets/javascripts/discourse/routes/build-category-route.js.es6
@@ -9,7 +9,6 @@ import PermissionType from "discourse/models/permission-type";
 import CategoryList from "discourse/models/category-list";
 import Category from "discourse/models/category";
 import { Promise, all } from "rsvp";
-import { isNone } from "@ember/utils";
 
 // A helper function to create a category route with parameters
 export default (filterArg, params) => {
@@ -88,10 +87,8 @@ export default (filterArg, params) => {
 
     _createSubcategoryList(category) {
       this._categoryList = null;
-      if (
-        isNone(category.get("parentCategory")) &&
-        category.get("show_subcategory_list")
-      ) {
+
+      if (category.isParent && category.show_subcategory_list) {
         return CategoryList.listForParent(this.store, category).then(
           list => (this._categoryList = list)
         );


### PR DESCRIPTION
The category list was displayed only for top level categories, which
had no parent.