### PR TITLE
FIX: Use scope name when serializing UserApiKeys

### DIFF
--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -131,7 +131,7 @@ class UserSerializer < UserCardSerializer
       {
         id: k.id,
         application_name: k.application_name,
-        scopes: k.scopes.map { |s| I18n.t("user_api_key.scopes.#{s}") },
+        scopes: k.scopes.map { |s| I18n.t("user_api_key.scopes.#{s.name}") },
         created_at: k.created_at,
         last_used_at: k.last_used_at,
       }


### PR DESCRIPTION
This issue was introduced in 1ba9b34b034c2a27c9e04f430eefbccae5942bcf, when the scopes were changed from an array of strings to a dedicated table

<img width="1171" alt="Screenshot 2020-10-08 at 17 53 25" src="https://user-images.githubusercontent.com/6270921/95490106-a8afd100-098f-11eb-8220-a6703291cf0b.png">

I intend to switch this to use a proper activerecord serializer for UserApiKeys, so this fix should be considered a short-term solution.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
