### PR TITLE
More granular User API Key scopes, and plugin support

### DIFF
--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -62,10 +62,10 @@ class ApiKey < ActiveRecord::Base
     Digest::SHA256.hexdigest key
   end
 
-  def request_allowed?(request, route_param)
-    return false if allowed_ips.present? && allowed_ips.none? { |ip| ip.include?(request.ip) }
+  def request_allowed?(env)
+    return false if allowed_ips.present? && allowed_ips.none? { |ip| ip.include?(Rack::Request.new(env).ip) }
 
-    api_key_scopes.blank? || api_key_scopes.any? { |s| s.permits?(route_param) }
+    api_key_scopes.blank? || api_key_scopes.any? { |s| s.permits?(env) }
   end
 end
 

--- a/app/models/api_key_scope.rb
+++ b/app/models/api_key_scope.rb
@@ -77,38 +77,14 @@ class ApiKeyScope < ActiveRecord::Base
     end
   end
 
-  def permits?(route_param)
-    path_params = "#{route_param['controller']}##{route_param['action']}"
-
-    mapping[:actions].include?(path_params) && (allowed_parameters.blank? || params_allowed?(route_param))
+  def permits?(env)
+    RouteMatcher.new(**mapping.except(:urls), allowed_param_values: allowed_parameters).match?(env: env)
   end
 
   private
 
-  def params_allowed?(route_param)
-    mapping[:params].all? do |param|
-      param_alias = mapping.dig(:aliases, param)
-      allowed_values = [allowed_parameters[param.to_s]].flatten
-      value = route_param[param.to_s]
-      alias_value = route_param[param_alias.to_s]
-
-      return false if value.present? && alias_value.present?
-
-      value = value || alias_value
-      value = extract_category_id(value) if param_alias == :category_slug_path_with_id
-
-      allowed_values.blank? || allowed_values.include?(value)
-    end
-  end
-
   def mapping
     @mapping ||= self.class.scope_mappings.dig(resource.to_sym, action.to_sym)
-  end
-
-  def extract_category_id(category_slug_with_id)
-    parts = category_slug_with_id.split('/')
-
-    !parts.empty? && parts.last =~ /\A\d+\Z/ ? parts.pop : nil
   end
 end
 

--- a/app/models/user_api_key_scope.rb
+++ b/app/models/user_api_key_scope.rb
@@ -17,7 +17,11 @@ class UserApiKeyScope < ActiveRecord::Base
   }
 
   def self.all_scopes
-    SCOPES
+    scopes = SCOPES
+    DiscoursePluginRegistry.user_api_key_scope_mappings.each do |mapping|
+      scopes = scopes.merge!(mapping)
+    end
+    scopes
   end
 
   def permits?(env)

--- a/app/models/user_api_key_scope.rb
+++ b/app/models/user_api_key_scope.rb
@@ -1,6 +1,34 @@
 # frozen_string_literal: true
 
 class UserApiKeyScope < ActiveRecord::Base
+  SCOPES = {
+    read: [ RouteMatcher.new(methods: :get) ],
+    write: [ RouteMatcher.new(methods: [:get, :post, :patch, :put, :delete]) ],
+    message_bus: [ RouteMatcher.new(methods: :post, actions: 'message_bus') ],
+    push: [],
+    one_time_password: [],
+    notifications: [
+      RouteMatcher.new(methods: :post, actions: 'message_bus'),
+      RouteMatcher.new(methods: :get, actions: 'notifications#index'),
+      RouteMatcher.new(methods: :put, actions: 'notifications#mark_read')
+    ],
+    session_info: [ RouteMatcher.new(methods: :get, actions: 'session#current') ]
+  }
+
+  def self.all_scopes
+    SCOPES
+  end
+
+  def permits?(env)
+    matchers.any? { |m| m.match?(env: env) }
+  end
+
+  private
+
+  def matchers
+    @matchers ||= Array(self.class.all_scopes[name.to_sym])
+  end
+
 end
 
 # == Schema Information

--- a/app/models/user_api_key_scope.rb
+++ b/app/models/user_api_key_scope.rb
@@ -12,7 +12,8 @@ class UserApiKeyScope < ActiveRecord::Base
       RouteMatcher.new(methods: :get, actions: 'notifications#index'),
       RouteMatcher.new(methods: :put, actions: 'notifications#mark_read')
     ],
-    session_info: [ RouteMatcher.new(methods: :get, actions: 'session#current') ]
+    session_info: [ RouteMatcher.new(methods: :get, actions: 'session#current') ],
+    bookmarks_calendar: [ RouteMatcher.new(methods: :get, actions: 'users#bookmarks', formats: :ics, params: %i[username]) ]
   }
 
   def self.all_scopes
@@ -20,7 +21,7 @@ class UserApiKeyScope < ActiveRecord::Base
   end
 
   def permits?(env)
-    matchers.any? { |m| m.match?(env: env) }
+    matchers.any? { |m| m.with_allowed_param_values(allowed_parameters).match?(env: env) }
   end
 
   private
@@ -35,11 +36,12 @@ end
 #
 # Table name: user_api_key_scopes
 #
-#  id              :bigint           not null, primary key
-#  user_api_key_id :integer          not null
-#  name            :string           not null
-#  created_at      :datetime         not null
-#  updated_at      :datetime         not null
+#  id                 :bigint           not null, primary key
+#  user_api_key_id    :integer          not null
+#  name               :string           not null
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  allowed_parameters :jsonb
 #
 # Indexes
 #

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1055,6 +1055,7 @@ en:
       read: "Read all"
       write: "Write all"
       one_time_password: "Create a one-time login token"
+      bookmarks_calendar: "Read bookmark reminders"
     invalid_public_key: "Sorry, the public key is invalid."
     invalid_auth_redirect: "Sorry, this auth_redirect host is not allowed."
     invalid_token: "Missing, invalid or expired token."

--- a/db/migrate/20201008105539_add_allowed_parameters_to_user_api_key_scope.rb
+++ b/db/migrate/20201008105539_add_allowed_parameters_to_user_api_key_scope.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddAllowedParametersToUserApiKeyScope < ActiveRecord::Migration[6.0]
+  def change
+    add_column :user_api_key_scopes, :allowed_parameters, :jsonb
+  end
+end

--- a/lib/auth/default_current_user_provider.rb
+++ b/lib/auth/default_current_user_provider.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require_relative '../route_matcher'
 
 class Auth::DefaultCurrentUserProvider
 
@@ -20,9 +21,9 @@ class Auth::DefaultCurrentUserProvider
   BAD_TOKEN ||= "_DISCOURSE_BAD_TOKEN"
 
   PARAMETER_API_PATTERNS ||= [
-    {
-      method: :get,
-      route: [
+    RouteMatcher.new(
+      methods: :get,
+      actions: [
         "posts#latest",
         "posts#user_posts_feed",
         "groups#posts_feed",
@@ -37,18 +38,18 @@ class Auth::DefaultCurrentUserProvider
         *[:all, :yearly, :quarterly, :monthly, :weekly, :daily].map { |p| "list#top_#{p}_feed" },
         *[:latest, :unread, :new, :read, :posted, :bookmarks].map { |f| "tags#show_#{f}" }
       ],
-      format: :rss
-    },
-    {
-      method: :get,
-      route: "users#bookmarks",
-      format: :ics
-    },
-    {
-      method: :post,
-      route: "admin/email#handle_mail",
-      format: "*"
-    }
+      formats: :rss
+    ),
+    RouteMatcher.new(
+      methods: :get,
+      actions: "users#bookmarks",
+      formats: :ics
+    ),
+    RouteMatcher.new(
+      methods: :post,
+      actions: "admin/email#handle_mail",
+      formats: nil
+    )
   ]
 
   # do all current user initialization here
@@ -335,8 +336,7 @@ class Auth::DefaultCurrentUserProvider
     if api_key = ApiKey.active.with_key(api_key_value).includes(:user).first
       api_username = header_api_key? ? @env[HEADER_API_USERNAME] : request[API_USERNAME]
 
-      params = @env['action_dispatch.request.parameters']
-      unless api_key.request_allowed?(request, params)
+      unless api_key.request_allowed?(@env)
         Rails.logger.warn("[Unauthorized API Access] username: #{api_username}, IP address: #{request.ip}")
         return nil
       end
@@ -370,17 +370,7 @@ class Auth::DefaultCurrentUserProvider
   # However, in some scenarios it is essential to send them via url parameters
   # so we need to add some exceptions
   def api_parameter_allowed?
-    request_method = @env["REQUEST_METHOD"]&.downcase&.to_sym
-    request_format = @env['action_dispatch.request.formats']&.first&.symbol
-
-    path_params = @env['action_dispatch.request.path_parameters']
-    request_route = "#{path_params[:controller]}##{path_params[:action]}" if path_params
-
-    parameter_api_patterns.any? do |p|
-      (p[:method] == "*" || Array(p[:method]).include?(request_method)) &&
-      (p[:format] == "*" || Array(p[:format]).include?(request_format)) &&
-      (p[:route] == "*" || Array(p[:route]).include?(request_route))
-    end
+    parameter_api_patterns.any? { |p| p.match?(env: @env) }
   end
 
   def header_api_key?

--- a/lib/discourse_plugin_registry.rb
+++ b/lib/discourse_plugin_registry.rb
@@ -81,6 +81,7 @@ class DiscoursePluginRegistry
 
   define_filtered_register :api_parameter_routes
   define_filtered_register :api_key_scope_mappings
+  define_filtered_register :user_api_key_scope_mappings
 
   define_filtered_register :permitted_bulk_action_parameters
 

--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -793,6 +793,35 @@ class Plugin::Instance
     DiscoursePluginRegistry.register_api_key_scope_mapping({ resource => action }, self)
   end
 
+  # Register a new UserApiKey scope, and its allowed routes. Scope will be prefixed
+  # with the (parametetized) plugin name followed by a colon.
+  #
+  # For example, if discourse-awesome-plugin registered this:
+  #
+  # add_user_api_key_scope(:read_my_route,
+  #   methods: :get,
+  #   actions: "mycontroller#myaction",
+  #   formats: :ics,
+  #   parameters: :testparam
+  # )
+  #
+  # The scope registered would be `discourse-awesome-plugin:read_my_route`
+  #
+  # Multiple matchers can be attached by supplying an array of parameter hashes
+  #
+  # See UserApiKeyScope::SCOPES for more examples
+  # And lib/route_matcher.rb for the route matching logic
+  def add_user_api_key_scope(scope_name, matcher_parameters)
+    raise ArgumentError.new("scope_name must be a symbol") if !scope_name.is_a?(Symbol)
+    matcher_parameters = [matcher_parameters] if !matcher_parameters.is_a?(Array)
+
+    prefixed_scope_name = :"#{(name || directory_name).parameterize}:#{scope_name}"
+    DiscoursePluginRegistry.register_user_api_key_scope_mapping(
+      {
+        prefixed_scope_name => matcher_parameters&.map { |m| RouteMatcher.new(**m) }
+      }, self)
+  end
+
   # Register a route which can be authenticated using an api key or user api key
   # in a query parameter rather than a header. For example:
   #

--- a/lib/route_matcher.rb
+++ b/lib/route_matcher.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+class RouteMatcher
+  attr_reader :actions, :params, :methods, :aliases, :formats, :allowed_param_values
+
+  def initialize(actions: nil, params: nil, methods: nil, formats: nil, aliases: nil, allowed_param_values: nil)
+    @actions = Array(actions) if actions
+    @params = Array(params) if params
+    @methods = Array(methods) if methods
+    @formats = Array(formats) if formats
+    @aliases = aliases
+    @allowed_param_values = allowed_param_values
+  end
+
+  # Return an identical route matcher, with the allowed_param_values replaced
+  def with_allowed_param_values(new_allowed_param_values)
+    RouteMatcher.new(
+      actions: actions,
+      params: params,
+      methods: methods,
+      formats: formats,
+      aliases: aliases,
+      allowed_param_values: new_allowed_param_values
+    )
+  end
+
+  def match?(env:)
+    request = ActionDispatch::Request.new(env)
+
+    action_allowed?(request) &&
+      params_allowed?(request) &&
+      method_allowed?(request) &&
+      format_allowed?(request)
+  end
+
+  private
+
+  def action_allowed?(request)
+    return true if actions.nil? # actions are unrestricted
+    path_params = request.path_parameters
+
+    # message_bus is not a rails route, special handling
+    return true if actions.include?("message_bus") && request.fullpath =~ /^\/message-bus\/.*\/poll/
+
+    actions.include? "#{path_params[:controller]}##{path_params[:action]}"
+  end
+
+  def params_allowed?(request)
+    return true if params.nil? || allowed_param_values.blank? # params are unrestricted
+
+    requested_params = request.parameters
+
+    params.all? do |param|
+      param_alias = aliases&.[](param)
+      allowed_values = [allowed_param_values[param.to_s]].flatten
+
+      value = requested_params[param.to_s]
+      alias_value = requested_params[param_alias.to_s]
+
+      return false if value.present? && alias_value.present?
+
+      value = value || alias_value
+      value = extract_category_id(value) if param_alias == :category_slug_path_with_id
+
+      allowed_values.blank? || allowed_values.include?(value)
+    end
+  end
+
+  def extract_category_id(category_slug_with_id)
+    parts = category_slug_with_id.split('/')
+    !parts.empty? && parts.last =~ /\A\d+\Z/ ? parts.pop : nil
+  end
+
+  def method_allowed?(request)
+    return true if methods.nil?
+    request_method = request.request_method&.downcase&.to_sym
+    methods.include?(request_method)
+  end
+
+  def format_allowed?(request)
+    return true if formats.nil?
+    request_format = request.formats&.first&.symbol
+    formats.include?(request_format)
+  end
+end

--- a/spec/fabricators/user_api_key_fabricator.rb
+++ b/spec/fabricators/user_api_key_fabricator.rb
@@ -8,3 +8,10 @@ Fabricator(:readonly_user_api_key, from: :user_api_key) do
   client_id { SecureRandom.hex }
   application_name 'some app'
 end
+
+Fabricator(:bookmarks_calendar_user_api_key, from: :user_api_key) do
+  user
+  scopes { [Fabricate.build(:user_api_key_scope, name: 'bookmarks_calendar')] }
+  client_id { SecureRandom.hex }
+  application_name 'some app'
+end

--- a/spec/fabricators/user_api_key_fabricator.rb
+++ b/spec/fabricators/user_api_key_fabricator.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
-Fabricator(:user_api_key_scope)
-
-Fabricator(:readonly_user_api_key, from: :user_api_key) do
+Fabricator(:user_api_key) do
   user
-  scopes { [Fabricate.build(:user_api_key_scope, name: 'read')] }
   client_id { SecureRandom.hex }
   application_name 'some app'
 end
 
+Fabricator(:user_api_key_scope)
+
+Fabricator(:readonly_user_api_key, from: :user_api_key) do
+  scopes { [Fabricate.build(:user_api_key_scope, name: 'read')] }
+end
+
 Fabricator(:bookmarks_calendar_user_api_key, from: :user_api_key) do
-  user
   scopes { [Fabricate.build(:user_api_key_scope, name: 'bookmarks_calendar')] }
-  client_id { SecureRandom.hex }
-  application_name 'some app'
 end

--- a/spec/integration/api_keys_spec.rb
+++ b/spec/integration/api_keys_spec.rb
@@ -128,4 +128,24 @@ describe 'user api keys' do
     expect(response.status).to eq(200) # Can access own calendar
   end
 
+  context "with a plugin registered user api key scope" do
+    let(:user_api_key) { Fabricate(:user_api_key) }
+
+    before do
+      metadata = Plugin::Metadata.new
+      metadata.name = "My Amazing Plugin"
+      plugin = Plugin::Instance.new metadata
+      plugin.add_user_api_key_scope :my_magic_scope, methods: :get, actions: "session#current"
+      user_api_key.scopes = [UserApiKeyScope.new(name: "my-amazing-plugin:my_magic_scope")]
+      user_api_key.save!
+    end
+
+    it 'allows parameter access to the registered route' do
+      get '/session/current.json', headers: {
+        HTTP_USER_API_KEY: user_api_key.key
+      }
+      expect(response.status).to eq(200)
+    end
+  end
+
 end

--- a/spec/models/user_api_key_spec.rb
+++ b/spec/models/user_api_key_spec.rb
@@ -4,37 +4,40 @@ require 'rails_helper'
 
 describe UserApiKey do
   context "#allow?" do
+    def request_env(method, path, **path_parameters)
+      ActionDispatch::TestRequest.create.tap do |request|
+        request.request_method = method
+        request.path = path
+        request.path_parameters = path_parameters
+      end.env
+    end
+
     it "can look up permissions correctly" do
       key = UserApiKey.new(scopes: ['message_bus', 'notifications'].map { |name| UserApiKeyScope.new(name: name) })
 
-      expect(key.allow?("PATH_INFO" => "/random", "REQUEST_METHOD" => "GET")).to eq(false)
-      expect(key.allow?("PATH_INFO" => "/message-bus/1234/poll", "REQUEST_METHOD" => "POST")).to eq(true)
+      expect(key.allow?(request_env("GET", "/random"))).to eq(false)
+      expect(key.allow?(request_env("POST", "/message-bus/1234/poll"))).to eq(true)
 
-      expect(key.allow?("action_dispatch.request.path_parameters" => { controller: "notifications", action: "mark_read" },
-                        "PATH_INFO" => "/xyz", "REQUEST_METHOD" => "PUT")).to eq(true)
+      expect(key.allow?(request_env("PUT", "/xyz", controller: "notifications", action: "mark_read"))).to eq(true)
 
-      expect(key.allow?("action_dispatch.request.path_parameters" => { controller: "user_api_keys", action: "revoke" },
-                        "PATH_INFO" => "/xyz", "REQUEST_METHOD" => "POST")).to eq(true)
-
+      expect(key.allow?(request_env("POST", "/xyz", controller: "user_api_keys", action: "revoke"))).to eq(true)
     end
 
     it "can allow all correct scopes to write" do
-
       key = UserApiKey.new(scopes: ["write"].map { |name| UserApiKeyScope.new(name: name) })
 
-      expect(key.allow?("PATH_INFO" => "/random", "REQUEST_METHOD" => "GET")).to eq(true)
-      expect(key.allow?("PATH_INFO" => "/random", "REQUEST_METHOD" => "PUT")).to eq(true)
-      expect(key.allow?("PATH_INFO" => "/random", "REQUEST_METHOD" => "PATCH")).to eq(true)
-      expect(key.allow?("PATH_INFO" => "/random", "REQUEST_METHOD" => "DELETE")).to eq(true)
-      expect(key.allow?("PATH_INFO" => "/random", "REQUEST_METHOD" => "POST")).to eq(true)
+      expect(key.allow?(request_env("GET", "/random"))).to eq(true)
+      expect(key.allow?(request_env("PUT", "/random"))).to eq(true)
+      expect(key.allow?(request_env("PATCH", "/random"))).to eq(true)
+      expect(key.allow?(request_env("DELETE", "/random"))).to eq(true)
+      expect(key.allow?(request_env("POST", "/random"))).to eq(true)
     end
 
     it "can allow blanket read" do
-
       key = UserApiKey.new(scopes: ["read"].map { |name| UserApiKeyScope.new(name: name) })
 
-      expect(key.allow?("PATH_INFO" => "/random", "REQUEST_METHOD" => "GET")).to eq(true)
-      expect(key.allow?("PATH_INFO" => "/random", "REQUEST_METHOD" => "PUT")).to eq(false)
+      expect(key.allow?(request_env("GET", "/random"))).to eq(true)
+      expect(key.allow?(request_env("PUT", "/random"))).to eq(false)
     end
   end
 end


### PR DESCRIPTION
This PR includes three commits, which I intend to "rebase and merge", so that they remain separate. Please check each commit message for details. 

The overall aim here is to allow core/plugins to create a user api key, scoped to a specific route with specific parameters.