### PR TITLE
Refactor: tags/show should use d-navigation

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-navigation.js
+++ b/app/assets/javascripts/discourse/app/components/d-navigation.js
@@ -60,14 +60,20 @@ export default Component.extend(FilterModeMixin, {
   @discourseComputed("category.can_edit")
   showCategoryEdit: (canEdit) => canEdit,
 
-  @discourseComputed("filterType", "category", "noSubcategories")
-  navItems(filterType, category, noSubcategories) {
+  @discourseComputed("additionalTags", "category", "tag.id")
+  showToggleInfo(additionalTags, category, tagId) {
+    return !additionalTags && !category && tagId !== "none";
+  },
+
+  @discourseComputed("filterType", "category", "noSubcategories", "tag.id")
+  navItems(filterType, category, noSubcategories, tagId) {
     const currentRouteQueryParams = this.get("router.currentRoute.queryParams");
 
     return NavItem.buildList(category, {
       filterType,
       noSubcategories,
       currentRouteQueryParams,
+      tagId,
       siteSettings: this.siteSettings,
     });
   },
@@ -94,6 +100,25 @@ export default Component.extend(FilterModeMixin, {
       } else {
         this.createTopic();
       }
+    },
+
+    toggleTagInfo() {
+      return this.toggleProperty("showInfo");
+    },
+
+    changeTagNotificationLevel(notificationLevel) {
+      this.tagNotification
+        .update({ notification_level: notificationLevel })
+        .then((response) => {
+          this.currentUser.set(
+            "muted_tag_ids",
+            this.currentUser.calculateMutedIds(
+              notificationLevel,
+              response.responseJson.tag_id,
+              "muted_tag_ids"
+            )
+          );
+        });
     },
   },
 });

--- a/app/assets/javascripts/discourse/app/components/d-navigation.js
+++ b/app/assets/javascripts/discourse/app/components/d-navigation.js
@@ -107,24 +107,5 @@ export default Component.extend(FilterModeMixin, {
         this.createTopic();
       }
     },
-
-    toggleTagInfo() {
-      return this.toggleProperty("showInfo");
-    },
-
-    changeTagNotificationLevel(notificationLevel) {
-      this.tagNotification
-        .update({ notification_level: notificationLevel })
-        .then((response) => {
-          this.currentUser.set(
-            "muted_tag_ids",
-            this.currentUser.calculateMutedIds(
-              notificationLevel,
-              response.responseJson.tag_id,
-              "muted_tag_ids"
-            )
-          );
-        });
-    },
   },
 });

--- a/app/assets/javascripts/discourse/app/components/d-navigation.js
+++ b/app/assets/javascripts/discourse/app/components/d-navigation.js
@@ -25,14 +25,20 @@ export default Component.extend(FilterModeMixin, {
   @discourseComputed(
     "createTopicDisabled",
     "hasDraft",
-    "categoryReadOnlyBanner"
+    "categoryReadOnlyBanner",
+    "canCreateTopicOnTag",
+    "tagId"
   )
   createTopicButtonDisabled(
     createTopicDisabled,
     hasDraft,
-    categoryReadOnlyBanner
+    categoryReadOnlyBanner,
+    canCreateTopicOnTag,
+    tagId
   ) {
-    if (categoryReadOnlyBanner && !hasDraft) {
+    if (tagId && !canCreateTopicOnTag) {
+      return true;
+    } else if (categoryReadOnlyBanner && !hasDraft) {
       return false;
     }
     return createTopicDisabled;
@@ -60,12 +66,12 @@ export default Component.extend(FilterModeMixin, {
   @discourseComputed("category.can_edit")
   showCategoryEdit: (canEdit) => canEdit,
 
-  @discourseComputed("additionalTags", "category", "tag.id")
+  @discourseComputed("additionalTags", "category", "tagId")
   showToggleInfo(additionalTags, category, tagId) {
     return !additionalTags && !category && tagId !== "none";
   },
 
-  @discourseComputed("filterType", "category", "noSubcategories", "tag.id")
+  @discourseComputed("filterType", "category", "noSubcategories", "tagId")
   navItems(filterType, category, noSubcategories, tagId) {
     const currentRouteQueryParams = this.get("router.currentRoute.queryParams");
 

--- a/app/assets/javascripts/discourse/app/components/d-navigation.js
+++ b/app/assets/javascripts/discourse/app/components/d-navigation.js
@@ -27,7 +27,7 @@ export default Component.extend(FilterModeMixin, {
     "hasDraft",
     "categoryReadOnlyBanner",
     "canCreateTopicOnTag",
-    "tagId"
+    "tag.id"
   )
   createTopicButtonDisabled(
     createTopicDisabled,
@@ -66,12 +66,12 @@ export default Component.extend(FilterModeMixin, {
   @discourseComputed("category.can_edit")
   showCategoryEdit: (canEdit) => canEdit,
 
-  @discourseComputed("additionalTags", "category", "tagId")
+  @discourseComputed("additionalTags", "category", "tag.id")
   showToggleInfo(additionalTags, category, tagId) {
     return !additionalTags && !category && tagId !== "none";
   },
 
-  @discourseComputed("filterType", "category", "noSubcategories", "tagId")
+  @discourseComputed("filterType", "category", "noSubcategories", "tag.id")
   navItems(filterType, category, noSubcategories, tagId) {
     const currentRouteQueryParams = this.get("router.currentRoute.queryParams");
 

--- a/app/assets/javascripts/discourse/app/components/tag-heading.js
+++ b/app/assets/javascripts/discourse/app/components/tag-heading.js
@@ -1,0 +1,4 @@
+import Component from "@ember/component";
+export default Component.extend({
+  tagName: "",
+});

--- a/app/assets/javascripts/discourse/app/templates/components/bread-crumbs.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/bread-crumbs.hbs
@@ -18,7 +18,7 @@
     {{!-- the tag filter doesn't work with tag intersections, so hide it --}}
     {{#if siteSettings.show_filter_by_tag}}
       {{tag-drop firstCategory=category tagId=tag.id}}
-    {{/if}}  
+    {{/if}}
   {{/unless}}
 {{/if}}
 

--- a/app/assets/javascripts/discourse/app/templates/components/bread-crumbs.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/bread-crumbs.hbs
@@ -14,7 +14,12 @@
 {{/each}}
 
 {{#if siteSettings.tagging_enabled}}
-  {{tag-drop firstCategory=category tagId=tagId}}
+  {{#unless additionalTags}}
+    {{!-- the tag filter doesn't work with tag intersections, so hide it --}}
+    {{#if siteSettings.show_filter_by_tag}}
+      {{tag-drop firstCategory=category tagId=tag.id}}
+    {{/if}}  
+  {{/unless}}
 {{/if}}
 
 {{plugin-outlet name="bread-crumbs-right" connectorTagName="li" tagName=""}}

--- a/app/assets/javascripts/discourse/app/templates/components/d-navigation.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/d-navigation.hbs
@@ -1,4 +1,6 @@
-{{bread-crumbs categories=categories category=category noSubcategories=noSubcategories}}
+{{bread-crumbs categories=categories category=category noSubcategories=noSubcategories tagId=tagId}}
+
+{{navigation-bar navItems=navItems filterMode=filterMode category=category}}
 
 {{#if showCategoryAdmin}}
   {{categories-admin-dropdown
@@ -9,14 +11,39 @@
   }}
 {{/if}}
 
-{{navigation-bar navItems=navItems filterMode=filterMode category=category}}
+{{#if category}}
+  {{#unless tagId}}
+    {{#if showCategoryEdit}}
+      {{d-button
+        class="btn-default edit-category"
+        action=editCategory
+        icon="wrench"
+        label="category.edit"}}
+    {{/if}}
 
-{{#if showCategoryNotifications}}
-  {{category-notifications-button
-    value=category.notification_level
-    category=category
-    onChange=(action "changeCategoryNotificationLevel")
-  }}
+    {{#if showCategoryNotifications}}
+      {{category-notifications-button
+        value=category.notification_level
+        category=category
+        onChange=(action "changeCategoryNotificationLevel")
+      }}
+    {{/if}}
+  {{/unless}}
+{{/if}}
+
+{{#if tagId}}
+  {{#if showToggleInfo}}
+    {{d-button icon="tag" class="btn-default" label="tagging.info" action=(action "toggleTagInfo") id="show-tag-info"}}
+  {{/if}}
+
+  {{#if tagNotification}}
+    {{#unless additionalTags}}
+      {{tag-notifications-button
+        onChange=(action "changeTagNotificationLevel")
+        value=tagNotification.notification_level
+      }}
+    {{/unless}}
+  {{/if}}
 {{/if}}
 
 {{plugin-outlet name="before-create-topic-button"
@@ -34,10 +61,3 @@
   btnClass=createTopicClass
 }}
 
-{{#if showCategoryEdit}}
-  {{d-button
-    class="btn-default edit-category"
-    action=editCategory
-    icon="wrench"
-    label="category.edit"}}
-{{/if}}

--- a/app/assets/javascripts/discourse/app/templates/components/d-navigation.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/d-navigation.hbs
@@ -1,6 +1,9 @@
-{{bread-crumbs categories=categories category=category noSubcategories=noSubcategories tagId=tagId}}
+{{bread-crumbs categories=categories category=category noSubcategories=noSubcategories tag=tag additionalTags=additionalTags}}
 
-{{navigation-bar navItems=navItems filterMode=filterMode category=category}}
+{{#unless additionalTags}}
+  {{!-- nav bar doesn't work with tag intersections --}}
+  {{navigation-bar navItems=navItems filterMode=filterMode category=category}}
+{{/unless}}
 
 {{#if showCategoryAdmin}}
   {{categories-admin-dropdown
@@ -12,15 +15,8 @@
 {{/if}}
 
 {{#if category}}
-  {{#unless tagId}}
-    {{#if showCategoryEdit}}
-      {{d-button
-        class="btn-default edit-category"
-        action=editCategory
-        icon="wrench"
-        label="category.edit"}}
-    {{/if}}
-
+  {{#unless tag}}
+    {{!-- don't show category notification menu on tag pages --}}
     {{#if showCategoryNotifications}}
       {{category-notifications-button
         value=category.notification_level
@@ -31,13 +27,10 @@
   {{/unless}}
 {{/if}}
 
-{{#if tagId}}
-  {{#if showToggleInfo}}
-    {{d-button icon="tag" class="btn-default" label="tagging.info" action=toggleInfo id="show-tag-info"}}
-  {{/if}}
-
+{{#if tag}}
   {{#if tagNotification}}
     {{#unless additionalTags}}
+      {{!-- don't show tag notification menu on tag intersections --}}
       {{tag-notifications-button
         onChange=changeTagNotificationLevel
         value=tagNotification.notification_level
@@ -62,3 +55,21 @@
   canCreateTopicOnTag=canCreateTopicOnTag
 }}
 
+{{#if category}}
+  {{#unless tag}}
+    {{!-- don't show category edit button on tag pages --}}
+    {{#if showCategoryEdit}}
+      {{d-button
+        class="btn-default edit-category"
+        action=editCategory
+        icon="wrench"
+        label="category.edit"}}
+    {{/if}}
+  {{/unless}}
+{{/if}}
+
+{{#if tag}}
+  {{#if showToggleInfo}}
+    {{d-button icon="tag" class="btn-default" label="tagging.info" action=toggleInfo id="show-tag-info"}}
+  {{/if}}
+{{/if}}

--- a/app/assets/javascripts/discourse/app/templates/components/d-navigation.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/d-navigation.hbs
@@ -33,13 +33,13 @@
 
 {{#if tagId}}
   {{#if showToggleInfo}}
-    {{d-button icon="tag" class="btn-default" label="tagging.info" action=(action "toggleTagInfo") id="show-tag-info"}}
+    {{d-button icon="tag" class="btn-default" label="tagging.info" action=toggleInfo id="show-tag-info"}}
   {{/if}}
 
   {{#if tagNotification}}
     {{#unless additionalTags}}
       {{tag-notifications-button
-        onChange=(action "changeTagNotificationLevel")
+        onChange=changeTagNotificationLevel
         value=tagNotification.notification_level
       }}
     {{/unless}}

--- a/app/assets/javascripts/discourse/app/templates/components/d-navigation.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/d-navigation.hbs
@@ -59,5 +59,6 @@
   disabled=createTopicButtonDisabled
   label=createTopicLabel
   btnClass=createTopicClass
+  canCreateTopicOnTag=canCreateTopicOnTag
 }}
 

--- a/app/assets/javascripts/discourse/app/templates/components/tag-heading.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/tag-heading.hbs
@@ -1,0 +1,11 @@
+<h2 class="tag-show-heading">
+  {{#link-to "tags"}}
+    {{i18n "tagging.tags"}}
+  {{/link-to}}
+  {{d-icon "angle-right"}}
+  {{discourse-tag-bound tagRecord=tag style="simple"}}
+  {{#each additionalTags as |tag|}}
+    <span>&amp;</span>
+    {{discourse-tag tag style="simple"}}
+  {{/each}}
+</h2>

--- a/app/assets/javascripts/discourse/app/templates/tags/index.hbs
+++ b/app/assets/javascripts/discourse/app/templates/tags/index.hbs
@@ -3,7 +3,7 @@
 </div>
 
 <div class="list-controls">
-  <div class="container">
+  <div class="container tags-controls">
     {{#if canAdminTags}}
       {{tags-admin-dropdown actionsMapping=actionsMapping}}
     {{/if}}

--- a/app/assets/javascripts/discourse/app/templates/tags/show.hbs
+++ b/app/assets/javascripts/discourse/app/templates/tags/show.hbs
@@ -6,6 +6,16 @@
   <div class="list-controls">
     <div class="container">
       <section class="navigation-container tag-navigation">
+
+        {{#if showTagFilter}}
+          {{#if additionalTags}}
+            {{!-- Tag intersections don't work with the tag filter, so show the tag heading instead --}}
+            {{tag-heading tag=tag additionalTags=additionalTags}}
+          {{/if}}
+        {{else}}
+          {{tag-heading tag=tag additionalTags=additionalTags}}
+        {{/if}}
+
         {{d-navigation
           filterMode=filterMode
           canCreateTopic=canCreateTopic
@@ -13,10 +23,11 @@
           createTopic=(route-action "createTopic")
           categories=categories
           category=category
-          tagId=tag.id
+          tag=tag
           noSubcategories=noSubcategories
           showToggleInfo=showToggleInfo
           tagNotification=tagNotification
+          additionalTags=additionalTags
           showInfo=showInfo
           canCreateTopicOnTag=canCreateTopicOnTag
           changeTagNotificationLevel=(action "changeTagNotificationLevel")

--- a/app/assets/javascripts/discourse/app/templates/tags/show.hbs
+++ b/app/assets/javascripts/discourse/app/templates/tags/show.hbs
@@ -18,6 +18,7 @@
           showToggleInfo=showToggleInfo
           tagNotification=tagNotification
           showInfo=showInfo
+          canCreateTopicOnTag=canCreateTopicOnTag
           }}
       </section>
     </div>

--- a/app/assets/javascripts/discourse/app/templates/tags/show.hbs
+++ b/app/assets/javascripts/discourse/app/templates/tags/show.hbs
@@ -5,53 +5,20 @@
 
   <div class="list-controls">
     <div class="container">
-      <section class="navigation-container">
-        {{#if showTagFilter}}
-          {{bread-crumbs
-            categories=categories
-            category=category
-            tagId=tag.id
-            noSubcategories=noSubcategories
-          }}
-          {{navigation-bar navItems=navItems filterMode=filterMode}}
-        {{else}}
-          <h2 class="tag-show-heading">
-            {{#link-to "tags"}}{{i18n "tagging.tags"}}{{/link-to}}
-            {{d-icon "angle-right"}}
-            {{discourse-tag-bound tagRecord=tag style="simple"}}
-            {{#each additionalTags as |tag|}}
-              <span>&amp;</span>
-              {{discourse-tag tag style="simple"}}
-            {{/each}}
-          </h2>
-        {{/if}}
-
-        {{#if tagNotification}}
-          {{#unless additionalTags}}
-            {{tag-notifications-button
-              onChange=(action "changeTagNotificationLevel")
-              value=tagNotification.notification_level
-            }}
-          {{/unless}}
-        {{/if}}
-
-        {{plugin-outlet name="before-create-topic-button"
-          args=(hash
-            canCreateTopic=canCreateTopic
-            createTopicDisabled=createTopicDisabled
-            createTopicLabel=createTopicLabel)
-        }}
-
-        {{create-topic-button
+      <section class="navigation-container tag-navigation">
+        {{d-navigation
+          filterMode=filterMode
           canCreateTopic=canCreateTopic
-          disabled=createTopicDisabled
-          label=createTopicLabel
-          action=(route-action "createTopic")
-        }}
-
-        {{#if showToggleInfo}}
-          {{d-button icon="tag" class="btn-default" label="tagging.info" action=(action "toggleInfo") id="show-tag-info"}}
-        {{/if}}
+          hasDraft=draft
+          createTopic=(route-action "createTopic")
+          categories=categories
+          category=category
+          tagId=tag.id
+          noSubcategories=noSubcategories
+          showToggleInfo=showToggleInfo
+          tagNotification=tagNotification
+          showInfo=showInfo
+          }}
       </section>
     </div>
   </div>

--- a/app/assets/javascripts/discourse/app/templates/tags/show.hbs
+++ b/app/assets/javascripts/discourse/app/templates/tags/show.hbs
@@ -19,6 +19,8 @@
           tagNotification=tagNotification
           showInfo=showInfo
           canCreateTopicOnTag=canCreateTopicOnTag
+          changeTagNotificationLevel=(action "changeTagNotificationLevel")
+          toggleInfo=(action "toggleInfo")
           }}
       </section>
     </div>

--- a/app/assets/stylesheets/common/base/tagging.scss
+++ b/app/assets/stylesheets/common/base/tagging.scss
@@ -38,10 +38,9 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: hidden;
-  @include breakpoint(mobile-large) {
-    width: 100%;
-  }
-  .d-icon {
+  width: 100%;
+  .d-icon,
+  span {
     margin: 0 0.25em;
   }
 }

--- a/app/assets/stylesheets/mobile/topic-list.scss
+++ b/app/assets/stylesheets/mobile/topic-list.scss
@@ -480,6 +480,14 @@ ol.category-breadcrumb {
   display: none;
 }
 
+.tags-controls {
+  display: flex;
+  h2 {
+    order: -1;
+    margin-right: auto;
+  }
+}
+
 .staff.tags-page #create-topic {
   clear: right;
 }


### PR DESCRIPTION
Currently the tag topic list template is duplicating d-navigation and adding the tag pieces, but we should probably use d-navigation directly.