### PR TITLE
 FIX: Actually error when topic timer time is in the past

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -445,6 +445,11 @@ class TopicsController < ApplicationController
     params.permit(:time, :based_on_last_post, :category_id)
     params.require(:status_type)
 
+    if params[:time] && !(Float(params[:time]) rescue nil)
+      time = Time.find_zone("UTC").parse(params[:time])
+      raise Discourse::InvalidParameters.new(:time) if time < Time.current
+    end
+
     status_type =
       begin
         TopicTimer.types.fetch(params[:status_type].to_sym)

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -445,11 +445,6 @@ class TopicsController < ApplicationController
     params.permit(:time, :based_on_last_post, :category_id)
     params.require(:status_type)
 
-    if params[:time] && !(Float(params[:time]) rescue nil)
-      time = Time.find_zone("UTC").parse(params[:time])
-      raise Discourse::InvalidParameters.new(:time) if time < Time.current
-    end
-
     status_type =
       begin
         TopicTimer.types.fetch(params[:status_type].to_sym)

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1344,6 +1344,7 @@ class Topic < ActiveRecord::Base
         topic_timer.execute_at = timestamp
       end
     end
+
     if topic_timer.execute_at
       if by_user&.staff? || by_user&.trust_level == TrustLevel[4]
         topic_timer.user = by_user

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1339,13 +1339,11 @@ class Topic < ActiveRecord::Base
         topic_timer.execute_at = num_hours.hours.from_now if num_hours > 0
       else
         timestamp = utc.parse(time)
-        raise Discourse::InvalidParameters unless timestamp
+        raise Discourse::InvalidParameters unless timestamp && timestamp > utc.now
         # a timestamp in client's time zone, like "2015-5-27 12:00"
         topic_timer.execute_at = timestamp
-        topic_timer.errors.add(:execute_at, :invalid) if timestamp < utc.now
       end
     end
-
     if topic_timer.execute_at
       if by_user&.staff? || by_user&.trust_level == TrustLevel[4]
         topic_timer.user = by_user

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -1756,10 +1756,13 @@ describe Topic do
 
     it "sets a validation error when given a timestamp in the past" do
       freeze_time now
-      topic.set_or_create_timer(TopicTimer.types[:close], '2013-11-19 5:00', by_user: admin)
 
-      expect(topic.topic_timers.first.execute_at).to eq_time(Time.zone.local(2013, 11, 19, 5, 0))
-      expect(topic.topic_timers.first.errors[:execute_at]).to be_present
+      expect do
+        topic.set_or_create_timer(
+          TopicTimer.types[:close],
+          '2013-11-19 5:00', by_user: admin
+        )
+      end.to raise_error(Discourse::InvalidParameters)
     end
 
     it "sets a validation error when give a timestamp of an invalid format" do

--- a/spec/requests/api/topics_spec.rb
+++ b/spec/requests/api/topics_spec.rb
@@ -954,7 +954,7 @@ describe 'topics' do
           category_id: { type: :string, nullable: true },
         }
 
-        let(:request_body) { { time: '2020-07-11+18:00-06:00', status_type: 'close' } }
+        let(:request_body) { { time: Time.current + 1.day, status_type: 'close' } }
         let!(:topic_post) { Fabricate(:post) }
         let(:id) { topic_post.topic.id }
 

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -2932,6 +2932,19 @@ RSpec.describe TopicsController do
       end
     end
 
+    context 'when time is in the past' do
+      it 'returns an error' do
+        freeze_time
+        sign_in(admin)
+
+        post "/t/#{topic.id}/timer.json", params: {
+          time: Time.current - 1.day,
+          status_type: TopicTimer.types[1]
+        }
+        expect(response.status).to eq(400)
+      end
+    end
+
     context 'when logged in as an admin' do
       before do
         freeze_time


### PR DESCRIPTION
The error that was being added to the topic_timer record was being ignored. It was set here https://github.com/discourse/discourse/blob/7a079b9e3be47ae3920e23a7e847c5f2ef7fff50/app/models/topic.rb#L1345

But the record would become valid after this line 
https://github.com/discourse/discourse/blob/7a079b9e3be47ae3920e23a7e847c5f2ef7fff50/app/models/topic.rb#L1351

Resulting in no error and an `execute_at` in the past on a valid topic_timer. This makes it go boom instead.