### PR TITLE
FIX: Stop bypassing email checks for invite emails

### DIFF
--- a/lib/email/sender.rb
+++ b/lib/email/sender.rb
@@ -17,7 +17,7 @@ BYPASS_DISABLE_TYPES = %w(
   test_message
   new_version
   group_smtp
-  invite
+  invite_password_instructions
   download_backup_message
   admin_confirmation_message
 )


### PR DESCRIPTION
See https://github.com/discourse/discourse/pull/10794 for original context.

I did not mean to add `invite` to the `BYPASS_TYPES` for `Email::Sender`, it was supposed to be `invite_password_instructions`.
