### PR TITLE
FEATURE: Allow admins to opt out of chunked encoding

### DIFF
--- a/app/assets/javascripts/discourse/app/initializers/message-bus.js
+++ b/app/assets/javascripts/discourse/app/initializers/message-bus.js
@@ -64,8 +64,9 @@ export default {
     messageBus.baseUrl =
       siteSettings.long_polling_base_url.replace(/\/$/, "") + "/";
 
+    messageBus.enableChunkedEncoding = siteSettings.enable_chunked_encoding;
+
     if (messageBus.baseUrl !== "/") {
-      // zepto compatible, 1 param only
       messageBus.ajax = function (opts) {
         opts.headers = opts.headers || {};
         opts.headers["X-Shared-Session-Key"] = $(
@@ -90,7 +91,6 @@ export default {
 
     if (user) {
       messageBus.callbackInterval = siteSettings.polling_interval;
-      messageBus.enableLongPolling = true;
     }
   },
 };

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1510,6 +1510,7 @@ en:
     enable_personal_messages: "Allow trust level 1 (configurable via min trust level to send messages) users to create messages and reply to messages. Note that staff can always send messages no matter what."
     enable_system_message_replies: "Allows users to reply to system messages, even if personal messages are disabled"
     enable_long_polling: "Message bus used for notification can use long polling"
+    enable_chunked_encoding: "Enable chunked encoding responses by the server. This feature works on most setups however some proxies may buffer, causing responses to be delayed"
     long_polling_base_url: "Base URL used for long polling (when a CDN is serving dynamic content, be sure to set this to origin pull) eg: http://origin.site.com"
     long_polling_interval: "Amount of time the server should wait before responding to clients when there is no data to send (logged on users only)"
     polling_interval: "When not long polling, how often should logged on clients poll in milliseconds"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1721,6 +1721,9 @@ developer:
   enable_long_polling:
     client: true
     default: true
+  enable_chunked_encoding:
+    client: true
+    default: true
   long_polling_interval:
     default: 25000
     max: 25000


### PR DESCRIPTION
Most proxies out there will work with chunked encoding transfer. However
some proxies buffer, causing large delays which in turn force the message
bus client to disable chunked encoding. This wastes a request to the message
bus causing superfluous load on the server.

Also

- enableLongPolling is already default true in the client, no need to set it
- remove confusing comment about zepto
