### PR TITLE
FIX: Preserve code blocks when quoting

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/utilities.js
+++ b/app/assets/javascripts/discourse/app/lib/utilities.js
@@ -134,6 +134,7 @@ export function selectedText() {
   for (let r = 0; r < selection.rangeCount; r++) {
     const range = selection.getRangeAt(r);
     const $ancestor = $(range.commonAncestorContainer);
+    const $codeBlockTest = $ancestor.parent("pre");
 
     // ensure we never quote text in the post menu area
     const $postMenuArea = $ancestor.find(".post-menu-area")[0];
@@ -141,7 +142,15 @@ export function selectedText() {
       range.setEndBefore($postMenuArea);
     }
 
-    $div.append(range.cloneContents());
+    if ($codeBlockTest.length) {
+      const $pre = $("<pre>");
+      const $code = $("<code>");
+      $code.append(range.cloneContents());
+      $pre.append($code);
+      $div.append($pre);
+    } else {
+      $div.append(range.cloneContents());
+    }
   }
 
   return toMarkdown($div.html());

--- a/app/assets/javascripts/discourse/app/lib/utilities.js
+++ b/app/assets/javascripts/discourse/app/lib/utilities.js
@@ -143,11 +143,16 @@ export function selectedText() {
     }
 
     if ($codeBlockTest.length) {
-      const $pre = $("<pre>");
       const $code = $("<code>");
       $code.append(range.cloneContents());
-      $pre.append($code);
-      $div.append($pre);
+      // Even though this was a code block, produce a non-block quote if it's a single line.
+      if (/\n/.test($code.text())) {
+        const $pre = $("<pre>");
+        $pre.append($code);
+        $div.append($pre);
+      } else {
+        $div.append($code);
+      }
     } else {
       $div.append(range.cloneContents());
     }


### PR DESCRIPTION
https://meta.discourse.org/t/quotes-containing-code-block-must-start-with-newline/25369/8?u=riking

Using jQuery all over to match the surrounding code.