### PR TITLE
UX: Ignore name parameter from IDP when it is equal to email

### DIFF
--- a/lib/auth/managed_authenticator.rb
+++ b/lib/auth/managed_authenticator.rb
@@ -92,6 +92,11 @@ class Auth::ManagedAuthenticator < Auth::Authenticator
     info = auth_token[:info]
     result.email = info[:email]
     result.name = (info[:first_name] && info[:last_name]) ? "#{info[:first_name]} #{info[:last_name]}" : info[:name]
+    if result.name.present? && result.name == result.email
+      # Some IDPs send the email address in the name parameter (e.g. Auth0 with default configuration)
+      # We add some generic protection here, so that users don't accidently make their email addresses public
+      result.name = nil
+    end
     result.username = info[:nickname]
     result.email_valid = primary_email_verified?(auth_token) if result.email
     result.extra_data = {

--- a/spec/components/auth/managed_authenticator_spec.rb
+++ b/spec/components/auth/managed_authenticator_spec.rb
@@ -12,7 +12,7 @@ describe Auth::ManagedAuthenticator do
   }
 
   let(:hash) {
-    {
+    OmniAuth::AuthHash.new(
       provider: "myauth",
       uid: "1234",
       info: {
@@ -28,14 +28,14 @@ describe Auth::ManagedAuthenticator do
           randominfo: "some info"
         }
       }
-    }
+    )
   }
 
   let(:create_hash) {
-    {
+    OmniAuth::AuthHash.new(
       provider: "myauth",
       uid: "1234"
-    }
+    )
   }
 
   describe 'after_authenticate' do
@@ -150,6 +150,12 @@ describe Auth::ManagedAuthenticator do
         }.to change { UserAssociatedAccount.count }.by(1)
         expect(UserAssociatedAccount.last.user).to eq(nil)
         expect(UserAssociatedAccount.last.info["nickname"]).to eq("IAmGroot")
+      end
+
+      it 'will ignore name when equal to email' do
+        result = authenticator.after_authenticate(hash.deep_merge(info: { name: hash.info.email }))
+        expect(result.email).to eq(hash.info.email)
+        expect(result.name).to eq(nil)
       end
     end
 


### PR DESCRIPTION
Some auth providers (e.g. Auth0 with default configuration) send the email address in the name field. In Discourse, the name field is made public, so this commit adds a safeguard to prevent emails being made public.