### PR TITLE
FIX: race conditions in search menu

### DIFF
--- a/app/assets/javascripts/discourse/widgets/search-menu-controls.js
+++ b/app/assets/javascripts/discourse/widgets/search-menu-controls.js
@@ -35,7 +35,7 @@ createWidget("search-term", {
     }
 
     const val = this.attrs.value;
-    const newVal = $(`#${this.buildId()}`).val();
+    const newVal = e.target.value.replace(/[\u200B-\u200D\uFEFF]/, "");
 
     if (newVal !== val) {
       this.sendWidgetAction("searchTermChanged", newVal);

--- a/app/assets/javascripts/discourse/widgets/search-menu-controls.js
+++ b/app/assets/javascripts/discourse/widgets/search-menu-controls.js
@@ -35,6 +35,7 @@ createWidget("search-term", {
     }
 
     const val = this.attrs.value;
+    // remove zero-width chars
     const newVal = e.target.value.replace(/[\u200B-\u200D\uFEFF]/, "");
 
     if (newVal !== val) {


### PR DESCRIPTION
Race conditions could lead the previous query search term to be used in the next query. This commit also attempts to simplify code.