### PR TITLE
FIX: styleguide is only a parent url and is accessed with /styleguide

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/url.js
+++ b/app/assets/javascripts/discourse/app/lib/url.js
@@ -34,7 +34,7 @@ const SERVER_SIDE_ONLY = [
   /^\/admin\/logs\/watched_words\/action\/[^\/]+\/download$/,
   /^\/pub\//,
   /^\/invites\//,
-  /^\/styleguide\//,
+  /^\/styleguide/,
 ];
 
 // The amount of height (in pixles) that we factor in when jumpEnd is called so


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
