### PR TITLE
FIX: Reject invalid Category slugs

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -342,7 +342,12 @@ class Category < ActiveRecord::Base
       slug = SiteSetting.slug_generation_method == 'encoded' ? CGI.unescape(self.slug) : self.slug
       # sanitize the custom slug
       self.slug = Slug.sanitize(slug)
-      errors.add(:slug, 'is already in use') if duplicate_slug?
+
+      if self.slug.blank?
+        errors.add(:slug, :invalid)
+      elsif duplicate_slug?
+        errors.add(:slug, 'is already in use')
+      end
     else
       # auto slug
       self.slug = Slug.for(name, '')

--- a/spec/requests/categories_controller_spec.rb
+++ b/spec/requests/categories_controller_spec.rb
@@ -480,8 +480,9 @@ describe CategoriesController do
       end
 
       it 'rejects invalid custom slug' do
-        put "/category/#{category.id}/slug.json", params: { slug: '  ' }
+        put "/category/#{category.id}/slug.json", params: { slug: '.' }
         expect(response.status).to eq(422)
+        expect(response.parsed_body["errors"]).to eq(["Slug is invalid"])
       end
     end
   end

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -377,14 +377,9 @@ RSpec.describe ListController do
         # One category has another category's id at the beginning of its name
         let!(:other_category) {
           # Our validations don't allow this to happen now, but did historically
-          Fabricate(:category_with_definition, name: "#{category.id} name", slug: '-').tap { |c|
-            DB.exec <<~SQL
-              UPDATE categories
-              SET slug = '#{category.id}-name'
-              WHERE id = #{c.id}
-            SQL
-            c.reload
-          }
+          Fabricate(:category_with_definition, name: "#{category.id} name", slug: 'will-be-changed').tap do |category|
+            category.update_column(:slug, "#{category.id}-name")
+          end
         }
 
         it 'uses the correct category' do


### PR DESCRIPTION
Previously it would sanitize a given slug and then save the resulting empty slug.