### PR TITLE
FIX: Limit personal message participants when converting from topic

### DIFF
--- a/app/jobs/regular/topic_action_converter.rb
+++ b/app/jobs/regular/topic_action_converter.rb
@@ -13,7 +13,7 @@ class Jobs::TopicActionConverter < ::Jobs::Base
       action_type: [UserAction::GOT_PRIVATE_MESSAGE, UserAction::NEW_PRIVATE_MESSAGE]).find_each do |ua|
         UserAction.remove_action!(ua.attributes.symbolize_keys.slice(:action_type, :user_id, :acting_user_id, :target_topic_id, :target_post_id))
       end
-    topic.posts.each { |post| UserActionManager.post_created(post) }
+    topic.posts.find_each { |post| UserActionManager.post_created(post) }
     UserActionManager.topic_created(topic)
   end
 

--- a/app/models/topic_converter.rb
+++ b/app/models/topic_converter.rb
@@ -82,6 +82,10 @@ class TopicConverter
     existing_allowed_users = @topic.topic_allowed_users.pluck(:user_id)
     users_to_allow = posters << @user.id
 
+    if (users_to_allow | existing_allowed_users).length > SiteSetting.max_allowed_message_recipients
+      users_to_allow = [@user.id]
+    end
+
     (users_to_allow - existing_allowed_users).uniq.each do |user_id|
       @topic.topic_allowed_users.build(user_id: user_id)
     end

--- a/spec/models/topic_converter_spec.rb
+++ b/spec/models/topic_converter_spec.rb
@@ -152,6 +152,18 @@ describe TopicConverter do
         expect(Notification.exists?(user_notification.id)).to eq(false)
         expect(Notification.exists?(admin_notification.id)).to eq(true)
       end
+
+      it "limits PM participants" do
+        SiteSetting.max_allowed_message_recipients = 2
+        Fabricate(:post, topic: topic)
+        Fabricate(:post, topic: topic)
+
+        private_message = topic.convert_to_private_message(post.user)
+
+        # Skips posters and just adds the acting user
+        expect(private_message.topic_allowed_users.count).to eq(1)
+      end
+
     end
 
     context 'topic has replies' do


### PR DESCRIPTION
Previously all topic posters would be added which could lead to major performance issues. Now if there are too many posters, only the acting user will be added as a participant.