### PR TITLE
FIX: Normalize links by converting them to lower case

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/link-lookup.js
+++ b/app/assets/javascripts/discourse/app/lib/link-lookup.js
@@ -1,5 +1,9 @@
-const _warned = {};
+let _warned = {};
 const NO_RESULT = [false, null];
+
+export function reset() {
+  _warned = {};
+}
 
 export default class LinkLookup {
   constructor(links) {
@@ -11,7 +15,10 @@ export default class LinkLookup {
       return NO_RESULT;
     }
 
-    const normalized = href.replace(/^https?:\/\//, "").replace(/\/$/, "");
+    const normalized = href
+      .toLowerCase()
+      .replace(/^https?:\/\//, "")
+      .replace(/\/$/, "");
     if (_warned[normalized]) {
       return NO_RESULT;
     }

--- a/app/assets/javascripts/discourse/tests/unit/lib/link-lookup-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/link-lookup-test.js
@@ -1,0 +1,48 @@
+import LinkLookup, { reset } from "discourse/lib/link-lookup";
+import { module, test } from "qunit";
+import Post from "discourse/models/post";
+
+module("Unit | Utility | link-lookup", function (hooks) {
+  hooks.afterEach(() => reset());
+  hooks.beforeEach(function () {
+    this.post = Post.create();
+    this.linkLookup = new LinkLookup({
+      "en.wikipedia.org/wiki/handheld_game_console": {
+        post_number: 1,
+      },
+    });
+  });
+
+  test("works with https", function (assert) {
+    assert.ok(
+      this.linkLookup.check(
+        this.post,
+        "https://en.wikipedia.org/wiki/handheld_game_console"
+      )[0]
+    );
+  });
+  test("works with http", function (assert) {
+    assert.ok(
+      this.linkLookup.check(
+        this.post,
+        "http://en.wikipedia.org/wiki/handheld_game_console"
+      )[0]
+    );
+  });
+  test("works with trailing slash", function (assert) {
+    assert.ok(
+      this.linkLookup.check(
+        this.post,
+        "https://en.wikipedia.org/wiki/handheld_game_console/"
+      )[0]
+    );
+  });
+  test("works with uppercase characters", function (assert) {
+    assert.ok(
+      this.linkLookup.check(
+        this.post,
+        "https://en.wikipedia.org/wiki/Handheld_game_console"
+      )[0]
+    );
+  });
+});


### PR DESCRIPTION
The server side does this so the same link on the client side with any
upper case letters does not warn as a duplicate.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
