### PR TITLE
FIX: Improve styling of share-and-invite modal

### DIFF
--- a/app/assets/javascripts/discourse/templates/components/invite-panel.hbs
+++ b/app/assets/javascripts/discourse/templates/components/invite-panel.hbs
@@ -1,9 +1,6 @@
 {{#if inviteModel.error}}
   <div class="alert alert-error">
-    <button class="close" data-dismiss="alert">×</button>
-    <div class="error-message">
-      {{{errorMessage}}}
-    </div>
+    {{{errorMessage}}}
   </div>
 {{/if}}
 

--- a/app/assets/stylesheets/common/components/share-and-invite-modal.scss
+++ b/app/assets/stylesheets/common/components/share-and-invite-modal.scss
@@ -1,7 +1,7 @@
 .share-and-invite.modal {
   .modal-body {
-    max-width: 475px;
-    min-width: 320px;
+    overflow-y: visible;
+    width: 475px;
   }
 
   .modal-header {


### PR DESCRIPTION
Before:

<img width="383" alt="Screen Shot 2020-02-19 at 11 24 22" src="https://user-images.githubusercontent.com/4147664/74820872-699f1380-530b-11ea-8fee-f260d716b4b9.png">

After:

<img width="383" alt="Screen Shot 2020-02-19 at 11 24 40" src="https://user-images.githubusercontent.com/4147664/74820864-67d55000-530b-11ea-800f-c36819f22b43.png">