### PR TITLE
FIX: Calculate email attachment size limit correctly

### DIFF
--- a/lib/email/sender.rb
+++ b/lib/email/sender.rb
@@ -281,7 +281,7 @@ module Email
         end
 
         attached_upload = optimized_1X || original_upload
-        next if email_size + original_upload.filesize > max_email_size
+        next if email_size + attached_upload.filesize > max_email_size
 
         begin
           path = if attached_upload.local?

--- a/spec/components/email/sender_spec.rb
+++ b/spec/components/email/sender_spec.rb
@@ -486,12 +486,15 @@ describe Email::Sender do
 
         context "when the uploaded secure image has an optimized image" do
           let!(:optimized) { Fabricate(:optimized_image, upload: @secure_image) }
-          let!(:optimized_image_file) { file_from_fixtures("logo-dev.png", "images") }
+          let!(:optimized_image_file) { file_from_fixtures("smallest.png", "images") }
 
-          it "uses the email styles and the optimized image to inline secure images and attaches the secure image upload to the email" do
+          before do
             Discourse.store.store_optimized_image(optimized_image_file, optimized)
             optimized.update(url: Discourse.store.absolute_base_url + '/' + optimized.url)
             Discourse.store.cache_file(optimized_image_file, File.basename("#{optimized.sha1}.png"))
+          end
+
+          it "uses the email styles and the optimized image to inline secure images and attaches the secure image upload to the email" do
             Email::Sender.new(message, :valid_type).send
             expect(message.attachments.length).to eq(4)
             expect(message.attachments.map(&:filename))
@@ -499,7 +502,13 @@ describe Email::Sender do
             expect(message.attachments["logo.png"].body.raw_source.force_encoding("UTF-8")).to eq(File.read(optimized_image_file))
             expect(message.html_part.body).to include("cid:")
             expect(message.html_part.body).to include("embedded-secure-image")
+          end
+
+          it "uses the optimized image size in the max size limit calculation, not the original image size" do
+            SiteSetting.email_total_attachment_size_limit_kb = 45
+            Email::Sender.new(message, :valid_type).send
             expect(message.attachments.length).to eq(4)
+            expect(message.attachments["logo.png"].body.raw_source.force_encoding("UTF-8")).to eq(File.read(optimized_image_file))
           end
         end
       end


### PR DESCRIPTION
When calculating whether the attached uploads went over the `SiteSetting.email_total_attachment_size_limit_kb.kilobytes` limit, we were using the `original_upload` for the calculation instead of the actually `attached_upload`, which will be smaller in most cases because it can be an optimized image.