### PR TITLE
FIX: Serialize an empty array if no suggested topics exist

### DIFF
--- a/app/serializers/suggested_topics_mixin.rb
+++ b/app/serializers/suggested_topics_mixin.rb
@@ -7,11 +7,11 @@ module SuggestedTopicsMixin
   end
 
   def include_related_messages?
-    object.next_page.nil? && object.related_messages&.topics.present?
+    object.next_page.nil? && object.related_messages&.topics
   end
 
   def include_suggested_topics?
-    object.next_page.nil? && object.suggested_topics&.topics.present?
+    object.next_page.nil? && object.suggested_topics&.topics
   end
 
   def related_messages


### PR DESCRIPTION
It used to return nil instead, which was ambiguous (empty vs absent
result).