### PR TITLE
UX: When input placeholders are too long, truncate with an ellipsis

### DIFF
--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -227,6 +227,10 @@ input {
   }
 }
 
+::placeholder {
+  text-overflow: ellipsis;
+}
+
 .input {
   &-prepend,
   &-append {


### PR DESCRIPTION
This is a global change that targets all placeholders, but since you can't scroll overflowing placeholders I'm not aware of any downsides to making the change everywhere. This is a bigger problem with placeholders in languages more verbose than English.

Before:
![Screen Shot 2020-12-15 at 9 59 36 PM](https://user-images.githubusercontent.com/1681963/102299670-52c45000-3f21-11eb-917e-593b5a28182c.png)

After:
![Screen Shot 2020-12-15 at 9 59 28 PM](https://user-images.githubusercontent.com/1681963/102299669-52c45000-3f21-11eb-9ca4-7ee603f9db9f.png)
