### PR TITLE
FIX: ensures defined expired_in is passed from write to write_entry

### DIFF
--- a/lib/cache.rb
+++ b/lib/cache.rb
@@ -22,6 +22,8 @@ class Cache
   # pointless data
   MAX_CACHE_AGE = 1.day unless defined? MAX_CACHE_AGE
 
+  attr_reader :namespace
+
   # we don't need this feature, 1 day expiry is enough
   # it makes lookups a tad cheaper
   def self.supports_cache_versioning?
@@ -66,7 +68,7 @@ class Cache
   end
 
   def write(name, value, expires_in: nil)
-    write_entry(normalize_key(name), value, expires_in: nil)
+    write_entry(normalize_key(name), value, expires_in: expires_in)
   end
 
   def delete(name)

--- a/spec/components/cache_spec.rb
+++ b/spec/components/cache_spec.rb
@@ -98,4 +98,14 @@ describe Cache do
 
     expect(cache.keys("users:*").count).to eq(2)
   end
+
+  it "can fetch namespace" do
+    expect(cache.namespace).to eq("_CACHE")
+  end
+
+  it "uses the defined expires_in" do
+    cache.write "foo:bar", "baz", expires_in: 3.minutes
+
+    expect(cache.redis.ttl("#{cache.namespace}:foo:bar")).to eq(180)
+  end
 end


### PR DESCRIPTION
This commit also makes `Cache#namespace` readable to help writing tests easier and make them more robust.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
