### PR TITLE
DEV: Load plugin stylesheets before theme stylesheets

### DIFF
--- a/app/views/common/_discourse_stylesheet.html.erb
+++ b/app/views/common/_discourse_stylesheet.html.erb
@@ -8,10 +8,11 @@
   <%= discourse_stylesheet_link_tag(:admin) %>
 <%- end %>
 
+<%- Discourse.find_plugin_css_assets(include_official: allow_plugins?, include_unofficial: allow_third_party_plugins?, mobile_view: mobile_view?, desktop_view: !mobile_view?, request: request).each do |file| %>
+  <%= discourse_stylesheet_link_tag(file) %>
+<%- end %>
+
 <%- if theme_ids.present? %>
   <%= discourse_stylesheet_link_tag(mobile_view? ? :mobile_theme : :desktop_theme) %>
 <%- end %>
 
-<%- Discourse.find_plugin_css_assets(include_official: allow_plugins?, include_unofficial: allow_third_party_plugins?, mobile_view: mobile_view?, desktop_view: !mobile_view?, request: request).each do |file| %>
-  <%= discourse_stylesheet_link_tag(file) %>
-<%- end %>


### PR DESCRIPTION
This is a more logical order, since themes are more lightweight than plugins, and are often used to augment plugin styles