### PR TITLE
FIX: Prevent race condition when post processing post

### DIFF
--- a/app/jobs/regular/process_post.rb
+++ b/app/jobs/regular/process_post.rb
@@ -7,43 +7,45 @@ module Jobs
   class ProcessPost < ::Jobs::Base
 
     def execute(args)
-      post = Post.find_by(id: args[:post_id])
-      # two levels of deletion
-      return unless post.present? && post.topic.present?
+      DistributedMutex.synchronize("process_post_#{args[:post_id]}") do
+        post = Post.find_by(id: args[:post_id])
+        # two levels of deletion
+        return unless post.present? && post.topic.present?
 
-      orig_cooked = post.cooked
-      recooked = nil
+        orig_cooked = post.cooked
+        recooked = nil
 
-      if args[:cook].present?
-        cooking_options = args[:cooking_options] || {}
-        cooking_options[:topic_id] = post.topic_id
-        recooked = post.cook(post.raw, cooking_options.symbolize_keys)
-        post.update_columns(cooked: recooked, baked_at: Time.zone.now, baked_version: Post::BAKED_VERSION)
-      end
-
-      cp = CookedPostProcessor.new(post, args)
-      cp.post_process(bypass_bump: args[:bypass_bump], new_post: args[:new_post])
-
-      # If we changed the document, save it
-      cooked = cp.html
-
-      if cooked != (recooked || orig_cooked)
-
-        if orig_cooked.present? && cooked.blank?
-          # TODO stop/restart the worker if needed, let's gather a few here first
-          Rails.logger.warn("Cooked post processor in FATAL state, bypassing. You need to urgently restart sidekiq\norig: #{orig_cooked}\nrecooked: #{recooked}\ncooked: #{cooked}\npost id: #{post.id}")
-        else
-          post.update_column(:cooked, cp.html)
-          extract_links(post)
-          post.publish_change_to_clients! :revised
+        if args[:cook].present?
+          cooking_options = args[:cooking_options] || {}
+          cooking_options[:topic_id] = post.topic_id
+          recooked = post.cook(post.raw, cooking_options.symbolize_keys)
+          post.update_columns(cooked: recooked, baked_at: Time.zone.now, baked_version: Post::BAKED_VERSION)
         end
-      end
 
-      if !post.user&.staff? && !post.user&.staged?
-        s = post.cooked
-        s << " #{post.topic.title}" if post.post_number == 1
-        if !args[:bypass_bump] && WordWatcher.new(s).should_flag?
-          PostActionCreator.create(Discourse.system_user, post, :inappropriate)
+        cp = CookedPostProcessor.new(post, args)
+        cp.post_process(bypass_bump: args[:bypass_bump], new_post: args[:new_post])
+
+        # If we changed the document, save it
+        cooked = cp.html
+
+        if cooked != (recooked || orig_cooked)
+
+          if orig_cooked.present? && cooked.blank?
+            # TODO stop/restart the worker if needed, let's gather a few here first
+            Rails.logger.warn("Cooked post processor in FATAL state, bypassing. You need to urgently restart sidekiq\norig: #{orig_cooked}\nrecooked: #{recooked}\ncooked: #{cooked}\npost id: #{post.id}")
+          else
+            post.update_column(:cooked, cp.html)
+            extract_links(post)
+            post.publish_change_to_clients! :revised
+          end
+        end
+
+        if !post.user&.staff? && !post.user&.staged?
+          s = post.cooked
+          s << " #{post.topic.title}" if post.post_number == 1
+          if !args[:bypass_bump] && WordWatcher.new(s).should_flag?
+            PostActionCreator.create(Discourse.system_user, post, :inappropriate)
+          end
         end
       end
     end


### PR DESCRIPTION
If a post is being cooked twice (for example after an edit), there is a chance the 'raw' and 'cooked' column to be inconsistent. This reduces the chances of that happening.