### PR TITLE
FIX: Get only the correct collapse title in emails

### DIFF
--- a/plugins/discourse-details/plugin.rb
+++ b/plugins/discourse-details/plugin.rb
@@ -33,7 +33,7 @@ after_initialize do
 
   on(:reduce_cooked) do |fragment, post|
     fragment.css("details").each do |el|
-      text = fragment.css("summary").text
+      text = el.css("summary").text
       link = fragment.document.create_element("a")
       link["href"] = post.url if post
       link.content = I18n.t("details.excerpt_details")

--- a/plugins/discourse-details/spec/components/pretty_text_spec.rb
+++ b/plugins/discourse-details/spec/components/pretty_text_spec.rb
@@ -41,6 +41,29 @@ describe PrettyText do
     expect(md).to eq(html)
   end
 
+  it 'properly handles multiple spoiler blocks in a post' do
+    md = PrettyText.cook(<<~EOF)
+      [details="First"]
+      body secret stuff very long
+      [/details]
+      [details="Second"]
+      body secret stuff very long
+      [/details]
+
+      Hey there.
+
+      [details="Third"]
+      body secret stuff very long
+      [/details]
+    EOF
+
+    md = PrettyText.format_for_email(md, post)
+    expect(md).not_to include('secret stuff')
+    expect(md.scan(/First/).size).to eq(1)
+    expect(md.scan(/Third/).size).to eq(1)
+    expect(md.scan(I18n.t('details.excerpt_details')).size).to eq(3)
+  end
+
   it 'escapes summary text' do
     md = PrettyText.cook(<<~EOF)
       <script>alert('hello')</script>


### PR DESCRIPTION
Previously, this would get _every_ details block title from the entire post, for every details block.