### PR TITLE
UX: Improve color scheme choices in user prefs

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/preferences/interface.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/interface.js
@@ -33,7 +33,6 @@ const TITLE_COUNT_MODES = ["notifications", "contextual"];
 export default Controller.extend({
   currentThemeId: -1,
   previewingColorScheme: false,
-  selectedColorSchemeId: null,
   selectedDarkColorSchemeId: null,
   preferencesController: inject("preferences"),
   makeColorSchemeDefault: true,
@@ -160,7 +159,7 @@ export default Controller.extend({
 
     const currentThemeColorSchemeId = userThemes.findBy("id", themeId)
       .color_scheme_id;
-    return userColorSchemes.find((cs) => cs.id === currentThemeColorSchemeId);
+    return userColorSchemes.findBy("id", currentThemeColorSchemeId);
   },
 
   showColorSchemeNoneItem: not("currentSchemeCanBeSelected"),

--- a/app/assets/javascripts/discourse/app/templates/preferences/interface.hbs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/interface.hbs
@@ -29,14 +29,14 @@
       {{/if}}
       <div class="controls">
         {{combo-box
-                content=userSelectableColorSchemes
-                value=selectedColorSchemeId
-                onChange=(action "loadColorScheme")
-                options=(hash
-                  translatedNone=selectedColorSchemeNoneLabel
-                )
-
-              }}
+          content=userSelectableColorSchemes
+          value=selectedColorSchemeId
+          onChange=(action "loadColorScheme")
+          options=(hash
+            translatedNone=selectedColorSchemeNoneLabel
+            autoInsertNoneItem=showColorSchemeNoneItem
+          )
+        }}
       </div>
     </div>
     {{#if showDarkColorSchemeSelector}}

--- a/app/assets/javascripts/discourse/tests/acceptance/user-preferences-interface-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-preferences-interface-test.js
@@ -61,7 +61,7 @@ acceptance("User Preferences - Interface", function (needs) {
 
   test("does not show option to disable dark mode by default", async function (assert) {
     await visit("/u/eviltrout/preferences/interface");
-    assert.equal($(".control-group.dark-mode").length, 0);
+    assert.ok(!exists(".control-group.dark-mode"), "option not visible");
   });
 
   test("shows light/dark color scheme pickers", async function (assert) {
@@ -72,8 +72,8 @@ acceptance("User Preferences - Interface", function (needs) {
     ]);
 
     await visit("/u/eviltrout/preferences/interface");
-    assert.ok($(".light-color-scheme").length, "has regular dropdown");
-    assert.ok($(".dark-color-scheme").length, "has dark color scheme dropdown");
+    assert.ok(exists(".light-color-scheme"), "has regular dropdown");
+    assert.ok(exists(".dark-color-scheme"), "has dark color scheme dropdown");
   });
 
   test("shows light color scheme default option when theme's color scheme is not user selectable", async function (assert) {
@@ -85,7 +85,7 @@ acceptance("User Preferences - Interface", function (needs) {
     site.set("user_color_schemes", [{ id: 2, name: "Cool Breeze" }]);
 
     await visit("/u/eviltrout/preferences/interface");
-    assert.ok($(".light-color-scheme").length, "has regular dropdown");
+    assert.ok(exists(".light-color-scheme"), "has regular dropdown");
 
     assert.equal(
       selectKit(".light-color-scheme .select-kit").header().value(),
@@ -121,12 +121,12 @@ acceptance("User Preferences - Interface", function (needs) {
 
     await visit("/u/eviltrout/preferences/interface");
 
-    assert.ok($(".light-color-scheme").length, "has regular dropdown");
+    assert.ok(exists(".light-color-scheme"), "has regular dropdown");
     assert.equal(selectKit(".theme .select-kit").header().value(), 2);
 
     await selectKit(".light-color-scheme .select-kit").expand();
     assert.equal(
-      $(".light-color-scheme .select-kit .select-kit-row").length,
+      queryAll(".light-color-scheme .select-kit .select-kit-row").length,
       2
     );
 
@@ -151,7 +151,7 @@ acceptance(
       await visit("/u/eviltrout/preferences/interface");
 
       assert.ok(
-        $(".control-group.dark-mode").length,
+        exists(".control-group.dark-mode"),
         "it has the option to disable dark mode"
       );
     });
@@ -161,7 +161,7 @@ acceptance(
       site.set("user_color_schemes", []);
 
       await visit("/u/eviltrout/preferences/interface");
-      assert.equal($(".control-group.color-scheme").length, 0);
+      assert.ok(!exists(".control-group.color-scheme"));
     });
 
     test("light color scheme picker", async function (assert) {
@@ -169,10 +169,9 @@ acceptance(
       site.set("user_color_schemes", [{ id: 2, name: "Cool Breeze" }]);
 
       await visit("/u/eviltrout/preferences/interface");
-      assert.ok($(".light-color-scheme").length, "has regular picker dropdown");
-      assert.equal(
-        $(".dark-color-scheme").length,
-        0,
+      assert.ok(exists(".light-color-scheme"), "has regular picker dropdown");
+      assert.ok(
+        !exists(".dark-color-scheme"),
         "does not have a dark color scheme picker"
       );
     });
@@ -196,18 +195,15 @@ acceptance(
       };
 
       await visit("/u/eviltrout/preferences/interface");
-      assert.ok($(".light-color-scheme").length, "has regular dropdown");
-      assert.ok(
-        $(".dark-color-scheme").length,
-        "has dark color scheme dropdown"
-      );
+      assert.ok(exists(".light-color-scheme"), "has regular dropdown");
+      assert.ok(exists(".dark-color-scheme"), "has dark color scheme dropdown");
       assert.equal(
-        $(".dark-color-scheme .selected-name").data("value"),
+        queryAll(".dark-color-scheme .selected-name").data("value"),
         session.userDarkSchemeId,
         "sets site default as selected dark scheme"
       );
-      assert.equal(
-        $(".control-group.dark-mode").length,
+      assert.ok(
+        !exists(".control-group.dark-mode"),
         0,
         "it does not show disable dark mode checkbox"
       );

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -58,8 +58,7 @@ class Theme < ActiveRecord::Base
       theme_fields.select(&:basic_html_field?).each(&:invalidate_baked!)
     end
 
-    Theme.expire_site_cache! if saved_change_to_user_selectable? || saved_change_to_name?
-    Theme.expire_site_cache! if saved_change_to_color_scheme_id?
+    Theme.expire_site_cache! if saved_change_to_color_scheme_id? || saved_change_to_user_selectable? || saved_change_to_name?
     notify_with_scheme = saved_change_to_color_scheme_id?
 
     reload

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -59,6 +59,7 @@ class Theme < ActiveRecord::Base
     end
 
     Theme.expire_site_cache! if saved_change_to_user_selectable? || saved_change_to_name?
+    Theme.expire_site_cache! if saved_change_to_color_scheme_id?
     notify_with_scheme = saved_change_to_color_scheme_id?
 
     reload

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -947,7 +947,7 @@ en:
       color_scheme_default_on_all_devices: "Set default color scheme(s) on all my devices"
       color_scheme: "Color Scheme"
       color_schemes:
-        default_description: "Default"
+        default_description: "Theme default"
         disable_dark_scheme: "Same as regular"
         dark_instructions: "You can preview the dark mode color scheme by toggling your device's dark mode."
         undo: "Reset"

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -21,6 +21,8 @@ describe Site do
     default_theme = Fabricate(:theme)
     SiteSetting.default_theme_id = default_theme.id
     user_theme = Fabricate(:theme, user_selectable: true)
+    second_user_theme = Fabricate(:theme, user_selectable: true)
+    color_scheme = Fabricate(:color_scheme)
 
     anon_guardian = Guardian.new
     user_guardian = Guardian.new(Fabricate(:user))
@@ -39,6 +41,11 @@ describe Site do
     expect_correct_themes(anon_guardian)
     expect_correct_themes(user_guardian)
 
+    second_user_theme.color_scheme_id = color_scheme.id
+    second_user_theme.save!
+
+    expect_correct_themes(anon_guardian)
+    expect_correct_themes(user_guardian)
   end
 
   it "returns correct notification level for categories" do


### PR DESCRIPTION
Previously, we were showing a "Default" option in the Color Scheme dropdown (in user preferences) at all times. This PR renames that option to the "Theme default", and only shows it if the currently selected theme's color scheme is not marked as user selectable. 

This PR also fixes an issue where a color scheme's ID was being displayed if the user had previously selected it and the scheme was no longer available (deleted or no longer user selectable). 
