### PR TITLE
FIX: Set current user timezone when saving profile timezone

### DIFF
--- a/app/assets/javascripts/discourse/controllers/preferences/profile.js.es6
+++ b/app/assets/javascripts/discourse/controllers/preferences/profile.js.es6
@@ -93,6 +93,12 @@ export default Controller.extend(PreferencesTabController, {
       return model
         .save(this.saveAttrNames)
         .then(() => {
+          // update the timezone in memory so we can use the new
+          // one if we change routes without reloading the user
+          if (this.currentUser.id === this.model.id) {
+            this.currentUser.timezone = this.model.user_option.timezone;
+          }
+
           cookAsync(model.get("bio_raw"))
             .then(() => {
               model.set("bio_cooked");


### PR DESCRIPTION
 If you are changing your own profile timezone, then on save we set the current user timezone, in case this property needs to be accessed again before the user is reloaded.