### PR TITLE
UX: adjust default menu width

### DIFF
--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -28,7 +28,7 @@
   background-color: var(--secondary);
   z-index: z("header");
   padding: 0.5em;
-  width: 300px;
+  width: 320px;
   overflow: hidden;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
The notification panel gets resized and the JS uses maxWidth of 320.

This tends to fight with the CSS causing notifications to "jump" a bit when a new one lands.
