### PR TITLE
FIX: Remove custom 'error' action on build-category-route

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/build-category-route.js
+++ b/app/assets/javascripts/discourse/app/routes/build-category-route.js
@@ -66,17 +66,12 @@ export default (filterArg, params) => {
           parts.pop();
         }
 
-        return Category.reloadBySlugPath(parts.join("/"))
-          .then((result) => {
-            const record = this.store.createRecord("category", result.category);
-            record.setupGroupsAndPermissions();
-            this.site.updateCategory(record);
-            return { category: record, modelParams };
-          })
-          .catch(() => {
-            // afterModel will call replaceWith(/404)
-            return null;
-          });
+        return Category.reloadBySlugPath(parts.join("/")).then((result) => {
+          const record = this.store.createRecord("category", result.category);
+          record.setupGroupsAndPermissions();
+          this.site.updateCategory(record);
+          return { category: record, modelParams };
+        });
       }
 
       if (category) {
@@ -244,18 +239,6 @@ export default (filterArg, params) => {
     },
 
     actions: {
-      error(err) {
-        const json = err.jqXHR.responseJSON;
-        if (json && json.extras && json.extras.html) {
-          this.controllerFor("discovery").set(
-            "errorHtml",
-            err.jqXHR.responseJSON.extras.html
-          );
-        } else {
-          this.replaceWith("exception");
-        }
-      },
-
       setNotification(notification_level) {
         this.currentModel.setNotification(notification_level);
       },

--- a/app/assets/javascripts/discourse/app/templates/discovery.hbs
+++ b/app/assets/javascripts/discourse/app/templates/discovery.hbs
@@ -1,41 +1,37 @@
-{{#if errorHtml}}
-  {{html-safe errorHtml}}
-{{else}}
+<div class="container">
+  {{discourse-banner user=currentUser banner=site.banner}}
+  {{#unless viewingCategoriesList}}
+    {{category-read-only-banner category=category readOnly=navigationCategory.cannotCreateTopicOnCategory}}
+  {{/unless}}
+</div>
+
+<div class="list-controls">
   <div class="container">
-    {{discourse-banner user=currentUser banner=site.banner}}
-    {{#unless viewingCategoriesList}}
-      {{category-read-only-banner category=category readOnly=navigationCategory.cannotCreateTopicOnCategory}}
-    {{/unless}}
+    {{outlet "navigation-bar"}}
   </div>
+</div>
 
-  <div class="list-controls">
-    <div class="container">
-      {{outlet "navigation-bar"}}
-    </div>
-  </div>
+{{conditional-loading-spinner condition=loading}}
 
-  {{conditional-loading-spinner condition=loading}}
+{{plugin-outlet name="discovery-above"}}
 
-  {{plugin-outlet name="discovery-above"}}
-
-  <div class="container list-container {{if loading "hidden"}}">
-    <div class="row">
-      <div class="full-width">
-        <div id="header-list-area">
-          {{outlet "header-list-container"}}
-        </div>
-      </div>
-    </div>
-    <div class="row">
-      <div class="full-width">
-        <div id="list-area">
-          {{plugin-outlet name="discovery-list-container-top"
-                          args=(hash category=category listLoading=loading)}}
-          {{outlet "list-container"}}
-        </div>
+<div class="container list-container {{if loading "hidden"}}">
+  <div class="row">
+    <div class="full-width">
+      <div id="header-list-area">
+        {{outlet "header-list-container"}}
       </div>
     </div>
   </div>
+  <div class="row">
+    <div class="full-width">
+      <div id="list-area">
+        {{plugin-outlet name="discovery-list-container-top"
+                        args=(hash category=category listLoading=loading)}}
+        {{outlet "list-container"}}
+      </div>
+    </div>
+  </div>
+</div>
 
-  {{plugin-outlet name="discovery-below"}}
-{{/if}}
+{{plugin-outlet name="discovery-below"}}


### PR DESCRIPTION
The root cause of the issue was that the route was overriding the 'error' action from the correctly implemented handler in routes/application.js. Remove the custom handler.

Fixes: e16b3da04a8be659a035a6ae2f45c1e92799ef9f / #11424

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
