### PR TITLE
FIX: Selected Tag Group permission shouldn’t change during save

### DIFF
--- a/app/assets/javascripts/discourse/app/components/tag-groups-form.js
+++ b/app/assets/javascripts/discourse/app/components/tag-groups-form.js
@@ -99,14 +99,18 @@ export default Component.extend(bufferedProperty("model"), {
     },
 
     setPermissionsGroups(groupIds) {
-      let permissions = {};
+      let updatedPermissions = Object.assign(
+        {},
+        this.buffered.get("permissions")
+      );
+
       this.allGroups.forEach((group) => {
         if (groupIds.includes(group.id)) {
-          permissions[group.name] = PermissionType.FULL;
+          updatedPermissions[group.name] = PermissionType.FULL;
         }
       });
 
-      this.buffered.set("permissions", permissions);
+      this.buffered.set("permissions", updatedPermissions);
     },
 
     save() {

--- a/app/assets/javascripts/discourse/tests/acceptance/tag-groups-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/tag-groups-test.js
@@ -62,12 +62,18 @@ acceptance("Tag Groups", function (needs) {
     await tags.expand();
     await tags.selectRowByValue("monkey");
 
-    await click("#private-permission");
+    await click("#visible-permission");
     assert.ok(queryAll(".tag-group-content .btn.btn-default:disabled").length);
 
     await groups.expand();
     await groups.selectRowByIndex(1);
     await groups.selectRowByIndex(0);
     assert.ok(!queryAll(".tag-group-content .btn.btn-default")[0].disabled);
+
+    await click(".tag-group-content .btn.btn-default");
+    assert.ok(
+      exists("#visible-permission:checked"),
+      "selected permission does not change after saving"
+    );
   });
 });


### PR DESCRIPTION
`setPermissionsGroups` would initialize an empty permissions object whenever new groups were added to the Tag Group. This meant that if you selected the `visible` permission and then added groups to the Tag Group, the `visible` permission would be obliterated and the Tag Group would be treated as though it was `private`.
