### PR TITLE
FIX: Skip 'invited' small action if user is in an invited group

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1441,7 +1441,9 @@ class Topic < ActiveRecord::Base
     Topic.transaction do
       rate_limit_topic_invitation(invited_by)
       topic_allowed_users.create!(user_id: target_user.id) unless topic_allowed_users.exists?(user_id: target_user.id)
-      add_small_action(invited_by, "invited_user", target_user.username)
+
+      user_in_allowed_group = (user.group_ids & topic_allowed_groups.map(&:group_id)).present?
+      add_small_action(invited_by, "invited_user", target_user.username) if !user_in_allowed_group
 
       create_invite_notification!(
         target_user,

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -618,6 +618,15 @@ describe Topic do
           expect(Post.last.action_code).to eq("removed_user")
         end
 
+        it 'should not create a small action if user is already invited through a group' do
+          group = Fabricate(:group, users: [user, another_user])
+          expect(topic.invite_group(user, group)).to eq(true)
+
+          expect { topic.invite(user, another_user.username) }
+            .to change { Notification.count }.by(1)
+            .and change { Post.where(post_type: Post.types[:small_action]).count }.by(0)
+        end
+
         context "from a muted user" do
           before { MutedUser.create!(user: another_user, muted_user: user) }
 


### PR DESCRIPTION
Inviting a user that is already invited through a group used to generate
a small action and a notification. This commit skips that small action.