### PR TITLE
FIX: prevents errors on /tags when a tag `constructor` exists

### DIFF
--- a/app/assets/javascripts/discourse/app/models/store.js
+++ b/app/assets/javascripts/discourse/app/models/store.js
@@ -25,21 +25,21 @@ function storeMap(type, id, obj) {
 
 function fromMap(type, id) {
   const byType = _identityMap[type];
-  if (byType) {
+  if (byType && byType.hasOwnProperty(id)) {
     return byType[id];
   }
 }
 
 function removeMap(type, id) {
   const byType = _identityMap[type];
-  if (byType) {
+  if (byType && byType.hasOwnProperty(id)) {
     delete byType[id];
   }
 }
 
 function findAndRemoveMap(type, id) {
   const byType = _identityMap[type];
-  if (byType) {
+  if (byType && byType.hasOwnProperty(id)) {
     const result = byType[id];
     delete byType[id];
     return result;

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -5,7 +5,8 @@ class Tag < ActiveRecord::Base
   include HasDestroyedWebHook
 
   RESERVED_TAGS = [
-    'none'
+    'none',
+    'constructor' # prevents issues with javascript's constructor of objects
   ]
 
   validates :name,


### PR DESCRIPTION
This is due to js objects having a constructor property:

```
const obj = {};
obj['constructor'] // return [native code] and not undefined
```