### PR TITLE
DEV: include cors header to public file server in dev environment.

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -28,6 +28,10 @@ Discourse::Application.configure do
 
   config.assets.debug = false
 
+  config.public_file_server.headers = {
+    'Access-Control-Allow-Origin' => '*'
+  }
+
   # Raise an error on page load if there are pending migrations
   config.active_record.migration_error = :page_load
   config.watchable_dirs['lib'] = [:rb]


### PR DESCRIPTION
While enabling the CORS header in localhost we should include it in the public file server too. Else it will return the errors.