### PR TITLE
UX: add space between links and text in labels

### DIFF
--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -132,6 +132,11 @@ label {
     align-self: center;
     margin-right: 4px;
   }
+  a {
+    // flex removes whitespace characters between text nodes and elements
+    // so we need to add it back
+    margin: 0 0.25em;
+  }
 }
 
 input {


### PR DESCRIPTION
Flex removes spaces between text and elements, so we need to add a little margin to avoid this: 

![Screen Shot 2021-01-08 at 9 07 45 PM](https://user-images.githubusercontent.com/1681963/104080500-51233a80-51f6-11eb-9ee6-5801a07e408d.png)

