### PR TITLE
FIX: Allow .otf fonts to be delivered via cdn

### DIFF
--- a/config/nginx.sample.conf
+++ b/config/nginx.sample.conf
@@ -5,7 +5,7 @@ types {
 
 upstream discourse {
   server unix:/var/www/discourse/tmp/sockets/nginx.http.sock;
-  server unix:/var/www/discourse/tmp/sockets/nginx.https.sock; 
+  server unix:/var/www/discourse/tmp/sockets/nginx.https.sock;
 }
 
 # inactive means we keep stuff around for 1440m minutes regardless of last access (1 week)
@@ -112,7 +112,7 @@ server {
       break;
     }
 
-    location ~* (fonts|assets|plugins|uploads)/.*\.(eot|ttf|woff|woff2|ico)$ {
+    location ~* (fonts|assets|plugins|uploads)/.*\.(eot|ttf|woff|woff2|ico|otf)$ {
       expires 1y;
       add_header Cache-Control public,immutable;
       add_header Access-Control-Allow-Origin *;


### PR DESCRIPTION
The discourse-fonts package includes NotoSansJP (bold and regular), but
it is an OTF font, and it results in 404s in CDN requests.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
