### PR TITLE
FIX: Deprecated overwriting of computed property

### DIFF
--- a/app/assets/javascripts/discourse/app/components/discourse-banner.js
+++ b/app/assets/javascripts/discourse/app/components/discourse-banner.js
@@ -2,6 +2,8 @@ import discourseComputed from "discourse-common/utils/decorators";
 import Component from "@ember/component";
 
 export default Component.extend({
+  hide: false,
+
   @discourseComputed("banner.html")
   content(bannerHtml) {
     const $div = $("<div>");
@@ -30,7 +32,7 @@ export default Component.extend({
       if (this.user) {
         this.user.dismissBanner(this.get("banner.key"));
       } else {
-        this.set("visible", false);
+        this.set("hide", true);
         this.keyValueStore.set({
           key: "dismissed_banner_key",
           value: this.get("banner.key"),


### PR DESCRIPTION
We can set `hide` to true instead of overwriting the property on
dismiss.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
