### PR TITLE
UX: when creating linked topic use URL and let onebox work its magic

### DIFF
--- a/app/jobs/regular/create_linked_topic.rb
+++ b/app/jobs/regular/create_linked_topic.rb
@@ -35,12 +35,12 @@ module Jobs
         previous_topics = ""
         linked_topic_ids = LinkedTopic.where(original_topic_id: original_topic_id).pluck(:topic_id)
         Topic.where(id: linked_topic_ids).order(:id).each do |topic|
-          previous_topics += "- [#{topic.title}](#{topic.url})\n"
+          previous_topics += "- #{topic.url}\n"
         end
 
         # create new topic
         new_topic_title = I18n.t("create_linked_topic.topic_title_with_sequence", topic_title: raw_title, count: sequence)
-        new_topic_raw = I18n.t('create_linked_topic.post_raw', parent_title: "[#{parent_title}](#{reference_post.full_url})", previous_topics: previous_topics)
+        new_topic_raw = I18n.t('create_linked_topic.post_raw', parent_url: reference_post.full_url, previous_topics: previous_topics)
         system_user = Discourse.system_user
         new_post = PostCreator.create!(
           system_user,
@@ -73,7 +73,7 @@ module Jobs
         SQL
 
         # add moderator post to old topic
-        parent_topic.add_moderator_post(system_user, I18n.t('create_linked_topic.moderator_post_raw', new_title: "[#{new_topic_title}](#{new_topic.url})"))
+        parent_topic.add_moderator_post(system_user, I18n.t('create_linked_topic.moderator_post_raw', new_url: new_topic.url))
       end
     end
   end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -4944,5 +4944,5 @@ en:
     topic_title_with_sequence:
       one: "%{topic_title} (Part %{count})"
       other: "%{topic_title} (Part %{count})"
-    post_raw: "Continuing the discussion from %{parent_title}.\n\nPrevious discussions:\n\n%{previous_topics}"
-    moderator_post_raw: "Continue discussion here: %{new_title}"
+    post_raw: "Continuing the discussion from %{parent_url}.\n\nPrevious discussions:\n\n%{previous_topics}"
+    moderator_post_raw: "Continue discussion here: %{new_url}"

--- a/spec/jobs/create_linked_topic_spec.rb
+++ b/spec/jobs/create_linked_topic_spec.rb
@@ -44,7 +44,7 @@ describe Jobs::CreateLinkedTopic do
       new_topic = Topic.last
       linked_topic = new_topic.linked_topic
       expect(topic.title).to include(I18n.t("create_linked_topic.topic_title_with_sequence", topic_title: raw_title, count: 1))
-      expect(topic.posts.last.raw).to eq(I18n.t('create_linked_topic.moderator_post_raw', new_title: "[#{new_topic.title}](#{new_topic.url})"))
+      expect(topic.posts.last.raw).to eq(I18n.t('create_linked_topic.moderator_post_raw', new_url: new_topic.url))
       expect(new_topic.title).to include(I18n.t("create_linked_topic.topic_title_with_sequence", topic_title: raw_title, count: 2))
       expect(new_topic.first_post.raw).to include(topic.url)
       expect(new_topic.topic_users.count).to eq(3)


### PR DESCRIPTION
When the linked topic is created we'll not hardcode the topic title and let onebox work its magic instead so that the title can be updated automatically.

https://meta.discourse.org/t/linked-topics-splitting-and-managing-megatopics/168992/3?u=techapj