### PR TITLE
FIX: properly add 'two-rows' class to header-topic-info container

### DIFF
--- a/app/assets/javascripts/discourse/widgets/header-topic-info.js
+++ b/app/assets/javascripts/discourse/widgets/header-topic-info.js
@@ -56,9 +56,12 @@ createWidget("topic-header-participant", {
 
 export default createWidget("header-topic-info", {
   tagName: "div.extra-info-wrapper",
+  contents: null,
+  title: null,
 
-  buildClasses(attrs) {
-    return this.showCategory(attrs.topic) ? "two-rows" : "";
+  buildClasses(attrs, state) {
+    this.buildAttributes(attrs, state);
+    return this.containerClassName();
   },
 
   buildFancyTitleClass() {
@@ -73,7 +76,7 @@ export default createWidget("header-topic-info", {
       .join(" ");
   },
 
-  html(attrs, state) {
+  buildAttributes(attrs, state) {
     const topic = attrs.topic;
 
     const heading = [];
@@ -112,7 +115,7 @@ export default createWidget("header-topic-info", {
       );
     }
 
-    const title = [h("h1.header-title", heading)];
+    this.title = [h("h1.header-title", heading)];
     const category = topic.get("category");
 
     if (loaded || category) {
@@ -126,7 +129,7 @@ export default createWidget("header-topic-info", {
         }
         categories.push(this.attach("category-link", { category }));
 
-        title.push(h("div.categories-wrapper", categories));
+        this.title.push(h("div.categories-wrapper", categories));
       }
 
       let extra = [];
@@ -196,16 +199,23 @@ export default createWidget("header-topic-info", {
         }
       }
       if (extra.length) {
-        title.push(h("div.topic-header-extra", extra));
+        this.title.push(h("div.topic-header-extra", extra));
       }
     }
 
-    const contents = h("div.title-wrapper", title);
+    this.contents = h("div.title-wrapper", this.title);
+  },
+
+  html(attrs, state) {
     return h(
       "div.extra-info",
-      { className: title.length > 1 ? "two-rows" : "" },
-      contents
+      { className: this.containerClassName() },
+      this.contents
     );
+  },
+
+  containerClassName() {
+    return this.title.length > 1 ? "two-rows" : "";
   },
 
   showCategory(topic) {

--- a/app/assets/javascripts/discourse/widgets/header-topic-info.js
+++ b/app/assets/javascripts/discourse/widgets/header-topic-info.js
@@ -206,7 +206,7 @@ export default createWidget("header-topic-info", {
     this.contents = h("div.title-wrapper", this.title);
   },
 
-  html(attrs, state) {
+  html() {
     return h(
       "div.extra-info",
       { className: this.containerClassName() },

--- a/app/assets/javascripts/discourse/widgets/header-topic-info.js
+++ b/app/assets/javascripts/discourse/widgets/header-topic-info.js
@@ -119,7 +119,11 @@ export default createWidget("header-topic-info", {
     const category = topic.get("category");
 
     if (loaded || category) {
-      if (this.showCategory(topic)) {
+      if (
+        category &&
+        (!category.isUncategorizedCategory ||
+          !this.siteSettings.suppress_uncategorized_badge)
+      ) {
         const parentCategory = category.get("parentCategory");
         const categories = [];
         if (parentCategory) {
@@ -216,14 +220,6 @@ export default createWidget("header-topic-info", {
 
   containerClassName() {
     return this.title.length > 1 ? "two-rows" : "";
-  },
-
-  showCategory(topic) {
-    return (
-      topic.category &&
-      (!topic.category.isUncategorizedCategory ||
-        !this.siteSettings.suppress_uncategorized_badge)
-    );
   },
 
   jumpToTopPost() {


### PR DESCRIPTION
In this commit https://github.com/discourse/discourse/commit/e5233f5ce69acc5ecc5edf29fe692d29e73703f2, I used incorrect logic to add the "two-rows" class to the container of the `header-topic-info` widget. I was just checking for a category, but many other variables need to be taken into account, which previously happened in the `html` function.

This change re-arranges some logic, so that the title/contents of the widget are set before `buildClasses` returns, so they can be used to calculate the needed className. Then in `html()`, the variables are accessed using `this`.:

The change felt big locally, but it is funny how tiny the diff is.


