### PR TITLE
 REFACTOR: Allow helpers to access site settings

### DIFF
--- a/app/assets/javascripts/discourse-common/addon/lib/helpers.js
+++ b/app/assets/javascripts/discourse-common/addon/lib/helpers.js
@@ -45,6 +45,17 @@ export function registerHelpers(registry) {
   });
 }
 
+let _helperContext;
+export function createHelperContext(siteSettings) {
+  _helperContext = {
+    siteSettings
+  };
+}
+
+export function helperContext() {
+  return _helperContext;
+}
+
 function resolveParams(ctx, options) {
   let params = {};
   const hash = options.hash;

--- a/app/assets/javascripts/discourse/app/helpers/category-link.js
+++ b/app/assets/javascripts/discourse/app/helpers/category-link.js
@@ -1,7 +1,7 @@
 import getURL from "discourse-common/lib/get-url";
 import I18n from "I18n";
 import { get } from "@ember/object";
-import { registerUnbound } from "discourse-common/lib/helpers";
+import { helperContext, registerUnbound } from "discourse-common/lib/helpers";
 import { isRTL } from "discourse/lib/text-direction";
 import { iconHTML } from "discourse-common/lib/icon-library";
 import Category from "discourse/models/category";
@@ -39,18 +39,19 @@ export function addExtraIconRenderer(renderer) {
     @param {Number}  [opts.depth] Current category depth, used for limiting recursive calls
 **/
 export function categoryBadgeHTML(category, opts) {
+  let siteSettings = helperContext().siteSettings;
   opts = opts || {};
 
   if (
     !category ||
     (!opts.allowUncategorized &&
       get(category, "id") === Site.currentProp("uncategorized_category_id") &&
-      Discourse.SiteSettings.suppress_uncategorized_badge)
+      siteSettings.suppress_uncategorized_badge)
   )
     return "";
 
   const depth = (opts.depth || 1) + 1;
-  if (opts.recursive && depth <= Discourse.SiteSettings.max_category_nesting) {
+  if (opts.recursive && depth <= siteSettings.max_category_nesting) {
     const parentCategory = Category.findById(category.parent_category_id);
     opts.depth = depth;
     return categoryBadgeHTML(parentCategory, opts) + _renderer(category, opts);
@@ -118,8 +119,9 @@ function defaultCategoryLinkRenderer(category, opts) {
     parentCat = Category.findById(get(category, "parent_category_id"));
   }
 
-  const categoryStyle =
-    opts.categoryStyle || Discourse.SiteSettings.category_style;
+  let siteSettings = helperContext().siteSettings;
+
+  const categoryStyle = opts.categoryStyle || siteSettings.category_style;
   if (categoryStyle !== "none") {
     if (parentCat && parentCat !== category) {
       html += categoryStripe(
@@ -150,7 +152,7 @@ function defaultCategoryLinkRenderer(category, opts) {
 
   let categoryName = escapeExpression(get(category, "name"));
 
-  if (Discourse.SiteSettings.support_mixed_text_direction) {
+  if (siteSettings.support_mixed_text_direction) {
     categoryDir = isRTL(categoryName) ? 'dir="rtl"' : 'dir="ltr"';
   }
 

--- a/app/assets/javascripts/discourse/app/helpers/cold-age-class.js
+++ b/app/assets/javascripts/discourse/app/helpers/cold-age-class.js
@@ -1,4 +1,4 @@
-import { registerUnbound } from "discourse-common/lib/helpers";
+import { registerUnbound, helperContext } from "discourse-common/lib/helpers";
 
 function daysSinceEpoch(dt) {
   // 1000 * 60 * 60 * 24 = days since epoch
@@ -6,23 +6,24 @@ function daysSinceEpoch(dt) {
 }
 
 registerUnbound("cold-age-class", function(dt, params) {
-  var className = params["class"] || "age";
+  let className = params["class"] || "age";
 
   if (!dt) {
     return className;
   }
 
-  var startDate = params.startDate || new Date();
+  let startDate = params.startDate || new Date();
 
   // Show heat on age
-  var nowDays = daysSinceEpoch(startDate),
+  let nowDays = daysSinceEpoch(startDate),
     epochDays = daysSinceEpoch(new Date(dt));
 
-  if (nowDays - epochDays > Discourse.SiteSettings.cold_age_days_high)
+  let siteSettings = helperContext().siteSettings;
+  if (nowDays - epochDays > siteSettings.cold_age_days_high)
     return className + " coldmap-high";
-  if (nowDays - epochDays > Discourse.SiteSettings.cold_age_days_medium)
+  if (nowDays - epochDays > siteSettings.cold_age_days_medium)
     return className + " coldmap-med";
-  if (nowDays - epochDays > Discourse.SiteSettings.cold_age_days_low)
+  if (nowDays - epochDays > siteSettings.cold_age_days_low)
     return className + " coldmap-low";
 
   return className;

--- a/app/assets/javascripts/discourse/app/helpers/dir-span.js
+++ b/app/assets/javascripts/discourse/app/helpers/dir-span.js
@@ -1,10 +1,11 @@
-import { registerUnbound } from "discourse-common/lib/helpers";
+import { registerUnbound, helperContext } from "discourse-common/lib/helpers";
 import { isRTL } from "discourse/lib/text-direction";
 import { htmlSafe } from "@ember/template";
 
 function setDir(text) {
   let content = text ? text : "";
-  if (content && Discourse.SiteSettings.support_mixed_text_direction) {
+  let siteSettings = helperContext().siteSettings;
+  if (content && siteSettings.support_mixed_text_direction) {
     let textDir = isRTL(content) ? "rtl" : "ltr";
     return `<span dir="${textDir}">${content}</span>`;
   }

--- a/app/assets/javascripts/discourse/app/initializers/auto-load-modules.js
+++ b/app/assets/javascripts/discourse/app/initializers/auto-load-modules.js
@@ -1,4 +1,7 @@
-import { registerHelpers } from "discourse-common/lib/helpers";
+import {
+  registerHelpers,
+  createHelperContext
+} from "discourse-common/lib/helpers";
 import RawHandlebars from "discourse-common/lib/raw-handlebars";
 import { registerRawHelpers } from "discourse-common/lib/raw-handlebars-helpers";
 import Handlebars from "handlebars";
@@ -12,6 +15,8 @@ export function autoLoadModules(container, registry) {
       requirejs(entry, null, null, true);
     }
   });
+  let siteSettings = container.lookup("site-settings:main");
+  createHelperContext(siteSettings);
   registerHelpers(registry);
   registerRawHelpers(RawHandlebars, Handlebars);
 }

--- a/test/javascripts/helpers/component-test.js
+++ b/test/javascripts/helpers/component-test.js
@@ -27,8 +27,7 @@ export default function(name, opts) {
     this.registry.injection("component", "site", "site:main");
 
     this.siteSettings = currentSettings();
-
-    autoLoadModules(this.registry, this.registry);
+    autoLoadModules(this.container, this.registry);
 
     const store = createStore();
     if (!opts.anonymous) {

--- a/test/javascripts/test_helper.js
+++ b/test/javascripts/test_helper.js
@@ -43,6 +43,8 @@
 //= require jquery.magnific-popup.min.js
 
 let resetSettings = require("helpers/site-settings").resetSettings;
+let createHelperContext = require("discourse-common/lib/helpers")
+  .createHelperContext;
 
 const buildResolver = require("discourse-common/resolver").buildResolver;
 window.setResolver(buildResolver("discourse").create({ namespace: Discourse }));
@@ -106,7 +108,7 @@ function resetSite(siteSettings, extras) {
 }
 
 QUnit.testStart(function(ctx) {
-  resetSettings();
+  let settings = resetSettings();
   server = createPretender.default;
   createPretender.applyDefaultHandlers(server);
   server.handlers = [];
@@ -152,8 +154,6 @@ QUnit.testStart(function(ctx) {
     );
   }
 
-  resetSettings();
-
   let getURL = require("discourse-common/lib/get-url");
   getURL.setupURL(null, "http://localhost:3000", "");
   getURL.setupS3CDN(null, null);
@@ -162,7 +162,8 @@ QUnit.testStart(function(ctx) {
   let Session = require("discourse/models/session").default;
   Session.resetCurrent();
   User.resetCurrent();
-  resetSite(Discourse.SiteSettings);
+  resetSite(settings);
+  createHelperContext(settings);
 
   _DiscourseURL.redirectedTo = null;
   _DiscourseURL.redirectTo = function(url) {


### PR DESCRIPTION
Since `Discourse.SiteSettings` is removed, helpers can now include and
call `helperContext().siteSettings` to get access to the settings
without using a global variable.