### PR TITLE
FIX: emails.rake use authentication

### DIFF
--- a/lib/tasks/emails.rake
+++ b/lib/tasks/emails.rake
@@ -86,7 +86,7 @@ task 'emails:test', [:email] => [:environment] do |_, args|
     #  s.auth_login(smtp[:user_name], smtp[:password])
     #end
 
-    Net::SMTP.start(smtp[:address], smtp[:port], 'localhost', smtp[:user_name], smtp[:password])
+    Net::SMTP.start(smtp[:address], smtp[:port], 'localhost', smtp[:user_name], smtp[:password], smtp[:authentication])
   rescue Exception => e
 
     if e.to_s.match(/execution expired/)


### PR DESCRIPTION
It looks like support got added for DISCOURSE_SMTP_AUTHENTICATION in Discourse, but not in this rake task (or perhaps it's always been broken?).

N.B.: I have not tested this code, but it reportedly works and looks safe to me.

https://meta.discourse.org/t/smtp-unrecognized-authentication-type-with-office-365/145830/6?u=pfaffman

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
