### PR TITLE
DEV: Guardian for hiding about stats

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/about.hbs
+++ b/app/assets/javascripts/discourse/app/templates/about.hbs
@@ -64,50 +64,52 @@
           </section>
         {{/each}}
       {{/if}}
-      <section class="about stats">
-        <h3>{{d-icon "far-chart-bar"}}  {{i18n "about.stats"}}</h3>
+      {{#if model.can_see_about_stats}}
+        <section class="about stats">
+          <h3>{{d-icon "far-chart-bar"}}  {{i18n "about.stats"}}</h3>
 
-        <table class="table">
-          <tbody>
-            <tr>
-              <th>&nbsp;</th>
-              <th>{{i18n "about.stat.last_7_days"}}</th>
-              <th>{{i18n "about.stat.last_30_days"}}</th>
-              <th>{{i18n "about.stat.all_time"}}</th>
-            </tr>
-            <tr>
-              <td class="title">{{i18n "about.topic_count"}}</td>
-              <td>{{number model.stats.topics_7_days}}</td>
-              <td>{{number model.stats.topics_30_days}}</td>
-              <td>{{number model.stats.topic_count}}</td>
-            </tr>
-            <tr>
-              <td>{{i18n "about.post_count"}}</td>
-              <td>{{number model.stats.posts_7_days}}</td>
-              <td>{{number model.stats.posts_30_days}}</td>
-              <td>{{number model.stats.post_count}}</td>
-            </tr>
-            <tr>
-              <td>{{i18n "about.user_count"}}</td>
-              <td>{{number model.stats.users_7_days}}</td>
-              <td>{{number model.stats.users_30_days}}</td>
-              <td>{{number model.stats.user_count}}</td>
-            </tr>
-            <tr>
-              <td>{{i18n "about.active_user_count"}}</td>
-              <td>{{number model.stats.active_users_7_days}}</td>
-              <td>{{number model.stats.active_users_30_days}}</td>
-              <td>&mdash;</td>
-            </tr>
-            <tr>
-              <td>{{i18n "about.like_count"}}</td>
-              <td>{{number model.stats.likes_7_days}}</td>
-              <td>{{number model.stats.likes_30_days}}</td>
-              <td>{{number model.stats.like_count}}</td>
-            </tr>
-          </tbody>
-        </table>
-      </section>
+          <table class="table">
+            <tbody>
+              <tr>
+                <th>&nbsp;</th>
+                <th>{{i18n "about.stat.last_7_days"}}</th>
+                <th>{{i18n "about.stat.last_30_days"}}</th>
+                <th>{{i18n "about.stat.all_time"}}</th>
+              </tr>
+              <tr>
+                <td class="title">{{i18n "about.topic_count"}}</td>
+                <td>{{number model.stats.topics_7_days}}</td>
+                <td>{{number model.stats.topics_30_days}}</td>
+                <td>{{number model.stats.topic_count}}</td>
+              </tr>
+              <tr>
+                <td>{{i18n "about.post_count"}}</td>
+                <td>{{number model.stats.posts_7_days}}</td>
+                <td>{{number model.stats.posts_30_days}}</td>
+                <td>{{number model.stats.post_count}}</td>
+              </tr>
+              <tr>
+                <td>{{i18n "about.user_count"}}</td>
+                <td>{{number model.stats.users_7_days}}</td>
+                <td>{{number model.stats.users_30_days}}</td>
+                <td>{{number model.stats.user_count}}</td>
+              </tr>
+              <tr>
+                <td>{{i18n "about.active_user_count"}}</td>
+                <td>{{number model.stats.active_users_7_days}}</td>
+                <td>{{number model.stats.active_users_30_days}}</td>
+                <td>&mdash;</td>
+              </tr>
+              <tr>
+                <td>{{i18n "about.like_count"}}</td>
+                <td>{{number model.stats.likes_7_days}}</td>
+                <td>{{number model.stats.likes_30_days}}</td>
+                <td>{{number model.stats.like_count}}</td>
+              </tr>
+            </tbody>
+          </table>
+        </section>
+      {{/if}}
 
       {{#if contactInfo}}
         <section class="about contact">

--- a/app/controllers/about_controller.rb
+++ b/app/controllers/about_controller.rb
@@ -16,7 +16,7 @@ class AboutController < ApplicationController
         render :index
       end
       format.json do
-        render_serialized(@about, AboutSerializer)
+        render_json_dump(AboutSerializer.new(@about, scope: guardian))
       end
     end
   end

--- a/app/serializers/about_serializer.rb
+++ b/app/serializers/about_serializer.rb
@@ -21,7 +21,16 @@ class AboutSerializer < ApplicationSerializer
              :title,
              :locale,
              :version,
-             :https
+             :https,
+             :can_see_about_stats
+
+  def can_see_about_stats
+    scope.can_see_about_stats?
+  end
+
+  def include_stats?
+    can_see_about_stats
+  end
 
   def stats
     object.class.fetch_cached_stats || Jobs::AboutStats.new.execute({})

--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -493,6 +493,10 @@ class Guardian
     is_staff?
   end
 
+  def can_see_about_stats?
+    true
+  end
+
   def auth_token
     if cookie = request&.cookies[Auth::DefaultCurrentUserProvider::TOKEN_COOKIE]
       UserAuthToken.hash_token(cookie)

--- a/test/javascripts/fixtures/about.js
+++ b/test/javascripts/fixtures/about.js
@@ -1,6 +1,7 @@
 export default {
   "about.json": {
     about: {
+      can_see_about_stats: true,
       stats: {
         topic_count: 27480,
         post_count: 490358,


### PR DESCRIPTION
This allows the About site statistics to be hidden for certain users via a plugin. 

With the guardian always returning true (core behavior - no change): 
![Screenshot from 2020-05-20 09-26-04](https://user-images.githubusercontent.com/16214023/82458173-faf16380-9a7b-11ea-9a4c-99481e701b95.png)

___
In a plugin I am going to return false for some users, and they will instead see this:

![Screenshot from 2020-05-20 09-25-55](https://user-images.githubusercontent.com/16214023/82458247-0e9cca00-9a7c-11ea-8b69-580b88eadeae.png)
