### PR TITLE
FIX: Suggested Topics was being set inside a computed property

### DIFF
--- a/app/assets/javascripts/discourse/app/models/topic.js
+++ b/app/assets/javascripts/discourse/app/models/topic.js
@@ -194,12 +194,7 @@ const Topic = RestModel.extend({
   @discourseComputed("suggested_topics")
   suggestedTopics(suggestedTopics) {
     if (suggestedTopics) {
-      const store = this.store;
-
-      return this.set(
-        "suggested_topics",
-        suggestedTopics.map((st) => store.createRecord("topic", st))
-      );
+      return suggestedTopics.map((st) => this.store.createRecord("topic", st));
     }
   },
 


### PR DESCRIPTION
This is bad because changing the `suggested_topics` proeprty could cause
a `set` on `suggested_topics`.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
