### PR TITLE
FIX: add short_path to upload_serializer

### DIFF
--- a/app/serializers/upload_serializer.rb
+++ b/app/serializers/upload_serializer.rb
@@ -11,6 +11,7 @@ class UploadSerializer < ApplicationSerializer
              :thumbnail_height,
              :extension,
              :short_url,
+             :short_path,
              :retain_hours,
              :human_filesize
 

--- a/spec/serializers/upload_serializer_spec.rb
+++ b/spec/serializers/upload_serializer_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe UploadSerializer do
     expect(json_data['height']).to eql upload.height
     expect(json_data['thumbnail_width']).to eql upload.thumbnail_width
     expect(json_data['thumbnail_height']).to eql upload.thumbnail_height
+    expect(json_data['short_path']).to eql upload.short_path
   end
 
   context "when the upload is secure" do


### PR DESCRIPTION
What problem am I trying to solve?

When an encrypted message is crafted and the image is added - discourse needs a hard refresh to display that image.

What is happening?

Everything starts here - when the upload is finished we add serialized object to the cache https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/components/composer-editor.js#L748:L757

Then, `discourse-encrypt` is trying to get an image from the cache and use `short_path` property
https://github.com/discourse/discourse-encrypt/blob/master/assets/javascripts/discourse/initializers/hook-decrypt-post.js.es6#L142:L143

Why is it working after a hard refresh?

After refresh, we populate cache once again using that function: https://github.com/discourse/discourse/blob/master/app/assets/javascripts/pretty-text/upload-short-url.js#L11:L17

And lookup_urls method from backend is returning `short_path`
https://github.com/discourse/discourse/blob/master/app/controllers/uploads_controller.rb#L55:L64

TL;DR We should expose short path in upload serializer. I ensured that this serializer is used only when attachments are uploaded so it should not affect performance.