### PR TITLE
UX: handle large email addresses on email skipped and bounced tabs

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/email-bounced.hbs
+++ b/app/assets/javascripts/admin/addon/templates/email-bounced.hbs
@@ -27,7 +27,7 @@
               &mdash;
             {{/if}}
           </td>
-          <td><a href="mailto:{{l.to_address}}">{{l.to_address}}</a></td>
+          <td class="email-address"><a href="mailto:{{l.to_address}}">{{l.to_address}}</a></td>
           {{#if l.has_bounce_key}}
             <td><a href {{action "showIncomingEmail" l.id}}>{{l.email_type}}</a></td>
           {{else}}

--- a/app/assets/javascripts/admin/addon/templates/email-skipped.hbs
+++ b/app/assets/javascripts/admin/addon/templates/email-skipped.hbs
@@ -29,7 +29,7 @@
               &mdash;
             {{/if}}
           </td>
-          <td><a href="mailto:{{l.to_address}}">{{l.to_address}}</a></td>
+          <td class="email-address"><a href="mailto:{{l.to_address}}">{{l.to_address}}</a></td>
           <td>{{l.email_type}}</td>
           <td>
             {{#if l.post_url}}

--- a/app/assets/stylesheets/common/admin/emails.scss
+++ b/app/assets/stylesheets/common/admin/emails.scss
@@ -28,6 +28,10 @@
     max-width: 300px;
     overflow-wrap: break-word;
   }
+  .email-address {
+    max-width: 250px;
+    @include ellipsis;
+  }
 }
 
 .incoming-emails {


### PR DESCRIPTION
Before:

![Screenshot from 2020-11-17 12-53-22](https://user-images.githubusercontent.com/5732281/99358719-f47d6080-28d3-11eb-923f-4b6ddc4e00f2.png)

After:

![Screenshot from 2020-11-17 12-51-15](https://user-images.githubusercontent.com/5732281/99358717-f34c3380-28d3-11eb-8a69-f963c5b2d986.png)