### PR TITLE
FIX: when a post is moved copy notifications level

### DIFF
--- a/app/models/post_mover.rb
+++ b/app/models/post_mover.rb
@@ -332,8 +332,7 @@ class PostMover
       old_topic_id: original_topic.id,
       new_topic_id: destination_topic.id,
       old_highest_post_number: destination_topic.highest_post_number,
-      old_highest_staff_post_number: destination_topic.highest_staff_post_number,
-      default_notification_level: NotificationLevels.topic_levels[:regular]
+      old_highest_staff_post_number: destination_topic.highest_staff_post_number
     }
 
     DB.exec(<<~SQL, params)
@@ -365,9 +364,7 @@ class PostMover
              )                                           AS last_emailed_post_number,
              GREATEST(tu.first_visited_at, t.created_at) AS first_visited_at,
              GREATEST(tu.last_visited_at, t.created_at)  AS last_visited_at,
-             CASE
-               WHEN p.user_id IS NOT NULL THEN tu.notification_level
-               ELSE :default_notification_level END      AS notification_level,
+             tu.notification_level,
              tu.notifications_changed_at,
              tu.notifications_reason_id
       FROM topic_users tu

--- a/spec/models/post_mover_spec.rb
+++ b/spec/models/post_mover_spec.rb
@@ -470,7 +470,7 @@ describe PostMover do
                       last_read_post_number: 2,
                       highest_seen_post_number: 2,
                       last_emailed_post_number: 2,
-                      notification_level: TopicUser.notification_levels[:regular],
+                      notification_level: TopicUser.notification_levels[:tracking],
                       posted: false
                     )
               expect(TopicUser.find_by(topic: new_topic, user: user2))
@@ -486,7 +486,7 @@ describe PostMover do
                       last_read_post_number: 1,
                       highest_seen_post_number: 2,
                       last_emailed_post_number: 2,
-                      notification_level: TopicUser.notification_levels[:regular],
+                      notification_level: TopicUser.notification_levels[:watching],
                       posted: false
                     )
             end


### PR DESCRIPTION
This is a revert of https://github.com/discourse/discourse/commit/2c011252f1c0443965ca5317169550083a43c657

More information on meta: https://meta.discourse.org/t/when-a-reply-is-moved-to-a-new-topic-the-followers-of-the-previous-topic-are-automatically-follower-of-the-new-topic-as-well/130025