### PR TITLE
FIX: removes persistedQueryParams as it should work out of the box

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-navigation.js
+++ b/app/assets/javascripts/discourse/app/components/d-navigation.js
@@ -6,7 +6,6 @@ import FilterModeMixin from "discourse/mixins/filter-mode";
 
 export default Component.extend(FilterModeMixin, {
   router: service(),
-  persistedQueryParams: null,
 
   tagName: "",
 
@@ -62,25 +61,12 @@ export default Component.extend(FilterModeMixin, {
 
   @discourseComputed("filterType", "category", "noSubcategories")
   navItems(filterType, category, noSubcategories) {
-    let params;
     const currentRouteQueryParams = this.get("router.currentRoute.queryParams");
-    if (this.persistedQueryParams && currentRouteQueryParams) {
-      const currentKeys = Object.keys(currentRouteQueryParams);
-      const discoveryKeys = Object.keys(this.persistedQueryParams);
-      const supportedKeys = currentKeys.filter(
-        i => discoveryKeys.indexOf(i) > 0
-      );
-      params = supportedKeys.reduce((object, key) => {
-        object[key] = currentRouteQueryParams[key];
-        return object;
-      }, {});
-    }
 
     return NavItem.buildList(category, {
       filterType,
       noSubcategories,
       currentRouteQueryParams,
-      persistedQueryParams: params,
       siteSettings: this.siteSettings
     });
   },

--- a/app/assets/javascripts/discourse/app/components/navigation-item.js
+++ b/app/assets/javascripts/discourse/app/components/navigation-item.js
@@ -51,14 +51,6 @@ export default Component.extend(FilterModeMixin, {
       }
     }
 
-    // ensures we keep discovery query params added through plugin api
-    if (content.persistedQueryParams) {
-      Object.keys(content.persistedQueryParams).forEach(key => {
-        const value = content.persistedQueryParams[key];
-        queryParams.push(`${key}=${value}`);
-      });
-    }
-
     // To reset the "filter" sticky param, at least one query param is needed.
     // If no query param is present, add an empty one to ensure a ? is
     // appended to the URL.

--- a/app/assets/javascripts/discourse/app/controllers/discovery-sortable.js
+++ b/app/assets/javascripts/discourse/app/controllers/discovery-sortable.js
@@ -1,7 +1,6 @@
 import { alias } from "@ember/object/computed";
 import { inject } from "@ember/controller";
 import Controller from "@ember/controller";
-import DiscourseNavigation from "discourse/components/d-navigation";
 
 // Just add query params here to have them automatically passed to topic list filters.
 export const queryParams = {
@@ -37,12 +36,6 @@ export const addDiscoveryQueryParam = function(p, opts) {
   cOpts[p] = alias(`discoveryTopics.${p}`);
   cOpts["queryParams"] = Object.keys(queryParams);
   SortableController.reopen(cOpts);
-
-  if (opts && opts.persisted) {
-    DiscourseNavigation.reopen({
-      persistedQueryParams: queryParams
-    });
-  }
 };
 
 export default SortableController;

--- a/app/assets/javascripts/discourse/app/models/nav-item.js
+++ b/app/assets/javascripts/discourse/app/models/nav-item.js
@@ -175,9 +175,6 @@ NavItem.reopenClass({
     if (opts.currentRouteQueryParams) {
       args.currentRouteQueryParams = opts.currentRouteQueryParams;
     }
-    if (opts.persistedQueryParams) {
-      args.persistedQueryParams = opts.persistedQueryParams;
-    }
     if (opts.noSubcategories) {
       args.noSubcategories = true;
     }


### PR DESCRIPTION
This hack is only attempting to hide something which should have been working in core and for which we should provide a fix soon. Also it's not working as it should.