### PR TITLE
DEPRECATION: Remove support for api creds in query params

### DIFF
--- a/lib/auth/default_current_user_provider.rb
+++ b/lib/auth/default_current_user_provider.rb
@@ -317,12 +317,13 @@ class Auth::DefaultCurrentUserProvider
   private
 
   def is_whitelisted_query_param_auth_route?(request)
-    (is_rss_feed?(request) || is_handle_mail?(request))
+    (is_user_feed?(request) || is_handle_mail?(request))
   end
 
-  def is_rss_feed?(request)
+  def is_user_feed?(request)
     return true if request.path.match?(/\/(c|t){1}\/\S*.(rss|json)/) && request.get? # topic or category route
     return true if request.path.match?(/\/(latest|top|categories).(rss|json)/) && request.get? # specific routes with rss
+    return true if request.path.match?(/\/u\/\S*\/bookmarks.(ics|json)/) && request.get? # specific routes with ics
   end
 
   def is_handle_mail?(request)

--- a/lib/auth/default_current_user_provider.rb
+++ b/lib/auth/default_current_user_provider.rb
@@ -286,12 +286,8 @@ class Auth::DefaultCurrentUserProvider
     if api_key = ApiKey.active.with_key(api_key_value).includes(:user).first
       api_username = header_api_key? ? @env[HEADER_API_USERNAME] : request[API_USERNAME]
 
-      # Check for deprecated api auth
       if !header_api_key?
-        unless is_whitelisted_query_param_auth_route?(request)
-          # Notify admins of deprecated auth method
-          AdminDashboardData.add_problem_message('dashboard.deprecated_api_usage', 1.day)
-        end
+        raise Discourse::InvalidAccess unless is_whitelisted_query_param_auth_route?(request)
       end
 
       if api_key.allowed_ips.present? && !api_key.allowed_ips.any? { |ip| ip.include?(request.ip) }

--- a/spec/components/auth/default_current_user_provider_spec.rb
+++ b/spec/components/auth/default_current_user_provider_spec.rb
@@ -33,7 +33,8 @@ describe Auth::DefaultCurrentUserProvider do
     it "finds a user for a correct per-user api key" do
       user = Fabricate(:user)
       api_key = ApiKey.create!(user_id: user.id, created_by_id: -1)
-      good_provider = provider("/?api_key=#{api_key.key}")
+      params = { "HTTP_API_KEY" => api_key.key }
+      good_provider = provider("/", params)
       expect(good_provider.current_user.id).to eq(user.id)
       expect(good_provider.is_api?).to eq(true)
       expect(good_provider.is_user_api?).to eq(false)
@@ -67,20 +68,22 @@ describe Auth::DefaultCurrentUserProvider do
 
     it "raises for a revoked key" do
       user = Fabricate(:user)
-      key = ApiKey.create!
+      api_key = ApiKey.create!
+      params = { "HTTP_API_USERNAME" => user.username.downcase, "HTTP_API_KEY" => api_key.key }
       expect(
-        provider("/?api_key=#{key.key}&api_username=#{user.username.downcase}").current_user.id
+        provider("/", params).current_user.id
       ).to eq(user.id)
 
-      key.reload.update(revoked_at: Time.zone.now, last_used_at: nil)
-      expect(key.reload.last_used_at).to eq(nil)
+      api_key.reload.update(revoked_at: Time.zone.now, last_used_at: nil)
+      expect(api_key.reload.last_used_at).to eq(nil)
+      params = { "HTTP_API_USERNAME" => user.username.downcase, "HTTP_API_KEY" => api_key.key }
 
       expect {
-        provider("/?api_key=#{key.key}&api_username=#{user.username.downcase}").current_user
+        provider("/", params).current_user
       }.to raise_error(Discourse::InvalidAccess)
 
-      key.reload
-      expect(key.last_used_at).to eq(nil)
+      api_key.reload
+      expect(api_key.last_used_at).to eq(nil)
     end
 
     it "raises for a user with a mismatching ip" do
@@ -97,25 +100,35 @@ describe Auth::DefaultCurrentUserProvider do
       freeze_time
 
       user = Fabricate(:user)
-      key = ApiKey.create!(user_id: user.id, created_by_id: -1, allowed_ips: ['100.0.0.0/24'])
+      api_key = ApiKey.create!(user_id: user.id, created_by_id: -1, allowed_ips: ['100.0.0.0/24'])
+      params = {
+        "HTTP_API_USERNAME" => user.username.downcase,
+        "HTTP_API_KEY" => api_key.key,
+        "REMOTE_ADDR" => "100.0.0.22"
+      }
 
-      found_user = provider("/?api_key=#{key.key}&api_username=#{user.username.downcase}",
-                            "REMOTE_ADDR" => "100.0.0.22").current_user
+      found_user = provider("/", params).current_user
 
       expect(found_user.id).to eq(user.id)
 
-      found_user = provider("/?api_key=#{key.key}&api_username=#{user.username.downcase}",
-                            "HTTP_X_FORWARDED_FOR" => "10.1.1.1, 100.0.0.22").current_user
+      params = {
+        "HTTP_API_USERNAME" => user.username.downcase,
+        "HTTP_API_KEY" => api_key.key,
+        "HTTP_X_FORWARDED_FOR" => "10.1.1.1, 100.0.0.22"
+      }
+
+      found_user = provider("/", params).current_user
       expect(found_user.id).to eq(user.id)
 
-      key.reload
-      expect(key.last_used_at).to eq_time(Time.zone.now)
+      api_key.reload
+      expect(api_key.last_used_at).to eq_time(Time.zone.now)
     end
 
     it "finds a user for a correct system api key" do
       user = Fabricate(:user)
       api_key = ApiKey.create!(created_by_id: -1)
-      expect(provider("/?api_key=#{api_key.key}&api_username=#{user.username.downcase}").current_user.id).to eq(user.id)
+      params = { "HTTP_API_USERNAME" => user.username.downcase, "HTTP_API_KEY" => api_key.key }
+      expect(provider("/", params).current_user.id).to eq(user.id)
     end
 
     it "raises for a mismatched api_key param and header username" do
@@ -130,8 +143,9 @@ describe Auth::DefaultCurrentUserProvider do
     it "finds a user for a correct system api key with external id" do
       user = Fabricate(:user)
       api_key = ApiKey.create!(created_by_id: -1)
+      params = { "HTTP_API_KEY" => api_key.key, "HTTP_API_USER_EXTERNAL_ID" => "abc" }
       SingleSignOnRecord.create(user_id: user.id, external_id: "abc", last_payload: '')
-      expect(provider("/?api_key=#{api_key.key}&api_user_external_id=abc").current_user.id).to eq(user.id)
+      expect(provider("/", params).current_user.id).to eq(user.id)
     end
 
     it "raises for a mismatched api_key param and header external id" do
@@ -147,7 +161,8 @@ describe Auth::DefaultCurrentUserProvider do
     it "finds a user for a correct system api key with id" do
       user = Fabricate(:user)
       api_key = ApiKey.create!(created_by_id: -1)
-      expect(provider("/?api_key=#{api_key.key}&api_user_id=#{user.id}").current_user.id).to eq(user.id)
+      params = { "HTTP_API_USER_ID" => user.id, "HTTP_API_KEY" => api_key.key }
+      expect(provider("/", params).current_user.id).to eq(user.id)
     end
 
     it "raises for a mismatched api_key param and header user id" do
@@ -176,34 +191,71 @@ describe Auth::DefaultCurrentUserProvider do
         user = Fabricate(:user)
         api_key = ApiKey.create!(created_by_id: -1)
         key = api_key.key
+        user_params = { "HTTP_API_KEY" => key, "HTTP_API_USERNAME" => user.username.downcase }
+        system_params = { "HTTP_API_KEY" => key, "HTTP_API_USERNAME" => "system" }
 
-        provider("/?api_key=#{key}&api_username=#{user.username.downcase}").current_user
-        provider("/?api_key=#{key}&api_username=system").current_user
-        provider("/?api_key=#{key}&api_username=#{user.username.downcase}").current_user
+        provider("/", user_params).current_user
+        provider("/", system_params).current_user
+        provider("/", user_params).current_user
 
         expect do
-          provider("/?api_key=#{key}&api_username=system").current_user
+          provider("/", system_params).current_user
         end.to raise_error(RateLimiter::LimitExceeded)
 
         freeze_time 59.seconds.from_now
 
         expect do
-          provider("/?api_key=#{key}&api_username=system").current_user
+          provider("/", system_params).current_user
         end.to raise_error(RateLimiter::LimitExceeded)
 
         freeze_time 2.seconds.from_now
 
         # 1 minute elapsed
-        provider("/?api_key=#{key}&api_username=system").current_user
+        provider("/", system_params).current_user
 
         # should not rake limit a random key
         api_key.destroy
         api_key = ApiKey.create!(created_by_id: -1)
-        provider("/?api_key=#{api_key.key}&api_username=#{user.username.downcase}").current_user
+        user_params = { "HTTP_API_KEY" => api_key.key, "HTTP_API_USERNAME" => user.username.downcase }
+        provider("/", user_params).current_user
 
       end
     end
 
+  end
+
+  context "whitelisted api auth query param routes" do
+
+    it "allows rss feeds" do
+      user = Fabricate(:user)
+      api_key = ApiKey.create!(user_id: user.id, created_by_id: -1)
+      url = "/latest.rss?api_key=#{api_key.key}&api_username=#{user.username.downcase}"
+      expect(provider(url).current_user.id).to eq(user.id)
+    end
+
+    it "allows handle mail route" do
+      user = Fabricate(:user)
+      api_key = ApiKey.create!(user_id: user.id, created_by_id: -1)
+      url = "/admin/email/handle_mail?api_key=#{api_key.key}&api_username=#{user.username.downcase}"
+      opts = { method: "POST" }
+      expect(provider(url, opts).current_user.id).to eq(user.id)
+    end
+
+    it "raises errors for non whitlisted routes" do
+      user = Fabricate(:user)
+      api_key = ApiKey.create!(user_id: user.id, created_by_id: -1)
+      url = "/u?api_key=#{api_key.key}&api_username=#{user.username.downcase}"
+      expect {
+        provider(url).current_user
+      }.to raise_error(Discourse::InvalidAccess)
+    end
+
+    it "still allows header based auth" do
+      user = Fabricate(:user)
+      api_key = ApiKey.create!(user_id: user.id, created_by_id: -1)
+      params = { "HTTP_API_KEY" => api_key.key, "HTTP_API_USERNAME" => user.username.downcase }
+      expect(provider("/", params).current_user.id).to eq(user.id)
+    end
   end
 
   context "server header api" do

--- a/spec/components/auth/default_current_user_provider_spec.rb
+++ b/spec/components/auth/default_current_user_provider_spec.rb
@@ -233,6 +233,13 @@ describe Auth::DefaultCurrentUserProvider do
       expect(provider(url).current_user.id).to eq(user.id)
     end
 
+    it "allows ics feeds" do
+      user = Fabricate(:user)
+      api_key = ApiKey.create!(user_id: user.id, created_by_id: -1)
+      url = "/u/#{user.username}/bookmarks.ics?api_key=#{api_key.key}&api_username=#{user.username.downcase}"
+      expect(provider(url).current_user.id).to eq(user.id)
+    end
+
     it "allows handle mail route" do
       user = Fabricate(:user)
       api_key = ApiKey.create!(user_id: user.id, created_by_id: -1)

--- a/spec/integration/invite_only_registration_spec.rb
+++ b/spec/integration/invite_only_registration_spec.rb
@@ -19,22 +19,23 @@ describe 'invite only' do
         username: 'bob',
         password: 'strongpassword',
         email: 'bob@bob.com',
-        api_key: api_key.key,
-        api_username: admin.username
+      }, headers: {
+        HTTP_API_KEY: api_key.key,
+        HTTP_API_USERNAME: admin.username
       }
 
       user_id = JSON.parse(response.body)["user_id"]
       expect(user_id).to be > 0
 
       # activate and approve
-      put "/admin/users/#{user_id}/activate.json", params: {
-        api_key: api_key.key,
-        api_username: admin.username
+      put "/admin/users/#{user_id}/activate.json", headers: {
+        HTTP_API_KEY: api_key.key,
+        HTTP_API_USERNAME: admin.username
       }
 
-      put "/admin/users/#{user_id}/approve.json", params: {
-        api_key: api_key.key,
-        api_username: admin.username
+      put "/admin/users/#{user_id}/approve.json", headers: {
+        HTTP_API_KEY: api_key.key,
+        HTTP_API_USERNAME: admin.username
       }
 
       u = User.find(user_id)

--- a/spec/integration/rate_limiting_spec.rb
+++ b/spec/integration/rate_limiting_spec.rb
@@ -60,16 +60,16 @@ describe 'rate limiter integration' do
 
     global_setting :max_admin_api_reqs_per_key_per_minute, 1
 
-    get '/admin/api/keys.json', params: {
-      api_key: api_key.key,
-      api_username: admin.username
+    get '/admin/api/keys.json', headers: {
+      HTTP_API_KEY: api_key.key,
+      HTTP_API_USERNAME: admin.username
     }
 
     expect(response.status).to eq(200)
 
-    get '/admin/api/keys.json', params: {
-      api_key: api_key.key,
-      api_username: admin.username
+    get '/admin/api/keys.json', headers: {
+      HTTP_API_KEY: api_key.key,
+      HTTP_API_USERNAME: admin.username
     }
 
     expect(response.status).to eq(429)

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -757,50 +757,6 @@ RSpec.describe Admin::UsersController do
     end
   end
 
-  describe '#invite_admin' do
-    let(:api_key) { Fabricate(:api_key, user: admin) }
-    let(:headers) do
-      { HTTP_API_KEY: api_key.key, HTTP_API_USERNAME: admin.username }
-    end
-
-    it "doesn't work when not via API" do
-      post "/admin/users/invite_admin.json", params: {
-        name: 'Bill', username: 'bill22', email: 'bill@bill.com'
-      }
-
-      expect(response.status).to eq(403)
-    end
-
-    it 'should invite admin' do
-      expect do
-        post "/admin/users/invite_admin.json", params: {
-          name: 'Bill', username: 'bill22', email: 'bill@bill.com'
-        }, headers: headers
-      end.to change { Jobs::CriticalUserEmail.jobs.size }.by(1)
-
-      expect(response.status).to eq(200)
-
-      u = User.find_by_email('bill@bill.com')
-      expect(u.name).to eq("Bill")
-      expect(u.username).to eq("bill22")
-      expect(u.admin).to eq(true)
-      expect(u.active).to eq(true)
-      expect(u.approved).to eq(true)
-    end
-
-    it "doesn't send the email with send_email falsey" do
-      expect do
-        post "/admin/users/invite_admin.json", params: {
-          name: 'Bill', username: 'bill22', email: 'bill@bill.com', send_email: '0'
-        }, headers: headers
-      end.to change { Jobs::CriticalUserEmail.jobs.size }.by(0)
-
-      expect(response.status).to eq(200)
-      json = ::JSON.parse(response.body)
-      expect(json["password_url"]).to be_present
-    end
-  end
-
   describe '#sync_sso' do
     let(:sso) { SingleSignOn.new }
     let(:sso_secret) { "sso secret" }

--- a/spec/requests/embed_controller_spec.rb
+++ b/spec/requests/embed_controller_spec.rb
@@ -49,7 +49,8 @@ describe EmbedController do
 
         it "returns information about the topic" do
           get '/embed/info.json',
-            params: { embed_url: topic_embed.embed_url, api_key: api_key.key, api_username: "system" }
+            params: { embed_url: topic_embed.embed_url },
+            headers: { HTTP_API_KEY: api_key.key, HTTP_API_USERNAME: "system" }
 
           json = JSON.parse(response.body)
           expect(json['topic_id']).to eq(topic_embed.topic.id)
@@ -61,7 +62,8 @@ describe EmbedController do
       context "without invalid embed url" do
         it "returns error response" do
           get '/embed/info.json',
-            params: { embed_url: "http://nope.com", api_key: api_key.key, api_username: "system" }
+            params: { embed_url: "http://nope.com" },
+            headers: { HTTP_API_KEY: api_key.key, HTTP_API_USERNAME: "system" }
 
           json = JSON.parse(response.body)
           expect(json["error_type"]).to eq("not_found")

--- a/spec/requests/uploads_controller_spec.rb
+++ b/spec/requests/uploads_controller_spec.rb
@@ -60,7 +60,10 @@ describe UploadsController do
 
         stub_request(:get, url).to_return(status: 200, body: png)
 
-        post "/uploads.json", params: { url: url, type: "avatar", api_key: api_key, api_username: user.username }
+        post "/uploads.json", params: { url: url, type: "avatar" }, headers: {
+          HTTP_API_KEY: api_key,
+          HTTP_API_USERNAME: user.username.downcase
+        }
 
         json = ::JSON.parse(response.body)
 

--- a/spec/requests/user_badges_controller_spec.rb
+++ b/spec/requests/user_badges_controller_spec.rb
@@ -123,9 +123,13 @@ describe UserBadgesController do
     it 'grants badges from master api calls' do
       api_key = Fabricate(:api_key)
 
-      post "/user_badges.json", params: {
-        badge_id: badge.id, username: user.username, api_key: api_key.key, api_username: "system"
-      }
+      post "/user_badges.json",
+        params: {
+          badge_id: badge.id, username: user.username
+        },
+        headers: {
+          HTTP_API_KEY: api_key.key, HTTP_API_USERNAME: "system"
+        }
 
       expect(response.status).to eq(200)
       user_badge = UserBadge.find_by(user: user, badge: badge)

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -743,7 +743,7 @@ describe UsersController do
 
         it "won't create the user as active with a regular key" do
           post "/u.json",
-            params: post_user_params.merge(active: true, api_key: api_key.key)
+            params: post_user_params.merge(active: true), headers: { HTTP_API_KEY: api_key.key }
 
           expect(response.status).to eq(200)
           expect(JSON.parse(response.body)['active']).to be_falsey
@@ -759,7 +759,7 @@ describe UsersController do
           SiteSetting.must_approve_users = true
 
           #Sidekiq::Client.expects(:enqueue).never
-          post "/u.json", params: post_user_params.merge(approved: true, active: true, api_key: api_key.key)
+          post "/u.json", params: post_user_params.merge(approved: true, active: true), headers: { HTTP_API_KEY: api_key.key }
 
           expect(Jobs::CriticalUserEmail.jobs.size).to eq(0)
           expect(Jobs::SendSystemMessage.jobs.size).to eq(0)
@@ -781,7 +781,7 @@ describe UsersController do
           Jobs.run_immediately!
           SiteSetting.must_approve_users = true
 
-          post "/u.json", params: post_user_params.merge(active: true, api_key: api_key.key)
+          post "/u.json", params: post_user_params.merge(active: true), headers: { HTTP_API_KEY: api_key.key }
 
           expect(response.status).to eq(200)
           json = JSON.parse(response.body)
@@ -796,7 +796,7 @@ describe UsersController do
           Jobs.run_immediately!
           SiteSetting.must_approve_users = true
 
-          post "/u.json", params: post_user_params.merge(api_key: api_key.key)
+          post "/u.json", params: post_user_params, headers: { HTTP_API_KEY: api_key.key }
 
           expect(response.status).to eq(200)
           json = JSON.parse(response.body)
@@ -810,7 +810,7 @@ describe UsersController do
         it "won't create the developer as active" do
           UsernameCheckerService.expects(:is_developer?).returns(true)
 
-          post "/u.json", params: post_user_params.merge(active: true, api_key: api_key.key)
+          post "/u.json", params: post_user_params.merge(active: true), headers: { HTTP_API_KEY: api_key.key }
           expect(response.status).to eq(200)
           expect(JSON.parse(response.body)['active']).to be_falsy
         end
@@ -819,7 +819,7 @@ describe UsersController do
           SiteSetting.allow_user_locale = true
           admin.update!(locale: :fr)
 
-          post "/u.json", params: post_user_params.merge(active: true, api_key: api_key.key)
+          post "/u.json", params: post_user_params.merge(active: true), headers: { HTTP_API_KEY: api_key.key }
           expect(response.status).to eq(200)
 
           json = JSON.parse(response.body)
@@ -858,7 +858,7 @@ describe UsersController do
         fab!(:api_key, refind: false) { Fabricate(:api_key, user: user) }
 
         it "won't create the user as staged with a regular key" do
-          post "/u.json", params: post_user_params.merge(staged: true, api_key: api_key.key)
+          post "/u.json", params: post_user_params.merge(staged: true), headers: { HTTP_API_KEY: api_key.key }
           expect(response.status).to eq(200)
 
           new_user = User.where(username: post_user_params[:username]).first
@@ -871,7 +871,7 @@ describe UsersController do
         fab!(:api_key, refind: false) { Fabricate(:api_key, user: user) }
 
         it "creates the user as staged with a regular key" do
-          post "/u.json", params: post_user_params.merge(staged: true, api_key: api_key.key)
+          post "/u.json", params: post_user_params.merge(staged: true), headers: { HTTP_API_KEY: api_key.key }
           expect(response.status).to eq(200)
 
           new_user = User.where(username: post_user_params[:username]).first
@@ -880,7 +880,7 @@ describe UsersController do
 
         it "won't create the developer as staged" do
           UsernameCheckerService.expects(:is_developer?).returns(true)
-          post "/u.json", params: post_user_params.merge(staged: true, api_key: api_key.key)
+          post "/u.json", params: post_user_params.merge(staged: true), headers: { HTTP_API_KEY: api_key.key }
           expect(response.status).to eq(200)
 
           new_user = User.where(username: post_user_params[:username]).first
@@ -1850,8 +1850,9 @@ describe UsersController do
                 },
                 user_fields: {
                   user_field.id.to_s => 'user field value'
-                },
-                api_key: api_key.key
+                }
+              }, headers: {
+                HTTP_API_KEY: api_key.key
               }
               expect(response.status).to eq(200)
               u = User.find_by_email('user@mail.com')

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -832,7 +832,7 @@ describe UsersController do
           SiteSetting.must_approve_users = true
           SiteSetting.auto_approve_email_domains = "example.com"
 
-          post "/u.json", params: post_user_params.merge(active: true, api_key: api_key.key)
+          post "/u.json", params: post_user_params.merge(active: true), headers: { HTTP_API_KEY: api_key.key }
 
           expect(response.status).to eq(200)
           json = JSON.parse(response.body)


### PR DESCRIPTION
This commit removes support for api credentials in query params except
for a few whitelisted routes like rss/json feeds and the handle_mail
route.

Several tests were written to valid these changes, but the bulk of the
spec changes are just switching them over to use header based auth so
that they will pass without changing what they were actually testing.

Original commit that notified admins this change was coming was created
over 3 months ago: 2db20031879dbafd1a90cbb1a43bca55d51c1b08