### PR TITLE
FIX: no email when the category is muted and mailing list is on

### DIFF
--- a/app/jobs/regular/notify_mailing_list_subscribers.rb
+++ b/app/jobs/regular/notify_mailing_list_subscribers.rb
@@ -65,6 +65,10 @@ module Jobs
         users = users.where(approved: true)
       end
 
+      if SiteSetting.mute_all_categories_by_default
+        users = users.watching_topic_when_mute_categories_by_default(post.topic)
+      end
+
       DiscourseEvent.trigger(:notify_mailing_list_subscribers, users, post)
       users.find_each do |user|
         if Guardian.new(user).can_see?(post)

--- a/app/models/topic_tracking_state.rb
+++ b/app/models/topic_tracking_state.rb
@@ -107,11 +107,7 @@ class TopicTrackingState
 
   def self.publish_unmuted(topic)
     return if !SiteSetting.mute_all_categories_by_default
-    user_ids = User
-      .joins(DB.sql_fragment("LEFT JOIN category_users ON category_users.user_id = users.id AND category_users.category_id = :category_id", category_id: topic.category_id))
-      .joins(DB.sql_fragment("LEFT JOIN topic_users ON topic_users.user_id = users.id AND topic_users.topic_id = :topic_id",  topic_id: topic.id))
-      .joins("LEFT JOIN tag_users ON tag_users.user_id = users.id AND tag_users.tag_id IN (#{topic.tag_ids.join(",").presence || 'NULL'})")
-      .where("category_users.notification_level > 0 OR topic_users.notification_level > 0 OR tag_users.notification_level > 0")
+    user_ids = User.watching_topic_when_mute_categories_by_default(topic)
       .where("users.last_seen_at > ?", 7.days.ago)
       .order("users.last_seen_at DESC")
       .limit(100)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -234,6 +234,13 @@ class User < ActiveRecord::Base
     end
   end
 
+  scope :watching_topic_when_mute_categories_by_default, ->(topic) do
+    joins(DB.sql_fragment("LEFT JOIN category_users ON category_users.user_id = users.id AND category_users.category_id = :category_id", category_id: topic.category_id))
+      .joins(DB.sql_fragment("LEFT JOIN topic_users ON topic_users.user_id = users.id AND topic_users.topic_id = :topic_id",  topic_id: topic.id))
+      .joins("LEFT JOIN tag_users ON tag_users.user_id = users.id AND tag_users.tag_id IN (#{topic.tag_ids.join(",").presence || 'NULL'})")
+      .where("category_users.notification_level > 0 OR topic_users.notification_level > 0 OR tag_users.notification_level > 0")
+  end
+
   module NewTopicDuration
     ALWAYS = -1
     LAST_VISIT = -2

--- a/spec/jobs/notify_mailing_list_subscribers_spec.rb
+++ b/spec/jobs/notify_mailing_list_subscribers_spec.rb
@@ -137,6 +137,35 @@ describe Jobs::NotifyMailingListSubscribers do
         include_examples "no emails"
       end
 
+      context "mute all categories by default setting" do
+        before { SiteSetting.mute_all_categories_by_default = true }
+        include_examples "no emails"
+      end
+
+      context "mute all categories by default setting but user is watching category" do
+        before do
+          SiteSetting.mute_all_categories_by_default = true
+          CategoryUser.create(user: mailing_list_user, category: post.topic.category, notification_level: CategoryUser.notification_levels[:watching])
+        end
+        include_examples "one email"
+      end
+
+      context "mute all categories by default setting but user is watching tag" do
+        before do
+          SiteSetting.mute_all_categories_by_default = true
+          TagUser.create(user: mailing_list_user, tag: tag, notification_level: TagUser.notification_levels[:watching])
+        end
+        include_examples "one email"
+      end
+
+      context "mute all categories by default setting but user is watching topic" do
+        before do
+          SiteSetting.mute_all_categories_by_default = true
+          TopicUser.create(user: mailing_list_user, topic: post.topic, notification_level: TopicUser.notification_levels[:watching])
+        end
+        include_examples "one email"
+      end
+
       context "from a muted tag" do
         before { TagUser.create(user: mailing_list_user, tag: tag, notification_level: TagUser.notification_levels[:muted]) }
         include_examples "no emails"


### PR DESCRIPTION
When `mute_all_categories_by_default` setting is enabled we should not send mailing list until category, tag or topic is explicitly watched.
