### PR TITLE
FIX: hidden tags returned in extras of tags index json

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -50,8 +50,12 @@ class TagsController < ::ApplicationController
         .includes(:tags)
 
       category_tag_counts = categories.map do |c|
-        { id: c.id, tags: self.class.tag_counts_json(c.tags.where(target_tag_id: nil)) }
-      end
+        category_tags = self.class.tag_counts_json(
+          DiscourseTagging.filter_visible(c.tags.where(target_tag_id: nil), guardian)
+        )
+        next if category_tags.empty?
+        { id: c.id, tags: category_tags }
+      end.compact
 
       @tags = self.class.tag_counts_json(unrestricted_tags, show_pm_tags: guardian.can_tag_pms?)
       @extras = { categories: category_tag_counts }

--- a/spec/requests/tags_controller_spec.rb
+++ b/spec/requests/tags_controller_spec.rb
@@ -106,7 +106,6 @@ describe TagsController do
     end
 
     context "when user can admin tags" do
-
       it "succesfully retrieve all tags" do
         sign_in(admin)
 
@@ -117,7 +116,88 @@ describe TagsController do
         tags = response.parsed_body["tags"]
         expect(tags.length).to eq(2)
       end
+    end
 
+    context "with hidden tags" do
+      before do
+        create_hidden_tags(["staff1"])
+      end
+
+      it "is returned to admins" do
+        sign_in(admin)
+        get "/tags.json"
+        expect(response.parsed_body["tags"].map { |t| t["text"] }).to include("staff1")
+        expect(response.parsed_body["extras"]["categories"]).to be_empty
+      end
+
+      it "is not returned to anon" do
+        get "/tags.json"
+        expect(response.parsed_body["tags"].map { |t| t["text"] }).to_not include("staff1")
+        expect(response.parsed_body["extras"]["categories"]).to be_empty
+      end
+
+      it "is not returned to regular user" do
+        sign_in(user)
+        get "/tags.json"
+        expect(response.parsed_body["tags"].map { |t| t["text"] }).to_not include("staff1")
+        expect(response.parsed_body["extras"]["categories"]).to be_empty
+      end
+
+      context "restricted to a category" do
+        before do
+          category.tags = [Tag.find_by_name("staff1")]
+        end
+
+        it "is returned to admins" do
+          sign_in(admin)
+          get "/tags.json"
+          expect(response.parsed_body["tags"].map { |t| t["text"] }).to include("staff1")
+          categories = response.parsed_body["extras"]["categories"]
+          expect(categories.length).to eq(1)
+          expect(categories.first["tags"].map { |t| t["text"] }).to include("staff1")
+        end
+
+        it "is not returned to anon" do
+          get "/tags.json"
+          expect(response.parsed_body["tags"].map { |t| t["text"] }).to_not include("staff1")
+          expect(response.parsed_body["extras"]["categories"]).to be_empty
+        end
+
+        it "is not returned to regular user" do
+          sign_in(user)
+          get "/tags.json"
+          expect(response.parsed_body["tags"].map { |t| t["text"] }).to_not include("staff1")
+          expect(response.parsed_body["extras"]["categories"]).to be_empty
+        end
+      end
+
+      context "listed by group" do
+        before do
+          SiteSetting.tags_listed_by_group = true
+        end
+
+        it "is returned to admins" do
+          sign_in(admin)
+          get "/tags.json"
+          expect(response.parsed_body["tags"].map { |t| t["text"] }).to_not include("staff1")
+          tag_groups = response.parsed_body["extras"]["tag_groups"]
+          expect(tag_groups.length).to eq(1)
+          expect(tag_groups.first["tags"].map { |t| t["text"] }).to include("staff1")
+        end
+
+        it "is not returned to anon" do
+          get "/tags.json"
+          expect(response.parsed_body["tags"].map { |t| t["text"] }).to_not include("staff1")
+          expect(response.parsed_body["extras"]["tag_groups"]).to be_empty
+        end
+
+        it "is not returned to regular user" do
+          sign_in(user)
+          get "/tags.json"
+          expect(response.parsed_body["tags"].map { |t| t["text"] }).to_not include("staff1")
+          expect(response.parsed_body["extras"]["tag_groups"]).to be_empty
+        end
+      end
     end
   end
 


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
