### PR TITLE
DEV: De-arrowify tests

### DIFF
--- a/app/assets/javascripts/discourse/tests/acceptance/about-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/about-test.js
@@ -4,7 +4,7 @@ import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("About", function () {
-  test("viewing", async (assert) => {
+  test("viewing", async function (assert) {
     await visit("/about");
 
     assert.ok($("body.about-page").length, "has body class");

--- a/app/assets/javascripts/discourse/tests/acceptance/account-created-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/account-created-test.js
@@ -6,7 +6,7 @@ import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import PreloadStore from "discourse/lib/preload-store";
 
 acceptance("Account Created", function () {
-  test("account created - message", async (assert) => {
+  test("account created - message", async function (assert) {
     PreloadStore.store("accountCreated", {
       message: "Hello World",
     });
@@ -21,7 +21,7 @@ acceptance("Account Created", function () {
     assert.notOk(exists(".activation-controls"));
   });
 
-  test("account created - resend email", async (assert) => {
+  test("account created - resend email", async function (assert) {
     PreloadStore.store("accountCreated", {
       message: "Hello World",
       username: "eviltrout",
@@ -45,7 +45,7 @@ acceptance("Account Created", function () {
     assert.equal(email, "eviltrout@example.com");
   });
 
-  test("account created - update email - cancel", async (assert) => {
+  test("account created - update email - cancel", async function (assert) {
     PreloadStore.store("accountCreated", {
       message: "Hello World",
       username: "eviltrout",
@@ -65,7 +65,7 @@ acceptance("Account Created", function () {
     assert.equal(currentPath(), "account-created.index");
   });
 
-  test("account created - update email - submit", async (assert) => {
+  test("account created - update email - submit", async function (assert) {
     PreloadStore.store("accountCreated", {
       message: "Hello World",
       username: "eviltrout",

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-emails-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-emails-test.js
@@ -28,7 +28,7 @@ acceptance("Admin - Emails", function (needs) {
     });
   });
 
-  test("shows selected and elided text", async (assert) => {
+  test("shows selected and elided text", async function (assert) {
     await visit("/admin/email/advanced-test");
     await fillIn("textarea.email-body", EMAIL.trim());
     await click(".email-advanced-test button");

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-search-log-term-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-search-log-term-test.js
@@ -6,7 +6,7 @@ import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 acceptance("Admin - Search Log Term", function (needs) {
   needs.user();
 
-  test("show search log term details", async (assert) => {
+  test("show search log term details", async function (assert) {
     await visit("/admin/logs/search_logs/term?term=ruby");
 
     assert.ok($("div.search-logs-filter").length, "has the search type filter");

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-search-logs-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-search-logs-test.js
@@ -6,7 +6,7 @@ import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 acceptance("Admin - Search Logs", function (needs) {
   needs.user();
 
-  test("show search logs", async (assert) => {
+  test("show search logs", async function (assert) {
     await visit("/admin/logs/search_logs");
 
     assert.ok($("table.search-logs-list.grid").length, "has the div class");

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-site-settings-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-site-settings-test.js
@@ -30,7 +30,7 @@ acceptance("Admin - Site Settings", function (needs) {
     updatedTitle = null;
   });
 
-  test("upload site setting", async (assert) => {
+  test("upload site setting", async function (assert) {
     await visit("/admin/site_settings");
 
     assert.ok(
@@ -41,7 +41,7 @@ acceptance("Admin - Site Settings", function (needs) {
     assert.ok(exists(".row.setting.upload .undo"), "undo button is present");
   });
 
-  test("changing value updates dirty state", async (assert) => {
+  test("changing value updates dirty state", async function (assert) {
     await visit("/admin/site_settings");
     await fillIn("#setting-filter", " title ");
     assert.equal(count(".row.setting"), 1, "filter returns 1 site setting");
@@ -88,7 +88,7 @@ acceptance("Admin - Site Settings", function (needs) {
     );
   });
 
-  test("always shows filtered site settings if a filter is set", async (assert) => {
+  test("always shows filtered site settings if a filter is set", async function (assert) {
     await visit("/admin/site_settings");
     await fillIn("#setting-filter", "title");
     assert.equal(count(".row.setting"), 1);
@@ -102,7 +102,7 @@ acceptance("Admin - Site Settings", function (needs) {
     assert.equal(count(".row.setting"), 1);
   });
 
-  test("filter settings by plugin name", async (assert) => {
+  test("filter settings by plugin name", async function (assert) {
     await visit("/admin/site_settings");
 
     await fillIn("#setting-filter", "plugin:discourse-logo");
@@ -113,7 +113,7 @@ acceptance("Admin - Site Settings", function (needs) {
     assert.equal(count(".row.setting"), 0);
   });
 
-  test("category name is preserved", async (assert) => {
+  test("category name is preserved", async function (assert) {
     await visit("admin/site_settings/category/basic?filter=menu");
     assert.equal(
       currentURL(),
@@ -121,7 +121,7 @@ acceptance("Admin - Site Settings", function (needs) {
     );
   });
 
-  test("shows all_results if current category has none", async (assert) => {
+  test("shows all_results if current category has none", async function (assert) {
     await visit("admin/site_settings");
 
     await click(".admin-nav .basic a");

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-site-text-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-site-text-test.js
@@ -7,7 +7,7 @@ import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 acceptance("Admin - Site Texts", function (needs) {
   needs.user();
 
-  test("search for a key", async (assert) => {
+  test("search for a key", async function (assert) {
     await visit("/admin/customize/site_texts");
 
     await fillIn(".site-text-search", "Test");
@@ -28,7 +28,7 @@ acceptance("Admin - Site Texts", function (needs) {
     assert.ok(exists(".site-text.overridden"));
   });
 
-  test("edit and revert a site text by key", async (assert) => {
+  test("edit and revert a site text by key", async function (assert) {
     await visit("/admin/customize/site_texts/site.test");
 
     assert.equal(queryAll(".title h3").text(), "site.test");

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-suspend-user-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-suspend-user-test.js
@@ -25,7 +25,7 @@ acceptance("Admin - Suspend User", function (needs) {
     );
   });
 
-  test("suspend a user - cancel", async (assert) => {
+  test("suspend a user - cancel", async function (assert) {
     await visit("/admin/users/1234/regular");
     await click(".suspend-user");
 
@@ -36,7 +36,7 @@ acceptance("Admin - Suspend User", function (needs) {
     assert.equal(queryAll(".suspend-user-modal:visible").length, 0);
   });
 
-  test("suspend a user - cancel with input", async (assert) => {
+  test("suspend a user - cancel with input", async function (assert) {
     await visit("/admin/users/1234/regular");
     await click(".suspend-user");
 
@@ -63,7 +63,7 @@ acceptance("Admin - Suspend User", function (needs) {
     assert.equal(queryAll(".bootbox.modal:visible").length, 0);
   });
 
-  test("suspend, then unsuspend a user", async (assert) => {
+  test("suspend, then unsuspend a user", async function (assert) {
     const suspendUntilCombobox = selectKit(".suspend-until .combobox");
 
     await visit("/admin/flags/active");

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-user-badges-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-user-badges-test.js
@@ -6,7 +6,7 @@ import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 acceptance("Admin - Users Badges", function (needs) {
   needs.user();
 
-  test("lists badges", async (assert) => {
+  test("lists badges", async function (assert) {
     await visit("/admin/users/1/eviltrout/badges");
 
     assert.ok(exists(`span[data-badge-name="Badge 8"]`));

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-user-emails-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-user-emails-test.js
@@ -35,13 +35,13 @@ function assertMultipleSecondary(assert, firstEmail, secondEmail) {
 acceptance("Admin - User Emails", function (needs) {
   needs.user();
 
-  test("viewing self without secondary emails", async (assert) => {
+  test("viewing self without secondary emails", async function (assert) {
     await visit("/admin/users/1/eviltrout");
 
     assertNoSecondary(assert);
   });
 
-  test("viewing self with multiple secondary emails", async (assert) => {
+  test("viewing self with multiple secondary emails", async function (assert) {
     await visit("/admin/users/3/markvanlan");
 
     assert.equal(
@@ -57,14 +57,14 @@ acceptance("Admin - User Emails", function (needs) {
     );
   });
 
-  test("viewing another user with no secondary email", async (assert) => {
+  test("viewing another user with no secondary email", async function (assert) {
     await visit("/admin/users/1234/regular");
     await click(`.display-row.secondary-emails button`);
 
     assertNoSecondary(assert);
   });
 
-  test("viewing another account with secondary emails", async (assert) => {
+  test("viewing another account with secondary emails", async function (assert) {
     await visit("/admin/users/1235/regular1");
     await click(`.display-row.secondary-emails button`);
 

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-user-index-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-user-index-test.js
@@ -39,7 +39,7 @@ acceptance("Admin - User Index", function (needs) {
     });
   });
 
-  test("can edit username", async (assert) => {
+  test("can edit username", async function (assert) {
     await visit("/admin/users/2/sam");
 
     assert.equal(queryAll(".display-row.username .value").text().trim(), "sam");
@@ -60,7 +60,7 @@ acceptance("Admin - User Index", function (needs) {
     );
   });
 
-  test("will clear unsaved groups when switching user", async (assert) => {
+  test("will clear unsaved groups when switching user", async function (assert) {
     await visit("/admin/users/2/sam");
 
     assert.equal(

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-users-list-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-users-list-test.js
@@ -8,14 +8,14 @@ import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 acceptance("Admin - Users List", function (needs) {
   needs.user();
 
-  test("lists users", async (assert) => {
+  test("lists users", async function (assert) {
     await visit("/admin/users/list/active");
 
     assert.ok(exists(".users-list .user"));
     assert.ok(!exists(".user:eq(0) .email small"), "escapes email");
   });
 
-  test("sorts users", async (assert) => {
+  test("sorts users", async function (assert) {
     await visit("/admin/users/list/active");
 
     assert.ok(exists(".users-list .user"));
@@ -39,7 +39,7 @@ acceptance("Admin - Users List", function (needs) {
     );
   });
 
-  test("toggles email visibility", async (assert) => {
+  test("toggles email visibility", async function (assert) {
     await visit("/admin/users/list/active");
 
     assert.ok(exists(".users-list .user"));
@@ -61,7 +61,7 @@ acceptance("Admin - Users List", function (needs) {
     );
   });
 
-  test("switching tabs", async (assert) => {
+  test("switching tabs", async function (assert) {
     const activeUser = "eviltrout";
     const suspectUser = "sam";
     const activeTitle = I18n.t("admin.users.titles.active");

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-watched-words-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-watched-words-test.js
@@ -7,7 +7,7 @@ import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 acceptance("Admin - Watched Words", function (needs) {
   needs.user();
 
-  test("list words in groups", async (assert) => {
+  test("list words in groups", async function (assert) {
     await visit("/admin/logs/watched_words/action/block");
 
     assert.ok(exists(".watched-words-list"));
@@ -44,7 +44,7 @@ acceptance("Admin - Watched Words", function (needs) {
     assert.ok(!exists(".watched-words-list .watched-word"), "Empty word list.");
   });
 
-  test("add words", async (assert) => {
+  test("add words", async function (assert) {
     await visit("/admin/logs/watched_words/action/block");
 
     click(".show-words-checkbox");
@@ -61,7 +61,7 @@ acceptance("Admin - Watched Words", function (needs) {
     assert.equal(found.length, 1);
   });
 
-  test("remove words", async (assert) => {
+  test("remove words", async function (assert) {
     await visit("/admin/logs/watched_words/action/block");
     await click(".show-words-checkbox");
 

--- a/app/assets/javascripts/discourse/tests/acceptance/auth-complete-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/auth-complete-test.js
@@ -20,7 +20,7 @@ acceptance("Auth Complete", function (needs) {
       .removeChild(document.getElementById("data-authentication"));
   });
 
-  test("when login not required", async (assert) => {
+  test("when login not required", async function (assert) {
     await visit("/");
 
     assert.equal(currentPath(), "discovery.latest", "it stays on the homepage");

--- a/app/assets/javascripts/discourse/tests/acceptance/badges-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/badges-test.js
@@ -7,7 +7,7 @@ import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 acceptance("Badges", function (needs) {
   needs.user();
 
-  test("Visit Badge Pages", async (assert) => {
+  test("Visit Badge Pages", async function (assert) {
     await visit("/badges");
 
     assert.ok($("body.badges-page").length, "has body class");
@@ -20,7 +20,7 @@ acceptance("Badges", function (needs) {
     assert.ok(!exists(".badge-card:eq(0) script"));
   });
 
-  test("shows correct badge titles to choose from", async (assert) => {
+  test("shows correct badge titles to choose from", async function (assert) {
     const availableBadgeTitles = selectKit(".select-kit");
     await visit("/badges/50/custombadge");
     await availableBadgeTitles.expand();

--- a/app/assets/javascripts/discourse/tests/acceptance/bookmarks-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/bookmarks-test.js
@@ -39,7 +39,7 @@ acceptance("Bookmarking", function (needs) {
     );
   });
 
-  test("Bookmarks modal opening", async (assert) => {
+  test("Bookmarks modal opening", async function (assert) {
     await visit("/t/internationalization-localization/280");
     await openBookmarkModal();
     assert.ok(
@@ -48,7 +48,7 @@ acceptance("Bookmarking", function (needs) {
     );
   });
 
-  test("Bookmarks modal selecting reminder type", async (assert) => {
+  test("Bookmarks modal selecting reminder type", async function (assert) {
     await visit("/t/internationalization-localization/280");
 
     await openBookmarkModal();
@@ -79,7 +79,7 @@ acceptance("Bookmarking", function (needs) {
     ]);
   });
 
-  test("Saving a bookmark with a reminder", async (assert) => {
+  test("Saving a bookmark with a reminder", async function (assert) {
     await visit("/t/internationalization-localization/280");
     await openBookmarkModal();
     await fillIn("input#bookmark-name", "Check this out later");
@@ -98,7 +98,7 @@ acceptance("Bookmarking", function (needs) {
     assert.deepEqual(steps, ["tomorrow"]);
   });
 
-  test("Opening the options panel and remembering the option", async (assert) => {
+  test("Opening the options panel and remembering the option", async function (assert) {
     await visit("/t/internationalization-localization/280");
     await openBookmarkModal();
     await click(".bookmark-options-button");
@@ -119,7 +119,7 @@ acceptance("Bookmarking", function (needs) {
     assert.deepEqual(steps, ["none"]);
   });
 
-  test("Saving a bookmark with no reminder or name", async (assert) => {
+  test("Saving a bookmark with no reminder or name", async function (assert) {
     await visit("/t/internationalization-localization/280");
     await openBookmarkModal();
     await click("#save-bookmark");
@@ -137,7 +137,7 @@ acceptance("Bookmarking", function (needs) {
     assert.deepEqual(steps, ["none"]);
   });
 
-  test("Deleting a bookmark with a reminder", async (assert) => {
+  test("Deleting a bookmark with a reminder", async function (assert) {
     await visit("/t/internationalization-localization/280");
     await openBookmarkModal();
     await click("#tap_tile_tomorrow");
@@ -169,7 +169,7 @@ acceptance("Bookmarking", function (needs) {
     );
   });
 
-  test("Cancelling saving a bookmark", async (assert) => {
+  test("Cancelling saving a bookmark", async function (assert) {
     await visit("/t/internationalization-localization/280");
     await openBookmarkModal();
     await click(".d-modal-cancel");
@@ -179,7 +179,7 @@ acceptance("Bookmarking", function (needs) {
     );
   });
 
-  test("Editing a bookmark", async (assert) => {
+  test("Editing a bookmark", async function (assert) {
     await visit("/t/internationalization-localization/280");
     let now = moment.tz(loggedInUser().resolvedTimezone(loggedInUser()));
     let tomorrow = now.add(1, "day").format("YYYY-MM-DD");

--- a/app/assets/javascripts/discourse/tests/acceptance/category-banner-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/category-banner-test.js
@@ -37,7 +37,7 @@ acceptance("Category Banners", function (needs) {
     ],
   });
 
-  test("Does not display category banners when not set", async (assert) => {
+  test("Does not display category banners when not set", async function (assert) {
     await visit("/c/test-read-only-without-banner");
 
     await click("#create-topic");
@@ -48,7 +48,7 @@ acceptance("Category Banners", function (needs) {
     );
   });
 
-  test("Displays category banners when set", async (assert) => {
+  test("Displays category banners when set", async function (assert) {
     await visit("/c/test-read-only-with-banner");
 
     await click("#create-topic");
@@ -85,7 +85,7 @@ acceptance("Anonymous Category Banners", function (needs) {
     ],
   });
 
-  test("Does not display category banners when set", async (assert) => {
+  test("Does not display category banners when set", async function (assert) {
     await visit("/c/test-read-only-with-banner");
     assert.ok(
       !visible(".category-read-only-banner"),

--- a/app/assets/javascripts/discourse/tests/acceptance/category-chooser-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/category-chooser-test.js
@@ -9,7 +9,7 @@ acceptance("CategoryChooser", function (needs) {
     allow_uncategorized_topics: false,
   });
 
-  test("does not display uncategorized if not allowed", async (assert) => {
+  test("does not display uncategorized if not allowed", async function (assert) {
     const categoryChooser = selectKit(".category-chooser");
 
     await visit("/");
@@ -19,7 +19,7 @@ acceptance("CategoryChooser", function (needs) {
     assert.ok(categoryChooser.rowByIndex(0).name() !== "uncategorized");
   });
 
-  test("prefill category when category_id is set", async (assert) => {
+  test("prefill category when category_id is set", async function (assert) {
     await visit("/new-topic?category_id=1");
 
     assert.equal(selectKit(".category-chooser").header().value(), 1);

--- a/app/assets/javascripts/discourse/tests/acceptance/category-edit-security-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/category-edit-security-test.js
@@ -7,7 +7,7 @@ import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 acceptance("Category Edit - security", function (needs) {
   needs.user();
 
-  test("default", async (assert) => {
+  test("default", async function (assert) {
     await visit("/c/bug/edit/security");
 
     const $firstItem = queryAll(".permission-list li:eq(0)");
@@ -19,7 +19,7 @@ acceptance("Category Edit - security", function (needs) {
     assert.equal(permission, "Create / Reply / See");
   });
 
-  test("removing a permission", async (assert) => {
+  test("removing a permission", async function (assert) {
     const availableGroups = selectKit(".available-groups");
 
     await visit("/c/bug/edit/security");
@@ -43,7 +43,7 @@ acceptance("Category Edit - security", function (needs) {
     );
   });
 
-  test("adding a permission", async (assert) => {
+  test("adding a permission", async function (assert) {
     const availableGroups = selectKit(".available-groups");
     const permissionSelector = selectKit(".permission-selector");
 
@@ -67,7 +67,7 @@ acceptance("Category Edit - security", function (needs) {
     assert.equal(permission, "Reply / See");
   });
 
-  test("adding a previously removed permission", async (assert) => {
+  test("adding a previously removed permission", async function (assert) {
     const availableGroups = selectKit(".available-groups");
 
     await visit("/c/bug/edit/security");

--- a/app/assets/javascripts/discourse/tests/acceptance/category-edit-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/category-edit-test.js
@@ -10,7 +10,7 @@ acceptance("Category Edit", function (needs) {
   needs.user();
   needs.settings({ email_in: true });
 
-  test("Editing the category", async (assert) => {
+  test("Editing the category", async function (assert) {
     await visit("/c/bug");
 
     await click("button.edit-category");
@@ -57,7 +57,7 @@ acceptance("Category Edit", function (needs) {
     );
   });
 
-  test("Index Route", async (assert) => {
+  test("Index Route", async function (assert) {
     await visit("/c/bug/edit");
     assert.equal(
       currentURL(),
@@ -66,7 +66,7 @@ acceptance("Category Edit", function (needs) {
     );
   });
 
-  test("Slugless Route", async (assert) => {
+  test("Slugless Route", async function (assert) {
     await visit("/c/1-category/edit");
     assert.equal(
       currentURL(),
@@ -76,7 +76,7 @@ acceptance("Category Edit", function (needs) {
     assert.equal(queryAll("input.category-name").val(), "bug");
   });
 
-  test("Error Saving", async (assert) => {
+  test("Error Saving", async function (assert) {
     await visit("/c/bug/edit/settings");
     await fillIn(".email-in", "duplicate@example.com");
     await click("#save-category");
@@ -88,7 +88,7 @@ acceptance("Category Edit", function (needs) {
     assert.ok(!visible(".bootbox"));
   });
 
-  test("Subcategory list settings", async (assert) => {
+  test("Subcategory list settings", async function (assert) {
     await visit("/c/bug/edit/settings");
 
     assert.ok(

--- a/app/assets/javascripts/discourse/tests/acceptance/category-new-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/category-new-test.js
@@ -9,7 +9,7 @@ import sinon from "sinon";
 acceptance("Category New", function (needs) {
   needs.user();
 
-  test("Creating a new category", async (assert) => {
+  test("Creating a new category", async function (assert) {
     await visit("/new-category");
     assert.ok(queryAll(".badge-category"));
 

--- a/app/assets/javascripts/discourse/tests/acceptance/click-track-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/click-track-test.js
@@ -12,7 +12,7 @@ acceptance("Click Track", function (needs) {
     });
   });
 
-  test("Do not track mentions", async (assert) => {
+  test("Do not track mentions", async function (assert) {
     await visit("/t/internationalization-localization/280");
     assert.ok(
       queryAll(".user-card.show").length === 0,

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-actions-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-actions-test.js
@@ -19,7 +19,7 @@ acceptance("Composer Actions", function (needs) {
   needs.settings({ enable_whispers: true });
   needs.site({ can_tag_topics: true });
 
-  test("creating new topic and then reply_as_private_message keeps attributes", async (assert) => {
+  test("creating new topic and then reply_as_private_message keeps attributes", async function (assert) {
     await visit("/");
     await click("button#create-topic");
 
@@ -34,7 +34,7 @@ acceptance("Composer Actions", function (needs) {
     assert.ok(queryAll(".d-editor-input").val(), "this is the reply");
   });
 
-  test("replying to post", async (assert) => {
+  test("replying to post", async function (assert) {
     const composerActions = selectKit(".composer-actions");
 
     await visit("/t/internationalization-localization/280");
@@ -52,7 +52,7 @@ acceptance("Composer Actions", function (needs) {
     assert.equal(composerActions.rowByIndex(5).value(), undefined);
   });
 
-  test("replying to post - reply_as_private_message", async (assert) => {
+  test("replying to post - reply_as_private_message", async function (assert) {
     const composerActions = selectKit(".composer-actions");
 
     await visit("/t/internationalization-localization/280");
@@ -68,7 +68,7 @@ acceptance("Composer Actions", function (needs) {
     );
   });
 
-  test("replying to post - reply_to_topic", async (assert) => {
+  test("replying to post - reply_to_topic", async function (assert) {
     const composerActions = selectKit(".composer-actions");
 
     await visit("/t/internationalization-localization/280");
@@ -95,7 +95,7 @@ acceptance("Composer Actions", function (needs) {
     );
   });
 
-  test("replying to post - toggle_whisper", async (assert) => {
+  test("replying to post - toggle_whisper", async function (assert) {
     const composerActions = selectKit(".composer-actions");
 
     await visit("/t/internationalization-localization/280");
@@ -113,7 +113,7 @@ acceptance("Composer Actions", function (needs) {
     );
   });
 
-  test("replying to post - reply_as_new_topic", async (assert) => {
+  test("replying to post - reply_as_new_topic", async function (assert) {
     sinon
       .stub(Draft, "get")
       .returns(Promise.resolve({ draft: "", draft_sequence: 0 }));
@@ -144,7 +144,7 @@ acceptance("Composer Actions", function (needs) {
     sinon.restore();
   });
 
-  test("reply_as_new_topic without a new_topic draft", async (assert) => {
+  test("reply_as_new_topic without a new_topic draft", async function (assert) {
     await visit("/t/internationalization-localization/280");
     await click(".create.reply");
     const composerActions = selectKit(".composer-actions");
@@ -153,7 +153,7 @@ acceptance("Composer Actions", function (needs) {
     assert.equal(exists(queryAll(".bootbox")), false);
   });
 
-  test("reply_as_new_group_message", async (assert) => {
+  test("reply_as_new_group_message", async function (assert) {
     await visit("/t/lorem-ipsum-dolor-sit-amet/130");
     await click(".create.reply");
     const composerActions = selectKit(".composer-actions");
@@ -168,7 +168,7 @@ acceptance("Composer Actions", function (needs) {
     assert.deepEqual(items, ["foo", "foo_group"]);
   });
 
-  test("hide component if no content", async (assert) => {
+  test("hide component if no content", async function (assert) {
     await visit("/");
     await click("button#create-topic");
 
@@ -184,7 +184,7 @@ acceptance("Composer Actions", function (needs) {
     assert.equal(composerActions.rows().length, 2);
   });
 
-  test("interactions", async (assert) => {
+  test("interactions", async function (assert) {
     const composerActions = selectKit(".composer-actions");
     const quote = "Life is like riding a bicycle.";
 
@@ -265,7 +265,7 @@ acceptance("Composer Actions", function (needs) {
     assert.equal(composerActions.rows().length, 3);
   });
 
-  test("replying to post - toggle_topic_bump", async (assert) => {
+  test("replying to post - toggle_topic_bump", async function (assert) {
     const composerActions = selectKit(".composer-actions");
 
     await visit("/t/internationalization-localization/280");
@@ -293,7 +293,7 @@ acceptance("Composer Actions", function (needs) {
     );
   });
 
-  test("replying to post as staff", async (assert) => {
+  test("replying to post as staff", async function (assert) {
     const composerActions = selectKit(".composer-actions");
 
     updateCurrentUser({ admin: true });
@@ -305,7 +305,7 @@ acceptance("Composer Actions", function (needs) {
     assert.equal(composerActions.rowByIndex(4).value(), "toggle_topic_bump");
   });
 
-  test("replying to post as TL3 user", async (assert) => {
+  test("replying to post as TL3 user", async function (assert) {
     const composerActions = selectKit(".composer-actions");
 
     updateCurrentUser({ moderator: false, admin: false, trust_level: 3 });
@@ -323,7 +323,7 @@ acceptance("Composer Actions", function (needs) {
     });
   });
 
-  test("replying to post as TL4 user", async (assert) => {
+  test("replying to post as TL4 user", async function (assert) {
     const composerActions = selectKit(".composer-actions");
 
     updateCurrentUser({ moderator: false, admin: false, trust_level: 4 });
@@ -335,7 +335,7 @@ acceptance("Composer Actions", function (needs) {
     assert.equal(composerActions.rowByIndex(3).value(), "toggle_topic_bump");
   });
 
-  test("replying to first post - reply_as_private_message", async (assert) => {
+  test("replying to first post - reply_as_private_message", async function (assert) {
     const composerActions = selectKit(".composer-actions");
 
     await visit("/t/internationalization-localization/280");
@@ -351,7 +351,7 @@ acceptance("Composer Actions", function (needs) {
     );
   });
 
-  test("editing post", async (assert) => {
+  test("editing post", async function (assert) {
     const composerActions = selectKit(".composer-actions");
 
     await visit("/t/internationalization-localization/280");
@@ -385,7 +385,7 @@ acceptance("Composer Actions With New Topic Draft", function (needs) {
   needs.hooks.beforeEach(() => _clearSnapshots());
   needs.hooks.afterEach(() => _clearSnapshots());
 
-  test("shared draft", async (assert) => {
+  test("shared draft", async function (assert) {
     stubDraftResponse();
     try {
       toggleCheckDraftPopup(true);
@@ -427,7 +427,7 @@ acceptance("Composer Actions With New Topic Draft", function (needs) {
     sinon.restore();
   });
 
-  test("reply_as_new_topic with new_topic draft", async (assert) => {
+  test("reply_as_new_topic with new_topic draft", async function (assert) {
     await visit("/t/internationalization-localization/280");
     await click(".create.reply");
     const composerActions = selectKit(".composer-actions");

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-attachment-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-attachment-test.js
@@ -33,7 +33,7 @@ acceptance("Composer Attachment", function (needs) {
   needs.user();
   needs.pretender(pretender);
 
-  test("attachments are cooked properly", async (assert) => {
+  test("attachments are cooked properly", async function (assert) {
     await writeInComposer(assert);
     assert.equal(
       queryAll(".d-editor-preview:visible").html().trim(),
@@ -47,7 +47,7 @@ acceptance("Composer Attachment - Secure Media Enabled", function (needs) {
   needs.settings({ secure_media: true });
   needs.pretender(pretender);
 
-  test("attachments are cooked properly when secure media is enabled", async (assert) => {
+  test("attachments are cooked properly when secure media is enabled", async function (assert) {
     await writeInComposer(assert);
     assert.equal(
       queryAll(".d-editor-preview:visible").html().trim(),

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-edit-conflict-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-edit-conflict-test.js
@@ -15,7 +15,7 @@ acceptance("Composer - Edit conflict", function (needs) {
     });
   });
 
-  test("Edit a post that causes an edit conflict", async (assert) => {
+  test("Edit a post that causes an edit conflict", async function (assert) {
     await visit("/t/internationalization-localization/280");
     await click(".topic-post:eq(0) button.show-more-actions");
     await click(".topic-post:eq(0) button.edit");
@@ -33,7 +33,7 @@ acceptance("Composer - Edit conflict", function (needs) {
     await click(".modal .btn-primary");
   });
 
-  test("Should not send originalText when posting a new reply", async (assert) => {
+  test("Should not send originalText when posting a new reply", async function (assert) {
     await visit("/t/internationalization-localization/280");
     await click(".topic-post:eq(0) button.reply");
     await fillIn(
@@ -43,7 +43,7 @@ acceptance("Composer - Edit conflict", function (needs) {
     assert.ok(lastBody.indexOf("originalText") === -1);
   });
 
-  test("Should send originalText when editing a reply", async (assert) => {
+  test("Should send originalText when editing a reply", async function (assert) {
     await visit("/t/internationalization-localization/280");
     await click(".topic-post:eq(0) button.show-more-actions");
     await click(".topic-post:eq(0) button.edit");

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-hyperlink-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-hyperlink-test.js
@@ -7,7 +7,7 @@ import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 acceptance("Composer - Hyperlink", function (needs) {
   needs.user();
 
-  test("add a hyperlink to a reply", async (assert) => {
+  test("add a hyperlink to a reply", async function (assert) {
     await visit("/t/internationalization-localization/280");
     await click(".topic-post:first-child button.reply");
     await fillIn(".d-editor-input", "This is a link to ");

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-onebox-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-onebox-test.js
@@ -10,7 +10,7 @@ acceptance("Composer - Onebox", function (needs) {
     enable_markdown_linkify: true,
   });
 
-  test("Preview update should respect max_oneboxes_per_post site setting", async (assert) => {
+  test("Preview update should respect max_oneboxes_per_post site setting", async function (assert) {
     await visit("/t/internationalization-localization/280");
     await click("#topic-footer-buttons .btn.create");
 

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-tags-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-tags-test.js
@@ -16,7 +16,7 @@ acceptance("Composer - Tags", function (needs) {
   });
   needs.site({ can_tag_topics: true });
 
-  test("staff bypass tag validation rule", async (assert) => {
+  test("staff bypass tag validation rule", async function (assert) {
     await visit("/");
     await click("#create-topic");
 
@@ -33,7 +33,7 @@ acceptance("Composer - Tags", function (needs) {
     assert.notEqual(currentURL(), "/");
   });
 
-  test("users do not bypass tag validation rule", async (assert) => {
+  test("users do not bypass tag validation rule", async function (assert) {
     await visit("/");
     await click("#create-topic");
 

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
@@ -24,7 +24,7 @@ acceptance("Composer", function (needs) {
     });
   });
 
-  skip("Tests the Composer controls", async (assert) => {
+  skip("Tests the Composer controls", async function (assert) {
     await visit("/");
     assert.ok(exists("#create-topic"), "the create button is visible");
 
@@ -102,7 +102,7 @@ acceptance("Composer", function (needs) {
     assert.ok(!exists(".bootbox.modal"), "the confirmation can be cancelled");
   });
 
-  test("Composer upload placeholder", async (assert) => {
+  test("Composer upload placeholder", async function (assert) {
     await visit("/");
     await click("#create-topic");
 
@@ -198,7 +198,7 @@ acceptance("Composer", function (needs) {
     );
   });
 
-  test("Create a topic with server side errors", async (assert) => {
+  test("Create a topic with server side errors", async function (assert) {
     await visit("/");
     await click("#create-topic");
     await fillIn("#reply-title", "this title triggers an error");
@@ -210,7 +210,7 @@ acceptance("Composer", function (needs) {
     assert.ok(exists(".d-editor-input"), "the composer input is visible");
   });
 
-  test("Create a Topic", async (assert) => {
+  test("Create a Topic", async function (assert) {
     await visit("/");
     await click("#create-topic");
     await fillIn("#reply-title", "Internationalization Localization");
@@ -226,7 +226,7 @@ acceptance("Composer", function (needs) {
     );
   });
 
-  test("Create an enqueued Topic", async (assert) => {
+  test("Create an enqueued Topic", async function (assert) {
     await visit("/");
     await click("#create-topic");
     await fillIn("#reply-title", "Internationalization Localization");
@@ -239,7 +239,7 @@ acceptance("Composer", function (needs) {
     assert.ok(invisible(".d-modal"), "the modal can be dismissed");
   });
 
-  test("Can display a message and route to a URL", async (assert) => {
+  test("Can display a message and route to a URL", async function (assert) {
     await visit("/");
     await click("#create-topic");
     await fillIn("#reply-title", "This title doesn't matter");
@@ -259,7 +259,7 @@ acceptance("Composer", function (needs) {
     );
   });
 
-  test("Create a Reply", async (assert) => {
+  test("Create a Reply", async function (assert) {
     await visit("/t/internationalization-localization/280");
 
     assert.ok(
@@ -282,7 +282,7 @@ acceptance("Composer", function (needs) {
     );
   });
 
-  test("Can edit a post after starting a reply", async (assert) => {
+  test("Can edit a post after starting a reply", async function (assert) {
     await visit("/t/internationalization-localization/280");
 
     await click("#topic-footer-buttons .create");
@@ -300,7 +300,7 @@ acceptance("Composer", function (needs) {
     );
   });
 
-  test("Posting on a different topic", async (assert) => {
+  test("Posting on a different topic", async function (assert) {
     await visit("/t/internationalization-localization/280");
     await click("#topic-footer-buttons .btn.create");
     await fillIn(
@@ -320,7 +320,7 @@ acceptance("Composer", function (needs) {
     );
   });
 
-  test("Create an enqueued Reply", async (assert) => {
+  test("Create an enqueued Reply", async function (assert) {
     await visit("/t/internationalization-localization/280");
 
     assert.notOk(queryAll(".pending-posts .reviewable-item").length);
@@ -347,7 +347,7 @@ acceptance("Composer", function (needs) {
     assert.ok(queryAll(".pending-posts .reviewable-item").length);
   });
 
-  test("Edit the first post", async (assert) => {
+  test("Edit the first post", async function (assert) {
     await visit("/t/internationalization-localization/280");
 
     assert.ok(
@@ -385,7 +385,7 @@ acceptance("Composer", function (needs) {
     );
   });
 
-  test("Composer can switch between edits", async (assert) => {
+  test("Composer can switch between edits", async function (assert) {
     await visit("/t/this-is-a-test-topic/9");
 
     await click(".topic-post:eq(0) button.edit");
@@ -402,7 +402,7 @@ acceptance("Composer", function (needs) {
     );
   });
 
-  test("Composer with dirty edit can toggle to another edit", async (assert) => {
+  test("Composer with dirty edit can toggle to another edit", async function (assert) {
     await visit("/t/this-is-a-test-topic/9");
 
     await click(".topic-post:eq(0) button.edit");
@@ -418,7 +418,7 @@ acceptance("Composer", function (needs) {
     );
   });
 
-  test("Composer can toggle between edit and reply", async (assert) => {
+  test("Composer can toggle between edit and reply", async function (assert) {
     await visit("/t/this-is-a-test-topic/9");
 
     await click(".topic-post:eq(0) button.edit");
@@ -437,7 +437,7 @@ acceptance("Composer", function (needs) {
     );
   });
 
-  test("Composer can toggle whispers", async (assert) => {
+  test("Composer can toggle whispers", async function (assert) {
     const menu = selectKit(".toolbar-popup-menu-options");
 
     await visit("/t/this-is-a-test-topic/9");
@@ -472,7 +472,7 @@ acceptance("Composer", function (needs) {
     );
   });
 
-  test("Composer can toggle layouts (open, fullscreen and draft)", async (assert) => {
+  test("Composer can toggle layouts (open, fullscreen and draft)", async function (assert) {
     await visit("/t/this-is-a-test-topic/9");
     await click(".topic-post:eq(0) button.reply");
 
@@ -511,7 +511,7 @@ acceptance("Composer", function (needs) {
     );
   });
 
-  test("Composer can toggle between reply and createTopic", async (assert) => {
+  test("Composer can toggle between reply and createTopic", async function (assert) {
     await visit("/t/this-is-a-test-topic/9");
     await click(".topic-post:eq(0) button.reply");
 
@@ -557,7 +557,7 @@ acceptance("Composer", function (needs) {
     );
   });
 
-  test("Composer with dirty reply can toggle to edit", async (assert) => {
+  test("Composer with dirty reply can toggle to edit", async function (assert) {
     await visit("/t/this-is-a-test-topic/9");
 
     await click(".topic-post:eq(0) button.reply");
@@ -572,7 +572,7 @@ acceptance("Composer", function (needs) {
     );
   });
 
-  test("Composer draft with dirty reply can toggle to edit", async (assert) => {
+  test("Composer draft with dirty reply can toggle to edit", async function (assert) {
     await visit("/t/this-is-a-test-topic/9");
 
     await click(".topic-post:eq(0) button.reply");
@@ -592,7 +592,7 @@ acceptance("Composer", function (needs) {
     );
   });
 
-  test("Composer draft can switch to draft in new context without destroying current draft", async (assert) => {
+  test("Composer draft can switch to draft in new context without destroying current draft", async function (assert) {
     await visit("/t/this-is-a-test-topic/9");
 
     await click(".topic-post:eq(0) button.reply");
@@ -614,7 +614,7 @@ acceptance("Composer", function (needs) {
     );
   });
 
-  test("Checks for existing draft", async (assert) => {
+  test("Checks for existing draft", async function (assert) {
     try {
       toggleCheckDraftPopup(true);
 
@@ -634,7 +634,7 @@ acceptance("Composer", function (needs) {
     }
   });
 
-  test("Can switch states without abandon popup", async (assert) => {
+  test("Can switch states without abandon popup", async function (assert) {
     try {
       toggleCheckDraftPopup(true);
 
@@ -684,7 +684,7 @@ acceptance("Composer", function (needs) {
     sinon.restore();
   });
 
-  test("Loading draft also replaces the recipients", async (assert) => {
+  test("Loading draft also replaces the recipients", async function (assert) {
     try {
       toggleCheckDraftPopup(true);
 
@@ -706,7 +706,7 @@ acceptance("Composer", function (needs) {
     }
   });
 
-  test("Deleting the text content of the first post in a private message", async (assert) => {
+  test("Deleting the text content of the first post in a private message", async function (assert) {
     await visit("/t/34");
 
     await click("#post_1 .d-icon-ellipsis-h");
@@ -730,7 +730,7 @@ acceptance("Composer", function (needs) {
     );
   };
 
-  test("Image resizing buttons", async (assert) => {
+  test("Image resizing buttons", async function (assert) {
     await visit("/");
     await click("#create-topic");
 

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-topic-links-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-topic-links-test.js
@@ -12,7 +12,7 @@ acceptance("Composer topic featured links", function (needs) {
     enable_markdown_linkify: true,
   });
 
-  test("onebox with title", async (assert) => {
+  test("onebox with title", async function (assert) {
     await visit("/");
     await click("#create-topic");
     await fillIn("#reply-title", "http://www.example.com/has-title.html");
@@ -31,7 +31,7 @@ acceptance("Composer topic featured links", function (needs) {
     );
   });
 
-  test("onebox result doesn't include a title", async (assert) => {
+  test("onebox result doesn't include a title", async function (assert) {
     await visit("/");
     await click("#create-topic");
     await fillIn("#reply-title", "http://www.example.com/no-title.html");
@@ -50,7 +50,7 @@ acceptance("Composer topic featured links", function (needs) {
     );
   });
 
-  test("no onebox result", async (assert) => {
+  test("no onebox result", async function (assert) {
     await visit("/");
     await click("#create-topic");
     await fillIn("#reply-title", "http://www.example.com/nope-onebox.html");
@@ -69,7 +69,7 @@ acceptance("Composer topic featured links", function (needs) {
     );
   });
 
-  test("ignore internal links", async (assert) => {
+  test("ignore internal links", async function (assert) {
     await visit("/");
     await click("#create-topic");
     const title = "http://" + window.location.hostname + "/internal-page.html";
@@ -91,7 +91,7 @@ acceptance("Composer topic featured links", function (needs) {
     );
   });
 
-  test("link is longer than max title length", async (assert) => {
+  test("link is longer than max title length", async function (assert) {
     await visit("/");
     await click("#create-topic");
     await fillIn(
@@ -113,7 +113,7 @@ acceptance("Composer topic featured links", function (needs) {
     );
   });
 
-  test("onebox with title but extra words in title field", async (assert) => {
+  test("onebox with title but extra words in title field", async function (assert) {
     await visit("/");
     await click("#create-topic");
     await fillIn("#reply-title", "http://www.example.com/has-title.html test");
@@ -146,7 +146,7 @@ acceptance(
       allow_uncategorized_topics: false,
     });
 
-    test("Pasting a link enables the text input area", async (assert) => {
+    test("Pasting a link enables the text input area", async function (assert) {
       await visit("/");
       await click("#create-topic");
       assert.ok(

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-uncategorized-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-uncategorized-test.js
@@ -14,7 +14,7 @@ acceptance(
       allow_uncategorized_topics: false,
     });
 
-    test("Disable body until category is selected", async (assert) => {
+    test("Disable body until category is selected", async function (assert) {
       await visit("/");
       await click("#create-topic");
       assert.ok(exists(".d-editor-input"), "the composer input is visible");
@@ -80,7 +80,7 @@ acceptance(
         },
       ],
     });
-    test("Enable composer/body if no topic templates present", async (assert) => {
+    test("Enable composer/body if no topic templates present", async function (assert) {
       await visit("/");
       await click("#create-topic");
       assert.ok(exists(".d-editor-input"), "the composer input is visible");

--- a/app/assets/javascripts/discourse/tests/acceptance/create-account-external-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/create-account-external-test.js
@@ -21,7 +21,7 @@ acceptance("Create Account - external auth", function (needs) {
       .removeChild(document.getElementById("data-authentication"));
   });
 
-  test("when skip is disabled (default)", async (assert) => {
+  test("when skip is disabled (default)", async function (assert) {
     await visit("/");
 
     assert.ok(

--- a/app/assets/javascripts/discourse/tests/acceptance/create-account-user-fields-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/create-account-user-fields-test.js
@@ -28,7 +28,7 @@ acceptance("Create Account - User Fields", function (needs) {
     ],
   });
 
-  test("create account with user fields", async (assert) => {
+  test("create account with user fields", async function (assert) {
     await visit("/");
     await click("header .sign-up-button");
 

--- a/app/assets/javascripts/discourse/tests/acceptance/custom-html-set-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/custom-html-set-test.js
@@ -7,12 +7,12 @@ import { setCustomHTML } from "discourse/helpers/custom-html";
 import PreloadStore from "discourse/lib/preload-store";
 
 acceptance("CustomHTML set", function () {
-  test("has no custom HTML in the top", async (assert) => {
+  test("has no custom HTML in the top", async function (assert) {
     await visit("/static/faq");
     assert.ok(!exists("span.custom-html-test"), "it has no markup");
   });
 
-  test("renders set HTML", async (assert) => {
+  test("renders set HTML", async function (assert) {
     setCustomHTML("top", '<span class="custom-html-test">HTML</span>');
 
     await visit("/static/faq");
@@ -23,7 +23,7 @@ acceptance("CustomHTML set", function () {
     );
   });
 
-  test("renders preloaded HTML", async (assert) => {
+  test("renders preloaded HTML", async function (assert) {
     PreloadStore.store("customHTML", {
       top: "<span class='cookie'>monster</span>",
     });

--- a/app/assets/javascripts/discourse/tests/acceptance/custom-html-template-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/custom-html-template-test.js
@@ -14,7 +14,7 @@ acceptance("CustomHTML template", function (needs) {
     delete Ember.TEMPLATES["top"];
   });
 
-  test("renders custom template", async (assert) => {
+  test("renders custom template", async function (assert) {
     await visit("/static/faq");
     assert.equal(
       queryAll("span.top-span").text(),

--- a/app/assets/javascripts/discourse/tests/acceptance/dashboard-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/dashboard-test.js
@@ -24,13 +24,13 @@ acceptance("Dashboard", function (needs) {
     ],
   });
 
-  test("default", async (assert) => {
+  test("default", async function (assert) {
     await visit("/admin");
 
     assert.ok(exists(".dashboard"), "has dashboard-next class");
   });
 
-  test("tabs", async (assert) => {
+  test("tabs", async function (assert) {
     await visit("/admin");
 
     assert.ok(exists(".dashboard .navigation-item.general"), "general tab");
@@ -42,7 +42,7 @@ acceptance("Dashboard", function (needs) {
     assert.ok(exists(".dashboard .navigation-item.reports"), "reports tab");
   });
 
-  test("general tab", async (assert) => {
+  test("general tab", async function (assert) {
     await visit("/admin");
     assert.ok(exists(".admin-report.signups"), "signups report");
     assert.ok(exists(".admin-report.posts"), "posts report");
@@ -65,7 +65,7 @@ acceptance("Dashboard", function (needs) {
     );
   });
 
-  test("activity metrics", async (assert) => {
+  test("activity metrics", async function (assert) {
     await visit("/admin");
 
     assert.ok(exists(".admin-report.page-view-total-reqs .today-count"));
@@ -74,7 +74,7 @@ acceptance("Dashboard", function (needs) {
     assert.ok(exists(".admin-report.page-view-total-reqs .thirty-days-count"));
   });
 
-  test("reports tab", async (assert) => {
+  test("reports tab", async function (assert) {
     await visit("/admin");
     await click(".dashboard .navigation-item.reports .navigation-link");
 
@@ -112,7 +112,7 @@ acceptance("Dashboard", function (needs) {
     );
   });
 
-  test("reports filters", async (assert) => {
+  test("reports filters", async function (assert) {
     await visit(
       '/admin/reports/signups_with_groups?end_date=2018-07-16&filters=%7B"group"%3A88%7D&start_date=2018-06-16'
     );
@@ -131,7 +131,7 @@ acceptance("Dashboard: dashboard_visible_tabs", function (needs) {
   needs.user();
   needs.settings({ dashboard_visible_tabs: "general|security|reports" });
 
-  test("visible tabs", async (assert) => {
+  test("visible tabs", async function (assert) {
     await visit("/admin");
 
     assert.ok(exists(".dashboard .navigation-item.general"), "general tab");
@@ -151,7 +151,7 @@ acceptance("Dashboard: dashboard_hidden_reports", function (needs) {
     dashboard_hidden_reports: "posts|dau_by_mau",
   });
 
-  test("hidden reports", async (assert) => {
+  test("hidden reports", async function (assert) {
     await visit("/admin");
 
     assert.ok(exists(".admin-report.signups.is-visible"), "signups report");

--- a/app/assets/javascripts/discourse/tests/acceptance/emoji-picker-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/emoji-picker-test.js
@@ -15,7 +15,7 @@ acceptance("EmojiPicker", function (needs) {
     this.emojiStore.reset();
   });
 
-  test("emoji picker can be opened/closed", async (assert) => {
+  test("emoji picker can be opened/closed", async function (assert) {
     await visit("/t/internationalization-localization/280");
     await click("#topic-footer-buttons .btn.create");
 
@@ -26,7 +26,7 @@ acceptance("EmojiPicker", function (needs) {
     assert.notOk(exists(".emoji-picker.opened"), "it closes the picker");
   });
 
-  test("emoji picker triggers event when picking emoji", async (assert) => {
+  test("emoji picker triggers event when picking emoji", async function (assert) {
     await visit("/t/internationalization-localization/280");
     await click("#topic-footer-buttons .btn.create");
     await click("button.emoji.btn");
@@ -39,7 +39,7 @@ acceptance("EmojiPicker", function (needs) {
     );
   });
 
-  test("emoji picker adds leading whitespace before emoji", async (assert) => {
+  test("emoji picker adds leading whitespace before emoji", async function (assert) {
     await visit("/t/internationalization-localization/280");
     await click("#topic-footer-buttons .btn.create");
 
@@ -64,7 +64,7 @@ acceptance("EmojiPicker", function (needs) {
     );
   });
 
-  test("emoji picker has a list of recently used emojis", async (assert) => {
+  test("emoji picker has a list of recently used emojis", async function (assert) {
     await visit("/t/internationalization-localization/280");
     await click("#topic-footer-buttons .btn.create");
     await click("button.emoji.btn");
@@ -102,7 +102,7 @@ acceptance("EmojiPicker", function (needs) {
     );
   });
 
-  test("emoji picker correctly orders recently used emojis", async (assert) => {
+  test("emoji picker correctly orders recently used emojis", async function (assert) {
     await visit("/t/internationalization-localization/280");
     await click("#topic-footer-buttons .btn.create");
     await click("button.emoji.btn");
@@ -125,7 +125,7 @@ acceptance("EmojiPicker", function (needs) {
     );
   });
 
-  test("emoji picker persists state", async (assert) => {
+  test("emoji picker persists state", async function (assert) {
     await visit("/t/internationalization-localization/280");
     await click("#topic-footer-buttons .btn.create");
     await click("button.emoji.btn");

--- a/app/assets/javascripts/discourse/tests/acceptance/emoji-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/emoji-test.js
@@ -7,7 +7,7 @@ import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 acceptance("Emoji", function (needs) {
   needs.user();
 
-  test("emoji is cooked properly", async (assert) => {
+  test("emoji is cooked properly", async function (assert) {
     await visit("/t/internationalization-localization/280");
     await click("#topic-footer-buttons .btn.create");
 
@@ -18,7 +18,7 @@ acceptance("Emoji", function (needs) {
     );
   });
 
-  test("skin toned emoji is cooked properly", async (assert) => {
+  test("skin toned emoji is cooked properly", async function (assert) {
     await visit("/t/internationalization-localization/280");
     await click("#topic-footer-buttons .btn.create");
 

--- a/app/assets/javascripts/discourse/tests/acceptance/encoded-category-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/encoded-category-test.js
@@ -43,7 +43,7 @@ acceptance("Encoded Sub Category Discovery", function (needs) {
     );
   });
 
-  test("Visit subcategory by slug", async (assert) => {
+  test("Visit subcategory by slug", async function (assert) {
     let bodySelector =
       "body.category-\\%E6\\%BC\\%A2\\%E5\\%AD\\%97-parent-\\%E6\\%BC\\%A2\\%E5\\%AD\\%97-subcategory";
     await visit("/c/%E6%BC%A2%E5%AD%97-parent/%E6%BC%A2%E5%AD%97-subcategory");

--- a/app/assets/javascripts/discourse/tests/acceptance/flag-post-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/flag-post-test.js
@@ -82,13 +82,13 @@ acceptance("flagging", function (needs) {
     });
   });
 
-  test("Flag modal opening", async (assert) => {
+  test("Flag modal opening", async function (assert) {
     await visit("/t/internationalization-localization/280");
     await openFlagModal();
     assert.ok(exists(".flag-modal-body"), "it shows the flag modal");
   });
 
-  test("Flag take action dropdown exists", async (assert) => {
+  test("Flag take action dropdown exists", async function (assert) {
     await visit("/t/internationalization-localization/280");
     await openFlagModal();
     await click("#radio_inappropriate");
@@ -101,7 +101,7 @@ acceptance("flagging", function (needs) {
     assert.ok(exists(".silence-user-modal"), "it shows the silence modal");
   });
 
-  test("Can silence from take action", async (assert) => {
+  test("Can silence from take action", async function (assert) {
     await visit("/t/internationalization-localization/280");
     await openFlagModal();
     await click("#radio_inappropriate");
@@ -116,7 +116,7 @@ acceptance("flagging", function (needs) {
     assert.equal(queryAll(".bootbox.modal:visible").length, 0);
   });
 
-  test("Gets dismissable warning from canceling incomplete silence from take action", async (assert) => {
+  test("Gets dismissable warning from canceling incomplete silence from take action", async function (assert) {
     await visit("/t/internationalization-localization/280");
     await openFlagModal();
     await click("#radio_inappropriate");

--- a/app/assets/javascripts/discourse/tests/acceptance/forgot-password-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/forgot-password-test.js
@@ -16,7 +16,7 @@ acceptance("Forgot password", function (needs) {
     });
   });
 
-  test("requesting password reset", async (assert) => {
+  test("requesting password reset", async function (assert) {
     await visit("/");
     await click("header .login-button");
     await click("#forgot-password-link");

--- a/app/assets/javascripts/discourse/tests/acceptance/group-index-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-index-test.js
@@ -9,7 +9,7 @@ import {
 } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Group Members - Anonymous", function () {
-  test("Viewing Members as anon user", async (assert) => {
+  test("Viewing Members as anon user", async function (assert) {
     await visit("/g/discourse");
 
     assert.ok(
@@ -34,7 +34,7 @@ acceptance("Group Members - Anonymous", function () {
 acceptance("Group Members", function (needs) {
   needs.user();
 
-  test("Viewing Members as a group owner", async (assert) => {
+  test("Viewing Members as a group owner", async function (assert) {
     updateCurrentUser({ moderator: false, admin: false });
 
     await visit("/g/discourse");
@@ -47,7 +47,7 @@ acceptance("Group Members", function (needs) {
     );
   });
 
-  test("Viewing Members as an admin user", async (assert) => {
+  test("Viewing Members as an admin user", async function (assert) {
     await visit("/g/discourse");
 
     assert.ok(

--- a/app/assets/javascripts/discourse/tests/acceptance/group-manage-categories-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-manage-categories-test.js
@@ -8,7 +8,7 @@ import {
 } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Managing Group Category Notification Defaults", function () {
-  test("As an anonymous user", async (assert) => {
+  test("As an anonymous user", async function (assert) {
     await visit("/g/discourse/manage/categories");
 
     assert.ok(
@@ -20,7 +20,7 @@ acceptance("Managing Group Category Notification Defaults", function () {
 
 acceptance("Managing Group Category Notification Defaults", function (needs) {
   needs.user();
-  test("As an admin", async (assert) => {
+  test("As an admin", async function (assert) {
     await visit("/g/discourse/manage/categories");
 
     assert.ok(
@@ -29,7 +29,7 @@ acceptance("Managing Group Category Notification Defaults", function (needs) {
     );
   });
 
-  test("As a group owner", async (assert) => {
+  test("As a group owner", async function (assert) {
     updateCurrentUser({ moderator: false, admin: false });
 
     await visit("/g/discourse/manage/categories");

--- a/app/assets/javascripts/discourse/tests/acceptance/group-manage-interaction-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-manage-interaction-test.js
@@ -10,7 +10,7 @@ acceptance("Managing Group Interaction Settings", function (needs) {
   needs.user();
   needs.settings({ email_in: true });
 
-  test("As an admin", async (assert) => {
+  test("As an admin", async function (assert) {
     updateCurrentUser({
       moderator: false,
       admin: true,
@@ -50,7 +50,7 @@ acceptance("Managing Group Interaction Settings", function (needs) {
     );
   });
 
-  test("As a group owner", async (assert) => {
+  test("As a group owner", async function (assert) {
     updateCurrentUser({
       moderator: false,
       admin: false,

--- a/app/assets/javascripts/discourse/tests/acceptance/group-manage-logs-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-manage-logs-test.js
@@ -94,7 +94,7 @@ acceptance("Group logs", function (needs) {
     });
   });
 
-  test("Browsing group logs", async (assert) => {
+  test("Browsing group logs", async function (assert) {
     await visit("/g/snorlax/manage/logs");
     assert.ok(
       queryAll("tr.group-manage-logs-row").length === 2,

--- a/app/assets/javascripts/discourse/tests/acceptance/group-manage-membership-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-manage-membership-test.js
@@ -10,7 +10,7 @@ import selectKit from "discourse/tests/helpers/select-kit-helper";
 acceptance("Managing Group Membership", function (needs) {
   needs.user();
 
-  test("As an admin", async (assert) => {
+  test("As an admin", async function (assert) {
     updateCurrentUser({ can_create_group: true });
 
     await visit("/g/alternative-group/manage/membership");
@@ -79,7 +79,7 @@ acceptance("Managing Group Membership", function (needs) {
     assert.equal(emailDomains.header().value(), "foo.com");
   });
 
-  test("As a group owner", async (assert) => {
+  test("As a group owner", async function (assert) {
     updateCurrentUser({ moderator: false, admin: false });
 
     await visit("/g/discourse/manage/membership");

--- a/app/assets/javascripts/discourse/tests/acceptance/group-manage-profile-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-manage-profile-test.js
@@ -8,7 +8,7 @@ import {
 } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Managing Group Profile", function () {
-  test("As an anonymous user", async (assert) => {
+  test("As an anonymous user", async function (assert) {
     await visit("/g/discourse/manage/profile");
 
     assert.ok(
@@ -21,7 +21,7 @@ acceptance("Managing Group Profile", function () {
 acceptance("Managing Group Profile", function (needs) {
   needs.user();
 
-  test("As an admin", async (assert) => {
+  test("As an admin", async function (assert) {
     await visit("/g/discourse/manage/profile");
 
     assert.ok(
@@ -42,7 +42,7 @@ acceptance("Managing Group Profile", function (needs) {
     );
   });
 
-  test("As a group owner", async (assert) => {
+  test("As a group owner", async function (assert) {
     updateCurrentUser({
       moderator: false,
       admin: false,

--- a/app/assets/javascripts/discourse/tests/acceptance/group-manage-tags-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-manage-tags-test.js
@@ -8,7 +8,7 @@ import {
 } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Managing Group Tag Notification Defaults", function () {
-  test("As an anonymous user", async (assert) => {
+  test("As an anonymous user", async function (assert) {
     await visit("/g/discourse/manage/tags");
 
     assert.ok(
@@ -21,7 +21,7 @@ acceptance("Managing Group Tag Notification Defaults", function () {
 acceptance("Managing Group Tag Notification Defaults", function (needs) {
   needs.user();
 
-  test("As an admin", async (assert) => {
+  test("As an admin", async function (assert) {
     await visit("/g/discourse/manage/tags");
 
     assert.ok(
@@ -30,7 +30,7 @@ acceptance("Managing Group Tag Notification Defaults", function (needs) {
     );
   });
 
-  test("As a group owner", async (assert) => {
+  test("As a group owner", async function (assert) {
     updateCurrentUser({ moderator: false, admin: false });
 
     await visit("/g/discourse/manage/tags");

--- a/app/assets/javascripts/discourse/tests/acceptance/group-requests-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-requests-test.js
@@ -83,7 +83,7 @@ acceptance("Group Requests", function (needs) {
     });
   });
 
-  test("Group Requests", async (assert) => {
+  test("Group Requests", async function (assert) {
     await visit("/g/Macdonald/requests");
 
     assert.equal(queryAll(".group-members tr").length, 2);

--- a/app/assets/javascripts/discourse/tests/acceptance/group-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-test.js
@@ -76,7 +76,7 @@ acceptance("Group - Anonymous", function (needs) {
     );
   });
 
-  test("Anonymous Viewing Automatic Group", async (assert) => {
+  test("Anonymous Viewing Automatic Group", async function (assert) {
     await visit("/g/moderators");
 
     assert.equal(
@@ -185,7 +185,7 @@ acceptance("Group - Authenticated", function (needs) {
     );
   });
 
-  test("User Viewing Group", async (assert) => {
+  test("User Viewing Group", async function (assert) {
     await visit("/g");
     await click(".group-index-request");
 
@@ -218,7 +218,7 @@ acceptance("Group - Authenticated", function (needs) {
     );
   });
 
-  test("Admin viewing group messages when there are no messages", async (assert) => {
+  test("Admin viewing group messages when there are no messages", async function (assert) {
     await visit("/g/alternative-group");
     await click(".nav-pills li a[title='Messages']");
 
@@ -229,7 +229,7 @@ acceptance("Group - Authenticated", function (needs) {
     );
   });
 
-  test("Admin viewing group messages", async (assert) => {
+  test("Admin viewing group messages", async function (assert) {
     await visit("/g/discourse");
     await click(".nav-pills li a[title='Messages']");
 
@@ -240,7 +240,7 @@ acceptance("Group - Authenticated", function (needs) {
     );
   });
 
-  test("Admin Viewing Group", async (assert) => {
+  test("Admin Viewing Group", async function (assert) {
     await visit("/g/discourse");
 
     assert.ok(
@@ -260,7 +260,7 @@ acceptance("Group - Authenticated", function (needs) {
     );
   });
 
-  test("Moderator Viewing Group", async (assert) => {
+  test("Moderator Viewing Group", async function (assert) {
     await visit("/g/alternative-group");
 
     assert.ok(

--- a/app/assets/javascripts/discourse/tests/acceptance/groups-index-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/groups-index-test.js
@@ -9,7 +9,7 @@ import {
 } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Groups", function () {
-  test("Browsing Groups", async (assert) => {
+  test("Browsing Groups", async function (assert) {
     await visit("/g?username=eviltrout");
 
     assert.equal(count(".group-box"), 1, "it displays user's groups");

--- a/app/assets/javascripts/discourse/tests/acceptance/groups-new-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/groups-new-test.js
@@ -5,7 +5,7 @@ import I18n from "I18n";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("New Group - Anonymous", function () {
-  test("As an anon user", async (assert) => {
+  test("As an anon user", async function (assert) {
     await visit("/g");
 
     assert.equal(
@@ -18,7 +18,7 @@ acceptance("New Group - Anonymous", function () {
 
 acceptance("New Group - Authenticated", function (needs) {
   needs.user();
-  test("Creating a new group", async (assert) => {
+  test("Creating a new group", async function (assert) {
     await visit("/g");
     await click(".groups-header-new");
 

--- a/app/assets/javascripts/discourse/tests/acceptance/hamburger-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/hamburger-menu-test.js
@@ -13,7 +13,7 @@ acceptance("Opening the hamburger menu with some reviewables", function (
   needs.pretender((server, helper) => {
     server.get("/review/count.json", () => helper.response({ count: 3 }));
   });
-  test("As a staff member", async (assert) => {
+  test("As a staff member", async function (assert) {
     updateCurrentUser({ moderator: true, admin: false });
 
     await visit("/");

--- a/app/assets/javascripts/discourse/tests/acceptance/hashtags-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/hashtags-test.js
@@ -18,7 +18,7 @@ acceptance("Category and Tag Hashtags", function (needs) {
     });
   });
 
-  test("hashtags are cooked properly", async (assert) => {
+  test("hashtags are cooked properly", async function (assert) {
     await visit("/t/internationalization-localization/280");
     await click("#topic-footer-buttons .btn.create");
 

--- a/app/assets/javascripts/discourse/tests/acceptance/invite-accept-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/invite-accept-test.js
@@ -8,7 +8,7 @@ import PreloadStore from "discourse/lib/preload-store";
 acceptance("Invite Accept", function (needs) {
   needs.settings({ full_name_required: true });
 
-  test("Invite Acceptance Page", async (assert) => {
+  test("Invite Acceptance Page", async function (assert) {
     PreloadStore.store("invite_info", {
       invited_by: {
         id: 123,

--- a/app/assets/javascripts/discourse/tests/acceptance/invite-show-user-fields-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/invite-show-user-fields-test.js
@@ -28,7 +28,7 @@ acceptance("Accept Invite - User Fields", function (needs) {
     ],
   });
 
-  test("accept invite with user fields", async (assert) => {
+  test("accept invite with user fields", async function (assert) {
     PreloadStore.store("invite_info", {
       invited_by: {
         id: 123,

--- a/app/assets/javascripts/discourse/tests/acceptance/jump-to-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/jump-to-test.js
@@ -21,7 +21,7 @@ acceptance("Jump to", function (needs) {
     });
   });
 
-  test("default", async (assert) => {
+  test("default", async function (assert) {
     await visit("/t/internationalization-localization/280");
     await click("nav#topic-progress .nums");
     await click("button.jump-to-post");
@@ -38,7 +38,7 @@ acceptance("Jump to", function (needs) {
     );
   });
 
-  test("invalid date", async (assert) => {
+  test("invalid date", async function (assert) {
     await visit("/t/internationalization-localization/280");
     await click("nav#topic-progress .nums");
     await click("button.jump-to-post");

--- a/app/assets/javascripts/discourse/tests/acceptance/keyboard-shortcuts-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/keyboard-shortcuts-test.js
@@ -23,7 +23,7 @@ acceptance("Keyboard Shortcuts", function (needs) {
     });
   });
 
-  test("go to first suggested topic", async (assert) => {
+  test("go to first suggested topic", async function (assert) {
     await visit("/t/this-is-a-test-topic/9");
     await keyEvent(document, "keypress", "g".charCodeAt(0));
     await keyEvent(document, "keypress", "s".charCodeAt(0));

--- a/app/assets/javascripts/discourse/tests/acceptance/login-required-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/login-required-test.js
@@ -6,7 +6,7 @@ import { acceptance, invisible } from "discourse/tests/helpers/qunit-helpers";
 acceptance("Login Required", function (needs) {
   needs.settings({ login_required: true });
 
-  test("redirect", async (assert) => {
+  test("redirect", async function (assert) {
     await visit("/latest");
     assert.equal(currentPath(), "login", "it redirects them to login");
 

--- a/app/assets/javascripts/discourse/tests/acceptance/login-with-email-and-hide-email-address-taken-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/login-with-email-and-hide-email-address-taken-test.js
@@ -16,7 +16,7 @@ acceptance("Login with email - hide email address taken", function (needs) {
     });
   });
 
-  test("with hide_email_address_taken enabled", async (assert) => {
+  test("with hide_email_address_taken enabled", async function (assert) {
     await visit("/");
     await click("header .login-button");
     await fillIn("#login-account-name", "someuser@example.com");

--- a/app/assets/javascripts/discourse/tests/acceptance/login-with-email-and-no-social-logins-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/login-with-email-and-no-social-logins-test.js
@@ -9,14 +9,14 @@ acceptance("Login with email - no social logins", function (needs) {
   needs.pretender((server, helper) => {
     server.post("/u/email-login", () => helper.response({ success: "OK" }));
   });
-  test("with login with email enabled", async (assert) => {
+  test("with login with email enabled", async function (assert) {
     await visit("/");
     await click("header .login-button");
 
     assert.ok(exists(".login-with-email-button"));
   });
 
-  test("with login with email disabled", async (assert) => {
+  test("with login with email disabled", async function (assert) {
     await visit("/");
     await click("header .login-button");
 

--- a/app/assets/javascripts/discourse/tests/acceptance/login-with-email-disabled-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/login-with-email-disabled-test.js
@@ -9,7 +9,7 @@ acceptance("Login with email disabled", function (needs) {
     enable_facebook_logins: true,
   });
 
-  test("with email button", async (assert) => {
+  test("with email button", async function (assert) {
     await visit("/");
     await click("header .login-button");
 

--- a/app/assets/javascripts/discourse/tests/acceptance/login-with-email-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/login-with-email-test.js
@@ -18,7 +18,7 @@ acceptance("Login with email", function (needs) {
     );
   });
 
-  test("with email button", async (assert) => {
+  test("with email button", async function (assert) {
     await visit("/");
     await click("header .login-button");
 

--- a/app/assets/javascripts/discourse/tests/acceptance/mobile-discovery-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/mobile-discovery-test.js
@@ -5,7 +5,7 @@ import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Topic Discovery - Mobile", function (needs) {
   needs.mobileView();
-  test("Visit Discovery Pages", async (assert) => {
+  test("Visit Discovery Pages", async function (assert) {
     await visit("/");
     assert.ok(exists(".topic-list"), "The list of topics was rendered");
     assert.ok(exists(".topic-list .topic-list-item"), "has topics");

--- a/app/assets/javascripts/discourse/tests/acceptance/mobile-sign-in-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/mobile-sign-in-test.js
@@ -5,7 +5,7 @@ import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Signing In - Mobile", function (needs) {
   needs.mobileView();
-  test("sign in", async (assert) => {
+  test("sign in", async function (assert) {
     await visit("/");
     await click("header .login-button");
     assert.ok(exists("#login-form"), "it shows the login modal");

--- a/app/assets/javascripts/discourse/tests/acceptance/mobile-users-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/mobile-users-test.js
@@ -5,7 +5,7 @@ import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("User Directory - Mobile", function (needs) {
   needs.mobileView();
-  test("Visit Page", async (assert) => {
+  test("Visit Page", async function (assert) {
     await visit("/u");
     assert.ok(exists(".directory .user"), "has a list of users");
   });

--- a/app/assets/javascripts/discourse/tests/acceptance/new-message-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/new-message-test.js
@@ -5,7 +5,7 @@ import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("New Message - Anonymous", function () {
-  test("accessing new-message route when logged out", async (assert) => {
+  test("accessing new-message route when logged out", async function (assert) {
     await visit(
       "/new-message?username=charlie&title=message%20title&body=message%20body"
     );
@@ -17,7 +17,7 @@ acceptance("New Message - Anonymous", function () {
 acceptance("New Message - Authenticated", function (needs) {
   needs.user();
 
-  test("accessing new-message route when logged in", async (assert) => {
+  test("accessing new-message route when logged in", async function (assert) {
     await visit(
       "/new-message?username=charlie&title=message%20title&body=message%20body"
     );

--- a/app/assets/javascripts/discourse/tests/acceptance/new-topic-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/new-topic-test.js
@@ -6,7 +6,7 @@ import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("New Topic - Anonymous", function () {
-  test("accessing new-topic route when logged out", async (assert) => {
+  test("accessing new-topic route when logged out", async function (assert) {
     await visit("/new-topic?title=topic%20title&body=topic%20body");
 
     assert.ok(exists(".modal.login-modal"), "it shows the login modal");
@@ -15,7 +15,7 @@ acceptance("New Topic - Anonymous", function () {
 
 acceptance("New Topic - Authenticated", function (needs) {
   needs.user();
-  test("accessing new-topic route when logged in", async (assert) => {
+  test("accessing new-topic route when logged in", async function (assert) {
     await visit(
       "/new-topic?title=topic%20title&body=topic%20body&category=bug"
     );

--- a/app/assets/javascripts/discourse/tests/acceptance/notifications-filter-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/notifications-filter-test.js
@@ -7,13 +7,13 @@ import selectKit from "discourse/tests/helpers/select-kit-helper";
 acceptance("Notifications filter", function (needs) {
   needs.user();
 
-  test("Notifications filter true", async (assert) => {
+  test("Notifications filter true", async function (assert) {
     await visit("/u/eviltrout/notifications");
 
     assert.ok(queryAll(".large-notification").length >= 0);
   });
 
-  test("Notifications filter read", async (assert) => {
+  test("Notifications filter read", async function (assert) {
     await visit("/u/eviltrout/notifications");
 
     const dropdown = selectKit(".notifications-filter");
@@ -23,7 +23,7 @@ acceptance("Notifications filter", function (needs) {
     assert.ok(queryAll(".large-notification").length >= 0);
   });
 
-  test("Notifications filter unread", async (assert) => {
+  test("Notifications filter unread", async function (assert) {
     await visit("/u/eviltrout/notifications");
 
     const dropdown = selectKit(".notifications-filter");

--- a/app/assets/javascripts/discourse/tests/acceptance/page-publishing-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/page-publishing-test.js
@@ -25,7 +25,7 @@ acceptance("Page Publishing", function (needs) {
     });
   });
 
-  test("can publish a page via modal", async (assert) => {
+  test("can publish a page via modal", async function (assert) {
     await visit("/t/internationalization-localization/280");
     await click(".topic-post:eq(0) button.show-more-actions");
     await click(".topic-post:eq(0) button.show-post-admin-menu");

--- a/app/assets/javascripts/discourse/tests/acceptance/password-reset-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/password-reset-test.js
@@ -59,7 +59,7 @@ acceptance("Password Reset", function (needs) {
     });
   });
 
-  test("Password Reset Page", async (assert) => {
+  test("Password Reset Page", async function (assert) {
     PreloadStore.store("password_reset", { is_developer: false });
 
     await visit("/u/password-reset/myvalidtoken");
@@ -93,7 +93,7 @@ acceptance("Password Reset", function (needs) {
     assert.ok(DiscourseURL.redirectTo.calledWith("/"), "form is gone");
   });
 
-  test("Password Reset Page With Second Factor", async (assert) => {
+  test("Password Reset Page With Second Factor", async function (assert) {
     PreloadStore.store("password_reset", {
       is_developer: false,
       second_factor_required: true,

--- a/app/assets/javascripts/discourse/tests/acceptance/personal-message-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/personal-message-test.js
@@ -8,7 +8,7 @@ import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 acceptance("Personal Message", function (needs) {
   needs.user();
 
-  test("footer edit button", async (assert) => {
+  test("footer edit button", async function (assert) {
     await visit("/t/pm-for-testing/12");
 
     assert.ok(
@@ -17,7 +17,7 @@ acceptance("Personal Message", function (needs) {
     );
   });
 
-  test("suggested messages", async (assert) => {
+  test("suggested messages", async function (assert) {
     await visit("/t/pm-for-testing/12");
 
     assert.equal(

--- a/app/assets/javascripts/discourse/tests/acceptance/plugin-keyboard-shortcut-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/plugin-keyboard-shortcut-test.js
@@ -11,7 +11,7 @@ acceptance("Plugin Keyboard Shortcuts - Logged In", function (needs) {
   needs.hooks.beforeEach(function () {
     KeyboardShortcutInitializer.initialize(this.container);
   });
-  test("a plugin can add a keyboard shortcut", async (assert) => {
+  test("a plugin can add a keyboard shortcut", async function (assert) {
     withPluginApi("0.8.38", (api) => {
       api.addKeyboardShortcut("]", () => {
         $("#qunit-fixture").html(
@@ -34,7 +34,7 @@ acceptance("Plugin Keyboard Shortcuts - Anonymous", function (needs) {
   needs.hooks.beforeEach(function () {
     KeyboardShortcutInitializer.initialize(this.container);
   });
-  test("a plugin can add a keyboard shortcut with an option", async (assert) => {
+  test("a plugin can add a keyboard shortcut with an option", async function (assert) {
     let spy = sinon.spy(KeyboardShortcuts, "_bindToPath");
     withPluginApi("0.8.38", (api) => {
       api.addKeyboardShortcut("]", () => {}, {

--- a/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-connector-class-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-connector-class-test.js
@@ -67,7 +67,7 @@ acceptance("Plugin Outlet - Connector Class", function (needs) {
     delete Ember.TEMPLATES[`${PREFIX}/user-profile-primary/dont-render`];
   });
 
-  test("Renders a template into the outlet", async (assert) => {
+  test("Renders a template into the outlet", async function (assert) {
     await visit("/u/eviltrout");
     assert.ok(
       queryAll(".user-profile-primary-outlet.hello").length === 1,

--- a/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-decorator-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-decorator-test.js
@@ -42,7 +42,7 @@ acceptance("Plugin Outlet - Decorator", function (needs) {
     delete Ember.TEMPLATES[`${PREFIX}/discovery-list-container-top/bar`];
   });
 
-  test("Calls the plugin callback with the rendered outlet", async (assert) => {
+  test("Calls the plugin callback with the rendered outlet", async function (assert) {
     await visit("/");
 
     const fooConnector = queryAll(

--- a/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-multi-template-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-multi-template-test.js
@@ -25,7 +25,7 @@ acceptance("Plugin Outlet - Multi Template", function (needs) {
     clearCache();
   });
 
-  test("Renders a template into the outlet", async (assert) => {
+  test("Renders a template into the outlet", async function (assert) {
     await visit("/u/eviltrout");
     assert.ok(
       queryAll(".user-profile-primary-outlet.hello").length === 1,

--- a/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-single-template-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-single-template-test.js
@@ -17,7 +17,7 @@ acceptance("Plugin Outlet - Single Template", function (needs) {
     delete Ember.TEMPLATES[CONNECTOR];
   });
 
-  test("Renders a template into the outlet", async (assert) => {
+  test("Renders a template into the outlet", async function (assert) {
     await visit("/u/eviltrout");
     assert.ok(
       queryAll(".user-profile-primary-outlet.hello").length === 1,

--- a/app/assets/javascripts/discourse/tests/acceptance/post-admin-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/post-admin-menu-test.js
@@ -4,7 +4,7 @@ import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Post - Admin Menu - Anonymous", function () {
-  test("Enter as a anon user", async (assert) => {
+  test("Enter as a anon user", async function (assert) {
     await visit("/t/internationalization-localization/280");
     await click(".show-more-actions");
 
@@ -22,7 +22,7 @@ acceptance("Post - Admin Menu - Anonymous", function () {
 
 acceptance("Post - Admin Menu - Authenticated", function (needs) {
   needs.user();
-  test("Enter as a user with group moderator permissions", async (assert) => {
+  test("Enter as a user with group moderator permissions", async function (assert) {
     await visit("/t/topic-for-group-moderators/2480");
     await click(".show-more-actions");
     await click(".show-post-admin-menu");

--- a/app/assets/javascripts/discourse/tests/acceptance/preferences-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/preferences-test.js
@@ -71,7 +71,7 @@ function preferencesPretender(server, helper) {
 acceptance("User Preferences", function (needs) {
   needs.user();
   needs.pretender(preferencesPretender);
-  test("update some fields", async (assert) => {
+  test("update some fields", async function (assert) {
     await visit("/u/eviltrout/preferences");
 
     assert.ok($("body.user-preferences-page").length, "has the body class");
@@ -128,12 +128,12 @@ acceptance("User Preferences", function (needs) {
     );
   });
 
-  test("username", async (assert) => {
+  test("username", async function (assert) {
     await visit("/u/eviltrout/preferences/username");
     assert.ok(exists("#change_username"), "it has the input element");
   });
 
-  test("email", async (assert) => {
+  test("email", async function (assert) {
     await visit("/u/eviltrout/preferences/email");
 
     assert.ok(exists("#change-email"), "it has the input element");
@@ -147,7 +147,7 @@ acceptance("User Preferences", function (needs) {
     );
   });
 
-  test("email field always shows up", async (assert) => {
+  test("email field always shows up", async function (assert) {
     await visit("/u/eviltrout/preferences/email");
 
     assert.ok(exists("#change-email"), "it has the input element");
@@ -161,7 +161,7 @@ acceptance("User Preferences", function (needs) {
     assert.ok(exists("#change-email"), "it has the input element");
   });
 
-  test("connected accounts", async (assert) => {
+  test("connected accounts", async function (assert) {
     await visit("/u/eviltrout/preferences/account");
 
     assert.ok(
@@ -182,7 +182,7 @@ acceptance("User Preferences", function (needs) {
       .indexOf("Connect") > -1;
   });
 
-  test("second factor totp", async (assert) => {
+  test("second factor totp", async function (assert) {
     await visit("/u/eviltrout/preferences/second-factor");
 
     assert.ok(exists("#password"), "it has a password input");
@@ -203,7 +203,7 @@ acceptance("User Preferences", function (needs) {
     );
   });
 
-  test("second factor security keys", async (assert) => {
+  test("second factor security keys", async function (assert) {
     await visit("/u/eviltrout/preferences/second-factor");
 
     assert.ok(exists("#password"), "it has a password input");
@@ -229,7 +229,7 @@ acceptance("User Preferences", function (needs) {
     }
   });
 
-  test("default avatar selector", async (assert) => {
+  test("default avatar selector", async function (assert) {
     await visit("/u/eviltrout/preferences");
 
     await click(".pref-avatar .btn");
@@ -266,7 +266,7 @@ acceptance("Second Factor Backups", function (needs) {
     });
   });
 
-  test("second factor backup", async (assert) => {
+  test("second factor backup", async function (assert) {
     updateCurrentUser({ second_factor_enabled: true });
     await visit("/u/eviltrout/preferences/second-factor");
     await click(".edit-2fa-backup");
@@ -294,7 +294,7 @@ acceptance("Avatar selector when selectable avatars is enabled", function (
     );
   });
 
-  test("selectable avatars", async (assert) => {
+  test("selectable avatars", async function (assert) {
     await visit("/u/eviltrout/preferences");
     await click(".pref-avatar .btn");
     assert.ok(
@@ -308,7 +308,7 @@ acceptance("User Preferences when badges are disabled", function (needs) {
   needs.settings({ enable_badges: false });
   needs.pretender(preferencesPretender);
 
-  test("visit my preferences", async (assert) => {
+  test("visit my preferences", async function (assert) {
     await visit("/u/eviltrout/preferences");
     assert.ok($("body.user-preferences-page").length, "has the body class");
     assert.equal(
@@ -319,7 +319,7 @@ acceptance("User Preferences when badges are disabled", function (needs) {
     assert.ok(exists(".user-preferences"), "it shows the preferences");
   });
 
-  test("recently connected devices", async (assert) => {
+  test("recently connected devices", async function (assert) {
     await visit("/u/eviltrout/preferences");
 
     assert.equal(
@@ -374,7 +374,7 @@ acceptance(
       });
     });
 
-    test("setting featured topic on profile", async (assert) => {
+    test("setting featured topic on profile", async function (assert) {
       await visit("/u/eviltrout/preferences/profile");
 
       assert.ok(
@@ -429,7 +429,7 @@ acceptance("Custom User Fields", function (needs) {
   });
   needs.pretender(preferencesPretender);
 
-  test("can select an option from a dropdown", async (assert) => {
+  test("can select an option from a dropdown", async function (assert) {
     await visit("/u/eviltrout/preferences/profile");
     assert.ok(exists(".user-field"), "it has at least one user field");
     await click(".user-field.dropdown");
@@ -455,7 +455,7 @@ acceptance(
       top_menu: "categories|latest|top|bookmarks",
     });
 
-    test("selecting bookmarks as home directs home to bookmarks", async (assert) => {
+    test("selecting bookmarks as home directs home to bookmarks", async function (assert) {
       await visit("/u/eviltrout/preferences/interface");
       assert.ok(exists(".home .combo-box"), "it has a home selector combo-box");
 

--- a/app/assets/javascripts/discourse/tests/acceptance/raw-plugin-outlet-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/raw-plugin-outlet-test.js
@@ -22,7 +22,7 @@ acceptance("Raw Plugin Outlet", function (needs) {
   needs.hooks.afterEach(() => {
     removeRawTemplate(CONNECTOR);
   });
-  test("Renders the raw plugin outlet", async (assert) => {
+  test("Renders the raw plugin outlet", async function (assert) {
     await visit("/");
     assert.ok(queryAll(".topic-lala").length > 0, "it renders the outlet");
     assert.equal(

--- a/app/assets/javascripts/discourse/tests/acceptance/redirect-to-top-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/redirect-to-top-test.js
@@ -20,7 +20,7 @@ acceptance("Redirect to Top", function (needs) {
   });
   needs.user();
 
-  test("redirects categories to weekly top", async (assert) => {
+  test("redirects categories to weekly top", async function (assert) {
     updateCurrentUser({
       should_be_redirected_to_top: true,
       redirected_to_top: {
@@ -37,7 +37,7 @@ acceptance("Redirect to Top", function (needs) {
     );
   });
 
-  test("redirects latest to monthly top", async (assert) => {
+  test("redirects latest to monthly top", async function (assert) {
     updateCurrentUser({
       should_be_redirected_to_top: true,
       redirected_to_top: {
@@ -50,7 +50,7 @@ acceptance("Redirect to Top", function (needs) {
     assert.equal(currentPath(), "discovery.topMonthly", "it works for latest");
   });
 
-  test("redirects root to All top", async (assert) => {
+  test("redirects root to All top", async function (assert) {
     updateCurrentUser({
       should_be_redirected_to_top: true,
       redirected_to_top: {

--- a/app/assets/javascripts/discourse/tests/acceptance/reports-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/reports-test.js
@@ -6,7 +6,7 @@ import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 acceptance("Reports", function (needs) {
   needs.user();
 
-  test("Visit reports page", async (assert) => {
+  test("Visit reports page", async function (assert) {
     await visit("/admin/reports");
 
     assert.equal($(".reports-list .report").length, 1);
@@ -21,7 +21,7 @@ acceptance("Reports", function (needs) {
     );
   });
 
-  test("Visit report page", async (assert) => {
+  test("Visit report page", async function (assert) {
     await visit("/admin/reports/staff_logins");
 
     assert.ok(exists(".export-csv-btn"));

--- a/app/assets/javascripts/discourse/tests/acceptance/review-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/review-test.js
@@ -9,7 +9,7 @@ acceptance("Review", function (needs) {
 
   const user = ".reviewable-item[data-reviewable-id=1234]";
 
-  test("It returns a list of reviewable items", async (assert) => {
+  test("It returns a list of reviewable items", async function (assert) {
     await visit("/review");
 
     assert.ok(queryAll(".reviewable-item").length, "has a list of items");
@@ -28,7 +28,7 @@ acceptance("Review", function (needs) {
     );
   });
 
-  test("Grouped by topic", async (assert) => {
+  test("Grouped by topic", async function (assert) {
     await visit("/review/topics");
     assert.ok(
       queryAll(".reviewable-topic").length,
@@ -36,7 +36,7 @@ acceptance("Review", function (needs) {
     );
   });
 
-  test("Settings", async (assert) => {
+  test("Settings", async function (assert) {
     await visit("/review/settings");
 
     assert.ok(
@@ -52,7 +52,7 @@ acceptance("Review", function (needs) {
     assert.ok(queryAll(".reviewable-settings .saved").length, "it saved");
   });
 
-  test("Flag related", async (assert) => {
+  test("Flag related", async function (assert) {
     await visit("/review");
 
     assert.ok(
@@ -72,7 +72,7 @@ acceptance("Review", function (needs) {
     );
   });
 
-  test("Flag related", async (assert) => {
+  test("Flag related", async function (assert) {
     await visit("/review/1");
 
     assert.ok(
@@ -81,7 +81,7 @@ acceptance("Review", function (needs) {
     );
   });
 
-  test("Clicking the buttons triggers actions", async (assert) => {
+  test("Clicking the buttons triggers actions", async function (assert) {
     await visit("/review");
     await click(`${user} .reviewable-action.approve`);
     assert.equal(
@@ -91,7 +91,7 @@ acceptance("Review", function (needs) {
     );
   });
 
-  test("Editing a reviewable", async (assert) => {
+  test("Editing a reviewable", async function (assert) {
     const topic = ".reviewable-item[data-reviewable-id=4321]";
     await visit("/review");
     assert.ok(queryAll(`${topic} .reviewable-action.approve`).length);

--- a/app/assets/javascripts/discourse/tests/acceptance/search-full-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-full-test.js
@@ -91,7 +91,7 @@ acceptance("Search - Full Page", function (needs) {
     });
   });
 
-  test("perform various searches", async (assert) => {
+  test("perform various searches", async function (assert) {
     await visit("/search");
 
     assert.ok($("body.search-page").length, "has body class");
@@ -111,7 +111,7 @@ acceptance("Search - Full Page", function (needs) {
     assert.ok(queryAll(".fps-topic").length === 1, "has one post");
   });
 
-  test("escape search term", async (assert) => {
+  test("escape search term", async function (assert) {
     await visit("/search");
     await fillIn(".search-query", "@<script>prompt(1337)</script>gmail.com");
 
@@ -123,7 +123,7 @@ acceptance("Search - Full Page", function (needs) {
     );
   });
 
-  skip("update username through advanced search ui", async (assert) => {
+  skip("update username through advanced search ui", async function (assert) {
     await visit("/search");
     await fillIn(".search-query", "none");
     await fillIn(".search-advanced-options .user-selector", "admin");
@@ -156,7 +156,7 @@ acceptance("Search - Full Page", function (needs) {
     });
   });
 
-  test("update category through advanced search ui", async (assert) => {
+  test("update category through advanced search ui", async function (assert) {
     const categoryChooser = selectKit(
       ".search-advanced-options .category-chooser"
     );
@@ -180,7 +180,7 @@ acceptance("Search - Full Page", function (needs) {
     );
   });
 
-  test("update in:title filter through advanced search ui", async (assert) => {
+  test("update in:title filter through advanced search ui", async function (assert) {
     await visit("/search");
     await fillIn(".search-query", "none");
     await click(".search-advanced-options .in-title");
@@ -203,7 +203,7 @@ acceptance("Search - Full Page", function (needs) {
     );
   });
 
-  test("update in:likes filter through advanced search ui", async (assert) => {
+  test("update in:likes filter through advanced search ui", async function (assert) {
     await visit("/search");
     await fillIn(".search-query", "none");
     await click(".search-advanced-options .in-likes");
@@ -219,7 +219,7 @@ acceptance("Search - Full Page", function (needs) {
     );
   });
 
-  test("update in:personal filter through advanced search ui", async (assert) => {
+  test("update in:personal filter through advanced search ui", async function (assert) {
     await visit("/search");
     await fillIn(".search-query", "none");
     await click(".search-advanced-options .in-private");
@@ -243,7 +243,7 @@ acceptance("Search - Full Page", function (needs) {
     );
   });
 
-  test("update in:seen filter through advanced search ui", async (assert) => {
+  test("update in:seen filter through advanced search ui", async function (assert) {
     await visit("/search");
     await fillIn(".search-query", "none");
     await click(".search-advanced-options .in-seen");
@@ -267,7 +267,7 @@ acceptance("Search - Full Page", function (needs) {
     );
   });
 
-  test("update in filter through advanced search ui", async (assert) => {
+  test("update in filter through advanced search ui", async function (assert) {
     const inSelector = selectKit(".search-advanced-options .select-kit#in");
 
     await visit("/search");
@@ -288,7 +288,7 @@ acceptance("Search - Full Page", function (needs) {
     );
   });
 
-  test("update status through advanced search ui", async (assert) => {
+  test("update status through advanced search ui", async function (assert) {
     const statusSelector = selectKit(
       ".search-advanced-options .select-kit#status"
     );
@@ -311,7 +311,7 @@ acceptance("Search - Full Page", function (needs) {
     );
   });
 
-  test("doesn't update status filter header if wrong value entered through searchbox", async (assert) => {
+  test("doesn't update status filter header if wrong value entered through searchbox", async function (assert) {
     const statusSelector = selectKit(
       ".search-advanced-options .select-kit#status"
     );
@@ -323,7 +323,7 @@ acceptance("Search - Full Page", function (needs) {
     assert.equal(statusSelector.header().label(), "any", 'has "any" populated');
   });
 
-  test("doesn't update in filter header if wrong value entered through searchbox", async (assert) => {
+  test("doesn't update in filter header if wrong value entered through searchbox", async function (assert) {
     const inSelector = selectKit(".search-advanced-options .select-kit#in");
 
     await visit("/search");
@@ -333,7 +333,7 @@ acceptance("Search - Full Page", function (needs) {
     assert.equal(inSelector.header().label(), "any", 'has "any" populated');
   });
 
-  test("update post time through advanced search ui", async (assert) => {
+  test("update post time through advanced search ui", async function (assert) {
     await visit("/search?expanded=true&q=after:2018-08-22");
 
     assert.equal(
@@ -366,7 +366,7 @@ acceptance("Search - Full Page", function (needs) {
     );
   });
 
-  test("update min post count through advanced search ui", async (assert) => {
+  test("update min post count through advanced search ui", async function (assert) {
     await visit("/search");
     await fillIn(".search-query", "none");
     await fillIn("#search-min-post-count", "5");
@@ -383,7 +383,7 @@ acceptance("Search - Full Page", function (needs) {
     );
   });
 
-  test("update max post count through advanced search ui", async (assert) => {
+  test("update max post count through advanced search ui", async function (assert) {
     await visit("/search");
     await fillIn(".search-query", "none");
     await fillIn("#search-max-post-count", "5");
@@ -400,7 +400,7 @@ acceptance("Search - Full Page", function (needs) {
     );
   });
 
-  test("validate advanced search when initially empty", async (assert) => {
+  test("validate advanced search when initially empty", async function (assert) {
     await visit("/search?expanded=true");
     await click(".search-advanced-options .in-likes");
 

--- a/app/assets/javascripts/discourse/tests/acceptance/search-mobile-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-mobile-test.js
@@ -7,7 +7,7 @@ import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 acceptance("Search - Mobile", function (needs) {
   needs.mobileView();
 
-  test("search", async (assert) => {
+  test("search", async function (assert) {
     await visit("/");
 
     await click("#search-button");

--- a/app/assets/javascripts/discourse/tests/acceptance/search-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-test.js
@@ -19,7 +19,7 @@ acceptance("Search - Anonymous", function (needs) {
     });
   });
 
-  test("search", async (assert) => {
+  test("search", async function (assert) {
     await visit("/");
 
     await click("#search-button");
@@ -48,7 +48,7 @@ acceptance("Search - Anonymous", function (needs) {
     );
   });
 
-  test("search for a tag", async (assert) => {
+  test("search for a tag", async function (assert) {
     await visit("/");
 
     await click("#search-button");
@@ -58,7 +58,7 @@ acceptance("Search - Anonymous", function (needs) {
     assert.ok(exists(".search-menu .results ul li"), "it shows results");
   });
 
-  test("search scope checkbox", async (assert) => {
+  test("search scope checkbox", async function (assert) {
     await visit("/tag/important");
     await click("#search-button");
     assert.ok(
@@ -91,7 +91,7 @@ acceptance("Search - Anonymous", function (needs) {
     );
   });
 
-  test("Search with context", async (assert) => {
+  test("Search with context", async function (assert) {
     await visit("/t/internationalization-localization/280/1");
 
     await click("#search-button");
@@ -126,7 +126,7 @@ acceptance("Search - Anonymous", function (needs) {
     assert.ok(!$(".search-context input[type=checkbox]").is(":checked"));
   });
 
-  test("Right filters are shown to anonymous users", async (assert) => {
+  test("Right filters are shown to anonymous users", async function (assert) {
     const inSelector = selectKit(".select-kit#in");
 
     await visit("/search?expanded=true");
@@ -153,7 +153,7 @@ acceptance("Search - Anonymous", function (needs) {
 acceptance("Search - Authenticated", function (needs) {
   needs.user();
 
-  test("Right filters are shown to logged-in users", async (assert) => {
+  test("Right filters are shown to logged-in users", async function (assert) {
     const inSelector = selectKit(".select-kit#in");
 
     await visit("/search?expanded=true");
@@ -181,7 +181,7 @@ acceptance("Search - with tagging enabled", function (needs) {
   needs.user();
   needs.settings({ tagging_enabled: true });
 
-  test("displays tags", async (assert) => {
+  test("displays tags", async function (assert) {
     await visit("/");
 
     await click("#search-button");

--- a/app/assets/javascripts/discourse/tests/acceptance/share-and-invite-desktop-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/share-and-invite-desktop-test.js
@@ -7,7 +7,7 @@ import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 acceptance("Share and Invite modal - desktop", function (needs) {
   needs.user();
 
-  test("Topic footer button", async (assert) => {
+  test("Topic footer button", async function (assert) {
     await visit("/t/internationalization-localization/280");
 
     assert.ok(
@@ -69,7 +69,7 @@ acceptance("Share and Invite modal - desktop", function (needs) {
     );
   });
 
-  test("Post date link", async (assert) => {
+  test("Post date link", async function (assert) {
     await visit("/t/internationalization-localization/280");
     await click("#post_2 .post-info.post-date a");
 
@@ -80,7 +80,7 @@ acceptance("Share and Invite modal - desktop", function (needs) {
 acceptance("Share url with badges disabled - desktop", function (needs) {
   needs.user();
   needs.settings({ enable_badges: false });
-  test("topic footer button - badges disabled - desktop", async (assert) => {
+  test("topic footer button - badges disabled - desktop", async function (assert) {
     await visit("/t/internationalization-localization/280");
     await click("#topic-footer-button-share-and-invite");
 

--- a/app/assets/javascripts/discourse/tests/acceptance/share-and-invite-mobile-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/share-and-invite-mobile-test.js
@@ -9,7 +9,7 @@ acceptance("Share and Invite modal - mobile", function (needs) {
   needs.user();
   needs.mobileView();
 
-  test("Topic footer mobile button", async (assert) => {
+  test("Topic footer mobile button", async function (assert) {
     await visit("/t/internationalization-localization/280");
 
     assert.ok(
@@ -57,7 +57,7 @@ acceptance("Share and Invite modal - mobile", function (needs) {
     );
   });
 
-  test("Post date link", async (assert) => {
+  test("Post date link", async function (assert) {
     await visit("/t/internationalization-localization/280");
     await click("#post_2 .post-info.post-date a");
 
@@ -71,7 +71,7 @@ acceptance("Share url with badges disabled - mobile", function (needs) {
   needs.settings({
     enable_badges: false,
   });
-  test("topic footer button - badges disabled - mobile", async (assert) => {
+  test("topic footer button - badges disabled - mobile", async function (assert) {
     await visit("/t/internationalization-localization/280");
 
     const subject = selectKit(".topic-footer-mobile-dropdown");

--- a/app/assets/javascripts/discourse/tests/acceptance/shared-drafts-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/shared-drafts-test.js
@@ -5,7 +5,7 @@ import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Shared Drafts", function () {
-  test("Viewing", async (assert) => {
+  test("Viewing", async function (assert) {
     await visit("/t/some-topic/9");
     assert.ok(queryAll(".shared-draft-controls").length === 1);
     let categoryChooser = selectKit(".shared-draft-controls .category-chooser");

--- a/app/assets/javascripts/discourse/tests/acceptance/sign-in-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sign-in-test.js
@@ -5,7 +5,7 @@ import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Signing In", function () {
-  test("sign in", async (assert) => {
+  test("sign in", async function (assert) {
     await visit("/");
     await click("header .login-button");
     assert.ok(exists(".login-modal"), "it shows the login modal");
@@ -29,7 +29,7 @@ acceptance("Signing In", function () {
     );
   });
 
-  test("sign in - not activated", async (assert) => {
+  test("sign in - not activated", async function (assert) {
     await visit("/");
     await click("header .login-button");
     assert.ok(exists(".login-modal"), "it shows the login modal");
@@ -51,7 +51,7 @@ acceptance("Signing In", function () {
     assert.ok(!exists(".modal-body small"), "it escapes the email address");
   });
 
-  test("sign in - not activated - edit email", async (assert) => {
+  test("sign in - not activated - edit email", async function (assert) {
     await visit("/");
     await click("header .login-button");
     assert.ok(exists(".login-modal"), "it shows the login modal");
@@ -72,7 +72,7 @@ acceptance("Signing In", function () {
     assert.equal(queryAll(".modal-body b").text(), "different@example.com");
   });
 
-  test("second factor", async (assert) => {
+  test("second factor", async function (assert) {
     await visit("/");
     await click("header .login-button");
 
@@ -105,7 +105,7 @@ acceptance("Signing In", function () {
     );
   });
 
-  test("security key", async (assert) => {
+  test("security key", async function (assert) {
     await visit("/");
     await click("header .login-button");
 
@@ -131,7 +131,7 @@ acceptance("Signing In", function () {
     assert.not(exists("#login-button:visible"), "hides the login button");
   });
 
-  test("create account", async (assert) => {
+  test("create account", async function (assert) {
     await visit("/");
     await click("header .sign-up-button");
 
@@ -170,7 +170,7 @@ acceptance("Signing In", function () {
     );
   });
 
-  test("second factor backup - valid token", async (assert) => {
+  test("second factor backup - valid token", async function (assert) {
     await visit("/");
     await click("header .login-button");
     await fillIn("#login-account-name", "eviltrout");
@@ -186,7 +186,7 @@ acceptance("Signing In", function () {
     );
   });
 
-  test("second factor backup - invalid token", async (assert) => {
+  test("second factor backup - invalid token", async function (assert) {
     await visit("/");
     await click("header .login-button");
     await fillIn("#login-account-name", "eviltrout");

--- a/app/assets/javascripts/discourse/tests/acceptance/static-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/static-test.js
@@ -4,7 +4,7 @@ import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Static", function () {
-  test("Static Pages", async (assert) => {
+  test("Static Pages", async function (assert) {
     await visit("/faq");
     assert.ok($("body.static-faq").length, "has the body class");
     assert.ok(exists(".body-page"), "The content is present");

--- a/app/assets/javascripts/discourse/tests/acceptance/tag-groups-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/tag-groups-test.js
@@ -35,7 +35,7 @@ acceptance("Tag Groups", function (needs) {
     });
   });
 
-  test("tag groups can be saved and deleted", async (assert) => {
+  test("tag groups can be saved and deleted", async function (assert) {
     const tags = selectKit(".tag-chooser");
 
     await visit("/tag_groups");
@@ -51,7 +51,7 @@ acceptance("Tag Groups", function (needs) {
     assert.ok(!queryAll(".tag-group-content .btn.btn-danger")[0].disabled);
   });
 
-  test("tag groups can have multiple groups added to them", async (assert) => {
+  test("tag groups can have multiple groups added to them", async function (assert) {
     const tags = selectKit(".tag-chooser");
     const groups = selectKit(".group-chooser");
 

--- a/app/assets/javascripts/discourse/tests/acceptance/tags-intersection-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/tags-intersection-test.js
@@ -31,7 +31,7 @@ acceptance("Tags intersection", function (needs) {
     });
   });
 
-  test("Populate tags when creating new topic", async (assert) => {
+  test("Populate tags when creating new topic", async function (assert) {
     await visit("/tags/intersection/first/second");
     await click("#create-topic");
 

--- a/app/assets/javascripts/discourse/tests/acceptance/tags-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/tags-test.js
@@ -10,7 +10,7 @@ import {
 acceptance("Tags", function (needs) {
   needs.user();
 
-  test("list the tags", async (assert) => {
+  test("list the tags", async function (assert) {
     await visit("/tags");
 
     assert.ok($("body.tags-page").length, "has the body class");
@@ -85,7 +85,7 @@ acceptance("Tags listed by group", function (needs) {
     );
   });
 
-  test("list the tags in groups", async (assert) => {
+  test("list the tags in groups", async function (assert) {
     await visit("/tags");
     assert.equal(
       $(".tag-list").length,
@@ -126,7 +126,7 @@ acceptance("Tags listed by group", function (needs) {
     );
   });
 
-  test("new topic button is not available for staff-only tags", async (assert) => {
+  test("new topic button is not available for staff-only tags", async function (assert) {
     updateCurrentUser({ moderator: false, admin: false });
 
     await visit("/tag/regular-tag");
@@ -225,7 +225,7 @@ acceptance("Tag info", function (needs) {
     );
   });
 
-  test("tag info can show synonyms", async (assert) => {
+  test("tag info can show synonyms", async function (assert) {
     updateCurrentUser({ moderator: false, admin: false });
 
     await visit("/tag/planters");
@@ -250,7 +250,7 @@ acceptance("Tag info", function (needs) {
     assert.ok(!exists("#delete-tag"), "can't delete tag");
   });
 
-  test("admin can manage tags", async (assert) => {
+  test("admin can manage tags", async function (assert) {
     updateCurrentUser({ moderator: false, admin: true });
 
     await visit("/tag/planters");

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-admin-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-admin-menu-test.js
@@ -7,7 +7,7 @@ import {
 } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Topic - Admin Menu Anonymous Users", function () {
-  test("Enter as a regular user", async (assert) => {
+  test("Enter as a regular user", async function (assert) {
     await visit("/t/internationalization-localization/280");
     assert.ok(exists("#topic"), "The topic was rendered");
     assert.ok(
@@ -19,7 +19,7 @@ acceptance("Topic - Admin Menu Anonymous Users", function () {
 
 acceptance("Topic - Admin Menu", function (needs) {
   needs.user();
-  test("Enter as a user with group moderator permissions", async (assert) => {
+  test("Enter as a user with group moderator permissions", async function (assert) {
     updateCurrentUser({ moderator: false, admin: false, trust_level: 1 });
 
     await visit("/t/topic-for-group-moderators/2480");
@@ -30,7 +30,7 @@ acceptance("Topic - Admin Menu", function (needs) {
     );
   });
 
-  test("Enter as a user with moderator and admin permissions", async (assert) => {
+  test("Enter as a user with moderator and admin permissions", async function (assert) {
     updateCurrentUser({ moderator: true, admin: true, trust_level: 4 });
 
     await visit("/t/internationalization-localization/280");
@@ -41,7 +41,7 @@ acceptance("Topic - Admin Menu", function (needs) {
     );
   });
 
-  test("Toggle the menu as admin focuses the first item", async (assert) => {
+  test("Toggle the menu as admin focuses the first item", async function (assert) {
     updateCurrentUser({ admin: true });
 
     await visit("/t/internationalization-localization/280");

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-anonymous-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-anonymous-test.js
@@ -5,7 +5,7 @@ import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Topic - Anonymous", function () {
-  test("Enter a Topic", async (assert) => {
+  test("Enter a Topic", async function (assert) {
     await visit("/t/internationalization-localization/280/1");
     assert.ok(exists("#topic"), "The topic was rendered");
     assert.ok(exists("#topic .cooked"), "The topic has cooked posts");
@@ -15,24 +15,24 @@ acceptance("Topic - Anonymous", function () {
     );
   });
 
-  test("Enter without an id", async (assert) => {
+  test("Enter without an id", async function (assert) {
     await visit("/t/internationalization-localization");
     assert.ok(exists("#topic"), "The topic was rendered");
   });
 
-  test("Enter a 404 topic", async (assert) => {
+  test("Enter a 404 topic", async function (assert) {
     await visit("/t/not-found/404");
     assert.ok(!exists("#topic"), "The topic was not rendered");
     assert.ok(exists(".topic-error"), "An error message is displayed");
   });
 
-  test("Enter without access", async (assert) => {
+  test("Enter without access", async function (assert) {
     await visit("/t/i-dont-have-access/403");
     assert.ok(!exists("#topic"), "The topic was not rendered");
     assert.ok(exists(".topic-error"), "An error message is displayed");
   });
 
-  test("Enter with 500 errors", async (assert) => {
+  test("Enter with 500 errors", async function (assert) {
     await visit("/t/throws-error/500");
     assert.ok(!exists("#topic"), "The topic was not rendered");
     assert.ok(exists(".topic-error"), "An error message is displayed");

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-discovery-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-discovery-test.js
@@ -13,7 +13,7 @@ acceptance("Topic Discovery", function (needs) {
     show_pinned_excerpt_desktop: true,
   });
 
-  test("Visit Discovery Pages", async (assert) => {
+  test("Visit Discovery Pages", async function (assert) {
     await visit("/");
     assert.ok($("body.navigation-topics").length, "has the default navigation");
     assert.ok(exists(".topic-list"), "The list of topics was rendered");
@@ -72,7 +72,7 @@ acceptance("Topic Discovery", function (needs) {
     );
   });
 
-  test("Clearing state after leaving a category", async (assert) => {
+  test("Clearing state after leaving a category", async function (assert) {
     await visit("/c/dev");
     assert.ok(
       exists(".topic-list-item[data-topic-id=11994] .topic-excerpt"),
@@ -85,7 +85,7 @@ acceptance("Topic Discovery", function (needs) {
     );
   });
 
-  test("Live update unread state", async (assert) => {
+  test("Live update unread state", async function (assert) {
     await visit("/");
     assert.ok(
       exists(".topic-list-item:not(.visited) a[data-topic-id='11995']"),
@@ -114,7 +114,7 @@ acceptance("Topic Discovery", function (needs) {
     );
   });
 
-  test("Using period chooser when query params are present", async (assert) => {
+  test("Using period chooser when query params are present", async function (assert) {
     await visit("/top?f=foo&d=bar");
 
     sinon.stub(DiscourseURL, "routeTo");

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-edit-timer-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-edit-timer-test.js
@@ -25,7 +25,7 @@ acceptance("Topic - Edit timer", function (needs) {
     );
   });
 
-  test("default", async (assert) => {
+  test("default", async function (assert) {
     updateCurrentUser({ moderator: true });
     const futureDateInputSelector = selectKit(".future-date-input-selector");
 
@@ -40,7 +40,7 @@ acceptance("Topic - Edit timer", function (needs) {
     assert.equal(futureDateInputSelector.header().value(), null);
   });
 
-  test("autoclose - specific time", async (assert) => {
+  test("autoclose - specific time", async function (assert) {
     updateCurrentUser({ moderator: true });
     const futureDateInputSelector = selectKit(".future-date-input-selector");
 
@@ -61,7 +61,7 @@ acceptance("Topic - Edit timer", function (needs) {
     assert.ok(regex.test(html));
   });
 
-  skip("autoclose", async (assert) => {
+  skip("autoclose", async function (assert) {
     updateCurrentUser({ moderator: true });
     const futureDateInputSelector = selectKit(".future-date-input-selector");
 
@@ -123,7 +123,7 @@ acceptance("Topic - Edit timer", function (needs) {
     assert.ok(regex3.test(html3));
   });
 
-  test("close temporarily", async (assert) => {
+  test("close temporarily", async function (assert) {
     updateCurrentUser({ moderator: true });
     const timerType = selectKit(".select-kit.timer-type");
     const futureDateInputSelector = selectKit(".future-date-input-selector");
@@ -174,7 +174,7 @@ acceptance("Topic - Edit timer", function (needs) {
     assert.ok(regex2.test(html2));
   });
 
-  test("schedule", async (assert) => {
+  test("schedule", async function (assert) {
     updateCurrentUser({ moderator: true });
     const timerType = selectKit(".select-kit.timer-type");
     const categoryChooser = selectKit(".modal-body .category-chooser");
@@ -212,7 +212,7 @@ acceptance("Topic - Edit timer", function (needs) {
     assert.ok(regex.test(text));
   });
 
-  test("TL4 can't auto-delete", async (assert) => {
+  test("TL4 can't auto-delete", async function (assert) {
     updateCurrentUser({ moderator: false, admin: false, trust_level: 4 });
 
     await visit("/t/internationalization-localization");
@@ -226,7 +226,7 @@ acceptance("Topic - Edit timer", function (needs) {
     assert.ok(!timerType.rowByValue("delete").exists());
   });
 
-  test("auto delete", async (assert) => {
+  test("auto delete", async function (assert) {
     updateCurrentUser({ moderator: true });
     const timerType = selectKit(".select-kit.timer-type");
     const futureDateInputSelector = selectKit(".future-date-input-selector");
@@ -257,7 +257,7 @@ acceptance("Topic - Edit timer", function (needs) {
     assert.ok(regex.test(html));
   });
 
-  test("Inline delete timer", async (assert) => {
+  test("Inline delete timer", async function (assert) {
     updateCurrentUser({ moderator: true });
     const futureDateInputSelector = selectKit(".future-date-input-selector");
 

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-footer-buttons-mobile-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-footer-buttons-mobile-test.js
@@ -37,7 +37,7 @@ acceptance("Topic footer buttons mobile", function (needs) {
     _test = undefined;
   });
 
-  test("default", async (assert) => {
+  test("default", async function (assert) {
     await visit("/t/internationalization-localization/280");
 
     assert.equal(_test, null);

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-list-tracker-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-list-tracker-test.js
@@ -8,7 +8,7 @@ import {
 } from "discourse/lib/topic-list-tracker";
 
 acceptance("Topic list tracking", function () {
-  test("Navigation", async (assert) => {
+  test("Navigation", async function (assert) {
     await visit("/");
     let url = await nextTopicUrl();
     assert.equal(url, "/t/error-after-upgrade-to-0-9-7-9/11557");

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-move-posts-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-move-posts-test.js
@@ -7,7 +7,7 @@ import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 acceptance("Topic move posts", function (needs) {
   needs.user();
 
-  test("default", async (assert) => {
+  test("default", async function (assert) {
     await visit("/t/internationalization-localization");
     await click(".toggle-admin-menu");
     await click(".topic-admin-multi-select .btn");
@@ -50,7 +50,7 @@ acceptance("Topic move posts", function (needs) {
     );
   });
 
-  test("moving all posts", async (assert) => {
+  test("moving all posts", async function (assert) {
     await visit("/t/internationalization-localization");
     await click(".toggle-admin-menu");
     await click(".topic-admin-multi-select .btn");
@@ -86,7 +86,7 @@ acceptance("Topic move posts", function (needs) {
     );
   });
 
-  test("moving posts from personal message", async (assert) => {
+  test("moving posts from personal message", async function (assert) {
     await visit("/t/pm-for-testing/12");
     await click(".toggle-admin-menu");
     await click(".topic-admin-multi-select .btn");
@@ -122,7 +122,7 @@ acceptance("Topic move posts", function (needs) {
     );
   });
 
-  test("group moderator moving posts", async (assert) => {
+  test("group moderator moving posts", async function (assert) {
     await visit("/t/topic-for-group-moderators/2480");
     await click(".toggle-admin-menu");
     await click(".topic-admin-multi-select .btn");

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-notifications-button-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-notifications-button-test.js
@@ -12,7 +12,7 @@ acceptance("Topic Notifications button", function (needs) {
     });
   });
 
-  test("Updating topic notification level", async (assert) => {
+  test("Updating topic notification level", async function (assert) {
     const notificationOptions = selectKit(
       "#topic-footer-buttons .topic-notifications-options"
     );

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-quote-button-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-quote-button-test.js
@@ -22,7 +22,7 @@ acceptance("Topic - Quote button - logged in", function (needs) {
     share_quote_buttons: "twitter|email",
   });
 
-  test("Does not show the quote share buttons by default", async (assert) => {
+  test("Does not show the quote share buttons by default", async function (assert) {
     await visit("/t/internationalization-localization/280");
     selectText("#post_5 blockquote");
     assert.ok(exists(".insert-quote"), "it shows the quote button");

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-test.js
@@ -26,7 +26,7 @@ acceptance("Topic", function (needs) {
     });
   });
 
-  test("Reply as new topic", async (assert) => {
+  test("Reply as new topic", async function (assert) {
     await visit("/t/internationalization-localization/280");
     await click("button.share:eq(0)");
     await click(".reply-as-new-topic a");
@@ -45,7 +45,7 @@ acceptance("Topic", function (needs) {
     );
   });
 
-  test("Reply as new message", async (assert) => {
+  test("Reply as new message", async function (assert) {
     await visit("/t/pm-for-testing/12");
     await click("button.share:eq(0)");
     await click(".reply-as-new-topic a");
@@ -79,14 +79,14 @@ acceptance("Topic", function (needs) {
     );
   });
 
-  test("Share Modal", async (assert) => {
+  test("Share Modal", async function (assert) {
     await visit("/t/internationalization-localization/280");
     await click(".topic-post:first-child button.share");
 
     assert.ok(exists("#share-link"), "it shows the share modal");
   });
 
-  test("Showing and hiding the edit controls", async (assert) => {
+  test("Showing and hiding the edit controls", async function (assert) {
     await visit("/t/internationalization-localization/280");
 
     await click("#topic-title .d-icon-pencil-alt");
@@ -102,7 +102,7 @@ acceptance("Topic", function (needs) {
     assert.ok(!exists("#edit-title"), "it hides the editing controls");
   });
 
-  test("Updating the topic title and category", async (assert) => {
+  test("Updating the topic title and category", async function (assert) {
     const categoryChooser = selectKit(".title-wrapper .category-chooser");
 
     await visit("/t/internationalization-localization/280");
@@ -125,7 +125,7 @@ acceptance("Topic", function (needs) {
     );
   });
 
-  test("Marking a topic as wiki", async (assert) => {
+  test("Marking a topic as wiki", async function (assert) {
     await visit("/t/internationalization-localization/280");
 
     assert.ok(
@@ -140,7 +140,7 @@ acceptance("Topic", function (needs) {
     assert.ok(queryAll("a.wiki").length === 1, "it shows the wiki icon");
   });
 
-  test("Visit topic routes", async (assert) => {
+  test("Visit topic routes", async function (assert) {
     await visit("/t/12");
 
     assert.equal(
@@ -158,7 +158,7 @@ acceptance("Topic", function (needs) {
     );
   });
 
-  test("Updating the topic title with emojis", async (assert) => {
+  test("Updating the topic title with emojis", async function (assert) {
     await visit("/t/internationalization-localization/280");
     await click("#topic-title .d-icon-pencil-alt");
 
@@ -173,7 +173,7 @@ acceptance("Topic", function (needs) {
     );
   });
 
-  test("Updating the topic title with unicode emojis", async (assert) => {
+  test("Updating the topic title with unicode emojis", async function (assert) {
     await visit("/t/internationalization-localization/280");
     await click("#topic-title .d-icon-pencil-alt");
 
@@ -204,7 +204,7 @@ acceptance("Topic", function (needs) {
     );
   });
 
-  test("Suggested topics", async (assert) => {
+  test("Suggested topics", async function (assert) {
     await visit("/t/internationalization-localization/280");
 
     assert.equal(
@@ -213,7 +213,7 @@ acceptance("Topic", function (needs) {
     );
   });
 
-  test("Deleting a topic", async (assert) => {
+  test("Deleting a topic", async function (assert) {
     await visit("/t/internationalization-localization/280");
     await click(".topic-post:eq(0) button.show-more-actions");
     await click(".widget-button.delete");
@@ -242,7 +242,7 @@ acceptance("Topic", function (needs) {
     assert.ok(exists(".topic-admin-recover"), "it shows the recover button");
   });
 
-  test("Group category moderator posts", async (assert) => {
+  test("Group category moderator posts", async function (assert) {
     await visit("/t/topic-for-group-moderators/2480");
 
     assert.ok(exists(".category-moderator"), "it has a class applied");
@@ -256,7 +256,7 @@ acceptance("Topic featured links", function (needs) {
     topic_featured_link_enabled: true,
     max_topic_title_length: 80,
   });
-  test("remove featured link", async (assert) => {
+  test("remove featured link", async function (assert) {
     await visit("/t/-/299/1");
     assert.ok(
       exists(".title-wrapper .topic-featured-link"),
@@ -274,7 +274,7 @@ acceptance("Topic featured links", function (needs) {
     assert.ok(!exists(".title-wrapper .topic-featured-link"), "link is gone");
   });
 
-  test("Converting to a public topic", async (assert) => {
+  test("Converting to a public topic", async function (assert) {
     await visit("/t/test-pm/34");
     assert.ok(exists(".private_message"));
     await click(".toggle-admin-menu");
@@ -290,7 +290,7 @@ acceptance("Topic featured links", function (needs) {
     assert.ok(!exists(".private_message"));
   });
 
-  test("Unpinning unlisted topic", async (assert) => {
+  test("Unpinning unlisted topic", async function (assert) {
     await visit("/t/internationalization-localization/280");
 
     await click(".toggle-admin-menu");
@@ -307,7 +307,7 @@ acceptance("Topic featured links", function (needs) {
     );
   });
 
-  test("selecting posts", async (assert) => {
+  test("selecting posts", async function (assert) {
     await visit("/t/internationalization-localization/280");
     await click(".toggle-admin-menu");
     await click(".topic-admin-multi-select .btn");
@@ -323,7 +323,7 @@ acceptance("Topic featured links", function (needs) {
     );
   });
 
-  test("select below", async (assert) => {
+  test("select below", async function (assert) {
     await visit("/t/internationalization-localization/280");
     await click(".toggle-admin-menu");
     await click(".topic-admin-multi-select .btn");
@@ -346,14 +346,14 @@ acceptance("Topic featured links", function (needs) {
     );
   });
 
-  test("View Hidden Replies", async (assert) => {
+  test("View Hidden Replies", async function (assert) {
     await visit("/t/internationalization-localization/280");
     await click(".gap");
 
     assert.equal(queryAll(".gap").length, 0, "it hides gap");
   });
 
-  test("Quoting a quote keeps the original poster name", async (assert) => {
+  test("Quoting a quote keeps the original poster name", async function (assert) {
     await visit("/t/internationalization-localization/280");
     selectText("#post_5 blockquote");
     await click(".quote-button .insert-quote");
@@ -365,7 +365,7 @@ acceptance("Topic featured links", function (needs) {
     );
   });
 
-  test("Quoting a quote of a different topic keeps the original topic title", async (assert) => {
+  test("Quoting a quote of a different topic keeps the original topic title", async function (assert) {
     await visit("/t/internationalization-localization/280");
     selectText("#post_9 blockquote");
     await click(".quote-button .insert-quote");
@@ -379,7 +379,7 @@ acceptance("Topic featured links", function (needs) {
     );
   });
 
-  test("Quoting a quote with the Reply button keeps the original poster name", async (assert) => {
+  test("Quoting a quote with the Reply button keeps the original poster name", async function (assert) {
     await visit("/t/internationalization-localization/280");
     selectText("#post_5 blockquote");
     await click(".reply");
@@ -391,7 +391,7 @@ acceptance("Topic featured links", function (needs) {
     );
   });
 
-  test("Quoting a quote with replyAsNewTopic keeps the original poster name", async (assert) => {
+  test("Quoting a quote with replyAsNewTopic keeps the original poster name", async function (assert) {
     await visit("/t/internationalization-localization/280");
     selectText("#post_5 blockquote");
     await keyEvent(document, "keypress", "j".charCodeAt(0));
@@ -404,7 +404,7 @@ acceptance("Topic featured links", function (needs) {
     );
   });
 
-  test("Quoting by selecting text can mark the quote as full", async (assert) => {
+  test("Quoting by selecting text can mark the quote as full", async function (assert) {
     await visit("/t/internationalization-localization/280");
     selectText("#post_5 .cooked");
     await click(".quote-button .insert-quote");
@@ -426,7 +426,7 @@ acceptance("Topic with title decorated", function (needs) {
       });
     });
   });
-  test("Decorate topic title", async (assert) => {
+  test("Decorate topic title", async function (assert) {
     await visit("/t/internationalization-localization/280");
 
     assert.ok(

--- a/app/assets/javascripts/discourse/tests/acceptance/unknown-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/unknown-test.js
@@ -27,17 +27,17 @@ acceptance("Unknown", function (needs) {
     });
   });
 
-  test("Permalink Unknown URL", async (assert) => {
+  test("Permalink Unknown URL", async function (assert) {
     await visit("/url-that-doesn't-exist");
     assert.ok(exists(".page-not-found"), "The not found content is present");
   });
 
-  test("Permalink URL to a Topic", async (assert) => {
+  test("Permalink URL to a Topic", async function (assert) {
     await visit("/viewtopic.php?f=8&t=280");
     assert.equal(currentURL(), "/t/internationalization-localization/280");
   });
 
-  test("Permalink URL to a static page", async (assert) => {
+  test("Permalink URL to a static page", async function (assert) {
     await visit("/not-the-url-for-faq");
     assert.equal(currentURL(), "/faq");
   });

--- a/app/assets/javascripts/discourse/tests/acceptance/user-anonymous-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-anonymous-test.js
@@ -4,13 +4,13 @@ import { test } from "qunit";
 import { acceptance, count } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("User Anonymous", function () {
-  test("Root URL", async (assert) => {
+  test("Root URL", async function (assert) {
     await visit("/u/eviltrout");
     assert.ok($("body.user-summary-page").length, "has the body class");
     assert.equal(currentPath(), "user.summary", "it defaults to summary");
   });
 
-  test("Filters", async (assert) => {
+  test("Filters", async function (assert) {
     await visit("/u/eviltrout/activity");
     assert.ok($("body.user-activity-page").length, "has the body class");
     assert.ok(exists(".user-main .about"), "it has the about section");
@@ -27,13 +27,13 @@ acceptance("User Anonymous", function () {
     assert.ok(exists(".user-stream.filter-5"), "stream has filter class");
   });
 
-  test("Badges", async (assert) => {
+  test("Badges", async function (assert) {
     await visit("/u/eviltrout/badges");
     assert.ok($("body.user-badges-page").length, "has the body class");
     assert.ok(exists(".user-badges-list .badge-card"), "shows a badge");
   });
 
-  test("Restricted Routes", async (assert) => {
+  test("Restricted Routes", async function (assert) {
     await visit("/u/eviltrout/preferences");
 
     assert.equal(

--- a/app/assets/javascripts/discourse/tests/acceptance/user-bookmarks-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-bookmarks-test.js
@@ -10,7 +10,7 @@ import { cloneJSON } from "discourse-common/lib/object";
 acceptance("User's bookmarks", function (needs) {
   needs.user();
 
-  test("removing a bookmark with no reminder does not show a confirmation", async (assert) => {
+  test("removing a bookmark with no reminder does not show a confirmation", async function (assert) {
     await visit("/u/eviltrout/activity/bookmarks");
     assert.ok(queryAll(".bookmark-list-item").length > 0);
 
@@ -33,7 +33,7 @@ acceptance("User's bookmarks - reminder", function (needs) {
     });
   });
 
-  test("removing a bookmark with a reminder shows a confirmation", async (assert) => {
+  test("removing a bookmark with a reminder shows a confirmation", async function (assert) {
     await visit("/u/eviltrout/activity/bookmarks");
 
     const dropdown = selectKit(".bookmark-actions-dropdown");
@@ -58,7 +58,7 @@ acceptance("User's bookmarks - no bookmarks", function (needs) {
     );
   });
 
-  test("listing users bookmarks - no bookmarks", async (assert) => {
+  test("listing users bookmarks - no bookmarks", async function (assert) {
     await visit("/u/eviltrout/activity/bookmarks");
     assert.equal(queryAll(".alert.alert-info").text(), "no bookmarks");
   });

--- a/app/assets/javascripts/discourse/tests/acceptance/user-card-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-card-test.js
@@ -15,7 +15,7 @@ acceptance("User Card - Show Local Time", function (needs) {
     server.get("/u/charlie/card.json", () => helper.response(cardResponse));
   });
 
-  test("user card local time - does not update timezone for another user", async (assert) => {
+  test("user card local time - does not update timezone for another user", async function (assert) {
     User.current().changeTimezone("Australia/Brisbane");
 
     await visit("/t/internationalization-localization/280");

--- a/app/assets/javascripts/discourse/tests/acceptance/user-drafts-stream-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-drafts-stream-test.js
@@ -7,7 +7,7 @@ import { click } from "@ember/test-helpers";
 acceptance("User Drafts", function (needs) {
   needs.user();
 
-  test("Stream", async (assert) => {
+  test("Stream", async function (assert) {
     await visit("/u/eviltrout/activity/drafts");
     assert.ok(queryAll(".user-stream-item").length === 3, "has drafts");
 
@@ -18,7 +18,7 @@ acceptance("User Drafts", function (needs) {
     );
   });
 
-  test("Stream - resume draft", async (assert) => {
+  test("Stream - resume draft", async function (assert) {
     await visit("/u/eviltrout/activity/drafts");
     assert.ok(queryAll(".user-stream-item").length > 0, "has drafts");
 

--- a/app/assets/javascripts/discourse/tests/acceptance/user-preferences-interface-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-preferences-interface-test.js
@@ -12,7 +12,7 @@ import { click } from "@ember/test-helpers";
 acceptance("User Preferences - Interface", function (needs) {
   needs.user();
 
-  test("font size change", async (assert) => {
+  test("font size change", async function (assert) {
     removeCookie("text_size");
 
     const savePreferences = async () => {
@@ -57,12 +57,12 @@ acceptance("User Preferences - Interface", function (needs) {
     removeCookie("text_size");
   });
 
-  test("does not show option to disable dark mode by default", async (assert) => {
+  test("does not show option to disable dark mode by default", async function (assert) {
     await visit("/u/eviltrout/preferences/interface");
     assert.equal($(".control-group.dark-mode").length, 0);
   });
 
-  test("shows light/dark color scheme pickers", async (assert) => {
+  test("shows light/dark color scheme pickers", async function (assert) {
     let site = Site.current();
     site.set("user_color_schemes", [
       { id: 2, name: "Cool Breeze" },
@@ -88,7 +88,7 @@ acceptance(
       });
     });
 
-    test("show option to disable dark mode", async (assert) => {
+    test("show option to disable dark mode", async function (assert) {
       await visit("/u/eviltrout/preferences/interface");
 
       assert.ok(
@@ -97,7 +97,7 @@ acceptance(
       );
     });
 
-    test("no color scheme picker by default", async (assert) => {
+    test("no color scheme picker by default", async function (assert) {
       let site = Site.current();
       site.set("user_color_schemes", []);
 
@@ -105,7 +105,7 @@ acceptance(
       assert.equal($(".control-group.color-scheme").length, 0);
     });
 
-    test("light color scheme picker", async (assert) => {
+    test("light color scheme picker", async function (assert) {
       let site = Site.current();
       site.set("user_color_schemes", [{ id: 2, name: "Cool Breeze" }]);
 
@@ -118,7 +118,7 @@ acceptance(
       );
     });
 
-    test("light and dark color scheme pickers", async (assert) => {
+    test("light and dark color scheme pickers", async function (assert) {
       let site = Site.current();
       let session = Session.current();
       session.userDarkSchemeId = 1; // same as default set in site settings

--- a/app/assets/javascripts/discourse/tests/acceptance/user-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-test.js
@@ -13,29 +13,29 @@ acceptance("User Routes", function (needs) {
       helper.response(400, {})
     );
   });
-  test("Invalid usernames", async (assert) => {
+  test("Invalid usernames", async function (assert) {
     await visit("/u/eviltrout%2F..%2F..%2F/summary");
 
     assert.equal(currentPath(), "exception-unknown");
   });
 
-  test("Unicode usernames", async (assert) => {
+  test("Unicode usernames", async function (assert) {
     await visit("/u/%E3%83%A9%E3%82%A4%E3%82%AA%E3%83%B3/summary");
 
     assert.equal(currentPath(), "user.summary");
   });
 
-  test("Invites", async (assert) => {
+  test("Invites", async function (assert) {
     await visit("/u/eviltrout/invited/pending");
     assert.ok($("body.user-invites-page").length, "has the body class");
   });
 
-  test("Messages", async (assert) => {
+  test("Messages", async function (assert) {
     await visit("/u/eviltrout/messages");
     assert.ok($("body.user-messages-page").length, "has the body class");
   });
 
-  test("Notifications", async (assert) => {
+  test("Notifications", async function (assert) {
     await visit("/u/eviltrout/notifications");
     assert.ok($("body.user-notifications-page").length, "has the body class");
 
@@ -48,7 +48,7 @@ acceptance("User Routes", function (needs) {
     );
   });
 
-  test("Root URL - Viewing Self", async (assert) => {
+  test("Root URL - Viewing Self", async function (assert) {
     await visit("/u/eviltrout");
     assert.ok($("body.user-activity-page").length, "has the body class");
     assert.equal(
@@ -59,7 +59,7 @@ acceptance("User Routes", function (needs) {
     assert.ok(exists(".container.viewing-self"), "has the viewing-self class");
   });
 
-  test("Viewing Summary", async (assert) => {
+  test("Viewing Summary", async function (assert) {
     await visit("/u/eviltrout/summary");
 
     assert.ok(exists(".replies-section li a"), "replies");
@@ -75,7 +75,7 @@ acceptance("User Routes", function (needs) {
     );
   });
 
-  test("Viewing Drafts", async (assert) => {
+  test("Viewing Drafts", async function (assert) {
     await visit("/u/eviltrout/activity/drafts");
     assert.ok(exists(".user-stream"), "has drafts stream");
     assert.ok(

--- a/app/assets/javascripts/discourse/tests/acceptance/users-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/users-test.js
@@ -4,24 +4,24 @@ import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("User Directory", function () {
-  test("Visit Page", async (assert) => {
+  test("Visit Page", async function (assert) {
     await visit("/u");
     assert.ok($("body.users-page").length, "has the body class");
     assert.ok(exists(".directory table tr"), "has a list of users");
   });
 
-  test("Visit All Time", async (assert) => {
+  test("Visit All Time", async function (assert) {
     await visit("/u?period=all");
     assert.ok(exists(".time-read"), "has time read column");
   });
 
-  test("Visit Without Usernames", async (assert) => {
+  test("Visit Without Usernames", async function (assert) {
     await visit("/u?exclude_usernames=system");
     assert.ok($("body.users-page").length, "has the body class");
     assert.ok(exists(".directory table tr"), "has a list of users");
   });
 
-  test("Visit With Group Filter", async (assert) => {
+  test("Visit With Group Filter", async function (assert) {
     await visit("/u?group=trust_level_0");
     assert.ok($("body.users-page").length, "has the body class");
     assert.ok(exists(".directory table tr"), "has a list of users");

--- a/app/assets/javascripts/discourse/tests/integration/components/keyboard-shortcuts-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/keyboard-shortcuts-test.js
@@ -117,21 +117,21 @@ Object.keys(functionBindings).forEach((func) => {
   });
 });
 
-test("selectDown calls _moveSelection with 1", (assert) => {
+test("selectDown calls _moveSelection with 1", function (assert) {
   let stub = sinon.stub(KeyboardShortcuts, "_moveSelection");
 
   KeyboardShortcuts.selectDown();
   assert.ok(stub.calledWith(1), "_moveSelection is called with 1");
 });
 
-test("selectUp calls _moveSelection with -1", (assert) => {
+test("selectUp calls _moveSelection with -1", function (assert) {
   let stub = sinon.stub(KeyboardShortcuts, "_moveSelection");
 
   KeyboardShortcuts.selectUp();
   assert.ok(stub.calledWith(-1), "_moveSelection is called with -1");
 });
 
-test("goBack calls history.back", (assert) => {
+test("goBack calls history.back", function (assert) {
   let called = false;
   sinon.stub(history, "back").callsFake(function () {
     called = true;
@@ -141,14 +141,14 @@ test("goBack calls history.back", (assert) => {
   assert.ok(called, "history.back is called");
 });
 
-test("nextSection calls _changeSection with 1", (assert) => {
+test("nextSection calls _changeSection with 1", function (assert) {
   let spy = sinon.spy(KeyboardShortcuts, "_changeSection");
 
   KeyboardShortcuts.nextSection();
   assert.ok(spy.calledWith(1), "_changeSection is called with 1");
 });
 
-test("prevSection calls _changeSection with -1", (assert) => {
+test("prevSection calls _changeSection with -1", function (assert) {
   let spy = sinon.spy(KeyboardShortcuts, "_changeSection");
 
   KeyboardShortcuts.prevSection();

--- a/app/assets/javascripts/discourse/tests/unit/ember/resolver-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/ember/resolver-test.js
@@ -31,7 +31,7 @@ module("lib:resolver", {
   },
 });
 
-test("finds templates in top level dir", (assert) => {
+test("finds templates in top level dir", function (assert) {
   setTemplates(["foobar", "fooBar", "foo_bar", "foo.bar"]);
 
   lookupTemplate(assert, "template:foobar", "foobar", "by lowcased name");
@@ -40,7 +40,7 @@ test("finds templates in top level dir", (assert) => {
   lookupTemplate(assert, "template:foo.bar", "foo.bar", "by dotted name");
 });
 
-test("finds templates in first-level subdir", (assert) => {
+test("finds templates in first-level subdir", function (assert) {
   setTemplates(["foo/bar_baz"]);
 
   lookupTemplate(
@@ -69,7 +69,7 @@ test("finds templates in first-level subdir", (assert) => {
   );
 });
 
-test("resolves precedence between overlapping top level dir and first level subdir templates", (assert) => {
+test("resolves precedence between overlapping top level dir and first level subdir templates", function (assert) {
   setTemplates(["fooBar", "foo_bar", "foo.bar", "foo/bar"]);
 
   lookupTemplate(
@@ -92,7 +92,7 @@ test("resolves precedence between overlapping top level dir and first level subd
   );
 });
 
-test("finds templates in subdir deeper than one level", (assert) => {
+test("finds templates in subdir deeper than one level", function (assert) {
   setTemplates(["foo/bar/baz/qux"]);
 
   lookupTemplate(
@@ -146,7 +146,7 @@ test("finds templates in subdir deeper than one level", (assert) => {
   );
 });
 
-test("resolves mobile templates to 'mobile/' namespace", (assert) => {
+test("resolves mobile templates to 'mobile/' namespace", function (assert) {
   setTemplates(["mobile/foo", "bar", "mobile/bar", "baz"]);
 
   setResolverOption("mobileView", true);
@@ -171,7 +171,7 @@ test("resolves mobile templates to 'mobile/' namespace", (assert) => {
   );
 });
 
-test("resolves plugin templates to 'javascripts/' namespace", (assert) => {
+test("resolves plugin templates to 'javascripts/' namespace", function (assert) {
   setTemplates(["javascripts/foo", "bar", "javascripts/bar", "baz"]);
 
   lookupTemplate(
@@ -194,7 +194,7 @@ test("resolves plugin templates to 'javascripts/' namespace", (assert) => {
   );
 });
 
-test("resolves templates with 'admin' prefix to 'admin/templates/' namespace", (assert) => {
+test("resolves templates with 'admin' prefix to 'admin/templates/' namespace", function (assert) {
   setTemplates([
     "admin/templates/foo",
     "adminBar",
@@ -248,7 +248,7 @@ test("resolves templates with 'admin' prefix to 'admin/templates/' namespace", (
   );
 });
 
-test("returns 'not_found' template when template name cannot be resolved", (assert) => {
+test("returns 'not_found' template when template name cannot be resolved", function (assert) {
   setTemplates(["not_found"]);
 
   lookupTemplate(assert, "template:foo/bar/baz", "not_found", "");

--- a/app/assets/javascripts/discourse/tests/unit/lib/allow-lister-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/allow-lister-test.js
@@ -3,7 +3,7 @@ import AllowLister from "pretty-text/allow-lister";
 
 module("lib:allowLister");
 
-test("allowLister", (assert) => {
+test("allowLister", function (assert) {
   const allowLister = new AllowLister();
 
   assert.ok(

--- a/app/assets/javascripts/discourse/tests/unit/lib/bbcode-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/bbcode-test.js
@@ -3,7 +3,7 @@ import { parseBBCodeTag } from "pretty-text/engines/discourse-markdown/bbcode-bl
 
 module("lib:pretty-text:bbcode");
 
-test("block with multiple quoted attributes", (assert) => {
+test("block with multiple quoted attributes", function (assert) {
   const parsed = parseBBCodeTag('[test one="foo" two="bar bar"]', 0, 30);
 
   assert.equal(parsed.tag, "test");

--- a/app/assets/javascripts/discourse/tests/unit/lib/bookmark-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/bookmark-test.js
@@ -13,7 +13,7 @@ module("lib:bookmark", {
   },
 });
 
-test("formattedReminderTime works when the reminder time is tomorrow", (assert) => {
+test("formattedReminderTime works when the reminder time is tomorrow", function (assert) {
   let reminderAt = "2020-04-12 09:45:00";
   let reminderAtDate = moment
     .tz(reminderAt, "Australia/Brisbane")
@@ -24,7 +24,7 @@ test("formattedReminderTime works when the reminder time is tomorrow", (assert) 
   );
 });
 
-test("formattedReminderTime works when the reminder time is today", (assert) => {
+test("formattedReminderTime works when the reminder time is today", function (assert) {
   let reminderAt = "2020-04-11 09:45:00";
   let reminderAtDate = moment
     .tz(reminderAt, "Australia/Brisbane")
@@ -35,7 +35,7 @@ test("formattedReminderTime works when the reminder time is today", (assert) => 
   );
 });
 
-test("formattedReminderTime works when the reminder time is in the future", (assert) => {
+test("formattedReminderTime works when the reminder time is in the future", function (assert) {
   let reminderAt = "2020-04-15 09:45:00";
   let reminderAtDate = moment
     .tz(reminderAt, "Australia/Brisbane")

--- a/app/assets/javascripts/discourse/tests/unit/lib/break-string-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/break-string-test.js
@@ -3,7 +3,7 @@ import { test, module } from "qunit";
 
 module("lib:breakString", {});
 
-test("breakString", (assert) => {
+test("breakString", function (assert) {
   var b = function (s, hint) {
     return new BreakString(s).break(hint);
   };

--- a/app/assets/javascripts/discourse/tests/unit/lib/category-badge-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/category-badge-test.js
@@ -8,11 +8,11 @@ discourseModule("lib:category-link");
 
 import { categoryBadgeHTML } from "discourse/helpers/category-link";
 
-test("categoryBadge without a category", (assert) => {
+test("categoryBadge without a category", function (assert) {
   assert.blank(categoryBadgeHTML(), "it returns no HTML");
 });
 
-test("Regular categoryBadge", (assert) => {
+test("Regular categoryBadge", function (assert) {
   const store = createStore();
   const category = store.createRecord("category", {
     name: "hello",
@@ -39,7 +39,7 @@ test("Regular categoryBadge", (assert) => {
   );
 });
 
-test("undefined color", (assert) => {
+test("undefined color", function (assert) {
   const store = createStore();
   const noColor = store.createRecord("category", { name: "hello", id: 123 });
   const tag = $.parseHTML(categoryBadgeHTML(noColor))[0];
@@ -50,7 +50,7 @@ test("undefined color", (assert) => {
   );
 });
 
-test("topic count", (assert) => {
+test("topic count", function (assert) {
   const store = createStore();
   const category = store.createRecord("category", { name: "hello", id: 123 });
 
@@ -65,7 +65,7 @@ test("topic count", (assert) => {
   );
 });
 
-test("allowUncategorized", (assert) => {
+test("allowUncategorized", function (assert) {
   const store = createStore();
   const uncategorized = store.createRecord("category", {
     name: "uncategorized",

--- a/app/assets/javascripts/discourse/tests/unit/lib/click-track-edit-history-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/click-track-edit-history-test.js
@@ -60,7 +60,7 @@ function generateClickEventOn(selector) {
   return $.Event("click", { currentTarget: fixture(selector).first() });
 }
 
-skip("tracks internal URLs", async (assert) => {
+skip("tracks internal URLs", async function (assert) {
   assert.expect(2);
   sinon.stub(DiscourseURL, "origin").returns("http://discuss.domain.com");
 
@@ -76,7 +76,7 @@ skip("tracks internal URLs", async (assert) => {
   assert.notOk(track(generateClickEventOn("#same-site")));
 });
 
-skip("tracks external URLs", async (assert) => {
+skip("tracks external URLs", async function (assert) {
   assert.expect(2);
 
   const done = assert.async();
@@ -91,7 +91,7 @@ skip("tracks external URLs", async (assert) => {
   assert.notOk(track(generateClickEventOn("a")));
 });
 
-skip("tracks external URLs when opening in another window", async (assert) => {
+skip("tracks external URLs when opening in another window", async function (assert) {
   assert.expect(3);
   User.currentProp("external_links_in_new_tab", true);
 

--- a/app/assets/javascripts/discourse/tests/unit/lib/click-track-profile-page-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/click-track-profile-page-test.js
@@ -53,7 +53,7 @@ function generateClickEventOn(selector) {
   return $.Event("click", { currentTarget: fixture(selector).first() });
 }
 
-skip("tracks internal URLs", async (assert) => {
+skip("tracks internal URLs", async function (assert) {
   assert.expect(2);
   sinon.stub(DiscourseURL, "origin").returns("http://discuss.domain.com");
 
@@ -66,7 +66,7 @@ skip("tracks internal URLs", async (assert) => {
   assert.notOk(track(generateClickEventOn("#same-site")));
 });
 
-skip("tracks external URLs", async (assert) => {
+skip("tracks external URLs", async function (assert) {
   assert.expect(2);
 
   const done = assert.async();
@@ -81,7 +81,7 @@ skip("tracks external URLs", async (assert) => {
   assert.notOk(track(generateClickEventOn("a")));
 });
 
-skip("tracks external URLs in other posts", async (assert) => {
+skip("tracks external URLs in other posts", async function (assert) {
   assert.expect(2);
 
   const done = assert.async();

--- a/app/assets/javascripts/discourse/tests/unit/lib/click-track-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/click-track-test.js
@@ -54,7 +54,7 @@ function generateClickEventOn(selector) {
   return $.Event("click", { currentTarget: fixture(selector).first() });
 }
 
-skip("tracks internal URLs", async (assert) => {
+skip("tracks internal URLs", async function (assert) {
   assert.expect(2);
   sinon.stub(DiscourseURL, "origin").returns("http://discuss.domain.com");
 
@@ -70,11 +70,11 @@ skip("tracks internal URLs", async (assert) => {
   assert.notOk(track(generateClickEventOn("#same-site")));
 });
 
-test("does not track elements with no href", async (assert) => {
+test("does not track elements with no href", async function (assert) {
   assert.ok(track(generateClickEventOn(".a-without-href")));
 });
 
-test("does not track attachments", async (assert) => {
+test("does not track attachments", async function (assert) {
   sinon.stub(DiscourseURL, "origin").returns("http://discuss.domain.com");
 
   pretender.post("/clicks/track", () => assert.ok(false));
@@ -87,7 +87,7 @@ test("does not track attachments", async (assert) => {
   );
 });
 
-skip("tracks external URLs", async (assert) => {
+skip("tracks external URLs", async function (assert) {
   assert.expect(2);
 
   const done = assert.async();
@@ -102,7 +102,7 @@ skip("tracks external URLs", async (assert) => {
   assert.notOk(track(generateClickEventOn("a")));
 });
 
-skip("tracks external URLs when opening in another window", async (assert) => {
+skip("tracks external URLs when opening in another window", async function (assert) {
   assert.expect(3);
   User.currentProp("external_links_in_new_tab", true);
 
@@ -119,39 +119,39 @@ skip("tracks external URLs when opening in another window", async (assert) => {
   assert.ok(window.open.calledWith("http://www.google.com", "_blank"));
 });
 
-test("does not track clicks on lightboxes", async (assert) => {
+test("does not track clicks on lightboxes", async function (assert) {
   assert.notOk(track(generateClickEventOn(".lightbox")));
 });
 
-test("does not track clicks when forcibly disabled", async (assert) => {
+test("does not track clicks when forcibly disabled", async function (assert) {
   assert.notOk(track(generateClickEventOn(".no-track-link")));
 });
 
-test("does not track clicks on back buttons", async (assert) => {
+test("does not track clicks on back buttons", async function (assert) {
   assert.notOk(track(generateClickEventOn(".back")));
 });
 
-test("does not track right clicks inside quotes", async (assert) => {
+test("does not track right clicks inside quotes", async function (assert) {
   const event = generateClickEventOn(".quote a:first-child");
   event.which = 3;
   assert.ok(track(event));
 });
 
-test("does not track clicks links in quotes", async (assert) => {
+test("does not track clicks links in quotes", async function (assert) {
   User.currentProp("external_links_in_new_tab", true);
   assert.notOk(track(generateClickEventOn(".quote a:last-child")));
   assert.ok(window.open.calledWith("https://google.com/", "_blank"));
 });
 
-test("does not track clicks on category badges", async (assert) => {
+test("does not track clicks on category badges", async function (assert) {
   assert.notOk(track(generateClickEventOn(".hashtag")));
 });
 
-test("does not track clicks on mailto", async (assert) => {
+test("does not track clicks on mailto", async function (assert) {
   assert.ok(track(generateClickEventOn(".mailto")));
 });
 
-test("removes the href and put it as a data attribute", async (assert) => {
+test("removes the href and put it as a data attribute", async function (assert) {
   User.currentProp("external_links_in_new_tab", true);
 
   assert.notOk(track(generateClickEventOn("a")));
@@ -164,7 +164,7 @@ test("removes the href and put it as a data attribute", async (assert) => {
   assert.ok(window.open.calledWith("http://www.google.com/", "_blank"));
 });
 
-test("restores the href after a while", async (assert) => {
+test("restores the href after a while", async function (assert) {
   assert.expect(2);
 
   assert.notOk(track(generateClickEventOn("a")));
@@ -184,24 +184,24 @@ function badgeClickCount(assert, id, expected) {
   assert.equal(parseInt($badge.html(), 10), expected);
 }
 
-test("does not update badge clicks on my own link", async (assert) => {
+test("does not update badge clicks on my own link", async function (assert) {
   sinon.stub(User, "currentProp").withArgs("id").returns(314);
   badgeClickCount(assert, "with-badge", 1);
 });
 
-test("does not update badge clicks in my own post", async (assert) => {
+test("does not update badge clicks in my own post", async function (assert) {
   sinon.stub(User, "currentProp").withArgs("id").returns(3141);
   badgeClickCount(assert, "with-badge-but-not-mine", 1);
 });
 
-test("updates badge counts correctly", async (assert) => {
+test("updates badge counts correctly", async function (assert) {
   badgeClickCount(assert, "inside-onebox", 1);
   badgeClickCount(assert, "inside-onebox-forced", 2);
   badgeClickCount(assert, "with-badge", 2);
 });
 
 function testOpenInANewTab(description, clickEventModifier) {
-  test(description, async (assert) => {
+  test(description, async function (assert) {
     var clickEvent = generateClickEventOn("a");
     clickEventModifier(clickEvent);
     assert.ok(track(clickEvent));

--- a/app/assets/javascripts/discourse/tests/unit/lib/computed-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/computed-test.js
@@ -45,7 +45,7 @@ test("setting", function (assert) {
   );
 });
 
-test("propertyEqual", (assert) => {
+test("propertyEqual", function (assert) {
   var t = EmberObject.extend({
     same: propertyEqual("cookies", "biscuits"),
   }).create({
@@ -58,7 +58,7 @@ test("propertyEqual", (assert) => {
   assert.ok(!t.get("same"), "it isn't true when one property is different");
 });
 
-test("propertyNotEqual", (assert) => {
+test("propertyNotEqual", function (assert) {
   var t = EmberObject.extend({
     diff: propertyNotEqual("cookies", "biscuits"),
   }).create({
@@ -71,7 +71,7 @@ test("propertyNotEqual", (assert) => {
   assert.ok(t.get("diff"), "it is true when one property is different");
 });
 
-test("fmt", (assert) => {
+test("fmt", function (assert) {
   var t = EmberObject.extend({
     exclaimyUsername: fmt("username", "!!! %@ !!!"),
     multiple: fmt("username", "mood", "%@ is %@"),
@@ -105,7 +105,7 @@ test("fmt", (assert) => {
   );
 });
 
-test("i18n", (assert) => {
+test("i18n", function (assert) {
   var t = EmberObject.extend({
     exclaimyUsername: i18n("username", "!!! %@ !!!"),
     multiple: i18n("username", "mood", "%@ is %@"),
@@ -139,7 +139,7 @@ test("i18n", (assert) => {
   );
 });
 
-test("url", (assert) => {
+test("url", function (assert) {
   var t, testClass;
 
   testClass = EmberObject.extend({
@@ -162,7 +162,7 @@ test("url", (assert) => {
   );
 });
 
-test("htmlSafe", (assert) => {
+test("htmlSafe", function (assert) {
   const cookies = "<p>cookies and <b>biscuits</b></p>";
   const t = EmberObject.extend({
     desc: htmlSafe("cookies"),

--- a/app/assets/javascripts/discourse/tests/unit/lib/emoji-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/emoji-test.js
@@ -131,7 +131,7 @@ test("emojiUnescape", function (assert) {
   );
 });
 
-test("Emoji search", (assert) => {
+test("Emoji search", function (assert) {
   // able to find an alias
   assert.equal(emojiSearch("+1").length, 1);
 

--- a/app/assets/javascripts/discourse/tests/unit/lib/get-url-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/get-url-test.js
@@ -12,19 +12,19 @@ import {
 
 module("lib:get-url");
 
-test("isAbsoluteURL", (assert) => {
+test("isAbsoluteURL", function (assert) {
   setupURL(null, "https://example.com", "/forum");
   assert.ok(isAbsoluteURL("https://example.com/test/thing"));
   assert.ok(!isAbsoluteURL("http://example.com/test/thing"));
   assert.ok(!isAbsoluteURL("https://discourse.org/test/thing"));
 });
 
-test("getAbsoluteURL", (assert) => {
+test("getAbsoluteURL", function (assert) {
   setupURL(null, "https://example.com", "/forum");
   assert.equal(getAbsoluteURL("/cool/path"), "https://example.com/cool/path");
 });
 
-test("withoutPrefix", (assert) => {
+test("withoutPrefix", function (assert) {
   setPrefix("/eviltrout");
   assert.equal(withoutPrefix("/eviltrout/hello"), "/hello");
   assert.equal(withoutPrefix("/eviltrout/"), "/");
@@ -41,7 +41,7 @@ test("withoutPrefix", (assert) => {
   assert.equal(withoutPrefix("/"), "/");
 });
 
-test("getURL with empty paths", (assert) => {
+test("getURL with empty paths", function (assert) {
   setupURL(null, "https://example.com", "/");
   assert.equal(getURL("/"), "/");
   assert.equal(getURL(""), "");
@@ -53,7 +53,7 @@ test("getURL with empty paths", (assert) => {
   assert.equal(getURL(""), "");
 });
 
-test("getURL on subfolder install", (assert) => {
+test("getURL on subfolder install", function (assert) {
   setupURL(null, "", "/forum");
   assert.equal(getURL("/"), "/forum/", "root url has subfolder");
   assert.equal(
@@ -81,7 +81,7 @@ test("getURL on subfolder install", (assert) => {
   );
 });
 
-test("getURLWithCDN on subfolder install with S3", (assert) => {
+test("getURLWithCDN on subfolder install with S3", function (assert) {
   setupURL(null, "", "/forum");
   setupS3CDN(
     "//test.s3-us-west-1.amazonaws.com/site",

--- a/app/assets/javascripts/discourse/tests/unit/lib/highlight-search-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/highlight-search-test.js
@@ -4,7 +4,7 @@ import { module, test } from "qunit";
 
 module("lib:highlight-search");
 
-test("highlighting text", (assert) => {
+test("highlighting text", function (assert) {
   fixture().html(
     `
     <p>This is some text to highlight</p>
@@ -26,7 +26,7 @@ test("highlighting text", (assert) => {
   );
 });
 
-test("highlighting unicode text", (assert) => {
+test("highlighting unicode text", function (assert) {
   fixture().html(
     `
     <p>This is some தமிழ் & русский text to highlight</p>

--- a/app/assets/javascripts/discourse/tests/unit/lib/i18n-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/i18n-test.js
@@ -99,12 +99,12 @@ module("lib:i18n", {
   },
 });
 
-test("defaults", (assert) => {
+test("defaults", function (assert) {
   assert.equal(I18n.defaultLocale, "en", "it has English as default locale");
   assert.ok(I18n.pluralizationRules["en"], "it has English pluralizer");
 });
 
-test("translations", (assert) => {
+test("translations", function (assert) {
   assert.equal(
     I18n.t("topic.reply.title"),
     "Répondre",
@@ -123,7 +123,7 @@ test("translations", (assert) => {
   assert.equal(I18n.t("hello.universe"), "", "allows empty strings");
 });
 
-test("extra translations", (assert) => {
+test("extra translations", function (assert) {
   I18n.locale = "pl_PL";
   I18n.extras = {
     en: {
@@ -195,7 +195,7 @@ test("extra translations", (assert) => {
   );
 });
 
-test("pluralizations", (assert) => {
+test("pluralizations", function (assert) {
   assert.equal(I18n.t("character_count", { count: 0 }), "0 ZERO");
   assert.equal(I18n.t("character_count", { count: 1 }), "1 ONE");
   assert.equal(I18n.t("character_count", { count: 2 }), "2 TWO");
@@ -211,7 +211,7 @@ test("pluralizations", (assert) => {
   assert.equal(I18n.t("word_count", { count: 100 }), "100 words");
 });
 
-test("fallback", (assert) => {
+test("fallback", function (assert) {
   assert.equal(
     I18n.t("days", { count: 1 }),
     "1 day",
@@ -243,7 +243,7 @@ test("fallback", (assert) => {
   );
 });
 
-test("Dollar signs are properly escaped", (assert) => {
+test("Dollar signs are properly escaped", function (assert) {
   assert.equal(
     I18n.t("dollar_sign", {
       description: "$& $&",

--- a/app/assets/javascripts/discourse/tests/unit/lib/icon-library-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/icon-library-test.js
@@ -7,7 +7,7 @@ import {
 
 module("lib:icon-library");
 
-test("return icon markup", (assert) => {
+test("return icon markup", function (assert) {
   assert.ok(iconHTML("bars").indexOf('use xlink:href="#bars"') > -1);
 
   const nodeIcon = iconNode("bars");
@@ -18,7 +18,7 @@ test("return icon markup", (assert) => {
   );
 });
 
-test("convert icon names", (assert) => {
+test("convert icon names", function (assert) {
   const fa5Icon = convertIconClass("fab fa-facebook");
   assert.ok(iconHTML(fa5Icon).indexOf("fab-facebook") > -1, "FA 5 syntax");
 

--- a/app/assets/javascripts/discourse/tests/unit/lib/key-value-store-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/key-value-store-test.js
@@ -3,13 +3,13 @@ import KeyValueStore from "discourse/lib/key-value-store";
 
 module("lib:key-value-store");
 
-test("it's able to get the result back from the store", (assert) => {
+test("it's able to get the result back from the store", function (assert) {
   const store = new KeyValueStore("_test");
   store.set({ key: "bob", value: "uncle" });
   assert.equal(store.get("bob"), "uncle");
 });
 
-test("is able to nuke the store", (assert) => {
+test("is able to nuke the store", function (assert) {
   const store = new KeyValueStore("_test");
   store.set({ key: "bob1", value: "uncle" });
   store.abandonLocal();

--- a/app/assets/javascripts/discourse/tests/unit/lib/link-mentions-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/link-mentions-test.js
@@ -8,7 +8,7 @@ import pretender from "discourse/tests/helpers/create-pretender";
 
 module("lib:link-mentions");
 
-test("linkSeenMentions replaces users and groups", async (assert) => {
+test("linkSeenMentions replaces users and groups", async function (assert) {
   pretender.get("/u/is_local_username", () => [
     200,
     { "Content-Type": "application/json" },

--- a/app/assets/javascripts/discourse/tests/unit/lib/load-script-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/load-script-test.js
@@ -5,7 +5,7 @@ import { PUBLIC_JS_VERSIONS as jsVersions } from "discourse/lib/public-js-versio
 
 module("lib:load-script");
 
-skip("load with a script tag, and callbacks are only executed after script is loaded", async (assert) => {
+skip("load with a script tag, and callbacks are only executed after script is loaded", async function (assert) {
   assert.ok(
     typeof window.ace === "undefined",
     "ensures ace is not previously loaded"
@@ -20,7 +20,7 @@ skip("load with a script tag, and callbacks are only executed after script is lo
   );
 });
 
-test("works when a value is not present", (assert) => {
+test("works when a value is not present", function (assert) {
   assert.equal(
     cacheBuster("/javascripts/my-script.js"),
     "/javascripts/my-script.js"
@@ -31,7 +31,7 @@ test("works when a value is not present", (assert) => {
   );
 });
 
-test("generates URLs with version number in the query params", (assert) => {
+test("generates URLs with version number in the query params", function (assert) {
   assert.equal(
     cacheBuster("/javascripts/pikaday.js"),
     `/javascripts/${jsVersions["pikaday.js"]}`

--- a/app/assets/javascripts/discourse/tests/unit/lib/oneboxer-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/oneboxer-test.js
@@ -17,7 +17,7 @@ function loadOnebox(element) {
 
 module("lib:oneboxer");
 
-test("load - failed onebox", async (assert) => {
+test("load - failed onebox", async function (assert) {
   let element = document.createElement("A");
   element.setAttribute("href", "http://somebadurl.com");
 
@@ -35,7 +35,7 @@ test("load - failed onebox", async (assert) => {
   );
 });
 
-test("load - successful onebox", async (assert) => {
+test("load - successful onebox", async function (assert) {
   const html = `
     <aside class="onebox allowlistedgeneric">
       <header class="source">

--- a/app/assets/javascripts/discourse/tests/unit/lib/preload-store-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/preload-store-test.js
@@ -8,7 +8,7 @@ module("preload-store", {
   },
 });
 
-test("get", (assert) => {
+test("get", function (assert) {
   assert.blank(PreloadStore.get("joker"), "returns blank for a missing key");
   assert.equal(
     PreloadStore.get("bane"),
@@ -17,30 +17,30 @@ test("get", (assert) => {
   );
 });
 
-test("remove", (assert) => {
+test("remove", function (assert) {
   PreloadStore.remove("bane");
   assert.blank(PreloadStore.get("bane"), "removes the value if the key exists");
 });
 
-test("getAndRemove returns a promise that resolves to null", async (assert) => {
+test("getAndRemove returns a promise that resolves to null", async function (assert) {
   assert.blank(await PreloadStore.getAndRemove("joker"));
 });
 
-test("getAndRemove returns a promise that resolves to the result of the finder", async (assert) => {
+test("getAndRemove returns a promise that resolves to the result of the finder", async function (assert) {
   const finder = () => "batdance";
   const result = await PreloadStore.getAndRemove("joker", finder);
 
   assert.equal(result, "batdance");
 });
 
-test("getAndRemove returns a promise that resolves to the result of the finder's promise", async (assert) => {
+test("getAndRemove returns a promise that resolves to the result of the finder's promise", async function (assert) {
   const finder = () => Promise.resolve("hahahah");
   const result = await PreloadStore.getAndRemove("joker", finder);
 
   assert.equal(result, "hahahah");
 });
 
-test("returns a promise that rejects with the result of the finder's rejected promise", async (assert) => {
+test("returns a promise that rejects with the result of the finder's rejected promise", async function (assert) {
   const finder = () => Promise.reject("error");
 
   await PreloadStore.getAndRemove("joker", finder).catch((result) => {
@@ -48,7 +48,7 @@ test("returns a promise that rejects with the result of the finder's rejected pr
   });
 });
 
-test("returns a promise that resolves to 'evil'", async (assert) => {
+test("returns a promise that resolves to 'evil'", async function (assert) {
   const result = await PreloadStore.getAndRemove("bane");
   assert.equal(result, "evil");
 });

--- a/app/assets/javascripts/discourse/tests/unit/lib/pretty-text-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/pretty-text-test.js
@@ -56,7 +56,7 @@ QUnit.assert.cookedPara = function (input, expected, message) {
   QUnit.assert.cooked(input, `<p>${expected}</p>`, message);
 };
 
-skip("Pending Engine fixes and spec fixes", (assert) => {
+skip("Pending Engine fixes and spec fixes", function (assert) {
   assert.cooked(
     "Derpy: http://derp.com?_test_=1",
     '<p>Derpy: <a href=https://derp.com?_test_=1"http://derp.com?_test_=1">http://derp.com?_test_=1</a></p>',
@@ -70,7 +70,7 @@ skip("Pending Engine fixes and spec fixes", (assert) => {
   );
 });
 
-test("buildOptions", (assert) => {
+test("buildOptions", function (assert) {
   assert.ok(
     buildOptions({ siteSettings: { enable_emoji: true } }).discourse.features
       .emoji,
@@ -83,7 +83,7 @@ test("buildOptions", (assert) => {
   );
 });
 
-test("basic cooking", (assert) => {
+test("basic cooking", function (assert) {
   assert.cooked("hello", "<p>hello</p>", "surrounds text with paragraphs");
   assert.cooked("**evil**", "<p><strong>evil</strong></p>", "it bolds text.");
   assert.cooked("__bold__", "<p><strong>bold</strong></p>", "it bolds text.");
@@ -121,7 +121,7 @@ test("basic cooking", (assert) => {
   );
 });
 
-test("Nested bold and italics", (assert) => {
+test("Nested bold and italics", function (assert) {
   assert.cooked(
     "*this is italic **with some bold** inside*",
     "<p><em>this is italic <strong>with some bold</strong> inside</em></p>",
@@ -129,7 +129,7 @@ test("Nested bold and italics", (assert) => {
   );
 });
 
-test("Traditional Line Breaks", (assert) => {
+test("Traditional Line Breaks", function (assert) {
   const input = "1\n2\n3";
   assert.cooked(
     input,
@@ -143,14 +143,14 @@ test("Traditional Line Breaks", (assert) => {
   );
 });
 
-test("Unbalanced underscores", (assert) => {
+test("Unbalanced underscores", function (assert) {
   assert.cooked(
     "[evil_trout][1] hello_\n\n[1]: http://eviltrout.com",
     '<p><a href="http://eviltrout.com">evil_trout</a> hello_</p>'
   );
 });
 
-test("Line Breaks", (assert) => {
+test("Line Breaks", function (assert) {
   assert.cooked(
     "[] first choice\n[] second choice",
     "<p>[] first choice<br>\n[] second choice</p>",
@@ -174,7 +174,7 @@ test("Line Breaks", (assert) => {
   );
 });
 
-test("Paragraphs for HTML", (assert) => {
+test("Paragraphs for HTML", function (assert) {
   assert.cooked(
     "<div>hello world</div>",
     "<div>hello world</div>",
@@ -197,7 +197,7 @@ test("Paragraphs for HTML", (assert) => {
   );
 });
 
-test("Links", (assert) => {
+test("Links", function (assert) {
   assert.cooked(
     "EvilTrout: http://eviltrout.com",
     '<p>EvilTrout: <a href="http://eviltrout.com">http://eviltrout.com</a></p>',
@@ -346,7 +346,7 @@ test("Links", (assert) => {
   );
 });
 
-test("simple quotes", (assert) => {
+test("simple quotes", function (assert) {
   assert.cooked(
     "> nice!",
     "<blockquote>\n<p>nice!</p>\n</blockquote>",
@@ -395,7 +395,7 @@ eviltrout</p>
   );
 });
 
-test("Quotes", (assert) => {
+test("Quotes", function (assert) {
   assert.cookedOptions(
     '[quote="eviltrout, post: 1"]\na quote\n\nsecond line\n\nthird line\n[/quote]',
     { topicId: 2 },
@@ -456,7 +456,7 @@ test("Quotes", (assert) => {
   );
 });
 
-test("Mentions", (assert) => {
+test("Mentions", function (assert) {
   assert.cooked(
     "Hello @sam",
     '<p>Hello <span class="mention">@sam</span></p>',
@@ -597,7 +597,7 @@ test("Mentions", (assert) => {
   );
 });
 
-test("Mentions - Unicode usernames enabled", (assert) => {
+test("Mentions - Unicode usernames enabled", function (assert) {
   assert.cookedOptions(
     "Hello @狮子",
     { siteSettings: { unicode_usernames: true } },
@@ -620,7 +620,7 @@ test("Mentions - Unicode usernames enabled", (assert) => {
   );
 });
 
-test("Mentions - disabled", (assert) => {
+test("Mentions - disabled", function (assert) {
   assert.cookedOptions(
     "@eviltrout",
     { siteSettings: { enable_mentions: false } },
@@ -628,7 +628,7 @@ test("Mentions - disabled", (assert) => {
   );
 });
 
-test("Category hashtags", (assert) => {
+test("Category hashtags", function (assert) {
   const alwaysTrue = {
     categoryHashtagLookup: function () {
       return ["http://test.discourse.org/category-hashtag", "category-hashtag"];
@@ -692,7 +692,7 @@ test("Category hashtags", (assert) => {
   );
 });
 
-test("Heading", (assert) => {
+test("Heading", function (assert) {
   assert.cooked(
     "**Bold**\n----------",
     "<h2><strong>Bold</strong></h2>",
@@ -700,7 +700,7 @@ test("Heading", (assert) => {
   );
 });
 
-test("bold and italics", (assert) => {
+test("bold and italics", function (assert) {
   assert.cooked(
     'a "**hello**"',
     "<p>a &quot;<strong>hello</strong>&quot;</p>",
@@ -738,7 +738,7 @@ test("bold and italics", (assert) => {
   );
 });
 
-test("Escaping", (assert) => {
+test("Escaping", function (assert) {
   assert.cooked(
     "*\\*laughs\\**",
     "<p><em>*laughs*</em></p>",
@@ -751,7 +751,7 @@ test("Escaping", (assert) => {
   );
 });
 
-test("New Lines", (assert) => {
+test("New Lines", function (assert) {
   // historically we would not continue inline em or b across lines,
   // however commonmark gives us no switch to do so and we would be very non compliant.
   // turning softbreaks into a newline is just a renderer option, not a parser switch.
@@ -767,7 +767,7 @@ test("New Lines", (assert) => {
   );
 });
 
-test("Oneboxing", (assert) => {
+test("Oneboxing", function (assert) {
   function matches(input, regexp) {
     return new PrettyText(defaultOpts).cook(input).match(regexp);
   }
@@ -813,7 +813,7 @@ test("Oneboxing", (assert) => {
   );
 });
 
-test("links with full urls", (assert) => {
+test("links with full urls", function (assert) {
   assert.cooked(
     "[http://eviltrout.com][1] is a url\n\n[1]: http://eviltrout.com",
     '<p><a href="http://eviltrout.com">http://eviltrout.com</a> is a url</p>',
@@ -821,7 +821,7 @@ test("links with full urls", (assert) => {
   );
 });
 
-test("Code Blocks", (assert) => {
+test("Code Blocks", function (assert) {
   assert.cooked(
     "<pre>\nhello\n</pre>\n",
     "<pre>\nhello\n</pre>",
@@ -943,7 +943,7 @@ test("Code Blocks", (assert) => {
   );
 });
 
-test("URLs in BBCode tags", (assert) => {
+test("URLs in BBCode tags", function (assert) {
   assert.cooked(
     "[img]http://eviltrout.com/eviltrout.png[/img][img]http://samsaffron.com/samsaffron.png[/img]",
     '<p><img src="http://eviltrout.com/eviltrout.png" alt/><img src="http://samsaffron.com/samsaffron.png" alt/></p>',
@@ -963,7 +963,7 @@ test("URLs in BBCode tags", (assert) => {
   );
 });
 
-test("images", (assert) => {
+test("images", function (assert) {
   assert.cooked(
     "[![folksy logo](http://folksy.com/images/folksy-colour.png)](http://folksy.com/)",
     '<p><a href="http://folksy.com/"><img src="http://folksy.com/images/folksy-colour.png" alt="folksy logo"/></a></p>',
@@ -977,7 +977,7 @@ test("images", (assert) => {
   );
 });
 
-test("attachment", (assert) => {
+test("attachment", function (assert) {
   assert.cooked(
     "[test.pdf|attachment](upload://o8iobpLcW3WSFvVH7YQmyGlKmGM.pdf)",
     `<p><a class="attachment" href="/404" data-orig-href="upload://o8iobpLcW3WSFvVH7YQmyGlKmGM.pdf">test.pdf</a></p>`,
@@ -985,7 +985,7 @@ test("attachment", (assert) => {
   );
 });
 
-test("attachment - mapped url - secure media disabled", (assert) => {
+test("attachment - mapped url - secure media disabled", function (assert) {
   function lookupUploadUrls() {
     let cache = {};
     cache["upload://o8iobpLcW3WSFvVH7YQmyGlKmGM.pdf"] = {
@@ -1007,7 +1007,7 @@ test("attachment - mapped url - secure media disabled", (assert) => {
   );
 });
 
-test("attachment - mapped url - secure media enabled", (assert) => {
+test("attachment - mapped url - secure media enabled", function (assert) {
   function lookupUploadUrls() {
     let cache = {};
     cache["upload://o8iobpLcW3WSFvVH7YQmyGlKmGM.pdf"] = {
@@ -1029,7 +1029,7 @@ test("attachment - mapped url - secure media enabled", (assert) => {
   );
 });
 
-test("video", (assert) => {
+test("video", function (assert) {
   assert.cooked(
     "![baby shark|video](upload://eyPnj7UzkU0AkGkx2dx8G4YM1Jx.mp4)",
     `<p><div class="video-container">
@@ -1042,7 +1042,7 @@ test("video", (assert) => {
   );
 });
 
-test("video - mapped url - secure media enabled", (assert) => {
+test("video - mapped url - secure media enabled", function (assert) {
   function lookupUploadUrls() {
     let cache = {};
     cache["upload://eyPnj7UzkU0AkGkx2dx8G4YM1Jx.mp4"] = {
@@ -1068,7 +1068,7 @@ test("video - mapped url - secure media enabled", (assert) => {
   );
 });
 
-test("audio", (assert) => {
+test("audio", function (assert) {
   assert.cooked(
     "![young americans|audio](upload://eyPnj7UzkU0AkGkx2dx8G4YM1Jx.mp3)",
     `<p><audio preload="metadata" controls>
@@ -1079,7 +1079,7 @@ test("audio", (assert) => {
   );
 });
 
-test("audio - mapped url - secure media enabled", (assert) => {
+test("audio - mapped url - secure media enabled", function (assert) {
   function lookupUploadUrls() {
     let cache = {};
     cache["upload://eyPnj7UzkU0AkGkx2dx8G4YM1Jx.mp3"] = {
@@ -1103,7 +1103,7 @@ test("audio - mapped url - secure media enabled", (assert) => {
   );
 });
 
-test("censoring", (assert) => {
+test("censoring", function (assert) {
   assert.cookedOptions(
     "Pleased to meet you, but pleeeease call me later, xyz123",
     {
@@ -1115,7 +1115,7 @@ test("censoring", (assert) => {
   // More tests in pretty_text_spec.rb
 });
 
-test("code blocks/spans hoisting", (assert) => {
+test("code blocks/spans hoisting", function (assert) {
   assert.cooked(
     "```\n\n    some code\n```",
     '<pre><code class="lang-auto">\n    some code\n</code></pre>',
@@ -1129,7 +1129,7 @@ test("code blocks/spans hoisting", (assert) => {
   );
 });
 
-test("basic bbcode", (assert) => {
+test("basic bbcode", function (assert) {
   assert.cookedPara(
     "[b]strong[/b]",
     '<span class="bbcode-b">strong</span>',
@@ -1177,7 +1177,7 @@ test("basic bbcode", (assert) => {
   );
 });
 
-test("urls", (assert) => {
+test("urls", function (assert) {
   assert.cookedPara(
     "[url]not a url[/url]",
     "not a url",
@@ -1204,7 +1204,7 @@ test("urls", (assert) => {
     "supports [url] with an embedded [img]"
   );
 });
-test("invalid bbcode", (assert) => {
+test("invalid bbcode", function (assert) {
   assert.cooked(
     "[code]I am not closed\n\nThis text exists.",
     "<p>[code]I am not closed</p>\n<p>This text exists.</p>",
@@ -1212,7 +1212,7 @@ test("invalid bbcode", (assert) => {
   );
 });
 
-test("code", (assert) => {
+test("code", function (assert) {
   assert.cooked(
     "[code]\nx++\n[/code]",
     '<pre><code class="lang-auto">x++</code></pre>',
@@ -1235,7 +1235,7 @@ test("code", (assert) => {
   );
 });
 
-test("tags with arguments", (assert) => {
+test("tags with arguments", function (assert) {
   assert.cookedPara(
     "[url=http://bettercallsaul.com]better call![/url]",
     '<a href="http://bettercallsaul.com" data-bbcode="true">better call!</a>',
@@ -1258,7 +1258,7 @@ test("tags with arguments", (assert) => {
   );
 });
 
-test("quotes", (assert) => {
+test("quotes", function (assert) {
   const post = Post.create({
     cooked: "<p><b>lorem</b> ipsum</p>",
     username: "eviltrout",
@@ -1318,7 +1318,7 @@ test("quotes", (assert) => {
   );
 });
 
-test("quoting a quote", (assert) => {
+test("quoting a quote", function (assert) {
   const post = Post.create({
     cooked: new PrettyText(defaultOpts).cook(
       '[quote="sam, post:1, topic:1, full:true"]\nhello\n[/quote]\n*Test*'
@@ -1340,7 +1340,7 @@ test("quoting a quote", (assert) => {
   );
 });
 
-test("quote formatting", (assert) => {
+test("quote formatting", function (assert) {
   assert.cooked(
     '[quote="EvilTrout, post:123, topic:456, full:true"]\n[sam]\n[/quote]',
     `<aside class=\"quote no-group\" data-username=\"EvilTrout\" data-post=\"123\" data-topic=\"456\" data-full=\"true\">
@@ -1443,7 +1443,7 @@ var bar = 'bar';
   );
 });
 
-test("quotes with trailing formatting", (assert) => {
+test("quotes with trailing formatting", function (assert) {
   const result = new PrettyText(defaultOpts).cook(
     '[quote="EvilTrout, post:123, topic:456, full:true"]\nhello\n[/quote]\n*Test*'
   );
@@ -1462,7 +1462,7 @@ test("quotes with trailing formatting", (assert) => {
   );
 });
 
-test("enable/disable features", (assert) => {
+test("enable/disable features", function (assert) {
   assert.cookedOptions("|a|\n--\n|a|", { features: { table: false } }, "");
   assert.cooked(
     "|a|\n--\n|a|",
@@ -1483,7 +1483,7 @@ test("enable/disable features", (assert) => {
   );
 });
 
-test("emoji", (assert) => {
+test("emoji", function (assert) {
   assert.cooked(
     ":smile:",
     `<p><img src="/images/emoji/emoji_one/smile.png?v=${v}" title=":smile:" class="emoji only-emoji" alt=":smile:"></p>`
@@ -1498,7 +1498,7 @@ test("emoji", (assert) => {
   );
 });
 
-test("emoji - enable_inline_emoji_translation", (assert) => {
+test("emoji - enable_inline_emoji_translation", function (assert) {
   assert.cookedOptions(
     "test:smile:test",
     { siteSettings: { enable_inline_emoji_translation: false } },
@@ -1512,7 +1512,7 @@ test("emoji - enable_inline_emoji_translation", (assert) => {
   );
 });
 
-test("emoji - emojiSet", (assert) => {
+test("emoji - emojiSet", function (assert) {
   assert.cookedOptions(
     ":smile:",
     { siteSettings: { emoji_set: "twitter" } },
@@ -1520,7 +1520,7 @@ test("emoji - emojiSet", (assert) => {
   );
 });
 
-test("emoji - registerEmoji", (assert) => {
+test("emoji - registerEmoji", function (assert) {
   registerEmoji("foo", "/images/d-logo-sketch.png");
 
   assert.cookedOptions(
@@ -1538,7 +1538,7 @@ test("emoji - registerEmoji", (assert) => {
   );
 });
 
-test("extractDataAttribute", (assert) => {
+test("extractDataAttribute", function (assert) {
   assert.deepEqual(extractDataAttribute("foo="), ["data-foo", ""]);
   assert.deepEqual(extractDataAttribute("foo=bar"), ["data-foo", "bar"]);
 
@@ -1546,7 +1546,7 @@ test("extractDataAttribute", (assert) => {
   assert.notOk(extractDataAttribute("https://discourse.org/?q=hello"));
 });
 
-test("video - display placeholder when previewing", (assert) => {
+test("video - display placeholder when previewing", function (assert) {
   assert.cookedOptions(
     `![baby shark|video](upload://eyPnj7UzkU0AkGkx2dx8G4YM1Jx.mp4)`,
     { previewing: true },

--- a/app/assets/javascripts/discourse/tests/unit/lib/sanitizer-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/sanitizer-test.js
@@ -4,7 +4,7 @@ import { hrefAllowed } from "pretty-text/sanitizer";
 
 module("lib:sanitizer");
 
-test("sanitize", (assert) => {
+test("sanitize", function (assert) {
   const pt = new PrettyText(
     buildOptions({
       siteSettings: {
@@ -131,7 +131,7 @@ test("sanitize", (assert) => {
   cooked(`<div dir="rtl">RTL text</div>`, `<div dir="rtl">RTL text</div>`);
 });
 
-test("ids on headings", (assert) => {
+test("ids on headings", function (assert) {
   const pt = new PrettyText(buildOptions({ siteSettings: {} }));
   assert.equal(pt.sanitize("<h3>Test Heading</h3>"), "<h3>Test Heading</h3>");
   assert.equal(
@@ -160,7 +160,7 @@ test("ids on headings", (assert) => {
   );
 });
 
-test("poorly formed ids on headings", (assert) => {
+test("poorly formed ids on headings", function (assert) {
   let pt = new PrettyText(buildOptions({ siteSettings: {} }));
   assert.equal(
     pt.sanitize(`<h1 id="evil-trout">Test Heading</h1>`),
@@ -188,7 +188,7 @@ test("poorly formed ids on headings", (assert) => {
   );
 });
 
-test("urlAllowed", (assert) => {
+test("urlAllowed", function (assert) {
   const allowed = (url, msg) => assert.equal(hrefAllowed(url), url, msg);
 
   allowed("/foo/bar.html", "allows relative urls");

--- a/app/assets/javascripts/discourse/tests/unit/lib/screen-track-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/screen-track-test.js
@@ -3,7 +3,7 @@ import ScreenTrack from "discourse/lib/screen-track";
 
 module("lib:screen-track");
 
-test("consolidateTimings", (assert) => {
+test("consolidateTimings", function (assert) {
   const tracker = new ScreenTrack();
 
   tracker.consolidateTimings({ 1: 10, 2: 5 }, 10, 1);

--- a/app/assets/javascripts/discourse/tests/unit/lib/search-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/search-test.js
@@ -7,7 +7,7 @@ import {
 
 module("lib:search");
 
-test("unescapesEmojisInBlurbs", (assert) => {
+test("unescapesEmojisInBlurbs", function (assert) {
   const source = {
     posts: [
       {
@@ -37,7 +37,7 @@ test("unescapesEmojisInBlurbs", (assert) => {
   assert.ok(blurb.indexOf(":thinking:") === -1);
 });
 
-test("searchContextDescription", (assert) => {
+test("searchContextDescription", function (assert) {
   assert.equal(
     searchContextDescription("topic"),
     I18n.t("search.context.topic")

--- a/app/assets/javascripts/discourse/tests/unit/lib/sharing-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/sharing-test.js
@@ -10,7 +10,7 @@ module("lib:sharing", {
   },
 });
 
-test("addSource", (assert) => {
+test("addSource", function (assert) {
   const sharingSettings = "facebook|twitter";
 
   assert.blank(Sharing.activeSources(sharingSettings));
@@ -22,7 +22,7 @@ test("addSource", (assert) => {
   assert.equal(Sharing.activeSources(sharingSettings).length, 1);
 });
 
-test("addSharingId", (assert) => {
+test("addSharingId", function (assert) {
   const sharingSettings = "";
 
   assert.blank(Sharing.activeSources(sharingSettings));

--- a/app/assets/javascripts/discourse/tests/unit/lib/text-direction-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/text-direction-test.js
@@ -3,7 +3,7 @@ import { isRTL, isLTR } from "discourse/lib/text-direction";
 
 module("lib:text-direction");
 
-test("isRTL", (assert) => {
+test("isRTL", function (assert) {
   // Hebrew
   assert.equal(isRTL("זה מבחן"), true);
 
@@ -17,7 +17,7 @@ test("isRTL", (assert) => {
   assert.equal(isRTL(""), false);
 });
 
-test("isLTR", (assert) => {
+test("isLTR", function (assert) {
   assert.equal(isLTR("This is a test"), true);
   assert.equal(isLTR("זה מבחן"), false);
 });

--- a/app/assets/javascripts/discourse/tests/unit/lib/to-markdown-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/to-markdown-test.js
@@ -3,7 +3,7 @@ import toMarkdown from "discourse/lib/to-markdown";
 
 module("lib:to-markdown");
 
-test("converts styles between normal words", (assert) => {
+test("converts styles between normal words", function (assert) {
   const html = `Line with <s>styles</s> <b><i>between</i></b> words.`;
   const markdown = `Line with ~~styles~~ ***between*** words.`;
   assert.equal(toMarkdown(html), markdown);
@@ -12,7 +12,7 @@ test("converts styles between normal words", (assert) => {
   assert.equal(toMarkdown("A <b>bold</b>, word"), "A **bold**, word");
 });
 
-test("converts inline nested styles", (assert) => {
+test("converts inline nested styles", function (assert) {
   let html = `<em>Italicised line with <strong>some random</strong> <b>bold</b> words.</em>`;
   let markdown = `*Italicised line with **some random** **bold** words.*`;
   assert.equal(toMarkdown(html), markdown);
@@ -24,7 +24,7 @@ test("converts inline nested styles", (assert) => {
   assert.equal(toMarkdown(html), markdown);
 });
 
-test("converts a link", (assert) => {
+test("converts a link", function (assert) {
   let html = `<a href="https://discourse.org">Discourse</a>`;
   let markdown = `[Discourse](https://discourse.org)`;
   assert.equal(toMarkdown(html), markdown);
@@ -34,7 +34,7 @@ test("converts a link", (assert) => {
   assert.equal(toMarkdown(html), markdown);
 });
 
-test("put raw URL instead of converting the link", (assert) => {
+test("put raw URL instead of converting the link", function (assert) {
   let url = "https://discourse.org";
   const html = () => `<a href="${url}">${url}</a>`;
 
@@ -44,11 +44,11 @@ test("put raw URL instead of converting the link", (assert) => {
   assert.equal(toMarkdown(html()), url);
 });
 
-test("skip empty link", (assert) => {
+test("skip empty link", function (assert) {
   assert.equal(toMarkdown(`<a href="https://example.com"></a>`), "");
 });
 
-test("converts heading tags", (assert) => {
+test("converts heading tags", function (assert) {
   const html = `
   <h1>Heading 1</h1>
   <h2>Heading 2</h2>
@@ -71,7 +71,7 @@ test("converts heading tags", (assert) => {
   assert.equal(toMarkdown(html), markdown);
 });
 
-test("converts ul list tag", (assert) => {
+test("converts ul list tag", function (assert) {
   let html = `
   <ul>
     <li>Item 1</li>
@@ -103,7 +103,7 @@ test("converts ul list tag", (assert) => {
   assert.equal(toMarkdown(html), markdown);
 });
 
-test("stripes unwanted inline tags", (assert) => {
+test("stripes unwanted inline tags", function (assert) {
   const html = `
   <p>Lorem ipsum <span>dolor sit amet, consectetur</span> <strike>elit.</strike></p>
   <p>Ut minim veniam, <label>quis nostrud</label> laboris <nisi> ut aliquip ex ea</nisi> commodo.</p>
@@ -112,7 +112,7 @@ test("stripes unwanted inline tags", (assert) => {
   assert.equal(toMarkdown(html), markdown);
 });
 
-test("converts table tags", (assert) => {
+test("converts table tags", function (assert) {
   let html = `<address>Discourse Avenue</address><b>laboris</b>
   <table>
     <thead> <tr><th>Heading 1</th><th>Head 2</th></tr> </thead>
@@ -134,7 +134,7 @@ test("converts table tags", (assert) => {
   assert.equal(toMarkdown(html), markdown);
 });
 
-test("replace pipes with spaces if table format not supported", (assert) => {
+test("replace pipes with spaces if table format not supported", function (assert) {
   let html = `<table>
     <thead> <tr><th>Headi<br><br>ng 1</th><th>Head 2</th></tr> </thead>
       <tbody>
@@ -160,7 +160,7 @@ test("replace pipes with spaces if table format not supported", (assert) => {
   assert.equal(toMarkdown(html), markdown);
 });
 
-test("converts img tag", (assert) => {
+test("converts img tag", function (assert) {
   const url = "https://example.com/image.png";
   const base62SHA1 = "q16M6GR110R47Z9p9Dk3PMXOJoE";
   let html = `<img src="${url}" width="100" height="50">`;
@@ -197,7 +197,7 @@ test("converts img tag", (assert) => {
   assert.equal(toMarkdown(html), `![description](${url})`);
 });
 
-test("supporting html tags by keeping them", (assert) => {
+test("supporting html tags by keeping them", function (assert) {
   let html =
     "Lorem <del>ipsum dolor</del> sit <big>amet, <ins>consectetur</ins></big>";
   let output = html;
@@ -221,7 +221,7 @@ test("supporting html tags by keeping them", (assert) => {
   assert.equal(toMarkdown(html), output);
 });
 
-test("converts code tags", (assert) => {
+test("converts code tags", function (assert) {
   let html = `Lorem ipsum dolor sit amet,
   <pre><code>var helloWorld = () => {
   alert('    hello \t\t world    ');
@@ -243,7 +243,7 @@ helloWorld();</code>consectetur.`;
   assert.equal(toMarkdown(html), output);
 });
 
-test("converts blockquote tag", (assert) => {
+test("converts blockquote tag", function (assert) {
   let html = "<blockquote>Lorem ipsum</blockquote>";
   let output = "> Lorem ipsum";
   assert.equal(toMarkdown(html), output);
@@ -259,7 +259,7 @@ test("converts blockquote tag", (assert) => {
   assert.equal(toMarkdown(html), output);
 });
 
-test("converts ol list tag", (assert) => {
+test("converts ol list tag", function (assert) {
   const html = `Testing
   <ol>
     <li>Item 1</li>
@@ -277,7 +277,7 @@ test("converts ol list tag", (assert) => {
   assert.equal(toMarkdown(html), markdown);
 });
 
-test("converts list tag from word", (assert) => {
+test("converts list tag from word", function (assert) {
   const html = `Sample<!--StartFragment-->
   <p class=MsoListParagraphCxSpFirst style='text-indent:-.25in;mso-list:l0 level1 lfo1'>
     <![if !supportLists]>
@@ -324,7 +324,7 @@ test("converts list tag from word", (assert) => {
   assert.equal(toMarkdown(html), markdown);
 });
 
-test("keeps mention/hash class", (assert) => {
+test("keeps mention/hash class", function (assert) {
   const html = `
     <p>User mention: <a class="mention" href="/u/discourse">@discourse</a></p>
     <p>Group mention: <a class="mention-group" href="/groups/discourse">@discourse-group</a></p>
@@ -337,7 +337,7 @@ test("keeps mention/hash class", (assert) => {
   assert.equal(toMarkdown(html), markdown);
 });
 
-test("keeps emoji and removes click count", (assert) => {
+test("keeps emoji and removes click count", function (assert) {
   const html = `
     <p>
       A <a href="http://example.com">link</a><span class="badge badge-notification clicks" title="1 click">1</span> with click count
@@ -350,7 +350,7 @@ test("keeps emoji and removes click count", (assert) => {
   assert.equal(toMarkdown(html), markdown);
 });
 
-test("keeps emoji syntax for custom emoji", (assert) => {
+test("keeps emoji syntax for custom emoji", function (assert) {
   const html = `
     <p>
       <img class="emoji emoji-custom" title=":custom_emoji:" src="https://d11a6trkgmumsb.cloudfront.net/images/emoji/custom_emoji" alt=":custom_emoji:" />
@@ -362,7 +362,7 @@ test("keeps emoji syntax for custom emoji", (assert) => {
   assert.equal(toMarkdown(html), markdown);
 });
 
-test("converts image lightboxes to markdown", (assert) => {
+test("converts image lightboxes to markdown", function (assert) {
   let html = `
   <a class="lightbox" href="https://d11a6trkgmumsb.cloudfront.net/uploads/default/original/1X/8hkjhk7692f6afed3cb99d43ab2abd4e30aa8cba.jpeg" data-download-href="https://d11a6trkgmumsb.cloudfront.net/uploads/default/8hkjhk7692f6afed3cb99d43ab2abd4e30aa8cba" title="sherlock3_sig.jpg" rel="nofollow noopener"><img src="https://d11a6trkgmumsb.cloudfront.net/uploads/default/optimized/1X/8hkjhk7692f6afed3cb99d43ab2abd4e30aa8cba_2_689x459.jpeg" alt="sherlock3_sig" width="689" height="459" class="d-lazyload" srcset="https://d11a6trkgmumsb.cloudfront.net/uploads/default/optimized/1X/8hkjhk7692f6afed3cb99d43ab2abd4e30aa8cba_2_689x459.jpeg, https://d11a6trkgmumsb.cloudfront.net/uploads/default/optimized/1X/8hkjhk7692f6afed3cb99d43ab2abd4e30aa8cba_2_1033x688.jpeg 1.5x, https://d11a6trkgmumsb.cloudfront.net/uploads/default/optimized/1X/8hkjhk7692f6afed3cb99d43ab2abd4e30aa8cba_2_1378x918.jpeg 2x"><div class="meta">
   <span class="filename">sherlock3_sig.jpg</span><span class="informations">5496×3664 2 MB</span><span class="expand"></span>
@@ -386,7 +386,7 @@ test("converts image lightboxes to markdown", (assert) => {
   assert.equal(toMarkdown(html), markdown);
 });
 
-test("converts quotes to markdown", (assert) => {
+test("converts quotes to markdown", function (assert) {
   let html = `
   <p>there is a quote below</p>
   <aside class="quote no-group" data-username="foo" data-post="1" data-topic="2">
@@ -413,7 +413,7 @@ there is a quote above
   assert.equal(toMarkdown(html), markdown.trim());
 });
 
-test("strips base64 image URLs", (assert) => {
+test("strips base64 image URLs", function (assert) {
   const html =
     '<img src="data:image/jpeg;base64,/9j/4AAQSkZJRgABAgAAZABkAAD/7AARRHVja3kAAQAEAAAAPAAA/+4AJkFkb2JlAGTAAAAAAQMAFQQDBgoNAAABywAAAgsAAAJpAAACyf/bAIQABgQEBAUEBgUFBgkGBQYJCwgGBggLDAoKCwoKDBAMDAwMDAwQDA4PEA8ODBMTFBQTExwbGxscHx8fHx8fHx8fHwEHBwcNDA0YEBAYGhURFRofHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8f/8IAEQgAEAAQAwERAAIRAQMRAf/EAJQAAQEBAAAAAAAAAAAAAAAAAAMFBwEAAwEAAAAAAAAAAAAAAAAAAAEDAhAAAQUBAQAAAAAAAAAAAAAAAgABAwQFESARAAIBAwIHAAAAAAAAAAAAAAERAgAhMRIDQWGRocEiIxIBAAAAAAAAAAAAAAAAAAAAIBMBAAMAAQQDAQAAAAAAAAAAAQARITHwQVGBYXGR4f/aAAwDAQACEQMRAAAB0UlMciEJn//aAAgBAQABBQK5bGtFn6pWi2K12wWTRkjb/9oACAECAAEFAvH/2gAIAQMAAQUCIuIJOqRndRiv/9oACAECAgY/Ah//2gAIAQMCBj8CH//aAAgBAQEGPwLWQzwHepfNbcUNfM4tUIbA9QL4AvnxTlAxacpWJReOlf/aAAgBAQMBPyHZDveuCyu4B4lz2lDKto2ca5uclPK0aoq32x8xgTSLeSgbyzT65n//2gAIAQIDAT8hlQjP/9oACAEDAwE/IaE9GcZFJ//aAAwDAQACEQMRAAAQ5F//2gAIAQEDAT8Q1oowKccI3KTdAWkPLw2ssIrwKYUzuJoUJsIHOCoG23ISlja+rU9QvCx//9oACAECAwE/EAuNIiKf/9oACAEDAwE/ECujJzHf7iwHOv5NhK+8efH50z//2Q==" />';
   assert.equal(toMarkdown(html), "[image]");

--- a/app/assets/javascripts/discourse/tests/unit/lib/upload-short-url-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/upload-short-url-test.js
@@ -92,7 +92,7 @@ module("lib:pretty-text/upload-short-url", {
   },
 });
 
-test("resolveAllShortUrls", async (assert) => {
+test("resolveAllShortUrls", async function (assert) {
   stubUrls();
   let lookup;
 
@@ -143,7 +143,7 @@ test("resolveAllShortUrls", async (assert) => {
   });
 });
 
-test("resolveAllShortUrls - href + src replaced correctly", async (assert) => {
+test("resolveAllShortUrls - href + src replaced correctly", async function (assert) {
   stubUrls();
   await resolveAllShortUrls(ajax, { secure_media: false }, fixture()[0]);
 
@@ -166,7 +166,7 @@ test("resolveAllShortUrls - href + src replaced correctly", async (assert) => {
   );
 });
 
-test("resolveAllShortUrls - url with full origin replaced correctly", async (assert) => {
+test("resolveAllShortUrls - url with full origin replaced correctly", async function (assert) {
   stubUrls();
   await resolveAllShortUrls(ajax, { secure_media: false }, fixture()[0]);
   let video = fixture().find("video").eq(1);
@@ -177,7 +177,7 @@ test("resolveAllShortUrls - url with full origin replaced correctly", async (ass
   );
 });
 
-test("resolveAllShortUrls - when secure media is enabled use the attachment full URL", async (assert) => {
+test("resolveAllShortUrls - when secure media is enabled use the attachment full URL", async function (assert) {
   stubUrls(
     null,
     [
@@ -198,7 +198,7 @@ test("resolveAllShortUrls - when secure media is enabled use the attachment full
   );
 });
 
-test("resolveAllShortUrls - scoped", async (assert) => {
+test("resolveAllShortUrls - scoped", async function (assert) {
   stubUrls();
   let lookup;
 

--- a/app/assets/javascripts/discourse/tests/unit/lib/uploads-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/uploads-test.js
@@ -193,7 +193,7 @@ test("allows valid uploads to go through", function (assert) {
   assert.not(bootbox.alert.calledOnce);
 });
 
-test("isImage", (assert) => {
+test("isImage", function (assert) {
   ["png", "webp", "jpg", "jpeg", "gif", "ico"].forEach((extension) => {
     var image = "image." + extension;
     assert.ok(isImage(image), image + " is recognized as an image");
@@ -271,7 +271,7 @@ function testUploadMarkdown(filename, opts = {}) {
   );
 }
 
-test("getUploadMarkdown", (assert) => {
+test("getUploadMarkdown", function (assert) {
   assert.equal(
     testUploadMarkdown("lolcat.gif"),
     "![lolcat|100x200](/uploads/123/abcdef.ext)"
@@ -298,7 +298,7 @@ test("getUploadMarkdown", (assert) => {
   );
 });
 
-test("getUploadMarkdown - replaces GUID in image alt text on iOS", (assert) => {
+test("getUploadMarkdown - replaces GUID in image alt text on iOS", function (assert) {
   assert.equal(
     testUploadMarkdown("8F2B469B-6B2C-4213-BC68-57B4876365A0.jpeg"),
     "![8F2B469B-6B2C-4213-BC68-57B4876365A0|100x200](/uploads/123/abcdef.ext)"

--- a/app/assets/javascripts/discourse/tests/unit/lib/url-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/url-test.js
@@ -7,7 +7,7 @@ import User from "discourse/models/user";
 
 module("lib:url");
 
-test("isInternal with a HTTP url", (assert) => {
+test("isInternal with a HTTP url", function (assert) {
   sinon.stub(DiscourseURL, "origin").returns("http://eviltrout.com");
 
   assert.not(DiscourseURL.isInternal(null), "a blank URL is not internal");
@@ -34,7 +34,7 @@ test("isInternal with a HTTP url", (assert) => {
   );
 });
 
-test("isInternal with a HTTPS url", (assert) => {
+test("isInternal with a HTTPS url", function (assert) {
   sinon.stub(DiscourseURL, "origin").returns("https://eviltrout.com");
   assert.ok(
     DiscourseURL.isInternal("http://eviltrout.com/monocle"),
@@ -42,7 +42,7 @@ test("isInternal with a HTTPS url", (assert) => {
   );
 });
 
-test("isInternal on subfolder install", (assert) => {
+test("isInternal on subfolder install", function (assert) {
   sinon.stub(DiscourseURL, "origin").returns("http://eviltrout.com/forum");
   assert.not(
     DiscourseURL.isInternal("http://eviltrout.com"),
@@ -58,18 +58,18 @@ test("isInternal on subfolder install", (assert) => {
   );
 });
 
-test("userPath", (assert) => {
+test("userPath", function (assert) {
   assert.equal(userPath(), "/u");
   assert.equal(userPath("eviltrout"), "/u/eviltrout");
 });
 
-test("userPath with prefix", (assert) => {
+test("userPath with prefix", function (assert) {
   setPrefix("/forum");
   assert.equal(userPath(), "/forum/u");
   assert.equal(userPath("eviltrout"), "/forum/u/eviltrout");
 });
 
-test("routeTo with prefix", async (assert) => {
+test("routeTo with prefix", async function (assert) {
   setPrefix("/forum");
   logIn();
   const user = User.current();
@@ -82,7 +82,7 @@ test("routeTo with prefix", async (assert) => {
   );
 });
 
-test("prefixProtocol", async (assert) => {
+test("prefixProtocol", async function (assert) {
   assert.equal(
     prefixProtocol("mailto:mr-beaver@aol.com"),
     "mailto:mr-beaver@aol.com"

--- a/app/assets/javascripts/discourse/tests/unit/lib/user-search-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/user-search-test.js
@@ -86,7 +86,7 @@ module("lib:user-search", {
   },
 });
 
-test("it flushes cache when switching categories", async (assert) => {
+test("it flushes cache when switching categories", async function (assert) {
   let results = await userSearch({ term: "hello", categoryId: 1 });
   assert.equal(results[0].username, "category_1");
   assert.equal(results.length, 1);
@@ -101,7 +101,7 @@ test("it flushes cache when switching categories", async (assert) => {
   assert.equal(results.length, 1);
 });
 
-test("it returns cancel when eager completing with no results", async (assert) => {
+test("it returns cancel when eager completing with no results", async function (assert) {
   // Do everything twice, to check the cache works correctly
 
   for (let i = 0; i < 2; i++) {
@@ -124,17 +124,17 @@ test("it returns cancel when eager completing with no results", async (assert) =
   }
 });
 
-test("it places groups unconditionally for exact match", async (assert) => {
+test("it places groups unconditionally for exact match", async function (assert) {
   let results = await userSearch({ term: "Team" });
   assert.equal(results[results.length - 1]["name"], "team");
 });
 
-test("it strips @ from the beginning", async (assert) => {
+test("it strips @ from the beginning", async function (assert) {
   let results = await userSearch({ term: "@Team" });
   assert.equal(results[results.length - 1]["name"], "team");
 });
 
-test("it skips a search depending on punctuations", async (assert) => {
+test("it skips a search depending on punctuations", async function (assert) {
   let results;
   let skippedTerms = [
     "@sam  s", // double space is not allowed

--- a/app/assets/javascripts/discourse/tests/unit/lib/utilities-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/utilities-test.js
@@ -22,7 +22,7 @@ import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
 
 discourseModule("lib:utilities");
 
-test("escapeExpression", (assert) => {
+test("escapeExpression", function (assert) {
   assert.equal(escapeExpression(">"), "&gt;", "escapes unsafe characters");
 
   assert.equal(
@@ -38,7 +38,7 @@ test("escapeExpression", (assert) => {
   );
 });
 
-test("emailValid", (assert) => {
+test("emailValid", function (assert) {
   assert.ok(
     emailValid("Bob@example.com"),
     "allows upper case in the first part of emails"
@@ -49,7 +49,7 @@ test("emailValid", (assert) => {
   );
 });
 
-test("extractDomainFromUrl", (assert) => {
+test("extractDomainFromUrl", function (assert) {
   assert.equal(
     extractDomainFromUrl("http://meta.discourse.org:443/random"),
     "meta.discourse.org",
@@ -72,7 +72,7 @@ test("extractDomainFromUrl", (assert) => {
   );
 });
 
-test("avatarUrl", (assert) => {
+test("avatarUrl", function (assert) {
   var rawSize = getRawSize;
   assert.blank(avatarUrl("", "tiny"), "no template returns blank");
   assert.equal(
@@ -95,7 +95,7 @@ var setDevicePixelRatio = function (value) {
   }
 };
 
-test("avatarImg", (assert) => {
+test("avatarImg", function (assert) {
   var oldRatio = window.devicePixelRatio;
   setDevicePixelRatio(2);
 
@@ -165,7 +165,7 @@ test("setDefaultHomepage", function (assert) {
   assert.equal(defaultHomepage(), "top");
 });
 
-test("caretRowCol", (assert) => {
+test("caretRowCol", function (assert) {
   var textarea = document.createElement("textarea");
   const content = document.createTextNode("01234\n56789\n012345");
   textarea.appendChild(content);
@@ -196,7 +196,7 @@ test("caretRowCol", (assert) => {
   document.body.removeChild(textarea);
 });
 
-test("toAsciiPrintable", (assert) => {
+test("toAsciiPrintable", function (assert) {
   const accentedString = "Créme_Brûlée!";
   const unicodeString = "談話";
 
@@ -219,7 +219,7 @@ test("toAsciiPrintable", (assert) => {
   );
 });
 
-test("slugify", (assert) => {
+test("slugify", function (assert) {
   const asciiString = "--- 0__( Some-cool Discourse Site! )__0 --- ";
   const accentedString = "Créme_Brûlée!";
   const unicodeString = "談話";
@@ -239,7 +239,7 @@ test("slugify", (assert) => {
   assert.equal(slugify(unicodeString), "", "it removes unicode characters");
 });
 
-test("fillMissingDates", (assert) => {
+test("fillMissingDates", function (assert) {
   const startDate = "2017-11-12"; // YYYY-MM-DD
   const endDate = "2017-12-12"; // YYYY-MM-DD
   const data =
@@ -252,7 +252,7 @@ test("fillMissingDates", (assert) => {
   );
 });
 
-test("inCodeBlock", (assert) => {
+test("inCodeBlock", function (assert) {
   const text =
     "000\n\n```\n111\n```\n\n000\n\n`111 111`\n\n000\n\n[code]\n111\n[/code]\n\n    111\n\t111\n\n000`000";
   for (let i = 0; i < text.length; ++i) {
@@ -264,7 +264,7 @@ test("inCodeBlock", (assert) => {
   }
 });
 
-skip("inCodeBlock - runs fast", (assert) => {
+skip("inCodeBlock - runs fast", function (assert) {
   const phrase = "Lorem ipsum dolor sit amet, consectetur adipiscing elit.";
   const text = `${phrase}\n\n\`\`\`\n${phrase}\n\`\`\`\n\n${phrase}\n\n\`${phrase}\n${phrase}\n\n${phrase}\n\n[code]\n${phrase}\n[/code]\n\n${phrase}\n\n    ${phrase}\n\n\`${phrase}\`\n\n${phrase}`;
 

--- a/app/assets/javascripts/discourse/tests/unit/mixins/setting-object-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/mixins/setting-object-test.js
@@ -4,7 +4,7 @@ import Setting from "admin/mixins/setting-object";
 
 module("mixin:setting-object");
 
-test("flat array", (assert) => {
+test("flat array", function (assert) {
   const FooSetting = EmberObject.extend(Setting);
 
   const fooSettingInstance = FooSetting.create({
@@ -15,7 +15,7 @@ test("flat array", (assert) => {
   assert.equal(fooSettingInstance.computedNameProperty, null);
 });
 
-test("object", (assert) => {
+test("object", function (assert) {
   const FooSetting = EmberObject.extend(Setting);
 
   const fooSettingInstance = FooSetting.create({
@@ -26,7 +26,7 @@ test("object", (assert) => {
   assert.equal(fooSettingInstance.computedNameProperty, "name");
 });
 
-test("no values", (assert) => {
+test("no values", function (assert) {
   const FooSetting = EmberObject.extend(Setting);
 
   const fooSettingInstance = FooSetting.create({
@@ -37,7 +37,7 @@ test("no values", (assert) => {
   assert.equal(fooSettingInstance.computedNameProperty, null);
 });
 
-test("value/name properties defined", (assert) => {
+test("value/name properties defined", function (assert) {
   const FooSetting = EmberObject.extend(Setting);
 
   const fooSettingInstance = FooSetting.create({

--- a/app/assets/javascripts/discourse/tests/unit/mixins/singleton-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/mixins/singleton-test.js
@@ -4,7 +4,7 @@ import Singleton from "discourse/mixins/singleton";
 
 module("mixin:singleton");
 
-test("current", (assert) => {
+test("current", function (assert) {
   var DummyModel = EmberObject.extend({});
   DummyModel.reopenClass(Singleton);
 
@@ -22,7 +22,7 @@ test("current", (assert) => {
   );
 });
 
-test("currentProp reading", (assert) => {
+test("currentProp reading", function (assert) {
   var DummyModel = EmberObject.extend({});
   DummyModel.reopenClass(Singleton);
   var current = DummyModel.current();
@@ -39,7 +39,7 @@ test("currentProp reading", (assert) => {
   );
 });
 
-test("currentProp writing", (assert) => {
+test("currentProp writing", function (assert) {
   var DummyModel = EmberObject.extend({});
   DummyModel.reopenClass(Singleton);
 
@@ -66,7 +66,7 @@ test("currentProp writing", (assert) => {
   );
 });
 
-test("createCurrent", (assert) => {
+test("createCurrent", function (assert) {
   var Shoe = EmberObject.extend({});
   Shoe.reopenClass(Singleton, {
     createCurrent: function () {
@@ -81,7 +81,7 @@ test("createCurrent", (assert) => {
   );
 });
 
-test("createCurrent that returns null", (assert) => {
+test("createCurrent that returns null", function (assert) {
   var Missing = EmberObject.extend({});
   Missing.reopenClass(Singleton, {
     createCurrent: function () {

--- a/app/assets/javascripts/discourse/tests/unit/models/badge-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/badge-test.js
@@ -3,14 +3,14 @@ import Badge from "discourse/models/badge";
 
 module("model:badge");
 
-test("newBadge", (assert) => {
+test("newBadge", function (assert) {
   const badge1 = Badge.create({ name: "New Badge" }),
     badge2 = Badge.create({ id: 1, name: "Old Badge" });
   assert.ok(badge1.get("newBadge"), "badges without ids are new");
   assert.ok(!badge2.get("newBadge"), "badges with ids are not new");
 });
 
-test("createFromJson array", (assert) => {
+test("createFromJson array", function (assert) {
   const badgesJson = {
     badge_types: [{ id: 6, name: "Silver 1" }],
     badges: [
@@ -29,7 +29,7 @@ test("createFromJson array", (assert) => {
   );
 });
 
-test("createFromJson single", (assert) => {
+test("createFromJson single", function (assert) {
   const badgeJson = {
     badge_types: [{ id: 6, name: "Silver 1" }],
     badge: { id: 1126, name: "Badge 1", description: null, badge_type_id: 6 },
@@ -40,7 +40,7 @@ test("createFromJson single", (assert) => {
   assert.ok(!Array.isArray(badge), "does not returns an array");
 });
 
-test("updateFromJson", (assert) => {
+test("updateFromJson", function (assert) {
   const badgeJson = {
     badge_types: [{ id: 6, name: "Silver 1" }],
     badge: { id: 1126, name: "Badge 1", description: null, badge_type_id: 6 },
@@ -55,7 +55,7 @@ test("updateFromJson", (assert) => {
   );
 });
 
-test("save", (assert) => {
+test("save", function (assert) {
   assert.expect(0);
   const badge = Badge.create({
     name: "New Badge",
@@ -65,7 +65,7 @@ test("save", (assert) => {
   return badge.save(["name", "description", "badge_type_id"]);
 });
 
-test("destroy", (assert) => {
+test("destroy", function (assert) {
   assert.expect(0);
   const badge = Badge.create({
     name: "New Badge",

--- a/app/assets/javascripts/discourse/tests/unit/models/category-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/category-test.js
@@ -5,7 +5,7 @@ import Category from "discourse/models/category";
 
 module("model:category");
 
-test("slugFor", (assert) => {
+test("slugFor", function (assert) {
   const store = createStore();
 
   const slugFor = function (cat, val, text) {
@@ -60,7 +60,7 @@ test("slugFor", (assert) => {
   );
 });
 
-test("findBySlug", (assert) => {
+test("findBySlug", function (assert) {
   assert.expect(6);
 
   const store = createStore();
@@ -124,7 +124,7 @@ test("findBySlug", (assert) => {
   sinon.restore();
 });
 
-test("findSingleBySlug", (assert) => {
+test("findSingleBySlug", function (assert) {
   assert.expect(6);
 
   const store = createStore();
@@ -186,7 +186,7 @@ test("findSingleBySlug", (assert) => {
   );
 });
 
-test("findBySlugPathWithID", (assert) => {
+test("findBySlugPathWithID", function (assert) {
   const store = createStore();
 
   const foo = store.createRecord("category", { id: 1, slug: "foo" });
@@ -210,7 +210,7 @@ test("findBySlugPathWithID", (assert) => {
   assert.deepEqual(Category.findBySlugPathWithID("foo/baz/3"), baz);
 });
 
-test("search with category name", (assert) => {
+test("search with category name", function (assert) {
   const store = createStore(),
     category1 = store.createRecord("category", {
       id: 1,
@@ -299,7 +299,7 @@ test("search with category name", (assert) => {
   sinon.restore();
 });
 
-test("search with category slug", (assert) => {
+test("search with category slug", function (assert) {
   const store = createStore(),
     category1 = store.createRecord("category", {
       id: 1,

--- a/app/assets/javascripts/discourse/tests/unit/models/composer-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/composer-test.js
@@ -29,7 +29,7 @@ function openComposer(opts) {
   return composer;
 }
 
-test("replyLength", (assert) => {
+test("replyLength", function (assert) {
   const replyLength = function (val, expectedLength) {
     const composer = createComposer({ reply: val });
     assert.equal(composer.get("replyLength"), expectedLength);
@@ -133,7 +133,7 @@ test("missingTitleCharacters", function (assert) {
   );
 });
 
-test("replyDirty", (assert) => {
+test("replyDirty", function (assert) {
   const composer = createComposer();
   assert.ok(!composer.get("replyDirty"), "by default it's false");
 
@@ -150,7 +150,7 @@ test("replyDirty", (assert) => {
   assert.ok(composer.get("replyDirty"), "it's true when the reply changes");
 });
 
-test("appendText", (assert) => {
+test("appendText", function (assert) {
   const composer = createComposer();
 
   assert.blank(composer.get("reply"), "the reply is blank by default");
@@ -183,7 +183,7 @@ test("appendText", (assert) => {
   assert.equal(composer.get("reply"), "c\n\nab");
 });
 
-test("prependText", (assert) => {
+test("prependText", function (assert) {
   const composer = createComposer();
 
   assert.blank(composer.get("reply"), "the reply is blank by default");
@@ -236,7 +236,7 @@ test("Title length for private messages", function (assert) {
   assert.ok(composer.get("titleLengthValid"), "in the range is okay");
 });
 
-test("Post length for private messages with non human users", (assert) => {
+test("Post length for private messages with non human users", function (assert) {
   const composer = createComposer({
     topic: EmberObject.create({ pm_with_non_human_user: true }),
   });
@@ -244,7 +244,7 @@ test("Post length for private messages with non human users", (assert) => {
   assert.equal(composer.get("minimumPostLength"), 1);
 });
 
-test("editingFirstPost", (assert) => {
+test("editingFirstPost", function (assert) {
   const composer = createComposer();
   assert.ok(!composer.get("editingFirstPost"), "it's false by default");
 
@@ -262,7 +262,7 @@ test("editingFirstPost", (assert) => {
   );
 });
 
-test("clearState", (assert) => {
+test("clearState", function (assert) {
   const composer = createComposer({
     originalText: "asdf",
     reply: "asdf2",
@@ -301,7 +301,7 @@ test("initial category when uncategorized is not allowed", function (assert) {
   );
 });
 
-test("open with a quote", (assert) => {
+test("open with a quote", function (assert) {
   const quote =
     '[quote="neil, post:5, topic:413"]\nSimmer down you two.\n[/quote]';
   const newComposer = function () {
@@ -397,7 +397,7 @@ test("allows featured link before choosing a category", function (assert) {
   assert.ok(composer.get("canEditTopicFeaturedLink"), "can paste link");
 });
 
-test("targetRecipientsArray contains types", (assert) => {
+test("targetRecipientsArray contains types", function (assert) {
   let composer = createComposer({
     targetRecipients: "test,codinghorror,staff,foo@bar.com",
   });

--- a/app/assets/javascripts/discourse/tests/unit/models/email-log-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/email-log-test.js
@@ -4,11 +4,11 @@ import { setPrefix } from "discourse-common/lib/get-url";
 
 module("model:email-log");
 
-test("create", (assert) => {
+test("create", function (assert) {
   assert.ok(EmailLog.create(), "it can be created without arguments");
 });
 
-test("subfolder support", (assert) => {
+test("subfolder support", function (assert) {
   setPrefix("/forum");
   const attrs = {
     id: 60,

--- a/app/assets/javascripts/discourse/tests/unit/models/group-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/group-test.js
@@ -3,7 +3,7 @@ import Group from "discourse/models/group";
 
 module("model:group");
 
-test("displayName", (assert) => {
+test("displayName", function (assert) {
   const group = Group.create({ name: "test", display_name: "donkey" });
 
   assert.equal(

--- a/app/assets/javascripts/discourse/tests/unit/models/invite-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/invite-test.js
@@ -3,6 +3,6 @@ import Invite from "discourse/models/invite";
 
 module("model:invite");
 
-test("create", (assert) => {
+test("create", function (assert) {
   assert.ok(Invite.create(), "it can be created without arguments");
 });

--- a/app/assets/javascripts/discourse/tests/unit/models/nav-item-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/nav-item-test.js
@@ -17,7 +17,7 @@ module("NavItem", {
   },
 });
 
-test("href", (assert) => {
+test("href", function (assert) {
   assert.expect(2);
 
   function href(text, expected, label) {
@@ -28,7 +28,7 @@ test("href", (assert) => {
   href("categories", "/categories", "categories");
 });
 
-test("count", (assert) => {
+test("count", function (assert) {
   const navItem = createStore().createRecord("nav-item", { name: "new" });
 
   assert.equal(navItem.get("count"), 0, "it has no count by default");

--- a/app/assets/javascripts/discourse/tests/unit/models/post-stream-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/post-stream-test.js
@@ -21,7 +21,7 @@ const buildStream = function (id, stream) {
 
 const participant = { username: "eviltrout" };
 
-test("create", (assert) => {
+test("create", function (assert) {
   const store = createStore();
   assert.ok(
     store.createRecord("postStream"),
@@ -29,7 +29,7 @@ test("create", (assert) => {
   );
 });
 
-test("defaults", (assert) => {
+test("defaults", function (assert) {
   const postStream = buildStream(1234);
   assert.blank(
     postStream.get("posts"),
@@ -39,7 +39,7 @@ test("defaults", (assert) => {
   assert.present(postStream.get("topic"));
 });
 
-test("appending posts", (assert) => {
+test("appending posts", function (assert) {
   const postStream = buildStream(4567, [1, 3, 4]);
   const store = postStream.store;
 
@@ -110,7 +110,7 @@ test("appending posts", (assert) => {
   );
 });
 
-test("closestPostNumberFor", (assert) => {
+test("closestPostNumberFor", function (assert) {
   const postStream = buildStream(1231);
   const store = postStream.store;
 
@@ -144,7 +144,7 @@ test("closestPostNumberFor", (assert) => {
   );
 });
 
-test("closestDaysAgoFor", (assert) => {
+test("closestDaysAgoFor", function (assert) {
   const postStream = buildStream(1231);
   postStream.set("timelineLookup", [
     [1, 10],
@@ -167,14 +167,14 @@ test("closestDaysAgoFor", (assert) => {
   assert.equal(postStream.closestDaysAgoFor(1), undefined);
 });
 
-test("closestDaysAgoFor - empty", (assert) => {
+test("closestDaysAgoFor - empty", function (assert) {
   const postStream = buildStream(1231);
   postStream.set("timelineLookup", []);
 
   assert.equal(postStream.closestDaysAgoFor(1), null);
 });
 
-test("updateFromJson", (assert) => {
+test("updateFromJson", function (assert) {
   const postStream = buildStream(1231);
 
   postStream.updateFromJson({
@@ -189,7 +189,7 @@ test("updateFromJson", (assert) => {
   assert.equal(postStream.get("extra_property"), 12);
 });
 
-test("removePosts", (assert) => {
+test("removePosts", function (assert) {
   const postStream = buildStream(10000001, [1, 2, 3]);
   const store = postStream.store;
 
@@ -210,7 +210,7 @@ test("removePosts", (assert) => {
   assert.deepEqual(postStream.get("stream"), [2]);
 });
 
-test("cancelFilter", (assert) => {
+test("cancelFilter", function (assert) {
   const postStream = buildStream(1235);
 
   sinon.stub(postStream, "refresh").returns(Promise.resolve());
@@ -227,7 +227,7 @@ test("cancelFilter", (assert) => {
   );
 });
 
-test("findPostIdForPostNumber", (assert) => {
+test("findPostIdForPostNumber", function (assert) {
   const postStream = buildStream(1234, [10, 20, 30, 40, 50, 60, 70]);
   postStream.set("gaps", { before: { 60: [55, 58] } });
 
@@ -249,7 +249,7 @@ test("findPostIdForPostNumber", (assert) => {
   assert.equal(postStream.findPostIdForPostNumber(8), 60, "it respects gaps");
 });
 
-test("fillGapBefore", (assert) => {
+test("fillGapBefore", function (assert) {
   const postStream = buildStream(1234, [60]);
   sinon.stub(postStream, "findPostsByIds").returns(Promise.resolve([]));
   let post = postStream.store.createRecord("post", { id: 60, post_number: 60 });
@@ -266,7 +266,7 @@ test("fillGapBefore", (assert) => {
   );
 });
 
-test("toggleParticipant", (assert) => {
+test("toggleParticipant", function (assert) {
   const postStream = buildStream(1236);
   sinon.stub(postStream, "refresh").returns(Promise.resolve());
 
@@ -289,7 +289,7 @@ test("toggleParticipant", (assert) => {
   );
 });
 
-test("streamFilters", (assert) => {
+test("streamFilters", function (assert) {
   const postStream = buildStream(1237);
   sinon.stub(postStream, "refresh").returns(Promise.resolve());
 
@@ -318,7 +318,7 @@ test("streamFilters", (assert) => {
   );
 });
 
-test("loading", (assert) => {
+test("loading", function (assert) {
   let postStream = buildStream(1234);
   assert.ok(!postStream.get("loading"), "we're not loading by default");
 
@@ -334,7 +334,7 @@ test("loading", (assert) => {
   assert.ok(postStream.get("loading"), "we're loading if loading a filter");
 });
 
-test("nextWindow", (assert) => {
+test("nextWindow", function (assert) {
   const postStream = buildStream(1234, [
     1,
     2,
@@ -376,7 +376,7 @@ test("nextWindow", (assert) => {
   );
 });
 
-test("previousWindow", (assert) => {
+test("previousWindow", function (assert) {
   const postStream = buildStream(1234, [
     1,
     2,
@@ -418,7 +418,7 @@ test("previousWindow", (assert) => {
   );
 });
 
-test("storePost", (assert) => {
+test("storePost", function (assert) {
   const postStream = buildStream(1234),
     store = postStream.store,
     post = store.createRecord("post", {
@@ -466,7 +466,7 @@ test("storePost", (assert) => {
   assert.equal(stored, postWithoutId, "it returns the same post back");
 });
 
-test("identity map", async (assert) => {
+test("identity map", async function (assert) {
   const postStream = buildStream(1234);
   const store = postStream.store;
 
@@ -492,12 +492,12 @@ test("identity map", async (assert) => {
   assert.equal(result.objectAt(2), p3);
 });
 
-test("loadIntoIdentityMap with no data", async (assert) => {
+test("loadIntoIdentityMap with no data", async function (assert) {
   const result = await buildStream(1234).loadIntoIdentityMap([]);
   assert.equal(result.length, 0, "requesting no posts produces no posts");
 });
 
-test("loadIntoIdentityMap with post ids", async (assert) => {
+test("loadIntoIdentityMap with post ids", async function (assert) {
   const postStream = buildStream(1234);
   await postStream.loadIntoIdentityMap([10]);
 
@@ -507,7 +507,7 @@ test("loadIntoIdentityMap with post ids", async (assert) => {
   );
 });
 
-test("appendMore for megatopic", async (assert) => {
+test("appendMore for megatopic", async function (assert) {
   const postStream = buildStream(1234);
   const store = createStore();
   const post = store.createRecord("post", { id: 1, post_number: 1 });
@@ -530,7 +530,7 @@ test("appendMore for megatopic", async (assert) => {
   );
 });
 
-test("prependMore for megatopic", async (assert) => {
+test("prependMore for megatopic", async function (assert) {
   const postStream = buildStream(1234);
   const store = createStore();
   const post = store.createRecord("post", { id: 6, post_number: 6 });
@@ -553,7 +553,7 @@ test("prependMore for megatopic", async (assert) => {
   );
 });
 
-test("staging and undoing a new post", (assert) => {
+test("staging and undoing a new post", function (assert) {
   const postStream = buildStream(10101, [1]);
   const store = postStream.store;
 
@@ -654,7 +654,7 @@ test("staging and undoing a new post", (assert) => {
   );
 });
 
-test("staging and committing a post", (assert) => {
+test("staging and committing a post", function (assert) {
   const postStream = buildStream(10101, [1]);
   const store = postStream.store;
 
@@ -733,7 +733,7 @@ test("staging and committing a post", (assert) => {
   );
 });
 
-test("loadedAllPosts when the id changes", (assert) => {
+test("loadedAllPosts when the id changes", function (assert) {
   // This can happen in a race condition between staging a post and it coming through on the
   // message bus. If the id of a post changes we should reconsider the loadedAllPosts property.
   const postStream = buildStream(10101, [1, 2]);
@@ -753,7 +753,7 @@ test("loadedAllPosts when the id changes", (assert) => {
   );
 });
 
-test("triggerRecoveredPost", async (assert) => {
+test("triggerRecoveredPost", async function (assert) {
   const postStream = buildStream(4567);
   const store = postStream.store;
 
@@ -786,7 +786,7 @@ test("triggerRecoveredPost", async (assert) => {
   );
 });
 
-test("comitting and triggerNewPostsInStream race condition", (assert) => {
+test("comitting and triggerNewPostsInStream race condition", function (assert) {
   const postStream = buildStream(4964);
   const store = postStream.store;
 
@@ -820,7 +820,7 @@ test("comitting and triggerNewPostsInStream race condition", (assert) => {
   );
 });
 
-test("triggerNewPostInStream for ignored posts", async (assert) => {
+test("triggerNewPostInStream for ignored posts", async function (assert) {
   const postStream = buildStream(280, [1]);
   const store = postStream.store;
   User.resetCurrent(
@@ -878,7 +878,7 @@ test("triggerNewPostInStream for ignored posts", async (assert) => {
   );
 });
 
-test("postsWithPlaceholders", async (assert) => {
+test("postsWithPlaceholders", async function (assert) {
   const postStream = buildStream(4964, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
   const postsWithPlaceholders = postStream.get("postsWithPlaceholders");
   const store = postStream.store;
@@ -927,7 +927,7 @@ test("postsWithPlaceholders", async (assert) => {
   assert.equal(testProxy.objectAt(3), p4);
 });
 
-test("filteredPostsCount", (assert) => {
+test("filteredPostsCount", function (assert) {
   const postStream = buildStream(4567, [1, 3, 4]);
 
   assert.equal(postStream.get("filteredPostsCount"), 3);
@@ -939,7 +939,7 @@ test("filteredPostsCount", (assert) => {
   assert.equal(postStream.get("filteredPostsCount"), 4);
 });
 
-test("firstPostId", (assert) => {
+test("firstPostId", function (assert) {
   const postStream = buildStream(4567, [1, 3, 4]);
 
   assert.equal(postStream.get("firstPostId"), 1);
@@ -952,7 +952,7 @@ test("firstPostId", (assert) => {
   assert.equal(postStream.get("firstPostId"), 2);
 });
 
-test("lastPostId", (assert) => {
+test("lastPostId", function (assert) {
   const postStream = buildStream(4567, [1, 3, 4]);
 
   assert.equal(postStream.get("lastPostId"), 4);
@@ -965,7 +965,7 @@ test("lastPostId", (assert) => {
   assert.equal(postStream.get("lastPostId"), 2);
 });
 
-test("progressIndexOfPostId", (assert) => {
+test("progressIndexOfPostId", function (assert) {
   const postStream = buildStream(4567, [1, 3, 4]);
   const store = createStore();
   const post = store.createRecord("post", { id: 1, post_number: 5 });

--- a/app/assets/javascripts/discourse/tests/unit/models/post-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/post-test.js
@@ -18,13 +18,13 @@ var buildPost = function (args) {
   );
 };
 
-test("defaults", (assert) => {
+test("defaults", function (assert) {
   var post = Post.create({ id: 1 });
   assert.blank(post.get("deleted_at"), "it has no deleted_at by default");
   assert.blank(post.get("deleted_by"), "there is no deleted_by by default");
 });
 
-test("new_user", (assert) => {
+test("new_user", function (assert) {
   var post = Post.create({ trust_level: 0 });
   assert.ok(post.get("new_user"), "post is from a new user");
 
@@ -32,7 +32,7 @@ test("new_user", (assert) => {
   assert.ok(!post.get("new_user"), "post is no longer from a new user");
 });
 
-test("firstPost", (assert) => {
+test("firstPost", function (assert) {
   var post = Post.create({ post_number: 1 });
   assert.ok(post.get("firstPost"), "it's the first post");
 
@@ -40,7 +40,7 @@ test("firstPost", (assert) => {
   assert.ok(!post.get("firstPost"), "post is no longer the first post");
 });
 
-test("updateFromPost", (assert) => {
+test("updateFromPost", function (assert) {
   var post = Post.create({
     post_number: 1,
     raw: "hello world",
@@ -58,7 +58,7 @@ test("updateFromPost", (assert) => {
   assert.equal(post.get("raw"), "different raw", "raw field updated");
 });
 
-test("destroy by staff", async (assert) => {
+test("destroy by staff", async function (assert) {
   let user = User.create({ username: "staff", moderator: true });
   let post = buildPost({ user: user });
 
@@ -83,7 +83,7 @@ test("destroy by staff", async (assert) => {
   );
 });
 
-test("destroy by non-staff", async (assert) => {
+test("destroy by non-staff", async function (assert) {
   const originalCooked = "this is the original cooked value";
   const user = User.create({ username: "evil trout" });
   const post = buildPost({ user: user, cooked: originalCooked });

--- a/app/assets/javascripts/discourse/tests/unit/models/report-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/report-test.js
@@ -16,7 +16,7 @@ function reportWithData(data) {
   });
 }
 
-test("counts", (assert) => {
+test("counts", function (assert) {
   const report = reportWithData([5, 4, 3, 2, 1, 100, 99, 98, 1000]);
 
   assert.equal(report.get("todayCount"), 5);
@@ -40,7 +40,7 @@ test("counts", (assert) => {
   );
 });
 
-test("percentChangeString", (assert) => {
+test("percentChangeString", function (assert) {
   const report = reportWithData([]);
 
   assert.equal(report.percentChangeString(5, 8), "+60%", "value increased");
@@ -57,19 +57,19 @@ test("percentChangeString", (assert) => {
   );
 });
 
-test("yesterdayCountTitle with valid values", (assert) => {
+test("yesterdayCountTitle with valid values", function (assert) {
   const title = reportWithData([6, 8, 5, 2, 1]).get("yesterdayCountTitle");
   assert.ok(title.indexOf("+60%") !== -1);
   assert.ok(title.match(/Was 5/));
 });
 
-test("yesterdayCountTitle when two days ago was 0", (assert) => {
+test("yesterdayCountTitle when two days ago was 0", function (assert) {
   const title = reportWithData([6, 8, 0, 2, 1]).get("yesterdayCountTitle");
   assert.equal(title.indexOf("%"), -1);
   assert.ok(title.match(/Was 0/));
 });
 
-test("sevenDaysCountTitle", (assert) => {
+test("sevenDaysCountTitle", function (assert) {
   const title = reportWithData([
     100,
     1,
@@ -93,7 +93,7 @@ test("sevenDaysCountTitle", (assert) => {
   assert.ok(title.match(/Was 14/));
 });
 
-test("thirtyDaysCountTitle", (assert) => {
+test("thirtyDaysCountTitle", function (assert) {
   const report = reportWithData([5, 5, 5, 5]);
   report.set("prev30Days", 10);
   const title = report.get("thirtyDaysCountTitle");
@@ -102,7 +102,7 @@ test("thirtyDaysCountTitle", (assert) => {
   assert.ok(title.match(/Was 10/));
 });
 
-test("sevenDaysTrend", (assert) => {
+test("sevenDaysTrend", function (assert) {
   let report;
   let trend;
 
@@ -127,7 +127,7 @@ test("sevenDaysTrend", (assert) => {
   assert.ok(trend === "trending-down");
 });
 
-test("yesterdayTrend", (assert) => {
+test("yesterdayTrend", function (assert) {
   let report;
   let trend;
 
@@ -152,7 +152,7 @@ test("yesterdayTrend", (assert) => {
   assert.ok(trend === "trending-down");
 });
 
-test("thirtyDaysTrend", (assert) => {
+test("thirtyDaysTrend", function (assert) {
   let report;
   let trend;
 
@@ -342,7 +342,7 @@ test("thirtyDaysTrend", (assert) => {
   assert.ok(trend === "trending-down");
 });
 
-test("higher is better false", (assert) => {
+test("higher is better false", function (assert) {
   let report;
   let trend;
 
@@ -367,7 +367,7 @@ test("higher is better false", (assert) => {
   assert.ok(trend === "trending-up");
 });
 
-test("small variation (-2/+2% change) is no-change", (assert) => {
+test("small variation (-2/+2% change) is no-change", function (assert) {
   let report;
   let trend;
 
@@ -380,7 +380,7 @@ test("small variation (-2/+2% change) is no-change", (assert) => {
   assert.ok(trend === "no-change");
 });
 
-test("average", (assert) => {
+test("average", function (assert) {
   let report;
 
   report = reportWithData([5, 5, 5, 5, 5, 5, 5, 5]);
@@ -392,7 +392,7 @@ test("average", (assert) => {
   assert.ok(report.get("lastSevenDaysCount") === 35);
 });
 
-test("computed labels", (assert) => {
+test("computed labels", function (assert) {
   const data = [
     {
       username: "joffrey",

--- a/app/assets/javascripts/discourse/tests/unit/models/rest-model-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/rest-model-test.js
@@ -6,7 +6,7 @@ import createStore from "discourse/tests/helpers/create-store";
 import RestModel from "discourse/models/rest";
 import RestAdapter from "discourse/adapters/rest";
 
-test("munging", (assert) => {
+test("munging", function (assert) {
   const store = createStore();
   const Grape = RestModel.extend();
   Grape.reopenClass({
@@ -20,7 +20,7 @@ test("munging", (assert) => {
   assert.equal(g.get("inverse"), 0.6, "it runs `munge` on `create`");
 });
 
-test("update", async (assert) => {
+test("update", async function (assert) {
   const store = createStore();
   const widget = await store.find("widget", 123);
   assert.equal(widget.get("name"), "Trout Lure");
@@ -41,7 +41,7 @@ test("update", async (assert) => {
   assert.equal(result.target.name, widget.get("name"));
 });
 
-test("updating simultaneously", async (assert) => {
+test("updating simultaneously", async function (assert) {
   assert.expect(2);
 
   const store = createStore();
@@ -59,7 +59,7 @@ test("updating simultaneously", async (assert) => {
   });
 });
 
-test("save new", async (assert) => {
+test("save new", async function (assert) {
   const store = createStore();
   const widget = store.createRecord("widget");
 
@@ -85,7 +85,7 @@ test("save new", async (assert) => {
   assert.equal(result.target.name, widget.get("name"));
 });
 
-test("creating simultaneously", (assert) => {
+test("creating simultaneously", function (assert) {
   assert.expect(2);
 
   const store = createStore();
@@ -102,14 +102,14 @@ test("creating simultaneously", (assert) => {
   });
 });
 
-test("destroyRecord", async (assert) => {
+test("destroyRecord", async function (assert) {
   const store = createStore();
   const widget = await store.find("widget", 123);
 
   assert.ok(await widget.destroyRecord());
 });
 
-test("custom api name", async (assert) => {
+test("custom api name", async function (assert) {
   const store = createStore((type) => {
     if (type === "adapter:my-widget") {
       return RestAdapter.extend({

--- a/app/assets/javascripts/discourse/tests/unit/models/result-set-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/result-set-test.js
@@ -4,7 +4,7 @@ module("result-set");
 import ResultSet from "discourse/models/result-set";
 import createStore from "discourse/tests/helpers/create-store";
 
-test("defaults", (assert) => {
+test("defaults", function (assert) {
   const resultSet = ResultSet.create({ content: [] });
   assert.equal(resultSet.get("length"), 0);
   assert.equal(resultSet.get("totalRows"), 0);
@@ -14,7 +14,7 @@ test("defaults", (assert) => {
   assert.ok(!resultSet.get("refreshing"));
 });
 
-test("pagination support", async (assert) => {
+test("pagination support", async function (assert) {
   const store = createStore();
   const resultSet = await store.findAll("widget");
   assert.equal(resultSet.get("length"), 2);
@@ -33,7 +33,7 @@ test("pagination support", async (assert) => {
   assert.ok(!resultSet.get("canLoadMore"));
 });
 
-test("refresh support", async (assert) => {
+test("refresh support", async function (assert) {
   const store = createStore();
   const resultSet = await store.findAll("widget");
   assert.equal(

--- a/app/assets/javascripts/discourse/tests/unit/models/session-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/session-test.js
@@ -3,7 +3,7 @@ import Session from "discourse/models/session";
 
 module("model:session");
 
-test("highestSeenByTopic", (assert) => {
+test("highestSeenByTopic", function (assert) {
   const session = Session.current();
   assert.deepEqual(
     session.get("highestSeenByTopic"),

--- a/app/assets/javascripts/discourse/tests/unit/models/site-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/site-test.js
@@ -4,11 +4,11 @@ import Site from "discourse/models/site";
 
 module("model:site");
 
-test("create", (assert) => {
+test("create", function (assert) {
   assert.ok(Site.create(), "it can create with no parameters");
 });
 
-test("instance", (assert) => {
+test("instance", function (assert) {
   const site = Site.current();
 
   assert.present(site, "We have a current site singleton");
@@ -26,7 +26,7 @@ test("instance", (assert) => {
   );
 });
 
-test("create categories", (assert) => {
+test("create categories", function (assert) {
   const store = createStore();
   const site = store.createRecord("site", {
     categories: [

--- a/app/assets/javascripts/discourse/tests/unit/models/staff-action-log-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/staff-action-log-test.js
@@ -3,6 +3,6 @@ import StaffActionLog from "admin/models/staff-action-log";
 
 module("StaffActionLog");
 
-test("create", (assert) => {
+test("create", function (assert) {
   assert.ok(StaffActionLog.create(), "it can be created without arguments");
 });

--- a/app/assets/javascripts/discourse/tests/unit/models/store-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/store-test.js
@@ -3,7 +3,7 @@ module("service:store");
 
 import createStore from "discourse/tests/helpers/create-store";
 
-test("createRecord", (assert) => {
+test("createRecord", function (assert) {
   const store = createStore();
   const widget = store.createRecord("widget", { id: 111, name: "hello" });
 
@@ -12,7 +12,7 @@ test("createRecord", (assert) => {
   assert.equal(widget.get("id"), 111);
 });
 
-test("createRecord without an `id`", (assert) => {
+test("createRecord without an `id`", function (assert) {
   const store = createStore();
   const widget = store.createRecord("widget", { name: "hello" });
 
@@ -20,7 +20,7 @@ test("createRecord without an `id`", (assert) => {
   assert.ok(!widget.get("id"), "there is no id");
 });
 
-test("createRecord doesn't modify the input `id` field", (assert) => {
+test("createRecord doesn't modify the input `id` field", function (assert) {
   const store = createStore();
   const widget = store.createRecord("widget", { id: 1, name: "hello" });
 
@@ -32,7 +32,7 @@ test("createRecord doesn't modify the input `id` field", (assert) => {
   assert.equal(obj.id, 1, "it does not remove the id from the input");
 });
 
-test("createRecord without attributes", (assert) => {
+test("createRecord without attributes", function (assert) {
   const store = createStore();
   const widget = store.createRecord("widget");
 
@@ -40,7 +40,7 @@ test("createRecord without attributes", (assert) => {
   assert.ok(widget.get("isNew"), "it is a new record");
 });
 
-test("createRecord with a record as attributes returns that record from the map", (assert) => {
+test("createRecord with a record as attributes returns that record from the map", function (assert) {
   const store = createStore();
   const widget = store.createRecord("widget", { id: 33 });
   const secondWidget = store.createRecord("widget", { id: 33 });
@@ -48,7 +48,7 @@ test("createRecord with a record as attributes returns that record from the map"
   assert.equal(widget, secondWidget, "they should be the same");
 });
 
-test("find", async (assert) => {
+test("find", async function (assert) {
   const store = createStore();
 
   const widget = await store.find("widget", 123);
@@ -63,19 +63,19 @@ test("find", async (assert) => {
   assert.equal(widget.get("extras.hello"), "world", "extra attributes are set");
 });
 
-test("find with object id", async (assert) => {
+test("find with object id", async function (assert) {
   const store = createStore();
   const widget = await store.find("widget", { id: 123 });
   assert.equal(widget.get("firstObject.name"), "Trout Lure");
 });
 
-test("find with query param", async (assert) => {
+test("find with query param", async function (assert) {
   const store = createStore();
   const widget = await store.find("widget", { name: "Trout Lure" });
   assert.equal(widget.get("firstObject.id"), 123);
 });
 
-test("findStale with no stale results", async (assert) => {
+test("findStale with no stale results", async function (assert) {
   const store = createStore();
   const stale = store.findStale("widget", { name: "Trout Lure" });
 
@@ -89,20 +89,20 @@ test("findStale with no stale results", async (assert) => {
   );
 });
 
-test("update", async (assert) => {
+test("update", async function (assert) {
   const store = createStore();
   const result = await store.update("widget", 123, { name: "hello" });
   assert.ok(result);
 });
 
-test("update with a multi world name", async (assert) => {
+test("update with a multi world name", async function (assert) {
   const store = createStore();
   const result = await store.update("cool-thing", 123, { name: "hello" });
   assert.ok(result);
   assert.equal(result.payload.name, "hello");
 });
 
-test("findAll", async (assert) => {
+test("findAll", async function (assert) {
   const store = createStore();
   const result = await store.findAll("widget");
   assert.equal(result.get("length"), 2);
@@ -112,21 +112,21 @@ test("findAll", async (assert) => {
   assert.equal(widget.get("name"), "Evil Repellant");
 });
 
-test("destroyRecord", async (assert) => {
+test("destroyRecord", async function (assert) {
   const store = createStore();
   const widget = await store.find("widget", 123);
 
   assert.ok(await store.destroyRecord("widget", widget));
 });
 
-test("destroyRecord when new", async (assert) => {
+test("destroyRecord when new", async function (assert) {
   const store = createStore();
   const widget = store.createRecord("widget", { name: "hello" });
 
   assert.ok(await store.destroyRecord("widget", widget));
 });
 
-test("find embedded", async (assert) => {
+test("find embedded", async function (assert) {
   const store = createStore();
   const fruit = await store.find("fruit", 1);
   assert.ok(fruit.get("farmer"), "it has the embedded object");
@@ -139,7 +139,7 @@ test("find embedded", async (assert) => {
   assert.ok(fruit.get("category"), "categories are found automatically");
 });
 
-test("embedded records can be cleared", async (assert) => {
+test("embedded records can be cleared", async function (assert) {
   const store = createStore();
   let fruit = await store.find("fruit", 4);
   fruit.set("farmer", { dummy: "object" });
@@ -148,7 +148,7 @@ test("embedded records can be cleared", async (assert) => {
   assert.ok(!fruit.get("farmer"));
 });
 
-test("meta types", async (assert) => {
+test("meta types", async function (assert) {
   const store = createStore();
   const barn = await store.find("barn", 1);
   assert.equal(
@@ -158,7 +158,7 @@ test("meta types", async (assert) => {
   );
 });
 
-test("findAll embedded", async (assert) => {
+test("findAll embedded", async function (assert) {
   const store = createStore();
   const fruits = await store.findAll("fruit");
   assert.equal(fruits.objectAt(0).get("farmer.name"), "Old MacDonald");
@@ -181,7 +181,7 @@ test("findAll embedded", async (assert) => {
   assert.equal(fruits.objectAt(2).get("farmer.name"), "Luke Skywalker");
 });
 
-test("custom primaryKey", async (assert) => {
+test("custom primaryKey", async function (assert) {
   const store = createStore();
   const cats = await store.findAll("cat");
   assert.equal(cats.objectAt(0).name, "souna");

--- a/app/assets/javascripts/discourse/tests/unit/models/topic-details-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/topic-details-test.js
@@ -10,13 +10,13 @@ var buildDetails = function (id) {
   return topic.get("details");
 };
 
-test("defaults", (assert) => {
+test("defaults", function (assert) {
   var details = buildDetails(1234);
   assert.present(details, "the details are present by default");
   assert.ok(!details.get("loaded"), "details are not loaded by default");
 });
 
-test("updateFromJson", (assert) => {
+test("updateFromJson", function (assert) {
   var details = buildDetails(1234);
 
   details.updateFromJson({

--- a/app/assets/javascripts/discourse/tests/unit/models/topic-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/topic-test.js
@@ -8,14 +8,14 @@ import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
 
 discourseModule("model:topic");
 
-test("defaults", (assert) => {
+test("defaults", function (assert) {
   const topic = Topic.create({ id: 1234 });
 
   assert.blank(topic.get("deleted_at"), "deleted_at defaults to blank");
   assert.blank(topic.get("deleted_by"), "deleted_by defaults to blank");
 });
 
-test("visited", (assert) => {
+test("visited", function (assert) {
   const topic = Topic.create({
     highest_post_number: 2,
     last_read_post_number: 1,
@@ -36,7 +36,7 @@ test("visited", (assert) => {
   );
 });
 
-test("lastUnreadUrl", (assert) => {
+test("lastUnreadUrl", function (assert) {
   const category = EmberObject.create({
     navigate_to_first_post_after_read: true,
   });
@@ -53,7 +53,7 @@ test("lastUnreadUrl", (assert) => {
   assert.equal(topic.get("lastUnreadUrl"), "/t/hello/101/1");
 });
 
-test("has details", (assert) => {
+test("has details", function (assert) {
   const topic = Topic.create({ id: 1234 });
   const topicDetails = topic.get("details");
 
@@ -65,7 +65,7 @@ test("has details", (assert) => {
   );
 });
 
-test("has a postStream", (assert) => {
+test("has a postStream", function (assert) {
   const topic = Topic.create({ id: 1234 });
   const postStream = topic.get("postStream");
 
@@ -77,7 +77,7 @@ test("has a postStream", (assert) => {
   );
 });
 
-test("has suggestedTopics", (assert) => {
+test("has suggestedTopics", function (assert) {
   const topic = Topic.create({ suggested_topics: [{ id: 1 }, { id: 2 }] });
   const suggestedTopics = topic.get("suggestedTopics");
 
@@ -85,7 +85,7 @@ test("has suggestedTopics", (assert) => {
   assert.containsInstance(suggestedTopics, Topic);
 });
 
-test("category relationship", (assert) => {
+test("category relationship", function (assert) {
   // It finds the category by id
   const category = Category.list()[0];
   const topic = Topic.create({ id: 1111, category_id: category.get("id") });
@@ -93,7 +93,7 @@ test("category relationship", (assert) => {
   assert.equal(topic.get("category"), category);
 });
 
-test("updateFromJson", (assert) => {
+test("updateFromJson", function (assert) {
   const topic = Topic.create({ id: 1234 });
   const category = Category.list()[0];
 
@@ -110,7 +110,7 @@ test("updateFromJson", (assert) => {
   assert.equal(topic.get("category"), category);
 });
 
-test("recover", (assert) => {
+test("recover", function (assert) {
   const user = User.create({ username: "eviltrout" });
   const topic = Topic.create({
     id: 1234,
@@ -123,7 +123,7 @@ test("recover", (assert) => {
   assert.blank(topic.get("deleted_by"), "it clears deleted_by");
 });
 
-test("fancyTitle", (assert) => {
+test("fancyTitle", function (assert) {
   const topic = Topic.create({
     fancy_title: ":smile: with all :) the emojis :pear::peach:",
   });
@@ -152,7 +152,7 @@ test("fancyTitle direction", function (assert) {
   );
 });
 
-test("excerpt", (assert) => {
+test("excerpt", function (assert) {
   const topic = Topic.create({
     excerpt: "This is a test topic :smile:",
     pinned: true,

--- a/app/assets/javascripts/discourse/tests/unit/models/topic-tracking-state-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/topic-tracking-state-test.js
@@ -229,7 +229,7 @@ test("subscribe to category", function (assert) {
   );
 });
 
-test("getSubCategoryIds", (assert) => {
+test("getSubCategoryIds", function (assert) {
   const store = createStore();
   const foo = store.createRecord("category", { id: 1, slug: "foo" });
   const bar = store.createRecord("category", {
@@ -250,7 +250,7 @@ test("getSubCategoryIds", (assert) => {
   assert.deepEqual(Array.from(state.getSubCategoryIds(3)), [3]);
 });
 
-test("countNew", (assert) => {
+test("countNew", function (assert) {
   const store = createStore();
   const foo = store.createRecord("category", {
     id: 1,

--- a/app/assets/javascripts/discourse/tests/unit/models/user-action-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/user-action-test.js
@@ -3,7 +3,7 @@ import UserAction from "discourse/models/user-action";
 
 module("model: user-action");
 
-test("collapsing likes", (assert) => {
+test("collapsing likes", function (assert) {
   var actions = UserAction.collapseStream([
     UserAction.create({
       action_type: UserAction.TYPES.likes_given,

--- a/app/assets/javascripts/discourse/tests/unit/models/user-badge-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/user-badge-test.js
@@ -4,7 +4,7 @@ import badgeFixtures from "discourse/tests/fixtures/user-badges";
 
 module("model:user-badge");
 
-test("createFromJson single", (assert) => {
+test("createFromJson single", function (assert) {
   const userBadge = UserBadge.createFromJson(
     JSON.parse(JSON.stringify(badgeFixtures["/user_badges"]))
   );
@@ -26,7 +26,7 @@ test("createFromJson single", (assert) => {
   );
 });
 
-test("createFromJson array", (assert) => {
+test("createFromJson array", function (assert) {
   const userBadges = UserBadge.createFromJson(
     JSON.parse(JSON.stringify(badgeFixtures["/user-badges/:username"]))
   );
@@ -38,22 +38,22 @@ test("createFromJson array", (assert) => {
   );
 });
 
-test("findByUsername", async (assert) => {
+test("findByUsername", async function (assert) {
   const badges = await UserBadge.findByUsername("anne3");
   assert.ok(Array.isArray(badges), "returns an array");
 });
 
-test("findByBadgeId", async (assert) => {
+test("findByBadgeId", async function (assert) {
   const badges = await UserBadge.findByBadgeId(880);
   assert.ok(Array.isArray(badges), "returns an array");
 });
 
-test("grant", async (assert) => {
+test("grant", async function (assert) {
   const userBadge = await UserBadge.grant(1, "username");
   assert.ok(!Array.isArray(userBadge), "does not return an array");
 });
 
-test("revoke", async (assert) => {
+test("revoke", async function (assert) {
   assert.expect(0);
   const userBadge = UserBadge.create({ id: 1 });
   await userBadge.revoke();

--- a/app/assets/javascripts/discourse/tests/unit/models/user-drafts-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/user-drafts-test.js
@@ -6,7 +6,7 @@ import User from "discourse/models/user";
 
 module("model:user-drafts");
 
-test("stream", (assert) => {
+test("stream", function (assert) {
   const user = User.create({ id: 1, username: "eviltrout" });
   const stream = user.get("userDraftsStream");
   assert.present(stream, "a user has a drafts stream by default");
@@ -14,7 +14,7 @@ test("stream", (assert) => {
   assert.blank(stream.get("content"), "no content by default");
 });
 
-test("draft", (assert) => {
+test("draft", function (assert) {
   const drafts = [
     UserDraft.create({
       draft_key: "topic_1",

--- a/app/assets/javascripts/discourse/tests/unit/models/user-stream-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/user-stream-test.js
@@ -4,7 +4,7 @@ import User from "discourse/models/user";
 
 module("model: UserStream");
 
-test("basics", (assert) => {
+test("basics", function (assert) {
   var user = User.create({ id: 1, username: "eviltrout" });
   var stream = user.get("stream");
   assert.present(stream, "a user has a stream by default");
@@ -17,7 +17,7 @@ test("basics", (assert) => {
   assert.ok(!stream.get("loaded"), "the stream is not loaded by default");
 });
 
-test("filterParam", (assert) => {
+test("filterParam", function (assert) {
   var user = User.create({ id: 1, username: "eviltrout" });
   var stream = user.get("stream");
 

--- a/app/assets/javascripts/discourse/tests/unit/models/user-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/user-test.js
@@ -7,7 +7,7 @@ import pretender from "discourse/tests/helpers/create-pretender";
 
 module("model:user");
 
-test("staff", (assert) => {
+test("staff", function (assert) {
   var user = User.create({ id: 1, username: "eviltrout" });
 
   assert.ok(!user.get("staff"), "user is not staff");
@@ -19,7 +19,7 @@ test("staff", (assert) => {
   assert.ok(user.get("staff"), "admins are staff");
 });
 
-test("searchContext", (assert) => {
+test("searchContext", function (assert) {
   var user = User.create({ id: 1, username: "EvilTrout" });
 
   assert.deepEqual(
@@ -29,7 +29,7 @@ test("searchContext", (assert) => {
   );
 });
 
-test("isAllowedToUploadAFile", (assert) => {
+test("isAllowedToUploadAFile", function (assert) {
   var user = User.create({ trust_level: 0, admin: true });
   assert.ok(
     user.isAllowedToUploadAFile("image"),
@@ -43,7 +43,7 @@ test("isAllowedToUploadAFile", (assert) => {
   );
 });
 
-test("canMangeGroup", (assert) => {
+test("canMangeGroup", function (assert) {
   let user = User.create({ admin: true });
   let group = Group.create({ automatic: true });
 
@@ -72,7 +72,7 @@ test("canMangeGroup", (assert) => {
   );
 });
 
-test("resolvedTimezone", (assert) => {
+test("resolvedTimezone", function (assert) {
   const tz = "Australia/Brisbane";
   let user = User.create({ timezone: tz, username: "chuck", id: 111 });
   let stub = sinon.stub(moment.tz, "guess").returns("America/Chicago");
@@ -124,7 +124,7 @@ test("resolvedTimezone", (assert) => {
   stub.restore();
 });
 
-test("muted ids", (assert) => {
+test("muted ids", function (assert) {
   let user = User.create({ username: "chuck", muted_category_ids: [] });
 
   assert.deepEqual(user.calculateMutedIds(0, 1, "muted_category_ids"), [1]);

--- a/app/assets/javascripts/wizard/test/acceptance/wizard-test.js
+++ b/app/assets/javascripts/wizard/test/acceptance/wizard-test.js
@@ -18,13 +18,13 @@ function exists(selector) {
   return document.querySelector(selector) !== null;
 }
 
-test("Wizard starts", async (assert) => {
+test("Wizard starts", async function (assert) {
   await visit("/");
   assert.ok(exists(".wizard-column-contents"));
   assert.equal(currentPath(), "step");
 });
 
-test("Going back and forth in steps", async (assert) => {
+test("Going back and forth in steps", async function (assert) {
   await visit("/steps/hello-world");
   assert.ok(exists(".wizard-step"));
   assert.ok(

--- a/app/assets/javascripts/wizard/test/models/wizard-field-test.js
+++ b/app/assets/javascripts/wizard/test/models/wizard-field-test.js
@@ -4,14 +4,14 @@ import WizardField from "wizard/models/wizard-field";
 
 moduleFor("model:wizard-field");
 
-test("basic state", (assert) => {
+test("basic state", function (assert) {
   const w = WizardField.create({ type: "text" });
   assert.ok(w.get("unchecked"));
   assert.ok(!w.get("valid"));
   assert.ok(!w.get("invalid"));
 });
 
-test("text - required - validation", (assert) => {
+test("text - required - validation", function (assert) {
   const w = WizardField.create({ type: "text", required: true });
   assert.ok(w.get("unchecked"));
 
@@ -27,7 +27,7 @@ test("text - required - validation", (assert) => {
   assert.ok(!w.get("invalid"));
 });
 
-test("text - optional - validation", (assert) => {
+test("text - optional - validation", function (assert) {
   const f = WizardField.create({ type: "text" });
   assert.ok(f.get("unchecked"));
 

--- a/plugins/discourse-details/test/javascripts/acceptance/details-button-test.js.es6
+++ b/plugins/discourse-details/test/javascripts/acceptance/details-button-test.js.es6
@@ -7,7 +7,7 @@ acceptance("Details Button", function (needs) {
   needs.user();
   needs.hooks.beforeEach(() => clearPopupMenuOptionsCallback());
 
-  test("details button", async (assert) => {
+  test("details button", async function (assert) {
     const popupMenu = selectKit(".toolbar-popup-menu-options");
 
     await visit("/");
@@ -107,7 +107,7 @@ acceptance("Details Button", function (needs) {
     );
   });
 
-  test("details button surrounds all selected text in a single details block", async (assert) => {
+  test("details button surrounds all selected text in a single details block", async function (assert) {
     const multilineInput = "first line\n\nsecond line\n\nthird line";
     const popupMenu = selectKit(".toolbar-popup-menu-options");
 

--- a/plugins/discourse-details/test/javascripts/lib/details-cooked-test.js.es6
+++ b/plugins/discourse-details/test/javascripts/lib/details-cooked-test.js.es6
@@ -13,7 +13,7 @@ const defaultOpts = buildOptions({
   getURL: (url) => url,
 });
 
-test("details", (assert) => {
+test("details", function (assert) {
   const cooked = (input, expected, text) => {
     assert.equal(
       new PrettyText(defaultOpts).cook(input),

--- a/plugins/discourse-local-dates/test/javascripts/acceptance/local-dates-composer-test.js.es6
+++ b/plugins/discourse-local-dates/test/javascripts/acceptance/local-dates-composer-test.js.es6
@@ -4,7 +4,7 @@ acceptance("Local Dates - composer", function (needs) {
   needs.user();
   needs.settings({ discourse_local_dates_enabled: true });
 
-  test("composer bbcode", async (assert) => {
+  test("composer bbcode", async function (assert) {
     const getAttr = (attr) => {
       return queryAll(
         ".d-editor-preview .discourse-local-date.cooked-date"

--- a/plugins/discourse-local-dates/test/javascripts/lib/date-with-zone-helper-test.js.es6
+++ b/plugins/discourse-local-dates/test/javascripts/lib/date-with-zone-helper-test.js.es6
@@ -17,7 +17,7 @@ function buildDateHelper(params = {}) {
   });
 }
 
-test("#format", (assert) => {
+test("#format", function (assert) {
   let date = buildDateHelper({
     day: 15,
     month: 2,
@@ -28,7 +28,7 @@ test("#format", (assert) => {
   assert.equal(date.format(), "2020-03-15T15:36:00.000+01:00");
 });
 
-test("#repetitionsBetweenDates", (assert) => {
+test("#repetitionsBetweenDates", function (assert) {
   let date;
 
   date = buildDateHelper({
@@ -96,7 +96,7 @@ test("#repetitionsBetweenDates", (assert) => {
   );
 });
 
-test("#add", (assert) => {
+test("#add", function (assert) {
   let date;
   let futureLocalDate;
 

--- a/plugins/discourse-local-dates/test/javascripts/lib/local-date-builder-test.js.es6
+++ b/plugins/discourse-local-dates/test/javascripts/lib/local-date-builder-test.js.es6
@@ -61,7 +61,7 @@ QUnit.assert.buildsCorrectDate = function (options, expected, message) {
   }
 };
 
-test("date", (assert) => {
+test("date", function (assert) {
   freezeTime({ date: "2020-03-11" }, () => {
     assert.buildsCorrectDate(
       { date: "2020-03-22", timezone: PARIS },
@@ -71,7 +71,7 @@ test("date", (assert) => {
   });
 });
 
-test("date and time", (assert) => {
+test("date and time", function (assert) {
   assert.buildsCorrectDate(
     { date: "2020-04-11", time: "11:00" },
     { formated: "April 11, 2020 1:00 PM" },
@@ -85,7 +85,7 @@ test("date and time", (assert) => {
   );
 });
 
-test("option[format]", (assert) => {
+test("option[format]", function (assert) {
   freezeTime({ date: "2020-03-11" }, () => {
     assert.buildsCorrectDate(
       { format: "YYYY" },
@@ -95,7 +95,7 @@ test("option[format]", (assert) => {
   });
 });
 
-test("option[displayedTimezone]", (assert) => {
+test("option[displayedTimezone]", function (assert) {
   freezeTime({}, () => {
     assert.buildsCorrectDate(
       { displayedTimezone: SYDNEY },
@@ -129,7 +129,7 @@ test("option[displayedTimezone]", (assert) => {
   });
 });
 
-test("option[timezone]", (assert) => {
+test("option[timezone]", function (assert) {
   freezeTime({}, () => {
     assert.buildsCorrectDate(
       { timezone: SYDNEY, displayedTimezone: PARIS },
@@ -139,7 +139,7 @@ test("option[timezone]", (assert) => {
   });
 });
 
-test("option[recurring]", (assert) => {
+test("option[recurring]", function (assert) {
   freezeTime({ date: "2020-04-06 06:00", timezone: LAGOS }, () => {
     assert.buildsCorrectDate(
       {
@@ -219,7 +219,7 @@ test("option[recurring]", (assert) => {
   });
 });
 
-test("option[countown]", (assert) => {
+test("option[countown]", function (assert) {
   freezeTime({ date: "2020-03-21 23:59" }, () => {
     assert.buildsCorrectDate(
       {
@@ -247,7 +247,7 @@ test("option[countown]", (assert) => {
   });
 });
 
-test("option[calendar]", (assert) => {
+test("option[calendar]", function (assert) {
   freezeTime({ date: "2020-03-23 23:00" }, () => {
     assert.buildsCorrectDate(
       { date: "2020-03-22", time: "23:59", timezone: PARIS },
@@ -328,7 +328,7 @@ test("option[calendar]", (assert) => {
   });
 });
 
-test("previews", (assert) => {
+test("previews", function (assert) {
   freezeTime({ date: "2020-03-22" }, () => {
     assert.buildsCorrectDate(
       { timezone: PARIS },

--- a/plugins/poll/test/javascripts/acceptance/poll-breakdown-test.js.es6
+++ b/plugins/poll/test/javascripts/acceptance/poll-breakdown-test.js.es6
@@ -58,7 +58,7 @@ acceptance("Poll breakdown", function (needs) {
     );
   });
 
-  test("Displaying the poll breakdown modal", async (assert) => {
+  test("Displaying the poll breakdown modal", async function (assert) {
     await visit("/t/-/topic_with_pie_chart_poll");
 
     assert.equal(
@@ -87,7 +87,7 @@ acceptance("Poll breakdown", function (needs) {
     );
   });
 
-  test("Changing the display mode from percentage to count", async (assert) => {
+  test("Changing the display mode from percentage to count", async function (assert) {
     await visit("/t/-/topic_with_pie_chart_poll");
     await click(".poll-show-breakdown:first");
 

--- a/plugins/poll/test/javascripts/acceptance/poll-builder-disabled-test.js.es6
+++ b/plugins/poll/test/javascripts/acceptance/poll-builder-disabled-test.js.es6
@@ -14,7 +14,7 @@ acceptance("Poll Builder - polls are disabled", function (needs) {
   });
   needs.hooks.beforeEach(() => clearPopupMenuOptionsCallback());
 
-  test("regular user - sufficient trust level", async (assert) => {
+  test("regular user - sufficient trust level", async function (assert) {
     updateCurrentUser({ moderator: false, admin: false, trust_level: 3 });
 
     await displayPollBuilderButton();
@@ -25,7 +25,7 @@ acceptance("Poll Builder - polls are disabled", function (needs) {
     );
   });
 
-  test("regular user - insufficient trust level", async (assert) => {
+  test("regular user - insufficient trust level", async function (assert) {
     updateCurrentUser({ moderator: false, admin: false, trust_level: 1 });
 
     await displayPollBuilderButton();
@@ -36,7 +36,7 @@ acceptance("Poll Builder - polls are disabled", function (needs) {
     );
   });
 
-  test("staff", async (assert) => {
+  test("staff", async function (assert) {
     updateCurrentUser({ moderator: true });
 
     await displayPollBuilderButton();

--- a/plugins/poll/test/javascripts/acceptance/poll-builder-enabled-test.js.es6
+++ b/plugins/poll/test/javascripts/acceptance/poll-builder-enabled-test.js.es6
@@ -16,7 +16,7 @@ acceptance("Poll Builder - polls are enabled", function (needs) {
   });
   needs.hooks.beforeEach(() => clearPopupMenuOptionsCallback());
 
-  test("regular user - sufficient trust level", async (assert) => {
+  test("regular user - sufficient trust level", async function (assert) {
     updateCurrentUser({ moderator: false, admin: false, trust_level: 1 });
 
     await displayPollBuilderButton();
@@ -27,7 +27,7 @@ acceptance("Poll Builder - polls are enabled", function (needs) {
     );
   });
 
-  test("regular user - insufficient trust level", async (assert) => {
+  test("regular user - insufficient trust level", async function (assert) {
     updateCurrentUser({ moderator: false, admin: false, trust_level: 0 });
 
     await displayPollBuilderButton();
@@ -38,7 +38,7 @@ acceptance("Poll Builder - polls are enabled", function (needs) {
     );
   });
 
-  test("staff - with insufficient trust level", async (assert) => {
+  test("staff - with insufficient trust level", async function (assert) {
     updateCurrentUser({ moderator: true, trust_level: 0 });
 
     await displayPollBuilderButton();
@@ -49,7 +49,7 @@ acceptance("Poll Builder - polls are enabled", function (needs) {
     );
   });
 
-  test("poll preview", async (assert) => {
+  test("poll preview", async function (assert) {
     await displayPollBuilderButton();
 
     const popupMenu = selectKit(".toolbar-popup-menu-options");

--- a/plugins/poll/test/javascripts/acceptance/poll-pie-chart-test.js.es6
+++ b/plugins/poll/test/javascripts/acceptance/poll-pie-chart-test.js.es6
@@ -8,7 +8,7 @@ acceptance("Rendering polls with pie charts", function (needs) {
     poll_groupable_user_fields: "something",
   });
 
-  test("Displays the pie chart", async (assert) => {
+  test("Displays the pie chart", async function (assert) {
     await visit("/t/-/topic_with_pie_chart_poll");
 
     const poll = queryAll(".poll")[0];

--- a/plugins/poll/test/javascripts/acceptance/poll-quote-test.js.es6
+++ b/plugins/poll/test/javascripts/acceptance/poll-quote-test.js.es6
@@ -676,7 +676,7 @@ acceptance("Poll quote", function (needs) {
     });
   });
 
-  test("Quoted polls", async (assert) => {
+  test("Quoted polls", async function (assert) {
     await visit("/t/-/topic_with_two_quoted_polls");
     await click(".quote-controls");
     assert.equal(queryAll(".poll").length, 2);

--- a/plugins/poll/test/javascripts/acceptance/polls-bar-chart-test-desktop.js.es6
+++ b/plugins/poll/test/javascripts/acceptance/polls-bar-chart-test-desktop.js.es6
@@ -40,7 +40,7 @@ acceptance("Rendering polls with bar charts - desktop", function (needs) {
     });
   });
 
-  test("Polls", async (assert) => {
+  test("Polls", async function (assert) {
     await visit("/t/-/15");
 
     const polls = queryAll(".poll");
@@ -60,7 +60,7 @@ acceptance("Rendering polls with bar charts - desktop", function (needs) {
     );
   });
 
-  test("Public poll", async (assert) => {
+  test("Public poll", async function (assert) {
     await visit("/t/-/14");
 
     const polls = queryAll(".poll");
@@ -83,7 +83,7 @@ acceptance("Rendering polls with bar charts - desktop", function (needs) {
     );
   });
 
-  test("Public number poll", async (assert) => {
+  test("Public number poll", async function (assert) {
     await visit("/t/-/13");
 
     const polls = queryAll(".poll");

--- a/plugins/poll/test/javascripts/acceptance/polls-bar-chart-test-mobile.js.es6
+++ b/plugins/poll/test/javascripts/acceptance/polls-bar-chart-test-mobile.js.es6
@@ -22,7 +22,7 @@ acceptance("Rendering polls with bar charts - mobile", function (needs) {
     clearPopupMenuOptionsCallback();
   });
 
-  test("Public number poll", async (assert) => {
+  test("Public number poll", async function (assert) {
     await visit("/t/-/13");
 
     const polls = queryAll(".poll");


### PR DESCRIPTION
Using arrow functions changes `this` context, which is undesired in tests, e.g. it makes it impossible to setup things like pretender (`this.server`) in `beforeEach` hooks.

Ember guides always use classic functions in examples (e.g. https://guides.emberjs.com/release/testing/test-types/), and that's what it uses in its own test suite, as do various addons and ember apps.

It was also already used in Discourse where `this` was required. Moving forward, it will be needed in more places as we migrate toward ember-cli.

(I might later add a custom rule to eslint-discourse-ember to enforce this)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
