### PR TITLE
FEATURE: add class to <aside> quote block when quoting an ignored user

### DIFF
--- a/app/assets/javascripts/discourse/widgets/post-cooked.js
+++ b/app/assets/javascripts/discourse/widgets/post-cooked.js
@@ -241,7 +241,7 @@ export default class PostCooked {
         .slice(0, -1);
       if (username.length > 0 && this.ignoredUsers.includes(username)) {
         $aside.find("p").remove();
-        $aside.addClass('ignored-user');
+        $aside.addClass("ignored-user");
       }
     }
     $(".quote-controls", $aside).html(expandContract + navLink);

--- a/app/assets/javascripts/discourse/widgets/post-cooked.js
+++ b/app/assets/javascripts/discourse/widgets/post-cooked.js
@@ -241,6 +241,7 @@ export default class PostCooked {
         .slice(0, -1);
       if (username.length > 0 && this.ignoredUsers.includes(username)) {
         $aside.find("p").remove();
+        $aside.addClass('ignored-user');
       }
     }
     $(".quote-controls", $aside).html(expandContract + navLink);


### PR DESCRIPTION
Adds the class 'ignored-user' to the `<aside>` quote block, when we are looking at a quote from an ignored user.

Per https://meta.discourse.org/t/tiny-feature-request-for-core-add-3-classes/148725
