### PR TITLE
FEATURE: Create revision when bulk moving topics

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2244,6 +2244,8 @@ en:
     share_quote_buttons: "Determine which items appear in the quote sharing widget, and in what order."
     share_quote_visibility: "Determine when to show quote sharing buttons: never, to anonymous users only or all users. "
 
+    create_revision_on_bulk_topic_moves: "Create revision for first posts when topics are moved into a new category in bulk."
+
     errors:
       invalid_email: "Invalid email address."
       invalid_username: "There's no user with that username."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2164,6 +2164,9 @@ uncategorized:
     default: false
     hidden: true
 
+  create_revision_on_bulk_topic_moves:
+    default: true
+
 user_preferences:
   default_email_digest_frequency:
     enum: "DigestEmailSiteSetting"

--- a/lib/topics_bulk_action.rb
+++ b/lib/topics_bulk_action.rb
@@ -86,9 +86,26 @@ class TopicsBulkAction
   end
 
   def change_category
-    topics.each do |t|
-      if guardian.can_edit?(t)
-        @changed_ids << t.id if t.change_category_to_id(@operation[:category_id])
+    updatable_topics = topics.where.not(category_id: @operation[:category_id])
+
+    if SiteSetting.create_revision_on_bulk_topic_moves
+      opts = {
+        bypass_bump: true,
+        validate_post: false,
+        bypass_rate_limiter: true
+      }
+
+      updatable_topics.each do |t|
+        if guardian.can_edit?(t)
+          changes = { category_id: @operation[:category_id] }
+          @changed_ids << t.id if t.first_post.revise(@user, changes, opts)
+        end
+      end
+    else
+      updatable_topics.each do |t|
+        if guardian.can_edit?(t)
+          @changed_ids << t.id if t.change_category_to_id(@operation[:category_id])
+        end
       end
     end
   end

--- a/spec/components/topics_bulk_action_spec.rb
+++ b/spec/components/topics_bulk_action_spec.rb
@@ -59,14 +59,59 @@ describe TopicsBulkAction do
 
   describe "change_category" do
     fab!(:category) { Fabricate(:category) }
+    fab!(:fist_post) { Fabricate(:post, topic: topic) }
 
     context "when the user can edit the topic" do
-      it "changes the category and returns the topic_id" do
-        tba = TopicsBulkAction.new(topic.user, [topic.id], type: 'change_category', category_id: category.id)
-        topic_ids = tba.perform!
-        expect(topic_ids).to eq([topic.id])
-        topic.reload
-        expect(topic.category).to eq(category)
+      context "with 'create_revision_on_bulk_topic_moves' setting enabled" do
+        before do
+          SiteSetting.create_revision_on_bulk_topic_moves = true
+        end
+
+        it "changes the category, creates a post revision and returns the topic_id" do
+          old_category_id = topic.category_id
+          tba = TopicsBulkAction.new(topic.user, [topic.id], type: 'change_category', category_id: category.id)
+          topic_ids = tba.perform!
+          expect(topic_ids).to eq([topic.id])
+          topic.reload
+          expect(topic.category).to eq(category)
+
+          revision = topic.first_post.revisions.last
+          expect(revision).to be_present
+          expect(revision.modifications).to eq ({ "category_id" => [old_category_id, category.id] })
+        end
+
+        it "doesn't do anything when category stays the same" do
+          tba = TopicsBulkAction.new(topic.user, [topic.id], type: 'change_category', category_id: topic.category_id)
+          topic_ids = tba.perform!
+          expect(topic_ids).to be_empty
+
+          topic.reload
+          revision = topic.first_post.revisions.last
+          expect(revision).to be_nil
+        end
+      end
+
+      context "with 'create_revision_on_bulk_topic_moves' setting disabled" do
+        before do
+          SiteSetting.create_revision_on_bulk_topic_moves = false
+        end
+
+        it "changes the category, doesn't create a post revision and returns the topic_id" do
+          tba = TopicsBulkAction.new(topic.user, [topic.id], type: 'change_category', category_id: category.id)
+          topic_ids = tba.perform!
+          expect(topic_ids).to eq([topic.id])
+          topic.reload
+          expect(topic.category).to eq(category)
+
+          revision = topic.first_post.revisions.last
+          expect(revision).to be_nil
+        end
+
+        it "doesn't do anything when category stays the same" do
+          tba = TopicsBulkAction.new(topic.user, [topic.id], type: 'change_category', category_id: topic.category_id)
+          topic_ids = tba.perform!
+          expect(topic_ids).to be_empty
+        end
       end
     end
 


### PR DESCRIPTION
This behavior can be configured with the new "create_revision_on_bulk_topic_moves" site setting. It's enabled by default.