### PR TITLE
FIX: don't error-index category job when missing category

### DIFF
--- a/app/jobs/regular/index_category_for_search.rb
+++ b/app/jobs/regular/index_category_for_search.rb
@@ -3,7 +3,7 @@
 class Jobs::IndexCategoryForSearch < Jobs::Base
   def execute(args)
     category = Category.find_by(id: args[:category_id])
-    raise Discourse::InvalidParameters.new(:category_id) if category.blank?
+    return if category.blank?
 
     SearchIndexer.index(category, force: args[:force] || false)
   end


### PR DESCRIPTION
When the category is missing we should not throw an error but just finish the job.