### PR TITLE
FIX: dont error when bookmark topic is nil

### DIFF
--- a/lib/bookmark_reminder_notification_handler.rb
+++ b/lib/bookmark_reminder_notification_handler.rb
@@ -7,6 +7,7 @@ class BookmarkReminderNotificationHandler
       if bookmark.post.blank? || bookmark.post.deleted_at.present?
         return clear_reminder(bookmark)
       end
+      return unless bookmark.topic
 
       create_notification(bookmark)
 

--- a/spec/jobs/bookmark_reminder_notifications_spec.rb
+++ b/spec/jobs/bookmark_reminder_notifications_spec.rb
@@ -59,4 +59,9 @@ RSpec.describe Jobs::BookmarkReminderNotifications do
       end
     end
   end
+
+  it 'will not send notification when topic is not available' do
+    bookmark1.topic.destroy
+    expect { subject.execute }.not_to raise_error
+  end
 end

--- a/spec/jobs/bookmark_reminder_notifications_spec.rb
+++ b/spec/jobs/bookmark_reminder_notifications_spec.rb
@@ -62,6 +62,8 @@ RSpec.describe Jobs::BookmarkReminderNotifications do
 
   it 'will not send notification when topic is not available' do
     bookmark1.topic.destroy
-    expect { subject.execute }.not_to raise_error
+    bookmark2.topic.destroy
+    bookmark3.topic.destroy
+    expect { subject.execute }.not_to change { Notification.where(notification_type: Notification.types[:bookmark_reminder]).count }
   end
 end


### PR DESCRIPTION
BookmarkReminderNotifcationHandler should not error when topic is not available
