### PR TITLE
FIX: Align the close modal button with other header elements

### DIFF
--- a/app/assets/stylesheets/common/base/modal.scss
+++ b/app/assets/stylesheets/common/base/modal.scss
@@ -69,7 +69,6 @@
   }
 
   .modal-close {
-    align-self: flex-start;
     order: 2;
     margin-left: auto;
     padding-left: 2em;


### PR DESCRIPTION
Before/after

<img width="333" alt="Screen Shot 2020-07-12 at 14 19 16" src="https://user-images.githubusercontent.com/66961/87246080-1dd04080-c44b-11ea-93a6-e68226d6abc7.png"> <img width="333" alt="Screen Shot 2020-07-12 at 14 19 20" src="https://user-images.githubusercontent.com/66961/87246083-20329a80-c44b-11ea-9e83-ecd0336af031.png">
