### PR TITLE
FIX: paste the spreadsheet to the composer

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-editor.js
+++ b/app/assets/javascripts/discourse/app/components/d-editor.js
@@ -894,7 +894,7 @@ export default Component.extend({
       !isInlinePasting &&
       !isCodeBlock
     ) {
-      plainText = plainText.trim().replace(/\r/g, "");
+      plainText = plainText.replace(/\r/g, "");
       const table = this._extractTable(plainText);
       if (table) {
         this.appEvents.trigger("composer:insert-text", table);

--- a/app/assets/javascripts/discourse/app/components/d-editor.js
+++ b/app/assets/javascripts/discourse/app/components/d-editor.js
@@ -313,6 +313,10 @@ export default Component.extend({
       this.appEvents.on("composer:replace-text", this, "_replaceText");
     }
     this._mouseTrap = mouseTrap;
+
+    if (isTesting()) {
+      this.element.addEventListener("paste", this.paste.bind(this));
+    }
   },
 
   _insertBlock(text) {
@@ -336,6 +340,10 @@ export default Component.extend({
       mouseTrap.unbind(sc)
     );
     $(this.element.querySelector(".d-editor-preview")).off("click.preview");
+
+    if (isTesting()) {
+      this.element.removeEventListener("paste", this.paste);
+    }
   },
 
   @discourseComputed()
@@ -870,7 +878,7 @@ export default Component.extend({
   },
 
   paste(e) {
-    if (!$(".d-editor-input").is(":focus")) {
+    if (!$(".d-editor-input").is(":focus") && !isTesting()) {
       return;
     }
 

--- a/app/assets/javascripts/discourse/tests/integration/components/d-editor-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/d-editor-test.js
@@ -84,6 +84,7 @@ function composerTestCase(title, testFunc) {
     beforeEach() {
       this.set("value", "hello world.");
     },
+
     test(assert) {
       const textarea = jumpEnd(queryAll("textarea.d-editor-input")[0]);
       testFunc.call(this, assert, textarea);
@@ -680,6 +681,26 @@ composerTestCase("replace-text event for composer", async function (assert) {
     .trigger("composer:replace-text", "green", "yellow");
 
   assert.equal(this.value, "red yellow blue");
+});
+
+function paste(element, text) {
+  let e = new Event("paste");
+  e.clipboardData = { getData: () => text };
+  element.dispatchEvent(e);
+}
+
+componentTest("paste table", {
+  template: "{{d-editor value=value composerEvents=true}}",
+  beforeEach() {
+    this.set("value", "");
+    this.siteSettings.enable_rich_text_paste = true;
+  },
+
+  async test(assert) {
+    let element = queryAll(".d-editor")[0];
+    await paste(element, "\ta\tb\n1\t2\t3");
+    assert.equal(this.value, "||a|b|\n|---|---|---|\n|1|2|3|\n");
+  },
 });
 
 (() => {


### PR DESCRIPTION
If we paste spreadsheet with the missing label we receive
`"	this \n1	2"`

If we trim whitespace at the beginning then our later calculation to determine if it is a table is incorrect (because we have 1 column in label and 2 columns in data row):

```
      const columns = rows.map((r) => r.split("\t").length);
      const isTable =
        columns.reduce((a, b) => a && columns[0] === b && b > 1)
```

https://meta.discourse.org/t/pasting-from-spreadsheet-wont-work-if-corner-cell-is-empty/169443