### PR TITLE
Remove more global variables from tests.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,5 +9,6 @@
     "testStart": "off",
     "testDone": "off",
     "sinon": "off",
+    "currentURL": "off",
   }
 }

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-site-settings-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-site-settings-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { visit, currentURL } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import siteSettingFixture from "discourse/tests/fixtures/site-settings";

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-site-text-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-site-text-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { visit, currentURL } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/category-edit-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/category-edit-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { visit, currentURL } from "@ember/test-helpers";
 import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";

--- a/app/assets/javascripts/discourse/tests/acceptance/click-track-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/click-track-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { visit, currentURL } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-actions-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-actions-test.js
@@ -10,6 +10,7 @@ import { _clearSnapshots } from "select-kit/components/composer-actions";
 import { toggleCheckDraftPopup } from "discourse/controllers/composer";
 import Draft from "discourse/models/draft";
 import { Promise } from "rsvp";
+import sinon from "sinon";
 
 acceptance("Composer Actions", function (needs) {
   needs.user();
@@ -110,7 +111,7 @@ acceptance("Composer Actions", function (needs) {
   });
 
   test("replying to post - reply_as_new_topic", async (assert) => {
-    sandbox
+    sinon
       .stub(Draft, "get")
       .returns(Promise.resolve({ draft: "", draft_sequence: 0 }));
     const composerActions = selectKit(".composer-actions");
@@ -137,7 +138,7 @@ acceptance("Composer Actions", function (needs) {
       I18n.t("topic.create_long")
     );
     assert.ok(find(".d-editor-input").val().includes(quote));
-    sandbox.restore();
+    sinon.restore();
   });
 
   test("reply_as_new_topic without a new_topic draft", async (assert) => {
@@ -359,7 +360,7 @@ acceptance("Composer Actions", function (needs) {
 });
 
 function stubDraftResponse() {
-  sandbox.stub(Draft, "get").returns(
+  sinon.stub(Draft, "get").returns(
     Promise.resolve({
       draft:
         '{"reply":"dum de dum da ba.","action":"createTopic","title":"dum da ba dum dum","categoryId":null,"archetypeId":"regular","metaData":null,"composerTime":540879,"typingTime":3400}',
@@ -418,7 +419,7 @@ acceptance("Composer Actions With New Topic Draft", function (needs) {
     } finally {
       toggleCheckDraftPopup(false);
     }
-    sandbox.restore();
+    sinon.restore();
   });
 
   test("reply_as_new_topic with new_topic draft", async (assert) => {
@@ -433,6 +434,6 @@ acceptance("Composer Actions With New Topic Draft", function (needs) {
       I18n.t("composer.composer_actions.reply_as_new_topic.confirm")
     );
     await click(".modal-footer .btn.btn-default");
-    sandbox.restore();
+    sinon.restore();
   });
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-tags-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-tags-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { visit, currentURL } from "@ember/test-helpers";
 import { test } from "qunit";
 import Category from "discourse/models/category";
 import {

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { visit, currentURL } from "@ember/test-helpers";
 import { skip } from "qunit";
 import { test } from "qunit";
 import I18n from "I18n";
@@ -8,6 +8,7 @@ import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import { toggleCheckDraftPopup } from "discourse/controllers/composer";
 import Draft from "discourse/models/draft";
 import { Promise } from "rsvp";
+import sinon from "sinon";
 
 acceptance("Composer", function (needs) {
   needs.user();
@@ -633,7 +634,7 @@ acceptance("Composer", function (needs) {
 
       const longText = "a".repeat(256);
 
-      sandbox.stub(Draft, "get").returns(
+      sinon.stub(Draft, "get").returns(
         Promise.resolve({
           draft: null,
           draft_sequence: 0,
@@ -672,14 +673,14 @@ acceptance("Composer", function (needs) {
     } finally {
       toggleCheckDraftPopup(false);
     }
-    sandbox.restore();
+    sinon.restore();
   });
 
   test("Loading draft also replaces the recipients", async (assert) => {
     try {
       toggleCheckDraftPopup(true);
 
-      sandbox.stub(Draft, "get").returns(
+      sinon.stub(Draft, "get").returns(
         Promise.resolve({
           draft:
             '{"reply":"hello","action":"privateMessage","title":"hello","categoryId":null,"archetypeId":"private_message","metaData":null,"recipients":"codinghorror","composerTime":9159,"typingTime":2500}',

--- a/app/assets/javascripts/discourse/tests/acceptance/jump-to-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/jump-to-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { visit, currentURL } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/keyboard-shortcuts-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/keyboard-shortcuts-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { visit, currentURL } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/plugin-keyboard-shortcut-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/plugin-keyboard-shortcut-test.js
@@ -4,6 +4,7 @@ import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import KeyboardShortcuts from "discourse/lib/keyboard-shortcuts";
 import KeyboardShortcutInitializer from "discourse/initializers/keyboard-shortcuts";
+import sinon from "sinon";
 
 acceptance("Plugin Keyboard Shortcuts - Logged In", function (needs) {
   needs.user();
@@ -34,7 +35,7 @@ acceptance("Plugin Keyboard Shortcuts - Anonymous", function (needs) {
     KeyboardShortcutInitializer.initialize(this.container);
   });
   test("a plugin can add a keyboard shortcut with an option", async (assert) => {
-    let spy = sandbox.spy(KeyboardShortcuts, "_bindToPath");
+    let spy = sinon.spy(KeyboardShortcuts, "_bindToPath");
     withPluginApi("0.8.38", (api) => {
       api.addKeyboardShortcut("]", () => {}, {
         anonymous: true,

--- a/app/assets/javascripts/discourse/tests/acceptance/preferences-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/preferences-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { visit, currentURL } from "@ember/test-helpers";
 import { test } from "qunit";
 import I18n from "I18n";
 import {

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-discovery-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-discovery-test.js
@@ -4,6 +4,7 @@ import DiscourseURL from "discourse/lib/url";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import MessageBus from "message-bus-client";
+import sinon from "sinon";
 
 acceptance("Topic Discovery", function (needs) {
   needs.settings({
@@ -114,7 +115,7 @@ acceptance("Topic Discovery", function (needs) {
   test("Using period chooser when query params are present", async (assert) => {
     await visit("/top?f=foo&d=bar");
 
-    sandbox.stub(DiscourseURL, "routeTo");
+    sinon.stub(DiscourseURL, "routeTo");
 
     const periodChooser = selectKit(".period-chooser");
 

--- a/app/assets/javascripts/discourse/tests/acceptance/unknown-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/unknown-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { visit, currentURL } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/user-anonymous-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-anonymous-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { visit, currentURL } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
+++ b/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
@@ -40,6 +40,7 @@ import Site from "discourse/models/site";
 import createStore from "discourse/tests/helpers/create-store";
 import { getApplication } from "@ember/test-helpers";
 import deprecated from "discourse-common/lib/deprecated";
+import sinon from "sinon";
 
 export function currentUser() {
   return User.create(sessionFixtures["/session/current.json"].current_user);
@@ -61,7 +62,7 @@ export function loggedInUser() {
 
 export function fakeTime(timeString, timezone = null, advanceTime = false) {
   let now = moment.tz(timeString, timezone);
-  return sandbox.useFakeTimers({
+  return sinon.useFakeTimers({
     now: now.valueOf(),
     shouldAdvanceTime: advanceTime,
   });

--- a/app/assets/javascripts/discourse/tests/integration/components/keyboard-shortcuts-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/keyboard-shortcuts-test.js
@@ -1,16 +1,17 @@
 import { test, module } from "qunit";
 import DiscourseURL from "discourse/lib/url";
-
-var testMouseTrap;
+import sinon from "sinon";
 import KeyboardShortcuts from "discourse/lib/keyboard-shortcuts";
+
+let testMouseTrap;
 
 module("lib:keyboard-shortcuts", {
   beforeEach() {
-    var _bindings = {};
+    let _bindings = {};
 
     testMouseTrap = {
       bind: function (bindings, callback) {
-        var registerBinding = function (binding) {
+        let registerBinding = function (binding) {
           _bindings[binding] = callback;
         }.bind(this);
 
@@ -26,7 +27,7 @@ module("lib:keyboard-shortcuts", {
       },
     };
 
-    sandbox.stub(DiscourseURL, "routeTo");
+    sinon.stub(DiscourseURL, "routeTo");
 
     $("#qunit-fixture").html(
       [
@@ -69,10 +70,10 @@ module("lib:keyboard-shortcuts", {
   },
 });
 
-var pathBindings = KeyboardShortcuts.PATH_BINDINGS || {};
+let pathBindings = KeyboardShortcuts.PATH_BINDINGS || {};
 Object.keys(pathBindings).forEach((path) => {
   const binding = pathBindings[path];
-  var testName = binding + " goes to " + path;
+  let testName = binding + " goes to " + path;
 
   test(testName, function (assert) {
     KeyboardShortcuts.bindEvents();
@@ -82,12 +83,12 @@ Object.keys(pathBindings).forEach((path) => {
   });
 });
 
-var clickBindings = KeyboardShortcuts.CLICK_BINDINGS || {};
+let clickBindings = KeyboardShortcuts.CLICK_BINDINGS || {};
 Object.keys(clickBindings).forEach((selector) => {
   const binding = clickBindings[selector];
-  var bindings = binding.split(",");
+  let bindings = binding.split(",");
 
-  var testName = binding + " clicks on " + selector;
+  let testName = binding + " clicks on " + selector;
 
   test(testName, function (assert) {
     KeyboardShortcuts.bindEvents();
@@ -101,13 +102,13 @@ Object.keys(clickBindings).forEach((selector) => {
   });
 });
 
-var functionBindings = KeyboardShortcuts.FUNCTION_BINDINGS || {};
+let functionBindings = KeyboardShortcuts.FUNCTION_BINDINGS || {};
 Object.keys(functionBindings).forEach((func) => {
   const binding = functionBindings[func];
-  var testName = binding + " calls " + func;
+  let testName = binding + " calls " + func;
 
   test(testName, function (assert) {
-    sandbox.stub(KeyboardShortcuts, func, function () {
+    sinon.stub(KeyboardShortcuts, func, function () {
       assert.ok(true, func + " is called when " + binding + " is triggered");
     });
     KeyboardShortcuts.bindEvents();
@@ -117,22 +118,22 @@ Object.keys(functionBindings).forEach((func) => {
 });
 
 test("selectDown calls _moveSelection with 1", (assert) => {
-  var stub = sandbox.stub(KeyboardShortcuts, "_moveSelection");
+  let stub = sinon.stub(KeyboardShortcuts, "_moveSelection");
 
   KeyboardShortcuts.selectDown();
   assert.ok(stub.calledWith(1), "_moveSelection is called with 1");
 });
 
 test("selectUp calls _moveSelection with -1", (assert) => {
-  var stub = sandbox.stub(KeyboardShortcuts, "_moveSelection");
+  let stub = sinon.stub(KeyboardShortcuts, "_moveSelection");
 
   KeyboardShortcuts.selectUp();
   assert.ok(stub.calledWith(-1), "_moveSelection is called with -1");
 });
 
 test("goBack calls history.back", (assert) => {
-  var called = false;
-  sandbox.stub(history, "back").callsFake(function () {
+  let called = false;
+  sinon.stub(history, "back").callsFake(function () {
     called = true;
   });
 
@@ -141,14 +142,14 @@ test("goBack calls history.back", (assert) => {
 });
 
 test("nextSection calls _changeSection with 1", (assert) => {
-  var spy = sandbox.spy(KeyboardShortcuts, "_changeSection");
+  let spy = sinon.spy(KeyboardShortcuts, "_changeSection");
 
   KeyboardShortcuts.nextSection();
   assert.ok(spy.calledWith(1), "_changeSection is called with 1");
 });
 
 test("prevSection calls _changeSection with -1", (assert) => {
-  var spy = sandbox.spy(KeyboardShortcuts, "_changeSection");
+  let spy = sinon.spy(KeyboardShortcuts, "_changeSection");
 
   KeyboardShortcuts.prevSection();
   assert.ok(spy.calledWith(-1), "_changeSection is called with -1");

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/category-drop-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/category-drop-test.js
@@ -8,6 +8,7 @@ import {
   ALL_CATEGORIES_ID,
 } from "select-kit/components/category-drop";
 import { set } from "@ember/object";
+import sinon from "sinon";
 
 testSelectKitModule("category-drop");
 
@@ -332,7 +333,7 @@ componentTest("category url", {
 
   beforeEach() {
     initCategoriesWithParentCategory(this);
-    sandbox.stub(DiscourseURL, "routeTo");
+    sinon.stub(DiscourseURL, "routeTo");
   },
 
   async test(assert) {

--- a/app/assets/javascripts/discourse/tests/integration/components/text-field-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/text-field-test.js
@@ -1,3 +1,4 @@
+import sinon from "sinon";
 import { moduleForComponent } from "ember-qunit";
 import I18n from "I18n";
 import componentTest from "discourse/tests/helpers/component-test";
@@ -16,7 +17,7 @@ componentTest("support a placeholder", {
   template: `{{text-field placeholderKey="placeholder.i18n.key"}}`,
 
   beforeEach() {
-    sandbox.stub(I18n, "t").returnsArg(0);
+    sinon.stub(I18n, "t").returnsArg(0);
   },
 
   test(assert) {

--- a/app/assets/javascripts/discourse/tests/integration/widgets/user-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/user-menu-test.js
@@ -1,3 +1,4 @@
+import sinon from "sinon";
 import I18n from "I18n";
 import DiscourseURL from "discourse/lib/url";
 import {
@@ -68,7 +69,7 @@ widgetTest("notifications", {
       )
     );
 
-    const routeToStub = sandbox.stub(DiscourseURL, "routeTo");
+    const routeToStub = sinon.stub(DiscourseURL, "routeTo");
     await click(".user-notifications-link");
     assert.ok(
       routeToStub.calledWith(find(".user-notifications-link")[0].href),
@@ -131,7 +132,7 @@ widgetTest("private messages - enabled", {
       "should correctly render emoji in message title"
     );
 
-    const routeToStub = sandbox.stub(DiscourseURL, "routeTo");
+    const routeToStub = sinon.stub(DiscourseURL, "routeTo");
     await click(".user-pms-link");
     assert.ok(
       routeToStub.calledWith(userPmsLink.href),
@@ -159,7 +160,7 @@ widgetTest("bookmarks", {
       "should correctly render emoji in bookmark title"
     );
 
-    const routeToStub = sandbox.stub(DiscourseURL, "routeTo");
+    const routeToStub = sinon.stub(DiscourseURL, "routeTo");
     await click(".user-bookmarks-link");
     assert.ok(
       routeToStub.calledWith(find(".user-bookmarks-link")[0].href),

--- a/app/assets/javascripts/discourse/tests/setup-tests.js
+++ b/app/assets/javascripts/discourse/tests/setup-tests.js
@@ -67,6 +67,18 @@ export default function setupTests(app, container) {
       return server;
     },
   });
+  Object.defineProperty(window, "sandbox", {
+    get() {
+      deprecated(
+        "Accessing the global variable `sandbox` is deprecated. Import `sinon` instead",
+        {
+          since: "2.6.0.beta.4",
+          dropFrom: "2.6.0",
+        }
+      );
+      return window.sinon;
+    },
+  });
 
   QUnit.testStart(function (ctx) {
     let settings = resetSettings();
@@ -125,17 +137,16 @@ export default function setupTests(app, container) {
 
     PreloadStore.reset();
 
-    window.sandbox = sinon;
-    window.sandbox.stub(ScrollingDOMMethods, "screenNotFull");
-    window.sandbox.stub(ScrollingDOMMethods, "bindOnScroll");
-    window.sandbox.stub(ScrollingDOMMethods, "unbindOnScroll");
+    window.sinon.stub(ScrollingDOMMethods, "screenNotFull");
+    window.sinon.stub(ScrollingDOMMethods, "bindOnScroll");
+    window.sinon.stub(ScrollingDOMMethods, "unbindOnScroll");
 
     // Unless we ever need to test this, let's leave it off.
     $.fn.autocomplete = function () {};
   });
 
   QUnit.testDone(function () {
-    window.sandbox.restore();
+    window.sinon.restore();
 
     // Destroy any modals
     $(".modal-backdrop").remove();

--- a/app/assets/javascripts/discourse/tests/unit/controllers/bookmark-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/controllers/bookmark-test.js
@@ -1,3 +1,4 @@
+import sinon from "sinon";
 import { moduleFor } from "ember-qunit";
 import { test } from "qunit";
 import { logIn } from "discourse/tests/helpers/qunit-helpers";
@@ -20,7 +21,7 @@ moduleFor("controller:bookmark", {
   },
 
   afterEach() {
-    sandbox.restore();
+    sinon.restore();
   },
 });
 
@@ -223,7 +224,7 @@ test("loadLastUsedCustomReminderDatetime does not fills the custom reminder date
 
 test("user timezone updates when the modal is shown", function (assert) {
   User.current().changeTimezone(null);
-  let stub = sandbox.stub(moment.tz, "guess").returns("Europe/Moscow");
+  let stub = sinon.stub(moment.tz, "guess").returns("Europe/Moscow");
   BookmarkController.onShow();
   assert.equal(BookmarkController.userHasTimezoneSet, true);
   assert.equal(

--- a/app/assets/javascripts/discourse/tests/unit/lib/bookmark-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/bookmark-test.js
@@ -1,3 +1,4 @@
+import sinon from "sinon";
 import { test, module } from "qunit";
 import { formattedReminderTime } from "discourse/lib/bookmark";
 import { fakeTime } from "discourse/tests/helpers/qunit-helpers";
@@ -8,7 +9,7 @@ module("lib:bookmark", {
   },
 
   afterEach() {
-    sandbox.restore();
+    sinon.restore();
   },
 });
 

--- a/app/assets/javascripts/discourse/tests/unit/lib/category-badge-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/category-badge-test.js
@@ -2,6 +2,7 @@ import { test } from "qunit";
 import createStore from "discourse/tests/helpers/create-store";
 import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
 import Site from "discourse/models/site";
+import sinon from "sinon";
 
 discourseModule("lib:category-link");
 
@@ -71,7 +72,7 @@ test("allowUncategorized", (assert) => {
     id: 345,
   });
 
-  sandbox
+  sinon
     .stub(Site, "currentProp")
     .withArgs("uncategorized_category_id")
     .returns(345);

--- a/app/assets/javascripts/discourse/tests/unit/lib/click-track-edit-history-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/click-track-edit-history-test.js
@@ -1,3 +1,4 @@
+import sinon from "sinon";
 import { module, skip } from "qunit";
 import DiscourseURL from "discourse/lib/url";
 import ClickTrack from "discourse/lib/click-track";
@@ -10,11 +11,11 @@ module("lib:click-track-edit-history", {
     logIn();
 
     let win = { focus: function () {} };
-    sandbox.stub(window, "open").returns(win);
-    sandbox.stub(win, "focus");
+    sinon.stub(window, "open").returns(win);
+    sinon.stub(win, "focus");
 
-    sandbox.stub(DiscourseURL, "routeTo");
-    sandbox.stub(DiscourseURL, "redirectTo");
+    sinon.stub(DiscourseURL, "routeTo");
+    sinon.stub(DiscourseURL, "redirectTo");
 
     sessionStorage.clear();
 
@@ -61,7 +62,7 @@ function generateClickEventOn(selector) {
 
 skip("tracks internal URLs", async (assert) => {
   assert.expect(2);
-  sandbox.stub(DiscourseURL, "origin").returns("http://discuss.domain.com");
+  sinon.stub(DiscourseURL, "origin").returns("http://discuss.domain.com");
 
   const done = assert.async();
   pretender.post("/clicks/track", (request) => {

--- a/app/assets/javascripts/discourse/tests/unit/lib/click-track-profile-page-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/click-track-profile-page-test.js
@@ -1,3 +1,4 @@
+import sinon from "sinon";
 import { module, skip } from "qunit";
 import DiscourseURL from "discourse/lib/url";
 import ClickTrack from "discourse/lib/click-track";
@@ -9,11 +10,11 @@ module("lib:click-track-profile-page", {
     logIn();
 
     let win = { focus: function () {} };
-    sandbox.stub(window, "open").returns(win);
-    sandbox.stub(win, "focus");
+    sinon.stub(window, "open").returns(win);
+    sinon.stub(win, "focus");
 
-    sandbox.stub(DiscourseURL, "routeTo");
-    sandbox.stub(DiscourseURL, "redirectTo");
+    sinon.stub(DiscourseURL, "routeTo");
+    sinon.stub(DiscourseURL, "redirectTo");
 
     sessionStorage.clear();
 
@@ -54,7 +55,7 @@ function generateClickEventOn(selector) {
 
 skip("tracks internal URLs", async (assert) => {
   assert.expect(2);
-  sandbox.stub(DiscourseURL, "origin").returns("http://discuss.domain.com");
+  sinon.stub(DiscourseURL, "origin").returns("http://discuss.domain.com");
 
   const done = assert.async();
   pretender.post("/clicks/track", (request) => {

--- a/app/assets/javascripts/discourse/tests/unit/lib/click-track-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/click-track-test.js
@@ -1,3 +1,4 @@
+import sinon from "sinon";
 import { skip } from "qunit";
 import { test, module } from "qunit";
 import { later } from "@ember/runloop";
@@ -12,11 +13,11 @@ module("lib:click-track", {
     logIn();
 
     let win = { focus: function () {} };
-    sandbox.stub(window, "open").returns(win);
-    sandbox.stub(win, "focus");
+    sinon.stub(window, "open").returns(win);
+    sinon.stub(win, "focus");
 
-    sandbox.stub(DiscourseURL, "routeTo");
-    sandbox.stub(DiscourseURL, "redirectTo");
+    sinon.stub(DiscourseURL, "routeTo");
+    sinon.stub(DiscourseURL, "redirectTo");
 
     sessionStorage.clear();
 
@@ -55,7 +56,7 @@ function generateClickEventOn(selector) {
 
 skip("tracks internal URLs", async (assert) => {
   assert.expect(2);
-  sandbox.stub(DiscourseURL, "origin").returns("http://discuss.domain.com");
+  sinon.stub(DiscourseURL, "origin").returns("http://discuss.domain.com");
 
   const done = assert.async();
   pretender.post("/clicks/track", (request) => {
@@ -74,7 +75,7 @@ test("does not track elements with no href", async (assert) => {
 });
 
 test("does not track attachments", async (assert) => {
-  sandbox.stub(DiscourseURL, "origin").returns("http://discuss.domain.com");
+  sinon.stub(DiscourseURL, "origin").returns("http://discuss.domain.com");
 
   pretender.post("/clicks/track", () => assert.ok(false));
 
@@ -184,12 +185,12 @@ function badgeClickCount(assert, id, expected) {
 }
 
 test("does not update badge clicks on my own link", async (assert) => {
-  sandbox.stub(User, "currentProp").withArgs("id").returns(314);
+  sinon.stub(User, "currentProp").withArgs("id").returns(314);
   badgeClickCount(assert, "with-badge", 1);
 });
 
 test("does not update badge clicks in my own post", async (assert) => {
-  sandbox.stub(User, "currentProp").withArgs("id").returns(3141);
+  sinon.stub(User, "currentProp").withArgs("id").returns(3141);
   badgeClickCount(assert, "with-badge-but-not-mine", 1);
 });
 

--- a/app/assets/javascripts/discourse/tests/unit/lib/computed-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/computed-test.js
@@ -1,3 +1,4 @@
+import sinon from "sinon";
 import { test } from "qunit";
 import I18n from "I18n";
 import EmberObject from "@ember/object";
@@ -15,7 +16,7 @@ import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
 
 discourseModule("lib:computed", {
   beforeEach() {
-    sandbox.stub(I18n, "t").callsFake(function (scope) {
+    sinon.stub(I18n, "t").callsFake(function (scope) {
       return "%@ translated: " + scope;
     });
   },

--- a/app/assets/javascripts/discourse/tests/unit/lib/uploads-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/uploads-test.js
@@ -1,3 +1,4 @@
+import sinon from "sinon";
 import { test } from "qunit";
 import I18n from "I18n";
 import {
@@ -31,7 +32,7 @@ test("validateUploadedFiles", function (assert) {
 });
 
 test("uploading one file", function (assert) {
-  sandbox.stub(bootbox, "alert");
+  sinon.stub(bootbox, "alert");
 
   assert.not(
     validateUploadedFiles([1, 2], { siteSettings: this.siteSettings })
@@ -41,7 +42,7 @@ test("uploading one file", function (assert) {
 
 test("new user cannot upload images", function (assert) {
   this.siteSettings.newuser_max_embedded_media = 0;
-  sandbox.stub(bootbox, "alert");
+  sinon.stub(bootbox, "alert");
 
   assert.not(
     validateUploadedFiles([{ name: "image.png" }], {
@@ -61,7 +62,7 @@ test("new user cannot upload images", function (assert) {
 test("new user can upload images if allowed", function (assert) {
   this.siteSettings.newuser_max_embedded_media = 1;
   this.siteSettings.default_trust_level = 0;
-  sandbox.stub(bootbox, "alert");
+  sinon.stub(bootbox, "alert");
 
   assert.ok(
     validateUploadedFiles([{ name: "image.png" }], {
@@ -73,7 +74,7 @@ test("new user can upload images if allowed", function (assert) {
 
 test("TL1 can upload images", function (assert) {
   this.siteSettings.newuser_max_embedded_media = 0;
-  sandbox.stub(bootbox, "alert");
+  sinon.stub(bootbox, "alert");
 
   assert.ok(
     validateUploadedFiles([{ name: "image.png" }], {
@@ -85,7 +86,7 @@ test("TL1 can upload images", function (assert) {
 
 test("new user cannot upload attachments", function (assert) {
   this.siteSettings.newuser_max_attachments = 0;
-  sandbox.stub(bootbox, "alert");
+  sinon.stub(bootbox, "alert");
 
   assert.not(
     validateUploadedFiles([{ name: "roman.txt" }], {
@@ -101,7 +102,7 @@ test("new user cannot upload attachments", function (assert) {
 });
 
 test("ensures an authorized upload", function (assert) {
-  sandbox.stub(bootbox, "alert");
+  sinon.stub(bootbox, "alert");
   assert.not(
     validateUploadedFiles([{ name: "unauthorized.html" }], {
       siteSettings: this.siteSettings,
@@ -118,7 +119,7 @@ test("ensures an authorized upload", function (assert) {
 
 test("skipping validation works", function (assert) {
   const files = [{ name: "backup.tar.gz" }];
-  sandbox.stub(bootbox, "alert");
+  sinon.stub(bootbox, "alert");
 
   assert.not(
     validateUploadedFiles(files, {
@@ -137,7 +138,7 @@ test("skipping validation works", function (assert) {
 test("staff can upload anything in PM", function (assert) {
   const files = [{ name: "some.docx" }];
   this.siteSettings.authorized_extensions = "jpeg";
-  sandbox.stub(bootbox, "alert");
+  sinon.stub(bootbox, "alert");
 
   let user = User.create({ moderator: true });
   assert.not(
@@ -171,7 +172,7 @@ const dummyBlob = function () {
 };
 
 test("allows valid uploads to go through", function (assert) {
-  sandbox.stub(bootbox, "alert");
+  sinon.stub(bootbox, "alert");
 
   let user = User.create({ trust_level: 1 });
 
@@ -303,7 +304,7 @@ test("getUploadMarkdown - replaces GUID in image alt text on iOS", (assert) => {
     "![8F2B469B-6B2C-4213-BC68-57B4876365A0|100x200](/uploads/123/abcdef.ext)"
   );
 
-  sandbox.stub(Utilities, "isAppleDevice").returns(true);
+  sinon.stub(Utilities, "isAppleDevice").returns(true);
   assert.equal(
     testUploadMarkdown("8F2B469B-6B2C-4213-BC68-57B4876365A0.jpeg"),
     "![image|100x200](/uploads/123/abcdef.ext)"

--- a/app/assets/javascripts/discourse/tests/unit/lib/url-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/url-test.js
@@ -1,3 +1,4 @@
+import sinon from "sinon";
 import { test, module } from "qunit";
 import DiscourseURL, { userPath, prefixProtocol } from "discourse/lib/url";
 import { setPrefix } from "discourse-common/lib/get-url";
@@ -7,7 +8,7 @@ import User from "discourse/models/user";
 module("lib:url");
 
 test("isInternal with a HTTP url", (assert) => {
-  sandbox.stub(DiscourseURL, "origin").returns("http://eviltrout.com");
+  sinon.stub(DiscourseURL, "origin").returns("http://eviltrout.com");
 
   assert.not(DiscourseURL.isInternal(null), "a blank URL is not internal");
   assert.ok(DiscourseURL.isInternal("/test"), "relative URLs are internal");
@@ -34,7 +35,7 @@ test("isInternal with a HTTP url", (assert) => {
 });
 
 test("isInternal with a HTTPS url", (assert) => {
-  sandbox.stub(DiscourseURL, "origin").returns("https://eviltrout.com");
+  sinon.stub(DiscourseURL, "origin").returns("https://eviltrout.com");
   assert.ok(
     DiscourseURL.isInternal("http://eviltrout.com/monocle"),
     "HTTPS urls match HTTP urls"
@@ -42,7 +43,7 @@ test("isInternal with a HTTPS url", (assert) => {
 });
 
 test("isInternal on subfolder install", (assert) => {
-  sandbox.stub(DiscourseURL, "origin").returns("http://eviltrout.com/forum");
+  sinon.stub(DiscourseURL, "origin").returns("http://eviltrout.com/forum");
   assert.not(
     DiscourseURL.isInternal("http://eviltrout.com"),
     "the host root is not internal"
@@ -73,7 +74,7 @@ test("routeTo with prefix", async (assert) => {
   logIn();
   const user = User.current();
 
-  sandbox.stub(DiscourseURL, "handleURL");
+  sinon.stub(DiscourseURL, "handleURL");
   DiscourseURL.routeTo("/my/messages");
   assert.ok(
     DiscourseURL.handleURL.calledWith(`/u/${user.username}/messages`),

--- a/app/assets/javascripts/discourse/tests/unit/models/category-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/category-test.js
@@ -1,3 +1,4 @@
+import sinon from "sinon";
 import { test, module } from "qunit";
 import createStore from "discourse/tests/helpers/create-store";
 import Category from "discourse/models/category";
@@ -87,7 +88,7 @@ test("findBySlug", (assert) => {
     }),
     categoryList = [darth, luke, hurricane, newsFeed, time, bah];
 
-  sandbox.stub(Category, "list").returns(categoryList);
+  sinon.stub(Category, "list").returns(categoryList);
 
   assert.deepEqual(
     Category.findBySlug("darth"),
@@ -120,7 +121,7 @@ test("findBySlug", (assert) => {
     "we can find a category with english slug whose parent slug is CJK"
   );
 
-  sandbox.restore();
+  sinon.restore();
 });
 
 test("findSingleBySlug", (assert) => {
@@ -151,7 +152,7 @@ test("findSingleBySlug", (assert) => {
     }),
     categoryList = [darth, luke, hurricane, newsFeed, time, bah];
 
-  sandbox.stub(Category, "list").returns(categoryList);
+  sinon.stub(Category, "list").returns(categoryList);
 
   assert.deepEqual(
     Category.findSingleBySlug("darth"),
@@ -201,7 +202,7 @@ test("findBySlugPathWithID", (assert) => {
   });
 
   const categoryList = [foo, bar, baz];
-  sandbox.stub(Category, "list").returns(categoryList);
+  sinon.stub(Category, "list").returns(categoryList);
 
   assert.deepEqual(Category.findBySlugPathWithID("foo"), foo);
   assert.deepEqual(Category.findBySlugPathWithID("foo/bar"), bar);
@@ -222,7 +223,7 @@ test("search with category name", (assert) => {
       slug: "another-different-slug",
     });
 
-  sandbox.stub(Category, "listByActivity").returns([category1, category2]);
+  sinon.stub(Category, "listByActivity").returns([category1, category2]);
 
   assert.deepEqual(
     Category.search("term", { limit: 0 }),
@@ -254,7 +255,7 @@ test("search with category name", (assert) => {
     "orders matching begin with and then contains"
   );
 
-  sandbox.restore();
+  sinon.restore();
 
   const child_category1 = store.createRecord("category", {
       id: 3,
@@ -267,7 +268,7 @@ test("search with category name", (assert) => {
       read_restricted: true,
     });
 
-  sandbox
+  sinon
     .stub(Category, "listByActivity")
     .returns([read_restricted_category, category1, child_category1, category2]);
 
@@ -295,7 +296,7 @@ test("search with category name", (assert) => {
     "prioritize non read_restricted with limit"
   );
 
-  sandbox.restore();
+  sinon.restore();
 });
 
 test("search with category slug", (assert) => {
@@ -311,7 +312,7 @@ test("search with category slug", (assert) => {
       slug: "another-different-slug",
     });
 
-  sandbox.stub(Category, "listByActivity").returns([category1, category2]);
+  sinon.stub(Category, "listByActivity").returns([category1, category2]);
 
   assert.deepEqual(
     Category.search("different-slug"),

--- a/app/assets/javascripts/discourse/tests/unit/models/post-stream-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/post-stream-test.js
@@ -1,3 +1,4 @@
+import sinon from "sinon";
 import { test, module } from "qunit";
 import ArrayProxy from "@ember/array/proxy";
 import Post from "discourse/models/post";
@@ -212,7 +213,7 @@ test("removePosts", (assert) => {
 test("cancelFilter", (assert) => {
   const postStream = buildStream(1235);
 
-  sandbox.stub(postStream, "refresh").returns(Promise.resolve());
+  sinon.stub(postStream, "refresh").returns(Promise.resolve());
 
   postStream.set("summary", true);
   postStream.cancelFilter();
@@ -250,7 +251,7 @@ test("findPostIdForPostNumber", (assert) => {
 
 test("fillGapBefore", (assert) => {
   const postStream = buildStream(1234, [60]);
-  sandbox.stub(postStream, "findPostsByIds").returns(Promise.resolve([]));
+  sinon.stub(postStream, "findPostsByIds").returns(Promise.resolve([]));
   let post = postStream.store.createRecord("post", { id: 60, post_number: 60 });
   postStream.set("gaps", {
     before: { 60: [51, 52, 53, 54, 55, 56, 57, 58, 59] },
@@ -267,7 +268,7 @@ test("fillGapBefore", (assert) => {
 
 test("toggleParticipant", (assert) => {
   const postStream = buildStream(1236);
-  sandbox.stub(postStream, "refresh").returns(Promise.resolve());
+  sinon.stub(postStream, "refresh").returns(Promise.resolve());
 
   assert.equal(
     postStream.get("userFilters.length"),
@@ -290,7 +291,7 @@ test("toggleParticipant", (assert) => {
 
 test("streamFilters", (assert) => {
   const postStream = buildStream(1237);
-  sandbox.stub(postStream, "refresh").returns(Promise.resolve());
+  sinon.stub(postStream, "refresh").returns(Promise.resolve());
 
   assert.deepEqual(
     postStream.get("streamFilters"),
@@ -807,7 +808,7 @@ test("comitting and triggerNewPostsInStream race condition", (assert) => {
   );
   stagedPost.set("id", 123);
 
-  sandbox.stub(postStream, "appendMore");
+  sinon.stub(postStream, "appendMore");
   postStream.triggerNewPostsInStream([123]);
   assert.equal(postStream.get("filteredPostsCount"), 1, "it added the post");
 
@@ -845,7 +846,7 @@ test("triggerNewPostInStream for ignored posts", async (assert) => {
     username: "ignoreduser",
   });
 
-  var stub = sandbox
+  let stub = sinon
     .stub(postStream, "findPostsByIds")
     .returns(Promise.resolve([post2]));
 
@@ -862,7 +863,7 @@ test("triggerNewPostInStream for ignored posts", async (assert) => {
   );
 
   stub.restore();
-  sandbox.stub(postStream, "findPostsByIds").returns(Promise.resolve([post3]));
+  sinon.stub(postStream, "findPostsByIds").returns(Promise.resolve([post3]));
 
   await postStream.triggerNewPostsInStream([102]);
   assert.equal(

--- a/app/assets/javascripts/discourse/tests/unit/models/rest-model-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/rest-model-test.js
@@ -1,3 +1,4 @@
+import sinon from "sinon";
 import { test, module } from "qunit";
 module("rest-model");
 
@@ -25,8 +26,8 @@ test("update", async (assert) => {
   assert.equal(widget.get("name"), "Trout Lure");
   assert.ok(!widget.get("isSaving"), "it is not saving");
 
-  const spyBeforeUpdate = sandbox.spy(widget, "beforeUpdate");
-  const spyAfterUpdate = sandbox.spy(widget, "afterUpdate");
+  const spyBeforeUpdate = sinon.spy(widget, "beforeUpdate");
+  const spyAfterUpdate = sinon.spy(widget, "afterUpdate");
   const promise = widget.update({ name: "new name" });
   assert.ok(widget.get("isSaving"), "it is saving");
   assert.ok(spyBeforeUpdate.calledOn(widget));
@@ -66,8 +67,8 @@ test("save new", async (assert) => {
   assert.ok(!widget.get("isCreated"), "it is not created");
   assert.ok(!widget.get("isSaving"), "it is not saving");
 
-  const spyBeforeCreate = sandbox.spy(widget, "beforeCreate");
-  const spyAfterCreate = sandbox.spy(widget, "afterCreate");
+  const spyBeforeCreate = sinon.spy(widget, "beforeCreate");
+  const spyAfterCreate = sinon.spy(widget, "afterCreate");
   const promise = widget.save({ name: "Evil Widget" });
   assert.ok(widget.get("isSaving"), "it is not saving");
   assert.ok(spyBeforeCreate.calledOn(widget));

--- a/app/assets/javascripts/discourse/tests/unit/models/topic-tracking-state-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/topic-tracking-state-test.js
@@ -175,7 +175,7 @@ test("subscribe to category", function (assert) {
     }),
     categoryList = [darth, luke];
 
-  sandbox.stub(Category, "list").returns(categoryList);
+  sinon.stub(Category, "list").returns(categoryList);
 
   const state = TopicTrackingState.create();
 
@@ -242,7 +242,7 @@ test("getSubCategoryIds", (assert) => {
     slug: "baz",
     parent_category_id: bar.id,
   });
-  sandbox.stub(Category, "list").returns([foo, bar, baz]);
+  sinon.stub(Category, "list").returns([foo, bar, baz]);
 
   const state = TopicTrackingState.create();
   assert.deepEqual(Array.from(state.getSubCategoryIds(1)), [1, 2, 3]);
@@ -270,7 +270,7 @@ test("countNew", (assert) => {
     id: 4,
     slug: "qux",
   });
-  sandbox.stub(Category, "list").returns([foo, bar, baz, qux]);
+  sinon.stub(Category, "list").returns([foo, bar, baz, qux]);
 
   let currentUser = User.create({
     username: "chuck",

--- a/app/assets/javascripts/discourse/tests/unit/models/user-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/user-test.js
@@ -1,3 +1,4 @@
+import sinon from "sinon";
 import { test, module } from "qunit";
 import User from "discourse/models/user";
 import Group from "discourse/models/group";
@@ -74,13 +75,13 @@ test("canMangeGroup", (assert) => {
 test("resolvedTimezone", (assert) => {
   const tz = "Australia/Brisbane";
   let user = User.create({ timezone: tz, username: "chuck", id: 111 });
-  let stub = sandbox.stub(moment.tz, "guess").returns("America/Chicago");
+  let stub = sinon.stub(moment.tz, "guess").returns("America/Chicago");
 
   pretender.put("/u/chuck.json", () => {
     return [200, { "Content-Type": "application/json" }, {}];
   });
 
-  let spy = sandbox.spy(ajaxlib, "ajax");
+  let spy = sinon.spy(ajaxlib, "ajax");
   assert.equal(
     user.resolvedTimezone(user),
     tz,

--- a/app/assets/javascripts/test-shims.js
+++ b/app/assets/javascripts/test-shims.js
@@ -30,6 +30,9 @@ define("@ember/test-helpers", () => {
     visit() {
       return window.visit(...arguments);
     },
+    currentURL() {
+      return window.currentURL(...arguments);
+    },
   };
 });
 define("pretender", () => {

--- a/plugins/discourse-local-dates/test/javascripts/lib/local-date-builder-test.js.es6
+++ b/plugins/discourse-local-dates/test/javascripts/lib/local-date-builder-test.js.es6
@@ -1,6 +1,6 @@
+import sinon from "sinon";
 import I18n from "I18n";
 import LocalDateBuilder from "./local-date-builder";
-import sinon from "sinon";
 
 const UTC = "Etc/UTC";
 const SYDNEY = "Australia/Sydney";
@@ -11,16 +11,14 @@ const LONDON = "Europe/London";
 
 module("lib:local-date-builder");
 
-const sandbox = sinon.createSandbox();
-
 function freezeTime({ date, timezone }, cb) {
   date = date || "2020-01-22 10:34";
   const newTimezone = timezone || PARIS;
   const previousZone = moment.tz.guess();
   const now = moment.tz(date, newTimezone).valueOf();
 
-  sandbox.useFakeTimers(now);
-  sandbox.stub(moment.tz, "guess");
+  sinon.useFakeTimers(now);
+  sinon.stub(moment.tz, "guess");
   moment.tz.guess.returns(newTimezone);
   moment.tz.setDefault(newTimezone);
 
@@ -28,7 +26,7 @@ function freezeTime({ date, timezone }, cb) {
 
   moment.tz.guess.returns(previousZone);
   moment.tz.setDefault(previousZone);
-  sandbox.restore();
+  sinon.restore();
 }
 
 QUnit.assert.buildsCorrectDate = function (options, expected, message) {


### PR DESCRIPTION
* Use `sinon` instead of `sandbox` and require an import.
* You need to import `currentURL` to use it.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
