### PR TITLE
DEV: Remove with_deleted workarounds for old Rails version

### DIFF
--- a/app/models/concerns/trashable.rb
+++ b/app/models/concerns/trashable.rb
@@ -4,29 +4,10 @@ module Trashable
   extend ActiveSupport::Concern
 
   included do
-    default_scope { where(with_deleted_scope_sql) }
+    default_scope { where(deleted_at: nil) }
+    scope :with_deleted, -> { unscope(where: :deleted_at) }
 
-    # scope unscoped does not work
     belongs_to :deleted_by, class_name: 'User'
-  end
-
-  module ClassMethods
-    def with_deleted
-      # lifted from acts_as_paranoid, works around https://github.com/rails/rails/issues/4306
-      #
-      # with this in place Post.limit(10).with_deleted, will work as expected
-      #
-      scope = self.all
-
-      # must use :send here cause predicates is protected
-      # careful with updates of this API
-      scope.where_clause.send(:predicates).delete(with_deleted_scope_sql)
-      scope
-    end
-
-    def with_deleted_scope_sql
-      all.table[:deleted_at].eq(nil).to_sql
-    end
   end
 
   def trashed?

--- a/app/models/topic_tracking_state.rb
+++ b/app/models/topic_tracking_state.rb
@@ -235,7 +235,7 @@ class TopicTrackingState
                 always: User::NewTopicDuration::ALWAYS,
                 default_duration: SiteSetting.default_other_new_topic_duration_minutes,
                 min_date: Time.at(SiteSetting.min_new_topics_time).to_datetime
-              ).where_clause.send(:predicates)[0]
+              ).where_clause.ast.to_sql
   end
 
   def self.include_tags_in_report?
@@ -313,8 +313,7 @@ class TopicTrackingState
       else
         TopicQuery
           .unread_filter(Topic, -999, staff: opts && opts[:staff])
-          .where_clause.send(:predicates)
-          .join(" AND ")
+          .where_clause.ast.to_sql
           .gsub("-999", ":user_id")
       end
 
@@ -329,7 +328,7 @@ class TopicTrackingState
       if opts[:skip_new]
         "1=0"
       else
-        TopicQuery.new_filter(Topic, "xxx").where_clause.send(:predicates).join(" AND ").gsub!("'xxx'", treat_as_new_topic_clause) +
+        TopicQuery.new_filter(Topic, "xxx").where_clause.ast.to_sql.gsub!("'xxx'", treat_as_new_topic_clause) +
           " AND topics.created_at > :min_new_topic_date" +
           " AND (category_users.last_seen_at IS NULL OR topics.created_at > category_users.last_seen_at)"
       end

--- a/plugins/poll/app/models/poll.rb
+++ b/plugins/poll/app/models/poll.rb
@@ -4,7 +4,7 @@ class Poll < ActiveRecord::Base
   # because we want to use the 'type' column and don't want to use STI
   self.inheritance_column = nil
 
-  belongs_to :post, -> { unscope(:where) }
+  belongs_to :post, -> { with_deleted }
 
   has_many :poll_options, -> { order(:id) }, dependent: :destroy
   has_many :poll_votes


### PR DESCRIPTION
These workarounds using private APIs are no longer required in the latest version of Rails. The referenced issue (https://github.com/rails/rails/issues/4306) was closed in 2013. The acts_as_paranoid workaround which this was based on was removed for rails > 5.

Switching to using a scope also allows us to use it within a `belongs_to` relation (e.g. in the Poll model). This avoids issues which can be caused by unscoping all `where` clauses.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
