### PR TITLE
FEATURE: load hidden posts in segments

### DIFF
--- a/app/assets/javascripts/discourse/app/models/post-stream.js
+++ b/app/assets/javascripts/discourse/app/models/post-stream.js
@@ -317,10 +317,7 @@ export default RestModel.extend({
           });
 
           if (tailGap.length > 0) {
-            this.set(
-              "gaps.before",
-              Object.assign(this.get("gaps.before"), { [postId]: tailGap })
-            );
+            this.get("gaps.before")[postId] = tailGap;
           } else {
             delete this.get("gaps.before")[postId];
           }

--- a/app/assets/javascripts/discourse/app/models/post-stream.js
+++ b/app/assets/javascripts/discourse/app/models/post-stream.js
@@ -304,8 +304,11 @@ export default RestModel.extend({
 
       let postIdx = currentPosts.indexOf(post);
       const origIdx = postIdx;
+
+      let headGap = gap.slice(0, this.topic.chunk_size);
+      let tailGap = gap.slice(this.topic.chunk_size);
       if (postIdx !== -1) {
-        return this.findPostsByIds(gap).then(posts => {
+        return this.findPostsByIds(headGap).then(posts => {
           posts.forEach(p => {
             const stored = this.storePost(p);
             if (!currentPosts.includes(stored)) {
@@ -313,7 +316,14 @@ export default RestModel.extend({
             }
           });
 
-          delete this.get("gaps.before")[postId];
+          if (tailGap.length > 0) {
+            this.set(
+              "gaps.before",
+              Object.assign(this.get("gaps.before"), { [postId]: tailGap })
+            );
+          } else {
+            delete this.get("gaps.before")[postId];
+          }
           this.stream.arrayContentDidChange();
           this.postsWithPlaceholders.arrayContentDidChange(
             origIdx,

--- a/app/assets/javascripts/discourse/app/widgets/post-gap.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-gap.js
@@ -27,6 +27,8 @@ export default createWidget("post-gap", {
     return this.sendWidgetAction(
       attrs.pos === "before" ? "fillGapBefore" : "fillGapAfter",
       args
-    );
+    ).then(() => {
+      state.loading = false;
+    });
   }
 });


### PR DESCRIPTION
Currently, when "View hidden replies" button is clicked, all replies are loaded like there is no tomorrow. When there is plenty of hidden replies, it may cause a timeout.

Therefore, we should load them in pages and display the view link as long as we have more hidden replies.

![AMwYCUo3x3 mp4](https://user-images.githubusercontent.com/72780/87507956-aa7c3800-c6b1-11ea-8caf-c7e088ae667f.gif)
