### PR TITLE
FIX: composer problem on the categories page

### DIFF
--- a/app/serializers/topic_list_item_serializer.rb
+++ b/app/serializers/topic_list_item_serializer.rb
@@ -21,7 +21,7 @@ class TopicListItemSerializer < ListableTopicSerializer
   has_many :participants, serializer: TopicPosterSerializer, embed: :objects
 
   def posters
-    object.posters || []
+    object.posters || object.posters_summary || []
   end
 
   def op_like_count

--- a/spec/serializers/topic_list_item_serializer_spec.rb
+++ b/spec/serializers/topic_list_item_serializer_spec.rb
@@ -83,5 +83,15 @@ describe TopicListItemSerializer do
 
       expect(json[:tags]).to eq([])
     end
+
+    it 'return posters' do
+      json = TopicListItemSerializer.new(topic,
+        scope: Guardian.new(user),
+        hidden_tag_names: [hidden_tag.name],
+        root: false
+      ).as_json
+
+      expect(json[:posters].length).to eq(1)
+    end
   end
 end


### PR DESCRIPTION
When the user is on `/categories` page and tries to create a new topic, an error is raised.

Problem is that on categories we are using `topics.posters` to display avatars. https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/models/topic.js#L59:L74

Then, when the user is trying to compose a new topic, we are sending a query to get similar topics
https://github.com/discourse/discourse/blob/master/app/controllers/similar_topics_controller.rb#L25:L27

Serializer is trying to add `posters` but in the end, it is an empty array -
https://github.com/discourse/discourse/blob/master/app/serializers/topic_list_item_serializer.rb#L23:L25

Reason for that is that `posters` is just accessor https://github.com/discourse/discourse/blob/master/app/models/topic.rb#L143

That accessor is populated when topics are received using topics query https://github.com/discourse/discourse/blob/3d9c320aabd54c3cce1bb4e9f29769f0d7c4c9ab/lib/topic_query.rb#L441:L447

However, when we are looking for similar topics, `posters` field is not populated and avatars are crashing on `/categories` page.

The solution is to fall back to `posters_summary`