### PR TITLE
FEATURE: Site setting to always show category definitions

### DIFF
--- a/app/controllers/list_controller.rb
+++ b/app/controllers/list_controller.rb
@@ -52,7 +52,9 @@ class ListController < ApplicationController
       list_opts = build_topic_list_options
       list_opts.merge!(options) if options
       user = list_target_user
-      list_opts[:no_definitions] = true if params[:category].blank? && filter == :latest
+      if params[:category].blank? && filter == :latest && !SiteSetting.always_show_category_definitions
+        list_opts[:no_definitions] = true
+      end
 
       list = TopicQuery.new(user, list_opts).public_send("list_#{filter}")
 

--- a/app/controllers/list_controller.rb
+++ b/app/controllers/list_controller.rb
@@ -52,7 +52,7 @@ class ListController < ApplicationController
       list_opts = build_topic_list_options
       list_opts.merge!(options) if options
       user = list_target_user
-      if params[:category].blank? && filter == :latest && !SiteSetting.always_show_category_definitions
+      if params[:category].blank? && filter == :latest && !SiteSetting.show_category_definitions_in_topic_lists
         list_opts[:no_definitions] = true
       end
 

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2030,6 +2030,9 @@ uncategorized:
   overridden_robots_txt:
     default: ""
     hidden: true
+  always_show_category_definitions:
+    default: false
+    hidden: true
 
 user_preferences:
   default_email_digest_frequency:

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2030,7 +2030,7 @@ uncategorized:
   overridden_robots_txt:
     default: ""
     hidden: true
-  always_show_category_definitions:
+  show_category_definitions_in_topic_lists:
     default: false
     hidden: true
 

--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -736,7 +736,7 @@ class TopicQuery
     result = result.listable_topics
 
     # Don't include the category topics if excluded
-    if options[:no_definitions]
+    if options[:no_definitions] && !SiteSetting.always_show_category_definitions
       result = result.where('COALESCE(categories.topic_id, 0) <> topics.id')
     end
 

--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -736,7 +736,7 @@ class TopicQuery
     result = result.listable_topics
 
     # Don't include the category topics if excluded
-    if options[:no_definitions] && !SiteSetting.always_show_category_definitions
+    if options[:no_definitions]
       result = result.where('COALESCE(categories.topic_id, 0) <> topics.id')
     end
 


### PR DESCRIPTION
Adds a hidden site settings to always show category definition topics in the topic list.