### PR TITLE
UI: Fix button overlapping longer group names in group card

### DIFF
--- a/app/assets/stylesheets/desktop/group.scss
+++ b/app/assets/stylesheets/desktop/group.scss
@@ -45,12 +45,6 @@
   }
 }
 
-.group-details-button {
-  position: absolute;
-  top: 20px;
-  right: 20px;
-}
-
 .groups-form.groups-notifications-form {
   width: 500px;
   max-width: 100%;


### PR DESCRIPTION
This commit fixes the group buttons from overlapping long group names in the group card.

### Before
![image](https://user-images.githubusercontent.com/30537603/97910297-2b1d7d80-1d0f-11eb-830a-af26440539c4.png)


### After
![image](https://user-images.githubusercontent.com/30537603/97910210-09bc9180-1d0f-11eb-81d7-a71c683e1046.png)


<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
