### PR TITLE
FEATURE: Enable inline Onebox for all domains by default

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1605,7 +1605,7 @@ onebox:
     type: list
     list_type: compact
   enable_inline_onebox_on_all_domains:
-    default: false
+    default: true
   force_custom_user_agent_hosts:
     default: "http://codepen.io"
     type: list

--- a/lib/inline_oneboxer.rb
+++ b/lib/inline_oneboxer.rb
@@ -42,6 +42,9 @@ class InlineOneboxer
             opts[:post_author] = post_author_for_title(topic, post_number)
           end
           return onebox_for(url, topic.title, opts)
+        else
+          # not permitted to see topic
+          return nil
         end
       end
     end

--- a/spec/components/inline_oneboxer_spec.rb
+++ b/spec/components/inline_oneboxer_spec.rb
@@ -148,6 +148,7 @@ describe InlineOneboxer do
     end
 
     it "will not crawl domains that aren't allowlisted" do
+      SiteSetting.enable_inline_onebox_on_all_domains = false
       onebox = InlineOneboxer.lookup("https://eviltrout.com", skip_cache: true)
       expect(onebox).to be_blank
     end


### PR DESCRIPTION
Meta topic: https://meta.discourse.org/t/add-easier-way-of-linking-previous-comments/172601?u=osama