### PR TITLE
FIX: Scroll to the last position when navigating back to the tag topic list.

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-list.js
+++ b/app/assets/javascripts/discourse/app/components/topic-list.js
@@ -1,9 +1,9 @@
 import { alias, reads } from "@ember/object/computed";
+import { debounce, schedule } from "@ember/runloop";
 import discourseComputed, { observes } from "discourse-common/utils/decorators";
 import Component from "@ember/component";
 import LoadMore from "discourse/mixins/load-more";
 import { on } from "@ember/object/evented";
-import { schedule } from "@ember/runloop";
 
 export default Component.extend(LoadMore, {
   tagName: "table",
@@ -73,7 +73,17 @@ export default Component.extend(LoadMore, {
 
     let scrollTo = this.session.get("topicListScrollPosition");
     if (scrollTo && scrollTo >= 0) {
-      schedule("afterRender", () => $(window).scrollTop(scrollTo + 1));
+      schedule("afterRender", () => {
+        debounce(
+          this,
+          function () {
+            if (this.element && !this.isDestroying && !this.isDestroyed) {
+              $(window).scrollTop(scrollTo + 1);
+            }
+          },
+          0
+        );
+      });
     }
   },
 

--- a/app/assets/javascripts/discourse/app/templates/tags/show.hbs
+++ b/app/assets/javascripts/discourse/app/templates/tags/show.hbs
@@ -59,6 +59,7 @@
                   order=order
                   ascending=ascending
                   changeSort=(action "changeSort")
+                  scrollOnLoad=true
                 }}
               {{/discovery-topics-list}}
             {{/if}}


### PR DESCRIPTION
Scrolling was not working as expected after clicking the browser back button and navigating back to the tag topic list. We need to wrap the scroll inside a debounce function to ensure that the "window.pageYOffset" property is populated before our function runs.

