### PR TITLE
DEV: Add Ember.PromiseProxyMixin to ember modules

### DIFF
--- a/app/assets/javascripts/discourse-loader.js
+++ b/app/assets/javascripts/discourse-loader.js
@@ -77,6 +77,7 @@ var define, requirejs;
       },
       "@ember/object/mixin": { default: Ember.Mixin },
       "@ember/object/proxy": { default: Ember.ObjectProxy },
+      "@ember/object/promise-proxy-mixin": { default: Ember.PromiseProxyMixin },
       "@ember/object/evented": {
         default: Ember.Evented,
         on: Ember.on


### PR DESCRIPTION
### This PR: 
- [x] Adds [Ember.PromiseProxyMixin ](https://api.emberjs.com/ember/3.12/classes/PromiseProxyMixin) to ember modules. Reason for this is to make components work with async computed props. Good example can be found [here](https://lolma.us/en/blog/promise-proxy-mixin/). 

This could be useful in discourse theme development if you need some data that is not available at the moment. For example: for some reason you want to decorate poster avatar with border in topic list if the poster is a staff member. To find out if user is staff member you'll need to send a request to `/u` endpoint, and if true react accordingly to that condition in template.

