### PR TITLE
DEV: Fix an apparently "too modern" git command

### DIFF
--- a/spec/components/version_spec.rb
+++ b/spec/components/version_spec.rb
@@ -106,7 +106,7 @@ describe Discourse::VERSION do
 
         # Simulate a remote upstream
         `cd #{path} && git remote add origin #{path}/.git && git fetch -q`
-        `cd #{path} && git branch -u origin/$(git branch --show-current)`
+        `cd #{path} && git branch -u origin/$(git rev-parse --abbrev-ref HEAD)`
       end
 
       path


### PR DESCRIPTION
A follow-up to a follow-up. (6932a373a34a7150f8514af7edaf9048cc719a7d and 572da7a57b7ec672fcde673a5d7ac4ce555f249d)
Our `discourse_test` Docker image uses git 2.20.1 released on Dec 15, 2018. It does not support `git branch --show-current`. (it was added in 2.22.0)
