### PR TITLE
FIX: reset gravatar cache by adding random param to URL

### DIFF
--- a/app/models/user_avatar.rb
+++ b/app/models/user_avatar.rb
@@ -20,7 +20,7 @@ class UserAvatar < ActiveRecord::Base
         return if user.blank? || user.primary_email.blank?
 
         email_hash = user_id == Discourse::SYSTEM_USER_ID ? User.email_hash("info@discourse.org") : user.email_hash
-        gravatar_url = "https://#{SiteSetting.gravatar_base_url}/avatar/#{email_hash}.png?s=#{max}&d=404"
+        gravatar_url = "https://#{SiteSetting.gravatar_base_url}/avatar/#{email_hash}.png?s=#{max}&d=404&reset_cache=#{SecureRandom.urlsafe_base64(5)}"
 
         # follow redirects in case gravatar change rules on us
         tempfile = FileHelper.download(

--- a/spec/models/user_avatar_spec.rb
+++ b/spec/models/user_avatar_spec.rb
@@ -99,10 +99,10 @@ describe UserAvatar do
     describe "404 should be silent, nothing to do really" do
 
       it "does nothing when avatar is 404" do
-
+        SecureRandom.stubs(:urlsafe_base64).returns("5555")
         freeze_time Time.now
 
-        stub_request(:get, "https://www.gravatar.com/avatar/#{avatar.user.email_hash}.png?d=404&s=360").
+        stub_request(:get, "https://www.gravatar.com/avatar/#{avatar.user.email_hash}.png?d=404&reset_cache=5555&s=360").
           to_return(status: 404, body: "", headers: {})
 
         expect do


### PR DESCRIPTION
Users noticed that sometimes, avatar from Gravatar is not correctly updated - https://meta.discourse.org/t/updated-image-on-gravatar-not-seeing-it-update-on-site/54357

A potential reason for that is that even if you update your avatar in Gravatar, URL stays the same and if the cache is involved, service is still receiving the old photo.

For example. In my case, when I click the button to refresh avatar the
new Upload record is created with `origin` URL to new avatar, and `url` to
old one

I made some tests in the rails console and adding random param to Gravatar URL is deceiving cache and correct, the newest avatar is downloaded