### PR TITLE
DEV: Live refresh all themes when watching stylesheets

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -48,16 +48,6 @@ class ApplicationController < ActionController::Base
 
   layout :set_layout
 
-  if Rails.env == "development"
-    after_action :remember_theme_id
-
-    def remember_theme_id
-      if @theme_ids.present? && request.format == "html"
-        Stylesheet::Watcher.theme_id = @theme_ids.first if defined? Stylesheet::Watcher
-      end
-    end
-  end
-
   def has_escaped_fragment?
     SiteSetting.enable_escaped_fragments? && params.key?("_escaped_fragment_")
   end


### PR DESCRIPTION
While working on multiple themes concurrently (multiple browsers open, each set to a different theme), I was frustrated by styles only refreshing on one browser, the one that was loaded last. 

This change triggers SCSS refreshing for all enabled themes, thus making it easier to see changes that affect multiple themes locally. Refreshes are slightly slower given the multiple messages, but I think we should try it, it is nice to have all themes update. 