### PR TITLE
FIX: Only TL4 users and staff should be able to see the disable slow mode button

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/slow-mode-info.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/slow-mode-info.hbs
@@ -6,9 +6,11 @@
         {{i18n "topic.slow_mode_notice.duration" duration=durationText}}
       </span>
 
-      {{d-button class="slow-mode-remove"
-                 action=(action "disableSlowMode")
-                 icon="trash-alt"}}
+      {{#if user.canManageTopic}}
+        {{d-button class="slow-mode-remove"
+                  action=(action "disableSlowMode")
+                  icon="trash-alt"}}
+      {{/if}}
     </h3>
   </div>
 {{/if}}


### PR DESCRIPTION
If you click the button and don't have enough permissions, a forbidden error will be returned.