### PR TITLE
FIX: Opening new topic draft never creates reply post

### DIFF
--- a/app/assets/javascripts/discourse/models/composer.js.es6
+++ b/app/assets/javascripts/discourse/models/composer.js.es6
@@ -912,6 +912,10 @@ const Composer = RestModel.extend({
   },
 
   createPost(opts) {
+    if (this.action === CREATE_TOPIC) {
+      this.set("topic", null);
+    }
+
     const post = this.post;
     const topic = this.topic;
     const user = this.user;


### PR DESCRIPTION
This PR addresses [this issue](https://meta.discourse.org/t/duplicating-a-tab-breaks-a-change-from-a-quote-to-create-a-new-topic/140243?u=markvanlan), where a reply post is being created rather than a new topic.