### PR TITLE
FIX: Include lazyYT-container in cooked post HTML

### DIFF
--- a/plugins/lazy-yt/plugin.rb
+++ b/plugins/lazy-yt/plugin.rb
@@ -32,7 +32,7 @@ class Onebox::Engine::YoutubeOnebox
       escaped_title = ERB::Util.html_escape(video_title)
 
       <<~EOF
-      <div class="onebox lazyYT"
+      <div class="onebox lazyYT lazyYT-container"
            data-youtube-id="#{video_id}"
            data-youtube-title="#{escaped_title}"
            data-width="#{video_width}"


### PR DESCRIPTION
This applies the new styles without waiting for the JS to run.

Tested locally, this does not interfere with the lazyYT script initalization at all.