### PR TITLE
FIX: prefer timezones over timezone for previews

### DIFF
--- a/plugins/discourse-local-dates/assets/javascripts/lib/local-date-builder.js.es6
+++ b/plugins/discourse-local-dates/assets/javascripts/lib/local-date-builder.js.es6
@@ -83,9 +83,7 @@ export default class LocalDateBuilder {
     const previewedTimezones = [];
 
     const timezones = this.timezones.filter(
-      timezone =>
-        !this._isEqualZones(timezone, this.localTimezone) &&
-        !this._isEqualZones(timezone, this.timezone)
+      timezone => !this._isEqualZones(timezone, this.localTimezone)
     );
 
     previewedTimezones.push({
@@ -105,7 +103,8 @@ export default class LocalDateBuilder {
       this.timezone &&
       displayedTimezone === this.localTimezone &&
       this.timezone !== displayedTimezone &&
-      !this._isEqualZones(displayedTimezone, this.timezone)
+      !this._isEqualZones(displayedTimezone, this.timezone) &&
+      !this.timezones.any(t => this._isEqualZones(t, this.timezone))
     ) {
       timezones.unshift(this.timezone);
     }


### PR DESCRIPTION
eg:

timezone="America/Detroit"
timezones="US/Eastern"

Before this commit we would show America/Detroit in previews and not US/Eastern, given US/Eastern and America/Detroit are equivalent.

After this commit, we will display the date with America/Detroit but show US/Eastern in the previews.