### PR TITLE
UX: More upbeat message when topic list is empty

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/discovery/topics.js
+++ b/app/assets/javascripts/discourse/app/controllers/discovery/topics.js
@@ -136,7 +136,7 @@ const controllerOpts = {
 
   @discourseComputed("model")
   canCreateTopicOnCategory(model) {
-    return model.can_create_topic
+    return model.can_create_topic;
   },
 
   @discourseComputed("allLoaded", "model.topics.length")

--- a/app/assets/javascripts/discourse/app/controllers/discovery/topics.js
+++ b/app/assets/javascripts/discourse/app/controllers/discovery/topics.js
@@ -134,6 +134,11 @@ const controllerOpts = {
   weekly: equal("period", "weekly"),
   daily: equal("period", "daily"),
 
+  @discourseComputed("model")
+  canCreateTopicOnCategory(model) {
+    return model.can_create_topic
+  },
+
   @discourseComputed("allLoaded", "model.topics.length")
   footerMessage(allLoaded, topicsLength) {
     if (!allLoaded) {

--- a/app/assets/javascripts/discourse/app/templates/discovery/topics.hbs
+++ b/app/assets/javascripts/discourse/app/templates/discovery/topics.hbs
@@ -100,7 +100,10 @@
 
     {{#footer-message education=footerEducation message=footerMessage}}
       {{#if latest}}
-        {{#if canCreateTopicOnCategory}}<a href {{action "createTopic"}}>{{i18n "topic.suggest_create_topic"}}</a>{{/if}}
+        {{#if canCreateTopicOnCategory}}
+          {{i18n "topics.none.ready_to_create"}}
+          <a href {{action "createTopic"}}>{{i18n "topic.suggest_create_topic"}}</a>
+        {{/if}}
       {{else if top}}
         {{#link-to "discovery.categories"}}{{i18n "topic.browse_all_categories"}}{{/link-to}}, {{#link-to "discovery.latest"}}{{i18n "topic.view_latest_topics"}}{{/link-to}} {{i18n "or"}} {{i18n "filters.top.other_periods"}}
         {{top-period-buttons period=period action=(action "changePeriod")}}
@@ -108,6 +111,5 @@
         {{#link-to "discovery.categories"}} {{i18n "topic.browse_all_categories"}}{{/link-to}} {{i18n "or"}} {{#link-to "discovery.latest"}}{{i18n "topic.view_latest_topics"}}{{/link-to}}
       {{/if}}
     {{/footer-message}}
-
   {{/if}}
 </footer>

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2172,7 +2172,8 @@ en:
         new: "You have no new topics."
         read: "You haven't read any topics yet."
         posted: "You haven't posted in any topics yet."
-        latest: "There are no latest topics. That's sad."
+        ready_to_create: "Ready to "
+        latest: "You're all caught up!"
         bookmarks: "You have no bookmarked topics yet."
         category: "There are no %{category} topics."
         top: "There are no top topics."
@@ -2280,7 +2281,7 @@ en:
       browse_all_tags: Browse all tags
 
       view_latest_topics: view latest topics
-      suggest_create_topic: Why not create a topic?
+      suggest_create_topic: start a new conversation?
       jump_reply_up: jump to earlier reply
       jump_reply_down: jump to later reply
       deleted: "The topic has been deleted"


### PR DESCRIPTION
This message used to say "There are no topics here. That's sad." Now it is a much happier message.

<img width="274" alt="Annotation 2020-09-24 085727" src="https://user-images.githubusercontent.com/16214023/94173757-3d231b00-fe49-11ea-9f71-5ce6ab05f884.png">

I added `canCreateTopicOnCategory` for `/latest` route as well.