### PR TITLE
Upgrade message_bus to 3.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,7 +182,7 @@ GEM
       mini_mime (>= 0.1.1)
     maxminddb (0.1.22)
     memory_profiler (0.9.14)
-    message_bus (2.2.4)
+    message_bus (3.0.0)
       rack (>= 1.1.3)
     method_source (0.9.2)
     mini_mime (1.0.2)


### PR DESCRIPTION
Fixes an issue where specifying `group_ids` and `user_ids` while
publishing a message would result in an intersection between both
options.