### PR TITLE
FEATURE: Download remote images even for old posts

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1452,7 +1452,6 @@ en:
     crawl_images: "Retrieve images from remote URLs to insert the correct width and height dimensions."
     download_remote_images_to_local: "Convert remote images to local images by downloading them; this prevents broken images."
     download_remote_images_threshold: "Minimum disk space necessary to download remote images locally (in percent)"
-    download_remote_images_max_days_old: "Don't download remote images for posts that are more than n days old."
     disabled_image_download_domains: "Remote images will never be downloaded from these domains. Pipe-delimited list."
     editing_grace_period: "For (n) seconds after posting, editing will not create a new version in the post history."
     editing_grace_period_max_diff: "Maximum number of character changes allowed in editing grace period, if more changed store another post revision (trust level 0 and 1)"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1166,10 +1166,6 @@ files:
   download_remote_images_to_local:
     default: true
   download_remote_images_threshold: 10
-  download_remote_images_max_days_old:
-    default: 30
-    min: 1
-    max: 10000
   disabled_image_download_domains:
     type: list
     default: ""

--- a/lib/cooked_post_processor.rb
+++ b/lib/cooked_post_processor.rb
@@ -666,8 +666,6 @@ class CookedPostProcessor
     return if @opts[:skip_pull_hotlinked_images]
     # have we enough disk space?
     disable_if_low_on_disk_space # But still enqueue the job
-    # don't download remote images for posts that are more than n days old
-    return unless @post.created_at > (Date.today - SiteSetting.download_remote_images_max_days_old)
     # make sure no other job is scheduled
     Jobs.cancel_scheduled_job(:pull_hotlinked_images, post_id: @post.id)
     # schedule the job

--- a/spec/components/cooked_post_processor_spec.rb
+++ b/spec/components/cooked_post_processor_spec.rb
@@ -1555,34 +1555,6 @@ describe CookedPostProcessor do
 
   end
 
-  context "#download_remote_images_max_days_old" do
-
-    let(:post) { build(:post, created_at: 20.days.ago) }
-    let(:cpp) { CookedPostProcessor.new(post) }
-
-    before do
-      SiteSetting.download_remote_images_to_local = true
-      cpp.expects(:disable_if_low_on_disk_space).returns(false)
-    end
-
-    it "does not run when download_remote_images_max_days_old is not satisfied" do
-      SiteSetting.download_remote_images_max_days_old = 15
-      Jobs.expects(:cancel_scheduled_job).never
-      cpp.pull_hotlinked_images
-    end
-
-    it "runs when download_remote_images_max_days_old is satisfied" do
-      SiteSetting.download_remote_images_max_days_old = 30
-
-      Jobs.expects(:cancel_scheduled_job).with(:pull_hotlinked_images, post_id: post.id).once
-
-      delay = SiteSetting.editing_grace_period + 1
-      Jobs.expects(:enqueue_in).with(delay.seconds, :pull_hotlinked_images, post_id: post.id).once
-
-      cpp.pull_hotlinked_images
-    end
-  end
-
   context "#is_a_hyperlink?" do
 
     let(:post) { build(:post) }


### PR DESCRIPTION
When a post is rebaked, the admins expect it to work the same regardless of how old the post is.