### PR TITLE
DEV: Add theme name as class

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -125,7 +125,7 @@ module ApplicationHelper
 
   def body_classes
     result = ApplicationHelper.extra_body_classes.to_a
-    result << theme.name if theme
+    result << theme.name.gsub(" ", "-") if theme
 
     if @category && @category.url.present?
       result << "category-#{@category.url.sub(/^\/c\//, '').gsub(/\//, '-')}"
@@ -402,7 +402,7 @@ module ApplicationHelper
   end
 
   def scheme_id
-    theme.color_scheme_id
+    theme&.color_scheme_id
   end
 
   def theme

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -125,6 +125,7 @@ module ApplicationHelper
 
   def body_classes
     result = ApplicationHelper.extra_body_classes.to_a
+    result << theme.name if theme
 
     if @category && @category.url.present?
       result << "category-#{@category.url.sub(/^\/c\//, '').gsub(/\//, '-')}"
@@ -401,11 +402,13 @@ module ApplicationHelper
   end
 
   def scheme_id
+    theme.color_scheme_id
+  end
+
+  def theme
     return if theme_ids.blank?
-    Theme
-      .where(id: theme_ids.first)
-      .pluck(:color_scheme_id)
-      .first
+
+    Theme.find_by(id: theme_ids.first)
   end
 
   def current_homepage


### PR DESCRIPTION
This is useful for plugins to affect specific themes. It is certainly an edge case, and in general we do not want this to happen. This gives the flexibility to do so, and could be helpful for future projects.

For the material design theme for example the body looks like this:

![Screenshot from 2020-05-08 11-27-21](https://user-images.githubusercontent.com/16214023/81426540-f5605900-911e-11ea-90da-a104d05d7365.png)
