### PR TITLE
FEATURE: IMAP detect spammed email and delete associated Discourse topic

### DIFF
--- a/db/migrate/20210107005832_add_imap_missing_column_to_incoming_email.rb
+++ b/db/migrate/20210107005832_add_imap_missing_column_to_incoming_email.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddImapMissingColumnToIncomingEmail < ActiveRecord::Migration[6.0]
+  def change
+    add_column :incoming_emails, :imap_missing, :boolean, default: false, null: false
+  end
+end

--- a/spec/components/imap/sync_spec.rb
+++ b/spec/components/imap/sync_spec.rb
@@ -321,6 +321,7 @@ describe Imap::Sync do
 
         provider.stubs(:uids).with(to: 100).returns([])
         provider.stubs(:uids).with(from: 101).returns([])
+        provider.stubs(:find_spam_by_message_ids).returns(stub(spam_emails: []))
         provider.stubs(:find_trashed_by_message_ids).returns(
           stub(
             trashed_emails: [
@@ -339,6 +340,49 @@ describe Imap::Sync do
         expect(incoming_100.imap_uid).to eq(10)
         expect(Post.with_deleted.find(incoming_100.post_id).deleted_at).not_to eq(nil)
         expect(Topic.with_deleted.find(incoming_100.topic_id).deleted_at).not_to eq(nil)
+      end
+
+      it "detects previously synced UIDs are missing and deletes the posts if they are in the spam/junk mailbox" do
+        sync_handler.process
+        incoming_100 = IncomingEmail.find_by(imap_uid: 100)
+        provider.stubs(:uids).with.returns([])
+
+        provider.stubs(:uids).with(to: 100).returns([])
+        provider.stubs(:uids).with(from: 101).returns([])
+        provider.stubs(:find_trashed_by_message_ids).returns(stub(trashed_emails: []))
+        provider.stubs(:find_spam_by_message_ids).returns(
+          stub(
+            spam_emails: [
+              stub(
+                uid: 10,
+                message_id: incoming_100.message_id
+              )
+            ],
+            spam_uid_validity: 99
+          )
+        )
+        sync_handler.process
+
+        incoming_100.reload
+        expect(incoming_100.imap_uid_validity).to eq(99)
+        expect(incoming_100.imap_uid).to eq(10)
+        expect(Post.with_deleted.find(incoming_100.post_id).deleted_at).not_to eq(nil)
+        expect(Topic.with_deleted.find(incoming_100.topic_id).deleted_at).not_to eq(nil)
+      end
+
+      it "marks the incoming email as IMAP missing if it cannot be found in spam or trash" do
+        sync_handler.process
+        incoming_100 = IncomingEmail.find_by(imap_uid: 100)
+        provider.stubs(:uids).with.returns([])
+
+        provider.stubs(:uids).with(to: 100).returns([])
+        provider.stubs(:uids).with(from: 101).returns([])
+        provider.stubs(:find_trashed_by_message_ids).returns(stub(trashed_emails: []))
+        provider.stubs(:find_spam_by_message_ids).returns(stub(spam_emails: []))
+        sync_handler.process
+
+        incoming_100.reload
+        expect(incoming_100.imap_missing).to eq(true)
       end
 
       it "detects the topic being deleted on the discourse site and deletes on the IMAP server and
@@ -385,6 +429,7 @@ describe Imap::Sync do
 
         provider.stubs(:uids).with(to: 100).returns([])
         provider.stubs(:uids).with(from: 101).returns([])
+        provider.stubs(:find_spam_by_message_ids).returns(stub(spam_emails: []))
         provider.stubs(:find_trashed_by_message_ids).returns(
           stub(
             trashed_emails: [


### PR DESCRIPTION
This PR adds functionality for the IMAP sync code to detect if a UID that is missing from the mail group mailbox is in the Spam/Junk folder for the mail account, and if so delete the associated Discourse topic. This is identical to what we do for emails that are moved for Trash.

If an email is missing but not in Spam or Trash, then we mark the incoming email record with `imap_missing: true`. This may be used in future to further filter or identify these emails, and perhaps go hunting for them in the email account in bulk.

Note: This adds some code duplication because the trash and spam email detection and handling is very similar. I intend to do more refactors/improvements to the IMAP sync code in time because there is a lot of room for improvement.