### PR TITLE
FIX: display correct reply count for crawler

### DIFF
--- a/app/views/list/list.erb
+++ b/app/views/list/list.erb
@@ -102,7 +102,7 @@
             <% end %>
           </td>
           <td class="replies">
-            <span class='posts' title='<%= t 'posts' %>'><%= t.posts_count %></span>
+            <span class='posts' title='<%= t 'posts' %>'><%= t.posts_count - 1 %></span>
           </td>
           <td class="views">
             <span class='views' title='<%= t 'views' %>'><%= t.views %></span>


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
Subtract one from post count for reply count, like what the js app implement. Very tiny change no deserve a special test.