### PR TITLE
FIX: Remove social sharing icons from private contexts

### DIFF
--- a/app/assets/javascripts/discourse/app/components/share-panel.js
+++ b/app/assets/javascripts/discourse/app/components/share-panel.js
@@ -16,7 +16,10 @@ export default Component.extend({
 
   @discourseComputed
   sources() {
-    return Sharing.activeSources(this.siteSettings.share_links);
+    const privateContext =
+      this.siteSettings.login_required || this.topic.isPrivateMessage;
+
+    return Sharing.activeSources(this.siteSettings.share_links, privateContext);
   },
 
   @discourseComputed("type", "topic.title")

--- a/app/assets/javascripts/discourse/app/components/share-panel.js
+++ b/app/assets/javascripts/discourse/app/components/share-panel.js
@@ -14,11 +14,9 @@ export default Component.extend({
 
   topic: alias("panel.model.topic"),
 
-  @discourseComputed
-  sources() {
-    const privateContext =
-      this.siteSettings.login_required || this.topic.isPrivateMessage;
-
+  @discourseComputed("topic.isPrivateMessage")
+  sources(isPM) {
+    const privateContext = this.siteSettings.login_required || isPM;
     return Sharing.activeSources(this.siteSettings.share_links, privateContext);
   },
 

--- a/app/assets/javascripts/discourse/app/components/share-popup.js
+++ b/app/assets/javascripts/discourse/app/components/share-popup.js
@@ -17,7 +17,6 @@ export default Component.extend({
   @discourseComputed("topic.isPrivateMessage")
   sources(isPM) {
     const privateContext = this.siteSettings.login_required || isPM;
-
     return Sharing.activeSources(this.siteSettings.share_links, privateContext);
   },
 

--- a/app/assets/javascripts/discourse/app/components/share-popup.js
+++ b/app/assets/javascripts/discourse/app/components/share-popup.js
@@ -14,10 +14,9 @@ export default Component.extend({
   link: null,
   visible: null,
 
-  @discourseComputed("topic")
-  sources() {
-    const privateContext =
-      this.siteSettings.login_required || this.topic.isPrivateMessage;
+  @discourseComputed("topic.isPrivateMessage")
+  sources(isPM) {
+    const privateContext = this.siteSettings.login_required || isPM;
 
     return Sharing.activeSources(this.siteSettings.share_links, privateContext);
   },

--- a/app/assets/javascripts/discourse/app/components/share-popup.js
+++ b/app/assets/javascripts/discourse/app/components/share-popup.js
@@ -14,9 +14,12 @@ export default Component.extend({
   link: null,
   visible: null,
 
-  @discourseComputed
+  @discourseComputed("topic")
   sources() {
-    return Sharing.activeSources(this.siteSettings.share_links);
+    const privateContext =
+      this.siteSettings.login_required || this.topic.isPrivateMessage;
+
+    return Sharing.activeSources(this.siteSettings.share_links, privateContext);
   },
 
   @discourseComputed("type", "postNumber")

--- a/app/assets/javascripts/discourse/app/initializers/sharing-sources.js
+++ b/app/assets/javascripts/discourse/app/initializers/sharing-sources.js
@@ -40,6 +40,7 @@ export default {
       id: "email",
       icon: "envelope-square",
       title: I18n.t("share.email"),
+      showInPrivateContext: true,
       generateUrl: function(link, title) {
         return (
           "mailto:?to=&subject=" +

--- a/app/assets/javascripts/discourse/app/lib/sharing.js
+++ b/app/assets/javascripts/discourse/app/lib/sharing.js
@@ -11,7 +11,7 @@
 
       // The icon that will be displayed, choose between icon name `icon` and custom HTML `htmlIcon`.
       // When both provided, prefer `icon`
-      icon: 'twitter-square'
+      icon: 'twitter-square',
       htmlIcon: '<img src="example.com/example.jpg">',
 
       // A callback for generating the remote link from the `link` and `title`
@@ -22,11 +22,14 @@
       // If provided, handle by custom javascript rather than default url open
       clickHandler: function(link, title){
         alert("Hello!")
-      }
+      },
 
       // If true, opens in a popup of `popupHeight` size. If false it's opened in a new tab
       shouldOpenInPopup: true,
-      popupHeight: 265
+      popupHeight: 265,
+
+      // If true, will show the sharing service in PMs and login_required sites
+      showInPrivateContext: false
     });
   ```
 **/
@@ -77,12 +80,16 @@ export default {
     }
   },
 
-  activeSources(linksSetting = "") {
-    return linksSetting
+  activeSources(linksSetting = "", privateContext = false) {
+    const sources = linksSetting
       .split("|")
       .concat(_customSharingIds)
       .map(s => _sources[s])
       .compact();
+
+    return privateContext
+      ? sources.filter(s => s.showInPrivateContext)
+      : sources;
   },
 
   _reset() {

--- a/test/javascripts/lib/sharing-test.js
+++ b/test/javascripts/lib/sharing-test.js
@@ -39,4 +39,29 @@ QUnit.test("addSharingId", assert => {
     1,
     "it adds sharing id to existing sharing settings"
   );
+
+  const privateContext = true;
+
+  Sharing.addSource({
+    id: "another-source"
+  });
+  Sharing.addSharingId("another-source");
+
+  assert.equal(
+    Sharing.activeSources(sharingSettings, privateContext).length,
+    0,
+    "it does not add a regular source to sources in a private context"
+  );
+
+  Sharing.addSource({
+    id: "a-private-friendly-source",
+    showInPrivateContext: true
+  });
+  Sharing.addSharingId("a-private-friendly-source");
+
+  assert.equal(
+    Sharing.activeSources(sharingSettings, privateContext).length,
+    1,
+    "it does not add a regular source to sources in a private context"
+  );
 });


### PR DESCRIPTION
This removes Twitter/Facebook icons in the share dialogs when: 

- in a login-required site
- in a private message

Themes/plugins can use the new `showInPrivateContext` option to add their source to these private contexts. 