### PR TITLE
FIX: Missing timezone guess on email session login

### DIFF
--- a/app/assets/javascripts/discourse/controllers/email-login.js
+++ b/app/assets/javascripts/discourse/controllers/email-login.js
@@ -23,7 +23,10 @@ export default Controller.extend({
 
   actions: {
     finishLogin() {
-      let data = { second_factor_method: this.secondFactorMethod };
+      let data = {
+        second_factor_method: this.secondFactorMethod,
+        timezone: moment.tz.guess()
+      };
       if (this.securityKeyCredential) {
         data.second_factor_token = this.securityKeyCredential;
       } else {

--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -368,6 +368,7 @@ class SessionController < ApplicationController
       elsif payload = login_error_check(user)
         return render json: payload
       else
+        user.update_timezone_if_missing(params[:timezone])
         log_on_user(user)
         return render json: success_json
       end

--- a/spec/requests/session_controller_spec.rb
+++ b/spec/requests/session_controller_spec.rb
@@ -252,6 +252,14 @@ RSpec.describe SessionController do
         end
       end
 
+      context "when timezone param is provided" do
+        it "sets the user_option timezone for the user" do
+          post "/session/email-login/#{email_token.token}.json", params: { timezone: "Australia/Melbourne" }
+          expect(response.status).to eq(200)
+          expect(user.reload.user_option.timezone).to eq("Australia/Melbourne")
+        end
+      end
+
       it "fails when user is suspended" do
         user.update!(
           suspended_till: 2.days.from_now,


### PR DESCRIPTION
Timezone is guessed by moment.js if unset upon a normal login, but was not when
logging in via an email link. This adds logic to update a guessed
timezone upon email login so timezones don't end up blank.