### PR TITLE
FIX: Stop updating bookmarked column from TopicUser.update_post_action_cache

### DIFF
--- a/app/models/post_action.rb
+++ b/app/models/post_action.rb
@@ -224,7 +224,7 @@ class PostAction < ActiveRecord::Base
     topic_id = Post.with_deleted.where(id: post_id).pluck_first(:topic_id)
 
     # topic_user
-    if [:like, :bookmark].include? post_action_type_key
+    if post_action_type_key == :like
       TopicUser.update_post_action_cache(user_id: user_id,
                                          topic_id: topic_id,
                                          post_action_type: post_action_type_key)

--- a/app/models/topic_user.rb
+++ b/app/models/topic_user.rb
@@ -22,6 +22,10 @@ class TopicUser < ActiveRecord::Base
     level(topic_id, :watching)
   }
 
+  def topic_bookmarks
+    Bookmark.where(topic: topic, user: user)
+  end
+
   # Class methods
   class << self
 
@@ -369,13 +373,11 @@ class TopicUser < ActiveRecord::Base
     action_type = opts[:post_action_type]
 
     action_type_name = "liked" if action_type == :like
-    action_type_name = "bookmarked" if action_type == :bookmark
 
     raise ArgumentError, "action_type" if action_type && !action_type_name
 
     unless action_type_name
       update_post_action_cache(opts.merge(post_action_type: :like))
-      update_post_action_cache(opts.merge(post_action_type: :bookmark))
       return
     end
 

--- a/db/migrate/20200708035330_fix_topic_user_bookmarked_sync_issues.rb
+++ b/db/migrate/20200708035330_fix_topic_user_bookmarked_sync_issues.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class FixTopicUserBookmarkedSyncIssues < ActiveRecord::Migration[6.0]
+  def up
+    sql = <<~SQL
+      UPDATE topic_users SET bookmarked = true WHERE id IN (
+        SELECT topic_users.id
+        FROM topic_users
+        INNER JOIN bookmarks ON bookmarks.user_id = topic_users.user_id AND
+          bookmarks.topic_id = topic_users.topic_id
+        WHERE NOT topic_users.bookmarked
+      ) AND NOT bookmarked
+    SQL
+    DB.exec(sql)
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
* This is causing issues where sometimes bookmarked is out of sync with what is in the Bookmark table. The BookmarkManager handles updating this column now.
* Add migration to fix bookmarked column that is incorrectly marked false when a Bookmark record exists.