### PR TITLE
FIX: Correct "no tags" route in tag drop-down

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/tag-drop.js
+++ b/app/assets/javascripts/select-kit/addon/components/tag-drop.js
@@ -81,7 +81,7 @@ export default ComboBoxComponent.extend(TagsMixin, {
   }),
 
   noTagsUrl: computed("firstCategory", "secondCategory", function () {
-    let url = "/tags";
+    let url = "/tag";
     if (this.currentCategory) {
       url += `/c/${Category.slugFor(this.currentCategory)}/${
         this.currentCategory.id


### PR DESCRIPTION
We refactored routes and removed /tags/none... instead is should be /tag/none
