### PR TITLE
FEATURE: Allow users to opt out of automatic dark mode

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/preferences/interface.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/interface.js
@@ -151,16 +151,16 @@ export default Controller.extend({
   },
 
   @discourseComputed
-  showDisableDarkMode() {
+  showDarkModeToggle() {
     return this.siteSettings.default_dark_mode_color_scheme_id > 0;
   },
 
-  disableDarkMode: computed({
+  enableDarkMode: computed({
     set(key, value) {
       return value;
     },
     get() {
-      return this.get("model.user_option.dark_scheme_id") === -1 ? true : false;
+      return this.get("model.user_option.dark_scheme_id") === -1 ? false : true;
     }
   }),
 
@@ -179,7 +179,7 @@ export default Controller.extend({
 
       this.set(
         "model.user_option.dark_scheme_id",
-        this.disableDarkMode ? -1 : null
+        this.enableDarkMode ? null : -1
       );
 
       return this.model

--- a/app/assets/javascripts/discourse/app/controllers/preferences/interface.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/interface.js
@@ -33,6 +33,7 @@ export default Controller.extend({
     let attrs = [
       "locale",
       "external_links_in_new_tab",
+      "dark_scheme_id",
       "dynamic_favicon",
       "enable_quoting",
       "enable_defer",
@@ -149,6 +150,20 @@ export default Controller.extend({
     return result;
   },
 
+  @discourseComputed
+  showDisableDarkMode() {
+    return this.siteSettings.default_dark_mode_color_scheme_id > 0;
+  },
+
+  disableDarkMode: computed({
+    set(key, value) {
+      return value;
+    },
+    get() {
+      return this.get("model.user_option.dark_scheme_id") === -1 ? true : false;
+    }
+  }),
+
   actions: {
     save() {
       this.set("saved", false);
@@ -161,6 +176,11 @@ export default Controller.extend({
       if (makeTextSizeDefault) {
         this.set("model.user_option.text_size", this.textSize);
       }
+
+      this.set(
+        "model.user_option.dark_scheme_id",
+        this.disableDarkMode ? -1 : null
+      );
 
       return this.model
         .save(this.saveAttrNames)

--- a/app/assets/javascripts/discourse/app/models/user.js
+++ b/app/assets/javascripts/discourse/app/models/user.js
@@ -300,6 +300,7 @@ const User = RestModel.extend({
       "email_messages_level",
       "email_level",
       "email_previous_replies",
+      "dark_scheme_id",
       "dynamic_favicon",
       "enable_quoting",
       "enable_defer",

--- a/app/assets/javascripts/discourse/app/templates/preferences/interface.hbs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/interface.hbs
@@ -20,11 +20,11 @@
   </div>
 {{/if}}
 
-{{#if showDisableDarkMode}}
+{{#if showDarkModeToggle}}
   <div class="control-group dark-mode">
     <label class="control-label">{{i18n "user.dark_mode"}}</label>
     <div class="controls">
-      {{preference-checkbox labelKey="user.dark_mode_disable" checked=disableDarkMode}}
+      {{preference-checkbox labelKey="user.dark_mode_enable" checked=enableDarkMode}}
     </div>
   </div>
 {{/if}}

--- a/app/assets/javascripts/discourse/app/templates/preferences/interface.hbs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/interface.hbs
@@ -20,6 +20,15 @@
   </div>
 {{/if}}
 
+{{#if showDisableDarkMode}}
+  <div class="control-group dark-mode">
+    <label class="control-label">{{i18n "user.dark_mode"}}</label>
+    <div class="controls">
+      {{preference-checkbox labelKey="user.dark_mode_disable" checked=disableDarkMode}}
+    </div>
+  </div>
+{{/if}}
+
 <div class="control-group text-size">
   <label class="control-label">{{i18n "user.text_size.title"}}</label>
   <div class="controls">

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -454,7 +454,9 @@ module ApplicationHelper
     result = +""
     result << Stylesheet::Manager.color_scheme_stylesheet_link_tag(scheme_id)
 
-    dark_scheme_id = SiteSetting.default_dark_mode_color_scheme_id
+    user_dark_scheme_id = current_user&.user_option&.dark_scheme_id
+    dark_scheme_id =  user_dark_scheme_id || SiteSetting.default_dark_mode_color_scheme_id
+
     if dark_scheme_id != -1
       result << Stylesheet::Manager.color_scheme_stylesheet_link_tag(dark_scheme_id, '(prefers-color-scheme: dark)')
     end

--- a/app/serializers/user_option_serializer.rb
+++ b/app/serializers/user_option_serializer.rb
@@ -8,6 +8,7 @@ class UserOptionSerializer < ApplicationSerializer
              :email_level,
              :email_messages_level,
              :external_links_in_new_tab,
+             :dark_scheme_id,
              :dynamic_favicon,
              :enable_quoting,
              :enable_defer,

--- a/app/services/user_updater.rb
+++ b/app/services/user_updater.rb
@@ -25,6 +25,7 @@ class UserUpdater
     :external_links_in_new_tab,
     :enable_quoting,
     :enable_defer,
+    :dark_scheme_id,
     :dynamic_favicon,
     :automatically_unpin_topics,
     :digest_after_minutes,

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -926,7 +926,7 @@ en:
       dynamic_favicon: "Show counts on browser icon"
       theme_default_on_all_devices: "Make this the default theme on all my devices"
       dark_mode: "Dark Mode"
-      dark_mode_disable: "Disable automatically switching the color scheme when your devices are in dark mode."
+      dark_mode_enable: "Enable automatic dark mode color scheme"
       text_size_default_on_all_devices: "Make this the default text size on all my devices"
       allow_private_messages: "Allow other users to send me personal messages"
       external_links_in_new_tab: "Open all external links in a new tab"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -925,6 +925,8 @@ en:
       first_notification: "Your first notification! Select it to begin."
       dynamic_favicon: "Show counts on browser icon"
       theme_default_on_all_devices: "Make this the default theme on all my devices"
+      dark_mode: "Dark Mode"
+      dark_mode_disable: "Disable automatically switching the color scheme when your devices are in dark mode."
       text_size_default_on_all_devices: "Make this the default text size on all my devices"
       allow_private_messages: "Allow other users to send me personal messages"
       external_links_in_new_tab: "Open all external links in a new tab"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -248,6 +248,7 @@ basic:
   default_dark_mode_color_scheme_id:
     default: -1
     hidden: true
+    client: true
   relative_date_duration:
     client: true
     default: 30

--- a/db/migrate/20200805151752_add_dark_scheme_id_to_user_options.rb
+++ b/db/migrate/20200805151752_add_dark_scheme_id_to_user_options.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDarkSchemeIdToUserOptions < ActiveRecord::Migration[6.0]
+  def change
+    add_column :user_options, :dark_scheme_id, :integer
+  end
+end

--- a/lib/stylesheet/manager.rb
+++ b/lib/stylesheet/manager.rb
@@ -93,12 +93,16 @@ class Stylesheet::Manager
     end
   end
 
-  def self.color_scheme_stylesheet_details(color_scheme_id = nil)
+  def self.color_scheme_stylesheet_details(color_scheme_id = nil, media)
     color_scheme = begin
       ColorScheme.find(color_scheme_id)
     rescue
+      # don't load fallback when requesting dark color scheme
+      return false if media != "all"
       Theme.find_by_id(SiteSetting.default_theme_id)&.color_scheme || ColorScheme.base
     end
+
+    return false if !color_scheme
 
     target = COLOR_SCHEME_STYLESHEET.to_sym
     current_hostname = Discourse.current_hostname
@@ -119,7 +123,9 @@ class Stylesheet::Manager
   end
 
   def self.color_scheme_stylesheet_link_tag(color_scheme_id = nil, media = 'all')
-    stylesheet = color_scheme_stylesheet_details(color_scheme_id)
+    stylesheet = color_scheme_stylesheet_details(color_scheme_id, media)
+    return '' if !stylesheet
+
     href = stylesheet[:new_href]
     %[<link href="#{href}" media="#{media}" rel="stylesheet"/>].html_safe
   end

--- a/spec/components/stylesheet/manager_spec.rb
+++ b/spec/components/stylesheet/manager_spec.rb
@@ -177,9 +177,14 @@ describe Stylesheet::Manager do
       expect(link).not_to eq("")
     end
 
-    it "does not crash on missing color scheme" do
+    it "loads base scheme when defined scheme id is missing" do
       link = Stylesheet::Manager.color_scheme_stylesheet_link_tag(125)
-      expect(link).not_to eq("")
+      expect(link).to include("color_definitions_base")
+    end
+
+    it "loads nothing when defined dark scheme id is missing" do
+      link = Stylesheet::Manager.color_scheme_stylesheet_link_tag(125, "(prefers-color-scheme: dark)")
+      expect(link).to eq("")
     end
 
     it "uses the correct color scheme from the default site theme" do

--- a/test/javascripts/acceptance/preferences-test.js
+++ b/test/javascripts/acceptance/preferences-test.js
@@ -479,3 +479,19 @@ QUnit.test("can select an option from a dropdown", async assert => {
   await field.selectRowByValue("Cat");
   assert.equal(field.header().value(), "Cat", "it sets the value of the field");
 });
+
+acceptance("User Preferences disabling dark mode", {
+  loggedIn: true,
+  settings: { default_dark_mode_color_scheme_id: 1 }
+});
+
+QUnit.test("shows option to disable dark mode", async assert => {
+  await visit("/u/eviltrout/preferences/interface");
+  assert.ok(
+    $(".control-group.dark-mode").length,
+    "it has the option to disable dark mode"
+  );
+  await click(".control-group.dark-mode .checkbox-label");
+
+  pauseTest();
+});

--- a/test/javascripts/acceptance/preferences-test.js
+++ b/test/javascripts/acceptance/preferences-test.js
@@ -491,7 +491,4 @@ QUnit.test("shows option to disable dark mode", async assert => {
     $(".control-group.dark-mode").length,
     "it has the option to disable dark mode"
   );
-  await click(".control-group.dark-mode .checkbox-label");
-
-  pauseTest();
 });


### PR DESCRIPTION
When admins have enabled automatic dark mode via the `default_dark_mode_color_scheme_id` site setting, users will see a new checkbox in ther interface preferences that lets them disable auto dark mode switching. 

<img width="843" alt="image" src="https://user-images.githubusercontent.com/368961/89484245-17906400-d76c-11ea-9c31-881acdce48c4.png">
