### PR TITLE
FIX: Show restricted tags in bulk select

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/tags/show.hbs
+++ b/app/assets/javascripts/discourse/app/templates/tags/show.hbs
@@ -48,7 +48,7 @@
           {{#unless loading}}
             {{#if list.topics}}
               {{#discovery-topics-list model=list refresh=(action "refresh")}}
-                {{bulk-select-button selected=selected action=(action "refresh")}}
+                {{bulk-select-button selected=selected action=(action "refresh") category=category}}
                 {{topic-list
                   topics=list.topics
                   canBulkSelect=canBulkSelect


### PR DESCRIPTION
Navigating to a category and tag page, selecting topics and attempting
to bulk append a tag showed all but the tags restricted to the category.
