### PR TITLE
Fix image optimization pipeline

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -3735,6 +3735,7 @@ en:
     file_missing: "Sorry, you must provide a file to upload."
     empty: "Sorry, but the file you provided is empty."
     png_to_jpg_conversion_failure_message: "An error happened when converting from PNG to JPG."
+    optimize_failure_message: "An error occured while optimizing the uploaded image."
     attachments:
       too_large: "Sorry, the file you are trying to upload is too big (maximum size is %{max_size_kb}KB)."
     images:

--- a/lib/upload_creator.rb
+++ b/lib/upload_creator.rb
@@ -252,7 +252,6 @@ class UploadCreator
         from,
         to,
         "50%",
-        filename: @filename,
         allow_animation: allow_animation,
         raise_on_error: true
       )

--- a/lib/upload_creator.rb
+++ b/lib/upload_creator.rb
@@ -263,6 +263,8 @@ class UploadCreator
 
       return if filesize >= original_size || pixels == 0 || !should_downsize?
     end
+  rescue
+    @upload.errors.add(:base, I18n.t("upload.optimize_failure_message"))
   end
 
   def is_still_too_big?


### PR DESCRIPTION
This pull request addresses two issues:

1. The image optimization pipeline tried to optimize `jpeg`s using the operations for `png` images.

2. ImageMagick errors were returned to the user, but were not helpful at all.