### PR TITLE
Add computed property to Create Account modal

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/create-account.js
+++ b/app/assets/javascripts/discourse/app/controllers/create-account.js
@@ -74,6 +74,14 @@ export default Controller.extend(
       return false;
     },
 
+    @discourseComputed("userFields", "hasAtLeastOneLoginButton")
+    modalBodyClasses(userFields, hasAtLeastOneLoginButton) {
+      const classes = [];
+      if (userFields) classes.push("has-user-fields");
+      if (hasAtLeastOneLoginButton) classes.push("has-alt-auth");
+      return classes.join(" ");
+    },
+
     @discourseComputed("authOptions", "authOptions.can_edit_username")
     usernameDisabled(authOptions, canEditUsername) {
       return authOptions && !canEditUsername;

--- a/app/assets/javascripts/discourse/app/templates/modal/create-account.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/create-account.hbs
@@ -1,7 +1,7 @@
 {{#create-account email=accountEmail disabled=submitDisabled action=(action "createAccount")}}
   {{#unless complete}}
     {{plugin-outlet name="create-account-before-modal-body"}}
-    {{#d-modal-body title="create_account.title" class=(concat (if hasAtLeastOneLoginButton "has-alt-auth") " " (if userFields "has-user-fields"))}}
+    {{#d-modal-body title="create_account.title" class=modalBodyClasses}}
 
       {{#unless hasAuthOptions}}
         {{login-buttons externalLogin=(action "externalLogin")}}


### PR DESCRIPTION
Carry over the regime used in the Login modal to Create Account to
facilitate overriding of the classes set for the d-modal-body Component
using a new Computed Property having the same naming convention.