### PR TITLE
FIX: No tags should be set if tag chooser is hidden

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/tag-show.js
+++ b/app/assets/javascripts/discourse/app/routes/tag-show.js
@@ -185,7 +185,8 @@ export default DiscourseRoute.extend(FilterModeMixin, {
       if (controller.get("list.draft")) {
         this.openTopicDraft(controller.get("list"));
       } else {
-        this.controllerFor("composer")
+        const composerController = this.controllerFor("composer");
+        composerController
           .open({
             categoryId: controller.get("category.id"),
             action: Composer.CREATE_TOPIC,
@@ -194,7 +195,7 @@ export default DiscourseRoute.extend(FilterModeMixin, {
           })
           .then(() => {
             // Pre-fill the tags input field
-            if (controller.get("model.id")) {
+            if (composerController.canEditTags && controller.get("model.id")) {
               const composerModel = this.controllerFor("composer").get("model");
               composerModel.set(
                 "tags",

--- a/app/assets/javascripts/discourse/tests/acceptance/tags-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/tags-test.js
@@ -308,4 +308,11 @@ acceptance("Tag info", function (needs) {
       "removed a synonym"
     );
   });
+
+  test("composer will not set tags if user cannot create them", async function (assert) {
+    await visit("/tag/planters");
+    await click("#create-topic");
+    const composer = this.container.lookup("controller:composer");
+    assert.equal(composer.model.tags, null);
+  });
 });


### PR DESCRIPTION
If a user could not set tags because they had a trust level lower than
min_trust_level_to_tag_topics site setting, the "Create Topic" button
from a tags page would still show up and be enabled. Clicking it caused
the composer model to silently have the tags set.