### PR TITLE
DEV: Use the `type: :multisite` spec setting

### DIFF
--- a/spec/requests/uploads_controller_spec.rb
+++ b/spec/requests/uploads_controller_spec.rb
@@ -401,10 +401,7 @@ describe UploadsController do
           expect(response.code).to eq("403")
         end
 
-        context "when running on a multisite connection" do
-          before do
-            Rails.configuration.multisite = true
-          end
+        context "when running on a multisite connection", type: :multisite do
           it "redirects to the signed_url_for_path with the multisite DB name in the url" do
             freeze_time
             get upload.short_path

--- a/spec/tasks/redis_spec.rb
+++ b/spec/tasks/redis_spec.rb
@@ -2,17 +2,11 @@
 
 require 'rails_helper'
 
-RSpec.describe "Redis rake tasks" do
+RSpec.describe "Redis rake tasks", type: :multisite do
   let(:redis) { Discourse.redis.without_namespace }
 
   before do
-    @multisite = Rails.configuration.multisite
-    Rails.configuration.multisite = true
     Discourse::Application.load_tasks
-  end
-
-  after do
-    Rails.configuration.multisite = @multisite
   end
 
   describe 'clean up' do

--- a/spec/tasks/uploads_spec.rb
+++ b/spec/tasks/uploads_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "tasks/uploads" do
     context "when the store is internal" do
       it "does nothing; this is for external store only" do
         Upload.expects(:transaction).never
-        invoke_task
+        expect { invoke_task }.to raise_error(SystemExit)
       end
     end
 


### PR DESCRIPTION
Fixes recent spec flakiness.

Also includes:
DEV: Prevent accidental exit from specs