### PR TITLE
FIX: Set the lang/xml:lang html attrs in emails

### DIFF
--- a/app/helpers/email_helper.rb
+++ b/app/helpers/email_helper.rb
@@ -26,7 +26,10 @@ module EmailHelper
   end
 
   def email_html_template
-    EmailStyle.new.html.sub('%{email_content}', capture { yield }).html_safe
+    EmailStyle.new.html
+      .sub('%{email_content}', capture { yield })
+      .gsub('%{html_lang}', html_lang)
+      .html_safe
   end
 
   protected

--- a/spec/mailers/user_notifications_spec.rb
+++ b/spec/mailers/user_notifications_spec.rb
@@ -236,6 +236,14 @@ describe UserNotifications do
         expect(html).to include(topic_url)
         expect(text).to include(topic_url)
       end
+
+      it "applies lang/xml:lang html attributes" do
+        SiteSetting.default_locale = "pl_PL"
+        html = subject.html_part.to_s
+
+        expect(html).to match(' lang="pl-PL"')
+        expect(html).to match(' xml:lang="pl-PL"')
+      end
     end
 
   end


### PR DESCRIPTION
In some rare cases emails were incorrectly sent out with lang placeholders in body (e.g. `xml:lang="%{html_lang}"`)