### PR TITLE
FIX: Staff can create and edit posts even if a topic is in slow mode.

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -648,9 +648,19 @@ export default Controller.extend({
     }
 
     const topic = composer.topic;
+    const slowModePost =
+      topic && topic.slow_mode_seconds && topic.user_last_posted_at;
+    const notEditing = this.get("model.action") !== "edit";
 
-    if (topic && topic.slow_mode_seconds && topic.user_last_posted_at) {
-      if (cannotPostAgain(topic.slow_mode_seconds, topic.user_last_posted_at)) {
+    // Editing a topic in slow mode is directly handled by the backend.
+    if (slowModePost && notEditing) {
+      if (
+        cannotPostAgain(
+          this.currentUser,
+          topic.slow_mode_seconds,
+          topic.user_last_posted_at
+        )
+      ) {
         const message = I18n.t("composer.slow_mode.error");
 
         bootbox.alert(message);

--- a/app/assets/javascripts/discourse/app/helpers/slow-mode.js
+++ b/app/assets/javascripts/discourse/app/helpers/slow-mode.js
@@ -29,9 +29,9 @@ export function durationTextFromSeconds(seconds) {
   return moment.duration(seconds, "seconds").humanize();
 }
 
-export function cannotPostAgain(duration, last_posted_at) {
+export function cannotPostAgain(user, duration, last_posted_at) {
   let threshold = new Date(last_posted_at);
   threshold = new Date(threshold.getTime() + duration * 1000);
 
-  return new Date() < threshold;
+  return !user.staff && new Date() < threshold;
 }

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -383,6 +383,7 @@ en:
   too_late_to_edit: "That post was created too long ago. It can no longer be edited or deleted."
   edit_conflict: "That post was edited by another user and your changes can no longer be saved."
   revert_version_same: "The current version is same as the version you are trying to revert to."
+  cannot_edit_on_slow_mode: "The topic is in slow mode and that post can no longer be edited."
 
   excerpt_image: "image"
 

--- a/lib/guardian/topic_guardian.rb
+++ b/lib/guardian/topic_guardian.rb
@@ -219,4 +219,8 @@ module TopicGuardian
     can_perform_action_available_to_group_moderators?(topic)
   end
 
+  def affected_by_slow_mode?(topic)
+    topic&.slow_mode_seconds.to_i > 0 && @user.human? && !is_staff?
+  end
+
 end

--- a/lib/post_creator.rb
+++ b/lib/post_creator.rb
@@ -159,7 +159,7 @@ class PostCreator
         return false
       end
 
-      if @topic&.slow_mode_seconds.to_i > 0
+      if guardian.affected_by_slow_mode?(@topic)
         tu = TopicUser.find_by(user: @user, topic: @topic)
 
         if tu&.last_posted_at

--- a/lib/post_revisor.rb
+++ b/lib/post_revisor.rb
@@ -144,6 +144,11 @@ class PostRevisor
     @revised_at = @opts[:revised_at] || Time.now
     @last_version_at = @post.last_version_at || Time.now
 
+    if guardian.affected_by_slow_mode?(@topic) && !ninja_edit?
+      @post.errors.add(:base, I18n.t("cannot_edit_on_slow_mode"))
+      return false
+    end
+
     @version_changed = false
     @post_successfully_saved = true
 
@@ -194,7 +199,7 @@ class PostRevisor
 
     # We log staff/group moderator edits to posts
     if (
-      (@editor.staff? || (@post.is_category_description? && Guardian.new(@editor).can_edit_category_description?(@post.topic.category))) &&
+      (@editor.staff? || (@post.is_category_description? && guardian.can_edit_category_description?(@post.topic.category))) &&
       @editor.id != @post.user_id &&
       @fields.has_key?('raw') &&
       !@opts[:skip_staff_log]
@@ -637,6 +642,10 @@ class PostRevisor
 
   def successfully_saved_post_and_topic
     @post_successfully_saved && !@topic_changes.errored?
+  end
+
+  def guardian
+    @guardian ||= Guardian.new(@editor)
   end
 
 end

--- a/spec/components/post_creator_spec.rb
+++ b/spec/components/post_creator_spec.rb
@@ -747,6 +747,17 @@ describe PostCreator do
         expect(post).to be_present
         expect(creator.errors.count).to be_zero
       end
+
+      it 'creates the topic if the user is a staff member' do
+        admin = Fabricate(:admin)
+        post_creator = PostCreator.new(admin, raw: 'test reply', topic_id: topic.id, reply_to_post_number: 4)
+        TopicUser.create!(user: admin, topic: topic, last_posted_at: 10.minutes.ago)
+
+        post = post_creator.create
+
+        expect(post).to be_present
+        expect(post_creator.errors.count).to be_zero
+      end
     end
   end
 


### PR DESCRIPTION
Additionally, ninja edits are no longer restricted.