### PR TITLE
Add upload-actions plugin outlet

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/modal/upload-selector.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/upload-selector.hbs
@@ -34,5 +34,6 @@
 
 <div class="modal-footer">
   {{d-button action=(action "upload") class="btn-primary" icon=uploadIcon label="upload"}}
+  {{plugin-outlet name="upload-actions"}}
   {{d-modal-cancel close=(route-action "closeModal")}}
 </div>


### PR DESCRIPTION
Adding plugin outlet to the file upload modal to enable adding actions such as "Upload to Vimeo" (a plugin I am creating).