### PR TITLE
FIX: Show "group members forbidden" message on mobile

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/mobile/group-index.hbs
+++ b/app/assets/javascripts/discourse/app/templates/mobile/group-index.hbs
@@ -55,9 +55,13 @@
     {{/load-more}}
 
     {{conditional-loading-spinner condition=loading}}
-  {{else}}
+  {{else if model.can_see_members}}
     <br>
 
     <div>{{i18n "groups.empty.members"}}</div>
+  {{else}}
+    <br>
+
+    <div>{{i18n "groups.members.forbidden"}}</div>
   {{/if}}
 </section>


### PR DESCRIPTION
This commit fixes an oversight in commit 88359b0f167a16b9eb59a9315ceefa84e4c7ec7c.