### PR TITLE
FEATURE: when we fail to ship topic timings attempt to retry

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/screen-track.js
+++ b/app/assets/javascripts/discourse/app/lib/screen-track.js
@@ -174,11 +174,12 @@ export default class {
             this.consolidateTimings(timings, topicTime, topicId);
           }
         }
-        // TODO decide if we want to log this anywhere, at the moment we simply eat the
-        // errors and do not report anywhere (it may still show up on server logs though)
-        //
-        // User will be aware of this problem cause the blue dot will be "stuck" and they
-        // should notice that.
+
+        if (window.console && window.console.warn) {
+          window.console.warn(
+            `Failed to update topic times for topic ${topicId} due to ${e.jqXHR.status} error`
+          );
+        }
       })
       .finally(() => {
         this._inProgress = false;

--- a/app/assets/javascripts/discourse/app/lib/screen-track.js
+++ b/app/assets/javascripts/discourse/app/lib/screen-track.js
@@ -17,6 +17,7 @@ export default class {
     this.session = session;
     this.currentUser = currentUser;
     this.reset();
+    this._consolidatedTimings = [];
   }
 
   start(topicId, topicController) {
@@ -89,8 +90,6 @@ export default class {
   }
 
   consolidateTimings(timings, topicTime, topicId) {
-    this._consolidatedTimings = this._consolidatedTimings || [];
-
     let foundIndex = this._consolidatedTimings.findIndex(
       (elem) => elem.topicId === topicId
     );
@@ -122,7 +121,7 @@ export default class {
   }
 
   sendNextConsolidatedTiming() {
-    if (!this._consolidatedTimings || this._consolidatedTimings.length === 0) {
+    if (this._consolidatedTimings.length === 0) {
       return;
     }
 

--- a/app/assets/javascripts/discourse/tests/unit/lib/screen-track-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/screen-track-test.js
@@ -1,0 +1,21 @@
+import { test, module } from "qunit";
+import ScreenTrack from "discourse/lib/screen-track";
+
+module("lib:screen-track");
+
+test("consolidateTimings", (assert) => {
+  const tracker = new ScreenTrack();
+
+  tracker.consolidateTimings({ 1: 10, 2: 5 }, 10, 1);
+  tracker.consolidateTimings({ 1: 5, 3: 1 }, 3, 1);
+  const consolidated = tracker.consolidateTimings({ 1: 5, 3: 1 }, 3, 2);
+
+  assert.deepEqual(
+    consolidated,
+    [
+      [{ 1: 5, 3: 1 }, 3, 2],
+      [{ 1: 15, 2: 5, 3: 1 }, 13, 1],
+    ],
+    "expecting consolidated timings to match correctly"
+  );
+});

--- a/app/assets/javascripts/discourse/tests/unit/lib/screen-track-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/screen-track-test.js
@@ -13,8 +13,8 @@ test("consolidateTimings", (assert) => {
   assert.deepEqual(
     consolidated,
     [
-      [{ 1: 5, 3: 1 }, 3, 2],
-      [{ 1: 15, 2: 5, 3: 1 }, 13, 1],
+      { timings: { 1: 15, 2: 5, 3: 1 }, topicTime: 13, topicId: 1 },
+      { timings: { 1: 5, 3: 1 }, topicTime: 3, topicId: 2 },
     ],
     "expecting consolidated timings to match correctly"
   );


### PR DESCRIPTION
This change amends it so

1. Topic timings are treated as background requests and subject to more
 aggressive rate limits.

2. If we notice an error when we ship timings we back off exponentially

The commit allows 405, 429, 500, 501, 502, 503 and 504 errors to be retried.

500+ errors usually happen when self hosters are rebuilding or some other
weird condition.

405 happens when site is in readonly.
429 happens when user is rate limited.

The retry cadence is hardcoded in AJAX_FAILURE_DELAYS, longest delay is
40 seconds, we may consider enlarging it.

After the last delay passes we give up and do not write timings to the
server.
