### PR TITLE
FIX: prevents rendering empty timeline-controls

### DIFF
--- a/app/assets/javascripts/discourse/components/topic-progress.js
+++ b/app/assets/javascripts/discourse/components/topic-progress.js
@@ -34,11 +34,8 @@ export default Component.extend({
     "postStream.filteredPostsCount"
   )
   hideProgress(loaded, currentPost, filteredPostsCount) {
-    return (
-      !loaded ||
-      !currentPost ||
-      (!this.site.mobileView && filteredPostsCount < 2)
-    );
+    const hideOnShortStream = !this.site.mobileView && filteredPostsCount < 2;
+    return !loaded || !currentPost || hideOnShortStream;
   },
 
   @discourseComputed("postStream.filteredPostsCount")

--- a/app/assets/javascripts/discourse/widgets/topic-timeline.js
+++ b/app/assets/javascripts/discourse/widgets/topic-timeline.js
@@ -442,7 +442,6 @@ export default createWidget("topic-timeline", {
   html(attrs) {
     const { topic } = attrs;
     const createdAt = new Date(topic.created_at);
-    const stream = attrs.topic.get("postStream.stream");
     const { currentUser } = this;
     const { tagging_enabled, topic_featured_link_enabled } = this.siteSettings;
 
@@ -517,15 +516,6 @@ export default createWidget("topic-timeline", {
     }
 
     result.push(this.attach("timeline-controls", attrs));
-    const streamLength = stream.length;
-
-    if (streamLength !== 0 && streamLength < 3) {
-      const topicHeight = $("#topic").height();
-      const windowHeight = $(window).height();
-      if (topicHeight / windowHeight < 2.0) {
-        return result;
-      }
-    }
 
     const bottomAge = relativeAge(new Date(topic.last_posted_at), {
       addAgo: true,


### PR DESCRIPTION
The streamlength/height code when true would return just after we had inserted the timeline-controls, resulting, on topic-progress event to display an empty timeline-controls when clicked.

I think this code in unecessary and we should only rely on the code in `hideProgress` which will currenly hide the progress is the stream has only one post displayed on desktop (always shown on mobile).