### PR TITLE
Use response helper

### DIFF
--- a/app/assets/javascripts/discourse/tests/acceptance/preferences-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/preferences-test.js
@@ -282,14 +282,13 @@ acceptance("Avatar selector when selectable avatars is enabled", function (
 ) {
   needs.user();
   needs.settings({ selectable_avatars_enabled: true });
-  needs.pretender((server) => {
-    server.get("/site/selectable-avatars.json", () => {
-      return [
-        200,
-        { "Content-Type": "application/json" },
-        ["https://www.discourse.org", "https://meta.discourse.org"],
-      ];
-    });
+  needs.pretender((server, helper) => {
+    server.get("/site/selectable-avatars.json", () =>
+      helper.response([
+        "https://www.discourse.org",
+        "https://meta.discourse.org",
+      ])
+    );
   });
 
   test("selectable avatars", async (assert) => {

--- a/app/assets/javascripts/discourse/tests/acceptance/user-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-test.js
@@ -1,16 +1,16 @@
 import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
-import pretender from "discourse/tests/helpers/create-pretender";
 
 acceptance("User Routes", function (needs) {
   needs.user();
 
+  needs.pretender((server, helper) => {
+    server.get("/u/eviltrout%2F..%2F..%2F.json", () =>
+      helper.response(400, {})
+    );
+  });
   test("Invalid usernames", async (assert) => {
-    pretender.get("/u/eviltrout%2F..%2F..%2F.json", () => {
-      return [400, { "Content-Type": "application/json" }, {}];
-    });
-
     await visit("/u/eviltrout%2F..%2F..%2F/summary");
 
     assert.equal(currentPath(), "exception-unknown");

--- a/app/assets/javascripts/discourse/tests/helpers/create-pretender.js
+++ b/app/assets/javascripts/discourse/tests/helpers/create-pretender.js
@@ -88,45 +88,41 @@ export function applyDefaultHandlers(pretender) {
   });
 
   pretender.get("/tags", () => {
-    return [
-      200,
-      { "Content-Type": "application/json" },
-      {
-        tags: [
-          { id: "eviltrout", count: 1 },
-          { id: "planned", text: "planned", count: 7, pm_count: 0 },
-          { id: "private", text: "private", count: 0, pm_count: 7 },
+    return response({
+      tags: [
+        { id: "eviltrout", count: 1 },
+        { id: "planned", text: "planned", count: 7, pm_count: 0 },
+        { id: "private", text: "private", count: 0, pm_count: 7 },
+      ],
+      extras: {
+        tag_groups: [
+          {
+            id: 2,
+            name: "Ford Cars",
+            tags: [
+              { id: "Escort", text: "Escort", count: 1, pm_count: 0 },
+              { id: "focus", text: "focus", count: 3, pm_count: 0 },
+            ],
+          },
+          {
+            id: 1,
+            name: "Honda Cars",
+            tags: [
+              { id: "civic", text: "civic", count: 4, pm_count: 0 },
+              { id: "accord", text: "accord", count: 2, pm_count: 0 },
+            ],
+          },
+          {
+            id: 1,
+            name: "Makes",
+            tags: [
+              { id: "ford", text: "ford", count: 5, pm_count: 0 },
+              { id: "honda", text: "honda", count: 6, pm_count: 0 },
+            ],
+          },
         ],
-        extras: {
-          tag_groups: [
-            {
-              id: 2,
-              name: "Ford Cars",
-              tags: [
-                { id: "Escort", text: "Escort", count: 1, pm_count: 0 },
-                { id: "focus", text: "focus", count: 3, pm_count: 0 },
-              ],
-            },
-            {
-              id: 1,
-              name: "Honda Cars",
-              tags: [
-                { id: "civic", text: "civic", count: 4, pm_count: 0 },
-                { id: "accord", text: "accord", count: 2, pm_count: 0 },
-              ],
-            },
-            {
-              id: 1,
-              name: "Makes",
-              tags: [
-                { id: "ford", text: "ford", count: 5, pm_count: 0 },
-                { id: "honda", text: "honda", count: 6, pm_count: 0 },
-              ],
-            },
-          ],
-        },
       },
-    ];
+    });
   });
 
   pretender.delete("/bookmarks/:id", () => response({}));
@@ -467,11 +463,7 @@ export function applyDefaultHandlers(pretender) {
   pretender.put("/posts/:post_id", (request) => {
     const data = parsePostData(request.requestBody);
     if (data.post.raw === "this will 409") {
-      return [
-        409,
-        { "Content-Type": "application/json" },
-        { errors: ["edit conflict"] },
-      ];
+      return response(409, { errors: ["edit conflict"] });
     }
     data.post.id = request.params.post_id;
     data.post.version = 2;


### PR DESCRIPTION
These tests were using a much more verbose API. `response` is much
simpler.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
