### PR TITLE
PERF: Keep track of first unread PM and first unread group PM for user.

### DIFF
--- a/app/jobs/scheduled/ensure_db_consistency.rb
+++ b/app/jobs/scheduled/ensure_db_consistency.rb
@@ -35,6 +35,9 @@ module Jobs
       UserStat.ensure_consistency!(13.hours.ago)
       measure(UserStat)
 
+      GroupUser.ensure_consistency!(13.hours.ago)
+      measure(GroupUser)
+
       Rails.logger.debug(format_measure)
       nil
     end

--- a/app/models/group_user.rb
+++ b/app/models/group_user.rb
@@ -19,6 +19,52 @@ class GroupUser < ActiveRecord::Base
     NotificationLevels.all
   end
 
+  def self.ensure_consistency!(last_seen = 1.hour.ago)
+    update_first_unread_pm(last_seen)
+  end
+
+  def self.update_first_unread_pm(last_seen, limit: 10_000)
+    DB.exec(<<~SQL, archetype: Archetype.private_message, last_seen: last_seen, limit: limit)
+    UPDATE group_users gu
+    SET first_unread_pm_at = Y.min_date
+    FROM (
+      SELECT
+        X.group_id,
+        X.user_id,
+        X.min_date
+      FROM (
+        SELECT
+          gu2.group_id,
+          gu2.user_id,
+          MIN(t.updated_at) min_date
+        FROM group_users gu2
+        INNER JOIN topic_allowed_groups tag ON tag.group_id = gu2.group_id
+        INNER JOIN topics t ON t.id = tag.topic_id
+        INNER JOIN users u ON u.id = gu2.user_id
+        LEFT JOIN topic_users tu ON t.id = tu.topic_id AND tu.user_id = gu2.user_id
+        WHERE t.deleted_at IS NULL
+        AND t.archetype = :archetype
+        AND tu.last_read_post_number < CASE
+                                       WHEN u.admin OR u.moderator
+                                       THEN t.highest_staff_post_number
+                                       ELSE t.highest_post_number
+                                       END
+        AND (COALESCE(tu.notification_level, 1) >= 2)
+        GROUP BY gu2.user_id, gu2.group_id
+      ) AS X
+      WHERE X.user_id IN (
+        SELECT id
+        FROM users
+        WHERE last_seen_at IS NOT NULL
+        AND last_seen_at > :last_seen
+        ORDER BY last_seen_at DESC
+        LIMIT :limit
+      )
+    ) Y
+    WHERE gu.user_id = Y.user_id AND gu.group_id = Y.group_id
+    SQL
+  end
+
   protected
 
   def set_notification_level

--- a/app/models/user_stat.rb
+++ b/app/models/user_stat.rb
@@ -12,10 +12,59 @@ class UserStat < ActiveRecord::Base
     update_distinct_badge_count
     update_view_counts(last_seen)
     update_first_unread(last_seen)
+    update_first_unread_pm(last_seen)
   end
 
-  def self.update_first_unread(last_seen, limit: 10_000)
-    DB.exec(<<~SQL, min_date: last_seen, limit: limit, now: 10.minutes.ago)
+  UPDATE_UNREAD_MINUTES_AGO = 10
+  UPDATE_UNREAD_USERS_LIMIT = 10_000
+
+  def self.update_first_unread_pm(last_seen, limit: UPDATE_UNREAD_USERS_LIMIT)
+    DB.exec(<<~SQL, archetype: Archetype.private_message, now: UPDATE_UNREAD_MINUTES_AGO.minutes.ago, last_seen: last_seen, limit: limit)
+    UPDATE user_stats us
+    SET first_unread_pm_at = COALESCE(Z.min_date, :now)
+    FROM (
+      SELECT
+        Y.user_id,
+        Y.min_date
+      FROM (
+        SELECT
+          u1.id user_id,
+          X.min_date
+        FROM users u1
+        LEFT JOIN (
+          SELECT
+            tau.user_id,
+            MIN(t.updated_at) min_date
+          FROM topic_allowed_users tau
+          INNER JOIN topics t ON t.id = tau.topic_id
+          INNER JOIN users u ON u.id = tau.user_id
+          LEFT JOIN topic_users tu ON t.id = tu.topic_id AND tu.user_id = tau.user_id
+          WHERE t.deleted_at IS NULL
+          AND t.archetype = :archetype
+          AND tu.last_read_post_number < CASE
+                                         WHEN u.admin OR u.moderator
+                                         THEN t.highest_staff_post_number
+                                         ELSE t.highest_post_number
+                                         END
+          AND (COALESCE(tu.notification_level, 1) >= 2)
+          GROUP BY tau.user_id
+        ) AS X ON X.user_id = u1.id
+      ) AS Y
+      WHERE Y.user_id IN (
+        SELECT id
+        FROM users
+        WHERE last_seen_at IS NOT NULL
+        AND last_seen_at > :last_seen
+        ORDER BY last_seen_at DESC
+        LIMIT :limit
+      )
+    ) AS Z
+    WHERE us.user_id = Z.user_id
+    SQL
+  end
+
+  def self.update_first_unread(last_seen, limit: UPDATE_UNREAD_USERS_LIMIT)
+    DB.exec(<<~SQL, min_date: last_seen, limit: limit, now: UPDATE_UNREAD_MINUTES_AGO.minutes.ago)
       UPDATE user_stats us
       SET first_unread_at = COALESCE(Y.min_date, :now)
       FROM (

--- a/db/migrate/20200902054531_add_first_unread_pm_a_to_group_user.rb
+++ b/db/migrate/20200902054531_add_first_unread_pm_a_to_group_user.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AddFirstUnreadPmAToGroupUser < ActiveRecord::Migration[6.0]
+  def up
+    add_column :group_users, :first_unread_pm_at, :datetime, null: false, default: -> { 'CURRENT_TIMESTAMP' }
+
+    execute <<~SQL
+    UPDATE group_users gu
+    SET first_unread_pm_at = gu.created_at
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/migrate/20200902082203_add_first_unread_pm_at_to_user_stats.rb
+++ b/db/migrate/20200902082203_add_first_unread_pm_at_to_user_stats.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class AddFirstUnreadPmAtToUserStats < ActiveRecord::Migration[6.0]
+  def up
+    add_column :user_stats, :first_unread_pm_at, :datetime, null: false, default: -> { 'CURRENT_TIMESTAMP' }
+
+    execute <<~SQL
+    UPDATE user_stats us
+    SET first_unread_pm_at = u.created_at
+    FROM users u
+    WHERE u.id = us.user_id
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/post_migrate/20200903045539_add_index_topics_on_timestamps_private.rb
+++ b/db/post_migrate/20200903045539_add_index_topics_on_timestamps_private.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class AddIndexTopicsOnTimestampsPrivate < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
+  def up
+    execute <<~SQL
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS
+    index_topics_on_timestamps_private
+    ON topics (bumped_at, created_at, updated_at)
+    WHERE deleted_at IS NULL AND archetype = 'private_message'
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -967,9 +967,19 @@ class TopicQuery
   def unread_messages(params)
     query = TopicQuery.unread_filter(
       messages_for_groups_or_user(params[:my_group_ids]),
-      @user&.id,
-      staff: @user&.staff?)
-      .limit(params[:count])
+      @user.id,
+      staff: @user.staff?
+    )
+
+    first_unread_pm_at =
+      if params[:my_group_ids].present?
+        GroupUser.where(user_id: @user.id, group_id: params[:my_group_ids]).minimum(:first_unread_pm_at)
+      else
+        UserStat.where(user_id: @user.id).pluck(:first_unread_pm_at).first
+      end
+
+    query = query.where("topics.updated_at >= ?", first_unread_pm_at) if first_unread_pm_at
+    query = query.limit(params[:count]) if params[:count]
     query
   end
 

--- a/spec/models/post_timing_spec.rb
+++ b/spec/models/post_timing_spec.rb
@@ -184,4 +184,41 @@ describe PostTiming do
       expect(post.reload.reads).to eq initial_read_count
     end
   end
+
+  describe '.destroy_last_for' do
+    it 'updates first unread for a user correctly when topic is public' do
+      post = Fabricate(:post)
+      post.topic.update!(updated_at: 10.minutes.ago)
+      PostTiming.process_timings(post.user, post.topic_id, 1, [[post.post_number, 100]])
+
+      PostTiming.destroy_last_for(post.user, post.topic_id)
+
+      expect(post.user.user_stat.reload.first_unread_at).to eq_time(post.topic.updated_at)
+    end
+
+    it 'updates first unread for a user correctly when topic is a pm' do
+      post = Fabricate(:private_message_post)
+      post.topic.update!(updated_at: 10.minutes.ago)
+      PostTiming.process_timings(post.user, post.topic_id, 1, [[post.post_number, 100]])
+
+      PostTiming.destroy_last_for(post.user, post.topic_id)
+
+      expect(post.user.user_stat.reload.first_unread_pm_at).to eq_time(post.topic.updated_at)
+    end
+
+    it 'updates first unread for a user correctly when topic is a group pm' do
+      topic = Fabricate(:private_message_topic, updated_at: 10.minutes.ago)
+      post = Fabricate(:post, topic: topic)
+      user = Fabricate(:user)
+      group = Fabricate(:group)
+      group.add(user)
+      topic.allowed_groups << group
+      PostTiming.process_timings(user, topic.id, 1, [[post.post_number, 100]])
+
+      PostTiming.destroy_last_for(user, topic.id)
+
+      expect(GroupUser.find_by(user: user, group: group).first_unread_pm_at)
+        .to eq_time(post.topic.updated_at)
+    end
+  end
 end


### PR DESCRIPTION
This optimization helps to filter away topics so that the joins on
related tables when querying for unread messages is not expensive.