### PR TITLE
DEV: Remove 'diff local changes' when updating remote themes

### DIFF
--- a/app/assets/javascripts/admin/addon/models/theme.js
+++ b/app/assets/javascripts/admin/addon/models/theme.js
@@ -5,11 +5,6 @@ import { or, gt } from "@ember/object/computed";
 import RestModel from "discourse/models/rest";
 import discourseComputed from "discourse-common/utils/decorators";
 import { popupAjaxError } from "discourse/lib/ajax-error";
-import { ajax } from "discourse/lib/ajax";
-import { escapeExpression } from "discourse/lib/utilities";
-import highlightSyntax from "discourse/lib/highlight-syntax";
-import { url } from "discourse/lib/computed";
-import bootbox from "bootbox";
 
 const THEME_UPLOAD_VAR = 2;
 const FIELDS_IDS = [0, 1, 5];
@@ -23,7 +18,6 @@ const Theme = RestModel.extend({
   isPendingUpdates: gt("remote_theme.commits_behind", 0),
   hasEditedFields: gt("editedFields.length", 0),
   hasParents: gt("parent_themes.length", 0),
-  diffLocalChangesUrl: url("id", "/admin/themes/%@/diff_local_changes"),
 
   @discourseComputed("theme_fields.[]")
   targets() {
@@ -292,37 +286,9 @@ const Theme = RestModel.extend({
   },
 
   updateToLatest() {
-    return ajax(this.diffLocalChangesUrl).then((json) => {
-      if (json && json.error) {
-        bootbox.alert(
-          I18n.t("generic_error_with_reason", {
-            error: json.error,
-          })
-        );
-      } else if (json && json.diff) {
-        bootbox.confirm(
-          I18n.t("admin.customize.theme.update_confirm") +
-            `<pre><code class="diff">${escapeExpression(
-              json.diff
-            )}</code></pre>`,
-          I18n.t("cancel"),
-          I18n.t("admin.customize.theme.update_confirm_yes"),
-          (result) => {
-            if (result) {
-              return this.save({ remote_update: true }).then(() =>
-                this.set("changed", false)
-              );
-            }
-          }
-        );
-        // TODO: Models shouldn't be updating the DOM
-        highlightSyntax(undefined, this.siteSettings, this.session);
-      } else {
-        return this.save({ remote_update: true }).then(() =>
-          this.set("changed", false)
-        );
-      }
-    });
+    return this.save({ remote_update: true }).then(() =>
+      this.set("changed", false)
+    );
   },
 
   changed: false,

--- a/app/controllers/admin/themes_controller.rb
+++ b/app/controllers/admin/themes_controller.rb
@@ -266,15 +266,6 @@ class Admin::ThemesController < Admin::AdminController
     exporter.cleanup!
   end
 
-  def diff_local_changes
-    theme = Theme.find_by(id: params[:id])
-    raise Discourse::InvalidParameters.new(:id) unless theme
-    changes = theme.remote_theme&.diff_local_changes
-    respond_to do |format|
-      format.json { render json: changes || {} }
-    end
-  end
-
   def update_single_setting
     params.require("name")
     @theme = Theme.find_by(id: params[:id])

--- a/app/models/remote_theme.rb
+++ b/app/models/remote_theme.rb
@@ -200,21 +200,6 @@ class RemoteTheme < ActiveRecord::Base
     end
   end
 
-  def diff_local_changes
-    return unless is_git?
-    importer = ThemeStore::GitImporter.new(remote_url, private_key: private_key, branch: branch)
-    begin
-      importer.import!
-    rescue RemoteTheme::ImportError => err
-      { error: err.message }
-    else
-      changes = importer.diff_local_changes(self.id)
-      return nil if changes.blank?
-
-      { diff: changes }
-    end
-  end
-
   def normalize_override(hex)
     return unless hex
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -213,7 +213,6 @@ Discourse::Application.routes.draw do
       post "themes/upload_asset" => "themes#upload_asset"
       post "themes/generate_key_pair" => "themes#generate_key_pair"
       get "themes/:id/preview" => "themes#preview"
-      get "themes/:id/diff_local_changes" => "themes#diff_local_changes"
       put "themes/:id/setting" => "themes#update_single_setting"
 
       scope "/customize", constraints: AdminConstraint.new do

--- a/lib/theme_store/git_importer.rb
+++ b/lib/theme_store/git_importer.rb
@@ -30,27 +30,6 @@ class ThemeStore::GitImporter
     end
   end
 
-  def diff_local_changes(remote_theme_id)
-    theme = Theme.find_by(remote_theme_id: remote_theme_id)
-    raise Discourse::InvalidParameters.new(:id) unless theme
-    local_version = theme.remote_theme&.local_version
-
-    exporter = ThemeStore::ZipExporter.new(theme)
-    local_temp_folder = exporter.export_to_folder
-
-    Discourse::Utils.execute_command(chdir: @temp_folder) do |runner|
-      runner.exec("git", "checkout", local_version)
-      runner.exec("rm -rf ./*/")
-      runner.exec("cp", "-rf", "#{local_temp_folder}/#{exporter.export_name}/.", @temp_folder)
-      runner.exec("git", "checkout", "about.json")
-      # add + diff staged to catch uploads but exclude renamed assets
-      runner.exec("git", "add", "-A")
-      return runner.exec("git", "diff", "--staged", "--diff-filter=r")
-    end
-  ensure
-    FileUtils.rm_rf local_temp_folder if local_temp_folder
-  end
-
   def commits_since(hash)
     commit_hash, commits_behind = nil
 

--- a/spec/models/remote_theme_spec.rb
+++ b/spec/models/remote_theme_spec.rb
@@ -157,14 +157,6 @@ describe RemoteTheme do
 
       scheme = ColorScheme.find_by(theme_id: @theme.id)
       expect(scheme.colors.find_by(name: 'tertiary_low_color')).to eq(nil)
-
-      # It should detect local changes
-      @theme.set_field(target: :common, name: :scss, value: 'body {background-color: blue};')
-      @theme.save
-      @theme.reload
-
-      expect(remote.diff_local_changes[:diff]).not_to include("similarity index 100%")
-      expect(remote.diff_local_changes[:diff]).to include("background-color: blue")
     end
   end
 

--- a/spec/requests/admin/themes_controller_spec.rb
+++ b/spec/requests/admin/themes_controller_spec.rb
@@ -569,15 +569,6 @@ describe Admin::ThemesController do
     end
   end
 
-  describe '#diff_local_changes' do
-    let(:theme) { Fabricate(:theme) }
-
-    it "should return empty for a default theme" do
-      get "/admin/themes/#{theme.id}/diff_local_changes.json"
-      expect(response.body).to eq("{}")
-    end
-  end
-
   describe '#update_single_setting' do
     let(:theme) { Fabricate(:theme) }
 


### PR DESCRIPTION
Since 65e123498b4f8f260a8461e48995a3ca166b605e, it is now impossible to make local changes to remote themes, so this warning is not needed.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
