### PR TITLE
FIX: Improve category hashtag lookup

### DIFF
--- a/app/controllers/category_hashtags_controller.rb
+++ b/app/controllers/category_hashtags_controller.rb
@@ -9,7 +9,7 @@ class CategoryHashtagsController < ApplicationController
     ids = category_slugs.map { |category_slug| Category.query_from_hashtag_slug(category_slug).try(:id) }
 
     valid_categories = Category.secured(guardian).where(id: ids).map do |category|
-      { slug: category.hashtag_slug, url: category.url }
+      { slug: category.slug_path.join(':'), url: category.url }
     end.compact
 
     render json: { valid: valid_categories }

--- a/app/controllers/category_hashtags_controller.rb
+++ b/app/controllers/category_hashtags_controller.rb
@@ -8,8 +8,12 @@ class CategoryHashtagsController < ApplicationController
 
     ids = category_slugs.map { |category_slug| Category.query_from_hashtag_slug(category_slug).try(:id) }
 
-    valid_categories = Category.secured(guardian).where(id: ids).map do |category|
-      { slug: category.slug_path.join(':'), url: category.url }
+    valid_categories = []
+
+    Category.secured(guardian).where(id: ids).each do |category|
+      slug_path = category.slug_path
+      valid_categories << { slug: slug_path.join(':'), url: category.url }
+      valid_categories << { slug: slug_path[-2..].join(':'), url: category.url } if slug_path.size > 2
     end.compact
 
     render json: { valid: valid_categories }

--- a/app/controllers/category_hashtags_controller.rb
+++ b/app/controllers/category_hashtags_controller.rb
@@ -8,14 +8,15 @@ class CategoryHashtagsController < ApplicationController
 
     ids = category_slugs.map { |category_slug| Category.query_from_hashtag_slug(category_slug).try(:id) }
 
-    valid_categories = []
+    slugs_and_urls = {}
 
     Category.secured(guardian).where(id: ids).each do |category|
-      slug_path = category.slug_path
-      valid_categories << { slug: slug_path.join(':'), url: category.url }
-      valid_categories << { slug: slug_path[-2..].join(':'), url: category.url } if slug_path.size > 2
-    end.compact
+      slugs_and_urls[category.slug] ||= category.url
+      slugs_and_urls[category.slug_path.last(2).join(':')] ||= category.url
+    end
 
-    render json: { valid: valid_categories }
+    render json: {
+      valid: slugs_and_urls.map { |slug, url| { slug: slug, url: url } }
+    }
   end
 end

--- a/app/models/concerns/category_hashtag.rb
+++ b/app/models/concerns/category_hashtag.rb
@@ -7,19 +7,8 @@ module CategoryHashtag
 
   class_methods do
     def query_from_hashtag_slug(category_slug)
-      parent_slug, child_slug = category_slug.split(SEPARATOR, 2)
-
-      categories = Category.where(slug: parent_slug)
-
-      if child_slug
-        Category.where(slug: child_slug, parent_category_id: categories.select(:id)).first
-      else
-        categories.where(parent_category_id: nil).first
-      end
+      slug_path = category_slug.split(SEPARATOR)
+      Category.find_by_slug_path(slug_path)
     end
-  end
-
-  def hashtag_slug
-    full_slug.split("-").last(2).join(SEPARATOR)
   end
 end

--- a/app/models/concerns/category_hashtag.rb
+++ b/app/models/concerns/category_hashtag.rb
@@ -8,7 +8,23 @@ module CategoryHashtag
   class_methods do
     def query_from_hashtag_slug(category_slug)
       slug_path = category_slug.split(SEPARATOR)
-      Category.find_by_slug_path(slug_path)
+
+      return nil if slug_path.empty? || slug_path.size > SiteSetting.max_category_nesting
+
+      if SiteSetting.slug_generation_method == "encoded"
+        slug_path.map! { |slug| CGI.escape(slug) }
+      end
+
+      last_category_id = nil
+
+      slug_path.each do |slug|
+        query = Category.select(:id).where(slug: slug)
+        query = query.where(parent_category_id: last_category_id) if last_category_id.present?
+        return nil if query.blank?
+        last_category_id = query
+      end
+
+      Category.find_by_id(last_category_id)
     end
   end
 end

--- a/app/models/concerns/category_hashtag.rb
+++ b/app/models/concerns/category_hashtag.rb
@@ -8,23 +8,19 @@ module CategoryHashtag
   class_methods do
     def query_from_hashtag_slug(category_slug)
       slug_path = category_slug.split(SEPARATOR)
-
       return nil if slug_path.empty? || slug_path.size > 2
 
       if SiteSetting.slug_generation_method == "encoded"
         slug_path.map! { |slug| CGI.escape(slug) }
       end
 
-      last_category_id = nil
-
-      slug_path.each do |slug|
-        query = Category.select(:id).where(slug: slug)
-        query = query.where(parent_category_id: last_category_id) if last_category_id.present?
-        return nil if query.blank?
-        last_category_id = query.first
+      parent_slug, child_slug = slug_path.last(2)
+      categories = Category.where(slug: parent_slug)
+      if child_slug
+        Category.where(slug: child_slug, parent_category_id: categories.select(:id)).first
+      else
+        categories.where(parent_category_id: nil).first
       end
-
-      Category.find_by_id(last_category_id)
     end
   end
 end

--- a/app/models/concerns/category_hashtag.rb
+++ b/app/models/concerns/category_hashtag.rb
@@ -9,7 +9,7 @@ module CategoryHashtag
     def query_from_hashtag_slug(category_slug)
       slug_path = category_slug.split(SEPARATOR)
 
-      return nil if slug_path.empty? || slug_path.size > SiteSetting.max_category_nesting
+      return nil if slug_path.empty? || slug_path.size > 2
 
       if SiteSetting.slug_generation_method == "encoded"
         slug_path.map! { |slug| CGI.escape(slug) }
@@ -21,7 +21,7 @@ module CategoryHashtag
         query = Category.select(:id).where(slug: slug)
         query = query.where(parent_category_id: last_category_id) if last_category_id.present?
         return nil if query.blank?
-        last_category_id = query
+        last_category_id = query.first
       end
 
       Category.find_by_id(last_category_id)

--- a/spec/requests/category_hashtags_controller_spec.rb
+++ b/spec/requests/category_hashtags_controller_spec.rb
@@ -78,7 +78,8 @@ describe CategoryHashtagsController do
           expect(response.parsed_body).to eq("valid" => [
             { "slug" => category.slug, "url" => category.url },
             { "slug" => "#{category.slug}:#{subcategory.slug}", "url" => subcategory.url },
-            { "slug" => "#{category.slug}:#{subcategory.slug}:#{subsubcategory.slug}", "url" => subsubcategory.url }
+            { "slug" => "#{category.slug}:#{subcategory.slug}:#{subsubcategory.slug}", "url" => subsubcategory.url },
+            { "slug" => "#{subcategory.slug}:#{subsubcategory.slug}", "url" => subsubcategory.url }
           ])
         end
       end

--- a/spec/requests/category_hashtags_controller_spec.rb
+++ b/spec/requests/category_hashtags_controller_spec.rb
@@ -82,7 +82,7 @@ describe CategoryHashtagsController do
           }
 
           expect(response.status).to eq(200)
-          expect(response.parsed_body).to eq("valid" => [
+          expect(response.parsed_body["valid"]).to contain_exactly(
             { "slug" => "foo",     "url" => foo.url },
             { "slug" => "bar",     "url" => foobar.url },
             { "slug" => "foo:bar", "url" => foobar.url },
@@ -90,7 +90,7 @@ describe CategoryHashtagsController do
             { "slug" => "bar:baz", "url" => foobarbaz.url },
             { "slug" => "qux",     "url" => qux.url },
             { "slug" => "qux:bar", "url" => quxbar.url }
-          ])
+          )
         end
       end
     end


### PR DESCRIPTION
This commit improves support for sub-sub-categories and does not include
the ID of the category in the slug, which fixes the composer preview.