### PR TITLE
FIX: Correct casing of whitelisted SVG elements

### DIFF
--- a/lib/upload_creator.rb
+++ b/lib/upload_creator.rb
@@ -9,7 +9,7 @@ class UploadCreator
   ALLOWED_SVG_ELEMENTS ||= %w{
     circle clipPath defs ellipse feGaussianBlur filter g line linearGradient
     marker path polygon polyline radialGradient rect stop style svg text
-    textpath tref tspan use
+    textPath tref tspan use
   }.each(&:freeze)
 
   include ActiveSupport::Deprecation::DeprecatedConstantAccessor

--- a/lib/upload_creator.rb
+++ b/lib/upload_creator.rb
@@ -7,7 +7,7 @@ class UploadCreator
   TYPES_TO_CROP ||= %w{avatar card_background custom_emoji profile_background}.each(&:freeze)
 
   ALLOWED_SVG_ELEMENTS ||= %w{
-    circle clippath defs ellipse feGaussianBlur filter g line linearGradient
+    circle clipPath defs ellipse feGaussianBlur filter g line linearGradient
     marker path polygon polyline radialGradient rect stop style svg text
     textpath tref tspan use
   }.each(&:freeze)


### PR DESCRIPTION
Fix casing of SVG elements `clipPath` and `textPath`.

Tests omitted because they already cover whitelisted SVG elements.