### PR TITLE
Move CSS link tags above JS in the head

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,8 @@
     <%= render partial: "layouts/head" %>
     <%= discourse_csrf_tags %>
 
+    <%= render partial: "common/discourse_stylesheet" %>
+
     <%- if SiteSetting.enable_escaped_fragments? %>
       <meta name="fragment" content="!">
     <%- end %>
@@ -51,7 +53,6 @@
         <meta name="apple-itunes-app" content="app-id=<%= SiteSetting.ios_app_id %><%= ios_app_argument %>">
     <%- end %>
 
-    <%= render partial: "common/discourse_stylesheet" %>
 
     <%= yield :head %>
 


### PR DESCRIPTION
CSS are blocking resources, so keeping them below JS delays
rendering of the page. CSS should be loaded ASAP.
This change speeds up first contentful paint by 0.2s on localhost.
The slower the device, the bigger the difference could be.

<details>
Before
<img width="903" alt="image" src="https://user-images.githubusercontent.com/546845/99343135-9168db00-288d-11eb-806b-049588d29a0c.png">

---

After
<img width="920" alt="image" src="https://user-images.githubusercontent.com/546845/99343123-8ada6380-288d-11eb-86a5-70f029213e8f.png">
</details>
