### PR TITLE
FIX: don't error topic RSS when posts are deleted

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -840,9 +840,10 @@ class TopicsController < ApplicationController
   end
 
   def feed
+    raise Discourse::NotFound if Post.where(topic_id: params[:topic_id]).count == 0
+
     @topic_view = TopicView.new(params[:topic_id])
     discourse_expires_in 1.minute
-    raise Discourse::NotFound if @topic_view.posts.blank?
     render 'topics/show', formats: [:rss]
   end
 

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -840,7 +840,7 @@ class TopicsController < ApplicationController
   end
 
   def feed
-    raise Discourse::NotFound if Post.where(topic_id: params[:topic_id]).count == 0
+    raise Discourse::NotFound if !Post.exists?(topic_id: params[:topic_id])
 
     @topic_view = TopicView.new(params[:topic_id])
     discourse_expires_in 1.minute

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -842,6 +842,7 @@ class TopicsController < ApplicationController
   def feed
     @topic_view = TopicView.new(params[:topic_id])
     discourse_expires_in 1.minute
+    raise Discourse::NotFound if @topic_view.posts.blank?
     render 'topics/show', formats: [:rss]
   end
 

--- a/app/views/topics/show.rss.erb
+++ b/app/views/topics/show.rss.erb
@@ -6,7 +6,7 @@
     <% site_email = SiteSetting.find_by_name('contact_email').try(:value) %>
     <title><%= @topic_view.title %></title>
     <link><%= topic_url %></link>
-    <description><%= @topic_view.posts.first&.raw %></description>
+    <description><%= @topic_view.posts.first.raw %></description>
     <% if lang %><language><%= lang.sub('_', '-')%></language><% end %>
     <lastBuildDate><%= @topic_view.topic.bumped_at.rfc2822 %></lastBuildDate>
     <category><%= @topic_view.topic.category.name %></category>

--- a/app/views/topics/show.rss.erb
+++ b/app/views/topics/show.rss.erb
@@ -6,7 +6,7 @@
     <% site_email = SiteSetting.find_by_name('contact_email').try(:value) %>
     <title><%= @topic_view.title %></title>
     <link><%= topic_url %></link>
-    <description><%= @topic_view.posts.first.raw %></description>
+    <description><%= @topic_view.posts.first&.raw %></description>
     <% if lang %><language><%= lang.sub('_', '-')%></language><% end %>
     <lastBuildDate><%= @topic_view.topic.bumped_at.rfc2822 %></lastBuildDate>
     <category><%= @topic_view.topic.category.name %></category>

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -2521,7 +2521,7 @@ RSpec.describe TopicsController do
     end
 
     it 'returns 404 when posts are deleted' do
-      topic.posts.map(&:trash!)
+      topic.posts.each(&:trash!)
       get "/t/foo/#{topic.id}.rss"
       expect(response.status).to eq(404)
     end

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -2512,6 +2512,13 @@ RSpec.describe TopicsController do
       expect(response.media_type).to eq('application/rss+xml')
     end
 
+    it 'renders rss even if post is deleted' do
+      topic.posts.map(&:destroy)
+      get "/t/foo/#{topic.id}.rss"
+      expect(response.status).to eq(200)
+      expect(response.media_type).to eq('application/rss+xml')
+    end
+
     it 'renders rss of the topic correctly with subfolder' do
       set_subfolder "/forum"
       get "/t/foo/#{topic.id}.rss"

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -2512,19 +2512,18 @@ RSpec.describe TopicsController do
       expect(response.media_type).to eq('application/rss+xml')
     end
 
-    it 'renders rss even if post is deleted' do
-      topic.posts.map(&:destroy)
-      get "/t/foo/#{topic.id}.rss"
-      expect(response.status).to eq(200)
-      expect(response.media_type).to eq('application/rss+xml')
-    end
-
     it 'renders rss of the topic correctly with subfolder' do
       set_subfolder "/forum"
       get "/t/foo/#{topic.id}.rss"
       expect(response.status).to eq(200)
       expect(response.body).to_not include("/forum/forum")
       expect(response.body).to include("http://test.localhost/forum/t/#{topic.slug}")
+    end
+
+    it 'returns 404 when posts are deleted' do
+      topic.posts.map(&:trash!)
+      get "/t/foo/#{topic.id}.rss"
+      expect(response.status).to eq(404)
     end
   end
 


### PR DESCRIPTION
Crawlers should not trigger an error and return 404 when posts are soft deleted
