### PR TITLE
DEV: Trigger 'user_added_to_group' when accepting invite with groups

### DIFF
--- a/app/models/invite_redeemer.rb
+++ b/app/models/invite_redeemer.rb
@@ -124,6 +124,7 @@ InviteRedeemer = Struct.new(:invite, :username, :name, :password, :user_custom_f
     new_group_ids = invite.groups.pluck(:id) - invited_user.group_users.pluck(:group_id)
     new_group_ids.each do |id|
       invited_user.group_users.create(group_id: id)
+      DiscourseEvent.trigger(:user_added_to_group, invited_user, Group.find_by(id: id), automatic: false)
     end
   end
 


### PR DESCRIPTION
When a user accepts an invite that automatically adds them to 1 or more groups, the DiscourseEvent for `user_added_to_group` is never triggered. 

This is because the trigger is only called inside `Group#add`
https://github.com/discourse/discourse/blob/01f2819ddec1f0291cbe67bbfa76d41146a986aa/app/models/group.rb#L645

