### PR TITLE
FIX: Stop using duplicate composer button ID

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-editor.js
+++ b/app/assets/javascripts/discourse/app/components/d-editor.js
@@ -104,7 +104,7 @@ class Toolbar {
     }
 
     this.addButton({
-      id: "quote",
+      id: "blockquote",
       group: "insertions",
       icon: "quote-right",
       shortcut: "Shift+9",

--- a/app/assets/javascripts/discourse/tests/integration/components/d-editor-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/d-editor-test.js
@@ -459,13 +459,13 @@ third line`
 
       textarea.selectionStart = 0;
 
-      await click("button.quote");
+      await click("button.blockquote");
 
       assert.equal(this.value, "> one\n> \n> two\n> \n> three");
       assert.equal(textarea.selectionStart, 0);
       assert.equal(textarea.selectionEnd, 25);
 
-      await click("button.quote");
+      await click("button.blockquote");
       assert.equal(this.value, "one\n\ntwo\n\nthree");
     },
   });
@@ -481,7 +481,7 @@ third line`
       textarea.selectionStart = 6;
       textarea.selectionEnd = 10;
 
-      await click("button.quote");
+      await click("button.blockquote");
       assert.equal(this.value, "one\n\n\n> \n> two");
     },
   });
@@ -490,12 +490,12 @@ third line`
     textarea.selectionStart = 6;
     textarea.selectionEnd = 9;
 
-    await click("button.quote");
+    await click("button.blockquote");
     assert.equal(this.value, "hello\n\n> wor\n\nld.");
     assert.equal(textarea.selectionStart, 7);
     assert.equal(textarea.selectionEnd, 12);
 
-    await click("button.quote");
+    await click("button.blockquote");
 
     assert.equal(this.value, "hello\n\nwor\n\nld.");
     assert.equal(textarea.selectionStart, 7);
@@ -504,7 +504,7 @@ third line`
     textarea.selectionStart = 15;
     textarea.selectionEnd = 15;
 
-    await click("button.quote");
+    await click("button.blockquote");
     assert.equal(this.value, "hello\n\nwor\n\nld.\n\n> Blockquote");
   });
 


### PR DESCRIPTION
"quote" is used by the button added in `composer-editor`.
https://github.com/discourse/discourse/blob/bbe5d8d5cf1220165842985c0e2cd4c454d501cd/app/assets/javascripts/discourse/app/components/composer-editor.js#L875-L882

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
