### PR TITLE
DEV: don't add username to share links when badges are disabled

### DIFF
--- a/app/assets/javascripts/discourse/app/helpers/share-url.js
+++ b/app/assets/javascripts/discourse/app/helpers/share-url.js
@@ -1,7 +1,7 @@
 import { helperContext } from "discourse-common/lib/helpers";
 import User from "discourse/models/user";
 
-export function resolveShareUrl(url, context) {
+export function resolveShareUrl(url) {
   const siteSettings = helperContext().siteSettings;
   const user = User.current();
   const badgesEnabled = siteSettings.enable_badges;

--- a/app/assets/javascripts/discourse/app/helpers/share-url.js
+++ b/app/assets/javascripts/discourse/app/helpers/share-url.js
@@ -1,10 +1,7 @@
 import { helperContext } from "discourse-common/lib/helpers";
-import User from "discourse/models/user";
 
-export function resolveShareUrl(url) {
-  const siteSettings = helperContext().siteSettings;
-  const user = User.current();
-  const badgesEnabled = siteSettings.enable_badges;
+export function resolveShareUrl(url, user) {
+  const badgesEnabled = helperContext().siteSettings.enable_badges;
   const userSuffix = user && badgesEnabled ? `?u=${user.username_lower}` : "";
 
   return url + userSuffix;

--- a/app/assets/javascripts/discourse/app/helpers/share-url.js
+++ b/app/assets/javascripts/discourse/app/helpers/share-url.js
@@ -1,0 +1,11 @@
+import { helperContext } from "discourse-common/lib/helpers";
+import User from "discourse/models/user";
+
+export function resolveShareUrl(url, context) {
+  const siteSettings = helperContext().siteSettings;
+  const user = User.current();
+  const badgesEnabled = siteSettings.enable_badges;
+  const userSuffix = user && badgesEnabled ? `?u=${user.username_lower}` : "";
+
+  return url + userSuffix;
+}

--- a/app/assets/javascripts/discourse/app/models/post.js
+++ b/app/assets/javascripts/discourse/app/models/post.js
@@ -22,8 +22,7 @@ import { resolveShareUrl } from "discourse/helpers/share-url";
 const Post = RestModel.extend({
   @discourseComputed("url")
   shareUrl(url) {
-    const context = this;
-    return resolveShareUrl(url, context);
+    return resolveShareUrl(url);
   },
 
   new_user: equal("trust_level", 0),

--- a/app/assets/javascripts/discourse/app/models/post.js
+++ b/app/assets/javascripts/discourse/app/models/post.js
@@ -17,19 +17,13 @@ import Site from "discourse/models/site";
 import User from "discourse/models/user";
 import showModal from "discourse/lib/show-modal";
 import { fancyTitle } from "discourse/lib/topic-fancy-title";
+import { resolveShareUrl } from "discourse/helpers/share-url";
 
 const Post = RestModel.extend({
   @discourseComputed("url")
   shareUrl(url) {
-    const user = User.current();
-    const badgesEnabled = this.siteSettings.enable_badges;
-    const userSuffix = user && badgesEnabled ? `?u=${user.username_lower}` : "";
-
-    if (this.firstPost) {
-      return this.topic.url + userSuffix;
-    } else {
-      return url + userSuffix;
-    }
+    const context = this;
+    return resolveShareUrl(url, context);
   },
 
   new_user: equal("trust_level", 0),

--- a/app/assets/javascripts/discourse/app/models/post.js
+++ b/app/assets/javascripts/discourse/app/models/post.js
@@ -22,7 +22,8 @@ import { resolveShareUrl } from "discourse/helpers/share-url";
 const Post = RestModel.extend({
   @discourseComputed("url")
   shareUrl(url) {
-    return resolveShareUrl(url);
+    const user = User.current();
+    return resolveShareUrl(url, user);
   },
 
   new_user: equal("trust_level", 0),

--- a/app/assets/javascripts/discourse/app/models/post.js
+++ b/app/assets/javascripts/discourse/app/models/post.js
@@ -22,10 +22,11 @@ const Post = RestModel.extend({
   @discourseComputed("url")
   shareUrl(url) {
     const user = User.current();
-    const userSuffix = user ? `?u=${user.username_lower}` : "";
+    const badgesEnabled = this.siteSettings.enable_badges;
+    const userSuffix = user && badgesEnabled ? `?u=${user.username_lower}` : "";
 
     if (this.firstPost) {
-      return this.get("topic.url") + userSuffix;
+      return this.topic.url + userSuffix;
     } else {
       return url + userSuffix;
     }

--- a/app/assets/javascripts/discourse/app/models/topic.js
+++ b/app/assets/javascripts/discourse/app/models/topic.js
@@ -242,8 +242,10 @@ const Topic = RestModel.extend({
   @discourseComputed("url")
   shareUrl(url) {
     const user = User.current();
-    const userQueryString = user ? `?u=${user.get("username_lower")}` : "";
-    return `${url}${userQueryString}`;
+    const badgesEnabled = this.siteSettings.enable_badges;
+    const userSuffix = user && badgesEnabled ? `?u=${user.username_lower}` : "";
+
+    return url + userSuffix;
   },
 
   printUrl: fmt("url", "%@/print"),

--- a/app/assets/javascripts/discourse/app/models/topic.js
+++ b/app/assets/javascripts/discourse/app/models/topic.js
@@ -24,6 +24,7 @@ import Site from "discourse/models/site";
 import User from "discourse/models/user";
 import bootbox from "bootbox";
 import { deepMerge } from "discourse-common/lib/object";
+import { resolveShareUrl } from "discourse/helpers/share-url"
 
 export function loadTopicView(topic, args) {
   const data = deepMerge({}, args);
@@ -241,11 +242,8 @@ const Topic = RestModel.extend({
 
   @discourseComputed("url")
   shareUrl(url) {
-    const user = User.current();
-    const badgesEnabled = this.siteSettings.enable_badges;
-    const userSuffix = user && badgesEnabled ? `?u=${user.username_lower}` : "";
-
-    return url + userSuffix;
+    const context = this;
+    return resolveShareUrl(url, context);
   },
 
   printUrl: fmt("url", "%@/print"),

--- a/app/assets/javascripts/discourse/app/models/topic.js
+++ b/app/assets/javascripts/discourse/app/models/topic.js
@@ -23,7 +23,7 @@ import { Promise } from "rsvp";
 import Site from "discourse/models/site";
 import bootbox from "bootbox";
 import { deepMerge } from "discourse-common/lib/object";
-import { resolveShareUrl } from "discourse/helpers/share-url"
+import { resolveShareUrl } from "discourse/helpers/share-url";
 
 export function loadTopicView(topic, args) {
   const data = deepMerge({}, args);

--- a/app/assets/javascripts/discourse/app/models/topic.js
+++ b/app/assets/javascripts/discourse/app/models/topic.js
@@ -21,7 +21,6 @@ import Category from "discourse/models/category";
 import Session from "discourse/models/session";
 import { Promise } from "rsvp";
 import Site from "discourse/models/site";
-import User from "discourse/models/user";
 import bootbox from "bootbox";
 import { deepMerge } from "discourse-common/lib/object";
 import { resolveShareUrl } from "discourse/helpers/share-url"
@@ -242,8 +241,7 @@ const Topic = RestModel.extend({
 
   @discourseComputed("url")
   shareUrl(url) {
-    const context = this;
-    return resolveShareUrl(url, context);
+    return resolveShareUrl(url);
   },
 
   printUrl: fmt("url", "%@/print"),

--- a/app/assets/javascripts/discourse/app/models/topic.js
+++ b/app/assets/javascripts/discourse/app/models/topic.js
@@ -21,6 +21,7 @@ import Category from "discourse/models/category";
 import Session from "discourse/models/session";
 import { Promise } from "rsvp";
 import Site from "discourse/models/site";
+import User from "discourse/models/user";
 import bootbox from "bootbox";
 import { deepMerge } from "discourse-common/lib/object";
 import { resolveShareUrl } from "discourse/helpers/share-url";
@@ -241,7 +242,8 @@ const Topic = RestModel.extend({
 
   @discourseComputed("url")
   shareUrl(url) {
-    return resolveShareUrl(url);
+    const user = User.current();
+    return resolveShareUrl(url, user);
   },
 
   printUrl: fmt("url", "%@/print"),

--- a/test/javascripts/acceptance/share-and-invite-desktop-test.js
+++ b/test/javascripts/acceptance/share-and-invite-desktop-test.js
@@ -1,10 +1,10 @@
 import { acceptance } from "helpers/qunit-helpers";
 
 acceptance("Share and Invite modal - desktop", {
-  loggedIn: true,
+  loggedIn: true
 });
 
-QUnit.test("Topic footer button", async (assert) => {
+QUnit.test("Topic footer button", async assert => {
   await visit("/t/internationalization-localization/280");
 
   assert.ok(
@@ -64,7 +64,7 @@ QUnit.test("Topic footer button", async (assert) => {
   );
 });
 
-QUnit.test("Post date link", async (assert) => {
+QUnit.test("Post date link", async assert => {
   await visit("/t/internationalization-localization/280");
   await click("#post_2 .post-info.post-date a");
 

--- a/test/javascripts/acceptance/share-and-invite-desktop-test.js
+++ b/test/javascripts/acceptance/share-and-invite-desktop-test.js
@@ -1,10 +1,10 @@
 import { acceptance } from "helpers/qunit-helpers";
 
 acceptance("Share and Invite modal - desktop", {
-  loggedIn: true
+  loggedIn: true,
 });
 
-QUnit.test("Topic footer button", async assert => {
+QUnit.test("Topic footer button", async (assert) => {
   await visit("/t/internationalization-localization/280");
 
   assert.ok(
@@ -64,7 +64,7 @@ QUnit.test("Topic footer button", async assert => {
   );
 });
 
-QUnit.test("Post date link", async assert => {
+QUnit.test("Post date link", async (assert) => {
   await visit("/t/internationalization-localization/280");
   await click("#post_2 .post-info.post-date a");
 
@@ -74,18 +74,21 @@ QUnit.test("Post date link", async assert => {
 acceptance("Share url with badges disabled - desktop", {
   loggedIn: true,
   settings: {
-    enable_badges: false
+    enable_badges: false,
+  },
+});
+
+QUnit.test(
+  "topic footer button - badges disabled - desktop",
+  async (assert) => {
+    await visit("/t/internationalization-localization/280");
+    await click("#topic-footer-button-share-and-invite");
+
+    assert.notOk(
+      find(".share-and-invite.modal .modal-panel.share .topic-share-url")
+        .val()
+        .includes("?u=eviltrout"),
+      "it doesn't add the username param when badges are disabled"
+    );
   }
-});
-
-QUnit.test("topic footer button - badges disabled - desktop", async assert => {
-  await visit("/t/internationalization-localization/280");
-  await click("#topic-footer-button-share-and-invite");
-
-  assert.notOk(
-    find(".share-and-invite.modal .modal-panel.share .topic-share-url")
-      .val()
-      .includes("?u=eviltrout"),
-    "it doesn't add the username param when badges are disabled"
-  );
-});
+);

--- a/test/javascripts/acceptance/share-and-invite-desktop-test.js
+++ b/test/javascripts/acceptance/share-and-invite-desktop-test.js
@@ -70,3 +70,22 @@ QUnit.test("Post date link", async (assert) => {
 
   assert.ok(exists("#share-link"), "it shows the share modal");
 });
+
+acceptance("Share url with badges disabled - desktop", {
+  loggedIn: true,
+  settings: {
+    enable_badges: false
+  }
+});
+
+QUnit.test("topic footer button - badges disabled - desktop", async assert => {
+  await visit("/t/internationalization-localization/280");
+  await click("#topic-footer-button-share-and-invite");
+
+  assert.notOk(
+    find(".share-and-invite.modal .modal-panel.share .topic-share-url")
+      .val()
+      .includes("?u=eviltrout"),
+    "it doesn't add the username param when badges are disabled"
+  );
+});

--- a/test/javascripts/acceptance/share-and-invite-mobile-test.js
+++ b/test/javascripts/acceptance/share-and-invite-mobile-test.js
@@ -3,10 +3,10 @@ import { acceptance } from "helpers/qunit-helpers";
 
 acceptance("Share and Invite modal - mobile", {
   loggedIn: true,
-  mobileView: true,
+  mobileView: true
 });
 
-QUnit.test("Topic footer mobile button", async (assert) => {
+QUnit.test("Topic footer mobile button", async assert => {
   await visit("/t/internationalization-localization/280");
 
   assert.ok(
@@ -54,7 +54,7 @@ QUnit.test("Topic footer mobile button", async (assert) => {
   );
 });
 
-QUnit.test("Post date link", async (assert) => {
+QUnit.test("Post date link", async assert => {
   await visit("/t/internationalization-localization/280");
   await click("#post_2 .post-info.post-date a");
 
@@ -71,7 +71,10 @@ acceptance("Share url with badges disabled - mobile", {
 
 QUnit.test("topic footer button - badges disabled - mobile", async assert => {
   await visit("/t/internationalization-localization/280");
-  await click("#topic-footer-button-share-and-invite");
+
+  const subject = selectKit(".topic-footer-mobile-dropdown");
+  await subject.expand();
+  await subject.selectRowByValue("share-and-invite");
 
   assert.notOk(
     find(".share-and-invite.modal .modal-panel.share .topic-share-url")

--- a/test/javascripts/acceptance/share-and-invite-mobile-test.js
+++ b/test/javascripts/acceptance/share-and-invite-mobile-test.js
@@ -60,3 +60,23 @@ QUnit.test("Post date link", async (assert) => {
 
   assert.ok(exists("#share-link"), "it shows the share modal");
 });
+
+acceptance("Share url with badges disabled - mobile", {
+  loggedIn: true,
+  mobileView: true,
+  settings: {
+    enable_badges: false
+  }
+});
+
+QUnit.test("topic footer button - badges disabled - mobile", async assert => {
+  await visit("/t/internationalization-localization/280");
+  await click("#topic-footer-button-share-and-invite");
+
+  assert.notOk(
+    find(".share-and-invite.modal .modal-panel.share .topic-share-url")
+      .val()
+      .includes("?u=eviltrout"),
+    "it doesn't add the username param when badges are disabled"
+  );
+});

--- a/test/javascripts/acceptance/share-and-invite-mobile-test.js
+++ b/test/javascripts/acceptance/share-and-invite-mobile-test.js
@@ -3,10 +3,10 @@ import { acceptance } from "helpers/qunit-helpers";
 
 acceptance("Share and Invite modal - mobile", {
   loggedIn: true,
-  mobileView: true
+  mobileView: true,
 });
 
-QUnit.test("Topic footer mobile button", async assert => {
+QUnit.test("Topic footer mobile button", async (assert) => {
   await visit("/t/internationalization-localization/280");
 
   assert.ok(
@@ -54,7 +54,7 @@ QUnit.test("Topic footer mobile button", async assert => {
   );
 });
 
-QUnit.test("Post date link", async assert => {
+QUnit.test("Post date link", async (assert) => {
   await visit("/t/internationalization-localization/280");
   await click("#post_2 .post-info.post-date a");
 
@@ -65,11 +65,11 @@ acceptance("Share url with badges disabled - mobile", {
   loggedIn: true,
   mobileView: true,
   settings: {
-    enable_badges: false
-  }
+    enable_badges: false,
+  },
 });
 
-QUnit.test("topic footer button - badges disabled - mobile", async assert => {
+QUnit.test("topic footer button - badges disabled - mobile", async (assert) => {
   await visit("/t/internationalization-localization/280");
 
   const subject = selectKit(".topic-footer-mobile-dropdown");


### PR DESCRIPTION
Context: https://meta.discourse.org/t/stop-appending-username-to-url-when-badge-system-disabled/164904

Share links for topics and posts have the current username appended to them when the user is logged in. 

If badges are disabled, those added usernames are not beneficial since they're only used to track progress towards certain badges. 

This PR makes two change. 

1. it moves the logic for the share link url to a centralized helper because it's shared in both topic and post models. 
2. it stops username params from being added to share links when badges are disabled.

