### PR TITLE
DEV: Add ENV variable for enabling MiniProfiler snapshots

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -31,6 +31,7 @@ class ApplicationController < ActionController::Base
   before_action :check_readonly_mode
   before_action :handle_theme
   before_action :set_current_user_for_logs
+  before_action :set_mp_snapshot_fields
   before_action :clear_notifications
   around_action :with_resolved_locale
   before_action :set_mobile_view
@@ -293,6 +294,10 @@ class ApplicationController < ActionController::Base
       response.headers["X-Discourse-Username"] = current_user.username
     end
     response.headers["X-Discourse-Route"] = "#{controller_name}/#{action_name}"
+  end
+
+  def set_mp_snapshot_fields
+    Rack::MiniProfiler.add_snapshot_custom_field("application version", Discourse.git_version)
   end
 
   def clear_notifications

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -297,7 +297,9 @@ class ApplicationController < ActionController::Base
   end
 
   def set_mp_snapshot_fields
-    Rack::MiniProfiler.add_snapshot_custom_field("application version", Discourse.git_version)
+    if defined?(Rack::MiniProfiler)
+      Rack::MiniProfiler.add_snapshot_custom_field("application version", Discourse.git_version)
+    end
   end
 
   def clear_notifications

--- a/config/discourse_defaults.conf
+++ b/config/discourse_defaults.conf
@@ -95,6 +95,10 @@ smtp_openssl_verify_mode =
 # load MiniProfiler in production, to be used by developers
 load_mini_profiler = true
 
+# Every how many requests should MP profile a request (aka take snapshot)
+# Default is never
+mini_profiler_snapshots_period = 0
+
 # recommended, cdn used to access assets
 cdn_url =
 

--- a/config/initializers/006-mini_profiler.rb
+++ b/config/initializers/006-mini_profiler.rb
@@ -24,7 +24,8 @@ if defined?(Rack::MiniProfiler) && defined?(Rack::MiniProfiler::Config)
     connection:  DiscourseRedis.new(nil, namespace: false)
   )
 
-  skip = [
+  Rack::MiniProfiler.config.snapshot_every_n_requests = GlobalSetting.mini_profiler_snapshots_period
+  Rack::MiniProfiler.config.skip_paths = [
     /^\/message-bus/,
     /^\/extra-locales/,
     /topics\/timings/,
@@ -51,10 +52,7 @@ if defined?(Rack::MiniProfiler) && defined?(Rack::MiniProfiler::Config)
   # we DO NOT WANT mini-profiler loading on anything but real desktops and laptops
   # so let's rule out all handheld, tablet, and mobile devices
   Rack::MiniProfiler.config.pre_authorize_cb = lambda do |env|
-    path = env['PATH_INFO']
-
-    (env['HTTP_USER_AGENT'] !~ /iPad|iPhone|Android/) &&
-    !skip.any? { |re| re =~ path }
+    env['HTTP_USER_AGENT'] !~ /iPad|iPhone|Android/
   end
 
   # without a user provider our results will use the ip address for namespacing


### PR DESCRIPTION
Also add a tiny `before_action` hook that adds Discourse version to snapshot.