### PR TITLE
FIX: Make all email subject vars available in notification subjects

### DIFF
--- a/app/models/translation_override.rb
+++ b/app/models/translation_override.rb
@@ -9,6 +9,13 @@ class TranslationOverride < ActiveRecord::Base
       topic_title_url_encoded
       site_title_url_encoded
       context
+
+      site_name
+      optional_re
+      optional_pm
+      optional_cat
+      optional_tags
+      topic_title
     }
   }
   include ActiveSupport::Deprecation::DeprecatedConstantAccessor

--- a/lib/email/message_builder.rb
+++ b/lib/email/message_builder.rb
@@ -53,7 +53,15 @@ module Email
     def subject
       if @opts[:template] &&
           TranslationOverride.exists?(locale: I18n.locale, translation_key: "#{@opts[:template]}.subject_template")
-        subject = I18n.t("#{@opts[:template]}.subject_template", @template_args)
+        augmented_template_args = @template_args.merge({
+          site_name: @template_args[:email_prefix],
+          optional_re: @opts[:add_re_to_subject] ? I18n.t('subject_re') : '',
+          optional_pm: @opts[:private_reply] ? @template_args[:subject_pm] : '',
+          optional_cat: @template_args[:show_category_in_subject] ? "[#{@template_args[:show_category_in_subject]}] " : '',
+          optional_tags: @template_args[:show_tags_in_subject] ? "#{@template_args[:show_tags_in_subject]} " : '',
+          topic_title: @template_args[:topic_title] ? @template_args[:topic_title] : '',
+        })
+        subject = I18n.t("#{@opts[:template]}.subject_template", augmented_template_args)
       elsif @opts[:use_site_subject]
         subject = String.new(SiteSetting.email_subject)
         subject.gsub!("%{site_name}", @template_args[:email_prefix])


### PR DESCRIPTION
A site owner attempting to use both the email_subject site setting and translation overrides for normal post notification
email subjects would find themselves frusturated at the lack of template argument parity.
Make all the variables available for translation overrides by adding the subject variables to the custom interpolation keys list and applying them.

Reported at https://meta.discourse.org/t/customize-subject-format-for-standard-emails/20801/47?u=riking

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
