### PR TITLE
WIP: FIX: missing edit notification after like

### DIFF
--- a/spec/services/post_alerter_spec.rb
+++ b/spec/services/post_alerter_spec.rb
@@ -206,6 +206,28 @@ describe PostAlerter do
       }.to change(evil_trout.notifications, :count).by(1)
     end
 
+    it 'does notify when edit right after like' do
+      post = Fabricate(:post, raw: '[quote="EvilTrout, post:1"]whatup[/quote]', topic: topic)
+      Notification.create!(topic: post.topic,
+                           post_number: post.post_number,
+                           read: false,
+                           notification_type: Notification.types[:liked],
+                           user: evil_trout,
+                           data: { topic_title: "test topic" }.to_json
+                          )
+      post_revision = Fabricate(:post_revision, post: post)
+
+      expect {
+        described_class.new.create_notification(
+          evil_trout,
+          Notification.types[:edited],
+          post_revision.post,
+          display_username: post_revision.user.username,
+          acting_user_id: post_revision&.user_id,
+          revision_number: post_revision.number)
+      }.to change(evil_trout.notifications, :count).by(1)
+    end
+
     it 'does not collapse quote notifications' do
       expect {
         2.times do


### PR DESCRIPTION
In this commit https://github.com/discourse/discourse/commit/e90f9e5cc47 I tried to fix bug mentioned here https://meta.discourse.org/t/reply-then-edit-to-add-quote-notification-redundancy/138358

The idea was that when a user replies to a post and then edit and for example add mention or quote, we should not create another notification.

![image](https://user-images.githubusercontent.com/72780/80939498-2dfeea80-8e20-11ea-9017-c93c2cb040d3.png)

However, that solution was broken and created new bug mentioned here. https://meta.discourse.org/t/edits-not-being-stored-in-user-actions-table/145025

So if for example admin first like the post of the user, and then edit, we already got `like` notification, but it doesn't mean that edit one should be skipped.

So I reverted original solution and now we are allowing to skip notification if we have notification of the exact same type or type of `edited_group` (replied, mentioned, quoted, edited)

![image](https://user-images.githubusercontent.com/72780/80939485-22132880-8e20-11ea-911c-b06524d6ff59.png)
