### PR TITLE
PERF: apply sprockets patch in a test environment

### DIFF
--- a/lib/freedom_patches/sprockets_patches.rb
+++ b/lib/freedom_patches/sprockets_patches.rb
@@ -8,7 +8,7 @@
 # 2. Stop using a concatenator that does tons of work checking for semicolons when
 #     when rebuilding an asset
 
-if Rails.env == "development"
+if Rails.env.development? || Rails.env.test?
   module ActionView::Helpers::AssetUrlHelper
 
     def asset_path(source, options = {})


### PR DESCRIPTION
When plugin spec is evaluated for the first time, it took 30 seconds to run:
```
rm -rf tmp/* && LOAD_PLUGINS=1 be rspec ./plugins/discourse-solved/spec/requests/topics_controller_spec.rb
```

Applying sprocket patch in test environment solves that issue
