### PR TITLE
FIX: attempts to convert french quotes to regular quotes in dates

### DIFF
--- a/plugins/discourse-local-dates/assets/javascripts/lib/discourse-markdown/discourse-local-dates.js.es6
+++ b/plugins/discourse-local-dates/assets/javascripts/lib/discourse-markdown/discourse-local-dates.js.es6
@@ -13,7 +13,7 @@ function addLocalDate(buffer, matches, state) {
     countdown: null,
   };
 
-  const matchString = matches[1].replace(/„|“/g, '"');
+  const matchString = matches[1].replace(/„|“|«|»/g, '"');
 
   let parsed = parseBBCodeTag(
     "[date date" + matchString + "]",

--- a/plugins/discourse-local-dates/spec/lib/pretty_text_spec.rb
+++ b/plugins/discourse-local-dates/spec/lib/pretty_text_spec.rb
@@ -89,4 +89,13 @@ describe PrettyText do
       expect(excerpt).to eq('Wednesday, October 16, 2019 6:00 PM (UTC)')
     end
   end
+
+  context 'french quotes' do
+    let(:post) { Fabricate(:post, raw: '[date=2019-10-16 time=14:00:00 format="LLLL" timezone=«America/New_York»]') }
+
+    it 'converts french quotes to regular quotes' do
+      excerpt = PrettyText.excerpt(post.cooked, 200)
+      expect(excerpt).to eq('Wednesday, October 16, 2019 6:00 PM (UTC)')
+    end
+  end
 end


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
