### PR TITLE
FIX: Restore stream position in Safari

### DIFF
--- a/app/assets/javascripts/discourse/app/components/scrolling-post-stream.js
+++ b/app/assets/javascripts/discourse/app/components/scrolling-post-stream.js
@@ -333,6 +333,13 @@ export default MountWidget.extend({
     });
 
     this.appEvents.on("post-stream:refresh", this, "_refresh");
+
+    // restore scroll position on browsers with aggressive BFCaches (like Safari)
+    window.onpageshow = function(event) {
+      if (event.persisted) {
+        DiscourseURL.routeTo(this.location.pathname);
+      }
+    };
   },
 
   willDestroyElement() {


### PR DESCRIPTION
Safari uses an aggressive back/forward cache, which means the app loads very quickly when hitting the Back button. But, in topics with > 30 posts, hitting Back runs post stream calculations too early, which means that users get taken back to an earlier point in the stream, consistently.

Using `onpageshow`, we can restore the correct location before the post stream calculations take place.

In theory the fix should apply to other browser with aggressive back/forward caching, but in my tests I did not see this in Chrome or Firefox (will test other browsers shortly). 