### PR TITLE
FIX: flaky post_alerter_spec.rb because of missing order

### DIFF
--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -463,6 +463,7 @@ class PostAlerter
         .where("push_url IS NOT NULL AND push_url <> ''")
         .where("position(push_url IN ?) > 0", SiteSetting.allowed_user_api_push_urls)
         .where("revoked_at IS NULL")
+        .order(client_id: :asc)
         .pluck(:client_id, :push_url)
 
       if clients.length > 0


### PR DESCRIPTION
Randomly failing spec - https://github.com/discourse/discourse/blob/master/spec/services/post_alerter_spec.rb#L756