### PR TITLE
FEATURE: allows to add a description link to a report

### DIFF
--- a/app/assets/javascripts/admin/models/report.js.es6
+++ b/app/assets/javascripts/admin/models/report.js.es6
@@ -21,6 +21,8 @@ const Report = EmberObject.extend({
   average: false,
   percent: false,
   higher_is_better: true,
+  description_link: null,
+  description: null,
 
   @discourseComputed("type", "start_date", "end_date")
   reportUrl(type, start_date, end_date) {

--- a/app/assets/javascripts/admin/templates/components/admin-report.hbs
+++ b/app/assets/javascripts/admin/templates/components/admin-report.hbs
@@ -23,9 +23,15 @@
             </a>
 
             {{#if model.description}}
-              <span class="info" data-tooltip="{{model.description}}">
-                {{d-icon "question-circle"}}
-              </span>
+              {{#if model.description_link}}
+                <a target="_blank" rel="noopener" href="{{model.description_link}}" class="info" data-tooltip="{{model.description}}">
+                  {{d-icon "question-circle"}}
+                </a>
+              {{else}}
+                <span class="info" data-tooltip="{{model.description}}">
+                  {{d-icon "question-circle"}}
+                </span>
+              {{/if}}
             {{/if}}
           </li>
           {{/unless}}

--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -11,11 +11,13 @@ class Admin::ReportsController < Admin::AdminController
     reports = reports_methods.map do |name|
       type = name.to_s.gsub('report_', '')
       description = I18n.t("reports.#{type}.description", default: '')
+      description_link = I18n.t("reports.#{type}.description_link", default: '')
 
       {
         type: type,
         title: I18n.t("reports.#{type}.title"),
         description: description.presence ? description : nil,
+        description_link: description_link.presence ? description_link : nil
       }
     end
 

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -99,12 +99,15 @@ class Report
 
   def as_json(options = nil)
     description = I18n.t("reports.#{type}.description", default: "")
+    description_link = I18n.t("reports.#{type}.description_link", default: "")
+
     {
       type: type,
       title: I18n.t("reports.#{type}.title", default: nil),
       xaxis: I18n.t("reports.#{type}.xaxis", default: nil),
       yaxis: I18n.t("reports.#{type}.yaxis", default: nil),
       description: description.presence ? description : nil,
+      description_link: description_link.presence ? description_link : nil,
       data: data,
       start_date: start_date&.iso8601,
       end_date: end_date&.iso8601,

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1175,6 +1175,7 @@ en:
       labels:
         level: Level
       description: "Number of users grouped by trust level."
+      description_link: "https://blog.discourse.org/2018/06/understanding-discourse-trust-levels/"
     users_by_type:
       title: "Users per Type"
       xaxis: "Type"


### PR DESCRIPTION
This commit adds a description link to users_per_trust_level report linking to our blog  article on the subject https://blog.discourse.org/2018/06/understanding-discourse-trust-levels/