### PR TITLE
FIX: remove whitespaces around inline HTML tags next to text.

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/to-markdown.js
+++ b/app/assets/javascripts/discourse/app/lib/to-markdown.js
@@ -25,7 +25,16 @@ export class Tag {
     }
 
     if (this.inline) {
-      text = " " + text + " ";
+      const prev = this.element.prev;
+      const next = this.element.next;
+
+      if (prev && prev.name !== "#text") {
+        text = " " + text;
+      }
+
+      if (next && next.name !== "#text") {
+        text = text + " ";
+      }
     }
 
     return text;

--- a/test/javascripts/unit/lib/to-markdown-test.js
+++ b/test/javascripts/unit/lib/to-markdown-test.js
@@ -8,6 +8,7 @@ QUnit.test("converts styles between normal words", (assert) => {
   assert.equal(toMarkdown(html), markdown);
 
   assert.equal(toMarkdown("A <b>bold </b>word"), "A **bold** word");
+  assert.equal(toMarkdown("A <b>bold</b>, word"), "A **bold**, word");
 });
 
 QUnit.test("converts inline nested styles", (assert) => {
@@ -239,7 +240,7 @@ helloWorld();</code></pre>
     return;
 }
 helloWorld();</code>consectetur.`;
-  output = `Lorem ipsum dolor sit amet, \`var helloWorld = () => {\n  alert('    hello \t\t world    ');\n    return;\n}\nhelloWorld();\` consectetur.`;
+  output = `Lorem ipsum dolor sit amet, \`var helloWorld = () => {\n  alert('    hello \t\t world    ');\n    return;\n}\nhelloWorld();\`consectetur.`;
 
   assert.equal(toMarkdown(html), output);
 });


### PR DESCRIPTION
Previously, extra space added like in the below example

#### HTML
``` html
To <b>demonstrate</b>, here is a sentence.
```

#### Markdown
``` markdown
To **demonstrate** , here is a sentence.
```