### PR TITLE
UI: Markdown Code Wrapping

### DIFF
--- a/app/assets/stylesheets/common/foundation/base.scss
+++ b/app/assets/stylesheets/common/foundation/base.scss
@@ -109,6 +109,9 @@ pre code {
   overflow: auto;
   -moz-tab-size: 4;
   tab-size: 4;
+  &.lang-markdown {
+    white-space: pre-wrap;
+  }
 }
 
 // TODO figure out a clean place to put stuff like this


### PR DESCRIPTION
Most code doesn't need to be wrapped inside of the "```" tags, but this will wrap markdown code in those tags, making super long markdown text readable in a code block.

You will need to specify "```markdown" for this to work.