### PR TITLE
FIX: Use updated_at in the S3 inventory job

### DIFF
--- a/lib/s3_inventory.rb
+++ b/lib/s3_inventory.rb
@@ -63,7 +63,7 @@ class S3Inventory
 
             list_missing_post_uploads if type == "original"
 
-            uploads = (model == Upload) ? model.by_users.where("created_at < ?", inventory_date) : model
+            uploads = (model == Upload) ? model.by_users.where("updated_at < ?", inventory_date) : model
             missing_uploads = uploads
               .joins("LEFT JOIN #{table_name} ON #{table_name}.etag = #{model.table_name}.etag")
               .where("#{table_name}.etag IS NULL AND #{model.table_name}.etag IS NOT NULL")

--- a/spec/components/s3_inventory_spec.rb
+++ b/spec/components/s3_inventory_spec.rb
@@ -62,12 +62,12 @@ describe "S3Inventory" do
     freeze_time
 
     CSV.foreach(csv_filename, headers: false) do |row|
-      Fabricate(:upload, etag: row[S3Inventory::CSV_ETAG_INDEX], created_at: 2.days.ago)
+      Fabricate(:upload, etag: row[S3Inventory::CSV_ETAG_INDEX], updated_at: 2.days.ago)
     end
 
-    upload = Fabricate(:upload, etag: "ETag", created_at: 1.days.ago)
-    Fabricate(:upload, etag: "ETag2", created_at: Time.now)
-    Fabricate(:upload, created_at: 2.days.ago)
+    upload = Fabricate(:upload, etag: "ETag", updated_at: 1.days.ago)
+    Fabricate(:upload, etag: "ETag2", updated_at: Time.now)
+    Fabricate(:upload, updated_at: 2.days.ago)
 
     inventory.expects(:files).returns([{ key: "Key", filename: "#{csv_filename}.gz" }]).times(3)
     inventory.expects(:inventory_date).returns(Time.now)
@@ -100,7 +100,7 @@ describe "S3Inventory" do
     freeze_time
 
     CSV.foreach(csv_filename, headers: false) do |row|
-      Fabricate(:upload, url: File.join(Discourse.store.absolute_base_url, row[S3Inventory::CSV_KEY_INDEX]), etag: row[S3Inventory::CSV_ETAG_INDEX], created_at: 2.days.ago)
+      Fabricate(:upload, url: File.join(Discourse.store.absolute_base_url, row[S3Inventory::CSV_KEY_INDEX]), etag: row[S3Inventory::CSV_ETAG_INDEX], updated_at: 2.days.ago)
     end
 
     upload = Upload.last


### PR DESCRIPTION
When we change upload's sha1 (e.g. when resizing images) it won't match the data in the most recent S3 inventory index. With this change the uploads that have been updated since the inventory has been generated are ignored.