### PR TITLE
FIX: Copy button was displayed on quoted codeblock

### DIFF
--- a/app/assets/javascripts/discourse/initializers/copy-codeblocks.js
+++ b/app/assets/javascripts/discourse/initializers/copy-codeblocks.js
@@ -114,7 +114,7 @@ export default {
         }
 
         const commands = postElements[0].querySelectorAll(
-          ":scope > pre > code, :scope :not(article) > pre > code"
+          ":scope > pre > code, :scope :not(article):not(blockquote) > pre > code"
         );
 
         const post = helper.getModel();


### PR DESCRIPTION
This removes an edge case where copy buttons were displayed on a quoted codeblock.