### PR TITLE
FIX: Show all topic statuses on full page search.

### DIFF
--- a/app/assets/javascripts/discourse/app/raw-views/topic-status.js
+++ b/app/assets/javascripts/discourse/app/raw-views/topic-status.js
@@ -58,6 +58,14 @@ export default EmberObject.extend({
       results.push({ icon: "far-eye-slash", key: "unlisted" });
     }
 
+    if (
+      this.showPrivateMessageIcon &&
+      topic.isPrivateMessage &&
+      !topic.is_warning
+    ) {
+      results.push({ icon: "envelope", key: "personal_message" });
+    }
+
     results.forEach((result) => {
       result.title = I18n.t(`topic_statuses.${result.key}.help`);
       if (

--- a/app/assets/javascripts/discourse/app/templates/full-page-search.hbs
+++ b/app/assets/javascripts/discourse/app/templates/full-page-search.hbs
@@ -87,7 +87,7 @@
                   {{/if}}
 
                   <a href={{result.url}} {{action "logClick" result.topic_id}} class="search-link">
-                    {{topic-status topic=result.topic disableActions=true showPrivateMessageIcon=true}}
+                    {{raw "topic-status" topic=result.topic showPrivateMessageIcon=true}}
                     <span class="topic-title">
                       {{#if result.useTopicTitleHeadline}}
                         {{html-safe result.topicTitleHeadline}}

--- a/app/assets/javascripts/discourse/tests/acceptance/search-full-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-full-test.js
@@ -105,10 +105,24 @@ acceptance("Search - Full Page", function (needs) {
     assert.ok(queryAll(".fps-topic").length === 0, "has no results");
     assert.ok(queryAll(".no-results-suggestion .google-search-form"));
 
-    await fillIn(".search-query", "posts");
+    await fillIn(".search-query", "discourse");
     await click(".search-cta");
 
     assert.ok(queryAll(".fps-topic").length === 1, "has one post");
+  });
+
+  test("search for personal messages", async function (assert) {
+    await visit("/search");
+
+    await fillIn(".search-query", "discourse in:personal");
+    await click(".search-cta");
+
+    assert.ok(queryAll(".fps-topic").length === 1, "has one post");
+
+    assert.ok(
+      queryAll(".topic-status .personal_message").length === 1,
+      "shows the right icon"
+    );
   });
 
   test("escape search term", async function (assert) {

--- a/app/assets/javascripts/discourse/tests/acceptance/search-mobile-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-mobile-test.js
@@ -28,7 +28,7 @@ acceptance("Search - Mobile", function (needs) {
       "it should expand advanced search filters"
     );
 
-    await fillIn(".search-query", "posts");
+    await fillIn(".search-query", "discourse");
     await click(".search-cta");
 
     assert.ok(queryAll(".fps-topic").length === 1, "has one post");
@@ -42,7 +42,7 @@ acceptance("Search - Mobile", function (needs) {
 
     assert.equal(
       queryAll("input.full-page-search").val(),
-      "posts",
+      "discourse",
       "it does not reset input when hitting search icon again"
     );
   });

--- a/app/assets/javascripts/discourse/tests/fixtures/search-fixtures.js
+++ b/app/assets/javascripts/discourse/tests/fixtures/search-fixtures.js
@@ -1,823 +1,63 @@
 export default {
   "/search.json": {
-    users: [
+    posts: [
       {
-        id: 19,
-        username: "eviltrout",
-        uploaded_avatar_id: 5275,
-        avatar_template:
-          "/user_avatar/meta.discourse.org/eviltrout/{size}/5275_1.png"
+        id: 10,
+        name: "system",
+        username: "system",
+        avatar_template: "/letter_avatar_proxy/v4/letter/s/bcef8e/{size}.png",
+        created_at: "2020-12-22T05:50:15.898Z",
+        like_count: 0,
+        blurb:
+          "The first paragraph of this pinned topic will be visible as a welcome message to all new visitors on your homepage. It’s important! Edit this into a brief description of your community: Who is it for? What can they find here? Why should they come here? Where can they read more (links, resources, ...",
+        post_number: 1,
+        topic_id: 7,
       },
-      {
-        id: 8617,
-        username: "Mittineague",
-        uploaded_avatar_id: 40997,
-        avatar_template:
-          "/user_avatar/meta.discourse.org/mittineague/{size}/40997_1.png"
-      },
-      {
-        id: 12662,
-        username: "singmajesty",
-        uploaded_avatar_id: 36342,
-        avatar_template:
-          "/user_avatar/meta.discourse.org/singmajesty/{size}/36342_1.png"
-      },
-      {
-        id: 6626,
-        username: "riking",
-        uploaded_avatar_id: 40212,
-        avatar_template:
-          "/user_avatar/meta.discourse.org/riking/{size}/40212_1.png"
-      },
-      {
-        id: 8300,
-        username: "cpradio",
-        uploaded_avatar_id: 4970,
-        avatar_template:
-          "/user_avatar/meta.discourse.org/cpradio/{size}/4970_1.png"
-      },
-      {
-        id: 2602,
-        username: "georgekaplan59",
-        uploaded_avatar_id: 31197,
-        avatar_template:
-          "/user_avatar/meta.discourse.org/georgekaplan59/{size}/31197_1.png"
-      },
-      {
-        id: 754,
-        username: "danneu",
-        uploaded_avatar_id: 6540,
-        avatar_template:
-          "/user_avatar/meta.discourse.org/danneu/{size}/6540_1.png"
-      },
-      {
-        id: 1995,
-        username: "zogstrip",
-        uploaded_avatar_id: 8630,
-        avatar_template:
-          "/user_avatar/meta.discourse.org/zogstrip/{size}/8630_1.png"
-      },
-      {
-        id: 1,
-        username: "sam",
-        uploaded_avatar_id: 5243,
-        avatar_template: "/user_avatar/meta.discourse.org/sam/{size}/5243_1.png"
-      },
-      {
-        id: 8810,
-        username: "fantasticfears",
-        uploaded_avatar_id: 36351,
-        avatar_template:
-          "/user_avatar/meta.discourse.org/fantasticfears/{size}/36351_1.png"
-      },
-      {
-        id: 14446,
-        username: "ladydanger",
-        uploaded_avatar_id: null,
-        avatar_template:
-          "/letter_avatar/ladydanger/{size}/5_fcf819f9b3791cb8c87edf29c8984f83.png"
-      },
-      {
-        id: 14474,
-        username: "dnatoli_redbubble",
-        uploaded_avatar_id: null,
-        avatar_template:
-          "/letter_avatar/dnatoli_redbubble/{size}/5_fcf819f9b3791cb8c87edf29c8984f83.png"
-      },
-      {
-        id: 14514,
-        username: "adelsmee",
-        uploaded_avatar_id: 40445,
-        avatar_template:
-          "/user_avatar/meta.discourse.org/adelsmee/{size}/40445_1.png"
-      },
-      {
-        id: 32,
-        username: "codinghorror",
-        uploaded_avatar_id: 5297,
-        avatar_template:
-          "/user_avatar/meta.discourse.org/codinghorror/{size}/5297_1.png"
-      },
-      {
-        id: 14448,
-        username: "snjqi188",
-        uploaded_avatar_id: null,
-        avatar_template:
-          "/letter_avatar/snjqi188/{size}/5_fcf819f9b3791cb8c87edf29c8984f83.png"
-      },
-      {
-        id: 14657,
-        username: "Alex_Flom",
-        uploaded_avatar_id: 41037,
-        avatar_template:
-          "/user_avatar/meta.discourse.org/alex_flom/{size}/41037_1.png"
-      },
-      {
-        id: 14353,
-        username: "Simon_Cossar",
-        uploaded_avatar_id: 40130,
-        avatar_template:
-          "/user_avatar/meta.discourse.org/simon_cossar/{size}/40130_1.png"
-      },
-      {
-        id: 14184,
-        username: "takaminacchan",
-        uploaded_avatar_id: 39685,
-        avatar_template:
-          "/user_avatar/meta.discourse.org/takaminacchan/{size}/39685_1.png"
-      },
-      {
-        id: 9931,
-        username: "Frank",
-        uploaded_avatar_id: null,
-        avatar_template:
-          "/letter_avatar/frank/{size}/5_fcf819f9b3791cb8c87edf29c8984f83.png"
-      },
-      {
-        id: 8364,
-        username: "codetricity",
-        uploaded_avatar_id: 3773,
-        avatar_template:
-          "/user_avatar/meta.discourse.org/codetricity/{size}/3773_1.png"
-      },
-      {
-        id: 4949,
-        username: "brodock",
-        uploaded_avatar_id: 13541,
-        avatar_template:
-          "/user_avatar/meta.discourse.org/brodock/{size}/13541_1.png"
-      },
-      {
-        id: 14,
-        username: "clay",
-        uploaded_avatar_id: 5265,
-        avatar_template:
-          "/user_avatar/meta.discourse.org/clay/{size}/5265_1.png"
-      },
-      {
-        id: 8385,
-        username: "zchrykng",
-        uploaded_avatar_id: 18517,
-        avatar_template:
-          "/user_avatar/meta.discourse.org/zchrykng/{size}/18517_1.png"
-      },
-      {
-        id: 3520,
-        username: "arlyxiao",
-        uploaded_avatar_id: 11206,
-        avatar_template:
-          "/user_avatar/meta.discourse.org/arlyxiao/{size}/11206_1.png"
-      },
-      {
-        id: 3493,
-        username: "richp10",
-        uploaded_avatar_id: 11160,
-        avatar_template:
-          "/user_avatar/meta.discourse.org/richp10/{size}/11160_1.png"
-      },
-      {
-        id: 2395,
-        username: "lookingsideways",
-        uploaded_avatar_id: 9290,
-        avatar_template:
-          "/user_avatar/meta.discourse.org/lookingsideways/{size}/9290_1.png"
-      },
-      {
-        id: 2477,
-        username: "billybonks",
-        uploaded_avatar_id: 9430,
-        avatar_template:
-          "/user_avatar/meta.discourse.org/billybonks/{size}/9430_1.png"
-      },
-      {
-        id: 7301,
-        username: "jasonwhat",
-        uploaded_avatar_id: null,
-        avatar_template:
-          "/letter_avatar/jasonwhat/{size}/5_fcf819f9b3791cb8c87edf29c8984f83.png"
-      },
-      {
-        id: 1819,
-        username: "stephan",
-        uploaded_avatar_id: 8327,
-        avatar_template:
-          "/user_avatar/meta.discourse.org/stephan/{size}/8327_1.png"
-      },
-      {
-        id: 2,
-        username: "neil",
-        uploaded_avatar_id: 5245,
-        avatar_template:
-          "/user_avatar/meta.discourse.org/neil/{size}/5245_1.png"
-      },
-      {
-        id: 2471,
-        username: "robconery",
-        uploaded_avatar_id: 9418,
-        avatar_template:
-          "/user_avatar/meta.discourse.org/robconery/{size}/9418_1.png"
-      }
     ],
-    topic_list: {
+    topics: [
+      {
+        id: 7,
+        title: "Welcome to Discourse",
+        fancy_title: "Welcome to Discourse",
+        slug: "welcome-to-discourse",
+        posts_count: 1,
+        reply_count: 0,
+        highest_post_number: 1,
+        created_at: "2020-12-22T05:50:15.837Z",
+        last_posted_at: "2020-12-22T05:50:15.898Z",
+        bumped: true,
+        bumped_at: "2020-12-22T05:50:15.898Z",
+        archetype: "regular",
+        unseen: false,
+        pinned: true,
+        unpinned: null,
+        excerpt:
+          "The first paragraph of this pinned topic will be visible as a welcome message to all new visitors on your homepage. It’s important! \nEdit this into a brief description of your community: \n\nWho is it for?\nWhat can they fi&hellip;",
+        visible: true,
+        closed: false,
+        archived: false,
+        bookmarked: null,
+        liked: null,
+        category_id: 1,
+      },
+    ],
+    users: [],
+    categories: [],
+    groups: [],
+    grouped_search_result: {
+      more_posts: null,
+      more_users: null,
+      more_categories: null,
+      term: "discourse",
+      search_log_id: 2,
+      more_full_page_results: null,
       can_create_topic: false,
-      draft: null,
-      draft_key: "new_topic",
-      draft_sequence: null,
-      per_page: 30,
-      topics: [
-        {
-          id: 9318,
-          title: "Discourse has a new Markdown Parser!",
-          fancy_title: "Discourse has a new Markdown Parser!",
-          slug: "discourse-has-a-new-markdown-parser",
-          posts_count: 1,
-          reply_count: 0,
-          highest_post_number: 1,
-          image_url: null,
-          created_at: "2013-08-24T18:08:06.063Z",
-          last_posted_at: "2013-08-24T18:08:06.259Z",
-          bumped: true,
-          bumped_at: "2015-03-09T04:54:43.977Z",
-          unseen: false,
-          linked_post_number: 1,
-          pinned: false,
-          unpinned: null,
-          excerpt:
-            '...0 lines of Javascript code! An inline example Let\'s say you want to replace all occurances of "evil trout" with a link that says "EVIL TROUT IS AWESOME": Discourse.Dialect.on("register", function(event) {...',
-          visible: true,
-          closed: false,
-          archived: false,
-          bookmarked: null,
-          liked: null,
-          views: 2645,
-          like_count: 21,
-          has_summary: false,
-          archetype: "regular",
-          last_poster_username: "eviltrout",
-          category_id: 7,
-          pinned_globally: false,
-          posters: [
-            {
-              extras: "latest single",
-              description: "Original Poster, Most Recent Poster",
-              user_id: 19
-            }
-          ]
-        },
-        {
-          id: 21792,
-          title: "Adding custom emoji/emoticons via a plugin",
-          fancy_title: "Adding custom emoji/emoticons via a plugin",
-          slug: "adding-custom-emoji-emoticons-via-a-plugin",
-          posts_count: 34,
-          reply_count: 24,
-          highest_post_number: 35,
-          image_url: null,
-          created_at: "2014-11-03T21:48:48.283Z",
-          last_posted_at: "2014-12-23T12:45:11.245Z",
-          bumped: true,
-          bumped_at: "2014-12-23T12:45:11.245Z",
-          unseen: false,
-          linked_post_number: 1,
-          pinned: false,
-          unpinned: null,
-          excerpt:
-            "...plugin that executes the following method to register a new emoji: Discourse.Dialect.registerEmoji('trout', 'http://cdn.eviltrout.com/images/trout-square.jpg'); Here's a sample plugin that adds a :trout: e...",
-          visible: true,
-          closed: false,
-          archived: false,
-          bookmarked: null,
-          liked: null,
-          views: 1260,
-          like_count: 25,
-          has_summary: false,
-          archetype: "regular",
-          last_poster_username: "cpradio",
-          category_id: 22,
-          pinned_globally: false,
-          posters: [
-            {
-              extras: null,
-              description: "Original Poster",
-              user_id: 19
-            },
-            {
-              extras: null,
-              description: "Frequent Poster",
-              user_id: 8617
-            },
-            {
-              extras: null,
-              description: "Frequent Poster",
-              user_id: 12662
-            },
-            {
-              extras: null,
-              description: "Frequent Poster",
-              user_id: 6626
-            },
-            {
-              extras: "latest",
-              description: "Most Recent Poster",
-              user_id: 8300
-            }
-          ]
-        },
-        {
-          id: 3071,
-          title: "Would it be possible to make Slug localizable?",
-          fancy_title: "Would it be possible to make Slug localizable?",
-          slug: "would-it-be-possible-to-make-slug-localizable",
-          posts_count: 12,
-          reply_count: 7,
-          highest_post_number: 12,
-          image_url: null,
-          created_at: "2013-02-14T11:48:21.474Z",
-          last_posted_at: "2014-09-18T14:38:59.064Z",
-          bumped: true,
-          bumped_at: "2014-09-18T14:38:59.064Z",
-          unseen: false,
-          linked_post_number: 10,
-          pinned: false,
-          unpinned: null,
-          excerpt:
-            "...in `block (2 levels) in &lt; top (required) &gt; ' 3) Slug replaces symbols Failure/Error: Slug.for('evil#trout').should == 'evil-trout' expected: \"evil-trout\" got: \"evil-number-trout\" (using ==) # ./spec/compon...",
-          visible: true,
-          closed: false,
-          archived: false,
-          bookmarked: null,
-          liked: null,
-          views: 766,
-          like_count: 5,
-          has_summary: false,
-          archetype: "regular",
-          last_poster_username: "fantasticfears",
-          category_id: 17,
-          pinned_globally: false,
-          posters: [
-            {
-              extras: null,
-              description: "Original Poster",
-              user_id: 2602
-            },
-            {
-              extras: null,
-              description: "Frequent Poster",
-              user_id: 754
-            },
-            {
-              extras: null,
-              description: "Frequent Poster",
-              user_id: 1995
-            },
-            {
-              extras: null,
-              description: "Frequent Poster",
-              user_id: 1
-            },
-            {
-              extras: "latest",
-              description: "Most Recent Poster",
-              user_id: 8810
-            }
-          ]
-        },
-        {
-          id: 26875,
-          title: "Rails Girls SoC Banter",
-          fancy_title: "Rails Girls SoC Banter",
-          slug: "rails-girls-soc-banter",
-          posts_count: 48,
-          reply_count: 30,
-          highest_post_number: 48,
-          image_url: null,
-          created_at: "2015-03-27T11:26:09.903Z",
-          last_posted_at: "2015-07-13T23:11:31.481Z",
-          bumped: true,
-          bumped_at: "2015-07-13T23:11:31.481Z",
-          unseen: false,
-          linked_post_number: 42,
-          pinned: false,
-          unpinned: null,
-          excerpt:
-            '...e inserted by plugins. ## Usage If you handlebars template has: ```handlebars {{plugin-outlet "evil-trout"}} ``` Then any handlebars files you create in the `connectors/evil-trout` directory will automatic...',
-          visible: true,
-          closed: false,
-          archived: false,
-          bookmarked: null,
-          liked: null,
-          views: 1224,
-          like_count: 81,
-          has_summary: false,
-          archetype: "regular",
-          last_poster_username: "snjqi188",
-          category_id: 7,
-          pinned_globally: false,
-          posters: [
-            {
-              extras: null,
-              description: "Original Poster",
-              user_id: 14446
-            },
-            {
-              extras: null,
-              description: "Frequent Poster",
-              user_id: 14474
-            },
-            {
-              extras: null,
-              description: "Frequent Poster",
-              user_id: 14514
-            },
-            {
-              extras: null,
-              description: "Frequent Poster",
-              user_id: 32
-            },
-            {
-              extras: "latest",
-              description: "Most Recent Poster",
-              user_id: 14448
-            }
-          ]
-        },
-        {
-          id: 31001,
-          title:
-            "Beginner's Guide to Creating Discourse Plugins Part 2: Plugin Outlets",
-          fancy_title:
-            "Beginner&rsquo;s Guide to Creating Discourse Plugins Part 2: Plugin Outlets",
-          slug:
-            "beginners-guide-to-creating-discourse-plugins-part-2-plugin-outlets",
-          posts_count: 1,
-          reply_count: 0,
-          highest_post_number: 1,
-          image_url: null,
-          created_at: "2015-07-12T17:48:27.322Z",
-          last_posted_at: "2015-07-12T17:48:27.403Z",
-          bumped: true,
-          bumped_at: "2015-07-13T04:18:14.901Z",
-          unseen: false,
-          linked_post_number: 1,
-          pinned: false,
-          unpinned: null,
-          excerpt:
-            '...nectors/ &lt; outlet name &gt; in it. For example, if your handlebars template has: {{plugin-outlet "evil-trout"}} Then any handlebars files you create in the connectors/evil-trout directory will automatically b...',
-          visible: true,
-          closed: false,
-          archived: false,
-          bookmarked: null,
-          liked: null,
-          views: 220,
-          like_count: 16,
-          has_summary: false,
-          archetype: "regular",
-          last_poster_username: "eviltrout",
-          category_id: 10,
-          pinned_globally: false,
-          posters: [
-            {
-              extras: "latest single",
-              description: "Original Poster, Most Recent Poster",
-              user_id: 19
-            }
-          ]
-        },
-        {
-          id: 29176,
-          title:
-            "How can I add some custom html to the bottom of the categories page?",
-          fancy_title:
-            "How can I add some custom html to the bottom of the categories page?",
-          slug:
-            "how-can-i-add-some-custom-html-to-the-bottom-of-the-categories-page",
-          posts_count: 12,
-          reply_count: 10,
-          highest_post_number: 13,
-          image_url: null,
-          created_at: "2015-05-23T19:08:35.447Z",
-          last_posted_at: "2015-05-25T08:16:25.989Z",
-          bumped: true,
-          bumped_at: "2015-05-25T08:16:25.989Z",
-          unseen: false,
-          linked_post_number: 12,
-          pinned: false,
-          unpinned: null,
-          excerpt:
-            '...e inserted by plugins. ## Usage If you handlebars template has: ```handlebars {{plugin-outlet "evil-trout"}} ``` Then any handlebars files you create in the `connectors/evil-trout` directory will automatic...',
-          visible: true,
-          closed: false,
-          archived: false,
-          bookmarked: null,
-          liked: null,
-          views: 190,
-          like_count: 8,
-          has_summary: false,
-          archetype: "regular",
-          last_poster_username: "sam",
-          category_id: 6,
-          pinned_globally: false,
-          posters: [
-            {
-              extras: null,
-              description: "Original Poster",
-              user_id: 14657
-            },
-            {
-              extras: null,
-              description: "Frequent Poster",
-              user_id: 6626
-            },
-            {
-              extras: null,
-              description: "Frequent Poster",
-              user_id: 8617
-            },
-            {
-              extras: null,
-              description: "Frequent Poster",
-              user_id: 14353
-            },
-            {
-              extras: "latest",
-              description: "Most Recent Poster",
-              user_id: 1
-            }
-          ]
-        },
-        {
-          id: 26192,
-          title: "403 when embedding a DigitalOcean droplet",
-          fancy_title: "403 when embedding a DigitalOcean droplet",
-          slug: "403-when-embedding-a-digital-ocean-droplet",
-          posts_count: 7,
-          reply_count: 3,
-          highest_post_number: 7,
-          image_url: null,
-          created_at: "2015-03-10T21:22:19.206Z",
-          last_posted_at: "2015-03-11T22:31:04.520Z",
-          bumped: true,
-          bumped_at: "2015-03-11T22:31:04.520Z",
-          unseen: false,
-          linked_post_number: 4,
-          pinned: false,
-          unpinned: null,
-          excerpt:
-            "Yes I am Robin as well as Evil Trout smile :smile: If you followed those instructions and are getting access errors, you might want to d...",
-          visible: true,
-          closed: false,
-          archived: false,
-          bookmarked: null,
-          liked: null,
-          views: 232,
-          like_count: 2,
-          has_summary: false,
-          archetype: "regular",
-          last_poster_username: "codinghorror",
-          category_id: 6,
-          pinned_globally: false,
-          posters: [
-            {
-              extras: null,
-              description: "Original Poster",
-              user_id: 14184
-            },
-            {
-              extras: null,
-              description: "Frequent Poster",
-              user_id: 19
-            },
-            {
-              extras: "latest",
-              description: "Most Recent Poster",
-              user_id: 32
-            }
-          ]
-        },
-        {
-          id: 20883,
-          title: "S3 competitor integration",
-          fancy_title: "S3 competitor integration",
-          slug: "s3-competitor-integration",
-          posts_count: 3,
-          reply_count: 1,
-          highest_post_number: 3,
-          image_url:
-            "https://discourse-cdn.global.ssl.fastly.net/meta/images/emoji/twitter/smile.png?v=1",
-          created_at: "2014-10-07T13:37:19.628Z",
-          last_posted_at: "2014-10-07T18:46:22.493Z",
-          bumped: true,
-          bumped_at: "2014-10-07T18:46:22.493Z",
-          unseen: false,
-          linked_post_number: 3,
-          pinned: false,
-          unpinned: null,
-          excerpt:
-            "I have seem some of your testing 'stuff' (evil trout's actually). And it looks like a HUUUUUUUUGGGE time sink (ice pick to the eyeballs). but...I believ...",
-          visible: true,
-          closed: false,
-          archived: false,
-          bookmarked: null,
-          liked: null,
-          views: 141,
-          like_count: 2,
-          has_summary: false,
-          archetype: "regular",
-          last_poster_username: "Frank",
-          category_id: 2,
-          pinned_globally: false,
-          posters: [
-            {
-              extras: "latest",
-              description: "Original Poster, Most Recent Poster",
-              user_id: 9931
-            },
-            {
-              extras: null,
-              description: "Frequent Poster",
-              user_id: 1995
-            }
-          ]
-        },
-        {
-          id: 13534,
-          title: "Blogging Platforms, Ghost, and Discourse",
-          fancy_title: "Blogging Platforms, Ghost, and Discourse",
-          slug: "blogging-platforms-ghost-and-discourse",
-          posts_count: 18,
-          reply_count: 13,
-          highest_post_number: 18,
-          image_url: null,
-          created_at: "2014-03-08T15:46:35.174Z",
-          last_posted_at: "2014-03-26T18:25:45.895Z",
-          bumped: true,
-          bumped_at: "2014-03-26T18:25:45.895Z",
-          unseen: false,
-          linked_post_number: 1,
-          pinned: false,
-          unpinned: null,
-          excerpt:
-            "...urse, do you mean that the blog comments for Ghost will be driven by Discourse, similar to the Evil Trout blog ? What about using Discourse as the blog platform itself, not as the comment engine at the end...",
-          visible: true,
-          closed: false,
-          archived: false,
-          bookmarked: null,
-          liked: null,
-          views: 2182,
-          like_count: 17,
-          has_summary: false,
-          archetype: "regular",
-          last_poster_username: "codetricity",
-          category_id: 17,
-          pinned_globally: false,
-          posters: [
-            {
-              extras: "latest",
-              description: "Original Poster, Most Recent Poster",
-              user_id: 8364
-            },
-            {
-              extras: null,
-              description: "Frequent Poster",
-              user_id: 4949
-            },
-            {
-              extras: null,
-              description: "Frequent Poster",
-              user_id: 14
-            },
-            {
-              extras: null,
-              description: "Frequent Poster",
-              user_id: 32
-            },
-            {
-              extras: null,
-              description: "Frequent Poster",
-              user_id: 8385
-            }
-          ]
-        },
-        {
-          id: 4859,
-          title: "All of the site functions based on ajax?",
-          fancy_title: "All of the site functions based on ajax?",
-          slug: "all-of-the-site-functions-based-on-ajax",
-          posts_count: 28,
-          reply_count: 20,
-          highest_post_number: 28,
-          image_url: null,
-          created_at: "2013-03-18T08:59:46.135Z",
-          last_posted_at: "2013-10-18T20:22:30.677Z",
-          bumped: true,
-          bumped_at: "2013-10-18T20:22:30.677Z",
-          unseen: false,
-          linked_post_number: 21,
-          pinned: false,
-          unpinned: null,
-          excerpt:
-            "please see evil trouts blog post http://eviltrout.com/2013/02/27/adding-to-discourse-part-1.html",
-          visible: true,
-          closed: false,
-          archived: false,
-          bookmarked: null,
-          liked: null,
-          views: 1629,
-          like_count: 17,
-          has_summary: false,
-          archetype: "regular",
-          last_poster_username: "jasonwhat",
-          category_id: 17,
-          pinned_globally: false,
-          posters: [
-            {
-              extras: null,
-              description: "Original Poster",
-              user_id: 3520
-            },
-            {
-              extras: null,
-              description: "Frequent Poster",
-              user_id: 3493
-            },
-            {
-              extras: null,
-              description: "Frequent Poster",
-              user_id: 2395
-            },
-            {
-              extras: null,
-              description: "Frequent Poster",
-              user_id: 2477
-            },
-            {
-              extras: "latest",
-              description: "Most Recent Poster",
-              user_id: 7301
-            }
-          ]
-        },
-        {
-          id: 7220,
-          title: "Javascript dependencies",
-          fancy_title: "Javascript dependencies",
-          slug: "javascript-dependencies",
-          posts_count: 8,
-          reply_count: 5,
-          highest_post_number: 8,
-          image_url: null,
-          created_at: "2013-06-06T11:11:18.522Z",
-          last_posted_at: "2013-06-07T18:43:51.449Z",
-          bumped: true,
-          bumped_at: "2013-06-07T18:43:51.449Z",
-          unseen: false,
-          linked_post_number: 3,
-          pinned: false,
-          unpinned: null,
-          excerpt:
-            "...ould be in vendor directory of one of the gems Ahh I need to look at Gemfile Ahh I need to use Evil Trouts bundle open handlebars trick. I am completely against this new best practice, its inconsistent wit...",
-          visible: true,
-          closed: false,
-          archived: false,
-          bookmarked: null,
-          liked: null,
-          views: 1010,
-          like_count: 0,
-          has_summary: false,
-          archetype: "regular",
-          last_poster_username: "eviltrout",
-          category_id: 7,
-          pinned_globally: false,
-          posters: [
-            {
-              extras: null,
-              description: "Original Poster",
-              user_id: 1819
-            },
-            {
-              extras: null,
-              description: "Frequent Poster",
-              user_id: 2
-            },
-            {
-              extras: null,
-              description: "Frequent Poster",
-              user_id: 1
-            },
-            {
-              extras: null,
-              description: "Frequent Poster",
-              user_id: 2471
-            },
-            {
-              extras: "latest",
-              description: "Most Recent Poster",
-              user_id: 19
-            }
-          ]
-        }
-      ]
-    }
+      error: null,
+      post_ids: [10],
+      user_ids: [],
+      category_ids: [],
+      group_ids: [],
+    },
   },
   "search/query": {
     posts: [
@@ -856,44 +96,44 @@ export default {
             id: 2,
             count: 0,
             hidden: false,
-            can_act: false
+            can_act: false,
           },
           {
             id: 3,
             count: 0,
             hidden: false,
-            can_act: false
+            can_act: false,
           },
           {
             id: 4,
             count: 0,
             hidden: false,
-            can_act: false
+            can_act: false,
           },
           {
             id: 5,
             count: 0,
             hidden: true,
-            can_act: false
+            can_act: false,
           },
           {
             id: 6,
             count: 0,
             hidden: false,
-            can_act: false
+            can_act: false,
           },
           {
             id: 7,
             count: 0,
             hidden: false,
-            can_act: false
+            can_act: false,
           },
           {
             id: 8,
             count: 0,
             hidden: false,
-            can_act: false
-          }
+            can_act: false,
+          },
         ],
         moderator: false,
         admin: false,
@@ -908,7 +148,7 @@ export default {
         can_view_edit_history: true,
         wiki: false,
         blurb:
-          "I've gotten vagrant up and running with a development environment but it's taking forever to load. For example http://192.168.10.200:3000/ takes..."
+          "I've gotten vagrant up and running with a development environment but it's taking forever to load. For example http://192.168.10.200:3000/ takes...",
       },
       {
         id: 48887,
@@ -946,44 +186,44 @@ export default {
             id: 2,
             count: 15,
             hidden: false,
-            can_act: false
+            can_act: false,
           },
           {
             id: 3,
             count: 0,
             hidden: false,
-            can_act: false
+            can_act: false,
           },
           {
             id: 4,
             count: 0,
             hidden: false,
-            can_act: false
+            can_act: false,
           },
           {
             id: 5,
             count: 0,
             hidden: true,
-            can_act: false
+            can_act: false,
           },
           {
             id: 6,
             count: 0,
             hidden: false,
-            can_act: false
+            can_act: false,
           },
           {
             id: 7,
             count: 0,
             hidden: false,
-            can_act: false
+            can_act: false,
           },
           {
             id: 8,
             count: 0,
             hidden: false,
-            can_act: false
-          }
+            can_act: false,
+          },
         ],
         moderator: true,
         admin: true,
@@ -998,7 +238,7 @@ export default {
         can_view_edit_history: true,
         wiki: true,
         blurb:
-          "So you want to set up Discourse on Ubuntu to hack on and develop with? We'll assume that you don't have Ruby/Rails/Postgre/Redis installed on your Ubuntu system..."
+          "So you want to set up Discourse on Ubuntu to hack on and develop with? We'll assume that you don't have Ruby/Rails/Postgre/Redis installed on your Ubuntu system...",
       },
       {
         id: 53437,
@@ -1036,44 +276,44 @@ export default {
             id: 2,
             count: 13,
             hidden: false,
-            can_act: false
+            can_act: false,
           },
           {
             id: 3,
             count: 0,
             hidden: false,
-            can_act: false
+            can_act: false,
           },
           {
             id: 4,
             count: 0,
             hidden: false,
-            can_act: false
+            can_act: false,
           },
           {
             id: 5,
             count: 0,
             hidden: true,
-            can_act: false
+            can_act: false,
           },
           {
             id: 6,
             count: 0,
             hidden: false,
-            can_act: false
+            can_act: false,
           },
           {
             id: 7,
             count: 0,
             hidden: false,
-            can_act: false
+            can_act: false,
           },
           {
             id: 8,
             count: 0,
             hidden: false,
-            can_act: false
-          }
+            can_act: false,
+          },
         ],
         moderator: true,
         admin: true,
@@ -1088,7 +328,7 @@ export default {
         can_view_edit_history: true,
         wiki: true,
         blurb:
-          "So you want to set up Discourse on Mac OS X to hack on and develop with? We'll assume that you don't have Ruby/Rails/Postgre/Redis installed on your Mac. Let's be..."
+          "So you want to set up Discourse on Mac OS X to hack on and develop with? We'll assume that you don't have Ruby/Rails/Postgre/Redis installed on your Mac. Let's be...",
       },
       {
         id: 38398,
@@ -1125,44 +365,44 @@ export default {
             id: 2,
             count: 0,
             hidden: false,
-            can_act: false
+            can_act: false,
           },
           {
             id: 3,
             count: 0,
             hidden: false,
-            can_act: false
+            can_act: false,
           },
           {
             id: 4,
             count: 0,
             hidden: false,
-            can_act: false
+            can_act: false,
           },
           {
             id: 5,
             count: 0,
             hidden: true,
-            can_act: false
+            can_act: false,
           },
           {
             id: 6,
             count: 0,
             hidden: false,
-            can_act: false
+            can_act: false,
           },
           {
             id: 7,
             count: 0,
             hidden: false,
-            can_act: false
+            can_act: false,
           },
           {
             id: 8,
             count: 0,
             hidden: false,
-            can_act: false
-          }
+            can_act: false,
+          },
         ],
         moderator: false,
         admin: false,
@@ -1177,7 +417,7 @@ export default {
         can_view_edit_history: true,
         wiki: false,
         blurb:
-          "...ed to do is go to /admin/docker , refresh once, hit upgrade, and test it out. What is the preferred development environment these days? I have Vagrant up and running as recommended in Discourse as Your F..."
+          "...ed to do is go to /admin/docker , refresh once, hit upgrade, and test it out. What is the preferred development environment these days? I have Vagrant up and running as recommended in Discourse as Your F...",
       },
       {
         id: 4782,
@@ -1214,44 +454,44 @@ export default {
             id: 2,
             count: 0,
             hidden: false,
-            can_act: false
+            can_act: false,
           },
           {
             id: 3,
             count: 0,
             hidden: false,
-            can_act: false
+            can_act: false,
           },
           {
             id: 4,
             count: 0,
             hidden: false,
-            can_act: false
+            can_act: false,
           },
           {
             id: 5,
             count: 0,
             hidden: true,
-            can_act: false
+            can_act: false,
           },
           {
             id: 6,
             count: 0,
             hidden: false,
-            can_act: false
+            can_act: false,
           },
           {
             id: 7,
             count: 0,
             hidden: false,
-            can_act: false
+            can_act: false,
           },
           {
             id: 8,
             count: 0,
             hidden: false,
-            can_act: false
-          }
+            can_act: false,
+          },
         ],
         moderator: false,
         admin: false,
@@ -1266,8 +506,8 @@ export default {
         can_view_edit_history: true,
         wiki: false,
         blurb:
-          "Is there any trick to getting a dev instance to send email? I managed to get a copy set up and running, but when I sign up, the email n..."
-      }
+          "Is there any trick to getting a dev instance to send email? I managed to get a copy set up and running, but when I sign up, the email n...",
+      },
     ],
     topics: [
       {
@@ -1299,7 +539,7 @@ export default {
         category_id: 7,
         pinned_globally: false,
         posters: [],
-        tags: ["dev", "slow"]
+        tags: ["dev", "slow"],
       },
       {
         id: 14727,
@@ -1331,7 +571,7 @@ export default {
         last_poster_username: null,
         category_id: 10,
         pinned_globally: false,
-        posters: []
+        posters: [],
       },
       {
         id: 15772,
@@ -1365,7 +605,7 @@ export default {
         last_poster_username: null,
         category_id: 10,
         pinned_globally: false,
-        posters: []
+        posters: [],
       },
       {
         id: 12170,
@@ -1395,7 +635,7 @@ export default {
         last_poster_username: null,
         category_id: 7,
         pinned_globally: false,
-        posters: []
+        posters: [],
       },
       {
         id: 2507,
@@ -1425,8 +665,8 @@ export default {
         last_poster_username: null,
         category_id: 7,
         pinned_globally: false,
-        posters: []
-      }
+        posters: [],
+      },
     ],
     users: [
       {
@@ -1434,36 +674,36 @@ export default {
         username: "dev",
         uploaded_avatar_id: null,
         avatar_template:
-          "/letter_avatar/dev/{size}/5_fcf819f9b3791cb8c87edf29c8984f83.png"
+          "/letter_avatar/dev/{size}/5_fcf819f9b3791cb8c87edf29c8984f83.png",
       },
       {
         id: 13166,
         username: "devon",
         uploaded_avatar_id: 37175,
         avatar_template:
-          "/user_avatar/meta.discourse.org/devon/{size}/37175_1.png"
+          "/user_avatar/meta.discourse.org/devon/{size}/37175_1.png",
       },
       {
         id: 12979,
         username: "devlesedi",
         uploaded_avatar_id: null,
         avatar_template:
-          "/letter_avatar/devlesedi/{size}/5_fcf819f9b3791cb8c87edf29c8984f83.png"
+          "/letter_avatar/devlesedi/{size}/5_fcf819f9b3791cb8c87edf29c8984f83.png",
       },
       {
         id: 13381,
         username: "devwizard",
         uploaded_avatar_id: null,
         avatar_template:
-          "/letter_avatar/devwizard/{size}/5_fcf819f9b3791cb8c87edf29c8984f83.png"
+          "/letter_avatar/devwizard/{size}/5_fcf819f9b3791cb8c87edf29c8984f83.png",
       },
       {
         id: 5993,
         username: "devmach",
         uploaded_avatar_id: null,
         avatar_template:
-          "/letter_avatar/devmach/{size}/5_fcf819f9b3791cb8c87edf29c8984f83.png"
-      }
+          "/letter_avatar/devmach/{size}/5_fcf819f9b3791cb8c87edf29c8984f83.png",
+      },
     ],
     categories: [
       {
@@ -1481,8 +721,8 @@ export default {
         topic_url: "/t/category-definition-for-dev/1026",
         read_restricted: false,
         permission: null,
-        notification_level: null
-      }
+        notification_level: null,
+      },
     ],
     grouped_search_result: {
       term: "dev",
@@ -1491,7 +731,7 @@ export default {
       more_categories: null,
       post_ids: [3833, 48887, 53437, 38398, 4782],
       user_ids: [3229, 13166, 12979, 13381, 5993],
-      category_ids: [7]
-    }
-  }
+      category_ids: [7],
+    },
+  },
 };

--- a/app/assets/javascripts/discourse/tests/helpers/create-pretender.js
+++ b/app/assets/javascripts/discourse/tests/helpers/create-pretender.js
@@ -219,31 +219,15 @@ export function applyDefaultHandlers(pretender) {
   pretender.post("/clicks/track", success);
 
   pretender.get("/search", (request) => {
-    if (request.queryParams.q === "posts") {
-      return response({
-        posts: [
-          {
-            id: 1234,
-          },
-        ],
-      });
-    } else if (request.queryParams.q === "evil") {
-      return response({
-        posts: [
-          {
-            id: 1234,
-          },
-        ],
-        tags: [
-          {
-            id: 6,
-            name: "eviltrout",
-          },
-        ],
-      });
+    if (request.queryParams.q === "discourse") {
+      return response(fixturesByUrl["/search.json"]);
+    } else if (request.queryParams.q === "discourse in:personal") {
+      const fixtures = fixturesByUrl["/search.json"];
+      fixtures.topics.firstObject.archetype = "private_message";
+      return response(fixtures);
+    } else {
+      return response({});
     }
-
-    return response({});
   });
 
   pretender.put("/u/eviltrout.json", () => response({ user: {} }));


### PR DESCRIPTION
This component is a less flexible version of https://github.com/discourse/discourse/blob/07bf7a91f4085b32342e3a0b8916b03a0f17c142/app/assets/javascripts/discourse/app/components/topic-status.js and makes it hard for plugin to add additional statuses like what we do for the `discourse-solved` plugin in https://github.com/discourse/discourse-solved/blob/584060102526cca953f270281751034c14b98d67/assets/javascripts/discourse/initializers/extend-for-solved-button.js.es6#L239-L264. 

This change is required for https://meta.discourse.org/t/boost-solved-search-results-in-search/158881 where we want to boost solved topics in search results. From a UX perspective, we first need to be able to show which topics are solved and which aren't through the topic status icon.

Related PR in discourse-solved: https://github.com/discourse/discourse-solved/pull/105