### PR TITLE
FIX: Do not optimize animated images in cooked posts

### DIFF
--- a/lib/cooked_post_processor.rb
+++ b/lib/cooked_post_processor.rb
@@ -384,7 +384,7 @@ class CookedPostProcessor
     w, h = img["width"].to_i, img["height"].to_i
 
     # note: optimize_urls cooks the src and data-small-upload further after this
-    thumbnail = upload.thumbnail(w, h)
+    thumbnail = !upload.animated && upload.thumbnail(w, h)
     if thumbnail && thumbnail.filesize.to_i < upload.filesize
       img["src"] = thumbnail.url
 

--- a/spec/components/cooked_post_processor_spec.rb
+++ b/spec/components/cooked_post_processor_spec.rb
@@ -960,6 +960,19 @@ describe CookedPostProcessor do
       expect(doc.css('img').first['srcset']).to_not eq(nil)
     end
 
+    it "does not optimize animated images" do
+      upload.update!(animated: true)
+      post = Fabricate(:post, raw: "![image|1024x768, 50%](#{upload.short_url})")
+
+      cpp = CookedPostProcessor.new(post, disable_loading_image: true)
+      cpp.post_process
+
+      doc = Nokogiri::HTML5::fragment(cpp.html)
+      expect(doc.css('.lightbox-wrapper').size).to eq(1)
+      expect(doc.css('img').first['src']).to include(upload.url)
+      expect(doc.css('img').first['srcset']).to eq(nil)
+    end
+
     it "optimizes images in quotes" do
       post = Fabricate(:post, raw: <<~MD)
         [quote]


### PR DESCRIPTION
CookedPostProcessor replaces all large images with their optimized
versions, but for GIF images the optimized version is limited to first
frame only. This caused animations it cooked posts to require a click
to show up the lightbox and start playing.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
