### PR TITLE
FIX: Improve clearing store cache

### DIFF
--- a/lib/file_store/base_store.rb
+++ b/lib/file_store/base_store.rb
@@ -151,22 +151,9 @@ module FileStore
       FileUtils.mkdir_p(dir) unless Dir.exist?(dir)
       FileUtils.cp(file.path, path)
 
-      # Keep latest 500 files
-      processes = Open3.pipeline(
-        ["ls -t #{CACHE_DIR}", err: "/dev/null"],
-        "tail -n +#{CACHE_MAXIMUM_SIZE + 1}",
-        "awk '$0=\"#{CACHE_DIR}\"$0'",
-        "xargs rm -f"
-      )
-
-      ls = processes.shift
-
-      # Exit status `1` in `ls` occurs when e.g. "listing a directory
-      # in which entries are actively being removed or renamed".
-      # It's safe to ignore it here.
-      if ![0, 1].include?(ls.exitstatus) || !processes.all?(&:success?)
-        raise "Error clearing old cache"
-      end
+      # Remove all but 500 most recent files
+      files = Dir.glob("#{CACHE_DIR}*").sort_by { |file| File.mtime(file) }[0...-500]
+      FileUtils.rm(files, force: true)
     end
 
     private


### PR DESCRIPTION
1. Shorter
2. Simpler
3. Doesn't depend on external binaries
4. Doesn't fail on large amounts of files
5. Hopefully eliminates flaky spec errors