### PR TITLE
DEV: Allow specifying if a notification is high_priority on create

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -45,7 +45,9 @@ class Notification < ActiveRecord::Base
   end
 
   before_create do
-    self.high_priority = Notification.high_priority_types.include?(self.notification_type)
+    # if we have manually set the notification to high_priority on create then
+    # make sure that is respected
+    self.high_priority = self.high_priority || Notification.high_priority_types.include?(self.notification_type)
   end
 
   def self.purge_old!

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -87,6 +87,24 @@ describe Notification do
 
   end
 
+  describe 'high priority creation' do
+    fab!(:user) { Fabricate(:user) }
+
+    it "automatically marks the notification as high priority if it is a high priority type" do
+      notif = Notification.create(user: user, notification_type: Notification.types[:bookmark_reminder], data: {})
+      expect(notif.high_priority).to eq(true)
+      notif = Notification.create(user: user, notification_type: Notification.types[:private_message], data: {})
+      expect(notif.high_priority).to eq(true)
+      notif = Notification.create(user: user, notification_type: Notification.types[:liked], data: {})
+      expect(notif.high_priority).to eq(false)
+    end
+
+    it "allows manually specifying a notification is high priority" do
+      notif = Notification.create(user: user, notification_type: Notification.types[:liked], data: {}, high_priority: true)
+      expect(notif.high_priority).to eq(true)
+    end
+  end
+
   describe 'unread counts' do
 
     fab!(:user) { Fabricate(:user) }


### PR DESCRIPTION
This allows for special cases where we may not want a certain notification type to ALWAYS be high priority (e.g. a topic timer).