### PR TITLE
REFACTOR: Removes `Discourse.SiteSettings` constant from tests

### DIFF
--- a/app/assets/javascripts/discourse/tests/helpers/site-settings.js
+++ b/app/assets/javascripts/discourse/tests/helpers/site-settings.js
@@ -101,7 +101,6 @@ const ORIGINAL_SETTINGS = {
 };
 
 let siteSettings = Object.assign({}, ORIGINAL_SETTINGS);
-Discourse.SiteSettings = siteSettings;
 
 export function currentSettings() {
   return siteSettings;

--- a/app/assets/javascripts/discourse/tests/test_helper.js
+++ b/app/assets/javascripts/discourse/tests/test_helper.js
@@ -45,8 +45,10 @@
 //= require jquery.magnific-popup.min.js
 
 let App = window.Discourse;
-let resetSettings = require("discourse/tests/helpers/site-settings")
-  .resetSettings;
+let {
+  resetSettings,
+  currentSettings,
+} = require("discourse/tests/helpers/site-settings");
 let createHelperContext = require("discourse-common/lib/helpers")
   .createHelperContext;
 
@@ -78,6 +80,7 @@ d.write(
 App.rootElement = "#ember-testing";
 App.setupForTesting();
 App.injectTestHelpers();
+App.SiteSettings = currentSettings();
 App.start();
 
 // disable logster error reporting


### PR DESCRIPTION
This does not work in the Ember CLI world.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
