### PR TITLE
FIX: Sort out the route navigation in admin/email-style

### DIFF
--- a/app/assets/javascripts/admin/routes/admin-customize-email-style-index.js.es6
+++ b/app/assets/javascripts/admin/routes/admin-customize-email-style-index.js.es6
@@ -1,7 +1,7 @@
 import Route from "@ember/routing/route";
 
 export default Route.extend({
-  model() {
-    return this.store.find("email-style");
+  beforeModel() {
+    this.replaceWith("adminCustomizeEmailStyle.edit", "html");
   }
 });


### PR DESCRIPTION
Previously it would go to the "html" page when refreshing on the "css" page, and would open an invalid empty-state page when trying to go to the "email style" tab if already on it.