### PR TITLE
A11Y: Add label to share link input

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/share-panel.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/share-panel.hbs
@@ -3,7 +3,7 @@
 </div>
 
 <div class="body">
-  {{d-textarea value=shareUrl class="topic-share-url" name="share-url" aria-label=(I18n "share.url")}}
+  {{d-textarea value=shareUrl class="topic-share-url" aria-label=(I18n "share.url")}}
 
   <div class="sources">
     {{#each sources as |source|}}

--- a/app/assets/javascripts/discourse/app/templates/components/share-panel.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/share-panel.hbs
@@ -3,7 +3,7 @@
 </div>
 
 <div class="body">
-  {{textarea value=shareUrl class="topic-share-url"}}
+  {{d-textarea value=shareUrl class="topic-share-url" name="share-url" aria-label=(I18n "share.url")}}
 
   <div class="sources">
     {{#each sources as |source|}}

--- a/app/assets/javascripts/discourse/app/templates/components/share-popup.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/share-popup.hbs
@@ -7,7 +7,7 @@
 </div>
 
 <div>
-  <input type="text">
+  <input type="text" aria-label={{i18n "share.url"}}>
 </div>
 
 <div class="actions">

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -138,6 +138,7 @@ en:
       twitter: "Share on Twitter"
       facebook: "Share on Facebook"
       email: "Send via email"
+      url: "Copy and share URL"
 
     action_codes:
       public_topic: "made this topic public %{when}"


### PR DESCRIPTION
This input needs to be labeled for screen readers, discussion here: https://meta.discourse.org/t/ramp-accessibility-issues/164000/7