### PR TITLE
DEV: Use `.sort!` instead of `.sort` for user archive specs

### DIFF
--- a/spec/jobs/export_user_archive_spec.rb
+++ b/spec/jobs/export_user_archive_spec.rb
@@ -371,9 +371,9 @@ describe Jobs::ExportUserArchive do
 
       expect(csv_out).to_not match(admin.username)
 
-      expect(data[0]['post_raw']).to eq('hello world post contents.')
-      expect(data[0]['other_json']).to match('reply_to_post_number')
-      expect(data[1]['other_json']).to match('example_tag')
+      expect(data[0]['other_json']).to match('example_tag')
+      expect(data[1]['post_raw']).to eq('hello world post contents.')
+      expect(data[1]['other_json']).to match('reply_to_post_number')
     end
   end
 

--- a/spec/jobs/export_user_archive_spec.rb
+++ b/spec/jobs/export_user_archive_spec.rb
@@ -331,7 +331,7 @@ describe Jobs::ExportUserArchive do
 
       expect(data.find { |r| r['category_id'] == category.id }).to be_nil
       expect(data.length).to eq(4)
-      data.sort { |a, b| a['category_id'] <=> b['category_id'] }
+      data.sort! { |a, b| a['category_id'] <=> b['category_id'] }
 
       expect(data[0][:category_id]).to eq(subcategory.id.to_s)
       expect(data[0][:notification_level].to_s).to eq('tracking')
@@ -358,7 +358,6 @@ describe Jobs::ExportUserArchive do
     let(:admin) { Fabricate(:admin) }
 
     it 'correctly exports queued posts' do
-      skip 'flaky'
       SiteSetting.tagging_enabled = true
 
       reviewable_post.perform(admin, :reject_post)
@@ -368,7 +367,7 @@ describe Jobs::ExportUserArchive do
 
       data, csv_out = make_component_csv
       expect(data.length).to eq(2)
-      data.sort { |e| e['id'].to_i }
+      data.sort! { |e| e['id'].to_i }
 
       expect(csv_out).to_not match(admin.username)
 


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
