### PR TITLE
FIX: Gracefully handle force pushes for remote themes

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-customize-themes-show.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-customize-themes-show.js
@@ -151,6 +151,15 @@ export default Controller.extend({
 
   hasTranslations: notEmpty("translations"),
 
+  @discourseComputed(
+    "model.remote_theme.local_version",
+    "model.remote_theme.remote_version",
+    "model.remote_theme.commits_behind"
+  )
+  hasOverwrittenHistory(localVersion, remoteVersion, commitsBehind) {
+    return localVersion !== remoteVersion && commitsBehind === -1;
+  },
+
   @discourseComputed("model.remoteError", "updatingRemote")
   showRemoteError(errorMessage, updating) {
     return errorMessage && !updating;

--- a/app/assets/javascripts/admin/addon/templates/customize-themes-show.hbs
+++ b/app/assets/javascripts/admin/addon/templates/customize-themes-show.hbs
@@ -105,7 +105,11 @@
               {{i18n "admin.customize.theme.updating"}}
             {{else}}
               {{#if model.remote_theme.commits_behind}}
-                {{i18n "admin.customize.theme.commits_behind" count=model.remote_theme.commits_behind}}
+                {{#if hasOverwrittenHistory}}
+                  {{i18n "admin.customize.theme.has_overwritten_history"}}
+                {{else}}
+                  {{i18n "admin.customize.theme.commits_behind" count=model.remote_theme.commits_behind}}
+                {{/if}}
                 {{#if model.remote_theme.github_diff_link}}
                   <a href={{model.remote_theme.github_diff_link}}>
                     {{i18n "admin.customize.theme.compare_commits"}}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4067,6 +4067,7 @@ en:
           check_for_updates: "Check for Updates"
           updating: "Updating..."
           up_to_date: "Theme is up-to-date, last checked:"
+          has_overwritten_history: "Current theme version no longer exists because the Git history has been overwritten by a force push."
           add: "Add"
           theme_settings: "Theme Settings"
           no_settings: "This theme has no settings."

--- a/lib/theme_store/git_importer.rb
+++ b/lib/theme_store/git_importer.rb
@@ -35,7 +35,7 @@ class ThemeStore::GitImporter
 
     Discourse::Utils.execute_command(chdir: @temp_folder) do |runner|
       commit_hash = runner.exec("git", "rev-parse", "HEAD").strip
-      commits_behind = runner.exec("git", "rev-list", "#{hash}..HEAD", "--count").strip
+      commits_behind = runner.exec("git", "rev-list", "#{hash}..HEAD", "--count").strip rescue -1
     end
 
     [commit_hash, commits_behind]

--- a/spec/models/remote_theme_spec.rb
+++ b/spec/models/remote_theme_spec.rb
@@ -158,6 +158,29 @@ describe RemoteTheme do
       scheme = ColorScheme.find_by(theme_id: @theme.id)
       expect(scheme.colors.find_by(name: 'tertiary_low_color')).to eq(nil)
     end
+
+    it "can update themes with overwritten history" do
+      theme = RemoteTheme.import_theme(initial_repo)
+      remote = theme.remote_theme
+
+      old_version = `cd #{initial_repo} && git rev-parse HEAD`.strip
+      expect(theme.name).to eq('awesome theme')
+      expect(remote.remote_url).to eq(initial_repo)
+      expect(remote.local_version).to eq(old_version)
+      expect(remote.remote_version).to eq(old_version)
+
+      `cd #{initial_repo} && git commit --amend -m "amended commit"`
+      new_version = `cd #{initial_repo} && git rev-parse HEAD`.strip
+
+      # make sure that the amended commit does not exist anymore
+      `cd #{initial_repo} && git reflog expire --all --expire=now`
+      `cd #{initial_repo} && git prune`
+
+      remote.update_remote_version
+      expect(remote.reload.local_version).to eq(old_version)
+      expect(remote.reload.remote_version).to eq(new_version)
+      expect(remote.reload.commits_behind).to eq(-1)
+    end
   end
 
   let(:github_repo) do


### PR DESCRIPTION
Force pushing a commit to a theme repository used to break the updater,
because the system was not able to count the commits behind the old and
new version. This operation failed because a force push deleted the old
commits.

The user was prompted with a simple "500 server error" message.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
