### PR TITLE
FIX: removes extra slashes from URL

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/discourse-location.js
+++ b/app/assets/javascripts/discourse/app/lib/discourse-location.js
@@ -66,6 +66,7 @@ const DiscourseLocation = EmberObject.extend({
     let url = withoutPrefix(this.location.pathname);
     const search = this.location.search || "";
     url += search;
+    url = url.replace(/\/\//g, "/"); // remove extra slashes
     return url;
   },
 


### PR DESCRIPTION
This is similar to a fix used in ember core: https://github.com/emberjs/ember.js/blob/master/packages/@ember/-internals/routing/lib/location/history_location.ts#L140

It will prevent a URL with a double slash to hang and end up in a 404.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
