### PR TITLE
FIX: Error messages from editing user being swallowed

### DIFF
--- a/app/assets/javascripts/admin/addon/models/admin-user.js
+++ b/app/assets/javascripts/admin/addon/models/admin-user.js
@@ -139,8 +139,8 @@ const AdminUser = User.extend({
           bootbox.hideAll();
           let error;
           AdminUser.find(user.get("id")).then((u) => user.setProperties(u));
-          if (e.responseJSON && e.responseJSON.errors) {
-            error = e.responseJSON.errors[0];
+          if (e.jqXHR.responseJSON && e.jqXHR.responseJSON.errors) {
+            error = e.jqXHR.responseJSON.errors[0];
           }
           error = error || I18n.t("admin.user.delete_posts_failed");
           bootbox.alert(error);
@@ -236,8 +236,8 @@ const AdminUser = User.extend({
       .then(() => window.location.reload())
       .catch((e) => {
         let error;
-        if (e.responseJSON && e.responseJSON.errors) {
-          error = e.responseJSON.errors[0];
+        if (e.jqXHR.responseJSON && e.jqXHR.responseJSON.errors) {
+          error = e.jqXHR.responseJSON.errors[0];
         }
         error =
           error ||
@@ -260,8 +260,8 @@ const AdminUser = User.extend({
       .then(() => window.location.reload())
       .catch((e) => {
         let error;
-        if (e.responseJSON && e.responseJSON.errors) {
-          error = e.responseJSON.errors[0];
+        if (e.jqXHR.responseJSON && e.jqXHR.responseJSON.errors) {
+          error = e.jqXHR.responseJSON.errors[0];
         }
         error =
           error ||


### PR DESCRIPTION
The format of the error responses is different than what the code is expecting. This was causing error messages to be ignored. Here is an example of the correct format being used. https://github.com/discourse/discourse/blob/6e2be3e60bb882dd92d270d11c71fba9b0901b5e/app/assets/javascripts/discourse/app/controllers/preferences/email.js#L103

<img width="360" alt="Screenshot 2020-10-13 100610" src="https://user-images.githubusercontent.com/16214023/95879711-457dc000-0d3c-11eb-8ebe-0b197cac4cd3.png">
