### PR TITLE
FIX: Ensure manual category slugs are valid per slug encoding setting

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -343,7 +343,7 @@ class Category < ActiveRecord::Base
       # if we don't unescape it first we strip the % from the encoded version
       slug = SiteSetting.slug_generation_method == 'encoded' ? CGI.unescape(self.slug) : self.slug
       # sanitize the custom slug
-      self.slug = Slug.sanitize(slug)
+      self.slug = Slug.for(slug)
 
       if self.slug.blank?
         errors.add(:slug, :invalid)

--- a/lib/slug.rb
+++ b/lib/slug.rb
@@ -23,11 +23,6 @@ module Slug
     (slug.blank? || slug_is_only_numbers?(slug)) ? default : slug
   end
 
-  def self.sanitize(string, downcase: false, max_length: MAX_LENGTH)
-    slug = self.encoded_generator(string, downcase: downcase)
-    self.prettify_slug(slug, max_length: max_length)
-  end
-
   private
 
   def self.slug_is_only_numbers?(slug)


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
