### PR TITLE
FEATURE: allow plugins to show custom HTML via renderTags

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/full-page-search.hbs
+++ b/app/assets/javascripts/discourse/app/templates/full-page-search.hbs
@@ -104,7 +104,7 @@
                       {{category-link result.topic.category.parentCategory}}
                     {{/if}}
                     {{category-link result.topic.category hideParent=true}}
-                    {{#if result.topic.tags}}
+                    {{#if result.topic}}
                       {{discourse-tags result.topic}}
                     {{/if}}
                     {{plugin-outlet name="full-page-search-category" args=(hash result=result)}}


### PR DESCRIPTION
This commit allows discourse-assign plugin to show custom HTML via renderTags even if topic has no tags.

