### PR TITLE
FIX: Show quote replies when filtering

### DIFF
--- a/lib/topic_view.rb
+++ b/lib/topic_view.rb
@@ -773,10 +773,12 @@ class TopicView
 
     # Filter replies
     if @replies_to_post_number.present?
+      post_id = filtered_post_id(@replies_to_post_number.to_i)
       @filtered_posts = @filtered_posts.where('
         posts.post_number = 1
         OR posts.post_number = :post_number
-        OR posts.reply_to_post_number = :post_number', { post_number: @replies_to_post_number.to_i })
+        OR posts.reply_to_post_number = :post_number
+        OR posts.id IN (SELECT pr.reply_post_id FROM post_replies pr WHERE pr.post_id = :post_id)', { post_number: @replies_to_post_number.to_i, post_id: post_id })
 
       @contains_gaps = true
     end

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -2105,6 +2105,8 @@ RSpec.describe TopicsController do
         let!(:post3) { Fabricate(:post, topic: topic, reply_to_post_number: post2.post_number) }
         let!(:post4) { Fabricate(:post, topic: topic, reply_to_post_number: post2.post_number) }
         let!(:post5) { Fabricate(:post, topic: topic) }
+        let!(:quote_reply) { Fabricate(:basic_reply, user: user, topic: topic) }
+        let!(:post_reply) { PostReply.create(post_id: post2.id, reply_post_id: quote_reply.id) }
 
         it 'should return the right posts' do
           get "/t/#{topic.id}.json", params: {
@@ -2119,7 +2121,7 @@ RSpec.describe TopicsController do
           expect(body.has_key?("related_messages")).to eq(false)
 
           ids = body["post_stream"]["posts"].map { |p| p["id"] }
-          expect(ids).to eq([post.id, post2.id, post3.id, post4.id])
+          expect(ids).to eq([post.id, post2.id, post3.id, post4.id, quote_reply.id])
         end
       end
 


### PR DESCRIPTION
Only applies when using the `enable_filtered_replies_view` site setting.

The filter query was not accounting for quote replies.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
