### PR TITLE
UX: Include muted categories on the category page by default

### DIFF
--- a/app/assets/javascripts/discourse/templates/components/categories-boxes.hbs
+++ b/app/assets/javascripts/discourse/templates/components/categories-boxes.hbs
@@ -1,5 +1,5 @@
 {{#each categories as |c|}}
-  <div class='category category-box category-box-{{unbound c.slug}}' style={{border-color c.color}}
+  <div class='category category-box category-box-{{unbound c.slug}}' style={{border-color c.color}} data-category-id={{c.id}} data-notification-level={{c.notification_level}}
    data-url={{c.url}}>
     <div class='category-box-inner'>
       <div class="category-logo">
@@ -28,7 +28,7 @@
         </div>
         {{#if c.isGrandParent}}
           {{#each c.subcategories as |subcategory|}}
-            <div data-category-id={{subcategory.id}}  style={{border-color subcategory.color}} class="subcategory with-subcategories {{if subcategory.uploaded_logo.url 'has-logo' 'no-logo'}}">
+            <div data-category-id={{subcategory.id}} data-notification-level={{subcategory.notification_level}}  style={{border-color subcategory.color}} class="subcategory with-subcategories {{if subcategory.uploaded_logo.url 'has-logo' 'no-logo'}}">
               <div class="subcategory-box-inner">
                 {{category-title-link tagName="h4" category=subcategory}}
                 {{#if subcategory.subcategories}}

--- a/app/assets/javascripts/discourse/templates/components/categories-only.hbs
+++ b/app/assets/javascripts/discourse/templates/components/categories-only.hbs
@@ -11,7 +11,7 @@
     </thead>
     <tbody aria-labelledby="categories-only-category">
       {{#each categories as |c|}}
-        <tr data-category-id={{c.id}} class="{{if c.description_excerpt 'has-description' 'no-description'}} {{if c.uploaded_logo.url 'has-logo' 'no-logo'}}">
+        <tr data-category-id={{c.id}} data-notification-level={{c.notification_level}} class="{{if c.description_excerpt 'has-description' 'no-description'}} {{if c.uploaded_logo.url 'has-logo' 'no-logo'}}">
           <td class="category" style={{border-color c.color}}>
             {{category-title-link category=c}}
             {{#if c.description_excerpt}}
@@ -22,7 +22,7 @@
             {{#if c.isGrandParent}}
               <table class="category-list subcategories-with-subcategories">
                 {{#each c.subcategories as |subcategory|}}
-                  <tr data-category-id={{subcategory.id}} class="{{if subcategory.description_excerpt 'has-description' 'no-description'}} {{if subcategory.uploaded_logo.url 'has-logo' 'no-logo'}}">
+                  <tr data-category-id={{subcategory.id}} data-notification-level={{subcategory.notification_level}} class="{{if subcategory.description_excerpt 'has-description' 'no-description'}} {{if subcategory.uploaded_logo.url 'has-logo' 'no-logo'}}">
                     <td class="category" style={{border-color subcategory.color}}>
                       {{category-title-link tagName="h4" category=subcategory}}
                       {{#if subcategory.description_excerpt}}

--- a/app/models/category_list.rb
+++ b/app/models/category_list.rb
@@ -20,7 +20,6 @@ class CategoryList
     find_categories
 
     prune_empty
-    prune_muted
     find_user_data
     sort_unpinned
     trim_results
@@ -137,10 +136,6 @@ class CategoryList
   def prune_empty
     return if SiteSetting.allow_uncategorized_topics
     @categories.delete_if { |c| c.uncategorized? && c.displayable_topics.blank? }
-  end
-
-  def prune_muted
-    @categories.delete_if { |c| c.notification_level == CategoryUser.notification_levels[:muted] }
   end
 
   # Attach some data for serialization to each topic

--- a/spec/models/category_list_spec.rb
+++ b/spec/models/category_list_spec.rb
@@ -53,16 +53,6 @@ describe CategoryList do
       expect(CategoryList.new(Guardian.new(nil), include_topics: true).categories.find { |x| x.name == private_cat.name }).to eq(nil)
     end
 
-    it "properly hide muted categories" do
-      cat_muted = Fabricate(:category_with_definition)
-      CategoryUser.create!(user_id: user.id,
-                           category_id: cat_muted.id,
-                           notification_level: CategoryUser.notification_levels[:muted])
-
-      # uncategorized + cat_muted for admin
-      expect(CategoryList.new(Guardian.new admin).categories.count).to eq(2)
-      expect(CategoryList.new(Guardian.new user).categories.count).to eq(1)
-    end
   end
 
   context "when mute_all_categories_by_default enabled" do

--- a/spec/models/category_list_spec.rb
+++ b/spec/models/category_list_spec.rb
@@ -77,11 +77,6 @@ describe CategoryList do
       notification_level = CategoryList.new(Guardian.new).categories.find { |c| c.id == category.id }.notification_level
       expect(notification_level).to eq(CategoryUser.notification_levels[:regular])
     end
-
-    it "removes the default muted categories for anonymous" do
-      SiteSetting.default_categories_muted = category.id.to_s
-      expect(CategoryList.new(Guardian.new).categories).not_to include(category)
-    end
   end
 
   context "with a category" do


### PR DESCRIPTION
This improves discoverability for muted categories, particularly when they are muted by default. If sites want to retain the old behaviour, this commit introduces the `data-notification-level` attribute in the category list UI.