### PR TITLE
DEV: Add discourse-teambuild to official plugins

### DIFF
--- a/lib/plugin/metadata.rb
+++ b/lib/plugin/metadata.rb
@@ -64,6 +64,7 @@ class Plugin::Metadata
     "discourse-spoiler-alert",
     "discourse-user-notes",
     "styleguide",
+    "discourse-teambuild",
     "discourse-tooltips",
     "discourse-translator",
     "discourse-user-card-badges",


### PR DESCRIPTION
Discourse-teambuild is [marked official on its Meta topic](https://meta.discourse.org/t/discourse-teambuild-run-your-own-team-building-activity/134907) and is included in the [all-the-plugins](https://github.com/discourse/all-the-plugins/blob/1193bcdc0caa531442e45d15992c2da849b66eb7/.gitmodules#L520-L522) repo.