### PR TITLE
FIX: Validate type when picking an avatar.

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/modal/avatar-selector.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/avatar-selector.hbs
@@ -12,21 +12,21 @@
       {{radio-button id="system-avatar" name="avatar" value="system" selection=selected}}
       <label class="radio" for="system-avatar">{{bound-avatar-template user.system_avatar_template "large"}} {{html-safe (i18n "user.change_avatar.letter_based")}}</label>
     </div>
-    <div class="avatar-choice">
-      {{radio-button id="gravatar" name="avatar" value="gravatar" selection=selected}}
-      <label class="radio" for="gravatar">{{bound-avatar-template user.gravatar_avatar_template "large"}} <span>{{html-safe (i18n "user.change_avatar.gravatar" gravatarName=gravatarName gravatarBaseUrl=gravatarBaseUrl gravatarLoginUrl=gravatarLoginUrl)}} {{user.email}}</span></label>
-
-      {{d-button action=(action "refreshGravatar")
-                 translatedTitle=(i18n "user.change_avatar.refresh_gravatar_title" gravatarName=gravatarName)
-                 disabled=gravatarRefreshDisabled
-                 icon="sync"
-                 class="btn-default avatar-selector-refresh-gravatar"}}
-
-      {{#if gravatarFailed}}
-        <p class="error">{{I18n "user.change_avatar.gravatar_failed" gravatarName=gravatarName}}</p>
-      {{/if}}
-    </div>
     {{#if allowAvatarUpload}}
+      <div class="avatar-choice">
+        {{radio-button id="gravatar" name="avatar" value="gravatar" selection=selected}}
+        <label class="radio" for="gravatar">{{bound-avatar-template user.gravatar_avatar_template "large"}} <span>{{html-safe (i18n "user.change_avatar.gravatar" gravatarName=gravatarName gravatarBaseUrl=gravatarBaseUrl gravatarLoginUrl=gravatarLoginUrl)}} {{user.email}}</span></label>
+
+        {{d-button action=(action "refreshGravatar")
+                   translatedTitle=(i18n "user.change_avatar.refresh_gravatar_title" gravatarName=gravatarName)
+                   disabled=gravatarRefreshDisabled
+                   icon="sync"
+                   class="btn-default avatar-selector-refresh-gravatar"}}
+
+        {{#if gravatarFailed}}
+          <p class="error">{{I18n "user.change_avatar.gravatar_failed" gravatarName=gravatarName}}</p>
+        {{/if}}
+      </div>
       <div class="avatar-choice">
         {{radio-button id="uploaded-avatar" name="avatar" value="uploaded" selection=selected}}
         <label class="radio" for="uploaded-avatar">

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -2309,6 +2309,29 @@ describe UsersController do
         expect(response.status).to eq(422)
       end
 
+      it 'ignores the upload if picking a system avatar' do
+        SiteSetting.allow_uploaded_avatars = false
+        another_upload = Fabricate(:upload)
+
+        put "/u/#{user.username}/preferences/avatar/pick.json", params: {
+          upload_id: another_upload.id, type: "system"
+        }
+
+        expect(response.status).to eq(200)
+        expect(user.reload.uploaded_avatar_id).to eq(nil)
+      end
+
+      it 'raises an error if the type is invalid' do
+        SiteSetting.allow_uploaded_avatars = false
+        another_upload = Fabricate(:upload)
+
+        put "/u/#{user.username}/preferences/avatar/pick.json", params: {
+          upload_id: another_upload.id, type: "x"
+        }
+
+        expect(response.status).to eq(422)
+      end
+
       it 'can successfully pick the system avatar' do
         put "/u/#{user.username}/preferences/avatar/pick.json"
 


### PR DESCRIPTION
This change improves the `UsersController#pick_avatar` validations to raise an error when `allow_uploaded_avatars` is disabled.

