### PR TITLE
FIX: move hp request from /users to /token

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/create-account.js
+++ b/app/assets/javascripts/discourse/app/controllers/create-account.js
@@ -229,7 +229,7 @@ export default Controller.extend(
         return this._hpPromise;
       }
 
-      this._hpPromise = ajax(userPath("hp.json"))
+      this._hpPromise = ajax("/session/hp.json")
         .then((json) => {
           this._challengeDate = new Date();
           // remove 30 seconds for jitter, make sure this works for at least

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -47,6 +47,9 @@ class ApplicationController < ActionController::Base
   after_action  :dont_cache_page
   after_action  :conditionally_allow_site_embedding
 
+  HONEYPOT_KEY ||= 'HONEYPOT_KEY'
+  CHALLENGE_KEY ||= 'CHALLENGE_KEY'
+
   layout :set_layout
 
   def has_escaped_fragment?
@@ -832,6 +835,14 @@ class ApplicationController < ActionController::Base
   end
 
   protected
+
+  def honeypot_value
+    secure_session[HONEYPOT_KEY] ||= SecureRandom.hex
+  end
+
+  def challenge_value
+    secure_session[CHALLENGE_KEY] ||= SecureRandom.hex
+  end
 
   def render_post_json(post, add_raw: true)
     post_serializer = PostSerializer.new(post, scope: guardian, root: false)

--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -451,6 +451,17 @@ class SessionController < ApplicationController
     end
   end
 
+  def get_honeypot_value
+    secure_session.set(HONEYPOT_KEY, honeypot_value, expires: 1.hour)
+    secure_session.set(CHALLENGE_KEY, challenge_value, expires: 1.hour)
+
+    render json: {
+      value: honeypot_value,
+      challenge: challenge_value,
+      expires_in: SecureSession.expiry
+    }
+  end
+
   protected
 
   def check_local_login_allowed(user: nil, check_login_via_email: false)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -35,7 +35,6 @@ class UsersController < ApplicationController
   skip_before_action :verify_authenticity_token, only: [:create]
   skip_before_action :redirect_to_login_if_required, only: [:check_username,
                                                             :create,
-                                                            :get_honeypot_value,
                                                             :account_created,
                                                             :activate_account,
                                                             :perform_account_activation,
@@ -640,17 +639,6 @@ class UsersController < ApplicationController
     render json: {
       success: false,
       message: I18n.t("login.something_already_taken")
-    }
-  end
-
-  def get_honeypot_value
-    secure_session.set(HONEYPOT_KEY, honeypot_value, expires: 1.hour)
-    secure_session.set(CHALLENGE_KEY, challenge_value, expires: 1.hour)
-
-    render json: {
-      value: honeypot_value,
-      challenge: challenge_value,
-      expires_in: SecureSession.expiry
     }
   end
 
@@ -1520,19 +1508,6 @@ class UsersController < ApplicationController
         @bookmark_reminders = Bookmark.where(user_id: user.id).where.not(reminder_at: nil).joins(:topic)
       end
     end
-  end
-
-  HONEYPOT_KEY ||= 'HONEYPOT_KEY'
-  CHALLENGE_KEY ||= 'CHALLENGE_KEY'
-
-  protected
-
-  def honeypot_value
-    secure_session[HONEYPOT_KEY] ||= SecureRandom.hex
-  end
-
-  def challenge_value
-    secure_session[CHALLENGE_KEY] ||= SecureRandom.hex
   end
 
   private

--- a/app/views/users/activate_account.html.erb
+++ b/app/views/users/activate_account.html.erb
@@ -13,7 +13,7 @@
   <%= preload_script "ember_jquery" %>
   <%= preload_script "vendor" %>
   <%= render_google_universal_analytics_code %>
-  <%= tag.meta id: 'data-activate-account', data: { path: path('/u/hp') } %>
+  <%= tag.meta id: 'data-activate-account', data: { path: path('/session/hp') } %>
 <%- end %>
 
 <%= preload_script "activate-account" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -358,6 +358,7 @@ Discourse::Application.routes.draw do
     get "session/sso_provider" => "session#sso_provider"
     get "session/current" => "session#current"
     get "session/csrf" => "session#csrf"
+    get "session/hp" => "session#get_honeypot_value"
     get "session/email-login/:token" => "session#email_login_info"
     post "session/email-login/:token" => "session#email_login"
     get "session/otp/:token" => "session#one_time_password", constraints: { token: /[0-9a-f]+/ }
@@ -406,7 +407,6 @@ Discourse::Application.routes.draw do
       put "#{root_path}/second_factors_backup" => "users#create_second_factor_backup"
 
       put "#{root_path}/update-activation-email" => "users#update_activation_email"
-      get "#{root_path}/hp" => "users#get_honeypot_value"
       post "#{root_path}/email-login" => "users#email_login"
       get "#{root_path}/admin-login" => "users#admin_login"
       put "#{root_path}/admin-login" => "users#admin_login"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -522,7 +522,7 @@ users:
   reserved_usernames:
     type: list
     list_type: compact
-    default: "admin|moderator|administrator|mod|sys|system|community|info|you|name|username|user|nickname|discourse|discourseorg|discourseforum|support|hp"
+    default: "admin|moderator|administrator|mod|sys|system|community|info|you|name|username|user|nickname|discourse|discourseorg|discourseforum|support"
   min_password_length:
     client: true
     default: 10

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -9,7 +9,7 @@ describe UsersController do
   describe "#full account registration flow" do
     it "will correctly handle honeypot and challenge" do
 
-      get '/u/hp.json'
+      get '/session/hp.json'
       expect(response.status).to eq(200)
 
       json = response.parsed_body
@@ -584,7 +584,7 @@ describe UsersController do
 
   describe '#create' do
     def honeypot_magic(params)
-      get '/u/hp.json'
+      get '/session/hp.json'
       json = response.parsed_body
       params[:password_confirmation] = json["value"]
       params[:challenge] = json["challenge"].reverse
@@ -1297,6 +1297,8 @@ describe UsersController do
       before do
         UsersController.any_instance.stubs(:honeypot_value).returns("abc")
         UsersController.any_instance.stubs(:challenge_value).returns("efg")
+        SessionController.any_instance.stubs(:honeypot_value).returns("abc")
+        SessionController.any_instance.stubs(:challenge_value).returns("efg")
       end
 
       let!(:staged) { Fabricate(:staged, email: "staged@account.com", active: true) }

--- a/spec/support/integration_helpers.rb
+++ b/spec/support/integration_helpers.rb
@@ -2,7 +2,7 @@
 
 module IntegrationHelpers
   def create_user
-    get "/u/hp.json"
+    get "/session/hp.json"
 
     expect(response.status).to eq(200)
 

--- a/test/javascripts/helpers/create-pretender.js
+++ b/test/javascripts/helpers/create-pretender.js
@@ -416,7 +416,7 @@ export function applyDefaultHandlers(pretender) {
   pretender.post("/u/action/send_activation_email", success);
   pretender.put("/u/update-activation-email", success);
 
-  pretender.get("/u/hp.json", function () {
+  pretender.get("/session/hp.json", function () {
     return response({
       value: "32faff1b1ef1ac3",
       challenge: "61a3de0ccf086fb9604b76e884d75801",

--- a/test/javascripts/unit/lib/url-test.js
+++ b/test/javascripts/unit/lib/url-test.js
@@ -59,14 +59,12 @@ QUnit.test("isInternal on subfolder install", (assert) => {
 QUnit.test("userPath", (assert) => {
   assert.equal(userPath(), "/u");
   assert.equal(userPath("eviltrout"), "/u/eviltrout");
-  assert.equal(userPath("hp.json"), "/u/hp.json");
 });
 
 QUnit.test("userPath with prefix", (assert) => {
   setPrefix("/forum");
   assert.equal(userPath(), "/forum/u");
   assert.equal(userPath("eviltrout"), "/forum/u/eviltrout");
-  assert.equal(userPath("hp.json"), "/forum/u/hp.json");
 });
 
 QUnit.test("routeTo with prefix", async (assert) => {


### PR DESCRIPTION
`hp` is a valid username and we should allow users to sign up with it.