### PR TITLE
Revert "Build(deps): Bump redis from 4.2.2 to 4.2.3"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -298,7 +298,7 @@ GEM
       msgpack (>= 0.4.3)
       optimist (>= 3.0.0)
     rchardet (1.8.0)
-    redis (4.2.3)
+    redis (4.2.2)
     redis-namespace (1.8.0)
       redis (>= 3.0.4)
     regexp_parser (1.8.2)


### PR DESCRIPTION
This reverts commit f31de2fa200e58ca25b3f9d03631287fb82dc104.

This is causing `NoMethodError (undefined method `bytesize' for nil:NilClass)` in the anonymous cache. More investigation required

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
