### PR TITLE
FIX: Don't enqueue imported users when there're multiple custom fields.

### DIFF
--- a/spec/jobs/enqueue_suspect_users_spec.rb
+++ b/spec/jobs/enqueue_suspect_users_spec.rb
@@ -80,5 +80,13 @@ describe Jobs::EnqueueSuspectUsers do
 
       expect(ReviewableUser.where(target: suspect_user).exists?).to eq(true)
     end
+
+    it 'ignores imported users even if they have multiple custom fields' do
+      suspect_user.upsert_custom_fields({ field_a: 'value', field_b: 'value', import_id: 'fake_id' })
+
+      subject.execute({})
+
+      expect(ReviewableUser.where(target: suspect_user).exists?).to eq(false)
+    end
   end
 end


### PR DESCRIPTION
My initial implementation didn't consider this case. We should skip imported users if the "imported_id" field is present, even if there're other custom fields.

