### PR TITLE
DEV: Add optional ENV variables for MiniProfiler snapshots transporter

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -305,7 +305,10 @@ class ApplicationController < ActionController::Base
 
   def set_mp_snapshot_fields
     if defined?(Rack::MiniProfiler)
-      Rack::MiniProfiler.add_snapshot_custom_field("application version", Discourse.git_version)
+      Rack::MiniProfiler.add_snapshot_custom_field("Application version", Discourse.git_version)
+      if Rack::MiniProfiler.snapshots_transporter?
+        Rack::MiniProfiler.add_snapshot_custom_field("Site", Discourse.current_hostname)
+      end
     end
   end
 

--- a/config/discourse_defaults.conf
+++ b/config/discourse_defaults.conf
@@ -99,6 +99,16 @@ load_mini_profiler = true
 # Default is never
 mini_profiler_snapshots_period = 0
 
+# specify the URL of the destination that MiniProfiler should ship snapshots to
+# mini_profiler_snapshots_transport_auth_key is required as well
+mini_profiler_snapshots_transport_url =
+
+# authorization key that will be included as a header in requests made by the
+# snapshots transporter to the URL specified above. The destination should
+# know this key and only accept requests that have this key in the
+# `Mini-Profiler-Transport-Auth` header.
+mini_profiler_snapshots_transport_auth_key =
+
 # recommended, cdn used to access assets
 cdn_url =
 

--- a/config/initializers/006-mini_profiler.rb
+++ b/config/initializers/006-mini_profiler.rb
@@ -25,6 +25,8 @@ if defined?(Rack::MiniProfiler) && defined?(Rack::MiniProfiler::Config)
   )
 
   Rack::MiniProfiler.config.snapshot_every_n_requests = GlobalSetting.mini_profiler_snapshots_period
+  Rack::MiniProfiler.config.snapshots_transport_destination_url = GlobalSetting.mini_profiler_snapshots_transport_url
+  Rack::MiniProfiler.config.snapshots_transport_auth_key = GlobalSetting.mini_profiler_snapshots_transport_auth_key
   Rack::MiniProfiler.config.skip_paths = [
     /^\/message-bus/,
     /^\/extra-locales/,


### PR DESCRIPTION
Latest version of MiniProfiler has snapshots transporter that requires some configs, so we need to have ENV variables for those configs.