### PR TITLE
DEV: Add class to header-topic-info widget

### DIFF
--- a/app/assets/javascripts/discourse/widgets/header-topic-info.js
+++ b/app/assets/javascripts/discourse/widgets/header-topic-info.js
@@ -57,6 +57,10 @@ createWidget("topic-header-participant", {
 export default createWidget("header-topic-info", {
   tagName: "div.extra-info-wrapper",
 
+  buildClasses(attrs) {
+    return this.showCategory(attrs.topic) ? "two-rows" : "";
+  },
+
   buildFancyTitleClass() {
     const baseClass = ["topic-link"];
     const flatten = array => [].concat.apply([], array);
@@ -112,11 +116,7 @@ export default createWidget("header-topic-info", {
     const category = topic.get("category");
 
     if (loaded || category) {
-      if (
-        category &&
-        (!category.get("isUncategorizedCategory") ||
-          !this.siteSettings.suppress_uncategorized_badge)
-      ) {
+      if (this.showCategory(topic)) {
         const parentCategory = category.get("parentCategory");
         const categories = [];
         if (parentCategory) {
@@ -205,6 +205,14 @@ export default createWidget("header-topic-info", {
       "div.extra-info",
       { className: title.length > 1 ? "two-rows" : "" },
       contents
+    );
+  },
+
+  showCategory(topic) {
+    return (
+      topic.category &&
+      (!topic.category.get("isUncategorizedCategory") ||
+        !this.siteSettings.suppress_uncategorized_badge)
     );
   },
 

--- a/app/assets/javascripts/discourse/widgets/header-topic-info.js
+++ b/app/assets/javascripts/discourse/widgets/header-topic-info.js
@@ -211,7 +211,7 @@ export default createWidget("header-topic-info", {
   showCategory(topic) {
     return (
       topic.category &&
-      (!topic.category.get("isUncategorizedCategory") ||
+      (!topic.category.isUncategorizedCategory ||
         !this.siteSettings.suppress_uncategorized_badge)
     );
   },


### PR DESCRIPTION
There is an `.extra-info-wrapper` holding the `.extra-info` div. Right now, a `.two-rows` class gets added to `.extra-info` when viewing a topic with a category showing. If the topic is uncategorized, and suppress uncategorized is true, the `.two-rows` class is not present.

In **some plugins** we decorate this widget like so: `header-topic-info:after`. The problem here is that we need the `two-rows` class to be on the PARENT of `header-topic-info` so that we can use it as a css selector.