### PR TITLE
go permalinks: Add path suffixing, query parameter handling

### DIFF
--- a/app/controllers/permalinks_controller.rb
+++ b/app/controllers/permalinks_controller.rb
@@ -3,35 +3,35 @@
 class PermalinksController < ApplicationController
   skip_before_action :check_xhr, :preload_json
 
+  def go
+    url = request.fullpath
+    permalink = Permalink.match_go(url).first
+    raise Discourse::NotFound unless permalink
+
+    given = URI.parse(url)
+    path_suffix = Permalink.normalize_basic(given.path).delete_prefix(permalink.url).delete_prefix('/')
+
+    # Short circuit: Nothing special in the request
+    # TODO(riking): enable once features are settled
+    # return redirect_to(permalink.target_url, status: 302) if path_suffix.blank? && given.query.blank?
+
+    target = URI.parse(permalink.target_url)
+
+    if !path_suffix.blank?
+      target.path = (target.path.delete_suffix('/')) + '/' + path_suffix
+    end
+
+    if given.query
+      given_query = Rack::Utils.parse_query(given.query)
+      target_query = Rack::Utils.parse_query(target.query)
+      target.query = target_query.merge(given_query).to_query
+    end
+
+    redirect_to target.to_s, status: 302
+  end
+
   def show
     url = request.fullpath
-
-    if url.start_with?('/go/')
-      permalink = Permalink.match_go(url).first
-      raise Discourse::NotFound unless permalink
-
-      given = URI.parse(url)
-      path_suffix = Permalink.normalize_basic(given.path).delete_prefix(permalink.url).delete_prefix('/')
-
-      # Short circuit: Nothing special in the request
-      # TODO(riking): enable once features are settled
-      # return redirect_to(permalink.target_url, status: 302) if path_suffix.blank? && given.query.blank?
-
-      target = URI.parse(permalink.target_url)
-
-      if !path_suffix.blank?
-        target.path = (target.path.delete_suffix('/')) + '/' + path_suffix
-      end
-
-      if given.query
-        given_query = Rack::Utils.parse_query(given.query)
-        target_query = Rack::Utils.parse_query(target.query)
-        target.query = target_query.merge(given_query).to_query
-      end
-
-      redirect_to target.to_s, status: 302
-      return
-    end
 
     permalink = Permalink.find_by_url(url)
 

--- a/app/controllers/permalinks_controller.rb
+++ b/app/controllers/permalinks_controller.rb
@@ -6,6 +6,33 @@ class PermalinksController < ApplicationController
   def show
     url = request.fullpath
 
+    if url.start_with?('/go/')
+      permalink = Permalink.match_go(url).first
+      raise Discourse::NotFound unless permalink
+
+      given = URI.parse(url)
+      path_suffix = Permalink.normalize_basic(given.path).delete_prefix(permalink.url).delete_prefix('/')
+
+      # Short circuit: Nothing special in the request
+      # TODO(riking): enable once features are settled
+      # return redirect_to(permalink.target_url, status: 302) if path_suffix.blank? && given.query.blank?
+
+      target = URI.parse(permalink.target_url)
+
+      if !path_suffix.blank?
+        target.path = (target.path.delete_suffix('/')) + '/' + path_suffix
+      end
+
+      if given.query
+        given_query = Rack::Utils.parse_query(given.query)
+        target_query = Rack::Utils.parse_query(target.query)
+        target.query = target_query.merge(given_query).to_query
+      end
+
+      redirect_to target.to_s, status: 302
+      return
+    end
+
     permalink = Permalink.find_by_url(url)
 
     raise Discourse::NotFound unless permalink

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -951,6 +951,7 @@ Discourse::Application.routes.draw do
 
   resources :csp_reports, only: [:create]
 
+  get "/go/*url", to: 'permalinks#go'
   get "*url", to: 'permalinks#show', constraints: PermalinkConstraint.new
   end
 end

--- a/lib/permalink_constraint.rb
+++ b/lib/permalink_constraint.rb
@@ -3,6 +3,10 @@
 class PermalinkConstraint
 
   def matches?(request)
+    if request.fullpath.start_with?('/go/')
+      return Permalink.match_go(request.fullpath).exists?
+    end
+
     Permalink.where(url: Permalink.normalize_url(request.fullpath)).exists?
   end
 

--- a/lib/permalink_constraint.rb
+++ b/lib/permalink_constraint.rb
@@ -3,10 +3,7 @@
 class PermalinkConstraint
 
   def matches?(request)
-    if request.fullpath.start_with?('/go/')
-      return Permalink.match_go(request.fullpath).exists?
-    end
-
+    # note: /go/ handled in the router
     Permalink.where(url: Permalink.normalize_url(request.fullpath)).exists?
   end
 

--- a/spec/requests/permalinks_controller_spec.rb
+++ b/spec/requests/permalinks_controller_spec.rb
@@ -47,4 +47,107 @@ describe PermalinksController do
       expect(response.status).to eq(404)
     end
   end
+
+  describe 'show go' do
+    fab!(:go_link) { Fabricate(:permalink, url: 'go/meta', external_url: 'https://meta.discourse.org/') }
+    fab!(:go_topic) { Fabricate(:permalink, url: 'go/important', topic_id: topic.id) }
+    fab!(:go_tricky) { Fabricate(:permalink, url: 'go/tricky', external_url: 'https://example.com/folder?tricky=true') }
+    fab!(:go_slashes) { Fabricate(:permalink, url: 'go/meta/codinghorror', external_url: 'https://meta.discourse.org/u/codinghorror/') }
+
+    it 'redirects to the link target with a non-permanent redirect' do
+      get '/go/meta'
+      expect(response.status).to eq(302)
+      expect(response).to redirect_to('https://meta.discourse.org/')
+    end
+
+    it 'works with a trailing slash' do
+      get '/go/meta/'
+      expect(response.status).to eq(302)
+      expect(response).to redirect_to('https://meta.discourse.org/')
+    end
+
+    it 'works with topic targets' do
+      get '/go/important'
+      expect(response.status).to eq(302)
+      expect(response).to redirect_to(topic.relative_url)
+    end
+
+    it 'works for subfolder installs too' do
+      set_subfolder "/forum"
+
+      get '/go/meta/'
+      expect(response.status).to eq(302)
+      expect(response).to redirect_to('https://meta.discourse.org/')
+      get '/go/important'
+      expect(response.status).to eq(302)
+      expect(response).to redirect_to(topic.relative_url)
+    end
+
+    it 'accepts and forwards query parameters' do
+      get '/go/meta?safe_mode=no_custom'
+      expect(response.status).to eq(302)
+      expect(response).to redirect_to('https://meta.discourse.org/?safe_mode=no_custom')
+    end
+
+    it 'accepts and forwards extraneous path elements with or without a slash in the target' do
+      ['https://meta.discourse.org', 'https://meta.discourse.org/'].each do |target|
+        go_link.update!(external_url: target)
+
+        get '/go/meta/c/praise'
+        expect(response.status).to eq(302)
+        expect(response).to redirect_to('https://meta.discourse.org/c/praise')
+      end
+    end
+
+    it 'accepts and forwards extraneous path elements with query parameters' do
+      get '/go/meta/c/praise?order=views'
+      expect(response.status).to eq(302)
+      expect(response).to redirect_to('https://meta.discourse.org/c/praise?order=views')
+    end
+
+    it 'preserves query parameters in the target with extraneous path elements and query parameters' do
+      get '/go/tricky/item?view=full'
+      expect(response.status).to eq(302)
+      expect(response).to redirect_to('https://example.com/folder/item?tricky=true&view=full')
+    end
+
+    it 'works with slashes inside the link definition' do
+      get '/go/meta/codinghorror'
+      expect(response).to redirect_to('https://meta.discourse.org/u/codinghorror/')
+      expect(response.status).to eq(302)
+
+      get '/go/meta/codinghorror/summary'
+      expect(response).to redirect_to('https://meta.discourse.org/u/codinghorror/summary')
+      expect(response.status).to eq(302)
+    end
+
+    it 'overwrites query parameters using those in the request' do
+      get '/go/tricky?tricky=override'
+      expect(response.status).to eq(302)
+      expect(response).to redirect_to('https://example.com/folder?tricky=override')
+    end
+
+    describe 'preservation of trailing slashes' do
+      [
+        # When request has no suffix: match target_url
+        { e: 'https://meta.discourse.org', t: 'https://meta.discourse.org', r: '/go/meta' },
+        { e: 'https://meta.discourse.org/', t: 'https://meta.discourse.org/', r: '/go/meta' },
+        { e: 'https://meta.discourse.org/faq', t: 'https://meta.discourse.org/faq', r: '/go/meta' },
+        { e: 'https://meta.discourse.org/faq/', t: 'https://meta.discourse.org/faq/', r: '/go/meta' },
+        # When request has a suffix: override with rails behavior (no trailing slash)
+        { e: 'https://meta.discourse.org/', t: 'https://meta.discourse.org/faq', r: '/go/meta/faq' },
+        { e: 'https://meta.discourse.org/faq', t: 'https://meta.discourse.org/faq/faq', r: '/go/meta/faq' },
+        { e: 'https://meta.discourse.org/faq/', t: 'https://meta.discourse.org/faq/faq', r: '/go/meta/faq' },
+      ].each do |testcase|
+        it "external_url: #{testcase[:e].inspect} destination: #{testcase[:t].inspect} request: #{testcase[:r].inspect}" do
+          go_link.update!(external_url: testcase[:e])
+
+          get testcase[:r]
+          expect(response.status).to eq(302)
+          expect(response).to redirect_to(testcase[:t])
+        end
+      end
+    end
+
+  end
 end

--- a/spec/requests/permalinks_controller_spec.rb
+++ b/spec/requests/permalinks_controller_spec.rb
@@ -48,7 +48,7 @@ describe PermalinksController do
     end
   end
 
-  describe 'show go' do
+  describe 'go' do
     fab!(:go_link) { Fabricate(:permalink, url: 'go/meta', external_url: 'https://meta.discourse.org/') }
     fab!(:go_topic) { Fabricate(:permalink, url: 'go/important', topic_id: topic.id) }
     fab!(:go_tricky) { Fabricate(:permalink, url: 'go/tricky', external_url: 'https://example.com/folder?tricky=true') }


### PR DESCRIPTION
This allows people to write links like:

```
go/meta
go/meta/c/praise
go/meta/c/praise?order=views
go/meta?safe_mode=no_custom
```

Additionally, change go links to a 302 instead of 301 as we anticipate that forum admins might edit them + avoiding premature optimization.