### PR TITLE
FIX: Generate correct prev and next topics page URL

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -449,6 +449,7 @@ class TagsController < ::ApplicationController
       q: params[:q]
     )
     options[:no_subcategories] = true if params[:no_subcategories] == 'true'
+    options[:per_page] = params[:per_page].to_i.clamp(1, 30) if params[:per_page].present?
 
     if params[:tag_id] == 'none'
       options.delete(:tags)

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -409,8 +409,6 @@ class TagsController < ::ApplicationController
   end
 
   def construct_url_with(action, opts)
-    method = url_method(opts)
-
     page_params =
       case action
       when :prev
@@ -421,13 +419,13 @@ class TagsController < ::ApplicationController
         raise "unreachable"
       end
 
-    if page_params.include?(:category_slug_path_with_id)
-      opts = opts.dup
-      opts.delete(:category)
-    end
+    opts = opts.merge(page_params)
+    opts.delete(:category) if opts.include?(:category_slug_path_with_id)
+
+    method = url_method(opts)
 
     begin
-      url = public_send(method, opts.merge(page_params))
+      url = public_send(method, opts)
     rescue ActionController::UrlGenerationError
       raise Discourse::NotFound
     end

--- a/spec/requests/tags_controller_spec.rb
+++ b/spec/requests/tags_controller_spec.rb
@@ -204,6 +204,15 @@ describe TagsController do
         expect(topic_ids).to_not include(topic_out_of_category.id)
         expect(topic_ids).to_not include(topic_in_category_without_tag.id)
       end
+
+      it "should produce the right next topic URL" do
+        TopicQuery.any_instance.stubs(:per_page_setting).returns(1)
+
+        get "/tags/c/#{category.slug_path.join("/")}/#{category.id}/#{tag.name}.json"
+
+        expect(response.parsed_body['topic_list']['more_topics_url'])
+          .to start_with("/tags/c/#{category.slug_path.join('/')}/#{category.id}/#{tag.name}")
+      end
     end
 
     context "with a subcategory in the path" do

--- a/spec/requests/tags_controller_spec.rb
+++ b/spec/requests/tags_controller_spec.rb
@@ -206,9 +206,7 @@ describe TagsController do
       end
 
       it "should produce the right next topic URL" do
-        TopicQuery.any_instance.stubs(:per_page_setting).returns(1)
-
-        get "/tags/c/#{category.slug_path.join("/")}/#{category.id}/#{tag.name}.json"
+        get "/tags/c/#{category.slug_path.join("/")}/#{category.id}/#{tag.name}.json?per_page=1"
 
         expect(response.parsed_body['topic_list']['more_topics_url'])
           .to start_with("/tags/c/#{category.slug_path.join('/')}/#{category.id}/#{tag.name}")


### PR DESCRIPTION
It did not work well for category + tags pages

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
