### PR TITLE
FEATURE: new category-list-above-each-category plugin outlet

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/categories-only.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/categories-only.hbs
@@ -11,6 +11,7 @@
     </thead>
     <tbody aria-labelledby="categories-only-category">
       {{#each categories as |c|}}
+        {{plugin-outlet name="category-list-above-each-category" connectorTagName="" tagName="" args=(hash category=c)}}
         <tr data-category-id={{c.id}} data-notification-level={{c.notificationLevelString}} class="{{if c.description_excerpt "has-description" "no-description"}} {{if c.uploaded_logo.url "has-logo" "no-logo"}}">
           <td class="category {{if c.isMuted "muted"}} {{if noCategoryStyle "no-category-style"}}" style={{unless noCategoryStyle (border-color c.color)}}>
             {{category-title-link category=c}}

--- a/app/assets/javascripts/discourse/app/templates/mobile/components/categories-only.hbs
+++ b/app/assets/javascripts/discourse/app/templates/mobile/components/categories-only.hbs
@@ -1,6 +1,7 @@
 {{#if categories}}
   <div class="category-list {{if showTopics "with-topics"}}">
     {{#each categories as |c|}}
+      {{plugin-outlet name="category-list-above-each-category" connectorTagName="" tagName="" args=(hash category=c)}}
       <div data-category-id={{c.id}} data-notification-level={{c.notificationLevelString}} style={{border-color c.color}} class="category-list-item category {{if c.isMuted "muted"}}">
         <table class="topic-list">
           <tbody>


### PR DESCRIPTION
This plugin outlet will appear above each category listed in the category list, allowing themes and plugins to easily add features like category dividers and other interesting elements.

All of the "Preview" sections in the rough example below were adding using a theme component that makes use of these outlets.

<img width="1209" alt="example" src="https://user-images.githubusercontent.com/22733864/84556904-da16d980-acda-11ea-9518-91fc672aa4e4.png">

