### PR TITLE
FIX: NotificationLevels import was incorrect

### DIFF
--- a/app/assets/javascripts/discourse/app/models/topic-details.js
+++ b/app/assets/javascripts/discourse/app/models/topic-details.js
@@ -9,7 +9,7 @@ import getURL from "discourse-common/lib/get-url";
   A model representing a Topic's details that aren't always present, such as a list of participants.
   When showing topics in lists and such this information should not be required.
 **/
-import NotificationLevels from "discourse/lib/notification-levels";
+import { NotificationLevels } from "discourse/lib/notification-levels";
 import RestModel from "discourse/models/rest";
 
 const TopicDetails = RestModel.extend({


### PR DESCRIPTION
This was causing NotificationLevels.muted to be undefined.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
