### PR TITLE
FIX: when creating linked topics make sure they belong to same category

### DIFF
--- a/app/jobs/regular/create_linked_topic.rb
+++ b/app/jobs/regular/create_linked_topic.rb
@@ -7,8 +7,9 @@ module Jobs
       reference_post = Post.find_by(id: args[:post_id])
       return unless reference_post.present?
       parent_topic = reference_post.topic
-      return unless parent_topic.present?
+      return unless parent_topic.present? && parent_topic.regular?
       parent_topic_id = parent_topic.id
+      parent_category_id = parent_topic.category_id
       parent_title = parent_topic.title
       @post_creator = nil
 
@@ -47,6 +48,7 @@ module Jobs
           system_user,
           title: new_topic_title,
           raw: new_topic_raw,
+          category: parent_category_id,
           skip_validations: true,
           skip_jobs: true)
         new_post = @post_creator.create

--- a/spec/jobs/create_linked_topic_spec.rb
+++ b/spec/jobs/create_linked_topic_spec.rb
@@ -11,7 +11,8 @@ describe Jobs::CreateLinkedTopic do
 
   context 'with a post' do
 
-    fab!(:topic) { Fabricate(:topic) }
+    fab!(:category) { Fabricate(:category) }
+    fab!(:topic) { Fabricate(:topic, category: category) }
     fab!(:post) do
       Fabricate(:post, topic: topic)
     end
@@ -48,6 +49,7 @@ describe Jobs::CreateLinkedTopic do
       expect(topic.posts.last.raw).to include(I18n.t('create_linked_topic.small_action_post_raw', new_title: "[#{new_topic.title}](#{new_topic.url})"))
       expect(new_topic.title).to include(I18n.t("create_linked_topic.topic_title_with_sequence", topic_title: raw_title, count: 2))
       expect(new_topic.first_post.raw).to include(topic.url)
+      expect(new_topic.category.id).to eq(category.id)
       expect(new_topic.topic_users.count).to eq(3)
       expect(new_topic.topic_users.pluck(:notification_level)).to contain_exactly(muted, tracking, watching)
       expect(linked_topic.topic_id).to eq(new_topic.id)


### PR DESCRIPTION
This PR fixes a bug where the newly created linked topic was being assigned "uncategorized" category. Now we'll assign linked topics the same category as that of parent topic.

Meta reference: https://meta.discourse.org/t/linked-topics-splitting-and-managing-megatopics/168992/10?u=techapj
