### PR TITLE
FIX: Admin user list not showing 2FA icon for only security keys enabled

### DIFF
--- a/app/serializers/admin_user_list_serializer.rb
+++ b/app/serializers/admin_user_list_serializer.rb
@@ -109,7 +109,7 @@ class AdminUserListSerializer < BasicUserSerializer
   def include_second_factor_enabled?
     !SiteSetting.enable_sso &&
       SiteSetting.enable_local_logins &&
-      object.totps.present?
+      object.has_any_second_factor_methods_enabled?
   end
 
   def second_factor_enabled

--- a/spec/serializers/admin_user_list_serializer_spec.rb
+++ b/spec/serializers/admin_user_list_serializer_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe AdminUserListSerializer do
-  fab!(:user) { Fabricate(:user_second_factor_totp).user }
+  fab!(:user) { Fabricate(:user) }
   fab!(:admin) { Fabricate(:admin) }
   let(:guardian) { Guardian.new(admin) }
 
@@ -11,10 +11,26 @@ describe AdminUserListSerializer do
     AdminUserListSerializer.new(user, scope: guardian, root: false)
   end
 
-  it "returns the right values when user has second factor totp enabled" do
-    json = serializer.as_json
+  context "when totp enabled" do
+    before do
+      Fabricate(:user_second_factor_totp, user: user)
+    end
+    it "returns the right values" do
+      json = serializer.as_json
 
-    expect(json[:second_factor_enabled]).to eq(true)
+      expect(json[:second_factor_enabled]).to eq(true)
+    end
+  end
+
+  context "when security keys enabled" do
+    before do
+      Fabricate(:user_security_key, user: user)
+    end
+    it "returns the right values" do
+      json = serializer.as_json
+
+      expect(json[:second_factor_enabled]).to eq(true)
+    end
   end
 
   context "emails" do


### PR DESCRIPTION
If someone only had security keys enabled, the icon to say they had 2FA enabled would not show in the admin staff user list. It would only show if they had TOTP enabled.