### PR TITLE
FIX: prevent scheduled publishing to deleted category

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -198,6 +198,8 @@ class CategoriesController < ApplicationController
     guardian.ensure_can_delete!(@category)
     @category.destroy
 
+    TopicTimer.where(category_id: @category.id).destroy_all
+
     Scheduler::Defer.later "Log staff action delete category" do
       @staff_action_logger.log_category_deletion(@category)
     end


### PR DESCRIPTION
This change will destroy any `TopicTimer` that is associated with a category upon that category's deletion. This prevents an edge case that can happen when a pending "Schedule Publishing" `TopicTimer` is set to a category that is deleted after the timer is created.

