### PR TITLE
FEATURE: New plugin outlet under badges page title

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/badges/index.hbs
+++ b/app/assets/javascripts/discourse/app/templates/badges/index.hbs
@@ -2,6 +2,8 @@
   <div class="container badges">
     <h1>{{i18n "badges.title"}}</h1>
 
+    {{plugin-outlet name="below-badges-title"}}
+
     <div class="badge-groups">
       {{#each badgeGroups as |bg|}}
         <div class="badge-grouping">


### PR DESCRIPTION
This outlet will enable Discourse sites to include a description/message beneath the Badges page title.

<img width="1431" alt="Screen Shot 2020-05-29 at 2 40 53 PM" src="https://user-images.githubusercontent.com/22733864/83308140-03077c80-a1bb-11ea-91a0-731c3012bd09.png">
