### PR TITLE
FIX: Remove error for PostCreator in a transaction without skip_jobs

### DIFF
--- a/lib/post_creator.rb
+++ b/lib/post_creator.rb
@@ -199,12 +199,6 @@ class PostCreator
   end
 
   def create
-    if !Rails.env.test? && !@opts[:import_mode]
-      if ActiveRecord::Base.connection.open_transactions > 0 && !@opts[:skip_jobs]
-        raise "You must use 'skip_jobs = true' when creating a post inside a transaction, otherwise jobs won't run properly."
-      end
-    end
-
     if valid?
       transaction do
         build_post_stats


### PR DESCRIPTION
Partial revert of b143412be473bacb50bad4c0ef8909d6a4717b67 (the refactoring is not reverted)

This broke a few things, so we need to investigate and make some changes before reinstating the error

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
