### PR TITLE
FIX: Sync Ember and non-Ember layouts

### DIFF
--- a/app/assets/stylesheets/common/base/header.scss
+++ b/app/assets/stylesheets/common/base/header.scss
@@ -79,14 +79,14 @@
   }
 
   .login-button,
-  button.sign-up-button {
+  .sign-up-button {
     padding: 6px 10px;
     .fa {
       margin-right: 3px;
     }
   }
 
-  button.login-button {
+  .login-button {
     margin-left: 7px;
   }
 }

--- a/app/views/application/_header.html.erb
+++ b/app/views/application/_header.html.erb
@@ -1,24 +1,24 @@
 <%= replace_plugin_html('server:simple-header') do %>
   <header class="d-header">
     <div class="wrap">
-      <div class="contents">
-        <div class="header-row">
-          <div class="logo-wrapper">
-            <a href="<%= path "/" %>">
-              <%- if application_logo_url.present? %>
-                <img src="<%= application_logo_url %>" alt="<%= SiteSetting.title %>" id="site-logo">
-              <%- else %>
-                <h2 id='site-text-logo'><%= SiteSetting.title %></h2>
-              <%- end %>
-            </a>
-          </div>
+      <div class="contents clearfix">
+        <div class="title">
+          <a href="<%= path "/" %>">
+            <%- if application_logo_url.present? %>
+              <img src="<%= application_logo_url %>" alt="<%= SiteSetting.title %>" id="site-logo">
+            <%- else %>
+              <h2 id='site-text-logo'><%= SiteSetting.title %></h2>
+            <%- end %>
+          </a>
+        </div>
+        <div class="panel clearfix">
           <%- unless current_user || local_assigns[:hide_auth_buttons] %>
-            <div class='auth-buttons'>
+            <span class='header-buttons'>
               <%- if can_sign_up? %>
-                <a href="<%= path "/signup"%>" class='btn btn-primary btn-small signup-button'><%= I18n.t('sign_up') %></a>
+                <a href="<%= path "/signup"%>" class='btn btn-primary btn-small sign-up-button'><%= I18n.t('sign_up') %></a>
               <%- end %>
               <a href="<%= path "/login"%>" class='btn btn-primary btn-small login-button btn-icon-text'><%= SvgSprite.raw_svg('fa-user') %><%= I18n.t('log_in') %></a>
-            </div>
+            </span>
           <%- end %>
         </div>
       </div>


### PR DESCRIPTION
There are still a few subtle differences (using `<a>` instead of `<button>`), but at least the styling is consistent.

Before:

<img width="279" alt="Screen Shot 2020-02-24 at 11 26 39" src="https://user-images.githubusercontent.com/4147664/75140995-b2364280-56f8-11ea-8d95-4756b246250a.png">

<img width="279" alt="Screen Shot 2020-02-24 at 11 26 42" src="https://user-images.githubusercontent.com/4147664/75140998-b2ced900-56f8-11ea-925c-68f38fcee2b8.png">

After:

<img width="279" alt="Screen Shot 2020-02-24 at 11 26 53" src="https://user-images.githubusercontent.com/4147664/75140970-9fbc0900-56f8-11ea-81b8-68a72dd62ba7.png">

<img width="279" alt="Screen Shot 2020-02-24 at 11 26 55" src="https://user-images.githubusercontent.com/4147664/75140971-a0549f80-56f8-11ea-9671-fc433f3cd052.png">