### PR TITLE
FIX: Stop category 404s from breaking the router

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/build-category-route.js
+++ b/app/assets/javascripts/discourse/app/routes/build-category-route.js
@@ -66,12 +66,17 @@ export default (filterArg, params) => {
           parts.pop();
         }
 
-        return Category.reloadBySlugPath(parts.join("/")).then((result) => {
-          const record = this.store.createRecord("category", result.category);
-          record.setupGroupsAndPermissions();
-          this.site.updateCategory(record);
-          return { category: record, modelParams };
-        });
+        return Category.reloadBySlugPath(parts.join("/"))
+          .then((result) => {
+            const record = this.store.createRecord("category", result.category);
+            record.setupGroupsAndPermissions();
+            this.site.updateCategory(record);
+            return { category: record, modelParams };
+          })
+          .catch(() => {
+            // afterModel will call replaceWith(/404)
+            return null;
+          });
       }
 
       if (category) {

--- a/app/assets/javascripts/discourse/tests/acceptance/unknown-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/unknown-test.js
@@ -1,6 +1,28 @@
 import { acceptance, exists } from "discourse/tests/helpers/qunit-helpers";
-import { currentURL, visit } from "@ember/test-helpers";
+import { click, currentURL, visit } from "@ember/test-helpers";
 import { test } from "qunit";
+
+acceptance("Category 404", function (needs) {
+  needs.pretender((server, helper) => {
+    server.get("/c/category-does-not-exist/find_by_slug.json", () => {
+      return helper.response(404, {
+        errors: ["The requested URL or resource could not be found."],
+        error_type: "not_found",
+        extras: { html: "<div class='page-not-found'>not found</div>" },
+      });
+    });
+  });
+  test("Navigating to a bad category link does not break the router", async function (assert) {
+    await visit("/t/internationalization-localization/280");
+
+    await click('[data-for-test="category-404"]');
+    assert.equal(currentURL(), "/404");
+
+    // See that we can navigate away
+    await click("#site-logo");
+    assert.equal(currentURL(), "/");
+  });
+});
 
 acceptance("Unknown", function (needs) {
   const urls = {

--- a/app/assets/javascripts/discourse/tests/fixtures/topic.js
+++ b/app/assets/javascripts/discourse/tests/fixtures/topic.js
@@ -374,7 +374,7 @@ export default {
           uploaded_avatar_id: 40181,
           created_at: "2013-02-05T21:32:47.649Z",
           cooked:
-            '<p>The application strings <a href="https://github.com/discourse/discourse/blob/master/config/locales/en.yml" rel="nofollow">are externalized</a>, so localization should be entirely possible with enough translation effort.</p>',
+            '<p>The application strings <a href="https://github.com/discourse/discourse/blob/master/config/locales/en.yml" rel="nofollow">are externalized</a>, so localization should be entirely possible with enough translation effort.</p><p>Link for unknown-test: <a href="/c/category-does-not-exist/99999" data-for-test="category-404">link</a></p>',
           post_number: 2,
           post_type: 1,
           updated_at: "2013-02-06T10:15:27.965Z",


### PR DESCRIPTION
The propagated promise failure from model() caused the router to reject future route transitions, even though it correctly routed to the last-resort 404 page.

https://meta.discourse.org/t/error-page-appears-repeatedly-after-you-try-accessing-a-private-page/170557/

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
