### PR TITLE
DEV: Skip missing icon warnings in production

### DIFF
--- a/app/assets/javascripts/discourse-common/addon/lib/icon-library.js
+++ b/app/assets/javascripts/discourse-common/addon/lib/icon-library.js
@@ -1,6 +1,7 @@
 import I18n from "I18n";
 import { h } from "virtual-dom";
 import attributeHook from "discourse-common/lib/attribute-hook";
+import { isDevelopment } from "discourse-common/config/environment";
 
 const SVG_NAMESPACE = "http://www.w3.org/2000/svg";
 let _renderers = [];
@@ -115,13 +116,11 @@ export function setIconList(iconList) {
 }
 
 export function isExistingIconId(id) {
-  // TODO: investigate why _iconList is actually an array as a string: '["foo", "bar"]'
-  // in local and a real array in production
   return _iconList && _iconList.indexOf(id) >= 0;
 }
 
 function warnIfMissing(id) {
-  if (warnMissingIcons && !isExistingIconId(id)) {
+  if (warnMissingIcons && isDevelopment() && !isExistingIconId(id)) {
     console.warn(`The icon "${id}" is missing from the SVG subset.`); // eslint-disable-line no-console
   }
 }

--- a/app/assets/javascripts/discourse/app/pre-initializers/discourse-bootstrap.js
+++ b/app/assets/javascripts/discourse/app/pre-initializers/discourse-bootstrap.js
@@ -95,7 +95,7 @@ export default {
     session.userDarkSchemeId = parseInt(setupData.userDarkSchemeId, 10) || -1;
 
     if (isDevelopment()) {
-      setIconList(setupData.svgIconList);
+      setIconList(JSON.parse(setupData.svgIconList));
     }
 
     if (setupData.s3BaseUrl) {


### PR DESCRIPTION
The list of SVG icons is unavailable in production, and the previous
refactor here was causing incorrect and noisy console warnings.

This also parses the `svgIconList` string in a dev environment, icons
should now match more accurately.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
