### PR TITLE
FIX: on invite redemption only update pending ReviewableUser record

### DIFF
--- a/app/models/invite_redeemer.rb
+++ b/app/models/invite_redeemer.rb
@@ -145,7 +145,7 @@ InviteRedeemer = Struct.new(:invite, :email, :username, :name, :password, :user_
   end
 
   def approve_account_if_needed
-    if invited_user.present? && reviewable_user = ReviewableUser.find_by(target: invited_user)
+    if invited_user.present? && reviewable_user = ReviewableUser.find_by(target: invited_user, status: Reviewable.statuses[:pending])
       reviewable_user.perform(
         invite.invited_by,
         :approve_user,

--- a/spec/models/invite_redeemer_spec.rb
+++ b/spec/models/invite_redeemer_spec.rb
@@ -189,6 +189,28 @@ describe InviteRedeemer do
       expect(invite.invited_users.first).to be_present
     end
 
+    context "ReviewableUser" do
+      it "approves pending record" do
+        reviewable = ReviewableUser.needs_review!(target: Fabricate(:user, email: invite.email), created_by: invite.invited_by)
+        reviewable.status = Reviewable.statuses[:pending]
+        reviewable.save!
+        invite_redeemer.redeem
+
+        reviewable.reload
+        expect(reviewable.status).to eq(Reviewable.statuses[:approved])
+      end
+
+      it "does not raise error if record is not pending" do
+        reviewable = ReviewableUser.needs_review!(target: Fabricate(:user, email: invite.email), created_by: invite.invited_by)
+        reviewable.status = Reviewable.statuses[:ignored]
+        reviewable.save!
+        invite_redeemer.redeem
+
+        reviewable.reload
+        expect(reviewable.status).to eq(Reviewable.statuses[:ignored])
+      end
+    end
+
     context 'invite_link' do
       fab!(:invite_link) { Fabricate(:invite, max_redemptions_allowed: 5, expires_at: 1.month.from_now, emailed_status: Invite.emailed_status_types[:not_required]) }
       let(:invite_redeemer) { InviteRedeemer.new(invite: invite_link, email: 'foo@example.com') }


### PR DESCRIPTION
When the invite was being redeemed and the ReviewableUser record status for the invited user was not pending an error was being raised.

This commit makes sure that we are only looking for ReviewableUser record with status pending and updates that to approved.