### PR TITLE
FEATURE: Plugin support for transpiling regular `.js` files

### DIFF
--- a/lib/discourse_js_processor.rb
+++ b/lib/discourse_js_processor.rb
@@ -4,6 +4,10 @@ require 'mini_racer'
 
 class DiscourseJsProcessor
 
+  def self.plugin_transpile_paths
+    @@plugin_transpile_paths ||= Set.new
+  end
+
   def self.call(input)
     root_path = input[:load_path] || ''
     logical_path = (input[:filename] || '').sub(root_path, '').gsub(/\.(js|es6).*$/, '').sub(/^\//, '')
@@ -55,6 +59,8 @@ class DiscourseJsProcessor
       auto-redirect
       embed-application
     ).any? { |f| relative_path == "#{js_root}/#{f}.js" }
+
+    return true if plugin_transpile_paths.any? { |prefix| relative_path.start_with?(prefix) }
 
     !!(relative_path =~ /^#{js_root}\/[^\/]+\// ||
       relative_path =~ /^#{test_root}\/[^\/]+\//)

--- a/lib/plugin/metadata.rb
+++ b/lib/plugin/metadata.rb
@@ -78,7 +78,7 @@ class Plugin::Metadata
     "discourse-internet-explorer"
   ])
 
-  FIELDS ||= [:name, :about, :version, :authors, :url, :required_version]
+  FIELDS ||= [:name, :about, :version, :authors, :url, :required_version, :transpile_js]
   attr_accessor(*FIELDS)
 
   def self.parse(text)


### PR DESCRIPTION
This adds support for a new piece of metadata to your plugin.rb
files. If you add:

```
transpile_js: true
```

Then Discourse will support transpilation of assets in your
`assets/javascripts` directory. Previously they had to be named
`.js.es6` but now regular `.js` will work.

Note this is opt-in because some plugins currently have `.js` files in
app/assets that are not meant to be transpiled.

Going forward all plugins should migrate to this setting as they are
comfortable able to do so.