### PR TITLE
Move `click` and `fillIn` to imports

### DIFF
--- a/app/assets/javascripts/discourse/tests/acceptance/account-created-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/account-created-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { visit, click, fillIn } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import PreloadStore from "discourse/lib/preload-store";

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-emails-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-emails-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { fillIn, click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-search-logs-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-search-logs-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-site-settings-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-site-settings-test.js
@@ -1,4 +1,4 @@
-import { visit, currentURL } from "@ember/test-helpers";
+import { fillIn, click, visit, currentURL } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import siteSettingFixture from "discourse/tests/fixtures/site-settings";

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-site-text-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-site-text-test.js
@@ -1,4 +1,4 @@
-import { visit, currentURL } from "@ember/test-helpers";
+import { fillIn, click, visit, currentURL } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-suspend-user-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-suspend-user-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { visit, click, fillIn } from "@ember/test-helpers";
 import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-user-emails-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-user-emails-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import I18n from "I18n";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-user-index-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-user-index-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-users-list-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-users-list-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import I18n from "I18n";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-watched-words-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-watched-words-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { fillIn, click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/bookmarks-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/bookmarks-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import I18n from "I18n";
 import selectKit from "discourse/tests/helpers/select-kit-helper";

--- a/app/assets/javascripts/discourse/tests/acceptance/category-banner-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/category-banner-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import DiscoveryFixtures from "discourse/tests/fixtures/discovery-fixtures";

--- a/app/assets/javascripts/discourse/tests/acceptance/category-chooser-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/category-chooser-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";

--- a/app/assets/javascripts/discourse/tests/acceptance/category-edit-security-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/category-edit-security-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";

--- a/app/assets/javascripts/discourse/tests/acceptance/category-edit-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/category-edit-test.js
@@ -1,4 +1,4 @@
-import { visit, currentURL } from "@ember/test-helpers";
+import { click, fillIn, visit, currentURL } from "@ember/test-helpers";
 import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";

--- a/app/assets/javascripts/discourse/tests/acceptance/category-new-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/category-new-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { fillIn, click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import I18n from "I18n";

--- a/app/assets/javascripts/discourse/tests/acceptance/click-track-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/click-track-test.js
@@ -1,4 +1,4 @@
-import { visit, currentURL } from "@ember/test-helpers";
+import { click, visit, currentURL } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-actions-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-actions-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import I18n from "I18n";
 import selectKit from "discourse/tests/helpers/select-kit-helper";

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-attachment-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-attachment-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-edit-conflict-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-edit-conflict-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import I18n from "I18n";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-hyperlink-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-hyperlink-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-onebox-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-onebox-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-tags-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-tags-test.js
@@ -1,4 +1,4 @@
-import { visit, currentURL } from "@ember/test-helpers";
+import { click, fillIn, visit, currentURL } from "@ember/test-helpers";
 import { test } from "qunit";
 import Category from "discourse/models/category";
 import {

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
@@ -1,4 +1,4 @@
-import { visit, currentURL } from "@ember/test-helpers";
+import { click, fillIn, visit, currentURL } from "@ember/test-helpers";
 import { skip } from "qunit";
 import { test } from "qunit";
 import I18n from "I18n";

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-topic-links-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-topic-links-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-uncategorized-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-uncategorized-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";

--- a/app/assets/javascripts/discourse/tests/acceptance/create-account-user-fields-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/create-account-user-fields-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/dashboard-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/dashboard-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";

--- a/app/assets/javascripts/discourse/tests/acceptance/emoji-picker-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/emoji-picker-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/emoji-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/emoji-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { IMAGE_VERSION as v } from "pretty-text/emoji/version";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";

--- a/app/assets/javascripts/discourse/tests/acceptance/enforce-second-factor-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/enforce-second-factor-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import {
   acceptance,

--- a/app/assets/javascripts/discourse/tests/acceptance/flag-post-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/flag-post-test.js
@@ -1,3 +1,4 @@
+import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";

--- a/app/assets/javascripts/discourse/tests/acceptance/forgot-password-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/forgot-password-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import I18n from "I18n";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";

--- a/app/assets/javascripts/discourse/tests/acceptance/group-index-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-index-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import I18n from "I18n";
 import {

--- a/app/assets/javascripts/discourse/tests/acceptance/group-manage-logs-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-manage-logs-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/group-manage-membership-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-manage-membership-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import {
   acceptance,

--- a/app/assets/javascripts/discourse/tests/acceptance/group-requests-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-requests-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/group-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import I18n from "I18n";
 import selectKit from "discourse/tests/helpers/select-kit-helper";

--- a/app/assets/javascripts/discourse/tests/acceptance/groups-index-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/groups-index-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/groups-new-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/groups-new-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import I18n from "I18n";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";

--- a/app/assets/javascripts/discourse/tests/acceptance/hamburger-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/hamburger-menu-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import {
   acceptance,

--- a/app/assets/javascripts/discourse/tests/acceptance/hashtags-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/hashtags-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/invite-accept-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/invite-accept-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import PreloadStore from "discourse/lib/preload-store";

--- a/app/assets/javascripts/discourse/tests/acceptance/invite-show-user-fields-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/invite-show-user-fields-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { fillIn, click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import PreloadStore from "discourse/lib/preload-store";

--- a/app/assets/javascripts/discourse/tests/acceptance/jump-to-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/jump-to-test.js
@@ -1,4 +1,4 @@
-import { visit, currentURL } from "@ember/test-helpers";
+import { click, fillIn, visit, currentURL } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/login-required-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/login-required-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/login-with-email-and-hide-email-address-taken-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/login-with-email-and-hide-email-address-taken-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import I18n from "I18n";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";

--- a/app/assets/javascripts/discourse/tests/acceptance/login-with-email-and-no-social-logins-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/login-with-email-and-no-social-logins-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/login-with-email-disabled-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/login-with-email-disabled-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/login-with-email-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/login-with-email-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { fillIn, click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import I18n from "I18n";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";

--- a/app/assets/javascripts/discourse/tests/acceptance/mobile-sign-in-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/mobile-sign-in-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/modal-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/modal-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import I18n from "I18n";
 import { run } from "@ember/runloop";

--- a/app/assets/javascripts/discourse/tests/acceptance/page-publishing-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/page-publishing-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/password-reset-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/password-reset-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { visit, click, fillIn } from "@ember/test-helpers";
 import { test } from "qunit";
 import I18n from "I18n";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";

--- a/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-connector-class-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-connector-class-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { visit, click } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import { extraConnectorClass } from "discourse/lib/plugin-connectors";

--- a/app/assets/javascripts/discourse/tests/acceptance/post-admin-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/post-admin-menu-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { visit, click } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/preferences-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/preferences-test.js
@@ -1,4 +1,4 @@
-import { visit, currentURL } from "@ember/test-helpers";
+import { visit, currentURL, click, fillIn } from "@ember/test-helpers";
 import { test } from "qunit";
 import I18n from "I18n";
 import {

--- a/app/assets/javascripts/discourse/tests/acceptance/review-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/review-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { visit, click, fillIn } from "@ember/test-helpers";
 import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";

--- a/app/assets/javascripts/discourse/tests/acceptance/search-full-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-full-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { visit, fillIn, click } from "@ember/test-helpers";
 import { skip } from "qunit";
 import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";

--- a/app/assets/javascripts/discourse/tests/acceptance/search-mobile-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-mobile-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/search-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";

--- a/app/assets/javascripts/discourse/tests/acceptance/share-and-invite-desktop-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/share-and-invite-desktop-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/share-and-invite-mobile-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/share-and-invite-mobile-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";

--- a/app/assets/javascripts/discourse/tests/acceptance/shared-drafts-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/shared-drafts-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";

--- a/app/assets/javascripts/discourse/tests/acceptance/sign-in-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sign-in-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/tag-groups-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/tag-groups-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";

--- a/app/assets/javascripts/discourse/tests/acceptance/tags-intersection-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/tags-intersection-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/tags-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/tags-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import {
   updateCurrentUser,

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-admin-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-admin-menu-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import {
   acceptance,

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-edit-timer-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-edit-timer-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { click, fillIn, visit } from "@ember/test-helpers";
 import { skip } from "qunit";
 import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-move-posts-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-move-posts-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import I18n from "I18n";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import I18n from "I18n";
 import { withPluginApi } from "discourse/lib/plugin-api";

--- a/app/assets/javascripts/discourse/tests/acceptance/user-bookmarks-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-bookmarks-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import selectKit from "discourse/tests/helpers/select-kit-helper";

--- a/app/assets/javascripts/discourse/tests/acceptance/user-card-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-card-test.js
@@ -3,6 +3,7 @@ import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import userFixtures from "discourse/tests/fixtures/user-fixtures";
 import User from "discourse/models/user";
+import { click } from "@ember/test-helpers";
 
 acceptance("User Card - Show Local Time", function (needs) {
   needs.user();

--- a/app/assets/javascripts/discourse/tests/acceptance/user-drafts-stream-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-drafts-stream-test.js
@@ -1,6 +1,7 @@
 import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+import { click } from "@ember/test-helpers";
 
 acceptance("User Drafts", function (needs) {
   needs.user();

--- a/app/assets/javascripts/discourse/tests/acceptance/user-preferences-interface-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-preferences-interface-test.js
@@ -5,6 +5,7 @@ import selectKit from "discourse/tests/helpers/select-kit-helper";
 import Site from "discourse/models/site";
 import Session from "discourse/models/session";
 import cookie, { removeCookie } from "discourse/lib/cookie";
+import { click } from "@ember/test-helpers";
 
 acceptance("User Preferences - Interface", function (needs) {
   needs.user();

--- a/app/assets/javascripts/discourse/tests/acceptance/user-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-test.js
@@ -1,6 +1,7 @@
 import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+import { click } from "@ember/test-helpers";
 
 acceptance("User Routes", function (needs) {
   needs.user();

--- a/app/assets/javascripts/discourse/tests/helpers/select-kit-helper.js
+++ b/app/assets/javascripts/discourse/tests/helpers/select-kit-helper.js
@@ -1,5 +1,6 @@
 import { moduleForComponent } from "ember-qunit";
 import { isEmpty } from "@ember/utils";
+import { click, fillIn } from "@ember/test-helpers";
 
 function checkSelectKitIsNotExpanded(selector) {
   if (find(selector).hasClass("is-expanded")) {

--- a/app/assets/javascripts/discourse/tests/integration/components/admin-report-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/admin-report-test.js
@@ -1,6 +1,7 @@
 import { moduleForComponent } from "ember-qunit";
 import componentTest from "discourse/tests/helpers/component-test";
 import pretender from "discourse/tests/helpers/create-pretender";
+import { click } from "@ember/test-helpers";
 
 moduleForComponent("admin-report", {
   integration: true,

--- a/app/assets/javascripts/discourse/tests/integration/components/badge-title-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/badge-title-test.js
@@ -3,6 +3,7 @@ import selectKit from "discourse/tests/helpers/select-kit-helper";
 import componentTest from "discourse/tests/helpers/component-test";
 import EmberObject from "@ember/object";
 import pretender from "discourse/tests/helpers/create-pretender";
+import { click } from "@ember/test-helpers";
 
 moduleForComponent("badge-title", { integration: true });
 

--- a/app/assets/javascripts/discourse/tests/integration/components/d-editor-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/d-editor-test.js
@@ -9,6 +9,7 @@ import {
   setTextareaSelection,
   getTextareaSelection,
 } from "discourse/tests/helpers/textarea-selection-helper";
+import { fillIn, click } from "@ember/test-helpers";
 
 moduleForComponent("d-editor", { integration: true });
 

--- a/app/assets/javascripts/discourse/tests/integration/components/date-input-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/date-input-test.js
@@ -1,5 +1,6 @@
 import { moduleForComponent } from "ember-qunit";
 import componentTest from "discourse/tests/helpers/component-test";
+import { click } from "@ember/test-helpers";
 
 moduleForComponent("date-input", { integration: true });
 

--- a/app/assets/javascripts/discourse/tests/integration/components/date-time-input-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/date-time-input-test.js
@@ -1,5 +1,6 @@
 import { moduleForComponent } from "ember-qunit";
 import componentTest from "discourse/tests/helpers/component-test";
+import { click } from "@ember/test-helpers";
 
 moduleForComponent("date-time-input", { integration: true });
 

--- a/app/assets/javascripts/discourse/tests/integration/components/image-uploader-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/image-uploader-test.js
@@ -1,5 +1,7 @@
 import { moduleForComponent } from "ember-qunit";
 import componentTest from "discourse/tests/helpers/component-test";
+import { click } from "@ember/test-helpers";
+
 moduleForComponent("image-uploader", { integration: true });
 
 componentTest("with image", {

--- a/app/assets/javascripts/discourse/tests/integration/components/secret-value-list-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/secret-value-list-test.js
@@ -1,6 +1,8 @@
 import { moduleForComponent } from "ember-qunit";
 import I18n from "I18n";
 import componentTest from "discourse/tests/helpers/component-test";
+import { fillIn, click } from "@ember/test-helpers";
+
 moduleForComponent("secret-value-list", { integration: true });
 
 componentTest("adding a value", {

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/combo-box-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/combo-box-test.js
@@ -1,6 +1,7 @@
 import { moduleForComponent } from "ember-qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import componentTest from "discourse/tests/helpers/component-test";
+import { click } from "@ember/test-helpers";
 
 moduleForComponent("select-kit/combo-box", {
   integration: true,

--- a/app/assets/javascripts/discourse/tests/integration/components/simple-list-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/simple-list-test.js
@@ -1,5 +1,7 @@
 import { moduleForComponent } from "ember-qunit";
 import componentTest from "discourse/tests/helpers/component-test";
+import { click, fillIn } from "@ember/test-helpers";
+
 moduleForComponent("simple-list", { integration: true });
 
 componentTest("adding a value", {

--- a/app/assets/javascripts/discourse/tests/integration/components/text-field-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/text-field-test.js
@@ -2,6 +2,7 @@ import sinon from "sinon";
 import { moduleForComponent } from "ember-qunit";
 import I18n from "I18n";
 import componentTest from "discourse/tests/helpers/component-test";
+import { fillIn } from "@ember/test-helpers";
 
 moduleForComponent("text-field", { integration: true });
 

--- a/app/assets/javascripts/discourse/tests/integration/components/value-list-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/value-list-test.js
@@ -1,6 +1,8 @@
 import { moduleForComponent } from "ember-qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import componentTest from "discourse/tests/helpers/component-test";
+import { click } from "@ember/test-helpers";
+
 moduleForComponent("value-list", { integration: true });
 
 componentTest("adding a value", {

--- a/app/assets/javascripts/discourse/tests/integration/widgets/header-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/header-test.js
@@ -2,6 +2,7 @@ import {
   moduleForWidget,
   widgetTest,
 } from "discourse/tests/helpers/widget-test";
+import { click } from "@ember/test-helpers";
 
 moduleForWidget("header");
 

--- a/app/assets/javascripts/discourse/tests/integration/widgets/post-links-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/post-links-test.js
@@ -2,6 +2,7 @@ import {
   moduleForWidget,
   widgetTest,
 } from "discourse/tests/helpers/widget-test";
+import { click } from "@ember/test-helpers";
 
 moduleForWidget("post-links");
 

--- a/app/assets/javascripts/discourse/tests/integration/widgets/post-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/post-test.js
@@ -4,6 +4,7 @@ import {
   moduleForWidget,
   widgetTest,
 } from "discourse/tests/helpers/widget-test";
+import { click } from "@ember/test-helpers";
 
 moduleForWidget("post");
 

--- a/app/assets/javascripts/discourse/tests/integration/widgets/user-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/user-menu-test.js
@@ -5,6 +5,7 @@ import {
   moduleForWidget,
   widgetTest,
 } from "discourse/tests/helpers/widget-test";
+import { click } from "@ember/test-helpers";
 
 moduleForWidget("user-menu");
 

--- a/app/assets/javascripts/discourse/tests/integration/widgets/widget-dropdown-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/widget-dropdown-test.js
@@ -3,6 +3,7 @@ import {
   moduleForWidget,
   widgetTest,
 } from "discourse/tests/helpers/widget-test";
+import { click } from "@ember/test-helpers";
 
 moduleForWidget("widget-dropdown");
 

--- a/app/assets/javascripts/discourse/tests/integration/widgets/widget-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/widget-test.js
@@ -8,6 +8,7 @@ import { createWidget } from "discourse/widgets/widget";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import { Promise } from "rsvp";
 import hbs from "discourse/widgets/hbs-compiler";
+import { click } from "@ember/test-helpers";
 
 moduleForWidget("base");
 

--- a/app/assets/javascripts/test-shims.js
+++ b/app/assets/javascripts/test-shims.js
@@ -19,21 +19,20 @@ define("ember-qunit", () => {
 });
 let _app;
 define("@ember/test-helpers", () => {
-  return {
-    setResolver: window.setResolver,
+  let helpers = {
     setApplication(app) {
       _app = app;
     },
     getApplication() {
       return _app;
     },
-    visit() {
-      return window.visit(...arguments);
-    },
-    currentURL() {
-      return window.currentURL(...arguments);
-    },
   };
+  ["click", "visit", "currentURL", "fillIn", "setResolver"].forEach((attr) => {
+    helpers[attr] = function () {
+      return window[attr](...arguments);
+    };
+  });
+  return helpers;
 });
 define("pretender", () => {
   return { default: window.Pretender };


### PR DESCRIPTION
Previously they were global functions.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
