### PR TITLE
Drop support for outdated browsers

### DIFF
--- a/plugins/discourse-unsupported-browser/config/settings.yml
+++ b/plugins/discourse-unsupported-browser/config/settings.yml
@@ -1,6 +1,7 @@
 plugins:
   discourse_unsupported_browser_enabled:
-    default: true
+    default: false
+    hidden: true
   browser_deprecation_warning:
     default: true
     client: true

--- a/plugins/discourse-unsupported-browser/spec/middleware/anonymous_cache_spec.rb
+++ b/plugins/discourse-unsupported-browser/spec/middleware/anonymous_cache_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 describe Middleware::AnonymousCache::Helper do
+  before { SiteSetting.discourse_unsupported_browser_enabled = true }
+
   def env(opts = {})
     {
       "HTTP_HOST" => "http://test.com",


### PR DESCRIPTION
In particular, this includes Internet Explorer 11. Code which existed to support old browsers will be removed over the coming weeks.

https://meta.discourse.org/t/discourse-is-ending-support-for-internet-explorer-11-ie11-on-june-1-2020/137984