### PR TITLE
FIX: Preserve PostCreator's created_at resolution

### DIFF
--- a/lib/post_creator.rb
+++ b/lib/post_creator.rb
@@ -494,7 +494,12 @@ class PostCreator
     end
 
     post.extract_quoted_post_numbers
-    post.created_at = Time.zone.parse(@opts[:created_at].to_s) if @opts[:created_at].present?
+
+    post.created_at = if @opts[:created_at].is_a?(Time)
+      @opts[:created_at]
+    elsif @opts[:created_at].present?
+      Time.zone.parse(@opts[:created_at].to_s)
+    end
 
     if fields = @opts[:custom_fields]
       post.custom_fields = fields

--- a/spec/components/post_creator_spec.rb
+++ b/spec/components/post_creator_spec.rb
@@ -944,24 +944,48 @@ describe PostCreator do
   end
 
   context 'setting created_at' do
-    created_at = 1.week.ago
-    let(:topic) do
-      PostCreator.create(user,
-                         raw: 'This is very interesting test post content',
-                         title: 'This is a very interesting test post title',
-                         created_at: created_at)
+    it 'supports Time instances' do
+      freeze_time
+
+      post1 = PostCreator.create(user,
+        raw: 'This is very interesting test post content',
+        title: 'This is a very interesting test post title',
+        created_at: 1.week.ago
+      )
+      topic = post1.topic
+
+      post2 = PostCreator.create(user,
+        raw: 'This is very interesting test post content',
+        topic_id: topic,
+        created_at: 1.week.ago
+      )
+
+      expect(post1.created_at).to be_within(1.second).of(1.week.ago)
+      expect(post2.created_at).to be_within(1.second).of(1.week.ago)
+      expect(topic.created_at).to be_within(1.second).of(1.week.ago)
     end
 
-    let(:post) do
-      PostCreator.create(user,
-                         raw: 'This is very interesting test post content',
-                         topic_id: Topic.last,
-                         created_at: created_at)
-    end
+    it 'supports strings' do
+      freeze_time
 
-    it 'acts correctly' do
-      expect(topic.created_at).to be_within(10.seconds).of(created_at)
-      expect(post.created_at).to be_within(10.seconds).of(created_at)
+      time = Time.zone.parse('2019-09-02')
+
+      post1 = PostCreator.create(user,
+        raw: 'This is very interesting test post content',
+        title: 'This is a very interesting test post title',
+        created_at: '2019-09-02'
+      )
+      topic = post1.topic
+
+      post2 = PostCreator.create(user,
+        raw: 'This is very interesting test post content',
+        topic_id: topic,
+        created_at: '2019-09-02 00:00:00 UTC'
+      )
+
+      expect(post1.created_at).to be_within(1.second).of(time)
+      expect(post2.created_at).to be_within(1.second).of(time)
+      expect(topic.created_at).to be_within(1.second).of(time)
     end
   end
 


### PR DESCRIPTION
`PostMover` passes to `PostCreator` a `created_at` that is a `ActiveSupport::WithTimeZone/Time` instance.

Previously it was always being processed through `Time.zone.parse` so it would lose sub-second information.

Now, it takes `Time` input as-is, while still parsing other types.