### PR TITLE
FIX: Local dates showed incorrect timezones with extra whitespace

### DIFF
--- a/plugins/discourse-local-dates/assets/javascripts/lib/discourse-markdown/discourse-local-dates.js.es6
+++ b/plugins/discourse-local-dates/assets/javascripts/lib/discourse-markdown/discourse-local-dates.js.es6
@@ -25,7 +25,7 @@ function addLocalDate(buffer, matches, state) {
   config.format = parsed.attrs.format;
   config.calendar = parsed.attrs.calendar;
   config.time = parsed.attrs.time;
-  config.timezone = parsed.attrs.timezone;
+  config.timezone = (parsed.attrs.timezone || "").trim();
   config.recurring = parsed.attrs.recurring;
   config.timezones = parsed.attrs.timezones;
   config.displayedTimezone = parsed.attrs.displayedTimezone;

--- a/plugins/discourse-local-dates/test/javascripts/acceptance/local-dates-composer-test.js.es6
+++ b/plugins/discourse-local-dates/test/javascripts/acceptance/local-dates-composer-test.js.es6
@@ -16,7 +16,7 @@ acceptance("Local Dates - composer", function (needs) {
 
     await fillIn(
       ".d-editor-input",
-      '[date=2017-10-23 time=01:30:00 displayedTimezone="America/Chicago" format="LLLL" calendar="off" recurring="1.weeks" timezone="Asia/Calcutta" timezones="Europe/Paris|America/Los_Angeles"]'
+      '[date=2017-10-23 time=01:30:00 displayedTimezone="America/Chicago" format="LLLL" calendar="off" recurring="1.weeks" timezone=" Asia/Calcutta" timezones="Europe/Paris|America/Los_Angeles"]'
     );
 
     assert.equal(getAttr("date"), "2017-10-23", "it has the correct date");


### PR DESCRIPTION
You might wonder why this matters. It turns out in some locales like
French, we replace quotation marks with « and » -- this should likely
not happen before BBCode is parsed but that is not the case for this
plugin. The plugin has code to handle this situation, but it means extra
spaces are inserted around the time zone which breaks it.

This fix allows us to supply extra whitespace and will show the correct
time zone.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
