### PR TITLE
FIX: calculate page if  page param is not given to TopicView

### DIFF
--- a/spec/components/topic_view_spec.rb
+++ b/spec/components/topic_view_spec.rb
@@ -273,13 +273,15 @@ describe TopicView do
       let!(:post) { Fabricate(:post, topic: topic, user: user) }
       let!(:post2) { Fabricate(:post, topic: topic, user: user) }
       let!(:post3) { Fabricate(:post, topic: topic, user: user) }
+      let!(:post4) { Fabricate(:post, topic: topic, user: user) }
+      let!(:post5) { Fabricate(:post, topic: topic, user: user) }
 
       before do
         TopicView.stubs(:chunk_size).returns(2)
       end
 
       it "should return the next page" do
-        expect(TopicView.new(topic.id, user).next_page).to eql(2)
+        expect(TopicView.new(topic.id, user, { post_number: post.post_number }).next_page).to eql(3)
       end
     end
 


### PR DESCRIPTION
Currently, when page param is not given to TopicView we calculate page for canonical_path, however, it is skipped for next_path.

We should use the same calculation to define page, so next page URL will be accurate. Currently if you view source of meta post - view-source:https://meta.discourse.org/t/post-rate-limit-trigger-for-a-topic-thats-heating-up/98294/46 you will see:

```
<link rel="canonical" href="https://meta.discourse.org/t/post-rate-limit-trigger-for-a-topic-thats-heating-up/98294?page=3" />
<link rel="next" href="/t/post-rate-limit-trigger-for-a-topic-thats-heating-up/98294?page=2">
```

https://meta.discourse.org/t/page-sometimes-redirects-to-a-page-with-a-different-canonical-url/167305