### PR TITLE
FIX: Include `.json` suffix for email login route

### DIFF
--- a/app/assets/javascripts/discourse/routes/email-login.js.es6
+++ b/app/assets/javascripts/discourse/routes/email-login.js.es6
@@ -7,6 +7,6 @@ export default DiscourseRoute.extend({
   },
 
   model(params) {
-    return ajax(`/session/email-login/${params.token}`);
+    return ajax(`/session/email-login/${params.token}.json`);
   }
 });


### PR DESCRIPTION
In IE11, the browser returns the cached HTML response, rather than the JSON formatted response. Adding the `.json` suffix ensures that the cache is not shared. Same root cause as b0211772