### PR TITLE
FIX: Search filters text was not able to be overridden

### DIFF
--- a/app/assets/javascripts/discourse/app/components/search-advanced-options.js
+++ b/app/assets/javascripts/discourse/app/components/search-advanced-options.js
@@ -29,47 +29,54 @@ const REGEXP_POST_TIME_WHEN = /^(before|after)/gi;
 
 const IN_OPTIONS_MAPPING = { images: "with" };
 
-const inOptionsForUsers = [
-  { name: I18n.t("search.advanced.filters.unseen"), value: "unseen" },
-  { name: I18n.t("search.advanced.filters.posted"), value: "posted" },
-  { name: I18n.t("search.advanced.filters.created"), value: "created" },
-  { name: I18n.t("search.advanced.filters.watching"), value: "watching" },
-  { name: I18n.t("search.advanced.filters.tracking"), value: "tracking" },
-  { name: I18n.t("search.advanced.filters.bookmarks"), value: "bookmarks" },
-];
+let _extraOptions = [];
 
-const inOptionsForAll = [
-  { name: I18n.t("search.advanced.filters.first"), value: "first" },
-  { name: I18n.t("search.advanced.filters.pinned"), value: "pinned" },
-  { name: I18n.t("search.advanced.filters.wiki"), value: "wiki" },
-  { name: I18n.t("search.advanced.filters.images"), value: "images" },
-];
+function inOptionsForUsers() {
+  return [
+    { name: I18n.t("search.advanced.filters.unseen"), value: "unseen" },
+    { name: I18n.t("search.advanced.filters.posted"), value: "posted" },
+    { name: I18n.t("search.advanced.filters.created"), value: "created" },
+    { name: I18n.t("search.advanced.filters.watching"), value: "watching" },
+    { name: I18n.t("search.advanced.filters.tracking"), value: "tracking" },
+    { name: I18n.t("search.advanced.filters.bookmarks"), value: "bookmarks" },
+  ].concat(..._extraOptions.map((eo) => eo.inOptionsForUsers).filter(Boolean));
+}
 
-const statusOptions = [
-  { name: I18n.t("search.advanced.statuses.open"), value: "open" },
-  { name: I18n.t("search.advanced.statuses.closed"), value: "closed" },
-  { name: I18n.t("search.advanced.statuses.public"), value: "public" },
-  { name: I18n.t("search.advanced.statuses.archived"), value: "archived" },
-  {
-    name: I18n.t("search.advanced.statuses.noreplies"),
-    value: "noreplies",
-  },
-  {
-    name: I18n.t("search.advanced.statuses.single_user"),
-    value: "single_user",
-  },
-];
+function inOptionsForAll() {
+  return [
+    { name: I18n.t("search.advanced.filters.first"), value: "first" },
+    { name: I18n.t("search.advanced.filters.pinned"), value: "pinned" },
+    { name: I18n.t("search.advanced.filters.wiki"), value: "wiki" },
+    { name: I18n.t("search.advanced.filters.images"), value: "images" },
+  ].concat(..._extraOptions.map((eo) => eo.inOptionsForAll).filter(Boolean));
+}
 
-const postTimeOptions = [
-  { name: I18n.t("search.advanced.post.time.before"), value: "before" },
-  { name: I18n.t("search.advanced.post.time.after"), value: "after" },
-];
+function statusOptions() {
+  return [
+    { name: I18n.t("search.advanced.statuses.open"), value: "open" },
+    { name: I18n.t("search.advanced.statuses.closed"), value: "closed" },
+    { name: I18n.t("search.advanced.statuses.public"), value: "public" },
+    { name: I18n.t("search.advanced.statuses.archived"), value: "archived" },
+    {
+      name: I18n.t("search.advanced.statuses.noreplies"),
+      value: "noreplies",
+    },
+    {
+      name: I18n.t("search.advanced.statuses.single_user"),
+      value: "single_user",
+    },
+  ].concat(..._extraOptions.map((eo) => eo.statusOptions).filter(Boolean));
+}
 
-function addAdvancedSearchOptions(options) {
-  inOptionsForAll.pushObjects(options.inOptionsForAll);
-  inOptionsForUsers.pushObjects(options.inOptionsForUsers);
-  statusOptions.pushObjects(options.statusOptions);
-  postTimeOptions.pushObjects(options.postTimeOptions);
+function postTimeOptions() {
+  return [
+    { name: I18n.t("search.advanced.post.time.before"), value: "before" },
+    { name: I18n.t("search.advanced.post.time.after"), value: "after" },
+  ].concat(..._extraOptions.map((eo) => eo.postTimeOptions).filter(Boolean));
+}
+
+export function addAdvancedSearchOptions(options) {
+  _extraOptions.push(options);
 }
 
 export default Component.extend({
@@ -105,10 +112,10 @@ export default Component.extend({
         },
       },
       inOptions: this.currentUser
-        ? inOptionsForUsers.concat(inOptionsForAll)
-        : inOptionsForAll,
-      statusOptions: statusOptions,
-      postTimeOptions: postTimeOptions,
+        ? inOptionsForUsers().concat(inOptionsForAll())
+        : inOptionsForAll(),
+      statusOptions: statusOptions(),
+      postTimeOptions: postTimeOptions(),
     });
   },
 
@@ -736,5 +743,3 @@ export default Component.extend({
     this.onChangeSearchTerm(searchTerm.trim());
   },
 });
-
-export { addAdvancedSearchOptions };


### PR DESCRIPTION
This is because the translations were being applied when the JS files
were parsed, which is before the overrides are loaded.

The solution is to return the filters in a function which is executed
when they are needed.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
