### PR TITLE
DEV: Add show_created_at option for invite_serializer

### DIFF
--- a/app/serializers/invite_serializer.rb
+++ b/app/serializers/invite_serializer.rb
@@ -3,6 +3,7 @@
 class InviteSerializer < ApplicationSerializer
 
   attributes :email, :updated_at, :redeemed_at, :expired, :user
+  attribute :created_at, if: :show_created_at?
 
   def include_email?
     options[:show_emails] && !object.redeemed?
@@ -18,4 +19,7 @@ class InviteSerializer < ApplicationSerializer
     ser.as_json
   end
 
+  def show_created_at?
+    options[:show_created_at]
+  end
 end


### PR DESCRIPTION
In a plugin, I want to show when an invite was created. This allows me the ability to do that.