### PR TITLE
Remove darken lighten

### DIFF
--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -349,7 +349,7 @@
 
     li {
       .d-icon-users {
-        color: lighten($primary, 40%);
+        color: $primary-medium;
         padding: 0 2px;
       }
 

--- a/app/assets/stylesheets/common/base/emoji.scss
+++ b/app/assets/stylesheets/common/base/emoji.scss
@@ -209,7 +209,7 @@ sup img.emoji {
   display: inline-block;
   vertical-align: top;
   border-radius: 2px;
-  background-color: lighten($tertiary, 40%);
+  background-color: $tertiary-low;
 }
 
 .emoji-picker-modal.fadeIn {

--- a/app/assets/stylesheets/common/base/topic-admin-menu.scss
+++ b/app/assets/stylesheets/common/base/topic-admin-menu.scss
@@ -120,15 +120,15 @@
       }
       &:active {
         @include linear-gradient(
-          darken($tertiary, 18%),
-          darken($tertiary, 12%)
+          $tertiary-hover,
+          $tertiary
         );
         color: $secondary;
       }
     }
     &[disabled] {
       text-shadow: 0 1px 0 rgba($primary, 0.2);
-      @include linear-gradient($tertiary, darken($tertiary, 20%));
+      @include linear-gradient($tertiary, $tertiary-hover);
       box-shadow: inset 0 1px 0 rgba(0, 0, 0, 0.33);
     }
   }

--- a/app/assets/stylesheets/common/base/topic-admin-menu.scss
+++ b/app/assets/stylesheets/common/base/topic-admin-menu.scss
@@ -119,10 +119,7 @@
         background: $tertiary-high;
       }
       &:active {
-        @include linear-gradient(
-          $tertiary-hover,
-          $tertiary
-        );
+        @include linear-gradient($tertiary-hover, $tertiary);
         color: $secondary;
       }
     }

--- a/app/assets/stylesheets/common/components/buttons.scss
+++ b/app/assets/stylesheets/common/components/buttons.scss
@@ -50,10 +50,7 @@
   }
   &:active,
   &.btn-active {
-    @include linear-gradient(
-      $hover-bg-color 0%,
-      $bg-color 100%
-    );
+    @include linear-gradient($hover-bg-color 0%, $bg-color 100%);
   }
   &[disabled],
   &.disabled {

--- a/app/assets/stylesheets/common/components/buttons.scss
+++ b/app/assets/stylesheets/common/components/buttons.scss
@@ -51,8 +51,8 @@
   &:active,
   &.btn-active {
     @include linear-gradient(
-      scale-color($bg-color, $lightness: -20%),
-      $bg-color
+      $hover-bg-color 0%,
+      $bg-color 100%
     );
   }
   &[disabled],
@@ -113,7 +113,7 @@
     $text-color: $secondary,
     $bg-color: $tertiary,
     $icon-color: $secondary,
-    $hover-bg-color: darken($tertiary, 10%),
+    $hover-bg-color: $tertiary-hover,
     $hover-icon-color: $secondary
   );
 }
@@ -126,11 +126,7 @@
     $text-color: $secondary,
     $bg-color: $danger,
     $icon-color: $danger-low,
-    $hover-bg-color:
-      dark-light-choose(
-        scale-color($danger, $lightness: -20%),
-        scale-color($danger, $lightness: 20%)
-      ),
+    $hover-bg-color: $danger-hover,
     $hover-icon-color: $danger-low
   );
 }
@@ -143,11 +139,7 @@
     $text-color: $secondary,
     $bg-color: $danger,
     $icon-color: $secondary,
-    $hover-bg-color:
-      dark-light-choose(
-        scale-color($danger, $lightness: -20%),
-        scale-color($danger, $lightness: 20%)
-      ),
+    $hover-bg-color: $danger-hover,
     $hover-icon-color: $secondary
   );
 }
@@ -157,11 +149,7 @@
     $text-color: $secondary,
     $bg-color: $success,
     $icon-color: $secondary,
-    $hover-bg-color:
-      dark-light-choose(
-        scale-color($success, $lightness: -20%),
-        scale-color($success, $lightness: 20%)
-      ),
+    $hover-bg-color: $success-hover,
     $hover-icon-color: $secondary
   );
 }
@@ -195,19 +183,19 @@
     }
     &:hover {
       color: currentColor;
-      background: darken($google, 5%);
+      background: $google-hover;
     }
   }
   &.instagram {
     background: $instagram;
     &:hover {
-      background: darken($instagram, 15%);
+      background: $instagram-hover;
     }
   }
   &.facebook {
     background: $facebook;
     &:hover {
-      background: darken($facebook, 15%);
+      background: $facebook-hover;
     }
   }
   &.cas {
@@ -216,19 +204,19 @@
   &.twitter {
     background: $twitter;
     &:hover {
-      background: darken($twitter, 10%);
+      background: $twitter-hover;
     }
   }
   &.github {
     background: $github;
     &:hover {
-      background: lighten($github, 20%);
+      background: $github-hover;
     }
   }
   &.discord {
     background: $discord;
     &:hover {
-      background: darken($discord, 10%);
+      background: $discord-hover;
     }
   }
 }

--- a/app/assets/stylesheets/common/foundation/color_transformations.scss
+++ b/app/assets/stylesheets/common/foundation/color_transformations.scss
@@ -53,6 +53,7 @@ $secondary-very-high: dark-light-diff($secondary, $primary, 7%, -7%) !default;
 $tertiary-low: dark-light-diff($tertiary, $secondary, 85%, -65%) !default;
 $tertiary-medium: dark-light-diff($tertiary, $secondary, 50%, -45%) !default;
 $tertiary-high: dark-light-diff($tertiary, $secondary, 20%, -25%) !default;
+$tertiary-hover: dark-light-diff($tertiary, $secondary, -25%, -25%) !default;
 
 //quaternary
 $quaternary-low: dark-light-diff($quaternary, $secondary, 70%, -70%) !default;
@@ -65,10 +66,12 @@ $highlight-high: dark-light-diff($highlight, $secondary, -50%, -10%) !default;
 //danger
 $danger-low: dark-light-diff($danger, $secondary, 85%, -64%) !default;
 $danger-medium: dark-light-diff($danger, $secondary, 30%, -35%) !default;
+$danger-hover: dark-light-diff($danger, $secondary, -20%, -20%) !default;
 
 //success
 $success-low: dark-light-diff($success, $secondary, 80%, -60%) !default;
 $success-medium: dark-light-diff($success, $secondary, 50%, -40%) !default;
+$success-hover: dark-light-diff($success, $secondary, -20%, -20%) !default;
 
 //love
 $love-low: dark-light-diff($love, $secondary, 85%, -60%) !default;

--- a/app/assets/stylesheets/common/foundation/variables.scss
+++ b/app/assets/stylesheets/common/foundation/variables.scss
@@ -89,7 +89,7 @@ $z-layers: (
     "popover": 1500,
     "dropdown": 1400,
     "content": 1300,
-    "overlay": 1200
+    "overlay": 1200,
   ),
   "fullscreen": 1150,
   "mobile-composer": 1100,
@@ -101,12 +101,12 @@ $z-layers: (
     "dropdown": 700,
     "tooltip": 600,
     "popover": 500,
-    "content": 400
+    "content": 400,
   ),
   "dropdown": 300,
   "usercard": 200,
   "timeline": 100,
-  "base": 1
+  "base": 1,
 );
 
 @function map-has-nested-keys($map, $keys...) {
@@ -146,10 +146,10 @@ $box-shadow: (
   "footer-nav": 0 0 2px 0 rgba(0, 0, 0, 0.25),
   "kbd": (
     0 2px 0 rgba(0, 0, 0, 0.2),
-    0 0 0 1px dark-light-choose(#fff, #000) inset
+    0 0 0 1px dark-light-choose(#fff, #000) inset,
   ),
   "focus": 0 0 6px 0 $tertiary,
-  "focus-danger": 0 0 6px 0 $danger
+  "focus-danger": 0 0 6px 0 $danger,
 );
 
 @function shadow($key) {

--- a/app/assets/stylesheets/common/foundation/variables.scss
+++ b/app/assets/stylesheets/common/foundation/variables.scss
@@ -89,7 +89,7 @@ $z-layers: (
     "popover": 1500,
     "dropdown": 1400,
     "content": 1300,
-    "overlay": 1200,
+    "overlay": 1200
   ),
   "fullscreen": 1150,
   "mobile-composer": 1100,
@@ -101,12 +101,12 @@ $z-layers: (
     "dropdown": 700,
     "tooltip": 600,
     "popover": 500,
-    "content": 400,
+    "content": 400
   ),
   "dropdown": 300,
   "usercard": 200,
   "timeline": 100,
-  "base": 1,
+  "base": 1
 );
 
 @function map-has-nested-keys($map, $keys...) {
@@ -146,10 +146,10 @@ $box-shadow: (
   "footer-nav": 0 0 2px 0 rgba(0, 0, 0, 0.25),
   "kbd": (
     0 2px 0 rgba(0, 0, 0, 0.2),
-    0 0 0 1px dark-light-choose(#fff, #000) inset,
+    0 0 0 1px dark-light-choose(#fff, #000) inset
   ),
   "focus": 0 0 6px 0 $tertiary,
-  "focus-danger": 0 0 6px 0 $danger,
+  "focus-danger": 0 0 6px 0 $danger
 );
 
 @function shadow($key) {

--- a/app/assets/stylesheets/common/foundation/variables.scss
+++ b/app/assets/stylesheets/common/foundation/variables.scss
@@ -18,12 +18,18 @@ $topic-avatar-width: 45px;
 // --------------------------------------------------
 
 $google: #ffffff !default;
+$google-hover: darken($google, 5%);
 $instagram: #e1306c !default;
+$instagram-hover: darken($instagram, 15%);
 $facebook: #4267b2 !default;
+$facebook-hover: darken($facebook, 15%);
 $cas: #70ba61 !default;
 $twitter: #1da1f2 !default;
+$twitter-hover: darken($twitter, 10%);
 $github: #100e0f !default;
+$github-hover: lighten($github, 20%);
 $discord: #7289da !default;
+$discord-hover: darken($discord, 10%);
 
 // Badge color variables
 // --------------------------------------------------

--- a/app/assets/stylesheets/common/foundation/variables.scss
+++ b/app/assets/stylesheets/common/foundation/variables.scss
@@ -18,18 +18,18 @@ $topic-avatar-width: 45px;
 // --------------------------------------------------
 
 $google: #ffffff !default;
-$google-hover: darken($google, 5%);
+$google-hover: darken($google, 5%) !default;
 $instagram: #e1306c !default;
-$instagram-hover: darken($instagram, 15%);
+$instagram-hover: darken($instagram, 15%) !default;
 $facebook: #4267b2 !default;
-$facebook-hover: darken($facebook, 15%);
+$facebook-hover: darken($facebook, 15%) !default;
 $cas: #70ba61 !default;
 $twitter: #1da1f2 !default;
-$twitter-hover: darken($twitter, 10%);
+$twitter-hover: darken($twitter, 10%) !default;
 $github: #100e0f !default;
-$github-hover: lighten($github, 20%);
+$github-hover: lighten($github, 20%) !default;
 $discord: #7289da !default;
-$discord-hover: darken($discord, 10%);
+$discord-hover: darken($discord, 10%) !default;
 
 // Badge color variables
 // --------------------------------------------------

--- a/app/assets/stylesheets/common/select-kit/future-date-input-selector.scss
+++ b/app/assets/stylesheets/common/select-kit/future-date-input-selector.scss
@@ -30,7 +30,7 @@
 
       .future-date-input-selector-row {
         .future-date-input-selector-icons {
-          color: lighten($primary, 40%);
+          color: $primary-medium;
         }
       }
     }

--- a/app/assets/stylesheets/desktop/user.scss
+++ b/app/assets/stylesheets/desktop/user.scss
@@ -111,7 +111,7 @@
       .details {
         padding: 15px 0;
         margin: 0;
-        color: dark-light-choose(lighten($primary, 10%), $secondary);
+        color: $secondary;
       }
     }
 

--- a/app/assets/stylesheets/embed.scss
+++ b/app/assets/stylesheets/embed.scss
@@ -18,7 +18,7 @@ article.post {
   }
 
   .quote .title {
-    border-left: 5px solid darken($primary-low, 5%);
+    border-left: 5px solid $primary-very-low;
     padding: 10px 10px 0 12px;
     .avatar {
       margin-right: 7px;
@@ -33,7 +33,7 @@ article.post {
   blockquote {
     padding: 10px 8px 10px 13px;
     margin: 0 0 10px 0;
-    border-left: 5px solid darken($primary-low, 5%);
+    border-left: 5px solid $primary-very-low;
     p {
       margin: 0 0 10px 0;
     }


### PR DESCRIPTION
Here I remove instances of `darken()` or `lighten()` color functions from the following files, as well as create new `hover` variables for `$tertiary`, `$danger`, `$success`, and the social colors.

These examples show that there is little to no difference by switching to a method that does not use these color functions.

1. `compose.scss`
<img width="522" alt="image" src="https://user-images.githubusercontent.com/30537603/88706473-8586bc80-d0d6-11ea-9c1f-0231ebe63b3d.png">


2. `emoji.scss` changes bg-hover color of emoji when selecting

<img width="525" alt="image" src="https://user-images.githubusercontent.com/30537603/88706896-16f62e80-d0d7-11ea-8e72-7e84ddcfdfde.png">

3. `topic-admin-menu.scss` changes active/hover color on select posts menu buttons

### New
<img src="https://user-images.githubusercontent.com/30537603/88707287-ab609100-d0d7-11ea-84ab-1bd89fc3db08.gif" width="250"/>

### Old
<img src="https://user-images.githubusercontent.com/30537603/88708156-d8617380-d0d8-11ea-96d4-0a6ea3fb79f6.gif" width="250"/>

4. `buttons.scss` changes buttons hover/active
<img width="450" alt="image" src="https://user-images.githubusercontent.com/30537603/88708958-11e6ae80-d0da-11ea-8098-b9e3c2e55844.png">
