### PR TITLE
FIX: Onebox image alignment

### DIFF
--- a/app/assets/stylesheets/common/base/onebox.scss
+++ b/app/assets/stylesheets/common/base/onebox.scss
@@ -188,6 +188,7 @@ aside.onebox {
 
       // full size images for instagram, twitter, etc.
       .aspect-image-full-size {
+        margin: 0.5em 0;
         max-height: 100%;
         width: calc(500px * var(--aspect-ratio));
         max-width: 100%;
@@ -198,7 +199,6 @@ aside.onebox {
           max-width: initial;
           max-height: initial;
           float: none;
-          padding: 5px 5px 5px 5px;
         }
       }
 


### PR DESCRIPTION
It was overlapping with elements after it and was unnecessarily indented relative to the text before it.

before/after

<img width="354" alt="before" src="https://user-images.githubusercontent.com/66961/99918040-94901b00-2d14-11eb-9671-a6a082bccaca.png"> <img width="354" alt="after" src="https://user-images.githubusercontent.com/66961/99918042-96f27500-2d14-11eb-96b1-77f5d9ea76df.png">
