### PR TITLE
DEV: Add more debugging context to onebox generation

### DIFF
--- a/app/controllers/onebox_controller.rb
+++ b/app/controllers/onebox_controller.rb
@@ -21,7 +21,7 @@ class OneboxController < ApplicationController
 
     return render(body: nil, status: 404) if Oneboxer.recently_failed?(url)
 
-    hijack do
+    hijack(info: "#{url} topic_id: #{topic_id} user_id: #{user_id}") do
       Oneboxer.preview_onebox!(user_id)
 
       preview = Oneboxer.preview(url,

--- a/lib/hijack.rb
+++ b/lib/hijack.rb
@@ -7,7 +7,7 @@ require 'method_profiler'
 # free up a unicorn worker while the remote IO is happening
 module Hijack
 
-  def hijack(&blk)
+  def hijack(info: nil, &blk)
     controller_class = self.class
 
     if hijack = request.env['rack.hijack']
@@ -31,7 +31,7 @@ module Hijack
       # on the way down the stack
       original_headers = response.headers.dup
 
-      Scheduler::Defer.later("hijack #{params["controller"]} #{params["action"]}") do
+      Scheduler::Defer.later("hijack #{params["controller"]} #{params["action"]} #{info}") do
 
         MethodProfiler.start(transfer_timings)
         begin


### PR DESCRIPTION
Previously if a onebox timed out we would not present the users in the log
with any information regarding the onebox. This makes it very difficult to
debug.

This adds url/topic/user in the debugging output.
