### PR TITLE
FIX: Remove unnecessary audio/video parent element load

### DIFF
--- a/app/assets/javascripts/pretty-text/addon/upload-short-url.js
+++ b/app/assets/javascripts/pretty-text/addon/upload-short-url.js
@@ -147,10 +147,6 @@ function _loadCachedShortUrls(uploadElements, siteSettings, opts) {
 
           upload.src = url;
 
-          // this is necessary, otherwise because of the src change the
-          // video/audio just doesn't bother loading!
-          upload.parentElement.load();
-
           // set the url and text for the <a> tag within the <video/audio> tag
           const link = upload.parentElement.querySelector("a");
           if (link) {


### PR DESCRIPTION
Meta report: https://meta.discourse.org/t/sending-many-requests-for-video-audio-upload-while-editing-post/161487

When typing in the composer we are sending a lot of unnecessary load() requests for the video/audio elements. This line was added months ago before we improved previewing/video thumbnails, which have improved things, so it is no longer required. After removing this line everything still works and no more additional requests are sent.