### PR TITLE
FIX: Make migrations from S3 more robust; fix bare URL migration

### DIFF
--- a/lib/tasks/uploads.rake
+++ b/lib/tasks/uploads.rake
@@ -225,7 +225,7 @@ def migrate_from_s3(max: nil, limit: nil)
       end
 
       if updated
-        post.save!
+        post.save!(validate: false)
         post.rebake!
         posts_modified += 1
         if max


### PR DESCRIPTION
Fix handling of bare URLs to (more) correctly process URLs present
in s3 or a clone when migrating to local, including changing to an
`upload:` psuedo-protocol URL, tagging audio and video files, using
the `![name](url)` syntax, and in the process not creating non-URLs
that point to nothing.

Fix `batch_migrate_from_s3` to take both a max number of posts to
actually modify in a migration (the original but failed intent of
limit) and a limit of total posts to consider for migration (for
cheaper database queries).  Because a primary goal of the `max`
limit is debugging, also use it to cause verbose logging output.

Print diagnostic messages for conditions that might require manual
intervention, such as file too large (if upload sizes were reduced
in site settings) or failure to download (which can happen on an
intermittent basis and might require re-running the migration).

Finally, in the case of a truly unexpected error, print the error
and stop processing, so that error cascades do not become hidden
failures stopping a successful migration, but can instead be resolved.