### PR TITLE
DEV: Set owner on raw views

### DIFF
--- a/app/assets/javascripts/discourse/app/helpers/raw.js
+++ b/app/assets/javascripts/discourse/app/helpers/raw.js
@@ -1,6 +1,7 @@
 import { registerUnbound } from "discourse-common/lib/helpers";
 import { findRawTemplate } from "discourse/lib/raw-templates";
 import { htmlSafe } from "@ember/template";
+import { setOwner } from "@ember/application";
 
 let _injections;
 
@@ -16,6 +17,7 @@ function renderRaw(ctx, container, template, templateName, params) {
       session: container.lookup("session:main"),
       topicTrackingState: container.lookup("topic-tracking-state:main")
     };
+    setOwner(_injections, container);
   }
 
   if (!params.view) {


### PR DESCRIPTION
This allows things like `Ember.inject.service` to be used within the raw view. setOwner simply sets one property on the object, and the result is cached along with the other injected properties, so this should have negligible performance impact.