### PR TITLE
FIX: Capybara diet upgrade, can eat real 🌿 now

### DIFF
--- a/plugins/discourse-narrative-bot/lib/discourse_narrative_bot/new_user_narrative.rb
+++ b/plugins/discourse-narrative-bot/lib/discourse_narrative_bot/new_user_narrative.rb
@@ -141,6 +141,10 @@ module DiscourseNarrativeBot
       ':herb:'
     end
 
+    def self.search_answer_emoji
+      "\u{1F33F}"
+    end
+
     def self.reset_trigger
       I18n.t('discourse_narrative_bot.new_user_narrative.reset_trigger')
     end
@@ -567,7 +571,7 @@ module DiscourseNarrativeBot
       post_topic_id = @post.topic_id
       return unless valid_topic?(post_topic_id)
 
-      if @post.raw.match(/#{NewUserNarrative.search_answer}/)
+      if @post.raw.include?(NewUserNarrative.search_answer) || @post.raw.include?(NewUserNarrative.search_answer_emoji)
         fake_delay
         reply_to(@post, I18n.t("#{I18N_KEY}.search.reply", i18n_post_args(search_url: url_helpers(:search_url))))
       else

--- a/plugins/discourse-narrative-bot/spec/discourse_narrative_bot/new_user_narrative_spec.rb
+++ b/plugins/discourse-narrative-bot/spec/discourse_narrative_bot/new_user_narrative_spec.rb
@@ -1128,6 +1128,23 @@ describe DiscourseNarrativeBot::NewUserNarrative do
             name: DiscourseNarrativeBot::NewUserNarrative.badge_name).exists?
           ).to eq(true)
         end
+
+        it 'should accept a raw emoji' do
+          post.update!(
+            raw: "#{described_class.search_answer_emoji} this is the emoji you mentioned"
+          )
+
+          expect do
+            DiscourseNarrativeBot::TrackSelector.new(:reply, user, post_id: post.id).select
+          end.to change { Post.count }.by(2)
+
+          new_post = topic.ordered_posts.last(2).first
+
+          expect(new_post.raw).to eq(I18n.t(
+            'discourse_narrative_bot.new_user_narrative.search.reply',
+            search_url: "#{Discourse.base_url}/search", base_uri: ''
+          ).chomp)
+        end
       end
     end
   end


### PR DESCRIPTION
More seriously: discobot wasn't reacting properly if users used their
emoji keyboard to insert a real herb emoji, which works just as well
in a real post.

While we're here, use String#include? instead of constructing a new regexp.

https://meta.discourse.org/t/capybaras-dont-eat-real-emojis/168361

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
