### PR TITLE
FIX: Escaped `mailto` URLs would raise an exception

### DIFF
--- a/lib/url_helper.rb
+++ b/lib/url_helper.rb
@@ -70,7 +70,7 @@ class UrlHelper
   def self.rails_route_from_url(url)
     path = URI.parse(encode(url)).path
     Rails.application.routes.recognize_path(path)
-  rescue Addressable::URI::InvalidURIError
+  rescue Addressable::URI::InvalidURIError, URI::InvalidComponentError
     nil
   end
 

--- a/spec/components/url_helper_spec.rb
+++ b/spec/components/url_helper_spec.rb
@@ -205,5 +205,10 @@ describe UrlHelper do
       url = "http://URL:%20https://google.com"
       expect(described_class.rails_route_from_url(url)).to eq(nil)
     end
+
+    it "does not raise for invalid mailtos" do
+      url = "mailto:eviltrout%2540example.com"
+      expect(described_class.rails_route_from_url(url)).to eq(nil)
+    end
   end
 end


### PR DESCRIPTION
This prevents exceptions from being raised if a URL has an invalid
component.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
