### PR TITLE
FEATURE: Default allow embed secure images in email to true

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1236,7 +1236,7 @@ files:
     default: false
     client: true
   secure_media_allow_embed_images_in_emails:
-    default: false
+    default: true
   secure_media_max_email_embed_image_size_kb:
     default: 1024
     min: 1

--- a/spec/components/email/sender_spec.rb
+++ b/spec/components/email/sender_spec.rb
@@ -4,6 +4,9 @@ require 'rails_helper'
 require 'email/sender'
 
 describe Email::Sender do
+  before do
+    SiteSetting.secure_media_allow_embed_images_in_emails = false
+  end
   fab!(:post) { Fabricate(:post) }
 
   context "disable_emails is enabled" do


### PR DESCRIPTION
We are making the changes from the PR https://github.com/discourse/discourse/pull/10563 the default behaviour. Now, if secure media is enabled, secure images will be embedded in emails by default instead of redacting them and displaying a message. This will be a nicer overall experience by default, and for forums that want to be super strict with redaction this setting can always be disabled.