### PR TITLE
DEV: Fix all 'require-valid-alt-text' lints except in reused compoments

### DIFF
--- a/app/assets/javascripts/admin/templates/badges-index.hbs
+++ b/app/assets/javascripts/admin/templates/badges-index.hbs
@@ -1,6 +1,6 @@
 {{#d-section class="current-badges"}}
   <div class="badge-intro admin-intro">
-    <img src={{badgeIntroEmoji}} class="badge-intro-emoji">
+    <img src={{badgeIntroEmoji}} class="badge-intro-emoji" alt={{i18n 'admin.badges.badge_intro.emoji'}}>
     <div class="content-wrapper">
       <h1>{{i18n 'admin.badges.badge_intro.title'}}</h1>
       <div class="external-resources">

--- a/app/assets/javascripts/admin/templates/customize-themes-index.hbs
+++ b/app/assets/javascripts/admin/templates/customize-themes-index.hbs
@@ -1,5 +1,5 @@
 <div class="themes-intro admin-intro">
-  <img src={{womanArtistEmojiURL}}>
+  <img src={{womanArtistEmojiURL}} alt={{i18n "admin.customize.theme.themes_intro_emoji"}}>
   <div class="content-wrapper">
     <h1>{{i18n "admin.customize.theme.themes_intro"}}</h1>
     <div class="create-actions">

--- a/app/assets/javascripts/admin/templates/emojis.hbs
+++ b/app/assets/javascripts/admin/templates/emojis.hbs
@@ -31,7 +31,7 @@
       <tbody>
         {{#each sortedEmojis as |e|}}
           <tr>
-            <th><img class="emoji emoji-custom" src={{e.url}} title={{e.name}}></th>
+            <th><img class="emoji emoji-custom" src={{e.url}} title={{e.name}} alt={{i18n "admin.emoji.alt"}}></th>
             <th>:{{e.name}}:</th>
             <th>{{e.group}}</th>
             <th>

--- a/app/assets/javascripts/discourse/templates/components/group-flair-inputs.hbs
+++ b/app/assets/javascripts/discourse/templates/components/group-flair-inputs.hbs
@@ -35,13 +35,13 @@
 
   <div class="avatar-flair-preview">
     <div class="avatar-wrapper">
-      <img width="45" height="45" src={{demoAvatarUrl}} class="avatar actor">
+      <img width="45" height="45" src={{demoAvatarUrl}} class="avatar actor" alt="" role="presentation">
     </div>
 
     {{#if flairPreviewImage}}
       <div class="avatar-flair demo {{flairPreviewClasses}}" style={{flairPreviewStyle}}></div>
     {{else}}
-      <div class="avatar-flair demo {{flairPreviewClasses}}" style={{flairPreviewStyle}}>
+      <div class="avatar-flair demo {{flairPreviewClasses}}" style={{flairPreviewStyle}} role="presentation">
         {{d-icon flairPreviewIconUrl}}
       </div>
     {{/if}}

--- a/app/assets/javascripts/discourse/templates/email-login.hbs
+++ b/app/assets/javascripts/discourse/templates/email-login.hbs
@@ -1,6 +1,6 @@
 <div class="container email-login clearfix">
   <div class="pull-left col-image">
-    <img src={{lockImageUrl}} class="password-reset-img">
+    <img src={{lockImageUrl}} class="password-reset-img" alt={{i18n "email_login.emoji"}}>
   </div>
 
   <div class="pull-left col-form">

--- a/app/assets/javascripts/discourse/templates/invites/show.hbs
+++ b/app/assets/javascripts/discourse/templates/invites/show.hbs
@@ -3,7 +3,7 @@
 
   <div class="two-col">
     <div class="col-image">
-      <img src={{inviteImageUrl}}>
+      <img src={{inviteImageUrl}} alt={{i18n 'invites.emoji'}}>
     </div>
 
     <div class="col-form">

--- a/app/assets/javascripts/discourse/templates/password-reset.hbs
+++ b/app/assets/javascripts/discourse/templates/password-reset.hbs
@@ -1,6 +1,6 @@
 <div class="container password-reset clearfix">
   <div class="pull-left col-image">
-    <img src={{lockImageUrl}} class="password-reset-img">
+    <img src={{lockImageUrl}} class="password-reset-img" alt={{i18n "user.change_password.emoji"}}>
   </div>
 
   <div class="pull-left col-form">

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -983,6 +983,7 @@ en:
         success: "(email sent)"
         in_progress: "(sending email)"
         error: "(error)"
+        emoji: "lock emoji"
         action: "Send Password Reset Email"
         set_password: "Set Password"
         choose_new: "Choose a new password"
@@ -1504,6 +1505,7 @@ en:
     email_login:
       link_label: "Email me a login link"
       button_label: "with email"
+      emoji: "lock emoji"
       complete_username: "If an account matches the username <b>%{username}</b>, you should receive an email with a login link shortly."
       complete_email: "If an account matches <b>%{email}</b>, you should receive an email with a login link shortly."
       complete_username_found: "We found an account that matches the username <b>%{username}</b>, you should receive an email with a login link shortly."
@@ -1584,6 +1586,7 @@ en:
         backup_code: "Use a backup code instead"
     invites:
       accept_title: "Invitation"
+      emoji: "envelope emoji"
       welcome_to: "Welcome to %{site_name}!"
       invited_by: "You were invited by:"
       social_login_available: "You'll also be able to sign in with any social login using that email."
@@ -3719,6 +3722,7 @@ en:
           theme_name: "Theme name"
           component_name: "Component name"
           themes_intro: "Select an existing theme or install a new one to get started"
+          themes_intro_emoji: "woman artist emoji"
           beginners_guide_title: "Beginner’s guide to using Discourse Themes"
           developers_guide_title: "Developer’s guide to Discourse Themes"
           browse_themes: "Browse community themes"
@@ -4580,6 +4584,7 @@ en:
             with_time: <span class="username">%{username}</span> at <span class="time">%{time}</span>
         badge_intro:
           title: "Select an existing badge or create a new one to get started"
+          emoji: "woman student emoji"
           what_are_badges_title: "What are badges?"
           badge_query_examples_title: "Badge query examples"
         mass_award:
@@ -4599,6 +4604,7 @@ en:
         name: "Name"
         group: "Group"
         image: "Image"
+        alt: "custom emoji preview"
         delete_confirm: "Are you sure you want to delete the :%{name}: emoji?"
 
       embedding:


### PR DESCRIPTION
Three violations require parameters from the caller to generate valid alt text.