### PR TITLE
FIX: limit_topics_per_day should only apply to regular topics

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -441,6 +441,7 @@ class Topic < ActiveRecord::Base
 
   # Additional rate limits on topics: per day and private messages per day
   def limit_topics_per_day
+    return unless regular?
     if user && user.new_user_posting_on_first_day?
       limit_first_day_topics_per_day
     else

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -2215,6 +2215,29 @@ describe Topic do
     end
   end
 
+  context "per day personal message limit" do
+    before do
+      SiteSetting.max_personal_messages_per_day = 1
+      SiteSetting.max_topics_per_day = 0
+      SiteSetting.max_topics_in_first_day = 0
+      RateLimiter.enable
+    end
+
+    after do
+      RateLimiter.clear_all!
+      RateLimiter.disable
+    end
+
+    it "limits according to max_personal_messages_per_day" do
+      user1 = Fabricate(:user)
+      user2 = Fabricate(:user)
+      create_post(user: user, archetype: 'private_message', target_usernames: [user1.username, user2.username])
+      expect {
+        create_post(user: user, archetype: 'private_message', target_usernames: [user1.username, user2.username])
+      }.to raise_error(RateLimiter::LimitExceeded)
+    end
+  end
+
   describe ".count_exceeds_minimun?" do
     before { SiteSetting.minimum_topics_similar = 20 }
 


### PR DESCRIPTION
PMs were being evaluated by both the `limit_topics_per_day` and `limit_private_messages_per_day` rate limiters when it should only be the latter.

This bug was first reported here: https://meta.discourse.org/t/limits-on-personal-messages-vs-topics/168930

I'm hoping the test is sufficient, but if there are any improvements I can make, please let me know!