### PR TITLE
FIX: Users without shared drafts access can still have access to the category.

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/topic.js
+++ b/app/assets/javascripts/discourse/app/controllers/topic.js
@@ -110,10 +110,21 @@ export default Controller.extend(bufferedProperty("model"), {
     }
   },
 
-  @discourseComputed("model.postStream.loaded", "model.category_id")
-  showSharedDraftControls(loaded, categoryId) {
+  @discourseComputed(
+    "model.postStream.loaded",
+    "model.category_id",
+    "model.is_shared_draft"
+  )
+  showSharedDraftControls(loaded, categoryId, isSharedDraft) {
     let draftCat = this.site.shared_drafts_category_id;
-    return loaded && draftCat && categoryId && draftCat === categoryId;
+
+    return (
+      loaded &&
+      draftCat &&
+      categoryId &&
+      draftCat === categoryId &&
+      isSharedDraft
+    );
   },
 
   @discourseComputed("site.mobileView", "model.posts_count")

--- a/app/assets/javascripts/discourse/tests/fixtures/topic.js
+++ b/app/assets/javascripts/discourse/tests/fixtures/topic.js
@@ -4031,6 +4031,7 @@ export default {
     archetype: "regular",
     slug: "this-is-a-test-topic",
     category_id: 24,
+    is_shared_draft: true,
     word_count: 15,
     deleted_at: null,
     user_id: 1,

--- a/app/controllers/list_controller.rb
+++ b/app/controllers/list_controller.rb
@@ -62,7 +62,7 @@ class ListController < ApplicationController
         if @category.id == SiteSetting.shared_drafts_category.to_i
           # On shared drafts, show the destination category
           list.topics.each do |t|
-            t.includes_destination_category = true
+            t.includes_destination_category = t.shared_draft.present?
           end
         else
           # When viewing a non-shared draft category, find topics whose

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -168,6 +168,8 @@ class TopicsController < ApplicationController
     topic = Topic.find(params[:id])
     category = Category.find(params[:destination_category_id])
 
+    raise Discourse::InvalidParameters if category.id == SiteSetting.shared_drafts_category.to_i
+
     guardian.ensure_can_publish_topic!(topic, category)
     topic = TopicPublisher.new(topic, current_user, category.id).publish!
 

--- a/app/serializers/topic_view_serializer.rb
+++ b/app/serializers/topic_view_serializer.rb
@@ -74,7 +74,8 @@ class TopicViewSerializer < ApplicationSerializer
     :show_read_indicator,
     :requested_group_name,
     :thumbnails,
-    :user_last_posted_at
+    :user_last_posted_at,
+    :is_shared_draft
   )
 
   has_one :details, serializer: TopicViewDetailsSerializer, root: false, embed: :objects
@@ -240,6 +241,11 @@ class TopicViewSerializer < ApplicationSerializer
       object.topic.category_id == SiteSetting.shared_drafts_category.to_i &&
       object.topic.shared_draft.present?
   end
+
+  def is_shared_draft
+    include_destination_category_id?
+  end
+  alias_method :include_is_shared_draft?, :include_destination_category_id?
 
   def include_pending_posts?
     scope.authenticated? && object.queued_posts_enabled

--- a/lib/guardian/topic_guardian.rb
+++ b/lib/guardian/topic_guardian.rb
@@ -172,6 +172,8 @@ module TopicGuardian
       return authenticated? && topic.all_allowed_users.where(id: @user.id).exists?
     end
 
+    return false if topic.shared_draft && !can_create_shared_draft?
+
     category = topic.category
     can_see_category?(category) &&
       (!category.read_restricted || !is_staged? || secure_category_ids.include?(category.id) || topic.user == user)

--- a/lib/topic_creator.rb
+++ b/lib/topic_creator.rb
@@ -56,8 +56,10 @@ class TopicCreator
   private
 
   def create_shared_draft(topic)
-    return unless @opts[:shared_draft] && @opts[:category].present?
-    SharedDraft.create(topic_id: topic.id, category_id: @opts[:category])
+    return if @opts[:shared_draft].blank? || @opts[:shared_draft] == 'false'
+
+    category_id = @opts[:category].blank? ? SiteSetting.shared_drafts_category.to_i : @opts[:category]
+    SharedDraft.create(topic_id: topic.id, category_id: category_id)
   end
 
   def create_warning(topic)

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -3535,6 +3535,11 @@ RSpec.describe TopicsController do
           expect(result.category_id).to eq(category.id)
           expect(result.visible).to eq(true)
         end
+
+        it 'fails if the destination category is the shared drafts category' do
+          put "/t/#{topic.id}/publish.json", params: { destination_category_id: shared_drafts_category.id }
+          expect(response.status).to eq(400)
+        end
       end
     end
   end


### PR DESCRIPTION
This is an edge-case of 9fb3629. An admin could set the shared draft category to one where both TL2 and TL3 users have access but only give shared draft access to TL3 users. If something like this happens, we need to make sure that TL2 users won't be able to see them, and they won't be listed on latest.

Before this change, `SharedDrafts` were lazily created when a destination category was selected. We now create it alongside the topic and set the destination to the same shared draft category.
