### PR TITLE
FIX: Hide notification count on document title in Do Not Disturb

### DIFF
--- a/app/assets/javascripts/discourse/app/services/document-title.js
+++ b/app/assets/javascripts/discourse/app/services/document-title.js
@@ -84,7 +84,8 @@ export default Service.extend({
     let dynamicFavicon = this.currentUser && this.currentUser.dynamic_favicon;
 
     if (this.currentUser && this.currentUser.isInDoNotDisturb()) {
-      return (document.title = title);
+      document.title = title;
+      return;
     }
     if (displayCount > 0 && !dynamicFavicon) {
       title = `(${displayCount}) ${title}`;

--- a/app/assets/javascripts/discourse/app/services/document-title.js
+++ b/app/assets/javascripts/discourse/app/services/document-title.js
@@ -82,6 +82,10 @@ export default Service.extend({
 
     let displayCount = this._displayCount();
     let dynamicFavicon = this.currentUser && this.currentUser.dynamic_favicon;
+
+    if (this.currentUser && this.currentUser.isInDoNotDisturb()) {
+      return (document.title = title);
+    }
     if (displayCount > 0 && !dynamicFavicon) {
       title = `(${displayCount}) ${title}`;
     }

--- a/app/assets/javascripts/discourse/tests/unit/services/document-title-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/services/document-title-test.js
@@ -42,7 +42,7 @@ discourseModule("Unit | Service | document-title", function (hooks) {
     assert.equal(document.title, "test notifications");
   });
 
-  test("it doesn't displays notification counts for users in do not disturb", function (assert) {
+  test("it doesn't display notification counts for users in do not disturb", function (assert) {
     this.documentTitle.currentUser = currentUser();
 
     const date = new Date();

--- a/app/assets/javascripts/discourse/tests/unit/services/document-title-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/services/document-title-test.js
@@ -42,6 +42,22 @@ discourseModule("Unit | Service | document-title", function (hooks) {
     assert.equal(document.title, "test notifications");
   });
 
+  test("it doesn't displays notification counts for users in do not disturb", function (assert) {
+    this.documentTitle.currentUser = currentUser();
+
+    const date = new Date();
+    date.setHours(date.getHours() + 1);
+    this.documentTitle.currentUser.do_not_disturb_until = date.toUTCString();
+
+    this.documentTitle.currentUser.dynamic_favicon = false;
+    this.documentTitle.setTitle("test notifications");
+    this.documentTitle.updateNotificationCount(5);
+    assert.equal(document.title, "test notifications");
+    this.documentTitle.setFocus(false);
+    this.documentTitle.updateNotificationCount(6);
+    assert.equal(document.title, "test notifications");
+  });
+
   test("it doesn't increment background context counts when focused", function (assert) {
     this.documentTitle.setTitle("background context");
     this.documentTitle.setFocus(true);


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
