### PR TITLE
FIX: Rebake theme fields if upload changes

### DIFF
--- a/app/models/theme_field.rb
+++ b/app/models/theme_field.rb
@@ -483,7 +483,7 @@ class ThemeField < ActiveRecord::Base
   end
 
   before_save do
-    if will_save_change_to_value? && !will_save_change_to_value_baked?
+    if (will_save_change_to_value? || will_save_change_to_upload_id?) && !will_save_change_to_value_baked?
       self.value_baked = nil
     end
   end

--- a/spec/models/theme_field_spec.rb
+++ b/spec/models/theme_field_spec.rb
@@ -419,4 +419,15 @@ HTML
     end
   end
 
+  context "SVG sprite theme fields" do
+    let(:upload) { Fabricate(:upload) }
+    let(:theme) { Fabricate(:theme) }
+    let(:theme_field) { ThemeField.create!(theme: theme, target_id: 0, name: SvgSprite.theme_sprite_variable_name, upload: upload, value: "", value_baked: "baked", type_id: ThemeField.types[:theme_upload_var]) }
+
+    it "is rebaked when upload changes" do
+      theme_field.update(upload: Fabricate(:upload))
+      expect(theme_field.value_baked).to eq(nil)
+    end
+  end
+
 end


### PR DESCRIPTION
Updating SVG sprites of a theme did not take effect immediately because
the cache was not cleared.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
