### PR TITLE
FEATURE: Add css classes to stylesheet link elements

### DIFF
--- a/lib/stylesheet/manager.rb
+++ b/lib/stylesheet/manager.rb
@@ -135,7 +135,10 @@ class Stylesheet::Manager
     return '' if !stylesheet
 
     href = stylesheet[:new_href]
-    %[<link href="#{href}" media="#{media}" rel="stylesheet"/>].html_safe
+
+    css_class = media == 'all' ? "light-scheme" : "dark-scheme"
+
+    %[<link href="#{href}" media="#{media}" rel="stylesheet" class="#{css_class}"/>].html_safe
   end
 
   def self.color_scheme_cache_key(color_scheme, theme_id = nil)


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->

Adding these classes to the stylesheet `link` elements in order to `toggle` dark/light schemes via [this theme-component.](https://github.com/jordanvidrine/discourse-color-scheme-toggle) Eventually this theme-component could possible be merged into core.


