### PR TITLE
FIX: similar topic pg error with trailing slashes

### DIFF
--- a/lib/search.rb
+++ b/lib/search.rb
@@ -1106,6 +1106,7 @@ class Search
   end
 
   def self.set_tsquery_weight_filter(term, weight_filter)
+    term = term.gsub(/\\+$/, '') # Remove any trailing '\' to avoid quote escaping issues
     term = term.gsub("'", "''")
     "''#{PG::Connection.escape_string(term)}'':*#{weight_filter}"
   end

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -523,6 +523,10 @@ describe Topic do
       expect(Topic.similar_to('some title', 'https://discourse.org/#INCORRECT#URI')).to be_empty
     end
 
+    it 'does not result in an invalid statement with trailing slash' do
+      expect(Topic.similar_to('Title with trailing slashes\\\\', 'no body')).to be_empty
+    end
+
     context 'with a similar topic' do
       fab!(:post) {
         SearchIndexer.enable


### PR DESCRIPTION
If a title contains a trailing slash pg would throw an invalid statement
error due to quotes being escaped when looking up similar topic titles.
