### PR TITLE
FIX: Make Email::Styles preserve email structure when it exists

### DIFF
--- a/app/views/email/default_template.html
+++ b/app/views/email/default_template.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" lang="%{html_lang}" xml:lang="%{html_lang}">
 
 <head>

--- a/lib/email/styles.rb
+++ b/lib/email/styles.rb
@@ -15,7 +15,16 @@ module Email
     def initialize(html, opts = nil)
       @html = html
       @opts = opts || {}
-      @fragment = Nokogiri::HTML5.parse(@html)
+
+      # This is a hack. Having to have this conditional is unfortunate, but
+      # emails may or may not have overarching structure with html and body
+      # tags and we want to handle both cases.
+      if @html.include?("<body")
+        @fragment = Nokogiri::HTML5.parse(@html)
+      else
+        @fragment = Nokogiri::HTML5.fragment(@html)
+      end
+
       @custom_styles = nil
     end
 
@@ -242,11 +251,7 @@ module Email
       strip_classes_and_ids
       replace_relative_urls
       replace_secure_media_urls
-      include_body? ? @fragment.at("body").to_html : @fragment.at("body").children.to_html
-    end
-
-    def include_body?
-      @html =~ /<body>/i
+      @fragment.to_html.strip
     end
 
     def strip_avatars_and_emojis


### PR DESCRIPTION
Applying styles shouldn't alter the structure of the HTML that is being
manipulated. In particular, meta tags were being omitted during this
process.

This does mean that, now, when we create emails, they have a html5
doctype by default. I changed the doctype in the default template to
match since it's being ignored anyway (because we're using an html5
parser).