### PR TITLE
Revert "Build(deps): Bump i18n from 1.8.5 to 1.8.6 (#11621)"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,7 +147,7 @@ GEM
     hkdf (0.3.0)
     htmlentities (4.3.4)
     http_accept_language (2.1.1)
-    i18n (1.8.6)
+    i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     image_size (1.5.0)
     in_threads (1.5.4)


### PR DESCRIPTION
This reverts commit ff54d3a0243152e0f4b4e3a878ab072fe8324de9.

The update possibly broke some plugins. Investigating.