### PR TITLE
DEV: Add DEBUG_PRELOADED_APP_DATA to log pre-loaded JSON in development

### DIFF
--- a/app/assets/javascripts/preload-application-data.js.no-module.es6
+++ b/app/assets/javascripts/preload-application-data.js.no-module.es6
@@ -1,16 +1,21 @@
 (function() {
   var ps = require("preload-store").default;
   var preloadedDataElement = document.getElementById("data-preloaded");
+  var setupData = document.getElementById("data-discourse-setup").dataset;
 
   if (preloadedDataElement) {
     var preloaded = JSON.parse(preloadedDataElement.dataset.preloaded);
 
     Object.keys(preloaded).forEach(function(key) {
       ps.store(key, JSON.parse(preloaded[key]));
+
+      if (setupData.debugPreloadedAppData === "true") {
+        /* eslint-disable no-console */
+        console.log(key, ps.get(key));
+        /* eslint-enable no-console */
+      }
     });
   }
-
-  var setupData = document.getElementById("data-discourse-setup").dataset;
 
   window.Logster = window.Logster || {};
   window.Logster.enabled = setupData.enableJsErrorReporting === "true";

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -475,6 +475,10 @@ module ApplicationHelper
 
     if Rails.env.development?
       setup_data[:svg_icon_list] = SvgSprite.all_icons(theme_ids)
+
+      if ENV['DEBUG_PRELOADED_APP_DATA']
+        setup_data[:debug_preloaded_app_data] = true
+      end
     end
 
     if guardian.can_enable_safe_mode? && params["safe_mode"]

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -265,6 +265,36 @@ describe ApplicationHelper do
     end
   end
 
+  describe "client_side_setup_data" do
+    context "when Rails.env.development? is true" do
+      before do
+        Rails.env.stubs(:development?).returns(true)
+      end
+
+      it "returns the correct service worker url" do
+        expect(helper.client_side_setup_data[:service_worker_url]).to eq("service-worker.js")
+      end
+
+      it "returns the svg_icon_list in the setup data" do
+        expect(helper.client_side_setup_data[:svg_icon_list]).not_to eq(nil)
+      end
+
+      it "does not return debug_preloaded_app_data without the env var" do
+        expect(helper.client_side_setup_data.key?(:debug_preloaded_app_data)).to eq(false)
+      end
+
+      context "if the DEBUG_PRELOADED_APP_DATA env var is provided" do
+        before do
+          ENV['DEBUG_PRELOADED_APP_DATA'] = 'true'
+        end
+
+        it "returns that key as true" do
+          expect(helper.client_side_setup_data[:debug_preloaded_app_data]).to eq(true)
+        end
+      end
+    end
+  end
+
   describe 'crawlable_meta_data' do
     context "opengraph image" do
       it 'returns the correct image' do


### PR DESCRIPTION
Extracted from https://github.com/discourse/discourse/pull/8772

This will allow developers (in rails development mode only) to log pre-loaded JSON app data to the browser console for inspection.

