### PR TITLE
FIX: URL encode tag name

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -152,7 +152,7 @@ class Tag < ActiveRecord::Base
   end
 
   def full_url
-    "#{Discourse.base_url}/tag/#{self.name}"
+    "#{Discourse.base_url}/tag/#{UrlHelper.encode_component(self.name)}"
   end
 
   def index_search

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -202,6 +202,14 @@ describe Tag do
     end
   end
 
+  context "full_url" do
+    let(:tag) { Fabricate(:tag, name: "🚀") }
+
+    it "percent encodes emojis" do
+      expect(tag.full_url).to eq("http://test.localhost/tag/%F0%9F%9A%80")
+    end
+  end
+
   context "synonyms" do
     let(:synonym) { Fabricate(:tag, target_tag: tag) }
 


### PR DESCRIPTION
Tags with emoji in the name were failing to redirect via permalink handling. This commit percent encodes the emoji name which fixes the issue.

https://meta.discourse.org/t/permalinks-not-working-in-unicode-tags/171757/
