### PR TITLE
FEATURE: don't notify about changed tags for a private message

### DIFF
--- a/app/jobs/regular/notify_tag_change.rb
+++ b/app/jobs/regular/notify_tag_change.rb
@@ -7,7 +7,7 @@ module Jobs
 
       if post&.topic&.visible?
         post_alerter = PostAlerter.new
-        post_alerter.notify_post_users(post, User.where(id: args[:notified_user_ids]), include_category_watchers: false)
+        post_alerter.notify_post_users(post, User.where(id: args[:notified_user_ids]), include_topic_watchers: !post.topic.private_message?, include_category_watchers: false)
         post_alerter.notify_first_post_watchers(post, post_alerter.tag_watchers(post.topic))
       end
     end

--- a/spec/services/post_alerter_spec.rb
+++ b/spec/services/post_alerter_spec.rb
@@ -1098,6 +1098,35 @@ describe PostAlerter do
         expect(user.notifications.where(notification_type: Notification.types[:watching_first_post]).count).to eq(0)
       end
     end
+
+    context "private message" do
+      fab!(:post) { Fabricate(:private_message_post) }
+      fab!(:other_tag) { Fabricate(:tag) }
+      fab!(:other_tag2) { Fabricate(:tag) }
+      fab!(:other_tag3) { Fabricate(:tag) }
+      fab!(:other_category) { Fabricate(:category) }
+      fab!(:user) { Fabricate(:user) }
+      fab!(:staged) { Fabricate(:staged) }
+      fab!(:admin) { Fabricate(:admin) }
+
+      before do
+        SiteSetting.tagging_enabled = true
+        SiteSetting.allow_staff_to_tag_pms = true
+        Jobs.run_immediately!
+        TopicUser.change(user.id, post.topic.id, notification_level: TopicUser.notification_levels[:watching])
+        TopicUser.change(staged.id, post.topic.id, notification_level: TopicUser.notification_levels[:watching])
+        TagUser.change(staged.id, other_tag.id, TagUser.notification_levels[:watching])
+        TagUser.change(admin.id, other_tag3.id, TagUser.notification_levels[:watching])
+        post.topic.allowed_users << user
+        post.topic.allowed_users << staged
+      end
+
+      it "only notifes staff watching added tag" do
+        expect { PostRevisor.new(post).revise!(Fabricate(:user), tags: [other_tag.name]) }.not_to change { Notification.where(user_id: staged.id).count }
+        expect { PostRevisor.new(post).revise!(Fabricate(:user), tags: [other_tag2.name]) }.not_to change { Notification.where(user_id: admin.id).count }
+        expect { PostRevisor.new(post).revise!(Fabricate(:admin), tags: [other_tag3.name]) }.to change { Notification.where(user_id: admin.id).count }.by(1)
+      end
+    end
   end
 
   describe '#extract_linked_users' do


### PR DESCRIPTION
Only staff members observing specific tag should receive a notification