### PR TITLE
FEATURE: add penalty options for take action

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/flag.js
+++ b/app/assets/javascripts/discourse/app/controllers/flag.js
@@ -29,23 +29,23 @@ export default Controller.extend(ModalFunctionality, {
         id: "agree_and_keep",
         icon: "thumbs-up",
         label: I18n.t("flagging.take_action_options.default.title"),
-        description: I18n.t("flagging.take_action_options.default.details")
+        description: I18n.t("flagging.take_action_options.default.details"),
       },
       {
         id: "agree_and_suspend",
         icon: "ban",
         label: I18n.t("flagging.take_action_options.suspend.title"),
         description: I18n.t("flagging.take_action_options.suspend.details"),
-        client_action: "suspend"
+        client_action: "suspend",
       },
       {
         id: "agree_and_silence",
         icon: "microphone-slash",
         label: I18n.t("flagging.take_action_options.silence.title"),
         description: I18n.t("flagging.take_action_options.silence.details"),
-        client_action: "silence"
-      }
-    ]
+        client_action: "silence",
+      },
+    ],
   },
 
   clientSuspend(performAction) {
@@ -65,7 +65,7 @@ export default Controller.extend(ModalFunctionality, {
       return adminTools[adminToolMethod](createdBy, {
         postId,
         postEdit,
-        before: performAction
+        before: performAction,
       });
     }
   },
@@ -73,12 +73,12 @@ export default Controller.extend(ModalFunctionality, {
   onShow() {
     this.setProperties({
       selected: null,
-      spammerDetails: null
+      spammerDetails: null,
     });
 
     let adminTools = this.adminTools;
     if (adminTools) {
-      adminTools.checkSpammer(this.get("model.user_id")).then(result => {
+      adminTools.checkSpammer(this.get("model.user_id")).then((result) => {
         this.set("spammerDetails", result);
       });
     }
@@ -114,15 +114,15 @@ export default Controller.extend(ModalFunctionality, {
       // flagging topic
       let lookup = EmberObject.create();
       let model = this.model;
-      model.get("actions_summary").forEach(a => {
+      model.get("actions_summary").forEach((a) => {
         a.flagTopic = model;
         a.actionType = this.site.topicFlagTypeById(a.id);
         lookup.set(a.actionType.get("name_key"), ActionSummary.create(a));
       });
       this.set("topicActionByName", lookup);
 
-      return this.site.get("topic_flag_types").filter(item => {
-        return this.get("model.actions_summary").some(a => {
+      return this.site.get("topic_flag_types").filter((item) => {
+        return this.get("model.actions_summary").some((a) => {
           return a.id === item.get("id") && a.can_act;
         });
       });
@@ -249,10 +249,10 @@ export default Controller.extend(ModalFunctionality, {
             this.set("message", "");
           }
           this.appEvents.trigger("post-stream:refresh", {
-            id: this.get("model.id")
+            id: this.get("model.id"),
           });
         })
-        .catch(error => {
+        .catch((error) => {
           this.send("closeModal");
           popupAjaxError(error);
         });
@@ -265,7 +265,7 @@ export default Controller.extend(ModalFunctionality, {
 
     changePostActionType(action) {
       this.set("selected", action);
-    }
+    },
   },
 
   @discourseComputed("flagTopic", "selected.name_key")
@@ -273,5 +273,5 @@ export default Controller.extend(ModalFunctionality, {
     return (
       !flagTopic && this.currentUser.get("staff") && nameKey === "notify_user"
     );
-  }
+  },
 });

--- a/app/assets/javascripts/discourse/app/controllers/flag.js
+++ b/app/assets/javascripts/discourse/app/controllers/flag.js
@@ -20,32 +20,36 @@ export default Controller.extend(ModalFunctionality, {
   isWarning: false,
   topicActionByName: null,
   spammerDetails: null,
+  flagActions: null,
 
-  flagActions: {
-    icon: "gavel",
-    label: I18n.t("flagging.take_action"),
-    actions: [
-      {
-        id: "agree_and_keep",
-        icon: "thumbs-up",
-        label: I18n.t("flagging.take_action_options.default.title"),
-        description: I18n.t("flagging.take_action_options.default.details"),
-      },
-      {
-        id: "agree_and_suspend",
-        icon: "ban",
-        label: I18n.t("flagging.take_action_options.suspend.title"),
-        description: I18n.t("flagging.take_action_options.suspend.details"),
-        client_action: "suspend",
-      },
-      {
-        id: "agree_and_silence",
-        icon: "microphone-slash",
-        label: I18n.t("flagging.take_action_options.silence.title"),
-        description: I18n.t("flagging.take_action_options.silence.details"),
-        client_action: "silence",
-      },
-    ],
+  init() {
+    this._super(...arguments);
+    this.flagActions = {
+      icon: "gavel",
+      label: I18n.t("flagging.take_action"),
+      actions: [
+        {
+          id: "agree_and_keep",
+          icon: "thumbs-up",
+          label: I18n.t("flagging.take_action_options.default.title"),
+          description: I18n.t("flagging.take_action_options.default.details"),
+        },
+        {
+          id: "agree_and_suspend",
+          icon: "ban",
+          label: I18n.t("flagging.take_action_options.suspend.title"),
+          description: I18n.t("flagging.take_action_options.suspend.details"),
+          client_action: "suspend",
+        },
+        {
+          id: "agree_and_silence",
+          icon: "microphone-slash",
+          label: I18n.t("flagging.take_action_options.silence.title"),
+          description: I18n.t("flagging.take_action_options.silence.details"),
+          client_action: "silence",
+        },
+      ],
+    };
   },
 
   clientSuspend(performAction) {
@@ -57,12 +61,11 @@ export default Controller.extend(ModalFunctionality, {
   },
 
   async _penalize(adminToolMethod, performAction) {
-    let adminTools = this.adminTools;
-    if (adminTools) {
+    if (this.adminTools) {
       let createdBy = await User.findByUsername(this.model.username);
       let postId = this.model.id;
       let postEdit = this.model.cooked;
-      return adminTools[adminToolMethod](createdBy, {
+      return this.adminTools[adminToolMethod](createdBy, {
         postId,
         postEdit,
         before: performAction,
@@ -76,9 +79,8 @@ export default Controller.extend(ModalFunctionality, {
       spammerDetails: null,
     });
 
-    let adminTools = this.adminTools;
-    if (adminTools) {
-      adminTools.checkSpammer(this.get("model.user_id")).then((result) => {
+    if (this.adminTools) {
+      this.adminTools.checkSpammer(this.get("model.user_id")).then((result) => {
         this.set("spammerDetails", result);
       });
     }

--- a/app/assets/javascripts/discourse/app/templates/modal/flag.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/flag.hbs
@@ -35,13 +35,10 @@
   {{/if}}
 
   {{#if canTakeAction}}
-    {{d-button
-      class="btn-danger"
-      action=(action "takeAction")
-      disabled=submitDisabled
-      title="flagging.take_action_tooltip"
-      icon="gavel"
-      label="flagging.take_action"
+    {{reviewable-bundled-action
+        bundle=flagActions
+        performAction=(action "takeAction")
+        reviewableUpdating=submitDisabled
     }}
   {{/if}}
 

--- a/app/assets/javascripts/discourse/tests/acceptance/flag-post-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/flag-post-test.js
@@ -35,7 +35,7 @@ acceptance("flagging", {
         public_admission: false,
         allow_membership_requests: true,
         membership_request_template: "Please add me",
-        full_name: null
+        full_name: null,
       });
     });
     pretenderServer.get("/admin/users/5.json", () => {
@@ -60,20 +60,20 @@ acceptance("flagging", {
         public_admission: false,
         allow_membership_requests: true,
         membership_request_template: "Please add me",
-        full_name: null
+        full_name: null,
       });
     });
     pretenderServer.put("admin/users/5/silence", () => {
       return helper.response({
-        silenced: true
+        silenced: true,
       });
     });
     pretenderServer.post("post_actions", () => {
       return helper.response({
-        response: true
+        response: true,
       });
     });
-  }
+  },
 });
 
 async function openFlagModal() {
@@ -84,13 +84,13 @@ async function openFlagModal() {
   await click(".topic-post:first-child button.create-flag");
 }
 
-test("Flag modal opening", async assert => {
+test("Flag modal opening", async (assert) => {
   await visit("/t/internationalization-localization/280");
   await openFlagModal();
   assert.ok(exists(".flag-modal-body"), "it shows the flag modal");
 });
 
-test("Flag take action dropdown exists", async assert => {
+test("Flag take action dropdown exists", async (assert) => {
   await visit("/t/internationalization-localization/280");
   await openFlagModal();
   await click("#radio_inappropriate");
@@ -103,7 +103,7 @@ test("Flag take action dropdown exists", async assert => {
   assert.ok(exists(".silence-user-modal"), "it shows the silence modal");
 });
 
-test("Can silence from take action", async assert => {
+test("Can silence from take action", async (assert) => {
   await visit("/t/internationalization-localization/280");
   await openFlagModal();
   await click("#radio_inappropriate");
@@ -118,7 +118,7 @@ test("Can silence from take action", async assert => {
   assert.equal(find(".bootbox.modal:visible").length, 0);
 });
 
-test("Gets dismissable warning from canceling incomplete silence from take action", async assert => {
+test("Gets dismissable warning from canceling incomplete silence from take action", async (assert) => {
   await visit("/t/internationalization-localization/280");
   await openFlagModal();
   await click("#radio_inappropriate");

--- a/app/assets/javascripts/discourse/tests/acceptance/flag-post-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/flag-post-test.js
@@ -1,0 +1,144 @@
+import { test } from "qunit";
+import selectKit from "discourse/tests/helpers/select-kit-helper";
+import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+import userFixtures from "discourse/tests/fixtures/user-fixtures";
+
+acceptance("flagging", {
+  loggedIn: true,
+  afterEach() {
+    sandbox.restore();
+  },
+  pretend(pretenderServer, helper) {
+    const userResponse = Object.assign({}, userFixtures["/u/charlie.json"]);
+    pretenderServer.get("/u/uwe_keim.json", () => {
+      return helper.response(userResponse);
+    });
+    pretenderServer.get("/admin/users/255.json", () => {
+      return helper.response({
+        id: 255,
+        automatic: false,
+        name: "admin",
+        username: "admin",
+        user_count: 0,
+        alias_level: 99,
+        visible: true,
+        automatic_membership_email_domains: "",
+        primary_group: false,
+        title: null,
+        grant_trust_level: null,
+        has_messages: false,
+        flair_url: null,
+        flair_bg_color: null,
+        flair_color: null,
+        bio_raw: null,
+        bio_cooked: null,
+        public_admission: false,
+        allow_membership_requests: true,
+        membership_request_template: "Please add me",
+        full_name: null
+      });
+    });
+    pretenderServer.get("/admin/users/5.json", () => {
+      return helper.response({
+        id: 5,
+        automatic: false,
+        name: "user",
+        username: "user",
+        user_count: 0,
+        alias_level: 99,
+        visible: true,
+        automatic_membership_email_domains: "",
+        primary_group: false,
+        title: null,
+        grant_trust_level: null,
+        has_messages: false,
+        flair_url: null,
+        flair_bg_color: null,
+        flair_color: null,
+        bio_raw: null,
+        bio_cooked: null,
+        public_admission: false,
+        allow_membership_requests: true,
+        membership_request_template: "Please add me",
+        full_name: null
+      });
+    });
+    pretenderServer.put("admin/users/5/silence", () => {
+      return helper.response({
+        silenced: true
+      });
+    });
+    pretenderServer.post("post_actions", () => {
+      return helper.response({
+        response: true
+      });
+    });
+  }
+});
+
+async function openFlagModal() {
+  if (exists(".topic-post:first-child button.show-more-actions")) {
+    await click(".topic-post:first-child button.show-more-actions");
+  }
+
+  await click(".topic-post:first-child button.create-flag");
+}
+
+test("Flag modal opening", async assert => {
+  await visit("/t/internationalization-localization/280");
+  await openFlagModal();
+  assert.ok(exists(".flag-modal-body"), "it shows the flag modal");
+});
+
+test("Flag take action dropdown exists", async assert => {
+  await visit("/t/internationalization-localization/280");
+  await openFlagModal();
+  await click("#radio_inappropriate");
+  await selectKit(".reviewable-action-dropdown").expand();
+  assert.ok(
+    exists("[data-value='agree_and_silence']"),
+    "it shows the silence action option"
+  );
+  await click("[data-value='agree_and_silence']");
+  assert.ok(exists(".silence-user-modal"), "it shows the silence modal");
+});
+
+test("Can silence from take action", async assert => {
+  await visit("/t/internationalization-localization/280");
+  await openFlagModal();
+  await click("#radio_inappropriate");
+  await selectKit(".reviewable-action-dropdown").expand();
+  await click("[data-value='agree_and_silence']");
+
+  const silenceUntilCombobox = selectKit(".silence-until .combobox");
+  await silenceUntilCombobox.expand();
+  await silenceUntilCombobox.selectRowByValue("tomorrow");
+  await fillIn(".silence-reason", "for breaking the rules");
+  await click(".perform-silence");
+  assert.equal(find(".bootbox.modal:visible").length, 0);
+});
+
+test("Gets dismissable warning from canceling incomplete silence from take action", async assert => {
+  await visit("/t/internationalization-localization/280");
+  await openFlagModal();
+  await click("#radio_inappropriate");
+  await selectKit(".reviewable-action-dropdown").expand();
+  await click("[data-value='agree_and_silence']");
+
+  const silenceUntilCombobox = selectKit(".silence-until .combobox");
+  await silenceUntilCombobox.expand();
+  await silenceUntilCombobox.selectRowByValue("tomorrow");
+  await fillIn(".silence-reason", "for breaking the rules");
+  await click(".d-modal-cancel");
+  assert.equal(find(".bootbox.modal:visible").length, 1);
+
+  await click(".modal-footer .btn-default");
+  assert.equal(find(".bootbox.modal:visible").length, 0);
+  assert.ok(exists(".silence-user-modal"), "it shows the silence modal");
+
+  await click(".d-modal-cancel");
+  assert.equal(find(".bootbox.modal:visible").length, 1);
+
+  await click(".modal-footer .btn-primary");
+  assert.equal(find(".bootbox.modal:visible").length, 0);
+});

--- a/app/assets/stylesheets/common/base/reviewables.scss
+++ b/app/assets/stylesheets/common/base/reviewables.scss
@@ -490,6 +490,10 @@
   }
 }
 
+.flag-modal .modal-inner-container .select-kit.reviewable-action-dropdown {
+  width: initial;
+}
+
 @media screen and (max-width: 1000px) {
   table.reviewable-scores {
     width: 100%;

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2997,7 +2997,17 @@ en:
     flagging:
       title: "Thanks for helping to keep our community civil!"
       action: "Flag Post"
-      take_action: "Take Action"
+      take_action: "Take Action..."
+      take_action_options:
+        default:
+          title: "Take Action"
+          details: "Reach the flag threshold immediately, rather than waiting for more community flags"
+        suspend:
+          title: "Suspend User"
+          details: "Reach the flag threshold, and suspend the user"
+        silence:
+          title: "Silence User"
+          details: "Reach the flag threshold, and silence the user"
       notify_action: "Message"
       official_warning: "Official Warning"
       delete_spammer: "Delete Spammer"


### PR DESCRIPTION
Add the ability to silence or suspend users from the "take action"
button when moderators are flagging posts. This allows for a more streamlined
active moderation workflow, when moderating against a topic directly.

![Screenshot from 2020-10-14 16-49-44](https://user-images.githubusercontent.com/1322534/96057227-4c402c00-0e3d-11eb-91f2-f6e2689d0970.png)
