### PR TITLE
FIX: ensures group automatic membership dropdown works

### DIFF
--- a/app/assets/javascripts/discourse/components/groups-form-membership-fields.js.es6
+++ b/app/assets/javascripts/discourse/components/groups-form-membership-fields.js.es6
@@ -46,9 +46,16 @@ export default Component.extend({
     return allowMembershipRequests || visibility_level > 1;
   },
 
+  emailDomains: computed("model.emailDomains", function() {
+    return this.model.emailDomains.split(this.tokenSeparator).filter(Boolean);
+  }),
+
   actions: {
     onChangeEmailDomainsSetting(value) {
-      this.set("model.emailDomains", value.join(this.tokenSeparator));
+      this.set(
+        "model.automatic_membership_email_domains",
+        value.join(this.tokenSeparator)
+      );
     }
   }
 });

--- a/app/assets/javascripts/discourse/templates/components/groups-form-membership-fields.hbs
+++ b/app/assets/javascripts/discourse/templates/components/groups-form-membership-fields.hbs
@@ -8,9 +8,14 @@
 
     {{list-setting
       name="automatic_membership"
-      settingValue=model.emailDomains
       class="group-form-automatic-membership-automatic"
+      value=emailDomains
+      choices=emailDomains
+      settingName="name"
+      nameProperty=null
+      valueProperty=null
       onChange=(action "onChangeEmailDomainsSetting")
+      options=(hash allowAny=true)
     }}
 
     <label>

--- a/test/javascripts/acceptance/group-manage-membership-test.js.es6
+++ b/test/javascripts/acceptance/group-manage-membership-test.js.es6
@@ -1,4 +1,5 @@
 import { acceptance, updateCurrentUser } from "helpers/qunit-helpers";
+import selectKit from "helpers/select-kit-helper";
 
 acceptance("Managing Group Membership", {
   loggedIn: true
@@ -65,6 +66,13 @@ QUnit.test("As an admin", async assert => {
     1,
     "it should display the membership request template field"
   );
+
+  const emailDomains = selectKit(".group-form-automatic-membership-automatic");
+  await emailDomains.expand();
+  await emailDomains.fillInFilter("foo.com");
+  await emailDomains.keyboard("enter");
+
+  assert.equal(emailDomains.header().value(), "foo.com");
 });
 
 QUnit.test("As a group owner", async assert => {


### PR DESCRIPTION
This commit also fixes a deprecation warning as the previous  component was overriding a computed property from the group model.

Finally a test has been added as this is the only place where we use list-setting outside of the settings, this was highly subject to regressions.