### PR TITLE
FIX: Use 'hostname' when Discourse.os_hostname is not available

### DIFF
--- a/lib/discourse_logstash_logger.rb
+++ b/lib/discourse_logstash_logger.rb
@@ -4,11 +4,19 @@ require 'logstash-logger'
 
 class DiscourseLogstashLogger
   def self.logger(uri:, type:)
+    # See Discourse.os_hostname
+    hostname = begin
+      require 'socket'
+      Socket.gethostname
+    rescue => e
+      `hostname`.chomp
+    end
+
     LogStashLogger.new(
       uri: uri,
       sync: true,
       customize_event: ->(event) {
-        event['hostname'] = Discourse.os_hostname
+        event['hostname'] = hostname
         event['severity_name'] = event['severity']
         event['severity'] = Object.const_get("Logger::Severity::#{event['severity']}")
         event['type'] = type


### PR DESCRIPTION
This may be the case when DiscourseLogstashLogger is initialized before
the application (see unicorn.conf.rb)

This commit is a follow-up to 28292d275994145c8e295470dee6627bfd84c936.

Co-authored-by: David Taylor <david@taylorhq.com>
Co-authored-by: Sam Saffron <sam.saffron@gmail.com>