### PR TITLE
FIX: User export category preferences on a deleted category.

### DIFF
--- a/app/jobs/regular/export_user_archive.rb
+++ b/app/jobs/regular/export_user_archive.rb
@@ -162,7 +162,7 @@ module Jobs
         .each do |cu|
         yield [
           cu.category_id,
-          piped_category_name(cu.category.id),
+          piped_category_name(cu.category_id),
           NotificationLevels.all[cu.notification_level],
           cu.last_seen_at
         ]


### PR DESCRIPTION
Tests from a1dd761bd97e748bff5b21d7347ff2a642409fc2 were incomplete and did not test a deleted category's category_users record.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
