### PR TITLE
FIX: Backfill topic timer duration

### DIFF
--- a/app/services/topic_status_updater.rb
+++ b/app/services/topic_status_updater.rb
@@ -89,7 +89,7 @@ TopicStatusUpdater = Struct.new(:topic, :user) do
   def message_for_autoclosed(locale_key)
     num_minutes =
       if @topic_status_update&.based_on_last_post
-        @topic_status_update.duration.hours
+        (@topic_status_update.duration || 0).hours
       elsif @topic_status_update&.created_at
         Time.zone.now - @topic_status_update.created_at
       else

--- a/db/migrate/20200320193612_back_fill_topic_timer_durations.rb
+++ b/db/migrate/20200320193612_back_fill_topic_timer_durations.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class BackFillTopicTimerDurations < ActiveRecord::Migration[6.0]
+  def up
+    DB.exec <<~SQL
+      UPDATE topic_timers
+      SET duration = 0
+      WHERE duration IS NULL AND (execute_at IS NULL OR created_at IS NULL)
+    SQL
+
+    DB.exec <<~SQL
+      UPDATE topic_timers
+      SET duration = EXTRACT(EPOCH FROM execute_at - created_at) / 3600
+      WHERE duration IS NULL AND execute_at IS NOT NULL AND created_at IS NOT NULL
+    SQL
+  end
+
+  def down
+  end
+end

--- a/lib/post_creator.rb
+++ b/lib/post_creator.rb
@@ -470,7 +470,7 @@ class PostCreator
 
       if topic_timer &&
          topic_timer.based_on_last_post &&
-         topic_timer.duration > 0
+         topic_timer.duration.to_i > 0
 
         @topic.set_or_create_timer(TopicTimer.types[:close],
           nil,


### PR DESCRIPTION
Since `TopicTimer#duration` can be nil for existing timers, we should backfill them or `TopicStatusUpdater#message_for_autoclosed` will fail.


cc @vinothkannans 