### PR TITLE
DEV: Added topic-list-after-title outlet in the mobile template

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/mobile/list/topic-list-item.hbr
+++ b/app/assets/javascripts/discourse/app/templates/mobile/list/topic-list-item.hbr
@@ -23,6 +23,7 @@
           {{~#if topic.featured_link~}}
           {{~topic-featured-link topic~}}
           {{~/if~}}
+          {{~raw-plugin-outlet name="topic-list-after-title"}}
           {{~#if topic.unseen~}}
             <span class="topic-post-badges">&nbsp;<span class="badge-notification new-topic"></span></span>
           {{~/if~}}


### PR DESCRIPTION
- Added the outlet as discussed here. https://meta.discourse.org/t/adding-topic-list-after-title-outlet-to-the-mobile-template/155087/3