### PR TITLE
FIX: There are two elements with a `suspend-reason` class

### DIFF
--- a/app/assets/javascripts/discourse/tests/acceptance/admin-suspend-user-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-suspend-user-test.js
@@ -42,7 +42,7 @@ acceptance("Admin - Suspend User", function (needs) {
 
     assert.equal(queryAll(".suspend-user-modal:visible").length, 1);
 
-    await fillIn(".suspend-reason", "for breaking the rules");
+    await fillIn("input.suspend-reason", "for breaking the rules");
     await fillIn(".suspend-message", "this is an email reason why");
 
     await click(".d-modal-cancel");


### PR DESCRIPTION
We only want to fill in the text one. (This is an Ember CLI fix)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
