### PR TITLE
DEV: require fileutils gem on boot

### DIFF
--- a/bin/unicorn
+++ b/bin/unicorn
@@ -9,6 +9,7 @@ RAILS_ROOT = File.expand_path("../../", Pathname.new(__FILE__).realpath)
 require 'rubygems'
 require 'bundler/setup'
 require 'digest'
+require 'fileutils'
 
 dev_mode = false
 


### PR DESCRIPTION
Quite a few devs [are seeing](https://meta.discourse.org/t/beginners-guide-to-install-discourse-on-ubuntu-for-development/14727/439?u=techapj) `uninitialized constant FileUtils (NameError)` error on boot (myself included on M1 mac). I guess there's no harm in requiring `fileutils` explicitly?