### PR TITLE
FIX: when the user is promoted to TL2 invite to advance training

### DIFF
--- a/lib/system_message.rb
+++ b/lib/system_message.rb
@@ -43,7 +43,7 @@ class SystemMessage
 
     post = I18n.with_locale(@recipient.effective_locale) { creator.create }
 
-    DiscourseEvent.trigger(:system_message_sent, post: post, message_type: type)
+    DiscourseEvent.trigger(:system_message_sent, post: post, message_type: type, target_user: @recipient)
 
     if creator.errors.present?
       raise StandardError, creator.errors.full_messages.join(" ")

--- a/lib/system_message.rb
+++ b/lib/system_message.rb
@@ -43,7 +43,7 @@ class SystemMessage
 
     post = I18n.with_locale(@recipient.effective_locale) { creator.create }
 
-    DiscourseEvent.trigger(:system_message_sent, post: post, message_type: type, target_user: @recipient)
+    DiscourseEvent.trigger(:system_message_sent, post: post, message_type: type)
 
     if creator.errors.present?
       raise StandardError, creator.errors.full_messages.join(" ")

--- a/plugins/discourse-narrative-bot/config/locales/server.en.yml
+++ b/plugins/discourse-narrative-bot/config/locales/server.en.yml
@@ -24,10 +24,8 @@ en:
     bio: "Hi, I’m not a real person. I’m a bot that can teach you about this site. To interact with me, send me a message or mention **`@%{discobot_username}`** anywhere."
 
     tl2_promotion_message:
-      subject_template: "Congratulations on your trust level promotion!"
+      subject_template: "Now that you’ve been promoted, it’s time to learn about some advanced features!"
       text_body_template: |
-        Now that you’ve been promoted, it’s time to learn about some advanced features!
-
         Reply to this message with `@%{discobot_username} %{reset_trigger}` to find out more about what you can do.
 
     timeout:

--- a/plugins/discourse-narrative-bot/plugin.rb
+++ b/plugins/discourse-narrative-bot/plugin.rb
@@ -297,8 +297,9 @@ after_initialize do
         ::DiscourseNarrativeBot::Base.new.discobot_user,
         title: I18n.t("discourse_narrative_bot.tl2_promotion_message.subject_template"),
         raw: raw,
-        topic_id: args[:post].topic_id,
-        skip_validations: true
+        skip_validations: true,
+        archetype: Archetype.private_message,
+        target_usernames: args[:target_user].username
       )
     end
   end

--- a/plugins/discourse-narrative-bot/plugin.rb
+++ b/plugins/discourse-narrative-bot/plugin.rb
@@ -293,13 +293,15 @@ after_initialize do
                   discobot_username: ::DiscourseNarrativeBot::Base.new.discobot_username,
                   reset_trigger: "#{::DiscourseNarrativeBot::TrackSelector.reset_trigger} #{::DiscourseNarrativeBot::AdvancedUserNarrative.reset_trigger}")
 
+      recipient = args[:post].topic.topic_users.where.not(user_id: args[:post].user_id).last.user
+
       PostCreator.create!(
         ::DiscourseNarrativeBot::Base.new.discobot_user,
         title: I18n.t("discourse_narrative_bot.tl2_promotion_message.subject_template"),
         raw: raw,
         skip_validations: true,
         archetype: Archetype.private_message,
-        target_usernames: args[:target_user].username
+        target_usernames: recipient.username
       )
     end
   end

--- a/plugins/discourse-narrative-bot/spec/discourse_narrative_bot/advanced_user_narrative_spec.rb
+++ b/plugins/discourse-narrative-bot/spec/discourse_narrative_bot/advanced_user_narrative_spec.rb
@@ -734,10 +734,11 @@ RSpec.describe DiscourseNarrativeBot::AdvancedUserNarrative do
   end
 
   it 'invites to advanced training when user is promoted to TL2' do
+    recipient = Fabricate(:user)
     expect {
-      DiscourseEvent.trigger(:system_message_sent, post: Post.last, message_type: 'tl2_promotion_message', target_user: user)
+      DiscourseEvent.trigger(:system_message_sent, post: Post.last, message_type: 'tl2_promotion_message')
     }.to change { Topic.count }
     expect(Topic.last.title).to eq(I18n.t("discourse_narrative_bot.tl2_promotion_message.subject_template"))
-    expect(Topic.last.topic_users.map(&:user_id).sort).to eq([DiscourseNarrativeBot::Base.new.discobot_user.id, user.id])
+    expect(Topic.last.topic_users.map(&:user_id).sort).to eq([DiscourseNarrativeBot::Base.new.discobot_user.id, recipient.id])
   end
 end

--- a/plugins/discourse-narrative-bot/spec/discourse_narrative_bot/advanced_user_narrative_spec.rb
+++ b/plugins/discourse-narrative-bot/spec/discourse_narrative_bot/advanced_user_narrative_spec.rb
@@ -732,4 +732,12 @@ RSpec.describe DiscourseNarrativeBot::AdvancedUserNarrative do
       end
     end
   end
+
+  it 'invites to advanced training when user is promoted to TL2' do
+    expect {
+      DiscourseEvent.trigger(:system_message_sent, post: Post.last, message_type: 'tl2_promotion_message', target_user: user)
+    }.to change { Topic.count }
+    expect(Topic.last.title).to eq(I18n.t("discourse_narrative_bot.tl2_promotion_message.subject_template"))
+    expect(Topic.last.topic_users.map(&:user_id).sort).to eq([DiscourseNarrativeBot::Base.new.discobot_user.id, user.id])
+  end
 end


### PR DESCRIPTION
Invitation to advanced training should be sent as a separate private message instead of hooking into TL2 promotion message.