### PR TITLE
FIX: do not allow a tag to be synonym of its own

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/tag-info.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/tag-info.hbs
@@ -56,6 +56,7 @@
         {{tag-chooser
           id="add-synonyms"
           tags=newSynonyms
+          blockedTags=tagInfo.name
           everyTag=true
           excludeSynonyms=true
           excludeHasSynonyms=true

--- a/lib/discourse_tagging.rb
+++ b/lib/discourse_tagging.rb
@@ -481,6 +481,7 @@ module DiscourseTagging
   # tags that failed to be added, with errors on each Tag.
   def self.add_or_create_synonyms_by_name(target_tag, synonym_names)
     tag_names = DiscourseTagging.tags_for_saving(synonym_names, Guardian.new(Discourse.system_user)) || []
+    tag_names -= [target_tag.name]
     existing = Tag.where_name(tag_names).all
     target_tag.synonyms << existing
     (tag_names - target_tag.synonyms.map(&:name)).each do |name|

--- a/spec/components/discourse_tagging_spec.rb
+++ b/spec/components/discourse_tagging_spec.rb
@@ -601,6 +601,14 @@ describe DiscourseTagging do
       expect(tag2.reload.target_tag).to eq(tag1)
     end
 
+    it "removes target tag name from synonyms if present " do
+      expect {
+        expect(DiscourseTagging.add_or_create_synonyms_by_name(tag1, [tag1.name, tag2.name])).to eq(true)
+      }.to_not change { Tag.count }
+      expect_same_tag_names(tag1.reload.synonyms, [tag2])
+      expect(tag2.reload.target_tag).to eq(tag1)
+    end
+
     it "can create new tags" do
       expect {
         expect(DiscourseTagging.add_or_create_synonyms_by_name(tag1, ['synonym1'])).to eq(true)


### PR DESCRIPTION
Meta bug report: https://meta.discourse.org/t/adding-synonym-to-the-same-tag-gets-stuck/169801/
