### PR TITLE
FIX: Add aria-labels to topic list items

### DIFF
--- a/app/assets/javascripts/discourse/helpers/application.js.es6
+++ b/app/assets/javascripts/discourse/helpers/application.js.es6
@@ -41,6 +41,13 @@ registerUnbound("number", (orig, params) => {
   if (n.toString() !== title.toString() && addTitle) {
     result += " title='" + Handlebars.Utils.escapeExpression(title) + "'";
   }
+  if (params.ariaLabel) {
+    result +=
+      " aria-label='" +
+      Handlebars.Utils.escapeExpression(params.ariaLabel) +
+      "'";
+  }
+
   result += ">" + n + "</span>";
 
   return new safe(result);

--- a/app/assets/javascripts/discourse/helpers/application.js.es6
+++ b/app/assets/javascripts/discourse/helpers/application.js.es6
@@ -42,10 +42,8 @@ registerUnbound("number", (orig, params) => {
     result += " title='" + Handlebars.Utils.escapeExpression(title) + "'";
   }
   if (params.ariaLabel) {
-    result +=
-      " aria-label='" +
-      Handlebars.Utils.escapeExpression(params.ariaLabel) +
-      "'";
+    const ariaLabel = Handlebars.Utils.escapeExpression(params.ariaLabel);
+    result += ` aria-label='${ariaLabel}'`;
   }
 
   result += ">" + n + "</span>";

--- a/app/assets/javascripts/discourse/lib/utilities.js.es6
+++ b/app/assets/javascripts/discourse/lib/utilities.js.es6
@@ -66,9 +66,12 @@ export function avatarImg(options, getURL) {
 
   const classes =
     "avatar" + (options.extraClasses ? " " + options.extraClasses : "");
-  const title = options.title
-    ? " title='" + escapeExpression(options.title || "") + "'"
-    : "";
+
+  let title = "";
+  if (options.title) {
+    let escaped = escapeExpression(options.title || "");
+    title = ` title='${escaped}' aria-label='${escaped}'`;
+  }
 
   return (
     "<img alt='' width='" +

--- a/app/assets/javascripts/discourse/lib/utilities.js.es6
+++ b/app/assets/javascripts/discourse/lib/utilities.js.es6
@@ -69,7 +69,7 @@ export function avatarImg(options, getURL) {
 
   let title = "";
   if (options.title) {
-    let escaped = escapeExpression(options.title || "");
+    const escaped = escapeExpression(options.title || "");
     title = ` title='${escaped}' aria-label='${escaped}'`;
   }
 

--- a/app/assets/javascripts/discourse/templates/list/posts-count-column.hbr
+++ b/app/assets/javascripts/discourse/templates/list/posts-count-column.hbr
@@ -1,6 +1,6 @@
 <{{view.tagName}} class='num posts-map posts {{view.likesHeat}}' title='{{view.title}}'>
   <a href class='posts-map badge-posts {{view.likesHeat}}'>
     {{raw-plugin-outlet name="topic-list-before-reply-count"}}
-    {{number topic.replyCount noTitle="true"}}
+    {{number topic.replyCount noTitle="true" ariaLabel=view.title}}
   </a>
 </{{view.tagName}}>

--- a/test/javascripts/lib/utilities-test.js.es6
+++ b/test/javascripts/lib/utilities-test.js.es6
@@ -89,7 +89,7 @@ QUnit.test("avatarImg", assert => {
       size: "tiny",
       title: "evilest trout"
     }),
-    "<img alt='' width='20' height='20' src='/path/to/avatar/40.png' class='avatar' title='evilest trout'>",
+    "<img alt='' width='20' height='20' src='/path/to/avatar/40.png' class='avatar' title='evilest trout' aria-label='evilest trout'>",
     "it adds a title if supplied"
   );
 

--- a/test/javascripts/models/report-test.js.es6
+++ b/test/javascripts/models/report-test.js.es6
@@ -459,7 +459,7 @@ QUnit.test("computed labels", assert => {
   const computedUsernameLabel = usernameLabel.compute(row);
   assert.equal(
     computedUsernameLabel.formatedValue,
-    "<a href='/admin/users/1/joffrey'><img alt='' width='20' height='20' src='/' class='avatar' title='joffrey'><span class='username'>joffrey</span></a>"
+    "<a href='/admin/users/1/joffrey'><img alt='' width='20' height='20' src='/' class='avatar' title='joffrey' aria-label='joffrey'><span class='username'>joffrey</span></a>"
   );
   assert.equal(computedUsernameLabel.value, "joffrey");
 
@@ -542,6 +542,6 @@ QUnit.test("computed labels", assert => {
   const userLink = computedLabels[0].compute(row).formatedValue;
   assert.equal(
     userLink,
-    "<a href='/forum/admin/users/1/joffrey'><img alt='' width='20' height='20' src='/forum/' class='avatar' title='joffrey'><span class='username'>joffrey</span></a>"
+    "<a href='/forum/admin/users/1/joffrey'><img alt='' width='20' height='20' src='/forum/' class='avatar' title='joffrey' aria-label='joffrey'><span class='username'>joffrey</span></a>"
   );
 });


### PR DESCRIPTION
Before this fix you could navigate the topic list using a screen reader
and a keyboard but some of the items were not as descriptive as they
could be. The newly added labels make it easier to understand what you
are tabbing over.

context:
https://meta.discourse.org/t/accessibility-aria-attributes-are-not-defined-for-links-under-replies-category/142539