### PR TITLE
FEATURE: add advanced order to search

### DIFF
--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -190,6 +190,22 @@ class Plugin::Instance
     DiscoursePluginRegistry.register_editable_group_custom_field(field, self)
   end
 
+  # Allows to define custom search order. Example usage:
+  #   Search.advanced_order(:chars) do |posts|
+  #     posts.reorder("(SELECT LENGTH(raw) FROM posts WHERE posts.topic_id = subquery.topic_id) DESC")
+  #   end
+  def register_search_advanced_order(trigger, &block)
+    Search.advanced_order(trigger, &block)
+  end
+
+  # Allows to define custom search filters. Example usage:
+  #   Search.advanced_filter(/^min_chars:(\d+)$/) do |posts, match|
+  #     posts.where("(SELECT LENGTH(p2.raw) FROM posts p2 WHERE p2.id = posts.id) >= ?", match.to_i)
+  #   end
+  def register_search_advanced_filter(trigger, &block)
+    Search.advanced_filter(trigger, &block)
+  end
+
   # Request a new size for topic thumbnails
   # Will respect plugin enabled setting is enabled
   # Size should be an array with two elements [max_width, max_height]

--- a/lib/search.rb
+++ b/lib/search.rb
@@ -1013,8 +1013,10 @@ class Search
       posts = aggregate_relation.from(posts)
     end
 
-    advanced_order = Search.advanced_orders&.fetch(@order, nil)
-    posts = advanced_order.call(posts) if advanced_order
+    if @order
+      advanced_order = Search.advanced_orders&.fetch(@order, nil)
+      posts = advanced_order.call(posts) if advanced_order
+    end
 
     posts = posts.offset(offset)
     posts.limit(limit)

--- a/lib/search.rb
+++ b/lib/search.rb
@@ -667,7 +667,7 @@ class Search
         end
       end
 
-      if word == 'order:latest' || word == 'l'
+      if word == 'l'
         @order = :latest
         nil
       elsif word =~ /order:\w+/

--- a/spec/components/search_spec.rb
+++ b/spec/components/search_spec.rb
@@ -1690,4 +1690,33 @@ describe Search do
     end
   end
 
+  context "advanced filter" do
+    let!(:topic0) { Fabricate(:topic, title: 'I am first topic about advanced filter') }
+    let!(:post0) { Fabricate(:post, raw: 'this is the first post about advanced filter with length more than 50 chars') }
+    let!(:topic1) { Fabricate(:topic, title: 'I am second topic about advanced filter') }
+    let!(:post1) { Fabricate(:post, raw: 'this is the second post about advanced filter') }
+
+    it 'allows to define custom filter' do
+      expect(Search.new("advanced").execute.posts).to eq([post1, post0])
+      Search.advanced_filter(/^min_chars:(\d+)$/) do |posts, match|
+        posts.where("(SELECT LENGTH(p2.raw) FROM posts p2 WHERE p2.id = posts.id) >= ?", match.to_i)
+      end
+      expect(Search.new("advanced min_chars:50").execute.posts).to eq([post0])
+    end
+  end
+
+  context "advanced order" do
+    let!(:topic0) { Fabricate(:topic, title: 'I am first topic about advanced order') }
+    let!(:post0) { Fabricate(:post, raw: 'this is the first post about advanced order with length more than 50 chars') }
+    let!(:topic1) { Fabricate(:topic, title: 'I am second topic about advanced order') }
+    let!(:post1) { Fabricate(:post, raw: 'this is the second post about advanced order') }
+
+    it 'allows to define custom order' do
+      expect(Search.new("advanced").execute.posts).to eq([post1, post0])
+      Search.advanced_order(:chars) do |posts|
+        posts.reorder("(SELECT LENGTH(raw) FROM posts WHERE posts.topic_id = subquery.topic_id) DESC")
+      end
+      expect(Search.new("advanced order:chars").execute.posts).to eq([post0, post1])
+    end
+  end
 end

--- a/spec/components/search_spec.rb
+++ b/spec/components/search_spec.rb
@@ -1690,7 +1690,7 @@ describe Search do
     end
   end
 
-  context "advanced filter" do
+  context 'plugin extensions' do
     let!(:post0) { Fabricate(:post, raw: 'this is the first post about advanced filter with length more than 50 chars') }
     let!(:post1) { Fabricate(:post, raw: 'this is the second post about advanced filter') }
 
@@ -1701,11 +1701,6 @@ describe Search do
       end
       expect(Search.new("advanced min_chars:50").execute.posts).to eq([post0])
     end
-  end
-
-  context "advanced order" do
-    let!(:post0) { Fabricate(:post, raw: 'this is the first post about advanced order with length more than 50 chars') }
-    let!(:post1) { Fabricate(:post, raw: 'this is the second post about advanced order') }
 
     it 'allows to define custom order' do
       expect(Search.new("advanced").execute.posts).to eq([post1, post0])

--- a/spec/components/search_spec.rb
+++ b/spec/components/search_spec.rb
@@ -1691,9 +1691,7 @@ describe Search do
   end
 
   context "advanced filter" do
-    let!(:topic0) { Fabricate(:topic, title: 'I am first topic about advanced filter') }
     let!(:post0) { Fabricate(:post, raw: 'this is the first post about advanced filter with length more than 50 chars') }
-    let!(:topic1) { Fabricate(:topic, title: 'I am second topic about advanced filter') }
     let!(:post1) { Fabricate(:post, raw: 'this is the second post about advanced filter') }
 
     it 'allows to define custom filter' do
@@ -1706,9 +1704,7 @@ describe Search do
   end
 
   context "advanced order" do
-    let!(:topic0) { Fabricate(:topic, title: 'I am first topic about advanced order') }
     let!(:post0) { Fabricate(:post, raw: 'this is the first post about advanced order with length more than 50 chars') }
-    let!(:topic1) { Fabricate(:topic, title: 'I am second topic about advanced order') }
     let!(:post1) { Fabricate(:post, raw: 'this is the second post about advanced order') }
 
     it 'allows to define custom order' do


### PR DESCRIPTION
Similar to `advanced_filter` I introduced `advanced_order`.

I needed a new option because default orders are evaluated after advanced_filter so I couldn't use it.

Also, that part is a little bit more generic
```
elsif word =~ /order:\w+/
  @order = word.gsub('order:', '').to_sym
nil
```

After those changes, I can use them in plugins in this way:
```
Search.advanced_order(:votes) do |posts|
  posts.reorder("COALESCE((SELECT dvvc.counter FROM discourse_voting_vote_counters dvvc WHERE dvvc.topic_id = subquery.topic_id), 0) DESC")
end
```