### PR TITLE
DEV: Add a basic licensed config

### DIFF
--- a/.licensed.yml
+++ b/.licensed.yml
@@ -1,0 +1,12 @@
+sources:
+  yarn: true
+  bundler: true
+allowed:
+  - mit
+  - apache-2.0
+  - bsd-2-clause
+  - bsd-3-clause
+  - cc0-1.0
+  - isc
+  - other
+  - none  


### PR DESCRIPTION
This means a dev can run https://github.com/github/licensed
in order to obtain license information easily