### PR TITLE
fix global leak

### DIFF
--- a/app/models/discourse_single_sign_on.rb
+++ b/app/models/discourse_single_sign_on.rb
@@ -305,27 +305,32 @@ class DiscourseSingleSignOn < SingleSignOn
       end
     end
 
-    profile_background_missing = user.user_profile.profile_background_upload.blank? || Upload.get_from_url(user.user_profile.profile_background_upload.url).blank?
-    if (profile_background_missing || SiteSetting.sso_overrides_profile_background) && profile_background_url.present?
-      profile_background_changed = sso_record.external_profile_background_url != profile_background_url
-      if profile_background_changed || profile_background_missing
-        Jobs.enqueue(:download_profile_background_from_url,
-            url: profile_background_url,
-            user_id: user.id,
-            is_card_background: false
-        )
+    if profile_background_url.present?
+      profile_background_missing = user.user_profile.profile_background_upload.blank? || Upload.get_from_url(user.user_profile.profile_background_upload.url).blank?
+
+      if profile_background_missing || SiteSetting.sso_overrides_profile_background
+        profile_background_changed = sso_record.external_profile_background_url != profile_background_url
+        if profile_background_changed || profile_background_missing
+          Jobs.enqueue(:download_profile_background_from_url,
+              url: profile_background_url,
+              user_id: user.id,
+              is_card_background: false
+          )
+        end
       end
     end
 
-    card_background_missing = user.user_profile.card_background_upload.blank? || Upload.get_from_url(user.user_profile.card_background_upload.url).blank?
-    if (card_background_missing || SiteSetting.sso_overrides_profile_background) && card_background_url.present?
-      card_background_changed = sso_record.external_card_background_url != card_background_url
-      if card_background_changed || card_background_missing
-        Jobs.enqueue(:download_profile_background_from_url,
-            url: card_background_url,
-            user_id: user.id,
-            is_card_background: true
-        )
+    if card_background_url.present?
+      card_background_missing = user.user_profile.card_background_upload.blank? || Upload.get_from_url(user.user_profile.card_background_upload.url).blank?
+      if card_background_missing || SiteSetting.sso_overrides_profile_background
+        card_background_changed = sso_record.external_card_background_url != card_background_url
+        if card_background_changed || card_background_missing
+          Jobs.enqueue(:download_profile_background_from_url,
+              url: card_background_url,
+              user_id: user.id,
+              is_card_background: true
+          )
+        end
       end
     end
 

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -36,11 +36,6 @@ task 'assets:precompile:before' do
 
   require 'sprockets'
   require 'digest/sha1'
-
-  # Needed for proper source maps with a CDN
-  load "#{Rails.root}/lib/global_path.rb"
-  include GlobalPath
-
 end
 
 task 'assets:precompile:css' => 'environment' do
@@ -78,6 +73,20 @@ end
 
 def assets_path
   "#{Rails.root}/public/assets"
+end
+
+def global_path_klass
+  @global_path_klass ||= Class.new do
+    extend GlobalPath
+  end
+end
+
+def cdn_path(p)
+  global_path_klass.cdn_relative_path(p)
+end
+
+def cdn_relative_path(p)
+  global_path_klass.cdn_relative_path(p)
 end
 
 def compress_node(from, to)


### PR DESCRIPTION
- PERF: avoid checking card background and user background when not supplied
- FIX: stop including GlobalPath in default context
