### PR TITLE
PERF: Prefer joins for `User#private_posts_for_user` take 2.

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -79,10 +79,6 @@ class Post < ActiveRecord::Base
   register_custom_field_type(MISSING_UPLOADS, :json)
   register_custom_field_type(MISSING_UPLOADS_IGNORED, :boolean)
 
-  scope :private_posts_for_user, ->(user) {
-    where("posts.topic_id IN (#{Topic::PRIVATE_MESSAGES_SQL})", user_id: user.id)
-  }
-
   scope :by_newest, -> { order('created_at DESC, id DESC') }
   scope :by_post_number, -> { order('post_number ASC') }
   scope :with_user, -> { includes(:user) }

--- a/spec/components/search_spec.rb
+++ b/spec/components/search_spec.rb
@@ -364,7 +364,7 @@ describe Search do
 
         # private only
         results = Search.execute('in:all cheese', guardian: Guardian.new(u1))
-        expect(results.posts).to contain_exactly(private_post1)
+        expect(results.posts).to contain_exactly(private_post2)
 
         # public only
         results = Search.execute('in:all eggs', guardian: Guardian.new(u1))
@@ -394,13 +394,13 @@ describe Search do
 
         # same keyword for different users
         results = Search.execute('in:all ham', guardian: Guardian.new(u1))
-        expect(results.posts).to contain_exactly(public_post1, private_post1)
+        expect(results.posts).to contain_exactly(public_post2, private_post1)
 
         results = Search.execute('in:all ham', guardian: Guardian.new(u2))
-        expect(results.posts).to contain_exactly(public_post1, private_post1)
+        expect(results.posts).to contain_exactly(public_post2, private_post1)
 
         results = Search.execute('in:all ham', guardian: Guardian.new(u3))
-        expect(results.posts).to contain_exactly(public_post1)
+        expect(results.posts).to contain_exactly(public_post2)
       end
     end
   end


### PR DESCRIPTION
The subquery here prevents the planner from optimizing the query. As
such, we prefer joining against the requried tables instead.