### PR TITLE
UX: Add full date title to fps-result date

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/full-page-search.hbs
+++ b/app/assets/javascripts/discourse/app/templates/full-page-search.hbs
@@ -112,8 +112,8 @@
                 </div>
 
                 <div class="blurb container">
-                  <span class="date" title={{raw-date result.created_at}}>
-                    {{format-age result.created_at}}
+                  <span class="date">
+                    {{format-date result.created_at format="tiny"}}
                     {{#if result.blurb}}
                       -
                     {{/if}}

--- a/app/assets/javascripts/discourse/app/templates/full-page-search.hbs
+++ b/app/assets/javascripts/discourse/app/templates/full-page-search.hbs
@@ -112,7 +112,7 @@
                 </div>
 
                 <div class="blurb container">
-                  <span class="date">
+                  <span class="date" title={{raw-date result.created_at}}>
                     {{format-age result.created_at}}
                     {{#if result.blurb}}
                       -


### PR DESCRIPTION
This is a tiny change that will allow users to hover the date element of a full page search result to see the raw date. It's not always easy to know what the exact date was "20d" ago, so hopefully this helps when it's relevant.

<img width="802" alt="Screen Shot 2020-12-09 at 2 39 25 PM" src="https://user-images.githubusercontent.com/22733864/101699056-5fcbd580-3a2f-11eb-9208-22f27afabc14.png">
