### PR TITLE
DEV: Remove `bypass_bump` from CookedPostProcessor

### DIFF
--- a/app/jobs/regular/process_post.rb
+++ b/app/jobs/regular/process_post.rb
@@ -23,7 +23,7 @@ module Jobs
         end
 
         cp = CookedPostProcessor.new(post, args)
-        cp.post_process(bypass_bump: args[:bypass_bump], new_post: args[:new_post])
+        cp.post_process(new_post: args[:new_post])
 
         # If we changed the document, save it
         cooked = cp.html

--- a/lib/cooked_post_processor.rb
+++ b/lib/cooked_post_processor.rb
@@ -32,7 +32,7 @@ class CookedPostProcessor
     @omit_nofollow = post.omit_nofollow?
   end
 
-  def post_process(bypass_bump: false, new_post: false)
+  def post_process(new_post: false)
     DistributedMutex.synchronize("post_process_#{@post.id}", validity: 10.minutes) do
       DiscourseEvent.trigger(:before_post_process_cooked, @doc, @post)
       remove_full_quote_on_direct_reply if new_post
@@ -43,7 +43,7 @@ class CookedPostProcessor
       remove_user_ids
       update_post_image
       enforce_nofollow
-      pull_hotlinked_images(bypass_bump)
+      pull_hotlinked_images
       grant_badges
       @post.link_post_uploads(fragments: @doc)
       DiscourseEvent.trigger(:post_process_cooked, @doc, @post)
@@ -655,7 +655,7 @@ class CookedPostProcessor
     end
   end
 
-  def pull_hotlinked_images(bypass_bump = false)
+  def pull_hotlinked_images
     # have we enough disk space?
     disable_if_low_on_disk_space # But still enqueue the job
     # don't download remote images for posts that are more than n days old
@@ -666,7 +666,7 @@ class CookedPostProcessor
     Jobs.cancel_scheduled_job(:pull_hotlinked_images, post_id: @post.id)
     # schedule the job
     delay = SiteSetting.editing_grace_period + 1
-    Jobs.enqueue_in(delay.seconds.to_i, :pull_hotlinked_images, post_id: @post.id, bypass_bump: bypass_bump)
+    Jobs.enqueue_in(delay.seconds.to_i, :pull_hotlinked_images, post_id: @post.id)
   end
 
   def disable_if_low_on_disk_space

--- a/spec/components/cooked_post_processor_spec.rb
+++ b/spec/components/cooked_post_processor_spec.rb
@@ -1529,7 +1529,7 @@ describe CookedPostProcessor do
             Jobs.expects(:cancel_scheduled_job).with(:pull_hotlinked_images, post_id: post.id).once
 
             delay = SiteSetting.editing_grace_period + 1
-            Jobs.expects(:enqueue_in).with(delay.seconds, :pull_hotlinked_images, post_id: post.id, bypass_bump: false).once
+            Jobs.expects(:enqueue_in).with(delay.seconds, :pull_hotlinked_images, post_id: post.id).once
 
             cpp.pull_hotlinked_images
           end
@@ -1603,7 +1603,7 @@ describe CookedPostProcessor do
       Jobs.expects(:cancel_scheduled_job).with(:pull_hotlinked_images, post_id: post.id).once
 
       delay = SiteSetting.editing_grace_period + 1
-      Jobs.expects(:enqueue_in).with(delay.seconds, :pull_hotlinked_images, post_id: post.id, bypass_bump: false).once
+      Jobs.expects(:enqueue_in).with(delay.seconds, :pull_hotlinked_images, post_id: post.id).once
 
       cpp.pull_hotlinked_images
     end


### PR DESCRIPTION
It was only passing it along to `PullHotlinkedImages` and that class have not used that arg since April 2014 (https://github.com/discourse/discourse/commit/c52ee665b45241a89b4de8b916860f380ecf0141)

(No plugin in all-the-plugins uses it either)