### PR TITLE
DEV: Drop unused image_url column from posts and topics

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -10,8 +10,10 @@ class Post < ActiveRecord::Base
   include HasCustomFields
   include LimitedEdit
 
-  # TODO(2021-01-04): remove
-  self.ignored_columns = ["avg_time"]
+  self.ignored_columns = [
+    "avg_time", # TODO(2021-01-04): remove
+    "image_url" # TODO(2021-06-01): remove
+  ]
 
   cattr_accessor :plugin_permitted_create_params
   self.plugin_permitted_create_params = {}
@@ -1145,7 +1147,6 @@ end
 #  raw_email               :text
 #  public_version          :integer          default(1), not null
 #  action_code             :string
-#  image_url               :string
 #  locked_by_id            :integer
 #  image_upload_id         :bigint
 #

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -10,8 +10,10 @@ class Topic < ActiveRecord::Base
   include LimitedEdit
   extend Forwardable
 
-  # TODO(2021-01-04): remove
-  self.ignored_columns = ["avg_time"]
+  self.ignored_columns = [
+    "avg_time", # TODO(2021-01-04): remove
+    "image_url" # TODO(2021-06-01): remove
+  ]
 
   def_delegator :featured_users, :user_ids, :featured_user_ids
   def_delegator :featured_users, :choose, :feature_topic_users
@@ -1663,7 +1665,6 @@ end
 #  featured_user3_id         :integer
 #  deleted_at                :datetime
 #  highest_post_number       :integer          default(0), not null
-#  image_url                 :string
 #  like_count                :integer          default(0), not null
 #  incoming_link_count       :integer          default(0), not null
 #  category_id               :integer

--- a/db/post_migrate/20200601111500_remove_image_url_from_post_and_topic.rb
+++ b/db/post_migrate/20200601111500_remove_image_url_from_post_and_topic.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class RemoveImageUrlFromPostAndTopic < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
+  def up
+    execute <<~SQL
+      ALTER TABLE topics DROP COLUMN IF EXISTS image_url
+    SQL
+
+    ActiveRecord::Base.transaction do
+      execute "DROP VIEW badge_posts"
+
+      execute <<~SQL
+        ALTER TABLE posts DROP COLUMN IF EXISTS image_url
+      SQL
+
+      # we must recreate this view every time we amend posts
+      # p.* is auto expanded and persisted into the view definition
+      # at create time
+      execute <<~SQL
+        CREATE VIEW badge_posts AS
+        SELECT p.*
+        FROM posts p
+        JOIN topics t ON t.id = p.topic_id
+        JOIN categories c ON c.id = t.category_id
+        WHERE c.allow_badges AND
+              p.deleted_at IS NULL AND
+              t.deleted_at IS NULL AND
+              NOT c.read_restricted AND
+              t.visible AND
+              p.post_type IN (1,2,3)
+      SQL
+    end
+  end
+
+  def down
+    # do nothing re-runnable
+  end
+end


### PR DESCRIPTION
This has been superseded by image_upload_id. The image_url value in API responses is now generated dynamically from the upload record.