### PR TITLE
UX: show a generic error on upload for XHR status 0

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/uploads.js
+++ b/app/assets/javascripts/discourse/app/lib/uploads.js
@@ -269,8 +269,9 @@ export function getUploadMarkdown(upload) {
 export function displayErrorForUpload(data, siteSettings) {
   if (data.jqXHR) {
     switch (data.jqXHR.status) {
-      // cancelled by the user
+      // didn't get headers from server, or browser refuses to tell us
       case 0:
+        bootbox.alert(I18n.t("post.errors.upload"));
         return;
 
       // entity too large, usually returned from the web server

--- a/app/assets/javascripts/discourse/app/mixins/upload.js
+++ b/app/assets/javascripts/discourse/app/mixins/upload.js
@@ -106,7 +106,7 @@ export default Mixin.create({
     });
 
     $upload.on("fileuploadfail", (e, data) => {
-      if (!data || data.errorThrown !== "abort") {
+      if (!data) {
         displayErrorForUpload(data, this.siteSettings);
       }
       reset();


### PR DESCRIPTION
This indication covers all cases of network errors, not just "cancelled by user".
The post upload component already has its own handling for user-cancelled uploads, but the generic upload component does not.

Because this error code frequently indicates the browser is refusing to tell the page what's wrong, suggest checking the developer console.

Tested by stopping my localhost server right before attempting to upload a file (browser's net::ERR_CONNECTION_REFUSED).