### PR TITLE
FIX: getURL on a subfolder site should ignore prefix in middle of URL

### DIFF
--- a/app/assets/javascripts/discourse.js.es6
+++ b/app/assets/javascripts/discourse.js.es6
@@ -29,8 +29,8 @@ const Discourse = Ember.Application.extend(FocusEvent, {
     // if it's a non relative URL, return it.
     if (url !== "/" && !/^\/[^\/]/.test(url)) return url;
 
-    if (url.indexOf(Discourse.BaseUri) !== -1) return url;
     if (url[0] !== "/") url = "/" + url;
+    if (url.startsWith(Discourse.BaseUri)) return url;
 
     return Discourse.BaseUri + url;
   },

--- a/test/javascripts/lib/discourse-test.js.es6
+++ b/test/javascripts/lib/discourse-test.js.es6
@@ -10,6 +10,18 @@ QUnit.test("getURL on subfolder install", assert => {
     "/forum/u/neil",
     "relative url has subfolder"
   );
+
+  assert.equal(
+    Discourse.getURL("/svg-sprite/forum.example.com/svg-sprite.js"),
+    "/forum/svg-sprite/forum.example.com/svg-sprite.js",
+    "works when the url has the prefix in the middle"
+  );
+
+  assert.equal(
+    Discourse.getURL("/forum/t/123"),
+    "/forum/t/123",
+    "does not prefix if the URL is already prefixed"
+  );
 });
 
 QUnit.test("getURLWithCDN on subfolder install with S3", assert => {


### PR DESCRIPTION
https://meta.discourse.org/t/discourse-docker-blocked-csp-error-with-svg-sprite-when-using-subfolders/139492/9