### PR TITLE
FIX: handles different cases of canInvite/canRemove states in PM

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/private-message-map.js
+++ b/app/assets/javascripts/discourse/app/widgets/private-message-map.js
@@ -158,15 +158,27 @@ export default createWidget("private-message-map", {
     const result = [h(`div.participants${hideNamesClass}`, participants)];
     const controls = [];
 
-    if (
-      attrs.canInvite ||
-      attrs.canRemoveAllowedUsers ||
-      attrs.canRemoveSelfId
-    ) {
+    const canRemove = attrs.canRemoveAllowedUsers || attrs.canRemoveSelfId;
+
+    if (attrs.canInvite || canRemove) {
+      let key;
+      let action;
+
+      if (attrs.canInvite && canRemove) {
+        key = "edit";
+        action = "toggleEditing";
+      } else if (!attrs.canInvite && canRemove) {
+        key = "remove";
+        action = "toggleEditing";
+      } else {
+        key = "add";
+        action = "showInvite";
+      }
+
       controls.push(
         this.attach("button", {
-          action: "toggleEditing",
-          label: "private_message_info.edit",
+          action,
+          label: `private_message_info.${key}`,
           className: "btn btn-default add-remove-participant-btn",
         })
       );

--- a/app/assets/javascripts/discourse/app/widgets/private-message-map.js
+++ b/app/assets/javascripts/discourse/app/widgets/private-message-map.js
@@ -162,14 +162,12 @@ export default createWidget("private-message-map", {
 
     if (attrs.canInvite || canRemove) {
       let key;
-      let action;
+      let action = "toggleEditing";
 
       if (attrs.canInvite && canRemove) {
         key = "edit";
-        action = "toggleEditing";
       } else if (!attrs.canInvite && canRemove) {
         key = "remove";
-        action = "toggleEditing";
       } else {
         key = "add";
         action = "showInvite";

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1586,6 +1586,8 @@ en:
       title: "Message"
       invite: "Invite Others ..."
       edit: "Add or Remove ..."
+      remove: "Remove ..."
+      add: "Add ..."
       leave_message: "Do you really want to leave this message?"
       remove_allowed_user: "Do you really want to remove %{name} from this message?"
       remove_allowed_group: "Do you really want to remove %{name} from this message?"


### PR DESCRIPTION
can add and remove:
<img width="719" alt="Screenshot 2020-09-05 at 21 13 02" src="https://user-images.githubusercontent.com/339945/92312314-d0420100-efbf-11ea-8a73-89d0c4c336c8.png">
<img width="718" alt="Screenshot 2020-09-05 at 21 13 06" src="https://user-images.githubusercontent.com/339945/92312315-d1732e00-efbf-11ea-932b-c33560b3b864.png">

can add and not remove:
<img width="716" alt="Screenshot 2020-09-05 at 21 13 19" src="https://user-images.githubusercontent.com/339945/92312317-d20bc480-efbf-11ea-819a-f4cf137075e7.png">
<img width="731" alt="Screenshot 2020-09-05 at 21 13 22" src="https://user-images.githubusercontent.com/339945/92312319-d2a45b00-efbf-11ea-927b-e9465d6fbdd8.png">

cannot add can remove:
<img width="716" alt="Screenshot 2020-09-05 at 21 13 38" src="https://user-images.githubusercontent.com/339945/92312320-d33cf180-efbf-11ea-84ee-155c6b3d49a9.png">
<img width="715" alt="Screenshot 2020-09-05 at 21 13 42" src="https://user-images.githubusercontent.com/339945/92312321-d3d58800-efbf-11ea-95a6-4ae1d62eefc2.png">
