### PR TITLE
DEV: Retry when Net::HTTP throws EOFError

### DIFF
--- a/lib/tasks/qunit.rake
+++ b/lib/tasks/qunit.rake
@@ -86,7 +86,7 @@ task "qunit:test", [:timeout, :qunit_path] do |_, args|
     puts "Warming up Rails server"
     begin
       Net::HTTP.get(uri)
-    rescue Errno::ECONNREFUSED, Errno::EADDRNOTAVAIL, Net::ReadTimeout
+    rescue Errno::ECONNREFUSED, Errno::EADDRNOTAVAIL, Net::ReadTimeout, EOFError
       sleep 1
       retry unless elapsed() > 60
       puts "Timed out. Can not connect to forked server!"


### PR DESCRIPTION
Might fix an inconsistent issue when running tests in CI.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
