### PR TITLE
FEATURE: Submit post from mobile composer preview

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -616,6 +616,10 @@ export default Controller.extend({
       this.set("model.isWarning", false);
     }
 
+    if (this.site.mobileView && this.showPreview) {
+      this.set("showPreview", false);
+    }
+
     const composer = this.model;
 
     if (composer.cantSubmitPost) {

--- a/app/assets/stylesheets/mobile/compose.scss
+++ b/app/assets/stylesheets/mobile/compose.scss
@@ -122,6 +122,12 @@
   }
 
   &.show-preview {
+    .submit-panel .save-or-cancel {
+      z-index: z("fullscreen") + 1;
+      .cancel {
+        display: none;
+      }
+    }
     .d-editor-preview-wrapper {
       position: fixed;
       z-index: z("fullscreen");
@@ -130,6 +136,7 @@
       left: 0;
       right: 0;
       background-color: $secondary;
+      border-bottom: 40px solid $secondary;
       max-width: 100%;
       margin: 0;
       padding: 10px;


### PR DESCRIPTION
This will bring the behavior of the [Submit From Preview mobile theme component](https://meta.discourse.org/t/submit-from-preview-mobile/157881) into core.

**Before**
<img width="504" alt="before" src="https://user-images.githubusercontent.com/22733864/88114279-63d28600-cb68-11ea-949a-3ee6cfc26007.png">

**After**
<img width="500" alt="after" src="https://user-images.githubusercontent.com/22733864/88114287-68973a00-cb68-11ea-8b81-d5b95b2239e9.png">


**Behavior Notes**
- A bottom-border has been added to the preview to effectively create a "button footer". I think this makes the buttons much more readable.
- Submitting a post that does not meet title, body, etc requirements will immediately close the preview, exposing the relevant requirement tips that are normally displayed in the composer.
- While the preview is open, the auto-save checkmark may display next to the submit button as it would when the preview is not displayed
- The cancel/trash draft icons are suppressed while the preview is open. I don't think we need to expose _every_ button option in the preview.