### PR TITLE
REFACTOR: Allow us to import `keyEvent`

### DIFF
--- a/app/assets/javascripts/discourse/tests/acceptance/admin-site-settings-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-site-settings-test.js
@@ -1,6 +1,12 @@
 import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
-import { fillIn, click, visit, currentURL } from "@ember/test-helpers";
+import {
+  fillIn,
+  click,
+  keyEvent,
+  visit,
+  currentURL,
+} from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance, count } from "discourse/tests/helpers/qunit-helpers";
 import siteSettingFixture from "discourse/tests/fixtures/site-settings";

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-hyperlink-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-hyperlink-test.js
@@ -1,6 +1,6 @@
 import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
-import { click, fillIn, visit } from "@ember/test-helpers";
+import { click, fillIn, keyEvent, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/keyboard-shortcuts-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/keyboard-shortcuts-test.js
@@ -1,4 +1,4 @@
-import { visit, currentURL } from "@ember/test-helpers";
+import { keyEvent, visit, currentURL } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/modal-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/modal-test.js
@@ -1,5 +1,5 @@
 import { queryAll } from "discourse/tests/helpers/qunit-helpers";
-import { click, visit } from "@ember/test-helpers";
+import { click, keyEvent, visit } from "@ember/test-helpers";
 import { skip, test } from "qunit";
 import I18n from "I18n";
 import { run } from "@ember/runloop";

--- a/app/assets/javascripts/discourse/tests/acceptance/plugin-keyboard-shortcut-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/plugin-keyboard-shortcut-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { keyEvent, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import { withPluginApi } from "discourse/lib/plugin-api";

--- a/app/assets/javascripts/discourse/tests/acceptance/search-full-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-full-test.js
@@ -1,6 +1,6 @@
 import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
-import { visit, fillIn, click } from "@ember/test-helpers";
+import { keyEvent, visit, fillIn, click } from "@ember/test-helpers";
 import { skip, test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import {

--- a/app/assets/javascripts/discourse/tests/acceptance/search-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-test.js
@@ -1,6 +1,6 @@
 import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
-import { click, fillIn, visit } from "@ember/test-helpers";
+import { click, keyEvent, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-test.js
@@ -1,6 +1,6 @@
 import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
-import { click, fillIn, visit } from "@ember/test-helpers";
+import { click, keyEvent, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import I18n from "I18n";
 import { withPluginApi } from "discourse/lib/plugin-api";

--- a/app/assets/javascripts/discourse/tests/integration/components/simple-list-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/simple-list-test.js
@@ -1,7 +1,7 @@
 import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { moduleForComponent } from "ember-qunit";
 import componentTest from "discourse/tests/helpers/component-test";
-import { click, fillIn } from "@ember/test-helpers";
+import { click, keyEvent, fillIn } from "@ember/test-helpers";
 
 moduleForComponent("simple-list", { integration: true });
 

--- a/app/assets/javascripts/test-shims.js
+++ b/app/assets/javascripts/test-shims.js
@@ -37,6 +37,7 @@ define("@ember/test-helpers", () => {
     "currentRouteName",
     "fillIn",
     "setResolver",
+    "keyEvent",
   ].forEach((attr) => {
     helpers[attr] = function () {
       return window[attr](...arguments);


### PR DESCRIPTION
This change should be quite safe as it only adds extra support for
imports rather than global variables.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
