### PR TITLE
FEATURE: Add an API key scopes for handling incoming email.

### DIFF
--- a/app/models/api_key_scope.rb
+++ b/app/models/api_key_scope.rb
@@ -38,6 +38,9 @@ class ApiKeyScope < ActiveRecord::Base
           sync_sso: { actions: %w[admin/users#sync_sso], params: %i[sso sig] },
           show: { actions: %w[users#show], params: %i[username external_id] },
           check_emails: { actions: %w[users#check_emails], params: %i[username] }
+        },
+        email: {
+          receive_emails: { actions: %w[admin/email#handle_mail] }
         }
       }
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3735,6 +3735,8 @@ en:
               sync_sso: Synchronize a user using SSO.
               show: Obtain information about an user.
               check_emails: List user emails.
+            mail:
+              receive_emails: Combine this scope with the mail-receiver to process incoming emails.
 
       web_hooks:
         title: "Webhooks"

--- a/spec/requests/admin/api_controller_spec.rb
+++ b/spec/requests/admin/api_controller_spec.rb
@@ -222,7 +222,7 @@ describe Admin::ApiController do
 
         scopes = response.parsed_body['scopes']
 
-        expect(scopes.keys).to contain_exactly('topics', 'users')
+        expect(scopes.keys).to contain_exactly('topics', 'users', 'email')
       end
     end
   end


### PR DESCRIPTION
Admins need to create a global API key if they want to use the mail-receiver. Let's add a scope for that.

