### PR TITLE
DEV: Use a copy of the fixture file instead of the original one

### DIFF
--- a/spec/requests/user_avatars_controller_spec.rb
+++ b/spec/requests/user_avatars_controller_spec.rb
@@ -27,7 +27,7 @@ describe UserAvatarsController do
       # travis is not good here, no image magick
       if !ENV["TRAVIS"]
         let :upload do
-          File.open("#{Rails.root}/spec/fixtures/images/cropped.png") do |f|
+          File.open(file_from_fixtures("cropped.png")) do |f|
             UploadCreator.new(
               f,
               "test.png"


### PR DESCRIPTION
There are some rare cases where `./spec/requests/admin/badges_controller_spec.rb:196` fails. The only suspicious thing I found about this spec is that it uses the `cropped.png` file to test what happens if a non-CSV gets uploaded.

I believe we may be corrupting the original file somehow since we pass it to the UploadCreator. We should use a copy instead.
