### PR TITLE
DEV: Add fully-automated dev setup with Gitpod

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,7 @@
+FROM gitpod/workspace-postgres
+
+USER gitpod
+
+RUN sudo apt-get update && \
+    sudo apt-get install -y redis-server && \
+    sudo rm -rf /var/lib/apt/lists/*

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,32 @@
+image:
+  file: .gitpod.Dockerfile
+
+ports:
+  - port: 3000
+    onOpen: open-preview
+  - port: 5432
+    onOpen: ignore
+  - port: 6379
+    onOpen: ignore
+
+tasks:
+  - name: Redis
+    before: redis-server &
+  - name: Discourse
+    init: >
+      bundle install &&
+      gp await-port 6379 &&
+      bundle exec rake db:create db:migrate &&
+      RAILS_ENV=test bundle exec rake db:create db:migrate
+    command: DISCOURSE_DEV_HOSTS=.gitpod.io bundle exec rails s -b 0.0.0.0
+
+github:
+  prebuilds:
+    master: true
+    branches: true
+    pullRequests: true
+    pullRequestsFromForks: true
+    addCheck: true
+    addComment: true
+    addBadge: false
+    addLabel: false

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ To get your environment setup, follow the community setup guide for your operati
 1. If you're on Ubuntu, try the [Ubuntu development guide](https://meta.discourse.org/t/beginners-guide-to-install-discourse-on-ubuntu-for-development/14727).
 1. If you're on Windows, try the [Windows 10 development guide](https://meta.discourse.org/t/beginners-guide-to-install-discourse-on-windows-10-for-development/75149).
 
+You can also [open this repository in Gitpod.io](https://gitpod.io/#https://github.com/discourse/discourse) to launch a fully pre-configured Discourse development environment in your browser.
+
 If you're familiar with how Rails works and are comfortable setting up your own environment, you can also try out the [**Discourse Advanced Developer Guide**](docs/DEVELOPER-ADVANCED.md), which is aimed primarily at Ubuntu and macOS environments.
 
 Before you get started, ensure you have the following minimum versions: [Ruby 2.5+](https://www.ruby-lang.org/en/downloads/), [PostgreSQL 10+](https://www.postgresql.org/download/), [Redis 2.6+](https://redis.io/download). If you're having trouble, please see our [**TROUBLESHOOTING GUIDE**](docs/TROUBLESHOOTING.md) first!
@@ -67,6 +69,7 @@ Plus *lots* of Ruby Gems, a complete list of which is at [/master/Gemfile](https
 ## Contributing
 
 [![Build Status](https://api.travis-ci.org/discourse/discourse.svg?branch=master)](https://travis-ci.org/discourse/discourse)
+[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/discourse/discourse)
 
 Discourse is **100% free** and **open source**. We encourage and support an active, healthy community that
 accepts contributions from the public &ndash; including you!


### PR DESCRIPTION
Hi Discourse team! 👋

As discussed [in Meta](https://meta.discourse.org/t/hello-from-gitpod-installing-on-google-cloud-automated-dev-setup/128783), I work on [Gitpod.io](https://www.gitpod.io) and we've recently migrated our [community](https://community.gitpod.io) to Discourse. So far we're loving it! Thanks a lot for your help, and for making such a fantastic discussion platform. 👍

I also wanted to contribute a fully-automated dev setup for Discourse, to help new contributors and busy developers get started coding on Discourse without friction, in one click.

It comes with:
- All Discouse dev dependencies pre-installed (Ruby 2.6, PostgreSQL, Redis, etc.)
- All bundle gems pre-installed
- A freshly created DB
- A preview that opens automatically when Discourse starts.

Here is what it looks like:
<img width="1552" alt="Screenshot 2020-02-23 at 19 26 03" src="https://user-images.githubusercontent.com/599268/75117519-6a6cd800-5672-11ea-9a99-5d0a48614067.png">
You can try it by opening my fork in Gitpod:

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/jankeromnes/discourse)