### PR TITLE
DEV: DiscourseEvents fired when users are added/removed from groups

### DIFF
--- a/app/services/group_action_logger.rb
+++ b/app/services/group_action_logger.rb
@@ -28,6 +28,7 @@ class GroupActionLogger
   def log_add_user_to_group(target_user)
     (target_user == @acting_user && @group.public_admission) || can_edit?
 
+    DiscourseEvent.trigger(:user_added_to_group, target_user, @group)
     GroupHistory.create!(default_params.merge(
       action: GroupHistory.actions[:add_user_to_group],
       target_user: target_user
@@ -37,6 +38,7 @@ class GroupActionLogger
   def log_remove_user_from_group(target_user)
     (target_user == @acting_user && @group.public_exit) || can_edit?
 
+    DiscourseEvent.trigger(:user_removed_from_group, target_user, @group)
     GroupHistory.create!(default_params.merge(
       action: GroupHistory.actions[:remove_user_from_group],
       target_user: target_user


### PR DESCRIPTION
These are generally useful hooks that plugins for centuries to come will likely hook into.

There could also be put into `GroupHistory` and fired whenever a GroupHistory record is created. I thought 'GroupActionLogger' sounded like a proper place though.