### PR TITLE
FIX: Show correct user info in post stream bar

### DIFF
--- a/app/assets/javascripts/discourse/app/components/scrolling-post-stream.js
+++ b/app/assets/javascripts/discourse/app/components/scrolling-post-stream.js
@@ -41,6 +41,7 @@ export default MountWidget.extend({
     return this.getProperties(
       "posts",
       "canCreatePost",
+      "filteredPostsCount",
       "multiSelect",
       "gaps",
       "selectedQuery",

--- a/app/assets/javascripts/discourse/app/templates/topic.hbs
+++ b/app/assets/javascripts/discourse/app/templates/topic.hbs
@@ -200,6 +200,7 @@
                 canCreatePost=model.details.can_create_post
                 multiSelect=multiSelect
                 selectedPostsCount=selectedPostsCount
+                filteredPostsCount=model.postStream.filteredPostsCount
                 selectedQuery=selectedQuery
                 gaps=model.postStream.gaps
                 showReadIndicator=model.show_read_indicator

--- a/app/assets/javascripts/discourse/app/widgets/post-stream.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-stream.js
@@ -119,22 +119,24 @@ createWidget("posts-filtered-notice", {
         this.attach("filter-show-all", attrs),
       ];
     } else if (filters.username_filters) {
+      const firstUserPost = attrs.posts[1],
+        userPostsCount = parseInt(attrs.filteredPostsCount, 10) - 1;
       return [
         h(
           "span.filtered-replies-viewing",
           I18n.t("post.filtered_replies.viewing_posts_by", {
-            post_count: attrs.posts.length,
+            post_count: userPostsCount,
           })
         ),
         h(
           "span.filtered-avatar",
           avatarFor.call(this, "small", {
-            template: attrs.posts[0].avatar_template,
-            username: attrs.posts[0].username,
-            url: attrs.posts[0].usernameUrl,
+            template: firstUserPost.avatar_template,
+            username: firstUserPost.username,
+            url: firstUserPost.usernameUrl,
           })
         ),
-        this.attach("poster-name", attrs.posts[0]),
+        this.attach("poster-name", firstUserPost),
         this.attach("filter-show-all", attrs),
       ];
     }
@@ -282,6 +284,7 @@ export default createWidget("post-stream", {
         this.attach("posts-filtered-notice", {
           posts: postArray,
           streamFilters: attrs.streamFilters,
+          filteredPostsCount: attrs.filteredPostsCount,
         })
       );
     }


### PR DESCRIPTION
When filtering by user, the first post in the stream is the OP, so we were showing the wrong user info. 

This also fixes the displayed count of posts when filtered by user (on posts with >20 replies by the same user).

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
