### PR TITLE
FIX: Handle uncaught exception

### DIFF
--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -412,7 +412,7 @@ module Discourse
     unless uri.is_a?(URI)
       uri = begin
         URI(uri)
-      rescue URI::Error
+      rescue ArgumentError, URI::Error
       end
     end
 

--- a/lib/search.rb
+++ b/lib/search.rb
@@ -265,14 +265,11 @@ class Search
       if @term =~ /^\d+$/
         single_topic(@term.to_i)
       else
-        begin
-          if route = Discourse.route_for(@term)
-            if route[:controller] == "topics" && route[:action] == "show"
-              topic_id = (route[:id] || route[:topic_id]).to_i
-              single_topic(topic_id) if topic_id > 0
-            end
+        if route = Discourse.route_for(@term)
+          if route[:controller] == "topics" && route[:action] == "show"
+            topic_id = (route[:id] || route[:topic_id]).to_i
+            single_topic(topic_id) if topic_id > 0
           end
-        rescue ActionController::RoutingError
         end
       end
     end

--- a/spec/requests/search_controller_spec.rb
+++ b/spec/requests/search_controller_spec.rb
@@ -231,8 +231,8 @@ describe SearchController do
       expect(SearchLog.where(term: 'wookie')).to be_blank
     end
 
-    it "does not raise 500" do
-      get "/search/query.json", params: { term: "F status:public", type_filter: "topic", search_for_id: true }
+    it "does not raise 500 with an empty term" do
+      get "/search/query.json", params: { term: "in:first", type_filter: "topic", search_for_id: true }
       expect(response.status).to eq(200)
     end
 

--- a/spec/requests/search_controller_spec.rb
+++ b/spec/requests/search_controller_spec.rb
@@ -231,6 +231,11 @@ describe SearchController do
       expect(SearchLog.where(term: 'wookie')).to be_blank
     end
 
+    it "does not raise 500" do
+      get "/search/query.json", params: { term: "F status:public", type_filter: "topic", search_for_id: true }
+      expect(response.status).to eq(200)
+    end
+
     context 'rate limited' do
       it 'rate limits anon searches per user' do
         SiteSetting.rate_limit_search_anon_user = 2


### PR DESCRIPTION
After the search term is parsed for advanced search filters, term may become
empty. Later, the same term will be passed to Discourse.route_for which will
raise an ArgumentError.

> URI(nil)
ArgumentError: bad argument (expected URI object or URI string)