### PR TITLE
DEV: load styleguide assets only when needed

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/url.js
+++ b/app/assets/javascripts/discourse/app/lib/url.js
@@ -34,6 +34,7 @@ const SERVER_SIDE_ONLY = [
   /^\/admin\/logs\/watched_words\/action\/[^\/]+\/download$/,
   /^\/pub\//,
   /^\/invites\//,
+  /^\/styleguide\//,
 ];
 
 // The amount of height (in pixles) that we factor in when jumpEnd is called so

--- a/plugins/styleguide/plugin.rb
+++ b/plugins/styleguide/plugin.rb
@@ -13,3 +13,9 @@ load File.expand_path('../lib/styleguide/engine.rb', __FILE__)
 Discourse::Application.routes.append do
   mount ::Styleguide::Engine, at: '/styleguide'
 end
+
+after_initialize do
+  register_asset_filter do |type, request|
+    request.fullpath && request.fullpath.start_with?('/styleguide')
+  end
+end

--- a/plugins/styleguide/plugin.rb
+++ b/plugins/styleguide/plugin.rb
@@ -16,6 +16,6 @@ end
 
 after_initialize do
   register_asset_filter do |type, request|
-    request.fullpath && request.fullpath.start_with?('/styleguide')
+    request&.fullpath&.start_with?('/styleguide')
   end
 end

--- a/plugins/styleguide/spec/integration/assets_spec.rb
+++ b/plugins/styleguide/spec/integration/assets_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Styleguide assets' do
+  before do
+    SiteSetting.styleguide_enabled = true
+    sign_in(Fabricate(:admin))
+  end
+
+  context 'visits homepage' do
+    it 'doesn’t load styleguide assets' do
+      get '/'
+      expect(response.body).to_not include('styleguide')
+    end
+  end
+
+  context 'visits styleguide' do
+    it 'loads styleguide assets' do
+      get '/styleguide'
+      expect(response.body).to include('styleguide')
+    end
+  end
+end


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
