### PR TITLE
DEV: Always use a tmp directory for storing uploads in tests

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -519,8 +519,8 @@ Discourse::Application.routes.draw do
   get "uploads/short-url/:base62(.:extension)" => "uploads#show_short", constraints: { site: /\w+/, base62: /[a-zA-Z0-9]+/, extension: /[a-z0-9\._]+/i }, as: :upload_short
   # used to download attachments
   get "uploads/:site/original/:tree:sha(.:extension)" => "uploads#show", constraints: { site: /\w+/, tree: /([a-z0-9]+\/)+/i, sha: /\h{40}/, extension: /[a-z0-9\._]+/i }
-  if Discourse.is_parallel_test?
-    get "uploads/:site/:index/original/:tree:sha(.:extension)" => "uploads#show", constraints: { site: /\w+/, index: /\d+/, tree: /([a-z0-9]+\/)+/i, sha: /\h{40}/, extension: /[a-z0-9\._]+/i }
+  if Rails.env.test?
+    get "uploads/:site/test_:index/original/:tree:sha(.:extension)" => "uploads#show", constraints: { site: /\w+/, index: /\d+/, tree: /([a-z0-9]+\/)+/i, sha: /\h{40}/, extension: /[a-z0-9\._]+/i }
   end
   # used to download attachments (old route)
   get "uploads/:site/:id/:sha" => "uploads#show", constraints: { site: /\w+/, id: /\d+/, sha: /\h{16}/, format: /.*/ }

--- a/lib/file_store/base_store.rb
+++ b/lib/file_store/base_store.rb
@@ -32,10 +32,8 @@ module FileStore
 
     def upload_path
       path = File.join("uploads", RailsMultisite::ConnectionManagement.current_db)
-      return path unless Discourse.is_parallel_test?
-
-      n = ENV['TEST_ENV_NUMBER'].presence || '1'
-      File.join(path, n)
+      return path if !Rails.env.test?
+      File.join(path, "test_#{ENV['TEST_ENV_NUMBER'].presence || '0'}")
     end
 
     def has_been_uploaded?(url)

--- a/lib/s3_helper.rb
+++ b/lib/s3_helper.rb
@@ -248,8 +248,8 @@ class S3Helper
 
   def multisite_upload_path
     path = File.join("uploads", RailsMultisite::ConnectionManagement.current_db, "/")
-    return path unless Discourse.is_parallel_test?
-    File.join(path, ENV['TEST_ENV_NUMBER'].presence || '1', "/")
+    return path if !Rails.env.test?
+    File.join(path, "test_#{ENV['TEST_ENV_NUMBER'].presence || '0'}", "/")
   end
 
   def s3_resource

--- a/spec/lib/backup_restore/uploads_restorer_spec.rb
+++ b/spec/lib/backup_restore/uploads_restorer_spec.rb
@@ -73,9 +73,7 @@ describe BackupRestore::UploadsRestorer do
   def uploads_path(database)
     path = File.join("uploads", database)
 
-    if Discourse.is_parallel_test?
-      path = File.join(path, ENV['TEST_ENV_NUMBER'].presence || '1')
-    end
+    path = File.join(path, "test_#{ENV['TEST_ENV_NUMBER'].presence || '0'}")
 
     "/#{path}/"
   end


### PR DESCRIPTION
This avoids development-mode upload files from polluting the test environment