### PR TITLE
FEATURE: Delay push notifications as we do with emails

### DIFF
--- a/app/jobs/regular/send_push_notification.rb
+++ b/app/jobs/regular/send_push_notification.rb
@@ -4,6 +4,8 @@ module Jobs
   class SendPushNotification < ::Jobs::Base
     def execute(args)
       user = User.find_by(id: args[:user_id])
+      return if (user.last_seen_at.present? && user.last_seen_at > SiteSetting.email_time_window_mins.minutes.ago)
+
       PushNotificationPusher.push(user, args[:payload]) if user
     end
   end

--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -467,7 +467,7 @@ class PostAlerter
     return if user.do_not_disturb?
 
     if user.push_subscriptions.exists?
-      Jobs.enqueue(:send_push_notification, user_id: user.id, payload: payload)
+      Jobs.enqueue_in(SiteSetting.email_time_window_mins.minutes, :send_push_notification, user_id: user.id, payload: payload)
     end
 
     if SiteSetting.allow_user_api_key_scopes.split("|").include?("push") && SiteSetting.allowed_user_api_push_urls.present?


### PR DESCRIPTION
@tgxworld What is your opinion here?

My problem is that while actively navigating Meta I get push notifications for replies I already read and replied.

![Screenshot_20201223-183903.png](https://user-images.githubusercontent.com/1385470/103038839-342c0d80-454e-11eb-8ba2-621b176f01ae.png)

In my opinion, mirroring our email delay would solve this problem cheaply.

I could also check if the target post of a notifications was already read, but that depends on the notification type and it's expensive to query post_timings.