### PR TITLE
PERF: optimize homepage and topic performance

### DIFF
--- a/lib/file_helper.rb
+++ b/lib/file_helper.rb
@@ -14,15 +14,15 @@ class FileHelper
   end
 
   def self.is_supported_image?(filename)
-    (filename =~ supported_images_regexp).present?
+    filename.match?(supported_images_regexp)
   end
 
   def self.is_inline_image?(filename)
-    (filename =~ inline_images_regexp).present?
+    filename.match?(inline_images_regexp)
   end
 
   def self.is_supported_media?(filename)
-    (filename =~ supported_media_regexp).present?
+    filename.match?(supported_media_regexp)
   end
 
   class FakeIO
@@ -162,7 +162,10 @@ class FileHelper
   end
 
   def self.supported_media_regexp
-    media = supported_images | supported_audio | supported_video
-    @@supported_media_regexp ||= /\.(#{media.to_a.join("|")})$/i
+    @@supported_media_regexp ||=
+      begin
+        media = supported_images | supported_audio | supported_video
+        /\.(#{media.to_a.join("|")})$/i
+      end
   end
 end

--- a/lib/guardian/post_guardian.rb
+++ b/lib/guardian/post_guardian.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#mixin for all guardian methods dealing with post permissions
+# mixin for all guardian methods dealing with post permissions
 module PostGuardian
 
   def unrestricted_link_posting?
@@ -104,7 +104,6 @@ module PostGuardian
     user.post_count <= SiteSetting.delete_all_posts_max.to_i
   end
 
-  # Creating Method
   def can_create_post?(parent)
     return false if !SiteSetting.enable_system_message_replies? && parent.try(:subtype) == "system_message"
 
@@ -115,7 +114,6 @@ module PostGuardian
     )
   end
 
-  # Editing Method
   def can_edit_post?(post)
     if Discourse.static_doc_topic_ids.include?(post.topic_id) && !is_admin?
       return false
@@ -181,7 +179,6 @@ module PostGuardian
     post.is_first_post? ? post.topic && can_delete_topic?(post.topic) : can_delete_post?(post)
   end
 
-  # Deleting Methods
   def can_delete_post?(post)
     return false if !can_see_post?(post)
 
@@ -198,11 +195,11 @@ module PostGuardian
     can_moderate
   end
 
-  # Recovery Method
   def can_recover_post?(post)
     return false unless post
 
-    topic = Topic.with_deleted.find(post.topic_id) if post.topic_id
+    # PERF, vast majority of the time topic will not be deleted
+    topic = (post.topic || Topic.with_deleted.find(post.topic_id)) if post.topic_id
 
     if can_moderate_topic?(topic)
       !!post.deleted_at

--- a/lib/url_helper.rb
+++ b/lib/url_helper.rb
@@ -79,12 +79,6 @@ class UrlHelper
   def self.cook_url(url, secure: false)
     return url unless is_local(url)
 
-    uri = URI.parse(url)
-    filename = File.basename(uri.path)
-    is_attachment = !FileHelper.is_supported_media?(filename)
-
-    no_cdn = SiteSetting.login_required || SiteSetting.prevent_anons_from_downloading_files
-
     url = secure ? secure_proxy_without_cdn(url) : absolute_without_cdn(url)
 
     # we always want secure media to come from
@@ -92,6 +86,19 @@ class UrlHelper
     # to avoid asset_host mixups
     return schemaless(url) if secure
 
+    # PERF: avoid parsing url excpet for extreme conditions
+    # this is a hot path used on home page
+    filename = url
+    if url.include?("?")
+      uri = URI.parse(url)
+      filename = File.basename(uri.path)
+    end
+
+    # this technically requires a filename, but will work with a URL as long as it end with the
+    # extension and has no query params
+    is_attachment = !FileHelper.is_supported_media?(filename)
+
+    no_cdn = SiteSetting.login_required || SiteSetting.prevent_anons_from_downloading_files
     unless is_attachment && no_cdn
       url = Discourse.store.cdn_url(url)
       url = local_cdn_url(url) if Discourse.store.external?


### PR DESCRIPTION
These are a few small tweaks that slightly improve performance.

- we omitted 1 query from the post guardian which could cause an N+1
- cook_url has been sped up a bit
- url helper avoids re-creating sets for no reason
