### PR TITLE
FIX: Missing PG topic title headline when pg headlines is enabled.

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/search-menu-results.js
+++ b/app/assets/javascripts/discourse/app/widgets/search-menu-results.js
@@ -151,7 +151,10 @@ createSearchResult({
       h(
         "span.topic-title",
         { attributes: { "data-topic-id": topic.id } },
-        new Highlighted(topic.fancyTitle, term)
+        this.siteSettings.use_pg_headlines_for_excerpt &&
+          result.topic_title_headline
+          ? new RawHtml({ html: `<span>${result.topic_title_headline}</span>` })
+          : new Highlighted(topic.fancyTitle, term)
       ),
     ];
 


### PR DESCRIPTION
Our search fixtures for JS test is outdated and does not reflect the actual payload that the server application is sending down. We should fix it at some point but I really need to get this fix out without taking a huge detour.