### PR TITLE
FEATURE: special shortcut for searching for own posts

### DIFF
--- a/lib/search.rb
+++ b/lib/search.rb
@@ -617,7 +617,14 @@ class Search
   end
 
   advanced_filter(/^\@([a-zA-Z0-9_\-.]+)$/i) do |posts, match|
-    user_id = User.where(staged: false).where(username_lower: match.downcase).pluck_first(:id)
+    username = match.downcase
+
+    user_id = User.where(staged: false).where(username_lower: username).pluck_first(:id)
+
+    if !user_id && username == "me"
+      user_id = @guardian.user&.id
+    end
+
     if user_id
       posts.where("posts.user_id = #{user_id}")
     else

--- a/spec/components/search_spec.rb
+++ b/spec/components/search_spec.rb
@@ -308,7 +308,7 @@ describe Search do
     context 'personal_messages filter' do
       it 'does not allow a normal user to search for personal messages of another user' do
         expect do
-          results = Search.execute(
+          Search.execute(
             "mars personal_messages:#{post.user.username}",
             guardian: Guardian.new(Fabricate(:user))
           )
@@ -397,16 +397,21 @@ describe Search do
       it 'can filter direct PMs by @username' do
         pm = create_pm(users: [current, participant])
         pm_2 = create_pm(users: [participant, current])
-        _pm_3 = create_pm(users: [participant_2, current])
+        pm_3 = create_pm(users: [participant_2, current])
         [
           "@#{participant.username} in:personal-direct",
-          "@#{participant.username} iN:pErSoNaL-dIrEcT"
+          "@#{participant.username} iN:pErSoNaL-dIrEcT",
         ].each do |query|
           results = Search.execute(query, guardian: Guardian.new(current))
           expect(results.posts.size).to eq(2)
-          expect(results.posts.map(&:topic_id)).to eq([pm_2.id, pm.id])
+          expect(results.posts.map(&:topic_id)).to contain_exactly(pm_2.id, pm.id)
           expect(results.posts.map(&:user_id).uniq).to eq([participant.id])
         end
+
+        results = Search.execute("@me in:personal-direct", guardian: Guardian.new(current))
+        expect(results.posts.size).to eq(3)
+        expect(results.posts.map(&:topic_id)).to contain_exactly(pm_3.id, pm_2.id, pm.id)
+        expect(results.posts.map(&:user_id).uniq).to eq([current.id])
       end
 
       it "doesn't include PMs that have more than 2 participants" do
@@ -584,7 +589,7 @@ describe Search do
     end
 
     it 'aggregates searches in a topic by returning the post with the highest rank' do
-      post = Fabricate(:post, topic: topic, raw: "this is a play post")
+      _post = Fabricate(:post, topic: topic, raw: "this is a play post")
       post2 = Fabricate(:post, topic: topic, raw: "play play playing played play")
       post3 = Fabricate(:post, raw: "this is a play post")
 
@@ -1144,9 +1149,6 @@ describe Search do
       _post = Fabricate(:post, raw: 'boom boom shake the room', topic: topic)
 
       topic.update_pinned(true)
-
-      user = Fabricate(:user)
-      guardian = Guardian.new(user)
 
       expect(Search.execute('boom in:pinned').posts.length).to eq(1)
       expect(Search.execute('boom IN:PINNED').posts.length).to eq(1)
@@ -1727,7 +1729,7 @@ describe Search do
   context 'in:title' do
     it 'allows for search in title' do
       topic = Fabricate(:topic, title: 'I am testing a title search')
-      post2 = Fabricate(:post, topic: topic, raw: 'this is the second post', post_number: 2)
+      _post2 = Fabricate(:post, topic: topic, raw: 'this is the second post', post_number: 2)
       post = Fabricate(:post, topic: topic, raw: 'this is the first post', post_number: 1)
 
       results = Search.execute('title in:title')


### PR DESCRIPTION
You can now use `@me` to search for posts created by yourself, this is particularly handy if you have a long username.

`@me rainbow` will find all posts you created with the word rainbow.

Also cleans up test suite so it has no warnings.
