### PR TITLE
FIX: Ignore preferences were disabled for users below TL2

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/preferences/users.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/users.js
@@ -1,5 +1,5 @@
 import { makeArray } from "discourse-common/lib/helpers";
-import { alias, gte, or, and } from "@ember/object/computed";
+import { alias, and } from "@ember/object/computed";
 import { action, computed } from "@ember/object";
 import Controller from "@ember/controller";
 import { popupAjaxError } from "discourse/lib/ajax-error";
@@ -7,8 +7,6 @@ import discourseComputed from "discourse-common/utils/decorators";
 
 export default Controller.extend({
   ignoredUsernames: alias("model.ignored_usernames"),
-  userIsMemberOrAbove: gte("model.trust_level", 2),
-  ignoredEnabled: or("userIsMemberOrAbove", "model.staff"),
   allowPmUsersEnabled: and(
     "model.user_option.enable_allowed_pm_users",
     "model.user_option.allow_private_messages"
@@ -61,6 +59,13 @@ export default Controller.extend({
   @discourseComputed("model.user_option.allow_private_messages")
   disableAllowPmUsersSetting(allowPrivateMessages) {
     return !allowPrivateMessages;
+  },
+
+  @discourseComputed("model.staff", "model.trust_level")
+  ignoredEnabled(staff, trustLevel) {
+    return (
+      staff || trustLevel >= this.siteSettings.min_trust_level_to_allow_ignore
+    );
   },
 
   @action

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1421,6 +1421,7 @@ trust:
     enum: "TrustLevelSetting"
   min_trust_level_to_allow_ignore:
     default: 2
+    client: true
     enum: "TrustLevelSetting"
   allow_flagging_staff: true
   send_tl1_welcome_message: true


### PR DESCRIPTION
This is a follow up to https://github.com/discourse/discourse/pull/11297 where we added a site setting to allow admins to control which trust level is allowed to ignore.

Ignoring was working directly from a user's profile, but I missed that the ignore management section of the user preferences rendered based on a hard-coded trust level value (per https://github.com/discourse/discourse/commit/dc60128355170691ceb8065584a3335f8507a620)