### PR TITLE
FIX: PostgreSQL fallback was broken due to Rails masking exception

### DIFF
--- a/lib/active_record/connection_adapters/postgresql_fallback_adapter.rb
+++ b/lib/active_record/connection_adapters/postgresql_fallback_adapter.rb
@@ -154,7 +154,7 @@ module ActiveRecord
         begin
           connection = postgresql_connection(config)
           fallback_handler.initialized ||= true
-        rescue PG::ConnectionBad => e
+        rescue ::ActiveRecord::NoDatabaseError, PG::ConnectionBad => e
           fallback_handler.master_down
           fallback_handler.verify_master
 


### PR DESCRIPTION
The PR https://github.com/rails/rails/pull/36612 changes the raised exception
if the error message includes the target database name.

Since the error message contains the hostname, this could be triggered when
the hostname contains the database name.