### PR TITLE
FIX: Clear notification of skipped narrative bot PM

### DIFF
--- a/plugins/discourse-narrative-bot/plugin.rb
+++ b/plugins/discourse-narrative-bot/plugin.rb
@@ -196,7 +196,7 @@ after_initialize do
     first_post = topic.ordered_posts.first
 
     notification = Notification.where(topic_id: topic.id, post_number: first_post.post_number).first
-    if (notification.present?)
+    if notification.present?
       Notification.read(self, notification.id)
       self.saw_notification_id(notification.id)
       self.reload

--- a/plugins/discourse-narrative-bot/plugin.rb
+++ b/plugins/discourse-narrative-bot/plugin.rb
@@ -194,6 +194,15 @@ after_initialize do
     return if topic.blank?
 
     first_post = topic.ordered_posts.first
+
+    notification = Notification.where(topic_id: topic.id, post_number: first_post.post_number).first
+    if (notification.present?)
+      Notification.read(self, notification.id)
+      self.saw_notification_id(notification.id)
+      self.reload
+      self.publish_notifications_state
+    end
+
     PostDestroyer.new(Discourse.system_user, first_post, skip_staff_log: true).destroy
     DiscourseNarrativeBot::Store.remove(self.id)
   end

--- a/plugins/discourse-narrative-bot/spec/user_spec.rb
+++ b/plugins/discourse-narrative-bot/spec/user_spec.rb
@@ -123,6 +123,7 @@ describe User do
           user.user_option.save!
         }.to change { Topic.count }.by(-1)
           .and change { UserHistory.count }.by(0)
+          .and change { user.unread_high_priority_notifications }.by(-1)
       end
     end
 

--- a/plugins/discourse-narrative-bot/spec/user_spec.rb
+++ b/plugins/discourse-narrative-bot/spec/user_spec.rb
@@ -124,6 +124,7 @@ describe User do
         }.to change { Topic.count }.by(-1)
           .and change { UserHistory.count }.by(0)
           .and change { user.unread_high_priority_notifications }.by(-1)
+          .and change { user.notifications.count }.by(-1)
       end
     end
 


### PR DESCRIPTION
Resets a new user's PM count in their badge after skipping user tips.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
