### PR TITLE
FEATURE: Support for GitHub Codespaces development

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+{
+	"name": "Discourse",
+	"image": "discourse/discourse_dev:release",
+	"workspaceMount": "source=${localWorkspaceFolder}/../..,target=/var/www/discourse,type=bind",
+	"workspaceFolder": "/var/www/discourse",
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+	"postCreateCommand": "sudo /sbin/boot",
+	"extensions": ["rebornix.Ruby"],
+    "forwardPorts": [9292],
+	"remoteUser": "discourse"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -137,8 +137,10 @@ node_modules
 # ignore generated api documentation files
 openapi/*
 
-# ignore VSCode config files
-.vscode
+# ignore custom VSCode config files
+.vscode/*
+!.vscode/launch.json
+!.vscode/tasks.json
 
 # ignore direnv
 .envrc

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Discourse",
+            "type": "Ruby",
+            "request": "launch",
+            "cwd": "/home/discourse/workspace/discourse", 
+            // run bundle install before rails server
+            "preLaunchTask": "Prepare discourse",
+            "env": { "DISCOURSE_DEV_HOSTS": "${env:CLOUDENV_ENVIRONMENT_ID}-9292.apps.codespaces.githubusercontent.com", "UNICORN_BIND_ALL": "1", "UNICORN_WORKERS": "4", "DISCOURSE_DEV_ALLOW_ANON_TO_IMPERSONATE": "1" },
+            "program": "bin/unicorn",
+            "args": ["-x"],
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,12 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Prepare discourse",
+            "type": "shell",
+            "command": "cd /home/discourse/workspace/discourse && bundle install && yarn && bin/rake db:migrate"
+        }, 
+    ], 
+}


### PR DESCRIPTION
This has a basic config to use the new Codespaces feature in GitHub.

If you have access to the feature all you need to do is:

1. Visit https://github.com/discourse/discourse
2. Click on Code > Open with Codespaces > New codespace
3. Wait it to prepare the environment
4. Click on File > Run > Run without Debug or press <kbd>CTRL</kbd>+<kbd>F5</kbd>
5. When prompted click on the green pop-up on the lower left to open the running Discourse app in a new tab

