### PR TITLE
FIX: keep tag filter value when changing the category dropdown.

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/bread-crumbs.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/bread-crumbs.hbs
@@ -3,6 +3,7 @@
     {{category-drop
       category=breadcrumb.category
       categories=breadcrumb.options
+      tagId=tagId
       options=(hash
         parentCategory=breadcrumb.parentCategory
         subCategory=breadcrumb.isSubcategory

--- a/app/assets/javascripts/select-kit/addon/components/category-drop.js
+++ b/app/assets/javascripts/select-kit/addon/components/category-drop.js
@@ -161,7 +161,14 @@ export default ComboBoxComponent.extend({
     onChange(categoryId) {
       let categoryURL;
 
-      if (categoryId === ALL_CATEGORIES_ID) {
+      if (this.tagId && !this.category) {
+        const category = Category.findById(parseInt(categoryId, 10));
+        categoryURL = getURL(
+          `/tags/c/${Category.slugFor(category)}/${
+            category.id
+          }/${this.tagId.toLowerCase()}`
+        );
+      } else if (categoryId === ALL_CATEGORIES_ID) {
         categoryURL = this.allCategoriesUrl;
       } else if (categoryId === NO_CATEGORIES_ID) {
         categoryURL = this.noCategoriesUrl;


### PR DESCRIPTION
Previously, while filtering the topics by tag, selecting a category loses the selected tag value.