### PR TITLE
FIX: Only confirm bookmark delete if a reminder has been set

### DIFF
--- a/app/assets/javascripts/discourse/controllers/bookmark.js
+++ b/app/assets/javascripts/discourse/controllers/bookmark.js
@@ -436,17 +436,25 @@ export default Controller.extend(ModalFunctionality, {
 
     delete() {
       this._deleting = true;
-      bootbox.confirm(I18n.t("bookmarks.confirm_delete"), result => {
-        if (result) {
-          this._closeWithoutSaving = true;
-          this._deleteBookmark()
-            .then(() => {
-              this._deleting = false;
-              this.send("closeModal");
-            })
-            .catch(e => this._handleSaveError(e));
-        }
-      });
+      let deleteAction = () => {
+        this._closeWithoutSaving = true;
+        this._deleteBookmark()
+          .then(() => {
+            this._deleting = false;
+            this.send("closeModal");
+          })
+          .catch(e => this._handleSaveError(e));
+      };
+
+      if (this._existingBookmarkHasReminder()) {
+        bootbox.confirm(I18n.t("bookmarks.confirm_delete"), result => {
+          if (result) {
+            deleteAction();
+          }
+        });
+      } else {
+        deleteAction();
+      }
     },
 
     closeWithoutSavingBookmark() {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -312,7 +312,7 @@ en:
       created_with_at_desktop_reminder: "you've bookmarked this post and will be reminded next time you are at your desktop"
       remove: "Remove Bookmark"
       delete: "Delete Bookmark"
-      confirm_delete: "Are you sure you want to delete this bookmark? If you set a reminder it will also be deleted."
+      confirm_delete: "Are you sure you want to delete this bookmark? The reminder will also be deleted."
       confirm_clear: "Are you sure you want to clear all your bookmarks from this topic?"
       save: "Save"
       no_timezone: 'You have not set a timezone yet. You will not be able to set reminders. Set one up <a href="%{basePath}/my/preferences/profile">in your profile</a>.'


### PR DESCRIPTION
We do not need a secondary bootbox confirm if the bookmark has no reminder, because nothing really will be lost in that case.