### PR TITLE
Improve staff_like_weight copy to indicate how the value is applied

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1884,7 +1884,7 @@ en:
     newuser_spam_host_threshold: "How many times a new user can post a link to the same host within their `newuser_spam_host_threshold` posts before being considered spam."
 
     allowed_spam_host_domains: "A list of domains excluded from spam host testing. New users will never be restricted from creating posts with links to these domains."
-    staff_like_weight: "How much extra weighting factor to give staff likes."
+    staff_like_weight: "How much weight to give staff likes (non-staff likes have a weight of 1.)"
     topic_view_duration_hours: "Count a new topic view once per IP/User every N hours"
     user_profile_view_duration_hours: "Count a new user profile view once per IP/User every N hours"
 


### PR DESCRIPTION
This PR is just updating the copy of the `staff_like_weight` setting, so no tests are included.

The change is intended to make it clear how the setting is used by Discourse. There is a discussion on Meta about it here: https://meta.discourse.org/t/staff-like-weight-0-or-1-to-match-regular-users/164374
