### PR TITLE
PERF: introduce aggressive rate limiting for anonymous

### DIFF
--- a/lib/middleware/request_tracker.rb
+++ b/lib/middleware/request_tracker.rb
@@ -241,7 +241,8 @@ class Middleware::RequestTracker
         "global_ip_limit_10_#{ip}",
         GlobalSetting.max_reqs_per_ip_per_10_seconds,
         10,
-        global: true
+        global: true,
+        aggressive: true
       )
 
       limiter60 = RateLimiter.new(
@@ -249,7 +250,8 @@ class Middleware::RequestTracker
         "global_ip_limit_60_#{ip}",
         GlobalSetting.max_reqs_per_ip_per_minute,
         60,
-        global: true
+        global: true,
+        aggressive: true
       )
 
       limiter_assets10 = RateLimiter.new(

--- a/spec/components/rate_limiter_spec.rb
+++ b/spec/components/rate_limiter_spec.rb
@@ -38,6 +38,48 @@ describe RateLimiter do
       RateLimiter.disable
     end
 
+    context 'aggressive rate limiter' do
+
+      it 'can operate correctly and totally stop limiting' do
+
+        freeze_time
+
+        # 2 requests every 30 seconds
+        limiter = RateLimiter.new(nil, "test", 2, 30, global: true, aggressive: true)
+        limiter.clear!
+
+        limiter.performed!
+        limiter.performed!
+
+        freeze_time 29.seconds.from_now
+
+        expect do
+          limiter.performed!
+        end.to raise_error(RateLimiter::LimitExceeded)
+
+        expect do
+          limiter.performed!
+        end.to raise_error(RateLimiter::LimitExceeded)
+
+        # in aggressive mode both these ^^^ count as an attempt
+        freeze_time 29.seconds.from_now
+
+        expect do
+          limiter.performed!
+        end.to raise_error(RateLimiter::LimitExceeded)
+
+        expect do
+          limiter.performed!
+        end.to raise_error(RateLimiter::LimitExceeded)
+
+        freeze_time 31.seconds.from_now
+
+        limiter.performed!
+        limiter.performed!
+
+      end
+    end
+
     context 'global rate limiter' do
 
       it 'can operate in global mode' do


### PR DESCRIPTION
Previous to this change our anonymous rate limits acted as a throttle.
New implementation means we now also consider rate limited requests towards
the limit.

This means that if an anonymous user is hammering the server it will not be
able to get any requests through until it subsides with traffic.
