### PR TITLE
FIX: muted message should be sent after edit

### DIFF
--- a/app/models/topic_tracking_state.rb
+++ b/app/models/topic_tracking_state.rb
@@ -72,8 +72,8 @@ class TopicTrackingState
     "/unread/#{user_id}"
   end
 
-  def self.publish_muted(post)
-    user_ids = post.topic.topic_users
+  def self.publish_muted(topic)
+    user_ids = topic.topic_users
       .where(notification_level: NotificationLevels.all[:muted])
       .joins(:user)
       .where("users.last_seen_at > ?", 7.days.ago)
@@ -82,7 +82,7 @@ class TopicTrackingState
       .pluck(:user_id)
     return if user_ids.blank?
     message = {
-      topic_id: post.topic_id,
+      topic_id: topic.id,
       message_type: MUTED_MESSAGE_TYPE,
     }
     MessageBus.publish("/latest", message.as_json, user_ids: user_ids)

--- a/lib/post_jobs_enqueuer.rb
+++ b/lib/post_jobs_enqueuer.rb
@@ -58,7 +58,7 @@ class PostJobsEnqueuer
 
   def after_post_create
     if @post.post_number > 1
-      TopicTrackingState.publish_muted(@post)
+      TopicTrackingState.publish_muted(@post.topic)
       TopicTrackingState.publish_unread(@post)
     end
     TopicTrackingState.publish_latest(@topic, @post.whisper?)

--- a/lib/post_revisor.rb
+++ b/lib/post_revisor.rb
@@ -523,6 +523,7 @@ class PostRevisor
   def bump_topic
     return if bypass_bump? || !is_last_post?
     @topic.update_column(:bumped_at, Time.now)
+    TopicTrackingState.publish_muted(@topic)
     TopicTrackingState.publish_latest(@topic)
   end
 

--- a/spec/models/topic_tracking_state_spec.rb
+++ b/spec/models/topic_tracking_state_spec.rb
@@ -81,9 +81,9 @@ describe TopicTrackingState do
     end
 
     it 'can correctly publish muted' do
-      TopicUser.find_by(topic: post.topic, user: post.user).update(notification_level: 0)
+      TopicUser.find_by(topic: topic, user: post.user).update(notification_level: 0)
       messages = MessageBus.track_publish("/latest") do
-        TopicTrackingState.publish_muted(post)
+        TopicTrackingState.publish_muted(topic)
       end
 
       muted_message = messages.find { |message| message.data["message_type"] == "muted" }
@@ -94,7 +94,7 @@ describe TopicTrackingState do
 
     it 'should not publish any message when notification level is not muted' do
       messages = MessageBus.track_publish("/latest") do
-        TopicTrackingState.publish_muted(post)
+        TopicTrackingState.publish_muted(topic)
       end
       muted_messages = messages.select { |message| message.data["message_type"] == "muted" }
 
@@ -102,10 +102,10 @@ describe TopicTrackingState do
     end
 
     it 'should not publish any message when the user was not seen in the last 7 days' do
-      TopicUser.find_by(topic: post.topic, user: post.user).update(notification_level: 0)
+      TopicUser.find_by(topic: topic, user: post.user).update(notification_level: 0)
       post.user.update(last_seen_at: 8.days.ago)
       messages = MessageBus.track_publish("/latest") do
-        TopicTrackingState.publish_muted(post)
+        TopicTrackingState.publish_muted(topic)
       end
       muted_messages = messages.select { |message| message.data["message_type"] == "muted" }
       expect(muted_messages).to eq([])


### PR DESCRIPTION
Recently, we added feature that we are sending `/muted` to users who muted specific topic just before `/latest` so the client knows to ignore those messages

https://github.com/discourse/discourse/pull/9482

Same `/muted` message should be included when the post is edited