### PR TITLE
FIX: Don't skip the new user badge

### DIFF
--- a/app/services/badge_granter.rb
+++ b/app/services/badge_granter.rb
@@ -45,7 +45,7 @@ class BadgeGranter
   def grant
     return if @granted_by && !Guardian.new(@granted_by).can_grant_badges?(@user)
     return unless @badge.enabled?
-    return if @badge.badge_grouping_id == BadgeGrouping::GettingStarted && @user.user_option.skip_new_user_tips
+    return if @badge.badge_grouping_id == BadgeGrouping::GettingStarted && @badge.id != Badge::NewUserOfTheMonth && @user.user_option.skip_new_user_tips
 
     find_by = { badge_id: @badge.id, user_id: @user.id }
 

--- a/spec/services/badge_granter_spec.rb
+++ b/spec/services/badge_granter_spec.rb
@@ -225,6 +225,15 @@ describe BadgeGranter do
       expect(user_badge).to eq(nil)
     end
 
+    it "grants the New User of the Month badge when user skipped new user tips" do
+      freeze_time
+      user.user_option.update!(skip_new_user_tips: true)
+      badge = Badge.find(Badge::NewUserOfTheMonth)
+
+      user_badge = BadgeGranter.grant(badge, user, created_at: 1.year.ago)
+      expect(user_badge).to be_present
+    end
+
     it 'grants multiple badges' do
       badge = Fabricate(:badge, multiple_grant: true)
       user_badge = BadgeGranter.grant(badge, user)


### PR DESCRIPTION
The NewUserOfTheMonth badge is part of the Badges::GettingStarted group. This group is skipped in BadgeGranter if the user skips the new user tips. However, the NewUserOfTheMonth badge granter job does not account for this. Instead, it notifies the user they've received the badge even if they did not.

This PR introduces a simple fix to allow granting of this badge even to users who skipped the new user tips.
