### PR TITLE
FIX: ensures insert hyperlink works with mailto

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/insert-hyperlink.js
+++ b/app/assets/javascripts/discourse/app/controllers/insert-hyperlink.js
@@ -4,12 +4,7 @@ import Controller from "@ember/controller";
 import ModalFunctionality from "discourse/mixins/modal-functionality";
 import { searchForTerm } from "discourse/lib/search";
 import { bind } from "discourse-common/utils/decorators";
-
-function prefixProtocol(url) {
-  return url.indexOf("://") === -1 && url.indexOf("mailto:") === -1
-    ? "https://" + url
-    : url;
-}
+import { prefixProtocol } from "discourse/lib/url";
 
 export default Controller.extend(ModalFunctionality, {
   _debounced: null,

--- a/app/assets/javascripts/discourse/app/controllers/insert-hyperlink.js
+++ b/app/assets/javascripts/discourse/app/controllers/insert-hyperlink.js
@@ -5,6 +5,12 @@ import ModalFunctionality from "discourse/mixins/modal-functionality";
 import { searchForTerm } from "discourse/lib/search";
 import { bind } from "discourse-common/utils/decorators";
 
+function prefixProtocol(url) {
+  return url.indexOf("://") === -1 && url.indexOf("mailto:") === -1
+    ? "https://" + url
+    : url;
+}
+
 export default Controller.extend(ModalFunctionality, {
   _debounced: null,
   _activeSearch: null,
@@ -144,8 +150,7 @@ export default Controller.extend(ModalFunctionality, {
   actions: {
     ok() {
       const origLink = this.linkUrl;
-      const linkUrl =
-        origLink.indexOf("://") === -1 ? `http://${origLink}` : origLink;
+      const linkUrl = prefixProtocol(origLink);
       const sel = this.toolbarEvent.selected;
 
       if (isEmpty(linkUrl)) {

--- a/app/assets/javascripts/discourse/app/lib/url.js
+++ b/app/assets/javascripts/discourse/app/lib/url.js
@@ -493,4 +493,10 @@ export function setURLContainer(container) {
   setOwner(_urlInstance, container);
 }
 
+export function prefixProtocol(url) {
+  return url.indexOf("://") === -1 && url.indexOf("mailto:") !== 0
+    ? "https://" + url
+    : url;
+}
+
 export default _urlInstance;

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-hyperlink-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-hyperlink-test.js
@@ -33,23 +33,6 @@ test("add a hyperlink to a reply", async (assert) => {
     "modal dismissed after submitting link"
   );
 
-  await fillIn(".d-editor-input", "");
-  await click(".d-editor button.link");
-  await fillIn(".modal-body .link-url", "mailto:mr-beaver@aol.com");
-  await fillIn(".modal-body .link-text", "Mister Beaver");
-  await click(".modal-footer button.btn-primary");
-
-  assert.equal(
-    find(".d-editor-input").val(),
-    "[Mister Beaver](mailto:mr-beaver@aol.com)",
-    "works with mailto"
-  );
-
-  assert.ok(
-    !exists(".insert-link.modal-body"),
-    "modal dismissed after submitting link"
-  );
-
   await fillIn(".d-editor-input", "Reset textarea contents.");
 
   await click(".d-editor button.link");

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-hyperlink-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-hyperlink-test.js
@@ -24,8 +24,25 @@ test("add a hyperlink to a reply", async (assert) => {
 
   assert.equal(
     find(".d-editor-input").val(),
-    "This is a link to [Google](http://google.com)",
-    "adds link with url and text, prepends 'http://'"
+    "This is a link to [Google](https://google.com)",
+    "adds link with url and text, prepends 'https://'"
+  );
+
+  assert.ok(
+    !exists(".insert-link.modal-body"),
+    "modal dismissed after submitting link"
+  );
+
+  await fillIn(".d-editor-input", "");
+  await click(".d-editor button.link");
+  await fillIn(".modal-body .link-url", "mailto:mr-beaver@aol.com");
+  await fillIn(".modal-body .link-text", "Mister Beaver");
+  await click(".modal-footer button.btn-primary");
+
+  assert.equal(
+    find(".d-editor-input").val(),
+    "[Mister Beaver](mailto:mr-beaver@aol.com)",
+    "works with mailto"
   );
 
   assert.ok(
@@ -43,7 +60,7 @@ test("add a hyperlink to a reply", async (assert) => {
   assert.equal(
     find(".d-editor-input").val(),
     "Reset textarea contents.",
-    "adds link with url and text, prepends 'http://'"
+    "doesn’t insert anything after cancelling"
   );
 
   assert.ok(
@@ -61,7 +78,7 @@ test("add a hyperlink to a reply", async (assert) => {
 
   assert.equal(
     find(".d-editor-input").val(),
-    "[Reset](http://somelink.com) textarea contents.",
+    "[Reset](https://somelink.com) textarea contents.",
     "adds link to a selected text"
   );
 

--- a/app/assets/javascripts/discourse/tests/unit/lib/url-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/url-test.js
@@ -1,5 +1,5 @@
 import { test, module } from "qunit";
-import DiscourseURL, { userPath } from "discourse/lib/url";
+import DiscourseURL, { userPath, prefixProtocol } from "discourse/lib/url";
 import { setPrefix } from "discourse-common/lib/get-url";
 import { logIn } from "discourse/tests/helpers/qunit-helpers";
 import User from "discourse/models/user";
@@ -78,5 +78,21 @@ test("routeTo with prefix", async (assert) => {
   assert.ok(
     DiscourseURL.handleURL.calledWith(`/u/${user.username}/messages`),
     "it should navigate to the messages page"
+  );
+});
+
+test("prefixProtocol", async (assert) => {
+  assert.equal(
+    prefixProtocol("mailto:mr-beaver@aol.com"),
+    "mailto:mr-beaver@aol.com"
+  );
+  assert.equal(prefixProtocol("discourse.org"), "https://discourse.org");
+  assert.equal(
+    prefixProtocol("www.discourse.org"),
+    "https://www.discourse.org"
+  );
+  assert.equal(
+    prefixProtocol("www.discourse.org/mailto:foo"),
+    "https://www.discourse.org/mailto:foo"
   );
 });


### PR DESCRIPTION
This commit also renames an incorrectly named test and uses https as default instead of http, in 2020 it's reasonnable to think we most likely want https and not http. User can still specify http if required.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
