### PR TITLE
FEATURE: Add site setting to restrict ignore feature to trust level

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1840,7 +1840,7 @@ en:
     min_trust_level_to_allow_profile_background: "The minimum trust level required to upload a profile background"
     min_trust_level_to_allow_user_card_background: "The minimum trust level required to upload a user card background"
     min_trust_level_to_allow_invite: "The minimum trust level required to invite users"
-    min_trust_level_to_ignore: "The minimum trust level required to ignore users"
+    min_trust_level_to_allow_ignore: "The minimum trust level required to ignore users"
     allowed_link_domains: "Domains that users may link to even if they don't have the appropriate trust level to post links"
 
     newuser_max_links: "How many links a new user can add to a post."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1840,6 +1840,7 @@ en:
     min_trust_level_to_allow_profile_background: "The minimum trust level required to upload a profile background"
     min_trust_level_to_allow_user_card_background: "The minimum trust level required to upload a user card background"
     min_trust_level_to_allow_invite: "The minimum trust level required to invite users"
+    min_trust_level_to_ignore: "The minimum trust level required to ignore users"
     allowed_link_domains: "Domains that users may link to even if they don't have the appropriate trust level to post links"
 
     newuser_max_links: "How many links a new user can add to a post."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1419,7 +1419,7 @@ trust:
   min_trust_level_to_allow_invite:
     default: 2
     enum: "TrustLevelSetting"
-  min_trust_level_to_ignore:
+  min_trust_level_to_allow_ignore:
     default: 2
     enum: "TrustLevelSetting"
   allow_flagging_staff: true

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1419,6 +1419,9 @@ trust:
   min_trust_level_to_allow_invite:
     default: 2
     enum: "TrustLevelSetting"
+  min_trust_level_to_ignore:
+    default: 2
+    enum: "TrustLevelSetting"
   allow_flagging_staff: true
   send_tl1_welcome_message: true
   send_tl2_promotion_message: true

--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -487,7 +487,7 @@ class Guardian
 
   def can_ignore_users?
     return false if anonymous?
-    @user.staff? || @user.has_trust_level?(SiteSetting.min_trust_level_to_ignore.to_i)
+    @user.staff? || @user.has_trust_level?(SiteSetting.min_trust_level_to_allow_ignore.to_i)
   end
 
   def allowed_theme_repo_import?(repo)

--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -487,7 +487,7 @@ class Guardian
 
   def can_ignore_users?
     return false if anonymous?
-    @user.staff? || @user.trust_level >= TrustLevel.levels[:member]
+    @user.staff? || @user.has_trust_level?(SiteSetting.min_trust_level_to_ignore.to_i)
   end
 
   def allowed_theme_repo_import?(repo)

--- a/spec/components/guardian_spec.rb
+++ b/spec/components/guardian_spec.rb
@@ -2961,7 +2961,7 @@ describe Guardian do
 
   describe '#can_ignore_user?' do
     before do
-      SiteSetting.min_trust_level_to_ignore = 1
+      SiteSetting.min_trust_level_to_allow_ignore = 1
     end
 
     let(:guardian) { Guardian.new(trust_level_2) }

--- a/spec/components/guardian_spec.rb
+++ b/spec/components/guardian_spec.rb
@@ -2960,6 +2960,9 @@ describe Guardian do
   end
 
   describe '#can_ignore_user?' do
+    before do
+      SiteSetting.min_trust_level_to_ignore = 1
+    end
 
     let(:guardian) { Guardian.new(trust_level_2) }
 
@@ -2983,26 +2986,29 @@ describe Guardian do
       end
     end
 
-    context "when ignorer's trust level is below tl2" do
-      let(:guardian) { Guardian.new(trust_level_1) }
-      let!(:trust_level_1) { build(:user, trust_level: 1) }
-
-      it 'does not allow ignoring user' do
-        expect(guardian.can_ignore_user?(another_user)).to eq(false)
-      end
-    end
-
     context "when ignorer is staff" do
       let(:guardian) { Guardian.new(admin) }
-
       it 'allows ignoring user' do
         expect(guardian.can_ignore_user?(another_user)).to eq(true)
       end
     end
 
-    context "when ignorer's trust level is tl2" do
-      let(:guardian) { Guardian.new(trust_level_2) }
+    context "when ignorer's trust level is below min_trust_to_ignore" do
+      let(:guardian) { Guardian.new(trust_level_0) }
+      it 'does not allow ignoring user' do
+        expect(guardian.can_ignore_user?(another_user)).to eq(false)
+      end
+    end
 
+    context "when ignorer's trust level is equal to min_trust_to_ignore site setting" do
+      let(:guardian) { Guardian.new(trust_level_1) }
+      it 'allows ignoring user' do
+        expect(guardian.can_ignore_user?(another_user)).to eq(true)
+      end
+    end
+
+    context "when ignorer's trust level is above min_trust_to_ignore site setting" do
+      let(:guardian) { Guardian.new(trust_level_3) }
       it 'allows ignoring user' do
         expect(guardian.can_ignore_user?(another_user)).to eq(true)
       end

--- a/spec/components/guardian_spec.rb
+++ b/spec/components/guardian_spec.rb
@@ -2993,21 +2993,21 @@ describe Guardian do
       end
     end
 
-    context "when ignorer's trust level is below min_trust_to_ignore" do
+    context "when ignorer's trust level is below min_trust_level_to_allow_ignore" do
       let(:guardian) { Guardian.new(trust_level_0) }
       it 'does not allow ignoring user' do
         expect(guardian.can_ignore_user?(another_user)).to eq(false)
       end
     end
 
-    context "when ignorer's trust level is equal to min_trust_to_ignore site setting" do
+    context "when ignorer's trust level is equal to min_trust_level_to_allow_ignore site setting" do
       let(:guardian) { Guardian.new(trust_level_1) }
       it 'allows ignoring user' do
         expect(guardian.can_ignore_user?(another_user)).to eq(true)
       end
     end
 
-    context "when ignorer's trust level is above min_trust_to_ignore site setting" do
+    context "when ignorer's trust level is above min_trust_level_to_allow_ignore site setting" do
       let(:guardian) { Guardian.new(trust_level_3) }
       it 'allows ignoring user' do
         expect(guardian.can_ignore_user?(another_user)).to eq(true)


### PR DESCRIPTION
This adds a new `min_trust_level_to_allow_ignore` site setting to allow admins to control the point at which as user is allow to ignore other users.

<img width="757" alt="Screen Shot 2020-11-20 at 1 15 36 AM" src="https://user-images.githubusercontent.com/22733864/99782405-f0b52e00-2acd-11eb-826d-de8dabb9af8f.png">

