### PR TITLE
FIX: Users can remove themselves from a PM even if they can still access it through a group.

### DIFF
--- a/app/serializers/topic_view_details_serializer.rb
+++ b/app/serializers/topic_view_details_serializer.rb
@@ -163,7 +163,9 @@ class TopicViewDetailsSerializer < ApplicationSerializer
   end
 
   def allowed_users
-    object.topic.allowed_users.reject { |user| object.group_allowed_user_ids.include?(user.id) }
+    object.topic.allowed_users.reject do |user|
+      object.group_allowed_user_ids.include?(user.id) && user != scope.user
+    end
   end
 
   def include_allowed_users?

--- a/spec/serializers/topic_view_details_serializer_spec.rb
+++ b/spec/serializers/topic_view_details_serializer_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe TopicViewDetailsSerializer do
+  describe '#allowed_users' do
+    it "add the current user to the allowed user's list even if they are an allowed group member" do
+      participant = Fabricate(:user)
+      another_participant = Fabricate(:user)
+
+      participant_group = Fabricate(:group)
+      participant_group.add(participant)
+      participant_group.add(another_participant)
+
+      pm = Fabricate(:private_message_topic,
+        topic_allowed_users: [
+          Fabricate.build(:topic_allowed_user, user: participant),
+          Fabricate.build(:topic_allowed_user, user: another_participant)
+        ],
+        topic_allowed_groups: [Fabricate.build(:topic_allowed_group, group: participant_group)]
+      )
+
+      serializer = described_class.new(TopicView.new(pm, participant), scope: Guardian.new(participant))
+      allowed_users = serializer.as_json.dig(:topic_view_details, :allowed_users).map { |u| u[:id] }
+
+      expect(allowed_users).to contain_exactly(participant.id)
+    end
+  end
+end


### PR DESCRIPTION
If a group you're a member of is invited to a PM, you can no longer remove yourself from it. This means you won't be able to remove the message from your inbox, and even if you archive it, it'll come back once someone replies.

With this change, it's up to them to decide if they want to keep it in their inbox or not.

<img width="729" alt="Screen Shot 2021-01-12 at 15 54 16" src="https://user-images.githubusercontent.com/5025816/104359532-89749280-54ee-11eb-9e5d-b90977b916c0.png">


