### PR TITLE
FIX: prevents registering multiple `topic-notifications-button:changed`

### DIFF
--- a/app/assets/javascripts/discourse/widgets/topic-timeline.js
+++ b/app/assets/javascripts/discourse/widgets/topic-timeline.js
@@ -388,7 +388,8 @@ createWidget("timeline-footer-controls", {
             topic,
             showFullTitle: false,
             appendReason: false,
-            placement: "bottom-end"
+            placement: "bottom-end",
+            mountedAsWidget: true
           },
           ["notificationLevel"]
         )

--- a/app/assets/javascripts/select-kit/components/topic-notifications-button.js
+++ b/app/assets/javascripts/select-kit/components/topic-notifications-button.js
@@ -10,21 +10,25 @@ export default Component.extend({
   didInsertElement() {
     this._super(...arguments);
 
-    this.appEvents.on(
-      "topic-notifications-button:changed",
-      this,
-      "_changeTopicNotificationLevel"
-    );
+    if (!this.mountedAsWidget) {
+      this.appEvents.on(
+        "topic-notifications-button:changed",
+        this,
+        "_changeTopicNotificationLevel"
+      );
+    }
   },
 
   willDestroyElement() {
     this._super(...arguments);
 
-    this.appEvents.off(
-      "topic-notifications-button:changed",
-      this,
-      "_changeTopicNotificationLevel"
-    );
+    if (!this.mountedAsWidget) {
+      this.appEvents.off(
+        "topic-notifications-button:changed",
+        this,
+        "_changeTopicNotificationLevel"
+      );
+    }
   },
 
   _changeTopicNotificationLevel(level) {


### PR DESCRIPTION
A large topic page will always have the bottom tracking button, and will also have the timeline, meaning we already had 2 tracking events.

But it gets even worse when you know that the timeline button is a component connector which will trigger `didInsertElement` very frequently, meaning we were constantly adding more and more appEvents handlers.