### PR TITLE
FIX: allow for final sigma in suggested usernames

### DIFF
--- a/lib/user_name_suggester.rb
+++ b/lib/user_name_suggester.rb
@@ -110,6 +110,14 @@ module UserNameSuggester
 
     if SiteSetting.unicode_usernames
       name.unicode_normalize!
+
+      # TODO: Jan 2022, review if still needed
+      # see: https://meta.discourse.org/t/unicode-username-with-as-the-final-char-leads-to-an-error-loading-profile-page/173182
+      if name.include?('Σ')
+        ctx = MiniRacer::Context.new
+        name = ctx.eval("#{name.inspect}.toLowerCase()")
+        ctx.dispose
+      end
     else
       name = ActiveSupport::Inflector.transliterate(name)
     end

--- a/lib/user_name_suggester.rb
+++ b/lib/user_name_suggester.rb
@@ -115,7 +115,7 @@ module UserNameSuggester
       # see: https://meta.discourse.org/t/unicode-username-with-as-the-final-char-leads-to-an-error-loading-profile-page/173182
       if name.include?('Σ')
         ctx = MiniRacer::Context.new
-        name = ctx.eval("#{name.inspect}.toLowerCase()")
+        name = ctx.eval("#{name.to_s.to_json}.toLowerCase()")
         ctx.dispose
       end
     else

--- a/spec/components/user_name_suggester_spec.rb
+++ b/spec/components/user_name_suggester_spec.rb
@@ -128,6 +128,10 @@ describe UserNameSuggester do
     context "with Unicode usernames enabled" do
       before { SiteSetting.unicode_usernames = true }
 
+      it "normalizes unicode usernames with Σ to lowercase" do
+        expect(UserNameSuggester.suggest('ΣΣ\'"ΣΣ')).to eq('σς_σς')
+      end
+
       it "does not transliterate" do
         expect(UserNameSuggester.suggest("Jørn")).to eq('Jørn')
       end


### PR DESCRIPTION
Final sigma is not lower cased correctly in Ruby causing issues with routing.

This works around the issue by downcasing all usernames containing a sigma using JS.
