### PR TITLE
FIX: If bookmarking discobot posts, skip the reminder modal

### DIFF
--- a/app/assets/javascripts/discourse/models/post.js
+++ b/app/assets/javascripts/discourse/models/post.js
@@ -336,20 +336,6 @@ const Post = RestModel.extend({
   },
 
   toggleBookmarkWithReminder() {
-    // if we are talking to discobot then any bookmarks should just
-    // be created without reminder options, to streamline the new user
-    // narrative.
-    if (this.username === "discobot" && !this.bookmarked_with_reminder) {
-      return ajax("/bookmarks", { type: "POST", data: { post_id: this.id } }).then((response) => {
-        this.setProperties({
-          "topic.bookmarked": true,
-          bookmarked_with_reminder: true,
-          bookmark_id: response.id
-        });
-        this.appEvents.trigger("post-stream:refresh", { id: this.id });
-      });
-    }
-
     return new Promise(resolve => {
       let controller = showModal("bookmark", {
         model: {

--- a/app/assets/javascripts/discourse/models/post.js
+++ b/app/assets/javascripts/discourse/models/post.js
@@ -336,6 +336,20 @@ const Post = RestModel.extend({
   },
 
   toggleBookmarkWithReminder() {
+    // if we are talking to discobot then any bookmarks should just
+    // be created without reminder options, to streamline the new user
+    // narrative.
+    if (this.username === "discobot" && !this.bookmarked_with_reminder) {
+      return ajax("/bookmarks", { type: "POST", data: { post_id: this.id } }).then((response) => {
+        this.setProperties({
+          "topic.bookmarked": true,
+          bookmarked_with_reminder: true,
+          bookmark_id: response.id
+        });
+        this.appEvents.trigger("post-stream:refresh", { id: this.id });
+      });
+    }
+
     return new Promise(resolve => {
       let controller = showModal("bookmark", {
         model: {

--- a/plugins/discourse-narrative-bot/assets/javascripts/initializers/new-user-narrative.js.es6
+++ b/plugins/discourse-narrative-bot/assets/javascripts/initializers/new-user-narrative.js.es6
@@ -19,7 +19,10 @@ function initialize(api) {
       // be created without reminder options, to streamline the new user
       // narrative.
       if (this.username === "discobot" && !this.bookmarked_with_reminder) {
-        return ajax("/bookmarks", { type: "POST", data: { post_id: this.id } }).then((response) => {
+        return ajax("/bookmarks", {
+          type: "POST",
+          data: { post_id: this.id }
+        }).then(response => {
           this.setProperties({
             "topic.bookmarked": true,
             bookmarked_with_reminder: true,

--- a/plugins/discourse-narrative-bot/assets/javascripts/initializers/new-user-narrative.js.es6
+++ b/plugins/discourse-narrative-bot/assets/javascripts/initializers/new-user-narrative.js.es6
@@ -1,4 +1,5 @@
 import { withPluginApi } from "discourse/lib/plugin-api";
+import { ajax } from "discourse/lib/ajax";
 
 function initialize(api) {
   const messageBus = api.container.lookup("message-bus:main");
@@ -9,6 +10,25 @@ function initialize(api) {
     didInsertElement() {
       this._super(...arguments);
       this.dispatch("header:search-context-trigger", "header");
+    }
+  });
+
+  api.modifyClass("model:post", {
+    toggleBookmarkWithReminder() {
+      // if we are talking to discobot then any bookmarks should just
+      // be created without reminder options, to streamline the new user
+      // narrative.
+      if (this.username === "discobot" && !this.bookmarked_with_reminder) {
+        return ajax("/bookmarks", { type: "POST", data: { post_id: this.id } }).then((response) => {
+          this.setProperties({
+            "topic.bookmarked": true,
+            bookmarked_with_reminder: true,
+            bookmark_id: response.id
+          });
+          this.appEvents.trigger("post-stream:refresh", { id: this.id });
+        });
+      }
+      this._super();
     }
   });
 

--- a/plugins/discourse-narrative-bot/assets/javascripts/initializers/new-user-narrative.js.es6
+++ b/plugins/discourse-narrative-bot/assets/javascripts/initializers/new-user-narrative.js.es6
@@ -18,7 +18,8 @@ function initialize(api) {
       // if we are talking to discobot then any bookmarks should just
       // be created without reminder options, to streamline the new user
       // narrative.
-      if (this.username === "discobot" && !this.bookmarked_with_reminder) {
+      const discobotUserId = -2;
+      if (this.user_id === discobotUserId && !this.bookmarked_with_reminder) {
         return ajax("/bookmarks", {
           type: "POST",
           data: { post_id: this.id }

--- a/plugins/discourse-narrative-bot/config/locales/server.en.yml
+++ b/plugins/discourse-narrative-bot/config/locales/server.en.yml
@@ -242,7 +242,7 @@ en:
 
       bookmark:
         instructions: |-
-          If you’d like to learn more, select <img src="%{base_uri}/plugins/discourse-narrative-bot/images/font-awesome-ellipsis.png" width="16" height="16"> below and <img src="%{base_uri}/plugins/discourse-narrative-bot/images/font-awesome-bookmark.png" width="16" height="16"> **bookmark this personal message** selecting "no reminder needed". If you do, there may be a :gift: in your future!
+          If you’d like to learn more, select <img src="%{base_uri}/plugins/discourse-narrative-bot/images/font-awesome-ellipsis.png" width="16" height="16"> below and <img src="%{base_uri}/plugins/discourse-narrative-bot/images/font-awesome-bookmark.png" width="16" height="16"> **bookmark this personal message**. If you do, there may be a :gift: in your future!
         reply: |-
           Excellent! Now you can easily find your way back to our private conversation any time, right from [the bookmarks tab on your profile](%{bookmark_url}). Just select your profile picture at the upper right &#8599;
         not_found: |-


### PR DESCRIPTION
This is to streamline the new user narrative. only works when creating the bookmark, if editing/deleting the modal is shown.