### PR TITLE
FIX: Negative limit values shouldn't cause error 500

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -214,6 +214,10 @@ class TagsController < ::ApplicationController
       exclude_has_synonyms: params[:excludeHasSynonyms]
     }
 
+    if filter_params[:limit] && filter_params[:limit].to_i < 0
+      raise Discourse::InvalidParameters.new(:limit)
+    end
+
     if params[:categoryId]
       filter_params[:category] = Category.find_by_id(params[:categoryId])
     end

--- a/spec/requests/tags_controller_spec.rb
+++ b/spec/requests/tags_controller_spec.rb
@@ -707,6 +707,13 @@ describe TagsController do
           ['common1', 'common2', 'group1tag', 'group1tag2']
         )
       end
+
+      it 'returns error 400 for negative limit' do
+        get "/tags/filter/search.json", params: { q: '', limit: -1 }
+
+        expect(response.status).to eq(400)
+        expect(response.parsed_body['errors'].first).to eq(I18n.t('invalid_params', message: 'limit'))
+      end
     end
   end
 


### PR DESCRIPTION
This PR fixes errors such as:

```
PG::InvalidRowCountInLimitClause (ERROR:  LIMIT must not be negative
)
/var/www/discourse/vendor/bundle/ruby/2.6.0/gems/rack-mini-profiler-2.0.2/lib/patches/db/pg.rb:110:in `exec'
```

when `/tags/filter/search` endpoint is hit with a negative `limit` param.