### PR TITLE
FIX: Allow 'c' as a tag

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -5,7 +5,6 @@ class Tag < ActiveRecord::Base
   include HasDestroyedWebHook
 
   RESERVED_TAGS = [
-    'c',
     'none'
   ]
 


### PR DESCRIPTION
The new tag routes allow the use of tag 'c'.