### PR TITLE
FEATURE: Add reply_as_new_group_message composer action

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/composer-actions.js
+++ b/app/assets/javascripts/select-kit/addon/components/composer-actions.js
@@ -90,8 +90,29 @@ export default DropdownSelectBoxComponent.extend({
     let items = [];
 
     if (
+      this.action === REPLY &&
+      this.topic.isPrivateMessage &&
+      (this.topic.details.allowed_users.length > 1 ||
+        this.topic.details.allowed_groups.length > 0) &&
+      !this.isEditing &&
+      _topicSnapshot
+    ) {
+      items.push({
+        name: I18n.t(
+          "composer.composer_actions.reply_as_new_group_message.label"
+        ),
+        description: I18n.t(
+          "composer.composer_actions.reply_as_new_group_message.desc"
+        ),
+        icon: "plus",
+        id: "reply_as_new_group_message"
+      });
+    }
+
+    if (
       this.action !== CREATE_TOPIC &&
       this.action !== CREATE_SHARED_DRAFT &&
+      !(this.action === REPLY && this.topic.isPrivateMessage) &&
       !this.isEditing &&
       _topicSnapshot
     ) {
@@ -237,6 +258,21 @@ export default DropdownSelectBoxComponent.extend({
 
   toggleTopicBumpSelected(options, model) {
     model.toggleProperty("noBump");
+  },
+
+  replyAsNewGroupMessageSelected(options) {
+    const recipients = [];
+
+    const details = this.topic.details;
+    details.allowed_users.forEach(u => recipients.push(u.username));
+    details.allowed_groups.forEach(g => recipients.push(g.name));
+
+    options.action = PRIVATE_MESSAGE;
+    options.recipients = recipients.join(",");
+    options.archetypeId = "private_message";
+    options.skipDraftCheck = true;
+
+    this._replyFromExisting(options, _postSnapshot, _topicSnapshot);
   },
 
   replyToTopicSelected(options) {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1858,6 +1858,9 @@ en:
           label: Reply as linked topic
           desc: Create a new topic linked to this topic
           confirm: You have a new topic draft saved, which will be overwritten if you create a linked topic.
+        reply_as_new_group_message:
+          label: Reply as new group message
+          desc: Create a new private message with the same recipients
         reply_as_private_message:
           label: New message
           desc: Create a new personal message

--- a/test/javascripts/acceptance/composer-actions-test.js
+++ b/test/javascripts/acceptance/composer-actions-test.js
@@ -168,6 +168,260 @@ QUnit.test("reply_as_new_topic without a new_topic draft", async assert => {
   assert.equal(exists(find(".bootbox")), false);
 });
 
+QUnit.test("reply_as_new_group_message", async assert => {
+  // eslint-disable-next-line
+  server.get("/t/130.json", () => {
+    return [
+      200,
+      { "Content-Type": "application/json" },
+      {
+        post_stream: {
+          posts: [
+            {
+              id: 133,
+              name: null,
+              username: "bianca",
+              avatar_template:
+                "/letter_avatar_proxy/v4/letter/b/3be4f8/{size}.png",
+              created_at: "2020-07-05T09:28:36.371Z",
+              cooked:
+                "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas a varius ipsum. Nunc euismod, metus non vulputate malesuada, ligula metus pharetra tortor, vel sodales arcu lacus sed mauris. Nam semper, orci vitae fringilla placerat, dui tellus convallis felis, ultricies laoreet sapien mi et metus. Mauris facilisis, mi fermentum rhoncus feugiat, dolor est vehicula leo, id porta leo ex non enim. In a ligula vel tellus commodo scelerisque non in ex. Pellentesque semper leo quam, nec varius est viverra eget. Donec vehicula sem et massa faucibus tempus.</p>",
+              post_number: 1,
+              post_type: 1,
+              updated_at: "2020-07-05T09:28:36.371Z",
+              reply_count: 0,
+              reply_to_post_number: null,
+              quote_count: 0,
+              incoming_link_count: 0,
+              reads: 1,
+              readers_count: 0,
+              score: 0,
+              yours: true,
+              topic_id: 130,
+              topic_slug: "lorem-ipsum-dolor-sit-amet",
+              display_username: null,
+              primary_group_name: null,
+              primary_group_flair_url: null,
+              primary_group_flair_bg_color: null,
+              primary_group_flair_color: null,
+              version: 1,
+              can_edit: true,
+              can_delete: false,
+              can_recover: false,
+              can_wiki: true,
+              read: true,
+              user_title: "Tester",
+              title_is_group: false,
+              actions_summary: [
+                {
+                  id: 3,
+                  can_act: true
+                },
+                {
+                  id: 4,
+                  can_act: true
+                },
+                {
+                  id: 8,
+                  can_act: true
+                },
+                {
+                  id: 7,
+                  can_act: true
+                }
+              ],
+              moderator: false,
+              admin: true,
+              staff: true,
+              user_id: 1,
+              hidden: false,
+              trust_level: 0,
+              deleted_at: null,
+              user_deleted: false,
+              edit_reason: null,
+              can_view_edit_history: true,
+              wiki: false,
+              reviewable_id: 0,
+              reviewable_score_count: 0,
+              reviewable_score_pending_count: 0
+            }
+          ],
+          stream: [133]
+        },
+        timeline_lookup: [[1, 0]],
+        related_messages: [],
+        suggested_topics: [],
+        id: 130,
+        title: "Lorem ipsum dolor sit amet",
+        fancy_title: "Lorem ipsum dolor sit amet",
+        posts_count: 1,
+        created_at: "2020-07-05T09:28:36.260Z",
+        views: 1,
+        reply_count: 0,
+        like_count: 0,
+        last_posted_at: "2020-07-05T09:28:36.371Z",
+        visible: true,
+        closed: false,
+        archived: false,
+        has_summary: false,
+        archetype: "private_message",
+        slug: "lorem-ipsum-dolor-sit-amet",
+        category_id: null,
+        word_count: 86,
+        deleted_at: null,
+        user_id: 1,
+        featured_link: null,
+        pinned_globally: false,
+        pinned_at: null,
+        pinned_until: null,
+        image_url: null,
+        draft: null,
+        draft_key: "topic_130",
+        draft_sequence: 0,
+        posted: true,
+        unpinned: null,
+        pinned: false,
+        current_post_number: 1,
+        highest_post_number: 1,
+        last_read_post_number: 1,
+        last_read_post_id: 133,
+        deleted_by: null,
+        has_deleted: false,
+        actions_summary: [
+          {
+            id: 4,
+            count: 0,
+            hidden: false,
+            can_act: true
+          },
+          {
+            id: 8,
+            count: 0,
+            hidden: false,
+            can_act: true
+          },
+          {
+            id: 7,
+            count: 0,
+            hidden: false,
+            can_act: true
+          }
+        ],
+        chunk_size: 20,
+        bookmarked: false,
+        message_archived: false,
+        topic_timer: null,
+        private_topic_timer: null,
+        message_bus_last_id: 5,
+        participant_count: 1,
+        pm_with_non_human_user: false,
+        show_read_indicator: false,
+        requested_group_name: null,
+        thumbnails: null,
+        tags_disable_ads: false,
+        details: {
+          notification_level: 3,
+          notifications_reason_id: 1,
+          can_move_posts: true,
+          can_edit: true,
+          can_delete: true,
+          can_remove_allowed_users: true,
+          can_invite_to: true,
+          can_invite_via_email: true,
+          can_create_post: true,
+          can_reply_as_new_topic: true,
+          can_flag_topic: true,
+          can_convert_topic: true,
+          can_review_topic: true,
+          can_remove_self_id: 1,
+          participants: [
+            {
+              id: 1,
+              username: "bianca",
+              name: null,
+              avatar_template:
+                "/letter_avatar_proxy/v4/letter/b/3be4f8/{size}.png",
+              post_count: 1,
+              primary_group_name: null,
+              primary_group_flair_url: null,
+              primary_group_flair_color: null,
+              primary_group_flair_bg_color: null
+            }
+          ],
+          allowed_users: [
+            {
+              id: 7,
+              username: "foo",
+              name: null,
+              avatar_template:
+                "/letter_avatar_proxy/v4/letter/f/b19c9b/{size}.png"
+            }
+          ],
+          created_by: {
+            id: 1,
+            username: "bianca",
+            name: null,
+            avatar_template:
+              "/letter_avatar_proxy/v4/letter/b/3be4f8/{size}.png"
+          },
+          last_poster: {
+            id: 1,
+            username: "bianca",
+            name: null,
+            avatar_template:
+              "/letter_avatar_proxy/v4/letter/b/3be4f8/{size}.png"
+          },
+          allowed_groups: [
+            {
+              id: 43,
+              automatic: false,
+              name: "foo_group",
+              user_count: 4,
+              mentionable_level: 0,
+              messageable_level: 99,
+              visibility_level: 0,
+              automatic_membership_email_domains: "",
+              primary_group: false,
+              title: null,
+              grant_trust_level: null,
+              incoming_email: null,
+              has_messages: true,
+              flair_url: null,
+              flair_bg_color: "",
+              flair_color: "",
+              bio_raw: null,
+              bio_cooked: null,
+              bio_excerpt: null,
+              public_admission: false,
+              public_exit: false,
+              allow_membership_requests: false,
+              full_name: null,
+              default_notification_level: 3,
+              membership_request_template: null,
+              members_visibility_level: 0,
+              can_see_members: true,
+              publish_read_state: false
+            }
+          ]
+        }
+      }
+    ];
+  });
+
+  await visit("/t/lorem-ipsum-dolor-sit-amet/130");
+  await click(".create.reply");
+  const composerActions = selectKit(".composer-actions");
+  await composerActions.expand();
+  await composerActions.selectRowByValue("reply_as_new_group_message");
+
+  const items = [];
+  find(".users-input .item").each((_, item) =>
+    items.push(item.textContent.trim())
+  );
+
+  assert.deepEqual(items, ["foo", "foo_group"]);
+});
+
 QUnit.test("hide component if no content", async assert => {
   await visit("/");
   await click("button#create-topic");


### PR DESCRIPTION
This commit changes two things: 
1. hides the `reply as linked topic` option from private messages as it did not make a lot of sense; 
2. adds a new `reply as new message` composer action which will start the composer to create a new topic with the target recipients filled with the current participants.