### PR TITLE
Add category_id to TopicViewWordpressSerializer

### DIFF
--- a/app/serializers/topic_view_wordpress_serializer.rb
+++ b/app/serializers/topic_view_wordpress_serializer.rb
@@ -4,6 +4,7 @@ class TopicViewWordpressSerializer < ApplicationSerializer
 
   # These attributes will be delegated to the topic
   attributes :id,
+             :category_id,
              :posts_count,
              :filtered_posts_count,
              :posts
@@ -13,6 +14,10 @@ class TopicViewWordpressSerializer < ApplicationSerializer
 
   def id
     object.topic.id
+  end
+
+  def category_id
+    object.topic.category_id
   end
 
   def posts_count


### PR DESCRIPTION
The WordPress plugin needs the topic ID returned so that it can avoid saving comments for posts that have been re-categorized to protected categories on Discourse if the WordPress plugin's "Don't display private comments" setting is enabled. This will also handle the edge-case of any topic published from WP that gets converted to a PM.