### PR TITLE
Improvements to group mentions

### DIFF
--- a/app/assets/javascripts/discourse/components/composer-editor.js.es6
+++ b/app/assets/javascripts/discourse/components/composer-editor.js.es6
@@ -180,7 +180,7 @@ export default Component.extend({
       term,
       topicId,
       categoryId,
-      includeMentionableGroups: true
+      includeGroups: true
     });
   },
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -901,22 +901,21 @@ class UsersController < ApplicationController
 
     groups =
       if current_user
-        if params[:include_mentionable_groups] == 'true'
+        if params[:include_groups] == 'true'
+          Group.visible_groups(current_user)
+        elsif params[:include_mentionable_groups] == 'true'
           Group.mentionable(current_user)
         elsif params[:include_messageable_groups] == 'true'
           Group.messageable(current_user)
         end
       end
 
-    include_groups = params[:include_groups] == "true"
-
     # blank term is only handy for in-topic search of users after @
     # we do not want group results ever if term is blank
-    include_groups = groups = nil if term.blank?
+    groups = nil if term.blank?
 
-    if include_groups || groups
+    if groups
       groups = Group.search_groups(term, groups: groups)
-      groups = groups.where(visibility_level: Group.visibility_levels[:public]) if include_groups
       groups = groups.order('groups.name asc')
 
       to_render[:groups] = groups.map do |m|

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -308,7 +308,7 @@ class UsersController < ApplicationController
     groups = Group.where(name: usernames).pluck(:name)
     mentionable_groups =
       if current_user
-        Group.mentionable(current_user)
+        Group.mentionable
           .where(name: usernames)
           .pluck(:name, :user_count)
           .map do |name, user_count|

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -3176,6 +3176,15 @@ describe UsersController do
         )
       end
 
+      let!(:private_group) do
+        Fabricate(:group,
+          mentionable_level: Group::ALIAS_LEVELS[:members_mods_and_admins],
+          messageable_level: Group::ALIAS_LEVELS[:members_mods_and_admins],
+          visibility_level: Group.visibility_levels[:members],
+          name: 'aaa4'
+        )
+      end
+
       describe 'when signed in' do
         before do
           sign_in(user)
@@ -3198,7 +3207,7 @@ describe UsersController do
           groups = JSON.parse(response.body)["groups"]
 
           expect(groups.map { |group| group['name'] })
-            .to_not include(mentionable_group_2.name)
+            .to_not include(private_group.name)
         end
 
         it "doesn't search for groups" do


### PR DESCRIPTION
For example, even though group `trust_level_0` was not mentionable, it showed up as a mention in the preview.

Before:
![Screen Shot 2020-02-11 at 19 07 59](https://user-images.githubusercontent.com/4147664/74260241-d742b280-4d01-11ea-97be-5bad580464c0.png)

After:
![Screen Shot 2020-02-11 at 19 06 31](https://user-images.githubusercontent.com/4147664/74260245-d7db4900-4d01-11ea-91aa-f5bc0977dee2.png)
