### PR TITLE
DEV: Add outlet args to `editor-preview` outlet

### DIFF
--- a/app/assets/javascripts/discourse/templates/components/d-editor.hbs
+++ b/app/assets/javascripts/discourse/templates/components/d-editor.hbs
@@ -44,7 +44,7 @@
 
   <div class="d-editor-preview-wrapper {{if forcePreview 'force-preview'}}">
     <div class="d-editor-preview">{{{preview}}}</div>
-    {{plugin-outlet name="editor-preview" classNames="d-editor-plugin"}}
+    {{plugin-outlet name="editor-preview" classNames="d-editor-plugin" args=outletArgs}}
   </div>
 </div>
 


### PR DESCRIPTION
Those are the same arguments that are passed into `after-d-editor` outlet. This will enable plugins that attach to editor preview to be conditionally enabled, usually only for the composer.
Plugins that will use this: discourse-canned-responses, discourse-zoom.