### PR TITLE
FIX: symbols and strings should be treated similarly while saving custom fields

### DIFF
--- a/app/models/concerns/has_custom_fields.rb
+++ b/app/models/concerns/has_custom_fields.rb
@@ -274,7 +274,7 @@ module HasCustomFields
 protected
 
   def refresh_custom_fields_from_db
-    target = Hash.new
+    target = HashWithIndifferentAccess.new
     _custom_fields.order('id asc').pluck(:name, :value).each do |key, value|
       self.class.append_custom_field(target, key, value)
     end

--- a/app/models/concerns/has_custom_fields.rb
+++ b/app/models/concerns/has_custom_fields.rb
@@ -203,7 +203,7 @@ module HasCustomFields
 
   def save_custom_fields(force = false)
     if force || !custom_fields_clean?
-      dup = @custom_fields.dup
+      dup = @custom_fields.dup.with_indifferent_access
       array_fields = {}
 
       ActiveRecord::Base.transaction do

--- a/spec/components/concern/has_custom_fields_spec.rb
+++ b/spec/components/concern/has_custom_fields_spec.rb
@@ -354,7 +354,7 @@ describe HasCustomFields do
          expect(test_item.custom_fields[:bob]).to eq('marley')
          expect(test_item.custom_fields[:jack]).to eq('black')
 
-         ## Update via string index again
+         # Update via string index again
          test_item.custom_fields['bob'] = 'the builder'
 
          expect(test_item.custom_fields[:bob]).to eq('the builder')

--- a/spec/components/concern/has_custom_fields_spec.rb
+++ b/spec/components/concern/has_custom_fields_spec.rb
@@ -337,6 +337,32 @@ describe HasCustomFields do
         expect(test_item.custom_fields['hello']).to eq('world')
         expect(test_item.custom_fields['abc']).to eq('ghi')
       end
+
+      it 'allows using string and symbol indices interchangably' do
+        test_item = CustomFieldsTestItem.new
+
+        test_item.custom_fields["bob"] = "marley"
+        test_item.custom_fields["jack"] = "black"
+
+         # In memory
+         expect(test_item.custom_fields[:bob]).to eq('marley')
+         expect(test_item.custom_fields[:jack]).to eq('black')
+
+         # Persisted
+         test_item.save
+         test_item.reload
+         expect(test_item.custom_fields[:bob]).to eq('marley')
+         expect(test_item.custom_fields[:jack]).to eq('black')
+
+         ## Update via string index again
+         test_item.custom_fields['bob'] = 'the builder'
+
+         expect(test_item.custom_fields[:bob]).to eq('the builder')
+         test_item.save
+         test_item.reload
+
+         expect(test_item.custom_fields[:bob]).to eq('the builder')
+      end
     end
   end
 end

--- a/spec/components/concern/has_custom_fields_spec.rb
+++ b/spec/components/concern/has_custom_fields_spec.rb
@@ -338,7 +338,7 @@ describe HasCustomFields do
         expect(test_item.custom_fields['abc']).to eq('ghi')
       end
 
-      it 'allows using string and symbol indices interchangably' do
+      it 'allows using string and symbol indices interchangeably' do
         test_item = CustomFieldsTestItem.new
 
         test_item.custom_fields["bob"] = "marley"


### PR DESCRIPTION
- As discussed here
https://meta.discourse.org/t/inconsistent-behaviour-in-userupdater-class/161360