### PR TITLE
FIX: Make find_by_slug_path work with default slugs

### DIFF
--- a/app/assets/javascripts/discourse/app/models/category.js
+++ b/app/assets/javascripts/discourse/app/models/category.js
@@ -495,12 +495,6 @@ Category.reopenClass({
   },
 
   reloadCategoryWithPermissions(params, store, site) {
-    if (params.slug && params.slug.match(/^\d+-category/)) {
-      const id = parseInt(params.slug, 10);
-      return this.reloadById(id).then((result) =>
-        this._includePermissions(result.category, store, site)
-      );
-    }
     return this.reloadBySlugPath(params.slug).then((result) =>
       this._includePermissions(result.category, store, site)
     );

--- a/app/assets/javascripts/discourse/tests/helpers/create-pretender.js
+++ b/app/assets/javascripts/discourse/tests/helpers/create-pretender.js
@@ -313,6 +313,10 @@ export function applyDefaultHandlers(pretender) {
     response(fixturesByUrl["/c/1/show.json"])
   );
 
+  pretender.get("/c/1-category/find_by_slug.json", () =>
+    response(fixturesByUrl["/c/1/show.json"])
+  );
+
   pretender.put("/categories/:category_id", (request) => {
     const category = parsePostData(request.requestBody);
     category.id = parseInt(request.params.category_id, 10);

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -801,10 +801,13 @@ class Category < ActiveRecord::Base
 
     query =
       slug_path.inject(nil) do |parent_id, slug|
-        Category.where(
-          slug: slug,
-          parent_category_id: parent_id,
-        ).select(:id)
+        category = Category.where(slug: slug, parent_category_id: parent_id)
+
+        if match_id = /^(\d+)-category/.match(slug).presence
+          category = category.or(Category.where(id: match_id[1], parent_category_id: parent_id))
+        end
+
+        category.select(:id)
       end
 
     Category.find_by_id(query)

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1185,4 +1185,36 @@ describe Category do
     end
   end
 
+  describe "#find_by_slug_path" do
+    it 'works for categories with slugs' do
+      category = Fabricate(:category, slug: 'cat1')
+
+      expect(Category.find_by_slug_path(['cat1'])).to eq(category)
+    end
+
+    it 'works for categories without slugs' do
+      SiteSetting.slug_generation_method = 'none'
+
+      category = Fabricate(:category, slug: 'cat1')
+
+      expect(Category.find_by_slug_path(["#{category.id}-category"])).to eq(category)
+    end
+
+    it 'works for subcategories with slugs' do
+      category = Fabricate(:category, slug: 'cat1')
+      subcategory = Fabricate(:category, slug: 'cat2', parent_category: category)
+
+      expect(Category.find_by_slug_path(['cat1', 'cat2'])).to eq(subcategory)
+    end
+
+    it 'works for subcategories without slugs' do
+      SiteSetting.slug_generation_method = 'none'
+
+      category = Fabricate(:category, slug: 'cat1')
+      subcategory = Fabricate(:category, slug: 'cat2', parent_category: category)
+
+      expect(Category.find_by_slug_path(['cat1', "#{subcategory.id}-category"])).to eq(subcategory)
+      expect(Category.find_by_slug_path(["#{category.id}-category", "#{subcategory.id}-category"])).to eq(subcategory)
+    end
+  end
 end


### PR DESCRIPTION
Default slugs are generated by adding '-category' to category ID.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
