### PR TITLE
make unix domain sockets listening example match web.socketed.template.yml

### DIFF
--- a/config/nginx.sample.conf
+++ b/config/nginx.sample.conf
@@ -4,10 +4,8 @@ types {
 }
 
 upstream discourse {
-  server unix:/var/www/discourse/tmp/sockets/thin.0.sock;
-  server unix:/var/www/discourse/tmp/sockets/thin.1.sock;
-  server unix:/var/www/discourse/tmp/sockets/thin.2.sock;
-  server unix:/var/www/discourse/tmp/sockets/thin.3.sock;
+  server unix:/var/www/discourse/tmp/sockets/nginx.http.sock;
+  server unix:/var/www/discourse/tmp/sockets/nginx.https.sock; 
 }
 
 # inactive means we keep stuff around for 1440m minutes regardless of last access (1 week)


### PR DESCRIPTION
I cannot find any google results for `"server unix:/var/www/discourse/tmp/sockets/thin.0.sock;"`. Therefore I think it is not actually used by anyone in public writing about discourse in that way.

It would be more useful to use the same as [web.socketed.template.yml](https://github.com/discourse/discourse_docker/blob/master/templates/web.socketed.template.yml). Would make the example a bit easier to understand.