### PR TITLE
Fixes for getURL() in subfolders and basePath in translations

### DIFF
--- a/app/assets/javascripts/admin/controllers/admin-dashboard-general.js
+++ b/app/assets/javascripts/admin/controllers/admin-dashboard-general.js
@@ -107,7 +107,7 @@ export default Controller.extend(PeriodComputationMixin, {
   @discourseComputed
   trendingSearchDisabledLabel() {
     return I18n.t("admin.dashboard.reports.trending_search.disabled", {
-      basePath: getURL("/")
+      basePath: getURL("")
     });
   },
 

--- a/app/assets/javascripts/admin/templates/dashboard_general.hbs
+++ b/app/assets/javascripts/admin/templates/dashboard_general.hbs
@@ -147,7 +147,7 @@
           filters=trendingSearchFilters
           isEnabled=logSearchQueriesEnabled
           disabledLabel=trendingSearchDisabledLabel}}
-        {{html-safe (i18n "admin.dashboard.reports.trending_search.more" basePath=(base-url))}}
+        {{html-safe (i18n "admin.dashboard.reports.trending_search.more" basePath=(base-path))}}
       </div>
     {{/if}}
   </div>

--- a/app/assets/javascripts/discourse-common/addon/helpers/get-url.js
+++ b/app/assets/javascripts/discourse-common/addon/helpers/get-url.js
@@ -1,5 +1,10 @@
 import { registerUnbound } from "discourse-common/lib/helpers";
 import getUrl from "discourse-common/lib/get-url";
+import deprecated from "discourse-common/lib/deprecated";
 
 registerUnbound("get-url", value => getUrl(value));
-registerUnbound("base-url", () => getUrl(""));
+registerUnbound("base-url", () => {
+  deprecated("Use `{{base-path}}` instead of `{{base-url}}`");
+  return getUrl("");
+});
+registerUnbound("base-path", () => getUrl(""));

--- a/app/assets/javascripts/discourse-common/addon/lib/get-url.js
+++ b/app/assets/javascripts/discourse-common/addon/lib/get-url.js
@@ -2,10 +2,12 @@ let cdn, baseUrl, baseUri;
 let S3BaseUrl, S3CDN;
 
 export default function getURL(url) {
-  if (!url) return url;
-
   if (baseUri === undefined) {
     baseUri = $('meta[name="discourse-base-uri"]').attr("content") || "";
+  }
+
+  if (!url) {
+    return baseUri === "/" ? "" : baseUri;
   }
 
   // if it's a non relative URL, return it.

--- a/app/assets/javascripts/discourse/app/components/suggested-topics.js
+++ b/app/assets/javascripts/discourse/app/components/suggested-topics.js
@@ -63,7 +63,7 @@ export default Component.extend({
         CATEGORY: category ? true : false,
         latestLink: opts.latestLink,
         catLink: opts.catLink,
-        basePath: ""
+        basePath: getURL("")
       });
     } else if (category) {
       return I18n.t("topic.read_more_in_category", opts);

--- a/app/assets/javascripts/discourse/app/controllers/forgot-password.js
+++ b/app/assets/javascripts/discourse/app/controllers/forgot-password.js
@@ -31,7 +31,7 @@ export default Controller.extend(ModalFunctionality, {
     help() {
       this.setProperties({
         offerHelp: I18n.t("forgot_password.help", {
-          basePath: getURL("/")
+          basePath: getURL("")
         }),
         helpSeen: true
       });

--- a/app/assets/javascripts/discourse/app/models/topic-details.js
+++ b/app/assets/javascripts/discourse/app/models/topic-details.js
@@ -58,7 +58,7 @@ const TopicDetails = RestModel.extend({
     } else {
       return I18n.t(localeString, {
         username: User.currentProp("username_lower"),
-        basePath: getURL("/")
+        basePath: getURL("")
       });
     }
   },

--- a/app/assets/javascripts/discourse/app/templates/modal/bookmark.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/bookmark.hbs
@@ -99,7 +99,7 @@
         {{/tap-tile-grid}}
 
       {{else}}
-        <div class="alert alert-info">{{html-safe (i18n "bookmarks.no_timezone" basePath=(base-uri))}}</div>
+        <div class="alert alert-info">{{html-safe (i18n "bookmarks.no_timezone" basePath=(base-path))}}</div>
       {{/if}}
     </div>
 

--- a/test/javascripts/lib/get-url-test.js
+++ b/test/javascripts/lib/get-url-test.js
@@ -62,6 +62,12 @@ QUnit.test("getURL on subfolder install", assert => {
   );
 
   assert.equal(
+    getURL(""),
+    "/forum",
+    "relative url has subfolder without trailing slash"
+  );
+
+  assert.equal(
     getURL("/svg-sprite/forum.example.com/svg-sprite.js"),
     "/forum/svg-sprite/forum.example.com/svg-sprite.js",
     "works when the url has the prefix in the middle"


### PR DESCRIPTION
It also deprecates the `base-url` helper in favor of `base-path`. Mostly for consistency reasons. Ruby uses `base_path` as well. See https://meta.discourse.org/t/94797/8