### PR TITLE
FEATURE: Always disable customizations on the `/safe-mode` route

### DIFF
--- a/app/controllers/safe_mode_controller.rb
+++ b/app/controllers/safe_mode_controller.rb
@@ -3,6 +3,7 @@
 class SafeModeController < ApplicationController
   layout 'no_ember'
   before_action :ensure_safe_mode_enabled
+  before_action :force_safe_mode_for_route
 
   skip_before_action :preload_json, :check_xhr
 
@@ -27,6 +28,11 @@ class SafeModeController < ApplicationController
 
   def ensure_safe_mode_enabled
     raise Discourse::NotFound unless guardian.can_enable_safe_mode?
+  end
+
+  def force_safe_mode_for_route
+    request.env[ApplicationController::NO_CUSTOM] = true
+    request.env[ApplicationController::NO_PLUGINS] = true
   end
 
 end

--- a/spec/requests/safe_mode_controller_spec.rb
+++ b/spec/requests/safe_mode_controller_spec.rb
@@ -3,6 +3,18 @@
 require 'rails_helper'
 
 RSpec.describe SafeModeController do
+  describe 'index' do
+    it 'never includes customizations' do
+      theme = Fabricate(:theme)
+      theme.set_field(target: :common, name: "header", value: "My Custom Header")
+      theme.save!
+      theme.set_default!
+
+      get '/safe-mode'
+      expect(response.body).not_to include("My Custom Header")
+    end
+  end
+
   describe 'enter' do
     context 'when no params are given' do
       it 'should redirect back to safe mode page' do


### PR DESCRIPTION
This makes it easier to enter safe mode when a customization has made the UI unusable

Context: https://meta.discourse.org/t/-/142666/8