### PR TITLE
DEV: Remove the return value of disable_if_low_on_disk_space

### DIFF
--- a/lib/cooked_post_processor.rb
+++ b/lib/cooked_post_processor.rb
@@ -670,11 +670,12 @@ class CookedPostProcessor
   end
 
   def disable_if_low_on_disk_space
-    return false if Discourse.store.external?
-    return false if !SiteSetting.download_remote_images_to_local
-    return false if available_disk_space >= SiteSetting.download_remote_images_threshold
+    return if Discourse.store.external?
+    return if !SiteSetting.download_remote_images_to_local
+    return if available_disk_space >= SiteSetting.download_remote_images_threshold
 
     SiteSetting.download_remote_images_to_local = false
+
     # log the site setting change
     reason = I18n.t("disable_remote_images_download_reason")
     staff_action_logger = StaffActionLogger.new(Discourse.system_user)
@@ -682,8 +683,6 @@ class CookedPostProcessor
 
     # also send a private message to the site contact user
     notify_about_low_disk_space
-
-    true
   end
 
   def notify_about_low_disk_space

--- a/spec/components/cooked_post_processor_spec.rb
+++ b/spec/components/cooked_post_processor_spec.rb
@@ -1513,7 +1513,7 @@ describe CookedPostProcessor do
 
       context "and there is enough disk space" do
 
-        before { cpp.expects(:disable_if_low_on_disk_space).returns(false) }
+        before { cpp.expects(:disable_if_low_on_disk_space) }
 
         it "does not run when the system user updated the post" do
           post.last_editor_id = Discourse.system_user.id
@@ -1555,7 +1555,7 @@ describe CookedPostProcessor do
 
     it "does nothing when there's enough disk space" do
       SiteSetting.expects(:download_remote_images_to_local=).never
-      expect(cpp.disable_if_low_on_disk_space).to eq(false)
+      cpp.disable_if_low_on_disk_space
     end
 
     context "when there's not enough disk space" do
@@ -1565,7 +1565,8 @@ describe CookedPostProcessor do
       it "disables download_remote_images_threshold and send a notification to the admin" do
         StaffActionLogger.any_instance.expects(:log_site_setting_change).once
         SystemMessage.expects(:create_from_system_user).with(Discourse.site_contact_user, :download_remote_images_disabled).once
-        expect(cpp.disable_if_low_on_disk_space).to eq(true)
+        cpp.disable_if_low_on_disk_space
+
         expect(SiteSetting.download_remote_images_to_local).to eq(false)
       end
 
@@ -1573,7 +1574,8 @@ describe CookedPostProcessor do
         SiteSetting.s3_access_key_id = "s3-access-key-id"
         SiteSetting.s3_secret_access_key = "s3-secret-access-key"
         SiteSetting.enable_s3_uploads = true
-        expect(cpp.disable_if_low_on_disk_space).to eq(false)
+        cpp.disable_if_low_on_disk_space
+
         expect(SiteSetting.download_remote_images_to_local).to eq(true)
       end
 


### PR DESCRIPTION
It was used only in specs. It is not used by any plugin in all-the-plugins.