### PR TITLE
FIX: Change store.js.es6 to allow for random ID generation for duplicate records

### DIFF
--- a/test/javascripts/models/store-test.js.es6
+++ b/test/javascripts/models/store-test.js.es6
@@ -36,8 +36,14 @@ QUnit.test("createRecord with randomMapKey option specified", assert => {
   const obj = { test: "test" };
   const widget = store.createRecord("widget", obj, { randomMapKey: true });
   const storeMapId = widget.__storeMapId;
-  assert.ok(storeMapId, "a random map Id is create for the the object in the store");
-  assert.ok(storeMapId < 0, "the random Id is negative to distinguish it from real Ids");
+  assert.ok(
+    storeMapId,
+    "a random map Id is create for the the object in the store"
+  );
+  assert.ok(
+    storeMapId < 0,
+    "the random Id is negative to distinguish it from real Ids"
+  );
 });
 
 QUnit.test("createRecord without attributes", assert => {

--- a/test/javascripts/models/store-test.js.es6
+++ b/test/javascripts/models/store-test.js.es6
@@ -31,6 +31,15 @@ QUnit.test("createRecord doesn't modify the input `id` field", assert => {
   assert.equal(obj.id, 1, "it does not remove the id from the input");
 });
 
+QUnit.test("createRecord with randomMapKey option specified", assert => {
+  const store = createStore();
+  const obj = { test: "test" };
+  const widget = store.createRecord("widget", obj, { randomMapKey: true });
+  const storeMapId = widget.__storeMapId;
+  assert.ok(storeMapId, "a random map Id is create for the the object in the store");
+  assert.ok(storeMapId < 0, "the random Id is negative to distinguish it from real Ids");
+});
+
 QUnit.test("createRecord without attributes", assert => {
   const store = createStore();
   const widget = store.createRecord("widget");


### PR DESCRIPTION
Extracted from https://github.com/discourse/discourse/pull/8772

In some cases we want to use a random value instead of the object's id, e.g. if we have a list where the same ID database record shows multiple times but with different attached data. In the bookmarks PR for example the topic list shows multiple copies of the same topic because you can bookmark multiple posts in a topic with different reminder dates + times.