### PR TITLE
FIX: Don't raise an exception if a topic cannot be retrieved

### DIFF
--- a/app/models/topic_embed.rb
+++ b/app/models/topic_embed.rb
@@ -116,7 +116,7 @@ class TopicEmbed < ActiveRecord::Base
     )
 
     url = fd.resolve
-    raise URI::InvalidURIError if url.blank?
+    return if url.blank?
 
     opts = {
       tags: %w[div p code pre h1 h2 h3 b em i strong a img ul li ol blockquote],

--- a/spec/models/topic_embed_spec.rb
+++ b/spec/models/topic_embed_spec.rb
@@ -311,9 +311,10 @@ describe TopicEmbed do
     end
 
     context "non-http URL" do
-      let(:url) { '/test.txt' }
       it "throws an error" do
-        expect { TopicEmbed.find_remote(url) }.to raise_error(URI::InvalidURIError)
+        url = '/test.txt'
+
+        expect(TopicEmbed.find_remote(url)).to be_nil
       end
     end
 


### PR DESCRIPTION
Trying to retrieve a post with a non-existent URL will raise an exception every time, flooding our logs.

Should we set a rate limit in the EmbedsController#comments method when the URL cannot be retrieved?



