### PR TITLE
FIX: Preserve anchors in permalink transitions

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/url.js
+++ b/app/assets/javascripts/discourse/app/lib/url.js
@@ -480,6 +480,8 @@ const DiscourseURL = EmberObject.extend({
     }
 
     transition._discourse_intercepted = true;
+    transition._discourse_anchor = elementId;
+
     const promise = transition.promise || transition;
     promise.then(() => jumpToElement(elementId));
   }

--- a/app/assets/javascripts/discourse/app/routes/unknown.js
+++ b/app/assets/javascripts/discourse/app/routes/unknown.js
@@ -11,7 +11,13 @@ export default DiscourseRoute.extend({
       if (results.found) {
         // Avoid polluting the history stack for external links
         transition.abort();
-        DiscourseURL.routeTo(results.target_url);
+
+        let url = results.target_url;
+        if (transition._discourse_anchor) {
+          url += `#${transition._discourse_anchor}`;
+        }
+
+        DiscourseURL.routeTo(url);
         return "";
       } else {
         // 404 body HTML

--- a/app/assets/javascripts/discourse/app/routes/unknown.js
+++ b/app/assets/javascripts/discourse/app/routes/unknown.js
@@ -13,7 +13,12 @@ export default DiscourseRoute.extend({
         transition.abort();
 
         let url = results.target_url;
+
         if (transition._discourse_anchor) {
+          // Remove the anchor from the permalink if present
+          url = url.split("#")[0];
+
+          // Add the anchor from the transition
           url += `#${transition._discourse_anchor}`;
         }
 


### PR DESCRIPTION
When visiting a permalink with an anchor (e.g. `/important-link#notes`) the anchor part was being dropped during redirection.

The change doesn't have a test. Functions like `scrollToPost` or `scrollToElement` don't have any effect in the test environment.