### PR TITLE
FIX: Re-run remove flag and queued post web hook migrations.

### DIFF
--- a/db/migrate/20201218000000_remove_flag_web_hooks.rb
+++ b/db/migrate/20201218000000_remove_flag_web_hooks.rb
@@ -4,12 +4,12 @@ class RemoveFlagWebHooks < ActiveRecord::Migration[6.0]
   def up
     flag_event_type_id = 7
 
-    DB.exec <<~SQL
+    execute <<~SQL
     DELETE FROM web_hook_event_types_hooks
     WHERE web_hook_event_type_id = #{flag_event_type_id}
     SQL
 
-    DB.exec <<~SQL
+    execute <<~SQL
     DELETE FROM web_hook_event_types
     WHERE id = #{flag_event_type_id}
     SQL

--- a/db/migrate/20201218000001_remove_queued_post_web_hooks.rb
+++ b/db/migrate/20201218000001_remove_queued_post_web_hooks.rb
@@ -4,12 +4,12 @@ class RemoveQueuedPostWebHooks < ActiveRecord::Migration[6.0]
   def up
     queued_post_event_type_id = 8
 
-    DB.exec <<~SQL
+    execute <<~SQL
     DELETE FROM web_hook_event_types_hooks
     WHERE web_hook_event_type_id = #{queued_post_event_type_id}
     SQL
 
-    DB.exec <<~SQL
+    execute <<~SQL
     DELETE FROM web_hook_event_types
     WHERE id = #{queued_post_event_type_id}
     SQL


### PR DESCRIPTION
There have been production instances where the migrations has run but the records
that were meant to be deleted have not been deleted. The root cause is
unknown but the migration is safe and simple to re-run. The problem is
not reproducible locally so we're not spending too much time on digging
up the root. Time vs business cost tradeoff.

Follow-up fb15da43da1a4f8f733812dc4af455f27e756418