### PR TITLE
UX: Allow quick access profile content to scroll

### DIFF
--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -343,6 +343,14 @@
     @include unselectable;
 
     &.quick-access-profile {
+      display: inline;
+      overflow-y: auto; // There's no "show all" for this content, so it always needs to be scrollable
+      ul {
+        display: inline;
+        a {
+          box-sizing: border-box; // without this you end up with horizontal scroll
+        }
+      }
       li:not(.show-all) a {
         color: var(--primary);
         display: flex;


### PR DESCRIPTION
You need to scroll this panel in some cases so you can access logout. This only changes the user tab, other tabs don't need to scroll because they have "view all" buttons. 

Before:
![Screen Shot 2021-01-05 at 5 52 25 PM](https://user-images.githubusercontent.com/1681963/103708560-cd134d80-4f7e-11eb-8062-f3f2c39f7754.png)

After:
![Screen Shot 2021-01-05 at 5 52 13 PM](https://user-images.githubusercontent.com/1681963/103708561-cedd1100-4f7e-11eb-9391-f7be999bf641.png)

This also fixes a secondary issue where some links would overflow and disappear (despite having space available) for some unknown reason. 