### PR TITLE
FIX: remove deprecated URI.escape

### DIFF
--- a/app/jobs/regular/update_username.rb
+++ b/app/jobs/regular/update_username.rb
@@ -158,7 +158,7 @@ module Jobs
 
       doc.css("a.mention").each do |a|
         a.content = a.content.gsub(@cooked_mention_username_regex, "@#{@new_username}")
-        a["href"] = a["href"].gsub(@cooked_mention_user_path_regex, "/u/#{URI.escape(@new_username)}") if a["href"]
+        a["href"] = a["href"].gsub(@cooked_mention_user_path_regex, "/u/#{UrlHelper.encode_component(@new_username)}") if a["href"]
       end
 
       doc.css("aside.quote").each do |aside|

--- a/lib/pretty_text.rb
+++ b/lib/pretty_text.rb
@@ -286,7 +286,7 @@ module PrettyText
     doc.css("a").each do |l|
       href = l["href"].to_s
       begin
-        uri = URI(URI.escape(href))
+        uri = URI(UrlHelper.encode_component(href))
         site_uri ||= URI(Discourse.base_url)
 
         if !uri.host.present? ||
@@ -466,13 +466,13 @@ module PrettyText
 
         case type
         when USER_TYPE
-          element['href'] = "#{Discourse::base_uri}/u/#{URI.escape(name)}"
+          element['href'] = "#{Discourse::base_uri}/u/#{UrlHelper.encode_component(name)}"
         when GROUP_MENTIONABLE_TYPE
           element['class'] = 'mention-group notify'
-          element['href'] = "#{Discourse::base_uri}/groups/#{URI.escape(name)}"
+          element['href'] = "#{Discourse::base_uri}/groups/#{UrlHelper.encode_component(name)}"
         when GROUP_TYPE
           element['class'] = 'mention-group'
-          element['href'] = "#{Discourse::base_uri}/groups/#{URI.escape(name)}"
+          element['href'] = "#{Discourse::base_uri}/groups/#{UrlHelper.encode_component(name)}"
         end
       end
     end


### PR DESCRIPTION
During Nokogumbo changes I introduced back URI.escape which is deprecated.