### PR TITLE
Add non_automatic group type param to groups index

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -85,6 +85,8 @@ class GroupsController < ApplicationController
       type_filters = type_filters - [:my, :owner]
     end
 
+    type_filters.delete(:non_automatic)
+
     # count the total before doing pagination
     total = groups.count
 

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -34,6 +34,9 @@ class GroupsController < ApplicationController
     },
     automatic: Proc.new { |groups|
       groups.where(automatic: true)
+    },
+    non_automatic: Proc.new { |groups|
+      groups.where(automatic: false)
     }
   }
   ADD_MEMBERS_LIMIT = 1000

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -172,7 +172,7 @@ describe GroupsController do
       expect(body["load_more_groups"]).to eq("/groups?page=1")
       expect(body["total_rows_groups"]).to eq(1)
       expect(body["extras"]["type_filters"].map(&:to_sym)).to eq(
-        described_class::TYPE_FILTERS.keys - [:my, :owner, :automatic]
+        described_class::TYPE_FILTERS.keys - [:my, :owner, :automatic, :non_automatic]
       )
     end
 
@@ -288,7 +288,7 @@ describe GroupsController do
         expect(body["total_rows_groups"]).to eq(10)
 
         expect(body["extras"]["type_filters"].map(&:to_sym)).to eq(
-          described_class::TYPE_FILTERS.keys
+          described_class::TYPE_FILTERS.keys - [:non_automatic]
         )
       end
 

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -330,6 +330,16 @@ describe GroupsController do
           end
         end
 
+        describe 'non automatic groups' do
+          it 'should return the right response' do
+            group2 = Fabricate(:group)
+            expect_type_to_return_right_groups(
+              'non_automatic',
+              [group.id, group2.id]
+            )
+          end
+        end
+
         describe 'public groups' do
           it 'should return the right response' do
             group2 = Fabricate(:group, public_admission: true)


### PR DESCRIPTION
A list of all non automatic groups is sometimes needed when listing groups for an admin on a client consuming the API. I am specifically hoping to use this for this PR to wp-discourse: https://github.com/discourse/wp-discourse/pull/372
