### PR TITLE
FEATURE: don't display new/unread notification for muted topics

### DIFF
--- a/app/assets/javascripts/discourse/models/topic-tracking-state.js
+++ b/app/assets/javascripts/discourse/models/topic-tracking-state.js
@@ -53,11 +53,7 @@ const TopicTrackingState = EmberObject.extend({
     const tracker = this;
 
     const process = data => {
-      if (
-        tracker
-          .trackMutedTopics(data)
-          .findBy("topicId", data.topic_id)
-      ) {
+      if (tracker.trackMutedTopics(data).findBy("topicId", data.topic_id)) {
         return;
       }
 

--- a/app/assets/javascripts/discourse/models/topic-tracking-state.js
+++ b/app/assets/javascripts/discourse/models/topic-tracking-state.js
@@ -116,7 +116,6 @@ const TopicTrackingState = EmberObject.extend({
 
     this.messageBus.subscribe("/new", process);
     this.messageBus.subscribe("/latest", process);
-    this.messageBus.subscribe("/muted-topics", process);
     if (this.currentUser) {
       this.messageBus.subscribe(
         "/unread/" + this.currentUser.get("id"),

--- a/app/assets/javascripts/discourse/models/topic-tracking-state.js
+++ b/app/assets/javascripts/discourse/models/topic-tracking-state.js
@@ -146,7 +146,7 @@ const TopicTrackingState = EmberObject.extend({
       return [];
     }
     let mutedTopics = this.currentUser.muted_topics || [];
-    let now = new Date();
+    let now = Date.now();
 
     if (data.message_type === "muted") {
       mutedTopics = mutedTopics.concat({

--- a/app/assets/javascripts/discourse/models/topic-tracking-state.js
+++ b/app/assets/javascripts/discourse/models/topic-tracking-state.js
@@ -56,7 +56,7 @@ const TopicTrackingState = EmberObject.extend({
       if (
         tracker
           .trackMutedTopics(data)
-          .find(mutedTopic => mutedTopic.topicId === data.topic_id)
+          .findBy("topicId", data.topic_id)
       ) {
         return;
       }

--- a/app/assets/javascripts/discourse/models/topic-tracking-state.js
+++ b/app/assets/javascripts/discourse/models/topic-tracking-state.js
@@ -116,13 +116,10 @@ const TopicTrackingState = EmberObject.extend({
 
     this.messageBus.subscribe("/new", process);
     this.messageBus.subscribe("/latest", process);
+    this.messageBus.subscribe("/muted-topics", process);
     if (this.currentUser) {
       this.messageBus.subscribe(
         "/unread/" + this.currentUser.get("id"),
-        process
-      );
-      this.messageBus.subscribe(
-        "/muted/" + this.currentUser.get("id"),
         process
       );
     }

--- a/app/models/topic_tracking_state.rb
+++ b/app/models/topic_tracking_state.rb
@@ -72,18 +72,13 @@ class TopicTrackingState
     "/unread/#{user_id}"
   end
 
-  def self.muted_channel_key(user_id)
-    "/muted/#{user_id}"
-  end
-
   def self.publish_muted(post)
-    post.topic.topic_users.where(notification_level: NotificationLevels.all[:muted]).order(notifications_changed_at: :desc).limit(100).pluck(:user_id).each do |user_id|
-      message = {
-        topic_id: post.topic_id,
-        message_type: MUTED_MESSAGE_TYPE,
-      }
-      MessageBus.publish(self.muted_channel_key(user_id), message.as_json)
-    end
+    user_ids = post.topic.topic_users.where(notification_level: NotificationLevels.all[:muted]).order(notifications_changed_at: :desc).limit(100).pluck(:user_id)
+    message = {
+      topic_id: post.topic_id,
+      message_type: MUTED_MESSAGE_TYPE,
+    }
+    MessageBus.publish("/muted-topics", message.as_json, user_ids: user_ids) if user_ids.present?
   end
 
   def self.publish_unread(post)

--- a/app/models/topic_tracking_state.rb
+++ b/app/models/topic_tracking_state.rb
@@ -85,7 +85,7 @@ class TopicTrackingState
       topic_id: post.topic_id,
       message_type: MUTED_MESSAGE_TYPE,
     }
-    MessageBus.publish("/muted-topics", message.as_json, user_ids: user_ids)
+    MessageBus.publish("/latest", message.as_json, user_ids: user_ids)
   end
 
   def self.publish_unread(post)

--- a/lib/post_jobs_enqueuer.rb
+++ b/lib/post_jobs_enqueuer.rb
@@ -57,7 +57,10 @@ class PostJobsEnqueuer
   end
 
   def after_post_create
-    TopicTrackingState.publish_unread(@post) if @post.post_number > 1
+    if @post.post_number > 1
+      TopicTrackingState.publish_muted(@post)
+      TopicTrackingState.publish_unread(@post)
+    end
     TopicTrackingState.publish_latest(@topic, @post.whisper?)
 
     Jobs.enqueue_in(SiteSetting.email_time_window_mins.minutes,

--- a/spec/models/topic_tracking_state_spec.rb
+++ b/spec/models/topic_tracking_state_spec.rb
@@ -75,7 +75,7 @@ describe TopicTrackingState do
   describe '#publish_muted' do
     it "can correctly publish muted" do
       TopicUser.find_by(topic: post.topic, user: post.user).update(notification_level: 0)
-      message = MessageBus.track_publish(described_class.muted_channel_key(post.user.id)) do
+      message = MessageBus.track_publish("/muted-topics") do
         TopicTrackingState.publish_muted(post)
       end.first
 
@@ -86,7 +86,7 @@ describe TopicTrackingState do
     end
 
     it 'should not publish any message when notification level is not muted' do
-      messages = MessageBus.track_publish(described_class.muted_channel_key(post.user.id)) do
+      messages = MessageBus.track_publish("/muted-topics") do
         TopicTrackingState.publish_muted(post)
       end
 

--- a/spec/models/topic_tracking_state_spec.rb
+++ b/spec/models/topic_tracking_state_spec.rb
@@ -72,6 +72,28 @@ describe TopicTrackingState do
     end
   end
 
+  describe '#publish_muted' do
+    it "can correctly publish muted" do
+      TopicUser.find_by(topic: post.topic, user: post.user).update(notification_level: 0)
+      message = MessageBus.track_publish(described_class.muted_channel_key(post.user.id)) do
+        TopicTrackingState.publish_muted(post)
+      end.first
+
+      data = message.data
+
+      expect(data["topic_id"]).to eq(topic.id)
+      expect(data["message_type"]).to eq(described_class::MUTED_MESSAGE_TYPE)
+    end
+
+    it 'should not publish any message when notification level is not muted' do
+      messages = MessageBus.track_publish(described_class.muted_channel_key(post.user.id)) do
+        TopicTrackingState.publish_muted(post)
+      end
+
+      expect(messages).to eq([])
+    end
+  end
+
   describe '#publish_private_message' do
     fab!(:admin) { Fabricate(:admin) }
 

--- a/test/javascripts/models/topic-tracking-state-test.js
+++ b/test/javascripts/models/topic-tracking-state-test.js
@@ -186,22 +186,13 @@ QUnit.test("mute topic", function(assert) {
 
   const state = TopicTrackingState.create({ currentUser });
 
-  state.trackMutedTopics({
-    message_type: "muted",
-    topic_id: 1
-  });
+  state.trackMutedTopic(1);
   assert.equal(currentUser.muted_topics[0].topicId, 1);
 
-  state.trackMutedTopics({
-    message_type: "latest",
-    topic_id: 1
-  });
-  assert.equal(currentUser.muted_topics.length, 1);
+  state.pruneOldMutedTopics();
+  assert.equal(state.isMutedTopic(1), true);
 
   this.clock.tick(60000);
-  state.trackMutedTopics({
-    message_type: "latest",
-    topic_id: 1
-  });
-  assert.equal(currentUser.muted_topics.length, 0);
+  state.pruneOldMutedTopics();
+  assert.equal(state.isMutedTopic(1), false);
 });

--- a/test/javascripts/models/topic-tracking-state-test.js
+++ b/test/javascripts/models/topic-tracking-state-test.js
@@ -2,8 +2,17 @@ import TopicTrackingState from "discourse/models/topic-tracking-state";
 import createStore from "helpers/create-store";
 import Category from "discourse/models/category";
 import { NotificationLevels } from "discourse/lib/notification-levels";
+import User from "discourse/models/user";
 
-QUnit.module("model:topic-tracking-state");
+QUnit.module("model:topic-tracking-state", {
+  beforeEach() {
+    this.clock = sinon.useFakeTimers(new Date(2012, 11, 31, 12, 0).getTime());
+  },
+
+  afterEach() {
+    this.clock.restore();
+  }
+});
 
 QUnit.test("sync", function(assert) {
   const state = TopicTrackingState.create();
@@ -167,4 +176,32 @@ QUnit.test("countNew", assert => {
   assert.equal(state.countNew(1), 3);
   assert.equal(state.countNew(2), 2);
   assert.equal(state.countNew(3), 1);
+});
+
+QUnit.test("mute topic", function(assert) {
+  let currentUser = User.create({
+    username: "chuck",
+    muted_category_ids: []
+  });
+
+  const state = TopicTrackingState.create({ currentUser });
+
+  state.trackMutedTopics({
+    message_type: "muted",
+    topic_id: 1
+  });
+  assert.equal(currentUser.muted_topics[0].topicId, 1);
+
+  state.trackMutedTopics({
+    message_type: "latest",
+    topic_id: 1
+  });
+  assert.equal(currentUser.muted_topics.length, 1);
+
+  this.clock.tick(60000);
+  state.trackMutedTopics({
+    message_type: "latest",
+    topic_id: 1
+  });
+  assert.equal(currentUser.muted_topics.length, 0);
 });


### PR DESCRIPTION
Currently, even if user mute topic, when a new reply to that topic arrives, the user will get "See 1 new or updated topic" message. After clicking on that link, nothing is visible (because the topic is muted)

To solve that problem, we will send background message to all users who recently muted that topic that update is coming and they can ignore the next message about that topic.