### PR TITLE
FEATURE: Link to text customization when editing system badges

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-badges-show.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-badges-show.js
@@ -48,6 +48,11 @@ export default Controller.extend(bufferedProperty("model"), {
     });
   },
 
+  @discourseComputed("model.slug")
+  text_customization_name(slug) {
+    return slug.replaceAll("-", "_");
+  },
+
   @discourseComputed("model.query", "buffered.query")
   hasQuery(modelQuery, bufferedQuery) {
     if (bufferedQuery) {

--- a/app/assets/javascripts/admin/addon/controllers/admin-badges-show.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-badges-show.js
@@ -48,17 +48,17 @@ export default Controller.extend(bufferedProperty("model"), {
     });
   },
 
-  @discourseComputed("model.slug")
-  text_customization_name(slug) {
-    return slug.replaceAll("-", "_");
-  },
-
   @discourseComputed("model.query", "buffered.query")
   hasQuery(modelQuery, bufferedQuery) {
     if (bufferedQuery) {
       return bufferedQuery.trim().length > 0;
     }
     return modelQuery && modelQuery.trim().length > 0;
+  },
+
+  @discourseComputed("model.i18n_name")
+  textCustomizationPrefix(i18n_name) {
+    return `badges.${i18n_name}.`;
   },
 
   @observes("model.id")

--- a/app/assets/javascripts/admin/addon/templates/badges-show.hbs
+++ b/app/assets/javascripts/admin/addon/templates/badges-show.hbs
@@ -4,6 +4,9 @@
       <label for="name">{{i18n "admin.badges.name"}}</label>
       {{#if readOnly}}
         {{input type="text" name="name" value=buffered.name disabled=true}}
+        <p class="help">
+          {{html-safe (i18n "admin.badges.read_only_setting_help" basePath=(base-path) name=text_customization_name detail="name")}}
+        </p>
       {{else}}
         {{input type="text" name="name" value=buffered.name}}
       {{/if}}
@@ -64,6 +67,9 @@
       <label for="description">{{i18n "admin.badges.description"}}</label>
       {{#if buffered.system}}
         {{textarea name="description" value=buffered.description disabled=true}}
+        <p class="help">
+          {{html-safe (i18n "admin.badges.read_only_setting_help" basePath=(base-path) name=text_customization_name detail="description")}}
+        </p>
       {{else}}
         {{textarea name="description" value=buffered.description}}
       {{/if}}
@@ -73,6 +79,9 @@
       <label for="long_description">{{i18n "admin.badges.long_description"}}</label>
       {{#if buffered.system}}
         {{textarea name="long_description" value=buffered.long_description disabled=true}}
+        <p class="help">
+          {{html-safe (i18n "admin.badges.read_only_setting_help" basePath=(base-path) name=text_customization_name detail="long_description")}}
+        </p>
       {{else}}
         {{textarea name="long_description" value=buffered.long_description}}
       {{/if}}

--- a/app/assets/javascripts/admin/addon/templates/badges-show.hbs
+++ b/app/assets/javascripts/admin/addon/templates/badges-show.hbs
@@ -5,7 +5,9 @@
       {{#if readOnly}}
         {{input type="text" name="name" value=buffered.name disabled=true}}
         <p class="help">
-          {{html-safe (i18n "admin.badges.read_only_setting_help" basePath=(base-path) name=text_customization_name detail="name")}}
+          {{#link-to "adminSiteText.edit" (concat textCustomizationPrefix "name")}}
+            {{i18n "admin.badges.read_only_setting_help"}}
+          {{/link-to}}
         </p>
       {{else}}
         {{input type="text" name="name" value=buffered.name}}
@@ -68,7 +70,9 @@
       {{#if buffered.system}}
         {{textarea name="description" value=buffered.description disabled=true}}
         <p class="help">
-          {{html-safe (i18n "admin.badges.read_only_setting_help" basePath=(base-path) name=text_customization_name detail="description")}}
+          {{#link-to "adminSiteText.edit" (concat textCustomizationPrefix "description")}}
+            {{i18n "admin.badges.read_only_setting_help"}}
+          {{/link-to}}
         </p>
       {{else}}
         {{textarea name="description" value=buffered.description}}
@@ -80,7 +84,9 @@
       {{#if buffered.system}}
         {{textarea name="long_description" value=buffered.long_description disabled=true}}
         <p class="help">
-          {{html-safe (i18n "admin.badges.read_only_setting_help" basePath=(base-path) name=text_customization_name detail="long_description")}}
+          {{#link-to "adminSiteText.edit" (concat textCustomizationPrefix "long_description")}}
+            {{i18n "admin.badges.read_only_setting_help"}}
+          {{/link-to}}
         </p>
       {{else}}
         {{textarea name="long_description" value=buffered.long_description}}

--- a/app/models/badge.rb
+++ b/app/models/badge.rb
@@ -289,14 +289,14 @@ class Badge < ActiveRecord::Base
     query.blank? && !system?
   end
 
+  def i18n_name
+    @i18n_name ||= self.class.i18n_name(name)
+  end
+
   protected
 
   def ensure_not_system
     self.id = [Badge.maximum(:id) + 1, 100].max unless id
-  end
-
-  def i18n_name
-    @i18n_name ||= self.class.i18n_name(name)
   end
 end
 

--- a/app/serializers/admin_badge_serializer.rb
+++ b/app/serializers/admin_badge_serializer.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
 class AdminBadgeSerializer < BadgeSerializer
-  attributes :query, :trigger, :target_posts, :auto_revoke, :show_posts
+  attributes :query, :trigger, :target_posts, :auto_revoke, :show_posts, :i18n_name
 
   def include_long_description?
     true
+  end
+
+  def include_i18n_name?
+    object.system?
   end
 end

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4889,7 +4889,7 @@ en:
         image: Image
         icon_help: "Enter a Font Awesome icon name (use prefix 'far-' for regular icons and 'fab-' for brand icons)"
         image_help: "Enter the URL of the image (overrides icon field if both are set)"
-        read_only_setting_help: "<a href='%{basePath}/admin/customize/site_texts/badges.%{name}.%{detail}'>Customize text</a>"
+        read_only_setting_help: "Customize text"
         query: Badge Query (SQL)
         target_posts: Query targets posts
         auto_revoke: Run revocation query daily

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4889,6 +4889,7 @@ en:
         image: Image
         icon_help: "Enter a Font Awesome icon name (use prefix 'far-' for regular icons and 'fab-' for brand icons)"
         image_help: "Enter the URL of the image (overrides icon field if both are set)"
+        read_only_setting_help: "<a href='%{basePath}/admin/customize/site_texts/badges.%{name}.%{detail}'>Customize text</a>"
         query: Badge Query (SQL)
         target_posts: Query targets posts
         auto_revoke: Run revocation query daily


### PR DESCRIPTION
Being that system badges ship with every instance of Discourse, we've opted to define the name, description, and long description in our locales files to promote translation into other languages. When an admin visits the overview page of a system badge in their admin panel, they are met with disabled inputs for these text properties. The problem is that we fail to educate the admin that the text needs to be managed via the site text customization settings. This can lead to support requests.

This change will add a "Customize text" link under the disabled inputs that will take the user to the relevant site text customization.

<img width="600" alt="Screen Shot 2020-11-24 at 5 50 52 PM" src="https://user-images.githubusercontent.com/22733864/100176585-70078080-2e85-11eb-96f8-13f64faff121.png">


In the future, it may be nice to enable the inputs, connecting them directly to the text customization, but this seemed like a quick and easy way to improve the current situation.

Noting that slugs use dashes and the text customization keys use underscores when badge names include multiple words.  The `text_customization_name` property handles this conversion.

This seems like a simple change, but if there is a specific test that would make sense for this, please let me know.