### PR TITLE
FIX: prevents error when opening a composer from a tag page

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/tags-show.js
+++ b/app/assets/javascripts/discourse/app/routes/tags-show.js
@@ -1,3 +1,4 @@
+import { makeArray } from "discourse-common/lib/helpers";
 import I18n from "I18n";
 import DiscourseRoute from "discourse/routes/discourse";
 import Composer from "discourse/models/composer";
@@ -199,7 +200,7 @@ export default DiscourseRoute.extend(FilterModeMixin, {
                 "tags",
                 [
                   controller.get("model.id"),
-                  ...controller.get("additionalTags"),
+                  ...makeArray(controller.additionalTags),
                 ].filter(Boolean)
               );
             }


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
