### PR TITLE
FIX: always truncate uncomplete emojis in excerpts

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -486,7 +486,7 @@ class Post < ActiveRecord::Base
   end
 
   def excerpt_for_topic
-    Post.excerpt(cooked, SiteSetting.topic_excerpt_maxlength, strip_links: true, strip_images: true, strip_truncated_emoji_code: true, post: self)
+    Post.excerpt(cooked, SiteSetting.topic_excerpt_maxlength, strip_links: true, strip_images: true, post: self)
   end
 
   def is_first_post?

--- a/lib/excerpt_parser.rb
+++ b/lib/excerpt_parser.rb
@@ -220,6 +220,6 @@ class ExcerptParser < Nokogiri::XML::SAX::Document
   end
 
   def emoji?(string)
-    string.match?(/^:\w+:$/)
+    string.match?(/\A:\w+:\Z/)
   end
 end

--- a/lib/excerpt_parser.rb
+++ b/lib/excerpt_parser.rb
@@ -13,7 +13,6 @@ class ExcerptParser < Nokogiri::XML::SAX::Document
     options || {}
     @strip_links = options[:strip_links] == true
     @strip_images = options[:strip_images] == true
-    @strip_truncated_emoji_code = options[:strip_truncated_emoji_code] == true
     @text_entities = options[:text_entities] == true
     @markdown_images = options[:markdown_images] == true
     @keep_newlines = options[:keep_newlines] == true
@@ -208,7 +207,7 @@ class ExcerptParser < Nokogiri::XML::SAX::Document
     encode = encode ? lambda { |s| ERB::Util.html_escape(s) } : lambda { |s| s }
     if count_it && @current_length + string.length > @length
       length = [0, @length - @current_length - 1].max
-      @excerpt << encode.call(string[0..length]) if truncate && !truncated_emoji_code?(string)
+      @excerpt << encode.call(string[0..length]) if truncate && !emoji?(string)
       @excerpt << (@text_entities ? "..." : "&hellip;")
       @excerpt << "</a>" if @in_a
       @excerpt << after_string if after_string
@@ -220,11 +219,7 @@ class ExcerptParser < Nokogiri::XML::SAX::Document
     @current_length += string.length if count_it
   end
 
-  def truncated_emoji_code?(string)
-    @strip_truncated_emoji_code && emoji?(string)
-  end
-
   def emoji?(string)
-    string.match?(/:\w+:/)
+    string.match?(/^:\w+:$/)
   end
 end

--- a/spec/components/pretty_text_spec.rb
+++ b/spec/components/pretty_text_spec.rb
@@ -641,16 +641,14 @@ describe PrettyText do
         html = <<~EOS
           <img src=\"//localhost:3000/images/emoji/twitter/bike.png?v=9\" title=\":bike:\" class=\"emoji\" alt=\":bike:\"> <img src=\"//localhost:3000/images/emoji/twitter/cat.png?v=9\" title=\":cat:\" class=\"emoji\" alt=\":cat:\"> <img src=\"//localhost:3000/images/emoji/twitter/discourse.png?v=9\" title=\":discourse:\" class=\"emoji\" alt=\":discourse:\">
         EOS
-        expect(PrettyText.excerpt(html, 10, strip_truncated_emoji_code: false)).to eq(":bike: :ca&hellip;")
-
-        expect(PrettyText.excerpt(html, 7, strip_truncated_emoji_code: true)).to eq(":bike: &hellip;")
-        expect(PrettyText.excerpt(html, 8, strip_truncated_emoji_code: true)).to eq(":bike: &hellip;")
-        expect(PrettyText.excerpt(html, 9, strip_truncated_emoji_code: true)).to eq(":bike: &hellip;")
-        expect(PrettyText.excerpt(html, 10, strip_truncated_emoji_code: true)).to eq(":bike: &hellip;")
-        expect(PrettyText.excerpt(html, 11, strip_truncated_emoji_code: true)).to eq(":bike: &hellip;")
-        expect(PrettyText.excerpt(html, 12, strip_truncated_emoji_code: true)).to eq(":bike: :cat: &hellip;")
-        expect(PrettyText.excerpt(html, 13, strip_truncated_emoji_code: true)).to eq(":bike: :cat: &hellip;")
-        expect(PrettyText.excerpt(html, 14, strip_truncated_emoji_code: true)).to eq(":bike: :cat: &hellip;")
+        expect(PrettyText.excerpt(html, 7)).to eq(":bike: &hellip;")
+        expect(PrettyText.excerpt(html, 8)).to eq(":bike: &hellip;")
+        expect(PrettyText.excerpt(html, 9)).to eq(":bike: &hellip;")
+        expect(PrettyText.excerpt(html, 10)).to eq(":bike: &hellip;")
+        expect(PrettyText.excerpt(html, 11)).to eq(":bike: &hellip;")
+        expect(PrettyText.excerpt(html, 12)).to eq(":bike: :cat: &hellip;")
+        expect(PrettyText.excerpt(html, 13)).to eq(":bike: :cat: &hellip;")
+        expect(PrettyText.excerpt(html, 14)).to eq(":bike: :cat: &hellip;")
       end
     end
 


### PR DESCRIPTION
Additional fix after https://github.com/discourse/discourse/pull/11667

Always truncate "broken" emojis from excerpts.