### PR TITLE
FEATURE: add user opt to select bookmarks as home

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/preferences/interface.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/interface.js
@@ -25,6 +25,7 @@ const USER_HOMES = {
   3: "unread",
   4: "new",
   5: "top",
+  6: "bookmarks",
 };
 
 const TEXT_SIZES = ["smallest", "smaller", "normal", "larger", "largest"];

--- a/app/models/user_option.rb
+++ b/app/models/user_option.rb
@@ -163,6 +163,7 @@ class UserOption < ActiveRecord::Base
     when 3 then "unread"
     when 4 then "new"
     when 5 then "top"
+    when 6 then "bookmarks"
     else SiteSetting.homepage
     end
   end

--- a/test/javascripts/acceptance/preferences-test.js
+++ b/test/javascripts/acceptance/preferences-test.js
@@ -427,3 +427,33 @@ QUnit.test("can select an option from a dropdown", async (assert) => {
   await field.selectRowByValue("Cat");
   assert.equal(field.header().value(), "Cat", "it sets the value of the field");
 });
+
+acceptance(
+  "User Preferences, selecting bookmarks discovery as user's default homepage",
+  {
+    loggedIn: true,
+    settings: {
+      top_menu: "categories|latest|top|bookmarks",
+    },
+  }
+);
+
+QUnit.test(
+  "selecting bookmarks as home directs home to bookmarks",
+  async (assert) => {
+    await visit("/u/eviltrout/preferences/interface");
+    assert.ok(exists(".home .combo-box"), "it has a home selector combo-box");
+
+    const field = selectKit(".home .combo-box");
+    await field.expand();
+    await field.selectRowByValue("6");
+    await click(".save-changes");
+    await visit("/");
+    assert.ok(exists(".topic-list"), "The list of topics was rendered");
+    assert.equal(
+      currentPath(),
+      "discovery.bookmarks",
+      "it navigates to bookmarks"
+    );
+  }
+);

--- a/test/javascripts/fixtures/discovery_fixtures.js
+++ b/test/javascripts/fixtures/discovery_fixtures.js
@@ -1143,6 +1143,250 @@ export default {
       ]
     }
   },
+  "/bookmarks.json": {
+    users: [
+      { id: 7204, username: "reyman64", avatar_template: "/images/avatar.png" },
+      { id: 1, username: "sam", avatar_template: "/images/avatar.png" },
+      { id: 5481, username: "f0rkz", avatar_template: "/images/avatar.png" },
+      { id: 6473, username: "jkf", avatar_template: "/images/avatar.png" },
+      {
+        id: 6973,
+        username: "stellarhopper",
+        avatar_template: "/images/avatar.png"
+      },
+      {
+        id: 19,
+        username: "eviltrout",
+        name: "Evil Trout",
+        avatar_template: "/images/avatar.png"
+      },
+      { id: 14, username: "clay", avatar_template: "/images/avatar.png" },
+      {
+        id: 32,
+        username: "codinghorror",
+        avatar_template: "/images/avatar.png"
+      },
+      { id: 1917, username: "sil", avatar_template: "/images/avatar.png" },
+      { id: 7197, username: "peeja", avatar_template: "/images/avatar.png" },
+      { id: 1995, username: "zogstrip", avatar_template: "/images/avatar.png" },
+      {
+        id: 8021,
+        username: "Abhishek_Gupta",
+        avatar_template: "/images/avatar.png"
+      },
+      { id: 2291, username: "PabloC", avatar_template: "/images/avatar.png" },
+      { id: 791, username: "srid", avatar_template: "/images/avatar.png" },
+      {
+        id: 1580,
+        username: "ABillionSuns",
+        avatar_template: "/images/avatar.png"
+      },
+      { id: 7270, username: "mhurwi", avatar_template: "/images/avatar.png" },
+      {
+        id: 6695,
+        username: "illspirit",
+        avatar_template: "/images/avatar.png"
+      },
+      { id: 6929, username: "BCHK", avatar_template: "/images/avatar.png" },
+      { id: 4385, username: "jeans", avatar_template: "/images/avatar.png" },
+      { id: 7073, username: "5an1ty", avatar_template: "/images/avatar.png" },
+      { id: 6626, username: "riking", avatar_template: "/images/avatar.png" },
+      { id: 4457, username: "Lee_Ars", avatar_template: "/images/avatar.png" },
+      { id: 4263, username: "mcwumbly", avatar_template: "/images/avatar.png" },
+      {
+        id: 8134,
+        username: "iontishina",
+        avatar_template: "/images/avatar.png"
+      },
+      { id: 2072, username: "nXqd", avatar_template: "/images/avatar.png" },
+      {
+        id: 4983,
+        username: "hey_julien",
+        avatar_template: "/images/avatar.png"
+      },
+      {
+        id: 3657,
+        username: "steelmaiden",
+        avatar_template: "/images/avatar.png"
+      },
+      { id: 2624, username: "BowlingX", avatar_template: "/images/avatar.png" },
+      {
+        id: 8085,
+        username: "watchmanmonitor",
+        avatar_template: "/images/avatar.png"
+      },
+      { id: 4612, username: "Iszi", avatar_template: "/images/avatar.png" },
+      {
+        id: 8018,
+        username: "shivermetimbers",
+        avatar_template: "/images/avatar.png"
+      },
+      {
+        id: 6060,
+        username: "lightyear",
+        avatar_template: "/images/avatar.png"
+      },
+      { id: 2, username: "neil", avatar_template: "/images/avatar.png" },
+      { id: 8037, username: "printec", avatar_template: "/images/avatar.png" },
+      { id: 3415, username: "radq", avatar_template: "/images/avatar.png" },
+      {
+        id: 6283,
+        username: "hrishikesh",
+        avatar_template: "/images/avatar.png"
+      },
+      {
+        id: 471,
+        username: "BhaelOchon",
+        avatar_template: "/images/avatar.png"
+      },
+      { id: 6548, username: "michaeld", avatar_template: "/images/avatar.png" },
+      {
+        id: 7286,
+        username: "mrotsnahoj",
+        avatar_template: "/images/avatar.png"
+      },
+      { id: 3169, username: "dgw", avatar_template: "/images/avatar.png" },
+      {
+        id: 926,
+        username: "martinnormark",
+        avatar_template: "/images/avatar.png"
+      },
+      { id: 2003, username: "taylor", avatar_template: "/images/avatar.png" },
+      { id: 369, username: "CvX", avatar_template: "/images/avatar.png" },
+      { id: 562, username: "nightpool", avatar_template: "/images/avatar.png" },
+      { id: 6653, username: "amitfrid", avatar_template: "/images/avatar.png" },
+      {
+        id: 6677,
+        username: "Tropnevad",
+        avatar_template: "/images/avatar.png"
+      },
+      {
+        id: 5048,
+        username: "SneakySly",
+        avatar_template: "/images/avatar.png"
+      },
+      { id: 7333, username: "Jong", avatar_template: "/images/avatar.png" },
+      { id: 3124, username: "sipp11", avatar_template: "/images/avatar.png" },
+      { id: 7604, username: "citkane", avatar_template: "/images/avatar.png" },
+      { id: 3929, username: "ScotterC", avatar_template: "/images/avatar.png" },
+      { id: 6680, username: "cdman", avatar_template: "/images/avatar.png" },
+      { id: 500, username: "aeid", avatar_template: "/images/avatar.png" },
+      { id: 8, username: "geek", avatar_template: "/images/avatar.png" },
+      { id: 606, username: "Cafeine", avatar_template: "/images/avatar.png" }
+    ],
+    topic_list: {
+      can_create_topic: false,
+      more_topics_url: "/bookmarks.json?page=1",
+      draft: null,
+      draft_key: "new_topic",
+      draft_sequence: null,
+      topics: [
+        {
+          id: 11557,
+          title: "Error after upgrade to 0.9.7.9+",
+          fancy_title: "Error after upgrade to 0.9.7.9+",
+          slug: "error-after-upgrade-to-0-9-7-9",
+          posts_count: 83,
+          reply_count: 58,
+          highest_post_number: 85,
+          image_url: null,
+          created_at: "2013-12-22T17:12:05.000-05:00",
+          last_posted_at: "2014-01-16T00:52:30.000-05:00",
+          bumped: true,
+          bumped_at: "2014-01-16T00:52:30.000-05:00",
+          unseen: false,
+          pinned: true,
+          excerpt:
+            "Hi, \n\nI&#39;m using webfaction postgresql specific private instance to run discourse (custom port already configured for discourse 0.9.7.6). \n\nThis is not my first update, but this time i have an error. Impossible to upgrade&hellip;",
+          visible: true,
+          closed: false,
+          archived: false,
+          views: 1230,
+          like_count: 40,
+          has_summary: true,
+          archetype: "regular",
+          last_poster_username: "stellarhopper",
+          category_id: 17,
+          posters: [
+            { extras: null, description: "Original Poster", user_id: 7204 },
+            { extras: null, description: "Most Posts", user_id: 1 },
+            { extras: null, description: "Frequent Poster", user_id: 5481 },
+            { extras: null, description: "Frequent Poster", user_id: 6473 },
+            {
+              extras: "latest",
+              description: "Most Recent Poster",
+              user_id: 6973
+            }
+          ]
+        },
+        {
+          id: 1,
+          title: "Welcome to meta.discourse.org",
+          fancy_title: "Welcome to meta.discourse.org",
+          slug: "welcome-to-meta-discourse-org",
+          posts_count: 5,
+          reply_count: 5,
+          highest_post_number: 23,
+          image_url: null,
+          created_at: "2013-01-31T23:52:28.000-05:00",
+          last_posted_at: "2013-02-07T16:50:41.000-05:00",
+          bumped: true,
+          bumped_at: "2013-02-07T11:57:34.000-05:00",
+          unseen: false,
+          pinned: true,
+          excerpt:
+            "Welcome to meta, the official site for discussing the next-gen open source Discourse forum software. You&#39;ll find topics on features, bugs, hosting, development, and general support here. \n\nDiscourse is early beta softwar&hellip;",
+          visible: true,
+          closed: true,
+          archived: false,
+          views: 13792,
+          like_count: 108,
+          has_summary: false,
+          archetype: "regular",
+          last_poster_username: "codinghorror",
+          category_id: 17,
+          posters: [
+            { extras: null, description: "Original Poster", user_id: 1 },
+            { extras: null, description: "Most Posts", user_id: 19 },
+            { extras: null, description: "Frequent Poster", user_id: 14 },
+            { extras: "latest", description: "Most Recent Poster", user_id: 32 }
+          ]
+        },
+        {
+          id: 11997,
+          title: "Create topic in the future",
+          fancy_title: "Create topic in the future",
+          slug: "create-topic-in-the-future",
+          posts_count: 1,
+          reply_count: 0,
+          highest_post_number: 1,
+          image_url: null,
+          created_at: "2014-01-16T12:14:36.000-05:00",
+          last_posted_at: "2014-01-16T12:14:36.000-05:00",
+          bumped: false,
+          bumped_at: "2014-01-16T12:14:36.000-05:00",
+          unseen: false,
+          pinned: false,
+          visible: true,
+          closed: false,
+          archived: false,
+          views: 7,
+          like_count: 0,
+          has_summary: false,
+          archetype: "regular",
+          last_poster_username: "sil",
+          category_id: 2,
+          posters: [
+            {
+              extras: "latest",
+              description: "Original Poster, Most Recent Poster",
+              user_id: 1917
+            }
+          ]
+        }
+      ]
+    }
+  },
   "/categories.json": {
     category_list: {
       can_create_category: false,

--- a/test/javascripts/fixtures/site-fixtures.js
+++ b/test/javascripts/fixtures/site-fixtures.js
@@ -31,7 +31,8 @@ export default {
         "starred",
         "read",
         "posted",
-        "search"
+        "search",
+        "bookmarks"
       ],
       periods: ["all", "yearly", "quarterly", "monthly", "weekly", "daily"],
       top_menu_items: [
@@ -42,15 +43,10 @@ export default {
         "read",
         "posted",
         "categories",
-        "top"
-      ],
-      anonymous_top_menu_items: [
-        "latest",
         "top",
-        "categories",
-        "categories",
-        "top"
+        "bookmarks"
       ],
+      anonymous_top_menu_items: ["latest", "top", "categories"],
       uncategorized_category_id: 17,
       is_readonly: false,
       categories: [

--- a/test/javascripts/helpers/site.js
+++ b/test/javascripts/helpers/site.js
@@ -29,7 +29,15 @@ PreloadStore.store("site", {
     { id: 20, name: "ubuntu" },
     { id: 21, name: "test" },
   ],
-  filters: ["latest", "unread", "new", "starred", "read", "posted"],
+  filters: [
+    "latest",
+    "unread",
+    "new",
+    "starred",
+    "read",
+    "posted",
+    "bookmarks",
+  ],
   periods: ["all", "yearly", "monthly", "weekly", "daily"],
   top_menu_items: [
     "latest",


### PR DESCRIPTION
Admins can currently add the bookmarks discovery route link
to the homepage interface, but users can't presently select
that as their default home view.  This change facilitates that,
adding the option to the existing Default Home Page dropdown on
the User Preferences Interface page.