### PR TITLE
FIX - don't hide tags if user has correct permissions

### DIFF
--- a/lib/discourse_tagging.rb
+++ b/lib/discourse_tagging.rb
@@ -32,7 +32,7 @@ module DiscourseTagging
 
       # tag names which are visible, but not usable, by *some users*
       readonly_tags = DiscourseTagging.readonly_tag_names(guardian)
-      # tags names which are not visibile or usuable by *some users*
+      # tags names which are not visibile or usuable by this user
       hidden_tags = DiscourseTagging.hidden_tag_names(guardian)
 
       # tag names which ARE permitted by *this user*
@@ -43,7 +43,6 @@ module DiscourseTagging
       # restricted tags
       if permitted_tags.present?
         readonly_tags = readonly_tags - permitted_tags
-        hidden_tags = hidden_tags - permitted_tags
       end
 
       # visible, but not usable, tags this user is trying to use
@@ -373,7 +372,7 @@ module DiscourseTagging
   end
 
   def self.hidden_tag_names(guardian = nil)
-    guardian&.is_staff? ? [] : hidden_tags_query.pluck(:name)
+    guardian&.is_staff? ? [] : hidden_tags_query.pluck(:name) - permitted_tag_names(guardian)
   end
 
   # most restrictive level of tag groups
@@ -392,7 +391,7 @@ module DiscourseTagging
   def self.permitted_group_ids(guardian = nil)
     group_ids = [Group::AUTO_GROUPS[:everyone]]
 
-    if guardian.authenticated?
+    if guardian&.authenticated?
       group_ids.concat(guardian.user.groups.pluck(:id))
     end
 

--- a/spec/components/discourse_tagging_spec.rb
+++ b/spec/components/discourse_tagging_spec.rb
@@ -115,6 +115,17 @@ describe DiscourseTagging do
           tags = DiscourseTagging.filter_allowed_tags(Guardian.new(user3)).to_a
           expect(sorted_tag_names(tags)).to eq(sorted_tag_names([tag1, tag2, tag3]))
         end
+
+        it 'should not hide group tags to member of group' do
+          tags = DiscourseTagging.hidden_tag_names(Guardian.new(user)).to_a
+          expect(sorted_tag_names(tags)).to eq([])
+        end
+
+        it 'should hide group tags to non-member of group' do
+          other_user = Fabricate(:user)
+          tags = DiscourseTagging.hidden_tag_names(Guardian.new(other_user)).to_a
+          expect(sorted_tag_names(tags)).to eq([hidden_tag.name])
+        end
       end
 
       context 'with required tags from tag group' do


### PR DESCRIPTION
`hidden_tag_names` should return the definitive list of hidden tag names for the current guardian/user, and not rely on post-processing of that list (i.e., how things used to work, before more granular control of tag group permissions was added in).