### PR TITLE
FIX: empty highlighted_languages resulted in ["", "auto", "nohighlight"]

### DIFF
--- a/app/assets/javascripts/pretty-text/engines/discourse-markdown/code.js
+++ b/app/assets/javascripts/pretty-text/engines/discourse-markdown/code.js
@@ -37,6 +37,7 @@ export function setup(helper) {
     opts.defaultCodeLang = siteSettings.default_code_lang;
     opts.acceptableCodeClasses = (siteSettings.highlighted_languages || "")
       .split("|")
+      .filter(Boolean)
       .concat(["auto", "nohighlight"]);
   });
 


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
