### PR TITLE
FIX: Remove the border from YT thumbnail placeholder

### DIFF
--- a/app/assets/stylesheets/common/base/lightbox.scss
+++ b/app/assets/stylesheets/common/base/lightbox.scss
@@ -14,7 +14,7 @@ $meta-element-margin: 6px;
   box-sizing: border-box;
 }
 
-.onebox img.d-lazyload-hidden {
+.onebox img.d-lazyload-hidden:not(.ytp-thumbnail-image) {
   border: 1px solid $primary-low;
 }
 


### PR DESCRIPTION
Before/after (notice the misalignment of the header and the thumbnail placeholder)

<img width="351" alt="Screen Shot 2020-07-22 at 13 58 47" src="https://user-images.githubusercontent.com/66961/88176557-c3439b00-cc27-11ea-8e4e-3858ea571904.png"> <img width="351" alt="Screen Shot 2020-07-22 at 13 59 10" src="https://user-images.githubusercontent.com/66961/88176562-c5a5f500-cc27-11ea-85b5-85d541edd6a4.png">
