### PR TITLE
DEV: move user references deletion code to `before_destroy`.

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -161,6 +161,13 @@ class User < ActiveRecord::Base
 
     # our relationship filters on enabled, this makes sure everything is deleted
     UserSecurityKey.where(user_id: self.id).delete_all
+
+    Developer.where(user_id: self.id).delete_all
+    DraftSequence.where(user_id: self.id).delete_all
+    GivenDailyLike.where(user_id: self.id).delete_all
+    MutedUser.where(user_id: self.id).or(MutedUser.where(muted_user_id: self.id)).delete_all
+    IgnoredUser.where(user_id: self.id).or(IgnoredUser.where(ignored_user_id: self.id)).delete_all
+    UserAvatar.where(user_id: self.id).delete_all
   end
 
   # Skip validating email, for example from a particular auth provider plugin

--- a/app/services/user_merger.rb
+++ b/app/services/user_merger.rb
@@ -22,7 +22,6 @@ class UserMerger
     update_user_stats
 
     delete_source_user
-    delete_source_user_references
     log_merge
 
     @target_user.reload
@@ -366,17 +365,6 @@ class UserMerger
     )
 
     UserDestroyer.new(Discourse.system_user).destroy(@source_user, quiet: true)
-  end
-
-  def delete_source_user_references
-    Developer.where(user_id: @source_user.id).delete_all
-    DraftSequence.where(user_id: @source_user.id).delete_all
-    GivenDailyLike.where(user_id: @source_user.id).delete_all
-    MutedUser.where(user_id: @source_user.id).or(MutedUser.where(muted_user_id: @source_user.id)).delete_all
-    IgnoredUser.where(user_id: @source_user.id).or(IgnoredUser.where(ignored_user_id: @source_user.id)).delete_all
-    UserAuthTokenLog.where(user_id: @source_user.id).delete_all
-    UserAvatar.where(user_id: @source_user.id).delete_all
-    UserAction.where(acting_user_id: @source_user.id).delete_all
   end
 
   def log_merge

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2224,6 +2224,7 @@ describe User do
       UserAction.create!(user_id: user.id, action_type: UserAction::LIKE)
       UserAction.create!(user_id: -1, action_type: UserAction::LIKE, target_user_id: user.id)
       UserAction.create!(user_id: -1, action_type: UserAction::LIKE, acting_user_id: user.id)
+      Developer.create!(user_id: user.id)
 
       user.reload
 
@@ -2233,6 +2234,7 @@ describe User do
       expect(UserAction.where(target_user_id: user.id).length).to eq(0)
       expect(UserAction.where(acting_user_id: user.id).length).to eq(0)
       expect(PostAction.with_deleted.where(user_id: user.id).length).to eq(0)
+      expect(Developer.where(user_id: user.id).length).to eq(0)
     end
   end
 


### PR DESCRIPTION
Moving the `delete_source_user_references` method code from user merger service to user model.