### PR TITLE
FEATURE: Add weekly bookmark cleanup code

### DIFF
--- a/app/jobs/scheduled/weekly.rb
+++ b/app/jobs/scheduled/weekly.rb
@@ -14,6 +14,7 @@ module Jobs
       UserAuthToken.cleanup!
       Email::Cleaner.delete_rejected!
       Notification.purge_old!
+      Bookmark.cleanup!
     end
   end
 end

--- a/spec/models/bookmark_spec.rb
+++ b/spec/models/bookmark_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Bookmark do
+  describe "#cleanup!" do
+    it "deletes bookmarks attached to a deleted post which has been deleted for > 3 days" do
+      post = Fabricate(:post)
+      bookmark = Fabricate(:bookmark, post: post, topic: post.topic)
+      bookmark2 = Fabricate(:bookmark)
+      post.trash!
+      post.update(deleted_at: 4.days.ago)
+      Bookmark.cleanup!
+      expect(Bookmark.find_by(id: bookmark.id)).to eq(nil)
+      expect(Bookmark.find_by(id: bookmark2.id)).to eq(bookmark2)
+    end
+
+    it "deletes bookmarks attached to a deleted topic which has been deleted for > 3 days" do
+      post = Fabricate(:post)
+      bookmark = Fabricate(:bookmark, post: post, topic: post.topic)
+      bookmark2 = Fabricate(:bookmark)
+      post.topic.trash!
+      post.topic.update(deleted_at: 4.days.ago)
+      Bookmark.cleanup!
+      expect(Bookmark.find_by(id: bookmark.id)).to eq(nil)
+      expect(Bookmark.find_by(id: bookmark2.id)).to eq(bookmark2)
+    end
+
+    it "does not delete bookmarks attached to posts that are not deleted or that have not met the 3 day grace period" do
+      post = Fabricate(:post)
+      bookmark = Fabricate(:bookmark, post: post, topic: post.topic)
+      bookmark2 = Fabricate(:bookmark)
+      Bookmark.cleanup!
+      expect(Bookmark.find(bookmark.id)).to eq(bookmark)
+      post.trash!
+      Bookmark.cleanup!
+      expect(Bookmark.find(bookmark.id)).to eq(bookmark)
+      expect(Bookmark.find_by(id: bookmark2.id)).to eq(bookmark2)
+    end
+  end
+end

--- a/spec/models/bookmark_spec.rb
+++ b/spec/models/bookmark_spec.rb
@@ -7,7 +7,7 @@ describe Bookmark do
     it "deletes bookmarks attached to a deleted post which has been deleted for > 3 days" do
       post = Fabricate(:post)
       bookmark = Fabricate(:bookmark, post: post, topic: post.topic)
-      bookmark2 = Fabricate(:bookmark)
+      bookmark2 = Fabricate(:bookmark, post: Fabricate(:post, topic: post.topic))
       post.trash!
       post.update(deleted_at: 4.days.ago)
       Bookmark.cleanup!
@@ -18,12 +18,14 @@ describe Bookmark do
     it "deletes bookmarks attached to a deleted topic which has been deleted for > 3 days" do
       post = Fabricate(:post)
       bookmark = Fabricate(:bookmark, post: post, topic: post.topic)
-      bookmark2 = Fabricate(:bookmark)
+      bookmark2 = Fabricate(:bookmark, topic: post.topic, post: Fabricate(:post, topic: post.topic))
+      bookmark3 = Fabricate(:bookmark)
       post.topic.trash!
       post.topic.update(deleted_at: 4.days.ago)
       Bookmark.cleanup!
       expect(Bookmark.find_by(id: bookmark.id)).to eq(nil)
-      expect(Bookmark.find_by(id: bookmark2.id)).to eq(bookmark2)
+      expect(Bookmark.find_by(id: bookmark2.id)).to eq(nil)
+      expect(Bookmark.find_by(id: bookmark3.id)).to eq(bookmark3)
     end
 
     it "does not delete bookmarks attached to posts that are not deleted or that have not met the 3 day grace period" do


### PR DESCRIPTION
When posts or topics are deleted we don't want to immediately delete associated bookmarks, so we have a grace period to recover them and their reminders if the post or topic is un-deleted. This PR adds a task to the `Weekly` scheduled job to go and delete bookmarks attached to posts or topics deleted > 3 days ago.
