### PR TITLE
UI: Category Onebox styling changes

### DIFF
--- a/app/assets/stylesheets/common/base/onebox.scss
+++ b/app/assets/stylesheets/common/base/onebox.scss
@@ -670,6 +670,11 @@ aside.onebox.stackexchange .onebox-body {
       margin-right: 0.5em;
     }
   }
+  &.category-onebox {
+    border: 1px solid var(--primary-low);
+    padding-left: calc(1em - 5px);
+    margin-left: 5px;
+  }
 }
 
 .onebox.gfycat p {

--- a/lib/onebox/templates/discourse_category_onebox.mustache
+++ b/lib/onebox/templates/discourse_category_onebox.mustache
@@ -1,10 +1,13 @@
-<aside class="onebox" style="border-left: 5px solid #{{color}}">
-  <article class="onebox-body category-onebox">
+<aside class="onebox category-onebox" style="box-shadow: -5px 0px #{{color}};">
+  <article class="onebox-body category-onebox-body">
     {{#logo_url}}
       <img src="{{logo_url}}" class="thumbnail" />
     {{/logo_url}}
     <h3>
       <a class="badge-wrapper bullet" href="{{url}}">
+        {{#color}}
+          <span class="badge-category-bg" style="background-color: #{{{color}}}"></span>
+        {{/color}}
         <span class="clear-badge"><span>{{{name}}}</span></span>
       </a>
     </h3>


### PR DESCRIPTION
This commit adjusts the category one box styling to be more in line with the discourse categories UI.

## New
![image](https://user-images.githubusercontent.com/30537603/101662717-79f5bb80-3a0f-11eb-8dc9-13428e6d8398.png)

## Old
![image](https://user-images.githubusercontent.com/30537603/101662784-8bd75e80-3a0f-11eb-8a9e-e4d9345e52fa.png)



<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
