### PR TITLE
Remove extra padding, follow-up to 8be04ff

### DIFF
--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -566,7 +566,9 @@ blockquote {
   position: relative;
   border-top: 1px solid var(--primary-low);
   padding: 12px 0 0 0;
-  .topic-meta-data,
+  .topic-meta-data {
+    padding: 0 $topic-body-width-padding 0.25em $topic-body-width-padding;
+  }
   .cooked {
     padding: 1em $topic-body-width-padding 0.25em $topic-body-width-padding;
   }


### PR DESCRIPTION

Accidentally added padding to topic-meta-data, should have just been on cooked... don't want this extra space here!

![Screen Shot 2020-11-16 at 11 05 01 PM](https://user-images.githubusercontent.com/1681963/99345411-3c62a000-2860-11eb-948b-6187e6ec40ea.png)

