### PR TITLE
FIX: Remove timezone in brackets from user card

### DIFF
--- a/app/assets/javascripts/discourse/app/components/user-card-contents.js
+++ b/app/assets/javascripts/discourse/app/components/user-card-contents.js
@@ -77,7 +77,7 @@ export default Component.extend(CardContentsBase, CanCheckEmails, CleansUp, {
 
   @discourseComputed("userTimezone")
   formattedUserLocalTime(timezone) {
-    return moment.tz(timezone).format(I18n.t("dates.time_with_zone"));
+    return moment.tz(timezone).format(I18n.t("dates.time"));
   },
 
   @discourseComputed("username")

--- a/app/assets/javascripts/discourse/app/templates/components/user-card-contents.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/user-card-contents.hbs
@@ -171,7 +171,7 @@
               </span>
             {{/if}}
             {{#if showUserLocalTime}}
-              <span class="local-time">
+              <span class="local-time" title="{{i18n "local_time"}}">
                 {{d-icon "far-clock"}}
                 <span>{{this.formattedUserLocalTime}}</span>
               </span>

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1444,6 +1444,7 @@ en:
     mute: Mute
     unmute: Unmute
     last_post: Posted
+    local_time: "Local Time"
     time_read: Read
     time_read_recently: "%{time_read} recently"
     time_read_tooltip: "%{time_read} total time read"

--- a/test/javascripts/acceptance/user-card-test.js
+++ b/test/javascripts/acceptance/user-card-test.js
@@ -25,11 +25,10 @@ QUnit.test("user card local time", async assert => {
   assert.ok(invisible(".user-card"), "user card is invisible by default");
   await click("a[data-user-card=eviltrout]:first");
 
-  let expectedTime =
-    moment
-      .tz("Australia/Brisbane")
-      .add(-2, "hours")
-      .format("hh:mm a") + " (AWST)";
+  let expectedTime = moment
+    .tz("Australia/Brisbane")
+    .add(-2, "hours")
+    .format("h:mm a");
 
   assert.ok(visible(".user-card"), "card should appear");
   assert.equal(
@@ -51,11 +50,10 @@ QUnit.test("user card local time", async assert => {
 
   await click("a[data-user-card=charlie]:first");
 
-  expectedTime =
-    moment
-      .tz("Australia/Brisbane")
-      .add(-14, "hours")
-      .format("hh:mm a") + " (EDT)";
+  expectedTime = moment
+    .tz("Australia/Brisbane")
+    .add(-14, "hours")
+    .format("h:mm a");
 
   assert.equal(
     find(".user-card .local-time")


### PR DESCRIPTION
For clarity and to save space remove the timezone in brackets e.g. (EDT) from the user card. Also add a title to the user time span to say it is Local Time.

![image](https://user-images.githubusercontent.com/920448/80455391-fd760700-896e-11ea-8f2e-8654bfc5c26f.png)
