### PR TITLE
FEATURE: Allow /u/by-external to work for all managed authenticators

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -492,6 +492,7 @@ Discourse::Application.routes.draw do
       get "#{root_path}/:username/notifications/:filter" => "users#show", constraints: { username: RouteFormat.username }
       delete "#{root_path}/:username" => "users#destroy", constraints: { username: RouteFormat.username }
       get "#{root_path}/by-external/:external_id" => "users#show", constraints: { external_id: /[^\/]+/ }
+      get "#{root_path}/by-external/:external_provider/:external_id" => "users#show", constraints: { external_id: /[^\/]+/ }
       get "#{root_path}/:username/flagged-posts" => "users#show", constraints: { username: RouteFormat.username }
       get "#{root_path}/:username/deleted-posts" => "users#show", constraints: { username: RouteFormat.username }
       get "#{root_path}/:username/topic-tracking-state" => "users#topic_tracking_state", constraints: { username: RouteFormat.username }

--- a/lib/auth/managed_authenticator.rb
+++ b/lib/auth/managed_authenticator.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 class Auth::ManagedAuthenticator < Auth::Authenticator
+  def is_managed?
+    # Tells core that it can safely assume this authenticator
+    # uses UserAssociatedAccount
+    true
+  end
+
   def description_for_user(user)
     associated_account = UserAssociatedAccount.find_by(provider_name: name, user_id: user.id)
     return "" if associated_account.nil?


### PR DESCRIPTION
Previously, `/u/by-external/{id}` would only work for 'Discourse SSO' systems. This commit adds a new 'provider' parameter to the URL: `/u/by-external/{provider}/{id}`

This is compatible with all auth methods which have migrated to the 'ManagedAuthenticator' pattern. At the time of this commit, that includes all core providers except GitHub, and includes popular plugins such as discourse-oauth2-basic and discourse-openid-connect.

The new route is admin-only, since some authenticators use sensitive information like email addresses as the external id.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
