### PR TITLE
FIX: correct tracking when mute all categories

### DIFF
--- a/app/assets/javascripts/discourse/app/models/topic-tracking-state.js
+++ b/app/assets/javascripts/discourse/app/models/topic-tracking-state.js
@@ -55,14 +55,21 @@ const TopicTrackingState = EmberObject.extend({
     const tracker = this;
 
     const process = (data) => {
-      if (data.message_type === "muted") {
-        tracker.trackMutedTopic(data.topic_id);
+      if (["muted", "unmuted"].includes(data.message_type)) {
+        tracker.trackMutedOrUnmutedTopic(data);
         return;
       }
 
-      tracker.pruneOldMutedTopics();
+      tracker.pruneOldMutedAndUnmutedTopics();
 
       if (tracker.isMutedTopic(data.topic_id)) {
+        return;
+      }
+
+      if (
+        this.siteSettings.mute_all_categories_by_default &&
+        !tracker.isUnmutedTopic(data.topic_id)
+      ) {
         return;
       }
 
@@ -166,24 +173,45 @@ const TopicTrackingState = EmberObject.extend({
     return (this.currentUser && this.currentUser.muted_topics) || [];
   },
 
-  trackMutedTopic(topicId) {
-    let mutedTopics = this.mutedTopics().concat({
-      topicId: topicId,
-      createdAt: Date.now(),
-    });
-    this.currentUser && this.currentUser.set("muted_topics", mutedTopics);
+  unmutedTopics() {
+    return (this.currentUser && this.currentUser.unmuted_topics) || [];
   },
 
-  pruneOldMutedTopics() {
+  trackMutedOrUnmutedTopic(data) {
+    let topics, key;
+    if (data.message_type === "muted") {
+      key = "muted_topics";
+      topics = this.mutedTopics();
+    } else {
+      key = "unmuted_topics";
+      topics = this.unmutedTopics();
+    }
+    topics = topics.concat({
+      topicId: data.topic_id,
+      createdAt: Date.now(),
+    });
+    this.currentUser && this.currentUser.set(key, topics);
+  },
+
+  pruneOldMutedAndUnmutedTopics() {
     const now = Date.now();
     let mutedTopics = this.mutedTopics().filter(
       (mutedTopic) => now - mutedTopic.createdAt < 60000
     );
-    this.currentUser && this.currentUser.set("muted_topics", mutedTopics);
+    let unmutedTopics = this.unmutedTopics().filter(
+      (unmutedTopic) => now - unmutedTopic.createdAt < 60000
+    );
+    this.currentUser &&
+      this.currentUser.set("muted_topics", mutedTopics) &&
+      this.currentUser.set("unmuted_topics", unmutedTopics);
   },
 
   isMutedTopic(topicId) {
     return !!this.mutedTopics().findBy("topicId", topicId);
+  },
+
+  isUnmutedTopic(topicId) {
+    return !!this.unmutedTopics().findBy("topicId", topicId);
   },
 
   updateSeen(topicId, highestSeen) {

--- a/app/assets/javascripts/discourse/tests/unit/models/topic-tracking-state-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/topic-tracking-state-test.js
@@ -327,7 +327,7 @@ module("Unit | Model | topic-tracking-state", function (hooks) {
     assert.equal(state.countNew(4), 0);
   });
 
-  test("mute topic", function (assert) {
+  test("mute and unmute topic", function (assert) {
     let currentUser = User.create({
       username: "chuck",
       muted_category_ids: [],
@@ -335,14 +335,19 @@ module("Unit | Model | topic-tracking-state", function (hooks) {
 
     const state = TopicTrackingState.create({ currentUser });
 
-    state.trackMutedTopic(1);
+    state.trackMutedOrUnmutedTopic({ topic_id: 1, message_type: "muted" });
     assert.equal(currentUser.muted_topics[0].topicId, 1);
 
-    state.pruneOldMutedTopics();
+    state.trackMutedOrUnmutedTopic({ topic_id: 2, message_type: "unmuted" });
+    assert.equal(currentUser.unmuted_topics[0].topicId, 2);
+
+    state.pruneOldMutedAndUnmutedTopics();
     assert.equal(state.isMutedTopic(1), true);
+    assert.equal(state.isUnmutedTopic(2), true);
 
     this.clock.tick(60000);
-    state.pruneOldMutedTopics();
+    state.pruneOldMutedAndUnmutedTopics();
     assert.equal(state.isMutedTopic(1), false);
+    assert.equal(state.isUnmutedTopic(2), false);
   });
 });

--- a/app/models/topic_tracking_state.rb
+++ b/app/models/topic_tracking_state.rb
@@ -12,6 +12,7 @@ class TopicTrackingState
   UNREAD_MESSAGE_TYPE = "unread"
   LATEST_MESSAGE_TYPE = "latest"
   MUTED_MESSAGE_TYPE = "muted"
+  UNMUTED_MESSAGE_TYPE = "unmuted"
 
   attr_accessor :user_id,
                 :topic_id,
@@ -100,6 +101,25 @@ class TopicTrackingState
     message = {
       topic_id: topic.id,
       message_type: MUTED_MESSAGE_TYPE,
+    }
+    MessageBus.publish("/latest", message.as_json, user_ids: user_ids)
+  end
+
+  def self.publish_unmuted(topic)
+    return if !SiteSetting.mute_all_categories_by_default
+    user_ids = User
+      .joins("LEFT JOIN category_users ON category_users.user_id = users.id AND category_users.category_id = #{topic.category_id}")
+      .joins("LEFT JOIN topic_users ON topic_users.user_id = users.id AND topic_users.topic_id = #{topic.id}")
+      .joins("LEFT JOIN tag_users ON tag_users.user_id = users.id AND tag_users.tag_id IN (#{topic.tag_ids.join(",").presence || 'NULL'})")
+      .where("category_users.notification_level > 0 OR topic_users.notification_level > 0 OR tag_users.notification_level > 0")
+      .where("users.last_seen_at > ?", 7.days.ago)
+      .order("users.last_seen_at DESC")
+      .limit(100)
+      .pluck(:id)
+    return if user_ids.blank?
+    message = {
+      topic_id: topic.id,
+      message_type: UNMUTED_MESSAGE_TYPE,
     }
     MessageBus.publish("/latest", message.as_json, user_ids: user_ids)
   end

--- a/app/models/topic_tracking_state.rb
+++ b/app/models/topic_tracking_state.rb
@@ -108,8 +108,8 @@ class TopicTrackingState
   def self.publish_unmuted(topic)
     return if !SiteSetting.mute_all_categories_by_default
     user_ids = User
-      .joins("LEFT JOIN category_users ON category_users.user_id = users.id AND category_users.category_id = #{topic.category_id}")
-      .joins("LEFT JOIN topic_users ON topic_users.user_id = users.id AND topic_users.topic_id = #{topic.id}")
+      .joins(DB.sql_fragment("LEFT JOIN category_users ON category_users.user_id = users.id AND category_users.category_id = :category_id", category_id: topic.category_id))
+      .joins(DB.sql_fragment("LEFT JOIN topic_users ON topic_users.user_id = users.id AND topic_users.topic_id = :topic_id",  topic_id: topic.id))
       .joins("LEFT JOIN tag_users ON tag_users.user_id = users.id AND tag_users.tag_id IN (#{topic.tag_ids.join(",").presence || 'NULL'})")
       .where("category_users.notification_level > 0 OR topic_users.notification_level > 0 OR tag_users.notification_level > 0")
       .where("users.last_seen_at > ?", 7.days.ago)

--- a/lib/post_jobs_enqueuer.rb
+++ b/lib/post_jobs_enqueuer.rb
@@ -57,6 +57,7 @@ class PostJobsEnqueuer
   end
 
   def after_post_create
+    TopicTrackingState.publish_unmuted(@post.topic)
     if @post.post_number > 1
       TopicTrackingState.publish_muted(@post.topic)
       TopicTrackingState.publish_unread(@post)

--- a/lib/post_revisor.rb
+++ b/lib/post_revisor.rb
@@ -537,6 +537,7 @@ class PostRevisor
     return if bypass_bump? || !is_last_post?
     @topic.update_column(:bumped_at, Time.now)
     TopicTrackingState.publish_muted(@topic)
+    TopicTrackingState.publish_unmuted(@topic)
     TopicTrackingState.publish_latest(@topic)
   end
 


### PR DESCRIPTION
Currently, we have a solution for muted topics. Basically, when a post is created first we send a `muted` message to users who muted that specific topic:

https://github.com/discourse/discourse/blob/master/app/models/topic_tracking_state.rb#L91

Later, topic tracking state filters if the topic is muted or not before update state:

https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/app/models/topic-tracking-state.js#L58:L67

That solution works quite well.

I wanted to extend it to handle `mute all categories by default` setting as well.

In that case, we should only inform the user about new topic/post when they explicitly want to.

If that setting is enabled, we would send "unmuted" message to a user who watches specific category, topic or tag. In all other cases, don't inform user about new topic as all categories are muted by default.

Meta: https://meta.discourse.org/t/threads-muted-by-mute-all-by-default-are-showing-up-as-new-but-not-visible/168324

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
