### PR TITLE
FIX: Wizard previews if color step is excluded

### DIFF
--- a/app/assets/javascripts/wizard/models/wizard.js
+++ b/app/assets/javascripts/wizard/models/wizard.js
@@ -28,7 +28,7 @@ const Wizard = EmberObject.extend({
   getCurrentColors(schemeId) {
     const colorStep = this.steps.findBy("id", "colors");
     if (!colorStep) {
-      return;
+      return this.current_color_scheme;
     }
 
     const themeChoice = colorStep.get("fieldsById.theme_previews");

--- a/app/serializers/wizard_serializer.rb
+++ b/app/serializers/wizard_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class WizardSerializer < ApplicationSerializer
-  attributes :start, :completed
+  attributes :start, :completed, :current_color_scheme
 
   has_many :steps, serializer: WizardStepSerializer, embed: :objects
 
@@ -11,5 +11,15 @@ class WizardSerializer < ApplicationSerializer
 
   def completed
     object.completed?
+  end
+
+  def current_color_scheme
+    color_scheme = Theme.find(SiteSetting.default_theme_id).color_scheme
+    colors = color_scheme ? color_scheme.colors : ColorScheme.base_colors
+
+    # The frontend expects the color hexs to start with '#'
+    colors_with_hash = {}
+    colors.each { |color, hex| colors_with_hash[color] = "##{hex}" }
+    colors_with_hash
   end
 end


### PR DESCRIPTION
The colors for all the previews in the wizard, are found using `getCurrentColors` https://github.com/discourse/discourse/blob/675e9b81c63494cdb62add81edbd86ac626714e5/app/assets/javascripts/wizard/lib/preview.js#L86

[That function](https://github.com/discourse/discourse/blob/675e9b81c63494cdb62add81edbd86ac626714e5/app/assets/javascripts/wizard/models/wizard.js#L28) relies on the `color` step to be present to know the current color scheme colors. This is generally fine, but in [this commit](https://github.com/discourse/discourse/commit/c14f6d4ceda5fec6cb1730fb37d5426ef154d74a#diff-09391891d530f552a629c5ad59c8c698) I added the ability for plugins to exclude plugin steps.

If a plugin excludes the color step, all of the previews will be blank, looking like this: 

![Screenshot from 2020-05-26 10-13-51](https://user-images.githubusercontent.com/16214023/82917917-a5183200-9f39-11ea-9315-5a15d452fa83.png)


By adding the `current_color_scheme` to the wizard serializer, we have a fallback if the `color` step is not present.