### PR TITLE
FEATURE: Add auto update field to themes

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-customize-themes-show.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-customize-themes-show.js
@@ -35,6 +35,11 @@ export default Controller.extend({
   childThemesNames: mapBy("model.childThemes", "name"),
   extraFiles: filterBy("model.theme_fields", "target", "extra_js"),
 
+  @discourseComputed("model.component", "model.remote_theme")
+  showCheckboxes() {
+    return !this.model.component || this.model.remote_theme;
+  },
+
   @discourseComputed("model.editedFields")
   editedFieldsFormatted() {
     const descriptions = [];
@@ -302,6 +307,10 @@ export default Controller.extend({
 
     applyUserSelectable() {
       this.model.saveChanges("user_selectable");
+    },
+
+    applyAutoUpdateable() {
+      this.model.saveChanges("auto_update");
     },
 
     addChildTheme() {

--- a/app/assets/javascripts/admin/addon/templates/customize-themes-show.hbs
+++ b/app/assets/javascripts/admin/addon/templates/customize-themes-show.hbs
@@ -134,12 +134,17 @@
     {{/if}}
   </div>
 
-  {{#unless model.component}}
+  {{#if showCheckboxes}}
     <div class="control-unit">
-      {{inline-edit-checkbox action=(action "applyDefault") labelKey="admin.customize.theme.is_default" checked=model.default}}
-      {{inline-edit-checkbox action=(action "applyUserSelectable") labelKey="admin.customize.theme.user_selectable" checked=model.user_selectable}}
+      {{#unless model.component}}
+        {{inline-edit-checkbox action=(action "applyDefault") labelKey="admin.customize.theme.is_default" checked=model.default}}
+        {{inline-edit-checkbox action=(action "applyUserSelectable") labelKey="admin.customize.theme.user_selectable" checked=model.user_selectable}}
+      {{/unless}}
+      {{#if model.remote_theme}}
+        {{inline-edit-checkbox action=(action "applyAutoUpdateable") labelKey="admin.customize.theme.auto_update" checked=model.auto_update}}
+      {{/if}}
     </div>
-  {{/unless}}
+  {{/if}}
 
   {{#unless model.component}}
     {{#d-section class="form-horizontal theme settings control-unit"}}

--- a/app/controllers/admin/themes_controller.rb
+++ b/app/controllers/admin/themes_controller.rb
@@ -178,7 +178,7 @@ class Admin::ThemesController < Admin::AdminController
     disables_component = [false, "false"].include?(theme_params[:enabled])
     enables_component = [true, "true"].include?(theme_params[:enabled])
 
-    [:name, :color_scheme_id, :user_selectable, :enabled].each do |field|
+    [:name, :color_scheme_id, :user_selectable, :enabled, :auto_update].each do |field|
       if theme_params.key?(field)
         @theme.public_send("#{field}=", theme_params[field])
       end
@@ -348,6 +348,7 @@ class Admin::ThemesController < Admin::AdminController
           :user_selectable,
           :component,
           :enabled,
+          :auto_update,
           settings: {},
           translations: {},
           theme_fields: [:name, :target, :value, :upload_id, :type_id],

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -606,6 +606,7 @@ end
 #  remote_theme_id  :integer
 #  component        :boolean          default(FALSE), not null
 #  enabled          :boolean          default(TRUE), not null
+#  auto_update      :boolean          default(FALSE), not null
 #
 # Indexes
 #

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -606,7 +606,7 @@ end
 #  remote_theme_id  :integer
 #  component        :boolean          default(FALSE), not null
 #  enabled          :boolean          default(TRUE), not null
-#  auto_update      :boolean          default(FALSE), not null
+#  auto_update      :boolean          default(TRUE), not null
 #
 # Indexes
 #

--- a/app/serializers/theme_serializer.rb
+++ b/app/serializers/theme_serializer.rb
@@ -63,8 +63,9 @@ class RemoteThemeSerializer < ApplicationSerializer
 end
 
 class ThemeSerializer < BasicThemeSerializer
-  attributes :color_scheme, :color_scheme_id, :user_selectable, :remote_theme_id,
-             :settings, :errors, :supported?, :description, :enabled?, :disabled_at
+  attributes :color_scheme, :color_scheme_id, :user_selectable, :auto_update,
+             :remote_theme_id, :settings, :errors, :supported?, :description,
+             :enabled?, :disabled_at
 
   has_one :user, serializer: UserNameSerializer, embed: :object
   has_one :disabled_by, serializer: UserNameSerializer, embed: :object

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3980,6 +3980,7 @@ en:
           is_default: "Theme is enabled by default"
           user_selectable: "Theme can be selected by users"
           color_scheme_user_selectable: "Color scheme can be selected by users"
+          auto_update: "Auto update when Discourse is updated"
           color_scheme: "Color Palette"
           default_light_scheme: "Light (default)"
           color_scheme_select: "Select colors to be used by theme"

--- a/db/migrate/20201102162044_add_auto_update_to_themes.rb
+++ b/db/migrate/20201102162044_add_auto_update_to_themes.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddAutoUpdateToThemes < ActiveRecord::Migration[6.0]
+  def change
+    add_column :themes, :auto_update, :boolean, null: false, default: false
+  end
+end

--- a/db/migrate/20201102162044_add_auto_update_to_themes.rb
+++ b/db/migrate/20201102162044_add_auto_update_to_themes.rb
@@ -2,6 +2,6 @@
 
 class AddAutoUpdateToThemes < ActiveRecord::Migration[6.0]
   def change
-    add_column :themes, :auto_update, :boolean, null: false, default: false
+    add_column :themes, :auto_update, :boolean, null: false, default: true
   end
 end

--- a/lib/tasks/themes.rake
+++ b/lib/tasks/themes.rake
@@ -51,6 +51,16 @@ task "themes:install" => :environment do |task, args|
   end
 end
 
+desc "Update themes & theme components"
+task "themes:update" => :environment do |task, args|
+  Theme.where(auto_update: true).find_each do |theme|
+    if theme.remote_theme.present?
+      puts "Updating #{theme.name}..."
+      theme.remote_theme.update_from_remote
+    end
+  end
+end
+
 desc "List all the installed themes on the site"
 task "themes:audit" => :environment do
   components = Set.new

--- a/lib/tasks/themes.rake
+++ b/lib/tasks/themes.rake
@@ -54,9 +54,15 @@ end
 desc "Update themes & theme components"
 task "themes:update" => :environment do |task, args|
   Theme.where(auto_update: true).find_each do |theme|
-    if theme.remote_theme.present?
-      puts "Updating #{theme.name}..."
-      theme.remote_theme.update_from_remote
+    begin
+      if theme.remote_theme.present?
+        puts "Updating #{theme.name}..."
+        theme.remote_theme.update_from_remote
+      end
+    rescue => e
+      STDERR.puts "Failed to update #{theme.name}"
+      STDERR.puts e
+      STDERR.puts e.backtrace
     end
   end
 end


### PR DESCRIPTION
Themes marked for auto update will be automatically updated when
Discourse is updated. This is triggered by discourse_docker running
Rake task 'themes:update'.

![image](https://user-images.githubusercontent.com/4147664/97900000-be23db00-1d42-11eb-9554-094f9f83ae6b.png)
