### PR TITLE
add postmark webhook handling

### DIFF
--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -63,6 +63,23 @@ class WebhooksController < ActionController::Base
     success
   end
 
+  def postmark
+    # see https://postmarkapp.com/developer/webhooks/bounce-webhook#bounce-webhook-data
+    # and https://postmarkapp.com/developer/api/bounce-api#bounce-types
+
+    message_id = params["MessageID"]
+    to_address = params["Email"]
+    type =  params["Type"]
+    case type
+    when "HardBounce", "SpamNotification", "SpamComplaint"
+      process_bounce(message_id, to_address, SiteSetting.hard_bounce_score)
+    when "SoftBounce"
+      process_bounce(message_id, to_address, SiteSetting.soft_bounce_score)
+    end
+
+    success
+  end
+
   def sparkpost
     events = params["_json"] || [params]
     events.each do |event|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Discourse::Application.routes.draw do
   post "webhooks/mailgun"  => "webhooks#mailgun"
   post "webhooks/mailjet"  => "webhooks#mailjet"
   post "webhooks/mandrill" => "webhooks#mandrill"
+  post "webhooks/postmark" => "webhooks#postmark"
   post "webhooks/sendgrid" => "webhooks#sendgrid"
   post "webhooks/sparkpost" => "webhooks#sparkpost"
 

--- a/spec/requests/webhooks_controller_spec.rb
+++ b/spec/requests/webhooks_controller_spec.rb
@@ -138,6 +138,40 @@ describe WebhooksController do
     end
   end
 
+  context "postmark" do
+    it "works" do
+      user = Fabricate(:user, email: email)
+      email_log = Fabricate(:email_log, user: user, message_id: message_id, to_address: email)
+
+      post "/webhooks/postmark.json", params: {
+             "Type"=> "HardBounce",
+             "MessageID"=> message_id,
+             "Email"=> email
+           }
+      expect(response.status).to eq(200)
+
+      email_log.reload
+      expect(email_log.bounced).to eq(true)
+      expect(email_log.user.user_stat.bounce_score).to eq(SiteSetting.hard_bounce_score)
+    end
+    it "soft bounces" do
+      user = Fabricate(:user, email: email)
+      email_log = Fabricate(:email_log, user: user, message_id: message_id, to_address: email)
+
+      post "/webhooks/postmark.json", params: {
+             "Type"=> "SoftBounce",
+             "MessageID"=> message_id,
+             "Email"=> email
+           }
+      expect(response.status).to eq(200)
+
+      email_log.reload
+      expect(email_log.bounced).to eq(true)
+      expect(email_log.user.user_stat.bounce_score).to eq(SiteSetting.soft_bounce_score)
+    end
+  end
+
+
   context "sparkpost" do
     it "works" do
       user = Fabricate(:user, email: email)


### PR DESCRIPTION
Add webhook processing for postmark bounces and spam complaints.

It appears to do the Right Thing for Bounce and Spam complaint webhook processing.