### PR TITLE
REFACTOR: Remove `window.sinon` and `window.MouseTrap` from tests

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
+++ b/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
@@ -118,6 +118,8 @@ export default {
   },
 
   teardown() {
+    this.keyTrapper.reset();
+    this.keyTrapper = null;
     this.container = null;
   },
 

--- a/app/assets/javascripts/discourse/tests/setup-tests.js
+++ b/app/assets/javascripts/discourse/tests/setup-tests.js
@@ -76,7 +76,7 @@ export default function setupTests(app, container) {
           dropFrom: "2.6.0",
         }
       );
-      return window.sinon;
+      return sinon;
     },
   });
   Object.defineProperty(window, "exists", {
@@ -121,7 +121,8 @@ export default function setupTests(app, container) {
       const error =
         "Unhandled request in test environment: " + path + " (" + verb + ")";
 
-      window.console.error(error);
+      // eslint-disable-next-line no-console
+      console.error(error);
       throw new Error(error);
     };
 
@@ -144,16 +145,16 @@ export default function setupTests(app, container) {
 
     PreloadStore.reset();
 
-    window.sinon.stub(ScrollingDOMMethods, "screenNotFull");
-    window.sinon.stub(ScrollingDOMMethods, "bindOnScroll");
-    window.sinon.stub(ScrollingDOMMethods, "unbindOnScroll");
+    sinon.stub(ScrollingDOMMethods, "screenNotFull");
+    sinon.stub(ScrollingDOMMethods, "bindOnScroll");
+    sinon.stub(ScrollingDOMMethods, "unbindOnScroll");
 
     // Unless we ever need to test this, let's leave it off.
     $.fn.autocomplete = function () {};
   });
 
   QUnit.testDone(function () {
-    window.sinon.restore();
+    sinon.restore();
 
     // Destroy any modals
     $(".modal-backdrop").remove();
@@ -166,7 +167,6 @@ export default function setupTests(app, container) {
 
     MessageBus.unsubscribe("*");
     server = null;
-    window.Mousetrap.reset();
   });
 
   // Load ES6 tests


### PR DESCRIPTION
Also allow us to reset mousetrap in a teardown method.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
