### PR TITLE
FIX: Check for permalinks before showing the 404 page

### DIFF
--- a/app/assets/javascripts/discourse/lib/url.js
+++ b/app/assets/javascripts/discourse/lib/url.js
@@ -24,7 +24,6 @@ const SERVER_SIDE_ONLY = [
   /^\/posts\/\d+\/raw/,
   /^\/raw\/\d+/,
   /^\/wizard/,
-  /^\/go\//, // EXPERIMENTAL: https://meta.discourse.org/t/-/142605
   /\.rss$/,
   /\.json$/,
   /^\/admin\/upgrade$/,

--- a/app/assets/javascripts/discourse/routes/unknown.js
+++ b/app/assets/javascripts/discourse/routes/unknown.js
@@ -1,8 +1,22 @@
-import DiscourseRoute from "discourse/routes/discourse";
 import { ajax } from "discourse/lib/ajax";
+import DiscourseURL from "discourse/lib/url";
+import DiscourseRoute from "discourse/routes/discourse";
 
 export default DiscourseRoute.extend({
-  model() {
-    return ajax("/404-body", { dataType: "html" });
+  model(params, transition) {
+    const path = params.path;
+    return ajax("/permalink-check.json", {
+      data: { path }
+    }).then(results => {
+      if (results.found) {
+        // Avoid polluting the history stack for external links
+        transition.abort();
+        DiscourseURL.routeTo(results.target_url);
+        return "";
+      } else {
+        // 404 body HTML
+        return results.html;
+      }
+    });
   }
 });

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4578,7 +4578,7 @@ en:
 
       permalink:
         title: "Permalinks"
-        description: "Please note this only applies to external sources, links posted on your forum will not be redirected."
+        description: "Redirections to apply for URLs not known by the forum."
         url: "URL"
         topic_id: "Topic ID"
         topic_title: "Topic"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -954,6 +954,8 @@ Discourse::Application.routes.draw do
 
   resources :csp_reports, only: [:create]
 
+  get "/permalink-check", to: 'permalinks#check'
+
   get "*url", to: 'permalinks#show', constraints: PermalinkConstraint.new
   end
 end

--- a/test/javascripts/acceptance/unknown-test.js.es6
+++ b/test/javascripts/acceptance/unknown-test.js.es6
@@ -1,8 +1,49 @@
 import { acceptance } from "helpers/qunit-helpers";
+import pretender from "helpers/create-pretender";
 acceptance("Unknown");
 
-QUnit.test("Unknown URL", async assert => {
-  assert.expect(1);
+QUnit.test("Permalink Unknown URL", async assert => {
   await visit("/url-that-doesn't-exist");
   assert.ok(exists(".page-not-found"), "The not found content is present");
+});
+
+QUnit.test("Permalink URL to a Topic", async assert => {
+  pretender.get("/permalink-check.json", () => {
+    return [
+      200,
+      { "Content-Type": "application/json" },
+      {
+        found: true,
+        internal: true,
+        target_url: "/t/internationalization-localization/280"
+      }
+    ];
+  });
+
+  await visit("/viewtopic.php?f=8&t=280");
+  assert.ok(exists(".topic-post"));
+});
+
+QUnit.test("Permalink URL to a static page", async assert => {
+  pretender.get("/permalink-check.json", () => {
+    return [
+      200,
+      { "Content-Type": "application/json" },
+      {
+        found: true,
+        internal: true,
+        target_url: "/faq"
+      }
+    ];
+  });
+
+  await visit("/not-the-url-for-faq");
+
+  // body is outside of #ember-testing-container and needs to be targeted
+  // through document instead of find
+  assert.ok(
+    document.querySelector("body.static-faq"),
+    "routed to the faq page"
+  );
+  assert.ok(exists(".body-page"));
 });

--- a/test/javascripts/helpers/create-pretender.js.es6
+++ b/test/javascripts/helpers/create-pretender.js.es6
@@ -267,12 +267,11 @@ export function applyDefaultHandlers(pretender) {
   pretender.put("/t/:id/recover", success);
   pretender.put("/t/:id/publish", success);
 
-  pretender.get("/404-body", () => {
-    return [
-      200,
-      { "Content-Type": "text/html" },
-      "<div class='page-not-found'>not found</div>"
-    ];
+  pretender.get("/permalink-check.json", () => {
+    return response({
+      found: false,
+      html: "<div class='page-not-found'>not found</div>"
+    });
   });
 
   pretender.delete("/draft.json", success);


### PR DESCRIPTION
Implements the "internal routing from posts" part of https://meta.discourse.org/t/feature-interest-survey-go-permalinks/142605