### PR TITLE
FEATURE: Link site setting titles directly to their change log

### DIFF
--- a/app/assets/javascripts/admin/addon/components/site-setting.js
+++ b/app/assets/javascripts/admin/addon/components/site-setting.js
@@ -2,6 +2,7 @@ import Component from "@ember/component";
 import BufferedContent from "discourse/mixins/buffered-content";
 import SiteSetting from "admin/models/site-setting";
 import SettingComponent from "admin/mixins/setting-component";
+import { readOnly } from "@ember/object/computed";
 
 export default Component.extend(BufferedContent, SettingComponent, {
   updateExistingUsers: null,
@@ -12,4 +13,6 @@ export default Component.extend(BufferedContent, SettingComponent, {
       updateExistingUsers: this.updateExistingUsers,
     });
   },
+
+  staffLogFilter: readOnly("setting.staffLogFilter"),
 });

--- a/app/assets/javascripts/admin/addon/models/site-setting.js
+++ b/app/assets/javascripts/admin/addon/models/site-setting.js
@@ -2,8 +2,21 @@ import I18n from "I18n";
 import { ajax } from "discourse/lib/ajax";
 import Setting from "admin/mixins/setting-object";
 import EmberObject from "@ember/object";
+import discourseComputed from "discourse-common/utils/decorators";
 
-const SiteSetting = EmberObject.extend(Setting, {});
+const SiteSetting = EmberObject.extend(Setting, {
+  @discourseComputed("setting")
+  staffLogFilter(setting) {
+    if (!setting) {
+      return;
+    }
+
+    return JSON.stringify({
+      subject: setting,
+      action_name: "change_site_setting",
+    });
+  },
+});
 
 SiteSetting.reopenClass({
   findAll() {

--- a/app/assets/javascripts/admin/addon/templates/components/site-setting.hbs
+++ b/app/assets/javascripts/admin/addon/templates/components/site-setting.hbs
@@ -1,5 +1,16 @@
 <div class="setting-label">
-  <h3>{{settingName}}</h3>
+  <h3>
+    {{#if staffLogFilter}}
+      {{#link-to "adminLogs.staffActionLogs" (query-params filter=staffLogFilter) title=(i18n "admin.settings.history")}}
+        {{settingName}}
+        <span class="history-icon">
+          {{d-icon "history"}}
+        </span>
+      {{/link-to}}
+    {{else}}
+      {{settingName}}
+    {{/if}}
+  </h3>
   {{#if defaultIsAvailable}}
     <a href onClick={{action "setDefaultValues"}}>{{setting.setDefaultValuesLabel}}</a>
   {{/if}}

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-site-settings-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-site-settings-test.js
@@ -1,3 +1,4 @@
+import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
 import { fillIn, click, visit, currentURL } from "@ember/test-helpers";
 import { test } from "qunit";
@@ -39,6 +40,16 @@ acceptance("Admin - Site Settings", function (needs) {
     );
 
     assert.ok(exists(".row.setting.upload .undo"), "undo button is present");
+  });
+
+  test("links to staff action log", async function (assert) {
+    await visit("/admin/site_settings");
+
+    assert.equal(
+      queryAll(".row.setting .setting-label h3 a").attr("href"),
+      "/admin/logs/staff_action_logs?filter=%7B%22subject%22%3A%22title%22%2C%22action_name%22%3A%22change_site_setting%22%7D",
+      "it links to the staff action log"
+    );
   });
 
   test("changing value updates dirty state", async function (assert) {

--- a/app/assets/stylesheets/common/admin/settings.scss
+++ b/app/assets/stylesheets/common/admin/settings.scss
@@ -15,6 +15,19 @@
           margin-bottom: 6px;
         }
       }
+      h3 {
+        a:any-link {
+          color: unset;
+        }
+        .history-icon {
+          opacity: 0;
+          transition: opacity 0.3s;
+          color: var(--primary-medium);
+        }
+        &:hover .history-icon {
+          opacity: 1;
+        }
+      }
     }
     .setting-value {
       float: left;

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4767,6 +4767,7 @@ en:
 
       settings: # used by theme and site settings
         show_overriden: "Only show overridden"
+        history: "View change history"
         reset: "reset"
         none: "none"
       site_settings:


### PR DESCRIPTION
This makes it much easier to check the staff action logs for a specific site setting. A small history icon will appear when hovering over a site setting name. On click, you will be taken to the pre-filtered staff action log for the site setting.

<img width="300" alt="Screenshot 2020-11-12 at 11 33 34" src="https://user-images.githubusercontent.com/6270921/98937591-86552a00-24de-11eb-9c41-ec09d1f43275.png">


<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
