### PR TITLE
DEV: Update the site title in qunit fixtures

### DIFF
--- a/test/javascripts/fixtures/about.js.es6
+++ b/test/javascripts/fixtures/about.js.es6
@@ -19,7 +19,7 @@ export default {
       },
       description:
         "Discussion about the next-generation open source Discourse forum software",
-      title: "Discourse Meta",
+      title: "QUnit Discourse Tests",
       locale: "en_US",
       version: "2.2.0.beta8",
       https: true,

--- a/test/javascripts/helpers/site-settings.js
+++ b/test/javascripts/helpers/site-settings.js
@@ -1,6 +1,6 @@
 /*jshint maxlen:10000000 */
 Discourse.SiteSettingsOriginal = {
-  title: "Discourse Meta",
+  title: "QUnit Discourse Tests",
   site_logo_url: "/assets/logo.png",
   site_logo_url: "/assets/logo.png",
   site_logo_small_url: "/assets/logo-single.png",


### PR DESCRIPTION
This confuses me every time I run qunit tests in the browser. The tab gets labelled Meta, but it's not Meta! This change has no functional impact on the tests.