### PR TITLE
FIX: Condense line codes in emails

### DIFF
--- a/lib/email/styles.rb
+++ b/lib/email/styles.rb
@@ -195,7 +195,7 @@ module Email
       style('div.summary-footer', 'color:#666; font-size:95%; text-align:center; padding-top:15px;')
       style('span.post-count', 'margin: 0 5px; color: #777;')
       style('pre', 'word-wrap: break-word; max-width: 694px;')
-      style('code', 'background-color: #f1f1ff; padding: 2px 5px;')
+      style('code', 'background-color: #f1f1ff; line-height: 50%; padding: 2px 5px;')
       style('pre code', 'display: block; background-color: #f1f1ff; padding: 5px;')
       style('.featured-topic a', "text-decoration: none; font-weight: bold; color: #{SiteSetting.email_link_color}; line-height:1.5em;")
       style('.secure-image-notice', 'font-style: italic; background-color: #f1f1ff; padding: 5px;')


### PR DESCRIPTION
Before
<img width="740" alt="Screenshot 2020-03-17 at 16 41 30" src="https://user-images.githubusercontent.com/23153890/76867607-7103ff00-686e-11ea-819c-3d4639dfeff4.png">

After
<img width="740" alt="Screenshot 2020-03-17 at 16 41 32" src="https://user-images.githubusercontent.com/23153890/76867614-73665900-686e-11ea-83f8-5b062b5b78ba.png">
