### PR TITLE
DEV: Add RakeHelpers.print_message to wrap puts

### DIFF
--- a/lib/rake_helpers.rb
+++ b/lib/rake_helpers.rb
@@ -10,4 +10,10 @@ class RakeHelpers
     return if Rails.env.test? && !ENV['RAILS_ENABLE_TEST_LOG']
     print "\r\033[K%9d / %d (%5.1f%%)" % [current, max, ((current.to_f / max.to_f) * 100).round(1)]
   end
+
+  def self.print_message(*messages)
+    messages = "" if messages.blank?
+    return if Rails.env.test? && !ENV['RAILS_ENABLE_TEST_LOG']
+    puts messages
+  end
 end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -138,10 +138,6 @@ module Helpers
     $stdout = old_stdout
   end
 
-  def disable_puts_stdout
-    IO.any_instance.stubs(:puts)
-  end
-
   def set_subfolder(f)
     global_setting :relative_url_root, f
     old_root = ActionController::Base.config.relative_url_root

--- a/spec/tasks/uploads_spec.rb
+++ b/spec/tasks/uploads_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe "tasks/uploads" do
   before do
     Rake::Task.clear
     Discourse::Application.load_tasks
-    disable_puts_stdout
   end
 
   describe "uploads:ensure_correct_acl" do


### PR DESCRIPTION
* Rake tasks often have a heavy output to inform the person
  running it what is going on. however if we want to test the
  rake task we don't want all that output clogging up the CI
  build logs.

  RakeHelpers.print_message can be used in place of puts in rake
  tasks, and when running the spec for the task the output is
  not printed RAILS_ENABLE_TEST_LOG is switched on