### PR TITLE
DEV: skip_jobs when seeding topics

### DIFF
--- a/lib/post_creator.rb
+++ b/lib/post_creator.rb
@@ -199,8 +199,10 @@ class PostCreator
   end
 
   def create
-    if !Rails.env.test? && ActiveRecord::Base.connection.open_transactions > 0 && !@opts[:skip_jobs]
-      raise "You must use 'skip_jobs = true' when creating a post inside a transaction, otherwise jobs won't run properly."
+    if !Rails.env.test? && !@opts[:import_mode]
+      if ActiveRecord::Base.connection.open_transactions > 0 && !@opts[:skip_jobs]
+        raise "You must use 'skip_jobs = true' when creating a post inside a transaction, otherwise jobs won't run properly."
+      end
     end
 
     if valid?

--- a/lib/seed_data/topics.rb
+++ b/lib/seed_data/topics.rb
@@ -131,6 +131,7 @@ module SeedData
         Discourse.system_user,
         title: title,
         raw: raw,
+        skip_jobs: true,
         skip_validations: true,
         category: category&.id
       )
@@ -139,6 +140,7 @@ module SeedData
         PostCreator.create!(
           Discourse.system_user,
           raw: first_reply_raw(title),
+          skip_jobs: true,
           skip_validations: true,
           topic_id: post.topic_id
         )


### PR DESCRIPTION
Don't raise an exception when creating a post inside a transaction in `import_mode`.

Follow-up to 7af061fafa.