### PR TITLE
FEATURE: Digital Ocean Spaces compatibility for Object Storage

### DIFF
--- a/lib/tasks/s3.rake
+++ b/lib/tasks/s3.rake
@@ -21,8 +21,7 @@ def upload(path, remote_path, content_type, content_encoding = nil)
   options = {
     cache_control: 'max-age=31556952, public, immutable',
     content_type: content_type,
-    acl: 'public-read',
-    tagging: ''
+    acl: 'public-read'
   }
 
   if content_encoding


### PR DESCRIPTION
DO does not implement tagging support for S3 objects. Removing our default
empty tag fixes compatibility.

The expire_missing_assets rake task can't be used with that service still,
but this patch allows normal operation.