### PR TITLE
UX: Add simple-list setting type

### DIFF
--- a/app/assets/javascripts/admin/components/simple-list.js
+++ b/app/assets/javascripts/admin/components/simple-list.js
@@ -1,0 +1,80 @@
+import { empty } from "@ember/object/computed";
+import Component from "@ember/component";
+import { on } from "discourse-common/utils/decorators";
+
+export default Component.extend({
+  classNameBindings: [":simple-list", ":value-list"],
+  inputEmpty: empty("newValue"),
+  inputDelimiter: null,
+  inputType: null,
+  newValue: "",
+  collection: null,
+  values: null,
+
+  @on("didReceiveAttrs")
+  _setupCollection() {
+    const values = this.values;
+    if (this.inputType === "array") {
+      this.set("collection", values || []);
+      return;
+    }
+
+    this.set(
+      "collection",
+      this._splitValues(values, this.inputDelimiter || "\n")
+    );
+  },
+
+  keyDown(event) {
+    if (event.keyCode === 13) this.send("addValue", this.newValue);
+  },
+
+  actions: {
+    changeValue(index, newValue) {
+      this._replaceValue(index, newValue);
+    },
+
+    addValue(newValue) {
+      if (this.inputInvalid) return;
+
+      this.set("newValue", null);
+      this._addValue(newValue);
+    },
+
+    removeValue(value) {
+      this._removeValue(value);
+    }
+  },
+
+  _addValue(value) {
+    this.collection.addObject(value);
+    this._saveValues();
+  },
+
+  _removeValue(value) {
+    this.collection.removeObject(value);
+    this._saveValues();
+  },
+
+  _replaceValue(index, newValue) {
+    this.collection.replace(index, 1, [newValue]);
+    this._saveValues();
+  },
+
+  _saveValues() {
+    if (this.inputType === "array") {
+      this.set("values", this.collection);
+      return;
+    }
+
+    this.set("values", this.collection.join(this.inputDelimiter || "\n"));
+  },
+
+  _splitValues(values, delimiter) {
+    if (values && values.length) {
+      return values.split(delimiter).filter(x => x);
+    } else {
+      return [];
+    }
+  }
+});

--- a/app/assets/javascripts/admin/mixins/setting-component.js
+++ b/app/assets/javascripts/admin/mixins/setting-component.js
@@ -25,7 +25,8 @@ const CUSTOM_TYPES = [
   "upload",
   "group_list",
   "tag_list",
-  "color"
+  "color",
+  "simple_list"
 ];
 
 const AUTO_REFRESH_ON_SAVE = ["logo", "logo_small", "large_icon"];

--- a/app/assets/javascripts/admin/templates/components/simple-list.hbs
+++ b/app/assets/javascripts/admin/templates/components/simple-list.hbs
@@ -1,0 +1,40 @@
+{{#if collection}}
+  <div class="values">
+    {{#each collection as |value index|}}
+      <div data-index={{index}} class="value">
+        {{d-button
+              action=(action "removeValue")
+              actionParam=value
+              icon="times"
+              class="remove-value-btn btn-small"
+            }}
+
+        {{input
+              title=value
+              value=value
+              class="value-input"
+              focus-out=(action "changeValue" index)
+            }}
+      </div>
+    {{/each}}
+  </div>
+{{/if}}
+
+<div class="simple-list-input">
+  {{input
+    type="text"
+    value=newValue
+    placeholderKey="admin.site_settings.simple_list.add_item"
+    class="add-value-input"
+    autocomplete="discourse"
+    autocorrect="off"
+    autocapitalize="off"}}
+
+  {{d-button
+      action=(action "addValue")
+      actionParam=newValue
+      disabled=inputEmpty
+      icon="plus"
+      class="add-value-btn btn-small"
+    }}
+</div>

--- a/app/assets/javascripts/admin/templates/components/site-settings/simple-list.hbs
+++ b/app/assets/javascripts/admin/templates/components/site-settings/simple-list.hbs
@@ -1,0 +1,3 @@
+{{simple-list values=value inputDelimiter="|"}}
+{{setting-validation-message message=validationMessage}}
+<div class="desc">{{html-safe setting.description}}</div>

--- a/app/assets/stylesheets/common/admin/admin_base.scss
+++ b/app/assets/stylesheets/common/admin/admin_base.scss
@@ -931,6 +931,20 @@ table#user-badges {
   }
 }
 
+.simple-list-input {
+  display: flex;
+
+  input {
+    margin: 0;
+    box-sizing: border-box;
+    flex: 1 0 0px;
+  }
+
+  button {
+    margin-left: 0.25em;
+  }
+}
+
 // Mobile view text-inputs need some padding
 .mobile-view .admin-contents {
   input[type="text"] {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4584,6 +4584,8 @@ en:
           modal_description: "Would you like to apply this change historically? This will change preferences for %{count} existing users."
           modal_yes: "Yes"
           modal_no: "No, only apply change going forward"
+        simple_list:
+          add_item: "Add item..."
 
       badges:
         title: Badges

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1445,7 +1445,7 @@ security:
   content_security_policy_collect_reports:
     default: false
   content_security_policy_script_src:
-    type: list
+    type: simple_list
     default: ""
   invalidate_inactive_admin_email_after_days:
     default: 365

--- a/lib/site_settings/type_supervisor.rb
+++ b/lib/site_settings/type_supervisor.rb
@@ -34,7 +34,8 @@ class SiteSettings::TypeSupervisor
       group: 19,
       group_list: 20,
       tag_list: 21,
-      color: 22
+      color: 22,
+      simple_list: 23
     )
   end
 

--- a/spec/components/site_settings/type_supervisor_spec.rb
+++ b/spec/components/site_settings/type_supervisor_spec.rb
@@ -88,6 +88,9 @@ describe SiteSettings::TypeSupervisor do
       it "'color' should be at the right position" do
         expect(SiteSettings::TypeSupervisor.types[:color]).to eq(22)
       end
+      it "'simple_list' should be at the right position" do
+        expect(SiteSettings::TypeSupervisor.types[:simple_list]).to eq(23)
+      end
     end
   end
 

--- a/test/javascripts/components/simple-list-test.js
+++ b/test/javascripts/components/simple-list-test.js
@@ -1,0 +1,106 @@
+import componentTest from "helpers/component-test";
+moduleForComponent("simple-list", { integration: true });
+
+componentTest("adding a value", {
+  template: "{{simple-list values=values}}",
+
+  beforeEach() {
+    this.set("values", "vinkas\nosama");
+  },
+
+  async test(assert) {
+    assert.ok(
+      find(".add-value-btn[disabled]").length,
+      "while loading the + button is disabled"
+    );
+
+    await fillIn(".add-value-input", "penar");
+    await click(".add-value-btn");
+
+    assert.ok(
+      find(".values .value").length === 3,
+      "it adds the value to the list of values"
+    );
+
+    assert.deepEqual(
+      this.values,
+      "vinkas\nosama\npenar",
+      "it adds the value to the list of values"
+    );
+
+    await fillIn(".add-value-input", "eviltrout");
+    await keyEvent(".add-value-input", "keydown", 13); // enter
+
+    assert.ok(
+      find(".values .value").length === 4,
+      "it adds the value when keying Enter"
+    );
+  }
+});
+
+componentTest("removing a value", {
+  template: "{{simple-list values=values}}",
+
+  beforeEach() {
+    this.set("values", "vinkas\nosama");
+  },
+
+  async test(assert) {
+    await click(".values .value[data-index='0'] .remove-value-btn");
+
+    assert.ok(
+      find(".values .value").length === 1,
+      "it removes the value from the list of values"
+    );
+
+    assert.equal(this.values, "osama", "it removes the expected value");
+  }
+});
+
+componentTest("array support", {
+  template: "{{simple-list values=values inputType='array'}}",
+
+  beforeEach() {
+    this.set("values", ["vinkas", "osama"]);
+  },
+
+  async test(assert) {
+    await fillIn(".add-value-input", "eviltrout");
+    await click(".add-value-btn");
+
+    assert.ok(
+      find(".values .value").length === 3,
+      "it adds the value to the list of values"
+    );
+
+    assert.deepEqual(
+      this.values,
+      ["vinkas", "osama", "eviltrout"],
+      "it adds the value to the list of values"
+    );
+  }
+});
+
+componentTest("delimiter support", {
+  template: "{{simple-list values=values inputDelimiter='|'}}",
+
+  beforeEach() {
+    this.set("values", "vinkas|osama");
+  },
+
+  async test(assert) {
+    await fillIn(".add-value-input", "eviltrout");
+    await click(".add-value-btn");
+
+    assert.ok(
+      find(".values .value").length === 3,
+      "it adds the value to the list of values"
+    );
+
+    assert.deepEqual(
+      this.values,
+      "vinkas|osama|eviltrout",
+      "it adds the value to the list of values"
+    );
+  }
+});


### PR DESCRIPTION
Adds a new site setting list type called simple list, to be used only with settings that **do not** have a list of choices available. 

![screencast 2020-06-02 22-19-13](https://user-images.githubusercontent.com/368961/83588437-62e58680-a51f-11ea-834a-ad416aa69295.gif)

This PR only enables this new setting type for the `content security policy script src` setting, as a first step., Support for other site settings (and theme settings) will be added in subsequent PRs. 