### PR TITLE
DEV: Find existing themes consistently in themes_install_task

### DIFF
--- a/app/services/themes_install_task.rb
+++ b/app/services/themes_install_task.rb
@@ -40,8 +40,15 @@ class ThemesInstallTask
     end
   end
 
+  def repo_name
+    @url.gsub(Regexp.union('git@github.com:', 'https://github.com/', '.git'), '')
+  end
+
   def theme_exists?
-    @remote_theme = RemoteTheme.find_by(remote_url: @url, branch: @options.fetch(:branch, nil))
+    @remote_theme = RemoteTheme
+      .where("remote_url like ?", "%#{repo_name}%")
+      .where(branch: @options.fetch(:branch, nil))
+      .first
     @theme = @remote_theme&.theme
     @theme.present?
   end

--- a/spec/services/themes_spec.rb
+++ b/spec/services/themes_spec.rb
@@ -141,4 +141,23 @@ describe ThemesInstallTask do
       end
     end
   end
+  describe '#theme_exists?' do
+    it 'can use https or ssh and find the same repo' do
+      remote_theme = RemoteTheme.create!(
+        remote_url: "https://github.com/org/testtheme.git",
+        local_version: "a2ec030e551fc8d8579790e1954876fe769fe40a",
+        remote_version: "21122230dbfed804067849393c3332083ddd0c07",
+        commits_behind: 2
+      )
+      Fabricate(:theme, remote_theme: remote_theme)
+
+      # https
+      installer = ThemesInstallTask.new({ "url": "https://github.com/org/testtheme" })
+      expect(installer.theme_exists?).to eq(true)
+
+      # ssh
+      installer = ThemesInstallTask.new({ "url": "git@github.com:org/testtheme.git" })
+      expect(installer.theme_exists?).to eq(true)
+    end
+  end
 end


### PR DESCRIPTION
I noticed that using the theme install rake task with different protocals will duplicated themes/components.

The existing remote_theme is now found using just the org/repo-name like `discourse/discourse-placeholder-theme-component`, the the https or git@github stripped out.