### PR TITLE
DEV: skip click track test

### DIFF
--- a/test/javascripts/acceptance/click-track-test.js
+++ b/test/javascripts/acceptance/click-track-test.js
@@ -3,7 +3,7 @@ import { acceptance } from "helpers/qunit-helpers";
 
 acceptance("Click Track", {});
 
-QUnit.test("Do not track mentions", async assert => {
+QUnit.skip("Do not track mentions", async assert => {
   pretender.post("/clicks/track", () => assert.ok(false));
 
   await visit("/t/internationalization-localization/280");


### PR DESCRIPTION
This test might be responsible of random test failures, skip this for now to check if the random failure sill happens after dozens of tests.