### PR TITLE
DEV: Review fixes for bookmark-list

### DIFF
--- a/app/assets/javascripts/discourse/app/components/bookmark-list.js
+++ b/app/assets/javascripts/discourse/app/components/bookmark-list.js
@@ -1,4 +1,5 @@
 import Component from "@ember/component";
+import { Promise } from "rsvp";
 import I18n from "I18n";
 import { action } from "@ember/object";
 import showModal from "discourse/lib/show-modal";
@@ -13,18 +14,28 @@ export default Component.extend({
 
   @action
   removeBookmark(bookmark) {
-    const deleteBookmark = () => {
-      return bookmark
-        .destroy()
-        .then(() => this._removeBookmarkFromList(bookmark));
-    };
-    if (!bookmark.reminder_at) {
-      return deleteBookmark();
-    }
-    bootbox.confirm(I18n.t("bookmarks.confirm_delete"), (result) => {
-      if (result) {
-        return deleteBookmark();
+    return new Promise((resolve, reject) => {
+      const deleteBookmark = () => {
+        bookmark
+          .destroy()
+          .then(() => {
+            this._removeBookmarkFromList(bookmark);
+            resolve(true);
+          })
+          .catch((error) => {
+            reject(error);
+          });
+      };
+      if (!bookmark.reminder_at) {
+        deleteBookmark();
       }
+      bootbox.confirm(I18n.t("bookmarks.confirm_delete"), (result) => {
+        if (result) {
+          deleteBookmark();
+        } else {
+          resolve(false);
+        }
+      });
     });
   },
 
@@ -50,9 +61,7 @@ export default Component.extend({
       title: "post.bookmarks.edit",
       modalClass: "bookmark-with-reminder",
     });
-    controller.setProperties({
-      afterSave: () => this.reload(),
-    });
+    controller.set("afterSave", () => this.reload());
   },
 
   _removeBookmarkFromList(bookmark) {

--- a/app/assets/javascripts/discourse/app/components/bookmark-list.js
+++ b/app/assets/javascripts/discourse/app/components/bookmark-list.js
@@ -27,7 +27,7 @@ export default Component.extend({
           });
       };
       if (!bookmark.reminder_at) {
-        deleteBookmark();
+        return deleteBookmark();
       }
       bootbox.confirm(I18n.t("bookmarks.confirm_delete"), (result) => {
         if (result) {


### PR DESCRIPTION
Make `removeBookmark` return a promise and do not use `setProperties` for no reason.

More context at https://review.discourse.org/t/fix-add-bookmark-list-component-10451/14450/3