### PR TITLE
FIX: Do not downsize GIF images

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,7 +134,7 @@ GEM
     faraday-net_http (1.0.0)
     fast_blank (1.0.0)
     fast_xs (0.8.0)
-    fastimage (2.2.0)
+    fastimage (2.2.1)
     ffi (1.14.2)
     fspath (3.1.2)
     gc_tracer (1.5.1)

--- a/spec/lib/upload_creator_spec.rb
+++ b/spec/lib/upload_creator_spec.rb
@@ -497,4 +497,20 @@ RSpec.describe UploadCreator do
       end
     end
   end
+
+  describe '#should_downsize?' do
+    context "GIF image" do
+      let(:gif_file) { file_from_fixtures("animated.gif") }
+
+      before do
+        SiteSetting.max_image_size_kb = 1
+      end
+
+      it "is not downsized" do
+        creator = UploadCreator.new(gif_file, "animated.gif")
+        creator.extract_image_info!
+        expect(creator.should_downsize?).to eq(false)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This is problematic because during this operation only the first frame
is kept.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
