### PR TITLE
FIX: Resolve pull hotlinked image and broken link issues for secure media URLs

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -307,7 +307,7 @@ class Post < ActiveRecord::Base
       each_upload_url do |url|
         uri = URI.parse(url)
         if FileHelper.is_supported_media?(File.basename(uri.path))
-          raw = raw.sub(Discourse.store.s3_upload_host, "#{Discourse.base_url}/secure-media-uploads")
+          raw = raw.sub(Discourse.store.s3_upload_host, "#{Discourse.base_url}/#{Upload::SECURE_MEDIA_ROUTE}")
         end
       end
     end

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -9,6 +9,7 @@ class Upload < ActiveRecord::Base
   SHA1_LENGTH = 40
   SEEDED_ID_THRESHOLD = 0
   URL_REGEX ||= /(\/original\/\dX[\/\.\w]*\/([a-zA-Z0-9]+)[\.\w]*)/
+  SECURE_MEDIA_ROUTE = "secure-media-uploads".freeze
 
   belongs_to :user
   belongs_to :access_control_post, class_name: 'Post'
@@ -118,6 +119,19 @@ class Upload < ActiveRecord::Base
 
   def short_path
     self.class.short_path(sha1: self.sha1, extension: self.extension)
+  end
+
+  def self.secure_media_url?(url)
+    url.include?(SECURE_MEDIA_ROUTE)
+  end
+
+  def self.signed_url_from_secure_media_url(url)
+    secure_upload_s3_path = url.sub(Discourse.base_url, "").sub("/#{SECURE_MEDIA_ROUTE}/", "")
+    Discourse.store.signed_url_for_path(secure_upload_s3_path)
+  end
+
+  def self.secure_media_url_from_upload_url(url)
+    url.sub(SiteSetting.Upload.absolute_base_url, "/#{SECURE_MEDIA_ROUTE}")
   end
 
   def self.short_path(sha1:, extension:)

--- a/lib/cooked_post_processor.rb
+++ b/lib/cooked_post_processor.rb
@@ -284,9 +284,8 @@ class CookedPostProcessor
 
     # we can't direct FastImage to our secure-media-uploads url because it bounces
     # anonymous requests with a 404 error
-    if url&.include?("/secure-media-uploads/")
-      secure_upload_s3_path = absolute_url.sub(Discourse.base_url, "").sub("/secure-media-uploads/", "")
-      absolute_url = Discourse.store.signed_url_for_path(secure_upload_s3_path)
+    if url && Upload.secure_media_url?(url)
+      absolute_url = Upload.signed_url_from_secure_media_url(absolute_url)
     end
 
     return unless is_valid_image_url?(absolute_url)

--- a/lib/email/styles.rb
+++ b/lib/email/styles.rb
@@ -288,7 +288,7 @@ module Email
 
     def replace_secure_media_urls
       @fragment.css('[href]').each do |a|
-        if a['href'][/secure-media-uploads/]
+        if a['href'][/#{Upload::SECURE_MEDIA_ROUTE}/]
           a.add_next_sibling "<p class='secure-media-notice'>#{I18n.t("emails.secure_media_placeholder")}</p>"
           a.remove
         end
@@ -296,7 +296,7 @@ module Email
 
       @fragment.search('img').each do |img|
         next unless img['src']
-        if img['src'][/secure-media-uploads/]
+        if img['src'][/#{Upload::SECURE_MEDIA_ROUTE}/]
           img.add_next_sibling "<p class='secure-media-notice'>#{I18n.t("emails.secure_media_placeholder")}</p>"
           img.remove
         end

--- a/lib/pretty_text.rb
+++ b/lib/pretty_text.rb
@@ -388,7 +388,7 @@ module PrettyText
 
   def self.strip_secure_media(doc)
     doc.css("a[href]").each do |a|
-      if a["href"].include?("/secure-media-uploads/") && FileHelper.is_supported_media?(a["href"])
+      if a["href"].include?("/#{Upload::SECURE_MEDIA_ROUTE}/") && FileHelper.is_supported_media?(a["href"])
         target = %w(video audio).include?(a&.parent&.parent&.name) ? a.parent.parent : a
         target.replace "<p class='secure-media-notice'>#{I18n.t("emails.secure_media_placeholder")}</p>"
       end

--- a/lib/pretty_text/helpers.rb
+++ b/lib/pretty_text/helpers.rb
@@ -72,7 +72,7 @@ module PrettyText
 
             short_urls.each do |short_url|
               result[short_url] = {
-                url: secure_media ? secure_media_url(url) : Discourse.store.cdn_url(url),
+                url: secure_media ? Upload.secure_media_url_from_upload_url(url) : Discourse.store.cdn_url(url),
                 short_path: Upload.short_path(sha1: sha1, extension: extension),
                 base62_sha1: Upload.base62_sha1(sha1)
               }
@@ -82,10 +82,6 @@ module PrettyText
       end
 
       result
-    end
-
-    def secure_media_url(url)
-      url.sub(SiteSetting.Upload.absolute_base_url, "/secure-media-uploads")
     end
 
     def get_topic_info(topic_id)

--- a/lib/url_helper.rb
+++ b/lib/url_helper.rb
@@ -57,8 +57,7 @@ class UrlHelper
   end
 
   def self.secure_proxy_without_cdn(url)
-    url = url.sub(SiteSetting.Upload.absolute_base_url, "/secure-media-uploads")
-    self.absolute(url, nil)
+    self.absolute(Upload.secure_media_url_from_upload_url(url), nil)
   end
 
   # Prevents double URL encode


### PR DESCRIPTION
When `pull_hotlinked_images` tried to run on posts with secure media (which had already been downloaded from external sources) we were getting a 404 when trying to download the image because the secure endpoint doesn't allow anon downloads.

Also, we were getting into an infinite loop of `pull_hotlinked_images` because the job didn't consider the secure media URLs as "downloaded" already so it kept trying to download them over and over.

In this PR I have also refactored secure-media-upload URL checks and mutations into single source of truth in Upload, adding a `SECURE_MEDIA_ROUTE` constant to check URLs against too.