### PR TITLE
DEV: prevents random test failure

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/user-search.js
+++ b/app/assets/javascripts/discourse/app/lib/user-search.js
@@ -1,10 +1,10 @@
+import { isTesting } from "discourse-common/config/environment";
 import discourseDebounce from "discourse/lib/debounce";
 import { CANCELLED_STATUS } from "discourse/lib/autocomplete";
 import { userPath } from "discourse/lib/url";
 import { emailValid } from "discourse/lib/utilities";
 import { Promise } from "rsvp";
 import { later, cancel } from "@ember/runloop";
-import { isTesting } from "discourse-common/config/environment";
 
 var cache = {},
   cacheKey,
@@ -182,12 +182,10 @@ export default function userSearch(options) {
 
     cacheKey = newCacheKey;
 
-    const clearPromise = later(
-      () => {
-        resolve(CANCELLED_STATUS);
-      },
-      isTesting() ? 250 : 5000
-    );
+    let clearPromise;
+    if (!isTesting()) {
+      clearPromise = later(() => resolve(CANCELLED_STATUS), 5000);
+    }
 
     if (skipSearch(term, options.allowEmails)) {
       resolve([]);


### PR DESCRIPTION
To repro use a later with 0:

```
const clearPromise = later(() => {
      resolve(CANCELLED_STATUS);
    }, 0);
```

In this case, the cancel will hit before the debounced (300ms) has finished, and the debounce will still be called even if we called resolve as it's not cancelled (the debounce). A future improvement would be to refactor more deeply user-search to be able to cancel the debounce if we clear the promise.

The goal of the lower later time, was to prevent callback to be fired in another test, but it seems a low timer makes more harm than a high timer.