### PR TITLE
FIX: Check for link target attribute on link clink

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/link.js
+++ b/app/assets/javascripts/discourse/app/widgets/link.js
@@ -43,9 +43,6 @@ export default createWidget("link", {
         ? I18n.t(attrs.title, attrs.titleOptions)
         : this.label(attrs),
     };
-    if (attrs.target) {
-      ret["target"] = attrs.target;
-    }
     if (attrs.attributes) {
       Object.keys(attrs.attributes).forEach(
         (k) => (ret[k] = attrs.attributes[k])
@@ -104,9 +101,14 @@ export default createWidget("link", {
   },
 
   click(e) {
-    if (wantsNewWindow(e) || this.attrs.target === "_blank") {
+    if (this.attrs.attributes && this.attrs.attributes.target === "_blank") {
       return;
     }
+
+    if (wantsNewWindow(e)) {
+      return;
+    }
+
     e.preventDefault();
 
     if (this.attrs.action) {

--- a/app/assets/javascripts/discourse/app/widgets/link.js
+++ b/app/assets/javascripts/discourse/app/widgets/link.js
@@ -43,6 +43,9 @@ export default createWidget("link", {
         ? I18n.t(attrs.title, attrs.titleOptions)
         : this.label(attrs),
     };
+    if (attrs.target) {
+      ret["target"] = attrs.target;
+    }
     if (attrs.attributes) {
       Object.keys(attrs.attributes).forEach(
         (k) => (ret[k] = attrs.attributes[k])
@@ -97,12 +100,11 @@ export default createWidget("link", {
         );
       }
     }
-
     return result;
   },
 
   click(e) {
-    if (wantsNewWindow(e)) {
+    if (wantsNewWindow(e) || this.attrs.target === "_blank") {
       return;
     }
     e.preventDefault();


### PR DESCRIPTION
This PR will add the ability for a widget link's target attribute to be specified.

Allowing `target: "_blank"` to work properly.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
