### PR TITLE
DEV: Pass the is_image flag when triggering the before_upload_creation event

### DIFF
--- a/lib/upload_creator.rb
+++ b/lib/upload_creator.rb
@@ -34,16 +34,14 @@ class UploadCreator
       return @upload
     end
 
-    DiscourseEvent.trigger(:before_upload_creation, @file)
+    @image_info = FastImage.new(@file) rescue nil
+    is_image = FileHelper.is_supported_image?(@filename)
+    is_image ||= @image_info && FileHelper.is_supported_image?("test.#{@image_info.type}")
+    is_image = false if @opts[:for_theme]
+
+    DiscourseEvent.trigger(:before_upload_creation, @file, is_image)
 
     DistributedMutex.synchronize("upload_#{user_id}_#{@filename}") do
-      # test for image regardless of input
-      @image_info = FastImage.new(@file) rescue nil
-
-      is_image = FileHelper.is_supported_image?(@filename)
-      is_image ||= @image_info && FileHelper.is_supported_image?("test.#{@image_info.type}")
-      is_image = false if @opts[:for_theme]
-
       if is_image
         extract_image_info!
         return @upload if @upload.errors.present?


### PR DESCRIPTION
We would like to know if the file we're going to upload it's an image or not. 
I don't want the event to be triggered inside the DistributedMutex since they are executed synchronously, and they could be slow.