### PR TITLE
DEV: enforces ember-template-lint: no-unbound

### DIFF
--- a/.template-lintrc.js
+++ b/.template-lintrc.js
@@ -9,6 +9,7 @@ module.exports = {
     "no-invalid-interactive": true,
     "link-rel-noopener": true,
     "no-unnecessary-concat": true,
-    "no-unused-block-params": true
+    "no-unused-block-params": true,
+    "no-unbound": true
   }
 };

--- a/app/assets/javascripts/admin/templates/components/site-setting.hbs
+++ b/app/assets/javascripts/admin/templates/components/site-setting.hbs
@@ -1,5 +1,5 @@
 <div class='setting-label'>
-   <h3>{{unbound settingName}}</h3>
+   <h3>{{settingName}}</h3>
    {{#if defaultIsAvailable}}
      <a href onClick={{action 'setDefaultValues'}}>{{setting.setDefaultValuesLabel}}</a>
    {{/if}}

--- a/app/assets/javascripts/admin/templates/components/site-settings/bool.hbs
+++ b/app/assets/javascripts/admin/templates/components/site-settings/bool.hbs
@@ -1,5 +1,5 @@
 <label>
   {{input type="checkbox" checked=enabled}}
-  <span>{{{unbound setting.description}}}</span>
+  <span>{{{setting.description}}}</span>
   {{setting-validation-message message=validationMessage}}
 </label>

--- a/app/assets/javascripts/admin/templates/components/site-settings/category-list.hbs
+++ b/app/assets/javascripts/admin/templates/components/site-settings/category-list.hbs
@@ -3,5 +3,5 @@
   onChange=(action "onChangeSelectedCategories")
 }}
 
-<div class='desc'>{{{unbound setting.description}}}</div>
+<div class='desc'>{{{setting.description}}}</div>
 {{setting-validation-message message=validationMessage}}

--- a/app/assets/javascripts/admin/templates/components/site-settings/category.hbs
+++ b/app/assets/javascripts/admin/templates/components/site-settings/category.hbs
@@ -4,4 +4,4 @@
   onChange=(action (mut value))
 }}
 {{setting-validation-message message=validationMessage}}
-<div class='desc'>{{{unbound setting.description}}}</div>
+<div class='desc'>{{{setting.description}}}</div>

--- a/app/assets/javascripts/admin/templates/components/site-settings/color.hbs
+++ b/app/assets/javascripts/admin/templates/components/site-settings/color.hbs
@@ -6,4 +6,4 @@
   onChangeColor=(action "onChangeColor")
 }}
 {{setting-validation-message message=validationMessage}}
-<div class="desc">{{{unbound setting.description}}}</div>
+<div class="desc">{{{setting.description}}}</div>

--- a/app/assets/javascripts/admin/templates/components/site-settings/compact-list.hbs
+++ b/app/assets/javascripts/admin/templates/components/site-settings/compact-list.hbs
@@ -8,4 +8,4 @@
 }}
 
 {{setting-validation-message message=validationMessage}}
-<div class='desc'>{{{unbound setting.description}}}</div>
+<div class='desc'>{{{setting.description}}}</div>

--- a/app/assets/javascripts/admin/templates/components/site-settings/enum.hbs
+++ b/app/assets/javascripts/admin/templates/components/site-settings/enum.hbs
@@ -15,5 +15,5 @@
 {{setting-validation-message message=validationMessage}}
 
 <div class='desc'>
-  {{{unbound setting.description}}}
+  {{{setting.description}}}
 </div>

--- a/app/assets/javascripts/admin/templates/components/site-settings/group-list.hbs
+++ b/app/assets/javascripts/admin/templates/components/site-settings/group-list.hbs
@@ -7,4 +7,4 @@
   onChange=(action "onChangeGroupListSetting")
 }}
 {{setting-validation-message message=validationMessage}}
-<div class='desc'>{{{unbound setting.description}}}</div>
+<div class='desc'>{{{setting.description}}}</div>

--- a/app/assets/javascripts/admin/templates/components/site-settings/host-list.hbs
+++ b/app/assets/javascripts/admin/templates/components/site-settings/host-list.hbs
@@ -1,3 +1,3 @@
 {{value-list values=value addKey="admin.site_settings.add_host"}}
 {{setting-validation-message message=validationMessage}}
-<div class='desc'>{{{unbound setting.description}}}</div>
+<div class='desc'>{{{setting.description}}}</div>

--- a/app/assets/javascripts/admin/templates/components/site-settings/list.hbs
+++ b/app/assets/javascripts/admin/templates/components/site-settings/list.hbs
@@ -1,3 +1,3 @@
 {{value-list values=value inputDelimiter="|" choices=setting.choices}}
 {{setting-validation-message message=validationMessage}}
-<div class='desc'>{{{unbound setting.description}}}</div>
+<div class='desc'>{{{setting.description}}}</div>

--- a/app/assets/javascripts/admin/templates/components/site-settings/secret-list.hbs
+++ b/app/assets/javascripts/admin/templates/components/site-settings/secret-list.hbs
@@ -1,3 +1,3 @@
 {{secret-value-list setting=setting values=value isSecret=isSecret}}
 {{setting-validation-message message=validationMessage}}
-<div class='desc'>{{{unbound setting.description}}}</div>
+<div class='desc'>{{{setting.description}}}</div>

--- a/app/assets/javascripts/admin/templates/components/site-settings/string.hbs
+++ b/app/assets/javascripts/admin/templates/components/site-settings/string.hbs
@@ -7,4 +7,4 @@
 {{/if}}
 
 {{setting-validation-message message=validationMessage}}
-<div class='desc'>{{{unbound setting.description}}}</div>
+<div class='desc'>{{{setting.description}}}</div>

--- a/app/assets/javascripts/admin/templates/components/site-settings/tag-list.hbs
+++ b/app/assets/javascripts/admin/templates/components/site-settings/tag-list.hbs
@@ -1,3 +1,3 @@
 {{tag-chooser tags=selectedTags}}
-<div class='desc'>{{{unbound setting.description}}}</div>
+<div class='desc'>{{{setting.description}}}</div>
 {{setting-validation-message message=validationMessage}}

--- a/app/assets/javascripts/admin/templates/components/site-settings/upload.hbs
+++ b/app/assets/javascripts/admin/templates/components/site-settings/upload.hbs
@@ -1,2 +1,2 @@
 {{site-settings-image-uploader imageUrl=value placeholderUrl=setting.placeholder type="site_setting"}}
-<div class='desc'>{{{unbound setting.description}}}</div>
+<div class='desc'>{{{setting.description}}}</div>

--- a/app/assets/javascripts/admin/templates/components/site-settings/uploaded-image-list.hbs
+++ b/app/assets/javascripts/admin/templates/components/site-settings/uploaded-image-list.hbs
@@ -1,2 +1,2 @@
 {{d-button label="admin.site_settings.uploaded_image_list.label" action=(action "showUploadModal") actionParam=(hash value=value setting=setting)}}
-<div class='desc'>{{{unbound setting.description}}}</div>
+<div class='desc'>{{{setting.description}}}</div>

--- a/app/assets/javascripts/admin/templates/components/site-settings/url-list.hbs
+++ b/app/assets/javascripts/admin/templates/components/site-settings/url-list.hbs
@@ -1,3 +1,3 @@
 {{value-list values=value addKey="admin.site_settings.add_url"}}
 {{setting-validation-message message=validationMessage}}
-<div class='desc'>{{{unbound setting.description}}}</div>
+<div class='desc'>{{{setting.description}}}</div>

--- a/app/assets/javascripts/admin/templates/components/site-settings/value-list.hbs
+++ b/app/assets/javascripts/admin/templates/components/site-settings/value-list.hbs
@@ -1,3 +1,3 @@
 {{value-list values=value}}
 {{setting-validation-message message=validationMessage}}
-<div class='desc'>{{{unbound setting.description}}}</div>
+<div class='desc'>{{{setting.description}}}</div>

--- a/app/assets/javascripts/admin/templates/email-bounced.hbs
+++ b/app/assets/javascripts/admin/templates/email-bounced.hbs
@@ -27,7 +27,7 @@
               &mdash;
             {{/if}}
           </td>
-          <td><a href='mailto:{{unbound l.to_address}}'>{{l.to_address}}</a></td>
+          <td><a href='mailto:{{l.to_address}}'>{{l.to_address}}</a></td>
           {{#if l.has_bounce_key}}
             <td><a href {{action "showIncomingEmail" l.id}}>{{l.email_type}}</a></td>
           {{else}}

--- a/app/assets/javascripts/admin/templates/email-received.hbs
+++ b/app/assets/javascripts/admin/templates/email-received.hbs
@@ -34,10 +34,10 @@
           </td>
           <td class="addresses">
             {{#each email.to_addresses as |to|}}
-              <p><a href="mailto:{{unbound to}}" title="TO">{{unbound to}}</a></p>
+              <p><a href="mailto:{{to}}" title="TO">{{to}}</a></p>
             {{/each}}
             {{#each email.cc_addresses as |cc|}}
-              <p><a href="mailto:{{unbound cc}}" title="CC">{{unbound cc}}</a></p>
+              <p><a href="mailto:{{cc}}" title="CC">{{cc}}</a></p>
             {{/each}}
           </td>
           <td>

--- a/app/assets/javascripts/admin/templates/email-rejected.hbs
+++ b/app/assets/javascripts/admin/templates/email-rejected.hbs
@@ -31,7 +31,7 @@
                 {{/link-to}}
               {{else}}
                 {{#if email.from_address}}
-                  <a href='mailto:{{unbound email.from_address}}'>{{email.from_address}}</a>
+                  <a href='mailto:{{email.from_address}}'>{{email.from_address}}</a>
                 {{else}}
                   &mdash;
                 {{/if}}
@@ -40,10 +40,10 @@
           </td>
           <td class="addresses">
             {{#each email.to_addresses as |to|}}
-              <p><a href="mailto:{{unbound to}}" title="TO">{{unbound to}}</a></p>
+              <p><a href="mailto:{{to}}" title="TO">{{to}}</a></p>
             {{/each}}
             {{#each email.cc_addresses as |cc|}}
-              <p><a href="mailto:{{unbound cc}}" title="CC">{{unbound cc}}</a></p>
+              <p><a href="mailto:{{cc}}" title="CC">{{cc}}</a></p>
             {{/each}}
           </td>
           <td>{{email.subject}}</td>

--- a/app/assets/javascripts/admin/templates/email-sent.hbs
+++ b/app/assets/javascripts/admin/templates/email-sent.hbs
@@ -31,7 +31,7 @@
           </td>
           <td>
             {{#if l.bounced}}{{d-icon "redo" title="admin.email.bounced"}}{{/if}}
-            <a href='mailto:{{unbound l.to_address}}'>{{l.to_address}}</a>
+            <a href='mailto:{{l.to_address}}'>{{l.to_address}}</a>
           </td>
           <td>{{l.email_type}}</td>
           <td class='post-link'>

--- a/app/assets/javascripts/admin/templates/email-skipped.hbs
+++ b/app/assets/javascripts/admin/templates/email-skipped.hbs
@@ -29,7 +29,7 @@
               &mdash;
             {{/if}}
           </td>
-          <td><a href='mailto:{{unbound l.to_address}}'>{{l.to_address}}</a></td>
+          <td><a href='mailto:{{l.to_address}}'>{{l.to_address}}</a></td>
           <td>{{l.email_type}}</td>
           <td>
             {{#if l.post_url}}

--- a/app/assets/javascripts/admin/templates/emojis.hbs
+++ b/app/assets/javascripts/admin/templates/emojis.hbs
@@ -18,7 +18,7 @@
         <tbody>
           {{#each sortedEmojis as |e|}}
             <tr>
-              <th><img class="emoji emoji-custom" src={{unbound e.url}} title={{unbound e.name}}></th>
+              <th><img class="emoji emoji-custom" src={{e.url}} title={{e.name}}></th>
               <th>:{{e.name}}:</th>
               <th>
                 {{d-button

--- a/app/assets/javascripts/admin/templates/permalinks.hbs
+++ b/app/assets/javascripts/admin/templates/permalinks.hbs
@@ -27,22 +27,22 @@
             <td class="col first url">{{pl.url}}</td>
             <td class="col topic">
               {{#if pl.topic_id}}
-                <a href={{unbound pl.topic_url}}>{{pl.topic_title}}</a>
+                <a href={{pl.topic_url}}>{{pl.topic_title}}</a>
               {{/if}}
             </td>
             <td class="col post">
               {{#if pl.post_id}}
-                <a href={{unbound pl.post_url}}>#{{pl.post_number}} {{pl.post_topic_title}}</a>
+                <a href={{pl.post_url}}>#{{pl.post_number}} {{pl.post_topic_title}}</a>
               {{/if}}
             </td>
             <td class="col category">
               {{#if pl.category_id}}
-                <a href={{unbound pl.category_url}}>{{pl.category_name}}</a>
+                <a href={{pl.category_url}}>{{pl.category_name}}</a>
               {{/if}}
             </td>
             <td class="col external_url">
               {{#if pl.external_url}}
-                <a href={{unbound pl.external_url}}>{{pl.external_url}}</a>
+                <a href={{pl.external_url}}>{{pl.external_url}}</a>
               {{/if}}
             </td>
             <td class="col action">

--- a/app/assets/javascripts/admin/templates/search-logs-term.hbs
+++ b/app/assets/javascripts/admin/templates/search-logs-term.hbs
@@ -23,15 +23,15 @@
   {{#each model.search_result.posts as |result|}}
     <div class='fps-result'>
       <div class='author'>
-        <a href={{result.userPath}} data-user-card={{unbound result.username}}>
+        <a href={{result.userPath}} data-user-card={{result.username}}>
           {{avatar result imageSize="large"}}
         </a>
       </div>
 
       <div class='fps-topic'>
         <div class='topic'>
-          <a class='search-link' href={{unbound result.url}}>
-            {{topic-status topic=result.topic disableActions=true}}<span class='topic-title'>{{#highlight-text highlight=term}}{{{unbound result.topic.fancyTitle}}}{{/highlight-text}}</span>
+          <a class='search-link' href={{result.url}}>
+            {{topic-status topic=result.topic disableActions=true}}<span class='topic-title'>{{#highlight-text highlight=term}}{{{result.topic.fancyTitle}}}{{/highlight-text}}</span>
           </a>
 
           <div class='search-category'>
@@ -55,7 +55,7 @@
 
           {{#if result.blurb}}
             {{#highlight-text highlight=term}}
-              {{{unbound result.blurb}}}
+              {{{result.blurb}}}
             {{/highlight-text}}
           {{/if}}
         </div>

--- a/app/assets/javascripts/admin/templates/user-badges.hbs
+++ b/app/assets/javascripts/admin/templates/user-badges.hbs
@@ -55,7 +55,7 @@
             </td>
             <td class='reason'>
               {{#if userBadge.postUrl}}
-              <a href={{unbound userBadge.postUrl}}>{{userBadge.topic_title}}</a>
+              <a href={{userBadge.postUrl}}>{{userBadge.topic_title}}</a>
               {{/if}}
             </td>
             <td>{{age-with-tooltip userBadge.granted_at}}</td>

--- a/app/assets/javascripts/admin/templates/user-index.hbs
+++ b/app/assets/javascripts/admin/templates/user-index.hbs
@@ -59,7 +59,7 @@
           <div class="controls">{{i18n "admin.users.not_verified"}}</div>
         {{/unless}}
         {{#if model.email}}
-          <a href="mailto:{{unbound model.email}}">{{model.email}}</a>
+          <a href="mailto:{{model.email}}">{{model.email}}</a>
         {{else}}
           {{d-button
             class="btn-default"
@@ -79,7 +79,7 @@
           {{#if model.secondary_emails}}
             <ul>
               {{#each model.secondary_emails as |email| }}
-                <li><a href="mailto:{{unbound email}}">{{email}}</a></li>
+                <li><a href="mailto:{{email}}">{{email}}</a></li>
               {{/each}}
             </ul>
           {{else}}

--- a/app/assets/javascripts/admin/templates/users-list-show.hbs
+++ b/app/assets/javascripts/admin/templates/users-list-show.hbs
@@ -49,7 +49,7 @@
               {{/if}}
             </td>
             <td class='email'>
-              {{user.email~}}
+              {{~user.email~}}
             </td>
             <td class="last-emailed">
               <div class="label">{{i18n 'admin.users.last_emailed'}}</div>

--- a/app/assets/javascripts/admin/templates/users-list-show.hbs
+++ b/app/assets/javascripts/admin/templates/users-list-show.hbs
@@ -40,16 +40,16 @@
         {{#each model as |user|}}
           <tr class="user {{user.selected}} {{unless user.active 'not-activated'}}">
             <td class="username">
-              <a href={{unbound user.path}} data-user-card={{unbound user.username}}>
+              <a href={{user.path}} data-user-card={{user.username}}>
                 {{avatar user imageSize="small"}}
               </a>
-              {{#link-to 'adminUser' user}}{{unbound user.username}}{{/link-to}}
+              {{#link-to 'adminUser' user}}{{user.username}}{{/link-to}}
               {{#if user.staged}}
                 {{d-icon "far-envelope" title="user.staged" }}
               {{/if}}
             </td>
             <td class='email'>
-              {{~unbound user.email~}}
+              {{user.email~}}
             </td>
             <td class="last-emailed">
               <div class="label">{{i18n 'admin.users.last_emailed'}}</div>

--- a/app/assets/javascripts/discourse/templates/badges/show.hbs
+++ b/app/assets/javascripts/discourse/templates/badges/show.hbs
@@ -42,7 +42,7 @@
           {{#user-info user=ub.user size="medium" class="badge-info" date=ub.granted_at}}
             <div class="granted-on">{{i18n 'badges.granted_on' date=(inline-date ub.granted_at)}}</div>
             {{#if ub.post_number}}
-              <a class="post-link" href="{{unbound ub.topic.url}}/{{unbound ub.post_number}}">{{{ub.topic.fancyTitle}}}</a>
+              <a class="post-link" href="{{ub.topic.url}}/{{ub.post_number}}">{{{ub.topic.fancyTitle}}}</a>
             {{/if}}
           {{/user-info}}
         {{/each}}

--- a/app/assets/javascripts/discourse/templates/components/categories-boxes-topic.hbs
+++ b/app/assets/javascripts/discourse/templates/components/categories-boxes-topic.hbs
@@ -1,5 +1,5 @@
 {{d-icon topicStatusIcon}}
 
-<a class='title' href={{unbound topic.lastUnreadUrl}}>
+<a class='title' href={{topic.lastUnreadUrl}}>
   {{text-overflow class="overflow" text=topic.fancyTitle}}
 </a>

--- a/app/assets/javascripts/discourse/templates/components/categories-boxes-with-topics.hbs
+++ b/app/assets/javascripts/discourse/templates/components/categories-boxes-with-topics.hbs
@@ -1,5 +1,5 @@
 {{#each categories as |c|}}
-  <div class='category category-box category-box-{{unbound c.slug}}' style={{border-color c.color}}>
+  <div class='category category-box category-box-{{c.slug}}' style={{border-color c.color}}>
     <div class='category-box-inner'>
       <div class='category-box-heading'>
         <a href={{c.url}}>

--- a/app/assets/javascripts/discourse/templates/components/categories-boxes.hbs
+++ b/app/assets/javascripts/discourse/templates/components/categories-boxes.hbs
@@ -1,5 +1,5 @@
 {{#each categories as |c|}}
-  <div class='category category-box category-box-{{unbound c.slug}}' style={{border-color c.color}} data-category-id={{c.id}} data-notification-level={{c.notificationLevelString}}
+  <div class='category category-box category-box-{{c.slug}}' style={{border-color c.color}} data-category-id={{c.id}} data-notification-level={{c.notificationLevelString}}
    data-url={{c.url}}>
     <div class='category-box-inner'>
       <div class="category-logo">

--- a/app/assets/javascripts/discourse/templates/components/category-unread.hbs
+++ b/app/assets/javascripts/discourse/templates/components/category-unread.hbs
@@ -1,6 +1,6 @@
 {{#if category.unreadTopics}}
-  <a href={{unbound category.unreadUrl}} class='badge new-posts badge-notification' title={{i18n 'topic.unread_topics' count=category.unreadTopics}}>{{i18n 'filters.unread.lower_title_with_count' count=category.unreadTopics}}</a>
+  <a href={{category.unreadUrl}} class='badge new-posts badge-notification' title={{i18n 'topic.unread_topics' count=category.unreadTopics}}>{{i18n 'filters.unread.lower_title_with_count' count=category.unreadTopics}}</a>
 {{/if}}
 {{#if category.newTopics}}
-  <a href={{unbound category.newUrl}} class='badge new-posts badge-notification' title={{i18n 'topic.new_topics' count=category.newTopics}}>{{i18n 'filters.new.lower_title_with_count' count=category.newTopics}}</a>
+  <a href={{category.newUrl}} class='badge new-posts badge-notification' title={{i18n 'topic.new_topics' count=category.newTopics}}>{{i18n 'filters.new.lower_title_with_count' count=category.newTopics}}</a>
 {{/if}}

--- a/app/assets/javascripts/discourse/templates/components/choose-message.hbs
+++ b/app/assets/javascripts/discourse/templates/components/choose-message.hbs
@@ -11,7 +11,7 @@
     {{#each messages as |m|}}
       <div class='controls existing-message'>
         <label class='radio'>
-          <input type='radio' id="choose-message-{{unbound m.id}}" name='choose_message_id' {{action "chooseMessage" m}}>
+          <input type='radio' id="choose-message-{{m.id}}" name='choose_message_id' {{action "chooseMessage" m}}>
           <span class="message-title">
             {{m.title}}
           </span>

--- a/app/assets/javascripts/discourse/templates/components/choose-topic.hbs
+++ b/app/assets/javascripts/discourse/templates/components/choose-topic.hbs
@@ -11,7 +11,7 @@
     {{#each topics as |t|}}
       <div class='controls existing-topic'>
         <label class='radio'>
-          <input type='radio' id="choose-topic-{{unbound t.id}}" name='choose_topic_id' {{action "chooseTopic" t}}>
+          <input type='radio' id="choose-topic-{{t.id}}" name='choose_topic_id' {{action "chooseTopic" t}}>
           {{raw "topic-status" topic=t}}
           <span class="topic-title">
             {{t.title}}

--- a/app/assets/javascripts/discourse/templates/components/featured-topic.hbs
+++ b/app/assets/javascripts/discourse/templates/components/featured-topic.hbs
@@ -1,12 +1,12 @@
 {{raw "topic-status" topic=topic}}
-<a class='title' href={{unbound topic.lastUnreadUrl}}>{{{unbound topic.fancyTitle}}}</a>
+<a class='title' href={{topic.lastUnreadUrl}}>{{{topic.fancyTitle}}}</a>
 {{topic-post-badges newPosts=topic.totalUnread unseen=topic.unseen url=topic.lastUnreadUrl}}
 
 {{#if latestTopicOnly}}
   <div class='last-user-info'>
-    {{i18n 'categories.latest_by'}} <a href={{{unbound topic.lastPosterUrl}}}>{{unbound topic.last_poster.username}}</a>
-    <a href={{unbound topic.lastPostUrl}}>{{format-age topic.last_posted_at}}</a>
+    {{i18n 'categories.latest_by'}} <a href={{{topic.lastPosterUrl}}}>{{topic.last_poster.username}}</a>
+    <a href={{topic.lastPostUrl}}>{{format-age topic.last_posted_at}}</a>
   </div>
 {{else}}
-  <a href={{unbound topic.lastPostUrl}} class="last-posted-at">{{format-age topic.last_posted_at}}</a>
+  <a href={{topic.lastPostUrl}} class="last-posted-at">{{format-age topic.last_posted_at}}</a>
 {{/if}}

--- a/app/assets/javascripts/discourse/templates/components/flag-action-type.hbs
+++ b/app/assets/javascripts/discourse/templates/components/flag-action-type.hbs
@@ -2,7 +2,7 @@
   <h3>{{formattedName}}</h3>
   <div class='controls'>
     <label class='radio'>
-      <input type='radio' id="radio_{{unbound flag.name_key}}" {{action "changePostActionType" flag}} name='post_action_type_index'>
+      <input type='radio' id="radio_{{flag.name_key}}" {{action "changePostActionType" flag}} name='post_action_type_index'>
 
       <div class='flag-action-type-details'>
         <span class='description'>{{{flag.description}}}</span>
@@ -20,7 +20,7 @@
 {{else}}
   <div class="controls {{flag.name_key}}">
     <label class='radio'>
-      <input type='radio' id="radio_{{unbound flag.name_key}}" {{action "changePostActionType" flag}} name='post_action_type_index'>
+      <input type='radio' id="radio_{{flag.name_key}}" {{action "changePostActionType" flag}} name='post_action_type_index'>
       <div class='flag-action-type-details'>
         <strong>{{formattedName}}</strong>
         {{#if showDescription}}

--- a/app/assets/javascripts/discourse/templates/components/group-post.hbs
+++ b/app/assets/javascripts/discourse/templates/components/group-post.hbs
@@ -1,5 +1,5 @@
 <div class='clearfix info'>
-    <a href={{unbound post.user.userUrl}} data-user-card={{unbound post.user.username}} class='avatar-link'>
+    <a href={{post.user.userUrl}} data-user-card={{post.user.username}} class='avatar-link'>
       {{avatar post.user imageSize="large" extraClasses="actor" ignoreTitle="true"}}
     </a>
     <span class='time'>{{format-date post.created_at leaveAgo="true"}}</span>

--- a/app/assets/javascripts/discourse/templates/components/ip-lookup.hbs
+++ b/app/assets/javascripts/discourse/templates/components/ip-lookup.hbs
@@ -25,7 +25,7 @@
         <dt>{{i18n "ip_lookup.location"}}</dt>
         <dd>
           {{#if location.location}}
-            <a href="https://maps.google.com/maps?q={{unbound location.latitude}},{{unbound location.longitude}}" rel="noopener" target="_blank">
+            <a href="https://maps.google.com/maps?q={{location.latitude}},{{location.longitude}}" rel="noopener" target="_blank">
               {{location.location}}
             </a>
           {{else}}

--- a/app/assets/javascripts/discourse/templates/components/share-source.hbs
+++ b/app/assets/javascripts/discourse/templates/components/share-source.hbs
@@ -1,4 +1,4 @@
-<a href {{action "share" source}} title={{unbound source.title}} aria-label={{unbound source.title}}>
+<a href {{action "share" source}} title={{source.title}} aria-label={{source.title}}>
   {{#if source.icon}}
     {{d-icon source.icon}}
   {{else}}

--- a/app/assets/javascripts/discourse/templates/components/user-info.hbs
+++ b/app/assets/javascripts/discourse/templates/components/user-info.hbs
@@ -1,6 +1,6 @@
 <div class="user-image">
   <div class="user-image-inner">
-    <a href={{unbound userPath}} data-user-card={{unbound user.username}}>{{avatar user imageSize="large"}}</a>
+    <a href={{userPath}} data-user-card={{user.username}}>{{avatar user imageSize="large"}}</a>
     {{#if user.primary_group_name}}
       {{avatar-flair
         flairURL=user.primary_group_flair_url
@@ -13,10 +13,10 @@
 
 <div class="user-detail">
   <div class='name-line'>
-    <span class="username"><a href={{unbound userPath}} data-user-card={{unbound user.username}}>{{format-username user.username}}</a></span>
-    <span class="name">{{unbound name}}</span>
+    <span class="username"><a href={{userPath}} data-user-card={{user.username}}>{{format-username user.username}}</a></span>
+    <span class="name">{{name}}</span>
   </div>
-  <div class="title">{{unbound user.title}}</div>
+  <div class="title">{{user.title}}</div>
 
   {{#if hasBlock}}
     <div class='details'>

--- a/app/assets/javascripts/discourse/templates/components/user-summary-topic.hbs
+++ b/app/assets/javascripts/discourse/templates/components/user-summary-topic.hbs
@@ -6,4 +6,4 @@
   {{/if}}
 </span>
 <br>
-<a href={{unbound url}}>{{{topic.fancyTitle}}}</a>
+<a href={{url}}>{{{topic.fancyTitle}}}</a>

--- a/app/assets/javascripts/discourse/templates/composer.hbs
+++ b/app/assets/javascripts/discourse/templates/composer.hbs
@@ -213,7 +213,7 @@
       {{else}}
         <div class='saving-text'>
           {{#if model.createdPost}}
-            {{i18n 'composer.saved'}} <a class='permalink' href={{unbound createdPost.url}} {{action "viewNewReply"}}>{{i18n 'composer.view_new_post'}}</a>
+            {{i18n 'composer.saved'}} <a class='permalink' href={{createdPost.url}} {{action "viewNewReply"}}>{{i18n 'composer.view_new_post'}}</a>
           {{else}}
             {{i18n 'composer.saving'}} {{loading-spinner size="small"}}
           {{/if}}

--- a/app/assets/javascripts/discourse/templates/full-page-search.hbs
+++ b/app/assets/javascripts/discourse/templates/full-page-search.hbs
@@ -73,7 +73,7 @@
           {{#each model.posts as |result|}}
             <div class='fps-result'>
               <div class='author'>
-                <a href={{result.userPath}} data-user-card={{unbound result.username}}>
+                <a href={{result.userPath}} data-user-card={{result.username}}>
                   {{avatar result imageSize="large"}}
                 </a>
               </div>
@@ -84,9 +84,9 @@
                     {{track-selected selectedList=selected selectedId=result.topic}}
                   {{/if}}
 
-                  <a class='search-link' href={{unbound result.url}} {{action "logClick" result.topic_id}}>
+                  <a class='search-link' href={{result.url}} {{action "logClick" result.topic_id}}>
                     {{topic-status topic=result.topic disableActions=true showPrivateMessageIcon=true}}
-                    <span class='topic-title'>{{#highlight-text highlight=q}}{{{unbound result.topic.fancyTitle}}}{{/highlight-text}}</span>
+                    <span class='topic-title'>{{#highlight-text highlight=q}}{{{result.topic.fancyTitle}}}{{/highlight-text}}</span>
                   </a>
 
                   <div class='search-category'>
@@ -111,7 +111,7 @@
 
                   {{#if result.blurb}}
                     {{#highlight-text highlight=highlightQuery}}
-                      {{{unbound result.blurb}}}
+                      {{{result.blurb}}}
                     {{/highlight-text}}
                   {{/if}}
                 </div>

--- a/app/assets/javascripts/discourse/templates/mobile/components/basic-topic-list.hbs
+++ b/app/assets/javascripts/discourse/templates/mobile/components/basic-topic-list.hbs
@@ -26,7 +26,7 @@
                 <div class="topic-excerpt">
                   {{{t.excerpt}}}
                   {{#if t.excerptTruncated}}
-                    {{#unless t.canClearPin}}<a href={{unbound t.url}}>{{i18n 'read_more'}}</a>{{/unless}}
+                    {{#unless t.canClearPin}}<a href={{t.url}}>{{i18n 'read_more'}}</a>{{/unless}}
                   {{/if}}
                   {{#if t.canClearPin}}
                     <a href {{action "clearPin" t}} title={{i18n 'topic.clear_pin.help'}}>{{i18n 'topic.clear_pin.title'}}</a>

--- a/app/assets/javascripts/discourse/templates/modal/bulk-notification-level.hbs
+++ b/app/assets/javascripts/discourse/templates/modal/bulk-notification-level.hbs
@@ -1,8 +1,8 @@
 {{#each notificationLevels as |level|}}
   <div class='controls'>
     <label class='radio'>
-      {{radio-button value=level.id name="notification_level" selection=notificationLevelId}} <strong>{{unbound level.name}}</strong>
-      <div class='description'>{{{unbound level.description}}}</div>
+      {{radio-button value=level.id name="notification_level" selection=notificationLevelId}} <strong>{{level.name}}</strong>
+      <div class='description'>{{{level.description}}}</div>
     </label>
   </div>
 {{/each}}

--- a/app/assets/javascripts/discourse/templates/outlet-list.hbs
+++ b/app/assets/javascripts/discourse/templates/outlet-list.hbs
@@ -1,1 +1,1 @@
-{{connector templateId=(unbound templateId) class=(unbound outletClasses) tagName=(unbound tagName)}}
+{{connector templateId=templateId class=outletClasses tagName=tagName}}

--- a/app/assets/javascripts/discourse/templates/preferences/categories.hbs
+++ b/app/assets/javascripts/discourse/templates/preferences/categories.hbs
@@ -4,7 +4,7 @@
   <div class="controls tracking-controls">
     <label>{{d-icon "d-watching"}} {{i18n 'user.watched_categories'}}</label>
     {{#if canSee}}
-      <a class="show-tracking" href={{unbound model.watchingTopicsPath}}>{{i18n 'user.tracked_topics_link'}}</a>
+      <a class="show-tracking" href={{model.watchingTopicsPath}}>{{i18n 'user.tracked_topics_link'}}</a>
     {{/if}}
     {{category-selector
       categories=model.watchedCategories
@@ -18,7 +18,7 @@
   <div class="controls tracking-controls">
     <label>{{d-icon "d-tracking"}} {{i18n 'user.tracked_categories'}}</label>
     {{#if canSee}}
-      <a class="show-tracking" href={{unbound model.trackingTopicsPath}}>{{i18n 'user.tracked_topics_link'}}</a>
+      <a class="show-tracking" href={{model.trackingTopicsPath}}>{{i18n 'user.tracked_topics_link'}}</a>
     {{/if}}
     {{category-selector
       categories=model.trackedCategories
@@ -43,7 +43,7 @@
     <div class="controls tracking-controls">
       <label>{{d-icon "d-muted"}} {{i18n 'user.muted_categories'}}</label>
       {{#if canSee}}
-        <a class="show-tracking" href={{unbound model.mutedTopicsPath}}>{{i18n 'user.tracked_topics_link'}}</a>
+        <a class="show-tracking" href={{model.mutedTopicsPath}}>{{i18n 'user.tracked_topics_link'}}</a>
       {{/if}}
       {{category-selector
         categories=model.mutedCategories

--- a/app/assets/javascripts/discourse/templates/topic.hbs
+++ b/app/assets/javascripts/discourse/templates/topic.hbs
@@ -57,7 +57,7 @@
           </div>
 
         {{else}}
-          <h1 data-topic-id={{unbound model.id}}>
+          <h1 data-topic-id={{model.id}}>
             {{#unless model.is_warning}}
               {{#if siteSettings.enable_personal_messages}}
                 {{private-message-glyph
@@ -73,7 +73,7 @@
 
             {{#if model.details.loaded}}
               {{topic-status topic=model}}
-              <a href={{unbound model.url}} {{action "jumpTop"}} class="fancy-title">
+              <a href={{model.url}} {{action "jumpTop"}} class="fancy-title">
                 {{{model.fancyTitle}}}
               </a>
             {{/if}}
@@ -170,7 +170,7 @@
       {{/topic-navigation}}
 
       <div class="row">
-        <section class="topic-area" id="topic" data-topic-id={{unbound model.id}}>
+        <section class="topic-area" id="topic" data-topic-id={{model.id}}>
 
           <div class="posts-wrapper">
             {{conditional-loading-spinner condition=model.postStream.loadingAbove}}

--- a/app/assets/javascripts/discourse/templates/user-invited-show.hbs
+++ b/app/assets/javascripts/discourse/templates/user-invited-show.hbs
@@ -74,13 +74,13 @@
                       <td>{{number invite.user.posts_read_count}}</td>
                       <td>{{{format-duration invite.user.time_read}}}</td>
                       <td>
-                        <span title={{i18n 'user.invited.days_visited'}}>{{{unbound invite.user.days_visited}}}</span>
+                        <span title={{i18n 'user.invited.days_visited'}}>{{{invite.user.days_visited}}}</span>
                           /
-                        <span title={{i18n 'user.invited.account_age_days'}}>{{{unbound invite.user.days_since_created}}}</span>
+                        <span title={{i18n 'user.invited.account_age_days'}}>{{{invite.user.days_since_created}}}</span>
                       </td>
                     {{/if}}
                   {{else}}
-                    <td>{{unbound invite.email}}</td>
+                    <td>{{invite.email}}</td>
                     <td>{{format-date invite.updated_at}}</td>
                     <td>
                       {{#if invite.expired}}

--- a/app/assets/javascripts/discourse/templates/user/summary.hbs
+++ b/app/assets/javascripts/discourse/templates/user/summary.hbs
@@ -79,15 +79,15 @@
           {{#each model.links as |link|}}
             <li>
               <a class='domain'
-                 href={{unbound link.url}}
-                 title={{unbound link.title}}
+                 href={{link.url}}
+                 title={{link.title}}
                  rel='noopener {{unless user.removeNoFollow 'nofollow ugc'}}'
                  target='_blank'>
                 {{shorten-url link.url}}
               </a>
               <span class='badge badge-notification clicks' title='{{i18n 'topic_map.clicks' count=link.clicks}}'>{{number link.clicks}}</span>
               <br>
-              <a href="{{unbound link.post_url}}">{{{link.topic.fancyTitle}}}</a>
+              <a href="{{link.post_url}}">{{{link.topic.fancyTitle}}}</a>
             </li>
           {{/each}}
         </ul>

--- a/plugins/discourse-local-dates/assets/javascripts/discourse/templates/components/discourse-local-dates-create-form.hbs
+++ b/plugins/discourse-local-dates/assets/javascripts/discourse/templates/components/discourse-local-dates-create-form.hbs
@@ -55,7 +55,7 @@
         {{#if fromSelected}}
           <div class="time-pickers">
             {{d-icon "far-clock"}}
-            {{input maxlength=5 placeholder="hh:mm" input=(action "setTime") type="time" value=(unbound time) class="time-picker"}}
+            {{input maxlength=5 placeholder="hh:mm" input=(action "setTime") type="time" value=time class="time-picker"}}
           </div>
         {{/if}}
 
@@ -63,7 +63,7 @@
         {{#if toDate}}
           <div class="time-pickers">
             {{d-icon "far-clock"}}
-            {{input maxlength=5 placeholder="hh:mm" input=(action "setToTime") type="time" value=(unbound toTime) class="time-picker"}}
+            {{input maxlength=5 placeholder="hh:mm" input=(action "setToTime") type="time" value=toTime class="time-picker"}}
           </div>
         {{/if}}
         {{/if}}


### PR DESCRIPTION
From ember-template-lint documentation (https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/rule/no-unbound.md):

```
{{unbound}} is a legacy hold over from the days in which Ember's template engine was less performant. Its use today is vestigial, and it no longer offers performance benefits.

It is also a poor practice to use it for rendering only the initial value of a property that may later change.
```