### PR TITLE
FIX: Show read indicator only for group PMs

### DIFF
--- a/lib/topic_view.rb
+++ b/lib/topic_view.rb
@@ -106,7 +106,7 @@ class TopicView
   end
 
   def show_read_indicator?
-    return false unless @user || topic.private_message?
+    return false if !@user || !topic.private_message?
 
     topic.allowed_groups.any? do |group|
       group.publish_read_state? && group.users.include?(@user)

--- a/spec/components/topic_view_spec.rb
+++ b/spec/components/topic_view_spec.rb
@@ -795,4 +795,30 @@ describe TopicView do
       end
     end
   end
+
+  describe '#show_read_indicator?' do
+    let(:topic) { Fabricate(:topic) }
+    let(:pm_topic) { Fabricate(:private_message_topic) }
+
+    it "shows read indicator for private messages" do
+      group = Fabricate(:group, users: [admin], publish_read_state: true)
+      pm_topic.topic_allowed_groups = [Fabricate.build(:topic_allowed_group, group: group)]
+
+      topic_view = TopicView.new(pm_topic.id, admin)
+      expect(topic_view.show_read_indicator?).to be_truthy
+    end
+
+    it "does not show read indicator if groups do not have read indicator enabled" do
+      topic_view = TopicView.new(pm_topic.id, admin)
+      expect(topic_view.show_read_indicator?).to be_falsey
+    end
+
+    it "does not show read indicator for topics with allowed groups" do
+      group = Fabricate(:group, users: [admin], publish_read_state: true)
+      topic.topic_allowed_groups = [Fabricate.build(:topic_allowed_group, group: group)]
+
+      topic_view = TopicView.new(topic.id, admin)
+      expect(topic_view.show_read_indicator?).to be_falsey
+    end
+  end
 end


### PR DESCRIPTION
It used to show for PMs converted to public topics.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
