### PR TITLE
DEV: Add group name as class to group-box

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/groups/index.hbs
+++ b/app/assets/javascripts/discourse/app/templates/groups/index.hbs
@@ -36,7 +36,7 @@
         <div class="container">
           <div class="groups-boxes">
             {{#each groups as |group|}}
-              {{#link-to "group.members" group.name class="group-box"}}
+              {{#link-to "group.members" group.name classNames=(concat "group-box " group.name)}}
                 <div class="group-box-inner">
                   <div class="group-info-wrapper">
                     {{#if group.flair_url}}


### PR DESCRIPTION
This adds the group name as a class to the group box on group index page.

![Screenshot from 2020-06-30 10-21-30](https://user-images.githubusercontent.com/16214023/86144624-88809400-babb-11ea-88ad-60653d28a72b.png)
