### PR TITLE
FIX: don't error Topic#similar_to when prepared raw is blank

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -597,9 +597,11 @@ class Topic < ActiveRecord::Base
         PrettyText.cook(raw[0...MAX_SIMILAR_BODY_LENGTH].strip)
       )
 
-      if cooked.present?
+      prepared_data = cooked.present? && Search.prepare_data(cooked)
+
+      if prepared_data.present?
         raw_tsquery = Search.set_tsquery_weight_filter(
-          Search.prepare_data(cooked),
+          prepared_data,
           'B'
         )
 

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -519,6 +519,10 @@ describe Topic do
       expect(Topic.similar_to('some title', '#')).to eq([])
     end
 
+    it 'does not result in invalid statement when prepared data is blank' do
+      expect(Topic.similar_to('some title', 'https://discourse.org/#INCORRECT#URI')).to eq([])
+    end
+
     context 'with a similar topic' do
       fab!(:post) {
         SearchIndexer.enable

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -520,7 +520,7 @@ describe Topic do
     end
 
     it 'does not result in invalid statement when prepared data is blank' do
-      expect(Topic.similar_to('some title', 'https://discourse.org/#INCORRECT#URI')).to eq([])
+      expect(Topic.similar_to('some title', 'https://discourse.org/#INCORRECT#URI')).to be_empty
     end
 
     context 'with a similar topic' do


### PR DESCRIPTION
If raw contains incorrect URL, `prepare_data` returns empty string:

https://github.com/discourse/discourse/blob/master/lib/search.rb#L91

Therefore we should not only check if the cooked post is not blank but also if prepared data is not blank.