### PR TITLE
REFACTOR: Continue to converge on what Ember CLI wants us to do

### DIFF
--- a/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
+++ b/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
@@ -38,6 +38,7 @@ import QUnit, { module } from "qunit";
 import siteFixtures from "discourse/tests/fixtures/site-fixtures";
 import Site from "discourse/models/site";
 import createStore from "discourse/tests/helpers/create-store";
+import { getApplication } from "@ember/test-helpers";
 
 export function currentUser() {
   return User.create(sessionFixtures["/session/current.json"].current_user);
@@ -201,7 +202,7 @@ export function acceptance(name, options) {
         resetSite(currentSettings(), options.site);
       }
 
-      Discourse.reset();
+      getApplication().reset();
       this.container = getOwner(this);
       setURLContainer(this.container);
       setDefaultOwner(this.container);
@@ -212,6 +213,7 @@ export function acceptance(name, options) {
     },
 
     afterEach() {
+      let app = getApplication();
       if (options && options.afterEach) {
         options.afterEach.call(this);
       }
@@ -236,15 +238,12 @@ export function acceptance(name, options) {
       _clearSnapshots();
       setURLContainer(null);
       setDefaultOwner(null);
-      Discourse._runInitializer(
-        "instanceInitializers",
-        (initName, initializer) => {
-          if (initializer && initializer.teardown) {
-            initializer.teardown(this.container);
-          }
+      app._runInitializer("instanceInitializers", (initName, initializer) => {
+        if (initializer && initializer.teardown) {
+          initializer.teardown(this.container);
         }
-      );
-      Discourse.reset();
+      });
+      app.reset();
 
       // We do this after reset so that the willClearRender will have already fired
       resetWidgetCleanCallbacks();

--- a/app/assets/javascripts/discourse/tests/setup-tests.js
+++ b/app/assets/javascripts/discourse/tests/setup-tests.js
@@ -25,10 +25,10 @@ import QUnit from "qunit";
 import MessageBus from "message-bus-client";
 import deprecated from "discourse-common/lib/deprecated";
 import sinon from "sinon";
-import { setResolver } from "@ember/test-helpers";
+import { setApplication, setResolver } from "@ember/test-helpers";
 
-export default function setupTests(App) {
-  setResolver(buildResolver("discourse").create({ namespace: App }));
+export default function setupTests(app, container) {
+  setResolver(buildResolver("discourse").create({ namespace: app }));
 
   sinon.config = {
     injectIntoThis: false,
@@ -41,17 +41,10 @@ export default function setupTests(App) {
   // Stop the message bus so we don't get ajax calls
   MessageBus.stop();
 
-  document.write(
-    '<div id="ember-testing-container"><div id="ember-testing"></div></div>'
-  );
-  document.write(
-    "<style>#ember-testing-container { position: absolute; background: white; bottom: 0; right: 0; width: 640px; height: 384px; overflow: auto; z-index: 9999; border: 1px solid #ccc; } #ember-testing { zoom: 50%; }</style>"
-  );
-
-  App.rootElement = "#ember-testing";
-  App.setupForTesting();
-  App.SiteSettings = currentSettings();
-  App.start();
+  app.rootElement = "#ember-testing";
+  app.setupForTesting();
+  app.SiteSettings = currentSettings();
+  app.start();
 
   // disable logster error reporting
   if (window.Logster) {
@@ -185,6 +178,7 @@ export default function setupTests(App) {
 
   // forces 0 as duration for all jquery animations
   jQuery.fx.off = true;
-  setDefaultOwner(App.__container__);
+  setApplication(app);
+  setDefaultOwner(container);
   resetSite();
 }

--- a/app/assets/javascripts/discourse/tests/test_helper.js
+++ b/app/assets/javascripts/discourse/tests/test_helper.js
@@ -43,6 +43,14 @@
 //= require test-shims
 //= require jquery.magnific-popup.min.js
 
-Discourse.injectTestHelpers();
+document.write(
+  '<div id="ember-testing-container"><div id="ember-testing"></div></div>'
+);
+document.write(
+  "<style>#ember-testing-container { position: absolute; background: white; bottom: 0; right: 0; width: 640px; height: 384px; overflow: auto; z-index: 9999; border: 1px solid #ccc; } #ember-testing { zoom: 50%; }</style>"
+);
+
+let app = window.Discourse;
+app.injectTestHelpers();
 let setupTests = require("discourse/tests/setup-tests").default;
-setupTests(window.Discourse);
+setupTests(app, app.__container__);

--- a/app/assets/javascripts/test-shims.js
+++ b/app/assets/javascripts/test-shims.js
@@ -17,9 +17,16 @@ define("ember-qunit", () => {
     moduleForComponent: window.moduleForComponent,
   };
 });
+let _app;
 define("@ember/test-helpers", () => {
   return {
     setResolver: window.setResolver,
+    setApplication(app) {
+      _app = app;
+    },
+    getApplication() {
+      return _app;
+    },
     visit() {
       return window.visit(...arguments);
     },


### PR DESCRIPTION
* The creation of a testing div is specific to Rails, so that is
moved back out of setupTests();

* We've removed the `Discourse` globals from the acceptance helpers in favor of
`setApplication`/`getApplication`.

* We pass the container to setupTests because there is no
`__container__` in later Ember versions.

* `App` is now `app` because it's not a constant or class, it's an
instance of an application.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
