### PR TITLE
FIX: Make reviewable claiming work with deleted topics

### DIFF
--- a/app/assets/javascripts/discourse/components/reviewable-item.js.es6
+++ b/app/assets/javascripts/discourse/components/reviewable-item.js.es6
@@ -22,9 +22,14 @@ export default Component.extend({
     return type.dasherize();
   },
 
-  @discourseComputed("siteSettings.reviewable_claiming", "reviewable.topic")
-  claimEnabled(claimMode, topic) {
-    return claimMode !== "disabled" && !!topic;
+  @discourseComputed("reviewable.topic_id", "reviewable.removed_topic_id")
+  topicId(topicId, removedTopicId) {
+    return topicId || removedTopicId;
+  },
+
+  @discourseComputed("siteSettings.reviewable_claiming", "topicId")
+  claimEnabled(claimMode, topicId) {
+    return claimMode !== "disabled" && !!topicId;
   },
 
   @discourseComputed(

--- a/app/assets/javascripts/discourse/templates/components/reviewable-item.hbs
+++ b/app/assets/javascripts/discourse/templates/components/reviewable-item.hbs
@@ -47,7 +47,7 @@
     {{#if claimEnabled}}
       <div class='claimed-actions'>
         <span class='help'>{{{claimHelp}}}</span>
-        {{reviewable-claimed-topic topicId=reviewable.topic.id claimedBy=reviewable.claimed_by}}
+        {{reviewable-claimed-topic topicId=topicId claimedBy=reviewable.claimed_by}}
       </div>
     {{/if}}
 

--- a/app/controllers/reviewable_claimed_topics_controller.rb
+++ b/app/controllers/reviewable_claimed_topics_controller.rb
@@ -4,7 +4,7 @@ class ReviewableClaimedTopicsController < ApplicationController
   requires_login
 
   def create
-    topic = Topic.find_by(id: params[:reviewable_claimed_topic][:topic_id])
+    topic = Topic.with_deleted.find_by(id: params[:reviewable_claimed_topic][:topic_id])
     guardian.ensure_can_claim_reviewable_topic!(topic)
 
     begin
@@ -22,7 +22,7 @@ class ReviewableClaimedTopicsController < ApplicationController
   end
 
   def destroy
-    topic = Topic.find_by(id: params[:id])
+    topic = Topic.with_deleted.find_by(id: params[:id])
     raise Discourse::NotFound if topic.blank?
 
     guardian.ensure_can_claim_reviewable_topic!(topic)

--- a/spec/requests/reviewable_claimed_topics_controller_spec.rb
+++ b/spec/requests/reviewable_claimed_topics_controller_spec.rb
@@ -36,6 +36,17 @@ describe ReviewableClaimedTopicsController do
         expect(messages[0].data[:user][:id]).to eq(moderator.id)
       end
 
+      it "works with deleted topics" do
+        SiteSetting.reviewable_claiming = 'optional'
+        first_post = topic.first_post || Fabricate(:post, topic: topic)
+        PostDestroyer.new(Discourse.system_user, first_post).destroy
+
+        post "/reviewable_claimed_topics.json", params: params
+
+        expect(response.status).to eq(200)
+        expect(ReviewableClaimedTopic.where(user_id: moderator.id, topic_id: topic.id).exists?).to eq(true)
+      end
+
       it "raises an error if user cannot claim the topic" do
         post "/reviewable_claimed_topics.json", params: params
 

--- a/spec/requests/reviewable_claimed_topics_controller_spec.rb
+++ b/spec/requests/reviewable_claimed_topics_controller_spec.rb
@@ -86,6 +86,17 @@ describe ReviewableClaimedTopicsController do
       expect(messages[0].data[:user]).to eq(nil)
     end
 
+    it "works with deleted topics" do
+      SiteSetting.reviewable_claiming = 'optional'
+      first_post = topic.first_post || Fabricate(:post, topic: topic)
+      PostDestroyer.new(Discourse.system_user, first_post).destroy
+
+      delete "/reviewable_claimed_topics/#{claimed.topic_id}.json"
+
+      expect(response.status).to eq(200)
+      expect(ReviewableClaimedTopic.where(user_id: moderator.id, topic_id: topic.id).exists?).to eq(false)
+    end
+
     it "raises an error if topic is missing" do
       delete "/reviewable_claimed_topics/111111111.json"
 


### PR DESCRIPTION
This fixes the case when the reviewed topic is deleted (for example, in
discourse-akismet).