### PR TITLE
FIX: handle heroku style HTTP_X_REQUEST_START

### DIFF
--- a/lib/middleware/request_tracker.rb
+++ b/lib/middleware/request_tracker.rb
@@ -145,7 +145,11 @@ class Middleware::RequestTracker
   def self.populate_request_queue_seconds!(env)
     if !env['REQUEST_QUEUE_SECONDS']
       if queue_start = env['HTTP_X_REQUEST_START']
-        queue_start = queue_start.split("t=")[1].to_f
+        queue_start = if queue_start.start_with?("t=")
+          queue_start.split("t=")[1].to_f
+        else
+          queue_start.to_f / 1000.0
+        end
         queue_time = (Time.now.to_f - queue_start)
         env['REQUEST_QUEUE_SECONDS'] = queue_time
       end


### PR DESCRIPTION
Noticed search and other features were not working on our heroku instance after upgrade. A little sleuthing showed the issue:

```
$ rbtrace --ps "puma: cluster" -m 'Middleware::RequestTracker#rate_limit(request.env["REQUEST_QUEUE_SECONDS"])'
*** attached to process 78
Middleware::RequestTracker#rate_limit(request.env["REQUEST_QUEUE_SECONDS"]=1592524121.9201534) <0.002393>
Middleware::RequestTracker#rate_limit(request.env["REQUEST_QUEUE_SECONDS"]=1592524122.3583024) <0.002228>
Middleware::RequestTracker#rate_limit(request.env["REQUEST_QUEUE_SECONDS"]=1592524122.6266675) <0.002415>
```

after this PR:

```
Middleware::RequestTracker#rate_limit(request.env["REQUEST_QUEUE_SECONDS"]=0.009975671768188477) <0.006217>
```

cc @SamSaffron 