### PR TITLE
FIX: Publish DND ends_at updates in httpdate format

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -637,7 +637,7 @@ class User < ActiveRecord::Base
   end
 
   def publish_do_not_disturb(ends_at: nil)
-    MessageBus.publish("/do-not-disturb/#{id}", { ends_at: ends_at }, user_ids: [id])
+    MessageBus.publish("/do-not-disturb/#{id}", { ends_at: ends_at&.httpdate }, user_ids: [id])
   end
 
   def password=(password)


### PR DESCRIPTION
```
// Chrome
new Date("2021-01-11 20:49:00 UTC")
Mon Jan 11 2021 14:49:00 GMT-0600 (Central Standard Time)

// Firefox
new Date("2021-01-11 20:49:00 UTC")
Invalid Date
```
There is a bug with firefox, where the `do_not_disturb_until` is set to this style of date via messagebus. Simply forcing the format to `httpdate` fixes it for firefox and still works in chrome.