### PR TITLE
another edit to text when no invites to display

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1405,7 +1405,7 @@ en:
           max_redemptions_allowed_label: "How many people are allowed to register using this link?"
           expires_at: "When will this invite link expire?"
         bulk_invite:
-          none: "No invitations to display on this page. You can invite specific people using their email, or create an invite link that can be used by anybody."
+          none: "No invitations to display on this page."
           text: "Bulk Invite"
           success: "File uploaded successfully, you will be notified via message when the process is complete."
           error: "Sorry, file should be CSV format."


### PR DESCRIPTION
this copy is also shown when viewing invite tabs of other users, so the instructions don't make sense in all cases. shortened it to just say "No invitations to display on this page." users can discover this on their own.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
