### PR TITLE
UX: Remove forgot password button from `/login-preferences`

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/login-preferences.hbs
+++ b/app/assets/javascripts/discourse/app/templates/login-preferences.hbs
@@ -4,7 +4,4 @@
   <p style="margin-top: 1em">{{i18n "login.preferences"}}</p>
 
   {{d-button class="btn-primary" action=(route-action "showLogin") label="log_in"}}
-  {{#unless siteSettings.enable_sso}}
-    {{d-button action=(route-action "showForgotPassword") label="login.forgot"}}
-  {{/unless}}
 </div>

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1690,7 +1690,6 @@ en:
       sent_activation_email_again_generic: "We sent another activation email. It might take a few minutes for it to arrive; be sure to check your spam folder."
       to_continue: "Please Log In"
       preferences: "You need to be logged in to change your user preferences."
-      forgot: "I don't recall my account details"
       not_approved: "Your account hasn't been approved yet. You will be notified by email when you are ready to log in."
       google_oauth2:
         name: "Google"


### PR DESCRIPTION
Showing this button is confusing for sites which are using external authentication. Clicking 'log in' already pops up the login modal, which includes a forgot password link when appropriate.

Before:
<img width="654" alt="Screenshot 2020-10-22 at 13 03 36" src="https://user-images.githubusercontent.com/6270921/96869601-98a3f100-1467-11eb-83dc-a50c19613fdd.png">

After:
<img width="521" alt="Screenshot 2020-10-22 at 13 03 47" src="https://user-images.githubusercontent.com/6270921/96869610-9cd00e80-1467-11eb-8d7b-18fe187bd244.png">



<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
