### PR TITLE
FIX: Error message when setting enforce 2fa with social logins

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -193,6 +193,7 @@ en:
       s3_bucket_reused: "You cannot use the same bucket for 's3_upload_bucket' and 's3_backup_bucket'. Choose a different bucket or use a different path for each bucket."
       secure_media_requirements: "S3 uploads must be enabled before enabling secure media."
       share_quote_facebook_requirements: "You must set a Facebook app id to enable quote sharing for Facebook."
+      second_factor_cannot_enforce_with_socials: "You cannot enforce 2FA with social logins enabled. You must first disable login via: %{auth_provider_names}"
       second_factor_cannot_be_enforced_with_disabled_local_login: "You cannot enforce 2FA if local logins are disabled."
       local_login_cannot_be_disabled_if_second_factor_enforced: "You cannot disable local login if 2FA is enforced. Disable enforced 2FA before disabling local logins."
       cannot_enable_s3_uploads_when_s3_enabled_globally: "You cannot enable S3 uploads because S3 uploads are already globally enabled, and enabling this site-level could cause critical issues with uploads"

--- a/lib/site_settings/validations.rb
+++ b/lib/site_settings/validations.rb
@@ -156,6 +156,10 @@ module SiteSettings::Validations
   end
 
   def validate_enforce_second_factor(new_val)
+    if new_val == "all" && Discourse.enabled_auth_providers.count > 0
+      auth_provider_names = Discourse.enabled_auth_providers.map(&:name).join(", ")
+      return validate_error(:second_factor_cannot_enforce_with_socials, auth_provider_names: auth_provider_names)
+    end
     return if SiteSetting.enable_local_logins
     return if new_val == "no"
     validate_error :second_factor_cannot_be_enforced_with_disabled_local_login

--- a/spec/lib/site_settings/validations_spec.rb
+++ b/spec/lib/site_settings/validations_spec.rb
@@ -115,10 +115,10 @@ describe SiteSettings::Validations do
     end
   end
 
-  describe "enforce second factor & local login interplay" do
+  describe "enforce second factor & local/auth provider login interplay" do
     describe "#validate_enforce_second_factor" do
-      let(:error_message) { I18n.t("errors.site_settings.second_factor_cannot_be_enforced_with_disabled_local_login") }
       context "when local logins are disabled" do
+        let(:error_message) { I18n.t("errors.site_settings.second_factor_cannot_be_enforced_with_disabled_local_login") }
         before do
           SiteSetting.enable_local_logins = false
         end
@@ -135,6 +135,18 @@ describe SiteSettings::Validations do
 
         it "should be ok" do
           expect { subject.validate_enforce_second_factor("t") }.not_to raise_error
+        end
+      end
+
+      context "when social logins are enabled" do
+        let(:error_message) { I18n.t("errors.site_settings.second_factor_cannot_enforce_with_socials", auth_provider_names: "facebook, github") }
+        before do
+          SiteSetting.enable_facebook_logins = true
+          SiteSetting.enable_github_logins = true
+        end
+
+        it "raises and error, and specifies the auth providers" do
+          expect { subject.validate_enforce_second_factor("all") }.to raise_error(Discourse::InvalidParameters, error_message)
         end
       end
     end


### PR DESCRIPTION
Right now, 2fa does not work with social logins. This PR does not allow sites to set `enforce_second_factor` for all users if social logins are enabled. This is still allow `enforce_second_factor` for staff, as staff can just be forced to not use social login.

![2020-08-19_11-47](https://user-images.githubusercontent.com/16214023/90665594-de4b0000-e211-11ea-8849-0e5ef8b9a3b1.png)
