### PR TITLE
FEATURE: Add site settings for images and links in excerpts

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -482,7 +482,10 @@ class Post < ActiveRecord::Base
   end
 
   def excerpt_for_topic
-    Post.excerpt(cooked, Post.excerpt_size, strip_links: true, strip_images: true, post: self)
+    strip_links = SiteSetting.post_excerpt_strip_links
+    strip_images = SiteSetting.post_excerpt_strip_images
+    markdown_images = SiteSetting.post_excerpt_markdown_images
+    Post.excerpt(cooked, Post.excerpt_size, strip_links: strip_links, strip_images: strip_images, markdown_images: markdown_images, post: self)
   end
 
   def is_first_post?

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2007,6 +2007,18 @@ uncategorized:
     default: false
     hidden: true
 
+  post_excerpt_strip_links:
+    default: true
+    hidden: true
+
+  post_excerpt_strip_images:
+    default: true
+    hidden: true
+
+  post_excerpt_markdown_images:
+    default: false
+    hidden: true
+
   max_bulk_invites:
     default: 50000
     hidden: true


### PR DESCRIPTION
The ExcertParser has the features to not strip out the images and
links from the excerpt. This change enables site admins to turn
this feature on or off. The default behaviour remains the same.