### PR TITLE
FIX: Add enable_email_sync_demon global variable and disable EmailSync demon by default

### DIFF
--- a/config/discourse_defaults.conf
+++ b/config/discourse_defaults.conf
@@ -296,3 +296,12 @@ anon_cache_store_threshold = 2
 # list is a comma seperated list of git repos eg:
 # https://github.com/discourse/discourse-custom-header-links.git,https://github.com/discourse/discourse-simple-theme.git
 whitelisted_theme_repos =
+
+# Demon::EmailSync is used in conjunction with the enable_imap site setting
+# to sync N IMAP mailboxes with specific groups. It is a process started in
+# unicorn.conf, and it spawns N threads (one for each multisite connection) and
+# for each database spans another N threads (one for each configured group).
+#
+# We want this off by default so the process is not started when it does not
+# need to be (e.g. development, test, certain hosting tiers)
+enable_email_sync_demon = false


### PR DESCRIPTION
`Demon::EmailSync` is used in conjunction with the `SiteSetting.enable_imap` to sync N IMAP mailboxes with specific groups. It is a process started in unicorn.conf, and it spawns N threads (one for each multisite connection) and for each database spans another N threads (one for each configured group).

We want this off by default so the process is not started when it does not need to be (e.g. development, test, certain hosting tiers)