### PR TITLE
UX: Wider canvas buttons in wizard

### DIFF
--- a/app/assets/javascripts/wizard/components/font-preview.js
+++ b/app/assets/javascripts/wizard/components/font-preview.js
@@ -38,7 +38,7 @@ export default createPreviewComponent(659, 320, {
       this.drawFullHeader(colors, headingFont, this.logo);
     }
 
-    const margin = width * 0.04;
+    const margin = 20;
     const avatarSize = height * 0.2;
     const lineHeight = height / 11;
 
@@ -69,24 +69,28 @@ export default createPreviewComponent(659, 320, {
     }
 
     // Share Button
+    const shareButtonWidth = I18n.t("wizard.previews.share_button").length * 11;
+
     ctx.beginPath();
-    ctx.rect(margin, line + lineHeight, width * 0.125, height * 0.1);
+    ctx.rect(margin, line + lineHeight, shareButtonWidth, height * 0.1);
     ctx.fillStyle = darkLightDiff(colors.primary, colors.secondary, 90, 65);
     ctx.fill();
     ctx.fillStyle = chooseDarker(colors.primary, colors.secondary);
     ctx.font = `${bodyFontSize}em '${font}'`;
     ctx.fillText(
       I18n.t("wizard.previews.share_button"),
-      margin + width / 65,
+      margin + 10,
       line + lineHeight * 1.7
     );
 
     // Reply Button
+    const replyButtonWidth = I18n.t("wizard.previews.reply_button").length * 11;
+
     ctx.beginPath();
     ctx.rect(
-      margin + width * 0.145,
+      shareButtonWidth + margin + 10,
       line + lineHeight,
-      width * 0.13,
+      replyButtonWidth,
       height * 0.1
     );
     ctx.fillStyle = colors.tertiary;
@@ -95,7 +99,7 @@ export default createPreviewComponent(659, 320, {
     ctx.font = `${bodyFontSize}em '${font}'`;
     ctx.fillText(
       I18n.t("wizard.previews.reply_button"),
-      margin + width * 0.14 + width / 55,
+      shareButtonWidth + margin + 20,
       line + lineHeight * 1.7
     );
 

--- a/app/assets/javascripts/wizard/components/font-preview.js
+++ b/app/assets/javascripts/wizard/components/font-preview.js
@@ -70,24 +70,24 @@ export default createPreviewComponent(659, 320, {
 
     // Share Button
     ctx.beginPath();
-    ctx.rect(margin, line + lineHeight, width * 0.1, height * 0.12);
+    ctx.rect(margin, line + lineHeight, width * 0.125, height * 0.1);
     ctx.fillStyle = darkLightDiff(colors.primary, colors.secondary, 90, 65);
     ctx.fill();
     ctx.fillStyle = chooseDarker(colors.primary, colors.secondary);
     ctx.font = `${bodyFontSize}em '${font}'`;
     ctx.fillText(
       I18n.t("wizard.previews.share_button"),
-      margin + width / 55,
-      line + lineHeight * 1.85
+      margin + width / 65,
+      line + lineHeight * 1.7
     );
 
     // Reply Button
     ctx.beginPath();
     ctx.rect(
-      margin + width * 0.12,
+      margin + width * 0.145,
       line + lineHeight,
-      width * 0.1,
-      height * 0.12
+      width * 0.13,
+      height * 0.1
     );
     ctx.fillStyle = colors.tertiary;
     ctx.fill();
@@ -95,8 +95,8 @@ export default createPreviewComponent(659, 320, {
     ctx.font = `${bodyFontSize}em '${font}'`;
     ctx.fillText(
       I18n.t("wizard.previews.reply_button"),
-      margin + width * 0.12 + width / 55,
-      line + lineHeight * 1.85
+      margin + width * 0.14 + width / 55,
+      line + lineHeight * 1.7
     );
 
     // Draw Timeline

--- a/app/assets/javascripts/wizard/components/theme-preview.js
+++ b/app/assets/javascripts/wizard/components/theme-preview.js
@@ -71,24 +71,27 @@ export default createPreviewComponent(305, 165, {
     }
 
     // Share Button
+    const shareButtonWidth = I18n.t("wizard.previews.share_button").length * 9;
+
     ctx.beginPath();
-    ctx.rect(margin, line + lineHeight, width * 0.14, height * 0.14);
+    ctx.rect(margin, line + lineHeight, shareButtonWidth, height * 0.14);
     ctx.fillStyle = darkLightDiff(colors.primary, colors.secondary, 90, 65);
     ctx.fill();
     ctx.fillStyle = chooseDarker(colors.primary, colors.secondary);
     ctx.font = `${bodyFontSize}em '${font}'`;
     ctx.fillText(
       I18n.t("wizard.previews.share_button"),
-      margin + width / 55,
+      margin + 8,
       line + lineHeight * 1.85
     );
 
     // Reply Button
+    const replyButtonWidth = I18n.t("wizard.previews.reply_button").length * 9;
     ctx.beginPath();
     ctx.rect(
-      margin * 2 + width * 0.14,
+      shareButtonWidth + margin + 10,
       line + lineHeight,
-      width * 0.14,
+      replyButtonWidth,
       height * 0.14
     );
     ctx.fillStyle = colors.tertiary;
@@ -97,7 +100,7 @@ export default createPreviewComponent(305, 165, {
     ctx.font = `${bodyFontSize}em '${font}'`;
     ctx.fillText(
       I18n.t("wizard.previews.reply_button"),
-      margin * 2 + width * 0.14 + width / 55,
+      shareButtonWidth + margin + 18,
       line + lineHeight * 1.85
     );
 


### PR DESCRIPTION
Two buttons in the wizard are too small, especially in non-English locales. 

For example, in Spanish. 

Before: 
<img width="400" alt="image" src="https://user-images.githubusercontent.com/368961/98157884-027cbb80-1ea8-11eb-82c4-7c08fabb14d7.png">

After
<img width="400" alt="image" src="https://user-images.githubusercontent.com/368961/98157807-e24cfc80-1ea7-11eb-9084-fe7fff5f3b91.png">
