### PR TITLE
DEV: enforces ember-template-lint: no-triple-curlies

### DIFF
--- a/.template-lintrc.js
+++ b/.template-lintrc.js
@@ -12,5 +12,6 @@ module.exports = {
     "no-unused-block-params": true,
     "no-unbound": true,
     "simple-unless": true
+    // "no-triple-curlies": true
   }
 };

--- a/.template-lintrc.js
+++ b/.template-lintrc.js
@@ -11,7 +11,7 @@ module.exports = {
     "no-unnecessary-concat": true,
     "no-unused-block-params": true,
     "no-unbound": true,
-    "simple-unless": true
-    // "no-triple-curlies": true
+    "simple-unless": true,
+    "no-triple-curlies": true
   }
 };

--- a/app/assets/javascripts/admin/templates/badges-award.hbs
+++ b/app/assets/javascripts/admin/templates/badges-award.hbs
@@ -9,11 +9,11 @@
           {{icon-or-image model}}
           <span class="badge-display-name">{{model.name}}</span>
         {{else}}
-          <span class='badge-placeholder'>{{I18n 'admin.badges.mass_award.no_badge_selected'}}</span>
+          <span class='badge-placeholder'>{{i18n 'admin.badges.mass_award.no_badge_selected'}}</span>
         {{/if}}
       </div>
       <div>
-        <h4>{{I18n 'admin.badges.mass_award.upload_csv'}}</h4>
+        <h4>{{i18n 'admin.badges.mass_award.upload_csv'}}</h4>
         <input type='file' id='massAwardCSVUpload' accept='.csv'>
       </div>
       <div>
@@ -34,6 +34,6 @@
       {{/link-to}}
     </form>
   {{else}}
-    <span class='badge-required'>{{I18n 'admin.badges.mass_award.no_badge_selected'}}</span>
+    <span class='badge-required'>{{i18n 'admin.badges.mass_award.no_badge_selected'}}</span>
   {{/if}}
 {{/d-section}}

--- a/app/assets/javascripts/admin/templates/badges-index.hbs
+++ b/app/assets/javascripts/admin/templates/badges-index.hbs
@@ -7,7 +7,7 @@
         {{#each badgeIntroLinks as |link|}}
           <a href={{link.href}} class="external-link" target="_blank" rel="noopener">
             {{d-icon link.icon}}
-            <span>{{I18n link.text}}</span>
+            <span>{{i18n link.text}}</span>
           </a>
         {{/each}}
       </div>

--- a/app/assets/javascripts/admin/templates/components/admin-report-storage-stats.hbs
+++ b/app/assets/javascripts/admin/templates/components/admin-report-storage-stats.hbs
@@ -15,7 +15,7 @@
 
       {{#if backupStats.last_backup_taken_at}}
         <br>
-        {{{i18n "admin.dashboard.lastest_backup" date=(format-date backupStats.last_backup_taken_at leaveAgo="true")}}}
+        {{i18n "admin.dashboard.lastest_backup" date=(format-date backupStats.last_backup_taken_at leaveAgo="true")}}
       {{/if}}
     </p>
   </div>

--- a/app/assets/javascripts/admin/templates/components/admin-report-table-cell.hbs
+++ b/app/assets/javascripts/admin/templates/components/admin-report-table-cell.hbs
@@ -1,1 +1,1 @@
-{{{formatedValue}}}
+{{html-safe formatedValue}}

--- a/app/assets/javascripts/admin/templates/components/admin-report.hbs
+++ b/app/assets/javascripts/admin/templates/components/admin-report.hbs
@@ -199,6 +199,6 @@
 {{/conditional-loading-section}}
 {{else}}
   <div class="alert alert-info">
-    {{{disabledLabel}}}
+    {{html-safe disabledLabel}}
   </div>
 {{/if}}

--- a/app/assets/javascripts/admin/templates/components/admin-user-field-item.hbs
+++ b/app/assets/javascripts/admin/templates/components/admin-user-field-item.hbs
@@ -46,7 +46,7 @@
     <div class="form-display">
       <strong>{{userField.name}}</strong>
       <br>
-      {{{userField.description}}}
+      {{html-safe userField.description}}
     </div>
     <div class="form-display">{{fieldName}}</div>
     <div class="form-element controls">

--- a/app/assets/javascripts/admin/templates/components/penalty-post-action.hbs
+++ b/app/assets/javascripts/admin/templates/components/penalty-post-action.hbs
@@ -1,7 +1,7 @@
 <div class='penalty-post-controls'>
   <label>
     <div class='penalty-post-label'>
-      {{{i18n 'admin.user.penalty_post_actions'}}}
+      {{i18n 'admin.user.penalty_post_actions'}}
     </div>
   </label>
   {{combo-box

--- a/app/assets/javascripts/admin/templates/components/silence-details.hbs
+++ b/app/assets/javascripts/admin/templates/components/silence-details.hbs
@@ -1,7 +1,7 @@
 <div class='reason-controls'>
   <label>
     <div class='silence-reason-label'>
-      {{{i18n 'admin.user.silence_reason_label'}}}
+      {{i18n 'admin.user.silence_reason_label'}}
     </div>
     </label>
     {{text-field

--- a/app/assets/javascripts/admin/templates/components/site-settings/bool.hbs
+++ b/app/assets/javascripts/admin/templates/components/site-settings/bool.hbs
@@ -1,5 +1,5 @@
 <label>
   {{input type="checkbox" checked=enabled}}
-  <span>{{{setting.description}}}</span>
+  <span>{{html-safe setting.description}}</span>
   {{setting-validation-message message=validationMessage}}
 </label>

--- a/app/assets/javascripts/admin/templates/components/site-settings/category-list.hbs
+++ b/app/assets/javascripts/admin/templates/components/site-settings/category-list.hbs
@@ -3,5 +3,5 @@
   onChange=(action "onChangeSelectedCategories")
 }}
 
-<div class='desc'>{{{setting.description}}}</div>
+<div class='desc'>{{html-safe setting.description}}</div>
 {{setting-validation-message message=validationMessage}}

--- a/app/assets/javascripts/admin/templates/components/site-settings/category.hbs
+++ b/app/assets/javascripts/admin/templates/components/site-settings/category.hbs
@@ -4,4 +4,4 @@
   onChange=(action (mut value))
 }}
 {{setting-validation-message message=validationMessage}}
-<div class='desc'>{{{setting.description}}}</div>
+<div class='desc'>{{html-safe setting.description}}</div>

--- a/app/assets/javascripts/admin/templates/components/site-settings/color.hbs
+++ b/app/assets/javascripts/admin/templates/components/site-settings/color.hbs
@@ -6,4 +6,4 @@
   onChangeColor=(action "onChangeColor")
 }}
 {{setting-validation-message message=validationMessage}}
-<div class="desc">{{{setting.description}}}</div>
+<div class="desc">{{html-safe setting.description}}</div>

--- a/app/assets/javascripts/admin/templates/components/site-settings/compact-list.hbs
+++ b/app/assets/javascripts/admin/templates/components/site-settings/compact-list.hbs
@@ -8,4 +8,4 @@
 }}
 
 {{setting-validation-message message=validationMessage}}
-<div class='desc'>{{{setting.description}}}</div>
+<div class='desc'>{{html-safe setting.description}}</div>

--- a/app/assets/javascripts/admin/templates/components/site-settings/enum.hbs
+++ b/app/assets/javascripts/admin/templates/components/site-settings/enum.hbs
@@ -15,5 +15,5 @@
 {{setting-validation-message message=validationMessage}}
 
 <div class='desc'>
-  {{{setting.description}}}
+  {{html-safe setting.description}}
 </div>

--- a/app/assets/javascripts/admin/templates/components/site-settings/group-list.hbs
+++ b/app/assets/javascripts/admin/templates/components/site-settings/group-list.hbs
@@ -7,4 +7,4 @@
   onChange=(action "onChangeGroupListSetting")
 }}
 {{setting-validation-message message=validationMessage}}
-<div class='desc'>{{{setting.description}}}</div>
+<div class='desc'>{{html-safe setting.description}}</div>

--- a/app/assets/javascripts/admin/templates/components/site-settings/host-list.hbs
+++ b/app/assets/javascripts/admin/templates/components/site-settings/host-list.hbs
@@ -1,3 +1,3 @@
 {{value-list values=value addKey="admin.site_settings.add_host"}}
 {{setting-validation-message message=validationMessage}}
-<div class='desc'>{{{setting.description}}}</div>
+<div class='desc'>{{html-safe setting.description}}</div>

--- a/app/assets/javascripts/admin/templates/components/site-settings/list.hbs
+++ b/app/assets/javascripts/admin/templates/components/site-settings/list.hbs
@@ -1,3 +1,3 @@
 {{value-list values=value inputDelimiter="|" choices=setting.choices}}
 {{setting-validation-message message=validationMessage}}
-<div class='desc'>{{{setting.description}}}</div>
+<div class='desc'>{{html-safe setting.description}}</div>

--- a/app/assets/javascripts/admin/templates/components/site-settings/secret-list.hbs
+++ b/app/assets/javascripts/admin/templates/components/site-settings/secret-list.hbs
@@ -1,3 +1,3 @@
 {{secret-value-list setting=setting values=value isSecret=isSecret}}
 {{setting-validation-message message=validationMessage}}
-<div class='desc'>{{{setting.description}}}</div>
+<div class='desc'>{{html-safe setting.description}}</div>

--- a/app/assets/javascripts/admin/templates/components/site-settings/string.hbs
+++ b/app/assets/javascripts/admin/templates/components/site-settings/string.hbs
@@ -7,4 +7,4 @@
 {{/if}}
 
 {{setting-validation-message message=validationMessage}}
-<div class='desc'>{{{setting.description}}}</div>
+<div class='desc'>{{html-safe setting.description}}</div>

--- a/app/assets/javascripts/admin/templates/components/site-settings/tag-list.hbs
+++ b/app/assets/javascripts/admin/templates/components/site-settings/tag-list.hbs
@@ -1,3 +1,3 @@
 {{tag-chooser tags=selectedTags}}
-<div class='desc'>{{{setting.description}}}</div>
+<div class='desc'>{{html-safe setting.description}}</div>
 {{setting-validation-message message=validationMessage}}

--- a/app/assets/javascripts/admin/templates/components/site-settings/upload.hbs
+++ b/app/assets/javascripts/admin/templates/components/site-settings/upload.hbs
@@ -1,2 +1,2 @@
 {{site-settings-image-uploader imageUrl=value placeholderUrl=setting.placeholder type="site_setting"}}
-<div class='desc'>{{{setting.description}}}</div>
+<div class='desc'>{{html-safe setting.description}}</div>

--- a/app/assets/javascripts/admin/templates/components/site-settings/uploaded-image-list.hbs
+++ b/app/assets/javascripts/admin/templates/components/site-settings/uploaded-image-list.hbs
@@ -1,2 +1,2 @@
 {{d-button label="admin.site_settings.uploaded_image_list.label" action=(action "showUploadModal") actionParam=(hash value=value setting=setting)}}
-<div class='desc'>{{{setting.description}}}</div>
+<div class='desc'>{{html-safe setting.description}}</div>

--- a/app/assets/javascripts/admin/templates/components/site-settings/url-list.hbs
+++ b/app/assets/javascripts/admin/templates/components/site-settings/url-list.hbs
@@ -1,3 +1,3 @@
 {{value-list values=value addKey="admin.site_settings.add_url"}}
 {{setting-validation-message message=validationMessage}}
-<div class='desc'>{{{setting.description}}}</div>
+<div class='desc'>{{html-safe setting.description}}</div>

--- a/app/assets/javascripts/admin/templates/components/site-settings/value-list.hbs
+++ b/app/assets/javascripts/admin/templates/components/site-settings/value-list.hbs
@@ -1,3 +1,3 @@
 {{value-list values=value}}
 {{setting-validation-message message=validationMessage}}
-<div class='desc'>{{{setting.description}}}</div>
+<div class='desc'>{{html-safe setting.description}}</div>

--- a/app/assets/javascripts/admin/templates/components/suspension-details.hbs
+++ b/app/assets/javascripts/admin/templates/components/suspension-details.hbs
@@ -2,9 +2,9 @@
   <label>
     <div class='suspend-reason-label'>
       {{#if siteSettings.hide_suspension_reasons}}
-        {{{i18n 'admin.user.suspend_reason_hidden_label'}}}
+        {{i18n 'admin.user.suspend_reason_hidden_label'}}
       {{else}}
-        {{{i18n 'admin.user.suspend_reason_label'}}}
+        {{i18n 'admin.user.suspend_reason_label'}}
       {{/if}}
     </div>
   </label>

--- a/app/assets/javascripts/admin/templates/components/themes-list-item.hbs
+++ b/app/assets/javascripts/admin/templates/components/themes-list-item.hbs
@@ -28,14 +28,14 @@
 
   {{#if displayComponents}}
     <div class="components-list">
-      <span class="components">{{{childrenString}}}</span>
+      <span class="components">{{html-safe childrenString}}</span>
 
       {{#if displayHasMore}}
         <a href {{action "toggleChildrenExpanded"}} class="others-count">
           {{#if childrenExpanded}}
-            {{I18n "admin.customize.theme.collapse"}}
+            {{i18n "admin.customize.theme.collapse"}}
           {{else}}
-            {{I18n "admin.customize.theme.and_x_more" count=moreCount}}
+            {{i18n "admin.customize.theme.and_x_more" count=moreCount}}
           {{/if}}
         </a>
       {{/if}}

--- a/app/assets/javascripts/admin/templates/components/themes-list.hbs
+++ b/app/assets/javascripts/admin/templates/components/themes-list.hbs
@@ -25,9 +25,9 @@
         <div class="themes-list-item inactive-indicator">
           <span class="empty">
             {{#if themesTabActive}}
-              {{I18n "admin.customize.theme.inactive_themes"}}
+              {{i18n "admin.customize.theme.inactive_themes"}}
             {{else}}
-              {{I18n "admin.customize.theme.inactive_components"}}
+              {{i18n "admin.customize.theme.inactive_components"}}
             {{/if}}
           </span>
         </div>
@@ -41,7 +41,7 @@
     {{/if}}
   {{else}}
     <div class="themes-list-item">
-      <span class="empty">{{I18n "admin.customize.theme.empty"}}</span>
+      <span class="empty">{{i18n "admin.customize.theme.empty"}}</span>
     </div>
   {{/if}}
 

--- a/app/assets/javascripts/admin/templates/customize-themes-index.hbs
+++ b/app/assets/javascripts/admin/templates/customize-themes-index.hbs
@@ -1,7 +1,7 @@
 <div class="themes-intro admin-intro">
   <img src={{womanArtistEmojiURL}}>
   <div class="content-wrapper">
-    <h1>{{I18n "admin.customize.theme.themes_intro"}}</h1>
+    <h1>{{i18n "admin.customize.theme.themes_intro"}}</h1>
      <div class="create-actions">
       {{d-button action=(route-action "installModal") icon="upload" label="admin.customize.install" class="btn-primary"}}
     </div>
@@ -9,7 +9,7 @@
       {{#each externalResources as |resource|}}
         <a href={{resource.link}} class="external-link" rel="noopener" target="_blank">
           {{d-icon resource.icon}}
-          {{I18n resource.key}}
+          {{i18n resource.key}}
         </a>
       {{/each}}
     </div>

--- a/app/assets/javascripts/admin/templates/customize-themes-show.hbs
+++ b/app/assets/javascripts/admin/templates/customize-themes-show.hbs
@@ -89,7 +89,7 @@
 
         {{#if showRemoteError}}
           <div class="error-message">
-            {{d-icon "exclamation-triangle"}} {{I18n "admin.customize.theme.repo_unreachable"}}
+            {{d-icon "exclamation-triangle"}} {{i18n "admin.customize.theme.repo_unreachable"}}
           </div>
           <div class="raw-error">
             <code>{{model.remoteError}}</code>

--- a/app/assets/javascripts/admin/templates/dashboard-problems.hbs
+++ b/app/assets/javascripts/admin/templates/dashboard-problems.hbs
@@ -12,7 +12,7 @@
         <div class="problem-messages">
           <ul>
             {{#each problems as |problem|}}
-              <li>{{{problem}}}</li>
+              <li>{{html-safe problem}}</li>
             {{/each}}
           </ul>
         </div>

--- a/app/assets/javascripts/admin/templates/dashboard_general.hbs
+++ b/app/assets/javascripts/admin/templates/dashboard_general.hbs
@@ -142,7 +142,7 @@
         filters=trendingSearchFilters
         isEnabled=logSearchQueriesEnabled
         disabledLabel=trendingSearchDisabledLabel}}
-      {{{i18n "admin.dashboard.reports.trending_search.more" basePath=basePath}}}
+      {{i18n "admin.dashboard.reports.trending_search.more" basePath=basePath}}
     </div>
   </div>
 

--- a/app/assets/javascripts/admin/templates/email-advanced-test.hbs
+++ b/app/assets/javascripts/admin/templates/email-advanced-test.hbs
@@ -14,13 +14,13 @@
   <hr>
   <div class="text">
     <h3>{{i18n 'admin.email.advanced_test.text'}}</h3>
-    <pre class="full-reason">{{{text}}}</pre>
+    <pre class="full-reason">{{html-safe text}}</pre>
   </div>
 
   <hr>
   <div class="elided">
     <h3>{{i18n 'admin.email.advanced_test.elided'}}</h3>
-    <pre class="full-reason">{{{elided}}}</pre>
+    <pre class="full-reason">{{html-safe elided}}</pre>
   </div>
 {{/if}}
 

--- a/app/assets/javascripts/admin/templates/email-preview-digest.hbs
+++ b/app/assets/javascripts/admin/templates/email-preview-digest.hbs
@@ -53,7 +53,7 @@
           <iframe srcdoc={{model.html_content}} />
         {{/if}}
       {{else}}
-        <pre>{{{model.text_content}}}</pre>
+        <pre>{{html-safe model.text_content}}</pre>
       {{/if}}
     </div>
   </div>

--- a/app/assets/javascripts/admin/templates/embedding.hbs
+++ b/app/assets/javascripts/admin/templates/embedding.hbs
@@ -23,7 +23,7 @@
 
 {{#if showSecondary}}
   <div class='embedding-secondary'>
-    <p>{{{i18n "admin.embedding.sample"}}}</p>
+    <p>{{i18n "admin.embedding.sample"}}</p>
     {{highlighted-code code=embeddingCode lang="html"}}
   </div>
 

--- a/app/assets/javascripts/admin/templates/logs/staff-action-logs.hbs
+++ b/app/assets/javascripts/admin/templates/logs/staff-action-logs.hbs
@@ -88,7 +88,7 @@
               <td class="col value created-at">{{age-with-tooltip item.created_at}}</td>
               <td class="col value details">
                 <div>
-                  {{{item.formattedDetails}}}
+                  {{html-safe item.formattedDetails}}
                   {{#if item.useCustomModalForDetails}}
                     <a href {{action "showCustomDetailsModal" item}}>{{d-icon "info-circle"}} {{i18n 'admin.logs.staff_actions.show'}}</a>
                   {{/if}}

--- a/app/assets/javascripts/admin/templates/modal/admin-badge-preview.hbs
+++ b/app/assets/javascripts/admin/templates/modal/admin-badge-preview.hbs
@@ -17,9 +17,9 @@
   {{else}}
     <p class="grant-count">
       {{#if count}}
-        {{{i18n "admin.badges.preview.grant_count" count=count}}}
+        {{i18n "admin.badges.preview.grant_count" count=count}}
       {{else}}
-        {{{i18n "admin.badges.preview.no_grant_count"}}}
+        {{i18n "admin.badges.preview.no_grant_count"}}
       {{/if}}
     </p>
 
@@ -41,14 +41,14 @@
       </p>
       <ul>
         {{#each processedSample as |html|}}
-          <li>{{{html}}}</li>
+          <li>{{html-safe html}}</li>
         {{/each}}
       </ul>
     {{/if}}
 
     {{#if hasQueryPlan}}
       <div class="badge-query-plan">
-        {{{queryPlanHtml}}}
+        {{html-safe queryPlanHtml}}
       </div>
     {{/if}}
   {{/if}}

--- a/app/assets/javascripts/admin/templates/modal/admin-install-theme.hbs
+++ b/app/assets/javascripts/admin/templates/modal/admin-install-theme.hbs
@@ -24,7 +24,7 @@
 
             <div class="popular-theme-buttons">
               {{#if theme.installed}}
-                <span>{{I18n "admin.customize.theme.installed"}}</span>
+                <span>{{i18n "admin.customize.theme.installed"}}</span>
               {{else}}
                 {{d-button class='btn-small'
                   label="admin.customize.theme.install"
@@ -33,7 +33,7 @@
                   action=(action "installThemeFromList" theme.value)}}
 
                 {{#if theme.preview}}
-                  <a href={{theme.preview}} rel="noopener" target="_blank">{{d-icon "desktop"}} {{I18n "admin.customize.theme.preview"}}</a>
+                  <a href={{theme.preview}} rel="noopener" target="_blank">{{d-icon "desktop"}} {{i18n "admin.customize.theme.preview"}}</a>
                 {{/if}}
               {{/if}}
             </div>
@@ -85,10 +85,10 @@
 
     {{#if create}}
       <div class="inputs">
-        <div class="label">{{I18n "admin.customize.theme.create_name"}}</div>
+        <div class="label">{{i18n "admin.customize.theme.create_name"}}</div>
         {{input value=name placeholder=placeholder}}
 
-        <div class="label">{{I18n "admin.customize.theme.create_type"}}</div>
+        <div class="label">{{i18n "admin.customize.theme.create_type"}}</div>
         {{combo-box
           valueProperty="value"
           content=createTypes

--- a/app/assets/javascripts/admin/templates/modal/admin-theme-change.hbs
+++ b/app/assets/javascripts/admin/templates/modal/admin-theme-change.hbs
@@ -1,6 +1,6 @@
 <div>
   {{#d-modal-body title="admin.logs.staff_actions.modal_title"}}
-    {{{diff}}}
+    {{html-safe diff}}
   {{/d-modal-body}}
   <div class="modal-footer">
     {{d-button

--- a/app/assets/javascripts/admin/templates/modal/admin-theme-item.hbs
+++ b/app/assets/javascripts/admin/templates/modal/admin-theme-item.hbs
@@ -7,7 +7,7 @@
   </div>
   <div class="popular-theme-buttons">
     {{#if theme.installed}}
-      <span>{{I18n "admin.customize.theme.installed"}}</span>
+      <span>{{i18n "admin.customize.theme.installed"}}</span>
     {{else}}
       {{d-button class='btn-small'
         label="admin.customize.theme.install"

--- a/app/assets/javascripts/admin/templates/search-logs-term.hbs
+++ b/app/assets/javascripts/admin/templates/search-logs-term.hbs
@@ -31,7 +31,7 @@
       <div class='fps-topic'>
         <div class='topic'>
           <a class='search-link' href={{result.url}}>
-            {{topic-status topic=result.topic disableActions=true}}<span class='topic-title'>{{#highlight-text highlight=term}}{{{result.topic.fancyTitle}}}{{/highlight-text}}</span>
+            {{topic-status topic=result.topic disableActions=true}}<span class='topic-title'>{{#highlight-text highlight=term}}{{html-safe result.topic.fancyTitle}}{{/highlight-text}}</span>
           </a>
 
           <div class='search-category'>
@@ -55,7 +55,7 @@
 
           {{#if result.blurb}}
             {{#highlight-text highlight=term}}
-              {{{result.blurb}}}
+              {{html-safe result.blurb}}
             {{/highlight-text}}
           {{/if}}
         </div>

--- a/app/assets/javascripts/admin/templates/user-index.hbs
+++ b/app/assets/javascripts/admin/templates/user-index.hbs
@@ -132,7 +132,7 @@
     <div class="field">{{i18n "user.avatar.title"}}</div>
     <div class="value">{{avatar model imageSize="large"}}</div>
     <div class="controls">
-      {{{i18n "admin.user.visit_profile" url=preferencesPath}}}
+      {{i18n "admin.user.visit_profile" url=preferencesPath}}
     </div>
   </div>
 
@@ -509,7 +509,7 @@
     <h1>{{i18n "admin.groups.title"}}</h1>
       <div class="display-row">
         <div class="field">{{i18n "admin.groups.automatic"}}</div>
-        <div class="value">{{{automaticGroups}}}</div>
+        <div class="value">{{html-safe automaticGroups}}</div>
       </div>
       <div class="display-row">
         <div class="field">{{i18n "admin.groups.custom"}}</div>
@@ -616,11 +616,11 @@
   </div>
   <div class="display-row">
     <div class="field">{{i18n "admin.user.time_read"}}</div>
-    <div class="value">{{{format-duration model.time_read}}}</div>
+    <div class="value">{{format-duration model.time_read}}</div>
   </div>
   <div class="display-row">
     <div class="field">{{i18n "user.invited.days_visited"}}</div>
-    <div class="value">{{{model.days_visited}}}</div>
+    <div class="value">{{html-safe model.days_visited}}</div>
   </div>
 </section>
 

--- a/app/assets/javascripts/admin/templates/users-list-show.hbs
+++ b/app/assets/javascripts/admin/templates/users-list-show.hbs
@@ -53,11 +53,11 @@
             </td>
             <td class="last-emailed">
               <div class="label">{{i18n 'admin.users.last_emailed'}}</div>
-              <div>{{{format-duration user.last_emailed_age}}}</div>
+              <div>{{format-duration user.last_emailed_age}}</div>
             </td>
             <td class="last-seen">
               <div class="label">{{i18n 'last_seen'}}</div>
-              <div>{{{format-duration user.last_seen_age}}}</div>
+              <div>{{format-duration user.last_seen_age}}</div>
             </td>
             <td class="topics-entered">
               <div class="label">{{i18n 'admin.user.topics_entered'}}</div>
@@ -69,12 +69,12 @@
             </td>
             <td class="time-read">
               <div class="label">{{i18n 'admin.user.time_read'}}</div>
-              <div>{{{format-duration user.time_read}}}</div>
+              <div>{{format-duration user.time_read}}</div>
             </td>
 
             <td class="created">
               <div class="label">{{i18n 'created'}}</div>
-              <div>{{{format-duration user.created_at_age}}}</div>
+              <div>{{format-duration user.created_at_age}}</div>
             </td>
 
             {{#if siteSettings.must_approve_users}}

--- a/app/assets/javascripts/discourse-common/helpers/html-safe.js.es6
+++ b/app/assets/javascripts/discourse-common/helpers/html-safe.js.es6
@@ -1,0 +1,6 @@
+import { registerUnbound } from "discourse-common/lib/helpers";
+import { htmlSafe } from "@ember/template";
+
+registerUnbound("html-safe", function(string) {
+  return htmlSafe(string);
+});

--- a/app/assets/javascripts/discourse-common/helpers/i18n.js.es6
+++ b/app/assets/javascripts/discourse-common/helpers/i18n.js.es6
@@ -1,6 +1,7 @@
 import { registerUnbound } from "discourse-common/lib/helpers";
+import { htmlSafe } from "@ember/template";
 
-registerUnbound("i18n", (key, params) => I18n.t(key, params));
+registerUnbound("i18n", (key, params) => htmlSafe(I18n.t(key, params)));
 registerUnbound("i18n-yes-no", (value, params) =>
   I18n.t(value ? "yes_value" : "no_value", params)
 );

--- a/app/assets/javascripts/discourse/components/text-overflow.js.es6
+++ b/app/assets/javascripts/discourse/components/text-overflow.js.es6
@@ -1,8 +1,19 @@
 import { next } from "@ember/runloop";
+import { htmlSafe } from "@ember/template";
 import Component from "@ember/component";
+
 export default Component.extend({
+  text: null,
+
+  init() {
+    this._super(...arguments);
+
+    this.set("text", htmlSafe(this.text));
+  },
+
   didInsertElement() {
     this._super(...arguments);
+
     next(null, () => {
       const $this = $(this.element);
 

--- a/app/assets/javascripts/discourse/helpers/application.js.es6
+++ b/app/assets/javascripts/discourse/helpers/application.js.es6
@@ -4,14 +4,12 @@ import {
   autoUpdatingRelativeAge,
   number
 } from "discourse/lib/formatter";
+import { htmlSafe } from "@ember/template";
 
-const safe = Handlebars.SafeString;
+registerUnbound("raw-date", dt => htmlSafe(longDate(new Date(dt))));
 
-registerUnbound("raw-date", dt => longDate(new Date(dt)));
-
-registerUnbound(
-  "age-with-tooltip",
-  dt => new safe(autoUpdatingRelativeAge(new Date(dt), { title: true }))
+registerUnbound("age-with-tooltip", dt =>
+  htmlSafe(autoUpdatingRelativeAge(new Date(dt), { title: true }))
 );
 
 registerUnbound("number", (orig, params) => {
@@ -48,5 +46,5 @@ registerUnbound("number", (orig, params) => {
 
   result += ">" + n + "</span>";
 
-  return new safe(result);
+  return htmlSafe(result);
 });

--- a/app/assets/javascripts/discourse/helpers/dir-span.js.es6
+++ b/app/assets/javascripts/discourse/helpers/dir-span.js.es6
@@ -1,5 +1,6 @@
 import { registerUnbound } from "discourse-common/lib/helpers";
 import { isRTL } from "discourse/lib/text-direction";
+import { htmlSafe } from "@ember/template";
 
 function setDir(text) {
   let content = text ? text : "";
@@ -11,5 +12,5 @@ function setDir(text) {
 }
 
 export default registerUnbound("dir-span", function(str) {
-  return new Handlebars.SafeString(setDir(str));
+  return htmlSafe(setDir(str));
 });

--- a/app/assets/javascripts/discourse/helpers/format-age.js.es6
+++ b/app/assets/javascripts/discourse/helpers/format-age.js.es6
@@ -1,11 +1,12 @@
 import { autoUpdatingRelativeAge, durationTiny } from "discourse/lib/formatter";
 import { registerUnbound } from "discourse-common/lib/helpers";
+import { htmlSafe } from "@ember/template";
 
 registerUnbound("format-age", function(dt) {
   dt = new Date(dt);
-  return new Handlebars.SafeString(autoUpdatingRelativeAge(dt));
+  return htmlSafe(autoUpdatingRelativeAge(dt));
 });
 
 registerUnbound("format-duration", function(seconds) {
-  return new Handlebars.SafeString(durationTiny(seconds));
+  return htmlSafe(durationTiny(seconds));
 });

--- a/app/assets/javascripts/discourse/lib/computed.js.es6
+++ b/app/assets/javascripts/discourse/lib/computed.js.es6
@@ -1,5 +1,6 @@
 import { computed } from "@ember/object";
 import addonFmt from "ember-addons/fmt";
+import { htmlSafe as htmlSafeTemplateHelper } from "@ember/template";
 
 /**
   Returns whether two properties are equal to each other.
@@ -54,6 +55,21 @@ export function i18n(...args) {
   const format = args.pop();
   return computed(...args, function() {
     return I18n.t(addonFmt(format, ...args.map(a => this.get(a))));
+  });
+}
+/**
+  Returns htmlSafe version of a string.
+
+  @method htmlSafe
+  @params {String} properties* to htmlify
+  @return {Function} discourseComputedProperty function
+**/
+export function htmlSafe(...args) {
+  return computed(...args, {
+    get() {
+      const path = args.pop();
+      return htmlSafeTemplateHelper(this.get(path));
+    }
   });
 }
 

--- a/app/assets/javascripts/discourse/templates/about.hbs
+++ b/app/assets/javascripts/discourse/templates/about.hbs
@@ -112,7 +112,7 @@
       {{#if contactInfo}}
         <section class='about contact'>
             <h3>{{d-icon "far-envelope"}} {{i18n 'about.contact'}}</h3>
-            <p>{{{contactInfo}}}</p>
+            <p>{{html-safe contactInfo}}</p>
         </section>
       {{/if}}
 

--- a/app/assets/javascripts/discourse/templates/account-created/index.hbs
+++ b/app/assets/javascripts/discourse/templates/account-created/index.hbs
@@ -1,5 +1,5 @@
 <div class='ac-message'>
-  {{{accountCreated.message}}}
+  {{html-safe accountCreated.message}}
 </div>
 {{#if accountCreated.show_controls}}
   {{activation-controls sendActivationEmail=(action "sendActivationEmail")

--- a/app/assets/javascripts/discourse/templates/account-created/resent.hbs
+++ b/app/assets/javascripts/discourse/templates/account-created/resent.hbs
@@ -1,6 +1,6 @@
 <div class='ac-message'>
   {{#if email}}
-    {{{i18n 'login.sent_activation_email_again' currentEmail=email}}}
+    {{i18n 'login.sent_activation_email_again' currentEmail=email}}
   {{else}}
     {{i18n 'login.sent_activation_email_again_generic'}}
   {{/if}}

--- a/app/assets/javascripts/discourse/templates/badges/show.hbs
+++ b/app/assets/javascripts/discourse/templates/badges/show.hbs
@@ -42,7 +42,7 @@
           {{#user-info user=ub.user size="medium" class="badge-info" date=ub.granted_at}}
             <div class="granted-on">{{i18n 'badges.granted_on' date=(inline-date ub.granted_at)}}</div>
             {{#if ub.post_number}}
-              <a class="post-link" href="{{ub.topic.url}}/{{ub.post_number}}">{{{ub.topic.fancyTitle}}}</a>
+              <a class="post-link" href="{{ub.topic.url}}/{{ub.post_number}}">{{html-safe ub.topic.fancyTitle}}</a>
             {{/if}}
           {{/user-info}}
         {{/each}}

--- a/app/assets/javascripts/discourse/templates/components/about-page-users.hbs
+++ b/app/assets/javascripts/discourse/templates/components/about-page-users.hbs
@@ -3,7 +3,7 @@
     <div class="user-image">
       <div class="user-image-inner">
         <a href={{userTemplate.userPath}} data-user-card={{userTemplate.username}}>
-          {{{userTemplate.avatar}}}
+          {{html-safe userTemplate.avatar}}
         </a>
       </div>
     </div>

--- a/app/assets/javascripts/discourse/templates/components/badge-card.hbs
+++ b/app/assets/javascripts/discourse/templates/components/badge-card.hbs
@@ -11,7 +11,7 @@
   <div class='badge-info'>
     <div class='badge-info-item'>
       <h3><a href={{url}} class='badge-link'>{{badge.name}}</a></h3>
-      <div class='badge-summary'>{{{summary}}}</div>
+      <div class='badge-summary'>{{html-safe summary}}</div>
     </div>
   </div>
 </div>

--- a/app/assets/javascripts/discourse/templates/components/categories-boxes.hbs
+++ b/app/assets/javascripts/discourse/templates/components/categories-boxes.hbs
@@ -24,7 +24,7 @@
         </div>
 
         <div class='description'>
-          {{{text-overflow class="overflow" text=c.description_excerpt}}}
+          {{text-overflow class="overflow" text=c.description_excerpt}}
         </div>
         {{#if c.isGrandParent}}
           {{#each c.subcategories as |subcategory|}}

--- a/app/assets/javascripts/discourse/templates/components/categories-only.hbs
+++ b/app/assets/javascripts/discourse/templates/components/categories-only.hbs
@@ -16,7 +16,7 @@
             {{category-title-link category=c}}
             {{#if c.description_excerpt}}
               <div class="category-description">
-                {{{dir-span c.description_excerpt}}}
+                {{dir-span c.description_excerpt}}
               </div>
             {{/if}}
             {{#if c.isGrandParent}}
@@ -28,7 +28,7 @@
                         {{category-title-link tagName="h4" category=subcategory}}
                         {{#if subcategory.description_excerpt}}
                           <div class="category-description subcategory-description">
-                            {{{dir-span subcategory.description_excerpt}}}
+                            {{dir-span subcategory.description_excerpt}}
                           </div>
                         {{/if}}
                         {{#if subcategory.subcategories}}
@@ -45,7 +45,7 @@
                         {{else}}
                           {{#if subcategory.description_excerpt}}
                             <div class="category-description subcategory-description">
-                              {{{dir-span subcategory.description_excerpt}}}
+                              {{dir-span subcategory.description_excerpt}}
                             </div>
                           {{/if}}
                         {{/if}}
@@ -69,7 +69,7 @@
             {{/if}}
           </td>
           <td class="topics">
-            <div title={{c.statTitle}}>{{{c.stat}}}</div>
+            <div title={{c.statTitle}}>{{html-safe c.stat}}</div>
             {{category-unread category=c tagName="div" class="unread-new"}}
           </td>
           {{#if showTopics}}

--- a/app/assets/javascripts/discourse/templates/components/d-button.hbs
+++ b/app/assets/javascripts/discourse/templates/components/d-button.hbs
@@ -3,7 +3,7 @@
 {{/if}}
 
 {{#if translatedLabel}}
-  <span class='d-button-label'>{{{translatedLabel}}}{{#if ellipsis}}&hellip;{{/if}}</span>
+  <span class='d-button-label'>{{html-safe translatedLabel}}{{#if ellipsis}}&hellip;{{/if}}</span>
 {{/if}}
 
 {{yield}}

--- a/app/assets/javascripts/discourse/templates/components/d-editor.hbs
+++ b/app/assets/javascripts/discourse/templates/components/d-editor.hbs
@@ -46,7 +46,7 @@
   </div>
 
   <div class="d-editor-preview-wrapper {{if forcePreview 'force-preview'}}">
-    <div class="d-editor-preview">{{{preview}}}</div>
+    <div class="d-editor-preview">{{html-safe preview}}</div>
     {{plugin-outlet name="editor-preview" classNames="d-editor-plugin" args=outletArgs}}
   </div>
 </div>

--- a/app/assets/javascripts/discourse/templates/components/discourse-banner.hbs
+++ b/app/assets/javascripts/discourse/templates/components/discourse-banner.hbs
@@ -3,9 +3,9 @@
     <div id="banner" class={{overlay}}>
       {{d-button icon="times" action="dismiss" class="btn btn-flat close" title="banner.close"}}
       <div id="banner-content">
-        {{{content}}}
+        {{html-safe content}}
         {{#if currentUser.staff}}
-          <p><a href={{banner.url}}>{{{i18n "banner.edit"}}}</a></p>
+          <p><a href={{banner.url}}>{{i18n "banner.edit"}}</a></p>
         {{/if}}
       </div>
     </div>

--- a/app/assets/javascripts/discourse/templates/components/discourse-linked-text.hbs
+++ b/app/assets/javascripts/discourse/templates/components/discourse-linked-text.hbs
@@ -1,1 +1,1 @@
-{{{translatedText}}}
+{{html-safe translatedText}}

--- a/app/assets/javascripts/discourse/templates/components/edit-category-general.hbs
+++ b/app/assets/javascripts/discourse/templates/components/edit-category-general.hbs
@@ -1,7 +1,7 @@
 {{#if category.isUncategorizedCategory}}
   <p class="warning">
     {{d-icon "exclamation-triangle"}}
-    {{{i18n 'category.uncategorized_general_warning' settingLink=uncategorizedSiteSettingLink customizeLink=customizeTextContentLink}}}
+    {{i18n 'category.uncategorized_general_warning' settingLink=uncategorizedSiteSettingLink customizeLink=customizeTextContentLink}}
   </p>
 {{/if}}
 
@@ -36,7 +36,7 @@
     <section class='field'>
       <label>{{i18n 'category.description'}}</label>
       {{#if category.description}}
-        {{{category.description}}}
+        {{html-safe category.description}}
       {{else}}
         {{i18n 'category.no_description'}}
       {{/if}}
@@ -51,7 +51,7 @@
     <section class='field'>
       <label>{{i18n 'category.badge_colors'}}</label>
       <div class="category-color-editor">
-        {{{categoryBadgePreview}}}
+        {{html-safe categoryBadgePreview}}
 
         <div class='input-prepend input-append' style="margin-top: 10px;">
           <span class='color-title'>{{i18n 'category.background_color'}}:</span>

--- a/app/assets/javascripts/discourse/templates/components/edit-category-security.hbs
+++ b/app/assets/javascripts/discourse/templates/components/edit-category-security.hbs
@@ -11,7 +11,7 @@
       {{#each category.permissions as |p|}}
         <li>
           <span class="name"><span class="badge-group">{{p.group_name}}</span></span>
-          {{{i18n "category.can"}}}
+          {{i18n "category.can"}}
           <span class="permission">{{p.permission.description}}</span>
           {{#if editingPermissions}}
             <a class="remove-permission" href {{action "removePermission" p}}>{{d-icon "times-circle"}}</a>

--- a/app/assets/javascripts/discourse/templates/components/featured-topic.hbs
+++ b/app/assets/javascripts/discourse/templates/components/featured-topic.hbs
@@ -1,10 +1,10 @@
 {{raw "topic-status" topic=topic}}
-<a class='title' href={{topic.lastUnreadUrl}}>{{{topic.fancyTitle}}}</a>
+<a class='title' href={{topic.lastUnreadUrl}}>{{html-safe topic.fancyTitle}}</a>
 {{topic-post-badges newPosts=topic.totalUnread unseen=topic.unseen url=topic.lastUnreadUrl}}
 
 {{#if latestTopicOnly}}
   <div class='last-user-info'>
-    {{i18n 'categories.latest_by'}} <a href={{{topic.lastPosterUrl}}}>{{topic.last_poster.username}}</a>
+    {{i18n 'categories.latest_by'}} <a href={{html-safe topic.lastPosterUrl}}>{{topic.last_poster.username}}</a>
     <a href={{topic.lastPostUrl}}>{{format-age topic.last_posted_at}}</a>
   </div>
 {{else}}

--- a/app/assets/javascripts/discourse/templates/components/flag-action-type.hbs
+++ b/app/assets/javascripts/discourse/templates/components/flag-action-type.hbs
@@ -5,7 +5,7 @@
       <input type='radio' id="radio_{{flag.name_key}}" {{action "changePostActionType" flag}} name='post_action_type_index'>
 
       <div class='flag-action-type-details'>
-        <span class='description'>{{{flag.description}}}</span>
+        <span class='description'>{{html-safe flag.description}}</span>
         {{#if showMessageInput}}
           {{textarea name="message" class="flag-message" placeholder=customPlaceholder value=message}}
           <div class="custom-message-length {{customMessageLengthClasses}}">{{customMessageLength}}</div>
@@ -24,7 +24,7 @@
       <div class='flag-action-type-details'>
         <strong>{{formattedName}}</strong>
         {{#if showDescription}}
-          <div class='description'>{{{description}}}</div>
+          <div class='description'>{{html-safe description}}</div>
         {{/if}}
         {{#if showMessageInput}}
           {{textarea name="message" class="flag-message" placeholder=customPlaceholder value=message}}

--- a/app/assets/javascripts/discourse/templates/components/footer-message.hbs
+++ b/app/assets/javascripts/discourse/templates/components/footer-message.hbs
@@ -1,4 +1,4 @@
-{{#if education}}<div class="education">{{{education}}}</div>{{/if}}
+{{#if education}}<div class="education">{{html-safe education}}</div>{{/if}}
 <h3>
   {{message}}
   {{yield}}

--- a/app/assets/javascripts/discourse/templates/components/global-notice.hbs
+++ b/app/assets/javascripts/discourse/templates/components/global-notice.hbs
@@ -2,9 +2,9 @@
   <div class="row">
     <div id="global-notice-{{notice.id}}" class="alert alert-{{notice.options.level}} {{notice.id}}">
       {{#if notice.options.html}}
-        {{{notice.options.html}}}
+        {{html-safe notice.options.html}}
       {{/if}}
-      <span class="text">{{{notice.text}}}</span>
+      <span class="text">{{html-safe notice.text}}</span>
 
       {{#if notice.options.dismissable}}
         {{d-button

--- a/app/assets/javascripts/discourse/templates/components/group-card-contents.hbs
+++ b/app/assets/javascripts/discourse/templates/components/group-card-contents.hbs
@@ -43,7 +43,7 @@
 
     {{#if group.bio_cooked}}
       <div class="card-row second-row">
-        <div class='bio'>{{{group.bio_cooked}}}</div>
+        <div class='bio'>{{html-safe group.bio_cooked}}</div>
       </div>
     {{/if}}
 

--- a/app/assets/javascripts/discourse/templates/components/group-post.hbs
+++ b/app/assets/javascripts/discourse/templates/components/group-post.hbs
@@ -8,7 +8,7 @@
   <div class='stream-topic-details'>
       <div class='stream-topic-title'>
         <span class='title'>
-          <a href={{postUrl}}>{{{post.topic.fancyTitle}}}</a>
+          <a href={{postUrl}}>{{html-safe post.topic.fancyTitle}}</a>
         </span>
       </div>
       <div class="group-post-category">{{category-link post.category}}</div>
@@ -24,8 +24,8 @@
 
 <div class='excerpt'>
   {{#if post.expandedExcerpt}}
-    {{{post.expandedExcerpt}}}
+    {{html-safe post.expandedExcerpt}}
   {{else}}
-    {{{post.excerpt}}}
+    {{html-safe post.excerpt}}
   {{/if}}
 </div>

--- a/app/assets/javascripts/discourse/templates/components/invite-panel.hbs
+++ b/app/assets/javascripts/discourse/templates/components/invite-panel.hbs
@@ -1,6 +1,6 @@
 {{#if inviteModel.error}}
   <div class="alert alert-error">
-    {{{errorMessage}}}
+    {{html-safe errorMessage}}
   </div>
 {{/if}}
 
@@ -10,7 +10,7 @@
       {{generated-invite-link link=inviteModel.inviteLink email=emailOrUsername}}
     {{else}}
       <div class="success-message">
-        {{{successMessage}}}
+        {{html-safe successMessage}}
       </div>
     {{/if}}
   {{else}}

--- a/app/assets/javascripts/discourse/templates/components/ip-lookup.hbs
+++ b/app/assets/javascripts/discourse/templates/components/ip-lookup.hbs
@@ -14,7 +14,7 @@
       {{d-button action=(action "copy") class="pull-right no-text" icon="copy"}}
     {{/if}}
     <h4>{{i18n "ip_lookup.title"}}</h4>
-    <p class='powered-by'>{{{i18n "ip_lookup.powered_by"}}}</p>
+    <p class='powered-by'>{{i18n "ip_lookup.powered_by"}}</p>
     <dl>
       {{#if location}}
         {{#if location.hostname}}

--- a/app/assets/javascripts/discourse/templates/components/mobile-category-topic.hbs
+++ b/app/assets/javascripts/discourse/templates/components/mobile-category-topic.hbs
@@ -5,7 +5,7 @@
     {{#if topic.unseen}}
       <span class="badge-notification new-topic"></span>
     {{/if}}
-    <span class={{cold-age-class topic.last_posted_at}} title={{raw-date topic.last_posted_at}}>{{{format-age topic.last_posted_at}}}</span>
+    <span class={{cold-age-class topic.last_posted_at}} title={{raw-date topic.last_posted_at}}>{{format-age topic.last_posted_at}}</span>
   </div>
 </td>
 <td class='num posts'>{{raw "list/post-count-or-badges" topic=topic postBadgesEnabled="true"}}</td>

--- a/app/assets/javascripts/discourse/templates/components/related-messages.hbs
+++ b/app/assets/javascripts/discourse/templates/components/related-messages.hbs
@@ -10,5 +10,5 @@
 </div>
 
 {{#if targetUser}}
-  <h3 class="see-all-pms-message">{{{i18n "related_messages.see_all" path=searchLink username=targetUser.username}}}</h3>
+  <h3 class="see-all-pms-message">{{i18n "related_messages.see_all" path=searchLink username=targetUser.username}}</h3>
 {{/if}}

--- a/app/assets/javascripts/discourse/templates/components/reviewable-conversation-post.hbs
+++ b/app/assets/javascripts/discourse/templates/components/reviewable-conversation-post.hbs
@@ -3,6 +3,6 @@
     {{#if showUsername}}
       {{#link-to 'user' post.user class="username"}}@{{post.user.username}}{{/link-to}}
     {{/if}}
-    {{{post.excerpt}}}
+    {{html-safe post.excerpt}}
   </div>
 {{/if}}

--- a/app/assets/javascripts/discourse/templates/components/reviewable-flagged-post.hbs
+++ b/app/assets/javascripts/discourse/templates/components/reviewable-flagged-post.hbs
@@ -17,7 +17,7 @@
       {{#if reviewable.blank_post}}
         <p>{{i18n "review.deleted_post"}}</p>
       {{else}}
-        {{{reviewable.cooked}}}
+        {{html-safe reviewable.cooked}}
       {{/if}}
     </div>
     {{plugin-outlet name="after-reviewable-flagged-post-body" args=(hash model=reviewable)}}

--- a/app/assets/javascripts/discourse/templates/components/reviewable-item.hbs
+++ b/app/assets/javascripts/discourse/templates/components/reviewable-item.hbs
@@ -46,7 +46,7 @@
   <div class='reviewable-actions'>
     {{#if claimEnabled}}
       <div class='claimed-actions'>
-        <span class='help'>{{{claimHelp}}}</span>
+        <span class='help'>{{html-safe claimHelp}}</span>
         {{reviewable-claimed-topic topicId=topicId claimedBy=reviewable.claimed_by}}
       </div>
     {{/if}}

--- a/app/assets/javascripts/discourse/templates/components/reviewable-score.hbs
+++ b/app/assets/javascripts/discourse/templates/components/reviewable-score.hbs
@@ -49,7 +49,7 @@
 {{#if rs.reason}}
   <tr>
     <td colspan='7'>
-      <div class='reviewable-score-reason'>{{{rs.reason}}}</div>
+      <div class='reviewable-score-reason'>{{html-safe rs.reason}}</div>
     </td>
   </tr>
 {{/if}}

--- a/app/assets/javascripts/discourse/templates/components/second-factor-form.hbs
+++ b/app/assets/javascripts/discourse/templates/components/second-factor-form.hbs
@@ -1,7 +1,7 @@
 <div id="second-factor">
   <h3>{{secondFactorTitle}}</h3>
   {{#if optionalText}}
-    <p>{{{optionalText}}}</p>
+    <p>{{html-safe optionalText}}</p>
   {{/if}}
   <p>{{secondFactorDescription}}</p>
   {{yield}}

--- a/app/assets/javascripts/discourse/templates/components/share-panel.hbs
+++ b/app/assets/javascripts/discourse/templates/components/share-panel.hbs
@@ -1,5 +1,5 @@
 <div class="header">
-  <h3 class="title">{{{shareTitle}}}</h3>
+  <h3 class="title">{{html-safe shareTitle}}</h3>
 </div>
 
 <div class="body">

--- a/app/assets/javascripts/discourse/templates/components/share-popup.hbs
+++ b/app/assets/javascripts/discourse/templates/components/share-popup.hbs
@@ -1,5 +1,5 @@
 <div class="title">
-  <h3>{{{shareTitle}}}</h3>
+  <h3>{{html-safe shareTitle}}</h3>
 
   {{#if date}}
     <span class="date">{{displayDate}}</span>

--- a/app/assets/javascripts/discourse/templates/components/share-source.hbs
+++ b/app/assets/javascripts/discourse/templates/components/share-source.hbs
@@ -2,6 +2,6 @@
   {{#if source.icon}}
     {{d-icon source.icon}}
   {{else}}
-    {{{source.htmlIcon}}}
+    {{html-safe source.htmlIcon}}
   {{/if}}
 </a>

--- a/app/assets/javascripts/discourse/templates/components/shared-draft-controls.hbs
+++ b/app/assets/javascripts/discourse/templates/components/shared-draft-controls.hbs
@@ -2,7 +2,7 @@
   {{#if publishing}}
     {{i18n "shared_drafts.publishing"}}
   {{else}}
-    {{{i18n "shared_drafts.notice" category=topic.category.name}}}
+    {{i18n "shared_drafts.notice" category=topic.category.name}}
 
     <div class='publish-field'>
       <label>{{i18n "shared_drafts.destination_category"}}</label>

--- a/app/assets/javascripts/discourse/templates/components/suggested-topics.hbs
+++ b/app/assets/javascripts/discourse/templates/components/suggested-topics.hbs
@@ -13,4 +13,4 @@
   {{/if}}
 </div>
 
-<h3 class="suggested-topics-message">{{{browseMoreMessage}}}</h3>
+<h3 class="suggested-topics-message">{{html-safe browseMoreMessage}}</h3>

--- a/app/assets/javascripts/discourse/templates/components/tag-info.hbs
+++ b/app/assets/javascripts/discourse/templates/components/tag-info.hbs
@@ -32,7 +32,7 @@
     {{#if tagInfo.synonyms}}
       <div class="synonyms-list">
         <h3>{{i18n "tagging.synonyms"}}</h3>
-        <div>{{{i18n "tagging.synonyms_description" base_tag_name=tagInfo.name}}}</div>
+        <div>{{i18n "tagging.synonyms_description" base_tag_name=tagInfo.name}}</div>
         <div class="tag-list">
           {{#each tagInfo.synonyms as |tag|}}
             <div class='tag-box'>

--- a/app/assets/javascripts/discourse/templates/components/text-overflow.hbs
+++ b/app/assets/javascripts/discourse/templates/components/text-overflow.hbs
@@ -1,1 +1,1 @@
-{{{text}}}
+{{html-safe text}}

--- a/app/assets/javascripts/discourse/templates/components/topic-entrance.hbs
+++ b/app/assets/javascripts/discourse/templates/components/topic-entrance.hbs
@@ -1,7 +1,7 @@
 {{#d-button action=(action "enterTop") class="full jump-top"}}
-  {{d-icon 'step-backward'}} {{{topDate}}}
+  {{d-icon 'step-backward'}} {{html-safe topDate}}
 {{/d-button}}
 
 {{#d-button action=(action "enterBottom") class="full jump-bottom"}}
-  {{{bottomDate}}} {{d-icon 'step-forward'}}
+  {{html-safe bottomDate}} {{d-icon 'step-forward'}}
 {{/d-button}}

--- a/app/assets/javascripts/discourse/templates/components/user-card-contents.hbs
+++ b/app/assets/javascripts/discourse/templates/components/user-card-contents.hbs
@@ -144,7 +144,7 @@
         <div class="card-row">
           <div class="featured-topic">
             <span class="desc">{{i18n 'user.featured_topic'}}</span>
-            {{#link-to "topic" user.featured_topic.slug user.featured_topic.id }}{{{user.featured_topic.fancy_title}}}{{/link-to}}
+            {{#link-to "topic" user.featured_topic.slug user.featured_topic.id }}{{html-safe user.featured_topic.fancy_title}}{{/link-to}}
           </div>
         </div>
       {{/if}}

--- a/app/assets/javascripts/discourse/templates/components/user-fields/confirm.hbs
+++ b/app/assets/javascripts/discourse/templates/components/user-fields/confirm.hbs
@@ -1,6 +1,6 @@
 {{#if field.name}}
   <label class="control-label" for={{concat 'user-' elementId}}>
-    {{{field.name}}}   {{#if field.required}}<span class='required'>*</span>{{/if}}
+    {{html-safe field.name}}   {{#if field.required}}<span class='required'>*</span>{{/if}}
   </label>
 {{/if}}
 
@@ -8,7 +8,7 @@
   <label class="control-label checkbox-label">
     {{input id=(concat 'user-' elementId) checked=value type="checkbox"}}
     <span>
-      {{{field.description}}}   {{#unless field.name}}{{#if field.required}}<span class='required'>*</span>{{/if}}{{/unless}}
+      {{html-safe field.description}}   {{#unless field.name}}{{#if field.required}}<span class='required'>*</span>{{/if}}{{/unless}}
     </span>
   </label>
 </div>

--- a/app/assets/javascripts/discourse/templates/components/user-fields/dropdown.hbs
+++ b/app/assets/javascripts/discourse/templates/components/user-fields/dropdown.hbs
@@ -1,4 +1,4 @@
-<label class="control-label" for={{concat 'user-' elementId}}>{{{field.name}}} {{#if field.required}}<span class='required'>*</span>{{/if}}
+<label class="control-label" for={{concat 'user-' elementId}}>{{html-safe field.name}} {{#if field.required}}<span class='required'>*</span>{{/if}}
 </label>
 <div class='controls'>
   {{combo-box
@@ -10,5 +10,5 @@
     none=noneLabel
     onChange=(action (mut value))
   }}
-  <div class="instructions">{{{field.description}}}</div>
+  <div class="instructions">{{html-safe field.description}}</div>
 </div>

--- a/app/assets/javascripts/discourse/templates/components/user-fields/text.hbs
+++ b/app/assets/javascripts/discourse/templates/components/user-fields/text.hbs
@@ -1,6 +1,6 @@
-<label class="control-label" for={{concat 'user-' elementId}}>{{{field.name}}} {{#if field.required}}<span class='required'>*</span>{{/if}}
+<label class="control-label" for={{concat 'user-' elementId}}>{{html-safe field.name}} {{#if field.required}}<span class='required'>*</span>{{/if}}
 </label>
 <div class='controls'>
   {{input id=(concat 'user-' elementId) value=value maxlength=site.user_field_max_length}}
-  <div class="instructions">{{{field.description}}}</div>
+  <div class="instructions">{{html-safe field.description}}</div>
 </div>

--- a/app/assets/javascripts/discourse/templates/components/user-stat.hbs
+++ b/app/assets/javascripts/discourse/templates/components/user-stat.hbs
@@ -9,5 +9,5 @@
 </span>
 <span class='label'>
   {{#if icon}}{{d-icon icon}}{{/if}}
-  {{{i18n label count=value}}}
+  {{i18n label count=value}}
 </span>

--- a/app/assets/javascripts/discourse/templates/components/user-stream-item.hbs
+++ b/app/assets/javascripts/discourse/templates/components/user-stream-item.hbs
@@ -42,7 +42,7 @@
   {{else}}
     {{~{item.excerpt}~}}
   {{/if~}}
-  {{!-- template-lint-enable no-triple-curlies --}}
+  {{!-- template-lint-enable --}}
 </p>
 
 {{#each item.children as |child|}}

--- a/app/assets/javascripts/discourse/templates/components/user-stream-item.hbs
+++ b/app/assets/javascripts/discourse/templates/components/user-stream-item.hbs
@@ -36,11 +36,13 @@
 {{/if}}
 
 <p class='excerpt' data-topic-id={{item.topic_id}} data-post-id={{item.post_id}} data-user-id={{item.user_id}}>
+  {{!-- template-lint-disable no-triple-curlies --}}
   {{~#if item.expandedExcerpt}}
     {{~{item.expandedExcerpt}~}}
   {{else}}
     {{~{item.excerpt}~}}
   {{/if~}}
+  {{!-- template-lint-enable no-triple-curlies --}}
 </p>
 
 {{#each item.children as |child|}}

--- a/app/assets/javascripts/discourse/templates/components/user-stream-item.hbs
+++ b/app/assets/javascripts/discourse/templates/components/user-stream-item.hbs
@@ -2,7 +2,7 @@
   <a href={{item.userUrl}} data-user-card={{item.username}} class='avatar-link'><div class='avatar-wrapper'>{{avatar item imageSize="large" extraClasses="actor" ignoreTitle="true"}}</div></a>
   <span class='time'>{{format-date item.created_at}}</span>
   {{#if item.draftType}}
-    <span class='draft-type'>{{{item.draftType}}}</span>
+    <span class='draft-type'>{{html-safe item.draftType}}</span>
   {{else}}
     {{expand-post item=item}}
   {{/if}}
@@ -11,9 +11,9 @@
       {{topic-status topic=item disableActions=true}}
       <span class="title">
         {{#if item.postUrl}}
-          <a href={{item.postUrl}}>{{{item.title}}}</a>
+          <a href={{item.postUrl}}>{{html-safe item.title}}</a>
         {{else}}
-          {{{item.title}}}
+          {{html-safe item.title}}
         {{/if}}
       </span>
     </div>

--- a/app/assets/javascripts/discourse/templates/components/user-summary-topic.hbs
+++ b/app/assets/javascripts/discourse/templates/components/user-summary-topic.hbs
@@ -6,4 +6,4 @@
   {{/if}}
 </span>
 <br>
-<a href={{url}}>{{{topic.fancyTitle}}}</a>
+<a href={{url}}>{{html-safe topic.fancyTitle}}</a>

--- a/app/assets/javascripts/discourse/templates/composer.hbs
+++ b/app/assets/javascripts/discourse/templates/composer.hbs
@@ -204,7 +204,7 @@
                   {{d-button action=(action "togglePreview") class="hide-preview" label="composer.hide_preview"}}
                 {{/if}}
               {{else}}
-                <a href {{action "togglePreview"}} class='toggle-preview'>{{{toggleText}}}</a>
+                <a href {{action "togglePreview"}} class='toggle-preview'>{{html-safe toggleText}}</a>
               {{/if}}
 
           </div>
@@ -221,7 +221,7 @@
 
         <div class='draft-text'>
           {{#if model.topic}}
-            {{d-icon "share"}} {{{draftTitle}}}
+            {{d-icon "share"}} {{html-safe draftTitle}}
           {{else}}
             {{i18n "composer.saved_draft"}}
           {{/if}}

--- a/app/assets/javascripts/discourse/templates/composer/custom-body.hbs
+++ b/app/assets/javascripts/discourse/templates/composer/custom-body.hbs
@@ -1,3 +1,3 @@
 <a href {{action "closeMessage"}} class='close'>{{d-icon "times"}}</a>
 {{#if message.title}}<h3>{{message.title}}</h3>{{/if}}
-<p>{{{message.body}}}</p>
+<p>{{html-safe message.body}}</p>

--- a/app/assets/javascripts/discourse/templates/composer/education.hbs
+++ b/app/assets/javascripts/discourse/templates/composer/education.hbs
@@ -1,2 +1,2 @@
 <a href {{action "closeMessage"}} class='close'>{{d-icon "times"}}</a>
-{{{message.body}}}
+{{html-safe message.body}}

--- a/app/assets/javascripts/discourse/templates/composer/group-mentioned.hbs
+++ b/app/assets/javascripts/discourse/templates/composer/group-mentioned.hbs
@@ -1,2 +1,2 @@
 <a href {{action "closeMessage"}} class='close'>{{d-icon "times"}}</a>
-{{{message.body}}}
+{{html-safe message.body}}

--- a/app/assets/javascripts/discourse/templates/discovery.hbs
+++ b/app/assets/javascripts/discourse/templates/discovery.hbs
@@ -1,5 +1,5 @@
 {{#if errorHtml}}
-  {{{errorHtml}}}
+  {{html-safe errorHtml}}
 {{else}}
   <div class="container">
     {{discourse-banner user=currentUser banner=site.banner}}

--- a/app/assets/javascripts/discourse/templates/full-page-search.hbs
+++ b/app/assets/javascripts/discourse/templates/full-page-search.hbs
@@ -49,7 +49,7 @@
 
       <div class='search-info'>
         <div class='result-count'>
-          {{{resultCountLabel}}}
+          {{html-safe resultCountLabel}}
         </div>
         <div class='sort-by'>
           <span class='desc'>
@@ -88,7 +88,7 @@
 
                   <a class='search-link' href={{result.url}} {{action "logClick" result.topic_id}}>
                     {{topic-status topic=result.topic disableActions=true showPrivateMessageIcon=true}}
-                    <span class='topic-title'>{{#highlight-text highlight=q}}{{{result.topic.fancyTitle}}}{{/highlight-text}}</span>
+                    <span class='topic-title'>{{#highlight-text highlight=q}}{{html-safe result.topic.fancyTitle}}{{/highlight-text}}</span>
                   </a>
 
                   <div class='search-category'>
@@ -113,7 +113,7 @@
 
                   {{#if result.blurb}}
                     {{#highlight-text highlight=highlightQuery}}
-                      {{{result.blurb}}}
+                      {{html-safe result.blurb}}
                     {{/highlight-text}}
                   {{/if}}
                 </div>

--- a/app/assets/javascripts/discourse/templates/group.hbs
+++ b/app/assets/javascripts/discourse/templates/group.hbs
@@ -26,7 +26,7 @@
       <hr>
 
       <div class='group-bio'>
-        <p>{{{model.bio_cooked}}}</p>
+        <p>{{html-safe model.bio_cooked}}</p>
       </div>
     {{/if}}
 

--- a/app/assets/javascripts/discourse/templates/groups/index.hbs
+++ b/app/assets/javascripts/discourse/templates/groups/index.hbs
@@ -51,7 +51,7 @@
                     </span>
                   </div>
 
-                  <div class="group-description">{{{group.bio_excerpt}}}</div>
+                  <div class="group-description">{{html-safe group.bio_excerpt}}</div>
 
                   <div class="group-membership">
                     {{#group-membership-button tagName='' model=group showLogin=(route-action "showLogin")}}

--- a/app/assets/javascripts/discourse/templates/invites/show.hbs
+++ b/app/assets/javascripts/discourse/templates/invites/show.hbs
@@ -10,12 +10,12 @@
     <div class="col-form">
       {{#if successMessage}}
         <br><br>
-        <div class='alert alert-info'><p>{{{successMessage}}}</p></div>
+        <div class='alert alert-info'><p>{{html-safe successMessage}}</p></div>
       {{else}}
         <p>{{i18n 'invites.invited_by'}}</p>
         <p>{{user-info user=invitedBy}}</p>
 
-        <p>{{{yourEmailMessage}}}
+        <p>{{html-safe yourEmailMessage}}
         {{#if externalAuthsEnabled}}
              {{i18n 'invites.social_login_available'}}
         {{/if}}

--- a/app/assets/javascripts/discourse/templates/list/activity-column.hbr
+++ b/app/assets/javascripts/discourse/templates/list/activity-column.hbr
@@ -1,4 +1,4 @@
-<{{tagName}} class="{{class}} {{cold-age-class topic.createdAt startDate=topic.bumpedAt class=""}} activity" title="{{{topic.bumpedAtTitle}}}">
+<{{tagName}} class="{{class}} {{cold-age-class topic.createdAt startDate=topic.bumpedAt class=""}} activity" title="{{html-safe topic.bumpedAtTitle}}">
   <a class="post-activity" href="{{topic.lastPostUrl}}">
     {{~raw-plugin-outlet name="topic-list-before-relative-date"~}}
     {{~format-date topic.bumpedAt format="tiny" noTitle="true"~}}

--- a/app/assets/javascripts/discourse/templates/list/topic-excerpt.hbr
+++ b/app/assets/javascripts/discourse/templates/list/topic-excerpt.hbr
@@ -1,6 +1,6 @@
 {{#if topic.hasExcerpt}}
   <div class="topic-excerpt">
-    {{{dir-span topic.escapedExcerpt}}}
+    {{dir-span topic.escapedExcerpt}}
     {{#if topic.excerptTruncated}}
       <a href="{{topic.url}}">{{i18n 'read_more'}}</a>
     {{/if}}

--- a/app/assets/javascripts/discourse/templates/mobile/components/basic-topic-list.hbs
+++ b/app/assets/javascripts/discourse/templates/mobile/components/basic-topic-list.hbs
@@ -24,7 +24,7 @@
               {{/if}}
               {{#if t.hasExcerpt}}
                 <div class="topic-excerpt">
-                  {{{t.excerpt}}}
+                  {{html-safe t.excerpt}}
                   {{#if t.excerptTruncated}}
                     {{#unless t.canClearPin}}<a href={{t.url}}>{{i18n 'read_more'}}</a>{{/unless}}
                   {{/if}}
@@ -42,7 +42,7 @@
               {{discourse-tags t mode="list" tagsForUser=tagsForUser}}
               <div class="pull-right">
                 {{raw "list/activity-column" topic=t tagName="div" class="num activity last"}}
-                <a href={{t.lastPostUrl}} title='{{i18n 'last_post'}}: {{{raw-date t.bumped_at}}}'>{{t.last_poster_username}}</a>
+                <a href={{t.lastPostUrl}} title='{{i18n 'last_post'}}: {{raw-date t.bumped_at}}'>{{t.last_poster_username}}</a>
               </div>
               {{#unless hideCategory}}
                 <div class='category'>

--- a/app/assets/javascripts/discourse/templates/mobile/components/categories-only.hbs
+++ b/app/assets/javascripts/discourse/templates/mobile/components/categories-only.hbs
@@ -13,7 +13,7 @@
             {{#if c.description_excerpt}}
               <tr class="category-description">
                 <td colspan="3">
-                  {{{c.description_excerpt}}}
+                  {{html-safe c.description_excerpt}}
                 </td>
               </tr>
             {{/if}}

--- a/app/assets/javascripts/discourse/templates/mobile/components/mobile-nav.hbs
+++ b/app/assets/javascripts/discourse/templates/mobile/components/mobile-nav.hbs
@@ -1,7 +1,7 @@
 {{#if selectedHtml}}
   <li>
     <a href class='expander' {{action 'toggleExpanded'}}>
-      <span>{{{selectedHtml}}}</span>
+      <span>{{html-safe selectedHtml}}</span>
       {{d-icon "caret-down"}}
     </a>
   </li>

--- a/app/assets/javascripts/discourse/templates/modal/activation-resent.hbs
+++ b/app/assets/javascripts/discourse/templates/modal/activation-resent.hbs
@@ -1,5 +1,5 @@
 {{#d-modal-body}}
-  {{{i18n 'login.sent_activation_email_again' currentEmail=currentEmail}}}
+  {{i18n 'login.sent_activation_email_again' currentEmail=currentEmail}}
 {{/d-modal-body}}
 
 {{modal-footer-close closeModal=(route-action "closeModal")}}

--- a/app/assets/javascripts/discourse/templates/modal/auth-token.hbs
+++ b/app/assets/javascripts/discourse/templates/modal/auth-token.hbs
@@ -1,7 +1,7 @@
 {{#d-modal-body title="user.auth_tokens.was_this_you"}}
   <div>
     <p>{{i18n 'user.auth_tokens.was_this_you_description'}}</p>
-    <p>{{{i18n 'user.second_factor.extended_description'}}}</p>
+    <p>{{i18n 'user.second_factor.extended_description'}}</p>
   </div>
 
   <div>
@@ -21,9 +21,9 @@
       </h3>
 
       {{#if expanded}}
-        <blockquote>{{{latest_post.cooked}}}</blockquote>
+        <blockquote>{{html-safe latest_post.cooked}}</blockquote>
       {{else}}
-        <blockquote>{{{latest_post.excerpt}}}</blockquote>
+        <blockquote>{{html-safe latest_post.excerpt}}</blockquote>
       {{/if}}
     </div>
   {{/if}}

--- a/app/assets/javascripts/discourse/templates/modal/avatar-selector.hbs
+++ b/app/assets/javascripts/discourse/templates/modal/avatar-selector.hbs
@@ -10,11 +10,11 @@
   {{else}}
     <div class="avatar-choice">
       {{radio-button id="system-avatar" name="avatar" value="system" selection=selected}}
-      <label class="radio" for="system-avatar">{{bound-avatar-template user.system_avatar_template "large"}} {{{i18n 'user.change_avatar.letter_based'}}}</label>
+      <label class="radio" for="system-avatar">{{bound-avatar-template user.system_avatar_template "large"}} {{i18n 'user.change_avatar.letter_based'}}</label>
     </div>
     <div class="avatar-choice">
       {{radio-button id="gravatar" name="avatar" value="gravatar" selection=selected}}
-      <label class="radio" for="gravatar">{{bound-avatar-template user.gravatar_avatar_template "large"}} <span>{{{i18n 'user.change_avatar.gravatar'}}} {{user.email}}</span></label>
+      <label class="radio" for="gravatar">{{bound-avatar-template user.gravatar_avatar_template "large"}} <span>{{i18n 'user.change_avatar.gravatar'}} {{user.email}}</span></label>
 
       {{d-button action=(action "refreshGravatar")
                  title="user.change_avatar.refresh_gravatar_title"
@@ -23,7 +23,7 @@
                  class="btn-default avatar-selector-refresh-gravatar"}}
 
       {{#if gravatarFailed}}
-        <p class="error">{{I18n 'user.change_avatar.gravatar_failed'}}</p>
+        <p class="error">{{i18n 'user.change_avatar.gravatar_failed'}}</p>
       {{/if}}
     </div>
     {{#if allowAvatarUpload}}

--- a/app/assets/javascripts/discourse/templates/modal/bookmark.hbs
+++ b/app/assets/javascripts/discourse/templates/modal/bookmark.hbs
@@ -38,7 +38,7 @@
           <!-- {{tap-tile icon="calendar-alt" text=(I18n "bookmarks.reminders.custom") tileId=reminderTypes.CUSTOM activeTile=grid.activeTile onChange=(action "selectReminderType")}} -->
         {{/tap-tile-grid}}
       {{else}}
-        <div class="alert alert-info">{{{i18n "bookmarks.no_timezone" basePath=basePath }}}</div>
+        <div class="alert alert-info">{{i18n "bookmarks.no_timezone" basePath=basePath }}</div>
       {{/if}}
     </div>
     {{/if}}

--- a/app/assets/javascripts/discourse/templates/modal/bulk-notification-level.hbs
+++ b/app/assets/javascripts/discourse/templates/modal/bulk-notification-level.hbs
@@ -2,7 +2,7 @@
   <div class='controls'>
     <label class='radio'>
       {{radio-button value=level.id name="notification_level" selection=notificationLevelId}} <strong>{{level.name}}</strong>
-      <div class='description'>{{{level.description}}}</div>
+      <div class='description'>{{html-safe level.description}}</div>
     </label>
   </div>
 {{/each}}

--- a/app/assets/javascripts/discourse/templates/modal/change-owner.hbs
+++ b/app/assets/javascripts/discourse/templates/modal/change-owner.hbs
@@ -1,6 +1,6 @@
 {{#d-modal-body class='change-ownership'}}
   <span>
-    {{{i18n 'topic.change_owner.instructions' count=selectedPostsCount old_user=selectedPostsUsername}}}
+    {{i18n 'topic.change_owner.instructions' count=selectedPostsCount old_user=selectedPostsUsername}}
   </span>
 
   <form>

--- a/app/assets/javascripts/discourse/templates/modal/create-account.hbs
+++ b/app/assets/javascripts/discourse/templates/modal/create-account.hbs
@@ -126,7 +126,7 @@
           {{/d-button}}
         {{/conditional-loading-spinner}}
 
-      <div class='disclaimer'>{{{disclaimerHtml}}}</div>
+      <div class='disclaimer'>{{html-safe disclaimerHtml}}</div>
       </div>
 
       {{plugin-outlet name="create-account-after-modal-footer" tagName=""}}

--- a/app/assets/javascripts/discourse/templates/modal/delete-topic-disallowed.hbs
+++ b/app/assets/javascripts/discourse/templates/modal/delete-topic-disallowed.hbs
@@ -1,5 +1,5 @@
 {{#d-modal-body}}
-  <p>{{{i18n "post.controls.delete_topic_disallowed_modal"}}}</p>
+  <p>{{i18n "post.controls.delete_topic_disallowed_modal"}}</p>
 {{/d-modal-body}}
 <div class="modal-footer">
   {{d-button action=(route-action "closeModal") class="btn-primary" label="close"}}

--- a/app/assets/javascripts/discourse/templates/modal/edit-category.hbs
+++ b/app/assets/javascripts/discourse/templates/modal/edit-category.hbs
@@ -34,7 +34,7 @@
                    label="category.delete"}}
 
         <div class="cannot_delete_reason {{if hiddenTooltip "hidden" ""}}">
-          {{{model.cannot_delete_reason}}}
+          {{html-safe model.cannot_delete_reason}}
         </div>
       </div>
     {{/if}}

--- a/app/assets/javascripts/discourse/templates/modal/feature-topic.hbs
+++ b/app/assets/javascripts/discourse/templates/modal/feature-topic.hbs
@@ -6,9 +6,9 @@
           <p>
             {{#conditional-loading-spinner size="small" condition=loading}}
               {{#if pinnedGloballyCount}}
-                {{{i18n "topic.feature_topic.already_pinned_globally" count=pinnedGloballyCount}}}
+                {{i18n "topic.feature_topic.already_pinned_globally" count=pinnedGloballyCount}}
               {{else}}
-                {{{i18n "topic.feature_topic.not_pinned_globally"}}}
+                {{i18n "topic.feature_topic.not_pinned_globally"}}
               {{/if}}
             {{/conditional-loading-spinner}}
           </p>
@@ -16,12 +16,12 @@
         {{else}}
           <p>
             {{#conditional-loading-spinner size="small" condition=loading}}
-              {{{alreadyPinnedMessage}}}
+              {{html-safe alreadyPinnedMessage}}
             {{/conditional-loading-spinner}}
           </p>
           <p>{{i18n "topic.feature_topic.pin_note"}}</p>
         {{/if}}
-        <p>{{{unPinMessage}}}</p>
+        <p>{{html-safe unPinMessage}}</p>
         <p>{{d-button action=(action "unpin") icon="thumbtack" label="topic.feature.unpin" class="btn-primary"}}</p>
       </div>
     </div>
@@ -30,7 +30,7 @@
       <div class="desc">
         <p>
           {{#conditional-loading-spinner size="small" condition=loading}}
-            {{{alreadyPinnedMessage}}}
+            {{html-safe alreadyPinnedMessage}}
           {{/conditional-loading-spinner}}
         </p>
         <p>
@@ -38,7 +38,7 @@
         </p>
         {{#if site.isMobileDevice}}
           <p>
-            {{{pinMessage}}}
+            {{html-safe pinMessage}}
           </p>
           <p class="with-validation">
             {{future-date-input
@@ -52,7 +52,7 @@
           </p>
         {{else}}
           <p class="with-validation">
-            {{{pinMessage}}}
+            {{html-safe pinMessage}}
             {{d-icon "far-clock"}}
             {{future-date-input
               class="pin-until"
@@ -74,9 +74,9 @@
         <p>
           {{#conditional-loading-spinner size="small" condition=loading}}
             {{#if pinnedGloballyCount}}
-              {{{i18n "topic.feature_topic.already_pinned_globally" count=pinnedGloballyCount}}}
+              {{i18n "topic.feature_topic.already_pinned_globally" count=pinnedGloballyCount}}
             {{else}}
-              {{{i18n "topic.feature_topic.not_pinned_globally"}}}
+              {{i18n "topic.feature_topic.not_pinned_globally"}}
             {{/if}}
           {{/conditional-loading-spinner}}
         </p>
@@ -123,9 +123,9 @@
         <p>
           {{#conditional-loading-spinner size="small" condition=loading}}
             {{#if bannerCount}}
-              {{{i18n "topic.feature_topic.banner_exists"}}}
+              {{i18n "topic.feature_topic.banner_exists"}}
             {{else}}
-              {{{i18n "topic.feature_topic.no_banner_exists"}}}
+              {{i18n "topic.feature_topic.no_banner_exists"}}
             {{/if}}
           {{/conditional-loading-spinner}}
         </p>

--- a/app/assets/javascripts/discourse/templates/modal/forgot-password.hbs
+++ b/app/assets/javascripts/discourse/templates/modal/forgot-password.hbs
@@ -1,7 +1,7 @@
 <form>
   {{#d-modal-body class="forgot-password-modal"}}
     {{#if offerHelp}}
-      {{{offerHelp}}}
+      {{html-safe offerHelp}}
     {{else}}
       <label for='username-or-email'>{{i18n 'forgot_password.invite'}}</label>
       {{text-field value=accountEmailOrUsername placeholderKey="login.email_placeholder" id="username-or-email" autocorrect="off" autocapitalize="off"}}

--- a/app/assets/javascripts/discourse/templates/modal/history.hbs
+++ b/app/assets/javascripts/discourse/templates/modal/history.hbs
@@ -21,7 +21,7 @@
           &mdash; {{disabled-icon icon="shield-alt" disabled=postTypeDisabled}}
         {{/if}}
         {{#if model.category_id_changes}}
-          &mdash; {{{previousCategory}}} &rarr; {{{currentCategory}}}
+          &mdash; {{html-safe previousCategory}} &rarr; {{html-safe currentCategory}}
         {{/if}}
       {{/unless}}
     </div>
@@ -50,7 +50,7 @@
   <div id="revisions" data-post-id={{model.post_id}} class={{hiddenClasses}}>
     {{#if model.title_changes}}
       <div class="row">
-        <h2>{{{titleDiff}}}</h2>
+        <h2>{{html-safe titleDiff}}</h2>
       </div>
     {{/if}}
     {{#if site.mobileView}}
@@ -72,7 +72,7 @@
       {{/if}}
       {{#if model.category_id_changes}}
         <div class="row">
-          {{{previousCategory}}} &rarr; {{{currentCategory}}}
+          {{html-safe previousCategory}} &rarr; {{html-safe currentCategory}}
         </div>
       {{/if}}
     {{/if}}
@@ -100,7 +100,7 @@
     {{plugin-outlet name="post-revisions" args=(hash model=model)}}
 
     {{#links-redirect class="row"}}
-      {{{bodyDiff}}}
+      {{html-safe bodyDiff}}
     {{/links-redirect}}
   </div>
 {{/d-modal-body}}
@@ -111,7 +111,7 @@
       {{d-button class="btn-default" action=(action "loadPreviousVersion") icon="backward" title="post.revisions.controls.previous" disabled=loadPreviousDisabled}}
       <div id="revision-numbers" class={{unless displayRevisions 'invisible'}}>
         {{#conditional-loading-spinner condition=loading size="small"}}
-          {{{revisionsText}}}
+          {{html-safe revisionsText}}
         {{/conditional-loading-spinner}}
       </div>
       {{d-button class="btn-default" action=(action "loadNextVersion") icon="forward" title="post.revisions.controls.next" disabled=loadNextDisabled}}

--- a/app/assets/javascripts/discourse/templates/modal/keyboard-shortcuts-help.hbs
+++ b/app/assets/javascripts/discourse/templates/modal/keyboard-shortcuts-help.hbs
@@ -3,29 +3,29 @@
     <section>
       <h4>{{i18n "keyboard_shortcuts_help.jump_to.title"}}</h4>
       <ul>
-        <li>{{{shortcuts.jump_to.home}}}</li>
-        <li>{{{shortcuts.jump_to.latest}}}</li>
-        <li>{{{shortcuts.jump_to.new}}}</li>
-        <li>{{{shortcuts.jump_to.unread}}}</li>
-        <li>{{{shortcuts.jump_to.categories}}}</li>
-        <li>{{{shortcuts.jump_to.top}}}</li>
-        <li>{{{shortcuts.jump_to.bookmarks}}}</li>
-        <li>{{{shortcuts.jump_to.profile}}}</li>
+        <li>{{html-safe shortcuts.jump_to.home}}</li>
+        <li>{{html-safe shortcuts.jump_to.latest}}</li>
+        <li>{{html-safe shortcuts.jump_to.new}}</li>
+        <li>{{html-safe shortcuts.jump_to.unread}}</li>
+        <li>{{html-safe shortcuts.jump_to.categories}}</li>
+        <li>{{html-safe shortcuts.jump_to.top}}</li>
+        <li>{{html-safe shortcuts.jump_to.bookmarks}}</li>
+        <li>{{html-safe shortcuts.jump_to.profile}}</li>
         {{#if siteSettings.enable_personal_messages}}
-          <li>{{{shortcuts.jump_to.messages}}}</li>
+          <li>{{html-safe shortcuts.jump_to.messages}}</li>
         {{/if}}
-        <li>{{{shortcuts.jump_to.drafts}}}</li>
+        <li>{{html-safe shortcuts.jump_to.drafts}}</li>
       </ul>
     </section>
     <section>
       <h4>{{i18n "keyboard_shortcuts_help.navigation.title"}}</h4>
       <ul>
-        <li>{{{shortcuts.navigation.back}}}</li>
-        <li>{{{shortcuts.navigation.jump}}}</li>
-        <li>{{{shortcuts.navigation.up_down}}}</li>
-        <li>{{{shortcuts.navigation.open}}}</li>
-        <li>{{{shortcuts.navigation.next_prev}}}</li>
-        <li>{{{shortcuts.navigation.go_to_unread_post}}}</li>
+        <li>{{html-safe shortcuts.navigation.back}}</li>
+        <li>{{html-safe shortcuts.navigation.jump}}</li>
+        <li>{{html-safe shortcuts.navigation.up_down}}</li>
+        <li>{{html-safe shortcuts.navigation.open}}</li>
+        <li>{{html-safe shortcuts.navigation.next_prev}}</li>
+        <li>{{html-safe shortcuts.navigation.go_to_unread_post}}</li>
       </ul>
     </section>
   </div>
@@ -33,26 +33,26 @@
     <section>
       <h4>{{i18n "keyboard_shortcuts_help.application.title"}}</h4>
       <ul>
-        <li>{{{shortcuts.application.hamburger_menu}}}</li>
-        <li>{{{shortcuts.application.user_profile_menu}}}</li>
-        <li>{{{shortcuts.application.show_incoming_updated_topics}}}</li>
-        <li>{{{shortcuts.application.search}}}</li>
-        <li>{{{shortcuts.application.help}}}</li>
-        <li>{{{shortcuts.application.dismiss_new_posts}}}</li>
-        <li>{{{shortcuts.application.dismiss_topics}}}</li>
-        <li>{{{shortcuts.application.log_out}}}</li>
+        <li>{{html-safe shortcuts.application.hamburger_menu}}</li>
+        <li>{{html-safe shortcuts.application.user_profile_menu}}</li>
+        <li>{{html-safe shortcuts.application.show_incoming_updated_topics}}</li>
+        <li>{{html-safe shortcuts.application.search}}</li>
+        <li>{{html-safe shortcuts.application.help}}</li>
+        <li>{{html-safe shortcuts.application.dismiss_new_posts}}</li>
+        <li>{{html-safe shortcuts.application.dismiss_topics}}</li>
+        <li>{{html-safe shortcuts.application.log_out}}</li>
       </ul>
     </section>
     <section>
       <h4>{{i18n "keyboard_shortcuts_help.composing.title"}}</h4>
       <ul>
-        <li>{{{shortcuts.composing.return}}}</li>
-        <li>{{{shortcuts.composing.fullscreen}}}</li>
-        <li>{{{shortcuts.application.create}}}</li>
-        <li>{{{shortcuts.actions.reply_as_new_topic}}}</li>
-        <li>{{{shortcuts.actions.reply_topic}}}</li>
-        <li>{{{shortcuts.actions.reply_post}}}</li>
-        <li>{{{shortcuts.actions.quote_post}}}</li>
+        <li>{{html-safe shortcuts.composing.return}}</li>
+        <li>{{html-safe shortcuts.composing.fullscreen}}</li>
+        <li>{{html-safe shortcuts.application.create}}</li>
+        <li>{{html-safe shortcuts.actions.reply_as_new_topic}}</li>
+        <li>{{html-safe shortcuts.actions.reply_topic}}</li>
+        <li>{{html-safe shortcuts.actions.reply_post}}</li>
+        <li>{{html-safe shortcuts.actions.quote_post}}</li>
       </ul>
     </section>
   </div>
@@ -60,22 +60,22 @@
     <section>
       <h4>{{i18n "keyboard_shortcuts_help.actions.title"}}</h4>
       <ul>
-        <li>{{{shortcuts.actions.bookmark_topic}}}</li>
-        <li>{{{shortcuts.actions.pin_unpin_topic}}}</li>
-        <li>{{{shortcuts.actions.share_topic}}}</li>
-        <li>{{{shortcuts.actions.share_post}}}</li>
-        <li>{{{shortcuts.actions.like}}}</li>
-        <li>{{{shortcuts.actions.flag}}}</li>
-        <li>{{{shortcuts.actions.bookmark}}}</li>
-        <li>{{{shortcuts.actions.edit}}}</li>
-        <li>{{{shortcuts.actions.delete}}}</li>
-        <li>{{{shortcuts.actions.mark_muted}}}</li>
-        <li>{{{shortcuts.actions.mark_regular}}}</li>
-        <li>{{{shortcuts.actions.mark_tracking}}}</li>
-        <li>{{{shortcuts.actions.mark_watching}}}</li>
-        <li>{{{shortcuts.actions.defer}}}</li>
-        <li>{{{shortcuts.actions.print}}}</li>
-        <li>{{{shortcuts.actions.topic_admin_actions}}}</li>
+        <li>{{html-safe shortcuts.actions.bookmark_topic}}</li>
+        <li>{{html-safe shortcuts.actions.pin_unpin_topic}}</li>
+        <li>{{html-safe shortcuts.actions.share_topic}}</li>
+        <li>{{html-safe shortcuts.actions.share_post}}</li>
+        <li>{{html-safe shortcuts.actions.like}}</li>
+        <li>{{html-safe shortcuts.actions.flag}}</li>
+        <li>{{html-safe shortcuts.actions.bookmark}}</li>
+        <li>{{html-safe shortcuts.actions.edit}}</li>
+        <li>{{html-safe shortcuts.actions.delete}}</li>
+        <li>{{html-safe shortcuts.actions.mark_muted}}</li>
+        <li>{{html-safe shortcuts.actions.mark_regular}}</li>
+        <li>{{html-safe shortcuts.actions.mark_tracking}}</li>
+        <li>{{html-safe shortcuts.actions.mark_watching}}</li>
+        <li>{{html-safe shortcuts.actions.defer}}</li>
+        <li>{{html-safe shortcuts.actions.print}}</li>
+        <li>{{html-safe shortcuts.actions.topic_admin_actions}}</li>
       </ul>
     </section>
   </div>

--- a/app/assets/javascripts/discourse/templates/modal/move-to-topic.hbs
+++ b/app/assets/javascripts/discourse/templates/modal/move-to-topic.hbs
@@ -17,7 +17,7 @@
 
     {{#if canSplitTopic}}
       {{#if newMessage}}
-        <p>{{{i18n 'topic.move_to_new_message.instructions' count=selectedPostsCount}}}</p>
+        <p>{{i18n 'topic.move_to_new_message.instructions' count=selectedPostsCount}}</p>
         <form>
           <label>{{i18n 'topic.move_to_new_message.message_title'}}</label>
           {{text-field value=topicName placeholderKey="composer.title_placeholder" elementId='split-topic-name'}}
@@ -31,7 +31,7 @@
     {{/if}}
 
     {{#if existingMessage}}
-      <p>{{{i18n 'topic.move_to_existing_message.instructions' count=selectedPostsCount}}}</p>
+      <p>{{i18n 'topic.move_to_existing_message.instructions' count=selectedPostsCount}}</p>
       <form>
         {{choose-message currentTopicId=model.id selectedTopicId=selectedTopicId}}
 
@@ -64,7 +64,7 @@
     </div>
 
     {{#if existingTopic}}
-      <p>{{{i18n 'topic.merge_topic.instructions' count=selectedPostsCount}}}</p>
+      <p>{{i18n 'topic.merge_topic.instructions' count=selectedPostsCount}}</p>
       <form>
         {{choose-topic currentTopicId=model.id selectedTopicId=selectedTopicId}}
       </form>
@@ -72,7 +72,7 @@
 
     {{#if canSplitTopic}}
       {{#if newTopic}}
-        <p>{{{i18n 'topic.split_topic.instructions' count=selectedPostsCount}}}</p>
+        <p>{{i18n 'topic.split_topic.instructions' count=selectedPostsCount}}</p>
         <form>
           <label>{{i18n 'topic.split_topic.topic_name'}}</label>
           {{text-field value=topicName placeholderKey="composer.title_placeholder" elementId='split-topic-name'}}
@@ -93,7 +93,7 @@
 
     {{#if canSplitTopic}}
       {{#if newMessage}}
-        <p>{{{i18n 'topic.move_to_new_message.instructions' count=selectedPostsCount}}}</p>
+        <p>{{i18n 'topic.move_to_new_message.instructions' count=selectedPostsCount}}</p>
         <form>
           <label>{{i18n 'topic.move_to_new_message.message_title'}}</label>
           {{text-field value=topicName placeholderKey="composer.title_placeholder" elementId='split-topic-name'}}

--- a/app/assets/javascripts/discourse/templates/modal/not-activated.hbs
+++ b/app/assets/javascripts/discourse/templates/modal/not-activated.hbs
@@ -1,5 +1,5 @@
 {{#d-modal-body}}
-  {{{i18n 'login.not_activated' sentTo=sentTo}}}
+  {{i18n 'login.not_activated' sentTo=sentTo}}
 {{/d-modal-body}}
 
 <div class="modal-footer">

--- a/app/assets/javascripts/discourse/templates/modal/post-enqueued.hbs
+++ b/app/assets/javascripts/discourse/templates/modal/post-enqueued.hbs
@@ -1,7 +1,7 @@
 {{#d-modal-body}}
   <p>{{i18n "review.approval.description"}}</p>
 
-  <p>{{{i18n "review.approval.pending_posts" count=model.pending_count}}}</p>
+  <p>{{i18n "review.approval.pending_posts" count=model.pending_count}}</p>
 {{/d-modal-body}}
 <div class="modal-footer">
   {{d-button action=(route-action "closeModal") class="btn-primary" label="review.approval.ok"}}

--- a/app/assets/javascripts/discourse/templates/modal/second-factor-add-security-key.hbs
+++ b/app/assets/javascripts/discourse/templates/modal/second-factor-add-security-key.hbs
@@ -10,7 +10,7 @@
 
     <div class="control-group">
       <div class="controls">
-        {{{i18n 'user.second_factor.enable_security_key_description'}}}
+        {{i18n 'user.second_factor.enable_security_key_description'}}
       </div>
     </div>
 

--- a/app/assets/javascripts/discourse/templates/modal/second-factor-add-totp.hbs
+++ b/app/assets/javascripts/discourse/templates/modal/second-factor-add-totp.hbs
@@ -10,7 +10,7 @@
 
     <div class="control-group">
       <div class="controls">
-        {{{i18n 'user.second_factor.enable_description'}}}
+        {{i18n 'user.second_factor.enable_description'}}
       </div>
     </div>
 
@@ -18,7 +18,7 @@
       <div class="controls">
         <div class="qr-code-container">
           <div class="qr-code">
-            {{{secondFactorImage}}}
+            {{html-safe secondFactorImage}}
           </div>
         </div>
 

--- a/app/assets/javascripts/discourse/templates/modal/second-factor-backup-edit.hbs
+++ b/app/assets/javascripts/discourse/templates/modal/second-factor-backup-edit.hbs
@@ -14,7 +14,7 @@
     {{/if}}
 
     {{#if backupEnabled}}
-      {{{i18n "user.second_factor_backup.remaining_codes" count=remainingCodes}}}
+      {{i18n "user.second_factor_backup.remaining_codes" count=remainingCodes}}
     {{/if}}
 
     <div class="actions">

--- a/app/assets/javascripts/discourse/templates/modal/topic-bulk-actions.hbs
+++ b/app/assets/javascripts/discourse/templates/modal/topic-bulk-actions.hbs
@@ -1,4 +1,4 @@
 {{#d-modal-body}}
-  <p>{{{i18n 'topics.bulk.selected' count=model.topics.length}}}</p>
+  <p>{{i18n 'topics.bulk.selected' count=model.topics.length}}</p>
   {{outlet "bulkOutlet"}}
 {{/d-modal-body}}

--- a/app/assets/javascripts/discourse/templates/navigation/category.hbs
+++ b/app/assets/javascripts/discourse/templates/navigation/category.hbs
@@ -9,7 +9,7 @@
         width=category.uploaded_logo.width
         height=category.uploaded_logo.height}}
       {{#if category.description}}
-        <p>{{{dir-span category.description}}}</p>
+        <p>{{dir-span category.description}}</p>
       {{/if}}
     {{/if}}
   </section>

--- a/app/assets/javascripts/discourse/templates/preferences-second-factor.hbs
+++ b/app/assets/javascripts/discourse/templates/preferences-second-factor.hbs
@@ -86,7 +86,7 @@
           <h2>{{i18n "user.second_factor_backup.title"}}</h2>
           {{#if model.second_factor_enabled}}
             {{#if model.second_factor_backup_enabled}}
-              {{{i18n 'user.second_factor_backup.manage' count=model.second_factor_remaining_backup_codes}}}
+              {{i18n 'user.second_factor_backup.manage' count=model.second_factor_remaining_backup_codes}}
             {{else}}
               {{i18n 'user.second_factor_backup.enable_long'}}
             {{/if}}

--- a/app/assets/javascripts/discourse/templates/preferences/account.hbs
+++ b/app/assets/javascripts/discourse/templates/preferences/account.hbs
@@ -9,7 +9,7 @@
   </div>
   {{#if siteSettings.enable_mentions}}
     <div class='instructions'>
-      {{{i18n 'user.username.short_instructions' username=model.username}}}
+      {{i18n 'user.username.short_instructions' username=model.username}}
     </div>
   {{/if}}
 </div>

--- a/app/assets/javascripts/discourse/templates/preferences/emails.hbs
+++ b/app/assets/javascripts/discourse/templates/preferences/emails.hbs
@@ -73,7 +73,7 @@
   <div class='control-group pref-mailing-list-mode'>
     <label class="control-label">{{i18n 'user.mailing_list_mode.label'}}</label>
     {{preference-checkbox labelKey="user.mailing_list_mode.enabled" checked=model.user_option.mailing_list_mode}}
-    <div class='instructions'>{{{i18n 'user.mailing_list_mode.instructions'}}}</div>
+    <div class='instructions'>{{i18n 'user.mailing_list_mode.instructions'}}</div>
     {{#if model.user_option.mailing_list_mode}}
       <div class='controls controls-dropdown'>
         {{combo-box

--- a/app/assets/javascripts/discourse/templates/preferences/profile.hbs
+++ b/app/assets/javascripts/discourse/templates/preferences/profile.hbs
@@ -66,7 +66,7 @@
     <label class="control-label">{{i18n 'user.featured_topic'}}</label>
     {{#if model.featured_topic}}
       <label class="featured-topic-link">
-      {{#link-to "topic" model.featured_topic.slug model.featured_topic.id}}{{{model.featured_topic.fancy_title}}}{{/link-to}}
+      {{#link-to "topic" model.featured_topic.slug model.featured_topic.id}}{{html-safe model.featured_topic.fancy_title}}{{/link-to}}
       </label>
     {{/if}}
 

--- a/app/assets/javascripts/discourse/templates/static.hbs
+++ b/app/assets/javascripts/discourse/templates/static.hbs
@@ -2,7 +2,7 @@
   {{#watch-read action=(action "markFaqRead") path=model.path}}
     <div class='contents clearfix body-page'>
       {{plugin-outlet name="above-static"}}
-      {{{model.html}}}
+      {{html-safe model.html}}
 
       {{#if showSignupButton}}
         {{d-button action=(route-action "showCreateAccount") class="btn-primary sign-up-button" label="sign_up"}}

--- a/app/assets/javascripts/discourse/templates/topic.hbs
+++ b/app/assets/javascripts/discourse/templates/topic.hbs
@@ -74,7 +74,7 @@
             {{#if model.details.loaded}}
               {{topic-status topic=model}}
               <a href={{model.url}} {{action "jumpTop"}} class="fancy-title">
-                {{{model.fancyTitle}}}
+                {{html-safe model.fancyTitle}}
               </a>
             {{/if}}
 
@@ -264,7 +264,7 @@
               {{#if model.queued_posts_count}}
                 <div class="has-pending-posts">
                   <div>
-                    {{{i18n "review.topic_has_pending" count=model.queued_posts_count}}}
+                    {{i18n "review.topic_has_pending" count=model.queued_posts_count}}
                   </div>
 
                   {{#link-to 'review' (query-params topic_id=model.id type="ReviewableQueuedPost" status="pending")}}
@@ -351,7 +351,7 @@
     <div class="container">
       {{#conditional-loading-spinner condition=noErrorYet}}
         {{#if model.errorHtml}}
-          <div class="not-found">{{{model.errorHtml}}}</div>
+          <div class="not-found">{{html-safe model.errorHtml}}</div>
         {{else}}
           <div class="topic-error">
             <div>{{model.errorMessage}}</div>

--- a/app/assets/javascripts/discourse/templates/unknown.hbs
+++ b/app/assets/javascripts/discourse/templates/unknown.hbs
@@ -1,3 +1,3 @@
 <div class='container'>
-  {{{model}}}
+  {{html-safe model}}
 </div>

--- a/app/assets/javascripts/discourse/templates/user-invited-show.hbs
+++ b/app/assets/javascripts/discourse/templates/user-invited-show.hbs
@@ -72,11 +72,11 @@
                       <td>{{format-date invite.user.last_seen_at}}</td>
                       <td>{{number invite.user.topics_entered}}</td>
                       <td>{{number invite.user.posts_read_count}}</td>
-                      <td>{{{format-duration invite.user.time_read}}}</td>
+                      <td>{{format-duration invite.user.time_read}}</td>
                       <td>
-                        <span title={{i18n 'user.invited.days_visited'}}>{{{invite.user.days_visited}}}</span>
+                        <span title={{i18n 'user.invited.days_visited'}}>{{html-safe invite.user.days_visited}}</span>
                           /
-                        <span title={{i18n 'user.invited.account_age_days'}}>{{{invite.user.days_since_created}}}</span>
+                        <span title={{i18n 'user.invited.account_age_days'}}>{{html-safe invite.user.days_since_created}}</span>
                       </td>
                     {{/if}}
                   {{else}}
@@ -109,7 +109,7 @@
         {{else}}
           <div class="user-invite-none">
             {{#if canBulkInvite}}
-              {{{i18n 'user.invited.bulk_invite.none'}}}
+              {{i18n 'user.invited.bulk_invite.none'}}
             {{else}}
               {{i18n 'user.invited.none'}}
             {{/if}}

--- a/app/assets/javascripts/discourse/templates/user.hbs
+++ b/app/assets/javascripts/discourse/templates/user.hbs
@@ -100,7 +100,7 @@
             {{#if showFeaturedTopic}}
               <h3 class="featured-topic">
                 <span>{{i18n 'user.featured_topic'}}</span>
-                {{#link-to "topic" model.featured_topic.slug model.featured_topic.id}}{{{model.featured_topic.fancy_title}}}{{/link-to}}
+                {{#link-to "topic" model.featured_topic.slug model.featured_topic.id}}{{html-safe model.featured_topic.fancy_title}}{{/link-to}}
               </h3>
             {{/if}}
 
@@ -137,7 +137,7 @@
                 </div>
               {{/if}}
               {{#if isNotSuspendedOrIsStaff}}
-                {{{model.bio_cooked}}}
+                {{html-safe model.bio_cooked}}
               {{/if}}
             </div>
 

--- a/app/assets/javascripts/discourse/templates/user/stream.hbs
+++ b/app/assets/javascripts/discourse/templates/user/stream.hbs
@@ -1,4 +1,4 @@
 {{#if model.noContent}}
-  <div class='alert alert-info'>{{{model.noContentHelp}}}</div>
+  <div class='alert alert-info'>{{html-safe model.noContentHelp}}</div>
 {{/if}}
 {{user-stream stream=model}}

--- a/app/assets/javascripts/discourse/templates/user/summary.hbs
+++ b/app/assets/javascripts/discourse/templates/user/summary.hbs
@@ -87,7 +87,7 @@
               </a>
               <span class='badge badge-notification clicks' title='{{i18n 'topic_map.clicks' count=link.clicks}}'>{{number link.clicks}}</span>
               <br>
-              <a href="{{link.post_url}}">{{{link.topic.fancyTitle}}}</a>
+              <a href="{{link.post_url}}">{{html-safe link.topic.fancyTitle}}</a>
             </li>
           {{/each}}
         </ul>

--- a/app/assets/javascripts/select-kit/templates/components/category-row.hbs
+++ b/app/assets/javascripts/select-kit/templates/components/category-row.hbs
@@ -9,8 +9,8 @@
   </div>
 
   {{#if shouldDisplayDescription}}
-    <div class="category-desc">{{{dir-span description}}}</div>
+    <div class="category-desc">{{dir-span description}}</div>
   {{/if}}
 {{else}}
-  {{{label}}}
+  {{html-safe label}}
 {{/if}}

--- a/app/assets/javascripts/select-kit/templates/components/dropdown-select-box/dropdown-select-box-row.hbs
+++ b/app/assets/javascripts/select-kit/templates/components/dropdown-select-box/dropdown-select-box-row.hbs
@@ -8,6 +8,6 @@
 {{/if}}
 
 <div class="texts">
-  <span class="name">{{{label}}}</span>
-  <span class="desc">{{{description}}}</span>
+  <span class="name">{{html-safe label}}</span>
+  <span class="desc">{{html-safe description}}</span>
 </div>

--- a/app/assets/javascripts/select-kit/templates/components/pinned-button.hbs
+++ b/app/assets/javascripts/select-kit/templates/components/pinned-button.hbs
@@ -1,5 +1,5 @@
 {{pinned-options value=pinned topic=topic}}
 
 <p class="reason">
-  {{{reasonText}}}
+  {{html-safe reasonText}}
 </p>

--- a/app/assets/javascripts/select-kit/templates/components/topic-notifications-button.hbs
+++ b/app/assets/javascripts/select-kit/templates/components/topic-notifications-button.hbs
@@ -10,6 +10,6 @@
 
 {{#if appendReason}}
   <p class="reason">
-    {{{topic.details.notificationReasonText}}}
+    {{html-safe topic.details.notificationReasonText}}
   </p>
 {{/if}}

--- a/app/assets/javascripts/wizard/templates/components/radio-button.hbs
+++ b/app/assets/javascripts/wizard/templates/components/radio-button.hbs
@@ -8,7 +8,7 @@
   </span>
   {{#if extraLabel}}
     <span class='extra-label'>
-      {{{extraLabel}}}
+      {{html-safe extraLabel}}
     </span>
   {{/if}}
 </div>

--- a/app/assets/javascripts/wizard/templates/components/wizard-field.hbs
+++ b/app/assets/javascripts/wizard/templates/components/wizard-field.hbs
@@ -2,7 +2,7 @@
   <span class='label-value'>{{field.label}}</span>
 
   {{#if field.description}}
-    <div class='field-description'>{{{field.description}}}</div>
+    <div class='field-description'>{{html-safe field.description}}</div>
   {{/if}}
 </label>
 
@@ -11,5 +11,5 @@
 </div>
 
 {{#if field.errorDescription}}
-  <div class='field-error-description'>{{{field.errorDescription}}}</div>
+  <div class='field-error-description'>{{html-safe field.errorDescription}}</div>
 {{/if}}

--- a/app/assets/javascripts/wizard/templates/components/wizard-step.hbs
+++ b/app/assets/javascripts/wizard/templates/components/wizard-step.hbs
@@ -8,7 +8,7 @@
   {{/if}}
 
   {{#if step.description}}
-    <p class='wizard-step-description'>{{{step.description}}}</p>
+    <p class='wizard-step-description'>{{html-safe step.description}}</p>
   {{/if}}
 
   {{#wizard-step-form step=step}}

--- a/lib/onebox/templates/discourse_topic_onebox.hbs
+++ b/lib/onebox/templates/discourse_topic_onebox.hbs
@@ -1,10 +1,10 @@
 <aside class='quote' data-post="{{post_number}}" data-topic="{{topic_id}}">
   <div class='title'>
     <div class='quote-controls'></div>
-    {{{avatar}}}
-    <a href="{{original_url}}">{{{title}}}</a> {{{category_html}}}
+    {{html-safe avatar}}
+    <a href="{{original_url}}">{{html-safe title}}</a> {{html-safe category_html}}
   </div>
   <blockquote>
-    {{{quote}}}
+    {{html-safe quote}}
   </blockquote>
 </aside>

--- a/lib/onebox/templates/discourse_user_onebox.hbs
+++ b/lib/onebox/templates/discourse_user_onebox.hbs
@@ -1,7 +1,7 @@
 <aside class="onebox">
   <article class="onebox-body user-onebox">
-    {{{avatar}}}
-    <h3><a href="{{original_url}}">{{{username}}}</a></h3>
+    {{html-safe avatar}}
+    <h3><a href="{{original_url}}">{{html-safe username}}</a></h3>
     <div>
       {{#name}}
         <span class="full-name">{{name}}</span>
@@ -11,7 +11,7 @@
           <svg class="fa d-icon d-icon-map-marker-alt svg-icon" xmlns="http://www.w3.org/2000/svg">
             <use xlink:href="#map-marker-alt"></use>
           </svg>
-          {{{location}}}
+          {{html-safe location}}
         </span>
       {{/location}}
       {{#website}}
@@ -19,12 +19,12 @@
           <svg class="fa d-icon d-icon-globe-americas svg-icon" xmlns="http://www.w3.org/2000/svg">
             <use xlink:href="#globe-americas"></use>
           </svg>
-          <a href="{{website}}">{{{website_name}}}</a>
+          <a href="{{website}}">{{html-safe website_name}}</a>
         </span>
       {{/website}}
     </div>
     {{#bio}}
-      <p>{{{bio}}}</p>
+      <p>{{html-safe bio}}</p>
     {{/bio}}
     <span>{{joined}} {{created_at}}</span>
   </article>

--- a/plugins/discourse-local-dates/assets/javascripts/discourse/templates/components/discourse-local-dates-create-form.hbs
+++ b/plugins/discourse-local-dates/assets/javascripts/discourse/templates/components/discourse-local-dates-create-form.hbs
@@ -85,7 +85,7 @@
             <label class="control-label">
               {{i18n "discourse_local_dates.create.form.recurring_title"}}
             </label>
-            <p>{{{i18n "discourse_local_dates.create.form.recurring_description"}}}</p>
+            <p>{{i18n "discourse_local_dates.create.form.recurring_description"}}</p>
             <div class="controls">
               {{combo-box
                 content=recurringOptions

--- a/test/javascripts/components/html-safe-helper-test.js.es6
+++ b/test/javascripts/components/html-safe-helper-test.js.es6
@@ -1,0 +1,14 @@
+import componentTest from "helpers/component-test";
+moduleForComponent("html-safe-helper", { integration: true });
+
+componentTest("default", {
+  template: "{{html-safe string}}",
+
+  beforeEach() {
+    this.set("string", "<p class='cookies'>biscuits</p>");
+  },
+
+  async test(assert) {
+    assert.ok(exists("p.cookies"), "it displays the string as html");
+  }
+});

--- a/test/javascripts/lib/computed-test.js.es6
+++ b/test/javascripts/lib/computed-test.js.es6
@@ -5,7 +5,8 @@ import {
   propertyNotEqual,
   fmt,
   i18n,
-  url
+  url,
+  htmlSafe
 } from "discourse/lib/computed";
 
 QUnit.module("lib:computed", {
@@ -153,4 +154,13 @@ QUnit.test("url", assert => {
     "/prefixed/u/eviltrout",
     "it supports urls with a prefix"
   );
+});
+
+QUnit.test("htmlSafe", assert => {
+  const cookies = "<p>cookies and <b>biscuits</b></p>";
+  const t = EmberObject.extend({
+    desc: htmlSafe("cookies")
+  }).create({ cookies });
+
+  assert.equal(t.get("desc").string, cookies);
 });


### PR DESCRIPTION
This pr replaces `{{{ }}}` usage by a {{html-safe}} helper. While it doesn't solve the underlying issue, it gives us a path forward without risking breaking too much existing behavior.

Also introduces an htmlSafe computed macro:

```
import { htmlSafe } from "discourse/lib/computed";

htmlDescription: htmlSafe("description")
```

Overtime {{html-safe}} usage should be removed and moved to components properties or specialized components/helpers.