### PR TITLE
FIX: Clear in-process theme cache after clearing DB cache

### DIFF
--- a/app/models/theme_translation_override.rb
+++ b/app/models/theme_translation_override.rb
@@ -4,9 +4,9 @@ class ThemeTranslationOverride < ActiveRecord::Base
   belongs_to :theme
 
   after_commit do
+    theme.theme_fields.where(target_id: Theme.targets[:translations]).update_all(value_baked: nil)
     theme.clear_cached_settings!
     theme.remove_from_cache!
-    theme.theme_fields.where(target_id: Theme.targets[:translations]).update_all(value_baked: nil)
   end
 end
 


### PR DESCRIPTION
If we clear the in-process cache first, it might get re-filled from the
DB before we clear the DB cache. This would be more likely on high-traffic
sites.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
