### PR TITLE
FIX: Disable save button for API key creation when invalid

### DIFF
--- a/app/assets/javascripts/admin/templates/api-keys-new.hbs
+++ b/app/assets/javascripts/admin/templates/api-keys-new.hbs
@@ -32,7 +32,7 @@
       {{/admin-form-row}}
     {{/if}}
     {{#admin-form-row}}
-      {{d-button icon="check" label="admin.api.save" action=(action "save") class="btn-primary"}}
+      {{d-button icon="check" label="admin.api.save" action=(action "save") class="btn-primary" disabled=saveDisabled}}
     {{/admin-form-row}}
   {{/if}}
 </div>


### PR DESCRIPTION
Possible alternative to https://github.com/discourse/discourse/pull/9000