### PR TITLE
FIX: The `title` attribute of the diversity scales was incorrect

### DIFF
--- a/app/assets/javascripts/discourse/app/components/emoji-picker.js
+++ b/app/assets/javascripts/discourse/app/components/emoji-picker.js
@@ -12,6 +12,7 @@ import Component from "@ember/component";
 import { createPopper } from "@popperjs/core";
 import { htmlSafe } from "@ember/template";
 import { inject as service } from "@ember/service";
+import { underscore } from "@ember/string";
 
 function customEmojis() {
   const list = extendedEmojiList();
@@ -149,6 +150,7 @@ export default Component.extend({
     ].map((name, index) => {
       return {
         name,
+        title: `emoji_picker.${underscore(name)}_tone`,
         icon: index + 1 === this.selectedDiversity ? "check" : "",
       };
     });

--- a/app/assets/javascripts/discourse/app/templates/components/emoji-picker.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/emoji-picker.hbs
@@ -84,7 +84,7 @@
             {{d-button
               icon=diversityScale.icon
               class=(concat "diversity-scale " diversityScale.name)
-              title=(concat "emoji_picker." diversityScale.name "_tone")
+              title=diversityScale.title
               action=(action "onDiversitySelection" index)
             }}
           {{/each}}


### PR DESCRIPTION
It needed to be underscored, since it had dashes in it.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
