### PR TITLE
FIX: prevents setting default values on setting component to reload page

### DIFF
--- a/app/assets/javascripts/admin/mixins/setting-component.js.es6
+++ b/app/assets/javascripts/admin/mixins/setting-component.js.es6
@@ -246,6 +246,7 @@ export default Mixin.create({
           .uniq()
           .join("|")
       );
+      return false;
     }
   }
 });


### PR DESCRIPTION
This would happen when clicking on "add all themes" for example.