### PR TITLE
FIX: Include secure media URLs when linking post uploads

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -988,7 +988,7 @@ class Post < ActiveRecord::Base
       next if Rails.configuration.multisite && src.exclude?(current_db)
 
       src = "#{SiteSetting.force_https ? "https" : "http"}:#{src}" if src.start_with?("//")
-      next unless Discourse.store.has_been_uploaded?(src) || (include_local_upload && src =~ /\A\/[^\/]/i)
+      next unless Discourse.store.has_been_uploaded?(src) || Upload.secure_media_url?(src) || (include_local_upload && src =~ /\A\/[^\/]/i)
 
       path = begin
         URI(UrlHelper.unencode(GlobalSetting.cdn_url ? src.sub(GlobalSetting.cdn_url, "") : src))&.path

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1657,8 +1657,6 @@ describe Post do
        <img src="#{upload2_path}"/>
       RAW
 
-      urls = []
-      paths = []
       sha1s = []
 
       post.each_upload_url do |src, path, sha|

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1642,6 +1642,32 @@ describe Post do
       )
     end
 
+    it "correctly identifies secure uploads" do
+      enable_secure_media_and_s3
+      upload1 = Fabricate(:upload_s3, secure: true)
+      upload2 = Fabricate(:upload_s3, secure: true)
+
+      # Test including domain:
+      upload1_url = UrlHelper.cook_url(upload1.url, secure: true)
+      # Test without domain:
+      upload2_path = URI.parse(UrlHelper.cook_url(upload2.url, secure: true)).path
+
+      post = Fabricate(:post, raw: <<~RAW)
+       <img src="#{upload1_url}"/>
+       <img src="#{upload2_path}"/>
+      RAW
+
+      urls = []
+      paths = []
+      sha1s = []
+
+      post.each_upload_url do |src, path, sha|
+        sha1s << sha
+      end
+
+      expect(sha1s).to contain_exactly(upload1.sha1, upload2.sha1)
+    end
+
     it "correctly identifies missing uploads with short url" do
       upload = Fabricate(:upload)
       url = upload.short_url


### PR DESCRIPTION
Normally, secure media urls are linked like `/secure-media-uploads/...`. In this case, uploads were already being linked correctly.

But sometimes (e.g. when pulling hotlinked onebox images) secure media is referenced with a full domain name (`//example.com/secure-media-uploads`). This commit ensures that those uploads are also linked correctly.