### PR TITLE
FIX: Improve email validation error handling for external logins

### DIFF
--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -244,7 +244,7 @@ class SessionController < ApplicationController
       text = nil
 
       # If there's a problem with the email we can explain that
-      if (e.record.is_a?(User) && e.record.errors[:email].present?)
+      if (e.record.is_a?(User) && e.record.errors[:primary_email].present?)
         if e.record.email.blank?
           text = I18n.t("sso.no_email")
         else


### PR DESCRIPTION
- Display reason for validation error when logging in via an authenticator
- Fix email validation handling for 'Discourse SSO', and add a spec

Previously, validation errors (e.g. blocked or already-taken emails) would raise a generic error with no useful information.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
