### PR TITLE
FIX: Show time input in poll builder

### DIFF
--- a/plugins/poll/assets/javascripts/discourse/templates/modal/poll-ui-builder.hbs
+++ b/plugins/poll/assets/javascripts/discourse/templates/modal/poll-ui-builder.hbs
@@ -101,6 +101,9 @@
         <div class="input-group poll-date">
           {{date-picker-future value=date containerId="date-container"}}
           {{input type="time" value=time}}
+        </div>
+
+        <div class="input-group poll-date">
           <div id="date-container"></div>
         </div>
       {{/if}}

--- a/plugins/poll/assets/stylesheets/common/poll.scss
+++ b/plugins/poll/assets/stylesheets/common/poll.scss
@@ -200,3 +200,9 @@ body.crawler {
     }
   }
 }
+
+.poll-ui-builder {
+  .poll-date input {
+    height: 30px;
+  }
+}


### PR DESCRIPTION
Before

<img width="700" alt="Screenshot 2020-03-06 at 10 51 13" src="https://user-images.githubusercontent.com/23153890/76067860-c6036380-5f98-11ea-9f3a-b6e6de327b8a.png">

After

<img width="700" alt="Screenshot 2020-03-06 at 10 48 20" src="https://user-images.githubusercontent.com/23153890/76067866-c865bd80-5f98-11ea-93d7-d3ae057b14c2.png">
