### PR TITLE
FIX: When quoting an attachment, keep the |attachment in markdown

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/to-markdown.js
+++ b/app/assets/javascripts/discourse/app/lib/to-markdown.js
@@ -273,7 +273,13 @@ export class Tag {
 
         if (attr.href && text !== attr.href) {
           text = text.replace(/\n{2,}/g, "\n");
-          return "[" + text + "](" + attr.href + ")";
+
+          let linkModifier = "";
+          if (attr.class && attr.class.includes("attachment")) {
+            linkModifier = "|attachment";
+          }
+
+          return "[" + text + linkModifier + "](" + attr.href + ")";
         }
 
         return text;

--- a/app/assets/javascripts/discourse/tests/unit/lib/to-markdown-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/to-markdown-test.js
@@ -38,6 +38,12 @@ module("Unit | Utility | to-markdown", function () {
     assert.equal(toMarkdown(html), markdown);
   });
 
+  test("converts a link which is an attachment", function (assert) {
+    let html = `<a class="attachment" href="https://discourse.org/pdfs/stuff.pdf">stuff.pdf</a>`;
+    let markdown = `[stuff.pdf|attachment](https://discourse.org/pdfs/stuff.pdf)`;
+    assert.equal(toMarkdown(html), markdown);
+  });
+
   test("put raw URL instead of converting the link", function (assert) {
     let url = "https://discourse.org";
     const html = () => `<a href="${url}">${url}</a>`;


### PR DESCRIPTION
When quoting a portion of a post that contains an attachment link, the `|attachment` portion of the link markdown is lost.

![image](https://user-images.githubusercontent.com/920448/100180712-7a2c8c00-2f24-11eb-8ea8-3d17058d3ae8.png)
![image](https://user-images.githubusercontent.com/920448/100183127-ecec3600-2f29-11eb-8d60-297e2913678c.png)

This is not ideal because an `attachment` class should be added to the link which is used by various things like `clickTrack.js` which handles `prevent_anon_from_downloading_files`.