### PR TITLE
FIX: add a way to cancel initialization of new draft

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/discard-draft.js
+++ b/app/assets/javascripts/discourse/app/controllers/discard-draft.js
@@ -1,0 +1,40 @@
+import Controller from "@ember/controller";
+import ModalFunctionality from "discourse/mixins/modal-functionality";
+import discourseComputed from "discourse-common/utils/decorators";
+
+export default Controller.extend(ModalFunctionality, {
+  differentDraft: null,
+
+  @discourseComputed()
+  keyPrefix() {
+    return this.model.action === "edit" ? "post.abandon_edit" : "post.abandon";
+  },
+
+  @discourseComputed("keyPrefix")
+  descriptionKey(keyPrefix) {
+    return `${keyPrefix}.confirm`;
+  },
+
+  @discourseComputed("keyPrefix")
+  discardKey(keyPrefix) {
+    return `${keyPrefix}.yes_value`;
+  },
+
+  @discourseComputed("keyPrefix", "differentDraft")
+  saveKey(keyPrefix, differentDraft) {
+    return differentDraft
+      ? `${keyPrefix}.no_save_draft`
+      : `${keyPrefix}.no_value`;
+  },
+
+  actions: {
+    _destroyDraft() {
+      this.onDestroyDraft();
+      this.send("closeModal");
+    },
+    _saveDraft() {
+      this.onSaveDraft();
+      this.send("closeModal");
+    },
+  },
+});

--- a/app/assets/javascripts/discourse/app/templates/modal/discard-draft.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/discard-draft.hbs
@@ -1,0 +1,10 @@
+{{#d-modal-body}}
+  <div class="instructions">
+    {{i18n descriptionKey}}
+  </div>
+{{/d-modal-body}}
+
+<div class="modal-footer">
+  {{d-button label=discardKey class="btn-danger" action=(action "_destroyDraft")}}
+  {{d-button label=saveKey action=(action "_saveDraft")}}
+</div>

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
@@ -291,9 +291,9 @@ acceptance("Composer", function (needs) {
     await click(".topic-post:eq(0) button.show-more-actions");
     await click(".topic-post:eq(0) button.edit");
 
-    await click("a[data-handler='0']");
+    await click(".modal-footer button:eq(1)");
 
-    assert.ok(!visible(".bootbox.modal"));
+    assert.ok(!visible(".discard-draft-modal.modal"));
     assert.equal(
       queryAll(".d-editor-input").val(),
       "this is the content of my reply"
@@ -408,9 +408,12 @@ acceptance("Composer", function (needs) {
     await click(".topic-post:eq(0) button.edit");
     await fillIn(".d-editor-input", "This is a dirty reply");
     await click(".topic-post:eq(1) button.edit");
-    assert.ok(exists(".bootbox.modal"), "it pops up a confirmation dialog");
+    assert.ok(
+      exists(".discard-draft-modal.modal"),
+      "it pops up a confirmation dialog"
+    );
 
-    await click(".modal-footer a:eq(0)");
+    await click(".modal-footer button:eq(0)");
     assert.equal(
       queryAll(".d-editor-input").val().indexOf("This is the second post."),
       0,
@@ -563,8 +566,11 @@ acceptance("Composer", function (needs) {
     await click(".topic-post:eq(0) button.reply");
     await fillIn(".d-editor-input", "This is a dirty reply");
     await click(".topic-post:eq(0) button.edit");
-    assert.ok(exists(".bootbox.modal"), "it pops up a confirmation dialog");
-    await click(".modal-footer a:eq(0)");
+    assert.ok(
+      exists(".discard-draft-modal.modal"),
+      "it pops up a confirmation dialog"
+    );
+    await click(".modal-footer button:eq(0)");
     assert.equal(
       queryAll(".d-editor-input").val().indexOf("This is the first post."),
       0,
@@ -579,12 +585,15 @@ acceptance("Composer", function (needs) {
     await fillIn(".d-editor-input", "This is a dirty reply");
     await click(".toggler");
     await click(".topic-post:eq(1) button.edit");
-    assert.ok(exists(".bootbox.modal"), "it pops up a confirmation dialog");
+    assert.ok(
+      exists(".discard-draft-modal.modal"),
+      "it pops up a confirmation dialog"
+    );
     assert.equal(
-      queryAll(".modal-footer a:eq(1)").text(),
+      queryAll(".modal-footer button:eq(1)").text().trim(),
       I18n.t("post.abandon.no_value")
     );
-    await click(".modal-footer a:eq(0)");
+    await click(".modal-footer button:eq(0)");
     assert.equal(
       queryAll(".d-editor-input").val().indexOf("This is the second post."),
       0,
@@ -601,12 +610,15 @@ acceptance("Composer", function (needs) {
     await click("#site-logo");
     await click("#create-topic");
 
-    assert.ok(exists(".bootbox.modal"), "it pops up a confirmation dialog");
+    assert.ok(
+      exists(".discard-draft-modal.modal"),
+      "it pops up a confirmation dialog"
+    );
     assert.equal(
-      queryAll(".modal-footer a:eq(1)").text(),
+      queryAll(".modal-footer button:eq(1)").text().trim(),
       I18n.t("post.abandon.no_save_draft")
     );
-    await click(".modal-footer a:eq(1)");
+    await click(".modal-footer button:eq(1)");
     assert.equal(
       queryAll(".d-editor-input").val(),
       "",

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2762,6 +2762,7 @@ en:
         yes_value: "Yes, discard edit"
 
       abandon:
+        title: "Abandon Draft"
         confirm: "Are you sure you want to abandon your post?"
         no_value: "No, keep"
         no_save_draft: "No, save draft"


### PR DESCRIPTION
When a user is replying on a topic and (with composer still open) navigates away to different topic and tries to reply on that topic, they see:

<img width="632" alt="Screenshot 2020-11-03 at 4 45 03 PM" src="https://user-images.githubusercontent.com/5732281/97978704-f20b0900-1df3-11eb-9105-ed45ef06f842.png">

Both of the buttons on above modal closes the existing composer and there is no way to just close the modal and keep on editing in the existing composer.

This commit replaces the bootbox with a custom modal. Here's how it looks:

<img width="347" alt="Screenshot 2020-11-12 at 5 50 14 PM" src="https://user-images.githubusercontent.com/5732281/98939650-c1238600-250f-11eb-9b4b-5b6fcb53b4b2.png">
