### PR TITLE
FIX: topic_creator accepts participant_count in import mode

### DIFF
--- a/lib/topic_creator.rb
+++ b/lib/topic_creator.rb
@@ -106,6 +106,10 @@ class TopicCreator
       topic_params[:views] = @opts[:views].to_i
     end
 
+    if topic_params[:import_mode] && @opts[:participant_count].to_i > 0
+      topic_params[:participant_count] = @opts[:participant_count].to_i
+    end
+
     # Automatically give it a moderator warning subtype if specified
     topic_params[:subtype] = TopicSubtype.moderator_warning if @opts[:is_warning]
 

--- a/spec/components/topic_creator_spec.rb
+++ b/spec/components/topic_creator_spec.rb
@@ -70,6 +70,16 @@ describe TopicCreator do
           expect(topic).to be_valid
           expect(topic.category).to eq(category)
         end
+
+        it "ignores participant_count without raising an error" do
+          topic = TopicCreator.create(user, Guardian.new(user), valid_attrs.merge(participant_count: 3))
+          expect(topic.participant_count).to eq(1)
+        end
+
+        it "accepts participant_count in import mode" do
+          topic = TopicCreator.create(user, Guardian.new(user), valid_attrs.merge(import_mode: true, participant_count: 3))
+          expect(topic.participant_count).to eq(3)
+        end
       end
     end
 


### PR DESCRIPTION
The issue mentioned here: https://meta.discourse.org/t/imported-private-discussion-doesnt-appear-in-the-author-inbox/163252

`participant_count` is important to attribute for private messages. If they are imported, we should allow them to set that attribute.

A workaround would be evaluating `update_statistics` method on each Topic but that is less performant.