### PR TITLE
FIX: Prevent `LockOn` conflicts

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/url.js
+++ b/app/assets/javascripts/discourse/app/lib/url.js
@@ -66,6 +66,9 @@ export function groupPath(subPath) {
 }
 
 let _jumpScheduled = false;
+let _transitioning = false;
+let lockon = null;
+
 export function jumpToElement(elementId) {
   if (_jumpScheduled || isEmpty(elementId)) {
     return;
@@ -74,16 +77,19 @@ export function jumpToElement(elementId) {
   const selector = `#${elementId}, a[name=${elementId}]`;
   _jumpScheduled = true;
   schedule("afterRender", function() {
-    const lockon = new LockOn(selector, {
+    if (lockon) {
+      return;
+    }
+
+    lockon = new LockOn(selector, {
       finished() {
         _jumpScheduled = false;
+        lockon = null;
       }
     });
     lockon.lock();
   });
 }
-
-let _transitioning = false;
 
 const DiscourseURL = EmberObject.extend({
   isJumpScheduled() {
@@ -135,9 +141,14 @@ const DiscourseURL = EmberObject.extend({
         holder = $(elementId);
       }
 
-      const lockon = new LockOn(elementId, {
+      if (lockon) {
+        return;
+      }
+
+      lockon = new LockOn(elementId, {
         finished() {
           _transitioning = false;
+          lockon = null;
         }
       });
 

--- a/app/assets/javascripts/discourse/app/lib/url.js
+++ b/app/assets/javascripts/discourse/app/lib/url.js
@@ -74,8 +74,9 @@ export function jumpToElement(elementId) {
     return;
   }
 
-  const selector = `#${elementId}, a[name=${elementId}]`;
+  const selector = `#main #${elementId}, a[name=${elementId}]`;
   _jumpScheduled = true;
+
   schedule("afterRender", function() {
     if (lockon) {
       lockon.clearLock();
@@ -132,7 +133,7 @@ const DiscourseURL = EmberObject.extend({
       let holder;
 
       if (opts.anchor) {
-        selector = `#${opts.anchor}, a[name=${opts.anchor}]`;
+        selector = `#main #${opts.anchor}, a[name=${opts.anchor}]`;
         holder = document.querySelector(selector);
       }
 

--- a/app/assets/javascripts/discourse/app/lib/url.js
+++ b/app/assets/javascripts/discourse/app/lib/url.js
@@ -104,9 +104,6 @@ const DiscourseURL = EmberObject.extend({
     _transitioning = postNumber > 1;
 
     schedule("afterRender", () => {
-      let elementId;
-      let holder;
-
       if (opts.jumpEnd) {
         let $holder = $(holderId);
         let holderHeight = $holder.height();
@@ -131,32 +128,35 @@ const DiscourseURL = EmberObject.extend({
         return;
       }
 
+      let selector;
+      let holder;
+
       if (opts.anchor) {
-        elementId = opts.anchor;
-        holder = $(elementId);
+        selector = `#${opts.anchor}`;
+        holder = document.querySelector(selector);
       }
 
-      if (!holder || holder.length === 0) {
-        elementId = holderId;
-        holder = $(elementId);
+      if (!holder) {
+        selector = holderId;
+        holder = document.querySelector(selector);
       }
 
       if (lockon) {
         lockon.clearLock();
       }
 
-      lockon = new LockOn(elementId, {
+      lockon = new LockOn(selector, {
         finished() {
           _transitioning = false;
           lockon = null;
         }
       });
 
-      if (holder.length > 0 && opts && opts.skipIfOnScreen) {
+      if (holder && opts.skipIfOnScreen) {
         const elementTop = lockon.elementTop();
         const scrollTop = $(window).scrollTop();
         const windowHeight = $(window).height() - offsetCalculator();
-        const height = holder.height();
+        const height = $(holder).height();
 
         if (
           elementTop > scrollTop &&
@@ -388,9 +388,9 @@ const DiscourseURL = EmberObject.extend({
             jumpEnd: routeOpts.jumpEnd
           };
 
-          const m = /#.+$/.exec(path);
-          if (m) {
-            jumpOpts.anchor = m[0];
+          const anchorMatch = /#(.+)$/.exec(path);
+          if (anchorMatch) {
+            jumpOpts.anchor = anchorMatch[1];
           }
 
           this.jumpToPost(closest, jumpOpts);

--- a/app/assets/javascripts/discourse/app/lib/url.js
+++ b/app/assets/javascripts/discourse/app/lib/url.js
@@ -132,7 +132,7 @@ const DiscourseURL = EmberObject.extend({
       let holder;
 
       if (opts.anchor) {
-        selector = `#${opts.anchor}`;
+        selector = `#${opts.anchor}, a[name=${opts.anchor}]`;
         holder = document.querySelector(selector);
       }
 

--- a/app/assets/javascripts/discourse/app/lib/url.js
+++ b/app/assets/javascripts/discourse/app/lib/url.js
@@ -78,7 +78,7 @@ export function jumpToElement(elementId) {
   _jumpScheduled = true;
   schedule("afterRender", function() {
     if (lockon) {
-      return;
+      lockon.clearLock();
     }
 
     lockon = new LockOn(selector, {
@@ -142,7 +142,7 @@ const DiscourseURL = EmberObject.extend({
       }
 
       if (lockon) {
-        return;
+        lockon.clearLock();
       }
 
       lockon = new LockOn(elementId, {

--- a/app/assets/javascripts/discourse/app/routes/post.js
+++ b/app/assets/javascripts/discourse/app/routes/post.js
@@ -2,14 +2,16 @@ import DiscourseRoute from "discourse/routes/discourse";
 import { ajax } from "discourse/lib/ajax";
 
 export default DiscourseRoute.extend({
-  beforeModel({ params }) {
+  beforeModel({ params, _discourse_anchor }) {
     return ajax(`/p/${params.post.id}`).then(t => {
-      this.transitionTo(
+      const transition = this.transitionTo(
         "topic.fromParamsNear",
         t.slug,
         t.id,
         t.current_post_number
       );
+
+      transition._discourse_anchor = _discourse_anchor;
     });
   }
 });

--- a/app/assets/javascripts/discourse/app/routes/topic-from-params.js
+++ b/app/assets/javascripts/discourse/app/routes/topic-from-params.js
@@ -65,8 +65,8 @@ export default DiscourseRoute.extend({
         );
 
         const opts = {};
-        if (document.location.hash && document.location.hash.length) {
-          opts.anchor = document.location.hash;
+        if (document.location.hash) {
+          opts.anchor = document.location.hash.substr(1);
         } else if (_discourse_anchor) {
           opts.anchor = _discourse_anchor;
         }

--- a/app/assets/javascripts/discourse/app/routes/topic-from-params.js
+++ b/app/assets/javascripts/discourse/app/routes/topic-from-params.js
@@ -17,7 +17,7 @@ export default DiscourseRoute.extend({
     this.controllerFor("topic").unsubscribe();
   },
 
-  setupController(controller, params) {
+  setupController(controller, params, { _discourse_anchor }) {
     params = params || {};
     params.track_visit = true;
 
@@ -67,6 +67,8 @@ export default DiscourseRoute.extend({
         const opts = {};
         if (document.location.hash && document.location.hash.length) {
           opts.anchor = document.location.hash;
+        } else if (_discourse_anchor) {
+          opts.anchor = _discourse_anchor;
         }
         DiscourseURL.jumpToPost(closest, opts);
 


### PR DESCRIPTION
If there's already a `LockOn` instance, don't create a new one.

Fixes a shaky viewport effect after certain transitions:

<img src="https://user-images.githubusercontent.com/66961/90007821-b1d83680-dc9b-11ea-9243-7c50f01d242e.gif" width="450">

(as in #10421, the change doesn't have a test. Functions like `scrollToPost` or `scrollToElement` don't have any effect in the test environment)