### PR TITLE
DEV: Reorder appending extra header icons

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/header.js
+++ b/app/assets/javascripts/discourse/app/widgets/header.js
@@ -188,6 +188,14 @@ createWidget("header-icons", {
       return [];
     }
 
+    const icons = [];
+
+    if (_extraHeaderIcons) {
+      _extraHeaderIcons.forEach(icon => {
+        icons.push(this.attach(icon));
+      });
+    }
+
     const hamburger = this.attach("header-dropdown", {
       title: "hamburger_menu",
       icon: "bars",
@@ -210,6 +218,7 @@ createWidget("header-icons", {
         }
       }
     });
+    icons.push(hamburger);
 
     const search = this.attach("header-dropdown", {
       title: "search.title",
@@ -219,8 +228,8 @@ createWidget("header-icons", {
       active: attrs.searchVisible,
       href: Discourse.getURL("/search")
     });
+    icons.push(search);
 
-    const icons = [search, hamburger];
     if (attrs.user) {
       icons.push(
         this.attach("user-dropdown", {
@@ -230,12 +239,6 @@ createWidget("header-icons", {
           user: attrs.user
         })
       );
-    }
-
-    if (_extraHeaderIcons) {
-      _extraHeaderIcons.forEach(icon => {
-        icons.push(this.attach(icon));
-      });
     }
 
     return icons;

--- a/app/assets/javascripts/discourse/app/widgets/header.js
+++ b/app/assets/javascripts/discourse/app/widgets/header.js
@@ -20,9 +20,12 @@ export function addToHeaderIcons(icon) {
 
 const dropdown = {
   buildClasses(attrs) {
+    let classes = attrs.classNames || [];
     if (attrs.active) {
-      return "active";
+      classes.push("active");
     }
+
+    return classes;
   },
 
   click(e) {
@@ -202,7 +205,8 @@ createWidget("header-icons", {
       iconId: "search-button",
       action: "toggleSearchMenu",
       active: attrs.searchVisible,
-      href: Discourse.getURL("/search")
+      href: Discourse.getURL("/search"),
+      classNames: ["search-dropdown"]
     });
 
     icons.push(search);
@@ -214,6 +218,8 @@ createWidget("header-icons", {
       active: attrs.hamburgerVisible,
       action: "toggleHamburger",
       href: "",
+      classNames: ["hamburger-dropdown"],
+
       contents() {
         let { currentUser } = this;
         if (currentUser && currentUser.reviewable_count) {

--- a/app/assets/javascripts/discourse/app/widgets/header.js
+++ b/app/assets/javascripts/discourse/app/widgets/header.js
@@ -196,6 +196,17 @@ createWidget("header-icons", {
       });
     }
 
+    const search = this.attach("header-dropdown", {
+      title: "search.title",
+      icon: "search",
+      iconId: "search-button",
+      action: "toggleSearchMenu",
+      active: attrs.searchVisible,
+      href: Discourse.getURL("/search")
+    });
+
+    icons.push(search);
+
     const hamburger = this.attach("header-dropdown", {
       title: "hamburger_menu",
       icon: "bars",
@@ -218,17 +229,8 @@ createWidget("header-icons", {
         }
       }
     });
-    icons.push(hamburger);
 
-    const search = this.attach("header-dropdown", {
-      title: "search.title",
-      icon: "search",
-      iconId: "search-button",
-      action: "toggleSearchMenu",
-      active: attrs.searchVisible,
-      href: Discourse.getURL("/search")
-    });
-    icons.push(search);
+    icons.push(hamburger);
 
     if (attrs.user) {
       icons.push(

--- a/app/assets/javascripts/discourse/app/widgets/header.js
+++ b/app/assets/javascripts/discourse/app/widgets/header.js
@@ -206,7 +206,7 @@ createWidget("header-icons", {
       iconId: "search-button",
       action: "toggleSearchMenu",
       active: attrs.searchVisible,
-      href: Discourse.getURL("/search"),
+      href: getURL("/search"),
       classNames: ["search-dropdown"]
     });
 


### PR DESCRIPTION
I know the temp variables `search` and `hamburger` are not NEEDED because we could push them directly into the `icons` array, but I really like being able to read which widget is which.

I just want to swap the order of when the extra icons are appended. This could have a sort of `start` and `end` option added eventually if needed... Not needed now though.