### PR TITLE
FIX: Preload uploads in groups#search to prevent N+1

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -537,6 +537,7 @@ class GroupsController < ApplicationController
   def search
     groups = Group.visible_groups(current_user)
       .where("groups.id <> ?", Group::AUTO_GROUPS[:everyone])
+      .includes(:flair_upload)
       .order(:name)
 
     if (term = params[:term]).present?


### PR DESCRIPTION
`BasicGroupSerializer` includes `flair_url` which uses `flair_upload` relation, so the N in N+1 in this case was the number of groups with flair in the forum.