### PR TITLE
FEATURE: Pending queued posts are included even if they don't pass the minimum priority threshold

### DIFF
--- a/app/models/reviewable.rb
+++ b/app/models/reviewable.rb
@@ -472,9 +472,14 @@ class Reviewable < ActiveRecord::Base
     result = result.where(type: type) if type
     result = result.where(category_id: category_id) if category_id
     result = result.where(topic_id: topic_id) if topic_id
-    result = result.where("score >= ?", min_score) if min_score > 0
     result = result.where("created_at >= ?", from_date) if from_date
     result = result.where("created_at <= ?", to_date) if to_date
+
+    if min_score > 0 && status == :pending && type.nil?
+      result = result.where("score >= ? OR type = ?", min_score, ReviewableQueuedPost.name)
+    elsif min_score > 0
+      result = result.where("score >= ?", min_score)
+    end
 
     if !custom_filters.empty?
       result = custom_filters.reduce(result) do |memo, filter|

--- a/spec/models/reviewable_spec.rb
+++ b/spec/models/reviewable_spec.rb
@@ -175,6 +175,26 @@ RSpec.describe Reviewable, type: :model do
           expect(list[0].id).to eq(r0.id)
           expect(list[1].id).to eq(r1.id)
         end
+
+        describe "Including pending queued posts even if they don't pass the minimum priority threshold" do
+          before do
+            SiteSetting.reviewable_default_visibility = :high
+            Reviewable.set_priorities(high: 10)
+            @queued_post = Fabricate(:reviewable_queued_post, score: 0, target: post)
+          end
+
+          it 'includes queued posts when searching for pending reviewables' do
+            expect(Reviewable.list_for(user)).to contain_exactly(@queued_post)
+          end
+
+          it 'excludes pending queued posts when applying a different status filter' do
+            expect(Reviewable.list_for(user, status: :deleted)).to be_empty
+          end
+
+          it 'excludes pending queued posts when applying a different type filter' do
+            expect(Reviewable.list_for(user, type: ReviewableFlaggedPost.name)).to be_empty
+          end
+        end
       end
     end
 
@@ -203,7 +223,6 @@ RSpec.describe Reviewable, type: :model do
         expect(Reviewable.list_for(moderator)).to include(reviewable)
       end
     end
-
   end
 
   it "valid_types returns the appropriate types" do


### PR DESCRIPTION
The minimum priority threshold hides low score queued posts, leaving them unreviewed for a long time. This change guarantees they will be shown when displaying pending reviewables.