### PR TITLE
FIX: limit number of users addable to group at once

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -36,6 +36,7 @@ class GroupsController < ApplicationController
       groups.where(automatic: true)
     }
   }
+  ADD_MEMBERS_LIMIT = 1000
 
   def index
     unless SiteSetting.enable_group_directory? || current_user&.staff?
@@ -327,6 +328,11 @@ class GroupsController < ApplicationController
     if users.empty? && emails.empty?
       raise Discourse::InvalidParameters.new(
         'usernames or emails must be present'
+      )
+    end
+    if users.length > ADD_MEMBERS_LIMIT
+      return render_json_error(
+        I18n.t("groups.errors.adding_too_many_users", limit: ADD_MEMBERS_LIMIT)
       )
     end
     usernames_already_in_group = group.users.where(id: users.map(&:id)).pluck(:username)

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -411,6 +411,7 @@ en:
       email_already_used_in_category: "'%{email}' is already used by the category '%{category_name}'."
       cant_allow_membership_requests: "You cannot allow membership requests for a group without any owners."
       already_requested_membership: "You have already requested membership for this group."
+      adding_too_many_users: "Maximum %{limit} users can be added at once"
     default_names:
       everyone: "everyone"
       admins: "admins"

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -1245,6 +1245,28 @@ describe GroupsController do
             count: 3
           ))
         end
+
+        it 'display error when try to add to many users at once' do
+          GroupsController.send(:remove_const, "ADD_MEMBERS_LIMIT")
+          GroupsController.const_set("ADD_MEMBERS_LIMIT", 4)
+          user1.update!(username: 'john')
+          user2.update!(username: 'alice')
+          user3 = Fabricate(:user, username: 'bob')
+          user4 = Fabricate(:user, username: 'anna')
+          user5 = Fabricate(:user, username: 'sarah')
+
+          expect do
+            put "/groups/#{group.id}/members.json",
+              params: { user_emails: [user1.email, user2.email, user3.email, user4.email, user5.email].join(",") }
+          end.to change { group.users.count }.by(0)
+
+          expect(response.status).to eq(422)
+
+          expect(response.parsed_body["errors"]).to include(I18n.t(
+            "groups.errors.adding_too_many_users",
+            limit: 4
+          ))
+        end
       end
 
       it "returns 422 if member already exists" do

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -1247,25 +1247,30 @@ describe GroupsController do
         end
 
         it 'display error when try to add to many users at once' do
-          GroupsController.send(:remove_const, "ADD_MEMBERS_LIMIT")
-          GroupsController.const_set("ADD_MEMBERS_LIMIT", 4)
-          user1.update!(username: 'john')
-          user2.update!(username: 'alice')
-          user3 = Fabricate(:user, username: 'bob')
-          user4 = Fabricate(:user, username: 'anna')
-          user5 = Fabricate(:user, username: 'sarah')
+          begin
+            GroupsController.send(:remove_const, "ADD_MEMBERS_LIMIT")
+            GroupsController.const_set("ADD_MEMBERS_LIMIT", 4)
+            user1.update!(username: 'john')
+            user2.update!(username: 'alice')
+            user3 = Fabricate(:user, username: 'bob')
+            user4 = Fabricate(:user, username: 'anna')
+            user5 = Fabricate(:user, username: 'sarah')
 
-          expect do
-            put "/groups/#{group.id}/members.json",
-              params: { user_emails: [user1.email, user2.email, user3.email, user4.email, user5.email].join(",") }
-          end.to change { group.users.count }.by(0)
+            expect do
+              put "/groups/#{group.id}/members.json",
+                params: { user_emails: [user1.email, user2.email, user3.email, user4.email, user5.email].join(",") }
+            end.to change { group.users.count }.by(0)
 
-          expect(response.status).to eq(422)
+            expect(response.status).to eq(422)
 
-          expect(response.parsed_body["errors"]).to include(I18n.t(
-            "groups.errors.adding_too_many_users",
-            limit: 4
-          ))
+            expect(response.parsed_body["errors"]).to include(I18n.t(
+              "groups.errors.adding_too_many_users",
+              limit: 4
+            ))
+          ensure
+            GroupsController.send(:remove_const, "ADD_MEMBERS_LIMIT")
+            GroupsController.const_set("ADD_MEMBERS_LIMIT", 1000)
+          end
         end
       end
 


### PR DESCRIPTION
When someone wants to add > 1000 users at once they will hit a timeout.
Therefore, we should introduce limit and inform the user when limit is exceeded.