### PR TITLE
FIX: default canonical URL

### DIFF
--- a/lib/canonical_url.rb
+++ b/lib/canonical_url.rb
@@ -13,12 +13,18 @@ module CanonicalURL
   end
 
   module Helpers
+    ALLOWED_CANONICAL_PARAMS = %w(page)
     def canonical_link_tag(url = nil)
       tag('link', rel: 'canonical', href: url || @canonical_url || default_canonical)
     end
 
     def default_canonical
-      "#{Discourse.base_url_no_prefix}#{request.path}"
+      canonical = +"#{Discourse.base_url_no_prefix}#{request.path}"
+      allowed_params = params.select { |key| ALLOWED_CANONICAL_PARAMS.include?(key) }
+      if allowed_params.present?
+        canonical << "?#{allowed_params.keys.zip(allowed_params.values).map { |key, value| "#{key}=#{value}" }.join("&")}"
+      end
+      canonical
     end
   end
 end

--- a/lib/canonical_url.rb
+++ b/lib/canonical_url.rb
@@ -14,8 +14,11 @@ module CanonicalURL
 
   module Helpers
     def canonical_link_tag(url = nil)
-      return '' unless url || @canonical_url
-      tag('link', rel: 'canonical', href: url || @canonical_url || request.url)
+      tag('link', rel: 'canonical', href: url || @canonical_url || default_canonical)
+    end
+
+    def default_canonical
+      "#{Discourse.base_url_no_prefix}#{request.path}"
     end
   end
 end

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -606,7 +606,7 @@ RSpec.describe ApplicationController do
     expect(response.body).to include('Discourse')
   end
 
-  it 'has cannonical tag' do
+  it 'has canonical tag' do
     get '/', headers: { HTTP_ACCEPT: '*/*' }
     expect(response.body).to have_tag("link", with: { rel: "canonical", href: "http://test.localhost/" })
     get '/?query_param=true', headers: { HTTP_ACCEPT: '*/*' }

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -609,6 +609,8 @@ RSpec.describe ApplicationController do
   it 'has cannonical tag' do
     get '/', headers: { HTTP_ACCEPT: '*/*' }
     expect(response.body).to have_tag("link", with: { rel: "canonical", href: "http://test.localhost/" })
+    get '/?query_param=true', headers: { HTTP_ACCEPT: '*/*' }
+    expect(response.body).to have_tag("link", with: { rel: "canonical", href: "http://test.localhost/" })
     get '/404', headers: { HTTP_ACCEPT: '*/*' }
     expect(response.body).to have_tag("link", with: { rel: "canonical", href: "http://test.localhost/404" })
     topic = create_post.topic

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -611,6 +611,8 @@ RSpec.describe ApplicationController do
     expect(response.body).to have_tag("link", with: { rel: "canonical", href: "http://test.localhost/" })
     get '/?query_param=true', headers: { HTTP_ACCEPT: '*/*' }
     expect(response.body).to have_tag("link", with: { rel: "canonical", href: "http://test.localhost/" })
+    get '/latest?page=2&additional_param=true', headers: { HTTP_ACCEPT: '*/*' }
+    expect(response.body).to have_tag("link", with: { rel: "canonical", href: "http://test.localhost/latest?page=2" })
     get '/404', headers: { HTTP_ACCEPT: '*/*' }
     expect(response.body).to have_tag("link", with: { rel: "canonical", href: "http://test.localhost/404" })
     topic = create_post.topic

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -605,4 +605,14 @@ RSpec.describe ApplicationController do
     expect(response.status).to eq(200)
     expect(response.body).to include('Discourse')
   end
+
+  it 'has cannonical tag' do
+    get '/', headers: { HTTP_ACCEPT: '*/*' }
+    expect(response.body).to have_tag("link", with: { rel: "canonical", href: "http://test.localhost/" })
+    get '/404', headers: { HTTP_ACCEPT: '*/*' }
+    expect(response.body).to have_tag("link", with: { rel: "canonical", href: "http://test.localhost/404" })
+    topic = create_post.topic
+    get "/t/#{topic.slug}/#{topic.id}"
+    expect(response.body).to have_tag("link", with: { rel: "canonical", href: "http://test.localhost/t/#{topic.slug}/#{topic.id}" })
+  end
 end


### PR DESCRIPTION
As a fallback, we should always have a canonical URL defined as base_url + path