### PR TITLE
FIX: Removal of i18nPrefix deprecations

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/category-notifications-button.js
+++ b/app/assets/javascripts/select-kit/addon/components/category-notifications-button.js
@@ -7,9 +7,7 @@ export default NotificationOptionsComponent.extend({
   isHidden: or("category.deleted"),
 
   selectKitOptions: {
-    i18nPrefix: "i18nPrefix",
+    i18nPrefix: "category.notifications",
     showFullTitle: false
-  },
-
-  i18nPrefix: "category.notifications"
+  }
 });

--- a/app/assets/javascripts/select-kit/addon/components/group-notifications-button.js
+++ b/app/assets/javascripts/select-kit/addon/components/group-notifications-button.js
@@ -5,8 +5,6 @@ export default NotificationOptionsComponent.extend({
   classNames: ["group-notifications-button"],
 
   selectKitOptions: {
-    i18nPrefix: "i18nPrefix"
-  },
-
-  i18nPrefix: "groups.notifications"
+    i18nPrefix: "groups.notifications"
+  }
 });

--- a/app/assets/javascripts/select-kit/addon/components/tag-notifications-button.js
+++ b/app/assets/javascripts/select-kit/addon/components/tag-notifications-button.js
@@ -6,8 +6,6 @@ export default NotificationsButtonComponent.extend({
 
   selectKitOptions: {
     showFullTitle: false,
-    i18nPrefix: "i18nPrefix"
-  },
-
-  i18nPrefix: "tagging.notifications"
+    i18nPrefix: "tagging.notifications"
+  }
 });

--- a/app/assets/javascripts/select-kit/addon/components/topic-notifications-options.js
+++ b/app/assets/javascripts/select-kit/addon/components/topic-notifications-options.js
@@ -8,7 +8,7 @@ export default NotificationsButtonComponent.extend({
   content: topicLevels,
 
   selectKitOptions: {
-    i18nPrefix: "i18nPrefix",
+    i18nPrefix: "topic.notifications",
     i18nPostfix: "i18nPostfix",
     showCaret: true
   },


### PR DESCRIPTION
It seems that these have been deprecated for 5 months now, so I don't think the backwards compatibility + warnings should be necessary anymore.

