### PR TITLE
FIX: Add check for youtube thumbnail

### DIFF
--- a/app/assets/javascripts/discourse/app/initializers/ensure-max-image-dimensions.js
+++ b/app/assets/javascripts/discourse/app/initializers/ensure-max-image-dimensions.js
@@ -22,7 +22,7 @@ export default {
     const style = "max-width:" + width + "px;" + "max-height:" + height + "px;";
 
     $(
-      '<style id="image-sizing-hack">#reply-control .d-editor-preview img:not(.thumbnail), .cooked img:not(.thumbnail) {' +
+      '<style id="image-sizing-hack">#reply-control .d-editor-preview img:not(.thumbnail):not(.ytp-thumbnail-image), .cooked img:not(.thumbnail):not(.ytp-thumbnail-image) {' +
         style +
         "}</style>"
     ).appendTo("head");


### PR DESCRIPTION
This commit adds a check for the youtube thumbnail class when enforcing max-image-dimensions.

### Before
![image](https://user-images.githubusercontent.com/30537603/96905448-1105b480-145e-11eb-9d11-e4d329a35b11.png)

### After
![image](https://user-images.githubusercontent.com/30537603/96905518-28dd3880-145e-11eb-965d-c1d6bc18e43c.png)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
