### PR TITLE
DEV: Adds raw plugin outlets to topic list headers

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/topic-list-header.hbr
+++ b/app/assets/javascripts/discourse/app/templates/topic-list-header.hbr
@@ -1,3 +1,4 @@
+{{~raw-plugin-outlet name="topic-list-header-before"~}}
 {{#if bulkSelectEnabled}}
   <th class="bulk-select">
     {{#if canBulkSelect}}
@@ -18,3 +19,4 @@
 {{/if}}
 {{raw "topic-list-header-column" sortable=sortable number='true' order='views' name='views'}}
 {{raw "topic-list-header-column" sortable=sortable number='true' order='activity' name='activity'}}
+{{~raw-plugin-outlet name="topic-list-header-after"~}}


### PR DESCRIPTION
This PR adds a couple of raw plugin outlets to topic list headers to avoid template overrides.
