### PR TITLE
FIX: Only block local edits for git-sourced themes

### DIFF
--- a/app/assets/javascripts/admin/addon/routes/admin-customize-themes-edit.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-customize-themes-edit.js
@@ -28,7 +28,7 @@ export default Route.extend({
     const fields = wrapper.model
       .get("fields")
       [wrapper.target].map((f) => f.name);
-    if (wrapper.model.remote_theme) {
+    if (wrapper.model.remote_theme && wrapper.model.remote_theme.is_git) {
       this.transitionTo("adminCustomizeThemes.index");
       return;
     }

--- a/app/assets/javascripts/admin/addon/templates/customize-themes-show.hbs
+++ b/app/assets/javascripts/admin/addon/templates/customize-themes-show.hbs
@@ -201,7 +201,7 @@
     {{/d-section}}
   {{/if}}
 
-  {{#unless model.remote_theme}}
+  {{#unless model.remote_theme.is_git}}
     <div class="control-unit">
       <div class="mini-title">{{i18n "admin.customize.theme.css_html"}}</div>
       {{#if model.hasEditedFields}}

--- a/app/controllers/admin/themes_controller.rb
+++ b/app/controllers/admin/themes_controller.rb
@@ -291,7 +291,7 @@ class Admin::ThemesController < Admin::AdminController
   end
 
   def ban_for_remote_theme!
-    raise Discourse::InvalidAccess if @theme.remote_theme
+    raise Discourse::InvalidAccess if @theme.remote_theme&.is_git?
   end
 
   def add_relative_themes!(kind, ids)

--- a/spec/requests/admin/themes_controller_spec.rb
+++ b/spec/requests/admin/themes_controller_spec.rb
@@ -378,12 +378,28 @@ describe Admin::ThemesController do
         theme: {
           theme_fields: [
             { name: 'scss', target: 'common', value: '' },
-            { name: 'test', target: 'common', value: 'filename.jpg', upload_id: 4 }
+            { name: 'header', target: 'common', value: 'filename.jpg', upload_id: 4 }
           ]
         }
       }
 
       expect(response.status).to eq(403)
+    end
+
+    it 'allows zip-imported theme fields to be locally edited' do
+      r = RemoteTheme.create!(remote_url: "")
+      theme.update!(remote_theme_id: r.id)
+
+      put "/admin/themes/#{theme.id}.json", params: {
+        theme: {
+          theme_fields: [
+            { name: 'scss', target: 'common', value: '' },
+            { name: 'header', target: 'common', value: 'filename.jpg', upload_id: 4 }
+          ]
+        }
+      }
+
+      expect(response.status).to eq(200)
     end
 
     it 'updates a child theme' do


### PR DESCRIPTION
Themes uploaded as zip files are given a row in the `remote_themes` table to store metadata, even though they are not truly remote.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
