### PR TITLE
FIX: Show error message if user is already silenced or suspended

### DIFF
--- a/app/assets/javascripts/admin/addon/mixins/penalty-controller.js
+++ b/app/assets/javascripts/admin/addon/mixins/penalty-controller.js
@@ -7,6 +7,7 @@ import { Promise } from "rsvp";
 import bootbox from "bootbox";
 
 export default Mixin.create(ModalFunctionality, {
+  errorMessage: null,
   reason: null,
   message: null,
   postEdit: null,
@@ -18,6 +19,7 @@ export default Mixin.create(ModalFunctionality, {
 
   resetModal() {
     this.setProperties({
+      errorMessage: null,
       reason: null,
       message: null,
       loadingUser: true,

--- a/app/assets/javascripts/admin/addon/mixins/penalty-controller.js
+++ b/app/assets/javascripts/admin/addon/mixins/penalty-controller.js
@@ -1,6 +1,6 @@
 import I18n from "I18n";
 import ModalFunctionality from "discourse/mixins/modal-functionality";
-import { popupAjaxError } from "discourse/lib/ajax-error";
+import { extractError } from "discourse/lib/ajax-error";
 import Mixin from "@ember/object/mixin";
 import { next } from "@ember/runloop";
 import { Promise } from "rsvp";
@@ -66,6 +66,8 @@ export default Mixin.create(ModalFunctionality, {
           callback(result);
         }
       })
-      .catch(popupAjaxError);
+      .catch((error) => {
+        this.set("errorMessage", extractError(error));
+      });
   },
 });

--- a/app/assets/javascripts/admin/addon/models/admin-user.js
+++ b/app/assets/javascripts/admin/addon/models/admin-user.js
@@ -352,28 +352,17 @@ const AdminUser = User.extend({
       type: "PUT",
     })
       .then((result) => this.setProperties(result.unsilence))
-      .catch((e) => {
-        const error = I18n.t("admin.user.unsilence_failed", {
-          error: this._formatError(e),
-        });
-        bootbox.alert(error);
-      })
       .finally(() => this.set("silencingUser", false));
   },
 
   silence(data) {
     this.set("silencingUser", true);
+
     return ajax(`/admin/users/${this.id}/silence`, {
       type: "PUT",
       data,
     })
       .then((result) => this.setProperties(result.silence))
-      .catch((e) => {
-        const error = I18n.t("admin.user.silence_failed", {
-          error: this._formatError(e),
-        });
-        bootbox.alert(error);
-      })
       .finally(() => this.set("silencingUser", false));
   },
 

--- a/app/assets/javascripts/admin/addon/templates/modal/admin-silence-user.hbs
+++ b/app/assets/javascripts/admin/addon/templates/modal/admin-silence-user.hbs
@@ -1,6 +1,10 @@
 {{#d-modal-body title="admin.user.silence_modal_title"}}
   {{#conditional-loading-spinner condition=loadingUser}}
 
+    {{#if errorMessage}}
+      <div class="alert alert-error">{{errorMessage}}</div>
+    {{/if}}
+
     <div class="until-controls">
       <label>
         {{future-date-input

--- a/app/assets/javascripts/admin/addon/templates/modal/admin-suspend-user.hbs
+++ b/app/assets/javascripts/admin/addon/templates/modal/admin-suspend-user.hbs
@@ -1,6 +1,10 @@
 {{#d-modal-body title="admin.user.suspend_modal_title"}}
   {{#conditional-loading-spinner condition=loadingUser}}
 
+    {{#if errorMessage}}
+      <div class="alert alert-error">{{errorMessage}}</div>
+    {{/if}}
+
     {{#if user.canSuspend}}
       <div class="until-controls">
         <label>

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -96,7 +96,7 @@ class Admin::UsersController < Admin::AdminController
 
     if @user.suspended?
       suspend_record = @user.suspend_record
-      message = I18n.t("user.suspended",
+      message = I18n.t("user.already_suspended",
         staff: suspend_record.acting_user.username,
         time_ago: FreedomPatches::Rails4.time_ago_in_words(suspend_record.created_at, true, scope: :'datetime.distance_in_words_verbose')
       )
@@ -327,7 +327,7 @@ class Admin::UsersController < Admin::AdminController
 
     if @user.silenced?
       silenced_record = @user.silenced_record
-      message = I18n.t("user.silenced",
+      message = I18n.t("user.already_silenced",
         staff: silenced_record.acting_user.username,
         time_ago: FreedomPatches::Rails4.time_ago_in_words(silenced_record.created_at, true, scope: :'datetime.distance_in_words_verbose')
       )

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -93,6 +93,16 @@ class Admin::UsersController < Admin::AdminController
 
   def suspend
     guardian.ensure_can_suspend!(@user)
+
+    if @user.suspended?
+      suspend_record = @user.suspend_record
+      message = I18n.t("user.suspended",
+        staff: suspend_record.acting_user.username,
+        time_ago: FreedomPatches::Rails4.time_ago_in_words(suspend_record.created_at, true, scope: :'datetime.distance_in_words_verbose')
+      )
+      return render json: failed_json.merge(message: message), status: 409
+    end
+
     params.require([:suspend_until, :reason])
 
     @user.suspended_till = params[:suspend_until]
@@ -314,6 +324,15 @@ class Admin::UsersController < Admin::AdminController
 
   def silence
     guardian.ensure_can_silence_user! @user
+
+    if @user.silenced?
+      silenced_record = @user.silenced_record
+      message = I18n.t("user.silenced",
+        staff: silenced_record.acting_user.username,
+        time_ago: FreedomPatches::Rails4.time_ago_in_words(silenced_record.created_at, true, scope: :'datetime.distance_in_words_verbose')
+      )
+      return render json: failed_json.merge(message: message), status: 409
+    end
 
     message = params[:message]
 

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2503,6 +2503,8 @@ en:
       same_ip_address: "Same IP address (%{ip_address}) as other users"
       inactive_user: "Inactive user"
     email_in_spam_header: "User's first email was flagged as spam"
+    silenced: "User was already silenced by %{staff} %{time_ago}."
+    suspended: "User was already suspended by %{staff} %{time_ago}."
 
   reviewables_reminder:
     submitted:

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2503,8 +2503,8 @@ en:
       same_ip_address: "Same IP address (%{ip_address}) as other users"
       inactive_user: "Inactive user"
     email_in_spam_header: "User's first email was flagged as spam"
-    silenced: "User was already silenced by %{staff} %{time_ago}."
-    suspended: "User was already suspended by %{staff} %{time_ago}."
+    already_silenced: "User was already silenced by %{staff} %{time_ago}."
+    already_suspended: "User was already suspended by %{staff} %{time_ago}."
 
   reviewables_reminder:
     submitted:

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -149,6 +149,21 @@ RSpec.describe Admin::UsersController do
       expect(log.details).to match(/because I said so/)
     end
 
+    it "checks if user is suspended" do
+      put "/admin/users/#{user.id}/suspend.json", params: {
+        suspend_until: 5.hours.from_now,
+        reason: "because I said so"
+      }
+
+      put "/admin/users/#{user.id}/suspend.json", params: {
+        suspend_until: 5.hours.from_now,
+        reason: "because I said so too"
+      }
+
+      expect(response.status).to eq(409)
+      expect(response.parsed_body["message"]).to eq("User was already suspended by #{admin.username} just now.")
+    end
+
     it "requires suspend_until and reason" do
       expect(user).not_to be_suspended
       put "/admin/users/#{user.id}/suspend.json", params: {}
@@ -748,6 +763,21 @@ RSpec.describe Admin::UsersController do
       expect(response.status).to eq(200)
       reg_user.reload
       expect(reg_user).to be_silenced
+    end
+
+    it "checks if user is silenced" do
+      put "/admin/users/#{user.id}/silence.json", params: {
+        silenced_till: 5.hours.from_now,
+        reason: "because I said so"
+      }
+
+      put "/admin/users/#{user.id}/silence.json", params: {
+        silenced_till: 5.hours.from_now,
+        reason: "because I said so too"
+      }
+
+      expect(response.status).to eq(409)
+      expect(response.parsed_body["message"]).to eq("User was already silenced by #{admin.username} just now.")
     end
   end
 

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -161,7 +161,13 @@ RSpec.describe Admin::UsersController do
       }
 
       expect(response.status).to eq(409)
-      expect(response.parsed_body["message"]).to eq("User was already suspended by #{admin.username} just now.")
+      expect(response.parsed_body["message"]).to eq(
+        I18n.t(
+          "user.already_suspended",
+          staff: admin.username,
+          time_ago: FreedomPatches::Rails4.time_ago_in_words(user.suspend_record.created_at, true, scope: :'datetime.distance_in_words_verbose')
+        )
+      )
     end
 
     it "requires suspend_until and reason" do
@@ -777,7 +783,13 @@ RSpec.describe Admin::UsersController do
       }
 
       expect(response.status).to eq(409)
-      expect(response.parsed_body["message"]).to eq("User was already silenced by #{admin.username} just now.")
+      expect(response.parsed_body["message"]).to eq(
+        I18n.t(
+          "user.already_silenced",
+          staff: admin.username,
+          time_ago: FreedomPatches::Rails4.time_ago_in_words(user.silenced_record.created_at, true, scope: :'datetime.distance_in_words_verbose')
+        )
+      )
     end
   end
 


### PR DESCRIPTION
This commit displays error messages in modal like this:

![image](https://user-images.githubusercontent.com/23153890/96752129-ba08cc80-13d6-11eb-8e8a-b99844c75275.png)
