### PR TITLE
FIX: Mitigate issue where legacy pre-secure hotlinked media would not be redownloaded

### DIFF
--- a/app/jobs/regular/pull_hotlinked_images.rb
+++ b/app/jobs/regular/pull_hotlinked_images.rb
@@ -175,14 +175,13 @@ module Jobs
 
         # Someone could hotlink a file from a different site on the same CDN,
         # so check whether we have it in this database
-        upload = Upload.get_from_url(src)
-
+        #
         # if the upload already exists and is attached to a different post,
         # or the original_sha1 is missing meaning it was created before secure
         # media was enabled, then we definitely want to redownload again otherwise
         # we end up reusing existing uploads which may be linked to many posts
         # already.
-        upload = Upload.invalid_secure_upload_reuse?(upload, post) ? nil : upload
+        upload = Upload.consider_for_reuse(Upload.get_from_url(src), post)
 
         return !upload.present?
       end

--- a/app/jobs/regular/pull_hotlinked_images.rb
+++ b/app/jobs/regular/pull_hotlinked_images.rb
@@ -56,7 +56,7 @@ module Jobs
         src = original_src = node['src'] || node['href']
         src = "#{SiteSetting.force_https ? "https" : "http"}:#{src}" if src.start_with?("//")
 
-        if should_download_image?(src)
+        if should_download_image?(src, post)
           begin
             # have we already downloaded that file?
             schemeless_src = remove_scheme(original_src)
@@ -89,6 +89,7 @@ module Jobs
                 has_new_broken_image = true
               end
             end
+
             # have we successfully downloaded that file?
             if downloaded_urls[src].present?
               escaped_src = Regexp.escape(original_src)
@@ -163,7 +164,7 @@ module Jobs
         doc.css(".lightbox img[src]")
     end
 
-    def should_download_image?(src)
+    def should_download_image?(src, post)
       # make sure we actually have a url
       return false unless src.present?
 
@@ -174,7 +175,16 @@ module Jobs
 
         # Someone could hotlink a file from a different site on the same CDN,
         # so check whether we have it in this database
-        return !Upload.get_from_url(src)
+        upload = Upload.get_from_url(src)
+
+        # if the upload already exists and is attached to a different post,
+        # or the original_sha1 is missing meaning it was created before secure
+        # media was enabled, then we definitely want to redownload again otherwise
+        # we end up reusing existing uploads which may be linked to many posts
+        # already.
+        upload = Upload.invalid_secure_upload_reuse?(upload, post) ? nil : upload
+
+        return !upload.present?
       end
 
       # Don't download non-local images unless site setting enabled

--- a/app/jobs/regular/pull_hotlinked_images.rb
+++ b/app/jobs/regular/pull_hotlinked_images.rb
@@ -164,7 +164,7 @@ module Jobs
         doc.css(".lightbox img[src]")
     end
 
-    def should_download_image?(src, post)
+    def should_download_image?(src, post = nil)
       # make sure we actually have a url
       return false unless src.present?
 

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -122,7 +122,7 @@ class Upload < ActiveRecord::Base
   end
 
   def self.invalid_secure_upload_reuse?(upload, post)
-    return false if !SiteSetting.secure_media? || upload.blank?
+    return false if !SiteSetting.secure_media? || upload.blank? || post.blank?
     upload.access_control_post_id != post.id || upload.original_sha1.blank?
   end
 

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -121,6 +121,11 @@ class Upload < ActiveRecord::Base
     self.class.short_path(sha1: self.sha1, extension: self.extension)
   end
 
+  def self.invalid_secure_upload_reuse?(upload, post)
+    return false if !SiteSetting.secure_media? || upload.blank?
+    upload.access_control_post_id != post.id || upload.original_sha1.blank?
+  end
+
   def self.secure_media_url?(url)
     url.include?(SECURE_MEDIA_ROUTE)
   end

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -121,9 +121,10 @@ class Upload < ActiveRecord::Base
     self.class.short_path(sha1: self.sha1, extension: self.extension)
   end
 
-  def self.invalid_secure_upload_reuse?(upload, post)
-    return false if !SiteSetting.secure_media? || upload.blank? || post.blank?
-    upload.access_control_post_id != post.id || upload.original_sha1.blank?
+  def self.consider_for_reuse(upload, post)
+    return upload if !SiteSetting.secure_media? || upload.blank? || post.blank?
+    return nil if upload.access_control_post_id != post.id || upload.original_sha1.blank?
+    upload
   end
 
   def self.secure_media_url?(url)

--- a/lib/cooked_post_processor.rb
+++ b/lib/cooked_post_processor.rb
@@ -330,7 +330,15 @@ class CookedPostProcessor
       img["height"] = height
     end
 
-    if upload = Upload.get_from_url(src)
+    upload = Upload.get_from_url(src)
+
+    # if the upload already exists and is attached to a different post,
+    # or the original_sha1 is missing meaning it was created before secure
+    # media was enabled. we want to re-thumbnail and re-optimize in this case
+    # to avoid using uploads linked to many other posts
+    upload = Upload.invalid_secure_upload_reuse?(upload, @post) ? nil : upload
+
+    if upload.present?
       upload.create_thumbnail!(width, height, crop: crop)
 
       each_responsive_ratio do |ratio|
@@ -351,7 +359,9 @@ class CookedPostProcessor
       add_lightbox!(img, original_width, original_height, upload, cropped: crop)
     end
 
-    optimize_image!(img, upload, cropped: crop) if upload
+    if upload.present?
+      optimize_image!(img, upload, cropped: crop)
+    end
   end
 
   def loading_image(upload)

--- a/lib/cooked_post_processor.rb
+++ b/lib/cooked_post_processor.rb
@@ -330,13 +330,11 @@ class CookedPostProcessor
       img["height"] = height
     end
 
-    upload = Upload.get_from_url(src)
-
     # if the upload already exists and is attached to a different post,
     # or the original_sha1 is missing meaning it was created before secure
     # media was enabled. we want to re-thumbnail and re-optimize in this case
     # to avoid using uploads linked to many other posts
-    upload = Upload.invalid_secure_upload_reuse?(upload, @post) ? nil : upload
+    upload = Upload.consider_for_reuse(Upload.get_from_url(src), @post)
 
     if upload.present?
       upload.create_thumbnail!(width, height, crop: crop)

--- a/spec/fabricators/upload_fabricator.rb
+++ b/spec/fabricators/upload_fabricator.rb
@@ -51,3 +51,9 @@ Fabricator(:upload_s3, from: :upload) do
     end
   end
 end
+
+Fabricator(:secure_upload_s3, from: :upload_s3) do
+  secure { true }
+  sha1 { SecureRandom.hex(20) }
+  original_sha1 { sequence(:sha1) { |n| Digest::SHA1.hexdigest(n.to_s) } }
+end

--- a/spec/models/topic_converter_spec.rb
+++ b/spec/models/topic_converter_spec.rb
@@ -131,6 +131,11 @@ describe TopicConverter do
           public_reply.link_post_uploads
           public_reply.update_uploads_secure_status
 
+          # we need to do this otherwise we get infinite loop shenanigans, as the pull hotlinked
+          # images is never satisfied and keeps calling cooked post processor which in turn runs
+          # pull hotlinked images
+          Jobs::PullHotlinkedImages.stubs(:new).returns(Helpers::StubbedJob.new)
+
           expect(public_reply.uploads[0].secure).to eq(false)
           public_topic.convert_to_private_message(admin)
           expect(public_topic.reload.posts.find(public_reply.id).uploads[0].secure).to eq(true)

--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -288,16 +288,16 @@ describe Upload do
     end
   end
 
-  describe ".invalid_secure_upload_reuse?" do
+  describe ".consider_for_reuse" do
     let(:post) { Fabricate(:post) }
     let(:upload) { Fabricate(:upload) }
 
-    it "returns false when the provided upload is blank" do
-      expect(Upload.invalid_secure_upload_reuse?(nil, post)).to eq(false)
+    it "returns nil when the provided upload is blank" do
+      expect(Upload.consider_for_reuse(nil, post)).to eq(nil)
     end
 
-    it "returns false when secure media is disabled" do
-      expect(Upload.invalid_secure_upload_reuse?(upload, post)).to eq(false)
+    it "returns the upload when secure media is disabled" do
+      expect(Upload.consider_for_reuse(upload, post)).to eq(upload)
     end
 
     context "when secure media enabled" do
@@ -310,8 +310,8 @@ describe Upload do
           upload.update(access_control_post_id: Fabricate(:post).id)
         end
 
-        it "returns true" do
-          expect(Upload.invalid_secure_upload_reuse?(upload, post)).to eq(true)
+        it "returns nil" do
+          expect(Upload.consider_for_reuse(upload, post)).to eq(nil)
         end
       end
 
@@ -320,16 +320,16 @@ describe Upload do
           upload.update(original_sha1: nil, access_control_post: post)
         end
 
-        it "returns true" do
-          expect(Upload.invalid_secure_upload_reuse?(upload, post)).to eq(true)
+        it "returns nil" do
+          expect(Upload.consider_for_reuse(upload, post)).to eq(nil)
         end
       end
 
       context "when the upload original_sha1 is present and access control post is correct" do
         let(:upload) { Fabricate(:secure_upload_s3, access_control_post: post) }
 
-        it "returns false" do
-          expect(Upload.invalid_secure_upload_reuse?(upload, post)).to eq(false)
+        it "returns the upload" do
+          expect(Upload.consider_for_reuse(upload, post)).to eq(upload)
         end
       end
     end

--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -288,6 +288,53 @@ describe Upload do
     end
   end
 
+  describe ".invalid_secure_upload_reuse?" do
+    let(:post) { Fabricate(:post) }
+    let(:upload) { Fabricate(:upload) }
+
+    it "returns false when the provided upload is blank" do
+      expect(Upload.invalid_secure_upload_reuse?(nil, post)).to eq(false)
+    end
+
+    it "returns false when secure media is disabled" do
+      expect(Upload.invalid_secure_upload_reuse?(upload, post)).to eq(false)
+    end
+
+    context "when secure media enabled" do
+      before do
+        enable_secure_media
+      end
+
+      context "when the upload access control post is != to the provided post" do
+        before do
+          upload.update(access_control_post_id: Fabricate(:post).id)
+        end
+
+        it "returns true" do
+          expect(Upload.invalid_secure_upload_reuse?(upload, post)).to eq(true)
+        end
+      end
+
+      context "when the upload original_sha1 is blank (pre-secure-media upload)" do
+        before do
+          upload.update(original_sha1: nil, access_control_post: post)
+        end
+
+        it "returns true" do
+          expect(Upload.invalid_secure_upload_reuse?(upload, post)).to eq(true)
+        end
+      end
+
+      context "when the upload original_sha1 is present and access control post is correct" do
+        let(:upload) { Fabricate(:secure_upload_s3, access_control_post: post) }
+
+        it "returns false" do
+          expect(Upload.invalid_secure_upload_reuse?(upload, post)).to eq(false)
+        end
+      end
+    end
+  end
+
   describe '.update_secure_status' do
     it "respects the secure_override_value parameter if provided" do
       upload.update!(secure: true)
@@ -344,18 +391,7 @@ describe Upload do
 
     context "secure media enabled" do
       before do
-        SiteSetting.enable_s3_uploads = true
-        SiteSetting.s3_upload_bucket = "s3-upload-bucket"
-        SiteSetting.s3_access_key_id = "some key"
-        SiteSetting.s3_secret_access_key = "some secrets3_region key"
-        SiteSetting.secure_media = true
-
-        stub_request(:head, "https://#{SiteSetting.s3_upload_bucket}.s3.amazonaws.com/")
-
-        stub_request(
-          :put,
-          "https://#{SiteSetting.s3_upload_bucket}.s3.amazonaws.com/original/1X/#{upload.sha1}.#{upload.extension}?acl"
-        )
+        enable_secure_media
       end
 
       it 'does not mark an image upload as not secure when there is no access control post id, to avoid unintentional exposure' do
@@ -398,5 +434,20 @@ describe Upload do
       expect(upload1.reload.extension).to eq(nil)
       expect(upload2.reload.extension).to eq("png")
     end
+  end
+
+  def enable_secure_media
+    SiteSetting.enable_s3_uploads = true
+    SiteSetting.s3_upload_bucket = "s3-upload-bucket"
+    SiteSetting.s3_access_key_id = "some key"
+    SiteSetting.s3_secret_access_key = "some secrets3_region key"
+    SiteSetting.secure_media = true
+
+    stub_request(:head, "https://#{SiteSetting.s3_upload_bucket}.s3.amazonaws.com/")
+
+    stub_request(
+      :put,
+      "https://#{SiteSetting.s3_upload_bucket}.s3.amazonaws.com/original/1X/#{upload.sha1}.#{upload.extension}?acl"
+    )
   end
 end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -147,4 +147,9 @@ module Helpers
       ActionController::Base.config.relative_url_root = old_root
     end
   end
+
+  class StubbedJob
+    def initialize; end
+    def perform(args); end
+  end
 end


### PR DESCRIPTION
Basically, say you had already downloaded a certain image from a certain URL
using pull_hotlinked_images and the onebox. The upload would be stored
by its sha as an upload record. Whenever you linked to the same URL again
in a post (e.g. in our case an og:image on review.discourse) we would
would reuse the original upload record because of the sha1.

However when you turned on secure media this could cause problems as
the first post that uses that upload after secure media is enabled
will set the access control post for the upload to the new post.
Then if the post is deleted every single onebox/link to that same image
URL will fail forever with 403 as the secure-media-uploads URL fails
if the access control post has been deleted.

To fix this when cooking posts and pulling hotlinked images, we only
allow using an original upload by URL if its access control post
matches the current post, and if the original_sha1 is filled in,
meaning it was uploaded AFTER secure media was enabled. otherwise
we just redownload the media again to be safe, as the URL will always
be new then.