### PR TITLE
DEV: Use short_date helper for email post template

### DIFF
--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -174,14 +174,6 @@ class UserNotifications < ActionMailer::Base
     )
   end
 
-  def short_date(dt)
-    if dt.year == Time.now.year
-      I18n.l(dt, format: :short_no_year)
-    else
-      I18n.l(dt, format: :date_only)
-    end
-  end
-
   def digest(user, opts = {})
     build_summary_for(user)
     min_date = opts[:since] || user.last_emailed_at || user.last_seen_at || 1.month.ago

--- a/app/views/email/_post.html.erb
+++ b/app/views/email/_post.html.erb
@@ -20,7 +20,7 @@
           <span class='user-title'><%= post.user.title %></span>
         <% end %>
         <br>
-        <span class='notification-date'><%= l post.created_at, format: :short_no_year %></span>
+        <span class='notification-date'><%= short_date(post.created_at) %></span>
       </td>
     </tr>
   </table>


### PR DESCRIPTION
The removed `short_date` method in UserNotifications is identical to the method with the same name in ApplicationHelper.