### PR TITLE
REFACTOR: Support importing of `Pretender`

### DIFF
--- a/app/assets/javascripts/discourse-loader.js
+++ b/app/assets/javascripts/discourse-loader.js
@@ -150,6 +150,9 @@ var define, requirejs;
         // eslint-disable-next-line
         default: I18n,
       },
+      pretender: {
+        default: window.Pretender,
+      },
     };
   }
 

--- a/app/assets/javascripts/discourse/tests/helpers/create-pretender.js
+++ b/app/assets/javascripts/discourse/tests/helpers/create-pretender.js
@@ -1,4 +1,5 @@
 import User from "discourse/models/user";
+import Pretender from "pretender";
 
 export function parsePostData(query) {
   const result = {};

--- a/app/assets/javascripts/wizard/test/test_helper.js
+++ b/app/assets/javascripts/wizard/test/test_helper.js
@@ -6,6 +6,9 @@
 //= require ember.debug
 //= require locales/i18n
 //= require locales/en_US
+//= require route-recognizer/dist/route-recognizer
+//= require fake_xml_http_request
+//= require pretender/pretender
 //= require discourse-loader
 //= require jquery.debug
 //= require handlebars
@@ -19,9 +22,6 @@
 //= require_tree ./acceptance
 //= require_tree ./models
 //= require_tree ./components
-//= require fake_xml_http_request
-//= require route-recognizer/dist/route-recognizer
-//= require pretender/pretender
 //= require ./wizard-pretender
 
 // Trick JSHint into allow document.write

--- a/app/assets/javascripts/wizard/test/wizard-pretender.js
+++ b/app/assets/javascripts/wizard/test/wizard-pretender.js
@@ -1,3 +1,5 @@
+import Pretender from "pretender";
+
 // TODO: This file has some copied and pasted functions from `create-pretender` - would be good
 // to centralize that code at some point.
 


### PR DESCRIPTION
We shouldn't be using global variables for libraries.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
