### PR TITLE
 FIX: Hide bootbox after a negative answer

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -1040,7 +1040,7 @@ export default Controller.extend({
     const keyPrefix =
       this.model.action === "edit" ? "post.abandon_edit" : "post.abandon";
 
-    let promise = new Promise(resolve => {
+    let promise = new Promise((resolve, reject) => {
       if (this.get("model.hasMetaData") || this.get("model.replyDirty")) {
         bootbox.dialog(I18n.t(keyPrefix + ".confirm"), [
           {
@@ -1052,8 +1052,10 @@ export default Controller.extend({
               if (differentDraft) {
                 this.model.clearState();
                 this.close();
+                resolve();
               }
-              resolve();
+
+              reject();
             }
           },
           {

--- a/test/javascripts/acceptance/composer-test.js
+++ b/test/javascripts/acceptance/composer-test.js
@@ -271,6 +271,24 @@ QUnit.test("Create a Reply", async assert => {
   );
 });
 
+QUnit.test("Can edit a post after starting a reply", async assert => {
+  await visit("/t/internationalization-localization/280");
+
+  await click("#topic-footer-buttons .create");
+  await fillIn(".d-editor-input", "this is the content of my reply");
+
+  await click(".topic-post:eq(0) button.show-more-actions");
+  await click(".topic-post:eq(0) button.edit");
+
+  await click("a[data-handler='0']");
+
+  assert.ok(!visible(".bootbox.modal"));
+  assert.equal(
+    find(".d-editor-input").val(),
+    "this is the content of my reply"
+  );
+});
+
 QUnit.test("Posting on a different topic", async assert => {
   await visit("/t/internationalization-localization/280");
   await click("#topic-footer-buttons .btn.create");


### PR DESCRIPTION
Starting to reply and then editing a post was not possible because of a
bootbox which kept showing up.