### PR TITLE
DEV: TopicTrackingState calls should happen in the background

### DIFF
--- a/app/jobs/regular/post_update_topic_tracking_state.rb
+++ b/app/jobs/regular/post_update_topic_tracking_state.rb
@@ -3,8 +3,6 @@
 module Jobs
   class PostUpdateTopicTrackingState < ::Jobs::Base
 
-    sidekiq_options queue: 'critical'
-
     def execute(args)
       post = Post.find_by(id: args[:post_id])
 

--- a/app/jobs/regular/post_update_topic_tracking_state.rb
+++ b/app/jobs/regular/post_update_topic_tracking_state.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Jobs
+  class PostUpdateTopicTrackingState < ::Jobs::Base
+
+    sidekiq_options queue: 'critical'
+
+    def execute(args)
+      post = Post.find_by(id: args[:post_id])
+
+      if post
+        TopicTrackingState.publish_unmuted(post.topic)
+        if post.post_number > 1
+          TopicTrackingState.publish_muted(post.topic)
+          TopicTrackingState.publish_unread(post)
+        end
+        TopicTrackingState.publish_latest(post.topic, post.whisper?)
+      end
+    end
+
+  end
+end

--- a/lib/post_jobs_enqueuer.rb
+++ b/lib/post_jobs_enqueuer.rb
@@ -57,12 +57,7 @@ class PostJobsEnqueuer
   end
 
   def after_post_create
-    TopicTrackingState.publish_unmuted(@post.topic)
-    if @post.post_number > 1
-      TopicTrackingState.publish_muted(@post.topic)
-      TopicTrackingState.publish_unread(@post)
-    end
-    TopicTrackingState.publish_latest(@topic, @post.whisper?)
+    Jobs.enqueue(:post_update_topic_tracking_state, post_id: @post.id)
 
     Jobs.enqueue_in(SiteSetting.email_time_window_mins.minutes,
       :notify_mailing_list_subscribers,

--- a/spec/components/post_creator_spec.rb
+++ b/spec/components/post_creator_spec.rb
@@ -128,8 +128,13 @@ describe PostCreator do
         expect(channels.find { |s| s =~ /new/ }).to eq(nil)
       end
 
-      it "generates the correct messages for a secure topic" do
+      it 'enqueues job to generate messages' do
+        p = creator.create
+        expect(job_enqueued?(job: :post_update_topic_tracking_state, args: { post_id: p.id })).to eq(true)
+      end
 
+      it "generates the correct messages for a secure topic" do
+        Jobs.run_immediately!
         UserActionManager.enable
 
         admin = Fabricate(:admin)
@@ -169,7 +174,7 @@ describe PostCreator do
       end
 
       it 'generates the correct messages for a normal topic' do
-
+        Jobs.run_immediately!
         UserActionManager.enable
 
         p = nil


### PR DESCRIPTION
It was observed that calling TopicTrackingState on popular topics could result in a large number of calls to redis, resulting in slow response times when posting replies.

These calls should be moved to a background job.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
