### PR TITLE
FIX: Do not optimize uploaded custom emoji

### DIFF
--- a/lib/upload_creator.rb
+++ b/lib/upload_creator.rb
@@ -371,6 +371,8 @@ class UploadCreator
   end
 
   def should_crop?
+    return false if @opts[:type] == 'custom_emoji' && animated?(@file)
+
     TYPES_TO_CROP.include?(@opts[:type])
   end
 

--- a/spec/lib/upload_creator_spec.rb
+++ b/spec/lib/upload_creator_spec.rb
@@ -443,6 +443,21 @@ RSpec.describe UploadCreator do
         end
       end
     end
+
+    context 'custom emojis' do
+      let(:animated_filename) { "animated.gif" }
+      let(:animated_file) { file_from_fixtures(animated_filename) }
+
+      it 'should not be cropped if animated' do
+        upload = UploadCreator.new(animated_file, animated_filename,
+          force_optimize: true,
+          type: 'custom_emoji'
+        ).create_for(user.id)
+
+        expect(upload.animated).to eq(true)
+        expect(FastImage.size(Discourse.store.path_for(upload))).to eq([320, 320])
+      end
+    end
   end
 
   describe '#clean_svg!' do


### PR DESCRIPTION
Animated emojis were converted to static images. This commit moves the
responsability on site admins to optimize their animated emojis before
uploading them (gifsicle is no longer used).

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
