### PR TITLE
UX: Set focus when launching composer on iOS

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -54,6 +54,7 @@
 //= require ./discourse/lib/autocomplete
 //= require ./discourse/lib/after-transition
 //= require ./discourse/lib/safari-hacks
+//= require ./discourse/lib/put-cursor-at-end
 //= require_tree ./discourse/adapters
 //= require ./discourse/models/post-action-type
 //= require ./discourse/models/post

--- a/app/assets/javascripts/discourse/components/composer-body.js
+++ b/app/assets/javascripts/discourse/components/composer-body.js
@@ -150,28 +150,27 @@ export default Component.extend(KeyEnterEscape, {
   },
 
   viewportResize() {
-    const composerVH = window.visualViewport.height * 0.01;
+    const composerVH = window.visualViewport.height * 0.01,
+      doc = document.documentElement;
 
-    document.documentElement.style.setProperty(
-      "--composer-vh",
-      `${composerVH}px`
-    );
+    doc.style.setProperty("--composer-vh", `${composerVH}px`);
 
     const viewportWindowDiff =
       window.innerHeight - window.visualViewport.height;
 
+    viewportWindowDiff
+      ? doc.classList.add("keyboard-visible")
+      : doc.classList.remove("keyboard-visible");
     // adds bottom padding when using a hardware keyboard and the accessory bar is visible
     // accessory bar height is 55px, using 75 allows a small buffer
-    if (viewportWindowDiff > 0 && viewportWindowDiff < 75) {
-      document.documentElement.style.setProperty(
+
+    if (viewportWindowDiff < 75) {
+      doc.style.setProperty(
         "--composer-ipad-padding",
         `${viewportWindowDiff}px`
       );
     } else {
-      document.documentElement.style.setProperty(
-        "--composer-ipad-padding",
-        "0px"
-      );
+      doc.style.setProperty("--composer-ipad-padding", "0px");
     }
   },
 

--- a/app/assets/javascripts/discourse/components/composer-editor.js
+++ b/app/assets/javascripts/discourse/components/composer-editor.js
@@ -28,7 +28,6 @@ import {
   tinyAvatar,
   formatUsername,
   clipboardData,
-  safariHacksDisabled,
   caretPosition,
   inCodeBlock,
   putCursorAtEnd
@@ -210,10 +209,7 @@ export default Component.extend({
     }
 
     // Focus on the body unless we have a title
-    if (
-      !this.get("composer.canEditTitle") &&
-      (!this.capabilities.isIOS || safariHacksDisabled())
-    ) {
+    if (!this.get("composer.canEditTitle")) {
       putCursorAtEnd(this.element.querySelector(".d-editor-input"));
     }
 

--- a/app/assets/javascripts/discourse/components/composer-editor.js
+++ b/app/assets/javascripts/discourse/components/composer-editor.js
@@ -29,9 +29,9 @@ import {
   formatUsername,
   clipboardData,
   caretPosition,
-  inCodeBlock,
-  putCursorAtEnd
+  inCodeBlock
 } from "discourse/lib/utilities";
+import putCursorAtEnd from "discourse/lib/put-cursor-at-end";
 import {
   validateUploadedFiles,
   authorizesOneOrMoreImageExtensions,

--- a/app/assets/javascripts/discourse/components/composer-title.js
+++ b/app/assets/javascripts/discourse/components/composer-title.js
@@ -7,7 +7,7 @@ import { lookupCache } from "pretty-text/oneboxer-cache";
 import { ajax } from "discourse/lib/ajax";
 import ENV from "discourse-common/config/environment";
 import EmberObject from "@ember/object";
-import { putCursorAtEnd } from "discourse/lib/utilities";
+import putCursorAtEnd from "discourse/lib/put-cursor-at-end";
 
 export default Component.extend({
   classNames: ["title-input"],

--- a/app/assets/javascripts/discourse/components/composer-user-selector.js
+++ b/app/assets/javascripts/discourse/components/composer-user-selector.js
@@ -1,7 +1,7 @@
 import { schedule } from "@ember/runloop";
 import Component from "@ember/component";
 import discourseComputed, { observes } from "discourse-common/utils/decorators";
-import { putCursorAtEnd } from "discourse/lib/utilities";
+import putCursorAtEnd from "discourse/lib/put-cursor-at-end";
 
 export default Component.extend({
   showSelector: true,

--- a/app/assets/javascripts/discourse/controllers/composer.js
+++ b/app/assets/javascripts/discourse/controllers/composer.js
@@ -13,7 +13,7 @@ import discourseComputed, {
   on
 } from "discourse-common/utils/decorators";
 import { getOwner } from "discourse-common/lib/get-owner";
-import { escapeExpression, safariHacksDisabled } from "discourse/lib/utilities";
+import { escapeExpression } from "discourse/lib/utilities";
 import {
   authorizesOneOrMoreExtensions,
   uploadIcon
@@ -136,10 +136,6 @@ export default Controller.extend({
     "model.composeState"
   )
   focusTarget(replyingToTopic, creatingPM, usernames, composeState) {
-    if (this.capabilities.isIOS && !safariHacksDisabled()) {
-      return "none";
-    }
-
     // Focus on usernames if it's blank or if it's just you
     usernames = usernames || "";
     if (

--- a/app/assets/javascripts/discourse/lib/put-cursor-at-end.js
+++ b/app/assets/javascripts/discourse/lib/put-cursor-at-end.js
@@ -1,0 +1,16 @@
+import positioningWorkaround from "discourse/lib/safari-hacks";
+import { isAppleDevice } from "discourse/lib/utilities";
+
+export default function(element) {
+  if (isAppleDevice() && positioningWorkaround.touchstartEvent) {
+    positioningWorkaround.touchstartEvent(element);
+  } else {
+    element.focus();
+  }
+
+  const len = element.value.length;
+  element.setSelectionRange(len, len);
+
+  // Scroll to the bottom, in case we're in a tall textarea
+  element.scrollTop = 999999;
+}

--- a/app/assets/javascripts/discourse/lib/utilities.js
+++ b/app/assets/javascripts/discourse/lib/utilities.js
@@ -1,6 +1,5 @@
 import { escape } from "pretty-text/sanitizer";
 import toMarkdown from "discourse/lib/to-markdown";
-import positioningWorkaround from "discourse/lib/safari-hacks";
 
 const homepageSelector = "meta[name=discourse_current_homepage]";
 
@@ -443,20 +442,6 @@ export function inCodeBlock(text, pos) {
   }
 
   return result;
-}
-
-export function putCursorAtEnd(element) {
-  if (isAppleDevice() && positioningWorkaround.touchstartEvent) {
-    positioningWorkaround.touchstartEvent(element);
-  } else {
-    element.focus();
-  }
-
-  const len = element.value.length;
-  element.setSelectionRange(len, len);
-
-  // Scroll to the bottom, in case we're in a tall textarea
-  element.scrollTop = 999999;
 }
 
 // This prevents a mini racer crash

--- a/app/assets/javascripts/discourse/lib/utilities.js
+++ b/app/assets/javascripts/discourse/lib/utilities.js
@@ -1,5 +1,6 @@
 import { escape } from "pretty-text/sanitizer";
 import toMarkdown from "discourse/lib/to-markdown";
+import positioningWorkaround from "discourse/lib/safari-hacks";
 
 const homepageSelector = "meta[name=discourse_current_homepage]";
 
@@ -445,9 +446,17 @@ export function inCodeBlock(text, pos) {
 }
 
 export function putCursorAtEnd(element) {
-  element.focus();
+  if (isAppleDevice() && positioningWorkaround.touchstartEvent) {
+    positioningWorkaround.touchstartEvent(element);
+  } else {
+    element.focus();
+  }
+
   const len = element.value.length;
   element.setSelectionRange(len, len);
+
+  // Scroll to the bottom, in case we're in a tall textarea
+  element.scrollTop = 999999;
 }
 
 // This prevents a mini racer crash

--- a/app/assets/stylesheets/mobile/compose.scss
+++ b/app/assets/stylesheets/mobile/compose.scss
@@ -26,9 +26,10 @@
 
   body.ios-safari-composer-hacks &.open {
     height: calc(var(--composer-vh, 1vh) * 100);
-    .reply-area {
-      padding-bottom: 0px;
-    }
+  }
+
+  .keyboard-visible body.ios-safari-composer-hacks &.open .reply-area {
+    padding-bottom: 0px;
   }
 
   .reply-to {


### PR DESCRIPTION
A small refactor of our Safari iOS hacks to enable setting focus on inputs/textareas when launching the composer. Should improve user experience when using an iPad with a keyboard, no need to tap the screen now while using keyboard shortcuts like `c` or `r`. 