### PR TITLE
FIX: Do not save bookmark if close (X) on modal is clicked

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-modal.js
+++ b/app/assets/javascripts/discourse/app/components/d-modal.js
@@ -76,10 +76,10 @@ export default Component.extend({
       $target.hasClass("modal-middle-container") ||
       $target.hasClass("modal-outer-container")
     ) {
-      // Delegate click to modal close if clicked outside.
-      // We do this because some CSS of ours seems to cover
-      // the backdrop and makes it unclickable.
-      $(".modal-header button.modal-close").click();
+      // Send modal close (which bubbles to ApplicationRoute) if clicked outside.
+      // We do this because some CSS of ours seems to cover the backdrop and makes
+      // it unclickable.
+      return this.sendAction("closeModal", "initiatedByClickOut");
     }
   },
 

--- a/app/assets/javascripts/discourse/app/components/d-modal.js
+++ b/app/assets/javascripts/discourse/app/components/d-modal.js
@@ -79,7 +79,9 @@ export default Component.extend({
       // Send modal close (which bubbles to ApplicationRoute) if clicked outside.
       // We do this because some CSS of ours seems to cover the backdrop and makes
       // it unclickable.
-      return this.sendAction("closeModal", "initiatedByClickOut");
+      return (
+        this.attrs.closeModal && this.attrs.closeModal("initiatedByClickOut")
+      );
     }
   },
 

--- a/app/assets/javascripts/discourse/app/controllers/bookmark.js
+++ b/app/assets/javascripts/discourse/app/controllers/bookmark.js
@@ -84,7 +84,11 @@ export default Controller.extend(ModalFunctionality, {
    * We always want to save the bookmark unless the user specifically
    * clicks the save or cancel button to mimic browser behaviour.
    */
-  onClose() {
+  onClose(opts = {}) {
+    if (opts.initiatedByCloseButton) {
+      this._closeWithoutSaving = true;
+    }
+
     this._unbindKeyboardShortcuts();
     this._restoreGlobalShortcuts();
     if (!this._closeWithoutSaving && !this._savingBookmarkManually) {

--- a/app/assets/javascripts/discourse/app/routes/application.js
+++ b/app/assets/javascripts/discourse/app/routes/application.js
@@ -154,7 +154,7 @@ const ApplicationRoute = DiscourseRoute.extend(OpenComposer, {
     },
 
     // Close the current modal, and destroy its state.
-    closeModal() {
+    closeModal(initiatedBy) {
       const route = getOwner(this).lookup("route:application");
       let modalController = route.controllerFor("modal");
       const controllerName = modalController.get("name");
@@ -177,7 +177,10 @@ const ApplicationRoute = DiscourseRoute.extend(OpenComposer, {
           `controller:${controllerName}`
         );
         if (controller && controller.onClose) {
-          controller.onClose();
+          controller.onClose({
+            initiatedByCloseButton: initiatedBy === "initiatedByCloseButton",
+            initiatedByClickOut: initiatedBy === "initiatedByClickOut"
+          });
         }
         modalController.set("name", null);
       }

--- a/app/assets/javascripts/discourse/app/templates/components/d-modal.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/d-modal.hbs
@@ -3,7 +3,7 @@
     <div class="modal-inner-container">
       <div class="modal-header">
         {{#if dismissable}}
-          {{d-button icon="times" action=(route-action "closeModal") class="btn btn-flat modal-close close" title="modal.close"}}
+          {{d-button icon="times" action=(route-action "closeModal" "initiatedByCloseButton") class="btn btn-flat modal-close close" title="modal.close"}}
         {{/if}}
 
         {{#if panels}}

--- a/app/assets/javascripts/discourse/app/templates/components/d-modal.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/d-modal.hbs
@@ -3,7 +3,7 @@
     <div class="modal-inner-container">
       <div class="modal-header">
         {{#if dismissable}}
-          {{d-button icon="times" action=(route-action "closeModal" "initiatedByCloseButton") class="btn btn-flat modal-close close" title="modal.close"}}
+          {{d-button icon="times" action=(route-action "closeModal" "initiatedByCloseButton") class="btn-flat modal-close close" title="modal.close"}}
         {{/if}}
 
         {{#if panels}}


### PR DESCRIPTION
* After this change the bookmark will still be saved if clicking out of the modal or pressing escape
* To achieve this I implemented an initiatedBy parameter for modal closing from d-modal. If clicking on the cross it is initiated by close, if clicking out of the modal it is by click out.
* These options can then be compared in controllers consuming `onClose`