### PR TITLE
REFACTOR: Replace global `find` with `queryAll`

### DIFF
--- a/app/assets/javascripts/admin/tests/admin/integration/components/themes-list-item-test.js
+++ b/app/assets/javascripts/admin/tests/admin/integration/components/themes-list-item-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { moduleForComponent } from "ember-qunit";
 import I18n from "I18n";
 import componentTest from "discourse/tests/helpers/component-test";
@@ -13,7 +14,11 @@ componentTest("default theme", {
 
   test(assert) {
     assert.expect(1);
-    assert.equal(find(".d-icon-check").length, 1, "shows default theme icon");
+    assert.equal(
+      queryAll(".d-icon-check").length,
+      1,
+      "shows default theme icon"
+    );
   },
 });
 
@@ -28,7 +33,11 @@ componentTest("pending updates", {
 
   test(assert) {
     assert.expect(1);
-    assert.equal(find(".d-icon-sync").length, 1, "shows pending update icon");
+    assert.equal(
+      queryAll(".d-icon-sync").length,
+      1,
+      "shows pending update icon"
+    );
   },
 });
 
@@ -47,7 +56,7 @@ componentTest("broken theme", {
   test(assert) {
     assert.expect(1);
     assert.equal(
-      find(".d-icon-exclamation-circle").length,
+      queryAll(".d-icon-exclamation-circle").length,
       1,
       "shows broken theme icon"
     );
@@ -75,7 +84,7 @@ componentTest("with children", {
   test(assert) {
     assert.expect(2);
     assert.deepEqual(
-      find(".components")
+      queryAll(".components")
         .text()
         .trim()
         .split(",")
@@ -88,7 +97,7 @@ componentTest("with children", {
       "lists the first 4 children"
     );
     assert.deepEqual(
-      find(".others-count").text().trim(),
+      queryAll(".others-count").text().trim(),
       I18n.t("admin.customize.theme.and_x_more", { count: 1 }),
       "shows count of remaining children"
     );

--- a/app/assets/javascripts/admin/tests/admin/integration/components/themes-list-test.js
+++ b/app/assets/javascripts/admin/tests/admin/integration/components/themes-list-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { moduleForComponent } from "ember-qunit";
 import I18n from "I18n";
 import componentTest from "discourse/tests/helpers/component-test";
@@ -29,36 +30,40 @@ componentTest("current tab is themes", {
 
   test(assert) {
     assert.equal(
-      find(".themes-tab").hasClass("active"),
+      queryAll(".themes-tab").hasClass("active"),
       true,
       "themes tab is active"
     );
     assert.equal(
-      find(".components-tab").hasClass("active"),
+      queryAll(".components-tab").hasClass("active"),
       false,
       "components tab is not active"
     );
 
     assert.equal(
-      find(".inactive-indicator").index(),
+      queryAll(".inactive-indicator").index(),
       -1,
       "there is no inactive themes separator when all themes are inactive"
     );
-    assert.equal(find(".themes-list-item").length, 5, "displays all themes");
+    assert.equal(
+      queryAll(".themes-list-item").length,
+      5,
+      "displays all themes"
+    );
 
     [2, 3].forEach((num) => this.themes[num].set("user_selectable", true));
     this.themes[4].set("default", true);
     this.set("themes", this.themes);
     const names = [4, 2, 3, 0, 1].map((num) => this.themes[num].get("name")); // default theme always on top, followed by user-selectable ones and then the rest
     assert.deepEqual(
-      Array.from(find(".themes-list-item").find(".name")).map((node) =>
+      Array.from(queryAll(".themes-list-item .name")).map((node) =>
         node.innerText.trim()
       ),
       names,
       "sorts themes correctly"
     );
     assert.equal(
-      find(".inactive-indicator").index(),
+      queryAll(".inactive-indicator").index(),
       3,
       "the separator is in the right location"
     );
@@ -66,19 +71,19 @@ componentTest("current tab is themes", {
     this.themes.forEach((theme) => theme.set("user_selectable", true));
     this.set("themes", this.themes);
     assert.equal(
-      find(".inactive-indicator").index(),
+      queryAll(".inactive-indicator").index(),
       -1,
       "there is no inactive themes separator when all themes are user-selectable"
     );
 
     this.set("themes", []);
     assert.equal(
-      find(".themes-list-item").length,
+      queryAll(".themes-list-item").length,
       1,
       "shows one entry with a message when there is nothing to display"
     );
     assert.equal(
-      find(".themes-list-item span.empty").text().trim(),
+      queryAll(".themes-list-item span.empty").text().trim(),
       I18n.t("admin.customize.theme.empty"),
       "displays the right message"
     );
@@ -109,35 +114,35 @@ componentTest("current tab is components", {
 
   test(assert) {
     assert.equal(
-      find(".components-tab").hasClass("active"),
+      queryAll(".components-tab").hasClass("active"),
       true,
       "components tab is active"
     );
     assert.equal(
-      find(".themes-tab").hasClass("active"),
+      queryAll(".themes-tab").hasClass("active"),
       false,
       "themes tab is not active"
     );
 
     assert.equal(
-      find(".inactive-indicator").index(),
+      queryAll(".inactive-indicator").index(),
       -1,
       "there is no separator"
     );
     assert.equal(
-      find(".themes-list-item").length,
+      queryAll(".themes-list-item").length,
       5,
       "displays all components"
     );
 
     this.set("components", []);
     assert.equal(
-      find(".themes-list-item").length,
+      queryAll(".themes-list-item").length,
       1,
       "shows one entry with a message when there is nothing to display"
     );
     assert.equal(
-      find(".themes-list-item span.empty").text().trim(),
+      queryAll(".themes-list-item span.empty").text().trim(),
       I18n.t("admin.customize.theme.empty"),
       "displays the right message"
     );

--- a/app/assets/javascripts/discourse/tests/acceptance/account-created-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/account-created-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
 import { visit, click, fillIn } from "@ember/test-helpers";
 import { test } from "qunit";
@@ -13,7 +14,7 @@ acceptance("Account Created", function () {
 
     assert.ok(exists(".account-created"));
     assert.equal(
-      find(".account-created .ac-message").text().trim(),
+      queryAll(".account-created .ac-message").text().trim(),
       "Hello World",
       "it displays the message"
     );
@@ -32,7 +33,7 @@ acceptance("Account Created", function () {
 
     assert.ok(exists(".account-created"));
     assert.equal(
-      find(".account-created .ac-message").text().trim(),
+      queryAll(".account-created .ac-message").text().trim(),
       "Hello World",
       "it displays the message"
     );
@@ -40,7 +41,7 @@ acceptance("Account Created", function () {
     await click(".activation-controls .resend");
 
     assert.equal(currentPath(), "account-created.resent");
-    const email = find(".account-created .ac-message b").text();
+    const email = queryAll(".account-created .ac-message b").text();
     assert.equal(email, "eviltrout@example.com");
   });
 
@@ -57,7 +58,7 @@ acceptance("Account Created", function () {
     await click(".activation-controls .edit-email");
 
     assert.equal(currentPath(), "account-created.edit-email");
-    assert.ok(find(".activation-controls .btn-primary:disabled").length);
+    assert.ok(queryAll(".activation-controls .btn-primary:disabled").length);
 
     await click(".activation-controls .edit-cancel");
 
@@ -76,16 +77,16 @@ acceptance("Account Created", function () {
 
     await click(".activation-controls .edit-email");
 
-    assert.ok(find(".activation-controls .btn-primary:disabled").length);
+    assert.ok(queryAll(".activation-controls .btn-primary:disabled").length);
 
     await fillIn(".activate-new-email", "newemail@example.com");
 
-    assert.notOk(find(".activation-controls .btn-primary:disabled").length);
+    assert.notOk(queryAll(".activation-controls .btn-primary:disabled").length);
 
     await click(".activation-controls .btn-primary");
 
     assert.equal(currentPath(), "account-created.resent");
-    const email = find(".account-created .ac-message b").text();
+    const email = queryAll(".account-created .ac-message b").text();
     assert.equal(email, "newemail@example.com");
   });
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-emails-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-emails-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { fillIn, click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
@@ -32,9 +33,9 @@ acceptance("Admin - Emails", function (needs) {
     await fillIn("textarea.email-body", EMAIL.trim());
     await click(".email-advanced-test button");
 
-    assert.equal(find(".text pre").text(), "Hello, this is a test!");
+    assert.equal(queryAll(".text pre").text(), "Hello, this is a test!");
     assert.equal(
-      find(".elided pre").text(),
+      queryAll(".elided pre").text(),
       "---\n\nThis part should be elided."
     );
   });

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-site-text-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-site-text-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
 import { fillIn, click, visit, currentURL } from "@ember/test-helpers";
 import { test } from "qunit";
@@ -30,7 +31,7 @@ acceptance("Admin - Site Texts", function (needs) {
   test("edit and revert a site text by key", async (assert) => {
     await visit("/admin/customize/site_texts/site.test");
 
-    assert.equal(find(".title h3").text(), "site.test");
+    assert.equal(queryAll(".title h3").text(), "site.test");
     assert.ok(!exists(".saved"));
     assert.ok(!exists(".revert-site-text"));
 

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-suspend-user-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-suspend-user-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
 import { visit, click, fillIn } from "@ember/test-helpers";
 import { test } from "qunit";
@@ -28,38 +29,38 @@ acceptance("Admin - Suspend User", function (needs) {
     await visit("/admin/users/1234/regular");
     await click(".suspend-user");
 
-    assert.equal(find(".suspend-user-modal:visible").length, 1);
+    assert.equal(queryAll(".suspend-user-modal:visible").length, 1);
 
     await click(".d-modal-cancel");
 
-    assert.equal(find(".suspend-user-modal:visible").length, 0);
+    assert.equal(queryAll(".suspend-user-modal:visible").length, 0);
   });
 
   test("suspend a user - cancel with input", async (assert) => {
     await visit("/admin/users/1234/regular");
     await click(".suspend-user");
 
-    assert.equal(find(".suspend-user-modal:visible").length, 1);
+    assert.equal(queryAll(".suspend-user-modal:visible").length, 1);
 
     await fillIn(".suspend-reason", "for breaking the rules");
     await fillIn(".suspend-message", "this is an email reason why");
 
     await click(".d-modal-cancel");
 
-    assert.equal(find(".bootbox.modal:visible").length, 1);
+    assert.equal(queryAll(".bootbox.modal:visible").length, 1);
 
     await click(".modal-footer .btn-default");
-    assert.equal(find(".suspend-user-modal:visible").length, 1);
+    assert.equal(queryAll(".suspend-user-modal:visible").length, 1);
     assert.equal(
-      find(".suspend-message")[0].value,
+      queryAll(".suspend-message")[0].value,
       "this is an email reason why"
     );
 
     await click(".d-modal-cancel");
-    assert.equal(find(".bootbox.modal:visible").length, 1);
-    assert.equal(find(".suspend-user-modal:visible").length, 0);
+    assert.equal(queryAll(".bootbox.modal:visible").length, 1);
+    assert.equal(queryAll(".suspend-user-modal:visible").length, 0);
     await click(".modal-footer .btn-primary");
-    assert.equal(find(".bootbox.modal:visible").length, 0);
+    assert.equal(queryAll(".bootbox.modal:visible").length, 0);
   });
 
   test("suspend, then unsuspend a user", async (assert) => {
@@ -74,7 +75,7 @@ acceptance("Admin - Suspend User", function (needs) {
     await click(".suspend-user");
 
     assert.equal(
-      find(".perform-suspend[disabled]").length,
+      queryAll(".perform-suspend[disabled]").length,
       1,
       "disabled by default"
     );
@@ -86,14 +87,14 @@ acceptance("Admin - Suspend User", function (needs) {
     await fillIn(".suspend-message", "this is an email reason why");
 
     assert.equal(
-      find(".perform-suspend[disabled]").length,
+      queryAll(".perform-suspend[disabled]").length,
       0,
       "no longer disabled"
     );
 
     await click(".perform-suspend");
 
-    assert.equal(find(".suspend-user-modal:visible").length, 0);
+    assert.equal(queryAll(".suspend-user-modal:visible").length, 0);
     assert.ok(exists(".suspension-info"));
 
     await click(".unsuspend-user");

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-user-emails-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-user-emails-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import I18n from "I18n";
@@ -5,13 +6,13 @@ import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 function assertNoSecondary(assert) {
   assert.equal(
-    find(".display-row.email .value a").text(),
+    queryAll(".display-row.email .value a").text(),
     "eviltrout@example.com",
     "it should display the primary email"
   );
 
   assert.equal(
-    find(".display-row.secondary-emails .value").text().trim(),
+    queryAll(".display-row.secondary-emails .value").text().trim(),
     I18n.t("user.email.no_secondary"),
     "it should not display secondary emails"
   );
@@ -19,13 +20,13 @@ function assertNoSecondary(assert) {
 
 function assertMultipleSecondary(assert, firstEmail, secondEmail) {
   assert.equal(
-    find(".display-row.secondary-emails .value li:first-of-type a").text(),
+    queryAll(".display-row.secondary-emails .value li:first-of-type a").text(),
     firstEmail,
     "it should display the first secondary email"
   );
 
   assert.equal(
-    find(".display-row.secondary-emails .value li:last-of-type a").text(),
+    queryAll(".display-row.secondary-emails .value li:last-of-type a").text(),
     secondEmail,
     "it should display the second secondary email"
   );
@@ -44,7 +45,7 @@ acceptance("Admin - User Emails", function (needs) {
     await visit("/admin/users/3/markvanlan");
 
     assert.equal(
-      find(".display-row.email .value a").text(),
+      queryAll(".display-row.email .value a").text(),
       "markvanlan@example.com",
       "it should display the user's primary email"
     );

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-user-index-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-user-index-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
@@ -41,26 +42,29 @@ acceptance("Admin - User Index", function (needs) {
   test("can edit username", async (assert) => {
     await visit("/admin/users/2/sam");
 
-    assert.equal(find(".display-row.username .value").text().trim(), "sam");
+    assert.equal(queryAll(".display-row.username .value").text().trim(), "sam");
 
     // Trying cancel.
     await click(".display-row.username button");
     await fillIn(".display-row.username .value input", "new-sam");
     await click(".display-row.username a");
-    assert.equal(find(".display-row.username .value").text().trim(), "sam");
+    assert.equal(queryAll(".display-row.username .value").text().trim(), "sam");
 
     // Doing edit.
     await click(".display-row.username button");
     await fillIn(".display-row.username .value input", "new-sam");
     await click(".display-row.username button");
-    assert.equal(find(".display-row.username .value").text().trim(), "new-sam");
+    assert.equal(
+      queryAll(".display-row.username .value").text().trim(),
+      "new-sam"
+    );
   });
 
   test("will clear unsaved groups when switching user", async (assert) => {
     await visit("/admin/users/2/sam");
 
     assert.equal(
-      find(".display-row.username .value").text().trim(),
+      queryAll(".display-row.username .value").text().trim(),
       "sam",
       "the name should be correct"
     );
@@ -73,13 +77,13 @@ acceptance("Admin - User Index", function (needs) {
     await visit("/admin/users/1/eviltrout");
 
     assert.equal(
-      find(".display-row.username .value").text().trim(),
+      queryAll(".display-row.username .value").text().trim(),
       "eviltrout",
       "the name should be correct"
     );
 
     assert.equal(
-      find('.group-chooser span[title="Macdonald"]').length,
+      queryAll('.group-chooser span[title="Macdonald"]').length,
       0,
       "group should not be set"
     );

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-users-list-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-users-list-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
 import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
@@ -22,7 +23,7 @@ acceptance("Admin - Users List", function (needs) {
     await click(".users-list .sortable:nth-child(1)");
 
     assert.ok(
-      find(".users-list .user:nth-child(1) .username")
+      queryAll(".users-list .user:nth-child(1) .username")
         .text()
         .includes("eviltrout"),
       "list should be sorted by username"
@@ -31,7 +32,7 @@ acceptance("Admin - Users List", function (needs) {
     await click(".users-list .sortable:nth-child(1)");
 
     assert.ok(
-      find(".users-list .user:nth-child(1) .username")
+      queryAll(".users-list .user:nth-child(1) .username")
         .text()
         .includes("discobot"),
       "list should be sorted ascending by username"
@@ -46,7 +47,7 @@ acceptance("Admin - Users List", function (needs) {
     await click(".show-emails");
 
     assert.equal(
-      find(".users-list .user:nth-child(1) .email").text(),
+      queryAll(".users-list .user:nth-child(1) .email").text(),
       "<small>eviltrout@example.com</small>",
       "shows the emails"
     );
@@ -54,7 +55,7 @@ acceptance("Admin - Users List", function (needs) {
     await click(".hide-emails");
 
     assert.equal(
-      find(".users-list .user:nth-child(1) .email").text(),
+      queryAll(".users-list .user:nth-child(1) .email").text(),
       "",
       "hides the emails"
     );
@@ -68,36 +69,36 @@ acceptance("Admin - Users List", function (needs) {
 
     await visit("/admin/users/list/active");
 
-    assert.equal(find(".admin-title h2").text(), activeTitle);
+    assert.equal(queryAll(".admin-title h2").text(), activeTitle);
     assert.ok(
-      find(".users-list .user:nth-child(1) .username")
+      queryAll(".users-list .user:nth-child(1) .username")
         .text()
         .includes(activeUser)
     );
 
     await click('a[href="/admin/users/list/new"]');
 
-    assert.equal(find(".admin-title h2").text(), suspectTitle);
+    assert.equal(queryAll(".admin-title h2").text(), suspectTitle);
     assert.ok(
-      find(".users-list .user:nth-child(1) .username")
+      queryAll(".users-list .user:nth-child(1) .username")
         .text()
         .includes(suspectUser)
     );
 
     await click(".users-list .sortable:nth-child(4)");
 
-    assert.equal(find(".admin-title h2").text(), suspectTitle);
+    assert.equal(queryAll(".admin-title h2").text(), suspectTitle);
     assert.ok(
-      find(".users-list .user:nth-child(1) .username")
+      queryAll(".users-list .user:nth-child(1) .username")
         .text()
         .includes(suspectUser)
     );
 
     await click('a[href="/admin/users/list/active"]');
 
-    assert.equal(find(".admin-title h2").text(), activeTitle);
+    assert.equal(queryAll(".admin-title h2").text(), activeTitle);
     assert.ok(
-      find(".users-list .user:nth-child(1) .username")
+      queryAll(".users-list .user:nth-child(1) .username")
         .text()
         .includes(activeUser)
     );

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-watched-words-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-watched-words-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
 import { fillIn, click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
@@ -18,7 +19,7 @@ acceptance("Admin - Watched Words", function (needs) {
     await fillIn(".admin-controls .controls input[type=text]", "li");
 
     assert.equal(
-      find(".watched-words-list .watched-word").length,
+      queryAll(".watched-words-list .watched-word").length,
       1,
       "When filtering, show words even if checkbox is unchecked."
     );
@@ -52,7 +53,7 @@ acceptance("Admin - Watched Words", function (needs) {
     await click(".watched-word-form button");
 
     let found = [];
-    $.each(find(".watched-words-list .watched-word"), (index, elem) => {
+    $.each(queryAll(".watched-words-list .watched-word"), (index, elem) => {
       if ($(elem).text().trim() === "poutine") {
         found.push(true);
       }
@@ -66,7 +67,7 @@ acceptance("Admin - Watched Words", function (needs) {
 
     let word = null;
 
-    $.each(find(".watched-words-list .watched-word"), (index, elem) => {
+    $.each(queryAll(".watched-words-list .watched-word"), (index, elem) => {
       if ($(elem).text().trim() === "anise") {
         word = elem;
       }
@@ -74,6 +75,6 @@ acceptance("Admin - Watched Words", function (needs) {
 
     await click("#" + $(word).attr("id"));
 
-    assert.equal(find(".watched-words-list .watched-word").length, 2);
+    assert.equal(queryAll(".watched-words-list .watched-word").length, 2);
   });
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/bookmarks-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/bookmarks-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
 import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
@@ -154,7 +155,7 @@ acceptance("Bookmarking", function (needs) {
 
     assert.ok(exists(".bootbox.modal"), "it asks for delete confirmation");
     assert.ok(
-      find(".bootbox.modal")
+      queryAll(".bootbox.modal")
         .text()
         .includes(I18n.t("bookmarks.confirm_delete")),
       "it shows delete confirmation message"
@@ -188,17 +189,17 @@ acceptance("Bookmarking", function (needs) {
 
     await openEditBookmarkModal();
     assert.equal(
-      find("#bookmark-name").val(),
+      queryAll("#bookmark-name").val(),
       "Test name",
       "it should prefill the bookmark name"
     );
     assert.equal(
-      find("#bookmark-custom-date > input").val(),
+      queryAll("#bookmark-custom-date > input").val(),
       tomorrow,
       "it should prefill the bookmark date"
     );
     assert.equal(
-      find("#bookmark-custom-time").val(),
+      queryAll("#bookmark-custom-time").val(),
       "08:00",
       "it should prefill the bookmark time"
     );

--- a/app/assets/javascripts/discourse/tests/acceptance/category-banner-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/category-banner-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance, visible } from "discourse/tests/helpers/qunit-helpers";
@@ -57,7 +58,7 @@ acceptance("Category Banners", function (needs) {
     assert.ok(!visible(".bootbox.modal"), "it closes the modal");
     assert.ok(visible(".category-read-only-banner"), "it shows a banner");
     assert.ok(
-      find(".category-read-only-banner .inner").length === 1,
+      queryAll(".category-read-only-banner .inner").length === 1,
       "it allows staff to embed html in the message"
     );
   });

--- a/app/assets/javascripts/discourse/tests/acceptance/category-edit-security-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/category-edit-security-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
@@ -9,12 +10,12 @@ acceptance("Category Edit - security", function (needs) {
   test("default", async (assert) => {
     await visit("/c/bug/edit/security");
 
-    const $permissionListItems = find(".permission-list li");
+    const $firstItem = queryAll(".permission-list li:eq(0)");
 
-    const badgeName = $permissionListItems.eq(0).find(".badge-group").text();
+    const badgeName = $firstItem.find(".badge-group").text();
     assert.equal(badgeName, "everyone");
 
-    const permission = $permissionListItems.eq(0).find(".permission").text();
+    const permission = $firstItem.find(".permission").text();
     assert.equal(permission, "Create / Reply / See");
   });
 
@@ -55,7 +56,7 @@ acceptance("Category Edit - security", function (needs) {
     await permissionSelector.selectRowByValue("2");
     await click(".edit-category-tab-security .add-permission");
 
-    const $addedPermissionItem = find(
+    const $addedPermissionItem = queryAll(
       ".edit-category-tab-security .permission-list li:nth-child(2)"
     );
 
@@ -77,7 +78,7 @@ acceptance("Category Edit - security", function (needs) {
     );
 
     assert.equal(
-      find(".edit-category-tab-security .permission-list li").length,
+      queryAll(".edit-category-tab-security .permission-list li").length,
       0,
       "it removes the permission from the list"
     );
@@ -87,17 +88,17 @@ acceptance("Category Edit - security", function (needs) {
     await click(".edit-category-tab-security .add-permission");
 
     assert.equal(
-      find(".edit-category-tab-security .permission-list li").length,
+      queryAll(".edit-category-tab-security .permission-list li").length,
       1,
       "it adds the permission to the list"
     );
 
-    const $permissionListItems = find(".permission-list li");
+    const $firstItem = queryAll(".permission-list li:eq(0)");
 
-    const badgeName = $permissionListItems.eq(0).find(".badge-group").text();
+    const badgeName = $firstItem.find(".badge-group").text();
     assert.equal(badgeName, "everyone");
 
-    const permission = $permissionListItems.eq(0).find(".permission").text();
+    const permission = $firstItem.find(".permission").text();
     assert.equal(permission, "Create / Reply / See");
   });
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/category-edit-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/category-edit-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { click, fillIn, visit, currentURL } from "@ember/test-helpers";
 import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
@@ -19,9 +20,9 @@ acceptance("Category Edit", function (needs) {
       "it jumps to the correct screen"
     );
 
-    assert.equal(find(".badge-category").text(), "bug");
+    assert.equal(queryAll(".badge-category").text(), "bug");
     await fillIn("input.category-name", "testing");
-    assert.equal(find(".badge-category").text(), "testing");
+    assert.equal(queryAll(".badge-category").text(), "testing");
 
     await fillIn("#edit-text-color", "#ff0000");
 
@@ -72,7 +73,7 @@ acceptance("Category Edit", function (needs) {
       "/c/1-category/edit/general",
       "it goes to the general tab"
     );
-    assert.equal(find("input.category-name").val(), "bug");
+    assert.equal(queryAll("input.category-name").val(), "bug");
   });
 
   test("Error Saving", async (assert) => {
@@ -81,7 +82,7 @@ acceptance("Category Edit", function (needs) {
     await click("#save-category");
 
     assert.ok(visible(".bootbox"));
-    assert.equal(find(".bootbox .modal-body").html(), "duplicate email");
+    assert.equal(queryAll(".bootbox .modal-body").html(), "duplicate email");
 
     await click(".bootbox .btn-primary");
     assert.ok(!visible(".bootbox"));

--- a/app/assets/javascripts/discourse/tests/acceptance/category-new-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/category-new-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { fillIn, click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
@@ -10,15 +11,15 @@ acceptance("Category New", function (needs) {
 
   test("Creating a new category", async (assert) => {
     await visit("/new-category");
-    assert.ok(find(".badge-category"));
+    assert.ok(queryAll(".badge-category"));
 
     await fillIn("input.category-name", "testing");
-    assert.equal(find(".badge-category").text(), "testing");
+    assert.equal(queryAll(".badge-category").text(), "testing");
 
     await click("#save-category");
 
     assert.equal(
-      find(".edit-category-title h2").text(),
+      queryAll(".edit-category-title h2").text(),
       I18n.t("category.edit_dialog_title", {
         categoryName: "testing",
       })
@@ -26,13 +27,13 @@ acceptance("Category New", function (needs) {
 
     await click(".edit-category-security a");
     assert.ok(
-      find("button.edit-permission"),
+      queryAll("button.edit-permission"),
       "it can switch to the security tab"
     );
 
     await click(".edit-category-settings a");
     assert.ok(
-      find("#category-search-priority"),
+      queryAll("#category-search-priority"),
       "it can switch to the settings tab"
     );
 

--- a/app/assets/javascripts/discourse/tests/acceptance/click-track-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/click-track-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { click, visit, currentURL } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
@@ -13,10 +14,13 @@ acceptance("Click Track", function (needs) {
 
   test("Do not track mentions", async (assert) => {
     await visit("/t/internationalization-localization/280");
-    assert.ok(find(".user-card.show").length === 0, "card should not appear");
+    assert.ok(
+      queryAll(".user-card.show").length === 0,
+      "card should not appear"
+    );
 
     await click("article[data-post-id=3651] a.mention");
-    assert.ok(find(".user-card.show").length === 1, "card appear");
+    assert.ok(queryAll(".user-card.show").length === 1, "card appear");
     assert.equal(currentURL(), "/t/internationalization-localization/280");
     assert.ok(!tracked);
   });

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-actions-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-actions-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
 import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
@@ -29,8 +30,8 @@ acceptance("Composer Actions", function (needs) {
     await composerActions.expand();
     await composerActions.selectRowByValue("reply_as_private_message");
 
-    assert.ok(find("#reply-title").val(), "this is the title");
-    assert.ok(find(".d-editor-input").val(), "this is the reply");
+    assert.ok(queryAll("#reply-title").val(), "this is the title");
+    assert.ok(queryAll(".d-editor-input").val(), "this is the reply");
   });
 
   test("replying to post", async (assert) => {
@@ -60,9 +61,10 @@ acceptance("Composer Actions", function (needs) {
     await composerActions.expand();
     await composerActions.selectRowByValue("reply_as_private_message");
 
-    assert.equal(find(".users-input .item:eq(0)").text(), "codinghorror");
+    assert.equal(queryAll(".users-input .item:eq(0)").text(), "codinghorror");
     assert.ok(
-      find(".d-editor-input").val().indexOf("Continuing the discussion") >= 0
+      queryAll(".d-editor-input").val().indexOf("Continuing the discussion") >=
+        0
     );
   });
 
@@ -80,15 +82,15 @@ acceptance("Composer Actions", function (needs) {
     await composerActions.selectRowByValue("reply_to_topic");
 
     assert.equal(
-      find(".action-title .topic-link").text().trim(),
+      queryAll(".action-title .topic-link").text().trim(),
       "Internationalization / localization"
     );
     assert.equal(
-      find(".action-title .topic-link").attr("href"),
+      queryAll(".action-title .topic-link").attr("href"),
       "/t/internationalization-localization/280"
     );
     assert.equal(
-      find(".d-editor-input").val(),
+      queryAll(".d-editor-input").val(),
       "test replying to topic when initially replied to post"
     );
   });
@@ -107,7 +109,7 @@ acceptance("Composer Actions", function (needs) {
     await composerActions.selectRowByValue("toggle_whisper");
 
     assert.ok(
-      find(".composer-fields .whisper .d-icon-far-eye-slash").length === 1
+      queryAll(".composer-fields .whisper .d-icon-far-eye-slash").length === 1
     );
   });
 
@@ -135,10 +137,10 @@ acceptance("Composer Actions", function (needs) {
 
     assert.equal(categoryChooserReplyArea.header().name(), "faq");
     assert.equal(
-      find(".action-title").text().trim(),
+      queryAll(".action-title").text().trim(),
       I18n.t("topic.create_long")
     );
-    assert.ok(find(".d-editor-input").val().includes(quote));
+    assert.ok(queryAll(".d-editor-input").val().includes(quote));
     sinon.restore();
   });
 
@@ -148,7 +150,7 @@ acceptance("Composer Actions", function (needs) {
     const composerActions = selectKit(".composer-actions");
     await composerActions.expand();
     await composerActions.selectRowByValue("reply_as_new_topic");
-    assert.equal(exists(find(".bootbox")), false);
+    assert.equal(exists(queryAll(".bootbox")), false);
   });
 
   test("reply_as_new_group_message", async (assert) => {
@@ -159,7 +161,7 @@ acceptance("Composer Actions", function (needs) {
     await composerActions.selectRowByValue("reply_as_new_group_message");
 
     const items = [];
-    find(".users-input .item").each((_, item) =>
+    queryAll(".users-input .item").each((_, item) =>
       items.push(item.textContent.trim())
     );
 
@@ -193,10 +195,10 @@ acceptance("Composer Actions", function (needs) {
     await composerActions.selectRowByValue("reply_to_topic");
 
     assert.equal(
-      find(".action-title").text().trim(),
+      queryAll(".action-title").text().trim(),
       "Internationalization / localization"
     );
-    assert.equal(find(".d-editor-input").val(), quote);
+    assert.equal(queryAll(".d-editor-input").val(), quote);
 
     await composerActions.expand();
 
@@ -213,12 +215,12 @@ acceptance("Composer Actions", function (needs) {
     await composerActions.selectRowByValue("reply_to_post");
     await composerActions.expand();
 
-    assert.ok(exists(find(".action-title img.avatar")));
+    assert.ok(exists(queryAll(".action-title img.avatar")));
     assert.equal(
-      find(".action-title .user-link").text().trim(),
+      queryAll(".action-title .user-link").text().trim(),
       "codinghorror"
     );
-    assert.equal(find(".d-editor-input").val(), quote);
+    assert.equal(queryAll(".d-editor-input").val(), quote);
     assert.equal(composerActions.rowByIndex(0).value(), "reply_as_new_topic");
     assert.equal(
       composerActions.rowByIndex(1).value(),
@@ -233,10 +235,10 @@ acceptance("Composer Actions", function (needs) {
     await composerActions.expand();
 
     assert.equal(
-      find(".action-title").text().trim(),
+      queryAll(".action-title").text().trim(),
       I18n.t("topic.create_long")
     );
-    assert.ok(find(".d-editor-input").val().includes(quote));
+    assert.ok(queryAll(".d-editor-input").val().includes(quote));
     assert.equal(composerActions.rowByIndex(0).value(), "reply_to_post");
     assert.equal(
       composerActions.rowByIndex(1).value(),
@@ -250,11 +252,12 @@ acceptance("Composer Actions", function (needs) {
     await composerActions.expand();
 
     assert.equal(
-      find(".action-title").text().trim(),
+      queryAll(".action-title").text().trim(),
       I18n.t("topic.private_message")
     );
     assert.ok(
-      find(".d-editor-input").val().indexOf("Continuing the discussion") === 0
+      queryAll(".d-editor-input").val().indexOf("Continuing the discussion") ===
+        0
     );
     assert.equal(composerActions.rowByIndex(0).value(), "reply_as_new_topic");
     assert.equal(composerActions.rowByIndex(1).value(), "reply_to_post");
@@ -269,7 +272,7 @@ acceptance("Composer Actions", function (needs) {
     await click("article#post_3 button.reply");
 
     assert.ok(
-      find(".composer-fields .no-bump").length === 0,
+      queryAll(".composer-fields .no-bump").length === 0,
       "no-bump text is not visible"
     );
 
@@ -277,7 +280,7 @@ acceptance("Composer Actions", function (needs) {
     await composerActions.selectRowByValue("toggle_topic_bump");
 
     assert.ok(
-      find(".composer-fields .no-bump").length === 1,
+      queryAll(".composer-fields .no-bump").length === 1,
       "no-bump icon is visible"
     );
 
@@ -285,7 +288,7 @@ acceptance("Composer Actions", function (needs) {
     await composerActions.selectRowByValue("toggle_topic_bump");
 
     assert.ok(
-      find(".composer-fields .no-bump").length === 0,
+      queryAll(".composer-fields .no-bump").length === 0,
       "no-bump icon is not visible"
     );
   });
@@ -341,9 +344,10 @@ acceptance("Composer Actions", function (needs) {
     await composerActions.expand();
     await composerActions.selectRowByValue("reply_as_private_message");
 
-    assert.equal(find(".users-input .item:eq(0)").text(), "uwe_keim");
+    assert.equal(queryAll(".users-input .item:eq(0)").text(), "uwe_keim");
     assert.ok(
-      find(".d-editor-input").val().indexOf("Continuing the discussion") >= 0
+      queryAll(".d-editor-input").val().indexOf("Continuing the discussion") >=
+        0
     );
   });
 
@@ -406,16 +410,16 @@ acceptance("Composer Actions With New Topic Draft", function (needs) {
       assert.equal(tags.header().value(), "monkey", "tags are not reset");
 
       assert.equal(
-        find("#reply-title").val(),
+        queryAll("#reply-title").val(),
         "This is the new text for the title using 'quotes'"
       );
 
       assert.equal(
-        find("#reply-control .btn-primary.create .d-button-label").text(),
+        queryAll("#reply-control .btn-primary.create .d-button-label").text(),
         I18n.t("composer.create_shared_draft")
       );
 
-      assert.ok(find("#reply-control.composing-shared-draft").length === 1);
+      assert.ok(queryAll("#reply-control.composing-shared-draft").length === 1);
       await click(".modal-footer .btn.btn-default");
     } finally {
       toggleCheckDraftPopup(false);
@@ -431,7 +435,7 @@ acceptance("Composer Actions With New Topic Draft", function (needs) {
     stubDraftResponse();
     await composerActions.selectRowByValue("reply_as_new_topic");
     assert.equal(
-      find(".bootbox .modal-body").text(),
+      queryAll(".bootbox .modal-body").text(),
       I18n.t("composer.composer_actions.reply_as_new_topic.confirm")
     );
     await click(".modal-footer .btn.btn-default");

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-attachment-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-attachment-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
@@ -21,7 +22,7 @@ async function writeInComposer(assert) {
   await fillIn(".d-editor-input", "[test](upload://abcdefg.png)");
 
   assert.equal(
-    find(".d-editor-preview:visible").html().trim(),
+    queryAll(".d-editor-preview:visible").html().trim(),
     '<p><a href="/404">test</a></p>'
   );
 
@@ -35,7 +36,7 @@ acceptance("Composer Attachment", function (needs) {
   test("attachments are cooked properly", async (assert) => {
     await writeInComposer(assert);
     assert.equal(
-      find(".d-editor-preview:visible").html().trim(),
+      queryAll(".d-editor-preview:visible").html().trim(),
       '<p><a class="attachment" href="/uploads/short-url/asdsad.png">test</a></p>'
     );
   });
@@ -49,7 +50,7 @@ acceptance("Composer Attachment - Secure Media Enabled", function (needs) {
   test("attachments are cooked properly when secure media is enabled", async (assert) => {
     await writeInComposer(assert);
     assert.equal(
-      find(".d-editor-preview:visible").html().trim(),
+      queryAll(".d-editor-preview:visible").html().trim(),
       '<p><a class="attachment" href="/secure-media-uploads/default/3X/1/asjdiasjdiasida.png">test</a></p>'
     );
   });

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-edit-conflict-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-edit-conflict-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import I18n from "I18n";
@@ -21,12 +22,12 @@ acceptance("Composer - Edit conflict", function (needs) {
     await fillIn(".d-editor-input", "this will 409");
     await click("#reply-control button.create");
     assert.equal(
-      find("#reply-control button.create").text().trim(),
+      queryAll("#reply-control button.create").text().trim(),
       I18n.t("composer.overwrite_edit"),
       "it shows the overwrite button"
     );
     assert.ok(
-      find("#draft-status .d-icon-user-edit"),
+      queryAll("#draft-status .d-icon-user-edit"),
       "error icon should be there"
     );
     await click(".modal .btn-primary");

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-hyperlink-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-hyperlink-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
 import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
@@ -24,7 +25,7 @@ acceptance("Composer - Hyperlink", function (needs) {
     await click(".modal-footer button.btn-primary");
 
     assert.equal(
-      find(".d-editor-input").val(),
+      queryAll(".d-editor-input").val(),
       "This is a link to [Google](https://google.com)",
       "adds link with url and text, prepends 'https://'"
     );
@@ -42,7 +43,7 @@ acceptance("Composer - Hyperlink", function (needs) {
     await click(".modal-footer button.btn-danger");
 
     assert.equal(
-      find(".d-editor-input").val(),
+      queryAll(".d-editor-input").val(),
       "Reset textarea contents.",
       "doesn’t insert anything after cancelling"
     );
@@ -52,7 +53,7 @@ acceptance("Composer - Hyperlink", function (needs) {
       "modal dismissed after cancelling"
     );
 
-    const textarea = find("#reply-control .d-editor-input")[0];
+    const textarea = queryAll("#reply-control .d-editor-input")[0];
     textarea.selectionStart = 0;
     textarea.selectionEnd = 6;
     await click(".d-editor button.link");
@@ -61,7 +62,7 @@ acceptance("Composer - Hyperlink", function (needs) {
     await click(".modal-footer button.btn-primary");
 
     assert.equal(
-      find(".d-editor-input").val(),
+      queryAll(".d-editor-input").val(),
       "[Reset](https://somelink.com) textarea contents.",
       "adds link to a selected text"
     );
@@ -92,7 +93,7 @@ acceptance("Composer - Hyperlink", function (needs) {
     );
 
     assert.ok(
-      find(".link-url").val().includes("http"),
+      queryAll(".link-url").val().includes("http"),
       "replaces link url field with internal link"
     );
   });

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-onebox-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-onebox-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
@@ -29,7 +30,7 @@ http://www.example.com/has-title.html
     );
 
     assert.equal(
-      find(".d-editor-preview:visible").html().trim(),
+      queryAll(".d-editor-preview:visible").html().trim(),
       `
 <p><aside class=\"onebox\"><article class=\"onebox-body\"><h3><a href=\"http://www.example.com/article.html\">An interesting article</a></h3></article></aside><br>
 This is another test <a href=\"http://www.example.com/has-title.html\" class=\"inline-onebox\">This is a great title</a></p>

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
 import { click, fillIn, visit, currentURL } from "@ember/test-helpers";
 import { skip, test } from "qunit";
@@ -65,7 +66,7 @@ acceptance("Composer", function (needs) {
 
     await fillIn(".d-editor-input", "this is the *content* of a post");
     assert.equal(
-      find(".d-editor-preview").html().trim(),
+      queryAll(".d-editor-preview").html().trim(),
       "<p>this is the <em>content</em> of a post</p>",
       "it previews content"
     );
@@ -74,7 +75,7 @@ acceptance("Composer", function (needs) {
       "the body is now good"
     );
 
-    const textarea = find("#reply-control .d-editor-input")[0];
+    const textarea = queryAll("#reply-control .d-editor-input")[0];
     textarea.selectionStart = textarea.value.length;
     textarea.selectionEnd = textarea.value.length;
 
@@ -89,7 +90,7 @@ acceptance("Composer", function (needs) {
 
     const example = I18n.t(`composer.bold_text`);
     assert.equal(
-      find("#reply-control .d-editor-input").val().trim(),
+      queryAll("#reply-control .d-editor-input").val().trim(),
       `this is the *content* of a post**${example}**`,
       "it supports keyboard shortcuts"
     );
@@ -153,43 +154,46 @@ acceptance("Composer", function (needs) {
       },
     };
 
-    await find(".wmd-controls").trigger("fileuploadsend", data1);
-    assert.equal(find(".d-editor-input").val(), "[Uploading: test.png...]() ");
-
-    await find(".wmd-controls").trigger("fileuploadsend", data2);
+    await queryAll(".wmd-controls").trigger("fileuploadsend", data1);
     assert.equal(
-      find(".d-editor-input").val(),
+      queryAll(".d-editor-input").val(),
+      "[Uploading: test.png...]() "
+    );
+
+    await queryAll(".wmd-controls").trigger("fileuploadsend", data2);
+    assert.equal(
+      queryAll(".d-editor-input").val(),
       "[Uploading: test.png...]() [Uploading: test.png(1)...]() "
     );
 
-    await find(".wmd-controls").trigger("fileuploadsend", data4);
+    await queryAll(".wmd-controls").trigger("fileuploadsend", data4);
     assert.equal(
-      find(".d-editor-input").val(),
+      queryAll(".d-editor-input").val(),
       "[Uploading: test.png...]() [Uploading: test.png(1)...]() [Uploading: ima++ge.png...]() ",
       "should accept files with unescaped characters"
     );
 
-    await find(".wmd-controls").trigger("fileuploadsend", data3);
+    await queryAll(".wmd-controls").trigger("fileuploadsend", data3);
     assert.equal(
-      find(".d-editor-input").val(),
+      queryAll(".d-editor-input").val(),
       "[Uploading: test.png...]() [Uploading: test.png(1)...]() [Uploading: ima++ge.png...]() [Uploading: image.png...]() "
     );
 
-    await find(".wmd-controls").trigger("fileuploaddone", data2);
+    await queryAll(".wmd-controls").trigger("fileuploaddone", data2);
     assert.equal(
-      find(".d-editor-input").val(),
+      queryAll(".d-editor-input").val(),
       "[Uploading: test.png...]() ![test|100x200](/images/avatar.png?2) [Uploading: ima++ge.png...]() [Uploading: image.png...]() "
     );
 
-    await find(".wmd-controls").trigger("fileuploaddone", data3);
+    await queryAll(".wmd-controls").trigger("fileuploaddone", data3);
     assert.equal(
-      find(".d-editor-input").val(),
+      queryAll(".d-editor-input").val(),
       "[Uploading: test.png...]() ![test|100x200](/images/avatar.png?2) [Uploading: ima++ge.png...]() ![image|300x400](/images/avatar.png?3) "
     );
 
-    await find(".wmd-controls").trigger("fileuploaddone", data1);
+    await queryAll(".wmd-controls").trigger("fileuploaddone", data1);
     assert.equal(
-      find(".d-editor-input").val(),
+      queryAll(".d-editor-input").val(),
       "![test|200x300](/images/avatar.png?1) ![test|100x200](/images/avatar.png?2) [Uploading: ima++ge.png...]() ![image|300x400](/images/avatar.png?3) "
     );
   });
@@ -242,7 +246,7 @@ acceptance("Composer", function (needs) {
     await fillIn(".d-editor-input", "custom message");
     await click("#reply-control button.create");
     assert.equal(
-      find(".bootbox .modal-body").text(),
+      queryAll(".bootbox .modal-body").text(),
       "This is a custom response"
     );
     assert.equal(currentURL(), "/", "it doesn't change routes");
@@ -273,7 +277,7 @@ acceptance("Composer", function (needs) {
     await fillIn(".d-editor-input", "this is the content of my reply");
     await click("#reply-control button.create");
     assert.equal(
-      find(".cooked:last p").text(),
+      queryAll(".cooked:last p").text(),
       "If you use gettext format you could leverage Launchpad 13 translations and the community behind it."
     );
   });
@@ -291,7 +295,7 @@ acceptance("Composer", function (needs) {
 
     assert.ok(!visible(".bootbox.modal"));
     assert.equal(
-      find(".d-editor-input").val(),
+      queryAll(".d-editor-input").val(),
       "this is the content of my reply"
     );
   });
@@ -311,7 +315,7 @@ acceptance("Composer", function (needs) {
 
     await click(".btn-reply-here");
     assert.equal(
-      find(".cooked:last p").text(),
+      queryAll(".cooked:last p").text(),
       "If you use gettext format you could leverage Launchpad 13 translations and the community behind it."
     );
   });
@@ -319,7 +323,7 @@ acceptance("Composer", function (needs) {
   test("Create an enqueued Reply", async (assert) => {
     await visit("/t/internationalization-localization/280");
 
-    assert.notOk(find(".pending-posts .reviewable-item").length);
+    assert.notOk(queryAll(".pending-posts .reviewable-item").length);
 
     await click("#topic-footer-buttons .btn.create");
     assert.ok(exists(".d-editor-input"), "the composer input is visible");
@@ -331,7 +335,7 @@ acceptance("Composer", function (needs) {
     await fillIn(".d-editor-input", "enqueue this content please");
     await click("#reply-control button.create");
     assert.ok(
-      find(".cooked:last p").text() !== "enqueue this content please",
+      queryAll(".cooked:last p").text() !== "enqueue this content please",
       "it doesn't insert the post"
     );
 
@@ -340,7 +344,7 @@ acceptance("Composer", function (needs) {
     await click(".modal-footer button");
     assert.ok(invisible(".d-modal"), "the modal can be dismissed");
 
-    assert.ok(find(".pending-posts .reviewable-item").length);
+    assert.ok(queryAll(".pending-posts .reviewable-item").length);
   });
 
   test("Edit the first post", async (assert) => {
@@ -354,7 +358,7 @@ acceptance("Composer", function (needs) {
     await click(".topic-post:eq(0) button.show-more-actions");
     await click(".topic-post:eq(0) button.edit");
     assert.equal(
-      find(".d-editor-input").val().indexOf("Any plans to support"),
+      queryAll(".d-editor-input").val().indexOf("Any plans to support"),
       0,
       "it populates the input with the post text"
     );
@@ -368,13 +372,13 @@ acceptance("Composer", function (needs) {
       "it has the edits icon"
     );
     assert.ok(
-      find("#topic-title h1")
+      queryAll("#topic-title h1")
         .text()
         .indexOf("This is the new text for the title") !== -1,
       "it shows the new title"
     );
     assert.ok(
-      find(".topic-post:eq(0) .cooked")
+      queryAll(".topic-post:eq(0) .cooked")
         .text()
         .indexOf("This is the new text for the post") !== -1,
       "it updates the post"
@@ -386,13 +390,13 @@ acceptance("Composer", function (needs) {
 
     await click(".topic-post:eq(0) button.edit");
     assert.equal(
-      find(".d-editor-input").val().indexOf("This is the first post."),
+      queryAll(".d-editor-input").val().indexOf("This is the first post."),
       0,
       "it populates the input with the post text"
     );
     await click(".topic-post:eq(1) button.edit");
     assert.equal(
-      find(".d-editor-input").val().indexOf("This is the second post."),
+      queryAll(".d-editor-input").val().indexOf("This is the second post."),
       0,
       "it populates the input with the post text"
     );
@@ -408,7 +412,7 @@ acceptance("Composer", function (needs) {
 
     await click(".modal-footer a:eq(0)");
     assert.equal(
-      find(".d-editor-input").val().indexOf("This is the second post."),
+      queryAll(".d-editor-input").val().indexOf("This is the second post."),
       0,
       "it populates the input with the post text"
     );
@@ -419,15 +423,15 @@ acceptance("Composer", function (needs) {
 
     await click(".topic-post:eq(0) button.edit");
     assert.equal(
-      find(".d-editor-input").val().indexOf("This is the first post."),
+      queryAll(".d-editor-input").val().indexOf("This is the first post."),
       0,
       "it populates the input with the post text"
     );
     await click(".topic-post:eq(0) button.reply");
-    assert.equal(find(".d-editor-input").val(), "", "it clears the input");
+    assert.equal(queryAll(".d-editor-input").val(), "", "it clears the input");
     await click(".topic-post:eq(0) button.edit");
     assert.equal(
-      find(".d-editor-input").val().indexOf("This is the first post."),
+      queryAll(".d-editor-input").val().indexOf("This is the first post."),
       0,
       "it populates the input with the post text"
     );
@@ -443,7 +447,7 @@ acceptance("Composer", function (needs) {
     await menu.selectRowByValue("toggleWhisper");
 
     assert.ok(
-      find(".composer-fields .whisper .d-icon-far-eye-slash").length === 1,
+      queryAll(".composer-fields .whisper .d-icon-far-eye-slash").length === 1,
       "it sets the post type to whisper"
     );
 
@@ -451,7 +455,7 @@ acceptance("Composer", function (needs) {
     await menu.selectRowByValue("toggleWhisper");
 
     assert.ok(
-      find(".composer-fields .whisper .d-icon-far-eye-slash").length === 0,
+      queryAll(".composer-fields .whisper .d-icon-far-eye-slash").length === 0,
       "it removes the whisper mode"
     );
 
@@ -473,21 +477,21 @@ acceptance("Composer", function (needs) {
     await click(".topic-post:eq(0) button.reply");
 
     assert.ok(
-      find("#reply-control.open").length === 1,
+      queryAll("#reply-control.open").length === 1,
       "it starts in open state by default"
     );
 
     await click(".toggle-fullscreen");
 
     assert.ok(
-      find("#reply-control.fullscreen").length === 1,
+      queryAll("#reply-control.fullscreen").length === 1,
       "it expands composer to full screen"
     );
 
     await click(".toggle-fullscreen");
 
     assert.ok(
-      find("#reply-control.open").length === 1,
+      queryAll("#reply-control.open").length === 1,
       "it collapses composer to regular size"
     );
 
@@ -495,14 +499,14 @@ acceptance("Composer", function (needs) {
     await click(".toggler");
 
     assert.ok(
-      find("#reply-control.draft").length === 1,
+      queryAll("#reply-control.draft").length === 1,
       "it collapses composer to draft bar"
     );
 
     await click(".toggle-fullscreen");
 
     assert.ok(
-      find("#reply-control.open").length === 1,
+      queryAll("#reply-control.open").length === 1,
       "from draft, it expands composer back to open state"
     );
   });
@@ -517,7 +521,7 @@ acceptance("Composer", function (needs) {
     );
 
     assert.ok(
-      find(".composer-fields .whisper .d-icon-far-eye-slash").length === 1,
+      queryAll(".composer-fields .whisper .d-icon-far-eye-slash").length === 1,
       "it sets the post type to whisper"
     );
 
@@ -526,7 +530,7 @@ acceptance("Composer", function (needs) {
 
     await click("#create-topic");
     assert.ok(
-      find(".composer-fields .whisper .d-icon-far-eye-slash").length === 0,
+      queryAll(".composer-fields .whisper .d-icon-far-eye-slash").length === 0,
       "it should reset the state of the composer's model"
     );
 
@@ -536,7 +540,7 @@ acceptance("Composer", function (needs) {
     );
 
     assert.ok(
-      find(".composer-fields .unlist")
+      queryAll(".composer-fields .unlist")
         .text()
         .indexOf(I18n.t("composer.unlist")) > 0,
       "it sets the topic to unlisted"
@@ -546,7 +550,7 @@ acceptance("Composer", function (needs) {
 
     await click(".topic-post:eq(0) button.reply");
     assert.ok(
-      find(".composer-fields .whisper")
+      queryAll(".composer-fields .whisper")
         .text()
         .indexOf(I18n.t("composer.unlist")) === -1,
       "it should reset the state of the composer's model"
@@ -562,7 +566,7 @@ acceptance("Composer", function (needs) {
     assert.ok(exists(".bootbox.modal"), "it pops up a confirmation dialog");
     await click(".modal-footer a:eq(0)");
     assert.equal(
-      find(".d-editor-input").val().indexOf("This is the first post."),
+      queryAll(".d-editor-input").val().indexOf("This is the first post."),
       0,
       "it populates the input with the post text"
     );
@@ -577,12 +581,12 @@ acceptance("Composer", function (needs) {
     await click(".topic-post:eq(1) button.edit");
     assert.ok(exists(".bootbox.modal"), "it pops up a confirmation dialog");
     assert.equal(
-      find(".modal-footer a:eq(1)").text(),
+      queryAll(".modal-footer a:eq(1)").text(),
       I18n.t("post.abandon.no_value")
     );
     await click(".modal-footer a:eq(0)");
     assert.equal(
-      find(".d-editor-input").val().indexOf("This is the second post."),
+      queryAll(".d-editor-input").val().indexOf("This is the second post."),
       0,
       "it populates the input with the post text"
     );
@@ -599,12 +603,12 @@ acceptance("Composer", function (needs) {
 
     assert.ok(exists(".bootbox.modal"), "it pops up a confirmation dialog");
     assert.equal(
-      find(".modal-footer a:eq(1)").text(),
+      queryAll(".modal-footer a:eq(1)").text(),
       I18n.t("post.abandon.no_save_draft")
     );
     await click(".modal-footer a:eq(1)");
     assert.equal(
-      find(".d-editor-input").val(),
+      queryAll(".d-editor-input").val(),
       "",
       "it populates the input with the post text"
     );
@@ -620,7 +624,7 @@ acceptance("Composer", function (needs) {
       await click(".topic-post:eq(0) button.edit");
 
       assert.equal(
-        find(".modal-body").text(),
+        queryAll(".modal-body").text(),
         I18n.t("drafts.abandon.confirm")
       );
 
@@ -656,24 +660,24 @@ acceptance("Composer", function (needs) {
       await composerActions.selectRowByValue("reply_as_private_message");
 
       assert.equal(
-        find(".modal-body").text(),
+        queryAll(".modal-body").text(),
         "",
         "abandon popup shouldn't come"
       );
 
       assert.ok(
-        find(".d-editor-input").val().includes(longText),
+        queryAll(".d-editor-input").val().includes(longText),
         "entered text should still be there"
       );
 
       assert.ok(
-        find(
+        queryAll(
           '.action-title a[href="/t/internationalization-localization/280"]'
         ),
         "mode should have changed"
       );
 
-      assert.ok(find(".save-animation"), "save animation should show");
+      assert.ok(queryAll(".save-animation"), "save animation should show");
     } finally {
       toggleCheckDraftPopup(false);
     }
@@ -696,7 +700,7 @@ acceptance("Composer", function (needs) {
       await click("button.compose-pm");
       await click(".modal .btn-default");
 
-      assert.equal(find(".users-input .item:eq(0)").text(), "codinghorror");
+      assert.equal(queryAll(".users-input .item:eq(0)").text(), "codinghorror");
     } finally {
       toggleCheckDraftPopup(false);
     }
@@ -712,7 +716,7 @@ acceptance("Composer", function (needs) {
     await fillIn(".d-editor-input", "");
 
     assert.equal(
-      find(".d-editor-container textarea").attr("placeholder"),
+      queryAll(".d-editor-container textarea").attr("placeholder"),
       I18n.t("composer.reply_placeholder"),
       "it should not block because of missing category"
     );
@@ -720,7 +724,7 @@ acceptance("Composer", function (needs) {
 
   const assertImageResized = (assert, uploads) => {
     assert.equal(
-      find(".d-editor-input").val(),
+      queryAll(".d-editor-input").val(),
       uploads.join("\n"),
       "it resizes uploaded image"
     );
@@ -761,7 +765,7 @@ acceptance("Composer", function (needs) {
     await fillIn(".d-editor-input", uploads.join("\n"));
 
     assert.ok(
-      find(".button-wrapper").length === 10,
+      queryAll(".button-wrapper").length === 10,
       "it adds correct amount of scaling button groups"
     );
 
@@ -769,7 +773,9 @@ acceptance("Composer", function (needs) {
     uploads[0] =
       "<a href='https://example.com'>![test|690x313, 50%](upload://test.png)</a>";
     await click(
-      find(".button-wrapper[data-image-index='0'] .scale-btn[data-scale='50']")
+      queryAll(
+        ".button-wrapper[data-image-index='0'] .scale-btn[data-scale='50']"
+      )
     );
     assertImageResized(assert, uploads);
 
@@ -777,7 +783,9 @@ acceptance("Composer", function (needs) {
     uploads[6] =
       "![onTheSameLine1|200x200, 50%](upload://onTheSameLine1.jpeg) ![onTheSameLine2|250x250](upload://onTheSameLine2.jpeg)";
     await click(
-      find(".button-wrapper[data-image-index='3'] .scale-btn[data-scale='50']")
+      queryAll(
+        ".button-wrapper[data-image-index='3'] .scale-btn[data-scale='50']"
+      )
     );
     assertImageResized(assert, uploads);
 
@@ -785,35 +793,45 @@ acceptance("Composer", function (needs) {
     uploads[6] =
       "![onTheSameLine1|200x200, 50%](upload://onTheSameLine1.jpeg) ![onTheSameLine2|250x250, 75%](upload://onTheSameLine2.jpeg)";
     await click(
-      find(".button-wrapper[data-image-index='4'] .scale-btn[data-scale='75']")
+      queryAll(
+        ".button-wrapper[data-image-index='4'] .scale-btn[data-scale='75']"
+      )
     );
     assertImageResized(assert, uploads);
 
     // Make sure we target the correct image if there are duplicates
     uploads[7] = "![identicalImage|300x300, 50%](upload://identicalImage.png)";
     await click(
-      find(".button-wrapper[data-image-index='5'] .scale-btn[data-scale='50']")
+      queryAll(
+        ".button-wrapper[data-image-index='5'] .scale-btn[data-scale='50']"
+      )
     );
     assertImageResized(assert, uploads);
 
     // Try the other dupe
     uploads[8] = "![identicalImage|300x300, 75%](upload://identicalImage.png)";
     await click(
-      find(".button-wrapper[data-image-index='6'] .scale-btn[data-scale='75']")
+      queryAll(
+        ".button-wrapper[data-image-index='6'] .scale-btn[data-scale='75']"
+      )
     );
     assertImageResized(assert, uploads);
 
     // Don't mess with image titles
     uploads[10] = `![image|690x220, 75%](upload://test.png "image title")`;
     await click(
-      find(".button-wrapper[data-image-index='8'] .scale-btn[data-scale='75']")
+      queryAll(
+        ".button-wrapper[data-image-index='8'] .scale-btn[data-scale='75']"
+      )
     );
     assertImageResized(assert, uploads);
 
     // Keep data attributes
     uploads[12] = `![test|foo=bar|690x313, 75%|bar=baz](upload://test.png)`;
     await click(
-      find(".button-wrapper[data-image-index='9'] .scale-btn[data-scale='75']")
+      queryAll(
+        ".button-wrapper[data-image-index='9'] .scale-btn[data-scale='75']"
+      )
     );
     assertImageResized(assert, uploads);
 
@@ -827,7 +845,7 @@ acceptance("Composer", function (needs) {
     );
 
     assert.ok(
-      find("script").length === 0,
+      queryAll("script").length === 0,
       "it does not unescapes script tags in code blocks"
     );
   });

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-topic-links-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-topic-links-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
 import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
@@ -16,7 +17,7 @@ acceptance("Composer topic featured links", function (needs) {
     await click("#create-topic");
     await fillIn("#reply-title", "http://www.example.com/has-title.html");
     assert.ok(
-      find(".d-editor-preview").html().trim().indexOf("onebox") > 0,
+      queryAll(".d-editor-preview").html().trim().indexOf("onebox") > 0,
       "it pastes the link into the body and previews it"
     );
     assert.ok(
@@ -24,7 +25,7 @@ acceptance("Composer topic featured links", function (needs) {
       "the body is now good"
     );
     assert.equal(
-      find(".title-input input").val(),
+      queryAll(".title-input input").val(),
       "An interesting article",
       "title is from the oneboxed article"
     );
@@ -35,7 +36,7 @@ acceptance("Composer topic featured links", function (needs) {
     await click("#create-topic");
     await fillIn("#reply-title", "http://www.example.com/no-title.html");
     assert.ok(
-      find(".d-editor-preview").html().trim().indexOf("onebox") > 0,
+      queryAll(".d-editor-preview").html().trim().indexOf("onebox") > 0,
       "it pastes the link into the body and previews it"
     );
     assert.ok(
@@ -43,7 +44,7 @@ acceptance("Composer topic featured links", function (needs) {
       "the body is now good"
     );
     assert.equal(
-      find(".title-input input").val(),
+      queryAll(".title-input input").val(),
       "http://www.example.com/no-title.html",
       "title is unchanged"
     );
@@ -54,7 +55,7 @@ acceptance("Composer topic featured links", function (needs) {
     await click("#create-topic");
     await fillIn("#reply-title", "http://www.example.com/nope-onebox.html");
     assert.ok(
-      find(".d-editor-preview").html().trim().indexOf("onebox") > 0,
+      queryAll(".d-editor-preview").html().trim().indexOf("onebox") > 0,
       "it pastes the link into the body and previews it"
     );
     assert.ok(
@@ -62,7 +63,7 @@ acceptance("Composer topic featured links", function (needs) {
       "link is pasted into body"
     );
     assert.equal(
-      find(".title-input input").val(),
+      queryAll(".title-input input").val(),
       "http://www.example.com/nope-onebox.html",
       "title is unchanged"
     );
@@ -74,16 +75,20 @@ acceptance("Composer topic featured links", function (needs) {
     const title = "http://" + window.location.hostname + "/internal-page.html";
     await fillIn("#reply-title", title);
     assert.equal(
-      find(".d-editor-preview").html().trim().indexOf("onebox"),
+      queryAll(".d-editor-preview").html().trim().indexOf("onebox"),
       -1,
       "onebox preview doesn't show"
     );
     assert.equal(
-      find(".d-editor-input").val().length,
+      queryAll(".d-editor-input").val().length,
       0,
       "link isn't put into the post"
     );
-    assert.equal(find(".title-input input").val(), title, "title is unchanged");
+    assert.equal(
+      queryAll(".title-input input").val(),
+      title,
+      "title is unchanged"
+    );
   });
 
   test("link is longer than max title length", async (assert) => {
@@ -94,7 +99,7 @@ acceptance("Composer topic featured links", function (needs) {
       "http://www.example.com/has-title-and-a-url-that-is-more-than-80-characters-because-thats-good-for-seo-i-guess.html"
     );
     assert.ok(
-      find(".d-editor-preview").html().trim().indexOf("onebox") > 0,
+      queryAll(".d-editor-preview").html().trim().indexOf("onebox") > 0,
       "it pastes the link into the body and previews it"
     );
     assert.ok(
@@ -102,7 +107,7 @@ acceptance("Composer topic featured links", function (needs) {
       "the body is now good"
     );
     assert.equal(
-      find(".title-input input").val(),
+      queryAll(".title-input input").val(),
       "An interesting article",
       "title is from the oneboxed article"
     );
@@ -113,17 +118,17 @@ acceptance("Composer topic featured links", function (needs) {
     await click("#create-topic");
     await fillIn("#reply-title", "http://www.example.com/has-title.html test");
     assert.equal(
-      find(".d-editor-preview").html().trim().indexOf("onebox"),
+      queryAll(".d-editor-preview").html().trim().indexOf("onebox"),
       -1,
       "onebox preview doesn't show"
     );
     assert.equal(
-      find(".d-editor-input").val().length,
+      queryAll(".d-editor-input").val().length,
       0,
       "link isn't put into the post"
     );
     assert.equal(
-      find(".title-input input").val(),
+      queryAll(".title-input input").val(),
       "http://www.example.com/has-title.html test",
       "title is unchanged"
     );
@@ -145,12 +150,12 @@ acceptance(
       await visit("/");
       await click("#create-topic");
       assert.ok(
-        find(".d-editor-textarea-wrapper.disabled").length,
+        queryAll(".d-editor-textarea-wrapper.disabled").length,
         "textarea is disabled"
       );
       await fillIn("#reply-title", "http://www.example.com/has-title.html");
       assert.ok(
-        find(".d-editor-preview").html().trim().indexOf("onebox") > 0,
+        queryAll(".d-editor-preview").html().trim().indexOf("onebox") > 0,
         "it pastes the link into the body and previews it"
       );
       assert.ok(
@@ -158,12 +163,12 @@ acceptance(
         "the body is now good"
       );
       assert.equal(
-        find(".title-input input").val(),
+        queryAll(".title-input input").val(),
         "An interesting article",
         "title is from the oneboxed article"
       );
       assert.ok(
-        find(".d-editor-textarea-wrapper.disabled").length === 0,
+        queryAll(".d-editor-textarea-wrapper.disabled").length === 0,
         "textarea is enabled"
       );
     });

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-uncategorized-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-uncategorized-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
 import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
@@ -36,7 +37,7 @@ acceptance(
       await categoryChooser.selectRowByValue(2);
 
       assert.ok(
-        find(".d-editor-textarea-wrapper.disabled").length === 0,
+        queryAll(".d-editor-textarea-wrapper.disabled").length === 0,
         "textarea is enabled"
       );
 
@@ -45,7 +46,7 @@ acceptance(
       await categoryChooser.selectRowByIndex(0);
 
       assert.ok(
-        find(".d-editor-textarea-wrapper.disabled").length === 0,
+        queryAll(".d-editor-textarea-wrapper.disabled").length === 0,
         "textarea is still enabled"
       );
     });
@@ -88,7 +89,7 @@ acceptance(
         "category errors are hidden by default"
       );
       assert.ok(
-        find(".d-editor-textarea-wrapper.disabled").length === 0,
+        queryAll(".d-editor-textarea-wrapper.disabled").length === 0,
         "textarea is enabled"
       );
 

--- a/app/assets/javascripts/discourse/tests/acceptance/create-account-user-fields-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/create-account-user-fields-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
 import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
@@ -36,7 +37,10 @@ acceptance("Create Account - User Fields", function (needs) {
 
     await click(".modal-footer .btn-primary");
     assert.ok(exists("#modal-alert"), "it shows the required field alert");
-    assert.equal(find("#modal-alert").text(), "Please enter an email address");
+    assert.equal(
+      queryAll("#modal-alert").text(),
+      "Please enter an email address"
+    );
 
     await fillIn("#new-account-name", "Dr. Good Tuna");
     await fillIn("#new-account-password", "cool password bro");
@@ -56,12 +60,12 @@ acceptance("Create Account - User Fields", function (needs) {
     );
 
     await click(".modal-footer .btn-primary");
-    assert.equal(find("#modal-alert")[0].style.display, "");
+    assert.equal(queryAll("#modal-alert")[0].style.display, "");
 
     await fillIn(".user-field input[type=text]:first", "Barky");
     await click(".user-field input[type=checkbox]");
 
     await click(".modal-footer .btn-primary");
-    assert.equal(find("#modal-alert")[0].style.display, "none");
+    assert.equal(queryAll("#modal-alert")[0].style.display, "none");
   });
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/custom-html-set-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/custom-html-set-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
 import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
@@ -16,7 +17,7 @@ acceptance("CustomHTML set", function () {
 
     await visit("/static/faq");
     assert.equal(
-      find("span.custom-html-test").text(),
+      queryAll("span.custom-html-test").text(),
       "HTML",
       "it inserted the markup"
     );
@@ -29,7 +30,7 @@ acceptance("CustomHTML set", function () {
 
     await visit("/static/faq");
     assert.equal(
-      find("span.cookie").text(),
+      queryAll("span.cookie").text(),
       "monster",
       "it inserted the markup"
     );

--- a/app/assets/javascripts/discourse/tests/acceptance/custom-html-template-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/custom-html-template-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
@@ -16,7 +17,7 @@ acceptance("CustomHTML template", function (needs) {
   test("renders custom template", async (assert) => {
     await visit("/static/faq");
     assert.equal(
-      find("span.top-span").text(),
+      queryAll("span.top-span").text(),
       "TOP",
       "it inserted the template"
     );

--- a/app/assets/javascripts/discourse/tests/acceptance/dashboard-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/dashboard-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
 import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
@@ -78,14 +79,16 @@ acceptance("Dashboard", function (needs) {
     await click(".dashboard .navigation-item.reports .navigation-link");
 
     assert.equal(
-      find(".dashboard .reports-index.section .reports-list .report").length,
+      queryAll(".dashboard .reports-index.section .reports-list .report")
+        .length,
       1
     );
 
     await fillIn(".dashboard .filter-reports-input", "flags");
 
     assert.equal(
-      find(".dashboard .reports-index.section .reports-list .report").length,
+      queryAll(".dashboard .reports-index.section .reports-list .report")
+        .length,
       0
     );
 
@@ -93,7 +96,8 @@ acceptance("Dashboard", function (needs) {
     await click(".dashboard .navigation-item.reports .navigation-link");
 
     assert.equal(
-      find(".dashboard .reports-index.section .reports-list .report").length,
+      queryAll(".dashboard .reports-index.section .reports-list .report")
+        .length,
       1,
       "navigating back and forth resets filter"
     );
@@ -101,7 +105,8 @@ acceptance("Dashboard", function (needs) {
     await fillIn(".dashboard .filter-reports-input", "activities");
 
     assert.equal(
-      find(".dashboard .reports-index.section .reports-list .report").length,
+      queryAll(".dashboard .reports-index.section .reports-list .report")
+        .length,
       1,
       "filter is case insensitive"
     );

--- a/app/assets/javascripts/discourse/tests/acceptance/emoji-picker-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/emoji-picker-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
 import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
@@ -32,7 +33,7 @@ acceptance("EmojiPicker", function (needs) {
     await click(".emoji-picker-emoji-area img.emoji[title='grinning']");
 
     assert.equal(
-      find(".d-editor-input").val(),
+      queryAll(".d-editor-input").val(),
       ":grinning:",
       "it adds the emoji code in the editor when selected"
     );
@@ -47,7 +48,7 @@ acceptance("EmojiPicker", function (needs) {
     await click("button.emoji.btn");
     await click(".emoji-picker-emoji-area img.emoji[title='grinning']");
     assert.equal(
-      find(".d-editor-input").val(),
+      queryAll(".d-editor-input").val(),
       "This is a test input :grinning:",
       "it adds the emoji code and a leading whitespace when there is text"
     );
@@ -57,7 +58,7 @@ acceptance("EmojiPicker", function (needs) {
     await click(".emoji-picker-emoji-area img.emoji[title='grinning']");
 
     assert.equal(
-      find(".d-editor-input").val(),
+      queryAll(".d-editor-input").val(),
       "This is a test input :grinning:",
       "it adds the emoji code and no leading whitespace when user already entered whitespace"
     );
@@ -109,14 +110,15 @@ acceptance("EmojiPicker", function (needs) {
     await click(".emoji-picker-emoji-area img.emoji[title='grinning']");
 
     assert.equal(
-      find('.section[data-section="recent"] .section-group img.emoji').length,
+      queryAll('.section[data-section="recent"] .section-group img.emoji')
+        .length,
       2,
       "it has multiple recent emojis"
     );
 
     assert.equal(
       /grinning/.test(
-        find(".section.recent .section-group img.emoji").first().attr("src")
+        queryAll(".section.recent .section-group img.emoji").first().attr("src")
       ),
       true,
       "it puts the last used emoji in first"

--- a/app/assets/javascripts/discourse/tests/acceptance/emoji-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/emoji-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { IMAGE_VERSION as v } from "pretty-text/emoji/version";
@@ -12,7 +13,7 @@ acceptance("Emoji", function (needs) {
 
     await fillIn(".d-editor-input", "this is an emoji :blonde_woman:");
     assert.equal(
-      find(".d-editor-preview:visible").html().trim(),
+      queryAll(".d-editor-preview:visible").html().trim(),
       `<p>this is an emoji <img src="/images/emoji/emoji_one/blonde_woman.png?v=${v}" title=":blonde_woman:" class="emoji" alt=":blonde_woman:"></p>`
     );
   });
@@ -23,7 +24,7 @@ acceptance("Emoji", function (needs) {
 
     await fillIn(".d-editor-input", "this is an emoji :blonde_woman:t5:");
     assert.equal(
-      find(".d-editor-preview:visible").html().trim(),
+      queryAll(".d-editor-preview:visible").html().trim(),
       `<p>this is an emoji <img src="/images/emoji/emoji_one/blonde_woman/5.png?v=${v}" title=":blonde_woman:t5:" class="emoji" alt=":blonde_woman:t5:"></p>`
     );
   });

--- a/app/assets/javascripts/discourse/tests/acceptance/enforce-second-factor-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/enforce-second-factor-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import {
@@ -23,7 +24,7 @@ acceptance("Enforce Second Factor", function (needs) {
     await visit("/u/eviltrout/summary");
 
     assert.equal(
-      find(".control-label").text(),
+      queryAll(".control-label").text(),
       "Password",
       "it will not transition from second-factor preferences"
     );
@@ -32,7 +33,7 @@ acceptance("Enforce Second Factor", function (needs) {
     await click("a.admin-link");
 
     assert.equal(
-      find(".control-label").text(),
+      queryAll(".control-label").text(),
       "Password",
       "it stays at second-factor preferences"
     );
@@ -47,7 +48,7 @@ acceptance("Enforce Second Factor", function (needs) {
     await visit("/u/eviltrout/summary");
 
     assert.equal(
-      find(".control-label").text(),
+      queryAll(".control-label").text(),
       "Password",
       "it will not transition from second-factor preferences"
     );
@@ -56,7 +57,7 @@ acceptance("Enforce Second Factor", function (needs) {
     await click("a.about-link");
 
     assert.equal(
-      find(".control-label").text(),
+      queryAll(".control-label").text(),
       "Password",
       "it stays at second-factor preferences"
     );
@@ -72,7 +73,7 @@ acceptance("Enforce Second Factor", function (needs) {
     await visit("/u/eviltrout/summary");
 
     assert.notEqual(
-      find(".control-label").text(),
+      queryAll(".control-label").text(),
       "Password",
       "it will transition from second-factor preferences"
     );
@@ -81,7 +82,7 @@ acceptance("Enforce Second Factor", function (needs) {
     await click("a.about-link");
 
     assert.notEqual(
-      find(".control-label").text(),
+      queryAll(".control-label").text(),
       "Password",
       "it is possible to navigate to other pages"
     );

--- a/app/assets/javascripts/discourse/tests/acceptance/flag-post-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/flag-post-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
 import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
@@ -112,7 +113,7 @@ acceptance("flagging", function (needs) {
     await silenceUntilCombobox.selectRowByValue("tomorrow");
     await fillIn(".silence-reason", "for breaking the rules");
     await click(".perform-silence");
-    assert.equal(find(".bootbox.modal:visible").length, 0);
+    assert.equal(queryAll(".bootbox.modal:visible").length, 0);
   });
 
   test("Gets dismissable warning from canceling incomplete silence from take action", async (assert) => {
@@ -127,16 +128,16 @@ acceptance("flagging", function (needs) {
     await silenceUntilCombobox.selectRowByValue("tomorrow");
     await fillIn(".silence-reason", "for breaking the rules");
     await click(".d-modal-cancel");
-    assert.equal(find(".bootbox.modal:visible").length, 1);
+    assert.equal(queryAll(".bootbox.modal:visible").length, 1);
 
     await click(".modal-footer .btn-default");
-    assert.equal(find(".bootbox.modal:visible").length, 0);
+    assert.equal(queryAll(".bootbox.modal:visible").length, 0);
     assert.ok(exists(".silence-user-modal"), "it shows the silence modal");
 
     await click(".d-modal-cancel");
-    assert.equal(find(".bootbox.modal:visible").length, 1);
+    assert.equal(queryAll(".bootbox.modal:visible").length, 1);
 
     await click(".modal-footer .btn-primary");
-    assert.equal(find(".bootbox.modal:visible").length, 0);
+    assert.equal(queryAll(".bootbox.modal:visible").length, 0);
   });
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/forgot-password-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/forgot-password-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
 import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
@@ -21,7 +22,7 @@ acceptance("Forgot password", function (needs) {
     await click("#forgot-password-link");
 
     assert.equal(
-      find(".forgot-password-reset").attr("disabled"),
+      queryAll(".forgot-password-reset").attr("disabled"),
       "disabled",
       "it should disable the button until the field is filled"
     );
@@ -30,7 +31,7 @@ acceptance("Forgot password", function (needs) {
     await click(".forgot-password-reset");
 
     assert.equal(
-      find(".alert-error").html().trim(),
+      queryAll(".alert-error").html().trim(),
       I18n.t("forgot_password.complete_username_not_found", {
         username: "someuser",
       }),
@@ -41,7 +42,7 @@ acceptance("Forgot password", function (needs) {
     await click(".forgot-password-reset");
 
     assert.equal(
-      find(".alert-error").html().trim(),
+      queryAll(".alert-error").html().trim(),
       I18n.t("forgot_password.complete_email_not_found", {
         email: "someuser@gmail.com",
       }),
@@ -55,12 +56,12 @@ acceptance("Forgot password", function (needs) {
     await click(".forgot-password-reset");
 
     assert.notOk(
-      exists(find(".alert-error")),
+      exists(queryAll(".alert-error")),
       "it should remove the flash error when succeeding"
     );
 
     assert.equal(
-      find(".modal-body").html().trim(),
+      queryAll(".modal-body").html().trim(),
       I18n.t("forgot_password.complete_username_found", {
         username: "someuser",
       }),
@@ -74,7 +75,7 @@ acceptance("Forgot password", function (needs) {
     await click(".forgot-password-reset");
 
     assert.equal(
-      find(".modal-body").html().trim(),
+      queryAll(".modal-body").html().trim(),
       I18n.t("forgot_password.complete_email_found", {
         email: "someuser@gmail.com",
       }),

--- a/app/assets/javascripts/discourse/tests/acceptance/group-index-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-index-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import I18n from "I18n";
@@ -23,7 +24,7 @@ acceptance("Group Members - Anonymous", function () {
     );
 
     assert.equal(
-      find(".group-username-filter").attr("placeholder"),
+      queryAll(".group-username-filter").attr("placeholder"),
       I18n.t("groups.members.filter_placeholder"),
       "it should display the right filter placehodler"
     );
@@ -40,7 +41,7 @@ acceptance("Group Members", function (needs) {
     await click(".group-members-add");
 
     assert.equal(
-      find("#group-add-members-user-selector").length,
+      queryAll("#group-add-members-user-selector").length,
       1,
       "it should display the add members modal"
     );
@@ -55,7 +56,7 @@ acceptance("Group Members", function (needs) {
     );
 
     assert.equal(
-      find(".group-username-filter").attr("placeholder"),
+      queryAll(".group-username-filter").attr("placeholder"),
       I18n.t("groups.members.filter_placeholder_admin"),
       "it should display the right filter placehodler"
     );

--- a/app/assets/javascripts/discourse/tests/acceptance/group-manage-categories-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-manage-categories-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import {
@@ -23,7 +24,7 @@ acceptance("Managing Group Category Notification Defaults", function (needs) {
     await visit("/g/discourse/manage/categories");
 
     assert.ok(
-      find(".groups-notifications-form .category-selector").length === 5,
+      queryAll(".groups-notifications-form .category-selector").length === 5,
       "it should display category inputs"
     );
   });
@@ -34,7 +35,7 @@ acceptance("Managing Group Category Notification Defaults", function (needs) {
     await visit("/g/discourse/manage/categories");
 
     assert.ok(
-      find(".groups-notifications-form .category-selector").length === 5,
+      queryAll(".groups-notifications-form .category-selector").length === 5,
       "it should display category inputs"
     );
   });

--- a/app/assets/javascripts/discourse/tests/acceptance/group-manage-interaction-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-manage-interaction-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import {
@@ -19,31 +20,31 @@ acceptance("Managing Group Interaction Settings", function (needs) {
     await visit("/g/alternative-group/manage/interaction");
 
     assert.equal(
-      find(".groups-form-visibility-level").length,
+      queryAll(".groups-form-visibility-level").length,
       1,
       "it should display visibility level selector"
     );
 
     assert.equal(
-      find(".groups-form-mentionable-level").length,
+      queryAll(".groups-form-mentionable-level").length,
       1,
       "it should display mentionable level selector"
     );
 
     assert.equal(
-      find(".groups-form-messageable-level").length,
+      queryAll(".groups-form-messageable-level").length,
       1,
       "it should display messageable level selector"
     );
 
     assert.equal(
-      find(".groups-form-incoming-email").length,
+      queryAll(".groups-form-incoming-email").length,
       1,
       "it should display incoming email input"
     );
 
     assert.equal(
-      find(".groups-form-default-notification-level").length,
+      queryAll(".groups-form-default-notification-level").length,
       1,
       "it should display default notification level input"
     );
@@ -59,31 +60,31 @@ acceptance("Managing Group Interaction Settings", function (needs) {
     await visit("/g/discourse/manage/interaction");
 
     assert.equal(
-      find(".groups-form-visibility-level").length,
+      queryAll(".groups-form-visibility-level").length,
       0,
       "it should not display visibility level selector"
     );
 
     assert.equal(
-      find(".groups-form-mentionable-level").length,
+      queryAll(".groups-form-mentionable-level").length,
       1,
       "it should display mentionable level selector"
     );
 
     assert.equal(
-      find(".groups-form-messageable-level").length,
+      queryAll(".groups-form-messageable-level").length,
       1,
       "it should display messageable level selector"
     );
 
     assert.equal(
-      find(".groups-form-incoming-email").length,
+      queryAll(".groups-form-incoming-email").length,
       0,
       "it should not display incoming email input"
     );
 
     assert.equal(
-      find(".groups-form-default-notification-level").length,
+      queryAll(".groups-form-default-notification-level").length,
       1,
       "it should display default notification level input"
     );

--- a/app/assets/javascripts/discourse/tests/acceptance/group-manage-logs-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-manage-logs-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
@@ -96,13 +97,13 @@ acceptance("Group logs", function (needs) {
   test("Browsing group logs", async (assert) => {
     await visit("/g/snorlax/manage/logs");
     assert.ok(
-      find("tr.group-manage-logs-row").length === 2,
+      queryAll("tr.group-manage-logs-row").length === 2,
       "it should display the right number of logs"
     );
 
-    await click(find(".group-manage-logs-row button")[0]);
+    await click(queryAll(".group-manage-logs-row button")[0]);
     assert.ok(
-      find("tr.group-manage-logs-row").length === 1,
+      queryAll("tr.group-manage-logs-row").length === 1,
       "it should display the right number of logs"
     );
   });

--- a/app/assets/javascripts/discourse/tests/acceptance/group-manage-membership-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-manage-membership-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import {
@@ -15,37 +16,37 @@ acceptance("Managing Group Membership", function (needs) {
     await visit("/g/alternative-group/manage/membership");
 
     assert.ok(
-      find('label[for="automatic_membership"]').length === 1,
+      queryAll('label[for="automatic_membership"]').length === 1,
       "it should display automatic membership label"
     );
 
     assert.ok(
-      find(".groups-form-primary-group").length === 1,
+      queryAll(".groups-form-primary-group").length === 1,
       "it should display set as primary group checkbox"
     );
 
     assert.ok(
-      find(".groups-form-grant-trust-level").length === 1,
+      queryAll(".groups-form-grant-trust-level").length === 1,
       "it should display grant trust level selector"
     );
 
     assert.ok(
-      find(".group-form-public-admission").length === 1,
+      queryAll(".group-form-public-admission").length === 1,
       "it should display group public admission input"
     );
 
     assert.ok(
-      find(".group-form-public-exit").length === 1,
+      queryAll(".group-form-public-exit").length === 1,
       "it should display group public exit input"
     );
 
     assert.ok(
-      find(".group-form-allow-membership-requests").length === 1,
+      queryAll(".group-form-allow-membership-requests").length === 1,
       "it should display group allow_membership_request input"
     );
 
     assert.ok(
-      find(".group-form-allow-membership-requests[disabled]").length === 1,
+      queryAll(".group-form-allow-membership-requests[disabled]").length === 1,
       "it should disable group allow_membership_request input"
     );
 
@@ -53,17 +54,17 @@ acceptance("Managing Group Membership", function (needs) {
     await click(".group-form-allow-membership-requests");
 
     assert.ok(
-      find(".group-form-public-admission[disabled]").length === 1,
+      queryAll(".group-form-public-admission[disabled]").length === 1,
       "it should disable group public admission input"
     );
 
     assert.ok(
-      find(".group-form-public-exit[disabled]").length === 0,
+      queryAll(".group-form-public-exit[disabled]").length === 0,
       "it should not disable group public exit input"
     );
 
     assert.equal(
-      find(".group-form-membership-request-template").length,
+      queryAll(".group-form-membership-request-template").length,
       1,
       "it should display the membership request template field"
     );
@@ -84,42 +85,42 @@ acceptance("Managing Group Membership", function (needs) {
     await visit("/g/discourse/manage/membership");
 
     assert.ok(
-      find('label[for="automatic_membership"]').length === 0,
+      queryAll('label[for="automatic_membership"]').length === 0,
       "it should not display automatic membership label"
     );
 
     assert.ok(
-      find(".groups-form-automatic-membership-retroactive").length === 0,
+      queryAll(".groups-form-automatic-membership-retroactive").length === 0,
       "it should not display automatic membership retroactive checkbox"
     );
 
     assert.ok(
-      find(".groups-form-primary-group").length === 0,
+      queryAll(".groups-form-primary-group").length === 0,
       "it should not display set as primary group checkbox"
     );
 
     assert.ok(
-      find(".groups-form-grant-trust-level").length === 0,
+      queryAll(".groups-form-grant-trust-level").length === 0,
       "it should not display grant trust level selector"
     );
 
     assert.ok(
-      find(".group-form-public-admission").length === 1,
+      queryAll(".group-form-public-admission").length === 1,
       "it should display group public admission input"
     );
 
     assert.ok(
-      find(".group-form-public-exit").length === 1,
+      queryAll(".group-form-public-exit").length === 1,
       "it should display group public exit input"
     );
 
     assert.ok(
-      find(".group-form-allow-membership-requests").length === 1,
+      queryAll(".group-form-allow-membership-requests").length === 1,
       "it should display group allow_membership_request input"
     );
 
     assert.ok(
-      find(".group-form-allow-membership-requests[disabled]").length === 1,
+      queryAll(".group-form-allow-membership-requests[disabled]").length === 1,
       "it should disable group allow_membership_request input"
     );
   });

--- a/app/assets/javascripts/discourse/tests/acceptance/group-manage-profile-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-manage-profile-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import {
@@ -24,19 +25,19 @@ acceptance("Managing Group Profile", function (needs) {
     await visit("/g/discourse/manage/profile");
 
     assert.ok(
-      find(".group-flair-inputs").length === 1,
+      queryAll(".group-flair-inputs").length === 1,
       "it should display avatar flair inputs"
     );
     assert.ok(
-      find(".group-form-bio").length === 1,
+      queryAll(".group-form-bio").length === 1,
       "it should display group bio input"
     );
     assert.ok(
-      find(".group-form-name").length === 1,
+      queryAll(".group-form-name").length === 1,
       "it should display group name input"
     );
     assert.ok(
-      find(".group-form-full-name").length === 1,
+      queryAll(".group-form-full-name").length === 1,
       "it should display group full name input"
     );
   });
@@ -51,7 +52,7 @@ acceptance("Managing Group Profile", function (needs) {
     await visit("/g/discourse/manage/profile");
 
     assert.equal(
-      find(".group-form-name").length,
+      queryAll(".group-form-name").length,
       0,
       "it should not display group name input"
     );

--- a/app/assets/javascripts/discourse/tests/acceptance/group-manage-tags-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-manage-tags-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import {
@@ -24,7 +25,7 @@ acceptance("Managing Group Tag Notification Defaults", function (needs) {
     await visit("/g/discourse/manage/tags");
 
     assert.ok(
-      find(".groups-notifications-form .tag-chooser").length === 5,
+      queryAll(".groups-notifications-form .tag-chooser").length === 5,
       "it should display tag inputs"
     );
   });
@@ -35,7 +36,7 @@ acceptance("Managing Group Tag Notification Defaults", function (needs) {
     await visit("/g/discourse/manage/tags");
 
     assert.ok(
-      find(".groups-notifications-form .tag-chooser").length === 5,
+      queryAll(".groups-notifications-form .tag-chooser").length === 5,
       "it should display tag inputs"
     );
   });

--- a/app/assets/javascripts/discourse/tests/acceptance/group-requests-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-requests-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
@@ -85,30 +86,30 @@ acceptance("Group Requests", function (needs) {
   test("Group Requests", async (assert) => {
     await visit("/g/Macdonald/requests");
 
-    assert.equal(find(".group-members tr").length, 2);
+    assert.equal(queryAll(".group-members tr").length, 2);
     assert.equal(
-      find(".group-members tr:first-child td:nth-child(1)")
+      queryAll(".group-members tr:first-child td:nth-child(1)")
         .text()
         .trim()
         .replace(/\s+/g, " "),
       "eviltrout Robin Ward"
     );
     assert.equal(
-      find(".group-members tr:first-child td:nth-child(3)").text().trim(),
+      queryAll(".group-members tr:first-child td:nth-child(3)").text().trim(),
       "Please accept my membership request."
     );
     assert.equal(
-      find(".group-members tr:first-child .btn-primary").text().trim(),
+      queryAll(".group-members tr:first-child .btn-primary").text().trim(),
       "Accept"
     );
     assert.equal(
-      find(".group-members tr:first-child .btn-danger").text().trim(),
+      queryAll(".group-members tr:first-child .btn-danger").text().trim(),
       "Deny"
     );
 
     await click(".group-members tr:first-child .btn-primary");
     assert.ok(
-      find(".group-members tr:first-child td:nth-child(4)")
+      queryAll(".group-members tr:first-child td:nth-child(4)")
         .text()
         .trim()
         .indexOf("accepted") === 0
@@ -117,7 +118,7 @@ acceptance("Group Requests", function (needs) {
 
     await click(".group-members tr:last-child .btn-danger");
     assert.equal(
-      find(".group-members tr:last-child td:nth-child(4)").text().trim(),
+      queryAll(".group-members tr:last-child td:nth-child(4)").text().trim(),
       "denied"
     );
     assert.deepEqual(requests, [

--- a/app/assets/javascripts/discourse/tests/acceptance/group-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import I18n from "I18n";
@@ -35,18 +36,18 @@ acceptance("Group - Anonymous", function (needs) {
 
     await click(".activity-nav li a[href='/g/discourse/activity/topics']");
 
-    assert.ok(find(".topic-list"), "it shows the topic list");
+    assert.ok(queryAll(".topic-list"), "it shows the topic list");
     assert.equal(count(".topic-list-item"), 2, "it lists stream items");
 
     await click(".activity-nav li a[href='/g/discourse/activity/mentions']");
 
     assert.ok(count(".user-stream-item") > 0, "it lists stream items");
     assert.ok(
-      find(".nav-pills li a[title='Edit Group']").length === 0,
+      queryAll(".nav-pills li a[title='Edit Group']").length === 0,
       "it should not show messages tab if user is not admin"
     );
     assert.ok(
-      find(".nav-pills li a[title='Logs']").length === 0,
+      queryAll(".nav-pills li a[title='Logs']").length === 0,
       "it should not show Logs tab if user is not admin"
     );
     assert.ok(count(".user-stream-item") > 0, "it lists stream items");
@@ -69,7 +70,7 @@ acceptance("Group - Anonymous", function (needs) {
     await groupDropdown.expand();
 
     assert.equal(
-      find(".group-dropdown-filter").length,
+      queryAll(".group-dropdown-filter").length,
       0,
       "it should not display the default header"
     );
@@ -189,19 +190,19 @@ acceptance("Group - Authenticated", function (needs) {
     await click(".group-index-request");
 
     assert.equal(
-      find(".modal-header").text().trim(),
+      queryAll(".modal-header").text().trim(),
       I18n.t("groups.membership_request.title", { group_name: "Macdonald" })
     );
 
     assert.equal(
-      find(".request-group-membership-form textarea").val(),
+      queryAll(".request-group-membership-form textarea").val(),
       "Please add me"
     );
 
     await click(".modal-footer .btn-primary");
 
     assert.equal(
-      find(".fancy-title").text().trim(),
+      queryAll(".fancy-title").text().trim(),
       "Internationalization / localization"
     );
 
@@ -211,7 +212,7 @@ acceptance("Group - Authenticated", function (needs) {
 
     assert.ok(count("#reply-control") === 1, "it opens the composer");
     assert.equal(
-      find(".ac-wrap .item").text(),
+      queryAll(".ac-wrap .item").text(),
       "discourse",
       "it prefills the group name"
     );
@@ -222,7 +223,7 @@ acceptance("Group - Authenticated", function (needs) {
     await click(".nav-pills li a[title='Messages']");
 
     assert.equal(
-      find(".alert").text().trim(),
+      queryAll(".alert").text().trim(),
       I18n.t("choose_topic.none_found"),
       "it should display the right alert"
     );
@@ -233,7 +234,7 @@ acceptance("Group - Authenticated", function (needs) {
     await click(".nav-pills li a[title='Messages']");
 
     assert.equal(
-      find(".topic-list-item .link-top-line").text().trim(),
+      queryAll(".topic-list-item .link-top-line").text().trim(),
       "This is a private message 1",
       "it should display the list of group topics"
     );
@@ -243,7 +244,7 @@ acceptance("Group - Authenticated", function (needs) {
     await visit("/g/discourse");
 
     assert.ok(
-      find(".nav-pills li a[title='Manage']").length === 1,
+      queryAll(".nav-pills li a[title='Manage']").length === 1,
       "it should show manage group tab if user is admin"
     );
 
@@ -253,7 +254,7 @@ acceptance("Group - Authenticated", function (needs) {
       "it displays show group message button"
     );
     assert.equal(
-      find(".group-info-name").text(),
+      queryAll(".group-info-name").text(),
       "Awesome Team",
       "it should display the group name"
     );
@@ -263,14 +264,14 @@ acceptance("Group - Authenticated", function (needs) {
     await visit("/g/alternative-group");
 
     assert.ok(
-      find(".nav-pills li a[title='Manage']").length === 1,
+      queryAll(".nav-pills li a[title='Manage']").length === 1,
       "it should show manage group tab if user can_admin_group"
     );
 
     await click(".group-members-add.btn");
 
     assert.ok(
-      find(".group-add-members-modal .group-add-members-make-owner"),
+      queryAll(".group-add-members-modal .group-add-members-make-owner"),
       "it allows moderators to set group owners"
     );
 

--- a/app/assets/javascripts/discourse/tests/acceptance/groups-index-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/groups-index-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
 import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
@@ -17,12 +18,12 @@ acceptance("Groups", function () {
 
     assert.equal(count(".group-box"), 2, "it displays visible groups");
     assert.equal(
-      find(".group-index-join").length,
+      queryAll(".group-index-join").length,
       1,
       "it shows button to join group"
     );
     assert.equal(
-      find(".group-index-request").length,
+      queryAll(".group-index-request").length,
       1,
       "it shows button to request for group membership"
     );
@@ -42,7 +43,7 @@ acceptance("Groups", function () {
     await click("a[href='/g/discourse/members']");
 
     assert.equal(
-      find(".group-info-name").text().trim(),
+      queryAll(".group-info-name").text().trim(),
       "Awesome Team",
       "it displays the group page"
     );

--- a/app/assets/javascripts/discourse/tests/acceptance/groups-new-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/groups-new-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import I18n from "I18n";
@@ -8,7 +9,7 @@ acceptance("New Group - Anonymous", function () {
     await visit("/g");
 
     assert.equal(
-      find(".groups-header-new").length,
+      queryAll(".groups-header-new").length,
       0,
       "it should not display the button to create a group"
     );
@@ -22,7 +23,7 @@ acceptance("New Group - Authenticated", function (needs) {
     await click(".groups-header-new");
 
     assert.equal(
-      find(".group-form-save[disabled]").length,
+      queryAll(".group-form-save[disabled]").length,
       1,
       "save button should be disabled"
     );
@@ -30,13 +31,13 @@ acceptance("New Group - Authenticated", function (needs) {
     await fillIn("input[name='name']", "1");
 
     assert.equal(
-      find(".tip.bad").text().trim(),
+      queryAll(".tip.bad").text().trim(),
       I18n.t("admin.groups.new.name.too_short"),
       "it should show the right validation tooltip"
     );
 
     assert.ok(
-      find(".group-form-save:disabled").length === 1,
+      queryAll(".group-form-save:disabled").length === 1,
       "it should disable the save button"
     );
 
@@ -46,7 +47,7 @@ acceptance("New Group - Authenticated", function (needs) {
     );
 
     assert.equal(
-      find(".tip.bad").text().trim(),
+      queryAll(".tip.bad").text().trim(),
       I18n.t("admin.groups.new.name.too_long"),
       "it should show the right validation tooltip"
     );
@@ -54,7 +55,7 @@ acceptance("New Group - Authenticated", function (needs) {
     await fillIn("input[name='name']", "");
 
     assert.equal(
-      find(".tip.bad").text().trim(),
+      queryAll(".tip.bad").text().trim(),
       I18n.t("admin.groups.new.name.blank"),
       "it should show the right validation tooltip"
     );
@@ -62,7 +63,7 @@ acceptance("New Group - Authenticated", function (needs) {
     await fillIn("input[name='name']", "goodusername");
 
     assert.equal(
-      find(".tip.good").text().trim(),
+      queryAll(".tip.good").text().trim(),
       I18n.t("admin.groups.new.name.available"),
       "it should show the right validation tooltip"
     );
@@ -70,7 +71,7 @@ acceptance("New Group - Authenticated", function (needs) {
     await click(".group-form-public-admission");
 
     assert.equal(
-      find("groups-new-allow-membership-requests").length,
+      queryAll("groups-new-allow-membership-requests").length,
       0,
       "it should disable the membership requests checkbox"
     );

--- a/app/assets/javascripts/discourse/tests/acceptance/hamburger-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/hamburger-menu-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import {
@@ -18,6 +19,9 @@ acceptance("Opening the hamburger menu with some reviewables", function (
     await visit("/");
     await click(".hamburger-dropdown");
 
-    assert.equal(find(".review .badge-notification.reviewables").text(), "3");
+    assert.equal(
+      queryAll(".review .badge-notification.reviewables").text(),
+      "3"
+    );
   });
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/hashtags-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/hashtags-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
@@ -31,7 +32,7 @@ category vs tag: #bug vs #bug::tag`
     );
 
     assert.equal(
-      find(".d-editor-preview:visible").html().trim(),
+      queryAll(".d-editor-preview:visible").html().trim(),
       `<p>this is a category hashtag <a href="/c/bugs" class="hashtag">#<span>bug</span></a></p>
 <p>this is a tag hashtag <a href="/tag/monkey" class="hashtag">#<span>monkey</span></a></p>
 <p>category vs tag: <a href="/c/bugs" class="hashtag">#<span>bug</span></a> vs <a href="/tag/bug" class="hashtag">#<span>bug</span></a></p>`

--- a/app/assets/javascripts/discourse/tests/acceptance/invite-accept-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/invite-accept-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
 import { fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
@@ -25,7 +26,7 @@ acceptance("Invite Accept", function (needs) {
     assert.ok(exists("#new-account-email"), "shows the email input");
     assert.ok(exists("#new-account-username"), "shows the username input");
     assert.equal(
-      find("#new-account-username").val(),
+      queryAll("#new-account-username").val(),
       "invited",
       "username is prefilled"
     );

--- a/app/assets/javascripts/discourse/tests/acceptance/login-with-email-and-hide-email-address-taken-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/login-with-email-and-hide-email-address-taken-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import I18n from "I18n";
@@ -22,7 +23,7 @@ acceptance("Login with email - hide email address taken", function (needs) {
     await click(".login-with-email-button");
 
     assert.equal(
-      find(".alert-success").html().trim(),
+      queryAll(".alert-success").html().trim(),
       I18n.t("email_login.complete_email_found", {
         email: "someuser@example.com",
       }),

--- a/app/assets/javascripts/discourse/tests/acceptance/login-with-email-and-no-social-logins-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/login-with-email-and-no-social-logins-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
 import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
@@ -19,6 +20,6 @@ acceptance("Login with email - no social logins", function (needs) {
     await visit("/");
     await click("header .login-button");
 
-    assert.notOk(find(".login-buttons").is(":visible"));
+    assert.notOk(queryAll(".login-buttons").is(":visible"));
   });
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/login-with-email-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/login-with-email-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
 import { fillIn, click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
@@ -35,7 +36,7 @@ acceptance("Login with email", function (needs) {
     await click(".login-with-email-button");
 
     assert.equal(
-      find(".alert-error").html(),
+      queryAll(".alert-error").html(),
       I18n.t("email_login.complete_username_not_found", {
         username: "someuser",
       }),
@@ -46,7 +47,7 @@ acceptance("Login with email", function (needs) {
     await click(".login-with-email-button");
 
     assert.equal(
-      find(".alert-error").html(),
+      queryAll(".alert-error").html(),
       I18n.t("email_login.complete_email_not_found", {
         email: "someuser@gmail.com",
       }),
@@ -60,7 +61,7 @@ acceptance("Login with email", function (needs) {
     await click(".login-with-email-button");
 
     assert.equal(
-      find(".alert-success").html().trim(),
+      queryAll(".alert-success").html().trim(),
       I18n.t("email_login.complete_username_found", { username: "someuser" }),
       "it should display a success message for a valid username"
     );
@@ -71,7 +72,7 @@ acceptance("Login with email", function (needs) {
     await click(".login-with-email-button");
 
     assert.equal(
-      find(".alert-success").html().trim(),
+      queryAll(".alert-success").html().trim(),
       I18n.t("email_login.complete_email_found", {
         email: "someuser@gmail.com",
       }),

--- a/app/assets/javascripts/discourse/tests/acceptance/modal-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/modal-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import I18n from "I18n";
@@ -30,29 +31,32 @@ acceptance("Modal", function (needs) {
     await visit("/");
 
     assert.ok(
-      find(".d-modal:visible").length === 0,
+      queryAll(".d-modal:visible").length === 0,
       "there is no modal at first"
     );
 
     await click(".login-button");
-    assert.ok(find(".d-modal:visible").length === 1, "modal should appear");
+    assert.ok(queryAll(".d-modal:visible").length === 1, "modal should appear");
 
     let controller = controllerFor("modal");
     assert.equal(controller.name, "login");
 
     await click(".modal-outer-container");
     assert.ok(
-      find(".d-modal:visible").length === 0,
+      queryAll(".d-modal:visible").length === 0,
       "modal should disappear when you click outside"
     );
     assert.equal(controller.name, null);
 
     await click(".login-button");
-    assert.ok(find(".d-modal:visible").length === 1, "modal should reappear");
+    assert.ok(
+      queryAll(".d-modal:visible").length === 1,
+      "modal should reappear"
+    );
 
     await keyEvent("#main-outlet", "keyup", 27);
     assert.ok(
-      find(".d-modal:visible").length === 0,
+      queryAll(".d-modal:visible").length === 0,
       "ESC should close the modal"
     );
 
@@ -62,16 +66,16 @@ acceptance("Modal", function (needs) {
 
     run(() => showModal("not-dismissable", {}));
 
-    assert.ok(find(".d-modal:visible").length === 1, "modal should appear");
+    assert.ok(queryAll(".d-modal:visible").length === 1, "modal should appear");
 
     await click(".modal-outer-container");
     assert.ok(
-      find(".d-modal:visible").length === 1,
+      queryAll(".d-modal:visible").length === 1,
       "modal should not disappear when you click outside"
     );
     await keyEvent("#main-outlet", "keyup", 27);
     assert.ok(
-      find(".d-modal:visible").length === 1,
+      queryAll(".d-modal:visible").length === 1,
       "ESC should not close the modal"
     );
   });
@@ -87,7 +91,7 @@ acceptance("Modal", function (needs) {
     run(() => showModal("test-raw-title-panels", { panels }));
 
     assert.equal(
-      find(".d-modal .modal-tab:first-child").text().trim(),
+      queryAll(".d-modal .modal-tab:first-child").text().trim(),
       "Test 1",
       "it should display the raw title"
     );
@@ -103,7 +107,7 @@ acceptance("Modal", function (needs) {
 
     run(() => showModal("test-title", { title: "test_title" }));
     assert.equal(
-      find(".d-modal .title").text().trim(),
+      queryAll(".d-modal .title").text().trim(),
       "Test title",
       "it should display the title"
     );
@@ -112,7 +116,7 @@ acceptance("Modal", function (needs) {
 
     run(() => showModal("test-title-with-body", { title: "test_title" }));
     assert.equal(
-      find(".d-modal .title").text().trim(),
+      queryAll(".d-modal .title").text().trim(),
       "Test title",
       "it should display the title when used with d-modal-body"
     );
@@ -121,7 +125,7 @@ acceptance("Modal", function (needs) {
 
     run(() => showModal("test-title"));
     assert.ok(
-      find(".d-modal .title").length === 0,
+      queryAll(".d-modal .title").length === 0,
       "it should not re-use the previous title"
     );
   });
@@ -138,17 +142,17 @@ acceptance("Modal Keyboard Events", function (needs) {
     await keyEvent(".d-modal", "keyup", 13);
 
     assert.ok(
-      find("#modal-alert:visible").length === 1,
+      queryAll("#modal-alert:visible").length === 1,
       "hitting Enter triggers modal action"
     );
     assert.ok(
-      find(".d-modal:visible").length === 1,
+      queryAll(".d-modal:visible").length === 1,
       "hitting Enter does not dismiss modal due to alert error"
     );
 
     await keyEvent("#main-outlet", "keyup", 27);
     assert.ok(
-      find(".d-modal:visible").length === 0,
+      queryAll(".d-modal:visible").length === 0,
       "ESC should close the modal"
     );
 
@@ -158,7 +162,7 @@ acceptance("Modal Keyboard Events", function (needs) {
 
     await keyEvent(".d-modal", "keyup", 13);
     assert.ok(
-      find(".d-modal:visible").length === 0,
+      queryAll(".d-modal:visible").length === 0,
       "modal should disappear on hitting Enter"
     );
   });

--- a/app/assets/javascripts/discourse/tests/acceptance/new-message-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/new-message-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
 import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
@@ -23,17 +24,17 @@ acceptance("New Message - Authenticated", function (needs) {
 
     assert.ok(exists(".composer-fields"), "it opens composer");
     assert.equal(
-      find("#reply-title").val().trim(),
+      queryAll("#reply-title").val().trim(),
       "message title",
       "it pre-fills message title"
     );
     assert.equal(
-      find(".d-editor-input").val().trim(),
+      queryAll(".d-editor-input").val().trim(),
       "message body",
       "it pre-fills message body"
     );
     assert.equal(
-      find(".users-input .item:eq(0)").text().trim(),
+      queryAll(".users-input .item:eq(0)").text().trim(),
       "charlie",
       "it selects correct username"
     );

--- a/app/assets/javascripts/discourse/tests/acceptance/new-topic-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/new-topic-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
 import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
@@ -21,12 +22,12 @@ acceptance("New Topic - Authenticated", function (needs) {
 
     assert.ok(exists(".composer-fields"), "it opens composer");
     assert.equal(
-      find("#reply-title").val().trim(),
+      queryAll("#reply-title").val().trim(),
       "topic title",
       "it pre-fills topic title"
     );
     assert.equal(
-      find(".d-editor-input").val().trim(),
+      queryAll(".d-editor-input").val().trim(),
       "topic body",
       "it pre-fills topic body"
     );

--- a/app/assets/javascripts/discourse/tests/acceptance/notifications-filter-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/notifications-filter-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
@@ -9,7 +10,7 @@ acceptance("Notifications filter", function (needs) {
   test("Notifications filter true", async (assert) => {
     await visit("/u/eviltrout/notifications");
 
-    assert.ok(find(".large-notification").length >= 0);
+    assert.ok(queryAll(".large-notification").length >= 0);
   });
 
   test("Notifications filter read", async (assert) => {
@@ -19,7 +20,7 @@ acceptance("Notifications filter", function (needs) {
     await dropdown.expand();
     await dropdown.selectRowByValue("read");
 
-    assert.ok(find(".large-notification").length >= 0);
+    assert.ok(queryAll(".large-notification").length >= 0);
   });
 
   test("Notifications filter unread", async (assert) => {
@@ -29,6 +30,6 @@ acceptance("Notifications filter", function (needs) {
     await dropdown.expand();
     await dropdown.selectRowByValue("unread");
 
-    assert.ok(find(".large-notification").length >= 0);
+    assert.ok(queryAll(".large-notification").length >= 0);
   });
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/password-reset-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/password-reset-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
 import { visit, click, fillIn } from "@ember/test-helpers";
 import { test } from "qunit";
@@ -70,7 +71,7 @@ acceptance("Password Reset", function (needs) {
     await fillIn(".password-reset input", "123");
     assert.ok(exists(".password-reset .tip.bad"), "input is not valid");
     assert.ok(
-      find(".password-reset .tip.bad")
+      queryAll(".password-reset .tip.bad")
         .html()
         .indexOf(I18n.t("user.password.too_short")) > -1,
       "password too short"
@@ -80,7 +81,7 @@ acceptance("Password Reset", function (needs) {
     await click(".password-reset form button");
     assert.ok(exists(".password-reset .tip.bad"), "input is not valid");
     assert.ok(
-      find(".password-reset .tip.bad")
+      queryAll(".password-reset .tip.bad")
         .html()
         .indexOf("is the name of your cat") > -1,
       "server validation error message shows"
@@ -109,7 +110,7 @@ acceptance("Password Reset", function (needs) {
     assert.ok(exists(".alert-error"), "shows 2 factor error");
 
     assert.ok(
-      find(".alert-error").html().indexOf("invalid token") > -1,
+      queryAll(".alert-error").html().indexOf("invalid token") > -1,
       "shows server validation error message"
     );
 

--- a/app/assets/javascripts/discourse/tests/acceptance/personal-message-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/personal-message-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
 import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
@@ -20,7 +21,7 @@ acceptance("Personal Message", function (needs) {
     await visit("/t/pm-for-testing/12");
 
     assert.equal(
-      find("#suggested-topics .suggested-topics-title").text().trim(),
+      queryAll("#suggested-topics .suggested-topics-title").text().trim(),
       I18n.t("suggested_topics.pm_title")
     );
   });

--- a/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-connector-class-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-connector-class-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { visit, click } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
@@ -69,22 +70,26 @@ acceptance("Plugin Outlet - Connector Class", function (needs) {
   test("Renders a template into the outlet", async (assert) => {
     await visit("/u/eviltrout");
     assert.ok(
-      find(".user-profile-primary-outlet.hello").length === 1,
+      queryAll(".user-profile-primary-outlet.hello").length === 1,
       "it has class names"
     );
     assert.ok(
-      !find(".user-profile-primary-outlet.dont-render").length,
+      !queryAll(".user-profile-primary-outlet.dont-render").length,
       "doesn't render"
     );
 
     await click(".say-hello");
     assert.equal(
-      find(".hello-result").text(),
+      queryAll(".hello-result").text(),
       "hello!",
       "actions delegate properly"
     );
 
     await click(".say-hi");
-    assert.equal(find(".hi-result").text(), "hi!", "actions delegate properly");
+    assert.equal(
+      queryAll(".hi-result").text(),
+      "hi!",
+      "actions delegate properly"
+    );
   });
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-decorator-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-decorator-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
 import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
@@ -44,8 +45,12 @@ acceptance("Plugin Outlet - Decorator", function (needs) {
   test("Calls the plugin callback with the rendered outlet", async (assert) => {
     await visit("/");
 
-    const fooConnector = find(".discovery-list-container-top-outlet.foo ")[0];
-    const barConnector = find(".discovery-list-container-top-outlet.bar ")[0];
+    const fooConnector = queryAll(
+      ".discovery-list-container-top-outlet.foo "
+    )[0];
+    const barConnector = queryAll(
+      ".discovery-list-container-top-outlet.bar "
+    )[0];
 
     assert.ok(exists(fooConnector));
     assert.equal(fooConnector.style.backgroundColor, "yellow");

--- a/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-multi-template-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-multi-template-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
@@ -27,20 +28,20 @@ acceptance("Plugin Outlet - Multi Template", function (needs) {
   test("Renders a template into the outlet", async (assert) => {
     await visit("/u/eviltrout");
     assert.ok(
-      find(".user-profile-primary-outlet.hello").length === 1,
+      queryAll(".user-profile-primary-outlet.hello").length === 1,
       "it has class names"
     );
     assert.ok(
-      find(".user-profile-primary-outlet.goodbye").length === 1,
+      queryAll(".user-profile-primary-outlet.goodbye").length === 1,
       "it has class names"
     );
     assert.equal(
-      find(".hello-span").text(),
+      queryAll(".hello-span").text(),
       "Hello",
       "it renders into the outlet"
     );
     assert.equal(
-      find(".bye-span").text(),
+      queryAll(".bye-span").text(),
       "Goodbye",
       "it renders into the outlet"
     );

--- a/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-single-template-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-single-template-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
@@ -19,11 +20,11 @@ acceptance("Plugin Outlet - Single Template", function (needs) {
   test("Renders a template into the outlet", async (assert) => {
     await visit("/u/eviltrout");
     assert.ok(
-      find(".user-profile-primary-outlet.hello").length === 1,
+      queryAll(".user-profile-primary-outlet.hello").length === 1,
       "it has class names"
     );
     assert.equal(
-      find(".hello-username").text(),
+      queryAll(".hello-username").text(),
       "eviltrout",
       "it renders into the outlet"
     );

--- a/app/assets/javascripts/discourse/tests/acceptance/preferences-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/preferences-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
 import { visit, currentURL, click, fillIn } from "@ember/test-helpers";
 import { test } from "qunit";
@@ -85,7 +86,7 @@ acceptance("User Preferences", function (needs) {
       assert.ok(!exists(".saved"), "it hasn't been saved yet");
       await click(".save-changes");
       assert.ok(exists(".saved"), "it displays the saved message");
-      find(".saved").remove();
+      queryAll(".saved").remove();
     };
 
     fillIn(".pref-name input[type=text]", "Jon Snow");
@@ -140,7 +141,7 @@ acceptance("User Preferences", function (needs) {
     await fillIn("#change-email", "invalidemail");
 
     assert.equal(
-      find(".tip.bad").text().trim(),
+      queryAll(".tip.bad").text().trim(),
       I18n.t("user.email.invalid"),
       "it should display invalid email tip"
     );
@@ -168,7 +169,7 @@ acceptance("User Preferences", function (needs) {
       "it has the connected accounts section"
     );
     assert.ok(
-      find(".pref-associated-accounts table tr:first td:first")
+      queryAll(".pref-associated-accounts table tr:first td:first")
         .html()
         .indexOf("Facebook") > -1,
       "it lists facebook"
@@ -176,7 +177,7 @@ acceptance("User Preferences", function (needs) {
 
     await click(".pref-associated-accounts table tr:first td:last button");
 
-    find(".pref-associated-accounts table tr:first td:last button")
+    queryAll(".pref-associated-accounts table tr:first td:last button")
       .html()
       .indexOf("Connect") > -1;
   });
@@ -196,7 +197,8 @@ acceptance("User Preferences", function (needs) {
     await click(".add-totp");
 
     assert.ok(
-      find(".alert-error").html().indexOf("provide a name and the code") > -1,
+      queryAll(".alert-error").html().indexOf("provide a name and the code") >
+        -1,
       "shows name/token missing error message"
     );
   });
@@ -221,7 +223,7 @@ acceptance("User Preferences", function (needs) {
       await click(".add-security-key");
 
       assert.ok(
-        find(".alert-error").html().indexOf("provide a name") > -1,
+        queryAll(".alert-error").html().indexOf("provide a name") > -1,
         "shows name missing error message"
       );
     }
@@ -321,37 +323,39 @@ acceptance("User Preferences when badges are disabled", function (needs) {
     await visit("/u/eviltrout/preferences");
 
     assert.equal(
-      find(".auth-tokens > .auth-token:first .auth-token-device").text().trim(),
+      queryAll(".auth-tokens > .auth-token:first .auth-token-device")
+        .text()
+        .trim(),
       "Linux Computer",
       "it should display active token first"
     );
 
     assert.equal(
-      find(".pref-auth-tokens > a:first").text().trim(),
+      queryAll(".pref-auth-tokens > a:first").text().trim(),
       I18n.t("user.auth_tokens.show_all", { count: 3 }),
       "it should display two tokens"
     );
     assert.ok(
-      find(".pref-auth-tokens .auth-token").length === 2,
+      queryAll(".pref-auth-tokens .auth-token").length === 2,
       "it should display two tokens"
     );
 
     await click(".pref-auth-tokens > a:first");
 
     assert.ok(
-      find(".pref-auth-tokens .auth-token").length === 3,
+      queryAll(".pref-auth-tokens .auth-token").length === 3,
       "it should display three tokens"
     );
 
     await click(".auth-token-dropdown:first button");
     await click("li[data-value='notYou']");
 
-    assert.ok(find(".d-modal:visible").length === 1, "modal should appear");
+    assert.ok(queryAll(".d-modal:visible").length === 1, "modal should appear");
 
     await click(".modal-footer .btn-primary");
 
     assert.ok(
-      find(".pref-password.highlighted").length === 1,
+      queryAll(".pref-password.highlighted").length === 1,
       "it should highlight password preferences"
     );
   });
@@ -382,7 +386,7 @@ acceptance(
         "clear button not present"
       );
 
-      const selectTopicBtn = find(".feature-topic-on-profile-btn:first");
+      const selectTopicBtn = queryAll(".feature-topic-on-profile-btn:first");
       assert.ok(exists(selectTopicBtn), "feature topic button is present");
 
       await click(selectTopicBtn);
@@ -392,7 +396,7 @@ acceptance(
         "topic picker modal is open"
       );
 
-      const topicRadioBtn = find('input[name="choose_topic_id"]:first');
+      const topicRadioBtn = queryAll('input[name="choose_topic_id"]:first');
       assert.ok(exists(topicRadioBtn), "Topic options are prefilled");
       await click(topicRadioBtn);
 

--- a/app/assets/javascripts/discourse/tests/acceptance/raw-plugin-outlet-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/raw-plugin-outlet-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
@@ -23,9 +24,9 @@ acceptance("Raw Plugin Outlet", function (needs) {
   });
   test("Renders the raw plugin outlet", async (assert) => {
     await visit("/");
-    assert.ok(find(".topic-lala").length > 0, "it renders the outlet");
+    assert.ok(queryAll(".topic-lala").length > 0, "it renders the outlet");
     assert.equal(
-      find(".topic-lala:eq(0)").text(),
+      queryAll(".topic-lala:eq(0)").text(),
       "11557",
       "it has the topic id"
     );

--- a/app/assets/javascripts/discourse/tests/acceptance/review-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/review-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { visit, click, fillIn } from "@ember/test-helpers";
 import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
@@ -11,18 +12,18 @@ acceptance("Review", function (needs) {
   test("It returns a list of reviewable items", async (assert) => {
     await visit("/review");
 
-    assert.ok(find(".reviewable-item").length, "has a list of items");
-    assert.ok(find(user).length);
+    assert.ok(queryAll(".reviewable-item").length, "has a list of items");
+    assert.ok(queryAll(user).length);
     assert.ok(
-      find(`${user}.reviewable-user`).length,
+      queryAll(`${user}.reviewable-user`).length,
       "applies a class for the type"
     );
     assert.ok(
-      find(`${user} .reviewable-action.approve`).length,
+      queryAll(`${user} .reviewable-action.approve`).length,
       "creates a button for approve"
     );
     assert.ok(
-      find(`${user} .reviewable-action.reject`).length,
+      queryAll(`${user} .reviewable-action.reject`).length,
       "creates a button for reject"
     );
   });
@@ -30,7 +31,7 @@ acceptance("Review", function (needs) {
   test("Grouped by topic", async (assert) => {
     await visit("/review/topics");
     assert.ok(
-      find(".reviewable-topic").length,
+      queryAll(".reviewable-topic").length,
       "it has a list of reviewable topics"
     );
   });
@@ -38,37 +39,44 @@ acceptance("Review", function (needs) {
   test("Settings", async (assert) => {
     await visit("/review/settings");
 
-    assert.ok(find(".reviewable-score-type").length, "has a list of bonuses");
+    assert.ok(
+      queryAll(".reviewable-score-type").length,
+      "has a list of bonuses"
+    );
 
     const field = selectKit(".reviewable-score-type:eq(0) .field .combo-box");
     await field.expand();
     await field.selectRowByValue("5");
     await click(".save-settings");
 
-    assert.ok(find(".reviewable-settings .saved").length, "it saved");
+    assert.ok(queryAll(".reviewable-settings .saved").length, "it saved");
   });
 
   test("Flag related", async (assert) => {
     await visit("/review");
 
     assert.ok(
-      find(".reviewable-flagged-post .post-contents .username a[href]").length,
+      queryAll(".reviewable-flagged-post .post-contents .username a[href]")
+        .length,
       "it has a link to the user"
     );
 
     assert.equal(
-      find(".reviewable-flagged-post .post-body").html().trim(),
+      queryAll(".reviewable-flagged-post .post-body").html().trim(),
       "<b>cooked content</b>"
     );
 
-    assert.equal(find(".reviewable-flagged-post .reviewable-score").length, 2);
+    assert.equal(
+      queryAll(".reviewable-flagged-post .reviewable-score").length,
+      2
+    );
   });
 
   test("Flag related", async (assert) => {
     await visit("/review/1");
 
     assert.ok(
-      find(".reviewable-flagged-post").length,
+      queryAll(".reviewable-flagged-post").length,
       "it shows the flagged post"
     );
   });
@@ -76,29 +84,36 @@ acceptance("Review", function (needs) {
   test("Clicking the buttons triggers actions", async (assert) => {
     await visit("/review");
     await click(`${user} .reviewable-action.approve`);
-    assert.equal(find(user).length, 0, "it removes the reviewable on success");
+    assert.equal(
+      queryAll(user).length,
+      0,
+      "it removes the reviewable on success"
+    );
   });
 
   test("Editing a reviewable", async (assert) => {
     const topic = ".reviewable-item[data-reviewable-id=4321]";
     await visit("/review");
-    assert.ok(find(`${topic} .reviewable-action.approve`).length);
-    assert.ok(!find(`${topic} .category-name`).length);
-    assert.equal(find(`${topic} .discourse-tag:eq(0)`).text(), "hello");
-    assert.equal(find(`${topic} .discourse-tag:eq(1)`).text(), "world");
+    assert.ok(queryAll(`${topic} .reviewable-action.approve`).length);
+    assert.ok(!queryAll(`${topic} .category-name`).length);
+    assert.equal(queryAll(`${topic} .discourse-tag:eq(0)`).text(), "hello");
+    assert.equal(queryAll(`${topic} .discourse-tag:eq(1)`).text(), "world");
 
-    assert.equal(find(`${topic} .post-body`).text().trim(), "existing body");
+    assert.equal(
+      queryAll(`${topic} .post-body`).text().trim(),
+      "existing body"
+    );
 
     await click(`${topic} .reviewable-action.edit`);
     await click(`${topic} .reviewable-action.save-edit`);
     assert.ok(
-      find(`${topic} .reviewable-action.approve`).length,
+      queryAll(`${topic} .reviewable-action.approve`).length,
       "saving without changes is a cancel"
     );
     await click(`${topic} .reviewable-action.edit`);
 
     assert.equal(
-      find(`${topic} .reviewable-action.approve`).length,
+      queryAll(`${topic} .reviewable-action.approve`).length,
       0,
       "when editing actions are disabled"
     );
@@ -106,7 +121,7 @@ acceptance("Review", function (needs) {
     await fillIn(".editable-field.payload-raw textarea", "new raw contents");
     await click(`${topic} .reviewable-action.cancel-edit`);
     assert.equal(
-      find(`${topic} .post-body`).text().trim(),
+      queryAll(`${topic} .post-body`).text().trim(),
       "existing body",
       "cancelling does not update the value"
     );
@@ -124,11 +139,14 @@ acceptance("Review", function (needs) {
     await fillIn(".editable-field.payload-raw textarea", "new raw contents");
     await click(`${topic} .reviewable-action.save-edit`);
 
-    assert.equal(find(`${topic} .discourse-tag:eq(0)`).text(), "hello");
-    assert.equal(find(`${topic} .discourse-tag:eq(1)`).text(), "world");
-    assert.equal(find(`${topic} .discourse-tag:eq(2)`).text(), "monkey");
+    assert.equal(queryAll(`${topic} .discourse-tag:eq(0)`).text(), "hello");
+    assert.equal(queryAll(`${topic} .discourse-tag:eq(1)`).text(), "world");
+    assert.equal(queryAll(`${topic} .discourse-tag:eq(2)`).text(), "monkey");
 
-    assert.equal(find(`${topic} .post-body`).text().trim(), "new raw contents");
-    assert.equal(find(`${topic} .category-name`).text().trim(), "support");
+    assert.equal(
+      queryAll(`${topic} .post-body`).text().trim(),
+      "new raw contents"
+    );
+    assert.equal(queryAll(`${topic} .category-name`).text().trim(), "support");
   });
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/search-full-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-full-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
 import { visit, fillIn, click } from "@ember/test-helpers";
 import { skip, test } from "qunit";
@@ -95,19 +96,19 @@ acceptance("Search - Full Page", function (needs) {
 
     assert.ok($("body.search-page").length, "has body class");
     assert.ok(exists(".search-container"), "has container class");
-    assert.ok(find(".search-query").length > 0);
-    assert.ok(find(".fps-topic").length === 0);
+    assert.ok(queryAll(".search-query").length > 0);
+    assert.ok(queryAll(".fps-topic").length === 0);
 
     await fillIn(".search-query", "none");
     await click(".search-cta");
 
-    assert.ok(find(".fps-topic").length === 0, "has no results");
-    assert.ok(find(".no-results-suggestion .google-search-form"));
+    assert.ok(queryAll(".fps-topic").length === 0, "has no results");
+    assert.ok(queryAll(".no-results-suggestion .google-search-form"));
 
     await fillIn(".search-query", "posts");
     await click(".search-cta");
 
-    assert.ok(find(".fps-topic").length === 1, "has one post");
+    assert.ok(queryAll(".fps-topic").length === 1, "has one post");
   });
 
   test("escape search term", async (assert) => {
@@ -148,7 +149,7 @@ acceptance("Search - Full Page", function (needs) {
         'has "admin" pre-populated'
       );
       assert.equal(
-        find(".search-query").val(),
+        queryAll(".search-query").val(),
         "none @admin",
         'has updated search term to "none user:admin"'
       );
@@ -173,7 +174,7 @@ acceptance("Search - Full Page", function (needs) {
       'has "faq" populated'
     );
     assert.equal(
-      find(".search-query").val(),
+      queryAll(".search-query").val(),
       "none #faq",
       'has updated search term to "none #faq"'
     );
@@ -189,7 +190,7 @@ acceptance("Search - Full Page", function (needs) {
       'has "in title" populated'
     );
     assert.equal(
-      find(".search-query").val(),
+      queryAll(".search-query").val(),
       "none in:title",
       'has updated search term to "none in:title"'
     );
@@ -212,7 +213,7 @@ acceptance("Search - Full Page", function (needs) {
       'has "I liked" populated'
     );
     assert.equal(
-      find(".search-query").val(),
+      queryAll(".search-query").val(),
       "none in:likes",
       'has updated search term to "none in:likes"'
     );
@@ -229,7 +230,7 @@ acceptance("Search - Full Page", function (needs) {
     );
 
     assert.equal(
-      find(".search-query").val(),
+      queryAll(".search-query").val(),
       "none in:personal",
       'has updated search term to "none in:personal"'
     );
@@ -253,7 +254,7 @@ acceptance("Search - Full Page", function (needs) {
     );
 
     assert.equal(
-      find(".search-query").val(),
+      queryAll(".search-query").val(),
       "none in:seen",
       "it should update the search term"
     );
@@ -281,7 +282,7 @@ acceptance("Search - Full Page", function (needs) {
       'has "I bookmarked" populated'
     );
     assert.equal(
-      find(".search-query").val(),
+      queryAll(".search-query").val(),
       "none in:bookmarks",
       'has updated search term to "none in:bookmarks"'
     );
@@ -304,7 +305,7 @@ acceptance("Search - Full Page", function (needs) {
       'has "are closed" populated'
     );
     assert.equal(
-      find(".search-query").val(),
+      queryAll(".search-query").val(),
       "none status:closed",
       'has updated search term to "none status:closed"'
     );
@@ -336,7 +337,7 @@ acceptance("Search - Full Page", function (needs) {
     await visit("/search?expanded=true&q=after:2018-08-22");
 
     assert.equal(
-      find(".search-query").val(),
+      queryAll(".search-query").val(),
       "after:2018-08-22",
       "it should update the search term correctly"
     );
@@ -359,7 +360,7 @@ acceptance("Search - Full Page", function (needs) {
     );
 
     assert.equal(
-      find(".search-query").val(),
+      queryAll(".search-query").val(),
       "none after:2016-10-05",
       'has updated search term to "none after:2016-10-05"'
     );
@@ -371,12 +372,12 @@ acceptance("Search - Full Page", function (needs) {
     await fillIn("#search-min-post-count", "5");
 
     assert.equal(
-      find(".search-advanced-options #search-min-post-count").val(),
+      queryAll(".search-advanced-options #search-min-post-count").val(),
       "5",
       'has "5" populated'
     );
     assert.equal(
-      find(".search-query").val(),
+      queryAll(".search-query").val(),
       "none min_posts:5",
       'has updated search term to "none min_posts:5"'
     );
@@ -388,12 +389,12 @@ acceptance("Search - Full Page", function (needs) {
     await fillIn("#search-max-post-count", "5");
 
     assert.equal(
-      find(".search-advanced-options #search-max-post-count").val(),
+      queryAll(".search-advanced-options #search-max-post-count").val(),
       "5",
       'has "5" populated'
     );
     assert.equal(
-      find(".search-query").val(),
+      queryAll(".search-query").val(),
       "none max_posts:5",
       'has updated search term to "none max_posts:5"'
     );
@@ -409,7 +410,7 @@ acceptance("Search - Full Page", function (needs) {
     );
 
     assert.equal(
-      find(".search-query").val(),
+      queryAll(".search-query").val(),
       "in:likes",
       'has updated search term to "in:likes"'
     );

--- a/app/assets/javascripts/discourse/tests/acceptance/search-mobile-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-mobile-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
 import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
@@ -21,24 +22,24 @@ acceptance("Search - Mobile", function (needs) {
     await click(".search-advanced-title");
 
     assert.ok(
-      find(".search-advanced-filters").length === 1,
+      queryAll(".search-advanced-filters").length === 1,
       "it should expand advanced search filters"
     );
 
     await fillIn(".search-query", "posts");
     await click(".search-cta");
 
-    assert.ok(find(".fps-topic").length === 1, "has one post");
+    assert.ok(queryAll(".fps-topic").length === 1, "has one post");
 
     assert.ok(
-      find(".search-advanced-filters").length === 0,
+      queryAll(".search-advanced-filters").length === 0,
       "it should collapse advanced search filters"
     );
 
     await click("#search-button");
 
     assert.equal(
-      find("input.full-page-search").val(),
+      queryAll("input.full-page-search").val(),
       "posts",
       "it does not reset input when hitting search icon again"
     );

--- a/app/assets/javascripts/discourse/tests/acceptance/search-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
 import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
@@ -37,7 +38,7 @@ acceptance("Search - Anonymous", function (needs) {
     await click(".show-help");
 
     assert.equal(
-      find(".full-page-search").val(),
+      queryAll(".full-page-search").val(),
       "dev",
       "it shows the search term"
     );
@@ -102,7 +103,7 @@ acceptance("Search - Anonymous", function (needs) {
 
     const highlighted = [];
 
-    find("#post_7 span.highlighted").map((_, span) => {
+    queryAll("#post_7 span.highlighted").map((_, span) => {
       highlighted.push(span.innerText);
     });
 
@@ -188,7 +189,7 @@ acceptance("Search - with tagging enabled", function (needs) {
     await fillIn("#search-term", "dev");
     await keyEvent("#search-term", "keyup", 16);
 
-    const tags = find(".search-menu .results ul li:eq(0) .discourse-tags")
+    const tags = queryAll(".search-menu .results ul li:eq(0) .discourse-tags")
       .text()
       .trim();
 

--- a/app/assets/javascripts/discourse/tests/acceptance/share-and-invite-desktop-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/share-and-invite-desktop-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
 import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
@@ -34,20 +35,20 @@ acceptance("Share and Invite modal - desktop", function (needs) {
     );
 
     assert.equal(
-      find(".share-and-invite.modal .modal-panel.share .title").text(),
+      queryAll(".share-and-invite.modal .modal-panel.share .title").text(),
       "Topic: Internationalization / localization",
       "it shows the topic title"
     );
 
     assert.ok(
-      find(".share-and-invite.modal .modal-panel.share .topic-share-url")
+      queryAll(".share-and-invite.modal .modal-panel.share .topic-share-url")
         .val()
         .includes("/t/internationalization-localization/280?u=eviltrout"),
       "it shows the topic sharing url"
     );
 
     assert.ok(
-      find(".share-and-invite.modal .social-link").length > 1,
+      queryAll(".share-and-invite.modal .social-link").length > 1,
       "it shows social sources"
     );
 
@@ -84,7 +85,7 @@ acceptance("Share url with badges disabled - desktop", function (needs) {
     await click("#topic-footer-button-share-and-invite");
 
     assert.notOk(
-      find(".share-and-invite.modal .modal-panel.share .topic-share-url")
+      queryAll(".share-and-invite.modal .modal-panel.share .topic-share-url")
         .val()
         .includes("?u=eviltrout"),
       "it doesn't add the username param when badges are disabled"

--- a/app/assets/javascripts/discourse/tests/acceptance/share-and-invite-mobile-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/share-and-invite-mobile-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
 import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
@@ -38,20 +39,20 @@ acceptance("Share and Invite modal - mobile", function (needs) {
     );
 
     assert.equal(
-      find(".share-and-invite.modal .modal-panel.share .title").text(),
+      queryAll(".share-and-invite.modal .modal-panel.share .title").text(),
       "Topic: Internationalization / localization",
       "it shows the topic title"
     );
 
     assert.ok(
-      find(".share-and-invite.modal .modal-panel.share .topic-share-url")
+      queryAll(".share-and-invite.modal .modal-panel.share .topic-share-url")
         .val()
         .includes("/t/internationalization-localization/280?u=eviltrout"),
       "it shows the topic sharing url"
     );
 
     assert.ok(
-      find(".share-and-invite.modal .social-link").length > 1,
+      queryAll(".share-and-invite.modal .social-link").length > 1,
       "it shows social sources"
     );
   });
@@ -78,7 +79,7 @@ acceptance("Share url with badges disabled - mobile", function (needs) {
     await subject.selectRowByValue("share-and-invite");
 
     assert.notOk(
-      find(".share-and-invite.modal .modal-panel.share .topic-share-url")
+      queryAll(".share-and-invite.modal .modal-panel.share .topic-share-url")
         .val()
         .includes("?u=eviltrout"),
       "it doesn't add the username param when badges are disabled"

--- a/app/assets/javascripts/discourse/tests/acceptance/shared-drafts-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/shared-drafts-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
@@ -6,13 +7,13 @@ import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 acceptance("Shared Drafts", function () {
   test("Viewing", async (assert) => {
     await visit("/t/some-topic/9");
-    assert.ok(find(".shared-draft-controls").length === 1);
+    assert.ok(queryAll(".shared-draft-controls").length === 1);
     let categoryChooser = selectKit(".shared-draft-controls .category-chooser");
     assert.equal(categoryChooser.header().value(), "3");
 
     await click(".publish-shared-draft");
     await click(".bootbox .btn-primary");
 
-    assert.ok(find(".shared-draft-controls").length === 0);
+    assert.ok(queryAll(".shared-draft-controls").length === 0);
   });
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/sign-in-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sign-in-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
 import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
@@ -37,14 +38,14 @@ acceptance("Signing In", function () {
     await fillIn("#login-account-password", "not-activated");
     await click(".modal-footer .btn-primary");
     assert.equal(
-      find(".modal-body b").text(),
+      queryAll(".modal-body b").text(),
       "<small>eviltrout@example.com</small>"
     );
     assert.ok(!exists(".modal-body small"), "it escapes the email address");
 
     await click(".modal-footer button.resend");
     assert.equal(
-      find(".modal-body b").text(),
+      queryAll(".modal-body b").text(),
       "<small>current@example.com</small>"
     );
     assert.ok(!exists(".modal-body small"), "it escapes the email address");
@@ -59,16 +60,16 @@ acceptance("Signing In", function () {
     await fillIn("#login-account-password", "not-activated-edit");
     await click(".modal-footer .btn-primary");
     await click(".modal-footer button.edit-email");
-    assert.equal(find(".activate-new-email").val(), "current@example.com");
+    assert.equal(queryAll(".activate-new-email").val(), "current@example.com");
     assert.equal(
-      find(".modal-footer .btn-primary:disabled").length,
+      queryAll(".modal-footer .btn-primary:disabled").length,
       1,
       "must change email"
     );
     await fillIn(".activate-new-email", "different@example.com");
-    assert.equal(find(".modal-footer .btn-primary:disabled").length, 0);
+    assert.equal(queryAll(".modal-footer .btn-primary:disabled").length, 0);
     await click(".modal-footer .btn-primary");
-    assert.equal(find(".modal-body b").text(), "different@example.com");
+    assert.equal(queryAll(".modal-body b").text(), "different@example.com");
   });
 
   test("second factor", async (assert) => {

--- a/app/assets/javascripts/discourse/tests/acceptance/tag-groups-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/tag-groups-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
@@ -47,7 +48,7 @@ acceptance("Tag Groups", function (needs) {
     await click(".tag-group-content .btn.btn-default");
 
     await click(".tag-chooser .choice:first");
-    assert.ok(!find(".tag-group-content .btn.btn-danger")[0].disabled);
+    assert.ok(!queryAll(".tag-group-content .btn.btn-danger")[0].disabled);
   });
 
   test("tag groups can have multiple groups added to them", async (assert) => {
@@ -62,11 +63,11 @@ acceptance("Tag Groups", function (needs) {
     await tags.selectRowByValue("monkey");
 
     await click("#private-permission");
-    assert.ok(find(".tag-group-content .btn.btn-default:disabled").length);
+    assert.ok(queryAll(".tag-group-content .btn.btn-default:disabled").length);
 
     await groups.expand();
     await groups.selectRowByIndex(1);
     await groups.selectRowByIndex(0);
-    assert.ok(!find(".tag-group-content .btn.btn-default")[0].disabled);
+    assert.ok(!queryAll(".tag-group-content .btn.btn-default")[0].disabled);
   });
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/tags-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/tags-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
 import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
@@ -129,18 +130,18 @@ acceptance("Tags listed by group", function (needs) {
     updateCurrentUser({ moderator: false, admin: false });
 
     await visit("/tag/regular-tag");
-    assert.ok(find("#create-topic:disabled").length === 0);
+    assert.ok(queryAll("#create-topic:disabled").length === 0);
 
     await visit("/tag/staff-only-tag");
-    assert.ok(find("#create-topic:disabled").length === 1);
+    assert.ok(queryAll("#create-topic:disabled").length === 1);
 
     updateCurrentUser({ moderator: true });
 
     await visit("/tag/regular-tag");
-    assert.ok(find("#create-topic:disabled").length === 0);
+    assert.ok(queryAll("#create-topic:disabled").length === 0);
 
     await visit("/tag/staff-only-tag");
-    assert.ok(find("#create-topic:disabled").length === 0);
+    assert.ok(queryAll("#create-topic:disabled").length === 0);
   });
 });
 
@@ -228,20 +229,20 @@ acceptance("Tag info", function (needs) {
     updateCurrentUser({ moderator: false, admin: false });
 
     await visit("/tag/planters");
-    assert.ok(find("#show-tag-info").length === 1);
+    assert.ok(queryAll("#show-tag-info").length === 1);
 
     await click("#show-tag-info");
     assert.ok(exists(".tag-info .tag-name"), "show tag");
     assert.ok(
-      find(".tag-info .tag-associations").text().indexOf("Gardening") >= 0,
+      queryAll(".tag-info .tag-associations").text().indexOf("Gardening") >= 0,
       "show tag group names"
     );
     assert.ok(
-      find(".tag-info .synonyms-list .tag-box").length === 2,
+      queryAll(".tag-info .synonyms-list .tag-box").length === 2,
       "shows the synonyms"
     );
     assert.ok(
-      find(".tag-info .badge-category").length === 1,
+      queryAll(".tag-info .badge-category").length === 1,
       "show the category"
     );
     assert.ok(!exists("#rename-tag"), "can't rename tag");
@@ -253,7 +254,7 @@ acceptance("Tag info", function (needs) {
     updateCurrentUser({ moderator: false, admin: true });
 
     await visit("/tag/planters");
-    assert.ok(find("#show-tag-info").length === 1);
+    assert.ok(queryAll("#show-tag-info").length === 1);
 
     await click("#show-tag-info");
     assert.ok(exists("#rename-tag"), "can rename tag");
@@ -262,17 +263,17 @@ acceptance("Tag info", function (needs) {
 
     await click("#edit-synonyms");
     assert.ok(
-      find(".unlink-synonym:visible").length === 2,
+      queryAll(".unlink-synonym:visible").length === 2,
       "unlink UI is visible"
     );
     assert.ok(
-      find(".delete-synonym:visible").length === 2,
+      queryAll(".delete-synonym:visible").length === 2,
       "delete UI is visible"
     );
 
     await click(".unlink-synonym:first");
     assert.ok(
-      find(".tag-info .synonyms-list .tag-box").length === 1,
+      queryAll(".tag-info .synonyms-list .tag-box").length === 1,
       "removed a synonym"
     );
   });

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-anonymous-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-anonymous-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
 import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
@@ -9,7 +10,7 @@ acceptance("Topic - Anonymous", function () {
     assert.ok(exists("#topic"), "The topic was rendered");
     assert.ok(exists("#topic .cooked"), "The topic has cooked posts");
     assert.ok(
-      find(".shared-draft-notice").length === 0,
+      queryAll(".shared-draft-notice").length === 0,
       "no shared draft unless there's a dest category id"
     );
   });

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-discovery-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-discovery-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
 import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
@@ -19,7 +20,7 @@ acceptance("Topic Discovery", function (needs) {
     assert.ok(exists(".topic-list .topic-list-item"), "has topics");
 
     assert.equal(
-      find("a[data-user-card=eviltrout]:first img.avatar").attr("title"),
+      queryAll("a[data-user-card=eviltrout]:first img.avatar").attr("title"),
       "Evil Trout - Most Posts",
       "it shows user's full name in avatar title"
     );

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-edit-timer-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-edit-timer-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { click, fillIn, visit } from "@ember/test-helpers";
 import { skip } from "qunit";
 import { test } from "qunit";
@@ -54,7 +55,9 @@ acceptance("Topic - Edit timer", function (needs) {
     assert.equal(futureDateInputSelector.header().value(), "next_week");
 
     const regex = /will automatically close in/g;
-    const html = find(".future-date-input .topic-status-info").html().trim();
+    const html = queryAll(".future-date-input .topic-status-info")
+      .html()
+      .trim();
     assert.ok(regex.test(html));
   });
 
@@ -73,7 +76,9 @@ acceptance("Topic - Edit timer", function (needs) {
     assert.equal(futureDateInputSelector.header().value(), "next_week");
 
     const regex1 = /will automatically close in/g;
-    const html1 = find(".future-date-input .topic-status-info").html().trim();
+    const html1 = queryAll(".future-date-input .topic-status-info")
+      .html()
+      .trim();
     assert.ok(regex1.test(html1));
 
     await futureDateInputSelector.expand();
@@ -90,7 +95,9 @@ acceptance("Topic - Edit timer", function (needs) {
     );
 
     const regex2 = /will automatically close in/g;
-    const html2 = find(".future-date-input .topic-status-info").html().trim();
+    const html2 = queryAll(".future-date-input .topic-status-info")
+      .html()
+      .trim();
     assert.ok(regex2.test(html2));
 
     await futureDateInputSelector.expand();
@@ -110,7 +117,9 @@ acceptance("Topic - Edit timer", function (needs) {
     );
 
     const regex3 = /This topic will close.*after the last reply/g;
-    const html3 = find(".future-date-input .topic-status-info").html().trim();
+    const html3 = queryAll(".future-date-input .topic-status-info")
+      .html()
+      .trim();
     assert.ok(regex3.test(html3));
   });
 
@@ -139,7 +148,9 @@ acceptance("Topic - Edit timer", function (needs) {
     assert.equal(futureDateInputSelector.header().value(), "next_week");
 
     const regex1 = /will automatically open in/g;
-    const html1 = find(".future-date-input .topic-status-info").html().trim();
+    const html1 = queryAll(".future-date-input .topic-status-info")
+      .html()
+      .trim();
     assert.ok(regex1.test(html1));
 
     await futureDateInputSelector.expand();
@@ -157,7 +168,9 @@ acceptance("Topic - Edit timer", function (needs) {
     );
 
     const regex2 = /will automatically open in/g;
-    const html2 = find(".future-date-input .topic-status-info").html().trim();
+    const html2 = queryAll(".future-date-input .topic-status-info")
+      .html()
+      .trim();
     assert.ok(regex2.test(html2));
   });
 
@@ -193,7 +206,9 @@ acceptance("Topic - Edit timer", function (needs) {
     assert.equal(futureDateInputSelector.header().value(), "next_week");
 
     const regex = /will be published to #dev/g;
-    const text = find(".future-date-input .topic-status-info").text().trim();
+    const text = queryAll(".future-date-input .topic-status-info")
+      .text()
+      .trim();
     assert.ok(regex.test(text));
   });
 
@@ -236,7 +251,9 @@ acceptance("Topic - Edit timer", function (needs) {
     assert.equal(futureDateInputSelector.header().value(), "two_weeks");
 
     const regex = /will be automatically deleted/g;
-    const html = find(".future-date-input .topic-status-info").html().trim();
+    const html = queryAll(".future-date-input .topic-status-info")
+      .html()
+      .trim();
     assert.ok(regex.test(html));
   });
 
@@ -251,11 +268,13 @@ acceptance("Topic - Edit timer", function (needs) {
     await futureDateInputSelector.selectRowByValue("next_week");
     await click(".modal-footer button.btn-primary");
 
-    const removeTimerButton = find(".topic-status-info .topic-timer-remove");
+    const removeTimerButton = queryAll(
+      ".topic-status-info .topic-timer-remove"
+    );
     assert.equal(removeTimerButton.attr("title"), "remove timer");
 
     await click(".topic-status-info .topic-timer-remove");
-    const topicStatusInfo = find(".topic-status-info .topic-timer-remove");
+    const topicStatusInfo = queryAll(".topic-status-info .topic-timer-remove");
     assert.equal(topicStatusInfo.length, 0);
   });
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-move-posts-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-move-posts-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import I18n from "I18n";
@@ -13,7 +14,7 @@ acceptance("Topic move posts", function (needs) {
     await click("#post_11 .select-below");
 
     assert.equal(
-      find(".selected-posts .move-to-topic").text().trim(),
+      queryAll(".selected-posts .move-to-topic").text().trim(),
       I18n.t("topic.move_to.action"),
       "it should show the move to button"
     );
@@ -21,28 +22,28 @@ acceptance("Topic move posts", function (needs) {
     await click(".selected-posts .move-to-topic");
 
     assert.ok(
-      find(".choose-topic-modal .title")
+      queryAll(".choose-topic-modal .title")
         .html()
         .includes(I18n.t("topic.move_to.title")),
       "it opens move to modal"
     );
 
     assert.ok(
-      find(".choose-topic-modal .radios")
+      queryAll(".choose-topic-modal .radios")
         .html()
         .includes(I18n.t("topic.split_topic.radio_label")),
       "it shows an option to move to new topic"
     );
 
     assert.ok(
-      find(".choose-topic-modal .radios")
+      queryAll(".choose-topic-modal .radios")
         .html()
         .includes(I18n.t("topic.merge_topic.radio_label")),
       "it shows an option to move to existing topic"
     );
 
     assert.ok(
-      find(".choose-topic-modal .radios")
+      queryAll(".choose-topic-modal .radios")
         .html()
         .includes(I18n.t("topic.move_to_new_message.radio_label")),
       "it shows an option to move to new message"
@@ -57,28 +58,28 @@ acceptance("Topic move posts", function (needs) {
     await click(".selected-posts .move-to-topic");
 
     assert.ok(
-      find(".choose-topic-modal .title")
+      queryAll(".choose-topic-modal .title")
         .html()
         .includes(I18n.t("topic.move_to.title")),
       "it opens move to modal"
     );
 
     assert.not(
-      find(".choose-topic-modal .radios")
+      queryAll(".choose-topic-modal .radios")
         .html()
         .includes(I18n.t("topic.split_topic.radio_label")),
       "it does not show an option to move to new topic"
     );
 
     assert.ok(
-      find(".choose-topic-modal .radios")
+      queryAll(".choose-topic-modal .radios")
         .html()
         .includes(I18n.t("topic.merge_topic.radio_label")),
       "it shows an option to move to existing topic"
     );
 
     assert.not(
-      find(".choose-topic-modal .radios")
+      queryAll(".choose-topic-modal .radios")
         .html()
         .includes(I18n.t("topic.move_to_new_message.radio_label")),
       "it does not show an option to move to new message"
@@ -92,7 +93,7 @@ acceptance("Topic move posts", function (needs) {
     await click("#post_1 .select-post");
 
     assert.equal(
-      find(".selected-posts .move-to-topic").text().trim(),
+      queryAll(".selected-posts .move-to-topic").text().trim(),
       I18n.t("topic.move_to.action"),
       "it should show the move to button"
     );
@@ -100,21 +101,21 @@ acceptance("Topic move posts", function (needs) {
     await click(".selected-posts .move-to-topic");
 
     assert.ok(
-      find(".choose-topic-modal .title")
+      queryAll(".choose-topic-modal .title")
         .html()
         .includes(I18n.t("topic.move_to.title")),
       "it opens move to modal"
     );
 
     assert.ok(
-      find(".choose-topic-modal .radios")
+      queryAll(".choose-topic-modal .radios")
         .html()
         .includes(I18n.t("topic.move_to_new_message.radio_label")),
       "it shows an option to move to new message"
     );
 
     assert.ok(
-      find(".choose-topic-modal .radios")
+      queryAll(".choose-topic-modal .radios")
         .html()
         .includes(I18n.t("topic.move_to_existing_message.radio_label")),
       "it shows an option to move to existing message"
@@ -128,7 +129,7 @@ acceptance("Topic move posts", function (needs) {
     await click("#post_2 .select-below");
 
     assert.equal(
-      find(".selected-posts .move-to-topic").text().trim(),
+      queryAll(".selected-posts .move-to-topic").text().trim(),
       I18n.t("topic.move_to.action"),
       "it should show the move to button"
     );
@@ -136,7 +137,7 @@ acceptance("Topic move posts", function (needs) {
     await click(".selected-posts .move-to-topic");
 
     assert.ok(
-      find(".choose-topic-modal .title")
+      queryAll(".choose-topic-modal .title")
         .html()
         .includes(I18n.t("topic.move_to.title")),
       "it opens move to modal"

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-quote-button-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-quote-button-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
 import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
@@ -26,7 +27,7 @@ acceptance("Topic - Quote button - logged in", function (needs) {
     selectText("#post_5 blockquote");
     assert.ok(exists(".insert-quote"), "it shows the quote button");
     assert.equal(
-      find(".quote-sharing").length,
+      queryAll(".quote-sharing").length,
       0,
       "it does not show quote sharing"
     );
@@ -60,7 +61,7 @@ acceptance("Topic - Quote button - anonymous", function (needs) {
     await visit("/t/internationalization-localization/280");
     selectText("#post_5 blockquote");
 
-    assert.ok(find(".quote-sharing"), "it shows the quote sharing options");
+    assert.ok(queryAll(".quote-sharing"), "it shows the quote sharing options");
     assert.ok(
       exists(`.quote-sharing .btn[title='${I18n.t("share.twitter")}']`),
       "it includes the twitter share button"
@@ -70,7 +71,7 @@ acceptance("Topic - Quote button - anonymous", function (needs) {
       "it includes the email share button"
     );
     assert.equal(
-      find(".insert-quote").length,
+      queryAll(".insert-quote").length,
       0,
       "it does not show the quote button"
     );
@@ -88,7 +89,7 @@ acceptance("Topic - Quote button - anonymous", function (needs) {
       "it includes the twitter share button"
     );
     assert.equal(
-      find(".quote-share-label").length,
+      queryAll(".quote-share-label").length,
       0,
       "it does not show the Share label"
     );
@@ -101,13 +102,13 @@ acceptance("Topic - Quote button - anonymous", function (needs) {
     selectText("#post_5 blockquote");
 
     assert.equal(
-      find(".quote-sharing").length,
+      queryAll(".quote-sharing").length,
       0,
       "it does not show quote sharing"
     );
 
     assert.equal(
-      find(".insert-quote").length,
+      queryAll(".insert-quote").length,
       0,
       "it does not show the quote button"
     );

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
 import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
@@ -33,7 +34,7 @@ acceptance("Topic", function (needs) {
     assert.ok(exists(".d-editor-input"), "the composer input is visible");
 
     assert.equal(
-      find(".d-editor-input").val().trim(),
+      queryAll(".d-editor-input").val().trim(),
       `Continuing the discussion from [Internationalization / localization](${window.location.origin}/t/internationalization-localization/280):`,
       "it fills composer with the ring string"
     );
@@ -52,12 +53,12 @@ acceptance("Topic", function (needs) {
     assert.ok(exists(".d-editor-input"), "the composer input is visible");
 
     assert.equal(
-      find(".d-editor-input").val().trim(),
+      queryAll(".d-editor-input").val().trim(),
       `Continuing the discussion from [PM for testing](${window.location.origin}/t/pm-for-testing/12):`,
       "it fills composer with the ring string"
     );
 
-    const targets = find(".item span", ".composer-fields");
+    const targets = queryAll(".item span", ".composer-fields");
 
     assert.equal(
       $(targets[0]).text(),
@@ -113,12 +114,12 @@ acceptance("Topic", function (needs) {
     await click("#topic-title .submit-edit");
 
     assert.equal(
-      find("#topic-title .badge-category").text(),
+      queryAll("#topic-title .badge-category").text(),
       "faq",
       "it displays the new category"
     );
     assert.equal(
-      find(".fancy-title").text().trim(),
+      queryAll(".fancy-title").text().trim(),
       "this is the new title",
       "it displays the new title"
     );
@@ -127,20 +128,23 @@ acceptance("Topic", function (needs) {
   test("Marking a topic as wiki", async (assert) => {
     await visit("/t/internationalization-localization/280");
 
-    assert.ok(find("a.wiki").length === 0, "it does not show the wiki icon");
+    assert.ok(
+      queryAll("a.wiki").length === 0,
+      "it does not show the wiki icon"
+    );
 
     await click(".topic-post:eq(0) button.show-more-actions");
     await click(".topic-post:eq(0) button.show-post-admin-menu");
     await click(".btn.wiki");
 
-    assert.ok(find("a.wiki").length === 1, "it shows the wiki icon");
+    assert.ok(queryAll("a.wiki").length === 1, "it shows the wiki icon");
   });
 
   test("Visit topic routes", async (assert) => {
     await visit("/t/12");
 
     assert.equal(
-      find(".fancy-title").text().trim(),
+      queryAll(".fancy-title").text().trim(),
       "PM for testing",
       "it routes to the right topic"
     );
@@ -148,7 +152,7 @@ acceptance("Topic", function (needs) {
     await visit("/t/280/20");
 
     assert.equal(
-      find(".fancy-title").text().trim(),
+      queryAll(".fancy-title").text().trim(),
       "Internationalization / localization",
       "it routes to the right topic"
     );
@@ -163,7 +167,7 @@ acceptance("Topic", function (needs) {
     await click("#topic-title .submit-edit");
 
     assert.equal(
-      find(".fancy-title").html().trim(),
+      queryAll(".fancy-title").html().trim(),
       `emojis title <img width=\"20\" height=\"20\" src="/images/emoji/emoji_one/bike.png?v=${v}" title="bike" alt="bike" class="emoji"> <img width=\"20\" height=\"20\" src="/images/emoji/emoji_one/blonde_woman/6.png?v=${v}" title="blonde_woman:t6" alt="blonde_woman:t6" class="emoji">`,
       "it displays the new title with emojis"
     );
@@ -178,7 +182,7 @@ acceptance("Topic", function (needs) {
     await click("#topic-title .submit-edit");
 
     assert.equal(
-      find(".fancy-title").html().trim(),
+      queryAll(".fancy-title").html().trim(),
       `emojis title <img width=\"20\" height=\"20\" src="/images/emoji/emoji_one/man_farmer.png?v=${v}" title="man_farmer" alt="man_farmer" class="emoji"><img width=\"20\" height=\"20\" src="/images/emoji/emoji_one/pray.png?v=${v}" title="pray" alt="pray" class="emoji">`,
       "it displays the new title with escaped unicode emojis"
     );
@@ -194,7 +198,7 @@ acceptance("Topic", function (needs) {
     await click("#topic-title .submit-edit");
 
     assert.equal(
-      find(".fancy-title").html().trim(),
+      queryAll(".fancy-title").html().trim(),
       `Test<img width=\"20\" height=\"20\" src="/images/emoji/emoji_one/slightly_smiling_face.png?v=${v}" title="slightly_smiling_face" alt="slightly_smiling_face" class="emoji">Title`,
       "it displays the new title with escaped unicode emojis"
     );
@@ -204,7 +208,7 @@ acceptance("Topic", function (needs) {
     await visit("/t/internationalization-localization/280");
 
     assert.equal(
-      find("#suggested-topics .suggested-topics-title").text().trim(),
+      queryAll("#suggested-topics .suggested-topics-title").text().trim(),
       I18n.t("suggested_topics.title")
     );
   });
@@ -326,7 +330,7 @@ acceptance("Topic featured links", function (needs) {
     await click("#post_3 .select-below");
 
     assert.ok(
-      find(".selected-posts")
+      queryAll(".selected-posts")
         .html()
         .includes(I18n.t("topic.multi_select.description", { count: 18 })),
       "it should select the right number of posts"
@@ -335,7 +339,7 @@ acceptance("Topic featured links", function (needs) {
     await click("#post_2 .select-below");
 
     assert.ok(
-      find(".selected-posts")
+      queryAll(".selected-posts")
         .html()
         .includes(I18n.t("topic.multi_select.description", { count: 19 })),
       "it should select the right number of posts"
@@ -346,7 +350,7 @@ acceptance("Topic featured links", function (needs) {
     await visit("/t/internationalization-localization/280");
     await click(".gap");
 
-    assert.equal(find(".gap").length, 0, "it hides gap");
+    assert.equal(queryAll(".gap").length, 0, "it hides gap");
   });
 
   test("Quoting a quote keeps the original poster name", async (assert) => {
@@ -355,7 +359,7 @@ acceptance("Topic featured links", function (needs) {
     await click(".quote-button .insert-quote");
 
     assert.ok(
-      find(".d-editor-input")
+      queryAll(".d-editor-input")
         .val()
         .indexOf('quote="codinghorror said, post:3, topic:280"') !== -1
     );
@@ -367,7 +371,7 @@ acceptance("Topic featured links", function (needs) {
     await click(".quote-button .insert-quote");
 
     assert.ok(
-      find(".d-editor-input")
+      queryAll(".d-editor-input")
         .val()
         .indexOf(
           'quote="A new topic with a link to another topic, post:3, topic:62"'
@@ -381,7 +385,7 @@ acceptance("Topic featured links", function (needs) {
     await click(".reply");
 
     assert.ok(
-      find(".d-editor-input")
+      queryAll(".d-editor-input")
         .val()
         .indexOf('quote="codinghorror said, post:3, topic:280"') !== -1
     );
@@ -394,7 +398,7 @@ acceptance("Topic featured links", function (needs) {
     await keyEvent(document, "keypress", "t".charCodeAt(0));
 
     assert.ok(
-      find(".d-editor-input")
+      queryAll(".d-editor-input")
         .val()
         .indexOf('quote="codinghorror said, post:3, topic:280"') !== -1
     );
@@ -406,7 +410,7 @@ acceptance("Topic featured links", function (needs) {
     await click(".quote-button .insert-quote");
 
     assert.ok(
-      find(".d-editor-input")
+      queryAll(".d-editor-input")
         .val()
         .indexOf('quote="pekka, post:5, topic:280, full:true"') !== -1
     );
@@ -426,12 +430,12 @@ acceptance("Topic with title decorated", function (needs) {
     await visit("/t/internationalization-localization/280");
 
     assert.ok(
-      find(".fancy-title")[0].innerText.endsWith("-280-topic-title"),
+      queryAll(".fancy-title")[0].innerText.endsWith("-280-topic-title"),
       "it decorates topic title"
     );
 
     assert.ok(
-      find(".raw-topic-link:nth-child(1)")[0].innerText.endsWith(
+      queryAll(".raw-topic-link:nth-child(1)")[0].innerText.endsWith(
         "-27331-topic-list-item-title"
       ),
       "it decorates topic list item title"

--- a/app/assets/javascripts/discourse/tests/acceptance/user-bookmarks-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-bookmarks-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
 import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
@@ -11,7 +12,7 @@ acceptance("User's bookmarks", function (needs) {
 
   test("removing a bookmark with no reminder does not show a confirmation", async (assert) => {
     await visit("/u/eviltrout/activity/bookmarks");
-    assert.ok(find(".bookmark-list-item").length > 0);
+    assert.ok(queryAll(".bookmark-list-item").length > 0);
 
     const dropdown = selectKit(".bookmark-actions-dropdown:eq(0)");
     await dropdown.expand();
@@ -59,6 +60,6 @@ acceptance("User's bookmarks - no bookmarks", function (needs) {
 
   test("listing users bookmarks - no bookmarks", async (assert) => {
     await visit("/u/eviltrout/activity/bookmarks");
-    assert.equal(find(".alert.alert-info").text(), "no bookmarks");
+    assert.equal(queryAll(".alert.alert-info").text(), "no bookmarks");
   });
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/user-drafts-stream-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-drafts-stream-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
@@ -8,22 +9,22 @@ acceptance("User Drafts", function (needs) {
 
   test("Stream", async (assert) => {
     await visit("/u/eviltrout/activity/drafts");
-    assert.ok(find(".user-stream-item").length === 3, "has drafts");
+    assert.ok(queryAll(".user-stream-item").length === 3, "has drafts");
 
     await click(".user-stream-item:last-child .remove-draft");
     assert.ok(
-      find(".user-stream-item").length === 2,
+      queryAll(".user-stream-item").length === 2,
       "draft removed, list length diminished by one"
     );
   });
 
   test("Stream - resume draft", async (assert) => {
     await visit("/u/eviltrout/activity/drafts");
-    assert.ok(find(".user-stream-item").length > 0, "has drafts");
+    assert.ok(queryAll(".user-stream-item").length > 0, "has drafts");
 
     await click(".user-stream-item .resume-draft");
     assert.equal(
-      find(".d-editor-input").val().trim(),
+      queryAll(".d-editor-input").val().trim(),
       "A fun new topic for testing drafts."
     );
   });

--- a/app/assets/javascripts/discourse/tests/acceptance/user-preferences-interface-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-preferences-interface-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
 import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
@@ -18,7 +19,7 @@ acceptance("User Preferences - Interface", function (needs) {
       assert.ok(!exists(".saved"), "it hasn't been saved yet");
       await click(".save-changes");
       assert.ok(exists(".saved"), "it displays the saved message");
-      find(".saved").remove();
+      queryAll(".saved").remove();
     };
 
     await visit("/u/eviltrout/preferences/interface");
@@ -132,7 +133,7 @@ acceptance(
         assert.ok(!exists(".saved"), "it hasn't been saved yet");
         await click(".save-changes");
         assert.ok(exists(".saved"), "it displays the saved message");
-        find(".saved").remove();
+        queryAll(".saved").remove();
       };
 
       await visit("/u/eviltrout/preferences/interface");

--- a/app/assets/javascripts/discourse/tests/acceptance/user-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
 import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
@@ -38,7 +39,7 @@ acceptance("User Routes", function (needs) {
     await visit("/u/eviltrout/notifications");
     assert.ok($("body.user-notifications-page").length, "has the body class");
 
-    const $links = find(".item.notification a");
+    const $links = queryAll(".item.notification a");
 
     assert.ok(
       $links[1].href.includes(

--- a/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
+++ b/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
@@ -375,8 +375,12 @@ export async function selectDate(selector, date) {
   });
 }
 
+export function queryAll() {
+  return window.find(...arguments);
+}
+
 export function invisible(selector) {
-  const $items = find(selector + ":visible");
+  const $items = queryAll(selector + ":visible");
   return (
     $items.length === 0 ||
     $items.css("opacity") !== "1" ||
@@ -385,11 +389,11 @@ export function invisible(selector) {
 }
 
 export function visible(selector) {
-  return find(selector + ":visible").length > 0;
+  return queryAll(selector + ":visible").length > 0;
 }
 
 export function count(selector) {
-  return find(selector).length;
+  return queryAll(selector).length;
 }
 
 export function exists(selector) {

--- a/app/assets/javascripts/discourse/tests/helpers/select-kit-helper.js
+++ b/app/assets/javascripts/discourse/tests/helpers/select-kit-helper.js
@@ -1,17 +1,18 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { moduleForComponent } from "ember-qunit";
 import { isEmpty } from "@ember/utils";
 import { click, fillIn } from "@ember/test-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
 
 function checkSelectKitIsNotExpanded(selector) {
-  if (find(selector).hasClass("is-expanded")) {
+  if (queryAll(selector).hasClass("is-expanded")) {
     // eslint-disable-next-line no-console
     console.warn("You expected select-kit to be collapsed but it is expanded.");
   }
 }
 
 function checkSelectKitIsNotCollapsed(selector) {
-  if (!find(selector).hasClass("is-expanded")) {
+  if (!queryAll(selector).hasClass("is-expanded")) {
     // eslint-disable-next-line no-console
     console.warn("You expected select-kit to be expanded but it is collapsed.");
   }
@@ -31,7 +32,7 @@ async function selectKitFillInFilter(filter, selector) {
   checkSelectKitIsNotCollapsed(selector);
   await fillIn(
     `${selector} .filter-input`,
-    find(`${selector} .filter-input`).val() + filter
+    queryAll(`${selector} .filter-input`).val() + filter
   );
 }
 
@@ -57,11 +58,11 @@ async function selectKitSelectNoneRow(selector) {
 
 async function selectKitSelectRowByIndex(index, selector) {
   checkSelectKitIsNotCollapsed(selector);
-  await click(find(`${selector} .select-kit-row`).eq(index));
+  await click(queryAll(`${selector} .select-kit-row`).eq(index));
 }
 
 async function keyboardHelper(value, target, selector) {
-  target = find(selector).find(target || ".filter-input");
+  target = queryAll(selector).find(target || ".filter-input");
 
   if (value === "selectAll") {
     // special casing the only one not working with triggerEvent
@@ -200,27 +201,27 @@ export default function selectKit(selector) {
     },
 
     isExpanded() {
-      return find(selector).hasClass("is-expanded");
+      return queryAll(selector).hasClass("is-expanded");
     },
 
     isFocused() {
-      return find(selector).hasClass("is-focused");
+      return queryAll(selector).hasClass("is-focused");
     },
 
     isHidden() {
-      return find(selector).hasClass("is-hidden");
+      return queryAll(selector).hasClass("is-hidden");
     },
 
     header() {
-      return headerHelper(find(selector).find(".select-kit-header"));
+      return headerHelper(queryAll(selector).find(".select-kit-header"));
     },
 
     filter() {
-      return filterHelper(find(selector).find(".select-kit-filter"));
+      return filterHelper(queryAll(selector).find(".select-kit-filter"));
     },
 
     rows() {
-      return find(selector).find(".select-kit-row");
+      return queryAll(selector).find(".select-kit-row");
     },
 
     displayedContent() {
@@ -236,32 +237,32 @@ export default function selectKit(selector) {
 
     rowByValue(value) {
       return rowHelper(
-        find(selector).find('.select-kit-row[data-value="' + value + '"]')
+        queryAll(selector).find('.select-kit-row[data-value="' + value + '"]')
       );
     },
 
     rowByName(name) {
       return rowHelper(
-        find(selector).find('.select-kit-row[data-name="' + name + '"]')
+        queryAll(selector).find('.select-kit-row[data-name="' + name + '"]')
       );
     },
 
     rowByIndex(index) {
       return rowHelper(
-        find(selector).find(".select-kit-row:eq(" + index + ")")
+        queryAll(selector).find(".select-kit-row:eq(" + index + ")")
       );
     },
 
     el() {
-      return find(selector);
+      return queryAll(selector);
     },
 
     noneRow() {
-      return rowHelper(find(selector).find(".select-kit-row.none"));
+      return rowHelper(queryAll(selector).find(".select-kit-row.none"));
     },
 
     validationMessage() {
-      const validationMessage = find(selector).find(".validation-message");
+      const validationMessage = queryAll(selector).find(".validation-message");
 
       if (validationMessage.length) {
         return validationMessage.html().trim();
@@ -271,16 +272,20 @@ export default function selectKit(selector) {
     },
 
     selectedRow() {
-      return rowHelper(find(selector).find(".select-kit-row.is-selected"));
+      return rowHelper(queryAll(selector).find(".select-kit-row.is-selected"));
     },
 
     highlightedRow() {
-      return rowHelper(find(selector).find(".select-kit-row.is-highlighted"));
+      return rowHelper(
+        queryAll(selector).find(".select-kit-row.is-highlighted")
+      );
     },
 
     async deselectItem(value) {
       await click(
-        find(selector).find(".select-kit-header").find(`[data-value=${value}]`)
+        queryAll(selector)
+          .find(".select-kit-header")
+          .find(`[data-value=${value}]`)
       );
     },
 

--- a/app/assets/javascripts/discourse/tests/integration/components/ace-editor-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/ace-editor-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import componentTest from "discourse/tests/helpers/component-test";
 import { moduleForComponent } from "ember-qunit";
 
@@ -8,7 +9,7 @@ componentTest("css editor", {
   template: '{{ace-editor mode="css"}}',
   test(assert) {
     assert.expect(1);
-    assert.ok(find(".ace_editor").length, "it renders the ace editor");
+    assert.ok(queryAll(".ace_editor").length, "it renders the ace editor");
   },
 });
 
@@ -17,7 +18,7 @@ componentTest("html editor", {
   template: '{{ace-editor mode="html" content="<b>wat</b>"}}',
   test(assert) {
     assert.expect(1);
-    assert.ok(find(".ace_editor").length, "it renders the ace editor");
+    assert.ok(queryAll(".ace_editor").length, "it renders the ace editor");
   },
 });
 
@@ -26,7 +27,7 @@ componentTest("sql editor", {
   template: '{{ace-editor mode="sql" content="SELECT * FROM users"}}',
   test(assert) {
     assert.expect(1);
-    assert.ok(find(".ace_editor").length, "it renders the ace editor");
+    assert.ok(queryAll(".ace_editor").length, "it renders the ace editor");
   },
 });
 
@@ -35,7 +36,7 @@ componentTest("disabled editor", {
   template:
     '{{ace-editor mode="sql" content="SELECT * FROM users" disabled=true}}',
   test(assert) {
-    const $ace = find(".ace_editor");
+    const $ace = queryAll(".ace_editor");
     assert.expect(3);
     assert.ok($ace.length, "it renders the ace editor");
     assert.equal(

--- a/app/assets/javascripts/discourse/tests/integration/components/admin-report-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/admin-report-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
 import { moduleForComponent } from "ember-qunit";
 import componentTest from "discourse/tests/helpers/component-test";
@@ -17,31 +18,35 @@ componentTest("default", {
     assert.ok(exists(".admin-report.signups", "it defaults to table mode"));
 
     assert.equal(
-      find(".header .item.report").text().trim(),
+      queryAll(".header .item.report").text().trim(),
       "Signups",
       "it has a title"
     );
 
     assert.equal(
-      find(".header .info").attr("data-tooltip"),
+      queryAll(".header .info").attr("data-tooltip"),
       "New account registrations for this period",
       "it has a description"
     );
 
     assert.equal(
-      find(".admin-report-table thead tr th:first-child .title").text().trim(),
+      queryAll(".admin-report-table thead tr th:first-child .title")
+        .text()
+        .trim(),
       "Day",
       "it has col headers"
     );
 
     assert.equal(
-      find(".admin-report-table thead tr th:nth-child(2) .title").text().trim(),
+      queryAll(".admin-report-table thead tr th:nth-child(2) .title")
+        .text()
+        .trim(),
       "Count",
       "it has col headers"
     );
 
     assert.equal(
-      find(".admin-report-table tbody tr:nth-child(1) td:nth-child(1)")
+      queryAll(".admin-report-table tbody tr:nth-child(1) td:nth-child(1)")
         .text()
         .trim(),
       "June 16, 2018",
@@ -49,7 +54,7 @@ componentTest("default", {
     );
 
     assert.equal(
-      find(".admin-report-table tbody tr:nth-child(1) td:nth-child(2)")
+      queryAll(".admin-report-table tbody tr:nth-child(1) td:nth-child(2)")
         .text()
         .trim(),
       "12",
@@ -61,7 +66,7 @@ componentTest("default", {
     await click(".admin-report-table-header.y .sort-btn");
 
     assert.equal(
-      find(".admin-report-table tbody tr:nth-child(1) td:nth-child(2)")
+      queryAll(".admin-report-table tbody tr:nth-child(1) td:nth-child(2)")
         .text()
         .trim(),
       "7",
@@ -85,7 +90,7 @@ componentTest("options", {
   test(assert) {
     assert.ok(exists(".pagination"), "it paginates the results");
     assert.equal(
-      find(".pagination button").length,
+      queryAll(".pagination button").length,
       3,
       "it creates the correct number of pages"
     );

--- a/app/assets/javascripts/discourse/tests/integration/components/cook-text-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/cook-text-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { moduleForComponent } from "ember-qunit";
 import componentTest from "discourse/tests/helpers/component-test";
 import pretender from "discourse/tests/helpers/create-pretender";
@@ -9,7 +10,7 @@ componentTest("renders markdown", {
   template: '{{cook-text "_foo_" class="post-body"}}',
 
   test(assert) {
-    const html = find(".post-body")[0].innerHTML.trim();
+    const html = queryAll(".post-body")[0].innerHTML.trim();
     assert.equal(html, "<p><em>foo</em></p>");
   },
 });
@@ -38,7 +39,7 @@ componentTest("resolves short URLs", {
   },
 
   test(assert) {
-    const html = find(".post-body")[0].innerHTML.trim();
+    const html = queryAll(".post-body")[0].innerHTML.trim();
     assert.equal(html, '<p><img src="/images/avatar.png" alt="an image"></p>');
   },
 });

--- a/app/assets/javascripts/discourse/tests/integration/components/d-button-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/d-button-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
 import { moduleForComponent } from "ember-qunit";
 import I18n from "I18n";
@@ -9,11 +10,15 @@ componentTest("icon only button", {
 
   test(assert) {
     assert.ok(
-      find("button.btn.btn-icon.no-text").length,
+      queryAll("button.btn.btn-icon.no-text").length,
       "it has all the classes"
     );
-    assert.ok(find("button .d-icon.d-icon-plus").length, "it has the icon");
-    assert.equal(find("button").attr("tabindex"), "3", "it has the tabindex");
+    assert.ok(queryAll("button .d-icon.d-icon-plus").length, "it has the icon");
+    assert.equal(
+      queryAll("button").attr("tabindex"),
+      "3",
+      "it has the tabindex"
+    );
   },
 });
 
@@ -22,11 +27,14 @@ componentTest("icon and text button", {
 
   test(assert) {
     assert.ok(
-      find("button.btn.btn-icon-text").length,
+      queryAll("button.btn.btn-icon-text").length,
       "it has all the classes"
     );
-    assert.ok(find("button .d-icon.d-icon-plus").length, "it has the icon");
-    assert.ok(find("button span.d-button-label").length, "it has the label");
+    assert.ok(queryAll("button .d-icon.d-icon-plus").length, "it has the icon");
+    assert.ok(
+      queryAll("button span.d-button-label").length,
+      "it has the label"
+    );
   },
 });
 
@@ -34,8 +42,11 @@ componentTest("text only button", {
   template: '{{d-button label="topic.create"}}',
 
   test(assert) {
-    assert.ok(find("button.btn.btn-text").length, "it has all the classes");
-    assert.ok(find("button span.d-button-label").length, "it has the label");
+    assert.ok(queryAll("button.btn.btn-text").length, "it has all the classes");
+    assert.ok(
+      queryAll("button span.d-button-label").length,
+      "it has the label"
+    );
   },
 });
 
@@ -52,7 +63,7 @@ componentTest("link-styled button", {
 
   test(assert) {
     assert.ok(
-      find("button.btn-link:not(.btn)").length,
+      queryAll("button.btn-link:not(.btn)").length,
       "it has the right classes"
     );
   },
@@ -67,22 +78,22 @@ componentTest("isLoading button", {
 
   test(assert) {
     assert.ok(
-      find("button.is-loading .loading-icon").length,
+      queryAll("button.is-loading .loading-icon").length,
       "it has a spinner showing"
     );
     assert.ok(
-      find("button[disabled]").length,
+      queryAll("button[disabled]").length,
       "while loading the button is disabled"
     );
 
     this.set("isLoading", false);
 
     assert.notOk(
-      find("button .loading-icon").length,
+      queryAll("button .loading-icon").length,
       "it doesn't have a spinner showing"
     );
     assert.ok(
-      find("button:not([disabled])").length,
+      queryAll("button:not([disabled])").length,
       "while not loading the button is enabled"
     );
   },
@@ -96,11 +107,14 @@ componentTest("disabled button", {
   },
 
   test(assert) {
-    assert.ok(find("button[disabled]").length, "the button is disabled");
+    assert.ok(queryAll("button[disabled]").length, "the button is disabled");
 
     this.set("disabled", false);
 
-    assert.ok(find("button:not([disabled])").length, "the button is enabled");
+    assert.ok(
+      queryAll("button:not([disabled])").length,
+      "the button is enabled"
+    );
   },
 });
 
@@ -116,7 +130,7 @@ componentTest("aria-label", {
     this.set("ariaLabel", "test.fooAriaLabel");
 
     assert.equal(
-      find("button")[0].getAttribute("aria-label"),
+      queryAll("button")[0].getAttribute("aria-label"),
       I18n.t("test.fooAriaLabel")
     );
 
@@ -125,7 +139,7 @@ componentTest("aria-label", {
       translatedAriaLabel: "bar",
     });
 
-    assert.equal(find("button")[0].getAttribute("aria-label"), "bar");
+    assert.equal(queryAll("button")[0].getAttribute("aria-label"), "bar");
   },
 });
 
@@ -139,7 +153,7 @@ componentTest("title", {
   test(assert) {
     this.set("title", "test.fooTitle");
     assert.equal(
-      find("button")[0].getAttribute("title"),
+      queryAll("button")[0].getAttribute("title"),
       I18n.t("test.fooTitle")
     );
 
@@ -148,7 +162,7 @@ componentTest("title", {
       translatedTitle: "bar",
     });
 
-    assert.equal(find("button")[0].getAttribute("title"), "bar");
+    assert.equal(queryAll("button")[0].getAttribute("title"), "bar");
   },
 });
 
@@ -163,7 +177,7 @@ componentTest("label", {
     this.set("label", "test.fooLabel");
 
     assert.equal(
-      find("button .d-button-label").text(),
+      queryAll("button .d-button-label").text(),
       I18n.t("test.fooLabel")
     );
 
@@ -172,6 +186,6 @@ componentTest("label", {
       translatedLabel: "bar",
     });
 
-    assert.equal(find("button .d-button-label").text(), "bar");
+    assert.equal(queryAll("button .d-button-label").text(), "bar");
   },
 });

--- a/app/assets/javascripts/discourse/tests/integration/components/d-editor-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/d-editor-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { moduleForComponent } from "ember-qunit";
 import I18n from "I18n";
 import { next } from "@ember/runloop";
@@ -17,12 +18,12 @@ componentTest("preview updates with markdown", {
   template: "{{d-editor value=value}}",
 
   async test(assert) {
-    assert.ok(find(".d-editor-button-bar").length);
+    assert.ok(queryAll(".d-editor-button-bar").length);
     await fillIn(".d-editor-input", "hello **world**");
 
     assert.equal(this.value, "hello **world**");
     assert.equal(
-      find(".d-editor-preview").html().trim(),
+      queryAll(".d-editor-preview").html().trim(),
       "<p>hello <strong>world</strong></p>"
     );
   },
@@ -33,7 +34,7 @@ componentTest("preview sanitizes HTML", {
 
   async test(assert) {
     await fillIn(".d-editor-input", `"><svg onload="prompt(/xss/)"></svg>`);
-    assert.equal(find(".d-editor-preview").html().trim(), '<p>"&gt;</p>');
+    assert.equal(queryAll(".d-editor-preview").html().trim(), '<p>"&gt;</p>');
   },
 });
 
@@ -45,10 +46,16 @@ componentTest("updating the value refreshes the preview", {
   },
 
   async test(assert) {
-    assert.equal(find(".d-editor-preview").html().trim(), "<p>evil trout</p>");
+    assert.equal(
+      queryAll(".d-editor-preview").html().trim(),
+      "<p>evil trout</p>"
+    );
 
     await this.set("value", "zogstrip");
-    assert.equal(find(".d-editor-preview").html().trim(), "<p>zogstrip</p>");
+    assert.equal(
+      queryAll(".d-editor-preview").html().trim(),
+      "<p>zogstrip</p>"
+    );
   },
 });
 
@@ -65,7 +72,7 @@ function testCase(title, testFunc) {
       this.set("value", "hello world.");
     },
     test(assert) {
-      const textarea = jumpEnd(find("textarea.d-editor-input")[0]);
+      const textarea = jumpEnd(queryAll("textarea.d-editor-input")[0]);
       testFunc.call(this, assert, textarea);
     },
   });
@@ -78,7 +85,7 @@ function composerTestCase(title, testFunc) {
       this.set("value", "hello world.");
     },
     test(assert) {
-      const textarea = jumpEnd(find("textarea.d-editor-input")[0]);
+      const textarea = jumpEnd(queryAll("textarea.d-editor-input")[0]);
       testFunc.call(this, assert, textarea);
     },
   });
@@ -211,7 +218,7 @@ function xyz(x, y, z) {
   },
 
   async test(assert) {
-    const textarea = find("textarea.d-editor-input")[0];
+    const textarea = queryAll("textarea.d-editor-input")[0];
     textarea.selectionStart = 0;
     textarea.selectionEnd = textarea.value.length;
 
@@ -236,7 +243,7 @@ componentTest("code button", {
   },
 
   async test(assert) {
-    const textarea = jumpEnd(find("textarea.d-editor-input")[0]);
+    const textarea = jumpEnd(queryAll("textarea.d-editor-input")[0]);
 
     await click("button.code");
     assert.equal(this.value, `    ${I18n.t("composer.code_text")}`);
@@ -318,7 +325,7 @@ componentTest("code fences", {
   },
 
   async test(assert) {
-    const textarea = jumpEnd(find("textarea.d-editor-input")[0]);
+    const textarea = jumpEnd(queryAll("textarea.d-editor-input")[0]);
 
     await click("button.code");
     assert.equal(
@@ -430,7 +437,7 @@ componentTest("quote button - empty lines", {
     this.set("value", "one\n\ntwo\n\nthree");
   },
   async test(assert) {
-    const textarea = jumpEnd(find("textarea.d-editor-input")[0]);
+    const textarea = jumpEnd(queryAll("textarea.d-editor-input")[0]);
 
     textarea.selectionStart = 0;
 
@@ -451,7 +458,7 @@ componentTest("quote button - selecting empty lines", {
     this.set("value", "one\n\n\n\ntwo");
   },
   async test(assert) {
-    const textarea = jumpEnd(find("textarea.d-editor-input")[0]);
+    const textarea = jumpEnd(queryAll("textarea.d-editor-input")[0]);
 
     textarea.selectionStart = 6;
     textarea.selectionEnd = 10;
@@ -584,7 +591,7 @@ componentTest("clicking the toggle-direction changes dir from ltr to rtl", {
   },
 
   async test(assert) {
-    const textarea = find("textarea.d-editor-input");
+    const textarea = queryAll("textarea.d-editor-input");
     await click("button.toggle-direction");
     assert.equal(textarea.attr("dir"), "rtl");
   },
@@ -598,7 +605,7 @@ componentTest("clicking the toggle-direction changes dir from ltr to rtl", {
   },
 
   async test(assert) {
-    const textarea = find("textarea.d-editor-input");
+    const textarea = queryAll("textarea.d-editor-input");
     textarea.attr("dir", "ltr");
     await click("button.toggle-direction");
     assert.equal(textarea.attr("dir"), "rtl");
@@ -645,7 +652,7 @@ componentTest("emoji", {
   },
 
   async test(assert) {
-    jumpEnd(find("textarea.d-editor-input")[0]);
+    jumpEnd(queryAll("textarea.d-editor-input")[0]);
     await click("button.emoji");
 
     await click(

--- a/app/assets/javascripts/discourse/tests/integration/components/d-icon-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/d-icon-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { moduleForComponent } from "ember-qunit";
 import componentTest from "discourse/tests/helpers/component-test";
 
@@ -7,7 +8,7 @@ componentTest("default", {
   template: '<div class="test">{{d-icon "bars"}}</div>',
 
   test(assert) {
-    const html = find(".test").html().trim();
+    const html = queryAll(".test").html().trim();
     assert.equal(
       html,
       '<svg class="fa d-icon d-icon-bars svg-icon svg-string" xmlns="http://www.w3.org/2000/svg"><use xlink:href="#bars"></use></svg>'
@@ -19,7 +20,7 @@ componentTest("with replacement", {
   template: '<div class="test">{{d-icon "d-watching"}}</div>',
 
   test(assert) {
-    const html = find(".test").html().trim();
+    const html = queryAll(".test").html().trim();
     assert.equal(
       html,
       '<svg class="fa d-icon d-icon-d-watching svg-icon svg-string" xmlns="http://www.w3.org/2000/svg"><use xlink:href="#discourse-bell-exclamation"></use></svg>'

--- a/app/assets/javascripts/discourse/tests/integration/components/date-input-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/date-input-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { moduleForComponent } from "ember-qunit";
 import componentTest from "discourse/tests/helpers/component-test";
 import { click } from "@ember/test-helpers";
@@ -5,7 +6,7 @@ import { click } from "@ember/test-helpers";
 moduleForComponent("date-input", { integration: true });
 
 function dateInput() {
-  return find(".date-picker");
+  return queryAll(".date-picker");
 }
 
 function setDate(date) {

--- a/app/assets/javascripts/discourse/tests/integration/components/date-time-input-range-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/date-time-input-range-test.js
@@ -1,22 +1,23 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { moduleForComponent } from "ember-qunit";
 import componentTest from "discourse/tests/helpers/component-test";
 
 moduleForComponent("date-time-input-range", { integration: true });
 
 function fromDateInput() {
-  return find(".from.d-date-time-input .date-picker")[0];
+  return queryAll(".from.d-date-time-input .date-picker")[0];
 }
 
 function fromTimeInput() {
-  return find(".from.d-date-time-input .d-time-input .combo-box-header")[0];
+  return queryAll(".from.d-date-time-input .d-time-input .combo-box-header")[0];
 }
 
 function toDateInput() {
-  return find(".to.d-date-time-input .date-picker")[0];
+  return queryAll(".to.d-date-time-input .date-picker")[0];
 }
 
 function toTimeInput() {
-  return find(".to.d-date-time-input .d-time-input .combo-box-header")[0];
+  return queryAll(".to.d-date-time-input .d-time-input .combo-box-header")[0];
 }
 
 const DEFAULT_DATE_TIME = moment("2019-01-29 14:45");

--- a/app/assets/javascripts/discourse/tests/integration/components/date-time-input-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/date-time-input-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
 import { moduleForComponent } from "ember-qunit";
 import componentTest from "discourse/tests/helpers/component-test";
@@ -6,11 +7,11 @@ import { click } from "@ember/test-helpers";
 moduleForComponent("date-time-input", { integration: true });
 
 function dateInput() {
-  return find(".date-picker")[0];
+  return queryAll(".date-picker")[0];
 }
 
 function timeInput() {
-  return find(".d-time-input .combo-box-header")[0];
+  return queryAll(".d-time-input .combo-box-header")[0];
 }
 
 function setDate(date) {

--- a/app/assets/javascripts/discourse/tests/integration/components/highlighted-code-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/highlighted-code-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { moduleForComponent } from "ember-qunit";
 import componentTest from "discourse/tests/helpers/component-test";
 
@@ -16,7 +17,7 @@ componentTest("highlighting code", {
 
   test(assert) {
     assert.equal(
-      find("code.ruby.hljs .hljs-function .hljs-keyword").text().trim(),
+      queryAll("code.ruby.hljs .hljs-function .hljs-keyword").text().trim(),
       "def"
     );
   },
@@ -32,6 +33,6 @@ componentTest("large code blocks are not highlighted", {
   },
 
   test(assert) {
-    assert.equal(find("code").text().trim(), LONG_CODE_BLOCK.trim());
+    assert.equal(queryAll("code").text().trim(), LONG_CODE_BLOCK.trim());
   },
 });

--- a/app/assets/javascripts/discourse/tests/integration/components/iframed-html-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/iframed-html-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { moduleForComponent } from "ember-qunit";
 import componentTest from "discourse/tests/helpers/component-test";
 
@@ -7,7 +8,7 @@ componentTest("appends the html into the iframe", {
   template: `{{iframed-html html="<h1 id='find-me'>hello</h1>" className='this-is-an-iframe'}}`,
 
   async test(assert) {
-    const iframe = find("iframe.this-is-an-iframe");
+    const iframe = queryAll("iframe.this-is-an-iframe");
     assert.equal(iframe.length, 1, "inserts an iframe");
 
     assert.ok(

--- a/app/assets/javascripts/discourse/tests/integration/components/image-uploader-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/image-uploader-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { moduleForComponent } from "ember-qunit";
 import componentTest from "discourse/tests/helpers/component-test";
 import { click } from "@ember/test-helpers";
@@ -10,19 +11,19 @@ componentTest("with image", {
 
   async test(assert) {
     assert.equal(
-      find(".d-icon-far-image").length,
+      queryAll(".d-icon-far-image").length,
       1,
       "it displays the upload icon"
     );
 
     assert.equal(
-      find(".d-icon-far-trash-alt").length,
+      queryAll(".d-icon-far-trash-alt").length,
       1,
       "it displays the trash icon"
     );
 
     assert.equal(
-      find(".placeholder-overlay").length,
+      queryAll(".placeholder-overlay").length,
       0,
       "it does not display the placeholder image"
     );
@@ -42,19 +43,19 @@ componentTest("without image", {
 
   test(assert) {
     assert.equal(
-      find(".d-icon-far-image").length,
+      queryAll(".d-icon-far-image").length,
       1,
       "it displays the upload icon"
     );
 
     assert.equal(
-      find(".d-icon-far-trash-alt").length,
+      queryAll(".d-icon-far-trash-alt").length,
       0,
       "it does not display trash icon"
     );
 
     assert.equal(
-      find(".image-uploader-lightbox-btn").length,
+      queryAll(".image-uploader-lightbox-btn").length,
       0,
       "it does not display the button to open image lightbox"
     );
@@ -66,25 +67,25 @@ componentTest("with placeholder", {
 
   test(assert) {
     assert.equal(
-      find(".d-icon-far-image").length,
+      queryAll(".d-icon-far-image").length,
       1,
       "it displays the upload icon"
     );
 
     assert.equal(
-      find(".d-icon-far-trash-alt").length,
+      queryAll(".d-icon-far-trash-alt").length,
       0,
       "it does not display trash icon"
     );
 
     assert.equal(
-      find(".image-uploader-lightbox-btn").length,
+      queryAll(".image-uploader-lightbox-btn").length,
       0,
       "it does not display the button to open image lightbox"
     );
 
     assert.equal(
-      find(".placeholder-overlay").length,
+      queryAll(".placeholder-overlay").length,
       1,
       "it displays the placeholder image"
     );

--- a/app/assets/javascripts/discourse/tests/integration/components/secret-value-list-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/secret-value-list-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { moduleForComponent } from "ember-qunit";
 import I18n from "I18n";
 import componentTest from "discourse/tests/helpers/component-test";
@@ -15,7 +16,7 @@ componentTest("adding a value", {
     await click(".add-value-btn");
 
     assert.ok(
-      find(".values .value").length === 2,
+      queryAll(".values .value").length === 2,
       "it doesn't add the value to the list if secret is missing"
     );
 
@@ -24,7 +25,7 @@ componentTest("adding a value", {
     await click(".add-value-btn");
 
     assert.ok(
-      find(".values .value").length === 2,
+      queryAll(".values .value").length === 2,
       "it doesn't add the value to the list if key is missing"
     );
 
@@ -33,7 +34,7 @@ componentTest("adding a value", {
     await click(".add-value-btn");
 
     assert.ok(
-      find(".values .value").length === 3,
+      queryAll(".values .value").length === 3,
       "it adds the value to the list of values"
     );
 
@@ -54,7 +55,7 @@ componentTest("adding an invalid value", {
     await click(".add-value-btn");
 
     assert.ok(
-      find(".values .value").length === 0,
+      queryAll(".values .value").length === 0,
       "it doesn't add the value to the list of values"
     );
 
@@ -65,7 +66,7 @@ componentTest("adding an invalid value", {
     );
 
     assert.ok(
-      find(".validation-error")
+      queryAll(".validation-error")
         .html()
         .indexOf(I18n.t("admin.site_settings.secret_list.invalid_input")) > -1,
       "it shows validation error"
@@ -82,7 +83,7 @@ componentTest("removing a value", {
     await click(".values .value[data-index='0'] .remove-value-btn");
 
     assert.ok(
-      find(".values .value").length === 1,
+      queryAll(".values .value").length === 1,
       "it removes the value from the list of values"
     );
 

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/api-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/api-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import componentTest from "discourse/tests/helpers/component-test";
 import selectKit, {
   testSelectKitModule,
@@ -101,7 +102,7 @@ componentTest("modifySelectKit(identifier).onChange", {
 
     withPluginApi("0.8.43", (api) => {
       api.modifySelectKit("combo-box").onChange((component, value, item) => {
-        find("#test").text(item.name);
+        queryAll("#test").text(item.name);
       });
     });
   },
@@ -110,6 +111,6 @@ componentTest("modifySelectKit(identifier).onChange", {
     await this.comboBox.expand();
     await this.comboBox.selectRowByIndex(0);
 
-    assert.equal(find("#test").text(), "foo");
+    assert.equal(queryAll("#test").text(), "foo");
   },
 });

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/mini-tag-chooser-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/mini-tag-chooser-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import I18n from "I18n";
 import componentTest from "discourse/tests/helpers/component-test";
 import { testSelectKitModule } from "discourse/tests/helpers/select-kit-helper";
@@ -32,9 +33,9 @@ componentTest("create a tag", {
 
     await this.subject.expand();
     await this.subject.fillInFilter("mon");
-    assert.equal(find(".select-kit-row").text().trim(), "monkey x1");
+    assert.equal(queryAll(".select-kit-row").text().trim(), "monkey x1");
     await this.subject.fillInFilter("key");
-    assert.equal(find(".select-kit-row").text().trim(), "monkey x1");
+    assert.equal(queryAll(".select-kit-row").text().trim(), "monkey x1");
     await this.subject.keyboard("enter");
 
     assert.equal(this.subject.header().value(), "foo,bar,monkey");
@@ -56,7 +57,7 @@ componentTest("max_tags_per_topic", {
     await this.subject.fillInFilter("baz");
     await this.subject.keyboard("enter");
 
-    const error = find(".select-kit-error").text();
+    const error = queryAll(".select-kit-error").text();
     assert.equal(
       error,
       I18n.t("select_kit.max_content_reached", {

--- a/app/assets/javascripts/discourse/tests/integration/components/share-button-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/share-button-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { moduleForComponent } from "ember-qunit";
 import componentTest from "discourse/tests/helpers/component-test";
 
@@ -7,10 +8,10 @@ componentTest("share button", {
   template: '{{share-button url="https://eviltrout.com"}}',
 
   test(assert) {
-    assert.ok(find(`button.share`).length, "it has all the classes");
+    assert.ok(queryAll(`button.share`).length, "it has all the classes");
 
     assert.ok(
-      find('button[data-share-url="https://eviltrout.com"]').length,
+      queryAll('button[data-share-url="https://eviltrout.com"]').length,
       "it has the data attribute for sharing"
     );
   },

--- a/app/assets/javascripts/discourse/tests/integration/components/simple-list-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/simple-list-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { moduleForComponent } from "ember-qunit";
 import componentTest from "discourse/tests/helpers/component-test";
 import { click, fillIn } from "@ember/test-helpers";
@@ -13,7 +14,7 @@ componentTest("adding a value", {
 
   async test(assert) {
     assert.ok(
-      find(".add-value-btn[disabled]").length,
+      queryAll(".add-value-btn[disabled]").length,
       "while loading the + button is disabled"
     );
 
@@ -21,12 +22,13 @@ componentTest("adding a value", {
     await click(".add-value-btn");
 
     assert.ok(
-      find(".values .value").length === 3,
+      queryAll(".values .value").length === 3,
       "it adds the value to the list of values"
     );
 
     assert.ok(
-      find(".values .value[data-index='2'] .value-input")[0].value === "penar",
+      queryAll(".values .value[data-index='2'] .value-input")[0].value ===
+        "penar",
       "it sets the correct value for added item"
     );
 
@@ -34,7 +36,7 @@ componentTest("adding a value", {
     await keyEvent(".add-value-input", "keydown", 13); // enter
 
     assert.ok(
-      find(".values .value").length === 4,
+      queryAll(".values .value").length === 4,
       "it adds the value when keying Enter"
     );
   },
@@ -51,12 +53,13 @@ componentTest("removing a value", {
     await click(".values .value[data-index='0'] .remove-value-btn");
 
     assert.ok(
-      find(".values .value").length === 1,
+      queryAll(".values .value").length === 1,
       "it removes the value from the list of values"
     );
 
     assert.ok(
-      find(".values .value[data-index='0'] .value-input")[0].value === "osama",
+      queryAll(".values .value[data-index='0'] .value-input")[0].value ===
+        "osama",
       "it removes the correct value"
     );
   },
@@ -74,12 +77,12 @@ componentTest("delimiter support", {
     await click(".add-value-btn");
 
     assert.ok(
-      find(".values .value").length === 3,
+      queryAll(".values .value").length === 3,
       "it adds the value to the list of values"
     );
 
     assert.ok(
-      find(".values .value[data-index='2'] .value-input")[0].value ===
+      queryAll(".values .value[data-index='2'] .value-input")[0].value ===
         "eviltrout",
       "it adds the correct value"
     );

--- a/app/assets/javascripts/discourse/tests/integration/components/text-field-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/text-field-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import sinon from "sinon";
 import { moduleForComponent } from "ember-qunit";
 import I18n from "I18n";
@@ -10,7 +11,7 @@ componentTest("renders correctly with no properties set", {
   template: `{{text-field}}`,
 
   test(assert) {
-    assert.ok(find("input[type=text]").length);
+    assert.ok(queryAll("input[type=text]").length);
   },
 });
 
@@ -22,8 +23,8 @@ componentTest("support a placeholder", {
   },
 
   test(assert) {
-    assert.ok(find("input[type=text]").length);
-    assert.equal(find("input").prop("placeholder"), "placeholder.i18n.key");
+    assert.ok(queryAll("input[type=text]").length);
+    assert.equal(queryAll("input").prop("placeholder"), "placeholder.i18n.key");
   },
 });
 
@@ -34,7 +35,7 @@ componentTest("sets the dir attribute to ltr for Hebrew text", {
   },
 
   test(assert) {
-    assert.equal(find("input").attr("dir"), "rtl");
+    assert.equal(queryAll("input").attr("dir"), "rtl");
   },
 });
 
@@ -45,7 +46,7 @@ componentTest("sets the dir attribute to ltr for English text", {
   },
 
   test(assert) {
-    assert.equal(find("input").attr("dir"), "ltr");
+    assert.equal(queryAll("input").attr("dir"), "ltr");
   },
 });
 

--- a/app/assets/javascripts/discourse/tests/integration/components/user-selector-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/user-selector-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { moduleForComponent } from "ember-qunit";
 import componentTest from "discourse/tests/helpers/component-test";
 
@@ -17,7 +18,7 @@ componentTest("pasting a list of usernames", {
   },
 
   test(assert) {
-    let element = find(".test-selector")[0];
+    let element = queryAll(".test-selector")[0];
 
     assert.equal(this.get("usernames"), "evil,trout");
     paste(element, "zip,zap,zoom");
@@ -48,7 +49,7 @@ componentTest("excluding usernames", {
   },
 
   test(assert) {
-    let element = find(".test-selector")[0];
+    let element = queryAll(".test-selector")[0];
     paste(element, "roman,penar,jeff,robin");
     assert.equal(this.get("usernames"), "mark,roman,penar");
   },

--- a/app/assets/javascripts/discourse/tests/integration/components/value-list-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/value-list-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { moduleForComponent } from "ember-qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import componentTest from "discourse/tests/helpers/component-test";
@@ -20,7 +21,7 @@ componentTest("adding a value", {
     await selectKit().keyboard("enter");
 
     assert.ok(
-      find(".values .value").length === 3,
+      queryAll(".values .value").length === 3,
       "it adds the value to the list of values"
     );
 
@@ -43,7 +44,7 @@ componentTest("removing a value", {
     await click(".values .value[data-index='0'] .remove-value-btn");
 
     assert.ok(
-      find(".values .value").length === 1,
+      queryAll(".values .value").length === 1,
       "it removes the value from the list of values"
     );
 
@@ -52,7 +53,7 @@ componentTest("removing a value", {
     await selectKit().expand();
 
     assert.ok(
-      find(".select-kit-collection li.select-kit-row span.name")[0]
+      queryAll(".select-kit-collection li.select-kit-row span.name")[0]
         .innerText === "vinkas",
       "it adds the removed value to choices"
     );
@@ -74,7 +75,7 @@ componentTest("selecting a value", {
     await selectKit().selectRowByValue("maja");
 
     assert.ok(
-      find(".values .value").length === 3,
+      queryAll(".values .value").length === 3,
       "it adds the value to the list of values"
     );
 
@@ -101,7 +102,7 @@ componentTest("array support", {
     await selectKit().keyboard("enter");
 
     assert.ok(
-      find(".values .value").length === 3,
+      queryAll(".values .value").length === 3,
       "it adds the value to the list of values"
     );
 
@@ -128,7 +129,7 @@ componentTest("delimiter support", {
     await selectKit().keyboard("enter");
 
     assert.ok(
-      find(".values .value").length === 3,
+      queryAll(".values .value").length === 3,
       "it adds the value to the list of values"
     );
 

--- a/app/assets/javascripts/discourse/tests/integration/widgets/actions-summary-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/actions-summary-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import {
   moduleForWidget,
   widgetTest,
@@ -16,11 +17,11 @@ widgetTest("post deleted", {
   },
   test(assert) {
     assert.ok(
-      find(".post-action .d-icon-far-trash-alt").length === 1,
+      queryAll(".post-action .d-icon-far-trash-alt").length === 1,
       "it has the deleted icon"
     );
     assert.ok(
-      find(".avatar[title=eviltrout]").length === 1,
+      queryAll(".avatar[title=eviltrout]").length === 1,
       "it has the deleted by avatar"
     );
   },

--- a/app/assets/javascripts/discourse/tests/integration/widgets/avatar-flair-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/avatar-flair-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import {
   moduleForWidget,
   widgetTest,
@@ -15,10 +16,10 @@ widgetTest("avatar flair with an icon", {
     });
   },
   test(assert) {
-    assert.ok(find(".avatar-flair").length, "it has the tag");
-    assert.ok(find("svg.d-icon-bars").length, "it has the svg icon");
+    assert.ok(queryAll(".avatar-flair").length, "it has the tag");
+    assert.ok(queryAll("svg.d-icon-bars").length, "it has the svg icon");
     assert.equal(
-      find(".avatar-flair").attr("style"),
+      queryAll(".avatar-flair").attr("style"),
       "background-color: #CC0000; color: #FFFFFF; ",
       "it has styles"
     );
@@ -33,7 +34,7 @@ widgetTest("avatar flair with an image", {
     });
   },
   test(assert) {
-    assert.ok(find(".avatar-flair").length, "it has the tag");
-    assert.ok(find("svg").length === 0, "it does not have an svg icon");
+    assert.ok(queryAll(".avatar-flair").length, "it has the tag");
+    assert.ok(queryAll("svg").length === 0, "it does not have an svg icon");
   },
 });

--- a/app/assets/javascripts/discourse/tests/integration/widgets/button-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/button-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import {
   moduleForWidget,
   widgetTest,
@@ -14,11 +15,11 @@ widgetTest("icon only button", {
 
   test(assert) {
     assert.ok(
-      find("button.btn.btn-icon.no-text").length,
+      queryAll("button.btn.btn-icon.no-text").length,
       "it has all the classes"
     );
     assert.ok(
-      find("button .d-icon.d-icon-far-smile").length,
+      queryAll("button .d-icon.d-icon-far-smile").length,
       "it has the icon"
     );
   },
@@ -33,11 +34,14 @@ widgetTest("icon and text button", {
 
   test(assert) {
     assert.ok(
-      find("button.btn.btn-icon-text").length,
+      queryAll("button.btn.btn-icon-text").length,
       "it has all the classes"
     );
-    assert.ok(find("button .d-icon.d-icon-plus").length, "it has the icon");
-    assert.ok(find("button span.d-button-label").length, "it has the label");
+    assert.ok(queryAll("button .d-icon.d-icon-plus").length, "it has the icon");
+    assert.ok(
+      queryAll("button span.d-button-label").length,
+      "it has the label"
+    );
   },
 });
 
@@ -49,7 +53,10 @@ widgetTest("text only button", {
   },
 
   test(assert) {
-    assert.ok(find("button.btn.btn-text").length, "it has all the classes");
-    assert.ok(find("button span.d-button-label").length, "it has the label");
+    assert.ok(queryAll("button.btn.btn-text").length, "it has all the classes");
+    assert.ok(
+      queryAll("button span.d-button-label").length,
+      "it has the label"
+    );
   },
 });

--- a/app/assets/javascripts/discourse/tests/integration/widgets/default-notification-item-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/default-notification-item-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import EmberObject from "@ember/object";
 import pretender from "discourse/tests/helpers/create-pretender";
 import {
@@ -47,17 +48,17 @@ widgetTest("sets notification as read on middle click", {
       return [200, { "Content-Type": "application/json" }, { success: true }];
     });
 
-    assert.equal(find("li.read").length, 0);
+    assert.equal(queryAll("li.read").length, 0);
 
     await $(document).trigger(
       $.Event("mouseup", {
-        target: find("li")[0],
+        target: queryAll("li")[0],
         button: 1,
         which: 2,
       })
     );
 
-    assert.equal(find("li.read").length, 1);
+    assert.equal(queryAll("li.read").length, 1);
     assert.equal(requests, 1);
   },
 });

--- a/app/assets/javascripts/discourse/tests/integration/widgets/hamburger-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/hamburger-menu-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import {
   moduleForWidget,
   widgetTest,
@@ -20,8 +21,8 @@ widgetTest("prioritize faq", {
   },
 
   test(assert) {
-    assert.ok(find(".faq-priority").length);
-    assert.ok(!find(".faq-link").length);
+    assert.ok(queryAll(".faq-priority").length);
+    assert.ok(!queryAll(".faq-link").length);
   },
 });
 
@@ -34,8 +35,8 @@ widgetTest("prioritize faq - user has read", {
   },
 
   test(assert) {
-    assert.ok(!find(".faq-priority").length);
-    assert.ok(find(".faq-link").length);
+    assert.ok(!queryAll(".faq-priority").length);
+    assert.ok(queryAll(".faq-link").length);
   },
 });
 
@@ -47,7 +48,7 @@ widgetTest("staff menu - not staff", {
   },
 
   test(assert) {
-    assert.ok(!find(".admin-link").length);
+    assert.ok(!queryAll(".admin-link").length);
   },
 });
 
@@ -59,9 +60,9 @@ widgetTest("staff menu - moderator", {
   },
 
   test(assert) {
-    assert.ok(find(".admin-link").length);
-    assert.ok(find(".review").length);
-    assert.ok(!find(".settings-link").length);
+    assert.ok(queryAll(".admin-link").length);
+    assert.ok(queryAll(".review").length);
+    assert.ok(!queryAll(".settings-link").length);
   },
 });
 
@@ -73,7 +74,7 @@ widgetTest("staff menu - admin", {
   },
 
   test(assert) {
-    assert.ok(find(".settings-link").length);
+    assert.ok(queryAll(".settings-link").length);
   },
 });
 
@@ -81,8 +82,8 @@ widgetTest("logged in links", {
   template: '{{mount-widget widget="hamburger-menu"}}',
 
   test(assert) {
-    assert.ok(find(".new-topics-link").length);
-    assert.ok(find(".unread-topics-link").length);
+    assert.ok(queryAll(".new-topics-link").length);
+    assert.ok(queryAll(".unread-topics-link").length);
   },
 });
 
@@ -91,13 +92,13 @@ widgetTest("general links", {
   anonymous: true,
 
   test(assert) {
-    assert.ok(find("li[class='']").length === 0);
-    assert.ok(find(".latest-topics-link").length);
-    assert.ok(!find(".new-topics-link").length);
-    assert.ok(!find(".unread-topics-link").length);
-    assert.ok(find(".top-topics-link").length);
-    assert.ok(find(".badge-link").length);
-    assert.ok(find(".category-link").length > 0);
+    assert.ok(queryAll("li[class='']").length === 0);
+    assert.ok(queryAll(".latest-topics-link").length);
+    assert.ok(!queryAll(".new-topics-link").length);
+    assert.ok(!queryAll(".unread-topics-link").length);
+    assert.ok(queryAll(".top-topics-link").length);
+    assert.ok(queryAll(".badge-link").length);
+    assert.ok(queryAll(".category-link").length > 0);
   },
 });
 
@@ -112,9 +113,9 @@ widgetTest("top categories - anonymous", {
   },
 
   test(assert) {
-    assert.equal(find(".category-link").length, 8);
+    assert.equal(queryAll(".category-link").length, 8);
     assert.equal(
-      find(".category-link .category-name").text(),
+      queryAll(".category-link .category-name").text(),
       this.site
         .get("categoriesByCount")
         .slice(0, 8)
@@ -134,9 +135,9 @@ widgetTest("top categories - allow_uncategorized_topics", {
   },
 
   test(assert) {
-    assert.equal(find(".category-link").length, 8);
+    assert.equal(queryAll(".category-link").length, 8);
     assert.equal(
-      find(".category-link .category-name").text(),
+      queryAll(".category-link .category-name").text(),
       this.site
         .get("categoriesByCount")
         .filter((c) => c.name !== "uncategorized")
@@ -186,7 +187,7 @@ widgetTest("top categories", {
   },
 
   test(assert) {
-    assert.equal(find(".category-link").length, maxCategoriesToDisplay);
+    assert.equal(queryAll(".category-link").length, maxCategoriesToDisplay);
 
     categoriesByCount = categoriesByCount.filter(
       (c) => !mutedCategoryIds.includes(c.id)
@@ -200,7 +201,7 @@ widgetTest("top categories", {
       .slice(0, maxCategoriesToDisplay);
 
     assert.equal(
-      find(".category-link .category-name").text(),
+      queryAll(".category-link .category-name").text(),
       ids.map((i) => categoriesByCount.find((c) => c.id === i).name).join("")
     );
   },
@@ -214,7 +215,7 @@ widgetTest("badges link - disabled", {
   },
 
   test(assert) {
-    assert.ok(!find(".badge-link").length);
+    assert.ok(!queryAll(".badge-link").length);
   },
 });
 
@@ -222,7 +223,7 @@ widgetTest("badges link", {
   template: '{{mount-widget widget="hamburger-menu"}}',
 
   test(assert) {
-    assert.ok(find(".badge-link").length);
+    assert.ok(queryAll(".badge-link").length);
   },
 });
 
@@ -230,7 +231,7 @@ widgetTest("user directory link", {
   template: '{{mount-widget widget="hamburger-menu"}}',
 
   test(assert) {
-    assert.ok(find(".user-directory-link").length);
+    assert.ok(queryAll(".user-directory-link").length);
   },
 });
 
@@ -242,7 +243,7 @@ widgetTest("user directory link - disabled", {
   },
 
   test(assert) {
-    assert.ok(!find(".user-directory-link").length);
+    assert.ok(!queryAll(".user-directory-link").length);
   },
 });
 
@@ -250,7 +251,7 @@ widgetTest("general links", {
   template: '{{mount-widget widget="hamburger-menu"}}',
 
   test(assert) {
-    assert.ok(find(".about-link").length);
-    assert.ok(find(".keyboard-shortcuts-link").length);
+    assert.ok(queryAll(".about-link").length);
+    assert.ok(queryAll(".keyboard-shortcuts-link").length);
   },
 });

--- a/app/assets/javascripts/discourse/tests/integration/widgets/header-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/header-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
 import {
   moduleForWidget,
@@ -10,8 +11,8 @@ moduleForWidget("header");
 widgetTest("rendering basics", {
   template: '{{mount-widget widget="header"}}',
   test(assert) {
-    assert.ok(find("header.d-header").length);
-    assert.ok(find("#site-logo").length);
+    assert.ok(queryAll("header.d-header").length);
+    assert.ok(queryAll("#site-logo").length);
   },
 });
 
@@ -27,8 +28,8 @@ widgetTest("sign up / login buttons", {
   },
 
   async test(assert) {
-    assert.ok(find("button.sign-up-button").length);
-    assert.ok(find("button.login-button").length);
+    assert.ok(queryAll("button.sign-up-button").length);
+    assert.ok(queryAll("button.login-button").length);
 
     await click("button.sign-up-button");
     assert.ok(this.signupShown);

--- a/app/assets/javascripts/discourse/tests/integration/widgets/home-logo-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/home-logo-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import {
   moduleForWidget,
   widgetTest,
@@ -23,11 +24,11 @@ widgetTest("basics", {
   },
 
   test(assert) {
-    assert.ok(find(".title").length === 1);
+    assert.ok(queryAll(".title").length === 1);
 
-    assert.ok(find("img#site-logo.logo-big").length === 1);
-    assert.equal(find("#site-logo").attr("src"), bigLogo);
-    assert.equal(find("#site-logo").attr("alt"), title);
+    assert.ok(queryAll("img#site-logo.logo-big").length === 1);
+    assert.equal(queryAll("#site-logo").attr("src"), bigLogo);
+    assert.equal(queryAll("#site-logo").attr("alt"), title);
   },
 });
 
@@ -41,10 +42,10 @@ widgetTest("basics - minimized", {
   },
 
   test(assert) {
-    assert.ok(find("img.logo-small").length === 1);
-    assert.equal(find("img.logo-small").attr("src"), smallLogo);
-    assert.equal(find("img.logo-small").attr("alt"), title);
-    assert.equal(find("img.logo-small").attr("width"), 36);
+    assert.ok(queryAll("img.logo-small").length === 1);
+    assert.equal(queryAll("img.logo-small").attr("src"), smallLogo);
+    assert.equal(queryAll("img.logo-small").attr("alt"), title);
+    assert.equal(queryAll("img.logo-small").attr("width"), 36);
   },
 });
 
@@ -58,8 +59,8 @@ widgetTest("no logo", {
   },
 
   test(assert) {
-    assert.ok(find("h1#site-text-logo.text-logo").length === 1);
-    assert.equal(find("#site-text-logo").text(), title);
+    assert.ok(queryAll("h1#site-text-logo.text-logo").length === 1);
+    assert.equal(queryAll("#site-text-logo").text(), title);
   },
 });
 
@@ -73,7 +74,7 @@ widgetTest("no logo - minimized", {
   },
 
   test(assert) {
-    assert.ok(find(".d-icon-home").length === 1);
+    assert.ok(queryAll(".d-icon-home").length === 1);
   },
 });
 
@@ -86,8 +87,8 @@ widgetTest("mobile logo", {
   },
 
   test(assert) {
-    assert.ok(find("img#site-logo.logo-mobile").length === 1);
-    assert.equal(find("#site-logo").attr("src"), mobileLogo);
+    assert.ok(queryAll("img#site-logo.logo-mobile").length === 1);
+    assert.equal(queryAll("#site-logo").attr("src"), mobileLogo);
   },
 });
 
@@ -99,8 +100,8 @@ widgetTest("mobile without logo", {
   },
 
   test(assert) {
-    assert.ok(find("img#site-logo.logo-big").length === 1);
-    assert.equal(find("#site-logo").attr("src"), bigLogo);
+    assert.ok(queryAll("img#site-logo.logo-big").length === 1);
+    assert.equal(queryAll("#site-logo").attr("src"), bigLogo);
   },
 });
 
@@ -116,16 +117,16 @@ widgetTest("logo with dark mode alternative", {
   },
 
   test(assert) {
-    assert.ok(find("img#site-logo.logo-big").length === 1);
-    assert.equal(find("#site-logo").attr("src"), bigLogo);
+    assert.ok(queryAll("img#site-logo.logo-big").length === 1);
+    assert.equal(queryAll("#site-logo").attr("src"), bigLogo);
 
     assert.equal(
-      find("picture source").attr("media"),
+      queryAll("picture source").attr("media"),
       prefersDark,
       "includes dark mode media attribute"
     );
     assert.equal(
-      find("picture source").attr("srcset"),
+      queryAll("picture source").attr("srcset"),
       darkLogo,
       "includes dark mode alternative logo source"
     );
@@ -147,15 +148,15 @@ widgetTest("mobile logo with dark mode alternative", {
   },
 
   test(assert) {
-    assert.equal(find("#site-logo").attr("src"), mobileLogo);
+    assert.equal(queryAll("#site-logo").attr("src"), mobileLogo);
 
     assert.equal(
-      find("picture source").attr("media"),
+      queryAll("picture source").attr("media"),
       prefersDark,
       "includes dark mode media attribute"
     );
     assert.equal(
-      find("picture source").attr("srcset"),
+      queryAll("picture source").attr("srcset"),
       darkLogo,
       "includes dark mode alternative logo source"
     );
@@ -174,10 +175,10 @@ widgetTest("dark mode enabled but no dark logo set", {
   },
 
   test(assert) {
-    assert.ok(find("img#site-logo.logo-big").length === 1);
-    assert.equal(find("#site-logo").attr("src"), bigLogo);
+    assert.ok(queryAll("img#site-logo.logo-big").length === 1);
+    assert.equal(queryAll("#site-logo").attr("src"), bigLogo);
     assert.ok(
-      find("picture").length === 0,
+      queryAll("picture").length === 0,
       "does not include alternative logo"
     );
   },
@@ -191,10 +192,10 @@ widgetTest("dark logo set but no dark mode", {
   },
 
   test(assert) {
-    assert.ok(find("img#site-logo.logo-big").length === 1);
-    assert.equal(find("#site-logo").attr("src"), bigLogo);
+    assert.ok(queryAll("img#site-logo.logo-big").length === 1);
+    assert.equal(queryAll("#site-logo").attr("src"), bigLogo);
     assert.ok(
-      find("picture").length === 0,
+      queryAll("picture").length === 0,
       "does not include alternative logo"
     );
   },
@@ -211,10 +212,14 @@ widgetTest("dark color scheme and dark logo set", {
     Session.currentProp("defaultColorSchemeIsDark", null);
   },
   test(assert) {
-    assert.ok(find("img#site-logo.logo-big").length === 1);
-    assert.equal(find("#site-logo").attr("src"), darkLogo, "uses dark logo");
+    assert.ok(queryAll("img#site-logo.logo-big").length === 1);
+    assert.equal(
+      queryAll("#site-logo").attr("src"),
+      darkLogo,
+      "uses dark logo"
+    );
     assert.ok(
-      find("picture").length === 0,
+      queryAll("picture").length === 0,
       "does not add dark mode alternative"
     );
   },
@@ -231,9 +236,9 @@ widgetTest("dark color scheme and dark logo not set", {
     Session.currentProp("defaultColorSchemeIsDark", null);
   },
   test(assert) {
-    assert.ok(find("img#site-logo.logo-big").length === 1);
+    assert.ok(queryAll("img#site-logo.logo-big").length === 1);
     assert.equal(
-      find("#site-logo").attr("src"),
+      queryAll("#site-logo").attr("src"),
       bigLogo,
       "uses regular logo on dark scheme if no dark logo"
     );

--- a/app/assets/javascripts/discourse/tests/integration/widgets/post-links-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/post-links-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import {
   moduleForWidget,
   widgetTest,
@@ -27,7 +28,7 @@ widgetTest("duplicate links", {
   },
   test(assert) {
     assert.equal(
-      find(".post-links a.track-link").length,
+      queryAll(".post-links a.track-link").length,
       1,
       "it hides the dupe link"
     );
@@ -51,8 +52,8 @@ widgetTest("collapsed links", {
     });
   },
   async test(assert) {
-    assert.ok(find(".expand-links").length === 1, "collapsed by default");
+    assert.ok(queryAll(".expand-links").length === 1, "collapsed by default");
     await click("a.expand-links");
-    assert.equal(find(".post-links a.track-link").length, 7);
+    assert.equal(queryAll(".post-links a.track-link").length, 7);
   },
 });

--- a/app/assets/javascripts/discourse/tests/integration/widgets/post-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/post-menu-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import {
   moduleForWidget,
   widgetTest,
@@ -24,7 +25,7 @@ widgetTest("add extra button", {
   },
   async test(assert) {
     assert.ok(
-      find(".actions .extra-buttons .hot-coffee").length === 1,
+      queryAll(".actions .extra-buttons .hot-coffee").length === 1,
       "It renders extra button"
     );
   },
@@ -40,7 +41,7 @@ widgetTest("remove extra button", {
   },
   async test(assert) {
     assert.ok(
-      find(".actions .extra-buttons .hot-coffee").length === 0,
+      queryAll(".actions .extra-buttons .hot-coffee").length === 0,
       "It doesn't removes coffee button"
     );
   },

--- a/app/assets/javascripts/discourse/tests/integration/widgets/post-stream-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/post-stream-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import {
   moduleForWidget,
   widgetTest,
@@ -65,55 +66,55 @@ postStreamTest("basics", {
   },
 
   test(assert) {
-    assert.equal(find(".post-stream").length, 1);
-    assert.equal(find(".topic-post").length, 6, "renders all posts");
+    assert.equal(queryAll(".post-stream").length, 1);
+    assert.equal(queryAll(".topic-post").length, 6, "renders all posts");
 
     // look for special class bindings
     assert.equal(
-      find(".topic-post:eq(0).topic-owner").length,
+      queryAll(".topic-post:eq(0).topic-owner").length,
       1,
       "it applies the topic owner class"
     );
     assert.equal(
-      find(".topic-post:eq(0).group-trout").length,
+      queryAll(".topic-post:eq(0).group-trout").length,
       1,
       "it applies the primary group class"
     );
     assert.equal(
-      find(".topic-post:eq(0).regular").length,
+      queryAll(".topic-post:eq(0).regular").length,
       1,
       "it applies the regular class"
     );
     assert.equal(
-      find(".topic-post:eq(1).moderator").length,
+      queryAll(".topic-post:eq(1).moderator").length,
       1,
       "it applies the moderator class"
     );
     assert.equal(
-      find(".topic-post:eq(2).post-hidden").length,
+      queryAll(".topic-post:eq(2).post-hidden").length,
       1,
       "it applies the hidden class"
     );
     assert.equal(
-      find(".topic-post:eq(3).whisper").length,
+      queryAll(".topic-post:eq(3).whisper").length,
       1,
       "it applies the whisper class"
     );
     assert.equal(
-      find(".topic-post:eq(4).wiki").length,
+      queryAll(".topic-post:eq(4).wiki").length,
       1,
       "it applies the wiki class"
     );
 
     // it renders an article for the body with appropriate attributes
-    assert.equal(find("article#post_2").length, 1);
-    assert.equal(find("article[data-user-id=123]").length, 1);
-    assert.equal(find("article[data-post-id=3]").length, 1);
-    assert.equal(find("article#post_5.via-email").length, 1);
-    assert.equal(find("article#post_6.is-auto-generated").length, 1);
+    assert.equal(queryAll("article#post_2").length, 1);
+    assert.equal(queryAll("article[data-user-id=123]").length, 1);
+    assert.equal(queryAll("article[data-post-id=3]").length, 1);
+    assert.equal(queryAll("article#post_5.via-email").length, 1);
+    assert.equal(queryAll("article#post_6.is-auto-generated").length, 1);
 
     assert.equal(
-      find("article:eq(0) .main-avatar").length,
+      queryAll("article:eq(0) .main-avatar").length,
       1,
       "renders the main avatar"
     );
@@ -136,12 +137,12 @@ postStreamTest("deleted posts", {
 
   test(assert) {
     assert.equal(
-      find(".topic-post.deleted").length,
+      queryAll(".topic-post.deleted").length,
       1,
       "it applies the deleted class"
     );
     assert.equal(
-      find(".deleted-user-avatar").length,
+      queryAll(".deleted-user-avatar").length,
       1,
       "it has the trash avatar"
     );

--- a/app/assets/javascripts/discourse/tests/integration/widgets/post-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/post-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import I18n from "I18n";
 import EmberObject from "@ember/object";
 import {
@@ -14,11 +15,11 @@ widgetTest("basic elements", {
     this.set("args", { shareUrl: "/example", post_number: 1 });
   },
   test(assert) {
-    assert.ok(find(".names").length, "includes poster name");
+    assert.ok(queryAll(".names").length, "includes poster name");
 
-    assert.ok(find("a.post-date").length, "includes post date");
-    assert.ok(find("a.post-date[data-share-url]").length);
-    assert.ok(find("a.post-date[data-post-number]").length);
+    assert.ok(queryAll("a.post-date").length, "includes post date");
+    assert.ok(queryAll("a.post-date[data-share-url]").length);
+    assert.ok(queryAll("a.post-date[data-post-number]").length);
   },
 });
 
@@ -35,8 +36,8 @@ widgetTest("post - links", {
     });
   },
   async test(assert) {
-    assert.equal(find(".badge.clicks:nth(0)").text(), "1");
-    assert.equal(find(".badge.clicks:nth(1)").text(), "2");
+    assert.equal(queryAll(".badge.clicks:nth(0)").text(), "1");
+    assert.equal(queryAll(".badge.clicks:nth(1)").text(), "2");
   },
 });
 
@@ -133,8 +134,8 @@ widgetTest("whisper", {
     this.set("args", { isWhisper: true });
   },
   test(assert) {
-    assert.ok(find(".topic-post.whisper").length === 1);
-    assert.ok(find(".post-info.whisper").length === 1);
+    assert.ok(queryAll(".topic-post.whisper").length === 1);
+    assert.ok(queryAll(".post-info.whisper").length === 1);
   },
 });
 
@@ -153,18 +154,18 @@ widgetTest("like count button", {
     this.set("args", { likeCount: 1 });
   },
   async test(assert) {
-    assert.ok(find("button.like-count").length === 1);
-    assert.ok(find(".who-liked").length === 0);
+    assert.ok(queryAll("button.like-count").length === 1);
+    assert.ok(queryAll(".who-liked").length === 0);
 
     // toggle it on
     await click("button.like-count");
-    assert.ok(find(".who-liked").length === 1);
-    assert.ok(find(".who-liked a.trigger-user-card").length === 1);
+    assert.ok(queryAll(".who-liked").length === 1);
+    assert.ok(queryAll(".who-liked a.trigger-user-card").length === 1);
 
     // toggle it off
     await click("button.like-count");
-    assert.ok(find(".who-liked").length === 0);
-    assert.ok(find(".who-liked a.trigger-user-card").length === 0);
+    assert.ok(queryAll(".who-liked").length === 0);
+    assert.ok(queryAll(".who-liked a.trigger-user-card").length === 0);
   },
 });
 
@@ -174,7 +175,7 @@ widgetTest(`like count with no likes`, {
     this.set("args", { likeCount: 0 });
   },
   test(assert) {
-    assert.ok(find("button.like-count").length === 0);
+    assert.ok(queryAll("button.like-count").length === 0);
   },
 });
 
@@ -185,7 +186,7 @@ widgetTest("share button", {
   },
   test(assert) {
     assert.ok(
-      !!find(".actions button[data-share-url]").length,
+      !!queryAll(".actions button[data-share-url]").length,
       "it renders a share button"
     );
   },
@@ -203,18 +204,18 @@ widgetTest("liking", {
     });
   },
   async test(assert) {
-    assert.ok(!!find(".actions button.like").length);
-    assert.ok(find(".actions button.like-count").length === 0);
+    assert.ok(!!queryAll(".actions button.like").length);
+    assert.ok(queryAll(".actions button.like-count").length === 0);
 
     await click(".actions button.like");
-    assert.ok(!find(".actions button.like").length);
-    assert.ok(!!find(".actions button.has-like").length);
-    assert.ok(find(".actions button.like-count").length === 1);
+    assert.ok(!queryAll(".actions button.like").length);
+    assert.ok(!!queryAll(".actions button.has-like").length);
+    assert.ok(queryAll(".actions button.like-count").length === 1);
 
     await click(".actions button.has-like");
-    assert.ok(!!find(".actions button.like").length);
-    assert.ok(!find(".actions button.has-like").length);
-    assert.ok(find(".actions button.like-count").length === 0);
+    assert.ok(!!queryAll(".actions button.like").length);
+    assert.ok(!queryAll(".actions button.has-like").length);
+    assert.ok(queryAll(".actions button.like-count").length === 0);
   },
 });
 
@@ -228,11 +229,11 @@ widgetTest("anon liking", {
     this.on("showLogin", () => (this.loginShown = true));
   },
   async test(assert) {
-    assert.ok(!!find(".actions button.like").length);
-    assert.ok(find(".actions button.like-count").length === 0);
+    assert.ok(!!queryAll(".actions button.like").length);
+    assert.ok(queryAll(".actions button.like-count").length === 0);
 
     assert.equal(
-      find("button.like").attr("title"),
+      queryAll("button.like").attr("title"),
       I18n.t("post.controls.like"),
       `shows the right button title for anonymous users`
     );
@@ -261,7 +262,7 @@ widgetTest(`edit button - can't edit`, {
     this.set("args", { canEdit: false });
   },
   test(assert) {
-    assert.equal(find("button.edit").length, 0, `button is not displayed`);
+    assert.equal(queryAll("button.edit").length, 0, `button is not displayed`);
   },
 });
 
@@ -297,7 +298,11 @@ widgetTest(`delete topic button - can't delete`, {
     this.set("args", { canDeleteTopic: false });
   },
   test(assert) {
-    assert.equal(find("button.delete").length, 0, `button is not displayed`);
+    assert.equal(
+      queryAll("button.delete").length,
+      0,
+      `button is not displayed`
+    );
   },
 });
 
@@ -316,10 +321,14 @@ widgetTest(
     async test(assert) {
       await click(".show-more-actions");
 
-      assert.equal(find("button.create-flag").length, 1, `button is displayed`);
-      assert.equal(find("button.delete").length, 1, `button is displayed`);
       assert.equal(
-        find("button.delete").attr("title"),
+        queryAll("button.create-flag").length,
+        1,
+        `button is displayed`
+      );
+      assert.equal(queryAll("button.delete").length, 1, `button is displayed`);
+      assert.equal(
+        queryAll("button.delete").attr("title"),
         I18n.t("post.controls.delete_topic_disallowed"),
         `shows the right button title for users without permissions`
       );
@@ -346,7 +355,11 @@ widgetTest(`recover topic button - can't recover`, {
     this.set("args", { canRecoverTopic: false });
   },
   test(assert) {
-    assert.equal(find("button.recover").length, 0, `button is not displayed`);
+    assert.equal(
+      queryAll("button.recover").length,
+      0,
+      `button is not displayed`
+    );
   },
 });
 
@@ -370,7 +383,11 @@ widgetTest(`delete post button - can't delete`, {
     this.set("args", { canDelete: false });
   },
   test(assert) {
-    assert.equal(find("button.delete").length, 0, `button is not displayed`);
+    assert.equal(
+      queryAll("button.delete").length,
+      0,
+      `button is not displayed`
+    );
   },
 });
 
@@ -385,12 +402,12 @@ widgetTest(`delete post button - can't delete, can't flag`, {
   },
   test(assert) {
     assert.equal(
-      find("button.delete").length,
+      queryAll("button.delete").length,
       0,
       `delete button is not displayed`
     );
     assert.equal(
-      find("button.create-flag").length,
+      queryAll("button.create-flag").length,
       0,
       `flag button is not displayed`
     );
@@ -416,7 +433,11 @@ widgetTest(`recover post button - can't recover`, {
     this.set("args", { canRecover: false });
   },
   test(assert) {
-    assert.equal(find("button.recover").length, 0, `button is not displayed`);
+    assert.equal(
+      queryAll("button.recover").length,
+      0,
+      `button is not displayed`
+    );
   },
 });
 
@@ -428,7 +449,7 @@ widgetTest(`flagging`, {
     this.on("showFlags", () => (this.flagsShown = true));
   },
   async test(assert) {
-    assert.ok(find("button.create-flag").length === 1);
+    assert.ok(queryAll("button.create-flag").length === 1);
 
     await click("button.create-flag");
     assert.ok(this.flagsShown, "it triggered the action");
@@ -441,7 +462,7 @@ widgetTest(`flagging: can't flag`, {
     this.set("args", { canFlag: false });
   },
   test(assert) {
-    assert.ok(find("button.create-flag").length === 0);
+    assert.ok(queryAll("button.create-flag").length === 0);
   },
 });
 
@@ -451,7 +472,7 @@ widgetTest(`flagging: can't flag when post is hidden`, {
     this.set("args", { canFlag: true, hidden: true });
   },
   test(assert) {
-    assert.ok(find("button.create-flag").length === 0);
+    assert.ok(queryAll("button.create-flag").length === 0);
   },
 });
 
@@ -461,7 +482,7 @@ widgetTest(`read indicator`, {
     this.set("args", { read: true });
   },
   test(assert) {
-    assert.ok(find(".read-state.read").length);
+    assert.ok(queryAll(".read-state.read").length);
   },
 });
 
@@ -471,7 +492,7 @@ widgetTest(`unread indicator`, {
     this.set("args", { read: false });
   },
   test(assert) {
-    assert.ok(find(".read-state").length);
+    assert.ok(queryAll(".read-state").length);
   },
 });
 
@@ -485,9 +506,9 @@ widgetTest("reply directly above (supressed)", {
     });
   },
   test(assert) {
-    assert.equal(find("a.reply-to-tab").length, 0, "hides the tab");
+    assert.equal(queryAll("a.reply-to-tab").length, 0, "hides the tab");
     assert.equal(
-      find(".avoid-tab").length,
+      queryAll(".avoid-tab").length,
       0,
       "doesn't have the avoid tab class"
     );
@@ -504,8 +525,8 @@ widgetTest("reply a few posts above (supressed)", {
     });
   },
   test(assert) {
-    assert.ok(find("a.reply-to-tab").length, "shows the tab");
-    assert.equal(find(".avoid-tab").length, 1, "has the avoid tab class");
+    assert.ok(queryAll("a.reply-to-tab").length, "shows the tab");
+    assert.equal(queryAll(".avoid-tab").length, 1, "has the avoid tab class");
   },
 });
 
@@ -520,10 +541,10 @@ widgetTest("reply directly above", {
     this.siteSettings.suppress_reply_directly_above = false;
   },
   async test(assert) {
-    assert.equal(find(".avoid-tab").length, 1, "has the avoid tab class");
+    assert.equal(queryAll(".avoid-tab").length, 1, "has the avoid tab class");
     await click("a.reply-to-tab");
-    assert.equal(find("section.embedded-posts.top .cooked").length, 1);
-    assert.equal(find("section.embedded-posts .d-icon-arrow-up").length, 1);
+    assert.equal(queryAll("section.embedded-posts.top .cooked").length, 1);
+    assert.equal(queryAll("section.embedded-posts .d-icon-arrow-up").length, 1);
   },
 });
 
@@ -548,7 +569,7 @@ widgetTest("expand first post", {
   },
   async test(assert) {
     await click(".topic-body .expand-post");
-    assert.equal(find(".expand-post").length, 0, "button is gone");
+    assert.equal(queryAll(".expand-post").length, 0, "button is gone");
   },
 });
 
@@ -558,8 +579,8 @@ widgetTest("can't bookmark", {
     this.set("args", { canBookmark: false });
   },
   test(assert) {
-    assert.equal(find("button.bookmark").length, 0);
-    assert.equal(find("button.bookmarked").length, 0);
+    assert.equal(queryAll("button.bookmark").length, 0);
+    assert.equal(queryAll("button.bookmarked").length, 0);
   },
 });
 
@@ -573,8 +594,8 @@ widgetTest("bookmark", {
     this.on("toggleBookmark", () => (args.bookmarked = true));
   },
   async test(assert) {
-    assert.equal(find(".post-menu-area .bookmark").length, 1);
-    assert.equal(find("button.bookmarked").length, 0);
+    assert.equal(queryAll(".post-menu-area .bookmark").length, 1);
+    assert.equal(queryAll("button.bookmarked").length, 0);
   },
 });
 
@@ -584,7 +605,7 @@ widgetTest("can't show admin menu when you can't manage", {
     this.set("args", { canManage: false });
   },
   test(assert) {
-    assert.equal(find(".post-menu-area .show-post-admin-menu").length, 0);
+    assert.equal(queryAll(".post-menu-area .show-post-admin-menu").length, 0);
   },
 });
 
@@ -594,12 +615,12 @@ widgetTest("show admin menu", {
     this.set("args", { canManage: true });
   },
   async test(assert) {
-    assert.equal(find(".post-admin-menu").length, 0);
+    assert.equal(queryAll(".post-admin-menu").length, 0);
     await click(".post-menu-area .show-post-admin-menu");
-    assert.equal(find(".post-admin-menu").length, 1, "it shows the popup");
+    assert.equal(queryAll(".post-admin-menu").length, 1, "it shows the popup");
     await click(".post-menu-area");
     assert.equal(
-      find(".post-admin-menu").length,
+      queryAll(".post-admin-menu").length,
       0,
       "clicking outside clears the popup"
     );
@@ -619,7 +640,7 @@ widgetTest("toggle moderator post", {
     await click(".post-admin-menu .toggle-post-type");
 
     assert.ok(this.toggled);
-    assert.equal(find(".post-admin-menu").length, 0, "also hides the menu");
+    assert.equal(queryAll(".post-admin-menu").length, 0, "also hides the menu");
   },
 });
 widgetTest("toggle moderator post", {
@@ -635,7 +656,7 @@ widgetTest("toggle moderator post", {
     await click(".post-admin-menu .toggle-post-type");
 
     assert.ok(this.toggled);
-    assert.equal(find(".post-admin-menu").length, 0, "also hides the menu");
+    assert.equal(queryAll(".post-admin-menu").length, 0, "also hides the menu");
   },
 });
 
@@ -650,7 +671,7 @@ widgetTest("rebake post", {
     await click(".post-menu-area .show-post-admin-menu");
     await click(".post-admin-menu .rebuild-html");
     assert.ok(this.baked);
-    assert.equal(find(".post-admin-menu").length, 0, "also hides the menu");
+    assert.equal(queryAll(".post-admin-menu").length, 0, "also hides the menu");
   },
 });
 
@@ -665,7 +686,7 @@ widgetTest("unhide post", {
     await click(".post-menu-area .show-post-admin-menu");
     await click(".post-admin-menu .unhide-post");
     assert.ok(this.unhidden);
-    assert.equal(find(".post-admin-menu").length, 0, "also hides the menu");
+    assert.equal(queryAll(".post-admin-menu").length, 0, "also hides the menu");
   },
 });
 
@@ -681,7 +702,7 @@ widgetTest("change owner", {
     await click(".post-menu-area .show-post-admin-menu");
     await click(".post-admin-menu .change-owner");
     assert.ok(this.owned);
-    assert.equal(find(".post-admin-menu").length, 0, "also hides the menu");
+    assert.equal(queryAll(".post-admin-menu").length, 0, "also hides the menu");
   },
 });
 
@@ -704,7 +725,7 @@ widgetTest("reply - without permissions", {
     this.set("args", { canCreatePost: false });
   },
   test(assert) {
-    assert.equal(find(".post-controls .create").length, 0);
+    assert.equal(queryAll(".post-controls .create").length, 0);
   },
 });
 
@@ -714,7 +735,7 @@ widgetTest("replies - no replies", {
     this.set("args", { replyCount: 0 });
   },
   test(assert) {
-    assert.equal(find("button.show-replies").length, 0);
+    assert.equal(queryAll("button.show-replies").length, 0);
   },
 });
 
@@ -725,7 +746,7 @@ widgetTest("replies - multiple replies", {
     this.set("args", { replyCount: 2, replyDirectlyBelow: true });
   },
   test(assert) {
-    assert.equal(find("button.show-replies").length, 1);
+    assert.equal(queryAll("button.show-replies").length, 1);
   },
 });
 
@@ -736,7 +757,7 @@ widgetTest("replies - one below, suppressed", {
     this.set("args", { replyCount: 1, replyDirectlyBelow: true });
   },
   test(assert) {
-    assert.equal(find("button.show-replies").length, 0);
+    assert.equal(queryAll("button.show-replies").length, 0);
   },
 });
 
@@ -748,8 +769,11 @@ widgetTest("replies - one below, not suppressed", {
   },
   async test(assert) {
     await click("button.show-replies");
-    assert.equal(find("section.embedded-posts.bottom .cooked").length, 1);
-    assert.equal(find("section.embedded-posts .d-icon-arrow-down").length, 1);
+    assert.equal(queryAll("section.embedded-posts.bottom .cooked").length, 1);
+    assert.equal(
+      queryAll("section.embedded-posts .d-icon-arrow-down").length,
+      1
+    );
   },
 });
 
@@ -759,7 +783,7 @@ widgetTest("topic map not shown", {
     this.set("args", { showTopicMap: false });
   },
   test(assert) {
-    assert.equal(find(".topic-map").length, 0);
+    assert.equal(queryAll(".topic-map").length, 0);
   },
 });
 
@@ -774,14 +798,14 @@ widgetTest("topic map - few posts", {
   },
   async test(assert) {
     assert.equal(
-      find("li.avatars a.poster").length,
+      queryAll("li.avatars a.poster").length,
       0,
       "shows no participants when collapsed"
     );
 
     await click("nav.buttons button");
     assert.equal(
-      find(".topic-map-expanded a.poster").length,
+      queryAll(".topic-map-expanded a.poster").length,
       2,
       "shows all when expanded"
     );
@@ -805,19 +829,19 @@ widgetTest("topic map - participants", {
   },
   async test(assert) {
     assert.equal(
-      find("li.avatars a.poster").length,
+      queryAll("li.avatars a.poster").length,
       3,
       "limits to three participants"
     );
 
     await click("nav.buttons button");
-    assert.equal(find("li.avatars a.poster").length, 0);
+    assert.equal(queryAll("li.avatars a.poster").length, 0);
     assert.equal(
-      find(".topic-map-expanded a.poster").length,
+      queryAll(".topic-map-expanded a.poster").length,
       4,
       "shows all when expanded"
     );
-    assert.equal(find("a.poster.toggled").length, 2, "two are toggled");
+    assert.equal(queryAll("a.poster.toggled").length, 2, "two are toggled");
   },
 });
 
@@ -837,23 +861,23 @@ widgetTest("topic map - links", {
     });
   },
   async test(assert) {
-    assert.equal(find(".topic-map").length, 1);
-    assert.equal(find(".map.map-collapsed").length, 1);
-    assert.equal(find(".topic-map-expanded").length, 0);
+    assert.equal(queryAll(".topic-map").length, 1);
+    assert.equal(queryAll(".map.map-collapsed").length, 1);
+    assert.equal(queryAll(".topic-map-expanded").length, 0);
 
     await click("nav.buttons button");
-    assert.equal(find(".map.map-collapsed").length, 0);
-    assert.equal(find(".topic-map .d-icon-chevron-up").length, 1);
-    assert.equal(find(".topic-map-expanded").length, 1);
+    assert.equal(queryAll(".map.map-collapsed").length, 0);
+    assert.equal(queryAll(".topic-map .d-icon-chevron-up").length, 1);
+    assert.equal(queryAll(".topic-map-expanded").length, 1);
     assert.equal(
-      find(".topic-map-expanded .topic-link").length,
+      queryAll(".topic-map-expanded .topic-link").length,
       5,
       "it limits the links displayed"
     );
 
     await click(".link-summary button");
     assert.equal(
-      find(".topic-map-expanded .topic-link").length,
+      queryAll(".topic-map-expanded .topic-link").length,
       6,
       "all links now shown"
     );
@@ -866,7 +890,7 @@ widgetTest("topic map - no summary", {
     this.set("args", { showTopicMap: true });
   },
   test(assert) {
-    assert.equal(find(".toggle-summary").length, 0);
+    assert.equal(queryAll(".toggle-summary").length, 0);
   },
 });
 
@@ -878,7 +902,7 @@ widgetTest("topic map - has summary", {
     this.on("toggleSummary", () => (this.summaryToggled = true));
   },
   async test(assert) {
-    assert.equal(find(".toggle-summary").length, 1);
+    assert.equal(queryAll(".toggle-summary").length, 1);
 
     await click(".toggle-summary button");
     assert.ok(this.summaryToggled);
@@ -896,8 +920,8 @@ widgetTest("pm map", {
     });
   },
   test(assert) {
-    assert.equal(find(".private-message-map").length, 1);
-    assert.equal(find(".private-message-map .user").length, 1);
+    assert.equal(queryAll(".private-message-map").length, 1);
+    assert.equal(queryAll(".private-message-map .user").length, 1);
   },
 });
 
@@ -919,7 +943,7 @@ widgetTest("post notice - with username", {
   },
   test(assert) {
     assert.equal(
-      find(".post-notice.returning-user:not(.old)").text().trim(),
+      queryAll(".post-notice.returning-user:not(.old)").text().trim(),
       I18n.t("post.notice.returning_user", {
         user: "codinghorror",
         time: "2 days ago",
@@ -943,7 +967,7 @@ widgetTest("post notice - with name", {
   },
   test(assert) {
     assert.equal(
-      find(".post-notice.old.new-user").text().trim(),
+      queryAll(".post-notice.old.new-user").text().trim(),
       I18n.t("post.notice.new_user", { user: "Jeff", time: "Jan '10" })
     );
   },
@@ -958,7 +982,7 @@ widgetTest("show group request in post", {
     });
   },
   test(assert) {
-    const link = find(".group-request a");
+    const link = queryAll(".group-request a");
     assert.equal(link.text().trim(), I18n.t("groups.requests.handle"));
     assert.equal(link.attr("href"), "/g/testGroup/requests?filter=foo");
   },

--- a/app/assets/javascripts/discourse/tests/integration/widgets/poster-name-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/poster-name-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import {
   moduleForWidget,
   widgetTest,
@@ -16,12 +17,12 @@ widgetTest("basic rendering", {
     });
   },
   test(assert) {
-    assert.ok(find(".names").length);
-    assert.ok(find("span.username").length);
-    assert.ok(find("a[data-user-card=eviltrout]").length);
-    assert.equal(find(".username a").text(), "eviltrout");
-    assert.equal(find(".full-name a").text(), "Robin Ward");
-    assert.equal(find(".user-title").text(), "Trout Master");
+    assert.ok(queryAll(".names").length);
+    assert.ok(queryAll("span.username").length);
+    assert.ok(queryAll("a[data-user-card=eviltrout]").length);
+    assert.equal(queryAll(".username a").text(), "eviltrout");
+    assert.equal(queryAll(".full-name a").text(), "Robin Ward");
+    assert.equal(queryAll(".user-title").text(), "Trout Master");
   },
 });
 
@@ -39,12 +40,12 @@ widgetTest("extra classes and glyphs", {
     });
   },
   test(assert) {
-    assert.ok(find("span.staff").length);
-    assert.ok(find("span.admin").length);
-    assert.ok(find("span.moderator").length);
-    assert.ok(find(".d-icon-shield-alt").length);
-    assert.ok(find("span.new-user").length);
-    assert.ok(find("span.fish").length);
+    assert.ok(queryAll("span.staff").length);
+    assert.ok(queryAll("span.admin").length);
+    assert.ok(queryAll("span.moderator").length);
+    assert.ok(queryAll(".d-icon-shield-alt").length);
+    assert.ok(queryAll("span.new-user").length);
+    assert.ok(queryAll("span.fish").length);
   },
 });
 
@@ -55,7 +56,7 @@ widgetTest("disable display name on posts", {
     this.set("args", { username: "eviltrout", name: "Robin Ward" });
   },
   test(assert) {
-    assert.equal(find(".full-name").length, 0);
+    assert.equal(queryAll(".full-name").length, 0);
   },
 });
 
@@ -67,6 +68,6 @@ widgetTest("doesn't render a name if it's similar to the username", {
     this.set("args", { username: "eviltrout", name: "evil-trout" });
   },
   test(assert) {
-    assert.equal(find(".second").length, 0);
+    assert.equal(queryAll(".second").length, 0);
   },
 });

--- a/app/assets/javascripts/discourse/tests/integration/widgets/quick-access-item-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/quick-access-item-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import {
   moduleForWidget,
   widgetTest,
@@ -15,7 +16,7 @@ widgetTest("content attribute is escaped", {
   },
 
   test(assert) {
-    const contentDiv = find(CONTENT_DIV_SELECTOR)[0];
+    const contentDiv = queryAll(CONTENT_DIV_SELECTOR)[0];
     assert.equal(contentDiv.innerText, "<b>bold</b>");
   },
 });
@@ -28,7 +29,7 @@ widgetTest("escapedContent attribute is not escaped", {
   },
 
   test(assert) {
-    const contentDiv = find(CONTENT_DIV_SELECTOR)[0];
+    const contentDiv = queryAll(CONTENT_DIV_SELECTOR)[0];
     assert.equal(contentDiv.innerText, '"quote"');
   },
 });

--- a/app/assets/javascripts/discourse/tests/integration/widgets/small-user-list-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/small-user-list-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import {
   moduleForWidget,
   widgetTest,
@@ -16,8 +17,8 @@ widgetTest("renders avatars and support for unknown", {
     });
   },
   async test(assert) {
-    assert.ok(find("[data-user-card=eviltrout]").length === 1);
-    assert.ok(find("[data-user-card=someone]").length === 0);
-    assert.ok(find(".unknown").length, "includes unkown user");
+    assert.ok(queryAll("[data-user-card=eviltrout]").length === 1);
+    assert.ok(queryAll("[data-user-card=someone]").length === 0);
+    assert.ok(queryAll(".unknown").length, "includes unkown user");
   },
 });

--- a/app/assets/javascripts/discourse/tests/integration/widgets/topic-status-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/topic-status-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import {
   moduleForWidget,
   widgetTest,
@@ -15,7 +16,7 @@ widgetTest("basics", {
     });
   },
   test(assert) {
-    assert.ok(find(".topic-status .d-icon-lock").length);
+    assert.ok(queryAll(".topic-status .d-icon-lock").length);
   },
 });
 
@@ -35,6 +36,6 @@ widgetTest("extendability", {
     });
   },
   test(assert) {
-    assert.ok(find(".topic-status .d-icon-far-check-square").length);
+    assert.ok(queryAll(".topic-status .d-icon-far-check-square").length);
   },
 });

--- a/app/assets/javascripts/discourse/tests/integration/widgets/user-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/user-menu-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import sinon from "sinon";
 import I18n from "I18n";
 import DiscourseURL from "discourse/lib/url";
@@ -13,12 +14,12 @@ widgetTest("basics", {
   template: '{{mount-widget widget="user-menu"}}',
 
   test(assert) {
-    assert.ok(find(".user-menu").length);
-    assert.ok(find(".user-preferences-link").length);
-    assert.ok(find(".user-notifications-link").length);
-    assert.ok(find(".user-bookmarks-link").length);
-    assert.ok(find(".quick-access-panel").length);
-    assert.ok(find(".notifications-dismiss").length);
+    assert.ok(queryAll(".user-menu").length);
+    assert.ok(queryAll(".user-preferences-link").length);
+    assert.ok(queryAll(".user-notifications-link").length);
+    assert.ok(queryAll(".user-bookmarks-link").length);
+    assert.ok(queryAll(".quick-access-panel").length);
+    assert.ok(queryAll(".notifications-dismiss").length);
   },
 });
 
@@ -26,7 +27,7 @@ widgetTest("notifications", {
   template: '{{mount-widget widget="user-menu"}}',
 
   async test(assert) {
-    const $links = find(".quick-access-panel li a");
+    const $links = queryAll(".quick-access-panel li a");
 
     assert.equal($links.length, 5);
     assert.ok($links[0].href.includes("/t/a-slug/123"));
@@ -73,7 +74,7 @@ widgetTest("notifications", {
     const routeToStub = sinon.stub(DiscourseURL, "routeTo");
     await click(".user-notifications-link");
     assert.ok(
-      routeToStub.calledWith(find(".user-notifications-link")[0].href),
+      routeToStub.calledWith(queryAll(".user-notifications-link")[0].href),
       "a second click should redirect to the full notifications page"
     );
   },
@@ -88,7 +89,7 @@ widgetTest("log out", {
 
   async test(assert) {
     await click(".user-preferences-link");
-    assert.ok(find(".logout").length);
+    assert.ok(queryAll(".logout").length);
 
     await click(".logout");
     assert.ok(this.loggedOut);
@@ -102,7 +103,7 @@ widgetTest("private messages - disabled", {
   },
 
   test(assert) {
-    assert.ok(!find(".user-pms-link").length);
+    assert.ok(!queryAll(".user-pms-link").length);
   },
 });
 
@@ -113,11 +114,11 @@ widgetTest("private messages - enabled", {
   },
 
   async test(assert) {
-    const userPmsLink = find(".user-pms-link")[0];
+    const userPmsLink = queryAll(".user-pms-link")[0];
     assert.ok(userPmsLink);
     await click(".user-pms-link");
 
-    const message = find(".quick-access-panel li a")[0];
+    const message = queryAll(".quick-access-panel li a")[0];
     assert.ok(message);
 
     assert.ok(
@@ -148,7 +149,7 @@ widgetTest("bookmarks", {
   async test(assert) {
     await click(".user-bookmarks-link");
 
-    const bookmark = find(".quick-access-panel li a")[0];
+    const bookmark = queryAll(".quick-access-panel li a")[0];
     assert.ok(bookmark);
 
     assert.ok(bookmark.href.includes("/t/yelling-topic-title/119"));
@@ -164,7 +165,7 @@ widgetTest("bookmarks", {
     const routeToStub = sinon.stub(DiscourseURL, "routeTo");
     await click(".user-bookmarks-link");
     assert.ok(
-      routeToStub.calledWith(find(".user-bookmarks-link")[0].href),
+      routeToStub.calledWith(queryAll(".user-bookmarks-link")[0].href),
       "a second click should redirect to the full bookmarks page"
     );
   },
@@ -184,7 +185,7 @@ widgetTest("anonymous", {
 
   async test(assert) {
     await click(".user-preferences-link");
-    assert.ok(find(".enable-anonymous").length);
+    assert.ok(queryAll(".enable-anonymous").length);
 
     await click(".enable-anonymous");
     assert.ok(this.anonymous);
@@ -200,7 +201,7 @@ widgetTest("anonymous - disabled", {
 
   async test(assert) {
     await click(".user-preferences-link");
-    assert.ok(!find(".enable-anonymous").length);
+    assert.ok(!queryAll(".enable-anonymous").length);
   },
 });
 
@@ -217,7 +218,7 @@ widgetTest("anonymous - switch back", {
 
   async test(assert) {
     await click(".user-preferences-link");
-    assert.ok(find(".disable-anonymous").length);
+    assert.ok(queryAll(".disable-anonymous").length);
 
     await click(".disable-anonymous");
     assert.notOk(this.anonymous);

--- a/app/assets/javascripts/discourse/tests/integration/widgets/widget-dropdown-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/widget-dropdown-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
 import I18n from "I18n";
 import {
@@ -24,7 +25,7 @@ async function clickRowById(id) {
 }
 
 function rowById(id) {
-  return find(`#my-dropdown .widget-dropdown-item.item-${id}`)[0];
+  return queryAll(`#my-dropdown .widget-dropdown-item.item-${id}`)[0];
 }
 
 async function toggle() {
@@ -32,17 +33,17 @@ async function toggle() {
 }
 
 function headerLabel() {
-  return find(
+  return queryAll(
     "#my-dropdown .widget-dropdown-header .label"
   )[0].innerText.trim();
 }
 
 function header() {
-  return find("#my-dropdown .widget-dropdown-header")[0];
+  return queryAll("#my-dropdown .widget-dropdown-header")[0];
 }
 
 function body() {
-  return find("#my-dropdown .widget-dropdown-body")[0];
+  return queryAll("#my-dropdown .widget-dropdown-body")[0];
 }
 
 const TEMPLATE = `
@@ -151,7 +152,7 @@ widgetTest("onChange action", {
   async test(assert) {
     await toggle();
     await clickRowById(2);
-    assert.equal(find("#test").text(), 2, "it calls the onChange actions");
+    assert.equal(queryAll("#test").text(), 2, "it calls the onChange actions");
   },
 });
 
@@ -270,7 +271,7 @@ widgetTest("separator", {
   async test(assert) {
     await toggle();
     assert.ok(
-      find(
+      queryAll(
         "#my-dropdown .widget-dropdown-item:nth-child(3)"
       )[0].classList.contains("separator")
     );

--- a/app/assets/javascripts/discourse/tests/integration/widgets/widget-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/widget-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import I18n from "I18n";
 import { next } from "@ember/runloop";
 import {
@@ -25,7 +26,7 @@ widgetTest("widget attributes are passed in via args", {
   },
 
   test(assert) {
-    assert.equal(find(".test").text(), "Hello Robin");
+    assert.equal(queryAll(".test").text(), "Hello Robin");
   },
 });
 
@@ -41,7 +42,7 @@ widgetTest("hbs template - no tagName", {
   },
 
   test(assert) {
-    assert.equal(find("div.test").text(), "Hello Robin");
+    assert.equal(queryAll("div.test").text(), "Hello Robin");
   },
 });
 
@@ -58,7 +59,7 @@ widgetTest("hbs template - with tagName", {
   },
 
   test(assert) {
-    assert.equal(find("div.test").text(), "Hello Robin");
+    assert.equal(queryAll("div.test").text(), "Hello Robin");
   },
 });
 
@@ -72,7 +73,7 @@ widgetTest("hbs template - with data attributes", {
   },
 
   test(assert) {
-    assert.equal(find("div.mydiv").data("my-test"), "hello world");
+    assert.equal(queryAll("div.mydiv").data("my-test"), "hello world");
   },
 });
 
@@ -92,7 +93,10 @@ widgetTest("buildClasses", {
   },
 
   test(assert) {
-    assert.ok(find(".test.static.cool-class").length, "it has all the classes");
+    assert.ok(
+      queryAll(".test.static.cool-class").length,
+      "it has all the classes"
+    );
   },
 });
 
@@ -112,8 +116,8 @@ widgetTest("buildAttributes", {
   },
 
   test(assert) {
-    assert.ok(find(".test[data-evil=trout]").length);
-    assert.ok(find(".test[aria-label=accessibility]").length);
+    assert.ok(queryAll(".test[data-evil=trout]").length);
+    assert.ok(queryAll(".test[aria-label=accessibility]").length);
   },
 });
 
@@ -131,7 +135,7 @@ widgetTest("buildId", {
   },
 
   test(assert) {
-    assert.ok(find("#test-1234").length);
+    assert.ok(queryAll("#test-1234").length);
   },
 });
 
@@ -155,11 +159,11 @@ widgetTest("widget state", {
   },
 
   async test(assert) {
-    assert.ok(find("button.test").length, "it renders the button");
-    assert.equal(find("button.test").text(), "0 clicks");
+    assert.ok(queryAll("button.test").length, "it renders the button");
+    assert.equal(queryAll("button.test").text(), "0 clicks");
 
-    await click(find("button"));
-    assert.equal(find("button.test").text(), "1 clicks");
+    await click(queryAll("button"));
+    assert.equal(queryAll("button.test").text(), "1 clicks");
   },
 });
 
@@ -190,10 +194,10 @@ widgetTest("widget update with promise", {
   },
 
   async test(assert) {
-    assert.equal(find("button.test").text().trim(), "No name");
+    assert.equal(queryAll("button.test").text().trim(), "No name");
 
-    await click(find("button"));
-    assert.equal(find("button.test").text().trim(), "Robin");
+    await click(queryAll("button"));
+    assert.equal(queryAll("button.test").text().trim(), "Robin");
   },
 });
 
@@ -210,8 +214,8 @@ widgetTest("widget attaching", {
   },
 
   test(assert) {
-    assert.ok(find(".container").length, "renders container");
-    assert.ok(find(".container .embedded").length, "renders attached");
+    assert.ok(queryAll(".container").length, "renders container");
+    assert.ok(queryAll(".container .embedded").length, "renders attached");
   },
 });
 
@@ -228,8 +232,8 @@ widgetTest("magic attaching by name", {
   },
 
   test(assert) {
-    assert.ok(find(".container").length, "renders container");
-    assert.ok(find(".container .embedded").length, "renders attached");
+    assert.ok(queryAll(".container").length, "renders container");
+    assert.ok(queryAll(".container .embedded").length, "renders attached");
   },
 });
 
@@ -249,8 +253,8 @@ widgetTest("custom attrs to a magic attached widget", {
   },
 
   test(assert) {
-    assert.ok(find(".container").length, "renders container");
-    assert.equal(find(".container .value").text(), "hello world");
+    assert.ok(queryAll(".container").length, "renders container");
+    assert.equal(queryAll(".container .value").text(), "hello world");
   },
 });
 
@@ -264,7 +268,7 @@ widgetTest("handlebars d-icon", {
   },
 
   test(assert) {
-    assert.equal(find(".d-icon-arrow-down").length, 1);
+    assert.equal(queryAll(".d-icon-arrow-down").length, 1);
   },
 });
 
@@ -298,9 +302,9 @@ widgetTest("handlebars i18n", {
 
   test(assert) {
     // comin up
-    assert.equal(find("span.string").text(), "evil");
-    assert.equal(find("span.var").text(), "trout");
-    assert.equal(find("a").prop("title"), "evil");
+    assert.equal(queryAll("span.string").text(), "evil");
+    assert.equal(queryAll("span.var").text(), "trout");
+    assert.equal(queryAll("a").prop("title"), "evil");
   },
 });
 
@@ -323,8 +327,8 @@ widgetTest("handlebars #each", {
   },
 
   test(assert) {
-    assert.equal(find("ul li").length, 3);
-    assert.equal(find("ul li:eq(0)").text(), "one");
+    assert.equal(queryAll("ul li").length, 3);
+    assert.equal(queryAll("ul li:eq(0)").text(), "one");
   },
 });
 
@@ -349,9 +353,9 @@ widgetTest("widget decorating", {
   },
 
   test(assert) {
-    assert.ok(find(".decorate").length);
-    assert.equal(find(".decorate b").text(), "before");
-    assert.equal(find(".decorate i").text(), "after");
+    assert.ok(queryAll(".decorate").length);
+    assert.equal(queryAll(".decorate b").text(), "before");
+    assert.equal(queryAll(".decorate i").text(), "after");
   },
 });
 
@@ -367,7 +371,7 @@ widgetTest("widget settings", {
   },
 
   test(assert) {
-    assert.equal(find(".settings").text(), "age is 36");
+    assert.equal(queryAll(".settings").text(), "age is 36");
   },
 });
 
@@ -387,7 +391,7 @@ widgetTest("override settings", {
   },
 
   test(assert) {
-    assert.equal(find(".settings").text(), "age is 37");
+    assert.equal(queryAll(".settings").text(), "age is 37");
   },
 });
 
@@ -407,6 +411,6 @@ widgetTest("get accessor", {
   },
 
   test(assert) {
-    assert.equal(find("div.test").text(), "Hello eviltrout");
+    assert.equal(queryAll("div.test").text(), "Hello eviltrout");
   },
 });

--- a/app/assets/javascripts/wizard/test/components/invite-list-test.js
+++ b/app/assets/javascripts/wizard/test/components/invite-list-test.js
@@ -1,5 +1,6 @@
 import { moduleForComponent } from "ember-qunit";
 import { componentTest } from "wizard/test/helpers/component-test";
+
 moduleForComponent("invite-list", { integration: true });
 
 componentTest("can add users", {
@@ -11,10 +12,13 @@ componentTest("can add users", {
 
   async test(assert) {
     assert.ok(
-      find(".users-list .invite-list-user").length === 0,
+      document.querySelectorAll(".users-list .invite-list-user").length === 0,
       "no users at first"
     );
-    assert.ok(find(".new-user .invalid").length === 0, "not invalid at first");
+    assert.ok(
+      document.querySelectorAll(".new-user .invalid").length === 0,
+      "not invalid at first"
+    );
 
     const firstVal = JSON.parse(this.get("field.value"));
     assert.equal(firstVal.length, 0, "empty JSON at first");
@@ -26,19 +30,19 @@ componentTest("can add users", {
 
     await click(".add-user");
     assert.ok(
-      find(".users-list .invite-list-user").length === 0,
+      document.querySelectorAll(".users-list .invite-list-user").length === 0,
       "doesn't add a blank user"
     );
-    assert.ok(find(".new-user .invalid").length === 1);
+    assert.ok(document.querySelectorAll(".new-user .invalid").length === 1);
 
     await fillIn(".invite-email", "eviltrout@example.com");
     await click(".add-user");
 
     assert.ok(
-      find(".users-list .invite-list-user").length === 1,
+      document.querySelectorAll(".users-list .invite-list-user").length === 1,
       "adds the user"
     );
-    assert.ok(find(".new-user .invalid").length === 0);
+    assert.ok(document.querySelectorAll(".new-user .invalid").length === 0);
 
     const val = JSON.parse(this.get("field.value"));
     assert.equal(val.length, 1);
@@ -54,23 +58,23 @@ componentTest("can add users", {
     await click(".add-user");
 
     assert.ok(
-      find(".users-list .invite-list-user").length === 1,
+      document.querySelectorAll(".users-list .invite-list-user").length === 1,
       "can't add the same user twice"
     );
-    assert.ok(find(".new-user .invalid").length === 1);
+    assert.ok(document.querySelectorAll(".new-user .invalid").length === 1);
 
     await fillIn(".invite-email", "not-an-email");
     await click(".add-user");
 
     assert.ok(
-      find(".users-list .invite-list-user").length === 1,
+      document.querySelectorAll(".users-list .invite-list-user").length === 1,
       "won't add an invalid email"
     );
-    assert.ok(find(".new-user .invalid").length === 1);
+    assert.ok(document.querySelectorAll(".new-user .invalid").length === 1);
 
     await click(".invite-list .invite-list-user:eq(0) .remove-user");
     assert.ok(
-      find(".users-list .invite-list-user").length === 0,
+      document.querySelectorAll(".users-list .invite-list-user").length === 0,
       "removed the user"
     );
   },

--- a/plugins/discourse-details/test/javascripts/acceptance/details-button-test.js.es6
+++ b/plugins/discourse-details/test/javascripts/acceptance/details-button-test.js.es6
@@ -1,5 +1,5 @@
 import I18n from "I18n";
-import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+import { acceptance, queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { clearPopupMenuOptionsCallback } from "discourse/controllers/composer";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 
@@ -17,7 +17,7 @@ acceptance("Details Button", function (needs) {
     await popupMenu.selectRowByValue("insertDetails");
 
     assert.equal(
-      find(".d-editor-input").val(),
+      queryAll(".d-editor-input").val(),
       `\n[details="${I18n.t("composer.details_title")}"]\n${I18n.t(
         "composer.details_text"
       )}\n[/details]\n`,
@@ -26,7 +26,7 @@ acceptance("Details Button", function (needs) {
 
     await fillIn(".d-editor-input", "This is my title");
 
-    const textarea = find(".d-editor-input")[0];
+    const textarea = queryAll(".d-editor-input")[0];
     textarea.selectionStart = 0;
     textarea.selectionEnd = textarea.value.length;
 
@@ -34,7 +34,7 @@ acceptance("Details Button", function (needs) {
     await popupMenu.selectRowByValue("insertDetails");
 
     assert.equal(
-      find(".d-editor-input").val(),
+      queryAll(".d-editor-input").val(),
       `\n[details="${I18n.t(
         "composer.details_title"
       )}"]\nThis is my title\n[/details]\n`,
@@ -61,7 +61,7 @@ acceptance("Details Button", function (needs) {
     await popupMenu.selectRowByValue("insertDetails");
 
     assert.equal(
-      find(".d-editor-input").val(),
+      queryAll(".d-editor-input").val(),
       `Before \n[details="${I18n.t(
         "composer.details_title"
       )}"]\nsome text in between\n[/details]\n After`,
@@ -88,7 +88,7 @@ acceptance("Details Button", function (needs) {
     await popupMenu.selectRowByValue("insertDetails");
 
     assert.equal(
-      find(".d-editor-input").val(),
+      queryAll(".d-editor-input").val(),
       `Before \n\n[details="${I18n.t(
         "composer.details_title"
       )}"]\nsome text in between\n[/details]\n\n After`,
@@ -115,7 +115,7 @@ acceptance("Details Button", function (needs) {
     await click("#create-topic");
     await fillIn(".d-editor-input", multilineInput);
 
-    const textarea = find(".d-editor-input")[0];
+    const textarea = queryAll(".d-editor-input")[0];
     textarea.selectionStart = 0;
     textarea.selectionEnd = textarea.value.length;
 
@@ -123,7 +123,7 @@ acceptance("Details Button", function (needs) {
     await popupMenu.selectRowByValue("insertDetails");
 
     assert.equal(
-      find(".d-editor-input").val(),
+      queryAll(".d-editor-input").val(),
       `\n[details="${I18n.t(
         "composer.details_title"
       )}"]\n${multilineInput}\n[/details]\n`,

--- a/plugins/discourse-local-dates/test/javascripts/acceptance/local-dates-composer-test.js.es6
+++ b/plugins/discourse-local-dates/test/javascripts/acceptance/local-dates-composer-test.js.es6
@@ -1,4 +1,4 @@
-import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+import { acceptance, queryAll } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Local Dates - composer", function (needs) {
   needs.user();
@@ -6,9 +6,9 @@ acceptance("Local Dates - composer", function (needs) {
 
   test("composer bbcode", async (assert) => {
     const getAttr = (attr) => {
-      return find(".d-editor-preview .discourse-local-date.cooked-date").attr(
-        `data-${attr}`
-      );
+      return queryAll(
+        ".d-editor-preview .discourse-local-date.cooked-date"
+      ).attr(`data-${attr}`);
     };
 
     await visit("/");

--- a/plugins/poll/test/javascripts/acceptance/poll-breakdown-test.js.es6
+++ b/plugins/poll/test/javascripts/acceptance/poll-breakdown-test.js.es6
@@ -1,5 +1,6 @@
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import { clearPopupMenuOptionsCallback } from "discourse/controllers/composer";
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Poll breakdown", function (needs) {
   needs.user();
@@ -61,7 +62,7 @@ acceptance("Poll breakdown", function (needs) {
     await visit("/t/-/topic_with_pie_chart_poll");
 
     assert.equal(
-      find(".poll-show-breakdown").text(),
+      queryAll(".poll-show-breakdown").text(),
       "Show breakdown",
       "shows the breakdown button when poll_groupable_user_fields is non-empty"
     );
@@ -69,19 +70,19 @@ acceptance("Poll breakdown", function (needs) {
     await click(".poll-show-breakdown:first");
 
     assert.equal(
-      find(".poll-breakdown-total-votes")[0].textContent.trim(),
+      queryAll(".poll-breakdown-total-votes")[0].textContent.trim(),
       "2 votes",
       "display the correct total vote count"
     );
 
     assert.equal(
-      find(".poll-breakdown-chart-container").length,
+      queryAll(".poll-breakdown-chart-container").length,
       2,
       "renders a chart for each of the groups in group_results response"
     );
 
     assert.ok(
-      find(".poll-breakdown-chart-container > canvas")[0].$chartjs,
+      queryAll(".poll-breakdown-chart-container > canvas")[0].$chartjs,
       "$chartjs is defined on the pie charts"
     );
   });
@@ -91,7 +92,7 @@ acceptance("Poll breakdown", function (needs) {
     await click(".poll-show-breakdown:first");
 
     assert.equal(
-      find(".poll-breakdown-option-count:first")[0].textContent.trim(),
+      queryAll(".poll-breakdown-option-count:first")[0].textContent.trim(),
       "40.0%",
       "displays the correct vote percentage"
     );
@@ -99,7 +100,7 @@ acceptance("Poll breakdown", function (needs) {
     await click(".modal-tabs .count");
 
     assert.equal(
-      find(".poll-breakdown-option-count:first")[0].textContent.trim(),
+      queryAll(".poll-breakdown-option-count:first")[0].textContent.trim(),
       "2",
       "displays the correct vote count"
     );
@@ -107,7 +108,7 @@ acceptance("Poll breakdown", function (needs) {
     await click(".modal-tabs .percentage");
 
     assert.equal(
-      find(".poll-breakdown-option-count:last")[0].textContent.trim(),
+      queryAll(".poll-breakdown-option-count:last")[0].textContent.trim(),
       "20.0%",
       "displays the percentage again"
     );

--- a/plugins/poll/test/javascripts/acceptance/poll-builder-enabled-test.js.es6
+++ b/plugins/poll/test/javascripts/acceptance/poll-builder-enabled-test.js.es6
@@ -6,6 +6,7 @@ import {
 } from "discourse/tests/helpers/qunit-helpers";
 import { displayPollBuilderButton } from "discourse/plugins/poll/helpers/display-poll-builder-button";
 import { clearPopupMenuOptionsCallback } from "discourse/controllers/composer";
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Poll Builder - polls are enabled", function (needs) {
   needs.user();
@@ -57,11 +58,11 @@ acceptance("Poll Builder - polls are enabled", function (needs) {
     await fillIn(".poll-textarea textarea", "First option\nSecond option");
 
     assert.equal(
-      find(".d-editor-preview li:first-child").text(),
+      queryAll(".d-editor-preview li:first-child").text(),
       "First option"
     );
     assert.equal(
-      find(".d-editor-preview li:last-child").text(),
+      queryAll(".d-editor-preview li:last-child").text(),
       "Second option"
     );
   });

--- a/plugins/poll/test/javascripts/acceptance/poll-pie-chart-test.js.es6
+++ b/plugins/poll/test/javascripts/acceptance/poll-pie-chart-test.js.es6
@@ -1,4 +1,5 @@
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Rendering polls with pie charts", function (needs) {
   needs.user();
@@ -10,16 +11,16 @@ acceptance("Rendering polls with pie charts", function (needs) {
   test("Displays the pie chart", async (assert) => {
     await visit("/t/-/topic_with_pie_chart_poll");
 
-    const poll = find(".poll")[0];
+    const poll = queryAll(".poll")[0];
 
     assert.equal(
-      find(".info-number", poll)[0].innerHTML,
+      queryAll(".info-number", poll)[0].innerHTML,
       "2",
       "it should display the right number of voters"
     );
 
     assert.equal(
-      find(".info-number", poll)[1].innerHTML,
+      queryAll(".info-number", poll)[1].innerHTML,
       "5",
       "it should display the right number of votes"
     );
@@ -31,7 +32,7 @@ acceptance("Rendering polls with pie charts", function (needs) {
     );
 
     assert.equal(
-      find(".poll-results-chart", poll).length,
+      queryAll(".poll-results-chart", poll).length,
       1,
       "Renders the chart div instead of bar container"
     );

--- a/plugins/poll/test/javascripts/acceptance/poll-quote-test.js.es6
+++ b/plugins/poll/test/javascripts/acceptance/poll-quote-test.js.es6
@@ -1,5 +1,6 @@
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import { clearPopupMenuOptionsCallback } from "discourse/controllers/composer";
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Poll quote", function (needs) {
   needs.user();
@@ -678,6 +679,6 @@ acceptance("Poll quote", function (needs) {
   test("Quoted polls", async (assert) => {
     await visit("/t/-/topic_with_two_quoted_polls");
     await click(".quote-controls");
-    assert.equal(find(".poll").length, 2);
+    assert.equal(queryAll(".poll").length, 2);
   });
 });

--- a/plugins/poll/test/javascripts/acceptance/polls-bar-chart-test-desktop.js.es6
+++ b/plugins/poll/test/javascripts/acceptance/polls-bar-chart-test-desktop.js.es6
@@ -1,5 +1,6 @@
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import { clearPopupMenuOptionsCallback } from "discourse/controllers/composer";
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Rendering polls with bar charts - desktop", function (needs) {
   needs.user();
@@ -42,18 +43,18 @@ acceptance("Rendering polls with bar charts - desktop", function (needs) {
   test("Polls", async (assert) => {
     await visit("/t/-/15");
 
-    const polls = find(".poll");
+    const polls = queryAll(".poll");
 
     assert.equal(polls.length, 2, "it should render the polls correctly");
 
     assert.equal(
-      find(".info-number", polls[0]).text(),
+      queryAll(".info-number", polls[0]).text(),
       "2",
       "it should display the right number of votes"
     );
 
     assert.equal(
-      find(".info-number", polls[1]).text(),
+      queryAll(".info-number", polls[1]).text(),
       "3",
       "it should display the right number of votes"
     );
@@ -62,13 +63,13 @@ acceptance("Rendering polls with bar charts - desktop", function (needs) {
   test("Public poll", async (assert) => {
     await visit("/t/-/14");
 
-    const polls = find(".poll");
+    const polls = queryAll(".poll");
     assert.equal(polls.length, 1, "it should render the poll correctly");
 
     await click("button.toggle-results");
 
     assert.equal(
-      find(".poll-voters:first li").length,
+      queryAll(".poll-voters:first li").length,
       25,
       "it should display the right number of voters"
     );
@@ -76,7 +77,7 @@ acceptance("Rendering polls with bar charts - desktop", function (needs) {
     await click(".poll-voters-toggle-expand:first a");
 
     assert.equal(
-      find(".poll-voters:first li").length,
+      queryAll(".poll-voters:first li").length,
       26,
       "it should display the right number of voters"
     );
@@ -85,26 +86,26 @@ acceptance("Rendering polls with bar charts - desktop", function (needs) {
   test("Public number poll", async (assert) => {
     await visit("/t/-/13");
 
-    const polls = find(".poll");
+    const polls = queryAll(".poll");
     assert.equal(polls.length, 1, "it should render the poll correctly");
 
     await click("button.toggle-results");
 
     assert.equal(
-      find(".poll-voters:first li").length,
+      queryAll(".poll-voters:first li").length,
       25,
       "it should display the right number of voters"
     );
 
     assert.notOk(
-      find(".poll-voters:first li:first a").attr("href"),
+      queryAll(".poll-voters:first li:first a").attr("href"),
       "user URL does not exist"
     );
 
     await click(".poll-voters-toggle-expand:first a");
 
     assert.equal(
-      find(".poll-voters:first li").length,
+      queryAll(".poll-voters:first li").length,
       30,
       "it should display the right number of voters"
     );

--- a/plugins/poll/test/javascripts/acceptance/polls-bar-chart-test-mobile.js.es6
+++ b/plugins/poll/test/javascripts/acceptance/polls-bar-chart-test-mobile.js.es6
@@ -1,5 +1,6 @@
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import { clearPopupMenuOptionsCallback } from "discourse/controllers/composer";
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Rendering polls with bar charts - mobile", function (needs) {
   needs.user();
@@ -24,26 +25,26 @@ acceptance("Rendering polls with bar charts - mobile", function (needs) {
   test("Public number poll", async (assert) => {
     await visit("/t/-/13");
 
-    const polls = find(".poll");
+    const polls = queryAll(".poll");
     assert.equal(polls.length, 1, "it should render the poll correctly");
 
     await click("button.toggle-results");
 
     assert.equal(
-      find(".poll-voters:first li").length,
+      queryAll(".poll-voters:first li").length,
       25,
       "it should display the right number of voters"
     );
 
     assert.notOk(
-      find(".poll-voters:first li:first a").attr("href"),
+      queryAll(".poll-voters:first li:first a").attr("href"),
       "user URL does not exist"
     );
 
     await click(".poll-voters-toggle-expand:first a");
 
     assert.equal(
-      find(".poll-voters:first li").length,
+      queryAll(".poll-voters:first li").length,
       35,
       "it should display the right number of voters"
     );

--- a/plugins/poll/test/javascripts/widgets/discourse-poll-option-test.js.es6
+++ b/plugins/poll/test/javascripts/widgets/discourse-poll-option-test.js.es6
@@ -1,4 +1,9 @@
-import { moduleForWidget, widgetTest } from "discourse/tests/helpers/widget-test";
+import {
+  moduleForWidget,
+  widgetTest,
+} from "discourse/tests/helpers/widget-test";
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
+
 moduleForWidget("discourse-poll-option");
 
 const template = `{{mount-widget
@@ -14,7 +19,7 @@ widgetTest("single, not selected", {
   },
 
   test(assert) {
-    assert.ok(find("li .d-icon-far-circle:eq(0)").length === 1);
+    assert.ok(queryAll("li .d-icon-far-circle:eq(0)").length === 1);
   },
 });
 
@@ -27,7 +32,7 @@ widgetTest("single, selected", {
   },
 
   test(assert) {
-    assert.ok(find("li .d-icon-circle:eq(0)").length === 1);
+    assert.ok(queryAll("li .d-icon-circle:eq(0)").length === 1);
   },
 });
 
@@ -43,7 +48,7 @@ widgetTest("multi, not selected", {
   },
 
   test(assert) {
-    assert.ok(find("li .d-icon-far-square:eq(0)").length === 1);
+    assert.ok(queryAll("li .d-icon-far-square:eq(0)").length === 1);
   },
 });
 
@@ -59,6 +64,6 @@ widgetTest("multi, selected", {
   },
 
   test(assert) {
-    assert.ok(find("li .d-icon-far-check-square:eq(0)").length === 1);
+    assert.ok(queryAll("li .d-icon-far-check-square:eq(0)").length === 1);
   },
 });

--- a/plugins/poll/test/javascripts/widgets/discourse-poll-standard-results-test.js.es6
+++ b/plugins/poll/test/javascripts/widgets/discourse-poll-standard-results-test.js.es6
@@ -1,5 +1,9 @@
 import EmberObject from "@ember/object";
-import { moduleForWidget, widgetTest } from "discourse/tests/helpers/widget-test";
+import {
+  moduleForWidget,
+  widgetTest,
+} from "discourse/tests/helpers/widget-test";
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 
 moduleForWidget("discourse-poll-standard-results");
 
@@ -21,8 +25,8 @@ widgetTest("options in descending order", {
   },
 
   test(assert) {
-    assert.equal(find(".option .percentage:eq(0)").text(), "56%");
-    assert.equal(find(".option .percentage:eq(1)").text(), "44%");
+    assert.equal(queryAll(".option .percentage:eq(0)").text(), "56%");
+    assert.equal(queryAll(".option .percentage:eq(1)").text(), "44%");
   },
 });
 
@@ -40,8 +44,8 @@ widgetTest("options in ascending order", {
   },
 
   test(assert) {
-    assert.equal(find(".option .percentage:eq(0)").text(), "56%");
-    assert.equal(find(".option .percentage:eq(1)").text(), "44%");
+    assert.equal(queryAll(".option .percentage:eq(0)").text(), "56%");
+    assert.equal(queryAll(".option .percentage:eq(1)").text(), "44%");
   },
 });
 
@@ -67,12 +71,12 @@ widgetTest("multiple options in descending order", {
   },
 
   test(assert) {
-    assert.equal(find(".option .percentage:eq(0)").text(), "41%");
-    assert.equal(find(".option .percentage:eq(1)").text(), "33%");
-    assert.equal(find(".option .percentage:eq(2)").text(), "16%");
-    assert.equal(find(".option .percentage:eq(3)").text(), "8%");
-    assert.equal(find(".option span:nth-child(2):eq(3)").text(), "a");
-    assert.equal(find(".option .percentage:eq(4)").text(), "8%");
-    assert.equal(find(".option span:nth-child(2):eq(4)").text(), "b");
+    assert.equal(queryAll(".option .percentage:eq(0)").text(), "41%");
+    assert.equal(queryAll(".option .percentage:eq(1)").text(), "33%");
+    assert.equal(queryAll(".option .percentage:eq(2)").text(), "16%");
+    assert.equal(queryAll(".option .percentage:eq(3)").text(), "8%");
+    assert.equal(queryAll(".option span:nth-child(2):eq(3)").text(), "a");
+    assert.equal(queryAll(".option .percentage:eq(4)").text(), "8%");
+    assert.equal(queryAll(".option span:nth-child(2):eq(4)").text(), "b");
   },
 });

--- a/plugins/poll/test/javascripts/widgets/discourse-poll-test.js.es6
+++ b/plugins/poll/test/javascripts/widgets/discourse-poll-test.js.es6
@@ -4,6 +4,7 @@ import {
   moduleForWidget,
   widgetTest,
 } from "discourse/tests/helpers/widget-test";
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 
 let requests = 0;
 
@@ -99,16 +100,17 @@ widgetTest("can vote", {
 
     await click("li[data-poll-option-id='1f972d1df351de3ce35a787c89faad29']");
     assert.equal(requests, 1);
-    assert.equal(find(".chosen").length, 1);
-    assert.equal(find(".chosen").text(), "100%yes");
-    assert.equal(find(".toggle-results").text(), "Show vote");
+    assert.equal(queryAll(".chosen").length, 1);
+    assert.equal(queryAll(".chosen").text(), "100%yes");
+    assert.equal(queryAll(".toggle-results").text(), "Show vote");
 
     await click(".toggle-results");
     assert.equal(
-      find("li[data-poll-option-id='1f972d1df351de3ce35a787c89faad29']").length,
+      queryAll("li[data-poll-option-id='1f972d1df351de3ce35a787c89faad29']")
+        .length,
       1
     );
-    assert.equal(find(".toggle-results").text(), "Show results");
+    assert.equal(queryAll(".toggle-results").text(), "Show results");
   },
 });
 
@@ -146,10 +148,10 @@ widgetTest("cannot vote if not member of the right group", {
 
     await click("li[data-poll-option-id='1f972d1df351de3ce35a787c89faad29']");
     assert.equal(
-      find(".poll-container .alert").text(),
+      queryAll(".poll-container .alert").text(),
       I18n.t("poll.results.groups.title", { groups: "foo" })
     );
     assert.equal(requests, 0);
-    assert.equal(find(".chosen").length, 0);
+    assert.equal(queryAll(".chosen").length, 0);
   },
 });

--- a/test/javascripts/integration/components/invite-panel-test.js
+++ b/test/javascripts/integration/components/invite-panel-test.js
@@ -1,5 +1,7 @@
 import EmberObject, { set } from "@ember/object";
 import componentTest from "helpers/component-test";
+import { moduleForComponent } from "ember-qunit";
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 
 moduleForComponent("invite-panel", { integration: true });
 
@@ -17,6 +19,6 @@ componentTest("can_invite_via_email", {
 
   async test(assert) {
     await fillIn(".invite-user-input", "eviltrout@example.com");
-    assert.ok(find(".send-invite:disabled").length === 0);
+    assert.ok(queryAll(".send-invite:disabled").length === 0);
   },
 });


### PR DESCRIPTION
In newer Embers jQuery is removed. There is a `find` but it only returns
one element and not a jQuery selector. This patch migrates our code to a
new helper `queryAll` which allows us to remove the global.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
