### PR TITLE
FIX: ensures unchanged draft model is correctly clear on escape

### DIFF
--- a/app/assets/javascripts/discourse/controllers/composer.js
+++ b/app/assets/javascripts/discourse/controllers/composer.js
@@ -1062,7 +1062,6 @@ export default Controller.extend({
             }
           }
         );
-        // debugger;
       } else {
         // it is possible there is some sort of crazy draft with no body ... just give up on it
         this.destroyDraft().then(destroyedDraftModel => {


### PR DESCRIPTION
This fix will also make sure the bootbox will be correctly shown when using escape.

Test cases:
- edit post, wait for draft check, escape => should totally hide composer
- edit post, add a char, escape => should show bootbox, and reduce or hide depending on choice

Same behavior is expected when pressing on cancel.