### PR TITLE
FEATURE: Users can be ignored for six months.

### DIFF
--- a/app/assets/javascripts/select-kit/components/future-date-input-selector.js
+++ b/app/assets/javascripts/select-kit/components/future-date-input-selector.js
@@ -132,7 +132,7 @@ export const TIMEFRAMES = [
   buildTimeframe({
     id: "six_months",
     format: "MMM D",
-    enabled: opts => opts.includeFarFuture,
+    enabled: opts => opts.includeMidFuture,
     when: (time, timeOfDay) =>
       time
         .add(6, "month")


### PR DESCRIPTION
`includeFarFuture=false` is only used by the ignore feature. I think it's safe to move the six months timeframe into that group.