### PR TITLE
Hide large refactor commit from blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -46,3 +46,6 @@ ce3fe2f4c4ddf166949ee3cec3d9ecbf9108ab52
 
 # REFACTOR: Move qunit tests to a different directory structure
 bc97c79a35d8acd283d4d8b79aa079bce9d127c6
+
+# REFACTOR: Move javascript tests inside discourse app
+23f24bfb510edb25b18b6a0d5485270c88df9b24


### PR DESCRIPTION
It's mostly about moving tests from one place to another and needn't
pollute the git history.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
