### PR TITLE
FIX: prevents crash when to be unescaped emoji is not a string

### DIFF
--- a/app/assets/javascripts/pretty-text/emoji.js.es6
+++ b/app/assets/javascripts/pretty-text/emoji.js.es6
@@ -92,7 +92,7 @@ function isReplacableInlineEmoji(string, index, inlineEmoji) {
 }
 
 export function performEmojiUnescape(string, opts) {
-  if (!string) {
+  if (!string || typeof string !== "string") {
     return;
   }
 


### PR DESCRIPTION
I couldn't get a repro so this is a shot in the dark and doesn't solve the root issue, but should prevent topic view from crashing.