### PR TITLE
FIX: broken emojis in topic excerpt

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -486,7 +486,7 @@ class Post < ActiveRecord::Base
   end
 
   def excerpt_for_topic
-    Post.excerpt(cooked, SiteSetting.topic_excerpt_maxlength, strip_links: true, strip_images: true, strip_broken_emoji: true, post: self)
+    Post.excerpt(cooked, SiteSetting.topic_excerpt_maxlength, strip_links: true, strip_images: true, strip_truncated_emoji_code: true, post: self)
   end
 
   def is_first_post?

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -486,7 +486,7 @@ class Post < ActiveRecord::Base
   end
 
   def excerpt_for_topic
-    Post.excerpt(cooked, SiteSetting.topic_excerpt_maxlength, strip_links: true, strip_images: true, post: self)
+    Post.excerpt(cooked, SiteSetting.topic_excerpt_maxlength, strip_links: true, strip_images: true, strip_broken_emoji: true, post: self)
   end
 
   def is_first_post?

--- a/lib/excerpt_parser.rb
+++ b/lib/excerpt_parser.rb
@@ -13,6 +13,7 @@ class ExcerptParser < Nokogiri::XML::SAX::Document
     options || {}
     @strip_links = options[:strip_links] == true
     @strip_images = options[:strip_images] == true
+    @strip_broken_emoji = options[:strip_broken_emoji] == true
     @text_entities = options[:text_entities] == true
     @markdown_images = options[:markdown_images] == true
     @keep_newlines = options[:keep_newlines] == true
@@ -207,7 +208,7 @@ class ExcerptParser < Nokogiri::XML::SAX::Document
     encode = encode ? lambda { |s| ERB::Util.html_escape(s) } : lambda { |s| s }
     if count_it && @current_length + string.length > @length
       length = [0, @length - @current_length - 1].max
-      @excerpt << encode.call(string[0..length]) if truncate
+      @excerpt << encode.call(string[0..length]) if truncate && !broken_emoji?(string)
       @excerpt << (@text_entities ? "..." : "&hellip;")
       @excerpt << "</a>" if @in_a
       @excerpt << after_string if after_string
@@ -217,5 +218,13 @@ class ExcerptParser < Nokogiri::XML::SAX::Document
     @excerpt << encode.call(string)
     @excerpt << after_string if after_string
     @current_length += string.length if count_it
+  end
+
+  def broken_emoji?(string)
+    @strip_broken_emoji && emoji?(string)
+  end
+
+  def emoji?(string)
+    string.match?(/:\w+:/)
   end
 end

--- a/lib/excerpt_parser.rb
+++ b/lib/excerpt_parser.rb
@@ -13,7 +13,7 @@ class ExcerptParser < Nokogiri::XML::SAX::Document
     options || {}
     @strip_links = options[:strip_links] == true
     @strip_images = options[:strip_images] == true
-    @strip_broken_emoji = options[:strip_broken_emoji] == true
+    @strip_truncated_emoji_code = options[:strip_truncated_emoji_code] == true
     @text_entities = options[:text_entities] == true
     @markdown_images = options[:markdown_images] == true
     @keep_newlines = options[:keep_newlines] == true
@@ -208,7 +208,7 @@ class ExcerptParser < Nokogiri::XML::SAX::Document
     encode = encode ? lambda { |s| ERB::Util.html_escape(s) } : lambda { |s| s }
     if count_it && @current_length + string.length > @length
       length = [0, @length - @current_length - 1].max
-      @excerpt << encode.call(string[0..length]) if truncate && !broken_emoji?(string)
+      @excerpt << encode.call(string[0..length]) if truncate && !truncated_emoji_code?(string)
       @excerpt << (@text_entities ? "..." : "&hellip;")
       @excerpt << "</a>" if @in_a
       @excerpt << after_string if after_string
@@ -220,8 +220,8 @@ class ExcerptParser < Nokogiri::XML::SAX::Document
     @current_length += string.length if count_it
   end
 
-  def broken_emoji?(string)
-    @strip_broken_emoji && emoji?(string)
+  def truncated_emoji_code?(string)
+    @strip_truncated_emoji_code && emoji?(string)
   end
 
   def emoji?(string)

--- a/spec/components/pretty_text_spec.rb
+++ b/spec/components/pretty_text_spec.rb
@@ -641,16 +641,16 @@ describe PrettyText do
         html = <<~EOS
           <img src=\"//localhost:3000/images/emoji/twitter/bike.png?v=9\" title=\":bike:\" class=\"emoji\" alt=\":bike:\"> <img src=\"//localhost:3000/images/emoji/twitter/cat.png?v=9\" title=\":cat:\" class=\"emoji\" alt=\":cat:\"> <img src=\"//localhost:3000/images/emoji/twitter/discourse.png?v=9\" title=\":discourse:\" class=\"emoji\" alt=\":discourse:\">
         EOS
-        expect(PrettyText.excerpt(html, 10, strip_broken_emoji: false)).to eq(":bike: :ca&hellip;")
+        expect(PrettyText.excerpt(html, 10, strip_truncated_emoji_code: false)).to eq(":bike: :ca&hellip;")
 
-        expect(PrettyText.excerpt(html, 7, strip_broken_emoji: true)).to eq(":bike: &hellip;")
-        expect(PrettyText.excerpt(html, 8, strip_broken_emoji: true)).to eq(":bike: &hellip;")
-        expect(PrettyText.excerpt(html, 9, strip_broken_emoji: true)).to eq(":bike: &hellip;")
-        expect(PrettyText.excerpt(html, 10, strip_broken_emoji: true)).to eq(":bike: &hellip;")
-        expect(PrettyText.excerpt(html, 11, strip_broken_emoji: true)).to eq(":bike: &hellip;")
-        expect(PrettyText.excerpt(html, 12, strip_broken_emoji: true)).to eq(":bike: :cat: &hellip;")
-        expect(PrettyText.excerpt(html, 13, strip_broken_emoji: true)).to eq(":bike: :cat: &hellip;")
-        expect(PrettyText.excerpt(html, 14, strip_broken_emoji: true)).to eq(":bike: :cat: &hellip;")
+        expect(PrettyText.excerpt(html, 7, strip_truncated_emoji_code: true)).to eq(":bike: &hellip;")
+        expect(PrettyText.excerpt(html, 8, strip_truncated_emoji_code: true)).to eq(":bike: &hellip;")
+        expect(PrettyText.excerpt(html, 9, strip_truncated_emoji_code: true)).to eq(":bike: &hellip;")
+        expect(PrettyText.excerpt(html, 10, strip_truncated_emoji_code: true)).to eq(":bike: &hellip;")
+        expect(PrettyText.excerpt(html, 11, strip_truncated_emoji_code: true)).to eq(":bike: &hellip;")
+        expect(PrettyText.excerpt(html, 12, strip_truncated_emoji_code: true)).to eq(":bike: :cat: &hellip;")
+        expect(PrettyText.excerpt(html, 13, strip_truncated_emoji_code: true)).to eq(":bike: :cat: &hellip;")
+        expect(PrettyText.excerpt(html, 14, strip_truncated_emoji_code: true)).to eq(":bike: :cat: &hellip;")
       end
     end
 

--- a/spec/components/pretty_text_spec.rb
+++ b/spec/components/pretty_text_spec.rb
@@ -636,6 +636,24 @@ describe PrettyText do
       end
     end
 
+    context "emojis" do
+      it "should remove broken emoji" do
+        html = <<~EOS
+          <img src=\"//localhost:3000/images/emoji/twitter/bike.png?v=9\" title=\":bike:\" class=\"emoji\" alt=\":bike:\"> <img src=\"//localhost:3000/images/emoji/twitter/cat.png?v=9\" title=\":cat:\" class=\"emoji\" alt=\":cat:\"> <img src=\"//localhost:3000/images/emoji/twitter/discourse.png?v=9\" title=\":discourse:\" class=\"emoji\" alt=\":discourse:\">
+        EOS
+        expect(PrettyText.excerpt(html, 10, strip_broken_emoji: false)).to eq(":bike: :ca&hellip;")
+
+        expect(PrettyText.excerpt(html, 7, strip_broken_emoji: true)).to eq(":bike: &hellip;")
+        expect(PrettyText.excerpt(html, 8, strip_broken_emoji: true)).to eq(":bike: &hellip;")
+        expect(PrettyText.excerpt(html, 9, strip_broken_emoji: true)).to eq(":bike: &hellip;")
+        expect(PrettyText.excerpt(html, 10, strip_broken_emoji: true)).to eq(":bike: &hellip;")
+        expect(PrettyText.excerpt(html, 11, strip_broken_emoji: true)).to eq(":bike: &hellip;")
+        expect(PrettyText.excerpt(html, 12, strip_broken_emoji: true)).to eq(":bike: :cat: &hellip;")
+        expect(PrettyText.excerpt(html, 13, strip_broken_emoji: true)).to eq(":bike: :cat: &hellip;")
+        expect(PrettyText.excerpt(html, 14, strip_broken_emoji: true)).to eq(":bike: :cat: &hellip;")
+      end
+    end
+
     it "should have an option to strip links" do
       expect(PrettyText.excerpt("<a href='http://cnn.com'>cnn</a>", 100, strip_links: true)).to eq("cnn")
     end


### PR DESCRIPTION
When a post is truncated into the excerpt, sometimes we are breaking emojis

Before:
![image](https://user-images.githubusercontent.com/72780/103970703-fc170280-51bc-11eb-9acb-9fb2c9788023.png)

After:
![image](https://user-images.githubusercontent.com/72780/103970834-44cebb80-51bd-11eb-8427-c38a04d0b48a.png)


