### PR TITLE
REFACTOR: removes superfluous argument passed to findWidget

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/glue.js
+++ b/app/assets/javascripts/discourse/app/widgets/glue.js
@@ -58,11 +58,11 @@ export default class WidgetGlue {
       widget.vnode.children.forEach(child => {
         if (child.constructor.name === "CustomWidget") {
           widgets.push(child);
-          findWidgets(child, widgets);
+          findWidgets(child);
         }
       });
     };
-    findWidgets(this._tree, widgets);
+    findWidgets(this._tree);
     widgets.reverse().forEach(widget => widget.destroy());
 
     cancel(this._timeout);


### PR DESCRIPTION
findWidget accepts only one argument