### PR TITLE
Rename options passed to Readability::Document

### DIFF
--- a/app/models/topic_embed.rb
+++ b/app/models/topic_embed.rb
@@ -124,8 +124,8 @@ class TopicEmbed < ActiveRecord::Base
       remove_empty_nodes: false
     }
 
-    opts[:allowlist] = SiteSetting.allowed_embed_selectors if SiteSetting.allowed_embed_selectors.present?
-    opts[:blocklist] = SiteSetting.blocked_embed_selectors if SiteSetting.blocked_embed_selectors.present?
+    opts[:whitelist] = SiteSetting.allowed_embed_selectors if SiteSetting.allowed_embed_selectors.present?
+    opts[:blacklist] = SiteSetting.blocked_embed_selectors if SiteSetting.blocked_embed_selectors.present?
     allowed_embed_classnames = SiteSetting.allowed_embed_classnames if SiteSetting.allowed_embed_classnames.present?
 
     response = FetchResponse.new


### PR DESCRIPTION
We recently renamed the options passed to `Readability::Document` to `allowlist` and `blocklist`, but the method is still expecting the options to be named `whitelist` and `blacklist`. This means that the `allowed_embed_selects` site setting is not being respected - it's causing issues when the "Show Full Post" button is clicked for embedded posts.