### PR TITLE
FEATURE: Automatically disable slow mode.

### DIFF
--- a/app/assets/javascripts/discourse/app/components/future-date-input.js
+++ b/app/assets/javascripts/discourse/app/components/future-date-input.js
@@ -17,6 +17,7 @@ export default Component.extend({
   isBasedOnLastPost: equal("selection", "set_based_on_last_post"),
   displayDateAndTimePicker: and("includeDateTime", "isCustom"),
   displayLabel: null,
+  labelClasses: null,
   displayNumberInput: or("isBasedOnLastPost", "isBasedOnDuration"),
 
   init() {

--- a/app/assets/javascripts/discourse/app/controllers/edit-slow-mode.js
+++ b/app/assets/javascripts/discourse/app/controllers/edit-slow-mode.js
@@ -14,6 +14,7 @@ export default Controller.extend(ModalFunctionality, {
   minutes: null,
   seconds: null,
   saveDisabled: false,
+  enabledUntil: null,
   showCustomSelect: equal("selectedSlowMode", "custom"),
 
   init() {
@@ -99,7 +100,7 @@ export default Controller.extend(ModalFunctionality, {
       this._parseValue(this.seconds)
     );
 
-    Topic.setSlowMode(this.model.id, seconds)
+    Topic.setSlowMode(this.model.id, seconds, this.enabledUntil)
       .catch(popupAjaxError)
       .then(() => {
         this.set("model.slow_mode_seconds", seconds);

--- a/app/assets/javascripts/discourse/app/models/topic.js
+++ b/app/assets/javascripts/discourse/app/models/topic.js
@@ -837,8 +837,10 @@ Topic.reopenClass({
     return ajax(`/t/id_for/${slug}`);
   },
 
-  setSlowMode(topicId, seconds) {
+  setSlowMode(topicId, seconds, enabledUntil) {
     const data = { seconds };
+    data.enabled_until = enabledUntil;
+
     return ajax(`/t/${topicId}/slow_mode`, { type: "PUT", data });
   },
 });

--- a/app/assets/javascripts/discourse/app/templates/components/future-date-input.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/future-date-input.hbs
@@ -1,7 +1,7 @@
 <div class="future-date-input">
   {{#unless isBasedOnDuration}}
     <div class="control-group">
-      <label>{{displayLabel}}</label>
+      <label class={{labelClasses}}>{{displayLabel}}</label>
       {{future-date-input-selector
         minimumResultsForSearch=-1
         statusType=statusType

--- a/app/assets/javascripts/discourse/app/templates/modal/edit-slow-mode.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/edit-slow-mode.hbs
@@ -25,6 +25,18 @@
       {{input value=seconds type="number" class="input-small"}}
     </div>
   {{/if}}
+
+  <div class="control-group">
+    {{future-date-input
+      class="enabled-until"
+      label="topic.slow_mode_update.enabled_until"
+      labelClasses="slow-mode-label"
+      includeFarFuture=false
+      clearable=true
+      input=enabledUntil
+      onChangeInput=(action (mut enabledUntil))
+    }}
+  </div>
 {{/d-modal-body}}
 
 <div class="modal-footer">

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -936,9 +936,20 @@ class TopicsController < ApplicationController
 
   def set_slow_mode
     topic = Topic.find(params[:topic_id])
+    slow_mode_type = TopicTimer.types[:clear_slow_mode]
+    timer = TopicTimer.find_by(topic: topic, status_type: slow_mode_type)
 
     guardian.ensure_can_moderate!(topic)
     topic.update!(slow_mode_seconds: params[:seconds])
+    enabled = params[:seconds].to_i > 0
+
+    time = enabled && params[:enabled_until].present? ? params[:enabled_until] : nil
+
+    topic.set_or_create_timer(
+      slow_mode_type,
+      time,
+      by_user: timer&.user
+    )
 
     head :ok
   end

--- a/app/jobs/regular/clear_slow_mode.rb
+++ b/app/jobs/regular/clear_slow_mode.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Jobs
+  class ClearSlowMode < ::Jobs::Base
+
+    def execute(args)
+      topic_timer = TopicTimer.find_by(id: args[:topic_timer_id] || args[:topic_status_update_id])
+
+      if topic_timer.nil? || topic_timer.execute_at > Time.zone.now
+        return
+      end
+
+      topic = topic_timer&.topic
+
+      if topic.nil?
+        topic_timer.destroy!
+        return
+      end
+
+      topic.update!(slow_mode_seconds: 0)
+      topic_timer.trash!(Discourse.system_user)
+    end
+  end
+end

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2334,6 +2334,7 @@ en:
         select: "Users may only post in this topic once every:"
         description: "To promote thoughtful discussion in fast moving or contentious discussions, users must wait before posting again in this topic."
         save: "Enable"
+        enabled_until: "(Optional) Enabled until:"
         remove: "Disable"
         hours: "Hours:"
         minutes: "Minutes:"

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -3134,6 +3134,54 @@ RSpec.describe TopicsController do
         expect(topic.slow_mode_seconds).to eq(3600)
       end
     end
+
+    context 'auto-disable slow mode' do
+      before { sign_in(admin) }
+
+      let(:timestamp) { 1.week.from_now.to_formatted_s(:iso8601) }
+
+      it 'sets a topic timer to clear the slow mode automatically' do
+        put "/t/#{topic.id}/slow_mode.json", params: {
+          seconds: '3600', enabled_until: timestamp
+        }
+
+        created_timer = TopicTimer.find_by(topic: topic)
+        execute_at = created_timer.execute_at.to_formatted_s(:iso8601)
+
+        expect(execute_at).to eq(timestamp)
+      end
+
+      it 'deletes the topic timer' do
+        put "/t/#{topic.id}/slow_mode.json", params: {
+          seconds: '3600', enabled_until: timestamp
+        }
+
+        put "/t/#{topic.id}/slow_mode.json", params: {
+          seconds: '0', enabled_until: timestamp
+        }
+
+        created_timer = TopicTimer.find_by(topic: topic)
+
+        expect(created_timer).to be_nil
+      end
+
+      it 'updates the existing timer' do
+        put "/t/#{topic.id}/slow_mode.json", params: {
+          seconds: '3600', enabled_until: timestamp
+        }
+
+        updated_timestamp = 1.hour.from_now.to_formatted_s(:iso8601)
+
+        put "/t/#{topic.id}/slow_mode.json", params: {
+          seconds: '3600', enabled_until: updated_timestamp
+        }
+
+        created_timer = TopicTimer.find_by(topic: topic)
+        execute_at = created_timer.execute_at.to_formatted_s(:iso8601)
+
+        expect(execute_at).to eq(updated_timestamp)
+      end
+    end
   end
 
   describe '#invite' do


### PR DESCRIPTION
Staff and TL4 users can decide the slow mode duration. We'll internally set a topic timer to disable it.
