### PR TITLE
DEV: Upgrade highline gem to latest

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -125,8 +125,7 @@ gem 'mini_scheduler'
 gem 'execjs', require: false
 gem 'mini_racer'
 
-# TODO: determine why highline is being held back and upgrade to latest
-gem 'highline', '~> 1.7.0', require: false
+gem 'highline', require: false
 
 gem 'rack'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -144,7 +144,7 @@ GEM
     guess_html_encoding (0.0.11)
     hashdiff (1.0.1)
     hashie (4.1.0)
-    highline (1.7.10)
+    highline (2.0.3)
     hkdf (0.3.0)
     htmlentities (4.3.4)
     http_accept_language (2.1.1)
@@ -479,7 +479,7 @@ DEPENDENCIES
   fastimage
   flamegraph
   gc_tracer
-  highline (~> 1.7.0)
+  highline
   htmlentities
   http_accept_language
   json


### PR DESCRIPTION
Currently we have pinned highline to version 1.7.0. This is the gem that
we use to have an interactive command line for tasks like `rake
admin:create`.

Upgrading to the latest version 2.0.3 will remove ruby 2.7 deprecation
warnings.

I'm not sure why *this* gem was pinned. I manually executed a couple of
our rake tasks that use this and everything seems fine.