### PR TITLE
FIX: Scheduled jobs not showing up in /sidekiq/schedule in dev.

### DIFF
--- a/config/initializers/100-sidekiq.rb
+++ b/config/initializers/100-sidekiq.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Ensure that scheduled jobs are loaded before mini_scheduler is configured.
-if Rails.env == "development" && Sidekiq.server?
+if Rails.env == "development"
   require "jobs/base"
 
   Dir.glob("#{Rails.root}/app/jobs/scheduled/*.rb") do |f|


### PR DESCRIPTION
This reverts https://github.com/discourse/discourse/commit/20bd6d97977a1f9e21c1d671f8b7385600c9ea39 since I thought that it was strange to load Sidekiq stuff when not in the Sidekiq process previously.