### PR TITLE
UX: Increase the hit area of pinned topics on mobile

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/list/topic-excerpt.hbr
+++ b/app/assets/javascripts/discourse/app/templates/list/topic-excerpt.hbr
@@ -1,8 +1,8 @@
 {{#if topic.hasExcerpt}}
-  <div class="topic-excerpt">
+  <a href="{{topic.url}}" class="topic-excerpt">
     {{dir-span topic.escapedExcerpt}}
     {{#if topic.excerptTruncated}}
-      <a href="{{topic.url}}">{{i18n 'read_more'}}</a>
+      <span class="topic-excerpt-more">{{i18n 'read_more'}}</span>
     {{/if}}
-  </div>
+  </a>
 {{/if}}

--- a/app/assets/stylesheets/mobile/topic-list.scss
+++ b/app/assets/stylesheets/mobile/topic-list.scss
@@ -546,8 +546,13 @@ td .main-link {
   // so the topic excerpt is full width
   // as the containing div is 80%
   .topic-excerpt {
+    display: block;
     padding-right: 0;
     width: 120%;
+  }
+
+  .topic-excerpt-more {
+    color: var(--tertiary);
   }
 }
 


### PR DESCRIPTION
It used to be only the topic title, but that area has been increased to
include the excerpt too.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
