### PR TITLE
REFACTOR: Import `QUnit` and related helpers rather than globals

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,5 +2,11 @@
   "extends": "eslint-config-discourse",
   "rules": {
     "discourse-ember/global-ember": 2
+  },
+  "globals": {
+    "moduleFor": "off",
+    "moduleForComponent": "off",
+    "testStart": "off",
+    "testDone": "off"
   }
 }

--- a/app/assets/javascripts/admin/tests/admin/integration/components/group-list-setting-test.js
+++ b/app/assets/javascripts/admin/tests/admin/integration/components/group-list-setting-test.js
@@ -1,3 +1,4 @@
+import { moduleForComponent } from "ember-qunit";
 import EmberObject from "@ember/object";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import componentTest from "discourse/tests/helpers/component-test";

--- a/app/assets/javascripts/admin/tests/admin/integration/components/themes-list-item-test.js
+++ b/app/assets/javascripts/admin/tests/admin/integration/components/themes-list-item-test.js
@@ -1,3 +1,4 @@
+import { moduleForComponent } from "ember-qunit";
 import I18n from "I18n";
 import componentTest from "discourse/tests/helpers/component-test";
 import Theme from "admin/models/theme";

--- a/app/assets/javascripts/admin/tests/admin/integration/components/themes-list-test.js
+++ b/app/assets/javascripts/admin/tests/admin/integration/components/themes-list-test.js
@@ -1,3 +1,4 @@
+import { moduleForComponent } from "ember-qunit";
 import I18n from "I18n";
 import componentTest from "discourse/tests/helpers/component-test";
 import Theme, { THEMES, COMPONENTS } from "admin/models/theme";

--- a/app/assets/javascripts/admin/tests/admin/unit/controllers/admin-customize-themes-show-test.js
+++ b/app/assets/javascripts/admin/tests/admin/unit/controllers/admin-customize-themes-show-test.js
@@ -1,3 +1,5 @@
+import { moduleFor } from "ember-qunit";
+import { test } from "qunit";
 import { mapRoutes } from "discourse/mapping-router";
 import Theme from "admin/models/theme";
 
@@ -8,7 +10,7 @@ moduleFor("controller:admin-customize-themes-show", {
   needs: ["controller:adminUser"],
 });
 
-QUnit.test("can display source url for remote themes", function (assert) {
+test("can display source url for remote themes", function (assert) {
   const repoUrl = "https://github.com/discourse/discourse-brand-header.git";
   const remoteTheme = Theme.create({
     id: 2,
@@ -29,9 +31,7 @@ QUnit.test("can display source url for remote themes", function (assert) {
   );
 });
 
-QUnit.test("can display source url for remote theme branches", function (
-  assert
-) {
+test("can display source url for remote theme branches", function (assert) {
   const remoteTheme = Theme.create({
     id: 2,
     default: true,

--- a/app/assets/javascripts/admin/tests/admin/unit/controllers/admin-customize-themes-test.js
+++ b/app/assets/javascripts/admin/tests/admin/unit/controllers/admin-customize-themes-test.js
@@ -1,3 +1,5 @@
+import { moduleFor } from "ember-qunit";
+import { test } from "qunit";
 import { mapRoutes } from "discourse/mapping-router";
 import Theme from "admin/models/theme";
 
@@ -8,7 +10,7 @@ moduleFor("controller:admin-customize-themes", {
   needs: ["controller:adminUser"],
 });
 
-QUnit.test("can list themes correctly", function (assert) {
+test("can list themes correctly", function (assert) {
   const defaultTheme = Theme.create({ id: 2, default: true, name: "default" });
   const userTheme = Theme.create({
     id: 3,

--- a/app/assets/javascripts/admin/tests/admin/unit/controllers/admin-user-badges-test.js
+++ b/app/assets/javascripts/admin/tests/admin/unit/controllers/admin-user-badges-test.js
@@ -1,3 +1,5 @@
+import { moduleFor } from "ember-qunit";
+import { test } from "qunit";
 import Badge from "discourse/models/badge";
 import { mapRoutes } from "discourse/mapping-router";
 
@@ -8,7 +10,7 @@ moduleFor("controller:admin-user-badges", {
   needs: ["controller:adminUser"],
 });
 
-QUnit.test("grantableBadges", function (assert) {
+test("grantableBadges", function (assert) {
   const badgeFirst = Badge.create({
     id: 3,
     name: "A Badge",

--- a/app/assets/javascripts/admin/tests/admin/unit/models/theme-test.js
+++ b/app/assets/javascripts/admin/tests/admin/unit/models/theme-test.js
@@ -1,8 +1,9 @@
+import { test, module } from "qunit";
 import Theme from "admin/models/theme";
 
-QUnit.module("model:theme");
+module("model:theme");
 
-QUnit.test("can add an upload correctly", function (assert) {
+test("can add an upload correctly", function (assert) {
   let theme = Theme.create();
 
   assert.equal(

--- a/app/assets/javascripts/discourse-loader.js
+++ b/app/assets/javascripts/discourse-loader.js
@@ -153,6 +153,19 @@ var define, requirejs;
       pretender: {
         default: window.Pretender,
       },
+      "ember-qunit": {
+        moduleFor: window.moduleFor,
+        moduleForComponent: window.moduleForComponent,
+      },
+      qunit:
+        typeof window.QUnit !== "undefined"
+          ? {
+              default: window.QUnit,
+              test: window.QUnit.test,
+              skip: window.QUnit.skip,
+              module: window.QUnit.module,
+            }
+          : undefined,
     };
   }
 

--- a/app/assets/javascripts/discourse/tests/acceptance/about-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/about-test.js
@@ -1,7 +1,8 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 acceptance("About");
 
-QUnit.test("viewing", async (assert) => {
+test("viewing", async (assert) => {
   await visit("/about");
 
   assert.ok($("body.about-page").length, "has body class");

--- a/app/assets/javascripts/discourse/tests/acceptance/account-created-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/account-created-test.js
@@ -1,9 +1,10 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import PreloadStore from "discourse/lib/preload-store";
 
 acceptance("Account Created");
 
-QUnit.test("account created - message", async (assert) => {
+test("account created - message", async (assert) => {
   PreloadStore.store("accountCreated", {
     message: "Hello World",
   });
@@ -18,7 +19,7 @@ QUnit.test("account created - message", async (assert) => {
   assert.notOk(exists(".activation-controls"));
 });
 
-QUnit.test("account created - resend email", async (assert) => {
+test("account created - resend email", async (assert) => {
   PreloadStore.store("accountCreated", {
     message: "Hello World",
     username: "eviltrout",
@@ -42,7 +43,7 @@ QUnit.test("account created - resend email", async (assert) => {
   assert.equal(email, "eviltrout@example.com");
 });
 
-QUnit.test("account created - update email - cancel", async (assert) => {
+test("account created - update email - cancel", async (assert) => {
   PreloadStore.store("accountCreated", {
     message: "Hello World",
     username: "eviltrout",
@@ -62,7 +63,7 @@ QUnit.test("account created - update email - cancel", async (assert) => {
   assert.equal(currentPath(), "account-created.index");
 });
 
-QUnit.test("account created - update email - submit", async (assert) => {
+test("account created - update email - submit", async (assert) => {
   PreloadStore.store("accountCreated", {
     message: "Hello World",
     username: "eviltrout",

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-emails-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-emails-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import pretender from "discourse/tests/helpers/create-pretender";
 
@@ -16,7 +17,7 @@ Hello, this is a test!
 
 This part should be elided.`.trim();
 
-QUnit.test("shows selected and elided text", async (assert) => {
+test("shows selected and elided text", async (assert) => {
   pretender.post("/admin/email/advanced-test", () => {
     return [
       200,

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-search-log-term-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-search-log-term-test.js
@@ -1,7 +1,8 @@
+import { skip } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 acceptance("Admin - Search Log Term", { loggedIn: true });
 
-QUnit.skip("show search log term details", async (assert) => {
+skip("show search log term details", async (assert) => {
   await visit("/admin/logs/search_logs/term?term=ruby");
 
   assert.ok($("div.search-logs-filter").length, "has the search type filter");

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-search-logs-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-search-logs-test.js
@@ -1,7 +1,8 @@
+import { skip } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 acceptance("Admin - Search Logs", { loggedIn: true });
 
-QUnit.skip("show search logs", async (assert) => {
+skip("show search logs", async (assert) => {
   await visit("/admin/logs/search_logs");
 
   assert.ok($("table.search-logs-list.grid").length, "has the div class");

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-site-settings-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-site-settings-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import siteSettingFixture from "discourse/tests/fixtures/site-settings";
 
@@ -29,7 +30,7 @@ acceptance("Admin - Site Settings", {
   },
 });
 
-QUnit.test("upload site setting", async (assert) => {
+test("upload site setting", async (assert) => {
   await visit("/admin/site_settings");
 
   assert.ok(
@@ -40,7 +41,7 @@ QUnit.test("upload site setting", async (assert) => {
   assert.ok(exists(".row.setting.upload .undo"), "undo button is present");
 });
 
-QUnit.test("changing value updates dirty state", async (assert) => {
+test("changing value updates dirty state", async (assert) => {
   await visit("/admin/site_settings");
   await fillIn("#setting-filter", " title ");
   assert.equal(count(".row.setting"), 1, "filter returns 1 site setting");
@@ -87,24 +88,21 @@ QUnit.test("changing value updates dirty state", async (assert) => {
   );
 });
 
-QUnit.test(
-  "always shows filtered site settings if a filter is set",
-  async (assert) => {
-    await visit("/admin/site_settings");
-    await fillIn("#setting-filter", "title");
-    assert.equal(count(".row.setting"), 1);
+test("always shows filtered site settings if a filter is set", async (assert) => {
+  await visit("/admin/site_settings");
+  await fillIn("#setting-filter", "title");
+  assert.equal(count(".row.setting"), 1);
 
-    // navigate away to the "Dashboard" page
-    await click(".nav.nav-pills li:nth-child(1) a");
-    assert.equal(count(".row.setting"), 0);
+  // navigate away to the "Dashboard" page
+  await click(".nav.nav-pills li:nth-child(1) a");
+  assert.equal(count(".row.setting"), 0);
 
-    // navigate back to the "Settings" page
-    await click(".nav.nav-pills li:nth-child(2) a");
-    assert.equal(count(".row.setting"), 1);
-  }
-);
+  // navigate back to the "Settings" page
+  await click(".nav.nav-pills li:nth-child(2) a");
+  assert.equal(count(".row.setting"), 1);
+});
 
-QUnit.test("filter settings by plugin name", async (assert) => {
+test("filter settings by plugin name", async (assert) => {
   await visit("/admin/site_settings");
 
   await fillIn("#setting-filter", "plugin:discourse-logo");
@@ -115,12 +113,12 @@ QUnit.test("filter settings by plugin name", async (assert) => {
   assert.equal(count(".row.setting"), 0);
 });
 
-QUnit.test("category name is preserved", async (assert) => {
+test("category name is preserved", async (assert) => {
   await visit("admin/site_settings/category/basic?filter=menu");
   assert.equal(currentURL(), "admin/site_settings/category/basic?filter=menu");
 });
 
-QUnit.test("shows all_results if current category has none", async (assert) => {
+test("shows all_results if current category has none", async (assert) => {
   await visit("admin/site_settings");
 
   await click(".admin-nav .basic a");

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-site-text-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-site-text-test.js
@@ -1,8 +1,9 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Admin - Site Texts", { loggedIn: true });
 
-QUnit.test("search for a key", async (assert) => {
+test("search for a key", async (assert) => {
   await visit("/admin/customize/site_texts");
 
   await fillIn(".site-text-search", "Test");
@@ -23,7 +24,7 @@ QUnit.test("search for a key", async (assert) => {
   assert.ok(exists(".site-text.overridden"));
 });
 
-QUnit.test("edit and revert a site text by key", async (assert) => {
+test("edit and revert a site text by key", async (assert) => {
   await visit("/admin/customize/site_texts/site.test");
 
   assert.equal(find(".title h3").text(), "site.test");

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-suspend-user-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-suspend-user-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
@@ -23,7 +24,7 @@ acceptance("Admin - Suspend User", {
   },
 });
 
-QUnit.test("suspend a user - cancel", async (assert) => {
+test("suspend a user - cancel", async (assert) => {
   await visit("/admin/users/1234/regular");
   await click(".suspend-user");
 
@@ -34,7 +35,7 @@ QUnit.test("suspend a user - cancel", async (assert) => {
   assert.equal(find(".suspend-user-modal:visible").length, 0);
 });
 
-QUnit.test("suspend a user - cancel with input", async (assert) => {
+test("suspend a user - cancel with input", async (assert) => {
   await visit("/admin/users/1234/regular");
   await click(".suspend-user");
 
@@ -61,7 +62,7 @@ QUnit.test("suspend a user - cancel with input", async (assert) => {
   assert.equal(find(".bootbox.modal:visible").length, 0);
 });
 
-QUnit.test("suspend, then unsuspend a user", async (assert) => {
+test("suspend, then unsuspend a user", async (assert) => {
   const suspendUntilCombobox = selectKit(".suspend-until .combobox");
 
   await visit("/admin/flags/active");

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-user-badges-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-user-badges-test.js
@@ -1,8 +1,9 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Admin - Users Badges", { loggedIn: true });
 
-QUnit.test("lists badges", async (assert) => {
+test("lists badges", async (assert) => {
   await visit("/admin/users/1/eviltrout/badges");
 
   assert.ok(exists(`span[data-badge-name="Badge 8"]`));

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-user-emails-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-user-emails-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import I18n from "I18n";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
@@ -31,13 +32,13 @@ const assertMultipleSecondary = (assert, firstEmail, secondEmail) => {
   );
 };
 
-QUnit.test("viewing self without secondary emails", async (assert) => {
+test("viewing self without secondary emails", async (assert) => {
   await visit("/admin/users/1/eviltrout");
 
   assertNoSecondary(assert);
 });
 
-QUnit.test("viewing self with multiple secondary emails", async (assert) => {
+test("viewing self with multiple secondary emails", async (assert) => {
   await visit("/admin/users/3/markvanlan");
 
   assert.equal(
@@ -53,14 +54,14 @@ QUnit.test("viewing self with multiple secondary emails", async (assert) => {
   );
 });
 
-QUnit.test("viewing another user with no secondary email", async (assert) => {
+test("viewing another user with no secondary email", async (assert) => {
   await visit("/admin/users/1234/regular");
   await click(`.display-row.secondary-emails button`);
 
   assertNoSecondary(assert);
 });
 
-QUnit.test("viewing another account with secondary emails", async (assert) => {
+test("viewing another account with secondary emails", async (assert) => {
   await visit("/admin/users/1235/regular1");
   await click(`.display-row.secondary-emails button`);
 

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-user-index-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-user-index-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import pretender from "discourse/tests/helpers/create-pretender";
@@ -34,7 +35,7 @@ acceptance("Admin - User Index", {
   },
 });
 
-QUnit.test("can edit username", async (assert) => {
+test("can edit username", async (assert) => {
   pretender.put("/users/sam/preferences/username", () => [
     200,
     {
@@ -60,7 +61,7 @@ QUnit.test("can edit username", async (assert) => {
   assert.equal(find(".display-row.username .value").text().trim(), "new-sam");
 });
 
-QUnit.test("will clear unsaved groups when switching user", async (assert) => {
+test("will clear unsaved groups when switching user", async (assert) => {
   await visit("/admin/users/2/sam");
 
   assert.equal(

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-users-list-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-users-list-test.js
@@ -1,16 +1,17 @@
+import { test } from "qunit";
 import I18n from "I18n";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Admin - Users List", { loggedIn: true });
 
-QUnit.test("lists users", async (assert) => {
+test("lists users", async (assert) => {
   await visit("/admin/users/list/active");
 
   assert.ok(exists(".users-list .user"));
   assert.ok(!exists(".user:eq(0) .email small"), "escapes email");
 });
 
-QUnit.test("sorts users", async (assert) => {
+test("sorts users", async (assert) => {
   await visit("/admin/users/list/active");
 
   assert.ok(exists(".users-list .user"));
@@ -34,7 +35,7 @@ QUnit.test("sorts users", async (assert) => {
   );
 });
 
-QUnit.test("toggles email visibility", async (assert) => {
+test("toggles email visibility", async (assert) => {
   await visit("/admin/users/list/active");
 
   assert.ok(exists(".users-list .user"));
@@ -56,7 +57,7 @@ QUnit.test("toggles email visibility", async (assert) => {
   );
 });
 
-QUnit.test("switching tabs", async (assert) => {
+test("switching tabs", async (assert) => {
   const activeUser = "eviltrout";
   const suspectUser = "sam";
   const activeTitle = I18n.t("admin.users.titles.active");

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-watched-words-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-watched-words-test.js
@@ -1,7 +1,8 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 acceptance("Admin - Watched Words", { loggedIn: true });
 
-QUnit.test("list words in groups", async (assert) => {
+test("list words in groups", async (assert) => {
   await visit("/admin/logs/watched_words/action/block");
 
   assert.ok(exists(".watched-words-list"));
@@ -38,7 +39,7 @@ QUnit.test("list words in groups", async (assert) => {
   assert.ok(!exists(".watched-words-list .watched-word"), "Empty word list.");
 });
 
-QUnit.test("add words", async (assert) => {
+test("add words", async (assert) => {
   await visit("/admin/logs/watched_words/action/block");
 
   click(".show-words-checkbox");
@@ -55,7 +56,7 @@ QUnit.test("add words", async (assert) => {
   assert.equal(found.length, 1);
 });
 
-QUnit.test("remove words", async (assert) => {
+test("remove words", async (assert) => {
   await visit("/admin/logs/watched_words/action/block");
   await click(".show-words-checkbox");
 

--- a/app/assets/javascripts/discourse/tests/acceptance/auth-complete-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/auth-complete-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 acceptance("Auth Complete", {
   beforeEach() {
@@ -16,7 +17,7 @@ acceptance("Auth Complete", {
   },
 });
 
-QUnit.test("when login not required", async (assert) => {
+test("when login not required", async (assert) => {
   await visit("/");
 
   assert.equal(currentPath(), "discovery.latest", "it stays on the homepage");
@@ -27,7 +28,7 @@ QUnit.test("when login not required", async (assert) => {
   );
 });
 
-QUnit.test("when login required", async function (assert) {
+test("when login required", async function (assert) {
   this.siteSettings.login_required = true;
   await visit("/");
 

--- a/app/assets/javascripts/discourse/tests/acceptance/badges-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/badges-test.js
@@ -1,9 +1,10 @@
+import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Badges", { loggedIn: true });
 
-QUnit.test("Visit Badge Pages", async (assert) => {
+test("Visit Badge Pages", async (assert) => {
   await visit("/badges");
 
   assert.ok($("body.badges-page").length, "has body class");
@@ -16,7 +17,7 @@ QUnit.test("Visit Badge Pages", async (assert) => {
   assert.ok(!exists(".badge-card:eq(0) script"));
 });
 
-QUnit.test("shows correct badge titles to choose from", async (assert) => {
+test("shows correct badge titles to choose from", async (assert) => {
   const availableBadgeTitles = selectKit(".select-kit");
   await visit("/badges/50/custombadge");
   await availableBadgeTitles.expand();

--- a/app/assets/javascripts/discourse/tests/acceptance/bookmarks-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/bookmarks-test.js
@@ -1,3 +1,5 @@
+import { skip } from "qunit";
+import { test } from "qunit";
 import I18n from "I18n";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import {
@@ -236,25 +238,22 @@ acceptance("Bookmarking - Mobile", {
   },
 });
 
-QUnit.skip(
-  "Editing a bookmark that has a Later Today reminder, and it is before 6pm today",
-  async (assert) => {
-    await acceptanceUseFakeClock("2020-05-04T13:00:00", async () => {
-      mockSuccessfulBookmarkPost(assert);
-      await visit("/t/internationalization-localization/280");
-      await openBookmarkModal();
-      await fillIn("input#bookmark-name", "Test name");
-      await click("#tap_tile_later_today");
-      await openEditBookmarkModal();
-      assert.not(
-        exists("#bookmark-custom-date > input"),
-        "it does not show the custom date input"
-      );
-      assert.ok(
-        exists("#tap_tile_later_today.active"),
-        "it preselects Later Today"
-      );
-      assert.verifySteps(["later_today"]);
-    });
-  }
-);
+skip("Editing a bookmark that has a Later Today reminder, and it is before 6pm today", async (assert) => {
+  await acceptanceUseFakeClock("2020-05-04T13:00:00", async () => {
+    mockSuccessfulBookmarkPost(assert);
+    await visit("/t/internationalization-localization/280");
+    await openBookmarkModal();
+    await fillIn("input#bookmark-name", "Test name");
+    await click("#tap_tile_later_today");
+    await openEditBookmarkModal();
+    assert.not(
+      exists("#bookmark-custom-date > input"),
+      "it does not show the custom date input"
+    );
+    assert.ok(
+      exists("#tap_tile_later_today.active"),
+      "it preselects Later Today"
+    );
+    assert.verifySteps(["later_today"]);
+  });
+});

--- a/app/assets/javascripts/discourse/tests/acceptance/category-banner-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/category-banner-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import DiscoveryFixtures from "discourse/tests/fixtures/discovery-fixtures";
 
@@ -35,7 +36,7 @@ acceptance("Category Banners", {
   },
 });
 
-QUnit.test("Does not display category banners when not set", async (assert) => {
+test("Does not display category banners when not set", async (assert) => {
   await visit("/c/test-read-only-without-banner");
 
   await click("#create-topic");
@@ -46,7 +47,7 @@ QUnit.test("Does not display category banners when not set", async (assert) => {
   );
 });
 
-QUnit.test("Displays category banners when set", async (assert) => {
+test("Displays category banners when set", async (assert) => {
   await visit("/c/test-read-only-with-banner");
 
   await click("#create-topic");
@@ -84,7 +85,7 @@ acceptance("Anonymous Category Banners", {
   },
 });
 
-QUnit.test("Does not display category banners when set", async (assert) => {
+test("Does not display category banners when set", async (assert) => {
   await visit("/c/test-read-only-with-banner");
   assert.ok(
     !visible(".category-read-only-banner"),

--- a/app/assets/javascripts/discourse/tests/acceptance/category-chooser-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/category-chooser-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
@@ -8,7 +9,7 @@ acceptance("CategoryChooser", {
   },
 });
 
-QUnit.test("does not display uncategorized if not allowed", async (assert) => {
+test("does not display uncategorized if not allowed", async (assert) => {
   const categoryChooser = selectKit(".category-chooser");
 
   await visit("/");
@@ -19,13 +20,13 @@ QUnit.test("does not display uncategorized if not allowed", async (assert) => {
   assert.ok(categoryChooser.rowByIndex(0).name() !== "uncategorized");
 });
 
-QUnit.test("prefill category when category_id is set", async (assert) => {
+test("prefill category when category_id is set", async (assert) => {
   await visit("/new-topic?category_id=1");
 
   assert.equal(selectKit(".category-chooser").header().value(), 1);
 });
 
-QUnit.test("filter is case insensitive", async (assert) => {
+test("filter is case insensitive", async (assert) => {
   const categoryChooser = selectKit(".category-chooser");
 
   await visit("/");

--- a/app/assets/javascripts/discourse/tests/acceptance/category-edit-security-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/category-edit-security-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
@@ -5,7 +6,7 @@ acceptance("Category Edit - security", {
   loggedIn: true,
 });
 
-QUnit.test("default", async (assert) => {
+test("default", async (assert) => {
   await visit("/c/bug");
 
   await click(".edit-category");
@@ -20,7 +21,7 @@ QUnit.test("default", async (assert) => {
   assert.equal(permission, "Create / Reply / See");
 });
 
-QUnit.test("removing a permission", async (assert) => {
+test("removing a permission", async (assert) => {
   const availableGroups = selectKit(".available-groups");
 
   await visit("/c/bug");
@@ -46,7 +47,7 @@ QUnit.test("removing a permission", async (assert) => {
   );
 });
 
-QUnit.test("adding a permission", async (assert) => {
+test("adding a permission", async (assert) => {
   const availableGroups = selectKit(".available-groups");
   const permissionSelector = selectKit(".permission-selector");
 
@@ -72,7 +73,7 @@ QUnit.test("adding a permission", async (assert) => {
   assert.equal(permission, "Reply / See");
 });
 
-QUnit.test("adding a previously removed permission", async (assert) => {
+test("adding a previously removed permission", async (assert) => {
   const availableGroups = selectKit(".available-groups");
 
   await visit("/c/bug");

--- a/app/assets/javascripts/discourse/tests/acceptance/category-edit-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/category-edit-test.js
@@ -1,3 +1,5 @@
+import { skip } from "qunit";
+import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import DiscourseURL from "discourse/lib/url";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
@@ -7,7 +9,7 @@ acceptance("Category Edit", {
   settings: { email_in: true },
 });
 
-QUnit.test("Can open the category modal", async (assert) => {
+test("Can open the category modal", async (assert) => {
   await visit("/c/bug");
 
   await click(".edit-category");
@@ -17,7 +19,7 @@ QUnit.test("Can open the category modal", async (assert) => {
   assert.ok(!visible(".d-modal"), "it closes the modal");
 });
 
-QUnit.test("Editing the category", async (assert) => {
+test("Editing the category", async (assert) => {
   await visit("/c/bug");
 
   await click(".edit-category");
@@ -46,7 +48,7 @@ QUnit.test("Editing the category", async (assert) => {
   );
 });
 
-QUnit.skip("Edit the description without loosing progress", async (assert) => {
+skip("Edit the description without loosing progress", async (assert) => {
   let win = { focus: function () {} };
   let windowOpen = sandbox.stub(window, "open").returns(win);
   sandbox.stub(win, "focus");
@@ -61,7 +63,7 @@ QUnit.skip("Edit the description without loosing progress", async (assert) => {
   );
 });
 
-QUnit.test("Error Saving", async (assert) => {
+test("Error Saving", async (assert) => {
   await visit("/c/bug");
 
   await click(".edit-category");
@@ -72,7 +74,7 @@ QUnit.test("Error Saving", async (assert) => {
   assert.equal(find("#modal-alert").html(), "duplicate email");
 });
 
-QUnit.test("Subcategory list settings", async (assert) => {
+test("Subcategory list settings", async (assert) => {
   const categoryChooser = selectKit(
     ".edit-category-tab-general .category-chooser"
   );

--- a/app/assets/javascripts/discourse/tests/acceptance/click-track-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/click-track-test.js
@@ -1,9 +1,10 @@
+import { test } from "qunit";
 import pretender from "discourse/tests/helpers/create-pretender";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Click Track", {});
 
-QUnit.test("Do not track mentions", async (assert) => {
+test("Do not track mentions", async (assert) => {
   pretender.post("/clicks/track", () => assert.ok(false));
 
   await visit("/t/internationalization-localization/280");

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-actions-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-actions-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import I18n from "I18n";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import {
@@ -19,25 +20,22 @@ acceptance("Composer Actions", {
   },
 });
 
-QUnit.test(
-  "creating new topic and then reply_as_private_message keeps attributes",
-  async (assert) => {
-    await visit("/");
-    await click("button#create-topic");
+test("creating new topic and then reply_as_private_message keeps attributes", async (assert) => {
+  await visit("/");
+  await click("button#create-topic");
 
-    await fillIn("#reply-title", "this is the title");
-    await fillIn(".d-editor-input", "this is the reply");
+  await fillIn("#reply-title", "this is the title");
+  await fillIn(".d-editor-input", "this is the reply");
 
-    const composerActions = selectKit(".composer-actions");
-    await composerActions.expand();
-    await composerActions.selectRowByValue("reply_as_private_message");
+  const composerActions = selectKit(".composer-actions");
+  await composerActions.expand();
+  await composerActions.selectRowByValue("reply_as_private_message");
 
-    assert.ok(find("#reply-title").val(), "this is the title");
-    assert.ok(find(".d-editor-input").val(), "this is the reply");
-  }
-);
+  assert.ok(find("#reply-title").val(), "this is the title");
+  assert.ok(find(".d-editor-input").val(), "this is the reply");
+});
 
-QUnit.test("replying to post", async (assert) => {
+test("replying to post", async (assert) => {
   const composerActions = selectKit(".composer-actions");
 
   await visit("/t/internationalization-localization/280");
@@ -55,7 +53,7 @@ QUnit.test("replying to post", async (assert) => {
   assert.equal(composerActions.rowByIndex(5).value(), undefined);
 });
 
-QUnit.test("replying to post - reply_as_private_message", async (assert) => {
+test("replying to post - reply_as_private_message", async (assert) => {
   const composerActions = selectKit(".composer-actions");
 
   await visit("/t/internationalization-localization/280");
@@ -70,7 +68,7 @@ QUnit.test("replying to post - reply_as_private_message", async (assert) => {
   );
 });
 
-QUnit.test("replying to post - reply_to_topic", async (assert) => {
+test("replying to post - reply_to_topic", async (assert) => {
   const composerActions = selectKit(".composer-actions");
 
   await visit("/t/internationalization-localization/280");
@@ -97,7 +95,7 @@ QUnit.test("replying to post - reply_to_topic", async (assert) => {
   );
 });
 
-QUnit.test("replying to post - toggle_whisper", async (assert) => {
+test("replying to post - toggle_whisper", async (assert) => {
   const composerActions = selectKit(".composer-actions");
 
   await visit("/t/internationalization-localization/280");
@@ -115,7 +113,7 @@ QUnit.test("replying to post - toggle_whisper", async (assert) => {
   );
 });
 
-QUnit.test("replying to post - reply_as_new_topic", async (assert) => {
+test("replying to post - reply_as_new_topic", async (assert) => {
   sandbox
     .stub(Draft, "get")
     .returns(Promise.resolve({ draft: "", draft_sequence: 0 }));
@@ -146,7 +144,7 @@ QUnit.test("replying to post - reply_as_new_topic", async (assert) => {
   sandbox.restore();
 });
 
-QUnit.test("reply_as_new_topic without a new_topic draft", async (assert) => {
+test("reply_as_new_topic without a new_topic draft", async (assert) => {
   await visit("/t/internationalization-localization/280");
   await click(".create.reply");
   const composerActions = selectKit(".composer-actions");
@@ -155,7 +153,7 @@ QUnit.test("reply_as_new_topic without a new_topic draft", async (assert) => {
   assert.equal(exists(find(".bootbox")), false);
 });
 
-QUnit.test("reply_as_new_group_message", async (assert) => {
+test("reply_as_new_group_message", async (assert) => {
   // eslint-disable-next-line
   server.get("/t/130.json", () => {
     return [
@@ -408,7 +406,7 @@ QUnit.test("reply_as_new_group_message", async (assert) => {
   assert.deepEqual(items, ["foo", "foo_group"]);
 });
 
-QUnit.test("hide component if no content", async (assert) => {
+test("hide component if no content", async (assert) => {
   await visit("/");
   await click("button#create-topic");
 
@@ -424,7 +422,7 @@ QUnit.test("hide component if no content", async (assert) => {
   assert.equal(composerActions.rows().length, 2);
 });
 
-QUnit.test("interactions", async (assert) => {
+test("interactions", async (assert) => {
   const composerActions = selectKit(".composer-actions");
   const quote = "Life is like riding a bicycle.";
 
@@ -501,7 +499,7 @@ QUnit.test("interactions", async (assert) => {
   assert.equal(composerActions.rows().length, 3);
 });
 
-QUnit.test("replying to post - toggle_topic_bump", async (assert) => {
+test("replying to post - toggle_topic_bump", async (assert) => {
   const composerActions = selectKit(".composer-actions");
 
   await visit("/t/internationalization-localization/280");
@@ -529,7 +527,7 @@ QUnit.test("replying to post - toggle_topic_bump", async (assert) => {
   );
 });
 
-QUnit.test("replying to post as staff", async (assert) => {
+test("replying to post as staff", async (assert) => {
   const composerActions = selectKit(".composer-actions");
 
   updateCurrentUser({ admin: true });
@@ -541,7 +539,7 @@ QUnit.test("replying to post as staff", async (assert) => {
   assert.equal(composerActions.rowByIndex(4).value(), "toggle_topic_bump");
 });
 
-QUnit.test("replying to post as TL3 user", async (assert) => {
+test("replying to post as TL3 user", async (assert) => {
   const composerActions = selectKit(".composer-actions");
 
   updateCurrentUser({ moderator: false, admin: false, trust_level: 3 });
@@ -559,7 +557,7 @@ QUnit.test("replying to post as TL3 user", async (assert) => {
   });
 });
 
-QUnit.test("replying to post as TL4 user", async (assert) => {
+test("replying to post as TL4 user", async (assert) => {
   const composerActions = selectKit(".composer-actions");
 
   updateCurrentUser({ moderator: false, admin: false, trust_level: 4 });
@@ -571,25 +569,22 @@ QUnit.test("replying to post as TL4 user", async (assert) => {
   assert.equal(composerActions.rowByIndex(3).value(), "toggle_topic_bump");
 });
 
-QUnit.test(
-  "replying to first post - reply_as_private_message",
-  async (assert) => {
-    const composerActions = selectKit(".composer-actions");
+test("replying to first post - reply_as_private_message", async (assert) => {
+  const composerActions = selectKit(".composer-actions");
 
-    await visit("/t/internationalization-localization/280");
-    await click("article#post_1 button.reply");
+  await visit("/t/internationalization-localization/280");
+  await click("article#post_1 button.reply");
 
-    await composerActions.expand();
-    await composerActions.selectRowByValue("reply_as_private_message");
+  await composerActions.expand();
+  await composerActions.selectRowByValue("reply_as_private_message");
 
-    assert.equal(find(".users-input .item:eq(0)").text(), "uwe_keim");
-    assert.ok(
-      find(".d-editor-input").val().indexOf("Continuing the discussion") >= 0
-    );
-  }
-);
+  assert.equal(find(".users-input .item:eq(0)").text(), "uwe_keim");
+  assert.ok(
+    find(".d-editor-input").val().indexOf("Continuing the discussion") >= 0
+  );
+});
 
-QUnit.test("editing post", async (assert) => {
+test("editing post", async (assert) => {
   const composerActions = selectKit(".composer-actions");
 
   await visit("/t/internationalization-localization/280");
@@ -627,7 +622,7 @@ const stubDraftResponse = () => {
   );
 };
 
-QUnit.test("shared draft", async (assert) => {
+test("shared draft", async (assert) => {
   stubDraftResponse();
   try {
     toggleCheckDraftPopup(true);
@@ -669,7 +664,7 @@ QUnit.test("shared draft", async (assert) => {
   sandbox.restore();
 });
 
-QUnit.test("reply_as_new_topic with new_topic draft", async (assert) => {
+test("reply_as_new_topic with new_topic draft", async (assert) => {
   await visit("/t/internationalization-localization/280");
   await click(".create.reply");
   const composerActions = selectKit(".composer-actions");

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-attachment-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-attachment-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 function setupPretender(server, helper) {
@@ -33,7 +34,7 @@ acceptance("Composer Attachment", {
   },
 });
 
-QUnit.test("attachments are cooked properly", async (assert) => {
+test("attachments are cooked properly", async (assert) => {
   await writeInComposer(assert);
   assert.equal(
     find(".d-editor-preview:visible").html().trim(),
@@ -51,13 +52,10 @@ acceptance("Composer Attachment - Secure Media Enabled", {
   },
 });
 
-QUnit.test(
-  "attachments are cooked properly when secure media is enabled",
-  async (assert) => {
-    await writeInComposer(assert);
-    assert.equal(
-      find(".d-editor-preview:visible").html().trim(),
-      '<p><a class="attachment" href="/secure-media-uploads/default/3X/1/asjdiasjdiasida.png">test</a></p>'
-    );
-  }
-);
+test("attachments are cooked properly when secure media is enabled", async (assert) => {
+  await writeInComposer(assert);
+  assert.equal(
+    find(".d-editor-preview:visible").html().trim(),
+    '<p><a class="attachment" href="/secure-media-uploads/default/3X/1/asjdiasjdiasida.png">test</a></p>'
+  );
+});

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-edit-conflict-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-edit-conflict-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import I18n from "I18n";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import pretender from "discourse/tests/helpers/create-pretender";
@@ -6,7 +7,7 @@ acceptance("Composer - Edit conflict", {
   loggedIn: true,
 });
 
-QUnit.test("Edit a post that causes an edit conflict", async (assert) => {
+test("Edit a post that causes an edit conflict", async (assert) => {
   await visit("/t/internationalization-localization/280");
   await click(".topic-post:eq(0) button.show-more-actions");
   await click(".topic-post:eq(0) button.edit");
@@ -47,21 +48,18 @@ function handleDraftPretender(assert) {
   });
 }
 
-QUnit.test(
-  "Should not send originalText when posting a new reply",
-  async (assert) => {
-    handleDraftPretender(assert);
+test("Should not send originalText when posting a new reply", async (assert) => {
+  handleDraftPretender(assert);
 
-    await visit("/t/internationalization-localization/280");
-    await click(".topic-post:eq(0) button.reply");
-    await fillIn(
-      ".d-editor-input",
-      "hello world hello world hello world hello world hello world"
-    );
-  }
-);
+  await visit("/t/internationalization-localization/280");
+  await click(".topic-post:eq(0) button.reply");
+  await fillIn(
+    ".d-editor-input",
+    "hello world hello world hello world hello world hello world"
+  );
+});
 
-QUnit.test("Should send originalText when editing a reply", async (assert) => {
+test("Should send originalText when editing a reply", async (assert) => {
   handleDraftPretender(assert);
 
   await visit("/t/internationalization-localization/280");

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-hyperlink-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-hyperlink-test.js
@@ -1,10 +1,11 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Composer - Hyperlink", {
   loggedIn: true,
 });
 
-QUnit.test("add a hyperlink to a reply", async (assert) => {
+test("add a hyperlink to a reply", async (assert) => {
   await visit("/t/internationalization-localization/280");
   await click(".topic-post:first-child button.reply");
   await fillIn(".d-editor-input", "This is a link to ");

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-onebox-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-onebox-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Composer - Onebox", {
@@ -8,15 +9,13 @@ acceptance("Composer - Onebox", {
   },
 });
 
-QUnit.test(
-  "Preview update should respect max_oneboxes_per_post site setting",
-  async (assert) => {
-    await visit("/t/internationalization-localization/280");
-    await click("#topic-footer-buttons .btn.create");
+test("Preview update should respect max_oneboxes_per_post site setting", async (assert) => {
+  await visit("/t/internationalization-localization/280");
+  await click("#topic-footer-buttons .btn.create");
 
-    await fillIn(
-      ".d-editor-input",
-      `
+  await fillIn(
+    ".d-editor-input",
+    `
 http://www.example.com/has-title.html
 This is another test http://www.example.com/has-title.html
 
@@ -27,11 +26,11 @@ This is another test http://www.example.com/has-title.html
 
 http://www.example.com/has-title.html
       `
-    );
+  );
 
-    assert.equal(
-      find(".d-editor-preview:visible").html().trim(),
-      `
+  assert.equal(
+    find(".d-editor-preview:visible").html().trim(),
+    `
 <p><aside class=\"onebox\"><article class=\"onebox-body\"><h3><a href=\"http://www.example.com/article.html\">An interesting article</a></h3></article></aside><br>
 This is another test <a href=\"http://www.example.com/has-title.html\" class=\"inline-onebox\">This is a great title</a></p>
 <p><a href=\"http://www.example.com/no-title.html\" class=\"onebox\" target=\"_blank\">http://www.example.com/no-title.html</a></p>
@@ -39,6 +38,5 @@ This is another test <a href=\"http://www.example.com/has-title.html\" class=\"i
 This is another test <a href=\"http://www.example.com/has-title.html\" class=\"inline-onebox\">This is a great title</a></p>
 <p><aside class=\"onebox\"><article class=\"onebox-body\"><h3><a href=\"http://www.example.com/article.html\">An interesting article</a></h3></article></aside></p>
       `.trim()
-    );
-  }
-);
+  );
+});

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-tags-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-tags-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import Category from "discourse/models/category";
 import {
   acceptance,
@@ -17,7 +18,7 @@ acceptance("Composer - Tags", {
   },
 });
 
-QUnit.test("staff bypass tag validation rule", async (assert) => {
+test("staff bypass tag validation rule", async (assert) => {
   await visit("/");
   await click("#create-topic");
 
@@ -34,7 +35,7 @@ QUnit.test("staff bypass tag validation rule", async (assert) => {
   assert.notEqual(currentURL(), "/");
 });
 
-QUnit.test("users do not bypass tag validation rule", async (assert) => {
+test("users do not bypass tag validation rule", async (assert) => {
   await visit("/");
   await click("#create-topic");
 

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
@@ -1,3 +1,5 @@
+import { skip } from "qunit";
+import { test } from "qunit";
 import I18n from "I18n";
 import { run } from "@ember/runloop";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
@@ -18,7 +20,7 @@ acceptance("Composer", {
   },
 });
 
-QUnit.skip("Tests the Composer controls", async (assert) => {
+skip("Tests the Composer controls", async (assert) => {
   await visit("/");
   assert.ok(exists("#create-topic"), "the create button is visible");
 
@@ -96,7 +98,7 @@ QUnit.skip("Tests the Composer controls", async (assert) => {
   assert.ok(!exists(".bootbox.modal"), "the confirmation can be cancelled");
 });
 
-QUnit.test("Composer upload placeholder", async (assert) => {
+test("Composer upload placeholder", async (assert) => {
   await visit("/");
   await click("#create-topic");
 
@@ -189,7 +191,7 @@ QUnit.test("Composer upload placeholder", async (assert) => {
   );
 });
 
-QUnit.test("Create a topic with server side errors", async (assert) => {
+test("Create a topic with server side errors", async (assert) => {
   await visit("/");
   await click("#create-topic");
   await fillIn("#reply-title", "this title triggers an error");
@@ -201,7 +203,7 @@ QUnit.test("Create a topic with server side errors", async (assert) => {
   assert.ok(exists(".d-editor-input"), "the composer input is visible");
 });
 
-QUnit.test("Create a Topic", async (assert) => {
+test("Create a Topic", async (assert) => {
   await visit("/");
   await click("#create-topic");
   await fillIn("#reply-title", "Internationalization Localization");
@@ -214,7 +216,7 @@ QUnit.test("Create a Topic", async (assert) => {
   );
 });
 
-QUnit.test("Create an enqueued Topic", async (assert) => {
+test("Create an enqueued Topic", async (assert) => {
   await visit("/");
   await click("#create-topic");
   await fillIn("#reply-title", "Internationalization Localization");
@@ -227,7 +229,7 @@ QUnit.test("Create an enqueued Topic", async (assert) => {
   assert.ok(invisible(".d-modal"), "the modal can be dismissed");
 });
 
-QUnit.test("Can display a message and route to a URL", async (assert) => {
+test("Can display a message and route to a URL", async (assert) => {
   await visit("/");
   await click("#create-topic");
   await fillIn("#reply-title", "This title doesn't matter");
@@ -247,7 +249,7 @@ QUnit.test("Can display a message and route to a URL", async (assert) => {
   );
 });
 
-QUnit.test("Create a Reply", async (assert) => {
+test("Create a Reply", async (assert) => {
   await visit("/t/internationalization-localization/280");
 
   assert.ok(
@@ -267,7 +269,7 @@ QUnit.test("Create a Reply", async (assert) => {
   );
 });
 
-QUnit.test("Can edit a post after starting a reply", async (assert) => {
+test("Can edit a post after starting a reply", async (assert) => {
   await visit("/t/internationalization-localization/280");
 
   await click("#topic-footer-buttons .create");
@@ -285,7 +287,7 @@ QUnit.test("Can edit a post after starting a reply", async (assert) => {
   );
 });
 
-QUnit.test("Posting on a different topic", async (assert) => {
+test("Posting on a different topic", async (assert) => {
   await visit("/t/internationalization-localization/280");
   await click("#topic-footer-buttons .btn.create");
   await fillIn(".d-editor-input", "this is the content for a different topic");
@@ -302,7 +304,7 @@ QUnit.test("Posting on a different topic", async (assert) => {
   );
 });
 
-QUnit.test("Create an enqueued Reply", async (assert) => {
+test("Create an enqueued Reply", async (assert) => {
   await visit("/t/internationalization-localization/280");
 
   assert.notOk(find(".pending-posts .reviewable-item").length);
@@ -326,7 +328,7 @@ QUnit.test("Create an enqueued Reply", async (assert) => {
   assert.ok(find(".pending-posts .reviewable-item").length);
 });
 
-QUnit.test("Edit the first post", async (assert) => {
+test("Edit the first post", async (assert) => {
   await visit("/t/internationalization-localization/280");
 
   assert.ok(
@@ -364,7 +366,7 @@ QUnit.test("Edit the first post", async (assert) => {
   );
 });
 
-QUnit.test("Composer can switch between edits", async (assert) => {
+test("Composer can switch between edits", async (assert) => {
   await visit("/t/this-is-a-test-topic/9");
 
   await click(".topic-post:eq(0) button.edit");
@@ -381,26 +383,23 @@ QUnit.test("Composer can switch between edits", async (assert) => {
   );
 });
 
-QUnit.test(
-  "Composer with dirty edit can toggle to another edit",
-  async (assert) => {
-    await visit("/t/this-is-a-test-topic/9");
+test("Composer with dirty edit can toggle to another edit", async (assert) => {
+  await visit("/t/this-is-a-test-topic/9");
 
-    await click(".topic-post:eq(0) button.edit");
-    await fillIn(".d-editor-input", "This is a dirty reply");
-    await click(".topic-post:eq(1) button.edit");
-    assert.ok(exists(".bootbox.modal"), "it pops up a confirmation dialog");
+  await click(".topic-post:eq(0) button.edit");
+  await fillIn(".d-editor-input", "This is a dirty reply");
+  await click(".topic-post:eq(1) button.edit");
+  assert.ok(exists(".bootbox.modal"), "it pops up a confirmation dialog");
 
-    await click(".modal-footer a:eq(0)");
-    assert.equal(
-      find(".d-editor-input").val().indexOf("This is the second post."),
-      0,
-      "it populates the input with the post text"
-    );
-  }
-);
+  await click(".modal-footer a:eq(0)");
+  assert.equal(
+    find(".d-editor-input").val().indexOf("This is the second post."),
+    0,
+    "it populates the input with the post text"
+  );
+});
 
-QUnit.test("Composer can toggle between edit and reply", async (assert) => {
+test("Composer can toggle between edit and reply", async (assert) => {
   await visit("/t/this-is-a-test-topic/9");
 
   await click(".topic-post:eq(0) button.edit");
@@ -419,7 +418,7 @@ QUnit.test("Composer can toggle between edit and reply", async (assert) => {
   );
 });
 
-QUnit.test("Composer can toggle whispers", async (assert) => {
+test("Composer can toggle whispers", async (assert) => {
   const menu = selectKit(".toolbar-popup-menu-options");
 
   await visit("/t/this-is-a-test-topic/9");
@@ -454,98 +453,91 @@ QUnit.test("Composer can toggle whispers", async (assert) => {
   );
 });
 
-QUnit.test(
-  "Composer can toggle layouts (open, fullscreen and draft)",
-  async (assert) => {
-    await visit("/t/this-is-a-test-topic/9");
-    await click(".topic-post:eq(0) button.reply");
+test("Composer can toggle layouts (open, fullscreen and draft)", async (assert) => {
+  await visit("/t/this-is-a-test-topic/9");
+  await click(".topic-post:eq(0) button.reply");
 
-    assert.ok(
-      find("#reply-control.open").length === 1,
-      "it starts in open state by default"
-    );
+  assert.ok(
+    find("#reply-control.open").length === 1,
+    "it starts in open state by default"
+  );
 
-    await click(".toggle-fullscreen");
+  await click(".toggle-fullscreen");
 
-    assert.ok(
-      find("#reply-control.fullscreen").length === 1,
-      "it expands composer to full screen"
-    );
+  assert.ok(
+    find("#reply-control.fullscreen").length === 1,
+    "it expands composer to full screen"
+  );
 
-    await click(".toggle-fullscreen");
+  await click(".toggle-fullscreen");
 
-    assert.ok(
-      find("#reply-control.open").length === 1,
-      "it collapses composer to regular size"
-    );
+  assert.ok(
+    find("#reply-control.open").length === 1,
+    "it collapses composer to regular size"
+  );
 
-    await fillIn(".d-editor-input", "This is a dirty reply");
-    await click(".toggler");
+  await fillIn(".d-editor-input", "This is a dirty reply");
+  await click(".toggler");
 
-    assert.ok(
-      find("#reply-control.draft").length === 1,
-      "it collapses composer to draft bar"
-    );
+  assert.ok(
+    find("#reply-control.draft").length === 1,
+    "it collapses composer to draft bar"
+  );
 
-    await click(".toggle-fullscreen");
+  await click(".toggle-fullscreen");
 
-    assert.ok(
-      find("#reply-control.open").length === 1,
-      "from draft, it expands composer back to open state"
-    );
-  }
-);
+  assert.ok(
+    find("#reply-control.open").length === 1,
+    "from draft, it expands composer back to open state"
+  );
+});
 
-QUnit.test(
-  "Composer can toggle between reply and createTopic",
-  async (assert) => {
-    await visit("/t/this-is-a-test-topic/9");
-    await click(".topic-post:eq(0) button.reply");
+test("Composer can toggle between reply and createTopic", async (assert) => {
+  await visit("/t/this-is-a-test-topic/9");
+  await click(".topic-post:eq(0) button.reply");
 
-    await selectKit(".toolbar-popup-menu-options").expand();
-    await selectKit(".toolbar-popup-menu-options").selectRowByValue(
-      "toggleWhisper"
-    );
+  await selectKit(".toolbar-popup-menu-options").expand();
+  await selectKit(".toolbar-popup-menu-options").selectRowByValue(
+    "toggleWhisper"
+  );
 
-    assert.ok(
-      find(".composer-fields .whisper .d-icon-far-eye-slash").length === 1,
-      "it sets the post type to whisper"
-    );
+  assert.ok(
+    find(".composer-fields .whisper .d-icon-far-eye-slash").length === 1,
+    "it sets the post type to whisper"
+  );
 
-    await visit("/");
-    assert.ok(exists("#create-topic"), "the create topic button is visible");
+  await visit("/");
+  assert.ok(exists("#create-topic"), "the create topic button is visible");
 
-    await click("#create-topic");
-    assert.ok(
-      find(".composer-fields .whisper .d-icon-far-eye-slash").length === 0,
-      "it should reset the state of the composer's model"
-    );
+  await click("#create-topic");
+  assert.ok(
+    find(".composer-fields .whisper .d-icon-far-eye-slash").length === 0,
+    "it should reset the state of the composer's model"
+  );
 
-    await selectKit(".toolbar-popup-menu-options").expand();
-    await selectKit(".toolbar-popup-menu-options").selectRowByValue(
-      "toggleInvisible"
-    );
+  await selectKit(".toolbar-popup-menu-options").expand();
+  await selectKit(".toolbar-popup-menu-options").selectRowByValue(
+    "toggleInvisible"
+  );
 
-    assert.ok(
-      find(".composer-fields .unlist")
-        .text()
-        .indexOf(I18n.t("composer.unlist")) > 0,
-      "it sets the topic to unlisted"
-    );
+  assert.ok(
+    find(".composer-fields .unlist").text().indexOf(I18n.t("composer.unlist")) >
+      0,
+    "it sets the topic to unlisted"
+  );
 
-    await visit("/t/this-is-a-test-topic/9");
+  await visit("/t/this-is-a-test-topic/9");
 
-    await click(".topic-post:eq(0) button.reply");
-    assert.ok(
-      find(".composer-fields .whisper")
-        .text()
-        .indexOf(I18n.t("composer.unlist")) === -1,
-      "it should reset the state of the composer's model"
-    );
-  }
-);
+  await click(".topic-post:eq(0) button.reply");
+  assert.ok(
+    find(".composer-fields .whisper")
+      .text()
+      .indexOf(I18n.t("composer.unlist")) === -1,
+    "it should reset the state of the composer's model"
+  );
+});
 
-QUnit.test("Composer with dirty reply can toggle to edit", async (assert) => {
+test("Composer with dirty reply can toggle to edit", async (assert) => {
   await visit("/t/this-is-a-test-topic/9");
 
   await click(".topic-post:eq(0) button.reply");
@@ -560,55 +552,49 @@ QUnit.test("Composer with dirty reply can toggle to edit", async (assert) => {
   );
 });
 
-QUnit.test(
-  "Composer draft with dirty reply can toggle to edit",
-  async (assert) => {
-    await visit("/t/this-is-a-test-topic/9");
+test("Composer draft with dirty reply can toggle to edit", async (assert) => {
+  await visit("/t/this-is-a-test-topic/9");
 
-    await click(".topic-post:eq(0) button.reply");
-    await fillIn(".d-editor-input", "This is a dirty reply");
-    await click(".toggler");
-    await click(".topic-post:eq(1) button.edit");
-    assert.ok(exists(".bootbox.modal"), "it pops up a confirmation dialog");
-    assert.equal(
-      find(".modal-footer a:eq(1)").text(),
-      I18n.t("post.abandon.no_value")
-    );
-    await click(".modal-footer a:eq(0)");
-    assert.equal(
-      find(".d-editor-input").val().indexOf("This is the second post."),
-      0,
-      "it populates the input with the post text"
-    );
-  }
-);
+  await click(".topic-post:eq(0) button.reply");
+  await fillIn(".d-editor-input", "This is a dirty reply");
+  await click(".toggler");
+  await click(".topic-post:eq(1) button.edit");
+  assert.ok(exists(".bootbox.modal"), "it pops up a confirmation dialog");
+  assert.equal(
+    find(".modal-footer a:eq(1)").text(),
+    I18n.t("post.abandon.no_value")
+  );
+  await click(".modal-footer a:eq(0)");
+  assert.equal(
+    find(".d-editor-input").val().indexOf("This is the second post."),
+    0,
+    "it populates the input with the post text"
+  );
+});
 
-QUnit.test(
-  "Composer draft can switch to draft in new context without destroying current draft",
-  async (assert) => {
-    await visit("/t/this-is-a-test-topic/9");
+test("Composer draft can switch to draft in new context without destroying current draft", async (assert) => {
+  await visit("/t/this-is-a-test-topic/9");
 
-    await click(".topic-post:eq(0) button.reply");
-    await fillIn(".d-editor-input", "This is a dirty reply");
+  await click(".topic-post:eq(0) button.reply");
+  await fillIn(".d-editor-input", "This is a dirty reply");
 
-    await click("#site-logo");
-    await click("#create-topic");
+  await click("#site-logo");
+  await click("#create-topic");
 
-    assert.ok(exists(".bootbox.modal"), "it pops up a confirmation dialog");
-    assert.equal(
-      find(".modal-footer a:eq(1)").text(),
-      I18n.t("post.abandon.no_save_draft")
-    );
-    await click(".modal-footer a:eq(1)");
-    assert.equal(
-      find(".d-editor-input").val(),
-      "",
-      "it populates the input with the post text"
-    );
-  }
-);
+  assert.ok(exists(".bootbox.modal"), "it pops up a confirmation dialog");
+  assert.equal(
+    find(".modal-footer a:eq(1)").text(),
+    I18n.t("post.abandon.no_save_draft")
+  );
+  await click(".modal-footer a:eq(1)");
+  assert.equal(
+    find(".d-editor-input").val(),
+    "",
+    "it populates the input with the post text"
+  );
+});
 
-QUnit.test("Checks for existing draft", async (assert) => {
+test("Checks for existing draft", async (assert) => {
   try {
     toggleCheckDraftPopup(true);
 
@@ -625,7 +611,7 @@ QUnit.test("Checks for existing draft", async (assert) => {
   }
 });
 
-QUnit.test("Can switch states without abandon popup", async (assert) => {
+test("Can switch states without abandon popup", async (assert) => {
   try {
     toggleCheckDraftPopup(true);
 
@@ -673,7 +659,7 @@ QUnit.test("Can switch states without abandon popup", async (assert) => {
   sandbox.restore();
 });
 
-QUnit.test("Loading draft also replaces the recipients", async (assert) => {
+test("Loading draft also replaces the recipients", async (assert) => {
   try {
     toggleCheckDraftPopup(true);
 
@@ -695,24 +681,21 @@ QUnit.test("Loading draft also replaces the recipients", async (assert) => {
   }
 });
 
-QUnit.test(
-  "Deleting the text content of the first post in a private message",
-  async (assert) => {
-    await visit("/t/34");
+test("Deleting the text content of the first post in a private message", async (assert) => {
+  await visit("/t/34");
 
-    await click("#post_1 .d-icon-ellipsis-h");
+  await click("#post_1 .d-icon-ellipsis-h");
 
-    await click("#post_1 .d-icon-pencil-alt");
+  await click("#post_1 .d-icon-pencil-alt");
 
-    await fillIn(".d-editor-input", "");
+  await fillIn(".d-editor-input", "");
 
-    assert.equal(
-      find(".d-editor-container textarea").attr("placeholder"),
-      I18n.t("composer.reply_placeholder"),
-      "it should not block because of missing category"
-    );
-  }
-);
+  assert.equal(
+    find(".d-editor-container textarea").attr("placeholder"),
+    I18n.t("composer.reply_placeholder"),
+    "it should not block because of missing category"
+  );
+});
 
 const assertImageResized = (assert, uploads) => {
   assert.equal(
@@ -722,7 +705,7 @@ const assertImageResized = (assert, uploads) => {
   );
 };
 
-QUnit.test("Image resizing buttons", async (assert) => {
+test("Image resizing buttons", async (assert) => {
   await visit("/");
   await click("#create-topic");
 
@@ -828,7 +811,7 @@ QUnit.test("Image resizing buttons", async (assert) => {
   );
 });
 
-QUnit.test("can reply to a private message", async (assert) => {
+test("can reply to a private message", async (assert) => {
   let submitted;
 
   /* global server */

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-topic-links-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-topic-links-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import {
   acceptance,
   updateCurrentUser,
@@ -12,7 +13,7 @@ acceptance("Composer topic featured links", {
   },
 });
 
-QUnit.test("onebox with title", async (assert) => {
+test("onebox with title", async (assert) => {
   await visit("/");
   await click("#create-topic");
   await fillIn("#reply-title", "http://www.example.com/has-title.html");
@@ -31,7 +32,7 @@ QUnit.test("onebox with title", async (assert) => {
   );
 });
 
-QUnit.test("onebox result doesn't include a title", async (assert) => {
+test("onebox result doesn't include a title", async (assert) => {
   await visit("/");
   await click("#create-topic");
   await fillIn("#reply-title", "http://www.example.com/no-title.html");
@@ -50,7 +51,7 @@ QUnit.test("onebox result doesn't include a title", async (assert) => {
   );
 });
 
-QUnit.test("no onebox result", async (assert) => {
+test("no onebox result", async (assert) => {
   await visit("/");
   await click("#create-topic");
   await fillIn("#reply-title", "http://www.example.com/nope-onebox.html");
@@ -69,7 +70,7 @@ QUnit.test("no onebox result", async (assert) => {
   );
 });
 
-QUnit.test("ignore internal links", async (assert) => {
+test("ignore internal links", async (assert) => {
   await visit("/");
   await click("#create-topic");
   const title = "http://" + window.location.hostname + "/internal-page.html";
@@ -87,7 +88,7 @@ QUnit.test("ignore internal links", async (assert) => {
   assert.equal(find(".title-input input").val(), title, "title is unchanged");
 });
 
-QUnit.test("link is longer than max title length", async (assert) => {
+test("link is longer than max title length", async (assert) => {
   await visit("/");
   await click("#create-topic");
   await fillIn(
@@ -109,29 +110,26 @@ QUnit.test("link is longer than max title length", async (assert) => {
   );
 });
 
-QUnit.test(
-  "onebox with title but extra words in title field",
-  async (assert) => {
-    await visit("/");
-    await click("#create-topic");
-    await fillIn("#reply-title", "http://www.example.com/has-title.html test");
-    assert.equal(
-      find(".d-editor-preview").html().trim().indexOf("onebox"),
-      -1,
-      "onebox preview doesn't show"
-    );
-    assert.equal(
-      find(".d-editor-input").val().length,
-      0,
-      "link isn't put into the post"
-    );
-    assert.equal(
-      find(".title-input input").val(),
-      "http://www.example.com/has-title.html test",
-      "title is unchanged"
-    );
-  }
-);
+test("onebox with title but extra words in title field", async (assert) => {
+  await visit("/");
+  await click("#create-topic");
+  await fillIn("#reply-title", "http://www.example.com/has-title.html test");
+  assert.equal(
+    find(".d-editor-preview").html().trim().indexOf("onebox"),
+    -1,
+    "onebox preview doesn't show"
+  );
+  assert.equal(
+    find(".d-editor-input").val().length,
+    0,
+    "link isn't put into the post"
+  );
+  assert.equal(
+    find(".title-input input").val(),
+    "http://www.example.com/has-title.html test",
+    "title is unchanged"
+  );
+});
 
 acceptance("Composer topic featured links when uncategorized is not allowed", {
   loggedIn: true,
@@ -143,7 +141,7 @@ acceptance("Composer topic featured links when uncategorized is not allowed", {
   },
 });
 
-QUnit.test("Pasting a link enables the text input area", async (assert) => {
+test("Pasting a link enables the text input area", async (assert) => {
   updateCurrentUser({ moderator: false, admin: false, trust_level: 1 });
 
   await visit("/");

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-uncategorized-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-uncategorized-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import {
   acceptance,
@@ -15,7 +16,7 @@ acceptance(
   }
 );
 
-QUnit.test("Disable body until category is selected", async (assert) => {
+test("Disable body until category is selected", async (assert) => {
   updateCurrentUser({ moderator: false, admin: false, trust_level: 1 });
 
   await visit("/");
@@ -86,36 +87,33 @@ acceptance(
   }
 );
 
-QUnit.test(
-  "Enable composer/body if no topic templates present",
-  async (assert) => {
-    updateCurrentUser({ moderator: false, admin: false, trust_level: 1 });
+test("Enable composer/body if no topic templates present", async (assert) => {
+  updateCurrentUser({ moderator: false, admin: false, trust_level: 1 });
 
-    await visit("/");
-    await click("#create-topic");
-    assert.ok(exists(".d-editor-input"), "the composer input is visible");
-    assert.ok(
-      exists(".category-input .popup-tip.bad.hide"),
-      "category errors are hidden by default"
-    );
-    assert.ok(
-      find(".d-editor-textarea-wrapper.disabled").length === 0,
-      "textarea is enabled"
-    );
+  await visit("/");
+  await click("#create-topic");
+  assert.ok(exists(".d-editor-input"), "the composer input is visible");
+  assert.ok(
+    exists(".category-input .popup-tip.bad.hide"),
+    "category errors are hidden by default"
+  );
+  assert.ok(
+    find(".d-editor-textarea-wrapper.disabled").length === 0,
+    "textarea is enabled"
+  );
 
-    await click("#reply-control button.create");
-    assert.ok(
-      exists(".category-input .popup-tip.bad"),
-      "it shows the choose a category error"
-    );
+  await click("#reply-control button.create");
+  assert.ok(
+    exists(".category-input .popup-tip.bad"),
+    "it shows the choose a category error"
+  );
 
-    const categoryChooser = selectKit(".category-chooser");
-    await categoryChooser.expand();
-    await categoryChooser.selectRowByValue(1);
+  const categoryChooser = selectKit(".category-chooser");
+  await categoryChooser.expand();
+  await categoryChooser.selectRowByValue(1);
 
-    assert.ok(
-      !exists(".category-input .popup-tip.bad"),
-      "category error removed after selecting category"
-    );
-  }
-);
+  assert.ok(
+    !exists(".category-input .popup-tip.bad"),
+    "category error removed after selecting category"
+  );
+});

--- a/app/assets/javascripts/discourse/tests/acceptance/create-account-external-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/create-account-external-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Create Account - external auth", {
@@ -19,7 +20,7 @@ acceptance("Create Account - external auth", {
   },
 });
 
-QUnit.test("when skip is disabled (default)", async (assert) => {
+test("when skip is disabled (default)", async (assert) => {
   await visit("/");
 
   assert.ok(
@@ -30,7 +31,7 @@ QUnit.test("when skip is disabled (default)", async (assert) => {
   assert.ok(exists("#new-account-username"), "it shows the fields");
 });
 
-QUnit.test("when skip is enabled", async function (assert) {
+test("when skip is enabled", async function (assert) {
   this.siteSettings.external_auth_skip_create_confirm = true;
   await visit("/");
 

--- a/app/assets/javascripts/discourse/tests/acceptance/create-account-user-fields-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/create-account-user-fields-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Create Account - User Fields", {
@@ -25,7 +26,7 @@ acceptance("Create Account - User Fields", {
   },
 });
 
-QUnit.test("create account with user fields", async (assert) => {
+test("create account with user fields", async (assert) => {
   await visit("/");
   await click("header .sign-up-button");
 

--- a/app/assets/javascripts/discourse/tests/acceptance/custom-html-set-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/custom-html-set-test.js
@@ -1,15 +1,16 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import { setCustomHTML } from "discourse/helpers/custom-html";
 import PreloadStore from "discourse/lib/preload-store";
 
 acceptance("CustomHTML set");
 
-QUnit.test("has no custom HTML in the top", async (assert) => {
+test("has no custom HTML in the top", async (assert) => {
   await visit("/static/faq");
   assert.ok(!exists("span.custom-html-test"), "it has no markup");
 });
 
-QUnit.test("renders set HTML", async (assert) => {
+test("renders set HTML", async (assert) => {
   setCustomHTML("top", '<span class="custom-html-test">HTML</span>');
 
   await visit("/static/faq");
@@ -20,7 +21,7 @@ QUnit.test("renders set HTML", async (assert) => {
   );
 });
 
-QUnit.test("renders preloaded HTML", async (assert) => {
+test("renders preloaded HTML", async (assert) => {
   PreloadStore.store("customHTML", {
     top: "<span class='cookie'>monster</span>",
   });

--- a/app/assets/javascripts/discourse/tests/acceptance/custom-html-template-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/custom-html-template-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("CustomHTML template", {
@@ -12,7 +13,7 @@ acceptance("CustomHTML template", {
   },
 });
 
-QUnit.test("renders custom template", async (assert) => {
+test("renders custom template", async (assert) => {
   await visit("/static/faq");
   assert.equal(find("span.top-span").text(), "TOP", "it inserted the template");
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/dashboard-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/dashboard-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
@@ -21,13 +22,13 @@ acceptance("Dashboard", {
   },
 });
 
-QUnit.test("default", async (assert) => {
+test("default", async (assert) => {
   await visit("/admin");
 
   assert.ok(exists(".dashboard"), "has dashboard-next class");
 });
 
-QUnit.test("tabs", async (assert) => {
+test("tabs", async (assert) => {
   await visit("/admin");
 
   assert.ok(exists(".dashboard .navigation-item.general"), "general tab");
@@ -36,7 +37,7 @@ QUnit.test("tabs", async (assert) => {
   assert.ok(exists(".dashboard .navigation-item.reports"), "reports tab");
 });
 
-QUnit.test("general tab", async (assert) => {
+test("general tab", async (assert) => {
   await visit("/admin");
   assert.ok(exists(".admin-report.signups"), "signups report");
   assert.ok(exists(".admin-report.posts"), "posts report");
@@ -59,7 +60,7 @@ QUnit.test("general tab", async (assert) => {
   );
 });
 
-QUnit.test("activity metrics", async (assert) => {
+test("activity metrics", async (assert) => {
   await visit("/admin");
 
   assert.ok(exists(".admin-report.page-view-total-reqs .today-count"));
@@ -68,7 +69,7 @@ QUnit.test("activity metrics", async (assert) => {
   assert.ok(exists(".admin-report.page-view-total-reqs .thirty-days-count"));
 });
 
-QUnit.test("reports tab", async (assert) => {
+test("reports tab", async (assert) => {
   await visit("/admin");
   await click(".dashboard .navigation-item.reports .navigation-link");
 
@@ -102,7 +103,7 @@ QUnit.test("reports tab", async (assert) => {
   );
 });
 
-QUnit.test("reports filters", async (assert) => {
+test("reports filters", async (assert) => {
   await visit(
     '/admin/reports/signups_with_groups?end_date=2018-07-16&filters=%7B"group"%3A88%7D&start_date=2018-06-16'
   );
@@ -123,7 +124,7 @@ acceptance("Dashboard: dashboard_visible_tabs", {
   },
 });
 
-QUnit.test("visible tabs", async (assert) => {
+test("visible tabs", async (assert) => {
   await visit("/admin");
 
   assert.ok(exists(".dashboard .navigation-item.general"), "general tab");
@@ -143,7 +144,7 @@ acceptance("Dashboard: dashboard_hidden_reports", {
   },
 });
 
-QUnit.test("hidden reports", async (assert) => {
+test("hidden reports", async (assert) => {
   await visit("/admin");
 
   assert.ok(exists(".admin-report.signups.is-visible"), "signups report");

--- a/app/assets/javascripts/discourse/tests/acceptance/email-notice-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/email-notice-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import {
   acceptance,
   updateCurrentUser,
@@ -7,7 +8,7 @@ acceptance("Email Disabled Banner", {
   loggedIn: true,
 });
 
-QUnit.test("when disabled", async function (assert) {
+test("when disabled", async function (assert) {
   this.siteSettings.disable_emails = "no";
   await visit("/");
   assert.notOk(
@@ -16,7 +17,7 @@ QUnit.test("when disabled", async function (assert) {
   );
 });
 
-QUnit.test("when enabled", async function (assert) {
+test("when enabled", async function (assert) {
   this.siteSettings.disable_emails = "yes";
   await visit("/latest");
   assert.ok(
@@ -25,7 +26,7 @@ QUnit.test("when enabled", async function (assert) {
   );
 });
 
-QUnit.test("when non-staff", async function (assert) {
+test("when non-staff", async function (assert) {
   this.siteSettings.disable_emails = "non-staff";
   await visit("/");
   assert.ok(

--- a/app/assets/javascripts/discourse/tests/acceptance/emoji-picker-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/emoji-picker-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("EmojiPicker", {
@@ -11,7 +12,7 @@ acceptance("EmojiPicker", {
   },
 });
 
-QUnit.test("emoji picker can be opened/closed", async (assert) => {
+test("emoji picker can be opened/closed", async (assert) => {
   await visit("/t/internationalization-localization/280");
   await click("#topic-footer-buttons .btn.create");
 
@@ -22,7 +23,7 @@ QUnit.test("emoji picker can be opened/closed", async (assert) => {
   assert.notOk(exists(".emoji-picker.opened"), "it closes the picker");
 });
 
-QUnit.test("emoji picker triggers event when picking emoji", async (assert) => {
+test("emoji picker triggers event when picking emoji", async (assert) => {
   await visit("/t/internationalization-localization/280");
   await click("#topic-footer-buttons .btn.create");
   await click("button.emoji.btn");
@@ -35,101 +36,92 @@ QUnit.test("emoji picker triggers event when picking emoji", async (assert) => {
   );
 });
 
-QUnit.test(
-  "emoji picker adds leading whitespace before emoji",
-  async (assert) => {
-    await visit("/t/internationalization-localization/280");
-    await click("#topic-footer-buttons .btn.create");
+test("emoji picker adds leading whitespace before emoji", async (assert) => {
+  await visit("/t/internationalization-localization/280");
+  await click("#topic-footer-buttons .btn.create");
 
-    // Whitespace should be added on text
-    await fillIn(".d-editor-input", "This is a test input");
-    await click("button.emoji.btn");
-    await click(".emoji-picker-emoji-area img.emoji[title='grinning']");
-    assert.equal(
-      find(".d-editor-input").val(),
-      "This is a test input :grinning:",
-      "it adds the emoji code and a leading whitespace when there is text"
-    );
+  // Whitespace should be added on text
+  await fillIn(".d-editor-input", "This is a test input");
+  await click("button.emoji.btn");
+  await click(".emoji-picker-emoji-area img.emoji[title='grinning']");
+  assert.equal(
+    find(".d-editor-input").val(),
+    "This is a test input :grinning:",
+    "it adds the emoji code and a leading whitespace when there is text"
+  );
 
-    // Whitespace should not be added on whitespace
-    await fillIn(".d-editor-input", "This is a test input ");
-    await click(".emoji-picker-emoji-area img.emoji[title='grinning']");
+  // Whitespace should not be added on whitespace
+  await fillIn(".d-editor-input", "This is a test input ");
+  await click(".emoji-picker-emoji-area img.emoji[title='grinning']");
 
-    assert.equal(
-      find(".d-editor-input").val(),
-      "This is a test input :grinning:",
-      "it adds the emoji code and no leading whitespace when user already entered whitespace"
-    );
-  }
-);
+  assert.equal(
+    find(".d-editor-input").val(),
+    "This is a test input :grinning:",
+    "it adds the emoji code and no leading whitespace when user already entered whitespace"
+  );
+});
 
-QUnit.test(
-  "emoji picker has a list of recently used emojis",
-  async (assert) => {
-    await visit("/t/internationalization-localization/280");
-    await click("#topic-footer-buttons .btn.create");
-    await click("button.emoji.btn");
-    await click(".emoji-picker-emoji-area img.emoji[title='grinning']");
+test("emoji picker has a list of recently used emojis", async (assert) => {
+  await visit("/t/internationalization-localization/280");
+  await click("#topic-footer-buttons .btn.create");
+  await click("button.emoji.btn");
+  await click(".emoji-picker-emoji-area img.emoji[title='grinning']");
 
-    assert.ok(
-      exists(
-        ".emoji-picker .section.recent .section-group img.emoji[title='grinning']"
-      ),
-      "it shows recent selected emoji"
-    );
+  assert.ok(
+    exists(
+      ".emoji-picker .section.recent .section-group img.emoji[title='grinning']"
+    ),
+    "it shows recent selected emoji"
+  );
 
-    assert.ok(
-      exists('.emoji-picker .category-button[data-section="recent"]'),
-      "it shows recent category icon"
-    );
+  assert.ok(
+    exists('.emoji-picker .category-button[data-section="recent"]'),
+    "it shows recent category icon"
+  );
 
-    await click(".emoji-picker .trash-recent");
+  await click(".emoji-picker .trash-recent");
 
-    assert.notOk(
-      exists(
-        ".emoji-picker .section.recent .section-group img.emoji[title='grinning']"
-      ),
-      "it has cleared recent emojis"
-    );
+  assert.notOk(
+    exists(
+      ".emoji-picker .section.recent .section-group img.emoji[title='grinning']"
+    ),
+    "it has cleared recent emojis"
+  );
 
-    assert.notOk(
-      exists('.emoji-picker .section[data-section="recent"]'),
-      "it hides recent section"
-    );
+  assert.notOk(
+    exists('.emoji-picker .section[data-section="recent"]'),
+    "it hides recent section"
+  );
 
-    assert.notOk(
-      exists('.emoji-picker .category-button[data-section="recent"]'),
-      "it hides recent category icon"
-    );
-  }
-);
+  assert.notOk(
+    exists('.emoji-picker .category-button[data-section="recent"]'),
+    "it hides recent category icon"
+  );
+});
 
-QUnit.test(
-  "emoji picker correctly orders recently used emojis",
-  async (assert) => {
-    await visit("/t/internationalization-localization/280");
-    await click("#topic-footer-buttons .btn.create");
-    await click("button.emoji.btn");
-    await click(".emoji-picker-emoji-area img.emoji[title='sunglasses']");
-    await click(".emoji-picker-emoji-area img.emoji[title='grinning']");
+test("emoji picker correctly orders recently used emojis", async (assert) => {
+  await visit("/t/internationalization-localization/280");
+  await click("#topic-footer-buttons .btn.create");
+  await click("button.emoji.btn");
+  await click(".emoji-picker-emoji-area img.emoji[title='sunglasses']");
+  await click(".emoji-picker-emoji-area img.emoji[title='grinning']");
 
-    assert.equal(
-      find('.section[data-section="recent"] .section-group img.emoji').length,
-      2,
-      "it has multiple recent emojis"
-    );
+  assert.equal(
+    find('.section[data-section="recent"] .section-group img.emoji').length,
+    2,
+    "it has multiple recent emojis"
+  );
 
-    assert.equal(
-      /grinning/.test(
-        find(".section.recent .section-group img.emoji").first().attr("src")
-      ),
-      true,
-      "it puts the last used emoji in first"
-    );
-  }
-);
+  assert.equal(
+    /grinning/.test(
+      find(".section.recent .section-group img.emoji").first().attr("src")
+    ),
+    true,
+    "it puts the last used emoji in first"
+  );
+});
 
-QUnit.test("emoji picker persists state", async (assert) => {
+test("emoji picker persists state", async (assert) => {
   await visit("/t/internationalization-localization/280");
   await click("#topic-footer-buttons .btn.create");
   await click("button.emoji.btn");

--- a/app/assets/javascripts/discourse/tests/acceptance/emoji-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/emoji-test.js
@@ -1,9 +1,10 @@
+import { test } from "qunit";
 import { IMAGE_VERSION as v } from "pretty-text/emoji/version";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Emoji", { loggedIn: true });
 
-QUnit.test("emoji is cooked properly", async (assert) => {
+test("emoji is cooked properly", async (assert) => {
   await visit("/t/internationalization-localization/280");
   await click("#topic-footer-buttons .btn.create");
 
@@ -14,7 +15,7 @@ QUnit.test("emoji is cooked properly", async (assert) => {
   );
 });
 
-QUnit.test("skin toned emoji is cooked properly", async (assert) => {
+test("skin toned emoji is cooked properly", async (assert) => {
   await visit("/t/internationalization-localization/280");
   await click("#topic-footer-buttons .btn.create");
 

--- a/app/assets/javascripts/discourse/tests/acceptance/encoded-category-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/encoded-category-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import DiscoveryFixtures from "discourse/tests/fixtures/discovery-fixtures";
 
@@ -41,7 +42,7 @@ acceptance("Encoded Sub Category Discovery", {
   },
 });
 
-QUnit.test("Visit subcategory by slug", async (assert) => {
+test("Visit subcategory by slug", async (assert) => {
   let bodySelector =
     "body.category-\\%E6\\%BC\\%A2\\%E5\\%AD\\%97-parent-\\%E6\\%BC\\%A2\\%E5\\%AD\\%97-subcategory";
   await visit("/c/%E6%BC%A2%E5%AD%97-parent/%E6%BC%A2%E5%AD%97-subcategory");

--- a/app/assets/javascripts/discourse/tests/acceptance/enforce-second-factor-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/enforce-second-factor-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import {
   acceptance,
   updateCurrentUser,
@@ -15,7 +16,7 @@ acceptance("Enforce Second Factor", {
   },
 });
 
-QUnit.test("as an admin", async function (assert) {
+test("as an admin", async function (assert) {
   await visit("/u/eviltrout/preferences/second-factor");
   this.siteSettings.enforce_second_factor = "staff";
 
@@ -37,7 +38,7 @@ QUnit.test("as an admin", async function (assert) {
   );
 });
 
-QUnit.test("as a user", async function (assert) {
+test("as a user", async function (assert) {
   updateCurrentUser({ moderator: false, admin: false });
 
   await visit("/u/eviltrout/preferences/second-factor");
@@ -61,7 +62,7 @@ QUnit.test("as a user", async function (assert) {
   );
 });
 
-QUnit.test("as an anonymous user", async function (assert) {
+test("as an anonymous user", async function (assert) {
   updateCurrentUser({ moderator: false, admin: false, is_anonymous: true });
 
   await visit("/u/eviltrout/preferences/second-factor");

--- a/app/assets/javascripts/discourse/tests/acceptance/forgot-password-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/forgot-password-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import I18n from "I18n";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
@@ -13,7 +14,7 @@ acceptance("Forgot password", {
   },
 });
 
-QUnit.test("requesting password reset", async (assert) => {
+test("requesting password reset", async (assert) => {
   await visit("/");
   await click("header .login-button");
   await click("#forgot-password-link");

--- a/app/assets/javascripts/discourse/tests/acceptance/group-card-mobile-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-card-mobile-test.js
@@ -1,9 +1,10 @@
+import { skip } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import DiscourseURL from "discourse/lib/url";
 
 acceptance("Group Card - Mobile", { mobileView: true });
 
-QUnit.skip("group card", async (assert) => {
+skip("group card", async (assert) => {
   await visit("/t/-/301/1");
   assert.ok(
     invisible(".group-card"),

--- a/app/assets/javascripts/discourse/tests/acceptance/group-card-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-card-test.js
@@ -1,9 +1,10 @@
+import { skip } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import DiscourseURL from "discourse/lib/url";
 
 acceptance("Group Card");
 
-QUnit.skip("group card", async (assert) => {
+skip("group card", async (assert) => {
   await visit("/t/-/301/1");
   assert.ok(invisible(".group-card"), "user card is invisible by default");
 

--- a/app/assets/javascripts/discourse/tests/acceptance/group-index-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-index-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import I18n from "I18n";
 import {
   acceptance,
@@ -6,7 +7,7 @@ import {
 
 acceptance("Group Members");
 
-QUnit.test("Viewing Members as anon user", async (assert) => {
+test("Viewing Members as anon user", async (assert) => {
   await visit("/g/discourse");
 
   assert.ok(
@@ -29,7 +30,7 @@ QUnit.test("Viewing Members as anon user", async (assert) => {
 
 acceptance("Group Members", { loggedIn: true });
 
-QUnit.test("Viewing Members as a group owner", async (assert) => {
+test("Viewing Members as a group owner", async (assert) => {
   updateCurrentUser({ moderator: false, admin: false });
 
   await visit("/g/discourse");
@@ -42,7 +43,7 @@ QUnit.test("Viewing Members as a group owner", async (assert) => {
   );
 });
 
-QUnit.test("Viewing Members as an admin user", async (assert) => {
+test("Viewing Members as an admin user", async (assert) => {
   await visit("/g/discourse");
 
   assert.ok(

--- a/app/assets/javascripts/discourse/tests/acceptance/group-manage-categories-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-manage-categories-test.js
@@ -1,10 +1,11 @@
+import { test } from "qunit";
 import {
   acceptance,
   updateCurrentUser,
 } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Managing Group Category Notification Defaults");
-QUnit.test("As an anonymous user", async (assert) => {
+test("As an anonymous user", async (assert) => {
   await visit("/g/discourse/manage/categories");
 
   assert.ok(
@@ -15,7 +16,7 @@ QUnit.test("As an anonymous user", async (assert) => {
 
 acceptance("Managing Group Category Notification Defaults", { loggedIn: true });
 
-QUnit.test("As an admin", async (assert) => {
+test("As an admin", async (assert) => {
   await visit("/g/discourse/manage/categories");
 
   assert.ok(
@@ -24,7 +25,7 @@ QUnit.test("As an admin", async (assert) => {
   );
 });
 
-QUnit.test("As a group owner", async (assert) => {
+test("As a group owner", async (assert) => {
   updateCurrentUser({ moderator: false, admin: false });
 
   await visit("/g/discourse/manage/categories");

--- a/app/assets/javascripts/discourse/tests/acceptance/group-manage-interaction-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-manage-interaction-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import {
   acceptance,
   updateCurrentUser,
@@ -10,7 +11,7 @@ acceptance("Managing Group Interaction Settings", {
   },
 });
 
-QUnit.test("As an admin", async (assert) => {
+test("As an admin", async (assert) => {
   updateCurrentUser({
     moderator: false,
     admin: true,
@@ -50,7 +51,7 @@ QUnit.test("As an admin", async (assert) => {
   );
 });
 
-QUnit.test("As a group owner", async (assert) => {
+test("As a group owner", async (assert) => {
   updateCurrentUser({
     moderator: false,
     admin: false,

--- a/app/assets/javascripts/discourse/tests/acceptance/group-manage-logs-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-manage-logs-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Group logs", {
@@ -92,7 +93,7 @@ acceptance("Group logs", {
   },
 });
 
-QUnit.test("Browsing group logs", async (assert) => {
+test("Browsing group logs", async (assert) => {
   await visit("/g/snorlax/manage/logs");
   assert.ok(
     find("tr.group-manage-logs-row").length === 2,

--- a/app/assets/javascripts/discourse/tests/acceptance/group-manage-membership-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-manage-membership-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import {
   acceptance,
   updateCurrentUser,
@@ -8,7 +9,7 @@ acceptance("Managing Group Membership", {
   loggedIn: true,
 });
 
-QUnit.test("As an admin", async (assert) => {
+test("As an admin", async (assert) => {
   updateCurrentUser({ can_create_group: true });
 
   await visit("/g/alternative-group/manage/membership");
@@ -75,7 +76,7 @@ QUnit.test("As an admin", async (assert) => {
   assert.equal(emailDomains.header().value(), "foo.com");
 });
 
-QUnit.test("As a group owner", async (assert) => {
+test("As a group owner", async (assert) => {
   updateCurrentUser({ moderator: false, admin: false });
 
   await visit("/g/discourse/manage/membership");

--- a/app/assets/javascripts/discourse/tests/acceptance/group-manage-profile-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-manage-profile-test.js
@@ -1,10 +1,11 @@
+import { test } from "qunit";
 import {
   acceptance,
   updateCurrentUser,
 } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Managing Group Profile");
-QUnit.test("As an anonymous user", async (assert) => {
+test("As an anonymous user", async (assert) => {
   await visit("/g/discourse/manage/profile");
 
   assert.ok(
@@ -15,7 +16,7 @@ QUnit.test("As an anonymous user", async (assert) => {
 
 acceptance("Managing Group Profile", { loggedIn: true });
 
-QUnit.test("As an admin", async (assert) => {
+test("As an admin", async (assert) => {
   await visit("/g/discourse/manage/profile");
 
   assert.ok(
@@ -36,7 +37,7 @@ QUnit.test("As an admin", async (assert) => {
   );
 });
 
-QUnit.test("As a group owner", async (assert) => {
+test("As a group owner", async (assert) => {
   updateCurrentUser({
     moderator: false,
     admin: false,

--- a/app/assets/javascripts/discourse/tests/acceptance/group-manage-tags-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-manage-tags-test.js
@@ -1,10 +1,11 @@
+import { test } from "qunit";
 import {
   acceptance,
   updateCurrentUser,
 } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Managing Group Tag Notification Defaults");
-QUnit.test("As an anonymous user", async (assert) => {
+test("As an anonymous user", async (assert) => {
   await visit("/g/discourse/manage/tags");
 
   assert.ok(
@@ -15,7 +16,7 @@ QUnit.test("As an anonymous user", async (assert) => {
 
 acceptance("Managing Group Tag Notification Defaults", { loggedIn: true });
 
-QUnit.test("As an admin", async (assert) => {
+test("As an admin", async (assert) => {
   await visit("/g/discourse/manage/tags");
 
   assert.ok(
@@ -24,7 +25,7 @@ QUnit.test("As an admin", async (assert) => {
   );
 });
 
-QUnit.test("As a group owner", async (assert) => {
+test("As a group owner", async (assert) => {
   updateCurrentUser({ moderator: false, admin: false });
 
   await visit("/g/discourse/manage/tags");

--- a/app/assets/javascripts/discourse/tests/acceptance/group-requests-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-requests-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import { parsePostData } from "discourse/tests/helpers/create-pretender";
 
@@ -80,7 +81,7 @@ acceptance("Group Requests", {
   },
 });
 
-QUnit.test("Group Requests", async (assert) => {
+test("Group Requests", async (assert) => {
   await visit("/g/Macdonald/requests");
 
   assert.equal(find(".group-members tr").length, 2);

--- a/app/assets/javascripts/discourse/tests/acceptance/group-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import I18n from "I18n";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
@@ -22,7 +23,7 @@ const response = (object) => {
   return [200, { "Content-Type": "application/json" }, object];
 };
 
-QUnit.test("Anonymous Viewing Group", async function (assert) {
+test("Anonymous Viewing Group", async function (assert) {
   await visit("/g/discourse");
 
   assert.equal(
@@ -77,7 +78,7 @@ QUnit.test("Anonymous Viewing Group", async function (assert) {
   );
 });
 
-QUnit.test("Anonymous Viewing Automatic Group", async (assert) => {
+test("Anonymous Viewing Automatic Group", async (assert) => {
   await visit("/g/moderators");
 
   assert.equal(
@@ -89,7 +90,7 @@ QUnit.test("Anonymous Viewing Automatic Group", async (assert) => {
 
 acceptance("Group", Object.assign({ loggedIn: true }, groupArgs));
 
-QUnit.test("User Viewing Group", async (assert) => {
+test("User Viewing Group", async (assert) => {
   await visit("/g");
   await click(".group-index-request");
 
@@ -122,28 +123,25 @@ QUnit.test("User Viewing Group", async (assert) => {
   );
 });
 
-QUnit.test(
-  "Admin viewing group messages when there are no messages",
-  async (assert) => {
-    pretender.get(
-      "/topics/private-messages-group/eviltrout/discourse.json",
-      () => {
-        return response({ topic_list: { topics: [] } });
-      }
-    );
+test("Admin viewing group messages when there are no messages", async (assert) => {
+  pretender.get(
+    "/topics/private-messages-group/eviltrout/discourse.json",
+    () => {
+      return response({ topic_list: { topics: [] } });
+    }
+  );
 
-    await visit("/g/discourse");
-    await click(".nav-pills li a[title='Messages']");
+  await visit("/g/discourse");
+  await click(".nav-pills li a[title='Messages']");
 
-    assert.equal(
-      find(".alert").text().trim(),
-      I18n.t("choose_topic.none_found"),
-      "it should display the right alert"
-    );
-  }
-);
+  assert.equal(
+    find(".alert").text().trim(),
+    I18n.t("choose_topic.none_found"),
+    "it should display the right alert"
+  );
+});
 
-QUnit.test("Admin viewing group messages", async (assert) => {
+test("Admin viewing group messages", async (assert) => {
   pretender.get(
     "/topics/private-messages-group/eviltrout/discourse.json",
     () => {
@@ -238,7 +236,7 @@ QUnit.test("Admin viewing group messages", async (assert) => {
   );
 });
 
-QUnit.test("Admin Viewing Group", async (assert) => {
+test("Admin Viewing Group", async (assert) => {
   await visit("/g/discourse");
 
   assert.ok(

--- a/app/assets/javascripts/discourse/tests/acceptance/groups-index-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/groups-index-test.js
@@ -1,8 +1,9 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Groups");
 
-QUnit.test("Browsing Groups", async (assert) => {
+test("Browsing Groups", async (assert) => {
   await visit("/g?username=eviltrout");
 
   assert.equal(count(".group-box"), 1, "it displays user's groups");

--- a/app/assets/javascripts/discourse/tests/acceptance/groups-new-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/groups-new-test.js
@@ -1,9 +1,10 @@
+import { test } from "qunit";
 import I18n from "I18n";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("New Group");
 
-QUnit.test("As an anon user", async (assert) => {
+test("As an anon user", async (assert) => {
   await visit("/g");
 
   assert.equal(
@@ -15,7 +16,7 @@ QUnit.test("As an anon user", async (assert) => {
 
 acceptance("New Group", { loggedIn: true });
 
-QUnit.test("Creating a new group", async (assert) => {
+test("Creating a new group", async (assert) => {
   await visit("/g");
   await click(".groups-header-new");
 

--- a/app/assets/javascripts/discourse/tests/acceptance/hamburger-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/hamburger-menu-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import {
   acceptance,
   updateCurrentUser,
@@ -10,7 +11,7 @@ acceptance("Opening the hamburger menu with some reviewables", {
   },
 });
 
-QUnit.test("As a staff member", async (assert) => {
+test("As a staff member", async (assert) => {
   updateCurrentUser({ moderator: true, admin: false });
 
   await visit("/");

--- a/app/assets/javascripts/discourse/tests/acceptance/hashtags-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/hashtags-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Category and Tag Hashtags", {
@@ -16,7 +17,7 @@ acceptance("Category and Tag Hashtags", {
   },
 });
 
-QUnit.test("hashtags are cooked properly", async (assert) => {
+test("hashtags are cooked properly", async (assert) => {
   await visit("/t/internationalization-localization/280");
   await click("#topic-footer-buttons .btn.create");
 

--- a/app/assets/javascripts/discourse/tests/acceptance/invite-accept-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/invite-accept-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import PreloadStore from "discourse/lib/preload-store";
 
@@ -7,7 +8,7 @@ acceptance("Invite Accept", {
   },
 });
 
-QUnit.test("Invite Acceptance Page", async (assert) => {
+test("Invite Acceptance Page", async (assert) => {
   PreloadStore.store("invite_info", {
     invited_by: {
       id: 123,

--- a/app/assets/javascripts/discourse/tests/acceptance/invite-show-user-fields-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/invite-show-user-fields-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import PreloadStore from "discourse/lib/preload-store";
 
@@ -26,7 +27,7 @@ acceptance("Accept Invite - User Fields", {
   },
 });
 
-QUnit.test("accept invite with user fields", async (assert) => {
+test("accept invite with user fields", async (assert) => {
   PreloadStore.store("invite_info", {
     invited_by: {
       id: 123,

--- a/app/assets/javascripts/discourse/tests/acceptance/jump-to-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/jump-to-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Jump to", {
@@ -20,7 +21,7 @@ acceptance("Jump to", {
   },
 });
 
-QUnit.test("default", async (assert) => {
+test("default", async (assert) => {
   await visit("/t/internationalization-localization/280");
   await click("nav#topic-progress .nums");
   await click("button.jump-to-post");
@@ -37,7 +38,7 @@ QUnit.test("default", async (assert) => {
   );
 });
 
-QUnit.test("invalid date", async (assert) => {
+test("invalid date", async (assert) => {
   await visit("/t/internationalization-localization/280");
   await click("nav#topic-progress .nums");
   await click("button.jump-to-post");

--- a/app/assets/javascripts/discourse/tests/acceptance/keyboard-shortcuts-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/keyboard-shortcuts-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import pretender from "discourse/tests/helpers/create-pretender";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/login-redirect-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/login-redirect-test.js
@@ -1,7 +1,8 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Login redirect");
-QUnit.test("redirects login to default homepage", async function (assert) {
+test("redirects login to default homepage", async function (assert) {
   await visit("/login");
   assert.equal(
     currentPath(),
@@ -16,7 +17,7 @@ acceptance("Login redirect - categories default", {
   },
 });
 
-QUnit.test("when site setting is categories", async function (assert) {
+test("when site setting is categories", async function (assert) {
   await visit("/login");
   assert.equal(
     currentPath(),

--- a/app/assets/javascripts/discourse/tests/acceptance/login-required-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/login-required-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Login Required", {
@@ -6,7 +7,7 @@ acceptance("Login Required", {
   },
 });
 
-QUnit.test("redirect", async (assert) => {
+test("redirect", async (assert) => {
   await visit("/latest");
   assert.equal(currentPath(), "login", "it redirects them to login");
 

--- a/app/assets/javascripts/discourse/tests/acceptance/login-with-email-and-hide-email-address-taken-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/login-with-email-and-hide-email-address-taken-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import I18n from "I18n";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import pretender from "discourse/tests/helpers/create-pretender";
@@ -18,7 +19,7 @@ acceptance("Login with email - hide email address taken", {
   },
 });
 
-QUnit.test("with hide_email_address_taken enabled", async (assert) => {
+test("with hide_email_address_taken enabled", async (assert) => {
   await visit("/");
   await click("header .login-button");
   await fillIn("#login-account-name", "someuser@example.com");

--- a/app/assets/javascripts/discourse/tests/acceptance/login-with-email-and-no-social-logins-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/login-with-email-and-no-social-logins-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Login with email - no social logins", {
@@ -9,14 +10,14 @@ acceptance("Login with email - no social logins", {
   },
 });
 
-QUnit.test("with login with email enabled", async (assert) => {
+test("with login with email enabled", async (assert) => {
   await visit("/");
   await click("header .login-button");
 
   assert.ok(exists(".login-with-email-button"));
 });
 
-QUnit.test("with login with email disabled", async (assert) => {
+test("with login with email disabled", async (assert) => {
   await visit("/");
   await click("header .login-button");
 

--- a/app/assets/javascripts/discourse/tests/acceptance/login-with-email-disabled-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/login-with-email-disabled-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Login with email disabled", {
@@ -7,7 +8,7 @@ acceptance("Login with email disabled", {
   },
 });
 
-QUnit.test("with email button", async (assert) => {
+test("with email button", async (assert) => {
   await visit("/");
   await click("header .login-button");
 

--- a/app/assets/javascripts/discourse/tests/acceptance/login-with-email-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/login-with-email-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import I18n from "I18n";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
@@ -15,7 +16,7 @@ acceptance("Login with email", {
   },
 });
 
-QUnit.test("with email button", async (assert) => {
+test("with email button", async (assert) => {
   await visit("/");
   await click("header .login-button");
 

--- a/app/assets/javascripts/discourse/tests/acceptance/mobile-discovery-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/mobile-discovery-test.js
@@ -1,7 +1,8 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 acceptance("Topic Discovery - Mobile", { mobileView: true });
 
-QUnit.test("Visit Discovery Pages", async (assert) => {
+test("Visit Discovery Pages", async (assert) => {
   await visit("/");
   assert.ok(exists(".topic-list"), "The list of topics was rendered");
   assert.ok(exists(".topic-list .topic-list-item"), "has topics");

--- a/app/assets/javascripts/discourse/tests/acceptance/mobile-sign-in-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/mobile-sign-in-test.js
@@ -1,8 +1,9 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Signing In - Mobile", { mobileView: true });
 
-QUnit.test("sign in", async (assert) => {
+test("sign in", async (assert) => {
   await visit("/");
   await click("header .login-button");
   assert.ok(exists("#login-form"), "it shows the login modal");

--- a/app/assets/javascripts/discourse/tests/acceptance/mobile-users-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/mobile-users-test.js
@@ -1,8 +1,9 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("User Directory - Mobile", { mobileView: true });
 
-QUnit.test("Visit Page", async (assert) => {
+test("Visit Page", async (assert) => {
   await visit("/u");
   assert.ok(exists(".directory .user"), "has a list of users");
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/modal-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/modal-test.js
@@ -1,3 +1,5 @@
+import { skip } from "qunit";
+import { test } from "qunit";
 import I18n from "I18n";
 import { run } from "@ember/runloop";
 import {
@@ -24,7 +26,7 @@ acceptance("Modal", {
   },
 });
 
-QUnit.skip("modal", async function (assert) {
+skip("modal", async function (assert) {
   await visit("/");
 
   assert.ok(
@@ -74,7 +76,7 @@ QUnit.skip("modal", async function (assert) {
   );
 });
 
-QUnit.test("rawTitle in modal panels", async function (assert) {
+test("rawTitle in modal panels", async function (assert) {
   Ember.TEMPLATES["modal/test-raw-title-panels"] = Ember.HTMLBars.compile("");
   const panels = [
     { id: "test1", rawTitle: "Test 1" },
@@ -91,7 +93,7 @@ QUnit.test("rawTitle in modal panels", async function (assert) {
   );
 });
 
-QUnit.test("modal title", async function (assert) {
+test("modal title", async function (assert) {
   Ember.TEMPLATES["modal/test-title"] = Ember.HTMLBars.compile("");
   Ember.TEMPLATES["modal/test-title-with-body"] = Ember.HTMLBars.compile(
     "{{#d-modal-body}}test{{/d-modal-body}}"
@@ -126,7 +128,7 @@ QUnit.test("modal title", async function (assert) {
 
 acceptance("Modal Keyboard Events", { loggedIn: true });
 
-QUnit.test("modal-keyboard-events", async function (assert) {
+test("modal-keyboard-events", async function (assert) {
   await visit("/t/internationalization-localization/280");
 
   await click(".toggle-admin-menu");

--- a/app/assets/javascripts/discourse/tests/acceptance/new-message-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/new-message-test.js
@@ -1,8 +1,9 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("New Message");
 
-QUnit.test("accessing new-message route when logged out", async (assert) => {
+test("accessing new-message route when logged out", async (assert) => {
   await visit(
     "/new-message?username=charlie&title=message%20title&body=message%20body"
   );
@@ -11,7 +12,7 @@ QUnit.test("accessing new-message route when logged out", async (assert) => {
 });
 
 acceptance("New Message", { loggedIn: true });
-QUnit.test("accessing new-message route when logged in", async (assert) => {
+test("accessing new-message route when logged in", async (assert) => {
   await visit(
     "/new-message?username=charlie&title=message%20title&body=message%20body"
   );

--- a/app/assets/javascripts/discourse/tests/acceptance/new-topic-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/new-topic-test.js
@@ -1,16 +1,17 @@
+import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("New Topic");
 
-QUnit.test("accessing new-topic route when logged out", async (assert) => {
+test("accessing new-topic route when logged out", async (assert) => {
   await visit("/new-topic?title=topic%20title&body=topic%20body");
 
   assert.ok(exists(".modal.login-modal"), "it shows the login modal");
 });
 
 acceptance("New Topic", { loggedIn: true });
-QUnit.test("accessing new-topic route when logged in", async (assert) => {
+test("accessing new-topic route when logged in", async (assert) => {
   await visit("/new-topic?title=topic%20title&body=topic%20body&category=bug");
 
   assert.ok(exists(".composer-fields"), "it opens composer");

--- a/app/assets/javascripts/discourse/tests/acceptance/notifications-filter-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/notifications-filter-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/page-publishing-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/page-publishing-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Page Publishing", {
@@ -22,7 +23,7 @@ acceptance("Page Publishing", {
     });
   },
 });
-QUnit.test("can publish a page via modal", async (assert) => {
+test("can publish a page via modal", async (assert) => {
   await visit("/t/internationalization-localization/280");
   await click(".topic-post:eq(0) button.show-more-actions");
   await click(".topic-post:eq(0) button.show-post-admin-menu");

--- a/app/assets/javascripts/discourse/tests/acceptance/password-reset-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/password-reset-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import I18n from "I18n";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import PreloadStore from "discourse/lib/preload-store";
@@ -54,7 +55,7 @@ acceptance("Password Reset", {
   },
 });
 
-QUnit.test("Password Reset Page", async (assert) => {
+test("Password Reset Page", async (assert) => {
   PreloadStore.store("password_reset", { is_developer: false });
 
   await visit("/u/password-reset/myvalidtoken");
@@ -86,7 +87,7 @@ QUnit.test("Password Reset Page", async (assert) => {
   assert.ok(!exists(".password-reset form"), "form is gone");
 });
 
-QUnit.test("Password Reset Page With Second Factor", async (assert) => {
+test("Password Reset Page With Second Factor", async (assert) => {
   PreloadStore.store("password_reset", {
     is_developer: false,
     second_factor_required: true,

--- a/app/assets/javascripts/discourse/tests/acceptance/personal-message-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/personal-message-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import I18n from "I18n";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
@@ -5,7 +6,7 @@ acceptance("Personal Message", {
   loggedIn: true,
 });
 
-QUnit.test("footer edit button", async (assert) => {
+test("footer edit button", async (assert) => {
   await visit("/t/pm-for-testing/12");
 
   assert.ok(
@@ -14,7 +15,7 @@ QUnit.test("footer edit button", async (assert) => {
   );
 });
 
-QUnit.test("suggested messages", async (assert) => {
+test("suggested messages", async (assert) => {
   await visit("/t/pm-for-testing/12");
 
   assert.equal(

--- a/app/assets/javascripts/discourse/tests/acceptance/plugin-keyboard-shortcut-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/plugin-keyboard-shortcut-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import KeyboardShortcuts from "discourse/lib/keyboard-shortcuts";

--- a/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-connector-class-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-connector-class-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import { extraConnectorClass } from "discourse/lib/plugin-connectors";
 import { action } from "@ember/object";
@@ -64,7 +65,7 @@ acceptance("Plugin Outlet - Connector Class", {
   },
 });
 
-QUnit.test("Renders a template into the outlet", async (assert) => {
+test("Renders a template into the outlet", async (assert) => {
   await visit("/u/eviltrout");
   assert.ok(
     find(".user-profile-primary-outlet.hello").length === 1,

--- a/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-decorator-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-decorator-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import { withPluginApi } from "discourse/lib/plugin-api";
 
@@ -38,24 +39,21 @@ acceptance("Plugin Outlet - Decorator", {
   },
 });
 
-QUnit.test(
-  "Calls the plugin callback with the rendered outlet",
-  async (assert) => {
-    await visit("/");
+test("Calls the plugin callback with the rendered outlet", async (assert) => {
+  await visit("/");
 
-    const fooConnector = find(".discovery-list-container-top-outlet.foo ")[0];
-    const barConnector = find(".discovery-list-container-top-outlet.bar ")[0];
+  const fooConnector = find(".discovery-list-container-top-outlet.foo ")[0];
+  const barConnector = find(".discovery-list-container-top-outlet.bar ")[0];
 
-    assert.ok(exists(fooConnector));
-    assert.equal(fooConnector.style.backgroundColor, "yellow");
-    assert.equal(barConnector.style.backgroundColor, "");
+  assert.ok(exists(fooConnector));
+  assert.equal(fooConnector.style.backgroundColor, "yellow");
+  assert.equal(barConnector.style.backgroundColor, "");
 
-    await visit("/c/bug");
+  await visit("/c/bug");
 
-    assert.ok(fooConnector.classList.contains("in-category"));
+  assert.ok(fooConnector.classList.contains("in-category"));
 
-    await visit("/");
+  await visit("/");
 
-    assert.notOk(fooConnector.classList.contains("in-category"));
-  }
-);
+  assert.notOk(fooConnector.classList.contains("in-category"));
+});

--- a/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-multi-template-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-multi-template-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import { clearCache } from "discourse/lib/plugin-connectors";
 
@@ -23,7 +24,7 @@ acceptance("Plugin Outlet - Multi Template", {
   },
 });
 
-QUnit.test("Renders a template into the outlet", async (assert) => {
+test("Renders a template into the outlet", async (assert) => {
   await visit("/u/eviltrout");
   assert.ok(
     find(".user-profile-primary-outlet.hello").length === 1,

--- a/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-single-template-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-single-template-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 const CONNECTOR =
@@ -14,7 +15,7 @@ acceptance("Plugin Outlet - Single Template", {
   },
 });
 
-QUnit.test("Renders a template into the outlet", async (assert) => {
+test("Renders a template into the outlet", async (assert) => {
   await visit("/u/eviltrout");
   assert.ok(
     find(".user-profile-primary-outlet.hello").length === 1,

--- a/app/assets/javascripts/discourse/tests/acceptance/post-admin-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/post-admin-menu-test.js
@@ -1,8 +1,9 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Post - Admin Menu Anonymous Users", { loggedIn: false });
 
-QUnit.test("Enter as a anon user", async (assert) => {
+test("Enter as a anon user", async (assert) => {
   await visit("/t/internationalization-localization/280");
   await click(".show-more-actions");
 
@@ -19,17 +20,14 @@ QUnit.test("Enter as a anon user", async (assert) => {
 
 acceptance("Post - Admin Menu", { loggedIn: true });
 
-QUnit.test(
-  "Enter as a user with group moderator permissions",
-  async (assert) => {
-    await visit("/t/topic-for-group-moderators/2480");
-    await click(".show-more-actions");
-    await click(".show-post-admin-menu");
+test("Enter as a user with group moderator permissions", async (assert) => {
+  await visit("/t/topic-for-group-moderators/2480");
+  await click(".show-more-actions");
+  await click(".show-post-admin-menu");
 
-    assert.ok(
-      exists("#post_1 .post-controls .edit"),
-      "The edit button was rendered"
-    );
-    assert.ok(exists(".add-notice"), "The add notice button was rendered");
-  }
-);
+  assert.ok(
+    exists("#post_1 .post-controls .edit"),
+    "The edit button was rendered"
+  );
+  assert.ok(exists(".add-notice"), "The add notice button was rendered");
+});

--- a/app/assets/javascripts/discourse/tests/acceptance/preferences-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/preferences-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import I18n from "I18n";
 import {
   acceptance,
@@ -69,7 +70,7 @@ acceptance("User Preferences", {
   pretend: preferencesPretender,
 });
 
-QUnit.test("update some fields", async (assert) => {
+test("update some fields", async (assert) => {
   await visit("/u/eviltrout/preferences");
 
   assert.ok($("body.user-preferences-page").length, "has the body class");
@@ -124,12 +125,12 @@ QUnit.test("update some fields", async (assert) => {
   );
 });
 
-QUnit.test("username", async (assert) => {
+test("username", async (assert) => {
   await visit("/u/eviltrout/preferences/username");
   assert.ok(exists("#change_username"), "it has the input element");
 });
 
-QUnit.test("email", async (assert) => {
+test("email", async (assert) => {
   await visit("/u/eviltrout/preferences/email");
 
   assert.ok(exists("#change-email"), "it has the input element");
@@ -143,7 +144,7 @@ QUnit.test("email", async (assert) => {
   );
 });
 
-QUnit.test("email field always shows up", async (assert) => {
+test("email field always shows up", async (assert) => {
   await visit("/u/eviltrout/preferences/email");
 
   assert.ok(exists("#change-email"), "it has the input element");
@@ -157,7 +158,7 @@ QUnit.test("email field always shows up", async (assert) => {
   assert.ok(exists("#change-email"), "it has the input element");
 });
 
-QUnit.test("connected accounts", async (assert) => {
+test("connected accounts", async (assert) => {
   await visit("/u/eviltrout/preferences/account");
 
   assert.ok(
@@ -178,7 +179,7 @@ QUnit.test("connected accounts", async (assert) => {
     .indexOf("Connect") > -1;
 });
 
-QUnit.test("second factor totp", async (assert) => {
+test("second factor totp", async (assert) => {
   await visit("/u/eviltrout/preferences/second-factor");
 
   assert.ok(exists("#password"), "it has a password input");
@@ -198,7 +199,7 @@ QUnit.test("second factor totp", async (assert) => {
   );
 });
 
-QUnit.test("second factor security keys", async (assert) => {
+test("second factor security keys", async (assert) => {
   await visit("/u/eviltrout/preferences/second-factor");
 
   assert.ok(exists("#password"), "it has a password input");
@@ -224,7 +225,7 @@ QUnit.test("second factor security keys", async (assert) => {
   }
 });
 
-QUnit.test("default avatar selector", async (assert) => {
+test("default avatar selector", async (assert) => {
   await visit("/u/eviltrout/preferences");
 
   await click(".pref-avatar .btn");
@@ -260,7 +261,7 @@ acceptance("Second Factor Backups", {
     });
   },
 });
-QUnit.test("second factor backup", async (assert) => {
+test("second factor backup", async (assert) => {
   updateCurrentUser({ second_factor_enabled: true });
   await visit("/u/eviltrout/preferences/second-factor");
   await click(".edit-2fa-backup");
@@ -287,7 +288,7 @@ acceptance("Avatar selector when selectable avatars is enabled", {
   },
 });
 
-QUnit.test("selectable avatars", async (assert) => {
+test("selectable avatars", async (assert) => {
   await visit("/u/eviltrout/preferences");
 
   await click(".pref-avatar .btn");
@@ -301,7 +302,7 @@ acceptance("User Preferences when badges are disabled", {
   pretend: preferencesPretender,
 });
 
-QUnit.test("visit my preferences", async (assert) => {
+test("visit my preferences", async (assert) => {
   await visit("/u/eviltrout/preferences");
   assert.ok($("body.user-preferences-page").length, "has the body class");
   assert.equal(
@@ -312,7 +313,7 @@ QUnit.test("visit my preferences", async (assert) => {
   assert.ok(exists(".user-preferences"), "it shows the preferences");
 });
 
-QUnit.test("recently connected devices", async (assert) => {
+test("recently connected devices", async (assert) => {
   await visit("/u/eviltrout/preferences");
 
   assert.equal(
@@ -367,7 +368,7 @@ acceptance(
   }
 );
 
-QUnit.test("setting featured topic on profile", async (assert) => {
+test("setting featured topic on profile", async (assert) => {
   await visit("/u/eviltrout/preferences/profile");
 
   assert.ok(
@@ -418,7 +419,7 @@ acceptance("Custom User Fields", {
   pretend: preferencesPretender,
 });
 
-QUnit.test("can select an option from a dropdown", async (assert) => {
+test("can select an option from a dropdown", async (assert) => {
   await visit("/u/eviltrout/preferences/profile");
   assert.ok(exists(".user-field"), "it has at least one user field");
   await click(".user-field.dropdown");
@@ -441,22 +442,19 @@ acceptance(
   }
 );
 
-QUnit.test(
-  "selecting bookmarks as home directs home to bookmarks",
-  async (assert) => {
-    await visit("/u/eviltrout/preferences/interface");
-    assert.ok(exists(".home .combo-box"), "it has a home selector combo-box");
+test("selecting bookmarks as home directs home to bookmarks", async (assert) => {
+  await visit("/u/eviltrout/preferences/interface");
+  assert.ok(exists(".home .combo-box"), "it has a home selector combo-box");
 
-    const field = selectKit(".home .combo-box");
-    await field.expand();
-    await field.selectRowByValue("6");
-    await click(".save-changes");
-    await visit("/");
-    assert.ok(exists(".topic-list"), "The list of topics was rendered");
-    assert.equal(
-      currentPath(),
-      "discovery.bookmarks",
-      "it navigates to bookmarks"
-    );
-  }
-);
+  const field = selectKit(".home .combo-box");
+  await field.expand();
+  await field.selectRowByValue("6");
+  await click(".save-changes");
+  await visit("/");
+  assert.ok(exists(".topic-list"), "The list of topics was rendered");
+  assert.equal(
+    currentPath(),
+    "discovery.bookmarks",
+    "it navigates to bookmarks"
+  );
+});

--- a/app/assets/javascripts/discourse/tests/acceptance/raw-plugin-outlet-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/raw-plugin-outlet-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import compile from "handlebars-compiler";
 import {
@@ -21,7 +22,7 @@ acceptance("Raw Plugin Outlet", {
   },
 });
 
-QUnit.test("Renders the raw plugin outlet", async (assert) => {
+test("Renders the raw plugin outlet", async (assert) => {
   await visit("/");
   assert.ok(find(".topic-lala").length > 0, "it renders the outlet");
   assert.equal(

--- a/app/assets/javascripts/discourse/tests/acceptance/redirect-to-top-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/redirect-to-top-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import {
   acceptance,
   updateCurrentUser,
@@ -19,7 +20,7 @@ acceptance("Redirect to Top", {
   loggedIn: true,
 });
 
-QUnit.test("redirects categories to weekly top", async (assert) => {
+test("redirects categories to weekly top", async (assert) => {
   updateCurrentUser({
     should_be_redirected_to_top: true,
     redirected_to_top: {
@@ -32,7 +33,7 @@ QUnit.test("redirects categories to weekly top", async (assert) => {
   assert.equal(currentPath(), "discovery.topWeekly", "it works for categories");
 });
 
-QUnit.test("redirects latest to monthly top", async (assert) => {
+test("redirects latest to monthly top", async (assert) => {
   updateCurrentUser({
     should_be_redirected_to_top: true,
     redirected_to_top: {
@@ -45,7 +46,7 @@ QUnit.test("redirects latest to monthly top", async (assert) => {
   assert.equal(currentPath(), "discovery.topMonthly", "it works for latest");
 });
 
-QUnit.test("redirects root to All top", async (assert) => {
+test("redirects root to All top", async (assert) => {
   updateCurrentUser({
     should_be_redirected_to_top: true,
     redirected_to_top: {

--- a/app/assets/javascripts/discourse/tests/acceptance/reports-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/reports-test.js
@@ -1,10 +1,11 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Reports", {
   loggedIn: true,
 });
 
-QUnit.test("Visit reports page", async (assert) => {
+test("Visit reports page", async (assert) => {
   await visit("/admin/reports");
 
   assert.equal($(".reports-list .report").length, 1);
@@ -19,7 +20,7 @@ QUnit.test("Visit reports page", async (assert) => {
   );
 });
 
-QUnit.test("Visit report page", async (assert) => {
+test("Visit report page", async (assert) => {
   await visit("/admin/reports/staff_logins");
 
   assert.ok(exists(".export-csv-btn"));

--- a/app/assets/javascripts/discourse/tests/acceptance/review-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/review-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
@@ -7,7 +8,7 @@ acceptance("Review", {
 
 const user = ".reviewable-item[data-reviewable-id=1234]";
 
-QUnit.test("It returns a list of reviewable items", async (assert) => {
+test("It returns a list of reviewable items", async (assert) => {
   await visit("/review");
 
   assert.ok(find(".reviewable-item").length, "has a list of items");
@@ -26,7 +27,7 @@ QUnit.test("It returns a list of reviewable items", async (assert) => {
   );
 });
 
-QUnit.test("Grouped by topic", async (assert) => {
+test("Grouped by topic", async (assert) => {
   await visit("/review/topics");
   assert.ok(
     find(".reviewable-topic").length,
@@ -34,7 +35,7 @@ QUnit.test("Grouped by topic", async (assert) => {
   );
 });
 
-QUnit.test("Settings", async (assert) => {
+test("Settings", async (assert) => {
   await visit("/review/settings");
 
   assert.ok(find(".reviewable-score-type").length, "has a list of bonuses");
@@ -47,7 +48,7 @@ QUnit.test("Settings", async (assert) => {
   assert.ok(find(".reviewable-settings .saved").length, "it saved");
 });
 
-QUnit.test("Flag related", async (assert) => {
+test("Flag related", async (assert) => {
   await visit("/review");
 
   assert.ok(
@@ -63,7 +64,7 @@ QUnit.test("Flag related", async (assert) => {
   assert.equal(find(".reviewable-flagged-post .reviewable-score").length, 2);
 });
 
-QUnit.test("Flag related", async (assert) => {
+test("Flag related", async (assert) => {
   await visit("/review/1");
 
   assert.ok(
@@ -72,13 +73,13 @@ QUnit.test("Flag related", async (assert) => {
   );
 });
 
-QUnit.test("Clicking the buttons triggers actions", async (assert) => {
+test("Clicking the buttons triggers actions", async (assert) => {
   await visit("/review");
   await click(`${user} .reviewable-action.approve`);
   assert.equal(find(user).length, 0, "it removes the reviewable on success");
 });
 
-QUnit.test("Editing a reviewable", async (assert) => {
+test("Editing a reviewable", async (assert) => {
   const topic = ".reviewable-item[data-reviewable-id=4321]";
   await visit("/review");
   assert.ok(find(`${topic} .reviewable-action.approve`).length);

--- a/app/assets/javascripts/discourse/tests/acceptance/search-full-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-full-test.js
@@ -1,3 +1,5 @@
+import { skip } from "qunit";
+import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import {
   selectDate,
@@ -87,7 +89,7 @@ acceptance("Search - Full Page", {
   },
 });
 
-QUnit.test("perform various searches", async (assert) => {
+test("perform various searches", async (assert) => {
   await visit("/search");
 
   assert.ok($("body.search-page").length, "has body class");
@@ -107,7 +109,7 @@ QUnit.test("perform various searches", async (assert) => {
   assert.ok(find(".fps-topic").length === 1, "has one post");
 });
 
-QUnit.test("escape search term", async (assert) => {
+test("escape search term", async (assert) => {
   await visit("/search");
   await fillIn(".search-query", "@<script>prompt(1337)</script>gmail.com");
 
@@ -119,7 +121,7 @@ QUnit.test("escape search term", async (assert) => {
   );
 });
 
-QUnit.skip("update username through advanced search ui", async (assert) => {
+skip("update username through advanced search ui", async (assert) => {
   await visit("/search");
   await fillIn(".search-query", "none");
   await fillIn(".search-advanced-options .user-selector", "admin");
@@ -152,7 +154,7 @@ QUnit.skip("update username through advanced search ui", async (assert) => {
   });
 });
 
-QUnit.test("update category through advanced search ui", async (assert) => {
+test("update category through advanced search ui", async (assert) => {
   const categoryChooser = selectKit(
     ".search-advanced-options .category-chooser"
   );
@@ -176,106 +178,94 @@ QUnit.test("update category through advanced search ui", async (assert) => {
   );
 });
 
-QUnit.test(
-  "update in:title filter through advanced search ui",
-  async (assert) => {
-    await visit("/search");
-    await fillIn(".search-query", "none");
-    await click(".search-advanced-options .in-title");
+test("update in:title filter through advanced search ui", async (assert) => {
+  await visit("/search");
+  await fillIn(".search-query", "none");
+  await click(".search-advanced-options .in-title");
 
-    assert.ok(
-      exists(".search-advanced-options .in-title:checked"),
-      'has "in title" populated'
-    );
-    assert.equal(
-      find(".search-query").val(),
-      "none in:title",
-      'has updated search term to "none in:title"'
-    );
+  assert.ok(
+    exists(".search-advanced-options .in-title:checked"),
+    'has "in title" populated'
+  );
+  assert.equal(
+    find(".search-query").val(),
+    "none in:title",
+    'has updated search term to "none in:title"'
+  );
 
-    await fillIn(".search-query", "none in:titleasd");
+  await fillIn(".search-query", "none in:titleasd");
 
-    assert.not(
-      exists(".search-advanced-options .in-title:checked"),
-      "does not populate title only checkbox"
-    );
-  }
-);
+  assert.not(
+    exists(".search-advanced-options .in-title:checked"),
+    "does not populate title only checkbox"
+  );
+});
 
-QUnit.test(
-  "update in:likes filter through advanced search ui",
-  async (assert) => {
-    await visit("/search");
-    await fillIn(".search-query", "none");
-    await click(".search-advanced-options .in-likes");
+test("update in:likes filter through advanced search ui", async (assert) => {
+  await visit("/search");
+  await fillIn(".search-query", "none");
+  await click(".search-advanced-options .in-likes");
 
-    assert.ok(
-      exists(".search-advanced-options .in-likes:checked"),
-      'has "I liked" populated'
-    );
-    assert.equal(
-      find(".search-query").val(),
-      "none in:likes",
-      'has updated search term to "none in:likes"'
-    );
-  }
-);
+  assert.ok(
+    exists(".search-advanced-options .in-likes:checked"),
+    'has "I liked" populated'
+  );
+  assert.equal(
+    find(".search-query").val(),
+    "none in:likes",
+    'has updated search term to "none in:likes"'
+  );
+});
 
-QUnit.test(
-  "update in:personal filter through advanced search ui",
-  async (assert) => {
-    await visit("/search");
-    await fillIn(".search-query", "none");
-    await click(".search-advanced-options .in-private");
+test("update in:personal filter through advanced search ui", async (assert) => {
+  await visit("/search");
+  await fillIn(".search-query", "none");
+  await click(".search-advanced-options .in-private");
 
-    assert.ok(
-      exists(".search-advanced-options .in-private:checked"),
-      'has "are in my messages" populated'
-    );
+  assert.ok(
+    exists(".search-advanced-options .in-private:checked"),
+    'has "are in my messages" populated'
+  );
 
-    assert.equal(
-      find(".search-query").val(),
-      "none in:personal",
-      'has updated search term to "none in:personal"'
-    );
+  assert.equal(
+    find(".search-query").val(),
+    "none in:personal",
+    'has updated search term to "none in:personal"'
+  );
 
-    await fillIn(".search-query", "none in:personal-direct");
+  await fillIn(".search-query", "none in:personal-direct");
 
-    assert.not(
-      exists(".search-advanced-options .in-private:checked"),
-      "does not populate messages checkbox"
-    );
-  }
-);
+  assert.not(
+    exists(".search-advanced-options .in-private:checked"),
+    "does not populate messages checkbox"
+  );
+});
 
-QUnit.test(
-  "update in:seen filter through advanced search ui",
-  async (assert) => {
-    await visit("/search");
-    await fillIn(".search-query", "none");
-    await click(".search-advanced-options .in-seen");
+test("update in:seen filter through advanced search ui", async (assert) => {
+  await visit("/search");
+  await fillIn(".search-query", "none");
+  await click(".search-advanced-options .in-seen");
 
-    assert.ok(
-      exists(".search-advanced-options .in-seen:checked"),
-      "it should check the right checkbox"
-    );
+  assert.ok(
+    exists(".search-advanced-options .in-seen:checked"),
+    "it should check the right checkbox"
+  );
 
-    assert.equal(
-      find(".search-query").val(),
-      "none in:seen",
-      "it should update the search term"
-    );
+  assert.equal(
+    find(".search-query").val(),
+    "none in:seen",
+    "it should update the search term"
+  );
 
-    await fillIn(".search-query", "none in:seenasdan");
+  await fillIn(".search-query", "none in:seenasdan");
 
-    assert.not(
-      exists(".search-advanced-options .in-seen:checked"),
-      "does not populate seen checkbox"
-    );
-  }
-);
+  assert.not(
+    exists(".search-advanced-options .in-seen:checked"),
+    "does not populate seen checkbox"
+  );
+});
 
-QUnit.test("update in filter through advanced search ui", async (assert) => {
+test("update in filter through advanced search ui", async (assert) => {
   const inSelector = selectKit(".search-advanced-options .select-kit#in");
 
   await visit("/search");
@@ -296,7 +286,7 @@ QUnit.test("update in filter through advanced search ui", async (assert) => {
   );
 });
 
-QUnit.test("update status through advanced search ui", async (assert) => {
+test("update status through advanced search ui", async (assert) => {
   const statusSelector = selectKit(
     ".search-advanced-options .select-kit#status"
   );
@@ -319,35 +309,29 @@ QUnit.test("update status through advanced search ui", async (assert) => {
   );
 });
 
-QUnit.test(
-  "doesn't update status filter header if wrong value entered through searchbox",
-  async (assert) => {
-    const statusSelector = selectKit(
-      ".search-advanced-options .select-kit#status"
-    );
+test("doesn't update status filter header if wrong value entered through searchbox", async (assert) => {
+  const statusSelector = selectKit(
+    ".search-advanced-options .select-kit#status"
+  );
 
-    await visit("/search");
+  await visit("/search");
 
-    await fillIn(".search-query", "status:none");
+  await fillIn(".search-query", "status:none");
 
-    assert.equal(statusSelector.header().label(), "any", 'has "any" populated');
-  }
-);
+  assert.equal(statusSelector.header().label(), "any", 'has "any" populated');
+});
 
-QUnit.test(
-  "doesn't update in filter header if wrong value entered through searchbox",
-  async (assert) => {
-    const inSelector = selectKit(".search-advanced-options .select-kit#in");
+test("doesn't update in filter header if wrong value entered through searchbox", async (assert) => {
+  const inSelector = selectKit(".search-advanced-options .select-kit#in");
 
-    await visit("/search");
+  await visit("/search");
 
-    await fillIn(".search-query", "in:none");
+  await fillIn(".search-query", "in:none");
 
-    assert.equal(inSelector.header().label(), "any", 'has "any" populated');
-  }
-);
+  assert.equal(inSelector.header().label(), "any", 'has "any" populated');
+});
 
-QUnit.test("update post time through advanced search ui", async (assert) => {
+test("update post time through advanced search ui", async (assert) => {
   await visit("/search?expanded=true&q=after:2018-08-22");
 
   assert.equal(
@@ -380,47 +364,41 @@ QUnit.test("update post time through advanced search ui", async (assert) => {
   );
 });
 
-QUnit.test(
-  "update min post count through advanced search ui",
-  async (assert) => {
-    await visit("/search");
-    await fillIn(".search-query", "none");
-    await fillIn("#search-min-post-count", "5");
+test("update min post count through advanced search ui", async (assert) => {
+  await visit("/search");
+  await fillIn(".search-query", "none");
+  await fillIn("#search-min-post-count", "5");
 
-    assert.equal(
-      find(".search-advanced-options #search-min-post-count").val(),
-      "5",
-      'has "5" populated'
-    );
-    assert.equal(
-      find(".search-query").val(),
-      "none min_posts:5",
-      'has updated search term to "none min_posts:5"'
-    );
-  }
-);
+  assert.equal(
+    find(".search-advanced-options #search-min-post-count").val(),
+    "5",
+    'has "5" populated'
+  );
+  assert.equal(
+    find(".search-query").val(),
+    "none min_posts:5",
+    'has updated search term to "none min_posts:5"'
+  );
+});
 
-QUnit.test(
-  "update max post count through advanced search ui",
-  async (assert) => {
-    await visit("/search");
-    await fillIn(".search-query", "none");
-    await fillIn("#search-max-post-count", "5");
+test("update max post count through advanced search ui", async (assert) => {
+  await visit("/search");
+  await fillIn(".search-query", "none");
+  await fillIn("#search-max-post-count", "5");
 
-    assert.equal(
-      find(".search-advanced-options #search-max-post-count").val(),
-      "5",
-      'has "5" populated'
-    );
-    assert.equal(
-      find(".search-query").val(),
-      "none max_posts:5",
-      'has updated search term to "none max_posts:5"'
-    );
-  }
-);
+  assert.equal(
+    find(".search-advanced-options #search-max-post-count").val(),
+    "5",
+    'has "5" populated'
+  );
+  assert.equal(
+    find(".search-query").val(),
+    "none max_posts:5",
+    'has updated search term to "none max_posts:5"'
+  );
+});
 
-QUnit.test("validate advanced search when initially empty", async (assert) => {
+test("validate advanced search when initially empty", async (assert) => {
   await visit("/search?expanded=true");
   await click(".search-advanced-options .in-likes");
 

--- a/app/assets/javascripts/discourse/tests/acceptance/search-mobile-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-mobile-test.js
@@ -1,8 +1,9 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Search - Mobile", { mobileView: true });
 
-QUnit.test("search", async (assert) => {
+test("search", async (assert) => {
   await visit("/");
 
   await click("#search-button");

--- a/app/assets/javascripts/discourse/tests/acceptance/search-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
@@ -17,7 +18,7 @@ let searchArgs = {
 
 acceptance("Search", searchArgs);
 
-QUnit.test("search", async (assert) => {
+test("search", async (assert) => {
   await visit("/");
 
   await click("#search-button");
@@ -43,7 +44,7 @@ QUnit.test("search", async (assert) => {
   assert.ok(exists(".search-advanced-options"), "advanced search is expanded");
 });
 
-QUnit.test("search for a tag", async (assert) => {
+test("search for a tag", async (assert) => {
   await visit("/");
 
   await click("#search-button");
@@ -53,7 +54,7 @@ QUnit.test("search for a tag", async (assert) => {
   assert.ok(exists(".search-menu .results ul li"), "it shows results");
 });
 
-QUnit.test("search scope checkbox", async (assert) => {
+test("search scope checkbox", async (assert) => {
   await visit("/tag/important");
   await click("#search-button");
   assert.ok(
@@ -86,7 +87,7 @@ QUnit.test("search scope checkbox", async (assert) => {
   );
 });
 
-QUnit.test("Search with context", async (assert) => {
+test("Search with context", async (assert) => {
   await visit("/t/internationalization-localization/280/1");
 
   await click("#search-button");
@@ -126,7 +127,7 @@ QUnit.test("Search with context", async (assert) => {
   assert.ok(!$(".search-context input[type=checkbox]").is(":checked"));
 });
 
-QUnit.test("Right filters are shown to anonymous users", async (assert) => {
+test("Right filters are shown to anonymous users", async (assert) => {
   const inSelector = selectKit(".select-kit#in");
 
   await visit("/search?expanded=true");
@@ -151,7 +152,7 @@ QUnit.test("Right filters are shown to anonymous users", async (assert) => {
 
 acceptance("Search", Object.assign({ loggedIn: true, searchArgs }));
 
-QUnit.test("Right filters are shown to logged-in users", async (assert) => {
+test("Right filters are shown to logged-in users", async (assert) => {
   const inSelector = selectKit(".select-kit#in");
 
   await visit("/search?expanded=true");
@@ -183,7 +184,7 @@ acceptance(
   })
 );
 
-QUnit.test("displays tags", async (assert) => {
+test("displays tags", async (assert) => {
   await visit("/");
 
   await click("#search-button");

--- a/app/assets/javascripts/discourse/tests/acceptance/share-and-invite-desktop-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/share-and-invite-desktop-test.js
@@ -1,10 +1,11 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Share and Invite modal - desktop", {
   loggedIn: true,
 });
 
-QUnit.test("Topic footer button", async (assert) => {
+test("Topic footer button", async (assert) => {
   await visit("/t/internationalization-localization/280");
 
   assert.ok(
@@ -64,7 +65,7 @@ QUnit.test("Topic footer button", async (assert) => {
   );
 });
 
-QUnit.test("Post date link", async (assert) => {
+test("Post date link", async (assert) => {
   await visit("/t/internationalization-localization/280");
   await click("#post_2 .post-info.post-date a");
 
@@ -78,17 +79,14 @@ acceptance("Share url with badges disabled - desktop", {
   },
 });
 
-QUnit.test(
-  "topic footer button - badges disabled - desktop",
-  async (assert) => {
-    await visit("/t/internationalization-localization/280");
-    await click("#topic-footer-button-share-and-invite");
+test("topic footer button - badges disabled - desktop", async (assert) => {
+  await visit("/t/internationalization-localization/280");
+  await click("#topic-footer-button-share-and-invite");
 
-    assert.notOk(
-      find(".share-and-invite.modal .modal-panel.share .topic-share-url")
-        .val()
-        .includes("?u=eviltrout"),
-      "it doesn't add the username param when badges are disabled"
-    );
-  }
-);
+  assert.notOk(
+    find(".share-and-invite.modal .modal-panel.share .topic-share-url")
+      .val()
+      .includes("?u=eviltrout"),
+    "it doesn't add the username param when badges are disabled"
+  );
+});

--- a/app/assets/javascripts/discourse/tests/acceptance/share-and-invite-mobile-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/share-and-invite-mobile-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
@@ -6,7 +7,7 @@ acceptance("Share and Invite modal - mobile", {
   mobileView: true,
 });
 
-QUnit.test("Topic footer mobile button", async (assert) => {
+test("Topic footer mobile button", async (assert) => {
   await visit("/t/internationalization-localization/280");
 
   assert.ok(
@@ -54,7 +55,7 @@ QUnit.test("Topic footer mobile button", async (assert) => {
   );
 });
 
-QUnit.test("Post date link", async (assert) => {
+test("Post date link", async (assert) => {
   await visit("/t/internationalization-localization/280");
   await click("#post_2 .post-info.post-date a");
 
@@ -69,7 +70,7 @@ acceptance("Share url with badges disabled - mobile", {
   },
 });
 
-QUnit.test("topic footer button - badges disabled - mobile", async (assert) => {
+test("topic footer button - badges disabled - mobile", async (assert) => {
   await visit("/t/internationalization-localization/280");
 
   const subject = selectKit(".topic-footer-mobile-dropdown");

--- a/app/assets/javascripts/discourse/tests/acceptance/shared-drafts-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/shared-drafts-test.js
@@ -1,9 +1,10 @@
+import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Shared Drafts", { loggedIn: true });
 
-QUnit.test("Viewing", async (assert) => {
+test("Viewing", async (assert) => {
   await visit("/t/some-topic/9");
   assert.ok(find(".shared-draft-controls").length === 1);
   let categoryChooser = selectKit(".shared-draft-controls .category-chooser");

--- a/app/assets/javascripts/discourse/tests/acceptance/sign-in-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sign-in-test.js
@@ -1,7 +1,9 @@
+import { skip } from "qunit";
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 acceptance("Signing In");
 
-QUnit.test("sign in", async (assert) => {
+test("sign in", async (assert) => {
   await visit("/");
   await click("header .login-button");
   assert.ok(exists(".login-modal"), "it shows the login modal");
@@ -25,7 +27,7 @@ QUnit.test("sign in", async (assert) => {
   );
 });
 
-QUnit.test("sign in - not activated", async (assert) => {
+test("sign in - not activated", async (assert) => {
   await visit("/");
   await click("header .login-button");
   assert.ok(exists(".login-modal"), "it shows the login modal");
@@ -47,7 +49,7 @@ QUnit.test("sign in - not activated", async (assert) => {
   assert.ok(!exists(".modal-body small"), "it escapes the email address");
 });
 
-QUnit.test("sign in - not activated - edit email", async (assert) => {
+test("sign in - not activated - edit email", async (assert) => {
   await visit("/");
   await click("header .login-button");
   assert.ok(exists(".login-modal"), "it shows the login modal");
@@ -68,7 +70,7 @@ QUnit.test("sign in - not activated - edit email", async (assert) => {
   assert.equal(find(".modal-body b").text(), "different@example.com");
 });
 
-QUnit.skip("second factor", async (assert) => {
+skip("second factor", async (assert) => {
   await visit("/");
   await click("header .login-button");
 
@@ -101,7 +103,7 @@ QUnit.skip("second factor", async (assert) => {
   );
 });
 
-QUnit.skip("security key", async (assert) => {
+skip("security key", async (assert) => {
   await visit("/");
   await click("header .login-button");
 
@@ -127,7 +129,7 @@ QUnit.skip("security key", async (assert) => {
   assert.not(exists("#login-button:visible"), "hides the login button");
 });
 
-QUnit.test("create account", async (assert) => {
+test("create account", async (assert) => {
   await visit("/");
   await click("header .sign-up-button");
 
@@ -163,7 +165,7 @@ QUnit.test("create account", async (assert) => {
   );
 });
 
-QUnit.test("second factor backup - valid token", async (assert) => {
+test("second factor backup - valid token", async (assert) => {
   await visit("/");
   await click("header .login-button");
   await fillIn("#login-account-name", "eviltrout");
@@ -179,7 +181,7 @@ QUnit.test("second factor backup - valid token", async (assert) => {
   );
 });
 
-QUnit.test("second factor backup - invalid token", async (assert) => {
+test("second factor backup - invalid token", async (assert) => {
   await visit("/");
   await click("header .login-button");
   await fillIn("#login-account-name", "eviltrout");

--- a/app/assets/javascripts/discourse/tests/acceptance/static-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/static-test.js
@@ -1,7 +1,8 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 acceptance("Static");
 
-QUnit.test("Static Pages", async (assert) => {
+test("Static Pages", async (assert) => {
   await visit("/faq");
   assert.ok($("body.static-faq").length, "has the body class");
   assert.ok(exists(".body-page"), "The content is present");

--- a/app/assets/javascripts/discourse/tests/acceptance/tag-groups-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/tag-groups-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
@@ -20,7 +21,7 @@ acceptance("Tag Groups", {
   },
 });
 
-QUnit.test("tag groups can be saved and deleted", async (assert) => {
+test("tag groups can be saved and deleted", async (assert) => {
   const tags = selectKit(".tag-chooser");
 
   await visit("/tag_groups");

--- a/app/assets/javascripts/discourse/tests/acceptance/tags-intersection-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/tags-intersection-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Tags intersection", {
@@ -28,7 +29,7 @@ acceptance("Tags intersection", {
   },
 });
 
-QUnit.test("Populate tags when creating new topic", async (assert) => {
+test("Populate tags when creating new topic", async (assert) => {
   await visit("/tags/intersection/first/second");
   await click("#create-topic");
 

--- a/app/assets/javascripts/discourse/tests/acceptance/tags-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/tags-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import {
   updateCurrentUser,
   acceptance,
@@ -6,7 +7,7 @@ import pretender from "discourse/tests/helpers/create-pretender";
 
 acceptance("Tags", { loggedIn: true });
 
-QUnit.test("list the tags", async (assert) => {
+test("list the tags", async (assert) => {
   await visit("/tags");
 
   assert.ok($("body.tags-page").length, "has the body class");
@@ -23,7 +24,7 @@ acceptance("Tags listed by group", {
   },
 });
 
-QUnit.test("list the tags in groups", async (assert) => {
+test("list the tags in groups", async (assert) => {
   await visit("/tags");
   assert.equal(
     $(".tag-list").length,

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-admin-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-admin-menu-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import {
   acceptance,
   updateCurrentUser,
@@ -5,7 +6,7 @@ import {
 
 acceptance("Topic - Admin Menu Anonymous Users", { loggedIn: false });
 
-QUnit.test("Enter as a regular user", async (assert) => {
+test("Enter as a regular user", async (assert) => {
   await visit("/t/internationalization-localization/280");
   assert.ok(exists("#topic"), "The topic was rendered");
   assert.ok(
@@ -16,46 +17,31 @@ QUnit.test("Enter as a regular user", async (assert) => {
 
 acceptance("Topic - Admin Menu", { loggedIn: true });
 
-QUnit.test(
-  "Enter as a user with group moderator permissions",
-  async (assert) => {
-    updateCurrentUser({ moderator: false, admin: false, trust_level: 1 });
+test("Enter as a user with group moderator permissions", async (assert) => {
+  updateCurrentUser({ moderator: false, admin: false, trust_level: 1 });
 
-    await visit("/t/topic-for-group-moderators/2480");
-    assert.ok(exists("#topic"), "The topic was rendered");
-    assert.ok(
-      exists(".toggle-admin-menu"),
-      "The admin menu button was rendered"
-    );
-  }
-);
+  await visit("/t/topic-for-group-moderators/2480");
+  assert.ok(exists("#topic"), "The topic was rendered");
+  assert.ok(exists(".toggle-admin-menu"), "The admin menu button was rendered");
+});
 
-QUnit.test(
-  "Enter as a user with moderator and admin permissions",
-  async (assert) => {
-    updateCurrentUser({ moderator: true, admin: true, trust_level: 4 });
+test("Enter as a user with moderator and admin permissions", async (assert) => {
+  updateCurrentUser({ moderator: true, admin: true, trust_level: 4 });
 
-    await visit("/t/internationalization-localization/280");
-    assert.ok(exists("#topic"), "The topic was rendered");
-    assert.ok(
-      exists(".toggle-admin-menu"),
-      "The admin menu button was rendered"
-    );
-  }
-);
+  await visit("/t/internationalization-localization/280");
+  assert.ok(exists("#topic"), "The topic was rendered");
+  assert.ok(exists(".toggle-admin-menu"), "The admin menu button was rendered");
+});
 
-QUnit.test(
-  "Toggle the menu as admin focuses the first item",
-  async (assert) => {
-    updateCurrentUser({ admin: true });
+test("Toggle the menu as admin focuses the first item", async (assert) => {
+  updateCurrentUser({ admin: true });
 
-    await visit("/t/internationalization-localization/280");
-    assert.ok(exists("#topic"), "The topic was rendered");
-    await click(".toggle-admin-menu");
+  await visit("/t/internationalization-localization/280");
+  assert.ok(exists("#topic"), "The topic was rendered");
+  await click(".toggle-admin-menu");
 
-    assert.equal(
-      document.activeElement,
-      document.querySelector(".topic-admin-multi-select > button")
-    );
-  }
-);
+  assert.equal(
+    document.activeElement,
+    document.querySelector(".topic-admin-multi-select > button")
+  );
+});

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-anonymous-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-anonymous-test.js
@@ -1,7 +1,8 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 acceptance("Topic - Anonymous");
 
-QUnit.test("Enter a Topic", async (assert) => {
+test("Enter a Topic", async (assert) => {
   await visit("/t/internationalization-localization/280/1");
   assert.ok(exists("#topic"), "The topic was rendered");
   assert.ok(exists("#topic .cooked"), "The topic has cooked posts");
@@ -11,24 +12,24 @@ QUnit.test("Enter a Topic", async (assert) => {
   );
 });
 
-QUnit.test("Enter without an id", async (assert) => {
+test("Enter without an id", async (assert) => {
   await visit("/t/internationalization-localization");
   assert.ok(exists("#topic"), "The topic was rendered");
 });
 
-QUnit.test("Enter a 404 topic", async (assert) => {
+test("Enter a 404 topic", async (assert) => {
   await visit("/t/not-found/404");
   assert.ok(!exists("#topic"), "The topic was not rendered");
   assert.ok(exists(".topic-error"), "An error message is displayed");
 });
 
-QUnit.test("Enter without access", async (assert) => {
+test("Enter without access", async (assert) => {
   await visit("/t/i-dont-have-access/403");
   assert.ok(!exists("#topic"), "The topic was not rendered");
   assert.ok(exists(".topic-error"), "An error message is displayed");
 });
 
-QUnit.test("Enter with 500 errors", async (assert) => {
+test("Enter with 500 errors", async (assert) => {
   await visit("/t/throws-error/500");
   assert.ok(!exists("#topic"), "The topic was not rendered");
   assert.ok(exists(".topic-error"), "An error message is displayed");

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-discovery-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-discovery-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import DiscourseURL from "discourse/lib/url";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
@@ -9,7 +10,7 @@ acceptance("Topic Discovery", {
   },
 });
 
-QUnit.test("Visit Discovery Pages", async (assert) => {
+test("Visit Discovery Pages", async (assert) => {
   await visit("/");
   assert.ok($("body.navigation-topics").length, "has the default navigation");
   assert.ok(exists(".topic-list"), "The list of topics was rendered");
@@ -68,7 +69,7 @@ QUnit.test("Visit Discovery Pages", async (assert) => {
   );
 });
 
-QUnit.test("Clearing state after leaving a category", async (assert) => {
+test("Clearing state after leaving a category", async (assert) => {
   await visit("/c/dev");
   assert.ok(
     exists(".topic-list-item[data-topic-id=11994] .topic-excerpt"),
@@ -81,7 +82,7 @@ QUnit.test("Clearing state after leaving a category", async (assert) => {
   );
 });
 
-QUnit.test("Live update unread state", async (assert) => {
+test("Live update unread state", async (assert) => {
   await visit("/");
   assert.ok(
     exists(".topic-list-item:not(.visited) a[data-topic-id='11995']"),
@@ -110,21 +111,18 @@ QUnit.test("Live update unread state", async (assert) => {
   );
 });
 
-QUnit.test(
-  "Using period chooser when query params are present",
-  async (assert) => {
-    await visit("/top?f=foo&d=bar");
+test("Using period chooser when query params are present", async (assert) => {
+  await visit("/top?f=foo&d=bar");
 
-    sandbox.stub(DiscourseURL, "routeTo");
+  sandbox.stub(DiscourseURL, "routeTo");
 
-    const periodChooser = selectKit(".period-chooser");
+  const periodChooser = selectKit(".period-chooser");
 
-    await periodChooser.expand();
-    await periodChooser.selectRowByValue("yearly");
+  await periodChooser.expand();
+  await periodChooser.selectRowByValue("yearly");
 
-    assert.ok(
-      DiscourseURL.routeTo.calledWith("/top/yearly?f=foo&d=bar"),
-      "it keeps the query params"
-    );
-  }
-);
+  assert.ok(
+    DiscourseURL.routeTo.calledWith("/top/yearly?f=foo&d=bar"),
+    "it keeps the query params"
+  );
+});

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-edit-timer-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-edit-timer-test.js
@@ -1,3 +1,5 @@
+import { skip } from "qunit";
+import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import {
   acceptance,
@@ -22,7 +24,7 @@ acceptance("Topic - Edit timer", {
   },
 });
 
-QUnit.test("default", async (assert) => {
+test("default", async (assert) => {
   updateCurrentUser({ moderator: true });
   const futureDateInputSelector = selectKit(".future-date-input-selector");
 
@@ -34,7 +36,7 @@ QUnit.test("default", async (assert) => {
   assert.equal(futureDateInputSelector.header().value(), null);
 });
 
-QUnit.test("autoclose - specific time", async (assert) => {
+test("autoclose - specific time", async (assert) => {
   updateCurrentUser({ moderator: true });
   const futureDateInputSelector = selectKit(".future-date-input-selector");
 
@@ -53,7 +55,7 @@ QUnit.test("autoclose - specific time", async (assert) => {
   assert.ok(regex.test(html));
 });
 
-QUnit.skip("autoclose", async (assert) => {
+skip("autoclose", async (assert) => {
   updateCurrentUser({ moderator: true });
   const futureDateInputSelector = selectKit(".future-date-input-selector");
 
@@ -106,7 +108,7 @@ QUnit.skip("autoclose", async (assert) => {
   assert.ok(regex3.test(html3));
 });
 
-QUnit.test("close temporarily", async (assert) => {
+test("close temporarily", async (assert) => {
   updateCurrentUser({ moderator: true });
   const timerType = selectKit(".select-kit.timer-type");
   const futureDateInputSelector = selectKit(".future-date-input-selector");
@@ -144,7 +146,7 @@ QUnit.test("close temporarily", async (assert) => {
   assert.ok(regex2.test(html2));
 });
 
-QUnit.test("schedule", async (assert) => {
+test("schedule", async (assert) => {
   updateCurrentUser({ moderator: true });
   const timerType = selectKit(".select-kit.timer-type");
   const categoryChooser = selectKit(".modal-body .category-chooser");
@@ -177,7 +179,7 @@ QUnit.test("schedule", async (assert) => {
   assert.ok(regex.test(text));
 });
 
-QUnit.test("TL4 can't auto-delete", async (assert) => {
+test("TL4 can't auto-delete", async (assert) => {
   updateCurrentUser({ moderator: false, admin: false, trust_level: 4 });
 
   await visit("/t/internationalization-localization");
@@ -191,7 +193,7 @@ QUnit.test("TL4 can't auto-delete", async (assert) => {
   assert.ok(!timerType.rowByValue("delete").exists());
 });
 
-QUnit.test("auto delete", async (assert) => {
+test("auto delete", async (assert) => {
   updateCurrentUser({ moderator: true });
   const timerType = selectKit(".select-kit.timer-type");
   const futureDateInputSelector = selectKit(".future-date-input-selector");
@@ -217,7 +219,7 @@ QUnit.test("auto delete", async (assert) => {
   assert.ok(regex.test(html));
 });
 
-QUnit.test("Inline delete timer", async (assert) => {
+test("Inline delete timer", async (assert) => {
   updateCurrentUser({ moderator: true });
   const futureDateInputSelector = selectKit(".future-date-input-selector");
 

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-footer-buttons-mobile-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-footer-buttons-mobile-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import I18n from "I18n";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { withPluginApi } from "discourse/lib/plugin-api";
@@ -35,7 +36,7 @@ acceptance("Topic footer buttons mobile", {
   },
 });
 
-QUnit.test("default", async (assert) => {
+test("default", async (assert) => {
   await visit("/t/internationalization-localization/280");
 
   assert.equal(_test, null);

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-list-tracker-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-list-tracker-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import {
   nextTopicUrl,
@@ -6,7 +7,7 @@ import {
 } from "discourse/lib/topic-list-tracker";
 acceptance("Topic list tracking");
 
-QUnit.test("Navigation", async (assert) => {
+test("Navigation", async (assert) => {
   await visit("/");
   let url = await nextTopicUrl();
   assert.equal(url, "/t/error-after-upgrade-to-0-9-7-9/11557");

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-move-posts-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-move-posts-test.js
@@ -1,8 +1,9 @@
+import { test } from "qunit";
 import I18n from "I18n";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 acceptance("Topic move posts", { loggedIn: true });
 
-QUnit.test("default", async (assert) => {
+test("default", async (assert) => {
   await visit("/t/internationalization-localization");
   await click(".toggle-admin-menu");
   await click(".topic-admin-multi-select .btn");
@@ -45,7 +46,7 @@ QUnit.test("default", async (assert) => {
   );
 });
 
-QUnit.test("moving all posts", async (assert) => {
+test("moving all posts", async (assert) => {
   await visit("/t/internationalization-localization");
   await click(".toggle-admin-menu");
   await click(".topic-admin-multi-select .btn");
@@ -81,7 +82,7 @@ QUnit.test("moving all posts", async (assert) => {
   );
 });
 
-QUnit.test("moving posts from personal message", async (assert) => {
+test("moving posts from personal message", async (assert) => {
   await visit("/t/pm-for-testing/12");
   await click(".toggle-admin-menu");
   await click(".topic-admin-multi-select .btn");
@@ -117,7 +118,7 @@ QUnit.test("moving posts from personal message", async (assert) => {
   );
 });
 
-QUnit.test("group moderator moving posts", async (assert) => {
+test("group moderator moving posts", async (assert) => {
   await visit("/t/topic-for-group-moderators/2480");
   await click(".toggle-admin-menu");
   await click(".topic-admin-multi-select .btn");

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-notifications-button-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-notifications-button-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
@@ -10,7 +11,7 @@ acceptance("Topic Notifications button", {
   },
 });
 
-QUnit.test("Updating topic notification level", async (assert) => {
+test("Updating topic notification level", async (assert) => {
   const notificationOptions = selectKit(
     "#topic-footer-buttons .topic-notifications-options"
   );

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-quote-button-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-quote-button-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import I18n from "I18n";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
@@ -19,39 +20,33 @@ acceptance("Topic - Quote button - logged in", {
   },
 });
 
-QUnit.test(
-  "Does not show the quote share buttons by default",
-  async (assert) => {
-    await visit("/t/internationalization-localization/280");
-    selectText("#post_5 blockquote");
-    assert.ok(exists(".insert-quote"), "it shows the quote button");
-    assert.equal(
-      find(".quote-sharing").length,
-      0,
-      "it does not show quote sharing"
-    );
-  }
-);
+test("Does not show the quote share buttons by default", async (assert) => {
+  await visit("/t/internationalization-localization/280");
+  selectText("#post_5 blockquote");
+  assert.ok(exists(".insert-quote"), "it shows the quote button");
+  assert.equal(
+    find(".quote-sharing").length,
+    0,
+    "it does not show quote sharing"
+  );
+});
 
-QUnit.test(
-  "Shows quote share buttons with the right site settings",
-  async function (assert) {
-    this.siteSettings.share_quote_visibility = "all";
+test("Shows quote share buttons with the right site settings", async function (assert) {
+  this.siteSettings.share_quote_visibility = "all";
 
-    await visit("/t/internationalization-localization/280");
-    selectText("#post_5 blockquote");
+  await visit("/t/internationalization-localization/280");
+  selectText("#post_5 blockquote");
 
-    assert.ok(exists(".quote-sharing"), "it shows the quote sharing options");
-    assert.ok(
-      exists(`.quote-sharing .btn[title='${I18n.t("share.twitter")}']`),
-      "it includes the twitter share button"
-    );
-    assert.ok(
-      exists(`.quote-sharing .btn[title='${I18n.t("share.email")}']`),
-      "it includes the email share button"
-    );
-  }
-);
+  assert.ok(exists(".quote-sharing"), "it shows the quote sharing options");
+  assert.ok(
+    exists(`.quote-sharing .btn[title='${I18n.t("share.twitter")}']`),
+    "it includes the twitter share button"
+  );
+  assert.ok(
+    exists(`.quote-sharing .btn[title='${I18n.t("share.email")}']`),
+    "it includes the email share button"
+  );
+});
 
 acceptance("Topic - Quote button - anonymous", {
   loggedIn: false,
@@ -61,53 +56,45 @@ acceptance("Topic - Quote button - anonymous", {
   },
 });
 
-QUnit.test(
-  "Shows quote share buttons with the right site settings",
-  async function (assert) {
-    await visit("/t/internationalization-localization/280");
-    selectText("#post_5 blockquote");
+test("Shows quote share buttons with the right site settings", async function (assert) {
+  await visit("/t/internationalization-localization/280");
+  selectText("#post_5 blockquote");
 
-    assert.ok(find(".quote-sharing"), "it shows the quote sharing options");
-    assert.ok(
-      exists(`.quote-sharing .btn[title='${I18n.t("share.twitter")}']`),
-      "it includes the twitter share button"
-    );
-    assert.ok(
-      exists(`.quote-sharing .btn[title='${I18n.t("share.email")}']`),
-      "it includes the email share button"
-    );
-    assert.equal(
-      find(".insert-quote").length,
-      0,
-      "it does not show the quote button"
-    );
-  }
-);
+  assert.ok(find(".quote-sharing"), "it shows the quote sharing options");
+  assert.ok(
+    exists(`.quote-sharing .btn[title='${I18n.t("share.twitter")}']`),
+    "it includes the twitter share button"
+  );
+  assert.ok(
+    exists(`.quote-sharing .btn[title='${I18n.t("share.email")}']`),
+    "it includes the email share button"
+  );
+  assert.equal(
+    find(".insert-quote").length,
+    0,
+    "it does not show the quote button"
+  );
+});
 
-QUnit.test(
-  "Shows single share button when site setting only has one item",
-  async function (assert) {
-    this.siteSettings.share_quote_buttons = "twitter";
+test("Shows single share button when site setting only has one item", async function (assert) {
+  this.siteSettings.share_quote_buttons = "twitter";
 
-    await visit("/t/internationalization-localization/280");
-    selectText("#post_5 blockquote");
+  await visit("/t/internationalization-localization/280");
+  selectText("#post_5 blockquote");
 
-    assert.ok(exists(".quote-sharing"), "it shows the quote sharing options");
-    assert.ok(
-      exists(`.quote-sharing .btn[title='${I18n.t("share.twitter")}']`),
-      "it includes the twitter share button"
-    );
-    assert.equal(
-      find(".quote-share-label").length,
-      0,
-      "it does not show the Share label"
-    );
-  }
-);
+  assert.ok(exists(".quote-sharing"), "it shows the quote sharing options");
+  assert.ok(
+    exists(`.quote-sharing .btn[title='${I18n.t("share.twitter")}']`),
+    "it includes the twitter share button"
+  );
+  assert.equal(
+    find(".quote-share-label").length,
+    0,
+    "it does not show the Share label"
+  );
+});
 
-QUnit.test("Shows nothing when visibility is disabled", async function (
-  assert
-) {
+test("Shows nothing when visibility is disabled", async function (assert) {
   this.siteSettings.share_quote_visibility = "none";
 
   await visit("/t/internationalization-localization/280");

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-test.js
@@ -1,3 +1,5 @@
+import { skip } from "qunit";
+import { test } from "qunit";
 import I18n from "I18n";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
@@ -13,7 +15,7 @@ acceptance("Topic", {
   },
 });
 
-QUnit.test("Reply as new topic", async (assert) => {
+test("Reply as new topic", async (assert) => {
   await visit("/t/internationalization-localization/280");
   await click("button.share:eq(0)");
   await click(".reply-as-new-topic a");
@@ -32,7 +34,7 @@ QUnit.test("Reply as new topic", async (assert) => {
   );
 });
 
-QUnit.test("Reply as new message", async (assert) => {
+test("Reply as new message", async (assert) => {
   await visit("/t/pm-for-testing/12");
   await click("button.share:eq(0)");
   await click(".reply-as-new-topic a");
@@ -66,14 +68,14 @@ QUnit.test("Reply as new message", async (assert) => {
   );
 });
 
-QUnit.test("Share Modal", async (assert) => {
+test("Share Modal", async (assert) => {
   await visit("/t/internationalization-localization/280");
   await click(".topic-post:first-child button.share");
 
   assert.ok(exists("#share-link"), "it shows the share modal");
 });
 
-QUnit.test("Showing and hiding the edit controls", async (assert) => {
+test("Showing and hiding the edit controls", async (assert) => {
   await visit("/t/internationalization-localization/280");
 
   await click("#topic-title .d-icon-pencil-alt");
@@ -89,7 +91,7 @@ QUnit.test("Showing and hiding the edit controls", async (assert) => {
   assert.ok(!exists("#edit-title"), "it hides the editing controls");
 });
 
-QUnit.test("Updating the topic title and category", async (assert) => {
+test("Updating the topic title and category", async (assert) => {
   const categoryChooser = selectKit(".title-wrapper .category-chooser");
 
   await visit("/t/internationalization-localization/280");
@@ -112,7 +114,7 @@ QUnit.test("Updating the topic title and category", async (assert) => {
   );
 });
 
-QUnit.test("Marking a topic as wiki", async (assert) => {
+test("Marking a topic as wiki", async (assert) => {
   await visit("/t/internationalization-localization/280");
 
   assert.ok(find("a.wiki").length === 0, "it does not show the wiki icon");
@@ -124,7 +126,7 @@ QUnit.test("Marking a topic as wiki", async (assert) => {
   assert.ok(find("a.wiki").length === 1, "it shows the wiki icon");
 });
 
-QUnit.test("Visit topic routes", async (assert) => {
+test("Visit topic routes", async (assert) => {
   await visit("/t/12");
 
   assert.equal(
@@ -142,7 +144,7 @@ QUnit.test("Visit topic routes", async (assert) => {
   );
 });
 
-QUnit.test("Updating the topic title with emojis", async (assert) => {
+test("Updating the topic title with emojis", async (assert) => {
   await visit("/t/internationalization-localization/280");
   await click("#topic-title .d-icon-pencil-alt");
 
@@ -157,7 +159,7 @@ QUnit.test("Updating the topic title with emojis", async (assert) => {
   );
 });
 
-QUnit.test("Updating the topic title with unicode emojis", async (assert) => {
+test("Updating the topic title with unicode emojis", async (assert) => {
   await visit("/t/internationalization-localization/280");
   await click("#topic-title .d-icon-pencil-alt");
 
@@ -172,26 +174,23 @@ QUnit.test("Updating the topic title with unicode emojis", async (assert) => {
   );
 });
 
-QUnit.test(
-  "Updating the topic title with unicode emojis without whitespaces",
-  async function (assert) {
-    this.siteSettings.enable_inline_emoji_translation = true;
-    await visit("/t/internationalization-localization/280");
-    await click("#topic-title .d-icon-pencil-alt");
+test("Updating the topic title with unicode emojis without whitespaces", async function (assert) {
+  this.siteSettings.enable_inline_emoji_translation = true;
+  await visit("/t/internationalization-localization/280");
+  await click("#topic-title .d-icon-pencil-alt");
 
-    await fillIn("#edit-title", "Test🙂Title");
+  await fillIn("#edit-title", "Test🙂Title");
 
-    await click("#topic-title .submit-edit");
+  await click("#topic-title .submit-edit");
 
-    assert.equal(
-      find(".fancy-title").html().trim(),
-      `Test<img width=\"20\" height=\"20\" src="/images/emoji/emoji_one/slightly_smiling_face.png?v=${v}" title="slightly_smiling_face" alt="slightly_smiling_face" class="emoji">Title`,
-      "it displays the new title with escaped unicode emojis"
-    );
-  }
-);
+  assert.equal(
+    find(".fancy-title").html().trim(),
+    `Test<img width=\"20\" height=\"20\" src="/images/emoji/emoji_one/slightly_smiling_face.png?v=${v}" title="slightly_smiling_face" alt="slightly_smiling_face" class="emoji">Title`,
+    "it displays the new title with escaped unicode emojis"
+  );
+});
 
-QUnit.test("Suggested topics", async (assert) => {
+test("Suggested topics", async (assert) => {
   await visit("/t/internationalization-localization/280");
 
   assert.equal(
@@ -200,7 +199,7 @@ QUnit.test("Suggested topics", async (assert) => {
   );
 });
 
-QUnit.skip("Deleting a topic", async (assert) => {
+skip("Deleting a topic", async (assert) => {
   await visit("/t/internationalization-localization/280");
   await click(".topic-post:eq(0) button.show-more-actions");
   await click(".widget-button.delete");
@@ -208,7 +207,7 @@ QUnit.skip("Deleting a topic", async (assert) => {
   assert.ok(exists(".widget-button.recover"), "it shows the recover button");
 });
 
-QUnit.test("Group category moderator posts", async (assert) => {
+test("Group category moderator posts", async (assert) => {
   await visit("/t/topic-for-group-moderators/2480");
 
   assert.ok(exists(".category-moderator"), "it has a class applied");
@@ -223,7 +222,7 @@ acceptance("Topic featured links", {
   },
 });
 
-QUnit.skip("remove featured link", async (assert) => {
+skip("remove featured link", async (assert) => {
   await visit("/t/-/299/1");
   assert.ok(
     exists(".title-wrapper .topic-featured-link"),
@@ -241,7 +240,7 @@ QUnit.skip("remove featured link", async (assert) => {
   assert.ok(!exists(".title-wrapper .topic-featured-link"), "link is gone");
 });
 
-QUnit.test("Converting to a public topic", async (assert) => {
+test("Converting to a public topic", async (assert) => {
   await visit("/t/test-pm/34");
   assert.ok(exists(".private_message"));
   await click(".toggle-admin-menu");
@@ -255,7 +254,7 @@ QUnit.test("Converting to a public topic", async (assert) => {
   assert.ok(!exists(".private_message"));
 });
 
-QUnit.test("Unpinning unlisted topic", async (assert) => {
+test("Unpinning unlisted topic", async (assert) => {
   await visit("/t/internationalization-localization/280");
 
   await click(".toggle-admin-menu");
@@ -269,7 +268,7 @@ QUnit.test("Unpinning unlisted topic", async (assert) => {
   assert.ok(exists(".topic-admin-pin"), "it should show the multi select menu");
 });
 
-QUnit.test("selecting posts", async (assert) => {
+test("selecting posts", async (assert) => {
   await visit("/t/internationalization-localization/280");
   await click(".toggle-admin-menu");
   await click(".topic-admin-multi-select .btn");
@@ -285,7 +284,7 @@ QUnit.test("selecting posts", async (assert) => {
   );
 });
 
-QUnit.test("select below", async (assert) => {
+test("select below", async (assert) => {
   await visit("/t/internationalization-localization/280");
   await click(".toggle-admin-menu");
   await click(".topic-admin-multi-select .btn");
@@ -308,7 +307,7 @@ QUnit.test("select below", async (assert) => {
   );
 });
 
-QUnit.test("View Hidden Replies", async (assert) => {
+test("View Hidden Replies", async (assert) => {
   await visit("/t/internationalization-localization/280");
   await click(".gap");
 
@@ -325,7 +324,7 @@ function selectText(selector) {
   selection.addRange(range);
 }
 
-QUnit.test("Quoting a quote keeps the original poster name", async (assert) => {
+test("Quoting a quote keeps the original poster name", async (assert) => {
   await visit("/t/internationalization-localization/280");
   selectText("#post_5 blockquote");
   await click(".quote-button .insert-quote");
@@ -337,68 +336,56 @@ QUnit.test("Quoting a quote keeps the original poster name", async (assert) => {
   );
 });
 
-QUnit.test(
-  "Quoting a quote of a different topic keeps the original topic title",
-  async (assert) => {
-    await visit("/t/internationalization-localization/280");
-    selectText("#post_9 blockquote");
-    await click(".quote-button .insert-quote");
+test("Quoting a quote of a different topic keeps the original topic title", async (assert) => {
+  await visit("/t/internationalization-localization/280");
+  selectText("#post_9 blockquote");
+  await click(".quote-button .insert-quote");
 
-    assert.ok(
-      find(".d-editor-input")
-        .val()
-        .indexOf(
-          'quote="A new topic with a link to another topic, post:3, topic:62"'
-        ) !== -1
-    );
-  }
-);
+  assert.ok(
+    find(".d-editor-input")
+      .val()
+      .indexOf(
+        'quote="A new topic with a link to another topic, post:3, topic:62"'
+      ) !== -1
+  );
+});
 
-QUnit.test(
-  "Quoting a quote with the Reply button keeps the original poster name",
-  async (assert) => {
-    await visit("/t/internationalization-localization/280");
-    selectText("#post_5 blockquote");
-    await click(".reply");
+test("Quoting a quote with the Reply button keeps the original poster name", async (assert) => {
+  await visit("/t/internationalization-localization/280");
+  selectText("#post_5 blockquote");
+  await click(".reply");
 
-    assert.ok(
-      find(".d-editor-input")
-        .val()
-        .indexOf('quote="codinghorror said, post:3, topic:280"') !== -1
-    );
-  }
-);
+  assert.ok(
+    find(".d-editor-input")
+      .val()
+      .indexOf('quote="codinghorror said, post:3, topic:280"') !== -1
+  );
+});
 
-QUnit.test(
-  "Quoting a quote with replyAsNewTopic keeps the original poster name",
-  async (assert) => {
-    await visit("/t/internationalization-localization/280");
-    selectText("#post_5 blockquote");
-    await keyEvent(document, "keypress", "j".charCodeAt(0));
-    await keyEvent(document, "keypress", "t".charCodeAt(0));
+test("Quoting a quote with replyAsNewTopic keeps the original poster name", async (assert) => {
+  await visit("/t/internationalization-localization/280");
+  selectText("#post_5 blockquote");
+  await keyEvent(document, "keypress", "j".charCodeAt(0));
+  await keyEvent(document, "keypress", "t".charCodeAt(0));
 
-    assert.ok(
-      find(".d-editor-input")
-        .val()
-        .indexOf('quote="codinghorror said, post:3, topic:280"') !== -1
-    );
-  }
-);
+  assert.ok(
+    find(".d-editor-input")
+      .val()
+      .indexOf('quote="codinghorror said, post:3, topic:280"') !== -1
+  );
+});
 
-QUnit.test(
-  "Quoting by selecting text can mark the quote as full",
-  async (assert) => {
-    await visit("/t/internationalization-localization/280");
-    selectText("#post_5 .cooked");
-    await click(".quote-button .insert-quote");
+test("Quoting by selecting text can mark the quote as full", async (assert) => {
+  await visit("/t/internationalization-localization/280");
+  selectText("#post_5 .cooked");
+  await click(".quote-button .insert-quote");
 
-    assert.ok(
-      find(".d-editor-input")
-        .val()
-        .indexOf('quote="pekka, post:5, topic:280, full:true"') !== -1
-    );
-  }
-);
+  assert.ok(
+    find(".d-editor-input")
+      .val()
+      .indexOf('quote="pekka, post:5, topic:280, full:true"') !== -1
+  );
+});
 
 acceptance("Topic with title decorated", {
   loggedIn: true,
@@ -411,7 +398,7 @@ acceptance("Topic with title decorated", {
   },
 });
 
-QUnit.test("Decorate topic title", async (assert) => {
+test("Decorate topic title", async (assert) => {
   await visit("/t/internationalization-localization/280");
 
   assert.ok(

--- a/app/assets/javascripts/discourse/tests/acceptance/unknown-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/unknown-test.js
@@ -1,13 +1,14 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import pretender from "discourse/tests/helpers/create-pretender";
 acceptance("Unknown");
 
-QUnit.test("Permalink Unknown URL", async (assert) => {
+test("Permalink Unknown URL", async (assert) => {
   await visit("/url-that-doesn't-exist");
   assert.ok(exists(".page-not-found"), "The not found content is present");
 });
 
-QUnit.test("Permalink URL to a Topic", async (assert) => {
+test("Permalink URL to a Topic", async (assert) => {
   pretender.get("/permalink-check.json", () => {
     return [
       200,
@@ -24,7 +25,7 @@ QUnit.test("Permalink URL to a Topic", async (assert) => {
   assert.ok(exists(".topic-post"));
 });
 
-QUnit.test("Permalink URL to a static page", async (assert) => {
+test("Permalink URL to a static page", async (assert) => {
   pretender.get("/permalink-check.json", () => {
     return [
       200,

--- a/app/assets/javascripts/discourse/tests/acceptance/user-anonymous-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-anonymous-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 acceptance("User Anonymous");
 
@@ -11,13 +12,13 @@ function hasTopicList(assert) {
   assert.ok(count(".topic-list tr") > 0, "it has a topic list");
 }
 
-QUnit.test("Root URL", async (assert) => {
+test("Root URL", async (assert) => {
   await visit("/u/eviltrout");
   assert.ok($("body.user-summary-page").length, "has the body class");
   assert.equal(currentPath(), "user.summary", "it defaults to summary");
 });
 
-QUnit.test("Filters", async (assert) => {
+test("Filters", async (assert) => {
   await visit("/u/eviltrout/activity");
   assert.ok($("body.user-activity-page").length, "has the body class");
   hasStream(assert);
@@ -31,13 +32,13 @@ QUnit.test("Filters", async (assert) => {
   assert.ok(exists(".user-stream.filter-5"), "stream has filter class");
 });
 
-QUnit.test("Badges", async (assert) => {
+test("Badges", async (assert) => {
   await visit("/u/eviltrout/badges");
   assert.ok($("body.user-badges-page").length, "has the body class");
   assert.ok(exists(".user-badges-list .badge-card"), "shows a badge");
 });
 
-QUnit.test("Restricted Routes", async (assert) => {
+test("Restricted Routes", async (assert) => {
   await visit("/u/eviltrout/preferences");
 
   assert.equal(

--- a/app/assets/javascripts/discourse/tests/acceptance/user-bookmarks-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-bookmarks-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import pretender from "discourse/tests/helpers/create-pretender";

--- a/app/assets/javascripts/discourse/tests/acceptance/user-card-mobile-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-card-mobile-test.js
@@ -1,9 +1,10 @@
+import { skip } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import DiscourseURL from "discourse/lib/url";
 
 acceptance("User Card - Mobile", { mobileView: true });
 
-QUnit.skip("user card", async (assert) => {
+skip("user card", async (assert) => {
   await visit("/t/internationalization-localization/280");
   assert.ok(
     invisible(".user-card"),

--- a/app/assets/javascripts/discourse/tests/acceptance/user-card-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-card-test.js
@@ -1,3 +1,5 @@
+import { skip } from "qunit";
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import DiscourseURL from "discourse/lib/url";
 
@@ -10,7 +12,7 @@ acceptance("User Card - Show Local Time", {
   settings: { display_local_time_in_user_card: true },
 });
 
-QUnit.skip("user card local time", async (assert) => {
+skip("user card local time", async (assert) => {
   User.current().changeTimezone("Australia/Brisbane");
   let cardResponse = Object.assign({}, userFixtures["/u/eviltrout/card.json"]);
   cardResponse.user.timezone = "Australia/Perth";
@@ -60,32 +62,29 @@ QUnit.skip("user card local time", async (assert) => {
   );
 });
 
-QUnit.test(
-  "user card local time - does not update timezone for another user",
-  async (assert) => {
-    User.current().changeTimezone("Australia/Brisbane");
-    let cardResponse = Object.assign({}, userFixtures["/u/charlie/card.json"]);
-    delete cardResponse.user.timezone;
+test("user card local time - does not update timezone for another user", async (assert) => {
+  User.current().changeTimezone("Australia/Brisbane");
+  let cardResponse = Object.assign({}, userFixtures["/u/charlie/card.json"]);
+  delete cardResponse.user.timezone;
 
-    pretender.get("/u/charlie/card.json", () => [
-      200,
-      { "Content-Type": "application/json" },
-      cardResponse,
-    ]);
+  pretender.get("/u/charlie/card.json", () => [
+    200,
+    { "Content-Type": "application/json" },
+    cardResponse,
+  ]);
 
-    await visit("/t/internationalization-localization/280");
-    await click("a[data-user-card=charlie]:first");
+  await visit("/t/internationalization-localization/280");
+  await click("a[data-user-card=charlie]:first");
 
-    assert.not(
-      exists(".user-card .local-time"),
-      "it does not show the local time if the user card returns a null/undefined timezone for another user"
-    );
-  }
-);
+  assert.not(
+    exists(".user-card .local-time"),
+    "it does not show the local time if the user card returns a null/undefined timezone for another user"
+  );
+});
 
 acceptance("User Card", { loggedIn: true });
 
-QUnit.skip("user card", async (assert) => {
+skip("user card", async (assert) => {
   await visit("/t/internationalization-localization/280");
   assert.ok(invisible(".user-card"), "user card is invisible by default");
 

--- a/app/assets/javascripts/discourse/tests/acceptance/user-drafts-stream-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-drafts-stream-test.js
@@ -1,8 +1,9 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("User Drafts", { loggedIn: true });
 
-QUnit.test("Stream", async (assert) => {
+test("Stream", async (assert) => {
   await visit("/u/eviltrout/activity/drafts");
   assert.ok(find(".user-stream-item").length === 3, "has drafts");
 
@@ -13,7 +14,7 @@ QUnit.test("Stream", async (assert) => {
   );
 });
 
-QUnit.test("Stream - resume draft", async (assert) => {
+test("Stream - resume draft", async (assert) => {
   await visit("/u/eviltrout/activity/drafts");
   assert.ok(find(".user-stream-item").length > 0, "has drafts");
 

--- a/app/assets/javascripts/discourse/tests/acceptance/user-preferences-interface-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-preferences-interface-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import Site from "discourse/models/site";
@@ -8,7 +9,7 @@ acceptance("User Preferences - Interface", {
   loggedIn: true,
 });
 
-QUnit.test("font size change", async (assert) => {
+test("font size change", async (assert) => {
   removeCookie("text_size");
 
   const savePreferences = async () => {
@@ -53,15 +54,12 @@ QUnit.test("font size change", async (assert) => {
   removeCookie("text_size");
 });
 
-QUnit.test(
-  "does not show option to disable dark mode by default",
-  async (assert) => {
-    await visit("/u/eviltrout/preferences/interface");
-    assert.equal($(".control-group.dark-mode").length, 0);
-  }
-);
+test("does not show option to disable dark mode by default", async (assert) => {
+  await visit("/u/eviltrout/preferences/interface");
+  assert.equal($(".control-group.dark-mode").length, 0);
+});
 
-QUnit.test("shows light/dark color scheme pickers", async (assert) => {
+test("shows light/dark color scheme pickers", async (assert) => {
   let site = Site.current();
   site.set("user_color_schemes", [
     { id: 2, name: "Cool Breeze" },
@@ -87,7 +85,7 @@ acceptance("User Preferences Color Schemes (with default dark scheme)", {
   pretend: interfacePretender,
 });
 
-QUnit.test("show option to disable dark mode", async (assert) => {
+test("show option to disable dark mode", async (assert) => {
   await visit("/u/eviltrout/preferences/interface");
 
   assert.ok(
@@ -96,7 +94,7 @@ QUnit.test("show option to disable dark mode", async (assert) => {
   );
 });
 
-QUnit.test("no color scheme picker by default", async (assert) => {
+test("no color scheme picker by default", async (assert) => {
   let site = Site.current();
   site.set("user_color_schemes", []);
 
@@ -104,7 +102,7 @@ QUnit.test("no color scheme picker by default", async (assert) => {
   assert.equal($(".control-group.color-scheme").length, 0);
 });
 
-QUnit.test("light color scheme picker", async (assert) => {
+test("light color scheme picker", async (assert) => {
   let site = Site.current();
   site.set("user_color_schemes", [{ id: 2, name: "Cool Breeze" }]);
 
@@ -117,7 +115,7 @@ QUnit.test("light color scheme picker", async (assert) => {
   );
 });
 
-QUnit.test("light and dark color scheme pickers", async (assert) => {
+test("light and dark color scheme pickers", async (assert) => {
   let site = Site.current();
   let session = Session.current();
   session.userDarkSchemeId = 1; // same as default set in site settings

--- a/app/assets/javascripts/discourse/tests/acceptance/user-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import pretender from "discourse/tests/helpers/create-pretender";
 import Draft from "discourse/models/draft";
@@ -5,7 +6,7 @@ import { Promise } from "rsvp";
 
 acceptance("User", { loggedIn: true });
 
-QUnit.test("Invalid usernames", async (assert) => {
+test("Invalid usernames", async (assert) => {
   pretender.get("/u/eviltrout%2F..%2F..%2F.json", () => {
     return [400, { "Content-Type": "application/json" }, {}];
   });
@@ -15,23 +16,23 @@ QUnit.test("Invalid usernames", async (assert) => {
   assert.equal(currentPath(), "exception-unknown");
 });
 
-QUnit.test("Unicode usernames", async (assert) => {
+test("Unicode usernames", async (assert) => {
   await visit("/u/%E3%83%A9%E3%82%A4%E3%82%AA%E3%83%B3/summary");
 
   assert.equal(currentPath(), "user.summary");
 });
 
-QUnit.test("Invites", async (assert) => {
+test("Invites", async (assert) => {
   await visit("/u/eviltrout/invited/pending");
   assert.ok($("body.user-invites-page").length, "has the body class");
 });
 
-QUnit.test("Messages", async (assert) => {
+test("Messages", async (assert) => {
   await visit("/u/eviltrout/messages");
   assert.ok($("body.user-messages-page").length, "has the body class");
 });
 
-QUnit.test("Notifications", async (assert) => {
+test("Notifications", async (assert) => {
   await visit("/u/eviltrout/notifications");
   assert.ok($("body.user-notifications-page").length, "has the body class");
 
@@ -44,7 +45,7 @@ QUnit.test("Notifications", async (assert) => {
   );
 });
 
-QUnit.test("Root URL - Viewing Self", async (assert) => {
+test("Root URL - Viewing Self", async (assert) => {
   await visit("/u/eviltrout");
   assert.ok($("body.user-activity-page").length, "has the body class");
   assert.equal(
@@ -55,7 +56,7 @@ QUnit.test("Root URL - Viewing Self", async (assert) => {
   assert.ok(exists(".container.viewing-self"), "has the viewing-self class");
 });
 
-QUnit.test("Viewing Summary", async (assert) => {
+test("Viewing Summary", async (assert) => {
   await visit("/u/eviltrout/summary");
 
   assert.ok(exists(".replies-section li a"), "replies");
@@ -68,7 +69,7 @@ QUnit.test("Viewing Summary", async (assert) => {
   assert.ok(exists(".top-categories-section .category-link"), "top categories");
 });
 
-QUnit.test("Viewing Drafts", async (assert) => {
+test("Viewing Drafts", async (assert) => {
   sandbox.stub(Draft, "get").returns(
     Promise.resolve({
       draft: null,

--- a/app/assets/javascripts/discourse/tests/acceptance/users-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/users-test.js
@@ -1,24 +1,25 @@
+import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 acceptance("User Directory");
 
-QUnit.test("Visit Page", async (assert) => {
+test("Visit Page", async (assert) => {
   await visit("/u");
   assert.ok($("body.users-page").length, "has the body class");
   assert.ok(exists(".directory table tr"), "has a list of users");
 });
 
-QUnit.test("Visit All Time", async (assert) => {
+test("Visit All Time", async (assert) => {
   await visit("/u?period=all");
   assert.ok(exists(".time-read"), "has time read column");
 });
 
-QUnit.test("Visit Without Usernames", async (assert) => {
+test("Visit Without Usernames", async (assert) => {
   await visit("/u?exclude_usernames=system");
   assert.ok($("body.users-page").length, "has the body class");
   assert.ok(exists(".directory table tr"), "has a list of users");
 });
 
-QUnit.test("Visit With Group Filter", async (assert) => {
+test("Visit With Group Filter", async (assert) => {
   await visit("/u?group=trust_level_0");
   assert.ok($("body.users-page").length, "has the body class");
   assert.ok(exists(".directory table tr"), "has a list of users");

--- a/app/assets/javascripts/discourse/tests/helpers/component-test.js
+++ b/app/assets/javascripts/discourse/tests/helpers/component-test.js
@@ -6,6 +6,7 @@ import User from "discourse/models/user";
 import Site from "discourse/models/site";
 import Session from "discourse/models/session";
 import { currentSettings } from "discourse/tests/helpers/site-settings";
+import { test } from "qunit";
 
 export default function (name, opts) {
   opts = opts || {};

--- a/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
+++ b/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
@@ -35,6 +35,7 @@ import { setTopicList } from "discourse/lib/topic-list-tracker";
 import { setURLContainer } from "discourse/lib/url";
 import { setDefaultOwner } from "discourse-common/lib/get-owner";
 import bootbox from "bootbox";
+import { moduleFor } from "ember-qunit";
 
 export function currentUser() {
   return User.create(sessionFixtures["/session/current.json"].current_user);
@@ -134,7 +135,7 @@ export function controllerModule(name, args = {}) {
 }
 
 export function discourseModule(name, hooks) {
-  QUnit.module(name, {
+  module(name, {
     beforeEach() {
       this.container = getOwner(this);
       this.siteSettings = currentSettings();
@@ -157,7 +158,7 @@ export function acceptance(name, options) {
     _pretenderCallbacks[name] = options.pretend;
   }
 
-  QUnit.module("Acceptance: " + name, {
+  module("Acceptance: " + name, {
     beforeEach() {
       resetMobile();
 

--- a/app/assets/javascripts/discourse/tests/helpers/select-kit-helper.js
+++ b/app/assets/javascripts/discourse/tests/helpers/select-kit-helper.js
@@ -1,3 +1,4 @@
+import { moduleForComponent } from "ember-qunit";
 import { isEmpty } from "@ember/utils";
 
 function checkSelectKitIsNotExpanded(selector) {

--- a/app/assets/javascripts/discourse/tests/helpers/widget-test.js
+++ b/app/assets/javascripts/discourse/tests/helpers/widget-test.js
@@ -1,3 +1,4 @@
+import { moduleForComponent } from "ember-qunit";
 import componentTest from "discourse/tests/helpers/component-test";
 
 export function moduleForWidget(name, options = {}) {

--- a/app/assets/javascripts/discourse/tests/integration/components/ace-editor-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/ace-editor-test.js
@@ -1,4 +1,5 @@
 import componentTest from "discourse/tests/helpers/component-test";
+import { moduleForComponent } from "ember-qunit";
 
 moduleForComponent("ace-editor", { integration: true });
 

--- a/app/assets/javascripts/discourse/tests/integration/components/admin-report-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/admin-report-test.js
@@ -1,3 +1,4 @@
+import { moduleForComponent } from "ember-qunit";
 import componentTest from "discourse/tests/helpers/component-test";
 import pretender from "discourse/tests/helpers/create-pretender";
 

--- a/app/assets/javascripts/discourse/tests/integration/components/badge-title-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/badge-title-test.js
@@ -1,3 +1,4 @@
+import { moduleForComponent } from "ember-qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import componentTest from "discourse/tests/helpers/component-test";
 import EmberObject from "@ember/object";

--- a/app/assets/javascripts/discourse/tests/integration/components/cook-text-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/cook-text-test.js
@@ -1,3 +1,4 @@
+import { moduleForComponent } from "ember-qunit";
 import componentTest from "discourse/tests/helpers/component-test";
 import pretender from "discourse/tests/helpers/create-pretender";
 import { resetCache } from "pretty-text/upload-short-url";

--- a/app/assets/javascripts/discourse/tests/integration/components/d-button-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/d-button-test.js
@@ -1,3 +1,4 @@
+import { moduleForComponent } from "ember-qunit";
 import I18n from "I18n";
 import componentTest from "discourse/tests/helpers/component-test";
 moduleForComponent("d-button", { integration: true });

--- a/app/assets/javascripts/discourse/tests/integration/components/d-editor-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/d-editor-test.js
@@ -1,3 +1,4 @@
+import { moduleForComponent } from "ember-qunit";
 import I18n from "I18n";
 import { next } from "@ember/runloop";
 import { clearToolbarCallbacks } from "discourse/components/d-editor";

--- a/app/assets/javascripts/discourse/tests/integration/components/d-icon-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/d-icon-test.js
@@ -1,3 +1,4 @@
+import { moduleForComponent } from "ember-qunit";
 import componentTest from "discourse/tests/helpers/component-test";
 
 moduleForComponent("d-icon", { integration: true });

--- a/app/assets/javascripts/discourse/tests/integration/components/date-input-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/date-input-test.js
@@ -1,3 +1,4 @@
+import { moduleForComponent } from "ember-qunit";
 import componentTest from "discourse/tests/helpers/component-test";
 
 moduleForComponent("date-input", { integration: true });

--- a/app/assets/javascripts/discourse/tests/integration/components/date-time-input-range-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/date-time-input-range-test.js
@@ -1,3 +1,4 @@
+import { moduleForComponent } from "ember-qunit";
 import componentTest from "discourse/tests/helpers/component-test";
 
 moduleForComponent("date-time-input-range", { integration: true });

--- a/app/assets/javascripts/discourse/tests/integration/components/date-time-input-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/date-time-input-test.js
@@ -1,3 +1,4 @@
+import { moduleForComponent } from "ember-qunit";
 import componentTest from "discourse/tests/helpers/component-test";
 
 moduleForComponent("date-time-input", { integration: true });

--- a/app/assets/javascripts/discourse/tests/integration/components/group-membership-button-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/group-membership-button-test.js
@@ -1,6 +1,9 @@
+import { test } from "qunit";
+import { moduleFor } from "ember-qunit";
+
 moduleFor("component:group-membership-button");
 
-QUnit.test("canJoinGroup", function (assert) {
+test("canJoinGroup", function (assert) {
   this.subject().setProperties({
     model: { public_admission: false, is_group_user: true },
   });
@@ -28,7 +31,7 @@ QUnit.test("canJoinGroup", function (assert) {
   );
 });
 
-QUnit.test("canLeaveGroup", function (assert) {
+test("canLeaveGroup", function (assert) {
   this.subject().setProperties({
     model: { public_exit: false, is_group_user: false },
   });
@@ -56,7 +59,7 @@ QUnit.test("canLeaveGroup", function (assert) {
   );
 });
 
-QUnit.test("canRequestMembership", function (assert) {
+test("canRequestMembership", function (assert) {
   this.subject().setProperties({
     model: { allow_membership_requests: true, is_group_user: true },
   });
@@ -76,7 +79,7 @@ QUnit.test("canRequestMembership", function (assert) {
   );
 });
 
-QUnit.test("userIsGroupUser", function (assert) {
+test("userIsGroupUser", function (assert) {
   this.subject().setProperties({
     model: { is_group_user: true },
   });

--- a/app/assets/javascripts/discourse/tests/integration/components/highlighted-code-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/highlighted-code-test.js
@@ -1,3 +1,4 @@
+import { moduleForComponent } from "ember-qunit";
 import componentTest from "discourse/tests/helpers/component-test";
 
 const LONG_CODE_BLOCK = "puts a\n".repeat(15000);

--- a/app/assets/javascripts/discourse/tests/integration/components/html-safe-helper-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/html-safe-helper-test.js
@@ -1,3 +1,4 @@
+import { moduleForComponent } from "ember-qunit";
 import componentTest from "discourse/tests/helpers/component-test";
 moduleForComponent("html-safe-helper", { integration: true });
 

--- a/app/assets/javascripts/discourse/tests/integration/components/iframed-html-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/iframed-html-test.js
@@ -1,3 +1,4 @@
+import { moduleForComponent } from "ember-qunit";
 import componentTest from "discourse/tests/helpers/component-test";
 
 moduleForComponent("iframed-html", { integration: true });

--- a/app/assets/javascripts/discourse/tests/integration/components/image-uploader-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/image-uploader-test.js
@@ -1,3 +1,4 @@
+import { moduleForComponent } from "ember-qunit";
 import componentTest from "discourse/tests/helpers/component-test";
 moduleForComponent("image-uploader", { integration: true });
 

--- a/app/assets/javascripts/discourse/tests/integration/components/keyboard-shortcuts-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/keyboard-shortcuts-test.js
@@ -1,9 +1,10 @@
+import { test, module } from "qunit";
 import DiscourseURL from "discourse/lib/url";
 
 var testMouseTrap;
 import KeyboardShortcuts from "discourse/lib/keyboard-shortcuts";
 
-QUnit.module("lib:keyboard-shortcuts", {
+module("lib:keyboard-shortcuts", {
   beforeEach() {
     var _bindings = {};
 
@@ -115,21 +116,21 @@ Object.keys(functionBindings).forEach((func) => {
   });
 });
 
-QUnit.test("selectDown calls _moveSelection with 1", (assert) => {
+test("selectDown calls _moveSelection with 1", (assert) => {
   var stub = sandbox.stub(KeyboardShortcuts, "_moveSelection");
 
   KeyboardShortcuts.selectDown();
   assert.ok(stub.calledWith(1), "_moveSelection is called with 1");
 });
 
-QUnit.test("selectUp calls _moveSelection with -1", (assert) => {
+test("selectUp calls _moveSelection with -1", (assert) => {
   var stub = sandbox.stub(KeyboardShortcuts, "_moveSelection");
 
   KeyboardShortcuts.selectUp();
   assert.ok(stub.calledWith(-1), "_moveSelection is called with -1");
 });
 
-QUnit.test("goBack calls history.back", (assert) => {
+test("goBack calls history.back", (assert) => {
   var called = false;
   sandbox.stub(history, "back").callsFake(function () {
     called = true;
@@ -139,14 +140,14 @@ QUnit.test("goBack calls history.back", (assert) => {
   assert.ok(called, "history.back is called");
 });
 
-QUnit.test("nextSection calls _changeSection with 1", (assert) => {
+test("nextSection calls _changeSection with 1", (assert) => {
   var spy = sandbox.spy(KeyboardShortcuts, "_changeSection");
 
   KeyboardShortcuts.nextSection();
   assert.ok(spy.calledWith(1), "_changeSection is called with 1");
 });
 
-QUnit.test("prevSection calls _changeSection with -1", (assert) => {
+test("prevSection calls _changeSection with -1", (assert) => {
   var spy = sandbox.spy(KeyboardShortcuts, "_changeSection");
 
   KeyboardShortcuts.prevSection();

--- a/app/assets/javascripts/discourse/tests/integration/components/load-more-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/load-more-test.js
@@ -1,3 +1,4 @@
+import { moduleForComponent } from "ember-qunit";
 import { configureEyeline } from "discourse/lib/eyeline";
 import componentTest from "discourse/tests/helpers/component-test";
 

--- a/app/assets/javascripts/discourse/tests/integration/components/secret-value-list-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/secret-value-list-test.js
@@ -1,3 +1,4 @@
+import { moduleForComponent } from "ember-qunit";
 import I18n from "I18n";
 import componentTest from "discourse/tests/helpers/component-test";
 moduleForComponent("secret-value-list", { integration: true });

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/combo-box-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/combo-box-test.js
@@ -1,3 +1,4 @@
+import { moduleForComponent } from "ember-qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import componentTest from "discourse/tests/helpers/component-test";
 

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/dropdown-select-box-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/dropdown-select-box-test.js
@@ -1,3 +1,4 @@
+import { moduleForComponent } from "ember-qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import componentTest from "discourse/tests/helpers/component-test";
 

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/pinned-options-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/pinned-options-test.js
@@ -1,3 +1,4 @@
+import { moduleForComponent } from "ember-qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import componentTest from "discourse/tests/helpers/component-test";
 import Topic from "discourse/models/topic";

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/topic-notifications-button-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/topic-notifications-button-test.js
@@ -1,3 +1,4 @@
+import { moduleForComponent } from "ember-qunit";
 import I18n from "I18n";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import componentTest from "discourse/tests/helpers/component-test";

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/topic-notifications-options-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/topic-notifications-options-test.js
@@ -1,3 +1,4 @@
+import { moduleForComponent } from "ember-qunit";
 import I18n from "I18n";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import componentTest from "discourse/tests/helpers/component-test";

--- a/app/assets/javascripts/discourse/tests/integration/components/share-button-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/share-button-test.js
@@ -1,3 +1,4 @@
+import { moduleForComponent } from "ember-qunit";
 import componentTest from "discourse/tests/helpers/component-test";
 
 moduleForComponent("share-button", { integration: true });

--- a/app/assets/javascripts/discourse/tests/integration/components/simple-list-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/simple-list-test.js
@@ -1,3 +1,4 @@
+import { moduleForComponent } from "ember-qunit";
 import componentTest from "discourse/tests/helpers/component-test";
 moduleForComponent("simple-list", { integration: true });
 

--- a/app/assets/javascripts/discourse/tests/integration/components/text-field-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/text-field-test.js
@@ -1,3 +1,4 @@
+import { moduleForComponent } from "ember-qunit";
 import I18n from "I18n";
 import componentTest from "discourse/tests/helpers/component-test";
 

--- a/app/assets/javascripts/discourse/tests/integration/components/time-input-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/time-input-test.js
@@ -1,3 +1,4 @@
+import { moduleForComponent } from "ember-qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import componentTest from "discourse/tests/helpers/component-test";
 

--- a/app/assets/javascripts/discourse/tests/integration/components/user-selector-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/user-selector-test.js
@@ -1,3 +1,4 @@
+import { moduleForComponent } from "ember-qunit";
 import componentTest from "discourse/tests/helpers/component-test";
 
 moduleForComponent("user-selector", { integration: true });

--- a/app/assets/javascripts/discourse/tests/integration/components/value-list-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/value-list-test.js
@@ -1,3 +1,4 @@
+import { moduleForComponent } from "ember-qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import componentTest from "discourse/tests/helpers/component-test";
 moduleForComponent("value-list", { integration: true });

--- a/app/assets/javascripts/discourse/tests/unit/controllers/avatar-selector-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/controllers/avatar-selector-test.js
@@ -1,3 +1,5 @@
+import { moduleFor } from "ember-qunit";
+import { test } from "qunit";
 import { mapRoutes } from "discourse/mapping-router";
 
 moduleFor("controller:avatar-selector", "controller:avatar-selector", {
@@ -7,7 +9,7 @@ moduleFor("controller:avatar-selector", "controller:avatar-selector", {
   needs: ["controller:modal"],
 });
 
-QUnit.test("avatarTemplate", function (assert) {
+test("avatarTemplate", function (assert) {
   const avatarSelectorController = this.subject();
 
   avatarSelectorController.setProperties({

--- a/app/assets/javascripts/discourse/tests/unit/controllers/bookmark-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/controllers/bookmark-test.js
@@ -1,3 +1,5 @@
+import { moduleFor } from "ember-qunit";
+import { test } from "qunit";
 import { logIn } from "discourse/tests/helpers/qunit-helpers";
 import User from "discourse/models/user";
 import KeyboardShortcutInitializer from "discourse/initializers/keyboard-shortcuts";
@@ -26,39 +28,29 @@ function mockMomentTz(dateString) {
   fakeTime(dateString, BookmarkController.userTimezone);
 }
 
-QUnit.test("showLaterToday when later today is tomorrow do not show", function (
-  assert
-) {
+test("showLaterToday when later today is tomorrow do not show", function (assert) {
   mockMomentTz("2019-12-11T22:00:00");
 
   assert.equal(BookmarkController.get("showLaterToday"), false);
 });
 
-QUnit.test(
-  "showLaterToday when later today is after 5pm but before 6pm",
-  function (assert) {
-    mockMomentTz("2019-12-11T15:00:00");
-    assert.equal(BookmarkController.get("showLaterToday"), true);
-  }
-);
+test("showLaterToday when later today is after 5pm but before 6pm", function (assert) {
+  mockMomentTz("2019-12-11T15:00:00");
+  assert.equal(BookmarkController.get("showLaterToday"), true);
+});
 
-QUnit.test("showLaterToday when now is after the cutoff time (5pm)", function (
-  assert
-) {
+test("showLaterToday when now is after the cutoff time (5pm)", function (assert) {
   mockMomentTz("2019-12-11T17:00:00");
   assert.equal(BookmarkController.get("showLaterToday"), false);
 });
 
-QUnit.test(
-  "showLaterToday when later today is before the end of the day, show",
-  function (assert) {
-    mockMomentTz("2019-12-11T10:00:00");
+test("showLaterToday when later today is before the end of the day, show", function (assert) {
+  mockMomentTz("2019-12-11T10:00:00");
 
-    assert.equal(BookmarkController.get("showLaterToday"), true);
-  }
-);
+  assert.equal(BookmarkController.get("showLaterToday"), true);
+});
 
-QUnit.test("nextWeek gets next week correctly", function (assert) {
+test("nextWeek gets next week correctly", function (assert) {
   mockMomentTz("2019-12-11T08:00:00");
 
   assert.equal(
@@ -67,7 +59,7 @@ QUnit.test("nextWeek gets next week correctly", function (assert) {
   );
 });
 
-QUnit.test("nextMonth gets next month correctly", function (assert) {
+test("nextMonth gets next month correctly", function (assert) {
   mockMomentTz("2019-12-11T08:00:00");
 
   assert.equal(
@@ -76,7 +68,7 @@ QUnit.test("nextMonth gets next month correctly", function (assert) {
   );
 });
 
-QUnit.test("laterThisWeek gets 2 days from now", function (assert) {
+test("laterThisWeek gets 2 days from now", function (assert) {
   mockMomentTz("2019-12-10T08:00:00");
 
   assert.equal(
@@ -85,27 +77,24 @@ QUnit.test("laterThisWeek gets 2 days from now", function (assert) {
   );
 });
 
-QUnit.test(
-  "laterThisWeek returns null if we are at Thursday already",
-  function (assert) {
-    mockMomentTz("2019-12-12T08:00:00");
+test("laterThisWeek returns null if we are at Thursday already", function (assert) {
+  mockMomentTz("2019-12-12T08:00:00");
 
-    assert.equal(BookmarkController.laterThisWeek(), null);
-  }
-);
+  assert.equal(BookmarkController.laterThisWeek(), null);
+});
 
-QUnit.test("showLaterThisWeek returns true if < Thursday", function (assert) {
+test("showLaterThisWeek returns true if < Thursday", function (assert) {
   mockMomentTz("2019-12-10T08:00:00");
 
   assert.equal(BookmarkController.showLaterThisWeek, true);
 });
 
-QUnit.test("showLaterThisWeek returns false if > Thursday", function (assert) {
+test("showLaterThisWeek returns false if > Thursday", function (assert) {
   mockMomentTz("2019-12-12T08:00:00");
 
   assert.equal(BookmarkController.showLaterThisWeek, false);
 });
-QUnit.test("tomorrow gets tomorrow correctly", function (assert) {
+test("tomorrow gets tomorrow correctly", function (assert) {
   mockMomentTz("2019-12-11T08:00:00");
 
   assert.equal(
@@ -114,146 +103,125 @@ QUnit.test("tomorrow gets tomorrow correctly", function (assert) {
   );
 });
 
-QUnit.test(
-  "startOfDay changes the time of the provided date to 8:00am correctly",
-  function (assert) {
-    let dt = moment.tz(
-      "2019-12-11T11:37:16",
-      BookmarkController.currentUser.resolvedTimezone(
-        BookmarkController.currentUser
-      )
-    );
+test("startOfDay changes the time of the provided date to 8:00am correctly", function (assert) {
+  let dt = moment.tz(
+    "2019-12-11T11:37:16",
+    BookmarkController.currentUser.resolvedTimezone(
+      BookmarkController.currentUser
+    )
+  );
 
-    assert.equal(
-      BookmarkController.startOfDay(dt).format("YYYY-MM-DD HH:mm:ss"),
-      "2019-12-11 08:00:00"
-    );
-  }
-);
+  assert.equal(
+    BookmarkController.startOfDay(dt).format("YYYY-MM-DD HH:mm:ss"),
+    "2019-12-11 08:00:00"
+  );
+});
 
-QUnit.test(
-  "laterToday gets 3 hours from now and if before half-past, it rounds down",
-  function (assert) {
-    mockMomentTz("2019-12-11T08:13:00");
+test("laterToday gets 3 hours from now and if before half-past, it rounds down", function (assert) {
+  mockMomentTz("2019-12-11T08:13:00");
 
-    assert.equal(
-      BookmarkController.laterToday().format("YYYY-MM-DD HH:mm:ss"),
-      "2019-12-11 11:00:00"
-    );
-  }
-);
+  assert.equal(
+    BookmarkController.laterToday().format("YYYY-MM-DD HH:mm:ss"),
+    "2019-12-11 11:00:00"
+  );
+});
 
-QUnit.test(
-  "laterToday gets 3 hours from now and if after half-past, it rounds up to the next hour",
-  function (assert) {
-    mockMomentTz("2019-12-11T08:43:00");
+test("laterToday gets 3 hours from now and if after half-past, it rounds up to the next hour", function (assert) {
+  mockMomentTz("2019-12-11T08:43:00");
 
-    assert.equal(
-      BookmarkController.laterToday().format("YYYY-MM-DD HH:mm:ss"),
-      "2019-12-11 12:00:00"
-    );
-  }
-);
+  assert.equal(
+    BookmarkController.laterToday().format("YYYY-MM-DD HH:mm:ss"),
+    "2019-12-11 12:00:00"
+  );
+});
 
-QUnit.test(
-  "laterToday is capped to 6pm. later today at 3pm = 6pm, 3:30pm = 6pm, 4pm = 6pm, 4:59pm = 6pm",
-  function (assert) {
-    mockMomentTz("2019-12-11T15:00:00");
+test("laterToday is capped to 6pm. later today at 3pm = 6pm, 3:30pm = 6pm, 4pm = 6pm, 4:59pm = 6pm", function (assert) {
+  mockMomentTz("2019-12-11T15:00:00");
 
-    assert.equal(
-      BookmarkController.laterToday().format("YYYY-MM-DD HH:mm:ss"),
-      "2019-12-11 18:00:00",
-      "3pm should max to 6pm"
-    );
+  assert.equal(
+    BookmarkController.laterToday().format("YYYY-MM-DD HH:mm:ss"),
+    "2019-12-11 18:00:00",
+    "3pm should max to 6pm"
+  );
 
-    mockMomentTz("2019-12-11T15:31:00");
+  mockMomentTz("2019-12-11T15:31:00");
 
-    assert.equal(
-      BookmarkController.laterToday().format("YYYY-MM-DD HH:mm:ss"),
-      "2019-12-11 18:00:00",
-      "3:30pm should max to 6pm"
-    );
+  assert.equal(
+    BookmarkController.laterToday().format("YYYY-MM-DD HH:mm:ss"),
+    "2019-12-11 18:00:00",
+    "3:30pm should max to 6pm"
+  );
 
-    mockMomentTz("2019-12-11T16:00:00");
+  mockMomentTz("2019-12-11T16:00:00");
 
-    assert.equal(
-      BookmarkController.laterToday().format("YYYY-MM-DD HH:mm:ss"),
-      "2019-12-11 18:00:00",
-      "4pm should max to 6pm"
-    );
+  assert.equal(
+    BookmarkController.laterToday().format("YYYY-MM-DD HH:mm:ss"),
+    "2019-12-11 18:00:00",
+    "4pm should max to 6pm"
+  );
 
-    mockMomentTz("2019-12-11T16:59:00");
+  mockMomentTz("2019-12-11T16:59:00");
 
-    assert.equal(
-      BookmarkController.laterToday().format("YYYY-MM-DD HH:mm:ss"),
-      "2019-12-11 18:00:00",
-      "4:59pm should max to 6pm"
-    );
-  }
-);
+  assert.equal(
+    BookmarkController.laterToday().format("YYYY-MM-DD HH:mm:ss"),
+    "2019-12-11 18:00:00",
+    "4:59pm should max to 6pm"
+  );
+});
 
-QUnit.test("showLaterToday returns false if >= 5PM", function (assert) {
+test("showLaterToday returns false if >= 5PM", function (assert) {
   mockMomentTz("2019-12-11T17:00:01");
   assert.equal(BookmarkController.showLaterToday, false);
 });
 
-QUnit.test("showLaterToday returns false if >= 5PM", function (assert) {
+test("showLaterToday returns false if >= 5PM", function (assert) {
   mockMomentTz("2019-12-11T17:00:01");
   assert.equal(BookmarkController.showLaterToday, false);
 });
 
-QUnit.test(
-  "reminderAt - custom - defaults to 8:00am if the time is not selected",
-  function (assert) {
-    BookmarkController.customReminderDate = "2028-12-12";
-    BookmarkController.selectedReminderType =
-      BookmarkController.reminderTypes.CUSTOM;
-    const reminderAt = BookmarkController._reminderAt();
-    assert.equal(BookmarkController.customReminderTime, "08:00");
-    assert.equal(
-      reminderAt.toString(),
-      moment
-        .tz(
-          "2028-12-12 08:00",
-          BookmarkController.currentUser.resolvedTimezone(
-            BookmarkController.currentUser
-          )
+test("reminderAt - custom - defaults to 8:00am if the time is not selected", function (assert) {
+  BookmarkController.customReminderDate = "2028-12-12";
+  BookmarkController.selectedReminderType =
+    BookmarkController.reminderTypes.CUSTOM;
+  const reminderAt = BookmarkController._reminderAt();
+  assert.equal(BookmarkController.customReminderTime, "08:00");
+  assert.equal(
+    reminderAt.toString(),
+    moment
+      .tz(
+        "2028-12-12 08:00",
+        BookmarkController.currentUser.resolvedTimezone(
+          BookmarkController.currentUser
         )
-        .toString(),
-      "the custom date and time are parsed correctly with default time"
-    );
-  }
-);
+      )
+      .toString(),
+    "the custom date and time are parsed correctly with default time"
+  );
+});
 
-QUnit.test(
-  "loadLastUsedCustomReminderDatetime fills the custom reminder date + time if present in localStorage",
-  function (assert) {
-    mockMomentTz("2019-12-11T08:00:00");
-    localStorage.lastCustomBookmarkReminderDate = "2019-12-12";
-    localStorage.lastCustomBookmarkReminderTime = "08:00";
+test("loadLastUsedCustomReminderDatetime fills the custom reminder date + time if present in localStorage", function (assert) {
+  mockMomentTz("2019-12-11T08:00:00");
+  localStorage.lastCustomBookmarkReminderDate = "2019-12-12";
+  localStorage.lastCustomBookmarkReminderTime = "08:00";
 
-    BookmarkController._loadLastUsedCustomReminderDatetime();
+  BookmarkController._loadLastUsedCustomReminderDatetime();
 
-    assert.equal(BookmarkController.lastCustomReminderDate, "2019-12-12");
-    assert.equal(BookmarkController.lastCustomReminderTime, "08:00");
-  }
-);
+  assert.equal(BookmarkController.lastCustomReminderDate, "2019-12-12");
+  assert.equal(BookmarkController.lastCustomReminderTime, "08:00");
+});
 
-QUnit.test(
-  "loadLastUsedCustomReminderDatetime does not fills the custom reminder date + time if the datetime in localStorage is < now",
-  function (assert) {
-    mockMomentTz("2019-12-11T08:00:00");
-    localStorage.lastCustomBookmarkReminderDate = "2019-12-11";
-    localStorage.lastCustomBookmarkReminderTime = "07:00";
+test("loadLastUsedCustomReminderDatetime does not fills the custom reminder date + time if the datetime in localStorage is < now", function (assert) {
+  mockMomentTz("2019-12-11T08:00:00");
+  localStorage.lastCustomBookmarkReminderDate = "2019-12-11";
+  localStorage.lastCustomBookmarkReminderTime = "07:00";
 
-    BookmarkController._loadLastUsedCustomReminderDatetime();
+  BookmarkController._loadLastUsedCustomReminderDatetime();
 
-    assert.equal(BookmarkController.lastCustomReminderDate, null);
-    assert.equal(BookmarkController.lastCustomReminderTime, null);
-  }
-);
+  assert.equal(BookmarkController.lastCustomReminderDate, null);
+  assert.equal(BookmarkController.lastCustomReminderTime, null);
+});
 
-QUnit.test("user timezone updates when the modal is shown", function (assert) {
+test("user timezone updates when the modal is shown", function (assert) {
   User.current().changeTimezone(null);
   let stub = sandbox.stub(moment.tz, "guess").returns("Europe/Moscow");
   BookmarkController.onShow();
@@ -274,19 +242,13 @@ QUnit.test("user timezone updates when the modal is shown", function (assert) {
   stub.restore();
 });
 
-QUnit.test(
-  "opening the modal with an existing bookmark with reminder at prefills the custom reminder type",
-  function (assert) {
-    let name = "test";
-    let reminderAt = "2020-05-15T09:45:00";
-    BookmarkController.model = { id: 1, name: name, reminderAt: reminderAt };
-    BookmarkController.onShow();
-    assert.equal(
-      BookmarkController.selectedReminderType,
-      REMINDER_TYPES.CUSTOM
-    );
-    assert.equal(BookmarkController.customReminderDate, "2020-05-15");
-    assert.equal(BookmarkController.customReminderTime, "09:45");
-    assert.equal(BookmarkController.model.name, name);
-  }
-);
+test("opening the modal with an existing bookmark with reminder at prefills the custom reminder type", function (assert) {
+  let name = "test";
+  let reminderAt = "2020-05-15T09:45:00";
+  BookmarkController.model = { id: 1, name: name, reminderAt: reminderAt };
+  BookmarkController.onShow();
+  assert.equal(BookmarkController.selectedReminderType, REMINDER_TYPES.CUSTOM);
+  assert.equal(BookmarkController.customReminderDate, "2020-05-15");
+  assert.equal(BookmarkController.customReminderTime, "09:45");
+  assert.equal(BookmarkController.model.name, name);
+});

--- a/app/assets/javascripts/discourse/tests/unit/controllers/create-account-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/controllers/create-account-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import I18n from "I18n";
 import { controllerModule } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/unit/controllers/history-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/controllers/history-test.js
@@ -1,6 +1,8 @@
+import { moduleFor } from "ember-qunit";
+import { test } from "qunit";
 moduleFor("controller:history");
 
-QUnit.test("displayEdit", async function (assert) {
+test("displayEdit", async function (assert) {
   const HistoryController = this.subject();
 
   HistoryController.setProperties({

--- a/app/assets/javascripts/discourse/tests/unit/controllers/preferences-account-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/controllers/preferences-account-test.js
@@ -1,7 +1,9 @@
+import { moduleFor } from "ember-qunit";
+import { test } from "qunit";
 import EmberObject from "@ember/object";
 moduleFor("controller:preferences/account");
 
-QUnit.test("updating of associated accounts", function (assert) {
+test("updating of associated accounts", function (assert) {
   const controller = this.subject({
     siteSettings: {
       enable_google_oauth2_logins: true,

--- a/app/assets/javascripts/discourse/tests/unit/controllers/preferences-second-factor-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/controllers/preferences-second-factor-test.js
@@ -1,14 +1,13 @@
+import { moduleFor } from "ember-qunit";
+import { test } from "qunit";
 moduleFor("controller:preferences/second-factor");
 
-QUnit.test(
-  "displayOAuthWarning when OAuth login methods are enabled",
-  function (assert) {
-    const controller = this.subject({
-      siteSettings: {
-        enable_google_oauth2_logins: true,
-      },
-    });
+test("displayOAuthWarning when OAuth login methods are enabled", function (assert) {
+  const controller = this.subject({
+    siteSettings: {
+      enable_google_oauth2_logins: true,
+    },
+  });
 
-    assert.equal(controller.get("displayOAuthWarning"), true);
-  }
-);
+  assert.equal(controller.get("displayOAuthWarning"), true);
+});

--- a/app/assets/javascripts/discourse/tests/unit/controllers/reorder-categories-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/controllers/reorder-categories-test.js
@@ -1,3 +1,5 @@
+import { moduleFor } from "ember-qunit";
+import { test } from "qunit";
 import EmberObject from "@ember/object";
 import { mapRoutes } from "discourse/mapping-router";
 import createStore from "discourse/tests/helpers/create-store";
@@ -9,7 +11,7 @@ moduleFor("controller:reorder-categories", "controller:reorder-categories", {
   needs: ["controller:modal"],
 });
 
-QUnit.test("reorder set unique position number", function (assert) {
+test("reorder set unique position number", function (assert) {
   const store = createStore();
 
   const categories = [];
@@ -29,187 +31,175 @@ QUnit.test("reorder set unique position number", function (assert) {
     });
 });
 
-QUnit.test(
-  "reorder places subcategories after their parent categories, while maintaining the relative order",
-  function (assert) {
-    const store = createStore();
+test("reorder places subcategories after their parent categories, while maintaining the relative order", function (assert) {
+  const store = createStore();
 
-    const parent = store.createRecord("category", {
-      id: 1,
-      position: 1,
-      slug: "parent",
-    });
-    const child1 = store.createRecord("category", {
-      id: 2,
-      position: 3,
-      slug: "child1",
-      parent_category_id: 1,
-    });
-    const child2 = store.createRecord("category", {
-      id: 3,
-      position: 0,
-      slug: "child2",
-      parent_category_id: 1,
-    });
-    const other = store.createRecord("category", {
-      id: 4,
-      position: 2,
-      slug: "other",
-    });
+  const parent = store.createRecord("category", {
+    id: 1,
+    position: 1,
+    slug: "parent",
+  });
+  const child1 = store.createRecord("category", {
+    id: 2,
+    position: 3,
+    slug: "child1",
+    parent_category_id: 1,
+  });
+  const child2 = store.createRecord("category", {
+    id: 3,
+    position: 0,
+    slug: "child2",
+    parent_category_id: 1,
+  });
+  const other = store.createRecord("category", {
+    id: 4,
+    position: 2,
+    slug: "other",
+  });
 
-    const categories = [child2, parent, other, child1];
-    const expectedOrderSlugs = ["parent", "child2", "child1", "other"];
+  const categories = [child2, parent, other, child1];
+  const expectedOrderSlugs = ["parent", "child2", "child1", "other"];
 
-    const site = EmberObject.create({ categories: categories });
-    const reorderCategoriesController = this.subject({ site });
+  const site = EmberObject.create({ categories: categories });
+  const reorderCategoriesController = this.subject({ site });
 
-    reorderCategoriesController.reorder();
+  reorderCategoriesController.reorder();
 
-    assert.deepEqual(
-      reorderCategoriesController.get("categoriesOrdered").mapBy("slug"),
-      expectedOrderSlugs
-    );
-  }
-);
+  assert.deepEqual(
+    reorderCategoriesController.get("categoriesOrdered").mapBy("slug"),
+    expectedOrderSlugs
+  );
+});
 
-QUnit.test(
-  "changing the position number of a category should place it at given position",
-  function (assert) {
-    const store = createStore();
+test("changing the position number of a category should place it at given position", function (assert) {
+  const store = createStore();
 
-    const elem1 = store.createRecord("category", {
-      id: 1,
-      position: 0,
-      slug: "foo",
-    });
+  const elem1 = store.createRecord("category", {
+    id: 1,
+    position: 0,
+    slug: "foo",
+  });
 
-    const elem2 = store.createRecord("category", {
-      id: 2,
-      position: 1,
-      slug: "bar",
-    });
+  const elem2 = store.createRecord("category", {
+    id: 2,
+    position: 1,
+    slug: "bar",
+  });
 
-    const elem3 = store.createRecord("category", {
-      id: 3,
-      position: 2,
-      slug: "test",
-    });
+  const elem3 = store.createRecord("category", {
+    id: 3,
+    position: 2,
+    slug: "test",
+  });
 
-    const categories = [elem1, elem2, elem3];
-    const site = EmberObject.create({ categories: categories });
-    const reorderCategoriesController = this.subject({ site });
+  const categories = [elem1, elem2, elem3];
+  const site = EmberObject.create({ categories: categories });
+  const reorderCategoriesController = this.subject({ site });
 
-    reorderCategoriesController.actions.change.call(
-      reorderCategoriesController,
-      elem1,
-      { target: { value: "2" } }
-    );
+  reorderCategoriesController.actions.change.call(
+    reorderCategoriesController,
+    elem1,
+    { target: { value: "2" } }
+  );
 
-    assert.deepEqual(
-      reorderCategoriesController.get("categoriesOrdered").mapBy("slug"),
-      ["test", "bar", "foo"]
-    );
-  }
-);
+  assert.deepEqual(
+    reorderCategoriesController.get("categoriesOrdered").mapBy("slug"),
+    ["test", "bar", "foo"]
+  );
+});
 
-QUnit.test(
-  "changing the position number of a category should place it at given position and respect children",
-  function (assert) {
-    const store = createStore();
+test("changing the position number of a category should place it at given position and respect children", function (assert) {
+  const store = createStore();
 
-    const elem1 = store.createRecord("category", {
-      id: 1,
-      position: 0,
-      slug: "foo",
-    });
+  const elem1 = store.createRecord("category", {
+    id: 1,
+    position: 0,
+    slug: "foo",
+  });
 
-    const child1 = store.createRecord("category", {
-      id: 4,
-      position: 1,
-      slug: "foochild",
-      parent_category_id: 1,
-    });
+  const child1 = store.createRecord("category", {
+    id: 4,
+    position: 1,
+    slug: "foochild",
+    parent_category_id: 1,
+  });
 
-    const elem2 = store.createRecord("category", {
-      id: 2,
-      position: 2,
-      slug: "bar",
-    });
+  const elem2 = store.createRecord("category", {
+    id: 2,
+    position: 2,
+    slug: "bar",
+  });
 
-    const elem3 = store.createRecord("category", {
-      id: 3,
-      position: 3,
-      slug: "test",
-    });
+  const elem3 = store.createRecord("category", {
+    id: 3,
+    position: 3,
+    slug: "test",
+  });
 
-    const categories = [elem1, child1, elem2, elem3];
-    const site = EmberObject.create({ categories: categories });
-    const reorderCategoriesController = this.subject({ site });
+  const categories = [elem1, child1, elem2, elem3];
+  const site = EmberObject.create({ categories: categories });
+  const reorderCategoriesController = this.subject({ site });
 
-    reorderCategoriesController.actions.change.call(
-      reorderCategoriesController,
-      elem1,
-      { target: { value: 3 } }
-    );
+  reorderCategoriesController.actions.change.call(
+    reorderCategoriesController,
+    elem1,
+    { target: { value: 3 } }
+  );
 
-    assert.deepEqual(
-      reorderCategoriesController.get("categoriesOrdered").mapBy("slug"),
-      ["test", "bar", "foo", "foochild"]
-    );
-  }
-);
+  assert.deepEqual(
+    reorderCategoriesController.get("categoriesOrdered").mapBy("slug"),
+    ["test", "bar", "foo", "foochild"]
+  );
+});
 
-QUnit.test(
-  "changing the position through click on arrow of a category should place it at given position and respect children",
-  function (assert) {
-    const store = createStore();
+test("changing the position through click on arrow of a category should place it at given position and respect children", function (assert) {
+  const store = createStore();
 
-    const elem1 = store.createRecord("category", {
-      id: 1,
-      position: 0,
-      slug: "foo",
-    });
+  const elem1 = store.createRecord("category", {
+    id: 1,
+    position: 0,
+    slug: "foo",
+  });
 
-    const child1 = store.createRecord("category", {
-      id: 4,
-      position: 1,
-      slug: "foochild",
-      parent_category_id: 1,
-    });
+  const child1 = store.createRecord("category", {
+    id: 4,
+    position: 1,
+    slug: "foochild",
+    parent_category_id: 1,
+  });
 
-    const child2 = store.createRecord("category", {
-      id: 5,
-      position: 2,
-      slug: "foochildchild",
-      parent_category_id: 4,
-    });
+  const child2 = store.createRecord("category", {
+    id: 5,
+    position: 2,
+    slug: "foochildchild",
+    parent_category_id: 4,
+  });
 
-    const elem2 = store.createRecord("category", {
-      id: 2,
-      position: 3,
-      slug: "bar",
-    });
+  const elem2 = store.createRecord("category", {
+    id: 2,
+    position: 3,
+    slug: "bar",
+  });
 
-    const elem3 = store.createRecord("category", {
-      id: 3,
-      position: 4,
-      slug: "test",
-    });
+  const elem3 = store.createRecord("category", {
+    id: 3,
+    position: 4,
+    slug: "test",
+  });
 
-    const categories = [elem1, child1, child2, elem2, elem3];
-    const site = EmberObject.create({ categories: categories });
-    const reorderCategoriesController = this.subject({ site });
+  const categories = [elem1, child1, child2, elem2, elem3];
+  const site = EmberObject.create({ categories: categories });
+  const reorderCategoriesController = this.subject({ site });
 
-    reorderCategoriesController.reorder();
+  reorderCategoriesController.reorder();
 
-    reorderCategoriesController.actions.moveDown.call(
-      reorderCategoriesController,
-      elem1
-    );
+  reorderCategoriesController.actions.moveDown.call(
+    reorderCategoriesController,
+    elem1
+  );
 
-    assert.deepEqual(
-      reorderCategoriesController.get("categoriesOrdered").mapBy("slug"),
-      ["bar", "foo", "foochild", "foochildchild", "test"]
-    );
-  }
-);
+  assert.deepEqual(
+    reorderCategoriesController.get("categoriesOrdered").mapBy("slug"),
+    ["bar", "foo", "foochild", "foochildchild", "test"]
+  );
+});

--- a/app/assets/javascripts/discourse/tests/unit/controllers/topic-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/controllers/topic-test.js
@@ -1,3 +1,5 @@
+import { moduleFor } from "ember-qunit";
+import { test } from "qunit";
 import EmberObject from "@ember/object";
 import { next } from "@ember/runloop";
 import Topic from "discourse/models/topic";
@@ -25,7 +27,7 @@ function topicWithStream(streamDetails) {
   return topic;
 }
 
-QUnit.test("editTopic", function (assert) {
+test("editTopic", function (assert) {
   const model = Topic.create();
   const controller = this.subject({ model });
 
@@ -60,7 +62,7 @@ QUnit.test("editTopic", function (assert) {
   );
 });
 
-QUnit.test("toggleMultiSelect", function (assert) {
+test("toggleMultiSelect", function (assert) {
   const model = Topic.create();
   const controller = this.subject({ model });
 
@@ -100,7 +102,7 @@ QUnit.test("toggleMultiSelect", function (assert) {
   );
 });
 
-QUnit.test("selectedPosts", function (assert) {
+test("selectedPosts", function (assert) {
   let model = topicWithStream({ posts: [{ id: 1 }, { id: 2 }, { id: 3 }] });
   const controller = this.subject({ model });
 
@@ -117,7 +119,7 @@ QUnit.test("selectedPosts", function (assert) {
   );
 });
 
-QUnit.test("selectedAllPosts", function (assert) {
+test("selectedAllPosts", function (assert) {
   let model = topicWithStream({ stream: [1, 2, 3] });
   const controller = this.subject({ model });
 
@@ -147,7 +149,7 @@ QUnit.test("selectedAllPosts", function (assert) {
   );
 });
 
-QUnit.test("selectedPostsUsername", function (assert) {
+test("selectedPostsUsername", function (assert) {
   let model = topicWithStream({
     posts: [
       { id: 1, username: "gary" },
@@ -198,7 +200,7 @@ QUnit.test("selectedPostsUsername", function (assert) {
   );
 });
 
-QUnit.test("showSelectedPostsAtBottom", function (assert) {
+test("showSelectedPostsAtBottom", function (assert) {
   const site = EmberObject.create({ mobileView: false });
   const model = Topic.create({ posts_count: 3 });
   const controller = this.subject({ model, site });
@@ -220,7 +222,7 @@ QUnit.test("showSelectedPostsAtBottom", function (assert) {
   );
 });
 
-QUnit.test("canDeleteSelected", function (assert) {
+test("canDeleteSelected", function (assert) {
   const currentUser = User.create({ admin: false });
   this.registry.register("current-user:main", currentUser, {
     instantiate: false,
@@ -271,7 +273,7 @@ QUnit.test("canDeleteSelected", function (assert) {
   );
 });
 
-QUnit.test("Can split/merge topic", function (assert) {
+test("Can split/merge topic", function (assert) {
   let model = topicWithStream({
     posts: [
       { id: 1, post_number: 1, post_type: 1 },
@@ -316,7 +318,7 @@ QUnit.test("Can split/merge topic", function (assert) {
   );
 });
 
-QUnit.test("canChangeOwner", function (assert) {
+test("canChangeOwner", function (assert) {
   const currentUser = User.create({ admin: false });
   this.registry.register("current-user:main", currentUser, {
     instantiate: false,
@@ -358,7 +360,7 @@ QUnit.test("canChangeOwner", function (assert) {
   );
 });
 
-QUnit.test("canMergePosts", function (assert) {
+test("canMergePosts", function (assert) {
   let model = topicWithStream({
     posts: [
       { id: 1, username: "gary", can_delete: true },
@@ -405,7 +407,7 @@ QUnit.test("canMergePosts", function (assert) {
   );
 });
 
-QUnit.test("Select/deselect all", function (assert) {
+test("Select/deselect all", function (assert) {
   let model = topicWithStream({ stream: [1, 2, 3] });
   const controller = this.subject({ model });
 
@@ -432,7 +434,7 @@ QUnit.test("Select/deselect all", function (assert) {
   );
 });
 
-QUnit.test("togglePostSelection", function (assert) {
+test("togglePostSelection", function (assert) {
   const controller = this.subject();
   const selectedPostIds = controller.get("selectedPostIds");
 
@@ -455,7 +457,7 @@ QUnit.test("togglePostSelection", function (assert) {
   );
 });
 
-// QUnit.test("selectReplies", function(assert) {
+// test("selectReplies", function(assert) {
 //   const controller = this.subject();
 //   const selectedPostIds = controller.get("selectedPostIds");
 //
@@ -468,7 +470,7 @@ QUnit.test("togglePostSelection", function (assert) {
 //   assert.equal(selectedPostIds[2], 100, "selected post #100");
 // });
 
-QUnit.test("selectBelow", function (assert) {
+test("selectBelow", function (assert) {
   const site = EmberObject.create({
     post_types: { small_action: 3, whisper: 4 },
   });
@@ -493,7 +495,7 @@ QUnit.test("selectBelow", function (assert) {
   assert.equal(selectedPostIds[3], 8, "also selected 3rd post below post #3");
 });
 
-QUnit.test("topVisibleChanged", function (assert) {
+test("topVisibleChanged", function (assert) {
   let model = topicWithStream({
     posts: [{ id: 1 }],
   });
@@ -509,38 +511,35 @@ QUnit.test("topVisibleChanged", function (assert) {
   );
 });
 
-QUnit.test(
-  "deletePost - no modal is shown if post does not have replies",
-  function (assert) {
-    pretender.get("/posts/2/reply-ids.json", () => {
-      return [200, { "Content-Type": "application/json" }, []];
-    });
+test("deletePost - no modal is shown if post does not have replies", function (assert) {
+  pretender.get("/posts/2/reply-ids.json", () => {
+    return [200, { "Content-Type": "application/json" }, []];
+  });
 
-    let destroyed;
-    const post = EmberObject.create({
-      id: 2,
-      post_number: 2,
-      can_delete: true,
-      reply_count: 3,
-      destroy: () => {
-        destroyed = true;
-        return Promise.resolve();
-      },
-    });
+  let destroyed;
+  const post = EmberObject.create({
+    id: 2,
+    post_number: 2,
+    can_delete: true,
+    reply_count: 3,
+    destroy: () => {
+      destroyed = true;
+      return Promise.resolve();
+    },
+  });
 
-    const currentUser = EmberObject.create({ moderator: true });
-    let model = topicWithStream({
-      stream: [2, 3, 4],
-      posts: [post, { id: 3 }, { id: 4 }],
-    });
-    const controller = this.subject({ model, currentUser });
+  const currentUser = EmberObject.create({ moderator: true });
+  let model = topicWithStream({
+    stream: [2, 3, 4],
+    posts: [post, { id: 3 }, { id: 4 }],
+  });
+  const controller = this.subject({ model, currentUser });
 
-    const done = assert.async();
-    controller.send("deletePost", post);
+  const done = assert.async();
+  controller.send("deletePost", post);
 
-    next(() => {
-      assert.ok(destroyed, "post was destroyed");
-      done();
-    });
-  }
-);
+  next(() => {
+    assert.ok(destroyed, "post was destroyed");
+    done();
+  });
+});

--- a/app/assets/javascripts/discourse/tests/unit/ember/resolver-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/ember/resolver-test.js
@@ -1,3 +1,4 @@
+import { test, module } from "qunit";
 import { setResolverOption, buildResolver } from "discourse-common/resolver";
 
 let originalTemplates;
@@ -17,7 +18,7 @@ function setTemplates(lookupTemplateStrings) {
 
 const DiscourseResolver = buildResolver("discourse");
 
-QUnit.module("lib:resolver", {
+module("lib:resolver", {
   beforeEach() {
     originalTemplates = Ember.TEMPLATES;
     Ember.TEMPLATES = {};
@@ -30,7 +31,7 @@ QUnit.module("lib:resolver", {
   },
 });
 
-QUnit.test("finds templates in top level dir", (assert) => {
+test("finds templates in top level dir", (assert) => {
   setTemplates(["foobar", "fooBar", "foo_bar", "foo.bar"]);
 
   lookupTemplate(assert, "template:foobar", "foobar", "by lowcased name");
@@ -39,7 +40,7 @@ QUnit.test("finds templates in top level dir", (assert) => {
   lookupTemplate(assert, "template:foo.bar", "foo.bar", "by dotted name");
 });
 
-QUnit.test("finds templates in first-level subdir", (assert) => {
+test("finds templates in first-level subdir", (assert) => {
   setTemplates(["foo/bar_baz"]);
 
   lookupTemplate(
@@ -68,33 +69,30 @@ QUnit.test("finds templates in first-level subdir", (assert) => {
   );
 });
 
-QUnit.test(
-  "resolves precedence between overlapping top level dir and first level subdir templates",
-  (assert) => {
-    setTemplates(["fooBar", "foo_bar", "foo.bar", "foo/bar"]);
+test("resolves precedence between overlapping top level dir and first level subdir templates", (assert) => {
+  setTemplates(["fooBar", "foo_bar", "foo.bar", "foo/bar"]);
 
-    lookupTemplate(
-      assert,
-      "template:foo.bar",
-      "foo/bar",
-      "preferring first level subdir for dotted name"
-    );
-    lookupTemplate(
-      assert,
-      "template:fooBar",
-      "fooBar",
-      "preferring top level dir for camel cased name"
-    );
-    lookupTemplate(
-      assert,
-      "template:foo_bar",
-      "foo_bar",
-      "preferring top level dir for underscored name"
-    );
-  }
-);
+  lookupTemplate(
+    assert,
+    "template:foo.bar",
+    "foo/bar",
+    "preferring first level subdir for dotted name"
+  );
+  lookupTemplate(
+    assert,
+    "template:fooBar",
+    "fooBar",
+    "preferring top level dir for camel cased name"
+  );
+  lookupTemplate(
+    assert,
+    "template:foo_bar",
+    "foo_bar",
+    "preferring top level dir for underscored name"
+  );
+});
 
-QUnit.test("finds templates in subdir deeper than one level", (assert) => {
+test("finds templates in subdir deeper than one level", (assert) => {
   setTemplates(["foo/bar/baz/qux"]);
 
   lookupTemplate(
@@ -148,7 +146,7 @@ QUnit.test("finds templates in subdir deeper than one level", (assert) => {
   );
 });
 
-QUnit.test("resolves mobile templates to 'mobile/' namespace", (assert) => {
+test("resolves mobile templates to 'mobile/' namespace", (assert) => {
   setTemplates(["mobile/foo", "bar", "mobile/bar", "baz"]);
 
   setResolverOption("mobileView", true);
@@ -173,94 +171,85 @@ QUnit.test("resolves mobile templates to 'mobile/' namespace", (assert) => {
   );
 });
 
-QUnit.test(
-  "resolves plugin templates to 'javascripts/' namespace",
-  (assert) => {
-    setTemplates(["javascripts/foo", "bar", "javascripts/bar", "baz"]);
+test("resolves plugin templates to 'javascripts/' namespace", (assert) => {
+  setTemplates(["javascripts/foo", "bar", "javascripts/bar", "baz"]);
 
-    lookupTemplate(
-      assert,
-      "template:foo",
-      "javascripts/foo",
-      "finding plugin version even if normal one is not present"
-    );
-    lookupTemplate(
-      assert,
-      "template:bar",
-      "javascripts/bar",
-      "preferring plugin version when both versions are present"
-    );
-    lookupTemplate(
-      assert,
-      "template:baz",
-      "baz",
-      "falling back to a normal version when plugin version is not present"
-    );
-  }
-);
+  lookupTemplate(
+    assert,
+    "template:foo",
+    "javascripts/foo",
+    "finding plugin version even if normal one is not present"
+  );
+  lookupTemplate(
+    assert,
+    "template:bar",
+    "javascripts/bar",
+    "preferring plugin version when both versions are present"
+  );
+  lookupTemplate(
+    assert,
+    "template:baz",
+    "baz",
+    "falling back to a normal version when plugin version is not present"
+  );
+});
 
-QUnit.test(
-  "resolves templates with 'admin' prefix to 'admin/templates/' namespace",
-  (assert) => {
-    setTemplates([
-      "admin/templates/foo",
-      "adminBar",
-      "admin_bar",
-      "admin.bar",
-      "admin/templates/bar",
-    ]);
+test("resolves templates with 'admin' prefix to 'admin/templates/' namespace", (assert) => {
+  setTemplates([
+    "admin/templates/foo",
+    "adminBar",
+    "admin_bar",
+    "admin.bar",
+    "admin/templates/bar",
+  ]);
 
-    lookupTemplate(
-      assert,
-      "template:adminFoo",
-      "admin/templates/foo",
-      "when prefix is separated by camel case"
-    );
-    lookupTemplate(
-      assert,
-      "template:admin_foo",
-      "admin/templates/foo",
-      "when prefix is separated by underscore"
-    );
-    lookupTemplate(
-      assert,
-      "template:admin.foo",
-      "admin/templates/foo",
-      "when prefix is separated by dot"
-    );
+  lookupTemplate(
+    assert,
+    "template:adminFoo",
+    "admin/templates/foo",
+    "when prefix is separated by camel case"
+  );
+  lookupTemplate(
+    assert,
+    "template:admin_foo",
+    "admin/templates/foo",
+    "when prefix is separated by underscore"
+  );
+  lookupTemplate(
+    assert,
+    "template:admin.foo",
+    "admin/templates/foo",
+    "when prefix is separated by dot"
+  );
 
-    lookupTemplate(
-      assert,
-      "template:adminfoo",
-      undefined,
-      "but not when prefix is not separated in any way"
-    );
-    lookupTemplate(
-      assert,
-      "template:adminBar",
-      "adminBar",
-      "but not when template with the exact camel cased name exists"
-    );
-    lookupTemplate(
-      assert,
-      "template:admin_bar",
-      "admin_bar",
-      "but not when template with the exact underscored name exists"
-    );
-    lookupTemplate(
-      assert,
-      "template:admin.bar",
-      "admin.bar",
-      "but not when template with the exact dotted name exists"
-    );
-  }
-);
+  lookupTemplate(
+    assert,
+    "template:adminfoo",
+    undefined,
+    "but not when prefix is not separated in any way"
+  );
+  lookupTemplate(
+    assert,
+    "template:adminBar",
+    "adminBar",
+    "but not when template with the exact camel cased name exists"
+  );
+  lookupTemplate(
+    assert,
+    "template:admin_bar",
+    "admin_bar",
+    "but not when template with the exact underscored name exists"
+  );
+  lookupTemplate(
+    assert,
+    "template:admin.bar",
+    "admin.bar",
+    "but not when template with the exact dotted name exists"
+  );
+});
 
-QUnit.test(
-  "returns 'not_found' template when template name cannot be resolved",
-  (assert) => {
-    setTemplates(["not_found"]);
+test("returns 'not_found' template when template name cannot be resolved", (assert) => {
+  setTemplates(["not_found"]);
 
-    lookupTemplate(assert, "template:foo/bar/baz", "not_found", "");
-  }
-);
+  lookupTemplate(assert, "template:foo/bar/baz", "not_found", "");
+});

--- a/app/assets/javascripts/discourse/tests/unit/lib/bbcode-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/bbcode-test.js
@@ -1,8 +1,9 @@
+import { test, module } from "qunit";
 import { parseBBCodeTag } from "pretty-text/engines/discourse-markdown/bbcode-block";
 
-QUnit.module("lib:pretty-text:bbcode");
+module("lib:pretty-text:bbcode");
 
-QUnit.test("block with multiple quoted attributes", (assert) => {
+test("block with multiple quoted attributes", (assert) => {
   const parsed = parseBBCodeTag('[test one="foo" two="bar bar"]', 0, 30);
 
   assert.equal(parsed.tag, "test");

--- a/app/assets/javascripts/discourse/tests/unit/lib/bookmark-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/bookmark-test.js
@@ -1,7 +1,8 @@
+import { test, module } from "qunit";
 import { formattedReminderTime } from "discourse/lib/bookmark";
 import { fakeTime } from "discourse/tests/helpers/qunit-helpers";
 
-QUnit.module("lib:bookmark", {
+module("lib:bookmark", {
   beforeEach() {
     fakeTime("2020-04-11 08:00:00", "Australia/Brisbane");
   },
@@ -11,44 +12,35 @@ QUnit.module("lib:bookmark", {
   },
 });
 
-QUnit.test(
-  "formattedReminderTime works when the reminder time is tomorrow",
-  (assert) => {
-    let reminderAt = "2020-04-12 09:45:00";
-    let reminderAtDate = moment
-      .tz(reminderAt, "Australia/Brisbane")
-      .format("H:mm a");
-    assert.equal(
-      formattedReminderTime(reminderAt, "Australia/Brisbane"),
-      "tomorrow at " + reminderAtDate
-    );
-  }
-);
+test("formattedReminderTime works when the reminder time is tomorrow", (assert) => {
+  let reminderAt = "2020-04-12 09:45:00";
+  let reminderAtDate = moment
+    .tz(reminderAt, "Australia/Brisbane")
+    .format("H:mm a");
+  assert.equal(
+    formattedReminderTime(reminderAt, "Australia/Brisbane"),
+    "tomorrow at " + reminderAtDate
+  );
+});
 
-QUnit.test(
-  "formattedReminderTime works when the reminder time is today",
-  (assert) => {
-    let reminderAt = "2020-04-11 09:45:00";
-    let reminderAtDate = moment
-      .tz(reminderAt, "Australia/Brisbane")
-      .format("H:mm a");
-    assert.equal(
-      formattedReminderTime(reminderAt, "Australia/Brisbane"),
-      "today at " + reminderAtDate
-    );
-  }
-);
+test("formattedReminderTime works when the reminder time is today", (assert) => {
+  let reminderAt = "2020-04-11 09:45:00";
+  let reminderAtDate = moment
+    .tz(reminderAt, "Australia/Brisbane")
+    .format("H:mm a");
+  assert.equal(
+    formattedReminderTime(reminderAt, "Australia/Brisbane"),
+    "today at " + reminderAtDate
+  );
+});
 
-QUnit.test(
-  "formattedReminderTime works when the reminder time is in the future",
-  (assert) => {
-    let reminderAt = "2020-04-15 09:45:00";
-    let reminderAtDate = moment
-      .tz(reminderAt, "Australia/Brisbane")
-      .format("H:mm a");
-    assert.equal(
-      formattedReminderTime(reminderAt, "Australia/Brisbane"),
-      "at Apr 15, 2020 " + reminderAtDate
-    );
-  }
-);
+test("formattedReminderTime works when the reminder time is in the future", (assert) => {
+  let reminderAt = "2020-04-15 09:45:00";
+  let reminderAtDate = moment
+    .tz(reminderAt, "Australia/Brisbane")
+    .format("H:mm a");
+  assert.equal(
+    formattedReminderTime(reminderAt, "Australia/Brisbane"),
+    "at Apr 15, 2020 " + reminderAtDate
+  );
+});

--- a/app/assets/javascripts/discourse/tests/unit/lib/break-string-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/break-string-test.js
@@ -1,8 +1,9 @@
+import { test, module } from "qunit";
 /* global BreakString:true */
 
-QUnit.module("lib:breakString", {});
+module("lib:breakString", {});
 
-QUnit.test("breakString", (assert) => {
+test("breakString", (assert) => {
   var b = function (s, hint) {
     return new BreakString(s).break(hint);
   };

--- a/app/assets/javascripts/discourse/tests/unit/lib/category-badge-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/category-badge-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import createStore from "discourse/tests/helpers/create-store";
 import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
 import Site from "discourse/models/site";
@@ -6,11 +7,11 @@ discourseModule("lib:category-link");
 
 import { categoryBadgeHTML } from "discourse/helpers/category-link";
 
-QUnit.test("categoryBadge without a category", (assert) => {
+test("categoryBadge without a category", (assert) => {
   assert.blank(categoryBadgeHTML(), "it returns no HTML");
 });
 
-QUnit.test("Regular categoryBadge", (assert) => {
+test("Regular categoryBadge", (assert) => {
   const store = createStore();
   const category = store.createRecord("category", {
     name: "hello",
@@ -37,7 +38,7 @@ QUnit.test("Regular categoryBadge", (assert) => {
   );
 });
 
-QUnit.test("undefined color", (assert) => {
+test("undefined color", (assert) => {
   const store = createStore();
   const noColor = store.createRecord("category", { name: "hello", id: 123 });
   const tag = $.parseHTML(categoryBadgeHTML(noColor))[0];
@@ -48,7 +49,7 @@ QUnit.test("undefined color", (assert) => {
   );
 });
 
-QUnit.test("topic count", (assert) => {
+test("topic count", (assert) => {
   const store = createStore();
   const category = store.createRecord("category", { name: "hello", id: 123 });
 
@@ -63,7 +64,7 @@ QUnit.test("topic count", (assert) => {
   );
 });
 
-QUnit.test("allowUncategorized", (assert) => {
+test("allowUncategorized", (assert) => {
   const store = createStore();
   const uncategorized = store.createRecord("category", {
     name: "uncategorized",
@@ -85,7 +86,7 @@ QUnit.test("allowUncategorized", (assert) => {
   );
 });
 
-QUnit.test("category names are wrapped in dir-spans", function (assert) {
+test("category names are wrapped in dir-spans", function (assert) {
   this.siteSettings.support_mixed_text_direction = true;
   const store = createStore();
   const rtlCategory = store.createRecord("category", {
@@ -110,7 +111,7 @@ QUnit.test("category names are wrapped in dir-spans", function (assert) {
   assert.equal(dirSpan.dir, "ltr");
 });
 
-QUnit.test("recursive", function (assert) {
+test("recursive", function (assert) {
   const store = createStore();
 
   const foo = store.createRecord("category", {

--- a/app/assets/javascripts/discourse/tests/unit/lib/click-track-edit-history-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/click-track-edit-history-test.js
@@ -1,10 +1,11 @@
+import { skip } from "qunit";
 import DiscourseURL from "discourse/lib/url";
 import ClickTrack from "discourse/lib/click-track";
 import { fixture, logIn } from "discourse/tests/helpers/qunit-helpers";
 import User from "discourse/models/user";
 import pretender from "discourse/tests/helpers/create-pretender";
 
-QUnit.module("lib:click-track-edit-history", {
+module("lib:click-track-edit-history", {
   beforeEach() {
     logIn();
 
@@ -58,7 +59,7 @@ function generateClickEventOn(selector) {
   return $.Event("click", { currentTarget: fixture(selector).first() });
 }
 
-QUnit.skip("tracks internal URLs", async (assert) => {
+skip("tracks internal URLs", async (assert) => {
   assert.expect(2);
   sandbox.stub(DiscourseURL, "origin").returns("http://discuss.domain.com");
 
@@ -74,7 +75,7 @@ QUnit.skip("tracks internal URLs", async (assert) => {
   assert.notOk(track(generateClickEventOn("#same-site")));
 });
 
-QUnit.skip("tracks external URLs", async (assert) => {
+skip("tracks external URLs", async (assert) => {
   assert.expect(2);
 
   const done = assert.async();
@@ -89,22 +90,19 @@ QUnit.skip("tracks external URLs", async (assert) => {
   assert.notOk(track(generateClickEventOn("a")));
 });
 
-QUnit.skip(
-  "tracks external URLs when opening in another window",
-  async (assert) => {
-    assert.expect(3);
-    User.currentProp("external_links_in_new_tab", true);
+skip("tracks external URLs when opening in another window", async (assert) => {
+  assert.expect(3);
+  User.currentProp("external_links_in_new_tab", true);
 
-    const done = assert.async();
-    pretender.post("/clicks/track", (request) => {
-      assert.equal(
-        request.requestBody,
-        "url=http%3A%2F%2Fwww.google.com&post_id=42&topic_id=1337"
-      );
-      done();
-    });
+  const done = assert.async();
+  pretender.post("/clicks/track", (request) => {
+    assert.equal(
+      request.requestBody,
+      "url=http%3A%2F%2Fwww.google.com&post_id=42&topic_id=1337"
+    );
+    done();
+  });
 
-    assert.notOk(track(generateClickEventOn("a")));
-    assert.ok(window.open.calledWith("http://www.google.com", "_blank"));
-  }
-);
+  assert.notOk(track(generateClickEventOn("a")));
+  assert.ok(window.open.calledWith("http://www.google.com", "_blank"));
+});

--- a/app/assets/javascripts/discourse/tests/unit/lib/click-track-profile-page-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/click-track-profile-page-test.js
@@ -1,9 +1,10 @@
+import { skip } from "qunit";
 import DiscourseURL from "discourse/lib/url";
 import ClickTrack from "discourse/lib/click-track";
 import { fixture, logIn } from "discourse/tests/helpers/qunit-helpers";
 import pretender from "discourse/tests/helpers/create-pretender";
 
-QUnit.module("lib:click-track-profile-page", {
+module("lib:click-track-profile-page", {
   beforeEach() {
     logIn();
 
@@ -51,7 +52,7 @@ function generateClickEventOn(selector) {
   return $.Event("click", { currentTarget: fixture(selector).first() });
 }
 
-QUnit.skip("tracks internal URLs", async (assert) => {
+skip("tracks internal URLs", async (assert) => {
   assert.expect(2);
   sandbox.stub(DiscourseURL, "origin").returns("http://discuss.domain.com");
 
@@ -64,7 +65,7 @@ QUnit.skip("tracks internal URLs", async (assert) => {
   assert.notOk(track(generateClickEventOn("#same-site")));
 });
 
-QUnit.skip("tracks external URLs", async (assert) => {
+skip("tracks external URLs", async (assert) => {
   assert.expect(2);
 
   const done = assert.async();
@@ -79,7 +80,7 @@ QUnit.skip("tracks external URLs", async (assert) => {
   assert.notOk(track(generateClickEventOn("a")));
 });
 
-QUnit.skip("tracks external URLs in other posts", async (assert) => {
+skip("tracks external URLs in other posts", async (assert) => {
   assert.expect(2);
 
   const done = assert.async();

--- a/app/assets/javascripts/discourse/tests/unit/lib/click-track-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/click-track-test.js
@@ -1,3 +1,5 @@
+import { skip } from "qunit";
+import { test, module } from "qunit";
 import { later } from "@ember/runloop";
 import DiscourseURL from "discourse/lib/url";
 import ClickTrack from "discourse/lib/click-track";
@@ -5,7 +7,7 @@ import { fixture, logIn } from "discourse/tests/helpers/qunit-helpers";
 import User from "discourse/models/user";
 import pretender from "discourse/tests/helpers/create-pretender";
 
-QUnit.module("lib:click-track", {
+module("lib:click-track", {
   beforeEach() {
     logIn();
 
@@ -51,7 +53,7 @@ function generateClickEventOn(selector) {
   return $.Event("click", { currentTarget: fixture(selector).first() });
 }
 
-QUnit.skip("tracks internal URLs", async (assert) => {
+skip("tracks internal URLs", async (assert) => {
   assert.expect(2);
   sandbox.stub(DiscourseURL, "origin").returns("http://discuss.domain.com");
 
@@ -67,11 +69,11 @@ QUnit.skip("tracks internal URLs", async (assert) => {
   assert.notOk(track(generateClickEventOn("#same-site")));
 });
 
-QUnit.test("does not track elements with no href", async (assert) => {
+test("does not track elements with no href", async (assert) => {
   assert.ok(track(generateClickEventOn(".a-without-href")));
 });
 
-QUnit.test("does not track attachments", async (assert) => {
+test("does not track attachments", async (assert) => {
   sandbox.stub(DiscourseURL, "origin").returns("http://discuss.domain.com");
 
   pretender.post("/clicks/track", () => assert.ok(false));
@@ -84,7 +86,7 @@ QUnit.test("does not track attachments", async (assert) => {
   );
 });
 
-QUnit.skip("tracks external URLs", async (assert) => {
+skip("tracks external URLs", async (assert) => {
   assert.expect(2);
 
   const done = assert.async();
@@ -99,75 +101,69 @@ QUnit.skip("tracks external URLs", async (assert) => {
   assert.notOk(track(generateClickEventOn("a")));
 });
 
-QUnit.skip(
-  "tracks external URLs when opening in another window",
-  async (assert) => {
-    assert.expect(3);
-    User.currentProp("external_links_in_new_tab", true);
+skip("tracks external URLs when opening in another window", async (assert) => {
+  assert.expect(3);
+  User.currentProp("external_links_in_new_tab", true);
 
-    const done = assert.async();
-    pretender.post("/clicks/track", (request) => {
-      assert.ok(
-        request.requestBody,
-        "url=http%3A%2F%2Fwww.google.com&post_id=42&topic_id=1337"
-      );
-      done();
-    });
+  const done = assert.async();
+  pretender.post("/clicks/track", (request) => {
+    assert.ok(
+      request.requestBody,
+      "url=http%3A%2F%2Fwww.google.com&post_id=42&topic_id=1337"
+    );
+    done();
+  });
 
-    assert.notOk(track(generateClickEventOn("a")));
-    assert.ok(window.open.calledWith("http://www.google.com", "_blank"));
-  }
-);
+  assert.notOk(track(generateClickEventOn("a")));
+  assert.ok(window.open.calledWith("http://www.google.com", "_blank"));
+});
 
-QUnit.test("does not track clicks on lightboxes", async (assert) => {
+test("does not track clicks on lightboxes", async (assert) => {
   assert.notOk(track(generateClickEventOn(".lightbox")));
 });
 
-QUnit.test("does not track clicks when forcibly disabled", async (assert) => {
+test("does not track clicks when forcibly disabled", async (assert) => {
   assert.notOk(track(generateClickEventOn(".no-track-link")));
 });
 
-QUnit.test("does not track clicks on back buttons", async (assert) => {
+test("does not track clicks on back buttons", async (assert) => {
   assert.notOk(track(generateClickEventOn(".back")));
 });
 
-QUnit.test("does not track right clicks inside quotes", async (assert) => {
+test("does not track right clicks inside quotes", async (assert) => {
   const event = generateClickEventOn(".quote a:first-child");
   event.which = 3;
   assert.ok(track(event));
 });
 
-QUnit.test("does not track clicks links in quotes", async (assert) => {
+test("does not track clicks links in quotes", async (assert) => {
   User.currentProp("external_links_in_new_tab", true);
   assert.notOk(track(generateClickEventOn(".quote a:last-child")));
   assert.ok(window.open.calledWith("https://google.com/", "_blank"));
 });
 
-QUnit.test("does not track clicks on category badges", async (assert) => {
+test("does not track clicks on category badges", async (assert) => {
   assert.notOk(track(generateClickEventOn(".hashtag")));
 });
 
-QUnit.test("does not track clicks on mailto", async (assert) => {
+test("does not track clicks on mailto", async (assert) => {
   assert.ok(track(generateClickEventOn(".mailto")));
 });
 
-QUnit.test(
-  "removes the href and put it as a data attribute",
-  async (assert) => {
-    User.currentProp("external_links_in_new_tab", true);
+test("removes the href and put it as a data attribute", async (assert) => {
+  User.currentProp("external_links_in_new_tab", true);
 
-    assert.notOk(track(generateClickEventOn("a")));
+  assert.notOk(track(generateClickEventOn("a")));
 
-    var $link = fixture("a").first();
-    assert.ok($link.hasClass("no-href"));
-    assert.equal($link.data("href"), "http://www.google.com/");
-    assert.blank($link.attr("href"));
-    assert.ok($link.data("auto-route"));
-    assert.ok(window.open.calledWith("http://www.google.com/", "_blank"));
-  }
-);
+  var $link = fixture("a").first();
+  assert.ok($link.hasClass("no-href"));
+  assert.equal($link.data("href"), "http://www.google.com/");
+  assert.blank($link.attr("href"));
+  assert.ok($link.data("auto-route"));
+  assert.ok(window.open.calledWith("http://www.google.com/", "_blank"));
+});
 
-QUnit.test("restores the href after a while", async (assert) => {
+test("restores the href after a while", async (assert) => {
   assert.expect(2);
 
   assert.notOk(track(generateClickEventOn("a")));
@@ -187,24 +183,24 @@ function badgeClickCount(assert, id, expected) {
   assert.equal(parseInt($badge.html(), 10), expected);
 }
 
-QUnit.test("does not update badge clicks on my own link", async (assert) => {
+test("does not update badge clicks on my own link", async (assert) => {
   sandbox.stub(User, "currentProp").withArgs("id").returns(314);
   badgeClickCount(assert, "with-badge", 1);
 });
 
-QUnit.test("does not update badge clicks in my own post", async (assert) => {
+test("does not update badge clicks in my own post", async (assert) => {
   sandbox.stub(User, "currentProp").withArgs("id").returns(3141);
   badgeClickCount(assert, "with-badge-but-not-mine", 1);
 });
 
-QUnit.test("updates badge counts correctly", async (assert) => {
+test("updates badge counts correctly", async (assert) => {
   badgeClickCount(assert, "inside-onebox", 1);
   badgeClickCount(assert, "inside-onebox-forced", 2);
   badgeClickCount(assert, "with-badge", 2);
 });
 
 function testOpenInANewTab(description, clickEventModifier) {
-  QUnit.test(description, async (assert) => {
+  test(description, async (assert) => {
     var clickEvent = generateClickEventOn("a");
     clickEventModifier(clickEvent);
     assert.ok(track(clickEvent));

--- a/app/assets/javascripts/discourse/tests/unit/lib/computed-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/computed-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import I18n from "I18n";
 import EmberObject from "@ember/object";
 import {
@@ -24,7 +25,7 @@ discourseModule("lib:computed", {
   },
 });
 
-QUnit.test("setting", function (assert) {
+test("setting", function (assert) {
   let t = EmberObject.extend({
     siteSettings: this.siteSettings,
     vehicle: setting("vehicle"),
@@ -43,7 +44,7 @@ QUnit.test("setting", function (assert) {
   );
 });
 
-QUnit.test("propertyEqual", (assert) => {
+test("propertyEqual", (assert) => {
   var t = EmberObject.extend({
     same: propertyEqual("cookies", "biscuits"),
   }).create({
@@ -56,7 +57,7 @@ QUnit.test("propertyEqual", (assert) => {
   assert.ok(!t.get("same"), "it isn't true when one property is different");
 });
 
-QUnit.test("propertyNotEqual", (assert) => {
+test("propertyNotEqual", (assert) => {
   var t = EmberObject.extend({
     diff: propertyNotEqual("cookies", "biscuits"),
   }).create({
@@ -69,7 +70,7 @@ QUnit.test("propertyNotEqual", (assert) => {
   assert.ok(t.get("diff"), "it is true when one property is different");
 });
 
-QUnit.test("fmt", (assert) => {
+test("fmt", (assert) => {
   var t = EmberObject.extend({
     exclaimyUsername: fmt("username", "!!! %@ !!!"),
     multiple: fmt("username", "mood", "%@ is %@"),
@@ -103,7 +104,7 @@ QUnit.test("fmt", (assert) => {
   );
 });
 
-QUnit.test("i18n", (assert) => {
+test("i18n", (assert) => {
   var t = EmberObject.extend({
     exclaimyUsername: i18n("username", "!!! %@ !!!"),
     multiple: i18n("username", "mood", "%@ is %@"),
@@ -137,7 +138,7 @@ QUnit.test("i18n", (assert) => {
   );
 });
 
-QUnit.test("url", (assert) => {
+test("url", (assert) => {
   var t, testClass;
 
   testClass = EmberObject.extend({
@@ -160,7 +161,7 @@ QUnit.test("url", (assert) => {
   );
 });
 
-QUnit.test("htmlSafe", (assert) => {
+test("htmlSafe", (assert) => {
   const cookies = "<p>cookies and <b>biscuits</b></p>";
   const t = EmberObject.extend({
     desc: htmlSafe("cookies"),

--- a/app/assets/javascripts/discourse/tests/unit/lib/emoji-store-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/emoji-store-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
 
 discourseModule("lib:emoji-emojiStore", {
@@ -10,22 +11,22 @@ discourseModule("lib:emoji-emojiStore", {
   },
 });
 
-QUnit.test("defaults", function (assert) {
+test("defaults", function (assert) {
   assert.deepEqual(this.emojiStore.favorites, []);
   assert.equal(this.emojiStore.diversity, 1);
 });
 
-QUnit.test("diversity", function (assert) {
+test("diversity", function (assert) {
   this.emojiStore.diversity = 2;
   assert.equal(this.emojiStore.diversity, 2);
 });
 
-QUnit.test("favorites", function (assert) {
+test("favorites", function (assert) {
   this.emojiStore.favorites = ["smile"];
   assert.deepEqual(this.emojiStore.favorites, ["smile"]);
 });
 
-QUnit.test("track", function (assert) {
+test("track", function (assert) {
   this.emojiStore.track("woman:t4");
   assert.deepEqual(this.emojiStore.favorites, ["woman:t4"]);
   this.emojiStore.track("otter");

--- a/app/assets/javascripts/discourse/tests/unit/lib/emoji-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/emoji-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import { emojiSearch } from "pretty-text/emoji";
 import { IMAGE_VERSION as v } from "pretty-text/emoji/version";
 import { emojiUnescape } from "discourse/lib/text";
@@ -5,7 +6,7 @@ import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
 
 discourseModule("lib:emoji");
 
-QUnit.test("emojiUnescape", function (assert) {
+test("emojiUnescape", function (assert) {
   const testUnescape = (input, expected, description, settings = {}) => {
     const originalSettings = {};
     for (const [key, value] of Object.entries(settings)) {
@@ -130,7 +131,7 @@ QUnit.test("emojiUnescape", function (assert) {
   );
 });
 
-QUnit.test("Emoji search", (assert) => {
+test("Emoji search", (assert) => {
   // able to find an alias
   assert.equal(emojiSearch("+1").length, 1);
 

--- a/app/assets/javascripts/discourse/tests/unit/lib/formatter-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/formatter-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import {
   relativeAge,
   autoUpdatingRelativeAge,
@@ -48,7 +49,7 @@ function strip(html) {
   return $(html).text();
 }
 
-QUnit.test("formating medium length dates", function (assert) {
+test("formating medium length dates", function (assert) {
   let shortDateYear = shortDateTester("MMM D, 'YY");
 
   assert.equal(
@@ -119,7 +120,7 @@ QUnit.test("formating medium length dates", function (assert) {
   assert.equal(strip(formatDays(10, { format: "medium" })), shortDateYear(10));
 });
 
-QUnit.test("formating tiny dates", function (assert) {
+test("formating tiny dates", function (assert) {
   let shortDateYear = shortDateTester("MMM 'YY");
 
   assert.equal(formatMins(0), "1m");
@@ -182,7 +183,7 @@ QUnit.test("formating tiny dates", function (assert) {
   this.siteSettings.relative_date_duration = originalValue;
 });
 
-QUnit.test("autoUpdatingRelativeAge", function (assert) {
+test("autoUpdatingRelativeAge", function (assert) {
   var d = moment().subtract(1, "day").toDate();
 
   var $elem = $(autoUpdatingRelativeAge(d));
@@ -212,7 +213,7 @@ QUnit.test("autoUpdatingRelativeAge", function (assert) {
   assert.equal($elem.html(), "1 day");
 });
 
-QUnit.test("updateRelativeAge", function (assert) {
+test("updateRelativeAge", function (assert) {
   var d = new Date();
   var $elem = $(autoUpdatingRelativeAge(d));
   $elem.data("time", d.getTime() - 2 * 60 * 1000);
@@ -230,7 +231,7 @@ QUnit.test("updateRelativeAge", function (assert) {
   assert.equal($elem.html(), "2 mins ago");
 });
 
-QUnit.test("number", function (assert) {
+test("number", function (assert) {
   assert.equal(number(123), "123", "it returns a string version of the number");
   assert.equal(number("123"), "123", "it works with a string command");
   assert.equal(number(NaN), "0", "it returns 0 for NaN");
@@ -261,7 +262,7 @@ QUnit.test("number", function (assert) {
   );
 });
 
-QUnit.test("durationTiny", function (assert) {
+test("durationTiny", function (assert) {
   assert.equal(durationTiny(), "&mdash;", "undefined is a dash");
   assert.equal(durationTiny(null), "&mdash;", "null is a dash");
   assert.equal(durationTiny(0), "< 1m", "0 seconds shows as < 1m");

--- a/app/assets/javascripts/discourse/tests/unit/lib/get-url-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/get-url-test.js
@@ -1,3 +1,4 @@
+import { test, module } from "qunit";
 import {
   default as getURL,
   setupURL,
@@ -9,21 +10,21 @@ import {
   withoutPrefix,
 } from "discourse-common/lib/get-url";
 
-QUnit.module("lib:get-url");
+module("lib:get-url");
 
-QUnit.test("isAbsoluteURL", (assert) => {
+test("isAbsoluteURL", (assert) => {
   setupURL(null, "https://example.com", "/forum");
   assert.ok(isAbsoluteURL("https://example.com/test/thing"));
   assert.ok(!isAbsoluteURL("http://example.com/test/thing"));
   assert.ok(!isAbsoluteURL("https://discourse.org/test/thing"));
 });
 
-QUnit.test("getAbsoluteURL", (assert) => {
+test("getAbsoluteURL", (assert) => {
   setupURL(null, "https://example.com", "/forum");
   assert.equal(getAbsoluteURL("/cool/path"), "https://example.com/cool/path");
 });
 
-QUnit.test("withoutPrefix", (assert) => {
+test("withoutPrefix", (assert) => {
   setPrefix("/eviltrout");
   assert.equal(withoutPrefix("/eviltrout/hello"), "/hello");
   assert.equal(withoutPrefix("/eviltrout/"), "/");
@@ -40,7 +41,7 @@ QUnit.test("withoutPrefix", (assert) => {
   assert.equal(withoutPrefix("/"), "/");
 });
 
-QUnit.test("getURL with empty paths", (assert) => {
+test("getURL with empty paths", (assert) => {
   setupURL(null, "https://example.com", "/");
   assert.equal(getURL("/"), "/");
   assert.equal(getURL(""), "");
@@ -52,7 +53,7 @@ QUnit.test("getURL with empty paths", (assert) => {
   assert.equal(getURL(""), "");
 });
 
-QUnit.test("getURL on subfolder install", (assert) => {
+test("getURL on subfolder install", (assert) => {
   setupURL(null, "", "/forum");
   assert.equal(getURL("/"), "/forum/", "root url has subfolder");
   assert.equal(
@@ -80,7 +81,7 @@ QUnit.test("getURL on subfolder install", (assert) => {
   );
 });
 
-QUnit.test("getURLWithCDN on subfolder install with S3", (assert) => {
+test("getURLWithCDN on subfolder install with S3", (assert) => {
   setupURL(null, "", "/forum");
   setupS3CDN(
     "//test.s3-us-west-1.amazonaws.com/site",

--- a/app/assets/javascripts/discourse/tests/unit/lib/highlight-search-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/highlight-search-test.js
@@ -1,9 +1,10 @@
 import highlightSearch, { CLASS_NAME } from "discourse/lib/highlight-search";
 import { fixture } from "discourse/tests/helpers/qunit-helpers";
+import { test } from "qunit";
 
-QUnit.module("lib:highlight-search");
+module("lib:highlight-search");
 
-QUnit.test("highlighting text", (assert) => {
+test("highlighting text", (assert) => {
   fixture().html(
     `
     <p>This is some text to highlight</p>
@@ -25,7 +26,7 @@ QUnit.test("highlighting text", (assert) => {
   );
 });
 
-QUnit.test("highlighting unicode text", (assert) => {
+test("highlighting unicode text", (assert) => {
   fixture().html(
     `
     <p>This is some தமிழ் & русский text to highlight</p>

--- a/app/assets/javascripts/discourse/tests/unit/lib/i18n-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/i18n-test.js
@@ -1,5 +1,6 @@
+import { test, module } from "qunit";
 import I18n from "I18n";
-QUnit.module("lib:i18n", {
+module("lib:i18n", {
   _locale: I18n.locale,
   _fallbackLocale: I18n.fallbackLocale,
   _translations: I18n.translations,
@@ -98,12 +99,12 @@ QUnit.module("lib:i18n", {
   },
 });
 
-QUnit.test("defaults", (assert) => {
+test("defaults", (assert) => {
   assert.equal(I18n.defaultLocale, "en", "it has English as default locale");
   assert.ok(I18n.pluralizationRules["en"], "it has English pluralizer");
 });
 
-QUnit.test("translations", (assert) => {
+test("translations", (assert) => {
   assert.equal(
     I18n.t("topic.reply.title"),
     "Répondre",
@@ -122,7 +123,7 @@ QUnit.test("translations", (assert) => {
   assert.equal(I18n.t("hello.universe"), "", "allows empty strings");
 });
 
-QUnit.test("extra translations", (assert) => {
+test("extra translations", (assert) => {
   I18n.locale = "pl_PL";
   I18n.extras = {
     en: {
@@ -194,7 +195,7 @@ QUnit.test("extra translations", (assert) => {
   );
 });
 
-QUnit.test("pluralizations", (assert) => {
+test("pluralizations", (assert) => {
   assert.equal(I18n.t("character_count", { count: 0 }), "0 ZERO");
   assert.equal(I18n.t("character_count", { count: 1 }), "1 ONE");
   assert.equal(I18n.t("character_count", { count: 2 }), "2 TWO");
@@ -210,7 +211,7 @@ QUnit.test("pluralizations", (assert) => {
   assert.equal(I18n.t("word_count", { count: 100 }), "100 words");
 });
 
-QUnit.test("fallback", (assert) => {
+test("fallback", (assert) => {
   assert.equal(
     I18n.t("days", { count: 1 }),
     "1 day",
@@ -242,7 +243,7 @@ QUnit.test("fallback", (assert) => {
   );
 });
 
-QUnit.test("Dollar signs are properly escaped", (assert) => {
+test("Dollar signs are properly escaped", (assert) => {
   assert.equal(
     I18n.t("dollar_sign", {
       description: "$& $&",

--- a/app/assets/javascripts/discourse/tests/unit/lib/icon-library-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/icon-library-test.js
@@ -1,12 +1,13 @@
+import { test, module } from "qunit";
 import {
   iconHTML,
   iconNode,
   convertIconClass,
 } from "discourse-common/lib/icon-library";
 
-QUnit.module("lib:icon-library");
+module("lib:icon-library");
 
-QUnit.test("return icon markup", (assert) => {
+test("return icon markup", (assert) => {
   assert.ok(iconHTML("bars").indexOf('use xlink:href="#bars"') > -1);
 
   const nodeIcon = iconNode("bars");
@@ -17,7 +18,7 @@ QUnit.test("return icon markup", (assert) => {
   );
 });
 
-QUnit.test("convert icon names", (assert) => {
+test("convert icon names", (assert) => {
   const fa5Icon = convertIconClass("fab fa-facebook");
   assert.ok(iconHTML(fa5Icon).indexOf("fab-facebook") > -1, "FA 5 syntax");
 

--- a/app/assets/javascripts/discourse/tests/unit/lib/key-value-store-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/key-value-store-test.js
@@ -1,14 +1,15 @@
+import { test, module } from "qunit";
 import KeyValueStore from "discourse/lib/key-value-store";
 
-QUnit.module("lib:key-value-store");
+module("lib:key-value-store");
 
-QUnit.test("it's able to get the result back from the store", (assert) => {
+test("it's able to get the result back from the store", (assert) => {
   const store = new KeyValueStore("_test");
   store.set({ key: "bob", value: "uncle" });
   assert.equal(store.get("bob"), "uncle");
 });
 
-QUnit.test("is able to nuke the store", (assert) => {
+test("is able to nuke the store", (assert) => {
   const store = new KeyValueStore("_test");
   store.set({ key: "bob1", value: "uncle" });
   store.abandonLocal();

--- a/app/assets/javascripts/discourse/tests/unit/lib/link-mentions-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/link-mentions-test.js
@@ -1,3 +1,4 @@
+import { test, module } from "qunit";
 import {
   fetchUnseenMentions,
   linkSeenMentions,
@@ -5,9 +6,9 @@ import {
 import { Promise } from "rsvp";
 import pretender from "discourse/tests/helpers/create-pretender";
 
-QUnit.module("lib:link-mentions");
+module("lib:link-mentions");
 
-QUnit.test("linkSeenMentions replaces users and groups", async (assert) => {
+test("linkSeenMentions replaces users and groups", async (assert) => {
   pretender.get("/u/is_local_username", () => [
     200,
     { "Content-Type": "application/json" },

--- a/app/assets/javascripts/discourse/tests/unit/lib/load-script-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/load-script-test.js
@@ -1,27 +1,26 @@
+import { skip } from "qunit";
+import { test, module } from "qunit";
 import { loadScript, cacheBuster } from "discourse/lib/load-script";
 import { PUBLIC_JS_VERSIONS as jsVersions } from "discourse/lib/public-js-versions";
 
-QUnit.module("lib:load-script");
+module("lib:load-script");
 
-QUnit.skip(
-  "load with a script tag, and callbacks are only executed after script is loaded",
-  async (assert) => {
-    assert.ok(
-      typeof window.ace === "undefined",
-      "ensures ace is not previously loaded"
-    );
+skip("load with a script tag, and callbacks are only executed after script is loaded", async (assert) => {
+  assert.ok(
+    typeof window.ace === "undefined",
+    "ensures ace is not previously loaded"
+  );
 
-    const src = "/javascripts/ace/ace.js";
+  const src = "/javascripts/ace/ace.js";
 
-    await loadScript(src);
-    assert.ok(
-      typeof window.ace !== "undefined",
-      "callbacks should only be executed after the script has fully loaded"
-    );
-  }
-);
+  await loadScript(src);
+  assert.ok(
+    typeof window.ace !== "undefined",
+    "callbacks should only be executed after the script has fully loaded"
+  );
+});
 
-QUnit.test("works when a value is not present", (assert) => {
+test("works when a value is not present", (assert) => {
   assert.equal(
     cacheBuster("/javascripts/my-script.js"),
     "/javascripts/my-script.js"
@@ -32,16 +31,13 @@ QUnit.test("works when a value is not present", (assert) => {
   );
 });
 
-QUnit.test(
-  "generates URLs with version number in the query params",
-  (assert) => {
-    assert.equal(
-      cacheBuster("/javascripts/pikaday.js"),
-      `/javascripts/${jsVersions["pikaday.js"]}`
-    );
-    assert.equal(
-      cacheBuster("/javascripts/ace/ace.js"),
-      `/javascripts/${jsVersions["ace/ace.js"]}`
-    );
-  }
-);
+test("generates URLs with version number in the query params", (assert) => {
+  assert.equal(
+    cacheBuster("/javascripts/pikaday.js"),
+    `/javascripts/${jsVersions["pikaday.js"]}`
+  );
+  assert.equal(
+    cacheBuster("/javascripts/ace/ace.js"),
+    `/javascripts/${jsVersions["ace/ace.js"]}`
+  );
+});

--- a/app/assets/javascripts/discourse/tests/unit/lib/oneboxer-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/oneboxer-test.js
@@ -1,3 +1,4 @@
+import { test, module } from "qunit";
 import { load } from "pretty-text/oneboxer";
 import { ajax } from "discourse/lib/ajax";
 import { failedCache, localCache } from "pretty-text/oneboxer-cache";
@@ -14,9 +15,9 @@ function loadOnebox(element) {
   });
 }
 
-QUnit.module("lib:oneboxer");
+module("lib:oneboxer");
 
-QUnit.test("load - failed onebox", async (assert) => {
+test("load - failed onebox", async (assert) => {
   let element = document.createElement("A");
   element.setAttribute("href", "http://somebadurl.com");
 
@@ -34,7 +35,7 @@ QUnit.test("load - failed onebox", async (assert) => {
   );
 });
 
-QUnit.test("load - successful onebox", async (assert) => {
+test("load - successful onebox", async (assert) => {
   const html = `
     <aside class="onebox allowlistedgeneric">
       <header class="source">

--- a/app/assets/javascripts/discourse/tests/unit/lib/preload-store-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/preload-store-test.js
@@ -1,13 +1,14 @@
+import { test, module } from "qunit";
 import PreloadStore from "discourse/lib/preload-store";
 import { Promise } from "rsvp";
 
-QUnit.module("preload-store", {
+module("preload-store", {
   beforeEach() {
     PreloadStore.store("bane", "evil");
   },
 });
 
-QUnit.test("get", (assert) => {
+test("get", (assert) => {
   assert.blank(PreloadStore.get("joker"), "returns blank for a missing key");
   assert.equal(
     PreloadStore.get("bane"),
@@ -16,50 +17,38 @@ QUnit.test("get", (assert) => {
   );
 });
 
-QUnit.test("remove", (assert) => {
+test("remove", (assert) => {
   PreloadStore.remove("bane");
   assert.blank(PreloadStore.get("bane"), "removes the value if the key exists");
 });
 
-QUnit.test(
-  "getAndRemove returns a promise that resolves to null",
-  async (assert) => {
-    assert.blank(await PreloadStore.getAndRemove("joker"));
-  }
-);
+test("getAndRemove returns a promise that resolves to null", async (assert) => {
+  assert.blank(await PreloadStore.getAndRemove("joker"));
+});
 
-QUnit.test(
-  "getAndRemove returns a promise that resolves to the result of the finder",
-  async (assert) => {
-    const finder = () => "batdance";
-    const result = await PreloadStore.getAndRemove("joker", finder);
+test("getAndRemove returns a promise that resolves to the result of the finder", async (assert) => {
+  const finder = () => "batdance";
+  const result = await PreloadStore.getAndRemove("joker", finder);
 
-    assert.equal(result, "batdance");
-  }
-);
+  assert.equal(result, "batdance");
+});
 
-QUnit.test(
-  "getAndRemove returns a promise that resolves to the result of the finder's promise",
-  async (assert) => {
-    const finder = () => Promise.resolve("hahahah");
-    const result = await PreloadStore.getAndRemove("joker", finder);
+test("getAndRemove returns a promise that resolves to the result of the finder's promise", async (assert) => {
+  const finder = () => Promise.resolve("hahahah");
+  const result = await PreloadStore.getAndRemove("joker", finder);
 
-    assert.equal(result, "hahahah");
-  }
-);
+  assert.equal(result, "hahahah");
+});
 
-QUnit.test(
-  "returns a promise that rejects with the result of the finder's rejected promise",
-  async (assert) => {
-    const finder = () => Promise.reject("error");
+test("returns a promise that rejects with the result of the finder's rejected promise", async (assert) => {
+  const finder = () => Promise.reject("error");
 
-    await PreloadStore.getAndRemove("joker", finder).catch((result) => {
-      assert.equal(result, "error");
-    });
-  }
-);
+  await PreloadStore.getAndRemove("joker", finder).catch((result) => {
+    assert.equal(result, "error");
+  });
+});
 
-QUnit.test("returns a promise that resolves to 'evil'", async (assert) => {
+test("returns a promise that resolves to 'evil'", async (assert) => {
   const result = await PreloadStore.getAndRemove("bane");
   assert.equal(result, "evil");
 });

--- a/app/assets/javascripts/discourse/tests/unit/lib/pretty-text-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/pretty-text-test.js
@@ -1,3 +1,5 @@
+import { skip } from "qunit";
+import { test, module } from "qunit";
 import { buildQuote } from "discourse/lib/quote";
 import Post from "discourse/models/post";
 import PrettyText, { buildOptions } from "pretty-text/pretty-text";
@@ -9,8 +11,9 @@ import {
 import { extractDataAttribute } from "pretty-text/engines/discourse-markdown-it";
 import { registerEmoji } from "pretty-text/emoji";
 import { deepMerge } from "discourse-common/lib/object";
+import QUnit from "qunit";
 
-QUnit.module("lib:pretty-text");
+module("lib:pretty-text");
 
 const rawOpts = {
   siteSettings: {
@@ -53,7 +56,7 @@ QUnit.assert.cookedPara = function (input, expected, message) {
   QUnit.assert.cooked(input, `<p>${expected}</p>`, message);
 };
 
-QUnit.skip("Pending Engine fixes and spec fixes", (assert) => {
+skip("Pending Engine fixes and spec fixes", (assert) => {
   assert.cooked(
     "Derpy: http://derp.com?_test_=1",
     '<p>Derpy: <a href=https://derp.com?_test_=1"http://derp.com?_test_=1">http://derp.com?_test_=1</a></p>',
@@ -67,7 +70,7 @@ QUnit.skip("Pending Engine fixes and spec fixes", (assert) => {
   );
 });
 
-QUnit.test("buildOptions", (assert) => {
+test("buildOptions", (assert) => {
   assert.ok(
     buildOptions({ siteSettings: { enable_emoji: true } }).discourse.features
       .emoji,
@@ -80,7 +83,7 @@ QUnit.test("buildOptions", (assert) => {
   );
 });
 
-QUnit.test("basic cooking", (assert) => {
+test("basic cooking", (assert) => {
   assert.cooked("hello", "<p>hello</p>", "surrounds text with paragraphs");
   assert.cooked("**evil**", "<p><strong>evil</strong></p>", "it bolds text.");
   assert.cooked("__bold__", "<p><strong>bold</strong></p>", "it bolds text.");
@@ -118,7 +121,7 @@ QUnit.test("basic cooking", (assert) => {
   );
 });
 
-QUnit.test("Nested bold and italics", (assert) => {
+test("Nested bold and italics", (assert) => {
   assert.cooked(
     "*this is italic **with some bold** inside*",
     "<p><em>this is italic <strong>with some bold</strong> inside</em></p>",
@@ -126,7 +129,7 @@ QUnit.test("Nested bold and italics", (assert) => {
   );
 });
 
-QUnit.test("Traditional Line Breaks", (assert) => {
+test("Traditional Line Breaks", (assert) => {
   const input = "1\n2\n3";
   assert.cooked(
     input,
@@ -140,14 +143,14 @@ QUnit.test("Traditional Line Breaks", (assert) => {
   );
 });
 
-QUnit.test("Unbalanced underscores", (assert) => {
+test("Unbalanced underscores", (assert) => {
   assert.cooked(
     "[evil_trout][1] hello_\n\n[1]: http://eviltrout.com",
     '<p><a href="http://eviltrout.com">evil_trout</a> hello_</p>'
   );
 });
 
-QUnit.test("Line Breaks", (assert) => {
+test("Line Breaks", (assert) => {
   assert.cooked(
     "[] first choice\n[] second choice",
     "<p>[] first choice<br>\n[] second choice</p>",
@@ -171,7 +174,7 @@ QUnit.test("Line Breaks", (assert) => {
   );
 });
 
-QUnit.test("Paragraphs for HTML", (assert) => {
+test("Paragraphs for HTML", (assert) => {
   assert.cooked(
     "<div>hello world</div>",
     "<div>hello world</div>",
@@ -194,7 +197,7 @@ QUnit.test("Paragraphs for HTML", (assert) => {
   );
 });
 
-QUnit.test("Links", (assert) => {
+test("Links", (assert) => {
   assert.cooked(
     "EvilTrout: http://eviltrout.com",
     '<p>EvilTrout: <a href="http://eviltrout.com">http://eviltrout.com</a></p>',
@@ -343,7 +346,7 @@ QUnit.test("Links", (assert) => {
   );
 });
 
-QUnit.test("simple quotes", (assert) => {
+test("simple quotes", (assert) => {
   assert.cooked(
     "> nice!",
     "<blockquote>\n<p>nice!</p>\n</blockquote>",
@@ -392,7 +395,7 @@ eviltrout</p>
   );
 });
 
-QUnit.test("Quotes", (assert) => {
+test("Quotes", (assert) => {
   assert.cookedOptions(
     '[quote="eviltrout, post: 1"]\na quote\n\nsecond line\n\nthird line\n[/quote]',
     { topicId: 2 },
@@ -453,7 +456,7 @@ QUnit.test("Quotes", (assert) => {
   );
 });
 
-QUnit.test("Mentions", (assert) => {
+test("Mentions", (assert) => {
   assert.cooked(
     "Hello @sam",
     '<p>Hello <span class="mention">@sam</span></p>',
@@ -594,7 +597,7 @@ QUnit.test("Mentions", (assert) => {
   );
 });
 
-QUnit.test("Mentions - Unicode usernames enabled", (assert) => {
+test("Mentions - Unicode usernames enabled", (assert) => {
   assert.cookedOptions(
     "Hello @狮子",
     { siteSettings: { unicode_usernames: true } },
@@ -617,7 +620,7 @@ QUnit.test("Mentions - Unicode usernames enabled", (assert) => {
   );
 });
 
-QUnit.test("Mentions - disabled", (assert) => {
+test("Mentions - disabled", (assert) => {
   assert.cookedOptions(
     "@eviltrout",
     { siteSettings: { enable_mentions: false } },
@@ -625,7 +628,7 @@ QUnit.test("Mentions - disabled", (assert) => {
   );
 });
 
-QUnit.test("Category hashtags", (assert) => {
+test("Category hashtags", (assert) => {
   const alwaysTrue = {
     categoryHashtagLookup: function () {
       return ["http://test.discourse.org/category-hashtag", "category-hashtag"];
@@ -689,7 +692,7 @@ QUnit.test("Category hashtags", (assert) => {
   );
 });
 
-QUnit.test("Heading", (assert) => {
+test("Heading", (assert) => {
   assert.cooked(
     "**Bold**\n----------",
     "<h2><strong>Bold</strong></h2>",
@@ -697,7 +700,7 @@ QUnit.test("Heading", (assert) => {
   );
 });
 
-QUnit.test("bold and italics", (assert) => {
+test("bold and italics", (assert) => {
   assert.cooked(
     'a "**hello**"',
     "<p>a &quot;<strong>hello</strong>&quot;</p>",
@@ -735,7 +738,7 @@ QUnit.test("bold and italics", (assert) => {
   );
 });
 
-QUnit.test("Escaping", (assert) => {
+test("Escaping", (assert) => {
   assert.cooked(
     "*\\*laughs\\**",
     "<p><em>*laughs*</em></p>",
@@ -748,7 +751,7 @@ QUnit.test("Escaping", (assert) => {
   );
 });
 
-QUnit.test("New Lines", (assert) => {
+test("New Lines", (assert) => {
   // historically we would not continue inline em or b across lines,
   // however commonmark gives us no switch to do so and we would be very non compliant.
   // turning softbreaks into a newline is just a renderer option, not a parser switch.
@@ -764,7 +767,7 @@ QUnit.test("New Lines", (assert) => {
   );
 });
 
-QUnit.test("Oneboxing", (assert) => {
+test("Oneboxing", (assert) => {
   function matches(input, regexp) {
     return new PrettyText(defaultOpts).cook(input).match(regexp);
   }
@@ -810,7 +813,7 @@ QUnit.test("Oneboxing", (assert) => {
   );
 });
 
-QUnit.test("links with full urls", (assert) => {
+test("links with full urls", (assert) => {
   assert.cooked(
     "[http://eviltrout.com][1] is a url\n\n[1]: http://eviltrout.com",
     '<p><a href="http://eviltrout.com">http://eviltrout.com</a> is a url</p>',
@@ -818,7 +821,7 @@ QUnit.test("links with full urls", (assert) => {
   );
 });
 
-QUnit.test("Code Blocks", (assert) => {
+test("Code Blocks", (assert) => {
   assert.cooked(
     "<pre>\nhello\n</pre>\n",
     "<pre>\nhello\n</pre>",
@@ -940,7 +943,7 @@ QUnit.test("Code Blocks", (assert) => {
   );
 });
 
-QUnit.test("URLs in BBCode tags", (assert) => {
+test("URLs in BBCode tags", (assert) => {
   assert.cooked(
     "[img]http://eviltrout.com/eviltrout.png[/img][img]http://samsaffron.com/samsaffron.png[/img]",
     '<p><img src="http://eviltrout.com/eviltrout.png" alt/><img src="http://samsaffron.com/samsaffron.png" alt/></p>',
@@ -960,7 +963,7 @@ QUnit.test("URLs in BBCode tags", (assert) => {
   );
 });
 
-QUnit.test("images", (assert) => {
+test("images", (assert) => {
   assert.cooked(
     "[![folksy logo](http://folksy.com/images/folksy-colour.png)](http://folksy.com/)",
     '<p><a href="http://folksy.com/"><img src="http://folksy.com/images/folksy-colour.png" alt="folksy logo"/></a></p>',
@@ -974,7 +977,7 @@ QUnit.test("images", (assert) => {
   );
 });
 
-QUnit.test("attachment", (assert) => {
+test("attachment", (assert) => {
   assert.cooked(
     "[test.pdf|attachment](upload://o8iobpLcW3WSFvVH7YQmyGlKmGM.pdf)",
     `<p><a class="attachment" href="/404" data-orig-href="upload://o8iobpLcW3WSFvVH7YQmyGlKmGM.pdf">test.pdf</a></p>`,
@@ -982,7 +985,7 @@ QUnit.test("attachment", (assert) => {
   );
 });
 
-QUnit.test("attachment - mapped url - secure media disabled", (assert) => {
+test("attachment - mapped url - secure media disabled", (assert) => {
   function lookupUploadUrls() {
     let cache = {};
     cache["upload://o8iobpLcW3WSFvVH7YQmyGlKmGM.pdf"] = {
@@ -1004,7 +1007,7 @@ QUnit.test("attachment - mapped url - secure media disabled", (assert) => {
   );
 });
 
-QUnit.test("attachment - mapped url - secure media enabled", (assert) => {
+test("attachment - mapped url - secure media enabled", (assert) => {
   function lookupUploadUrls() {
     let cache = {};
     cache["upload://o8iobpLcW3WSFvVH7YQmyGlKmGM.pdf"] = {
@@ -1026,7 +1029,7 @@ QUnit.test("attachment - mapped url - secure media enabled", (assert) => {
   );
 });
 
-QUnit.test("video", (assert) => {
+test("video", (assert) => {
   assert.cooked(
     "![baby shark|video](upload://eyPnj7UzkU0AkGkx2dx8G4YM1Jx.mp4)",
     `<p><div class="video-container">
@@ -1039,7 +1042,7 @@ QUnit.test("video", (assert) => {
   );
 });
 
-QUnit.test("video - mapped url - secure media enabled", (assert) => {
+test("video - mapped url - secure media enabled", (assert) => {
   function lookupUploadUrls() {
     let cache = {};
     cache["upload://eyPnj7UzkU0AkGkx2dx8G4YM1Jx.mp4"] = {
@@ -1065,7 +1068,7 @@ QUnit.test("video - mapped url - secure media enabled", (assert) => {
   );
 });
 
-QUnit.test("audio", (assert) => {
+test("audio", (assert) => {
   assert.cooked(
     "![young americans|audio](upload://eyPnj7UzkU0AkGkx2dx8G4YM1Jx.mp3)",
     `<p><audio preload="metadata" controls>
@@ -1076,7 +1079,7 @@ QUnit.test("audio", (assert) => {
   );
 });
 
-QUnit.test("audio - mapped url - secure media enabled", (assert) => {
+test("audio - mapped url - secure media enabled", (assert) => {
   function lookupUploadUrls() {
     let cache = {};
     cache["upload://eyPnj7UzkU0AkGkx2dx8G4YM1Jx.mp3"] = {
@@ -1100,7 +1103,7 @@ QUnit.test("audio - mapped url - secure media enabled", (assert) => {
   );
 });
 
-QUnit.test("censoring", (assert) => {
+test("censoring", (assert) => {
   assert.cookedOptions(
     "Pleased to meet you, but pleeeease call me later, xyz123",
     {
@@ -1112,7 +1115,7 @@ QUnit.test("censoring", (assert) => {
   // More tests in pretty_text_spec.rb
 });
 
-QUnit.test("code blocks/spans hoisting", (assert) => {
+test("code blocks/spans hoisting", (assert) => {
   assert.cooked(
     "```\n\n    some code\n```",
     '<pre><code class="lang-auto">\n    some code\n</code></pre>',
@@ -1126,7 +1129,7 @@ QUnit.test("code blocks/spans hoisting", (assert) => {
   );
 });
 
-QUnit.test("basic bbcode", (assert) => {
+test("basic bbcode", (assert) => {
   assert.cookedPara(
     "[b]strong[/b]",
     '<span class="bbcode-b">strong</span>',
@@ -1174,7 +1177,7 @@ QUnit.test("basic bbcode", (assert) => {
   );
 });
 
-QUnit.test("urls", (assert) => {
+test("urls", (assert) => {
   assert.cookedPara(
     "[url]not a url[/url]",
     "not a url",
@@ -1201,7 +1204,7 @@ QUnit.test("urls", (assert) => {
     "supports [url] with an embedded [img]"
   );
 });
-QUnit.test("invalid bbcode", (assert) => {
+test("invalid bbcode", (assert) => {
   assert.cooked(
     "[code]I am not closed\n\nThis text exists.",
     "<p>[code]I am not closed</p>\n<p>This text exists.</p>",
@@ -1209,7 +1212,7 @@ QUnit.test("invalid bbcode", (assert) => {
   );
 });
 
-QUnit.test("code", (assert) => {
+test("code", (assert) => {
   assert.cooked(
     "[code]\nx++\n[/code]",
     '<pre><code class="lang-auto">x++</code></pre>',
@@ -1232,7 +1235,7 @@ QUnit.test("code", (assert) => {
   );
 });
 
-QUnit.test("tags with arguments", (assert) => {
+test("tags with arguments", (assert) => {
   assert.cookedPara(
     "[url=http://bettercallsaul.com]better call![/url]",
     '<a href="http://bettercallsaul.com" data-bbcode="true">better call!</a>',
@@ -1255,7 +1258,7 @@ QUnit.test("tags with arguments", (assert) => {
   );
 });
 
-QUnit.test("quotes", (assert) => {
+test("quotes", (assert) => {
   const post = Post.create({
     cooked: "<p><b>lorem</b> ipsum</p>",
     username: "eviltrout",
@@ -1315,7 +1318,7 @@ QUnit.test("quotes", (assert) => {
   );
 });
 
-QUnit.test("quoting a quote", (assert) => {
+test("quoting a quote", (assert) => {
   const post = Post.create({
     cooked: new PrettyText(defaultOpts).cook(
       '[quote="sam, post:1, topic:1, full:true"]\nhello\n[/quote]\n*Test*'
@@ -1337,7 +1340,7 @@ QUnit.test("quoting a quote", (assert) => {
   );
 });
 
-QUnit.test("quote formatting", (assert) => {
+test("quote formatting", (assert) => {
   assert.cooked(
     '[quote="EvilTrout, post:123, topic:456, full:true"]\n[sam]\n[/quote]',
     `<aside class=\"quote no-group\" data-username=\"EvilTrout\" data-post=\"123\" data-topic=\"456\" data-full=\"true\">
@@ -1440,7 +1443,7 @@ var bar = 'bar';
   );
 });
 
-QUnit.test("quotes with trailing formatting", (assert) => {
+test("quotes with trailing formatting", (assert) => {
   const result = new PrettyText(defaultOpts).cook(
     '[quote="EvilTrout, post:123, topic:456, full:true"]\nhello\n[/quote]\n*Test*'
   );
@@ -1459,7 +1462,7 @@ QUnit.test("quotes with trailing formatting", (assert) => {
   );
 });
 
-QUnit.test("enable/disable features", (assert) => {
+test("enable/disable features", (assert) => {
   assert.cookedOptions("|a|\n--\n|a|", { features: { table: false } }, "");
   assert.cooked(
     "|a|\n--\n|a|",
@@ -1480,7 +1483,7 @@ QUnit.test("enable/disable features", (assert) => {
   );
 });
 
-QUnit.test("emoji", (assert) => {
+test("emoji", (assert) => {
   assert.cooked(
     ":smile:",
     `<p><img src="/images/emoji/emoji_one/smile.png?v=${v}" title=":smile:" class="emoji only-emoji" alt=":smile:"></p>`
@@ -1495,7 +1498,7 @@ QUnit.test("emoji", (assert) => {
   );
 });
 
-QUnit.test("emoji - enable_inline_emoji_translation", (assert) => {
+test("emoji - enable_inline_emoji_translation", (assert) => {
   assert.cookedOptions(
     "test:smile:test",
     { siteSettings: { enable_inline_emoji_translation: false } },
@@ -1509,7 +1512,7 @@ QUnit.test("emoji - enable_inline_emoji_translation", (assert) => {
   );
 });
 
-QUnit.test("emoji - emojiSet", (assert) => {
+test("emoji - emojiSet", (assert) => {
   assert.cookedOptions(
     ":smile:",
     { siteSettings: { emoji_set: "twitter" } },
@@ -1517,7 +1520,7 @@ QUnit.test("emoji - emojiSet", (assert) => {
   );
 });
 
-QUnit.test("emoji - registerEmoji", (assert) => {
+test("emoji - registerEmoji", (assert) => {
   registerEmoji("foo", "/images/d-logo-sketch.png");
 
   assert.cookedOptions(
@@ -1535,7 +1538,7 @@ QUnit.test("emoji - registerEmoji", (assert) => {
   );
 });
 
-QUnit.test("extractDataAttribute", (assert) => {
+test("extractDataAttribute", (assert) => {
   assert.deepEqual(extractDataAttribute("foo="), ["data-foo", ""]);
   assert.deepEqual(extractDataAttribute("foo=bar"), ["data-foo", "bar"]);
 

--- a/app/assets/javascripts/discourse/tests/unit/lib/sanitizer-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/sanitizer-test.js
@@ -1,9 +1,10 @@
+import { test, module } from "qunit";
 import PrettyText, { buildOptions } from "pretty-text/pretty-text";
 import { hrefAllowed } from "pretty-text/sanitizer";
 
-QUnit.module("lib:sanitizer");
+module("lib:sanitizer");
 
-QUnit.test("sanitize", (assert) => {
+test("sanitize", (assert) => {
   const pt = new PrettyText(
     buildOptions({
       siteSettings: {
@@ -130,7 +131,7 @@ QUnit.test("sanitize", (assert) => {
   cooked(`<div dir="rtl">RTL text</div>`, `<div dir="rtl">RTL text</div>`);
 });
 
-QUnit.test("ids on headings", (assert) => {
+test("ids on headings", (assert) => {
   const pt = new PrettyText(buildOptions({ siteSettings: {} }));
   assert.equal(pt.sanitize("<h3>Test Heading</h3>"), "<h3>Test Heading</h3>");
   assert.equal(
@@ -159,7 +160,7 @@ QUnit.test("ids on headings", (assert) => {
   );
 });
 
-QUnit.test("poorly formed ids on headings", (assert) => {
+test("poorly formed ids on headings", (assert) => {
   let pt = new PrettyText(buildOptions({ siteSettings: {} }));
   assert.equal(
     pt.sanitize(`<h1 id="evil-trout">Test Heading</h1>`),
@@ -187,7 +188,7 @@ QUnit.test("poorly formed ids on headings", (assert) => {
   );
 });
 
-QUnit.test("urlAllowed", (assert) => {
+test("urlAllowed", (assert) => {
   const allowed = (url, msg) => assert.equal(hrefAllowed(url), url, msg);
 
   allowed("/foo/bar.html", "allows relative urls");

--- a/app/assets/javascripts/discourse/tests/unit/lib/search-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/search-test.js
@@ -1,12 +1,13 @@
+import { test, module } from "qunit";
 import I18n from "I18n";
 import {
   translateResults,
   searchContextDescription,
 } from "discourse/lib/search";
 
-QUnit.module("lib:search");
+module("lib:search");
 
-QUnit.test("unescapesEmojisInBlurbs", (assert) => {
+test("unescapesEmojisInBlurbs", (assert) => {
   const source = {
     posts: [
       {
@@ -36,7 +37,7 @@ QUnit.test("unescapesEmojisInBlurbs", (assert) => {
   assert.ok(blurb.indexOf(":thinking:") === -1);
 });
 
-QUnit.test("searchContextDescription", (assert) => {
+test("searchContextDescription", (assert) => {
   assert.equal(
     searchContextDescription("topic"),
     I18n.t("search.context.topic")

--- a/app/assets/javascripts/discourse/tests/unit/lib/sharing-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/sharing-test.js
@@ -1,6 +1,7 @@
+import { test, module } from "qunit";
 import Sharing from "discourse/lib/sharing";
 
-QUnit.module("lib:sharing", {
+module("lib:sharing", {
   beforeEach() {
     Sharing._reset();
   },
@@ -9,7 +10,7 @@ QUnit.module("lib:sharing", {
   },
 });
 
-QUnit.test("addSource", (assert) => {
+test("addSource", (assert) => {
   const sharingSettings = "facebook|twitter";
 
   assert.blank(Sharing.activeSources(sharingSettings));
@@ -21,7 +22,7 @@ QUnit.test("addSource", (assert) => {
   assert.equal(Sharing.activeSources(sharingSettings).length, 1);
 });
 
-QUnit.test("addSharingId", (assert) => {
+test("addSharingId", (assert) => {
   const sharingSettings = "";
 
   assert.blank(Sharing.activeSources(sharingSettings));

--- a/app/assets/javascripts/discourse/tests/unit/lib/text-direction-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/text-direction-test.js
@@ -1,8 +1,9 @@
+import { test, module } from "qunit";
 import { isRTL, isLTR } from "discourse/lib/text-direction";
 
-QUnit.module("lib:text-direction");
+module("lib:text-direction");
 
-QUnit.test("isRTL", (assert) => {
+test("isRTL", (assert) => {
   // Hebrew
   assert.equal(isRTL("זה מבחן"), true);
 
@@ -16,7 +17,7 @@ QUnit.test("isRTL", (assert) => {
   assert.equal(isRTL(""), false);
 });
 
-QUnit.test("isLTR", (assert) => {
+test("isLTR", (assert) => {
   assert.equal(isLTR("This is a test"), true);
   assert.equal(isLTR("זה מבחן"), false);
 });

--- a/app/assets/javascripts/discourse/tests/unit/lib/to-markdown-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/to-markdown-test.js
@@ -1,8 +1,9 @@
+import { test, module } from "qunit";
 import toMarkdown from "discourse/lib/to-markdown";
 
-QUnit.module("lib:to-markdown");
+module("lib:to-markdown");
 
-QUnit.test("converts styles between normal words", (assert) => {
+test("converts styles between normal words", (assert) => {
   const html = `Line with <s>styles</s> <b><i>between</i></b> words.`;
   const markdown = `Line with ~~styles~~ ***between*** words.`;
   assert.equal(toMarkdown(html), markdown);
@@ -11,7 +12,7 @@ QUnit.test("converts styles between normal words", (assert) => {
   assert.equal(toMarkdown("A <b>bold</b>, word"), "A **bold**, word");
 });
 
-QUnit.test("converts inline nested styles", (assert) => {
+test("converts inline nested styles", (assert) => {
   let html = `<em>Italicised line with <strong>some random</strong> <b>bold</b> words.</em>`;
   let markdown = `*Italicised line with **some random** **bold** words.*`;
   assert.equal(toMarkdown(html), markdown);
@@ -23,7 +24,7 @@ QUnit.test("converts inline nested styles", (assert) => {
   assert.equal(toMarkdown(html), markdown);
 });
 
-QUnit.test("converts a link", (assert) => {
+test("converts a link", (assert) => {
   let html = `<a href="https://discourse.org">Discourse</a>`;
   let markdown = `[Discourse](https://discourse.org)`;
   assert.equal(toMarkdown(html), markdown);
@@ -33,7 +34,7 @@ QUnit.test("converts a link", (assert) => {
   assert.equal(toMarkdown(html), markdown);
 });
 
-QUnit.test("put raw URL instead of converting the link", (assert) => {
+test("put raw URL instead of converting the link", (assert) => {
   let url = "https://discourse.org";
   const html = () => `<a href="${url}">${url}</a>`;
 
@@ -43,11 +44,11 @@ QUnit.test("put raw URL instead of converting the link", (assert) => {
   assert.equal(toMarkdown(html()), url);
 });
 
-QUnit.test("skip empty link", (assert) => {
+test("skip empty link", (assert) => {
   assert.equal(toMarkdown(`<a href="https://example.com"></a>`), "");
 });
 
-QUnit.test("converts heading tags", (assert) => {
+test("converts heading tags", (assert) => {
   const html = `
   <h1>Heading 1</h1>
   <h2>Heading 2</h2>
@@ -70,7 +71,7 @@ QUnit.test("converts heading tags", (assert) => {
   assert.equal(toMarkdown(html), markdown);
 });
 
-QUnit.test("converts ul list tag", (assert) => {
+test("converts ul list tag", (assert) => {
   let html = `
   <ul>
     <li>Item 1</li>
@@ -102,7 +103,7 @@ QUnit.test("converts ul list tag", (assert) => {
   assert.equal(toMarkdown(html), markdown);
 });
 
-QUnit.test("stripes unwanted inline tags", (assert) => {
+test("stripes unwanted inline tags", (assert) => {
   const html = `
   <p>Lorem ipsum <span>dolor sit amet, consectetur</span> <strike>elit.</strike></p>
   <p>Ut minim veniam, <label>quis nostrud</label> laboris <nisi> ut aliquip ex ea</nisi> commodo.</p>
@@ -111,7 +112,7 @@ QUnit.test("stripes unwanted inline tags", (assert) => {
   assert.equal(toMarkdown(html), markdown);
 });
 
-QUnit.test("converts table tags", (assert) => {
+test("converts table tags", (assert) => {
   let html = `<address>Discourse Avenue</address><b>laboris</b>
   <table>
     <thead> <tr><th>Heading 1</th><th>Head 2</th></tr> </thead>
@@ -133,36 +134,33 @@ QUnit.test("converts table tags", (assert) => {
   assert.equal(toMarkdown(html), markdown);
 });
 
-QUnit.test(
-  "replace pipes with spaces if table format not supported",
-  (assert) => {
-    let html = `<table>
+test("replace pipes with spaces if table format not supported", (assert) => {
+  let html = `<table>
     <thead> <tr><th>Headi<br><br>ng 1</th><th>Head 2</th></tr> </thead>
       <tbody>
         <tr><td>Lorem</td><td>ipsum</td></tr>
         <tr><td><a href="http://example.com"><img src="http://dolor.com/image.png" /></a></td> <td><i>sit amet</i></td></tr></tbody>
 </table>
   `;
-    let markdown = `Headi\n\nng 1 Head 2\nLorem ipsum\n[![](http://dolor.com/image.png)](http://example.com) *sit amet*`;
-    assert.equal(toMarkdown(html), markdown);
+  let markdown = `Headi\n\nng 1 Head 2\nLorem ipsum\n[![](http://dolor.com/image.png)](http://example.com) *sit amet*`;
+  assert.equal(toMarkdown(html), markdown);
 
-    html = `<table>
+  html = `<table>
     <thead> <tr><th>Heading 1</th></tr> </thead>
       <tbody>
         <tr><td>Lorem</td></tr>
         <tr><td><i>sit amet</i></td></tr></tbody>
 </table>
   `;
-    markdown = `Heading 1\nLorem\n*sit amet*`;
-    assert.equal(toMarkdown(html), markdown);
+  markdown = `Heading 1\nLorem\n*sit amet*`;
+  assert.equal(toMarkdown(html), markdown);
 
-    html = `<table><tr><td>Lorem</td><td><strong>sit amet</strong></td></tr></table>`;
-    markdown = `Lorem **sit amet**`;
-    assert.equal(toMarkdown(html), markdown);
-  }
-);
+  html = `<table><tr><td>Lorem</td><td><strong>sit amet</strong></td></tr></table>`;
+  markdown = `Lorem **sit amet**`;
+  assert.equal(toMarkdown(html), markdown);
+});
 
-QUnit.test("converts img tag", (assert) => {
+test("converts img tag", (assert) => {
   const url = "https://example.com/image.png";
   const base62SHA1 = "q16M6GR110R47Z9p9Dk3PMXOJoE";
   let html = `<img src="${url}" width="100" height="50">`;
@@ -199,7 +197,7 @@ QUnit.test("converts img tag", (assert) => {
   assert.equal(toMarkdown(html), `![description](${url})`);
 });
 
-QUnit.test("supporting html tags by keeping them", (assert) => {
+test("supporting html tags by keeping them", (assert) => {
   let html =
     "Lorem <del>ipsum dolor</del> sit <big>amet, <ins>consectetur</ins></big>";
   let output = html;
@@ -223,7 +221,7 @@ QUnit.test("supporting html tags by keeping them", (assert) => {
   assert.equal(toMarkdown(html), output);
 });
 
-QUnit.test("converts code tags", (assert) => {
+test("converts code tags", (assert) => {
   let html = `Lorem ipsum dolor sit amet,
   <pre><code>var helloWorld = () => {
   alert('    hello \t\t world    ');
@@ -245,7 +243,7 @@ helloWorld();</code>consectetur.`;
   assert.equal(toMarkdown(html), output);
 });
 
-QUnit.test("converts blockquote tag", (assert) => {
+test("converts blockquote tag", (assert) => {
   let html = "<blockquote>Lorem ipsum</blockquote>";
   let output = "> Lorem ipsum";
   assert.equal(toMarkdown(html), output);
@@ -261,7 +259,7 @@ QUnit.test("converts blockquote tag", (assert) => {
   assert.equal(toMarkdown(html), output);
 });
 
-QUnit.test("converts ol list tag", (assert) => {
+test("converts ol list tag", (assert) => {
   const html = `Testing
   <ol>
     <li>Item 1</li>
@@ -279,7 +277,7 @@ QUnit.test("converts ol list tag", (assert) => {
   assert.equal(toMarkdown(html), markdown);
 });
 
-QUnit.test("converts list tag from word", (assert) => {
+test("converts list tag from word", (assert) => {
   const html = `Sample<!--StartFragment-->
   <p class=MsoListParagraphCxSpFirst style='text-indent:-.25in;mso-list:l0 level1 lfo1'>
     <![if !supportLists]>
@@ -326,7 +324,7 @@ QUnit.test("converts list tag from word", (assert) => {
   assert.equal(toMarkdown(html), markdown);
 });
 
-QUnit.test("keeps mention/hash class", (assert) => {
+test("keeps mention/hash class", (assert) => {
   const html = `
     <p>User mention: <a class="mention" href="/u/discourse">@discourse</a></p>
     <p>Group mention: <a class="mention-group" href="/groups/discourse">@discourse-group</a></p>
@@ -339,7 +337,7 @@ QUnit.test("keeps mention/hash class", (assert) => {
   assert.equal(toMarkdown(html), markdown);
 });
 
-QUnit.test("keeps emoji and removes click count", (assert) => {
+test("keeps emoji and removes click count", (assert) => {
   const html = `
     <p>
       A <a href="http://example.com">link</a><span class="badge badge-notification clicks" title="1 click">1</span> with click count
@@ -352,7 +350,7 @@ QUnit.test("keeps emoji and removes click count", (assert) => {
   assert.equal(toMarkdown(html), markdown);
 });
 
-QUnit.test("keeps emoji syntax for custom emoji", (assert) => {
+test("keeps emoji syntax for custom emoji", (assert) => {
   const html = `
     <p>
       <img class="emoji emoji-custom" title=":custom_emoji:" src="https://d11a6trkgmumsb.cloudfront.net/images/emoji/custom_emoji" alt=":custom_emoji:" />
@@ -364,7 +362,7 @@ QUnit.test("keeps emoji syntax for custom emoji", (assert) => {
   assert.equal(toMarkdown(html), markdown);
 });
 
-QUnit.test("converts image lightboxes to markdown", (assert) => {
+test("converts image lightboxes to markdown", (assert) => {
   let html = `
   <a class="lightbox" href="https://d11a6trkgmumsb.cloudfront.net/uploads/default/original/1X/8hkjhk7692f6afed3cb99d43ab2abd4e30aa8cba.jpeg" data-download-href="https://d11a6trkgmumsb.cloudfront.net/uploads/default/8hkjhk7692f6afed3cb99d43ab2abd4e30aa8cba" title="sherlock3_sig.jpg" rel="nofollow noopener"><img src="https://d11a6trkgmumsb.cloudfront.net/uploads/default/optimized/1X/8hkjhk7692f6afed3cb99d43ab2abd4e30aa8cba_2_689x459.jpeg" alt="sherlock3_sig" width="689" height="459" class="d-lazyload" srcset="https://d11a6trkgmumsb.cloudfront.net/uploads/default/optimized/1X/8hkjhk7692f6afed3cb99d43ab2abd4e30aa8cba_2_689x459.jpeg, https://d11a6trkgmumsb.cloudfront.net/uploads/default/optimized/1X/8hkjhk7692f6afed3cb99d43ab2abd4e30aa8cba_2_1033x688.jpeg 1.5x, https://d11a6trkgmumsb.cloudfront.net/uploads/default/optimized/1X/8hkjhk7692f6afed3cb99d43ab2abd4e30aa8cba_2_1378x918.jpeg 2x"><div class="meta">
   <span class="filename">sherlock3_sig.jpg</span><span class="informations">5496×3664 2 MB</span><span class="expand"></span>
@@ -388,7 +386,7 @@ QUnit.test("converts image lightboxes to markdown", (assert) => {
   assert.equal(toMarkdown(html), markdown);
 });
 
-QUnit.test("converts quotes to markdown", (assert) => {
+test("converts quotes to markdown", (assert) => {
   let html = `
   <p>there is a quote below</p>
   <aside class="quote no-group" data-username="foo" data-post="1" data-topic="2">
@@ -415,7 +413,7 @@ there is a quote above
   assert.equal(toMarkdown(html), markdown.trim());
 });
 
-QUnit.test("strips base64 image URLs", (assert) => {
+test("strips base64 image URLs", (assert) => {
   const html =
     '<img src="data:image/jpeg;base64,/9j/4AAQSkZJRgABAgAAZABkAAD/7AARRHVja3kAAQAEAAAAPAAA/+4AJkFkb2JlAGTAAAAAAQMAFQQDBgoNAAABywAAAgsAAAJpAAACyf/bAIQABgQEBAUEBgUFBgkGBQYJCwgGBggLDAoKCwoKDBAMDAwMDAwQDA4PEA8ODBMTFBQTExwbGxscHx8fHx8fHx8fHwEHBwcNDA0YEBAYGhURFRofHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8f/8IAEQgAEAAQAwERAAIRAQMRAf/EAJQAAQEBAAAAAAAAAAAAAAAAAAMFBwEAAwEAAAAAAAAAAAAAAAAAAAEDAhAAAQUBAQAAAAAAAAAAAAAAAgABAwQFESARAAIBAwIHAAAAAAAAAAAAAAERAgAhMRIDQWGRocEiIxIBAAAAAAAAAAAAAAAAAAAAIBMBAAMAAQQDAQAAAAAAAAAAAQARITHwQVGBYXGR4f/aAAwDAQACEQMRAAAB0UlMciEJn//aAAgBAQABBQK5bGtFn6pWi2K12wWTRkjb/9oACAECAAEFAvH/2gAIAQMAAQUCIuIJOqRndRiv/9oACAECAgY/Ah//2gAIAQMCBj8CH//aAAgBAQEGPwLWQzwHepfNbcUNfM4tUIbA9QL4AvnxTlAxacpWJReOlf/aAAgBAQMBPyHZDveuCyu4B4lz2lDKto2ca5uclPK0aoq32x8xgTSLeSgbyzT65n//2gAIAQIDAT8hlQjP/9oACAEDAwE/IaE9GcZFJ//aAAwDAQACEQMRAAAQ5F//2gAIAQEDAT8Q1oowKccI3KTdAWkPLw2ssIrwKYUzuJoUJsIHOCoG23ISlja+rU9QvCx//9oACAECAwE/EAuNIiKf/9oACAEDAwE/ECujJzHf7iwHOv5NhK+8efH50z//2Q==" />';
   assert.equal(toMarkdown(html), "[image]");

--- a/app/assets/javascripts/discourse/tests/unit/lib/upload-short-url-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/upload-short-url-test.js
@@ -1,3 +1,4 @@
+import { test, module } from "qunit";
 import {
   lookupCachedUploadUrl,
   resolveAllShortUrls,
@@ -85,13 +86,13 @@ function stubUrls(imageSrcs, attachmentSrcs, otherMediaSrcs) {
         .join("")
   );
 }
-QUnit.module("lib:pretty-text/upload-short-url", {
+module("lib:pretty-text/upload-short-url", {
   afterEach() {
     resetCache();
   },
 });
 
-QUnit.test("resolveAllShortUrls", async (assert) => {
+test("resolveAllShortUrls", async (assert) => {
   stubUrls();
   let lookup;
 
@@ -142,71 +143,62 @@ QUnit.test("resolveAllShortUrls", async (assert) => {
   });
 });
 
-QUnit.test(
-  "resolveAllShortUrls - href + src replaced correctly",
-  async (assert) => {
-    stubUrls();
-    await resolveAllShortUrls(ajax, { secure_media: false }, fixture()[0]);
+test("resolveAllShortUrls - href + src replaced correctly", async (assert) => {
+  stubUrls();
+  await resolveAllShortUrls(ajax, { secure_media: false }, fixture()[0]);
 
-    let image1 = fixture().find("img").eq(0);
-    let image2 = fixture().find("img").eq(1);
-    let link = fixture().find("a");
-    let audio = fixture().find("audio").eq(0);
-    let video = fixture().find("video").eq(0);
+  let image1 = fixture().find("img").eq(0);
+  let image2 = fixture().find("img").eq(1);
+  let link = fixture().find("a");
+  let audio = fixture().find("audio").eq(0);
+  let video = fixture().find("video").eq(0);
 
-    assert.equal(image1.attr("src"), "/images/avatar.png?a");
-    assert.equal(image2.attr("src"), "/images/avatar.png?b");
-    assert.equal(link.attr("href"), "/uploads/short-url/c.pdf");
-    assert.equal(
-      video.find("source").attr("src"),
-      "/uploads/default/original/3X/c/b/4.mp4"
-    );
-    assert.equal(
-      audio.find("source").attr("src"),
-      "/uploads/default/original/3X/c/b/5.mp3"
-    );
-  }
-);
+  assert.equal(image1.attr("src"), "/images/avatar.png?a");
+  assert.equal(image2.attr("src"), "/images/avatar.png?b");
+  assert.equal(link.attr("href"), "/uploads/short-url/c.pdf");
+  assert.equal(
+    video.find("source").attr("src"),
+    "/uploads/default/original/3X/c/b/4.mp4"
+  );
+  assert.equal(
+    audio.find("source").attr("src"),
+    "/uploads/default/original/3X/c/b/5.mp3"
+  );
+});
 
-QUnit.test(
-  "resolveAllShortUrls - url with full origin replaced correctly",
-  async (assert) => {
-    stubUrls();
-    await resolveAllShortUrls(ajax, { secure_media: false }, fixture()[0]);
-    let video = fixture().find("video").eq(1);
+test("resolveAllShortUrls - url with full origin replaced correctly", async (assert) => {
+  stubUrls();
+  await resolveAllShortUrls(ajax, { secure_media: false }, fixture()[0]);
+  let video = fixture().find("video").eq(1);
 
-    assert.equal(
-      video.find("source").attr("src"),
-      "http://localhost:3000/uploads/default/original/3X/c/b/6.mp4"
-    );
-  }
-);
+  assert.equal(
+    video.find("source").attr("src"),
+    "http://localhost:3000/uploads/default/original/3X/c/b/6.mp4"
+  );
+});
 
-QUnit.test(
-  "resolveAllShortUrls - when secure media is enabled use the attachment full URL",
-  async (assert) => {
-    stubUrls(
-      null,
-      [
-        {
-          short_url: "upload://c.pdf",
-          url: "/secure-media-uploads/default/original/3X/c/b/3.pdf",
-          short_path: "/uploads/short-url/c.pdf",
-        },
-      ],
-      null
-    );
-    await resolveAllShortUrls(ajax, { secure_media: true }, fixture()[0]);
+test("resolveAllShortUrls - when secure media is enabled use the attachment full URL", async (assert) => {
+  stubUrls(
+    null,
+    [
+      {
+        short_url: "upload://c.pdf",
+        url: "/secure-media-uploads/default/original/3X/c/b/3.pdf",
+        short_path: "/uploads/short-url/c.pdf",
+      },
+    ],
+    null
+  );
+  await resolveAllShortUrls(ajax, { secure_media: true }, fixture()[0]);
 
-    let link = fixture().find("a");
-    assert.equal(
-      link.attr("href"),
-      "/secure-media-uploads/default/original/3X/c/b/3.pdf"
-    );
-  }
-);
+  let link = fixture().find("a");
+  assert.equal(
+    link.attr("href"),
+    "/secure-media-uploads/default/original/3X/c/b/3.pdf"
+  );
+});
 
-QUnit.test("resolveAllShortUrls - scoped", async (assert) => {
+test("resolveAllShortUrls - scoped", async (assert) => {
   stubUrls();
   let lookup;
 

--- a/app/assets/javascripts/discourse/tests/unit/lib/uploads-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/uploads-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import I18n from "I18n";
 import {
   validateUploadedFiles,
@@ -14,7 +15,7 @@ import bootbox from "bootbox";
 
 discourseModule("lib:uploads");
 
-QUnit.test("validateUploadedFiles", function (assert) {
+test("validateUploadedFiles", function (assert) {
   assert.not(
     validateUploadedFiles(null, { siteSettings: this.siteSettings }),
     "no files are invalid"
@@ -29,7 +30,7 @@ QUnit.test("validateUploadedFiles", function (assert) {
   );
 });
 
-QUnit.test("uploading one file", function (assert) {
+test("uploading one file", function (assert) {
   sandbox.stub(bootbox, "alert");
 
   assert.not(
@@ -38,7 +39,7 @@ QUnit.test("uploading one file", function (assert) {
   assert.ok(bootbox.alert.calledWith(I18n.t("post.errors.too_many_uploads")));
 });
 
-QUnit.test("new user cannot upload images", function (assert) {
+test("new user cannot upload images", function (assert) {
   this.siteSettings.newuser_max_embedded_media = 0;
   sandbox.stub(bootbox, "alert");
 
@@ -57,7 +58,7 @@ QUnit.test("new user cannot upload images", function (assert) {
   );
 });
 
-QUnit.test("new user can upload images if allowed", function (assert) {
+test("new user can upload images if allowed", function (assert) {
   this.siteSettings.newuser_max_embedded_media = 1;
   this.siteSettings.default_trust_level = 0;
   sandbox.stub(bootbox, "alert");
@@ -70,7 +71,7 @@ QUnit.test("new user can upload images if allowed", function (assert) {
   );
 });
 
-QUnit.test("TL1 can upload images", function (assert) {
+test("TL1 can upload images", function (assert) {
   this.siteSettings.newuser_max_embedded_media = 0;
   sandbox.stub(bootbox, "alert");
 
@@ -82,7 +83,7 @@ QUnit.test("TL1 can upload images", function (assert) {
   );
 });
 
-QUnit.test("new user cannot upload attachments", function (assert) {
+test("new user cannot upload attachments", function (assert) {
   this.siteSettings.newuser_max_attachments = 0;
   sandbox.stub(bootbox, "alert");
 
@@ -99,7 +100,7 @@ QUnit.test("new user cannot upload attachments", function (assert) {
   );
 });
 
-QUnit.test("ensures an authorized upload", function (assert) {
+test("ensures an authorized upload", function (assert) {
   sandbox.stub(bootbox, "alert");
   assert.not(
     validateUploadedFiles([{ name: "unauthorized.html" }], {
@@ -115,7 +116,7 @@ QUnit.test("ensures an authorized upload", function (assert) {
   );
 });
 
-QUnit.test("skipping validation works", function (assert) {
+test("skipping validation works", function (assert) {
   const files = [{ name: "backup.tar.gz" }];
   sandbox.stub(bootbox, "alert");
 
@@ -133,7 +134,7 @@ QUnit.test("skipping validation works", function (assert) {
   );
 });
 
-QUnit.test("staff can upload anything in PM", function (assert) {
+test("staff can upload anything in PM", function (assert) {
   const files = [{ name: "some.docx" }];
   this.siteSettings.authorized_extensions = "jpeg";
   sandbox.stub(bootbox, "alert");
@@ -169,7 +170,7 @@ const dummyBlob = function () {
   }
 };
 
-QUnit.test("allows valid uploads to go through", function (assert) {
+test("allows valid uploads to go through", function (assert) {
   sandbox.stub(bootbox, "alert");
 
   let user = User.create({ trust_level: 1 });
@@ -191,7 +192,7 @@ QUnit.test("allows valid uploads to go through", function (assert) {
   assert.not(bootbox.alert.calledOnce);
 });
 
-QUnit.test("isImage", (assert) => {
+test("isImage", (assert) => {
   ["png", "webp", "jpg", "jpeg", "gif", "ico"].forEach((extension) => {
     var image = "image." + extension;
     assert.ok(isImage(image), image + " is recognized as an image");
@@ -205,7 +206,7 @@ QUnit.test("isImage", (assert) => {
   assert.not(isImage(""));
 });
 
-QUnit.test("allowsImages", function (assert) {
+test("allowsImages", function (assert) {
   this.siteSettings.authorized_extensions = "jpg|jpeg|gif";
   assert.ok(allowsImages(false, this.siteSettings), "works");
 
@@ -228,7 +229,7 @@ QUnit.test("allowsImages", function (assert) {
   );
 });
 
-QUnit.test("allowsAttachments", function (assert) {
+test("allowsAttachments", function (assert) {
   this.siteSettings.authorized_extensions = "jpg|jpeg|gif";
   assert.not(
     allowsAttachments(false, this.siteSettings),
@@ -269,7 +270,7 @@ function testUploadMarkdown(filename, opts = {}) {
   );
 }
 
-QUnit.test("getUploadMarkdown", (assert) => {
+test("getUploadMarkdown", (assert) => {
   assert.equal(
     testUploadMarkdown("lolcat.gif"),
     "![lolcat|100x200](/uploads/123/abcdef.ext)"
@@ -296,18 +297,15 @@ QUnit.test("getUploadMarkdown", (assert) => {
   );
 });
 
-QUnit.test(
-  "getUploadMarkdown - replaces GUID in image alt text on iOS",
-  (assert) => {
-    assert.equal(
-      testUploadMarkdown("8F2B469B-6B2C-4213-BC68-57B4876365A0.jpeg"),
-      "![8F2B469B-6B2C-4213-BC68-57B4876365A0|100x200](/uploads/123/abcdef.ext)"
-    );
+test("getUploadMarkdown - replaces GUID in image alt text on iOS", (assert) => {
+  assert.equal(
+    testUploadMarkdown("8F2B469B-6B2C-4213-BC68-57B4876365A0.jpeg"),
+    "![8F2B469B-6B2C-4213-BC68-57B4876365A0|100x200](/uploads/123/abcdef.ext)"
+  );
 
-    sandbox.stub(Utilities, "isAppleDevice").returns(true);
-    assert.equal(
-      testUploadMarkdown("8F2B469B-6B2C-4213-BC68-57B4876365A0.jpeg"),
-      "![image|100x200](/uploads/123/abcdef.ext)"
-    );
-  }
-);
+  sandbox.stub(Utilities, "isAppleDevice").returns(true);
+  assert.equal(
+    testUploadMarkdown("8F2B469B-6B2C-4213-BC68-57B4876365A0.jpeg"),
+    "![image|100x200](/uploads/123/abcdef.ext)"
+  );
+});

--- a/app/assets/javascripts/discourse/tests/unit/lib/url-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/url-test.js
@@ -1,11 +1,12 @@
+import { test, module } from "qunit";
 import DiscourseURL, { userPath } from "discourse/lib/url";
 import { setPrefix } from "discourse-common/lib/get-url";
 import { logIn } from "discourse/tests/helpers/qunit-helpers";
 import User from "discourse/models/user";
 
-QUnit.module("lib:url");
+module("lib:url");
 
-QUnit.test("isInternal with a HTTP url", (assert) => {
+test("isInternal with a HTTP url", (assert) => {
   sandbox.stub(DiscourseURL, "origin").returns("http://eviltrout.com");
 
   assert.not(DiscourseURL.isInternal(null), "a blank URL is not internal");
@@ -32,7 +33,7 @@ QUnit.test("isInternal with a HTTP url", (assert) => {
   );
 });
 
-QUnit.test("isInternal with a HTTPS url", (assert) => {
+test("isInternal with a HTTPS url", (assert) => {
   sandbox.stub(DiscourseURL, "origin").returns("https://eviltrout.com");
   assert.ok(
     DiscourseURL.isInternal("http://eviltrout.com/monocle"),
@@ -40,7 +41,7 @@ QUnit.test("isInternal with a HTTPS url", (assert) => {
   );
 });
 
-QUnit.test("isInternal on subfolder install", (assert) => {
+test("isInternal on subfolder install", (assert) => {
   sandbox.stub(DiscourseURL, "origin").returns("http://eviltrout.com/forum");
   assert.not(
     DiscourseURL.isInternal("http://eviltrout.com"),
@@ -56,18 +57,18 @@ QUnit.test("isInternal on subfolder install", (assert) => {
   );
 });
 
-QUnit.test("userPath", (assert) => {
+test("userPath", (assert) => {
   assert.equal(userPath(), "/u");
   assert.equal(userPath("eviltrout"), "/u/eviltrout");
 });
 
-QUnit.test("userPath with prefix", (assert) => {
+test("userPath with prefix", (assert) => {
   setPrefix("/forum");
   assert.equal(userPath(), "/forum/u");
   assert.equal(userPath("eviltrout"), "/forum/u/eviltrout");
 });
 
-QUnit.test("routeTo with prefix", async (assert) => {
+test("routeTo with prefix", async (assert) => {
   setPrefix("/forum");
   logIn();
   const user = User.current();

--- a/app/assets/javascripts/discourse/tests/unit/lib/user-search-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/user-search-test.js
@@ -1,8 +1,9 @@
+import { test, module } from "qunit";
 import userSearch from "discourse/lib/user-search";
 import { CANCELLED_STATUS } from "discourse/lib/autocomplete";
 import pretender from "discourse/tests/helpers/create-pretender";
 
-QUnit.module("lib:user-search", {
+module("lib:user-search", {
   beforeEach() {
     const response = (object) => {
       return [200, { "Content-Type": "application/json" }, object];
@@ -85,7 +86,7 @@ QUnit.module("lib:user-search", {
   },
 });
 
-QUnit.test("it flushes cache when switching categories", async (assert) => {
+test("it flushes cache when switching categories", async (assert) => {
   let results = await userSearch({ term: "hello", categoryId: 1 });
   assert.equal(results[0].username, "category_1");
   assert.equal(results.length, 1);
@@ -100,46 +101,40 @@ QUnit.test("it flushes cache when switching categories", async (assert) => {
   assert.equal(results.length, 1);
 });
 
-QUnit.test(
-  "it returns cancel when eager completing with no results",
-  async (assert) => {
-    // Do everything twice, to check the cache works correctly
+test("it returns cancel when eager completing with no results", async (assert) => {
+  // Do everything twice, to check the cache works correctly
 
-    for (let i = 0; i < 2; i++) {
-      // No topic or category, will always cancel
-      let result = await userSearch({ term: "" });
-      assert.equal(result, CANCELLED_STATUS);
-    }
-
-    for (let i = 0; i < 2; i++) {
-      // Unsecured category, so has no recommendations
-      let result = await userSearch({ term: "", categoryId: 3 });
-      assert.equal(result, CANCELLED_STATUS);
-    }
-
-    for (let i = 0; i < 2; i++) {
-      // Secured category, will have 1 recommendation
-      let results = await userSearch({ term: "", categoryId: 1 });
-      assert.equal(results[0].username, "category_1");
-      assert.equal(results.length, 1);
-    }
+  for (let i = 0; i < 2; i++) {
+    // No topic or category, will always cancel
+    let result = await userSearch({ term: "" });
+    assert.equal(result, CANCELLED_STATUS);
   }
-);
 
-QUnit.test(
-  "it places groups unconditionally for exact match",
-  async (assert) => {
-    let results = await userSearch({ term: "Team" });
-    assert.equal(results[results.length - 1]["name"], "team");
+  for (let i = 0; i < 2; i++) {
+    // Unsecured category, so has no recommendations
+    let result = await userSearch({ term: "", categoryId: 3 });
+    assert.equal(result, CANCELLED_STATUS);
   }
-);
 
-QUnit.test("it strips @ from the beginning", async (assert) => {
+  for (let i = 0; i < 2; i++) {
+    // Secured category, will have 1 recommendation
+    let results = await userSearch({ term: "", categoryId: 1 });
+    assert.equal(results[0].username, "category_1");
+    assert.equal(results.length, 1);
+  }
+});
+
+test("it places groups unconditionally for exact match", async (assert) => {
+  let results = await userSearch({ term: "Team" });
+  assert.equal(results[results.length - 1]["name"], "team");
+});
+
+test("it strips @ from the beginning", async (assert) => {
   let results = await userSearch({ term: "@Team" });
   assert.equal(results[results.length - 1]["name"], "team");
 });
 
-QUnit.test("it skips a search depending on punctuations", async (assert) => {
+test("it skips a search depending on punctuations", async (assert) => {
   let results;
   let skippedTerms = [
     "@sam  s", // double space is not allowed

--- a/app/assets/javascripts/discourse/tests/unit/lib/utilities-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/utilities-test.js
@@ -1,3 +1,5 @@
+import { skip } from "qunit";
+import { test } from "qunit";
 import {
   escapeExpression,
   emailValid,
@@ -20,7 +22,7 @@ import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
 
 discourseModule("lib:utilities");
 
-QUnit.test("escapeExpression", (assert) => {
+test("escapeExpression", (assert) => {
   assert.equal(escapeExpression(">"), "&gt;", "escapes unsafe characters");
 
   assert.equal(
@@ -36,7 +38,7 @@ QUnit.test("escapeExpression", (assert) => {
   );
 });
 
-QUnit.test("emailValid", (assert) => {
+test("emailValid", (assert) => {
   assert.ok(
     emailValid("Bob@example.com"),
     "allows upper case in the first part of emails"
@@ -47,7 +49,7 @@ QUnit.test("emailValid", (assert) => {
   );
 });
 
-QUnit.test("extractDomainFromUrl", (assert) => {
+test("extractDomainFromUrl", (assert) => {
   assert.equal(
     extractDomainFromUrl("http://meta.discourse.org:443/random"),
     "meta.discourse.org",
@@ -70,7 +72,7 @@ QUnit.test("extractDomainFromUrl", (assert) => {
   );
 });
 
-QUnit.test("avatarUrl", (assert) => {
+test("avatarUrl", (assert) => {
   var rawSize = getRawSize;
   assert.blank(avatarUrl("", "tiny"), "no template returns blank");
   assert.equal(
@@ -93,7 +95,7 @@ var setDevicePixelRatio = function (value) {
   }
 };
 
-QUnit.test("avatarImg", (assert) => {
+test("avatarImg", (assert) => {
   var oldRatio = window.devicePixelRatio;
   setDevicePixelRatio(2);
 
@@ -132,7 +134,7 @@ QUnit.test("avatarImg", (assert) => {
   setDevicePixelRatio(oldRatio);
 });
 
-QUnit.test("defaultHomepage via meta tag", function (assert) {
+test("defaultHomepage via meta tag", function (assert) {
   let meta = document.createElement("meta");
   meta.name = "discourse_current_homepage";
   meta.content = "hot";
@@ -146,7 +148,7 @@ QUnit.test("defaultHomepage via meta tag", function (assert) {
   document.body.removeChild(meta);
 });
 
-QUnit.test("defaultHomepage via site settings", function (assert) {
+test("defaultHomepage via site settings", function (assert) {
   this.siteSettings.top_menu = "top|latest|hot";
   initializeDefaultHomepage(this.siteSettings);
   assert.equal(
@@ -156,14 +158,14 @@ QUnit.test("defaultHomepage via site settings", function (assert) {
   );
 });
 
-QUnit.test("setDefaultHomepage", function (assert) {
+test("setDefaultHomepage", function (assert) {
   initializeDefaultHomepage(this.siteSettings);
   assert.equal(defaultHomepage(), "latest");
   setDefaultHomepage("top");
   assert.equal(defaultHomepage(), "top");
 });
 
-QUnit.test("caretRowCol", (assert) => {
+test("caretRowCol", (assert) => {
   var textarea = document.createElement("textarea");
   const content = document.createTextNode("01234\n56789\n012345");
   textarea.appendChild(content);
@@ -194,7 +196,7 @@ QUnit.test("caretRowCol", (assert) => {
   document.body.removeChild(textarea);
 });
 
-QUnit.test("toAsciiPrintable", (assert) => {
+test("toAsciiPrintable", (assert) => {
   const accentedString = "Créme_Brûlée!";
   const unicodeString = "談話";
 
@@ -217,7 +219,7 @@ QUnit.test("toAsciiPrintable", (assert) => {
   );
 });
 
-QUnit.test("slugify", (assert) => {
+test("slugify", (assert) => {
   const asciiString = "--- 0__( Some-cool Discourse Site! )__0 --- ";
   const accentedString = "Créme_Brûlée!";
   const unicodeString = "談話";
@@ -237,7 +239,7 @@ QUnit.test("slugify", (assert) => {
   assert.equal(slugify(unicodeString), "", "it removes unicode characters");
 });
 
-QUnit.test("fillMissingDates", (assert) => {
+test("fillMissingDates", (assert) => {
   const startDate = "2017-11-12"; // YYYY-MM-DD
   const endDate = "2017-12-12"; // YYYY-MM-DD
   const data =
@@ -250,7 +252,7 @@ QUnit.test("fillMissingDates", (assert) => {
   );
 });
 
-QUnit.test("inCodeBlock", (assert) => {
+test("inCodeBlock", (assert) => {
   const text =
     "000\n\n```\n111\n```\n\n000\n\n`111 111`\n\n000\n\n[code]\n111\n[/code]\n\n    111\n\t111\n\n000`000";
   for (let i = 0; i < text.length; ++i) {
@@ -262,7 +264,7 @@ QUnit.test("inCodeBlock", (assert) => {
   }
 });
 
-QUnit.skip("inCodeBlock - runs fast", (assert) => {
+skip("inCodeBlock - runs fast", (assert) => {
   const phrase = "Lorem ipsum dolor sit amet, consectetur adipiscing elit.";
   const text = `${phrase}\n\n\`\`\`\n${phrase}\n\`\`\`\n\n${phrase}\n\n\`${phrase}\n${phrase}\n\n${phrase}\n\n[code]\n${phrase}\n[/code]\n\n${phrase}\n\n    ${phrase}\n\n\`${phrase}\`\n\n${phrase}`;
 

--- a/app/assets/javascripts/discourse/tests/unit/lib/white-lister-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/white-lister-test.js
@@ -1,8 +1,9 @@
+import { test, module } from "qunit";
 import WhiteLister from "pretty-text/white-lister";
 
-QUnit.module("lib:whiteLister");
+module("lib:whiteLister");
 
-QUnit.test("whiteLister", (assert) => {
+test("whiteLister", (assert) => {
   const whiteLister = new WhiteLister();
 
   assert.ok(

--- a/app/assets/javascripts/discourse/tests/unit/localization-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/localization-test.js
@@ -1,7 +1,8 @@
+import { test, module } from "qunit";
 import I18n from "I18n";
 import LocalizationInitializer from "discourse/initializers/localization";
 
-QUnit.module("initializer:localization", {
+module("initializer:localization", {
   _locale: I18n.locale,
   _translations: I18n.translations,
   _overrides: I18n._overrides,
@@ -36,7 +37,7 @@ QUnit.module("initializer:localization", {
   },
 });
 
-QUnit.test("translation overrides", function (assert) {
+test("translation overrides", function (assert) {
   I18n._overrides = {
     "js.composer.reply": "WAT",
     "js.topic.reply.help": "foobar",
@@ -55,15 +56,12 @@ QUnit.test("translation overrides", function (assert) {
   );
 });
 
-QUnit.test(
-  "skip translation override if parent node is not an object",
-  function (assert) {
-    I18n._overrides = {
-      "js.composer.reply": "WAT",
-      "js.composer.reply.help": "foobar",
-    };
-    LocalizationInitializer.initialize(this.registry);
+test("skip translation override if parent node is not an object", function (assert) {
+  I18n._overrides = {
+    "js.composer.reply": "WAT",
+    "js.composer.reply.help": "foobar",
+  };
+  LocalizationInitializer.initialize(this.registry);
 
-    assert.equal(I18n.t("composer.reply.help"), "[fr.composer.reply.help]");
-  }
-);
+  assert.equal(I18n.t("composer.reply.help"), "[fr.composer.reply.help]");
+});

--- a/app/assets/javascripts/discourse/tests/unit/mixins/grant-badge-controller-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/mixins/grant-badge-controller-test.js
@@ -1,8 +1,9 @@
+import { test, module } from "qunit";
 import Controller from "@ember/controller";
 import GrantBadgeControllerMixin from "discourse/mixins/grant-badge-controller";
 import Badge from "discourse/models/badge";
 
-QUnit.module("mixin:grant-badge-controller", {
+module("mixin:grant-badge-controller", {
   before: function () {
     this.GrantBadgeController = Controller.extend(GrantBadgeControllerMixin);
 
@@ -52,7 +53,7 @@ QUnit.module("mixin:grant-badge-controller", {
   },
 });
 
-QUnit.test("grantableBadges", function (assert) {
+test("grantableBadges", function (assert) {
   const sortedNames = [
     this.badgeFirst.name,
     this.badgeMiddle.name,
@@ -73,7 +74,7 @@ QUnit.test("grantableBadges", function (assert) {
   assert.deepEqual(badgeNames, sortedNames, "sorts badges by name");
 });
 
-QUnit.test("selectedBadgeGrantable", function (assert) {
+test("selectedBadgeGrantable", function (assert) {
   this.subject.set("selectedBadgeId", this.badgeDisabled.id);
   assert.not(this.subject.get("selectedBadgeGrantable"));
 

--- a/app/assets/javascripts/discourse/tests/unit/mixins/setting-object-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/mixins/setting-object-test.js
@@ -1,9 +1,10 @@
+import { test, module } from "qunit";
 import EmberObject from "@ember/object";
 import Setting from "admin/mixins/setting-object";
 
-QUnit.module("mixin:setting-object");
+module("mixin:setting-object");
 
-QUnit.test("flat array", (assert) => {
+test("flat array", (assert) => {
   const FooSetting = EmberObject.extend(Setting);
 
   const fooSettingInstance = FooSetting.create({
@@ -14,7 +15,7 @@ QUnit.test("flat array", (assert) => {
   assert.equal(fooSettingInstance.computedNameProperty, null);
 });
 
-QUnit.test("object", (assert) => {
+test("object", (assert) => {
   const FooSetting = EmberObject.extend(Setting);
 
   const fooSettingInstance = FooSetting.create({
@@ -25,7 +26,7 @@ QUnit.test("object", (assert) => {
   assert.equal(fooSettingInstance.computedNameProperty, "name");
 });
 
-QUnit.test("no values", (assert) => {
+test("no values", (assert) => {
   const FooSetting = EmberObject.extend(Setting);
 
   const fooSettingInstance = FooSetting.create({
@@ -36,7 +37,7 @@ QUnit.test("no values", (assert) => {
   assert.equal(fooSettingInstance.computedNameProperty, null);
 });
 
-QUnit.test("value/name properties defined", (assert) => {
+test("value/name properties defined", (assert) => {
   const FooSetting = EmberObject.extend(Setting);
 
   const fooSettingInstance = FooSetting.create({

--- a/app/assets/javascripts/discourse/tests/unit/mixins/singleton-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/mixins/singleton-test.js
@@ -1,9 +1,10 @@
+import { test, module } from "qunit";
 import EmberObject from "@ember/object";
 import Singleton from "discourse/mixins/singleton";
 
-QUnit.module("mixin:singleton");
+module("mixin:singleton");
 
-QUnit.test("current", (assert) => {
+test("current", (assert) => {
   var DummyModel = EmberObject.extend({});
   DummyModel.reopenClass(Singleton);
 
@@ -21,7 +22,7 @@ QUnit.test("current", (assert) => {
   );
 });
 
-QUnit.test("currentProp reading", (assert) => {
+test("currentProp reading", (assert) => {
   var DummyModel = EmberObject.extend({});
   DummyModel.reopenClass(Singleton);
   var current = DummyModel.current();
@@ -38,7 +39,7 @@ QUnit.test("currentProp reading", (assert) => {
   );
 });
 
-QUnit.test("currentProp writing", (assert) => {
+test("currentProp writing", (assert) => {
   var DummyModel = EmberObject.extend({});
   DummyModel.reopenClass(Singleton);
 
@@ -65,7 +66,7 @@ QUnit.test("currentProp writing", (assert) => {
   );
 });
 
-QUnit.test("createCurrent", (assert) => {
+test("createCurrent", (assert) => {
   var Shoe = EmberObject.extend({});
   Shoe.reopenClass(Singleton, {
     createCurrent: function () {
@@ -80,7 +81,7 @@ QUnit.test("createCurrent", (assert) => {
   );
 });
 
-QUnit.test("createCurrent that returns null", (assert) => {
+test("createCurrent that returns null", (assert) => {
   var Missing = EmberObject.extend({});
   Missing.reopenClass(Singleton, {
     createCurrent: function () {

--- a/app/assets/javascripts/discourse/tests/unit/models/badge-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/badge-test.js
@@ -1,15 +1,16 @@
+import { test, module } from "qunit";
 import Badge from "discourse/models/badge";
 
-QUnit.module("model:badge");
+module("model:badge");
 
-QUnit.test("newBadge", (assert) => {
+test("newBadge", (assert) => {
   const badge1 = Badge.create({ name: "New Badge" }),
     badge2 = Badge.create({ id: 1, name: "Old Badge" });
   assert.ok(badge1.get("newBadge"), "badges without ids are new");
   assert.ok(!badge2.get("newBadge"), "badges with ids are not new");
 });
 
-QUnit.test("createFromJson array", (assert) => {
+test("createFromJson array", (assert) => {
   const badgesJson = {
     badge_types: [{ id: 6, name: "Silver 1" }],
     badges: [
@@ -28,7 +29,7 @@ QUnit.test("createFromJson array", (assert) => {
   );
 });
 
-QUnit.test("createFromJson single", (assert) => {
+test("createFromJson single", (assert) => {
   const badgeJson = {
     badge_types: [{ id: 6, name: "Silver 1" }],
     badge: { id: 1126, name: "Badge 1", description: null, badge_type_id: 6 },
@@ -39,7 +40,7 @@ QUnit.test("createFromJson single", (assert) => {
   assert.ok(!Array.isArray(badge), "does not returns an array");
 });
 
-QUnit.test("updateFromJson", (assert) => {
+test("updateFromJson", (assert) => {
   const badgeJson = {
     badge_types: [{ id: 6, name: "Silver 1" }],
     badge: { id: 1126, name: "Badge 1", description: null, badge_type_id: 6 },
@@ -54,7 +55,7 @@ QUnit.test("updateFromJson", (assert) => {
   );
 });
 
-QUnit.test("save", (assert) => {
+test("save", (assert) => {
   assert.expect(0);
   const badge = Badge.create({
     name: "New Badge",
@@ -64,7 +65,7 @@ QUnit.test("save", (assert) => {
   return badge.save(["name", "description", "badge_type_id"]);
 });
 
-QUnit.test("destroy", (assert) => {
+test("destroy", (assert) => {
   assert.expect(0);
   const badge = Badge.create({
     name: "New Badge",

--- a/app/assets/javascripts/discourse/tests/unit/models/category-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/category-test.js
@@ -1,9 +1,10 @@
+import { test, module } from "qunit";
 import createStore from "discourse/tests/helpers/create-store";
 import Category from "discourse/models/category";
 
-QUnit.module("model:category");
+module("model:category");
 
-QUnit.test("slugFor", (assert) => {
+test("slugFor", (assert) => {
   const store = createStore();
 
   const slugFor = function (cat, val, text) {
@@ -58,7 +59,7 @@ QUnit.test("slugFor", (assert) => {
   );
 });
 
-QUnit.test("findBySlug", (assert) => {
+test("findBySlug", (assert) => {
   assert.expect(6);
 
   const store = createStore();
@@ -122,7 +123,7 @@ QUnit.test("findBySlug", (assert) => {
   sandbox.restore();
 });
 
-QUnit.test("findSingleBySlug", (assert) => {
+test("findSingleBySlug", (assert) => {
   assert.expect(6);
 
   const store = createStore();
@@ -184,7 +185,7 @@ QUnit.test("findSingleBySlug", (assert) => {
   );
 });
 
-QUnit.test("findBySlugPathWithID", (assert) => {
+test("findBySlugPathWithID", (assert) => {
   const store = createStore();
 
   const foo = store.createRecord("category", { id: 1, slug: "foo" });
@@ -208,7 +209,7 @@ QUnit.test("findBySlugPathWithID", (assert) => {
   assert.deepEqual(Category.findBySlugPathWithID("foo/baz/3"), baz);
 });
 
-QUnit.test("search with category name", (assert) => {
+test("search with category name", (assert) => {
   const store = createStore(),
     category1 = store.createRecord("category", {
       id: 1,
@@ -297,7 +298,7 @@ QUnit.test("search with category name", (assert) => {
   sandbox.restore();
 });
 
-QUnit.test("search with category slug", (assert) => {
+test("search with category slug", (assert) => {
   const store = createStore(),
     category1 = store.createRecord("category", {
       id: 1,

--- a/app/assets/javascripts/discourse/tests/unit/models/composer-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/composer-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import EmberObject from "@ember/object";
 import {
   discourseModule,
@@ -28,7 +29,7 @@ function openComposer(opts) {
   return composer;
 }
 
-QUnit.test("replyLength", (assert) => {
+test("replyLength", (assert) => {
   const replyLength = function (val, expectedLength) {
     const composer = createComposer({ reply: val });
     assert.equal(composer.get("replyLength"), expectedLength);
@@ -49,7 +50,7 @@ QUnit.test("replyLength", (assert) => {
   );
 });
 
-QUnit.test("missingReplyCharacters", function (assert) {
+test("missingReplyCharacters", function (assert) {
   this.siteSettings.min_first_post_length = 40;
   const missingReplyCharacters = function (
     val,
@@ -109,7 +110,7 @@ QUnit.test("missingReplyCharacters", function (assert) {
   );
 });
 
-QUnit.test("missingTitleCharacters", function (assert) {
+test("missingTitleCharacters", function (assert) {
   const missingTitleCharacters = function (val, isPM, expected, message) {
     const composer = createComposer({
       title: val,
@@ -132,7 +133,7 @@ QUnit.test("missingTitleCharacters", function (assert) {
   );
 });
 
-QUnit.test("replyDirty", (assert) => {
+test("replyDirty", (assert) => {
   const composer = createComposer();
   assert.ok(!composer.get("replyDirty"), "by default it's false");
 
@@ -149,7 +150,7 @@ QUnit.test("replyDirty", (assert) => {
   assert.ok(composer.get("replyDirty"), "it's true when the reply changes");
 });
 
-QUnit.test("appendText", (assert) => {
+test("appendText", (assert) => {
   const composer = createComposer();
 
   assert.blank(composer.get("reply"), "the reply is blank by default");
@@ -182,7 +183,7 @@ QUnit.test("appendText", (assert) => {
   assert.equal(composer.get("reply"), "c\n\nab");
 });
 
-QUnit.test("prependText", (assert) => {
+test("prependText", (assert) => {
   const composer = createComposer();
 
   assert.blank(composer.get("reply"), "the reply is blank by default");
@@ -205,7 +206,7 @@ QUnit.test("prependText", (assert) => {
   );
 });
 
-QUnit.test("Title length for regular topics", function (assert) {
+test("Title length for regular topics", function (assert) {
   this.siteSettings.min_topic_title_length = 5;
   this.siteSettings.max_topic_title_length = 10;
   const composer = createComposer();
@@ -220,7 +221,7 @@ QUnit.test("Title length for regular topics", function (assert) {
   assert.ok(composer.get("titleLengthValid"), "in the range is okay");
 });
 
-QUnit.test("Title length for private messages", function (assert) {
+test("Title length for private messages", function (assert) {
   this.siteSettings.min_personal_message_title_length = 5;
   this.siteSettings.max_topic_title_length = 10;
   const composer = createComposer({ action: PRIVATE_MESSAGE });
@@ -235,18 +236,15 @@ QUnit.test("Title length for private messages", function (assert) {
   assert.ok(composer.get("titleLengthValid"), "in the range is okay");
 });
 
-QUnit.test(
-  "Post length for private messages with non human users",
-  (assert) => {
-    const composer = createComposer({
-      topic: EmberObject.create({ pm_with_non_human_user: true }),
-    });
+test("Post length for private messages with non human users", (assert) => {
+  const composer = createComposer({
+    topic: EmberObject.create({ pm_with_non_human_user: true }),
+  });
 
-    assert.equal(composer.get("minimumPostLength"), 1);
-  }
-);
+  assert.equal(composer.get("minimumPostLength"), 1);
+});
 
-QUnit.test("editingFirstPost", (assert) => {
+test("editingFirstPost", (assert) => {
   const composer = createComposer();
   assert.ok(!composer.get("editingFirstPost"), "it's false by default");
 
@@ -264,7 +262,7 @@ QUnit.test("editingFirstPost", (assert) => {
   );
 });
 
-QUnit.test("clearState", (assert) => {
+test("clearState", (assert) => {
   const composer = createComposer({
     originalText: "asdf",
     reply: "asdf2",
@@ -280,7 +278,7 @@ QUnit.test("clearState", (assert) => {
   assert.blank(composer.get("title"));
 });
 
-QUnit.test("initial category when uncategorized is allowed", function (assert) {
+test("initial category when uncategorized is allowed", function (assert) {
   this.siteSettings.allow_uncategorized_topics = true;
   const composer = openComposer({
     action: CREATE_TOPIC,
@@ -290,9 +288,7 @@ QUnit.test("initial category when uncategorized is allowed", function (assert) {
   assert.ok(!composer.get("categoryId"), "Uncategorized by default");
 });
 
-QUnit.test("initial category when uncategorized is not allowed", function (
-  assert
-) {
+test("initial category when uncategorized is not allowed", function (assert) {
   this.siteSettings.allow_uncategorized_topics = false;
   const composer = openComposer({
     action: CREATE_TOPIC,
@@ -305,7 +301,7 @@ QUnit.test("initial category when uncategorized is not allowed", function (
   );
 });
 
-QUnit.test("open with a quote", (assert) => {
+test("open with a quote", (assert) => {
   const quote =
     '[quote="neil, post:5, topic:413"]\nSimmer down you two.\n[/quote]';
   const newComposer = function () {
@@ -329,7 +325,7 @@ QUnit.test("open with a quote", (assert) => {
   );
 });
 
-QUnit.test("Title length for static page topics as admin", function (assert) {
+test("Title length for static page topics as admin", function (assert) {
   this.siteSettings.min_topic_title_length = 5;
   this.siteSettings.max_topic_title_length = 10;
   const composer = createComposer();
@@ -357,7 +353,7 @@ QUnit.test("Title length for static page topics as admin", function (assert) {
   );
 });
 
-QUnit.test("title placeholder depends on what you're doing", function (assert) {
+test("title placeholder depends on what you're doing", function (assert) {
   let composer = createComposer({ action: CREATE_TOPIC });
   assert.equal(
     composer.get("titlePlaceholder"),
@@ -389,9 +385,7 @@ QUnit.test("title placeholder depends on what you're doing", function (assert) {
   );
 });
 
-QUnit.test("allows featured link before choosing a category", function (
-  assert
-) {
+test("allows featured link before choosing a category", function (assert) {
   this.siteSettings.topic_featured_link_enabled = true;
   this.siteSettings.allow_uncategorized_topics = false;
   let composer = createComposer({ action: CREATE_TOPIC });
@@ -403,7 +397,7 @@ QUnit.test("allows featured link before choosing a category", function (
   assert.ok(composer.get("canEditTopicFeaturedLink"), "can paste link");
 });
 
-QUnit.test("targetRecipientsArray contains types", (assert) => {
+test("targetRecipientsArray contains types", (assert) => {
   let composer = createComposer({
     targetRecipients: "test,codinghorror,staff,foo@bar.com",
   });

--- a/app/assets/javascripts/discourse/tests/unit/models/email-log-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/email-log-test.js
@@ -1,13 +1,14 @@
+import { test, module } from "qunit";
 import EmailLog from "admin/models/email-log";
 import { setPrefix } from "discourse-common/lib/get-url";
 
-QUnit.module("model:email-log");
+module("model:email-log");
 
-QUnit.test("create", (assert) => {
+test("create", (assert) => {
   assert.ok(EmailLog.create(), "it can be created without arguments");
 });
 
-QUnit.test("subfolder support", (assert) => {
+test("subfolder support", (assert) => {
   setPrefix("/forum");
   const attrs = {
     id: 60,

--- a/app/assets/javascripts/discourse/tests/unit/models/group-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/group-test.js
@@ -1,8 +1,9 @@
+import { test, module } from "qunit";
 import Group from "discourse/models/group";
 
-QUnit.module("model:group");
+module("model:group");
 
-QUnit.test("displayName", (assert) => {
+test("displayName", (assert) => {
   const group = Group.create({ name: "test", display_name: "donkey" });
 
   assert.equal(

--- a/app/assets/javascripts/discourse/tests/unit/models/invite-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/invite-test.js
@@ -1,7 +1,8 @@
+import { test, module } from "qunit";
 import Invite from "discourse/models/invite";
 
-QUnit.module("model:invite");
+module("model:invite");
 
-QUnit.test("create", (assert) => {
+test("create", (assert) => {
   assert.ok(Invite.create(), "it can be created without arguments");
 });

--- a/app/assets/javascripts/discourse/tests/unit/models/nav-item-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/nav-item-test.js
@@ -1,10 +1,11 @@
+import { test, module } from "qunit";
 import { run } from "@ember/runloop";
 import createStore from "discourse/tests/helpers/create-store";
 import NavItem from "discourse/models/nav-item";
 import Category from "discourse/models/category";
 import Site from "discourse/models/site";
 
-QUnit.module("NavItem", {
+module("NavItem", {
   beforeEach() {
     run(function () {
       const asianCategory = Category.create({
@@ -16,7 +17,7 @@ QUnit.module("NavItem", {
   },
 });
 
-QUnit.test("href", (assert) => {
+test("href", (assert) => {
   assert.expect(2);
 
   function href(text, expected, label) {
@@ -27,7 +28,7 @@ QUnit.test("href", (assert) => {
   href("categories", "/categories", "categories");
 });
 
-QUnit.test("count", (assert) => {
+test("count", (assert) => {
   const navItem = createStore().createRecord("nav-item", { name: "new" });
 
   assert.equal(navItem.get("count"), 0, "it has no count by default");

--- a/app/assets/javascripts/discourse/tests/unit/models/post-stream-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/post-stream-test.js
@@ -1,3 +1,4 @@
+import { test, module } from "qunit";
 import ArrayProxy from "@ember/array/proxy";
 import Post from "discourse/models/post";
 import createStore from "discourse/tests/helpers/create-store";
@@ -5,7 +6,7 @@ import User from "discourse/models/user";
 import { Promise } from "rsvp";
 import pretender from "discourse/tests/helpers/create-pretender";
 
-QUnit.module("model:post-stream");
+module("model:post-stream");
 
 const buildStream = function (id, stream) {
   const store = createStore();
@@ -19,7 +20,7 @@ const buildStream = function (id, stream) {
 
 const participant = { username: "eviltrout" };
 
-QUnit.test("create", (assert) => {
+test("create", (assert) => {
   const store = createStore();
   assert.ok(
     store.createRecord("postStream"),
@@ -27,7 +28,7 @@ QUnit.test("create", (assert) => {
   );
 });
 
-QUnit.test("defaults", (assert) => {
+test("defaults", (assert) => {
   const postStream = buildStream(1234);
   assert.blank(
     postStream.get("posts"),
@@ -37,7 +38,7 @@ QUnit.test("defaults", (assert) => {
   assert.present(postStream.get("topic"));
 });
 
-QUnit.test("appending posts", (assert) => {
+test("appending posts", (assert) => {
   const postStream = buildStream(4567, [1, 3, 4]);
   const store = postStream.store;
 
@@ -108,7 +109,7 @@ QUnit.test("appending posts", (assert) => {
   );
 });
 
-QUnit.test("closestPostNumberFor", (assert) => {
+test("closestPostNumberFor", (assert) => {
   const postStream = buildStream(1231);
   const store = postStream.store;
 
@@ -142,7 +143,7 @@ QUnit.test("closestPostNumberFor", (assert) => {
   );
 });
 
-QUnit.test("closestDaysAgoFor", (assert) => {
+test("closestDaysAgoFor", (assert) => {
   const postStream = buildStream(1231);
   postStream.set("timelineLookup", [
     [1, 10],
@@ -165,14 +166,14 @@ QUnit.test("closestDaysAgoFor", (assert) => {
   assert.equal(postStream.closestDaysAgoFor(1), undefined);
 });
 
-QUnit.test("closestDaysAgoFor - empty", (assert) => {
+test("closestDaysAgoFor - empty", (assert) => {
   const postStream = buildStream(1231);
   postStream.set("timelineLookup", []);
 
   assert.equal(postStream.closestDaysAgoFor(1), null);
 });
 
-QUnit.test("updateFromJson", (assert) => {
+test("updateFromJson", (assert) => {
   const postStream = buildStream(1231);
 
   postStream.updateFromJson({
@@ -187,7 +188,7 @@ QUnit.test("updateFromJson", (assert) => {
   assert.equal(postStream.get("extra_property"), 12);
 });
 
-QUnit.test("removePosts", (assert) => {
+test("removePosts", (assert) => {
   const postStream = buildStream(10000001, [1, 2, 3]);
   const store = postStream.store;
 
@@ -208,7 +209,7 @@ QUnit.test("removePosts", (assert) => {
   assert.deepEqual(postStream.get("stream"), [2]);
 });
 
-QUnit.test("cancelFilter", (assert) => {
+test("cancelFilter", (assert) => {
   const postStream = buildStream(1235);
 
   sandbox.stub(postStream, "refresh").returns(Promise.resolve());
@@ -225,7 +226,7 @@ QUnit.test("cancelFilter", (assert) => {
   );
 });
 
-QUnit.test("findPostIdForPostNumber", (assert) => {
+test("findPostIdForPostNumber", (assert) => {
   const postStream = buildStream(1234, [10, 20, 30, 40, 50, 60, 70]);
   postStream.set("gaps", { before: { 60: [55, 58] } });
 
@@ -247,7 +248,7 @@ QUnit.test("findPostIdForPostNumber", (assert) => {
   assert.equal(postStream.findPostIdForPostNumber(8), 60, "it respects gaps");
 });
 
-QUnit.test("fillGapBefore", (assert) => {
+test("fillGapBefore", (assert) => {
   const postStream = buildStream(1234, [60]);
   sandbox.stub(postStream, "findPostsByIds").returns(Promise.resolve([]));
   let post = postStream.store.createRecord("post", { id: 60, post_number: 60 });
@@ -264,7 +265,7 @@ QUnit.test("fillGapBefore", (assert) => {
   );
 });
 
-QUnit.test("toggleParticipant", (assert) => {
+test("toggleParticipant", (assert) => {
   const postStream = buildStream(1236);
   sandbox.stub(postStream, "refresh").returns(Promise.resolve());
 
@@ -287,7 +288,7 @@ QUnit.test("toggleParticipant", (assert) => {
   );
 });
 
-QUnit.test("streamFilters", (assert) => {
+test("streamFilters", (assert) => {
   const postStream = buildStream(1237);
   sandbox.stub(postStream, "refresh").returns(Promise.resolve());
 
@@ -316,7 +317,7 @@ QUnit.test("streamFilters", (assert) => {
   );
 });
 
-QUnit.test("loading", (assert) => {
+test("loading", (assert) => {
   let postStream = buildStream(1234);
   assert.ok(!postStream.get("loading"), "we're not loading by default");
 
@@ -332,7 +333,7 @@ QUnit.test("loading", (assert) => {
   assert.ok(postStream.get("loading"), "we're loading if loading a filter");
 });
 
-QUnit.test("nextWindow", (assert) => {
+test("nextWindow", (assert) => {
   const postStream = buildStream(1234, [
     1,
     2,
@@ -374,7 +375,7 @@ QUnit.test("nextWindow", (assert) => {
   );
 });
 
-QUnit.test("previousWindow", (assert) => {
+test("previousWindow", (assert) => {
   const postStream = buildStream(1234, [
     1,
     2,
@@ -416,7 +417,7 @@ QUnit.test("previousWindow", (assert) => {
   );
 });
 
-QUnit.test("storePost", (assert) => {
+test("storePost", (assert) => {
   const postStream = buildStream(1234),
     store = postStream.store,
     post = store.createRecord("post", {
@@ -464,7 +465,7 @@ QUnit.test("storePost", (assert) => {
   assert.equal(stored, postWithoutId, "it returns the same post back");
 });
 
-QUnit.test("identity map", async (assert) => {
+test("identity map", async (assert) => {
   const postStream = buildStream(1234);
   const store = postStream.store;
 
@@ -490,12 +491,12 @@ QUnit.test("identity map", async (assert) => {
   assert.equal(result.objectAt(2), p3);
 });
 
-QUnit.test("loadIntoIdentityMap with no data", async (assert) => {
+test("loadIntoIdentityMap with no data", async (assert) => {
   const result = await buildStream(1234).loadIntoIdentityMap([]);
   assert.equal(result.length, 0, "requesting no posts produces no posts");
 });
 
-QUnit.test("loadIntoIdentityMap with post ids", async (assert) => {
+test("loadIntoIdentityMap with post ids", async (assert) => {
   const postStream = buildStream(1234);
   await postStream.loadIntoIdentityMap([10]);
 
@@ -505,7 +506,7 @@ QUnit.test("loadIntoIdentityMap with post ids", async (assert) => {
   );
 });
 
-QUnit.test("appendMore for megatopic", async (assert) => {
+test("appendMore for megatopic", async (assert) => {
   const postStream = buildStream(1234);
   const store = createStore();
   const post = store.createRecord("post", { id: 1, post_number: 1 });
@@ -528,7 +529,7 @@ QUnit.test("appendMore for megatopic", async (assert) => {
   );
 });
 
-QUnit.test("prependMore for megatopic", async (assert) => {
+test("prependMore for megatopic", async (assert) => {
   const postStream = buildStream(1234);
   const store = createStore();
   const post = store.createRecord("post", { id: 6, post_number: 6 });
@@ -551,7 +552,7 @@ QUnit.test("prependMore for megatopic", async (assert) => {
   );
 });
 
-QUnit.test("staging and undoing a new post", (assert) => {
+test("staging and undoing a new post", (assert) => {
   const postStream = buildStream(10101, [1]);
   const store = postStream.store;
 
@@ -652,7 +653,7 @@ QUnit.test("staging and undoing a new post", (assert) => {
   );
 });
 
-QUnit.test("staging and committing a post", (assert) => {
+test("staging and committing a post", (assert) => {
   const postStream = buildStream(10101, [1]);
   const store = postStream.store;
 
@@ -731,7 +732,7 @@ QUnit.test("staging and committing a post", (assert) => {
   );
 });
 
-QUnit.test("loadedAllPosts when the id changes", (assert) => {
+test("loadedAllPosts when the id changes", (assert) => {
   // This can happen in a race condition between staging a post and it coming through on the
   // message bus. If the id of a post changes we should reconsider the loadedAllPosts property.
   const postStream = buildStream(10101, [1, 2]);
@@ -751,7 +752,7 @@ QUnit.test("loadedAllPosts when the id changes", (assert) => {
   );
 });
 
-QUnit.test("triggerRecoveredPost", async (assert) => {
+test("triggerRecoveredPost", async (assert) => {
   const postStream = buildStream(4567);
   const store = postStream.store;
 
@@ -784,7 +785,7 @@ QUnit.test("triggerRecoveredPost", async (assert) => {
   );
 });
 
-QUnit.test("comitting and triggerNewPostInStream race condition", (assert) => {
+test("comitting and triggerNewPostInStream race condition", (assert) => {
   const postStream = buildStream(4964);
   const store = postStream.store;
 
@@ -818,7 +819,7 @@ QUnit.test("comitting and triggerNewPostInStream race condition", (assert) => {
   );
 });
 
-QUnit.test("triggerNewPostInStream for ignored posts", async (assert) => {
+test("triggerNewPostInStream for ignored posts", async (assert) => {
   const postStream = buildStream(280, [1]);
   const store = postStream.store;
   User.resetCurrent(
@@ -876,7 +877,7 @@ QUnit.test("triggerNewPostInStream for ignored posts", async (assert) => {
   );
 });
 
-QUnit.test("postsWithPlaceholders", async (assert) => {
+test("postsWithPlaceholders", async (assert) => {
   const postStream = buildStream(4964, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
   const postsWithPlaceholders = postStream.get("postsWithPlaceholders");
   const store = postStream.store;
@@ -925,7 +926,7 @@ QUnit.test("postsWithPlaceholders", async (assert) => {
   assert.equal(testProxy.objectAt(3), p4);
 });
 
-QUnit.test("filteredPostsCount", (assert) => {
+test("filteredPostsCount", (assert) => {
   const postStream = buildStream(4567, [1, 3, 4]);
 
   assert.equal(postStream.get("filteredPostsCount"), 3);
@@ -937,7 +938,7 @@ QUnit.test("filteredPostsCount", (assert) => {
   assert.equal(postStream.get("filteredPostsCount"), 4);
 });
 
-QUnit.test("firstPostId", (assert) => {
+test("firstPostId", (assert) => {
   const postStream = buildStream(4567, [1, 3, 4]);
 
   assert.equal(postStream.get("firstPostId"), 1);
@@ -950,7 +951,7 @@ QUnit.test("firstPostId", (assert) => {
   assert.equal(postStream.get("firstPostId"), 2);
 });
 
-QUnit.test("lastPostId", (assert) => {
+test("lastPostId", (assert) => {
   const postStream = buildStream(4567, [1, 3, 4]);
 
   assert.equal(postStream.get("lastPostId"), 4);
@@ -963,7 +964,7 @@ QUnit.test("lastPostId", (assert) => {
   assert.equal(postStream.get("lastPostId"), 2);
 });
 
-QUnit.test("progressIndexOfPostId", (assert) => {
+test("progressIndexOfPostId", (assert) => {
   const postStream = buildStream(4567, [1, 3, 4]);
   const store = createStore();
   const post = store.createRecord("post", { id: 1, post_number: 5 });

--- a/app/assets/javascripts/discourse/tests/unit/models/post-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/post-test.js
@@ -1,8 +1,9 @@
+import { test, module } from "qunit";
 import Post from "discourse/models/post";
 import User from "discourse/models/user";
 import { deepMerge } from "discourse-common/lib/object";
 
-QUnit.module("model: Post");
+module("model: Post");
 
 var buildPost = function (args) {
   return Post.create(
@@ -17,13 +18,13 @@ var buildPost = function (args) {
   );
 };
 
-QUnit.test("defaults", (assert) => {
+test("defaults", (assert) => {
   var post = Post.create({ id: 1 });
   assert.blank(post.get("deleted_at"), "it has no deleted_at by default");
   assert.blank(post.get("deleted_by"), "there is no deleted_by by default");
 });
 
-QUnit.test("new_user", (assert) => {
+test("new_user", (assert) => {
   var post = Post.create({ trust_level: 0 });
   assert.ok(post.get("new_user"), "post is from a new user");
 
@@ -31,7 +32,7 @@ QUnit.test("new_user", (assert) => {
   assert.ok(!post.get("new_user"), "post is no longer from a new user");
 });
 
-QUnit.test("firstPost", (assert) => {
+test("firstPost", (assert) => {
   var post = Post.create({ post_number: 1 });
   assert.ok(post.get("firstPost"), "it's the first post");
 
@@ -39,7 +40,7 @@ QUnit.test("firstPost", (assert) => {
   assert.ok(!post.get("firstPost"), "post is no longer the first post");
 });
 
-QUnit.test("updateFromPost", (assert) => {
+test("updateFromPost", (assert) => {
   var post = Post.create({
     post_number: 1,
     raw: "hello world",
@@ -57,7 +58,7 @@ QUnit.test("updateFromPost", (assert) => {
   assert.equal(post.get("raw"), "different raw", "raw field updated");
 });
 
-QUnit.test("destroy by staff", async (assert) => {
+test("destroy by staff", async (assert) => {
   let user = User.create({ username: "staff", moderator: true });
   let post = buildPost({ user: user });
 
@@ -82,7 +83,7 @@ QUnit.test("destroy by staff", async (assert) => {
   );
 });
 
-QUnit.test("destroy by non-staff", async (assert) => {
+test("destroy by non-staff", async (assert) => {
   const originalCooked = "this is the original cooked value";
   const user = User.create({ username: "evil trout" });
   const post = buildPost({ user: user, cooked: originalCooked });

--- a/app/assets/javascripts/discourse/tests/unit/models/report-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/report-test.js
@@ -1,7 +1,8 @@
+import { test, module } from "qunit";
 import Report from "admin/models/report";
 import { setPrefix } from "discourse-common/lib/get-url";
 
-QUnit.module("Report");
+module("Report");
 
 function reportWithData(data) {
   return Report.create({
@@ -15,7 +16,7 @@ function reportWithData(data) {
   });
 }
 
-QUnit.test("counts", (assert) => {
+test("counts", (assert) => {
   const report = reportWithData([5, 4, 3, 2, 1, 100, 99, 98, 1000]);
 
   assert.equal(report.get("todayCount"), 5);
@@ -39,7 +40,7 @@ QUnit.test("counts", (assert) => {
   );
 });
 
-QUnit.test("percentChangeString", (assert) => {
+test("percentChangeString", (assert) => {
   const report = reportWithData([]);
 
   assert.equal(report.percentChangeString(5, 8), "+60%", "value increased");
@@ -56,19 +57,19 @@ QUnit.test("percentChangeString", (assert) => {
   );
 });
 
-QUnit.test("yesterdayCountTitle with valid values", (assert) => {
+test("yesterdayCountTitle with valid values", (assert) => {
   const title = reportWithData([6, 8, 5, 2, 1]).get("yesterdayCountTitle");
   assert.ok(title.indexOf("+60%") !== -1);
   assert.ok(title.match(/Was 5/));
 });
 
-QUnit.test("yesterdayCountTitle when two days ago was 0", (assert) => {
+test("yesterdayCountTitle when two days ago was 0", (assert) => {
   const title = reportWithData([6, 8, 0, 2, 1]).get("yesterdayCountTitle");
   assert.equal(title.indexOf("%"), -1);
   assert.ok(title.match(/Was 0/));
 });
 
-QUnit.test("sevenDaysCountTitle", (assert) => {
+test("sevenDaysCountTitle", (assert) => {
   const title = reportWithData([
     100,
     1,
@@ -92,7 +93,7 @@ QUnit.test("sevenDaysCountTitle", (assert) => {
   assert.ok(title.match(/Was 14/));
 });
 
-QUnit.test("thirtyDaysCountTitle", (assert) => {
+test("thirtyDaysCountTitle", (assert) => {
   const report = reportWithData([5, 5, 5, 5]);
   report.set("prev30Days", 10);
   const title = report.get("thirtyDaysCountTitle");
@@ -101,7 +102,7 @@ QUnit.test("thirtyDaysCountTitle", (assert) => {
   assert.ok(title.match(/Was 10/));
 });
 
-QUnit.test("sevenDaysTrend", (assert) => {
+test("sevenDaysTrend", (assert) => {
   let report;
   let trend;
 
@@ -126,7 +127,7 @@ QUnit.test("sevenDaysTrend", (assert) => {
   assert.ok(trend === "trending-down");
 });
 
-QUnit.test("yesterdayTrend", (assert) => {
+test("yesterdayTrend", (assert) => {
   let report;
   let trend;
 
@@ -151,7 +152,7 @@ QUnit.test("yesterdayTrend", (assert) => {
   assert.ok(trend === "trending-down");
 });
 
-QUnit.test("thirtyDaysTrend", (assert) => {
+test("thirtyDaysTrend", (assert) => {
   let report;
   let trend;
 
@@ -341,7 +342,7 @@ QUnit.test("thirtyDaysTrend", (assert) => {
   assert.ok(trend === "trending-down");
 });
 
-QUnit.test("higher is better false", (assert) => {
+test("higher is better false", (assert) => {
   let report;
   let trend;
 
@@ -366,7 +367,7 @@ QUnit.test("higher is better false", (assert) => {
   assert.ok(trend === "trending-up");
 });
 
-QUnit.test("small variation (-2/+2% change) is no-change", (assert) => {
+test("small variation (-2/+2% change) is no-change", (assert) => {
   let report;
   let trend;
 
@@ -379,7 +380,7 @@ QUnit.test("small variation (-2/+2% change) is no-change", (assert) => {
   assert.ok(trend === "no-change");
 });
 
-QUnit.test("average", (assert) => {
+test("average", (assert) => {
   let report;
 
   report = reportWithData([5, 5, 5, 5, 5, 5, 5, 5]);
@@ -391,7 +392,7 @@ QUnit.test("average", (assert) => {
   assert.ok(report.get("lastSevenDaysCount") === 35);
 });
 
-QUnit.test("computed labels", (assert) => {
+test("computed labels", (assert) => {
   const data = [
     {
       username: "joffrey",

--- a/app/assets/javascripts/discourse/tests/unit/models/rest-model-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/rest-model-test.js
@@ -1,10 +1,11 @@
-QUnit.module("rest-model");
+import { test, module } from "qunit";
+module("rest-model");
 
 import createStore from "discourse/tests/helpers/create-store";
 import RestModel from "discourse/models/rest";
 import RestAdapter from "discourse/adapters/rest";
 
-QUnit.test("munging", (assert) => {
+test("munging", (assert) => {
   const store = createStore();
   const Grape = RestModel.extend();
   Grape.reopenClass({
@@ -18,7 +19,7 @@ QUnit.test("munging", (assert) => {
   assert.equal(g.get("inverse"), 0.6, "it runs `munge` on `create`");
 });
 
-QUnit.test("update", async (assert) => {
+test("update", async (assert) => {
   const store = createStore();
   const widget = await store.find("widget", 123);
   assert.equal(widget.get("name"), "Trout Lure");
@@ -39,7 +40,7 @@ QUnit.test("update", async (assert) => {
   assert.equal(result.target.name, widget.get("name"));
 });
 
-QUnit.test("updating simultaneously", async (assert) => {
+test("updating simultaneously", async (assert) => {
   assert.expect(2);
 
   const store = createStore();
@@ -57,7 +58,7 @@ QUnit.test("updating simultaneously", async (assert) => {
   });
 });
 
-QUnit.test("save new", async (assert) => {
+test("save new", async (assert) => {
   const store = createStore();
   const widget = store.createRecord("widget");
 
@@ -83,7 +84,7 @@ QUnit.test("save new", async (assert) => {
   assert.equal(result.target.name, widget.get("name"));
 });
 
-QUnit.test("creating simultaneously", (assert) => {
+test("creating simultaneously", (assert) => {
   assert.expect(2);
 
   const store = createStore();
@@ -100,14 +101,14 @@ QUnit.test("creating simultaneously", (assert) => {
   });
 });
 
-QUnit.test("destroyRecord", async (assert) => {
+test("destroyRecord", async (assert) => {
   const store = createStore();
   const widget = await store.find("widget", 123);
 
   assert.ok(await widget.destroyRecord());
 });
 
-QUnit.test("custom api name", async (assert) => {
+test("custom api name", async (assert) => {
   const store = createStore((type) => {
     if (type === "adapter:my-widget") {
       return RestAdapter.extend({

--- a/app/assets/javascripts/discourse/tests/unit/models/result-set-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/result-set-test.js
@@ -1,9 +1,10 @@
-QUnit.module("result-set");
+import { test, module } from "qunit";
+module("result-set");
 
 import ResultSet from "discourse/models/result-set";
 import createStore from "discourse/tests/helpers/create-store";
 
-QUnit.test("defaults", (assert) => {
+test("defaults", (assert) => {
   const resultSet = ResultSet.create({ content: [] });
   assert.equal(resultSet.get("length"), 0);
   assert.equal(resultSet.get("totalRows"), 0);
@@ -13,7 +14,7 @@ QUnit.test("defaults", (assert) => {
   assert.ok(!resultSet.get("refreshing"));
 });
 
-QUnit.test("pagination support", async (assert) => {
+test("pagination support", async (assert) => {
   const store = createStore();
   const resultSet = await store.findAll("widget");
   assert.equal(resultSet.get("length"), 2);
@@ -32,7 +33,7 @@ QUnit.test("pagination support", async (assert) => {
   assert.ok(!resultSet.get("canLoadMore"));
 });
 
-QUnit.test("refresh support", async (assert) => {
+test("refresh support", async (assert) => {
   const store = createStore();
   const resultSet = await store.findAll("widget");
   assert.equal(

--- a/app/assets/javascripts/discourse/tests/unit/models/session-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/session-test.js
@@ -1,8 +1,9 @@
+import { test, module } from "qunit";
 import Session from "discourse/models/session";
 
-QUnit.module("model:session");
+module("model:session");
 
-QUnit.test("highestSeenByTopic", (assert) => {
+test("highestSeenByTopic", (assert) => {
   const session = Session.current();
   assert.deepEqual(
     session.get("highestSeenByTopic"),

--- a/app/assets/javascripts/discourse/tests/unit/models/site-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/site-test.js
@@ -1,13 +1,14 @@
+import { test, module } from "qunit";
 import createStore from "discourse/tests/helpers/create-store";
 import Site from "discourse/models/site";
 
-QUnit.module("model:site");
+module("model:site");
 
-QUnit.test("create", (assert) => {
+test("create", (assert) => {
   assert.ok(Site.create(), "it can create with no parameters");
 });
 
-QUnit.test("instance", (assert) => {
+test("instance", (assert) => {
   const site = Site.current();
 
   assert.present(site, "We have a current site singleton");
@@ -25,7 +26,7 @@ QUnit.test("instance", (assert) => {
   );
 });
 
-QUnit.test("create categories", (assert) => {
+test("create categories", (assert) => {
   const store = createStore();
   const site = store.createRecord("site", {
     categories: [

--- a/app/assets/javascripts/discourse/tests/unit/models/staff-action-log-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/staff-action-log-test.js
@@ -1,7 +1,8 @@
+import { test, module } from "qunit";
 import StaffActionLog from "admin/models/staff-action-log";
 
-QUnit.module("StaffActionLog");
+module("StaffActionLog");
 
-QUnit.test("create", (assert) => {
+test("create", (assert) => {
   assert.ok(StaffActionLog.create(), "it can be created without arguments");
 });

--- a/app/assets/javascripts/discourse/tests/unit/models/store-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/store-test.js
@@ -1,8 +1,9 @@
-QUnit.module("service:store");
+import { test, module } from "qunit";
+module("service:store");
 
 import createStore from "discourse/tests/helpers/create-store";
 
-QUnit.test("createRecord", (assert) => {
+test("createRecord", (assert) => {
   const store = createStore();
   const widget = store.createRecord("widget", { id: 111, name: "hello" });
 
@@ -11,7 +12,7 @@ QUnit.test("createRecord", (assert) => {
   assert.equal(widget.get("id"), 111);
 });
 
-QUnit.test("createRecord without an `id`", (assert) => {
+test("createRecord without an `id`", (assert) => {
   const store = createStore();
   const widget = store.createRecord("widget", { name: "hello" });
 
@@ -19,7 +20,7 @@ QUnit.test("createRecord without an `id`", (assert) => {
   assert.ok(!widget.get("id"), "there is no id");
 });
 
-QUnit.test("createRecord doesn't modify the input `id` field", (assert) => {
+test("createRecord doesn't modify the input `id` field", (assert) => {
   const store = createStore();
   const widget = store.createRecord("widget", { id: 1, name: "hello" });
 
@@ -31,7 +32,7 @@ QUnit.test("createRecord doesn't modify the input `id` field", (assert) => {
   assert.equal(obj.id, 1, "it does not remove the id from the input");
 });
 
-QUnit.test("createRecord without attributes", (assert) => {
+test("createRecord without attributes", (assert) => {
   const store = createStore();
   const widget = store.createRecord("widget");
 
@@ -39,18 +40,15 @@ QUnit.test("createRecord without attributes", (assert) => {
   assert.ok(widget.get("isNew"), "it is a new record");
 });
 
-QUnit.test(
-  "createRecord with a record as attributes returns that record from the map",
-  (assert) => {
-    const store = createStore();
-    const widget = store.createRecord("widget", { id: 33 });
-    const secondWidget = store.createRecord("widget", { id: 33 });
+test("createRecord with a record as attributes returns that record from the map", (assert) => {
+  const store = createStore();
+  const widget = store.createRecord("widget", { id: 33 });
+  const secondWidget = store.createRecord("widget", { id: 33 });
 
-    assert.equal(widget, secondWidget, "they should be the same");
-  }
-);
+  assert.equal(widget, secondWidget, "they should be the same");
+});
 
-QUnit.test("find", async (assert) => {
+test("find", async (assert) => {
   const store = createStore();
 
   const widget = await store.find("widget", 123);
@@ -65,19 +63,19 @@ QUnit.test("find", async (assert) => {
   assert.equal(widget.get("extras.hello"), "world", "extra attributes are set");
 });
 
-QUnit.test("find with object id", async (assert) => {
+test("find with object id", async (assert) => {
   const store = createStore();
   const widget = await store.find("widget", { id: 123 });
   assert.equal(widget.get("firstObject.name"), "Trout Lure");
 });
 
-QUnit.test("find with query param", async (assert) => {
+test("find with query param", async (assert) => {
   const store = createStore();
   const widget = await store.find("widget", { name: "Trout Lure" });
   assert.equal(widget.get("firstObject.id"), 123);
 });
 
-QUnit.test("findStale with no stale results", async (assert) => {
+test("findStale with no stale results", async (assert) => {
   const store = createStore();
   const stale = store.findStale("widget", { name: "Trout Lure" });
 
@@ -91,20 +89,20 @@ QUnit.test("findStale with no stale results", async (assert) => {
   );
 });
 
-QUnit.test("update", async (assert) => {
+test("update", async (assert) => {
   const store = createStore();
   const result = await store.update("widget", 123, { name: "hello" });
   assert.ok(result);
 });
 
-QUnit.test("update with a multi world name", async (assert) => {
+test("update with a multi world name", async (assert) => {
   const store = createStore();
   const result = await store.update("cool-thing", 123, { name: "hello" });
   assert.ok(result);
   assert.equal(result.payload.name, "hello");
 });
 
-QUnit.test("findAll", async (assert) => {
+test("findAll", async (assert) => {
   const store = createStore();
   const result = await store.findAll("widget");
   assert.equal(result.get("length"), 2);
@@ -114,21 +112,21 @@ QUnit.test("findAll", async (assert) => {
   assert.equal(widget.get("name"), "Evil Repellant");
 });
 
-QUnit.test("destroyRecord", async (assert) => {
+test("destroyRecord", async (assert) => {
   const store = createStore();
   const widget = await store.find("widget", 123);
 
   assert.ok(await store.destroyRecord("widget", widget));
 });
 
-QUnit.test("destroyRecord when new", async (assert) => {
+test("destroyRecord when new", async (assert) => {
   const store = createStore();
   const widget = store.createRecord("widget", { name: "hello" });
 
   assert.ok(await store.destroyRecord("widget", widget));
 });
 
-QUnit.test("find embedded", async (assert) => {
+test("find embedded", async (assert) => {
   const store = createStore();
   const fruit = await store.find("fruit", 1);
   assert.ok(fruit.get("farmer"), "it has the embedded object");
@@ -141,7 +139,7 @@ QUnit.test("find embedded", async (assert) => {
   assert.ok(fruit.get("category"), "categories are found automatically");
 });
 
-QUnit.test("embedded records can be cleared", async (assert) => {
+test("embedded records can be cleared", async (assert) => {
   const store = createStore();
   let fruit = await store.find("fruit", 4);
   fruit.set("farmer", { dummy: "object" });
@@ -150,7 +148,7 @@ QUnit.test("embedded records can be cleared", async (assert) => {
   assert.ok(!fruit.get("farmer"));
 });
 
-QUnit.test("meta types", async (assert) => {
+test("meta types", async (assert) => {
   const store = createStore();
   const barn = await store.find("barn", 1);
   assert.equal(
@@ -160,7 +158,7 @@ QUnit.test("meta types", async (assert) => {
   );
 });
 
-QUnit.test("findAll embedded", async (assert) => {
+test("findAll embedded", async (assert) => {
   const store = createStore();
   const fruits = await store.findAll("fruit");
   assert.equal(fruits.objectAt(0).get("farmer.name"), "Old MacDonald");
@@ -183,7 +181,7 @@ QUnit.test("findAll embedded", async (assert) => {
   assert.equal(fruits.objectAt(2).get("farmer.name"), "Luke Skywalker");
 });
 
-QUnit.test("custom primaryKey", async (assert) => {
+test("custom primaryKey", async (assert) => {
   const store = createStore();
   const cats = await store.findAll("cat");
   assert.equal(cats.objectAt(0).name, "souna");

--- a/app/assets/javascripts/discourse/tests/unit/models/topic-details-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/topic-details-test.js
@@ -1,6 +1,7 @@
+import { test, module } from "qunit";
 import User from "discourse/models/user";
 
-QUnit.module("model:topic-details");
+module("model:topic-details");
 
 import Topic from "discourse/models/topic";
 
@@ -9,13 +10,13 @@ var buildDetails = function (id) {
   return topic.get("details");
 };
 
-QUnit.test("defaults", (assert) => {
+test("defaults", (assert) => {
   var details = buildDetails(1234);
   assert.present(details, "the details are present by default");
   assert.ok(!details.get("loaded"), "details are not loaded by default");
 });
 
-QUnit.test("updateFromJson", (assert) => {
+test("updateFromJson", (assert) => {
   var details = buildDetails(1234);
 
   details.updateFromJson({

--- a/app/assets/javascripts/discourse/tests/unit/models/topic-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/topic-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import EmberObject from "@ember/object";
 import { IMAGE_VERSION as v } from "pretty-text/emoji/version";
 import Category from "discourse/models/category";
@@ -7,14 +8,14 @@ import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
 
 discourseModule("model:topic");
 
-QUnit.test("defaults", (assert) => {
+test("defaults", (assert) => {
   const topic = Topic.create({ id: 1234 });
 
   assert.blank(topic.get("deleted_at"), "deleted_at defaults to blank");
   assert.blank(topic.get("deleted_by"), "deleted_by defaults to blank");
 });
 
-QUnit.test("visited", (assert) => {
+test("visited", (assert) => {
   const topic = Topic.create({
     highest_post_number: 2,
     last_read_post_number: 1,
@@ -35,7 +36,7 @@ QUnit.test("visited", (assert) => {
   );
 });
 
-QUnit.test("lastUnreadUrl", (assert) => {
+test("lastUnreadUrl", (assert) => {
   const category = EmberObject.create({
     navigate_to_first_post_after_read: true,
   });
@@ -52,7 +53,7 @@ QUnit.test("lastUnreadUrl", (assert) => {
   assert.equal(topic.get("lastUnreadUrl"), "/t/hello/101/1");
 });
 
-QUnit.test("has details", (assert) => {
+test("has details", (assert) => {
   const topic = Topic.create({ id: 1234 });
   const topicDetails = topic.get("details");
 
@@ -64,7 +65,7 @@ QUnit.test("has details", (assert) => {
   );
 });
 
-QUnit.test("has a postStream", (assert) => {
+test("has a postStream", (assert) => {
   const topic = Topic.create({ id: 1234 });
   const postStream = topic.get("postStream");
 
@@ -76,7 +77,7 @@ QUnit.test("has a postStream", (assert) => {
   );
 });
 
-QUnit.test("has suggestedTopics", (assert) => {
+test("has suggestedTopics", (assert) => {
   const topic = Topic.create({ suggested_topics: [{ id: 1 }, { id: 2 }] });
   const suggestedTopics = topic.get("suggestedTopics");
 
@@ -84,7 +85,7 @@ QUnit.test("has suggestedTopics", (assert) => {
   assert.containsInstance(suggestedTopics, Topic);
 });
 
-QUnit.test("category relationship", (assert) => {
+test("category relationship", (assert) => {
   // It finds the category by id
   const category = Category.list()[0];
   const topic = Topic.create({ id: 1111, category_id: category.get("id") });
@@ -92,7 +93,7 @@ QUnit.test("category relationship", (assert) => {
   assert.equal(topic.get("category"), category);
 });
 
-QUnit.test("updateFromJson", (assert) => {
+test("updateFromJson", (assert) => {
   const topic = Topic.create({ id: 1234 });
   const category = Category.list()[0];
 
@@ -109,7 +110,7 @@ QUnit.test("updateFromJson", (assert) => {
   assert.equal(topic.get("category"), category);
 });
 
-QUnit.test("recover", (assert) => {
+test("recover", (assert) => {
   const user = User.create({ username: "eviltrout" });
   const topic = Topic.create({
     id: 1234,
@@ -122,7 +123,7 @@ QUnit.test("recover", (assert) => {
   assert.blank(topic.get("deleted_by"), "it clears deleted_by");
 });
 
-QUnit.test("fancyTitle", (assert) => {
+test("fancyTitle", (assert) => {
   const topic = Topic.create({
     fancy_title: ":smile: with all :) the emojis :pear::peach:",
   });
@@ -134,7 +135,7 @@ QUnit.test("fancyTitle", (assert) => {
   );
 });
 
-QUnit.test("fancyTitle direction", function (assert) {
+test("fancyTitle direction", function (assert) {
   const rtlTopic = Topic.create({ fancy_title: "هذا اختبار" });
   const ltrTopic = Topic.create({ fancy_title: "This is a test" });
 
@@ -151,7 +152,7 @@ QUnit.test("fancyTitle direction", function (assert) {
   );
 });
 
-QUnit.test("excerpt", (assert) => {
+test("excerpt", (assert) => {
   const topic = Topic.create({
     excerpt: "This is a test topic :smile:",
     pinned: true,

--- a/app/assets/javascripts/discourse/tests/unit/models/topic-tracking-state-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/topic-tracking-state-test.js
@@ -1,10 +1,11 @@
+import { test, module } from "qunit";
 import TopicTrackingState from "discourse/models/topic-tracking-state";
 import createStore from "discourse/tests/helpers/create-store";
 import Category from "discourse/models/category";
 import { NotificationLevels } from "discourse/lib/notification-levels";
 import User from "discourse/models/user";
 
-QUnit.module("model:topic-tracking-state", {
+module("model:topic-tracking-state", {
   beforeEach() {
     this.clock = sinon.useFakeTimers(new Date(2012, 11, 31, 12, 0).getTime());
   },
@@ -14,7 +15,7 @@ QUnit.module("model:topic-tracking-state", {
   },
 });
 
-QUnit.test("tag counts", function (assert) {
+test("tag counts", function (assert) {
   const state = TopicTrackingState.create();
 
   state.loadStates([
@@ -64,7 +65,7 @@ QUnit.test("tag counts", function (assert) {
   assert.equal(states["unread"].newCount, 0, "unread counts");
 });
 
-QUnit.test("forEachTracked", function (assert) {
+test("forEachTracked", function (assert) {
   const state = TopicTrackingState.create();
 
   state.loadStates([
@@ -139,7 +140,7 @@ QUnit.test("forEachTracked", function (assert) {
   assert.equal(sevenUnread, 2, "seven unread");
 });
 
-QUnit.test("sync", function (assert) {
+test("sync", function (assert) {
   const state = TopicTrackingState.create();
   state.states["t111"] = { last_read_post_number: null };
 
@@ -163,7 +164,7 @@ QUnit.test("sync", function (assert) {
   );
 });
 
-QUnit.test("subscribe to category", function (assert) {
+test("subscribe to category", function (assert) {
   const store = createStore();
   const darth = store.createRecord("category", { id: 1, slug: "darth" }),
     luke = store.createRecord("category", {
@@ -227,7 +228,7 @@ QUnit.test("subscribe to category", function (assert) {
   );
 });
 
-QUnit.test("getSubCategoryIds", (assert) => {
+test("getSubCategoryIds", (assert) => {
   const store = createStore();
   const foo = store.createRecord("category", { id: 1, slug: "foo" });
   const bar = store.createRecord("category", {
@@ -248,7 +249,7 @@ QUnit.test("getSubCategoryIds", (assert) => {
   assert.deepEqual(Array.from(state.getSubCategoryIds(3)), [3]);
 });
 
-QUnit.test("countNew", (assert) => {
+test("countNew", (assert) => {
   const store = createStore();
   const foo = store.createRecord("category", {
     id: 1,
@@ -326,7 +327,7 @@ QUnit.test("countNew", (assert) => {
   assert.equal(state.countNew(4), 0);
 });
 
-QUnit.test("mute topic", function (assert) {
+test("mute topic", function (assert) {
   let currentUser = User.create({
     username: "chuck",
     muted_category_ids: [],

--- a/app/assets/javascripts/discourse/tests/unit/models/user-action-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/user-action-test.js
@@ -1,8 +1,9 @@
+import { test, module } from "qunit";
 import UserAction from "discourse/models/user-action";
 
-QUnit.module("model: user-action");
+module("model: user-action");
 
-QUnit.test("collapsing likes", (assert) => {
+test("collapsing likes", (assert) => {
   var actions = UserAction.collapseStream([
     UserAction.create({
       action_type: UserAction.TYPES.likes_given,

--- a/app/assets/javascripts/discourse/tests/unit/models/user-badge-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/user-badge-test.js
@@ -1,9 +1,10 @@
+import { test, module } from "qunit";
 import UserBadge from "discourse/models/user-badge";
 import badgeFixtures from "discourse/tests/fixtures/user-badges";
 
-QUnit.module("model:user-badge");
+module("model:user-badge");
 
-QUnit.test("createFromJson single", (assert) => {
+test("createFromJson single", (assert) => {
   const userBadge = UserBadge.createFromJson(
     JSON.parse(JSON.stringify(badgeFixtures["/user_badges"]))
   );
@@ -25,7 +26,7 @@ QUnit.test("createFromJson single", (assert) => {
   );
 });
 
-QUnit.test("createFromJson array", (assert) => {
+test("createFromJson array", (assert) => {
   const userBadges = UserBadge.createFromJson(
     JSON.parse(JSON.stringify(badgeFixtures["/user-badges/:username"]))
   );
@@ -37,22 +38,22 @@ QUnit.test("createFromJson array", (assert) => {
   );
 });
 
-QUnit.test("findByUsername", async (assert) => {
+test("findByUsername", async (assert) => {
   const badges = await UserBadge.findByUsername("anne3");
   assert.ok(Array.isArray(badges), "returns an array");
 });
 
-QUnit.test("findByBadgeId", async (assert) => {
+test("findByBadgeId", async (assert) => {
   const badges = await UserBadge.findByBadgeId(880);
   assert.ok(Array.isArray(badges), "returns an array");
 });
 
-QUnit.test("grant", async (assert) => {
+test("grant", async (assert) => {
   const userBadge = await UserBadge.grant(1, "username");
   assert.ok(!Array.isArray(userBadge), "does not return an array");
 });
 
-QUnit.test("revoke", async (assert) => {
+test("revoke", async (assert) => {
   assert.expect(0);
   const userBadge = UserBadge.create({ id: 1 });
   await userBadge.revoke();

--- a/app/assets/javascripts/discourse/tests/unit/models/user-drafts-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/user-drafts-test.js
@@ -1,11 +1,12 @@
+import { test, module } from "qunit";
 import I18n from "I18n";
 import UserDraft from "discourse/models/user-draft";
 import { NEW_TOPIC_KEY } from "discourse/models/composer";
 import User from "discourse/models/user";
 
-QUnit.module("model:user-drafts");
+module("model:user-drafts");
 
-QUnit.test("stream", (assert) => {
+test("stream", (assert) => {
   const user = User.create({ id: 1, username: "eviltrout" });
   const stream = user.get("userDraftsStream");
   assert.present(stream, "a user has a drafts stream by default");
@@ -13,7 +14,7 @@ QUnit.test("stream", (assert) => {
   assert.blank(stream.get("content"), "no content by default");
 });
 
-QUnit.test("draft", (assert) => {
+test("draft", (assert) => {
   const drafts = [
     UserDraft.create({
       draft_key: "topic_1",

--- a/app/assets/javascripts/discourse/tests/unit/models/user-stream-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/user-stream-test.js
@@ -1,9 +1,10 @@
+import { test, module } from "qunit";
 import UserAction from "discourse/models/user-action";
 import User from "discourse/models/user";
 
-QUnit.module("model: UserStream");
+module("model: UserStream");
 
-QUnit.test("basics", (assert) => {
+test("basics", (assert) => {
   var user = User.create({ id: 1, username: "eviltrout" });
   var stream = user.get("stream");
   assert.present(stream, "a user has a stream by default");
@@ -16,7 +17,7 @@ QUnit.test("basics", (assert) => {
   assert.ok(!stream.get("loaded"), "the stream is not loaded by default");
 });
 
-QUnit.test("filterParam", (assert) => {
+test("filterParam", (assert) => {
   var user = User.create({ id: 1, username: "eviltrout" });
   var stream = user.get("stream");
 

--- a/app/assets/javascripts/discourse/tests/unit/models/user-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/user-test.js
@@ -1,11 +1,12 @@
+import { test, module } from "qunit";
 import User from "discourse/models/user";
 import Group from "discourse/models/group";
 import * as ajaxlib from "discourse/lib/ajax";
 import pretender from "discourse/tests/helpers/create-pretender";
 
-QUnit.module("model:user");
+module("model:user");
 
-QUnit.test("staff", (assert) => {
+test("staff", (assert) => {
   var user = User.create({ id: 1, username: "eviltrout" });
 
   assert.ok(!user.get("staff"), "user is not staff");
@@ -17,7 +18,7 @@ QUnit.test("staff", (assert) => {
   assert.ok(user.get("staff"), "admins are staff");
 });
 
-QUnit.test("searchContext", (assert) => {
+test("searchContext", (assert) => {
   var user = User.create({ id: 1, username: "EvilTrout" });
 
   assert.deepEqual(
@@ -27,7 +28,7 @@ QUnit.test("searchContext", (assert) => {
   );
 });
 
-QUnit.test("isAllowedToUploadAFile", (assert) => {
+test("isAllowedToUploadAFile", (assert) => {
   var user = User.create({ trust_level: 0, admin: true });
   assert.ok(
     user.isAllowedToUploadAFile("image"),
@@ -41,7 +42,7 @@ QUnit.test("isAllowedToUploadAFile", (assert) => {
   );
 });
 
-QUnit.test("canMangeGroup", (assert) => {
+test("canMangeGroup", (assert) => {
   let user = User.create({ admin: true });
   let group = Group.create({ automatic: true });
 
@@ -70,7 +71,7 @@ QUnit.test("canMangeGroup", (assert) => {
   );
 });
 
-QUnit.test("resolvedTimezone", (assert) => {
+test("resolvedTimezone", (assert) => {
   const tz = "Australia/Brisbane";
   let user = User.create({ timezone: tz, username: "chuck", id: 111 });
   let stub = sandbox.stub(moment.tz, "guess").returns("America/Chicago");
@@ -122,7 +123,7 @@ QUnit.test("resolvedTimezone", (assert) => {
   stub.restore();
 });
 
-QUnit.test("muted ids", (assert) => {
+test("muted ids", (assert) => {
   let user = User.create({ username: "chuck", muted_category_ids: [] });
 
   assert.deepEqual(user.calculateMutedIds(0, 1, "muted_category_ids"), [1]);

--- a/app/assets/javascripts/discourse/tests/unit/services/document-title-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/services/document-title-test.js
@@ -1,3 +1,4 @@
+import { test } from "qunit";
 import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
 import { currentUser } from "discourse/tests/helpers/qunit-helpers";
 
@@ -12,26 +13,21 @@ discourseModule("service:document-title", {
   },
 });
 
-QUnit.test("it updates the document title", function (assert) {
+test("it updates the document title", function (assert) {
   this.documentTitle.setTitle("Test Title");
   assert.equal(document.title, "Test Title", "title is correct");
 });
 
-QUnit.test(
-  "it doesn't display notification counts for anonymous users",
-  function (assert) {
-    this.documentTitle.setTitle("test notifications");
-    this.documentTitle.updateNotificationCount(5);
-    assert.equal(document.title, "test notifications");
-    this.documentTitle.setFocus(false);
-    this.documentTitle.updateNotificationCount(6);
-    assert.equal(document.title, "test notifications");
-  }
-);
+test("it doesn't display notification counts for anonymous users", function (assert) {
+  this.documentTitle.setTitle("test notifications");
+  this.documentTitle.updateNotificationCount(5);
+  assert.equal(document.title, "test notifications");
+  this.documentTitle.setFocus(false);
+  this.documentTitle.updateNotificationCount(6);
+  assert.equal(document.title, "test notifications");
+});
 
-QUnit.test("it displays notification counts for logged in users", function (
-  assert
-) {
+test("it displays notification counts for logged in users", function (assert) {
   this.documentTitle.currentUser = currentUser();
   this.documentTitle.currentUser.dynamic_favicon = false;
   this.documentTitle.setTitle("test notifications");
@@ -44,24 +40,18 @@ QUnit.test("it displays notification counts for logged in users", function (
   assert.equal(document.title, "test notifications");
 });
 
-QUnit.test(
-  "it doesn't increment background context counts when focused",
-  function (assert) {
-    this.documentTitle.setTitle("background context");
-    this.documentTitle.setFocus(true);
-    this.documentTitle.incrementBackgroundContextCount();
-    assert.equal(document.title, "background context");
-  }
-);
+test("it doesn't increment background context counts when focused", function (assert) {
+  this.documentTitle.setTitle("background context");
+  this.documentTitle.setFocus(true);
+  this.documentTitle.incrementBackgroundContextCount();
+  assert.equal(document.title, "background context");
+});
 
-QUnit.test(
-  "it increments background context counts when not focused",
-  function (assert) {
-    this.documentTitle.setTitle("background context");
-    this.documentTitle.setFocus(false);
-    this.documentTitle.incrementBackgroundContextCount();
-    assert.equal(document.title, "(1) background context");
-    this.documentTitle.setFocus(true);
-    assert.equal(document.title, "background context");
-  }
-);
+test("it increments background context counts when not focused", function (assert) {
+  this.documentTitle.setTitle("background context");
+  this.documentTitle.setFocus(false);
+  this.documentTitle.incrementBackgroundContextCount();
+  assert.equal(document.title, "(1) background context");
+  this.documentTitle.setFocus(true);
+  assert.equal(document.title, "background context");
+});

--- a/app/assets/javascripts/discourse/tests/unit/utils/decorators-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/utils/decorators-test.js
@@ -1,6 +1,7 @@
 import { afterRender } from "discourse-common/utils/decorators";
 import Component from "@ember/component";
 import componentTest from "discourse/tests/helpers/component-test";
+import { moduleForComponent } from "ember-qunit";
 
 const fooComponent = Component.extend({
   layoutName: "foo-component",

--- a/app/assets/javascripts/wizard/test/acceptance/wizard-test.js
+++ b/app/assets/javascripts/wizard/test/acceptance/wizard-test.js
@@ -1,8 +1,9 @@
+import { test, module } from "qunit";
 import { run } from "@ember/runloop";
 import startApp from "wizard/test/helpers/start-app";
 
 var wizard;
-QUnit.module("Acceptance: wizard", {
+module("Acceptance: wizard", {
   beforeEach() {
     wizard = startApp();
   },

--- a/app/assets/javascripts/wizard/test/components/invite-list-test.js
+++ b/app/assets/javascripts/wizard/test/components/invite-list-test.js
@@ -1,3 +1,4 @@
+import { moduleForComponent } from "ember-qunit";
 import { componentTest } from "wizard/test/helpers/component-test";
 moduleForComponent("invite-list", { integration: true });
 

--- a/app/assets/javascripts/wizard/test/helpers/component-test.js
+++ b/app/assets/javascripts/wizard/test/helpers/component-test.js
@@ -1,4 +1,5 @@
 import initializer from "wizard/initializers/load-helpers";
+import { test } from "qunit";
 
 export function componentTest(name, opts) {
   opts = opts || {};

--- a/app/assets/javascripts/wizard/test/models/wizard-field-test.js
+++ b/app/assets/javascripts/wizard/test/models/wizard-field-test.js
@@ -1,3 +1,5 @@
+import { moduleFor } from "ember-qunit";
+import { test } from "qunit";
 import WizardField from "wizard/models/wizard-field";
 
 moduleFor("model:wizard-field");

--- a/app/assets/javascripts/wizard/test/test_helper.js
+++ b/app/assets/javascripts/wizard/test/test_helper.js
@@ -9,12 +9,12 @@
 //= require route-recognizer/dist/route-recognizer
 //= require fake_xml_http_request
 //= require pretender/pretender
+//= require qunit/qunit/qunit
+//= require ember-qunit
 //= require discourse-loader
 //= require jquery.debug
 //= require handlebars
 //= require ember-template-compiler
-//= require qunit/qunit/qunit
-//= require ember-qunit
 //= require wizard-application
 //= require wizard-vendor
 //= require helpers/assertions

--- a/plugins/discourse-details/test/javascripts/lib/details-cooked-test.js.es6
+++ b/plugins/discourse-details/test/javascripts/lib/details-cooked-test.js.es6
@@ -1,6 +1,6 @@
 import PrettyText, { buildOptions } from "pretty-text/pretty-text";
 
-QUnit.module("lib:details-cooked-test");
+module("lib:details-cooked-test");
 
 const defaultOpts = buildOptions({
   siteSettings: {

--- a/plugins/discourse-local-dates/test/javascripts/lib/date-with-zone-helper-test.js.es6
+++ b/plugins/discourse-local-dates/test/javascripts/lib/date-with-zone-helper-test.js.es6
@@ -3,7 +3,7 @@ import DateWithZoneHelper from "./date-with-zone-helper";
 const PARIS = "Europe/Paris";
 const SYDNEY = "Australia/Sydney";
 
-QUnit.module("lib:date-with-zone-helper");
+module("lib:date-with-zone-helper");
 
 function buildDateHelper(params = {}) {
   return new DateWithZoneHelper({
@@ -17,7 +17,7 @@ function buildDateHelper(params = {}) {
   });
 }
 
-QUnit.test("#format", (assert) => {
+test("#format", (assert) => {
   let date = buildDateHelper({
     day: 15,
     month: 2,
@@ -28,7 +28,7 @@ QUnit.test("#format", (assert) => {
   assert.equal(date.format(), "2020-03-15T15:36:00.000+01:00");
 });
 
-QUnit.test("#repetitionsBetweenDates", (assert) => {
+test("#repetitionsBetweenDates", (assert) => {
   let date;
 
   date = buildDateHelper({
@@ -96,7 +96,7 @@ QUnit.test("#repetitionsBetweenDates", (assert) => {
   );
 });
 
-QUnit.test("#add", (assert) => {
+test("#add", (assert) => {
   let date;
   let futureLocalDate;
 

--- a/plugins/discourse-local-dates/test/javascripts/lib/local-date-builder-test.js.es6
+++ b/plugins/discourse-local-dates/test/javascripts/lib/local-date-builder-test.js.es6
@@ -8,7 +8,7 @@ const PARIS = "Europe/Paris";
 const LAGOS = "Africa/Lagos";
 const LONDON = "Europe/London";
 
-QUnit.module("lib:local-date-builder");
+module("lib:local-date-builder");
 
 const sandbox = sinon.createSandbox();
 
@@ -62,7 +62,7 @@ QUnit.assert.buildsCorrectDate = function (options, expected, message) {
   }
 };
 
-QUnit.test("date", (assert) => {
+test("date", (assert) => {
   freezeTime({ date: "2020-03-11" }, () => {
     assert.buildsCorrectDate(
       { date: "2020-03-22", timezone: PARIS },
@@ -72,7 +72,7 @@ QUnit.test("date", (assert) => {
   });
 });
 
-QUnit.test("date and time", (assert) => {
+test("date and time", (assert) => {
   assert.buildsCorrectDate(
     { date: "2020-04-11", time: "11:00" },
     { formated: "April 11, 2020 1:00 PM" },
@@ -86,7 +86,7 @@ QUnit.test("date and time", (assert) => {
   );
 });
 
-QUnit.test("option[format]", (assert) => {
+test("option[format]", (assert) => {
   freezeTime({ date: "2020-03-11" }, () => {
     assert.buildsCorrectDate(
       { format: "YYYY" },
@@ -96,7 +96,7 @@ QUnit.test("option[format]", (assert) => {
   });
 });
 
-QUnit.test("option[displayedTimezone]", (assert) => {
+test("option[displayedTimezone]", (assert) => {
   freezeTime({}, () => {
     assert.buildsCorrectDate(
       { displayedTimezone: SYDNEY },
@@ -130,7 +130,7 @@ QUnit.test("option[displayedTimezone]", (assert) => {
   });
 });
 
-QUnit.test("option[timezone]", (assert) => {
+test("option[timezone]", (assert) => {
   freezeTime({}, () => {
     assert.buildsCorrectDate(
       { timezone: SYDNEY, displayedTimezone: PARIS },
@@ -140,7 +140,7 @@ QUnit.test("option[timezone]", (assert) => {
   });
 });
 
-QUnit.test("option[recurring]", (assert) => {
+test("option[recurring]", (assert) => {
   freezeTime({ date: "2020-04-06 06:00", timezone: LAGOS }, () => {
     assert.buildsCorrectDate(
       {
@@ -220,7 +220,7 @@ QUnit.test("option[recurring]", (assert) => {
   });
 });
 
-QUnit.test("option[countown]", (assert) => {
+test("option[countown]", (assert) => {
   freezeTime({ date: "2020-03-21 23:59" }, () => {
     assert.buildsCorrectDate(
       {
@@ -248,7 +248,7 @@ QUnit.test("option[countown]", (assert) => {
   });
 });
 
-QUnit.test("option[calendar]", (assert) => {
+test("option[calendar]", (assert) => {
   freezeTime({ date: "2020-03-23 23:00" }, () => {
     assert.buildsCorrectDate(
       { date: "2020-03-22", time: "23:59", timezone: PARIS },
@@ -329,7 +329,7 @@ QUnit.test("option[calendar]", (assert) => {
   });
 });
 
-QUnit.test("previews", (assert) => {
+test("previews", (assert) => {
   freezeTime({ date: "2020-03-22" }, () => {
     assert.buildsCorrectDate(
       { timezone: PARIS },


### PR DESCRIPTION
We used many global functions to handle tests when they should be
imported like other libraries in our application. This also gets us
closer to the way Ember CLI prefers our tests to be laid out.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
