### PR TITLE
PERF: Preload topic thumbnails for all topic lists

### DIFF
--- a/app/models/topic_list.rb
+++ b/app/models/topic_list.rb
@@ -130,6 +130,8 @@ class TopicList < DraftableList
       ft.topic_list = self
     end
 
+    ActiveRecord::Associations::Preloader.new.preload(@topics, [:image_upload, topic_thumbnails: :optimized_image])
+
     if preloaded_custom_fields.present?
       Topic.preload_custom_fields(@topics, preloaded_custom_fields)
     end

--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -873,8 +873,6 @@ class TopicQuery
     result = result.where('topics.posts_count <= ?', options[:max_posts]) if options[:max_posts].present?
     result = result.where('topics.posts_count >= ?', options[:min_posts]) if options[:min_posts].present?
 
-    result = preload_thumbnails(result)
-
     result = TopicQuery.apply_custom_filters(result, self)
 
     result
@@ -1113,10 +1111,6 @@ class TopicQuery
     end
 
     result.order('topics.bumped_at DESC')
-  end
-
-  def preload_thumbnails(result)
-    result.preload(:image_upload, topic_thumbnails: :optimized_image)
   end
 
   private


### PR DESCRIPTION
Previously thumbnails were only preloaded for queries using `TopicQuery#default_results`, which meant that requests for PM topic lists would lead to N+1 queries.

This commit moves the preloading into TopicList#load_topics, along with other similar preloads (e.g. plugin custom fields)

The direct call to `ActiveRecord::Associations::Preloader#preload` is necessary because `@topics` can be an array, not an `ActiveRecord::Relation`

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
