### PR TITLE
FEATURE: New site setting `embed_unlisted`

### DIFF
--- a/app/assets/javascripts/admin/templates/embedding.hbs
+++ b/app/assets/javascripts/admin/templates/embedding.hbs
@@ -38,6 +38,7 @@
                         value=embedding.embed_title_scrubber
                         placeholder="- site.com$"}}
     {{embedding-setting field="embed_truncate" value=embedding.embed_truncate type="checkbox"}}
+    {{embedding-setting field="embed_unlisted" value=embedding.embed_unlisted type="checkbox"}}
   </div>
 
   <div class='embedding-secondary'>

--- a/app/models/embedding.rb
+++ b/app/models/embedding.rb
@@ -10,6 +10,7 @@ class Embedding < OpenStruct
        embed_post_limit
        embed_title_scrubber
        embed_truncate
+       embed_unlisted
        embed_whitelist_selector
        embed_blacklist_selector
        embed_classname_whitelist)

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -127,7 +127,8 @@ class Post < ActiveRecord::Base
                                  flagged_by_tl3_user: 4,
                                  email_spam_header_found: 5,
                                  flagged_by_tl4_user: 6,
-                                 email_authentication_result_header: 7)
+                                 email_authentication_result_header: 7,
+                                 imported_as_unlisted: 8)
   end
 
   def self.types

--- a/app/models/topic_embed.rb
+++ b/app/models/topic_embed.rb
@@ -53,12 +53,18 @@ class TopicEmbed < ActiveRecord::Base
           Post.cook_methods[:raw_html]
         end
 
-        creator = PostCreator.new(user,
-                                  title: title,
-                                  raw: absolutize_urls(url, contents),
-                                  skip_validations: true,
-                                  cook_method: cook_method,
-                                  category: eh.try(:category_id))
+        create_args = {
+          title: title,
+          raw: absolutize_urls(url, contents),
+          skip_validations: true,
+          cook_method: cook_method,
+          category: eh.try(:category_id)
+        }
+        if SiteSetting.embed_unlisted?
+          create_args[:visible] = false
+        end
+
+        creator = PostCreator.new(user, create_args)
         post = creator.create
         if post.present?
           TopicEmbed.create!(topic_id: post.topic_id,

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4614,6 +4614,7 @@ en:
         embed_post_limit: "Maximum number of posts to embed"
         embed_title_scrubber: "Regular expression used to scrub the title of posts"
         embed_truncate: "Truncate the embedded posts"
+        embed_unlisted: "Imported topics will be unlisted until there is a reply."
         embed_whitelist_selector: "CSS selector for elements that are allowed in embeds"
         embed_blacklist_selector: "CSS selector for elements that are removed from embeds"
         embed_classname_whitelist: "Allowed CSS class names"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2068,6 +2068,7 @@ en:
     embed_topics_list: "Support HTML embedding of topics lists"
     embed_set_canonical_url: "Set the canonical URL for embeded topics to the embeded content's URL."
     embed_truncate: "Truncate the embedded posts."
+    embed_unlisted: "Imported topics will be unlisted until a user replies."
     embed_support_markdown: "Support Markdown formatting for embedded posts."
     embed_whitelist_selector: "A comma separated list of CSS elements that are allowed in embeds."
     allowed_href_schemes: "Schemes allowed in links in addition to http and https."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -901,12 +901,10 @@ posting:
   embed_any_origin: false
   embed_topics_list: false
   embed_set_canonical_url: false
-  embed_truncate:
-    default: true
-  embed_support_markdown:
-    default: false
-  embed_whitelist_selector:
-    default: ""
+  embed_unlisted: false
+  embed_truncate: true
+  embed_support_markdown: false
+  embed_whitelist_selector: ""
   allowed_href_schemes:
     client: true
     default: ""

--- a/lib/post_creator.rb
+++ b/lib/post_creator.rb
@@ -186,6 +186,7 @@ class PostCreator
         @post.link_post_uploads
         update_uploads_secure_status
         ensure_in_allowed_users if guardian.is_staff?
+        make_visible
         unarchive_message
         if !@opts[:import_mode]
           DraftSequence.next!(@user, draft_key)
@@ -411,6 +412,16 @@ class PostCreator
                                            )', @user.id).exists?
         @topic.topic_allowed_users.create!(user_id: @user.id)
       end
+    end
+  end
+
+  def make_visible
+    return unless SiteSetting.embed_unlisted?
+    return unless @post.post_number > 1
+    return if @post.topic.visible?
+
+    if embed = @post.topic.topic_embed
+      @post.topic.update_status('visible', true, @user)
     end
   end
 

--- a/spec/models/topic_embed_spec.rb
+++ b/spec/models/topic_embed_spec.rb
@@ -41,6 +41,7 @@ describe TopicEmbed do
         expect(TopicEmbed.where(topic_id: post.topic_id)).to be_present
 
         expect(post.topic.category).to eq(embeddable_host.category)
+        expect(post.topic).to be_visible
       end
 
       it "Supports updating the post content" do
@@ -70,6 +71,20 @@ describe TopicEmbed do
         cased_url = 'http://eviltrout.com/abcd'
         post = TopicEmbed.import(user, cased_url, title, "some random content")
         expect(post.cooked).to match(/#{cased_url}/)
+      end
+
+      it "will make the topic unlisted if `embed_unlisted` is set until someone replies" do
+        SiteSetting.embed_unlisted = true
+        imported_post = TopicEmbed.import(user, "http://eviltrout.com/abcd", title, "some random content")
+        expect(imported_post.topic).not_to be_visible
+        pc = PostCreator.new(
+          Fabricate(:user),
+          raw: "this is a reply that will make the topic visible",
+          topic_id: imported_post.topic_id,
+          reply_to_post_number: 1
+        )
+        pc.create
+        expect(imported_post.topic.reload).to be_visible
       end
     end
 


### PR DESCRIPTION
If enabled, posts imported to discourse via embeddings will default to
unlisted until they receive a reply.