### PR TITLE
DEV: Update mini_sql

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -194,7 +194,7 @@ GEM
       libv8 (~> 8.4.255)
     mini_scheduler (0.13.0)
       sidekiq (>= 4.2.3)
-    mini_sql (0.3)
+    mini_sql (1.0)
     mini_suffix (0.3.0)
       ffi (~> 1.9)
     minitest (5.14.2)

--- a/lib/mini_sql_multisite_connection.rb
+++ b/lib/mini_sql_multisite_connection.rb
@@ -19,9 +19,11 @@ class MiniSqlMultisiteConnection < MiniSql::Postgres::Connection
   end
 
   class ParamEncoder
-    def encode(*sql_array)
+    def encode(sql, *params)
+      return sql unless params && params.length > 0
+
       # use active record to avoid any discrepencies
-      ActiveRecord::Base.public_send(:sanitize_sql_array, sql_array)
+      ActiveRecord::Base.public_send(:sanitize_sql_array, [sql, *params])
     end
   end
 


### PR DESCRIPTION
mini_sql now expects that `encode` will check for empty params, see: https://github.com/discourse/mini_sql/pull/18

@SamSaffron do we want to fix it here or revert the change in mini_sql?