### PR TITLE
FIX: Make bundler use the cached directory in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,7 @@ jobs:
           gem install bundler -v 2.1.4 --no-doc
           bundle config deployment 'true'
           bundle config without 'development'
+          bundle config path vendor/bundle
 
       - name: Bundler cache
         uses: actions/cache@v1


### PR DESCRIPTION
It looks like this was accidentally omitted.