### PR TITLE
FIX: Do not show Email tab for group settings unless IMAP + SMTP enabled

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/group-manage.js
+++ b/app/assets/javascripts/discourse/app/controllers/group-manage.js
@@ -18,10 +18,12 @@ export default Controller.extend({
     ];
 
     if (!automatic) {
-      defaultTabs.splice(2, 0, {
-        route: "group.manage.email",
-        title: "groups.manage.email.title"
-      });
+      if (this.siteSettings.enable_imap && this.siteSettings.enable_smtp) {
+        defaultTabs.splice(2, 0, {
+          route: "group.manage.email",
+          title: "groups.manage.email.title"
+        });
+      }
 
       defaultTabs.splice(1, 0, {
         route: "group.manage.membership",

--- a/app/assets/javascripts/discourse/app/routes/group-manage-email.js
+++ b/app/assets/javascripts/discourse/app/routes/group-manage-email.js
@@ -4,6 +4,12 @@ import I18n from "I18n";
 export default DiscourseRoute.extend({
   showFooter: true,
 
+  beforeModel() {
+    if (!this.siteSettings.enable_imap && !this.siteSettings.enable_smtp) {
+      return this.transitionTo("group.manage.profile");
+    }
+  },
+
   titleToken() {
     return I18n.t("groups.manage.email.title");
   }

--- a/app/assets/javascripts/discourse/app/templates/components/groups-form-email-fields.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/groups-form-email-fields.hbs
@@ -22,8 +22,10 @@
   </div>
 
   <div class="control-group">
-    {{input type="checkbox" name="smtp_ssl" checked=model.smtp_ssl}}
-    <label class="control-group-inline" for="smtp_ssl">{{i18n "groups.manage.email.credentials.smtp_ssl"}}</label>
+    <label class="control-group-inline" for="smtp_ssl">
+      {{input type="checkbox" name="smtp_ssl" id="smtp_ssl" checked=model.smtp_ssl}}
+      {{i18n "groups.manage.email.credentials.smtp_ssl"}}
+    </label>
   </div>
 
   <div class="control-group">
@@ -37,8 +39,10 @@
   </div>
 
   <div class="control-group">
-    {{input type="checkbox" name="imap_ssl" checked=model.imap_ssl}}
-    <label class="control-group-inline" for="imap_ssl">{{i18n "groups.manage.email.credentials.imap_ssl"}}</label>
+    <label class="control-group-inline" for="imap_ssl">
+      {{input type="checkbox" name="imap_ssl" checked=model.imap_ssl id="imap_ssl"}}
+      {{i18n "groups.manage.email.credentials.imap_ssl"}}
+    </label>
   </div>
 
   <div class="control-group">

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1029,14 +1029,32 @@ email:
       - X-Spam-Flag
       - X-Spam-Status
       - X-SES-Spam-Verdict
-  enable_imap: false
-  enable_imap_write: false
-  enable_imap_idle: false
-  enable_smtp: false
-  imap_polling_period_mins: 5
-  imap_polling_old_emails: 1000
-  imap_polling_new_emails: 250
-  imap_batch_import_email: 100
+  enable_imap:
+    default: false
+    client: true
+    hidden: true
+  enable_imap_write:
+    default: false
+    hidden: true
+  enable_imap_idle:
+    default: false
+    hidden: true
+  enable_smtp:
+    default: false
+    client: true
+    hidden: true
+  imap_polling_period_mins:
+    default: 5
+    hidden: true
+  imap_polling_old_emails:
+    default: 1000
+    hidden: true
+  imap_polling_new_emails:
+    default: 250
+    hidden: true
+  imap_batch_import_email:
+    default: 100
+    hidden: true
   email_prefix: ""
   email_site_title: ""
   disable_emails:


### PR DESCRIPTION
Also hide all the SMTP/IMAP related settings to avoid confusion, as this feature is still not 100% ready to go.