### PR TITLE
FIX: count new and unread respects muted categories

### DIFF
--- a/app/assets/javascripts/discourse/app/models/topic-tracking-state.js
+++ b/app/assets/javascripts/discourse/app/models/topic-tracking-state.js
@@ -410,6 +410,7 @@ const TopicTrackingState = EmberObject.extend({
 
   countCategoryByState(fn, categoryId, tagId) {
     const subcategoryIds = this.getSubCategoryIds(categoryId);
+    const mutedCategoryIds = this.currentUser.muted_category_ids;
     return _.chain(this.states)
       .filter(fn)
       .filter(
@@ -417,7 +418,9 @@ const TopicTrackingState = EmberObject.extend({
           topic.archetype !== "private_message" &&
           !topic.deleted &&
           (!categoryId || subcategoryIds.has(topic.category_id)) &&
-          (!tagId || (topic.tags && topic.tags.indexOf(tagId) > -1))
+          (!tagId || (topic.tags && topic.tags.indexOf(tagId) > -1)) &&
+          (!mutedCategoryIds ||
+            mutedCategoryIds.indexOf(topic.category_id) === -1)
       )
       .value().length;
   },

--- a/app/assets/javascripts/discourse/app/models/topic-tracking-state.js
+++ b/app/assets/javascripts/discourse/app/models/topic-tracking-state.js
@@ -408,29 +408,31 @@ const TopicTrackingState = EmberObject.extend({
     return new Set(result);
   },
 
-  countCategoryByState(fn, categoryId, tagId) {
+  countCategoryByState(type, categoryId, tagId) {
     const subcategoryIds = this.getSubCategoryIds(categoryId);
-    const mutedCategoryIds = this.currentUser.muted_category_ids;
+    const mutedCategoryIds =
+      this.currentUser && this.currentUser.muted_category_ids;
     return _.chain(this.states)
-      .filter(fn)
+      .filter(type === "new" ? isNew : isUnread)
       .filter(
         topic =>
           topic.archetype !== "private_message" &&
           !topic.deleted &&
           (!categoryId || subcategoryIds.has(topic.category_id)) &&
           (!tagId || (topic.tags && topic.tags.indexOf(tagId) > -1)) &&
-          (!mutedCategoryIds ||
+          (type !== "new" ||
+            !mutedCategoryIds ||
             mutedCategoryIds.indexOf(topic.category_id) === -1)
       )
       .value().length;
   },
 
   countNew(categoryId, tagId) {
-    return this.countCategoryByState(isNew, categoryId, tagId);
+    return this.countCategoryByState("new", categoryId, tagId);
   },
 
   countUnread(categoryId, tagId) {
-    return this.countCategoryByState(isUnread, categoryId, tagId);
+    return this.countCategoryByState("unread", categoryId, tagId);
   },
 
   countTags(tags) {

--- a/test/javascripts/models/topic-tracking-state-test.js
+++ b/test/javascripts/models/topic-tracking-state-test.js
@@ -189,9 +189,18 @@ QUnit.test("countNew", assert => {
     slug: "baz",
     parent_category_id: bar.id
   });
-  sandbox.stub(Category, "list").returns([foo, bar, baz]);
+  const qux = store.createRecord("category", {
+    id: 4,
+    slug: "qux"
+  });
+  sandbox.stub(Category, "list").returns([foo, bar, baz, qux]);
 
-  const state = TopicTrackingState.create();
+  let currentUser = User.create({
+    username: "chuck",
+    muted_category_ids: [4]
+  });
+
+  const state = TopicTrackingState.create({ currentUser });
 
   assert.equal(state.countNew(1), 0);
   assert.equal(state.countNew(2), 0);
@@ -233,6 +242,13 @@ QUnit.test("countNew", assert => {
   assert.equal(state.countNew(1), 3);
   assert.equal(state.countNew(2), 2);
   assert.equal(state.countNew(3), 1);
+
+  state.states["t115"] = {
+    last_read_post_number: null,
+    id: 115,
+    category_id: 4
+  };
+  assert.equal(state.countNew(4), 0);
 });
 
 QUnit.test("mute topic", function(assert) {


### PR DESCRIPTION
countCategoryByState function should take categories muted by the user into consideration