### PR TITLE
PERF: Correctly memoize baseUri value in javascript app

### DIFF
--- a/app/assets/javascripts/discourse-common/addon/lib/get-url.js
+++ b/app/assets/javascripts/discourse-common/addon/lib/get-url.js
@@ -4,7 +4,7 @@ let S3BaseUrl, S3CDN;
 export default function getURL(url) {
   if (!url) return url;
 
-  if (!baseUri) {
+  if (baseUri === undefined) {
     baseUri = $('meta[name="discourse-base-uri"]').attr("content") || "";
   }
 


### PR DESCRIPTION
An empty string is a falsey value in javascript, so we were looking for the meta tag every time getURL was called.

This was a major performance drain on every keypress in the composer. On my browser, this cuts markdown cooking time (excluding setup) from 4ms to 0.8ms.

Before:

<img width="1464" alt="Screenshot 2020-06-05 at 11 16 22" src="https://user-images.githubusercontent.com/6270921/83869621-c391e080-a724-11ea-928f-850865175880.png">

After:
<img width="1066" alt="Screenshot 2020-06-05 at 12 12 36" src="https://user-images.githubusercontent.com/6270921/83870284-e40e6a80-a725-11ea-84f1-f454767695c3.png">

