### PR TITLE
UX: Show required indication consistently on signup

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/modal/create-account.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/create-account.hbs
@@ -17,7 +17,14 @@
             <table>
               <tbody>
                 <tr class="input create-account-email">
-                  <td class="label"><label for="new-account-email">{{i18n "user.email.title"}}</label></td>
+                  <td class="label">
+                    <label for="new-account-email">
+                      {{i18n "user.email.title"}}
+                      {{~#if userFields~}}
+                        <span class="required">*</span>
+                      {{/if}}
+                    </label>
+                  </td>
                   <td>
                     {{#if emailValidated}}
                       <span class="value">{{accountEmail}}</span>
@@ -34,7 +41,14 @@
                 </tr>
 
                 <tr class="input">
-                  <td class="label"><label for="new-account-username">{{i18n "user.username.title"}}</label></td>
+                  <td class="label">
+                    <label for="new-account-username">
+                      {{i18n "user.username.title"}}
+                      {{~#if userFields~}}
+                        <span class="required">*</span>
+                      {{/if}}
+                    </label>
+                  </td>
                   <td>
                     {{#if usernameDisabled}}
                       <span class="value">{{accountUsername}}</span>
@@ -52,7 +66,14 @@
                 {{#if fullnameRequired}}
                   <tr class="input">
                     <td class="label">
-                      <label for="new-account-name">{{i18n "user.name.title"}}</label>
+                      <label for="new-account-name">
+                        {{i18n "user.name.title"}}
+                        {{#if siteSettings.full_name_required}}
+                          {{~#if userFields~}}
+                            <span class="required">*</span>
+                          {{/if}}
+                        {{/if}}
+                      </label>
                     </td>
                     <td>
                       {{#if nameDisabled}}
@@ -83,7 +104,14 @@
 
                 {{#if passwordRequired}}
                   <tr class="input">
-                    <td class="label"><label for="new-account-password">{{i18n "user.password.title"}}</label></td>
+                    <td class="label">
+                      <label for="new-account-password">
+                        {{i18n "user.password.title"}}
+                        {{~#if userFields~}}
+                          <span class="required">*</span>
+                        {{/if}}
+                      </label>
+                    </td>
                     <td>
                       {{password-field value=accountPassword type="password" id="new-account-password" capsLockOn=capsLockOn}}
                     </td>

--- a/app/assets/stylesheets/common/base/user.scss
+++ b/app/assets/stylesheets/common/base/user.scss
@@ -339,6 +339,7 @@
   }
 }
 
+.login-form,
 .user-field {
   .required {
     vertical-align: top;


### PR DESCRIPTION
Had to revert 3ef6068, which accomplished the same thing but caused an issue where having `enable names` _disabled_, and `full name required` _enabled_ broke signup. That was because I had split up:

```javascript
    @discourseComputed
    fullnameRequired() {
      return (
        this.get("siteSettings.full_name_required") ||
        this.get("siteSettings.enable_names")
      );
    },
``` 
This PR does the same thing while keeping the above intact. 

-- --
When custom user fields are required at signup we show an asterisk to label them as required... but we don't do this for our default inputs. For the sake of consistency, this change adds an asterisk to our default sign-up fields only if custom user fields are present. 

This is a compromise between being simple by default, and consistent with added customization. 

![Screen Shot 2020-11-25 at 8 44 52 PM](https://user-images.githubusercontent.com/1681963/100298841-263f9880-2f60-11eb-88fc-f2b91ac80fa5.png)

![Screen Shot 2020-11-25 at 8 45 19 PM](https://user-images.githubusercontent.com/1681963/100298870-35264b00-2f60-11eb-90a7-a1fba6113d7d.png)


Relevant discussion here: https://meta.discourse.org/t/required-should-be-next-to-all-required-fields-in-sign-up-form/126235 and more recently here: https://meta.discourse.org/t/required-fields-not-shown-as-required-during-sign-up/170052

