### PR TITLE
FIX: Never mark uploads based on regular emoji secure

### DIFF
--- a/lib/upload_security.rb
+++ b/lib/upload_security.rb
@@ -28,7 +28,7 @@ class UploadSecurity
   private
 
   def uploading_in_public_context?
-    @upload.for_theme || @upload.for_site_setting || @upload.for_gravatar || public_type? || used_for_custom_emoji?
+    @upload.for_theme || @upload.for_site_setting || @upload.for_gravatar || public_type? || used_for_custom_emoji? || based_on_regular_emoji?
   end
 
   def supported_media?
@@ -72,7 +72,12 @@ class UploadSecurity
   end
 
   def used_for_custom_emoji?
-    return false if @upload.id.blank?
-    CustomEmoji.exists?(upload_id: @upload.id)
+    @upload.id.present? && CustomEmoji.exists?(upload_id: @upload.id)
+  end
+
+  def based_on_regular_emoji?
+    return false if @upload.origin.blank?
+    uri = URI.parse(@upload.origin)
+    Emoji.all.map(&:url).include?("#{uri.path}?#{uri.query}")
   end
 end

--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -431,6 +431,14 @@ describe Upload do
 
         expect(upload.reload.secure).to eq(false)
       end
+
+      it 'does not mark an upload whose origin matches a regular emoji as secure (sometimes emojis are downloaded in pull_hotlinked_images)' do
+        SiteSetting.login_required = true
+        grinning = Emoji.all.last
+        upload.update!(secure: false, origin: "http://localhost:3000#{grinning.url}")
+        expect { upload.update_secure_status }
+          .not_to change { upload.secure }
+      end
     end
   end
 


### PR DESCRIPTION
Sometimes PullHotlinkedImages pulls down a site emoji and creates a new upload record for it. In the cases  where these happen the upload is not created via the normal path that custom emoji follows, so we need to check in UploadSecurity whether the origin of the upload is based on a regular site emoji. If it is we never want to mark it as secure (we don't want emoji not accessible from other posts because of secure media).

This only became apparent because the `uploads:ensure_correct_acl` rake task uses `UploadSecurity` to check whether an upload should be secure, which would have marked a whole bunch of regular-old-emojis as secure.

The issue of `PullHotlinkedImages` downloading the emojis is strange in of itself, as it has an early return if detecting `/images/emoji` in the image `src`:

```
# If file is on the forum or CDN domain or already has the
# secure media url
if Discourse.store.has_been_uploaded?(src) || src =~ /\A\/[^\/]/i || Upload.secure_media_url?(src)
  return false if src =~ /\/images\/emoji\//

  # Someone could hotlink a file from a different site on the same CDN,
  # so check whether we have it in this database
  #
  # if the upload already exists and is attached to a different post,
  # or the original_sha1 is missing meaning it was created before secure
  # media was enabled, then we definitely want to redownload again otherwise
  # we end up reusing existing uploads which may be linked to many posts
  # already.
  upload = Upload.consider_for_reuse(Upload.get_from_url(src), post)

  return !upload.present?
end
```

However the top `if` statement returns false for emojis, so the early return is skipped and another Upload is created. This will be investigated + resolved in another PR :)