### PR TITLE
UX: increase limit of custom user fields

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-user-fields.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-user-fields.js
@@ -4,7 +4,7 @@ import Controller from "@ember/controller";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import bootbox from "bootbox";
 
-const MAX_FIELDS = 20;
+const MAX_FIELDS = 30;
 
 export default Controller.extend({
   fieldTypes: null,


### PR DESCRIPTION
Increase limit of custom user fields from 20 to 30

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
