### PR TITLE
FIX: Hide delete button if user cannot delete and/or flag a post

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/transform-post.js
+++ b/app/assets/javascripts/discourse/app/lib/transform-post.js
@@ -258,6 +258,7 @@ export default function transformPost(
     postAtts.showFlagDelete =
       !postAtts.canDelete &&
       postAtts.yours &&
+      postAtts.canFlag &&
       currentUser &&
       !currentUser.staff;
   } else {

--- a/app/assets/javascripts/discourse/app/widgets/post-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-menu.js
@@ -377,7 +377,7 @@ registerButton("delete", (attrs) => {
       icon: "far-trash-alt",
       className: "delete",
     };
-  } else if (attrs.showFlagDelete && attrs.canFlag) {
+  } else if (attrs.showFlagDelete) {
     return {
       id: "delete_topic",
       action: "showDeleteTopicModal",

--- a/app/assets/javascripts/discourse/app/widgets/post-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-menu.js
@@ -377,7 +377,7 @@ registerButton("delete", (attrs) => {
       icon: "far-trash-alt",
       className: "delete",
     };
-  } else if (attrs.showFlagDelete) {
+  } else if (attrs.showFlagDelete && attrs.canFlag) {
     return {
       id: "delete_topic",
       action: "showDeleteTopicModal",

--- a/app/assets/javascripts/discourse/tests/integration/widgets/post-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/post-test.js
@@ -308,10 +308,14 @@ widgetTest(
       this.set("args", {
         canDeleteTopic: false,
         showFlagDelete: true,
+        canFlag: true,
       });
     },
 
-    test(assert) {
+    async test(assert) {
+      await click(".show-more-actions");
+
+      assert.equal(find("button.create-flag").length, 1, `button is displayed`);
       assert.equal(find("button.delete").length, 1, `button is displayed`);
       assert.equal(
         find("button.delete").attr("title"),
@@ -349,10 +353,11 @@ widgetTest("delete post button", {
   template:
     '{{mount-widget widget="post" args=args deletePost=(action "deletePost")}}',
   beforeEach() {
-    this.set("args", { canDelete: true });
+    this.set("args", { canDelete: true, canFlag: true });
     this.on("deletePost", () => (this.deletePostCalled = true));
   },
   async test(assert) {
+    await click(".show-more-actions");
     await click("button.delete");
     assert.ok(this.deletePostCalled, "it triggered the delete action");
   },
@@ -365,6 +370,29 @@ widgetTest(`delete post button - can't delete`, {
   },
   test(assert) {
     assert.equal(find("button.delete").length, 0, `button is not displayed`);
+  },
+});
+
+widgetTest(`delete post button - can't delete, can't flag`, {
+  template: '{{mount-widget widget="post" args=args}}',
+  beforeEach() {
+    this.set("args", {
+      canDeleteTopic: false,
+      showFlagDelete: false,
+      canFlag: false,
+    });
+  },
+  test(assert) {
+    assert.equal(
+      find("button.delete").length,
+      0,
+      `delete button is not displayed`
+    );
+    assert.equal(
+      find("button.create-flag").length,
+      0,
+      `flag button is not displayed`
+    );
   },
 });
 


### PR DESCRIPTION
If a user has a trust level lower than the SiteSetting `min_trust_to_flag_posts`, they may not be able to flag posts. If so, don't show them the prompt suggesting they flag a post.