### PR TITLE
FIX: Find noscript element with crawler content

### DIFF
--- a/vendor/assets/javascripts/browser-update.js.erb
+++ b/vendor/assets/javascripts/browser-update.js.erb
@@ -21,10 +21,14 @@ var $buo = function() {
   document.getElementsByTagName('body')[0].classList.add("crawler");
   var mainElement = document.getElementById("main");
   var noscriptElements = document.getElementsByTagName("noscript");
-  // noscriptElements[0].innerHTML contains encoded HTML
-  var innerHTML = noscriptElements[0].childNodes[0].nodeValue;
-  mainElement.innerHTML = innerHTML;
-
+  // find the element with the "data-path" attribute set
+  for (var i = 0; i < noscriptElements.length; ++i) {
+    if (noscriptElements[i].dataset["path"]) {
+      // noscriptElements[i].innerHTML contains encoded HTML
+      mainElement.innerHTML = noscriptElements[i].childNodes[0].nodeValue;
+      break;
+    }
+  }
   // retrieve localized browser upgrade text
   var t = <%= "'" + I18n.t('js.browser_update') + "'" %>;
 


### PR DESCRIPTION
There can be more than one noscript element on a page (from various
plugins), but only the one with data-path attribute as set in
application.html.erb contains the crawler content.

Writing a test for this change is difficult as the testing infrastructure
must be built around an unsupported browser (or be mocked) and we
do not have that ability in our tests.