### PR TITLE
FIX: Paths with categories and tags were being generated incorrectly

### DIFF
--- a/app/assets/javascripts/discourse/app/models/nav-item.js
+++ b/app/assets/javascripts/discourse/app/models/nav-item.js
@@ -122,7 +122,12 @@ NavItem.reopenClass({
 
     if (context.tagId && Site.currentProp("filters").includes(filterType)) {
       includesTagContext = true;
-      path += "/tag";
+
+      if (context.category) {
+        path += "/tags";
+      } else {
+        path += "/tag";
+      }
     }
 
     if (context.category) {

--- a/app/assets/javascripts/discourse/tests/unit/models/nav-item-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/nav-item-test.js
@@ -8,23 +8,30 @@ import Site from "discourse/models/site";
 module("Unit | Model | nav-item", function (hooks) {
   hooks.beforeEach(function () {
     run(function () {
-      const asianCategory = Category.create({
-        name: "确实是这样",
-        id: 343434,
+      const fooCategory = Category.create({
+        slug: "foo",
+        id: 123,
       });
-      Site.currentProp("categories").addObject(asianCategory);
+      Site.currentProp("categories").addObject(fooCategory);
     });
   });
 
   test("href", function (assert) {
-    assert.expect(2);
+    assert.expect(4);
 
-    function href(text, expected, label) {
-      assert.equal(NavItem.fromText(text, {}).get("href"), expected, label);
+    function href(text, opts, expected, label) {
+      assert.equal(NavItem.fromText(text, opts).get("href"), expected, label);
     }
 
-    href("latest", "/latest", "latest");
-    href("categories", "/categories", "categories");
+    href("latest", {}, "/latest", "latest");
+    href("categories", {}, "/categories", "categories");
+    href("latest", { tagId: "bar" }, "/tag/bar/l/latest", "latest with tag");
+    href(
+      "latest",
+      { tagId: "bar", category: Category.findBySlugPath(["foo"]) },
+      "/tags/c/foo/123/bar/l/latest",
+      "latest with tag and category"
+    );
   });
 
   test("count", function (assert) {

--- a/app/assets/javascripts/select-kit/addon/components/tag-drop.js
+++ b/app/assets/javascripts/select-kit/addon/components/tag-drop.js
@@ -81,11 +81,13 @@ export default ComboBoxComponent.extend(TagsMixin, {
   }),
 
   noTagsUrl: computed("firstCategory", "secondCategory", function () {
-    let url = "/tag";
+    let url;
     if (this.currentCategory) {
-      url += `/c/${Category.slugFor(this.currentCategory)}/${
+      url = `/tags/c/${Category.slugFor(this.currentCategory)}/${
         this.currentCategory.id
       }`;
+    } else {
+      url = "/tag";
     }
     return getURL(`${url}/${NONE_TAG_ID}`);
   }),


### PR DESCRIPTION
Paths prefixed with /tag/ are exclusively for when the tag name is the
next string in the path. Therefore, when a category is being used as
context, the path should start with /tags/ instead.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
