### PR TITLE
REFACTOR: Move further away from `Discourse.SiteSettings`

### DIFF
--- a/app/assets/javascripts/admin/components/screened-ip-address-form.js
+++ b/app/assets/javascripts/admin/components/screened-ip-address-form.js
@@ -21,12 +21,7 @@ export default Component.extend({
   formSubmitted: false,
   actionName: "block",
 
-  @discourseComputed
-  adminWhitelistEnabled() {
-    return Discourse.SiteSettings.use_admin_ip_whitelist;
-  },
-
-  @discourseComputed("adminWhitelistEnabled")
+  @discourseComputed("siteSettings.use_admin_ip_whitelist")
   actionNames(adminWhitelistEnabled) {
     if (adminWhitelistEnabled) {
       return [

--- a/app/assets/javascripts/admin/models/admin-user.js
+++ b/app/assets/javascripts/admin/models/admin-user.js
@@ -35,7 +35,7 @@ const AdminUser = User.extend({
   bounceScoreExplanation(bounce_score) {
     if (bounce_score === 0) {
       return I18n.t("admin.user.bounce_score_explanation.none");
-    } else if (bounce_score < Discourse.SiteSettings.bounce_score_threshold) {
+    } else if (bounce_score < this.siteSettings.bounce_score_threshold) {
       return I18n.t("admin.user.bounce_score_explanation.some");
     } else {
       return I18n.t("admin.user.bounce_score_explanation.threshold_reached");

--- a/app/assets/javascripts/discourse/app/models/bookmark.js
+++ b/app/assets/javascripts/discourse/app/models/bookmark.js
@@ -171,7 +171,6 @@ const Bookmark = RestModel.extend({
 Bookmark.reopenClass({
   create(args) {
     args = args || {};
-    args.siteSettings = args.siteSettings || Discourse.SiteSettings;
     args.currentUser = args.currentUser || Discourse.currentUser;
     return this._super(args);
   }

--- a/app/assets/javascripts/discourse/app/models/composer.js
+++ b/app/assets/javascripts/discourse/app/models/composer.js
@@ -1211,7 +1211,6 @@ Composer.reopenClass({
     args = args || {};
     args.user = args.user || User.current();
     args.site = args.site || Site.current();
-    args.siteSettings = args.siteSettings || Discourse.SiteSettings;
     return this._super(args);
   },
 

--- a/app/assets/javascripts/discourse/app/models/post.js
+++ b/app/assets/javascripts/discourse/app/models/post.js
@@ -1,6 +1,6 @@
 import I18n from "I18n";
 import discourseComputed from "discourse-common/utils/decorators";
-import EmberObject, { computed, get } from "@ember/object";
+import EmberObject, { get } from "@ember/object";
 import { isEmpty } from "@ember/utils";
 import { equal, and, or, not } from "@ember/object/computed";
 import { ajax } from "discourse/lib/ajax";
@@ -18,18 +18,6 @@ import User from "discourse/models/user";
 import showModal from "discourse/lib/show-modal";
 
 const Post = RestModel.extend({
-  // TODO: Remove this once one instantiate all `Discourse.Post` models via the store.
-  siteSettings: computed({
-    get() {
-      return Discourse.SiteSettings;
-    },
-
-    // prevents model created from json to overridde this property
-    set() {
-      return Discourse.SiteSettings;
-    }
-  }),
-
   @discourseComputed("url")
   shareUrl(url) {
     const user = User.current();

--- a/app/assets/javascripts/discourse/app/models/store.js
+++ b/app/assets/javascripts/discourse/app/models/store.js
@@ -262,7 +262,6 @@ export default EmberObject.extend({
     // TODO: Have injections be automatic
     obj.topicTrackingState = this.register.lookup("topic-tracking-state:main");
     obj.keyValueStore = this.register.lookup("key-value-store:main");
-    obj.siteSettings = this.register.lookup("site-settings:main");
 
     const klass = this.register.lookupFactory("model:" + type) || RestModel;
     const model = klass.create(obj);

--- a/app/assets/javascripts/discourse/app/models/user.js
+++ b/app/assets/javascripts/discourse/app/models/user.js
@@ -50,7 +50,7 @@ const User = RestModel.extend({
 
   @discourseComputed("can_be_deleted", "post_count")
   canBeDeleted(canBeDeleted, postCount) {
-    const maxPostCount = Discourse.SiteSettings.delete_all_posts_max;
+    const maxPostCount = this.siteSettings.delete_all_posts_max;
     return canBeDeleted && postCount <= maxPostCount;
   },
 
@@ -100,7 +100,7 @@ const User = RestModel.extend({
 
   @discourseComputed("username", "name")
   displayName(username, name) {
-    if (Discourse.SiteSettings.enable_names && !isEmpty(name)) {
+    if (this.siteSettings.enable_names && !isEmpty(name)) {
       return name;
     }
     return username;
@@ -108,7 +108,7 @@ const User = RestModel.extend({
 
   @discourseComputed("profile_background_upload_url")
   profileBackgroundUrl(bgUrl) {
-    if (isEmpty(bgUrl) || !Discourse.SiteSettings.allow_profile_backgrounds) {
+    if (isEmpty(bgUrl) || !this.siteSettings.allow_profile_backgrounds) {
       return "".htmlSafe();
     }
     return ("background-image: url(" + getURLWithCDN(bgUrl) + ")").htmlSafe();
@@ -664,7 +664,7 @@ const User = RestModel.extend({
     return (
       this.staff ||
       this.trust_level > 0 ||
-      Discourse.SiteSettings[`newuser_max_${type}s`] > 0
+      this.siteSettings[`newuser_max_${type}s`] > 0
     );
   },
 
@@ -724,7 +724,7 @@ const User = RestModel.extend({
 
   @discourseComputed("can_delete_account")
   canDeleteAccount(canDeleteAccount) {
-    return !Discourse.SiteSettings.enable_sso && canDeleteAccount;
+    return !this.siteSettings.enable_sso && canDeleteAccount;
   },
 
   delete: function() {
@@ -881,7 +881,7 @@ const User = RestModel.extend({
 
   @discourseComputed("second_factor_enabled", "staff")
   enforcedSecondFactor(secondFactorEnabled, staff) {
-    const enforce = Discourse.SiteSettings.enforce_second_factor;
+    const enforce = this.siteSettings.enforce_second_factor;
     return (
       !secondFactorEnabled &&
       (enforce === "all" || (enforce === "staff" && staff))

--- a/app/assets/javascripts/discourse/app/pre-initializers/inject-discourse-objects.js
+++ b/app/assets/javascripts/discourse/app/pre-initializers/inject-discourse-objects.js
@@ -35,6 +35,12 @@ export default {
       app.inject(t, "messageBus", "message-bus:main")
     );
 
+    const siteSettings = app.SiteSettings;
+    app.register("site-settings:main", siteSettings, { instantiate: false });
+    ALL_TARGETS.concat("service").forEach(t =>
+      app.inject(t, "siteSettings", "site-settings:main")
+    );
+
     const currentUser = User.current();
     app.register("current-user:main", currentUser, { instantiate: false });
     app.currentUser = currentUser;
@@ -48,12 +54,6 @@ export default {
     });
     ALL_TARGETS.forEach(t =>
       app.inject(t, "topicTrackingState", "topic-tracking-state:main")
-    );
-
-    const siteSettings = app.SiteSettings;
-    app.register("site-settings:main", siteSettings, { instantiate: false });
-    ALL_TARGETS.concat("service").forEach(t =>
-      app.inject(t, "siteSettings", "site-settings:main")
     );
 
     const site = Site.current();

--- a/test/javascripts/helpers/component-test.js
+++ b/test/javascripts/helpers/component-test.js
@@ -4,6 +4,7 @@ import { autoLoadModules } from "discourse/initializers/auto-load-modules";
 import TopicTrackingState from "discourse/models/topic-tracking-state";
 import User from "discourse/models/user";
 import Site from "discourse/models/site";
+import { currentSettings } from "helpers/site-settings";
 
 export default function(name, opts) {
   opts = opts || {};
@@ -15,7 +16,7 @@ export default function(name, opts) {
   test(name, function(assert) {
     this.site = Site.current();
 
-    this.registry.register("site-settings:main", Discourse.SiteSettings, {
+    this.registry.register("site-settings:main", currentSettings(), {
       instantiate: false
     });
     this.registry.register("capabilities:main", EmberObject);
@@ -25,7 +26,7 @@ export default function(name, opts) {
     this.registry.injection("component", "capabilities", "capabilities:main");
     this.registry.injection("component", "site", "site:main");
 
-    this.siteSettings = Discourse.SiteSettings;
+    this.siteSettings = currentSettings();
 
     autoLoadModules(this.registry, this.registry);
 

--- a/test/javascripts/helpers/create-store.js
+++ b/test/javascripts/helpers/create-store.js
@@ -4,6 +4,7 @@ import KeyValueStore from "discourse/lib/key-value-store";
 import TopicListAdapter from "discourse/adapters/topic-list";
 import TopicTrackingState from "discourse/models/topic-tracking-state";
 import { buildResolver } from "discourse-common/resolver";
+import { currentSettings } from "helpers/site-settings";
 
 const CatAdapter = RestAdapter.extend({
   primaryKey: "cat_id"
@@ -40,7 +41,7 @@ export default function(customLookup = () => {}) {
           return this._tracker;
         }
         if (type === "site-settings:main") {
-          this._settings = this._settings || Discourse.SiteSettings;
+          this._settings = this._settings || currentSettings();
           return this._settings;
         }
         return customLookup(type);

--- a/test/javascripts/helpers/qunit-helpers.js
+++ b/test/javascripts/helpers/qunit-helpers.js
@@ -25,6 +25,7 @@ import { resetCustomPostMessageCallbacks } from "discourse/controllers/topic";
 import { _clearSnapshots } from "select-kit/components/composer-actions";
 import User from "discourse/models/user";
 import { mapRoutes } from "discourse/mapping-router";
+import { currentSettings, mergeSettings } from "helpers/site-settings";
 
 export function currentUser() {
   return User.create(sessionFixtures["/session/current.json"].current_user);
@@ -107,7 +108,7 @@ export function controllerModule(name, args = {}) {
     setup() {
       this.registry.register("router:main", mapRoutes());
       let controller = this.subject();
-      controller.siteSettings = Discourse.SiteSettings;
+      controller.siteSettings = currentSettings();
       if (args.setupController) {
         args.setupController(controller);
       }
@@ -119,8 +120,7 @@ export function controllerModule(name, args = {}) {
 export function discourseModule(name, hooks) {
   QUnit.module(name, {
     beforeEach() {
-      // Give us an API to change site settings without `Discourse.SiteSettings` in tests
-      this.siteSettings = Discourse.SiteSettings;
+      this.siteSettings = currentSettings();
       if (hooks && hooks.beforeEach) {
         hooks.beforeEach.call(this);
       }
@@ -161,16 +161,12 @@ export function acceptance(name, options) {
       }
 
       if (options.settings) {
-        Discourse.SiteSettings = jQuery.extend(
-          true,
-          Discourse.SiteSettings,
-          options.settings
-        );
+        mergeSettings(options.settings);
       }
-      this.siteSettings = Discourse.SiteSettings;
+      this.siteSettings = currentSettings();
 
       if (options.site) {
-        resetSite(Discourse.SiteSettings, options.site);
+        resetSite(currentSettings(), options.site);
       }
 
       clearOutletCache();
@@ -186,7 +182,7 @@ export function acceptance(name, options) {
       flushMap();
       localStorage.clear();
       User.resetCurrent();
-      resetSite(Discourse.SiteSettings);
+      resetSite(currentSettings());
       resetExtraClasses();
       clearOutletCache();
       clearHTMLCache();

--- a/test/javascripts/helpers/site-settings.js
+++ b/test/javascripts/helpers/site-settings.js
@@ -1,6 +1,4 @@
-// discourse-skip-module
-
-Discourse.SiteSettingsOriginal = {
+const ORIGINAL_SETTINGS = {
   title: "QUnit Discourse Tests",
   site_logo_url: "/assets/logo.png",
   site_logo_url: "/assets/logo.png",
@@ -103,8 +101,40 @@ Discourse.SiteSettingsOriginal = {
   secure_media: false
 };
 
-Discourse.SiteSettings = jQuery.extend(
-  true,
-  {},
-  Discourse.SiteSettingsOriginal
-);
+let siteSettings = Object.assign({}, ORIGINAL_SETTINGS);
+Discourse.SiteSettings = siteSettings;
+
+export function currentSettings() {
+  return siteSettings;
+}
+
+// In debug mode, Ember will decorate objects with setters that remind you to use
+// this.set() because they are bound (even if you use `unbound` or `readonly` in templates!).
+// Site settings are only ever changed in tests and these warnings are not wanted, so we'll
+// strip them when resetting our settings between tests.
+function setValue(k, v) {
+  let desc = Object.getOwnPropertyDescriptor(siteSettings, k);
+  if (desc && !desc.writable) {
+    Object.defineProperty(siteSettings, k, { writable: true });
+  }
+  siteSettings[k] = v;
+}
+
+export function mergeSettings(other) {
+  for (let p in other) {
+    if (other.hasOwnProperty(p)) {
+      setValue(p, other[p]);
+    }
+  }
+  return siteSettings;
+}
+
+export function resetSettings() {
+  for (let p in siteSettings) {
+    if (siteSettings.hasOwnProperty(p)) {
+      let v = ORIGINAL_SETTINGS[p];
+      typeof v !== "undefined" ? setValue(p, v) : delete siteSettings[p];
+    }
+  }
+  return siteSettings;
+}

--- a/test/javascripts/test_helper.js
+++ b/test/javascripts/test_helper.js
@@ -42,6 +42,8 @@
 //
 //= require jquery.magnific-popup.min.js
 
+let resetSettings = require("helpers/site-settings").resetSettings;
+
 const buildResolver = require("discourse-common/resolver").buildResolver;
 window.setResolver(buildResolver("discourse").create({ namespace: Discourse }));
 
@@ -104,6 +106,7 @@ function resetSite(siteSettings, extras) {
 }
 
 QUnit.testStart(function(ctx) {
+  resetSettings();
   server = createPretender.default;
   createPretender.applyDefaultHandlers(server);
   server.handlers = [];
@@ -149,8 +152,7 @@ QUnit.testStart(function(ctx) {
     );
   }
 
-  // Allow our tests to change site settings and have them reset before the next test
-  Discourse.SiteSettings = dup(Discourse.SiteSettingsOriginal);
+  resetSettings();
 
   let getURL = require("discourse-common/lib/get-url");
   getURL.setupURL(null, "http://localhost:3000", "");


### PR DESCRIPTION
This PR automatically injects settings in to all `RestModel` instances regardless of whether they are created via store or via calling `create()` directly, so that they can use `this.siteSettings` instead of `Discourse.SiteSettings`.

This exposed some other bugs where our test environment could have multiple instances of `Discourse.SiteSettings`, so this is changed to rely on a single instance which should cause less leakage between tests.