### PR TITLE
FIX: ensures toolbar is updated on composer action change

### DIFF
--- a/app/assets/javascripts/discourse/components/d-editor.js
+++ b/app/assets/javascripts/discourse/components/d-editor.js
@@ -328,7 +328,7 @@ export default Component.extend({
     $(this.element.querySelector(".d-editor-preview")).off("click.preview");
   },
 
-  @discourseComputed
+  @discourseComputed("attrs.outletArgs.composer.action")
   toolbar() {
     const toolbar = new Toolbar(
       this.getProperties("site", "siteSettings", "showLink")

--- a/test/javascripts/components/d-editor-test.js
+++ b/test/javascripts/components/d-editor-test.js
@@ -584,7 +584,7 @@ testCase(`list button with line sequence`, async function(assert, textarea) {
   assert.equal(textarea.selectionEnd, 18);
 });
 
-componentTest("clicking the toggle-direction button toggles the direction", {
+componentTest("clicking the toggle-direction changes dir from ltr to rtl", {
   template: "{{d-editor value=value}}",
   beforeEach() {
     this.siteSettings.support_mixed_text_direction = true;
@@ -595,8 +595,21 @@ componentTest("clicking the toggle-direction button toggles the direction", {
     const textarea = find("textarea.d-editor-input");
     await click("button.toggle-direction");
     assert.equal(textarea.attr("dir"), "rtl");
+  }
+});
+
+componentTest("clicking the toggle-direction changes dir from ltr to rtl", {
+  template: "{{d-editor value=value}}",
+  beforeEach() {
+    this.siteSettings.support_mixed_text_direction = true;
+    this.siteSettings.default_locale = "en_US";
+  },
+
+  async test(assert) {
+    const textarea = find("textarea.d-editor-input");
+    textarea.attr("dir", "ltr");
     await click("button.toggle-direction");
-    assert.equal(textarea.attr("dir"), "ltr");
+    assert.equal(textarea.attr("dir"), "rtl");
   }
 });
 


### PR DESCRIPTION
This will allow for example to hide/show a toolbar button only when editing, or only for first post