### PR TITLE
FIX: Make addNavigationBarItem subfolder compatible

### DIFF
--- a/app/assets/javascripts/discourse/app/models/nav-item.js
+++ b/app/assets/javascripts/discourse/app/models/nav-item.js
@@ -48,7 +48,7 @@ const NavItem = EmberObject.extend({
     }, this);
 
     if (customHref) {
-      return customHref;
+      return getURL(customHref);
     }
 
     const context = { category, noSubcategories, tagId };

--- a/app/assets/javascripts/discourse/app/models/nav-item.js
+++ b/app/assets/javascripts/discourse/app/models/nav-item.js
@@ -245,6 +245,10 @@ NavItem.reopenClass({
         item.init(item, category, args);
       }
 
+      if (item.href) {
+        item.href = getURL(item.href);
+      }
+
       const before = item.before;
       if (before) {
         let i = 0;


### PR DESCRIPTION
@danielwaterworth suggested taking a look at this when reviewing a plugin using this API. 

When declaring a new nav item using `addNavigationBarItem` and including the `href` attribute, we don't currently process that URL to be subfolder compatible. 

Nav bar items coming in via the API are considered `ExtraNavItem` and the `href` value is passed straight through to the `buildItems` method, vs using the computed href method. This PR adds a simple `getURL` call on that href value to ensure it's subfolder-safe.

I also accounted for the `customHref` function in the API to make those URLs subfolder safe as well.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
