### PR TITLE
FIX: Allow user to recover/delete post if they can review the topic

### DIFF
--- a/spec/components/post_destroyer_spec.rb
+++ b/spec/components/post_destroyer_spec.rb
@@ -280,8 +280,8 @@ describe PostDestroyer do
             SiteSetting.enable_category_group_moderation = true
             review_group = Fabricate(:group)
             review_category = Fabricate(:category, reviewable_by_group_id: review_group.id)
-            @reply.topic.update(category: review_category)
-            GroupUser.create(user: review_user, group: review_group)
+            @reply.topic.update!(category: review_category)
+            review_group.users << review_user
           end
 
           context "when the post has a Reviewable record" do
@@ -291,24 +291,26 @@ describe PostDestroyer do
 
             it "changes deleted_at to nil" do
               PostDestroyer.new(Discourse.system_user, @reply).destroy
-              expect(@reply.reload.user_deleted).to eq(false)
-              expect(@reply.reload.deleted_at).not_to eq(nil)
+              @reply.reload
+              expect(@reply.user_deleted).to eq(false)
+              expect(@reply.deleted_at).not_to eq(nil)
 
               PostDestroyer.new(review_user, @reply).recover
-              expect(@reply.reload.user_deleted).to eq(false)
-              expect(@reply.reload.deleted_at).to eq(nil)
+              @reply.reload
+              expect(@reply.deleted_at).to eq(nil)
             end
           end
 
           context "when the post does not have a Reviewable record" do
             it "does not recover the post" do
               PostDestroyer.new(Discourse.system_user, @reply).destroy
-              expect(@reply.reload.user_deleted).to eq(false)
-              expect(@reply.reload.deleted_at).not_to eq(nil)
+              @reply.reload
+              expect(@reply.user_deleted).to eq(false)
+              expect(@reply.deleted_at).not_to eq(nil)
 
               PostDestroyer.new(review_user, @reply).recover
-              expect(@reply.reload.user_deleted).to eq(false)
-              expect(@reply.reload.deleted_at).not_to eq(nil)
+              @reply.reload
+              expect(@reply.deleted_at).not_to eq(nil)
             end
           end
         end
@@ -470,8 +472,8 @@ describe PostDestroyer do
         SiteSetting.enable_category_group_moderation = true
         review_group = Fabricate(:group)
         review_category = Fabricate(:category, reviewable_by_group_id: review_group.id)
-        post.topic.update(category: review_category)
-        GroupUser.create(user: review_user, group: review_group)
+        post.topic.update!(category: review_category)
+        review_group.users << review_user
       end
 
       context "when the post has a reviewable" do


### PR DESCRIPTION
To reproduce the initial issue here:

1. A user makes a post, which discourse-akismet marks as spam (I cheated and called `DiscourseAkismet::PostsBouncer.new.send(:mark_as_spam, post)` for this)
2. The post lands in the review queue
3. The category the topic is in has a `reviewable_by_group_id`
4. A user in that group goes and looks at the Review queue, decides the post is not spam, and clicks Not Spam
5. Weird stuff happens because the `PostDestroyer#recover` method didn't handle this (the user who clicked Not Spam was not the owner of the post and was not a staff member, so the post didn't get un-destroyed and post counts didn't get updated)

Now users who belong to a group who can review a category now have the ability to recover/delete posts fully.