### PR TITLE
Remove `Discourse.SiteSettings` from tests

### DIFF
--- a/plugins/poll/test/javascripts/controllers/poll-ui-builder-test.js.es6
+++ b/plugins/poll/test/javascripts/controllers/poll-ui-builder-test.js.es6
@@ -1,9 +1,8 @@
-import { mapRoutes } from "discourse/mapping-router";
+import { controllerModule } from "helpers/qunit-helpers";
 
-moduleFor("controller:poll-ui-builder", "controller:poll-ui-builder", {
-  setup() {
-    this.registry.register("router:main", mapRoutes());
-    this.subject().set("toolbarEvent", {
+controllerModule("controller:poll-ui-builder", {
+  setupController(controller) {
+    controller.set("toolbarEvent", {
       getText: () => ""
     });
   },
@@ -31,7 +30,6 @@ test("isMultiple", function(assert) {
 
 test("isNumber", function(assert) {
   const controller = this.subject();
-  controller.siteSettings = Discourse.SiteSettings;
 
   controller.set("pollType", controller.regularPollType);
 
@@ -44,7 +42,6 @@ test("isNumber", function(assert) {
 
 test("showMinMax", function(assert) {
   const controller = this.subject();
-  controller.siteSettings = Discourse.SiteSettings;
 
   controller.set("pollType", controller.numberPollType);
   assert.equal(controller.showMinMax, true, "it should be true");
@@ -58,7 +55,6 @@ test("showMinMax", function(assert) {
 
 test("pollOptionsCount", function(assert) {
   const controller = this.subject();
-  controller.siteSettings = Discourse.SiteSettings;
 
   controller.set("pollOptions", "1\n2\n");
 
@@ -71,7 +67,6 @@ test("pollOptionsCount", function(assert) {
 
 test("pollMinOptions", function(assert) {
   const controller = this.subject();
-  controller.siteSettings = Discourse.SiteSettings;
 
   controller.setProperties({
     pollType: controller.multiplePollType,
@@ -110,7 +105,6 @@ test("pollMinOptions", function(assert) {
 
 test("pollMaxOptions", function(assert) {
   const controller = this.subject();
-  controller.siteSettings = Discourse.SiteSettings;
 
   controller.setProperties({
     pollType: controller.multiplePollType,
@@ -154,7 +148,6 @@ test("pollMaxOptions", function(assert) {
 
 test("pollStepOptions", function(assert) {
   const controller = this.subject();
-  controller.siteSettings = Discourse.SiteSettings;
   controller.siteSettings.poll_maximum_options = 3;
 
   assert.equal(controller.pollStepOptions, null, "is should return null");
@@ -174,7 +167,6 @@ test("pollStepOptions", function(assert) {
 
 test("disableInsert", function(assert) {
   const controller = this.subject();
-  controller.siteSettings = Discourse.SiteSettings;
 
   assert.equal(controller.disableInsert, true, "it should be true");
 
@@ -210,7 +202,6 @@ test("disableInsert", function(assert) {
 
 test("number pollOutput", function(assert) {
   const controller = this.subject();
-  controller.siteSettings = Discourse.SiteSettings;
   controller.siteSettings.poll_maximum_options = 20;
 
   controller.setProperties({
@@ -251,7 +242,6 @@ test("number pollOutput", function(assert) {
 
 test("regular pollOutput", function(assert) {
   const controller = this.subject();
-  controller.siteSettings = Discourse.SiteSettings;
   controller.siteSettings.poll_maximum_options = 20;
 
   controller.set("pollOptions", "1\n2");
@@ -285,7 +275,6 @@ test("regular pollOutput", function(assert) {
 
 test("multiple pollOutput", function(assert) {
   const controller = this.subject();
-  controller.siteSettings = Discourse.SiteSettings;
   controller.siteSettings.poll_maximum_options = 20;
 
   controller.setProperties({

--- a/test/javascripts/acceptance/auth-complete-test.js
+++ b/test/javascripts/acceptance/auth-complete-test.js
@@ -27,8 +27,8 @@ QUnit.test("when login not required", async assert => {
   );
 });
 
-QUnit.test("when login required", async assert => {
-  Discourse.SiteSettings.login_required = true;
+QUnit.test("when login required", async function(assert) {
+  this.siteSettings.login_required = true;
   await visit("/");
 
   assert.equal(currentPath(), "login", "it redirects to the login page");

--- a/test/javascripts/acceptance/composer-test.js
+++ b/test/javascripts/acceptance/composer-test.js
@@ -720,8 +720,6 @@ QUnit.test("Loading draft also replaces the recipients", async assert => {
 QUnit.test(
   "Deleting the text content of the first post in a private message",
   async assert => {
-    Discourse.SiteSettings.allow_uncategorized_topics = false;
-
     await visit("/t/34");
 
     await click("#post_1 .d-icon-ellipsis-h");

--- a/test/javascripts/acceptance/create-account-external-test.js
+++ b/test/javascripts/acceptance/create-account-external-test.js
@@ -30,8 +30,8 @@ QUnit.test("when skip is disabled (default)", async assert => {
   assert.ok(exists("#new-account-username"), "it shows the fields");
 });
 
-QUnit.test("when skip is enabled", async assert => {
-  Discourse.SiteSettings.external_auth_skip_create_confirm = true;
+QUnit.test("when skip is enabled", async function(assert) {
+  this.siteSettings.external_auth_skip_create_confirm = true;
   await visit("/");
 
   assert.ok(

--- a/test/javascripts/acceptance/email-notice-test.js
+++ b/test/javascripts/acceptance/email-notice-test.js
@@ -4,22 +4,26 @@ acceptance("Email Disabled Banner", {
   loggedIn: true
 });
 
-QUnit.test("shows banner when required", async assert => {
-  Discourse.set("SiteSettings.disable_emails", "no");
+QUnit.test("when disabled", async function(assert) {
+  this.siteSettings.disable_emails = "no";
   await visit("/");
   assert.notOk(
     exists(".alert-emails-disabled"),
     "alert is not displayed when email enabled"
   );
+});
 
-  Discourse.set("SiteSettings.disable_emails", "yes");
+QUnit.test("when enabled", async function(assert) {
+  this.siteSettings.disable_emails = "yes";
   await visit("/latest");
   assert.ok(
     exists(".alert-emails-disabled"),
     "alert is displayed when email disabled"
   );
+});
 
-  Discourse.set("SiteSettings.disable_emails", "non-staff");
+QUnit.test("when non-staff", async function(assert) {
+  this.siteSettings.disable_emails = "non-staff";
   await visit("/");
   assert.ok(
     exists(".alert-emails-disabled"),

--- a/test/javascripts/acceptance/enforce-second-factor-test.js
+++ b/test/javascripts/acceptance/enforce-second-factor-test.js
@@ -12,9 +12,9 @@ acceptance("Enforce Second Factor", {
   }
 });
 
-QUnit.test("as an admin", async assert => {
+QUnit.test("as an admin", async function(assert) {
   await visit("/u/eviltrout/preferences/second-factor");
-  Discourse.SiteSettings.enforce_second_factor = "staff";
+  this.siteSettings.enforce_second_factor = "staff";
 
   await visit("/u/eviltrout/summary");
 
@@ -34,11 +34,11 @@ QUnit.test("as an admin", async assert => {
   );
 });
 
-QUnit.test("as a user", async assert => {
+QUnit.test("as a user", async function(assert) {
   updateCurrentUser({ moderator: false, admin: false });
 
   await visit("/u/eviltrout/preferences/second-factor");
-  Discourse.SiteSettings.enforce_second_factor = "all";
+  this.siteSettings.enforce_second_factor = "all";
 
   await visit("/u/eviltrout/summary");
 
@@ -58,12 +58,12 @@ QUnit.test("as a user", async assert => {
   );
 });
 
-QUnit.test("as an anonymous user", async assert => {
+QUnit.test("as an anonymous user", async function(assert) {
   updateCurrentUser({ moderator: false, admin: false, is_anonymous: true });
 
   await visit("/u/eviltrout/preferences/second-factor");
-  Discourse.SiteSettings.enforce_second_factor = "all";
-  Discourse.SiteSettings.allow_anonymous_posting = true;
+  this.siteSettings.enforce_second_factor = "all";
+  this.siteSettings.allow_anonymous_posting = true;
 
   await visit("/u/eviltrout/summary");
 

--- a/test/javascripts/acceptance/group-test.js
+++ b/test/javascripts/acceptance/group-test.js
@@ -22,7 +22,7 @@ const response = object => {
   return [200, { "Content-Type": "application/json" }, object];
 };
 
-QUnit.test("Anonymous Viewing Group", async assert => {
+QUnit.test("Anonymous Viewing Group", async function(assert) {
   await visit("/g/discourse");
 
   assert.equal(
@@ -63,7 +63,7 @@ QUnit.test("Anonymous Viewing Group", async assert => {
     I18n.t("groups.index.all").toLowerCase()
   );
 
-  Discourse.SiteSettings.enable_group_directory = false;
+  this.siteSettings.enable_group_directory = false;
 
   await visit("/g");
   await visit("/g/discourse");

--- a/test/javascripts/acceptance/login-redirect-test.js
+++ b/test/javascripts/acceptance/login-redirect-test.js
@@ -2,14 +2,14 @@ import { acceptance } from "helpers/qunit-helpers";
 
 acceptance("Login redirect", {});
 
-QUnit.test("redirects login to default homepage", async assert => {
+QUnit.test("redirects login to default homepage", async function(assert) {
   await visit("/login");
   assert.equal(
     currentPath(),
     "discovery.latest",
     "it works when latest is the homepage"
   );
-  Discourse.SiteSettings.top_menu = "categories|latest|top|hot";
+  this.siteSettings.top_menu = "categories|latest|top|hot";
 
   await visit("/login");
   assert.equal(

--- a/test/javascripts/acceptance/topic-test.js
+++ b/test/javascripts/acceptance/topic-test.js
@@ -190,8 +190,8 @@ QUnit.test("Updating the topic title with unicode emojis", async assert => {
 
 QUnit.test(
   "Updating the topic title with unicode emojis without whitespaces",
-  async assert => {
-    Discourse.SiteSettings.enable_inline_emoji_translation = true;
+  async function(assert) {
+    this.siteSettings.enable_inline_emoji_translation = true;
     await visit("/t/internationalization-localization/280");
     await click("#topic-title .d-icon-pencil-alt");
 

--- a/test/javascripts/controllers/create-account-test.js
+++ b/test/javascripts/controllers/create-account-test.js
@@ -1,10 +1,7 @@
 import I18n from "I18n";
-import { mapRoutes } from "discourse/mapping-router";
+import { controllerModule } from "helpers/qunit-helpers";
 
-moduleFor("controller:create-account", "controller:create-account", {
-  beforeEach() {
-    this.registry.register("router:main", mapRoutes());
-  },
+controllerModule("controller:create-account", {
   needs: ["controller:modal", "controller:login"]
 });
 
@@ -12,7 +9,7 @@ test("basicUsernameValidation", async function(assert) {
   const subject = this.subject;
 
   const testInvalidUsername = async (username, expectedReason) => {
-    const controller = await subject({ siteSettings: Discourse.SiteSettings });
+    const controller = await subject();
     controller.set("accountUsername", username);
 
     assert.equal(
@@ -34,7 +31,7 @@ test("basicUsernameValidation", async function(assert) {
     I18n.t("user.username.too_long")
   );
 
-  const controller = await subject({ siteSettings: Discourse.SiteSettings });
+  const controller = await subject();
   controller.setProperties({
     accountUsername: "porkchops",
     prefilledUsername: "porkchops"
@@ -53,9 +50,7 @@ test("basicUsernameValidation", async function(assert) {
 });
 
 test("passwordValidation", async function(assert) {
-  const controller = await this.subject({
-    siteSettings: Discourse.SiteSettings
-  });
+  const controller = await this.subject();
 
   controller.set("passwordRequired", true);
   controller.set("accountEmail", "pork@chops.com");
@@ -92,7 +87,7 @@ test("passwordValidation", async function(assert) {
 });
 
 test("authProviderDisplayName", async function(assert) {
-  const controller = this.subject({ siteSettings: Discourse.SiteSettings });
+  const controller = this.subject();
 
   assert.equal(
     controller.authProviderDisplayName("facebook"),

--- a/test/javascripts/helpers/qunit-helpers.js
+++ b/test/javascripts/helpers/qunit-helpers.js
@@ -101,6 +101,15 @@ export function applyPretender(name, server, helper) {
   if (cb) cb(server, helper);
 }
 
+export function discourseModule(name) {
+  QUnit.module(name, {
+    beforeEach() {
+      // Give us an API to change site settings without `Discourse.SiteSettings` in tests
+      this.siteSettings = Discourse.SiteSettings;
+    }
+  });
+}
+
 export function acceptance(name, options) {
   options = options || {};
 

--- a/test/javascripts/helpers/qunit-helpers.js
+++ b/test/javascripts/helpers/qunit-helpers.js
@@ -101,11 +101,19 @@ export function applyPretender(name, server, helper) {
   if (cb) cb(server, helper);
 }
 
-export function discourseModule(name) {
+export function discourseModule(name, hooks) {
   QUnit.module(name, {
     beforeEach() {
       // Give us an API to change site settings without `Discourse.SiteSettings` in tests
       this.siteSettings = Discourse.SiteSettings;
+      if (hooks && hooks.beforeEach) {
+        hooks.beforeEach.call(this);
+      }
+    },
+    afterEach() {
+      if (hooks && hooks.afterEach) {
+        hooks.afterEach.call(this);
+      }
     }
   });
 }

--- a/test/javascripts/helpers/qunit-helpers.js
+++ b/test/javascripts/helpers/qunit-helpers.js
@@ -167,6 +167,7 @@ export function acceptance(name, options) {
           options.settings
         );
       }
+      this.siteSettings = Discourse.SiteSettings;
 
       if (options.site) {
         resetSite(Discourse.SiteSettings, options.site);

--- a/test/javascripts/helpers/qunit-helpers.js
+++ b/test/javascripts/helpers/qunit-helpers.js
@@ -24,6 +24,7 @@ import { resetCache as resetOneboxCache } from "pretty-text/oneboxer";
 import { resetCustomPostMessageCallbacks } from "discourse/controllers/topic";
 import { _clearSnapshots } from "select-kit/components/composer-actions";
 import User from "discourse/models/user";
+import { mapRoutes } from "discourse/mapping-router";
 
 export function currentUser() {
   return User.create(sessionFixtures["/session/current.json"].current_user);
@@ -99,6 +100,20 @@ let _pretenderCallbacks = {};
 export function applyPretender(name, server, helper) {
   const cb = _pretenderCallbacks[name];
   if (cb) cb(server, helper);
+}
+
+export function controllerModule(name, args = {}) {
+  moduleFor(name, name, {
+    setup() {
+      this.registry.register("router:main", mapRoutes());
+      let controller = this.subject();
+      controller.siteSettings = Discourse.SiteSettings;
+      if (args.setupController) {
+        args.setupController(controller);
+      }
+    },
+    needs: args.needs
+  });
 }
 
 export function discourseModule(name, hooks) {

--- a/test/javascripts/lib/category-badge-test.js
+++ b/test/javascripts/lib/category-badge-test.js
@@ -1,6 +1,7 @@
 import createStore from "helpers/create-store";
+import { discourseModule } from "helpers/qunit-helpers";
 
-QUnit.module("lib:category-link");
+discourseModule("lib:category-link");
 
 import { categoryBadgeHTML } from "discourse/helpers/category-link";
 
@@ -82,8 +83,8 @@ QUnit.test("allowUncategorized", assert => {
   );
 });
 
-QUnit.test("category names are wrapped in dir-spans", assert => {
-  Discourse.SiteSettings.support_mixed_text_direction = true;
+QUnit.test("category names are wrapped in dir-spans", function(assert) {
+  this.siteSettings.support_mixed_text_direction = true;
   const store = createStore();
   const rtlCategory = store.createRecord("category", {
     name: "תכנות עם Ruby",
@@ -107,7 +108,7 @@ QUnit.test("category names are wrapped in dir-spans", assert => {
   assert.equal(dirSpan.dir, "ltr");
 });
 
-QUnit.test("recursive", assert => {
+QUnit.test("recursive", function(assert) {
   const store = createStore();
 
   const foo = store.createRecord("category", {
@@ -127,20 +128,20 @@ QUnit.test("recursive", assert => {
     parent_category_id: bar.id
   });
 
-  Discourse.set("SiteSettings.max_category_nesting", 0);
+  this.siteSettings.max_category_nesting = 0;
   assert.ok(categoryBadgeHTML(baz, { recursive: true }).indexOf("baz") !== -1);
   assert.ok(categoryBadgeHTML(baz, { recursive: true }).indexOf("bar") === -1);
 
-  Discourse.set("SiteSettings.max_category_nesting", 1);
+  this.siteSettings.max_category_nesting = 1;
   assert.ok(categoryBadgeHTML(baz, { recursive: true }).indexOf("baz") !== -1);
   assert.ok(categoryBadgeHTML(baz, { recursive: true }).indexOf("bar") === -1);
 
-  Discourse.set("SiteSettings.max_category_nesting", 2);
+  this.siteSettings.max_category_nesting = 2;
   assert.ok(categoryBadgeHTML(baz, { recursive: true }).indexOf("baz") !== -1);
   assert.ok(categoryBadgeHTML(baz, { recursive: true }).indexOf("bar") !== -1);
   assert.ok(categoryBadgeHTML(baz, { recursive: true }).indexOf("foo") === -1);
 
-  Discourse.set("SiteSettings.max_category_nesting", 3);
+  this.siteSettings.max_category_nesting = 3;
   assert.ok(categoryBadgeHTML(baz, { recursive: true }).indexOf("baz") !== -1);
   assert.ok(categoryBadgeHTML(baz, { recursive: true }).indexOf("bar") !== -1);
   assert.ok(categoryBadgeHTML(baz, { recursive: true }).indexOf("foo") !== -1);

--- a/test/javascripts/lib/computed-test.js
+++ b/test/javascripts/lib/computed-test.js
@@ -10,8 +10,9 @@ import {
   htmlSafe
 } from "discourse/lib/computed";
 import { setPrefix } from "discourse-common/lib/get-url";
+import { discourseModule } from "helpers/qunit-helpers";
 
-QUnit.module("lib:computed", {
+discourseModule("lib:computed", {
   beforeEach() {
     sandbox.stub(I18n, "t").callsFake(function(scope) {
       return "%@ translated: " + scope;
@@ -23,13 +24,13 @@ QUnit.module("lib:computed", {
   }
 });
 
-QUnit.test("setting", assert => {
+QUnit.test("setting", function(assert) {
   var t = EmberObject.extend({
     vehicle: setting("vehicle"),
     missingProp: setting("madeUpThing")
   }).create();
 
-  Discourse.SiteSettings.vehicle = "airplane";
+  this.siteSettings.vehicle = "airplane";
   assert.equal(
     t.get("vehicle"),
     "airplane",

--- a/test/javascripts/lib/emoji-test.js
+++ b/test/javascripts/lib/emoji-test.js
@@ -1,21 +1,22 @@
 import { emojiSearch } from "pretty-text/emoji";
 import { IMAGE_VERSION as v } from "pretty-text/emoji/version";
 import { emojiUnescape } from "discourse/lib/text";
+import { discourseModule } from "helpers/qunit-helpers";
 
-QUnit.module("lib:emoji");
+discourseModule("lib:emoji");
 
-QUnit.test("emojiUnescape", assert => {
+QUnit.test("emojiUnescape", function(assert) {
   const testUnescape = (input, expected, description, settings = {}) => {
     const originalSettings = {};
     for (const [key, value] of Object.entries(settings)) {
-      originalSettings[key] = Discourse.SiteSettings[key];
-      Discourse.SiteSettings[key] = value;
+      originalSettings[key] = this.siteSettings[key];
+      this.siteSettings[key] = value;
     }
 
     assert.equal(emojiUnescape(input), expected, description);
 
     for (const [key, value] of Object.entries(originalSettings)) {
-      Discourse.SiteSettings[key] = value;
+      this.siteSettings[key] = value;
     }
   };
 

--- a/test/javascripts/lib/uploads-test.js
+++ b/test/javascripts/lib/uploads-test.js
@@ -9,8 +9,9 @@ import {
 } from "discourse/lib/uploads";
 import * as Utilities from "discourse/lib/utilities";
 import User from "discourse/models/user";
+import { discourseModule } from "helpers/qunit-helpers";
 
-QUnit.module("lib:uploads");
+discourseModule("lib:uploads");
 
 const validUpload = validateUploadedFiles;
 
@@ -27,8 +28,8 @@ QUnit.test("uploading one file", assert => {
   assert.ok(bootbox.alert.calledWith(I18n.t("post.errors.too_many_uploads")));
 });
 
-QUnit.test("new user cannot upload images", assert => {
-  Discourse.SiteSettings.newuser_max_images = 0;
+QUnit.test("new user cannot upload images", function(assert) {
+  this.siteSettings.newuser_max_images = 0;
   sandbox.stub(bootbox, "alert");
 
   assert.not(
@@ -43,8 +44,8 @@ QUnit.test("new user cannot upload images", assert => {
   );
 });
 
-QUnit.test("new user cannot upload attachments", assert => {
-  Discourse.SiteSettings.newuser_max_attachments = 0;
+QUnit.test("new user cannot upload attachments", function(assert) {
+  this.siteSettings.newuser_max_attachments = 0;
   sandbox.stub(bootbox, "alert");
 
   assert.not(validUpload([{ name: "roman.txt" }], { user: User.create() }));
@@ -75,9 +76,9 @@ QUnit.test("skipping validation works", assert => {
   assert.ok(validUpload(files, { skipValidation: true }));
 });
 
-QUnit.test("staff can upload anything in PM", assert => {
+QUnit.test("staff can upload anything in PM", function(assert) {
   const files = [{ name: "some.docx" }];
-  Discourse.SiteSettings.authorized_extensions = "jpeg";
+  this.siteSettings.authorized_extensions = "jpeg";
   sandbox.stub(bootbox, "alert");
 
   let user = User.create({ moderator: true });
@@ -137,43 +138,43 @@ QUnit.test("isImage", assert => {
   assert.not(isImage(""));
 });
 
-QUnit.test("allowsImages", assert => {
-  Discourse.SiteSettings.authorized_extensions = "jpg|jpeg|gif";
+QUnit.test("allowsImages", function(assert) {
+  this.siteSettings.authorized_extensions = "jpg|jpeg|gif";
   assert.ok(allowsImages(), "works");
 
-  Discourse.SiteSettings.authorized_extensions = ".jpg|.jpeg|.gif";
+  this.siteSettings.authorized_extensions = ".jpg|.jpeg|.gif";
   assert.ok(allowsImages(), "works with old extensions syntax");
 
-  Discourse.SiteSettings.authorized_extensions = "txt|pdf|*";
+  this.siteSettings.authorized_extensions = "txt|pdf|*";
   assert.ok(
     allowsImages(),
     "images are allowed when all extensions are allowed"
   );
 
-  Discourse.SiteSettings.authorized_extensions = "json|jpg|pdf|txt";
+  this.siteSettings.authorized_extensions = "json|jpg|pdf|txt";
   assert.ok(
     allowsImages(),
     "images are allowed when at least one extension is an image extension"
   );
 });
 
-QUnit.test("allowsAttachments", assert => {
-  Discourse.SiteSettings.authorized_extensions = "jpg|jpeg|gif";
+QUnit.test("allowsAttachments", function(assert) {
+  this.siteSettings.authorized_extensions = "jpg|jpeg|gif";
   assert.not(allowsAttachments(), "no attachments allowed by default");
 
-  Discourse.SiteSettings.authorized_extensions = "jpg|jpeg|gif|*";
+  this.siteSettings.authorized_extensions = "jpg|jpeg|gif|*";
   assert.ok(
     allowsAttachments(),
     "attachments are allowed when all extensions are allowed"
   );
 
-  Discourse.SiteSettings.authorized_extensions = "jpg|jpeg|gif|pdf";
+  this.siteSettings.authorized_extensions = "jpg|jpeg|gif|pdf";
   assert.ok(
     allowsAttachments(),
     "attachments are allowed when at least one extension is not an image extension"
   );
 
-  Discourse.SiteSettings.authorized_extensions = ".jpg|.jpeg|.gif|.pdf";
+  this.siteSettings.authorized_extensions = ".jpg|.jpeg|.gif|.pdf";
   assert.ok(allowsAttachments(), "works with old extensions syntax");
 });
 

--- a/test/javascripts/lib/utilities-test.js
+++ b/test/javascripts/lib/utilities-test.js
@@ -16,15 +16,12 @@ import {
   inCodeBlock
 } from "discourse/lib/utilities";
 import Handlebars from "handlebars";
+import { discourseModule } from "helpers/qunit-helpers";
 
-QUnit.module("lib:utilities");
+discourseModule("lib:utilities");
 
 QUnit.test("escapeExpression", assert => {
-  assert.equal(
-    escapeExpression(">"),
-    "&gt;",
-    "escapes unsafe characters"
-  );
+  assert.equal(escapeExpression(">"), "&gt;", "escapes unsafe characters");
 
   assert.equal(
     escapeExpression(new Handlebars.SafeString("&gt;")),
@@ -135,8 +132,8 @@ QUnit.test("avatarImg", assert => {
   setDevicePixelRatio(oldRatio);
 });
 
-QUnit.test("defaultHomepage", assert => {
-  Discourse.SiteSettings.top_menu = "latest|top|hot";
+QUnit.test("defaultHomepage", function(assert) {
+  this.siteSettings.top_menu = "latest|top|hot";
   assert.equal(
     defaultHomepage(),
     "latest",

--- a/test/javascripts/models/composer-test.js
+++ b/test/javascripts/models/composer-test.js
@@ -1,11 +1,11 @@
 import EmberObject from "@ember/object";
-import { currentUser } from "helpers/qunit-helpers";
+import { discourseModule, currentUser } from "helpers/qunit-helpers";
 import AppEvents from "discourse/services/app-events";
 import Composer from "discourse/models/composer";
 import Post from "discourse/models/post";
 import createStore from "helpers/create-store";
 
-QUnit.module("model:composer");
+discourseModule("model:composer");
 
 function createComposer(opts) {
   opts = opts || {};
@@ -41,8 +41,8 @@ QUnit.test("replyLength", assert => {
   );
 });
 
-QUnit.test("missingReplyCharacters", assert => {
-  Discourse.SiteSettings.min_first_post_length = 40;
+QUnit.test("missingReplyCharacters", function(assert) {
+  this.siteSettings.min_first_post_length = 40;
   const missingReplyCharacters = function(
     val,
     isPM,
@@ -62,21 +62,21 @@ QUnit.test("missingReplyCharacters", assert => {
     "hi",
     false,
     false,
-    Discourse.SiteSettings.min_post_length - 2,
+    this.siteSettings.min_post_length - 2,
     "too short public post"
   );
   missingReplyCharacters(
     "hi",
     false,
     true,
-    Discourse.SiteSettings.min_first_post_length - 2,
+    this.siteSettings.min_first_post_length - 2,
     "too short first post"
   );
   missingReplyCharacters(
     "hi",
     true,
     false,
-    Discourse.SiteSettings.min_personal_message_post_length - 2,
+    this.siteSettings.min_personal_message_post_length - 2,
     "too short private message"
   );
 
@@ -95,7 +95,7 @@ QUnit.test("missingReplyCharacters", assert => {
   );
 });
 
-QUnit.test("missingTitleCharacters", assert => {
+QUnit.test("missingTitleCharacters", function(assert) {
   const missingTitleCharacters = function(val, isPM, expected, message) {
     const composer = createComposer({
       title: val,
@@ -107,13 +107,13 @@ QUnit.test("missingTitleCharacters", assert => {
   missingTitleCharacters(
     "hi",
     false,
-    Discourse.SiteSettings.min_topic_title_length - 2,
+    this.siteSettings.min_topic_title_length - 2,
     "too short post title"
   );
   missingTitleCharacters(
     "z",
     true,
-    Discourse.SiteSettings.min_personal_message_title_length - 1,
+    this.siteSettings.min_personal_message_title_length - 1,
     "too short pm title"
   );
 });
@@ -191,9 +191,9 @@ QUnit.test("prependText", assert => {
   );
 });
 
-QUnit.test("Title length for regular topics", assert => {
-  Discourse.SiteSettings.min_topic_title_length = 5;
-  Discourse.SiteSettings.max_topic_title_length = 10;
+QUnit.test("Title length for regular topics", function(assert) {
+  this.siteSettings.min_topic_title_length = 5;
+  this.siteSettings.max_topic_title_length = 10;
   const composer = createComposer();
 
   composer.set("title", "asdf");
@@ -206,24 +206,9 @@ QUnit.test("Title length for regular topics", assert => {
   assert.ok(composer.get("titleLengthValid"), "in the range is okay");
 });
 
-QUnit.test("Title length for private messages", assert => {
-  Discourse.SiteSettings.min_personal_message_title_length = 5;
-  Discourse.SiteSettings.max_topic_title_length = 10;
-  const composer = createComposer({ action: Composer.PRIVATE_MESSAGE });
-
-  composer.set("title", "asdf");
-  assert.ok(!composer.get("titleLengthValid"), "short titles are not valid");
-
-  composer.set("title", "this is a long title");
-  assert.ok(!composer.get("titleLengthValid"), "long titles are not valid");
-
-  composer.set("title", "just right");
-  assert.ok(composer.get("titleLengthValid"), "in the range is okay");
-});
-
-QUnit.test("Title length for private messages", assert => {
-  Discourse.SiteSettings.min_personal_message_title_length = 5;
-  Discourse.SiteSettings.max_topic_title_length = 10;
+QUnit.test("Title length for private messages", function(assert) {
+  this.siteSettings.min_personal_message_title_length = 5;
+  this.siteSettings.max_topic_title_length = 10;
   const composer = createComposer({ action: Composer.PRIVATE_MESSAGE });
 
   composer.set("title", "asdf");
@@ -278,8 +263,8 @@ QUnit.test("clearState", assert => {
   assert.blank(composer.get("title"));
 });
 
-QUnit.test("initial category when uncategorized is allowed", assert => {
-  Discourse.SiteSettings.allow_uncategorized_topics = true;
+QUnit.test("initial category when uncategorized is allowed", function(assert) {
+  this.siteSettings.allow_uncategorized_topics = true;
   const composer = openComposer({
     action: "createTopic",
     draftKey: "asfd",
@@ -288,8 +273,10 @@ QUnit.test("initial category when uncategorized is allowed", assert => {
   assert.ok(!composer.get("categoryId"), "Uncategorized by default");
 });
 
-QUnit.test("initial category when uncategorized is not allowed", assert => {
-  Discourse.SiteSettings.allow_uncategorized_topics = false;
+QUnit.test("initial category when uncategorized is not allowed", function(
+  assert
+) {
+  this.siteSettings.allow_uncategorized_topics = false;
   const composer = openComposer({
     action: "createTopic",
     draftKey: "asfd",
@@ -325,9 +312,9 @@ QUnit.test("open with a quote", assert => {
   );
 });
 
-QUnit.test("Title length for static page topics as admin", assert => {
-  Discourse.SiteSettings.min_topic_title_length = 5;
-  Discourse.SiteSettings.max_topic_title_length = 10;
+QUnit.test("Title length for static page topics as admin", function(assert) {
+  this.siteSettings.min_topic_title_length = 5;
+  this.siteSettings.max_topic_title_length = 10;
   const composer = createComposer();
 
   const post = Post.create({
@@ -353,7 +340,7 @@ QUnit.test("Title length for static page topics as admin", assert => {
   );
 });
 
-QUnit.test("title placeholder depends on what you're doing", assert => {
+QUnit.test("title placeholder depends on what you're doing", function(assert) {
   let composer = createComposer({ action: Composer.CREATE_TOPIC });
   assert.equal(
     composer.get("titlePlaceholder"),
@@ -368,7 +355,7 @@ QUnit.test("title placeholder depends on what you're doing", assert => {
     "placeholder for private message"
   );
 
-  Discourse.SiteSettings.topic_featured_link_enabled = true;
+  this.siteSettings.topic_featured_link_enabled = true;
 
   composer = createComposer({ action: Composer.CREATE_TOPIC });
   assert.equal(
@@ -385,9 +372,9 @@ QUnit.test("title placeholder depends on what you're doing", assert => {
   );
 });
 
-QUnit.test("allows featured link before choosing a category", assert => {
-  Discourse.SiteSettings.topic_featured_link_enabled = true;
-  Discourse.SiteSettings.allow_uncategorized_topics = false;
+QUnit.test("allows featured link before choosing a category", function(assert) {
+  this.siteSettings.topic_featured_link_enabled = true;
+  this.siteSettings.allow_uncategorized_topics = false;
   let composer = createComposer({ action: Composer.CREATE_TOPIC });
   assert.equal(
     composer.get("titlePlaceholder"),

--- a/test/javascripts/models/topic-test.js
+++ b/test/javascripts/models/topic-test.js
@@ -3,8 +3,9 @@ import { IMAGE_VERSION as v } from "pretty-text/emoji/version";
 import Category from "discourse/models/category";
 import Topic from "discourse/models/topic";
 import User from "discourse/models/user";
+import { discourseModule } from "helpers/qunit-helpers";
 
-QUnit.module("model:topic");
+discourseModule("model:topic");
 
 QUnit.test("defaults", assert => {
   const topic = Topic.create({ id: 1234 });
@@ -133,11 +134,11 @@ QUnit.test("fancyTitle", assert => {
   );
 });
 
-QUnit.test("fancyTitle direction", assert => {
+QUnit.test("fancyTitle direction", function(assert) {
   const rtlTopic = Topic.create({ fancy_title: "هذا اختبار" });
   const ltrTopic = Topic.create({ fancy_title: "This is a test" });
 
-  Discourse.SiteSettings.support_mixed_text_direction = true;
+  this.siteSettings.support_mixed_text_direction = true;
   assert.equal(
     rtlTopic.get("fancyTitle"),
     `<span dir="rtl">هذا اختبار</span>`,


### PR DESCRIPTION
These commits add support for `this.siteSettings` to QUnit tests that need to change settings.

We are still using `Discourse.SiteSettings` behind the scenes but that should be easier to remove in the future if we stick to this API.

