### PR TITLE
FIX: Favicon count was not updated when window focus returned

### DIFF
--- a/app/assets/javascripts/discourse/app/services/document-title.js
+++ b/app/assets/javascripts/discourse/app/services/document-title.js
@@ -44,6 +44,7 @@ export default Service.extend({
       this.notificationCount = 0;
     }
     this.appEvents.trigger("discourse:focus-changed", session.hasFocus);
+    this._renderFavicon();
     this._renderTitle();
   },
 


### PR DESCRIPTION
This misses a test because Favcount doesn't exposes a get to the counter.

Also, since this code deals with all possible notifications configs we support:

- favicon notification
- favicon new content
- title notification
- title new content

the code is a bit complicated to follow. We may look into refactoring it when a
good opportunity arises, like if https://w3c.github.io/badging/ setClientBadge() method
gives us a cleaner way to notify users.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
