### PR TITLE
DEV: adds plugin api to add custom recipients of a post revision

### DIFF
--- a/app/services/post_action_notifier.rb
+++ b/app/services/post_action_notifier.rb
@@ -114,6 +114,10 @@ class PostActionNotifier
       )
     end
 
+    custom_post_revision_notifier_recipients.each do |block|
+      user_ids.concat(block.call(post_revision))
+    end
+
     if user_ids.present?
       DB.after_commit do
         Jobs.enqueue(:notify_post_revision,
@@ -136,5 +140,13 @@ class PostActionNotifier
         acting_user_id: post.last_editor.id
       )
     end
+  end
+
+  def self.custom_post_revision_notifier_recipients
+    @custom_post_revision_notifier_recipients ||= Set.new
+  end
+
+  def self.add_post_revision_notifier_recipients(&block)
+    custom_post_revision_notifier_recipients << block
   end
 end

--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -280,6 +280,15 @@ class Plugin::Instance
     end
   end
 
+  # Allows to add additional user_ids to the list of people notified when doing a post revision
+  def add_post_revision_notifier_recipients(&block)
+    reloadable_patch do |plugin|
+      ::PostActionNotifier.add_post_revision_notifier_recipients do |post_revision|
+        plugin.enabled? ? block.call(post_revision) : []
+      end
+    end
+  end
+
   # Applies to all sites in a multisite environment. Ignores plugin.enabled?
   def add_preloaded_group_custom_field(field)
     reloadable_patch do |plugin|

--- a/spec/services/post_action_notifier_spec.rb
+++ b/spec/services/post_action_notifier_spec.rb
@@ -116,7 +116,6 @@ describe PostActionNotifier do
         expect {
           post.revise(evil_trout, raw: "world is the new body of the message")
         }.to change {
-          lurker.reload
           lurker.notifications.count
         }.by(1)
       end

--- a/spec/services/post_action_notifier_spec.rb
+++ b/spec/services/post_action_notifier_spec.rb
@@ -98,6 +98,29 @@ describe PostActionNotifier do
 
     end
 
+    context 'when using plugin API to add custom recipients' do
+      let(:lurker) { Fabricate(:user) }
+
+      before do
+        plugin = Plugin::Instance.new
+        plugin.add_post_revision_notifier_recipients do |post_revision|
+          [lurker.id]
+        end
+      end
+
+      after do
+        DiscoursePluginRegistry.reset!
+      end
+
+      it 'notifies the specified user of the revision' do
+        expect {
+          post.revise(evil_trout, raw: "world is the new body of the message")
+        }.to change {
+          lurker.reload
+          lurker.notifications.count
+        }.by(1)
+      end
+    end
   end
 
   context 'private message' do


### PR DESCRIPTION
Usage:

```
add_post_revision_notifier_recipients do |post_revision|
  [78]
end
```