### PR TITLE
FIX: topic title in search contains data-topic-id

### DIFF
--- a/app/assets/javascripts/discourse/widgets/search-menu-results.js
+++ b/app/assets/javascripts/discourse/widgets/search-menu-results.js
@@ -145,7 +145,11 @@ createSearchResult({
 
     const firstLine = [
       this.attach("topic-status", { topic, disableActions: true }),
-      h("span.topic-title", new Highlighted(topic.fancyTitle, term))
+      h(
+        "span.topic-title",
+        { attributes: { "data-topic-id": topic.id } },
+        new Highlighted(topic.fancyTitle, term)
+      )
     ];
 
     const secondLine = [

--- a/test/javascripts/acceptance/search-test.js
+++ b/test/javascripts/acceptance/search-test.js
@@ -28,6 +28,10 @@ QUnit.test("search", async assert => {
   await fillIn("#search-term", "dev");
   await keyEvent("#search-term", "keyup", 16);
   assert.ok(exists(".search-menu .results ul li"), "it shows results");
+  assert.ok(
+    exists(".search-menu .results ul li .topic-title[data-topic-id]"),
+    "topic has data-topic-id"
+  );
 
   await click(".show-help");
 


### PR DESCRIPTION
Data topic id is required by the discourse-encrypt plugin.

Related to https://github.com/discourse/discourse-encrypt/pull/12