### PR TITLE
FEATURE: Add small action post to indicate forwarded email

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -184,6 +184,7 @@ en:
       banner:
         enabled: "made this a banner %{when}. It will appear at the top of every page until it is dismissed by the user."
         disabled: "removed this banner %{when}. It will no longer appear at the top of every page."
+      forwarded: "forwarded the above email"
 
     topic_admin_menu: "topic actions"
 

--- a/lib/email/receiver.rb
+++ b/lib/email/receiver.rb
@@ -844,7 +844,7 @@ module Email
                                           embedded_user: lambda { find_or_create_user(email, display_name) })
       return false unless post
 
-      if post&.topic
+      if post.topic
         # mark post as seen for the forwarder
         PostTiming.record_timing(user_id: user.id, topic_id: post.topic_id, post_number: post.post_number, msecs: 5000)
 
@@ -859,6 +859,8 @@ module Email
                        topic: post.topic,
                        post_type: post_type,
                        skip_validations: user.staged?)
+        else
+          post.topic.add_small_action(user, "forwarded")
         end
       end
 

--- a/spec/components/email/receiver_spec.rb
+++ b/spec/components/email/receiver_spec.rb
@@ -888,6 +888,18 @@ describe Email::Receiver do
         expect { process(:forwarded_email_3) }.to change(Topic, :count)
       end
 
+      it "adds a small action post to explain who forwarded the email when the sender didn't write anything" do
+        expect { process(:forwarded_email_4) }.to change(Topic, :count)
+
+        forwarded_post, last_post = *Post.last(2)
+
+        expect(forwarded_post.user.email).to eq("some@one.com")
+        expect(forwarded_post.raw).to match(/XoXo/)
+
+        expect(last_post.user.email).to eq("ba@bar.com")
+        expect(last_post.post_type).to eq(Post.types[:small_action])
+        expect(last_post.action_code).to eq("forwarded")
+      end
     end
 
     context "with forwarded emails behaviour set to quote" do

--- a/spec/fixtures/emails/forwarded_email_4.eml
+++ b/spec/fixtures/emails/forwarded_email_4.eml
@@ -1,0 +1,17 @@
+Message-ID: <62@foo.bar.mail>
+From: Ba Bar <ba@bar.com>
+To: Team <team@bar.com>
+Date: Mon, 1 Dec 2016 13:37:42 +0100
+Subject: Fwd: Discoursing much?
+
+---------- Forwarded message ---------
+From: Some One <some@one.com>
+To: Ba Bar <ba@bar.com>
+Date: Mon, 1 Dec 2016 00:13:37 +0100
+Subject: Discoursing much?
+
+Hello Ba Bar,
+
+Discoursing much today?
+
+XoXo


### PR DESCRIPTION
This happens only when the sender of the email didn't write anything in their email and `forwarded_emails_behaviour` is set to `create_replies`.

![image](https://user-images.githubusercontent.com/473736/74342666-22b09b80-4daa-11ea-9e9f-369aa2efb784.png)