### PR TITLE
FIX: Only staff can edit topic details when first post is locked

### DIFF
--- a/lib/guardian/topic_guardian.rb
+++ b/lib/guardian/topic_guardian.rb
@@ -74,6 +74,7 @@ module TopicGuardian
   def can_edit_topic?(topic)
     return false if Discourse.static_doc_topic_ids.include?(topic.id) && !is_admin?
     return false unless can_see?(topic)
+    return false if topic.first_post&.locked? && !is_staff?
 
     return true if is_admin?
     return true if is_moderator? && can_create_post?(topic)

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -1277,6 +1277,29 @@ RSpec.describe TopicsController do
           expect(response.status).to eq(200)
         end
 
+        describe "when first post is locked" do
+          it "blocks non-staff from editing even if 'trusted_users_can_edit_others' is true" do
+            SiteSetting.trusted_users_can_edit_others = true
+            user.update(trust_level: 3)
+            topic.first_post.update(locked_by_id: admin.id)
+
+            put "/t/#{topic.slug}/#{topic.id}.json", params: {
+              title: topic.title + " hello"
+            }
+            expect(response.status).to eq(403)
+          end
+
+          it "allows staff to edit" do
+            sign_in(Fabricate(:admin))
+            topic.first_post.update(locked_by_id: admin.id)
+
+            put "/t/#{topic.slug}/#{topic.id}.json", params: {
+              title: topic.title + " hello"
+            }
+            expect(response.status).to eq(200)
+          end
+        end
+
         context 'tags' do
           fab!(:tag) { Fabricate(:tag) }
 


### PR DESCRIPTION
This is addressing the meta topic here https://meta.discourse.org/t/user-able-to-edit-title-of-locked-post-still-again-possible/164547?u=markvanlan