### PR TITLE
PERF: Cache PrettyText instance for rendering composer preview

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/text.js
+++ b/app/assets/javascripts/discourse/app/lib/text.js
@@ -38,6 +38,15 @@ export function cookAsync(text, options) {
   return loadMarkdownIt().then(() => cook(text, options));
 }
 
+// Warm up pretty text with a set of options and return a function
+// which can be used to cook without rebuilding prettytext every time
+export function generateCookFunction(options) {
+  return loadMarkdownIt().then(() => {
+    const prettyText = createPrettyText(options);
+    return text => prettyText.cook(text);
+  });
+}
+
 export function sanitize(text, options) {
   return textSanitize(text, new WhiteLister(options));
 }


### PR DESCRIPTION
Previously we were building pretty-text from scratch on every keypress. In my browser, this cuts cooking a simple post from 2.5ms to 0.5ms

Before:
<img width="1098" alt="Screenshot 2020-06-05 at 11 20 05" src="https://user-images.githubusercontent.com/6270921/83869412-74e44680-a724-11ea-8c07-231787795ed4.png">

After:
<img width="1204" alt="Screenshot 2020-06-05 at 11 59 01" src="https://user-images.githubusercontent.com/6270921/83869418-77df3700-a724-11ea-8280-c68ab874f99f.png">
