### PR TITLE
FIX: Set null high_priority columns to false in high priority notification migration

### DIFF
--- a/db/migrate/20200329222246_add_high_priority_column_to_notifications.rb
+++ b/db/migrate/20200329222246_add_high_priority_column_to_notifications.rb
@@ -23,6 +23,10 @@ class AddHighPriorityColumnToNotifications < ActiveRecord::Migration[6.0]
       SQL
 
       execute <<~SQL
+        UPDATE notifications SET high_priority = FALSE WHERE high_priority IS NULL;
+      SQL
+
+      execute <<~SQL
         ALTER TABLE notifications ALTER COLUMN high_priority SET NOT NULL;
       SQL
     end


### PR DESCRIPTION
Some DBs failed on this migration, possibly due to new records being added, with the error

```
ActiveRecord::NotNullViolation: PG::NotNullViolation: ERROR:  column "high_priority" contains null values
```

Luckily, the migration is retryable as is.