### PR TITLE
DEV: Small refactor of topic progress wrapper positioning

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-progress.js
+++ b/app/assets/javascripts/discourse/app/components/topic-progress.js
@@ -162,7 +162,7 @@ export default Component.extend({
     if ($iPadFooterNav && $iPadFooterNav.length > 0) {
       bottom += $iPadFooterNav.outerHeight();
     }
-    const wrapperDir = $html.hasClass("rtl") ? "left" : "right";
+
     const draftComposerHeight = 40;
 
     if (composerHeight > 0) {
@@ -178,13 +178,6 @@ export default Component.extend({
     }
 
     this.set("docked", isDocked);
-
-    const $replyArea = $("#reply-control .reply-area");
-    if ($replyArea && $replyArea.length > 0) {
-      $wrapper.css(wrapperDir, `${$replyArea.offset().left}px`);
-    } else {
-      $wrapper.css(wrapperDir, "1em");
-    }
 
     $wrapper.css(
       "margin-bottom",

--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -8,7 +8,7 @@
   left: 0;
   margin-left: auto;
   margin-right: auto;
-  max-width: 1475px;
+  max-width: $reply-area-max-width;
   width: 100%;
   &.hide-preview {
     max-width: 740px;

--- a/app/assets/stylesheets/common/foundation/variables.scss
+++ b/app/assets/stylesheets/common/foundation/variables.scss
@@ -13,6 +13,7 @@ $input-padding: 4px 10px;
 $topic-body-width: 690px;
 $topic-body-width-padding: 11px;
 $topic-avatar-width: 45px;
+$reply-area-max-width: 1475px !default;
 
 // Brand color variables
 // --------------------------------------------------

--- a/app/assets/stylesheets/desktop/topic.scss
+++ b/app/assets/stylesheets/desktop/topic.scss
@@ -77,12 +77,22 @@
 
 #topic-progress-wrapper {
   position: fixed;
-  right: 1em;
+  right: 2em;
   bottom: 0;
+  left: 0;
+  margin: 0 auto;
+  max-width: $reply-area-max-width;
+  display: flex;
+  justify-content: flex-end;
   z-index: z("timeline");
   &.docked {
     position: absolute;
     bottom: -70px;
+  }
+  html.rtl & {
+    justify-content: flex-start;
+    right: 0;
+    left: 2em;
   }
 }
 
@@ -192,14 +202,6 @@
   #topic-progress-expanded {
     right: 0;
     left: 0;
-  }
-
-  #topic-progress-wrapper {
-    right: 19vw;
-  }
-
-  #topic-progress-wrapper.docked {
-    right: 19vw;
   }
 
   #topic-footer-main-buttons {

--- a/app/assets/stylesheets/mobile/topic.scss
+++ b/app/assets/stylesheets/mobile/topic.scss
@@ -43,11 +43,15 @@
 
 #topic-progress-wrapper {
   position: fixed;
-  right: 0;
+  right: 1em;
   bottom: 0;
   z-index: z("timeline");
   &:not(.docked) {
     margin-bottom: env(safe-area-inset-bottom);
+  }
+  html.rtl & {
+    right: 0;
+    left: 1em;
   }
 }
 


### PR DESCRIPTION
This moves the logic for horizontally placing the topic progress wrapper from the JS component to SCSS. Doing so means it is more easily overridable by themes and plugins. 

This also changes the left/right spacing from `1em` to `2em` for non-mobile screens (it fits better on iPad portrait especially). 