### PR TITLE
reduce min-width for better spacing, follow-up to 1455421

### DIFF
--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -260,7 +260,7 @@
       span.multi-username {
         @include ellipsis;
         flex: 0 1 auto;
-        min-width: 2em;
+        min-width: 1.2em;
         max-width: 10em;
         &:nth-of-type(2) {
           // margin for comma between username and username2


### PR DESCRIPTION
This needs a min-width so a long username doesn't truncate a short username into nothingness... but this was too large and causing a spacing issue with the comma