### PR TITLE
FIX: Bump rack version from 2.0.8 to 2.2.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -131,7 +131,7 @@ gem 'highline', '~> 1.7.0', require: false
 # This is a bit of a hornets nest cause in an ideal world we much prefer
 # if Sidekiq reused session and CSRF mitigation with Discourse on the
 # _forum_session cookie instead of a rack.session cookie
-gem 'rack', '2.0.8'
+gem 'rack', '2.2.2'
 
 gem 'rack-protection' # security
 gem 'cbor', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -265,7 +265,7 @@ GEM
     puma (4.3.3)
       nio4r (~> 2.0)
     r2 (0.2.7)
-    rack (2.0.8)
+    rack (2.2.2)
     rack-mini-profiler (2.0.1)
       rack (>= 1.2.0)
     rack-protection (2.0.8.1)
@@ -506,7 +506,7 @@ DEPENDENCIES
   pry-rails
   puma
   r2
-  rack (= 2.0.8)
+  rack (= 2.2.2)
   rack-mini-profiler
   rack-protection
   rails_multisite


### PR DESCRIPTION
Version 2.1.1 was not working with Sidekiq but version 2.2.2 is fine