### PR TITLE
FIX: update theme fields when updating from ThemesInstallTask

### DIFF
--- a/app/services/themes_install_task.rb
+++ b/app/services/themes_install_task.rb
@@ -61,6 +61,7 @@ class ThemesInstallTask
 
   def update
     @remote_theme.update_from_remote
+    @theme.save
     add_component_to_all_themes
   end
 

--- a/spec/services/themes_spec.rb
+++ b/spec/services/themes_spec.rb
@@ -148,6 +148,8 @@ describe ThemesInstallTask do
 
         scss = "body { background-color: black; }"
 
+        expect(theme.theme_fields.find_by(name: 'scss', value: scss)).to be_nil
+
         File.write("#{component_repo}/common/common.scss", scss)
 
         `cd #{component_repo} && git add common/common.scss`

--- a/spec/services/themes_spec.rb
+++ b/spec/services/themes_spec.rb
@@ -3,6 +3,7 @@
 require 'rails_helper'
 
 describe ThemesInstallTask do
+  fab!(:admin) { Fabricate(:admin) }
 
   before do
     Discourse::Application.load_tasks
@@ -139,8 +140,31 @@ describe ThemesInstallTask do
           expect(ChildTheme.find_by(parent_theme_id: parent_theme.id, child_theme_id: theme.id).nil?).to eq(false)
         end
       end
+
+      it 'updates installed theme' do
+        ThemesInstallTask.install({ "some_theme": component_repo })
+        theme = Theme.find_by(name: THEME_NAME)
+        remote = theme.remote_theme
+
+        scss = "body { background-color: black; }"
+
+        File.write("#{component_repo}/common/common.scss", scss)
+
+        `cd #{component_repo} && git add common/common.scss`
+        `cd #{component_repo} && git commit -am "update"`
+
+        remote.update_remote_version
+        expect(remote.commits_behind).to eq(1)
+        expect(remote.remote_version).to eq(`cd #{component_repo} && git rev-parse HEAD`.strip)
+
+        ThemesInstallTask.install({ "some_theme": component_repo })
+
+        expect(theme.theme_fields.find_by(name: 'scss', value: scss)).not_to be_nil
+        expect(remote.reload.commits_behind).to eq(0)
+      end
     end
   end
+
   describe '#theme_exists?' do
     it 'can use https or ssh and find the same repo' do
       remote_theme = RemoteTheme.create!(
@@ -149,7 +173,7 @@ describe ThemesInstallTask do
         remote_version: "21122230dbfed804067849393c3332083ddd0c07",
         commits_behind: 2
       )
-      Fabricate(:theme, remote_theme: remote_theme)
+      Fabricate(:theme, remote_theme: remote_theme, user: admin)
 
       # https
       installer = ThemesInstallTask.new({ "url": "https://github.com/org/testtheme" })

--- a/spec/services/themes_spec.rb
+++ b/spec/services/themes_spec.rb
@@ -141,7 +141,7 @@ describe ThemesInstallTask do
         end
       end
 
-      it 'updates installed theme' do
+      it 'updates theme fields' do
         ThemesInstallTask.install({ "some_theme": component_repo })
         theme = Theme.find_by(name: THEME_NAME)
         remote = theme.remote_theme


### PR DESCRIPTION
Theme values were not actually being updated via the theme install rake task, because `update_from_remote` does not save the theme.

In the admin controller, when updating a theme from remote, we see

https://github.com/discourse/discourse/blob/fe284ffd06f759a7109601609d71357599c04c0a/app/controllers/admin/themes_controller.rb#L207

And then `theme` is saved later in the action
https://github.com/discourse/discourse/blob/fe284ffd06f759a7109601609d71357599c04c0a/app/controllers/admin/themes_controller.rb#L211

The update_from_remote method sets fields on the `theme`, but does not save the theme.
https://github.com/discourse/discourse/blob/fe284ffd06f759a7109601609d71357599c04c0a/app/models/remote_theme.rb#L176

In the rake task, I was assuming that the theme was automatically saved by `update_from_remote`, so adding save here is a fix! It is a bit of an interesting paradigm to wait to save `theme` outside the update method, but it makes more sense in the context of how the controller uses the method.