### PR TITLE
FIX: Ensure old uploads can have animated field updated

### DIFF
--- a/app/jobs/scheduled/update_animated_uploads.rb
+++ b/app/jobs/scheduled/update_animated_uploads.rb
@@ -13,7 +13,8 @@ module Jobs
         .limit(MAX_PROCESSED_GIF_IMAGES)
         .each do |upload|
         uri = Discourse.store.path_for(upload) || upload.url
-        upload.update_columns(animated: FastImage.animated?(uri))
+        upload.animated = FastImage.animated?(uri)
+        upload.save(validate: false)
         upload.optimized_images.destroy_all if upload.animated
       end
 

--- a/app/jobs/scheduled/update_animated_uploads.rb
+++ b/app/jobs/scheduled/update_animated_uploads.rb
@@ -13,7 +13,7 @@ module Jobs
         .limit(MAX_PROCESSED_GIF_IMAGES)
         .each do |upload|
         uri = Discourse.store.path_for(upload) || upload.url
-        upload.update!(animated: FastImage.animated?(uri))
+        upload.update_columns(animated: FastImage.animated?(uri))
         upload.optimized_images.destroy_all if upload.animated
       end
 

--- a/spec/jobs/update_animated_uploads_spec.rb
+++ b/spec/jobs/update_animated_uploads_spec.rb
@@ -6,13 +6,23 @@ describe Jobs::UpdateAnimatedUploads do
   let!(:upload) { Fabricate(:upload) }
   let!(:gif_upload) { Fabricate(:upload, extension: "gif") }
 
-  it "affects only GIF uploads" do
+  before do
     url = Discourse.store.path_for(gif_upload) || gif_upload.url
     FastImage.expects(:animated?).with(url).returns(true).once
+  end
 
+  it "affects only GIF uploads" do
     described_class.new.execute({})
 
     expect(upload.reload.animated).to eq(nil)
+    expect(gif_upload.reload.animated).to eq(true)
+  end
+
+  it "works with uploads larger than current limits" do
+    SiteSetting.max_image_size_kb = 1
+
+    described_class.new.execute({})
+
     expect(gif_upload.reload.animated).to eq(true)
   end
 end


### PR DESCRIPTION
If admins decreased the maximum filesize limit the ActiveRecord
validations would fail.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
