### PR TITLE
FEATURE: Add topic excerpt max length site setting

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -159,14 +159,6 @@ class Post < ActiveRecord::Base
     includes(:post_details).find_by(post_details: { key: key, value: value })
   end
 
-  def self.excerpt_size=(sz)
-    @excerpt_size = sz
-  end
-
-  def self.excerpt_size
-    @excerpt_size || 220
-  end
-
   def whisper?
     post_type == Post.types[:whisper]
   end
@@ -482,7 +474,7 @@ class Post < ActiveRecord::Base
   end
 
   def excerpt_for_topic
-    Post.excerpt(cooked, Post.excerpt_size, strip_links: true, strip_images: true, post: self)
+    Post.excerpt(cooked, SiteSetting.topic_excerpt_maxlength, strip_links: true, strip_images: true, post: self)
   end
 
   def is_first_post?

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1467,6 +1467,7 @@ en:
     exclude_rel_nofollow_domains: "A list of domains where nofollow should not be added to links. example.com will automatically allow sub.example.com as well. As a minimum, you should add the domain of this site to help web crawlers find all content. If other parts of your website are at other domains, add those too."
 
     post_excerpt_maxlength: "Maximum length of a post excerpt / summary."
+    topic_excerpt_maxlength: "Maximum length of a topic excerpt / summary, generated from the first post in a topic."
     show_pinned_excerpt_mobile: "Show excerpt on pinned topics in mobile view."
     show_pinned_excerpt_desktop: "Show excerpt on pinned topics in desktop view."
     post_onebox_maxlength: "Maximum length of a oneboxed Discourse post in characters."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -819,6 +819,12 @@ posting:
       ja: 120
       zh_CN: 120
       zh_TW: 120
+  topic_excerpt_maxlength:
+    default: 220
+    locale_default:
+      ja: 120
+      zh_CN: 120
+      zh_TW: 120
   show_pinned_excerpt_mobile:
     client: true
     default: true

--- a/spec/components/search_spec.rb
+++ b/spec/components/search_spec.rb
@@ -444,7 +444,7 @@ describe Search do
       end
 
       let(:expected_blurb) do
-        "...to satisfy any test conditions that require content longer than the typical test post raw content. elephant"
+        "...quire content longer than the typical test post raw content. It really is some long content, folks. elephant"
       end
 
       it 'returns the post' do

--- a/spec/fabricators/post_fabricator.rb
+++ b/spec/fabricators/post_fabricator.rb
@@ -10,7 +10,7 @@ end
 Fabricator(:post_with_long_raw_content, from: :post) do
   raw 'This is a sample post with semi-long raw content. The raw content is also more than
       two hundred characters to satisfy any test conditions that require content longer
-      than the typical test post raw content.'
+      than the typical test post raw content. It really is some long content, folks.'
 end
 
 Fabricator(:post_with_youtube, from: :post) do

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1158,6 +1158,25 @@ describe Post do
     expect(post.custom_fields).to eq("Tommy" => "Hanks", "Vincent" => "Vega")
   end
 
+  describe "#excerpt_for_topic" do
+    it "returns a topic excerpt, defaulting to 220 chars" do
+      expected_excerpt = "This is a sample post with semi-long raw content. The raw content is also more than \ntwo hundred characters to satisfy any test conditions that require content longer \nthan the typical test post raw content. It really is&hellip;"
+      post = Fabricate(:post_with_long_raw_content)
+      post.rebake!
+      excerpt = post.excerpt_for_topic
+      expect(excerpt).to eq(expected_excerpt)
+    end
+
+    it "respects the site setting for topic excerpt" do
+      SiteSetting.topic_excerpt_maxlength = 10
+      expected_excerpt = "This is a &hellip;"
+      post = Fabricate(:post_with_long_raw_content)
+      post.rebake!
+      excerpt = post.excerpt_for_topic
+      expect(excerpt).to eq(expected_excerpt)
+    end
+  end
+
   describe "#rebake!" do
     it "will rebake a post correctly" do
       post = create_post


### PR DESCRIPTION
Adds a new `topic_excerpt_maxlength` site setting.

* When topic excerpt is requested for a post, use the new `topic_excerpt_maxlength` site setting to limit the size of the excerpt
* Remove code for getting/setting Post.excerpt_size as it is not used anywhere
