### PR TITLE
DEV: Ignore `ls` errors when clearing FileStore cache

### DIFF
--- a/lib/file_store/base_store.rb
+++ b/lib/file_store/base_store.rb
@@ -164,7 +164,7 @@ module FileStore
       # Exit status `1` in `ls` occurs when e.g. "listing a directory
       # in which entries are actively being removed or renamed".
       # It's safe to ignore it here.
-      unless ls.exitstatus.in?([0, 1]) && processes.all?(&:success?)
+      if ![0, 1].include?(ls.exitstatus) || !processes.all?(&:success?)
         raise "Error clearing old cache"
       end
     end

--- a/lib/file_store/base_store.rb
+++ b/lib/file_store/base_store.rb
@@ -150,14 +150,23 @@ module FileStore
       dir = File.dirname(path)
       FileUtils.mkdir_p(dir) unless Dir.exist?(dir)
       FileUtils.cp(file.path, path)
-      # keep latest 500 files
+
+      # Keep latest 500 files
       processes = Open3.pipeline(
-        "ls -t #{CACHE_DIR}",
+        ["ls -t #{CACHE_DIR}", err: "/dev/null"],
         "tail -n +#{CACHE_MAXIMUM_SIZE + 1}",
         "awk '$0=\"#{CACHE_DIR}\"$0'",
         "xargs rm -f"
       )
-      raise "Error clearing old cache" if !processes.all?(&:success?)
+
+      ls = processes.shift
+
+      # Exit status `1` in `ls` occurs when e.g. "listing a directory
+      # in which entries are actively being removed or renamed".
+      # It's safe to ignore it here.
+      unless ls.exitstatus.in?([0, 1]) && processes.all?(&:success?)
+        raise "Error clearing old cache"
+      end
     end
 
     private


### PR DESCRIPTION
A race condition issue is possible when multiple thread/processes are calling this method.
`ls` prints out to stderr "cannot access '...': No such file or directory" if any of the files it's currently trying to list are being removed by the `xargs rm -rf` in an another process. That doesn't affect the result, but it did raise an error before this change.

Tested on a production instance where the original issue was observed. This solution has @davidtaylorhq's blessing 😉