### PR TITLE
DEV: Allow plugins to request topic thumbnail sizes

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -33,11 +33,11 @@ class Topic < ActiveRecord::Base
   end
 
   def self.thumbnail_sizes
-    [ self.share_thumbnail_size ]
+    [ self.share_thumbnail_size ] + DiscoursePluginRegistry.topic_thumbnail_sizes
   end
 
-  def thumbnail_job_redis_key(extra_sizes)
-    "generate_topic_thumbnail_enqueue_#{id}_#{extra_sizes.inspect}"
+  def thumbnail_job_redis_key(sizes)
+    "generate_topic_thumbnail_enqueue_#{id}_#{sizes.inspect}"
   end
 
   def filtered_topic_thumbnails(extra_sizes: [])
@@ -79,7 +79,7 @@ class Topic < ActiveRecord::Base
     if SiteSetting.create_thumbnails &&
        enqueue_if_missing &&
        records.length < thumbnail_sizes.length &&
-       Discourse.redis.set(thumbnail_job_redis_key(extra_sizes), 1, nx: true, ex: 1.minute)
+       Discourse.redis.set(thumbnail_job_redis_key(thumbnail_sizes), 1, nx: true, ex: 1.minute)
 
       Jobs.enqueue(:generate_topic_thumbnails, { topic_id: id, extra_sizes: extra_sizes })
     end

--- a/lib/discourse_plugin_registry.rb
+++ b/lib/discourse_plugin_registry.rb
@@ -75,6 +75,8 @@ class DiscoursePluginRegistry
 
   define_filtered_register :editable_group_custom_fields
 
+  define_filtered_register :topic_thumbnail_sizes
+
   def self.register_auth_provider(auth_provider)
     self.auth_providers << auth_provider
   end

--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -165,6 +165,16 @@ class Plugin::Instance
     DiscoursePluginRegistry.register_editable_group_custom_field(field, self)
   end
 
+  # Request a new size for topic thumbnails
+  # Will respect plugin enabled setting is enabled
+  # Size should be an array with two elements [max_width, max_height]
+  def register_topic_thumbnail_size(size)
+    if !(size.kind_of?(Array) && size.length == 2)
+      raise ArgumentError.new("Topic thumbnail dimension is not valid")
+    end
+    DiscoursePluginRegistry.register_topic_thumbnail_size(size, self)
+  end
+
   def custom_avatar_column(column)
     reloadable_patch do |plugin|
       AvatarLookup.lookup_columns << column

--- a/spec/integration/topic_thumbnail_spec.rb
+++ b/spec/integration/topic_thumbnail_spec.rb
@@ -84,5 +84,38 @@ describe "Topic Thumbnails" do
         expect(thumbnails.length).to eq(5)
       end
     end
+
+    context "with a plugin" do
+      before do
+        plugin = Plugin::Instance.new
+        plugin.register_topic_thumbnail_size [512, 512]
+      end
+
+      after do
+        DiscoursePluginRegistry.reset!
+      end
+
+      it "includes the theme specified resolutions" do
+        topic_json = nil
+
+        expect do
+          topic_json = get_topic
+        end.to change { Jobs::GenerateTopicThumbnails.jobs.size }.by(1)
+
+        # Run the job
+        args = Jobs::GenerateTopicThumbnails.jobs.last["args"].first
+        Jobs::GenerateTopicThumbnails.new.execute(args.with_indifferent_access)
+
+        # Request again
+        expect do
+          topic_json = get_topic
+        end.to change { Jobs::GenerateTopicThumbnails.jobs.size }.by(0)
+
+        thumbnails = topic_json["thumbnails"]
+
+        # Original + Optimized + 1 plugin request
+        expect(thumbnails.length).to eq(3)
+      end
+    end
   end
 end


### PR DESCRIPTION
In plugin.rb, you can register new sizes like

```
register_topic_thumbnail_size [512, 512]
```

For more information about thumbnails see https://github.com/discourse/discourse/commit/03818e642a1ae871bffdc0c39c10f05f0b8b0398