### PR TITLE
FEATURE: Add setting to control the Expect header on S3 calls

### DIFF
--- a/config/discourse_defaults.conf
+++ b/config/discourse_defaults.conf
@@ -196,6 +196,7 @@ s3_secret_access_key =
 s3_use_iam_profile =
 s3_cdn_url =
 s3_endpoint =
+s3_http_continue_timeout =
 
 ### rate limits apply to all sites
 max_user_api_reqs_per_minute = 20

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1204,6 +1204,9 @@ files:
   s3_endpoint:
     default: ""
     regex: '^https?:\/\/.+[^\/]$'
+  s3_http_continue_timeout:
+    default: 1
+    hidden: true
   s3_cdn_url:
     default: ""
     regex: '^https?:\/\/.+[^\/]$'

--- a/lib/s3_helper.rb
+++ b/lib/s3_helper.rb
@@ -204,6 +204,7 @@ class S3Helper
     }
 
     opts[:endpoint] = SiteSetting.s3_endpoint if SiteSetting.s3_endpoint.present?
+    opts[:http_continue_timeout] = SiteSetting.s3_http_continue_timeout
 
     unless obj.s3_use_iam_profile
       opts[:access_key_id] = obj.s3_access_key_id


### PR DESCRIPTION
Some providers don't implement the Expect: 100-continue support,
which results in a mismatch in the object signature.

With this settings, users can disable the header and use such providers.