### PR TITLE
FIX: We were overriding the `canCreateTopicOnCategory` computed property

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/discovery/topics.js
+++ b/app/assets/javascripts/discourse/app/controllers/discovery/topics.js
@@ -27,6 +27,7 @@ const controllerOpts = {
   router: service(),
 
   period: null,
+  canCreateTopicOnCategory: null,
 
   canStar: alias("currentUser.id"),
   showTopicPostBadges: not("discoveryTopics.new"),
@@ -157,11 +158,6 @@ const controllerOpts = {
   monthly: equal("period", "monthly"),
   weekly: equal("period", "weekly"),
   daily: equal("period", "daily"),
-
-  @discourseComputed("model")
-  canCreateTopicOnCategory(model) {
-    return model.can_create_topic;
-  },
 
   @discourseComputed("allLoaded", "model.topics.length")
   footerMessage(allLoaded, topicsLength) {


### PR DESCRIPTION
It seems to be set everytime by the route so the old CP was not
required. This is not allowed in newer versions of ember.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
