### PR TITLE
UI: Remove background from group notifications of @mentions

### DIFF
--- a/app/assets/stylesheets/common/base/group.scss
+++ b/app/assets/stylesheets/common/base/group.scss
@@ -5,7 +5,6 @@
 span.mention-group {
   color: var(--primary-high-or-secondary-low);
   padding: 2px 4px;
-  background: rgba(var(--primary-rgb), 0.12);
   border-radius: 8px;
   font-weight: 600;
   font-size: $font-down-1;


### PR DESCRIPTION
This commit removes the background color from group @mention notifications. This resolves visual contrast issues when 'unread' styles are applied.

This edit was requested and approved by Sam.

![image](https://user-images.githubusercontent.com/30537603/94576182-b00e0680-023a-11eb-90a9-04063479a3b6.png)

![image](https://user-images.githubusercontent.com/30537603/94576159-a8e6f880-023a-11eb-9a35-5eeb47386c86.png)


<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
