### PR TITLE
FIX: when User is rejected disassociate ReviewableUser

### DIFF
--- a/app/services/user_destroyer.rb
+++ b/app/services/user_destroyer.rb
@@ -115,8 +115,9 @@ class UserDestroyer
       end
     end
 
-    # After the user is deleted, remove the reviewable
+    # After the user is deleted, disassociate the reviewable
     if reviewable = ReviewableUser.pending.find_by(target: user)
+      reviewable.update!(target_id: nil, target_type: nil)
       reviewable.perform(@actor, :reject_user_delete)
     end
 

--- a/db/migrate/20200824043616_disassociate_reviewable_user_data.rb
+++ b/db/migrate/20200824043616_disassociate_reviewable_user_data.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class DisassociateReviewableUserData < ActiveRecord::Migration[6.0]
+  def up
+    DB.exec(
+      <<~SQL
+        UPDATE reviewables r
+        SET target_type = NULL, target_id = NULL
+        FROM reviewables r2
+        LEFT JOIN users ON users.id = r2.target_id 
+        WHERE r2.type = 'ReviewableUser' AND r2.target_type = 'User' AND r2.status = 2 AND users.id IS NULL AND r.id = r2.id
+      SQL
+    )
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/models/reviewable_user_spec.rb
+++ b/spec/models/reviewable_user_spec.rb
@@ -48,6 +48,8 @@ RSpec.describe ReviewableUser, type: :model do
 
       UserDestroyer.new(Discourse.system_user).destroy(user)
       expect(reviewable.reload.rejected?).to eq(true)
+      expect(reviewable.target_id).to be_nil
+      expect(reviewable.target_type).to be_nil
     end
   end
 
@@ -91,6 +93,8 @@ RSpec.describe ReviewableUser, type: :model do
         # Rejecting deletes the user record
         reviewable.reload
         expect(reviewable.target).to be_blank
+        expect(reviewable.target_id).to be_nil
+        expect(reviewable.target_type).to be_nil
 
         expect(ScreenedEmail.should_block?(email)).to eq(true)
         expect(ScreenedIpAddress.should_block?(ip)).to eq(true)


### PR DESCRIPTION
When `must approve users` is set and the user is rejected, we delete
User object however we keep ReviewableUser. It is good for audit
purpose however we should disassociate target_id because another
user may register with the same id.

In addition, I added a migration to fix data

The issue was mentioned here:
https://meta.discourse.org/t/deleted-user-info-shows-up-in-new-user-approval/161720