### PR TITLE
FIX: Category drop shows undefined

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/category-row.js
+++ b/app/assets/javascripts/select-kit/addon/components/category-row.js
@@ -39,9 +39,11 @@ export default SelectKitRowComponent.extend({
     "description",
     "categoryName",
     function () {
-      return htmlToText(
-        this.descriptionText || this.description || this.categoryName
-      );
+      if (this.category) {
+        return htmlToText(
+          this.descriptionText || this.description || this.categoryName
+        );
+      }
     }
   ),
 


### PR DESCRIPTION
After 5fc239b535ece3e4b0c70298b2bc6c62f160d373, the category dropdown was showing "undefined" for the "all-categories" and "no-categories" messages. This commit introduces a check to run the HTML parser only if we're dealing with a real category, which fixes the above issue.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
