### PR TITLE
FIX: Trigger an event when a post is bookmarked.

### DIFF
--- a/app/assets/javascripts/discourse/app/models/post.js
+++ b/app/assets/javascripts/discourse/app/models/post.js
@@ -343,6 +343,7 @@ const Post = RestModel.extend({
             bookmark_id: savedData.id,
           });
           resolve({ closedWithoutSaving: false });
+          this.appEvents.trigger("page:bookmark-post-toggled", this);
           this.appEvents.trigger("post-stream:refresh", { id: this.id });
         },
         afterDelete: (topicBookmarked) => {


### PR DESCRIPTION
When we renamed `BookmarkWithReminder` to `Bookmark` in ca539fd, the bookmark event trigger was removed with the old code.
