### PR TITLE
FIX: Enter adds link in composer from hyperlink modal

### DIFF
--- a/app/assets/javascripts/discourse/templates/modal/insert-hyperlink.hbs
+++ b/app/assets/javascripts/discourse/templates/modal/insert-hyperlink.hbs
@@ -1,42 +1,44 @@
-{{#d-modal-body title="composer.link_dialog_title" class="insert-link"}}
-    <div class="inputs">
-      {{text-field
-        value=linkUrl
-        placeholderKey="composer.link_url_placeholder"
-        class="link-url"
-        key-up=(action "search")
-      }}
-      {{#if searchLoading}}
-        {{loading-spinner}}
-      {{/if}}
-      {{#if searchResults}}
-        <div class="internal-link-results">
-          {{#each searchResults as |result|}}
-            <a
-              class="search-link"
-              href={{result.url}}
-              onclick={{action "linkClick"}}
-              data-title={{result.title}}>
-              {{topic-status topic=result disableActions=true}}
-              {{replace-emoji result.fancy_title}}
-              <div class="search-category">
-                {{#if result.category.parentCategory}}
-                  {{category-link result.category.parentCategory}}
-                {{/if}}
-                {{category-link result.category hideParent=true}}
-                {{discourse-tags result}}
-              </div>
-            </a>
-          {{/each}}
-        </div>
-      {{/if}}
-    </div>
-    <div class="inputs">
-      {{text-field value=linkText placeholderKey="composer.link_optional_text" class="link-text"}}
-    </div>
-{{/d-modal-body}}
+<form {{action "ok" on="submit"}}>
+  {{#d-modal-body title="composer.link_dialog_title" class="insert-link"}}
+      <div class="inputs">
+        {{text-field
+          value=linkUrl
+          placeholderKey="composer.link_url_placeholder"
+          class="link-url"
+          key-up=(action "search")
+        }}
+        {{#if searchLoading}}
+          {{loading-spinner}}
+        {{/if}}
+        {{#if searchResults}}
+          <div class="internal-link-results">
+            {{#each searchResults as |result|}}
+              <a
+                class="search-link"
+                href={{result.url}}
+                onclick={{action "linkClick"}}
+                data-title={{result.title}}>
+                {{topic-status topic=result disableActions=true}}
+                {{replace-emoji result.fancy_title}}
+                <div class="search-category">
+                  {{#if result.category.parentCategory}}
+                    {{category-link result.category.parentCategory}}
+                  {{/if}}
+                  {{category-link result.category hideParent=true}}
+                  {{discourse-tags result}}
+                </div>
+              </a>
+            {{/each}}
+          </div>
+        {{/if}}
+      </div>
+      <div class="inputs">
+        {{text-field value=linkText placeholderKey="composer.link_optional_text" class="link-text"}}
+      </div>
+  {{/d-modal-body}}
 
-<div class="modal-footer">
-  {{d-button class="btn-primary" label="composer.modal_ok" action=(action "ok")}}
-  {{d-button class="btn-danger" label="composer.modal_cancel" action=(action "cancel")}}
-</div>
+  <div class="modal-footer">
+    {{d-button class="btn-primary" label="composer.modal_ok" action=(action "ok") type="submit"}}
+    {{d-button class="btn-danger" label="composer.modal_cancel" action=(action "cancel")}}
+  </div>
+</form>


### PR DESCRIPTION
@osioke reported that the hyperlink modal no longer adds the link when <kbd>Enter</kbd> is pressed.

All I do here is wrap the modal content and footer in a form, which on submit, adds the link.

![Screenshot from 2020-03-12 08-51-09](https://user-images.githubusercontent.com/16214023/76528500-e884f900-643e-11ea-8ca0-24c55de06dce.png)
