### PR TITLE
FIX: Include locale in cache key for not_found_topics

### DIFF
--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -373,7 +373,7 @@ RSpec.describe ApplicationController do
 
         it 'should handle 404 to a css file' do
 
-          Discourse.redis.del("page_not_found_topics")
+          Discourse.cache.delete("page_not_found_topics:#{I18n.locale}")
 
           topic1 = Fabricate(:topic)
           get '/stylesheets/mobile_1_4cd559272273fe6d3c7db620c617d596a5fdf240.css', headers: { 'HTTP_ACCEPT' => 'text/css,*/*,q=0.1' }
@@ -394,7 +394,8 @@ RSpec.describe ApplicationController do
       end
 
       it 'should cache results' do
-        Discourse.redis.del("page_not_found_topics")
+        Discourse.cache.delete("page_not_found_topics:#{I18n.locale}")
+        Discourse.cache.delete("page_not_found_topics:fr")
 
         topic1 = Fabricate(:topic)
         get '/t/nope-nope/99999999'
@@ -406,6 +407,13 @@ RSpec.describe ApplicationController do
         expect(response.status).to eq(404)
         expect(response.body).to include(topic1.title)
         expect(response.body).to_not include(topic2.title)
+
+        # Different locale should have different cache
+        SiteSetting.default_locale = :fr
+        get '/t/nope-nope/99999999'
+        expect(response.status).to eq(404)
+        expect(response.body).to include(topic1.title)
+        expect(response.body).to include(topic2.title)
       end
     end
   end


### PR DESCRIPTION
This ensures that users are only served cached content in their own language. This commit also refactors to make use of the `Discourse.cache` framework rather than direct redis access

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
