### PR TITLE
FIX: include both name and ID in color scheme stylesheet filenames

### DIFF
--- a/lib/stylesheet/manager.rb
+++ b/lib/stylesheet/manager.rb
@@ -106,7 +106,7 @@ class Stylesheet::Manager
 
     target = COLOR_SCHEME_STYLESHEET.to_sym
     current_hostname = Discourse.current_hostname
-    color_scheme_name = Slug.for(color_scheme.name)
+    color_scheme_name = Slug.for(color_scheme.name) + color_scheme&.id.to_s
     array_cache_key = "color_scheme_stylesheet_#{color_scheme_name}_#{current_hostname}"
     stylesheets = cache[array_cache_key]
     return stylesheets if stylesheets.present?
@@ -300,7 +300,7 @@ class Stylesheet::Manager
     if is_theme?
       "#{@target}_#{theme.id}"
     elsif @color_scheme
-      "#{@target}_#{Slug.for(@color_scheme.name)}"
+      "#{@target}_#{Slug.for(@color_scheme.name) + @color_scheme&.id.to_s}"
     else
       scheme_string = theme && theme.color_scheme ? "_#{theme.color_scheme.id}" : ""
       "#{@target}#{scheme_string}"

--- a/spec/components/stylesheet/manager_spec.rb
+++ b/spec/components/stylesheet/manager_spec.rb
@@ -193,12 +193,13 @@ describe Stylesheet::Manager do
       SiteSetting.default_theme_id = theme.id
 
       link = Stylesheet::Manager.color_scheme_stylesheet_link_tag()
-      expect(link).to include("/stylesheets/color_definitions_funky_")
+      expect(link).to include("/stylesheets/color_definitions_funky#{cs.id}_")
     end
 
     it "uses the correct scheme when colors are passed" do
       link = Stylesheet::Manager.color_scheme_stylesheet_link_tag(ColorScheme.first.id)
-      expect(link).to include("/stylesheets/color_definitions_#{Slug.for(ColorScheme.first.name)}_")
+      slug = Slug.for(ColorScheme.first.name) + ColorScheme.first.id.to_s
+      expect(link).to include("/stylesheets/color_definitions_#{slug}_")
     end
 
     it "does not fail with a color scheme name containing spaces and special characters" do
@@ -207,7 +208,7 @@ describe Stylesheet::Manager do
       SiteSetting.default_theme_id = theme.id
 
       link = Stylesheet::Manager.color_scheme_stylesheet_link_tag()
-      expect(link).to include("/stylesheets/color_definitions_funky-bunch_")
+      expect(link).to include("/stylesheets/color_definitions_funky-bunch#{cs.id}_")
     end
 
   end


### PR DESCRIPTION
Fixes an issue on sites with multiple color schemes with the same name. 