### PR TITLE
PERF: Pass element to resolveAllShortUrl function, not text selector

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-editor.js
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.js
@@ -1000,7 +1000,7 @@ export default Component.extend({
       );
 
       // Short upload urls need resolution
-      resolveAllShortUrls(ajax, this.siteSettings, ".d-editor-preview-wrapper");
+      resolveAllShortUrls(ajax, this.siteSettings, $preview[0]);
 
       if (this._enableAdvancedEditorPreviewSync()) {
         this._syncScroll(


### PR DESCRIPTION
We already have a reference to the preview element, so there is no need to look it up again. This saves about 1ms per keypress in my testing.