### PR TITLE
PERF: Remove post_upload recovery in daily EnsureS3UploadsExistence job

### DIFF
--- a/spec/components/s3_inventory_spec.rb
+++ b/spec/components/s3_inventory_spec.rb
@@ -76,7 +76,7 @@ describe "S3Inventory" do
       inventory.backfill_etags_and_list_missing
     end
 
-    expect(output).to eq("Listing missing post uploads...\n0 post uploads are missing.\n#{upload.url}\n1 of 5 uploads are missing\n")
+    expect(output).to eq("#{upload.url}\n1 of 5 uploads are missing\n")
     expect(Discourse.stats.get("missing_s3_uploads")).to eq(1)
   end
 


### PR DESCRIPTION
This is a very expensive process, and it should only be required in exceptional circumstances. It is possible to run a similar recovery using `rake uploads:recover` (https://github.com/discourse/discourse/blob/5284d41a8e8cfca1ab5ca21574429f082fb187dd/lib/upload_recovery.rb#L135-L184)