### PR TITLE
UX: Use appropriate logo on static pages

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -291,10 +291,18 @@ module ApplicationHelper
 
   def application_logo_url
     @application_logo_url ||= begin
-      if mobile_view? && SiteSetting.site_mobile_logo_url.present?
-        SiteSetting.site_mobile_logo_url
+      if mobile_view?
+        if dark_color_scheme? && SiteSetting.site_mobile_logo_dark_url.present?
+          SiteSetting.site_mobile_logo_dark_url
+        elsif SiteSetting.site_mobile_logo_url.present?
+          SiteSetting.site_mobile_logo_url
+        end
       else
-        SiteSetting.site_logo_url
+        if dark_color_scheme? && SiteSetting.site_logo_dark_url.present?
+          SiteSetting.site_logo_dark_url
+        else
+          SiteSetting.site_logo_url
+        end
       end
     end
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -81,6 +81,55 @@ describe ApplicationHelper do
     end
   end
 
+  describe "application_logo_url" do
+    context "when a dark color scheme is active" do
+      before do
+        dark_theme = Theme.create(
+          name: "Dark",
+          user_id: -1,
+          color_scheme_id: ColorScheme.find_by(base_scheme_id: "Dark").id
+        )
+        helper.request.env[:resolved_theme_ids] = [dark_theme.id]
+      end
+      context "on desktop" do
+        before do
+          session[:mobile_view] = '0'
+        end
+        context "when logo_dark is not set" do
+          it "will return site_logo_url instead" do
+            expect(helper.application_logo_url).to eq(SiteSetting.site_logo_url)
+          end
+        end
+        context "when logo_dark is set" do
+          before do
+            SiteSetting.logo_dark = Fabricate(:upload, url: '/images/logo-dark.png')
+          end
+          it "will return site_logo_dark_url" do
+            expect(helper.application_logo_url).to eq(SiteSetting.site_logo_dark_url)
+          end
+        end
+      end
+      context "on mobile" do
+        before do
+          session[:mobile_view] = '1'
+        end
+        context "when mobile_logo_dark is not set" do
+          it "will return site_mobile_logo_url instead" do
+            expect(helper.application_logo_url).to eq(SiteSetting.site_mobile_logo_url)
+          end
+        end
+        context "when mobile_logo_dark is set" do
+          before do
+            SiteSetting.mobile_logo_dark = Fabricate(:upload, url: '/images/mobile-logo-dark.png')
+          end
+          it "will return site_mobile_logo_dark_url" do
+            expect(helper.application_logo_url).to eq(SiteSetting.site_mobile_logo_dark_url)
+          end
+        end
+      end
+    end
+  end
+
   describe "mobile_view?" do
     context "enable_mobile_theme is true" do
       before do


### PR DESCRIPTION
Now that we have dark logo settings in core, we can relatively easily ensure that static pages (such as the 404 page) use a logo that is appropriate for the given light or dark color scheme.

This issue has been mentioned in at least a couple discussions on Meta:

https://meta.discourse.org/t/404-page-uses-incorrect-dark-theme-logo/138276
https://meta.discourse.org/t/certain-verification-pages-do-not-respect-the-selected-theme/86686/9

I'm not sure if the spec is too much or too little in this case, so please let me know if anything needs adjustment there.