### PR TITLE
DEV: Allow explicit definition of custom import id

### DIFF
--- a/script/import_scripts/base.rb
+++ b/script/import_scripts/base.rb
@@ -525,7 +525,6 @@ class ImportScripts::Base
         skipped += 1
       else
         import_id = params.dig(:custom_fields, :import_id) || params[:id].to_s
-        params.delete[:id]
 
         if post_id_from_imported_post_id(import_id)
           skipped += 1
@@ -563,6 +562,7 @@ class ImportScripts::Base
   STAFF_GUARDIAN ||= Guardian.new(Discourse.system_user)
 
   def create_post(opts, import_id)
+    opts = opts.dup.tap { |o| o.delete(:id) }
     user = User.find(opts[:user_id])
     post_create_action = opts.delete(:post_create_action)
     opts = opts.merge(skip_validations: true)


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->

It's not currently possible to explicitly define a custom import id using the `create_groups`, `create_categories`, `create_users`, and `create_posts` methods in `base.rb`. This may be helpful if one forum has multiple other forums imported into it to differentiate the imported content and avoid import id conflicts.

After running checks here I realize I need to fix tests, so I'll do that yet as well.

