### PR TITLE
FIX: Local time not updating between user cards

### DIFF
--- a/app/assets/javascripts/discourse/app/components/user-card-contents.js
+++ b/app/assets/javascripts/discourse/app/components/user-card-contents.js
@@ -75,9 +75,8 @@ export default Component.extend(CardContentsBase, CanCheckEmails, CleansUp, {
     return user.resolvedTimezone();
   },
 
-  @discourseComputed()
-  formattedUserLocalTime() {
-    const timezone = this.userTimezone;
+  @discourseComputed("userTimezone")
+  formattedUserLocalTime(timezone) {
     return moment.tz(timezone).format(I18n.t("dates.time_with_zone"));
   },
 

--- a/test/javascripts/acceptance/user-card-test.js
+++ b/test/javascripts/acceptance/user-card-test.js
@@ -39,6 +39,31 @@ QUnit.test("user card local time", async assert => {
     expectedTime,
     "user card contains the user's local time"
   );
+
+  cardResponse = _.clone(userFixtures["/u/charlie/card.json"]);
+  cardResponse.user.timezone = "America/New_York";
+
+  pretender.get("/u/charlie/card.json", () => [
+    200,
+    { "Content-Type": "application/json" },
+    cardResponse
+  ]);
+
+  await click("a[data-user-card=charlie]:first");
+
+  expectedTime =
+    moment
+      .tz("Australia/Brisbane")
+      .add(-14, "hours")
+      .format("hh:mm a") + " (EDT)";
+
+  assert.equal(
+    find(".user-card .local-time")
+      .text()
+      .trim(),
+    expectedTime,
+    "opening another user card updates the local time in the card (no caching)"
+  );
 });
 
 acceptance("User Card", { loggedIn: true });


### PR DESCRIPTION
The local time was not updating between user cards because the computed property was not used correctly.

There's an old saying in Tennessee — I know it's in Texas, probably in Tennessee — that says, fool me once computed properties, shame on — shame on you. Fool me — you can't get fooled again.