### PR TITLE
PERF: Simplify topic serialization for user summary page

### DIFF
--- a/app/serializers/user_summary_serializer.rb
+++ b/app/serializers/user_summary_serializer.rb
@@ -2,8 +2,8 @@
 
 class UserSummarySerializer < ApplicationSerializer
 
-  class TopicSerializer < ListableTopicSerializer
-    attributes :category_id, :like_count
+  class TopicSerializer < BasicTopicSerializer
+    attributes :category_id, :like_count, :created_at
   end
 
   class ReplySerializer < ApplicationSerializer


### PR DESCRIPTION
ListableTopicSerializer includes many attributes which we are not using, and is likely to cause N+1s when not used in conjunction with TopicQuery.
Using the BasicTopicSerializer means that no other tables are required.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
