### PR TITLE
FIX: published pages couldn't be routed from inside discourse

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/url.js
+++ b/app/assets/javascripts/discourse/app/lib/url.js
@@ -28,7 +28,8 @@ const SERVER_SIDE_ONLY = [
   /\.json$/,
   /^\/admin\/upgrade$/,
   /^\/logs($|\/)/,
-  /^\/admin\/logs\/watched_words\/action\/[^\/]+\/download$/
+  /^\/admin\/logs\/watched_words\/action\/[^\/]+\/download$/,
+  /^\/pub\//
 ];
 
 export function rewritePath(path) {


### PR DESCRIPTION
This will allow to post a link to published page in a post. Before this, users clicking this link would have seen a 404.

ATM /pub is server side only.