### PR TITLE
UX: Remove box-shadow from kbd, unify styling

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -644,18 +644,20 @@ pre {
 }
 
 kbd {
-  border-radius: 3px;
-  box-shadow: shadow("kbd");
+  align-items: center;
   background: dark-light-choose(#fafafa, #303030);
   border: 1px solid dark-light-choose(#d0d0d0, #505050);
-  border-bottom: none;
-
+  border-bottom-width: 2px;
+  border-radius: 3px;
+  box-sizing: border-box;
   color: $primary;
-  display: inline-block;
+  display: inline-flex;
   font-size: $font-down-1;
+  justify-content: center;
   line-height: $line-height-large;
-  margin: 0 0.1em;
-  padding: 0.1em 0.6em;
+  margin: 0 0.15em;
+  min-width: 24px;
+  padding: 0.15em 0.6em;
 
   // don't allow more than 3 nested elements to prevent FF from crashing
   // cf. http://what.thedailywtf.com/t/nested-elements/7927

--- a/app/assets/stylesheets/common/components/keyboard_shortcuts.scss
+++ b/app/assets/stylesheets/common/components/keyboard_shortcuts.scss
@@ -55,7 +55,7 @@
       border-radius: 3px;
       display: inline-flex;
       margin: 0 6px;
-      padding: 1px 0 5px;
+      padding: 2px 1px 4px;
     }
 
     span:first-child {
@@ -63,19 +63,8 @@
     }
 
     kbd {
-      align-items: center;
-      box-sizing: border-box;
-      color: dark-light-choose(#333, #aaa);
-      display: inline-flex;
       font-family: $base-font-family;
       font-weight: bold;
-      height: 24px;
-      justify-content: center;
-      margin: 0 3px;
-      min-width: 24px;
-      padding: 0 6px;
-      vertical-align: bottom;
-      white-space: nowrap;
     }
   }
 }


### PR DESCRIPTION
Having many elements with multiple box-shadows (e.g. in keyboard shortcuts modal) was tanking scrolling performance in some browsers.

Before/after

<table>
<tr>
<td><img width="250" alt="before_light_help" src="https://user-images.githubusercontent.com/66961/83351639-172bb500-a346-11ea-8428-f329835746e7.png"></td>
<td><img width="250" alt="after_light_help" src="https://user-images.githubusercontent.com/66961/83351663-535f1580-a346-11ea-91e6-a2c7ab0009d8.png"></td>
</tr>
<tr>
<td><img width="190" alt="before_light_post" src="https://user-images.githubusercontent.com/66961/83351635-1430c480-a346-11ea-8fa1-738d0e845f52.png"></td>
<td><img width="190" alt="after_light_post" src="https://user-images.githubusercontent.com/66961/83351662-535f1580-a346-11ea-802f-f93e031f5195.png"></td>
</tr>
<tr>
<td><img width="250" alt="before_dark_help" src="https://user-images.githubusercontent.com/66961/83351637-16931e80-a346-11ea-9e7a-ddff3aa2d10c.png"></td>
<td><img width="250" alt="after_dark_help" src="https://user-images.githubusercontent.com/66961/83351664-53f7ac00-a346-11ea-951b-410b57f12a60.png"></td>
</tr>
<tr>
<td><img width="190" alt="before_dark_post" src="https://user-images.githubusercontent.com/66961/83351636-1561f180-a346-11ea-8e78-88aafb013dc4.png"></td>
<td><img width="190" alt="after_dark_post" src="https://user-images.githubusercontent.com/66961/83351661-52c67f00-a346-11ea-9797-9249b2f113d0.png"></td>
</tr>
</table>