### PR TITLE
FIX: Reset button state on category edit page

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/edit-category-tabs.js
+++ b/app/assets/javascripts/discourse/app/controllers/edit-category-tabs.js
@@ -95,6 +95,7 @@ export default Controller.extend({
             model.setProperties({
               slug: result.category.slug,
               id: result.category.id,
+              can_edit: result.category.can_edit,
               permission: PermissionType.FULL,
               notification_level: NotificationLevels.REGULAR,
             });
@@ -115,15 +116,19 @@ export default Controller.extend({
         I18n.t("yes_value"),
         (result) => {
           if (result) {
-            this.model.destroy().then(
-              () => {
-                this.transitionToRoute("discovery.categories");
-              },
-              () => {
-                this.displayErrors([I18n.t("category.delete_error")]);
+            this.model
+              .destroy()
+              .then(
+                () => {
+                  this.transitionToRoute("discovery.categories");
+                },
+                () => {
+                  this.displayErrors([I18n.t("category.delete_error")]);
+                }
+              )
+              .finally(() => {
                 this.set("deleting", false);
-              }
-            );
+              });
           } else {
             this.set("deleting", false);
           }


### PR DESCRIPTION
Fixes two small issues:
- buttons stayed disabled after deleting a category
- on a newly-created category, the Edit button was missing on the category landing page

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
