### PR TITLE
A11Y: Don't show title attr on post avatars

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/post.js
+++ b/app/assets/javascripts/discourse/app/widgets/post.js
@@ -35,7 +35,12 @@ export function avatarImg(wanted, attrs) {
   if (!url || url.length === 0) {
     return;
   }
-  const title = attrs.name || formatUsername(attrs.username);
+
+  let title;
+
+  if (!attrs.hideTitle) {
+    title = attrs.name || formatUsername(attrs.username);
+  }
 
   let className =
     "avatar" + (attrs.extraClasses ? " " + attrs.extraClasses : "");
@@ -168,6 +173,7 @@ createWidget("post-avatar", {
         name: attrs.name,
         url: attrs.usernameUrl,
         className: "main-avatar",
+        hideTitle: true,
       });
     }
 


### PR DESCRIPTION
Despite having set `alt=""` (which is intended to hide a decorative image from screen readers) some screen readers will read the title attribute instead. This means some screen readers are reading the username twice, first on the avatar and then on the post content. 

Removing the title attribute should solve this.

Screen reader info: https://www.powermapper.com/tests/screen-readers/labelling/img-null-alt-title/

Topic here: https://meta.discourse.org/t/ramp-accessibility-issues/164000