### PR TITLE
FIX: Throw error when removing a user from group fails

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -398,14 +398,16 @@ class GroupsController < ApplicationController
     end
 
     users.each do |user|
-      group.remove(user)
-      GroupActionLogger.new(current_user, group).log_remove_user_from_group(user)
+      if group.remove(user)
+        GroupActionLogger.new(current_user, group).log_remove_user_from_group(user)
+      else
+        raise Discourse::InvalidParameters
+      end
     end
 
     render json: success_json.merge!(
       usernames: users.map(&:username)
     )
-
   end
 
   def request_membership

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -644,9 +644,11 @@ class Group < ActiveRecord::Base
   end
 
   def remove(user)
-    self.group_users.where(user: user).each(&:destroy)
+    result = self.group_users.where(user: user).each(&:destroy)
+    return false if result.blank?
     user.update_columns(primary_group_id: nil) if user.primary_group_id == self.id
     DiscourseEvent.trigger(:user_removed_from_group, user, self)
+    true
   end
 
   def add_owner(user)

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -347,8 +347,9 @@ RSpec.describe Admin::UsersController do
 
   describe '#remove_group' do
     it "also clears the user's primary group" do
-      g = Fabricate(:group)
-      u = Fabricate(:user, primary_group: g)
+      u = Fabricate(:user)
+      g = Fabricate(:group, users: [u])
+      u.update!(primary_group_id: g.id)
       delete "/admin/users/#{u.id}/groups/#{g.id}.json"
 
       expect(response.status).to eq(200)

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -1192,6 +1192,11 @@ describe GroupsController do
         expect(response.status).to eq(400)
       end
 
+      it "raises an error when removing a valid user but is not a member of that group" do
+        delete "/groups/#{group.id}/members.json", params: { user_id: -1 }
+        expect(response.status).to eq(400)
+      end
+
       context "is able to remove a member" do
         it "removes by id" do
           expect do
@@ -1314,12 +1319,10 @@ describe GroupsController do
           end
 
           it "only removes users in that group" do
-            expect do
-              delete "/groups/#{group1.id}/members.json",
-                params: { usernames: [user.username, user2.username].join(",") }
-            end.to change { group1.users.count }.by(-1)
+            delete "/groups/#{group1.id}/members.json",
+              params: { usernames: [user.username, user2.username].join(",") }
 
-            expect(response.status).to eq(200)
+            expect(response.status).to eq(400)
           end
         end
       end


### PR DESCRIPTION
This commit ensures that an error is thrown when a user fails to be
removed from a group instead of silently failing.

This means when using the api you will receive a 400 instead of a 200 if
there is a failure. The remove group endpoint allows the removal of
multiple users, this change means that if you try to delete 10 users,
but 1 of them fails you will receive a 400 instead of 200 even though
the other 9 were removed successfully. Rather than adding a bunch more
complexity I think this is more than adequate for most use cases.