### PR TITLE
FIX: Bug in setting notification level when the post was moved

### DIFF
--- a/app/models/post_mover.rb
+++ b/app/models/post_mover.rb
@@ -368,8 +368,12 @@ class PostMover
              CASE
                WHEN p.user_id IS NOT NULL THEN tu.notification_level
                ELSE :default_notification_level END      AS notification_level,
-             tu.notifications_changed_at,
-             tu.notifications_reason_id
+             CASE
+               WHEN p.user_id IS NOT NULL THEN tu.notifications_changed_at
+               ELSE null END      AS notifications_changed_at,
+             CASE
+               WHEN p.user_id IS NOT NULL THEN tu.notifications_reason_id
+               ELSE null END      AS notifications_reason_id
       FROM topic_users tu
            JOIN topics t ON (t.id = :new_topic_id)
            LEFT OUTER JOIN

--- a/spec/models/post_mover_spec.rb
+++ b/spec/models/post_mover_spec.rb
@@ -389,6 +389,8 @@ describe PostMover do
 
               Fabricate(:topic_user, opts.merge(
                 notification_level: TopicUser.notification_levels[notification_level],
+                notifications_reason_id: 1,
+                notifications_changed_at: DateTime.now,
                 topic: topic,
                 user: user
               ))
@@ -432,28 +434,31 @@ describe PostMover do
                       last_read_post_number: 4,
                       highest_seen_post_number: 4,
                       last_emailed_post_number: nil,
-                      notification_level: TopicUser.notification_levels[:tracking]
+                      notification_level: TopicUser.notification_levels[:tracking],
                     )
               expect(TopicUser.find_by(topic: topic, user: user1))
                 .to have_attributes(
                       last_read_post_number: 4,
                       highest_seen_post_number: 4,
                       last_emailed_post_number: 3,
-                      notification_level: TopicUser.notification_levels[:tracking]
+                      notification_level: TopicUser.notification_levels[:tracking],
+                      notifications_reason_id: 1
                     )
               expect(TopicUser.find_by(topic: topic, user: user2))
                 .to have_attributes(
                       last_read_post_number: 2,
                       highest_seen_post_number: 2,
                       last_emailed_post_number: 2,
-                      notification_level: TopicUser.notification_levels[:tracking]
+                      notification_level: TopicUser.notification_levels[:tracking],
+                      notifications_reason_id: 1
                     )
               expect(TopicUser.find_by(topic: topic, user: user3))
                 .to have_attributes(
                       last_read_post_number: 1,
                       highest_seen_post_number: 2,
                       last_emailed_post_number: 4,
-                      notification_level: TopicUser.notification_levels[:watching]
+                      notification_level: TopicUser.notification_levels[:watching],
+                      notifications_reason_id: 1
                     )
 
               expect(TopicUser.where(topic_id: new_topic.id).count).to eq(4)
@@ -463,6 +468,7 @@ describe PostMover do
                       highest_seen_post_number: 1,
                       last_emailed_post_number: nil,
                       notification_level: TopicUser.notification_levels[:watching],
+                      notifications_reason_id: 1,
                       posted: true
                     )
               expect(TopicUser.find_by(topic: new_topic, user: user1))
@@ -471,6 +477,8 @@ describe PostMover do
                       highest_seen_post_number: 2,
                       last_emailed_post_number: 2,
                       notification_level: TopicUser.notification_levels[:regular],
+                      notifications_reason_id: nil,
+                      notifications_changed_at: nil,
                       posted: false
                     )
               expect(TopicUser.find_by(topic: new_topic, user: user2))
@@ -479,6 +487,7 @@ describe PostMover do
                       highest_seen_post_number: 2,
                       last_emailed_post_number: 2,
                       notification_level: TopicUser.notification_levels[:tracking],
+                      notifications_reason_id: 1,
                       posted: true
                     )
               expect(TopicUser.find_by(topic: new_topic, user: user3))
@@ -487,6 +496,8 @@ describe PostMover do
                       highest_seen_post_number: 2,
                       last_emailed_post_number: 2,
                       notification_level: TopicUser.notification_levels[:regular],
+                      notifications_reason_id: nil,
+                      notifications_changed_at: nil,
                       posted: false
                     )
             end

--- a/spec/models/topic_user_spec.rb
+++ b/spec/models/topic_user_spec.rb
@@ -134,6 +134,13 @@ describe TopicUser do
       expect(topic_user.notification_level).to eq(TopicUser.notification_levels[:tracking])
     end
 
+    it 'should set to tracking if auto_track_topics is enabled and topic_user already exists' do
+      ensure_topic_user
+      user.user_option.update_column(:auto_track_topics_after_msecs, 0)
+      ensure_topic_user
+      expect(topic_user.reload.notification_level).to eq(TopicUser.notification_levels[:tracking])
+    end
+
     it 'should be set to "regular" notifications, by default on non creators' do
       ensure_topic_user
       expect(TopicUser.get(topic, user).notification_level).to eq(TopicUser.notification_levels[:regular])


### PR DESCRIPTION
When the post was moved from one topic into a new one, and the user with `Automatically track topics I enter` preferences, visits that topic for the first time notification_level was not modified.