### PR TITLE
FEATURE: disable default bing throttle

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1547,7 +1547,7 @@ security:
     list_type: compact
   slow_down_crawler_user_agents:
     type: list
-    default: "bingbot"
+    default: ""
     list_type: compact
   slow_down_crawler_rate: 60
   content_security_policy:


### PR DESCRIPTION
See: https://meta.discourse.org/t/bingbot-is-default-throttled/84620

It appears bing is behaving in a more reasonable way, disabling the default
throttle.
