### PR TITLE
FIX: Include default notification level in category serializer

### DIFF
--- a/app/serializers/category_serializer.rb
+++ b/app/serializers/category_serializer.rb
@@ -83,8 +83,9 @@ class CategorySerializer < SiteCategorySerializer
 
   def notification_level
     user = scope && scope.user
-   object.notification_level ||
-     (user && CategoryUser.where(user: user, category: object).first.try(:notification_level))
+    object.notification_level ||
+     (user && CategoryUser.where(user: user, category: object).first.try(:notification_level)) ||
+     CategoryUser.default_notification_level
   end
 
   def custom_fields

--- a/spec/serializers/category_serializer_spec.rb
+++ b/spec/serializers/category_serializer_spec.rb
@@ -28,4 +28,19 @@ describe CategorySerializer do
     json = described_class.new(category, scope: Guardian.new, root: false).as_json
     expect(json[:custom_fields]).to be_present
   end
+
+  it "includes the default notification level" do
+    json = described_class.new(category, scope: Guardian.new, root: false).as_json
+    expect(json[:notification_level]).to eq(CategoryUser.default_notification_level)
+  end
+
+  describe "user notification level" do
+    fab!(:user) { Fabricate(:user) }
+
+    it "includes the user's notification level" do
+      CategoryUser.set_notification_level_for_category(user, NotificationLevels.all[:watching], category.id)
+      json = described_class.new(category, scope: Guardian.new(user), root: false).as_json
+      expect(json[:notification_level]).to eq(NotificationLevels.all[:watching])
+    end
+  end
 end


### PR DESCRIPTION
Fixes an issue where the notification level state goes missing when user edits a category in the UI.