### PR TITLE
FIX:  Resolve issue where deleted spam topics marked as Not Spam were not being recovered

### DIFF
--- a/lib/post_destroyer.rb
+++ b/lib/post_destroyer.rb
@@ -214,7 +214,8 @@ class PostDestroyer
   private
 
   def post_is_reviewable?
-    Guardian.new(@user).can_review_topic?(@post.topic) && Reviewable.exists?(target: @post)
+    topic = @post.topic || Topic.with_deleted.find(@post.topic_id)
+    Guardian.new(@user).can_review_topic?(topic) && Reviewable.exists?(target: @post)
   end
 
   # we need topics to change if ever a post in them is deleted or created

--- a/spec/components/post_destroyer_spec.rb
+++ b/spec/components/post_destroyer_spec.rb
@@ -289,7 +289,7 @@ describe PostDestroyer do
               ReviewableFlaggedPost.needs_review!(target: @reply, created_by: Fabricate(:user))
             end
 
-            it "changes deleted_at to nil" do
+            def changes_deleted_at_to_nil
               PostDestroyer.new(Discourse.system_user, @reply).destroy
               @reply.reload
               expect(@reply.user_deleted).to eq(false)
@@ -298,6 +298,19 @@ describe PostDestroyer do
               PostDestroyer.new(review_user, @reply).recover
               @reply.reload
               expect(@reply.deleted_at).to eq(nil)
+            end
+
+            it "changes deleted_at to nil" do
+              changes_deleted_at_to_nil
+            end
+
+            context "when the topic is deleted" do
+              before do
+                @reply.topic.trash!
+              end
+              it "changes deleted_at to nil" do
+                changes_deleted_at_to_nil
+              end
             end
           end
 


### PR DESCRIPTION
If a user posted a topic and Akismet decided it was spam, the topic gets deleted and put into the review queue. If a category moderator for that category marked the post/topic as "Not Spam" the topic did not get recovered correctly because `Guardian.new(@user).can_review_topic?(@post.topic)` returned false incorrectly because the topic was deleted.