### PR TITLE
FIX: Resolve issues running qunit via rake

### DIFF
--- a/lib/plugin/metadata.rb
+++ b/lib/plugin/metadata.rb
@@ -46,7 +46,7 @@ class Plugin::Metadata
     "discourse-no-bump",
     "discourse-oauth2-basic",
     "discourse-patreon",
-    "discourse-perspective",
+    "discourse-perspective-api",
     "discourse-plugin-discord-auth",
     "discourse-plugin-linkedin-auth",
     "discourse-plugin-office365-auth",

--- a/lib/tasks/plugin.rake
+++ b/lib/tasks/plugin.rake
@@ -12,8 +12,7 @@ task 'plugin:install_all_official' do
   ])
 
   map = {
-    'Canned Replies' => 'https://github.com/discourse/discourse-canned-replies',
-    'discourse-perspective' => 'https://github.com/discourse/discourse-perspective-api'
+    'Canned Replies' => 'https://github.com/discourse/discourse-canned-replies'
   }
 
   STDERR.puts "Allowing write to all repos!" if ENV['GIT_WRITE']


### PR DESCRIPTION
discourse-perspective-api was not successfully running tests via the qunit:test rake task due to inconsistent naming between core and the plugin repo.

Main question here is: will changing this break anything except old installs of this plugin on the previous repo name? I can't think of any reasons not to make this change, but I very well may be missing something.

There's also this: https://github.com/discourse/discourse/blob/58e17d7eab3563d437fa0015a3a871d3d756eee3/lib/tasks/plugin.rake#L16

I'm assuming this is not necessary anymore once the change in `metadata.rb` is made. If so, I'll remove that line too.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
