### PR TITLE
FIX: trim no-break space in to-markdown

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/to-markdown.js
+++ b/app/assets/javascripts/discourse/app/lib/to-markdown.js
@@ -654,6 +654,7 @@ function trimUnwanted(html) {
   const body = html.match(/<body[^>]*>([\s\S]*?)<\/body>/);
   html = body ? body[1] : html;
   html = html.replace(/\r|\n|&nbsp;/g, " ");
+  html = html.replace(/\u00A0/g, " "); // trim no-break space
 
   let match;
   while ((match = html.match(/<[^\s>]+[^>]*>\s{2,}<[^\s>]+[^>]*>/))) {

--- a/app/assets/javascripts/discourse/tests/unit/lib/to-markdown-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/to-markdown-test.js
@@ -21,6 +21,11 @@ module("Unit | Utility | to-markdown", function () {
      random</b> <s>bold</s> words.</i>`;
     markdown = `<i>Italicised line with <b>some\nrandom</b> ~~bold~~ words.</i>`;
     assert.equal(toMarkdown(html), markdown);
+
+    // eslint-disable-next-line no-irregular-whitespace
+    html = `<span>this is<span> </span></span><strong>bold</strong><span><span> </span>statement</span>`;
+    markdown = `this is **bold** statement`;
+    assert.equal(toMarkdown(html), markdown);
   });
 
   test("converts a link", function (assert) {


### PR DESCRIPTION
No-break spaces were the reason for double spaces when pasting text to the composer.

![swlVqJAEAN](https://user-images.githubusercontent.com/72780/98202722-b0f72e00-1f86-11eb-8ca1-8cf406b2bcea.gif)

https://meta.discourse.org/t/extra-spaces-added-to-markdown-with-rich-text-pasted/112769