### PR TITLE
UX: Hotkey K can select partial posts

### DIFF
--- a/app/assets/javascripts/discourse/lib/keyboard-shortcuts.js
+++ b/app/assets/javascripts/discourse/lib/keyboard-shortcuts.js
@@ -455,7 +455,11 @@ export default {
       const offset = minimumOffset();
       $selected = $articles
         .toArray()
-        .find(article => article.getBoundingClientRect().top > offset);
+        .find(article =>
+          direction > 0
+            ? article.getBoundingClientRect().top > offset
+            : article.getBoundingClientRect().bottom > offset
+        );
       if (!$selected) {
         $selected = $articles[$articles.length - 1];
       }


### PR DESCRIPTION
When no post is selected, K selects first partial post and J selects
first full post.