### PR TITLE
FIX: Search topic title headline being truncated.

### DIFF
--- a/lib/search.rb
+++ b/lib/search.rb
@@ -1272,7 +1272,7 @@ class Search
             #{ts_config},
             t1.fancy_title,
             PLAINTO_TSQUERY(#{ts_config}, '#{search_term}'),
-            'StartSel=''<span class=\"#{HIGHLIGHT_CSS_CLASS}\">'', StopSel=''</span>'''
+            'StartSel=''<span class=\"#{HIGHLIGHT_CSS_CLASS}\">'', StopSel=''</span>'', HighlightAll=true'
           ) AS topic_title_headline",
           "TS_HEADLINE(
             #{ts_config},

--- a/spec/components/search_spec.rb
+++ b/spec/components/search_spec.rb
@@ -537,6 +537,19 @@ describe Search do
       expect(post.headline.include?('elephant')).to eq(false)
     end
 
+    it "does not truncate topic title when applying highlights" do
+      SiteSetting.use_pg_headlines_for_excerpt = true
+
+      topic = reply.topic
+      topic.update!(title: "#{'very ' * 7}long topic title with our search term in the middle of the title")
+
+      result = Search.execute('search term')
+
+      expect(result.posts.first.topic_title_headline).to eq(<<~TITLE.chomp)
+      Very very very very very very very long topic title with our <span class=\"#{Search::HIGHLIGHT_CSS_CLASS}\">search</span> <span class=\"#{Search::HIGHLIGHT_CSS_CLASS}\">term</span> in the middle of the title
+      TITLE
+    end
+
     it "limits the search headline to #{Search::GroupedSearchResults::BLURB_LENGTH} characters" do
       SiteSetting.use_pg_headlines_for_excerpt = true
 


### PR DESCRIPTION
Need to apply the `HighlightAll` option in order to avoid topic titles
from truncated in headlines when displaying search results.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
