### PR TITLE
DEV: Add skip seed flag

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -157,10 +157,13 @@ task 'multisite:migrate' => ['db:load_config', 'environment', 'set_locale'] do |
   SeedFu.seed(seed_paths, /001_refresh/)
 
   execute_concurently(concurrency, exceptions) do |db|
+
     if !Discourse.skip_post_deployment_migrations? && ENV['SKIP_OPTIMIZE_ICONS'] != '1'
-      puts "Seeding #{db}"
-      SeedFu.seed(seed_paths)
       SiteIconManager.ensure_optimized!
+      if ENV['SKIP_SEED'] != '1'
+        puts "Seeding #{db}"
+        SeedFu.seed(seed_paths)
+      end
     end
   end
 

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -200,7 +200,7 @@ task 'db:migrate' => ['load_config', 'environment', 'set_locale'] do |_, args|
     Rake::Task['db:_dump'].invoke
   end
 
-  SeedFu.quiet = true
+  SeedFu.quiet = false
 
   # Allows a plugin to exclude any specified seed data files from running
   filter = DiscoursePluginRegistry.seedfu_filter.any? ?

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -112,7 +112,7 @@ task 'multisite:migrate' => ['db:load_config', 'environment', 'set_locale'] do |
   old_stdout = $stdout
   $stdout = StdOutDemux.new($stdout)
 
-  SeedFu.quiet = true
+  SeedFu.quiet = false
 
   def execute_concurently(concurrency, exceptions)
     queue = Queue.new

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -158,6 +158,7 @@ task 'multisite:migrate' => ['db:load_config', 'environment', 'set_locale'] do |
     /^(?!.*(#{DiscoursePluginRegistry.seedfu_filter.to_a.join("|")})).*$/ : nil
 
   seed_paths = DiscoursePluginRegistry.seed_paths
+  puts "001_refresh"
   SeedFu.seed(seed_paths, /001_refresh/)
 
   execute_concurently(concurrency, exceptions) do |db|

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -157,12 +157,9 @@ task 'multisite:migrate' => ['db:load_config', 'environment', 'set_locale'] do |
   SeedFu.seed(seed_paths, /001_refresh/)
 
   execute_concurently(concurrency, exceptions) do |db|
-    if ENV['SKIP_SEED'] != '1'
+    if !Discourse.skip_post_deployment_migrations? && ENV['SKIP_OPTIMIZE_ICONS'] != '1'
       puts "Seeding #{db}"
       SeedFu.seed(seed_paths)
-    end
-
-    if !Discourse.skip_post_deployment_migrations? && ENV['SKIP_OPTIMIZE_ICONS'] != '1'
       SiteIconManager.ensure_optimized!
     end
   end


### PR DESCRIPTION
Sometimes we don't want seed data to run like when running our post_deploy tasks. The seed data has already ran so we don't need to run it a second time.