### PR TITLE
FIX: Hide publish_read_state option from non-admin users

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/groups-form-interaction-fields.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/groups-form-interaction-fields.hbs
@@ -62,15 +62,17 @@
   }}
 </div>
 
-<div class="control-group">
-  <label>
-    {{input type="checkbox"
-          checked=model.publish_read_state
-          class="groups-form-publish-read-state"}}
+{{#if currentUser.admin}}
+  <div class="control-group">
+    <label>
+      {{input type="checkbox"
+            checked=model.publish_read_state
+            class="groups-form-publish-read-state"}}
 
-    {{i18n "admin.groups.manage.interaction.publish_read_state"}}
-  </label>
-</div>
+      {{i18n "admin.groups.manage.interaction.publish_read_state"}}
+    </label>
+  </div>
+{{/if}}
 
 {{#if showEmailSettings}}
   <div class="control-group">


### PR DESCRIPTION
On the server-side, this setting can only be toggled by admin users