### PR TITLE
Clarify further distro support

### DIFF
--- a/docs/INSTALL-cloud.md
+++ b/docs/INSTALL-cloud.md
@@ -6,7 +6,7 @@
 
 Create your new cloud server, for example [on DigitalOcean][do]:
 
-- The default of **the current supported LTS release of Ubuntu Server** works fine. At minimum, a 64-bit Linux OS with a modern kernel version is required.
+- **Ubuntu Server LTS 18.04** works fine. At minimum, a 64-bit Linux OS with a modern kernel version is required.
 
 - The default of **1 GB** RAM works fine for small Discourse communities. We recommend 2 GB RAM for larger communities.
 


### PR DESCRIPTION
Hi,

Sorry to bother you with this. I started a thread:

https://meta.discourse.org/t/please-document-supported-distros/154087

and Jeff was kind enough to try and address some of my concerns with https://github.com/discourse/discourse/commit/dc49581344a9f0400a4b77e74331e269e995f648 . However, I thought the change is not correct, but as you can see, a moderator locked the thread. I contacted the moderator, and he said:

> everything has been said in that topic by multiple people in different words. You can choose whatever OS and version you want as long as it fulfills the minimum requirements stated in the documentation. The documentation was changed because of your suggestion. Feel free to create a pull request on Github if you think it’s still unclear.

I don't agree with this strategy (because I can't know what's the correct change to make in the PR), but I'm following his directive.

As mentioned in the commit message, at any given point in time there might be 2 or 3 "current supported LTS release of Ubuntu Server".

Perhaps when you create a VM in Digital Ocean, there's a blessed version of Ubuntu LTS, but I don't think it's appropriate to require creating an account in Digital Ocean to perform the easy cloud install of Discourse.

My ideal change would be to list the specific distributions/versions which are tested by the Discourse developers before releasing a new version. I have tried to find this out, but I haven't been able to. If such as set of distributions/versions exist, I would be happy to write an appropriate PR if necessary.

As I cannot be that, and I've been told to create a PR anyway, I've decided to choose a single version of LTS. I chose 18.04 because 20.04 is quite new right now and it has not seen a .1 release yet. Personally I would prefer 20.04, but I think this might be the best overall choice.

...

In any case, if this has been a waste of your time, I apologize, but this is the only course of action that I have been offered, other than shutting up. I don't like either option but I think this is the one with the best possibility of improving Discourse for someone.
