### PR TITLE
FIX: Abort emit_web_hook_event job cleanly if web hook was deleted

### DIFF
--- a/app/jobs/regular/emit_web_hook_event.rb
+++ b/app/jobs/regular/emit_web_hook_event.rb
@@ -14,6 +14,8 @@ module Jobs
       @web_hook = WebHook.find_by(id: @arguments[:web_hook_id])
       validate_arguments!
 
+      return if @web_hook.blank? # Web Hook was deleted
+
       unless ping_event?(@arguments[:event_type])
         validate_argument!(:payload)
 
@@ -31,7 +33,6 @@ module Jobs
     def validate_arguments!
       validate_argument!(:web_hook_id)
       validate_argument!(:event_type)
-      raise Discourse::InvalidParameters.new(:web_hook_id) if @web_hook.blank?
     end
 
     def validate_argument!(key)

--- a/spec/jobs/emit_web_hook_event_spec.rb
+++ b/spec/jobs/emit_web_hook_event_spec.rb
@@ -17,13 +17,13 @@ describe Jobs::EmitWebHookEvent do
 
   it 'raises an error when there is no event type' do
     expect do
-      subject.execute(web_hook_id: 1, payload: {})
+      subject.execute(web_hook_id: post_hook.id, payload: {})
     end.to raise_error(Discourse::InvalidParameters)
   end
 
   it 'raises an error when there is no payload' do
     expect do
-      subject.execute(web_hook_id: 1, event_type: 'post')
+      subject.execute(web_hook_id: post_hook.id, event_type: 'post')
     end.to raise_error(Discourse::InvalidParameters)
   end
 


### PR DESCRIPTION
Raising an error causes the job to be retried, and causes a lot of noise in the logs