### PR TITLE
FIX: skip insertion if the row already exists.

### DIFF
--- a/db/post_migrate/20200602153813_migrate_invite_redeemed_data_to_invited_users.rb
+++ b/db/post_migrate/20200602153813_migrate_invite_redeemed_data_to_invited_users.rb
@@ -17,6 +17,7 @@ class MigrateInviteRedeemedDataToInvitedUsers < ActiveRecord::Migration[6.0]
       SELECT user_id, id, redeemed_at, created_at, updated_at
       FROM invites
       WHERE user_id IS NOT NULL AND redeemed_at IS NOT NULL
+      ON CONFLICT DO NOTHING
     SQL
   end
 


### PR DESCRIPTION
If an invite is redeemed before the query is ran then there will be an index violation error. For those cases we should skip inserting the conflicting row.