### PR TITLE
FIX: show 'quote' button when topic is closed but composer is open

### DIFF
--- a/app/assets/javascripts/discourse/app/components/quote-button.js
+++ b/app/assets/javascripts/discourse/app/components/quote-button.js
@@ -254,7 +254,7 @@ export default Component.extend({
     return getAbsoluteURL(postUrl(topic.slug, topic.id, quoteState.postId));
   },
 
-  @discourseComputed("topic.details.can_create_post", "composer.visible")
+  @discourseComputed("topic.details.can_create_post", "composerVisible")
   embedQuoteButton(canCreatePost, composerOpened) {
     return (
       (canCreatePost || composerOpened) &&


### PR DESCRIPTION
Meta bug report: https://meta.discourse.org/t/regression-quoting-text-from-closed-topic/165777