### PR TITLE
FIX: keep chinese stopwords on search

### DIFF
--- a/lib/search.rb
+++ b/lib/search.rb
@@ -77,16 +77,7 @@ class Search
         require 'cppjieba_rb' unless defined? CppjiebaRb
         mode = (purpose == :query ? :query : :mix)
         data = CppjiebaRb.segment(search_data, mode: mode)
-
-        # TODO: we still want to tokenize here but the current stopword list is too wide
-        # in cppjieba leading to words such as volume to be skipped. PG already has an English
-        # stopword list so use that vs relying on cppjieba
-        if ts_config != 'english'
-          data = CppjiebaRb.filter_stop_word(data)
-        else
-          data = data.filter { |s| s.present? }
-        end
-
+        data = data.filter { |s| s.present? }
         data = data.join(' ')
 
       else

--- a/spec/components/search_spec.rb
+++ b/spec/components/search_spec.rb
@@ -1086,25 +1086,25 @@ describe Search do
     let(:sentence) { 'Discourse中国的基础设施网络正在组装' }
     let(:sentence_t) { 'Discourse太平山森林遊樂區' }
 
-    it 'splits English / Chinese and filter out stop words' do
+    it 'splits English / Chinese' do
       SiteSetting.default_locale = 'zh_CN'
       data = Search.prepare_data(sentence).split(' ')
-      expect(data).to eq(["Discourse", "中国", "基础", "设施", "基础设施", "网络", "正在", "组装"])
+      expect(data).to eq(["Discourse", "中国", "的", "基础", "设施", "基础设施", "网络", "正在", "组装"])
     end
 
-    it 'splits for indexing and filter out stop words' do
+    it 'splits for indexing' do
       SiteSetting.default_locale = 'zh_CN'
       data = Search.prepare_data(sentence, :index).split(' ')
-      expect(data).to eq(["Discourse", "中国", "基础设施", "网络", "正在", "组装"])
+      expect(data).to eq(["Discourse", "中国", "的", "基础设施", "网络", "正在", "组装"])
     end
 
-    it 'splits English / Traditional Chinese and filter out stop words' do
+    it 'splits English / Traditional Chinese' do
       SiteSetting.default_locale = 'zh_TW'
       data = Search.prepare_data(sentence_t).split(' ')
       expect(data).to eq(["Discourse", "太平", "平山", "太平山", "森林", "遊樂區"])
     end
 
-    it 'splits for indexing and filter out stop words' do
+    it 'splits for indexing' do
       SiteSetting.default_locale = 'zh_TW'
       data = Search.prepare_data(sentence_t, :index).split(' ')
       expect(data).to eq(["Discourse", "太平山", "森林", "遊樂區"])

--- a/spec/lib/search_spec.rb
+++ b/spec/lib/search_spec.rb
@@ -14,7 +14,7 @@ describe Search do
       SiteSetting.default_locale = 'zh_CN'
 
       tokenized = Search.prepare_data("monkey 吃香蕉 in a loud volume")
-      expect(tokenized).to eq("monkey 吃 香蕉 loud")
+      expect(tokenized).to eq("monkey 吃 香蕉 in a loud volume")
     end
   end
 


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
