### PR TITLE
DEV: stop warning about overwriting Kernel.open

### DIFF
--- a/plugins/poll/app/models/poll.rb
+++ b/plugins/poll/app/models/poll.rb
@@ -15,6 +15,10 @@ class Poll < ActiveRecord::Base
     number: 2,
   }
 
+  class << self
+    undef open
+  end
+
   enum status: {
     open: 0,
     closed: 1,


### PR DESCRIPTION
Enums for the status column will create a new method "open", which logs
a warning about overwriting the Kernel.open method.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
