### PR TITLE
FIX: jobs/delete_replies: Add Time+Duration, not Time+Time

### DIFF
--- a/app/jobs/regular/delete_replies.rb
+++ b/app/jobs/regular/delete_replies.rb
@@ -22,7 +22,7 @@ module Jobs
         PostDestroyer.new(topic_timer.user, post, context: I18n.t("topic_statuses.auto_deleted_by_timer")).destroy
       end
 
-      topic_timer.execute_at = (replies.minimum(:created_at) || Time.zone.now) + topic_timer.duration.days.ago
+      topic_timer.execute_at = (replies.minimum(:created_at) || Time.zone.now) + topic_timer.duration.days
       topic_timer.save
     end
 


### PR DESCRIPTION
Fixes `Job exception: can't convert ActiveSupport::TimeWithZone into an exact number`