### PR TITLE
FEATURE: set notification levels when added to a group

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/group-manage-categories.js
+++ b/app/assets/javascripts/discourse/app/controllers/group-manage-categories.js
@@ -1,0 +1,14 @@
+import discourseComputed from "discourse-common/utils/decorators";
+import Controller from "@ember/controller";
+
+export default Controller.extend({
+  @discourseComputed(
+    "model.watchingCategories.[]",
+    "model.watchingFirstPostCategories.[]",
+    "model.trackingCategories.[]",
+    "model.mutedCategories.[]"
+  )
+  selectedCategories(watching, watchingFirst, tracking, muted) {
+    return [].concat(watching, watchingFirst, tracking, muted).filter(t => t);
+  },
+});

--- a/app/assets/javascripts/discourse/app/controllers/group-manage-categories.js
+++ b/app/assets/javascripts/discourse/app/controllers/group-manage-categories.js
@@ -10,5 +10,5 @@ export default Controller.extend({
   )
   selectedCategories(watching, watchingFirst, tracking, muted) {
     return [].concat(watching, watchingFirst, tracking, muted).filter(t => t);
-  },
+  }
 });

--- a/app/assets/javascripts/discourse/app/controllers/group-manage-tags.js
+++ b/app/assets/javascripts/discourse/app/controllers/group-manage-tags.js
@@ -1,0 +1,14 @@
+import discourseComputed from "discourse-common/utils/decorators";
+import Controller from "@ember/controller";
+
+export default Controller.extend({
+  @discourseComputed(
+    "model.watching_tags.[]",
+    "model.watching_first_post_tags.[]",
+    "model.tracking_tags.[]",
+    "model.muted_tags.[]"
+  )
+  selectedTags(watching, watchingFirst, tracking, muted) {
+    return [].concat(watching, watchingFirst, tracking, muted).filter(t => t);
+  },
+});

--- a/app/assets/javascripts/discourse/app/controllers/group-manage-tags.js
+++ b/app/assets/javascripts/discourse/app/controllers/group-manage-tags.js
@@ -10,5 +10,5 @@ export default Controller.extend({
   )
   selectedTags(watching, watchingFirst, tracking, muted) {
     return [].concat(watching, watchingFirst, tracking, muted).filter(t => t);
-  },
+  }
 });

--- a/app/assets/javascripts/discourse/app/controllers/group-manage.js
+++ b/app/assets/javascripts/discourse/app/controllers/group-manage.js
@@ -13,6 +13,14 @@ export default Controller.extend({
         route: "group.manage.interaction",
         title: "groups.manage.interaction.title"
       },
+      {
+        route: "group.manage.categories",
+        title: "groups.manage.categories.title"
+      },
+      {
+        route: "group.manage.tags",
+        title: "groups.manage.tags.title"
+      },
 
       { route: "group.manage.logs", title: "groups.manage.logs.title" }
     ];

--- a/app/assets/javascripts/discourse/app/models/group.js
+++ b/app/assets/javascripts/discourse/app/models/group.js
@@ -176,6 +176,35 @@ const Group = RestModel.extend({
     }
   },
 
+  @observes("watching_category_ids")
+  _updateWatchingCategories() {
+    this.set(
+      "watchingCategories",
+      Category.findByIds(this.watching_category_ids)
+    );
+  },
+
+  @observes("tracking_category_ids")
+  _updateTrackingCategories() {
+    this.set(
+      "trackingCategories",
+      Category.findByIds(this.tracking_category_ids)
+    );
+  },
+
+  @observes("watching_first_post_category_ids")
+  _updateWatchingFirstPostCategories() {
+    this.set(
+      "watchingFirstPostCategories",
+      Category.findByIds(this.watching_first_post_category_ids)
+    );
+  },
+
+  @observes("muted_category_ids")
+  _updateMutedCategories() {
+    this.set("mutedCategories", Category.findByIds(this.muted_category_ids));
+  },
+
   asJSON() {
     const attrs = {
       name: this.name,
@@ -210,6 +239,26 @@ const Group = RestModel.extend({
       membership_request_template: this.membership_request_template,
       publish_read_state: this.publish_read_state
     };
+
+    ["muted", "watching", "tracking", "watching_first_post"].forEach(s => {
+      let prop =
+        s === "watching_first_post"
+          ? "watchingFirstPostCategories"
+          : s + "Categories";
+
+      let categories = this.get(prop);
+
+      if (categories) {
+        attrs[s + "_category_ids"] =
+          categories.length > 0 ? categories.map(c => c.get("id")) : [-1];
+      }
+
+      let tags = this.get(s + "_tags");
+
+      if (tags) {
+        attrs[s + "_tags"] = tags.length > 0 ? tags : [""];
+      }
+    });
 
     if (this.flair_type === "icon") {
       attrs["flair_icon"] = this.flair_icon;

--- a/app/assets/javascripts/discourse/app/routes/app-route-map.js
+++ b/app/assets/javascripts/discourse/app/routes/app-route-map.js
@@ -94,6 +94,8 @@ export default function() {
       this.route("interaction");
       this.route("email");
       this.route("members");
+      this.route("categories");
+      this.route("tags");
       this.route("logs");
     });
 

--- a/app/assets/javascripts/discourse/app/routes/group-manage-categories.js
+++ b/app/assets/javascripts/discourse/app/routes/group-manage-categories.js
@@ -1,0 +1,10 @@
+import I18n from "I18n";
+import DiscourseRoute from "discourse/routes/discourse";
+
+export default DiscourseRoute.extend({
+  showFooter: true,
+
+  titleToken() {
+    return I18n.t("groups.manage.categories.title");
+  }
+});

--- a/app/assets/javascripts/discourse/app/routes/group-manage-tags.js
+++ b/app/assets/javascripts/discourse/app/routes/group-manage-tags.js
@@ -1,0 +1,10 @@
+import I18n from "I18n";
+import DiscourseRoute from "discourse/routes/discourse";
+
+export default DiscourseRoute.extend({
+  showFooter: true,
+
+  titleToken() {
+    return I18n.t("groups.manage.tags.title");
+  }
+});

--- a/app/assets/javascripts/discourse/app/templates/group/manage/categories.hbs
+++ b/app/assets/javascripts/discourse/app/templates/group/manage/categories.hbs
@@ -1,0 +1,64 @@
+<form class="groups-form form-vertical groups-notifications-form">
+  <div class="control-group">
+    <label class="control-label">{{i18n "groups.manage.categories.long_title"}}</label>
+    <div>{{i18n "groups.manage.categories.description"}}</div>
+  </div>
+
+  <div class="control-group">
+    <label>{{d-icon "d-watching"}} {{i18n "user.watched_categories"}}</label>
+
+    {{category-selector
+      categories=model.watchingCategories
+      blacklist=selectedCategories
+      onChange=(action (mut model.watchingCategories))
+    }}
+
+    <div class="control-instructions">
+      {{i18n "groups.manage.categories.watched_categories_instructions"}}
+    </div>
+  </div>
+
+  <div class="control-group">
+    <label>{{d-icon "d-tracking"}} {{i18n "user.tracked_categories"}}</label>
+
+    {{category-selector
+      categories=model.trackingCategories
+      blacklist=selectedCategories
+      onChange=(action (mut model.trackingCategories))
+    }}
+
+    <div class="control-instructions">
+      {{i18n "groups.manage.categories.tracked_categories_instructions"}}
+    </div>
+  </div>
+
+  <div class="control-group">
+    <label>{{d-icon "d-watching-first"}} {{i18n "user.watched_first_post_categories"}}</label>
+
+    {{category-selector
+      categories=model.watchingFirstPostCategories
+      blacklist=selectedCategories
+      onChange=(action (mut model.watchingFirstPostCategories))
+    }}
+
+    <div class="control-instructions">
+      {{i18n "groups.manage.categories.watching_first_post_categories_instructions"}}
+    </div>
+  </div>
+
+  <div class="control-group">
+    <label>{{d-icon "d-muted"}} {{i18n "user.muted_categories"}}</label>
+
+    {{category-selector
+      categories=model.mutedCategories
+      blacklist=selectedCategories
+      onChange=(action (mut model.mutedCategories))
+    }}
+
+    <div class="control-instructions">
+      {{i18n "groups.manage.categories.muted_categories_instructions"}}
+    </div>
+  </div>
+
+  {{group-manage-save-button model=model}}
+</form>

--- a/app/assets/javascripts/discourse/app/templates/group/manage/tags.hbs
+++ b/app/assets/javascripts/discourse/app/templates/group/manage/tags.hbs
@@ -1,0 +1,72 @@
+<form class="groups-form form-vertical groups-notifications-form">
+  <div class="control-group">
+    <label class="control-label">{{i18n "groups.manage.tags.long_title"}}</label>
+    <div>{{i18n "groups.manage.tags.description"}}</div>
+  </div>
+
+  <div class="control-group">
+    <label>{{d-icon "d-watching"}} {{i18n "user.watched_tags"}}</label>
+
+    {{tag-chooser
+      tags=model.watching_tags
+      blacklist=selectedTags
+      allowCreate=false
+      everyTag=true
+      unlimitedTagCount=true
+    }}
+
+    <div class="control-instructions">
+      {{i18n "groups.manage.tags.watched_tags_instructions"}}
+    </div>
+  </div>
+
+  <div class="control-group">
+    <label>{{d-icon "d-tracking"}} {{i18n "user.tracked_tags"}}</label>
+
+    {{tag-chooser
+      tags=model.tracking_tags
+      blacklist=selectedTags
+      allowCreate=false
+      everyTag=true
+      unlimitedTagCount=true
+    }}
+
+    <div class="control-instructions">
+      {{i18n "groups.manage.tags.tracked_tags_instructions"}}
+    </div>
+  </div>
+
+  <div class="control-group">
+    <label>{{d-icon "d-watching-first"}} {{i18n "user.watched_first_post_tags"}}</label>
+
+    {{tag-chooser
+      tags=model.watching_first_post_tags
+      blacklist=selectedTags
+      allowCreate=false
+      everyTag=true
+      unlimitedTagCount=true
+    }}
+
+    <div class="control-instructions">
+      {{i18n "groups.manage.tags.watching_first_post_tags_instructions"}}
+    </div>
+  </div>
+
+  <div class="control-group">
+    <label>{{d-icon "d-muted"}} {{i18n "user.muted_tags"}}</label>
+
+    {{tag-chooser
+      tags=model.muted_tags
+      blacklist=selectedTags
+      allowCreate=false
+      everyTag=true
+      unlimitedTagCount=true
+    }}
+
+    <div class="control-instructions">
+      {{i18n "groups.manage.tags.muted_tags_instructions"}}
+    </div>
+  </div>
+
+  {{group-manage-save-button model=model}}
+</form>

--- a/app/assets/stylesheets/common/base/groups.scss
+++ b/app/assets/stylesheets/common/base/groups.scss
@@ -146,4 +146,17 @@
   .control-group-inline {
     display: inline;
   }
+  &.groups-notifications-form {
+    .control-instructions {
+      color: $primary-medium;
+      margin-bottom: 10px;
+      font-size: $font-down-1;
+      line-height: $line-height-large;
+    }
+
+    .category-selector,
+    .tag-chooser {
+      width: 100%;
+    }
+  }
 }

--- a/app/assets/stylesheets/desktop/group.scss
+++ b/app/assets/stylesheets/desktop/group.scss
@@ -50,3 +50,8 @@
   top: 20px;
   right: 20px;
 }
+
+.groups-form.groups-notifications-form {
+  width: 500px;
+  max-width: 100%;
+}

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -604,6 +604,13 @@ class GroupsController < ApplicationController
         default_params
       end
 
+    if !automatic || current_user.admin
+      [:muted, :tracking, :watching, :watching_first_post].each do |level|
+        permitted_params << { "#{level}_category_ids" => [] }
+        permitted_params << { "#{level}_tags" => [] }
+      end
+    end
+
     params.require(:group).permit(*permitted_params)
   end
 

--- a/app/models/concerns/roleable.rb
+++ b/app/models/concerns/roleable.rb
@@ -23,6 +23,7 @@ module Roleable
     set_permission('moderator', true)
     auto_approve_user
     enqueue_staff_welcome_message(:moderator)
+    set_default_notification_levels(:moderators)
   end
 
   def revoke_moderation!
@@ -34,6 +35,7 @@ module Roleable
     set_permission('admin', true)
     auto_approve_user
     enqueue_staff_welcome_message(:admin)
+    set_default_notification_levels(:admins)
   end
 
   def revoke_admin!
@@ -50,6 +52,13 @@ module Roleable
   def set_permission(permission_name, value)
     self.public_send("#{permission_name}=", value)
     save_and_refresh_staff_groups!
+  end
+
+  def set_default_notification_levels(group_name)
+    Group.set_category_and_tag_default_notification_levels!(self, group_name)
+    if group_name == :admins || group_name == :moderators
+      Group.set_category_and_tag_default_notification_levels!(self, :staff)
+    end
   end
 
   private

--- a/app/models/group_category_notification_default.rb
+++ b/app/models/group_category_notification_default.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+class GroupCategoryNotificationDefault < ActiveRecord::Base
+  belongs_to :group
+  belongs_to :category
+
+  def self.notification_levels
+    NotificationLevels.all
+  end
+
+  def self.lookup(group, level)
+    self.where(group: group, notification_level: notification_levels[level])
+  end
+
+  def self.batch_set(group, level, category_ids)
+    level_num = notification_levels[level]
+    category_ids = Category.where(id: category_ids).pluck(:id)
+
+    changed = false
+
+    # Update pre-existing
+    if category_ids.present? && GroupCategoryNotificationDefault
+        .where(group_id: group.id, category_id: category_ids)
+        .where.not(notification_level: level_num)
+        .update_all(notification_level: level_num) > 0
+
+      changed = true
+    end
+
+    # Remove extraneous category users
+    if GroupCategoryNotificationDefault
+        .where(group_id: group.id, notification_level: level_num)
+        .where.not(category_id: category_ids)
+        .delete_all > 0
+
+      changed = true
+    end
+
+    if category_ids.present?
+      params = {
+        group_id: group.id,
+        level_num: level_num,
+      }
+
+      sql = <<~SQL
+        INSERT INTO group_category_notification_defaults (group_id, category_id, notification_level)
+        SELECT :group_id, :category_id, :level_num
+        ON CONFLICT DO NOTHING
+      SQL
+
+      # we could use VALUES here but it would introduce a string
+      # into the query, plus it is a bit of a micro optimisation
+      category_ids.each do |category_id|
+        params[:category_id] = category_id
+        if DB.exec(sql, params) > 0
+          changed = true
+        end
+      end
+    end
+
+    changed
+  end
+end
+
+# == Schema Information
+#
+# Table name: group_category_notification_defaults
+#
+#  id                 :bigint           not null, primary key
+#  group_id           :integer          not null
+#  category_id        :integer          not null
+#  notification_level :integer          not null
+#
+# Indexes
+#
+#  idx_group_category_notification_defaults_unique  (group_id,category_id) UNIQUE
+#

--- a/app/models/group_tag_notification_default.rb
+++ b/app/models/group_tag_notification_default.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+class GroupTagNotificationDefault < ActiveRecord::Base
+  belongs_to :group
+  belongs_to :tag
+
+  def self.notification_levels
+    NotificationLevels.all
+  end
+
+  def self.lookup(group, level)
+    self.where(group: group, notification_level: notification_levels[level])
+  end
+
+  def self.batch_set(group, level, tag_names)
+    tag_names ||= []
+    changed = false
+
+    records = self.where(group: group, notification_level: notification_levels[level])
+    old_ids = records.pluck(:tag_id)
+
+    tag_ids = tag_names.empty? ? [] : Tag.where_name(tag_names).pluck(:id)
+
+    Tag.where_name(tag_names).joins(:target_tag).each do |tag|
+      tag_ids[tag_ids.index(tag.id)] = tag.target_tag_id
+    end
+
+    tag_ids.uniq!
+
+    remove = (old_ids - tag_ids)
+    if remove.present?
+      records.where('tag_id in (?)', remove).destroy_all
+      changed = true
+    end
+
+    (tag_ids - old_ids).each do |id|
+      self.create!(group: group, tag_id: id, notification_level: notification_levels[level])
+      changed = true
+    end
+
+    changed
+  end
+end
+
+# == Schema Information
+#
+# Table name: group_tag_notification_defaults
+#
+#  id                 :bigint           not null, primary key
+#  group_id           :integer          not null
+#  tag_id             :integer          not null
+#  notification_level :integer          not null
+#
+# Indexes
+#
+#  idx_group_tag_notification_defaults_unique  (group_id,tag_id) UNIQUE
+#

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -672,6 +672,22 @@ en:
         membership:
           title: Membership
           access: Access
+        categories:
+          title: Categories
+          long_title: "Category default notifications"
+          description: "When users are added to this group, their category notification settings will be set to these defaults. Afterwards, they can change them."
+          watched_categories_instructions: "Automatically watch all topics in these categories. Group members will be notified of all new posts and topics, and a count of new posts will also appear next to the topic."
+          tracked_categories_instructions: "Automatically track all topics in these categories. A count of new posts will appear next to the topic."
+          watching_first_post_categories_instructions: "Users will be notified of the first post in each new topic in these categories."
+          muted_categories_instructions: "Users will not be notified of anything about new topics in these categories, and they will not appear on the categories or latest topics pages."
+        tags:
+          title: Tags
+          long_title: "Tags default notifications"
+          description: "When users are added to this group, their tag notification settings will be set to these defaults. Afterwards, they can change them."
+          watched_tags_instructions: "Automatically watch all topics with these tags. Group members will be notified of all new posts and topics, and a count of new posts will also appear next to the topic."
+          tracked_tags_instructions: "Automatically track all topics with these tags. A count of new posts will appear next to the topic."
+          watching_first_post_tags_instructions: "Users will be notified of the first post in each new topic with these tags."
+          muted_tags_instructions: "Users will not be notified of anything about new topics with these tags, and they will not appear in latest."
         logs:
           title: "Logs"
           when: "When"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -577,6 +577,8 @@ Discourse::Application.routes.draw do
             manage/membership
             manage/interaction
             manage/email
+            manage/categories
+            manage/tags
             manage/logs
           }.each do |path|
             get path => 'groups#show'

--- a/db/migrate/20200730205554_create_group_default_tracking.rb
+++ b/db/migrate/20200730205554_create_group_default_tracking.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class CreateGroupDefaultTracking < ActiveRecord::Migration[6.0]
+  def change
+    create_table :group_category_notification_defaults do |t|
+      t.integer :group_id, null: false
+      t.integer :category_id, null: false
+      t.integer :notification_level, null: false
+    end
+
+    add_index :group_category_notification_defaults,
+      [:group_id, :category_id],
+      unique: true,
+      name: :idx_group_category_notification_defaults_unique
+
+    create_table :group_tag_notification_defaults do |t|
+      t.integer :group_id, null: false
+      t.integer :tag_id, null: false
+      t.integer :notification_level, null: false
+    end
+
+    add_index :group_tag_notification_defaults,
+      [:group_id, :tag_id],
+      unique: true,
+      name: :idx_group_tag_notification_defaults_unique
+  end
+end

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -615,6 +615,8 @@ describe GroupsController do
         public_exit: false
       )
     end
+    let(:category) { Fabricate(:category) }
+    let(:tag) { Fabricate(:tag) }
 
     context "custom_fields" do
       before do
@@ -688,7 +690,9 @@ describe GroupsController do
               allow_membership_requests: true,
               membership_request_template: 'testing',
               default_notification_level: 1,
-              name: 'testing'
+              name: 'testing',
+              tracking_category_ids: [category.id],
+              tracking_tags: [tag.name]
             }
           }
         end.to change { GroupHistory.count }.by(13)
@@ -716,6 +720,8 @@ describe GroupsController do
         expect(group.primary_group).to eq(false)
         expect(group.incoming_email).to eq(nil)
         expect(group.grant_trust_level).to eq(0)
+        expect(group.group_category_notification_defaults.first&.category).to eq(category)
+        expect(group.group_tag_notification_defaults.first&.tag).to eq(tag)
       end
 
       it 'should not be allowed to update automatic groups' do
@@ -753,7 +759,9 @@ describe GroupsController do
             automatic_membership_email_domains: 'test.org',
             grant_trust_level: 2,
             visibility_level: 1,
-            members_visibility_level: 3
+            members_visibility_level: 3,
+            tracking_category_ids: [category.id],
+            tracking_tags: [tag.name]
           }
         }
 
@@ -768,6 +776,8 @@ describe GroupsController do
         expect(group.members_visibility_level).to eq(3)
         expect(group.automatic_membership_email_domains).to eq('test.org')
         expect(group.grant_trust_level).to eq(2)
+        expect(group.group_category_notification_defaults.first&.category).to eq(category)
+        expect(group.group_tag_notification_defaults.first&.tag).to eq(tag)
 
         expect(Jobs::AutomaticGroupMembership.jobs.first["args"].first["group_id"])
           .to eq(group.id)
@@ -790,7 +800,9 @@ describe GroupsController do
             visibility_level: 1,
             mentionable_level: 1,
             messageable_level: 1,
-            default_notification_level: 1
+            default_notification_level: 1,
+            tracking_category_ids: [category.id],
+            tracking_tags: [tag.name]
           }
         }
 
@@ -803,6 +815,8 @@ describe GroupsController do
         expect(group.mentionable_level).to eq(1)
         expect(group.messageable_level).to eq(1)
         expect(group.default_notification_level).to eq(1)
+        expect(group.group_category_notification_defaults.first&.category).to eq(category)
+        expect(group.group_tag_notification_defaults.first&.tag).to eq(tag)
       end
 
       it 'triggers a extensibility event' do

--- a/test/javascripts/acceptance/group-manage-categories-test.js
+++ b/test/javascripts/acceptance/group-manage-categories-test.js
@@ -1,0 +1,33 @@
+import { acceptance, updateCurrentUser } from "helpers/qunit-helpers";
+
+acceptance("Managing Group Category Notification Defaults");
+QUnit.test("As an anonymous user", async assert => {
+  await visit("/g/discourse/manage/categories");
+
+  assert.ok(
+    count(".group-members tr") > 0,
+    "it should redirect to members page for an anonymous user"
+  );
+});
+
+acceptance("Managing Group Category Notification Defaults", { loggedIn: true });
+
+QUnit.test("As an admin", async assert => {
+  await visit("/g/discourse/manage/categories");
+
+  assert.ok(
+    find(".groups-notifications-form .category-selector").length === 4,
+    "it should display category inputs"
+  );
+});
+
+QUnit.test("As a group owner", async assert => {
+  updateCurrentUser({ moderator: false, admin: false });
+
+  await visit("/g/discourse/manage/categories");
+
+  assert.ok(
+    find(".groups-notifications-form .category-selector").length === 4,
+    "it should display category inputs"
+  );
+});

--- a/test/javascripts/acceptance/group-manage-tags-test.js
+++ b/test/javascripts/acceptance/group-manage-tags-test.js
@@ -1,0 +1,33 @@
+import { acceptance, updateCurrentUser } from "helpers/qunit-helpers";
+
+acceptance("Managing Group Tag Notification Defaults");
+QUnit.test("As an anonymous user", async assert => {
+  await visit("/g/discourse/manage/tags");
+
+  assert.ok(
+    count(".group-members tr") > 0,
+    "it should redirect to members page for an anonymous user"
+  );
+});
+
+acceptance("Managing Group Tag Notification Defaults", { loggedIn: true });
+
+QUnit.test("As an admin", async assert => {
+  await visit("/g/discourse/manage/tags");
+
+  assert.ok(
+    find(".groups-notifications-form .tag-chooser").length === 4,
+    "it should display tag inputs"
+  );
+});
+
+QUnit.test("As a group owner", async assert => {
+  updateCurrentUser({ moderator: false, admin: false });
+
+  await visit("/g/discourse/manage/tags");
+
+  assert.ok(
+    find(".groups-notifications-form .tag-chooser").length === 4,
+    "it should display tag inputs"
+  );
+});


### PR DESCRIPTION
This feature allows admins and group owners to define default
category and tag tracking levels that will be applied to user
preferences automatically at the time when users are added to the
group. Users are free to change those preferences afterwards.
When removed from a group, the user's notification preferences aren't
changed.