### PR TITLE
FIX: Use `filters` parameter instead of `filter` for staff action log

### DIFF
--- a/app/assets/javascripts/admin/addon/models/site-setting.js
+++ b/app/assets/javascripts/admin/addon/models/site-setting.js
@@ -11,10 +11,10 @@ const SiteSetting = EmberObject.extend(Setting, {
       return;
     }
 
-    return JSON.stringify({
+    return {
       subject: setting,
       action_name: "change_site_setting",
-    });
+    };
   },
 });
 

--- a/app/assets/javascripts/admin/addon/templates/components/site-setting.hbs
+++ b/app/assets/javascripts/admin/addon/templates/components/site-setting.hbs
@@ -1,7 +1,7 @@
 <div class="setting-label">
   <h3>
     {{#if staffLogFilter}}
-      {{#link-to "adminLogs.staffActionLogs" (query-params filter=staffLogFilter) title=(i18n "admin.settings.history")}}
+      {{#link-to "adminLogs.staffActionLogs" (query-params filters=staffLogFilter) title=(i18n "admin.settings.history")}}
         {{settingName}}
         <span class="history-icon">
           {{d-icon "history"}}

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-site-settings-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-site-settings-test.js
@@ -47,7 +47,7 @@ acceptance("Admin - Site Settings", function (needs) {
 
     assert.equal(
       queryAll(".row.setting .setting-label h3 a").attr("href"),
-      "/admin/logs/staff_action_logs?filter=%7B%22subject%22%3A%22title%22%2C%22action_name%22%3A%22change_site_setting%22%7D",
+      "/admin/logs/staff_action_logs?filters=%7B%22subject%22%3A%22title%22%2C%22action_name%22%3A%22change_site_setting%22%7D",
       "it links to the staff action log"
     );
   });


### PR DESCRIPTION
Fixing this also means that ember takes care of JSON encoding the query parameter

Follow-up to a4441b3984e4f518d8cddd7111e9b07eff5c0155

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
