### PR TITLE
FEATURE: Allow category group moderators to list/unlist topics

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/topic-admin-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/topic-admin-menu.js
@@ -250,7 +250,7 @@ export default createWidget("topic-admin-menu", {
       }
     }
 
-    if (this.get("currentUser.canManageTopic")) {
+    if (details.get("can_toggle_topic_visibility")) {
       this.addActionButton({
         className: "topic-admin-visible",
         buttonClass: "popup-menu-btn",
@@ -258,7 +258,9 @@ export default createWidget("topic-admin-menu", {
         icon: visible ? "far-eye-slash" : "far-eye",
         label: visible ? "actions.invisible" : "actions.visible",
       });
+    }
 
+    if (this.get("currentUser.canManageTopic")) {
       if (details.get("can_convert_topic")) {
         this.addActionButton({
           className: "topic-admin-convert",

--- a/app/assets/javascripts/discourse/tests/fixtures/topic.js
+++ b/app/assets/javascripts/discourse/tests/fixtures/topic.js
@@ -2205,6 +2205,7 @@ export default {
     details: {
       can_publish_page: true,
       can_invite_via_email: true,
+      can_toggle_topic_visibility: true,
       auto_close_at: null,
       auto_close_hours: null,
       auto_close_based_on_last_post: false,
@@ -5592,6 +5593,7 @@ export default {
       can_review_topic: true,
       can_close_topic: true,
       can_archive_topic: true,
+      can_toggle_topic_visibility: true,
       can_split_merge_topic: true,
       can_edit_staff_notes: true,
       can_moderate_category: true,

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -420,6 +420,8 @@ class TopicsController < ApplicationController
       guardian.ensure_can_close_topic!(@topic)
     when 'archived'
       guardian.ensure_can_archive_topic!(@topic)
+    when 'visible'
+      guardian.ensure_can_toggle_topic_visibility!(@topic)
     else
       guardian.ensure_can_moderate!(@topic)
     end

--- a/app/serializers/topic_view_details_serializer.rb
+++ b/app/serializers/topic_view_details_serializer.rb
@@ -20,6 +20,7 @@ class TopicViewDetailsSerializer < ApplicationSerializer
      :can_archive_topic,
      :can_split_merge_topic,
      :can_edit_staff_notes,
+     :can_toggle_topic_visibility,
      :can_moderate_category]
   end
 
@@ -142,6 +143,10 @@ class TopicViewDetailsSerializer < ApplicationSerializer
 
   def include_can_edit_tags?
     !scope.can_edit?(object.topic) && scope.can_edit_tags?(object.topic)
+  end
+
+  def include_can_toggle_topic_visibility?
+    scope.can_toggle_topic_visibility?(object.topic)
   end
 
   def can_perform_action_available_to_group_moderators?

--- a/lib/guardian/topic_guardian.rb
+++ b/lib/guardian/topic_guardian.rb
@@ -146,6 +146,10 @@ module TopicGuardian
     !Discourse.static_doc_topic_ids.include?(topic.id)
   end
 
+  def can_toggle_topic_visibility?(topic)
+    can_moderate?(topic) || can_perform_action_available_to_group_moderators?(topic)
+  end
+
   def can_convert_topic?(topic)
     return false unless SiteSetting.enable_personal_messages?
     return false if topic.blank?

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -948,6 +948,28 @@ RSpec.describe TopicsController do
         expect(response.status).to eq(403)
         expect(topic.reload.pinned_at).to eq(nil)
       end
+
+      it 'should allow a group moderator to unlist a topic' do
+        put "/t/#{topic.id}/status.json", params: {
+          status: 'visible', enabled: 'false'
+        }
+
+        expect(response.status).to eq(200)
+        expect(topic.reload.visible).to eq(false)
+        expect(topic.posts.last.action_code).to eq('visible.disabled')
+      end
+
+      it 'should allow a group moderator to list an unlisted topic' do
+        topic.update!(visible: false)
+
+        put "/t/#{topic.id}/status.json", params: {
+          status: 'visible', enabled: 'true'
+        }
+
+        expect(response.status).to eq(200)
+        expect(topic.reload.visible).to eq(true)
+        expect(topic.posts.last.action_code).to eq('visible.enabled')
+      end
     end
   end
 


### PR DESCRIPTION
If enabled via SiteSettings, a user belonging to a group which has been granted category group moderator privileges should be able to list/unlist topics belonging to the appropraite category.
