### PR TITLE
bulk select posts popup needs a higher z-index than select buttons

### DIFF
--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -643,7 +643,7 @@ blockquote {
 .selected-posts {
   width: 200px;
   position: fixed;
-  z-index: z("dropdown");
+  z-index: z("dropdown") + 1; // 1 higher than .select-posts
   box-shadow: shadow("card");
   padding: 0.714em;
   margin-bottom: 5px;


### PR DESCRIPTION
Fixes this issue:

![2020-12-10_21-01-30](https://user-images.githubusercontent.com/1681963/101853233-41e49a80-3b2d-11eb-973f-5e928df99f07.gif)

