### PR TITLE
FIX: Use getAttribute instead of dataset

### DIFF
--- a/vendor/assets/javascripts/browser-update.js.erb
+++ b/vendor/assets/javascripts/browser-update.js.erb
@@ -23,7 +23,7 @@ var $buo = function() {
   var noscriptElements = document.getElementsByTagName("noscript");
   // find the element with the "data-path" attribute set
   for (var i = 0; i < noscriptElements.length; ++i) {
-    if (noscriptElements[i].dataset["path"]) {
+    if (noscriptElements[i].getAttribute("data-path")) {
       // noscriptElements[i].innerHTML contains encoded HTML
       mainElement.innerHTML = noscriptElements[i].childNodes[0].nodeValue;
       break;


### PR DESCRIPTION
IE10 does not have dataset field.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
