### PR TITLE
FIX: Google groups import changed login URL

### DIFF
--- a/script/import_scripts/google_groups.rb
+++ b/script/import_scripts/google_groups.rb
@@ -186,7 +186,7 @@ def login
   get("https://myaccount.google.com/?utm_source=sign_in_no_continue")
 
   begin
-    wait_for_url { |url| url.start_with?("https://myaccount.google.com") }
+    wait_for_url { |url| url.start_with?("https://accounts.google.com") }
   rescue Selenium::WebDriver::Error::TimeoutError
     exit_with_error("Failed to login. Please check the content of your cookies.txt".red.bold)
   end


### PR DESCRIPTION
I'm not clear why changing only the `wait_for_url` address was necessary and not also the `get` a few lines above, but this change seems to work for me on both literatecomputing.com Groups and a public group.