### PR TITLE
FIX: Update preview when autocomplete is clicked

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-editor.js
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.js
@@ -181,6 +181,7 @@ export default Component.extend({
   _composerEditorInit() {
     const $input = $(this.element.querySelector(".d-editor-input"));
     const $preview = $(this.element.querySelector(".d-editor-preview-wrapper"));
+    const self = this;
 
     if (this.siteSettings.enable_mentions) {
       $input.autocomplete({
@@ -189,6 +190,8 @@ export default Component.extend({
         key: "@",
         transformComplete: v => v.username || v.name,
         afterComplete() {
+          self.composer.set("reply", $input.val());
+
           // ensures textarea scroll position is correct
           schedule("afterRender", () => $input.blur().focus());
         },

--- a/app/assets/javascripts/discourse/app/components/composer-editor.js
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.js
@@ -181,7 +181,6 @@ export default Component.extend({
   _composerEditorInit() {
     const $input = $(this.element.querySelector(".d-editor-input"));
     const $preview = $(this.element.querySelector(".d-editor-preview-wrapper"));
-    const self = this;
 
     if (this.siteSettings.enable_mentions) {
       $input.autocomplete({
@@ -189,8 +188,8 @@ export default Component.extend({
         dataSource: term => this.userSearchTerm.call(this, term),
         key: "@",
         transformComplete: v => v.username || v.name,
-        afterComplete() {
-          self.composer.set("reply", $input.val());
+        afterComplete: () => {
+          this.composer.set("reply", $input.val());
 
           // ensures textarea scroll position is correct
           schedule("afterRender", () => $input.blur().focus());

--- a/app/assets/javascripts/discourse/app/components/composer-editor.js
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.js
@@ -188,8 +188,8 @@ export default Component.extend({
         dataSource: term => this.userSearchTerm.call(this, term),
         key: "@",
         transformComplete: v => v.username || v.name,
-        afterComplete: () => {
-          this.composer.set("reply", $input.val());
+        afterComplete: value => {
+          this.composer.set("reply", value);
 
           // ensures textarea scroll position is correct
           schedule("afterRender", () => $input.blur().focus());


### PR DESCRIPTION
`d-editor` observes `value` changing, and should update the preview.

https://github.com/discourse/discourse/blob/ba3ee3444eb9bad94a8f612f4c3636d4985e57eb/app/assets/javascripts/discourse/app/components/d-editor.js#L390

This is happening when an autocomplete option is selected using the <kbd>ENTER</kbd>, but when you click an option, the value of the textarea is updated, but this observes does not pick up the change for some reason that I cannot see.

By manually resetting `composer.reply` (which is passed into d-editor [here](https://github.com/discourse/discourse/blob/ba3ee3444eb9bad94a8f612f4c3636d4985e57eb/app/assets/javascripts/discourse/app/templates/components/composer-editor.hbs#L3)), the `value` in `d-editor` is set, and the observes catches the change, which updates the preview. It is not the slickest thing I've ever seen, but I can't see why the textarea would be changing but the observes does not notice.