### PR TITLE
FIX: Keep category name in URL when filtering

### DIFF
--- a/app/assets/javascripts/admin/controllers/admin-site-settings.js
+++ b/app/assets/javascripts/admin/controllers/admin-site-settings.js
@@ -105,7 +105,7 @@ export default Controller.extend({
     if (this._skipBounce) {
       this.set("_skipBounce", false);
     } else {
-      this.filterContentNow();
+      this.filterContentNow(this.categoryNameKey);
     }
   }, INPUT_DELAY),
 

--- a/test/javascripts/acceptance/admin-site-settings-test.js
+++ b/test/javascripts/acceptance/admin-site-settings-test.js
@@ -10,7 +10,7 @@ acceptance("Admin - Site Settings", {
   },
 
   pretend(server, helper) {
-    server.put("/admin/site_settings/title", (body) => {
+    server.put("/admin/site_settings/title", body => {
       titleOverride = body.requestBody.split("=")[1];
       return helper.response({ success: "OK" });
     });
@@ -22,14 +22,14 @@ acceptance("Admin - Site Settings", {
         titleSetting.value = titleOverride;
       }
       const response = {
-        site_settings: [titleSetting, ...fixtures.slice(1)],
+        site_settings: [titleSetting, ...fixtures.slice(1)]
       };
       return helper.response(response);
     });
-  },
+  }
 });
 
-QUnit.test("upload site setting", async (assert) => {
+QUnit.test("upload site setting", async assert => {
   await visit("/admin/site_settings");
 
   assert.ok(
@@ -40,7 +40,7 @@ QUnit.test("upload site setting", async (assert) => {
   assert.ok(exists(".row.setting.upload .undo"), "undo button is present");
 });
 
-QUnit.test("changing value updates dirty state", async (assert) => {
+QUnit.test("changing value updates dirty state", async assert => {
   await visit("/admin/site_settings");
   await fillIn("#setting-filter", " title ");
   assert.equal(count(".row.setting"), 1, "filter returns 1 site setting");
@@ -89,7 +89,7 @@ QUnit.test("changing value updates dirty state", async (assert) => {
 
 QUnit.test(
   "always shows filtered site settings if a filter is set",
-  async (assert) => {
+  async assert => {
     await visit("/admin/site_settings");
     await fillIn("#setting-filter", "title");
     assert.equal(count(".row.setting"), 1);
@@ -104,7 +104,7 @@ QUnit.test(
   }
 );
 
-QUnit.test("filter settings by plugin name", async (assert) => {
+QUnit.test("filter settings by plugin name", async assert => {
   await visit("/admin/site_settings");
 
   await fillIn("#setting-filter", "plugin:discourse-logo");
@@ -113,4 +113,9 @@ QUnit.test("filter settings by plugin name", async (assert) => {
   // inexistent plugin
   await fillIn("#setting-filter", "plugin:discourse-plugin");
   assert.equal(count(".row.setting"), 0);
+});
+
+QUnit.test("category name is preserved", async assert => {
+  await visit("admin/site_settings/category/login?filter=test");
+  assert.equal(currentURL(), "admin/site_settings/category/login?filter=test");
 });


### PR DESCRIPTION
Navigating to `/admin/site_settings/category/required?filter=description` redirected to `/admin/site_settings/category/all_results?filter=description` even though no redirect was needed.