### PR TITLE
DEV: remove legacy code

### DIFF
--- a/db/migrate/20120803191426_add_admin_flag_to_users.rb
+++ b/db/migrate/20120803191426_add_admin_flag_to_users.rb
@@ -4,8 +4,5 @@ class AddAdminFlagToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :admin, :boolean, default: false, null: false
     add_column :users, :moderator, :boolean, default: false, null: false
-
-    # Make all of us admins
-    execute "UPDATE users SET admin = TRUE where lower(username) in ('eviltrout', 'codinghorror', 'sam', 'hanzo')"
   end
 end


### PR DESCRIPTION
This code is a no-op on all sites, even though it looks rather dangerous
this migration has long run prior to people trying exploit it.

That said ... hygiene here ... is not good.

Remove this legacy, we do not want it, even in historical migrations.
