### PR TITLE
FEATURE: Mailing list mode default disabled

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2188,7 +2188,7 @@ user_preferences:
     enum: "MailingListModeSiteSetting"
     default: 1
   disable_mailing_list_mode:
-    default: false
+    default: true
     client: true
   default_email_previous_replies:
     enum: "PreviousRepliesSiteSetting"

--- a/spec/models/topic_user_spec.rb
+++ b/spec/models/topic_user_spec.rb
@@ -453,6 +453,7 @@ describe TopicUser do
       user1 = Fabricate(:user)
 
       Jobs.run_immediately!
+      SiteSetting.disable_mailing_list_mode = false
       SiteSetting.default_email_mailing_list_mode = true
       SiteSetting.default_email_mailing_list_mode_frequency = 1
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1651,6 +1651,7 @@ describe User do
       SiteSetting.default_email_digest_frequency = 1440 # daily
       SiteSetting.default_email_level = UserOption.email_level_types[:never]
       SiteSetting.default_email_messages_level = UserOption.email_level_types[:never]
+      SiteSetting.disable_mailing_list_mode = false
       SiteSetting.default_email_mailing_list_mode = true
 
       SiteSetting.default_other_new_topic_duration_minutes = -1 # not viewed

--- a/spec/requests/email_controller_spec.rb
+++ b/spec/requests/email_controller_spec.rb
@@ -211,7 +211,8 @@ RSpec.describe EmailController do
         expect(body).not_to include("Don&#39;t send me any mail from Discourse")
       end
 
-      it 'correctly handles mailing list mode' do
+      it 'correctly handles mailing list mode' d
+        SiteSetting.disable_mailing_list_mode = false
         user.user_option.update_columns(mailing_list_mode: true)
 
         navigate_to_unsubscribe

--- a/spec/requests/email_controller_spec.rb
+++ b/spec/requests/email_controller_spec.rb
@@ -211,7 +211,7 @@ RSpec.describe EmailController do
         expect(body).not_to include("Don&#39;t send me any mail from Discourse")
       end
 
-      it 'correctly handles mailing list mode' d
+      it 'correctly handles mailing list mode' do
         SiteSetting.disable_mailing_list_mode = false
         user.user_option.update_columns(mailing_list_mode: true)
 

--- a/spec/services/user_updater_spec.rb
+++ b/spec/services/user_updater_spec.rb
@@ -143,6 +143,7 @@ describe UserUpdater do
       user = Fabricate(:user)
       updater = UserUpdater.new(acting_user, user)
       date_of_birth = Time.zone.now
+      SiteSetting.disable_mailing_list_mode = false
 
       theme = Fabricate(:theme, user_selectable: true)
 
@@ -213,6 +214,7 @@ describe UserUpdater do
     it "disables email_digests when enabling mailing_list_mode" do
       user = Fabricate(:user)
       updater = UserUpdater.new(acting_user, user)
+      SiteSetting.disable_mailing_list_mode = false
 
       val = updater.update(mailing_list_mode: true, email_digests: true)
       expect(val).to be_truthy


### PR DESCRIPTION
Mailing list mode can generate significant email volume, especially on sites with a large userbase. Disable mailing list mode via site settings by default so sites don't experience an unexpectedly large cost from outgoing email.