### PR TITLE
FIX: First pass to improve efficiency of secure uploads rake task

### DIFF
--- a/lib/tasks/uploads.rake
+++ b/lib/tasks/uploads.rake
@@ -710,15 +710,6 @@ task "uploads:secure_upload_analyse_and_update" => :environment do
       # secure based on site settings.
       uploads_to_update = Upload.includes(:posts, :optimized_images).joins(:post_uploads)
 
-      # we do this to avoid a heavier post query, and to make sure we only
-      # get unique posts AND include deleted posts (unscoped)
-      unique_access_control_posts = {}
-      Post.unscoped.select(:id, :topic_id)
-        .includes(topic: :category)
-        .where(id: uploads_to_update.pluck(:access_control_post_id).uniq).find_each do |post|
-        unique_access_control_posts[post.id] = post
-      end
-
       puts "There are #{uploads_to_update.count} upload(s) that could be marked secure.", ""
 
       # Simply mark all these uploads as secure if login_required because no anons will be able to access them
@@ -738,7 +729,7 @@ task "uploads:secure_upload_analyse_and_update" => :environment do
         upload_ids_to_mark_as_not_secure,
         posts_to_rebake,
         uploads_to_adjust_acl_for = determine_upload_security_and_posts_to_rebake(
-        uploads_to_update, mark_secure_in_loop_because_no_login_required, unique_access_control_posts
+        uploads_to_update, mark_secure_in_loop_because_no_login_required
       )
 
       if !SiteSetting.login_required?
@@ -836,13 +827,20 @@ def rebake_upload_posts(posts_to_rebake)
   post_rebake_errors
 end
 
-def determine_upload_security_and_posts_to_rebake(
-  uploads_to_update, mark_secure_in_loop_because_no_login_required, unique_access_control_posts
-)
+def determine_upload_security_and_posts_to_rebake(uploads_to_update, mark_secure_in_loop_because_no_login_required)
   upload_ids_to_mark_as_secure = []
   upload_ids_to_mark_as_not_secure = []
   uploads_to_adjust_acl_for = []
   posts_to_rebake = {}
+
+  # we do this to avoid a heavier post query, and to make sure we only
+  # get unique posts AND include deleted posts (unscoped)
+  unique_access_control_posts = {}
+  Post.unscoped.select(:id, :topic_id)
+    .includes(topic: :category)
+    .where(id: uploads_to_update.pluck(:access_control_post_id).uniq).find_each do |post|
+    unique_access_control_posts[post.id] = post
+  end
 
   i = 0
   uploads_to_update.find_each do |upload_to_update|


### PR DESCRIPTION
Get rid of harmful each loop over uploads to update. Instead we put all the unique access control posts for the uploads into a map for fast access (vs using the slow .find through array) and look up the post when it is needed when looping through the uploads in batches.

On a Discourse instance with ~93k uploads, a simplified version of the old method takes **> 1 minute**:

```
unique_access_control_posts = Post.unscoped.select(:id, :topic_id).includes(topic: :category).where(id: uploads_to_update.pluck(:access_control_post_id).uniq)
uploads_to_update.each do |upload|
  upload.access_control_post = unique_access_control_posts.find { |post| post.id == upload.access_control_post_id }
end
```

A simplified version of the new method takes **~18s** and uses a lot less memory:

```
unique_access_control_posts = {}
Post.unscoped.select(:id, :topic_id).includes(topic: :category)
       .where(id: uploads_to_update.pluck(:access_control_post_id).uniq).find_each do |post|
  unique_access_control_posts[post.id] = post
end

uploads_to_update.find_each do |upload|
  upload.access_control_post = unique_access_control_posts[upload.access_control_post_id]
end
```