### PR TITLE
DEV: Track redis calls count in mini profiler

### DIFF
--- a/config/initializers/006-mini_profiler.rb
+++ b/config/initializers/006-mini_profiler.rb
@@ -76,6 +76,7 @@ if defined?(Rack::MiniProfiler) && defined?(Rack::MiniProfiler::Config)
 
   Rack::MiniProfiler.config.backtrace_includes = [/^\/?(app|config|lib|test|plugins)/]
 
+  Rack::MiniProfiler.counter_method(Redis::Client, :call) { 'redis' }
   # Rack::MiniProfiler.counter_method(ActiveRecord::QueryMethods, 'build_arel')
   # Rack::MiniProfiler.counter_method(Array, 'uniq')
   # require "#{Rails.root}/vendor/backports/notification"


### PR DESCRIPTION
This adds metrics about redis like queries count and time in mini profiler.

![image](https://user-images.githubusercontent.com/17474474/97726788-ab11d080-1ae0-11eb-9ae9-9ed0ff06e830.png)