### PR TITLE
FIX: makes group_show_serializer#is_group_owner follow standards

### DIFF
--- a/app/serializers/group_show_serializer.rb
+++ b/app/serializers/group_show_serializer.rb
@@ -12,11 +12,11 @@ class GroupShowSerializer < BasicGroupSerializer
   end
 
   def include_is_group_owner?
-    authenticated?
+    authenticated? && fetch_group_user&.owner
   end
 
   def is_group_owner
-    fetch_group_user&.owner
+    true
   end
 
   def include_is_group_owner_display?

--- a/spec/serializers/group_show_serializer_spec.rb
+++ b/spec/serializers/group_show_serializer_spec.rb
@@ -13,7 +13,7 @@ describe GroupShowSerializer do
     it 'should return the right attributes' do
       json = GroupShowSerializer.new(group, scope: Guardian.new(user)).as_json
 
-      expect(json[:group_show][:is_group_owner]).to eq(false)
+      expect(json[:group_show][:is_group_owner]).to eq(nil)
       expect(json[:group_show][:is_group_user]).to eq(true)
     end
   end


### PR DESCRIPTION
It should only return if is_group_owner, otherwise the field won't be present in json.