### PR TITLE
FIX: Discobot exception when site_contact_username is promoted

### DIFF
--- a/plugins/discourse-narrative-bot/plugin.rb
+++ b/plugins/discourse-narrative-bot/plugin.rb
@@ -302,7 +302,9 @@ after_initialize do
                   discobot_username: ::DiscourseNarrativeBot::Base.new.discobot_username,
                   reset_trigger: "#{::DiscourseNarrativeBot::TrackSelector.reset_trigger} #{::DiscourseNarrativeBot::AdvancedUserNarrative.reset_trigger}")
 
-      recipient = args[:post].topic.topic_users.where.not(user_id: args[:post].user_id).last.user
+      recipient = args[:post].topic.topic_users.where.not(user_id: args[:post].user_id).last&.user
+      recipient ||= Discourse.site_contact_user if args[:post].user == Discourse.site_contact_user
+      return if recipient.nil?
 
       PostCreator.create!(
         ::DiscourseNarrativeBot::Base.new.discobot_user,

--- a/plugins/discourse-narrative-bot/spec/discourse_narrative_bot/advanced_user_narrative_spec.rb
+++ b/plugins/discourse-narrative-bot/spec/discourse_narrative_bot/advanced_user_narrative_spec.rb
@@ -741,4 +741,14 @@ RSpec.describe DiscourseNarrativeBot::AdvancedUserNarrative do
     expect(Topic.last.title).to eq(I18n.t("discourse_narrative_bot.tl2_promotion_message.subject_template"))
     expect(Topic.last.topic_users.map(&:user_id).sort).to eq([DiscourseNarrativeBot::Base.new.discobot_user.id, recipient.id])
   end
+
+  it 'invites the site_contact_username to advanced training fine as well' do
+    recipient = Post.last.user
+    SiteSetting.site_contact_username = recipient.username
+    expect {
+      DiscourseEvent.trigger(:system_message_sent, post: Post.last, message_type: 'tl2_promotion_message')
+    }.to change { Topic.count }
+    expect(Topic.last.title).to eq(I18n.t("discourse_narrative_bot.tl2_promotion_message.subject_template"))
+    expect(Topic.last.topic_users.map(&:user_id).sort).to eq([DiscourseNarrativeBot::Base.new.discobot_user.id, recipient.id])
+  end
 end


### PR DESCRIPTION
Because the site admin is sending a message to themselves, there is only one user in the topic_allowed_users, and `.last` returns nil.
Attempt to recognize this situation and continue, or bail without doing anything if this somehow happens another way.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
