### PR TITLE
DEV: Introduce `:before_auth` DiscourseEvent

### DIFF
--- a/app/controllers/users/associate_accounts_controller.rb
+++ b/app/controllers/users/associate_accounts_controller.rb
@@ -27,6 +27,7 @@ class Users::AssociateAccountsController < ApplicationController
     authenticator = Discourse.enabled_authenticators.find { |a| a.name == provider_name }
     raise Discourse::InvalidAccess.new(I18n.t('authenticator_not_found')) if authenticator.nil?
 
+    DiscourseEvent.trigger(:before_auth, authenticator, auth)
     auth_result = authenticator.after_authenticate(auth, existing_account: current_user)
     DiscourseEvent.trigger(:after_auth, authenticator, auth_result)
 

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -34,6 +34,7 @@ class Users::OmniauthCallbacksController < ApplicationController
       Discourse.redis.setex "#{Users::AssociateAccountsController::REDIS_PREFIX}_#{current_user.id}_#{token}", 10.minutes, auth.to_json
       return redirect_to "#{Discourse.base_path}/associate/#{token}"
     else
+      DiscourseEvent.trigger(:before_auth, authenticator, auth)
       @auth_result = authenticator.after_authenticate(auth)
       DiscourseEvent.trigger(:after_auth, authenticator, @auth_result)
     end

--- a/spec/requests/associate_accounts_controller_spec.rb
+++ b/spec/requests/associate_accounts_controller_spec.rb
@@ -69,6 +69,7 @@ RSpec.describe Users::AssociateAccountsController do
 
       # Make the connection
       events = DiscourseEvent.track_events { post "#{uri.path}.json" }
+      expect(events.any? { |e| e[:event_name] == :before_auth }).to eq(true)
       expect(events.any? { |e| e[:event_name] === :after_auth && Auth::GoogleOAuth2Authenticator === e[:params][0] && !e[:params][1].failed? }).to eq(true)
 
       expect(response.status).to eq(200)

--- a/spec/requests/omniauth_callbacks_controller_spec.rb
+++ b/spec/requests/omniauth_callbacks_controller_spec.rb
@@ -196,6 +196,7 @@ RSpec.describe Users::OmniauthCallbacksController do
         Rails.application.env_config["omniauth.origin"] = destination_url
 
         events = DiscourseEvent.track_events { get "/auth/google_oauth2/callback.json" }
+        expect(events.any? { |e| e[:event_name] == :before_auth }).to eq(true)
         expect(events.any? { |e| e[:event_name] === :after_auth && Auth::GoogleOAuth2Authenticator === e[:params][0] && !e[:params][1].failed? }).to eq(true)
 
         expect(response.status).to eq(302)


### PR DESCRIPTION
This is useful for plugins to manipulate the auth hash from OmniAuth before it is read by the Authenticator class

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
