### PR TITLE
FIX: SiteSettings::LocalProcessProvider didn't work on multisite

### DIFF
--- a/lib/site_settings/local_process_provider.rb
+++ b/lib/site_settings/local_process_provider.rb
@@ -3,9 +3,6 @@
 module SiteSettings; end
 
 class SiteSettings::LocalProcessProvider
-
-  attr_accessor :current_site
-
   class Setting
     attr_accessor :name, :data_type, :value
 
@@ -29,7 +26,6 @@ class SiteSettings::LocalProcessProvider
 
   def initialize
     @settings = {}
-    self.current_site = "test"
   end
 
   def all
@@ -61,4 +57,7 @@ class SiteSettings::LocalProcessProvider
     @settings[current_site] = {}
   end
 
+  def current_site
+    RailsMultisite::ConnectionManagement.current_db
+  end
 end

--- a/spec/components/site_setting_extension_spec.rb
+++ b/spec/components/site_setting_extension_spec.rb
@@ -163,11 +163,13 @@ describe SiteSettingExtension do
   end
 
   describe "multisite" do
-    it "has no db cross talk" do
+    it "has no db cross talk", type: :multisite do
       settings.setting(:hello, 1)
       settings.hello = 100
-      settings.provider.current_site = "boom"
-      expect(settings.hello).to eq(1)
+
+      test_multisite_connection("second") do
+        expect(settings.hello).to eq(1)
+      end
     end
   end
 

--- a/spec/components/site_settings/local_process_provider_spec.rb
+++ b/spec/components/site_settings/local_process_provider_spec.rb
@@ -59,6 +59,27 @@ describe SiteSettings::LocalProcessProvider do
   end
 
   it "returns the correct site name" do
-    expect(provider.current_site).to eq("test")
+    expect(provider.current_site).to eq("default")
+  end
+
+  describe "multisite", type: :multisite do
+    it "loads the correct settings" do
+      test_multisite_connection("default") { provider.save("test", "bla-default", 2) }
+      test_multisite_connection("second") { provider.save("test", "bla-second", 2) }
+
+      test_multisite_connection("default") do
+        expect_same_setting(provider.find("test"), setting("test", "bla-default", 2))
+      end
+
+      test_multisite_connection("second") do
+        expect_same_setting(provider.find("test"), setting("test", "bla-second", 2))
+      end
+    end
+
+    it "returns the correct site name" do
+      test_multisite_connection("second") do
+        expect(provider.current_site).to eq("second")
+      end
+    end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -214,9 +214,18 @@ RSpec.configure do |config|
       SiteSetting.defaults.set_regardless_of_locale(k, v) if SiteSetting.respond_to? k
     end
 
-    SiteSetting.provider = SiteSettings::LocalProcessProvider.new
+    SiteSetting.provider = TestLocalProcessProvider.new
 
     WebMock.disable_net_connect!
+  end
+
+  class TestLocalProcessProvider < SiteSettings::LocalProcessProvider
+    attr_accessor :current_site
+
+    def initialize
+      super
+      self.current_site = "test"
+    end
   end
 
   class DiscourseMockRedis < MockRedis


### PR DESCRIPTION
It always used "test" as current site. Probably because it was written for tests? But it's also used in the application, so this might have been broken?

https://github.com/discourse/discourse/blob/bad7c287ddf350a2059b1c2bb7c8ad92bdc3895b/config/initializers/005-site_settings.rb#L8-L17