### PR TITLE
FIX: end date of ranges in html preview was incorrect

### DIFF
--- a/plugins/discourse-local-dates/assets/javascripts/lib/local-date-builder.js.es6
+++ b/plugins/discourse-local-dates/assets/javascripts/lib/local-date-builder.js.es6
@@ -113,21 +113,15 @@ export default class LocalDateBuilder {
       previewedTimezones.push({
         timezone: this._zoneWithoutPrefix(timezone),
         formated: this._createDateTimeRange(
-          localDate.datetimeWithZone(timezone),
+          DateWithZoneHelper.fromDatetime(
+            localDate.datetime,
+            localDate.timezone,
+            timezone
+          ),
           this.time
         )
       });
     });
-
-    if (!previewedTimezones.length) {
-      previewedTimezones.push({
-        timezone: "UTC",
-        formated: this._createDateTimeRange(
-          localDate.datetimeWithZone("Etc/UTC"),
-          this.time
-        )
-      });
-    }
 
     return previewedTimezones.uniqBy("timezone");
   }

--- a/plugins/discourse-local-dates/test/javascripts/lib/local-date-builder-test.js.es6
+++ b/plugins/discourse-local-dates/test/javascripts/lib/local-date-builder-test.js.es6
@@ -330,7 +330,7 @@ QUnit.test("previews", assert => {
           },
           {
             formated:
-              "Monday, March 23, 2020 10:00 AM → Monday, March 23, 2020 10:00 AM",
+              "Sunday, March 22, 2020 10:00 AM → Monday, March 23, 2020 10:00 AM",
             timezone: "Sydney"
           }
         ]
@@ -403,7 +403,11 @@ QUnit.test("previews", assert => {
 
   freezeTime({ date: "2020-04-06", timezone: PARIS }, () => {
     assert.buildsCorrectDate(
-      { timezone: PARIS, date: "2020-04-07", timezones: [LONDON, LAGOS] },
+      {
+        timezone: PARIS,
+        date: "2020-04-07",
+        timezones: [LONDON, LAGOS, SYDNEY]
+      },
       {
         previews: [
           {
@@ -414,13 +418,50 @@ QUnit.test("previews", assert => {
           },
           {
             formated:
-              "Tuesday, April 7, 2020 11:00 PM → Tuesday, April 7, 2020 11:00 PM",
+              "Monday, April 6, 2020 11:00 PM → Tuesday, April 7, 2020 11:00 PM",
             timezone: "London"
           },
           {
             formated:
-              "Tuesday, April 7, 2020 11:00 PM → Tuesday, April 7, 2020 11:00 PM",
+              "Monday, April 6, 2020 11:00 PM → Tuesday, April 7, 2020 11:00 PM",
             timezone: "Lagos"
+          },
+          {
+            formated:
+              "Tuesday, April 7, 2020 8:00 AM → Wednesday, April 8, 2020 8:00 AM",
+            timezone: "Sydney"
+          }
+        ]
+      }
+    );
+  });
+
+  freezeTime({ date: "2020-04-06", timezone: PARIS }, () => {
+    assert.buildsCorrectDate(
+      {
+        timezone: PARIS,
+        date: "2020-04-07",
+        time: "14:54",
+        timezones: [LONDON, LAGOS, SYDNEY]
+      },
+      {
+        previews: [
+          {
+            current: true,
+            formated: "April 7, 2020 2:54 PM",
+            timezone: "Paris"
+          },
+          {
+            formated: "April 7, 2020 1:54 PM",
+            timezone: "London"
+          },
+          {
+            formated: "April 7, 2020 1:54 PM",
+            timezone: "Lagos"
+          },
+          {
+            formated: "April 7, 2020 10:54 PM",
+            timezone: "Sydney"
           }
         ]
       }


### PR DESCRIPTION
This commit also remove an unused block of code as previewedTimezones can't be empty anymore.