### PR TITLE
FIX: Hide the post history for TL4

### DIFF
--- a/lib/guardian/post_guardian.rb
+++ b/lib/guardian/post_guardian.rb
@@ -220,7 +220,7 @@ module PostGuardian
     end
 
     authenticated? &&
-    (is_staff? || @user.has_trust_level?(TrustLevel[4]) || @user.id == post.user_id) &&
+    (is_staff? || @user.id == post.user_id) &&
     can_see_post?(post)
   end
 

--- a/spec/components/guardian_spec.rb
+++ b/spec/components/guardian_spec.rb
@@ -890,12 +890,9 @@ describe Guardian do
           expect(Guardian.new(moderator).can_see?(post_revision)).to be_truthy
         end
 
-        it 'is true for trust level 4' do
-          expect(Guardian.new(trust_level_4).can_see?(post_revision)).to be_truthy
-        end
-
-        it 'is false for trust level lower than 4' do
+        it 'is false for trust level equal or lower than 4' do
           expect(Guardian.new(trust_level_3).can_see?(post_revision)).to be_falsey
+          expect(Guardian.new(trust_level_4).can_see?(post_revision)).to be_falsey
         end
       end
     end

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -1323,10 +1323,10 @@ describe PostsController do
         expect(response.status).to eq(200)
       end
 
-      it "ensures trust level 4 can see the revisions" do
+      it "ensures trust level 4 cannot see the revisions" do
         sign_in(Fabricate(:user, trust_level: 4))
         get "/posts/#{post_revision.post_id}/revisions/#{post_revision.number}.json"
-        expect(response.status).to eq(200)
+        expect(response.status).to eq(403)
       end
     end
 


### PR DESCRIPTION
TL4 users should not see the edit history if `edit_history_visible_to_public` site setting is disabled.