### PR TITLE
Ignore disabled out-of-date remote themes

### DIFF
--- a/app/models/remote_theme.rb
+++ b/app/models/remote_theme.rb
@@ -104,6 +104,7 @@ class RemoteTheme < ActiveRecord::Base
 
   def self.out_of_date_themes
     self.joined_remotes.where("commits_behind > 0 OR remote_version <> local_version")
+      .where(themes: { enabled: true })
       .pluck("themes.name", "themes.id")
   end
 

--- a/spec/models/remote_theme_spec.rb
+++ b/spec/models/remote_theme_spec.rb
@@ -245,6 +245,13 @@ describe RemoteTheme do
       remote.update!(local_version: "new version", commits_behind: 0)
       expect(described_class.out_of_date_themes).to eq([])
     end
+
+    it "ignores disabled out of date themes" do
+      remote.update!(local_version: "old version", remote_version: "new version", commits_behind: 2)
+      theme.update!(enabled: false)
+      expect(described_class.out_of_date_themes).to eq([])
+    end
+
   end
 
   context ".unreachable_themes" do


### PR DESCRIPTION
No need to alert in admin dashboard about out of date remote themes
that are disabled.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
