### PR TITLE
FEATURE: Webhooks and Event for user being granted a badge

### DIFF
--- a/app/models/web_hook_event_type.rb
+++ b/app/models/web_hook_event_type.rb
@@ -13,6 +13,7 @@ class WebHookEventType < ActiveRecord::Base
   NOTIFICATION = 10
   SOLVED = 11
   ASSIGN = 12
+  USER_BADGE = 13
 
   has_and_belongs_to_many :web_hooks
 

--- a/app/services/badge_granter.rb
+++ b/app/services/badge_granter.rb
@@ -410,7 +410,7 @@ class BadgeGranter
   end
 
   def self.send_notification(user_id, username, locale, badge)
-    I18n.with_locale(notification_locale(locale)) do
+    notification = I18n.with_locale(notification_locale(locale)) do
       Notification.create!(
         user_id: user_id,
         notification_type: Notification.types[:granted_badge],
@@ -423,6 +423,10 @@ class BadgeGranter
         }.to_json
       )
     end
+
+    DiscourseEvent.trigger(:user_badge_granted, badge, user_id)
+
+    notification
   end
 
 end

--- a/config/initializers/012-web_hook_events.rb
+++ b/config/initializers/012-web_hook_events.rb
@@ -74,6 +74,16 @@ end
   end
 end
 
+%i(
+  user_badge_granted
+).each do |event|
+  # user_badge_revoked
+  DiscourseEvent.on(event) do |badge, user_id|
+    ub = UserBadge.find_by(badge: badge, user_id: user_id)
+    WebHook.enqueue_object_hooks(:user_badge, ub, event, UserBadgeSerializer)
+  end
+end
+
 DiscourseEvent.on(:reviewable_created) do |reviewable|
   WebHook.enqueue_object_hooks(:reviewable, reviewable, :reviewable_created, reviewable.serializer)
 end

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3545,6 +3545,9 @@ en:
         notification_event:
           name: "Notification Event"
           details: "When a user receives a notification in their feed."
+        user_badge_event:
+          name: "Badge Grant Event"
+          details: "When a user receives a badge."
         delivery_status:
           title: "Delivery Status"
           inactive: "Inactive"

--- a/db/fixtures/007_web_hook_event_types.rb
+++ b/db/fixtures/007_web_hook_event_types.rb
@@ -59,3 +59,8 @@ WebHookEventType.seed do |b|
   b.id = WebHookEventType::ASSIGN
   b.name = "assign"
 end
+
+WebHookEventType.seed do |b|
+  b.id = WebHookEventType::USER_BADGE
+  b.name = "user_badge"
+end

--- a/spec/fabricators/web_hook_fabricator.rb
+++ b/spec/fabricators/web_hook_fabricator.rb
@@ -102,3 +102,11 @@ Fabricator(:notification_web_hook, from: :web_hook) do
     web_hook.web_hook_event_types = [transients[:notification_hook]]
   end
 end
+
+Fabricator(:user_badge_web_hook, from: :web_hook) do
+  transient user_badge_hook: WebHookEventType.find_by(name: 'user_badge')
+
+  after_build do |web_hook, transients|
+    web_hook.web_hook_event_types = [transients[:user_badge_hook]]
+  end
+end


### PR DESCRIPTION
Adding a webhook for badge revocation is left for future work as it's relatively rare.

The webhook type is named 'user_badge' instead of 'badge' just in case we want to add hooks for modifying badge properties in the future, I guess...?