### PR TITLE
FIX: removes legacy refreshQueryWithoutTransition from users route

### DIFF
--- a/app/assets/javascripts/discourse/routes/users.js.es6
+++ b/app/assets/javascripts/discourse/routes/users.js.es6
@@ -10,8 +10,6 @@ export default DiscourseRoute.extend({
     exclude_usernames: { refreshModel: true }
   },
 
-  refreshQueryWithoutTransition: true,
-
   titleToken() {
     return I18n.t("directory.title");
   },


### PR DESCRIPTION
This was causing the history state from period query params to get messedup when going back.