### PR TITLE
FIX: Specific email error for replies to digest emails

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -3094,6 +3094,16 @@ en:
 
         You don't have permissions to reply to the topic. If you believe this is an error, [contact a staff member](%{base_url}/about).
 
+    email_reject_reply_to_digest:
+      title: "Email Reject Reply To Summary"
+      subject_template: "[%{email_prefix}] Email issue -- Reply to Summary"
+      text_body_template: |
+        We're sorry, but your email message to %{destination} (titled %{former_title}) didn't work.
+
+        You replied to a Summary email, which is not accepted.
+
+        If you believe this is an error, [contact a staff member](%{base_url}/about).
+
     email_error_notification:
       title: "Email Error Notification"
       subject_template: "[%{email_prefix}] Email issue -- POP authentication error"

--- a/lib/email/processor.rb
+++ b/lib/email/processor.rb
@@ -66,6 +66,7 @@ module Email
                          when Discourse::InvalidAccess                     then :email_reject_invalid_access
                          when Email::Receiver::OldDestinationError         then :email_reject_old_destination
                          when Email::Receiver::ReplyNotAllowedError        then :email_reject_reply_not_allowed
+                         when Email::Receiver::ReplyToDigestError          then :email_reject_reply_to_digest
                          else                                                   :email_reject_unrecognized_error
       end
 

--- a/lib/email/receiver.rb
+++ b/lib/email/receiver.rb
@@ -191,7 +191,7 @@ module Email
           end
         end
 
-        raise ReplyToDigestError if EmailLog.find_by(message_id: @mail.in_reply_to).present?
+        raise ReplyToDigestError if EmailLog.find_by(email_type: "digest", message_id: @mail.in_reply_to).present?
         raise BadDestinationAddress
       end
     end

--- a/lib/email/receiver.rb
+++ b/lib/email/receiver.rb
@@ -32,6 +32,7 @@ module Email
     class UnsubscribeNotAllowed        < ProcessingError; end
     class EmailNotAllowed              < ProcessingError; end
     class OldDestinationError          < ProcessingError; end
+    class ReplyToDigestError           < ProcessingError; end
 
     attr_reader :incoming_email
     attr_reader :raw_email
@@ -190,6 +191,7 @@ module Email
           end
         end
 
+        raise ReplyToDigestError if EmailLog.find_by(message_id: @mail.in_reply_to).present?
         raise BadDestinationAddress
       end
     end

--- a/lib/email/receiver.rb
+++ b/lib/email/receiver.rb
@@ -191,7 +191,7 @@ module Email
           end
         end
 
-        raise ReplyToDigestError if EmailLog.find_by(email_type: "digest", message_id: @mail.in_reply_to).exists?
+        raise ReplyToDigestError if EmailLog.where(email_type: "digest", message_id: @mail.in_reply_to).exists?
         raise BadDestinationAddress
       end
     end

--- a/lib/email/receiver.rb
+++ b/lib/email/receiver.rb
@@ -191,7 +191,7 @@ module Email
           end
         end
 
-        raise ReplyToDigestError if EmailLog.find_by(email_type: "digest", message_id: @mail.in_reply_to).present?
+        raise ReplyToDigestError if EmailLog.find_by(email_type: "digest", message_id: @mail.in_reply_to).exists?
         raise BadDestinationAddress
       end
     end

--- a/spec/components/email/receiver_spec.rb
+++ b/spec/components/email/receiver_spec.rb
@@ -1531,4 +1531,41 @@ describe Email::Receiver do
     end
 
   end
+
+  describe "replying to digest" do
+    fab!(:user) { Fabricate(:user) }
+    fab!(:digest_message_id) { "7402d8ae-1c6e-44bc-9948-48e007839bcc@localhost" }
+    fab!(:email_log) { Fabricate(:email_log,
+      user: user,
+      email_type: 'digest',
+      to_address: user.email,
+      message_id: digest_message_id
+    )}
+    let(:email) {
+      <<~EOF
+      MIME-Version: 1.0
+      Date: Tue, 01 Jan 2019 00:00:00 +0300
+      From: someone <#{user.email}>
+      To: Discourse <#{SiteSetting.notification_email}>
+      Message-ID: <CANtGPwC3ZmWSxnnEuJHfosbtc9d0-ZV02b_7KuyircDt4peDC2@mail.gmail.com>
+      In-Reply-To: <#{digest_message_id}>
+      Subject: Re: [Discourse] Summary
+      References: <#{digest_message_id}>
+      Content-Type: text/plain; charset="UTF-8"
+
+      hello there! I like the digest!
+
+      EOF
+    }
+
+    before do
+      Jobs.run_immediately!
+    end
+
+    it 'returns a ReplyToDigestError' do
+      receiver = Email::Receiver.new(email)
+
+      expect { Email::Receiver.new(email).process! }.to raise_error(Email::Receiver::ReplyToDigestError)
+    end
+  end
 end

--- a/spec/components/email/receiver_spec.rb
+++ b/spec/components/email/receiver_spec.rb
@@ -1563,8 +1563,6 @@ describe Email::Receiver do
     end
 
     it 'returns a ReplyToDigestError' do
-      receiver = Email::Receiver.new(email)
-
       expect { Email::Receiver.new(email).process! }.to raise_error(Email::Receiver::ReplyToDigestError)
     end
   end


### PR DESCRIPTION
Emails the are replies to Digest emails, are getting rejected. Currently They are rejected by `BadDestinationError`. This is the catchall, that multiple cases result in. 

This PR adds a check to make sure sure that the `In-Reply-To` header of incoming messages does not match the `message_id` of a Digest email that was sent out. If this is the case, we can send a much more specific error email, saying that you cannot reply to a digest email.

:tada: Email debugging is **fun**
