### PR TITLE
FIX: Disabled action buttons on newly-created category

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/edit-category-tabs.js
+++ b/app/assets/javascripts/discourse/app/controllers/edit-category-tabs.js
@@ -93,8 +93,8 @@ export default Controller.extend({
             model.setProperties({
               slug: result.category.slug,
               id: result.category.id,
-              createdCategory: true,
             });
+            this.session.requiresRefresh = true;
           }
         })
         .catch((error) => {
@@ -132,11 +132,7 @@ export default Controller.extend({
     },
 
     goBack() {
-      if (this.model.createdCategory) {
-        DiscourseURL.redirectTo(this.model.url);
-      } else {
-        DiscourseURL.routeTo(this.model.url);
-      }
+      DiscourseURL.routeTo(this.model.url);
     },
 
     toggleMenu() {

--- a/app/assets/javascripts/discourse/app/controllers/edit-category-tabs.js
+++ b/app/assets/javascripts/discourse/app/controllers/edit-category-tabs.js
@@ -5,6 +5,8 @@ import bootbox from "bootbox";
 import { extractError } from "discourse/lib/ajax-error";
 import DiscourseURL from "discourse/lib/url";
 import { readOnly } from "@ember/object/computed";
+import PermissionType from "discourse/models/permission-type";
+import { NotificationLevels } from "discourse/lib/notification-levels";
 
 export default Controller.extend({
   selectedTab: "general",
@@ -93,8 +95,10 @@ export default Controller.extend({
             model.setProperties({
               slug: result.category.slug,
               id: result.category.id,
+              permission: PermissionType.FULL,
+              notification_level: NotificationLevels.REGULAR,
             });
-            this.session.requiresRefresh = true;
+            this.site.updateCategory(model);
           }
         })
         .catch((error) => {

--- a/app/assets/javascripts/discourse/tests/acceptance/category-new-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/category-new-test.js
@@ -37,12 +37,12 @@ acceptance("Category New", function (needs) {
       "it can switch to the settings tab"
     );
 
-    sinon.stub(DiscourseURL, "redirectTo");
+    sinon.stub(DiscourseURL, "routeTo");
 
     await click(".category-back");
     assert.ok(
-      DiscourseURL.redirectTo.calledWith("/c/testing/11"),
-      "it full page redirects after a newly created category"
+      DiscourseURL.routeTo.calledWith("/c/testing/11"),
+      "back routing works"
     );
   });
 });


### PR DESCRIPTION
Bug reported in https://meta.discourse.org/t/cant-create-a-new-topic-in-a-subcategory-newly-created-unless-we-reload-the-page/168694/2 

This ensures the newly created category record gives the current user permission to create a new topic and sets her notification level to the default value. 