### PR TITLE
DEV: Add the `@action` decorator

### DIFF
--- a/app/assets/javascripts/discourse-loader.js
+++ b/app/assets/javascripts/discourse-loader.js
@@ -16,6 +16,7 @@ var define, requirejs;
         inject: Ember.inject.controller
       },
       "@ember/object": {
+        action: Ember._action,
         default: Ember.Object,
         get: Ember.get,
         getProperties: Ember.getProperties,

--- a/app/assets/javascripts/discourse/components/plugin-connector.js.es6
+++ b/app/assets/javascripts/discourse/components/plugin-connector.js.es6
@@ -35,10 +35,14 @@ export default Component.extend({
     });
 
     const connectorClass = this.get("connector.connectorClass");
+    this.set("actions", connectorClass.actions);
+
+    for (const [name, action] of Object.entries(this.actions)) {
+      this.set(name, action);
+    }
+
     const merged = buildArgsWithDeprecations(args, deprecatedArgs);
     connectorClass.setupComponent.call(this, merged, this);
-
-    this.set("actions", connectorClass.actions);
   },
 
   willDestroyElement() {

--- a/test/javascripts/acceptance/plugin-outlet-connector-class-test.js.es6
+++ b/test/javascripts/acceptance/plugin-outlet-connector-class-test.js.es6
@@ -1,5 +1,6 @@
 import { acceptance } from "helpers/qunit-helpers";
 import { extraConnectorClass } from "discourse/lib/plugin-connectors";
+import { action } from "@ember/object";
 
 const PREFIX = "javascripts/single-test/connectors";
 acceptance("Plugin Outlet - Connector Class", {
@@ -10,6 +11,26 @@ acceptance("Plugin Outlet - Connector Class", {
           this.set("hello", "hello!");
         }
       }
+    });
+
+    extraConnectorClass("user-profile-primary/hi", {
+      setupComponent() {
+        this.appEvents.on("hi:sayHi", this, this.say);
+      },
+
+      teardownComponent() {
+        this.appEvents.off("hi:sayHi", this, this.say);
+      },
+
+      @action
+      say() {
+        this.set("hi", "hi!");
+      },
+
+      @action
+      sayHi() {
+        this.appEvents.trigger("hi:sayHi");
+      },
     });
 
     extraConnectorClass("user-profile-primary/dont-render", {
@@ -26,12 +47,19 @@ acceptance("Plugin Outlet - Connector Class", {
         <span class='hello-result'>{{hello}}</span>`
     );
     Ember.TEMPLATES[
+      `${PREFIX}/user-profile-primary/hi`
+    ] = Ember.HTMLBars.compile(
+      `<button class='say-hi' {{action "sayHi"}}></button>
+        <span class='hi-result'>{{hi}}</span>`
+    );
+    Ember.TEMPLATES[
       `${PREFIX}/user-profile-primary/dont-render`
     ] = Ember.HTMLBars.compile(`I'm not rendered!`);
   },
 
   afterEach() {
     delete Ember.TEMPLATES[`${PREFIX}/user-profile-primary/hello`];
+    delete Ember.TEMPLATES[`${PREFIX}/user-profile-primary/hi`];
     delete Ember.TEMPLATES[`${PREFIX}/user-profile-primary/dont-render`];
   }
 });
@@ -51,6 +79,13 @@ QUnit.test("Renders a template into the outlet", async assert => {
   assert.equal(
     find(".hello-result").text(),
     "hello!",
+    "actions delegate properly"
+  );
+
+  await click(".say-hi");
+  assert.equal(
+    find(".hi-result").text(),
+    "hi!",
     "actions delegate properly"
   );
 });

--- a/test/javascripts/acceptance/plugin-outlet-connector-class-test.js.es6
+++ b/test/javascripts/acceptance/plugin-outlet-connector-class-test.js.es6
@@ -30,7 +30,7 @@ acceptance("Plugin Outlet - Connector Class", {
       @action
       sayHi() {
         this.appEvents.trigger("hi:sayHi");
-      },
+      }
     });
 
     extraConnectorClass("user-profile-primary/dont-render", {
@@ -83,9 +83,5 @@ QUnit.test("Renders a template into the outlet", async assert => {
   );
 
   await click(".say-hi");
-  assert.equal(
-    find(".hi-result").text(),
-    "hi!",
-    "actions delegate properly"
-  );
+  assert.equal(find(".hi-result").text(), "hi!", "actions delegate properly");
 });


### PR DESCRIPTION
This also enables`@action` use in plugin connectors.

Setting `actions` earlier allows `setupComponents` to use them, for example, when setting up even listeners.