### PR TITLE
FIX: attempts to make autofocus more resilient in modals

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-modal.js
+++ b/app/assets/javascripts/discourse/app/components/d-modal.js
@@ -1,6 +1,6 @@
 import afterTransition from "discourse/lib/after-transition";
 import I18n from "I18n";
-import { next, schedule } from "@ember/runloop";
+import { next } from "@ember/runloop";
 import { on } from "discourse-common/utils/decorators";
 import Component from "@ember/component";
 
@@ -118,16 +118,14 @@ export default Component.extend({
       this.set("dismissable", true);
     }
 
-    schedule("afterRender", () => {
-      if (this.element) {
-        const autofocusInputs = this.element.querySelectorAll(
-          ".modal-body input[autofocus]"
-        );
+    if (this.element) {
+      const autofocusInputs = this.element.querySelectorAll(
+        ".modal-body input[autofocus]"
+      );
 
-        if (autofocusInputs.length) {
-          afterTransition(() => autofocusInputs[0].focus());
-        }
+      if (autofocusInputs.length) {
+        afterTransition(() => autofocusInputs[0].focus());
       }
-    });
+    }
   },
 });

--- a/app/assets/javascripts/discourse/app/components/d-modal.js
+++ b/app/assets/javascripts/discourse/app/components/d-modal.js
@@ -1,5 +1,6 @@
+import afterTransition from "discourse/lib/after-transition";
 import I18n from "I18n";
-import { next } from "@ember/runloop";
+import { next, schedule } from "@ember/runloop";
 import { on } from "discourse-common/utils/decorators";
 import Component from "@ember/component";
 
@@ -116,5 +117,17 @@ export default Component.extend({
     } else {
       this.set("dismissable", true);
     }
+
+    schedule("afterRender", () => {
+      if (this.element) {
+        const autofocusInputs = this.element.querySelectorAll(
+          ".modal-body input[autofocus]"
+        );
+
+        if (autofocusInputs.length) {
+          afterTransition(() => autofocusInputs[0].focus());
+        }
+      }
+    });
   },
 });

--- a/app/assets/javascripts/discourse/app/controllers/insert-hyperlink.js
+++ b/app/assets/javascripts/discourse/app/controllers/insert-hyperlink.js
@@ -26,8 +26,6 @@ export default Controller.extend(ModalFunctionality, {
       element
         .closest(".modal-inner-container")
         .addEventListener("mousedown", this.mouseDown);
-
-      document.activeElement.blur();
     });
   },
 


### PR DESCRIPTION
The current situation could cause a transition on the button to end after/during modal has shown and causing the button to get focus again. Browsers would then refuse to switch focus.

This is a kinda convulted solution, but it's a general purpose solution which doesn't involve changing anything in plugins/themes or core templates.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
