### PR TITLE
FIX: Load .js files from plugins in qunit testing env

### DIFF
--- a/app/assets/javascripts/admin.js.erb
+++ b/app/assets/javascripts/admin.js.erb
@@ -3,10 +3,10 @@ require_asset("main_include_admin.js")
 
 DiscoursePluginRegistry.admin_javascripts.each { |js| require_asset(js) }
 
-DiscoursePluginRegistry.each_globbed_asset(admin: true) do |f, ext|
+DiscoursePluginRegistry.each_globbed_asset(admin: true) do |f|
   if File.directory?(f)
     depend_on(f)
-  elsif f.to_s.end_with?(".#{ext}")
+  else
     require_asset(f)
   end
 end

--- a/app/assets/javascripts/discourse/tests/plugin_tests.js.erb
+++ b/app/assets/javascripts/discourse/tests/plugin_tests.js.erb
@@ -1,10 +1,10 @@
 <%
   DiscoursePluginRegistry.javascripts.each { |js| require_asset(js) }
   DiscoursePluginRegistry.handlebars.each { |hb| require_asset(hb) }
-  DiscoursePluginRegistry.each_globbed_asset do |f, ext|
+  DiscoursePluginRegistry.each_globbed_asset do |f|
     if File.directory?(f)
       depend_on(f)
-    elsif f.to_s.end_with?(".#{ext}")
+    else
       require_asset(f)
     end
   end

--- a/lib/discourse_plugin_registry.rb
+++ b/lib/discourse_plugin_registry.rb
@@ -131,7 +131,7 @@ class DiscoursePluginRegistry
         next if each_options[:admin]
       end
 
-      Dir.glob("#{root}/**/*") do |f|
+      Dir.glob("#{root}/**/*.#{ext}") do |f|
         yield f, ext
       end
     end

--- a/lib/discourse_plugin_registry.rb
+++ b/lib/discourse_plugin_registry.rb
@@ -132,7 +132,7 @@ class DiscoursePluginRegistry
       end
 
       Dir.glob("#{root}/**/*.#{ext}") do |f|
-        yield f, ext
+        yield f
       end
     end
   end

--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -588,11 +588,13 @@ class Plugin::Instance
 
       # Automatically include all ES6 JS and hbs files
       root_path = "#{root_dir_name}/assets/javascripts"
+      DiscoursePluginRegistry.register_glob(root_path, 'js')
       DiscoursePluginRegistry.register_glob(root_path, 'js.es6')
       DiscoursePluginRegistry.register_glob(root_path, 'hbs')
       DiscoursePluginRegistry.register_glob(root_path, 'hbr')
 
       admin_path = "#{root_dir_name}/admin/assets/javascripts"
+      DiscoursePluginRegistry.register_glob(admin_path, 'js', admin: true)
       DiscoursePluginRegistry.register_glob(admin_path, 'js.es6', admin: true)
       DiscoursePluginRegistry.register_glob(admin_path, 'hbs', admin: true)
       DiscoursePluginRegistry.register_glob(admin_path, 'hbr', admin: true)

--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -588,13 +588,13 @@ class Plugin::Instance
 
       # Automatically include all ES6 JS and hbs files
       root_path = "#{root_dir_name}/assets/javascripts"
-      DiscoursePluginRegistry.register_glob(root_path, 'js')
+      DiscoursePluginRegistry.register_glob(root_path, 'js') if transpile_js
       DiscoursePluginRegistry.register_glob(root_path, 'js.es6')
       DiscoursePluginRegistry.register_glob(root_path, 'hbs')
       DiscoursePluginRegistry.register_glob(root_path, 'hbr')
 
       admin_path = "#{root_dir_name}/admin/assets/javascripts"
-      DiscoursePluginRegistry.register_glob(admin_path, 'js', admin: true)
+      DiscoursePluginRegistry.register_glob(admin_path, 'js', admin: true) if transpile_js
       DiscoursePluginRegistry.register_glob(admin_path, 'js.es6', admin: true)
       DiscoursePluginRegistry.register_glob(admin_path, 'hbs', admin: true)
       DiscoursePluginRegistry.register_glob(admin_path, 'hbr', admin: true)


### PR DESCRIPTION
Files returned from `DiscoursePluginRegistry.each_globbed_asset`  are not filtered by the extension passed into the function!. Then we solved this by filtering out each file with the wrong extension where the function is used by doing this: `elsif f.to_s.end_with?(".#{ext}")`. This doesn't make sense and we should just correct the glob by changing 
`Dir.glob("#{root}/**/*") do |f|` to `Dir.glob("#{root}/**/*.#{ext}") do |f|`

Also JS tests in plugins using `transpile_js`, were not loading the `.js` files.