### PR TITLE
DEV: Better custom field preload error

### DIFF
--- a/app/models/concerns/has_custom_fields.rb
+++ b/app/models/concerns/has_custom_fields.rb
@@ -165,7 +165,7 @@ module HasCustomFields
         @preloaded[key]
       else
         # for now you can not mix preload an non preload, it better just to fail
-        raise StandardError, "Attempting to access a non preloaded custom field, this is disallowed to prevent N+1 queries."
+        raise StandardError, "Attempting to access the non preloaded custom field '#{key}'. this is disallowed to prevent N+1 queries."
       end
     end
   end

--- a/app/models/concerns/has_custom_fields.rb
+++ b/app/models/concerns/has_custom_fields.rb
@@ -165,7 +165,7 @@ module HasCustomFields
         @preloaded[key]
       else
         # for now you can not mix preload an non preload, it better just to fail
-        raise StandardError, "Attempting to access the non preloaded custom field '#{key}'. this is disallowed to prevent N+1 queries."
+        raise StandardError, "Attempted to access the non preloaded custom field '#{key}'. This is disallowed to prevent N+1 queries."
       end
     end
   end


### PR DESCRIPTION
This error does not show what field was accessed, and the backtrace isn't very helpful

<img width="686" alt="Screenshot 2020-10-27 094212" src="https://user-images.githubusercontent.com/16214023/97318753-30c02280-183a-11eb-8d36-ec4cd4d5bae3.png">

This message is much better.

<img width="772" alt="Screenshot 2020-10-27 095938" src="https://user-images.githubusercontent.com/16214023/97319753-26eaef00-183b-11eb-9cc4-8aa5583030ad.png">

