### PR TITLE
FEATURE - SiteSetting to disable user option to hide their profiles and presences

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/preferences/interface.hbs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/interface.hbs
@@ -135,7 +135,9 @@
   {{#if siteSettings.automatically_unpin_topics}}
     {{preference-checkbox labelKey="user.automatically_unpin_topics" checked=model.user_option.automatically_unpin_topics  class="pref-auto-unpin"}}
   {{/if}}
-  {{preference-checkbox labelKey="user.hide_profile_and_presence" checked=model.user_option.hide_profile_and_presence  class="pref-hide-profile"}}
+  {{#if siteSettings.allow_users_to_hide_profile}}
+    {{preference-checkbox labelKey="user.hide_profile_and_presence" checked=model.user_option.hide_profile_and_presence  class="pref-hide-profile"}}
+  {{/if}}
   {{#if isiPad}}
     {{preference-checkbox labelKey="user.enable_physical_keyboard" checked=disableSafariHacks  class="pref-safari-hacks"}}
   {{/if}}

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2028,6 +2028,7 @@ en:
     anonymous_account_duration_minutes: "To protect anonymity create a new anonymous account every N minutes for each user. Example: if set to 600, as soon as 600 minutes elapse from last post AND user switches to anon, a new anonymous account is created."
 
     hide_user_profiles_from_public: "Disable user cards, user profiles and user directory for anonymous users."
+    allow_users_to_hide_profile: "Allow users to hide their profile and presence"
 
     allow_featured_topic_on_user_profiles: "Allow users to feature a link to a topic on their user card and profile."
 

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -601,6 +601,9 @@ users:
   anonymous_account_duration_minutes:
     default: 10080
     max: 99000
+  allow_users_to_hide_profile:
+    default: true
+    client: true
   hide_user_profiles_from_public:
     default: false
     client: true

--- a/lib/guardian/user_guardian.rb
+++ b/lib/guardian/user_guardian.rb
@@ -111,6 +111,7 @@ module UserGuardian
 
   def can_see_profile?(user)
     return false if user.blank?
+    return true if !SiteSetting.allow_users_to_hide_profile?
 
     # If a user has hidden their profile, restrict it to them and staff
     if user.user_option.try(:hide_profile_and_presence?)

--- a/plugins/discourse-presence/assets/javascripts/discourse/lib/presence.js.es6
+++ b/plugins/discourse-presence/assets/javascripts/discourse/lib/presence.js.es6
@@ -102,7 +102,15 @@ const Presence = EmberObject.extend({
   },
 
   publish(state, whisper, postId, staffOnly) {
-    if (this.get("currentUser.hide_profile_and_presence")) {
+    var hiddenProfile = this.get("currentUser.user_option.hide_profile_and_presence");
+    if (hiddenProfile === undefined) {
+      hiddenProfile = this.get("currentUser.hide_profile_and_presence");
+    }
+
+    if (
+      hiddenProfile &&
+      this.get("siteSettings.allow_users_to_hide_profile")
+    ) {
       return;
     }
 

--- a/plugins/discourse-presence/assets/javascripts/discourse/lib/presence.js.es6
+++ b/plugins/discourse-presence/assets/javascripts/discourse/lib/presence.js.es6
@@ -102,15 +102,14 @@ const Presence = EmberObject.extend({
   },
 
   publish(state, whisper, postId, staffOnly) {
-    var hiddenProfile = this.get("currentUser.user_option.hide_profile_and_presence");
+    var hiddenProfile = this.get(
+      "currentUser.user_option.hide_profile_and_presence"
+    );
     if (hiddenProfile === undefined) {
       hiddenProfile = this.get("currentUser.hide_profile_and_presence");
     }
 
-    if (
-      hiddenProfile &&
-      this.get("siteSettings.allow_users_to_hide_profile")
-    ) {
+    if (hiddenProfile && this.get("siteSettings.allow_users_to_hide_profile")) {
       return;
     }
 

--- a/plugins/discourse-presence/assets/javascripts/discourse/lib/presence.js.es6
+++ b/plugins/discourse-presence/assets/javascripts/discourse/lib/presence.js.es6
@@ -102,7 +102,11 @@ const Presence = EmberObject.extend({
   },
 
   publish(state, whisper, postId, staffOnly) {
-    var hiddenProfile = this.get(
+    // NOTE: `user_option` is the correct place to get this value from, but
+    //       it may not have been set yet. It will always have been set directly
+    //       on the currentUser, via the preloaded_json payload.
+    // TODO: Remove this when preloaded_json is refactored.
+    let hiddenProfile = this.get(
       "currentUser.user_option.hide_profile_and_presence"
     );
     if (hiddenProfile === undefined) {

--- a/plugins/discourse-presence/plugin.rb
+++ b/plugins/discourse-presence/plugin.rb
@@ -155,7 +155,8 @@ after_initialize do
 
     def ensure_presence_enabled
       if !SiteSetting.presence_enabled ||
-         current_user.user_option.hide_profile_and_presence?
+         (SiteSetting.allow_users_to_hide_profile &&
+          current_user.user_option.hide_profile_and_presence?)
 
         raise Discourse::NotFound
       end

--- a/plugins/discourse-presence/spec/requests/presence_controller_spec.rb
+++ b/plugins/discourse-presence/spec/requests/presence_controller_spec.rb
@@ -45,6 +45,15 @@ describe ::Presence::PresencesController do
         expect(response.status).to eq(404)
       end
 
+      it 'returns the right response when user disables the presence feature and allow_users_to_hide_profile is disabled' do
+        user.user_option.update_column(:hide_profile_and_presence, true)
+        SiteSetting.allow_users_to_hide_profile = false
+
+        post '/presence/publish.json', params: { topic_id: public_topic.id, state: 'replying' }
+
+        expect(response.status).to eq(200)
+      end
+
       it 'returns the right response when the presence site settings is disabled' do
         SiteSetting.presence_enabled = false
 

--- a/spec/components/guardian/user_guardian_spec.rb
+++ b/spec/components/guardian/user_guardian_spec.rb
@@ -143,6 +143,10 @@ describe UserGuardian do
         expect(Guardian.new(admin).can_see_profile?(hidden_user)).to eq(true)
       end
 
+      it "is true if hiding profiles is disabled" do
+        SiteSetting.allow_users_to_hide_profile = false
+        expect(Guardian.new(user).can_see_profile?(hidden_user)).to eq(true)
+      end
     end
   end
 

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -603,10 +603,23 @@ RSpec.describe ListController do
       expect(json["topic_list"]["topics"].size).to eq(2)
     end
 
-    it "returns 404 if `hide_profile_and_presence` user option is checked" do
-      user.user_option.update_columns(hide_profile_and_presence: true)
-      get "/topics/created-by/#{user.username}.json"
-      expect(response.status).to eq(404)
+    context 'when `hide_profile_and_presence` is true' do
+      before do
+        user.user_option.update_columns(hide_profile_and_presence: true)
+      end
+
+      it "returns 404" do
+        get "/topics/created-by/#{user.username}.json"
+        expect(response.status).to eq(404)
+      end
+
+      it "should respond with a list when `allow_users_to_hide_profile` is false" do
+        SiteSetting.allow_users_to_hide_profile = false
+        get "/topics/created-by/#{user.username}.json"
+        expect(response.status).to eq(200)
+        json = response.parsed_body
+        expect(json["topic_list"]["topics"].size).to eq(2)
+      end
     end
   end
 

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -1752,6 +1752,17 @@ describe PostsController do
       get "/u/#{user.username}/activity.json"
       expect(response.status).to eq(404)
     end
+
+    it "succeeds when `allow_users_to_hide_profile` is false" do
+      user.user_option.update_columns(hide_profile_and_presence: true)
+      SiteSetting.allow_users_to_hide_profile = false
+
+      get "/u/#{user.username}/activity.rss"
+      expect(response.status).to eq(200)
+
+      get "/u/#{user.username}/activity.json"
+      expect(response.status).to eq(200)
+    end
   end
 
   describe '#latest' do

--- a/spec/requests/user_badges_controller_spec.rb
+++ b/spec/requests/user_badges_controller_spec.rb
@@ -44,13 +44,6 @@ describe UserBadgesController do
       expect(parsed["user_badges"].length).to eq(1)
     end
 
-    it "returns 404 if `hide_profile_and_presence` user option is checked" do
-      user.user_option.update_columns(hide_profile_and_presence: true)
-
-      get "/user-badges/#{user.username}.json"
-      expect(response.status).to eq(404)
-    end
-
     it 'returns user_badges for a user with period in username' do
       user.update!(username: "myname.test")
       get "/user-badges/#{user.username}", xhr: true
@@ -76,6 +69,24 @@ describe UserBadgesController do
       expect(response.status).to eq(200)
       parsed = response.parsed_body
       expect(parsed["user_badges"].first.has_key?('count')).to eq(true)
+    end
+
+    context 'hidden profiles' do
+      before do
+        user.user_option.update_columns(hide_profile_and_presence: true)
+      end
+
+      it "returns 404 if `hide_profile_and_presence` user option is checked" do
+        get "/user-badges/#{user.username}.json"
+        expect(response.status).to eq(404)
+      end
+
+      it "returns user_badges if `allow_users_to_hide_profile` is false" do
+        SiteSetting.allow_users_to_hide_profile = false
+
+        get "/user-badges/#{user.username}.json"
+        expect(response.status).to eq(200)
+      end
     end
   end
 


### PR DESCRIPTION
Implements a site setting to allow admins to disable the ability for individual users to hide the profile or presence to other users.