### PR TITLE
FIX: Extend bookmark cutoff time for "Later Today" to 5pm

### DIFF
--- a/app/assets/javascripts/discourse/controllers/bookmark.js
+++ b/app/assets/javascripts/discourse/controllers/bookmark.js
@@ -19,6 +19,7 @@ import KeyboardShortcuts from "discourse/lib/keyboard-shortcuts";
 const GLOBAL_SHORTCUTS_TO_PAUSE = ["c", "r", "l", "d", "t"];
 const START_OF_DAY_HOUR = 8;
 const LATER_TODAY_CUTOFF_HOUR = 17;
+const LATER_TODAY_MAX_HOUR = 18;
 const REMINDER_TYPES = {
   AT_DESKTOP: "at_desktop",
   LATER_TODAY: "later_today",
@@ -172,7 +173,7 @@ export default Controller.extend(ModalFunctionality, {
     let later = this.laterToday();
     return (
       !later.isSame(this.tomorrow(), "date") &&
-      later.hour() <= LATER_TODAY_CUTOFF_HOUR
+      this.now().hour() < LATER_TODAY_CUTOFF_HOUR
     );
   },
 
@@ -336,8 +337,11 @@ export default Controller.extend(ModalFunctionality, {
 
   laterToday() {
     let later = this.now().add(3, "hours");
+    if (later.hour() > LATER_TODAY_MAX_HOUR) {
+      return later.hour(LATER_TODAY_MAX_HOUR).startOf("hour");
+    }
     return later.minutes() < 30
-      ? later.minutes(30)
+      ? later.startOf("hour")
       : later.add(30, "minutes").startOf("hour");
   },
 

--- a/app/assets/javascripts/discourse/controllers/bookmark.js
+++ b/app/assets/javascripts/discourse/controllers/bookmark.js
@@ -337,7 +337,7 @@ export default Controller.extend(ModalFunctionality, {
 
   laterToday() {
     let later = this.now().add(3, "hours");
-    if (later.hour() > LATER_TODAY_MAX_HOUR) {
+    if (later.hour() >= LATER_TODAY_MAX_HOUR) {
       return later.hour(LATER_TODAY_MAX_HOUR).startOf("hour");
     }
     return later.minutes() < 30

--- a/test/javascripts/controllers/bookmark-test.js
+++ b/test/javascripts/controllers/bookmark-test.js
@@ -148,7 +148,7 @@ QUnit.test(
 );
 
 QUnit.test(
-  "laterToday is capped to 6pm. later today at 3pm = 6pm, 4pm = 6pm, 4:59pm = 6pm",
+  "laterToday is capped to 6pm. later today at 3pm = 6pm, 3:30pm = 6pm, 4pm = 6pm, 4:59pm = 6pm",
   function(assert) {
     mockMomentTz("2019-12-11T15:00:00");
 
@@ -156,6 +156,14 @@ QUnit.test(
       BookmarkController.laterToday().format("YYYY-MM-DD HH:mm:ss"),
       "2019-12-11 18:00:00",
       "3pm should max to 6pm"
+    );
+
+    mockMomentTz("2019-12-11T15:31:00");
+
+    assert.equal(
+      BookmarkController.laterToday().format("YYYY-MM-DD HH:mm:ss"),
+      "2019-12-11 18:00:00",
+      "3:30pm should max to 6pm"
     );
 
     mockMomentTz("2019-12-11T16:00:00");

--- a/test/javascripts/controllers/bookmark-test.js
+++ b/test/javascripts/controllers/bookmark-test.js
@@ -1,10 +1,12 @@
 import { logIn } from "helpers/qunit-helpers";
 import User from "discourse/models/user";
+import KeyboardShortcutInitializer from "discourse/initializers/keyboard-shortcuts";
 let BookmarkController;
 
 moduleFor("controller:bookmark", {
   beforeEach() {
     logIn();
+    KeyboardShortcutInitializer.initialize(Discourse.__container__);
     BookmarkController = this.subject({ currentUser: User.current() });
     BookmarkController.onShow();
   },
@@ -27,8 +29,18 @@ QUnit.test("showLaterToday when later today is tomorrow do not show", function(
   assert.equal(BookmarkController.get("showLaterToday"), false);
 });
 
-QUnit.test("showLaterToday when later today is after 5pm", function(assert) {
-  mockMomentTz("2019-12-11T15:00:00");
+QUnit.test(
+  "showLaterToday when later today is after 5pm but before 6pm",
+  function(assert) {
+    mockMomentTz("2019-12-11T15:00:00");
+    assert.equal(BookmarkController.get("showLaterToday"), true);
+  }
+);
+
+QUnit.test("showLaterToday when now is after the cutoff time (5pm)", function(
+  assert
+) {
+  mockMomentTz("2019-12-11T17:00:00");
   assert.equal(BookmarkController.get("showLaterToday"), false);
 });
 
@@ -112,13 +124,13 @@ QUnit.test(
 );
 
 QUnit.test(
-  "laterToday gets 3 hours from now and if before half-past, it sets the time to half-past",
+  "laterToday gets 3 hours from now and if before half-past, it rounds down",
   function(assert) {
     mockMomentTz("2019-12-11T08:13:00");
 
     assert.equal(
       BookmarkController.laterToday().format("YYYY-MM-DD HH:mm:ss"),
-      "2019-12-11 11:30:00"
+      "2019-12-11 11:00:00"
     );
   }
 );
@@ -134,6 +146,45 @@ QUnit.test(
     );
   }
 );
+
+QUnit.test(
+  "laterToday is capped to 6pm. later today at 3pm = 6pm, 4pm = 6pm, 4:59pm = 6pm",
+  function(assert) {
+    mockMomentTz("2019-12-11T15:00:00");
+
+    assert.equal(
+      BookmarkController.laterToday().format("YYYY-MM-DD HH:mm:ss"),
+      "2019-12-11 18:00:00",
+      "3pm should max to 6pm"
+    );
+
+    mockMomentTz("2019-12-11T16:00:00");
+
+    assert.equal(
+      BookmarkController.laterToday().format("YYYY-MM-DD HH:mm:ss"),
+      "2019-12-11 18:00:00",
+      "4pm should max to 6pm"
+    );
+
+    mockMomentTz("2019-12-11T16:59:00");
+
+    assert.equal(
+      BookmarkController.laterToday().format("YYYY-MM-DD HH:mm:ss"),
+      "2019-12-11 18:00:00",
+      "4:59pm should max to 6pm"
+    );
+  }
+);
+
+QUnit.test("showLaterToday returns false if >= 5PM", function(assert) {
+  mockMomentTz("2019-12-11T17:00:01");
+  assert.equal(BookmarkController.showLaterToday, false);
+});
+
+QUnit.test("showLaterToday returns false if >= 5PM", function(assert) {
+  mockMomentTz("2019-12-11T17:00:01");
+  assert.equal(BookmarkController.showLaterToday, false);
+});
 
 QUnit.test(
   "reminderAt - custom - defaults to 8:00am if the time is not selected",


### PR DESCRIPTION
As per discussions at https://meta.discourse.org/t/improved-bookmarks-with-reminders/144542/88?u=mjrbrennan

* users can now use the Later Today option for bookmark reminders up until 5PM
* the time for later today maxes out at 6pm, so any time it is used after 3pm it is maxed to 6pm
* round to hour instead of half-hour for Later Today as well