### PR TITLE
FIX: user destroyer spec

### DIFF
--- a/spec/services/user_destroyer_spec.rb
+++ b/spec/services/user_destroyer_spec.rb
@@ -213,13 +213,13 @@ describe UserDestroyer do
     end
 
     context 'user created category' do
-      let!(:topic) { Fabricate(:topic, user: @user) }
-      let!(:first_post) { Fabricate(:post, user: @user, topic: topic) }
-      let!(:second_post) { Fabricate(:post, user: @user, topic: topic) }
-      let!(:category) { Fabricate(:category, user: @user, topic_id: topic.id) }
+      let!(:topic) { Fabricate(:topic, user: user) }
+      let!(:first_post) { Fabricate(:post, user: user, topic: topic) }
+      let!(:second_post) { Fabricate(:post, user: user, topic: topic) }
+      let!(:category) { Fabricate(:category, user: user, topic_id: topic.id) }
 
       it 'changes author of first category post to system user and still deletes second post' do
-        UserDestroyer.new(@admin).destroy(@user, delete_posts: true)
+        UserDestroyer.new(admin).destroy(user, delete_posts: true)
 
         expect(first_post.reload.deleted_at).to eq(nil)
         expect(first_post.user_id).to eq(Discourse.system_user.id)


### PR DESCRIPTION
Don't use user and admin after https://github.com/discourse/discourse/commit/db235c5ff92
