### PR TITLE
FEATURE: Add embed_set_canonical_url setting

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2056,6 +2056,7 @@ en:
 
     embed_any_origin: "Allow embeddable content regardless of origin. This is required for mobile apps with static HTML."
     embed_topics_list: "Support HTML embedding of topics lists"
+    embed_set_canonical_url: "Set the canonical URL for embeded topics to the embeded content's URL."
     embed_truncate: "Truncate the embedded posts."
     embed_support_markdown: "Support Markdown formatting for embedded posts."
     embed_whitelist_selector: "A comma separated list of CSS elements that are allowed in embeds."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -876,6 +876,7 @@ posting:
       - code-fences
   embed_any_origin: false
   embed_topics_list: false
+  embed_set_canonical_url: false
   embed_truncate:
     default: true
   embed_support_markdown:

--- a/lib/topic_view.rb
+++ b/lib/topic_view.rb
@@ -113,6 +113,10 @@ class TopicView
   end
 
   def canonical_path
+    if SiteSetting.embed_set_canonical_url
+      topic_embed = topic.topic_embed
+      return topic_embed.embed_url if topic_embed
+    end
     path = relative_url.dup
     path <<
       if @page > 1

--- a/spec/components/topic_view_spec.rb
+++ b/spec/components/topic_view_spec.rb
@@ -249,20 +249,6 @@ describe TopicView do
       end
     end
 
-    describe "#get_canonical_path with embed_set_canonical_url true" do
-      fab!(:topic_embed) { Fabricate(:topic_embed, embed_url: "https://markvanlan.com") }
-      let(:path) { "/1234" }
-
-      before do
-        SiteSetting.embed_set_canonical_url = true
-        TopicView.any_instance.stubs(:find_topic).with(1234).returns(topic_embed.topic)
-      end
-
-      it "returns the topic_embeds URL if embed_set_canonical_url is true" do
-        expect(TopicView.new(1234, user).canonical_path).to eql(topic_embed.embed_url)
-      end
-    end
-
     describe "#next_page" do
       let!(:post) { Fabricate(:post, topic: topic, user: user) }
       let!(:post2) { Fabricate(:post, topic: topic, user: user) }

--- a/spec/components/topic_view_spec.rb
+++ b/spec/components/topic_view_spec.rb
@@ -249,6 +249,20 @@ describe TopicView do
       end
     end
 
+    describe "#get_canonical_path with embed_set_canonical_url true" do
+      fab!(:topic_embed) { Fabricate(:topic_embed, embed_url: "https://markvanlan.com") }
+      let(:path) { "/1234" }
+
+      before do
+        SiteSetting.embed_set_canonical_url = true
+        TopicView.any_instance.stubs(:find_topic).with(1234).returns(topic_embed.topic)
+      end
+
+      it "returns the topic_embeds URL if embed_set_canonical_url is true" do
+        expect(TopicView.new(1234, user).canonical_path).to eql(topic_embed.embed_url)
+      end
+    end
+
     describe "#next_page" do
       let!(:post) { Fabricate(:post, topic: topic, user: user) }
       let!(:post2) { Fabricate(:post, topic: topic, user: user) }

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -3072,6 +3072,22 @@ RSpec.describe TopicsController do
         expect(body).to include('<link rel="prev" href="' + topic.relative_url + "?page=2")
       end
 
+      context "canonical_url" do
+        fab!(:topic_embed) { Fabricate(:topic_embed, embed_url: "https://markvanlan.com") }
+        let(:user_agent) { "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)" }
+
+        it "set to topic.url when embed_set_canonical_url is false" do
+          get topic_embed.topic.url, env: { "HTTP_USER_AGENT" => user_agent }
+          expect(response.body).to include('<link rel="canonical" href="' + topic_embed.topic.url)
+        end
+
+        it "set to topic_embed.embed_url when embed_set_canonical_url is true" do
+          SiteSetting.embed_set_canonical_url = true
+          get topic_embed.topic.url, env: { "HTTP_USER_AGENT" => user_agent }
+          expect(response.body).to include('<link rel="canonical" href="' + topic_embed.embed_url)
+        end
+      end
+
       context "wayback machine" do
         it "renders crawler layout" do
           get topic.url, env: { "HTTP_USER_AGENT" => "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36", "HTTP_VIA" => "HTTP/1.0 web.archive.org (Wayback Save Page)" }


### PR DESCRIPTION
This sets the canonical_url to the topic's `topic_embed.embed_url` when the `embed_set_canonical_url` site setting is enabled.

Defaulted the site setting to `false`, because Falco was worried about the number of Meta complaints this will raise.