### PR TITLE
FIX: Improve selector for copy codeblock button

### DIFF
--- a/app/assets/javascripts/discourse/initializers/copy-codeblocks.js
+++ b/app/assets/javascripts/discourse/initializers/copy-codeblocks.js
@@ -114,7 +114,7 @@ export default {
         }
 
         const commands = postElements[0].querySelectorAll(
-          ":scope > pre > code"
+          ":scope > pre > code, :scope :not(article) > pre > code"
         );
 
         const post = helper.getModel();


### PR DESCRIPTION
Previous selector implementation was not accounting for codeblocks in
nested elements, like lists.