### PR TITLE
FIX: prevents autocomplete of username to appear on right

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/autocomplete.js
+++ b/app/assets/javascripts/discourse/app/lib/autocomplete.js
@@ -295,7 +295,7 @@ export default function (options) {
 
     if (isInput || options.treatAsTextarea) {
       return createPopper(me[0], div[0], {
-        placement: "auto-start",
+        placement: "bottom-start",
         strategy: "fixed",
       });
     }


### PR DESCRIPTION
Before:
<img width="660" alt="Capture d’écran 2021-01-04 à 10 32 47" src="https://user-images.githubusercontent.com/339945/103520931-407e6780-4e78-11eb-93ea-1328ba3847b4.png">

After:
<img width="392" alt="Capture d’écran 2021-01-04 à 10 33 43" src="https://user-images.githubusercontent.com/339945/103521006-57bd5500-4e78-11eb-8a72-bd61574be0c0.png">
