### PR TITLE
UX: Style video elements, show descriptions

### DIFF
--- a/app/assets/javascripts/pretty-text/addon/engines/discourse-markdown-it.js
+++ b/app/assets/javascripts/pretty-text/addon/engines/discourse-markdown-it.js
@@ -147,6 +147,7 @@ function videoHTML(token, opts) {
   const preloadType = opts.secureMedia ? "none" : "metadata";
   const dataOrigSrcAttr = origSrc !== null ? `data-orig-src="${origSrc}"` : "";
   return `<div class="video-container">
+    <p class="video-description">${opts.alt}</p>
     <video width="100%" height="100%" preload="${preloadType}" controls>
       <source src="${src}" ${dataOrigSrcAttr}>
       <a href="${src}">${src}</a>
@@ -176,7 +177,8 @@ function renderImageOrPlayableMedia(tokens, idx, options, env, slf) {
   // see https://github.com/markdown-it/markdown-it/blob/master/docs/architecture.md#renderer
   // handles |video and |audio alt transformations for image tags
   const mediaOpts = {
-    secureMedia: options.discourse.limitedSiteSettings.secureMedia
+    secureMedia: options.discourse.limitedSiteSettings.secureMedia,
+    alt: split[0]
   };
   if (split[1] === "video") {
     return videoHTML(token, mediaOpts);

--- a/app/assets/javascripts/pretty-text/addon/white-lister.js
+++ b/app/assets/javascripts/pretty-text/addon/white-lister.js
@@ -185,6 +185,7 @@ export const DEFAULT_LIST = [
   "span.excerpt",
   "div.excerpt",
   "div.video-container",
+  "p.video-description",
   "span.hashtag",
   "span.mention",
   "strike",

--- a/app/assets/stylesheets/common/base/onebox.scss
+++ b/app/assets/stylesheets/common/base/onebox.scss
@@ -703,6 +703,9 @@ aside.onebox.stackexchange .onebox-body {
 // Force oneboxed videos to 16:9 aspect ratio
 .onebox.video-onebox,
 .video-container {
+  background: $primary-very-low;
+  border: 1px solid $primary-low;
+  border-radius: 2px;
   position: relative;
   padding: 0 0 56.25% 0;
   width: 100%;
@@ -712,6 +715,12 @@ aside.onebox.stackexchange .onebox-body {
     width: 100%;
     height: 100%;
   }
+}
+
+.video-description {
+  color: $primary-medium;
+  margin: 1rem;
+  position: absolute;
 }
 
 .onebox-placeholder-container {

--- a/test/javascripts/lib/pretty-text-test.js
+++ b/test/javascripts/lib/pretty-text-test.js
@@ -1030,6 +1030,7 @@ QUnit.test("video - secure media enabled", assert => {
     "![baby shark|video](upload://eyPnj7UzkU0AkGkx2dx8G4YM1Jx.mp4)",
     { siteSettings: { secure_media: true } },
     `<p><div class="video-container">
+    <p class="video-description">baby shark</p>
     <video width="100%" height="100%" preload="none" controls>
       <source src="/404" data-orig-src="upload://eyPnj7UzkU0AkGkx2dx8G4YM1Jx.mp4">
       <a href="/404">/404</a>
@@ -1055,6 +1056,7 @@ QUnit.test("video", assert => {
   assert.cooked(
     "![baby shark|video](upload://eyPnj7UzkU0AkGkx2dx8G4YM1Jx.mp4)",
     `<p><div class="video-container">
+    <p class="video-description">baby shark</p>
     <video width="100%" height="100%" preload="metadata" controls>
       <source src="/404" data-orig-src="upload://eyPnj7UzkU0AkGkx2dx8G4YM1Jx.mp4">
       <a href="/404">/404</a>
@@ -1081,6 +1083,7 @@ QUnit.test("video - mapped url - secure media enabled", assert => {
       lookupUploadUrls: lookupUploadUrls
     },
     `<p><div class="video-container">
+    <p class="video-description">baby shark</p>
     <video width="100%" height="100%" preload="none" controls>
       <source src="/secure-media-uploads/original/3X/c/b/test.mp4">
       <a href="/secure-media-uploads/original/3X/c/b/test.mp4">/secure-media-uploads/original/3X/c/b/test.mp4</a>


### PR DESCRIPTION
It's a stop gap – ideally we would generate a thumbnail for uploaded videos. For now, a bit of intentionality in the style and a pinch of context should do:

Before/after

<img width="310" alt="light-before" src="https://user-images.githubusercontent.com/66961/84590750-7eaf2d80-ae39-11ea-883b-895296b87ed2.png"> <img width="310" alt="light-after" src="https://user-images.githubusercontent.com/66961/84590751-81118780-ae39-11ea-91e3-79be249e99b7.png">
<img width="310" alt="dark-before" src="https://user-images.githubusercontent.com/66961/84590772-9e465600-ae39-11ea-9c2c-e4348b7dd040.png"> <img width="310" alt="dark-after" src="https://user-images.githubusercontent.com/66961/84590774-9edeec80-ae39-11ea-9777-2d8f6c2ede71.png">
