### PR TITLE
FEATURE: Update the topic excerpt when the OP is rebaked

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -650,6 +650,10 @@ class Post < ActiveRecord::Base
       baked_version: BAKED_VERSION
     )
 
+    if is_first_post?
+      topic.update_excerpt(excerpt_for_topic)
+    end
+
     if invalidate_broken_images
       custom_fields.delete(BROKEN_IMAGES)
       save_custom_fields

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1476,6 +1476,13 @@ class Topic < ActiveRecord::Base
     private_topic
   end
 
+  def update_excerpt(excerpt)
+    update_column(:excerpt, excerpt)
+    if archetype == "banner"
+      ApplicationController.banner_json_cache.clear
+    end
+  end
+
   def pm_with_non_human_user?
     sql = <<~SQL
     SELECT 1 FROM topics

--- a/lib/post_revisor.rb
+++ b/lib/post_revisor.rb
@@ -567,11 +567,7 @@ class PostRevisor
   end
 
   def update_topic_excerpt
-    excerpt = @post.excerpt_for_topic
-    @topic.update_column(:excerpt, excerpt)
-    if @topic.archetype == "banner"
-      ApplicationController.banner_json_cache.clear
-    end
+    @topic.update_excerpt(@post.excerpt_for_topic)
   end
 
   def update_category_description

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1195,6 +1195,23 @@ describe Post do
       expect(post.cooked).to eq(first_cooked)
       expect(result).to eq(true)
     end
+
+    it "updates the topic excerpt at the same time if it is the OP" do
+      post = create_post
+      post.topic.update(excerpt: "test")
+      result = post.rebake!
+      post.topic.reload
+      expect(post.topic.excerpt).not_to eq("test")
+    end
+
+    it "does not update the topic excerpt if the post is not the OP" do
+      post = create_post
+      post2 = create_post
+      post.topic.update(excerpt: "test")
+      result = post2.rebake!
+      post.topic.reload
+      expect(post.topic.excerpt).to eq("test")
+    end
   end
 
   describe "#set_owner" do

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1199,6 +1199,8 @@ describe Post do
     it "updates the topic excerpt at the same time if it is the OP" do
       post = create_post
       post.topic.update(excerpt: "test")
+      DB.exec("UPDATE posts SET cooked = 'frogs' WHERE id = ?", [ post.id ])
+      post.reload
       result = post.rebake!
       post.topic.reload
       expect(post.topic.excerpt).not_to eq("test")


### PR DESCRIPTION
* We now have a site setting "topic_excerpt_maxlength" that is used when the OP is created or revised to generate a topic excerpt.
* However, posts created before this setting was introduced cannot benefit from this change unless they are revised, and if the topic excerpt length setting is changed that situation is also not covererd.
* This PR makes a change to `rebake!` to update the topic excerpt IF the post is the OP.