### PR TITLE
FEATURE: Sort search by oldest bumped topic

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/full-page-search.js
+++ b/app/assets/javascripts/discourse/app/controllers/full-page-search.js
@@ -22,6 +22,7 @@ const SortOrders = [
   { name: I18n.t("search.most_liked"), id: 2, term: "order:likes" },
   { name: I18n.t("search.most_viewed"), id: 3, term: "order:views" },
   { name: I18n.t("search.latest_topic"), id: 4, term: "order:latest_topic" },
+  { name: I18n.t("search.oldest_topic"), id: 5, term: "order:oldest" },
 ];
 const PAGE_LIMIT = 10;
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2084,6 +2084,7 @@ en:
       relevance: "Relevance"
       latest_post: "Latest Post"
       latest_topic: "Latest Topic"
+      oldest_topic: "Oldest Update"
       most_viewed: "Most Viewed"
       most_liked: "Most Liked"
       select_all: "Select All"

--- a/lib/search.rb
+++ b/lib/search.rb
@@ -986,6 +986,19 @@ class Search
           )
           .order("created_at DESC")
       end
+    elsif @order == :oldest
+      posts = posts.reorder("topics.bumped_at ASC")
+
+      if aggregate_search
+        posts = posts.select("topics.bumped_at topic_bumped_at")
+
+        aggregate_relation = aggregate_relation
+          .select(
+            "MIN(subquery.post_number) post_number",
+            "MAX(subquery.topic_bumped_at) topic_bumped_at"
+          )
+          .order("topic_bumped_at ASC")
+      end
     elsif @order == :latest_topic
       posts = posts.order("topics.created_at DESC")
 

--- a/spec/components/search_spec.rb
+++ b/spec/components/search_spec.rb
@@ -1424,6 +1424,34 @@ describe Search do
       ])
     end
 
+    it 'can order by oldest updated topic' do
+      first_ts = 2.months.ago
+      second_ts = 2.days.ago
+      third_ts = 2.minutes.ago
+
+      freeze_time first_ts
+      topic = Fabricate(:topic)
+      topic2 = Fabricate(:topic)
+      topic3 = Fabricate(:topic)
+      post = Fabricate(:post, raw: 'Topic', topic: topic)
+      post2 = Fabricate(:post, raw: 'Topic', topic: topic2)
+      post3 = Fabricate(:post, raw: 'Topic', topic: topic3)
+      freeze_time second_ts
+      post3b = Fabricate(:post, raw: 'no match to search', topic: topic3)
+      freeze_time third_ts
+      post1b = Fabricate(:post, raw: 'no match to search', topic: topic)
+
+      [topic, topic2, topic3].each(&:reset_bumped_at)
+
+      puts topic.bumped_at, topic2.bumped_at, topic3.bumped_at
+
+      expect(Search.execute('Topic order:oldest').posts.map(&:id)).to eq([
+        post2.id,
+        post3.id,
+        post.id
+      ])
+    end
+
     it 'can filter by topic views' do
       topic = Fabricate(:topic, views: 100)
       topic2 = Fabricate(:topic, views: 200)


### PR DESCRIPTION
The new 'order:oldest' qualifier will return posts in topics that have gone the longest without any new posts, using the bumped_at field.
This can be used in conjunction with other search terms and operators (e.g. status:open) to create a cycling work queue.

Requested on Meta: https://meta.discourse.org/t/add-orderdesc-modification-to-advanced-search/38545/5?u=riking

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
