### PR TITLE
FIX: Ensure staff can see /tag/none

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -453,6 +453,7 @@ class TagsController < ::ApplicationController
     options[:no_subcategories] = true if params[:no_subcategories] == 'true'
 
     if params[:tag_id] == 'none'
+      options.delete(:tags)
       options[:no_tags] = true
     else
       options[:tags] = tag_params

--- a/spec/requests/tags_controller_spec.rb
+++ b/spec/requests/tags_controller_spec.rb
@@ -123,6 +123,8 @@ describe TagsController do
 
   describe '#show' do
     fab!(:tag) { Fabricate(:tag, name: 'test') }
+    fab!(:topic_without_tags) { Fabricate(:topic) }
+    fab!(:topic_with_tags) { Fabricate(:topic, tags: [tag]) }
 
     it "should return the right response" do
       get "/tag/test.json"
@@ -160,6 +162,15 @@ describe TagsController do
 
       get "/tag/test"
       expect(response.status).to eq(200)
+    end
+
+    it "handles special tag 'none'" do
+      SiteSetting.allow_staff_to_tag_pms = true
+
+      sign_in(admin)
+
+      get "/tag/none.json"
+      expect(response.parsed_body['topic_list']['topics'].length).to eq(1)
     end
 
     context "with a category in the path" do


### PR DESCRIPTION
TopicQueryParams#build_topic_list_options changes params which could
lead to options[:no_tags] and options[:tags] be set simultaneously.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
