### PR TITLE
FIX - make Discobot new user tutorial a little more robust

### DIFF
--- a/plugins/discourse-narrative-bot/config/locales/server.en.yml
+++ b/plugins/discourse-narrative-bot/config/locales/server.en.yml
@@ -201,11 +201,23 @@ en:
         like_not_found: |-
           Did you forget to like :heart: my [post?](%{url}) :crying_cat_face:
         not_found: |-
-          Looks like you didn’t upload an image so I’ve choosen a picture that I’m _sure_ you will enjoy.
+          Looks like you didn’t upload an image so I’ve chosen a picture that I’m _sure_ you will enjoy.
 
           `%{image_url}`
 
           Try uploading that one next, or pasting the link in on a line by itself!
+
+      likes:
+        instructions: |-
+          Here’s a picture of a unicorn:
+
+          <img src="%{base_uri}/plugins/discourse-narrative-bot/images/unicorn.png" width="520" height="520">
+
+          If you like it (and who wouldn’t!) go ahead and press the like :heart: button below this post to let me know.
+        reply: |-
+          Thanks for liking my post!
+        not_found: |-
+          Did you forget to like :heart: my [post?](%{url}) :crying_cat_face:
 
       formatting:
         instructions: |-

--- a/plugins/discourse-narrative-bot/lib/discourse_narrative_bot/new_user_narrative.rb
+++ b/plugins/discourse-narrative-bot/lib/discourse_narrative_bot/new_user_narrative.rb
@@ -80,7 +80,22 @@ module DiscourseNarrativeBot
         }
       },
 
+      # Note: tutorial_images and tutorial_likes are mutually exclusive.
+      #       The prerequisites should ensure only one of them is called.
       tutorial_images: {
+        prerequisite: Proc.new { @user.has_trust_level?(SiteSetting.min_trust_to_post_embedded_media) },
+        next_state: :tutorial_likes,
+        next_instructions: Proc.new { I18n.t("#{I18N_KEY}.likes.instructions", base_uri: Discourse.base_uri) },
+        reply: {
+          action: :reply_to_image
+        },
+        like: {
+          action: :track_images_like
+        }
+      },
+
+      tutorial_likes: {
+        prerequisite: Proc.new { !@user.has_trust_level?(SiteSetting.min_trust_to_post_embedded_media) },
         next_state: :tutorial_flag,
         next_instructions: Proc.new {
           I18n.t("#{I18N_KEY}.flag.instructions",
@@ -88,11 +103,12 @@ module DiscourseNarrativeBot
             about_url: url_helpers(:about_index_url),
             base_uri: Discourse.base_uri)
         },
-        reply: {
-          action: :reply_to_image
-        },
         like: {
-          action: :track_like
+          action: :reply_to_likes
+        },
+        reply: {
+          next_state: :tutorial_likes,
+          action: :missing_likes_like
         }
       },
 
@@ -278,7 +294,7 @@ module DiscourseNarrativeBot
       end
     end
 
-    def track_like
+    def track_images_like
       post_topic_id = @post.topic_id
       return unless valid_topic?(post_topic_id)
 
@@ -360,6 +376,45 @@ module DiscourseNarrativeBot
       reply = reply_to(@post, raw) unless @data[:attempted] && !transition
       enqueue_timeout_job(@user)
       transition ? reply : false
+    end
+
+    def missing_likes_like
+      return unless valid_topic?(@post.topic_id)
+      return if @post.user_id == self.discobot_user.id
+
+      fake_delay
+      enqueue_timeout_job(@user)
+
+      last_post = Post.find_by(id: @data[:last_post_id])
+      reply_to(@post, I18n.t("#{I18N_KEY}.likes.not_found", i18n_post_args(url: last_post.url)))
+      false
+    end
+
+    def reply_to_likes
+      post_topic_id = @post.topic_id
+      return unless valid_topic?(post_topic_id)
+
+      post_liked = PostAction.find_by(
+        post_action_type_id: PostActionType.types[:like],
+        post_id: @data[:last_post_id],
+        user_id: @user.id
+      )
+
+      if post_liked
+        raw = <<~RAW
+          #{I18n.t("#{I18N_KEY}.likes.reply", i18n_post_args)}
+
+          #{instance_eval(&@next_instructions)}
+        RAW
+
+        fake_delay
+
+        reply = reply_to(@post, raw)
+        enqueue_timeout_job(@user)
+        return reply
+      end
+
+      false
     end
 
     def reply_to_formatting

--- a/plugins/discourse-narrative-bot/plugin.rb
+++ b/plugins/discourse-narrative-bot/plugin.rb
@@ -300,4 +300,17 @@ after_initialize do
     DiscourseNarrativeBot::BOT_USER_ID,
     "discobot@discourse.org"
   )
+
+  PostGuardian.class_eval do
+    alias_method :existing_can_create_post?, :can_create_post?
+
+    def can_create_post?(parent)
+      return true if SiteSetting.discourse_narrative_bot_enabled &&
+        parent.try(:subtype) == "system_message" &&
+        parent.try(:user) == ::DiscourseNarrativeBot::Base.new.discobot_user
+
+      existing_can_create_post?(parent)
+    end
+  end
+
 end

--- a/plugins/discourse-narrative-bot/spec/discourse_narrative_bot/new_user_narrative_spec.rb
+++ b/plugins/discourse-narrative-bot/spec/discourse_narrative_bot/new_user_narrative_spec.rb
@@ -542,8 +542,6 @@ describe DiscourseNarrativeBot::NewUserNarrative do
       end
     end
 
-    # TODO - ensure there are tests for the images and likes prerequisites
-
     describe 'likes tutorial' do
       let(:post_2) { Fabricate(:post, topic: topic) }
 
@@ -585,8 +583,6 @@ describe DiscourseNarrativeBot::NewUserNarrative do
 
             expect(narrative.get_data(user)[:state].to_sym).to eq(:tutorial_flag)
           end
-
-          # TODO - copy this for prerequisites
 
           describe 'when allow_flagging_staff is false' do
             it 'should go to the right state' do
@@ -761,8 +757,22 @@ describe DiscourseNarrativeBot::NewUserNarrative do
           end
         end
 
-        # TODO - the right reply depends on whether images are enabled or not
-        #      - see 'when user mentions is disabled' <-- copy that
+        describe 'when min_trust_to_post_embedded_media is too high' do
+          before do
+            SiteSetting.min_trust_to_post_embedded_media = 4
+          end
+
+          it 'should skip the images tutorial step' do
+            post.update!(
+              raw: "[quote=\"#{post.user}, post:#{post.post_number}, topic:#{topic.id}\"]\n:monkey: :fries:\n[/quote]"
+            )
+
+            narrative.expects(:enqueue_timeout_job).with(user)
+            narrative.input(:reply, user, post: post)
+
+            expect(narrative.get_data(user)[:state].to_sym).to eq(:tutorial_likes)
+          end
+        end
 
         it 'should create the right reply' do
           post.update!(


### PR DESCRIPTION
Plugin allows reply, regardless of other SiteSettings

Skip image upload step if user can’t upload images, calls new ‘likes’ step instead