### PR TITLE
UX: Tweaks to filtered replies

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/topic.js
+++ b/app/assets/javascripts/discourse/app/controllers/topic.js
@@ -52,7 +52,7 @@ export default Controller.extend(bufferedProperty("model"), {
   multiSelect: false,
   selectedPostIds: null,
   editingTopic: false,
-  queryParams: ["filter", "username_filters"],
+  queryParams: ["filter", "username_filters", "replies_to_post_number"],
   loadedAllPosts: or(
     "model.postStream.loadedAllPosts",
     "model.postStream.loadingLastPost"
@@ -64,6 +64,7 @@ export default Controller.extend(bufferedProperty("model"), {
   _progressIndex: null,
   hasScrolled: null,
   username_filters: null,
+  replies_to_post_number: null,
   filter: null,
   quoteState: null,
 

--- a/app/assets/javascripts/discourse/app/models/post-stream.js
+++ b/app/assets/javascripts/discourse/app/models/post-stream.js
@@ -46,7 +46,8 @@ export default RestModel.extend({
       stream: [],
       userFilters: [],
       summary: false,
-      filterRepliesToPostNumber: false,
+      filterRepliesToPostNumber:
+        parseInt(this.get("topic.replies_to_post_number"), 10) || false,
       filterUpwardsPostID: false,
       loaded: false,
       loadingAbove: false,

--- a/app/assets/javascripts/discourse/app/widgets/post-stream.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-stream.js
@@ -90,8 +90,8 @@ createWidget("posts-filtered-notice", {
       return [
         h(
           "span.filtered-replies-viewing",
-          I18n.t("post.filtered_replies.viewing", {
-            reply_count: sourcePost.reply_count,
+          I18n.t("post.filtered_replies_viewing", {
+            count: sourcePost.reply_count,
           })
         ),
         h("span.filtered-user-row", [

--- a/app/assets/javascripts/discourse/app/widgets/post-stream.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-stream.js
@@ -170,7 +170,7 @@ createWidget("filter-show-all", {
   },
 
   html() {
-    return [iconNode("far-comments"), I18n.t("post.filtered_replies.show_all")];
+    return [iconNode("arrows-alt-v"), I18n.t("post.filtered_replies.show_all")];
   },
 
   click() {

--- a/app/assets/javascripts/discourse/app/widgets/post.js
+++ b/app/assets/javascripts/discourse/app/widgets/post.js
@@ -120,7 +120,7 @@ createWidget("select-post", {
 createWidget("reply-to-tab", {
   tagName: "a.reply-to-tab",
   buildKey: (attrs) => `reply-to-tab-${attrs.id}`,
-
+  title: "post.in_reply_to",
   defaultState() {
     return { loading: false };
   },

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2753,6 +2753,8 @@ en:
         one: "View this post and its reply"
         other: "View this post and its %{count} replies"
 
+      in_reply_to: "Load parent post"
+
       errors:
         create: "Sorry, there was an error creating your post. Please try again."
         edit: "Sorry, there was an error editing your post. Please try again."

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2752,6 +2752,9 @@ en:
       filtered_replies_hint:
         one: "View this post and its reply"
         other: "View this post and its %{count} replies"
+      filtered_replies_viewing:
+          one: "Viewing %{count} reply to"
+          other: "Viewing %{count} replies to"
 
       in_reply_to: "Load parent post"
 
@@ -2926,7 +2929,6 @@ en:
             description: "Edit the bookmark name or change the reminder date and time"
 
       filtered_replies:
-        viewing: "Viewing %{reply_count} replies to"
         viewing_posts_by: "Viewing %{post_count} posts by"
         viewing_subset: "Some replies are collapsed"
         viewing_summary: "Viewing a summary of this topic"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1863,7 +1863,7 @@ en:
     body_min_entropy: "The minimum entropy (unique characters, non-english count for more) required for a post body."
     allow_uppercase_posts: "Allow all caps in a topic title or a post body."
     max_consecutive_replies: "Number of posts a user has to make in a row in a topic before being prevented from adding another reply."
-    enable_filtered_replies_view: "(n) replies button should collapse all other posts and only show the selected replies."
+    enable_filtered_replies_view: '"(n) replies" button collapses all other posts and only shows the current post and its replies.'
 
     title_fancy_entities: "Convert common ASCII characters to fancy HTML entities in topic titles, ala SmartyPants <a href='https://daringfireball.net/projects/smartypants/' target='_blank'>https://daringfireball.net/projects/smartypants/</a>"
 

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -728,7 +728,6 @@ posting:
   enable_filtered_replies_view:
     default: false
     client: true
-    hidden: true
   title_prettify:
     default: true
     locale_default:


### PR DESCRIPTION
- Include the `enable_filtered_replies_view` site setting in the admin UI
- Adds title label to in-reply-to widget
- Invokes the filtered UI when using `replies_to_post_number` as a query
parameter
- Replaces the "Show All" button icon
- Fixes grammar for "Viewing 1 reply to..." label
