### PR TITLE
FIX: Allow quoting from a closed topic while writing a reply

### DIFF
--- a/app/assets/javascripts/discourse/controllers/topic.js.es6
+++ b/app/assets/javascripts/discourse/controllers/topic.js.es6
@@ -76,10 +76,10 @@ export default Controller.extend(bufferedProperty("model"), {
     }
   },
 
-  @discourseComputed("model.details.can_create_post")
-  embedQuoteButton(canCreatePost) {
+  @discourseComputed("model.details.can_create_post", "composer.visible")
+  embedQuoteButton(canCreatePost, composerOpened) {
     return (
-      canCreatePost &&
+      (canCreatePost || composerOpened) &&
       this.currentUser &&
       this.currentUser.get("enable_quoting")
     );


### PR DESCRIPTION
composer.(controller).visible is true as long as state is not 'closed', so this works in collapsed, composing, and fullscreen modes.

https://meta.discourse.org/t/regression-quoting-text-from-a-closed-topic/142902/9?u=riking