### PR TITLE
FIX: Allow multiple hyphens in host

### DIFF
--- a/app/models/embeddable_host.rb
+++ b/app/models/embeddable_host.rb
@@ -61,7 +61,7 @@ class EmbeddableHost < ActiveRecord::Base
   end
 
   def host_must_be_valid
-    if host !~ /\A[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,24}(:[0-9]{1,5})?(\/.*)?\Z/i &&
+    if host !~ /\A[a-z0-9]+([\-\.]+{1}[a-z0-9]+)*\.[a-z]{2,24}(:[0-9]{1,5})?(\/.*)?\Z/i &&
        host !~ /\A(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})(:[0-9]{1,5})?(\/.*)?\Z/ &&
        host !~ /\A([a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.)?localhost(\:[0-9]{1,5})?(\/.*)?\Z/i
       errors.add(:host, I18n.t('errors.messages.invalid'))

--- a/spec/models/embeddable_host_spec.rb
+++ b/spec/models/embeddable_host_spec.rb
@@ -52,6 +52,12 @@ describe EmbeddableHost do
     expect(eh.host).to eq('discourse.localhost')
   end
 
+  it "supports multiple hyphens" do
+    eh = EmbeddableHost.new(host: 'deploy-preview-1--example.example.app')
+    expect(eh).to be_valid
+    expect(eh.host).to eq('deploy-preview-1--example.example.app')
+  end
+
   it "rejects misspellings of localhost" do
     eh = EmbeddableHost.new(host: 'alocalhost')
     expect(eh).not_to be_valid


### PR DESCRIPTION
Currently having multiple hyphens (-) in the host, throws an "invalid" error. For example, currently ```deploy-preview-1--example.netlify.app```, would not be considered valid.