### PR TITLE
FIX: Pass current_user to TopicQuery in for categories_and_top_topics

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -57,7 +57,7 @@ class CategoriesController < ApplicationController
           @topic_list = TopicQuery.new(current_user, topic_options).list_latest
           @topic_list.more_topics_url = url_for(public_send("latest_path"))
         elsif style == "categories_and_top_topics"
-          @topic_list = TopicQuery.new(nil, topic_options).list_top_for(SiteSetting.top_page_default_timeframe.to_sym)
+          @topic_list = TopicQuery.new(current_user, topic_options).list_top_for(SiteSetting.top_page_default_timeframe.to_sym)
           @topic_list.more_topics_url = url_for(public_send("top_path"))
         end
 


### PR DESCRIPTION
We are having an issue for the `categories_and_top_topics` style of topic list where the preloaded topic list ends up having one (or more) “unseen” topic (as determined by `ListableTopicSerializer`) which in turn makes the UI `topicTrackingState` think there is 1 new topic, where in reality there are 0. For example, if the user goes to /new no topics are shown.

The topic is only marked as unseen because the `TopicUser` data like `last_read_post_number` is not loaded, because current_user is not passed down to `TopicList`. In the UI `topicTrackingState` relies on this data.

cc @eviltrout 