### PR TITLE
FIX: Force string conversions to UTF-8 "bytes"

### DIFF
--- a/plugins/poll/assets/javascripts/lib/discourse-markdown/poll.js.es6
+++ b/plugins/poll/assets/javascripts/lib/discourse-markdown/poll.js.es6
@@ -403,10 +403,9 @@ function ii(a, b, c, d, x, s, t) {
 }
 
 function md51(s) {
-  // Converts the string to UTF-8 "bytes" when necessary
-  if (/[\x80-\xFF]/.test(s)) {
-    s = unescape(encodeURI(s));
-  }
+  // Converts the string to UTF-8 "bytes"
+  s = unescape(encodeURI(s));
+
   var n = s.length,
     state = [1732584193, -271733879, -1732584194, 271733878],
     i;

--- a/plugins/poll/spec/controllers/posts_controller_spec.rb
+++ b/plugins/poll/spec/controllers/posts_controller_spec.rb
@@ -71,6 +71,16 @@ describe PostsController do
       expect(json["errors"][0]).to eq(I18n.t("poll.default_poll_must_have_different_options"))
     end
 
+    it "accepts different Chinese options" do
+      SiteSetting.default_locale = 'zh_CN'
+      
+      post :create, params: {
+        title: title, raw: "[poll]\n- Microsoft Edge（新）\n- Microsoft Edge（旧）\n[/poll]"
+      }, format: :json
+
+      expect(response).to be_successful
+    end
+
     it "should have at least 1 options" do
       post :create, params: {
         title: title, raw: "[poll]\n[/poll]"

--- a/plugins/poll/spec/controllers/posts_controller_spec.rb
+++ b/plugins/poll/spec/controllers/posts_controller_spec.rb
@@ -73,7 +73,7 @@ describe PostsController do
 
     it "accepts different Chinese options" do
       SiteSetting.default_locale = 'zh_CN'
-      
+
       post :create, params: {
         title: title, raw: "[poll]\n- Microsoft Edge（新）\n- Microsoft Edge（旧）\n[/poll]"
       }, format: :json


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
