### PR TITLE
DEV: widget-dropdown CSS tweaks

### DIFF
--- a/app/assets/stylesheets/common/components/widget-dropdown.scss
+++ b/app/assets/stylesheets/common/components/widget-dropdown.scss
@@ -1,5 +1,4 @@
 .widget-dropdown {
-  margin: 1em;
   display: inline-flex;
   box-sizing: border-box;
 

--- a/app/assets/stylesheets/common/components/widget-dropdown.scss
+++ b/app/assets/stylesheets/common/components/widget-dropdown.scss
@@ -13,7 +13,6 @@
     flex-direction: column;
     padding: 0.25em;
     background: $secondary;
-    margin-top: 5px;
     z-index: z("dropdown");
     border: 1px solid $primary-low;
     max-height: 250px;


### PR DESCRIPTION
1. DEV: Remove the margin from widget-dropdown 2b99c96
Generic components should not have a margin. Those should be styled in the place where they are used. This doesn't affect the only current consumer, discourse-calendar, as it redefines its margin

2. DEV: Remove margin from the dropdown body 955555f
It triggered a warning in popper and was effectively a no-op as popper positions dropdowns on its own using `position: fixed` and `top/right/bottom/left` properties.