### PR TITLE
FIX: make can_invite_to_forum robust against plugin interference

### DIFF
--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -123,7 +123,7 @@ class CurrentUserSerializer < BasicUserSerializer
   end
 
   def can_invite_to_forum
-    true
+    scope.can_invite_to_forum?
   end
 
   def include_can_invite_to_forum?


### PR DESCRIPTION
A plugin was using `add_to_serializer`, which made the `include_...?` method overridden to 'true'. Copy the logic to the attribute method as well.