### PR TITLE
Revert "DEV: Move popups left if application.hbs wrapper is moved by …

### DIFF
--- a/app/assets/javascripts/discourse/app/components/share-popup.js
+++ b/app/assets/javascripts/discourse/app/components/share-popup.js
@@ -69,10 +69,7 @@ export default Component.extend({
     }
 
     const shareLinkWidth = $this.width();
-    const pageLeftOffset = document.querySelector(
-      ".ember-application > .ember-view"
-    ).offsetLeft;
-    let x = $currentTargetOffset.left - pageLeftOffset - shareLinkWidth / 2;
+    let x = $currentTargetOffset.left - shareLinkWidth / 2;
     if (x < 25) {
       x = 25;
     }

--- a/app/assets/javascripts/discourse/app/mixins/card-contents-base.js
+++ b/app/assets/javascripts/discourse/app/mixins/card-contents-base.js
@@ -201,10 +201,7 @@ export default Mixin.create({
               }
             } else {
               // The site direction is ltr
-              const pageLeftOffset = document.querySelector(
-                ".ember-application > .ember-view"
-              ).offsetLeft;
-              position.left += target.width() - pageLeftOffset + 10;
+              position.left += target.width() + 10;
 
               let overage = $(window).width() - 50 - (position.left + width);
               if (overage < 0) {


### PR DESCRIPTION
…theme"

This reverts commit 95c871be3eaf2ac8d3268a9aa25e06df705a849a.

We no longer need this change. No known theme or plugin actually creates an issue and so this is adding complexity for no reason at this point.