### PR TITLE
FIX: Stop wizard from creating duplicate Light theme

### DIFF
--- a/lib/wizard/builder.rb
+++ b/lib/wizard/builder.rb
@@ -181,11 +181,16 @@ class Wizard
           next unless scheme_name.present? && ColorScheme.is_base?(scheme_name)
 
           name = I18n.t("color_schemes.#{scheme_name.downcase.gsub(' ', '_')}_theme_name")
-
           theme = nil
           scheme = ColorScheme.find_by(base_scheme_id: scheme_name, via_wizard: true)
+          is_light_theme = (scheme_name == ColorScheme::LIGHT_THEME_ID)
           scheme ||= ColorScheme.create_from_base(name: name, via_wizard: true, base_scheme_id: scheme_name)
+
           themes = Theme.where(color_scheme_id: scheme.id).order(:id).to_a
+          if is_light_theme
+            themes = (themes || []).concat(Theme.where(color_scheme_id: nil).order(:id).to_a)
+            themes.sort_by(&:id)
+          end
           theme = themes.find(&:default?)
           theme ||= themes.first
 


### PR DESCRIPTION
Before this change, after going through the wizard and selecting 'Light' theme, there would be 2 Light themes, because the wizard step created a duplicate.

Here, I added logic to check if the color scheme of the selected theme is "Light". If so, add the default theme (The theme with `color_scheme_id == nil') to the `themes` array.

We do not have tests that test the outcome of submitting this step, but I extensively tested it in the browser to ensure it works.