### PR TITLE
FIX: missing default notification level on group creation

### DIFF
--- a/app/assets/javascripts/discourse/app/components/groups-form-interaction-fields.js
+++ b/app/assets/javascripts/discourse/app/components/groups-form-interaction-fields.js
@@ -1,5 +1,6 @@
 import Component from "@ember/component";
 import I18n from "I18n";
+import { NotificationLevels } from "discourse/lib/notification-levels";
 import discourseComputed from "discourse-common/utils/decorators";
 import { or } from "@ember/object/computed";
 
@@ -46,6 +47,8 @@ export default Component.extend({
       { name: I18n.t("groups.alias_levels.owners_mods_and_admins"), value: 4 },
       { name: I18n.t("groups.alias_levels.everyone"), value: 99 },
     ];
+
+    this.watchingNotificationLevel = NotificationLevels.WATCHING;
   },
 
   membersVisibilityLevel: or(
@@ -61,6 +64,11 @@ export default Component.extend({
   mentionableLevel: or(
     "model.mentionable_level",
     "aliasLevelOptions.firstObject.value"
+  ),
+
+  defaultNotificationLevel: or(
+    "model.default_notification_level",
+    "watchingNotificationLevel"
   ),
 
   @discourseComputed(

--- a/app/assets/javascripts/discourse/app/templates/components/groups-form-interaction-fields.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/groups-form-interaction-fields.hbs
@@ -94,10 +94,11 @@
   <label>{{i18n "groups.notification_level"}}</label>
 
   {{notifications-button
-    value=model.default_notification_level
+    value=defaultNotificationLevel
     class="groups-form-default-notification-level"
     options=(hash
       i18nPrefix="groups.notifications"
     )
+    onChange=(action (mut model.default_notification_level))
   }}
 </div>

--- a/app/assets/javascripts/discourse/tests/acceptance/groups-new-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/groups-new-test.js
@@ -74,5 +74,12 @@ acceptance("New Group - Authenticated", function (needs) {
       0,
       "it should disable the membership requests checkbox"
     );
+
+    assert.ok(
+      queryAll(".groups-form-default-notification-level .selected-name .name")
+        .text()
+        .trim() === I18n.t("groups.notifications.watching.title"),
+      "it has a default selection for notification level"
+    );
   });
 });


### PR DESCRIPTION
Before
<img width="322" alt="image" src="https://user-images.githubusercontent.com/368961/102395983-d6c21a80-3fa9-11eb-8c6f-2ae214b23821.png">


After
<img width="346" alt="image" src="https://user-images.githubusercontent.com/368961/102395921-c14cf080-3fa9-11eb-92f9-29c20f7dae17.png">
