### PR TITLE
DEV: ensure queue_time and background_requests are floats

### DIFF
--- a/lib/middleware/anonymous_cache.rb
+++ b/lib/middleware/anonymous_cache.rb
@@ -330,7 +330,8 @@ module Middleware
       end
 
       if (env["HTTP_DISCOURSE_BACKGROUND"] == "true") && (queue_time = env["REQUEST_QUEUE_SECONDS"])
-        if queue_time > GlobalSetting.background_requests_max_queue_length
+        max_time = GlobalSetting.background_requests_max_queue_length.to_f
+        if max_time > 0 && queue_time.to_f > max_time
           return [
             429,
             {

--- a/spec/components/middleware/anonymous_cache_spec.rb
+++ b/spec/components/middleware/anonymous_cache_spec.rb
@@ -136,7 +136,7 @@ describe Middleware::AnonymousCache do
         end
       )
 
-      global_setting :background_requests_max_queue_length, 1
+      global_setting :background_requests_max_queue_length, "0.5"
 
       env = {
         "HTTP_COOKIE" => "_t=#{SecureRandom.hex}",
@@ -161,7 +161,7 @@ describe Middleware::AnonymousCache do
       json = JSON.parse(body.join)
       expect(json["extras"]["wait_seconds"]).to be > 4.9
 
-      env["REQUEST_QUEUE_SECONDS"] = 0.5
+      env["REQUEST_QUEUE_SECONDS"] = 0.4
 
       status, _ = app.call(env.dup)
       expect(status).to eq(200)


### PR DESCRIPTION
GlobalSetting can end up with a String and we expect a Float
