### PR TITLE
FIX: Loading container needs same width as posts, follow up to da5841d

### DIFF
--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -598,6 +598,14 @@ blockquote {
   box-sizing: border-box;
 }
 
+.topic-area > .loading-container {
+  // loader needs to be same width as posts
+  width: calc(
+    #{$topic-avatar-width} + #{$topic-body-width} +
+      (#{$topic-body-width-padding} * 2)
+  );
+}
+
 /* hide the reply border above the time gap notices */
 
 .time-gap + .topic-post .topic-body,


### PR DESCRIPTION
When scrubbling far enough with the timeline to hide all previously visible posts, the loader needs the same width as posts to avoid a width change. 