### PR TITLE
FIX: Rename and deleting tags

### DIFF
--- a/app/assets/javascripts/discourse/app/adapters/tag.js
+++ b/app/assets/javascripts/discourse/app/adapters/tag.js
@@ -1,0 +1,7 @@
+import RESTAdapter from "discourse/adapters/rest";
+
+export default RESTAdapter.extend({
+  pathFor(store, type, id) {
+    return id ? `/tag/${id}` : `/tags`;
+  },
+});


### PR DESCRIPTION
The default mechanism for generating a path no longer works for tags.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
