### PR TITLE
DEV: Do not render header in wizard preview when logo is missing

### DIFF
--- a/app/assets/javascripts/wizard/components/font-preview.js
+++ b/app/assets/javascripts/wizard/components/font-preview.js
@@ -34,7 +34,9 @@ export default createPreviewComponent(659, 320, {
   paint({ ctx, colors, font, headingFont, width, height }) {
     const headerHeight = height * 0.3;
 
-    this.drawFullHeader(colors, headingFont, this.logo);
+    if (this.logo) {
+      this.drawFullHeader(colors, headingFont, this.logo);
+    }
 
     const margin = width * 0.04;
     const avatarSize = height * 0.2;


### PR DESCRIPTION
This can happen if a plugin skips the logo step of the wizard.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
