### PR TITLE
Update header_primary in shades of blue

### DIFF
--- a/app/models/color_scheme.rb
+++ b/app/models/color_scheme.rb
@@ -50,7 +50,7 @@ class ColorScheme < ActiveRecord::Base
       "tertiary" =>          '416376',
       "quaternary" =>        '5e99b9',
       "header_background" => '86bddb',
-      "header_primary" =>    'ffffff',
+      "header_primary" =>    '203243',
       "highlight" =>         '86bddb',
       "danger" =>            'bf3c3c',
       "success" =>           '70db82',


### PR DESCRIPTION
This PR changes header_primary to a shade of blue, fixing contrast issues with some text colors in the header.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
