### PR TITLE
UX: Fix confusing admin UI for color scheme updates

### DIFF
--- a/app/assets/javascripts/admin/addon/models/color-scheme.js
+++ b/app/assets/javascripts/admin/addon/models/color-scheme.js
@@ -20,7 +20,10 @@ const ColorScheme = EmberObject.extend({
   },
 
   startTrackingChanges() {
-    this.set("originals", { name: this.name });
+    this.set("originals", {
+      name: this.name,
+      user_selectable: this.user_selectable,
+    });
   },
 
   schemeJson() {
@@ -46,12 +49,20 @@ const ColorScheme = EmberObject.extend({
     return newScheme;
   },
 
-  @discourseComputed("name", "colors.@each.changed", "saving")
-  changed(name) {
+  @discourseComputed(
+    "name",
+    "user_selectable",
+    "colors.@each.changed",
+    "saving"
+  )
+  changed(name, user_selectable) {
     if (!this.originals) {
       return false;
     }
     if (this.originals.name !== name) {
+      return true;
+    }
+    if (this.originals.user_selectable !== user_selectable) {
       return true;
     }
     if (this.colors.any((c) => c.get("changed"))) {
@@ -80,9 +91,9 @@ const ColorScheme = EmberObject.extend({
     this.setProperties({ savingStatus: I18n.t("saving"), saving: true });
 
     const data = {};
-
     if (!opts || !opts.enabledOnly) {
       data.name = this.name;
+      data.user_selectable = this.user_selectable;
       data.base_scheme_id = this.base_scheme_id;
       data.colors = [];
       this.colors.forEach((c) => {

--- a/app/assets/javascripts/admin/addon/templates/customize-colors-show.hbs
+++ b/app/assets/javascripts/admin/addon/templates/customize-colors-show.hbs
@@ -41,7 +41,14 @@
     <br>
 
     <div class="admin-controls">
-      {{inline-edit-checkbox action=(action "applyUserSelectable") labelKey="admin.customize.theme.color_scheme_user_selectable" checked=model.user_selectable}}
+      {{#if model.theme_id}}
+        {{inline-edit-checkbox action=(action "applyUserSelectable") labelKey="admin.customize.theme.color_scheme_user_selectable" checked=model.user_selectable}}
+      {{else}}
+        <label>
+          {{input type="checkbox" checked=model.user_selectable}}
+          {{i18n "admin.customize.theme.color_scheme_user_selectable"}}
+        </label>
+      {{/if}}
     </div>
 
     {{#if colors.length}}


### PR DESCRIPTION
Previously we were showing two ways to save a change to a color scheme's "user selectable" property. 

<img width="753" alt="image" src="https://user-images.githubusercontent.com/368961/97889789-c7895500-1cfa-11eb-8329-68cacfc37a33.png">

Plus, only the small checkbox save button would save that property (the larger Save button would save the rest of the color scheme's changes.)

This PR changes the UI to omit the ✔️ when the user can make changes to the color scheme: 

<img width="752" alt="image" src="https://user-images.githubusercontent.com/368961/97890471-92313700-1cfb-11eb-9729-fae5f397c31d.png">

On color schemes inherited by themes (that the user can't edit), the ✔️ is maintained as before: 

<img width="751" alt="image" src="https://user-images.githubusercontent.com/368961/97890555-aa08bb00-1cfb-11eb-85f4-6455b981c0d6.png">
