### PR TITLE
FIX: S3 CDN warning was showing wrong warning message

### DIFF
--- a/app/models/admin_dashboard_data.rb
+++ b/app/models/admin_dashboard_data.rb
@@ -192,7 +192,7 @@ class AdminDashboardData
 
   def s3_cdn_check
     if (GlobalSetting.use_s3? || SiteSetting.enable_s3_uploads) && SiteSetting.Upload.s3_cdn_url.blank?
-      I18n.t('dashboard.s3_config_warning')
+      I18n.t('dashboard.s3_cdn_warning')
     end
   end
 


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
