### PR TITLE
UX: Align bulk select menu toggle relative to main wrapper when possible

### DIFF
--- a/app/assets/javascripts/discourse/components/bulk-select-button.js
+++ b/app/assets/javascripts/discourse/components/bulk-select-button.js
@@ -4,6 +4,18 @@ import showModal from "discourse/lib/show-modal";
 export default Component.extend({
   classNames: ["bulk-select-container"],
 
+  didInsertElement() {
+    this._super(...arguments);
+
+    let mainOutletPadding =
+      window.getComputedStyle(document.querySelector("#main-outlet"))
+        .paddingTop || 0;
+
+    document.querySelector(
+      ".bulk-select-container"
+    ).style.top = mainOutletPadding;
+  },
+
   actions: {
     showBulkActions() {
       const controller = showModal("topic-bulk-actions", {

--- a/app/assets/javascripts/discourse/components/bulk-select-button.js
+++ b/app/assets/javascripts/discourse/components/bulk-select-button.js
@@ -1,3 +1,4 @@
+import { schedule } from "@ember/runloop";
 import Component from "@ember/component";
 import showModal from "discourse/lib/show-modal";
 
@@ -7,13 +8,15 @@ export default Component.extend({
   didInsertElement() {
     this._super(...arguments);
 
-    let mainOutletPadding =
-      window.getComputedStyle(document.querySelector("#main-outlet"))
-        .paddingTop || 0;
+    schedule("afterRender", () => {
+      let mainOutletPadding =
+        window.getComputedStyle(document.querySelector("#main-outlet"))
+          .paddingTop || 0;
 
-    document.querySelector(
-      ".bulk-select-container"
-    ).style.top = mainOutletPadding;
+      document.querySelector(
+        ".bulk-select-container"
+      ).style.top = mainOutletPadding;
+    });
   },
 
   actions: {

--- a/app/assets/stylesheets/desktop/topic-list.scss
+++ b/app/assets/stylesheets/desktop/topic-list.scss
@@ -188,13 +188,28 @@
   }
 }
 
+.bulk-select-container {
+  @supports (position: sticky) {
+    @media screen and (min-width: 1250px) {
+      position: sticky;
+      position: -webkit-sticky;
+    }
+  }
+}
+
 #bulk-select {
   position: fixed;
   right: 20px;
   top: 130px;
-  padding: 5px;
   background-color: $secondary;
   z-index: z("dropdown");
+  @supports (position: sticky) {
+    @media screen and (min-width: 1250px) {
+      position: absolute;
+      right: -60px;
+      top: 0;
+    }
+  }
 }
 
 button.dismiss-read {


### PR DESCRIPTION
The goal is to align the bulk-select menu toggle relative to the content rather than the viewport as discussed here: https://meta.discourse.org/t/better-bulk-select-wrench-icon-placement/141396

I'm grabbing the padding on the top of `#main-outlet` so I can set the `top` value for `position:sticky;`... this should ensure that if the header height is increased/decreased the button would still align with the content (because the padding would also need to be increased/decreased).

Also checking for `position: sticky` support in the CSS and falling back to the current implementation if it's not. 

Before:
<img width="1453" alt="Screen Shot 2020-03-24 at 2 39 59 PM" src="https://user-images.githubusercontent.com/1681963/77464536-b6c84680-6ddd-11ea-8838-39d5d6bd0db1.png">

After: 
<img width="1250" alt="Screen Shot 2020-03-24 at 2 39 21 PM" src="https://user-images.githubusercontent.com/1681963/77464564-c051ae80-6ddd-11ea-94df-91fc46e0e6fd.png">

