### PR TITLE
FIX: Wizard could not send custom color schemes to the client correctly

### DIFF
--- a/app/models/color_scheme_color.rb
+++ b/app/models/color_scheme_color.rb
@@ -4,6 +4,10 @@ class ColorSchemeColor < ActiveRecord::Base
   belongs_to :color_scheme
 
   validates :hex, format: { with: /\A([0-9a-fA-F]{3}|[0-9a-fA-F]{6})\z/ }
+
+  def hex_with_hash
+    "##{hex}"
+  end
 end
 
 # == Schema Information

--- a/app/serializers/wizard_serializer.rb
+++ b/app/serializers/wizard_serializer.rb
@@ -15,11 +15,11 @@ class WizardSerializer < ApplicationSerializer
 
   def current_color_scheme
     color_scheme = Theme.where(id: SiteSetting.default_theme_id).first&.color_scheme
-    colors = color_scheme ? color_scheme.colors : ColorScheme.base_colors
+    colors = color_scheme ? color_scheme.colors : ColorScheme.base.colors
 
     # The frontend expects the color hexs to start with '#'
     colors_with_hash = {}
-    colors.each { |color, hex| colors_with_hash[color] = "##{hex}" }
+    colors.each { |color| colors_with_hash[color.name] = color.hex_with_hash }
     colors_with_hash
   end
 end

--- a/spec/serializers/wizard_serializer_spec.rb
+++ b/spec/serializers/wizard_serializer_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe WizardSerializer do
+  let(:admin) { Fabricate(:admin) }
+
+  after do
+    ColorScheme.hex_cache.clear
+  end
+
+  context "color scheme" do
+    it "works with base colors" do
+      expect(Theme.where(id: SiteSetting.default_theme_id).first&.color_scheme).to be_nil
+
+      wizard = Wizard::Builder.new(admin).build
+      serializer = WizardSerializer.new(wizard, scope: Guardian.new(admin))
+      json = MultiJson.load(MultiJson.dump(serializer.as_json))
+      wjson = json['wizard']
+
+      expect(wjson['current_color_scheme']['primary']).to eq('#222222')
+    end
+
+    it "should provide custom colors correctly" do
+      colors = ColorScheme.create_from_base(name: 'Customized', colors: { header_background: '00FF00', header_primary: '20CCFF' })
+      theme = Fabricate(:theme, color_scheme_id: colors.id)
+
+      SiteSetting.default_theme_id = theme.id
+
+      wizard = Wizard::Builder.new(admin).build
+
+      serializer = WizardSerializer.new(wizard, scope: Guardian.new(admin))
+      # serializer.as_json leaves in Ruby objects, force to true json
+      json = MultiJson.load(MultiJson.dump(serializer.as_json))
+      wjson = json['wizard']
+
+      expect(wjson['current_color_scheme']['header_background']).to eq('#00FF00')
+    end
+  end
+
+  context "steps" do
+    let(:wizard) { Wizard::Builder.new(admin).build }
+    let(:serializer) { WizardSerializer.new(wizard, scope: Guardian.new(admin)) }
+
+    it "has expected steps" do
+      json = MultiJson.load(MultiJson.dump(serializer.as_json))
+      steps = json['wizard']['steps']
+
+      expect(steps.first['id']).to eq('locale')
+      expect(steps.last['id']).to eq('finished')
+
+      privacy_step = steps.find { |s| s['id'] == 'privacy' }
+      expect(privacy_step).to_not be_nil
+      expect(privacy_step['fields'].find { |f| f['id'] == 'privacy' }['choices'].find { |c| c['id'] == 'open' }).to_not be_nil
+    end
+  end
+end


### PR DESCRIPTION
This was likely introduced with the refactor to make ColorSchemeColor a database object. Add a test so this doesn't happen again.

Also test other basics of the WizardSerializer.

For some reason, the .as_json left Ruby objects in; I solved this with a round trip through JSON during the test.