### PR TITLE
FIX: Group Requests loading was broken

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/group-requests.js
+++ b/app/assets/javascripts/discourse/app/controllers/group-requests.js
@@ -36,7 +36,7 @@ export default Controller.extend({
       return;
     }
 
-    if (!refresh && model.members.length >= model.user_count) {
+    if (!refresh && model.requesters.length >= model.user_count) {
       this.set("application.showFooter", true);
       return;
     }


### PR DESCRIPTION
We were referencing the wrong property, which meant the footer was
always being hidden and we were trying to load more requests when we'd
already loaded them all.

see:
https://meta.discourse.org/t/constant-loading-on-group-membership-request-tab/166284

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
