### PR TITLE
DEV: Resolve this child category pending request spec

### DIFF
--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -399,9 +399,9 @@ RSpec.describe ListController do
         end
 
         context "with invalid slug" do
-          xit "redirects" do
+          it "redirects" do
             get "/c/random_slug/another_random_slug/#{child_category.id}/l/latest"
-            expect(response).to redirect_to(child_category.url)
+            expect(response).to redirect_to("#{child_category.url}/l/latest")
           end
         end
       end


### PR DESCRIPTION
There is a request spec that was ignored with the `xit` flag almost a
year ago and every time you generate the api docs with

```
rake rswag:specs:swaggerize
```

it shows the output of this pending test and I guess I finally got sick
of looking at it, so here is a fix for it.

Original Commit: d84c34ad7523c6f894315dcbfc0b215dff3b3707
