### PR TITLE
DEV: Remove preserve_email_structure_when_styling setting

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1186,9 +1186,6 @@ email:
     client: true
     default: true
     hidden: true
-  preserve_email_structure_when_styling:
-    default: true
-    hidden: true
 
 files:
   max_image_size_kb:

--- a/lib/email/styles.rb
+++ b/lib/email/styles.rb
@@ -271,19 +271,11 @@ module Email
       strip_classes_and_ids
       replace_relative_urls
 
-      if SiteSetting.preserve_email_structure_when_styling
-        @fragment.to_html
-      else
-        include_body? ? @fragment.at("body").to_html : @fragment.at("body").children.to_html
-      end
+      @fragment.to_html
     end
 
     def to_s
       @fragment.to_s
-    end
-
-    def include_body?
-      @html =~ /<body>/i
     end
 
     def strip_avatars_and_emojis


### PR DESCRIPTION
This was made adjustable to allow rolling back quickly if problems came
up. The new behaviour was made default in 93137066 and no problems with
this have been reported.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
