### PR TITLE
FIX: Do not include URL query in auto-generated CSP header

### DIFF
--- a/lib/content_security_policy/extension.rb
+++ b/lib/content_security_policy/extension.rb
@@ -70,6 +70,8 @@ class ContentSecurityPolicy
         next if uri.host.nil? # Ignore same-domain scripts (theme-javascripts)
         next if uri.path.nil? # Ignore raw hosts
 
+        uri.query = nil # CSP should not include query part of url
+
         uri_string = uri.to_s.sub(/^\/\//, '') # Protocol-less CSP should not have // at beginning of URL
 
         auto_script_src_extension[:script_src] << uri_string

--- a/spec/lib/content_security_policy_spec.rb
+++ b/spec/lib/content_security_policy_spec.rb
@@ -239,6 +239,7 @@ describe ContentSecurityPolicy do
 
       theme.set_field(target: :common, name: "header", value: <<~SCRIPT)
         <script src='https://example.com/myscript.js'></script>
+        <script src='https://example.com/myscript2.js?with=query'></script>
         <script src='//example2.com/protocol-less-script.js'></script>
         <script src='domain-only.com'></script>
         <script>console.log('inline script')</script>
@@ -248,6 +249,8 @@ describe ContentSecurityPolicy do
       theme.save!
 
       expect(parse(theme_policy)['script-src']).to include('https://example.com/myscript.js')
+      expect(parse(theme_policy)['script-src']).to include('https://example.com/myscript2.js')
+      expect(parse(theme_policy)['script-src']).not_to include('?')
       expect(parse(theme_policy)['script-src']).to include('example2.com/protocol-less-script.js')
       expect(parse(theme_policy)['script-src']).not_to include('domain-only.com')
       expect(parse(theme_policy)['script-src']).not_to include(a_string_matching /^\/theme-javascripts/)


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
