### PR TITLE
FEATURE: Support for App Shortcuts Menu

### DIFF
--- a/app/controllers/metadata_controller.rb
+++ b/app/controllers/metadata_controller.rb
@@ -59,7 +59,8 @@ class MetadataController < ApplicationController
           icons: [
             {
               src: ActionController::Base.helpers.image_url("push-notifications/check.png"),
-              sizes: "128x128"
+              sizes: "128x128",
+              type: "image/png"
             }
           ]
         },
@@ -70,7 +71,8 @@ class MetadataController < ApplicationController
           icons: [
             {
               src: ActionController::Base.helpers.image_url("push-notifications/private_message.png"),
-              sizes: "128x128"
+              sizes: "128x128",
+              type: "image/png"
             }
           ]
         },
@@ -81,7 +83,8 @@ class MetadataController < ApplicationController
           icons: [
             {
               src: ActionController::Base.helpers.image_url("push-notifications/check.png"),
-              sizes: "128x128"
+              sizes: "128x128",
+              type: "image/png"
             }
           ]
         },
@@ -92,7 +95,8 @@ class MetadataController < ApplicationController
           icons: [
             {
               src: ActionController::Base.helpers.image_url("push-notifications/check.png"),
-              sizes: "128x128"
+              sizes: "128x128",
+              type: "image/png"
             }
           ]
         }

--- a/app/controllers/metadata_controller.rb
+++ b/app/controllers/metadata_controller.rb
@@ -50,7 +50,53 @@ class MetadataController < ApplicationController
           title: "title",
           text: "body"
         }
-      }
+      },
+      shortcuts: [
+        {
+          name: I18n.t('js.topic.create_long'),
+          short_name: I18n.t('js.topic.create'),
+          url: "/new-topic",
+          icons: [
+            {
+              src: ActionController::Base.helpers.image_url("push-notifications/check.png"),
+              sizes: "128x128"
+            }
+          ]
+        },
+        {
+          name: I18n.t('js.user.messages.inbox'),
+          short_name: I18n.t('js.user.messages.inbox'),
+          url: "/my/messages",
+          icons: [
+            {
+              src: ActionController::Base.helpers.image_url("push-notifications/private_message.png"),
+              sizes: "128x128"
+            }
+          ]
+        },
+        {
+          name: I18n.t('js.user.bookmarks'),
+          short_name: I18n.t('js.user.bookmarks'),
+          url: "/my/bookmarks",
+          icons: [
+            {
+              src: ActionController::Base.helpers.image_url("push-notifications/check.png"),
+              sizes: "128x128"
+            }
+          ]
+        },
+        {
+          name: I18n.t('js.filters.top.title'),
+          short_name: I18n.t('js.filters.top.title'),
+          url: "/top",
+          icons: [
+            {
+              src: ActionController::Base.helpers.image_url("push-notifications/check.png"),
+              sizes: "128x128"
+            }
+          ]
+        }
+      ]
     }
 
     logo = SiteSetting.site_manifest_icon_url

--- a/spec/requests/metadata_controller_spec.rb
+++ b/spec/requests/metadata_controller_spec.rb
@@ -86,6 +86,14 @@ RSpec.describe MetadataController do
       manifest = JSON.parse(response.body)
       expect(manifest["short_name"]).to eq("foo")
     end
+
+    it 'contains valid shortcuts by default' do
+      get "/manifest.webmanifest"
+      expect(response.status).to eq(200)
+      manifest = JSON.parse(response.body)
+      expect(manifest["shortcuts"].size).to be > 0
+      expect { URI.parse(manifest["shortcuts"][0]["icons"][0]["src"]) }.not_to raise_error
+    end
   end
 
   describe 'opensearch.xml' do


### PR DESCRIPTION
This adds a list of shortcuts to a installed Discourse instance.

It can be accessed by right clicks or long press on the app icon.

See https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/master/Shortcuts/explainer.md

List of possible follow ups include:

- Making it admin customizable
- Making it user customizable
- Using SVG icons from the site icon sprite (cc @pmusaraj )
- Picking an accent color for icons