### PR TITLE
FIX: Labels for modal close and dismiss-error buttons

### DIFF
--- a/app/assets/javascripts/discourse/templates/components/d-modal.hbs
+++ b/app/assets/javascripts/discourse/templates/components/d-modal.hbs
@@ -3,7 +3,7 @@
     <div class="modal-inner-container">
       <div class="modal-header">
         {{#if dismissable}}
-          {{d-button icon="times" action=(route-action "closeModal") class="btn btn-flat modal-close close" }}
+          {{d-button icon="times" action=(route-action "closeModal") class="btn btn-flat modal-close close" title="modal.close"}}
         {{/if}}
 
         {{#if panels}}
@@ -33,7 +33,7 @@
 
       {{#each errors as |error|}}
         <div class="alert alert-error">
-          <button class="close" data-dismiss="alert">×</button>
+          <button class="close" data-dismiss="alert" aria-label={{i18n "modal.dismiss_error"}}>×</button>
           {{error}}
         </div>
       {{/each}}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1381,6 +1381,9 @@ en:
         back: "Go Back"
         again: "Try Again"
         fixed: "Load Page"
+    modal:
+      close: "close"
+      dismiss_error: "Dismiss error"
     close: "Close"
     assets_changed_confirm: "This site was just updated. Refresh now for the latest version?"
     logout: "You were logged out."


### PR DESCRIPTION
Easy fix from the accessibility audit.

Chose to add a new translation for 'close' just in case it needs a different tense.