### PR TITLE
FEATURE: allow category group moderators to edit posts

### DIFF
--- a/lib/guardian/post_guardian.rb
+++ b/lib/guardian/post_guardian.rb
@@ -131,7 +131,8 @@ module PostGuardian
       (
         SiteSetting.trusted_users_can_edit_others? &&
         @user.has_trust_level?(TrustLevel[4])
-      )
+      ) ||
+      is_category_group_moderator?(post.topic.category)
     )
 
     if post.topic&.archived? || post.user_deleted || post.deleted_at

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -448,21 +448,6 @@ describe PostsController do
         expect(UserHistory.where(action: UserHistory.actions[:post_edit]).count).to eq(1)
       end
 
-      it "can not update other posts within the primary category topic" do
-        second_post = Fabricate(:post, user: user, topic: topic)
-
-        put "/posts/#{second_post.id}.json", params: update_params
-        expect(response.status).to eq(403)
-      end
-
-      it "can not update other first posts of topics in the same category" do
-        second_topic_in_category = Fabricate(:topic, category: category)
-        post_in_second_topic = Fabricate(:post, user: user, topic: second_topic_in_category)
-
-        put "/posts/#{post_in_second_topic.id}.json", params: update_params
-        expect(response.status).to eq(403)
-      end
-
       it "can not update category descriptions in other categories" do
         second_category = Fabricate(:category)
         topic.update!(category: second_category)


### PR DESCRIPTION
If the `enable_category_group_moderation` SiteSetting is enabled, posts should be editable by those belonging to the appropriate groups.