### PR TITLE
UX: sort user badges by Gold > Silver > Bronze.

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/user-badges.js
+++ b/app/assets/javascripts/discourse/app/controllers/user-badges.js
@@ -9,6 +9,6 @@ export default Controller.extend({
   init() {
     this._super(...arguments);
 
-    this.badgeSortOrder = ["badge.badge_type.sort_order", "badge.name"];
+    this.badgeSortOrder = ["badge.badge_type.sort_order:desc", "badge.name"];
   },
 });


### PR DESCRIPTION
https://meta.discourse.org/t/is-there-a-way-to-order-badges-in-user-cards/155676/6?u=techapj