### PR TITLE
PERF: Load users in batches when generating notifications

### DIFF
--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class PostAlerter
+  USER_BATCH_SIZE = 1000
+
   def self.post_created(post, opts = {})
     PostAlerter.new(opts).after_save_post(post, true)
     post
@@ -140,8 +142,7 @@ class PostAlerter
     users = User.where(id: user_ids)
 
     DiscourseEvent.trigger(:before_create_notifications_for_users, users, post)
-    users.pluck(:id).each do |user_id|
-      user = User.find_by(id: user_id)
+    each_user_in_batches(users) do |user|
       create_notification(user, Notification.types[:watching_first_post], post)
     end
   end
@@ -612,14 +613,22 @@ class PostAlerter
 
     already_seen_users = TopicUser.where(topic_id: post.topic.id).where("highest_seen_post_number >= ?", post.post_number).pluck(:user_id)
 
-    notify.pluck(:id).each do |user_id|
-      notification_type = already_seen_users.include?(user_id) ? Notification.types[:edited] : Notification.types[:posted]
-      user = User.find_by(id: user_id)
+    each_user_in_batches(notify) do |user|
+      notification_type = already_seen_users.include?(user.id) ? Notification.types[:edited] : Notification.types[:posted]
       create_notification(user, notification_type, post)
     end
   end
 
   def warn_if_not_sidekiq
     Rails.logger.warn("PostAlerter.#{caller_locations(1, 1)[0].label} was called outside of sidekiq") unless Sidekiq.server?
+  end
+
+  private
+
+  def each_user_in_batches(users)
+    # This is race-condition-safe, unlike #find_in_batches
+    users.pluck(:id).each_slice(USER_BATCH_SIZE) do |user_id_batches|
+      User.where(id: user_id_batches).each { |user| yield(user) }
+    end
   end
 end

--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -627,8 +627,8 @@ class PostAlerter
 
   def each_user_in_batches(users)
     # This is race-condition-safe, unlike #find_in_batches
-    users.pluck(:id).each_slice(USER_BATCH_SIZE) do |user_id_batches|
-      User.where(id: user_id_batches).each { |user| yield(user) }
+    users.pluck(:id).each_slice(USER_BATCH_SIZE) do |user_ids_batch|
+      User.where(id: user_ids_batch).each { |user| yield(user) }
     end
   end
 end

--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -140,7 +140,8 @@ class PostAlerter
     users = User.where(id: user_ids)
 
     DiscourseEvent.trigger(:before_create_notifications_for_users, users, post)
-    users.each do |user|
+    users.pluck(:id).each do |user_id|
+      user = User.find_by(id: user_id)
       create_notification(user, Notification.types[:watching_first_post], post)
     end
   end


### PR DESCRIPTION
Previously we were trying to load all the users into memory simultaneously, which can cause Sidekiq to run out of memory for large sites.

notify_first_post_watchers now matches the code for sending other types of notifications.