### PR TITLE
FIX: removes time from date in calendar range at midnight

### DIFF
--- a/plugins/discourse-local-dates/assets/javascripts/lib/local-date-builder.js.es6
+++ b/plugins/discourse-local-dates/assets/javascripts/lib/local-date-builder.js.es6
@@ -188,12 +188,16 @@ export default class LocalDateBuilder {
         );
 
       if (inCalendarRange && sameTimezone) {
-        return localDate
-          .datetimeWithZone(this.localTimezone)
-          .calendar(
-            moment.tz(localDate.timezone),
-            this._calendarFormats(this.time ? this.time : null)
-          );
+        const date = localDate.datetimeWithZone(this.localTimezone);
+
+        if (date.hours() === 0 && date.minutes() === 0) {
+          return date.format("dddd");
+        }
+
+        return date.calendar(
+          moment.tz(localDate.timezone),
+          this._calendarFormats(this.time ? this.time : null)
+        );
       }
     }
 

--- a/plugins/discourse-local-dates/test/javascripts/lib/local-date-builder-test.js.es6
+++ b/plugins/discourse-local-dates/test/javascripts/lib/local-date-builder-test.js.es6
@@ -259,8 +259,16 @@ QUnit.test("option[calendar]", (assert) => {
 
   freezeTime({ date: "2020-03-20 23:59" }, () =>
     assert.buildsCorrectDate(
+      { date: "2020-03-21", time: "01:00", timezone: PARIS },
+      { formated: "Tomorrow 1:00 AM" }
+    )
+  );
+
+  freezeTime({ date: "2020-03-20 23:59" }, () =>
+    assert.buildsCorrectDate(
       { date: "2020-03-21", time: "00:00", timezone: PARIS },
-      { formated: "Tomorrow 12:00 AM" }
+      { formated: "Saturday" },
+      "it displays the day with no time when the time in the displayed timezone is 00:00"
     )
   );
 


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
