### PR TITLE
UX: Add copied text upon copy button click

### DIFF
--- a/app/assets/javascripts/discourse/app/initializers/copy-codeblocks.js
+++ b/app/assets/javascripts/discourse/app/initializers/copy-codeblocks.js
@@ -2,6 +2,7 @@ import { withPluginApi } from "discourse/lib/plugin-api";
 import { cancel, later } from "@ember/runloop";
 import { Promise } from "rsvp";
 import { iconHTML } from "discourse-common/lib/icon-library";
+import I18n from "I18n";
 
 // http://github.com/feross/clipboard-copy
 function clipboardCopy(text) {

--- a/app/assets/javascripts/discourse/app/initializers/copy-codeblocks.js
+++ b/app/assets/javascripts/discourse/app/initializers/copy-codeblocks.js
@@ -86,6 +86,8 @@ export default {
         if (code) {
           clipboardCopy(code.innerText.trim()).then(() => {
             button.classList.add("copied");
+            const state = button.innerHTML;
+            button.innerHTML = I18n.t("copy_codeblock.copied");
 
             const commandId = Ember.guidFor(button);
 
@@ -96,6 +98,7 @@ export default {
 
             _fadeCopyCodeblocksRunners[commandId] = later(() => {
               button.classList.remove("copied");
+              button.innerHTML = state;
               delete _fadeCopyCodeblocksRunners[commandId];
             }, 3000);
           });

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -336,6 +336,9 @@ en:
         tomorrow_with_time: "tomorrow at %{time}"
         at_time: "at %{date_time}"
         existing_reminder: "You have a reminder set for this bookmark which will be sent"
+    
+    copy_codeblock:
+      copied: "copied!"
 
     drafts:
       resume: "Resume"


### PR DESCRIPTION
Adds copied text to the codeblock copy button on click. This improves the user experience by explicitly stating the copy has happened.