### PR TITLE
UX: Fix unreachable buttons on menus in Safari iOS

### DIFF
--- a/app/assets/stylesheets/mobile/menu-panel.scss
+++ b/app/assets/stylesheets/mobile/menu-panel.scss
@@ -8,7 +8,7 @@
   }
 }
 .header-cloak {
-  height: 100vh;
+  height: 100%;
   width: 100vw;
   position: fixed;
   background-color: black;
@@ -33,5 +33,5 @@
 }
 
 .panel-body-contents {
-  padding-bottom: env(safe-area-inset-bottom);
+  padding-bottom: calc(env(safe-area-inset-bottom) + 2em);
 }

--- a/app/assets/stylesheets/mobile/menu-panel.scss
+++ b/app/assets/stylesheets/mobile/menu-panel.scss
@@ -8,7 +8,7 @@
   }
 }
 .header-cloak {
-  height: 100%;
+  height: 100vh;
   width: 100vw;
   position: fixed;
   background-color: black;
@@ -33,5 +33,6 @@
 }
 
 .panel-body-contents {
+  // 2em padding very useful for iOS Safari's overlayed bottom nav
   padding-bottom: calc(env(safe-area-inset-bottom) + 2em);
 }


### PR DESCRIPTION
Safari overlays its own nav at the bottom of the screen. This makes buttons in that area virtually unclickable, so to ensure buttons there are reachable, we need to add enough bottom padding to menu panels.