### PR TITLE
DEV: Fix a deprecated `ember` import

### DIFF
--- a/app/assets/javascripts/discourse-loader.js
+++ b/app/assets/javascripts/discourse-loader.js
@@ -29,6 +29,7 @@ var define, requirejs;
         inject: Ember.inject.controller
       },
       "@ember/debug": {
+        isTesting: () => Ember.testing,
         warn: Ember.warn
       },
       "@ember/object": {

--- a/app/assets/javascripts/discourse/app/helpers/page-reloader.js
+++ b/app/assets/javascripts/discourse/app/helpers/page-reloader.js
@@ -1,9 +1,9 @@
 import EmberObject from "@ember/object";
-import Ember from "ember";
+import { isTesting } from "@ember/debug";
 
 export default EmberObject.create({
-  reload: function() {
-    if (!Ember.testing) {
+  reload() {
+    if (!isTesting()) {
       location.reload();
     }
   }


### PR DESCRIPTION
See the following for `Ember.testing` and `@ember/debug isTesting`:

* https://github.com/emberjs/ember.js/blob/8cf29959f76eee822192cb820347113d050b204e/packages/ember/index.js#L372-L376
* https://github.com/emberjs/ember.js/blob/8cf29959f76eee822192cb820347113d050b204e/packages/%40ember/debug/lib/testing.ts