### PR TITLE
DEV: Specs for serializing stats from AboutController

### DIFF
--- a/spec/requests/about_controller_spec.rb
+++ b/spec/requests/about_controller_spec.rb
@@ -36,5 +36,21 @@ describe AboutController do
         expect(response.body).to include("<title>About - Discourse</title>")
       end
     end
+
+    it "serializes stats when 'Guardian#can_see_about_stats?' is true" do
+      Guardian.any_instance.stubs(:can_see_about_stats?).returns(true)
+      get "/about.json"
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["about"].keys).to include("stats")
+    end
+
+    it "does not serialize stats when 'Guardian#can_see_about_stats?' is false" do
+      Guardian.any_instance.stubs(:can_see_about_stats?).returns(false)
+      get "/about.json"
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["about"].keys).not_to include("stats")
+    end
   end
 end


### PR DESCRIPTION
Tests for serialization of about stats, based on whether `Guardian#can_see_about_stats?` is true or false.

Prompted from https://review.discourse.org/t/dev-guardian-for-hiding-about-stats-9841/11951/4?u=markvanlan