### PR TITLE
Allow adding custom preferences to user notifications.

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/preferences/notifications.hbs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/notifications.hbs
@@ -66,6 +66,8 @@
 
 {{plugin-outlet name="user-preferences-notifications" args=(hash model=model save=(action "save"))}}
 
+{{plugin-outlet name="user-custom-notifications" args=(hash model=model)}}
+
 <br>
 
 {{plugin-outlet name="user-custom-controls" args=(hash model=model)}}


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->

No test, as wasn't able to locate an existing one for the extension point in `profile.hbs`.

Goal is to be able to move user preference for discourse-telegram-notifications from Profile section into Notifications section. The existing extension point doesn't result in the preference being saved.