### PR TITLE
FIX: Adjust reviewable menu placement on mobile

### DIFF
--- a/app/assets/javascripts/discourse/app/components/reviewable-bundled-action.js
+++ b/app/assets/javascripts/discourse/app/components/reviewable-bundled-action.js
@@ -1,10 +1,20 @@
 import { alias, gt } from "@ember/object/computed";
 import Component from "@ember/component";
+import discourseComputed from "discourse-common/utils/decorators";
+import { isRTL } from "discourse/lib/text-direction";
+
 export default Component.extend({
   tagName: "",
 
   multiple: gt("bundle.actions.length", 1),
   first: alias("bundle.actions.firstObject"),
+
+  @discourseComputed()
+  placement() {
+    const vertical = this.site.mobileView ? "top" : "bottom",
+      horizontal = isRTL() ? "end" : "start";
+    return `${vertical}-${horizontal}`;
+  },
 
   actions: {
     performById(id) {

--- a/app/assets/javascripts/discourse/app/templates/components/reviewable-bundled-action.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/reviewable-bundled-action.hbs
@@ -8,6 +8,7 @@
     options=(hash
       icon=bundle.icon
       disabled=reviewableUpdating
+      placement=placement
     )
   }}
 {{else}}


### PR DESCRIPTION
Shows the actions dropdown above the triggering button to avoid some
options from displaying below mobile navigation in DiscourseHub.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
