### PR TITLE
FIX: secure_media stripping on lightboxes, non-image links

### DIFF
--- a/lib/pretty_text.rb
+++ b/lib/pretty_text.rb
@@ -409,11 +409,12 @@ module PrettyText
     # images inside a lightbox or other link
     doc.css('a[href]').each do |a|
       next if !Upload.secure_media_url?(a['href'])
-      next if a.css('img[src]').empty?
 
       non_image_media = %w(video audio).include?(a&.parent&.name)
       target = non_image_media ? a.parent : a
       next if target.to_s.include?('stripped-secure-view-media')
+
+      next if a.css('img[src]').empty? && !non_image_media
 
       if a.classes.include?('lightbox')
         img = a.css('img[src]').first

--- a/spec/components/email/styles_spec.rb
+++ b/spec/components/email/styles_spec.rb
@@ -210,6 +210,31 @@ describe Email::Styles do
       frag = html_fragment("<a href=\"#{Discourse.base_url}\/t/secure-media-uploads/235723\">Visit Topic</a>")
       expect(frag.to_s).not_to include("Redacted")
     end
+
+    it "works in lightboxes with missing srcset attribute" do
+      frag = html_fragment("<a href=\"#{Discourse.base_url}\/secure-media-uploads/original/1X/testimage.png\" class=\"lightbox\"><img src=\"/secure-media-uploads/original/1X/testimage.png\"></a>")
+      expect(frag.at('img')).not_to be_present
+      expect(frag.to_s).to include("Redacted")
+    end
+
+    it "works in lightboxes with srcset attribute set" do
+      frag = html_fragment(
+        <<~HTML
+          <a href="#{Discourse.base_url}/secure-media-uploads/original/1X/testimage.png" class="lightbox">
+            <img src="/secure-media-uploads/original/1X/testimage.png" srcset="/secure-media-uploads/optimized/1X/testimage.png, /secure-media-uploads/original/1X/testimage.png 1.5x" />
+          </a>
+        HTML
+      )
+
+      expect(frag.at('img')).not_to be_present
+      expect(frag.to_s).to include("Redacted")
+    end
+
+    it "skips links with no images as children" do
+      frag = html_fragment("<a href=\"#{Discourse.base_url}\/secure-media-uploads/original/1X/testimage.png\"><span>Clearly not an image</span></a>")
+      expect(frag.to_s).to include("not an image")
+    end
+
   end
 
   context "inline_secure_images" do


### PR DESCRIPTION
- Fixes stripping of lightboxes with empty srcset attribute
- Does not fail when email has links with secure media URLs but no child image elements

