### PR TITLE
FIX: Correctly set scroll position when viewing a tag's topic list.

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/tags/show.hbs
+++ b/app/assets/javascripts/discourse/app/templates/tags/show.hbs
@@ -47,7 +47,7 @@
         <div id="list-area">
           {{#unless loading}}
             {{#if list.topics}}
-              {{#discovery-topics-list model=list refresh=(action "refresh")}}
+              {{#discovery-topics-list model=list refresh=(action "refresh")  as |discoveryTopicList|}}
                 {{bulk-select-button selected=selected action=(action "refresh") category=category}}
                 {{topic-list
                   topics=list.topics
@@ -59,6 +59,7 @@
                   order=order
                   ascending=ascending
                   changeSort=(action "changeSort")
+                  onScroll=discoveryTopicList.saveScrollPosition
                   scrollOnLoad=true
                 }}
               {{/discovery-topics-list}}


### PR DESCRIPTION
Follows up #11496. The scroll position was not updated when scrolling up.

