### PR TITLE
FIX: Pre-select Later Today on bookmark edit if the time is the same

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/bookmark.js
+++ b/app/assets/javascripts/discourse/app/controllers/bookmark.js
@@ -103,6 +103,11 @@ export default Controller.extend(ModalFunctionality, {
   _initializeExistingBookmarkData() {
     if (this._existingBookmarkHasReminder()) {
       let parsedReminderAt = this._parseCustomDateTime(this.model.reminderAt);
+
+      if (parsedReminderAt.isSame(this.laterToday())) {
+        return this.set("selectedReminderType", REMINDER_TYPES.LATER_TODAY);
+      }
+
       this.setProperties({
         customReminderDate: parsedReminderAt.format("YYYY-MM-DD"),
         customReminderTime: parsedReminderAt.format("HH:mm"),

--- a/test/javascripts/acceptance/bookmarks-test.js
+++ b/test/javascripts/acceptance/bookmarks-test.js
@@ -195,3 +195,21 @@ test("Editing a bookmark", async assert => {
   );
   assert.verifySteps(["tomorrow"]);
 });
+
+test("Editing a bookmark that has a Later Today reminder, and it is before 6pm today", async assert => {
+  mockSuccessfulBookmarkPost(assert);
+  await visit("/t/internationalization-localization/280");
+  await openBookmarkModal();
+  await fillIn("input#bookmark-name", "Test name");
+  await click("#tap_tile_later_today");
+  await openEditBookmarkModal();
+  assert.not(
+    exists("#bookmark-custon-date > input"),
+    "it does not show the custom date input"
+  );
+  assert.ok(
+    exists("#tap_tile_later_today.active"),
+    "it preselects Later Today"
+  );
+  assert.verifySteps(["later_today"]);
+});


### PR DESCRIPTION
If the user chooses "Later Today" as the reminder for a bookmark, then edits that bookmark, we should pre-select "Later Today" if that time has not changed (e.g. later is still 6pm). We do this to avoid confusion instead of opening the custom date + time section.