### PR TITLE
FIX: Use 1 column instead of 4 for permalink destination

### DIFF
--- a/app/assets/javascripts/admin/models/permalink.js
+++ b/app/assets/javascripts/admin/models/permalink.js
@@ -1,4 +1,7 @@
 import { ajax } from "discourse/lib/ajax";
+import discourseComputed from "discourse-common/utils/decorators";
+import DiscourseURL from "discourse/lib/url";
+import Category from "discourse/models/category";
 import EmberObject from "@ember/object";
 
 const Permalink = EmberObject.extend({
@@ -11,6 +14,16 @@ const Permalink = EmberObject.extend({
         permalink_type_value: this.permalink_type_value
       }
     });
+  },
+
+  @discourseComputed("category_id")
+  category: function(category_id) {
+    return Category.findById(category_id);
+  },
+
+  @discourseComputed("external_url")
+  linkIsExternal: function(external_url) {
+    return !DiscourseURL.isInternal(external_url);
   },
 
   destroy: function() {

--- a/app/assets/javascripts/admin/templates/permalinks.hbs
+++ b/app/assets/javascripts/admin/templates/permalinks.hbs
@@ -24,19 +24,18 @@
             <td class="col first url">{{pl.url}}</td>
             <td class="col destination">
               {{#if pl.topic_id}}
-                {{i18n 'admin.permalink.topic_title'}}
                 <a href={{pl.topic_url}}>{{pl.topic_title}}</a>
               {{/if}}
               {{#if pl.post_id}}
-                {{i18n 'admin.permalink.post_title'}}
-                <a href={{pl.post_url}}>#{{pl.post_number}} {{pl.post_topic_title}}</a>
+                <a href={{pl.post_url}}>{{pl.post_topic_title}} #{{pl.post_number}}</a>
               {{/if}}
               {{#if pl.category_id}}
-                {{i18n 'admin.permalink.category_title'}}
-                <a href={{pl.category_url}}>{{pl.category_name}}</a>
+                {{category-link pl.category}}
               {{/if}}
               {{#if pl.external_url}}
-                {{i18n 'admin.permalink.external_url'}}
+                {{#if pl.linkIsExternal}}
+                  {{d-icon "external-link-alt"}}
+                {{/if}}
                 <a href={{pl.external_url}}>{{pl.external_url}}</a>
               {{/if}}
             </td>

--- a/app/assets/javascripts/admin/templates/permalinks.hbs
+++ b/app/assets/javascripts/admin/templates/permalinks.hbs
@@ -15,33 +15,28 @@
     <table class='admin-logs-table permalinks grid'>
       <thead class="heading-container">
         <th class="col heading first url">{{i18n 'admin.permalink.url'}}</th>
-        <th class="col heading topic">{{i18n 'admin.permalink.topic_title'}}</th>
-        <th class="col heading post">{{i18n 'admin.permalink.post_title'}}</th>
-        <th class="col heading category">{{i18n 'admin.permalink.category_title'}}</th>
-        <th class="col heading external_url">{{i18n 'admin.permalink.external_url'}}</th>
+        <th class="col heading destination">{{i18n 'admin.permalink.destination'}}</th>
         <th class="col heading actions"></th>
       </thead>
       <tbody>
         {{#each model as |pl|}}
           <tr class="admin-list-item">
             <td class="col first url">{{pl.url}}</td>
-            <td class="col topic">
+            <td class="col destination">
               {{#if pl.topic_id}}
+                {{i18n 'admin.permalink.topic_title'}}
                 <a href={{pl.topic_url}}>{{pl.topic_title}}</a>
               {{/if}}
-            </td>
-            <td class="col post">
               {{#if pl.post_id}}
+                {{i18n 'admin.permalink.post_title'}}
                 <a href={{pl.post_url}}>#{{pl.post_number}} {{pl.post_topic_title}}</a>
               {{/if}}
-            </td>
-            <td class="col category">
               {{#if pl.category_id}}
+                {{i18n 'admin.permalink.category_title'}}
                 <a href={{pl.category_url}}>{{pl.category_name}}</a>
               {{/if}}
-            </td>
-            <td class="col external_url">
               {{#if pl.external_url}}
+                {{i18n 'admin.permalink.external_url'}}
                 <a href={{pl.external_url}}>{{pl.external_url}}</a>
               {{/if}}
             </td>

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4587,6 +4587,7 @@ en:
         category_id: "Category ID"
         category_title: "Category"
         external_url: "External URL"
+        destination: "Destination"
         delete_confirm: Are you sure you want to delete this permalink?
         form:
           label: "New:"


### PR DESCRIPTION
Fixes a major UX issue with the permalinks page. Having 4 columns meant it was nearly impossible to see where the links were actually going.

After:

![image](https://user-images.githubusercontent.com/627891/77359042-38e63b80-6d08-11ea-8a75-1e8c60d1f0b9.png)

Not sure about including the type in the field - thoughts?