### PR TITLE
FIX: Reset invite when resending it

### DIFF
--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -313,7 +313,7 @@ class Invite < ActiveRecord::Base
   end
 
   def resend_invite
-    self.update_columns(updated_at: Time.zone.now, expires_at: SiteSetting.invite_expiry_days.days.from_now)
+    self.update_columns(updated_at: Time.zone.now, invalidated_at: nil, expires_at: SiteSetting.invite_expiry_days.days.from_now)
     Jobs.enqueue(:invite_email, invite_id: self.id)
   end
 

--- a/spec/models/invite_spec.rb
+++ b/spec/models/invite_spec.rb
@@ -164,10 +164,11 @@ describe Invite do
 
         it 'resets expiry of a resent invite' do
           SiteSetting.invite_expiry_days = 2
-          invite.update!(expires_at: 10.days.ago)
+          invite.update!(invalidated_at: 10.days.ago, expires_at: 10.days.ago)
           expect(invite).to be_expired
 
           invite.resend_invite
+          expect(invite.invalidated_at).to be_nil
           expect(invite).not_to be_expired
         end
 


### PR DESCRIPTION
Resending an invite moved the expire date in the future, but did not
invalidate it. For example, if an invite was sent to an email,
invalidated and then resent, it would still be left invalidated.