### PR TITLE
Revert "FIX: Use topic title headline in search menu result."

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/search-menu-results.js
+++ b/app/assets/javascripts/discourse/app/widgets/search-menu-results.js
@@ -151,9 +151,7 @@ createSearchResult({
       h(
         "span.topic-title",
         { attributes: { "data-topic-id": topic.id } },
-        this.siteSettings.use_pg_headlines_for_excerpt
-          ? new RawHtml({ html: `<span>${result.topic_title_headline}</span>` })
-          : new Highlighted(topic.fancyTitle, term)
+        new Highlighted(topic.fancyTitle, term)
       ),
     ];
 


### PR DESCRIPTION
This reverts commit 4b8c15b857665463e082de3d94abb1528448ac1e.

This breaks topic title for topic similar search.