### PR TITLE
FIX: group notification level cannot be null

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/groups-form-interaction-fields.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/groups-form-interaction-fields.hbs
@@ -97,7 +97,6 @@
     value=model.default_notification_level
     class="groups-form-default-notification-level"
     options=(hash
-      none="select_kit.default_header_text"
       i18nPrefix="groups.notifications"
     )
   }}


### PR DESCRIPTION
Group's `default_notification_level` cannot be null so there is no need to provide "none" translation for group notification level dropdown.