### PR TITLE
FIX: Disallow editing of remote themes

### DIFF
--- a/app/assets/javascripts/admin/addon/routes/admin-customize-themes-edit.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-customize-themes-edit.js
@@ -28,6 +28,10 @@ export default Route.extend({
     const fields = wrapper.model
       .get("fields")
       [wrapper.target].map((f) => f.name);
+    if (wrapper.model.remote_theme) {
+      this.transitionTo("adminCustomizeThemes.index");
+      return;
+    }
     if (!fields.includes(wrapper.field_name)) {
       this.transitionTo(
         "adminCustomizeThemes.edit",

--- a/app/assets/javascripts/admin/addon/templates/customize-themes-show.hbs
+++ b/app/assets/javascripts/admin/addon/templates/customize-themes-show.hbs
@@ -1,4 +1,5 @@
 <div class="show-current-style">
+  {{plugin-outlet name="admin-customize-themes-show-top" args=(hash remote=model.remote_theme)}}
   <div class="title">
     {{#if editingName}}
       {{text-field value=model.name autofocus="true"}}

--- a/app/assets/javascripts/admin/addon/templates/customize-themes-show.hbs
+++ b/app/assets/javascripts/admin/addon/templates/customize-themes-show.hbs
@@ -1,5 +1,5 @@
 <div class="show-current-style">
-  {{plugin-outlet name="admin-customize-themes-show-top" args=(hash remote=model.remote_theme)}}
+  {{plugin-outlet name="admin-customize-themes-show-top" args=(hash theme=model)}}
   <div class="title">
     {{#if editingName}}
       {{text-field value=model.name autofocus="true"}}

--- a/app/assets/javascripts/admin/addon/templates/customize-themes-show.hbs
+++ b/app/assets/javascripts/admin/addon/templates/customize-themes-show.hbs
@@ -213,26 +213,26 @@
         action=(action "editTheme")
         label="admin.customize.theme.edit_css_html"}}
     </div>
-  {{/unless}}
 
-  <div class="control-unit">
-    <div class="mini-title">{{i18n "admin.customize.theme.uploads"}}</div>
-    {{#if model.uploads}}
-      <ul class="removable-list">
-        {{#each model.uploads as |upload|}}
-          <li>
-            <span class="col">${{upload.name}}: <a href={{upload.url}} rel="noopener noreferrer" target="_blank">{{upload.filename}}</a></span>
-            <span class="col">
-              {{d-button action=(action "removeUpload") actionParam=upload class="second btn-default btn-default cancel-edit" icon="times"}}
-            </span>
-          </li>
-        {{/each}}
-      </ul>
-    {{else}}
-      <div class="description">{{i18n "admin.customize.theme.no_uploads"}}</div>
-    {{/if}}
-    {{d-button action=(action "addUploadModal") class="btn-default" icon="plus" label="admin.customize.theme.add"}}
-  </div>
+    <div class="control-unit">
+      <div class="mini-title">{{i18n "admin.customize.theme.uploads"}}</div>
+      {{#if model.uploads}}
+        <ul class="removable-list">
+          {{#each model.uploads as |upload|}}
+            <li>
+              <span class="col">${{upload.name}}: <a href={{upload.url}} rel="noopener noreferrer" target="_blank">{{upload.filename}}</a></span>
+              <span class="col">
+                {{d-button action=(action "removeUpload") actionParam=upload class="second btn-default btn-default cancel-edit" icon="times"}}
+              </span>
+            </li>
+          {{/each}}
+        </ul>
+      {{else}}
+        <div class="description">{{i18n "admin.customize.theme.no_uploads"}}</div>
+      {{/if}}
+      {{d-button action=(action "addUploadModal") class="btn-default" icon="plus" label="admin.customize.theme.add"}}
+    </div>
+  {{/unless}}
 
   {{#if extraFiles.length}}
     <div class="control-unit">

--- a/app/assets/javascripts/admin/addon/templates/customize-themes-show.hbs
+++ b/app/assets/javascripts/admin/addon/templates/customize-themes-show.hbs
@@ -191,26 +191,28 @@
     {{/d-section}}
   {{/if}}
 
-  <div class="control-unit">
-    <div class="mini-title">{{i18n "admin.customize.theme.css_html"}}</div>
-    {{#if model.hasEditedFields}}
-      <div class="description">{{i18n "admin.customize.theme.custom_sections"}}</div>
-      <ul>
-        {{#each editedFieldsFormatted as |field|}}
-          <li>{{field}}</li>
-        {{/each}}
-      </ul>
-    {{else}}
-      <div class="description">
-        {{i18n "admin.customize.theme.edit_css_html_help"}}
-      </div>
-    {{/if}}
+  {{#unless model.remote_theme}}
+    <div class="control-unit">
+      <div class="mini-title">{{i18n "admin.customize.theme.css_html"}}</div>
+      {{#if model.hasEditedFields}}
+        <div class="description">{{i18n "admin.customize.theme.custom_sections"}}</div>
+        <ul>
+          {{#each editedFieldsFormatted as |field|}}
+            <li>{{field}}</li>
+          {{/each}}
+        </ul>
+      {{else}}
+        <div class="description">
+          {{i18n "admin.customize.theme.edit_css_html_help"}}
+        </div>
+      {{/if}}
 
-    {{d-button
-      class="btn-default edit"
-      action=(action "editTheme")
-      label="admin.customize.theme.edit_css_html"}}
-  </div>
+      {{d-button
+        class="btn-default edit"
+        action=(action "editTheme")
+        label="admin.customize.theme.edit_css_html"}}
+    </div>
+  {{/unless}}
 
   <div class="control-unit">
     <div class="mini-title">{{i18n "admin.customize.theme.uploads"}}</div>

--- a/app/controllers/admin/themes_controller.rb
+++ b/app/controllers/admin/themes_controller.rb
@@ -299,6 +299,10 @@ class Admin::ThemesController < Admin::AdminController
     raise Discourse::InvalidAccess if !GlobalSetting.allowed_theme_ids.nil?
   end
 
+  def ban_for_remote_theme!
+    raise Discourse::InvalidAccess if @theme.remote_theme
+  end
+
   def add_relative_themes!(kind, ids)
     expected = ids.map(&:to_i)
 
@@ -357,6 +361,7 @@ class Admin::ThemesController < Admin::AdminController
     return unless fields = theme_params[:theme_fields]
 
     ban_in_allowlist_mode!
+    ban_for_remote_theme!
 
     fields.each do |field|
       @theme.set_field(

--- a/app/controllers/admin/themes_controller.rb
+++ b/app/controllers/admin/themes_controller.rb
@@ -363,9 +363,9 @@ class Admin::ThemesController < Admin::AdminController
     return unless fields = theme_params[:theme_fields]
 
     ban_in_allowlist_mode!
+    ban_for_remote_theme!
 
     fields.each do |field|
-      next if @theme.remote_theme && field[:type_id] != UPLOAD_TYPE_ID
       @theme.set_field(
         target: field[:target],
         name: field[:name],

--- a/app/controllers/admin/themes_controller.rb
+++ b/app/controllers/admin/themes_controller.rb
@@ -6,8 +6,6 @@ class Admin::ThemesController < Admin::AdminController
 
   skip_before_action :check_xhr, only: [:show, :preview, :export]
 
-  UPLOAD_TYPE_ID = 2
-
   def preview
     theme = Theme.find_by(id: params[:id])
     raise Discourse::InvalidParameters.new(:id) unless theme

--- a/app/controllers/admin/themes_controller.rb
+++ b/app/controllers/admin/themes_controller.rb
@@ -6,6 +6,8 @@ class Admin::ThemesController < Admin::AdminController
 
   skip_before_action :check_xhr, only: [:show, :preview, :export]
 
+  UPLOAD_TYPE_ID = 2
+
   def preview
     theme = Theme.find_by(id: params[:id])
     raise Discourse::InvalidParameters.new(:id) unless theme
@@ -361,9 +363,9 @@ class Admin::ThemesController < Admin::AdminController
     return unless fields = theme_params[:theme_fields]
 
     ban_in_allowlist_mode!
-    ban_for_remote_theme!
 
     fields.each do |field|
+      next if @theme.remote_theme && field[:type_id] != UPLOAD_TYPE_ID
       @theme.set_field(
         target: field[:target],
         name: field[:name],

--- a/spec/requests/admin/themes_controller_spec.rb
+++ b/spec/requests/admin/themes_controller_spec.rb
@@ -370,6 +370,22 @@ describe Admin::ThemesController do
       expect(UserHistory.where(action: UserHistory.actions[:change_theme]).count).to eq(1)
     end
 
+    it 'blocks remote theme fields from being locally edited' do
+      r = RemoteTheme.create!(remote_url: "https://magic.com/repo.git")
+      theme.update!(remote_theme_id: r.id)
+
+      put "/admin/themes/#{theme.id}.json", params: {
+        theme: {
+          theme_fields: [
+            { name: 'scss', target: 'common', value: '' },
+            { name: 'test', target: 'common', value: 'filename.jpg', upload_id: 4 }
+          ]
+        }
+      }
+
+      expect(response.status).to eq(403)
+    end
+
     it 'updates a child theme' do
       child_theme = Fabricate(:theme, component: true)
       put "/admin/themes/#{child_theme.id}.json", params: {


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->

Allowing the editing of remote themes has been something Discourse has advised against for some time. This PR removes the ability to edit remote themes from Admin > Customize. 

I took a dive into the backend and didn't see a clear or easy path for restricting editing for remote themes, as we use the same `theme#update` method for both editing local themes and updating themes from a remote repository. 

We will not merge this PR until after the 2.6 release is completed.