### PR TITLE
FIX: try to make topic_tracking_state_spec stable

### DIFF
--- a/spec/models/topic_tracking_state_spec.rb
+++ b/spec/models/topic_tracking_state_spec.rb
@@ -296,23 +296,26 @@ describe TopicTrackingState do
 
   describe '#publish_read_private_message' do
     fab!(:group) { Fabricate(:group) }
-    let(:read_topic_key) { "/private-messages/unread-indicator/#{@group_message.id}" }
-    let(:read_post_key) { "/topic/#{@group_message.id}" }
+    let(:read_topic_key) { "/private-messages/unread-indicator/#{group_message.id}" }
+    let(:read_post_key) { "/topic/#{group_message.id}" }
     let(:latest_post_number) { 3 }
-
-    before do
-      group.add(user)
-      @group_message = Fabricate(:private_message_topic,
+    let(:group_message) { Fabricate(:private_message_topic,
         allowed_groups: [group],
         topic_allowed_users: [Fabricate.build(:topic_allowed_user, user: user)],
         highest_post_number: latest_post_number
       )
-      @post = Fabricate(:post, topic: @group_message, post_number: latest_post_number)
+    }
+    let!(:post) {
+      Fabricate(:post, topic: group_message, post_number: latest_post_number)
+    }
+
+    before do
+      group.add(user)
     end
 
     it 'does not trigger a read count update if no allowed groups have the option enabled' do
       messages = MessageBus.track_publish(read_post_key) do
-        TopicTrackingState.publish_read_indicator_on_read(@group_message.id, latest_post_number, user.id)
+        TopicTrackingState.publish_read_indicator_on_read(group_message.id, latest_post_number, user.id)
       end
 
       expect(messages).to be_empty
@@ -323,37 +326,37 @@ describe TopicTrackingState do
 
       it 'publishes a message to hide the unread indicator' do
         message = MessageBus.track_publish(read_topic_key) do
-          TopicTrackingState.publish_read_indicator_on_read(@group_message.id, latest_post_number, user.id)
+          TopicTrackingState.publish_read_indicator_on_read(group_message.id, latest_post_number, user.id)
         end.first
 
-        expect(message.data['topic_id']).to eq @group_message.id
+        expect(message.data['topic_id']).to eq group_message.id
         expect(message.data['show_indicator']).to eq false
       end
 
       it 'publishes a message to show the unread indicator when a non-member creates a new post' do
-        allowed_user = Fabricate(:topic_allowed_user, topic: @group_message)
+        allowed_user = Fabricate(:topic_allowed_user, topic: group_message)
         message = MessageBus.track_publish(read_topic_key) do
-          TopicTrackingState.publish_read_indicator_on_write(@group_message.id, latest_post_number, allowed_user.id)
+          TopicTrackingState.publish_read_indicator_on_write(group_message.id, latest_post_number, allowed_user.id)
         end.first
 
-        expect(message.data['topic_id']).to eq @group_message.id
+        expect(message.data['topic_id']).to eq group_message.id
         expect(message.data['show_indicator']).to eq true
       end
 
       it 'does not publish the unread indicator if the message is not the last one' do
         not_last_post_number = latest_post_number - 1
-        Fabricate(:post, topic: @group_message, post_number: not_last_post_number)
+        Fabricate(:post, topic: group_message, post_number: not_last_post_number)
         messages = MessageBus.track_publish(read_topic_key) do
-          TopicTrackingState.publish_read_indicator_on_read(@group_message.id, not_last_post_number, user.id)
+          TopicTrackingState.publish_read_indicator_on_read(group_message.id, not_last_post_number, user.id)
         end
 
         expect(messages).to be_empty
       end
 
       it 'does not publish the read indicator if the user is not a group member' do
-        allowed_user = Fabricate(:topic_allowed_user, topic: @group_message)
+        allowed_user = Fabricate(:topic_allowed_user, topic: group_message)
         messages = MessageBus.track_publish(read_topic_key) do
-          TopicTrackingState.publish_read_indicator_on_read(@group_message.id, latest_post_number, allowed_user.user_id)
+          TopicTrackingState.publish_read_indicator_on_read(group_message.id, latest_post_number, allowed_user.user_id)
         end
 
         expect(messages).to be_empty
@@ -361,7 +364,7 @@ describe TopicTrackingState do
 
       it 'publish a read count update to every client' do
         message = MessageBus.track_publish(read_post_key) do
-          TopicTrackingState.publish_read_indicator_on_read(@group_message.id, latest_post_number, user.id)
+          TopicTrackingState.publish_read_indicator_on_read(group_message.id, latest_post_number, user.id)
         end.first
 
         expect(message.data[:type]).to eq :read


### PR DESCRIPTION
Sometime parallel spec if failing with error:
```
NoMethodError:
       undefined method `data' for nil:NilClass
     # ./spec/models/topic_tracking_state_spec.rb:339:in `block (4 levels) in <main>'
```

I have a theory that it might be related to instance variables in before block

@tgxworld could you take a look if that theory makes any sense to you? If not at all, let's drop it as it is a wild guess