### PR TITLE
FIX - downcase strings consistently

### DIFF
--- a/lib/topic_creator.rb
+++ b/lib/topic_creator.rb
@@ -218,7 +218,7 @@ class TopicCreator
     names = usernames.split(',').flatten.map(&:downcase)
     len = 0
 
-    User.includes(:user_option).where('lower(username) in (?)', names).find_each do |user|
+    User.includes(:user_option).where('username_lower in (?)', names).find_each do |user|
       check_can_send_permission!(topic, user)
       @added_users << user
       topic.topic_allowed_users.build(user_id: user.id)

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -1083,11 +1083,17 @@ describe PostsController do
         user_2 = Fabricate(:user)
         user_3 = Fabricate(:user, username: "foo_bar")
 
+        # In certain edge cases, it's possible to end up with a username
+        # containing characters that would normally fail to validate
+        user_4 = Fabricate(:user, username: "Iyi_Iyi")
+        user_4.update_attribute(:username, "İyi_İyi")
+        user_4.update_attribute(:username_lower, "İyi_İyi".downcase)
+
         post "/posts.json", params: {
           raw: 'this is the test content',
           archetype: 'private_message',
           title: "this is some post",
-          target_recipients: "#{user_2.username},Foo_Bar"
+          target_recipients: "#{user_2.username},Foo_Bar,İyi_İyi"
         }
 
         expect(response.status).to eq(200)
@@ -1097,7 +1103,7 @@ describe PostsController do
 
         expect(new_post.user).to eq(user)
         expect(new_topic.private_message?).to eq(true)
-        expect(new_topic.allowed_users).to contain_exactly(user, user_2, user_3)
+        expect(new_topic.allowed_users).to contain_exactly(user, user_2, user_3, user_4)
       end
 
       context "when target_recipients not provided" do


### PR DESCRIPTION
ruby and postgres can treat certain characters differently when downcasing them. So do all the downcasing in ruby so that we get consistent results.
