### PR TITLE
FIX: an `<a>` with a target of _blank wants a new window

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/intercept-click.js
+++ b/app/assets/javascripts/discourse/app/lib/intercept-click.js
@@ -7,7 +7,7 @@ export function wantsNewWindow(e) {
     e.metaKey ||
     e.ctrlKey ||
     (e.button && e.button !== 0) ||
-    (e.target && e.target.target === "_blank")
+    (e.currentTarget && e.currentTarget.target === "_blank")
   );
 }
 


### PR DESCRIPTION
..even if it wraps an image.

Currently there's a bug preventing some links from opening new windows when they need it. E.g. in case an `<a>` element wraps an `<img>` like this:
```
<a href="http://example.com/" target="_blank"><img src="https://upload.wikimedia.org/wikipedia/commons/thumb/8/89/Acer_palmatum_sango_kaku.jpg/440px-Acer_palmatum_sango_kaku.jpg"/></a>
```
*Actual result:* In this case when user clicks the link the URL is opened in current window
*Expected result:* the URL should be opened in new window

This improves https://github.com/discourse/discourse/commit/246997dbd918bafff7336199463a0bfe1e500bef : `e.target` is an `<img>` in this case not having `target="_blank"`, while `e.currentTarget` is `<a>`. This fix also makes the `wantsNewWindow` code consistent with https://github.com/discourse/discourse/blob/7a2e8d3ead63c7d99e1069fc7823e933f931ba85/app/assets/javascripts/discourse/app/lib/click-track.js#L50
