### PR TITLE
DEV: Make it easier to customize link attributes in quick access menu

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/quick-access-item.js
+++ b/app/assets/javascripts/discourse/app/widgets/quick-access-item.js
@@ -44,7 +44,7 @@ createWidget("quick-access-item", {
       }
     }
 
-    return h("a", { attributes: { href } }, [
+    return h("a", { attributes: this._linkAttributes(href) }, [
       iconNode(icon),
       new RawHtml({
         html: `<div>${this._usernameHtml()}${content}</div>`,
@@ -58,6 +58,10 @@ createWidget("quick-access-item", {
       e.preventDefault();
       return this.sendWidgetAction(this.attrs.action, this.attrs.actionParam);
     }
+  },
+
+  _linkAttributes(href) {
+    return { href };
   },
 
   _contentHtml() {


### PR DESCRIPTION
This allows themes to customize link attributes:

```javascript
api.reopenWidget("quick-access-item", {
  _linkAttributes(href) {
    const attributes = this._super(...arguments);
    // do stuff
    return attributes;
  }
}
```
