### PR TITLE
DEV: Don't leak pretender handlers between tests

### DIFF
--- a/app/assets/javascripts/discourse/tests/helpers/create-pretender.js
+++ b/app/assets/javascripts/discourse/tests/helpers/create-pretender.js
@@ -1,5 +1,4 @@
 import User from "discourse/models/user";
-import Pretender from "pretender";
 
 export function parsePostData(query) {
   const result = {};
@@ -38,8 +37,6 @@ const loggedIn = () => !!User.current();
 const helpers = { response, success, parsePostData };
 
 export let fixturesByUrl;
-
-export default new Pretender();
 
 export function pretenderHelpers() {
   return { parsePostData, response, success };

--- a/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
+++ b/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
@@ -38,6 +38,7 @@ import QUnit, { module } from "qunit";
 import siteFixtures from "discourse/tests/fixtures/site-fixtures";
 import Site from "discourse/models/site";
 import createStore from "discourse/tests/helpers/create-store";
+import { pretenderHelpers } from "discourse/tests/helpers/create-pretender";
 import { getApplication } from "@ember/test-helpers";
 import deprecated from "discourse-common/lib/deprecated";
 import sinon from "sinon";
@@ -107,10 +108,12 @@ export function resetSite(siteSettings, extras) {
   return Site.resetCurrent(Site.create(siteAttrs));
 }
 
-export function applyPretender(name, server, helper) {
+const helpers = pretenderHelpers();
+
+export function applyPretender(name, server) {
   const cb = _pretenderCallbacks[name];
   if (cb) {
-    cb(server, helper);
+    cb(server, helpers);
   }
 }
 

--- a/app/assets/javascripts/discourse/tests/integration/components/admin-report-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/admin-report-test.js
@@ -1,6 +1,6 @@
 import { moduleForComponent } from "ember-qunit";
 import componentTest from "discourse/tests/helpers/component-test";
-import pretender from "discourse/tests/helpers/create-pretender";
+import { response } from "discourse/tests/helpers/create-pretender";
 import { click } from "@ember/test-helpers";
 
 moduleForComponent("admin-report", {
@@ -129,23 +129,19 @@ componentTest("exception", {
 });
 
 componentTest("rate limited", {
+  template: "{{admin-report dataSourceName='signups_rate_limited'}}",
+
   beforeEach() {
-    pretender.get("/admin/reports/bulk", () => {
-      return [
-        429,
-        { "Content-Type": "application/json" },
-        {
-          errors: [
-            "You’ve performed this action too many times. Please wait 10 seconds before trying again.",
-          ],
-          error_type: "rate_limit",
-          extras: { wait_seconds: 10 },
-        },
-      ];
+    window.server.get("/admin/reports/bulk", () => {
+      return response(429, {
+        errors: [
+          "You’ve performed this action too many times. Please wait 10 seconds before trying again.",
+        ],
+        error_type: "rate_limit",
+        extras: { wait_seconds: 10 },
+      });
     });
   },
-
-  template: "{{admin-report dataSourceName='signups_rate_limited'}}",
 
   test(assert) {
     assert.ok(

--- a/app/assets/javascripts/discourse/tests/integration/components/badge-title-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/badge-title-test.js
@@ -2,10 +2,14 @@ import { moduleForComponent } from "ember-qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import componentTest from "discourse/tests/helpers/component-test";
 import EmberObject from "@ember/object";
-import pretender from "discourse/tests/helpers/create-pretender";
+import { addPretenderCallback } from "discourse/tests/helpers/qunit-helpers";
 import { click } from "@ember/test-helpers";
 
 moduleForComponent("badge-title", { integration: true });
+
+addPretenderCallback("badge-title", (server, helper) => {
+  server.put("/u/eviltrout/preferences/badge_title", () => helper.response({}));
+});
 
 componentTest("badge title", {
   template:
@@ -27,11 +31,6 @@ componentTest("badge title", {
   },
 
   async test(assert) {
-    pretender.put("/u/eviltrout/preferences/badge_title", () => [
-      200,
-      { "Content-Type": "application/json" },
-      {},
-    ]);
     await this.subject.expand();
     await this.subject.selectRowByValue(42);
     await click(".btn");

--- a/app/assets/javascripts/discourse/tests/integration/components/cook-text-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/cook-text-test.js
@@ -1,6 +1,6 @@
 import { moduleForComponent } from "ember-qunit";
 import componentTest from "discourse/tests/helpers/component-test";
-import pretender from "discourse/tests/helpers/create-pretender";
+import { addPretenderCallback } from "discourse/tests/helpers/qunit-helpers";
 import { resetCache } from "pretty-text/upload-short-url";
 
 moduleForComponent("cook-text", { integration: true });
@@ -14,24 +14,20 @@ componentTest("renders markdown", {
   },
 });
 
+addPretenderCallback("cook-text", (server, helper) => {
+  server.post("/uploads/lookup-urls", () =>
+    helper.response([
+      {
+        short_url: "upload://a.png",
+        url: "/images/avatar.png",
+        short_path: "/images/d-logo-sketch.png",
+      },
+    ])
+  );
+});
+
 componentTest("resolves short URLs", {
   template: `{{cook-text "![an image](upload://a.png)" class="post-body"}}`,
-
-  beforeEach() {
-    pretender.post("/uploads/lookup-urls", () => {
-      return [
-        200,
-        { "Content-Type": "application/json" },
-        [
-          {
-            short_url: "upload://a.png",
-            url: "/images/avatar.png",
-            short_path: "/images/d-logo-sketch.png",
-          },
-        ],
-      ];
-    });
-  },
 
   afterEach() {
     resetCache();

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/tag-drop-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/tag-drop-test.js
@@ -3,28 +3,12 @@ import componentTest from "discourse/tests/helpers/component-test";
 import { testSelectKitModule } from "discourse/tests/helpers/select-kit-helper";
 import Site from "discourse/models/site";
 import { set } from "@ember/object";
-import pretender from "discourse/tests/helpers/create-pretender";
+import { addPretenderCallback } from "discourse/tests/helpers/qunit-helpers";
 
 testSelectKitModule("tag-drop", {
   beforeEach() {
     const site = Site.current();
     set(site, "top_tags", ["jeff", "neil", "arpit", "régis"]);
-
-    const response = (object) => {
-      return [200, { "Content-Type": "application/json" }, object];
-    };
-
-    pretender.get("/tags/filter/search", (params) => {
-      if (params.queryParams.q === "rég") {
-        return response({
-          results: [{ id: "régis", text: "régis", count: 2, pm_count: 0 }],
-        });
-      } else if (params.queryParams.q === "dav") {
-        return response({
-          results: [{ id: "David", text: "David", count: 2, pm_count: 0 }],
-        });
-      }
-    });
   },
 });
 
@@ -55,6 +39,20 @@ function template(options = []) {
     }}
   `;
 }
+
+addPretenderCallback("select-kit/tag-drop", (server, helper) => {
+  server.get("/tags/filter/search", (params) => {
+    if (params.queryParams.q === "rég") {
+      return helper.response({
+        results: [{ id: "régis", text: "régis", count: 2, pm_count: 0 }],
+      });
+    } else if (params.queryParams.q === "dav") {
+      return helper.response({
+        results: [{ id: "David", text: "David", count: 2, pm_count: 0 }],
+      });
+    }
+  });
+});
 
 componentTest("default", {
   template: template(["tagId=tagId"]),

--- a/app/assets/javascripts/discourse/tests/integration/widgets/default-notification-item-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/default-notification-item-test.js
@@ -1,5 +1,4 @@
 import EmberObject from "@ember/object";
-import { addPretenderCallback } from "discourse/tests/helpers/qunit-helpers";
 import {
   moduleForWidget,
   widgetTest,

--- a/app/assets/javascripts/discourse/tests/integration/widgets/default-notification-item-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/default-notification-item-test.js
@@ -1,5 +1,5 @@
 import EmberObject from "@ember/object";
-import pretender from "discourse/tests/helpers/create-pretender";
+import { addPretenderCallback } from "discourse/tests/helpers/qunit-helpers";
 import {
   moduleForWidget,
   widgetTest,
@@ -35,7 +35,7 @@ widgetTest("sets notification as read on middle click", {
   },
   async test(assert) {
     let requests = 0;
-    pretender.put("/notifications/mark-read", (request) => {
+    window.server.put("/notifications/mark-read", (request) => {
       ++requests;
 
       assert.equal(

--- a/app/assets/javascripts/discourse/tests/setup-tests.js
+++ b/app/assets/javascripts/discourse/tests/setup-tests.js
@@ -6,10 +6,7 @@ import { getOwner, setDefaultOwner } from "discourse-common/lib/get-owner";
 import { setupURL, setupS3CDN } from "discourse-common/lib/get-url";
 import { createHelperContext } from "discourse-common/lib/helpers";
 import { buildResolver } from "discourse-common/resolver";
-import createPretender, {
-  pretenderHelpers,
-  applyDefaultHandlers,
-} from "discourse/tests/helpers/create-pretender";
+import { applyDefaultHandlers } from "discourse/tests/helpers/create-pretender";
 import { flushMap } from "discourse/models/store";
 import { ScrollingDOMMethods } from "discourse/mixins/scrolling";
 import DiscourseURL from "discourse/lib/url";
@@ -26,6 +23,7 @@ import MessageBus from "message-bus-client";
 import deprecated from "discourse-common/lib/deprecated";
 import sinon from "sinon";
 import { setApplication, setResolver } from "@ember/test-helpers";
+import Pretender from "pretender";
 
 export default function setupTests(app, container) {
   setResolver(buildResolver("discourse").create({ namespace: app }));
@@ -82,8 +80,8 @@ export default function setupTests(app, container) {
 
   QUnit.testStart(function (ctx) {
     let settings = resetSettings();
-    server = createPretender;
-    server.handlers = [];
+
+    server = new Pretender();
     applyDefaultHandlers(server);
 
     server.prepareBody = function (body) {
@@ -116,7 +114,7 @@ export default function setupTests(app, container) {
     server.checkPassthrough = (request) =>
       request.requestHeaders["Discourse-Script"];
 
-    applyPretender(ctx.module, server, pretenderHelpers());
+    applyPretender(ctx.module, server);
 
     setupURL(null, "http://localhost:3000", "");
     setupS3CDN(null, null);
@@ -158,6 +156,7 @@ export default function setupTests(app, container) {
     clearAppEventsCache(getOwner(this));
 
     MessageBus.unsubscribe("*");
+    server.shutdown();
     server = null;
     window.Mousetrap.reset();
   });

--- a/app/assets/javascripts/discourse/tests/unit/controllers/topic-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/controllers/topic-test.js
@@ -6,7 +6,7 @@ import Topic from "discourse/models/topic";
 import { Placeholder } from "discourse/lib/posts-with-placeholders";
 import User from "discourse/models/user";
 import { Promise } from "rsvp";
-import pretender from "discourse/tests/helpers/create-pretender";
+import { addPretenderCallback } from "discourse/tests/helpers/qunit-helpers";
 
 moduleFor("controller:topic", "controller:topic", {
   needs: [
@@ -511,11 +511,11 @@ test("topVisibleChanged", function (assert) {
   );
 });
 
-test("deletePost - no modal is shown if post does not have replies", function (assert) {
-  pretender.get("/posts/2/reply-ids.json", () => {
-    return [200, { "Content-Type": "application/json" }, []];
-  });
+addPretenderCallback("controller:topic", (server, helper) => {
+  server.get("/posts/2/reply-ids.json", () => helper.response([]));
+});
 
+test("deletePost - no modal is shown if post does not have replies", function (assert) {
   let destroyed;
   const post = EmberObject.create({
     id: 2,

--- a/app/assets/javascripts/discourse/tests/unit/lib/click-track-edit-history-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/click-track-edit-history-test.js
@@ -4,7 +4,6 @@ import DiscourseURL from "discourse/lib/url";
 import ClickTrack from "discourse/lib/click-track";
 import { fixture, logIn } from "discourse/tests/helpers/qunit-helpers";
 import User from "discourse/models/user";
-import pretender from "discourse/tests/helpers/create-pretender";
 
 module("lib:click-track-edit-history", {
   beforeEach() {
@@ -65,7 +64,7 @@ skip("tracks internal URLs", async (assert) => {
   sinon.stub(DiscourseURL, "origin").returns("http://discuss.domain.com");
 
   const done = assert.async();
-  pretender.post("/clicks/track", (request) => {
+  window.server.post("/clicks/track", (request) => {
     assert.equal(
       request.requestBody,
       "url=http%3A%2F%2Fdiscuss.domain.com&post_id=42&topic_id=1337"
@@ -80,7 +79,7 @@ skip("tracks external URLs", async (assert) => {
   assert.expect(2);
 
   const done = assert.async();
-  pretender.post("/clicks/track", (request) => {
+  window.server.post("/clicks/track", (request) => {
     assert.equal(
       request.requestBody,
       "url=http%3A%2F%2Fwww.google.com&post_id=42&topic_id=1337"
@@ -96,7 +95,7 @@ skip("tracks external URLs when opening in another window", async (assert) => {
   User.currentProp("external_links_in_new_tab", true);
 
   const done = assert.async();
-  pretender.post("/clicks/track", (request) => {
+  window.server.post("/clicks/track", (request) => {
     assert.equal(
       request.requestBody,
       "url=http%3A%2F%2Fwww.google.com&post_id=42&topic_id=1337"

--- a/app/assets/javascripts/discourse/tests/unit/lib/click-track-profile-page-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/click-track-profile-page-test.js
@@ -3,7 +3,6 @@ import { module, skip } from "qunit";
 import DiscourseURL from "discourse/lib/url";
 import ClickTrack from "discourse/lib/click-track";
 import { fixture, logIn } from "discourse/tests/helpers/qunit-helpers";
-import pretender from "discourse/tests/helpers/create-pretender";
 
 module("lib:click-track-profile-page", {
   beforeEach() {
@@ -58,7 +57,7 @@ skip("tracks internal URLs", async (assert) => {
   sinon.stub(DiscourseURL, "origin").returns("http://discuss.domain.com");
 
   const done = assert.async();
-  pretender.post("/clicks/track", (request) => {
+  window.server.post("/clicks/track", (request) => {
     assert.equal(request.requestBody, "url=http%3A%2F%2Fdiscuss.domain.com");
     done();
   });
@@ -70,7 +69,7 @@ skip("tracks external URLs", async (assert) => {
   assert.expect(2);
 
   const done = assert.async();
-  pretender.post("/clicks/track", (request) => {
+  window.server.post("/clicks/track", (request) => {
     assert.equal(
       request.requestBody,
       "url=http%3A%2F%2Fwww.google.com&post_id=42&topic_id=1337"
@@ -85,7 +84,7 @@ skip("tracks external URLs in other posts", async (assert) => {
   assert.expect(2);
 
   const done = assert.async();
-  pretender.post("/clicks/track", (request) => {
+  window.server.post("/clicks/track", (request) => {
     assert.equal(
       request.requestBody,
       "url=http%3A%2F%2Fwww.google.com&post_id=24&topic_id=7331"

--- a/app/assets/javascripts/discourse/tests/unit/lib/click-track-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/click-track-test.js
@@ -6,7 +6,6 @@ import DiscourseURL from "discourse/lib/url";
 import ClickTrack from "discourse/lib/click-track";
 import { fixture, logIn } from "discourse/tests/helpers/qunit-helpers";
 import User from "discourse/models/user";
-import pretender from "discourse/tests/helpers/create-pretender";
 
 module("lib:click-track", {
   beforeEach() {
@@ -59,7 +58,7 @@ skip("tracks internal URLs", async (assert) => {
   sinon.stub(DiscourseURL, "origin").returns("http://discuss.domain.com");
 
   const done = assert.async();
-  pretender.post("/clicks/track", (request) => {
+  window.server.post("/clicks/track", (request) => {
     assert.ok(
       request.requestBody,
       "url=http%3A%2F%2Fdiscuss.domain.com&post_id=42&topic_id=1337"
@@ -77,7 +76,7 @@ test("does not track elements with no href", async (assert) => {
 test("does not track attachments", async (assert) => {
   sinon.stub(DiscourseURL, "origin").returns("http://discuss.domain.com");
 
-  pretender.post("/clicks/track", () => assert.ok(false));
+  window.server.post("/clicks/track", () => assert.ok(false));
 
   assert.notOk(track(generateClickEventOn(".attachment")));
   assert.ok(
@@ -91,7 +90,7 @@ skip("tracks external URLs", async (assert) => {
   assert.expect(2);
 
   const done = assert.async();
-  pretender.post("/clicks/track", (request) => {
+  window.server.post("/clicks/track", (request) => {
     assert.ok(
       request.requestBody,
       "url=http%3A%2F%2Fwww.google.com&post_id=42&topic_id=1337"
@@ -107,7 +106,7 @@ skip("tracks external URLs when opening in another window", async (assert) => {
   User.currentProp("external_links_in_new_tab", true);
 
   const done = assert.async();
-  pretender.post("/clicks/track", (request) => {
+  window.server.post("/clicks/track", (request) => {
     assert.ok(
       request.requestBody,
       "url=http%3A%2F%2Fwww.google.com&post_id=42&topic_id=1337"

--- a/app/assets/javascripts/discourse/tests/unit/lib/link-mentions-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/link-mentions-test.js
@@ -4,15 +4,13 @@ import {
   linkSeenMentions,
 } from "discourse/lib/link-mentions";
 import { Promise } from "rsvp";
-import pretender from "discourse/tests/helpers/create-pretender";
+import { addPretenderCallback } from "discourse/tests/helpers/qunit-helpers";
 
 module("lib:link-mentions");
 
-test("linkSeenMentions replaces users and groups", async (assert) => {
-  pretender.get("/u/is_local_username", () => [
-    200,
-    { "Content-Type": "application/json" },
-    {
+addPretenderCallback("lib:link-mentions", (server, helper) => {
+  server.get("/u/is_local_username", () =>
+    helper.response({
       valid: ["valid_user"],
       valid_groups: ["valid_group"],
       mentionable_groups: [
@@ -23,9 +21,11 @@ test("linkSeenMentions replaces users and groups", async (assert) => {
       ],
       cannot_see: [],
       max_users_notified_per_group_mention: 100,
-    },
-  ]);
+    })
+  );
+});
 
+test("linkSeenMentions replaces users and groups", async (assert) => {
   await fetchUnseenMentions([
     "valid_user",
     "mentionable_group",

--- a/app/assets/javascripts/discourse/tests/unit/lib/upload-short-url-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/upload-short-url-test.js
@@ -6,7 +6,6 @@ import {
 } from "pretty-text/upload-short-url";
 import { ajax } from "discourse/lib/ajax";
 import { fixture } from "discourse/tests/helpers/qunit-helpers";
-import pretender from "discourse/tests/helpers/create-pretender";
 
 function stubUrls(imageSrcs, attachmentSrcs, otherMediaSrcs) {
   const response = (object) => {
@@ -61,8 +60,8 @@ function stubUrls(imageSrcs, attachmentSrcs, otherMediaSrcs) {
       },
     ];
   }
-  // prettier-ignore
-  pretender.post("/uploads/lookup-urls", () => {
+
+  window.server.post("/uploads/lookup-urls", () => {
     return response(imageSrcs.concat(attachmentSrcs.concat(otherMediaSrcs)));
   });
 

--- a/app/assets/javascripts/discourse/tests/unit/lib/user-search-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/user-search-test.js
@@ -1,89 +1,85 @@
 import { test, module } from "qunit";
 import userSearch from "discourse/lib/user-search";
 import { CANCELLED_STATUS } from "discourse/lib/autocomplete";
-import pretender from "discourse/tests/helpers/create-pretender";
+import { addPretenderCallback } from "discourse/tests/helpers/qunit-helpers";
 
-module("lib:user-search", {
-  beforeEach() {
-    const response = (object) => {
-      return [200, { "Content-Type": "application/json" }, object];
-    };
+module("lib:user-search");
 
-    pretender.get("/u/search/users", (request) => {
-      // special responder for per category search
-      const categoryMatch = request.url.match(/category_id=([0-9]+)/);
-      if (categoryMatch) {
-        if (categoryMatch[1] === "3") {
-          return response({});
-        }
-        return response({
-          users: [
-            {
-              username: `category_${categoryMatch[1]}`,
-              name: "category user",
-              avatar_template:
-                "https://avatars.discourse.org/v3/letter/t/41988e/{size}.png",
-            },
-          ],
-        });
+addPretenderCallback("lib:user-search", (server, helper) => {
+  server.get("/u/search/users", (request) => {
+    // special responder for per category search
+    const categoryMatch = request.url.match(/category_id=([0-9]+)/);
+    if (categoryMatch) {
+      if (categoryMatch[1] === "3") {
+        return helper.response({});
       }
-
-      if (request.url.match(/no-results/)) {
-        return response({ users: [] });
-      }
-
-      return response({
+      return helper.response({
         users: [
           {
-            username: "TeaMoe",
-            name: "TeaMoe",
+            username: `category_${categoryMatch[1]}`,
+            name: "category user",
             avatar_template:
               "https://avatars.discourse.org/v3/letter/t/41988e/{size}.png",
           },
-          {
-            username: "TeamOneJ",
-            name: "J Cobb",
-            avatar_template:
-              "https://avatars.discourse.org/v3/letter/t/3d9bf3/{size}.png",
-          },
-          {
-            username: "kudos",
-            name: "Team Blogeto.com",
-            avatar_template:
-              "/user_avatar/meta.discourse.org/kudos/{size}/62185_1.png",
-          },
-          {
-            username: "RosieLinda",
-            name: "Linda Teaman",
-            avatar_template:
-              "https://avatars.discourse.org/v3/letter/r/bc8723/{size}.png",
-          },
-          {
-            username: "legalatom",
-            name: "Team LegalAtom",
-            avatar_template:
-              "https://avatars.discourse.org/v3/letter/l/a9a28c/{size}.png",
-          },
-          {
-            username: "dzsat_team",
-            name: "Dz Sat Dz Sat",
-            avatar_template:
-              "https://avatars.discourse.org/v3/letter/d/eb9ed0/{size}.png",
-          },
-        ],
-        groups: [
-          {
-            name: "bob",
-            usernames: [],
-          },
-          {
-            name: "team",
-            usernames: [],
-          },
         ],
       });
+    }
+
+    if (request.url.match(/no-results/)) {
+      return helper.response({ users: [] });
+    }
+
+    return helper.response({
+      users: [
+        {
+          username: "TeaMoe",
+          name: "TeaMoe",
+          avatar_template:
+            "https://avatars.discourse.org/v3/letter/t/41988e/{size}.png",
+        },
+        {
+          username: "TeamOneJ",
+          name: "J Cobb",
+          avatar_template:
+            "https://avatars.discourse.org/v3/letter/t/3d9bf3/{size}.png",
+        },
+        {
+          username: "kudos",
+          name: "Team Blogeto.com",
+          avatar_template:
+            "/user_avatar/meta.discourse.org/kudos/{size}/62185_1.png",
+        },
+        {
+          username: "RosieLinda",
+          name: "Linda Teaman",
+          avatar_template:
+            "https://avatars.discourse.org/v3/letter/r/bc8723/{size}.png",
+        },
+        {
+          username: "legalatom",
+          name: "Team LegalAtom",
+          avatar_template:
+            "https://avatars.discourse.org/v3/letter/l/a9a28c/{size}.png",
+        },
+        {
+          username: "dzsat_team",
+          name: "Dz Sat Dz Sat",
+          avatar_template:
+            "https://avatars.discourse.org/v3/letter/d/eb9ed0/{size}.png",
+        },
+      ],
+      groups: [
+        {
+          name: "bob",
+          usernames: [],
+        },
+        {
+          name: "team",
+          usernames: [],
+        },
+      ],
     });
-  },
+  });
 });
 
 test("it flushes cache when switching categories", async (assert) => {

--- a/app/assets/javascripts/discourse/tests/unit/models/post-stream-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/post-stream-test.js
@@ -5,7 +5,7 @@ import Post from "discourse/models/post";
 import createStore from "discourse/tests/helpers/create-store";
 import User from "discourse/models/user";
 import { Promise } from "rsvp";
-import pretender from "discourse/tests/helpers/create-pretender";
+import { addPretenderCallback } from "discourse/tests/helpers/qunit-helpers";
 
 module("model:post-stream");
 
@@ -753,6 +753,10 @@ test("loadedAllPosts when the id changes", (assert) => {
   );
 });
 
+addPretenderCallback("model:post-stream", (server, helper) => {
+  server.get("/posts/4", () => helper.response({ id: 4, post_number: 4 }));
+});
+
 test("triggerRecoveredPost", async (assert) => {
   const postStream = buildStream(4567);
   const store = postStream.store;
@@ -761,14 +765,6 @@ test("triggerRecoveredPost", async (assert) => {
     postStream.appendPost(
       store.createRecord("post", { id: id, post_number: id })
     );
-  });
-
-  const response = (object) => {
-    return [200, { "Content-Type": "application/json" }, object];
-  };
-
-  pretender.get("/posts/4", () => {
-    return response({ id: 4, post_number: 4 });
   });
 
   assert.equal(

--- a/app/assets/javascripts/discourse/tests/unit/models/user-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/user-test.js
@@ -71,7 +71,7 @@ test("canMangeGroup", (assert) => {
   );
 });
 
-test("resolvedTimezone", (assert) => {
+test("resolvedTimezone", async (assert) => {
   const tz = "Australia/Brisbane";
   let user = User.create({ timezone: tz, username: "chuck", id: 111 });
   let stub = sinon.stub(moment.tz, "guess").returns("America/Chicago");

--- a/app/assets/javascripts/discourse/tests/unit/models/user-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/user-test.js
@@ -3,7 +3,6 @@ import { test, module } from "qunit";
 import User from "discourse/models/user";
 import Group from "discourse/models/group";
 import * as ajaxlib from "discourse/lib/ajax";
-import pretender from "discourse/tests/helpers/create-pretender";
 
 module("model:user");
 
@@ -77,7 +76,7 @@ test("resolvedTimezone", (assert) => {
   let user = User.create({ timezone: tz, username: "chuck", id: 111 });
   let stub = sinon.stub(moment.tz, "guess").returns("America/Chicago");
 
-  pretender.put("/u/chuck.json", () => {
+  window.server.put("/u/chuck.json", () => {
     return [200, { "Content-Type": "application/json" }, {}];
   });
 


### PR DESCRIPTION
**⚠️ To be updated and merged after other upcoming changes**

Previously, all pretender handlers would stick around when installed until the end of the entire test suite run. This change resets pretender completely before each test (see: setup-tests.js)

Note: this does replace some of `pretender` imports with the deprecated `window.server`, though that's only a temporary measure. All are soon to be replaced with `this.server`.

---

Also fixes an accidental leak in `resolvedTimezone`. (unit/model/user-test; added in #9230)
The test wasn't marked as async, so it didn't wait for all the requests within it to finish.