### PR TITLE
UX: Add title attribute to watched word input

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/components/watched-word-form.hbs
+++ b/app/assets/javascripts/admin/addon/templates/components/watched-word-form.hbs
@@ -1,5 +1,5 @@
 <b>{{i18n "admin.watched_words.form.label"}}</b>
-{{text-field value=word disabled=formSubmitted class="watched-word-input" autocorrect="off" autocapitalize="off" placeholderKey=placeholderKey}}
+{{text-field value=word disabled=formSubmitted class="watched-word-input" autocorrect="off" autocapitalize="off" placeholderKey=placeholderKey title=(i18n placeholderKey)}}
 {{d-button class="btn-default" action=(action "submit") disabled=formSubmitted label="admin.watched_words.form.add"}}
 
 {{#if showMessage}}


### PR DESCRIPTION
This is useful for three reasons: 

1. In some languages the placeholder overflows and can't be read completely 
![Screen Shot 2020-12-15 at 10 29 46 PM](https://user-images.githubusercontent.com/1681963/102301577-0aa72c80-3f25-11eb-97cd-f24ed3095f8c.png)


2. When text is input, the placeholder is no longer available... so this is an alternative option
![Screen Shot 2020-12-15 at 10 28 36 PM](https://user-images.githubusercontent.com/1681963/102301506-e2b7c900-3f24-11eb-8d61-3a506ea0e53d.png)

3. Screen readers read title text, but not placeholders
