### PR TITLE
FIX: Compare Jobs::UserEmail type argument as string

### DIFF
--- a/app/jobs/regular/user_email.rb
+++ b/app/jobs/regular/user_email.rb
@@ -24,7 +24,7 @@ module Jobs
 
       send_user_email(args)
 
-      if args[:user_id].present? && args[:type] == :digest
+      if args[:user_id].present? && args[:type].to_s == "digest"
         # Record every attempt at sending a digest email, even if it was skipped
         UserStat.where(user_id: args[:user_id]).update_all(digest_attempted_at: Time.zone.now)
       end


### PR DESCRIPTION
In specs, symbols are passed through correctly. But in production, all arguments are provided to jobs as strings.

Followup to c0293339b87c39bbd2b91f87e2d39179f40c9a9a

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
