### PR TITLE
DEV: Users must be able to see a topic to moderate it.

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -453,7 +453,6 @@ class TopicsController < ApplicationController
     params.require(:duration) if based_on_last_post
 
     topic = Topic.find_by(id: params[:topic_id])
-    guardian.ensure_can_see!(topic)
     guardian.ensure_can_moderate!(topic)
 
     options = {

--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -170,7 +170,10 @@ class Guardian
   end
 
   def can_moderate?(obj)
-    obj && authenticated? && !is_silenced? && (is_staff? || (obj.is_a?(Topic) && @user.has_trust_level?(TrustLevel[4])))
+    obj && authenticated? && !is_silenced? && (
+      is_staff? ||
+      (obj.is_a?(Topic) && @user.has_trust_level?(TrustLevel[4]) && can_see_topic?(obj))
+    )
   end
   alias :can_see_flags? :can_moderate?
 


### PR DESCRIPTION
Follows-up a8c47e7c. It makes more sense to check if the user can see the topic inside the `can_moderate?` method instead of doing it separately.
