### PR TITLE
UX: Show vertical topic timeline while composing

### DIFF
--- a/app/assets/javascripts/discourse/components/topic-navigation.js.es6
+++ b/app/assets/javascripts/discourse/components/topic-navigation.js.es6
@@ -41,14 +41,15 @@ export default Component.extend(PanEvents, {
           composer = document.getElementById("reply-control"),
           timelineContainer = document.querySelectorAll(
             ".timeline-container"
-          )[0];
+          )[0],
+          headerHeight =
+            document.querySelectorAll(".d-header")[0].offsetHeight || 0;
 
         if (timelineContainer && composer) {
-          const tlRect = timelineContainer.getBoundingClientRect();
-          const tlOffset = tlRect.y + parseInt(tlRect.height, 10);
           renderTimeline =
             width > MIN_WIDTH_TIMELINE &&
-            window.innerHeight - composer.offsetHeight > tlOffset;
+            window.innerHeight - composer.offsetHeight - headerHeight >
+              timelineContainer.offsetHeight;
         }
       }
 

--- a/app/assets/javascripts/discourse/components/topic-navigation.js.es6
+++ b/app/assets/javascripts/discourse/components/topic-navigation.js.es6
@@ -1,6 +1,5 @@
 import EmberObject from "@ember/object";
-import { scheduleOnce } from "@ember/runloop";
-import { later } from "@ember/runloop";
+import { debounce, later } from "@ember/runloop";
 import Component from "@ember/component";
 import { observes } from "discourse-common/utils/decorators";
 import showModal from "discourse/lib/show-modal";
@@ -9,6 +8,8 @@ import PanEvents, {
   SWIPE_DISTANCE_THRESHOLD,
   SWIPE_VELOCITY_THRESHOLD
 } from "discourse/mixins/pan-events";
+
+const MIN_WIDTH_TIMELINE = 924;
 
 export default Component.extend(PanEvents, {
   composerOpen: null,
@@ -36,14 +37,19 @@ export default Component.extend(PanEvents, {
       let renderTimeline = !this.site.mobileView;
 
       if (renderTimeline) {
-        const width = $(window).width();
-        let height = $(window).height();
+        const width = window.innerWidth,
+          composer = document.getElementById("reply-control"),
+          timelineContainer = document.querySelectorAll(
+            ".timeline-container"
+          )[0];
 
-        if (this.composerOpen) {
-          height -= $("#reply-control").height();
+        if (timelineContainer && composer) {
+          const tlRect = timelineContainer.getBoundingClientRect();
+          const tlOffset = tlRect.y + parseInt(tlRect.height, 10);
+          renderTimeline =
+            width > MIN_WIDTH_TIMELINE &&
+            window.innerHeight - composer.offsetHeight > tlOffset;
         }
-
-        renderTimeline = width > 924 && height > 450;
       }
 
       info.setProperties({
@@ -54,7 +60,7 @@ export default Component.extend(PanEvents, {
   },
 
   _checkSize() {
-    scheduleOnce("afterRender", this, this._performCheckSize);
+    debounce(this, this._performCheckSize, 300);
   },
 
   // we need to store this so topic progress has something to init with
@@ -89,8 +95,7 @@ export default Component.extend(PanEvents, {
 
   composerOpened() {
     this.set("composerOpen", true);
-    // we need to do the check after animation is done
-    later(() => this._checkSize(), 500);
+    this._checkSize();
   },
 
   composerClosed() {
@@ -191,9 +196,9 @@ export default Component.extend(PanEvents, {
       $(window).on("resize.discourse-topic-navigation", () =>
         this._checkSize()
       );
-      this.appEvents.on("composer:will-open", this, this.composerOpened);
-      this.appEvents.on("composer:resized", this, this._checkSize);
-      this.appEvents.on("composer:will-close", this, this.composerClosed);
+      this.appEvents.on("composer:opened", this, this.composerOpened);
+      this.appEvents.on("composer:resized", this, this.composerOpened);
+      this.appEvents.on("composer:closed", this, this.composerClosed);
       $("#reply-control").on("div-resized.discourse-topic-navigation", () =>
         this._checkSize()
       );
@@ -214,9 +219,9 @@ export default Component.extend(PanEvents, {
 
     if (!this.site.mobileView) {
       $(window).off("resize.discourse-topic-navigation");
-      this.appEvents.off("composer:will-open", this, this.composerOpened);
-      this.appEvents.off("composer:resized", this, this._checkSize);
-      this.appEvents.off("composer:will-close", this, this.composerClosed);
+      this.appEvents.off("composer:opened", this, this.composerOpened);
+      this.appEvents.off("composer:resized", this, this.composerOpened);
+      this.appEvents.off("composer:closed", this, this.composerClosed);
       $("#reply-control").off("div-resized.discourse-topic-navigation");
     }
   }

--- a/app/assets/javascripts/discourse/components/topic-navigation.js.es6
+++ b/app/assets/javascripts/discourse/components/topic-navigation.js.es6
@@ -43,7 +43,7 @@ export default Component.extend(PanEvents, {
           height -= $("#reply-control").height();
         }
 
-        renderTimeline = width > 924 && height > 520;
+        renderTimeline = width > 924 && height > 450;
       }
 
       info.setProperties({
@@ -192,6 +192,7 @@ export default Component.extend(PanEvents, {
         this._checkSize()
       );
       this.appEvents.on("composer:will-open", this, this.composerOpened);
+      this.appEvents.on("composer:resized", this, this._checkSize);
       this.appEvents.on("composer:will-close", this, this.composerClosed);
       $("#reply-control").on("div-resized.discourse-topic-navigation", () =>
         this._checkSize()
@@ -214,6 +215,7 @@ export default Component.extend(PanEvents, {
     if (!this.site.mobileView) {
       $(window).off("resize.discourse-topic-navigation");
       this.appEvents.off("composer:will-open", this, this.composerOpened);
+      this.appEvents.off("composer:resized", this, this._checkSize);
       this.appEvents.off("composer:will-close", this, this.composerClosed);
       $("#reply-control").off("div-resized.discourse-topic-navigation");
     }

--- a/app/assets/javascripts/discourse/components/topic-timeline.js.es6
+++ b/app/assets/javascripts/discourse/components/topic-timeline.js.es6
@@ -103,5 +103,18 @@ export default MountWidget.extend(Docking, {
 
     this.dispatch("topic:current-post-scrolled", "timeline-scrollarea");
     this.dispatch("topic:toggle-actions", "topic-admin-menu-button");
+    if (!this.site.mobileView) {
+      this.appEvents.on("composer:opened", this, this.queueRerender);
+      this.appEvents.on("composer:resized", this, this.queueRerender);
+      this.appEvents.on("composer:closed", this, this.queueRerender);
+    }
+  },
+
+  willDestroyElement() {
+    if (!this.site.mobileView) {
+      this.appEvents.off("composer:opened", this, this.queueRerender);
+      this.appEvents.off("composer:resized", this, this.queueRerender);
+      this.appEvents.off("composer:closed", this, this.queueRerender);
+    }
   }
 });

--- a/app/assets/javascripts/discourse/widgets/topic-timeline.js.es6
+++ b/app/assets/javascripts/discourse/widgets/topic-timeline.js.es6
@@ -12,7 +12,13 @@ const SCROLLER_HEIGHT = 50;
 const LAST_READ_HEIGHT = 20;
 
 function scrollareaHeight() {
-  return $(window).height() < 425 ? 150 : 300;
+  const composer = document.getElementById("reply-control");
+  const availableHeight =
+    composer === null
+      ? window.innerHeight
+      : window.innerHeight - composer.offsetHeight;
+
+  return availableHeight < 500 ? 170 : 300;
 }
 
 function scrollareaRemaining() {

--- a/app/assets/javascripts/discourse/widgets/topic-timeline.js.es6
+++ b/app/assets/javascripts/discourse/widgets/topic-timeline.js.es6
@@ -10,15 +10,22 @@ import renderTopicFeaturedLink from "discourse/lib/render-topic-featured-link";
 
 const SCROLLER_HEIGHT = 50;
 const LAST_READ_HEIGHT = 20;
+const MIN_SCROLLAREA_HEIGHT = 170;
+const MAX_SCROLLAREA_HEIGHT = 300;
 
 function scrollareaHeight() {
-  const composer = document.getElementById("reply-control");
-  const availableHeight =
-    composer === null
-      ? window.innerHeight
-      : window.innerHeight - composer.offsetHeight;
+  const composerHeight =
+      document.getElementById("reply-control").offsetHeight || 0,
+    headerHeight = document.querySelectorAll(".d-header")[0].offsetHeight || 0;
 
-  return availableHeight < 500 ? 170 : 300;
+  // scrollarea takes up about half of the timeline's height
+  const availableHeight =
+    (window.innerHeight - composerHeight - headerHeight) / 2;
+
+  return Math.max(
+    MIN_SCROLLAREA_HEIGHT,
+    Math.min(availableHeight, MAX_SCROLLAREA_HEIGHT)
+  );
 }
 
 function scrollareaRemaining() {


### PR DESCRIPTION
When enough vertical space is available, we should show the vertical topic timeline, it provides easier access to navigating within the topic while replying. (This is particularly useful on long topics.)

The change is best described using before/after videos. 

**Before**
![current-timeline](https://user-images.githubusercontent.com/368961/73383787-ff5cfb00-4297-11ea-9c36-4e76cb2d0144.gif)

**After**
![proposed-timeline](https://user-images.githubusercontent.com/368961/73383861-21567d80-4298-11ea-9e75-c90fbc179f9b.gif)
