### PR TITLE
FIX: Do not incorrectly add topic bookmark on Escape

### DIFF
--- a/app/assets/javascripts/discourse/app/models/topic.js
+++ b/app/assets/javascripts/discourse/app/models/topic.js
@@ -430,8 +430,11 @@ const Topic = RestModel.extend({
     return this.firstPost().then(firstPost => {
       const toggleBookmarkOnServer = () => {
         if (bookmark) {
-          return firstPost.toggleBookmark().then(() => {
+          return firstPost.toggleBookmark().then(opts => {
             this.set("bookmarking", false);
+            if (opts.closedWithoutSaving) {
+              return;
+            }
             return this.afterTopicBookmarked(firstPost);
           });
         } else {

--- a/app/assets/javascripts/discourse/app/templates/modal/bookmark.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/bookmark.hbs
@@ -9,7 +9,7 @@
     {{/if}}
 
     <div class="control-group bookmark-name-wrap">
-      {{input id="bookmark-name" value=model.name name="bookmark-name" class="bookmark-name" placeholder=(i18n "post.bookmarks.name_placeholder")}}
+      {{input id="bookmark-name" value=model.name name="bookmark-name" class="bookmark-name" enter=(action "saveAndClose") placeholder=(i18n "post.bookmarks.name_placeholder")}}
       {{d-button icon="cog" action=(action "toggleOptionsPanel") class="bookmark-options-button"}}
     </div>
 


### PR DESCRIPTION
* The first post was showing as bookmarked incorrectly after pressing `f` to open the topic modal then pressing escape to cancel without saving, because the `closeWithoutSaving` option was not being respected.
* Also re-introduce the `enter` shortcut when the name input is focused to `saveAndClose` the bookmark modal by pressing enter.