### PR TITLE
FEATURE: Add `before_email_send` event

### DIFF
--- a/lib/email/sender.rb
+++ b/lib/email/sender.rb
@@ -209,6 +209,8 @@ module Email
 
       email_log.message_id = @message.message_id
 
+      DiscourseEvent.trigger(:before_email_send, @message, @email_type)
+
       begin
         @message.deliver_now
       rescue *SMTP_CLIENT_ERRORS => e


### PR DESCRIPTION
Plugins can use it to customize the message (e.g. add header) before the email is sent.