### PR TITLE
FIX: allow editing in composer before a category is selected

### DIFF
--- a/app/assets/javascripts/discourse/app/models/composer.js
+++ b/app/assets/javascripts/discourse/app/models/composer.js
@@ -442,10 +442,14 @@ const Composer = RestModel.extend({
 
   @discourseComputed("canCategorize", "categoryId")
   requiredCategoryMissing(canCategorize, categoryId) {
+    const hasTopicTemplates = this.site.categories.some(
+      (c) => c.topic_template
+    );
     return (
       canCategorize &&
       !categoryId &&
-      !this.siteSettings.allow_uncategorized_topics
+      !this.siteSettings.allow_uncategorized_topics &&
+      hasTopicTemplates
     );
   },
 

--- a/app/assets/javascripts/discourse/app/models/composer.js
+++ b/app/assets/javascripts/discourse/app/models/composer.js
@@ -442,14 +442,11 @@ const Composer = RestModel.extend({
 
   @discourseComputed("canCategorize", "categoryId")
   requiredCategoryMissing(canCategorize, categoryId) {
-    const hasTopicTemplates = this.site.categories.some(
-      (c) => c.topic_template
-    );
     return (
       canCategorize &&
       !categoryId &&
       !this.siteSettings.allow_uncategorized_topics &&
-      hasTopicTemplates
+      !!this._hasTopicTemplates
     );
   },
 
@@ -756,6 +753,10 @@ const Composer = RestModel.extend({
         this.set("categoryId", categories[0].id);
       }
     }
+
+    this._hasTopicTemplates = this.site.categories.some(
+      (c) => c.topic_template
+    );
 
     if (opts.postId) {
       promise = promise.then(() =>

--- a/test/javascripts/acceptance/composer-uncategorized-test.js
+++ b/test/javascripts/acceptance/composer-uncategorized-test.js
@@ -1,13 +1,16 @@
 import selectKit from "helpers/select-kit-helper";
 import { acceptance, updateCurrentUser } from "helpers/qunit-helpers";
 
-acceptance("Composer and uncategorized is not allowed", {
-  loggedIn: true,
-  settings: {
-    enable_whispers: true,
-    allow_uncategorized_topics: false,
-  },
-});
+acceptance(
+  "Composer disabled, uncategorized not allowed when any topic_template present",
+  {
+    loggedIn: true,
+    settings: {
+      enable_whispers: true,
+      allow_uncategorized_topics: false,
+    },
+  }
+);
 
 QUnit.test("Disable body until category is selected", async (assert) => {
   updateCurrentUser({ moderator: false, admin: false, trust_level: 1 });
@@ -47,3 +50,69 @@ QUnit.test("Disable body until category is selected", async (assert) => {
     "textarea is still enabled"
   );
 });
+
+acceptance(
+  "Composer enabled, uncategorized not allowed when topic_template not present",
+  {
+    loggedIn: true,
+    settings: {
+      allow_uncategorized_topics: false,
+    },
+    site: {
+      categories: [
+        {
+          id: 1,
+          name: "test won",
+          slug: "test-won",
+          topic_template: null,
+        },
+        {
+          id: 2,
+          name: "test too",
+          slug: "test-too",
+          topic_template: "",
+        },
+        {
+          id: 3,
+          name: "test free",
+          slug: "test-free",
+          topic_template: null,
+        },
+      ],
+    },
+  }
+);
+
+QUnit.test(
+  "Enable composer/body if no topic templates present",
+  async (assert) => {
+    updateCurrentUser({ moderator: false, admin: false, trust_level: 1 });
+
+    await visit("/");
+    await click("#create-topic");
+    assert.ok(exists(".d-editor-input"), "the composer input is visible");
+    assert.ok(
+      exists(".category-input .popup-tip.bad.hide"),
+      "category errors are hidden by default"
+    );
+    assert.ok(
+      find(".d-editor-textarea-wrapper.disabled").length === 0,
+      "textarea is enabled"
+    );
+
+    await click("#reply-control button.create");
+    assert.ok(
+      exists(".category-input .popup-tip.bad"),
+      "it shows the choose a category error"
+    );
+
+    const categoryChooser = selectKit(".category-chooser");
+    await categoryChooser.expand();
+    await categoryChooser.selectRowByValue(1);
+
+    assert.ok(
+      !exists(".category-input .popup-tip.bad"),
+      "category error removed after selecting category"
+    );
+  }
+);

--- a/test/javascripts/fixtures/site-fixtures.js
+++ b/test/javascripts/fixtures/site-fixtures.js
@@ -66,7 +66,8 @@ export default {
           notification_level: null,
           background_url: null,
           show_subcategory_list: false,
-          default_view: "latest"
+          default_view: "latest",
+          topic_template: "my topic template"
         },
         {
           id: 10,


### PR DESCRIPTION
If the site setting `allow_uncategorized_topics` is disabled, but no site categories have a topic template, the textarea of the composer should be enabled. This allows for a post body to be entered, however the post/topic should not be successfully created until a category is selected.

If `allow_uncategorized_topics` is disabled *and* one or more categories have a topic template, the textarea of the composer should remain disabled until a category is chosen (so that the body of their post isn’t overwritten by the template).
