### PR TITLE
FIX: erroneous condition which would cause an error if ever satisfied

### DIFF
--- a/app/assets/javascripts/discourse/app/mixins/upload.js
+++ b/app/assets/javascripts/discourse/app/mixins/upload.js
@@ -108,9 +108,7 @@ export default Mixin.create({
     });
 
     $upload.on("fileuploadfail", (e, data) => {
-      if (!data) {
-        displayErrorForUpload(data, this.siteSettings);
-      }
+      displayErrorForUpload(data, this.siteSettings);
       reset();
     });
   }),


### PR DESCRIPTION
~~I tried satisfying this condition forcefully which results in a console error.~~ If the value is falsy i.e. an empty array/object, the control would go to the generic error condition in https://github.com/discourse/discourse/blob/f2842490d3ccaf9e29b0ffc43f193350334ead94/app/assets/javascripts/discourse/app/lib/uploads.js#L300

 As an aside, would this condition ever be satisfied?

IMHO, the `displayErrorForUpload` method should always be called so that the correct reason for the error is displayed in the popup. The current code forces the popup to be displayed for the generic condition which is not very helpful for the user.

Here, an example where the method is called correctly(IMO) https://github.com/discourse/discourse/blob/f2842490d3ccaf9e29b0ffc43f193350334ead94/app/assets/javascripts/discourse/app/components/composer-editor.js#L772

I'll change the commit message if the changes are approved.