### PR TITLE
UX: Give furigana and other top-overflowing elements a little space

### DIFF
--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -359,10 +359,6 @@
   }
 }
 
-.cooked > *:first-child {
-  margin-top: 0;
-}
-
 .autocomplete {
   z-index: z("composer", "dropdown") + 1;
   position: absolute;

--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -81,6 +81,11 @@ $quote-share-maxwidth: 150px;
 .d-editor-preview {
   word-wrap: break-word;
   line-height: $line-height-large;
+
+  > *:first-child {
+    margin-top: 0;
+  }
+
   h1,
   h2,
   h3,

--- a/app/assets/stylesheets/common/d-editor.scss
+++ b/app/assets/stylesheets/common/d-editor.scss
@@ -137,10 +137,6 @@
   color: var(--primary-medium) !important;
 }
 
-.d-editor-preview > *:first-child {
-  margin-top: 0;
-}
-
 .hide-preview .d-editor-preview-wrapper {
   display: none;
   flex: 0;

--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -15,11 +15,6 @@
 }
 
 .topic-body {
-  // this ensures consistent top margin on topic posts even if the first line of a post
-  // is a top-margin-less element like a list or image.
-  .regular {
-    margin-top: 15px;
-  }
   padding: 0;
   &:first-of-type {
     border-top: none;
@@ -573,7 +568,7 @@ blockquote {
   padding: 12px 0 0 0;
   .topic-meta-data,
   .cooked {
-    padding: 0 $topic-body-width-padding 0.25em $topic-body-width-padding;
+    padding: 1em $topic-body-width-padding 0.25em $topic-body-width-padding;
   }
   .group-request {
     padding: 0.5em $topic-body-width-padding 0 $topic-body-width-padding;


### PR DESCRIPTION
Discussion here: https://meta.discourse.org/t/furigana-at-top-of-comment-get-cut-off/169206

Switching from margin on `.topic-body .regular` to padding on `.cooked` retains the same visual spacing, and gives vertically overflowing text a little extra space before it's cropped by `overflow: hidden`.

I did a little testing and this seems safe... this comment gave me second thoughts:

>  // this ensures consistent top margin on topic posts even if the first line of a post
>  // is a top-margin-less element like a list or image.

but it's old and no longer true due to:

```css
> *:first-child {
 margin-top: 0;
}
```

(all first children of `.cooked` have their `margin-top` removed)

The above first-child CSS was in `compose.scss` but isn't limited to the composer, so I moved it to `topic-post.scss` and removed a dupe. 