### PR TITLE
FIX: Ensure show_short URLs handle secure uploads using multisite

### DIFF
--- a/spec/requests/uploads_controller_spec.rb
+++ b/spec/requests/uploads_controller_spec.rb
@@ -398,8 +398,18 @@ describe UploadsController do
           upload.update(access_control_post: post)
 
           get upload.short_path
-
           expect(response.code).to eq("403")
+        end
+
+        context "when running on a multisite connection" do
+          before do
+            Rails.configuration.multisite = true
+          end
+          it "redirects to the signed_url_for_path with the multisite DB name in the url" do
+            freeze_time
+            get upload.short_path
+            expect(response.body).to include(RailsMultisite::ConnectionManagement.current_db)
+          end
         end
       end
     end


### PR DESCRIPTION
Meta report: https://meta.discourse.org/t/short-url-secure-uploads-s3/144224

* if the show_short route is hit for an upload that is
  secure, we redirect to the secure presigned URL. however
  this was not taking into account multisite so the db name
  was left off the path which broke the presigned URL
* we now use the correct url_for method if we know the
  upload (like in the show_short case) which takes into
  account multisite