### PR TITLE
DEV: Always enqueue sidekiq jobs after database transaction commit

### DIFF
--- a/app/jobs/base.rb
+++ b/app/jobs/base.rb
@@ -311,7 +311,7 @@ module Jobs
         hash['queue'] = queue
       end
 
-      klass.client_push(hash)
+      DB.after_commit { klass.client_push(hash) }
     else
       # Otherwise execute the job right away
       opts.delete(:delay_for)


### PR DESCRIPTION
When jobs are enqueued inside a transaction, it's possible that they will be executed before the necessary data is available in the database. This commit ensures all jobs are enqueued in an ActiveRecord after_commit hook.

One potential downside here is if the job fails to enqueue, the transaction will no longer be aborted. However, the chance of that happening is reasonably low, and the impact is significantly lower than the current issue where jobs are scheduled before their data is ready.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
