### PR TITLE
FIX: Don't display webhooks for inactive plugins

### DIFF
--- a/app/controllers/admin/web_hooks_controller.rb
+++ b/app/controllers/admin/web_hooks_controller.rb
@@ -16,7 +16,7 @@ class Admin::WebHooksController < Admin::AdminController
     json = {
       web_hooks: serialize_data(web_hooks, AdminWebHookSerializer),
       extras: {
-        event_types: WebHookEventType.all,
+        event_types: WebHookEventType.all_excluding_disabled_plugin_web_hooks,
         default_event_types: WebHook.default_event_types,
         content_types: WebHook.content_types.map { |name, id| { id: id, name: name } },
         delivery_statuses: WebHook.last_delivery_statuses.map { |name, id| { id: id, name: name.to_s } },

--- a/app/controllers/admin/web_hooks_controller.rb
+++ b/app/controllers/admin/web_hooks_controller.rb
@@ -16,7 +16,7 @@ class Admin::WebHooksController < Admin::AdminController
     json = {
       web_hooks: serialize_data(web_hooks, AdminWebHookSerializer),
       extras: {
-        event_types: WebHookEventType.all_excluding_disabled_plugin_web_hooks,
+        event_types: WebHookEventType.active,
         default_event_types: WebHook.default_event_types,
         content_types: WebHook.content_types.map { |name, id| { id: id, name: name } },
         delivery_statuses: WebHook.last_delivery_statuses.map { |name, id| { id: id, name: name.to_s } },

--- a/app/models/web_hook_event_type.rb
+++ b/app/models/web_hook_event_type.rb
@@ -20,7 +20,7 @@ class WebHookEventType < ActiveRecord::Base
 
   validates :name, presence: true, uniqueness: true
 
-  def self.all_excluding_disabled_plugin_web_hooks
+  def self.active
     ids_to_exclude = []
     ids_to_exclude << SOLVED unless defined?(SiteSetting.solved_enabled) && SiteSetting.solved_enabled
     ids_to_exclude << ASSIGN unless defined?(SiteSetting.assign_enabled) && SiteSetting.assign_enabled

--- a/app/models/web_hook_event_type.rb
+++ b/app/models/web_hook_event_type.rb
@@ -19,6 +19,15 @@ class WebHookEventType < ActiveRecord::Base
   default_scope { order('id ASC') }
 
   validates :name, presence: true, uniqueness: true
+
+  def self.all_excluding_disabled_plugin_web_hooks
+    ids_to_exclude = []
+    ids_to_exclude << SOLVED unless defined?(SiteSetting.solved_enabled) && SiteSetting.solved_enabled
+    ids_to_exclude << ASSIGN unless defined?(SiteSetting.assign_enabled) && SiteSetting.assign_enabled
+
+    self.where.not(id: ids_to_exclude)
+  end
+
 end
 
 # == Schema Information

--- a/spec/models/web_hook_spec.rb
+++ b/spec/models/web_hook_spec.rb
@@ -44,6 +44,22 @@ describe WebHook do
       expect(post_hook.payload_url).to eq("https://example.com")
     end
 
+    it "excludes disabled plugin web_hooks" do
+      web_hook_event_types = WebHookEventType.all_excluding_disabled_plugin_web_hooks.find_by(name: 'solved')
+      expect(web_hook_event_types).to eq(nil)
+    end
+
+    it "includes non-plugin web_hooks" do
+      web_hook_event_types = WebHookEventType.all_excluding_disabled_plugin_web_hooks.where(name: 'topic')
+      expect(web_hook_event_types.count).to eq(1)
+    end
+
+    it "includes enabled plugin web_hooks" do
+      SiteSetting.stubs(:solved_enabled).returns(true)
+      web_hook_event_types = WebHookEventType.all_excluding_disabled_plugin_web_hooks.where(name: 'solved')
+      expect(web_hook_event_types.count).to eq(1)
+    end
+
     describe '#active_web_hooks' do
       it "returns unique hooks" do
         post_hook.web_hook_event_types << WebHookEventType.find_by(name: 'topic')

--- a/spec/models/web_hook_spec.rb
+++ b/spec/models/web_hook_spec.rb
@@ -45,18 +45,18 @@ describe WebHook do
     end
 
     it "excludes disabled plugin web_hooks" do
-      web_hook_event_types = WebHookEventType.all_excluding_disabled_plugin_web_hooks.find_by(name: 'solved')
+      web_hook_event_types = WebHookEventType.active.find_by(name: 'solved')
       expect(web_hook_event_types).to eq(nil)
     end
 
     it "includes non-plugin web_hooks" do
-      web_hook_event_types = WebHookEventType.all_excluding_disabled_plugin_web_hooks.where(name: 'topic')
+      web_hook_event_types = WebHookEventType.active.where(name: 'topic')
       expect(web_hook_event_types.count).to eq(1)
     end
 
     it "includes enabled plugin web_hooks" do
       SiteSetting.stubs(:solved_enabled).returns(true)
-      web_hook_event_types = WebHookEventType.all_excluding_disabled_plugin_web_hooks.where(name: 'solved')
+      web_hook_event_types = WebHookEventType.active.where(name: 'solved')
       expect(web_hook_event_types.count).to eq(1)
     end
 


### PR DESCRIPTION
This commit ensures that we don't show webhooks for plugins that are not
installed or that are disabled.

Bug report:

https://meta.discourse.org/t/webhookeventtype-and-the-solved-and-assign-plugins/144180