### PR TITLE
FIX: Rename delete_when_reminder_sent? bookmark method to avoid conflict with AR

### DIFF
--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -69,11 +69,11 @@ class Bookmark < ActiveRecord::Base
     self.reminder_at.blank? && self.reminder_type.blank?
   end
 
-  def delete_when_reminder_sent?
+  def auto_delete_when_reminder_sent?
     self.auto_delete_preference == Bookmark.auto_delete_preferences[:when_reminder_sent]
   end
 
-  def delete_on_owner_reply?
+  def auto_delete_on_owner_reply?
     self.auto_delete_preference == Bookmark.auto_delete_preferences[:on_owner_reply]
   end
 

--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -354,10 +354,6 @@ class PostSerializer < BasicPostSerializer
     bookmarked
   end
 
-  def include_bookmark_delete_on_owner_reply?
-    bookmarked
-  end
-
   def include_bookmark_id?
     bookmarked
   end

--- a/lib/bookmark_reminder_notification_handler.rb
+++ b/lib/bookmark_reminder_notification_handler.rb
@@ -10,7 +10,7 @@ class BookmarkReminderNotificationHandler
 
       create_notification(bookmark)
 
-      if bookmark.delete_when_reminder_sent?
+      if bookmark.auto_delete_when_reminder_sent?
         BookmarkManager.new(bookmark.user).destroy(bookmark.id)
       end
 


### PR DESCRIPTION
I added `delete_when_reminder_sent` to `ignored_columns` because it no longer exists and added a shortcut method `delete_when_reminder_sent?` to the Bookmark model. However I have been seeing some weird errors like:

> Job exception: unknown attribute 'delete_when_reminder_sent' for Bookmark.

So I am very suspicious. I am just renaming the method to `auto_delete_when_reminder_sent?` to avoid any potential conflicts.

Also found `include_bookmark_delete_on_owner_reply?` in `PostSerializer` which is used for nothing; I must have forgotten to delete it before.