### PR TITLE
DEV: Use postgres 12 in GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         target: ["PLUGINS", "CORE"]
         os: [ubuntu-latest]
         ruby: ["2.6"]
-        postgres: ["10"]
+        postgres: ["12"]
         redis: ["4.x"]
 
     services:


### PR DESCRIPTION
12 is now the recommended and widely deployed version.