### PR TITLE
FIX: don't reset order in categories route

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/build-category-route.js
+++ b/app/assets/javascripts/discourse/app/routes/build-category-route.js
@@ -243,7 +243,10 @@ export default (filterArg, params) => {
       this._super(...arguments);
 
       if (this.controller) {
-        this.resetParams(this.controller);
+        this.controller.setProperties({
+          ascending: false,
+          max_posts: null
+        });
       }
     },
 


### PR DESCRIPTION
The change was introduced here:
https://github.com/discourse/discourse/commit/12913a46e4e

It behaves weirdly with custom tabs added by plugins because they are using order to navigate. Therefore I think we should not reset order.

Before:
![Zg5uAPFyQl](https://user-images.githubusercontent.com/72780/89612746-ecb92380-d8c3-11ea-99f5-b3cbb8ff9cb7.gif)

After:
![5bEbGiLN4c](https://user-images.githubusercontent.com/72780/89612787-09555b80-d8c4-11ea-9490-8339a9d2928c.gif)
