### PR TITLE
FEATURE: Disable post deletions by setting max_post_deletions to zero.

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1719,10 +1719,10 @@ rate_limits:
     min: 1
     default: 6
   max_post_deletions_per_minute:
-    min: 1
+    min: 0
     default: 2
   max_post_deletions_per_day:
-    min: 1
+    min: 0
     default: 10
   invite_link_max_redemptions_limit:
     min: 2


### PR DESCRIPTION
Allow admins to set "max_post_deletions_per_minute" and "max_post_deletions_per_day" to prevent users from deleting their posts.
