### PR TITLE
FIX: published-page-header should be a sibling to published-page-body

### DIFF
--- a/app/views/published_pages/show.html.erb
+++ b/app/views/published_pages/show.html.erb
@@ -9,11 +9,10 @@
         <div class="topic-created-at"><%= short_date(@topic.created_at) %></div>
       </div>
     </div>
-
-    <%- if @topic.first_post.present? %>
-      <div class="published-page-body">
-        <%= @topic.first_post.cooked.html_safe %>
-      </div>
-    <%- end -%>
   </div>
+  <%- if @topic.first_post.present? %>
+    <div class="published-page-body">
+      <%= @topic.first_post.cooked.html_safe %>
+    </div>
+  <%- end -%>
 </div>


### PR DESCRIPTION
According to the [Page Publishing Meta topic](https://meta.discourse.org/t/page-publishing/151971), the spec for the `published-page-header` element is "title and authorship information." This change will move `published-page-body` to be a sibling of `published-page-header` since it does not seem correct to include `published-page-body` as a child.

**Before:**
<img width="825" alt="Screen Shot 2020-06-25 at 11 05 04 AM" src="https://user-images.githubusercontent.com/22733864/85777320-601d2200-b6d6-11ea-9224-ecbd406c5991.png">

**After:**
<img width="823" alt="Screen Shot 2020-06-25 at 11 06 21 AM" src="https://user-images.githubusercontent.com/22733864/85777339-64e1d600-b6d6-11ea-8a34-fcb48036f6c0.png">
