### PR TITLE
DEV: no need to iterate through each tag for rendering

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/full-page-search.hbs
+++ b/app/assets/javascripts/discourse/app/templates/full-page-search.hbs
@@ -104,9 +104,9 @@
                       {{category-link result.topic.category.parentCategory}}
                     {{/if}}
                     {{category-link result.topic.category hideParent=true}}
-                    {{#each result.topic.tags as |tag|}}
-                      {{discourse-tag tag isPrivateMessage=isPrivateMessage}}
-                    {{/each}}
+                    {{#if result.topic.tags}}
+                      {{discourse-tags result.topic}}
+                    {{/if}}
                     {{plugin-outlet name="full-page-search-category" args=(hash result=result)}}
                   </div>
                 </div>

--- a/app/assets/stylesheets/common/base/search.scss
+++ b/app/assets/stylesheets/common/base/search.scss
@@ -226,6 +226,17 @@
     }
   }
 
+  .discourse-tags {
+    flex-wrap: wrap;
+    display: inline-flex;
+    font-weight: normal;
+
+    .discourse-tag.simple {
+      font-size: $font-down-1;
+      margin-right: 0.25em;
+    }
+  }
+
   input[type="checkbox"] {
     margin-top: 0;
     margin-left: 0;


### PR DESCRIPTION
This commit allows discourse-assign plugin to show assigned user next to tags.
