### PR TITLE
ARIA - add aria-label on topic input and post textarea

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-textarea.js
+++ b/app/assets/javascripts/discourse/app/components/d-textarea.js
@@ -1,0 +1,5 @@
+import TextArea from "@ember/component/text-area";
+
+export default TextArea.extend({
+  attributeBindings: ["aria-label"]
+});

--- a/app/assets/javascripts/discourse/app/components/text-field.js
+++ b/app/assets/javascripts/discourse/app/components/text-field.js
@@ -12,7 +12,8 @@ export default TextField.extend({
     "autocapitalize",
     "autofocus",
     "maxLength",
-    "dir"
+    "dir",
+    "aria-label"
   ],
 
   init() {

--- a/app/assets/javascripts/discourse/app/templates/components/composer-title.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/composer-title.hbs
@@ -3,6 +3,7 @@
              id="reply-title"
              maxLength=titleMaxLength
              placeholderKey=composer.titlePlaceholder
+             aria-label=(I18n composer.titlePlaceholder)
              disabled=disabled
              autocomplete="discourse"}}
 

--- a/app/assets/javascripts/discourse/app/templates/components/d-editor.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/d-editor.hbs
@@ -33,12 +33,13 @@
     </div>
 
     {{conditional-loading-spinner condition=loading}}
-    {{textarea
+    {{d-textarea
       autocomplete="discourse"
       tabindex=tabindex
       value=value
       class="d-editor-input"
       placeholder=placeholderTranslated
+      aria-label=placeholderTranslated
       disabled=disabled
       input=change}}
     {{popup-input-tip validation=validation}}

--- a/app/assets/javascripts/discourse/app/templates/composer.hbs
+++ b/app/assets/javascripts/discourse/app/templates/composer.hbs
@@ -10,7 +10,7 @@
                         messageCount=messageCount
                         addLinkLookup=(action "addLinkLookup")}}
     {{#if model.viewOpenOrFullscreen}}
-      <div class="reply-area {{if canEditTags "with-tags"}}">
+      <div role="form" aria-label={{I18n saveLabel}} class="reply-area {{if canEditTags "with-tags"}}">
         <div class="composer-fields">
           {{plugin-outlet name="composer-open" args=(hash model=model)}}
           <div class="reply-to">


### PR DESCRIPTION
Add reply form role with label as create/reply, and aria-labels on text inputs

Regarding d-textarea - Is this the only/best way to add html attributes to predefined components, until Ember Octane and Glimmer components are more widely used?