### PR TITLE
FIX: Allow staff to use HTML in the category read only banner

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/category-read-only-banner.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/category-read-only-banner.hbs
@@ -1,7 +1,7 @@
 {{#if shouldShow}}
   <div class="row">
     <div class="alert alert-info category-read-only-banner">
-      {{category.read_only_banner}}
+      {{html-safe category.read_only_banner}}
     </div>
   </div>
 {{/if}}

--- a/test/javascripts/acceptance/category-banner-test.js
+++ b/test/javascripts/acceptance/category-banner-test.js
@@ -29,7 +29,7 @@ acceptance("Category Banners", {
         slug: "test-read-only-with-banner",
         permission: null,
         read_only_banner:
-          "You need to video yourself doing the secret handshake to post here",
+          "You need to video yourself <div class='inner'>doing</div> the secret handshake to post here",
       },
     ],
   },
@@ -55,6 +55,10 @@ QUnit.test("Displays category banners when set", async (assert) => {
   await click(".modal-footer>.btn-primary");
   assert.ok(!visible(".bootbox.modal"), "it closes the modal");
   assert.ok(visible(".category-read-only-banner"), "it shows a banner");
+  assert.ok(
+    find(".category-read-only-banner .inner").length === 1,
+    "it allows staff to embed html in the message"
+  );
 });
 
 acceptance("Anonymous Category Banners", {


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
