### PR TITLE
FIX: Prevent producing "undefined" strings

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/utilities.js
+++ b/app/assets/javascripts/discourse/app/lib/utilities.js
@@ -25,6 +25,10 @@ export function translateSize(size) {
 }
 
 export function escapeExpression(string) {
+  if (!string) {
+    return "";
+  }
+
   // don't escape SafeStrings, since they're already safe
   if (string instanceof Handlebars.SafeString) {
     return string.toString();

--- a/test/javascripts/lib/utilities-test.js
+++ b/test/javascripts/lib/utilities-test.js
@@ -1,5 +1,6 @@
 /* global Int8Array:true */
 import {
+  escapeExpression,
   emailValid,
   extractDomainFromUrl,
   avatarUrl,
@@ -14,8 +15,29 @@ import {
   fillMissingDates,
   inCodeBlock
 } from "discourse/lib/utilities";
+import Handlebars from "handlebars";
 
 QUnit.module("lib:utilities");
+
+QUnit.test("escapeExpression", assert => {
+  assert.equal(
+    escapeExpression(">"),
+    "&gt;",
+    "escapes unsafe characters"
+  );
+
+  assert.equal(
+    escapeExpression(new Handlebars.SafeString("&gt;")),
+    "&gt;",
+    "does not double-escape safe strings"
+  );
+
+  assert.equal(
+    escapeExpression(undefined),
+    "",
+    "returns a falsy string when given a falsy value"
+  );
+});
 
 QUnit.test("emailValid", assert => {
   assert.ok(


### PR DESCRIPTION
Fixes a bug in search-menu-results (type: "group"), where:

```javascript
const fullName = escapeExpression(group.fullName);
const name = escapeExpression(group.name);
const groupNames = [h("span.name", fullName || name)];
```

`groupNames` could end up having value "undefined" if a group doesn't have a `fullName`.

---

Alternatively I could fix it in search-menu-results:

```javascript
const fullName = group.fullName && escapeExpression(group.fullName);
const name = escapeExpression(group.name);
const groupNames = [h("span.name", fullName || name)];
```