### PR TITLE
UX: Position topic admin menu next to wrench

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/topic-admin-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/topic-admin-menu.js
@@ -90,13 +90,15 @@ createWidget("topic-admin-menu-button", {
       $button = $(e.target).closest("button");
     }
 
-    const position = $button.position();
+    const position = $button.position(),
+      SPACING = 3,
+      MENU_WIDTH = 217;
 
     const rtl = $("html").hasClass("rtl");
     position.outerHeight = $button.outerHeight();
 
     if (rtl) {
-      position.left -= 217 - $button.outerWidth();
+      position.left -= MENU_WIDTH - $button.outerWidth();
     }
 
     if (this.attrs.fixed) {
@@ -105,12 +107,12 @@ createWidget("topic-admin-menu-button", {
 
     if (this.attrs.openUpwards) {
       if (rtl) {
-        position.left -= $button[0].offsetWidth;
+        position.left -= $button[0].offsetWidth + SPACING;
       } else {
-        position.left += $button[0].offsetWidth;
+        position.left += $button[0].offsetWidth + SPACING;
       }
     } else {
-      position.top += $button[0].offsetHeight;
+      position.top += $button[0].offsetHeight + SPACING;
     }
 
     if (this.site.mobileView && !this.attrs.rightSide) {

--- a/app/assets/javascripts/discourse/app/widgets/topic-admin-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/topic-admin-menu.js
@@ -103,6 +103,16 @@ createWidget("topic-admin-menu-button", {
       position.left += $button.width() - 203;
     }
 
+    if (this.attrs.openUpwards) {
+      if (rtl) {
+        position.left -= $button[0].offsetWidth;
+      } else {
+        position.left += $button[0].offsetWidth;
+      }
+    } else {
+      position.top += $button[0].offsetHeight;
+    }
+
     if (this.site.mobileView && !this.attrs.rightSide) {
       const headerCloak = document.querySelector(".header-cloak");
       if (headerCloak) headerCloak.style.display = "block";


### PR DESCRIPTION
Moves the admin menu below the button when next to the timeline: 

<img width="299" alt="image" src="https://user-images.githubusercontent.com/368961/83293070-32b58500-a1b9-11ea-8cdf-81dec05c6611.png">

and to the left (or right on RTL) of the button when next to the footer topic buttons: 

<img width="426" alt="image" src="https://user-images.githubusercontent.com/368961/83293131-4e209000-a1b9-11ea-8cfd-07c21607c786.png">
