### PR TITLE
DEV: Stop polluting `Class` with deprecated settings methods

### DIFF
--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -242,11 +242,11 @@ class SiteSetting < ActiveRecord::Base
   }
 
   ALLOWLIST_DEPRECATED_SITE_SETTINGS.each_pair do |old_method, new_method|
-    self.class.define_method(old_method) do
+    self.define_singleton_method(old_method) do
       Discourse.deprecate("#{old_method.to_s} is deprecated, use the #{new_method.to_s}.", drop_from: "2.6")
       send(new_method)
     end
-    self.class.define_method("#{old_method}=") do |args|
+    self.define_singleton_method("#{old_method}=") do |args|
       Discourse.deprecate("#{old_method.to_s} is deprecated, use the #{new_method.to_s}.", drop_from: "2.6")
       send("#{new_method}=", args)
     end


### PR DESCRIPTION
`self.class` here evaluates to `Class` and then we're calling `define_method` on it which means all classes will have those methods defined in them. For example:

```
~/discourse(master*) » rails c
Loading development environment (Rails 6.0.3.3)
[1] pry(main)> Integer.methods
=> [:sqrt,
 :yaml_tag,
 :email_domains_blacklist=,
 :email_domains_whitelist=,
 :unicode_username_character_whitelist=,
 :user_website_domains_whitelist=,
 :whitelisted_link_domains=,
 :email_domains_blacklist,
 :email_domains_whitelist,
 :unicode_username_character_whitelist,
...
...
```

Fix here is to use `self.define_singleton_method`.

(I noticed this while I was debugging other issues.)
