### PR TITLE
UX: truncate long nav items in dropdown menu

### DIFF
--- a/app/assets/stylesheets/mobile/discourse.scss
+++ b/app/assets/stylesheets/mobile/discourse.scss
@@ -125,6 +125,7 @@ blockquote {
           height: 100%;
           display: block;
           padding: 5px 8px;
+          @include ellipsis;
         }
       }
     }


### PR DESCRIPTION
Discussion here: https://meta.discourse.org/t/long-group-names-in-message-dropdown-should-be-shortened/169491

Before: 

![image](https://user-images.githubusercontent.com/1681963/98431510-f3eafb80-2083-11eb-9bce-4a5f14ade385.png)


After:


![Screen Shot 2020-11-06 at 10 59 26 PM](https://user-images.githubusercontent.com/1681963/98431497-e6ce0c80-2083-11eb-930d-072dd6f36abf.png)

