### PR TITLE
DEV: Use tag renderer in tags filter dropdown

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/tag-drop.js
+++ b/app/assets/javascripts/select-kit/addon/components/tag-drop.js
@@ -96,6 +96,10 @@ export default ComboBoxComponent.extend(TagsMixin, {
 
   noTagsLabel: i18n("tagging.selector_no_tags"),
 
+  modifyComponentForRow() {
+    return "tag-row";
+  },
+
   shortcuts: computed("tagId", function () {
     const shortcuts = [];
 

--- a/app/assets/stylesheets/common/select-kit/mini-tag-chooser.scss
+++ b/app/assets/stylesheets/common/select-kit/mini-tag-chooser.scss
@@ -47,12 +47,6 @@
           background: var(--tertiary-low);
         }
 
-        .discourse-tag {
-          &:hover {
-            color: var(--primary);
-          }
-        }
-
         .discourse-tag-count {
           margin-left: 0.5em;
         }

--- a/app/assets/stylesheets/common/select-kit/select-kit.scss
+++ b/app/assets/stylesheets/common/select-kit/select-kit.scss
@@ -170,8 +170,10 @@
     }
 
     .discourse-tag,
+    .discourse-tag:visited,
+    .discourse-tag:hover,
     .discourse-tag-count {
-      color: var(--primary);
+      color: var(--primary-high);
     }
 
     &.create-color-row {


### PR DESCRIPTION
A small change that would allow components to extend the tag
display in the filter dropdown, like they can in other contexts.

Was requested in the tag icons component, see
https://meta.discourse.org/t/tag-icons-component/109757/60?u=pmusaraj

The PR also changes slightly the tag color in the dropdown, now
matching the color of category rows.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
