### PR TITLE
DEV: Skip parallel autospec spec for a single file

### DIFF
--- a/lib/autospec/simple_runner.rb
+++ b/lib/autospec/simple_runner.rb
@@ -22,9 +22,9 @@ module Autospec
       ]
 
       command = begin
-        if ENV["PARALLEL_SPEC"] == '1' &&
-              !specs.split.any? { |s| puts s; s =~ /\:/ } # Parallel spec can't run specific groups
-
+        line_specified = specs.split.any? { |s| s =~ /\:/ } # Parallel spec can't run specific line
+        multiple_files = specs.split.count > 1 # Only paralellize multiple files
+        if ENV["PARALLEL_SPEC"] == '1' && multiple_files && !line_specified
           "bin/turbo_rspec #{args.join(" ")} #{specs.split.join(" ")}"
         else
           "bin/rspec #{args.join(" ")} #{specs.split.join(" ")}"


### PR DESCRIPTION
turbo_rspec can't parallelize a single spec file, so it's not worth the extra setup time for the parallel runner

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
