### PR TITLE
FIX: Correct the misalignment of popover arrows

### DIFF
--- a/app/assets/stylesheets/common/base/d-popover.scss
+++ b/app/assets/stylesheets/common/base/d-popover.scss
@@ -80,15 +80,14 @@ $d-popover-border: $primary-medium;
 
   .d-popover-top-arrow {
     border-color: transparent transparent $d-popover-border;
-    top: 8px;
-    transform: translate(0, -15px);
+    top: -8px;
     border-width: 0 8px 8px;
 
     &:after {
       border-color: transparent transparent $d-popover-background;
       border-style: solid;
       border-width: 0 7px 7px;
-      bottom: -8px;
+      bottom: -8.5px;
       margin-left: -7px;
       position: absolute;
       content: "";
@@ -97,8 +96,7 @@ $d-popover-border: $primary-medium;
 
   .d-popover-bottom-arrow {
     border-color: $d-popover-border transparent transparent;
-    top: calc(100% + 16px);
-    transform: translate(0, -16px);
+    top: 100%;
     border-width: 8px 8px 0;
 
     &:after {
@@ -107,7 +105,7 @@ $d-popover-border: $primary-medium;
       border-color: $d-popover-background transparent transparent;
       border-style: solid;
       border-width: 7px 7px 0;
-      bottom: 2px;
+      bottom: 1.5px;
       transform: translate(-7px, 0);
     }
   }


### PR DESCRIPTION
* Fixes position of the top arrow, and border width of both
* Merged `top` and `transform` properties
* .5px values are required to make arrow border appear the same with as overall popover border width

Before/after

<img width="308" alt="Screen Shot 2020-05-25 at 14 59 50" src="https://user-images.githubusercontent.com/66961/83350496-c2d00780-a33c-11ea-8ac0-daed6f4486cd.png"> <img width="308" alt="Screen Shot 2020-05-25 at 15 01 27" src="https://user-images.githubusercontent.com/66961/83350495-c19eda80-a33c-11ea-9f4c-133e87a5a5af.png">