### PR TITLE
FIX: Only render group card if user title is from group

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/transform-post.js
+++ b/app/assets/javascripts/discourse/app/lib/transform-post.js
@@ -47,6 +47,7 @@ export function transformBasicPost(post) {
     new_user: post.trust_level === 0,
     name: post.name,
     user_title: post.user_title,
+    title_is_group: post.title_is_group,
     created_at: post.created_at,
     updated_at: post.updated_at,
     canDelete: post.can_delete,

--- a/app/assets/javascripts/discourse/app/widgets/poster-name.js
+++ b/app/assets/javascripts/discourse/app/widgets/poster-name.js
@@ -18,7 +18,7 @@ createWidget("poster-name-title", {
 
   html(attrs) {
     let titleContents = attrs.title;
-    if (attrs.primaryGroupName) {
+    if (attrs.primaryGroupName && attrs.titleIsGroup) {
       const href = Discourse.getURL(`/g/${attrs.primaryGroupName}`);
       titleContents = h(
         "a.user-group",
@@ -126,10 +126,15 @@ export default createWidget("poster-name", {
       );
     }
 
-    const title = attrs.user_title;
+    const title = attrs.user_title,
+      titleIsGroup = attrs.title_is_group;
     if (title && title.length) {
       contents.push(
-        this.attach("poster-name-title", { title, primaryGroupName })
+        this.attach("poster-name-title", {
+          title,
+          primaryGroupName,
+          titleIsGroup
+        })
       );
     }
 

--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -47,6 +47,7 @@ class PostSerializer < BasicPostSerializer
              :link_counts,
              :read,
              :user_title,
+             :title_is_group,
              :reply_to_user,
              :bookmarked,
              :bookmark_reminder_at,
@@ -210,6 +211,14 @@ class PostSerializer < BasicPostSerializer
 
   def user_title
     object&.user&.title
+  end
+
+  def title_is_group
+    object&.user&.title == object.user&.primary_group&.title
+  end
+
+  def include_title_is_group?
+    object&.user&.title.present?
   end
 
   def trust_level


### PR DESCRIPTION
This was failing when a user with a primary_group chose to display a title coming from a badge.