### PR TITLE
REFACTOR: Some qunit `module` imports were missing

### DIFF
--- a/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
+++ b/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
@@ -36,6 +36,7 @@ import { setURLContainer } from "discourse/lib/url";
 import { setDefaultOwner } from "discourse-common/lib/get-owner";
 import bootbox from "bootbox";
 import { moduleFor } from "ember-qunit";
+import { module } from "qunit";
 
 export function currentUser() {
   return User.create(sessionFixtures["/session/current.json"].current_user);

--- a/app/assets/javascripts/discourse/tests/unit/lib/click-track-edit-history-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/click-track-edit-history-test.js
@@ -1,4 +1,4 @@
-import { skip } from "qunit";
+import { module, skip } from "qunit";
 import DiscourseURL from "discourse/lib/url";
 import ClickTrack from "discourse/lib/click-track";
 import { fixture, logIn } from "discourse/tests/helpers/qunit-helpers";

--- a/app/assets/javascripts/discourse/tests/unit/lib/click-track-profile-page-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/click-track-profile-page-test.js
@@ -1,4 +1,4 @@
-import { skip } from "qunit";
+import { module, skip } from "qunit";
 import DiscourseURL from "discourse/lib/url";
 import ClickTrack from "discourse/lib/click-track";
 import { fixture, logIn } from "discourse/tests/helpers/qunit-helpers";

--- a/app/assets/javascripts/discourse/tests/unit/lib/highlight-search-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/highlight-search-test.js
@@ -1,6 +1,6 @@
 import highlightSearch, { CLASS_NAME } from "discourse/lib/highlight-search";
 import { fixture } from "discourse/tests/helpers/qunit-helpers";
-import { test } from "qunit";
+import { module, test } from "qunit";
 
 module("lib:highlight-search");
 


### PR DESCRIPTION
These are tricky because `module.exports` is used by nodejs files as a
global, which is OK. But we don't want to allow `module` in JS tests
for qunit without importing it first.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
