### PR TITLE
FEATURE: notify admins about old credentials

### DIFF
--- a/app/jobs/scheduled/old_keys_reminder.rb
+++ b/app/jobs/scheduled/old_keys_reminder.rb
@@ -54,9 +54,9 @@ module Jobs
     end
 
     def keys_list
-      setting_key_messages = old_site_settings_keys.map { |key| "#{key.name} - #{key.updated_at}" }
-      api_key_messages = old_api_keys.map { |key| "#{[key.description, key.user&.username, key.created_at].compact.join(" - ")}" }
-      [setting_key_messages | api_key_messages].join("\n")
+      messages = old_site_settings_keys.map { |key| "#{key.name} - #{key.updated_at}" }
+      old_api_keys.each_with_object(messages) { |key, array| array << "#{[key.description, key.user&.username, key.created_at].compact.join(" - ")}" }
+      messages.join("\n")
     end
   end
 end

--- a/app/jobs/scheduled/old_keys_reminder.rb
+++ b/app/jobs/scheduled/old_keys_reminder.rb
@@ -4,19 +4,20 @@ module Jobs
   class OldKeysReminder < ::Jobs::Scheduled
     every 1.month
 
+    OLD_CREDENTIALS_PERIOD = 2.years
+
     def execute(_args)
-      return if SiteSetting.notify_about_secrets_older_than == 'never'
+      return if SiteSetting.send_old_credential_reminder_days.to_i == 0
+      return if message_exists?
       return if old_site_settings_keys.blank? && old_api_keys.blank?
-      admins.each do |admin|
-        PostCreator.create!(
-          Discourse.system_user,
-          title: title,
-          raw: body,
-          archetype: Archetype.private_message,
-          target_usernames: admin.username,
-          validate: false
-        )
-      end
+      PostCreator.create!(
+        Discourse.system_user,
+        title: title,
+        raw: body,
+        archetype: Archetype.private_message,
+        target_usernames: admins.map(&:username),
+        validate: false
+      )
     end
 
     private
@@ -25,28 +26,29 @@ module Jobs
       @old_site_settings_keys ||= SiteSetting.secret_settings.each_with_object([]) do |secret_name, old_keys|
         site_setting = SiteSetting.find_by(name: secret_name)
         next if site_setting&.value.blank?
-        next if site_setting.updated_at + calculate_period > Time.zone.now
+        next if site_setting.updated_at + OLD_CREDENTIALS_PERIOD > Time.zone.now
         old_keys << site_setting
       end.sort_by { |key| key.updated_at }
     end
 
     def old_api_keys
       @old_api_keys ||= ApiKey.all.order(created_at: :asc).each_with_object([]) do |api_key, old_keys|
-        next if api_key.created_at + calculate_period > Time.zone.now
+        next if api_key.created_at + OLD_CREDENTIALS_PERIOD > Time.zone.now
         old_keys << api_key
       end
-    end
-
-    def calculate_period
-      SiteSetting.notify_about_secrets_older_than.to_i.years
     end
 
     def admins
       User.real.admins
     end
 
+    def message_exists?
+      message = Topic.private_messages.with_deleted.find_by(title: title)
+      message && message.created_at + SiteSetting.send_old_credential_reminder_days.to_i.days > Time.zone.now
+    end
+
     def title
-      I18n.t('old_keys_reminder.title', keys_count: old_site_settings_keys.count + old_api_keys.count)
+      I18n.t('old_keys_reminder.title')
     end
 
     def body
@@ -54,8 +56,8 @@ module Jobs
     end
 
     def keys_list
-      messages = old_site_settings_keys.map { |key| "#{key.name} - #{key.updated_at}" }
-      old_api_keys.each_with_object(messages) { |key, array| array << "#{[key.description, key.user&.username, key.created_at].compact.join(" - ")}" }
+      messages = old_site_settings_keys.map { |key| "#{key.name} - #{key.updated_at.to_date.to_s(:db)}" }
+      old_api_keys.each_with_object(messages) { |key, array| array << "#{[key.description, key.user&.username, key.created_at.to_date.to_s(:db)].compact.join(" - ")}" }
       messages.join("\n")
     end
   end

--- a/app/jobs/scheduled/old_keys_reminder.rb
+++ b/app/jobs/scheduled/old_keys_reminder.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module Jobs
+  class OldKeysReminder < ::Jobs::Scheduled
+    every 1.month
+
+    def execute(_args)
+      return if SiteSetting.notify_about_secrets_older_than == 'never'
+      return if old_site_settings_keys.blank? && old_api_keys.blank?
+      admins.each do |admin|
+        PostCreator.create!(
+          Discourse.system_user,
+          title: title,
+          raw: body,
+          archetype: Archetype.private_message,
+          target_usernames: admin.username,
+          validate: false
+        )
+      end
+    end
+
+    private
+
+    def old_site_settings_keys
+      @old_site_settings_keys ||= SiteSetting.secret_settings.each_with_object([]) do |secret_name, old_keys|
+        site_setting = SiteSetting.find_by(name: secret_name)
+        next unless site_setting
+        next if site_setting.value.blank?
+        next if site_setting.updated_at + calculate_period > Time.zone.now
+        old_keys << site_setting
+      end
+    end
+
+    def old_api_keys
+      @old_api_keys ||= ApiKey.all.each_with_object([]) do |api_key, old_keys|
+        next if api_key.created_at + calculate_period > Time.zone.now
+        old_keys << api_key
+      end
+    end
+
+    def calculate_period
+      case SiteSetting.notify_about_secrets_older_than
+      when '1 year'
+        1.year
+      when '2 years'
+        2.years
+      when '3 years'
+        3.years
+      end
+    end
+
+    def admins
+      User.real.where(admin: true)
+    end
+
+    def title
+      I18n.t('old_keys_reminder.title', keys_count: old_site_settings_keys.count + old_api_keys.count)
+    end
+
+    def body
+      I18n.t('old_keys_reminder.body', keys: keys_list)
+    end
+
+    def keys_list
+      setting_key_messages = old_site_settings_keys.map { |key| "#{key.name} - #{key.updated_at}" }
+      api_key_messages = old_api_keys.map { |key| "#{[key.description, key.user&.username, key.created_at].compact.join(" - ")}" }
+      [setting_key_messages | api_key_messages].join("\n")
+    end
+  end
+end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1578,6 +1578,7 @@ en:
     moderators_view_emails: "Allow moderators to view user emails"
     prioritize_username_in_ux: "Show username first on user page, user card and posts (when disabled name is shown first)"
     enable_rich_text_paste: "Enable automatic HTML to Markdown conversion when pasting text into the composer. (Experimental)"
+    notify_about_secrets_older_than: "Notify about credentials older than"
 
     email_token_valid_hours: "Forgot password / activate account tokens are valid for (n) hours."
 
@@ -4812,3 +4813,12 @@ en:
 
   discord:
     not_in_allowed_guild: "Authentication failed. You are not a member of a permitted Discord guild."
+
+  old_keys_reminder:
+    title: "You have %{keys_count} old credentials"
+    body: |
+      We have detected you have the following credentials that are 2 years or older
+
+      %{keys}
+
+      These credentials are sensitive and we recommend resetting them every 2 years to avoid impact of any future data breaches

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1578,7 +1578,7 @@ en:
     moderators_view_emails: "Allow moderators to view user emails"
     prioritize_username_in_ux: "Show username first on user page, user card and posts (when disabled name is shown first)"
     enable_rich_text_paste: "Enable automatic HTML to Markdown conversion when pasting text into the composer. (Experimental)"
-    notify_about_secrets_older_than: "Notify about credentials older than"
+    send_old_credential_reminder_days: "Remind about old credentials after days"
 
     email_token_valid_hours: "Forgot password / activate account tokens are valid for (n) hours."
 
@@ -4815,10 +4815,12 @@ en:
     not_in_allowed_guild: "Authentication failed. You are not a member of a permitted Discord guild."
 
   old_keys_reminder:
-    title: "You have %{keys_count} old credentials"
+    title: "Reminder about old credentials"
     body: |
-      We have detected you have the following credentials that are 2 years or older
-
+      Hello! This is a routine yearly security reminder from your Discourse instance.
+      
+      As a courtesy, we wanted to let you know that the following credentials used on your Discourse instance have not been updated in more than two years:
+      
       %{keys}
-
-      These credentials are sensitive and we recommend resetting them every 2 years to avoid impact of any future data breaches
+      
+      No action is required at this time, however, it is considered good security practice to cycle all your important credentials every few years.

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1448,14 +1448,9 @@ security:
   allow_embedding_site_in_an_iframe:
     default: false
     hidden: true
-  notify_about_secrets_older_than:
-    default: "2 years"
-    type: enum
-    choices:
-      - never
-      - "1 year"
-      - "2 years"
-      - "3 years"
+  send_old_credential_reminder_days:
+    default: 0
+    hidden: true
 
 onebox:
   enable_flash_video_onebox: false

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1448,6 +1448,14 @@ security:
   allow_embedding_site_in_an_iframe:
     default: false
     hidden: true
+  notify_about_secrets_older_than:
+    default: "2 years"
+    type: enum
+    choices:
+      - never
+      - "1 year"
+      - "2 years"
+      - "3 years"
 
 onebox:
   enable_flash_video_onebox: false

--- a/spec/jobs/old_keys_reminder_spec.rb
+++ b/spec/jobs/old_keys_reminder_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Jobs::OldKeysReminder do
+  let!(:google_secret) { SiteSetting.create!(name: 'google_oauth2_client_secret', value: '123', data_type: 1) }
+  let!(:instagram_secret) { SiteSetting.create!(name: 'instagram_consumer_secret', value: '123', data_type: 1) }
+  let!(:api_key) { Fabricate(:api_key, description: 'api key description') }
+  let!(:admin) { Fabricate(:admin) }
+
+  it "detects old keys" do
+    SiteSetting.notify_about_secrets_older_than = "2 years"
+    freeze_time 2.years.from_now
+    expect(described_class.new.send(:old_site_settings_keys).sort).to eq([google_secret, instagram_secret].sort)
+    expect(described_class.new.send(:old_api_keys)).to eq([api_key])
+    SiteSetting.notify_about_secrets_older_than = "3 years"
+    expect(described_class.new.send(:old_site_settings_keys)).to eq([])
+    expect(described_class.new.send(:old_api_keys)).to eq([])
+  end
+
+  it 'has correct title' do
+    SiteSetting.notify_about_secrets_older_than = "2 years"
+    freeze_time 2.years.from_now
+    expect(described_class.new.send(:title)).to eq("You have 3 old credentials")
+  end
+
+  it 'has correct body' do
+    SiteSetting.notify_about_secrets_older_than = "2 years"
+    freeze_time 2.years.from_now
+    expect(described_class.new.send(:body)).to eq(<<-MSG)
+We have detected you have the following credentials that are 2 years or older
+
+google_oauth2_client_secret - #{google_secret.updated_at}
+instagram_consumer_secret - #{instagram_secret.updated_at}
+api key description - #{api_key.created_at}
+
+These credentials are sensitive and we recommend resetting them every 2 years to avoid impact of any future data breaches
+    MSG
+  end
+
+  it 'sends message to admin' do
+    freeze_time 2.years.from_now
+    expect { described_class.new.execute({}) }.to change { Post.count }.by(1)
+    post = Post.last
+    expect(post.archetype).to eq(Archetype.private_message)
+    expect(post.topic.topic_allowed_users.map(&:user_id).sort).to eq([Discourse.system_user.id, admin.id].sort)
+  end
+
+  it 'does not send message when notification set to never or no old keys' do
+    SiteSetting.notify_about_secrets_older_than = "never"
+    freeze_time 2.years.from_now
+    expect { described_class.new.execute({}) }.to change { Post.count }.by(0)
+    SiteSetting.notify_about_secrets_older_than = "never"
+    freeze_time 2.years.from_now
+    expect { described_class.new.execute({}) }.to change { Post.count }.by(0)
+  end
+end

--- a/spec/jobs/old_keys_reminder_spec.rb
+++ b/spec/jobs/old_keys_reminder_spec.rb
@@ -7,49 +7,72 @@ describe Jobs::OldKeysReminder do
   let!(:instagram_secret) { SiteSetting.create!(name: 'instagram_consumer_secret', value: '123', data_type: 1) }
   let!(:api_key) { Fabricate(:api_key, description: 'api key description') }
   let!(:admin) { Fabricate(:admin) }
+  let!(:another_admin) { Fabricate(:admin) }
 
   let!(:recent_twitter_secret) { SiteSetting.create!(name: 'twitter_consumer_secret', value: '123', data_type: 1, updated_at: 2.years.from_now) }
-  let!(:recent_api_key) { Fabricate(:api_key, description: 'recent api key description', created_at: 2.years.from_now) }
+  let!(:recent_api_key) { Fabricate(:api_key, description: 'recent api key description', created_at: 2.years.from_now, user_id: admin.id) }
+
+  it 'is disabled be default' do
+    freeze_time 2.years.from_now
+    expect { described_class.new.execute({}) }.not_to change { Post.count }
+  end
 
   it 'sends message to admin with old credentials' do
+    SiteSetting.send_old_credential_reminder_days = '365'
     freeze_time 2.years.from_now
     expect { described_class.new.execute({}) }.to change { Post.count }.by(1)
     post = Post.last
     expect(post.archetype).to eq(Archetype.private_message)
-    expect(post.topic.topic_allowed_users.map(&:user_id).sort).to eq([Discourse.system_user.id, admin.id].sort)
-    expect(post.topic.title).to eq("You have 3 old credentials")
+    expect(post.topic.topic_allowed_users.map(&:user_id).sort).to eq([Discourse.system_user.id, admin.id, another_admin.id].sort)
+    expect(post.topic.title).to eq('Reminder about old credentials')
     expect(post.raw).to eq(<<-MSG.rstrip)
-We have detected you have the following credentials that are 2 years or older
+Hello! This is a routine yearly security reminder from your Discourse instance.
 
-google_oauth2_client_secret - #{google_secret.updated_at}
-instagram_consumer_secret - #{instagram_secret.updated_at}
-api key description - #{api_key.created_at}
+As a courtesy, we wanted to let you know that the following credentials used on your Discourse instance have not been updated in more than two years:
 
-These credentials are sensitive and we recommend resetting them every 2 years to avoid impact of any future data breaches
+google_oauth2_client_secret - #{google_secret.updated_at.to_date.to_s(:db)}
+instagram_consumer_secret - #{instagram_secret.updated_at.to_date.to_s(:db)}
+api key description - #{api_key.created_at.to_date.to_s(:db)}
+
+No action is required at this time, however, it is considered good security practice to cycle all your important credentials every few years.
     MSG
 
+    post.topic.destroy
     freeze_time 4.years.from_now
     described_class.new.execute({})
     post = Post.last
-    expect(post.topic.title).to eq("You have 5 old credentials")
+    expect(post.topic.title).to eq('Reminder about old credentials')
     expect(post.raw).to eq(<<-MSG.rstrip)
-We have detected you have the following credentials that are 2 years or older
+Hello! This is a routine yearly security reminder from your Discourse instance.
 
-google_oauth2_client_secret - #{google_secret.updated_at}
-instagram_consumer_secret - #{instagram_secret.updated_at}
-twitter_consumer_secret - #{recent_twitter_secret.updated_at}
-api key description - #{api_key.created_at}
-recent api key description - #{recent_api_key.created_at}
+As a courtesy, we wanted to let you know that the following credentials used on your Discourse instance have not been updated in more than two years:
 
-These credentials are sensitive and we recommend resetting them every 2 years to avoid impact of any future data breaches
+google_oauth2_client_secret - #{google_secret.updated_at.to_date.to_s(:db)}
+instagram_consumer_secret - #{instagram_secret.updated_at.to_date.to_s(:db)}
+twitter_consumer_secret - #{recent_twitter_secret.updated_at.to_date.to_s(:db)}
+api key description - #{api_key.created_at.to_date.to_s(:db)}
+recent api key description - #{admin.username} - #{recent_api_key.created_at.to_date.to_s(:db)}
+
+No action is required at this time, however, it is considered good security practice to cycle all your important credentials every few years.
     MSG
   end
 
-  it 'does not send message when notification set to never or no old keys' do
-    SiteSetting.notify_about_secrets_older_than = "never"
+  it 'does not send message when send_old_credential_reminder_days is set to 0 or no old keys' do
+    expect { described_class.new.execute({}) }.to change { Post.count }.by(0)
+    SiteSetting.send_old_credential_reminder_days = '0'
     freeze_time 2.years.from_now
     expect { described_class.new.execute({}) }.to change { Post.count }.by(0)
-    SiteSetting.notify_about_secrets_older_than = "3 years"
+  end
+
+  it 'does not send a message if already exists' do
+    SiteSetting.send_old_credential_reminder_days = '367'
+    freeze_time 2.years.from_now
+    expect { described_class.new.execute({}) }.to change { Post.count }.by(1)
+    Topic.last.trash!
     expect { described_class.new.execute({}) }.to change { Post.count }.by(0)
+    freeze_time 1.years.from_now
+    expect { described_class.new.execute({}) }.to change { Post.count }.by(0)
+    freeze_time 3.days.from_now
+    expect { described_class.new.execute({}) }.to change { Post.count }.by(1)
   end
 end

--- a/spec/jobs/old_keys_reminder_spec.rb
+++ b/spec/jobs/old_keys_reminder_spec.rb
@@ -8,26 +8,17 @@ describe Jobs::OldKeysReminder do
   let!(:api_key) { Fabricate(:api_key, description: 'api key description') }
   let!(:admin) { Fabricate(:admin) }
 
-  it "detects old keys" do
-    SiteSetting.notify_about_secrets_older_than = "2 years"
-    freeze_time 2.years.from_now
-    expect(described_class.new.send(:old_site_settings_keys).sort).to eq([google_secret, instagram_secret].sort)
-    expect(described_class.new.send(:old_api_keys)).to eq([api_key])
-    SiteSetting.notify_about_secrets_older_than = "3 years"
-    expect(described_class.new.send(:old_site_settings_keys)).to eq([])
-    expect(described_class.new.send(:old_api_keys)).to eq([])
-  end
+  let!(:recent_twitter_secret) { SiteSetting.create!(name: 'twitter_consumer_secret', value: '123', data_type: 1, updated_at: 2.years.from_now) }
+  let!(:recent_api_key) { Fabricate(:api_key, description: 'recent api key description', created_at: 2.years.from_now) }
 
-  it 'has correct title' do
-    SiteSetting.notify_about_secrets_older_than = "2 years"
+  it 'sends message to admin with old credentials' do
     freeze_time 2.years.from_now
-    expect(described_class.new.send(:title)).to eq("You have 3 old credentials")
-  end
-
-  it 'has correct body' do
-    SiteSetting.notify_about_secrets_older_than = "2 years"
-    freeze_time 2.years.from_now
-    expect(described_class.new.send(:body)).to eq(<<-MSG)
+    expect { described_class.new.execute({}) }.to change { Post.count }.by(1)
+    post = Post.last
+    expect(post.archetype).to eq(Archetype.private_message)
+    expect(post.topic.topic_allowed_users.map(&:user_id).sort).to eq([Discourse.system_user.id, admin.id].sort)
+    expect(post.topic.title).to eq("You have 3 old credentials")
+    expect(post.raw).to eq(<<-MSG.rstrip)
 We have detected you have the following credentials that are 2 years or older
 
 google_oauth2_client_secret - #{google_secret.updated_at}
@@ -36,22 +27,29 @@ api key description - #{api_key.created_at}
 
 These credentials are sensitive and we recommend resetting them every 2 years to avoid impact of any future data breaches
     MSG
-  end
 
-  it 'sends message to admin' do
-    freeze_time 2.years.from_now
-    expect { described_class.new.execute({}) }.to change { Post.count }.by(1)
+    freeze_time 4.years.from_now
+    described_class.new.execute({})
     post = Post.last
-    expect(post.archetype).to eq(Archetype.private_message)
-    expect(post.topic.topic_allowed_users.map(&:user_id).sort).to eq([Discourse.system_user.id, admin.id].sort)
+    expect(post.topic.title).to eq("You have 5 old credentials")
+    expect(post.raw).to eq(<<-MSG.rstrip)
+We have detected you have the following credentials that are 2 years or older
+
+google_oauth2_client_secret - #{google_secret.updated_at}
+instagram_consumer_secret - #{instagram_secret.updated_at}
+twitter_consumer_secret - #{recent_twitter_secret.updated_at}
+api key description - #{api_key.created_at}
+recent api key description - #{recent_api_key.created_at}
+
+These credentials are sensitive and we recommend resetting them every 2 years to avoid impact of any future data breaches
+    MSG
   end
 
   it 'does not send message when notification set to never or no old keys' do
     SiteSetting.notify_about_secrets_older_than = "never"
     freeze_time 2.years.from_now
     expect { described_class.new.execute({}) }.to change { Post.count }.by(0)
-    SiteSetting.notify_about_secrets_older_than = "never"
-    freeze_time 2.years.from_now
+    SiteSetting.notify_about_secrets_older_than = "3 years"
     expect { described_class.new.execute({}) }.to change { Post.count }.by(0)
   end
 end


### PR DESCRIPTION
Security and API keys should be renewed periodically.
This additional notification should help admins keep their Discourse safe and secure.

This code was already merged and reverted. The last commit is improvements to reverted version