### PR TITLE
FIX: Add history icon to svg_sprite list

### DIFF
--- a/lib/svg_sprite/svg_sprite.rb
+++ b/lib/svg_sprite/svg_sprite.rb
@@ -129,6 +129,7 @@ module SvgSprite
     "hands-helping",
     "heading",
     "heart",
+    "history",
     "home",
     "hourglass-start",
     "id-card",


### PR DESCRIPTION
Follow-up to a4441b3984e4f518d8cddd7111e9b07eff5c0155

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
