### PR TITLE
FIX: move hp request from /users to /token

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/create-account.js
+++ b/app/assets/javascripts/discourse/app/controllers/create-account.js
@@ -229,7 +229,7 @@ export default Controller.extend(
         return this._hpPromise;
       }
 
-      this._hpPromise = ajax(userPath("hp.json"))
+      this._hpPromise = ajax("/token/hp.json")
         .then((json) => {
           this._challengeDate = new Date();
           // remove 30 seconds for jitter, make sure this works for at least

--- a/app/views/users/activate_account.html.erb
+++ b/app/views/users/activate_account.html.erb
@@ -13,7 +13,7 @@
   <%= preload_script "ember_jquery" %>
   <%= preload_script "vendor" %>
   <%= render_google_universal_analytics_code %>
-  <%= tag.meta id: 'data-activate-account', data: { path: path('/u/hp') } %>
+  <%= tag.meta id: 'data-activate-account', data: { path: path('/token/hp') } %>
 <%- end %>
 
 <%= preload_script "activate-account" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -383,6 +383,7 @@ Discourse::Application.routes.draw do
 
     get "user-cards" => "users#cards", format: :json
 
+    get "token/hp" => "users#get_honeypot_value"
     %w{users u}.each_with_index do |root_path, index|
       get "#{root_path}" => "users#index", constraints: { format: 'html' }
 
@@ -406,7 +407,6 @@ Discourse::Application.routes.draw do
       put "#{root_path}/second_factors_backup" => "users#create_second_factor_backup"
 
       put "#{root_path}/update-activation-email" => "users#update_activation_email"
-      get "#{root_path}/hp" => "users#get_honeypot_value"
       post "#{root_path}/email-login" => "users#email_login"
       get "#{root_path}/admin-login" => "users#admin_login"
       put "#{root_path}/admin-login" => "users#admin_login"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -522,7 +522,7 @@ users:
   reserved_usernames:
     type: list
     list_type: compact
-    default: "admin|moderator|administrator|mod|sys|system|community|info|you|name|username|user|nickname|discourse|discourseorg|discourseforum|support|hp"
+    default: "admin|moderator|administrator|mod|sys|system|community|info|you|name|username|user|nickname|discourse|discourseorg|discourseforum|support"
   min_password_length:
     client: true
     default: 10

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -9,7 +9,7 @@ describe UsersController do
   describe "#full account registration flow" do
     it "will correctly handle honeypot and challenge" do
 
-      get '/u/hp.json'
+      get '/token/hp.json'
       expect(response.status).to eq(200)
 
       json = response.parsed_body
@@ -584,7 +584,7 @@ describe UsersController do
 
   describe '#create' do
     def honeypot_magic(params)
-      get '/u/hp.json'
+      get '/token/hp.json'
       json = response.parsed_body
       params[:password_confirmation] = json["value"]
       params[:challenge] = json["challenge"].reverse

--- a/spec/support/integration_helpers.rb
+++ b/spec/support/integration_helpers.rb
@@ -2,7 +2,7 @@
 
 module IntegrationHelpers
   def create_user
-    get "/u/hp.json"
+    get "/token/hp.json"
 
     expect(response.status).to eq(200)
 

--- a/test/javascripts/helpers/create-pretender.js
+++ b/test/javascripts/helpers/create-pretender.js
@@ -416,7 +416,7 @@ export function applyDefaultHandlers(pretender) {
   pretender.post("/u/action/send_activation_email", success);
   pretender.put("/u/update-activation-email", success);
 
-  pretender.get("/u/hp.json", function () {
+  pretender.get("/token/hp.json", function () {
     return response({
       value: "32faff1b1ef1ac3",
       challenge: "61a3de0ccf086fb9604b76e884d75801",

--- a/test/javascripts/unit/lib/url-test.js
+++ b/test/javascripts/unit/lib/url-test.js
@@ -59,14 +59,12 @@ QUnit.test("isInternal on subfolder install", (assert) => {
 QUnit.test("userPath", (assert) => {
   assert.equal(userPath(), "/u");
   assert.equal(userPath("eviltrout"), "/u/eviltrout");
-  assert.equal(userPath("hp.json"), "/u/hp.json");
 });
 
 QUnit.test("userPath with prefix", (assert) => {
   setPrefix("/forum");
   assert.equal(userPath(), "/forum/u");
   assert.equal(userPath("eviltrout"), "/forum/u/eviltrout");
-  assert.equal(userPath("hp.json"), "/forum/u/hp.json");
 });
 
 QUnit.test("routeTo with prefix", async (assert) => {


### PR DESCRIPTION
`hp` is a valid username and we should not prevent users from registering it.