### PR TITLE
DEV: Remove blob: workers from CSP

### DIFF
--- a/app/assets/javascripts/admin/components/ace-editor.js
+++ b/app/assets/javascripts/admin/components/ace-editor.js
@@ -74,6 +74,8 @@ export default Component.extend({
 
     loadScript("/javascripts/ace/ace.js").then(() => {
       window.ace.require(["ace/ace"], loadedAce => {
+        loadedAce.config.set("loadWorkerFromBlob", false);
+
         if (!this.element || this.isDestroying || this.isDestroyed) {
           return;
         }

--- a/app/assets/javascripts/admin/components/ace-editor.js
+++ b/app/assets/javascripts/admin/components/ace-editor.js
@@ -1,5 +1,6 @@
 import Component from "@ember/component";
 import loadScript from "discourse/lib/load-script";
+import getURL from "discourse-common/lib/get-url";
 import { observes } from "discourse-common/utils/decorators";
 import { on } from "@ember/object/evented";
 
@@ -75,6 +76,7 @@ export default Component.extend({
     loadScript("/javascripts/ace/ace.js").then(() => {
       window.ace.require(["ace/ace"], loadedAce => {
         loadedAce.config.set("loadWorkerFromBlob", false);
+        loadedAce.config.set("workerPath", getURL("/javascripts/ace")); // Do not use CDN for workers
 
         if (!this.element || this.isDestroying || this.isDestroyed) {
           return;

--- a/config/nginx.sample.conf
+++ b/config/nginx.sample.conf
@@ -135,6 +135,7 @@ server {
     location ~ ^/javascripts/ {
       expires 1d;
       add_header Cache-Control public,immutable;
+      add_header Access-Control-Allow-Origin *;
     }
 
     location ~ ^/assets/(?<asset_path>.+)$ {

--- a/config/nginx.sample.conf
+++ b/config/nginx.sample.conf
@@ -135,7 +135,6 @@ server {
     location ~ ^/javascripts/ {
       expires 1d;
       add_header Cache-Control public,immutable;
-      add_header Access-Control-Allow-Origin *;
     }
 
     location ~ ^/assets/(?<asset_path>.+)$ {

--- a/lib/content_security_policy/default.rb
+++ b/lib/content_security_policy/default.rb
@@ -63,8 +63,7 @@ class ContentSecurityPolicy
 
     def worker_src
       [
-        "'self'",
-        "blob:",
+        "'self'", # For service worker
         *script_assets(worker: true)
       ]
     end

--- a/spec/lib/content_security_policy_spec.rb
+++ b/spec/lib/content_security_policy_spec.rb
@@ -37,7 +37,6 @@ describe ContentSecurityPolicy do
       worker_srcs = parse(policy)['worker-src']
       expect(worker_srcs).to eq(%w[
         'self'
-        blob:
         http://test.localhost/assets/
         http://test.localhost/brotli_asset/
         http://test.localhost/javascripts/


### PR DESCRIPTION
Ace editor is reconfigured to load workers directly from the JS URL. For this to work when an app cdn is in place, we need to add the Access-Control-Allow-Origin header to /javascripts/ routes