### PR TITLE
DEV: pass the current category to discovery-list-container-top on tag topic lists 

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/tags/show.hbs
+++ b/app/assets/javascripts/discourse/app/templates/tags/show.hbs
@@ -39,7 +39,7 @@
     {{tag-info tag=tag list=list deleteAction=(action "deleteTag")}}
   {{/if}}
 
-  {{plugin-outlet name="discovery-list-container-top"}}
+  {{plugin-outlet name="discovery-list-container-top" args=(hash category=category)}}
 
   <div class="container list-container">
     <div class="row">


### PR DESCRIPTION
We pass the current category to the `discovery-list-container-top` on category topic lists here.

https://github.com/discourse/discourse/blob/59ef48c0b9d70a6639a545d1c96f3cc6f93ebf2c/app/assets/javascripts/discourse/app/templates/discovery.hbs#L29-L30

but we don't pass it while on a category page and using a tag as a filter

https://github.com/discourse/discourse/blob/024d91410daab7e43629178544387e2746bbf86d/app/assets/javascripts/discourse/app/templates/tags/show.hbs#L42

This PR fixes that so that the current category is available there as well.

