### PR TITLE
DEV: generated release notes shouldn't include squashed commits

### DIFF
--- a/lib/tasks/release_note.rake
+++ b/lib/tasks/release_note.rake
@@ -11,7 +11,7 @@ task "release_note:generate", :from, :to do |t, args|
   sec_changes = Set.new
   perf_changes = Set.new
 
-  `git log #{from}..#{to}`.each_line do |comment|
+  `git log --pretty="tformat:%s" #{from}..#{to}`.each_line do |comment|
     next if comment =~ /^\s*Revert/
     split_comments(comment).each do |line|
       if line =~ /^FIX:/


### PR DESCRIPTION
Limit git log output to the first line of the commit message
when generating the list of commits in a release. Some commit messages
are including the names of all commits that were squashed, resulting
in duplicate and confusing lines in the release notes.