### PR TITLE
DEV: Function to get baseUri from get-url helper

### DIFF
--- a/app/assets/javascripts/discourse-common/addon/lib/get-url.js
+++ b/app/assets/javascripts/discourse-common/addon/lib/get-url.js
@@ -1,6 +1,5 @@
-let cdn, baseUrl;
+let cdn, baseUrl, baseUri;
 let S3BaseUrl, S3CDN;
-export let baseUri;
 
 export default function getURL(url) {
   if (!url) return url;
@@ -57,4 +56,8 @@ export function setupURL(configCdn, configBaseUrl, configBaseUri) {
 export function setupS3CDN(configS3BaseUrl, configS3CDN) {
   S3BaseUrl = configS3BaseUrl;
   S3CDN = configS3CDN;
+}
+
+export function getBaseUri() {
+  return baseUri;
 }

--- a/app/assets/javascripts/discourse-common/addon/lib/get-url.js
+++ b/app/assets/javascripts/discourse-common/addon/lib/get-url.js
@@ -1,5 +1,6 @@
-let cdn, baseUrl, baseUri;
+let cdn, baseUrl;
 let S3BaseUrl, S3CDN;
+export let baseUri;
 
 export default function getURL(url) {
   if (!url) return url;


### PR DESCRIPTION
@eviltrout This is so that I can get the subfolder path. I didn't want to export the variable, so that it cannot be set outside of the get-url file, so I wrote a get function.