### PR TITLE
PERF: Optimize the calculation of participant post counting

### DIFF
--- a/lib/guardian/topic_guardian.rb
+++ b/lib/guardian/topic_guardian.rb
@@ -31,6 +31,10 @@ module TopicGuardian
     is_staff? && SiteSetting.enable_whispers?
   end
 
+  def can_see_whispers?(_topic)
+    is_staff?
+  end
+
   def can_publish_topic?(topic, category)
     is_staff? && can_see?(topic) && can_create_topic?(category)
   end

--- a/spec/components/topic_view_spec.rb
+++ b/spec/components/topic_view_spec.rb
@@ -287,7 +287,7 @@ describe TopicView do
       it 'returns the two posters with their appropriate counts' do
         Fabricate(:post, topic: topic, user: evil_trout, post_type: Post.types[:whisper])
 
-        expect(topic_view.post_counts_by_user.to_a).to match_array([[first_poster.id, 2], [evil_trout.id, 2]])
+        expect(TopicView.new(topic.id, admin).post_counts_by_user.to_a).to match_array([[first_poster.id, 2], [evil_trout.id, 2]])
 
         expect(TopicView.new(topic.id, first_poster).post_counts_by_user.to_a).to match_array([[first_poster.id, 2], [evil_trout.id, 1]])
       end


### PR DESCRIPTION
Summary of V2:

Have the database recalculate the whole thing, instead of shipping the entire topic's post ID list back over the wire.

This will result in some behavior changes, but I think they're generally for the better. There will now only be two versions of the participant post counts available: staff and non-staff. Doesn't depend on whether you asked deleted posts to be visible. Which was kinda silly in the first place - why were we doing a different calculation when deleted posts were visible?  Much easier to have this segment of the topic map just entirely non-responsive to filters.
