### PR TITLE
FEATURE: Add anonymous topic read setting when login is required

### DIFF
--- a/app/assets/javascripts/discourse/controllers/application.js
+++ b/app/assets/javascripts/discourse/controllers/application.js
@@ -19,7 +19,11 @@ export default Controller.extend({
 
   @discourseComputed
   loginRequired() {
-    return Discourse.SiteSettings.login_required && !this.currentUser;
+    return (
+      Discourse.SiteSettings.login_required &&
+      !Discourse.SiteSettings.allow_reading_topics &&
+      !this.currentUser
+    );
   },
 
   @discourseComputed

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -741,6 +741,10 @@ class ApplicationController < ActionController::Base
     end
 
     if !current_user && SiteSetting.login_required?
+      if SiteSetting.allow_reading_topics && controller_name == "topics"
+        return
+      end
+
       flash.keep
       redirect_to_login
       return

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1592,6 +1592,7 @@ en:
     invite_only: "All new users must be explicitly invited by trusted users or staff. Public registration is disabled."
 
     login_required: "Require authentication to read content on this site, disallow anonymous access."
+    allow_reading_topics: "If authentication is required, still allow reading topics with the URL."
 
     min_username_length: "Minimum username length in characters. WARNING: if any existing users or groups have names shorter than this, your site will break!"
     max_username_length: "Maximum username length in characters. WARNING: if any existing users or groups have names longer than this, your site will break!"

--- a/config/locales/server.fr.yml
+++ b/config/locales/server.fr.yml
@@ -1437,6 +1437,7 @@ fr:
     invite_expiry_days: "Combien de temps (en jours) les clés d'invitation sont-elles valides"
     invite_only: "Tous les nouveaux utilisateurs doivent être explicitement invités par des utilisateurs de confiance ou du personnel. L'enregistrement public est désactivé."
     login_required: "Authentification requise pour lire le contenu du site, interdit l'accès anonyme."
+    allow_reading_topics: "Si l'authentification est requise, quand même permettre de lire anonymement des sujets via l'URL."
     min_username_length: "Longueur minimale du nom d'utilisateur en caractères. ATTENTION : si des utilisateurs ou groupes existants ont des noms plus courts que celui-ci, votre site se cassera !"
     max_username_length: "Longueur maximale du nom d'utilisateur en caractères. ATTENTION : si des utilisateurs ou groupes existants ont des noms plus longs que celui-ci, votre site se cassera !"
     unicode_usernames: "Autorisez les noms d'utilisateur et noms de groupes à contenir des lettres et des chiffres Unicode."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -333,6 +333,8 @@ login:
     refresh: true
     client: true
     default: false
+  allow_reading_topics:
+    default: false
   must_approve_users:
     client: true
     default: false

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -335,6 +335,8 @@ login:
     default: false
   allow_reading_topics:
     default: false
+    client: true
+    refresh: true
   must_approve_users:
     client: true
     default: false

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -1454,6 +1454,26 @@ RSpec.describe TopicsController do
           include_examples "various scenarios", expected
         end
 
+        context 'anonymous with login required but reading allowed' do
+          before do
+            SiteSetting.login_required = true
+            SiteSetting.allow_reading_topics = true
+          end
+
+          expected = {
+            normal_topic: 200,
+            secure_topic: 403,
+            private_topic: 403,
+            deleted_topic: 410,
+            deleted_secure_topic: 403,
+            deleted_private_topic: 403,
+            nonexist: 404,
+            secure_accessible_topic: 403
+          }
+
+          include_examples "various scenarios", expected
+        end
+
         context 'normal user' do
           before do
             sign_in(user)


### PR DESCRIPTION
This adds a setting to allow reading topics even when login is required.

### The problem I'm trying to solve
We have a gated community for our coworking coop where login is required, but privacy isn't of capital importance. It's just a nice add-on.

Users are still not totally on board with the forum, so we often share forum links by email, on Slack, Facebook, etc.

When this is done: (1) no preview appears, and (2) the linked topic is blank when you're logged out.

It's been talked about on Meta [about Slack](https://meta.discourse.org/t/allow-slack-to-unfurl-expand-links-to-login-required-discourse-instance/39547/4), for which there is now a plugin; and a request for ["special links"](https://meta.discourse.org/t/closed-forum-but-special-links-to-access-content/42975). If we look at the Slack topic, at least 95 people have been interested enough to click on the plugin link.

### The dream
It would be nice if we could share topic links as eg Google Docs and other services do it. You click a button, you get a nice hash in your URL to share. However it would take quite some work to get there.

For now, just being able to paste a URL somewhere and have anyone be able to read it is plenty.

### The fix
Going step by step, this setting just allows topic reads for anyone who has the URL. 

Yes, even guessed URLs like `/t/7`. Known limitation. We could make the code more complex by requiring a full URL when we're in this case. Not a road my intuition tells me to take, as this feature could grow in another direction eventually.

I figure this is a good first step since the login_required setting is quite hardcoded in some places. I would argue that permission to read is actually a function of the topic (or more broadly, category).

Other implementation notes:
- The setting name and configuration is maybe not ideal. Would another name fit better? Would it be better to turn `login_required` into a select that enums `:strict (true), :topic_reads_allowed, :no (false)`?

- At present, this is broken. Topic#show shows a spinner, and JS is stuck here:

![image](https://user-images.githubusercontent.com/949482/77813537-c9fa4100-707f-11ea-87f5-0b2b1215f227.png)

And so am I. I don't know where to go from here. Guidance would be appreciated.

I'm happy to go back to the forum if this is the more appropriate place for this.

I've pondered making this into a plugin, but I have the impression that hooking into `ApplicationController#redirect_to_login_if_required` and other tricky places might set me up for a maintenance failure down the line when the underlying code changes.

Overall guidance, advice and feedback are appreciated. Cheers!
