### PR TITLE
FIX: last visit bar regression

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-list.js
+++ b/app/assets/javascripts/discourse/app/components/topic-list.js
@@ -85,7 +85,7 @@ export default Component.extend(LoadMore, {
       return;
     }
 
-    if (order !== "default" && order !== "activity") {
+    if (order && order !== "activity") {
       return;
     }
 


### PR DESCRIPTION
Last visit bar is missing because of that change: https://github.com/discourse/discourse/commit/9b7000dbf10

Order property was changed from "default" to null and it was picked by guard condition