### PR TITLE
UX: inform staff users that new users will be auto-approved on invite

### DIFF
--- a/app/assets/javascripts/discourse/app/components/invite-link-panel.js
+++ b/app/assets/javascripts/discourse/app/components/invite-link-panel.js
@@ -1,7 +1,7 @@
 import I18n from "I18n";
 import Component from "@ember/component";
 import Group from "discourse/models/group";
-import { alias, readOnly } from "@ember/object/computed";
+import { and, readOnly } from "@ember/object/computed";
 import { action } from "@ember/object";
 import discourseComputed from "discourse-common/utils/decorators";
 import Invite from "discourse/models/invite";
@@ -10,12 +10,11 @@ export default Component.extend({
   inviteModel: readOnly("panel.model.inviteModel"),
   userInvitedShow: readOnly("panel.model.userInvitedShow"),
   isStaff: readOnly("currentUser.staff"),
+  isAdmin: readOnly("currentUser.admin"),
   maxRedemptionAllowed: 5,
   inviteExpiresAt: moment().add(1, "month").format("YYYY-MM-DD"),
   groupIds: null,
   allGroups: null,
-
-  isAdmin: alias("currentUser.admin"),
 
   init() {
     this._super(...arguments);
@@ -51,6 +50,8 @@ export default Component.extend({
       isAdmin || (groupUsers && groupUsers.some((groupUser) => groupUser.owner))
     );
   },
+
+  showApprovalMessage: and("isStaff", "siteSettings.must_approve_users"),
 
   reset() {
     this.setProperties({

--- a/app/assets/javascripts/discourse/app/components/invite-panel.js
+++ b/app/assets/javascripts/discourse/app/components/invite-panel.js
@@ -2,7 +2,7 @@ import I18n from "I18n";
 import discourseComputed from "discourse-common/utils/decorators";
 import { isEmpty } from "@ember/utils";
 import EmberObject, { action } from "@ember/object";
-import { alias, and, equal } from "@ember/object/computed";
+import { alias, and, equal, readOnly } from "@ember/object/computed";
 import Component from "@ember/component";
 import { emailValid } from "discourse/lib/utilities";
 import Group from "discourse/models/group";
@@ -17,6 +17,8 @@ export default Component.extend({
 
   inviteModel: alias("panel.model.inviteModel"),
   userInvitedShow: alias("panel.model.userInvitedShow"),
+  isStaff: readOnly("currentUser.staff"),
+  isAdmin: readOnly("currentUser.admin"),
 
   // If this isn't defined, it will proxy to the user topic on the preferences
   // page which is wrong.
@@ -25,8 +27,6 @@ export default Component.extend({
   customMessage: null,
   inviteIcon: "envelope",
   invitingExistingUserToTopic: false,
-
-  isAdmin: alias("currentUser.admin"),
 
   init() {
     this._super(...arguments);
@@ -287,6 +287,8 @@ export default Component.extend({
       ? "topic.invite_private.email_or_username_placeholder"
       : "topic.invite_reply.username_placeholder";
   },
+
+  showApprovalMessage: and("isStaff", "siteSettings.must_approve_users"),
 
   customMessagePlaceholder: i18n("invite.custom_message_placeholder"),
 

--- a/app/assets/javascripts/discourse/app/templates/components/invite-link-panel.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/invite-link-panel.hbs
@@ -41,6 +41,11 @@
       }}
     </div>
 
+    {{#if showApprovalMessage}}
+      <label class="instructions approval-notice">
+        {{i18n "invite.approval_not_required"}}
+      </label>
+    {{/if}}
   {{/if}}
 </div>
 

--- a/app/assets/javascripts/discourse/app/templates/components/invite-panel.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/invite-panel.hbs
@@ -76,6 +76,12 @@
       </div>
     {{/if}}
   {{/if}}
+
+  {{#if showApprovalMessage}}
+    <label class="instructions approval-notice">
+      {{i18n "invite.approval_not_required"}}
+    </label>
+  {{/if}}
 </div>
 
 <div class="footer">

--- a/app/assets/stylesheets/common/components/share-and-invite-modal.scss
+++ b/app/assets/stylesheets/common/components/share-and-invite-modal.scss
@@ -94,6 +94,10 @@
       margin-bottom: 8px;
     }
 
+    .instructions.approval-notice {
+      color: var(--secondary-medium);
+    }
+
     .email-or-username-input {
       width: 100%;
     }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3475,6 +3475,7 @@ en:
     invite:
       custom_message: "Make your invite a little bit more personal by writing a <a href>custom message</a>."
       custom_message_placeholder: "Enter your custom message"
+      approval_not_required: "User will be auto-approved as soon as they will accept this invite."
       custom_message_template_forum: "Hey, you should join this forum!"
       custom_message_template_topic: "Hey, I thought you might enjoy this topic!"
 


### PR DESCRIPTION
When `must_approve_users` is enabled then staff users assume that all users will have to be approved manually. But in case of invite we auto-approve users if they are invited by users. This commit adds an info on the bottom of invite modal informing staff users that new users will be auto-approved as soon as they accept invite.

Meta discussion: https://meta.discourse.org/t/how-to-configure-approval-based-sign-ups/112128/11?u=techapj

Demo:

<img width="494" alt="Screenshot 2020-10-29 at 12 48 11 PM" src="https://user-images.githubusercontent.com/5732281/97537645-22623a00-19e5-11eb-8c11-ad98a4c63df0.png">
