### PR TITLE
FIX: Use non-numeric user URLs in /about crawler view

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -103,6 +103,10 @@ module ApplicationHelper
     HTML
   end
 
+  def user_path(username)
+    "#{Discourse.base_uri}/u/#{username.downcase}"
+  end
+
   def discourse_csrf_tags
     # anon can not have a CSRF token cause these are all pages
     # that may be cached, causing a mismatch between session CSRF

--- a/spec/views/about/index.html.erb_spec.rb
+++ b/spec/views/about/index.html.erb_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "about/index.html.erb" do
+  let(:admin1) { Fabricate(:admin) }
+  let(:admin2) { Fabricate(:admin) }
+  let(:user) { Fabricate(:user) }
+
+  context "crawler view" do
+    before do
+      def controller.use_crawler_layout?
+        true
+      end
+      admin1
+      admin2
+    end
+    it "renders admin user page links" do
+      @about = About.new(user)
+
+      render
+
+      expect(rendered).to match("/u/#{admin1.username_lower}")
+      expect(rendered).to match(admin2.small_avatar_url)
+    end
+  end
+
+end


### PR DESCRIPTION
Add a test for the crawler view.

Followup to cc6d722de1d5f2c56799f02d9f2e4e7333d247da, to actually override the Rails behavior of `user_path`.