### PR TITLE
FIX: Restore users#topic_tracking_state route to api session_info scope

### DIFF
--- a/app/models/user_api_key_scope.rb
+++ b/app/models/user_api_key_scope.rb
@@ -12,7 +12,10 @@ class UserApiKeyScope < ActiveRecord::Base
       RouteMatcher.new(methods: :get, actions: 'notifications#index'),
       RouteMatcher.new(methods: :put, actions: 'notifications#mark_read')
     ],
-    session_info: [ RouteMatcher.new(methods: :get, actions: 'session#current') ],
+    session_info: [
+      RouteMatcher.new(methods: :get, actions: 'session#current'),
+      RouteMatcher.new(methods: :get, actions: 'users#topic_tracking_state')
+    ],
     bookmarks_calendar: [ RouteMatcher.new(methods: :get, actions: 'users#bookmarks', formats: :ics, params: %i[username]) ]
   }
 


### PR DESCRIPTION
This route was inadvertently removed in 1cec333f, and is required for showing new/unread counts in Discourse mobile apps

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
