### PR TITLE
FIX: Remove 4 month limit on IgnoredUser records

### DIFF
--- a/app/jobs/scheduled/purge_expired_ignored_users.rb
+++ b/app/jobs/scheduled/purge_expired_ignored_users.rb
@@ -5,7 +5,7 @@ module Jobs
     every 1.day
 
     def execute(args)
-      IgnoredUser.where("created_at <= ? OR expiring_at <= ?", 4.months.ago, Time.zone.now).delete_all
+      IgnoredUser.where("expiring_at <= ?", Time.zone.now).delete_all
     end
   end
 end

--- a/app/jobs/scheduled/purge_expired_ignored_users.rb
+++ b/app/jobs/scheduled/purge_expired_ignored_users.rb
@@ -6,6 +6,7 @@ module Jobs
 
     def execute(args)
       IgnoredUser.where("expiring_at <= ?", Time.zone.now).delete_all
+      IgnoredUser.where("created_at <= ? AND expiring_at IS NULL", 4.months.ago).delete_all
     end
   end
 end


### PR DESCRIPTION
b8c676e7 added the 'forever' option to the UI, and this is correctly stored in the database. However, we had a hard-coded limit of 4 months in the cleanup job. This commit removes the limit, so ignores can last forever.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
