### PR TITLE
DEV: Plugin api for adding category admin dropdown items

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-navigation.js
+++ b/app/assets/javascripts/discourse/app/components/d-navigation.js
@@ -4,6 +4,14 @@ import { inject as service } from "@ember/service";
 import Component from "@ember/component";
 import FilterModeMixin from "discourse/mixins/filter-mode";
 
+let _pluginCategoryAdminDropdownActions = {};
+
+export function addCategoryAdminDropdownAction(actionId, handler) {
+  _pluginCategoryAdminDropdownActions[actionId] =
+    _pluginCategoryAdminDropdownActions[actionId] || [];
+  _pluginCategoryAdminDropdownActions[actionId].push(handler);
+}
+
 export default Component.extend(FilterModeMixin, {
   router: service(),
   persistedQueryParams: null,
@@ -96,6 +104,10 @@ export default Component.extend(FilterModeMixin, {
         case "reorder":
           this.reorderCategories();
           break;
+      }
+      const pluginActions = _pluginCategoryAdminDropdownActions[actionId];
+      if (Array.isArray(pluginActions)) {
+        pluginActions.forEach(action => action());
       }
     },
 

--- a/app/assets/javascripts/discourse/app/lib/plugin-api.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.js
@@ -48,6 +48,7 @@ import {
   addComposerUploadHandler,
   addComposerUploadMarkdownResolver
 } from "discourse/components/composer-editor";
+import { addCategoryAdminDropdownAction } from "discourse/components/d-navigation";
 import { addCategorySortCriteria } from "discourse/components/edit-category-settings";
 import { addExtraIconRenderer } from "discourse/helpers/category-link";
 import { queryRegistry } from "discourse/widgets/widget";
@@ -1140,6 +1141,34 @@ class PluginApi {
    **/
   addCategoryLinkIcon(renderer) {
     addExtraIconRenderer(renderer);
+  }
+
+  /**
+   * adds an item and handler to the category admin dropdown
+   *
+   * ```
+   * api.addCategoryAdminDropdownItem(
+   *    {
+   *      id: "some-button",
+   *      name: I18n.t("some-button.name"),
+   *      description: I18n.t("some-button.description"),
+   *      icon: "plus"
+   *    },
+   *    function() {
+   *      console.log("clicked some-button!");
+   *    }
+   * );
+   * ```
+   *
+   **/
+  addCategoryAdminDropdownItem(item, handler) {
+    if (!item || !item.id) return;
+
+    modifySelectKit("categories-admin-dropdown").appendContent(function() {
+      return item;
+    });
+
+    addCategoryAdminDropdownAction(item.id, handler);
   }
 }
 


### PR DESCRIPTION
It is suprising difficult to add an item to this dropdown right now.

![Screenshot from 2020-05-29 10-33-50](https://user-images.githubusercontent.com/16214023/83277688-08070480-a198-11ea-8cfc-0b33b79b6764.png)

The actions for the items are defined in `app/assets/javascripts/discourse/app/components/d-navigation.js`, but the items themselves are defined [here](https://github.com/discourse/discourse/blob/94cb5ab17274a26f7bd972eb06a2d90b73f7a2f1/app/assets/javascripts/select-kit/addon/components/categories-admin-dropdown.js#L20).

This plugin api gives a single function to add an item to the dropdown, as well as a function to call when the item is clicked.

___
**Possible change?**

I could see including the callback function in `item` like
```
{
  id: X
  label: X
  onClick: function() {...}
}
```

And cutting out the onClick out of the `item` to pass it into 
```
modifySelectKit("categories-admin-dropdown").appendContent(function() {
    return item;
});
```