### PR TITLE
DEV: Various GitHub Actions CI tweaks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
             ${{ runner.os }}-gem-
 
       - name: Setup gems
-        run: bundle install --jobs 4 --retry 3
+        run: bundle install --jobs 4
 
       - name: Get yarn cache directory
         id: yarn-cache-dir

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,10 @@ jobs:
           architecture: 'x64'
 
       - name: Setup bundler
-        run: gem install bundler -v 2.1.4 --no-doc
+        run: |
+          gem install bundler -v 2.1.4 --no-doc && \
+          bundle config deployment 'true' && \
+          bundle config without 'development'
 
       - name: Bundler cache
         uses: actions/cache@v1
@@ -90,7 +93,7 @@ jobs:
             ${{ runner.os }}-gem-
 
       - name: Setup gems
-        run: bundle install --without development --deployment --jobs 4 --retry 3
+        run: bundle install --jobs 4 --retry 3
 
       - name: Get yarn cache directory
         id: yarn-cache-dir

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Setup packages
         if: env.BUILD_TYPE != 'LINT'
         run: |
-          sudo apt-get -yqq install postgresql-client libpq-dev gifsicle jpegoptim optipng jhead && \
+          sudo apt-get -yqq install postgresql-client libpq-dev gifsicle jpegoptim optipng jhead
           wget -qO- https://raw.githubusercontent.com/discourse/discourse_docker/master/image/base/install-pngquant | sudo sh
 
       - name: Setup redis
@@ -79,8 +79,8 @@ jobs:
 
       - name: Setup bundler
         run: |
-          gem install bundler -v 2.1.4 --no-doc && \
-          bundle config deployment 'true' && \
+          gem install bundler -v 2.1.4 --no-doc
+          bundle config deployment 'true'
           bundle config without 'development'
 
       - name: Bundler cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,9 @@ jobs:
           fetch-depth: 1
 
       - name: Setup Git
-        run:  git config --global user.email "ci@ci.invalid" && git config --global user.name "Discourse CI"
+        run: |
+          git config --global user.email "ci@ci.invalid"
+          git config --global user.name "Discourse CI"
 
       - name: Setup packages
         if: env.BUILD_TYPE != 'LINT'
@@ -117,11 +119,15 @@ jobs:
 
       - name: Create database
         if: env.BUILD_TYPE != 'LINT'
-        run: bin/rake db:create && bin/rake db:migrate
+        run: |
+          bin/rake db:create
+          bin/rake db:migrate
 
       - name: Create parallel databases
         if: env.BUILD_TYPE == 'BACKEND' && env.TARGET == 'CORE'
-        run: bin/rake parallel:create && bin/rake parallel:migrate
+        run: |
+          bin/rake parallel:create
+          bin/rake parallel:migrate
 
       - name: Rubocop
         if: env.BUILD_TYPE == 'LINT'
@@ -129,7 +135,9 @@ jobs:
 
       - name: ESLint
         if: env.BUILD_TYPE == 'LINT'
-        run: yarn eslint app/assets/javascripts test/javascripts && yarn eslint --ext .es6 app/assets/javascripts test/javascripts plugins
+        run: |
+          yarn eslint app/assets/javascripts test/javascripts
+          yarn eslint --ext .es6 app/assets/javascripts test/javascripts plugins
 
       - name: Prettier
         if: env.BUILD_TYPE == 'LINT'
@@ -139,7 +147,9 @@ jobs:
 
       - name: Core RSpec
         if: env.BUILD_TYPE == 'BACKEND' && env.TARGET == 'CORE'
-        run: bin/turbo_rspec && bin/rake plugin:spec
+        run: |
+          bin/turbo_rspec
+          bin/rake plugin:spec
 
       - name: Plugin RSpec
         if: env.BUILD_TYPE == 'BACKEND' && env.TARGET == 'PLUGINS'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
           architecture: 'x64'
 
       - name: Setup bundler
-        run: gem install bundler -v 2.1.1 --no-doc
+        run: gem install bundler -v 2.1.4 --no-doc
 
       - name: Bundler cache
         uses: actions/cache@v1


### PR DESCRIPTION
* DEV: Update bundler in GitHub Actions CI from 2.1.1 to 2.1.4

* DEV: Fix bundler deprecation warning
  Fixes the following two deprecation warnings:

  ```
  [DEPRECATED] The `--deployment` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set deployment 'true'`, and stop using this flag
  ```

  ```
  [DEPRECATED] The `--without` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set without 'development'`, and stop using this flag
  ```

* DEV: The default `retry` value is already `3`
  See https://bundler.io/v2.0/man/bundle-config.1.html:

  > retry (BUNDLE_RETRY): The number of times to retry failed network requests. Defaults to 3.

* DEV: `&& \` isn't required in multiline `step.run`
  Steps use the fail-fast strategy.

* DEV: Use multiline `step.run` where possible
