### PR TITLE
FIX: Set user_deleted to false when staff recovers post

### DIFF
--- a/lib/post_destroyer.rb
+++ b/lib/post_destroyer.rb
@@ -104,7 +104,9 @@ class PostDestroyer
   end
 
   def staff_recovered
-    @post.update_column(:user_id, Discourse::SYSTEM_USER_ID) if !@post.user_id
+    new_post_attrs = { user_deleted: false }
+    new_post_attrs[:user_id] = Discourse::SYSTEM_USER_ID if !@post.user_id
+    @post.update_columns(new_post_attrs)
     @post.recover!
 
     mark_topic_changed

--- a/spec/components/post_destroyer_spec.rb
+++ b/spec/components/post_destroyer_spec.rb
@@ -244,6 +244,14 @@ describe PostDestroyer do
       end
 
       context "recovered by admin" do
+        it "should set user_deleted to false" do
+          PostDestroyer.new(@user, @reply).destroy
+          expect(@reply.reload.user_deleted).to eq(true)
+
+          PostDestroyer.new(admin, @reply).recover
+          expect(@reply.reload.user_deleted).to eq(false)
+        end
+
         it "should increment the user's post count" do
           PostDestroyer.new(moderator, @reply).destroy
           expect(@user.reload.user_stat.topic_count).to eq(1)


### PR DESCRIPTION
Background is [here on meta](https://meta.discourse.org/t/topic-keeps-getting-deleted/128013/19?u=markvanlan)

TL;DR: System continues destroying posts that admin have restored, because the column `user_deleted` was still `false`.