### PR TITLE
DEV: Make component-test `afterEach` async aware

### DIFF
--- a/test/javascripts/helpers/component-test.js
+++ b/test/javascripts/helpers/component-test.js
@@ -55,12 +55,12 @@ export default function(name, opts) {
     });
 
     andThen(() => {
-      try {
-        opts.test.call(this, assert);
-      } finally {
-        if (opts.afterEach) {
-          opts.afterEach.call(opts);
-        }
+      return opts.test.call(this, assert);
+    }).finally(() => {
+      if (opts.afterEach) {
+        andThen(() => {
+          return opts.afterEach.call(opts);
+        });
       }
     });
   });


### PR DESCRIPTION
Before this fix, if a test case was async, `afterEach` callback would be executed immediately, without waiting for the test to finish. 😬