### PR TITLE
FIX: Improve bookmark modal on mobile and bookmark sync rake task

### DIFF
--- a/app/assets/javascripts/discourse/templates/modal/bookmark.hbs
+++ b/app/assets/javascripts/discourse/templates/modal/bookmark.hbs
@@ -38,14 +38,14 @@
           {{tap-tile icon="ban" text=(I18n "bookmarks.reminders.none") tileId=reminderTypes.NONE activeTile=grid.activeTile onChange=(action "selectReminderType")}}
         {{/tap-tile-grid}}
         {{#if customDateTimeSelected}}
-          <div class="control-group">
+          <div class="control-group custom-date-time-wrap">
             {{d-icon "calendar-alt"}}
             {{date-picker-future
               value=customReminderDate
               onSelect=(action (mut customReminderDate))
             }}
             {{d-icon "far-clock"}}
-            {{input placeholder="--:--" type="time" value=customReminderTime}}
+            {{input placeholder="--:--" type="time" class="time-input" value=customReminderTime}}
           </div>
         {{/if}}
 

--- a/app/assets/stylesheets/common/components/bookmark-modal.scss
+++ b/app/assets/stylesheets/common/components/bookmark-modal.scss
@@ -1,7 +1,11 @@
 .bookmark-with-reminder.modal {
+  .modal-inner-container {
+    max-width: 95%;
+  }
   .modal-body {
     max-width: 410px;
     min-width: 380px;
+    box-sizing: border-box;
 
     .control-label {
       font-weight: 700;
@@ -9,6 +13,28 @@
 
     .ember-text-field.bookmark-name {
       width: 100%;
+    }
+  }
+
+  .custom-date-time-wrap {
+    display: flex;
+    flex-direction: row;
+    align-items: baseline;
+
+    .svg-icon {
+      padding: 0 5px;
+    }
+
+    .date-picker-wrapper {
+      flex: 1;
+
+      .date-picker {
+        width: 100%;
+      }
+    }
+
+    .time-input {
+      flex: 1;
     }
   }
 }

--- a/spec/tasks/bookmarks_spec.rb
+++ b/spec/tasks/bookmarks_spec.rb
@@ -43,6 +43,17 @@ RSpec.describe "bookmarks tasks" do
     expect(Bookmark.all.count).to eq(1)
   end
 
+  it "skips post actions where the post topic no longer exists and does not error" do
+    post1.topic.delete
+    post1.reload
+    expect { invoke_task }.not_to raise_error
+  end
+
+  it "skips post actions where the post no longer exists and does not error" do
+    post1.delete
+    expect { invoke_task }.not_to raise_error
+  end
+
   def create_post_actions_and_existing_bookmarks
     Fabricate(:post_action, user: user1, post: post1, post_action_type_id: PostActionType.types[:bookmark])
     Fabricate(:post_action, user: user2, post: post2, post_action_type_id: PostActionType.types[:bookmark])


### PR DESCRIPTION
* Improve the bookmark mobile on modal so it doesn't go all the way to the edge and the custom datetime input is easier to use
* Improve the rake task for syncing so it does not error for topics that no longer exist and batches 2000 inserts at a time, clearing the array each time