### PR TITLE
FEATURE: Support translated email track/watch commands

### DIFF
--- a/lib/email/receiver.rb
+++ b/lib/email/receiver.rb
@@ -1021,11 +1021,11 @@ module Email
 
       body = body.strip.downcase
       case body
-      when "mute"
+      when "mute", "muted", I18n.t("js.topic.notifications.muted.title").downcase
         NotificationLevels.topic_levels[:muted]
-      when "track"
+      when "track", I18n.t("js.topic.notifications.tracking.title").downcase
         NotificationLevels.topic_levels[:tracking]
-      when "watch"
+      when "watch", I18n.t("js.topic.notifications.watching.title").downcase
         NotificationLevels.topic_levels[:watching]
       else nil
       end


### PR DESCRIPTION
https://meta.discourse.org/t/ability-to-like-1-a-post-via-email-reply/24135/32?u=riking

The "like" command is translated into the user's language, but track and watch are not.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
