### PR TITLE
FIX: WCAG-AA compliant topic list heatmap colors

### DIFF
--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -212,15 +212,16 @@
 
 .heatmap-high,
 .heatmap-high a {
-  color: #fe7a15 !important;
+  color: #ec7213 !important;
+  font-weight: bold;
 }
 .heatmap-med,
 .heatmap-med a {
-  color: #cf7721 !important;
+  color: #b06318 !important;
 }
 .heatmap-low,
 .heatmap-low a {
-  color: #9b764f !important;
+  color: #93704a !important;
 }
 
 .loading .topic-list {


### PR DESCRIPTION
Color #ec7213: 3.0, Bold - AA Large Pass
Color #b06318: 4.50, Normal - AA Pass
Color #93704a: 4.51, Normal - AA Pass

Used the Chrome Inspector color picker curves to preserve the hue and make minimally invasive changes to the coloring.

Screenshot of Meta with the new styles applied. I can hardly tell the difference ^.^

![image](https://user-images.githubusercontent.com/627891/78735130-d774be00-78fe-11ea-9952-aa7628929772.png)
