### PR TITLE
DEV: Run jobs sequentially in test mode

### DIFF
--- a/app/jobs/base.rb
+++ b/app/jobs/base.rb
@@ -281,8 +281,12 @@ module Jobs
     end
   end
 
-  def self.enqueue(job_name, opts = {})
-    klass = "::Jobs::#{job_name.to_s.camelcase}".constantize
+  def self.enqueue(job, opts = {})
+    if job.instance_of?(Class)
+      klass = job
+    else
+      klass = "::Jobs::#{job.to_s.camelcase}".constantize
+    end
 
     # Unless we want to work on all sites
     unless opts.delete(:all_sites)

--- a/spec/jobs/jobs_base_spec.rb
+++ b/spec/jobs/jobs_base_spec.rb
@@ -47,4 +47,43 @@ describe ::Jobs::Base do
     ::Jobs::Base.new.perform('hello' => 'world', 'sync_exec' => true)
   end
 
+  context "with fake jobs" do
+    let(:common_state) { [] }
+
+    before do
+      class Jobs::TestJob1 < Jobs::Base
+        def execute(args)
+          @@state << "job_1_executed"
+        end
+      end
+      Jobs::TestJob1.class_variable_set(:@@state, common_state)
+
+      class Jobs::TestJob2 < Jobs::Base
+        def execute(args)
+          @@state << "job_2_started"
+          Jobs.enqueue(:test_job_1)
+          @@state << "job_2_finished"
+        end
+      end
+      Jobs::TestJob2.class_variable_set(:@@state, common_state)
+    end
+
+    after do
+      Jobs.send(:remove_const, :TestJob1)
+      Jobs.send(:remove_const, :TestJob2)
+    end
+
+    it "runs jobs synchronously sequentially in tests" do
+      Jobs.run_immediately!
+      Jobs.enqueue(:test_job_2)
+
+      expect(common_state).to eq([
+        "job_2_started",
+        "job_2_finished",
+        "job_1_executed"
+      ])
+    end
+
+  end
+
 end


### PR DESCRIPTION
When running jobs in tests, we use `Jobs.run_immediately!`. This means that jobs are run synchronously when they are enqueued. Jobs sometimes enqueue other jobs, which are also executed synchronously. This means that the outermost job will block until the inner jobs have finished executing. In some cases (e.g. process_post with hotlinked images) this can lead to a deadlock.

This commit changes the behavior slightly. Now we will never run jobs inside other jobs. Instead, we will queue them up and run them sequentially in the order they were enqueued. As a whole, they are still executed synchronously. Consider the example

```ruby
class Jobs::InnerJob < Jobs::Base
  def execute(args)
    puts "Running inner job"
  end
end

class Jobs::OuterJob < Jobs::Base
  def execute(args)
    puts "Starting outer job"
    Jobs.enqueue(:inner_job)
    puts "Finished outer job"
  end
end

Jobs.enqueue(:outer_job)
puts "All jobs complete"
```

The old behavior would result in:

```
Starting outer job
Running inner job
Finished outer job
All jobs complete
```

The new behavior will result in:
```
Starting outer job
Finished outer job
Running inner job
All jobs complete
```