### PR TITLE
DEV: remove no-longer-necessary MULTISITE_PREFIX

### DIFF
--- a/lib/backup_restore/s3_backup_store.rb
+++ b/lib/backup_restore/s3_backup_store.rb
@@ -3,7 +3,6 @@
 module BackupRestore
   class S3BackupStore < BackupStore
     UPLOAD_URL_EXPIRES_AFTER_SECONDS ||= 21_600 # 6 hours
-    MULTISITE_PREFIX = "backups"
 
     def initialize(opts = {})
       s3_options = S3Helper.s3_options(SiteSetting)
@@ -100,7 +99,7 @@ module BackupRestore
 
     def s3_bucket_name_with_prefix
       if Rails.configuration.multisite
-        File.join(SiteSetting.s3_backup_bucket, MULTISITE_PREFIX, RailsMultisite::ConnectionManagement.current_db)
+        File.join(SiteSetting.s3_backup_bucket, RailsMultisite::ConnectionManagement.current_db)
       else
         SiteSetting.s3_backup_bucket
       end


### PR DESCRIPTION
We prevent s3_backup_bucket from being the parent or the same as s3_upload_bucket -- spec/lib/site_settings/validations_spec.rb#validate_s3_upload_bucket -- so this looks like it's not useful anymore.

Currently, with s3_upload_bucket of "bucket_name" and s3_backup_bucket of "bucket_name/backups", multisite backups are actually ending up in "bucket_name/backups/backups/site_name".

Is my understanding correct @gschlager?
Is there anything else that needs to change?
How can we move existing backups?