### PR TITLE
FIX: Use Discourse.system_user when we need a placeholder admin

### DIFF
--- a/app/models/category_featured_topic.rb
+++ b/app/models/category_featured_topic.rb
@@ -59,7 +59,7 @@ class CategoryFeaturedTopic < ActiveRecord::Base
     # no featured topics (all the previous 2x topics are only visible to admins)
 
     # Add topics, even if they're in secured categories or invisible
-    query = TopicQuery.new(CategoryFeaturedTopic.fake_admin, query_opts)
+    query = TopicQuery.new(Discourse.system_user, query_opts)
     results = query.list_category_topic_ids(c).uniq
 
     # Add some topics that are visible to everyone:
@@ -81,15 +81,6 @@ class CategoryFeaturedTopic < ActiveRecord::Base
       end
     end
   end
-
-  def self.fake_admin
-    # fake an admin
-    admin = User.new
-    admin.admin = true
-    admin.id = -1
-    admin
-  end
-
 end
 
 # == Schema Information

--- a/app/services/random_topic_selector.rb
+++ b/app/services/random_topic_selector.rb
@@ -25,7 +25,7 @@ class RandomTopicSelector
       end
 
       # don't leak private categories into the "everything" group
-      options[:guardian] = Guardian.new(CategoryFeaturedTopic.fake_admin)
+      options[:guardian] = Guardian.new(Discourse.system_user)
     end
 
     query = TopicQuery.new(nil, options)


### PR DESCRIPTION
No clue why a fake User object was created with `id = -1` when system_user is right there. This fixes some exceptions.