### PR TITLE
FIX: Toggle bookmark for topic was not working after cancelling the modal

### DIFF
--- a/app/assets/javascripts/discourse/controllers/bookmark.js
+++ b/app/assets/javascripts/discourse/controllers/bookmark.js
@@ -78,7 +78,7 @@ export default Controller.extend(ModalFunctionality, {
       closeWithoutSaving: false,
       isSavingBookmarkManually: false,
       customReminderDate: null,
-      customReminderTime: null,
+      customReminderTime: this.defaultCustomReminderTime(),
       lastCustomReminderDate: null,
       lastCustomReminderTime: null,
       userTimezone: this.currentUser.resolvedTimezone()
@@ -270,6 +270,10 @@ export default Controller.extend(ModalFunctionality, {
     return moment.tz(date + " " + time, this.userTimezone);
   },
 
+  defaultCustomReminderTime() {
+    return `0${START_OF_DAY_HOUR}:00`;
+  },
+
   reminderAt() {
     if (!this.selectedReminderType) {
       return;
@@ -295,7 +299,7 @@ export default Controller.extend(ModalFunctionality, {
       case REMINDER_TYPES.CUSTOM:
         this.set(
           "customReminderTime",
-          this.customReminderTime || `0${START_OF_DAY_HOUR}:00`
+          this.customReminderTime || this.defaultCustomReminderTime()
         );
         const customDateTime = this.parseCustomDateTime(
           this.customReminderDate,

--- a/app/assets/javascripts/discourse/models/post.js
+++ b/app/assets/javascripts/discourse/models/post.js
@@ -349,8 +349,8 @@ const Post = RestModel.extend({
         controller.setProperties({
           onCloseWithoutSaving: () => {
             this.toggleProperty("bookmarked_with_reminder");
+            resolve({ closedWithoutSaving: true });
             this.appEvents.trigger("post-stream:refresh", { id: this.id });
-            resolve();
           },
           afterSave: (reminderAtISO, reminderType) => {
             this.setProperties({
@@ -358,8 +358,8 @@ const Post = RestModel.extend({
               bookmark_reminder_at: reminderAtISO,
               bookmark_reminder_type: reminderType
             });
+            resolve({ closedWithoutSaving: false });
             this.appEvents.trigger("post-stream:refresh", { id: this.id });
-            resolve();
           }
         });
       });

--- a/app/assets/javascripts/discourse/models/topic.js
+++ b/app/assets/javascripts/discourse/models/topic.js
@@ -438,9 +438,13 @@ const Topic = RestModel.extend({
       const toggleBookmarkOnServer = () => {
         if (bookmark) {
           if (this.siteSettings.enable_bookmarks_with_reminders) {
-            return firstPost.toggleBookmarkWithReminder().then(() => {
+            return firstPost.toggleBookmarkWithReminder().then(response => {
               this.set("bookmarking", false);
-              return this.afterTopicBookmarked(firstPost);
+              if (response.closedWithoutSaving) {
+                this.set("bookmarked", false);
+              } else {
+                return this.afterTopicBookmarked(firstPost);
+              }
             });
           } else {
             return ajax(`/t/${this.id}/bookmark`, { type: "PUT" })


### PR DESCRIPTION
* When bookmarking the topic, if the user cancelled the bookmark modal the bookmark topic button no longer worked because we did not reset the "bookmarked" property
* Prefill the custom reminder time to `8:00am`