### PR TITLE
FIX: Remove foreign keys from bookmarks

### DIFF
--- a/db/post_migrate/20200520001619_remove_fks_from_bookmarks.rb
+++ b/db/post_migrate/20200520001619_remove_fks_from_bookmarks.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class RemoveFksFromBookmarks < ActiveRecord::Migration[6.0]
+  def change
+    remove_foreign_key :bookmarks, :topics
+    remove_foreign_key :bookmarks, :posts
+    remove_foreign_key :bookmarks, :users
+  end
+end


### PR DESCRIPTION
Bookmarks is one of the few tables that has foreign keys, and this was causing issues all over the place on deletes etc. Better to remove them for consistency across the DB.