### PR TITLE
FIX: ensures category order keeps consistent

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/discovery/topics.js
+++ b/app/assets/javascripts/discourse/app/controllers/discovery/topics.js
@@ -21,7 +21,7 @@ const controllerOpts = {
   showTopicPostBadges: not("discoveryTopics.new"),
   redirectedReason: alias("currentUser.redirected_to_top.reason"),
 
-  order: "default",
+  order: null,
   ascending: false,
   expandGloballyPinned: false,
   expandAllPinned: false,
@@ -38,7 +38,7 @@ const controllerOpts = {
       if (sortBy === this.order) {
         this.toggleProperty("ascending");
       } else {
-        this.setProperties({ order: sortBy, ascending: false });
+        this.setProperties({ order: sortBy, ascending: this.ascending });
       }
 
       this.model.refreshSort(sortBy, this.ascending);

--- a/app/assets/javascripts/discourse/app/controllers/discovery/topics.js
+++ b/app/assets/javascripts/discourse/app/controllers/discovery/topics.js
@@ -41,7 +41,7 @@ const controllerOpts = {
         this.setProperties({ order: sortBy, ascending: this.ascending });
       }
 
-      this.model.refreshSort(sortBy, this.ascending);
+      this.model.refreshSort(sortBy, false);
     },
 
     // Show newly inserted topics

--- a/app/assets/javascripts/discourse/app/controllers/discovery/topics.js
+++ b/app/assets/javascripts/discourse/app/controllers/discovery/topics.js
@@ -41,7 +41,7 @@ const controllerOpts = {
         this.setProperties({ order: sortBy, ascending: this.ascending });
       }
 
-      this.model.refreshSort(sortBy, false);
+      this.model.refreshSort(sortBy, this.ascending);
     },
 
     // Show newly inserted topics

--- a/app/assets/javascripts/discourse/app/controllers/discovery/topics.js
+++ b/app/assets/javascripts/discourse/app/controllers/discovery/topics.js
@@ -37,11 +37,11 @@ const controllerOpts = {
     changeSort(sortBy) {
       if (sortBy === this.order) {
         this.toggleProperty("ascending");
+        this.model.refreshSort(sortBy, this.ascending);
       } else {
-        this.setProperties({ order: sortBy, ascending: this.ascending });
+        this.setProperties({ order: sortBy, ascending: false });
+        this.model.refreshSort(sortBy, false);
       }
-
-      this.model.refreshSort(sortBy, this.ascending);
     },
 
     // Show newly inserted topics

--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -684,6 +684,9 @@ class TopicQuery
         if sort_order
           options[:order] = sort_order
           options[:ascending] = !!sort_ascending ? 'true' : 'false'
+        else
+          options[:order] = 'default'
+          options[:ascending] = 'false'
         end
       end
     end


### PR DESCRIPTION
Before this change:
- first full page load would get category defaults defined un cateory settings
- a navigation to a topic and then back to categories list would reset defaut to the ones defined in discovery/topics