### PR TITLE
FIX: Ensure disabling 2FA works as expected

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/preferences/second-factor.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/second-factor.js
@@ -128,7 +128,7 @@ export default Controller.extend(CanCheckEmails, {
           link: true
         },
         {
-          label: `${iconHTML("ban")}` + I18n.t("user.second_factor.disable"),
+          label: `${iconHTML("ban")}${I18n.t("user.second_factor.disable")}`,
           class: "btn-danger btn-icon-text",
           callback: () => {
             this.model

--- a/app/assets/javascripts/discourse/app/controllers/preferences/second-factor.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/second-factor.js
@@ -2,6 +2,7 @@ import I18n from "I18n";
 import { alias } from "@ember/object/computed";
 import Controller from "@ember/controller";
 import discourseComputed from "discourse-common/utils/decorators";
+import { iconHTML } from "discourse-common/lib/icon-library";
 import CanCheckEmails from "discourse/mixins/can-check-emails";
 import DiscourseURL, { userPath } from "discourse/lib/url";
 import { popupAjaxError } from "discourse/lib/ajax-error";
@@ -119,12 +120,17 @@ export default Controller.extend(CanCheckEmails, {
       if (this.loading) {
         return;
       }
-      bootbox.confirm(
-        I18n.t("user.second_factor.disable_confirm"),
-        I18n.t("cancel"),
-        I18n.t("user.second_factor.disable"),
-        result => {
-          if (result) {
+      const message = I18n.t("user.second_factor.disable_confirm");
+      const buttons = [
+        {
+          label: I18n.t("cancel"),
+          class: "d-modal-cancel",
+          link: true
+        },
+        {
+          label: `${iconHTML("ban")}` + I18n.t("user.second_factor.disable"),
+          class: "btn-danger btn-icon-text",
+          callback: () => {
             this.model
               .disableAllSecondFactors()
               .then(() => {
@@ -137,7 +143,11 @@ export default Controller.extend(CanCheckEmails, {
               .finally(() => this.set("loading", false));
           }
         }
-      );
+      ];
+
+      bootbox.dialog(message, buttons, {
+        classes: "disable-second-factor-modal"
+      });
     },
 
     createTotp() {

--- a/app/assets/javascripts/discourse/app/templates/preferences-second-factor.hbs
+++ b/app/assets/javascripts/discourse/app/templates/preferences-second-factor.hbs
@@ -120,7 +120,7 @@
                   icon="ban"
                   action=(action "disableAllSecondFactors")
                   disabled=loading
-                  label="disable"}}
+                  label="user.second_factor.disable_all"}}
               </div>
             </div>
           {{/unless}}

--- a/app/assets/stylesheets/common/base/user.scss
+++ b/app/assets/stylesheets/common/base/user.scss
@@ -616,7 +616,7 @@
         height: auto;
         text-align: center;
         width: 100%;
-        background: white;
+        background: var(--secondary);
         border: 0;
         cursor: auto;
         outline: none;

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1385,6 +1385,7 @@ class UsersController < ApplicationController
   def disable_second_factor
     # delete all second factors for a user
     current_user.user_second_factors.destroy_all
+    current_user.security_keys.destroy_all
 
     Jobs.enqueue(
       :critical_user_email,

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1076,6 +1076,7 @@ en:
       second_factor:
         title: "Two Factor Authentication"
         enable: "Manage Two Factor Authentication"
+        disable_all: "Disable All"
         forgot_password: "Forgot password?"
         confirm_password_description: "Please confirm your password to continue"
         name: "Name"
@@ -1093,7 +1094,7 @@ en:
         use: "Use Authenticator app"
         enforced_notice: "You are required to enable two factor authentication before accessing this site."
         disable: "Disable"
-        disable_confirm: "Are you sure you want to disable all second factors?"
+        disable_confirm: "Are you sure you want to disable all second factor methods?"
         save: "Save"
         edit: "Edit"
         edit_title: "Edit Second Factor"

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -4088,14 +4088,8 @@ describe UsersController do
       end
       context 'when user has a registered totp and security key' do
         before do
-          expect(user.user_second_factors).to be_empty
-          expect(user.security_keys).to be_empty
-
           totp_second_factor = Fabricate(:user_second_factor_totp, user: user)
           security_key_second_factor = Fabricate(:user_security_key, user: user, factor_type: UserSecurityKey.factor_types[:second_factor])
-
-          expect(user.reload.user_second_factors.totps.first).to eq(totp_second_factor)
-          expect(user.security_keys.first).to eq(security_key_second_factor)
         end
 
         it 'should disable all totp and security keys' do

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -4088,30 +4088,25 @@ describe UsersController do
       end
       context 'when user has a registered totp and security key' do
         before do
-          expect(user.reload.user_second_factors).to be_empty
-          expect(user.reload.security_keys).to be_empty
+          expect(user.user_second_factors).to be_empty
+          expect(user.security_keys).to be_empty
 
           totp_second_factor = Fabricate(:user_second_factor_totp, user: user)
           security_key_second_factor = Fabricate(:user_security_key, user: user, factor_type: UserSecurityKey.factor_types[:second_factor])
 
           expect(user.reload.user_second_factors.totps.first).to eq(totp_second_factor)
-          expect(user.reload.security_keys.first).to eq(security_key_second_factor)
+          expect(user.security_keys.first).to eq(security_key_second_factor)
         end
 
         it 'should disable all totp and security keys' do
-          expect do
+          expect_enqueued_with(job: :critical_user_email, args: { type: :account_second_factor_disabled, user_id: user.id }) do
             put "/u/disable_second_factor.json"
-          end.to change { Jobs::CriticalUserEmail.jobs.length }.by(1)
 
-          expect(response.status).to eq(200)
+            expect(response.status).to eq(200)
 
-          expect(user.reload.user_second_factors).to be_empty
-          expect(user.reload.security_keys).to be_empty
-
-          job_args = Jobs::CriticalUserEmail.jobs.first["args"].first
-
-          expect(job_args["user_id"]).to eq(user.id)
-          expect(job_args["type"]).to eq('account_second_factor_disabled')
+            expect(user.reload.user_second_factors).to be_empty
+            expect(user.security_keys).to be_empty
+          end
         end
       end
     end


### PR DESCRIPTION
This will fix the bug reported [here on Meta](https://meta.discourse.org/t/cant-disable-2fa/160500)

The second factor management page has previously included a "Disable" button. Selecting this button brings up a confirmation:

<img width="619" alt="old" src="https://user-images.githubusercontent.com/22733864/90696567-5a087500-e231-11ea-8156-1ce333502d9f.png">

Instead of disabling all registered TOTP Authenticators **and** Security Keys, confirming only disables all TOTP Authenticators.

---

This PR will change the "Disable" button on the second factor management page to say "Disable All," and make a few styling/copy improvements to the confirmation:

<img width="618" alt="Screen Shot 2020-08-13 at 6 45 51 PM" src="https://user-images.githubusercontent.com/22733864/90697350-0d259e00-e233-11ea-84cf-48b44d0389dd.png">

<img width="618" alt="Screen Shot 2020-08-19 at 3 31 25 PM" src="https://user-images.githubusercontent.com/22733864/90697359-13b41580-e233-11ea-98cb-95262ad444e2.png">


It also fixes the behavior so that **all** second factor methods are removed when using the "Disable All" button.


**Notes**

- The test was tricky and takes heavy inspirations from other tests. I imagine there may be a more elegant or complete implementation, but I'm pretty sure I have the most important functionality tested. If I need to make any changes, let me know.

- Both second factor methods can be disabled individually instead of using the "Disable All" button using the pencil icon buttons showing in the above screenshot. What I came to realize is that the implementation for individual disabling is quite different than the disable all method. The "Disable All" button deletes the relevant `user_second_factors` and `user_security_keys` records from the database, whereas disabling the second factors individually sets `enabled: false` in the relevant record and keeps it around. This is not new behavior and nothing is technically broken, I just wanted to bring it up in case we might want to have consistency. If anything needs to change, I imagine it can be addressed in a follow-up commit.