### PR TITLE
FIX: Users can insert links to topic templates

### DIFF
--- a/app/assets/javascripts/discourse/app/components/edit-category-topic-template.js
+++ b/app/assets/javascripts/discourse/app/components/edit-category-topic-template.js
@@ -3,6 +3,10 @@ import { buildCategoryPanel } from "discourse/components/edit-category-panel";
 import { observes } from "discourse-common/utils/decorators";
 
 export default buildCategoryPanel("topic-template", {
+  // Modals are defined using the singleton pattern.
+  // Opening the insert link modal will destroy the edit category modal.
+  showInsertLinkButton: false,
+
   @observes("activeTab")
   _activeTabChanged: function() {
     if (this.activeTab) {

--- a/app/assets/javascripts/discourse/app/templates/components/edit-category-topic-template.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/edit-category-topic-template.hbs
@@ -1,2 +1,2 @@
 <label>{{i18n "category.topic_template"}}</label>
-{{d-editor value=category.topic_template}}
+{{d-editor value=category.topic_template showLink=showInsertLinkButton}}


### PR DESCRIPTION
Fixing this is tricky. If someone can think of a better solution, please let me know.

When editing a category, both the topic templates editor and the insert hyperlink component are modals. Since we define modals using the singleton pattern, we destroy the modal containing the editor when a user wants to add a hyperlink and discard all their unsaved changes.

~~This PR adds a new action to the application route, which will receive a category object and open the edit modal showing the topic template tab. We pass this action as a callback to the insert-hyperlink component, to get the latest topic template with the new hyperlink.~~

~~We should later refactor this code and avoid using a modal to edit a category.~~


