### PR TITLE
FEATURE: Add support for custom gravatar-like services

### DIFF
--- a/app/assets/javascripts/discourse/controllers/avatar-selector.js.es6
+++ b/app/assets/javascripts/discourse/controllers/avatar-selector.js.es6
@@ -4,8 +4,13 @@ import ModalFunctionality from "discourse/mixins/modal-functionality";
 import { ajax } from "discourse/lib/ajax";
 import { allowsImages } from "discourse/lib/uploads";
 import { popupAjaxError } from "discourse/lib/ajax-error";
+import { setting } from "discourse/lib/computed";
 
 export default Controller.extend(ModalFunctionality, {
+  gravatarName: setting("gravatar_name"),
+  gravatarBaseUrl: setting("gravatar_base_url"),
+  gravatarLoginUrl: setting("gravatar_login_url"),
+
   @discourseComputed(
     "selected",
     "user.system_avatar_upload_id",

--- a/app/assets/javascripts/discourse/templates/modal/avatar-selector.hbs
+++ b/app/assets/javascripts/discourse/templates/modal/avatar-selector.hbs
@@ -14,16 +14,16 @@
     </div>
     <div class="avatar-choice">
       {{radio-button id="gravatar" name="avatar" value="gravatar" selection=selected}}
-      <label class="radio" for="gravatar">{{bound-avatar-template user.gravatar_avatar_template "large"}} <span>{{i18n 'user.change_avatar.gravatar'}} {{user.email}}</span></label>
+      <label class="radio" for="gravatar">{{bound-avatar-template user.gravatar_avatar_template "large"}} <span>{{i18n 'user.change_avatar.gravatar' gravatarName=gravatarName gravatarBaseUrl=gravatarBaseUrl gravatarLoginUrl=gravatarLoginUrl }} {{user.email}}</span></label>
 
       {{d-button action=(action "refreshGravatar")
-                 title="user.change_avatar.refresh_gravatar_title"
+                 translatedTitle=(i18n "user.change_avatar.refresh_gravatar_title" gravatarName=gravatarName)
                  disabled=gravatarRefreshDisabled
                  icon="sync"
                  class="btn-default avatar-selector-refresh-gravatar"}}
 
       {{#if gravatarFailed}}
-        <p class="error">{{i18n 'user.change_avatar.gravatar_failed'}}</p>
+        <p class="error">{{I18n 'user.change_avatar.gravatar_failed' gravatarName=gravatarName}}</p>
       {{/if}}
     </div>
     {{#if allowAvatarUpload}}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -741,7 +741,7 @@ class User < ActiveRecord::Base
   end
 
   def self.gravatar_template(email)
-    "//www.gravatar.com/avatar/#{self.email_hash(email)}.png?s={size}&r=pg&d=identicon"
+    "//#{SiteSetting.gravatar_base_url}/avatar/#{self.email_hash(email)}.png?s={size}&r=pg&d=identicon"
   end
 
   # Don't pass this up to the client - it's meant for server side use

--- a/app/models/user_avatar.rb
+++ b/app/models/user_avatar.rb
@@ -20,7 +20,7 @@ class UserAvatar < ActiveRecord::Base
         return if user.blank? || user.primary_email.blank?
 
         email_hash = user_id == Discourse::SYSTEM_USER_ID ? User.email_hash("info@discourse.org") : user.email_hash
-        gravatar_url = "https://www.gravatar.com/avatar/#{email_hash}.png?s=#{max}&d=404"
+        gravatar_url = "https://#{SiteSetting.gravatar_base_url}/avatar/#{email_hash}.png?s=#{max}&d=404"
 
         # follow redirects in case gravatar change rules on us
         tempfile = FileHelper.download(

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1057,10 +1057,10 @@ en:
 
       change_avatar:
         title: "Change your profile picture"
-        gravatar: "<a href='//gravatar.com/emails' target='_blank'>Gravatar</a>, based on"
-        gravatar_title: "Change your avatar on Gravatar's website"
-        gravatar_failed: "We could not find a Gravatar with that email address."
-        refresh_gravatar_title: "Refresh your Gravatar"
+        gravatar: "<a href='//{{gravatarBaseUrl}}{{gravatarLoginUrl}}' target='_blank'>{{gravatarName}}</a>, based on"
+        gravatar_title: "Change your avatar on {{gravatarName}}'s website"
+        gravatar_failed: "We could not find a {{gravatarName}} with that email address."
+        refresh_gravatar_title: "Refresh your {{gravatarName}}"
         letter_based: "System assigned profile picture"
         uploaded_avatar: "Custom picture"
         uploaded_avatar_empty: "Add a custom picture"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2185,6 +2185,10 @@ en:
 
     dashboard_general_tab_activity_metrics: "Choose reports to be displayed as activity metrics on the general tab."
 
+    gravatar_name: "Name of the Gravatar provider"
+    gravatar_base_url: "Url of the Gravatar provider's API base"
+    gravatar_login_url: "Url relative to gravatar_base_url, which provides the user with the login to the Gravatar service"
+
     errors:
       invalid_email: "Invalid email address."
       invalid_username: "There's no user with that username."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -598,6 +598,15 @@ users:
     client: true
   max_notifications_per_user:
     default: 10000
+  gravatar_name:
+    default: Gravatar
+    client: true
+  gravatar_base_url:
+    default: www.gravatar.com
+    client: true
+  gravatar_login_url:
+    default: /emails
+    client: true
 
 groups:
   enable_group_directory:

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1248,6 +1248,16 @@ describe User do
 
   end
 
+  describe "#custom_gravatar" do
+    before do
+      SiteSetting.gravatar_base_url = "seccdn.libravatar.org"
+    end
+
+    it "returns a gravatar url as set in the settings" do
+      expect(User.gravatar_template("em@il.com")).to eq("//seccdn.libravatar.org/avatar/6dc2fde946483a1d8a84b89345a1b638.png?s={size}&r=pg&d=identicon")
+    end
+  end
+
   describe "#letter_avatar_color" do
     before do
       SiteSetting.restrict_letter_avatar_colors = "2F70AC|ED207B|AAAAAA|77FF33"


### PR DESCRIPTION
Adds 3 config values that allow to set a custom provider of Gravatar-like API accessible from gravatar_base_url. The gravatar_name is purely cosmetic, but helps with associating name with the service that actually provides the avatars. gravatar_login_url is a link relative to gravatar_base_url, which provides the user with the login to the Gravatar service