### PR TITLE
FIX: prevent re-flagging when we have reviewed flags before

### DIFF
--- a/lib/post_action_creator.rb
+++ b/lib/post_action_creator.rb
@@ -141,11 +141,11 @@ private
 
   def cannot_flag_again?(reviewable)
     return false if @post_action_type_id == PostActionType.types[:notify_moderators]
-    flag_type_already_used = reviewable.reviewable_scores.any? { |rs| rs.reviewable_score_type == @post_action_type_id }
+    flag_type_already_used = reviewable.reviewable_scores.any? { |rs| rs.reviewable_score_type == @post_action_type_id && rs.status != ReviewableScore.statuses[:pending] }
     not_edited_since_last_review = @post.last_version_at.blank? || reviewable.updated_at > @post.last_version_at
     handled_recently = reviewable.updated_at > SiteSetting.cooldown_hours_until_reflag.to_i.hours.ago
 
-    !reviewable.pending? && flag_type_already_used && not_edited_since_last_review && handled_recently
+    flag_type_already_used && not_edited_since_last_review && handled_recently
   end
 
   def notify_subscribers

--- a/spec/components/post_action_creator_spec.rb
+++ b/spec/components/post_action_creator_spec.rb
@@ -159,15 +159,14 @@ describe PostActionCreator do
         end
 
         it "fails when other flag action types are open" do
-          expect(reviewable.pending?).to eq(false)
           freeze_time 10.seconds.from_now
           spam_result = PostActionCreator.create(user, post, :spam)
 
-          expect(reviewable.reload.pending?).to eq(true)
           inappropriate_result = PostActionCreator.create(Fabricate(:user), post, :inappropriate)
 
           reviewable.reload
 
+          expect(inappropriate_result.success?).to eq(false)
           expect(reviewable.pending?).to eq(true)
           expect(reviewable.reviewable_scores.select(&:pending?).count).to eq(1)
         end

--- a/spec/components/post_action_creator_spec.rb
+++ b/spec/components/post_action_creator_spec.rb
@@ -151,6 +151,27 @@ describe PostActionCreator do
           expect(result.success?).to eq(false)
         end
 
+        it "succeeds with other flag action types" do
+          freeze_time 10.seconds.from_now
+          spam_result = PostActionCreator.create(user, post, :spam)
+
+          expect(reviewable.reload.pending?).to eq(true)
+        end
+
+        it "fails when other flag action types are open" do
+          expect(reviewable.pending?).to eq(false)
+          freeze_time 10.seconds.from_now
+          spam_result = PostActionCreator.create(user, post, :spam)
+
+          expect(reviewable.reload.pending?).to eq(true)
+          inappropriate_result = PostActionCreator.create(Fabricate(:user), post, :inappropriate)
+
+          reviewable.reload
+
+          expect(reviewable.pending?).to eq(true)
+          expect(reviewable.reviewable_scores.select(&:pending?).count).to eq(1)
+        end
+
         it "succesfully flags the post if it was reviewed more than 24 hours ago" do
           reviewable.update!(updated_at: 25.hours.ago)
           post.last_version_at = 30.hours.ago


### PR DESCRIPTION
Fixes an edge case where a review can be reflagged when:
User flags as inappropriate.
Moderator rejects the flag.
Another user re-flags the post as spam.

Before, anyone was able to re-flag as inappropriate despite it being flagged
previously. With this, users are unable to re-flag for the same reason
regardless of reviewable status.