### PR TITLE
FIX: Make InlineUploads handle more URL formats

### DIFF
--- a/app/services/inline_uploads.rb
+++ b/app/services/inline_uploads.rb
@@ -148,7 +148,7 @@ class InlineUploads
   end
 
   def self.match_md_inline_img(markdown, external_src: false)
-    markdown.scan(/(!?\[([^\[\]]*)\]\(([a-zA-z0-9\.\/:-]+)([ ]*['"]{1}[^\)]*['"]{1}[ ]*)?\))/) do |match|
+    markdown.scan(/(!?\[([^\[\]]*)\]\((#{URI.regexp})([ ]*['"]{1}[^\)]*['"]{1}[ ]*)?\))/) do |match|
       if (matched_uploads(match[2]).present? || external_src) && block_given?
         yield(
           match[0],

--- a/app/services/inline_uploads.rb
+++ b/app/services/inline_uploads.rb
@@ -148,7 +148,7 @@ class InlineUploads
   end
 
   def self.match_md_inline_img(markdown, external_src: false)
-    markdown.scan(/(!?\[([^\[\]]*)\]\(([a-zA-z0-9\.\/:-]+|#{URI.regexp})([ ]*['"]{1}[^\)]*['"]{1}[ ]*)?\))/) do |match|
+    markdown.scan(/(!?\[([^\[\]]*)\]\(([^\s\)]+)([ ]*['"]{1}[^\)]*['"]{1}[ ]*)?\))/) do |match|
       if (matched_uploads(match[2]).present? || external_src) && block_given?
         yield(
           match[0],

--- a/app/services/inline_uploads.rb
+++ b/app/services/inline_uploads.rb
@@ -148,7 +148,7 @@ class InlineUploads
   end
 
   def self.match_md_inline_img(markdown, external_src: false)
-    markdown.scan(/(!?\[([^\[\]]*)\]\((#{URI.regexp})([ ]*['"]{1}[^\)]*['"]{1}[ ]*)?\))/) do |match|
+    markdown.scan(/(!?\[([^\[\]]*)\]\(([a-zA-z0-9\.\/:-]+|#{URI.regexp})([ ]*['"]{1}[^\)]*['"]{1}[ ]*)?\))/) do |match|
       if (matched_uploads(match[2]).present? || external_src) && block_given?
         yield(
           match[0],

--- a/spec/services/inline_uploads_spec.rb
+++ b/spec/services/inline_uploads_spec.rb
@@ -712,4 +712,17 @@ RSpec.describe InlineUploads do
       end
     end
   end
+
+  describe ".match_md_inline_img" do
+    it "matches URLs with various characters" do
+      md = <<~MD
+      ![test](https://some-site.com/a_test?q=1&b=hello%20there)
+      MD
+
+      url = nil
+      InlineUploads.match_md_inline_img(md, external_src: true) { |_match, src| url = src }
+
+      expect(url).to eq("https://some-site.com/a_test?q=1&b=hello%20there")
+    end
+  end
 end


### PR DESCRIPTION
It previously failed to match URLs with characters other than `[a-zA-z0-9\.\/:-]`. This meant that `PullHotlinkedImages` would sometimes download an external image and then never use it in any posts.