### PR TITLE
FEATURE: Search filter for searching all PMs on a site for admin.

### DIFF
--- a/spec/components/search_spec.rb
+++ b/spec/components/search_spec.rb
@@ -334,6 +334,26 @@ describe Search do
       end
     end
 
+    context 'all-pms flag' do
+      it 'returns matching PMs if the user is an admin' do
+        results = Search.execute('mars in:all-pms', guardian: Guardian.new(admin))
+
+        expect(results.posts).to include(reply, post2)
+      end
+
+      it 'returns nothing if the user is not an admin' do
+        results = Search.execute('mars in:all-pms', guardian: Guardian.new(Fabricate(:user)))
+
+        expect(results.posts).to be_empty
+      end
+
+      it 'returns nothing if the user is a moderator' do
+        results = Search.execute('mars in:all-pms', guardian: Guardian.new(Fabricate(:moderator)))
+
+        expect(results.posts).to be_empty
+      end
+    end
+
     context 'personal-direct flag' do
       let(:current) { Fabricate(:user, admin: true, username: "current_user") }
       let(:participant) { Fabricate(:user, username: "participant_1") }


### PR DESCRIPTION
Admins can search all PMS on a site by using the `in:all-pms` advanced filter.
