### PR TITLE
FIX: advanced tutorial errors when all categories are secured

### DIFF
--- a/plugins/discourse-narrative-bot/lib/discourse_narrative_bot/advanced_user_narrative.rb
+++ b/plugins/discourse-narrative-bot/lib/discourse_narrative_bot/advanced_user_narrative.rb
@@ -41,7 +41,7 @@ module DiscourseNarrativeBot
       tutorial_recover: {
         next_state: :tutorial_category_hashtag,
         next_instructions: Proc.new do
-          category = Category.secured.last
+          category = Category.secured(Guardian.new(@user)).last
           slug = category.slug
 
           if parent_category = category.parent_category


### PR DESCRIPTION
The category hashtag step will fail with an error when all categories aren't public. Choose a category that the user can see.