### PR TITLE
DEV: Upgrade actions/cache to v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
           bundle config path vendor/bundle
 
       - name: Bundler cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         id: bundler-cache
         with:
           path: vendor/bundle
@@ -110,7 +110,7 @@ jobs:
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
       - name: Yarn cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir.outputs.dir }}


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->

https://github.com/actions/cache/issues/381#issuecomment-662597653

v1 has issues with slow cache restoration. Tested with v2 in a branch on `knowledge-explorer` and it seemed to fire up quite a bit faster.