### PR TITLE
FIX: Stripping lines from incoming email shouldn't fail for blank body

### DIFF
--- a/lib/email/receiver.rb
+++ b/lib/email/receiver.rb
@@ -395,7 +395,7 @@ module Email
         text, elided_text, text_format = markdown, elided_markdown, Receiver::formats[:markdown]
       end
 
-      if SiteSetting.strip_incoming_email_lines
+      if SiteSetting.strip_incoming_email_lines && text.present?
         in_code = nil
 
         text = text.lines.map! do |line|

--- a/spec/components/email/receiver_spec.rb
+++ b/spec/components/email/receiver_spec.rb
@@ -1565,7 +1565,7 @@ describe Email::Receiver do
       EOF
 
       receiver = Email::Receiver.new(email)
-      text, elided, format = receiver.select_body
+      text, _elided, _format = receiver.select_body
       expect(text).to be_blank
     end
   end

--- a/spec/components/email/receiver_spec.rb
+++ b/spec/components/email/receiver_spec.rb
@@ -1549,6 +1549,25 @@ describe Email::Receiver do
       expect(text).to eq(stripped_text)
     end
 
+    it "works with empty mail body" do
+      SiteSetting.strip_incoming_email_lines = true
+
+      email = <<~EOF
+        Date: Tue, 01 Jan 2019 00:00:00 +0300
+        Subject: An email with whitespaces
+        From: Foo <foo@discourse.org>
+        To: bar@discourse.org
+        Content-Type: text/plain; charset="UTF-8"
+
+        --
+        my signature
+
+      EOF
+
+      receiver = Email::Receiver.new(email)
+      text, elided, format = receiver.select_body
+      expect(text).to be_blank
+    end
   end
 
   describe "replying to digest" do


### PR DESCRIPTION
https://meta.discourse.org/t/cant-email-forward-notifications-from-a-different-discourse-server/142586/3