### PR TITLE
FIX: Observers weren't working on admin email logs

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-email-logs.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-email-logs.js
@@ -1,9 +1,14 @@
 import Controller from "@ember/controller";
 import EmailLog from "admin/models/email-log";
+import EmberObject from "@ember/object";
 
 export default Controller.extend({
   loading: false,
 
+  init() {
+    this._super(...arguments);
+    this.set("filter", EmberObject.create());
+  },
   loadLogs(sourceModel, loadMore) {
     if ((loadMore && this.loading) || this.get("model.allLoaded")) {
       return;
@@ -13,8 +18,14 @@ export default Controller.extend({
 
     sourceModel = sourceModel || EmailLog;
 
+    let args = {};
+    Object.keys(this.filter).forEach((k) => {
+      if (this.filter[k]) {
+        args[k] = this.filter[k];
+      }
+    });
     return sourceModel
-      .findAll(this.filter, loadMore ? this.get("model.length") : null)
+      .findAll(args, loadMore ? this.get("model.length") : null)
       .then((logs) => {
         if (this.model && loadMore && logs.length < 50) {
           this.model.set("allLoaded", true);

--- a/app/assets/javascripts/admin/addon/routes/admin-email-incomings.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-email-incomings.js
@@ -8,6 +8,6 @@ export default DiscourseRoute.extend({
 
   setupController(controller, model) {
     controller.set("model", model);
-    controller.set("filter", { status: this.status });
+    controller.set("filter.status", this.status);
   },
 });


### PR DESCRIPTION
We were trying to observe a non-ember object which is undefined
behavior and was leaking to odd bugs. This replaces the `filter` object
with an Ember Object and things seem to work.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
