### PR TITLE
UX: Only link the icon for site setting history

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/components/site-setting.hbs
+++ b/app/assets/javascripts/admin/addon/templates/components/site-setting.hbs
@@ -1,8 +1,8 @@
 <div class="setting-label">
   <h3>
     {{#if staffLogFilter}}
+      {{settingName}}
       {{#link-to "adminLogs.staffActionLogs" (query-params filters=staffLogFilter) title=(i18n "admin.settings.history")}}
-        {{settingName}}
         <span class="history-icon">
           {{d-icon "history"}}
         </span>

--- a/app/assets/stylesheets/common/admin/settings.scss
+++ b/app/assets/stylesheets/common/admin/settings.scss
@@ -15,18 +15,13 @@
           margin-bottom: 6px;
         }
       }
-      h3 {
-        a:any-link {
-          color: unset;
-        }
-        .history-icon {
-          opacity: 0;
-          transition: opacity 0.3s;
-          color: var(--primary-medium);
-        }
-        &:hover .history-icon {
-          opacity: 1;
-        }
+      .history-icon {
+        opacity: 0;
+        transition: opacity 0.3s;
+        color: var(--primary-medium);
+      }
+      &:hover .history-icon {
+        opacity: 1;
       }
     }
     .setting-value {


### PR DESCRIPTION
Linking the whole site setting name makes it tricky to copy/paste the name, which is common when asking/answering support queries.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
