### PR TITLE
DEV: Move popups left if application.hbs wrapper is moved by theme

### DIFF
--- a/app/assets/javascripts/discourse/app/components/share-popup.js
+++ b/app/assets/javascripts/discourse/app/components/share-popup.js
@@ -69,7 +69,10 @@ export default Component.extend({
     }
 
     const shareLinkWidth = $this.width();
-    let x = $currentTargetOffset.left - shareLinkWidth / 2;
+    const pageLeftOffset = document.querySelector(
+      ".ember-application > .ember-view"
+    ).offsetLeft;
+    let x = $currentTargetOffset.left - pageLeftOffset - shareLinkWidth / 2;
     if (x < 25) {
       x = 25;
     }

--- a/app/assets/javascripts/discourse/app/mixins/card-contents-base.js
+++ b/app/assets/javascripts/discourse/app/mixins/card-contents-base.js
@@ -201,7 +201,10 @@ export default Mixin.create({
               }
             } else {
               // The site direction is ltr
-              position.left += target.width() + 10;
+              const pageLeftOffset = document.querySelector(
+                ".ember-application > .ember-view"
+              ).offsetLeft;
+              position.left += target.width() - pageLeftOffset + 10;
 
               let overage = $(window).width() - 50 - (position.left + width);
               if (overage < 0) {


### PR DESCRIPTION
We have a `div` that is inside `#main` because of the history of Ember explained [here](https://github.com/emberjs/rfcs/blob/master/text/0280-remove-application-wrapper.md). Once we have Ember cli, we can use optional feature flags and disable creating this div with [application-template-wrapper: false](https://guides.emberjs.com/release/configuring-ember/optional-features/#toc_application-template-wrapper), and refactor this code and any plugins that rely on that div being present (some plugin regarding remote collaboration??).