### PR TITLE
FEATURE: Topic slow mode.

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-messages.js
+++ b/app/assets/javascripts/discourse/app/components/composer-messages.js
@@ -4,7 +4,7 @@ import EmberObject from "@ember/object";
 import { scheduleOnce } from "@ember/runloop";
 import Component from "@ember/component";
 import LinkLookup from "discourse/lib/link-lookup";
-import { intervalTextFromSeconds } from "discourse/helpers/slow-mode";
+import { durationTextFromSeconds } from "discourse/helpers/slow-mode";
 
 let _messagesCache = {};
 
@@ -117,7 +117,7 @@ export default Component.extend({
       }
     }
 
-    const topic = composer.get("topic");
+    const topic = composer.topic;
     if (topic && topic.slow_mode_seconds) {
       const msg = composer.store.createRecord("composer-message", {
         id: "slow-mode-enabled",
@@ -125,7 +125,7 @@ export default Component.extend({
         templateName: "custom-body",
         title: I18n.t("composer.slow_mode.title"),
         body: I18n.t("composer.slow_mode.body", {
-          interval: intervalTextFromSeconds(topic.slow_mode_seconds),
+          duration: durationTextFromSeconds(topic.slow_mode_seconds),
         }),
       });
 
@@ -196,11 +196,11 @@ export default Component.extend({
 
     const composer = this.composer;
     const args = { composer_action: composer.get("action") };
-    const topic = composer.get("topic.id");
+    const topicId = composer.get("topic.id");
     const postId = composer.get("post.id");
 
-    if (topic && topic.id) {
-      args.topic_id = topic.id;
+    if (topicId) {
+      args.topic_id = topicId;
     }
     if (postId) {
       args.post_id = postId;

--- a/app/assets/javascripts/discourse/app/components/composer-messages.js
+++ b/app/assets/javascripts/discourse/app/components/composer-messages.js
@@ -117,6 +117,21 @@ export default Component.extend({
       }
     }
 
+    const topic = composer.get("topic");
+    if (topic && topic.slow_mode_seconds) {
+      const msg = composer.store.createRecord("composer-message", {
+        id: "slow-mode-enabled",
+        extraClass: "custom-body",
+        templateName: "custom-body",
+        title: I18n.t("composer.slow_mode.title"),
+        body: I18n.t("composer.slow_mode.body", {
+          interval: intervalTextFromSeconds(topic.slow_mode_seconds),
+        }),
+      });
+
+      this.send("popup", msg);
+    }
+
     this.queuedForTyping.forEach((msg) => this.send("popup", msg));
   },
 
@@ -181,21 +196,8 @@ export default Component.extend({
 
     const composer = this.composer;
     const args = { composer_action: composer.get("action") };
-    const topic = composer.get("topic");
+    const topic = composer.get("topic.id");
     const postId = composer.get("post.id");
-
-    if (topic && topic.slow_mode_seconds) {
-      const msg = composer.store.createRecord("composer-message", {
-        id: "slow-mode-enabled",
-        extraClass: "custom-body",
-        templateName: "custom-body",
-        title: I18n.t("composer.slow_mode.title"),
-        body: I18n.t("composer.slow_mode.body", {
-          interval: intervalTextFromSeconds(topic.slow_mode_seconds),
-        }),
-      });
-      this.send("popup", msg);
-    }
 
     if (topic && topic.id) {
       args.topic_id = topic.id;

--- a/app/assets/javascripts/discourse/app/components/slow-mode-info.js
+++ b/app/assets/javascripts/discourse/app/components/slow-mode-info.js
@@ -1,13 +1,14 @@
-import { intervalTextFromSeconds } from "discourse/helpers/slow-mode";
+import { durationTextFromSeconds } from "discourse/helpers/slow-mode";
 import Component from "@ember/component";
 import discourseComputed from "discourse-common/utils/decorators";
 import Topic from "discourse/models/topic";
 import { popupAjaxError } from "discourse/lib/ajax-error";
+import { action } from "@ember/object";
 
 export default Component.extend({
   @discourseComputed("topic.slow_mode_seconds")
-  intervalText(seconds) {
-    return intervalTextFromSeconds(seconds);
+  durationText(seconds) {
+    return durationTextFromSeconds(seconds);
   },
 
   @discourseComputed("topic.slow_mode_seconds", "topic.closed")
@@ -15,11 +16,10 @@ export default Component.extend({
     return seconds > 0 && !closed;
   },
 
-  actions: {
-    disableSlowMode() {
-      Topic.setSlowMode(this.topic.id, 0)
-        .catch(popupAjaxError)
-        .then(() => this.set("topic.slow_mode_seconds", 0));
-    },
+  @action
+  disableSlowMode() {
+    Topic.setSlowMode(this.topic.id, 0)
+      .catch(popupAjaxError)
+      .then(() => this.set("topic.slow_mode_seconds", 0));
   },
 });

--- a/app/assets/javascripts/discourse/app/components/slow-mode-info.js
+++ b/app/assets/javascripts/discourse/app/components/slow-mode-info.js
@@ -1,0 +1,25 @@
+import { intervalTextFromSeconds } from "discourse/helpers/slow-mode";
+import Component from "@ember/component";
+import discourseComputed from "discourse-common/utils/decorators";
+import Topic from "discourse/models/topic";
+import { popupAjaxError } from "discourse/lib/ajax-error";
+
+export default Component.extend({
+  @discourseComputed("topic.slow_mode_seconds")
+  intervalText(seconds) {
+    return intervalTextFromSeconds(seconds);
+  },
+
+  @discourseComputed("topic.slow_mode_seconds", "topic.closed")
+  showSlowModeNotice(seconds, closed) {
+    return seconds > 0 && !closed;
+  },
+
+  actions: {
+    disableSlowMode() {
+      Topic.setSlowMode(this.topic.id, 0)
+        .catch(popupAjaxError)
+        .then(() => this.set("topic.slow_mode_seconds", 0));
+    },
+  },
+});

--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -28,7 +28,6 @@ import { isTesting } from "discourse-common/config/environment";
 import EmberObject, { computed, action } from "@ember/object";
 import deprecated from "discourse-common/lib/deprecated";
 import bootbox from "bootbox";
-import { cannotPostAgain } from "discourse/helpers/slow-mode";
 
 function loadDraft(store, opts) {
   let promise = Promise.resolve();
@@ -645,17 +644,6 @@ export default Controller.extend({
     if (composer.cantSubmitPost) {
       this.set("lastValidatedAt", Date.now());
       return;
-    }
-
-    const topic = composer.get("topic");
-
-    if (topic.slow_mode_seconds && topic.user_last_posted_at) {
-      if (cannotPostAgain(topic.slow_mode_seconds, topic.user_last_posted_at)) {
-        const message = I18n.t("composer.slow_mode.error");
-
-        bootbox.alert(message);
-        return;
-      }
     }
 
     composer.set("disableDrafts", true);

--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -28,6 +28,7 @@ import { isTesting } from "discourse-common/config/environment";
 import EmberObject, { computed, action } from "@ember/object";
 import deprecated from "discourse-common/lib/deprecated";
 import bootbox from "bootbox";
+import { cannotPostAgain } from "discourse/helpers/slow-mode";
 
 function loadDraft(store, opts) {
   let promise = Promise.resolve();
@@ -644,6 +645,17 @@ export default Controller.extend({
     if (composer.cantSubmitPost) {
       this.set("lastValidatedAt", Date.now());
       return;
+    }
+
+    const topic = composer.get("topic");
+
+    if (topic.slow_mode_seconds && topic.user_last_posted_at) {
+      if (cannotPostAgain(topic.slow_mode_seconds, topic.user_last_posted_at)) {
+        const message = I18n.t("composer.slow_mode.error");
+
+        bootbox.alert(message);
+        return;
+      }
     }
 
     composer.set("disableDrafts", true);

--- a/app/assets/javascripts/discourse/app/controllers/edit-slow-mode.js
+++ b/app/assets/javascripts/discourse/app/controllers/edit-slow-mode.js
@@ -5,6 +5,8 @@ import I18n from "I18n";
 import Topic from "discourse/models/topic";
 import { fromSeconds, toSeconds } from "discourse/helpers/slow-mode";
 import { popupAjaxError } from "discourse/lib/ajax-error";
+import { equal } from "@ember/object/computed";
+import { action } from "@ember/object";
 
 export default Controller.extend(ModalFunctionality, {
   selectedSlowMode: null,
@@ -12,55 +14,55 @@ export default Controller.extend(ModalFunctionality, {
   minutes: null,
   seconds: null,
   saveDisabled: false,
+  showCustomSelect: equal("selectedSlowMode", "custom"),
 
-  slowModes: [
-    {
-      id: "900",
-      name: I18n.t("topic.slow_mode_update.intervals.15_minutes"),
-    },
-    {
-      id: "3600",
-      name: I18n.t("topic.slow_mode_update.intervals.1_hour"),
-    },
-    {
-      id: "14400",
-      name: I18n.t("topic.slow_mode_update.intervals.4_hours"),
-    },
-    {
-      id: "86400",
-      name: I18n.t("topic.slow_mode_update.intervals.1_day"),
-    },
-    {
-      id: "604800",
-      name: I18n.t("topic.slow_mode_update.intervals.1_week"),
-    },
-    {
-      id: "custom",
-      name: I18n.t("topic.slow_mode_update.intervals.custom"),
-    },
-  ],
+  init() {
+    this._super(...arguments);
+
+    this.set("slowModes", [
+      {
+        id: "900",
+        name: I18n.t("topic.slow_mode_update.durations.15_minutes"),
+      },
+      {
+        id: "3600",
+        name: I18n.t("topic.slow_mode_update.durations.1_hour"),
+      },
+      {
+        id: "14400",
+        name: I18n.t("topic.slow_mode_update.durations.4_hours"),
+      },
+      {
+        id: "86400",
+        name: I18n.t("topic.slow_mode_update.durations.1_day"),
+      },
+      {
+        id: "604800",
+        name: I18n.t("topic.slow_mode_update.durations.1_week"),
+      },
+      {
+        id: "custom",
+        name: I18n.t("topic.slow_mode_update.durations.custom"),
+      },
+    ]);
+  },
 
   onShow() {
-    const currentInterval = parseInt(this.model.slow_mode_seconds, 10);
+    const currentDuration = parseInt(this.model.slow_mode_seconds, 10);
 
-    if (currentInterval) {
-      const selectedInterval = this.slowModes.find((mode) => {
-        return mode.id === currentInterval.toString();
+    if (currentDuration) {
+      const selectedDuration = this.slowModes.find((mode) => {
+        return mode.id === currentDuration.toString();
       });
 
-      if (selectedInterval) {
-        this.set("selectedSlowMode", currentInterval.toString());
+      if (selectedDuration) {
+        this.set("selectedSlowMode", currentDuration.toString());
       } else {
         this.set("selectedSlowMode", "custom");
       }
 
-      this._setFromSeconds(currentInterval);
+      this._setFromSeconds(currentDuration);
     }
-  },
-
-  @discourseComputed("selectedSlowMode")
-  showCustomSelect(mode) {
-    return mode === "custom";
   },
 
   @discourseComputed("hours", "minutes", "seconds")
@@ -72,38 +74,39 @@ export default Controller.extend(ModalFunctionality, {
     this.setProperties(fromSeconds(seconds));
   },
 
-  actions: {
-    setSlowModeInterval(interval) {
-      if (interval !== "custom") {
-        let seconds = parseInt(interval, 10);
+  @action
+  setSlowModeDuration(duration) {
+    if (duration !== "custom") {
+      let seconds = parseInt(duration, 10);
 
-        this._setFromSeconds(seconds);
-      }
+      this._setFromSeconds(seconds);
+    }
 
-      this.set("selectedSlowMode", interval);
-    },
+    this.set("selectedSlowMode", duration);
+  },
 
-    enableSlowMode() {
-      this.set("saveDisabled", true);
-      const seconds = toSeconds(this.hours, this.minutes, this.seconds);
-      Topic.setSlowMode(this.model.id, seconds)
-        .catch(popupAjaxError)
-        .then(() => {
-          this.set("model.slow_mode_seconds", seconds);
-          this.send("closeModal");
-        })
-        .finally(() => this.set("saveDisabled", false));
-    },
+  @action
+  enableSlowMode() {
+    this.set("saveDisabled", true);
+    const seconds = toSeconds(this.hours, this.minutes, this.seconds);
+    Topic.setSlowMode(this.model.id, seconds)
+      .catch(popupAjaxError)
+      .then(() => {
+        this.set("model.slow_mode_seconds", seconds);
+        this.send("closeModal");
+      })
+      .finally(() => this.set("saveDisabled", false));
+  },
 
-    disableSlowMode() {
-      this.set("saveDisabled", true);
-      Topic.setSlowMode(this.model.id, 0)
-        .catch(popupAjaxError)
-        .then(() => {
-          this.set("model.slow_mode_seconds", 0);
-          this.send("closeModal");
-        })
-        .finally(() => this.set("saveDisabled", false));
-    },
+  @action
+  disableSlowMode() {
+    this.set("saveDisabled", true);
+    Topic.setSlowMode(this.model.id, 0)
+      .catch(popupAjaxError)
+      .then(() => {
+        this.set("model.slow_mode_seconds", 0);
+        this.send("closeModal");
+      })
+      .finally(() => this.set("saveDisabled", false));
   },
 });

--- a/app/assets/javascripts/discourse/app/controllers/edit-slow-mode.js
+++ b/app/assets/javascripts/discourse/app/controllers/edit-slow-mode.js
@@ -1,0 +1,130 @@
+import Controller from "@ember/controller";
+import ModalFunctionality from "discourse/mixins/modal-functionality";
+import discourseComputed from "discourse-common/utils/decorators";
+import I18n from "I18n";
+import Topic from "discourse/models/topic";
+
+export default Controller.extend(ModalFunctionality, {
+  selectedSlowMode: null,
+  hours: null,
+  minutes: null,
+  seconds: null,
+  saveDisabled: false,
+
+  slowModes: [
+    {
+      id: "900",
+      name: I18n.t("topic.slow_mode_update.intervals.15_minutes"),
+    },
+    {
+      id: "3600",
+      name: I18n.t("topic.slow_mode_update.intervals.1_hour"),
+    },
+    {
+      id: "14400",
+      name: I18n.t("topic.slow_mode_update.intervals.4_hours"),
+    },
+    {
+      id: "86400",
+      name: I18n.t("topic.slow_mode_update.intervals.1_day"),
+    },
+    {
+      id: "604800",
+      name: I18n.t("topic.slow_mode_update.intervals.1_week"),
+    },
+    {
+      id: "custom",
+      name: I18n.t("topic.slow_mode_update.intervals.custom")
+    }
+  ],
+
+  onShow() {
+    const currentInterval = parseInt(this.model.slow_mode_seconds, 10);
+
+    if (currentInterval) {
+      const selectedInterval = this.slowModes.find((mode) => {
+        return mode.id === currentInterval.toString();
+      })
+
+      if (selectedInterval) {
+        this.set("selectedSlowMode", currentInterval.toString());
+      } else {
+        this.set("selectedSlowMode", "custom");
+      }
+
+      this._setFromSeconds(currentInterval);
+    }
+  },
+
+  @discourseComputed("selectedSlowMode")
+  showCustomSelect(mode) {
+    return mode === "custom";
+  },
+
+  @discourseComputed("hours", "minutes", "seconds")
+  submitDisabled(hours, minutes, seconds) {
+    return this.saveDisabled || !(this.hours || this.minutes || this.seconds);
+  },
+
+  _setFromSeconds(seconds) {
+    let initialSeconds = seconds
+
+    let hours = initialSeconds / 3600
+    if (hours >= 1) {
+      initialSeconds = initialSeconds - (3600 * hours)
+    } else {
+      hours = 0
+    }
+
+    let minutes = initialSeconds / 60
+    if (minutes >= 1) {
+      initialSeconds = initialSeconds - (60 * minutes)  
+    } else {
+      minutes = 0
+    }
+
+    this.setProperties({
+      hours: hours,
+      minutes: minutes,
+      seconds: initialSeconds
+    })
+  },
+
+  _toSeconds() {
+    const hoursAsSeconds = parseInt(this.hours, 10) * 60 * 60
+    const minutesAsSeconds = parseInt(this.minutes, 10) * 60
+
+    return parseInt(this.seconds, 10) + hoursAsSeconds + minutesAsSeconds
+  },
+
+  actions: {
+    setSlowModeInterval(interval) {
+      if (interval !== "custom") {
+        let seconds = parseInt(interval, 10);
+        
+        this._setFromSeconds(seconds);
+      }
+
+      this.set("selectedSlowMode", interval);
+    },
+
+    enableSlowMode() {
+      this.set("saveDisabled", true);
+      const seconds = this._toSeconds()
+      Topic.setSlowMode(this.model.id, seconds).finally(() => {
+        this.set("model.slow_mode_seconds", seconds);
+        this.set("saveDisabled", false);
+      });
+    },
+
+    disableSlowMode() {
+      this.set("saveDisabled", true);
+      Topic.setSlowMode(this.model.id, 0).finally(() => { 
+        this.set("model.slow_mode_seconds", 0);
+        this.set("saveDisabled", false);
+      });
+    },
+  }
+})
+
+

--- a/app/assets/javascripts/discourse/app/helpers/slow-mode.js
+++ b/app/assets/javascripts/discourse/app/helpers/slow-mode.js
@@ -1,5 +1,3 @@
-import I18n from "I18n";
-
 export function fromSeconds(seconds) {
   let initialSeconds = seconds;
 
@@ -17,11 +15,7 @@ export function fromSeconds(seconds) {
     minutes = 0;
   }
 
-  return {
-    hours: hours,
-    minutes: minutes,
-    seconds: initialSeconds,
-  };
+  return { hours, minutes, seconds: initialSeconds };
 }
 
 export function toSeconds(hours, minutes, seconds) {
@@ -31,37 +25,6 @@ export function toSeconds(hours, minutes, seconds) {
   return parseInt(seconds, 10) + hoursAsSeconds + minutesAsSeconds;
 }
 
-export function intervalTextFromSeconds(seconds) {
-  const { hours, minutes, secs } = fromSeconds(seconds);
-  let hasHours = hours > 0;
-  let hasMinutes = minutes > 0;
-
-  if (!hasHours && !hasMinutes) {
-    return I18n.t("topic.slow_mode_intervals.seconds", { seconds: secs });
-  }
-
-  if (hasHours && hours >= 24) {
-    let days = hours / 24;
-    return I18n.t("topic.slow_mode_intervals.days", { days: days });
-  }
-
-  if (hasHours) {
-    if (hasMinutes) {
-      return I18n.t("topic.slow_mode_intervals.hours_and_minutes", {
-        hours: hours,
-        minutes: minutes,
-      });
-    } else {
-      return I18n.t("topic.slow_mode_intervals.hours", { hours: hours });
-    }
-  } else {
-    return I18n.t("topic.slow_mode_intervals.minutes", { minutes: minutes });
-  }
-}
-
-export function cannotPostAgain(interval, last_posted_at) {
-  let threshold = new Date(last_posted_at);
-  threshold = new Date(threshold.getTime() + interval * 1000);
-
-  return new Date() < threshold;
+export function durationTextFromSeconds(seconds) {
+  return moment.duration(seconds, "seconds").humanize();
 }

--- a/app/assets/javascripts/discourse/app/helpers/slow-mode.js
+++ b/app/assets/javascripts/discourse/app/helpers/slow-mode.js
@@ -58,3 +58,10 @@ export function intervalTextFromSeconds(seconds) {
     return I18n.t("topic.slow_mode_intervals.minutes", { minutes: minutes });
   }
 }
+
+export function cannotPostAgain(interval, last_posted_at) {
+  let threshold = new Date(last_posted_at);
+  threshold = new Date(threshold.getTime() + interval * 1000);
+
+  return new Date() < threshold;
+}

--- a/app/assets/javascripts/discourse/app/helpers/slow-mode.js
+++ b/app/assets/javascripts/discourse/app/helpers/slow-mode.js
@@ -1,0 +1,60 @@
+import I18n from "I18n";
+
+export function fromSeconds(seconds) {
+  let initialSeconds = seconds;
+
+  let hours = initialSeconds / 3600;
+  if (hours >= 1) {
+    initialSeconds = initialSeconds - 3600 * hours;
+  } else {
+    hours = 0;
+  }
+
+  let minutes = initialSeconds / 60;
+  if (minutes >= 1) {
+    initialSeconds = initialSeconds - 60 * minutes;
+  } else {
+    minutes = 0;
+  }
+
+  return {
+    hours: hours,
+    minutes: minutes,
+    seconds: initialSeconds,
+  };
+}
+
+export function toSeconds(hours, minutes, seconds) {
+  const hoursAsSeconds = parseInt(hours, 10) * 60 * 60;
+  const minutesAsSeconds = parseInt(minutes, 10) * 60;
+
+  return parseInt(seconds, 10) + hoursAsSeconds + minutesAsSeconds;
+}
+
+export function intervalTextFromSeconds(seconds) {
+  const { hours, minutes, secs } = fromSeconds(seconds);
+  let hasHours = hours > 0;
+  let hasMinutes = minutes > 0;
+
+  if (!hasHours && !hasMinutes) {
+    return I18n.t("topic.slow_mode_intervals.seconds", { seconds: secs });
+  }
+
+  if (hasHours && hours >= 24) {
+    let days = hours / 24;
+    return I18n.t("topic.slow_mode_intervals.days", { days: days });
+  }
+
+  if (hasHours) {
+    if (hasMinutes) {
+      return I18n.t("topic.slow_mode_intervals.hours_and_minutes", {
+        hours: hours,
+        minutes: minutes,
+      });
+    } else {
+      return I18n.t("topic.slow_mode_intervals.hours", { hours: hours });
+    }
+  } else {
+    return I18n.t("topic.slow_mode_intervals.minutes", { minutes: minutes });
+  }
+}

--- a/app/assets/javascripts/discourse/app/models/topic.js
+++ b/app/assets/javascripts/discourse/app/models/topic.js
@@ -849,7 +849,7 @@ Topic.reopenClass({
   setSlowMode(topicId, seconds) {
     const data = { seconds };
     return ajax(`/t/${topicId}/slow_mode`, { type: "PUT", data });
-  }
+  },
 });
 
 function moveResult(result) {

--- a/app/assets/javascripts/discourse/app/models/topic.js
+++ b/app/assets/javascripts/discourse/app/models/topic.js
@@ -845,6 +845,11 @@ Topic.reopenClass({
   idForSlug(slug) {
     return ajax(`/t/id_for/${slug}`);
   },
+
+  setSlowMode(topicId, seconds) {
+    const data = { seconds };
+    return ajax(`/t/${topicId}/slow_mode`, { type: "PUT", data });
+  }
 });
 
 function moveResult(result) {

--- a/app/assets/javascripts/discourse/app/routes/topic.js
+++ b/app/assets/javascripts/discourse/app/routes/topic.js
@@ -118,6 +118,12 @@ const TopicRoute = DiscourseRoute.extend({
       this.controllerFor("modal").set("modalClass", "edit-topic-timer-modal");
     },
 
+    showTopicSlowModeUpdate() {
+      const model = this.modelFor("topic");
+
+      showModal("edit-slow-mode", { model });
+    },
+
     showChangeTimestamp() {
       showModal("change-timestamp", {
         model: this.modelFor("topic"),

--- a/app/assets/javascripts/discourse/app/templates/components/slow-mode-info.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/slow-mode-info.hbs
@@ -1,0 +1,14 @@
+{{#if showSlowModeNotice}}
+  <div class="topic-status-info">
+    <h3 class="slow-mode-heading">
+      <span>
+        {{d-icon "hourglass-end"}}
+        {{i18n "topic.slow_mode_notice.interval" interval=intervalText}}
+      </span>
+
+      {{d-button class="slow-mode-remove"
+        action=(action "disableSlowMode")
+        icon="trash-alt"}}
+    </h3>
+  </div>
+{{/if}}

--- a/app/assets/javascripts/discourse/app/templates/components/slow-mode-info.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/slow-mode-info.hbs
@@ -3,12 +3,12 @@
     <h3 class="slow-mode-heading">
       <span>
         {{d-icon "hourglass-end"}}
-        {{i18n "topic.slow_mode_notice.interval" interval=intervalText}}
+        {{i18n "topic.slow_mode_notice.duration" duration=durationText}}
       </span>
 
       {{d-button class="slow-mode-remove"
-        action=(action "disableSlowMode")
-        icon="trash-alt"}}
+                 action=(action "disableSlowMode")
+                 icon="trash-alt"}}
     </h3>
   </div>
 {{/if}}

--- a/app/assets/javascripts/discourse/app/templates/components/topic-footer-buttons.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/topic-footer-buttons.hbs
@@ -3,6 +3,7 @@
     topic=topic
     openUpwards="true"
     toggleMultiSelect=toggleMultiSelect
+    showTopicSlowModeUpdate=showTopicSlowModeUpdate
     deleteTopic=deleteTopic
     recoverTopic=recoverTopic
     toggleFeaturedOnProfile=toggleFeaturedOnProfile

--- a/app/assets/javascripts/discourse/app/templates/modal/edit-slow-mode.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/edit-slow-mode.hbs
@@ -1,15 +1,15 @@
-{{#d-modal-body title="topic.slow_mode_update.title" autoFocus="false"}}
+{{#d-modal-body title="topic.slow_mode_update.title" autoFocus=false}}
   <div class="control-group">
-    <label>{{i18n "topic.slow_mode_update.description"}}</label>
+    <label class="slow-mode-label">{{i18n "topic.slow_mode_update.description"}}</label>
   </div>
 
   <div class="control-group">
-    <label>{{i18n "topic.slow_mode_update.select"}}</label>
+    <label class="slow-mode-label">{{i18n "topic.slow_mode_update.select"}}</label>
     {{combo-box
       class="slow-mode-type"
       content=slowModes
       value=selectedSlowMode
-      onChange=(action "setSlowModeInterval")
+      onChange=(action "setSlowModeDuration")
     }}
   </div>
 
@@ -40,9 +40,9 @@
   {{conditional-loading-spinner size="small" condition=loading}}
 
   {{#if model.slow_mode_seconds}}
-    {{d-button class="pull-right btn-danger"
-        action=(action "disableSlowMode")
-        disabled=submitDisabled
-        label="topic.slow_mode_update.remove"}}
+    {{d-button class="btn-danger"
+               action=(action "disableSlowMode")
+               disabled=submitDisabled
+               label="topic.slow_mode_update.remove"}}
   {{/if}}
 </div>

--- a/app/assets/javascripts/discourse/app/templates/modal/edit-slow-mode.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/edit-slow-mode.hbs
@@ -1,0 +1,48 @@
+{{#d-modal-body title="topic.slow_mode_update.title" autoFocus="false"}}
+  <div class="control-group">
+    <label>{{i18n "topic.slow_mode_update.description"}}</label>
+  </div>
+
+  <div class="control-group">
+    <label>{{i18n "topic.slow_mode_update.select"}}</label>
+    {{combo-box
+      class="slow-mode-type"
+      content=slowModes
+      value=selectedSlowMode
+      onChange=(action "setSlowModeInterval")
+    }}
+  </div>
+
+  {{#if showCustomSelect}}
+    <div class="control-group">
+      {{d-icon "hourglass-end"}}
+      {{input value=hours type="number" class="input-small" placeholder=(i18n "topic.slow_mode_update.hours")}}
+      {{input value=minutes type="number" class="input-small" placeholder=(i18n "topic.slow_mode_update.minutes")}}
+      {{input value=seconds type="number" class="input-small" placeholder=(i18n "topic.slow_mode_update.seconds")}}
+    </div>
+  {{/if}}
+
+  {{#if model.slow_mode_seconds}}
+    <div class="alert alert-info">
+      <b>
+        {{i18n "topic.slow_mode_update.current" hours=hours minutes=minutes seconds=seconds}}
+      </b>
+    </div>
+  {{/if}}
+{{/d-modal-body}}
+
+<div class="modal-footer">
+  {{d-button class="btn-primary"
+      disabled=submitDisabled
+      label="topic.slow_mode_update.save"
+      action=(action "enableSlowMode")}}
+
+  {{conditional-loading-spinner size="small" condition=loading}}
+
+  {{#if model.slow_mode_seconds}}
+    {{d-button class="pull-right btn-danger"
+        action=(action "disableSlowMode")
+        disabled=submitDisabled
+        label="topic.slow_mode_update.remove"}}
+  {{/if}}
+</div>

--- a/app/assets/javascripts/discourse/app/templates/topic.hbs
+++ b/app/assets/javascripts/discourse/app/templates/topic.hbs
@@ -145,6 +145,7 @@
             jumpToIndex=(action "jumpToIndex")
             replyToPost=(action "replyToPost")
             toggleMultiSelect=(action "toggleMultiSelect")
+            showTopicSlowModeUpdate=(route-action "showTopicSlowModeUpdate")
             deleteTopic=(action "deleteTopic")
             recoverTopic=(action "recoverTopic")
             toggleClosed=(action "toggleClosed")
@@ -168,6 +169,7 @@
               openUpwards="true"
               rightSide="true"
               toggleMultiSelect=(action "toggleMultiSelect")
+              showTopicSlowModeUpdate=(route-action "showTopicSlowModeUpdate")
               deleteTopic=(action "deleteTopic")
               recoverTopic=(action "recoverTopic")
               toggleClosed=(action "toggleClosed")
@@ -305,6 +307,7 @@
                   {{topic-footer-buttons
                     topic=model
                     toggleMultiSelect=(action "toggleMultiSelect")
+                    showTopicSlowModeUpdate=(route-action "showTopicSlowModeUpdate")
                     deleteTopic=(action "deleteTopic")
                     recoverTopic=(action "recoverTopic")
                     toggleClosed=(action "toggleClosed")

--- a/app/assets/javascripts/discourse/app/templates/topic.hbs
+++ b/app/assets/javascripts/discourse/app/templates/topic.hbs
@@ -288,6 +288,8 @@
                 </div>
               {{/if}}
 
+              {{slow-mode-info topic=model user=currentUser}}
+
               {{topic-timer-info
                   topicClosed=model.closed
                   statusType=model.topic_timer.status_type

--- a/app/assets/javascripts/discourse/app/widgets/topic-admin-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/topic-admin-menu.js
@@ -164,6 +164,14 @@ export default createWidget("topic-admin-menu", {
         });
       }
 
+      this.addActionButton({
+        className: "topic-admin-slow-mode",
+        buttonClass: "popup-menu-btn",
+        action: "showTopicSlowModeUpdate",
+        icon: "hourglass-end",
+        label: "actions.slow_mode",
+      });
+
       if (topic.get("deleted") && details.get("can_recover")) {
         this.addActionButton({
           className: "topic-admin-recover",

--- a/app/assets/stylesheets/common/base/modal.scss
+++ b/app/assets/stylesheets/common/base/modal.scss
@@ -811,3 +811,17 @@
     }
   }
 }
+
+.modal.edit-slow-mode-modal {
+  label {
+    display: inline-flex;
+  }
+
+  .alert.alert-info {
+    margin-bottom: 0;
+  }
+
+  .input-small {
+    width: 83px;
+  }
+}

--- a/app/assets/stylesheets/common/base/modal.scss
+++ b/app/assets/stylesheets/common/base/modal.scss
@@ -813,7 +813,7 @@
 }
 
 .modal.edit-slow-mode-modal {
-  label {
+  .slow-mode-label {
     display: inline-flex;
   }
 
@@ -822,6 +822,6 @@
   }
 
   .input-small {
-    width: 83px;
+    width: 15%;
   }
 }

--- a/app/assets/stylesheets/desktop/topic.scss
+++ b/app/assets/stylesheets/desktop/topic.scss
@@ -63,12 +63,14 @@
   border-top: 1px solid var(--primary-low);
   padding: 10px 0;
   max-width: 758px;
-  .topic-timer-heading {
+  .topic-timer-heading,
+  .slow-mode-heading {
     display: flex;
     align-items: center;
     margin: 0px;
   }
-  .topic-timer-remove {
+  .topic-timer-remove,
+  .slow-mode-remove {
     font-size: $font-down-2;
     background: transparent;
     margin-left: auto;

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -28,7 +28,8 @@ class TopicsController < ApplicationController
     :convert_topic,
     :bookmark,
     :publish,
-    :reset_bump_date
+    :reset_bump_date,
+    :set_slow_mode
   ]
 
   before_action :consider_user_for_promotion, only: :show
@@ -930,6 +931,15 @@ class TopicsController < ApplicationController
 
     topic.reset_bumped_at
     render body: nil
+  end
+
+  def set_slow_mode
+    topic = Topic.find(params[:topic_id])
+
+    guardian.ensure_can_moderate!(topic)
+    topic.update!(slow_mode_seconds: params[:seconds])
+
+    head :ok
   end
 
   private

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1770,6 +1770,7 @@ end
 #  archetype                 :string           default("regular"), not null
 #  featured_user4_id         :integer
 #  notify_moderators_count   :integer          default(0), not null
+#  slow_mode_seconds         :integer          default(0), not null
 #  spam_count                :integer          default(0), not null
 #  pinned_at                 :datetime
 #  score                     :float

--- a/app/models/topic_user.rb
+++ b/app/models/topic_user.rb
@@ -495,6 +495,7 @@ end
 #  posted                   :boolean          default(FALSE), not null
 #  last_read_post_number    :integer
 #  highest_seen_post_number :integer
+#  last_posted_at          :datetime
 #  last_visited_at          :datetime
 #  first_visited_at         :datetime
 #  notification_level       :integer          default(1), not null

--- a/app/serializers/topic_view_serializer.rb
+++ b/app/serializers/topic_view_serializer.rb
@@ -73,7 +73,8 @@ class TopicViewSerializer < ApplicationSerializer
     :queued_posts_count,
     :show_read_indicator,
     :requested_group_name,
-    :thumbnails
+    :thumbnails,
+    :user_last_posted_at
   )
 
   has_one :details, serializer: TopicViewDetailsSerializer, root: false, embed: :objects
@@ -280,5 +281,13 @@ class TopicViewSerializer < ApplicationSerializer
   def thumbnails
     extra_sizes = ThemeModifierHelper.new(request: scope.request).topic_thumbnail_sizes
     object.topic.thumbnail_info(enqueue_if_missing: true, extra_sizes: extra_sizes)
+  end
+
+  def user_last_posted_at
+    object.topic_user.last_posted_at
+  end
+
+  def include_user_last_posted_at?
+    object.topic.slow_mode_seconds.to_i > 0
   end
 end

--- a/app/serializers/topic_view_serializer.rb
+++ b/app/serializers/topic_view_serializer.rb
@@ -40,7 +40,8 @@ class TopicViewSerializer < ApplicationSerializer
     :pinned_globally,
     :pinned_at,
     :pinned_until,
-    :image_url
+    :image_url,
+    :slow_mode_seconds
   )
 
   attributes(

--- a/app/serializers/web_hook_topic_view_serializer.rb
+++ b/app/serializers/web_hook_topic_view_serializer.rb
@@ -20,6 +20,7 @@ class WebHookTopicViewSerializer < TopicViewSerializer
     topic_timer
     details
     image_url
+    slow_mode_seconds
   }.each do |attr|
     define_method("include_#{attr}?") do
       false

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1922,6 +1922,9 @@ en:
       yourself_confirm:
         title: "Did you forget to add recipients?"
         body: "Right now this message is only being sent to yourself!"
+      slow_mode:
+        title: "This topic is in slow mode."
+        body: "After submitting a post, you'll need to wait %{interval} before being able to post again."
 
       admin_options_title: "Optional staff settings for this topic"
 
@@ -2313,6 +2316,13 @@ en:
       jump_reply_down: jump to later reply
       deleted: "The topic has been deleted"
 
+      slow_mode_intervals:
+        weeks: "%{weeks} weeks"
+        days: "%{days} days"
+        hours_and_minutes: "%{hours} hours and %{minutes} minutes"
+        hours: "%{hours} hours"
+        minutes: "%{minutes} minutes"
+        seconds: "%{seconds} seconds"
       slow_mode_update:
         title: "Slow Mode"
         select: "Interval:"
@@ -2330,6 +2340,8 @@ en:
           1_day: "1 Day"
           1_week: "1 Week"
           custom: "Pick Interval"
+      slow_mode_notice:
+        interval: "You need to wait at least %{interval} between posts in this topic"
       topic_status_update:
         title: "Topic Timer"
         save: "Set Timer"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2313,6 +2313,23 @@ en:
       jump_reply_down: jump to later reply
       deleted: "The topic has been deleted"
 
+      slow_mode_update:
+        title: "Slow Mode"
+        select: "Interval:"
+        description: "Users will have to wait this interval to be able to post again."
+        current: "Current interval is %{hours} hours, %{minutes} minutes, and %{seconds} seconds."
+        save: "Save"
+        remove: "Disable"
+        hours: "Hours"
+        minutes: "Minutes"
+        seconds: "Seconds"
+        intervals:
+          15_minutes: "15 Minutes"
+          1_hour: "1 Hour"
+          4_hours: "4 Hours"
+          1_day: "1 Day"
+          1_week: "1 Week"
+          custom: "Pick Interval"
       topic_status_update:
         title: "Topic Timer"
         save: "Set Timer"
@@ -2447,6 +2464,7 @@ en:
         open: "Open Topic"
         close: "Close Topic"
         multi_select: "Select Posts…"
+        slow_mode: "Set Slow Mode"
         timed_update: "Set Topic Timer..."
         pin: "Pin Topic…"
         unpin: "Un-Pin Topic…"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1924,8 +1924,7 @@ en:
         body: "Right now this message is only being sent to yourself!"
       slow_mode:
         title: "This topic is in slow mode."
-        body: "After submitting a post, you'll need to wait %{interval} before being able to post again."
-        error: "You recently posted on this topic, which is in slow mode. Please wait so other users can have their chance to participate."
+        body: "After submitting a post, you'll need to wait %{duration} before being able to post again."
 
       admin_options_title: "Optional staff settings for this topic"
 
@@ -2317,32 +2316,25 @@ en:
       jump_reply_down: jump to later reply
       deleted: "The topic has been deleted"
 
-      slow_mode_intervals:
-        weeks: "%{weeks} weeks"
-        days: "%{days} days"
-        hours_and_minutes: "%{hours} hours and %{minutes} minutes"
-        hours: "%{hours} hours"
-        minutes: "%{minutes} minutes"
-        seconds: "%{seconds} seconds"
       slow_mode_update:
         title: "Slow Mode"
-        select: "Interval:"
-        description: "Users will have to wait this interval to be able to post again."
-        current: "Current interval is %{hours} hours, %{minutes} minutes, and %{seconds} seconds."
+        select: "Duration:"
+        description: "Users will have to wait to be able to post again."
+        current: "Current duration is %{hours} hours, %{minutes} minutes, and %{seconds} seconds."
         save: "Save"
         remove: "Disable"
         hours: "Hours"
         minutes: "Minutes"
         seconds: "Seconds"
-        intervals:
+        durations:
           15_minutes: "15 Minutes"
           1_hour: "1 Hour"
           4_hours: "4 Hours"
           1_day: "1 Day"
           1_week: "1 Week"
-          custom: "Pick Interval"
+          custom: "Pick Duration"
       slow_mode_notice:
-        interval: "You need to wait at least %{interval} between posts in this topic"
+        duration: "You need to wait %{duration} between posts in this topic"
       topic_status_update:
         title: "Topic Timer"
         save: "Set Timer"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1925,6 +1925,7 @@ en:
       slow_mode:
         title: "This topic is in slow mode."
         body: "After submitting a post, you'll need to wait %{interval} before being able to post again."
+        error: "You recently posted on this topic, which is in slow mode. Please wait so other users can have their chance to participate."
 
       admin_options_title: "Optional staff settings for this topic"
 

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -340,6 +340,7 @@ en:
   removed_direct_reply_full_quotes: "Automatically removed quote of whole previous post."
   secure_upload_not_allowed_in_public_topic: "Sorry, the following secure upload(s) cannot be used in a public topic: %{upload_filenames}."
   create_pm_on_existing_topic: "Sorry, you can't create a PM on an existing topic."
+  slow_mode: "Sorry, this topic is in slow mode."
 
   just_posted_that: "is too similar to what you recently posted"
   invalid_characters: "contains invalid characters"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -340,7 +340,7 @@ en:
   removed_direct_reply_full_quotes: "Automatically removed quote of whole previous post."
   secure_upload_not_allowed_in_public_topic: "Sorry, the following secure upload(s) cannot be used in a public topic: %{upload_filenames}."
   create_pm_on_existing_topic: "Sorry, you can't create a PM on an existing topic."
-  slow_mode: "Sorry, this topic is in slow mode."
+  slow_mode_enabled: "You recently posted on this topic, which is in slow mode. Please wait so other users can have their chance to participate."
 
   just_posted_that: "is too similar to what you recently posted"
   invalid_characters: "contains invalid characters"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -804,6 +804,7 @@ Discourse::Application.routes.draw do
     put "t/:topic_id/bookmark" => "topics#bookmark", constraints: { topic_id: /\d+/ }
     put "t/:topic_id/remove_bookmarks" => "topics#remove_bookmarks", constraints: { topic_id: /\d+/ }
     put "t/:topic_id/tags" => "topics#update_tags", constraints: { topic_id: /\d+/ }
+    put "t/:topic_id/slow_mode" => "topics#set_slow_mode", constraints: { topic_id: /\d+/ }
 
     post "t/:topic_id/notifications" => "topics#set_notifications" , constraints: { topic_id: /\d+/ }
 

--- a/db/migrate/20201005165544_add_topic_slow_mode_interval.rb
+++ b/db/migrate/20201005165544_add_topic_slow_mode_interval.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddTopicSlowModeInterval < ActiveRecord::Migration[6.0]
+  def change
+    add_column :topics, :slow_mode_seconds, :integer, null: false, default: 0
+  end
+end

--- a/db/migrate/20201009190955_add_last_posted_at_to_topic_user.rb
+++ b/db/migrate/20201009190955_add_last_posted_at_to_topic_user.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddLastPostedAtToTopicUser < ActiveRecord::Migration[6.0]
+  def change
+    add_column :topic_users, :last_posted_at, :datetime
+  end
+end

--- a/lib/svg_sprite/svg_sprite.rb
+++ b/lib/svg_sprite/svg_sprite.rb
@@ -130,6 +130,7 @@ module SvgSprite
     "heading",
     "heart",
     "home",
+    "hourglass-end",
     "id-card",
     "info-circle",
     "italic",

--- a/spec/components/post_creator_spec.rb
+++ b/spec/components/post_creator_spec.rb
@@ -722,6 +722,32 @@ describe PostCreator do
         expect(topic.word_count).to eq(6)
       end
     end
+
+    context 'when the topic is in slow mode' do
+      before do
+        one_day = 86400
+        topic.update!(slow_mode_seconds: one_day)
+      end
+
+      it 'fails if the user recently posted in this topic' do
+        TopicUser.create!(user: user, topic: topic, last_posted_at: 10.minutes.ago)
+
+        post = creator.create
+
+        expect(post).to be_blank
+        expect(creator.errors.count).to eq 1
+        expect(creator.errors.messages[:base][0]).to match I18n.t(:slow_mode)
+      end
+
+      it 'creates the topic if the user last post is older than the slow mode interval' do
+        TopicUser.create!(user: user, topic: topic, last_posted_at: 5.days.ago)
+
+        post = creator.create
+
+        expect(post).to be_present
+        expect(creator.errors.count).to be_zero
+      end
+    end
   end
 
   context 'closed topic' do
@@ -1193,6 +1219,19 @@ describe PostCreator do
       )
       topic_user = TopicUser.find_by(user_id: user.id, topic_id: pm.id)
       expect(topic_user.notification_level).to eq(3)
+    end
+
+    it 'sets the last_posted_at timestamp to track the last time the user posted' do
+      topic = Fabricate(:topic)
+
+      PostCreator.create(
+        user,
+        topic_id: topic.id,
+        raw: "this is a test reply 123 123 ;)"
+      )
+
+      topic_user = TopicUser.find_by(user_id: user.id, topic_id: topic.id)
+      expect(topic_user.last_posted_at).to be_present
     end
   end
 

--- a/spec/components/post_creator_spec.rb
+++ b/spec/components/post_creator_spec.rb
@@ -736,7 +736,7 @@ describe PostCreator do
 
         expect(post).to be_blank
         expect(creator.errors.count).to eq 1
-        expect(creator.errors.messages[:base][0]).to match I18n.t(:slow_mode)
+        expect(creator.errors.messages[:base][0]).to match I18n.t(:slow_mode_enabled)
       end
 
       it 'creates the topic if the user last post is older than the slow mode interval' do

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -3049,7 +3049,7 @@ RSpec.describe TopicsController do
 
   describe '#set_slow_mode' do
     context 'when not logged in' do
-      it 'xxx' do
+      it 'returns a forbidden response' do
         put "/t/#{topic.id}/slow_mode.json", params: {
           seconds: '3600'
         }

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -3047,6 +3047,58 @@ RSpec.describe TopicsController do
     end
   end
 
+  describe '#set_slow_mode' do
+    context 'when not logged in' do
+      it 'xxx' do
+        put "/t/#{topic.id}/slow_mode.json", params: {
+          seconds: '3600'
+        }
+
+        expect(response.status).to eq(403)
+      end
+    end
+
+    context 'logged in as an admin' do
+      it 'allows admins to set the slow mode interval' do
+        sign_in(admin)
+
+        put "/t/#{topic.id}/slow_mode.json", params: {
+          seconds: '3600'
+        }
+
+        topic.reload
+        expect(response.status).to eq(200)
+        expect(topic.slow_mode_seconds).to eq(3600)
+      end
+    end
+
+    context 'logged in as a regular user' do
+      it 'does nothing if the user is not TL4' do
+        user.update!(trust_level: TrustLevel[3])
+        sign_in(user)
+
+        put "/t/#{topic.id}/slow_mode.json", params: {
+          seconds: '3600'
+        }
+
+        expect(response.status).to eq(403)
+      end
+
+      it 'allows TL4 users to set the slow mode interval' do
+        user.update!(trust_level: TrustLevel[4])
+        sign_in(user)
+
+        put "/t/#{topic.id}/slow_mode.json", params: {
+          seconds: '3600'
+        }
+
+        topic.reload
+        expect(response.status).to eq(200)
+        expect(topic.slow_mode_seconds).to eq(3600)
+      end
+    end
+  end
+
   describe '#invite' do
     describe 'when not logged in' do
       it "should return the right response" do


### PR DESCRIPTION
Adds a new slow mode for topics that are heating up. Users will have to wait for a period of time before being able to post again.

We store this interval inside the topics table and track the last time a user posted using the `last_posted_at` datetime in the TopicUser relation.

Some screenshots:

<img width="272" alt="Screen Shot 2020-10-13 at 09 15 05" src="https://user-images.githubusercontent.com/5025816/95859595-3ba48e80-0d35-11eb-8723-a8878db4936b.png">
<img width="563" alt="Screen Shot 2020-10-13 at 09 15 50" src="https://user-images.githubusercontent.com/5025816/95859603-3e06e880-0d35-11eb-8071-dce09410101f.png">
<img width="827" alt="Screen Shot 2020-10-13 at 09 15 59" src="https://user-images.githubusercontent.com/5025816/95859608-3f381580-0d35-11eb-90e8-a5e069f0ab81.png">


Composer:

<img width="1499" alt="Screen Shot 2020-10-13 at 09 16 31" src="https://user-images.githubusercontent.com/5025816/95859660-570f9980-0d35-11eb-9c8f-9d948f81d9a9.png">

If the user ignores the warning and tries to post:

<img width="691" alt="Screen Shot 2020-10-13 at 09 19 07" src="https://user-images.githubusercontent.com/5025816/95859717-6858a600-0d35-11eb-8a1d-855597ff403f.png">



