### PR TITLE
FIX: Bypass `AnonymousCache` for `/srv/status` route.

### DIFF
--- a/lib/middleware/anonymous_cache.rb
+++ b/lib/middleware/anonymous_cache.rb
@@ -163,6 +163,7 @@ module Middleware
       def no_cache_bypass
         request = Rack::Request.new(@env)
         request.cookies['_bypass_cache'].nil? &&
+          (request.path != '/srv/status') &&
           request[Auth::DefaultCurrentUserProvider::API_KEY].nil? &&
           @env[Auth::DefaultCurrentUserProvider::USER_API_KEY].nil?
       end

--- a/spec/components/middleware/anonymous_cache_spec.rb
+++ b/spec/components/middleware/anonymous_cache_spec.rb
@@ -26,6 +26,10 @@ describe Middleware::AnonymousCache do
       it "is false if it has an auth cookie" do
         expect(new_helper("HTTP_COOKIE" => "jack=1; _t=#{"1" * 32}; jill=2").cacheable?).to eq(false)
       end
+
+      it "is false for srv/status routes" do
+        expect(new_helper("PATH_INFO" => "/srv/status").cacheable?).to eq(false)
+      end
     end
 
     context "per theme cache" do


### PR DESCRIPTION
`/srv/status` routes should not be cached at all. Also, we want to
decouple the route from Redis which `AnonymouseCache` relies on. The
`/srv/status` should continue to return a success response even if Redis
is down.