### PR TITLE
FEATURE: Add a site setting to control automatic auth redirect

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -707,11 +707,11 @@ class ApplicationController < ActionController::Base
   def redirect_to_login
     dont_cache_page
 
-    if SiteSetting.enable_sso?
+    if SiteSetting.external_auth_immediately && SiteSetting.enable_sso?
       # save original URL in a session so we can redirect after login
       session[:destination_url] = destination_url
       redirect_to path('/session/sso')
-    elsif !SiteSetting.enable_local_logins && Discourse.enabled_authenticators.length == 1 && !cookies[:authentication_data]
+    elsif SiteSetting.external_auth_immediately && !SiteSetting.enable_local_logins && Discourse.enabled_authenticators.length == 1 && !cookies[:authentication_data]
       # Only one authentication provider, direct straight to it.
       # If authentication_data is present, then we are halfway though registration. Don't redirect offsite
       cookies[:destination_url] = destination_url

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1621,6 +1621,7 @@ en:
     block_common_passwords: "Don't allow passwords that are in the 10,000 most common passwords."
 
     external_auth_skip_create_confirm: When signing up via external auth, skip the create account popup. Best used alongside sso_overrides_email, sso_overrides_username and sso_overrides_name.
+    external_auth_immediately: "Automatically redirect to the external login system without user interaction. This only takes effect when login_required is true, and there is only one external authentication method"
 
     enable_sso: "Enable single sign on via an external site (WARNING: USERS' EMAIL ADDRESSES *MUST* BE VALIDATED BY THE EXTERNAL SITE!)"
     verbose_sso_logging: "Log verbose SSO related diagnostics to <a href='%{base_path}/logs' target='_blank'>/logs</a>"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -421,6 +421,8 @@ login:
   external_auth_skip_create_confirm:
     default: false
     client: true
+  external_auth_immediately:
+    default: true
   enable_sso:
     client: true
     default: false

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -45,6 +45,24 @@ RSpec.describe ApplicationController do
       expect(response).to redirect_to("/login")
     end
 
+    it "should not redirect to SSO when external_auth_immediately is disabled" do
+      SiteSetting.external_auth_immediately = false
+      SiteSetting.sso_url = 'http://someurl.com'
+      SiteSetting.enable_sso = true
+
+      get "/"
+      expect(response).to redirect_to("/login")
+    end
+
+    it "should not redirect to authenticator when external_auth_immediately is disabled" do
+      SiteSetting.external_auth_immediately = false
+      SiteSetting.enable_google_oauth2_logins = true
+      SiteSetting.enable_local_logins = false
+
+      get "/"
+      expect(response).to redirect_to("/login")
+    end
+
     context "with omniauth in test mode" do
       before do
         OmniAuth.config.test_mode = true


### PR DESCRIPTION
This allows administrators to stop automatic redirect to an external authenticator. It only takes effect when there is a single authentication method, and the site is login_required

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
