### PR TITLE
FIX: Improve the usage of quotes inside bbcode attributes

### DIFF
--- a/plugins/discourse-local-dates/assets/javascripts/lib/discourse-markdown/discourse-local-dates.js.es6
+++ b/plugins/discourse-local-dates/assets/javascripts/lib/discourse-markdown/discourse-local-dates.js.es6
@@ -13,7 +13,7 @@ function addLocalDate(buffer, matches, state) {
     countdown: null,
   };
 
-  const matchString = matches[1].replace(/„|“/g, '"');
+  const matchString = matches[1].replace(/[„“”]/g, '"');
 
   let parsed = parseBBCodeTag(
     "[date date" + matchString + "]",

--- a/spec/components/cooked_post_processor_spec.rb
+++ b/spec/components/cooked_post_processor_spec.rb
@@ -1662,7 +1662,7 @@ describe CookedPostProcessor do
       let(:cp) do
         Fabricate(
           :post,
-          raw: "[quote=\"#{pp.user.username}, post: #{pp.post_number}, topic:#{pp.topic_id}]\nmodified\n[/quote]\ntest"
+          raw: "[quote=\"#{pp.user.username}, post: #{pp.post_number}, topic:#{pp.topic_id}\"]\nmodified\n[/quote]\ntest"
         )
       end
 

--- a/spec/components/pretty_text_spec.rb
+++ b/spec/components/pretty_text_spec.rb
@@ -1715,7 +1715,7 @@ HTML
       SiteSetting.enable_markdown_typographer = true
 
       md = <<~MD
-        [wrap=toc id="a” aa='b"' bb="f'"]
+        [wrap=toc id=“a” aa='b"' bb="f'"]
         taco1
         [/wrap]
       MD

--- a/test/javascripts/lib/bbcode-test.js
+++ b/test/javascripts/lib/bbcode-test.js
@@ -1,11 +1,43 @@
 import { parseBBCodeTag } from "pretty-text/engines/discourse-markdown/bbcode-block";
 
+function parseTag(bbcodeTag) {
+  return parseBBCodeTag(bbcodeTag, 0, bbcodeTag.length);
+}
+
 QUnit.module("lib:pretty-text:bbcode");
 
 QUnit.test("block with multiple quoted attributes", (assert) => {
-  const parsed = parseBBCodeTag('[test one="foo" two="bar bar"]', 0, 30);
+  const parsed = parseTag(`[test one="foo" two='bar bar']`);
 
   assert.equal(parsed.tag, "test");
   assert.equal(parsed.attrs.one, "foo");
   assert.equal(parsed.attrs.two, "bar bar");
+});
+
+QUnit.test("default attribute value", (assert) => {
+  const parsed = parseTag("[test='foo bar']");
+
+  assert.equal(parsed.tag, "test");
+  assert.equal(parsed.attrs._default, "foo bar");
+});
+
+// This is not supported because it conflicts with
+// the quoteless default attribute syntax:
+// [test=some random =) text]
+QUnit.skip("default and additional attributes", (assert) => {
+  const parsed = parseTag(`[date=2018-09-17 time=01:39:00 format="LLL"]`);
+
+  assert.equal(parsed.tag, "date");
+  assert.equal(parsed.attrs._default, "2018-09-17");
+  assert.equal(parsed.attrs.time, "01:39:00");
+  assert.equal(parsed.attrs.format, "LLL");
+});
+
+QUnit.test("quote characters inside a another quotes", (assert) => {
+  const parsed = parseTag(`[test one="foo's" two='“bar”' three=“"abc's"”]`);
+
+  assert.equal(parsed.tag, "test");
+  assert.equal(parsed.attrs.one, "foo's");
+  assert.equal(parsed.attrs.two, "“bar”");
+  assert.equal(parsed.attrs.three, `"abc's"`);
 });


### PR DESCRIPTION
Continuation of a91ee45de93c21637f9c062bd2eb6bf36a5213a1 and cba5baa42729da2574edb72592c48eef795d51f7.

Eventually I'd like to remove the support for "smart" quotes (e.g. `[test attr=“value”]`) after we make sure the standard quotes don't get accidentally transformed anywhere during the markdown processing.
