### PR TITLE
datetime: handle date string with encoded time portion.

### DIFF
--- a/plugins/discourse-local-dates/assets/javascripts/lib/local-date-builder.js.es6
+++ b/plugins/discourse-local-dates/assets/javascripts/lib/local-date-builder.js.es6
@@ -19,6 +19,9 @@ export default class LocalDateBuilder {
     this.format = params.format || (this.time ? TIME_FORMAT : DATE_FORMAT);
     this.countdown = params.countdown;
     this.localTimezone = localTimezone;
+    if (this.time === undefined && this.date.indexOf("T") > 0) {
+      [this.date, this.time] = this.date.split("T");
+    }
   }
 
   build() {

--- a/plugins/discourse-local-dates/test/javascripts/lib/local-date-builder-test.js.es6
+++ b/plugins/discourse-local-dates/test/javascripts/lib/local-date-builder-test.js.es6
@@ -74,6 +74,12 @@ QUnit.test("date", assert => {
       { formated: "April 11, 2020 1:00 PM" },
       "it displays the date with time"
     );
+
+    assert.buildsCorrectDate(
+      { date: "2020-04-11T11:00" },
+      { formated: "April 11, 2020 1:00 PM" },
+      "it displays the date with time (alt format)"
+    );
   });
 });
 


### PR DESCRIPTION
* This will handle input of the form `date=2020-05-14T19:31`.