### PR TITLE
FEATURE: Add category slug to body class on tag pages

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/tags/show.hbs
+++ b/app/assets/javascripts/discourse/app/templates/tags/show.hbs
@@ -1,4 +1,4 @@
-{{#d-section tagName="" pageClass="tags" bodyClass=(concat "tag-" tag.id)}}
+{{#d-section tagName="" pageClass="tags" bodyClass=(concat "tag-" tag.id (if category.slug (concat " category-" category.slug)) "")}}
   <div class="container">
     {{discourse-banner user=currentUser banner=site.banner}}
   </div>


### PR DESCRIPTION
This PR will add the category slug class to the body if the tag is a child of a category.

Currently, when visiting a tag topic list only the tag name is added to the body class.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
