### PR TITLE
DEV: added platform support to bundler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,6 +160,7 @@ GEM
     jwt (2.2.2)
     kgio (2.11.3)
     libv8 (8.4.255.0)
+    libv8 (8.4.255.0-x86_64-linux)
     listen (3.3.3)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -432,6 +433,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   actionmailer (= 6.0.3.3)


### PR DESCRIPTION
see: https://bundler.io/blog/2020/12/09/bundler-v2-2.html

New version of bundler includes explicit callouts for each platform supported

This means we need to bundle on all our supported platforms, the number should be fairly low as x86 linux covers most
