### PR TITLE
FIX: Reopen sidekiq log files after rotation

### DIFF
--- a/config/unicorn.conf.rb
+++ b/config/unicorn.conf.rb
@@ -95,6 +95,13 @@ before_fork do |server, worker|
         Demon::Sidekiq.stop
       end
 
+      # Trap USR1, so we can re-issue to sidekiq workers
+      # but chain the default unicorn implementation as well
+      old_handler = Signal.trap("USR1") do
+        Demon::Sidekiq.kill("USR1")
+        old_handler.call
+      end
+
       class ::Unicorn::HttpServer
         alias :master_sleep_orig :master_sleep
 

--- a/lib/demon/base.rb
+++ b/lib/demon/base.rb
@@ -37,6 +37,13 @@ class Demon::Base
     end
   end
 
+  def self.kill(signal)
+    return unless @demons
+    @demons.values.each do |demon|
+      demon.kill(signal)
+    end
+  end
+
   attr_reader :pid, :parent_pid, :started, :index
   attr_accessor :stop_timeout
 
@@ -61,6 +68,10 @@ class Demon::Base
     else
       false
     end
+  end
+
+  def kill(signal)
+    Process.kill(signal, @pid)
   end
 
   def stop_signal

--- a/lib/demon/sidekiq.rb
+++ b/lib/demon/sidekiq.rb
@@ -34,6 +34,13 @@ class Demon::Sidekiq < ::Demon::Base
     Sidekiq.logger = nil
     cli = Sidekiq::CLI.instance
 
+    # Unicorn uses USR1 to indicate that log files have been rotated
+    Signal.trap("USR1") do
+      puts "Sidekiq PID #{Process.pid} reopening logs..."
+      Unicorn::Util.reopen_logs
+      puts "Sidekiq PID #{Process.pid} done reopening logs..."
+    end
+
     options = ["-c", GlobalSetting.sidekiq_workers.to_s]
 
     [['critical', 8], ['default', 4], ['low', 2], ['ultra_low', 1]].each do |queue_name, weight|


### PR DESCRIPTION
Unicorn uses the USR1 to indicate that log files should be reopened. This commit implements the same functionality for our forked sidekiq workers:

- USR1 is intercepted in the unicorn master, and re-issued to all child processes
- USR1 is trapped in the sidekiq processes, and `Unicorn::Util.reopen_logs` is used to re-open log files