### PR TITLE
FIX: Do not forbid tags in /new-topic on mobile

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -1008,7 +1008,7 @@ export default Controller.extend({
         this.model.set("categoryId", opts.topicCategoryId);
       }
 
-      if (opts.topicTags && !this.site.mobileView && this.site.can_tag_topics) {
+      if (opts.topicTags && this.site.can_tag_topics) {
         let tags = escapeExpression(opts.topicTags)
           .split(",")
           .slice(0, this.siteSettings.max_tags_per_topic);


### PR DESCRIPTION
Now that mobile has a UI for tags, there is no longer any reason to forbid setting them via URL.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
