### PR TITLE
FEATURE: CTRL-SHIFT-ENTER and SHIFT-Click do not scroll on post

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-button.js
+++ b/app/assets/javascripts/discourse/app/components/d-button.js
@@ -89,7 +89,7 @@ export default Component.extend({
     return computedLabel;
   },
 
-  click() {
+  click(event) {
     let { action } = this;
 
     if (action) {
@@ -98,9 +98,9 @@ export default Component.extend({
         // There is already a warning in the console.
         this.sendAction("action", this.actionParam);
       } else if (typeof action === "object" && action.value) {
-        action.value(this.actionParam);
+        action.value(this.actionParam, event);
       } else if (typeof this.action === "function") {
-        action(this.actionParam);
+        action(this.actionParam, event);
       }
     }
 

--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -546,8 +546,9 @@ export default Controller.extend({
       this.cancelComposer(differentDraftContext);
     },
 
-    save() {
-      this.save();
+    save(ignore, event) {
+      const dontJump = event && event.shiftKey;
+      this.save(false, { dontJump });
     },
 
     displayEditReason() {
@@ -625,7 +626,7 @@ export default Controller.extend({
 
   disableSubmit: or("model.loading", "isUploading"),
 
-  save(force) {
+  save(force, options) {
     if (this.disableSubmit) {
       return;
     }
@@ -763,7 +764,7 @@ export default Controller.extend({
         this.currentUser.set("any_posts", true);
 
         const post = result.target;
-        if (post && !staged) {
+        if (post && !staged && !options?.dontJump) {
           DiscourseURL.routeTo(post.url, { skipIfOnScreen: true });
         }
       })

--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -547,8 +547,7 @@ export default Controller.extend({
     },
 
     save(ignore, event) {
-      const dontJump = event && event.shiftKey;
-      this.save(false, { dontJump });
+      this.save(false, { jump: !(event && event.shiftKey) });
     },
 
     displayEditReason() {
@@ -626,7 +625,7 @@ export default Controller.extend({
 
   disableSubmit: or("model.loading", "isUploading"),
 
-  save(force, options) {
+  save(force, options = {}) {
     if (this.disableSubmit) {
       return;
     }
@@ -764,7 +763,8 @@ export default Controller.extend({
         this.currentUser.set("any_posts", true);
 
         const post = result.target;
-        if (post && !staged && !options?.dontJump) {
+
+        if (post && !staged && options.jump !== false) {
           DiscourseURL.routeTo(post.url, { skipIfOnScreen: true });
         }
       })

--- a/app/assets/javascripts/discourse/app/mixins/key-enter-escape.js
+++ b/app/assets/javascripts/discourse/app/mixins/key-enter-escape.js
@@ -14,7 +14,7 @@ export default {
       //
       // iPad physical keyboard does not offer Command or Control detection
       // so use ALT-ENTER
-      this.save();
+      this.save(undefined, e);
       return false;
     }
   },


### PR DESCRIPTION
This allows for an advanced feature where hitting control on click or
CTRL-SHIFT-ENTER will lead to a post being made but the browser not to
scroll to the end.
