### PR TITLE
FIX: boolean api params should not be case sensitive

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -30,7 +30,7 @@ class Admin::UsersController < Admin::AdminController
     users = ::AdminUserIndexQuery.new(params).find_users
 
     opts = {}
-    if params[:show_emails].downcase == "true"
+    if params[:show_emails]&.downcase == "true"
       StaffActionLogger.new(current_user).log_show_emails(users, context: request.path)
       opts[:emails_desired] = true
     end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -30,7 +30,7 @@ class Admin::UsersController < Admin::AdminController
     users = ::AdminUserIndexQuery.new(params).find_users
 
     opts = {}
-    if params[:show_emails] == "true"
+    if params[:show_emails].downcase == "true"
       StaffActionLogger.new(current_user).log_show_emails(users, context: request.path)
       opts[:emails_desired] = true
     end

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Admin::UsersController do
 
     context 'when showing emails' do
       it "returns email for all the users" do
-        get "/admin/users/list.json", params: { show_emails: "true" }
+        get "/admin/users/list.json", params: { show_emails: "tRue" }
         expect(response.status).to eq(200)
         data = response.parsed_body
         data.each do |user|


### PR DESCRIPTION
Allow the `show_emails` param to be case insensitive so that
`true` or `TRUE` are both valid values to pass in.

This issue likely exists on many endpoints, but finding all of the
endpoints that accept boolean params isn't an easy task, so just fixing
this one endpoint for now.
