### PR TITLE
FIX: deprecate whitelist constants

### DIFF
--- a/app/models/topic_link_click.rb
+++ b/app/models/topic_link_click.rb
@@ -9,7 +9,9 @@ class TopicLinkClick < ActiveRecord::Base
 
   validates_presence_of :topic_link_id
 
-  WHITELISTED_REDIRECT_HOSTNAMES = Set.new(%W{www.youtube.com youtu.be})
+  ALLOWED_REDIRECT_HOSTNAMES = Set.new(%W{www.youtube.com youtu.be})
+  include ActiveSupport::Deprecation::DeprecatedConstantAccessor
+  deprecate_constant 'WHITELISTED_REDIRECT_HOSTNAMES', 'TopicLinkClick::ALLOWED_REDIRECT_HOSTNAMES'
 
   # Create a click from a URL and post_id
   def self.create_from(args = {})
@@ -93,7 +95,7 @@ class TopicLinkClick < ActiveRecord::Base
       return nil unless uri
 
       # Only redirect to allowlisted hostnames
-      return url if WHITELISTED_REDIRECT_HOSTNAMES.include?(uri.hostname) || is_cdn_link
+      return url if ALLOWED_REDIRECT_HOSTNAMES.include?(uri.hostname) || is_cdn_link
 
       return nil
     end

--- a/app/models/translation_override.rb
+++ b/app/models/translation_override.rb
@@ -4,13 +4,15 @@ require "i18n/i18n_interpolation_keys_finder"
 
 class TranslationOverride < ActiveRecord::Base
   # Allowlist i18n interpolation keys that can be included when customizing translations
-  CUSTOM_INTERPOLATION_KEYS_WHITELIST = {
+  ALLOWED_CUSTOM_INTERPOLATION_KEYS = {
     "user_notifications.user_" => %w{
       topic_title_url_encoded
       site_title_url_encoded
       context
     }
   }
+  include ActiveSupport::Deprecation::DeprecatedConstantAccessor
+  deprecate_constant 'CUSTOM_INTERPOLATION_KEYS_WHITELIST', 'TranslationOverride::ALLOWED_CUSTOM_INTERPOLATION_KEYS'
 
   validates_uniqueness_of :translation_key, scope: :locale
   validates_presence_of :locale, :translation_key, :value
@@ -98,7 +100,7 @@ class TranslationOverride < ActiveRecord::Base
 
       custom_interpolation_keys = []
 
-      CUSTOM_INTERPOLATION_KEYS_WHITELIST.select do |key, value|
+      ALLOWED_CUSTOM_INTERPOLATION_KEYS.select do |key, value|
         if transformed_key.start_with?(key)
           custom_interpolation_keys = value
         end

--- a/lib/upload_creator.rb
+++ b/lib/upload_creator.rb
@@ -6,11 +6,14 @@ class UploadCreator
 
   TYPES_TO_CROP ||= %w{avatar card_background custom_emoji profile_background}.each(&:freeze)
 
-  WHITELISTED_SVG_ELEMENTS ||= %w{
+  ALLOWED_SVG_ELEMENTS ||= %w{
     circle clippath defs ellipse feGaussianBlur filter g line linearGradient
     marker path polygon polyline radialGradient rect stop style svg text
     textpath tref tspan use
   }.each(&:freeze)
+
+  include ActiveSupport::Deprecation::DeprecatedConstantAccessor
+  deprecate_constant 'WHITELISTED_SVG_ELEMENTS', 'UploadCreator::ALLOWED_SVG_ELEMENTS'
 
   # Available options
   #  - type (string)
@@ -403,7 +406,7 @@ class UploadCreator
   end
 
   def svg_allowlist_xpath
-    @@svg_allowlist_xpath ||= "//*[#{WHITELISTED_SVG_ELEMENTS.map { |e| "name()!='#{e}'" }.join(" and ") }]"
+    @@svg_allowlist_xpath ||= "//*[#{ALLOWED_SVG_ELEMENTS.map { |e| "name()!='#{e}'" }.join(" and ") }]"
   end
 
   def add_metadata!

--- a/plugins/poll/assets/javascripts/lib/discourse-markdown/poll.js.es6
+++ b/plugins/poll/assets/javascripts/lib/discourse-markdown/poll.js.es6
@@ -3,7 +3,7 @@ import I18n from "I18n";
 
 const DATA_PREFIX = "data-poll-";
 const DEFAULT_POLL_NAME = "poll";
-const WHITELISTED_ATTRIBUTES = [
+const ALLOWED_ATTRIBUTES = [
   "close",
   "max",
   "min",
@@ -106,7 +106,7 @@ const rule = {
       attributes.push([DATA_PREFIX + "status", "open"]);
     }
 
-    WHITELISTED_ATTRIBUTES.forEach((name) => {
+    ALLOWED_ATTRIBUTES.forEach((name) => {
       if (attrs[name]) {
         attributes.push([DATA_PREFIX + name, attrs[name]]);
       }

--- a/spec/models/translation_override_spec.rb
+++ b/spec/models/translation_override_spec.rb
@@ -27,7 +27,7 @@ describe TranslationOverride do
             translation_override = TranslationOverride.upsert!(
               I18n.locale,
               'some_key',
-              "#{described_class::CUSTOM_INTERPOLATION_KEYS_WHITELIST['user_notifications.user_'].join(", ")} %{something}"
+              "#{described_class::ALLOWED_CUSTOM_INTERPOLATION_KEYS['user_notifications.user_'].join(", ")} %{something}"
             )
 
             expect(translation_override.errors.full_messages).to include(I18n.t(


### PR DESCRIPTION
Deprecation of:
WHITELISTED_REDIRECT_HOSTNAMES
CUSTOM_INTERPOLATION_KEYS_WHITELIST
WHITELISTED_SVG_ELEMENTS
