### PR TITLE
FIX: Use CDN for custom emojis

### DIFF
--- a/app/serializers/emoji_serializer.rb
+++ b/app/serializers/emoji_serializer.rb
@@ -2,4 +2,8 @@
 
 class EmojiSerializer < ApplicationSerializer
   attributes :name, :url, :group
+
+  def url
+    Discourse.store.cdn_url(object.url)
+  end
 end

--- a/spec/serializers/emoji_serializer_spec.rb
+++ b/spec/serializers/emoji_serializer_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe EmojiSerializer do
+  fab!(:emoji) do
+    CustomEmoji.create!(name: 'trout', upload: Fabricate(:upload))
+    Emoji.load_custom.first
+  end
+
+  subject { described_class.new(emoji, root: false) }
+
+  describe '#url' do
+    it 'returns a valid URL' do
+      expect(subject.url).to start_with('/uploads/')
+    end
+
+    it 'works with a CDN' do
+      set_cdn_url('https://cdn.com')
+      expect(subject.url).to start_with('https://cdn.com')
+    end
+  end
+end


### PR DESCRIPTION
The composer preview did not use CDN url for custom emojis.