### PR TITLE
FIX: Use `bio_excerpt` when checking for presence

### DIFF
--- a/app/assets/javascripts/discourse/components/user-card-contents.js.es6
+++ b/app/assets/javascripts/discourse/components/user-card-contents.js.es6
@@ -40,7 +40,7 @@ export default Component.extend(CardContentsBase, CanCheckEmails, CleansUp, {
   showDelete: and("viewingAdmin", "showName", "user.canBeDeleted"),
   linkWebsite: not("user.isBasic"),
   hasLocationOrWebsite: or("user.location", "user.website_name"),
-  isSuspendedOrHasBio: or("user.suspend_reason", "user.bio_cooked"),
+  isSuspendedOrHasBio: or("user.suspend_reason", "user.bio_excerpt"),
   showCheckEmail: and("user.staged", "canCheckEmails"),
 
   user: null,


### PR DESCRIPTION
When `enable_new_user_card_route` is enabled, only `bio_excerpt` is serialized for user cards. `bio_cooked` is only loaded on the main user route.