### PR TITLE
REFACTOR: Remove deprecated `action="something"` attributes

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-button.js
+++ b/app/assets/javascripts/discourse/app/components/d-button.js
@@ -94,6 +94,8 @@ export default Component.extend({
 
     if (action) {
       if (typeof action === "string") {
+        // Note: This is deprecated in new Embers and needs to be removed in the future.
+        // There is already a warning in the console.
         this.sendAction("action", this.actionParam);
       } else if (typeof action === "object" && action.value) {
         action.value(this.actionParam);

--- a/app/assets/javascripts/discourse/app/components/tag-info.js
+++ b/app/assets/javascripts/discourse/app/components/tag-info.js
@@ -74,7 +74,7 @@ export default Component.extend({
     },
 
     deleteTag() {
-      this.sendAction("deleteAction", this.tagInfo);
+      this.deleteAction(this.tagInfo);
     },
 
     unlinkSynonym(tag) {

--- a/app/assets/javascripts/discourse/app/templates/components/discourse-banner.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/discourse-banner.hbs
@@ -1,7 +1,7 @@
 {{#if visible}}
   <div class="row">
     <div id="banner" class={{overlay}}>
-      {{d-button icon="times" action="dismiss" class="btn btn-flat close" title="banner.close"}}
+      {{d-button icon="times" action=(action "dismiss") class="btn btn-flat close" title="banner.close"}}
       <div id="banner-content">
         {{html-safe content}}
         {{#if currentUser.staff}}

--- a/app/assets/javascripts/discourse/app/templates/components/notification-consent-banner.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/notification-consent-banner.hbs
@@ -11,7 +11,7 @@
       </span>
       {{d-button
         icon="times"
-        action="dismiss"
+        action=(action "dismiss")
         class="btn btn-flat close" title="banner.close"
       }}
     </div>

--- a/app/assets/javascripts/discourse/app/templates/components/pwa-install-banner.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/pwa-install-banner.hbs
@@ -9,7 +9,7 @@
       </span>
       {{d-button
         icon="times"
-        action="dismiss"
+        action=(action "dismiss")
         class="btn btn-flat close"
         title="banner.close"
       }}

--- a/app/assets/javascripts/discourse/app/templates/components/share-popup.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/share-popup.hbs
@@ -34,7 +34,8 @@
       </div>
     {{/if}}
 
-    {{d-button action=(action "close")
+    {{d-button
+      action=(action "close")
       class="btn btn-flat close"
       icon="times"
       aria-label="share.close"

--- a/app/assets/javascripts/discourse/app/templates/components/share-popup.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/share-popup.hbs
@@ -34,6 +34,11 @@
       </div>
     {{/if}}
 
-    {{d-button action="close" class="btn btn-flat close" icon="times" aria-label="share.close" title="share.close"}}
+    {{d-button action=(action "close")
+      class="btn btn-flat close"
+      icon="times"
+      aria-label="share.close"
+      title="share.close"
+    }}
   </div>
 </div>


### PR DESCRIPTION
In newer versions of Ember, `this.sendAction` is deprecated:

https://deprecations.emberjs.com/v3.x/#toc_ember-component-send-action

This patch removes most of our current uses (via `d-button`) but also
some other rogue `this.sendAction` calls too.

