### PR TITLE
FIX: Migration should only update ReviewableUsers where the user is not approved.

### DIFF
--- a/db/migrate/20200311135425_clear_approved_users_from_the_review_queue.rb
+++ b/db/migrate/20200311135425_clear_approved_users_from_the_review_queue.rb
@@ -5,7 +5,8 @@ class ClearApprovedUsersFromTheReviewQueue < ActiveRecord::Migration[6.0]
       UPDATE reviewables r
       SET status = #{Reviewable.statuses[:approved]}
       FROM users u
-      WHERE u.approved = true AND r.type = 'ReviewableUser' AND r.status = #{Reviewable.statuses[:pending]}
+      WHERE u.id = r.target_id AND u.approved = true 
+      AND r.type = 'ReviewableUser' AND r.status = #{Reviewable.statuses[:pending]}
       RETURNING r.id
     SQL
 


### PR DESCRIPTION
The reviewable was updated despite the user not being approved because a u.id = r.target_id condition is missing. It only affected user reviewables that were pending when the migration ran. Users were not auto-approved.

