### PR TITLE
FEATURE: Admins can configure the reflag cooldown window and if posts flagged as spam by TL3+ users get automatically hidden

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1873,6 +1873,8 @@ en:
     reviewable_claiming: "Does reviewable content need to be claimed before it can be acted upon?"
     reviewable_default_topics: "Show reviewable content grouped by topic by default"
     reviewable_default_visibility: "Don't show reviewable items unless they meet this priority"
+    high_trust_flaggers_auto_hide_posts: "New user posts are automatically hidden after being flagged as spam by a TL3+ user"
+    cooldown_hours_until_reflag: "How much time users will have to wait until they are able to reflag a post"
 
     reply_by_email_enabled: "Enable replying to topics via email."
     reply_by_email_address: "Template for reply by email incoming email address, for example: %%{reply_key}@reply.example.com or replies+%%{reply_key}@example.com"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1477,6 +1477,10 @@ spam:
   auto_silence_fast_typers_on_first_post: true
   auto_silence_fast_typers_max_trust_level: 0
   auto_silence_first_post_regex: ""
+  high_trust_flaggers_auto_hide_posts: true
+  cooldown_hours_until_reflag: 
+    default: 24
+    min: 0
 
   reviewable_claiming:
     client: true

--- a/lib/post_action_creator.rb
+++ b/lib/post_action_creator.rb
@@ -130,7 +130,7 @@ private
     return false if @post_action_type_id == PostActionType.types[:notify_moderators]
     flag_type_already_used = reviewable.reviewable_scores.any? { |rs| rs.reviewable_score_type == @post_action_type_id }
     not_edited_since_last_review = @post.last_version_at.blank? || reviewable.updated_at > @post.last_version_at
-    handled_recently = reviewable.updated_at > 24.hours.ago
+    handled_recently = reviewable.updated_at > SiteSetting.cooldown_hours_until_reflag.to_i.hours.ago
 
     !reviewable.pending? && flag_type_already_used && not_edited_since_last_review && handled_recently
   end
@@ -177,9 +177,11 @@ private
 
     # Special case: If you have TL3 and the user is TL0, and the flag is spam,
     # hide it immediately.
-    if @post_action_name == :spam &&
+    if SiteSetting.high_trust_flaggers_auto_hide_posts &&
+        @post_action_name == :spam &&
         @created_by.has_trust_level?(TrustLevel[3]) &&
         @post.user&.trust_level == TrustLevel[0]
+
       @post.hide!(@post_action_type_id, Post.hidden_reasons[:flagged_by_tl3_user])
       return
     end

--- a/spec/components/post_action_creator_spec.rb
+++ b/spec/components/post_action_creator_spec.rb
@@ -99,6 +99,29 @@ describe PostActionCreator do
       expect(score.reviewed_at).to be_blank
     end
 
+    describe "Auto hide spam flagged posts" do
+      before do
+        user.trust_level = TrustLevel[3]
+        post.user.trust_level = TrustLevel[0]
+      end
+
+      it "hides the post when the flagger is a TL3 user and the poster is a TL0 user" do
+        SiteSetting.high_trust_flaggers_auto_hide_posts = true
+
+        result = PostActionCreator.create(user, post, :spam)
+
+        expect(post.hidden?).to eq(true)
+      end
+
+      it 'does not hide the post if the setting is disabled' do
+        SiteSetting.high_trust_flaggers_auto_hide_posts = false
+
+        result = PostActionCreator.create(user, post, :spam)
+
+        expect(post.hidden?).to eq(false)
+      end
+    end
+
     context "existing reviewable" do
       let!(:reviewable) {
         PostActionCreator.create(Fabricate(:user), post, :inappropriate).reviewable


### PR DESCRIPTION
cc @featheredtoast 