### PR TITLE
FIX: show retina avatars on Chrome

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/utilities.js
+++ b/app/assets/javascripts/discourse/app/lib/utilities.js
@@ -59,7 +59,13 @@ export function avatarUrl(template, size) {
 
 export function getRawSize(size) {
   const pixelRatio = window.devicePixelRatio || 1;
-  return size * Math.min(3, Math.max(1, Math.round(pixelRatio)));
+  let rawSize = 1;
+  if (pixelRatio > 1.1 && pixelRatio < 2.1) {
+    rawSize = 2;
+  } else if (pixelRatio >= 2.1) {
+    rawSize = 3;
+  }
+  return size * rawSize;
 }
 
 export function avatarImg(options, customGetURL) {


### PR DESCRIPTION
chromium may report float device pixel ratio below 1.5 that is still clearly retina:

```
window.devicePixelRatio
1.4999998807907104
```

We used to round this down to 1 and not provide these browsers with retina avatars.

New algorithm is much more forgiving, anything over 1.1 gets 2x images, anything over 2.1 gets 3x images.
