### PR TITLE
FIX: Include resolved locale in anonymous cache key

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1425,7 +1425,7 @@ en:
     delete_old_hidden_posts: "Auto-delete any hidden posts that stay hidden for more than 30 days."
     default_locale: "The default language of this Discourse instance. You can replace the text of system generated categories and topics at <a href='%{base_path}/admin/customize/site_texts' target='_blank'>Customize / Text</a>."
     allow_user_locale: "Allow users to choose their own language interface preference"
-    set_locale_from_accept_language_header: "set interface language for anonymous users from their web browser's language headers. (EXPERIMENTAL, does not work with anonymous cache)"
+    set_locale_from_accept_language_header: "set interface language for anonymous users from their web browser's language headers. (EXPERIMENTAL)"
     support_mixed_text_direction: "Support mixed left-to-right and right-to-left text directions."
     min_post_length: "Minimum allowed post length in characters"
     min_first_post_length: "Minimum allowed first post (topic body) length in characters"

--- a/lib/middleware/anonymous_cache.rb
+++ b/lib/middleware/anonymous_cache.rb
@@ -13,7 +13,8 @@ module Middleware
         c: 'key_is_crawler?',
         b: 'key_has_brotli?',
         t: 'key_cache_theme_ids',
-        ca: 'key_compress_anon'
+        ca: 'key_compress_anon',
+        l: 'key_locale'
       }
     end
 
@@ -87,6 +88,10 @@ module Middleware
             @env[ACCEPT_ENCODING].to_s =~ /br/ ? :true : :false
           end
         @has_brotli == :true
+      end
+
+      def key_locale
+        I18n.locale if SiteSetting.allow_user_locale
       end
 
       def is_crawler?

--- a/spec/components/middleware/anonymous_cache_spec.rb
+++ b/spec/components/middleware/anonymous_cache_spec.rb
@@ -46,6 +46,28 @@ describe Middleware::AnonymousCache::Helper do
     end
   end
 
+  context "with user-selectable locale" do
+    it "handles different languages" do
+      # Normally does not differentiate
+      I18n.locale = :fr
+      with_french_header = new_helper.cache_key
+      I18n.locale = :en
+      with_english_header = new_helper.cache_key
+
+      expect(with_english_header).to eq(with_french_header)
+
+      # If per-user enabled:
+      SiteSetting.allow_user_locale = true
+
+      I18n.locale = :fr
+      with_french_header = new_helper.cache_key
+      I18n.locale = :en
+      with_english_header = new_helper.cache_key
+
+      expect(with_french_header).not_to eq(with_english_header)
+    end
+  end
+
   context 'force_anonymous!' do
     before do
       RateLimiter.enable


### PR DESCRIPTION
This only applies when allow_user_locale is enabled