### PR TITLE
UX: Improve Onebox code blocks with numbered lines

### DIFF
--- a/app/assets/stylesheets/common/base/onebox.scss
+++ b/app/assets/stylesheets/common/base/onebox.scss
@@ -333,17 +333,18 @@ blockquote {
 
 // -- Onebox Github Code Blob --
 pre.onebox code ol.lines li:before {
-  position: absolute;
-  display: inline-block;
-  width: 35px;
-  left: -40px;
-  color: #afafaf;
-  text-align: right;
-  padding-right: 5px;
-  font-size: $font-down-1;
-  line-height: $line-height-large;
+  @include unselectable;
+
+  border-right: 1px solid var(--primary-low);
+  color: var(--primary-low-mid);
   content: counter(li-counter);
   counter-increment: li-counter;
+  display: table-cell;
+  font-size: $font-down-1;
+  line-height: $line-height-large;
+  padding-left: 0.5em;
+  padding-right: 1em;
+  text-align: right;
 }
 
 pre.onebox code ol {
@@ -358,16 +359,18 @@ pre.onebox code li {
 }
 
 pre.onebox code ol.lines {
-  position: relative;
-  margin: 0 0 0 40px;
+  border-spacing: 1em 0;
+  display: table;
+  margin: 0;
+  margin-left: -1em;
+  padding: 0;
 }
 
 pre.onebox code ol.lines li {
+  display: table-row;
+  line-height: 1.5em;
   list-style-type: none;
-  padding-left: 5px;
-  margin-left: 0;
-  border-left: 1px solid #cfcfcf;
-  min-height: 1.5em; //show empty li lines
+  padding: 0;
   white-space: pre;
 }
 


### PR DESCRIPTION
Changes:
* numbers column now fits the content
* reduced the contrast of the border
* made the numbers color use our css vars (i.e. fixed the contrast on the dark theme)
* numbers are aligned with the code
* the text selection doesn't is no longer visible over the numbers

Note: uses `display: table` 👀 Should I change it to use `grid` instead? (probably)

before/after
<img width="354" alt="light-before" src="https://user-images.githubusercontent.com/66961/99921703-77ffdd00-2d2c-11eb-98db-79aa0391d9a0.png"> <img width="354" alt="light-after" src="https://user-images.githubusercontent.com/66961/99921708-7afacd80-2d2c-11eb-86a0-ba3e125c1f2f.png">
<img width="354" alt="dark-before" src="https://user-images.githubusercontent.com/66961/99921704-79c9a080-2d2c-11eb-80ae-c27179538aa4.png"> <img width="354" alt="dark-after" src="https://user-images.githubusercontent.com/66961/99921706-7a623700-2d2c-11eb-824a-0a9c7338831d.png">
