### PR TITLE
FIX: Group#flair_url must be a real URL

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -750,7 +750,7 @@ class Group < ActiveRecord::Base
   end
 
   def flair_url
-    flair_icon.presence || flair_upload&.short_path
+    flair_icon.presence || flair_upload&.url
   end
 
   [:muted, :regular, :tracking, :watching, :watching_first_post].each do |level|

--- a/spec/jobs/migrate_group_flair_images_spec.rb
+++ b/spec/jobs/migrate_group_flair_images_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Jobs::MigrateGroupFlairImages do
     group.reload
     upload = Upload.last
     expect(group.flair_upload).to eq(upload)
-    expect(group.flair_url).to eq(upload.short_path)
+    expect(group.flair_url).to eq(upload.url)
     expect(group[:flair_url]).to eq(nil)
   end
 


### PR DESCRIPTION
It used to be a short URL, but that did not work with the lightbox
in {{image-uploader}}.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
