### PR TITLE
Improve backup reliability

### DIFF
--- a/lib/backup_restore.rb
+++ b/lib/backup_restore.rb
@@ -172,9 +172,9 @@ module BackupRestore
 
   def self.spawn_process!(type, user_id, opts)
     script = File.join(Rails.root, "script", "spawn_backup_restore.rb")
-    command = ["bundle", "exec", "ruby", script, type, user_id, opts.to_json].shelljoin
+    command = ["bundle", "exec", "ruby", script, type, user_id, opts.to_json].map(&:to_s)
 
-    pid = spawn({ "RAILS_DB" => RailsMultisite::ConnectionManagement.current_db }, command)
+    pid = spawn({ "RAILS_DB" => RailsMultisite::ConnectionManagement.current_db }, *command)
     Process.detach(pid)
   end
 

--- a/lib/backup_restore/backuper.rb
+++ b/lib/backup_restore/backuper.rb
@@ -96,6 +96,8 @@ module BackupRestore
     end
 
     def listen_for_shutdown_signal
+      BackupRestore.clear_shutdown_signal!
+
       Thread.new do
         while BackupRestore.is_operation_running?
           exit if BackupRestore.should_shutdown?

--- a/lib/backup_restore/system_interface.rb
+++ b/lib/backup_restore/system_interface.rb
@@ -44,6 +44,8 @@ module BackupRestore
     end
 
     def listen_for_shutdown_signal
+      BackupRestore.clear_shutdown_signal!
+
       Thread.new do
         while BackupRestore.is_operation_running?
           exit if BackupRestore.should_shutdown?

--- a/script/spawn_backup_restore.rb
+++ b/script/spawn_backup_restore.rb
@@ -1,38 +1,40 @@
 # frozen_string_literal: true
 # This script is used by BackupRestore.backup! and BackupRestore.restore!
 
-require File.expand_path("../../config/environment", __FILE__)
+fork do
+  require File.expand_path("../../config/environment", __FILE__)
 
-def backup
-  user_id, opts = parse_params
-  BackupRestore::Backuper.new(user_id, opts).run
-end
+  def backup
+    user_id, opts = parse_params
+    BackupRestore::Backuper.new(user_id, opts).run
+  end
 
-def restore
-  user_id, opts = parse_params
+  def restore
+    user_id, opts = parse_params
 
-  BackupRestore::Restorer.new(
-    user_id: user_id,
-    filename: opts[:filename],
-    factory: BackupRestore::Factory.new(
+    BackupRestore::Restorer.new(
       user_id: user_id,
-      client_id: opts[:client_id]
-    ),
-    disable_emails: opts.fetch(:disable_emails, true)
-  ).run
-end
+      filename: opts[:filename],
+      factory: BackupRestore::Factory.new(
+        user_id: user_id,
+        client_id: opts[:client_id]
+      ),
+      disable_emails: opts.fetch(:disable_emails, true)
+    ).run
+  end
 
-def parse_params
-  user_id = ARGV[1].to_i
-  opts = JSON.parse(ARGV[2], symbolize_names: true)
-  [user_id, opts]
-end
+  def parse_params
+    user_id = ARGV[1].to_i
+    opts = JSON.parse(ARGV[2], symbolize_names: true)
+    [user_id, opts]
+  end
 
-case ARGV[0]
-when "backup"
-  backup
-when "restore"
-  restore
-else
-  raise "Unknown argument: #{ARGV[0]}"
+  case ARGV[0]
+  when "backup"
+    backup
+  when "restore"
+    restore
+  else
+    raise "Unknown argument: #{ARGV[0]}"
+  end
 end

--- a/spec/lib/backup_restore/system_interface_spec.rb
+++ b/spec/lib/backup_restore/system_interface_spec.rb
@@ -69,6 +69,15 @@ describe BackupRestore::SystemInterface do
         thread.join
       end.to raise_error(SystemExit)
     end
+
+    it "clears an existing shutdown signal before it starts to listen" do
+      BackupRestore.set_shutdown_signal!
+      expect(BackupRestore.should_shutdown?).to eq(true)
+
+      thread = subject.listen_for_shutdown_signal
+      expect(BackupRestore.should_shutdown?).to eq(false)
+      Thread.kill(thread)
+    end
   end
 
   describe "#pause_sidekiq" do


### PR DESCRIPTION
Contains two fixes:
* Backups didn’t work anymore after someone pressed the “Cancel” button in Admin 🡢 Backup
* Backups were aborted when the parent Unicorn worker was killed

Also, it spawns the new process without a shell.