### PR TITLE
FIX: Safely skip secure_media steps when it's not enabled

### DIFF
--- a/lib/email/styles.rb
+++ b/lib/email/styles.rb
@@ -278,7 +278,7 @@ module Email
     def to_html
       # needs to be before class + id strip because we need to style redacted
       # media and also not double-redact already redacted from lower levels
-      replace_secure_media_urls
+      replace_secure_media_urls if SiteSetting.secure_media?
       strip_classes_and_ids
       replace_relative_urls
 

--- a/lib/pretty_text.rb
+++ b/lib/pretty_text.rb
@@ -432,7 +432,7 @@ module PrettyText
 
     # images by themselves or inside a onebox
     doc.css('img[src]').each do |img|
-      url = if img.parent.classes.include?("aspect-image")
+      url = if img.parent.classes.include?("aspect-image") && img.attributes["srcset"].present?
 
         # we are using the first image from the srcset here so we get the
         # optimized image instead of the original, because an optimized

--- a/spec/components/email/styles_spec.rb
+++ b/spec/components/email/styles_spec.rb
@@ -188,6 +188,11 @@ describe Email::Styles do
   end
 
   context "replace_secure_media_urls" do
+    before do
+      setup_s3
+      SiteSetting.secure_media = true
+    end
+
     let(:attachments) { { 'testimage.png' => stub(url: 'email/test.png') } }
     it "replaces secure media within a link with a placeholder" do
       frag = html_fragment("<a href=\"#{Discourse.base_url}\/secure-media-uploads/original/1X/testimage.png\"><img src=\"/secure-media-uploads/original/1X/testimage.png\"></a>")
@@ -208,6 +213,11 @@ describe Email::Styles do
   end
 
   context "inline_secure_images" do
+    before do
+      setup_s3
+      SiteSetting.secure_media = true
+    end
+
     let(:attachments) { { 'testimage.png' => stub(url: 'cid:email/test.png') } }
     fab!(:upload) { Fabricate(:upload, original_filename: 'testimage.png', secure: true, sha1: '123456') }
     let(:html) { "<a href=\"#{Discourse.base_url}\/secure-media-uploads/original/1X/123456.png\"><img src=\"/secure-media-uploads/original/1X/123456.png\" width=\"20\" height=\"30\"></a>" }


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
