### PR TITLE
DEV: Add test case for /srv/status probers

### DIFF
--- a/spec/components/middleware/request_tracker_spec.rb
+++ b/spec/components/middleware/request_tracker_spec.rb
@@ -79,10 +79,18 @@ describe Middleware::RequestTracker do
 
       Middleware::RequestTracker.log_request(data)
 
+      # /srv/status is never a tracked view because content-type is text/plain
+      data = Middleware::RequestTracker.get_data(env(
+        "HTTP_USER_AGENT" => "kube-probe/1.18",
+        "REQUEST_URI" => "/srv/status?shutdown_ok=1",
+      ), ["200", { "Content-Type" => 'text/plain' }], 0.1)
+
+      Middleware::RequestTracker.log_request(data)
+
       ApplicationRequest.write_cache!
 
-      expect(ApplicationRequest.http_total.first.count).to eq(3)
-      expect(ApplicationRequest.http_2xx.first.count).to eq(3)
+      expect(ApplicationRequest.http_total.first.count).to eq(4)
+      expect(ApplicationRequest.http_2xx.first.count).to eq(4)
 
       expect(ApplicationRequest.page_view_anon.first.count).to eq(2)
       expect(ApplicationRequest.page_view_crawler.first.count).to eq(1)


### PR DESCRIPTION
Test case I wrote while investigating https://meta.discourse.org/t/do-hits-to-srv-status-count-as-crawlers/143431/13?u=riking .

Figured I'd submit it to ensure we don't regress here.