### PR TITLE
FIX: flaky groups_controller_spec

### DIFF
--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 
 describe GroupsController do
   fab!(:user) { Fabricate(:user) }
+  let(:user2) { Fabricate(:user) }
   let(:group) { Fabricate(:group, users: [user]) }
   let(:moderator_group_id) { Group::AUTO_GROUPS[:moderators] }
   fab!(:admin) { Fabricate(:admin) }
@@ -91,7 +92,7 @@ describe GroupsController do
         sign_in(user)
       end
 
-      let!(:other_group) { Fabricate(:group, name: "other_group", users: [user]) }
+      let!(:other_group) { Fabricate(:group, name: "other_group", users: [user, user2]) }
 
       context "with default (descending) order" do
         it "sorts by name" do


### PR DESCRIPTION
Sometimes spec which is testing order groups by user count is failing.

My theory is that cause is the randomness of Postgres when the order value is the same for 2 rows.

In spec, we got three groups
`moderator_group` - 0 users
`group` - 1 user
`other_group` - 1 user

And we are expecting that controller will return them in ascending order [moderator, group, other_group]

Because `group` and `other_group` contain the same amount of users, we are dealing with luck

Therefore, I believe that adding one more user to other_group should make that query reliable.

It was not crashing on my local machine, so I am not 100% sure.