### PR TITLE
DEV: Add env var to disable ActiveRecord logging in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -93,6 +93,10 @@ Discourse::Application.configure do
       end
     end
 
+    if ENV["RAILS_DISABLE_ACTIVERECORD_LOGS"] == "1"
+      ActiveRecord::Base.logger = nil
+    end
+
     if ENV['BULLET']
       Bullet.enable = true
       Bullet.rails_logger = true


### PR DESCRIPTION
If `RAILS_DISABLE_ACTIVERECORD_LOGS=1` is passed when starting Rails, none of the query log output will show (looks like this by default):

![image](https://user-images.githubusercontent.com/920448/96663945-1ba84700-1395-11eb-8503-f950924395ee.png)

This is very useful for debugging with breakpoints because logs are not flooding in constantly. 