### PR TITLE
FIX: Whitelist marker elements when uploading SVGs

### DIFF
--- a/lib/upload_creator.rb
+++ b/lib/upload_creator.rb
@@ -8,8 +8,8 @@ class UploadCreator
 
   WHITELISTED_SVG_ELEMENTS ||= %w{
     circle clippath defs ellipse feGaussianBlur filter g line linearGradient
-    path polygon polyline radialGradient rect stop style svg text textpath
-    tref tspan use
+    marker path polygon polyline radialGradient rect stop style svg text
+    textpath tref tspan use
   }.each(&:freeze)
 
   # Available options


### PR DESCRIPTION
As `<marker>` does not seem to have any [attributes](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/marker#Attributes) that affect security. It has been added to the whitelist of allowed elements within an uploaded SVG.

Discussed: https://meta.discourse.org/t/marker-element-being-striped-out-from-uploaded-svg/164432

No tests required for this change as I could see.