### PR TITLE
FIX: Error message for 403 when featuring topic on profile

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1362,7 +1362,7 @@ class UsersController < ApplicationController
     user = fetch_user_from_params
     topic = Topic.find(params[:topic_id].to_i)
 
-    if topic.nil? || !guardian.can_feature_topic?(user, topic)
+    if !guardian.can_feature_topic?(user, topic)
       return render_json_error(I18n.t('activerecord.errors.models.user_profile.attributes.featured_topic_id.invalid'), 403)
     end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1362,7 +1362,10 @@ class UsersController < ApplicationController
     user = fetch_user_from_params
     topic = Topic.find(params[:topic_id].to_i)
 
-    raise Discourse::InvalidAccess.new unless topic && guardian.can_feature_topic?(user, topic)
+    if !topic || !guardian.can_feature_topic?(user, topic)
+      return render_json_error(I18n.t('activerecord.errors.models.user_profile.attributes.featured_topic_id.invalid'), 403)
+    end
+
     user.user_profile.update(featured_topic_id: topic.id)
     render json: success_json
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1362,7 +1362,7 @@ class UsersController < ApplicationController
     user = fetch_user_from_params
     topic = Topic.find(params[:topic_id].to_i)
 
-    if !topic || !guardian.can_feature_topic?(user, topic)
+    if topic.nil? || !guardian.can_feature_topic?(user, topic)
       return render_json_error(I18n.t('activerecord.errors.models.user_profile.attributes.featured_topic_id.invalid'), 403)
     end
 

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -546,6 +546,10 @@ en:
               same_as_password: "is the same as your password."
             ip_address:
               signup_not_allowed: "Signup is not allowed from this account."
+        user_profile:
+          attributes:
+            featured_topic_id:
+              invalid: "This topic cannot be featured on your profile."
         user_email:
           attributes:
             user_id:

--- a/lib/guardian/user_guardian.rb
+++ b/lib/guardian/user_guardian.rb
@@ -129,6 +129,7 @@ module UserGuardian
   end
 
   def can_feature_topic?(user, topic)
+    return false if topic.nil?
     return false if !SiteSetting.allow_featured_topic_on_user_profiles?
     return false if !is_me?(user) && !is_staff?
     return false if !topic.visible


### PR DESCRIPTION
Problem described in [this meta topic](https://meta.discourse.org/t/can-t-set-featured-topic-in-profile-to-restricted-categories/143380?u=markvanlan)