### PR TITLE
FIX: randomly failing user_spec

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -874,7 +874,7 @@ describe User do
     end
 
     after do
-      Discourse.redis.flushall
+      Discourse.redis.del("user:#{user.id}:#{Time.zone.now.to_date}")
     end
 
     it "should act correctly" do
@@ -908,7 +908,7 @@ describe User do
     let!(:second_visit_date) { 2.hours.from_now }
 
     after do
-      Discourse.redis.flushall
+      Discourse.redis.del("user:#{user.id}:#{Time.zone.now.to_date}")
     end
 
     it "should update the last seen value" do
@@ -984,7 +984,9 @@ describe User do
 
     describe 'with no previous values' do
       after do
-        Discourse.redis.flushall
+        Discourse.redis.del("user:#{user.id}:#{Time.zone.now.to_date}")
+        unfreeze_time
+        Discourse.redis.del("user:#{user.id}:#{Time.zone.now.to_date}")
       end
 
       it "updates last_seen_at" do
@@ -1314,7 +1316,7 @@ describe User do
       let!(:now) { Time.zone.now }
       before { user.update_last_seen!(now) }
       after do
-        Discourse.redis.flushall
+        Discourse.redis.del("user:#{user.id}:#{now.to_date}")
       end
 
       it "with existing UserVisit record, increments the posts_read value" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -873,6 +873,10 @@ describe User do
       SiteSetting.previous_visit_timeout_hours = 1
     end
 
+    after do
+      Discourse.redis.flushall
+    end
+
     it "should act correctly" do
       expect(user.previous_visit_at).to eq(nil)
 
@@ -902,6 +906,10 @@ describe User do
     let(:user) { Fabricate(:user) }
     let!(:first_visit_date) { Time.zone.now }
     let!(:second_visit_date) { 2.hours.from_now }
+
+    after do
+      Discourse.redis.flushall
+    end
 
     it "should update the last seen value" do
       expect(user.last_seen_at).to eq nil
@@ -1305,6 +1313,9 @@ describe User do
       let!(:user) { Fabricate(:user) }
       let!(:now) { Time.zone.now }
       before { user.update_last_seen!(now) }
+      after do
+        Discourse.redis.flushall
+      end
 
       it "with existing UserVisit record, increments the posts_read value" do
         expect {


### PR DESCRIPTION
When we evaluate `update_last_seen!` we relay on Redis to not run that code too often

https://github.com/discourse/discourse/blob/master/app/models/user.rb#L753

The problem is that not all specs which are running `update_last_seen!` are cleaning after themselves
```
after do
  Discourse.redis.flushall
end
```
For examples specs in that block https://github.com/discourse/discourse/blob/master/spec/models/user_spec.rb#L901

So issue can be replicated when you run a few times
`bundle exec rspec  ./spec/models/user_spec.rb -e "should not update the first seen value if it doesn't exist" -e "should have 0 for days_visited"`

We should flush Redis after each spec which is evaluating `update_last_seen!`