### PR TITLE
DEV: Restore UploadRecovery specs

### DIFF
--- a/lib/upload_recovery.rb
+++ b/lib/upload_recovery.rb
@@ -95,21 +95,14 @@ class UploadRecovery
   end
 
   def recover_from_local(sha1:, user_id:)
-    public_path = Rails.root.join("public")
-
     @paths ||= begin
       Dir.glob(File.join(
-        public_path,
-        'uploads',
-        'tombstone',
-        RailsMultisite::ConnectionManagement.current_db,
+        Discourse.store.tombstone_dir,
         'original',
         '**',
         '*.*'
       )).concat(Dir.glob(File.join(
-        public_path,
-        'uploads',
-        RailsMultisite::ConnectionManagement.current_db,
+        Discourse.store.upload_path,
         'original',
         '**',
         '*.*'

--- a/spec/lib/upload_recovery_spec.rb
+++ b/spec/lib/upload_recovery_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe UploadRecovery do
 
   describe '#recover' do
     describe 'when given an invalid sha1' do
-      xit 'should not do anything' do
+      it 'does nothing' do
         upload_recovery.expects(:recover_from_local).never
 
         post.update!(
@@ -66,7 +66,7 @@ RSpec.describe UploadRecovery do
       end
     end
 
-    xit 'accepts a custom ActiveRecord relation' do
+    it 'accepts a custom ActiveRecord relation' do
       post.update!(updated_at: 2.days.ago)
       upload.destroy!
 
@@ -85,7 +85,7 @@ RSpec.describe UploadRecovery do
         ).tap(&:link_post_uploads)
       end
 
-      xit 'should recover the attachment' do
+      it 'recovers the attachment' do
         expect do
           upload2.destroy!
         end.to change { post.reload.uploads.count }.from(1).to(0)
@@ -99,7 +99,7 @@ RSpec.describe UploadRecovery do
       end
     end
 
-    xit 'should recover uploads and attachments' do
+    it 'recovers uploads and attachments' do
       stub_request(:get, "http://test.localhost#{upload.url}")
         .to_return(status: 200)
 
@@ -125,7 +125,7 @@ RSpec.describe UploadRecovery do
         ).tap(&:link_post_uploads)
       end
 
-      xit 'should recover the upload' do
+      it 'recovers the upload' do
         stub_request(:get, "http://test.localhost#{upload.url}")
           .to_return(status: 200)
 
@@ -152,7 +152,7 @@ RSpec.describe UploadRecovery do
         ).tap(&:link_post_uploads)
       end
 
-      xit 'should recover the upload' do
+      it 'recovers the upload' do
         stub_request(:get, "http://test.localhost#{upload.url}")
           .to_return(status: 200)
 
@@ -179,7 +179,7 @@ RSpec.describe UploadRecovery do
         ).tap(&:link_post_uploads)
       end
 
-      xit 'should recover the upload' do
+      it 'recovers the upload' do
         stub_request(:get, "http://test.localhost#{upload.url}")
           .to_return(status: 200)
 


### PR DESCRIPTION
Originally disabled in 0c0192e7dabf6959c4248fa0454da206ac9c780f. Upload specs now use separate paths for each spec worker.

Fixes an issue in `UploadRecovery#recover_from_local` – it didn't take into account the testing infix (e.g. `test_0`) in the uploads/tombstone paths.