### PR TITLE
Support plugin compatibility version manifests

### DIFF
--- a/lib/theme_store/git_importer.rb
+++ b/lib/theme_store/git_importer.rb
@@ -23,6 +23,12 @@ class ThemeStore::GitImporter
     else
       import_public!
     end
+    if version = Discourse.find_compatible_git_resource(@temp_folder)
+      Discourse::Utils.execute_command(chdir: @temp_folder) do |runner|
+        Rails.logger.warn "git reset --hard #{version}"
+        return runner.exec("git", "reset", "--hard", version)
+      end
+    end
   end
 
   def diff_local_changes(remote_theme_id)

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -3,6 +3,8 @@
 module Discourse
   VERSION_REGEXP = /\A\d+\.\d+\.\d+(\.beta\d+)?\z/ unless defined? ::Discourse::VERSION_REGEXP
 
+  VERSION_COMPATIBILITY_FILENAME = ".discourse-compatibility"
+
   # work around reloader
   unless defined? ::Discourse::VERSION
     module VERSION #:nodoc:
@@ -17,5 +19,41 @@ module Discourse
 
   def self.has_needed_version?(current, needed)
     Gem::Version.new(current) >= Gem::Version.new(needed)
+  end
+
+  # lookup an external resource (theme/plugin)'s best compatible version
+  # compatible resource files are YAML, in the format:
+  # `discourse_version: plugin/theme git reference.` For example:
+  #  2.5.0.beta6: c4a6c17
+  #  2.5.0.beta4: d1d2d3f
+  #  2.5.0.beta2: bbffee
+  #  2.4.4.beta6: some-other-branch-ref
+  #  2.4.2.beta1: v1-tag
+  def self.find_compatible_resource(version_list)
+
+    return unless version_list
+
+    version_list = YAML.load(version_list).sort_by { |version, pin| Gem::Version.new(version) }.reverse
+
+    # If plugin compat version is listed as less than current Discourse version, take the version/hash listed before.
+    checkout_version = nil
+    version_list.each do |core_compat, target|
+      if Gem::Version.new(core_compat) == Gem::Version.new(::Discourse::VERSION::STRING) # Exact version match - return it
+        checkout_version = target
+        break
+      elsif Gem::Version.new(core_compat) < Gem::Version.new(::Discourse::VERSION::STRING) # Core is on a higher version than listed, use a later version
+        break
+      end
+      checkout_version = target
+    end
+
+    checkout_version
+  end
+
+  # Find a compatible resource from a git repo
+  def self.find_compatible_git_resource(path)
+    return unless File.directory?("#{path}/.git")
+    compat_resource, std_error, s = Open3.capture3("git -C '#{path}' show HEAD@{upstream}:#{Discourse::VERSION_COMPATIBILITY_FILENAME}")
+    Discourse.find_compatible_resource(compat_resource) if s.success?
   end
 end


### PR DESCRIPTION
Adds a new rake task `plugin:checkout_compatible_all` and
`plugin:checkout_compatible[plugin-name]` that check out compatible plugin
versions.

Supports a .discourse-compatibility file in the root of plugins that list out
a plugin's compatibility with certain discourse versions:

eg: .discourse-compatibility
```
2.5.0.beta6: some-git-hash
2.4.4.beta4: some-git-tag
2.2.0: git-reference
```

This ensures older Discourse installs are able to find and install older
versions of plugins without intervention, through the manifest only.

It iterates through the versions in descending order. If the current Discourse
version matches an item in the manifest, it checks out the listed plugin target.
If the Discourse version is greater than an item in the manifest, it checks out
the next highest version listed in the manifest.

If no versions match, it makes no change.

It will also be pretty simple to integrate this task into docker_manager and our pups files once merged.