### PR TITLE
FIX: ensures period-chooser is not losing query params

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/discovery.js
+++ b/app/assets/javascripts/discourse/app/controllers/discovery.js
@@ -3,11 +3,13 @@ import Controller, { inject as controller } from "@ember/controller";
 import DiscourseURL from "discourse/lib/url";
 import Category from "discourse/models/category";
 import { observes } from "discourse-common/utils/decorators";
+import { inject as service } from "@ember/service";
 
 export default Controller.extend({
   discoveryTopics: controller("discovery/topics"),
   navigationCategory: controller("navigation/category"),
   application: controller(),
+  router: service(),
 
   loading: false,
 
@@ -32,6 +34,16 @@ export default Controller.extend({
     }
 
     url += "/top/" + period;
+
+    const queryParams = this.router.currentRoute.queryParams;
+    if (Object.keys(queryParams).length) {
+      url =
+        `${url}?` +
+        Object.keys(queryParams)
+          .map(key => `${key}=${queryParams[key]}`)
+          .join("&");
+    }
+
     return url;
   },
 

--- a/test/javascripts/acceptance/topic-discovery-test.js
+++ b/test/javascripts/acceptance/topic-discovery-test.js
@@ -1,3 +1,5 @@
+import DiscourseURL from "discourse/lib/url";
+import selectKit from "helpers/select-kit-helper";
 import { acceptance } from "helpers/qunit-helpers";
 import MessageBus from "message-bus-client";
 
@@ -107,3 +109,22 @@ QUnit.test("Live update unread state", async assert => {
     "shows the topic read"
   );
 });
+
+QUnit.test(
+  "Using period chooser when query params are present",
+  async assert => {
+    await visit("/top?f=foo&d=bar");
+
+    sandbox.stub(DiscourseURL, "routeTo");
+
+    const periodChooser = selectKit(".period-chooser");
+
+    await periodChooser.expand();
+    await periodChooser.selectRowByValue("yearly");
+
+    assert.ok(
+      DiscourseURL.routeTo.calledWith("/top/yearly?f=foo&d=bar"),
+      "it keeps the query params"
+    );
+  }
+);


### PR DESCRIPTION
eg repro before:
- visit http://pr-discourse.test/top/weekly?f=foo
- select another period in the period chooser
- f=foo was gone

After this commit it should still be present
