### PR TITLE
FIX: Tweak upload security emoji check

### DIFF
--- a/lib/upload_security.rb
+++ b/lib/upload_security.rb
@@ -78,6 +78,7 @@ class UploadSecurity
   def based_on_regular_emoji?
     return false if @upload.origin.blank?
     uri = URI.parse(@upload.origin)
-    Emoji.all.map(&:url).include?("#{uri.path}?#{uri.query}")
+    return true if Emoji.all.map(&:url).include?("#{uri.path}?#{uri.query}")
+    uri.path.include?("images/emoji")
   end
 end

--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -439,6 +439,13 @@ describe Upload do
         expect { upload.update_secure_status }
           .not_to change { upload.secure }
       end
+
+      it 'does not mark any upload with origin containing images/emoji in the URL' do
+        SiteSetting.login_required = true
+        upload.update!(secure: false, origin: "http://localhost:3000/images/emoji/test.png")
+        expect { upload.update_secure_status }
+          .not_to change { upload.secure }
+      end
     end
   end
 

--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -438,6 +438,7 @@ describe Upload do
         upload.update!(secure: false, origin: "http://localhost:3000#{grinning.url}")
         expect { upload.update_secure_status }
           .not_to change { upload.secure }
+        expect(upload.reload.secure).to eq(false)
       end
 
       it 'does not mark any upload with origin containing images/emoji in the URL' do
@@ -445,6 +446,7 @@ describe Upload do
         upload.update!(secure: false, origin: "http://localhost:3000/images/emoji/test.png")
         expect { upload.update_secure_status }
           .not_to change { upload.secure }
+        expect(upload.reload.secure).to eq(false)
       end
     end
   end


### PR DESCRIPTION
Further on from my earlier PR #8973 also reject upload as secure if its origin URL contains images/emoji. We still check `Emoji.all` first to try and be canonical.

This may be a little heavy handed (e.g. if an external URL followed this same path it would be a false positive), but there are a lot of emoji aliases where the actual Emoji url is something, but you can have another image that should not be secure that that thing is an alias for. For example slight_smile.png does not show up in Emoji.all BUT slightly_smiling_face does, and it aliases slight_smile e.g. `/images/emoji/twitter/slight_smile.png?v=9` and `/images/emoji/twitter/slightly_smiling_face.png?v=9` are equivalent.

Any suggestions on how to improve this are welcome; we could possibly add an `Emoji.all_with_aliases` method that lists every single URL including aliases?