### PR TITLE
Minor copyedit on flag stat popup

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -471,8 +471,8 @@ en:
 
       user_percentage:
         summary:
-          one: "%{agreed}, %{disagreed}, %{ignored} (%{count} total flag)"
-          other: "%{agreed}, %{disagreed}, %{ignored} (%{count} total flags)"
+          one: "%{agreed}, %{disagreed}, %{ignored} (of last flag)"
+          other: "%{agreed}, %{disagreed}, %{ignored} (of last %{count} flags)"
         agreed:
           one: "%{count}% agree"
           other: "%{count}% agree"


### PR DESCRIPTION
This change was requested by @coding-horror to improve the clarity of the flag stat popup that appears with flag reviewables:

<img width="824" alt="reviewable" src="https://user-images.githubusercontent.com/22733864/103846462-fdc4b700-5052-11eb-8213-4803fe8388d5.png">
