### PR TITLE
FIX: reenable draft check modal and fix focus on iOS for PMs

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -70,7 +70,7 @@ function loadDraft(store, opts) {
 
 const _popupMenuOptionsCallbacks = [];
 
-let _checkDraftPopup = !ENV.environment === "test";
+let _checkDraftPopup = ENV.environment !== "test";
 
 export function toggleCheckDraftPopup(enabled) {
   _checkDraftPopup = enabled;

--- a/app/assets/javascripts/discourse/app/routes/application.js
+++ b/app/assets/javascripts/discourse/app/routes/application.js
@@ -85,6 +85,7 @@ const ApplicationRoute = DiscourseRoute.extend(OpenComposer, {
         recipients,
         archetypeId: "private_message",
         draftKey: Composer.NEW_PRIVATE_MESSAGE_KEY,
+        draftSequence: 0,
         reply,
         title
       });

--- a/app/assets/javascripts/discourse/app/templates/components/composer-user-selector.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/composer-user-selector.hbs
@@ -10,6 +10,7 @@
     hasGroups=hasGroups
     allowEmails="true"
     autocomplete="discourse"
+    canReceiveUpdates=true
   }}
 {{else}}
   <a href {{action "toggleSelector"}}>


### PR DESCRIPTION
On iOS, checking for an existing draft synchronously gets in the way of setting focus to the composer. This PR switches to async checking. 

While working on this, I also noticed a typo that disabled draft popups in all environments.