### PR TITLE
FEATURE: Replace arrows when the markdown typographer is enabled.

### DIFF
--- a/app/assets/javascripts/discourse/tests/unit/lib/pretty-text-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/pretty-text-test.js
@@ -1554,4 +1554,35 @@ var bar = 'bar';
       </div></p>`
     );
   });
+
+  test("typographer arrows", function (assert) {
+    const enabledTypographer = {
+      siteSettings: { enable_markdown_typographer: true },
+    };
+
+    // Replace arrows
+    assert.cookedOptions(
+      "--> <--",
+      enabledTypographer,
+      "<p> \u2192 \u2190 </p>"
+    );
+    assert.cookedOptions("a --> b", enabledTypographer, "<p>a \u2192 b</p>");
+    assert.cookedOptions("-->", enabledTypographer, "<p> \u2192 </p>");
+    assert.cookedOptions("<--", enabledTypographer, "<p> \u2190 </p>");
+
+    // Don't replace arrows
+    assert.cookedOptions("<!-- an html comment -->", enabledTypographer, "");
+    assert.cookedOptions(
+      "(<--not an arrow)",
+      enabledTypographer,
+      "<p>(&lt;–not an arrow)</p>"
+    );
+    assert.cookedOptions("<-->", enabledTypographer, "<p>&lt;–&gt;</p>");
+    assert.cookedOptions("asd-->", enabledTypographer, "<p>asd–&gt;</p>");
+    assert.cookedOptions(" asd--> ", enabledTypographer, "<p>asd–&gt;</p>");
+    assert.cookedOptions(" asd-->", enabledTypographer, "<p>asd–&gt;</p>");
+    assert.cookedOptions("-->asd", enabledTypographer, "<p>–&gt;asd</p>");
+    assert.cookedOptions(" -->asd ", enabledTypographer, "<p>–&gt;asd</p>");
+    assert.cookedOptions(" -->asd", enabledTypographer, "<p>–&gt;asd</p>");
+  });
 });

--- a/app/assets/javascripts/pretty-text/engines/discourse-markdown/typographer-arrows.js
+++ b/app/assets/javascripts/pretty-text/engines/discourse-markdown/typographer-arrows.js
@@ -1,0 +1,32 @@
+function replaceArrows(state) {
+  for (let i = 0; i < state.tokens.length; i++) {
+    let token = state.tokens[i];
+
+    if (token.type !== "inline") {
+      continue;
+    }
+
+    const arrowsRegexp = /-->|<--/;
+    if (arrowsRegexp.test(token.content)) {
+      for (let ci = 0; ci < token.children.length; ci++) {
+        let child = token.children[ci];
+
+        if (child.type === "text") {
+          if (arrowsRegexp.test(child.content)) {
+            child.content = child.content
+              .replace(/(^|\s)-->(\s|$)/gm, "\u0020\u2192\u0020")
+              .replace(/(^|\s)<--(\s|$)/gm, "\u0020\u2190\u0020");
+          }
+        }
+      }
+    }
+  }
+}
+
+export function setup(helper) {
+  helper.registerPlugin((md) => {
+    if (md.options.typographer) {
+      md.core.ruler.before("replacements", "typographer-arrow", replaceArrows);
+    }
+  });
+}


### PR DESCRIPTION
By inserting this rule before markdown-it's replacement rule, we can replace "-->" with "&rarr;", and "<--" with "&larr;".

<img width="981" alt="Screen Shot 2021-01-05 at 19 35 30" src="https://user-images.githubusercontent.com/5025816/103707372-4023c080-4f8d-11eb-8e47-6f944c0b96ed.png">

