### PR TITLE
FIX: Do not set title attribute on header-topic-info widget

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/header-topic-info.js
+++ b/app/assets/javascripts/discourse/app/widgets/header-topic-info.js
@@ -115,7 +115,7 @@ export default createWidget("header-topic-info", {
       );
     }
 
-    this.title = [h("h1.header-title", heading)];
+    this.headerElements = [h("h1.header-title", heading)];
     const category = topic.get("category");
 
     if (loaded || category) {
@@ -133,7 +133,7 @@ export default createWidget("header-topic-info", {
         }
         categories.push(this.attach("category-link", { category }));
 
-        this.title.push(h("div.categories-wrapper", categories));
+        this.headerElements.push(h("div.categories-wrapper", categories));
       }
 
       let extra = [];
@@ -203,11 +203,10 @@ export default createWidget("header-topic-info", {
         }
       }
       if (extra.length) {
-        this.title.push(h("div.topic-header-extra", extra));
+        this.headerElements.push(h("div.topic-header-extra", extra));
       }
     }
-
-    this.contents = h("div.title-wrapper", this.title);
+    this.contents = h("div.title-wrapper", this.headerElements);
   },
 
   html() {
@@ -219,7 +218,7 @@ export default createWidget("header-topic-info", {
   },
 
   containerClassName() {
-    return this.title.length > 1 ? "two-rows" : "";
+    return this.headerElements.length > 1 ? "two-rows" : "";
   },
 
   jumpToTopPost() {


### PR DESCRIPTION
Before, setting `this.title` was setting the DOM title attribute like so

![Screenshot from 2020-04-23 12-06-58](https://user-images.githubusercontent.com/16214023/80128326-1b9ccb00-855b-11ea-8eef-5ea92c6b9710.png)

This renaming of the variables solves that issue, while being a more accurate name.