### PR TITLE
FIX: Ignore secure-media-uploads for miniprofiler

### DIFF
--- a/config/initializers/006-mini_profiler.rb
+++ b/config/initializers/006-mini_profiler.rb
@@ -41,6 +41,7 @@ if defined?(Rack::MiniProfiler) && defined?(Rack::MiniProfiler::Config)
     /^\/logs/,
     /^\/site_customizations/,
     /^\/uploads/,
+    /^\/secure-media-uploads/,
     /^\/javascripts\//,
     /^\/images\//,
     /^\/stylesheets\//,


### PR DESCRIPTION
Some users have reported running into 429 issues, and from looking at the logs a connection was made between the secure-media-uploads requests and the miniprofiler results reporter. This PR disables miniprofiler for /secure-media-uploads, same as for /uploads.