### PR TITLE
UX: Update dark mode styling of new user overlay

### DIFF
--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -419,10 +419,9 @@ table {
   right: -18px;
   background-image: radial-gradient(
     40px at 50% 50%,
-    transparent 95%,
-    var(--primary) 100%
+    rgba(255, 255, 255, 0.15) 95%,
+    rgba(var(--always-black-rgb), 0.65) 100%
   );
-  opacity: 0.85;
 }
 
 .ring-backdrop {
@@ -431,13 +430,12 @@ table {
   height: 80px;
   top: -18px !important;
   right: -18px !important;
-  box-shadow: 0 0 0 9999px rgba(var(--primary-rgb), 0.85);
+  box-shadow: 0 0 0 9999px rgba(var(--always-black-rgb), 0.65);
   z-index: z("modal", "overlay");
 }
 
 .ring-first-notification {
   position: absolute;
-  color: var(--secondary);
   text-align: left;
   right: 70px;
   top: 60px;
@@ -451,8 +449,12 @@ table {
 
   .skip-new-user-tips {
     font-size: $font-down-1;
-    color: var(--secondary);
     text-decoration: underline;
+  }
+
+  &,
+  .skip-new-user-tips {
+    color: #eee;
   }
 }
 


### PR DESCRIPTION
Changes the overlay colors so they don't flip on dark color schemes: 

## Light scheme (before, after)

![before-light](https://user-images.githubusercontent.com/368961/93513527-fb97ea80-f8f3-11ea-9f06-edafa894b6a8.png)
![after-light](https://user-images.githubusercontent.com/368961/93513530-fb97ea80-f8f3-11ea-977a-a28c4dfb4df4.png)

## Dark scheme (before, after)

![before-dark](https://user-images.githubusercontent.com/368961/93513583-0e122400-f8f4-11ea-96cd-c5a3d0ec2096.png)
![after-dark](https://user-images.githubusercontent.com/368961/93513586-0e122400-f8f4-11ea-8b32-10cf70eb2f90.png)
