### PR TITLE
DEV: Add has_many category_tag_stats in tag.rb

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -28,6 +28,7 @@ class Tag < ActiveRecord::Base
   has_many :topic_tags, dependent: :destroy
   has_many :topics, through: :topic_tags
 
+  has_many :category_tag_stats, dependent: :destroy
   has_many :category_tags, dependent: :destroy
   has_many :categories, through: :category_tags
 


### PR DESCRIPTION
We have the other side of this relationship already set up. 

https://github.com/discourse/discourse/blob/fb20b570577edb2d9a27079a0eb4fbb2fd1cc82b/app/models/category_tag_stat.rb#L5

This commit makes the following work:
```ruby
Tag.joins(:category_tag_stats).where("category_tag_stats.category_id = ?", category_id)
```