### PR TITLE
UX: Remove share as link fallback on touch devices

### DIFF
--- a/app/assets/javascripts/discourse/components/share-panel.js
+++ b/app/assets/javascripts/discourse/components/share-panel.js
@@ -42,9 +42,12 @@ export default Component.extend({
 
   didInsertElement() {
     this._super(...arguments);
-
-    const $linkInput = $(this.element.querySelector(".topic-share-url"));
-    window.setTimeout(() => $linkInput.select().focus(), 200);
+    window.setTimeout(() => {
+      const textArea = this.element.querySelector(".topic-share-url");
+      textArea.style.height = textArea.scrollHeight + "px";
+      textArea.focus();
+      textArea.setSelectionRange(0, this.shareUrl.length);
+    }, 200);
   },
 
   actions: {

--- a/app/assets/javascripts/discourse/components/share-panel.js
+++ b/app/assets/javascripts/discourse/components/share-panel.js
@@ -44,10 +44,12 @@ export default Component.extend({
   didInsertElement() {
     this._super(...arguments);
     later(() => {
-      const textArea = this.element.querySelector(".topic-share-url");
-      textArea.style.height = textArea.scrollHeight + "px";
-      textArea.focus();
-      textArea.setSelectionRange(0, this.shareUrl.length);
+      if (this.element) {
+        const textArea = this.element.querySelector(".topic-share-url");
+        textArea.style.height = textArea.scrollHeight + "px";
+        textArea.focus();
+        textArea.setSelectionRange(0, this.shareUrl.length);
+      }
     }, 200);
   },
 

--- a/app/assets/javascripts/discourse/components/share-panel.js
+++ b/app/assets/javascripts/discourse/components/share-panel.js
@@ -4,6 +4,7 @@ import Component from "@ember/component";
 import { escapeExpression } from "discourse/lib/utilities";
 import discourseComputed from "discourse-common/utils/decorators";
 import Sharing from "discourse/lib/sharing";
+import { later } from "@ember/runloop";
 
 export default Component.extend({
   tagName: null,
@@ -42,7 +43,7 @@ export default Component.extend({
 
   didInsertElement() {
     this._super(...arguments);
-    window.setTimeout(() => {
+    later(() => {
       const textArea = this.element.querySelector(".topic-share-url");
       textArea.style.height = textArea.scrollHeight + "px";
       textArea.focus();

--- a/app/assets/javascripts/discourse/components/share-panel.js
+++ b/app/assets/javascripts/discourse/components/share-panel.js
@@ -1,6 +1,5 @@
 import { isEmpty } from "@ember/utils";
 import { alias } from "@ember/object/computed";
-import { schedule } from "@ember/runloop";
 import Component from "@ember/component";
 import { escapeExpression } from "discourse/lib/utilities";
 import discourseComputed from "discourse-common/utils/decorators";
@@ -44,30 +43,8 @@ export default Component.extend({
   didInsertElement() {
     this._super(...arguments);
 
-    const shareUrl = this.shareUrl;
     const $linkInput = $(this.element.querySelector(".topic-share-url"));
-    const $linkForTouch = $(
-      this.element.querySelector(".topic-share-url-for-touch a")
-    );
-
-    schedule("afterRender", () => {
-      if (!this.capabilities.touch) {
-        $linkForTouch.parent().remove();
-
-        $linkInput
-          .val(shareUrl)
-          .select()
-          .focus();
-      } else {
-        $linkInput.remove();
-
-        $linkForTouch.attr("href", shareUrl).text(shareUrl);
-
-        const range = window.document.createRange();
-        range.selectNode($linkForTouch[0]);
-        window.getSelection().addRange(range);
-      }
-    });
+    window.setTimeout(() => $linkInput.select().focus(), 200);
   },
 
   actions: {

--- a/app/assets/javascripts/discourse/components/share-popup.js
+++ b/app/assets/javascripts/discourse/components/share-popup.js
@@ -35,21 +35,11 @@ export default Component.extend({
   },
 
   _focusUrl() {
-    const link = this.link;
-    if (!this.capabilities.touch) {
-      const $linkInput = $("#share-link input");
-      $linkInput.val(link);
+    const $linkInput = $("#share-link input");
+    $linkInput.val(this.link);
 
-      // Wait for the fade-in transition to finish before selecting the link:
-      window.setTimeout(() => $linkInput.select().focus(), 160);
-    } else {
-      const $linkForTouch = $("#share-link .share-for-touch a");
-      $linkForTouch.attr("href", link);
-      $linkForTouch.text(link);
-      const range = window.document.createRange();
-      range.selectNode($linkForTouch[0]);
-      window.getSelection().addRange(range);
-    }
+    // Wait for the fade-in transition to finish before selecting the link:
+    window.setTimeout(() => $linkInput.select().focus(), 200);
   },
 
   _showUrl($target, url) {

--- a/app/assets/javascripts/discourse/components/share-popup.js
+++ b/app/assets/javascripts/discourse/components/share-popup.js
@@ -35,13 +35,14 @@ export default Component.extend({
   },
 
   _focusUrl() {
-    const linkInput = this.element.querySelector("#share-link input");
-    linkInput.value = this.link;
-
     // Wait for the fade-in transition to finish before selecting the link:
     later(() => {
-      linkInput.setSelectionRange(0, this.link.length);
-      linkInput.focus();
+      if (this.element) {
+        const linkInput = this.element.querySelector("#share-link input");
+        linkInput.value = this.link;
+        linkInput.setSelectionRange(0, this.link.length);
+        linkInput.focus();
+      }
     }, 200);
   },
 

--- a/app/assets/javascripts/discourse/components/share-popup.js
+++ b/app/assets/javascripts/discourse/components/share-popup.js
@@ -1,5 +1,5 @@
 import { isEmpty } from "@ember/utils";
-import { bind, scheduleOnce } from "@ember/runloop";
+import { bind, scheduleOnce, later } from "@ember/runloop";
 import Component from "@ember/component";
 import { wantsNewWindow } from "discourse/lib/intercept-click";
 import { longDateNoYear } from "discourse/lib/formatter";
@@ -39,7 +39,7 @@ export default Component.extend({
     linkInput.value = this.link;
 
     // Wait for the fade-in transition to finish before selecting the link:
-    window.setTimeout(() => {
+    later(() => {
       linkInput.setSelectionRange(0, this.link.length);
       linkInput.focus();
     }, 200);

--- a/app/assets/javascripts/discourse/components/share-popup.js
+++ b/app/assets/javascripts/discourse/components/share-popup.js
@@ -35,11 +35,14 @@ export default Component.extend({
   },
 
   _focusUrl() {
-    const $linkInput = $("#share-link input");
-    $linkInput.val(this.link);
+    const linkInput = this.element.querySelector("#share-link input");
+    linkInput.value = this.link;
 
     // Wait for the fade-in transition to finish before selecting the link:
-    window.setTimeout(() => $linkInput.select().focus(), 200);
+    window.setTimeout(() => {
+      linkInput.setSelectionRange(0, this.link.length);
+      linkInput.focus();
+    }, 200);
   },
 
   _showUrl($target, url) {

--- a/app/assets/javascripts/discourse/templates/components/share-panel.hbs
+++ b/app/assets/javascripts/discourse/templates/components/share-panel.hbs
@@ -4,7 +4,6 @@
 
 <div class="body">
   {{textarea value=shareUrl class="topic-share-url"}}
-  <div class="topic-share-url-for-touch"><a></a></div>
 
   <div class="sources">
     {{#each sources as |source|}}

--- a/app/assets/javascripts/discourse/templates/components/share-popup.hbs
+++ b/app/assets/javascripts/discourse/templates/components/share-popup.hbs
@@ -8,7 +8,6 @@
 
 <div>
   <input type="text">
-  <div class="share-for-touch"><div class="overflow-ellipsis"><a></a></div></div>
 </div>
 
 <div class="actions">

--- a/app/assets/stylesheets/common/base/share_link.scss
+++ b/app/assets/stylesheets/common/base/share_link.scss
@@ -15,12 +15,6 @@
   input[type="text"] {
     width: 100%;
   }
-  .share-for-touch .overflow-ellipsis {
-    clear: both;
-  }
-  .share-for-touch {
-    margin: 14px 0;
-  }
 
   .title {
     margin-bottom: s(1);
@@ -108,10 +102,10 @@
   }
 }
 
-.discourse-no-touch #share-link .share-for-touch {
-  display: none;
-}
+// .discourse-no-touch #share-link .share-for-touch {
+//   display: none;
+// }
 
-.discourse-touch #share-link input[type="text"] {
-  display: none;
-}
+// .discourse-touch #share-link input[type="text"] {
+//   display: none;
+// }

--- a/app/assets/stylesheets/common/base/share_link.scss
+++ b/app/assets/stylesheets/common/base/share_link.scss
@@ -101,11 +101,3 @@
     }
   }
 }
-
-// .discourse-no-touch #share-link .share-for-touch {
-//   display: none;
-// }
-
-// .discourse-touch #share-link input[type="text"] {
-//   display: none;
-// }

--- a/app/assets/stylesheets/common/components/share-and-invite-modal.scss
+++ b/app/assets/stylesheets/common/components/share-and-invite-modal.scss
@@ -44,14 +44,6 @@
       box-sizing: border-box;
     }
 
-    .topic-share-url-for-touch {
-      a {
-        word-break: break-all;
-        font-size: $font-up-1;
-      }
-    }
-
-    .topic-share-url-for-touch,
     .topic-share-url {
       margin-bottom: s(2);
     }


### PR DESCRIPTION
Previously, there were three workflows when sharing a topic or a post: 

- sharing URL displayed in popup or modal, in an input or textarea element
- native sharing dialog on touch devices with native sharing support
- and a fallback to the URL displayed as link element on touch devices with no native sharing support

This PR removes the third option. We were only displaying this on non-iOS/non-Android touch devices like laptops with a touch screen, and it was buggy, see https://meta.discourse.org/t/user-experience-on-discourse-with-optional-touch-input/40190/24 for details. 