### PR TITLE
FIX: Avoid clock skew issues when logging in with Google

### DIFF
--- a/lib/auth/google_oauth2_authenticator.rb
+++ b/lib/auth/google_oauth2_authenticator.rb
@@ -29,6 +29,12 @@ class Auth::GoogleOAuth2Authenticator < Auth::ManagedAuthenticator
         if (google_oauth2_prompt = SiteSetting.google_oauth2_prompt).present?
           strategy.options[:prompt] = google_oauth2_prompt.gsub("|", " ")
         end
+
+        # All the data we need for the `info` and `credentials` auth hash
+        # are obtained via the user info API, not the JWT. Using and verifying
+        # the JWT can fail due to clock skew, so let's skip it completely.
+        # https://github.com/zquestz/omniauth-google-oauth2/pull/392
+        strategy.options[:skip_jwt] = true
       }
     }
     omniauth.provider :google_oauth2, options


### PR DESCRIPTION
All the data we need for the `info` and `credentials` auth hash
are obtained via the user info API, not the JWT. Using and verifying
the JWT can fail due to clock skew, so let's skip it completely.

PR opened to fix the upstream issue at https://github.com/zquestz/omniauth-google-oauth2/pull/392

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
