### PR TITLE
UX: Increase width & center category reorder input

### DIFF
--- a/app/assets/stylesheets/common/base/cat_reorder.scss
+++ b/app/assets/stylesheets/common/base/cat_reorder.scss
@@ -4,9 +4,10 @@
       padding-bottom: 0.5em;
     }
   }
-  input {
-    width: 2.333em;
-    padding: 4px;
+  input[type="text"] {
+    max-width: 2.5em;
+    padding: 0.35em;
+    text-align: center;
     @include breakpoint(mobile-extra-large) {
       width: 2em;
     }


### PR DESCRIPTION
Needed to increase selector specificity for padding to work. Also centered alignment.

Discussion here: https://meta.discourse.org/t/2-digit-numbers-not-fully-shown-in-the-categories-reorder-dialog/166933

<img width="487" alt="Screen Shot 2020-10-14 at 10 45 27 PM" src="https://user-images.githubusercontent.com/1681963/96070890-10be5580-0e6f-11eb-8245-50cf64120629.png">

