### PR TITLE
UX: Don't wrap popup-menu button text under icon

### DIFF
--- a/app/assets/stylesheets/common/base/popup-menu.scss
+++ b/app/assets/stylesheets/common/base/popup-menu.scss
@@ -19,6 +19,7 @@
   }
 
   .btn {
+    display: flex;
     text-align: left;
     background: none;
     width: 100%;


### PR DESCRIPTION
This one-line change stops text from wrapping under the icons in popup menus. This is especially noticeable in more verbose languages.

Before:

![image](https://user-images.githubusercontent.com/1681963/102294170-ada47a00-3f16-11eb-8957-05d9c4b5b50e.png)


After:


![Screen Shot 2020-12-15 at 8 47 20 PM](https://user-images.githubusercontent.com/1681963/102294208-c57bfe00-3f16-11eb-98eb-5df921f84e3e.png)