### PR TITLE
FIX: Ensure oneboxed secure images which are optimized and also lightboxed optimized images are embedded in email

### DIFF
--- a/lib/email/styles.rb
+++ b/lib/email/styles.rb
@@ -7,6 +7,8 @@
 module Email
   class Styles
     MAX_IMAGE_DIMENSION = 400
+    ONEBOX_IMAGE_BASE_STYLE = "max-height: 80%; max-width: 20%; height: auto; float: left; margin-right: 10px;"
+    ONEBOX_IMAGE_THUMBNAIL_STYLE = "width: 60px;"
 
     @@plugin_callbacks = []
 
@@ -125,8 +127,8 @@ module Email
       style('aside.onebox header img.site-icon', "width: 16px; height: 16px; margin-right: 3px;")
       style('aside.onebox header a[href]', "color: #222222; text-decoration: none;")
       style('aside.onebox .onebox-body', "clear: both")
-      style('aside.onebox .onebox-body img:not(.onebox-avatar-inline)', "max-height: 80%; max-width: 20%; height: auto; float: left; margin-right: 10px;")
-      style('aside.onebox .onebox-body img.thumbnail', "width: 60px;")
+      style('aside.onebox .onebox-body img:not(.onebox-avatar-inline)', ONEBOX_IMAGE_BASE_STYLE)
+      style('aside.onebox .onebox-body img.thumbnail', ONEBOX_IMAGE_THUMBNAIL_STYLE)
       style('aside.onebox .onebox-body h3, aside.onebox .onebox-body h4', "font-size: 1.17em; margin: 10px 0;")
       style('.onebox-metadata', "color: #919191")
       style('.github-info', "margin-top: 10px;")
@@ -259,18 +261,15 @@ module Email
         if attachments[original_filename]
           url = attachments[original_filename].url
 
-          # refer to the onebox styles above...not ideal to copy this but we do not already
-          # have this calculated at the redaction stage, redaction must occur before we kill
-          # all the classes and replace with styles
           style = if div['data-oneboxed']
-            "width: 60px; max-height: 80%; max-width: 20%; height: auto; float: left; margin-right: 10px;"
+            "#{ONEBOX_IMAGE_THUMBNAIL_STYLE} #{ONEBOX_IMAGE_BASE_STYLE}"
           else
             calculate_width_and_height_style(div)
           end
 
-          div.add_next_sibling(
-            "<img src=\"#{url}\" data-embedded-secure-image=\"true\" style=\"#{style}\" />"
-          )
+          div.add_next_sibling(<<~HTML)
+            <img src="#{url}" data-embedded-secure-image="true" style="#{style}" />
+          HTML
           div.remove
         end
       end

--- a/lib/email/styles.rb
+++ b/lib/email/styles.rb
@@ -247,7 +247,7 @@ module Email
         url = div['data-stripped-secure-media']
         filename = File.basename(url)
         filename_bare = filename.gsub(File.extname(filename), "")
-        sha1 = filename_bare.include?('_') ? filename_bare.partition('_').first : filename_bare
+        sha1 = filename_bare.partition('_').first
         upload_shas[url] = sha1
       end
       uploads = Upload.select(:original_filename, :sha1).where(sha1: upload_shas.values)

--- a/spec/components/email/styles_spec.rb
+++ b/spec/components/email/styles_spec.rb
@@ -210,10 +210,9 @@ describe Email::Styles do
   context "inline_secure_images" do
     let(:attachments) { { 'testimage.png' => stub(url: 'cid:email/test.png') } }
     fab!(:upload) { Fabricate(:upload, original_filename: 'testimage.png', secure: true, sha1: '123456') }
+    let(:html) { "<a href=\"#{Discourse.base_url}\/secure-media-uploads/original/1X/123456.png\"><img src=\"/secure-media-uploads/original/1X/123456.png\" width=\"20\" height=\"30\"></a>" }
 
     def strip_and_inline
-      html = "<a href=\"#{Discourse.base_url}\/secure-media-uploads/original/1X/123456.png\"><img src=\"/secure-media-uploads/original/1X/123456.png\" width=\"20\" height=\"30\"></a>"
-
       # strip out the secure media
       styler = Email::Styles.new(html)
       styler.format_basic
@@ -239,6 +238,63 @@ describe Email::Styles do
 
       expect(@frag.to_s).not_to include("cid:email/test.png")
       expect(@frag.css('[data-stripped-secure-media]')).to be_present
+    end
+
+    context "when an optimized image is used instead of the original" do
+      let(:html) { "<a href=\"#{Discourse.base_url}\/secure-media-uploads/optimized/2X/1/123456_2_20x30.png\"><img src=\"/secure-media-uploads/optimized/2X/1/123456_2_20x30.png\" width=\"20\" height=\"30\"></a>" }
+
+      it "inlines attachments where the stripped-secure-media data attr is present" do
+        optimized = Fabricate(:optimized_image, upload: upload, width: 20, height: 30)
+        strip_and_inline
+        expect(@frag.to_s).to include("cid:email/test.png")
+        expect(@frag.css('[data-stripped-secure-media]')).not_to be_present
+        expect(@frag.children.attr('style').value).to eq("width: 20px; height: 30px;")
+      end
+    end
+
+    context "when inlining an originally oneboxed image" do
+      before do
+        SiteSetting.authorized_extensions = "*"
+      end
+
+      let(:siteicon) { Fabricate(:upload, original_filename: "siteicon.ico") }
+      let(:attachments) do
+        {
+          'testimage.png' => stub(url: 'cid:email/test.png'),
+          'siteicon.ico' => stub(url: 'cid:email/test2.ico')
+        }
+      end
+      let(:html) do
+        <<~HTML
+<aside class="onebox allowlistedgeneric">
+  <header class="source">
+      <img src="#{Discourse.base_url}/secure-media-uploads/original/1X/#{siteicon.sha1}.ico" class="site-icon" width="64" height="64">
+      <a href="https://test.com/article" target="_blank" rel="noopener" title="02:33PM - 24 October 2020">Test</a>
+  </header>
+  <article class="onebox-body">
+    <div class="aspect-image" style="--aspect-ratio:20/30;"><img src="#{Discourse.base_url}/secure-media-uploads/optimized/2X/1/123456_2_20x30.png" class="thumbnail d-lazyload" width="20" height="30" srcset="#{Discourse.base_url}/secure-media-uploads/optimized/2X/1/123456_2_20x30.png"></div>
+
+<h3><a href="https://test.com/article" target="_blank" rel="noopener">Test</a></h3>
+
+<p>This is a test onebox.</p>
+
+  </article>
+  <div class="onebox-metadata">
+  </div>
+  <div style="clear: both"></div>
+</aside>
+        HTML
+      end
+
+      it "keeps the special site icon width and height and onebox styles" do
+        optimized = Fabricate(:optimized_image, upload: upload, width: 20, height: 30)
+        strip_and_inline
+        expect(@frag.to_s).to include("cid:email/test.png")
+        expect(@frag.to_s).to include("cid:email/test2.ico")
+        expect(@frag.css('[data-sripped-secure-media]')).not_to be_present
+        expect(@frag.css('[data-embedded-secure-image]')[0].attr('style')).to eq('width: 16px; height: 16px;')
+        expect(@frag.css('[data-embedded-secure-image]')[1].attr('style')).to eq('width: 60px; max-height: 80%; max-width: 20%; height: auto; float: left; margin-right: 10px;')
+      end
     end
   end
 end


### PR DESCRIPTION
We had an issue where onebox thumbnail was too large and thus was optimized, and we are using the image URLs in post to redact and re-embed, based on the sha1 in the URL. Optimized image URLs have extra stuff on the end like _99x99 so we were not parsing out the sha1 correctly. Another issue I found was for posts that have giant images, the original was being used to embed in the email and thus would basically never get included because it is huge.

For example the URL `http://localhost:3000/secure-media-uploads/optimized/2X/7/787b17ea6140f4f022eb7f1509a692f2873cfe35_2_690x335.jpeg` was not parsed correctly; we would end up with `787b17ea6140f4f022eb7f1509a692f2873cfe35_2_690x335.jpeg` as the sha1 which would not find the image to re-embed that was already attached to the email.

This fix will use the first optimized image of the detected upload when we are redacting and then re-embedding to make sure we are not sending giant things in email. Also, I detect if it is a onebox thumbnail or the site icon and force appropriate sizes and styles.