### PR TITLE
FIX: Show detailed error messages for category pages.

### DIFF
--- a/app/assets/javascripts/discourse/models/category.js.es6
+++ b/app/assets/javascripts/discourse/models/category.js.es6
@@ -411,6 +411,10 @@ Category.reopenClass({
       : ajax(`/c/${slug}/find_by_slug.json`);
   },
 
+  reloadBySlugPath(slugPath) {
+    return ajax(`/c/${slugPath}/find_by_slug.json`);
+  },
+
   search(term, opts) {
     var limit = 5;
 

--- a/app/assets/javascripts/discourse/routes/build-category-route.js.es6
+++ b/app/assets/javascripts/discourse/routes/build-category-route.js.es6
@@ -50,6 +50,20 @@ export default (filterArg, params) => {
         modelParams.category_slug_path_with_id
       );
 
+      if (!category) {
+        const parts = modelParams.category_slug_path_with_id.split("/");
+        if (parts.length > 0 && parts[parts.length - 1].match(/^\d+$/)) {
+          parts.pop();
+        }
+
+        return Category.reloadBySlugPath(parts.join("/")).then(result => {
+          const record = this.store.createRecord("category", result.category);
+          record.setupGroupsAndPermissions();
+          this.site.updateCategory(record);
+          return { category: record };
+        });
+      }
+
       if (category) {
         return { category };
       }


### PR DESCRIPTION
This is a temporary fix since `/c/.../find_by_slug` route does not work with sub-sub-categories.