### PR TITLE
FIX: Add secure media url to SERVER_SIDE_ONLY list

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/url.js
+++ b/app/assets/javascripts/discourse/app/lib/url.js
@@ -16,6 +16,7 @@ const TOPIC_REGEXP = /\/t\/([^\/]+)\/(\d+)\/?(\d+)?/;
 const SERVER_SIDE_ONLY = [
   /^\/assets\//,
   /^\/uploads\//,
+  /^\/secure-media-uploads\//,
   /^\/stylesheets\//,
   /^\/site_customizations\//,
   /^\/raw\//,

--- a/app/assets/javascripts/discourse/tests/unit/lib/url-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/url-test.js
@@ -96,4 +96,15 @@ module("Unit | Utility | url", function () {
       "https://www.discourse.org/mailto:foo"
     );
   });
+
+  test("routeTo redirects secure media URLS because they are server side only", async function (assert) {
+    sinon.stub(DiscourseURL, "redirectTo");
+    sinon.stub(DiscourseURL, "handleURL");
+    DiscourseURL.routeTo("/secure-media-uploads/original/1X/test.pdf");
+    assert.ok(
+      DiscourseURL.redirectTo.calledWith(
+        "/secure-media-uploads/original/1X/test.pdf"
+      )
+    );
+  });
 });


### PR DESCRIPTION
In `DiscourseURL`, we determine whether to handle a clicked link's URL on the client side or on the server side based on a `SERVER_SIDE_ONLY` regex list. Secure media URLs were not in this list, which caused issues such as https://meta.discourse.org/t/links-to-media-break-in-copy-or-quote-when-secure-media-is-on/167370 where a 404 error was shown on the client side instead of downloading the attachment.