### PR TITLE
FIX: `notify_file_change` was outputting a command to vim

### DIFF
--- a/bin/notify_file_change
+++ b/bin/notify_file_change
@@ -6,7 +6,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd ../tmp && pwd )"
 SOCKET="$DIR"/file_change.sock
 
 if [[ -e "$SOCKET" ]]; then
-  if command -v socat; then
+  if command -v socat &> /dev/null; then
     echo "$1 $2" | socat - UNIX-CONNECT:$SOCKET >/dev/null 2>/dev/null
   else
     echo "$1 $2" | nc -U $SOCKET >/dev/null 2>/dev/null


### PR DESCRIPTION
The check for `socat` needs to be silenced too, or vim will output the
path to `socat` every time you save a file.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
