### PR TITLE
FIX: correct edit notification username for PMs

### DIFF
--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -628,7 +628,9 @@ class PostAlerter
 
     each_user_in_batches(notify) do |user|
       notification_type = already_seen_user_ids.include?(user.id) ? Notification.types[:edited] : Notification.types[:posted]
-      create_notification(user, notification_type, post)
+      opts = {}
+      opts[:display_username] = post.last_editor.username if notification_type == Notification.types[:edited]
+      create_notification(user, notification_type, post, opts)
     end
   end
 

--- a/spec/services/post_alerter_spec.rb
+++ b/spec/services/post_alerter_spec.rb
@@ -1128,12 +1128,16 @@ describe PostAlerter do
   describe '#notify_post_users' do
     fab!(:topic) { Fabricate(:topic) }
     fab!(:post) { Fabricate(:post, topic: topic) }
+    fab!(:last_editor) { Fabricate(:user) }
+    fab!(:tag) { Fabricate(:tag) }
 
     it 'creates single edit notification when post is modified' do
       TopicUser.create!(user_id: user.id, topic_id: topic.id, notification_level: TopicUser.notification_levels[:watching], highest_seen_post_number: post.post_number)
+      PostRevisor.new(post).revise!(last_editor, tags: [tag.name])
       PostAlerter.new.notify_post_users(post, [])
       expect(Notification.count).to eq(1)
       expect(Notification.last.notification_type).to eq(Notification.types[:edited])
+      expect(JSON.parse(Notification.last.data)["display_username"]).to eq(last_editor.username)
 
       PostAlerter.new.notify_post_users(post, [])
       expect(Notification.count).to eq(1)


### PR DESCRIPTION
When the tag is added to PM by admin, notification has an incorrect username (post author username instead of admin username)