### PR TITLE
FIX: Shows all_results if current settings category has no results

### DIFF
--- a/app/assets/javascripts/admin/controllers/admin-site-settings.js
+++ b/app/assets/javascripts/admin/controllers/admin-site-settings.js
@@ -93,6 +93,14 @@ export default Controller.extend({
     all.hasMore = matches.length > 30;
     all.count = all.hasMore ? "30+" : matches.length;
 
+    const categoryMatches = matchesGroupedByCategory.findBy(
+      "nameKey",
+      category
+    );
+    if (!categoryMatches || categoryMatches.count === 0) {
+      category = "all_results";
+    }
+
     this.set("visibleSiteSettings", matchesGroupedByCategory);
     this.transitionToRoute(
       "adminSiteSettingsCategory",

--- a/test/javascripts/acceptance/admin-site-settings-test.js
+++ b/test/javascripts/acceptance/admin-site-settings-test.js
@@ -119,3 +119,19 @@ QUnit.test("category name is preserved", async assert => {
   await visit("admin/site_settings/category/login?filter=test");
   assert.equal(currentURL(), "admin/site_settings/category/login?filter=test");
 });
+
+QUnit.test("shows all_results if current category has none", async assert => {
+  await visit("admin/site_settings");
+
+  await click(".admin-nav .basic a");
+  assert.equal(currentURL(), "/admin/site_settings/category/basic");
+
+  await fillIn("#setting-filter", "menu");
+  assert.equal(currentURL(), "/admin/site_settings/category/basic?filter=menu");
+
+  await fillIn("#setting-filter", "contact");
+  assert.equal(
+    currentURL(),
+    "/admin/site_settings/category/all_results?filter=contact"
+  );
+});


### PR DESCRIPTION
Searching for a specific setting only showed results from the current selected category. Before fixing fd02856, it automatically redirected the user to all_results. This was a problem because the redirect always happened and there was no way to share a link to a specific category.

The fix to this bug is to simply redirect the user to all_results if there are no results to be displayed.