### PR TITLE
Improve max_personal_messages_per_day description copy

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1719,7 +1719,7 @@ en:
     max_bookmarks_per_day: "Maximum number of bookmarks per user per day."
     max_edits_per_day: "Maximum number of edits per user per day."
     max_topics_per_day: "Maximum number of topics a user can create per day."
-    max_personal_messages_per_day: "Maximum number of messages users can create per day."
+    max_personal_messages_per_day: "Maximum number of new personal message topics a user can create per day."
     max_invites_per_day: "Maximum number of invites a user can send per day."
     max_topic_invitations_per_day: "Maximum number of topic invitations a user can send per day."
 


### PR DESCRIPTION
Minor copy improvement as discussed on Meta:

https://meta.discourse.org/t/limits-on-personal-messages-vs-topics/168930/12