### PR TITLE
FEATURE: Add enable_bookmark_at_desktop_reminders site setting

### DIFF
--- a/app/assets/javascripts/discourse/controllers/bookmark.js
+++ b/app/assets/javascripts/discourse/controllers/bookmark.js
@@ -5,7 +5,6 @@ import discourseComputed from "discourse-common/utils/decorators";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { htmlSafe } from "@ember/template";
 import { ajax } from "discourse/lib/ajax";
-import { reads } from "@ember/object/computed";
 
 const START_OF_DAY_HOUR = 8;
 const REMINDER_TYPES = {
@@ -52,8 +51,15 @@ export default Controller.extend(ModalFunctionality, {
     }
   },
 
-  usingMobileDevice: reads("site.mobileView"),
   showBookmarkReminderControls: true,
+
+  @discourseComputed()
+  showAtDesktop() {
+    return (
+      this.siteSettings.enable_bookmark_at_desktop_reminders &&
+      this.site.mobileView
+    );
+  },
 
   @discourseComputed("selectedReminderType")
   customDateTimeSelected(selectedReminderType) {

--- a/app/assets/javascripts/discourse/templates/modal/bookmark.hbs
+++ b/app/assets/javascripts/discourse/templates/modal/bookmark.hbs
@@ -24,7 +24,7 @@
 
       {{#if userHasTimezoneSet}}
         {{#tap-tile-grid activeTile=selectedReminderType as |grid|}}
-          {{#if usingMobileDevice}}
+          {{#if showAtDesktop}}
             {{tap-tile icon="desktop" text=(i18n "bookmarks.reminders.at_desktop") tileId=reminderTypes.AT_DESKTOP activeTile=grid.activeTile onChange=(action "selectReminderType")}}
           {{/if}}
 

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -293,6 +293,10 @@ basic:
     client: true
     default: false
     hidden: true
+  enable_bookmark_at_desktop_reminders:
+    client: true
+    default: false
+    hidden: true
   push_notifications_prompt:
     default: true
     client: true


### PR DESCRIPTION
Add enable_bookmark_at_desktop_reminders site setting default to false a new hidden site setting to hide the "At Desktop" reminder option so we can restrict this further until it is polished.