### PR TITLE
DEV: adds afterCreate/beforeUpdate hooks to rest models

### DIFF
--- a/app/assets/javascripts/discourse/models/rest.js
+++ b/app/assets/javascripts/discourse/models/rest.js
@@ -9,6 +9,9 @@ const RestModel = EmberObject.extend({
   isSaving: false,
 
   beforeCreate() {},
+  afterCreate() {},
+
+  beforeUpdate() {},
   afterUpdate() {},
 
   update(props) {
@@ -17,6 +20,8 @@ const RestModel = EmberObject.extend({
     }
 
     props = props || this.updateProperties();
+
+    this.beforeUpdate(props);
 
     this.set("isSaving", true);
     return this.store
@@ -65,6 +70,7 @@ const RestModel = EmberObject.extend({
           this.set("__state", "created");
         }
 
+        this.afterCreate(res);
         res.target = this;
         return res;
       })

--- a/test/javascripts/models/rest-model-test.js.es6
+++ b/test/javascripts/models/rest-model-test.js.es6
@@ -24,10 +24,14 @@ QUnit.test("update", async assert => {
   assert.equal(widget.get("name"), "Trout Lure");
   assert.ok(!widget.get("isSaving"), "it is not saving");
 
+  const spyBeforeUpdate = sandbox.spy(widget, "beforeUpdate");
+  const spyAfterUpdate = sandbox.spy(widget, "afterUpdate");
   const promise = widget.update({ name: "new name" });
   assert.ok(widget.get("isSaving"), "it is saving");
+  assert.ok(spyBeforeUpdate.calledOn(widget));
 
   const result = await promise;
+  assert.ok(spyAfterUpdate.calledOn(widget));
   assert.ok(!widget.get("isSaving"), "it is no longer saving");
   assert.equal(widget.get("name"), "new name");
 
@@ -61,10 +65,14 @@ QUnit.test("save new", async assert => {
   assert.ok(!widget.get("isCreated"), "it is not created");
   assert.ok(!widget.get("isSaving"), "it is not saving");
 
+  const spyBeforeCreate = sandbox.spy(widget, "beforeCreate");
+  const spyAfterCreate = sandbox.spy(widget, "afterCreate");
   const promise = widget.save({ name: "Evil Widget" });
   assert.ok(widget.get("isSaving"), "it is not saving");
+  assert.ok(spyBeforeCreate.calledOn(widget));
 
   const result = await promise;
+  assert.ok(spyAfterCreate.calledOn(widget));
   assert.ok(!widget.get("isSaving"), "it is no longer saving");
   assert.ok(widget.get("id"), "it has an id");
   assert.ok(widget.get("name"), "Evil Widget");


### PR DESCRIPTION
We already have beforeCreate and afterUpdate and it seems these hooks can be useful and it's also unexpected to not have parity on this.