### PR TITLE
FIX: Disallow email invites if enable_local_logins is disabled

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/invite-panel.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/invite-panel.hbs
@@ -27,7 +27,7 @@
             hasGroups=hasGroups
             usernames=emailOrUsername
             placeholderKey=placeholderKey
-            allowEmails=true
+            allowEmails=canInviteViaEmail
             class="invite-user-input"
             autocomplete="discourse"
             value=emailOrUsername

--- a/test/javascripts/integration/components/invite-panel-test.js
+++ b/test/javascripts/integration/components/invite-panel-test.js
@@ -1,0 +1,22 @@
+import EmberObject, { set } from "@ember/object";
+import componentTest from "helpers/component-test";
+
+moduleForComponent("invite-panel", { integration: true });
+
+componentTest("can_invite_via_email", {
+  template: "{{invite-panel panel=panel}}",
+
+  beforeEach() {
+    set(this.currentUser, "details", { can_invite_via_email: true });
+    const inviteModel = JSON.parse(JSON.stringify(this.currentUser));
+    this.set("panel", {
+      id: "invite",
+      model: { inviteModel: EmberObject.create(inviteModel) },
+    });
+  },
+
+  async test(assert) {
+    await fillIn(".invite-user-input", "eviltrout@example.com");
+    assert.ok(find(".send-invite:disabled").length === 0);
+  },
+});


### PR DESCRIPTION
allowEmails used to always be set to true and did not use
can_invite_via_email, which checks for enable_local_logins.

It was a problem because on sites with local logins
disabled users were allowed to enter email addresses, but
received a generic error "error inviting that user".