### PR TITLE
FIX: include header offset relative to window in offset-calculator

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/offset-calculator.js
+++ b/app/assets/javascripts/discourse/app/lib/offset-calculator.js
@@ -7,7 +7,14 @@ export function minimumOffset() {
     iPadNav = document.querySelector(".footer-nav-ipad .footer-nav"),
     iPadNavHeight = iPadNav ? iPadNav.offsetHeight : 0;
 
-  return header ? header.offsetHeight + iPadNavHeight : 0;
+  // if the header has a positive offset from the top of the window, we need to include the offset
+  // this covers cases where a site has a custom header above d-header (covers fixed and unfixed)
+  const headerWrap = document.querySelector(".d-header-wrap"),
+    headerWrapOffset = headerWrap.getBoundingClientRect();
+
+  return header
+    ? header.offsetHeight + headerWrapOffset.top + iPadNavHeight
+    : 0;
 }
 
 export default function offsetCalculator() {


### PR DESCRIPTION
If a site has added content above the default header (above `.d-header-wrap`), the offset of `.d-header-wrap` needs to be factored in to the offset calculation. 

Before (note that you can't see the posters avatar): 

![unfixed](https://user-images.githubusercontent.com/1681963/98050524-de659f80-1dff-11eb-842b-8129cfd69c9f.gif)

After (back to the proper top of the post):

![fixed](https://user-images.githubusercontent.com/1681963/98050570-f806e700-1dff-11eb-9e8e-c66cb62adb6e.gif)


Tested in these 4 scenarios:

* No content above header
* Unfixed content above header (disappears on scroll)
* `position: fixed;` content above header (follows on scroll)
* `position: sticky;` content above header (follows on scroll)


