### PR TITLE
UX: Move reply filter button on mobile

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/post-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-menu.js
@@ -558,7 +558,11 @@ export default createWidget("post-menu", {
 
     const repliesButton = this.attachButton("replies", attrs);
     if (repliesButton) {
-      postControls.push(repliesButton);
+      if (!this.site.mobileView) {
+        postControls.push(repliesButton);
+      } else {
+        visibleButtons.splice(-1, 0, repliesButton);
+      }
     }
 
     const extraControls = applyDecorators(this, "extra-controls", attrs, state);

--- a/app/assets/stylesheets/mobile/topic-post.scss
+++ b/app/assets/stylesheets/mobile/topic-post.scss
@@ -106,9 +106,12 @@ span.badge-posts {
       display: flex;
       align-items: center;
       .show-replies {
+        margin-left: auto;
         display: flex;
-        padding: 8px;
         font-size: $font-up-1;
+        + .reply {
+          margin-left: 0;
+        }
         .d-icon {
           padding-left: 8px;
         }


### PR DESCRIPTION
Places the button next to the reply icon. Previously the button was placed to the very left of the row, and it meant that users would misclick when trying to invoke the Like action. 

<img src="https://user-images.githubusercontent.com/368961/102562867-ff2f3f00-40a5-11eb-846d-4779f34806df.png" width="300" />
