### PR TITLE
UX: truncate long usernames in multi-username notifications

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/liked-notification-item.js
+++ b/app/assets/javascripts/discourse/app/widgets/liked-notification-item.js
@@ -15,14 +15,14 @@ createWidgetFrom(DefaultNotificationItem, "liked-notification-item", {
       if (count === 0) {
         return I18n.t("notifications.liked_2", {
           description,
-          username,
-          username2,
+          username: `<span class="multi-username">${username}</span>`,
+          username2: `<span class="multi-username">${username2}</span>`,
         });
       } else {
         return I18n.t("notifications.liked_many", {
           description,
-          username,
-          username2,
+          username: `<span class="multi-username">${username}</span>`,
+          username2: `<span class="multi-username">${username2}</span>`,
           count,
         });
       }

--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -237,9 +237,9 @@
       }
 
       span.double-user, 
-      // username, username2
+      // e.g., "username, username2"
       span.multi-user
-      // username, username2, and n others
+      // e.g., "username, username2, and n others"
       {
         display: inline-flex;
         max-width: 100%;
@@ -248,7 +248,7 @@
       }
 
       span.multi-user 
-      // username, username2, and n others
+      // e.g., "username, username2, and n others"
       {
         span.multi-username:nth-of-type(2) {
           // margin between username2 and "and n others"
@@ -261,6 +261,7 @@
         @include ellipsis;
         flex: 0 1 auto;
         min-width: 2em;
+        max-width: 10em;
         &:nth-of-type(2) {
           // margin for comma between username and username2
           margin-left: 0.25em;

--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -236,6 +236,37 @@
         color: var(--primary);
       }
 
+      span.double-user, 
+      // username, username2
+      span.multi-user
+      // username, username2, and n others
+      {
+        display: inline-flex;
+        max-width: 100%;
+        align-items: baseline;
+        white-space: nowrap;
+      }
+
+      span.multi-user 
+      // username, username2, and n others
+      {
+        span.multi-username:nth-of-type(2) {
+          // margin between username2 and "and n others"
+          margin-right: 0.25em;
+        }
+      }
+
+      // truncate when usernames are very long
+      span.multi-username {
+        @include ellipsis;
+        flex: 0 1 auto;
+        min-width: 2em;
+        &:nth-of-type(2) {
+          // margin for comma between username and username2
+          margin-left: 0.25em;
+        }
+      }
+
       &:hover,
       &:focus {
         background-color: var(--highlight-medium);

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1989,10 +1989,10 @@ en:
       posted: "<span>%{username}</span> %{description}"
       edited: "<span>%{username}</span> %{description}"
       liked: "<span>%{username}</span> %{description}"
-      liked_2: "<span>%{username}, %{username2}</span> %{description}"
+      liked_2: "<span class='double-user'>%{username}, %{username2}</span> %{description}"
       liked_many:
-        one: "<span>%{username}, %{username2} and %{count} other</span> %{description}"
-        other: "<span>%{username}, %{username2} and %{count} others</span> %{description}"
+        one: "<span class='multi-user'>%{username}, %{username2} and %{count} other</span> %{description}"
+        other: "<span class='multi-user'>%{username}, %{username2} and %{count} others</span> %{description}"
       liked_consolidated_description:
         one: "liked %{count} of your posts"
         other: "liked %{count} of your posts"
@@ -2011,7 +2011,7 @@ en:
         one: "%{count} open membership request for '%{group_name}'"
         other: "%{count} open membership requests for '%{group_name}'"
       reaction: "<span>%{username}</span> %{description}"
-      reaction_2: "<span>%{username}, %{username2}</span> %{description}"
+      reaction_2: "<span class='double-user'>%{username}, %{username2}</span> %{description}"
       votes_released: "%{description} - completed"
 
       group_message_summary:

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2011,7 +2011,7 @@ en:
         one: "%{count} open membership request for '%{group_name}'"
         other: "%{count} open membership requests for '%{group_name}'"
       reaction: "<span>%{username}</span> %{description}"
-      reaction_2: "<span class='double-user'>%{username}, %{username2}</span> %{description}"
+      reaction_2: "<span>%{username}, %{username2}</span> %{description}"
       votes_released: "%{description} - completed"
 
       group_message_summary:


### PR DESCRIPTION
This solves this issue where multiple long usernames force the topic title out of the notification (https://meta.discourse.org/t/notification-with-two-long-usernames-cuts-off-topic-name/168950): 

The problem:

<img width="344" alt="Screen Shot 2020-11-06 at 4 57 26 PM" src="https://user-images.githubusercontent.com/1681963/98419210-8ecae200-2052-11eb-94e6-c04e1a1b12bd.png">

The solution:

<img width="364" alt="Screen Shot 2020-11-06 at 4 57 44 PM" src="https://user-images.githubusercontent.com/1681963/98419230-9c806780-2052-11eb-9683-05752c5f0033.png">

This truncates long usernames and favors preserving "and N more" and the topic title. The username section of notifications isn't allowed to expand beyond the first line. 

<img width="364" alt="Screen Shot 2020-11-06 at 4 50 02 PM" src="https://user-images.githubusercontent.com/1681963/98419266-b326be80-2052-11eb-8e16-09b8b511f8c2.png">

Long titles will still truncate as well:

<img width="356" alt="Screen Shot 2020-11-06 at 5 09 05 PM" src="https://user-images.githubusercontent.com/1681963/98419328-d487aa80-2052-11eb-98a9-712ea926dd2c.png">


