### PR TITLE
REFACTOR: Remove an unused Topic model observer

### DIFF
--- a/app/assets/javascripts/discourse/app/models/topic.js
+++ b/app/assets/javascripts/discourse/app/models/topic.js
@@ -236,16 +236,6 @@ const Topic = RestModel.extend({
     this.set("category", Category.findById(this.category_id));
   },
 
-  @observes("categoryName")
-  _categoryNameChanged() {
-    const categoryName = this.categoryName;
-    let category;
-    if (categoryName) {
-      category = this.site.get("categories").findBy("name", categoryName);
-    }
-    this.set("category", category);
-  },
-
   categoryClass: fmt("category.fullSlug", "category-%@"),
 
   @discourseComputed("tags")


### PR DESCRIPTION
As far I can tell nothing sets `categoryName` on the `Topic` model. Didn't find anything in all-the-plugins/all-the-themes either. Let's see what CI says.