### PR TITLE
FIX: Show hidden posts to staff members.

### DIFF
--- a/app/assets/javascripts/discourse/app/components/user-stream-item.js
+++ b/app/assets/javascripts/discourse/app/components/user-stream-item.js
@@ -1,16 +1,22 @@
 import Component from "@ember/component";
 import { propertyEqual } from "discourse/lib/computed";
+import { computed } from "@ember/object";
 import { actionDescription } from "discourse/widgets/post-small-action";
 
 export default Component.extend({
   classNameBindings: [
     ":user-stream-item",
     ":item", // DEPRECATED: 'item' class
-    "item.hidden",
+    "hidden",
     "item.deleted:deleted",
     "moderatorAction",
   ],
 
+  hidden: computed("item.hidden", function () {
+    return (
+      this.get("item.hidden") && !(this.currentUser && this.currentUser.staff)
+    );
+  }),
   moderatorAction: propertyEqual(
     "item.post_type",
     "site.post_types.moderator_action"


### PR DESCRIPTION
When looking at the list of a user's deleted posts, those that are also hidden are not listed. Context: https://meta.discourse.org/t/flagged-deleted-posts-do-not-show-up-on-users-profile/168527

