### PR TITLE
FEATURE: Add "Now" as an option (default hidden) to the future date input selector

### DIFF
--- a/app/assets/javascripts/discourse/app/pre-initializers/discourse-bootstrap.js
+++ b/app/assets/javascripts/discourse/app/pre-initializers/discourse-bootstrap.js
@@ -28,7 +28,7 @@ export default {
       Object.keys(preloaded).forEach(function(key) {
         PreloadStore.store(key, JSON.parse(preloaded[key]));
 
-        if (setupData.debugPreloadedAppData === "true") {
+        if (true) {
           /* eslint-disable no-console */
           console.log(key, PreloadStore.get(key));
           /* eslint-enable no-console */

--- a/app/assets/javascripts/discourse/app/pre-initializers/discourse-bootstrap.js
+++ b/app/assets/javascripts/discourse/app/pre-initializers/discourse-bootstrap.js
@@ -28,7 +28,7 @@ export default {
       Object.keys(preloaded).forEach(function(key) {
         PreloadStore.store(key, JSON.parse(preloaded[key]));
 
-        if (true) {
+        if (setupData.debugPreloadedAppData === "true") {
           /* eslint-disable no-console */
           console.log(key, PreloadStore.get(key));
           /* eslint-enable no-console */

--- a/app/assets/javascripts/discourse/app/templates/components/future-date-input.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/future-date-input.hbs
@@ -11,6 +11,7 @@
         includeWeekend=includeWeekend
         includeFarFuture=includeFarFuture
         includeMidFuture=includeMidFuture
+        includeNow=includeNow
         clearable=clearable
         none="topic.auto_update_input.none"
         onChangeInput=onChangeInput

--- a/app/assets/javascripts/select-kit/addon/components/future-date-input-selector.js
+++ b/app/assets/javascripts/select-kit/addon/components/future-date-input-selector.js
@@ -19,6 +19,13 @@ function buildTimeframe(opts) {
 
 export const TIMEFRAMES = [
   buildTimeframe({
+    id: "now",
+    format: "h:mm a",
+    enabled: opts => opts.canScheduleNow,
+    when: time => time.add(1, "minute"),
+    icon: "magic"
+  }),
+  buildTimeframe({
     id: "later_today",
     format: "h a",
     enabled: opts => opts.canScheduleToday,
@@ -214,6 +221,7 @@ export default ComboBoxComponent.extend(DatetimeMixin, {
       includeFarFuture: this.includeFarFuture,
       includeDateTime: this.includeDateTime,
       includeBasedOnLastPost: this.statusType === CLOSE_STATUS_TYPE,
+      canScheduleNow: this.includeNow || false,
       canScheduleToday: 24 - now.hour() > 6
     };
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2225,6 +2225,7 @@ en:
         time_frame_required: Please select a time frame
       auto_update_input:
         none: "Select a timeframe"
+        now: "Now"
         later_today: "Later today"
         tomorrow: "Tomorrow"
         later_this_week: "Later this week"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/920448/84616105-4a597100-af0e-11ea-9b03-f08780100725.png)

* Sometimes you need to schedule things from now onward. "Now" in this case is now + 1 minute. this option is hidden by default.