### PR TITLE
FIX: Add topic deleted check to email/sender

### DIFF
--- a/app/models/skipped_email_log.rb
+++ b/app/models/skipped_email_log.rb
@@ -36,7 +36,8 @@ class SkippedEmailLog < ActiveRecord::Base
       sender_body_blank: 19,
       sender_post_deleted: 20,
       sender_message_to_invalid: 21,
-      user_email_access_denied: 22
+      user_email_access_denied: 22,
+      sender_topic_deleted: 23
       # you need to add the reason in server.en.yml below the "skipped_email_log" key
       # when you add a new enum value
     )

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -3764,6 +3764,7 @@ en:
     sender_body_blank: "body is blank"
     sender_post_deleted: "post has been deleted"
     sender_message_to_invalid: "recipient has invalid email address"
+    sender_topic_deleted: "topic has been deleted"
 
   color_schemes:
     base_theme_name: "Base"

--- a/lib/email/sender.rb
+++ b/lib/email/sender.rb
@@ -96,12 +96,13 @@ module Email
       if topic_id.present? && post_id.present?
         post = Post.find_by(id: post_id, topic_id: topic_id)
 
-        # guards against deleted posts
-        return skip(SkippedEmailLog.reason_types[:sender_post_deleted]) unless post
-
-        add_attachments(post)
+        # guards against deleted posts and topics
+        return skip(SkippedEmailLog.reason_types[:sender_post_deleted]) if post.blank?
 
         topic = post.topic
+        return skip(SkippedEmailLog.reason_types[:sender_topic_deleted]) if topic.blank?
+
+        add_attachments(post)
         first_post = topic.ordered_posts.first
 
         topic_message_id = first_post.incoming_email&.message_id.present? ?

--- a/spec/components/email/sender_spec.rb
+++ b/spec/components/email/sender_spec.rb
@@ -433,6 +433,25 @@ describe Email::Sender do
 
   end
 
+  context 'with a deleted topic' do
+
+    it 'should skip sending the email' do
+      post = Fabricate(:post, topic: Fabricate(:topic, deleted_at: 1.day.ago))
+
+      message = Mail::Message.new to: 'disc@ourse.org', body: 'some content'
+      message.header['X-Discourse-Post-Id'] = post.id
+      message.header['X-Discourse-Topic-Id'] = post.topic_id
+      message.expects(:deliver_now).never
+
+      email_sender = Email::Sender.new(message, :valid_type)
+      expect { email_sender.send }.to change { SkippedEmailLog.count }
+
+      log = SkippedEmailLog.last
+      expect(log.reason_type).to eq(SkippedEmailLog.reason_types[:sender_topic_deleted])
+    end
+
+  end
+
   context 'with a user' do
     let(:message) do
       message = Mail::Message.new to: 'eviltrout@test.domain', body: 'test body'


### PR DESCRIPTION
It already had a deleted post check and log reason, add a topic one too to avoid errors