### PR TITLE
Update category_featured_topic.rb

### DIFF
--- a/app/models/category_featured_topic.rb
+++ b/app/models/category_featured_topic.rb
@@ -74,7 +74,7 @@ class CategoryFeaturedTopic < ActiveRecord::Base
         results.each_with_index do |topic_id, idx|
           begin
             c.category_featured_topics.create(topic_id: topic_id, rank: idx)
-          rescue PG::UniqueViolation
+          rescue PG::UniqueViolation, ActiveRecord::RecordNotUnique
             # If another process features this topic, just ignore it
           end
         end


### PR DESCRIPTION
Only made one change, catching ActiveRecord::RecordNotUnique as well as the pre-existing PG::UniqueViolation

In my experience, does not catch the PG::UniqueViolation as ActiveRecord::RecordNotUnique is on top of it, so you should have both. I ran into this problem when creating large amounts of topics at the same time (I usually find this downstream in the source code when I pull it and change it there after each git clone)