### PR TITLE
DEV: Fix heisentest

### DIFF
--- a/spec/components/js_locale_helper_spec.rb
+++ b/spec/components/js_locale_helper_spec.rb
@@ -19,9 +19,8 @@ describe JsLocaleHelper do
 
   JsLocaleHelper.extend StubLoadTranslations
 
-  after do
-    JsLocaleHelper.clear_cache!
-  end
+  before { JsLocaleHelper.clear_cache! }
+  after { JsLocaleHelper.clear_cache! }
 
   describe "#output_locale" do
 


### PR DESCRIPTION
This should fix the following sporadic spec failure:

```
  1) JsLocaleHelper performs fallbacks to English if a translation is not available
     Failure/Error: expect(ctx.eval('I18n.translations.uk.js').keys).to contain_exactly("all_three", "english_and_user", "only_user", "site_and_user")

       expected collection contained:  ["all_three", "english_and_user", "only_user", "site_and_user"]
       actual collection contained:    ["about", "action_codes", "activity", "admin", "admin_title", "adplugin", "age", "akismet", "all_time..."voting", "week", "week_desc", "weekly", "wizard_required", "year", "year_desc", "yes_value", "you"]
       the missing elements were:      ["all_three", "english_and_user", "only_user", "site_and_user"]
       the extra elements were:        ["about", "action_codes", "activity", "admin", "admin_title", "adplugin", "age", "akismet", "all_time..."voting", "week", "week_desc", "weekly", "wizard_required", "year", "year_desc", "yes_value", "you"]
     # ./spec/components/js_locale_helper_spec.rb:182:in `block (2 levels) in <main>'
     # ./bundle/ruby/2.6.0/gems/webmock-3.9.2/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
