### PR TITLE
FIX: Wizard theme preview when logo is missing

### DIFF
--- a/app/assets/javascripts/wizard/lib/preview.js
+++ b/app/assets/javascripts/wizard/lib/preview.js
@@ -161,21 +161,22 @@ export function createPreviewComponent(width, height, obj) {
         drawHeader(ctx, colors, width, headerHeight);
 
         const avatarSize = height * 0.1;
-
-        // Logo
         const headerMargin = headerHeight * 0.2;
-        const logoHeight = headerHeight - headerMargin * 2;
 
-        const ratio = logoHeight / logo.height;
-        this.scaleImage(
-          logo,
-          headerMargin,
-          headerMargin,
-          logo.width * ratio,
-          logoHeight
-        );
+        if (logo) {
+          const logoHeight = headerHeight - headerMargin * 2;
 
-        this.scaleImage(logo, width, headerMargin);
+          const ratio = logoHeight / logo.height;
+          this.scaleImage(
+            logo,
+            headerMargin,
+            headerMargin,
+            logo.width * ratio,
+            logoHeight
+          );
+
+          this.scaleImage(logo, width, headerMargin);
+        }
 
         // Top right menu
         this.scaleImage(


### PR DESCRIPTION
Fixes empty theme previews in the wizard, a bug introduced by yours
truly in a4356b99af0a7f4cd746b5d09960ab7635fe91a4

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
