### PR TITLE
FEATURE: composer option to reload page and force save draft

### DIFF
--- a/app/assets/javascripts/discourse/app/models/draft.js
+++ b/app/assets/javascripts/discourse/app/models/draft.js
@@ -23,11 +23,17 @@ Draft.reopenClass({
     return current;
   },
 
-  save(key, sequence, data, clientId) {
+  save(key, sequence, data, clientId, { forceSave = false } = {}) {
     data = typeof data === "string" ? data : JSON.stringify(data);
     return ajax("/draft.json", {
       type: "POST",
-      data: { draft_key: key, sequence, data, owner: clientId },
+      data: {
+        draft_key: key,
+        sequence,
+        data,
+        owner: clientId,
+        force_save: forceSave,
+      },
     });
   },
 });

--- a/app/controllers/draft_controller.rb
+++ b/app/controllers/draft_controller.rb
@@ -22,7 +22,8 @@ class DraftController < ApplicationController
           params[:draft_key],
           params[:sequence].to_i,
           params[:data],
-          params[:owner]
+          params[:owner],
+          force_save: params[:force_save]
         )
       rescue Draft::OutOfSequence
 

--- a/app/models/draft.rb
+++ b/app/models/draft.rb
@@ -9,8 +9,9 @@ class Draft < ActiveRecord::Base
 
   class OutOfSequence < StandardError; end
 
-  def self.set(user, key, sequence, data, owner = nil)
+  def self.set(user, key, sequence, data, owner = nil, force_save: false)
     return 0 if !User.human_user_id?(user.id)
+    force_save = force_save.to_s == "true"
 
     if SiteSetting.backup_drafts_to_pm_length > 0 && SiteSetting.backup_drafts_to_pm_length < data.length
       backup_draft(user, key, sequence, data)
@@ -41,10 +42,11 @@ class Draft < ActiveRecord::Base
     current_sequence ||= 0
 
     if draft_id
-      if current_sequence != sequence
+      if !force_save && (current_sequence != sequence)
         raise Draft::OutOfSequence
       end
 
+      sequence = current_sequence if force_save
       sequence += 1
 
       # we need to keep upping our sequence on every save

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1942,6 +1942,9 @@ en:
           label: "Toggle topic bump"
           desc: "Reply without changing latest reply date"
 
+      reload: "Reload"
+      ignore: "Ignore"
+
     notifications:
       tooltip:
         regular:

--- a/spec/models/draft_spec.rb
+++ b/spec/models/draft_spec.rb
@@ -137,6 +137,15 @@ describe Draft do
     expect(Draft.get(user, "test", 1)).to eq "hello"
   end
 
+  it "should disregard draft sequence if force_save is true" do
+    Draft.set(user, "test", 0, "data")
+    DraftSequence.next!(user, "test")
+    Draft.set(user, "test", 1, "hello")
+
+    seq = Draft.set(user, "test", 0, "foo", nil, force_save: true)
+    expect(seq).to eq(2)
+  end
+
   it 'can cleanup old drafts' do
     key = Draft::NEW_TOPIC
 


### PR DESCRIPTION
Previously when there was a draft conflict we used to show this modal:

<img width="628" alt="Screenshot 2020-09-29 at 6 37 24 PM" src="https://user-images.githubusercontent.com/5732281/94562426-f4bd9000-0282-11eb-994d-c3aad9287274.png">

The "OK" button was not so helpful. Now we'll show two action buttons instead:

<img width="622" alt="Screenshot 2020-09-29 at 6 42 23 PM" src="https://user-images.githubusercontent.com/5732281/94563438-5a5e4c00-0284-11eb-9e4b-c26640ed061c.png">

The "Reload" button, as expected, will reload the page. The "Ignore" button is rather interesting. If the user presses "Ignore" button the next draft save request will send `force_save` param as "true". This will force the draft to be saved and will increment the draft sequence by 1.

