### PR TITLE
Fix invalid byte sequence in UTF-8 (ArgumentError)

### DIFF
--- a/script/import_scripts/simplepress.rb
+++ b/script/import_scripts/simplepress.rb
@@ -195,6 +195,11 @@ class ImportScripts::SimplePress < ImportScripts::Base
   def process_simplepress_post(raw, import_id)
     s = raw.dup
 
+    # fix invalid byte sequence in UTF-8 (ArgumentError)
+    unless s.valid_encoding?
+      s.force_encoding("UTF-8")
+    end
+
     # convert the quote line
     s.gsub!(/\[quote='([^']+)'.*?pid='(\d+).*?\]/) {
       "[quote=\"#{convert_username($1, import_id)}, " + post_id_to_post_num_and_topic($2, import_id) + '"]'


### PR DESCRIPTION
Fix for invalid byte sequence in UTF-8 (ArgumentError) while importing SimplePress

```    
12503 / 146911 (  8.5%)  [16792037 items/min]  Traceback (most recent call last):
	14: from /var/www/discourse/script/import_scripts/iccsafe.rb:233:in `<main>'
	13: from /var/www/discourse/script/import_scripts/base.rb:47:in `perform'
	12: from /var/www/discourse/script/import_scripts/iccsafe.rb:32:in `execute'
	11: from /var/www/discourse/script/import_scripts/iccsafe.rb:152:in `import_posts'
	10: from /var/www/discourse/script/import_scripts/base.rb:881:in `batches'
	 9: from /var/www/discourse/script/import_scripts/base.rb:881:in `loop'
	 8: from /var/www/discourse/script/import_scripts/base.rb:882:in `block in batches'
	 7: from /var/www/discourse/script/import_scripts/iccsafe.rb:173:in `block in import_posts'
	 6: from /var/www/discourse/script/import_scripts/base.rb:502:in `create_posts'
	 5: from /usr/local/lib/ruby/gems/2.6.0/gems/rack-mini-profiler-1.1.6/lib/patches/db/mysql2.rb:8:in `each'
	 4: from /usr/local/lib/ruby/gems/2.6.0/gems/rack-mini-profiler-1.1.6/lib/patches/db/mysql2.rb:8:in `each'
	 3: from /var/www/discourse/script/import_scripts/base.rb:503:in `block in create_posts'
	 2: from /var/www/discourse/script/import_scripts/iccsafe.rb:179:in `block (2 levels) in import_posts'
	 1: from /var/www/discourse/script/import_scripts/iccsafe.rb:222:in `process_simplepress_post'
/var/www/discourse/script/import_scripts/iccsafe.rb:222:in `gsub!': invalid byte sequence in UTF-8 (ArgumentError)
```
