### PR TITLE
FIX: Focus first button in topic admin menu

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/topic-admin-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/topic-admin-menu.js
@@ -1,4 +1,5 @@
 import { createWidget, applyDecorators } from "discourse/widgets/widget";
+import { next } from "@ember/runloop";
 import { h } from "virtual-dom";
 
 createWidget("admin-menu-button", {
@@ -106,6 +107,16 @@ createWidget("topic-admin-menu-button", {
     }
 
     this.state.position = position;
+
+    next(() => {
+      let menuButtons = document.querySelectorAll(
+        ".topic-admin-popup-menu button"
+      );
+
+      if (menuButtons && menuButtons[0]) {
+        menuButtons[0].focus();
+      }
+    });
   },
 
   topicToggleActions() {

--- a/app/assets/javascripts/discourse/app/widgets/topic-admin-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/topic-admin-menu.js
@@ -1,5 +1,4 @@
 import { createWidget, applyDecorators } from "discourse/widgets/widget";
-import { next } from "@ember/runloop";
 import { h } from "virtual-dom";
 
 createWidget("admin-menu-button", {
@@ -107,16 +106,16 @@ createWidget("topic-admin-menu-button", {
     }
 
     this.state.position = position;
+  },
 
-    next(() => {
-      let menuButtons = document.querySelectorAll(
-        ".topic-admin-popup-menu button"
-      );
+  didRenderWidget() {
+    let menuButtons = document.querySelectorAll(
+      ".topic-admin-popup-menu button"
+    );
 
-      if (menuButtons && menuButtons[0]) {
-        menuButtons[0].focus();
-      }
-    });
+    if (menuButtons && menuButtons[0]) {
+      menuButtons[0].focus();
+    }
   },
 
   topicToggleActions() {

--- a/test/javascripts/acceptance/topic-admin-menu-test.js
+++ b/test/javascripts/acceptance/topic-admin-menu-test.js
@@ -34,3 +34,16 @@ QUnit.test(
     );
   }
 );
+
+QUnit.test("Toggle the menu as admin focuses the first item", async assert => {
+  updateCurrentUser({ admin: true });
+
+  await visit("/t/internationalization-localization/280");
+  assert.ok(exists("#topic"), "The topic was rendered");
+  await click(".toggle-admin-menu");
+
+  assert.equal(
+    document.activeElement,
+    document.querySelector(".topic-admin-multi-select > button")
+  );
+});


### PR DESCRIPTION
![Peek 2020-08-31 15-43](https://user-images.githubusercontent.com/920448/91686483-b6a85000-eba0-11ea-85fa-630e970e7e7e.gif)

When using Shift+A to toggle the admin menu for a topic the first button was not focused, so the menu could not be navigated with tab.