### PR TITLE
FIX: makes dashboard periods use current day and weekly 7 days

### DIFF
--- a/app/assets/javascripts/admin/addon/mixins/period-computation.js
+++ b/app/assets/javascripts/admin/addon/mixins/period-computation.js
@@ -14,7 +14,7 @@ export default Mixin.create({
 
   @discourseComputed("period")
   startDate(period) {
-    let fullDay = moment().locale("en").utc().subtract(1, "day");
+    let fullDay = moment().locale("en").utc().endOf("day");
 
     switch (period) {
       case "yearly":
@@ -24,7 +24,7 @@ export default Mixin.create({
         return fullDay.subtract(3, "month").startOf("day");
         break;
       case "weekly":
-        return fullDay.subtract(1, "week").startOf("day");
+        return fullDay.subtract(6, "days").startOf("day");
         break;
       case "monthly":
         return fullDay.subtract(1, "month").startOf("day");
@@ -46,7 +46,7 @@ export default Mixin.create({
 
   @discourseComputed()
   endDate() {
-    return moment().locale("en").utc().subtract(1, "day").endOf("day");
+    return moment().locale("en").utc().endOf("day");
   },
 
   @discourseComputed()

--- a/app/assets/javascripts/admin/addon/templates/dashboard_general.hbs
+++ b/app/assets/javascripts/admin/addon/templates/dashboard_general.hbs
@@ -10,7 +10,11 @@
               {{i18n "admin.dashboard.community_health"}}
             </a>
           </h2>
-          {{period-chooser period=period action=(action "changePeriod") content=availablePeriods fullDay=true}}
+          {{period-chooser
+            period=period
+            action=(action "changePeriod")
+            content=availablePeriods
+            fullDay=false}}
         </div>
 
         <div class="section-body">

--- a/app/assets/javascripts/admin/addon/templates/dashboard_moderation.hbs
+++ b/app/assets/javascripts/admin/addon/templates/dashboard_moderation.hbs
@@ -13,7 +13,7 @@
           period=period
           action=(action "changePeriod")
           content=availablePeriods
-          fullDay=true}}
+          fullDay=false}}
       </div>
 
       <div class="section-body">

--- a/app/assets/javascripts/discourse/app/helpers/period-title.js
+++ b/app/assets/javascripts/discourse/app/helpers/period-title.js
@@ -12,7 +12,7 @@ const TITLE_SUBS = {
 export default htmlHelper((period, options) => {
   const title = I18n.t("filters.top." + (TITLE_SUBS[period] || "this_week"));
   if (options.hash.showDateRange) {
-    var dateString = "";
+    let dateString = "";
     let finish;
 
     if (options.hash.fullDay) {
@@ -41,11 +41,15 @@ export default htmlHelper((period, options) => {
           finish.format(I18n.t("dates.long_no_year_no_time"));
         break;
       case "weekly":
+        let start;
+        if (options.hash.fullDay) {
+          start = finish.clone().subtract(1, "week");
+        } else {
+          start = finish.clone().subtract(6, "days");
+        }
+
         dateString =
-          finish
-            .clone()
-            .subtract(1, "week")
-            .format(I18n.t("dates.long_no_year_no_time")) +
+          start.format(I18n.t("dates.long_no_year_no_time")) +
           " - " +
           finish.format(I18n.t("dates.long_no_year_no_time"));
         break;


### PR DESCRIPTION
Prior to this fix, weekly could be 8 days and we could have differences between period chooser text and actual results in the chart.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
