### PR TITLE
FIX: tests for reindex_search_spec pass regardless of seed

### DIFF
--- a/spec/jobs/reindex_search_spec.rb
+++ b/spec/jobs/reindex_search_spec.rb
@@ -40,7 +40,7 @@ describe Jobs::ReindexSearch do
       end
 
       def self.posts
-        @posts
+        @posts ||= []
       end
 
       def self.reset


### PR DESCRIPTION
In this spec, `FakeIndexer.index` was never called, because the test does not reindex any posts. Thus `@posts` is nil.

We just set `@posts ||= []` and the tests are fixed. This went unnoticed because the test only fails if other tests have not been run first. 

This is the test that was failing https://github.com/discourse/discourse/blob/2aec92d0b4262a58cce86ed4c25a3346e77198f1/spec/jobs/reindex_search_spec.rb#L76

The index method sets `@posts` to an array here https://github.com/discourse/discourse/blob/2aec92d0b4262a58cce86ed4c25a3346e77198f1/spec/jobs/reindex_search_spec.rb#L37

and the reason index is not called is because post_ids is empty here 
https://github.com/discourse/discourse/blob/2aec92d0b4262a58cce86ed4c25a3346e77198f1/app/jobs/scheduled/reindex_search.rb#L75