### PR TITLE
DEV: Raise special check_xhr exception in tests

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -14,7 +14,7 @@ class GroupsController < ApplicationController
   ]
 
   skip_before_action :preload_json, :check_xhr, only: [:posts_feed, :mentions_feed]
-  skip_before_action :check_xhr, only: [:show]
+  skip_before_action :check_xhr, only: [:show, :new]
   after_action :add_noindex_header
 
   TYPE_FILTERS = {
@@ -133,6 +133,7 @@ class GroupsController < ApplicationController
   end
 
   def new
+    render 'default/empty'
   end
 
   def edit

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -1630,7 +1630,7 @@ describe GroupsController do
     describe 'for an admin user' do
       before { sign_in(Fabricate(:admin)) }
 
-      it 'should return 404' do
+      it 'should return html' do
         get '/groups/custom/new'
 
         expect(response.status).to eq(200)

--- a/spec/requests/notifications_controller_spec.rb
+++ b/spec/requests/notifications_controller_spec.rb
@@ -37,12 +37,12 @@ describe NotificationsController do
 
       describe '#index' do
         it 'should succeed for recent' do
-          get "/notifications", params: { recent: true }
+          get "/notifications.json", params: { recent: true }
           expect(response.status).to eq(200)
         end
 
         it 'should succeed for history' do
-          get "/notifications"
+          get "/notifications.json"
           expect(response.status).to eq(200)
         end
 

--- a/spec/requests/search_controller_spec.rb
+++ b/spec/requests/search_controller_spec.rb
@@ -466,7 +466,7 @@ describe SearchController do
         ip_address: '127.0.0.1'
       )
 
-      post "/search/click", params: {
+      post "/search/click.json", params: {
         search_log_id: search_log_id,
         search_result_id: 12345,
         search_result_type: 'topic'
@@ -525,7 +525,7 @@ describe SearchController do
         ip_address: '192.168.0.19'
       )
 
-      post "/search/click", params: {
+      post "/search/click.json", params: {
         search_log_id: search_log_id,
         search_result_id: 22222,
         search_result_type: 'topic'


### PR DESCRIPTION
Solves a papercut in tests when you forget .json on an endpoint by raising a special exception.