### PR TITLE
FIX: global setting needs to be coerced to float

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -173,9 +173,13 @@ class SearchController < ApplicationController
   protected
 
   def site_overloaded?
-    (queue_time = request.env['REQUEST_QUEUE_SECONDS']) &&
-      (GlobalSetting.disable_search_queue_threshold > 0) &&
-      (queue_time > GlobalSetting.disable_search_queue_threshold)
+    queue_time = request.env['REQUEST_QUEUE_SECONDS']
+    if queue_time
+      threshold = GlobalSetting.disable_search_queue_threshold.to_f
+      threshold > 0 && queue_time > threshold
+    else
+      false
+    end
   end
 
   def rate_limit_search


### PR DESCRIPTION
disable_search_queue_threshold needs to be coerced to a float so it is not
treated as a string when sub second values are provided.

Longer term fix is to possibly provide hints in the config so we do the
coersion automatically. However this would be a far more complex change.
