### PR TITLE
FIX: hide sso email behind a button click and log views

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-user-index.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-user-index.js
@@ -19,6 +19,7 @@ export default Controller.extend(CanCheckEmails, {
   customGroupIdsBuffer: null,
   availableGroups: null,
   userTitleValue: null,
+  ssoExternalEmail: null,
 
   showBadges: setting("enable_badges"),
   hasLockedTrustLevel: notEmpty("model.manual_locked_trust_level"),
@@ -338,6 +339,16 @@ export default Controller.extend(CanCheckEmails, {
           return this.model.deleteSSORecord();
         }
       );
+    },
+
+    checkSsoEmail() {
+      return ajax(userPath(`${this.model.username_lower}/sso-email.json`), {
+        data: { context: window.location.pathname },
+      }).then((result) => {
+        if (result) {
+          this.set("ssoExternalEmail", result.email);
+        }
+      });
     },
   },
 });

--- a/app/assets/javascripts/admin/addon/templates/user-index.hbs
+++ b/app/assets/javascripts/admin/addon/templates/user-index.hbs
@@ -671,10 +671,19 @@
         <div class="field">{{i18n "admin.user.sso.external_name"}}</div>
         <div class="value">{{sso.external_name}}</div>
       </div>
-      {{#if sso.external_email}}
+      {{#if canAdminCheckEmails}}
         <div class="display-row">
           <div class="field">{{i18n "admin.user.sso.external_email"}}</div>
-          <div class="value">{{sso.external_email}}</div>
+          {{#if ssoExternalEmail}}
+            <div class="value">{{ssoExternalEmail}}</div>
+          {{else}}
+            {{d-button
+              class="btn-default"
+              action=(action "checkSsoEmail")
+              actionParam=model icon="far-envelope"
+              label="admin.users.check_email.text"
+              title="admin.users.check_email.title"}}
+          {{/if}}
         </div>
       {{/if}}
       <div class="display-row">

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,7 +11,7 @@ class UsersController < ApplicationController
     :update_second_factor, :create_second_factor_backup, :select_avatar,
     :notification_level, :revoke_auth_token, :register_second_factor_security_key,
     :create_second_factor_security_key, :feature_topic, :clear_featured_topic,
-    :bookmarks, :invited, :invite_links
+    :bookmarks, :invited, :invite_links, :check_sso_email
   ]
 
   skip_before_action :check_xhr, only: [
@@ -202,6 +202,22 @@ class UsersController < ApplicationController
       unconfirmed_emails: unconfirmed_emails,
       associated_accounts: user.associated_accounts
     }
+  rescue Discourse::InvalidAccess
+    render json: failed_json, status: 403
+  end
+
+  def check_sso_email
+    user = fetch_user_from_params(include_inactive: true)
+
+    unless user == current_user
+      guardian.ensure_can_check_sso_email!(user)
+      StaffActionLogger.new(current_user).log_check_email(user, context: params[:context])
+    end
+
+    email = user&.single_sign_on_record&.external_email
+    email = I18n.t("user.email.does_not_exist") if email.blank?
+
+    render json: { email: email }
   rescue Discourse::InvalidAccess
     render json: failed_json, status: 403
   end

--- a/app/serializers/single_sign_on_record_serializer.rb
+++ b/app/serializers/single_sign_on_record_serializer.rb
@@ -4,12 +4,7 @@ class SingleSignOnRecordSerializer < ApplicationSerializer
   attributes :user_id, :external_id,
              :last_payload, :created_at,
              :updated_at, :external_username,
-             :external_email, :external_name,
-             :external_avatar_url,
+             :external_name, :external_avatar_url,
              :external_profile_background_url,
              :external_card_background_url
-
-  def include_external_email?
-    scope.is_admin?
-  end
 end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2501,6 +2501,7 @@ en:
       not_allowed: "is not allowed from that email provider. Please use another email address."
       blocked: "is not allowed."
       revoked: "Won't be sending emails to '%{email}' until %{date}."
+      does_not_exist: "N/A"
     ip_address:
       blocked: "New registrations are not allowed from your IP address."
       max_new_accounts_per_registration_ip: "New registrations are not allowed from your IP address (maximum limit reached). Contact a staff member."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -446,6 +446,7 @@ Discourse::Application.routes.draw do
       get({ "#{root_path}/:username" => "users#show", constraints: { username: RouteFormat.username } }.merge(index == 1 ? { as: 'user' } : {}))
       put "#{root_path}/:username" => "users#update", constraints: { username: RouteFormat.username }, defaults: { format: :json }
       get "#{root_path}/:username/emails" => "users#check_emails", constraints: { username: RouteFormat.username }
+      get "#{root_path}/:username/sso-email" => "users#check_sso_email", constraints: { username: RouteFormat.username }
       get "#{root_path}/:username/preferences" => "users#preferences", constraints: { username: RouteFormat.username }
       get "#{root_path}/:username/preferences/email" => "users_email#index", constraints: { username: RouteFormat.username }
       get "#{root_path}/:username/preferences/account" => "users#preferences", constraints: { username: RouteFormat.username }

--- a/lib/guardian/user_guardian.rb
+++ b/lib/guardian/user_guardian.rb
@@ -92,6 +92,10 @@ module UserGuardian
     is_admin? || (is_staff? && SiteSetting.moderators_view_emails)
   end
 
+  def can_check_sso_email?(user)
+    user && is_admin?
+  end
+
   def restrict_user_fields?(user)
     user.trust_level == TrustLevel[0] && anonymous?
   end

--- a/spec/serializers/single_sign_on_record_serializer_spec.rb
+++ b/spec/serializers/single_sign_on_record_serializer_spec.rb
@@ -18,20 +18,6 @@ RSpec.describe SingleSignOnRecordSerializer do
       payload = serializer.as_json
       expect(payload[:user_id]).to eq(user.id)
       expect(payload[:external_id]).to eq('12345')
-      expect(payload[:external_email]).to eq(user.email)
-    end
-  end
-
-  context "moderator" do
-    fab!(:moderator) { Fabricate(:moderator) }
-    let :serializer do
-      SingleSignOnRecordSerializer.new(sso, scope: Guardian.new(moderator), root: false)
-    end
-
-    it "should include user sso info" do
-      payload = serializer.as_json
-      expect(payload[:user_id]).to eq(user.id)
-      expect(payload[:external_id]).to eq('12345')
       expect(payload[:external_email]).to be_nil
     end
   end


### PR DESCRIPTION
This commit hides the SSO email behind a button, clicking on which log the email view.

<img width="325" alt="Screenshot 2020-11-10 at 10 10 41 PM" src="https://user-images.githubusercontent.com/5732281/98703628-b6e37980-23a1-11eb-92b5-ff8bc7d644c8.png">

Note that moderators can't see SSO email so they won't see this button (entire "Email" row).

Meta topic: https://meta.discourse.org/t/user-email-is-not-hidden-under-single-sign-on-area-of-admin-page/160657/