### PR TITLE
FIX: adjust user card position, follow-up to da5841d

### DIFF
--- a/app/assets/javascripts/discourse/app/mixins/card-contents-base.js
+++ b/app/assets/javascripts/discourse/app/mixins/card-contents-base.js
@@ -211,7 +211,6 @@ export default Mixin.create({
               }
             }
 
-            position.top -= $("#main-outlet").offset().top;
             if (isFixed) {
               position.top -= $("html").scrollTop();
               //if content is fixed and will be cut off on the bottom, display it above...


### PR DESCRIPTION
Due to the header changes (fixed => sticky) we no longer need to worry about the main-outlet offset here. 

Before: 
  
<img width="706" alt="Screen Shot 2020-10-26 at 8 49 53 PM" src="https://user-images.githubusercontent.com/1681963/97243518-de94e800-17cc-11eb-9a9f-d4d01420a5d9.png">



After:

<img width="735" alt="Screen Shot 2020-10-26 at 8 50 08 PM" src="https://user-images.githubusercontent.com/1681963/97243533-e48ac900-17cc-11eb-8224-b355205a4dd3.png">
