### PR TITLE
FIX: do not parameterize tag_id

### DIFF
--- a/lib/topic_query_params.rb
+++ b/lib/topic_query_params.rb
@@ -3,7 +3,7 @@
 module TopicQueryParams
   def build_topic_list_options
     options = {}
-    params[:tags] = [params[:tag_id].parameterize] if params[:tag_id].present? && guardian.can_tag_pms?
+    params[:tags] = [params[:tag_id]] if params[:tag_id].present? && guardian.can_tag_pms?
 
     TopicQuery.public_valid_options.each do |key|
       if params.key?(key)


### PR DESCRIPTION
Parameterizing tag_id was breaking tags with non-ascii characters or emoji.

Bug report: https://meta.discourse.org/t/unable-to-see-pm-lists-for-non-ascii-tag/151723/4