### PR TITLE
UX: remove timeline from print view, fix header in crawler view

### DIFF
--- a/app/assets/stylesheets/common/base/crawler_layout.scss
+++ b/app/assets/stylesheets/common/base/crawler_layout.scss
@@ -1,7 +1,6 @@
 body.crawler {
   > header {
     width: 100%;
-    position: absolute;
     top: 0;
     z-index: z("max");
     background-color: #fff;

--- a/app/assets/stylesheets/common/printer-friendly.scss
+++ b/app/assets/stylesheets/common/printer-friendly.scss
@@ -35,7 +35,8 @@
   .badge-category-bg,
   .badge-notification.clicks,
   .crawler-nav,
-  .powered-by-link {
+  .powered-by-link,
+  .timeline-container {
     display: none !important;
   }
   /* For readability */


### PR DESCRIPTION
Fixes this issue with the timeline (sometimes) showing when printing:

![Screen Shot 2020-12-14 at 9 33 23 PM](https://user-images.githubusercontent.com/1681963/102160839-31e1f900-3e54-11eb-9bbd-694cb48900cf.png)

and this header overlap in crawler view: 

![Screen Shot 2020-12-14 at 9 35 01 PM](https://user-images.githubusercontent.com/1681963/102160932-648bf180-3e54-11eb-90ad-c558ff09be1a.png)

