### PR TITLE
Convert HEIC uploads to JPG by default

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1181,7 +1181,7 @@ files:
     list_type: compact
   authorized_extensions:
     client: true
-    default: "jpg|jpeg|png|gif"
+    default: "jpg|jpeg|png|gif|heic|heif"
     refresh: true
     type: list
     list_type: compact
@@ -1326,8 +1326,6 @@ files:
   decompressed_backup_max_file_size_mb:
     default: 100000
     hidden: true
-  convert_heif_to_jpeg:
-    default: false
 
 trust:
   default_trust_level:

--- a/lib/upload_creator.rb
+++ b/lib/upload_creator.rb
@@ -218,7 +218,7 @@ class UploadCreator
   end
 
   def convert_heif_to_jpeg?
-    SiteSetting.convert_heif_to_jpeg && File.extname(@filename).downcase.match?(/\.hei(f|c)$/)
+    File.extname(@filename).downcase.match?(/\.hei(f|c)$/)
   end
 
   def convert_heif!

--- a/spec/lib/upload_creator_spec.rb
+++ b/spec/lib/upload_creator_spec.rb
@@ -174,11 +174,6 @@ RSpec.describe UploadCreator do
       let(:filename) { "should_be_jpeg.heic" }
       let(:file) { file_from_fixtures(filename, "images") }
 
-      before do
-        SiteSetting.convert_heif_to_jpeg = true
-        SiteSetting.authorized_extensions = 'jpg|heic'
-      end
-
       it 'should store the upload with the right extension' do
         expect do
           UploadCreator.new(file, filename).create_for(user.id)


### PR DESCRIPTION
This removes the `convert_heif_to_jpeg` site setting and adds `.heic` and `.heif` to the authorized extensions. The result is that uploads of HEIC images will automatically convert to JPG. (Sites that have modified their authorized extensions need to manually add `.heic` and `.heif`.) 

Context: https://meta.discourse.org/t/support-for-heic-images/144326/20?u=pmusaraj