### PR TITLE
DEV: Upgrade to Rails 6.0.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,13 +18,13 @@ else
   # this allows us to include the bits of rails we use without pieces we do not.
   #
   # To issue a rails update bump the version number here
-  gem 'actionmailer', '6.0.2.2'
-  gem 'actionpack', '6.0.2.2'
-  gem 'actionview', '6.0.2.2'
-  gem 'activemodel', '6.0.2.2'
-  gem 'activerecord', '6.0.2.2'
-  gem 'activesupport', '6.0.2.2'
-  gem 'railties', '6.0.2.2'
+  gem 'actionmailer', '6.0.3'
+  gem 'actionpack', '6.0.3'
+  gem 'actionview', '6.0.3'
+  gem 'activemodel', '6.0.3'
+  gem 'activerecord', '6.0.3'
+  gem 'activesupport', '6.0.3'
+  gem 'railties', '6.0.3'
   gem 'sprockets-rails'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,21 +1,21 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    actionmailer (6.0.2.2)
-      actionpack (= 6.0.2.2)
-      actionview (= 6.0.2.2)
-      activejob (= 6.0.2.2)
+    actionmailer (6.0.3)
+      actionpack (= 6.0.3)
+      actionview (= 6.0.3)
+      activejob (= 6.0.3)
       mail (~> 2.5, >= 2.5.4)
       rails-dom-testing (~> 2.0)
-    actionpack (6.0.2.2)
-      actionview (= 6.0.2.2)
-      activesupport (= 6.0.2.2)
+    actionpack (6.0.3)
+      actionview (= 6.0.3)
+      activesupport (= 6.0.3)
       rack (~> 2.0, >= 2.0.8)
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.2.0)
-    actionview (6.0.2.2)
-      activesupport (= 6.0.2.2)
+    actionview (6.0.3)
+      activesupport (= 6.0.3)
       builder (~> 3.1)
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
@@ -24,20 +24,20 @@ GEM
       actionview (>= 6.0.a)
     active_model_serializers (0.8.4)
       activemodel (>= 3.0)
-    activejob (6.0.2.2)
-      activesupport (= 6.0.2.2)
+    activejob (6.0.3)
+      activesupport (= 6.0.3)
       globalid (>= 0.3.6)
-    activemodel (6.0.2.2)
-      activesupport (= 6.0.2.2)
-    activerecord (6.0.2.2)
-      activemodel (= 6.0.2.2)
-      activesupport (= 6.0.2.2)
-    activesupport (6.0.2.2)
+    activemodel (6.0.3)
+      activesupport (= 6.0.3)
+    activerecord (6.0.3)
+      activemodel (= 6.0.3)
+      activesupport (= 6.0.3)
+    activesupport (6.0.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-      zeitwerk (~> 2.2)
+      zeitwerk (~> 2.2, >= 2.2.2)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     annotate (3.1.1)
@@ -184,7 +184,7 @@ GEM
       mini_mime (>= 0.1.1)
     maxminddb (0.1.22)
     memory_profiler (0.9.14)
-    message_bus (3.1.0)
+    message_bus (3.2.0)
       rack (>= 1.1.3)
     method_source (1.0.0)
     mini_mime (1.0.2)
@@ -281,9 +281,9 @@ GEM
     rails_multisite (2.1.1)
       activerecord (> 5.0, < 7)
       railties (> 5.0, < 7)
-    railties (6.0.2.2)
-      actionpack (= 6.0.2.2)
-      activesupport (= 6.0.2.2)
+    railties (6.0.3)
+      actionpack (= 6.0.3)
+      activesupport (= 6.0.3)
       method_source
       rake (>= 0.8.7)
       thor (>= 0.20.3, < 2.0)
@@ -428,14 +428,14 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  actionmailer (= 6.0.2.2)
-  actionpack (= 6.0.2.2)
-  actionview (= 6.0.2.2)
+  actionmailer (= 6.0.3)
+  actionpack (= 6.0.3)
+  actionview (= 6.0.3)
   actionview_precompiler
   active_model_serializers (~> 0.8.3)
-  activemodel (= 6.0.2.2)
-  activerecord (= 6.0.2.2)
-  activesupport (= 6.0.2.2)
+  activemodel (= 6.0.3)
+  activerecord (= 6.0.3)
+  activesupport (= 6.0.3)
   addressable
   annotate
   aws-sdk-s3
@@ -512,7 +512,7 @@ DEPENDENCIES
   rack-mini-profiler
   rack-protection
   rails_multisite
-  railties (= 6.0.2.2)
+  railties (= 6.0.3)
   rake
   rb-fsevent
   rb-inotify (~> 0.9)

--- a/config/application.rb
+++ b/config/application.rb
@@ -91,6 +91,11 @@ module Discourse
       end
     end
 
+    # we skip it cause we configure it in the initializer
+    # the railstie for message_bus would insert it in the
+    # wrong position
+    config.skip_message_bus_middleware = true
+
     # Disable so this is only run manually
     # we may want to change this later on
     # issue is image_optim crashes on missing dependencies

--- a/config/initializers/200-first_middlewares.rb
+++ b/config/initializers/200-first_middlewares.rb
@@ -6,12 +6,8 @@
 #
 # We aren't manipulating the middleware stack directly because of
 # https://github.com/rails/rails/pull/27936
-session_operations = Rails::Configuration::MiddlewareStackProxy.new([
-   [:delete, MessageBus::Rack::Middleware],
-   [:unshift, MessageBus::Rack::Middleware],
-])
 
-Rails.configuration.middleware = Rails.configuration.middleware + session_operations
+Rails.configuration.middleware.unshift(MessageBus::Rack::Middleware)
 
 # no reason to track this in development, that is 300+ redis calls saved per
 # page view (we serve all assets out of thin in development)

--- a/config/initializers/200-first_middlewares.rb
+++ b/config/initializers/200-first_middlewares.rb
@@ -24,8 +24,8 @@ if Rails.configuration.multisite
   # Multisite needs to be first, because the request tracker and message bus
   # rely on it
   session_operations = Rails::Configuration::MiddlewareStackProxy.new([
-     [:delete, RailsMultisite::Middleware],
-     [:unshift, [RailsMultisite::Middleware, RailsMultisite::DiscoursePatches.config]],
+    -> middleware { middleware.delete(RailsMultisite::Middleware) },
+    -> middleware { middleware.unshift(RailsMultisite::Middleware, RailsMultisite::DiscoursePatches.config) },
   ])
 
   Rails.configuration.middleware = Rails.configuration.middleware + session_operations


### PR DESCRIPTION
This reverts the revert of the upgrade and adds https://github.com/discourse/discourse/pull/9687/commits/2c8a871c1583f9419d4ba084033340ee131398a5.

See https://github.com/rails/rails/pull/38091 for the breaking change that caused the issues on the first attempt to upgrade.

cc: @SamSaffron