### PR TITLE
FIX: Pull hotlinked images even when edited by system users

### DIFF
--- a/app/jobs/regular/pull_hotlinked_images.rb
+++ b/app/jobs/regular/pull_hotlinked_images.rb
@@ -152,7 +152,10 @@ module Jobs
         changes = { raw: raw, edit_reason: I18n.t("upload.edit_reason") }
         post.revise(Discourse.system_user, changes, bypass_bump: true, skip_staff_log: true)
       elsif has_downloaded_image || has_new_large_image || has_new_broken_image
-        post.trigger_post_process(bypass_bump: true)
+        post.trigger_post_process(
+          bypass_bump: true,
+          skip_pull_hotlinked_images: true # Avoid an infinite loop of job scheduling
+        )
       end
     end
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -748,11 +748,12 @@ class Post < ActiveRecord::Base
   end
 
   # Enqueue post processing for this post
-  def trigger_post_process(bypass_bump: false, priority: :normal, new_post: false)
+  def trigger_post_process(bypass_bump: false, priority: :normal, new_post: false, skip_pull_hotlinked_images: false)
     args = {
       post_id: id,
       bypass_bump: bypass_bump,
       new_post: new_post,
+      skip_pull_hotlinked_images: skip_pull_hotlinked_images,
     }
     args[:image_sizes] = image_sizes if image_sizes.present?
     args[:invalidate_oneboxes] = true if invalidate_oneboxes.present?

--- a/lib/cooked_post_processor.rb
+++ b/lib/cooked_post_processor.rb
@@ -663,12 +663,11 @@ class CookedPostProcessor
   end
 
   def pull_hotlinked_images
+    return if @opts[:skip_pull_hotlinked_images]
     # have we enough disk space?
     disable_if_low_on_disk_space # But still enqueue the job
     # don't download remote images for posts that are more than n days old
     return unless @post.created_at > (Date.today - SiteSetting.download_remote_images_max_days_old)
-    # we only want to run the job whenever it's changed by a user
-    return if @post.last_editor_id && @post.last_editor_id <= 0
     # make sure no other job is scheduled
     Jobs.cancel_scheduled_job(:pull_hotlinked_images, post_id: @post.id)
     # schedule the job

--- a/spec/components/cooked_post_processor_spec.rb
+++ b/spec/components/cooked_post_processor_spec.rb
@@ -1486,8 +1486,8 @@ describe CookedPostProcessor do
       end
 
       it "does not run when requested to skip" do
-        Jobs.expects(:enqueue_in).never
         CookedPostProcessor.new(post, skip_pull_hotlinked_images: true).pull_hotlinked_images
+        expect(Jobs::PullHotlinkedImages.jobs.size).to eq(0)
       end
 
       context "and there is enough disk space" do

--- a/spec/components/cooked_post_processor_spec.rb
+++ b/spec/components/cooked_post_processor_spec.rb
@@ -1485,15 +1485,13 @@ describe CookedPostProcessor do
         expect(SiteSetting.download_remote_images_to_local).to eq(false)
       end
 
+      it "does not run when requested to skip" do
+        Jobs.expects(:enqueue_in).never
+        CookedPostProcessor.new(post, skip_pull_hotlinked_images: true).pull_hotlinked_images
+      end
+
       context "and there is enough disk space" do
-
         before { cpp.expects(:disable_if_low_on_disk_space) }
-
-        it "does not run when the system user updated the post" do
-          post.last_editor_id = Discourse.system_user.id
-          Jobs.expects(:cancel_scheduled_job).never
-          cpp.pull_hotlinked_images
-        end
 
         context "and the post has been updated by an actual user" do
 


### PR DESCRIPTION
Previously the pull hotlinked images job was skipped after system edits. This ensured that we never had an infinite loop of system-edit/pull-hotlinked/system-edit/pull-hotlinked etc.

A side effect was that edits made by system for any other reason (e.g. API, removing full quotes) would prevent pulling hotlinked images. This commit removes the system edit check, and replaces it with another method to avoid an infinite job scheduling loop.

Context: https://meta.discourse.org/t/thumbnail-generation-markdown-rendering-issue/152701/10