### PR TITLE
FIX: Update review settings.

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/review-settings.js
+++ b/app/assets/javascripts/discourse/app/controllers/review-settings.js
@@ -11,7 +11,7 @@ export default Controller.extend({
   actions: {
     save() {
       let priorities = {};
-      this.get("settings.reviewable_score_types").forEach((st) => {
+      this.scoreTypes.forEach((st) => {
         priorities[st.id] = parseFloat(st.reviewable_priority);
       });
 


### PR DESCRIPTION
We didn't update review settings even if the UI says it was successfully saved. After #11097, we started to clone each setting and store the changes there instead, but we still use the original objects when we perform the save action.

