### PR TITLE
DEV: Remove rb-inotify gem from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -159,10 +159,6 @@ group :test, :development do
 
   gem 'rb-fsevent', require: RUBY_PLATFORM =~ /darwin/i ? 'rb-fsevent' : false
 
-  # TODO determine if we can update this to 0.10, API changes happened
-  # we would like to upgrade it if possible
-  gem 'rb-inotify', '~> 0.9', require: RUBY_PLATFORM =~ /linux/i ? 'rb-inotify' : false
-
   gem 'rspec-rails'
 
   gem 'shoulda-matchers', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -521,7 +521,6 @@ DEPENDENCIES
   railties (= 6.0.3.2)
   rake
   rb-fsevent
-  rb-inotify (~> 0.9)
   rbtrace
   rchardet
   redis


### PR DESCRIPTION
We are no longer directly referencing the rb-inotify gem directly in
code. This was just a spec level dependency anyways.

Using `git log -S "Inotify"` resulted in these two commits as usages of
`Inotify`:

- b56b11d96aafa5cd9e2f004ae631348fba4574ae
- 9cf03b352cb2bff7c9a7a56211d56a921ed13664

both from 2013, but we no longer are using inotify in

https://github.com/discourse/discourse/blob/master/lib/tasks/autospec.rake

which appears to be the only file that was using it.

Based on this info we can safely remove rb-inotify from the Gemfile.

Just as a side note we still do have a couple of gems that do have
rb-inotify as a dependency: listen, and lru_redux.

I didn't add any additional tests because if one of the tests was actually using this gem I would hope that it would fail.
