### PR TITLE
FIX: Move consts and translations for bookmark auto delete prefs

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/bookmark.js
+++ b/app/assets/javascripts/discourse/app/controllers/bookmark.js
@@ -12,6 +12,7 @@ import { popupAjaxError } from "discourse/lib/ajax-error";
 import { ajax } from "discourse/lib/ajax";
 import KeyboardShortcuts from "discourse/lib/keyboard-shortcuts";
 import { formattedReminderTime, REMINDER_TYPES } from "discourse/lib/bookmark";
+import { AUTO_DELETE_PREFERENCES } from "discourse/models/bookmark";
 
 // global shortcuts that interfere with these modal shortcuts, they are rebound when the
 // modal is closed
@@ -27,21 +28,6 @@ const LATER_TODAY_CUTOFF_HOUR = 17;
 const LATER_TODAY_MAX_HOUR = 18;
 const MOMENT_MONDAY = 1;
 const MOMENT_THURSDAY = 4;
-const AUTO_DELETE_PREFERENCES = [
-  {
-    id: 0,
-    name: I18n.t("bookmarks.auto_delete_preference.never")
-  },
-  {
-    id: 1,
-    name: I18n.t("bookmarks.auto_delete_preference.when_reminder_sent")
-  },
-  {
-    id: 2,
-    name: I18n.t("bookmarks.auto_delete_preference.on_owner_reply")
-  }
-];
-
 const BOOKMARK_BINDINGS = {
   enter: { handler: "saveAndClose" },
   "l t": { handler: "selectReminderType", args: [REMINDER_TYPES.LATER_TODAY] },
@@ -238,7 +224,12 @@ export default Controller.extend(ModalFunctionality, {
 
   @discourseComputed()
   autoDeletePreferences: () => {
-    return AUTO_DELETE_PREFERENCES;
+    return Object.keys(AUTO_DELETE_PREFERENCES).map(key => {
+      return {
+        id: AUTO_DELETE_PREFERENCES[key],
+        name: I18n.t(`bookmarks.auto_delete_preference.${key.toLowerCase()}`)
+      };
+    });
   },
 
   showLastCustom: and("lastCustomReminderTime", "lastCustomReminderDate"),

--- a/app/assets/javascripts/discourse/app/controllers/topic.js
+++ b/app/assets/javascripts/discourse/app/controllers/topic.js
@@ -23,6 +23,7 @@ import showModal from "discourse/lib/show-modal";
 import TopicTimer from "discourse/models/topic-timer";
 import { Promise } from "rsvp";
 import { escapeExpression } from "discourse/lib/utilities";
+import { AUTO_DELETE_PREFERENCES } from "discourse/models/bookmark";
 
 let customPostMessageCallbacks = {};
 
@@ -190,7 +191,12 @@ export default Controller.extend(bufferedProperty("model"), {
   _removeDeleteOnOwnerReplyBookmarks() {
     let posts = this.model.get("postStream").posts;
     posts
-      .filter(p => p.bookmarked && p.bookmark_auto_delete_preference === 2) // 2 is on_owner_reply
+      .filter(
+        p =>
+          p.bookmarked &&
+          p.bookmark_auto_delete_preference ===
+            AUTO_DELETE_PREFERENCES.ON_OWNER_REPLY
+      )
       .forEach(p => {
         p.clearBookmark();
       });

--- a/app/assets/javascripts/discourse/app/models/bookmark.js
+++ b/app/assets/javascripts/discourse/app/models/bookmark.js
@@ -15,6 +15,12 @@ import RestModel from "discourse/models/rest";
 import discourseComputed from "discourse-common/utils/decorators";
 import { formattedReminderTime } from "discourse/lib/bookmark";
 
+export const AUTO_DELETE_PREFERENCES = {
+  NEVER: 0,
+  WHEN_REMINDER_SENT: 1,
+  ON_OWNER_REPLY: 2
+};
+
 const Bookmark = RestModel.extend({
   newBookmark: none("id"),
 

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -9,6 +9,27 @@ class Bookmark < ActiveRecord::Base
   belongs_to :post
   belongs_to :topic
 
+  def self.reminder_types
+    @reminder_types ||= Enum.new(
+      later_today: 1,
+      next_business_day: 2,
+      tomorrow: 3,
+      next_week: 4,
+      next_month: 5,
+      custom: 6,
+      start_of_next_business_week: 7,
+      later_this_week: 8
+    )
+  end
+
+  def self.auto_delete_preferences
+    @auto_delete_preferences ||= Enum.new(
+      never: 0,
+      when_reminder_sent: 1,
+      on_owner_reply: 2
+    )
+  end
+
   validates :reminder_at, presence: {
     message: I18n.t("bookmarks.errors.time_must_be_provided"),
     if: -> { reminder_type.present? }
@@ -62,27 +83,6 @@ class Bookmark < ActiveRecord::Base
 
   scope :pending_reminders_for_user, ->(user) do
     pending_reminders.where(user: user)
-  end
-
-  def self.reminder_types
-    @reminder_types ||= Enum.new(
-      later_today: 1,
-      next_business_day: 2,
-      tomorrow: 3,
-      next_week: 4,
-      next_month: 5,
-      custom: 6,
-      start_of_next_business_week: 7,
-      later_this_week: 8
-    )
-  end
-
-  def self.auto_delete_preferences
-    @auto_delete_preferences ||= Enum.new(
-      never: 0,
-      when_reminder_sent: 1,
-      on_owner_reply: 2
-    )
   end
 
   def self.count_per_day(opts = nil)


### PR DESCRIPTION
Based on a review by @eviltrout. Moves the const for `AUTO_DELETE_PREFERENCES` into the Bookmark file, removes an unnecessary comment, and changes translations to occur at render time instead of parsing of bookmark JS file.