### PR TITLE
FIX: Remove date from bookmark reminder non-English translations

### DIFF
--- a/config/locales/client.ar.yml
+++ b/config/locales/client.ar.yml
@@ -33,7 +33,7 @@ ar:
       time: "h:mm a"
       time_short_day: "ddd, HH:mm"
       timeline_date: "MMM YYYY"
-      long_no_year: "D MMM h:mm a"
+      long_no_year: "D MMM, h:mm a"
       long_no_year_no_time: "D MMM"
       full_no_year_no_time: "Do MMMM"
       long_with_year: "D MMM YYYY h:mm a"

--- a/config/locales/client.bg.yml
+++ b/config/locales/client.bg.yml
@@ -260,11 +260,11 @@ bg:
       remove: "Премахнете отметката"
       save: "Запази"
       reminders:
-        later_today: "По-късно днес <br/>{{date}}"
-        next_business_day: "Следващият работен ден <br/>{{date}}"
-        tomorrow: "Утре <br/>{{date}}"
-        next_week: "Следващата седмица <br/>{{date}}"
-        next_month: "Следващият месец <br/>{{date}}"
+        later_today: "По-късно днес"
+        next_business_day: "Следващият работен ден"
+        tomorrow: "Утре"
+        next_week: "Следващата седмица"
+        next_month: "Следващият месец"
     drafts:
       resume: "Продължи"
       remove: "Премахване"

--- a/config/locales/client.bg.yml
+++ b/config/locales/client.bg.yml
@@ -28,7 +28,7 @@ bg:
     dates:
       time: "h:mm a"
       timeline_date: "MMM YYYY"
-      long_no_year: "D MMM h:mm a"
+      long_no_year: "D MMM, h:mm a"
       long_no_year_no_time: "D MMM"
       full_no_year_no_time: "Do MMMM"
       long_with_year: "MMM D, YYYY h:mm a"

--- a/config/locales/client.bs_BA.yml
+++ b/config/locales/client.bs_BA.yml
@@ -294,11 +294,11 @@ bs_BA:
       no_timezone: 'Još uvijek niste postavili vremensku zonu, tako da nećete biti u mogućnosti koristiti podsjetnike. Postavite vremensku zonu <a href="%{basePath}/my/preferences/profile">na vašem profilu</a>.'
       reminders:
         at_desktop: "Sljedeći put sam za svojim desktop kompjuterom"
-        later_today: "Danas, malo kasnije <br/>{{date}}"
-        next_business_day: "Sljedeći radni dan <br/>{{date}}"
-        tomorrow: "Sutradan <br/>{{date}}"
-        next_week: "Sljedeće sedmice <br/>{{date}}"
-        next_month: "Sljedeći mjesec <br/>{{date}}"
+        later_today: "Danas, malo kasnije"
+        next_business_day: "Sljedeći radni dan"
+        tomorrow: "Sutradan"
+        next_week: "Sljedeće sedmice"
+        next_month: "Sljedeći mjesec"
         custom: "Precizno vrijeme i datum"
     drafts:
       resume: "Nastavi"

--- a/config/locales/client.bs_BA.yml
+++ b/config/locales/client.bs_BA.yml
@@ -29,7 +29,7 @@ bs_BA:
     dates:
       time: "HH: mm"
       timeline_date: "MMM YYYY"
-      long_no_year: "MMM D h:mm a"
+      long_no_year: "MMM D, h:mm a"
       long_no_year_no_time: "MMM D"
       full_no_year_no_time: "MMMM Do"
       long_with_year: "MMM D, YYYY h:mm a"

--- a/config/locales/client.ca.yml
+++ b/config/locales/client.ca.yml
@@ -28,7 +28,7 @@ ca:
     dates:
       time: "h:mm a"
       timeline_date: "MMM YYYY"
-      long_no_year: "MMM D h:mm a"
+      long_no_year: "MMM D, h:mm a"
       long_no_year_no_time: "MMM D"
       full_no_year_no_time: "MMMM Do"
       long_with_year: "D MMM YYYY HH:mm"

--- a/config/locales/client.cs.yml
+++ b/config/locales/client.cs.yml
@@ -30,7 +30,7 @@ cs:
     dates:
       time: "H:mm"
       timeline_date: "MMM YYYY"
-      long_no_year: "D. MMMM H:mm"
+      long_no_year: "D. MMMM, H:mm"
       long_no_year_no_time: "D. MMMM"
       full_no_year_no_time: "D. MMMM"
       long_with_year: "D. M. YYYY, H:mm"

--- a/config/locales/client.da.yml
+++ b/config/locales/client.da.yml
@@ -28,7 +28,7 @@ da:
     dates:
       time: "HH:mm"
       timeline_date: "MMM YYYY"
-      long_no_year: "D. MMM HH:mm"
+      long_no_year: "D. MMM, HH:mm"
       long_no_year_no_time: "D. MMM"
       full_no_year_no_time: "D. MMMM"
       long_with_year: "D. MMM YYYY HH:mm"

--- a/config/locales/client.da.yml
+++ b/config/locales/client.da.yml
@@ -265,9 +265,9 @@ da:
       confirm_clear: "Er du sikker på, at du vil rydde alle dine bogmærker fra dette emne?"
       save: "Gem"
       reminders:
-        tomorrow: "I morgen <br/>{{date}}"
-        next_week: "Næste uge <br/>{{date}}"
-        next_month: "Næste måned <br/>{{date}}"
+        tomorrow: "I morgen"
+        next_week: "Næste uge"
+        next_month: "Næste måned"
         custom: "Valgfri dato og tid"
     drafts:
       resume: "Genoptag"

--- a/config/locales/client.de.yml
+++ b/config/locales/client.de.yml
@@ -271,11 +271,11 @@ de:
       no_timezone: 'Du hast noch keine Zeitzone ausgewählt. Du wirst keine Erinnerungen erstellen können. Stelle eine <a href="%{basePath}/my/preferences/profile">in deinem Profil</a> ein.'
       reminders:
         at_desktop: "Nächstes mal wenn ich an meinem PC bin"
-        later_today: "Im Laufe des Tages <br/>{{date}}"
-        next_business_day: "Nächster Geschäftstag <br/>{{date}}"
-        tomorrow: "Morgen <br/>{{date}}"
-        next_week: "Nächste Woche <br/>{{date}}"
-        next_month: "Nächster Monat <br/>{{date}}"
+        later_today: "Im Laufe des Tages"
+        next_business_day: "Nächster Geschäftstag"
+        tomorrow: "Morgen"
+        next_week: "Nächste Woche"
+        next_month: "Nächster Monat"
         custom: "Eigenes Datum und Zeit"
     drafts:
       resume: "Fortsetzen"

--- a/config/locales/client.de.yml
+++ b/config/locales/client.de.yml
@@ -29,7 +29,7 @@ de:
       time: "HH:mm"
       time_short_day: "ddd, HH:mm"
       timeline_date: "MMM YYYY"
-      long_no_year: "D. MMM [um] HH:mm"
+      long_no_year: "D. MMM, [um] HH:mm"
       long_no_year_no_time: "D. MMM"
       full_no_year_no_time: "D. MMMM"
       long_with_year: "D. MMM YYYY [um] HH:mm"

--- a/config/locales/client.el.yml
+++ b/config/locales/client.el.yml
@@ -28,7 +28,7 @@ el:
     dates:
       time: "ΗΗ:mm"
       timeline_date: "MMM YYYY"
-      long_no_year: "DD MMM HH:mm"
+      long_no_year: "DD MMM, HH:mm"
       long_no_year_no_time: "DD MMM"
       full_no_year_no_time: "Do MMMM"
       long_with_year: "D MMM YYYY HH:mm"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -44,7 +44,7 @@ en:
       # Use Moment.js format string: https://momentjs.com/docs/#/displaying/format/
       timeline_date: "MMM YYYY"
       # Use Moment.js format string: https://momentjs.com/docs/#/displaying/format/
-      long_no_year: "D MMM HH:mm"
+      long_no_year: "D MMM, HH:mm"
       # Use Moment.js format string: https://momentjs.com/docs/#/displaying/format/
       long_no_year_no_time: "D MMM"
       # Use Moment.js format string: https://momentjs.com/docs/#/displaying/format/

--- a/config/locales/client.en_US.yml
+++ b/config/locales/client.en_US.yml
@@ -8,7 +8,7 @@ en_US:
       # Use Moment.js format string: https://momentjs.com/docs/#/displaying/format/
       timeline_date: "MMM YYYY"
       # Use Moment.js format string: https://momentjs.com/docs/#/displaying/format/
-      long_no_year: "MMM D h:mm a"
+      long_no_year: "MMM D, h:mm a"
       # Use Moment.js format string: https://momentjs.com/docs/#/displaying/format/
       long_no_year_no_time: "MMM D"
       # Use Moment.js format string: https://momentjs.com/docs/#/displaying/format/

--- a/config/locales/client.es.yml
+++ b/config/locales/client.es.yml
@@ -29,7 +29,7 @@ es:
       time: "HH:mm"
       time_short_day: "ddd, HH:mm"
       timeline_date: "MMM YYYY"
-      long_no_year: "D MMM HH:mm"
+      long_no_year: "D MMM, HH:mm"
       long_no_year_no_time: "D MMM"
       full_no_year_no_time: "Do MMMM"
       long_with_year: "D MMM YYYY HH:mm"

--- a/config/locales/client.es.yml
+++ b/config/locales/client.es.yml
@@ -271,11 +271,11 @@ es:
       no_timezone: 'No has establecido una zona horaria todavía. No podrás establecer recordatorios. Puedes elegir una <a href="%{basePath}/my/preferences/profile">en tu perfil</a>.'
       reminders:
         at_desktop: "La próxima vez que esté en mi ordenador"
-        later_today: "Más tarde hoy <br/>{{date}}"
-        next_business_day: "El próximo día hábil <br/>{{date}}"
-        tomorrow: "Mañana <br/>{{date}}"
-        next_week: "La próxima semana <br/>{{date}}"
-        next_month: "El mes que viene <br/>{{date}}"
+        later_today: "Más tarde hoy"
+        next_business_day: "El próximo día hábil"
+        tomorrow: "Mañana"
+        next_week: "La próxima semana"
+        next_month: "El mes que viene"
         custom: "Fecha y hora personalizadas"
     drafts:
       resume: "Reanudar"

--- a/config/locales/client.et.yml
+++ b/config/locales/client.et.yml
@@ -28,7 +28,7 @@ et:
     dates:
       time: "hh:mm"
       timeline_date: "MMM YYYY"
-      long_no_year: "D. MMMM hh:mm"
+      long_no_year: "D. MMMM, hh:mm"
       long_no_year_no_time: "D. MMMM"
       full_no_year_no_time: "Do MMMM"
       long_with_year: "D. MMMM, YYYY hh:mm"

--- a/config/locales/client.fa_IR.yml
+++ b/config/locales/client.fa_IR.yml
@@ -29,7 +29,7 @@ fa_IR:
       time: "h:mm a"
       time_short_day: "h:mm a"
       timeline_date: "MMM YYYY"
-      long_no_year: "MMM D h:mm a"
+      long_no_year: "MMM D, h:mm a"
       long_no_year_no_time: "MMM D"
       full_no_year_no_time: "MMMM Do"
       long_with_year: "MMM D, YYYY h:mm a"

--- a/config/locales/client.fa_IR.yml
+++ b/config/locales/client.fa_IR.yml
@@ -271,11 +271,11 @@ fa_IR:
       no_timezone: 'شما هنوز منطقه زمانی مشخص نکرده اید. شما قادر به تنظیم کردن یادآوری نیستید. یکی را در <a href="%{basePath}/my/preferences/profile"> پروفایل تان </a> تنظیم کنید.'
       reminders:
         at_desktop: "بار آینده من پشت میزم هستم"
-        later_today: "امروز کمی بعد <br/>{{date}}"
-        next_business_day: "روز کاری آینده <br/>{{date}}"
-        tomorrow: "فردا <br/>{{date}}"
-        next_week: "هفته ی آینده <br/>{{date}}"
-        next_month: "ماه آینده <br/>{{date}}"
+        later_today: "امروز کمی بعد"
+        next_business_day: "روز کاری آینده"
+        tomorrow: "فردا"
+        next_week: "هفته ی آینده"
+        next_month: "ماه آینده"
         custom: "درج تاریخ و ساعت"
     drafts:
       resume: "از سر گیری"

--- a/config/locales/client.fi.yml
+++ b/config/locales/client.fi.yml
@@ -29,7 +29,7 @@ fi:
       time: "H:mm"
       time_short_day: "ddd HH:mm"
       timeline_date: "MMM YYYY"
-      long_no_year: "D. MMMM[ta] H:mm"
+      long_no_year: "D. MMMM[ta], H:mm"
       long_no_year_no_time: "D. MMMM[ta]"
       full_no_year_no_time: "Do MMMM[ta]"
       long_with_year: "D. MMMM[ta] YYYY H:mm"

--- a/config/locales/client.fi.yml
+++ b/config/locales/client.fi.yml
@@ -271,11 +271,11 @@ fi:
       no_timezone: 'Et ole valinnut aikavyöhykettä, joten et voi asettaa muistutuksia. Aseta se  <a href="%{basePath}/my/preferences/profile">profiilisivullasi</a>.'
       reminders:
         at_desktop: "Ensi kerralla kun olen työpöytäympäristössäni"
-        later_today: "Myöhemmin tänään  <br/>{{date}}"
-        next_business_day: "Seuraavana arkipäivänä <br/>{{date}}"
-        tomorrow: "Huomenna <br/>{{date}}"
-        next_week: "Ensi viikolla <br/>{{date}}"
-        next_month: "Ensi kuussa <br/>{{date}}"
+        later_today: "Myöhemmin tänään "
+        next_business_day: "Seuraavana arkipäivänä"
+        tomorrow: "Huomenna"
+        next_week: "Ensi viikolla"
+        next_month: "Ensi kuussa"
         custom: "Valitse päivämäärä ja kellonaika"
     drafts:
       resume: "Jatka"

--- a/config/locales/client.fr.yml
+++ b/config/locales/client.fr.yml
@@ -29,7 +29,7 @@ fr:
       time: "HH:mm"
       time_short_day: "ddd [à] HH:mm"
       timeline_date: "MMM YYYY"
-      long_no_year: "DD MMM H:mm"
+      long_no_year: "DD MMM, H:mm"
       long_no_year_no_time: "D MMM"
       full_no_year_no_time: "Do MMMM"
       long_with_year: "DD MMM YYYY H:mm"

--- a/config/locales/client.gl.yml
+++ b/config/locales/client.gl.yml
@@ -28,7 +28,7 @@ gl:
     dates:
       time: "h:mm a"
       timeline_date: "MMM YYYY"
-      long_no_year: "D MMM h:mm a"
+      long_no_year: "D MMM, h:mm a"
       long_no_year_no_time: "D MMM"
       full_no_year_no_time: "D MMMM"
       long_with_year: "D MMM, YYYY h:mm a"

--- a/config/locales/client.he.yml
+++ b/config/locales/client.he.yml
@@ -319,11 +319,11 @@ he:
       no_timezone: 'עדיין לא הגדרת אזור זמן. לא תהיה לך אפשרות להגדיר תזכורות. ניתן להגדיר אותו <a href="%{basePath}/my/preferences/profile">בפרופיל שלך</a>.'
       reminders:
         at_desktop: "בשימוש הבא דרך שולחן העבודה"
-        later_today: "המשך היום <br/>{{date}}"
-        next_business_day: "ביום העסקים הבא <br/>{{date}}"
-        tomorrow: "מחר <br/>{{date}}"
-        next_week: "בשבוע הבא <br/>{{date}}"
-        next_month: "בחודש הבא <br/>{{date}}"
+        later_today: "המשך היום"
+        next_business_day: "ביום העסקים הבא"
+        tomorrow: "מחר"
+        next_week: "בשבוע הבא"
+        next_month: "בחודש הבא"
         custom: "תאריך ושעה מותאמים אישית"
     drafts:
       resume: "המשך"

--- a/config/locales/client.he.yml
+++ b/config/locales/client.he.yml
@@ -31,7 +31,7 @@ he:
       time: "h:mm a"
       time_short_day: "ddd, HH:mm"
       timeline_date: "MMM YYYY"
-      long_no_year: "D בMMM ‏HH:mm"
+      long_no_year: "D בMMM, ‏HH:mm"
       long_no_year_no_time: "D בMMM"
       full_no_year_no_time: "Do בMMMM"
       long_with_year: "D בMMM ‏YYYY ‏HH:mm"

--- a/config/locales/client.hu.yml
+++ b/config/locales/client.hu.yml
@@ -28,7 +28,7 @@ hu:
     dates:
       time: "h:mm a"
       timeline_date: "YYYY MMMM"
-      long_no_year: "MMM D h:mm a"
+      long_no_year: "MMM D, h:mm a"
       long_no_year_no_time: "MMM D"
       full_no_year_no_time: "MMM DD"
       long_with_year: "MMM D, YYYY h:mm a"

--- a/config/locales/client.hy.yml
+++ b/config/locales/client.hy.yml
@@ -28,7 +28,7 @@ hy:
     dates:
       time: "h:mm"
       timeline_date: "MMM YYYY"
-      long_no_year: "MMM D h:mm"
+      long_no_year: "MMM D, h:mm"
       long_no_year_no_time: "MMM D"
       full_no_year_no_time: "MMMM Do"
       long_with_year: "MMM D, YYYY h:mm a"

--- a/config/locales/client.id.yml
+++ b/config/locales/client.id.yml
@@ -28,7 +28,7 @@ id:
       time: "h:mm a"
       time_short_day: "ddd, HH: mm"
       timeline_date: "MMM YYYY"
-      long_no_year: "BBB D h:mm a"
+      long_no_year: "BBB D, h:mm a"
       long_no_year_no_time: "MMM D"
       full_no_year_no_time: "MMMM Do"
       long_with_year: "MMM D, YYYY h:mm a"

--- a/config/locales/client.it.yml
+++ b/config/locales/client.it.yml
@@ -29,7 +29,7 @@ it:
       time: "h:mm a"
       time_short_day: "ddd, HH:mm"
       timeline_date: "MMM YYYY"
-      long_no_year: "D MMM h:mm a"
+      long_no_year: "D MMM, h:mm a"
       long_no_year_no_time: "D MMM"
       full_no_year_no_time: "MMMM Do"
       long_with_year: "D MMM YYYY h:mm a"

--- a/config/locales/client.ja.yml
+++ b/config/locales/client.ja.yml
@@ -27,7 +27,7 @@ ja:
     dates:
       time: "H:mm"
       timeline_date: "YYYY年M月"
-      long_no_year: "M月D日 H:mm"
+      long_no_year: "M月D日, H:mm"
       long_no_year_no_time: "M月D日"
       full_no_year_no_time: "M月D日"
       long_with_year: "YYYY年M月D日 H:mm"

--- a/config/locales/client.ko.yml
+++ b/config/locales/client.ko.yml
@@ -27,7 +27,7 @@ ko:
     dates:
       time: "a h:mm"
       timeline_date: "YYYY MMM"
-      long_no_year: "M D a h:mm"
+      long_no_year: "M D a, h:mm"
       long_no_year_no_time: "MMM D"
       full_no_year_no_time: "MMMM Do"
       long_with_year: "YYYY MMM D a h:mm"

--- a/config/locales/client.lt.yml
+++ b/config/locales/client.lt.yml
@@ -30,7 +30,7 @@ lt:
     dates:
       time: "H:mm"
       timeline_date: "MMM YYYY"
-      long_no_year: "MMMM D H:mm"
+      long_no_year: "MMMM D, H:mm"
       long_no_year_no_time: "MMMM D"
       full_no_year_no_time: "MMMM Do"
       long_with_year: "YYYY MMMM D H:mm"

--- a/config/locales/client.lv.yml
+++ b/config/locales/client.lv.yml
@@ -29,7 +29,7 @@ lv:
     dates:
       time: "hh:mm"
       timeline_date: "MMM YYYY"
-      long_no_year: "MMM D hh:mm"
+      long_no_year: "MMM D, hh:mm"
       long_no_year_no_time: "MMM D"
       full_no_year_no_time: "MMMM Do"
       long_with_year: "MMM D, YYYY hh:mm"

--- a/config/locales/client.nb_NO.yml
+++ b/config/locales/client.nb_NO.yml
@@ -28,7 +28,7 @@ nb_NO:
     dates:
       time: "LT"
       timeline_date: "MMM YYYY"
-      long_no_year: "D MMM LT"
+      long_no_year: "D MMM, LT"
       long_no_year_no_time: "D MMM"
       full_no_year_no_time: "D. MMMM"
       long_with_year: "D MMM YYYY LT"

--- a/config/locales/client.nl.yml
+++ b/config/locales/client.nl.yml
@@ -271,11 +271,11 @@ nl:
       no_timezone: 'U hebt nog geen tijdzone ingesteld. Hierdoor kunt u geen herinneringen instellen. Stel er een in <a href="%{basePath}/my/preferences/profile">in uw profiel</a>.'
       reminders:
         at_desktop: "De volgende keer vanaf mijn computer"
-        later_today: "Later vandaag <br/>{{date}}"
-        next_business_day: "Volgende werkdag <br/>{{date}}"
-        tomorrow: "Morgen <br/>{{date}}"
-        next_week: "Volgende week <br/>{{date}}"
-        next_month: "Volgende maand <br/>{{date}}"
+        later_today: "Later vandaag"
+        next_business_day: "Volgende werkdag"
+        tomorrow: "Morgen"
+        next_week: "Volgende week"
+        next_month: "Volgende maand"
         custom: "Aangepaste datum en tijd"
     drafts:
       resume: "Hervatten"

--- a/config/locales/client.nl.yml
+++ b/config/locales/client.nl.yml
@@ -29,7 +29,7 @@ nl:
       time: "HH:mm"
       time_short_day: "ddd, HH:mm"
       timeline_date: "MMM YYYY"
-      long_no_year: "D MMM HH:mm"
+      long_no_year: "D MMM, HH:mm"
       long_no_year_no_time: "D MMM"
       full_no_year_no_time: "D MMMM"
       long_with_year: "D MMM YYYY HH:mm"

--- a/config/locales/client.pl_PL.yml
+++ b/config/locales/client.pl_PL.yml
@@ -30,7 +30,7 @@ pl_PL:
     dates:
       time: "H:mm"
       timeline_date: "MMM YYYY"
-      long_no_year: "D MMM H:mm"
+      long_no_year: "D MMM, H:mm"
       long_no_year_no_time: "D MMM"
       full_no_year_no_time: "MMMM Do"
       long_with_year: "D MMM YYYY H:mm"

--- a/config/locales/client.pt.yml
+++ b/config/locales/client.pt.yml
@@ -28,7 +28,7 @@ pt:
     dates:
       time: "hh:mm"
       timeline_date: "MMM YYYY"
-      long_no_year: "DD MMM hh:mm"
+      long_no_year: "DD MMM, hh:mm"
       long_no_year_no_time: "DD MMM"
       full_no_year_no_time: "Do MMMM"
       long_with_year: "DD MMM YYYY hh:mm"

--- a/config/locales/client.pt_BR.yml
+++ b/config/locales/client.pt_BR.yml
@@ -29,7 +29,7 @@ pt_BR:
       time: "H:mm"
       time_short_day: "ddd, HH:mm"
       timeline_date: "MMM YYYY"
-      long_no_year: "D MMM H:mm"
+      long_no_year: "D MMM, H:mm"
       long_no_year_no_time: "D MMM"
       full_no_year_no_time: "D de MMMM"
       long_with_year: "D MMM, YYYY H:mm"

--- a/config/locales/client.pt_BR.yml
+++ b/config/locales/client.pt_BR.yml
@@ -270,11 +270,11 @@ pt_BR:
       no_timezone: 'Você ainda não definiu um fuso horário. VOcê não poderá definir lembretes. Configure um <a href="%{basePath}/my/preferences/profile">no seu perfil</a>.'
       reminders:
         at_desktop: "Da próxima vez que estiver na minha área de trabalho"
-        later_today: "Hoje mais tarde <br/>{{date}}"
-        next_business_day: "Próximo dia comercial <br/>{{date}}"
-        tomorrow: "Amanhã <br/>{{date}}"
-        next_week: "Próxima semana <br/>{{date}}"
-        next_month: "Próximo mês <br/>{{date}}"
+        later_today: "Hoje mais tarde"
+        next_business_day: "Próximo dia comercial"
+        tomorrow: "Amanhã"
+        next_week: "Próxima semana"
+        next_month: "Próximo mês"
         custom: "Data e hora personalizadas"
     drafts:
       resume: "Resumir"

--- a/config/locales/client.ro.yml
+++ b/config/locales/client.ro.yml
@@ -29,7 +29,7 @@ ro:
     dates:
       time: "HH:mm"
       timeline_date: "MMM YYYY"
-      long_no_year: "DD MMM HH:mm"
+      long_no_year: "DD MMM, HH:mm"
       long_no_year_no_time: "DD MMM"
       full_no_year_no_time: "Do MMMM "
       long_with_year: "DD MMM YYYY HH:mm"

--- a/config/locales/client.ru.yml
+++ b/config/locales/client.ru.yml
@@ -319,11 +319,11 @@ ru:
       no_timezone: 'Укажите ваш часовой пояс <a href="%{basePath}/my/preferences/profile">в настройках своей учетной записи</a>, чтобы активировать функцию напоминаний.'
       reminders:
         at_desktop: "При следующем посещении форума"
-        later_today: "На сегодня, но чуть позже <br/>{{date}}"
-        next_business_day: "На следующий рабочий день <br/>{{date}}"
-        tomorrow: "На завтра <br/>{{date}}"
-        next_week: "На следующую неделю <br/>{{date}}"
-        next_month: "На следующий месяц <br/>{{date}}"
+        later_today: "На сегодня, но чуть позже"
+        next_business_day: "На следующий рабочий день"
+        tomorrow: "На завтра"
+        next_week: "На следующую неделю"
+        next_month: "На следующий месяц"
         custom: "Установить дату и время напоминания"
     drafts:
       resume: "Продолжить"

--- a/config/locales/client.ru.yml
+++ b/config/locales/client.ru.yml
@@ -31,7 +31,7 @@ ru:
       time: "HH:mm"
       time_short_day: "ddd, HH:mm"
       timeline_date: "MMM YYYY"
-      long_no_year: "D MMM HH:mm"
+      long_no_year: "D MMM, HH:mm"
       long_no_year_no_time: "D MMM"
       full_no_year_no_time: "D MMM"
       long_with_year: "D MMM YYYY, HH:mm"

--- a/config/locales/client.sk.yml
+++ b/config/locales/client.sk.yml
@@ -30,7 +30,7 @@ sk:
     dates:
       time: "h:mm a"
       timeline_date: "MMM YYYY"
-      long_no_year: "MMM D h:mm a"
+      long_no_year: "MMM D, h:mm a"
       long_no_year_no_time: "MMM D"
       full_no_year_no_time: "MMMM Do"
       long_with_year: "MMM D, YYYY h:mm a"

--- a/config/locales/client.sl.yml
+++ b/config/locales/client.sl.yml
@@ -30,7 +30,7 @@ sl:
     dates:
       time: "H:mm"
       timeline_date: "MMM YYYY"
-      long_no_year: "D. MMM H:mm"
+      long_no_year: "D. MMM, H:mm"
       long_no_year_no_time: "D MMM"
       full_no_year_no_time: "D. MMMM"
       long_with_year: "D. MMM YYYY H:mm"

--- a/config/locales/client.sq.yml
+++ b/config/locales/client.sq.yml
@@ -28,7 +28,7 @@ sq:
     dates:
       time: "h:mm a"
       timeline_date: "MMM YYYY"
-      long_no_year: "MMM D h:mm a"
+      long_no_year: "MMM D, h:mm a"
       long_no_year_no_time: "MMM D"
       full_no_year_no_time: "MMMM Do"
       long_with_year: "MMM D, YYYY h:mm a"

--- a/config/locales/client.sr.yml
+++ b/config/locales/client.sr.yml
@@ -29,7 +29,7 @@ sr:
     dates:
       time: "HH:mm"
       timeline_date: "MMM YYYY"
-      long_no_year: "D MMM HH:mm"
+      long_no_year: "D MMM, HH:mm"
       long_no_year_no_time: "D MMM"
       full_no_year_no_time: "MMMM Do"
       long_with_year: "D MMM YYYY HH:mm"

--- a/config/locales/client.sv.yml
+++ b/config/locales/client.sv.yml
@@ -271,11 +271,11 @@ sv:
       no_timezone: 'Du har ännu inte valt tidszon. Du kommer därför inte kunna sätta påminnelser. Ange en <a href="%{basePath}/my/preferences/profile">i din profil</a>.'
       reminders:
         at_desktop: "Nästa gång är jag vid datorn"
-        later_today: "Senare idag <br/>{{date}}"
-        next_business_day: "Nästa arbetsdag <br/>{{date}}"
-        tomorrow: "Imorgon <br/>{{date}}"
-        next_week: "Nästa vecka <br/>{{date}}"
-        next_month: "Nästa månad <br/>{{date}}"
+        later_today: "Senare idag"
+        next_business_day: "Nästa arbetsdag"
+        tomorrow: "Imorgon"
+        next_week: "Nästa vecka"
+        next_month: "Nästa månad"
         custom: "Anpassa datum och tid"
     drafts:
       resume: "Återuppta"

--- a/config/locales/client.sv.yml
+++ b/config/locales/client.sv.yml
@@ -29,7 +29,7 @@ sv:
       time: "h:mm a"
       time_short_day: "ddd, HH:mm"
       timeline_date: "MMM YYYY"
-      long_no_year: "MMM D h:mm a"
+      long_no_year: "MMM D, h:mm a"
       long_no_year_no_time: "MMM D"
       full_no_year_no_time: "MMMM Do"
       long_with_year: "D MMM, YYYY h:mm a"

--- a/config/locales/client.sw.yml
+++ b/config/locales/client.sw.yml
@@ -28,7 +28,7 @@ sw:
     dates:
       time: "h:mm a"
       timeline_date: "MMM YYYY"
-      long_no_year: "MMM D h:mm a"
+      long_no_year: "MMM D, h:mm a"
       long_no_year_no_time: "MMM D"
       full_no_year_no_time: "MMMM Do"
       long_with_year: "MMM D, YYYY h:mm a"

--- a/config/locales/client.te.yml
+++ b/config/locales/client.te.yml
@@ -24,7 +24,7 @@ te:
             tb: టీబీ
     dates:
       time: "h:mm a"
-      long_no_year: "MMM D h:mm a"
+      long_no_year: "MMM D, h:mm a"
       long_no_year_no_time: "MMM D"
       long_with_year: "MMM D, YYYY h:mm a"
       long_with_year_no_time: "MMM D, YYYY"

--- a/config/locales/client.th.yml
+++ b/config/locales/client.th.yml
@@ -27,7 +27,7 @@ th:
     dates:
       time: "h:mm a"
       timeline_date: "MMM YYYY"
-      long_no_year: "MMM D h:mm a"
+      long_no_year: "MMM D, h:mm a"
       long_no_year_no_time: "MMM D"
       full_no_year_no_time: "MMMM Do"
       long_with_year: "MMM D, YYYY h:mm a"

--- a/config/locales/client.tr_TR.yml
+++ b/config/locales/client.tr_TR.yml
@@ -29,7 +29,7 @@ tr_TR:
       time: "h:mm a"
       time_short_day: "ggg, SS:dd"
       timeline_date: "MMM YYYY"
-      long_no_year: "D MMM h:mm a"
+      long_no_year: "D MMM, h:mm a"
       long_no_year_no_time: "D MMM"
       full_no_year_no_time: "MMMM Do"
       long_with_year: "D MMM, YYYY h:mm a"

--- a/config/locales/client.uk.yml
+++ b/config/locales/client.uk.yml
@@ -31,7 +31,7 @@ uk:
       time: "HH:mm"
       time_short_day: "ddd, HH:mm"
       timeline_date: "MMM YYYY"
-      long_no_year: "D MMM HH:mm"
+      long_no_year: "D MMM, HH:mm"
       long_no_year_no_time: "D MMM"
       full_no_year_no_time: "Do MMMM"
       long_with_year: "D MMM YYYY, HH:mm"

--- a/config/locales/client.ur.yml
+++ b/config/locales/client.ur.yml
@@ -28,7 +28,7 @@ ur:
     dates:
       time: "h:mm a"
       timeline_date: "MMM YYYY"
-      long_no_year: "MMM D h:mm a"
+      long_no_year: "MMM D, h:mm a"
       long_no_year_no_time: "MMM D"
       full_no_year_no_time: "MMMM Do"
       long_with_year: "MMM D, YYYY h:mm a"

--- a/config/locales/client.vi.yml
+++ b/config/locales/client.vi.yml
@@ -28,7 +28,7 @@ vi:
       time: "HH:mm"
       time_short_day: "ddd, HH:mm"
       timeline_date: "MMM YYYY"
-      long_no_year: "D MMM HH:mm"
+      long_no_year: "D MMM, HH:mm"
       long_no_year_no_time: "D MMM"
       full_no_year_no_time: "Do MMMM"
       long_with_year: "D MMM YYYY HH:mm"

--- a/config/locales/client.zh_CN.yml
+++ b/config/locales/client.zh_CN.yml
@@ -248,9 +248,9 @@ zh_CN:
       reminders:
         at_desktop: "下次我使用桌面设备时"
         later_today: "今天晚些时候<br/> {{date}}"
-        next_business_day: "下个工作日<br/>{{date}}"
-        tomorrow: "明天<br/>{{date}}"
-        next_week: "下周<br/>{{date}}"
+        next_business_day: "下个工作日"
+        tomorrow: "明天"
+        next_week: "下周"
         next_month: "下个月<br/> {{date}}"
         custom: "自定义日期和时间"
     drafts:

--- a/config/locales/client.zh_CN.yml
+++ b/config/locales/client.zh_CN.yml
@@ -28,7 +28,7 @@ zh_CN:
       time: "HH:mm"
       time_short_day: "ddd, HH:mm"
       timeline_date: "YYYY[年]M[月]"
-      long_no_year: "M[月]D[日] HH:mm"
+      long_no_year: "M[月]D[日], HH:mm"
       long_no_year_no_time: "M月D日"
       full_no_year_no_time: "M月D日"
       long_with_year: "YYYY年M月D日 HH:mm"

--- a/config/locales/client.zh_TW.yml
+++ b/config/locales/client.zh_TW.yml
@@ -27,7 +27,7 @@ zh_TW:
     dates:
       time: "h:mm a"
       timeline_date: "YYYY年 M月"
-      long_no_year: "M月 D日 h:mm a"
+      long_no_year: "M月 D日, h:mm a"
       long_no_year_no_time: "M月 D日"
       full_no_year_no_time: "M月 D日"
       long_with_year: "YYYY年 M月 D日 h:mm a"

--- a/config/locales/server.bg.yml
+++ b/config/locales/server.bg.yml
@@ -176,11 +176,11 @@ bg:
   excerpt_image: "изображение"
   bookmarks:
     reminders:
-      later_today: "По-късно днес <br/>{{date}}"
-      next_business_day: "Следващият работен ден <br/>{{date}}"
-      tomorrow: "Утре <br/>{{date}}"
-      next_week: "Следващата седмица <br/>{{date}}"
-      next_month: "Следващият месец <br/>{{date}}"
+      later_today: "По-късно днес"
+      next_business_day: "Следващият работен ден"
+      tomorrow: "Утре"
+      next_week: "Следващата седмица"
+      next_month: "Следващият месец"
   groups:
     errors:
       invalid_domain: "'%{domain}' е невалиден домейн."

--- a/config/locales/server.bs_BA.yml
+++ b/config/locales/server.bs_BA.yml
@@ -154,11 +154,11 @@ bs_BA:
   bookmarks:
     reminders:
       at_desktop: "Sljedeći put sam za svojim desktop kompjuterom"
-      later_today: "Danas, malo kasnije <br/>{{date}}"
-      next_business_day: "Sljedeći radni dan <br/>{{date}}"
-      tomorrow: "Sutradan <br/>{{date}}"
-      next_week: "Sljedeće sedmice <br/>{{date}}"
-      next_month: "Naredni mjesec <br/>{{date}}"
+      later_today: "Danas, malo kasnije"
+      next_business_day: "Sljedeći radni dan"
+      tomorrow: "Sutradan"
+      next_week: "Sljedeće sedmice"
+      next_month: "Naredni mjesec"
       custom: "Ciljano vrijeme i datum"
   groups:
     default_names:

--- a/config/locales/server.da.yml
+++ b/config/locales/server.da.yml
@@ -293,9 +293,9 @@ da:
   excerpt_image: "billede"
   bookmarks:
     reminders:
-      tomorrow: "I morgen <br/>{{date}}"
-      next_week: "Næste uge <br/>{{date}}"
-      next_month: "Næste måned <br/>{{date}}"
+      tomorrow: "I morgen"
+      next_week: "Næste uge"
+      next_month: "Næste måned"
       custom: "Valgfri dato og tid"
   groups:
     success:

--- a/config/locales/server.de.yml
+++ b/config/locales/server.de.yml
@@ -331,11 +331,11 @@ de:
       time_must_be_provided: "Zeit muss eingestellt werden für alle Erinnerungen ausser '%{reminder_type}'"
     reminders:
       at_desktop: "Nächstes mal wenn ich an meinem PC bin"
-      later_today: "Im Laufe des Tages <br/>{{date}}"
-      next_business_day: "Nächster Geschäftstag <br/>{{date}}"
-      tomorrow: "Morgen <br/>{{date}}"
-      next_week: "Nächste Woche <br/>{{date}}"
-      next_month: "Nächster Monat <br/>{{date}}"
+      later_today: "Im Laufe des Tages"
+      next_business_day: "Nächster Geschäftstag"
+      tomorrow: "Morgen"
+      next_week: "Nächste Woche"
+      next_month: "Nächster Monat"
       custom: "Eigenes Datum und Zeit"
   groups:
     success:

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -391,11 +391,11 @@ en:
 
     reminders:
       at_desktop: "Next time I'm at my desktop"
-      later_today: "Later today <br/>{{date}}"
-      next_business_day: "Next business day <br/>{{date}}"
-      tomorrow: "Tomorrow <br/>{{date}}"
-      next_week: "Next week <br/>{{date}}"
-      next_month: "Next month <br/>{{date}}"
+      later_today: "Later today"
+      next_business_day: "Next business day"
+      tomorrow: "Tomorrow"
+      next_week: "Next week"
+      next_month: "Next month"
       custom: "Custom date and time"
 
   groups:

--- a/config/locales/server.es.yml
+++ b/config/locales/server.es.yml
@@ -331,11 +331,11 @@ es:
       time_must_be_provided: "se debe especificar la hora para todos los recordatorios excepto '%{reminder_type}'"
     reminders:
       at_desktop: "La próxima vez que esté en mi ordenador"
-      later_today: "Más tarde hoy <br/>{{date}}"
-      next_business_day: "El próximo día hábil <br/>{{date}}"
-      tomorrow: "Mañana <br/>{{date}}"
-      next_week: "La próxima semana <br/>{{date}}"
-      next_month: "El mes que viene <br/>{{date}}"
+      later_today: "Más tarde hoy"
+      next_business_day: "El próximo día hábil"
+      tomorrow: "Mañana"
+      next_week: "La próxima semana"
+      next_month: "El mes que viene"
       custom: "Fecha y hora personalizadas"
   groups:
     success:

--- a/config/locales/server.fa_IR.yml
+++ b/config/locales/server.fa_IR.yml
@@ -222,11 +222,11 @@ fa_IR:
   bookmarks:
     reminders:
       at_desktop: "بار آینده من پشت میزم هستم"
-      later_today: "امروز کمی بعد <br/>{{date}}"
-      next_business_day: "روز کاری آینده <br/>{{date}}"
-      tomorrow: "فردا <br/>{{date}}"
-      next_week: "هفته ی آینده <br/>{{date}}"
-      next_month: "ماه آینده <br/>{{date}}"
+      later_today: "امروز کمی بعد"
+      next_business_day: "روز کاری آینده"
+      tomorrow: "فردا"
+      next_week: "هفته ی آینده"
+      next_month: "ماه آینده"
       custom: "درج تاریخ و ساعت"
   groups:
     errors:

--- a/config/locales/server.fi.yml
+++ b/config/locales/server.fi.yml
@@ -331,11 +331,11 @@ fi:
       time_must_be_provided: "kaikkiin muistutuksiin paitsi '%{reminder_type}' tarvitaan aika"
     reminders:
       at_desktop: "Ensi kerralla kun olen työpöytäympäristössäni"
-      later_today: "Myöhemmin tänään  <br/>{{date}}"
-      next_business_day: "Seuraavana arkipäivänä <br/>{{date}}"
-      tomorrow: "Huomenna <br/>{{date}}"
-      next_week: "Ensi viikolla <br/>{{date}}"
-      next_month: "Ensi kuussa <br/>{{date}}"
+      later_today: "Myöhemmin tänään "
+      next_business_day: "Seuraavana arkipäivänä"
+      tomorrow: "Huomenna"
+      next_week: "Ensi viikolla"
+      next_month: "Ensi kuussa"
       custom: "Valitse päivämäärä ja kellonaika"
   groups:
     success:

--- a/config/locales/server.fr.yml
+++ b/config/locales/server.fr.yml
@@ -328,10 +328,10 @@ fr:
     reminders:
       at_desktop: "La prochaine fois je suis à mon bureau"
       later_today: "Plus tard dans la journée\n{{date}}"
-      next_business_day: "Prochain jour ouvré<br/>{{date}}"
-      tomorrow: "Demain<br/>{{date}}"
-      next_week: "La semaine prochaine<br/>{{date}}"
-      next_month: "Le mois prochain<br/>{{date}}"
+      next_business_day: "Prochain jour ouvré"
+      tomorrow: "Demain"
+      next_week: "La semaine prochaine"
+      next_month: "Le mois prochain"
       custom: "Date et heure personnalisés"
   groups:
     success:

--- a/config/locales/server.he.yml
+++ b/config/locales/server.he.yml
@@ -362,11 +362,11 @@ he:
       time_must_be_provided: "צריך לציין זמן לכל התזכורות למעט ‚%{reminder_type}’"
     reminders:
       at_desktop: "בשימוש הבא דרך שולחן העבודה"
-      later_today: "המשך היום <br/>{{date}}"
-      next_business_day: "ביום העסקים הבא <br/>{{date}}"
-      tomorrow: "מחר <br/>{{date}}"
-      next_week: "בשבוע הבא <br/>{{date}}"
-      next_month: "בחודש הבא <br/>{{date}}"
+      later_today: "המשך היום"
+      next_business_day: "ביום העסקים הבא"
+      tomorrow: "מחר"
+      next_week: "בשבוע הבא"
+      next_month: "בחודש הבא"
       custom: "תאריך ושעה מותאמים אישית"
   groups:
     success:

--- a/config/locales/server.nl.yml
+++ b/config/locales/server.nl.yml
@@ -332,11 +332,11 @@ nl:
       time_must_be_provided: "tijd moet voor alle herinneringen behalve '%{reminder_type}' worden opgegeven"
     reminders:
       at_desktop: "De volgende keer vanaf mijn computer"
-      later_today: "Later vandaag <br/>{{date}}"
-      next_business_day: "Volgende werkdag <br/>{{date}}"
-      tomorrow: "Morgen <br/>{{date}}"
-      next_week: "Volgende week <br/>{{date}}"
-      next_month: "Volgende maand <br/>{{date}}"
+      later_today: "Later vandaag"
+      next_business_day: "Volgende werkdag"
+      tomorrow: "Morgen"
+      next_week: "Volgende week"
+      next_month: "Volgende maand"
       custom: "Aangepaste datum en tijd"
   groups:
     success:

--- a/config/locales/server.pt_BR.yml
+++ b/config/locales/server.pt_BR.yml
@@ -316,11 +316,11 @@ pt_BR:
   bookmarks:
     reminders:
       at_desktop: "Da próxima vez que estiver na minha área de trabalho"
-      later_today: "Hoje mais tarde <br/>{{date}}"
-      next_business_day: "Próximo dia comercial <br/>{{date}}"
-      tomorrow: "Amanhã <br/>{{date}}"
-      next_week: "Próxima semana <br/>{{date}}"
-      next_month: "Próximo mês <br/>{{date}}"
+      later_today: "Hoje mais tarde"
+      next_business_day: "Próximo dia comercial"
+      tomorrow: "Amanhã"
+      next_week: "Próxima semana"
+      next_month: "Próximo mês"
       custom: "Data e hora personalizadas"
   groups:
     success:

--- a/config/locales/server.ru.yml
+++ b/config/locales/server.ru.yml
@@ -353,11 +353,11 @@ ru:
       time_must_be_provided: "время должно быть установлено для всех напоминаний, кроме '%{reminder_type}'"
     reminders:
       at_desktop: "При следующем посещении форума"
-      later_today: "На сегодня, но чуть позже <br/>{{date}}"
-      next_business_day: "На следующий рабочий день <br/>{{date}}"
-      tomorrow: "На завтра <br/>{{date}}"
-      next_week: "На следующую неделю <br/>{{date}}"
-      next_month: "На следующий месяц <br/>{{date}}"
+      later_today: "На сегодня, но чуть позже"
+      next_business_day: "На следующий рабочий день"
+      tomorrow: "На завтра"
+      next_week: "На следующую неделю"
+      next_month: "На следующий месяц"
       custom: "Установить дату и время напоминания"
   groups:
     success:

--- a/config/locales/server.sv.yml
+++ b/config/locales/server.sv.yml
@@ -332,11 +332,11 @@ sv:
       time_must_be_provided: "tid måste tillhandahållas för alla påminnelser utom '%{reminder_type}'"
     reminders:
       at_desktop: "Nästa gång är jag vid datorn"
-      later_today: "Senare idag <br/>{{date}}"
-      next_business_day: "Nästa arbetsdag <br/>{{date}}"
-      tomorrow: "Imorgon <br/>{{date}}"
-      next_week: "Nästa vecka <br/>{{date}}"
-      next_month: "Nästa månad <br/>{{date}}"
+      later_today: "Senare idag"
+      next_business_day: "Nästa arbetsdag"
+      tomorrow: "Imorgon"
+      next_week: "Nästa vecka"
+      next_month: "Nästa månad"
       custom: "Anpassa datum och tid"
   groups:
     success:

--- a/config/locales/server.zh_CN.yml
+++ b/config/locales/server.zh_CN.yml
@@ -317,10 +317,10 @@ zh_CN:
       time_must_be_provided: "必须为除“ %{reminder_type}”以外的所有提醒提供时间"
     reminders:
       at_desktop: "下次我使用桌面设备时"
-      later_today: "晚于今天的<br/>{{date}}"
-      next_business_day: "下个工作日的<br/>{{date}}"
-      tomorrow: "明天<br/>{{date}}"
-      next_week: "下周<br/>{{date}}"
+      later_today: "晚于今天的"
+      next_business_day: "下个工作日的"
+      tomorrow: "明天"
+      next_week: "下周"
       next_month: "下个月<br/> {{date}}"
       custom: "自定义日期和时间"
   groups:


### PR DESCRIPTION
The `{{date}}` interpolated value was removed from the English translations in https://github.com/discourse/discourse/pull/9329 but not from the other translations, causing breakages:

![image](https://user-images.githubusercontent.com/920448/78516931-b6c53f00-77fe-11ea-99da-f154b3432436.png)

Also adds a `,` inbetween date and time for reminders using `long_no_year` for readability.

![image](https://user-images.githubusercontent.com/920448/78516949-c93f7880-77fe-11ea-9a6e-9aa0224c656f.png)
