### PR TITLE
FIX: Remove duplicate category description

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/sub-category-row.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/sub-category-row.hbs
@@ -13,12 +13,6 @@
             {{sub-category-item category=subsubcategory hideUnread="true" listType=listType}}
           {{/each}}
         </div>
-      {{else}}
-        {{#if category.description_excerpt}}
-          <div class="category-description subcategory-description">
-            {{dir-span category.description_excerpt}}
-          </div>
-        {{/if}}
       {{/if}}
     </td>
   </tr>


### PR DESCRIPTION
This commit removes the duplicate category description on sub categories in the category list. I believe this went unnnoticed because we are hiding these by default.

![image](https://user-images.githubusercontent.com/30537603/98606175-5a526280-22ac-11eb-9135-d5821c960f0e.png)


<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
