### PR TITLE
FIX: Staff users can bypass tag validation rule

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -1157,6 +1157,7 @@ export default Controller.extend({
     const tagsArray = tags || [];
     if (
       this.site.can_tag_topics &&
+      !this.currentUser.staff &&
       category &&
       category.minimum_required_tags > tagsArray.length
     ) {

--- a/app/assets/javascripts/discourse/app/models/composer.js
+++ b/app/assets/javascripts/discourse/app/models/composer.js
@@ -374,7 +374,7 @@ const Composer = RestModel.extend({
     "tags",
     "topicFirstPost",
     "minimumRequiredTags",
-    "isStaffUser"
+    "user.staff"
   )
   cantSubmitPost(
     loading,

--- a/test/javascripts/acceptance/composer-tags-test.js
+++ b/test/javascripts/acceptance/composer-tags-test.js
@@ -1,0 +1,58 @@
+import Category from "discourse/models/category";
+import { acceptance, updateCurrentUser } from "helpers/qunit-helpers";
+import selectKit from "helpers/select-kit-helper";
+
+acceptance("Composer - Tags", {
+  loggedIn: true,
+  pretend(pretenderServer, helper) {
+    pretenderServer.post("/uploads/lookup-urls", () => {
+      return helper.response([]);
+    });
+  },
+  site: {
+    can_tag_topics: true
+  }
+});
+
+QUnit.test("staff bypass tag validation rule", async assert => {
+  await visit("/");
+  await click("#create-topic");
+
+  await fillIn("#reply-title", "this is my new topic title");
+  await fillIn(".d-editor-input", "this is the *content* of a post");
+
+  Category.findById(2).set("minimum_required_tags", 1);
+
+  const categoryChooser = selectKit(".category-chooser");
+  await categoryChooser.expand();
+  await categoryChooser.selectRowByValue(2);
+
+  await click("#reply-control button.create");
+  assert.notEqual(currentURL(), "/");
+});
+
+QUnit.test("users do not bypass tag validation rule", async assert => {
+  await visit("/");
+  await click("#create-topic");
+
+  await fillIn("#reply-title", "this is my new topic title");
+  await fillIn(".d-editor-input", "this is the *content* of a post");
+
+  Category.findById(2).set("minimum_required_tags", 1);
+
+  const categoryChooser = selectKit(".category-chooser");
+  await categoryChooser.expand();
+  await categoryChooser.selectRowByValue(2);
+
+  updateCurrentUser({ moderator: false, admin: false, trust_level: 1 });
+
+  await click("#reply-control button.create");
+  assert.equal(currentURL(), "/");
+
+  const tags = selectKit(".mini-tag-chooser");
+  await tags.expand();
+  await tags.selectRowByValue("monkey");
+
+  await click("#reply-control button.create");
+  assert.notEqual(currentURL(), "/");
+});


### PR DESCRIPTION
The rule was already bypassed on the server side.