### PR TITLE
FIX: wrap modal onShow inside next

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/show-modal.js
+++ b/app/assets/javascripts/discourse/app/lib/show-modal.js
@@ -1,3 +1,4 @@
+import { next } from "@ember/runloop";
 import I18n from "I18n";
 import { dasherize } from "@ember/string";
 import { getOwner } from "discourse-common/lib/get-owner";
@@ -72,7 +73,7 @@ export default function (name, opts) {
     controller.set("model", model);
   }
   if (controller.onShow) {
-    controller.onShow();
+    next(() => controller.onShow());
   }
   controller.set("flashMessage", null);
 


### PR DESCRIPTION
Before this commit, order of events in the onShow hook could be different than expected. This should ensure this code works for example:

```
onShow() {
  afterRender(() => {
    someInput.focus();
  })
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
