### PR TITLE
FIX: enable "remove tags" button only when tagging is enabled

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/topic-bulk-actions.js
+++ b/app/assets/javascripts/discourse/app/controllers/topic-bulk-actions.js
@@ -70,7 +70,8 @@ addBulkButton("showAppendTagTopics", "append_tags", {
 });
 addBulkButton("removeTags", "remove_tags", {
   icon: "tag",
-  class: "btn-danger",
+  class: "btn-default",
+  enabledSetting: "tagging_enabled",
 });
 addBulkButton("deleteTopics", "delete", {
   icon: "trash-alt",


### PR DESCRIPTION
UX: remove tags button does not qualify to be a danger button

