### PR TITLE
FIX: allows to select the action when agreeing with penalty

### DIFF
--- a/app/assets/javascripts/admin/components/penalty-post-action.js.es6
+++ b/app/assets/javascripts/admin/components/penalty-post-action.js.es6
@@ -1,7 +1,7 @@
 import discourseComputed from "discourse-common/utils/decorators";
 import { equal } from "@ember/object/computed";
-import { scheduleOnce } from "@ember/runloop";
 import Component from "@ember/component";
+import { afterRender } from "discourse-common/utils/decorators";
 
 const ACTIONS = ["delete", "delete_replies", "edit", "none"];
 
@@ -20,16 +20,21 @@ export default Component.extend({
   editing: equal("postAction", "edit"),
 
   actions: {
-    penaltyChanged() {
+    penaltyChanged(postAction) {
+      this.set("postAction", postAction);
+
       // If we switch to edit mode, jump to the edit textarea
-      if (this.postAction === "edit") {
-        scheduleOnce("afterRender", () => {
-          const elem = this.element;
-          const body = elem.closest(".modal-body");
-          body.scrollTop(body.height());
-          elem.querySelector(".post-editor").focus();
-        });
+      if (postAction === "edit") {
+        this._focusEditTextarea();
       }
     }
+  },
+
+  @afterRender
+  _focusEditTextarea() {
+    const elem = this.element;
+    const body = elem.closest(".modal-body");
+    body.scrollTo(0, body.clientHeight);
+    elem.querySelector(".post-editor").focus();
   }
 });


### PR DESCRIPTION
Note this commit also fixes an issue where the edit post actions was trying to focus the edit textarea, but was using jquery functions on a DOM node.

scrollTo is not available on IE11 but that shouldn't cause much trouble.