### PR TITLE
FIX: Topic progress bar was incorrectly showing up for <1s when entering topics

### DIFF
--- a/app/assets/javascripts/discourse/components/topic-navigation.js.es6
+++ b/app/assets/javascripts/discourse/components/topic-navigation.js.es6
@@ -61,7 +61,7 @@ export default Component.extend(PanEvents, {
   },
 
   _checkSize() {
-    debounce(this, this._performCheckSize, 300);
+    debounce(this, this._performCheckSize, 300, true);
   },
 
   // we need to store this so topic progress has something to init with


### PR DESCRIPTION
Not sure if anyone has noticed this, but since last week when I enter a topic I briefly see the topic progress bar for < 1s and then it's replaced with the topic timeline even though I'm on desktop and the composer is not open.

I looked into this and the reason this is happening is because `_checkSize` is called inside `didInsertElement` and inside `_checkSize` we debounce `_performCheckSize` (which determines whether we should show the topic timeline or progress bar) by 300 ms, and `debounce` by default triggers the debounced function on the **trailing** edge of the wait interval. That means for 300 ms, the topic progress bar is incorrectly shown on desktop for 300 ms.

To fix this we need to make `debounce` trigger on the leading edge of the wait interval so that there is no delay for the first time the function is triggered.