### PR TITLE
FEATURE: Redirect '/setup' to '/wizard'

### DIFF
--- a/app/controllers/wizard_controller.rb
+++ b/app/controllers/wizard_controller.rb
@@ -19,6 +19,10 @@ class WizardController < ApplicationController
     end
   end
 
+  def setup_redirect
+    redirect_to "/wizard"
+  end
+
   def qunit
     raise Discourse::InvalidAccess.new if Rails.env.production?
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,6 +67,7 @@ Discourse::Application.routes.draw do
 
   get "srv/status" => "forums#status"
 
+  get "setup" => "wizard#setup_redirect"
   get "wizard" => "wizard#index"
   get 'wizard/steps' => 'steps#index'
   get 'wizard/steps/:id' => "wizard#index"


### PR DESCRIPTION
Based on some feedback it seems like `/setup` is an expected location for the wizard. This adds a redirect from `/setup` to `/wizard`. 