### PR TITLE
FIX: Don't count HTML comments when calculating reply length.

### DIFF
--- a/app/assets/javascripts/discourse/app/models/composer.js
+++ b/app/assets/javascripts/discourse/app/models/composer.js
@@ -536,6 +536,11 @@ const Composer = RestModel.extend({
       return reply.length;
     }
 
+    const commentsRegexp = /<!--(.*?)-->/gm;
+    while (commentsRegexp.test(reply)) {
+      reply = reply.replace(commentsRegexp, "");
+    }
+
     while (QUOTE_REGEXP.test(reply)) {
       // make it global so we can strip as many quotes at once
       // keep in mind nested quotes mean we still need a loop here

--- a/app/assets/javascripts/discourse/tests/unit/models/composer-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/composer-test.js
@@ -47,6 +47,19 @@ discourseModule("Unit | Model | composer", function () {
       2,
       "handles nested quotes correctly"
     );
+    replyLength("<!-- a commnent -->", 0, "remove comments");
+
+    replyLength(
+      "<!-- a comment -->\n more text \n<!-- a comment -->",
+      9,
+      "remove multiple comments"
+    );
+
+    replyLength(
+      "<!-- <!-- a comment --> -->more text",
+      12,
+      "remove multiple comments"
+    );
   });
 
   test("missingReplyCharacters", function (assert) {

--- a/lib/validators/stripped_length_validator.rb
+++ b/lib/validators/stripped_length_validator.rb
@@ -2,8 +2,11 @@
 
 class StrippedLengthValidator < ActiveModel::EachValidator
   def self.validate(record, attribute, value, range)
-    unless value.nil?
-      stripped_length = value.strip.length
+    if !value.nil?
+      html_comments_regexp = /<!--(.*?)-->/
+      stripped_length = value.gsub(html_comments_regexp, '')
+      stripped_length = stripped_length.strip.length
+
       record.errors.add attribute, (I18n.t('errors.messages.too_short', count: range.begin)) unless
           stripped_length >= range.begin
       record.errors.add attribute, (I18n.t('errors.messages.too_long_validation', max: range.end, length: stripped_length)) unless

--- a/spec/components/validators/post_validator_spec.rb
+++ b/spec/components/validators/post_validator_spec.rb
@@ -57,6 +57,24 @@ describe PostValidator do
       validator.stripped_length(post)
       expect(post.errors.count).to eq(0)
     end
+
+    it "ignores an html comment" do
+      post.raw = "<!-- an html comment -->abc"
+      validator.stripped_length(post)
+      expect(post.errors.count).to eq(1)
+    end
+
+    it "ignores multiple html comments" do
+      post.raw = "<!-- an html comment -->\n abc \n<!-- a comment -->"
+      validator.stripped_length(post)
+      expect(post.errors.count).to eq(1)
+    end
+
+    it "ignores nested html comments" do
+      post.raw = "<!-- <!-- an html comment --> -->"
+      validator.stripped_length(post)
+      expect(post.errors.count).to eq(1)
+    end
   end
 
   context "too_many_posts" do


### PR DESCRIPTION
We'll remove them when we sanitize the post raw content.
