### PR TITLE
FEATURE: Additional control of iframes in oneboxes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,7 @@ gem 'redis-namespace'
 # better maintained living fork
 gem 'active_model_serializers', '~> 0.8.3'
 
-gem 'onebox', git: "https://github.com/discourse/onebox", branch: :"iframe-control"
+gem 'onebox'
 
 gem 'http_accept_language', require: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,7 @@ gem 'redis-namespace'
 # better maintained living fork
 gem 'active_model_serializers', '~> 0.8.3'
 
-gem 'onebox'
+gem 'onebox', git: "https://github.com/discourse/onebox", branch: :"iframe-control"
 
 gem 'http_accept_language', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,16 @@
+GIT
+  remote: https://github.com/discourse/onebox
+  revision: d11fc20e0bd9ec3159418c94cfbe5c9c796e70c7
+  branch: iframe-control
+  specs:
+    onebox (2.0.2)
+      addressable (~> 2.7.0)
+      htmlentities (~> 4.3)
+      multi_json (~> 1.11)
+      mustache
+      nokogiri (~> 1.7)
+      sanitize
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -242,13 +255,6 @@ GEM
     omniauth-twitter (1.4.0)
       omniauth-oauth (~> 1.1)
       rack
-    onebox (2.0.2)
-      addressable (~> 2.7.0)
-      htmlentities (~> 4.3)
-      multi_json (~> 1.11)
-      mustache
-      nokogiri (~> 1.7)
-      sanitize
     openssl-signature_algorithm (1.0.0)
     optimist (3.0.1)
     parallel (1.19.2)
@@ -511,7 +517,7 @@ DEPENDENCIES
   omniauth-instagram
   omniauth-oauth2
   omniauth-twitter
-  onebox
+  onebox!
   parallel_tests
   pg
   pry-byebug

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,3 @@
-GIT
-  remote: https://github.com/discourse/onebox
-  revision: a096d1804e657b55d86e40714b338e07913bf48a
-  branch: iframe-control
-  specs:
-    onebox (2.0.2)
-      addressable (~> 2.7.0)
-      htmlentities (~> 4.3)
-      multi_json (~> 1.11)
-      mustache
-      nokogiri (~> 1.7)
-      sanitize
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -255,6 +242,13 @@ GEM
     omniauth-twitter (1.4.0)
       omniauth-oauth (~> 1.1)
       rack
+    onebox (2.1.0)
+      addressable (~> 2.7.0)
+      htmlentities (~> 4.3)
+      multi_json (~> 1.11)
+      mustache
+      nokogiri (~> 1.7)
+      sanitize
     openssl-signature_algorithm (1.0.0)
     optimist (3.0.1)
     parallel (1.19.2)
@@ -517,7 +511,7 @@ DEPENDENCIES
   omniauth-instagram
   omniauth-oauth2
   omniauth-twitter
-  onebox!
+  onebox
   parallel_tests
   pg
   pry-byebug

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/discourse/onebox
-  revision: d11fc20e0bd9ec3159418c94cfbe5c9c796e70c7
+  revision: a096d1804e657b55d86e40714b338e07913bf48a
   branch: iframe-control
   specs:
     onebox (2.0.2)

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1553,6 +1553,7 @@ en:
     use_admin_ip_allowlist: "Admins can only log in if they are at an IP address defined in the Screened IPs list (Admin > Logs > Screened Ips)."
     blocked_ip_blocks: "A list of private IP blocks that should never be crawled by Discourse"
     allowed_internal_hosts: "A list of internal hosts that discourse can safely crawl for oneboxing and other purposes"
+    allowed_onebox_iframes: "A list of iframe src domains which are allowed via Onebox embeds. `*` will allow all default Onebox engines."
     allowed_iframes: "A list of iframe src domain prefixes that discourse can safely allow in posts"
     allowed_crawler_user_agents: "User agents of web crawlers that should be allowed to access the site. WARNING! SETTING THIS WILL DISALLOW ALL CRAWLERS NOT LISTED HERE!"
     blocked_crawler_user_agents: "Unique case insensitive word in the user agent string identifying web crawlers that should not be allowed to access the site. Does not apply if allowlist is defined."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1482,6 +1482,11 @@ security:
   allowed_internal_hosts:
     default: ""
     type: list
+  allowed_onebox_iframes:
+    default: "*"
+    type: list
+    allow_any: false
+    choices: "['*'] + Onebox::Engine.all_iframe_origins"
   allowed_iframes:
     default: "https://www.google.com/maps/embed?|https://www.openstreetmap.org/export/embed.html?|https://calendar.google.com/calendar/embed?|https://codepen.io/"
     type: list

--- a/lib/onebox/engine/allowlisted_generic_onebox.rb
+++ b/lib/onebox/engine/allowlisted_generic_onebox.rb
@@ -16,24 +16,6 @@ module Onebox
         Float::INFINITY
       end
 
-      private
-
-      # overwrite to allowlist iframes
-      def is_embedded?
-        return false unless data[:html] && data[:height]
-        return true if AllowlistedGenericOnebox.html_providers.include?(data[:provider_name])
-
-        if data[:html]["iframe"]
-          fragment = Nokogiri::HTML5::fragment(data[:html])
-          if iframe = fragment.at_css("iframe")
-            src = iframe["src"]
-            return src.present? && SiteSetting.allowed_iframes.split("|").any? { |url| src.start_with?(url) }
-          end
-        end
-
-        false
-      end
-
     end
   end
 end

--- a/lib/oneboxer.rb
+++ b/lib/oneboxer.rb
@@ -311,9 +311,16 @@ module Oneboxer
       uri = fd.resolve
       return blank_onebox if uri.blank? || blocked_domains.map { |hostname| uri.hostname.match?(hostname) }.any?
 
+      allowed_iframe_origins = SiteSetting.allowed_onebox_iframes.split("|")
+      if allowed_iframe_origins.include?("*")
+        allowed_iframe_origins = Onebox::Engine.all_iframe_origins
+      end
+      allowed_iframe_origins += SiteSetting.allowed_iframes.split("|")
+
       options = {
         max_width: 695,
         sanitize_config: Onebox::DiscourseOneboxSanitizeConfig::Config::DISCOURSE_ONEBOX,
+        allowed_iframe_origins: allowed_iframe_origins,
         hostname: GlobalSetting.hostname,
       }
 

--- a/spec/components/onebox/engine/allowlisted_generic_onebox_spec.rb
+++ b/spec/components/onebox/engine/allowlisted_generic_onebox_spec.rb
@@ -18,32 +18,4 @@ describe Onebox::Engine::AllowlistedGenericOnebox do
 
   end
 
-  it "allowlists iframes" do
-    allowlisted_body = '<html><head><link rel="alternate" type="application/json+oembed" href="https://allowlist.ed/iframes.json" />'
-    blocklisted_body = '<html><head><link rel="alternate" type="application/json+oembed" href="https://blocklist.ed/iframes.json" />'
-
-    allowlisted_oembed = {
-      type: "rich",
-      height: "100",
-      html: "<iframe src='https://ifram.es/foo/bar'></iframe>"
-    }
-
-    blocklisted_oembed = {
-      type: "rich",
-      height: "100",
-      html: "<iframe src='https://malicious/discourse.org/'></iframe>"
-    }
-
-    stub_request(:get, "https://blocklist.ed/iframes").to_return(status: 200, body: blocklisted_body)
-    stub_request(:get, "https://blocklist.ed/iframes.json").to_return(status: 200, body: blocklisted_oembed.to_json)
-
-    stub_request(:get, "https://allowlist.ed/iframes").to_return(status: 200, body: allowlisted_body)
-    stub_request(:get, "https://allowlist.ed/iframes.json").to_return(status: 200, body: allowlisted_oembed.to_json)
-
-    SiteSetting.allowed_iframes = "discourse.org|https://ifram.es"
-
-    expect(Onebox.preview("https://blocklist.ed/iframes").to_s).to be_empty
-    expect(Onebox.preview("https://allowlist.ed/iframes").to_s).to match("iframe src")
-  end
-
 end


### PR DESCRIPTION
This commit adds a new site setting "allowed_onebox_iframes". By default, all onebox iframes are allowed. When the list of domains is restricted, Onebox will automatically skip engines which require those domains, and use a fallback engine.

(For this draft, the Gemfile is updated to use the Onebox branch. Before merging, the Onebox gem will be bumped and the Gemfile updated to match)