### PR TITLE
UX: Make theme install modal more responsive

### DIFF
--- a/app/assets/stylesheets/common/admin/customize-install-theme.scss
+++ b/app/assets/stylesheets/common/admin/customize-install-theme.scss
@@ -65,8 +65,8 @@
   padding: 0px 0px 10px 20px;
   width: calc(100% - 200px);
   input[type="file"] {
-    width: unset;
-    max-width: 100%;
+    width: 100%;
+    overflow: hidden; // Chrome needs this
   }
 }
 

--- a/app/assets/stylesheets/common/admin/customize-install-theme.scss
+++ b/app/assets/stylesheets/common/admin/customize-install-theme.scss
@@ -1,6 +1,22 @@
+.admin-install-theme-modal {
+  .modal-inner-container {
+    width: 100%;
+  }
+}
+
 .install-theme {
-  min-width: 650px;
   display: flex;
+  @include breakpoint(mobile-extra-large) {
+    .install-theme-items {
+      flex: 0 0 150px;
+    }
+    .install-theme-content {
+      flex: 1 1 100%;
+    }
+    .select-kit {
+      width: 100%;
+    }
+  }
 }
 
 .install-theme-items {
@@ -48,6 +64,10 @@
 .install-theme-content {
   padding: 0px 0px 10px 20px;
   width: calc(100% - 200px);
+  input[type="file"] {
+    width: unset;
+    max-width: 100%;
+  }
 }
 
 .repo {


### PR DESCRIPTION
Two improvements here:

* Make the modal responsive... previously this would scroll horizontally when the browser was less than 700px wide, which made it hard to use on small screens. There's still room for improvement, but it's much easier to use now.

![Screen Shot 2020-12-15 at 9 22 40 PM](https://user-images.githubusercontent.com/1681963/102297245-ed6e6000-3f1c-11eb-83fa-fc1fb973f0a3.png)





* Give more space for uploaded filenames (this cap was previously much smaller than the modal width):
![Screen Shot 2020-12-15 at 9 20 32 PM](https://user-images.githubusercontent.com/1681963/102296972-733ddb80-3f1c-11eb-9065-faf00ac7adca.png)
