### PR TITLE
DEV: Add pry-byebug and optionally require pry behind a ENV var for better spec debugging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -112,6 +112,7 @@ gem 'oj'
 gem 'pg'
 gem 'mini_sql'
 gem 'pry-rails', require: false
+gem 'pry-byebug', require: false
 gem 'r2', require: false
 gem 'rake'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -267,6 +267,9 @@ GEM
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    pry-byebug (3.9.0)
+      byebug (~> 11.0)
+      pry (~> 0.13.0)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
     public_suffix (4.0.5)
@@ -516,6 +519,7 @@ DEPENDENCIES
   onebox
   parallel_tests
   pg
+  pry-byebug
   pry-rails
   puma
   r2

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,9 +7,12 @@ end
 
 require 'rubygems'
 require 'rbtrace'
-require 'pry'
-require 'pry-byebug'
-require 'pry-rails'
+
+if ENV['IMPROVED_SPEC_DEBUGGING']
+  require 'pry'
+  require 'pry-byebug'
+  require 'pry-rails'
+end
 
 # Loading more in this block will cause your tests to run faster. However,
 # if you change any configuration or code from libraries loaded here, you'll

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,9 @@ end
 
 require 'rubygems'
 require 'rbtrace'
+require 'pry'
+require 'pry-byebug'
+require 'pry-rails'
 
 # Loading more in this block will cause your tests to run faster. However,
 # if you change any configuration or code from libraries loaded here, you'll


### PR DESCRIPTION
We removed pry-nav a while back because it is not up to date with pry but it is super useful. Luckily [pry-byebug](https://github.com/deivid-rodriguez/pry-byebug) is here to save us all from Satan's power.

To get this to work you need to add the following to your `$HOME/.pryrc` file.

```
if defined?(PryByebug)
  Pry.commands.alias_command 'c', 'continue'
  Pry.commands.alias_command 's', 'step'
  Pry.commands.alias_command 'n', 'next'
  Pry.commands.alias_command 'f', 'finish'
end

Pry::Commands.command /^$/, "repeat last command" do
  pry_instance.run_command Pry.history.to_a.last
end
```

The require-ing of pry, pry-rails, and pry-byebug in specs is controlled by the `IMPROVED_SPEC_DEBUGGING` flag (disabled by default).
