### PR TITLE
FEATURE: Block vibration in Firefox Android

### DIFF
--- a/app/assets/javascripts/discourse/app/pre-initializers/sniff-capabilities.js
+++ b/app/assets/javascripts/discourse/app/pre-initializers/sniff-capabilities.js
@@ -46,7 +46,7 @@ export default {
       caps.hasContactPicker =
         "contacts" in navigator && "ContactsManager" in window;
 
-      caps.canVibrate = "vibrate" in navigator;
+      caps.canVibrate = "vibrate" in navigator && !caps.isFirefox; // Remove Firefox condition when https://arewefenixyet.com/ lands
     }
 
     // We consider high res a device with 1280 horizontal pixels. High DPI tablets like


### PR DESCRIPTION
Legacy Firefox Android has some quirks around vibration where it:

- asks for permission
- doesn't persist the permission

This makes the default like vibration popup a permission on Firefox
Android <= 68.

This isn't the case (yet?) on their new Firefox which is rolling out
worldwide right now.

I'd say we merge this now and revert in 3 months or so when
https://arewefenixyet.com/ shows a full rollout.