### PR TITLE
UX: Remove label and add danger class to remove draft button

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/user-stream-item.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/user-stream-item.hbs
@@ -68,6 +68,6 @@
 {{#if @item.editableDraft}}
   <div class="user-stream-item-draft-actions">
     {{d-button action=@resumeDraft actionParam=@item icon="pencil-alt" label="drafts.resume" class="btn-default resume-draft"}}
-    {{d-button action=@removeDraft actionParam=@item icon="far-trash-alt" label="drafts.remove" class="btn-default remove-draft"}}
+    {{d-button action=@removeDraft actionParam=@item icon="far-trash-alt" class="btn-danger remove-draft"}}
   </div>
 {{/if}}


### PR DESCRIPTION
Context: https://meta.discourse.org/t/confirm-removal-of-draft/169495/2?u=johani

This PR removes the label (since it's not needed) and changes the color of the delet draft button on the user's profile page.

before:


<img src="https://user-images.githubusercontent.com/33972521/98509264-dabc9780-229b-11eb-82cf-9613c5b23478.png" width="300">

after:

<img src="https://user-images.githubusercontent.com/33972521/98509292-ea3be080-229b-11eb-97d6-347d9b1eaae5.png" width="300">



