### PR TITLE
PERF: Memoize allowed user fields more efficiently

### DIFF
--- a/lib/guardian/user_guardian.rb
+++ b/lib/guardian/user_guardian.rb
@@ -114,9 +114,13 @@ module UserGuardian
 
   def allowed_user_field_ids(user)
     @allowed_user_field_ids ||= {}
-    @allowed_user_field_ids[user.id] ||=
+
+    is_staff_or_is_me = is_staff? || is_me?(user)
+    cache_key = is_staff_or_is_me ? :staff_or_me : :other
+
+    @allowed_user_field_ids[cache_key] ||=
       begin
-        if is_staff? || is_me?(user)
+        if is_staff_or_is_me
           UserField.pluck(:id)
         else
           UserField.where("show_on_profile OR show_on_user_card").pluck(:id)


### PR DESCRIPTION
Previously we were caching by user_id, but the there are only two possible outcomes. Therefore we only need to cache two values.

This removes another N+1 query when serializing multiple user cards.