### PR TITLE
DEV: Move logout redirect logic to server and add plugin hook

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/logout.js
+++ b/app/assets/javascripts/discourse/app/lib/logout.js
@@ -2,13 +2,13 @@ import getURL from "discourse-common/lib/get-url";
 import { isEmpty } from "@ember/utils";
 import { helperContext } from "discourse-common/lib/helpers";
 
-export default function logout({ redirect_url } = {}) {
+export default function logout({ redirect } = {}) {
   const ctx = helperContext();
   let keyValueStore = ctx.keyValueStore;
   keyValueStore.abandonLocal();
 
-  if (!isEmpty(redirect_url)) {
-    window.location.href = redirect_url;
+  if (!isEmpty(redirect)) {
+    window.location.href = redirect;
     return;
   }
 

--- a/app/assets/javascripts/discourse/app/lib/logout.js
+++ b/app/assets/javascripts/discourse/app/lib/logout.js
@@ -1,28 +1,14 @@
 import getURL from "discourse-common/lib/get-url";
 import { isEmpty } from "@ember/utils";
-import { findAll } from "discourse/models/login-method";
 import { helperContext } from "discourse-common/lib/helpers";
 
-export default function logout() {
+export default function logout({ redirect_url } = {}) {
   const ctx = helperContext();
-  let siteSettings = ctx.siteSettings;
   let keyValueStore = ctx.keyValueStore;
   keyValueStore.abandonLocal();
 
-  const redirect = siteSettings.logout_redirect;
-  if (!isEmpty(redirect)) {
-    window.location.href = redirect;
-    return;
-  }
-
-  const sso = siteSettings.enable_sso;
-  const oneAuthenticator =
-    !siteSettings.enable_local_logins && findAll().length === 1;
-
-  if (siteSettings.login_required && (sso || oneAuthenticator)) {
-    // In this situation visiting most URLs will start the auth process again
-    // Go to the `/login` page to avoid an immediate redirect
-    window.location.href = getURL("/login");
+  if (!isEmpty(redirect_url)) {
+    window.location.href = redirect_url;
     return;
   }
 

--- a/app/assets/javascripts/discourse/app/routes/application.js
+++ b/app/assets/javascripts/discourse/app/routes/application.js
@@ -278,7 +278,9 @@ const ApplicationRoute = DiscourseRoute.extend(OpenComposer, {
 
   _handleLogout() {
     if (this.currentUser) {
-      this.currentUser.destroySession().then(logout);
+      this.currentUser
+        .destroySession()
+        .then((response) => logout({ redirect: response["redirect_url"] }));
     }
   },
 });

--- a/app/assets/javascripts/discourse/app/routes/application.js
+++ b/app/assets/javascripts/discourse/app/routes/application.js
@@ -278,7 +278,7 @@ const ApplicationRoute = DiscourseRoute.extend(OpenComposer, {
 
   _handleLogout() {
     if (this.currentUser) {
-      this.currentUser.destroySession().then(() => logout());
+      this.currentUser.destroySession().then(logout);
     }
   },
 });


### PR DESCRIPTION
This will allow authentication plugins to provide single-logout functionality by redirecting users to the identity provider after logout.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
