### PR TITLE
FEATURE: change default so log_out_strict is default disabled

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -477,7 +477,7 @@ login:
     type: list
     list_type: simple
   hide_email_address_taken: false
-  log_out_strict: true
+  log_out_strict: false
   pending_users_reminder_delay:
     min: -1
     default: 8


### PR DESCRIPTION
Discourse used to break from convention by logging out all sessions on any
specific session logout.

This would leave users confused about why mobile is logged out when the user
logged out of desktop.

log_out_strict is too conservative for most and not the pattern the industry
has adopted (google/twitter/facebook all perform no strict logouts)
