### PR TITLE
FIX: Set category description to first posts cooked value

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -287,7 +287,7 @@ class Category < ActiveRecord::Base
       update_column(:topic_id, t.id)
       post = t.posts.build(raw: description || post_template, user: user)
       post.save!(validate: false)
-      update_column(:description, post.cooked)
+      update_column(:description, post.cooked) if description.present?
 
       t
     end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -287,6 +287,7 @@ class Category < ActiveRecord::Base
       update_column(:topic_id, t.id)
       post = t.posts.build(raw: description || post_template, user: user)
       post.save!(validate: false)
+      update_column(:description, post.cooked)
 
       t
     end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -403,6 +403,16 @@ describe Category do
       expect(@category.topics_year).to eq(0)
     end
 
+    it "cooks the definition" do
+      category = Category.create(
+        name: 'little-test',
+        user_id: Discourse.system_user.id,
+        description: "click the link [here](https://fakeurl.com)"
+      )
+      expect(category.description.include?("[here]")).to eq(false)
+      expect(category.description).to eq(category.topic.first_post.cooked)
+    end
+
     it "renames the definition when renamed" do
       @category.update(name: 'Troutfishing')
       @topic.reload


### PR DESCRIPTION
We do not notice this bug right now, because the default category description has no markdown that needs to be converted into html.

Once the category definition topic/post are created, simply set the description of the category to the posts `cooked` value.