### PR TITLE
FIX: ensures card cloak is removed

### DIFF
--- a/app/assets/javascripts/discourse/app/components/group-card-contents.js
+++ b/app/assets/javascripts/discourse/app/components/group-card-contents.js
@@ -65,9 +65,9 @@ export default Component.extend(CardContentsBase, CleansUp, {
   },
 
   _close() {
-    this._super(...arguments);
-
     this.set("group", null);
+
+    this._super(...arguments);
   },
 
   cleanUp() {

--- a/app/assets/javascripts/discourse/app/components/user-card-contents.js
+++ b/app/assets/javascripts/discourse/app/components/user-card-contents.js
@@ -177,12 +177,12 @@ export default Component.extend(CardContentsBase, CanCheckEmails, CleansUp, {
   },
 
   _close() {
-    this._super(...arguments);
-
     this.setProperties({
       user: null,
       topicPostCount: null
     });
+
+    this._super(...arguments);
   },
 
   cleanUp() {

--- a/app/assets/javascripts/discourse/app/mixins/card-contents-base.js
+++ b/app/assets/javascripts/discourse/app/mixins/card-contents-base.js
@@ -280,6 +280,8 @@ export default Mixin.create({
     if (this.site.mobileView) {
       this._unbindMobileScroll();
     }
+
+    this._hide();
   },
 
   willDestroyElement() {


### PR DESCRIPTION
Repro steps for current failure:
- use mobile view
- click on a different user avatar to show user card
- click message
- close composer
- cloak is still showing and prevents any click