### PR TITLE
FIX: Always let moderators to see their group PMs

### DIFF
--- a/lib/guardian/group_guardian.rb
+++ b/lib/guardian/group_guardian.rb
@@ -35,6 +35,7 @@ module GroupGuardian
 
   def can_see_group_messages?(group)
     return true if is_admin?
+    return true if is_moderator? && group.id == Group::AUTO_GROUPS[:moderators]
 
     SiteSetting.enable_personal_messages? && group.users.include?(user)
   end

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -197,6 +197,17 @@ RSpec.describe ListController do
           .to eq(topic.id)
       end
 
+      it 'should display moderator group private messages for a moderator' do
+        moderator = Fabricate(:moderator)
+        group = Group.find(Group::AUTO_GROUPS[:moderators])
+        topic = Fabricate(:private_message_topic, allowed_groups: [group])
+
+        sign_in(moderator)
+
+        get "/topics/private-messages-group/#{moderator.username}/#{group.name}.json"
+        expect(response.status).to eq(200)
+      end
+
       it "should not display group private messages for a moderator's group" do
         moderator = Fabricate(:moderator)
         sign_in(moderator)


### PR DESCRIPTION
When enable_personal_messages was disabled, moderators could not see
the private messages for the "moderators" group. The link was displayed
on the client side, but the checks on the server side did not allow it.
