### PR TITLE
DEV: Deprecate ordered_posts in favor of posts

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -370,7 +370,7 @@ class TopicsController < ApplicationController
     success = true
 
     if changes.length > 0
-      first_post = topic.ordered_posts.first
+      first_post = topic.posts.first
       success = PostRevisor.new(first_post, topic).revise!(current_user, changes, validate_post: false)
 
       if !success && topic.errors.blank?
@@ -546,7 +546,7 @@ class TopicsController < ApplicationController
 
   def bookmark
     topic = Topic.find(params[:topic_id].to_i)
-    first_post = topic.ordered_posts.first
+    first_post = topic.posts.first
 
     bookmark_manager = BookmarkManager.new(current_user)
     bookmark_manager.create(post_id: first_post.id)
@@ -562,7 +562,7 @@ class TopicsController < ApplicationController
     topic = Topic.find_by(id: params[:id])
     guardian.ensure_can_delete!(topic)
 
-    first_post = topic.ordered_posts.first
+    first_post = topic.posts.first
     PostDestroyer.new(current_user, first_post, context: params[:context]).destroy
 
     render body: nil

--- a/app/jobs/regular/delete_topic.rb
+++ b/app/jobs/regular/delete_topic.rb
@@ -13,7 +13,7 @@ module Jobs
       end
 
       if Guardian.new(topic_timer.user).can_delete?(topic)
-        first_post = topic.ordered_posts.first
+        first_post = topic.posts.first
         PostDestroyer.new(topic_timer.user, first_post, context: I18n.t("topic_statuses.auto_deleted_by_timer")).destroy
         topic_timer.trash!(Discourse.system_user)
       end

--- a/app/models/post_mover.rb
+++ b/app/models/post_mover.rb
@@ -482,7 +482,7 @@ class PostMover
   end
 
   def update_last_post_stats
-    post = destination_topic.ordered_posts.where.not(post_type: Post.types[:whisper]).last
+    post = destination_topic.posts.where.not(post_type: Post.types[:whisper]).last
     if post && post_ids.include?(post.id)
       attrs = {}
       attrs[:last_posted_at] = post.created_at

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -179,6 +179,7 @@ class Topic < ActiveRecord::Base
 
   belongs_to :category
   has_many :category_users, through: :category
+  has_many :unordered_posts, class_name: "Post"
   has_many :posts, -> { order(post_number: :asc) }, class_name: "Post"
   has_many :ordered_posts, -> {
     Discourse.deprecate(":ordered_posts is deprecated please use :posts instead", output_in_test: true)

--- a/app/models/topic_converter.rb
+++ b/app/models/topic_converter.rb
@@ -63,7 +63,7 @@ class TopicConverter
   private
 
   def posters
-    @posters ||= @topic.posts.distinct.pluck(:user_id).to_a
+    @posters ||= @topic.unordered_posts.distinct.pluck(:user_id).to_a
   end
 
   def update_user_stats

--- a/app/services/destroy_task.rb
+++ b/app/services/destroy_task.rb
@@ -18,9 +18,9 @@ class DestroyTask
     @io.puts "There are #{topics.count} topics to delete in #{descriptive_slug} category"
     topics.find_each do |topic|
       @io.puts "Deleting #{topic.slug}..."
-      first_post = topic.ordered_posts.first
+      first_post = topic.posts.first
       if first_post.nil?
-        return @io.puts "Topic.ordered_posts.first was nil"
+        return @io.puts "Topic.posts.first was nil"
       end
       @io.puts PostDestroyer.new(Discourse.system_user, first_post).destroy
     end
@@ -36,8 +36,8 @@ class DestroyTask
     end
     @io.puts "There are #{topics.count} topics to delete in #{c.slug} category"
     topics.find_each do |topic|
-      first_post = topic.ordered_posts.first
-      return @io.puts "Topic.ordered_posts.first was nil for topic: #{topic.id}" if first_post.nil?
+      first_post = topic.posts.first
+      return @io.puts "Topic.posts.first was nil for topic: #{topic.id}" if first_post.nil?
       PostDestroyer.new(Discourse.system_user, first_post).destroy
     end
     topics = Topic.where(category_id: c.id, pinned_at: nil)
@@ -54,7 +54,7 @@ class DestroyTask
   def destroy_private_messages
     Topic.where(archetype: "private_message").find_each do |pm|
       @io.puts "Destroying #{pm.slug} pm"
-      first_post = pm.ordered_posts.first
+      first_post = pm.posts.first
       @io.puts PostDestroyer.new(Discourse.system_user, first_post).destroy
     end
   end

--- a/app/services/staff_action_logger.rb
+++ b/app/services/staff_action_logger.rb
@@ -82,7 +82,7 @@ class StaffActionLogger
       "title: #{topic.title}"
     ]
 
-    if first_post = topic.ordered_posts.with_deleted.first
+    if first_post = topic.posts.with_deleted.first
       details << "raw: #{first_post.raw}"
     end
 

--- a/app/views/list/list.rss.erb
+++ b/app/views/list/list.rss.erb
@@ -17,7 +17,7 @@
           <dc:creator><![CDATA[<%= rss_creator(topic.user) -%>]]></dc:creator>
           <category><%= topic.category.name %></category>
           <description><![CDATA[
-            <%- if first_post = topic.ordered_posts.first %>
+            <%- if first_post = topic.posts.first %>
             <%= first_post.cooked.html_safe %>
             <%- end %>
             <p><small><%= t 'rss_num_posts', count: topic.posts_count %> - <%= t 'rss_num_participants', count: topic.participant_count %></small></p>

--- a/db/migrate/20130221215017_add_description_to_categories.rb
+++ b/db/migrate/20130221215017_add_description_to_categories.rb
@@ -19,7 +19,7 @@ class AddDescriptionToCategories < ActiveRecord::Migration[4.2]
       Discourse.reset_active_record_cache
 
       Category.order('id').each do |c|
-        post = c.topic.ordered_posts.first
+        post = c.topic.posts.first
         PostRevisor.new(post).update_category_description
       end
 

--- a/lib/email/sender.rb
+++ b/lib/email/sender.rb
@@ -103,7 +103,7 @@ module Email
         return skip(SkippedEmailLog.reason_types[:sender_topic_deleted]) if topic.blank?
 
         add_attachments(post)
-        first_post = topic.ordered_posts.first
+        first_post = topic.posts.first
 
         topic_message_id = first_post.incoming_email&.message_id.present? ?
           "<#{first_post.incoming_email.message_id}>" :

--- a/lib/flag_query.rb
+++ b/lib/flag_query.rb
@@ -85,7 +85,7 @@ module FlagQuery
         action[:name_key] = PostActionType.types.key(rs.reviewable_score_type)
 
         if rs.meta_topic.present?
-          meta_posts = rs.meta_topic.ordered_posts
+          meta_posts = rs.meta_topic.posts
 
           conversation = {}
           if response = meta_posts[0]

--- a/lib/guardian/topic_guardian.rb
+++ b/lib/guardian/topic_guardian.rb
@@ -115,7 +115,7 @@ module TopicGuardian
     if is_staff?
       !!(topic && topic.deleted_at)
     else
-      topic && can_recover_post?(topic.ordered_posts.first)
+      topic && can_recover_post?(topic.posts.first)
     end
   end
 

--- a/lib/import_export/base_exporter.rb
+++ b/lib/import_export/base_exporter.rb
@@ -117,7 +117,7 @@ module ImportExport
 
         topic_data[:posts] = []
 
-        topic.ordered_posts.find_each do |post|
+        topic.posts.find_each do |post|
           attributes = POST_ATTRS.inject({}) do |h, a|
             h[a] = post.public_send(a)
             h

--- a/lib/import_export/importer.rb
+++ b/lib/import_export/importer.rb
@@ -107,7 +107,7 @@ module ImportExport
           existing_categories << { category_id: category.id, value: import_id }
 
           if cat_attrs[:description].present?
-            post = category.topic.ordered_posts.first
+            post = category.topic.posts.first
             post.raw = cat_attrs[:description]
             post.skip_validation = true
             post.save!

--- a/lib/oneboxer.rb
+++ b/lib/oneboxer.rb
@@ -238,7 +238,7 @@ module Oneboxer
 
     post = post_number > 1 ?
       topic.posts.where(post_number: post_number).first :
-      topic.ordered_posts.first
+      topic.posts.first
 
     return if !post || post.hidden || !allowed_post_types.include?(post.post_type)
 

--- a/lib/post_revisor.rb
+++ b/lib/post_revisor.rb
@@ -96,7 +96,7 @@ class PostRevisor
       if prev_tags.sort != tags.sort
         tc.record_change('tags', prev_tags, tags)
         DB.after_commit do
-          post = tc.topic.ordered_posts.first
+          post = tc.topic.posts.first
           notified_user_ids = [post.user_id, post.last_editor_id].uniq
           Jobs.enqueue(:notify_tag_change, post_id: post.id, notified_user_ids: notified_user_ids)
         end

--- a/lib/reviewable/conversation.rb
+++ b/lib/reviewable/conversation.rb
@@ -33,7 +33,7 @@ class Reviewable < ActiveRecord::Base
       @permalink = "#{Discourse.base_url_no_prefix}#{meta_topic.relative_url}"
       @posts = []
 
-      meta_posts = meta_topic.ordered_posts.where(post_type: ::Post.types[:regular]).limit(2)
+      meta_posts = meta_topic.posts.where(post_type: ::Post.types[:regular]).limit(2)
 
       @conversation_posts = meta_posts.map { |mp| Reviewable::Conversation::Post.new(mp) }
       @has_more = meta_topic.posts_count > 2

--- a/lib/tasks/posts.rake
+++ b/lib/tasks/posts.rake
@@ -313,7 +313,7 @@ task 'posts:reorder_posts', [:topic_id] => [:environment] do |_, args|
     # update sort_order and flip post_number to prevent
     # unique constraint violations when updating post_number
     builder = DB.build(<<~SQL)
-      WITH ordered_posts AS (
+      WITH posts AS (
           SELECT
             id,
             ROW_NUMBER()
@@ -326,7 +326,7 @@ task 'posts:reorder_posts', [:topic_id] => [:environment] do |_, args|
       UPDATE posts AS p
       SET sort_order = o.new_post_number,
         post_number  = p.post_number * -1
-      FROM ordered_posts AS o
+      FROM posts AS o
       WHERE p.id = o.id AND
             p.post_number <> o.new_post_number
     SQL

--- a/lib/topic_view.rb
+++ b/lib/topic_view.rb
@@ -701,7 +701,7 @@ class TopicView
   end
 
   def unfiltered_posts
-    result = filter_post_types(@topic.posts)
+    result = filter_post_types(@topic.unordered_posts)
     result = result.with_deleted if @guardian.can_see_deleted_posts?
     result = result.where("user_id IS NOT NULL") if @exclude_deleted_users
     result = result.where(hidden: false) if @exclude_hidden

--- a/lib/topics_bulk_action.rb
+++ b/lib/topics_bulk_action.rb
@@ -140,7 +140,7 @@ class TopicsBulkAction
   def delete
     topics.each do |t|
       if guardian.can_delete?(t)
-        post = t.ordered_posts.first
+        post = t.posts.first
         PostDestroyer.new(@user, post).destroy if post
       end
     end

--- a/lib/validators/post_validator.rb
+++ b/lib/validators/post_validator.rb
@@ -138,7 +138,7 @@ class PostValidator < ActiveModel::Validator
     return if SiteSetting.max_consecutive_replies == 0 || post.id || post.acting_user&.staff? || private_message?(post)
 
     topic = post.topic
-    return if topic&.ordered_posts&.first&.user == post.user
+    return if topic&.posts&.first&.user == post.user
 
     last_posts_count = DB.query_single(<<~SQL, topic_id: post.topic_id, user_id: post.acting_user.id, max_replies: SiteSetting.max_consecutive_replies).first
       SELECT COUNT(*)
@@ -156,7 +156,7 @@ class PostValidator < ActiveModel::Validator
     return if last_posts_count < SiteSetting.max_consecutive_replies
 
     guardian = Guardian.new(post.acting_user)
-    if guardian.can_edit?(topic.ordered_posts.last)
+    if guardian.can_edit?(topic.posts.last)
       post.errors.add(:base, I18n.t(:max_consecutive_replies, count: SiteSetting.max_consecutive_replies))
     end
   end

--- a/plugins/discourse-narrative-bot/spec/discourse_narrative_bot/advanced_user_narrative_spec.rb
+++ b/plugins/discourse-narrative-bot/spec/discourse_narrative_bot/advanced_user_narrative_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe DiscourseNarrativeBot::AdvancedUserNarrative do
         #{I18n.t('discourse_narrative_bot.advanced_user_narrative.edit.instructions', base_uri: '')}
         RAW
 
-        new_post = topic.ordered_posts.last(2).first
+        new_post = topic.posts.last(2).first
 
         expect(narrative.get_data(user)).to eq("topic_id" => topic.id,
                                                "state" => "tutorial_edit",
@@ -110,7 +110,7 @@ RSpec.describe DiscourseNarrativeBot::AdvancedUserNarrative do
         #{I18n.t('discourse_narrative_bot.advanced_user_narrative.edit.instructions', base_uri: '')}
         RAW
 
-        new_post = Topic.last.ordered_posts.last(2).first
+        new_post = Topic.last.posts.last(2).first
 
         expect(narrative.get_data(user)).to eq(
           "topic_id" => new_post.topic.id,
@@ -243,7 +243,7 @@ RSpec.describe DiscourseNarrativeBot::AdvancedUserNarrative do
 
             DiscourseNarrativeBot::TrackSelector.new(:reply, user, post_id: post.id).select
 
-            new_post = topic.ordered_posts.last(2).first
+            new_post = topic.posts.last(2).first
 
             expect(new_post.raw).to eq(I18n.t(
               'discourse_narrative_bot.advanced_user_narrative.recover.instructions', base_uri: '')
@@ -279,7 +279,7 @@ RSpec.describe DiscourseNarrativeBot::AdvancedUserNarrative do
           RAW
 
           expect(narrative.get_data(user)[:state].to_sym).to eq(:tutorial_recover)
-          expect(topic.ordered_posts.last(2).first.raw).to eq(expected_raw.chomp)
+          expect(topic.posts.last(2).first.raw).to eq(expected_raw.chomp)
         end
 
         context 'when user is an admin' do
@@ -717,7 +717,7 @@ RSpec.describe DiscourseNarrativeBot::AdvancedUserNarrative do
         post.update!(raw: "[details=\"This is a test\"]\nwooohoo\n[/details]")
         narrative.input(:reply, user, post: post)
 
-        expect(topic.ordered_posts.last(2).first.raw).to eq(I18n.t(
+        expect(topic.posts.last(2).first.raw).to eq(I18n.t(
           'discourse_narrative_bot.advanced_user_narrative.details.reply', base_uri: ''
         ))
 

--- a/plugins/discourse-narrative-bot/spec/discourse_narrative_bot/new_user_narrative_spec.rb
+++ b/plugins/discourse-narrative-bot/spec/discourse_narrative_bot/new_user_narrative_spec.rb
@@ -972,7 +972,7 @@ describe DiscourseNarrativeBot::NewUserNarrative do
             DiscourseNarrativeBot::TrackSelector.new(:reply, user, post_id: post.id).select
           end.to change { Post.count }.by(2)
 
-          new_post = topic.ordered_posts.last(2).first
+          new_post = topic.posts.last(2).first
 
           expect(new_post.raw).to eq(I18n.t(
             'discourse_narrative_bot.new_user_narrative.search.reply',

--- a/spec/components/cooked_post_processor_spec.rb
+++ b/spec/components/cooked_post_processor_spec.rb
@@ -1758,7 +1758,7 @@ describe CookedPostProcessor do
         topic.bumped_at = 1.day.ago
         CookedPostProcessor.new(reply).remove_full_quote_on_direct_reply
 
-        expect(topic.ordered_posts.pluck(:id))
+        expect(topic.posts.pluck(:id))
           .to eq([post.id, hidden.id, small_action.id, reply.id])
 
         expect(topic.bumped_at).to eq_time(1.day.ago)
@@ -1772,14 +1772,14 @@ describe CookedPostProcessor do
     it 'does nothing if there are multiple quotes' do
       reply = Fabricate(:post, topic: topic, raw: raw3)
       CookedPostProcessor.new(reply).remove_full_quote_on_direct_reply
-      expect(topic.ordered_posts.pluck(:id)).to eq([post.id, reply.id])
+      expect(topic.posts.pluck(:id)).to eq([post.id, reply.id])
       expect(reply.raw).to eq(raw3)
     end
 
     it 'does not delete quote if not first paragraph' do
       reply = Fabricate(:post, topic: topic, raw: raw2)
       CookedPostProcessor.new(reply).remove_full_quote_on_direct_reply
-      expect(topic.ordered_posts.pluck(:id)).to eq([post.id, reply.id])
+      expect(topic.posts.pluck(:id)).to eq([post.id, reply.id])
       expect(reply.raw).to eq(raw2)
     end
 

--- a/spec/components/email/receiver_spec.rb
+++ b/spec/components/email/receiver_spec.rb
@@ -443,7 +443,7 @@ describe Email::Receiver do
     it "posts a reply to the topic when the post was deleted" do
       post.update_columns(deleted_at: 1.day.ago)
       expect { process(:reply_user_matching) }.to change { topic.posts.count }
-      expect(topic.ordered_posts.last.reply_to_post_number).to be_nil
+      expect(topic.posts.last.reply_to_post_number).to be_nil
     end
 
     describe 'Unsubscribing via email' do
@@ -796,7 +796,7 @@ describe Email::Receiver do
     it "cap the number of staged users created per email" do
       SiteSetting.maximum_staged_users_per_email = 1
       expect { process(:cc) }.to change(Topic, :count)
-      expect(Topic.last.ordered_posts[-1].post_type).to eq(Post.types[:moderator_action])
+      expect(Topic.last.posts[-1].post_type).to eq(Post.types[:moderator_action])
     end
 
     describe "when 'find_related_post_with_key' is disabled" do
@@ -809,11 +809,11 @@ describe Email::Receiver do
           .to change(Topic, :count).by(1) & change(Post, :count).by(3)
 
         topic = Topic.last
-        ordered_posts = topic.ordered_posts
+        posts = topic.posts
 
-        expect(ordered_posts.first.raw).to eq('This is email reply **1**.')
+        expect(posts.first.raw).to eq('This is email reply **1**.')
 
-        ordered_posts[1..-1].each do |post|
+        posts[1..-1].each do |post|
           expect(post.action_code).to eq('invited_user')
           expect(post.user.email).to eq('one@foo.com')
 
@@ -823,7 +823,7 @@ describe Email::Receiver do
 
         expect { process(:email_reply_2) }.to change { topic.posts.count }.by(1)
         expect { process(:email_reply_3) }.to change { topic.posts.count }.by(1)
-        ordered_posts[1..-1].each(&:trash!)
+        posts[1..-1].each(&:trash!)
         expect { process(:email_reply_4) }.to change { topic.posts.count }.by(1)
       end
     end

--- a/spec/components/post_revisor_spec.rb
+++ b/spec/components/post_revisor_spec.rb
@@ -531,7 +531,7 @@ describe PostRevisor do
       let!(:post) { Fabricate(:post, topic: topic) }
 
       it "should publish topic changes to clients" do
-        revisor = PostRevisor.new(topic.ordered_posts.first, topic)
+        revisor = PostRevisor.new(topic.posts.first, topic)
 
         message = MessageBus.track_publish("/topic/#{topic.id}") do
           revisor.revise!(newuser, title: 'this is a test topic')

--- a/spec/models/post_mover_spec.rb
+++ b/spec/models/post_mover_spec.rb
@@ -311,7 +311,8 @@ describe PostMover do
             expect(small_action.topic_id).to eq(topic.id)
             expect(hidden_small_action.topic_id).to eq(topic.id)
 
-            moderator_post = topic.posts.last
+            # Moderator post is inserted where the first post was
+            moderator_post = topic.posts.find_by(post_number: p2.post_number)
             expect(moderator_post.raw).to include("2 posts were split")
           end
 

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -390,7 +390,7 @@ describe PostsController do
       end
 
       it "doesn't allow updating of deleted posts" do
-        first_post = post.topic.ordered_posts.first
+        first_post = post.topic.posts.first
         PostDestroyer.new(moderator, first_post).destroy
 
         put "/posts/#{first_post.id}.json", params: update_params
@@ -404,7 +404,7 @@ describe PostsController do
       end
 
       it "supports updating posts in deleted topics" do
-        first_post = post.topic.ordered_posts.first
+        first_post = post.topic.posts.first
         PostDestroyer.new(moderator, first_post).destroy
 
         put "/posts/#{first_post.id}.json", params: update_params
@@ -1444,7 +1444,7 @@ describe PostsController do
       end
 
       it "supports reverting posts in deleted topics" do
-        first_post = post.topic.ordered_posts.first
+        first_post = post.topic.posts.first
         PostDestroyer.new(moderator, first_post).destroy
 
         put "/posts/#{post_id}/revisions/#{revision_id}/revert.json"


### PR DESCRIPTION
`posts` becomes `ordered_posts` and `ordered_posts` will be removed in the future.