### PR TITLE
FIX: Respect query params for latest.rss

### DIFF
--- a/app/controllers/list_controller.rb
+++ b/app/controllers/list_controller.rb
@@ -176,11 +176,13 @@ class ListController < ApplicationController
   def latest_feed
     discourse_expires_in 1.minute
 
+    options = { order: 'created' }.merge(build_topic_list_options)
+
     @title = "#{SiteSetting.title} - #{I18n.t("rss_description.latest")}"
     @link = "#{Discourse.base_url}/latest"
     @atom_link = "#{Discourse.base_url}/latest.rss"
     @description = I18n.t("rss_description.latest")
-    @topic_list = TopicQuery.new(nil, order: 'created').list_latest
+    @topic_list = TopicQuery.new(nil, options).list_latest
 
     render 'list', formats: [:rss]
   end

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -324,6 +324,13 @@ RSpec.describe ListController do
       expect(response.headers['X-Robots-Tag']).to eq('noindex')
     end
 
+    it 'renders latest RSS with query params' do
+      get "/latest.rss?status=closed"
+      expect(response.status).to eq(200)
+      expect(response.media_type).to eq('application/rss+xml')
+      expect(response.body).to_not include("<item>")
+    end
+
     it 'renders links correctly with subfolder' do
       set_subfolder "/forum"
       _post = Fabricate(:post, topic: topic, user: user)


### PR DESCRIPTION
Apparently latest.json and latest.rss are not routed to the same
controller methods. This change allows for any passed in query
parameters to actually be applied to the rss route.

This came in as a request on meta:

https://meta.discourse.org/t/-/155812/6