### PR TITLE
FEATURE: Add copy button to codeblocks

### DIFF
--- a/app/assets/javascripts/discourse/initializers/copy-codeblocks.js
+++ b/app/assets/javascripts/discourse/initializers/copy-codeblocks.js
@@ -82,12 +82,7 @@ export default {
         const code = button.nextSibling;
 
         if (code) {
-          let string = code.innerText;
-
-          if (string) {
-            string = string.trim();
-            clipboardCopy(string);
-          }
+          clipboardCopy(code.innerText.trim());
 
           button.classList.add("copied");
 
@@ -95,19 +90,21 @@ export default {
         }
       }
 
-      function _attachCommands($elem) {
+      function _attachCommands(postElements) {
         const siteSettings = container.lookup("site-settings:main");
         const { isIE11 } = container.lookup("capabilities:main");
         if (!siteSettings.show_copy_button_on_codeblocks || isIE11) {
           return;
         }
-        const commands = $elem[0].querySelectorAll(":scope > pre > code");
+        const commands = postElements[0].querySelectorAll(
+          ":scope > pre > code"
+        );
 
         if (!commands.length) {
           return;
         }
 
-        _clickHandlerElement = $elem[0];
+        _clickHandlerElement = postElements[0];
 
         commands.forEach(command => {
           const button = document.createElement("button");

--- a/app/assets/javascripts/discourse/initializers/copy-codeblocks.js
+++ b/app/assets/javascripts/discourse/initializers/copy-codeblocks.js
@@ -1,0 +1,123 @@
+import { withPluginApi } from "discourse/lib/plugin-api";
+import { later } from "@ember/runloop";
+import { Promise } from "rsvp";
+import { iconHTML } from "discourse-common/lib/icon-library";
+
+// http://github.com/feross/clipboard-copy
+function clipboardCopy(text) {
+  // Use the Async Clipboard API when available. Requires a secure browsing
+  // context (i.e. HTTPS)
+  if (navigator.clipboard) {
+    return navigator.clipboard.writeText(text).catch(function(err) {
+      throw err !== undefined
+        ? err
+        : new DOMException("The request is not allowed", "NotAllowedError");
+    });
+  }
+
+  // ...Otherwise, use document.execCommand() fallback
+
+  // Put the text to copy into a <span>
+  const span = document.createElement("span");
+  span.textContent = text;
+
+  // Preserve consecutive spaces and newlines
+  span.style.whiteSpace = "pre";
+
+  // Add the <span> to the page
+  document.body.appendChild(span);
+
+  // Make a selection object representing the range of text selected by the user
+  const selection = window.getSelection();
+  const range = window.document.createRange();
+  selection.removeAllRanges();
+  range.selectNode(span);
+  selection.addRange(range);
+
+  // Copy text to the clipboard
+  let success = false;
+  try {
+    success = window.document.execCommand("copy");
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.log("error", err);
+  }
+
+  // Cleanup
+  selection.removeAllRanges();
+  window.document.body.removeChild(span);
+
+  return success
+    ? Promise.resolve()
+    : Promise.reject(
+        new DOMException("The request is not allowed", "NotAllowedError")
+      );
+}
+
+let _clickHandlerElement = null;
+
+export default {
+  name: "copy-codeblocks",
+
+  initialize(container) {
+    withPluginApi("0.8.7", api => {
+      function _cleanUp() {
+        if (_clickHandlerElement) {
+          _clickHandlerElement.removeEventListener("click", _handleClick);
+          _clickHandlerElement = null;
+        }
+      }
+
+      function _handleClick(event) {
+        if (!event.target.classList.contains("copy-cmd")) {
+          return;
+        }
+
+        const button = event.target;
+        const code = button.nextSibling;
+
+        if (code) {
+          let string = code.innerText;
+
+          if (string) {
+            string = string.replace(/^\s+|\s+$/g, "");
+            clipboardCopy(string);
+          }
+
+          button.classList.add("copied");
+
+          later(() => button.classList.remove("copied"), 3000);
+        }
+      }
+
+      function _attachCommands($elem) {
+        const siteSettings = container.lookup("site-settings:main");
+        const { isIE11 } = api.container.lookup("capabilities:main");
+        if (!siteSettings.show_copy_button_on_codeblocks || isIE11) {
+          return;
+        }
+        const commands = $elem[0].querySelectorAll(":scope > pre > code");
+
+        if (!commands.length) {
+          return;
+        }
+
+        _clickHandlerElement = $elem[0];
+
+        commands.forEach(command => {
+          const button = document.createElement("button");
+          button.classList.add("btn", "nohighlight", "copy-cmd");
+          button.innerHTML = iconHTML("copy");
+          command.before(button);
+          command.parentElement.classList.add("copy-codeblocks");
+        });
+
+        _clickHandlerElement.addEventListener("click", _handleClick, false);
+      }
+
+      api.decorateCooked(_attachCommands, { id: "copy-codeblocks" });
+
+      api.cleanupStream(_cleanUp);
+    });
+  }
+};

--- a/app/assets/javascripts/discourse/initializers/copy-codeblocks.js
+++ b/app/assets/javascripts/discourse/initializers/copy-codeblocks.js
@@ -1,5 +1,5 @@
 import { withPluginApi } from "discourse/lib/plugin-api";
-import { later } from "@ember/runloop";
+import { cancel, later } from "@ember/runloop";
 import { Promise } from "rsvp";
 import { iconHTML } from "discourse-common/lib/icon-library";
 
@@ -55,6 +55,7 @@ function clipboardCopy(text) {
 }
 
 let _clickHandlerElement = null;
+let _runLater = null;
 
 export default {
   name: "copy-codeblocks",
@@ -65,6 +66,10 @@ export default {
         if (_clickHandlerElement) {
           _clickHandlerElement.removeEventListener("click", _handleClick);
           _clickHandlerElement = null;
+        }
+        if (_runLater) {
+          cancel(_runLater);
+          _runLater = null;
         }
       }
 
@@ -86,7 +91,7 @@ export default {
 
           button.classList.add("copied");
 
-          later(() => button.classList.remove("copied"), 3000);
+          _runLater = later(() => button.classList.remove("copied"), 3000);
         }
       }
 

--- a/app/assets/javascripts/discourse/initializers/copy-codeblocks.js
+++ b/app/assets/javascripts/discourse/initializers/copy-codeblocks.js
@@ -85,7 +85,7 @@ export default {
           let string = code.innerText;
 
           if (string) {
-            string = string.replace(/^\s+|\s+$/g, "");
+            string = string.trim();
             clipboardCopy(string);
           }
 

--- a/app/assets/javascripts/discourse/initializers/copy-codeblocks.js
+++ b/app/assets/javascripts/discourse/initializers/copy-codeblocks.js
@@ -97,7 +97,7 @@ export default {
 
       function _attachCommands($elem) {
         const siteSettings = container.lookup("site-settings:main");
-        const { isIE11 } = api.container.lookup("capabilities:main");
+        const { isIE11 } = container.lookup("capabilities:main");
         if (!siteSettings.show_copy_button_on_codeblocks || isIE11) {
           return;
         }

--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -609,6 +609,34 @@ pre {
   }
 }
 
+.copy-codeblocks {
+  display: block;
+  position: relative;
+  overflow: visible;
+
+  .copy-cmd {
+    position: absolute;
+    top: 0;
+    right: 0;
+    min-height: 0;
+    font-size: $font-down-2;
+    min-height: 0;
+    font-size: $font-down-2;
+    user-select: none;
+
+    &.copied {
+      .d-icon {
+        color: $tertiary;
+      }
+    }
+
+    .d-icon {
+      pointer-events: none;
+      margin-right: 0;
+    }
+  }
+}
+
 kbd {
   border-radius: 3px;
   box-shadow: shadow("kbd");

--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -247,6 +247,17 @@ nav.post-controls {
   }
 }
 
+pre.copy-codeblocks .copy-cmd:not(.copied) {
+  opacity: 0;
+  transition: 0.2s;
+  visibility: hidden;
+}
+
+pre.copy-codeblocks:hover .copy-cmd {
+  opacity: 1;
+  visibility: visible;
+}
+
 .embedded-posts {
   h1,
   h2,

--- a/app/assets/stylesheets/mobile/topic-post.scss
+++ b/app/assets/stylesheets/mobile/topic-post.scss
@@ -397,6 +397,10 @@ blockquote {
   margin-right: 0;
 }
 
+pre.copy-codeblocks code {
+  padding-right: 2.75em;
+}
+
 .gap {
   padding: 0.25em 0;
 }

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2064,7 +2064,7 @@ en:
     warn_reviving_old_topic_age: "When someone starts replying to a topic where the last reply is older than this many days, a warning will be displayed. Disable by setting to 0."
     autohighlight_all_code: "Force apply code highlighting to all preformatted code blocks even when they didn't explicitly specify the language."
     highlighted_languages: "Included syntax highlighting rules. (Warning: including too many languages may impact performance) see: <a href='https://highlightjs.org/static/demo/' target='_blank'>https://highlightjs.org/static/demo</a> for a demo"
-    show_copy_button_on_codeblocks: "Add a button to codeblocks to copy the block contents to the user's clipboard. This feature is not supported on Internet Explorer 11."
+    show_copy_button_on_codeblocks: "Add a button to codeblocks to copy the block contents to the user's clipboard. This feature is not supported on Internet Explorer."
 
     embed_any_origin: "Allow embeddable content regardless of origin. This is required for mobile apps with static HTML."
     embed_topics_list: "Support HTML embedding of topics lists"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2064,6 +2064,7 @@ en:
     warn_reviving_old_topic_age: "When someone starts replying to a topic where the last reply is older than this many days, a warning will be displayed. Disable by setting to 0."
     autohighlight_all_code: "Force apply code highlighting to all preformatted code blocks even when they didn't explicitly specify the language."
     highlighted_languages: "Included syntax highlighting rules. (Warning: including too many languages may impact performance) see: <a href='https://highlightjs.org/static/demo/' target='_blank'>https://highlightjs.org/static/demo</a> for a demo"
+    show_copy_button_on_codeblocks: "Add a button to codeblocks to copy the block contents to the user's clipboard. This feature is not supported on Internet Explorer 11."
 
     embed_any_origin: "Allow embeddable content regardless of origin. This is required for mobile apps with static HTML."
     embed_topics_list: "Support HTML embedding of topics lists"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -850,6 +850,9 @@ posting:
     type: list
     client: true
     list_type: compact
+  show_copy_button_on_codeblocks:
+    client: true
+    default: false
   delete_old_hidden_posts: true
   enable_emoji:
     default: true


### PR DESCRIPTION
This PR converts the copy codeblocks theme component to a core feature. The codeblocks are only shown when the `show copy button on codeblocks` site setting is enabled. This is defaulted to off.

Additionally, I've also fixed an issue where codeblocks inside of GitHub oneboxes have a copy button added. This uses the `:scope` selector, which is not compatible in IE 11. I did find a [possible polyfill](https://github.com/jonathantneal/element-qsa-scope/) we could use but my knowledge is limited there.