### PR TITLE
FIX: set showFooter to true on group topic list

### DIFF
--- a/app/assets/javascripts/discourse/routes/group-activity-topics.js.es6
+++ b/app/assets/javascripts/discourse/routes/group-activity-topics.js.es6
@@ -1,6 +1,8 @@
 import DiscourseRoute from "discourse/routes/discourse";
 
 export default DiscourseRoute.extend({
+  showFooter: true,
+
   titleToken() {
     return I18n.t(`groups.topics`);
   },
@@ -9,12 +11,5 @@ export default DiscourseRoute.extend({
     return this.store.findFiltered("topicList", {
       filter: `topics/groups/${this.modelFor("group").get("name")}`
     });
-  },
-
-  actions: {
-    didTransition() {
-      this.controllerFor("application").set("showFooter", true);
-      return true;
-    }
   }
 });

--- a/app/assets/javascripts/discourse/routes/group-activity-topics.js.es6
+++ b/app/assets/javascripts/discourse/routes/group-activity-topics.js.es6
@@ -9,5 +9,12 @@ export default DiscourseRoute.extend({
     return this.store.findFiltered("topicList", {
       filter: `topics/groups/${this.modelFor("group").get("name")}`
     });
+  },
+
+  actions: {
+    didTransition() {
+      this.controllerFor("application").set("showFooter", true);
+      return true;
+    }
   }
 });

--- a/app/assets/javascripts/discourse/routes/user-activity-replies.js.es6
+++ b/app/assets/javascripts/discourse/routes/user-activity-replies.js.es6
@@ -4,11 +4,5 @@ import UserAction from "discourse/models/user-action";
 export default UserActivityStreamRoute.extend({
   userActionType: UserAction.TYPES["posts"],
   noContentHelpKey: "user_activity.no_replies",
-
-  actions: {
-    didTransition() {
-      this.controllerFor("application").set("showFooter", true);
-      return true;
-    }
-  }
+  showFooter: true
 });

--- a/app/assets/javascripts/discourse/routes/user-activity-replies.js.es6
+++ b/app/assets/javascripts/discourse/routes/user-activity-replies.js.es6
@@ -4,5 +4,11 @@ import UserAction from "discourse/models/user-action";
 export default UserActivityStreamRoute.extend({
   userActionType: UserAction.TYPES["posts"],
   noContentHelpKey: "user_activity.no_replies",
-  showFooter: true
+
+  actions: {
+    didTransition() {
+      this.controllerFor("application").set("showFooter", true);
+      return true;
+    }
+  }
 });


### PR DESCRIPTION
If using `{{#if showFooter}}` in a template, `showFooter` is never set to `true` on a group's `g/groupname/activity/topics` route (it's correctly set on other group routes like `group-activity-posts`)

Not sure if this is the best way to do it here, but it's also what we do for some of the user activity routes. 