### PR TITLE
DEV: Add site header organism to styleguide

### DIFF
--- a/plugins/styleguide/assets/javascripts/discourse/lib/dummy-data.js.es6
+++ b/plugins/styleguide/assets/javascripts/discourse/lib/dummy-data.js.es6
@@ -114,7 +114,7 @@ export function createData(store) {
     );
   };
 
-  let topic = createTopic();
+  let topic = createTopic({ tags: ["example", "apple"] });
   topic.setProperties({
     details: EmberObject.create({
       can_create_post: true,

--- a/plugins/styleguide/assets/javascripts/discourse/templates/styleguide/organisms/site-header.hbs
+++ b/plugins/styleguide/assets/javascripts/discourse/templates/styleguide/organisms/site-header.hbs
@@ -1,0 +1,16 @@
+{{#styleguide-example title="site header - in topic - scrolled"}}
+  <div class="d-header-wrap">
+    <header class="d-header">
+      <div class="wrap">
+        <div class="contents">
+          {{mount-widget widget="home-logo" args=(hash minimized=true)}}
+          {{mount-widget widget="header-topic-info" args=dummy}}
+          <div class="panel clearfix">
+            {{mount-widget widget="header-icons" args=(hash user=dummy.user)}}
+          </div>
+        </div>
+      </div>
+    </header>
+  </div>
+{{/styleguide-example}}
+

--- a/plugins/styleguide/config/locales/client.en.yml
+++ b/plugins/styleguide/config/locales/client.en.yml
@@ -65,6 +65,8 @@ en:
           title: "Post"
         topic_map:
           title: "Topic Map"
+        site_header:
+          title: "Site Header"
         suggested_topics:
           title: "Suggested Topics"
         post_menu:


### PR DESCRIPTION
Adds UI to styleguide to preview the site header in a topic, after scrolling (i.e. with topic title/category/tags). 

<img width="946" alt="image" src="https://user-images.githubusercontent.com/368961/102251392-be330100-3ed2-11eb-8979-cc1db23d4bca.png">
