### PR TITLE
FEATURE: New plugin outlet for category-heading

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/navigation/category.hbs
+++ b/app/assets/javascripts/discourse/app/templates/navigation/category.hbs
@@ -12,6 +12,8 @@
         <p>{{dir-span category.description}}</p>
       {{/if}}
     {{/if}}
+
+    {{plugin-outlet name="category-heading" args=(hash category=category)}}
   </section>
 
   <div class="category-navigation">


### PR DESCRIPTION
This plugin outlet will enable much more flexibility around the customization of the category-heading element of a category page. The outlet's placing will ensure that a designer can add content even if a category logo has not been uploaded.