### PR TITLE
DEV: Maintain github_user_info primary key values during migration

### DIFF
--- a/db/migrate/20201109170951_migrate_github_user_infos.rb
+++ b/db/migrate/20201109170951_migrate_github_user_infos.rb
@@ -2,6 +2,11 @@
 
 class MigrateGithubUserInfos < ActiveRecord::Migration[6.0]
   def up
+    # If the user_associated_accounts table is currently empty,
+    # maintain the primary key from github_user_infos
+    # This is useful for people that are using data explorer to access the data
+    maintain_ids = DB.query_single("SELECT count(*) FROM user_associated_accounts")[0] == 0
+
     execute <<~SQL
       INSERT INTO user_associated_accounts (
         provider_name,
@@ -11,6 +16,7 @@ class MigrateGithubUserInfos < ActiveRecord::Migration[6.0]
         last_used,
         created_at,
         updated_at
+        #{", id" if maintain_ids}
       ) SELECT
         'github',
         github_user_id,
@@ -19,8 +25,18 @@ class MigrateGithubUserInfos < ActiveRecord::Migration[6.0]
         updated_at,
         created_at,
         updated_at
+        #{", id" if maintain_ids}
       FROM github_user_infos
     SQL
+
+    if maintain_ids
+      execute <<~SQL
+        SELECT setval(
+          pg_get_serial_sequence('user_associated_accounts', 'id'),
+          (select greatest(max(id), 1) from user_associated_accounts)
+        );
+      SQL
+    end
   end
 
   def down


### PR DESCRIPTION
This will only happen if the user_associated_accounts table is currently empty. It's useful for people that may be depending on primary key values in data explorer queries. This change will only have an effect on sites which have not already run this migration.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
