### PR TITLE
DEV: No need to pause Sidekiq during backups.

### DIFF
--- a/lib/backup_restore/backuper.rb
+++ b/lib/backup_restore/backuper.rb
@@ -33,14 +33,7 @@ module BackupRestore
       ensure_directory_exists(@archive_directory)
 
       update_metadata
-
-      begin
-        pause_sidekiq
-        wait_for_sidekiq
-        dump_public_schema
-      ensure
-        unpause_sidekiq
-      end
+      dump_public_schema
 
       log "Finalizing backup..."
 
@@ -125,32 +118,6 @@ module BackupRestore
       BackupMetadata.create!(name: "s3_cdn_url", value: SiteSetting.Upload.enable_s3_uploads ? SiteSetting.Upload.s3_cdn_url : nil)
       BackupMetadata.create!(name: "db_name", value: RailsMultisite::ConnectionManagement.current_db)
       BackupMetadata.create!(name: "multisite", value: Rails.configuration.multisite)
-    end
-
-    def pause_sidekiq
-      log "Pausing sidekiq..."
-      Sidekiq.pause!
-    end
-
-    def wait_for_sidekiq
-      log "Waiting for sidekiq to finish running jobs..."
-      iterations = 1
-      while sidekiq_has_running_jobs?
-        log "Waiting for sidekiq to finish running jobs... ##{iterations}"
-        sleep 5
-        iterations += 1
-        raise "Sidekiq did not finish running all the jobs in the allowed time!" if iterations > 6
-      end
-    end
-
-    def sidekiq_has_running_jobs?
-      Sidekiq::Workers.new.each do |_, _, worker|
-        payload = worker.try(:payload)
-        return true if payload.try(:all_sites)
-        return true if payload.try(:current_site_id) == @current_db
-      end
-
-      false
     end
 
     def dump_public_schema
@@ -401,14 +368,6 @@ module BackupRestore
       FileUtils.rm_rf(@tmp_directory) if Dir[@tmp_directory].present?
     rescue => ex
       log "Something went wrong while removing the following tmp directory: #{@tmp_directory}", ex
-    end
-
-    def unpause_sidekiq
-      return unless Sidekiq.paused?
-      log "Unpausing sidekiq..."
-      Sidekiq.unpause!
-    rescue => ex
-      log "Something went wrong while unpausing Sidekiq.", ex
     end
 
     def mark_backup_as_not_running


### PR DESCRIPTION
This was done for historical reasons where we stop all writes going to
the DB during a backup by setting the database to readonly mode.