### PR TITLE
DEV: Plugins can extend ReviewableScore types.

### DIFF
--- a/app/models/reviewable_score.rb
+++ b/app/models/reviewable_score.rb
@@ -21,6 +21,14 @@ class ReviewableScore < ActiveRecord::Base
     types
   end
 
+  def self.add_new_types(type_names)
+    next_id = types.values.max + 1
+
+    type_names.each_with_index do |name, idx|
+      @types[name] = next_id + idx
+    end
+  end
+
   def self.statuses
     @statuses ||= Enum.new(
       pending: 0,

--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -148,7 +148,7 @@ class Plugin::Instance
   end
 
   # Applies to all sites in a multisite environment. Ignores plugin.enabled?
-  def replace_flags(settings: ::FlagSettings.new)
+  def replace_flags(settings: ::FlagSettings.new, score_type_names: [])
     next_flag_id = ReviewableScore.types.values.max + 1
 
     yield(settings, next_flag_id)
@@ -156,6 +156,7 @@ class Plugin::Instance
     reloadable_patch do |plugin|
       ::PostActionType.replace_flag_settings(settings)
       ::ReviewableScore.reload_types
+      ::ReviewableScore.add_new_types(score_type_names)
     end
   end
 

--- a/spec/components/plugin/instance_spec.rb
+++ b/spec/components/plugin/instance_spec.rb
@@ -553,4 +553,39 @@ describe Plugin::Instance do
       expect(custom_emoji.group).to eq("baz")
     end
   end
+
+  describe '#replace_flags' do
+    let(:original_flags) { PostActionType.flag_settings }
+
+    it 'adds a new flag' do
+      highest_flag_id = ReviewableScore.types.values.max
+      flag_name = :new_flag
+
+      subject.replace_flags(settings: original_flags) do |settings, next_flag_id|
+        settings.add(
+          next_flag_id,
+          flag_name
+        )
+      end
+
+      expect(PostActionType.flag_settings.flag_types.keys).to include(flag_name)
+      expect(PostActionType.flag_settings.flag_types.values.max).to eq(highest_flag_id + 1)
+    end
+
+    it 'adds a new score type after adding a new flag' do
+      highest_flag_id = ReviewableScore.types.values.max
+      new_score_type = :new_score_type
+
+      subject.replace_flags(settings: original_flags, score_type_names: [new_score_type]) do |settings, next_flag_id|
+        settings.add(
+          next_flag_id,
+          :new_flag
+        )
+      end
+
+      expect(PostActionType.flag_settings.flag_types.values.max).to eq(highest_flag_id + 1)
+      expect(ReviewableScore.types.keys).to include(new_score_type)
+      expect(ReviewableScore.types.values.max).to eq(highest_flag_id + 2)
+    end
+  end
 end


### PR DESCRIPTION
Plugins will be able to add score types without also adding them to the post action types. For example, the antivirus plugin wants to add a `malicious_file` score type but don't want it to be available when a user flags a post.