### PR TITLE
DEV: Bump rotp gem to latest version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -224,8 +224,7 @@ gem 'logster'
 gem 'sassc', '2.0.1', require: false
 gem "sassc-rails"
 
-# see: https://github.com/mdp/rotp/issues/98
-gem 'rotp', '5.1.0' , require: false
+gem 'rotp', require: false
 
 gem 'rqrcode'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -315,8 +315,7 @@ GEM
       rack (>= 1.4)
     rexml (3.2.4)
     rinku (2.0.6)
-    rotp (5.1.0)
-      addressable (~> 2.5)
+    rotp (6.1.0)
     rqrcode (1.1.2)
       chunky_png (~> 1.0)
       rqrcode_core (~> 0.1)
@@ -534,7 +533,7 @@ DEPENDENCIES
   redis
   redis-namespace
   rinku
-  rotp (= 5.1.0)
+  rotp
   rqrcode
   rspec
   rspec-html-matchers

--- a/spec/components/concern/second_factor_manager_spec.rb
+++ b/spec/components/concern/second_factor_manager_spec.rb
@@ -44,19 +44,19 @@ RSpec.describe SecondFactorManager do
   describe '#totp_provisioning_uri' do
     it 'should return the right uri' do
       expect(user.user_second_factors.totps.first.totp_provisioning_uri).to eq(
-        "otpauth://totp/#{SiteSetting.title}:#{user.email}?secret=#{user_second_factor_totp.data}&issuer=#{SiteSetting.title}"
+        "otpauth://totp/#{SiteSetting.title}:#{ERB::Util.url_encode(user.email)}?secret=#{user_second_factor_totp.data}&issuer=#{SiteSetting.title}"
       )
     end
     it 'should handle a colon in the site title' do
       SiteSetting.title = 'Spaceballs: The Discourse'
       expect(user.user_second_factors.totps.first.totp_provisioning_uri).to eq(
-        "otpauth://totp/Spaceballs%20The%20Discourse:#{user.email}?secret=#{user_second_factor_totp.data}&issuer=Spaceballs+The+Discourse"
+        "otpauth://totp/Spaceballs%20The%20Discourse:#{ERB::Util.url_encode(user.email)}?secret=#{user_second_factor_totp.data}&issuer=Spaceballs%20The%20Discourse"
       )
     end
     it 'should handle a two words before a colon in the title' do
       SiteSetting.title = 'Our Spaceballs: The Discourse'
       expect(user.user_second_factors.totps.first.totp_provisioning_uri).to eq(
-        "otpauth://totp/Our%20Spaceballs%20The%20Discourse:#{user.email}?secret=#{user_second_factor_totp.data}&issuer=Our+Spaceballs+The+Discourse"
+        "otpauth://totp/Our%20Spaceballs%20The%20Discourse:#{ERB::Util.url_encode(user.email)}?secret=#{user_second_factor_totp.data}&issuer=Our%20Spaceballs%20The%20Discourse"
       )
     end
   end


### PR DESCRIPTION
The rotp gem is currently pinned to version 5.1.0 and this will bump it
up to version 6.0.1.

Follow up to: 85d4370f791a2e6e17a50cd9ab5de44cd1fcc0d2

because this issue we were waiting on is now closed:

https://github.com/mdp/rotp/issues/98

Because version 6 is now encoding the params I needed to update the
tests as well.