### PR TITLE
FEATURE: Allow plugins to register demon processes

### DIFF
--- a/lib/demon/base.rb
+++ b/lib/demon/base.rb
@@ -141,16 +141,13 @@ class Demon::Base
   end
 
   def run
-    if @pid = fork
-      write_pid_file
-      return
+    @pid = fork do
+      Process.setproctitle("discourse #{self.class.prefix}")
+      monitor_parent
+      establish_app
+      after_fork
     end
-
-    Process.setproctitle("discourse #{self.class.prefix}")
-    monitor_parent
-    establish_app
-    after_fork
-    exit 0 # Otherwise execution will return to wherever `start` was called
+    write_pid_file
   end
 
   def already_running?

--- a/lib/demon/base.rb
+++ b/lib/demon/base.rb
@@ -150,6 +150,7 @@ class Demon::Base
     monitor_parent
     establish_app
     after_fork
+    exit 0 # Otherwise execution will return to wherever `start` was called
   end
 
   def already_running?

--- a/lib/discourse_plugin_registry.rb
+++ b/lib/discourse_plugin_registry.rb
@@ -68,6 +68,7 @@ class DiscoursePluginRegistry
   define_register :vendored_pretty_text, Set
   define_register :vendored_core_pretty_text, Set
   define_register :seedfu_filter, Set
+  define_register :demon_processes, Set
 
   define_filtered_register :staff_user_custom_fields
   define_filtered_register :public_user_custom_fields

--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -861,6 +861,15 @@ class Plugin::Instance
       ), self)
   end
 
+  # Register a new demon process to be forked by the Unicorn master.
+  # The demon_class should inherit from Demon::Base.
+  # With great power comes great responsibility - this method should
+  # be used with extreme caution. See `config/unicorn.conf.rb`.
+  def register_demon_process(demon_class)
+    raise "Not a demon class" if !demon_class.ancestors.include?(Demon::Base)
+    DiscoursePluginRegistry.demon_processes << demon_class
+  end
+
   protected
 
   def self.js_path


### PR DESCRIPTION
This allows plugins to call `register_demon_process` with a Class inheriting from Demon::Base. The unicorn master process will take care of spawning, monitoring and restarting the process. This API should be used with extreme caution, but it is significantly cleaner than spawning processes/threads in an `after_initialize` block.

This commit also cleans up the demon spawning logging so that it uses the same format as unicorn worker logging. It also ensures that Demons exit after running, rather than returning execution to where the fork took place.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
