### PR TITLE
FIX: Prevent clipping user mentions

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -806,11 +806,12 @@ blockquote > *:last-child {
 }
 
 a.mention {
+  align-items: baseline;
+  display: inline-flex;
   font-weight: bold;
   font-size: 0.93em;
-  color: $primary;
   color: dark-light-choose($primary-high, $secondary-low);
-  padding: 2px 4px;
+  padding: 1px 4px;
   background: $primary-low;
   border-radius: 8px;
 }


### PR DESCRIPTION
Before/after:

<img width="260" alt="Screen Shot 2020-06-02 at 14 55 36" src="https://user-images.githubusercontent.com/66961/83528444-63fbc100-a4e9-11ea-97cd-e161d7ddb825.png"> <img width="260" alt="Screen Shot 2020-06-02 at 14 59 00" src="https://user-images.githubusercontent.com/66961/83528437-6231fd80-a4e9-11ea-865e-1b49a66e1f6d.png">