### PR TITLE
REFACTOR: Add support for `currentRouteName` in test helpers

### DIFF
--- a/app/assets/javascripts/discourse/tests/acceptance/account-created-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/account-created-test.js
@@ -1,6 +1,6 @@
 import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
-import { visit, click, fillIn } from "@ember/test-helpers";
+import { visit, click, fillIn, currentRouteName } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import PreloadStore from "discourse/lib/preload-store";
@@ -40,7 +40,7 @@ acceptance("Account Created", function () {
 
     await click(".activation-controls .resend");
 
-    assert.equal(currentPath(), "account-created.resent");
+    assert.equal(currentRouteName(), "account-created.resent");
     const email = queryAll(".account-created .ac-message b").text();
     assert.equal(email, "eviltrout@example.com");
   });
@@ -57,12 +57,12 @@ acceptance("Account Created", function () {
 
     await click(".activation-controls .edit-email");
 
-    assert.equal(currentPath(), "account-created.edit-email");
+    assert.equal(currentRouteName(), "account-created.edit-email");
     assert.ok(queryAll(".activation-controls .btn-primary:disabled").length);
 
     await click(".activation-controls .edit-cancel");
 
-    assert.equal(currentPath(), "account-created.index");
+    assert.equal(currentRouteName(), "account-created.index");
   });
 
   test("account created - update email - submit", async function (assert) {
@@ -85,7 +85,7 @@ acceptance("Account Created", function () {
 
     await click(".activation-controls .btn-primary");
 
-    assert.equal(currentPath(), "account-created.resent");
+    assert.equal(currentRouteName(), "account-created.resent");
     const email = queryAll(".account-created .ac-message b").text();
     assert.equal(email, "newemail@example.com");
   });

--- a/app/assets/javascripts/discourse/tests/acceptance/auth-complete-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/auth-complete-test.js
@@ -1,5 +1,5 @@
 import { exists } from "discourse/tests/helpers/qunit-helpers";
-import { visit } from "@ember/test-helpers";
+import { visit, currentRouteName } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
@@ -23,7 +23,11 @@ acceptance("Auth Complete", function (needs) {
   test("when login not required", async function (assert) {
     await visit("/");
 
-    assert.equal(currentPath(), "discovery.latest", "it stays on the homepage");
+    assert.equal(
+      currentRouteName(),
+      "discovery.latest",
+      "it stays on the homepage"
+    );
 
     assert.ok(
       exists("#discourse-modal div.create-account"),
@@ -35,7 +39,7 @@ acceptance("Auth Complete", function (needs) {
     this.siteSettings.login_required = true;
     await visit("/");
 
-    assert.equal(currentPath(), "login", "it redirects to the login page");
+    assert.equal(currentRouteName(), "login", "it redirects to the login page");
 
     assert.ok(
       exists("#discourse-modal div.create-account"),

--- a/app/assets/javascripts/discourse/tests/acceptance/login-redirect-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/login-redirect-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { visit, currentRouteName } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
@@ -6,7 +6,7 @@ acceptance("Login redirect - anonymous", function () {
   test("redirects login to default homepage", async function (assert) {
     await visit("/login");
     assert.equal(
-      currentPath(),
+      currentRouteName(),
       "discovery.latest",
       "it works when latest is the homepage"
     );
@@ -21,7 +21,7 @@ acceptance("Login redirect - categories default", function (needs) {
   test("when site setting is categories", async function (assert) {
     await visit("/login");
     assert.equal(
-      currentPath(),
+      currentRouteName(),
       "discovery.categories",
       "it works when categories is the homepage"
     );

--- a/app/assets/javascripts/discourse/tests/acceptance/login-required-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/login-required-test.js
@@ -1,5 +1,5 @@
 import { exists } from "discourse/tests/helpers/qunit-helpers";
-import { click, visit } from "@ember/test-helpers";
+import { click, visit, currentRouteName } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance, invisible } from "discourse/tests/helpers/qunit-helpers";
 
@@ -8,11 +8,11 @@ acceptance("Login Required", function (needs) {
 
   test("redirect", async function (assert) {
     await visit("/latest");
-    assert.equal(currentPath(), "login", "it redirects them to login");
+    assert.equal(currentRouteName(), "login", "it redirects them to login");
 
     await click("#site-logo");
     assert.equal(
-      currentPath(),
+      currentRouteName(),
       "login",
       "clicking the logo keeps them on login"
     );

--- a/app/assets/javascripts/discourse/tests/acceptance/preferences-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/preferences-test.js
@@ -1,6 +1,12 @@
 import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
-import { visit, currentURL, click, fillIn } from "@ember/test-helpers";
+import {
+  visit,
+  currentURL,
+  currentRouteName,
+  click,
+  fillIn,
+} from "@ember/test-helpers";
 import { test } from "qunit";
 import I18n from "I18n";
 import {
@@ -466,7 +472,7 @@ acceptance(
       await visit("/");
       assert.ok(exists(".topic-list"), "The list of topics was rendered");
       assert.equal(
-        currentPath(),
+        currentRouteName(),
         "discovery.bookmarks",
         "it navigates to bookmarks"
       );

--- a/app/assets/javascripts/discourse/tests/acceptance/redirect-to-top-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/redirect-to-top-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { visit, currentRouteName } from "@ember/test-helpers";
 import { test } from "qunit";
 import {
   acceptance,
@@ -31,7 +31,7 @@ acceptance("Redirect to Top", function (needs) {
 
     await visit("/categories");
     assert.equal(
-      currentPath(),
+      currentRouteName(),
       "discovery.topWeekly",
       "it works for categories"
     );
@@ -47,7 +47,11 @@ acceptance("Redirect to Top", function (needs) {
     });
 
     await visit("/latest");
-    assert.equal(currentPath(), "discovery.topMonthly", "it works for latest");
+    assert.equal(
+      currentRouteName(),
+      "discovery.topMonthly",
+      "it works for latest"
+    );
   });
 
   test("redirects root to All top", async function (assert) {
@@ -60,6 +64,6 @@ acceptance("Redirect to Top", function (needs) {
     });
 
     await visit("/");
-    assert.equal(currentPath(), "discovery.topAll", "it works for root");
+    assert.equal(currentRouteName(), "discovery.topAll", "it works for root");
   });
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/static-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/static-test.js
@@ -1,7 +1,6 @@
-import { exists } from "discourse/tests/helpers/qunit-helpers";
-import { visit } from "@ember/test-helpers";
+import { visit, currentRouteName } from "@ember/test-helpers";
 import { test } from "qunit";
-import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+import { acceptance, exists } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Static", function () {
   test("Static Pages", async function (assert) {
@@ -23,7 +22,7 @@ acceptance("Static", function () {
 
     await visit("/login");
     assert.equal(
-      currentPath(),
+      currentRouteName(),
       "discovery.latest",
       "it redirects them to latest unless `login_required`"
     );

--- a/app/assets/javascripts/discourse/tests/acceptance/user-anonymous-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-anonymous-test.js
@@ -1,13 +1,16 @@
-import { exists } from "discourse/tests/helpers/qunit-helpers";
-import { visit, currentURL } from "@ember/test-helpers";
+import { visit, currentURL, currentRouteName } from "@ember/test-helpers";
 import { test } from "qunit";
-import { acceptance, count } from "discourse/tests/helpers/qunit-helpers";
+import {
+  acceptance,
+  count,
+  exists,
+} from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("User Anonymous", function () {
   test("Root URL", async function (assert) {
     await visit("/u/eviltrout");
     assert.ok($("body.user-summary-page").length, "has the body class");
-    assert.equal(currentPath(), "user.summary", "it defaults to summary");
+    assert.equal(currentRouteName(), "user.summary", "it defaults to summary");
   });
 
   test("Filters", async function (assert) {

--- a/app/assets/javascripts/discourse/tests/acceptance/user-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-test.js
@@ -1,8 +1,10 @@
-import { queryAll } from "discourse/tests/helpers/qunit-helpers";
-import { exists } from "discourse/tests/helpers/qunit-helpers";
-import { visit } from "@ember/test-helpers";
+import { visit, currentRouteName } from "@ember/test-helpers";
 import { test } from "qunit";
-import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+import {
+  acceptance,
+  exists,
+  queryAll,
+} from "discourse/tests/helpers/qunit-helpers";
 import { click } from "@ember/test-helpers";
 
 acceptance("User Routes", function (needs) {
@@ -16,13 +18,13 @@ acceptance("User Routes", function (needs) {
   test("Invalid usernames", async function (assert) {
     await visit("/u/eviltrout%2F..%2F..%2F/summary");
 
-    assert.equal(currentPath(), "exception-unknown");
+    assert.equal(currentRouteName(), "exception-unknown");
   });
 
   test("Unicode usernames", async function (assert) {
     await visit("/u/%E3%83%A9%E3%82%A4%E3%82%AA%E3%83%B3/summary");
 
-    assert.equal(currentPath(), "user.summary");
+    assert.equal(currentRouteName(), "user.summary");
   });
 
   test("Invites", async function (assert) {
@@ -52,8 +54,8 @@ acceptance("User Routes", function (needs) {
     await visit("/u/eviltrout");
     assert.ok($("body.user-activity-page").length, "has the body class");
     assert.equal(
-      currentPath(),
-      "user.userActivity.index",
+      currentRouteName(),
+      "userActivity.index",
       "it defaults to activity"
     );
     assert.ok(exists(".container.viewing-self"), "has the viewing-self class");

--- a/app/assets/javascripts/test-shims.js
+++ b/app/assets/javascripts/test-shims.js
@@ -30,7 +30,14 @@ define("@ember/test-helpers", () => {
       // No-op in pre ember-cli environment
     },
   };
-  ["click", "visit", "currentURL", "fillIn", "setResolver"].forEach((attr) => {
+  [
+    "click",
+    "visit",
+    "currentURL",
+    "currentRouteName",
+    "fillIn",
+    "setResolver",
+  ].forEach((attr) => {
     helpers[attr] = function () {
       return window[attr](...arguments);
     };

--- a/app/assets/javascripts/wizard/test/acceptance/wizard-test.js
+++ b/app/assets/javascripts/wizard/test/acceptance/wizard-test.js
@@ -1,7 +1,7 @@
 import { test, module } from "qunit";
 import { run } from "@ember/runloop";
 import startApp from "wizard/test/helpers/start-app";
-import { visit } from "@ember/test-helpers";
+import { visit, currentRouteName } from "@ember/test-helpers";
 
 var wizard;
 module("Acceptance: wizard", {
@@ -21,7 +21,7 @@ function exists(selector) {
 test("Wizard starts", async function (assert) {
   await visit("/");
   assert.ok(exists(".wizard-column-contents"));
-  assert.equal(currentPath(), "step");
+  assert.equal(currentRouteName(), "step");
 });
 
 test("Going back and forth in steps", async function (assert) {


### PR DESCRIPTION
This replaces the global `currentPath`

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
