### PR TITLE
FIX: Show the Bookmark button for PM topics

### DIFF
--- a/app/assets/javascripts/discourse/app/initializers/topic-footer-buttons.js
+++ b/app/assets/javascripts/discourse/app/initializers/topic-footer-buttons.js
@@ -84,7 +84,7 @@ export default {
     });
 
     registerTopicFooterButton({
-      dependentKeys: ["topic.bookmarked", "topic.isPrivateMessage"],
+      dependentKeys: ["topic.bookmarked"],
       id: "bookmark",
       icon() {
         if (this.get("topic.bookmark_reminder_at")) {
@@ -120,9 +120,6 @@ export default {
       action: "toggleBookmark",
       dropdown() {
         return this.site.mobileView;
-      },
-      displayed() {
-        return !this.get("topic.isPrivateMessage");
       }
     });
 


### PR DESCRIPTION
There is no point in suppressing this now that we have bookmark reminders.