### PR TITLE
FIX: when the user is deleted anonymise category post

### DIFF
--- a/app/services/user_destroyer.rb
+++ b/app/services/user_destroyer.rb
@@ -52,7 +52,7 @@ class UserDestroyer
           end
 
           if post.is_first_post? && category_topic_ids.include?(post.topic_id)
-            post.update(user: Discourse.system_user)
+            post.update!(user: Discourse.system_user)
           else
             PostDestroyer.new(@actor.staff? ? @actor : Discourse.system_user, post).destroy
           end

--- a/app/services/user_destroyer.rb
+++ b/app/services/user_destroyer.rb
@@ -32,6 +32,8 @@ class UserDestroyer
       Draft.where(user_id: user.id).delete_all
       Reviewable.where(created_by_id: user.id).delete_all
 
+      category_topic_ids = Category.all.pluck(:topic_id).compact
+
       if opts[:delete_posts]
         user.posts.each do |post|
 
@@ -49,7 +51,11 @@ class UserDestroyer
             end
           end
 
-          PostDestroyer.new(@actor.staff? ? @actor : Discourse.system_user, post).destroy
+          if post.is_first_post? && category_topic_ids.include?(post.topic_id)
+            post.update(user: Discourse.system_user)
+          else
+            PostDestroyer.new(@actor.staff? ? @actor : Discourse.system_user, post).destroy
+          end
 
           if post.topic && post.is_first_post?
             Topic.unscoped.where(id: post.topic_id).update_all(user_id: nil)

--- a/app/services/user_destroyer.rb
+++ b/app/services/user_destroyer.rb
@@ -32,7 +32,7 @@ class UserDestroyer
       Draft.where(user_id: user.id).delete_all
       Reviewable.where(created_by_id: user.id).delete_all
 
-      category_topic_ids = Category.all.pluck(:topic_id).compact
+      category_topic_ids = Category.where("topic_id IS NOT NULL").pluck(:topic_id)
 
       if opts[:delete_posts]
         user.posts.each do |post|

--- a/spec/services/user_destroyer_spec.rb
+++ b/spec/services/user_destroyer_spec.rb
@@ -223,7 +223,7 @@ describe UserDestroyer do
       let!(:second_post) { Fabricate(:post, user: @user, topic: topic) }
       let!(:category) { Fabricate(:category, user: @user, topic_id: topic.id) }
 
-      it 'changes author of first category post to system user and still delete second post' do
+      it 'changes author of first category post to system user and still deletes second post' do
         UserDestroyer.new(@admin).destroy(@user, delete_posts: true)
 
         expect(first_post.reload.deleted_at).to eq(nil)

--- a/spec/services/user_destroyer_spec.rb
+++ b/spec/services/user_destroyer_spec.rb
@@ -217,6 +217,23 @@ describe UserDestroyer do
       end
     end
 
+    context 'user created category' do
+      let!(:topic) { Fabricate(:topic, user: @user) }
+      let!(:first_post) { Fabricate(:post, user: @user, topic: topic) }
+      let!(:second_post) { Fabricate(:post, user: @user, topic: topic) }
+      let!(:category) { Fabricate(:category, user: @user, topic_id: topic.id) }
+
+      it 'changes author of first category post to system user and still delete second post' do
+        UserDestroyer.new(@admin).destroy(@user, delete_posts: true)
+
+        expect(first_post.reload.deleted_at).to eq(nil)
+        expect(first_post.user_id).to eq(Discourse.system_user.id)
+
+        expect(second_post.reload.deleted_at).not_to eq(nil)
+        expect(second_post.user_id).to eq(nil)
+      end
+    end
+
     context 'user has no posts, but user_stats table has post_count > 0' do
       before do
         # out of sync user_stat data shouldn't break UserDestroyer


### PR DESCRIPTION
Fix for a bug when deleting a user who was an admin and created a category.

The first post with instruction about category should not be deleted but rather anonymised.

The bug was mentioned here: https://meta.discourse.org/t/cant-undelete-category-description-posts-created-by-deleted-user/173696/10