### PR TITLE
FIX: Reset 'filter' query parameter when clicking on a nav-item

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-navigation.js
+++ b/app/assets/javascripts/discourse/app/components/d-navigation.js
@@ -79,6 +79,7 @@ export default Component.extend(FilterModeMixin, {
     return NavItem.buildList(category, {
       filterType,
       noSubcategories,
+      currentRouteQueryParams,
       persistedQueryParams: params,
       siteSettings: this.siteSettings
     });

--- a/app/assets/javascripts/discourse/app/components/navigation-item.js
+++ b/app/assets/javascripts/discourse/app/components/navigation-item.js
@@ -59,6 +59,17 @@ export default Component.extend(FilterModeMixin, {
       });
     }
 
+    // To reset the "filter" sticky param, at least one query param is needed.
+    // If no query param is present, add an empty one to ensure a ? is
+    // appended to the URL.
+    if (content.currentRouteQueryParams) {
+      if (content.currentRouteQueryParams.filter) {
+        if (queryParams.length === 0) {
+          queryParams.push("");
+        }
+      }
+    }
+
     if (queryParams.length) {
       href += `?${queryParams.join("&")}`;
     }

--- a/app/assets/javascripts/discourse/app/models/nav-item.js
+++ b/app/assets/javascripts/discourse/app/models/nav-item.js
@@ -172,6 +172,9 @@ NavItem.reopenClass({
     if (opts.tagId) {
       args.tagId = opts.tagId;
     }
+    if (opts.currentRouteQueryParams) {
+      args.currentRouteQueryParams = opts.currentRouteQueryParams;
+    }
     if (opts.persistedQueryParams) {
       args.persistedQueryParams = opts.persistedQueryParams;
     }

--- a/app/assets/javascripts/discourse/app/routes/discovery.js
+++ b/app/assets/javascripts/discourse/app/routes/discovery.js
@@ -8,6 +8,10 @@ import { scrollTop } from "discourse/mixins/scroll-top";
 import User from "discourse/models/user";
 
 export default DiscourseRoute.extend(OpenComposer, {
+  queryParams: {
+    filter: { refreshModel: true }
+  },
+
   redirect() {
     return this.redirectIfLoginRequired();
   },


### PR DESCRIPTION
Usually, this would have been implemented using resetController, but
because we do not use link-to component for linking, that method is not
called.