### PR TITLE
Revert "FIX: adjust user card position, follow-up to da5841d (#11036)"

### DIFF
--- a/app/assets/javascripts/discourse/app/mixins/card-contents-base.js
+++ b/app/assets/javascripts/discourse/app/mixins/card-contents-base.js
@@ -211,6 +211,7 @@ export default Mixin.create({
               }
             }
 
+            position.top -= $("#main-outlet").offset().top;
             if (isFixed) {
               position.top -= $("html").scrollTop();
               //if content is fixed and will be cut off on the bottom, display it above...


### PR DESCRIPTION
This reverts commit 863f86c3a3045b410f340e4db07103d83d964a9a, looks like I misdiagnosed this issue in https://meta.discourse.org/t/user-cards-hidden-under-header/168320

