### PR TITLE
FIX: Redirects containing Unicode usernames didn't work

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -760,7 +760,7 @@ class ApplicationController < ActionController::Base
     return if !current_user
     return if !should_enforce_2fa?
 
-    redirect_path = "#{GlobalSetting.relative_url_root}/u/#{current_user.username}/preferences/second-factor"
+    redirect_path = path("/u/#{current_user.encoded_username}/preferences/second-factor")
     if !request.fullpath.start_with?(redirect_path)
       redirect_to path(redirect_path)
       nil

--- a/app/controllers/email_controller.rb
+++ b/app/controllers/email_controller.rb
@@ -7,7 +7,7 @@ class EmailController < ApplicationController
   before_action :ensure_logged_in, only: :preferences_redirect
 
   def preferences_redirect
-    redirect_to(email_preferences_path(current_user.username_lower))
+    redirect_to path("/u/#{current_user.encoded_username}/preferences/emails")
   end
 
   def unsubscribe

--- a/app/controllers/email_controller.rb
+++ b/app/controllers/email_controller.rb
@@ -4,11 +4,6 @@ class EmailController < ApplicationController
   layout 'no_ember'
 
   skip_before_action :check_xhr, :preload_json, :redirect_to_login_if_required
-  before_action :ensure_logged_in, only: :preferences_redirect
-
-  def preferences_redirect
-    redirect_to path("/u/#{current_user.encoded_username}/preferences/emails")
-  end
 
   def unsubscribe
     @not_found = true

--- a/app/controllers/user_avatars_controller.rb
+++ b/app/controllers/user_avatars_controller.rb
@@ -109,7 +109,7 @@ class UserAvatarsController < ApplicationController
 
     if !Discourse.avatar_sizes.include?(size) && Discourse.store.external?
       closest = Discourse.avatar_sizes.to_a.min { |a, b| (size - a).abs <=> (size - b).abs }
-      avatar_url = UserAvatar.local_avatar_url(hostname, user.username_lower, upload_id, closest)
+      avatar_url = UserAvatar.local_avatar_url(hostname, user.encoded_username(lower: true), upload_id, closest)
       return redirect_to cdn_path(avatar_url)
     end
 
@@ -117,7 +117,7 @@ class UserAvatarsController < ApplicationController
     upload ||= user.uploaded_avatar if user.uploaded_avatar_id == upload_id
 
     if user.uploaded_avatar && !upload
-      avatar_url = UserAvatar.local_avatar_url(hostname, user.username_lower, user.uploaded_avatar_id, size)
+      avatar_url = UserAvatar.local_avatar_url(hostname, user.encoded_username(lower: true), user.uploaded_avatar_id, size)
       return redirect_to cdn_path(avatar_url)
     elsif upload && optimized = get_optimized_image(upload, size)
       if optimized.local?

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,7 +4,7 @@ class UsersController < ApplicationController
   skip_before_action :authorize_mini_profiler, only: [:avatar]
 
   requires_login only: [
-    :username, :update, :user_preferences_redirect, :upload_user_image,
+    :username, :update, :upload_user_image,
     :pick_avatar, :destroy_user_image, :destroy, :check_emails,
     :topic_tracking_state, :preferences, :create_second_factor_totp,
     :enable_second_factor_totp, :disable_second_factor, :list_second_factors,
@@ -16,7 +16,7 @@ class UsersController < ApplicationController
 
   skip_before_action :check_xhr, only: [
     :show, :badges, :password_reset_show, :password_reset_update, :update, :account_created,
-    :activate_account, :perform_account_activation, :user_preferences_redirect, :avatar,
+    :activate_account, :perform_account_activation, :avatar,
     :my_redirect, :toggle_anon, :admin_login, :confirm_admin, :email_login, :summary,
     :feature_topic, :clear_featured_topic, :bookmarks
   ]
@@ -127,10 +127,6 @@ class UsersController < ApplicationController
   def badges
     raise Discourse::NotFound unless SiteSetting.enable_badges?
     show
-  end
-
-  def user_preferences_redirect
-    redirect_to path("/u/#{current_user.encoded_username}/preferences")
   end
 
   def update

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -130,7 +130,7 @@ class UsersController < ApplicationController
   end
 
   def user_preferences_redirect
-    redirect_to email_preferences_path(current_user.username_lower)
+    redirect_to path("/u/#{current_user.encoded_username}/preferences")
   end
 
   def update
@@ -273,7 +273,7 @@ class UsersController < ApplicationController
       cookies[:destination_url] = path("/my/#{params[:path]}")
       redirect_to path("/login-preferences")
     else
-      redirect_to(path("/u/#{current_user.username}/#{params[:path]}"))
+      redirect_to(path("/u/#{current_user.encoded_username}/#{params[:path]}"))
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1302,6 +1302,10 @@ class User < ActiveRecord::Base
       .pluck(:credential_id)
   end
 
+  def encoded_username(lower: false)
+    UrlHelper.encode_component(lower ? username_lower : username)
+  end
+
   protected
 
   def badge_grant

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -315,8 +315,6 @@ Discourse::Application.routes.draw do
 
     end # admin namespace
 
-    get "email_preferences" => "email#preferences_redirect", :as => "email_preferences_redirect"
-
     get "email/unsubscribe/:key" => "email#unsubscribe", as: "email_unsubscribe"
     get "email/unsubscribed" => "email#unsubscribed", as: "email_unsubscribed"
     post "email/unsubscribe/:key" => "email#perform_unsubscribe", as: "email_perform_unsubscribe"
@@ -374,7 +372,6 @@ Discourse::Application.routes.draw do
     end
 
     get "my/*path", to: 'users#my_redirect'
-    get "user_preferences" => "users#user_preferences_redirect"
     get ".well-known/change-password", to: redirect(relative_url_root + 'my/preferences/account', status: 302)
 
     get "user-cards" => "users#cards", format: :json
@@ -442,7 +439,7 @@ Discourse::Application.routes.draw do
       get({ "#{root_path}/:username" => "users#show", constraints: { username: RouteFormat.username } }.merge(index == 1 ? { as: 'user' } : {}))
       put "#{root_path}/:username" => "users#update", constraints: { username: RouteFormat.username }, defaults: { format: :json }
       get "#{root_path}/:username/emails" => "users#check_emails", constraints: { username: RouteFormat.username }
-      get({ "#{root_path}/:username/preferences" => "users#preferences", constraints: { username: RouteFormat.username } }.merge(index == 1 ? { as: :email_preferences } : {}))
+      get "#{root_path}/:username/preferences" => "users#preferences", constraints: { username: RouteFormat.username }
       get "#{root_path}/:username/preferences/email" => "users_email#index", constraints: { username: RouteFormat.username }
       get "#{root_path}/:username/preferences/account" => "users#preferences", constraints: { username: RouteFormat.username }
       get "#{root_path}/:username/preferences/profile" => "users#preferences", constraints: { username: RouteFormat.username }

--- a/spec/fabricators/user_fabricator.rb
+++ b/spec/fabricators/user_fabricator.rb
@@ -112,3 +112,7 @@ end
 Fabricator(:staged, from: :user) do
   staged true
 end
+
+Fabricator(:unicode_user, from: :user) do
+  username { sequence(:username) { |i| "Löwe#{i}" } }
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2373,4 +2373,19 @@ describe User do
   def reset_last_seen_cache!(user)
     Discourse.redis.del("user:#{user.id}:#{Time.zone.now.to_date}")
   end
+
+  describe ".encoded_username" do
+    it "doesn't encoded ASCII usernames" do
+      user = Fabricate(:user, username: "John")
+      expect(user.encoded_username).to eq("John")
+      expect(user.encoded_username(lower: true)).to eq("john")
+    end
+
+    it "encodes Unicode characters" do
+      SiteSetting.unicode_usernames = true
+      user = Fabricate(:user, username: "Löwe")
+      expect(user.encoded_username).to eq("L%C3%B6we")
+      expect(user.encoded_username(lower: true)).to eq("l%C3%B6we")
+    end
+  end
 end

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -162,6 +162,15 @@ RSpec.describe ApplicationController do
       expect(response.status).to eq(200)
     end
 
+    it "correctly redirects for Unicode usernames" do
+      SiteSetting.enforce_second_factor = "all"
+      SiteSetting.unicode_usernames = true
+      user = sign_in(Fabricate(:unicode_user))
+
+      get "/"
+      expect(response).to redirect_to("/u/#{user.encoded_username}/preferences/second-factor")
+    end
+
     context "when enforcing second factor for staff" do
       before do
         SiteSetting.enforce_second_factor = "staff"

--- a/spec/requests/email_controller_spec.rb
+++ b/spec/requests/email_controller_spec.rb
@@ -169,28 +169,6 @@ RSpec.describe EmailController do
     end
   end
 
-  context '#preferences_redirect' do
-    it 'requires you to be logged in' do
-      get "/email_preferences.json"
-      expect(response.status).to eq(403)
-    end
-
-    context 'when logged in' do
-      it 'redirects to your user preferences' do
-        user = sign_in(Fabricate(:user))
-        get "/email_preferences.json"
-        expect(response).to redirect_to("/u/#{user.username}/preferences/emails")
-      end
-
-      it "correctly redirects for Unicode usernames" do
-        SiteSetting.unicode_usernames = true
-        user = sign_in(Fabricate(:unicode_user))
-        get "/email_preferences.json"
-        expect(response).to redirect_to("/u/#{user.encoded_username}/preferences/emails")
-      end
-    end
-  end
-
   context '#unsubscribe' do
     it 'displays not found if key is not found' do
       navigate_to_unsubscribe(SecureRandom.hex)

--- a/spec/requests/email_controller_spec.rb
+++ b/spec/requests/email_controller_spec.rb
@@ -176,11 +176,17 @@ RSpec.describe EmailController do
     end
 
     context 'when logged in' do
-      let!(:user) { sign_in(Fabricate(:user)) }
-
       it 'redirects to your user preferences' do
+        user = sign_in(Fabricate(:user))
         get "/email_preferences.json"
-        expect(response).to redirect_to("/u/#{user.username}/preferences")
+        expect(response).to redirect_to("/u/#{user.username}/preferences/emails")
+      end
+
+      it "correctly redirects for Unicode usernames" do
+        SiteSetting.unicode_usernames = true
+        user = sign_in(Fabricate(:unicode_user))
+        get "/email_preferences.json"
+        expect(response).to redirect_to("/u/#{user.encoded_username}/preferences/emails")
       end
     end
   end

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -3496,26 +3496,6 @@ describe UsersController do
     end
   end
 
-  describe '#user_preferences_redirect' do
-    it 'requires the user to be logged in' do
-      get '/user_preferences'
-      expect(response.status).to eq(404)
-    end
-
-    it "redirects to their profile when logged in" do
-      sign_in(user)
-      get '/user_preferences'
-      expect(response).to redirect_to("/u/#{user.username}/preferences")
-    end
-
-    it "correctly redirects for Unicode usernames" do
-      SiteSetting.unicode_usernames = true
-      user = sign_in(Fabricate(:unicode_user))
-      get '/user_preferences'
-      expect(response).to redirect_to("/u/#{user.encoded_username}/preferences")
-    end
-  end
-
   describe '#email_login' do
     before do
       SiteSetting.enable_local_logins_via_email = true

--- a/spec/support/integration_helpers.rb
+++ b/spec/support/integration_helpers.rb
@@ -26,7 +26,7 @@ module IntegrationHelpers
   end
 
   def sign_in(user)
-    get "/session/#{user.username}/become"
+    get "/session/#{user.encoded_username}/become"
     user
   end
 


### PR DESCRIPTION
@eviltrout I wonder if we should remove the following two routes. I couldn't find any references in our code. AFAIK we are always using the `/my/...` routes.

https://github.com/discourse/discourse/blob/0f09fd22f3afa6ba22499e2fbf6d50a4574831aa/config/routes.rb#L318

https://github.com/discourse/discourse/blob/0f09fd22f3afa6ba22499e2fbf6d50a4574831aa/config/routes.rb#L377

I didn't even know that `/email_preferences` and `/user_preferences` were a thing. They exist since the beginning of the project.