### PR TITLE
UX: Tweaks to admin color palette dropdown

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/color-palettes/color-palettes-row.js
+++ b/app/assets/javascripts/select-kit/addon/components/color-palettes/color-palettes-row.js
@@ -10,11 +10,24 @@ export default SelectKitRowComponent.extend({
 
   palettes: computed("item.colors.[]", function() {
     return (this.item.colors || [])
+      .filter(color => color.name !== "secondary")
       .map(color => `#${escapeExpression(color.hex)}`)
       .map(
         hex => `<span class="palette" style="background-color:${hex}"></span>`
       )
       .join("")
       .htmlSafe();
+  }),
+
+  backgroundColor: computed("item.colors.[]", function() {
+    const secondary = (this.item.colors || []).find(
+      c => c.name === "secondary"
+    );
+
+    if (secondary && secondary.hex) {
+      return `background-color:#${escapeExpression(secondary.hex)}`.htmlSafe();
+    } else {
+      return "";
+    }
   })
 });

--- a/app/assets/javascripts/select-kit/addon/templates/components/color-palettes/color-palettes-row.hbs
+++ b/app/assets/javascripts/select-kit/addon/templates/components/color-palettes/color-palettes-row.hbs
@@ -3,7 +3,7 @@
 </span>
 
 {{#if item.colors}}
-  <div class="palettes">
+  <div class="palettes" style={{backgroundColor}}>
     {{palettes}}
   </div>
 {{/if}}

--- a/app/assets/stylesheets/common/select-kit/color-palettes.scss
+++ b/app/assets/stylesheets/common/select-kit/color-palettes.scss
@@ -7,6 +7,7 @@
           align-items: center;
           margin-left: 0.5em;
           flex: 1 0 0;
+          padding: 8px;
 
           .palette {
             height: 15px;

--- a/app/controllers/admin/themes_controller.rb
+++ b/app/controllers/admin/themes_controller.rb
@@ -135,8 +135,6 @@ class Admin::ThemesController < Admin::AdminController
                                           theme_fields: :upload
                                           )
     @color_schemes = ColorScheme.all.includes(:theme, color_scheme_colors: :color_scheme).to_a
-    light = ColorScheme.new(name: I18n.t("color_schemes.light_default"))
-    @color_schemes.unshift(light)
 
     payload = {
       themes: ActiveModel::ArraySerializer.new(@themes, each_serializer: ThemeSerializer),

--- a/spec/requests/admin/themes_controller_spec.rb
+++ b/spec/requests/admin/themes_controller_spec.rb
@@ -252,7 +252,7 @@ describe Admin::ThemesController do
 
       json = response.parsed_body
 
-      expect(json["extras"]["color_schemes"].length).to eq(2)
+      expect(json["extras"]["color_schemes"].length).to eq(1)
       theme_json = json["themes"].find { |t| t["id"] == theme.id }
       expect(theme_json["theme_fields"].length).to eq(2)
       expect(theme_json["remote_theme"]["remote_version"]).to eq("7")


### PR DESCRIPTION
1. Adds a color scheme's background color as a background in the palette preview for admins. 

<img width="346" alt="image" src="https://user-images.githubusercontent.com/368961/90844413-d1253280-e331-11ea-8bb0-d7294d8c34ee.png">

@markvanlan is this close enough to what you had in mind?

2. Following up on https://github.com/discourse/discourse/commit/328ad921fb5658ad4bcb477b0d63e1b9733fcd37, this removes the base scheme from the serializer (included in the frontend via the `translatedNone` select-kit option). 