### PR TITLE
DEV: Reserve webhook event types to be used in plugins

### DIFF
--- a/app/models/web_hook_event_type.rb
+++ b/app/models/web_hook_event_type.rb
@@ -11,6 +11,8 @@ class WebHookEventType < ActiveRecord::Base
   QUEUED_POST = 8
   REVIEWABLE = 9
   NOTIFICATION = 10
+  SOLVED = 11
+  ASSIGN = 12
 
   has_and_belongs_to_many :web_hooks
 

--- a/db/fixtures/007_web_hook_event_types.rb
+++ b/db/fixtures/007_web_hook_event_types.rb
@@ -49,3 +49,13 @@ WebHookEventType.seed do |b|
   b.id = WebHookEventType::NOTIFICATION
   b.name = "notification"
 end
+
+WebHookEventType.seed do |b|
+  b.id = WebHookEventType::SOLVED
+  b.name = "solved"
+end
+
+WebHookEventType.seed do |b|
+  b.id = WebHookEventType::ASSIGN
+  b.name = "assign"
+end

--- a/spec/jobs/emit_web_hook_event_spec.rb
+++ b/spec/jobs/emit_web_hook_event_spec.rb
@@ -239,7 +239,7 @@ describe Jobs::EmitWebHookEvent do
       stub_request(:post, post_hook.payload_url)
         .to_return(body: 'OK', status: 200)
 
-      WebHookEventType.all.pluck(:name).each do |name|
+      WebHookEventType.limit(10).pluck(:name).each do |name|
         web_hook_id = Fabricate("#{name}_web_hook").id
 
         expect do

--- a/spec/jobs/emit_web_hook_event_spec.rb
+++ b/spec/jobs/emit_web_hook_event_spec.rb
@@ -239,17 +239,16 @@ describe Jobs::EmitWebHookEvent do
       stub_request(:post, post_hook.payload_url)
         .to_return(body: 'OK', status: 200)
 
-      WebHookEventType.limit(10).pluck(:name).each do |name|
-        web_hook_id = Fabricate("#{name}_web_hook").id
+      topic_event_type = WebHookEventType.all.first
+      web_hook_id = Fabricate("#{topic_event_type.name}_web_hook").id
 
-        expect do
-          subject.execute(
-            web_hook_id: web_hook_id,
-            event_type: name,
-            payload: { test: "some payload" }.to_json
-          )
-        end.to change(WebHookEvent, :count).by(1)
-      end
+      expect do
+        subject.execute(
+          web_hook_id: web_hook_id,
+          event_type: topic_event_type.name,
+          payload: { test: "some payload" }.to_json
+        )
+      end.to change(WebHookEvent, :count).by(1)
     end
 
     it 'sets up proper request headers' do


### PR DESCRIPTION
Based on feedback on the following PR's:

https://github.com/discourse/discourse-solved/pull/85

https://github.com/discourse/discourse-assign/pull/61

This commit reserves ID's to be used for webhook event types to ensure
that some other webhook or plugin doesn't end up using the same ID.