### PR TITLE
UX: Adds back button to theme editor

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-customize-themes-edit.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-customize-themes-edit.js
@@ -64,5 +64,9 @@ export default Controller.extend({
         }
       }
     },
+
+    goBack() {
+      this.replaceRoute(this.showRouteName, this.model.id);
+    },
   },
 });

--- a/app/assets/javascripts/admin/addon/templates/customize-themes-edit.hbs
+++ b/app/assets/javascripts/admin/addon/templates/customize-themes-edit.hbs
@@ -1,6 +1,11 @@
 <div class="current-style {{if maximized "maximized"}}">
   <div class="wrapper">
-    <h2>{{i18n "admin.customize.theme.edit_css_html"}} {{#link-to showRouteName model.id replace=true}}{{model.name}}{{/link-to}}</h2>
+    <h2>
+      {{i18n "admin.customize.theme.edit_css_html"}}
+      {{#link-to showRouteName model.id replace=true}}
+        {{model.name}}
+      {{/link-to}}
+    </h2>
 
     {{admin-theme-editor
       theme=model
@@ -15,14 +20,24 @@
     <div class="admin-footer">
       <div class="status-actions">
         {{#unless model.changed}}
-          <a href={{previewUrl}} rel="noopener noreferrer" title={{i18n "admin.customize.explain_preview"}} class="preview-link" target="_blank">
+          <a
+            href={{previewUrl}}
+            rel="noopener noreferrer"
+            title={{i18n "admin.customize.explain_preview"}}
+            class="preview-link"
+            target="_blank"
+          >
             {{i18n "admin.customize.preview"}}
           </a>
         {{/unless}}
       </div>
 
       <div class="buttons">
-        {{#d-button action=(action "save") disabled=saveDisabled class="btn-primary"}}
+        {{#d-button
+          action=(action "save")
+          disabled=saveDisabled
+          class="btn-primary"
+        }}
           {{saveButtonText}}
         {{/d-button}}
       </div>

--- a/app/assets/javascripts/admin/addon/templates/customize-themes-edit.hbs
+++ b/app/assets/javascripts/admin/addon/templates/customize-themes-edit.hbs
@@ -1,11 +1,21 @@
 <div class="current-style {{if maximized "maximized"}}">
   <div class="wrapper">
-    <h2>
-      {{i18n "admin.customize.theme.edit_css_html"}}
-      {{#link-to showRouteName model.id replace=true}}
-        {{model.name}}
-      {{/link-to}}
-    </h2>
+    <div class="editor-information">
+      {{d-button
+        title="go_back"
+        action=(action "goBack")
+        icon="chevron-left"
+        class="btn-small editor-back-button"
+      }}
+
+      <span class="editor-theme-name-wrapper">
+        {{i18n "admin.customize.theme.edit_css_html"}}
+        {{#link-to showRouteName model.id replace=true class="editor-theme-name"
+        }}
+          {{model.name}}
+        {{/link-to}}
+      </span>
+    </div>
 
     {{admin-theme-editor
       theme=model

--- a/app/assets/stylesheets/common/admin/customize.scss
+++ b/app/assets/stylesheets/common/admin/customize.scss
@@ -348,6 +348,25 @@
     }
   }
 
+  .editor-information {
+    display: flex;
+    align-items: center;
+    font-size: $font-up-1;
+    margin-bottom: 0.5em;
+
+    .editor-back-button {
+      margin-right: 0.25em;
+    }
+
+    .editor-theme-name-wrapper {
+      margin-left: 0.25em;
+    }
+
+    .editor-theme-name {
+      font-weight: bold;
+    }
+  }
+
   .current-style.maximized {
     position: fixed;
     top: 0;


### PR DESCRIPTION
This commit adds a "go back" button to the theme editor. It was previously possible to return to the theme page by clicking on the linked name but adding a button should make it a bit easier to discover. 

The linked name is unchanged; the button is an addition. The PR also makes some minor style tweaks to the text (tones down the font-weight and reduces the font-size). There's also some handlebars formatting, but it's in a separate commit.

before 

<img width="200" src="https://user-images.githubusercontent.com/33972521/101300961-4fbac700-3872-11eb-9d18-af17e6764227.png">

after

<img width="200" src="https://user-images.githubusercontent.com/33972521/101300941-39147000-3872-11eb-83f0-62d1ae7cf4fd.png">