### PR TITLE
FIX: Tests were using jQuery selectors

### DIFF
--- a/app/assets/javascripts/discourse/tests/acceptance/admin-users-list-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-users-list-test.js
@@ -12,7 +12,7 @@ acceptance("Admin - Users List", function (needs) {
     await visit("/admin/users/list/active");
 
     assert.ok(exists(".users-list .user"));
-    assert.ok(!exists(".user:eq(0) .email small"), "escapes email");
+    assert.ok(!exists(".user:nth-of-type(1) .email small"), "escapes email");
   });
 
   test("sorts users", async function (assert) {

--- a/app/assets/javascripts/discourse/tests/acceptance/badges-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/badges-test.js
@@ -17,7 +17,7 @@ acceptance("Badges", function (needs) {
 
     assert.ok(exists(".badge-card"), "has the badge in the listing");
     assert.ok(exists(".user-info"), "has the list of users with that badge");
-    assert.ok(!exists(".badge-card:eq(0) script"));
+    assert.ok(!exists(".badge-card:nth-of-type(1) script"));
   });
 
   test("shows correct badge titles to choose from", async function (assert) {

--- a/app/assets/javascripts/discourse/tests/acceptance/category-edit-security-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/category-edit-security-test.js
@@ -118,7 +118,7 @@ acceptance("Category Edit - security", function (needs) {
       "staff group also has full permissions"
     );
 
-    await click(everyoneRow.find(".reply-toggle"));
+    await click(everyoneRow.find(".reply-toggle")[0]);
 
     assert.equal(
       everyoneRow.find(".reply-granted, .create-granted").length,
@@ -132,7 +132,7 @@ acceptance("Category Edit - security", function (needs) {
       "staff group still has full permissions"
     );
 
-    await click(staffRow.find(".reply-toggle"));
+    await click(staffRow.find(".reply-toggle")[0]);
 
     assert.equal(
       everyoneRow.find(".reply-granted, .create-granted").length,
@@ -152,7 +152,7 @@ acceptance("Category Edit - security", function (needs) {
       "staff does not have create permission"
     );
 
-    await click(everyoneRow.find(".create-toggle"));
+    await click(everyoneRow.find(".create-toggle")[0]);
 
     assert.equal(
       everyoneRow.find(".reply-granted, .create-granted").length,

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-actions-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-actions-test.js
@@ -61,7 +61,10 @@ acceptance("Composer Actions", function (needs) {
     await composerActions.expand();
     await composerActions.selectRowByValue("reply_as_private_message");
 
-    assert.equal(queryAll(".users-input .item:eq(0)").text(), "codinghorror");
+    assert.equal(
+      queryAll(".users-input .item:nth-of-type(1)").text(),
+      "codinghorror"
+    );
     assert.ok(
       queryAll(".d-editor-input").val().indexOf("Continuing the discussion") >=
         0
@@ -344,7 +347,10 @@ acceptance("Composer Actions", function (needs) {
     await composerActions.expand();
     await composerActions.selectRowByValue("reply_as_private_message");
 
-    assert.equal(queryAll(".users-input .item:eq(0)").text(), "uwe_keim");
+    assert.equal(
+      queryAll(".users-input .item:nth-of-type(1)").text(),
+      "uwe_keim"
+    );
     assert.ok(
       queryAll(".d-editor-input").val().indexOf("Continuing the discussion") >=
         0

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-edit-conflict-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-edit-conflict-test.js
@@ -17,8 +17,8 @@ acceptance("Composer - Edit conflict", function (needs) {
 
   test("Edit a post that causes an edit conflict", async function (assert) {
     await visit("/t/internationalization-localization/280");
-    await click(".topic-post:eq(0) button.show-more-actions");
-    await click(".topic-post:eq(0) button.edit");
+    await click(".topic-post:nth-of-type(1) button.show-more-actions");
+    await click(".topic-post:nth-of-type(1) button.edit");
     await fillIn(".d-editor-input", "this will 409");
     await click("#reply-control button.create");
     assert.equal(
@@ -35,7 +35,7 @@ acceptance("Composer - Edit conflict", function (needs) {
 
   test("Should not send originalText when posting a new reply", async function (assert) {
     await visit("/t/internationalization-localization/280");
-    await click(".topic-post:eq(0) button.reply");
+    await click(".topic-post:nth-of-type(1) button.reply");
     await fillIn(
       ".d-editor-input",
       "hello world hello world hello world hello world hello world"
@@ -45,8 +45,8 @@ acceptance("Composer - Edit conflict", function (needs) {
 
   test("Should send originalText when editing a reply", async function (assert) {
     await visit("/t/internationalization-localization/280");
-    await click(".topic-post:eq(0) button.show-more-actions");
-    await click(".topic-post:eq(0) button.edit");
+    await click(".topic-post:nth-of-type(1) button.show-more-actions");
+    await click(".topic-post:nth-of-type(1) button.edit");
     await fillIn(
       ".d-editor-input",
       "hello world hello world hello world hello world hello world"

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
@@ -98,7 +98,7 @@ acceptance("Composer", function (needs) {
     await click("#reply-control a.cancel");
     assert.ok(exists(".bootbox.modal"), "it pops up a confirmation dialog");
 
-    await click(".modal-footer a:eq(1)");
+    await click(".modal-footer a:nth-of-type(2)");
     assert.ok(!exists(".bootbox.modal"), "the confirmation can be cancelled");
   });
 
@@ -288,10 +288,10 @@ acceptance("Composer", function (needs) {
     await click("#topic-footer-buttons .create");
     await fillIn(".d-editor-input", "this is the content of my reply");
 
-    await click(".topic-post:eq(0) button.show-more-actions");
-    await click(".topic-post:eq(0) button.edit");
+    await click(".topic-post:nth-of-type(1) button.show-more-actions");
+    await click(".topic-post:nth-of-type(1) button.edit");
 
-    await click(".modal-footer button:eq(1)");
+    await click(".modal-footer button:nth-of-type(2)");
 
     assert.ok(!visible(".discard-draft-modal.modal"));
     assert.equal(
@@ -351,12 +351,12 @@ acceptance("Composer", function (needs) {
     await visit("/t/internationalization-localization/280");
 
     assert.ok(
-      !exists(".topic-post:eq(0) .post-info.edits"),
+      !exists(".topic-post:nth-of-type(1) .post-info.edits"),
       "it has no edits icon at first"
     );
 
-    await click(".topic-post:eq(0) button.show-more-actions");
-    await click(".topic-post:eq(0) button.edit");
+    await click(".topic-post:nth-of-type(1) button.show-more-actions");
+    await click(".topic-post:nth-of-type(1) button.edit");
     assert.equal(
       queryAll(".d-editor-input").val().indexOf("Any plans to support"),
       0,
@@ -368,7 +368,7 @@ acceptance("Composer", function (needs) {
     await click("#reply-control button.create");
     assert.ok(!exists(".d-editor-input"), "it closes the composer");
     assert.ok(
-      exists(".topic-post:eq(0) .post-info.edits"),
+      exists(".topic-post:nth-of-type(1) .post-info.edits"),
       "it has the edits icon"
     );
     assert.ok(
@@ -378,7 +378,7 @@ acceptance("Composer", function (needs) {
       "it shows the new title"
     );
     assert.ok(
-      queryAll(".topic-post:eq(0) .cooked")
+      queryAll(".topic-post:nth-of-type(1) .cooked")
         .text()
         .indexOf("This is the new text for the post") !== -1,
       "it updates the post"
@@ -388,13 +388,13 @@ acceptance("Composer", function (needs) {
   test("Composer can switch between edits", async function (assert) {
     await visit("/t/this-is-a-test-topic/9");
 
-    await click(".topic-post:eq(0) button.edit");
+    await click(".topic-post:nth-of-type(1) button.edit");
     assert.equal(
       queryAll(".d-editor-input").val().indexOf("This is the first post."),
       0,
       "it populates the input with the post text"
     );
-    await click(".topic-post:eq(1) button.edit");
+    await click(".topic-post:nth-of-type(2) button.edit");
     assert.equal(
       queryAll(".d-editor-input").val().indexOf("This is the second post."),
       0,
@@ -405,15 +405,15 @@ acceptance("Composer", function (needs) {
   test("Composer with dirty edit can toggle to another edit", async function (assert) {
     await visit("/t/this-is-a-test-topic/9");
 
-    await click(".topic-post:eq(0) button.edit");
+    await click(".topic-post:nth-of-type(1) button.edit");
     await fillIn(".d-editor-input", "This is a dirty reply");
-    await click(".topic-post:eq(1) button.edit");
+    await click(".topic-post:nth-of-type(2) button.edit");
     assert.ok(
       exists(".discard-draft-modal.modal"),
       "it pops up a confirmation dialog"
     );
 
-    await click(".modal-footer button:eq(0)");
+    await click(".modal-footer button:nth-of-type(1)");
     assert.equal(
       queryAll(".d-editor-input").val().indexOf("This is the second post."),
       0,
@@ -424,15 +424,15 @@ acceptance("Composer", function (needs) {
   test("Composer can toggle between edit and reply", async function (assert) {
     await visit("/t/this-is-a-test-topic/9");
 
-    await click(".topic-post:eq(0) button.edit");
+    await click(".topic-post:nth-of-type(1) button.edit");
     assert.equal(
       queryAll(".d-editor-input").val().indexOf("This is the first post."),
       0,
       "it populates the input with the post text"
     );
-    await click(".topic-post:eq(0) button.reply");
+    await click(".topic-post:nth-of-type(1) button.reply");
     assert.equal(queryAll(".d-editor-input").val(), "", "it clears the input");
-    await click(".topic-post:eq(0) button.edit");
+    await click(".topic-post:nth-of-type(1) button.edit");
     assert.equal(
       queryAll(".d-editor-input").val().indexOf("This is the first post."),
       0,
@@ -444,7 +444,7 @@ acceptance("Composer", function (needs) {
     const menu = selectKit(".toolbar-popup-menu-options");
 
     await visit("/t/this-is-a-test-topic/9");
-    await click(".topic-post:eq(0) button.reply");
+    await click(".topic-post:nth-of-type(1) button.reply");
 
     await menu.expand();
     await menu.selectRowByValue("toggleWhisper");
@@ -477,7 +477,7 @@ acceptance("Composer", function (needs) {
 
   test("Composer can toggle layouts (open, fullscreen and draft)", async function (assert) {
     await visit("/t/this-is-a-test-topic/9");
-    await click(".topic-post:eq(0) button.reply");
+    await click(".topic-post:nth-of-type(1) button.reply");
 
     assert.ok(
       queryAll("#reply-control.open").length === 1,
@@ -516,7 +516,7 @@ acceptance("Composer", function (needs) {
 
   test("Composer can toggle between reply and createTopic", async function (assert) {
     await visit("/t/this-is-a-test-topic/9");
-    await click(".topic-post:eq(0) button.reply");
+    await click(".topic-post:nth-of-type(1) button.reply");
 
     await selectKit(".toolbar-popup-menu-options").expand();
     await selectKit(".toolbar-popup-menu-options").selectRowByValue(
@@ -551,7 +551,7 @@ acceptance("Composer", function (needs) {
 
     await visit("/t/this-is-a-test-topic/9");
 
-    await click(".topic-post:eq(0) button.reply");
+    await click(".topic-post:nth-of-type(1) button.reply");
     assert.ok(
       queryAll(".composer-fields .whisper")
         .text()
@@ -563,14 +563,14 @@ acceptance("Composer", function (needs) {
   test("Composer with dirty reply can toggle to edit", async function (assert) {
     await visit("/t/this-is-a-test-topic/9");
 
-    await click(".topic-post:eq(0) button.reply");
+    await click(".topic-post:nth-of-type(1) button.reply");
     await fillIn(".d-editor-input", "This is a dirty reply");
-    await click(".topic-post:eq(0) button.edit");
+    await click(".topic-post:nth-of-type(1) button.edit");
     assert.ok(
       exists(".discard-draft-modal.modal"),
       "it pops up a confirmation dialog"
     );
-    await click(".modal-footer button:eq(0)");
+    await click(".modal-footer button:nth-of-type(1)");
     assert.equal(
       queryAll(".d-editor-input").val().indexOf("This is the first post."),
       0,
@@ -581,19 +581,19 @@ acceptance("Composer", function (needs) {
   test("Composer draft with dirty reply can toggle to edit", async function (assert) {
     await visit("/t/this-is-a-test-topic/9");
 
-    await click(".topic-post:eq(0) button.reply");
+    await click(".topic-post:nth-of-type(1) button.reply");
     await fillIn(".d-editor-input", "This is a dirty reply");
     await click(".toggler");
-    await click(".topic-post:eq(1) button.edit");
+    await click(".topic-post:nth-of-type(2) button.edit");
     assert.ok(
       exists(".discard-draft-modal.modal"),
       "it pops up a confirmation dialog"
     );
     assert.equal(
-      queryAll(".modal-footer button:eq(1)").text().trim(),
+      queryAll(".modal-footer button:nth-of-type(2)").text().trim(),
       I18n.t("post.abandon.no_value")
     );
-    await click(".modal-footer button:eq(0)");
+    await click(".modal-footer button:nth-of-type(1)");
     assert.equal(
       queryAll(".d-editor-input").val().indexOf("This is the second post."),
       0,
@@ -604,7 +604,7 @@ acceptance("Composer", function (needs) {
   test("Composer draft can switch to draft in new context without destroying current draft", async function (assert) {
     await visit("/t/this-is-a-test-topic/9");
 
-    await click(".topic-post:eq(0) button.reply");
+    await click(".topic-post:nth-of-type(1) button.reply");
     await fillIn(".d-editor-input", "This is a dirty reply");
 
     await click("#site-logo");
@@ -615,10 +615,10 @@ acceptance("Composer", function (needs) {
       "it pops up a confirmation dialog"
     );
     assert.equal(
-      queryAll(".modal-footer button:eq(1)").text().trim(),
+      queryAll(".modal-footer button:nth-of-type(2)").text().trim(),
       I18n.t("post.abandon.no_save_draft")
     );
-    await click(".modal-footer button:eq(1)");
+    await click(".modal-footer button:nth-of-type(2)");
     assert.equal(
       queryAll(".d-editor-input").val(),
       "",
@@ -632,8 +632,8 @@ acceptance("Composer", function (needs) {
 
       await visit("/t/internationalization-localization/280");
 
-      await click(".topic-post:eq(0) button.show-more-actions");
-      await click(".topic-post:eq(0) button.edit");
+      await click(".topic-post:nth-of-type(1) button.show-more-actions");
+      await click(".topic-post:nth-of-type(1) button.edit");
 
       assert.equal(
         queryAll(".modal-body").text(),
@@ -712,7 +712,10 @@ acceptance("Composer", function (needs) {
       await click("button.compose-pm");
       await click(".modal .btn-default");
 
-      assert.equal(queryAll(".users-input .item:eq(0)").text(), "codinghorror");
+      assert.equal(
+        queryAll(".users-input .item:nth-of-type(1)").text(),
+        "codinghorror"
+      );
     } finally {
       toggleCheckDraftPopup(false);
     }

--- a/app/assets/javascripts/discourse/tests/acceptance/new-message-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/new-message-test.js
@@ -34,7 +34,7 @@ acceptance("New Message - Authenticated", function (needs) {
       "it pre-fills message body"
     );
     assert.equal(
-      queryAll(".users-input .item:eq(0)").text().trim(),
+      queryAll(".users-input .item:nth-of-type(1)").text().trim(),
       "charlie",
       "it selects correct username"
     );

--- a/app/assets/javascripts/discourse/tests/acceptance/page-publishing-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/page-publishing-test.js
@@ -27,9 +27,9 @@ acceptance("Page Publishing", function (needs) {
 
   test("can publish a page via modal", async function (assert) {
     await visit("/t/internationalization-localization/280");
-    await click(".topic-post:eq(0) button.show-more-actions");
-    await click(".topic-post:eq(0) button.show-post-admin-menu");
-    await click(".topic-post:eq(0) .publish-page");
+    await click(".topic-post:nth-of-type(1) button.show-more-actions");
+    await click(".topic-post:nth-of-type(1) button.show-post-admin-menu");
+    await click(".topic-post:nth-of-type(1) .publish-page");
 
     await fillIn(".publish-slug", "bad-slug");
     assert.ok(!exists(".valid-slug"));

--- a/app/assets/javascripts/discourse/tests/acceptance/raw-plugin-outlet-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/raw-plugin-outlet-test.js
@@ -26,7 +26,7 @@ acceptance("Raw Plugin Outlet", function (needs) {
     await visit("/");
     assert.ok(queryAll(".topic-lala").length > 0, "it renders the outlet");
     assert.equal(
-      queryAll(".topic-lala:eq(0)").text(),
+      queryAll(".topic-lala:nth-of-type(1)")[0].innerText,
       "11557",
       "it has the topic id"
     );

--- a/app/assets/javascripts/discourse/tests/acceptance/review-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/review-test.js
@@ -44,7 +44,9 @@ acceptance("Review", function (needs) {
       "has a list of bonuses"
     );
 
-    const field = selectKit(".reviewable-score-type:eq(0) .field .combo-box");
+    const field = selectKit(
+      ".reviewable-score-type:nth-of-type(1) .field .combo-box"
+    );
     await field.expand();
     await field.selectRowByValue("5");
     await click(".save-settings");
@@ -96,8 +98,14 @@ acceptance("Review", function (needs) {
     await visit("/review");
     assert.ok(queryAll(`${topic} .reviewable-action.approve`).length);
     assert.ok(!queryAll(`${topic} .category-name`).length);
-    assert.equal(queryAll(`${topic} .discourse-tag:eq(0)`).text(), "hello");
-    assert.equal(queryAll(`${topic} .discourse-tag:eq(1)`).text(), "world");
+    assert.equal(
+      queryAll(`${topic} .discourse-tag:nth-of-type(1)`).text(),
+      "hello"
+    );
+    assert.equal(
+      queryAll(`${topic} .discourse-tag:nth-of-type(2)`).text(),
+      "world"
+    );
 
     assert.equal(
       queryAll(`${topic} .post-body`).text().trim(),
@@ -139,9 +147,18 @@ acceptance("Review", function (needs) {
     await fillIn(".editable-field.payload-raw textarea", "new raw contents");
     await click(`${topic} .reviewable-action.save-edit`);
 
-    assert.equal(queryAll(`${topic} .discourse-tag:eq(0)`).text(), "hello");
-    assert.equal(queryAll(`${topic} .discourse-tag:eq(1)`).text(), "world");
-    assert.equal(queryAll(`${topic} .discourse-tag:eq(2)`).text(), "monkey");
+    assert.equal(
+      queryAll(`${topic} .discourse-tag:nth-of-type(1)`).text(),
+      "hello"
+    );
+    assert.equal(
+      queryAll(`${topic} .discourse-tag:nth-of-type(2)`).text(),
+      "world"
+    );
+    assert.equal(
+      queryAll(`${topic} .discourse-tag:nth-of-type(3)`).text(),
+      "monkey"
+    );
 
     assert.equal(
       queryAll(`${topic} .post-body`).text().trim(),

--- a/app/assets/javascripts/discourse/tests/acceptance/search-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-test.js
@@ -189,7 +189,9 @@ acceptance("Search - with tagging enabled", function (needs) {
     await fillIn("#search-term", "dev");
     await triggerKeyEvent("#search-term", "keyup", 16);
 
-    const tags = queryAll(".search-menu .results ul li:eq(0) .discourse-tags")
+    const tags = queryAll(
+      ".search-menu .results ul li:nth-of-type(1) .discourse-tags"
+    )
       .text()
       .trim();
 

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-test.js
@@ -28,7 +28,7 @@ acceptance("Topic", function (needs) {
 
   test("Reply as new topic", async function (assert) {
     await visit("/t/internationalization-localization/280");
-    await click("button.share:eq(0)");
+    await click("button.share:nth-of-type(1)");
     await click(".reply-as-new-topic a");
 
     assert.ok(exists(".d-editor-input"), "the composer input is visible");
@@ -47,7 +47,7 @@ acceptance("Topic", function (needs) {
 
   test("Reply as new message", async function (assert) {
     await visit("/t/pm-for-testing/12");
-    await click("button.share:eq(0)");
+    await click("button.share:nth-of-type(1)");
     await click(".reply-as-new-topic a");
 
     assert.ok(exists(".d-editor-input"), "the composer input is visible");
@@ -133,8 +133,8 @@ acceptance("Topic", function (needs) {
       "it does not show the wiki icon"
     );
 
-    await click(".topic-post:eq(0) button.show-more-actions");
-    await click(".topic-post:eq(0) button.show-post-admin-menu");
+    await click(".topic-post:nth-of-type(1) button.show-more-actions");
+    await click(".topic-post:nth-of-type(1) button.show-post-admin-menu");
     await click(".btn.wiki");
 
     assert.ok(queryAll("a.wiki").length === 1, "it shows the wiki icon");
@@ -215,7 +215,7 @@ acceptance("Topic", function (needs) {
 
   test("Deleting a topic", async function (assert) {
     await visit("/t/internationalization-localization/280");
-    await click(".topic-post:eq(0) button.show-more-actions");
+    await click(".topic-post:nth-of-type(1) button.show-more-actions");
     await click(".widget-button.delete");
     await click(".toggle-admin-menu");
     assert.ok(exists(".topic-admin-recover"), "it shows the recover button");
@@ -224,7 +224,7 @@ acceptance("Topic", function (needs) {
   test("Deleting a popular topic displays confirmation modal", async function (assert) {
     this.siteSettings.min_topic_views_for_delete_confirm = 10;
     await visit("/t/internationalization-localization/280");
-    await click(".topic-post:eq(0) button.show-more-actions");
+    await click(".topic-post:nth-of-type(1) button.show-more-actions");
     await click(".widget-button.delete");
     assert.ok(
       visible(".delete-topic-confirm-modal"),

--- a/app/assets/javascripts/discourse/tests/acceptance/user-bookmarks-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-bookmarks-test.js
@@ -14,7 +14,7 @@ acceptance("User's bookmarks", function (needs) {
     await visit("/u/eviltrout/activity/bookmarks");
     assert.ok(queryAll(".bookmark-list-item").length > 0);
 
-    const dropdown = selectKit(".bookmark-actions-dropdown:eq(0)");
+    const dropdown = selectKit(".bookmark-actions-dropdown:nth-of-type(1)");
     await dropdown.expand();
     await dropdown.selectRowByValue("remove");
 

--- a/app/assets/javascripts/discourse/tests/acceptance/user-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-test.js
@@ -85,7 +85,7 @@ acceptance("User Routes", function (needs) {
       "has draft action buttons"
     );
 
-    await click(".user-stream button.resume-draft:eq(0)");
+    await click(".user-stream button.resume-draft:nth-of-type(1)");
     assert.ok(
       exists(".d-editor-input"),
       "composer is visible after resuming a draft"

--- a/app/assets/javascripts/discourse/tests/helpers/select-kit-helper.js
+++ b/app/assets/javascripts/discourse/tests/helpers/select-kit-helper.js
@@ -249,7 +249,9 @@ export default function selectKit(selector) {
 
     rowByIndex(index) {
       return rowHelper(
-        queryAll(selector).find(".select-kit-row:eq(" + index + ")")
+        queryAll(selector).find(
+          ".select-kit-row:nth-of-type(" + (index + 1) + ")"
+        )
       );
     },
 

--- a/app/assets/javascripts/discourse/tests/integration/widgets/post-stream-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/post-stream-test.js
@@ -76,37 +76,37 @@ discourseModule("Integration | Component | Widget | post-stream", function (
 
       // look for special class bindings
       assert.equal(
-        queryAll(".topic-post:eq(0).topic-owner").length,
+        queryAll(".topic-post:nth-of-type(1).topic-owner").length,
         1,
         "it applies the topic owner class"
       );
       assert.equal(
-        queryAll(".topic-post:eq(0).group-trout").length,
+        queryAll(".topic-post:nth-of-type(1).group-trout").length,
         1,
         "it applies the primary group class"
       );
       assert.equal(
-        queryAll(".topic-post:eq(0).regular").length,
+        queryAll(".topic-post:nth-of-type(1).regular").length,
         1,
         "it applies the regular class"
       );
       assert.equal(
-        queryAll(".topic-post:eq(1).moderator").length,
+        queryAll(".topic-post:nth-of-type(2).moderator").length,
         1,
         "it applies the moderator class"
       );
       assert.equal(
-        queryAll(".topic-post:eq(2).post-hidden").length,
+        queryAll(".topic-post:nth-of-type(3).post-hidden").length,
         1,
         "it applies the hidden class"
       );
       assert.equal(
-        queryAll(".topic-post:eq(3).whisper").length,
+        queryAll(".topic-post:nth-of-type(4).whisper").length,
         1,
         "it applies the whisper class"
       );
       assert.equal(
-        queryAll(".topic-post:eq(4).wiki").length,
+        queryAll(".topic-post:nth-of-type(5).wiki").length,
         1,
         "it applies the wiki class"
       );
@@ -119,7 +119,7 @@ discourseModule("Integration | Component | Widget | post-stream", function (
       assert.equal(queryAll("article#post_6.is-auto-generated").length, 1);
 
       assert.equal(
-        queryAll("article:eq(0) .main-avatar").length,
+        queryAll("article:nth-of-type(1) .main-avatar").length,
         1,
         "renders the main avatar"
       );

--- a/app/assets/javascripts/discourse/tests/integration/widgets/widget-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/widget-test.js
@@ -331,7 +331,7 @@ discourseModule("Integration | Component | Widget | base", function (hooks) {
 
     test(assert) {
       assert.equal(queryAll("ul li").length, 3);
-      assert.equal(queryAll("ul li:eq(0)").text(), "one");
+      assert.equal(queryAll("ul li:nth-of-type(1)").text(), "one");
     },
   });
 

--- a/app/assets/javascripts/wizard/components/wizard-step.js
+++ b/app/assets/javascripts/wizard/components/wizard-step.js
@@ -98,13 +98,15 @@ export default Component.extend({
 
   autoFocus() {
     schedule("afterRender", () => {
-      const $invalid = $(".wizard-field.invalid:eq(0) .wizard-focusable");
+      const $invalid = $(
+        ".wizard-field.invalid:nth-of-type(1) .wizard-focusable"
+      );
 
       if ($invalid.length) {
         return $invalid.focus();
       }
 
-      $(".wizard-focusable:eq(0)").focus();
+      $(".wizard-focusable:nth-of-type(1)").focus();
     });
   },
 

--- a/app/assets/javascripts/wizard/test/components/invite-list-test.js
+++ b/app/assets/javascripts/wizard/test/components/invite-list-test.js
@@ -72,7 +72,7 @@ componentTest("can add users", {
     );
     assert.ok(document.querySelectorAll(".new-user .invalid").length === 1);
 
-    await click(".invite-list .invite-list-user:eq(0) .remove-user");
+    await click(".invite-list .invite-list-user:nth-of-type(1) .remove-user");
     assert.ok(
       document.querySelectorAll(".users-list .invite-list-user").length === 0,
       "removed the user"

--- a/plugins/poll/test/javascripts/widgets/discourse-poll-option-test.js.es6
+++ b/plugins/poll/test/javascripts/widgets/discourse-poll-option-test.js.es6
@@ -19,7 +19,7 @@ widgetTest("single, not selected", {
   },
 
   test(assert) {
-    assert.ok(queryAll("li .d-icon-far-circle:eq(0)").length === 1);
+    assert.ok(queryAll("li .d-icon-far-circle:nth-of-type(1)").length === 1);
   },
 });
 
@@ -32,7 +32,7 @@ widgetTest("single, selected", {
   },
 
   test(assert) {
-    assert.ok(queryAll("li .d-icon-circle:eq(0)").length === 1);
+    assert.ok(queryAll("li .d-icon-circle:nth-of-type(1)").length === 1);
   },
 });
 
@@ -48,7 +48,7 @@ widgetTest("multi, not selected", {
   },
 
   test(assert) {
-    assert.ok(queryAll("li .d-icon-far-square:eq(0)").length === 1);
+    assert.ok(queryAll("li .d-icon-far-square:nth-of-type(1)").length === 1);
   },
 });
 
@@ -64,6 +64,8 @@ widgetTest("multi, selected", {
   },
 
   test(assert) {
-    assert.ok(queryAll("li .d-icon-far-check-square:eq(0)").length === 1);
+    assert.ok(
+      queryAll("li .d-icon-far-check-square:nth-of-type(1)").length === 1
+    );
   },
 });

--- a/plugins/poll/test/javascripts/widgets/discourse-poll-standard-results-test.js.es6
+++ b/plugins/poll/test/javascripts/widgets/discourse-poll-standard-results-test.js.es6
@@ -25,8 +25,8 @@ widgetTest("options in descending order", {
   },
 
   test(assert) {
-    assert.equal(queryAll(".option .percentage:eq(0)").text(), "56%");
-    assert.equal(queryAll(".option .percentage:eq(1)").text(), "44%");
+    assert.equal(queryAll(".option .percentage")[0].innerText, "56%");
+    assert.equal(queryAll(".option .percentage")[1].innerText, "44%");
   },
 });
 
@@ -44,8 +44,8 @@ widgetTest("options in ascending order", {
   },
 
   test(assert) {
-    assert.equal(queryAll(".option .percentage:eq(0)").text(), "56%");
-    assert.equal(queryAll(".option .percentage:eq(1)").text(), "44%");
+    assert.equal(queryAll(".option .percentage")[0].innerText, "56%");
+    assert.equal(queryAll(".option .percentage")[1].innerText, "44%");
   },
 });
 
@@ -71,12 +71,20 @@ widgetTest("multiple options in descending order", {
   },
 
   test(assert) {
-    assert.equal(queryAll(".option .percentage:eq(0)").text(), "41%");
-    assert.equal(queryAll(".option .percentage:eq(1)").text(), "33%");
-    assert.equal(queryAll(".option .percentage:eq(2)").text(), "16%");
-    assert.equal(queryAll(".option .percentage:eq(3)").text(), "8%");
-    assert.equal(queryAll(".option span:nth-child(2):eq(3)").text(), "a");
-    assert.equal(queryAll(".option .percentage:eq(4)").text(), "8%");
-    assert.equal(queryAll(".option span:nth-child(2):eq(4)").text(), "b");
+    let percentages = queryAll(".option .percentage");
+    assert.equal(percentages[0].innerText, "41%");
+    assert.equal(percentages[1].innerText, "33%");
+    assert.equal(percentages[2].innerText, "16%");
+    assert.equal(percentages[3].innerText, "8%");
+
+    assert.equal(
+      queryAll(".option")[3].querySelectorAll("span")[1].innerText,
+      "a"
+    );
+    assert.equal(percentages[4].innerText, "8%");
+    assert.equal(
+      queryAll(".option")[4].querySelectorAll("span")[1].innerText,
+      "b"
+    );
   },
 });


### PR DESCRIPTION
For the most part `querySelectorAll` will work with jQuery selectors,
but the big exception is `:eq(0)` and similar. Those needed to be
replaced.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
