### PR TITLE
DEV: Switch our fast_xor gem for xorcist

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,8 +79,7 @@ gem 'rails_multisite'
 
 gem 'fast_xs', platform: :ruby
 
-# may move to xorcist post: https://github.com/fny/xorcist/issues/4
-gem 'fast_xor', platform: :ruby
+gem 'xorcist'
 
 gem 'fastimage'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,9 +130,6 @@ GEM
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
     fast_blank (1.0.0)
-    fast_xor (1.1.3)
-      rake
-      rake-compiler
     fast_xs (0.8.0)
     fastimage (2.2.0)
     ffi (1.13.1)
@@ -296,8 +293,6 @@ GEM
     rainbow (3.0.0)
     raindrops (0.19.1)
     rake (13.0.1)
-    rake-compiler (1.1.1)
-      rake
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -429,6 +424,7 @@ GEM
     webpush (1.0.0)
       hkdf (~> 0.2)
       jwt (~> 2.0)
+    xorcist (1.1.2)
     yaml-lint (0.0.10)
     zeitwerk (2.4.0)
 
@@ -472,7 +468,6 @@ DEPENDENCIES
   fabrication
   fakeweb
   fast_blank
-  fast_xor
   fast_xs
   fastimage
   flamegraph
@@ -560,6 +555,7 @@ DEPENDENCIES
   unicorn
   webmock
   webpush
+  xorcist
   yaml-lint
 
 BUNDLED WITH

--- a/lib/pbkdf2.rb
+++ b/lib/pbkdf2.rb
@@ -1,17 +1,12 @@
 # frozen_string_literal: true
 
-# Note: the pbkdf2 gem is bust on 2.0, the logic is so simple I am not sure it makes sense to have this in a gem atm (Sam)
-#
-# Also PBKDF2 monkey patches string ... don't like that at all
-#
-# Happy to move back to PBKDF2 ruby gem provided:
-#
-# 1. It works on Ruby 2.0
-# 2. It works on 1.9.3
-# 3. It does not monkey patch string
+# Note: This logic was originaly extracted from the Pbkdf2 gem to fix Ruby 2.0
+# issues, but that gem has gone stale so we won't be returning to it.
 
 require 'openssl'
-require 'xor'
+require 'xorcist'
+require 'xorcist/refinements'
+using Xorcist::Refinements
 
 class Pbkdf2
 
@@ -23,18 +18,13 @@ class Pbkdf2
 
     2.upto(iterations) do
       u = prf(h, password, u)
-     ret.xor!(u)
+      ret.xor!(u)
     end
 
     ret.bytes.map { |b| ("0" + b.to_s(16))[-2..-1] }.join("")
   end
 
   protected
-
-  # fallback xor in case we need it for jruby ... way slower
-  def self.xor(x, y)
-    x.bytes.zip(y.bytes).map { |a, b| a ^ b }.pack('c*')
-  end
 
   def self.prf(hash_function, password, data)
     OpenSSL::HMAC.digest(hash_function, password, data)

--- a/lib/pbkdf2.rb
+++ b/lib/pbkdf2.rb
@@ -6,9 +6,9 @@
 require 'openssl'
 require 'xorcist'
 require 'xorcist/refinements'
-using Xorcist::Refinements
 
 class Pbkdf2
+  using Xorcist::Refinements
 
   def self.hash_password(password, salt, iterations, algorithm = "sha256")
 


### PR DESCRIPTION
We use the `xor` function as part of password hashing and we want to use
a faster version than the native ruby xor'ing feature so we use a gem
for this.

fast_xor has been abandoned, and xorcist fixed our initial holdup for
switching in https://github.com/fny/xorcist/issues/4

xorcist also has jruby support so we can remove our jruby fallback
logic.

Didn't add any new tests here because we already have existing tests that should catch any issues.
