### PR TITLE
FIX: save draft when either title or reply is present

### DIFF
--- a/app/assets/javascripts/discourse/app/models/composer.js
+++ b/app/assets/javascripts/discourse/app/models/composer.js
@@ -1127,26 +1127,22 @@ const Composer = RestModel.extend({
 
     if (this.canEditTitle) {
       // Save title and/or post body
-      if (!this.title && !this.reply) {
+      if (isEmpty(this.title) && isEmpty(this.reply)) {
         return Promise.resolve();
       }
 
-      if (
-        this.title &&
-        this.titleLengthValid &&
-        this.reply &&
-        this.replyLength < this.siteSettings.min_post_length
-      ) {
+      // Do not save when both title and reply's length are too small
+      if (!this.titleLengthValid && this.replyLength < this.minimumPostLength) {
         return Promise.resolve();
       }
     } else {
       // Do not save when there is no reply
-      if (!this.reply) {
+      if (isEmpty(this.reply)) {
         return Promise.resolve();
       }
 
       // Do not save when the reply's length is too small
-      if (this.replyLength < this.siteSettings.min_post_length) {
+      if (this.replyLength < this.minimumPostLength) {
         return Promise.resolve();
       }
     }


### PR DESCRIPTION
Here's how draft saving process works currently:

- if only title is present (no reply) the draft is saved
- if only reply is present (no title) the draft is saved
- if both title and reply are present, and reply length is less than `min_post_length` and the title length is less than `min_topic_title_length`, then the draft is saved
- if both title and reply are present, and reply length is less than `min_post_length`, then the draft is not saved

The current draft saving conditions are complex to understand and is causing confusion as seen here: https://meta.discourse.org/t/draft-is-not-being-saved-when-creating-a-new-pm/149990/6?u=techapj

This commit updates the process to always save the draft if either title or reply exists.
