### PR TITLE
Embedded topics are now unlisted by default

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -939,7 +939,7 @@ posting:
   embed_any_origin: false
   embed_topics_list: false
   embed_set_canonical_url: false
-  embed_unlisted: false
+  embed_unlisted: true
   embed_truncate: true
   embed_support_markdown: false
   allowed_embed_selectors: ""

--- a/spec/models/topic_embed_spec.rb
+++ b/spec/models/topic_embed_spec.rb
@@ -41,7 +41,7 @@ describe TopicEmbed do
         expect(TopicEmbed.where(topic_id: post.topic_id)).to be_present
 
         expect(post.topic.category).to eq(embeddable_host.category)
-        expect(post.topic).to be_visible
+        expect(post.topic).not_to be_visible
       end
 
       it "Supports updating the post content" do
@@ -87,6 +87,13 @@ describe TopicEmbed do
         )
         pc.create
         expect(imported_post.topic.reload).to be_visible
+      end
+
+      it "won't be invisible if `embed_unlisted` is set to false" do
+        Jobs.run_immediately!
+        SiteSetting.embed_unlisted = false
+        imported_post = TopicEmbed.import(user, "http://eviltrout.com/abcd", title, "some random content")
+        expect(imported_post.topic).to be_visible
       end
     end
 


### PR DESCRIPTION
Previously this site setting `embed unlisted` defaulted to false and
empty topics would be generated for embed, but those topics tend to take
up a lot of room on the topic lists.

This new default creates invisible topics by default until they receive
their first reply.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
