### PR TITLE
FIX: Prevent email encoding issues when attachments are added

### DIFF
--- a/lib/email/sender.rb
+++ b/lib/email/sender.rb
@@ -332,8 +332,11 @@ module Email
         content = Mail::Part.new do
           content_type "multipart/alternative"
 
-          part html_part
-          part text_part
+          # we have to re-specify the charset and give the part the decoded body
+          # here otherwise the parts will get encoded with US-ASCII which makes
+          # a bunch of characters not render correctly in the email
+          part content_type: "text/html; charset=utf-8", body: html_part.body.decoded
+          part content_type: "text/plain; charset=utf-8", body: text_part.body.decoded
         end
 
         @message.parts.unshift(content)

--- a/spec/components/email/sender_spec.rb
+++ b/spec/components/email/sender_spec.rb
@@ -378,7 +378,7 @@ describe Email::Sender do
     fab!(:post) { Fabricate(:post) }
     fab!(:reply) do
       raw = <<~RAW
-        Hello world!
+        Hello world! It’s a great day!
         #{UploadMarkdown.new(small_pdf).attachment_markdown}
         #{UploadMarkdown.new(large_pdf).attachment_markdown}
         #{UploadMarkdown.new(image).image_markdown}
@@ -460,6 +460,13 @@ describe Email::Sender do
           expect(message.html_part.body).to include("embedded-secure-image")
           expect(message.attachments.length).to eq(4)
         end
+
+        it "uses correct UTF-8 encoding for the body of the email" do
+          Email::Sender.new(message, :valid_type).send
+          expect(message.html_part.body).not_to include("Itâ\u0080\u0099s")
+          expect(message.html_part.body).to include("It’s")
+          expect(message.html_part.charset.downcase).to eq("utf-8")
+        end
       end
     end
 
@@ -490,6 +497,13 @@ describe Email::Sender do
       expect(message.parts.size).to eq(4)
       expect(message.parts[0].content_type).to start_with("multipart/alternative")
       expect(message.parts[0].parts.size).to eq(2)
+    end
+
+    it "uses correct UTF-8 encoding for the body of the email" do
+      Email::Sender.new(message, :valid_type).send
+      expect(message.html_part.body).not_to include("Itâ\u0080\u0099s")
+      expect(message.html_part.body).to include("It’s")
+      expect(message.html_part.charset.downcase).to eq("utf-8")
     end
   end
 


### PR DESCRIPTION
When attachments are added to an outgoing email we have to do some faffing around with the Mail gem parts (refer to https://github.com/discourse/discourse/blob/e5b7db38e3293297fb54d620eb699a8d0857c46b/lib/email/sender.rb#L301-L318). However this causes the charset of the html and text parts to revert to US-ASCII which causes encoding issues. For example this:

```
It’s a fine day.
```

Turns into:

```
Itâs a fine day.
```

This PR changes the way we add the parts back to the email to better reflect the example in https://www.rubydoc.info/github/mikel/mail/Mail/Message#part-instance_method where we use the decoded body string and provide the content type and charset as parameters so we are explicit about what we want.

The conclusion here was reached after much inspection of the Mail source code and associated documentation, specifically:

* https://github.com/mikel/mail/blob/aba0b5f/lib/mail/body.rb
* https://github.com/mikel/mail/blob/aba0b5f/lib/mail/part.rb
* https://github.com/mikel/mail/blob/aba0b5f/lib/mail/message.rb

And looking at https://stackoverflow.com/questions/4868205/rails-mail-getting-the-body-as-plain-text and https://github.com/mikel/mail/issues/282.