### PR TITLE
DEV: Plugins can extend color definitions

### DIFF
--- a/lib/discourse_plugin_registry.rb
+++ b/lib/discourse_plugin_registry.rb
@@ -54,6 +54,7 @@ class DiscoursePluginRegistry
   define_register :stylesheets, Hash
   define_register :mobile_stylesheets, Hash
   define_register :desktop_stylesheets, Hash
+  define_register :color_definition_stylesheets, Hash
   define_register :sass_variables, Set
   define_register :handlebars, Set
   define_register :serialized_current_user_fields, Set
@@ -153,6 +154,8 @@ class DiscoursePluginRegistry
       elsif opts == :desktop
         self.desktop_stylesheets[plugin_directory_name] ||= Set.new
         self.desktop_stylesheets[plugin_directory_name] << asset
+      elsif opts == :color_definitions
+        self.color_definition_stylesheets[plugin_directory_name] = asset
       elsif opts == :variables
         self.sass_variables << asset
       else

--- a/lib/stylesheet/compiler.rb
+++ b/lib/stylesheet/compiler.rb
@@ -19,6 +19,10 @@ module Stylesheet
         filename = "#{asset}.scss"
         path = "#{Stylesheet::Common::ASSET_ROOT}/#{filename}"
         file = File.read path
+
+        if asset.to_s == Stylesheet::Manager::COLOR_SCHEME_STYLESHEET
+          file += Stylesheet::Importer.import_color_definitions
+        end
       end
 
       compile(file, filename, options)

--- a/lib/stylesheet/importer.rb
+++ b/lib/stylesheet/importer.rb
@@ -115,6 +115,17 @@ module Stylesheet
 
     register_imports!
 
+    def self.import_color_definitions
+      return "" unless DiscoursePluginRegistry.color_definition_stylesheets.length
+      contents = +""
+      DiscoursePluginRegistry.color_definition_stylesheets.each do |name, path|
+        contents << "// Color definitions from #{name}\n\n"
+        contents << File.read(path.to_s)
+        contents << "\n\n"
+      end
+      contents
+    end
+
     def initialize(options)
       @theme = options[:theme]
       @theme_id = options[:theme_id]

--- a/spec/components/discourse_plugin_registry_spec.rb
+++ b/spec/components/discourse_plugin_registry_spec.rb
@@ -227,6 +227,12 @@ describe DiscoursePluginRegistry do
       expect(registry.stylesheets[plugin_directory_name]).to eq(nil)
     end
 
+    it "registers color definitions properly" do
+      registry.register_asset("test.css", :color_definitions, plugin_directory_name)
+      expect(registry.color_definition_stylesheets[plugin_directory_name]).to eq('test.css')
+      expect(registry.stylesheets[plugin_directory_name]).to eq(nil)
+    end
+
     it "registers sass variable properly" do
       registry.register_asset("test.css", :variables)
 

--- a/spec/components/plugin/instance_spec.rb
+++ b/spec/components/plugin/instance_spec.rb
@@ -11,8 +11,8 @@ describe Plugin::Instance do
   context "find_all" do
     it "can find plugins correctly" do
       plugins = Plugin::Instance.find_all("#{Rails.root}/spec/fixtures/plugins")
-      expect(plugins.count).to eq(3)
-      plugin = plugins[2]
+      expect(plugins.count).to eq(4)
+      plugin = plugins[3]
 
       expect(plugin.name).to eq("plugin-name")
       expect(plugin.path).to eq("#{Rails.root}/spec/fixtures/plugins/my_plugin/plugin.rb")

--- a/spec/components/stylesheet/compiler_spec.rb
+++ b/spec/components/stylesheet/compiler_spec.rb
@@ -84,5 +84,26 @@ describe Stylesheet::Compiler do
       expect(css).to include("--header_primary: #88af8e")
       expect(css).to include("--header_background-rgb: 248,116,92")
     end
+
+    context "with a plugin" do
+      before do
+        plugin = Plugin::Instance.new
+        plugin.path = "#{Rails.root}/spec/fixtures/plugins/color_definition/plugin.rb"
+        Discourse.plugins << plugin
+        plugin.activate!
+      end
+
+      after do
+        Discourse.plugins.pop
+        DiscoursePluginRegistry.reset!
+      end
+
+      it "does not include theme variables in plugins" do
+        css, _map = Stylesheet::Compiler.compile_asset("color_definitions")
+
+        expect(css).to include("--plugin-color")
+      end
+    end
+
   end
 end

--- a/spec/components/stylesheet/compiler_spec.rb
+++ b/spec/components/stylesheet/compiler_spec.rb
@@ -98,7 +98,7 @@ describe Stylesheet::Compiler do
         DiscoursePluginRegistry.reset!
       end
 
-      it "does not include theme variables in plugins" do
+      it "includes color definitions from plugins" do
         css, _map = Stylesheet::Compiler.compile_asset("color_definitions")
 
         expect(css).to include("--plugin-color")

--- a/spec/fixtures/plugins/color_definition/assets/stylesheets/colors.scss
+++ b/spec/fixtures/plugins/color_definition/assets/stylesheets/colors.scss
@@ -1,0 +1,3 @@
+:root {
+  --plugin-color: #{$primary};
+}

--- a/spec/fixtures/plugins/color_definition/plugin.rb
+++ b/spec/fixtures/plugins/color_definition/plugin.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# name: color_definition
+# about: Fixture plugin that extends color definitions
+# version: 1.0
+# authors: pmusaraj
+
+register_asset "stylesheets/colors.scss", :color_definitions


### PR DESCRIPTION
Since https://github.com/discourse/discourse/commit/c937afc75ec1fdf4fa2a5a3d76161c40272d0518, core uses CSS custom properties for colors. This PR allows plugins to add their own variations to the color definition stylesheets, therefore allowing for custom color variations that adjust correctly when switching to dark mode. 

Here is an example of a plugin with a custom color variation: 

```scss
.element {
  background: dark-light-choose(lighten($tertiary, 55%), darken($tertiary, 25%));
}
```

To properly support color scheme switching, the plugin should include a new SCSS file at `assets/stylesheets/colors.scss` with the following contents: 

```scss
:root {
  --custom-tertiary: #{dark-light-choose(
      lighten($tertiary, 55%),
      darken($tertiary, 25%)
    )};
}
```

It should register that stylesheet in `plugin.rb` via: 

```ruby
register_asset "stylesheets/colors.scss", :color_definitions
```

and then in the original stylesheet, it should replace the SCSS variable with the newly declared custom property: 

```scss
.element {
  background: var(--custom-tertiary);
}
```