### PR TITLE
FIX: Show 'New' filter when 'none' subcategory set

### DIFF
--- a/app/assets/javascripts/discourse/app/models/topic-tracking-state.js
+++ b/app/assets/javascripts/discourse/app/models/topic-tracking-state.js
@@ -468,7 +468,7 @@ const TopicTrackingState = EmberObject.extend({
 
   countCategoryByState(type, categoryId, tagId, noSubcategories) {
     const subcategoryIds = noSubcategories
-      ? new Set()
+      ? new Set([categoryId])
       : this.getSubCategoryIds(categoryId);
     const mutedCategoryIds =
       this.currentUser && this.currentUser.muted_category_ids;

--- a/app/assets/javascripts/discourse/tests/unit/models/topic-tracking-state-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/topic-tracking-state-test.js
@@ -290,6 +290,7 @@ module("Unit | Model | topic-tracking-state", function (hooks) {
     };
 
     assert.equal(state.countNew(1), 1);
+    assert.equal(state.countNew(1, undefined, true), 0);
     assert.equal(state.countNew(1, "missing-tag"), 0);
     assert.equal(state.countNew(2), 1);
     assert.equal(state.countNew(3), 0);


### PR DESCRIPTION
When set to 'none' it did not count topics from any category, but it
should count from the current one.

Follow up to df26d2e72a4bca98de08798b5301c062a9e93974.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
