### PR TITLE
UX: Improve published page avatar resolution

### DIFF
--- a/app/views/published_pages/show.html.erb
+++ b/app/views/published_pages/show.html.erb
@@ -3,7 +3,7 @@
     <h1 class="published-page-title"><%= @topic.title %></h1>
 
     <div class="published-page-author">
-      <img src="<%= @topic.user.small_avatar_url %>" class="avatar">
+      <img width="45" height="45" src="<%= @topic.user.avatar_template.gsub('{size}', '90') %>" class="avatar">
       <div class="published-page-author-details">
         <div class="username"><%= @topic.user.username %></div>
         <div class="topic-created-at"><%= short_date(@topic.created_at) %></div>


### PR DESCRIPTION
The user avatar image on published pages was a bit too small for high-resolution displays. This change will make sure the avatar image size matches what we use in posts. I'm using a similar approach to what we see here: 
https://github.com/discourse/discourse/blob/d984848aa94971c8fcab10b43bd596107fdbe9c5/app/views/embed/topics.html.erb#L27



**BEFORE**
<img width="346" alt="before" src="https://user-images.githubusercontent.com/22733864/79027374-d6cb6a00-7b40-11ea-8ca4-a4e0803d53c3.png">

**AFTER**
<img width="326" alt="after" src="https://user-images.githubusercontent.com/22733864/79027375-d7fc9700-7b40-11ea-8dc6-f3f3b97f52fa.png">
