### PR TITLE
FEATURE: Show votes in an "on voted" poll to the creator

### DIFF
--- a/plugins/poll/app/models/poll.rb
+++ b/plugins/poll/app/models/poll.rb
@@ -47,7 +47,11 @@ class Poll < ActiveRecord::Base
 
   def can_see_results?(user)
     return !!user&.staff? if staff_only?
-    !!(always? || (on_vote? && has_voted?(user)) || is_closed?)
+    !!(always? || (on_vote? && (is_me?(user) || has_voted?(user))) || is_closed?)
+  end
+
+  def is_me?(user)
+    user && post.user&.id == user&.id
   end
 
   def has_voted?(user)

--- a/plugins/poll/app/serializers/poll_serializer.rb
+++ b/plugins/poll/app/serializers/poll_serializer.rb
@@ -61,7 +61,7 @@ class PollSerializer < ApplicationSerializer
   end
 
   def include_preloaded_voters?
-    object.can_see_voters?(scope)
+    object.can_see_voters?(scope.user)
   end
 
 end

--- a/plugins/poll/assets/javascripts/widgets/discourse-poll.js.es6
+++ b/plugins/poll/assets/javascripts/widgets/discourse-poll.js.es6
@@ -678,6 +678,7 @@ createWidget("discourse-poll-buttons", {
     const staffOnly = poll.results === "staff_only";
     const isStaff = this.currentUser && this.currentUser.staff;
     const isAdmin = this.currentUser && this.currentUser.admin;
+    const isMe = this.currentUser && post.user_id === this.currentUser.id;
     const dataExplorerEnabled = this.siteSettings.data_explorer_enabled;
     const hideResultsDisabled = !staffOnly && (closed || topicArchived);
     const exportQueryID = this.siteSettings.poll_export_data_explorer_query_id;
@@ -710,7 +711,7 @@ createWidget("discourse-poll-buttons", {
         })
       );
     } else {
-      if (poll.get("results") === "on_vote" && !attrs.hasVoted) {
+      if (poll.get("results") === "on_vote" && !attrs.hasVoted && !isMe) {
         contents.push(infoTextHtml(I18n.t("poll.results.vote.title")));
       } else if (poll.get("results") === "on_close" && !closed) {
         contents.push(infoTextHtml(I18n.t("poll.results.closed.title")));

--- a/plugins/poll/lib/polls_updater.rb
+++ b/plugins/poll/lib/polls_updater.rb
@@ -93,7 +93,7 @@ module DiscoursePoll
 
         if has_changed
           polls = ::Poll.includes(poll_options: :poll_votes).where(post: post)
-          polls = ActiveModel::ArraySerializer.new(polls, each_serializer: PollSerializer, root: false).as_json
+          polls = ActiveModel::ArraySerializer.new(polls, each_serializer: PollSerializer, root: false, scope: Guardian.new(nil)).as_json
           post.publish_message!("/polls/#{post.topic_id}", post_id: post.id, polls: polls)
         end
       end

--- a/plugins/poll/spec/models/poll_spec.rb
+++ b/plugins/poll/spec/models/poll_spec.rb
@@ -31,8 +31,19 @@ describe ::DiscoursePoll::Poll do
       option = poll.poll_options.first
 
       expect(poll.can_see_results?(user)).to eq(false)
-      poll.poll_votes.create!(poll_option_id: option.id , user_id: user.id)
+      poll.poll_votes.create!(poll_option_id: option.id, user_id: user.id)
       expect(poll.can_see_results?(user)).to eq(true)
+    end
+
+    it "author can see results when results setting is on_vote" do
+      author = Fabricate(:user)
+      post = Fabricate(:post, user: author, raw: "[poll results=on_vote]\n- A\n- B\n[/poll]")
+      poll = post.polls.first
+      option = poll.poll_options.first
+
+      expect(poll.can_see_results?(author)).to eq(true)
+      poll.poll_votes.create!(poll_option_id: option.id, user_id: author.id)
+      expect(poll.can_see_results?(author)).to eq(true)
     end
 
     it "everyone can see results when results setting is on_vote and poll is closed" do


### PR DESCRIPTION
Implements https://meta.discourse.org/t/poll-creator-should-be-able-to-see-poll-results-even-when-shown-on-vote/138108

Had to plumb the Guardian through to the serializer. Notably, the client will not show results _by default_ to the poll author if they haven't voted - they need to click the button. 