### PR TITLE
FIX: Ensure topic user bookmarked synced on bookmark auto-delete

### DIFF
--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -77,6 +77,15 @@ class Bookmark < ActiveRecord::Base
     self.auto_delete_preference == Bookmark.auto_delete_preferences[:on_owner_reply]
   end
 
+  def clear_reminder!
+    update(
+      reminder_at: nil,
+      reminder_type: nil,
+      reminder_last_sent_at: Time.zone.now,
+      reminder_set_at: nil
+    )
+  end
+
   scope :pending_reminders, ->(before_time = Time.now.utc) do
     where("reminder_at IS NOT NULL AND reminder_at <= :before_time", before_time: before_time)
   end

--- a/db/migrate/20200728022830_sync_topic_user_bookmarked_column_with_bookmarks.rb
+++ b/db/migrate/20200728022830_sync_topic_user_bookmarked_column_with_bookmarks.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class SyncTopicUserBookmarkedColumnWithBookmarks < ActiveRecord::Migration[6.0]
+  def up
+    should_be_bookmarked_sql = <<~SQL
+      UPDATE topic_users SET bookmarked = true WHERE id IN (
+        SELECT topic_users.id
+        FROM topic_users
+        INNER JOIN bookmarks ON bookmarks.user_id = topic_users.user_id AND
+          bookmarks.topic_id = topic_users.topic_id
+        WHERE NOT topic_users.bookmarked
+      ) AND NOT bookmarked
+    SQL
+    DB.exec(should_be_bookmarked_sql)
+
+    # post_action_type_id 1 is bookmark
+    should_not_be_bookmarked_sql = <<~SQL
+    UPDATE topic_users SET bookmarked = FALSE WHERE ID IN (
+      SELECT DISTINCT topic_users.id FROM topic_users
+      LEFT JOIN bookmarks ON bookmarks.topic_id = topic_users.topic_id AND bookmarks.user_id = topic_users.user_id
+      LEFT JOIN post_actions ON post_actions.user_id = topic_users.user_id AND post_actions.post_action_type_id = 1 AND post_actions.post_id IN (SELECT id FROM posts WHERE posts.topic_id = topic_users.topic_id) 
+      WHERE topic_users.bookmarked = true AND (bookmarks.id IS NULL AND post_actions.id IS NULL))
+    SQL
+    DB.exec(should_not_be_bookmarked_sql)
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/lib/bookmark_reminder_notification_handler.rb
+++ b/lib/bookmark_reminder_notification_handler.rb
@@ -11,7 +11,7 @@ class BookmarkReminderNotificationHandler
       create_notification(bookmark)
 
       if bookmark.delete_when_reminder_sent?
-        return bookmark.destroy
+        BookmarkManager.new(bookmark.user).destroy(bookmark.id)
       end
 
       clear_reminder(bookmark)
@@ -23,12 +23,7 @@ class BookmarkReminderNotificationHandler
       "Clearing bookmark reminder for bookmark_id #{bookmark.id}. reminder info: #{bookmark.reminder_at} | #{Bookmark.reminder_types[bookmark.reminder_type]}"
     )
 
-    bookmark.update(
-      reminder_at: nil,
-      reminder_type: nil,
-      reminder_last_sent_at: Time.zone.now,
-      reminder_set_at: nil
-    )
+    bookmark.clear_reminder!
   end
 
   def self.create_notification(bookmark)

--- a/lib/post_creator.rb
+++ b/lib/post_creator.rb
@@ -405,10 +405,11 @@ class PostCreator
 
   def delete_owned_bookmarks
     return if !@post.topic_id
-    @user.bookmarks.where(
-      topic_id: @post.topic_id,
-      auto_delete_preference: Bookmark.auto_delete_preferences[:on_owner_reply]
-    ).destroy_all
+    BookmarkManager.new(@user).destroy_for_topic(
+      Topic.with_deleted.find(@post.topic_id),
+      { auto_delete_preference: Bookmark.auto_delete_preferences[:on_owner_reply] },
+      @opts
+    )
   end
 
   def handle_spam

--- a/spec/components/post_creator_spec.rb
+++ b/spec/components/post_creator_spec.rb
@@ -653,12 +653,22 @@ describe PostCreator do
       before do
         Fabricate(:bookmark, topic: topic, user: user, auto_delete_preference: Bookmark.auto_delete_preferences[:on_owner_reply])
         Fabricate(:bookmark, topic: topic, user: user, auto_delete_preference: Bookmark.auto_delete_preferences[:on_owner_reply])
+        TopicUser.create!(topic: topic, user: user, bookmarked: true)
+      end
+
+      it "deletes the bookmarks, but not the ones without an auto_delete_preference" do
         Fabricate(:bookmark, topic: topic, user: user)
         Fabricate(:bookmark, user: user)
-      end
-      it "deletes the bookmarks" do
         creator.create
         expect(Bookmark.where(user: user).count).to eq(2)
+        expect(TopicUser.find_by(topic: topic, user: user).bookmarked).to eq(true)
+      end
+
+      context "when there are no bookmarks left in the topic" do
+        it "sets TopicUser.bookmarked to false" do
+          creator.create
+          expect(TopicUser.find_by(topic: topic, user: user).bookmarked).to eq(false)
+        end
       end
     end
 


### PR DESCRIPTION
For the following conditions, the `TopicUser.bookmarked` column was not updated correctly:

* When a bookmark was auto-deleted because the reminder was sent
* When a bookmark was auto-deleted because the owner of the bookmark replied to the topic

This adds another migration to fix the out-of-sync column and also some refactors to `BookmarkManager` to allow for more of these delete cases. `BookmarkManager` is used instead of directly destroying the bookmark in `PostCreator` and `BookmarkReminderNotificationHandler`.