### PR TITLE
FIX: Show category name in badge preview on edit

### DIFF
--- a/app/assets/javascripts/discourse/app/components/edit-category-general.js
+++ b/app/assets/javascripts/discourse/app/components/edit-category-general.js
@@ -66,7 +66,7 @@ export default buildCategoryPanel("general", {
 
   @discourseComputed(
     "category.parent_category_id",
-    "category.categoryName",
+    "category.name",
     "category.color",
     "category.text_color"
   )

--- a/app/assets/javascripts/discourse/app/templates/components/category-name-fields.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/category-name-fields.hbs
@@ -2,7 +2,7 @@
   {{#unless category.isUncategorizedCategory}}
     <section class="field-item">
       <label>{{i18n "category.name"}}</label>
-      {{text-field value=category.name placeholderKey="category.name_placeholder" maxlength="50"}}
+      {{text-field value=category.name placeholderKey="category.name_placeholder" maxlength="50" class="category-name"}}
     </section>
   {{/unless}}
   <section class="field-item">

--- a/test/javascripts/acceptance/category-edit-test.js
+++ b/test/javascripts/acceptance/category-edit-test.js
@@ -21,6 +21,11 @@ QUnit.test("Editing the category", async assert => {
   await visit("/c/bug");
 
   await click(".edit-category");
+
+  assert.equal(find(".d-modal .badge-category").text(), "bug");
+  await fillIn("input.category-name", "testing");
+  assert.equal(find(".d-modal .badge-category").text(), "testing");
+
   await fillIn("#edit-text-color", "#ff0000");
 
   await click(".edit-category-topic-template");


### PR DESCRIPTION
Before/After

<img src="https://user-images.githubusercontent.com/66961/81490169-0d4eee80-927f-11ea-9c08-72518a186c1f.png" width="178"> <img src="https://user-images.githubusercontent.com/66961/81490156-e7c1e500-927e-11ea-93e5-b4212339ad1c.png" width="178">