### PR TITLE
fix(de-locale): remove unneeded "e" from titles

### DIFF
--- a/config/locales/client.de.yml
+++ b/config/locales/client.de.yml
@@ -2848,8 +2848,8 @@ de:
       not_available: "Nicht verfügbar!"
     categories_list: "Liste der Kategorien"
     filters:
-      with_topics: "%{filter}e Themen"
-      with_category: "%{filter}e Themen in %{category}"
+      with_topics: "%{filter}"
+      with_category: "%{filter} in %{category}"
       latest:
         title: "Aktuell"
         title_with_count:


### PR DESCRIPTION
In German not all Words can simply be pluralized with an ```e``` at the end. To make this more compatible with a multitude of German words i would suggest to change the ```js.filters.with_topics``` and ```js.filters.with_category``` translations.