### PR TITLE
FIX: Show Settings button if plugin has settings

### DIFF
--- a/app/assets/javascripts/admin/templates/plugins-index.hbs
+++ b/app/assets/javascripts/admin/templates/plugins-index.hbs
@@ -47,7 +47,7 @@
           </td>
           <td class="settings">
             {{#if currentUser.admin}}
-              {{#if plugin.enabled_setting}}
+              {{#if plugin.has_settings}}
                 {{d-button class="btn-default" action=(route-action "showSettings") actionParam=plugin icon="cog" label="admin.plugins.change_settings_short"}}
               {{/if}}
             {{/if}}

--- a/app/serializers/admin_plugin_serializer.rb
+++ b/app/serializers/admin_plugin_serializer.rb
@@ -8,6 +8,7 @@ class AdminPluginSerializer < ApplicationSerializer
              :admin_route,
              :enabled,
              :enabled_setting,
+             :has_settings,
              :is_official
 
   def id
@@ -36,6 +37,10 @@ class AdminPluginSerializer < ApplicationSerializer
 
   def enabled_setting
     object.enabled_site_setting
+  end
+
+  def has_settings
+    SiteSetting.plugins.values.include?(id)
   end
 
   def include_url?


### PR DESCRIPTION
It used to check if the plugin has an enabled_setting.