### PR TITLE
FEATURE: add after-reviewable-post-user plugin outlet

### DIFF
--- a/app/assets/javascripts/discourse/templates/components/reviewable-created-by-name.hbs
+++ b/app/assets/javascripts/discourse/templates/components/reviewable-created-by-name.hbs
@@ -9,4 +9,7 @@
       {{i18n "review.deleted_user"}}
     {{/if}}
   </span>
+  {{plugin-outlet name="after-reviewable-post-user"
+      tagName=""
+      args=(hash user=user)}}
 </div>

--- a/app/serializers/reviewable_serializer.rb
+++ b/app/serializers/reviewable_serializer.rb
@@ -19,13 +19,13 @@ class ReviewableSerializer < ApplicationSerializer
     :version,
   )
 
-  has_one :created_by, serializer: UserCustomFieldsSerializer, root: 'users'
-  has_one :target_created_by, serializer: UserCustomFieldsSerializer, root: 'users'
+  has_one :created_by, serializer: UserWithCustomFieldsSerializer, root: 'users'
+  has_one :target_created_by, serializer: UserWithCustomFieldsSerializer, root: 'users'
   has_one :topic, serializer: ListableTopicSerializer
   has_many :editable_fields, serializer: ReviewableEditableFieldSerializer, embed: :objects
   has_many :reviewable_scores, serializer: ReviewableScoreSerializer
   has_many :bundled_actions, serializer: ReviewableBundledActionSerializer
-  has_one :claimed_by, serializer: UserCustomFieldsSerializer, root: 'users'
+  has_one :claimed_by, serializer: UserWithCustomFieldsSerializer, root: 'users'
 
   # Used to keep track of our payload attributes
   class_attribute :_payload_for_serialization

--- a/app/serializers/reviewable_serializer.rb
+++ b/app/serializers/reviewable_serializer.rb
@@ -19,13 +19,13 @@ class ReviewableSerializer < ApplicationSerializer
     :version,
   )
 
-  has_one :created_by, serializer: BasicUserSerializer, root: 'users'
-  has_one :target_created_by, serializer: BasicUserSerializer, root: 'users'
+  has_one :created_by, serializer: UserCustomFieldsSerializer, root: 'users'
+  has_one :target_created_by, serializer: UserCustomFieldsSerializer, root: 'users'
   has_one :topic, serializer: ListableTopicSerializer
   has_many :editable_fields, serializer: ReviewableEditableFieldSerializer, embed: :objects
   has_many :reviewable_scores, serializer: ReviewableScoreSerializer
   has_many :bundled_actions, serializer: ReviewableBundledActionSerializer
-  has_one :claimed_by, serializer: BasicUserSerializer, root: 'users'
+  has_one :claimed_by, serializer: UserCustomFieldsSerializer, root: 'users'
 
   # Used to keep track of our payload attributes
   class_attribute :_payload_for_serialization

--- a/app/serializers/user_custom_fields_serializer.rb
+++ b/app/serializers/user_custom_fields_serializer.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# A basic user serializer, with custom fields
+class UserCustomFieldsSerializer < BasicUserSerializer
+  attributes :custom_fields
+
+  def custom_fields
+    fields = custom_field_keys
+
+    if fields.present?
+      if object.custom_fields_preloaded?
+        {}.tap { |h| fields.each { |f| h[f] = object.custom_fields[f] } }
+      else
+        User.custom_fields_for_ids([object.id], fields)[object.id] || {}
+      end
+    else
+      {}
+    end
+  end
+
+  private
+
+  def custom_field_keys
+    # Can be extended by other serializers
+    User.whitelisted_user_custom_fields(scope)
+  end
+end

--- a/app/serializers/user_with_custom_fields_serializer.rb
+++ b/app/serializers/user_with_custom_fields_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # A basic user serializer, with custom fields
-class UserCustomFieldsSerializer < BasicUserSerializer
+class UserWithCustomFieldsSerializer < BasicUserSerializer
   attributes :custom_fields
 
   def custom_fields


### PR DESCRIPTION
Add a plugin outlet after reviewable post user

Additionally adds custom field user serializer

Add a basic user serializer that includes custom fields.
Allows review queue serializer to include custom fields for its users