### PR TITLE
FEATURE: Introduce skip_auto_delete_reply_likes site setting

### DIFF
--- a/app/jobs/regular/delete_replies.rb
+++ b/app/jobs/regular/delete_replies.rb
@@ -18,6 +18,8 @@ module Jobs
       end
 
       replies = topic.posts.where("posts.post_number > 1")
+      replies = replies.where("like_count < ?", SiteSetting.skip_auto_delete_reply_likes) if SiteSetting.skip_auto_delete_reply_likes > 0
+
       replies.where('posts.created_at < ?', topic_timer.duration.days.ago).each do |post|
         PostDestroyer.new(topic_timer.user, post, context: I18n.t("topic_statuses.auto_deleted_by_timer")).destroy
       end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2182,7 +2182,7 @@ en:
     blur_tl0_flagged_posts_media: "Blur flagged posts images to hide potentially NSFW content."
     enable_page_publishing: "Allow staff members to publish topics to new URLs with their own styling."
     show_published_pages_login_required: "Anonymous users can see published pages, even when login is required."
-    skip_auto_delete_reply_likes: "Number of likes required by posts to be skipped by the Auto-Delete Replies Timer"
+    skip_auto_delete_reply_likes: "When automatically deleting old replies, skip deleting posts with this number of likes or more."
 
     default_email_digest_frequency: "How often users receive summary emails by default."
     default_include_tl0_in_digests: "Include posts from new users in summary emails by default. Users can change this in their preferences."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2182,6 +2182,7 @@ en:
     blur_tl0_flagged_posts_media: "Blur flagged posts images to hide potentially NSFW content."
     enable_page_publishing: "Allow staff members to publish topics to new URLs with their own styling."
     show_published_pages_login_required: "Anonymous users can see published pages, even when login is required."
+    skip_auto_delete_reply_likes: "Number of likes required by posts to be skipped by the Auto-Delete Replies Timer"
 
     default_email_digest_frequency: "How often users receive summary emails by default."
     default_include_tl0_in_digests: "Include posts from new users in summary emails by default. Users can change this in their preferences."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -996,6 +996,7 @@ posting:
     default: false
   show_published_pages_login_required:
     default: false
+  skip_auto_delete_reply_likes: 5
 
 email:
   email_time_window_mins:

--- a/spec/jobs/delete_replies_spec.rb
+++ b/spec/jobs/delete_replies_spec.rb
@@ -15,6 +15,8 @@ describe Jobs::DeleteReplies do
   end
 
   it "can delete replies of a topic" do
+    SiteSetting.skip_auto_delete_reply_likes = 0
+
     freeze_time (2.days.from_now)
 
     expect {
@@ -23,5 +25,17 @@ describe Jobs::DeleteReplies do
 
     topic_timer.reload
     expect(topic_timer.execute_at).to eq_time(2.day.from_now)
+  end
+
+  it "does not delete posts with likes over the threshold" do
+    SiteSetting.skip_auto_delete_reply_likes = 3
+
+    freeze_time (2.days.from_now)
+
+    topic.posts.last.update!(like_count: SiteSetting.skip_auto_delete_reply_likes + 1)
+
+    expect {
+      described_class.new.execute(topic_timer_id: topic_timer.id)
+    }.to change { topic.posts.count }.by(-1)
   end
 end


### PR DESCRIPTION
Posts from topics with 'auto delete replies timer' with more than
skip_auto_delete_reply_likes likes will no longer be deleted. If 0,
all posts will be deleted.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
