### PR TITLE
FIX: Apply category priority for empty query

### DIFF
--- a/lib/search.rb
+++ b/lib/search.rb
@@ -904,12 +904,36 @@ class Search
         posts = categories_ignored(posts) unless @category_filter_matched
         posts
       end
-
-    if @order == :latest || (@term.blank? && !@order)
+    if @order == :latest
       if opts[:aggregate_search]
         posts = posts.order("MAX(posts.created_at) DESC")
       else
         posts = posts.reorder("posts.created_at DESC")
+      end
+    elsif @term.blank? && !@order
+      data_ranking = <<~SQL
+      (
+        CASE categories.search_priority
+        WHEN #{Searchable::PRIORITIES[:very_low]}
+        THEN #{SiteSetting.category_search_priority_very_low_weight}
+        WHEN #{Searchable::PRIORITIES[:low]}
+        THEN #{SiteSetting.category_search_priority_low_weight}
+        WHEN #{Searchable::PRIORITIES[:high]}
+        THEN #{SiteSetting.category_search_priority_high_weight}
+        WHEN #{Searchable::PRIORITIES[:very_high]}
+        THEN #{SiteSetting.category_search_priority_very_high_weight}
+        ELSE
+          CASE WHEN topics.closed
+          THEN 0.9
+          ELSE 1
+          END
+        END
+      )
+      SQL
+      if opts[:aggregate_search]
+        posts = posts.order("MAX(#{data_ranking}) DESC").order("MAX(posts.created_at) DESC")
+      else
+        posts = posts.order("#{data_ranking} DESC").order("posts.created_at DESC")
       end
     elsif @order == :latest_topic
       if opts[:aggregate_search]


### PR DESCRIPTION
This PR is to apply category search priority when searching with empty query without specified order.

Per [https://meta.discourse.org/t/search-priority-for-categories-dont-work-with-empty-search-query/143642](https://meta.discourse.org/t/search-priority-for-categories-dont-work-with-empty-search-query/143642)