### PR TITLE
DEV: Update rspec-rails from 4.0.0.beta2 to 4.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -167,8 +167,7 @@ group :test, :development do
   # we would like to upgrade it if possible
   gem 'rb-inotify', '~> 0.9', require: RUBY_PLATFORM =~ /linux/i ? 'rb-inotify' : false
 
-  # TODO once 4.0.0 is released upgrade to it, at time of writing 3.9.0 is latest
-  gem 'rspec-rails', '4.0.0.beta2', require: false
+  gem 'rspec-rails', '~> 4.0', require: false
 
   gem 'shoulda-matchers', require: false
   gem 'rspec-html-matchers'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -328,14 +328,14 @@ GEM
     rspec-mocks (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
-    rspec-rails (4.0.0.beta2)
+    rspec-rails (4.0.0)
       actionpack (>= 4.2)
       activesupport (>= 4.2)
       railties (>= 4.2)
-      rspec-core (~> 3.8)
-      rspec-expectations (~> 3.8)
-      rspec-mocks (~> 3.8)
-      rspec-support (~> 3.8)
+      rspec-core (~> 3.9)
+      rspec-expectations (~> 3.9)
+      rspec-mocks (~> 3.9)
+      rspec-support (~> 3.9)
     rspec-support (3.9.2)
     rswag-specs (2.3.1)
       activesupport (>= 3.1, < 7.0)
@@ -524,7 +524,7 @@ DEPENDENCIES
   rqrcode
   rspec
   rspec-html-matchers
-  rspec-rails (= 4.0.0.beta2)
+  rspec-rails (~> 4.0)
   rswag-specs
   rtlit
   rubocop


### PR DESCRIPTION
Upgrades to rspec-rails 4.0.0 release.