### PR TITLE
DEV: add plugin hooks for silence message parameters

### DIFF
--- a/app/services/user_silencer.rb
+++ b/app/services/user_silencer.rb
@@ -36,7 +36,6 @@ class UserSilencer
         ).format
 
         context = "#{message_type}: '#{post.topic&.title rescue ''}' #{@opts[:reason]}"
-        SystemMessage.create(@user, message_type)
 
         if @by_user
           log_params = { context: context, details: details }
@@ -48,6 +47,7 @@ class UserSilencer
           )
         end
 
+        silence_message_params = {}
         DiscourseEvent.trigger(
           :user_silenced,
           user: @user,
@@ -57,8 +57,11 @@ class UserSilencer
           user_history: @user_history,
           post_id: @opts[:post_id],
           silenced_till: @user.silenced_till,
-          silenced_at: DateTime.now
+          silenced_at: DateTime.now,
+          silence_message_params: silence_message_params
         )
+
+        SystemMessage.create(@user, message_type, **silence_message_params)
         true
       end
     else

--- a/app/services/user_silencer.rb
+++ b/app/services/user_silencer.rb
@@ -61,7 +61,7 @@ class UserSilencer
           silence_message_params: silence_message_params
         )
 
-        SystemMessage.create(@user, message_type, **silence_message_params)
+        SystemMessage.create(@user, message_type, silence_message_params)
         true
       end
     else

--- a/lib/system_message.rb
+++ b/lib/system_message.rb
@@ -21,8 +21,8 @@ class SystemMessage
     params = defaults.merge(params)
     from_system = params[:from_system] || false
 
-    title = I18n.with_locale(@recipient.effective_locale) { I18n.t("system_messages.#{type}.subject_template", params) }
-    raw = I18n.with_locale(@recipient.effective_locale) { I18n.t("system_messages.#{type}.text_body_template", params) }
+    title = params[:message_title] || I18n.with_locale(@recipient.effective_locale) { I18n.t("system_messages.#{type}.subject_template", params) }
+    raw = params[:message_raw] || I18n.with_locale(@recipient.effective_locale) { I18n.t("system_messages.#{type}.text_body_template", params) }
 
     if from_system
       user = Discourse.system_user

--- a/spec/components/system_message_spec.rb
+++ b/spec/components/system_message_spec.rb
@@ -55,6 +55,19 @@ describe SystemMessage do
       ).count).to eq(0)
     end
 
+    it 'allows message_title and message_raw ops to override content' do
+      user = Fabricate(:user)
+      system_user = Discourse.system_user
+
+      post = SystemMessage.create_from_system_user(user, :welcome_invite, { message_title: "override title", message_raw: "override body" })
+      topic = post.topic
+
+      expect(topic.private_message?).to eq(true)
+      expect(topic.title).to eq("override title")
+      expect(topic.subtype).to eq(TopicSubtype.system_message)
+      expect(post.raw).to eq("override body")
+    end
+
     it 'should allow site_contact_group_name' do
       group = Fabricate(:group)
       SiteSetting.site_contact_group_name = group.name

--- a/spec/services/user_silencer_spec.rb
+++ b/spec/services/user_silencer_spec.rb
@@ -26,7 +26,7 @@ describe UserSilencer do
     context 'given a staff user argument' do
       it 'sends the correct message to the silenced user' do
         SystemMessage.unstub(:create)
-        SystemMessage.expects(:create).with(user, :silenced_by_staff).returns(true)
+        SystemMessage.expects(:create).with(user, :silenced_by_staff, {}).returns(true)
         UserSilencer.silence(user, Fabricate.build(:admin))
       end
     end
@@ -34,7 +34,7 @@ describe UserSilencer do
     context 'not given a staff user argument' do
       it 'sends a default message to the user' do
         SystemMessage.unstub(:create)
-        SystemMessage.expects(:create).with(user, :silenced_by_staff).returns(true)
+        SystemMessage.expects(:create).with(user, :silenced_by_staff, {}).returns(true)
         UserSilencer.silence(user, Fabricate.build(:admin))
       end
     end
@@ -42,7 +42,7 @@ describe UserSilencer do
     context 'given a message option' do
       it 'sends that message to the user' do
         SystemMessage.unstub(:create)
-        SystemMessage.expects(:create).with(user, :the_custom_message).returns(true)
+        SystemMessage.expects(:create).with(user, :the_custom_message, {}).returns(true)
         UserSilencer.silence(user, Fabricate.build(:admin), message: :the_custom_message)
       end
     end


### PR DESCRIPTION
Allows plugins to add, and update extra silence message params for custom
i18n vars