### PR TITLE
FIX: Hiding a post should not trigger the duplicate check

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -529,6 +529,7 @@ class Post < ActiveRecord::Base
     self.hidden = true
     self.hidden_at = Time.zone.now
     self.hidden_reason_id = reason
+    self.skip_unique_check = true
     save!
 
     Topic.where(

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1301,6 +1301,21 @@ describe Post do
     end
   end
 
+  describe ".hide!" do
+    after do
+      Discourse.redis.flushdb
+    end
+
+    it "should ignore the duplicate check" do
+      p1 = Fabricate(:post)
+      p2 = Fabricate(:post, user: p1.user)
+      SiteSetting.unique_posts_mins = 10
+      p1.store_unique_post_key
+      p2.reload.hide!(PostActionType.types[:off_topic])
+      expect(p2).to be_hidden
+    end
+  end
+
   describe ".unhide!" do
     before { SiteSetting.unique_posts_mins = 5 }
 


### PR DESCRIPTION
If for some reason a post was allowed to be duplicated (probably via
staff edit) hiding it should be permitted.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
