### PR TITLE
FIX: Adds important declaration to `.hidden` utility/helper class

### DIFF
--- a/app/assets/stylesheets/common/foundation/helpers.scss
+++ b/app/assets/stylesheets/common/foundation/helpers.scss
@@ -22,7 +22,7 @@
 
 .hide,
 .hidden {
-  display: none;
+  display: none !important;
 }
 
 .invisible {


### PR DESCRIPTION
This commit adds the `!important` declaration to `.hidden` utility/helper class. Without the `!important` declaration, the utility class is not applied correctly across the site.

Robin discovered this issue here: https://dev.discourse.org/t/how-do-we-hide-elements/33383/10

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
