### PR TITLE
DEV: Handle null notification level when generating data attribute

### DIFF
--- a/app/assets/javascripts/discourse/models/category.js.es6
+++ b/app/assets/javascripts/discourse/models/category.js.es6
@@ -88,9 +88,10 @@ const Category = RestModel.extend({
   @discourseComputed("notification_level")
   notificationLevelString(notificationLevel) {
     // Get the key from the value
-    return Object.keys(NotificationLevels)
-      .find(key => NotificationLevels[key] === notificationLevel)
-      .toLowerCase();
+    const notificationLevelString = Object.keys(NotificationLevels).find(
+      key => NotificationLevels[key] === notificationLevel
+    );
+    if (notificationLevelString) return notificationLevelString.toLowerCase();
   },
 
   @discourseComputed("name")


### PR DESCRIPTION
This happens in tests, but handling it properly will make the production code more robust. Followup to ebdebf152dd7fb259c0ecf06ce2356c5b0143c08