### PR TITLE
DEV: Better error handling for destroy:users task

### DIFF
--- a/app/services/destroy_task.rb
+++ b/app/services/destroy_task.rb
@@ -90,6 +90,8 @@ class DestroyTask
         raise Discourse::InvalidAccess.new("User #{user.username} has #{user.post_count} posts, so can't be deleted.")
       rescue NoMethodError
         @io.puts "#{user.username} could not be deleted"
+      rescue Discourse::InvalidAccess => e
+        @io.puts "#{user.username} #{e.message}"
       end
     end
   end


### PR DESCRIPTION
@oblakeerickson came up with this solution while helping me debug an issue with the `destroy:users` task. The task would abort if a single user exceeded the limits set in the `delete_all_posts_max` and `delete_user_max_post_age` site settings.

This change will prevent the rake task from aborting when hitting the `InvalidAccess` error and instead output the username and error message for any users that could not be deleted.