### PR TITLE
DEV: Add remove button function to PluginAPI

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/plugin-api.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.js
@@ -5,7 +5,7 @@ import { addPluginOutletDecorator } from "discourse/components/plugin-connector"
 import { addTopicTitleDecorator } from "discourse/components/topic-title";
 import ComposerEditor from "discourse/components/composer-editor";
 import DiscourseBanner from "discourse/components/discourse-banner";
-import { addButton } from "discourse/widgets/post-menu";
+import { addButton, removeButton } from "discourse/widgets/post-menu";
 import { includeAttributes } from "discourse/lib/transform-post";
 import { registerHighlightJSLanguage } from "discourse/lib/highlight-syntax";
 import { addToolbarCallback } from "discourse/components/d-editor";
@@ -399,9 +399,23 @@ class PluginApi {
    *     position: 'first'  // can be `first`, `last` or `second-last-hidden`
    *   };
    * });
+   * ```
    **/
   addPostMenuButton(name, callback) {
     addButton(name, callback);
+  }
+
+  /**
+   * Remove existing button below a post with your plugin.
+   *
+   * Example:
+   *
+   * ```
+   * api.removePostMenuButton('like');
+   * ```
+   **/
+  removePostMenuButton(name) {
+    removeButton(name);
   }
 
   /**

--- a/app/assets/javascripts/discourse/app/widgets/post-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-menu.js
@@ -41,6 +41,11 @@ export function addButton(name, builder) {
   _extraButtons[name] = builder;
 }
 
+export function removeButton(name) {
+  if (_extraButtons[name]) delete _extraButtons[name];
+  if (_builders[name]) delete _builders[name];
+}
+
 function registerButton(name, builder) {
   _builders[name] = builder;
 }

--- a/test/javascripts/widgets/post-menu-test.js
+++ b/test/javascripts/widgets/post-menu-test.js
@@ -1,0 +1,44 @@
+import { moduleForWidget, widgetTest } from "helpers/widget-test";
+import { withPluginApi } from "discourse/lib/plugin-api";
+
+moduleForWidget("post-menu");
+
+widgetTest("add extra button", {
+  template: '{{mount-widget widget="post-menu" args=args}}',
+  beforeEach() {
+    this.set("args", {});
+    withPluginApi("0.8", api => {
+      api.addPostMenuButton("coffee", () => {
+        return {
+          action: "drinkCoffee",
+          icon: "coffee",
+          className: "hot-coffee",
+          title: "coffee.title",
+          position: "first"
+        };
+      });
+    });
+  },
+  async test(assert) {
+    assert.ok(
+      find(".actions .extra-buttons .hot-coffee").length === 1,
+      "It renders extra button"
+    );
+  }
+});
+
+widgetTest("remove extra button", {
+  template: '{{mount-widget widget="post-menu" args=args}}',
+  beforeEach() {
+    this.set("args", {});
+    withPluginApi("0.8", api => {
+      api.removePostMenuButton("coffee");
+    });
+  },
+  async test(assert) {
+    assert.ok(
+      find(".actions .extra-buttons .hot-coffee").length === 0,
+      "It doesn't removes coffee button"
+    );
+  }
+});


### PR DESCRIPTION
### This PR
- [x] Introduces `removeButton` function to `post-menu` widget;
- [x] Introduces `removePostMenuButton` function to PluginAPI to complement `addPostMenuButton`
- [x] Adds tests for both `addButton` and `removeButton` functions in the `post-menu-test`