### PR TITLE
FIX: Prevent slow bookmark first post reminder at query for topic

### DIFF
--- a/lib/topic_view.rb
+++ b/lib/topic_view.rb
@@ -349,8 +349,12 @@ class TopicView
   end
 
   def first_post_bookmark_reminder_at
-    @topic.posts.with_deleted.where(post_number: 1).first
-      .bookmarks.where(user: @user).pluck_first(:reminder_at)
+    @first_post_bookmark_reminder_at ||= \
+      begin
+        first_post = @topic.posts.with_deleted.find_by(post_number: 1)
+        return if !first_post
+        first_post.bookmarks.where(user: @user).pluck_first(:reminder_at)
+      end
   end
 
   MAX_PARTICIPANTS = 24


### PR DESCRIPTION
On forums with a large amount of posts when a user had a bookmark in the topic, PostgreSQL was using an inefficient query plan to fetch the first post of the topic. When running this ActiveRecord query:

```ruby
topic.posts.with_deleted.where(post_number: 1).first
```

The following SQL was produced:

```
EXPLAIN ANALYZE SELECT "posts"."id", "posts"."user_id", "posts"."topic_id", "posts"."post_number", "posts"."raw", "posts"."cooked", "posts"."created_at", "posts"."updated_at", "posts"."reply_to_post_number", "posts"."reply_count", "posts"."quote_count", "posts"."deleted_at", "posts"."off_topic_count", "posts"."like_count", "posts"."incoming_link_count", "posts"."bookmark_count", "posts"."score", "posts"."reads", "posts"."post_type", "posts"."sort_order", "posts"."last_editor_id", "posts"."hidden", "posts"."hidden_reason_id", "posts"."notify_moderators_count", "posts"."spam_count", "posts"."illegal_count", "posts"."inappropriate_count", "posts"."last_version_at", "posts"."user_deleted", "posts"."reply_to_user_id", "posts"."percent_rank", "posts"."notify_user_count", "posts"."like_score", "posts"."deleted_by_id", "posts"."edit_reason", "posts"."word_count", "posts"."version", "posts"."cook_method", "posts"."wiki", "posts"."baked_at", "posts"."baked_version", "posts"."hidden_at", "posts"."self_edits", "posts"."reply_quoted", "posts"."via_email", "posts"."raw_email", "posts"."public_version", "posts"."action_code", "posts"."locked_by_id", "posts"."image_upload_id" FROM "posts" WHERE "posts"."topic_id" = 160918 AND "posts"."post_number" = 1 ORDER BY "posts"."id" ASC LIMIT 1;
```

And the associated query plan:

```
 Limit  (cost=0.43..583.49 rows=1 width=891) (actual time=3850.515..3850.515 rows=1 loops=1)
   ->  Index Scan using posts_pkey on posts  (cost=0.43..391231.51 rows=671 width=891) (actual time=3850.514..3850.514 
rows=1 loops=1)
         Filter: ((topic_id = 160918) AND (post_number = 1))
         Rows Removed by Filter: 2274520
 Planning time: 0.200 ms
 Execution time: 3850.559 ms
(6 rows)
```

The issue here is the combination of ORDER BY and LIMIT causing the ineficcient `Index Scan using posts_pkey on posts` to be used. When we correct the AR call to this:

```ruby
topic.posts.with_deleted.find_by(post_number: 1)
```

We end up with a query that still has a LIMIT but no ORDER BY:

```
EXPLAIN ANALYZE SELECT "posts"."id", "posts"."user_id", "posts"."topic_id", "posts"."post_number", "posts"."raw", "posts"."cooked", "posts"."created_at", "posts"."updated_at", "posts"."reply_to_post_number", "posts"."reply_count", "posts"."quote_count", "posts"."deleted_at", "posts"."off_topic_count", "posts"."like_count", "posts"."incoming_link_count", "posts"."bookmark_count", "posts"."score", "posts"."reads", "posts"."post_type", "posts"."sort_order", "posts"."last_editor_id", "posts"."hidden", "posts"."hidden_reason_id", "posts"."notify_moderators_count", "posts"."spam_count", "posts"."illegal_count", "posts"."inappropriate_count", "posts"."last_version_at", "posts"."user_deleted", "posts"."reply_to_user_id", "posts"."percent_rank", "posts"."notify_user_count", "posts"."like_score", "posts"."deleted_by_id", "posts"."edit_reason", "posts"."word_count", "posts"."version", "posts"."cook_method", "posts"."wiki", "posts"."baked_at", "posts"."baked_version", "posts"."hidden_at", "posts"."self_edits", "posts"."reply_quoted", "posts"."via_email", "posts"."raw_email", "posts"."public_version", "posts"."action_code", "posts"."locked_by_id", "posts"."image_upload_id" FROM "posts" WHERE "posts"."topic_id" = 160918 AND "posts"."post_number" = 1 LIMIT 1;
```

Which in turn creates a much more efficient query plan:

```
Limit  (cost=0.43..1.44 rows=1 width=891) (actual time=0.033..0.034 rows=1 loops=1)
   ->  Index Scan using index_posts_on_topic_id_and_post_number on posts  (cost=0.43..678.82 rows=671 width=891) (actua
l time=0.033..0.033 rows=1 loops=1)
         Index Cond: ((topic_id = 160918) AND (post_number = 1))
 Planning time: 0.167 ms
 Execution time: 0.072 ms
(5 rows)
```

This query plan uses the correct index, `Index Scan using index_posts_on_topic_id_and_post_number on posts`. Note that this is only a problem on forums with a larger amount of posts; tiny forums would not notice the difference. On large forums a query for a topic that takes 1s without a bookmark can take 8-30 seconds, and even end up with 502 errors from nginx.