### PR TITLE
FEATURE: Send notification emails when users leave do not disturb mode

### DIFF
--- a/app/controllers/do_not_disturb_controller.rb
+++ b/app/controllers/do_not_disturb_controller.rb
@@ -25,6 +25,9 @@ class DoNotDisturbController < ApplicationController
   def destroy
     current_user.active_do_not_disturb_timings.destroy_all
     current_user.publish_do_not_disturb(ends_at: nil)
+    current_user.notifications.unprocessed.each do |notification|
+      NotificationEmailer.process_notification(notification, no_delay: true)
+    end
     render json: success_json
   end
 

--- a/app/jobs/scheduled/process_shelved_notifications.rb
+++ b/app/jobs/scheduled/process_shelved_notifications.rb
@@ -16,7 +16,11 @@ module Jobs
       notification_ids = DB.query_single(sql, now: now)
 
       Notification.where(id: notification_ids).each do |notification|
-        NotificationEmailer.process_notification(notification, no_delay: true)
+        begin
+          NotificationEmailer.process_notification(notification, no_delay: true)
+        rescue
+          Rails.logger.warn("Failed to process notification with ID #{notification.id}")
+        end
       end
 
       DB.exec("DELETE FROM do_not_disturb_timings WHERE ends_at < :now", now: now)

--- a/app/jobs/scheduled/process_shelved_notifications.rb
+++ b/app/jobs/scheduled/process_shelved_notifications.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Jobs
+  class ProcessShelvedNotifications < ::Jobs::Scheduled
+    every 5.minutes
+
+    def execute(args)
+      sql = <<~SQL
+        SELECT n.id FROM notifications AS n
+        INNER JOIN do_not_disturb_timings AS dndt ON n.user_id = dndt.user_id
+        WHERE n.processed = false
+        AND dndt.ends_at <= :now
+      SQL
+
+      now = Time.zone.now
+      notification_ids = DB.query_single(sql, now: now)
+
+      Notification.where(id: notification_ids).each do |notification|
+        NotificationEmailer.process_notification(notification, no_delay: true)
+      end
+
+      DB.exec("DELETE FROM do_not_disturb_timings WHERE ends_at < :now", now: now)
+    end
+  end
+end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -282,8 +282,10 @@ class Notification < ActiveRecord::Base
   end
 
   def send_email
-    return if skip_send_email || user.do_not_disturb? # TODO: 'shelve' emails rather than skipping them entirely
-    NotificationEmailer.process_notification(self)
+    if skip_send_email
+      return update(processed: true)
+    end
+    NotificationEmailer.process_notification(self) unless user.do_not_disturb?
   end
 
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -10,6 +10,7 @@ class Notification < ActiveRecord::Base
   validates_presence_of :notification_type
 
   scope :unread, lambda { where(read: false) }
+  scope :unprocessed, lambda { where(processed: false) }
   scope :recent, lambda { |n = nil| n ||= 10; order('notifications.created_at desc').limit(n) }
   scope :visible , lambda { joins('LEFT JOIN topics ON notifications.topic_id = topics.id')
     .where('topics.id IS NULL OR topics.deleted_at IS NULL') }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1379,6 +1379,10 @@ class User < ActiveRecord::Base
     do_not_disturb_timings.where('starts_at <= ? AND ends_at > ?', now, now)
   end
 
+  def do_not_disturb_until
+    active_do_not_disturb_timings.maximum(:ends_at)
+  end
+
   protected
 
   def badge_grant

--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -238,8 +238,4 @@ class CurrentUserSerializer < BasicUserSerializer
   def featured_topic
     object.user_profile.featured_topic
   end
-
-  def do_not_disturb_until
-    object.active_do_not_disturb_timings.maximum(:ends_at)
-  end
 end

--- a/app/services/notification_consolidator.rb
+++ b/app/services/notification_consolidator.rb
@@ -44,8 +44,7 @@ class NotificationConsolidator
       consolidated_notification.update!(
           data: data_hash.to_json,
           read: false,
-          updated_at: timestamp,
-          processed: true
+          updated_at: timestamp
       )
       notification.destroy!
     end
@@ -68,8 +67,7 @@ class NotificationConsolidator
         user_id: notification.user_id,
         data: data.to_json,
         updated_at: timestamp,
-        created_at: timestamp,
-        processed: true
+        created_at: timestamp
       )
 
       notifications.destroy_all

--- a/app/services/notification_consolidator.rb
+++ b/app/services/notification_consolidator.rb
@@ -44,7 +44,8 @@ class NotificationConsolidator
       consolidated_notification.update!(
           data: data_hash.to_json,
           read: false,
-          updated_at: timestamp
+          updated_at: timestamp,
+          processed: true
       )
       notification.destroy!
     end
@@ -67,7 +68,8 @@ class NotificationConsolidator
         user_id: notification.user_id,
         data: data.to_json,
         updated_at: timestamp,
-        created_at: timestamp
+        created_at: timestamp,
+        processed: true
       )
 
       notifications.destroy_all

--- a/app/services/notification_emailer.rb
+++ b/app/services/notification_emailer.rb
@@ -7,6 +7,7 @@ class NotificationEmailer
 
     def initialize(notification, no_delay = false)
       @notification = notification
+      @no_delay = no_delay
     end
 
     def group_mentioned

--- a/app/services/notification_emailer.rb
+++ b/app/services/notification_emailer.rb
@@ -3,9 +3,9 @@
 class NotificationEmailer
 
   class EmailUser
-    attr_reader :notification
+    attr_reader :notification, :no_delay
 
-    def initialize(notification)
+    def initialize(notification, no_delay = false)
       @notification = notification
     end
 
@@ -98,11 +98,11 @@ class NotificationEmailer
     end
 
     def default_delay
-      SiteSetting.email_time_window_mins.minutes
+      no_delay ? 0 : SiteSetting.email_time_window_mins.minutes
     end
 
     def private_delay
-      SiteSetting.personal_email_time_window_seconds
+      no_delay ? 0 : SiteSetting.personal_email_time_window_seconds
     end
 
     def post_type
@@ -123,10 +123,11 @@ class NotificationEmailer
     @disabled = false
   end
 
-  def self.process_notification(notification)
+  def self.process_notification(notification, no_delay: false)
+    notification.update(processed: true)
     return if @disabled
 
-    email_user   = EmailUser.new(notification)
+    email_user   = EmailUser.new(notification, no_delay)
     email_method = Notification.types[notification.notification_type]
 
     email_user.public_send(email_method) if email_user.respond_to? email_method

--- a/app/services/notification_emailer.rb
+++ b/app/services/notification_emailer.rb
@@ -5,7 +5,7 @@ class NotificationEmailer
   class EmailUser
     attr_reader :notification, :no_delay
 
-    def initialize(notification, no_delay = false)
+    def initialize(notification, no_delay: false)
       @notification = notification
       @no_delay = no_delay
     end
@@ -128,7 +128,7 @@ class NotificationEmailer
     notification.update(processed: true)
     return if @disabled
 
-    email_user   = EmailUser.new(notification, no_delay)
+    email_user   = EmailUser.new(notification, no_delay: no_delay)
     email_method = Notification.types[notification.notification_type]
 
     email_user.public_send(email_method) if email_user.respond_to? email_method

--- a/db/migrate/20210105165605_add_processed_to_notifications.rb
+++ b/db/migrate/20210105165605_add_processed_to_notifications.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class AddProcessedToNotifications < ActiveRecord::Migration[6.0]
+  def up
+    add_column :notifications, :processed, :boolean, default: false
+    execute "UPDATE notifications SET processed = true"
+    change_column_null(:notifications, :processed, false)
+    # CREATE INDEX!
+  end
+
+  def down
+    remove_column :notifications, :processed
+  end
+end

--- a/db/migrate/20210105165605_add_processed_to_notifications.rb
+++ b/db/migrate/20210105165605_add_processed_to_notifications.rb
@@ -5,7 +5,7 @@ class AddProcessedToNotifications < ActiveRecord::Migration[6.0]
     add_column :notifications, :processed, :boolean, default: false
     execute "UPDATE notifications SET processed = true"
     change_column_null(:notifications, :processed, false)
-    # CREATE INDEX!
+    add_index :notifications, [:processed], unique: false
   end
 
   def down

--- a/spec/jobs/process_shelved_notifications_spec.rb
+++ b/spec/jobs/process_shelved_notifications_spec.rb
@@ -5,8 +5,6 @@ require "rails_helper"
 describe Jobs::ProcessShelvedNotifications do
   fab!(:user) { Fabricate(:user) }
   let(:post) { Fabricate(:post) }
-  let(:notification) { Notification.create!(read: false, user_id: user.id, topic_id: post.topic_id, post_number: post.post_number, data: '[]', notification_type: Notification.types[:mentioned], created_at: 0.days.from_now)
-  }
 
   it "removes all past do not disturb timings" do
     future = Fabricate(:do_not_disturb_timing, ends_at: 1.day.from_now)

--- a/spec/jobs/process_shelved_notifications_spec.rb
+++ b/spec/jobs/process_shelved_notifications_spec.rb
@@ -5,9 +5,20 @@ require "rails_helper"
 describe Jobs::ProcessShelvedNotifications do
   fab!(:user) { Fabricate(:user) }
   let(:post) { Fabricate(:post) }
-  Notification.create!(read: false, user_id: user.id, topic_id: post.topic_id, post_number: post.post_number, data: '[]', notification_type: type, created_at: 0.days.from_now)
+  let(:notification) { Notification.create!(read: false, user_id: user.id, topic_id: post.topic_id, post_number: post.post_number, data: '[]', notification_type: Notification.types[:mentioned], created_at: 0.days.from_now)
+  }
+  # it "automatically marks the notification as high priority if it is a high priority type" do
+    # notif = Notification.create(user: user, notification_type: Notification.types[:bookmark_reminder], data: {})
+  # end
 
-  it "automatically marks the notification as high priority if it is a high priority type" do
-    notif = Notification.create(user: user, notification_type: Notification.types[:bookmark_reminder], data: {})
+  it "removes all past do not disturb timings" do
+    future = Fabricate(:do_not_disturb_timing, ends_at: Time.now + 1.day)
+    past = Fabricate(:do_not_disturb_timing, starts_at: Time.zone.now - 2.day, ends_at: 1.minute.ago)
+
+    expect {
+      subject.execute({})
+    }.to change{ DoNotDisturbTiming.count }.by (-1)
+    expect(DoNotDisturbTiming.find_by(id: future.id)).to eq(future)
+    expect(DoNotDisturbTiming.find_by(id: past.id)).to eq(nil)
   end
 end

--- a/spec/jobs/process_shelved_notifications_spec.rb
+++ b/spec/jobs/process_shelved_notifications_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Jobs::ProcessShelvedNotifications do
+  fab!(:user) { Fabricate(:user) }
+  let(:post) { Fabricate(:post) }
+  Notification.create!(read: false, user_id: user.id, topic_id: post.topic_id, post_number: post.post_number, data: '[]', notification_type: type, created_at: 0.days.from_now)
+
+  it "automatically marks the notification as high priority if it is a high priority type" do
+    notif = Notification.create(user: user, notification_type: Notification.types[:bookmark_reminder], data: {})
+  end
+end

--- a/spec/requests/do_not_disturb_controller_spec.rb
+++ b/spec/requests/do_not_disturb_controller_spec.rb
@@ -42,5 +42,16 @@ describe DoNotDisturbController do
         expect(user.do_not_disturb_timings.last.ends_at.to_i).to eq(Time.new(2020, 11, 24, 23, 59, 59).utc.to_i)
       end
     end
+
+    describe "#destroy" do
+      it "process notifications that came in during DND" do
+        user.do_not_disturb_timings.create(starts_at: 2.days.ago, ends_at: 2.days.from_now)
+        notification = Notification.create(read: false, user_id: user.id, topic_id: 2, post_number: 1, data: '{}', notification_type: 1)
+
+        expect(notification.processed).to eq(false)
+        delete "/do-not-disturb.json"
+        expect(notification.reload.processed).to eq(true)
+      end
+    end
   end
 end

--- a/spec/services/notification_emailer_spec.rb
+++ b/spec/services/notification_emailer_spec.rb
@@ -28,9 +28,9 @@ describe NotificationEmailer do
       expect_enqueued_with(
         job: :user_email,
         args: NotificationEmailer::EmailUser.notification_params(notification, type),
-        at: Time.zone.now + delay
+        at: no_delay ? Time.zone.now : Time.zone.now + delay
       ) do
-        NotificationEmailer.process_notification(notification)
+        NotificationEmailer.process_notification(notification, no_delay: no_delay)
       end
     end
 
@@ -39,7 +39,7 @@ describe NotificationEmailer do
 
       it "doesn't enqueue a job" do
         expect_not_enqueued_with(job: :user_email, args: { type: type }) do
-          NotificationEmailer.process_notification(notification)
+          NotificationEmailer.process_notification(notification, no_delay: no_delay)
         end
       end
 
@@ -51,15 +51,15 @@ describe NotificationEmailer do
             job: :user_email,
             args: { type: type }
           ) do
-            NotificationEmailer.process_notification(notification)
+            NotificationEmailer.process_notification(notification, no_delay: no_delay)
           end
         else
           expect_enqueued_with(
             job: :user_email,
             args: NotificationEmailer::EmailUser.notification_params(notification, type),
-            at: Time.zone.now + delay
+            at: no_delay ? Time.zone.now : Time.zone.now + delay
           ) do
-            NotificationEmailer.process_notification(notification)
+            NotificationEmailer.process_notification(notification, no_delay: no_delay)
           end
         end
       end
@@ -73,15 +73,15 @@ describe NotificationEmailer do
             job: :user_email,
             args: { type: type }
           ) do
-            NotificationEmailer.process_notification(notification)
+            NotificationEmailer.process_notification(notification, no_delay: no_delay)
           end
         else
           expect_enqueued_with(
             job: :user_email,
             args: NotificationEmailer::EmailUser.notification_params(notification, type),
-            at: Time.zone.now + delay
+            at: no_delay ? Time.zone.now : Time.zone.now + delay
           ) do
-            NotificationEmailer.process_notification(notification)
+            NotificationEmailer.process_notification(notification, no_delay: no_delay)
           end
         end
       end
@@ -96,7 +96,7 @@ describe NotificationEmailer do
 
       it "doesn't enqueue a job" do
         expect_not_enqueued_with(job: :user_email, args: { type: type }) do
-          NotificationEmailer.process_notification(notification)
+          NotificationEmailer.process_notification(notification, no_delay: no_delay)
         end
       end
     end
@@ -107,7 +107,7 @@ describe NotificationEmailer do
         Post.any_instance.expects(:post_type).returns(Post.types[:small_action])
 
         expect_not_enqueued_with(job: :user_email, args: { type: type }) do
-          NotificationEmailer.process_notification(notification)
+          NotificationEmailer.process_notification(notification, no_delay: no_delay)
         end
       end
 
@@ -122,7 +122,7 @@ describe NotificationEmailer do
       notification.user.user_option.update_columns(email_level: UserOption.email_level_types[:never])
 
       expect_not_enqueued_with(job: :user_email, args: { type: type }) do
-        NotificationEmailer.process_notification(notification)
+        NotificationEmailer.process_notification(notification, no_delay: no_delay)
       end
     end
   end
@@ -140,98 +140,109 @@ describe NotificationEmailer do
 
   end
 
-  context 'user_mentioned' do
-    let(:type) { :user_mentioned }
-    let(:delay) { SiteSetting.email_time_window_mins.minutes }
-    let!(:notification) { create_notification(:mentioned) }
+  [true, false].each do |no_delay|
 
-    include_examples "enqueue_public"
+    context 'user_mentioned' do
+      let(:no_delay) { no_delay }
+      let(:type) { :user_mentioned }
+      let(:delay) { SiteSetting.email_time_window_mins.minutes }
+      let!(:notification) { create_notification(:mentioned) }
 
-    it "enqueue a delayed job for users that are online" do
-      notification.user.last_seen_at = 1.minute.ago
+      include_examples "enqueue_public"
 
-      expect_enqueued_with(
-        job: :user_email,
-        args: NotificationEmailer::EmailUser.notification_params(notification, type),
-        at: Time.zone.now + delay
-      ) do
-        NotificationEmailer.process_notification(notification)
+      it "enqueue a delayed job for users that are online" do
+        notification.user.last_seen_at = 1.minute.ago
+
+        expect_enqueued_with(
+          job: :user_email,
+          args: NotificationEmailer::EmailUser.notification_params(notification, type),
+          at: Time.zone.now + delay
+        ) do
+          NotificationEmailer.process_notification(notification)
+        end
       end
+
     end
 
-  end
+    context 'user_replied' do
+      let(:no_delay) { no_delay }
+      let(:type) { :user_replied }
+      let(:delay) { SiteSetting.email_time_window_mins.minutes }
+      let!(:notification) { create_notification(:replied) }
 
-  context 'user_replied' do
-    let(:type) { :user_replied }
-    let(:delay) { SiteSetting.email_time_window_mins.minutes }
-    let!(:notification) { create_notification(:replied) }
-
-    include_examples "enqueue_public"
-  end
-
-  context 'user_quoted' do
-    let(:type) { :user_quoted }
-    let(:delay) { SiteSetting.email_time_window_mins.minutes }
-    let!(:notification) { create_notification(:quoted) }
-
-    include_examples "enqueue_public"
-  end
-
-  context 'user_linked' do
-    let(:type) { :user_linked }
-    let(:delay) { SiteSetting.email_time_window_mins.minutes }
-    let!(:notification) { create_notification(:linked) }
-
-    include_examples "enqueue_public"
-  end
-
-  context 'user_posted' do
-    let(:type) { :user_posted }
-    let(:delay) { SiteSetting.email_time_window_mins.minutes }
-    let!(:notification) { create_notification(:posted) }
-
-    include_examples "enqueue_public"
-  end
-
-  context 'user_private_message' do
-    let(:type) { :user_private_message }
-    let(:delay) { SiteSetting.personal_email_time_window_seconds }
-    let!(:notification) { create_notification(:private_message) }
-
-    include_examples "enqueue_private"
-
-    it "doesn't enqueue a job for a small action" do
-      notification.data_hash["original_post_type"] = Post.types[:small_action]
-
-      expect_not_enqueued_with(job: :user_email, args: { type: type }) do
-        NotificationEmailer.process_notification(notification)
-      end
+      include_examples "enqueue_public"
     end
 
+    context 'user_quoted' do
+      let(:no_delay) { no_delay }
+      let(:type) { :user_quoted }
+      let(:delay) { SiteSetting.email_time_window_mins.minutes }
+      let!(:notification) { create_notification(:quoted) }
+
+      include_examples "enqueue_public"
+    end
+
+    context 'user_linked' do
+      let(:no_delay) { no_delay }
+      let(:type) { :user_linked }
+      let(:delay) { SiteSetting.email_time_window_mins.minutes }
+      let!(:notification) { create_notification(:linked) }
+
+      include_examples "enqueue_public"
+    end
+
+    context 'user_posted' do
+      let(:no_delay) { no_delay }
+      let(:type) { :user_posted }
+      let(:delay) { SiteSetting.email_time_window_mins.minutes }
+      let!(:notification) { create_notification(:posted) }
+
+      include_examples "enqueue_public"
+    end
+
+    context 'user_private_message' do
+      let(:no_delay) { no_delay }
+      let(:type) { :user_private_message }
+      let(:delay) { SiteSetting.personal_email_time_window_seconds }
+      let!(:notification) { create_notification(:private_message) }
+
+      include_examples "enqueue_private"
+
+      it "doesn't enqueue a job for a small action" do
+        notification.data_hash["original_post_type"] = Post.types[:small_action]
+
+        expect_not_enqueued_with(job: :user_email, args: { type: type }) do
+          NotificationEmailer.process_notification(notification)
+        end
+      end
+
+    end
+
+    context 'user_invited_to_private_message' do
+      let(:no_delay) { no_delay }
+      let(:type) { :user_invited_to_private_message }
+      let(:delay) { SiteSetting.personal_email_time_window_seconds }
+      let!(:notification) { create_notification(:invited_to_private_message) }
+
+      include_examples "enqueue_public"
+    end
+
+    context 'user_invited_to_topic' do
+      let(:no_delay) { no_delay }
+      let(:type) { :user_invited_to_topic }
+      let(:delay) { SiteSetting.personal_email_time_window_seconds }
+      let!(:notification) { create_notification(:invited_to_topic) }
+
+      include_examples "enqueue_public"
+    end
+
+    context 'watching the first post' do
+      let(:no_delay) { no_delay }
+      let(:type) { :user_watching_first_post }
+      let(:delay) { SiteSetting.email_time_window_mins.minutes }
+      let!(:notification) { create_notification(:watching_first_post) }
+
+      include_examples "enqueue_public"
+    end
   end
-
-  context 'user_invited_to_private_message' do
-    let(:type) { :user_invited_to_private_message }
-    let(:delay) { SiteSetting.personal_email_time_window_seconds }
-    let!(:notification) { create_notification(:invited_to_private_message) }
-
-    include_examples "enqueue_public"
-  end
-
-  context 'user_invited_to_topic' do
-    let(:type) { :user_invited_to_topic }
-    let(:delay) { SiteSetting.personal_email_time_window_seconds }
-    let!(:notification) { create_notification(:invited_to_topic) }
-
-    include_examples "enqueue_public"
-  end
-
-  context 'watching the first post' do
-    let(:type) { :user_watching_first_post }
-    let(:delay) { SiteSetting.email_time_window_mins.minutes }
-    let!(:notification) { create_notification(:watching_first_post) }
-
-    include_examples "enqueue_public"
-  end
-
 end


### PR DESCRIPTION
This adds a `processed` boolean to the notifications table, which is set to true when a notification is processed by `NotificationEmailer`. Notifications that are created for users while they are in Do Not Disturb, are left with `processed: false`. A job is then run every 5 minutes to process any unprocessed notifications for users who have left DND mode. 