### PR TITLE
FIX: Featuring topic on other users profile shows their topics

### DIFF
--- a/app/assets/javascripts/discourse/controllers/feature-topic-on-profile.js.es6
+++ b/app/assets/javascripts/discourse/controllers/feature-topic-on-profile.js.es6
@@ -3,11 +3,17 @@ import ModalFunctionality from "discourse/mixins/modal-functionality";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { none } from "@ember/object/computed";
+import discourseComputed from "discourse-common/utils/decorators";
 
 export default Controller.extend(ModalFunctionality, {
   newFeaturedTopic: null,
   saving: false,
   noTopicSelected: none("newFeaturedTopic"),
+
+  @discourseComputed("model")
+  additionalFilters(model) {
+    return `status:public created:@${model.username}`;
+  },
 
   onClose() {
     this.set("newFeaturedTopic", null);

--- a/app/assets/javascripts/discourse/templates/modal/feature-topic-on-profile.hbs
+++ b/app/assets/javascripts/discourse/templates/modal/feature-topic-on-profile.hbs
@@ -1,7 +1,7 @@
 {{#d-modal-body class="feature-topic-on-profile" id='choosing-topic'}}
   {{choose-topic currentTopicId=model.featured_topic.id
     selectedTopicId=newFeaturedTopicId
-    additionalFilters="in:created status:public"
+    additionalFilters=additionalFilters
     label="user.feature_topic_on_profile.search_label"
     topicChangedCallback=(action "newTopicSelected")
     loadOnInit=true

--- a/lib/search.rb
+++ b/lib/search.rb
@@ -382,6 +382,11 @@ class Search
     posts.where(user_id: @guardian.user.id, post_number: 1) if @guardian.user
   end
 
+  advanced_filter(/^created:@(.*)$/) do |posts, match|
+    user_id = User.where(username: match.downcase).pluck_first(:id)
+    posts.where(user_id: user_id, post_number: 1)
+  end
+
   advanced_filter(/^in:(watching|tracking)$/) do |posts, match|
     if @guardian.user
       level = TopicUser.notification_levels[match.to_sym]

--- a/spec/components/search_spec.rb
+++ b/spec/components/search_spec.rb
@@ -1044,12 +1044,20 @@ describe Search do
 
       expect(Search.execute('test in:posted', guardian: Guardian.new(topic.user)).posts.length).to eq(2)
 
-      expect(Search.execute('test in:created', guardian: Guardian.new(topic.user)).posts.length).to eq(1)
+      in_created = Search.execute('test in:created', guardian: Guardian.new(topic.user)).posts
+      created_by_user = Search.execute("test created:@#{topic.user.username}", guardian: Guardian.new(topic.user)).posts
+      expect(in_created.length).to eq(1)
+      expect(created_by_user.length).to eq(1)
+      expect(in_created).to eq(created_by_user)
+
+      expect(Search.execute("test created:@#{second_topic.user.username}", guardian: Guardian.new(topic.user)).posts.length).to eq(1)
+
+      new_user = Fabricate(:user)
+      expect(Search.execute("test created:@#{new_user.username}", guardian: Guardian.new(topic.user)).posts.length).to eq(0)
 
       TopicUser.change(topic.user.id, topic.id, notification_level: TopicUser.notification_levels[:tracking])
       expect(Search.execute('test in:watching', guardian: Guardian.new(topic.user)).posts.length).to eq(0)
       expect(Search.execute('test in:tracking', guardian: Guardian.new(topic.user)).posts.length).to eq(1)
-
     end
 
     it 'can find posts with images' do


### PR DESCRIPTION
[This topic](https://meta.discourse.org/t/feature-topic-on-profile-wrong-target-user-used-in-the-topic-selector-fitler/138667?u=markvanlan) explains the issue.

Basically we need a search filter where you can find topics created by a username. This adds that filter, and uses it for the `feature-topic-on-profile` topic results, so that admin can correctly set this for other users.