### PR TITLE
FIX: Use raw content when checking for watched words to flag

### DIFF
--- a/app/jobs/regular/process_post.rb
+++ b/app/jobs/regular/process_post.rb
@@ -41,7 +41,7 @@ module Jobs
         end
 
         if !post.user&.staff? && !post.user&.staged?
-          s = post.cooked
+          s = post.raw
           s << " #{post.topic.title}" if post.post_number == 1
           if !args[:bypass_bump] && WordWatcher.new(s).should_flag?
             PostActionCreator.create(


### PR DESCRIPTION
This makes flagged watched words match the behavior of censor, requires_approval and blocked watched words.