### PR TITLE
FEATURE: Decorate topic-level bookmark button with reminder time

### DIFF
--- a/app/assets/javascripts/discourse/controllers/bookmark.js
+++ b/app/assets/javascripts/discourse/controllers/bookmark.js
@@ -205,7 +205,7 @@ export default Controller.extend(ModalFunctionality, {
   },
 
   @discourseComputed()
-  textMonthFormatted() {
+  nextMonthFormatted() {
     return this.nextMonth().format(I18n.t("dates.long_no_year"));
   },
 

--- a/app/assets/javascripts/discourse/controllers/bookmark.js
+++ b/app/assets/javascripts/discourse/controllers/bookmark.js
@@ -7,6 +7,7 @@ import discourseComputed from "discourse-common/utils/decorators";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { ajax } from "discourse/lib/ajax";
 import KeyboardShortcuts from "discourse/lib/keyboard-shortcuts";
+import { REMINDER_TYPES } from "discourse/lib/bookmark";
 
 // global shortcuts that interfere with these modal shortcuts, they are rebound when the
 // modal is closed
@@ -20,19 +21,6 @@ const GLOBAL_SHORTCUTS_TO_PAUSE = ["c", "r", "l", "d", "t"];
 const START_OF_DAY_HOUR = 8;
 const LATER_TODAY_CUTOFF_HOUR = 17;
 const LATER_TODAY_MAX_HOUR = 18;
-const REMINDER_TYPES = {
-  AT_DESKTOP: "at_desktop",
-  LATER_TODAY: "later_today",
-  NEXT_BUSINESS_DAY: "next_business_day",
-  TOMORROW: "tomorrow",
-  NEXT_WEEK: "next_week",
-  NEXT_MONTH: "next_month",
-  CUSTOM: "custom",
-  LAST_CUSTOM: "last_custom",
-  NONE: "none",
-  START_OF_NEXT_BUSINESS_WEEK: "start_of_next_business_week",
-  LATER_THIS_WEEK: "later_this_week"
-};
 
 const BOOKMARK_BINDINGS = {
   enter: { handler: "saveAndClose" },
@@ -217,7 +205,7 @@ export default Controller.extend(ModalFunctionality, {
   },
 
   @discourseComputed()
-  nextMonthFormatted() {
+  textMonthFormatted() {
     return this.nextMonth().format(I18n.t("dates.long_no_year"));
   },
 

--- a/app/assets/javascripts/discourse/lib/bookmark.js
+++ b/app/assets/javascripts/discourse/lib/bookmark.js
@@ -1,5 +1,5 @@
 export function formattedReminderTime(reminderAt, timezone) {
-  let reminderAtDate = moment(reminderAt).tz(timezone);
+  let reminderAtDate = moment.tz(reminderAt, timezone);
   let formatted = reminderAtDate.format(I18n.t("dates.time"));
   let now = moment.tz(timezone);
   let tomorrow = moment(now).add(1, "day");

--- a/app/assets/javascripts/discourse/lib/bookmark.js
+++ b/app/assets/javascripts/discourse/lib/bookmark.js
@@ -1,0 +1,31 @@
+export function formattedReminderTime(reminderAt, timezone) {
+  let reminderAtDate = moment(reminderAt).tz(timezone);
+  let formatted = reminderAtDate.format(I18n.t("dates.time"));
+  let now = moment.tz(timezone);
+  let tomorrow = moment(now).add(1, "day");
+
+  if (reminderAtDate.isSame(tomorrow, "date")) {
+    return I18n.t("bookmarks.reminders.tomorrow_with_time", {
+      time: formatted
+    });
+  } else if (reminderAtDate.isSame(now, "date")) {
+    return I18n.t("bookmarks.reminders.today_with_time", { time: formatted });
+  }
+  return I18n.t("bookmarks.reminders.at_time", {
+    date_time: reminderAtDate.format(I18n.t("dates.long_with_year"))
+  });
+}
+
+export const REMINDER_TYPES = {
+  AT_DESKTOP: "at_desktop",
+  LATER_TODAY: "later_today",
+  NEXT_BUSINESS_DAY: "next_business_day",
+  TOMORROW: "tomorrow",
+  NEXT_WEEK: "next_week",
+  NEXT_MONTH: "next_month",
+  CUSTOM: "custom",
+  LAST_CUSTOM: "last_custom",
+  NONE: "none",
+  START_OF_NEXT_BUSINESS_WEEK: "start_of_next_business_week",
+  LATER_THIS_WEEK: "later_this_week"
+};

--- a/app/assets/javascripts/discourse/models/topic.js
+++ b/app/assets/javascripts/discourse/models/topic.js
@@ -401,6 +401,7 @@ const Topic = RestModel.extend({
     if (firstPost) {
       firstPost.set("bookmarked", true);
       if (this.siteSettings.enable_bookmarks_with_reminders) {
+        this.set("bookmark_reminder_at", firstPost.bookmark_reminder_at);
         firstPost.set("bookmarked_with_reminder", true);
       }
       return [firstPost.id];
@@ -440,7 +441,7 @@ const Topic = RestModel.extend({
           if (this.siteSettings.enable_bookmarks_with_reminders) {
             return firstPost.toggleBookmarkWithReminder().then(response => {
               this.set("bookmarking", false);
-              if (response.closedWithoutSaving) {
+              if (response && response.closedWithoutSaving) {
                 this.set("bookmarked", false);
               } else {
                 return this.afterTopicBookmarked(firstPost);
@@ -459,6 +460,7 @@ const Topic = RestModel.extend({
           return ajax(`/t/${this.id}/remove_bookmarks`, { type: "PUT" })
             .then(() => {
               this.toggleProperty("bookmarked");
+              this.set("bookmark_reminder_at", null);
               if (posts) {
                 const updated = [];
                 posts.forEach(post => {
@@ -474,6 +476,7 @@ const Topic = RestModel.extend({
                     updated.push(post.id);
                   }
                 });
+                firstPost.set("bookmarked_with_reminder", false);
                 return updated;
               }
             })

--- a/app/assets/javascripts/discourse/widgets/post-menu.js
+++ b/app/assets/javascripts/discourse/widgets/post-menu.js
@@ -5,6 +5,7 @@ import { h } from "virtual-dom";
 import showModal from "discourse/lib/show-modal";
 import { Promise } from "rsvp";
 import ENV from "discourse-common/config/environment";
+import { formattedReminderTime } from "discourse/lib/bookmark";
 
 const LIKE_ACTION = 2;
 const VIBRATE_DURATION = 5;
@@ -314,12 +315,13 @@ registerButton("bookmarkWithReminder", (attrs, state, siteSettings) => {
     classNames.push("bookmarked");
 
     if (attrs.bookmarkReminderAt) {
-      let reminderAtDate = moment(attrs.bookmarkReminderAt).tz(
+      let formattedReminder = formattedReminderTime(
+        attrs.bookmarkReminderAt,
         Discourse.currentUser.resolvedTimezone()
       );
       title = "bookmarks.created_with_reminder";
       titleOptions = {
-        date: reminderAtDate.format(I18n.t("dates.long_with_year"))
+        date: formattedReminder
       };
     } else if (attrs.bookmarkReminderType === "at_desktop") {
       title = "bookmarks.created_with_at_desktop_reminder";

--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -454,7 +454,8 @@ nav.post-controls {
       color: $tertiary;
     }
   }
-  .bookmark.bookmarked .d-icon-bookmark {
+  .bookmark.bookmarked .d-icon-bookmark,
+  .bookmark.bookmarked .d-icon-discourse-bookmark-clock {
     color: $tertiary;
   }
   .feature-on-profile.featured-on-profile .d-icon-id-card {

--- a/app/assets/stylesheets/mobile/topic-post.scss
+++ b/app/assets/stylesheets/mobile/topic-post.scss
@@ -237,7 +237,8 @@ a.reply-to-tab {
 #topic-footer-buttons {
   @include clearfix;
   padding: 20px 0 0 0;
-  .d-icon-bookmark.bookmarked {
+  .d-icon-bookmark.bookmarked,
+  .d-icon-discourse-bookmark-clock.bookmarked {
     color: $tertiary;
   }
   .combobox {

--- a/app/serializers/topic_view_serializer.rb
+++ b/app/serializers/topic_view_serializer.rb
@@ -61,6 +61,7 @@ class TopicViewSerializer < ApplicationSerializer
     :is_warning,
     :chunk_size,
     :bookmarked,
+    :bookmark_reminder_at,
     :message_archived,
     :topic_timer,
     :private_topic_timer,
@@ -190,6 +191,14 @@ class TopicViewSerializer < ApplicationSerializer
     else
       object.topic_user&.bookmarked
     end
+  end
+
+  def include_bookmark_reminder_at?
+    SiteSetting.enable_bookmarks_with_reminders? && bookmarked
+  end
+
+  def bookmark_reminder_at
+    object.first_post_bookmark_reminder_at
   end
 
   def topic_timer

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -302,11 +302,13 @@ en:
       help:
         bookmark: "Click to bookmark the first post on this topic"
         unbookmark: "Click to remove all bookmarks in this topic"
+        unbookmark_with_reminder: "Click to remove all bookmarks and reminders in this topic. You have a reminder set %{reminder_at} for this topic."
+
 
     bookmarks:
       created: "you've bookmarked this post"
       not_bookmarked: "bookmark this post"
-      created_with_reminder: "you've bookmarked this post with a reminder at %{date}"
+      created_with_reminder: "you've bookmarked this post with a reminder %{date}"
       created_with_at_desktop_reminder: "you've bookmarked this post and will be reminded next time you are at your desktop"
       remove: "Remove Bookmark"
       confirm_clear: "Are you sure you want to clear all your bookmarks from this topic?"
@@ -326,6 +328,9 @@ en:
         custom: "Custom date and time"
         last_custom: "Last"
         none: "No reminder needed"
+        today_with_time: "today at %{time}"
+        tomorrow_with_time: "tomorrow at %{time}"
+        at_time: "at %{date_time}"
 
     drafts:
       resume: "Resume"

--- a/lib/topic_view.rb
+++ b/lib/topic_view.rb
@@ -354,6 +354,10 @@ class TopicView
     @topic.bookmarks.exists?(user_id: @user.id)
   end
 
+  def first_post_bookmark_reminder_at
+    @topic.first_post.bookmarks.where(user: @user).pluck_first(:reminder_at)
+  end
+
   MAX_PARTICIPANTS = 24
 
   def post_counts_by_user

--- a/test/javascripts/lib/bookmark-test.js
+++ b/test/javascripts/lib/bookmark-test.js
@@ -1,0 +1,43 @@
+const timezone = "Australia/Brisbane";
+import { formattedReminderTime } from "discourse/lib/bookmark";
+
+QUnit.module("lib:bookmark", {
+  beforeEach() {
+    // set the current now time for all tests
+    let now = moment.tz("2020-04-11T08:00:00", timezone);
+    sandbox.useFakeTimers(now.valueOf());
+  }
+});
+
+QUnit.test(
+  "formattedReminderTime works when the reminder time is tomorrow",
+  assert => {
+    let reminderAt = "2020-04-12T09:45:00";
+    assert.equal(
+      formattedReminderTime(reminderAt, timezone),
+      "tomorrow at 9:45 am"
+    );
+  }
+);
+
+QUnit.test(
+  "formattedReminderTime works when the reminder time is today",
+  assert => {
+    let reminderAt = "2020-04-11T09:45:00";
+    assert.equal(
+      formattedReminderTime(reminderAt, timezone),
+      "today at 9:45 am"
+    );
+  }
+);
+
+QUnit.test(
+  "formattedReminderTime works when the reminder time is in the future",
+  assert => {
+    let reminderAt = "2020-04-15T09:45:00";
+    assert.equal(
+      formattedReminderTime(reminderAt, timezone),
+      "at Apr 15, 2020 9:45 am"
+    );
+  }
+);

--- a/test/javascripts/lib/bookmark-test.js
+++ b/test/javascripts/lib/bookmark-test.js
@@ -12,9 +12,12 @@ QUnit.test(
   "formattedReminderTime works when the reminder time is tomorrow",
   assert => {
     let reminderAt = "2020-04-12T09:45:00";
+    let reminderAtDate = moment(reminderAt)
+      .tz("Australia/Brisbane")
+      .format("H:mm a");
     assert.equal(
       formattedReminderTime(reminderAt, "Australia/Brisbane"),
-      "tomorrow at 9:45 am"
+      "tomorrow at " + reminderAtDate
     );
   }
 );
@@ -23,9 +26,12 @@ QUnit.test(
   "formattedReminderTime works when the reminder time is today",
   assert => {
     let reminderAt = "2020-04-11T09:45:00";
+    let reminderAtDate = moment(reminderAt)
+      .tz("Australia/Brisbane")
+      .format("H:mm a");
     assert.equal(
       formattedReminderTime(reminderAt, "Australia/Brisbane"),
-      "today at 9:45 am"
+      "today at " + reminderAtDate
     );
   }
 );
@@ -34,9 +40,12 @@ QUnit.test(
   "formattedReminderTime works when the reminder time is in the future",
   assert => {
     let reminderAt = "2020-04-15T09:45:00";
+    let reminderAtDate = moment(reminderAt)
+      .tz("Australia/Brisbane")
+      .format("H:mm a");
     assert.equal(
       formattedReminderTime(reminderAt, "Australia/Brisbane"),
-      "at Apr 15, 2020 9:45 am"
+      "at Apr 15, 2020 " + reminderAtDate
     );
   }
 );

--- a/test/javascripts/lib/bookmark-test.js
+++ b/test/javascripts/lib/bookmark-test.js
@@ -3,7 +3,7 @@ import { formattedReminderTime } from "discourse/lib/bookmark";
 QUnit.module("lib:bookmark", {
   beforeEach() {
     // set the current now time for all tests
-    let now = moment.tz("2020-04-11T08:00:00", "Australia/Brisbane");
+    let now = moment.tz("2020-04-11 08:00:00", "Australia/Brisbane");
     sandbox.useFakeTimers(now.valueOf());
   }
 });
@@ -11,9 +11,9 @@ QUnit.module("lib:bookmark", {
 QUnit.test(
   "formattedReminderTime works when the reminder time is tomorrow",
   assert => {
-    let reminderAt = "2020-04-12T09:45:00";
-    let reminderAtDate = moment(reminderAt)
-      .tz("Australia/Brisbane")
+    let reminderAt = "2020-04-12 09:45:00";
+    let reminderAtDate = moment
+      .tz(reminderAt, "Australia/Brisbane")
       .format("H:mm a");
     assert.equal(
       formattedReminderTime(reminderAt, "Australia/Brisbane"),
@@ -25,9 +25,9 @@ QUnit.test(
 QUnit.test(
   "formattedReminderTime works when the reminder time is today",
   assert => {
-    let reminderAt = "2020-04-11T09:45:00";
-    let reminderAtDate = moment(reminderAt)
-      .tz("Australia/Brisbane")
+    let reminderAt = "2020-04-11 09:45:00";
+    let reminderAtDate = moment
+      .tz(reminderAt, "Australia/Brisbane")
       .format("H:mm a");
     assert.equal(
       formattedReminderTime(reminderAt, "Australia/Brisbane"),
@@ -39,9 +39,9 @@ QUnit.test(
 QUnit.test(
   "formattedReminderTime works when the reminder time is in the future",
   assert => {
-    let reminderAt = "2020-04-15T09:45:00";
-    let reminderAtDate = moment(reminderAt)
-      .tz("Australia/Brisbane")
+    let reminderAt = "2020-04-15 09:45:00";
+    let reminderAtDate = moment
+      .tz(reminderAt, "Australia/Brisbane")
       .format("H:mm a");
     assert.equal(
       formattedReminderTime(reminderAt, "Australia/Brisbane"),

--- a/test/javascripts/lib/bookmark-test.js
+++ b/test/javascripts/lib/bookmark-test.js
@@ -1,10 +1,9 @@
-const timezone = "Australia/Brisbane";
 import { formattedReminderTime } from "discourse/lib/bookmark";
 
 QUnit.module("lib:bookmark", {
   beforeEach() {
     // set the current now time for all tests
-    let now = moment.tz("2020-04-11T08:00:00", timezone);
+    let now = moment.tz("2020-04-11T08:00:00", "Australia/Brisbane");
     sandbox.useFakeTimers(now.valueOf());
   }
 });
@@ -14,7 +13,7 @@ QUnit.test(
   assert => {
     let reminderAt = "2020-04-12T09:45:00";
     assert.equal(
-      formattedReminderTime(reminderAt, timezone),
+      formattedReminderTime(reminderAt, "Australia/Brisbane"),
       "tomorrow at 9:45 am"
     );
   }
@@ -25,7 +24,7 @@ QUnit.test(
   assert => {
     let reminderAt = "2020-04-11T09:45:00";
     assert.equal(
-      formattedReminderTime(reminderAt, timezone),
+      formattedReminderTime(reminderAt, "Australia/Brisbane"),
       "today at 9:45 am"
     );
   }
@@ -36,7 +35,7 @@ QUnit.test(
   assert => {
     let reminderAt = "2020-04-15T09:45:00";
     assert.equal(
-      formattedReminderTime(reminderAt, timezone),
+      formattedReminderTime(reminderAt, "Australia/Brisbane"),
       "at Apr 15, 2020 9:45 am"
     );
   }


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/920448/79300126-2cc95480-7f29-11ea-84da-7cfd5dc2e7d1.png)

* Show the correct bookmark with clock icon when topic-level bookmark reminder time is set and show the time of the reminder in the title on hover.
* Add a new bookmark lib and reminder time formatting function to show time with today/tomorrow shorthand for readability. E.g. tomorrow at 8:00am instead of Apr 16 2020 at 8:00am. This only applies to today + tomorrow, future dates are still treated the same.