### PR TITLE
UX: Blend header colors

### DIFF
--- a/app/assets/stylesheets/common/foundation/color_transformations.scss
+++ b/app/assets/stylesheets/common/foundation/color_transformations.scss
@@ -11,37 +11,44 @@ $primary-high: dark-light-diff($primary, $secondary, 30%, -25%) !default;
 $primary-very-high: dark-light-diff($primary, $secondary, 15%, -10%) !default;
 
 //header_primary
-$header_primary-low: dark-light-diff(
-  $header_primary,
-  $header_background,
-  90%,
-  -78%
-) !default;
-$header_primary-low-mid: dark-light-diff(
-  $header_primary,
-  $header_background,
-  70%,
-  -45%
-) !default;
+// $header_primary-low: dark-light-diff(
+//   $header_primary,
+//   $header_background,
+//   90%,
+//   -78%
+// ) !default;
 
-$header_primary-medium: dark-light-diff(
-  $header_primary,
-  $header_background,
-  50%,
-  -35%
-) !default;
-$header_primary-high: dark-light-diff(
-  $header_primary,
-  $header_background,
-  30%,
-  -25%
-) !default;
-$header_primary-very-high: dark-light-diff(
-  $header_primary,
-  $header_background,
-  15%,
-  -10%
-) !default;
+// $header_primary-low-mid: dark-light-diff(
+//   $header_primary,
+//   $header_background,
+//   70%,
+//   -45%
+// ) !default;
+
+// $header_primary-medium: dark-light-diff(
+//   $header_primary,
+//   $header_background,
+//   50%,
+//   -35%
+// ) !default;
+// $header_primary-high: dark-light-diff(
+//   $header_primary,
+//   $header_background,
+//   30%,
+//   -25%
+// ) !default;
+// $header_primary-very-high: dark-light-diff(
+//   $header_primary,
+//   $header_background,
+//   15%,
+//   -10%
+// ) !default;
+
+$header_primary-low: blend-header-primary-background(10%) !default;
+$header_primary-low-mid: blend-header-primary-background(35%) !default;
+$header_primary-medium: blend-header-primary-background(55%) !default;
+$header_primary-high: blend-header-primary-background(70%) !default;
+$header_primary-very-high: blend-header-primary-background(90%) !default;
 
 //secondary
 $secondary-low: dark-light-diff($secondary, $primary, 70%, -70%) !default;

--- a/app/assets/stylesheets/common/foundation/color_transformations.scss
+++ b/app/assets/stylesheets/common/foundation/color_transformations.scss
@@ -10,40 +10,6 @@ $primary-medium: dark-light-diff($primary, $secondary, 50%, -35%) !default;
 $primary-high: dark-light-diff($primary, $secondary, 30%, -25%) !default;
 $primary-very-high: dark-light-diff($primary, $secondary, 15%, -10%) !default;
 
-//header_primary
-// $header_primary-low: dark-light-diff(
-//   $header_primary,
-//   $header_background,
-//   90%,
-//   -78%
-// ) !default;
-
-// $header_primary-low-mid: dark-light-diff(
-//   $header_primary,
-//   $header_background,
-//   70%,
-//   -45%
-// ) !default;
-
-// $header_primary-medium: dark-light-diff(
-//   $header_primary,
-//   $header_background,
-//   50%,
-//   -35%
-// ) !default;
-// $header_primary-high: dark-light-diff(
-//   $header_primary,
-//   $header_background,
-//   30%,
-//   -25%
-// ) !default;
-// $header_primary-very-high: dark-light-diff(
-//   $header_primary,
-//   $header_background,
-//   15%,
-//   -10%
-// ) !default;
-
 $header_primary-low: blend-header-primary-background(10%) !default;
 $header_primary-low-mid: blend-header-primary-background(35%) !default;
 $header_primary-medium: blend-header-primary-background(55%) !default;

--- a/app/assets/stylesheets/common/foundation/variables.scss
+++ b/app/assets/stylesheets/common/foundation/variables.scss
@@ -192,6 +192,10 @@ $box-shadow: (
   @return srgb-scale($primary, $secondary, $percent);
 }
 
+@function blend-header-primary-background($percent) {
+  @return srgb-scale($header_primary, $header_background, $percent);
+}
+
 @function dark-light-diff(
   $adjusted-color,
   $comparison-color,


### PR DESCRIPTION
This is a breaking change for the derivative header colors. It uses blending between the header's primary and background colors to calculate the low, low-mid, medium, high and very high variants used for text and icons in the header. (Previously, the colors were changing the lightnes of the `header_primary` color). 

This works better in general, however, _some_ sites might experience undesired behaviour (especially if they have added their own styles to override core's CSS). 

Some before/after screenshots: 

Light
![light-before-after](https://user-images.githubusercontent.com/368961/102263364-3523c600-3ee2-11eb-9ecd-511195df2342.png)

Dark
<img width="1913" alt="dark-before-after" src="https://user-images.githubusercontent.com/368961/102263376-39e87a00-3ee2-11eb-9668-fb0495f4adcd.png">

Shades of Blue
![shades-blue-before-after](https://user-images.githubusercontent.com/368961/102263413-453ba580-3ee2-11eb-8032-bfac624f9b50.png)

Dark Rose
![dark-rose-before-after](https://user-images.githubusercontent.com/368961/102263451-5389c180-3ee2-11eb-8d78-06201e38478c.png)

Latte
![latte-before-after](https://user-images.githubusercontent.com/368961/102263471-5a183900-3ee2-11eb-9c4e-134cab96e785.png)
