### PR TITLE
FIX: Only include last_posted_at if there's a topic_user object.

### DIFF
--- a/app/assets/javascripts/discourse/app/components/slow-mode-info.js
+++ b/app/assets/javascripts/discourse/app/components/slow-mode-info.js
@@ -11,9 +11,9 @@ export default Component.extend({
     return durationTextFromSeconds(seconds);
   },
 
-  @discourseComputed("topic.slow_mode_seconds", "topic.closed")
-  showSlowModeNotice(seconds, closed) {
-    return seconds > 0 && !closed;
+  @discourseComputed("user", "topic.slow_mode_seconds", "topic.closed")
+  showSlowModeNotice(user, seconds, closed) {
+    return user && seconds > 0 && !closed;
   },
 
   @action

--- a/app/serializers/topic_view_serializer.rb
+++ b/app/serializers/topic_view_serializer.rb
@@ -288,6 +288,6 @@ class TopicViewSerializer < ApplicationSerializer
   end
 
   def include_user_last_posted_at?
-    object.topic.slow_mode_seconds.to_i > 0
+    has_topic_user? && object.topic.slow_mode_seconds.to_i > 0
   end
 end

--- a/spec/serializers/topic_view_serializer_spec.rb
+++ b/spec/serializers/topic_view_serializer_spec.rb
@@ -423,4 +423,38 @@ describe TopicViewSerializer do
     end
   end
 
+  describe '#user_last_posted_at' do
+    context 'When the slow mode is disabled' do
+      it 'returns nil' do
+        Fabricate(:topic_user, user: user, topic: topic, last_posted_at: 6.hours.ago)
+
+        json = serialize_topic(topic, user)
+
+        expect(json[:user_last_posted_at]).to be_nil
+      end
+    end
+
+    context 'Wwhen the slow mode is enabled' do
+      before { topic.update!(slow_mode_seconds: 1000) }
+
+      it 'returns nil if no user is given' do
+        json = serialize_topic(topic, nil)
+
+        expect(json[:user_last_posted_at]).to be_nil
+      end
+
+      it "returns nil if there's no topic_user association" do
+        json = serialize_topic(topic, user)
+
+        expect(json[:user_last_posted_at]).to be_nil
+      end
+
+      it 'returns the last time the user posted' do
+        Fabricate(:topic_user, user: user, topic: topic, last_posted_at: 6.hours.ago)
+        json = serialize_topic(topic, user)
+
+        expect(json[:user_last_posted_at]).to be_present
+      end
+    end
+  end
 end


### PR DESCRIPTION
Trying to include this attribute when topic_user is nil causes an error when visiting a topic as anon. Additionally, we don't display the slow mode banner for these users.

