### PR TITLE
PERF: we don't need to use a huge image to test thumbnails

### DIFF
--- a/spec/integration/topic_thumbnail_spec.rb
+++ b/spec/integration/topic_thumbnail_spec.rb
@@ -2,9 +2,12 @@
 require 'rails_helper'
 
 describe "Topic Thumbnails" do
-  before { SiteSetting.create_thumbnails = true }
+  before do
+    SiteSetting.create_thumbnails = true
+    ImageSizer.stubs(:resize).returns([9, 9])
+  end
 
-  fab!(:image) { Fabricate(:image_upload, width: 5000, height: 5000) }
+  fab!(:image) { Fabricate(:image_upload, width: 50, height: 50) }
   fab!(:topic) { Fabricate(:topic, image_upload_id: image.id) }
   fab!(:user) { Fabricate(:user) }
 
@@ -27,9 +30,9 @@ describe "Topic Thumbnails" do
       before do
         theme = Fabricate(:theme)
         theme.theme_modifier_set.topic_thumbnail_sizes = [
-          [100, 100],
-          [200, 200],
-          [300, 300]
+          [10, 10],
+          [20, 20],
+          [30, 30]
         ]
         theme.theme_modifier_set.save!
         theme.set_default!
@@ -71,8 +74,8 @@ describe "Topic Thumbnails" do
         # Check first optimized
         expect(thumbnails[1]["max_width"]).to eq(Topic.share_thumbnail_size[0])
         expect(thumbnails[1]["max_height"]).to eq(Topic.share_thumbnail_size[1])
-        expect(thumbnails[1]["width"]).to eq(1024)
-        expect(thumbnails[1]["height"]).to eq(1024)
+        expect(thumbnails[1]["width"]).to eq(9)
+        expect(thumbnails[1]["height"]).to eq(9)
         expect(thumbnails[1]["url"]).to include("/optimized/")
 
       end

--- a/spec/models/topic_thumbnail_spec.rb
+++ b/spec/models/topic_thumbnail_spec.rb
@@ -12,7 +12,7 @@ describe "TopicThumbnail" do
   before do
     SiteSetting.create_thumbnails = true
 
-    ImageSizer.stubs(:resize).returns([49, 49])
+    Topic.stubs(:thumbnail_sizes).returns([[49, 49]])
 
     topic.generate_thumbnails!(extra_sizes: nil)
 

--- a/spec/models/topic_thumbnail_spec.rb
+++ b/spec/models/topic_thumbnail_spec.rb
@@ -2,15 +2,18 @@
 require 'rails_helper'
 
 describe "TopicThumbnail" do
-  let(:upload1) { Fabricate(:image_upload, width: 5000, height: 5000) }
+  let(:upload1) { Fabricate(:image_upload, width: 50, height: 50) }
   let(:topic) { Fabricate(:topic, image_upload: upload1) }
-  let(:upload2) { Fabricate(:image_upload, width: 5000, height: 5000) }
+  let(:upload2) { Fabricate(:image_upload, width: 50, height: 50) }
   let(:topic2) { Fabricate(:topic, image_upload: upload2) }
   let(:upload3) { Fabricate(:upload_no_dimensions) }
   let(:topic3) { Fabricate(:topic, image_upload: upload3) }
 
   before do
     SiteSetting.create_thumbnails = true
+
+    ImageSizer.stubs(:resize).returns([49, 49])
+
     topic.generate_thumbnails!(extra_sizes: nil)
 
     TopicThumbnail.ensure_consistency!
@@ -69,5 +72,4 @@ describe "TopicThumbnail" do
 
     expect(topic.topic_thumbnails.length).to eq(0)
   end
-
 end


### PR DESCRIPTION
Generating images with 5000x5000 dimensions is an expensive operation.

Using smaller images reduce the time of model spec from 11s to 3s and integration spec from 6s to 2s.
