### PR TITLE
DEV: Make notify_file_change fallback to `nc` when `socat` missing

### DIFF
--- a/bin/notify_file_change
+++ b/bin/notify_file_change
@@ -6,7 +6,11 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd ../tmp && pwd )"
 SOCKET="$DIR"/file_change.sock
 
 if [[ -e "$SOCKET" ]]; then
-  echo "$1 $2" | socat - UNIX-CONNECT:$SOCKET >/dev/null 2>/dev/null
+  if command -v socat; then
+    echo "$1 $2" | socat - UNIX-CONNECT:$SOCKET >/dev/null 2>/dev/null
+  else
+    echo "$1 $2" | nc -U $SOCKET >/dev/null 2>/dev/null
+  fi
   if [ $? != 0 ]; then
     rm $SOCKET
   fi


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
