### PR TITLE
DEV: Strip unicode from color scheme stylesheet filenames

### DIFF
--- a/lib/stylesheet/manager.rb
+++ b/lib/stylesheet/manager.rb
@@ -313,7 +313,7 @@ class Stylesheet::Manager
     if is_theme?
       "#{@target}_#{theme.id}"
     elsif @color_scheme
-      "#{@target}_#{Slug.for(@color_scheme.name)}_#{@color_scheme&.id.to_s}"
+      "#{@target}_#{scheme_slug}_#{@color_scheme&.id.to_s}"
     else
       scheme_string = theme && theme.color_scheme ? "_#{theme.color_scheme.id}" : ""
       "#{@target}#{scheme_string}"
@@ -331,6 +331,10 @@ class Stylesheet::Manager
 
   def is_theme?
     !!(@target.to_s =~ THEME_REGEX)
+  end
+
+  def scheme_slug
+    Slug.for(ActiveSupport::Inflector.transliterate(@color_scheme.name), 'scheme')
   end
 
   # digest encodes the things that trigger a recompile

--- a/spec/components/stylesheet/manager_spec.rb
+++ b/spec/components/stylesheet/manager_spec.rb
@@ -273,6 +273,21 @@ describe Stylesheet::Manager do
 
       expect(stylesheet).to include("--special: rebeccapurple")
     end
+
+    context 'encoded slugs' do
+      before { SiteSetting.slug_generation_method = 'encoded' }
+      after { SiteSetting.slug_generation_method = 'ascii' }
+
+      it "strips unicode in color scheme stylesheet filenames" do
+        cs = Fabricate(:color_scheme, name: 'Grün')
+        cs2 = Fabricate(:color_scheme, name: '어두운')
+
+        link = Stylesheet::Manager.color_scheme_stylesheet_link_tag(cs.id)
+        expect(link).to include("/stylesheets/color_definitions_grun_#{cs.id}_")
+        link2 = Stylesheet::Manager.color_scheme_stylesheet_link_tag(cs2.id)
+        expect(link2).to include("/stylesheets/color_definitions_scheme_#{cs2.id}_")
+      end
+    end
   end
 
   # this test takes too long, we don't run it by default


### PR DESCRIPTION
Fix for https://meta.discourse.org/t/unicode-name-in-color-palettes/162762 