### PR TITLE
UX: Improved composer.saved_draft copy

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1703,7 +1703,7 @@ en:
       view_new_post: "View your new post."
       saving: "Saving"
       saved: "Saved!"
-      saved_draft: "Post draft in progress. Select to resume."
+      saved_draft: "Post draft in progress. Tap to resume."
       uploading: "Uploading..."
       show_preview: "show preview &raquo;"
       hide_preview: "&laquo; hide preview"


### PR DESCRIPTION
This is just a thought so let me know if the earlier version is better. 

![image](https://user-images.githubusercontent.com/5862206/73824331-f7fd9a80-481f-11ea-94ac-ca5bf393c052.png)

As Discourse is born to touch / tap on various devices, isn't the word **Tap** better for the post draft copy?

### Old

![select](https://user-images.githubusercontent.com/5862206/73824030-71e15400-481f-11ea-9c5a-0e81d3c3a7fe.JPG)

### New

![tap](https://user-images.githubusercontent.com/5862206/73824023-70b02700-481f-11ea-8cde-026b291fbbad.JPG)


