### PR TITLE
FIX: guardian always got user but sometimes it is anonymous

### DIFF
--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -319,7 +319,7 @@ class Guardian
   # Support sites that have to approve users
   def can_access_forum?
     return true unless SiteSetting.must_approve_users?
-    return false unless @user
+    return false if anonymous?
 
     # Staff can't lock themselves out of a site
     return true if is_staff?
@@ -442,7 +442,7 @@ class Guardian
   end
 
   def can_export_entity?(entity)
-    return false unless @user
+    return false if anonymous?
     return true if is_admin?
     return entity != 'user_list' if is_moderator?
 

--- a/spec/components/guardian_spec.rb
+++ b/spec/components/guardian_spec.rb
@@ -2743,6 +2743,7 @@ describe Guardian do
   end
 
   describe '#can_export_entity?' do
+    let(:anonymous_guardian) { Guardian.new() }
     let(:user_guardian) { Guardian.new(user) }
     let(:moderator_guardian) { Guardian.new(moderator) }
     let(:admin_guardian) { Guardian.new(admin) }
@@ -2757,6 +2758,10 @@ describe Guardian do
       expect(user_guardian.can_export_entity?('staff_action')).to be_falsey
       expect(moderator_guardian.can_export_entity?('staff_action')).to be_truthy
       expect(admin_guardian.can_export_entity?('staff_action')).to be_truthy
+    end
+
+    it 'does not allow anonymous to export' do
+      expect(anonymous_guardian.can_export_entity?('user_archive')).to be_falsey
     end
   end
 

--- a/spec/components/guardian_spec.rb
+++ b/spec/components/guardian_spec.rb
@@ -2743,7 +2743,7 @@ describe Guardian do
   end
 
   describe '#can_export_entity?' do
-    let(:anonymous_guardian) { Guardian.new() }
+    let(:anonymous_guardian) { Guardian.new }
     let(:user_guardian) { Guardian.new(user) }
     let(:moderator_guardian) { Guardian.new(moderator) }
     let(:admin_guardian) { Guardian.new(admin) }


### PR DESCRIPTION
```
  def initialize(user = nil, request = nil)
    @user = user.presence || AnonymousUser.new
    @request = request
  end
```

AnonymouseUser defines `blank?` method
```
  class AnonymousUser
    def blank?
      true
    end
    ...
  end
```
so if we would use `@user.present?` it would be correct, however, just `@user` is always true