### PR TITLE
FIX: Remove pie draw animation

### DIFF
--- a/plugins/poll/assets/javascripts/widgets/discourse-poll.js.es6
+++ b/plugins/poll/assets/javascripts/widgets/discourse-poll.js.es6
@@ -644,7 +644,7 @@ function pieChartConfig(data, labels, opts = {}) {
     options: {
       responsive: true,
       aspectRatio,
-      animation: { duration: 400 },
+      animation: { duration: 0 },
       legend: { display: false },
       legendCallback: function(chart) {
         let legends = "";


### PR DESCRIPTION
Someone on meta brought up that pie charts are constantly being re-drawn. This simply removes the animation so you cannot tell if it is redrawn

https://meta.discourse.org/t/poll-pie-chart-is-randomly-re-drawn-without-any-user-action/141393?u=markvanlan