### PR TITLE
FEATURE: Add endpoint for individual SVG icons

### DIFF
--- a/app/controllers/svg_sprite_controller.rb
+++ b/app/controllers/svg_sprite_controller.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 class SvgSpriteController < ApplicationController
-  skip_before_action :preload_json, :redirect_to_login_if_required, :check_xhr, :verify_authenticity_token, only: [:show, :search]
+  skip_before_action :preload_json, :redirect_to_login_if_required, :check_xhr, :verify_authenticity_token, only: [:show, :search, :svg_icon]
 
-  requires_login except: [:show]
+  requires_login except: [:show, :svg_icon]
 
   def show
 
@@ -47,6 +47,27 @@ class SvgSpriteController < ApplicationController
 
       icons = SvgSprite.icon_picker_search(filter)
       render json: icons.take(200), root: false
+    end
+  end
+
+  def svg_icon
+    no_cookies
+
+    RailsMultisite::ConnectionManagement.with_hostname(params[:hostname]) do
+      params.permit(:color)
+      name = params.require(:name)
+      icon = SvgSprite.search(name)
+
+      if icon.blank?
+        render body: nil, status: 404
+      else
+        doc = Nokogiri.XML(icon)
+        doc.at_xpath("symbol").name = "svg"
+        doc.at_xpath("svg")['xmlns'] = "http://www.w3.org/2000/svg"
+        doc.at_xpath("svg")['fill'] = "##{params[:color]}" if params[:color]
+
+        render plain: doc, disposition: nil, content_type: 'image/svg+xml'
+      end
     end
   end
 end

--- a/app/controllers/svg_sprite_controller.rb
+++ b/app/controllers/svg_sprite_controller.rb
@@ -66,6 +66,10 @@ class SvgSpriteController < ApplicationController
         doc.at_xpath("svg")['xmlns'] = "http://www.w3.org/2000/svg"
         doc.at_xpath("svg")['fill'] = "##{params[:color]}" if params[:color]
 
+        response.headers["Last-Modified"] = 1.years.ago.httpdate
+        response.headers["Content-Length"] = doc.to_s.bytesize.to_s
+        immutable_for 1.day
+
         render plain: doc, disposition: nil, content_type: 'image/svg+xml'
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -503,6 +503,7 @@ Discourse::Application.routes.draw do
   get "svg-sprite/:hostname/svg-:theme_ids-:version.js" => "svg_sprite#show", constraints: { hostname: /[\w\.-]+/, version: /\h{40}/, theme_ids: /([0-9]+(,[0-9]+)*)?/, format: :js }
   get "svg-sprite/search/:keyword" => "svg_sprite#search", format: false, constraints: { keyword: /[-a-z0-9\s\%]+/ }
   get "svg-sprite/picker-search" => "svg_sprite#icon_picker_search", defaults: { format: :json }
+  get "svg-sprite/icon(/:color)/:name.svg" => "svg_sprite#svg_icon", constraints: { name: /[-a-z0-9\s\%]+/, format: :svg }
 
   get "highlight-js/:hostname/:version.js" => "highlight_js#show", constraints: { hostname: /[\w\.-]+/, format: :js }
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -503,7 +503,7 @@ Discourse::Application.routes.draw do
   get "svg-sprite/:hostname/svg-:theme_ids-:version.js" => "svg_sprite#show", constraints: { hostname: /[\w\.-]+/, version: /\h{40}/, theme_ids: /([0-9]+(,[0-9]+)*)?/, format: :js }
   get "svg-sprite/search/:keyword" => "svg_sprite#search", format: false, constraints: { keyword: /[-a-z0-9\s\%]+/ }
   get "svg-sprite/picker-search" => "svg_sprite#icon_picker_search", defaults: { format: :json }
-  get "svg-sprite/icon(/:color)/:name.svg" => "svg_sprite#svg_icon", constraints: { name: /[-a-z0-9\s\%]+/, format: :svg }
+  get "svg-sprite/:hostname/icon(/:color)/:name.svg" => "svg_sprite#svg_icon", constraints: { hostname: /[\w\.-]+/, name: /[-a-z0-9\s\%]+/, color: /(\h{6})/, format: :svg }
 
   get "highlight-js/:hostname/:version.js" => "highlight_js#show", constraints: { hostname: /[\w\.-]+/, format: :js }
 

--- a/spec/requests/svg_sprite_controller_spec.rb
+++ b/spec/requests/svg_sprite_controller_spec.rb
@@ -93,4 +93,24 @@ describe SvgSpriteController do
       expect(data[0]["id"]).to eq("fab-500px")
     end
   end
+
+  context 'svg_icon' do
+    it "should return 404 when not appending .svg" do
+      get "/svg-sprite/icon/bolt"
+      expect(response.status).to eq(404)
+    end
+
+    it "should return SVG given an icon name" do
+      get "/svg-sprite/icon/bolt.svg"
+      expect(response.status).to eq(200)
+      expect(response.body).to include('bolt')
+    end
+
+    it "should return SVG given an icon name and a color" do
+      get "/svg-sprite/icon/CC0000/fab-github.svg"
+      expect(response.status).to eq(200)
+      expect(response.body).to include('fab-github')
+      expect(response.body).to include('fill="#CC0000"')
+    end
+  end
 end

--- a/spec/requests/svg_sprite_controller_spec.rb
+++ b/spec/requests/svg_sprite_controller_spec.rb
@@ -95,22 +95,30 @@ describe SvgSpriteController do
   end
 
   context 'svg_icon' do
-    it "should return 404 when not appending .svg" do
-      get "/svg-sprite/icon/bolt"
+    it "requires .svg extension" do
+      get "/svg-sprite/#{Discourse.current_hostname}/icon/bolt"
       expect(response.status).to eq(404)
     end
 
-    it "should return SVG given an icon name" do
-      get "/svg-sprite/icon/bolt.svg"
+    it "returns SVG given an icon name" do
+      get "/svg-sprite/#{Discourse.current_hostname}/icon/bolt.svg"
       expect(response.status).to eq(200)
       expect(response.body).to include('bolt')
     end
 
-    it "should return SVG given an icon name and a color" do
-      get "/svg-sprite/icon/CC0000/fab-github.svg"
+    it "returns SVG given an icon name and a color" do
+      get "/svg-sprite/#{Discourse.current_hostname}/icon/CC0000/fab-github.svg"
       expect(response.status).to eq(200)
+
       expect(response.body).to include('fab-github')
       expect(response.body).to include('fill="#CC0000"')
+      expect(response.headers["Cache-Control"]).to eq("max-age=86400, public, immutable")
     end
+
+    it "ignores non-HEX colors" do
+      get "/svg-sprite/#{Discourse.current_hostname}/icon/orange/fab-github.svg"
+      expect(response.status).to eq(404)
+    end
+
   end
 end


### PR DESCRIPTION
This adds an endpoint to render an SVG icon extracted from the included SVG sprites at `/svg-sprites/HOSTNAME/icon/ICON-NAME.svg`. An optional color parameter (HEX only) is also available, via "/svg-sprite/HOSTNAME/icon/CC0000/ICON-NAME.svg`. 

This should allow SVG icons to be used in PWA shortcuts menu, see https://github.com/discourse/discourse/pull/9749. cc @xfalcox 