### PR TITLE
DEV: Improvements to Discourse Merger script

### DIFF
--- a/script/bulk_import/discourse_merger.rb
+++ b/script/bulk_import/discourse_merger.rb
@@ -179,7 +179,6 @@ class BulkImport::DiscourseMerger < BulkImport::Base
 
     columns = Category.columns.map(&:name)
     imported_ids = []
-    parent_ids = []
     last_id = Category.unscoped.maximum(:id) || 1
 
     sql = "COPY categories (#{columns.map { |c| "\"#{c}\"" }.join(', ')}) FROM STDIN"


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->

After running the Discourse merge script, it was pretty evident it held up well after all these years ;)

Made a few fixes:
- Included an environment variable for DB_PASS as likely the password will need to be changed if running the import in an official Docker container (recommended)
- Set a hard order for imported categories, otherwise sometimes they'd be imported in a weird order making things unpredictable for parent/child category imports
- Fixed a couple of instances where we added unique indexes (such as on category slugs)
- Set up upload regex to handle AWS URLs better
- Fixed the script to work with frozen string literals

I tried to review for other performance improvements but this script is *fast* as it is already. The merge I ran took less than five minutes to complete (probably closer to two minutes).

When we're ready to merge this, I'll update the guide on Meta with some helpful info regarding the password change issue.