### PR TITLE
FIX: ensures category chooser is working with non english char

### DIFF
--- a/app/assets/javascripts/discourse/tests/acceptance/category-chooser-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/category-chooser-test.js
@@ -25,19 +25,3 @@ test("prefill category when category_id is set", async (assert) => {
 
   assert.equal(selectKit(".category-chooser").header().value(), 1);
 });
-
-test("filter is case insensitive", async (assert) => {
-  const categoryChooser = selectKit(".category-chooser");
-
-  await visit("/");
-  await click("#create-topic");
-  await categoryChooser.expand();
-  await categoryChooser.fillInFilter("bug");
-
-  assert.ok(categoryChooser.rows().length, 1);
-
-  await categoryChooser.emptyFilter();
-  await categoryChooser.fillInFilter("Bug");
-
-  assert.ok(categoryChooser.rows().length, 1);
-});

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/category-chooser-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/category-chooser-test.js
@@ -1,3 +1,4 @@
+import createStore from "discourse/tests/helpers/create-store";
 import I18n from "I18n";
 import componentTest from "discourse/tests/helpers/component-test";
 import { testSelectKitModule } from "discourse/tests/helpers/select-kit-helper";
@@ -142,5 +143,54 @@ componentTest("with allowed uncategorized and none", {
   test(assert) {
     assert.equal(this.subject.header().value(), null);
     assert.equal(this.subject.header().label(), "root none label");
+  },
+});
+
+componentTest("filter is case insensitive", {
+  template: template(),
+
+  async test(assert) {
+    await this.subject.expand();
+    await this.subject.fillInFilter("bug");
+
+    assert.ok(this.subject.rows().length, 1);
+    assert.equal(this.subject.rowByIndex(0).name(), "bug");
+
+    await this.subject.emptyFilter();
+    await this.subject.fillInFilter("Bug");
+
+    assert.ok(this.subject.rows().length, 1);
+    assert.equal(this.subject.rowByIndex(0).name(), "bug");
+  },
+});
+
+componentTest("filter works with non english characters", {
+  template: `
+    {{category-chooser
+      value=value
+      content=content
+    }}
+  `,
+
+  beforeEach() {
+    const store = createStore();
+    const nonEnglishCat = store.createRecord("category", {
+      id: 1,
+      name: "chữ Quốc ngữ",
+    });
+    const englishCat = store.createRecord("category", {
+      id: 2,
+      name: "Baz",
+    });
+
+    this.set("content", [nonEnglishCat, englishCat]);
+  },
+
+  async test(assert) {
+    await this.subject.expand();
+    await this.subject.fillInFilter("hữ");
+
+    assert.ok(this.subject.rows().length, 1);
+    assert.equal(this.subject.rowByIndex(0).name(), "chữ Quốc ngữ");
   },
 });

--- a/app/assets/javascripts/select-kit/addon/components/category-chooser.js
+++ b/app/assets/javascripts/select-kit/addon/components/category-chooser.js
@@ -67,7 +67,6 @@ export default ComboBoxComponent.extend({
 
   search(filter) {
     if (filter) {
-      filter = filter.toLowerCase();
       return this.content.filter((item) => {
         const category = Category.findById(this.getValue(item));
         const categoryName = this.getName(item);
@@ -147,6 +146,7 @@ export default ComboBoxComponent.extend({
   },
 
   _matchCategory(filter, categoryName) {
-    return this._normalize(categoryName).indexOf(filter) > -1;
+    const regex = RegExp(filter, "i");
+    return regex.test(categoryName);
   },
 });

--- a/app/assets/javascripts/select-kit/addon/components/category-chooser.js
+++ b/app/assets/javascripts/select-kit/addon/components/category-chooser.js
@@ -67,6 +67,7 @@ export default ComboBoxComponent.extend({
 
   search(filter) {
     if (filter) {
+      filter = this._normalize(filter);
       return this.content.filter((item) => {
         const category = Category.findById(this.getValue(item));
         const categoryName = this.getName(item);
@@ -146,7 +147,6 @@ export default ComboBoxComponent.extend({
   },
 
   _matchCategory(filter, categoryName) {
-    const regex = RegExp(filter, "i");
-    return regex.test(categoryName);
+    return this._normalize(categoryName).indexOf(filter) > -1;
   },
 });


### PR DESCRIPTION
This commit is also moving one test to a component test.

A followup to this commit would be to ensure every dropdowns are using a regex instead of the normalize/lowercase system we have now.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
