### PR TITLE
added 'addFeaturedLinkMetaDecorator' method to the plugin api

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/plugin-api.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.js
@@ -1176,9 +1176,9 @@ class PluginApi {
     addQuickAccessProfileItem(item);
   }
 
- addFeaturedLinkMetaDecorator(decorator) {
-   addFeaturedLinkMetaDecorator(decorator);
- }
+  addFeaturedLinkMetaDecorator(decorator) {
+    addFeaturedLinkMetaDecorator(decorator);
+  }
 }
 
 let _pluginv01;

--- a/app/assets/javascripts/discourse/app/lib/plugin-api.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.js
@@ -58,7 +58,7 @@ import Composer from "discourse/models/composer";
 import { on } from "@ember/object/evented";
 import { addQuickAccessProfileItem } from "discourse/widgets/quick-access-profile";
 import KeyboardShortcuts from "discourse/lib/keyboard-shortcuts";
-import { addFeaturedLinkMetaDecorator } from 'discourse/lib/render-topic-featured-link';
+import { addFeaturedLinkMetaDecorator } from "discourse/lib/render-topic-featured-link";
 
 // If you add any methods to the API ensure you bump up this number
 const PLUGIN_API_VERSION = "0.10.2";

--- a/app/assets/javascripts/discourse/app/lib/plugin-api.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.js
@@ -58,9 +58,10 @@ import Composer from "discourse/models/composer";
 import { on } from "@ember/object/evented";
 import { addQuickAccessProfileItem } from "discourse/widgets/quick-access-profile";
 import KeyboardShortcuts from "discourse/lib/keyboard-shortcuts";
+import { addFeaturedLinkMetaDecorator } from 'discourse/lib/render-topic-featured-link';
 
 // If you add any methods to the API ensure you bump up this number
-const PLUGIN_API_VERSION = "0.10.1";
+const PLUGIN_API_VERSION = "0.10.2";
 
 class PluginApi {
   constructor(version, container) {
@@ -1174,6 +1175,10 @@ class PluginApi {
   addQuickAccessProfileItem(item) {
     addQuickAccessProfileItem(item);
   }
+
+ addFeaturedLinkMetaDecorator(decorator) {
+   addFeaturedLinkMetaDecorator(decorator);
+ }
 }
 
 let _pluginv01;


### PR DESCRIPTION
- This method was added around 4 years ago. It works well too. I just thought it should be a part of the plugin API.