### PR TITLE
FIX: allows to change a user group notification level

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/user-private-messages.js
+++ b/app/assets/javascripts/discourse/app/controllers/user-private-messages.js
@@ -60,7 +60,7 @@ export default Controller.extend({
 
   actions: {
     changeGroupNotificationLevel(notificationLevel) {
-      this.group.setNotification(notificationLevel, this.get("user.id"));
+      this.group.setNotification(notificationLevel, this.get("user.model.id"));
     },
     archive() {
       this.bulkOperation("archive_messages");


### PR DESCRIPTION
The current code has an ambiguous name of "user" which is actually not a user model, the real user model is accessible on the model key of user.