### PR TITLE
UX: New Topics Will Appear Here display changes

### DIFF
--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -302,7 +302,12 @@ ol.category-breadcrumb {
 }
 
 div.education {
-  color: var(--primary-med-or-secondary-med);
+  color: var(--primary);
+  padding: 1em 2.5em 1em 1em;
+  margin-bottom: 2em;
+  border-top: 2px solid var(--primary-low);
+  border-bottom: 1px solid var(--primary-low);
+    
   .badge-notification.new-posts {
     vertical-align: text-bottom;
   }

--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -305,7 +305,7 @@ div.education {
   color: var(--primary);
   padding: 1em 2.5em 1em 1em;
   margin-bottom: 2em;
-  border-top: 2px solid var(--primary-low);
+  border-top: 3px solid var(--primary-low);
   border-bottom: 1px solid var(--primary-low);
     
   .badge-notification.new-posts {

--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -307,7 +307,7 @@ div.education {
   margin-bottom: 2em;
   border-top: 3px solid var(--primary-low);
   border-bottom: 1px solid var(--primary-low);
-    
+
   .badge-notification.new-posts {
     vertical-align: text-bottom;
   }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2190,7 +2190,8 @@ en:
         category: "There are no %{category} topics."
         top: "There are no top topics."
         educate:
-          new: '<p>New topics will appear here. Topics created within the last 2 days are considered new and will show a <span class="badge new-topic badge-notification" style="vertical-align:middle;line-height:inherit;"></span> indicator. This setting can be changed in your <a href="%{userPrefsUrl}">preferences</a>.</p>'
+          new: '<p>Your new topics will appear here. By default, topics are considered new and will show a <span class="badge new-topic badge-notification" style="vertical-align:middle;line-height:inherit;"></span> indicator if they were created in the last 2 days.</p><p>Visit your <a href="%{userPrefsUrl}">preferences</a> to change this.</p>'
+          unread: '<p>Your unread topics appear here.</p><p>By default, topics are considered unread and will show unread counts <span class="badge new-posts badge-notification">1</span> if you:</p><ul><li>Created the topic</li><li>Replied to the topic</li><li>Read the topic for more than 4 minutes</li></ul><p>Or if you have explicitly set the topic to Tracked or Watched via the notification control at the bottom of each topic.</p><p>Visit your <a href="%{userPrefsUrl}">preferences</a> to change this.</p>'
       bottom:
         latest: "There are no more latest topics."
         posted: "There are no more posted topics."

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2190,8 +2190,7 @@ en:
         category: "There are no %{category} topics."
         top: "There are no top topics."
         educate:
-          new: '<p>Your new topics appear here.</p><p>By default, topics are considered new and will show a <span class="badge new-topic badge-notification" style="vertical-align:middle;line-height:inherit;">new</span> indicator if they were created in the last 2 days.</p><p>Visit your <a href="%{userPrefsUrl}">preferences</a> to change this.</p>'
-          unread: '<p>Your unread topics appear here.</p><p>By default, topics are considered unread and will show unread counts <span class="badge new-posts badge-notification">1</span> if you:</p><ul><li>Created the topic</li><li>Replied to the topic</li><li>Read the topic for more than 4 minutes</li></ul><p>Or if you have explicitly set the topic to Tracked or Watched via the notification control at the bottom of each topic.</p><p>Visit your <a href="%{userPrefsUrl}">preferences</a> to change this.</p>'
+          new: '<p>New topics will appear here. Topics created within the last 2 days are considered new and will show a <span class="badge new-topic badge-notification" style="vertical-align:middle;line-height:inherit;"></span> indicator. This setting can be changed in your <a href="%{userPrefsUrl}">preferences</a>.</p>'
       bottom:
         latest: "There are no more latest topics."
         posted: "There are no more posted topics."


### PR DESCRIPTION
This PR will change the way the `new topics will appear here` message displays.

### New
![image](https://user-images.githubusercontent.com/30537603/95789183-a9ec4100-0ca2-11eb-8ad4-8ad1de4772fd.png)


versus

### Old
![image](https://user-images.githubusercontent.com/30537603/95788994-495d0400-0ca2-11eb-8a0f-c0f740b327ae.png)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
