### PR TITLE
FIX: Invalid URLs could raise unwanted exceptions

### DIFF
--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -168,7 +168,7 @@ class Upload < ActiveRecord::Base
     # have secure-media-uploads in the URL e.g. /t/secure-media-uploads-are-cool/223452
     route = UrlHelper.rails_route_from_url(url)
     route[:action] == "show_secure" && route[:controller] == "uploads" && FileHelper.is_supported_media?(url)
-  rescue ActionController::RoutingError
+  rescue ActionController::RoutingError, Addressable::URI::InvalidURIError
     false
   end
 

--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -493,5 +493,10 @@ describe Upload do
       url = "/uploads/default/test_0/original/1X/e1864389d8252958586c76d747b069e9f68827e3.png"
       expect(Upload.secure_media_url?(url)).to eq(false)
     end
+
+    it "does not raise for invalid URLs" do
+      url = "http://URL:%20https://google.com"
+      expect(Upload.secure_media_url?(url)).to eq(false)
+    end
   end
 end


### PR DESCRIPTION
Upload.secure_media_url? raised an exceptions when the URL was invalid,
which was a issue in some situations where secure media URLs must be
removed.

For example, sending digests used PrettyText.strip_secure_media,
which used Upload.secure_media_url? to replace secure media with
placeholders. If the URL was invalid, then an exception would be raised
and left unhandled.