### PR TITLE
DEV: Add jquery-free `decorateCookedElement` function to plugin api

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-editor.js
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.js
@@ -1019,7 +1019,7 @@ export default Component.extend({
 
       this._registerImageScaleButtonClick($preview);
 
-      this.trigger("previewRefreshed", $preview);
+      this.trigger("previewRefreshed", $preview[0]);
       this.afterRefresh($preview);
     }
   }

--- a/app/assets/javascripts/discourse/app/lib/lazy-load-images.js
+++ b/app/assets/javascripts/discourse/app/lib/lazy-load-images.js
@@ -84,8 +84,8 @@ function show(image) {
   }
 }
 
-function forEachImage($post, callback) {
-  $post[0].querySelectorAll("img").forEach(img => {
+function forEachImage(post, callback) {
+  post.querySelectorAll("img").forEach(img => {
     if (img.width >= MINIMUM_SIZE && img.height >= MINIMUM_SIZE) {
       callback(img);
     }
@@ -104,7 +104,7 @@ export function setupLazyLoading(api) {
     });
   }, OBSERVER_OPTIONS);
 
-  api.decorateCooked($post => forEachImage($post, img => hide(img)), {
+  api.decorateCookedElement(post => forEachImage(post, img => hide(img)), {
     onlyStream: true,
     id: "discourse-lazy-load"
   });
@@ -112,8 +112,8 @@ export function setupLazyLoading(api) {
   // IntersectionObserver.observe must be called after the cooked
   // content is adopted by the document element in chrome
   // https://bugs.chromium.org/p/chromium/issues/detail?id=1073469
-  api.decorateCooked(
-    $post => forEachImage($post, img => observer.observe(img)),
+  api.decorateCookedElement(
+    post => forEachImage(post, img => observer.observe(img)),
     {
       onlyStream: true,
       id: "discourse-lazy-load-after-adopt",

--- a/app/assets/javascripts/discourse/app/widgets/post-cooked.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-cooked.js
@@ -11,7 +11,7 @@ import {
 let _beforeAdoptDecorators = [];
 let _afterAdoptDecorators = [];
 
-// Don't call this directly: use `plugin-api/decorateCooked`
+// Don't call this directly: use `plugin-api/decorateCookedElement`
 export function addDecorator(callback, { afterAdopt = false } = {}) {
   if (afterAdopt) {
     _afterAdoptDecorators.push(callback);
@@ -67,13 +67,11 @@ export default class PostCooked {
   }
 
   _decorateAndAdopt(cooked) {
-    const $cooked = $(cooked);
-
-    _beforeAdoptDecorators.forEach(d => d($cooked, this.decoratorHelper));
+    _beforeAdoptDecorators.forEach(d => d(cooked, this.decoratorHelper));
 
     document.adoptNode(cooked);
 
-    _afterAdoptDecorators.forEach(d => d($cooked, this.decoratorHelper));
+    _afterAdoptDecorators.forEach(d => d(cooked, this.decoratorHelper));
   }
 
   _applySearchHighlight($html) {


### PR DESCRIPTION
This is a replacement for `decorateCooked` which will work without jquery.

A backwards compatibility layer is provided for existing plugins/themes which are currently using `decorateCooked`

We should make sure we are 100% happy with the naming here, because it will be very difficult to change in future