### PR TITLE
FIX: Invalidate database theme cache when hostname changes

### DIFF
--- a/app/models/theme_field.rb
+++ b/app/models/theme_field.rb
@@ -60,14 +60,6 @@ class ThemeField < ActiveRecord::Base
   validates :name, format: { with: /\A[a-z_][a-z0-9_-]*\z/i },
                    if: Proc.new { |field| ThemeField.theme_var_type_ids.include?(field.type_id) }
 
-  BASE_COMPILER_VERSION = 16
-  DEPENDENT_CONSTANTS = [
-    BASE_COMPILER_VERSION,
-    Ember::VERSION,
-    GlobalSetting.cdn_url
-  ]
-  COMPILER_VERSION = Digest::SHA1.hexdigest(DEPENDENT_CONSTANTS.join)
-
   belongs_to :theme
 
   def process_html(html)
@@ -311,18 +303,18 @@ class ThemeField < ActiveRecord::Base
   end
 
   def ensure_baked!
-    needs_baking = !self.value_baked || compiler_version != COMPILER_VERSION
+    needs_baking = !self.value_baked || compiler_version != Theme.compiler_version
     return unless needs_baking
 
     if basic_html_field? || translation_field?
       self.value_baked, self.error = translation_field? ? process_translation : process_html(self.value)
       self.error = nil unless self.error.present?
-      self.compiler_version = COMPILER_VERSION
+      self.compiler_version = Theme.compiler_version
       DB.after_commit { CSP::Extension.clear_theme_extensions_cache! }
     elsif extra_js_field?
       self.value_baked, self.error = process_extra_js(self.value)
       self.error = nil unless self.error.present?
-      self.compiler_version = COMPILER_VERSION
+      self.compiler_version = Theme.compiler_version
     elsif basic_scss_field?
       ensure_scss_compiles!
       DB.after_commit { Stylesheet::Manager.clear_theme_cache! }
@@ -332,12 +324,12 @@ class ThemeField < ActiveRecord::Base
       DB.after_commit { CSP::Extension.clear_theme_extensions_cache! }
       DB.after_commit { SvgSprite.expire_cache }
       self.value_baked = "baked"
-      self.compiler_version = COMPILER_VERSION
+      self.compiler_version = Theme.compiler_version
     elsif svg_sprite_field?
       DB.after_commit { SvgSprite.expire_cache }
       self.error = nil
       self.value_baked = "baked"
-      self.compiler_version = COMPILER_VERSION
+      self.compiler_version = Theme.compiler_version
     end
 
     if self.will_save_change_to_value_baked? ||
@@ -370,7 +362,7 @@ class ThemeField < ActiveRecord::Base
     rescue SassC::SyntaxError => e
       self.error = e.message unless self.destroyed?
     end
-    self.compiler_version = COMPILER_VERSION
+    self.compiler_version = Theme.compiler_version
     self.value_baked = Digest::SHA1.hexdigest(result.join(",")) # We don't use the compiled CSS here, we just use it to invalidate the stylesheet cache
   end
 

--- a/spec/models/theme_spec.rb
+++ b/spec/models/theme_spec.rb
@@ -716,7 +716,7 @@ HTML
       first_common_value = Theme.lookup_field(child.id, :desktop, "header")
       first_extra_js_value = Theme.lookup_field(child.id, :extra_js, nil)
 
-      stub_const(ThemeField, :COMPILER_VERSION, "SOME_NEW_HASH") do
+      Theme.stubs(:compiler_version).returns("SOME_NEW_HASH") do
         second_common_value = Theme.lookup_field(child.id, :desktop, "header")
         second_extra_js_value = Theme.lookup_field(child.id, :extra_js, nil)
 
@@ -729,6 +729,19 @@ HTML
         expect(new_common_compiler_version).to eq("SOME_NEW_HASH")
         expect(new_extra_js_compiler_version).to eq("SOME_NEW_HASH")
       end
+    end
+
+    it 'recompiles when the hostname changes' do
+      theme.set_field(target: :settings, name: :yaml, value: "name: bob")
+      theme_field = theme.set_field(target: :common, name: :after_header, value: '<script>console.log("hello world");</script>')
+      theme.save!
+
+      expect(Theme.lookup_field(theme.id, :common, :after_header)).to include("_ws=#{Discourse.current_hostname}")
+
+      Discourse.stubs(:current_hostname).returns("someotherhostname.com")
+      Theme.clear_cache!
+
+      expect(Theme.lookup_field(theme.id, :common, :after_header)).to include("_ws=someotherhostname.com")
     end
   end
 end

--- a/spec/models/theme_spec.rb
+++ b/spec/models/theme_spec.rb
@@ -738,7 +738,7 @@ HTML
 
       expect(Theme.lookup_field(theme.id, :common, :after_header)).to include("_ws=#{Discourse.current_hostname}")
 
-      Discourse.stubs(:current_hostname).returns("someotherhostname.com")
+      SiteSetting.force_hostname = "someotherhostname.com"
       Theme.clear_cache!
 
       expect(Theme.lookup_field(theme.id, :common, :after_header)).to include("_ws=someotherhostname.com")


### PR DESCRIPTION
Hostname can vary per-site on a multisite cluster, so this change requires converting the compiler_version from a constant into a class method which is evaluated at runtime. The value is stored in the theme DistributedCache, so performance impact should be negligible.