### PR TITLE
REFACTOR: Import `visit` helper rather than using a global variable

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,6 +8,6 @@
     "moduleForComponent": "off",
     "testStart": "off",
     "testDone": "off",
-    "sinon": "off"
+    "sinon": "off",
   }
 }

--- a/app/assets/javascripts/discourse-loader.js
+++ b/app/assets/javascripts/discourse-loader.js
@@ -146,9 +146,6 @@ var define, requirejs;
       "@ember/object/internals": {
         guidFor: Ember.guidFor,
       },
-      "@ember/test-helpers": {
-        setResolver: window.setResolver,
-      },
       I18n: {
         // eslint-disable-next-line
         default: I18n,

--- a/app/assets/javascripts/discourse/tests/acceptance/about-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/about-test.js
@@ -1,5 +1,7 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+
 acceptance("About");
 
 test("viewing", async (assert) => {

--- a/app/assets/javascripts/discourse/tests/acceptance/account-created-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/account-created-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import PreloadStore from "discourse/lib/preload-store";

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-emails-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-emails-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import pretender from "discourse/tests/helpers/create-pretender";

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-search-log-term-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-search-log-term-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { skip } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 acceptance("Admin - Search Log Term", { loggedIn: true });

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-search-logs-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-search-logs-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { skip } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 acceptance("Admin - Search Logs", { loggedIn: true });

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-site-settings-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-site-settings-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import siteSettingFixture from "discourse/tests/fixtures/site-settings";

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-site-text-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-site-text-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-suspend-user-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-suspend-user-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-user-badges-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-user-badges-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-user-emails-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-user-emails-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import I18n from "I18n";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-user-index-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-user-index-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-users-list-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-users-list-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import I18n from "I18n";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-watched-words-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-watched-words-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 acceptance("Admin - Watched Words", { loggedIn: true });

--- a/app/assets/javascripts/discourse/tests/acceptance/auth-complete-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/auth-complete-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 acceptance("Auth Complete", {

--- a/app/assets/javascripts/discourse/tests/acceptance/badges-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/badges-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";

--- a/app/assets/javascripts/discourse/tests/acceptance/bookmarks-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/bookmarks-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { skip } from "qunit";
 import { test } from "qunit";
 import I18n from "I18n";

--- a/app/assets/javascripts/discourse/tests/acceptance/category-banner-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/category-banner-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import DiscoveryFixtures from "discourse/tests/fixtures/discovery-fixtures";

--- a/app/assets/javascripts/discourse/tests/acceptance/category-chooser-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/category-chooser-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";

--- a/app/assets/javascripts/discourse/tests/acceptance/category-edit-security-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/category-edit-security-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";

--- a/app/assets/javascripts/discourse/tests/acceptance/category-edit-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/category-edit-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { skip } from "qunit";
 import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";

--- a/app/assets/javascripts/discourse/tests/acceptance/click-track-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/click-track-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import pretender from "discourse/tests/helpers/create-pretender";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-actions-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-actions-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import I18n from "I18n";
 import selectKit from "discourse/tests/helpers/select-kit-helper";

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-attachment-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-attachment-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-edit-conflict-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-edit-conflict-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import I18n from "I18n";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-hyperlink-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-hyperlink-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-onebox-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-onebox-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-tags-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-tags-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import Category from "discourse/models/category";
 import {

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { skip } from "qunit";
 import { test } from "qunit";
 import I18n from "I18n";

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-topic-links-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-topic-links-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import {
   acceptance,

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-uncategorized-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-uncategorized-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import {

--- a/app/assets/javascripts/discourse/tests/acceptance/create-account-external-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/create-account-external-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/create-account-user-fields-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/create-account-user-fields-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/custom-html-set-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/custom-html-set-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import { setCustomHTML } from "discourse/helpers/custom-html";

--- a/app/assets/javascripts/discourse/tests/acceptance/custom-html-template-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/custom-html-template-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/dashboard-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/dashboard-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";

--- a/app/assets/javascripts/discourse/tests/acceptance/email-notice-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/email-notice-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import {
   acceptance,

--- a/app/assets/javascripts/discourse/tests/acceptance/emoji-picker-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/emoji-picker-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/emoji-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/emoji-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { IMAGE_VERSION as v } from "pretty-text/emoji/version";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";

--- a/app/assets/javascripts/discourse/tests/acceptance/encoded-category-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/encoded-category-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import DiscoveryFixtures from "discourse/tests/fixtures/discovery-fixtures";

--- a/app/assets/javascripts/discourse/tests/acceptance/enforce-second-factor-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/enforce-second-factor-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import {
   acceptance,

--- a/app/assets/javascripts/discourse/tests/acceptance/forgot-password-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/forgot-password-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import I18n from "I18n";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";

--- a/app/assets/javascripts/discourse/tests/acceptance/group-card-mobile-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-card-mobile-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { skip } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import DiscourseURL from "discourse/lib/url";

--- a/app/assets/javascripts/discourse/tests/acceptance/group-card-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-card-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { skip } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import DiscourseURL from "discourse/lib/url";

--- a/app/assets/javascripts/discourse/tests/acceptance/group-index-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-index-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import I18n from "I18n";
 import {

--- a/app/assets/javascripts/discourse/tests/acceptance/group-manage-categories-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-manage-categories-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import {
   acceptance,

--- a/app/assets/javascripts/discourse/tests/acceptance/group-manage-interaction-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-manage-interaction-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import {
   acceptance,

--- a/app/assets/javascripts/discourse/tests/acceptance/group-manage-logs-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-manage-logs-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/group-manage-membership-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-manage-membership-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import {
   acceptance,

--- a/app/assets/javascripts/discourse/tests/acceptance/group-manage-profile-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-manage-profile-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import {
   acceptance,

--- a/app/assets/javascripts/discourse/tests/acceptance/group-manage-tags-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-manage-tags-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import {
   acceptance,

--- a/app/assets/javascripts/discourse/tests/acceptance/group-requests-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-requests-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import { parsePostData } from "discourse/tests/helpers/create-pretender";

--- a/app/assets/javascripts/discourse/tests/acceptance/group-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import I18n from "I18n";
 import selectKit from "discourse/tests/helpers/select-kit-helper";

--- a/app/assets/javascripts/discourse/tests/acceptance/groups-index-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/groups-index-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/groups-new-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/groups-new-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import I18n from "I18n";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";

--- a/app/assets/javascripts/discourse/tests/acceptance/hamburger-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/hamburger-menu-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import {
   acceptance,

--- a/app/assets/javascripts/discourse/tests/acceptance/hashtags-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/hashtags-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/invite-accept-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/invite-accept-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import PreloadStore from "discourse/lib/preload-store";

--- a/app/assets/javascripts/discourse/tests/acceptance/invite-show-user-fields-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/invite-show-user-fields-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import PreloadStore from "discourse/lib/preload-store";

--- a/app/assets/javascripts/discourse/tests/acceptance/jump-to-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/jump-to-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/keyboard-shortcuts-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/keyboard-shortcuts-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import pretender from "discourse/tests/helpers/create-pretender";

--- a/app/assets/javascripts/discourse/tests/acceptance/login-redirect-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/login-redirect-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/login-required-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/login-required-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/login-with-email-and-hide-email-address-taken-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/login-with-email-and-hide-email-address-taken-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import I18n from "I18n";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";

--- a/app/assets/javascripts/discourse/tests/acceptance/login-with-email-and-no-social-logins-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/login-with-email-and-no-social-logins-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/login-with-email-disabled-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/login-with-email-disabled-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/login-with-email-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/login-with-email-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import I18n from "I18n";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";

--- a/app/assets/javascripts/discourse/tests/acceptance/mobile-discovery-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/mobile-discovery-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 acceptance("Topic Discovery - Mobile", { mobileView: true });

--- a/app/assets/javascripts/discourse/tests/acceptance/mobile-sign-in-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/mobile-sign-in-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/mobile-users-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/mobile-users-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/modal-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/modal-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { skip } from "qunit";
 import { test } from "qunit";
 import I18n from "I18n";

--- a/app/assets/javascripts/discourse/tests/acceptance/new-message-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/new-message-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/new-topic-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/new-topic-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";

--- a/app/assets/javascripts/discourse/tests/acceptance/notifications-filter-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/notifications-filter-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import selectKit from "discourse/tests/helpers/select-kit-helper";

--- a/app/assets/javascripts/discourse/tests/acceptance/page-publishing-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/page-publishing-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/password-reset-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/password-reset-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import I18n from "I18n";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";

--- a/app/assets/javascripts/discourse/tests/acceptance/personal-message-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/personal-message-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import I18n from "I18n";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";

--- a/app/assets/javascripts/discourse/tests/acceptance/plugin-keyboard-shortcut-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/plugin-keyboard-shortcut-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import { withPluginApi } from "discourse/lib/plugin-api";

--- a/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-connector-class-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-connector-class-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import { extraConnectorClass } from "discourse/lib/plugin-connectors";

--- a/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-decorator-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-decorator-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import { withPluginApi } from "discourse/lib/plugin-api";

--- a/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-multi-template-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-multi-template-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import { clearCache } from "discourse/lib/plugin-connectors";

--- a/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-single-template-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-single-template-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/post-admin-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/post-admin-menu-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/preferences-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/preferences-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import I18n from "I18n";
 import {

--- a/app/assets/javascripts/discourse/tests/acceptance/raw-plugin-outlet-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/raw-plugin-outlet-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import compile from "handlebars-compiler";

--- a/app/assets/javascripts/discourse/tests/acceptance/redirect-to-top-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/redirect-to-top-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import {
   acceptance,

--- a/app/assets/javascripts/discourse/tests/acceptance/reports-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/reports-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/review-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/review-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";

--- a/app/assets/javascripts/discourse/tests/acceptance/search-full-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-full-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { skip } from "qunit";
 import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";

--- a/app/assets/javascripts/discourse/tests/acceptance/search-mobile-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-mobile-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/search-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";

--- a/app/assets/javascripts/discourse/tests/acceptance/share-and-invite-desktop-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/share-and-invite-desktop-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/share-and-invite-mobile-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/share-and-invite-mobile-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";

--- a/app/assets/javascripts/discourse/tests/acceptance/shared-drafts-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/shared-drafts-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";

--- a/app/assets/javascripts/discourse/tests/acceptance/sign-in-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sign-in-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { skip } from "qunit";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";

--- a/app/assets/javascripts/discourse/tests/acceptance/static-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/static-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 acceptance("Static");

--- a/app/assets/javascripts/discourse/tests/acceptance/tag-groups-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/tag-groups-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";

--- a/app/assets/javascripts/discourse/tests/acceptance/tags-intersection-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/tags-intersection-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/tags-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/tags-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import {
   updateCurrentUser,

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-admin-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-admin-menu-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import {
   acceptance,

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-anonymous-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-anonymous-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 acceptance("Topic - Anonymous");

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-discovery-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-discovery-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import DiscourseURL from "discourse/lib/url";
 import selectKit from "discourse/tests/helpers/select-kit-helper";

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-edit-timer-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-edit-timer-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { skip } from "qunit";
 import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-footer-buttons-mobile-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-footer-buttons-mobile-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import I18n from "I18n";
 import selectKit from "discourse/tests/helpers/select-kit-helper";

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-list-tracker-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-list-tracker-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import {

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-move-posts-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-move-posts-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import I18n from "I18n";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-notifications-button-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-notifications-button-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-quote-button-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-quote-button-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import I18n from "I18n";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { skip } from "qunit";
 import { test } from "qunit";
 import I18n from "I18n";

--- a/app/assets/javascripts/discourse/tests/acceptance/unknown-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/unknown-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import pretender from "discourse/tests/helpers/create-pretender";

--- a/app/assets/javascripts/discourse/tests/acceptance/user-anonymous-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-anonymous-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 acceptance("User Anonymous");

--- a/app/assets/javascripts/discourse/tests/acceptance/user-bookmarks-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-bookmarks-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import selectKit from "discourse/tests/helpers/select-kit-helper";

--- a/app/assets/javascripts/discourse/tests/acceptance/user-card-mobile-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-card-mobile-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { skip } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import DiscourseURL from "discourse/lib/url";

--- a/app/assets/javascripts/discourse/tests/acceptance/user-card-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-card-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { skip } from "qunit";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";

--- a/app/assets/javascripts/discourse/tests/acceptance/user-drafts-stream-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-drafts-stream-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/user-preferences-interface-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-preferences-interface-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import selectKit from "discourse/tests/helpers/select-kit-helper";

--- a/app/assets/javascripts/discourse/tests/acceptance/user-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-test.js
@@ -1,3 +1,4 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import pretender from "discourse/tests/helpers/create-pretender";

--- a/app/assets/javascripts/discourse/tests/acceptance/users-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/users-test.js
@@ -1,5 +1,7 @@
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+
 acceptance("User Directory");
 
 test("Visit Page", async (assert) => {

--- a/app/assets/javascripts/discourse/tests/setup-tests.js
+++ b/app/assets/javascripts/discourse/tests/setup-tests.js
@@ -50,7 +50,6 @@ export default function setupTests(App) {
 
   App.rootElement = "#ember-testing";
   App.setupForTesting();
-  App.injectTestHelpers();
   App.SiteSettings = currentSettings();
   App.start();
 

--- a/app/assets/javascripts/discourse/tests/test_helper.js
+++ b/app/assets/javascripts/discourse/tests/test_helper.js
@@ -43,5 +43,6 @@
 //= require test-shims
 //= require jquery.magnific-popup.min.js
 
+Discourse.injectTestHelpers();
 let setupTests = require("discourse/tests/setup-tests").default;
 setupTests(window.Discourse);

--- a/app/assets/javascripts/test-shims.js
+++ b/app/assets/javascripts/test-shims.js
@@ -20,6 +20,9 @@ define("ember-qunit", () => {
 define("@ember/test-helpers", () => {
   return {
     setResolver: window.setResolver,
+    visit() {
+      return window.visit(...arguments);
+    },
   };
 });
 define("pretender", () => {

--- a/app/assets/javascripts/wizard/test/acceptance/wizard-test.js
+++ b/app/assets/javascripts/wizard/test/acceptance/wizard-test.js
@@ -1,6 +1,7 @@
 import { test, module } from "qunit";
 import { run } from "@ember/runloop";
 import startApp from "wizard/test/helpers/start-app";
+import { visit } from "@ember/test-helpers";
 
 var wizard;
 module("Acceptance: wizard", {


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
