### PR TITLE
Improving topic quoting

### DIFF
--- a/app/assets/javascripts/discourse/app/components/quote-button.js
+++ b/app/assets/javascripts/discourse/app/components/quote-button.js
@@ -19,6 +19,12 @@ function getQuoteTitle(element) {
   if (!titleEl) {
     return;
   }
+
+  const titleLink = titleEl.querySelector("a:not(.back)");
+  if (titleLink) {
+    return titleLink.textContent.trim();
+  }
+
   return titleEl.textContent.trim().replace(/:$/, "");
 }
 

--- a/test/javascripts/acceptance/topic-test.js
+++ b/test/javascripts/acceptance/topic-test.js
@@ -338,6 +338,23 @@ QUnit.test("Quoting a quote keeps the original poster name", async (assert) => {
 });
 
 QUnit.test(
+  "Quoting a quote of a different topic keeps the original topic title",
+  async (assert) => {
+    await visit("/t/internationalization-localization/280");
+    selectText("#post_9 blockquote");
+    await click(".quote-button .insert-quote");
+
+    assert.ok(
+      find(".d-editor-input")
+        .val()
+        .indexOf(
+          'quote="A new topic with a link to another topic, post:3, topic:62"'
+        ) !== -1
+    );
+  }
+);
+
+QUnit.test(
   "Quoting a quote with the Reply button keeps the original poster name",
   async (assert) => {
     await visit("/t/internationalization-localization/280");

--- a/test/javascripts/fixtures/topic.js
+++ b/test/javascripts/fixtures/topic.js
@@ -851,7 +851,7 @@ export default {
           uploaded_avatar_id: 5253,
           created_at: "2013-02-07T14:14:12.666Z",
           cooked:
-            '<p><aside class="quote" data-post="8" data-topic="280"><div class="title">\n<div class="quote-controls"></div>\n<img width="20" height="20" src="/user_avatar/meta.discourse.org/sam/40/5243.png" class="avatar">sam said:</div>\n<blockquote><p>one letter change and all your translators need to validate it.</p></blockquote></aside></p>\n\n<p>Yeah, that\'s why I\'ve always been a friend of <code>message_error_nametooshort</code> placeholders, until I asked the SO question linked above. The accepted answer makes a good argument against those placeholders: you <em>want</em> translations to break even on small changes in the English original because the translations will probably need to reflect the change, too.  Maybe that\'s not the case right now as new stuff is being checked in pretty much every couple of hours, but in the long run, it\'ll be overwhelmingly true.</p>',
+             '<aside class="quote no-group\" data-post="3" data-topic="62">\n<div class="title">\n<div class="quote-controls"></div>\n<img alt="" width="20" height="20" src="/user_avatar/meta.discourse.org/sam/40/5243.png" class="avatar"><a href="/t/a-new-topic-with-a-link-to-another-topic/62/3">A new topic with a link to another topic</a>\n</div>\n<blockquote>\n<p>Thanks for posting this</p>\n</blockquote>\n</aside>\n<p>repost after a reload thank you!</p>',
           post_number: 9,
           post_type: 1,
           updated_at: "2013-02-07T14:18:09.569Z",

--- a/test/javascripts/fixtures/topic.js
+++ b/test/javascripts/fixtures/topic.js
@@ -851,7 +851,7 @@ export default {
           uploaded_avatar_id: 5253,
           created_at: "2013-02-07T14:14:12.666Z",
           cooked:
-             '<aside class="quote no-group\" data-post="3" data-topic="62">\n<div class="title">\n<div class="quote-controls"></div>\n<img alt="" width="20" height="20" src="/user_avatar/meta.discourse.org/sam/40/5243.png" class="avatar"><a href="/t/a-new-topic-with-a-link-to-another-topic/62/3">A new topic with a link to another topic</a>\n</div>\n<blockquote>\n<p>Thanks for posting this</p>\n</blockquote>\n</aside>\n<p>repost after a reload thank you!</p>',
+            '<aside class="quote no-group\" data-post="3" data-topic="62">\n<div class="title">\n<div class="quote-controls"></div>\n<img alt="" width="20" height="20" src="/user_avatar/meta.discourse.org/sam/40/5243.png" class="avatar"><a href="/t/a-new-topic-with-a-link-to-another-topic/62/3">A new topic with a link to another topic</a>\n</div>\n<blockquote>\n<p>Thanks for posting this</p>\n</blockquote>\n</aside>\n<p>repost after a reload thank you!</p>',
           post_number: 9,
           post_type: 1,
           updated_at: "2013-02-07T14:18:09.569Z",


### PR DESCRIPTION
It is possible to post a link in one topic (Topic A) to another topic (Topic B) on the same Discourse site. This will be rendered as a quote, with the title of the quote being Topic B's title. The category of the Topic B will be included next to the title of Topic B.

If a subsequent reply to Topic A includes a quote from the quoted text of Topic B, the title of new quote should not include the category of Topic B.