### PR TITLE
UX: Refactor topic list nav 

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/d-navigation.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/d-navigation.hbs
@@ -5,71 +5,75 @@
   {{navigation-bar navItems=navItems filterMode=filterMode category=category}}
 {{/unless}}
 
-{{#if showCategoryAdmin}}
-  {{categories-admin-dropdown
-    onChange=(action "selectCategoryAdminDropdownAction")
-    options=(hash
-      triggerOnChangeOnTab=false
-    )
-  }}
-{{/if}}
+<div class="navigation-controls">
 
-{{#if category}}
-  {{#unless tag}}
-    {{!-- don't show category notification menu on tag pages --}}
-    {{#if showCategoryNotifications}}
-      {{category-notifications-button
-        value=category.notification_level
-        category=category
-        onChange=(action "changeCategoryNotificationLevel")
-      }}
-    {{/if}}
-  {{/unless}}
-{{/if}}
+  {{#if showCategoryAdmin}}
+    {{categories-admin-dropdown
+      onChange=(action "selectCategoryAdminDropdownAction")
+      options=(hash
+        triggerOnChangeOnTab=false
+      )
+    }}
+  {{/if}}
 
-{{#if tag}}
-  {{#if tagNotification}}
-    {{#unless additionalTags}}
-      {{!-- don't show tag notification menu on tag intersections --}}
-      {{tag-notifications-button
-        onChange=changeTagNotificationLevel
-        value=tagNotification.notification_level
-      }}
+  {{#if category}}
+    {{#unless tag}}
+      {{!-- don't show category edit button on tag pages --}}
+      {{#if showCategoryEdit}}
+        {{d-button
+          class="btn-default edit-category"
+          action=editCategory
+          icon="wrench"
+          label="category.edit"}}
+      {{/if}}
     {{/unless}}
   {{/if}}
-{{/if}}
 
-{{plugin-outlet name="before-create-topic-button"
-  args=(hash
-    canCreateTopic=canCreateTopic
-    createTopicDisabled=createTopicDisabled
-    createTopicLabel=createTopicLabel)
-}}
-
-{{create-topic-button
-  canCreateTopic=canCreateTopic
-  action=(action "clickCreateTopicButton")
-  disabled=createTopicButtonDisabled
-  label=createTopicLabel
-  btnClass=createTopicClass
-  canCreateTopicOnTag=canCreateTopicOnTag
-}}
-
-{{#if category}}
-  {{#unless tag}}
-    {{!-- don't show category edit button on tag pages --}}
-    {{#if showCategoryEdit}}
-      {{d-button
-        class="btn-default edit-category"
-        action=editCategory
-        icon="wrench"
-        label="category.edit"}}
+  {{#if tag}}
+    {{#if showToggleInfo}}
+      {{d-button icon="tag" class="btn-default" label="tagging.info" action=toggleInfo id="show-tag-info"}}
     {{/if}}
-  {{/unless}}
-{{/if}}
-
-{{#if tag}}
-  {{#if showToggleInfo}}
-    {{d-button icon="tag" class="btn-default" label="tagging.info" action=toggleInfo id="show-tag-info"}}
   {{/if}}
-{{/if}}
+
+  {{plugin-outlet name="before-create-topic-button"
+    args=(hash
+      canCreateTopic=canCreateTopic
+      createTopicDisabled=createTopicDisabled
+      createTopicLabel=createTopicLabel)
+  }}
+
+  {{create-topic-button
+    canCreateTopic=canCreateTopic
+    action=(action "clickCreateTopicButton")
+    disabled=createTopicButtonDisabled
+    label=createTopicLabel
+    btnClass=createTopicClass
+    canCreateTopicOnTag=canCreateTopicOnTag
+  }}
+
+  {{#if category}}
+    {{#unless tag}}
+      {{!-- don't show category notification menu on tag pages --}}
+      {{#if showCategoryNotifications}}
+        {{category-notifications-button
+          value=category.notification_level
+          category=category
+          onChange=(action "changeCategoryNotificationLevel")
+        }}
+      {{/if}}
+    {{/unless}}
+  {{/if}}
+
+  {{#if tag}}
+    {{#if tagNotification}}
+      {{#unless additionalTags}}
+        {{!-- don't show tag notification menu on tag intersections --}}
+        {{tag-notifications-button
+          onChange=changeTagNotificationLevel
+          value=tagNotification.notification_level
+        }}
+      {{/unless}}
+    {{/if}}
+  {{/if}}
+
+</div>

--- a/app/assets/javascripts/discourse/app/templates/components/d-navigation.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/d-navigation.hbs
@@ -35,7 +35,7 @@
     {{/if}}
   {{/if}}
 
-  {{plugin-outlet name="before-create-topic-button"
+  {{plugin-outlet name="before-create-topic-button" tagName=""
     args=(hash
       canCreateTopic=canCreateTopic
       createTopicDisabled=createTopicDisabled

--- a/app/assets/javascripts/discourse/app/templates/navigation/category.hbs
+++ b/app/assets/javascripts/discourse/app/templates/navigation/category.hbs
@@ -1,5 +1,4 @@
-{{#d-section class="navigation-container"}}
-  {{add-category-tag-classes category=category}}
+ {{add-category-tag-classes category=category tagName=""}}
 
   <section class="category-heading">
     {{#if category.uploaded_logo.url}}
@@ -16,17 +15,18 @@
     {{plugin-outlet name="category-heading" args=(hash category=category)}}
   </section>
 
-  <div class="category-navigation">
-    {{d-navigation
-      category=category
-      filterMode=filterMode
-      noSubcategories=noSubcategories
-      canCreateTopic=canCreateTopic
-      createTopic=(route-action "createTopic")
-      createTopicDisabled=cannotCreateTopicOnCategory
-      hasDraft=draft
-      editCategory=(route-action "editCategory" category)}}
+{{#d-section class="navigation-container category-navigation"}}
+ 
+  {{d-navigation
+    category=category
+    filterMode=filterMode
+    noSubcategories=noSubcategories
+    canCreateTopic=canCreateTopic
+    createTopic=(route-action "createTopic")
+    createTopicDisabled=cannotCreateTopicOnCategory
+    hasDraft=draft
+    editCategory=(route-action "editCategory" category)}}
 
-    {{plugin-outlet name="category-navigation" args=(hash category=category)}}
-  </div>
+  {{plugin-outlet name="category-navigation" args=(hash category=category)}}
+  
 {{/d-section}}

--- a/app/assets/javascripts/discourse/app/templates/navigation/category.hbs
+++ b/app/assets/javascripts/discourse/app/templates/navigation/category.hbs
@@ -16,7 +16,7 @@
   </section>
 
 {{#d-section class="navigation-container category-navigation"}}
- 
+
   {{d-navigation
     category=category
     filterMode=filterMode
@@ -28,5 +28,5 @@
     editCategory=(route-action "editCategory" category)}}
 
   {{plugin-outlet name="category-navigation" args=(hash category=category)}}
-  
+
 {{/d-section}}

--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -1,3 +1,53 @@
+.navigation-container {
+  --nav-margin-bottom: 0.75em;
+
+  display: grid;
+  grid-template-rows: auto auto;
+  grid-template-columns: auto 1fr auto;
+  align-items: start;
+  grid-template-areas: "breadcrumb navigation controls";
+  @include breakpoint(medium) {
+    grid-template-rows: auto auto;
+    grid-template-columns: auto 1fr;
+    grid-template-areas:
+      "breadcrumb controls"
+      "navigation navigation";
+  }
+  @include breakpoint(mobile-extra-large) {
+    grid-template-rows: auto auto;
+    grid-template-columns: auto 1fr;
+    grid-template-areas:
+      "breadcrumb"
+      "navigation"
+      "controls";
+  }
+}
+
+.category-breadcrumb {
+  grid-area: breadcrumb;
+  margin: 0 0 var(--nav-margin-bottom);
+}
+
+.navigation-controls {
+  grid-area: controls;
+  margin-left: auto;
+  display: flex;
+  align-items: stretch;
+  margin-bottom: var(--nav-margin-bottom);
+  > * {
+    white-space: nowrap;
+  }
+  @include breakpoint(mobile-extra-large) {
+    margin-left: 0;
+  }
+}
+
+#navigation-bar {
+  grid-area: navigation;
+  display: flex;
+  margin: 0 0 var(--nav-margin-bottom);
+}
+
 .topic-list.shared-drafts {
   margin-bottom: 1.5em;
 }
@@ -12,7 +62,6 @@
 }
 
 .list-controls {
-  clear: both;
   margin-bottom: 5px;
   .combo-box .combo-box-header {
     background: var(--secondary);
@@ -43,6 +92,18 @@
   }
   .category-heading {
     max-width: 100%;
+  }
+
+  @include breakpoint(medium) {
+    // hide button labels to save space
+    .btn {
+      .d-button-label {
+        display: none;
+      }
+      .d-icon {
+        margin: 0;
+      }
+    }
   }
 }
 
@@ -270,16 +331,15 @@ ol.category-breadcrumb.hidden {
   display: none;
 }
 
-ol.category-breadcrumb {
+.category-breadcrumb {
   display: block;
   float: left;
   list-style: none;
-  margin: 0 10px 10px 0;
   padding: 0;
 
   li {
     float: left;
-    margin-right: 5px;
+    margin-right: 0.5em;
   }
 
   .bread-crumbs-right-outlet {

--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -69,6 +69,7 @@
 
 #navigation-bar {
   display: flex;
+  flex-wrap: wrap;
   margin: 0 0 var(--nav-space);
   margin-right: auto;
 }

--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -1,68 +1,27 @@
-.navigation-container {
-  --nav-margin-bottom: 0.75em;
-
-  display: grid;
-  grid-template-rows: auto auto;
-  grid-template-columns: auto 1fr auto;
-  align-items: start;
-  grid-template-areas: "breadcrumb navigation controls";
-  @include breakpoint(medium) {
-    grid-template-rows: auto auto;
-    grid-template-columns: auto 1fr;
-    grid-template-areas:
-      "breadcrumb controls"
-      "navigation navigation";
-  }
-  @include breakpoint(mobile-extra-large) {
-    grid-template-rows: auto auto;
-    grid-template-columns: auto 1fr;
-    grid-template-areas:
-      "breadcrumb"
-      "navigation"
-      "controls";
-  }
-}
-
-.category-breadcrumb {
-  grid-area: breadcrumb;
-  margin: 0 0 var(--nav-margin-bottom);
-}
-
-.navigation-controls {
-  grid-area: controls;
-  margin-left: auto;
-  display: flex;
-  align-items: stretch;
-  margin-bottom: var(--nav-margin-bottom);
-  > * {
-    white-space: nowrap;
-  }
-  @include breakpoint(mobile-extra-large) {
-    margin-left: 0;
-  }
-}
-
-#navigation-bar {
-  grid-area: navigation;
-  display: flex;
-  margin: 0 0 var(--nav-margin-bottom);
-}
-
-.topic-list.shared-drafts {
-  margin-bottom: 1.5em;
-}
-
-.show-more {
-  width: 100%;
-  z-index: z("base");
-  &.has-topics {
-    position: absolute;
-    top: 7px;
-  }
-}
+// Topic list navigation & controls
 
 .list-controls {
-  margin-bottom: 5px;
+  margin-bottom: 0.25em;
+
+  .btn {
+    &:not(:first-child) {
+      margin-left: 0.5em;
+    }
+    .d-button-label {
+      font-size: $font-up-1;
+      font-weight: normal;
+    }
+  }
+
+  .notifications-button {
+    margin-left: 0.5em;
+  }
+
+  a.badge-category {
+    padding: 3px 12px;
+    font-size: $font-up-1;
+  }
+
   .combo-box .combo-box-header {
     background: var(--secondary);
     color: var(--primary);
@@ -71,27 +30,9 @@
     transition: none;
   }
   .select-kit {
-    align-self: center;
     .select-kit-collection {
-      font-size: $font-down-1;
       max-height: 40vh;
-      .texts,
-      .icons {
-        font-size: $font-up-1;
-      }
     }
-    &.categories-admin-dropdown,
-    &.tags-admin-dropdown,
-    &.category-notifications-button,
-    &.tag-notifications-button {
-      float: right;
-      button {
-        display: inline-block;
-      }
-    }
-  }
-  .category-heading {
-    max-width: 100%;
   }
 
   @include breakpoint(medium) {
@@ -106,6 +47,81 @@
     }
   }
 }
+
+.navigation-container {
+  width: 100%;
+  --nav-space: 0.75em;
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.category-breadcrumb {
+  display: block;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  li {
+    float: left;
+    margin-bottom: var(--nav-space);
+    margin-right: 0.5em;
+  }
+}
+
+#navigation-bar {
+  display: flex;
+  margin: 0 0 var(--nav-space);
+  margin-right: auto;
+}
+
+.navigation-controls {
+  display: flex;
+  align-items: stretch;
+  margin-bottom: var(--nav-space);
+  > * {
+    white-space: nowrap;
+  }
+}
+
+.show-more {
+  width: 100%;
+  z-index: z("base");
+  &.has-topics {
+    position: absolute;
+    top: 7px;
+  }
+}
+
+.category-heading {
+  max-width: 100%;
+}
+
+.category-logo.aspect-image {
+  width: auto;
+  max-height: 150px;
+}
+
+@supports (--custom: property) {
+  .category-logo.aspect-image {
+    --max-height: 150px;
+    max-height: var(--max-height);
+    width: calc(var(--max-height) * var(--aspect-ratio));
+    max-width: 100%;
+    height: auto;
+
+    img {
+      width: 100%;
+      height: inherit;
+      max-width: initial;
+      max-height: initial;
+    }
+  }
+}
+
+.topic-list.shared-drafts {
+  margin-bottom: 1.5em;
+}
+
+// Topic list body
 
 .topic-list-item.visited,
 .latest-topic-list-item.visited,
@@ -324,26 +340,6 @@
   }
   .spinner {
     margin-top: 40px;
-  }
-}
-
-ol.category-breadcrumb.hidden {
-  display: none;
-}
-
-.category-breadcrumb {
-  display: block;
-  float: left;
-  list-style: none;
-  padding: 0;
-
-  li {
-    float: left;
-    margin-right: 0.5em;
-  }
-
-  .bread-crumbs-right-outlet {
-    float: left;
   }
 }
 

--- a/app/assets/stylesheets/common/components/navs.scss
+++ b/app/assets/stylesheets/common/components/navs.scss
@@ -23,7 +23,7 @@
 
   > li {
     float: left;
-    margin-right: 5px;
+    margin-right: 0.5em;
 
     > a {
       border: none;

--- a/app/assets/stylesheets/desktop/topic-list.scss
+++ b/app/assets/stylesheets/desktop/topic-list.scss
@@ -2,32 +2,6 @@
 // Topic lists
 // --------------------------------------------------
 
-// List controls
-// --------------------------------------------------
-
-.list-controls {
-  .nav {
-    margin-bottom: 0;
-  }
-
-  .btn {
-    &:not(:first-child) {
-      margin-left: 0.5em;
-    }
-    font-size: $font-up-1;
-    font-weight: normal;
-  }
-
-  .notifications-button {
-    margin-left: 0.5em;
-  }
-
-  a.badge-category {
-    padding: 3px 12px;
-    font-size: $font-up-1;
-  }
-}
-
 // Base list
 // --------------------------------------------------
 
@@ -226,35 +200,9 @@ button.dismiss-read {
   }
 }
 
-.category-navigation {
-  clear: both;
-}
-
 .category-logo.aspect-image {
   float: left;
   margin: 0.25em 1em 0.5em 0;
-
-  img {
-    width: auto;
-    max-height: 150px;
-  }
-}
-
-@supports (--custom: property) {
-  .category-logo.aspect-image {
-    --max-height: 150px;
-    max-height: var(--max-height);
-    max-width: 60%;
-    height: auto;
-    width: calc(var(--max-height) * var(--aspect-ratio));
-
-    img {
-      width: 100%;
-      height: inherit;
-      max-width: initial;
-      max-height: initial;
-    }
-  }
 }
 
 /* Tablet (portrait) ----------- */

--- a/app/assets/stylesheets/desktop/topic-list.scss
+++ b/app/assets/stylesheets/desktop/topic-list.scss
@@ -7,20 +7,19 @@
 
 .list-controls {
   .nav {
-    float: left;
-    margin-bottom: 10px;
+    margin-bottom: 0;
   }
 
   .btn {
-    float: right;
-    margin-left: 8px;
-    margin-bottom: 9px;
+    &:not(:first-child) {
+      margin-left: 0.5em;
+    }
     font-size: $font-up-1;
     font-weight: normal;
   }
 
-  .search .btn {
-    float: none;
+  .notifications-button {
+    margin-left: 0.5em;
   }
 
   a.badge-category {
@@ -266,16 +265,6 @@ button.dismiss-read {
     > li > a {
       font-size: $font-0;
       padding: 7px 10px;
-    }
-  }
-
-  // new topic just a "+" no text
-  button#create-topic {
-    span {
-      display: none;
-    }
-    .d-icon {
-      margin-right: 0;
     }
   }
 

--- a/app/assets/stylesheets/mobile/topic-list.scss
+++ b/app/assets/stylesheets/mobile/topic-list.scss
@@ -6,11 +6,6 @@
 // --------------------------------------------------
 
 .list-controls {
-  margin: 10px -3px 5px -3px;
-  .category-breadcrumb.hidden {
-    display: none;
-  }
-
   .container {
     display: flex;
     flex-wrap: wrap;
@@ -20,8 +15,6 @@
       display: flex;
       align-self: stretch;
       align-items: center;
-      margin: 0 3px 10px 3px;
-      order: 10; // always last for consistent placement
     }
   }
 
@@ -34,11 +27,9 @@
     display: flex;
     flex-wrap: wrap;
     width: 100%;
-    margin: 5px 0;
+    margin: 0.5em 0 0;
 
     button {
-      margin: 0 3px;
-
       &.select-kit-header {
         display: flex;
         height: 100%;
@@ -47,36 +38,8 @@
     }
   }
 
-  .select-kit:not(.is-hidden) {
-    display: flex;
-    align-self: stretch;
-    margin-bottom: 10px;
-  }
-
-  .btn:not(.select-kit-header) {
-    margin-bottom: 10px;
-  }
-
-  .categories-admin-dropdown,
-  .tag-notifications-button {
-    order: 2; // after main nav
-  }
-
-  .category-navigation {
-    display: flex;
-    flex-wrap: wrap;
-    width: 100%;
-    .edit-category {
-      @media screen and (max-width: 374px) {
-        // Hide edit label on very tiny screens
-        .d-icon {
-          margin: 0;
-        }
-        .d-button-label {
-          display: none;
-        }
-      }
-    }
+  .navigation-controls {
+    margin-bottom: 0.667em;
   }
 
   .nav-pills {
@@ -86,7 +49,6 @@
     position: relative;
     .navigation-toggle {
       flex: 0 1 auto;
-      margin-bottom: 5px;
     }
     > li {
       margin-right: 0;
@@ -128,6 +90,23 @@
 
 .list-container .full-width {
   margin-left: 0;
+}
+
+ol.category-breadcrumb {
+  margin: 0 -3px 5px -3px;
+  display: flex;
+  flex-wrap: wrap;
+  flex: 1 1 100%;
+  li.select-kit {
+    flex: 1 1 33%;
+    margin: 0 3px 5px 3px;
+    .select-kit-header .selected-name {
+      max-width: 80vw;
+      .badge-wrapper {
+        max-width: 100%;
+      }
+    }
+  }
 }
 
 // Base list
@@ -419,10 +398,6 @@ tr.category-topic-link {
 
 // Misc. stuff
 // --------------------------------------------------
-.btn-group .dropdown-toggle:active,
-.btn-group.open .dropdown-toggle {
-  outline: 0;
-}
 
 .dropdown {
   position: relative;
@@ -431,53 +406,9 @@ tr.category-topic-link {
 .open .dropdown-toggle {
   outline: 0;
 }
-.caret {
-  display: inline-block;
-  width: 0;
-  height: 0;
-  vertical-align: middle;
-  border-top: 4px solid var(--primary);
-  border-right: 4px solid transparent;
-  border-left: 4px solid transparent;
-  content: "";
-  margin-left: 5px;
-}
 
 .fade.in {
   opacity: 1;
-}
-
-ol.category-breadcrumb {
-  margin: 0 0 5px 0;
-  display: flex;
-  flex-wrap: wrap;
-  flex: 1 1 100%;
-  li.select-kit {
-    flex: 1 1 33%;
-    margin: 0 3px 5px 3px;
-    .select-kit-header .selected-name {
-      max-width: 80vw;
-      .badge-wrapper {
-        max-width: 100%;
-      }
-    }
-  }
-}
-
-.top-lists {
-  h2 {
-    margin-left: 10px;
-  }
-  .topic-list {
-    padding-bottom: 10px;
-  }
-  .btn-default.pull-right {
-    margin-right: 10px;
-  }
-}
-
-.tags-admin-menu {
-  display: none;
 }
 
 .tags-controls {
@@ -488,40 +419,12 @@ ol.category-breadcrumb {
   }
 }
 
-.staff.tags-page #create-topic {
-  clear: right;
-}
-
-.topic-list-bottom h3 {
-  clear: both;
-  padding-top: 10px;
-}
-
 .category-logo.aspect-image {
   display: block;
   margin: 8px 0;
 
   img {
-    width: auto;
     max-width: 100%;
-    max-height: 150px;
-  }
-}
-
-@supports (--custom: property) {
-  .category-logo.aspect-image {
-    --max-height: 150px;
-    max-height: var(--max-height);
-    width: calc(var(--max-height) * var(--aspect-ratio));
-    max-width: 100%;
-    height: auto;
-
-    img {
-      width: 100%;
-      height: inherit;
-      max-width: initial;
-      max-height: initial;
-    }
   }
 }
 


### PR DESCRIPTION
This paves the way for flexbox buttons (we had some button height issues here) as well as unified styles for desktop/mobile topic list nav (definitely more pieces needed, but this unifies some of the structure).  

On its own this accomplishes a handful of things; some improvements and general housekeeping:

* Restructured d-navigation  
  * elements in the DOM are in the order they appear, we were doing some stuff with floats to change order previously
  * wrapped the buttons in a common wrapper (`.navigation-controls`)... this is important for flex/grid layouts
  * removed ember wrappers to remove some empty containers in the DOM that mess with flex/grid layouts
  * there were some awkward wrapping situations happening:
  
    before:
![Screen Shot 2020-11-18 at 9 18 43 PM](https://user-images.githubusercontent.com/1681963/99613201-23372c00-29e5-11eb-87cb-f383f6ca32dc.png)

    after: 
![Screen Shot 2020-11-18 at 9 19 09 PM](https://user-images.githubusercontent.com/1681963/99613252-334f0b80-29e5-11eb-80e7-67913545332b.png)



  
* Some work on the category template
  * removed a couple more ember wrappers
  * moved the category headings outside of navigation container, technically they're not nav... but more importantly the inconsistency was making it harder to share common nav styles across page types (tags/categories/all)
* Removed some old unused styles
* Merged some common styles and reduced desktop/mobile duplication