### PR TITLE
DEV: upgrades sassc to 2.4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -219,9 +219,7 @@ gem 'logstash-event', require: false
 gem 'logstash-logger', require: false
 gem 'logster'
 
-# NOTE: later versions of sassc are causing a segfault, possibly dependent on processer architecture
-# and until resolved should be locked at 2.0.1
-gem 'sassc', '2.0.1', require: false
+gem 'sassc', '2.4.0', require: false
 gem "sassc-rails"
 
 # see: https://github.com/mdp/rotp/issues/98

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -375,9 +375,8 @@ GEM
       crass (~> 1.0.2)
       nokogiri (>= 1.8.0)
       nokogumbo (~> 2.0)
-    sassc (2.0.1)
+    sassc (2.4.0)
       ffi (~> 1.9)
-      rake
     sassc-rails (2.1.2)
       railties (>= 4.0.0)
       sassc (>= 2.0)
@@ -543,7 +542,7 @@ DEPENDENCIES
   ruby-prof
   ruby-readability
   rubyzip
-  sassc (= 2.0.1)
+  sassc (= 2.4.0)
   sassc-rails
   seed-fu
   shoulda-matchers


### PR DESCRIPTION
We were stuck on 2.0.1 but multiple reports on the original issue shows that the issue has been fixed since 2.3 and 2.4:

https://github.com/sass/sassc-ruby/issues/146#issuecomment-654522157
https://github.com/sass/sassc-ruby/issues/146#issuecomment-654522157

There's one report show it was not fixed in 2.3.0, but that's the only one, it's probably worth trying: https://github.com/sass/sassc-ruby/issues/146#issuecomment-639073736