### PR TITLE
UX: draft delete button was looking odd on user stream

### DIFF
--- a/app/assets/stylesheets/common/components/user-stream-item.scss
+++ b/app/assets/stylesheets/common/components/user-stream-item.scss
@@ -142,5 +142,8 @@
     &.d-icon-heart {
       color: var(--love);
     }
+    &.d-icon-far-trash-alt {
+      color: var(--secondary);
+    }
   }
 }


### PR DESCRIPTION
Fixes the contrast of "Remove Draft" button.

Before:

<img width="941" alt="Screenshot 2020-11-13 at 2 05 39 PM" src="https://user-images.githubusercontent.com/5732281/99049346-bd017200-25bc-11eb-8d60-a7ddb8a108b7.png">

After:

<img width="940" alt="Screenshot 2020-11-13 at 2 34 24 PM" src="https://user-images.githubusercontent.com/5732281/99049920-7102fd00-25bd-11eb-9a34-06fd323b9b90.png">
