### PR TITLE
import pkuczynski public key for RVM install

### DIFF
--- a/docs/DEVELOPER-ADVANCED.md
+++ b/docs/DEVELOPER-ADVANCED.md
@@ -16,6 +16,7 @@ To get your Ubuntu 16.04 or 18.04 LTS install up and running to develop Discours
 
     # Ruby
     curl -sSL https://rvm.io/mpapis.asc | gpg2 --import -
+    curl -sSL https://rvm.io/pkuczynski.asc | gpg2 --import -
     curl -sSL https://get.rvm.io | bash -s stable
     echo 'gem: --no-document' >> ~/.gemrc
 


### PR DESCRIPTION
[RVM release 1.29.10](https://github.com/rvm/rvm/releases/tag/1.29.10) is signed with @pkuczynski's key, so we need to import their key in order for the RVM installation to be verified. Otherwise it fails with this message:

```
gpg: key 3804BB82D39DC0E3: public key "Michal Papis (RVM signing) <mpapis@gmail.com>" imported
gpg: Total number processed: 1
gpg:               imported: 1
# ...
Downloading https://github.com/rvm/rvm/archive/1.29.10.tar.gz
Downloading https://github.com/rvm/rvm/releases/download/1.29.10/1.29.10.tar.gz.asc
gpg: Signature made Wed Mar 25 21:58:42 2020 UTC
gpg:                using RSA key 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
# ...
GPG signature verification failed for '/usr/local/rvm/archives/rvm-1.29.10.tgz' - 'https://github.com/rvm/rvm/releases/download/1.29.10/1.29.10.tar.gz.asc'! Try to install GPG v2 and then fetch the public key:

    gpg2 --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB

or if it fails:

    command curl -sSL https://rvm.io/mpapis.asc | gpg2 --import -
    command curl -sSL https://rvm.io/pkuczynski.asc | gpg2 --import -

In case of further problems with validation please refer to https://rvm.io/rvm/security
```

As per the recommendation in the error, this PR adds an `import` of @pkuczynski's key in addition to the one from @mpapis, assuming that it's still possible for a release to be signed by either's key.