### PR TITLE
FIX: Preserve TopicCreator's timestamp resolution

### DIFF
--- a/lib/topic_creator.rb
+++ b/lib/topic_creator.rb
@@ -118,9 +118,9 @@ class TopicCreator
 
     topic_params[:category_id] = category.id if category.present?
 
-    topic_params[:created_at] = Time.zone.parse(@opts[:created_at].to_s) if @opts[:created_at].present?
+    topic_params[:created_at] = convert_time(@opts[:created_at]) if @opts[:created_at].present?
 
-    topic_params[:pinned_at] = Time.zone.parse(@opts[:pinned_at].to_s) if @opts[:pinned_at].present?
+    topic_params[:pinned_at] = convert_time(@opts[:pinned_at]) if @opts[:pinned_at].present?
     topic_params[:pinned_globally] = @opts[:pinned_globally] if @opts[:pinned_globally].present?
 
     if SiteSetting.topic_featured_link_enabled && @opts[:featured_link].present? && @guardian.can_edit_featured_link?(topic_params[:category_id])
@@ -128,6 +128,14 @@ class TopicCreator
     end
 
     topic_params
+  end
+
+  def convert_time(timestamp)
+    if timestamp.is_a?(Time)
+      timestamp
+    else
+      Time.zone.parse(timestamp.to_s)
+    end
   end
 
   def find_category

--- a/spec/components/topic_creator_spec.rb
+++ b/spec/components/topic_creator_spec.rb
@@ -3,7 +3,6 @@
 require 'rails_helper'
 
 describe TopicCreator do
-
   fab!(:user)      { Fabricate(:user, trust_level: TrustLevel[2]) }
   fab!(:moderator) { Fabricate(:moderator) }
   fab!(:admin)     { Fabricate(:admin) }
@@ -235,6 +234,35 @@ describe TopicCreator do
             TopicCreator.create(user, Guardian.new(user), pm_to_email_valid_attrs)
           end.to raise_error(ActiveRecord::Rollback)
         end
+      end
+    end
+
+    context 'setting timestamps' do
+      it 'supports Time instances' do
+        freeze_time
+
+        topic = TopicCreator.create(user, Guardian.new(user), valid_attrs.merge(
+          created_at: 1.week.ago,
+          pinned_at: 3.days.ago
+        ))
+
+        expect(topic.created_at).to be_within(1.second).of(1.week.ago)
+        expect(topic.pinned_at).to be_within(1.second).of(3.days.ago)
+      end
+
+      it 'supports strings' do
+        freeze_time
+
+        time1 = Time.zone.parse('2019-09-02')
+        time2 = Time.zone.parse('2020-03-10 15:17')
+
+        topic = TopicCreator.create(user, Guardian.new(user), valid_attrs.merge(
+          created_at: '2019-09-02',
+          pinned_at: '2020-03-10 15:17'
+        ))
+
+        expect(topic.created_at).to be_within(1.second).of(time1)
+        expect(topic.pinned_at).to be_within(1.second).of(time2)
       end
     end
   end


### PR DESCRIPTION
Continuation of #9140. It's the last piece required for #9141.