### PR TITLE
REFACTOR: `LockOn` class

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/lock-on.js
+++ b/app/assets/javascripts/discourse/app/lib/lock-on.js
@@ -62,7 +62,7 @@ export default class LockOn {
       $(window).scrollTop(this.previousTop);
     }
 
-    this.interval = setInterval(() => this.performLocking(), 50);
+    this.interval = setInterval(() => this._performLocking(), 50);
 
     $("body, html")
       .off(SCROLL_EVENTS)
@@ -73,7 +73,7 @@ export default class LockOn {
       });
   }
 
-  performLocking() {
+  _performLocking() {
     const elementTop = this.elementTop();
 
     // If we can't find the element yet, wait a little bit more

--- a/app/assets/javascripts/discourse/app/lib/lock-on.js
+++ b/app/assets/javascripts/discourse/app/lib/lock-on.js
@@ -34,11 +34,15 @@ export default class LockOn {
   }
 
   elementTop() {
-    const $selected = $(this.selector);
-
-    if ($selected.length && $selected.offset && $selected.offset()) {
-      return $selected.offset().top - minimumOffset();
+    const element = document.querySelector(this.selector);
+    if (!element) {
+      return;
     }
+
+    const { top } = element.getBoundingClientRect();
+    const offset = top + window.scrollY;
+
+    return offset - minimumOffset();
   }
 
   clearLock() {

--- a/app/assets/javascripts/discourse/app/lib/lock-on.js
+++ b/app/assets/javascripts/discourse/app/lib/lock-on.js
@@ -79,7 +79,7 @@ export default class LockOn {
 
     const top = Math.max(0, elementTop);
 
-    if (typeof top === "undefined" || isNaN(top)) {
+    if (isNaN(top)) {
       return this.clearLock();
     }
 

--- a/app/assets/javascripts/discourse/app/lib/lock-on.js
+++ b/app/assets/javascripts/discourse/app/lib/lock-on.js
@@ -59,7 +59,7 @@ export default class LockOn {
     this.previousTop = this.elementTop();
 
     if (this.previousTop) {
-      $(window).scrollTop(this.previousTop);
+      window.scrollTo(window.pageXOffset, this.previousTop);
     }
 
     this.interval = setInterval(() => this._performLocking(), 50);
@@ -87,10 +87,11 @@ export default class LockOn {
       return this.clearLock();
     }
 
-    const scrollTop = $(window).scrollTop();
-
-    if (!within(4, top, this.previousTop) || !within(4, scrollTop, top)) {
-      $(window).scrollTop(top);
+    if (
+      !within(4, top, this.previousTop) ||
+      !within(4, window.scrollTop, top)
+    ) {
+      window.scrollTo(window.pageXOffset, top);
       this.previousTop = top;
     }
 

--- a/app/assets/javascripts/discourse/app/lib/lock-on.js
+++ b/app/assets/javascripts/discourse/app/lib/lock-on.js
@@ -40,9 +40,10 @@ export default class LockOn {
     }
   }
 
-  clearLock(interval) {
+  clearLock() {
     $("body, html").off(SCROLL_EVENTS);
-    clearInterval(interval);
+    clearInterval(this.interval);
+
     if (this.options.finished) {
       this.options.finished();
     }
@@ -53,7 +54,7 @@ export default class LockOn {
     let previousTop = this.elementTop();
     previousTop && $(window).scrollTop(previousTop);
 
-    const interval = setInterval(() => {
+    this.interval = setInterval(() => {
       const elementTop = this.elementTop();
       if (!previousTop && !elementTop) {
         // we can't find the element yet, wait a little bit more
@@ -64,7 +65,7 @@ export default class LockOn {
       const scrollTop = $(window).scrollTop();
 
       if (typeof top === "undefined" || isNaN(top)) {
-        return this.clearLock(interval);
+        return this.clearLock();
       }
 
       if (!within(4, top, previousTop) || !within(4, scrollTop, top)) {
@@ -74,7 +75,7 @@ export default class LockOn {
 
       // Stop after a little while
       if (Date.now() - startedAt > LOCK_DURATION_MS) {
-        return this.clearLock(interval);
+        return this.clearLock();
       }
     }, 50);
 
@@ -82,7 +83,7 @@ export default class LockOn {
       .off(SCROLL_EVENTS)
       .on(SCROLL_EVENTS, e => {
         if (e.which > 0 || SCROLL_TYPES.includes(e.type)) {
-          this.clearLock(interval);
+          this.clearLock();
         }
       });
   }


### PR DESCRIPTION
See the list of commits for the description of individual changes. (spoiler: mostly _de-jQuery-ification_)

This PR tries to closely preserve the original behavior. In a separate change I'd:

1. Remove deprecated event types (`DOMMouseScroll` and `mousewheel`)
2. Remove one of the event listener targets (i.e. either `body` or `html`)
3. Add an escape hatch, that will clear the lock if target element doesn't appear within e.g. 10 seconds