### PR TITLE
DEV: Add support for `api-initializers` to reduce boilerplate.

### DIFF
--- a/app/assets/javascripts/discourse/app/app.js
+++ b/app/assets/javascripts/discourse/app/app.js
@@ -37,7 +37,7 @@ const Discourse = Application.extend({
     Object.keys(requirejs._eak_seen).forEach((key) => {
       if (/\/pre\-initializers\//.test(key)) {
         this.initializer(this._prepareInitializer(key));
-      } else if (/\/initializers\//.test(key)) {
+      } else if (/\/(api\-)?initializers\//.test(key)) {
         this.instanceInitializer(this._prepareInitializer(key));
       }
     });

--- a/app/assets/javascripts/discourse/app/lib/api.js
+++ b/app/assets/javascripts/discourse/app/lib/api.js
@@ -1,0 +1,18 @@
+import { withPluginApi } from "discourse/lib/plugin-api";
+
+/**
+ * apiInitializer(version, apiCodeCallback, opts)
+ *
+ * An API to simplify the creation of initializers for plugins/themes by removing
+ * some of the boilerplate.
+ */
+let _apiInitializerId = 0;
+export function apiInitializer(version, cb, opts) {
+  return {
+    name: `api-initializer${_apiInitializerId++}`,
+    after: "inject-objects",
+    initialize() {
+      return withPluginApi(version, cb, opts);
+    },
+  };
+}


### PR DESCRIPTION
You can now create a file in your plugin/theme in the `api-initializers`
directory which has a simpler template than previous initializers.
Example:

```
// api-initializers/my-plugin.js
import { apiInitializer } from "discourse/lib/plugin-api";

export default apiInitializer("0.8", api => {
  console.log("hello world from api initializer!");
});
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
