### PR TITLE
DEV: Use `discourse/lib/ajax` instead of Ember global

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,13 +10,13 @@
 
 // Stuff we need to load first
 //= require ./discourse/lib/to-markdown
-//= require ./discourse/lib/ajax
 //= require ./discourse/lib/utilities
 //= require ./discourse/lib/page-visible
 //= require ./discourse/lib/logout
 //= require ./discourse/mixins/singleton
 //= require ./discourse/models/rest
 //= require ./discourse/models/session
+//= require ./discourse/lib/ajax
 //= require ./discourse/lib/text
 //= require ./discourse/lib/hash
 //= require ./discourse/lib/load-script
@@ -33,6 +33,7 @@
 //= require ./discourse/lib/text-direction
 //= require ./discourse/lib/eyeline
 //= require ./discourse/lib/show-modal
+//= require ./discourse/lib/rescue-theme-error
 //= require ./discourse/mixins/scrolling
 //= require ./discourse/lib/ajax-error
 //= require ./discourse/models/result-set

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,13 +10,13 @@
 
 // Stuff we need to load first
 //= require ./discourse/lib/to-markdown
+//= require ./discourse/lib/ajax
 //= require ./discourse/lib/utilities
 //= require ./discourse/lib/page-visible
 //= require ./discourse/lib/logout
 //= require ./discourse/mixins/singleton
 //= require ./discourse/models/rest
 //= require ./discourse/models/session
-//= require ./discourse/lib/ajax
 //= require ./discourse/lib/text
 //= require ./discourse/lib/hash
 //= require ./discourse/lib/load-script

--- a/app/assets/javascripts/discourse-common/lib/icon-library.js.es6
+++ b/app/assets/javascripts/discourse-common/lib/icon-library.js.es6
@@ -1,6 +1,7 @@
 import { h } from "virtual-dom";
 import attributeHook from "discourse-common/lib/attribute-hook";
 import deprecated from "discourse-common/lib/deprecated";
+import { ajax } from "discourse/lib/ajax";
 
 const SVG_NAMESPACE = "http://www.w3.org/2000/svg";
 let _renderers = [];
@@ -593,7 +594,7 @@ function warnIfDeprecated(oldId, newId) {
       stacktrace: Error().stack
     };
 
-    Ember.$.ajax(`${Discourse.BaseUri}/logs/report_js_error`, {
+    ajax("/logs/report_js_error", {
       data: errorData,
       type: "POST",
       cache: false

--- a/app/assets/javascripts/discourse/lib/rescue-theme-error.js.es6
+++ b/app/assets/javascripts/discourse/lib/rescue-theme-error.js.es6
@@ -1,0 +1,36 @@
+import { ajax } from "discourse/lib/ajax";
+
+function reportToLogster(name, error) {
+  const data = {
+    message: `${name} theme/component is throwing errors`,
+    stacktrace: error.stack
+  };
+
+  ajax("/logs/report_js_error", {
+    data,
+    type: "POST",
+    cache: false
+  });
+}
+
+// this function is used in lib/theme_javascript_compiler.rb
+export default function rescueThemeError(name, error, api) {
+  /* eslint-disable-next-line no-console */
+  console.error(`"${name}" error:`, error);
+  reportToLogster(name, error);
+
+  const currentUser = api.getCurrentUser();
+  if (!currentUser || !currentUser.admin) {
+    return;
+  }
+
+  const path = `${Discourse.BaseUri}/admin/customize/themes`;
+  const message = I18n.t("themes.broken_theme_alert", {
+    theme: name,
+    path: `<a href="${path}">${path}</a>`
+  });
+  const alertDiv = document.createElement("div");
+  alertDiv.classList.add("broken-theme-alert");
+  alertDiv.innerHTML = `⚠️ ${message}`;
+  document.body.prepend(alertDiv);
+}

--- a/app/assets/javascripts/discourse/lib/utilities.js.es6
+++ b/app/assets/javascripts/discourse/lib/utilities.js.es6
@@ -1,4 +1,5 @@
 import { escape } from "pretty-text/sanitizer";
+import { ajax } from "discourse/lib/ajax";
 import toMarkdown from "discourse/lib/to-markdown";
 
 const homepageSelector = "meta[name=discourse_current_homepage]";
@@ -389,7 +390,7 @@ function reportToLogster(name, error) {
     stacktrace: error.stack
   };
 
-  Ember.$.ajax(`${Discourse.BaseUri}/logs/report_js_error`, {
+  ajax("/logs/report_js_error", {
     data,
     type: "POST",
     cache: false

--- a/app/assets/javascripts/discourse/lib/utilities.js.es6
+++ b/app/assets/javascripts/discourse/lib/utilities.js.es6
@@ -1,5 +1,4 @@
 import { escape } from "pretty-text/sanitizer";
-import { ajax } from "discourse/lib/ajax";
 import toMarkdown from "discourse/lib/to-markdown";
 
 const homepageSelector = "meta[name=discourse_current_homepage]";
@@ -382,40 +381,6 @@ export function postRNWebviewMessage(prop, value) {
   if (window.ReactNativeWebView !== undefined) {
     window.ReactNativeWebView.postMessage(JSON.stringify({ [prop]: value }));
   }
-}
-
-function reportToLogster(name, error) {
-  const data = {
-    message: `${name} theme/component is throwing errors`,
-    stacktrace: error.stack
-  };
-
-  ajax("/logs/report_js_error", {
-    data,
-    type: "POST",
-    cache: false
-  });
-}
-// this function is used in lib/theme_javascript_compiler.rb
-export function rescueThemeError(name, error, api) {
-  /* eslint-disable-next-line no-console */
-  console.error(`"${name}" error:`, error);
-  reportToLogster(name, error);
-
-  const currentUser = api.getCurrentUser();
-  if (!currentUser || !currentUser.admin) {
-    return;
-  }
-
-  const path = `${Discourse.BaseUri}/admin/customize/themes`;
-  const message = I18n.t("themes.broken_theme_alert", {
-    theme: name,
-    path: `<a href="${path}">${path}</a>`
-  });
-  const alertDiv = document.createElement("div");
-  alertDiv.classList.add("broken-theme-alert");
-  alertDiv.innerHTML = `⚠️ ${message}`;
-  document.body.prepend(alertDiv);
 }
 
 const CODE_BLOCKS_REGEX = /^(    |\t).*|`[^`]+`|^```[^]*?^```|\[code\][^]*?\[\/code\]/gm;

--- a/lib/pretty_text.rb
+++ b/lib/pretty_text.rb
@@ -81,6 +81,7 @@ module PrettyText
     ctx_load_manifest(ctx, "markdown-it-bundle.js")
     root_path = "#{Rails.root}/app/assets/javascripts/"
 
+    apply_es6_file(ctx, root_path, "discourse/lib/ajax")
     apply_es6_file(ctx, root_path, "discourse/lib/to-markdown")
     apply_es6_file(ctx, root_path, "discourse/lib/utilities")
 

--- a/lib/pretty_text.rb
+++ b/lib/pretty_text.rb
@@ -81,7 +81,6 @@ module PrettyText
     ctx_load_manifest(ctx, "markdown-it-bundle.js")
     root_path = "#{Rails.root}/app/assets/javascripts/"
 
-    apply_es6_file(ctx, root_path, "discourse/lib/ajax")
     apply_es6_file(ctx, root_path, "discourse/lib/to-markdown")
     apply_es6_file(ctx, root_path, "discourse/lib/utilities")
 

--- a/lib/theme_javascript_compiler.rb
+++ b/lib/theme_javascript_compiler.rb
@@ -244,7 +244,7 @@ class ThemeJavascriptCompiler
             try {
             #{es6_source}
             } catch(err) {
-              const rescue = require("discourse/lib/utilities").rescueThemeError;
+              const rescue = require("discourse/lib/rescue-theme-error");
               rescue(__theme_name__, err, api);
             }
           });

--- a/spec/models/theme_spec.rb
+++ b/spec/models/theme_spec.rb
@@ -385,7 +385,7 @@ HTML
             try {
               alert(settings.name);var a = function a() {};
             } catch (err) {
-              var rescue = require("discourse/lib/utilities").rescueThemeError;
+              var rescue = require("discourse/lib/rescue-theme-error");
               rescue(__theme_name__, err, api);
             }
           });
@@ -421,7 +421,7 @@ HTML
             try {
               alert(settings.name);var a = function a() {};
             } catch (err) {
-              var rescue = require("discourse/lib/utilities").rescueThemeError;
+              var rescue = require("discourse/lib/rescue-theme-error");
               rescue(__theme_name__, err, api);
             }
           });


### PR DESCRIPTION
Submitting this one separately from the other import changes since it has a (slightly) higher risk of unintentional change of behavior.