### PR TITLE
FIX: ignore PGP data in emails by MIME type

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1149,7 +1149,7 @@ email:
     max: 36500
   blocked_attachment_content_types:
     type: list
-    default: "pkcs7|x-vcard"
+    default: "pkcs7|x-vcard|pgp-keys|pgp-signature"
     list_type: compact
   blocked_attachment_filenames:
     type: list


### PR DESCRIPTION
New version of Thunderbird email client reimplemented PGP support. Now the following attachments are added by default, if email signatures are enabled:

* OpenPGP_0x(pgp key id).asc
* OpenPGP_signature(.asc)

The last one has `name="OpenPGP_signature.asc"` in `Content-Type` but `filename="OpenPGP_signature"` (without extension) in `Content-Disposition: attachment`.

Since both the key and the signature have proper MIME types, filter them by default.

```
Content-Type: application/pgp-keys;
 name="OpenPGP_0x5CD7202EEF88F772.asc"
Content-Transfer-Encoding: quoted-printable
Content-Disposition: attachment;
 filename="OpenPGP_0x5CD7202EEF88F772.asc"
```

```
Content-Type: application/pgp-signature; name="OpenPGP_signature.asc"
Content-Description: OpenPGP digital signature
Content-Disposition: attachment; filename="OpenPGP_signature"
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
