### PR TITLE
FIX: Quick access panel undefined loading property

### DIFF
--- a/app/assets/javascripts/discourse/widgets/quick-access-panel.js.es6
+++ b/app/assets/javascripts/discourse/widgets/quick-access-panel.js.es6
@@ -85,21 +85,21 @@ export default createWidget("quick-access-panel", {
     return limit;
   },
 
-  refreshNotifications(state) {
-    if (state.loading) {
+  refreshNotifications() {
+    if (this.state.loading) {
       return;
     }
 
     if (this.getItems().length === 0) {
-      state.loading = true;
+      this.state.loading = true;
     }
 
     this.findNewItems()
       .then(newItems => this.setItems(newItems))
       .catch(() => this.setItems([]))
       .finally(() => {
-        state.loading = false;
-        state.loaded = true;
+        this.state.loading = false;
+        this.state.loaded = true;
         this.newItemsLoaded();
         this.sendWidgetAction("itemsLoaded", {
           hasUnread: this.hasUnread(),
@@ -109,12 +109,12 @@ export default createWidget("quick-access-panel", {
       });
   },
 
-  html(attrs, state) {
-    if (!state.loaded) {
-      this.refreshNotifications(state);
+  html() {
+    if (!this.state.loaded) {
+      this.refreshNotifications();
     }
 
-    if (state.loading) {
+    if (this.state.loading) {
       return [h("div.spinner-container", h("div.spinner"))];
     }
 

--- a/app/assets/javascripts/discourse/widgets/quick-access-panel.js.es6
+++ b/app/assets/javascripts/discourse/widgets/quick-access-panel.js.es6
@@ -86,7 +86,7 @@ export default createWidget("quick-access-panel", {
   },
 
   refreshNotifications(state) {
-    if (this.loading) {
+    if (state.loading) {
       return;
     }
 


### PR DESCRIPTION
### This PR
- [x] References the correct `loading` property which is on `state` object instead on `this` 
- [x] Changes the access to state directly instead of passing it around, like in other widgets