### PR TITLE
FIX: reverts to use an observer to support loading more notifications

### DIFF
--- a/app/assets/javascripts/discourse/app/components/user-notifications-large.js
+++ b/app/assets/javascripts/discourse/app/components/user-notifications-large.js
@@ -1,4 +1,5 @@
 import MountWidget from "discourse/components/mount-widget";
+import { observes } from "discourse-common/utils/decorators";
 
 export default MountWidget.extend({
   widget: "user-notifications-large",
@@ -6,9 +7,14 @@ export default MountWidget.extend({
   filter: null,
   args: null,
 
-  didReceiveAttrs() {
+  init() {
     this._super(...arguments);
 
+    this.args = { notifications: this.notifications, filter: this.filter };
+  },
+
+  @observes("notifications.length", "notifications.@each.read", "filter")
+  _triggerRefresh() {
     this.set("args", {
       notifications: this.notifications,
       filter: this.filter


### PR DESCRIPTION
Apparently, didReceiveAttrs is not called when loading more notifications, this would require a more heavy refactoring.