### PR TITLE
FIX: Use more specific selector for header

### DIFF
--- a/app/assets/javascripts/discourse/app/initializers/webview-background.js
+++ b/app/assets/javascripts/discourse/app/initializers/webview-background.js
@@ -16,7 +16,7 @@ export default {
   },
   updateAppBackground() {
     later(() => {
-      const header = document.querySelectorAll(".d-header")[0];
+      const header = document.querySelector(".d-header-wrap .d-header");
       if (header) {
         const styles = window.getComputedStyle(header);
         postRNWebviewMessage("headerBg", styles.backgroundColor);


### PR DESCRIPTION
In some cases, we can have multiple `.d-header` elements on the page, this should help consistently select the correct element. 

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
