### PR TITLE
FEATURE: Show rejected posts count in user summary

### DIFF
--- a/app/assets/javascripts/discourse/templates/user.hbs
+++ b/app/assets/javascripts/discourse/templates/user.hbs
@@ -16,6 +16,14 @@
             {{/link-to}}
           </div>
         {{/if}}
+        {{#if model.number_of_rejected_posts}}
+          <div>
+            {{#link-to 'review' (query-params username=model.username status='rejected' type='ReviewableQueuedPost')}}
+              <span class="flagged-posts">{{model.number_of_rejected_posts}}</span>{{i18n 'user.staff_counters.rejected_posts'}}
+            {{/link-to}}
+          </div>
+        {{/if}}
+        
         {{#if model.number_of_deleted_posts}}
           <div>
             {{#link-to 'user.deletedPosts' model}}

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1111,7 +1111,10 @@ class UsersController < ApplicationController
 
     result = {}
 
-    %W{number_of_deleted_posts number_of_flagged_posts number_of_flags_given number_of_suspensions warnings_received_count}.each do |info|
+    %W{
+      number_of_deleted_posts number_of_flagged_posts number_of_flags_given
+      number_of_suspensions warnings_received_count number_of_rejected_posts
+    }.each do |info|
       result[info] = @user.public_send(info)
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1125,6 +1125,14 @@ class User < ActiveRecord::Base
       .count
   end
 
+  def number_of_rejected_posts
+    Post.with_deleted
+      .where(user_id: self.id)
+      .joins('INNER JOIN reviewables r ON posts.id = r.target_id')
+      .where(r: { status: Reviewable.statuses[:rejected], type: ReviewableQueuedPost.name })
+      .count
+  end
+
   def number_of_flags_given
     PostAction.where(user_id: self.id)
       .where(disagreed_at: nil)

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -945,6 +945,7 @@ en:
         deleted_posts: "deleted posts"
         suspensions: "suspensions"
         warnings_received: "warnings"
+        rejected_posts: "rejected posts"
 
       messages:
         all: "All"


### PR DESCRIPTION
[Context](https://meta.discourse.org/t/add-number-of-rejected-posts-to-top-bar-on-user-summary-page/141643/6)