### PR TITLE
REFACTOR: removes useless variable assignment

### DIFF
--- a/app/assets/javascripts/select-kit/components/select-kit.js
+++ b/app/assets/javascripts/select-kit/components/select-kit.js
@@ -644,16 +644,15 @@ export default Component.extend(
       const highlightedIndex = this.mainCollection.indexOf(
         this.selectKit.highlighted
       );
-      let newHighlightedIndex = highlightedIndex;
       const count = this.mainCollection.length;
 
       if (highlightedIndex < count - 1) {
-        newHighlightedIndex = highlightedIndex + 1;
+        highlightedIndex = highlightedIndex + 1;
       } else {
-        newHighlightedIndex = 0;
+        highlightedIndex = 0;
       }
 
-      const highlighted = this.mainCollection.objectAt(newHighlightedIndex);
+      const highlighted = this.mainCollection.objectAt(highlightedIndex);
       if (highlighted) {
         this._scrollToRow(highlighted);
         this.set("selectKit.highlighted", highlighted);
@@ -664,16 +663,15 @@ export default Component.extend(
       const highlightedIndex = this.mainCollection.indexOf(
         this.selectKit.highlighted
       );
-      let newHighlightedIndex = highlightedIndex;
       const count = this.mainCollection.length;
 
       if (highlightedIndex > 0) {
-        newHighlightedIndex = highlightedIndex - 1;
+        highlightedIndex = highlightedIndex - 1;
       } else {
-        newHighlightedIndex = count - 1;
+        highlightedIndex = count - 1;
       }
 
-      const highlighted = this.mainCollection.objectAt(newHighlightedIndex);
+      const highlighted = this.mainCollection.objectAt(highlightedIndex);
       if (highlighted) {
         this._scrollToRow(highlighted);
         this.set("selectKit.highlighted", highlighted);

--- a/app/assets/javascripts/select-kit/components/select-kit.js
+++ b/app/assets/javascripts/select-kit/components/select-kit.js
@@ -641,7 +641,7 @@ export default Component.extend(
     },
 
     _highlightNext() {
-      const highlightedIndex = this.mainCollection.indexOf(
+      let highlightedIndex = this.mainCollection.indexOf(
         this.selectKit.highlighted
       );
       const count = this.mainCollection.length;
@@ -660,7 +660,7 @@ export default Component.extend(
     },
 
     _highlightPrevious() {
-      const highlightedIndex = this.mainCollection.indexOf(
+      let highlightedIndex = this.mainCollection.indexOf(
         this.selectKit.highlighted
       );
       const count = this.mainCollection.length;


### PR DESCRIPTION
The initial value of newHighlightedIndex is unused, since it is always overwritten.