### PR TITLE
 FEATURE: Filter settings by plugin

### DIFF
--- a/app/assets/javascripts/admin/controllers/admin-site-settings.js
+++ b/app/assets/javascripts/admin/controllers/admin-site-settings.js
@@ -20,7 +20,7 @@ export default Controller.extend({
       filter = this.filter
         .toLowerCase()
         .split(" ")
-        .filter((word) => {
+        .filter(word => {
           if (word.length === 0) {
             return false;
           }
@@ -51,13 +51,13 @@ export default Controller.extend({
     const all = {
       nameKey: "all_results",
       name: I18n.t("admin.site_settings.categories.all_results"),
-      siteSettings: [],
+      siteSettings: []
     };
     const matchesGroupedByCategory = [all];
 
     const matches = [];
-    this.allSiteSettings.forEach((settingsCategory) => {
-      const siteSettings = settingsCategory.siteSettings.filter((item) => {
+    this.allSiteSettings.forEach(settingsCategory => {
+      const siteSettings = settingsCategory.siteSettings.filter(item => {
         if (this.onlyOverridden && !item.get("overridden")) return false;
         if (pluginFilter && item.plugin !== pluginFilter) return false;
         if (filter) {
@@ -65,7 +65,10 @@ export default Controller.extend({
           return (
             setting.includes(filter) ||
             setting.replace(/_/g, " ").includes(filter) ||
-            item.get("description").toLowerCase().includes(filter) ||
+            item
+              .get("description")
+              .toLowerCase()
+              .includes(filter) ||
             (item.get("value") || "").toLowerCase().includes(filter)
           );
         } else {
@@ -80,7 +83,7 @@ export default Controller.extend({
             "admin.site_settings.categories." + settingsCategory.nameKey
           ),
           siteSettings,
-          count: siteSettings.length,
+          count: siteSettings.length
         });
       }
     });
@@ -97,7 +100,7 @@ export default Controller.extend({
   },
 
   @observes("filter", "onlyOverridden", "model")
-  filterContent: discourseDebounce(function () {
+  filterContent: discourseDebounce(function() {
     if (this._skipBounce) {
       this.set("_skipBounce", false);
     } else {
@@ -112,6 +115,6 @@ export default Controller.extend({
 
     toggleMenu() {
       $(".admin-detail").toggleClass("mobile-closed mobile-open");
-    },
-  },
+    }
+  }
 });

--- a/app/assets/javascripts/admin/routes/admin-plugins.js
+++ b/app/assets/javascripts/admin/routes/admin-plugins.js
@@ -9,20 +9,14 @@ export default Route.extend({
       const controller = this.controllerFor("adminSiteSettings");
       this.transitionTo("adminSiteSettingsCategory", "plugins").then(() => {
         if (plugin) {
-          const siteSettingFilter = plugin.get("enabled_setting_filter");
-          const match = /^(.*)_enabled/.exec(plugin.get("enabled_setting"));
-          const filter = siteSettingFilter || match[1];
-
-          if (filter) {
-            // filterContent() is normally on a debounce from typing.
-            // Because we don't want the default of "All Results", we tell it
-            // to skip the next debounce.
-            controller.set("filter", filter);
-            controller.set("_skipBounce", true);
-            controller.filterContentNow("plugins");
-          }
+          // filterContent() is normally on a debounce from typing.
+          // Because we don't want the default of "All Results", we tell it
+          // to skip the next debounce.
+          controller.set("filter", `plugin:${plugin.id}`);
+          controller.set("_skipBounce", true);
+          controller.filterContentNow("plugins");
         }
       });
-    }
-  }
+    },
+  },
 });

--- a/app/assets/javascripts/admin/routes/admin-plugins.js
+++ b/app/assets/javascripts/admin/routes/admin-plugins.js
@@ -17,6 +17,6 @@ export default Route.extend({
           controller.filterContentNow("plugins");
         }
       });
-    },
-  },
+    }
+  }
 });

--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -12,9 +12,9 @@ class SiteSetting < ActiveRecord::Base
     true
   end
 
-  def self.load_settings(file)
+  def self.load_settings(file, plugin: nil)
     SiteSettings::YamlLoader.new(file).load do |category, name, default, opts|
-      setting(name, default, opts.merge(category: category))
+      setting(name, default, opts.merge(category: category, plugin: plugin))
     end
   end
 
@@ -22,7 +22,7 @@ class SiteSetting < ActiveRecord::Base
 
   unless Rails.env.test? && ENV['LOAD_PLUGINS'] != "1"
     Dir[File.join(Rails.root, "plugins", "*", "config", "settings.yml")].each do |file|
-      load_settings(file)
+      load_settings(file, plugin: file.split("/")[-3])
     end
   end
 

--- a/app/serializers/admin_plugin_serializer.rb
+++ b/app/serializers/admin_plugin_serializer.rb
@@ -12,7 +12,7 @@ class AdminPluginSerializer < ApplicationSerializer
              :enabled_setting_filter
 
   def id
-    object.metadata.name
+    object.directory_name
   end
 
   def name

--- a/app/serializers/admin_plugin_serializer.rb
+++ b/app/serializers/admin_plugin_serializer.rb
@@ -8,8 +8,7 @@ class AdminPluginSerializer < ApplicationSerializer
              :admin_route,
              :enabled,
              :enabled_setting,
-             :is_official,
-             :enabled_setting_filter
+             :is_official
 
   def id
     object.directory_name
@@ -37,14 +36,6 @@ class AdminPluginSerializer < ApplicationSerializer
 
   def enabled_setting
     object.enabled_site_setting
-  end
-
-  def include_enabled_setting_filter?
-    object.enabled_site_setting_filter.present?
-  end
-
-  def enabled_setting_filter
-    object.enabled_site_setting_filter
   end
 
   def include_url?

--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -801,7 +801,7 @@ module Discourse
     redis_key = "deprecate-notice-#{digest}"
 
     if !Discourse.redis.without_namespace.get(redis_key)
-      Rails.logger.warn(warning)
+      Rails.logger.warn(warning) if Rails.logger
       begin
         Discourse.redis.without_namespace.setex(redis_key, 3600, "x")
       rescue Redis::CommandError => e

--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -638,11 +638,7 @@ class Plugin::Instance
   end
 
   def enabled_site_setting_filter(filter = nil)
-    if filter
-      @enabled_setting_filter = filter
-    else
-      @enabled_setting_filter
-    end
+    Discourse.deprecate("`enabled_site_setting_filter` is deprecated", output_in_test: true)
   end
 
   def enabled_site_setting(setting = nil)

--- a/lib/site_setting_extension.rb
+++ b/lib/site_setting_extension.rb
@@ -110,6 +110,10 @@ module SiteSettingExtension
     @secret_settings ||= []
   end
 
+  def plugins
+    @plugins ||= {}
+  end
+
   def setting(name_arg, default = nil, opts = {})
     name = name_arg.to_sym
 
@@ -156,6 +160,10 @@ module SiteSettingExtension
 
       if opts[:secret]
         secret_settings << name
+      end
+
+      if opts[:plugin]
+        plugins[name] = opts[:plugin]
       end
 
       type_supervisor.load_setting(
@@ -245,6 +253,8 @@ module SiteSettingExtension
         secret: secret_settings.include?(s),
         placeholder: placeholder(s)
       }.merge!(type_hash)
+
+      opts[:plugin] = plugins[s] if plugins[s]
 
       opts
     end.unshift(locale_setting_hash)

--- a/spec/components/plugin/instance_spec.rb
+++ b/spec/components/plugin/instance_spec.rb
@@ -502,21 +502,6 @@ describe Plugin::Instance do
     end
   end
 
-  describe '#enabled_site_setting_filter' do
-    describe 'when filter is blank' do
-      it 'should return the right value' do
-        expect(Plugin::Instance.new.enabled_site_setting_filter).to eq(nil)
-      end
-    end
-
-    it 'should set the right value' do
-      instance = Plugin::Instance.new
-      instance.enabled_site_setting_filter('test')
-
-      expect(instance.enabled_site_setting_filter).to eq('test')
-    end
-  end
-
   describe '#register_reviewable_types' do
     it 'Overrides the existing Reviewable types adding new ones' do
       current_types = Reviewable.types

--- a/test/javascripts/acceptance/admin-site-settings-test.js
+++ b/test/javascripts/acceptance/admin-site-settings-test.js
@@ -10,7 +10,7 @@ acceptance("Admin - Site Settings", {
   },
 
   pretend(server, helper) {
-    server.put("/admin/site_settings/title", body => {
+    server.put("/admin/site_settings/title", (body) => {
       titleOverride = body.requestBody.split("=")[1];
       return helper.response({ success: "OK" });
     });
@@ -22,14 +22,14 @@ acceptance("Admin - Site Settings", {
         titleSetting.value = titleOverride;
       }
       const response = {
-        site_settings: [titleSetting, ...fixtures.slice(1)]
+        site_settings: [titleSetting, ...fixtures.slice(1)],
       };
       return helper.response(response);
     });
-  }
+  },
 });
 
-QUnit.test("upload site setting", async assert => {
+QUnit.test("upload site setting", async (assert) => {
   await visit("/admin/site_settings");
 
   assert.ok(
@@ -40,7 +40,7 @@ QUnit.test("upload site setting", async assert => {
   assert.ok(exists(".row.setting.upload .undo"), "undo button is present");
 });
 
-QUnit.test("changing value updates dirty state", async assert => {
+QUnit.test("changing value updates dirty state", async (assert) => {
   await visit("/admin/site_settings");
   await fillIn("#setting-filter", " title ");
   assert.equal(count(".row.setting"), 1, "filter returns 1 site setting");
@@ -89,7 +89,7 @@ QUnit.test("changing value updates dirty state", async assert => {
 
 QUnit.test(
   "always shows filtered site settings if a filter is set",
-  async assert => {
+  async (assert) => {
     await visit("/admin/site_settings");
     await fillIn("#setting-filter", "title");
     assert.equal(count(".row.setting"), 1);
@@ -103,3 +103,14 @@ QUnit.test(
     assert.equal(count(".row.setting"), 1);
   }
 );
+
+QUnit.test("filter settings by plugin name", async (assert) => {
+  await visit("/admin/site_settings");
+
+  await fillIn("#setting-filter", "plugin:discourse-logo");
+  assert.equal(count(".row.setting"), 1);
+
+  // inexistent plugin
+  await fillIn("#setting-filter", "plugin:discourse-plugin");
+  assert.equal(count(".row.setting"), 0);
+});

--- a/test/javascripts/fixtures/site_settings.js
+++ b/test/javascripts/fixtures/site_settings.js
@@ -9,7 +9,7 @@ export default {
         category: "required",
         preview: null,
         secret: false,
-        type: "string"
+        type: "string",
       },
       {
         setting: "contact_email",
@@ -20,7 +20,7 @@ export default {
         category: "required",
         preview: null,
         secret: false,
-        type: "email"
+        type: "email",
       },
       {
         setting: "site_contact_username",
@@ -31,7 +31,7 @@ export default {
         category: "required",
         preview: null,
         secret: false,
-        type: "username"
+        type: "username",
       },
       {
         setting: "logo",
@@ -41,7 +41,7 @@ export default {
         category: "required",
         preview: null,
         secret: false,
-        type: "upload"
+        type: "upload",
       },
       {
         setting: "top_menu",
@@ -61,13 +61,24 @@ export default {
           "categories",
           "read",
           "posted",
-          "bookmarks"
+          "bookmarks",
         ],
-        list_type: "compact"
-      }
+        list_type: "compact",
+      },
+      {
+        setting: "plugin_logo",
+        description: "Some plugin logo",
+        default: "",
+        value: "/some/image",
+        category: "required",
+        preview: null,
+        secret: false,
+        type: "upload",
+        plugin: "discourse-logo",
+      },
     ],
     diags: {
-      last_message_processed: null
-    }
-  }
+      last_message_processed: null,
+    },
+  },
 };


### PR DESCRIPTION
This implements support for more advanced filters when searching a site setting. For example, `plugin:discourse-assign` will return all options of plugin discourse-assign. This was a problem before because clicking on the <kbd>Settings</kbd> button from the Plugins screen was simply setting a filter like `assign` and not all settings of a plugin will contain its name.