### PR TITLE
FIX: Failed to restore backups from versions without translation overrides

### DIFF
--- a/config/initializers/100-i18n.rb
+++ b/config/initializers/100-i18n.rb
@@ -9,7 +9,7 @@ I18n.backend = I18n::Backend::DiscourseI18n.new
 I18n.fallbacks = I18n::Backend::FallbackLocaleList.new
 I18n.config.missing_interpolation_argument_handler = proc { throw(:exception) }
 I18n.reload!
-I18n.init_accelerator!
+I18n.init_accelerator!(overrides_enabled: ENV['DISABLE_TRANSLATION_OVERRIDES'] != '1')
 
 unless Rails.env.test?
   MessageBus.subscribe("/i18n-flush") do

--- a/lib/backup_restore/database_restorer.rb
+++ b/lib/backup_restore/database_restorer.rb
@@ -134,7 +134,11 @@ module BackupRestore
       log "Migrating the database..."
 
       log Discourse::Utils.execute_command(
-        { "SKIP_POST_DEPLOYMENT_MIGRATIONS" => "0", "SKIP_OPTIMIZE_ICONS" => "1" },
+        {
+          "SKIP_POST_DEPLOYMENT_MIGRATIONS" => "0",
+          "SKIP_OPTIMIZE_ICONS" => "1",
+          "DISABLE_TRANSLATION_OVERRIDES" => "1"
+        },
         "rake db:migrate",
         failure_message: "Failed to migrate database.",
         chdir: Rails.root

--- a/lib/freedom_patches/translate_accelerator.rb
+++ b/lib/freedom_patches/translate_accelerator.rb
@@ -21,8 +21,8 @@ module I18n
 
     LRU_CACHE_SIZE = 400
 
-    def init_accelerator!
-      @overrides_enabled = true
+    def init_accelerator!(overrides_enabled: true)
+      @overrides_enabled = overrides_enabled
       execute_reload
     end
 

--- a/spec/lib/backup_restore/database_restorer_spec.rb
+++ b/spec/lib/backup_restore/database_restorer_spec.rb
@@ -38,6 +38,7 @@ describe BackupRestore::DatabaseRestorer do
     Discourse::Utils.expects(:execute_command).with do |env, command, options|
       env["SKIP_POST_DEPLOYMENT_MIGRATIONS"] == "0" &&
         env["SKIP_OPTIMIZE_ICONS"] == "1" &&
+        env["DISABLE_TRANSLATION_OVERRIDES"] == "1" &&
         command == "rake db:migrate" &&
         options[:chdir] == Rails.root
     end.once


### PR DESCRIPTION
Rails calls I18n.translate during initialization and by default translation overrides are used. Database migrations would fail if the system tried to migrate from an old version that didn't have the `translation_overrides` table with all its columns yet.

This makes restoring really old backups work again. Running `DISABLE_TRANSLATION_OVERRIDES=1 rake db:migrate` will allow you to upgrade such an old database as well.