### PR TITLE
FIX: Improve allowed_path column migration

### DIFF
--- a/db/migrate/20200728000854_duplicate_allowed_paths_from_path_whitelist.rb
+++ b/db/migrate/20200728000854_duplicate_allowed_paths_from_path_whitelist.rb
@@ -16,6 +16,7 @@ class DuplicateAllowedPathsFromPathWhitelist < ActiveRecord::Migration[6.0]
         SQL
       end
     end
+  end
 
   def down
     remove_column :embeddable_hosts, :allowed_paths

--- a/db/migrate/20200728000854_duplicate_allowed_paths_from_path_whitelist.rb
+++ b/db/migrate/20200728000854_duplicate_allowed_paths_from_path_whitelist.rb
@@ -6,6 +6,10 @@ class DuplicateAllowedPathsFromPathWhitelist < ActiveRecord::Migration[6.0]
       add_column :embeddable_hosts, :allowed_paths, :string
     end
 
+    if column_exists?(:embeddable_hosts, :path_whitelist)
+      Migration::ColumnDropper.mark_readonly('embeddable_hosts', 'path_whitelist')
+    end
+
     if column_exists?(:embeddable_hosts, :path_whitelist) && column_exists?(:embeddable_hosts, :allowed_paths)
       DB.exec <<~SQL
         UPDATE embeddable_hosts

--- a/db/migrate/20200728000854_duplicate_allowed_paths_from_path_whitelist.rb
+++ b/db/migrate/20200728000854_duplicate_allowed_paths_from_path_whitelist.rb
@@ -8,15 +8,14 @@ class DuplicateAllowedPathsFromPathWhitelist < ActiveRecord::Migration[6.0]
 
     if column_exists?(:embeddable_hosts, :path_whitelist)
       Migration::ColumnDropper.mark_readonly('embeddable_hosts', 'path_whitelist')
-    end
 
-    if column_exists?(:embeddable_hosts, :path_whitelist) && column_exists?(:embeddable_hosts, :allowed_paths)
-      DB.exec <<~SQL
-        UPDATE embeddable_hosts
-        SET allowed_paths = path_whitelist
-      SQL
+      if column_exists?(:embeddable_hosts, :allowed_paths)
+        DB.exec <<~SQL
+          UPDATE embeddable_hosts
+          SET allowed_paths = path_whitelist
+        SQL
+      end
     end
-  end
 
   def down
     remove_column :embeddable_hosts, :allowed_paths

--- a/db/migrate/20200728000854_duplicate_allowed_paths_from_path_whitelist.rb
+++ b/db/migrate/20200728000854_duplicate_allowed_paths_from_path_whitelist.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class DuplicateAllowedPathsFromPathWhitelist < ActiveRecord::Migration[6.0]
+  def up
+    unless column_exists?(:embeddable_hosts, :allowed_paths)
+      add_column :embeddable_hosts, :allowed_paths, :string
+    end
+
+    if column_exists?(:embeddable_hosts, :path_whitelist) && column_exists?(:embeddable_hosts, :allowed_paths)
+      DB.exec <<~SQL
+        UPDATE embeddable_hosts
+        SET allowed_paths = path_whitelist
+      SQL
+    end
+  end
+
+  def down
+    remove_column :embeddable_hosts, :allowed_paths
+  end
+end

--- a/db/post_migrate/20200629232159_rename_path_whitelist_to_allowed_paths.rb
+++ b/db/post_migrate/20200629232159_rename_path_whitelist_to_allowed_paths.rb
@@ -2,6 +2,6 @@
 
 class RenamePathWhitelistToAllowedPaths < ActiveRecord::Migration[6.0]
   def change
-    rename_column :embeddable_hosts, :path_whitelist, :allowed_paths
+    rename_column :embeddable_hosts, :path_whitelist, :allowed_paths unless column_exists?(:embeddable_hosts, :allowed_paths)
   end
 end

--- a/db/post_migrate/20200629232159_rename_path_whitelist_to_allowed_paths.rb
+++ b/db/post_migrate/20200629232159_rename_path_whitelist_to_allowed_paths.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-class RenamePathWhitelistToAllowedPaths < ActiveRecord::Migration[6.0]
-  def change
-    rename_column :embeddable_hosts, :path_whitelist, :allowed_paths unless column_exists?(:embeddable_hosts, :allowed_paths)
-  end
-end

--- a/db/post_migrate/20200728004302_drop_path_whitelist_from_embeddable_hosts.rb
+++ b/db/post_migrate/20200728004302_drop_path_whitelist_from_embeddable_hosts.rb
@@ -2,9 +2,7 @@
 
 class DropPathWhitelistFromEmbeddableHosts < ActiveRecord::Migration[6.0]
   def up
-    if column_exists?(:embeddable_hosts, :path_whitelist)
-      remove_column :embeddable_hosts, :path_whitelist
-    end
+    Migration::ColumnDropper.execute_drop(:embeddable_host, :path_whitelist)
   end
 
   def down

--- a/db/post_migrate/20200728004302_drop_path_whitelist_from_embeddable_hosts.rb
+++ b/db/post_migrate/20200728004302_drop_path_whitelist_from_embeddable_hosts.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class DropPathWhitelistFromEmbeddableHosts < ActiveRecord::Migration[6.0]
+  def up
+    if column_exists?(:embeddable_hosts, :path_whitelist)
+      remove_column :embeddable_hosts, :path_whitelist
+    end
+  end
+
+  def down
+    add_column :embeddable_hosts, :path_whitelist, :string
+  end
+end

--- a/db/post_migrate/20200728004302_drop_path_whitelist_from_embeddable_hosts.rb
+++ b/db/post_migrate/20200728004302_drop_path_whitelist_from_embeddable_hosts.rb
@@ -2,7 +2,7 @@
 
 class DropPathWhitelistFromEmbeddableHosts < ActiveRecord::Migration[6.0]
   def up
-    Migration::ColumnDropper.execute_drop(:embeddable_host, :path_whitelist)
+    Migration::ColumnDropper.execute_drop(:embeddable_hosts, %i(path_whitelist))
   end
 
   def down

--- a/db/post_migrate/20200728004302_drop_path_whitelist_from_embeddable_hosts.rb
+++ b/db/post_migrate/20200728004302_drop_path_whitelist_from_embeddable_hosts.rb
@@ -1,8 +1,14 @@
 # frozen_string_literal: true
 
 class DropPathWhitelistFromEmbeddableHosts < ActiveRecord::Migration[6.0]
+  DROPPED_COLUMNS ||= {
+    embeddable_hosts: %i{path_whitelist}
+  }
+
   def up
-    Migration::ColumnDropper.execute_drop(:embeddable_hosts, %i(path_whitelist))
+    DROPPED_COLUMNS.each do |table, columns|
+      Migration::ColumnDropper.execute_drop(table, columns)
+    end
   end
 
   def down


### PR DESCRIPTION
Because previous migration was already deployed and some databases were already migrated, I needed to add some conditions to the migration.

Previous migration - https://github.com/discourse/discourse/blob/master/db/post_migrate/20200629232159_rename_path_whitelist_to_allowed_paths.rb

What will happen in a scenario when previous migration was not run.
1. column allowed_paths will be created
2. allowed_path will be populated with data from path_whitelist
3. rename column will be skipped - `unless column_exists?(:embeddable_hosts, :allowed_paths)`
4. path_whitelist column will be dropped

What will happen in a scenario when previous migration was already run.
1. column allowed_paths will not be created because already exists - `unless column_exists?(:embeddable_hosts, :allowed_paths)`
2. Data will not be copied because path_whitelist is missing - `if column_exists?(:embeddable_hosts, :path_whitelist) && column_exists?(:embeddable_hosts, :allowed_paths)`
3. rename column will be skipped - `unless column_exists?(:embeddable_hosts, :allowed_paths)`
4. path_whitelist column deletion will be skipped - `if column_exists?(:embeddable_hosts, :path_whitelist)`