### PR TITLE
FIX: Serve .ico files without nginx 404 for secure media uploads

### DIFF
--- a/config/nginx.sample.conf
+++ b/config/nginx.sample.conf
@@ -104,6 +104,16 @@ server {
       break;
     }
 
+    location ~ ^/secure-media-uploads/ {
+      proxy_set_header Host $http_host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Request-Start "t=${msec}";
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $thescheme;
+      proxy_pass http://discourse;
+      break;
+    }
+
     location ~* (assets|plugins|uploads)/.*\.(eot|ttf|woff|woff2|ico)$ {
       expires 1y;
       add_header Cache-Control public,immutable;


### PR DESCRIPTION
Add nginx location to handle /secure-media-uploads/ requests .ico files were getting a 404 when being looked for via /secure-media-uploads/. this nginx config addition fixes the issue. Tested on my own Discourse instance on DO