### PR TITLE
FIX: Tests were performing `data[]` queries but without quotes

### DIFF
--- a/app/assets/javascripts/discourse/tests/acceptance/click-track-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/click-track-test.js
@@ -19,7 +19,7 @@ acceptance("Click Track", function (needs) {
       "card should not appear"
     );
 
-    await click("article[data-post-id=3651] a.mention");
+    await click('article[data-post-id="3651"] a.mention');
     assert.ok(queryAll(".user-card.show").length === 1, "card appear");
     assert.equal(currentURL(), "/t/internationalization-localization/280");
     assert.ok(!tracked);

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
@@ -263,7 +263,7 @@ acceptance("Composer", function (needs) {
     await visit("/t/internationalization-localization/280");
 
     assert.ok(
-      !exists("article[data-post-id=12345]"),
+      !exists('article[data-post-id="12345"]'),
       "the post is not in the DOM"
     );
 

--- a/app/assets/javascripts/discourse/tests/acceptance/review-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/review-test.js
@@ -7,7 +7,7 @@ import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 acceptance("Review", function (needs) {
   needs.user();
 
-  const user = ".reviewable-item[data-reviewable-id=1234]";
+  const user = '.reviewable-item[data-reviewable-id="1234"]';
 
   test("It returns a list of reviewable items", async function (assert) {
     await visit("/review");
@@ -92,7 +92,7 @@ acceptance("Review", function (needs) {
   });
 
   test("Editing a reviewable", async function (assert) {
-    const topic = ".reviewable-item[data-reviewable-id=4321]";
+    const topic = '.reviewable-item[data-reviewable-id="4321"]';
     await visit("/review");
     assert.ok(queryAll(`${topic} .reviewable-action.approve`).length);
     assert.ok(!queryAll(`${topic} .category-name`).length);

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-discovery-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-discovery-test.js
@@ -75,12 +75,12 @@ acceptance("Topic Discovery", function (needs) {
   test("Clearing state after leaving a category", async function (assert) {
     await visit("/c/dev");
     assert.ok(
-      exists(".topic-list-item[data-topic-id=11994] .topic-excerpt"),
+      exists('.topic-list-item[data-topic-id="11994"] .topic-excerpt'),
       "it expands pinned topics in a subcategory"
     );
     await visit("/");
     assert.ok(
-      !exists(".topic-list-item[data-topic-id=11557] .topic-excerpt"),
+      !exists('.topic-list-item[data-topic-id="11557"] .topic-excerpt'),
       "it doesn't expand all pinned in the latest category"
     );
   });

--- a/app/assets/javascripts/discourse/tests/acceptance/user-card-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-card-test.js
@@ -19,7 +19,7 @@ acceptance("User Card - Show Local Time", function (needs) {
     User.current().changeTimezone("Australia/Brisbane");
 
     await visit("/t/internationalization-localization/280");
-    await click("a[data-user-card=charlie]:first");
+    await click('a[data-user-card="charlie"]:first');
 
     assert.not(
       exists(".user-card .local-time"),

--- a/app/assets/javascripts/discourse/tests/helpers/select-kit-helper.js
+++ b/app/assets/javascripts/discourse/tests/helpers/select-kit-helper.js
@@ -285,7 +285,7 @@ export default function selectKit(selector) {
       await click(
         queryAll(selector)
           .find(".select-kit-header")
-          .find(`[data-value=${value}]`)
+          .find(`[data-value="${value}"]`)
       );
     },
 

--- a/app/assets/javascripts/discourse/tests/integration/widgets/post-stream-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/post-stream-test.js
@@ -113,8 +113,8 @@ discourseModule("Integration | Component | Widget | post-stream", function (
 
       // it renders an article for the body with appropriate attributes
       assert.equal(queryAll("article#post_2").length, 1);
-      assert.equal(queryAll("article[data-user-id=123]").length, 1);
-      assert.equal(queryAll("article[data-post-id=3]").length, 1);
+      assert.equal(queryAll('article[data-user-id="123"]').length, 1);
+      assert.equal(queryAll('article[data-post-id="3"]').length, 1);
       assert.equal(queryAll("article#post_5.via-email").length, 1);
       assert.equal(queryAll("article#post_6.is-auto-generated").length, 1);
 

--- a/app/assets/javascripts/discourse/tests/integration/widgets/poster-name-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/poster-name-test.js
@@ -24,7 +24,7 @@ discourseModule("Integration | Component | Widget | poster-name", function (
     test(assert) {
       assert.ok(queryAll(".names").length);
       assert.ok(queryAll("span.username").length);
-      assert.ok(queryAll("a[data-user-card=eviltrout]").length);
+      assert.ok(queryAll('a[data-user-card="eviltrout"]').length);
       assert.equal(queryAll(".username a").text(), "eviltrout");
       assert.equal(queryAll(".full-name a").text(), "Robin Ward");
       assert.equal(queryAll(".user-title").text(), "Trout Master");

--- a/app/assets/javascripts/discourse/tests/integration/widgets/small-user-list-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/small-user-list-test.js
@@ -22,8 +22,8 @@ discourseModule("Integration | Component | Widget | small-user-list", function (
       });
     },
     async test(assert) {
-      assert.ok(queryAll("[data-user-card=eviltrout]").length === 1);
-      assert.ok(queryAll("[data-user-card=someone]").length === 0);
+      assert.ok(queryAll('[data-user-card="eviltrout"]').length === 1);
+      assert.ok(queryAll('[data-user-card="someone"]').length === 0);
       assert.ok(queryAll(".unknown").length, "includes unkown user");
     },
   });

--- a/app/assets/javascripts/discourse/tests/integration/widgets/widget-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/widget-test.js
@@ -119,8 +119,8 @@ discourseModule("Integration | Component | Widget | base", function (hooks) {
     },
 
     test(assert) {
-      assert.ok(queryAll(".test[data-evil=trout]").length);
-      assert.ok(queryAll(".test[aria-label=accessibility]").length);
+      assert.ok(queryAll('.test[data-evil="trout"]').length);
+      assert.ok(queryAll('.test[aria-label="accessibility"]').length);
     },
   });
 


### PR DESCRIPTION
This works in jQuery but not querySelectorAll

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
