### PR TITLE
FIX: Fix bg color of header on published page

### DIFF
--- a/app/assets/stylesheets/publish.scss
+++ b/app/assets/stylesheets/publish.scss
@@ -9,7 +9,7 @@
   width: 100%;
   top: 0;
   z-index: z("header");
-  background-color: var(--secondary, $secondary);
+  background-color: var(--header_background, $header_background);
   box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.25);
   position: sticky;
   top: 0;


### PR DESCRIPTION
This commit correctly sets the bg color of the header on published pages to be `var(--header_background)` instead of `var(--secondary)`.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
