### PR TITLE
User export improvements 2

### DIFF
--- a/app/jobs/regular/export_user_archive.rb
+++ b/app/jobs/regular/export_user_archive.rb
@@ -15,6 +15,7 @@ module Jobs
       user_archive_profile
       badges
       category_preferences
+      visits
     )
 
     HEADER_ATTRS_FOR ||= HashWithIndifferentAccess.new(
@@ -22,6 +23,7 @@ module Jobs
       user_archive_profile: ['location', 'website', 'bio', 'views'],
       badges: ['badge_id', 'badge_name', 'granted_at', 'post_id', 'seq', 'granted_manually', 'notification_id', 'featured_rank'],
       category_preferences: ['category_id', 'category_names', 'notification_level', 'dismiss_new_timestamp'],
+      visits: ['visited_at', 'posts_read', 'mobile', 'time_read'],
     )
 
     def execute(args)
@@ -163,6 +165,22 @@ module Jobs
           piped_category_name(cu.category.id),
           NotificationLevels.all[cu.notification_level],
           cu.last_seen_at
+        ]
+      end
+    end
+
+    def visits_export
+      return enum_for(:visits_export) unless block_given?
+
+      UserVisit
+        .where(user_id: @current_user.id)
+        .order(visited_at: :asc)
+        .each do |uv|
+        yield [
+          uv.visited_at,
+          uv.posts_read,
+          uv.mobile,
+          uv.time_read,
         ]
       end
     end

--- a/app/jobs/regular/export_user_archive.rb
+++ b/app/jobs/regular/export_user_archive.rb
@@ -36,13 +36,13 @@ module Jobs
         if respond_to? filename_method
           h[:filename] = public_send(filename_method)
         else
-          h[:filename] = "#{name}-#{@current_user.username}-#{@timestamp}"
+          h[:filename] = name
         end
         components.push(h)
       end
 
       export_title = 'user_archive'.titleize
-      filename = components.first[:filename]
+      filename = "user_archive-#{@current_user.username}-#{@timestamp}"
       user_export = UserExport.create(file_name: filename, user_id: @current_user.id)
 
       filename = "#{filename}-#{user_export.id}"

--- a/spec/jobs/export_user_archive_spec.rb
+++ b/spec/jobs/export_user_archive_spec.rb
@@ -73,8 +73,8 @@ describe Jobs::ExportUserArchive do
       end
 
       expect(files.size).to eq(Jobs::ExportUserArchive::COMPONENTS.length)
-      expect(files.find { |f| f.match 'user_archive-john_doe-' }).to_not be_nil
-      expect(files.find { |f| f.match 'user_archive_profile-john_doe-' }).to_not be_nil
+      expect(files.find { |f| f == 'user_archive.csv' }).to_not be_nil
+      expect(files.find { |f| f == 'category_preferences.csv' }).to_not be_nil
     end
   end
 


### PR DESCRIPTION
Switch the in-zip filenames to predictable names, like `badges.csv`, and add user_badges / user_visits.