### PR TITLE
FIX: Narrative bot not working for bookmarks with reminders

### DIFF
--- a/plugins/discourse-narrative-bot/config/locales/server.en.yml
+++ b/plugins/discourse-narrative-bot/config/locales/server.en.yml
@@ -244,7 +244,7 @@ en:
         instructions: |-
           If you’d like to learn more, select <img src="%{base_uri}/plugins/discourse-narrative-bot/images/font-awesome-ellipsis.png" width="16" height="16"> below and <img src="%{base_uri}/plugins/discourse-narrative-bot/images/font-awesome-bookmark.png" width="16" height="16"> **bookmark this personal message**. If you do, there may be a :gift: in your future!
         reply: |-
-          Excellent! Now you can easily find your way back to our private conversation any time, right from [the bookmarks tab on your profile](%{profile_page_url}/activity/bookmarks). Just select your profile picture at the upper right &#8599;
+          Excellent! Now you can easily find your way back to our private conversation any time, right from [the bookmarks tab on your profile](%{bookmark_url}). Just select your profile picture at the upper right &#8599;
         not_found: |-
           Uh oh, I don’t see any bookmarks in this topic. Did you find the bookmark under each post? Use the show more <img src="%{base_uri}/plugins/discourse-narrative-bot/images/font-awesome-ellipsis.png" width="16" height="16"> to reveal additional actions if needed.
 

--- a/plugins/discourse-narrative-bot/lib/discourse_narrative_bot/new_user_narrative.rb
+++ b/plugins/discourse-narrative-bot/lib/discourse_narrative_bot/new_user_narrative.rb
@@ -233,8 +233,14 @@ module DiscourseNarrativeBot
       return unless valid_topic?(@post.topic_id)
       return unless @post.user_id == self.discobot_user.id
 
+      profile_page_url = url_helpers(:user_url, username: @user.username)
+      bookmark_url = if SiteSetting.enable_bookmarks_with_reminders?
+        "#{profile_page_url}/activity/bookmarks-with-reminders"
+      else
+        "#{profile_page_url}/activity/bookmarks"
+      end
       raw = <<~RAW
-        #{I18n.t("#{I18N_KEY}.bookmark.reply", i18n_post_args(profile_page_url: url_helpers(:user_url, username: @user.username)))}
+        #{I18n.t("#{I18N_KEY}.bookmark.reply", i18n_post_args(bookmark_url: bookmark_url))}
 
         #{instance_eval(&@next_instructions)}
       RAW

--- a/plugins/discourse-narrative-bot/plugin.rb
+++ b/plugins/discourse-narrative-bot/plugin.rb
@@ -240,6 +240,14 @@ after_initialize do
     end
   end
 
+  self.add_model_callback(Bookmark, :after_commit, on: :create) do
+    if SiteSetting.enable_bookmarks_with_reminders?
+      if self.post && self.user.enqueue_narrative_bot_job?
+        Jobs.enqueue(:bot_input, user_id: self.user_id, post_id: self.post_id, input: :bookmark)
+      end
+    end
+  end
+
   self.on(:topic_notification_level_changed) do |_, user_id, topic_id|
     user = User.find_by(id: user_id)
 

--- a/plugins/discourse-narrative-bot/spec/discourse_narrative_bot/new_user_narrative_spec.rb
+++ b/plugins/discourse-narrative-bot/spec/discourse_narrative_bot/new_user_narrative_spec.rb
@@ -256,7 +256,26 @@ describe DiscourseNarrativeBot::NewUserNarrative do
         profile_page_url = "#{Discourse.base_url}/u/#{user.username}"
 
         expected_raw = <<~RAW
-          #{I18n.t('discourse_narrative_bot.new_user_narrative.bookmark.reply', profile_page_url: profile_page_url, base_uri: '')}
+          #{I18n.t('discourse_narrative_bot.new_user_narrative.bookmark.reply', bookmark_url: "#{profile_page_url}/activity/bookmarks", base_uri: '')}
+
+          #{I18n.t('discourse_narrative_bot.new_user_narrative.onebox.instructions', base_uri: '')}
+        RAW
+
+        expect(new_post.raw).to eq(expected_raw.chomp)
+        expect(narrative.get_data(user)[:state].to_sym).to eq(:tutorial_onebox)
+      end
+
+      it 'should create the right reply when bookmarks with reminders are enabled' do
+        SiteSetting.enable_bookmarks_with_reminders = true
+        post.update!(user: discobot_user)
+        narrative.expects(:enqueue_timeout_job).with(user)
+
+        narrative.input(:bookmark, user, post: post)
+        new_post = Post.last
+        profile_page_url = "#{Discourse.base_url}/u/#{user.username}"
+
+        expected_raw = <<~RAW
+          #{I18n.t('discourse_narrative_bot.new_user_narrative.bookmark.reply', bookmark_url: "#{profile_page_url}/activity/bookmarks-with-reminders", base_uri: '')}
 
           #{I18n.t('discourse_narrative_bot.new_user_narrative.onebox.instructions', base_uri: '')}
         RAW


### PR DESCRIPTION
Reported https://meta.discourse.org/t/improved-bookmarks-with-reminders/144542/42?u=mjrbrennan

* There was no callback on the bookmark model to trigger the next step of the narrative bot on bookmark.
* Also the translation URL path was hardcoded, needs to be conditional based on whether the site setting is enabled.