### PR TITLE
FIX: add table name to topic view query

### DIFF
--- a/lib/topic_view.rb
+++ b/lib/topic_view.rb
@@ -546,7 +546,7 @@ class TopicView
       columns = [:id]
 
       if !is_mega_topic?
-        columns << 'EXTRACT(DAYS FROM CURRENT_TIMESTAMP - created_at)::INT AS days_ago'
+        columns << 'EXTRACT(DAYS FROM CURRENT_TIMESTAMP - posts.created_at)::INT AS days_ago'
       end
 
       posts.pluck(*columns)


### PR DESCRIPTION
When plugin is hooking into TopicView joining other tables, it may fail because `created_at` is potentially available on 2 tables. Therefore we should explicitly define which `created_at` we want.