### PR TITLE
UX: Timeline should jump to the bottom of the post in single-post topics

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/topic.js
+++ b/app/assets/javascripts/discourse/app/controllers/topic.js
@@ -721,8 +721,12 @@ export default Controller.extend(bufferedProperty("model"), {
     },
 
     jumpBottom() {
+      // When a topic only has one lengthy post
+      const jumpEnd = this.model.highest_post_number === 1 ? true : false;
+
       DiscourseURL.routeTo(this.get("model.lastPostUrl"), {
-        skipIfOnScreen: false
+        skipIfOnScreen: false,
+        jumpEnd
       });
     },
 

--- a/app/assets/javascripts/discourse/app/lib/url.js
+++ b/app/assets/javascripts/discourse/app/lib/url.js
@@ -35,6 +35,11 @@ const SERVER_SIDE_ONLY = [
   /^\/invites\//
 ];
 
+// The amount of height (in pixles) that we factor in when jumpEnd is called so
+// that we show a little bit of the post text even on mobile devices instead of
+// scrolling to "suggested topics".
+const JUMP_END_BUFFER = 250;
+
 export function rewritePath(path) {
   const params = path.split("?");
 
@@ -110,13 +115,9 @@ const DiscourseURL = EmberObject.extend({
         let holderHeight = $holder.height();
         let windowHeight = $(window).height() - offsetCalculator();
 
-        // scroll to the bottom of the post and if the post is yuge we go back up the
-        // timeline by a small % of the post height so we can see the bottom of the text.
-        //
-        // otherwise just jump to the top of the post using the lock & holder method.
         if (holderHeight > windowHeight) {
           $(window).scrollTop(
-            $holder.offset().top + (holderHeight - holderHeight / 10)
+            $holder.offset().top + (holderHeight - JUMP_END_BUFFER)
           );
           _transitioning = false;
           return;


### PR DESCRIPTION
Context: https://meta.discourse.org/t/scroll-to-bottom-of-a-topic-with-1-post/161173

Clicking the latest date or dragging the timeline scroller to the bottom in topics with a single lengthy post takes you to the top of that post - even if you're already there.

This PR attempts to address this issue.

The desired result is that topics with a single lengthy post have a slightly different behaviour. When you click on the latest date (or drag the timeline scroller to the very bottom) you should be taken to the bottom of that post.
This is what this PR does. 

I've tested this in a number of different scenarios and I haven't seen any regressions in terms of the current functionality. Again, this only affects topics with a single lengthy post.