### PR TITLE
Require rails_helper in spec

### DIFF
--- a/plugins/discourse-narrative-bot/spec/jobs/send_advanced_tutorial_message_spec.rb
+++ b/plugins/discourse-narrative-bot/spec/jobs/send_advanced_tutorial_message_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'rails_helper'
+
 RSpec.describe Jobs::SendAdvancedTutorialMessage do
   before do
     Jobs.run_immediately!


### PR DESCRIPTION
This spec doesn't require rails_helper and so it fails when run in isolation.

## Testing plan
- Run spec without this change and see it fail
- Run spec after this change and see it pass