### PR TITLE
DEV: Remove htmlparser dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "favcount": "https://github.com/chrishunt/favcount",
     "handlebars": "^4.7.0",
     "highlight.js": "https://github.com/highlightjs/highlight.js#d72f0817aaab8187711fca7c608f5272ea5147f6",
-    "htmlparser": "https://github.com/tautologistics/node-htmlparser",
     "intersection-observer": "^0.5.1",
     "jquery": "3.5.0",
     "jquery-color": "3.0.0-alpha.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1512,10 +1512,6 @@ homedir-polyfill@^1.0.1:
   dependencies:
     parse-passwd "^1.0.0"
 
-"htmlparser@https://github.com/tautologistics/node-htmlparser":
-  version "2.0.0"
-  resolved "https://github.com/tautologistics/node-htmlparser#9613b99096ac1757b81695b1a4bbee7f10afcd7f"
-
 https-proxy-agent@^2.2.1:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz#4ee7a737abd92678a293d9b34a1af4d0d08c787b"


### PR DESCRIPTION
We stopped using htmlparser in b5008586. There is no need to list it as a dependency