### PR TITLE
DEV: Plugin API function to add items to quick access profile

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/plugin-api.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.js
@@ -56,6 +56,7 @@ import { addExtraIconRenderer } from "discourse/helpers/category-link";
 import { queryRegistry } from "discourse/widgets/widget";
 import Composer from "discourse/models/composer";
 import { on } from "@ember/object/evented";
+import { addQuickAccessProfileItem } from "discourse/widgets/quick-access-profile";
 import KeyboardShortcuts from "discourse/lib/keyboard-shortcuts";
 
 // If you add any methods to the API ensure you bump up this number
@@ -1156,6 +1157,22 @@ class PluginApi {
    **/
   addToHeaderIcons(icon) {
     addToHeaderIcons(icon);
+  }
+
+  /**
+   * Adds an item to the quick access profile panel, before "Log Out".
+   *
+   * ```
+   * api.addQuickAccessProfileItem({
+   *   icon: "pencil-alt",
+   *   href: "/somewhere",
+   *   content: I18n.t("user.somewhere")
+   * })
+   * ```
+   *
+   **/
+  addQuickAccessProfileItem(item) {
+    addQuickAccessProfileItem(item);
   }
 }
 

--- a/app/assets/javascripts/discourse/app/widgets/quick-access-profile.js
+++ b/app/assets/javascripts/discourse/app/widgets/quick-access-profile.js
@@ -3,6 +3,12 @@ import QuickAccessPanel from "discourse/widgets/quick-access-panel";
 import { createWidgetFrom } from "discourse/widgets/widget";
 import { Promise } from "rsvp";
 
+const _extraItems = [];
+
+export function addQuickAccessProfileItem(item) {
+  _extraItems.push(item);
+}
+
 createWidgetFrom(QuickAccessPanel, "quick-access-profile", {
   tagName: "div.quick-access-panel.quick-access-profile",
 
@@ -22,10 +28,12 @@ createWidgetFrom(QuickAccessPanel, "quick-access-profile", {
   },
 
   _getItems() {
-    const items = this._getDefaultItems();
+    let items = this._getDefaultItems();
     if (this._showToggleAnonymousButton()) {
       items.push(this._toggleAnonymousButton());
     }
+    items = items.concat(_extraItems);
+
     if (this.attrs.showLogoutButton) {
       items.push(this._logOutButton());
     }


### PR DESCRIPTION
This new function allows pushing content to the quick access profile panel. Here, I used the function to add a link to invites

![2020-07-07_13-37](https://user-images.githubusercontent.com/16214023/86826967-08c46d80-c057-11ea-99f8-14fc295072bc.png)

in an initializer like so 
```
import { withPluginApi } from "discourse/lib/plugin-api";

export default {
  name: "add-invites-to-quick-access-panel",

  initialize() {
    withPluginApi("0.8.28", api => {
      api.addQuickAccessProfileItem({
        icon: "user-plus",
        href: "/my/invited/pending",
        content: "Invites"
      })
    });
  }
}
```