### PR TITLE
FIX: Bookmark list showing wrong no content message

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/user-activity-bookmarks.js
+++ b/app/assets/javascripts/discourse/app/controllers/user-activity-bookmarks.js
@@ -41,9 +41,20 @@ export default Controller.extend({
       });
   },
 
-  @discourseComputed("loaded", "content.length", "noResultsHelp")
-  noContent(loaded, contentLength, noResultsHelp) {
-    return loaded && contentLength === 0 && noResultsHelp;
+  @discourseComputed("loaded", "content.length")
+  noContent(loaded, contentLength) {
+    return loaded && contentLength === 0;
+  },
+
+  @discourseComputed("noResultsHelp", "noContent")
+  noResultsHelpMessage(noResultsHelp, noContent) {
+    if (noResultsHelp) {
+      return noResultsHelp;
+    }
+    if (noContent) {
+      return I18n.t("bookmarks.no_user_bookmarks");
+    }
+    return "";
   },
 
   @action
@@ -78,7 +89,6 @@ export default Controller.extend({
 
   _processLoadResponse(response) {
     if (!response) {
-      this._bookmarksListDenied();
       return;
     }
 

--- a/app/assets/javascripts/discourse/app/templates/user/bookmarks.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user/bookmarks.hbs
@@ -11,7 +11,7 @@
       icon="search"}}
 </div>
 {{#if noContent}}
-  <div class="alert alert-info">{{noResultsHelp}}</div>
+  <div class="alert alert-info">{{noResultsHelpMessage}}</div>
 {{else}}
   {{bookmark-list
     loadMore=(action "loadMore")

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -303,6 +303,7 @@ en:
       no_timezone: 'You have not set a timezone yet. You will not be able to set reminders. Set one up <a href="%{basePath}/my/preferences/profile">in your profile</a>.'
       invalid_custom_datetime: "The date and time you provided is invalid, please try again."
       list_permission_denied: "You do not have permission to view this user's bookmarks."
+      no_user_bookmarks: "You have no bookmarked posts; bookmarks allow you to quickly refer to specific posts."
       auto_delete_preference:
         label: "Automatically delete"
         never: "Never"


### PR DESCRIPTION
Meta report: https://meta.discourse.org/t/spurious-permissions-error-after-deleting-last-bookmark/161289

When deleting all bookmarks in their list, users were seeing an "access denied" message instead of the regular no content message. This is because when we were calling `loadMore` and no further results were returned, we were presuming the null response from the resolved promise meant that there was a permissions error. Fixed this and moved the message into a computed property to show the correct message.