### PR TITLE
Add new `cloneJSON` method for cloning an object

### DIFF
--- a/app/assets/javascripts/discourse-common/addon/lib/object.js
+++ b/app/assets/javascripts/discourse-common/addon/lib/object.js
@@ -3,6 +3,8 @@ function isObject(obj) {
 }
 
 // a fairly simple deep merge based on: https://gist.github.com/ahtcx/0cd94e62691f539160b32ecda18af3d6
+// note: this approach might reference the original object. If you mutate an object once you've deep
+// cloned it, say in a test, it might remain modified. Consider `cloneJSON` instead.
 export function deepMerge(...objects) {
   function deepMergeInner(target, source) {
     Object.keys(source).forEach((key) => {
@@ -52,4 +54,8 @@ export function deepEqual(obj1, obj2) {
     }
     return true;
   }
+}
+
+export function cloneJSON(obj) {
+  return JSON.parse(JSON.stringify(obj));
 }

--- a/app/assets/javascripts/discourse/tests/acceptance/user-bookmarks-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-bookmarks-test.js
@@ -3,6 +3,7 @@ import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import userFixtures from "discourse/tests/fixtures/user-fixtures";
+import { cloneJSON } from "discourse-common/lib/object";
 
 acceptance("User's bookmarks", function (needs) {
   needs.user();
@@ -23,15 +24,11 @@ acceptance("User's bookmarks - reminder", function (needs) {
   needs.user();
 
   needs.pretender((server, helper) => {
-    let listResponse = JSON.parse(
-      JSON.stringify(userFixtures["/u/eviltrout/bookmarks.json"])
-    );
-    listResponse.user_bookmark_list.bookmarks[0].reminder_at =
-      "2028-01-01T08:00";
-
-    server.get("/u/eviltrout/bookmarks.json", () =>
-      helper.response(listResponse)
-    );
+    server.get("/u/eviltrout/bookmarks.json", () => {
+      let json = cloneJSON(userFixtures["/u/eviltrout/bookmarks.json"]);
+      json.user_bookmark_list.bookmarks[0].reminder_at = "2028-01-01T08:00";
+      return helper.response(json);
+    });
   });
 
   test("removing a bookmark with a reminder shows a confirmation", async (assert) => {


### PR DESCRIPTION
This is useful in tests where `deepMerge` would retain references to old
objects.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
