### PR TITLE
FIX: bump nokogumbo to 2.0.3 with patch

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -204,7 +204,7 @@ GEM
     nio4r (2.5.4)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
-    nokogumbo (2.0.2)
+    nokogumbo (2.0.3)
       nokogiri (~> 1.8, >= 1.8.4)
     oauth (0.5.4)
     oauth2 (1.4.4)

--- a/lib/freedom_patches/nokogumbo.rb
+++ b/lib/freedom_patches/nokogumbo.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# TODO: Remove once fix is merged and nokogumbo version is bumped
+# https://github.com/rubys/nokogumbo/pull/158
+
+module Nokogiri
+  module HTML5
+    private
+
+    def self.read_and_encode(string, encoding)
+      # Read the string with the given encoding.
+      if string.respond_to?(:read)
+        if encoding.nil?
+          string = string.read
+        else
+          string = string.read(encoding: encoding)
+        end
+      else
+        # Otherwise the string has the given encoding.
+        string = string.to_s
+        if encoding
+          string = string.dup
+          string.force_encoding(encoding)
+        end
+      end
+
+      # convert to UTF-8
+      if string.encoding != Encoding::UTF_8
+        string = reencode(string)
+      end
+      string
+    end
+  end
+end


### PR DESCRIPTION
PR lodged to nokogumbo so later we should be able to drop freedom patch - https://github.com/rubys/nokogumbo/pull/158
