### PR TITLE
Revert "FEATURE: CTRL-SHIFT-ENTER and SHIFT-Click do not scroll on po…

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-button.js
+++ b/app/assets/javascripts/discourse/app/components/d-button.js
@@ -89,7 +89,7 @@ export default Component.extend({
     return computedLabel;
   },
 
-  click(event) {
+  click() {
     let { action } = this;
 
     if (action) {
@@ -98,9 +98,9 @@ export default Component.extend({
         // There is already a warning in the console.
         this.sendAction("action", this.actionParam);
       } else if (typeof action === "object" && action.value) {
-        action.value(this.actionParam, event);
+        action.value(this.actionParam);
       } else if (typeof this.action === "function") {
-        action(this.actionParam, event);
+        action(this.actionParam);
       }
     }
 

--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -546,8 +546,8 @@ export default Controller.extend({
       this.cancelComposer(differentDraftContext);
     },
 
-    save(ignore, event) {
-      this.save(false, { jump: !(event && event.shiftKey) });
+    save() {
+      this.save();
     },
 
     displayEditReason() {
@@ -625,7 +625,7 @@ export default Controller.extend({
 
   disableSubmit: or("model.loading", "isUploading"),
 
-  save(force, options = {}) {
+  save(force) {
     if (this.disableSubmit) {
       return;
     }
@@ -763,8 +763,7 @@ export default Controller.extend({
         this.currentUser.set("any_posts", true);
 
         const post = result.target;
-
-        if (post && !staged && options.jump !== false) {
+        if (post && !staged) {
           DiscourseURL.routeTo(post.url, { skipIfOnScreen: true });
         }
       })

--- a/app/assets/javascripts/discourse/app/mixins/key-enter-escape.js
+++ b/app/assets/javascripts/discourse/app/mixins/key-enter-escape.js
@@ -14,7 +14,7 @@ export default {
       //
       // iPad physical keyboard does not offer Command or Control detection
       // so use ALT-ENTER
-      this.save(undefined, e);
+      this.save();
       return false;
     }
   },


### PR DESCRIPTION
…st (#10939)"

This broke "composePrivateMessage" (and possibly others) because `d-button` now passes the event as a
second argument, and that action has an optional second argument.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
