### PR TITLE
PERF: Update index for category in a background job.

### DIFF
--- a/app/jobs/regular/index_category_for_search.rb
+++ b/app/jobs/regular/index_category_for_search.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Jobs::IndexCategoryForSearch < Jobs::Base
+  def execute(args)
+    category = Category.find_by(id: args[:category_id])
+    raise Discourse::InvalidParameters.new(:category_id) if category.blank?
+
+    SearchIndexer.index(category, force: args[:force] || false)
+  end
+end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -778,11 +778,10 @@ class Category < ActiveRecord::Base
   end
 
   def index_search
-    if saved_change_to_attribute?(:name)
-      SearchIndexer.queue_category_posts_reindex(self.id)
-    end
-
-    SearchIndexer.index(self)
+    Jobs.enqueue(:index_category_for_search,
+      category_id: self.id,
+      force: saved_change_to_attribute?(:name),
+    )
   end
 
   def update_reviewables

--- a/app/services/search_indexer.rb
+++ b/app/services/search_indexer.rb
@@ -243,6 +243,7 @@ class SearchIndexer
     end
 
     if Category === obj && (obj.saved_change_to_name? || force)
+      SearchIndexer.queue_category_posts_reindex(obj.id)
       SearchIndexer.update_categories_index(obj.id, obj.name)
     end
 

--- a/spec/components/search_spec.rb
+++ b/spec/components/search_spec.rb
@@ -8,6 +8,7 @@ describe Search do
 
   before do
     SearchIndexer.enable
+    Jobs.run_immediately!
   end
 
   context 'post indexing' do


### PR DESCRIPTION
Search indexing can get expensive and there is no need for us to block
the entire request just to wait for index to finish.