### PR TITLE
FIX: Polyfill Promise for IE11

### DIFF
--- a/plugins/discourse-internet-explorer/public/js/ie.js
+++ b/plugins/discourse-internet-explorer/public/js/ie.js
@@ -970,3 +970,12 @@ if (!String.prototype.startsWith) {
   return ES6;
 });
 /* eslint-enable */
+
+// Polyfill Promise - used by popper.js
+window.addEventListener(
+  "load",
+  function() {
+    window.Promise = require("rsvp").Promise;
+  },
+  false
+);


### PR DESCRIPTION
This is required for popper.js