### PR TITLE
Add same site cookie 'None' option to make cross domain systems possible

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1377,7 +1377,8 @@ security:
       - Lax
       - Strict
       - Disabled
-    regex: "^(Lax|Strict|Disabled)$"
+      - None
+    regex: "^(Lax|Strict|Disabled|None)$"
   enable_escaped_fragments: true
   allow_index_in_robots_txt: true
   moderators_create_categories: false


### PR DESCRIPTION
Added sameSite=None option to be able to send cookies to other domains.