### PR TITLE
FIX: Use <> link instead of code for discobot backup image link

### DIFF
--- a/plugins/discourse-narrative-bot/config/locales/server.en.yml
+++ b/plugins/discourse-narrative-bot/config/locales/server.en.yml
@@ -199,7 +199,7 @@ en:
         not_found: |-
           Looks like you didn’t upload an image so I’ve chosen a picture that I’m _sure_ you will enjoy.
 
-          `%{image_url}`
+          <%{image_url}>
 
           Try uploading that one next, or pasting the link in on a line by itself!
 


### PR DESCRIPTION
Due to the new enhanced copy-paste handling, the URL would be included in the user's reply as code, too!
By surrounding the link in angle brackets, we prevent the bot from accidentally including the link itself and spoiling the surprise.

I considered having the bot automatically edit the user's post to remove the backticks. I very quickly ran into a problem with spurious whitespace, and it would also look _super weird_ for the bot to edit your post when that's not what's being taught.
The seemingly bare link not automatically embedding is also weird, but slightly less so.

Fun fact: this doesn't work on localhost, because the onebox engine refuses to issue requests to localhost :)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->

Note: this change will need to percolate to translations, but let's let that happen naturally.
