### PR TITLE
UX: make category topic counts clickable on mobile

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/mobile/components/parent-category-row.hbs
+++ b/app/assets/javascripts/discourse/app/templates/mobile/components/parent-category-row.hbs
@@ -39,21 +39,27 @@
         {{/if}}
       </tbody>
     </table>
-    <footer class="clearfix">
+    <footer class="clearfix category-topics-count">
       <figure title={{i18n "all_time_desc"}}>
-        {{number category.topics_all_time}}
-        <figcaption>{{i18n "all_time"}}</figcaption>
+        <a href={{category.url}}>
+          {{number category.topics_all_time}}
+          <figcaption>{{i18n "all_time"}}</figcaption>
+        </a>
       </figure>
       {{#if category.pickMonth}}
         <figure title={{i18n "month_desc"}}>
-          {{number category.topics_month}}
-          <figcaption>/ {{i18n "month"}}</figcaption>
+          <a href={{category.url}}>
+            {{number category.topics_month}}
+            <figcaption>/ {{i18n "month"}}</figcaption>
+          </a>
         </figure>
       {{/if}}
       {{#if category.pickWeek}}
         <figure title={{i18n "week_desc"}}>
-          {{number category.topics_week}}
-          <figcaption>/ {{i18n "week"}}</figcaption>
+          <a href={{category.url}}>
+            {{number category.topics_week}}
+            <figcaption>/ {{i18n "week"}}</figcaption>
+          </a>
         </figure>
       {{/if}}
     </footer>

--- a/app/assets/stylesheets/mobile/topic-list.scss
+++ b/app/assets/stylesheets/mobile/topic-list.scss
@@ -409,6 +409,10 @@ tr.category-topic-link {
   }
 }
 
+.category-topics-count a {
+  color: var(--primary);
+}
+
 .topic-list-bottom {
   margin: 20px 0 0 0;
 }


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->

https://meta.discourse.org/t/total-number-of-topics-in-categorys-view-field-should-be-clickable-to-open-that-category/161901

Minor HTML changes. Had to introduce an extra CSS class to keep the existing color of the link, which was previously inherited from the root element.