### PR TITLE
UX: Do not include current user in group-filtered directory results

### DIFF
--- a/app/controllers/directory_items_controller.rb
+++ b/app/controllers/directory_items_controller.rb
@@ -71,7 +71,7 @@ class DirectoryItemsController < ApplicationController
     load_more_directory_items_json = "#{load_more_uri.path}.json?#{load_more_uri.query}"
 
     # Put yourself at the top of the first page
-    if result.present? && current_user.present? && page == 0
+    if result.present? && current_user.present? && page == 0 && !params[:group].present?
 
       position = result.index { |r| r.user_id == current_user.id }
 

--- a/spec/requests/directory_items_controller_spec.rb
+++ b/spec/requests/directory_items_controller_spec.rb
@@ -139,5 +139,14 @@ describe DirectoryItemsController do
       get '/directory_items.json', params: { period: 'all', group: group.name }
       expect(response.status).to eq(403)
     end
+
+    it "does not force-include self in group-filtered results" do
+      me = Fabricate(:user)
+      DirectoryItem.refresh!
+      sign_in(me)
+
+      get '/directory_items.json', params: { period: 'all', group: group.name }
+      expect(response.parsed_body['directory_items'].length).to eq(2)
+    end
   end
 end


### PR DESCRIPTION
At the moment, when filtering by group, the directory will unconditionally return the current user at the top of the list. This is quite unexpected, given that the user is deliberately trying to filter the list. This commit makes sure the 'include current user' logic only triggers for unfiltered directories