### PR TITLE
Preloaded Data Changes

### DIFF
--- a/app/assets/javascripts/discourse/app/pre-initializers/discourse-bootstrap.js
+++ b/app/assets/javascripts/discourse/app/pre-initializers/discourse-bootstrap.js
@@ -19,14 +19,14 @@ export default {
     if (isTesting()) {
       return;
     }
-    const preloadedDataElement = document.getElementById("data-preloaded");
+
+    const preloaded = document.querySelector('[type="text/discourse-preload"]');
+    const preloadedData = JSON.parse(preloaded.text.trim());
     const setupData = document.getElementById("data-discourse-setup").dataset;
 
-    if (preloadedDataElement) {
-      const preloaded = JSON.parse(preloadedDataElement.dataset.preloaded);
-
-      Object.keys(preloaded).forEach(function(key) {
-        PreloadStore.store(key, JSON.parse(preloaded[key]));
+    if (preloadedData) {
+      Object.keys(preloadedData).forEach(function(key) {
+        PreloadStore.store(key, preloadedData[key]);
 
         if (setupData.debugPreloadedAppData === "true") {
           /* eslint-disable no-console */

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -345,7 +345,7 @@ class ApplicationController < ActionController::Base
     # I dislike that there is a gsub as opposed to a gsub!
     #  but we can not be mucking with user input, I wonder if there is a way
     #  to inject this safty deeper in the library or even in AM serializer
-    @preloaded[key] = json.gsub("</", "<\\/")
+    @preloaded[key] = JSON.parse(json)
   end
 
   # If we are rendering HTML, preload the session data

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -452,7 +452,7 @@ module ApplicationHelper
 
   def preloaded_json
     return '{}' if @preloaded.blank?
-    @preloaded.transform_values { |value| escape_unicode(value) }.to_json
+    MultiJson.dump(@preloaded)
   end
 
   def client_side_setup_data

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -452,7 +452,10 @@ module ApplicationHelper
 
   def preloaded_json
     return '{}' if @preloaded.blank?
-    MultiJson.dump(@preloaded)
+    # I dislike that there is a gsub as opposed to a gsub!
+    #  but we can not be mucking with user input, I wonder if there is a way
+    #  to inject this safty deeper in the library or even in AM serializer
+    MultiJson.dump(@preloaded).gsub("</", "<\\/")
   end
 
   def client_side_setup_data

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -108,7 +108,9 @@
       </form>
     <% end %>
 
-    <div class="hidden" id="data-preloaded" data-preloaded="<%= preloaded_json %>"></div>
+    <script type="text/discourse-preload">
+      <%= preloaded_json.html_safe %>
+    </script>
     <%= preload_script "start-discourse" %>
 
     <%= yield :data %>


### PR DESCRIPTION
!!! This is just a draft for discussion !!!

This draft moves the big preloaded data payload we send on the HTML from a data-attribute to a Javascript variable.

In doing this, it greatly reduces the size of the HTML (around ~50KB depending on site, before gzip) and reduces the number of necessary `JSON.parse` on the browser boot. To work with CSP it adds a nonce to secure the inline script, keeping this payload inline with the main document.

On the Ruby side, we are still generating/storing JSONs everywhere, so this PR hacks around by doing parsing each part back into a Hash so it can create a proper JSON only in the last step. If this approach is deemed worth to follow up we will need to fix this by adding Hash versions of each method so we don't do double the work on the backend.

I would like the review on this refactor to see if it is something worth pursuing.

One unexpected change from this PR is that it fix the "View Source" breaking on Firefox :D . I believe the 350KB single HTML tag highlight was the culprit.