### PR TITLE
UX: Improve revert label in post history modal

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/history.js
+++ b/app/assets/javascripts/discourse/app/controllers/history.js
@@ -60,6 +60,11 @@ export default Controller.extend(ModalFunctionality, {
     );
   },
 
+  @discourseComputed("previousVersion")
+  revertToRevisionText(revision) {
+    return I18n.t("post.revisions.controls.revert", { revision });
+  },
+
   refresh(postId, postVersion) {
     this.set("loading", true);
 

--- a/app/assets/javascripts/discourse/app/templates/modal/history.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/history.hbs
@@ -128,7 +128,7 @@
       {{/if}}
 
       {{#if displayRevert}}
-        {{d-button action=(action "revertToVersion") icon="undo" label="post.revisions.controls.revert" class="btn-danger" disabled=loading}}
+        {{d-button action=(action "revertToVersion") icon="undo" translatedLabel=revertToRevisionText class="btn-danger" disabled=loading}}
       {{/if}}
 
       {{#if displayHide}}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2744,7 +2744,7 @@ en:
           last: "Last revision"
           hide: "Hide revision"
           show: "Show revision"
-          revert: "Revert to this revision"
+          revert: "Revert to revision %{revision}"
           edit_wiki: "Edit Wiki"
           edit_post: "Edit Post"
           comparing_previous_to_current_out_of_total: "<strong>%{previous}</strong> %{icon} <strong>%{current}</strong> / %{total}"

--- a/config/locales/client.pt_BR.yml
+++ b/config/locales/client.pt_BR.yml
@@ -2473,7 +2473,7 @@ pt_BR:
           last: "Última revisão"
           hide: "Esconder revisão"
           show: "Exibir revisão"
-          revert: "Reverter para esta revisão"
+          revert: "Reverter para a revisão %{revision}"
           edit_wiki: "Editar Wiki"
           edit_post: "Editar Postagem"
           comparing_previous_to_current_out_of_total: "<strong>%{previous}</strong> %{icon} <strong>%{current}</strong> / %{total}"


### PR DESCRIPTION
This is a starter task I found in Meta: https://meta.discourse.org/t/can-the-revert-button-be-moved-to-the-left-of-the-revision-dialog/126926/7
Please evaluate.