### PR TITLE
DEV: shutdown_ok parameter to /srv/status

### DIFF
--- a/app/controllers/forums_controller.rb
+++ b/app/controllers/forums_controller.rb
@@ -10,7 +10,7 @@ class ForumsController < ActionController::Base
 
   def status
     if $shutdown # rubocop:disable Style/GlobalVars
-      render plain: "shutting down", status: 500
+      render plain: "shutting down", status: (params[:shutdown_ok] ? 200 : 500)
     else
       render plain: "ok"
     end

--- a/spec/requests/forums_controller_spec.rb
+++ b/spec/requests/forums_controller_spec.rb
@@ -19,4 +19,22 @@ RSpec.describe ForumsController do
     end
   end
 
+  describe "during shutdown" do
+    before(:each) do
+      $shutdown = true
+    end
+    after(:each) do
+      $shutdown = nil
+    end
+
+    it "returns a 500 response" do
+      get "/srv/status"
+      expect(response.status).to eq(500)
+    end
+    it "returns a 200 response when given shutdown_ok" do
+      get "/srv/status?shutdown_ok=1"
+      expect(response.status).to eq(200)
+    end
+  end
+
 end


### PR DESCRIPTION
This allows probers to distinguish between liveness and readiness conditions, which you need to avoid k8s killing your container early in the shutdown sequence.

k8s does not allow checking the content of the probe response.

https://meta.discourse.org/t/do-hits-to-srv-status-count-as-crawlers/143431/9?u=riking