### PR TITLE
DEV: Remove hasBlock from user-info component

### DIFF
--- a/app/assets/javascripts/discourse/app/components/user-info.js
+++ b/app/assets/javascripts/discourse/app/components/user-info.js
@@ -11,16 +11,12 @@ export default Component.extend({
   classNameBindings: [":user-info", "size"],
   attributeBindings: ["data-username"],
   size: "small",
+  "data-username": alias("user.username"),
 
   @discourseComputed("user.username")
   userPath(username) {
     return userPath(username);
   },
-
-  "data-username": alias("user.username"),
-
-  // TODO: In later ember releases `hasBlock` works without this
-  hasBlock: alias("template"),
 
   @discourseComputed("user.name", "user.username")
   name(name, username) {


### PR DESCRIPTION
4 years ago, `hasBlock` had to be defined here in the component this way, but now it is baked in.

Testing out the UI where a block is passed in, the property is working.