### PR TITLE
FIX: allows PM owner to remove any user if >= TL2

### DIFF
--- a/lib/guardian/topic_guardian.rb
+++ b/lib/guardian/topic_guardian.rb
@@ -5,6 +5,7 @@ module TopicGuardian
 
   def can_remove_allowed_users?(topic, target_user = nil)
     is_staff? ||
+    (topic.user == user && user.has_trust_level?(TrustLevel[2])) ||
     (
       topic.allowed_users.count > 1 &&
       topic.user != target_user &&

--- a/spec/components/guardian_spec.rb
+++ b/spec/components/guardian_spec.rb
@@ -3446,8 +3446,23 @@ describe Guardian do
       end
     end
 
+    context 'trust_level >= 2 user' do
+      fab!(:topic_creator) { build(:user, trust_level: 2) }
+      fab!(:topic) { Fabricate(:topic, user: topic_creator) }
+
+      before do
+        topic.allowed_users << topic_creator
+        topic.allowed_users << another_user
+      end
+
+      it 'should be true' do
+        expect(Guardian.new(topic_creator).can_remove_allowed_users?(topic))
+          .to eq(true)
+      end
+    end
+
     context 'normal user' do
-      fab!(:topic) { Fabricate(:topic, user: Fabricate(:user)) }
+      fab!(:topic) { Fabricate(:topic, user: Fabricate(:user, trust_level: 1)) }
 
       before do
         topic.allowed_users << user


### PR DESCRIPTION
- `< TL2 user` can remove itself:
<img width="716" alt="Screenshot 2020-06-12 at 10 35 50" src="https://user-images.githubusercontent.com/339945/84483288-6bfdf280-ac99-11ea-9510-d61346970b80.png">

- `>= TL2 user` can remove everyone:
<img width="714" alt="Screenshot 2020-06-12 at 10 35 58" src="https://user-images.githubusercontent.com/339945/84483290-6d2f1f80-ac99-11ea-98f1-4a2f4bd6f5c3.png">
