### PR TITLE
UX: Add quick filters to reviewable page

### DIFF
--- a/app/assets/javascripts/discourse/controllers/review-index.js
+++ b/app/assets/javascripts/discourse/controllers/review-index.js
@@ -1,5 +1,6 @@
 import discourseComputed from "discourse-common/utils/decorators";
 import Controller from "@ember/controller";
+import { not } from "@ember/object/computed";
 
 export default Controller.extend({
   queryParams: [
@@ -85,6 +86,44 @@ export default Controller.extend({
     return filtersExpanded ? "chevron-up" : "chevron-down";
   },
 
+  @discourseComputed(
+    "type",
+    "priority",
+    "status",
+    "category_id",
+    "username",
+    "from_date",
+    "to_date",
+    "sort_order",
+    "additional_filters"
+  )
+  anyFilters(
+    type,
+    priority,
+    status,
+    category_id,
+    username,
+    from_date,
+    to_date,
+    sort_order,
+    additional_filters
+  ) {
+    return (
+      type != null ||
+      priority !== "low" ||
+      status !== "pending" ||
+      category_id !== null ||
+      username !== "" ||
+      from_date !== null ||
+      to_date !== null ||
+      sort_order !== "priority" ||
+      (additional_filters !== null &&
+        Object.keys(additional_filters).length !== 0)
+    );
+  },
+
+  disableFilterReset: not("anyFilters"),
+
   setRange(range) {
     if (range.from) {
       this.set("from", new Date(range.from).toISOString().split("T")[0]);
@@ -124,6 +163,27 @@ export default Controller.extend({
         additional_filters: JSON.stringify(this.additionalFilters)
       });
 
+      this.send("refreshRoute");
+    },
+
+    resetFilters() {
+      this.setProperties({
+        type: null,
+        priority: "low",
+        status: "pending",
+        category_id: null,
+        username: "",
+        from_date: null,
+        to_date: null,
+        sort_order: "priority",
+        additional_filters: null
+      });
+
+      this.send("refreshRoute");
+    },
+
+    setFilters(newFilters) {
+      this.setProperties(newFilters);
       this.send("refreshRoute");
     },
 

--- a/app/assets/javascripts/discourse/templates/review-index.hbs
+++ b/app/assets/javascripts/discourse/templates/review-index.hbs
@@ -17,16 +17,36 @@
   </div>
 
   <div class='reviewable-filters'>
-    <div class='reviewable-filter'>
-      <label class='filter-label'>{{i18n "review.filters.status"}}</label>
-      {{combo-box
-        value=filterStatus
-        content=statuses
-        onChange=(action (mut filterStatus))
-      }}
+    <div class='reviewable-filter quick-filters'>
+      {{i18n "review.filters.quick"}}
+      <div>
+        {{d-button
+          label="review.filters.reset"
+          icon="times"
+          class="btn-default"
+          disabled=disableFilterReset
+          action=(action "resetFilters")}}
+
+        {{plugin-outlet name="review-quick-filters" args=(hash model=model)}}
+
+        {{d-button
+          label="review.filters.resolved"
+          class="btn-default"
+          action=(action "setFilters")
+          actionParam=(hash sort_order="created_at" status="reviewed")}}
+      </div>
     </div>
 
     {{#if filtersExpanded}}
+
+      <div class='reviewable-filter'>
+        <label class='filter-label'>{{i18n "review.filters.status"}}</label>
+        {{combo-box
+          value=filterStatus
+          content=statuses
+          onChange=(action (mut filterStatus))
+        }}
+      </div>
 
       {{plugin-outlet name="above-review-filters" args=(hash model=model additionalFilters=additionalFilters)}}
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -492,7 +492,10 @@ en:
           title: "Type"
           all: "(all types)"
         minimum_score: "Minimum Score:"
+        quick: "Quick Filters"
         refresh: "Refresh"
+        reset: "Reset"
+        resolved: "Reviewed"
         status: "Status"
         category: "Category"
         orders:


### PR DESCRIPTION
It was annoying me to have to set two different dropdowns whenever I wanted to check for a recently resolved flag. Add a place for buttons for commonly used review filters, which replaces the status chooser above the mobile fold.

"Reset to default" gets special handling in the form of a disable handler.

Additional suggestions for other common filters welcome or can be added in followups.