### PR TITLE
FIX: Store Reviewable's force_review as a boolean.

### DIFF
--- a/app/models/reviewable.rb
+++ b/app/models/reviewable.rb
@@ -197,11 +197,6 @@ class Reviewable < ActiveRecord::Base
     user_accuracy_bonus = ReviewableScore.user_accuracy_bonus(user)
     sub_total = ReviewableScore.calculate_score(user, type_bonus, take_action_bonus)
 
-    # We can force a reviewable to hit the threshold, for example with queued posts
-    if force_review && sub_total < Reviewable.min_score_for_priority
-      sub_total = Reviewable.min_score_for_priority
-    end
-
     rs = reviewable_scores.new(
       user: user,
       status: ReviewableScore.statuses[:pending],
@@ -215,7 +210,7 @@ class Reviewable < ActiveRecord::Base
     rs.reason = reason.to_s if reason
     rs.save!
 
-    update(score: self.score + rs.score, latest_score: rs.created_at)
+    update(score: self.score + rs.score, latest_score: rs.created_at, force_review: force_review)
     topic.update(reviewable_score: topic.reviewable_score + rs.score) if topic
 
     rs
@@ -475,11 +470,8 @@ class Reviewable < ActiveRecord::Base
     result = result.where("reviewables.created_at >= ?", from_date) if from_date
     result = result.where("reviewables.created_at <= ?", to_date) if to_date
 
-    if min_score > 0 && status == :pending && type.nil?
-      result = result.where(
-        "reviewables.score >= ? OR reviewables.type IN (?)",
-        min_score, [ReviewableQueuedPost.name, ReviewableUser.name]
-      )
+    if min_score > 0 && status == :pending
+      result = result.where("reviewables.score >= ? OR reviewables.force_review", min_score)
     elsif min_score > 0
       result = result.where("reviewables.score >= ?", min_score)
     end

--- a/db/migrate/20201112142419_add_reviewables_force_review.rb
+++ b/db/migrate/20201112142419_add_reviewables_force_review.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddReviewablesForceReview < ActiveRecord::Migration[6.0]
+  def change
+    add_column :reviewables, :force_review, :boolean, default: false, null: false
+  end
+end

--- a/spec/components/new_post_manager_spec.rb
+++ b/spec/components/new_post_manager_spec.rb
@@ -363,8 +363,6 @@ describe NewPostManager do
     end
 
     it "calls custom enqueuing handlers" do
-      Reviewable.set_priorities(high: 20.5)
-      SiteSetting.reviewable_default_visibility = 'high'
       SiteSetting.tagging_enabled = true
       SiteSetting.min_trust_to_create_tag = 0
       SiteSetting.min_trust_level_to_tag_topics = 0
@@ -384,7 +382,7 @@ describe NewPostManager do
       expect(reviewable).to be_present
       expect(reviewable.payload['title']).to eq('this is the title of the queued post')
       expect(reviewable.reviewable_scores).to be_present
-      expect(reviewable.score).to eq(20.5)
+      expect(reviewable.force_review).to eq(true)
       expect(reviewable.reviewable_by_moderator?).to eq(true)
       expect(reviewable.category).to be_present
       expect(reviewable.payload['tags']).to eq(['hello', 'world'])

--- a/spec/components/post_action_creator_spec.rb
+++ b/spec/components/post_action_creator_spec.rb
@@ -120,15 +120,12 @@ describe PostActionCreator do
         expect(post.hidden?).to eq(false)
       end
 
-      it 'forces the review to surpass the minimum priority threshold' do
-        Reviewable.set_priorities(high: 40.0)
-        SiteSetting.reviewable_default_visibility = 'high'
+      it 'sets the force_review field' do
         result = PostActionCreator.create(user, post, :spam)
 
         reviewable = result.reviewable
-        reviewable_score = reviewable.reviewable_scores.find_by(user: user)
 
-        expect(reviewable_score.score).to eq(Reviewable.min_score_for_priority)
+        expect(reviewable.force_review).to eq(true)
       end
     end
 

--- a/spec/models/reviewable_spec.rb
+++ b/spec/models/reviewable_spec.rb
@@ -180,8 +180,8 @@ RSpec.describe Reviewable, type: :model do
           before do
             SiteSetting.reviewable_default_visibility = :high
             Reviewable.set_priorities(high: 10)
-            @queued_post = Fabricate(:reviewable_queued_post, score: 0, target: post)
-            @queued_user = Fabricate(:reviewable_user, score: 0)
+            @queued_post = Fabricate(:reviewable_queued_post, score: 0, target: post, force_review: true)
+            @queued_user = Fabricate(:reviewable_user, score: 0, force_review: true)
           end
 
           it 'includes queued posts when searching for pending reviewables' do


### PR DESCRIPTION
Using the `force_review` flag raises the score to hit the minimum visibility threshold. This strategy turned out to be ineffective on sites with a high number of flags, where these values could rapidly fluctuate.

This change adds a `force_review` column on the reviewables table and modifies the `Reviewable#list_for` method to show these items when passing the `status: :pending` option, even if the score is not high enough. ReviewableQueuedPosts and ReviewableUsers are always created using this option.

