### PR TITLE
FIX: Don't raise an error if a custom emoji image was deleted

### DIFF
--- a/app/serializers/emoji_serializer.rb
+++ b/app/serializers/emoji_serializer.rb
@@ -4,6 +4,7 @@ class EmojiSerializer < ApplicationSerializer
   attributes :name, :url, :group
 
   def url
+    return nil if object.url.blank?
     Discourse.store.cdn_url(object.url)
   end
 end

--- a/spec/serializers/emoji_serializer_spec.rb
+++ b/spec/serializers/emoji_serializer_spec.rb
@@ -3,14 +3,16 @@
 require 'rails_helper'
 
 describe EmojiSerializer do
-  fab!(:emoji) do
+  fab!(:custom_emoji) do
     CustomEmoji.create!(name: 'trout', upload: Fabricate(:upload))
-    Emoji.load_custom.first
   end
 
-  subject { described_class.new(emoji, root: false) }
-
   describe '#url' do
+    fab!(:emoji) do
+      Emoji.load_custom.first
+    end
+    subject { described_class.new(emoji, root: false) }
+
     it 'returns a valid URL' do
       expect(subject.url).to start_with('/uploads/')
     end
@@ -20,4 +22,32 @@ describe EmojiSerializer do
       expect(subject.url).to start_with('https://cdn.com')
     end
   end
+
+  context "missing uploads" do
+    before do
+      custom_emoji.upload.destroy!
+    end
+
+    it "doesn't raise an error with a missing upload and a CDN" do
+      emoji = Emoji.load_custom.first
+      set_cdn_url('https://cdn.com')
+      result = described_class.new(Emoji.load_custom.first, root: false).as_json
+      expect(result[:url]).to be_blank
+    end
+
+    it "doesn't raise an error with a missing upload and an s3 CDN" do
+      emoji = Emoji.load_custom.first
+
+      SiteSetting.enable_s3_uploads = true
+      SiteSetting.s3_upload_bucket = "s3bucket"
+      SiteSetting.s3_access_key_id = "s3_access_key_id"
+      SiteSetting.s3_secret_access_key = "s3_secret_access_key"
+      SiteSetting.s3_cdn_url = "https://example.com"
+      result = described_class.new(Emoji.load_custom.first, root: false).as_json
+
+      expect(result[:url]).to be_blank
+    end
+
+  end
+
 end


### PR DESCRIPTION
This could be catastrophic in production; a missing upload would mean
every request to the site would raise an error.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
