### PR TITLE
FEATURE: Diffrentiate between group + individual mentions

### DIFF
--- a/app/assets/javascripts/discourse-common/addon/lib/icon-library.js
+++ b/app/assets/javascripts/discourse-common/addon/lib/icon-library.js
@@ -19,7 +19,7 @@ const REPLACEMENTS = {
   "d-unliked": "far-heart",
   "d-liked": "heart",
   "notification.mentioned": "at",
-  "notification.group_mentioned": "at",
+  "notification.group_mentioned": "users",
   "notification.quoted": "quote-right",
   "notification.replied": "reply",
   "notification.posted": "reply",

--- a/app/assets/javascripts/discourse/app/widgets/default-notification-item.js
+++ b/app/assets/javascripts/discourse/app/widgets/default-notification-item.js
@@ -67,6 +67,17 @@ export const DefaultNotificationItem = createWidget(
         return escapeExpression(badgeName);
       }
 
+      const groupName = data.group_name;
+
+      if (groupName) {
+        if (this.attrs.fancy_title) {
+          if (this.attrs.topic_id) {
+            return `<span class="mention-group notify">@${groupName}</span><span data-topic-id="${this.attrs.topic_id}"> ${this.attrs.fancy_title}</span>`;
+          }
+          return `<span class="mention-group notify">@${groupName}</span> ${this.attrs.fancy_title}`;
+        }
+      }
+
       if (this.attrs.fancy_title) {
         if (this.attrs.topic_id) {
           return `<span data-topic-id="${this.attrs.topic_id}">${this.attrs.fancy_title}</span>`;
@@ -81,7 +92,7 @@ export const DefaultNotificationItem = createWidget(
 
     text(notificationName, data) {
       const username = formatUsername(data.display_username);
-      const description = this.description(data);
+      const description = this.description(data, notificationName);
 
       return I18n.t(`notifications.${notificationName}`, {
         description,

--- a/app/assets/stylesheets/common/base/group.scss
+++ b/app/assets/stylesheets/common/base/group.scss
@@ -5,7 +5,7 @@
 span.mention-group {
   color: var(--primary-high-or-secondary-low);
   padding: 2px 4px;
-  background: rgba(var(--primary-rgb),0.12);
+  background: rgba(var(--primary-rgb), 0.12);
   border-radius: 8px;
   font-weight: 600;
   font-size: $font-down-1;

--- a/app/assets/stylesheets/common/base/group.scss
+++ b/app/assets/stylesheets/common/base/group.scss
@@ -2,6 +2,15 @@
 // To style group content differently, use the existing classes with a .group parent class.
 // For example: .group .user-secondary-navigation
 
+span.mention-group {
+  color: var(--primary-high-or-secondary-low);
+  padding: 2px 4px;
+  background: rgba(var(--primary-rgb),0.12);
+  border-radius: 8px;
+  font-weight: 600;
+  font-size: $font-down-1;
+}
+
 .group-details-container {
   background: var(--primary-very-low);
   padding: 20px;


### PR DESCRIPTION
This commit adds the necessary code for Discorse core to differentiate between group + individual mentions in the notification user panel and notification page.

It changes the group mention icon from `at` to `users` as well as adds context as to which group was mentioned in the topic.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
