### PR TITLE
FEATURE: Set custom document title separator

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/application.js
+++ b/app/assets/javascripts/discourse/app/routes/application.js
@@ -52,7 +52,10 @@ const ApplicationRoute = DiscourseRoute.extend(OpenComposer, {
       ) {
         tokens.push(this.shortSiteDescription);
       }
-      Discourse.set("_docTitle", tokens.join(" - "));
+      Discourse.set(
+        "_docTitle",
+        tokens.join(this.siteSettings.document_title_separator)
+      );
     },
 
     // Ember doesn't provider a router `willTransition` event so let's make one

--- a/app/assets/javascripts/discourse/app/routes/application.js
+++ b/app/assets/javascripts/discourse/app/routes/application.js
@@ -54,7 +54,7 @@ const ApplicationRoute = DiscourseRoute.extend(OpenComposer, {
       }
       Discourse.set(
         "_docTitle",
-        tokens.join(this.siteSettings.document_title_separator)
+        tokens.join(` ${this.siteSettings.document_title_separator} `)
       );
     },
 

--- a/app/controllers/about_controller.rb
+++ b/app/controllers/about_controller.rb
@@ -10,7 +10,7 @@ class AboutController < ApplicationController
     return redirect_to path('/login') if SiteSetting.login_required? && current_user.nil?
 
     @about = About.new(current_user)
-    @title = "#{I18n.t("js.about.simple_title")} - #{SiteSetting.title}"
+    @title = I18n.t("js.about.simple_title") + " #{SiteSetting.document_title_separator} " + SiteSetting.title
     respond_to do |format|
       format.html do
         render :index

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -38,9 +38,9 @@ class CategoriesController < ApplicationController
     @category_list.draft = Draft.get(current_user, Draft::NEW_TOPIC, @category_list.draft_sequence) if current_user
 
     if category_options[:is_homepage] && SiteSetting.short_site_description.present?
-      @title = "#{SiteSetting.title} - #{SiteSetting.short_site_description}"
+      @title = SiteSetting.title + " #{SiteSetting.document_title_separator} " + SiteSetting.short_site_description
     elsif !category_options[:is_homepage]
-      @title = "#{I18n.t('js.filters.categories.title')} - #{SiteSetting.title}"
+      @title = I18n.t('js.filters.categories.title') + " #{SiteSetting.document_title_separator} " + SiteSetting.title
     end
 
     respond_to do |format|

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -169,7 +169,7 @@ class GroupsController < ApplicationController
       guardian,
       params.permit(:before_post_id, :category_id)
     ).limit(50)
-    @title = "#{SiteSetting.title} - #{I18n.t("rss_description.group_posts", group_name: group.name)}"
+    @title = SiteSetting.title + " #{SiteSetting.document_title_separator} " + I18n.t("rss_description.group_posts", group_name: group.name)
     @link = Discourse.base_url
     @description = I18n.t("rss_description.group_posts", group_name: group.name)
     render 'posts/latest', formats: [:rss]
@@ -192,7 +192,7 @@ class GroupsController < ApplicationController
       guardian,
       params.permit(:before_post_id, :category_id)
     ).limit(50)
-    @title = "#{SiteSetting.title} - #{I18n.t("rss_description.group_mentions", group_name: group.name)}"
+    @title = SiteSetting.title + " #{SiteSetting.document_title_separator} " + I18n.t("rss_description.group_mentions", group_name: group.name)
     @link = Discourse.base_url
     @description = I18n.t("rss_description.group_mentions", group_name: group.name)
     render 'posts/latest', formats: [:rss]

--- a/app/controllers/list_controller.rb
+++ b/app/controllers/list_controller.rb
@@ -91,9 +91,9 @@ class ListController < ApplicationController
           else
             @title = I18n.t('js.filters.with_topics', filter: filter_title)
           end
-          @title << " - #{SiteSetting.title}"
+          @title << SiteSetting.document_title_separator + SiteSetting.title
         elsif @category.blank? && (filter.to_s == current_homepage) && SiteSetting.short_site_description.present?
-          @title = "#{SiteSetting.title} - #{SiteSetting.short_site_description}"
+          @title = SiteSetting.title + " #{SiteSetting.document_title_separator} " + SiteSetting.short_site_description
         end
       end
 
@@ -168,7 +168,7 @@ class ListController < ApplicationController
   def latest_feed
     discourse_expires_in 1.minute
 
-    @title = "#{SiteSetting.title} - #{I18n.t("rss_description.latest")}"
+    @title = SiteSetting.title + " #{SiteSetting.document_title_separator} " + I18n.t("rss_description.latest")
     @link = "#{Discourse.base_url}/latest"
     @atom_link = "#{Discourse.base_url}/latest.rss"
     @description = I18n.t("rss_description.latest")
@@ -180,7 +180,7 @@ class ListController < ApplicationController
   def top_feed
     discourse_expires_in 1.minute
 
-    @title = "#{SiteSetting.title} - #{I18n.t("rss_description.top")}"
+    @title = SiteSetting.title + " #{SiteSetting.document_title_separator} " + I18n.t("rss_description.top")
     @link = "#{Discourse.base_url}/top"
     @atom_link = "#{Discourse.base_url}/top.rss"
     @description = I18n.t("rss_description.top")
@@ -193,7 +193,7 @@ class ListController < ApplicationController
     guardian.ensure_can_see!(@category)
     discourse_expires_in 1.minute
 
-    @title = "#{@category.name} - #{SiteSetting.title}"
+    @title = @category.name + " #{SiteSetting.document_title_separator} " + SiteSetting.title
     @link = "#{Discourse.base_url_no_prefix}#{@category.url}"
     @atom_link = "#{Discourse.base_url_no_prefix}#{@category.url}.rss"
     @description = "#{I18n.t('topics_in_category', category: @category.name)} #{@category.description}"
@@ -206,7 +206,7 @@ class ListController < ApplicationController
     discourse_expires_in 1.minute
     target_user = fetch_user_from_params
 
-    @title = "#{SiteSetting.title} - #{I18n.t("rss_description.user_topics", username: target_user.username)}"
+    @title = SiteSetting.title + " #{SiteSetting.document_title_separator} " + I18n.t("rss_description.user_topics", username: target_user.username)
     @link = "#{Discourse.base_url}/u/#{target_user.username}/activity/topics"
     @atom_link = "#{Discourse.base_url}/u/#{target_user.username}/activity/topics.rss"
     @description = I18n.t("rss_description.user_topics", username: target_user.username)
@@ -246,7 +246,7 @@ class ListController < ApplicationController
       @rss = "top_#{period}"
 
       if use_crawler_layout?
-        @title = I18n.t("js.filters.top.#{period}.title") + " - #{SiteSetting.title}"
+        @title = I18n.t("js.filters.top.#{period}.title") + " #{SiteSetting.document_title_separator} " + SiteSetting.title
       end
 
       respond_with_list(list)
@@ -268,7 +268,7 @@ class ListController < ApplicationController
       discourse_expires_in 1.minute
 
       @description = I18n.t("rss_description.top_#{period}")
-      @title = "#{SiteSetting.title} - #{@description}"
+      @title = SiteSetting.title + " #{SiteSetting.document_title_separator} " + @description
       @link = "#{Discourse.base_url}/top/#{period}"
       @atom_link = "#{Discourse.base_url}/top/#{period}.rss"
       @topic_list = TopicQuery.new(nil).list_top_for(period)

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -85,7 +85,7 @@ class PostsController < ApplicationController
     respond_to do |format|
       format.rss do
         @posts = posts
-        @title = "#{SiteSetting.title} - #{rss_description}"
+        @title = SiteSetting.title + " #{SiteSetting.document_title_separator} " + rss_description
         @link = Discourse.base_url
         @description = rss_description
         render 'posts/latest', formats: [:rss]
@@ -120,7 +120,7 @@ class PostsController < ApplicationController
     respond_to do |format|
       format.rss do
         @posts = posts
-        @title = "#{SiteSetting.title} - #{I18n.t("rss_description.user_posts", username: user.username)}"
+        @title = SiteSetting.title + " #{SiteSetting.document_title_separator} " + I18n.t("rss_description.user_posts", username: user.username)
         @link = "#{Discourse.base_url}/u/#{user.username}/activity"
         @description = I18n.t("rss_description.user_posts", username: user.username)
         render 'posts/latest', formats: [:rss]

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -44,7 +44,7 @@ class StaticController < ApplicationController
       else
         @topic.title
       end
-      @title = "#{title_prefix} - #{SiteSetting.title}"
+      @title = title_prefix + " #{SiteSetting.document_title_separator} " + SiteSetting.title
       @body = @topic.posts.first.cooked
       @faq_overriden = !SiteSetting.faq_url.blank?
       render :show, layout: !request.xhr?, formats: [:html]
@@ -53,7 +53,7 @@ class StaticController < ApplicationController
 
     unless @title.present?
       @title = if SiteSetting.short_site_description.present?
-        "#{SiteSetting.title} - #{SiteSetting.short_site_description}"
+        SiteSetting.title + " #{SiteSetting.document_title_separator} " + SiteSetting.short_site_description
       else
         SiteSetting.title
       end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -195,7 +195,7 @@ class TagsController < ::ApplicationController
     tag_id = params[:tag_id]
     @link = "#{Discourse.base_url}/tag/#{tag_id}"
     @description = I18n.t("rss_by_tag", tag: tag_id)
-    @title = "#{SiteSetting.title} - #{@description}"
+    @title = SiteSetting.title + " #{SiteSetting.document_title_separator} " + @description
     @atom_link = "#{Discourse.base_url}/tag/#{tag_id}.rss"
 
     query = TopicQuery.new(current_user, tags: [tag_id])

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -146,7 +146,7 @@
     <% end %>
   <% end %>
 
-  <% content_for(:title) { @title || "#{gsub_emoji_to_unicode(@topic_view.page_title)} - #{SiteSetting.title}" } %>
+  <% content_for(:title) { @title || gsub_emoji_to_unicode(@topic_view.page_title) + " #{SiteSetting.document_title_separator} " + SiteSetting.title } %>
 
   <% if @topic_view.print %>
     <% content_for :after_body do %>

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2048,6 +2048,8 @@ en:
 
     topic_page_title_includes_category: "Topic page <a href='https://developer.mozilla.org/en-US/docs/Web/HTML/Element/title' target='_blank'>title tag</a> includes the category name."
 
+    document_title_separator: "Change the separator in the page title tag."
+
     native_app_install_banner_ios: "Displays DiscourseHub app banner on iOS devices to regular users (trust level 1 and up)."
 
     native_app_install_banner_android: "Displays DiscourseHub app banner on Android devices to regular users (trust level 1 and up)."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1969,8 +1969,26 @@ uncategorized:
     client: true
 
   document_title_separator:
-    default: " - "
+    default: "-"
     client: true
+    type: enum
+    choices:
+      - "-"
+      - "--"
+      - "---"
+      - ":"
+      - "·"
+      - "•"
+      - "*"
+      - "⋆"
+      - "|"
+      - "~"
+      - "«"
+      - "»"
+      - "<"
+      - ">"
+      - "@"
+      - "#"
 
   native_app_install_banner_ios: false
 

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1968,6 +1968,10 @@ uncategorized:
     default: true
     client: true
 
+  document_title_separator:
+    default: " - "
+    client: true
+
   native_app_install_banner_ios: false
 
   native_app_install_banner_android: false


### PR DESCRIPTION
### This PR
- [x] Adds `document_title_separator` setting to update the title separator to enable different types of SEO titles, for example: `Test Topic | Discourse`. Defaults to `" - "`, as it was before. 
- [x] Adds locale option for this new option

Setting is an enum with list of separators inspired by [Yoast SEO WP plugin](https://yoast.com/wordpress/plugins/seo/). 

#### Note about tests
I've tried to write a meaningful test for this new option, but because the `qunit` creates it's own titles I coudn't verify in the test that this option applies. `qunit` titles are separated with commas, for example: `Test Topic,Qunit Discourse Test`. 