### PR TITLE
DEV: Export openNewCategoryModal from discovery-categories

### DIFF
--- a/app/assets/javascripts/discourse/routes/discovery-categories.js
+++ b/app/assets/javascripts/discourse/routes/discovery-categories.js
@@ -133,7 +133,7 @@ const DiscoveryCategoriesRoute = DiscourseRoute.extend(OpenComposer, {
   }
 });
 
-export const openNewCategoryModal = context => {
+export function openNewCategoryModal(context) {
   const groups = context.site.groups,
     everyoneName = groups.findBy("id", 0).name;
 
@@ -149,6 +149,6 @@ export const openNewCategoryModal = context => {
   });
 
   showModal("edit-category", { model }).set("selectedTab", "general");
-};
+}
 
 export default DiscoveryCategoriesRoute;

--- a/app/assets/javascripts/discourse/routes/discovery-categories.js
+++ b/app/assets/javascripts/discourse/routes/discovery-categories.js
@@ -110,22 +110,7 @@ const DiscoveryCategoriesRoute = DiscourseRoute.extend(OpenComposer, {
     },
 
     createCategory() {
-      const groups = this.site.groups,
-        everyoneName = groups.findBy("id", 0).name;
-
-      const model = this.store.createRecord("category", {
-        color: "0088CC",
-        text_color: "FFFFFF",
-        group_permissions: [{ group_name: everyoneName, permission_type: 1 }],
-        available_groups: groups.map(g => g.name),
-        allow_badges: true,
-        topic_featured_link_allowed: true,
-        custom_fields: {},
-        search_priority: searchPriorities.normal
-      });
-
-      showModal("edit-category", { model });
-      this.controllerFor("edit-category").set("selectedTab", "general");
+      openNewCategoryModal(this);
     },
 
     reorderCategories() {
@@ -147,5 +132,23 @@ const DiscoveryCategoriesRoute = DiscourseRoute.extend(OpenComposer, {
     }
   }
 });
+
+export const openNewCategoryModal = context => {
+  const groups = context.site.groups,
+    everyoneName = groups.findBy("id", 0).name;
+
+  const model = context.store.createRecord("category", {
+    color: "0088CC",
+    text_color: "FFFFFF",
+    group_permissions: [{ group_name: everyoneName, permission_type: 1 }],
+    available_groups: groups.map(g => g.name),
+    allow_badges: true,
+    topic_featured_link_allowed: true,
+    custom_fields: {},
+    search_priority: searchPriorities.normal
+  });
+
+  showModal("edit-category", { model }).set("selectedTab", "general");
+};
 
 export default DiscoveryCategoriesRoute;


### PR DESCRIPTION
Exporting this function allows plugins to be able to open the "Create Category" modal, without repeating any code.