### PR TITLE
FIX: Deprecation overwriting `translatedText` CP

### DIFF
--- a/app/assets/javascripts/discourse/app/components/discourse-linked-text.js
+++ b/app/assets/javascripts/discourse/app/components/discourse-linked-text.js
@@ -5,10 +5,10 @@ import discourseComputed from "discourse-common/utils/decorators";
 export default Component.extend({
   tagName: "span",
 
-  @discourseComputed("text")
+  @discourseComputed("text", "textParams")
   translatedText(text) {
     if (text) {
-      return I18n.t(text);
+      return I18n.t(...arguments);
     }
   },
 

--- a/app/assets/javascripts/discourse/app/templates/components/pwa-install-banner.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/pwa-install-banner.hbs
@@ -4,7 +4,8 @@
       <span>
         {{discourse-linked-text
           action=(action "turnOn")
-          translatedText=(i18n "pwa.install_banner" title=siteSettings.title)
+          text="pwa.install_banner"
+          textParams=(hash title=siteSettings.title)
         }}
       </span>
       {{d-button


### PR DESCRIPTION
This allows us to pass a `textParams` object for options that will be
translated via i18n.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
