### PR TITLE
Not rm Chinese stopwords s.t. not mess up search data

### DIFF
--- a/lib/search.rb
+++ b/lib/search.rb
@@ -81,11 +81,7 @@ class Search
         # TODO: we still want to tokenize here but the current stopword list is too wide
         # in cppjieba leading to words such as volume to be skipped. PG already has an English
         # stopword list so use that vs relying on cppjieba
-        if ts_config != 'english'
-          data = CppjiebaRb.filter_stop_word(data)
-        else
-          data = data.filter { |s| s.present? }
-        end
+        data = data.filter { |s| s.present? }
 
         data = data.join(' ')
 


### PR DESCRIPTION
Follow the suggestion https://meta.discourse.org/t/chinese-search-excerpts-appear-broken/169866/9?u=yiksanchan

I will add a few tests shortly.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
