### PR TITLE
FIX: 🐛 category & tag search regex to support thai character

### DIFF
--- a/lib/search.rb
+++ b/lib/search.rb
@@ -479,7 +479,7 @@ class Search
     end
   end
 
-  advanced_filter(/^\#([\p{L}0-9\-:=]+)$/) do |posts, match|
+  advanced_filter(/^\#([\p{L}\p{M}0-9\-:=]+)$/) do |posts, match|
 
     exact = true
 
@@ -601,11 +601,11 @@ class Search
     end
   end
 
-  advanced_filter(/^tags?:([\p{L}0-9,\-_+]+)$/) do |posts, match|
+  advanced_filter(/^tags?:([\p{L}\p{M}0-9,\-_+]+)$/) do |posts, match|
     search_tags(posts, match, positive: true)
   end
 
-  advanced_filter(/^\-tags?:([\p{L}0-9,\-_+]+)$/) do |posts, match|
+  advanced_filter(/^\-tags?:([\p{L}\p{M}0-9,\-_+]+)$/) do |posts, match|
     search_tags(posts, match, positive: false)
   end
 

--- a/spec/components/search_spec.rb
+++ b/spec/components/search_spec.rb
@@ -1459,6 +1459,14 @@ describe Search do
         expect(Search.execute('tags:さようなら').posts.map(&:id)).to eq([post.id])
       end
 
+      it 'can find posts with thai tag' do
+        topic = Fabricate(:topic)
+        topic.tags = [Fabricate(:tag, name: 'เรซิ่น')]
+        post = Fabricate(:post, raw: 'Testing post', topic: topic)
+
+        expect(Search.execute('tags:เรซิ่น').posts.map(&:id)).to eq([post.id])
+      end
+
       it 'can find posts with any tag from multiple tags' do
         expect(Search.execute('tags:eggs,lunch').posts.map(&:id).sort).to eq([post1.id, post2.id, post3.id, post4.id, post5.id].sort)
       end


### PR DESCRIPTION
This PR refers to this topic. https://meta.discourse.org/t/cannot-search-by-thai-tag/160699

Currently, advanced_filter regex will not match Thai character.
<img width="756" alt="image" src="https://user-images.githubusercontent.com/55190391/90759443-a1166900-e30a-11ea-9b0f-32ecb82a831e.png">


This fix will solve the issue for searching tag & category in Thai.
<img width="757" alt="image" src="https://user-images.githubusercontent.com/55190391/90759616-dfac2380-e30a-11ea-916e-cefb9e705805.png">
