### PR TITLE
FIX: improves bookmark shortcut reliability

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
+++ b/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
@@ -385,9 +385,7 @@ export default {
   },
 
   sendToTopicListItemView(action) {
-    const elem = document.querySelector(
-      "tr.selected.topic-list-item.ember-view"
-    );
+    const elem = document.querySelector("tr.selected.topic-list-item");
     if (elem) {
       const registry = this.container.lookup("-view-registry:main");
       if (registry) {

--- a/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
+++ b/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
@@ -426,11 +426,9 @@ export default {
   },
 
   sendToSelectedPost(action, elem) {
-    const container = this.container;
-
     // TODO: We should keep track of the post without a CSS class
     const selectedPost =
-      elem || document.querySelector("topic-post.selected article.boxed");
+      elem || document.querySelector(".topic-post.selected article.boxed");
 
     let selectedPostId;
     if (selectedPost) {
@@ -438,7 +436,7 @@ export default {
     }
 
     if (selectedPostId) {
-      const topicController = container.lookup("controller:topic");
+      const topicController = this.container.lookup("controller:topic");
       const post = topicController
         .get("model.postStream.posts")
         .findBy("id", selectedPostId);
@@ -447,7 +445,7 @@ export default {
 
         let actionMethod = topicController.actions[action];
         if (!actionMethod) {
-          const topicRoute = container.lookup("route:topic");
+          const topicRoute = this.container.lookup("route:topic");
           actionMethod = topicRoute.actions[action];
         }
 

--- a/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
+++ b/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
@@ -182,10 +182,14 @@ export default {
     this.sendToTopicListItemView("toggleBookmark");
   },
 
-  toggleBookmarkTopic() {
+  toggleBookmarkTopic(event) {
+    event.preventDefault();
+    event.stopPropagation();
+
     const topic = this.currentTopic();
+
     // BIG hack, need a cleaner way
-    if (topic && $(".posts-wrapper").length > 0) {
+    if (topic && document.querySelectorAll(".posts-wrapper").length) {
       this.container.lookup("controller:topic").send("toggleBookmark");
     } else {
       this.sendToTopicListItemView("toggleBookmark");
@@ -381,7 +385,9 @@ export default {
   },
 
   sendToTopicListItemView(action) {
-    const elem = $("tr.selected.topic-list-item.ember-view")[0];
+    const elem = document.querySelector(
+      "tr.selected.topic-list-item.ember-view"
+    );
     if (elem) {
       const registry = this.container.lookup("-view-registry:main");
       if (registry) {

--- a/app/assets/javascripts/discourse/app/models/topic.js
+++ b/app/assets/javascripts/discourse/app/models/topic.js
@@ -410,19 +410,22 @@ const Topic = RestModel.extend({
     const postStream = this.postStream;
     let firstPost = postStream.get("posts.firstObject");
 
-    if (firstPost.post_number === 1) {
+    if (firstPost && firstPost.post_number === 1) {
       return Promise.resolve(firstPost);
     }
 
     const postId = postStream.findPostIdForPostNumber(1);
+    if (postId) {
+      // try loading from identity map first
+      firstPost = postStream.findLoadedPost(postId);
+      if (firstPost) {
+        return Promise.resolve(firstPost);
+      }
 
-    // try loading from identity map first
-    firstPost = postStream.findLoadedPost(postId);
-    if (firstPost) {
-      return Promise.resolve(firstPost);
+      return this.postStream.loadPost(postId);
+    } else {
+      return this.postStream.loadPostByPostNumber(1);
     }
-
-    return this.postStream.loadPost(postId);
   },
 
   toggleBookmark() {


### PR DESCRIPTION
This commit reworks slightly the `toggleBookmark` and `toggleBookmarkTopic` functions.

The following cases have been identified:
- Pressing [f] (toggleBookmarkTopic)
  - a topic list item is selected, we attempt to toggle the related topic
  - a post is selected, we bookmark the current topic
  - nothing is selected, if there's a currentTopic we bookmark it

- Pressing [b] (toggleBookmark)
  - a post is selected, we bookmark it
  - a topic list item is selected, we attempt to toggle the related topic
  - nothing is selected, if there's a currentTopic we bookmark it

Note this, commit also reduces jquery usage, a bug where the [f] shortcut was propagated to the modal input, and attempts to fix a bug when bookmarking a topic list item on the front page and the firstPost couldn't be found, current repro before fix:
- navigate to /
- press [j] to select a topic list item
- press [f]
- `Uncaught TypeError: Cannot read property 'post_number' of undefined` error appears in console, the topic is not bookmarked