### PR TITLE
FIX: Validate category name on parent change

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -49,7 +49,7 @@ class Category < ActiveRecord::Base
 
   validates :user_id, presence: true
 
-  validates :name, if: Proc.new { |c| c.new_record? || c.will_save_change_to_name? },
+  validates :name, if: Proc.new { |c| c.new_record? || c.will_save_change_to_name? || c.will_save_change_to_parent_category_id? },
                    presence: true,
                    uniqueness: { scope: :parent_category_id, case_sensitive: false },
                    length: { in: 1..50 }

--- a/spec/requests/categories_controller_spec.rb
+++ b/spec/requests/categories_controller_spec.rb
@@ -314,6 +314,17 @@ describe CategoriesController do
         expect(response.status).to eq(422)
       end
 
+      it "returns errors when there is a name conflict while moving a category into another" do
+        parent_category = Fabricate(:category, name: "Parent", user: admin)
+        other_category = Fabricate(:category, name: category.name, user: admin, parent_category: parent_category, slug: "a-different-slug")
+
+        put "/categories/#{category.id}.json", params: {
+          parent_category_id: parent_category.id,
+        }
+
+        expect(response.status).to eq(422)
+      end
+
       it "returns 422 if email_in address is already in use for other category" do
         _other_category = Fabricate(:category, name: "Other", email_in: "mail@examle.com")
 


### PR DESCRIPTION
Previously, moving a category into another one, that already had a child category of that name (but with a non-conflicting slug) would cause a 500 error:

```
# PG::UniqueViolation:
#   ERROR:  duplicate key value violates unique constraint "unique_index_categories_on_name"
#   DETAIL:  Key (COALESCE(parent_category_id, '-1'::integer), name)=(5662, Amazing Category 0) already exists.
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
