### PR TITLE
add showPreview to composer fields plugin outlet

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/composer.hbs
+++ b/app/assets/javascripts/discourse/app/templates/composer.hbs
@@ -100,7 +100,7 @@
               </div>
             {{/if}}
 
-            {{plugin-outlet name="composer-fields" args=(hash model=model)}}
+            {{plugin-outlet name="composer-fields" args=(hash model=model showPreview=showPreview)}}
           {{/unless}}
 
         </div>


### PR DESCRIPTION
showPreview is necessary because we need to add 50% width class similar to: class="title-and-category with-preview" on the category and title div if the preview is shown.