### PR TITLE
DEV: Expose silencer customization options to plugins

### DIFF
--- a/app/services/staff_action_logger.rb
+++ b/app/services/staff_action_logger.rb
@@ -821,7 +821,7 @@ class StaffActionLogger
 
   def params(opts = nil)
     opts ||= {}
-    { acting_user_id: @admin.id, context: opts[:context] }
+    { acting_user_id: @admin.id, context: opts[:context], details: opts[:details] }
   end
 
   def validate_category(category)

--- a/app/services/user_silencer.rb
+++ b/app/services/user_silencer.rb
@@ -80,7 +80,7 @@ class UserSilencer
   def unsilence
     @user.silenced_till = nil
     if @user.save
-      DiscourseEvent.trigger(:user_unsilenced, user: @user)
+      DiscourseEvent.trigger(:user_unsilenced, user: @user, by_user: @by_user)
       SystemMessage.create(@user, :unsilenced)
       StaffActionLogger.new(@by_user).log_unsilence_user(@user) if @by_user
     end


### PR DESCRIPTION
Passes by_user to :user_unsilenced so plugins can detect whether or not
a silence was done automatically (by system user) or manually (by non-system)

Adds the ability to pass details in the action logger params so custom loggers
can pass their own details eg, in custom silence logs