### PR TITLE
FIX: hide 'category read only banner' in categories list page.

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/discovery.js
+++ b/app/assets/javascripts/discourse/app/controllers/discovery.js
@@ -1,4 +1,4 @@
-import { alias, not } from "@ember/object/computed";
+import { alias, not, equal } from "@ember/object/computed";
 import Controller, { inject as controller } from "@ember/controller";
 import DiscourseURL from "discourse/lib/url";
 import Category from "discourse/models/category";
@@ -10,6 +10,10 @@ export default Controller.extend({
   navigationCategory: controller("navigation/category"),
   application: controller(),
   router: service(),
+  viewingCategoriesList: equal(
+    "router.currentRouteName",
+    "discovery.categories"
+  ),
 
   loading: false,
 

--- a/app/assets/javascripts/discourse/app/templates/discovery.hbs
+++ b/app/assets/javascripts/discourse/app/templates/discovery.hbs
@@ -3,7 +3,9 @@
 {{else}}
   <div class="container">
     {{discourse-banner user=currentUser banner=site.banner}}
-    {{category-read-only-banner category=category readOnly=navigationCategory.cannotCreateTopicOnCategory}}
+    {{#unless viewingCategoriesList}}
+      {{category-read-only-banner category=category readOnly=navigationCategory.cannotCreateTopicOnCategory}}
+    {{/unless}}
   </div>
 
   <div class="list-controls">


### PR DESCRIPTION
Previously, while navigating away from a single category page to the categories list page "category read-only" banner is not hiding automatically.
