### PR TITLE
DEV: Buff theme install rake task - more options

### DIFF
--- a/app/services/themes_install_task.rb
+++ b/app/services/themes_install_task.rb
@@ -2,15 +2,15 @@
 
 class ThemesInstallTask
   def self.install(themes)
-    counts = { installed: 0, updated: 0, skipped: 0, errors: 0 }
+    counts = { installed: 0, updated: 0, errors: 0 }
     log = []
     themes.each do |name, val|
       installer = new(val)
 
       if installer.theme_exists?
         installer.update
-        log << "#{name}: is already installed"
-        counts[:skipped] += 1
+        log << "#{name}: is already installed. Updating from remote."
+        counts[:updated] += 1
       else
         begin
           installer.install
@@ -44,7 +44,7 @@ class ThemesInstallTask
   end
 
   def theme_exists?
-    !@theme.nil?
+    @theme.present?
   end
 
   def find_existing

--- a/lib/tasks/themes.rake
+++ b/lib/tasks/themes.rake
@@ -44,7 +44,6 @@ task "themes:install" => :environment do |task, args|
   puts "Results:"
   puts " Installed: #{counts[:installed]}"
   puts " Updated:   #{counts[:updated]}"
-  puts " Skipped:   #{counts[:skipped]}"
   puts " Errors:    #{counts[:errors]}"
 
   if counts[:errors] > 0

--- a/lib/tasks/themes.rake
+++ b/lib/tasks/themes.rake
@@ -20,7 +20,7 @@ require 'yaml'
 #   branch: "master"
 #   private_key: ""
 #   default: false
-#   install_to_all_themes: false  # only for components - install on every theme
+#   add_to_all_themes: false  # only for components - install on every theme
 #
 # In the first form, only the url is required.
 #

--- a/lib/tasks/themes.rake
+++ b/lib/tasks/themes.rake
@@ -26,26 +26,15 @@ require 'yaml'
 #
 desc "Install themes & theme components"
 task "themes:install" => :environment do |task, args|
-
   theme_args = (STDIN.tty?) ? '' : STDIN.read
   use_json = theme_args == ''
 
-  if use_json
-    begin
-      theme_args = JSON.parse(ARGV.last.gsub('--', ''))
-    rescue
-      puts "Invalid JSON input. \n#{ARGV.last}"
-      exit 1
-    end
-  else
-    begin
-      theme_args = YAML::load(theme_args)
-    rescue
-      puts "Invalid YML: \n#{theme_args}"
-      exit 1
-    end
-  end
-
+  theme_args = begin
+                 use_json ? JSON.parse(ARGV.last.gsub('--', '')) : YAML::load(theme_args)
+               rescue
+                 puts use_json ? "Invalid JSON input. \n#{ARGV.last}" : "Invalid YML: \n#{theme_args}"
+                 exit 1
+               end
 
   log, counts = ThemesInstallTask.install(theme_args)
 

--- a/spec/services/themes_spec.rb
+++ b/spec/services/themes_spec.rb
@@ -96,6 +96,7 @@ describe ThemesInstallTask do
 
     after do
       `rm -fr #{theme_repo}`
+      `rm -fr #{component_repo}`
     end
 
     it 'gracefully fails' do

--- a/spec/services/themes_spec.rb
+++ b/spec/services/themes_spec.rb
@@ -8,9 +8,6 @@ describe ThemesInstallTask do
     Discourse::Application.load_tasks
   end
 
-  let(:github_repo) { 'https://github.com/example/theme.git' }
-  let(:branch) { 'master' }
-
   describe '.new' do
     def setup_git_repo(files)
       dir = Dir.tmpdir

--- a/spec/services/themes_spec.rb
+++ b/spec/services/themes_spec.rb
@@ -12,71 +12,134 @@ describe ThemesInstallTask do
   let(:branch) { 'master' }
 
   describe '.new' do
-    context 'with url' do
-      subject { described_class.new(github_repo) }
-
-      it 'configures the url' do
-        expect(subject.url).to eq github_repo
+    def setup_git_repo(files)
+      dir = Dir.tmpdir
+      repo_dir = "#{dir}/#{SecureRandom.hex}"
+      `mkdir #{repo_dir}`
+      `cd #{repo_dir} && git init . `
+      `cd #{repo_dir} && git config user.email 'someone@cool.com'`
+      `cd #{repo_dir} && git config user.name 'The Cool One'`
+      `cd #{repo_dir} && git config commit.gpgsign 'false'`
+      files.each do |name, data|
+        FileUtils.mkdir_p(Pathname.new("#{repo_dir}/#{name}").dirname)
+        File.write("#{repo_dir}/#{name}", data)
+        `cd #{repo_dir} && git add #{name}`
       end
+      `cd #{repo_dir} && git commit -am 'first commit'`
+      repo_dir
+    end
 
-      it 'initializes without options' do
-        expect(subject.options).to eq({})
+    THEME_NAME = "awesome theme"
+
+    def about_json(love_color: "FAFAFA", tertiary_low_color: "FFFFFF", color_scheme_name: "Amazing", about_url: "https://www.site.com/about", component: false)
+      <<~JSON
+        {
+          "name": "#{THEME_NAME}",
+          "about_url": "#{about_url}",
+          "license_url": "https://www.site.com/license",
+          "theme_version": "1.0",
+          "minimum_discourse_version": "1.0.0",
+          "assets": {
+            "font": "assets/font.woff2"
+          },
+          "component": "#{component}",
+          "color_schemes": {
+            "#{color_scheme_name}": {
+              "love": "#{love_color}",
+              "tertiary-low": "#{tertiary_low_color}"
+            }
+          },
+          "modifiers": {
+            "serialize_topic_excerpts": true
+          }
+        }
+      JSON
+    end
+
+    let :scss_data do
+      "@font-face { font-family: magic; src: url($font)}; body {color: $color; content: $name;}"
+    end
+
+    let :theme_repo do
+      setup_git_repo(
+        "about.json" => about_json,
+        "desktop/desktop.scss" => scss_data,
+        "scss/oldpath.scss" => ".class2{color:blue}",
+        "stylesheets/file.scss" => ".class1{color:red}",
+        "stylesheets/empty.scss" => "",
+        "javascripts/discourse/controllers/test.js.es6" => "console.log('test');",
+        "common/header.html" => "I AM HEADER",
+        "common/random.html" => "I AM SILLY",
+        "common/embedded.scss" => "EMBED",
+        "assets/font.woff2" => "FAKE FONT",
+        "settings.yaml" => "boolean_setting: true",
+        "locales/en.yml" => "sometranslations"
+      )
+    end
+
+    let :component_repo do
+      setup_git_repo(
+        "about.json" => about_json(component: true),
+        "desktop/desktop.scss" => scss_data,
+        "scss/oldpath.scss" => ".class2{color:blue}",
+        "stylesheets/file.scss" => ".class1{color:red}",
+        "stylesheets/empty.scss" => "",
+        "javascripts/discourse/controllers/test.js.es6" => "console.log('test');",
+        "common/header.html" => "I AM HEADER",
+        "common/random.html" => "I AM SILLY",
+        "common/embedded.scss" => "EMBED",
+        "assets/font.woff2" => "FAKE FONT",
+        "settings.yaml" => "boolean_setting: true",
+        "locales/en.yml" => "sometranslations"
+      )
+    end
+
+    after do
+      `rm -fr #{theme_repo}`
+    end
+
+    it 'gracefully fails' do
+      ThemesInstallTask.install("nothing": "fail!")
+      expect(Theme.where(name: "fail!").exists?).to eq(false)
+    end
+
+    describe "no options" do
+      it 'installs a theme' do
+        ThemesInstallTask.install("some_theme": theme_repo)
+        expect(Theme.where(name: THEME_NAME).exists?).to eq(true)
       end
     end
 
-    context 'with options' do
-      subject { described_class.new(options) }
-      let(:options) { { 'url' => github_repo, 'branch' => branch } }
-
-      it 'configures the url' do
-        expect(subject.url).to eq github_repo
+    describe "with options" do
+      it 'installs a theme from only a url' do
+        ThemesInstallTask.install({ "some_theme": { "url": theme_repo } })
+        expect(Theme.where(name: THEME_NAME).exists?).to eq(true)
       end
 
-      it 'initializes options' do
-        expect(subject.options).to eq("url" => github_repo, "branch" => branch)
-      end
-    end
-  end
-
-  describe '#theme_exists?' do
-    let(:theme) { Fabricate(:theme) }
-    subject { described_class.new(options) }
-
-    context 'without branch' do
-      let(:options) { github_repo }
-
-      it 'returns true when a branchless theme exists' do
-        theme.create_remote_theme(remote_url: github_repo)
-        expect(subject.theme_exists?).to be true
+      it 'does not set the theme to default if the key/value is not present' do
+        ThemesInstallTask.install({ "some_theme": { "url": theme_repo } })
+        theme = Theme.find_by(name: THEME_NAME)
+        expect(theme.default?).to eq(false)
       end
 
-      it 'returns false when the url exists but with a branch' do
-        theme.create_remote_theme(remote_url: github_repo, branch: branch)
-        expect(subject.theme_exists?).to be false
+      it 'sets the theme to default if the key/value is true' do
+        ThemesInstallTask.install({ "some_theme": { "url": theme_repo, default: true } })
+        theme = Theme.find_by(name: THEME_NAME)
+        expect(theme.default?).to eq(true)
       end
 
-      it 'returns false when it doesnt exist' do
-        theme.create_remote_theme(remote_url: 'https://github.com/example/different_theme.git')
-        expect(subject.theme_exists?).to be false
-      end
-    end
-
-    context 'with branch' do
-      let(:options) { { 'url' => github_repo, 'branch' => branch } }
-
-      it 'returns false when a branchless theme exists' do
-        theme.create_remote_theme(remote_url: github_repo)
-        expect(subject.theme_exists?).to be false
+      it 'installs theme components, but does not add them to themes' do
+        ThemesInstallTask.install({ "some_theme": { "url": component_repo } })
+        theme = Theme.find_by(name: THEME_NAME)
+        expect(theme.component).to eq(true)
       end
 
-      it 'returns true when the url exists with a branch' do
-        theme.create_remote_theme(remote_url: github_repo, branch: branch)
-        expect(subject.theme_exists?).to be true
-      end
-
-      it 'returns false when it doesnt exist' do
-        theme.create_remote_theme(remote_url: 'https://github.com/example/different_theme.git')
-        expect(subject.theme_exists?).to be false
+      it 'adds component to all themes if "add_to_all_themes" is true' do
+        ThemesInstallTask.install({ "some_theme": { "url": component_repo, add_to_all_themes: true } })
+        theme = Theme.find_by(name: THEME_NAME)
+        Theme.where(component: false).each do |parent_theme|
+          expect(ChildTheme.find_by(parent_theme_id: parent_theme.id, child_theme_id: theme.id).nil?).to eq(false)
+        end
       end
     end
   end


### PR DESCRIPTION
This rake task was created from someone outside Discourse, and does not quite fit our needs. This PR keeps the existing functionality, while extending it.

Instead of "skipping" previously installed themes, call `update_from_remote` on them. Calling this rake task systematically, will install new themes and keep themes/components updated.

Add option to install a theme component to all existing themes: `add_to_all_themes`. Even if a theme component is previously installed, so it gets updated, the `add_to_all_themes` option will be in effect.

Also add ability to pass a JSON string into `rake themes:install`
```bash
bin/rake themes:install -- '--{"placeholder": {"url": "https://github.com/discourse/discourse-placeholder-theme-component.git", "install_to_all_themes": true}}'
```

This diff sucks - looks kind of tough to review.