### PR TITLE
DEV: Bump omniauth-github from 1.3.0 to 1.4.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -221,7 +221,7 @@ GEM
       rack (>= 1.6.2, < 3)
     omniauth-facebook (6.0.0)
       omniauth-oauth2 (~> 1.2)
-    omniauth-github (1.3.0)
+    omniauth-github (1.4.0)
       omniauth (~> 1.5)
       omniauth-oauth2 (>= 1.4.0, < 2.0)
     omniauth-google-oauth2 (0.8.0)


### PR DESCRIPTION
This switches the github API access to use header-based authentication, rather than the deprecated parameter-based method