### PR TITLE
FIX: don't send mailing list for post with empty content

### DIFF
--- a/app/jobs/regular/notify_mailing_list_subscribers.rb
+++ b/app/jobs/regular/notify_mailing_list_subscribers.rb
@@ -26,7 +26,7 @@ module Jobs
       post_id = args[:post_id]
       post = post_id ? Post.with_deleted.find_by(id: post_id) : nil
 
-      return if !post || post.trashed? || post.user_deleted? || !post.topic
+      return if !post || post.trashed? || post.user_deleted? || !post.topic || post.raw.blank?
 
       users =
           User.activated.not_silenced.not_suspended.real

--- a/spec/jobs/notify_mailing_list_subscribers_spec.rb
+++ b/spec/jobs/notify_mailing_list_subscribers_spec.rb
@@ -65,6 +65,11 @@ describe Jobs::NotifyMailingListSubscribers do
       include_examples "no emails"
     end
 
+    context "with a empty post" do
+      before { post.update_columns(raw: "") }
+      include_examples "no emails"
+    end
+
     context "with a user_deleted post" do
       before { post.update(user_deleted: true) }
       include_examples "no emails"


### PR DESCRIPTION
discourse-assign is creating posts with empty content to show that a user was assign/unassigned for a topic.

It is causing confusing emails with empty content.

The bug was mentioned here: https://meta.discourse.org/t/again-on-empty-emails-and-notifications-generated-on-topic-assignment/162213
