### PR TITLE
FIX: allows admin to use `blob:` as a valid worker-src

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1527,6 +1527,8 @@ security:
   content_security_policy_script_src:
     type: simple_list
     default: ""
+  content_security_policy_allow_service_worker_blob:
+    default: false
   invalidate_inactive_admin_email_after_days:
     default: 365
     min: 0

--- a/lib/content_security_policy/default.rb
+++ b/lib/content_security_policy/default.rb
@@ -65,7 +65,9 @@ class ContentSecurityPolicy
       [
         "'self'", # For service worker
         *script_assets(worker: true)
-      ]
+      ].tap do |sources|
+        sources << "blob:" if SiteSetting.content_security_policy_allow_service_worker_blob
+      end
     end
 
     def report_uri

--- a/spec/lib/content_security_policy_spec.rb
+++ b/spec/lib/content_security_policy_spec.rb
@@ -43,6 +43,17 @@ describe ContentSecurityPolicy do
         http://test.localhost/plugins/
       ])
     end
+
+    context 'content_security_policy_allow_service_worker_blob is enabled' do
+      before do
+        SiteSetting.content_security_policy_allow_service_worker_blob = true
+      end
+
+      it 'contains blob' do
+        worker_srcs = parse(policy)['worker-src']
+        expect(worker_srcs).to include('blob:')
+      end
+    end
   end
 
   describe 'script-src' do


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
