### PR TITLE
Remove "Alternative Logos" from popular themes list

### DIFF
--- a/app/assets/javascripts/discourse-common/addon/helpers/popular-themes.js
+++ b/app/assets/javascripts/discourse-common/addon/helpers/popular-themes.js
@@ -86,14 +86,6 @@ export const POPULAR_THEMES = [
     component: true,
   },
   {
-    name: "Alternative Logos",
-    value: "https://github.com/discourse/discourse-alt-logo",
-    description: "Add alternative logos for dark / light themes.",
-    meta_url:
-      "https://meta.discourse.org/t/alternative-logo-for-dark-themes/88502",
-    component: true,
-  },
-  {
     name: "Automatic Table of Contents",
     value: "https://github.com/discourse/DiscoTOC",
     description:


### PR DESCRIPTION
Core has had support for dark theme logos for a while now.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
