### PR TITLE
UX: When requiring user fields at signup, also mark default fields as required

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/create-account.js
+++ b/app/assets/javascripts/discourse/app/controllers/create-account.js
@@ -101,10 +101,12 @@ export default Controller.extend(
 
     @discourseComputed
     fullnameRequired() {
-      return (
-        this.get("siteSettings.full_name_required") ||
-        this.get("siteSettings.enable_names")
-      );
+      return this.get("siteSettings.full_name_required");
+    },
+
+    @discourseComputed
+    fullnameOptional() {
+      return this.get("siteSettings.enable_names");
     },
 
     @discourseComputed("authOptions.auth_provider")

--- a/app/assets/javascripts/discourse/app/controllers/create-account.js
+++ b/app/assets/javascripts/discourse/app/controllers/create-account.js
@@ -99,16 +99,6 @@ export default Controller.extend(
       return authOptions && !canEditName;
     },
 
-    @discourseComputed
-    fullnameRequired() {
-      return this.get("siteSettings.full_name_required");
-    },
-
-    @discourseComputed
-    fullnameOptional() {
-      return this.get("siteSettings.enable_names");
-    },
-
     @discourseComputed("authOptions.auth_provider")
     passwordRequired(authProvider) {
       return isEmpty(authProvider);

--- a/app/assets/javascripts/discourse/app/templates/modal/create-account.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/create-account.hbs
@@ -17,7 +17,14 @@
             <table>
               <tbody>
                 <tr class="input create-account-email">
-                  <td class="label"><label for="new-account-email">{{i18n "user.email.title"}}</label></td>
+                  <td class="label">
+                    <label for="new-account-email">
+                      {{i18n "user.email.title"}}
+                      {{~#if userFields~}}
+                        <span class="required">*</span>
+                      {{/if}}
+                    </label>
+                  </td>
                   <td>
                     {{#if emailValidated}}
                       <span class="value">{{accountEmail}}</span>
@@ -34,7 +41,14 @@
                 </tr>
 
                 <tr class="input">
-                  <td class="label"><label for="new-account-username">{{i18n "user.username.title"}}</label></td>
+                  <td class="label">
+                    <label for="new-account-username">
+                      {{i18n "user.username.title"}}
+                      {{~#if userFields~}}
+                        <span class="required">*</span>
+                      {{/if}}
+                    </label>
+                  </td>
                   <td>
                     {{#if usernameDisabled}}
                       <span class="value">{{accountUsername}}</span>
@@ -49,10 +63,17 @@
                   <td><label>{{i18n "user.username.instructions"}}</label></td>
                 </tr>
 
-                {{#if fullnameRequired}}
+                {{#if fullnameOptional}}
                   <tr class="input">
                     <td class="label">
-                      <label for="new-account-name">{{i18n "user.name.title"}}</label>
+                      <label for="new-account-name">
+                        {{i18n "user.name.title"}}
+                        {{#if fullnameRequired}}
+                          {{~#if userFields~}}
+                            <span class="required">*</span>
+                          {{/if}}
+                        {{/if}}
+                      </label>
                     </td>
                     <td>
                       {{#if nameDisabled}}
@@ -83,7 +104,14 @@
 
                 {{#if passwordRequired}}
                   <tr class="input">
-                    <td class="label"><label for="new-account-password">{{i18n "user.password.title"}}</label></td>
+                    <td class="label">
+                      <label for="new-account-password">
+                        {{i18n "user.password.title"}}
+                        {{~#if userFields~}}
+                          <span class="required">*</span>
+                        {{/if}}
+                      </label>
+                    </td>
                     <td>
                       {{password-field value=accountPassword type="password" id="new-account-password" capsLockOn=capsLockOn}}
                     </td>

--- a/app/assets/javascripts/discourse/app/templates/modal/create-account.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/create-account.hbs
@@ -63,12 +63,12 @@
                   <td><label>{{i18n "user.username.instructions"}}</label></td>
                 </tr>
 
-                {{#if fullnameOptional}}
+                {{#if siteSettings.enable_names}}
                   <tr class="input">
                     <td class="label">
                       <label for="new-account-name">
                         {{i18n "user.name.title"}}
-                        {{#if fullnameRequired}}
+                        {{#if siteSettings.full_name_required}}
                           {{~#if userFields~}}
                             <span class="required">*</span>
                           {{/if}}

--- a/app/assets/stylesheets/common/base/user.scss
+++ b/app/assets/stylesheets/common/base/user.scss
@@ -339,6 +339,7 @@
   }
 }
 
+.login-form,
 .user-field {
   .required {
     vertical-align: top;


### PR DESCRIPTION
When custom user fields are required at signup we show an asterisk to label them as required... but we don't do this for our default inputs. For the sake of consistency, this change adds an asterisk to our default sign-up fields only if custom user fields are present. 

This is a compromise between being simple by default, and consistent with added customization. 

![Screen Shot 2020-11-25 at 8 44 52 PM](https://user-images.githubusercontent.com/1681963/100298841-263f9880-2f60-11eb-88fc-f2b91ac80fa5.png)

![Screen Shot 2020-11-25 at 8 45 19 PM](https://user-images.githubusercontent.com/1681963/100298870-35264b00-2f60-11eb-90a7-a1fba6113d7d.png)





Relevant discussion here: https://meta.discourse.org/t/required-should-be-next-to-all-required-fields-in-sign-up-form/126235 and more recently here: https://meta.discourse.org/t/required-fields-not-shown-as-required-during-sign-up/170052

