### PR TITLE
PERF: Do not enqueue digest emails when attempted recently

### DIFF
--- a/app/jobs/regular/user_email.rb
+++ b/app/jobs/regular/user_email.rb
@@ -22,6 +22,15 @@ module Jobs
       # of extra work when emails are disabled.
       return if quit_email_early?
 
+      send_user_email(args)
+
+      if args[:user_id].present? && args[:type] == :digest
+        # Record every attempt at sending a digest email, even if it was skipped
+        UserStat.where(user_id: args[:user_id]).update_all(digest_attempted_at: Time.zone.now)
+      end
+    end
+
+    def send_user_email(args)
       post = nil
       notification = nil
       type = args[:type]

--- a/app/jobs/scheduled/enqueue_digest_emails.rb
+++ b/app/jobs/scheduled/enqueue_digest_emails.rb
@@ -6,12 +6,8 @@ module Jobs
     every 30.minutes
 
     def execute(args)
-      return if SiteSetting.disable_digest_emails? || SiteSetting.private_email?
+      return if SiteSetting.disable_digest_emails? || SiteSetting.private_email? || SiteSetting.disable_emails == 'yes'
       users = target_user_ids
-
-      if users.length > GlobalSetting.max_digests_enqueued_per_30_mins_per_site
-        users = users.shuffle[0...GlobalSetting.max_digests_enqueued_per_30_mins_per_site]
-      end
 
       users.each do |user_id|
         ::Jobs.enqueue(:user_email, type: :digest, user_id: user_id)
@@ -30,11 +26,15 @@ module Jobs
         .where("user_stats.bounce_score < #{SiteSetting.bounce_score_threshold}")
         .where("user_emails.primary")
         .where("COALESCE(last_emailed_at, '2010-01-01') <= CURRENT_TIMESTAMP - ('1 MINUTE'::INTERVAL * user_options.digest_after_minutes)")
+        .where("COALESCE(user_stats.digest_attempted_at, '2010-01-01') <= CURRENT_TIMESTAMP - ('1 MINUTE'::INTERVAL * user_options.digest_after_minutes)")
         .where("COALESCE(last_seen_at, '2010-01-01') <= CURRENT_TIMESTAMP - ('1 MINUTE'::INTERVAL * user_options.digest_after_minutes)")
         .where("COALESCE(last_seen_at, '2010-01-01') >= CURRENT_TIMESTAMP - ('1 DAY'::INTERVAL * #{SiteSetting.suppress_digest_email_after_days})")
+        .order("user_stats.digest_attempted_at ASC NULLS FIRST")
 
       # If the site requires approval, make sure the user is approved
       query = query.where("approved OR moderator OR admin") if SiteSetting.must_approve_users?
+
+      query = query.limit(GlobalSetting.max_digests_enqueued_per_30_mins_per_site)
 
       query.pluck(:id)
     end

--- a/app/models/user_stat.rb
+++ b/app/models/user_stat.rb
@@ -290,4 +290,5 @@ end
 #  flags_ignored            :integer          default(0), not null
 #  first_unread_at          :datetime         not null
 #  distinct_badge_count     :integer          default(0), not null
+#  digest_attempted_at      :datetime
 #

--- a/db/migrate/20201007124955_add_digest_attempted_at_to_user_stats.rb
+++ b/db/migrate/20201007124955_add_digest_attempted_at_to_user_stats.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDigestAttemptedAtToUserStats < ActiveRecord::Migration[6.0]
+  def change
+    add_column :user_stats, :digest_attempted_at, :timestamp
+  end
+end


### PR DESCRIPTION
Previously, Jobs::EnqueueDigestEmails would enqueue a digest job for every user, even if there are no topics to send. The digest job would exit, no email would send, and last_emailed_at would not change. 30 minutes later, Jobs::EnqueueDigestEmails would run again and re-enqueue jobs for the same users.

120fa8ad introduced a temporary mitigation for this issue, by randomly selecting a subset of those users each time.

This commit adds a new `digest_attempted_at` column to the `user_stats` table. This column is updated every time a digest job completes for a user. Using this, we can avoid scheduling digest jobs for the same user every 30 minutes. This also removes the random user selection in 120fa8ad, and instead prioritizes users who had digests attempted the longest time ago.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
