### PR TITLE
UX: PM title glyph alignment and consistency improvement

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/private-message-glyph.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/private-message-glyph.hbs
@@ -4,7 +4,7 @@
       <span class="private-message-glyph-wrapper">
         {{d-icon "envelope" class="private-message-glyph"}}
       </span>
-    </a>{{!-- whitespace control --}}
+    </a>
   {{~else}}
     <span class="private-message-glyph-wrapper">
       {{d-icon "envelope" class="private-message-glyph"}}

--- a/app/assets/javascripts/discourse/app/templates/components/private-message-glyph.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/private-message-glyph.hbs
@@ -4,10 +4,10 @@
       <span class="private-message-glyph-wrapper">
         {{d-icon "envelope" class="private-message-glyph"}}
       </span>
-    </a>
-  {{else}}
+    </a>{{!-- whitespace control --}}
+  {{~else}}
     <span class="private-message-glyph-wrapper">
       {{d-icon "envelope" class="private-message-glyph"}}
     </span>
-  {{/if}}
+  {{~/if}}
 {{/if}}

--- a/app/assets/javascripts/discourse/app/templates/topic.hbs
+++ b/app/assets/javascripts/discourse/app/templates/topic.hbs
@@ -17,7 +17,7 @@
       {{#topic-title cancelled=(action "cancelEditingTopic") save=(action "finishedEditingTopic") model=model}}
         {{#if editingTopic}}
           <div class="edit-topic-title">
-            {{private-message-glyph shouldShow=model.isPrivateMessage}}
+            {{private-message-glyph shouldShow=model.isPrivateMessage tagName=""}}
 
             {{text-field id="edit-title" value=buffered.title maxlength=siteSettings.max_topic_title_length autofocus="true"}}
 
@@ -65,9 +65,10 @@
                   href=pmPath
                   title="topic_statuses.personal_message.title"
                   ariaLabel="user.messages.inbox"
+                  tagName=""
                 }}
               {{else}}
-                {{private-message-glyph shouldShow=model.isPrivateMessage}}
+                {{private-message-glyph shouldShow=model.isPrivateMessage  tagName=""}}
               {{/if}}
             {{/unless}}
 

--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -748,7 +748,7 @@ table {
     display: inline-flex;
     color: var(--primary-medium);
     .d-icon {
-      height: 0.76em;
+      height: 0.74em;
       width: 0.75em;
     }
     &:not(:last-child) {

--- a/app/assets/stylesheets/common/base/topic.scss
+++ b/app/assets/stylesheets/common/base/topic.scss
@@ -183,16 +183,11 @@ a.badge-category {
 .private-message-glyph {
   color: var(--primary-medium);
   height: 0.95em;
-  &.d-icon-user-secret {
-    // special case because it's a tall icon
-    height: 0.8em;
-    vertical-align: baseline;
-  }
 }
 
 .private-message-glyph-wrapper {
   float: left;
-  margin-right: 0.15em;
+  margin-right: 0.25em;
 }
 
 .private_message {

--- a/app/assets/stylesheets/common/base/topic.scss
+++ b/app/assets/stylesheets/common/base/topic.scss
@@ -114,7 +114,7 @@
     display: inline-block;
   }
   .topic-statuses {
-    line-height: 1.2em;
+    line-height: 1.2;
     margin-right: 0.15em;
     &:empty {
       margin-right: 0;
@@ -181,16 +181,18 @@ a.badge-category {
 }
 
 .private-message-glyph {
-  color: var(--primary-low-mid-or-secondary-high);
+  color: var(--primary-medium);
+  height: 0.95em;
+  &.d-icon-user-secret {
+    // special case because it's a tall icon
+    height: 0.8em;
+    vertical-align: baseline;
+  }
 }
 
 .private-message-glyph-wrapper {
   float: left;
-
-  .private-message-glyph {
-    margin: 0 5px 0 0;
-    display: inline-block;
-  }
+  margin-right: 0.15em;
 }
 
 .private_message {

--- a/app/assets/stylesheets/mobile/topic.scss
+++ b/app/assets/stylesheets/mobile/topic.scss
@@ -184,10 +184,6 @@ sub sub {
     width: 100%;
     margin-top: 0;
   }
-
-  .topic-statuses {
-    line-height: $line-height-small;
-  }
 }
 
 // make mobile timeline top and bottom dates easier to select


### PR DESCRIPTION
A few things:

* removed some ember wrappers with `tagname=""`
* removed a whitespace in the template with `~`
* Updated PM glyph styles to better match topic statuses on public topics



Not so noticeable here: 

Before
![Screen Shot 2020-11-20 at 10 54 42 PM](https://user-images.githubusercontent.com/1681963/99867102-975c0600-2b84-11eb-93ed-bcf6bf8c8060.png)

After

![Screen Shot 2020-11-20 at 11 04 29 PM](https://user-images.githubusercontent.com/1681963/99867141-c6727780-2b84-11eb-85b3-86be393bf1fe.png)


but more obvious here:

Before
![Screen Shot 2020-11-20 at 11 00 23 PM](https://user-images.githubusercontent.com/1681963/99867105-9a56f680-2b84-11eb-9e47-c2d8063e3762.png)

After
![Screen Shot 2020-11-20 at 11 02 25 PM](https://user-images.githubusercontent.com/1681963/99867106-9a56f680-2b84-11eb-8202-71984d3c5ebd.png)
