### PR TITLE
FIX: include font import for embedded comments

### DIFF
--- a/app/assets/stylesheets/embed.scss
+++ b/app/assets/stylesheets/embed.scss
@@ -1,4 +1,4 @@
-@import "./font";
+@import "font";
 @import "./vendor/normalize";
 @import "./vendor/normalize-ext";
 @import "./common/foundation/base";

--- a/app/assets/stylesheets/embed.scss
+++ b/app/assets/stylesheets/embed.scss
@@ -1,3 +1,4 @@
+@import "./font";
 @import "./vendor/normalize";
 @import "./vendor/normalize-ext";
 @import "./common/foundation/base";


### PR DESCRIPTION
Embedded comments currently using unassigned variable 

<img width="221" alt="Screen Shot 2020-10-19 at 10 08 33 PM" src="https://user-images.githubusercontent.com/1681963/96531509-cd415e00-1257-11eb-8479-70b033e61091.png">

<img width="715" alt="Screen Shot 2020-10-19 at 10 08 49 PM" src="https://user-images.githubusercontent.com/1681963/96531510-cd415e00-1257-11eb-9a7a-c04ecd0a14bf.png">
