### PR TITLE
FIX: Safari iOS page title and url regression when sharing 

### DIFF
--- a/app/assets/javascripts/discourse/app/initializers/opengraph-tag-updater.js
+++ b/app/assets/javascripts/discourse/app/initializers/opengraph-tag-updater.js
@@ -1,0 +1,20 @@
+import { getAbsoluteURL } from "discourse-common/lib/get-url";
+
+export default {
+  name: "opengraph-tag-updater",
+
+  initialize(container) {
+    // workaround for Safari on iOS 14.3
+    // seems it has started using opengraph tags when sharing
+    let appEvents = container.lookup("service:app-events");
+    const ogTitle = document.querySelector("meta[property='og:title']"),
+      ogUrl = document.querySelector("meta[property='og:url']");
+
+    if (ogTitle && ogUrl) {
+      appEvents.on("page:changed", (data) => {
+        ogTitle.setAttribute("content", data.title);
+        ogUrl.setAttribute("content", getAbsoluteURL(data.url));
+      });
+    }
+  },
+};

--- a/app/assets/javascripts/discourse/tests/acceptance/opengraph-tag-updater-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/opengraph-tag-updater-test.js
@@ -1,0 +1,32 @@
+import { click, visit } from "@ember/test-helpers";
+import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+import { test } from "qunit";
+
+acceptance("Opengraph Tag Updater", function (needs) {
+  needs.pretender((server, helper) => {
+    server.get("/about", () => {
+      return helper.response({});
+    });
+  });
+
+  test("updates OG title and URL", async function (assert) {
+    await visit("/");
+    await click("#toggle-hamburger-menu");
+    await click("a.about-link");
+
+    assert.equal(
+      document
+        .querySelector("meta[property='og:title']")
+        .getAttribute("content"),
+      document.title,
+      "it should update OG title"
+    );
+    assert.ok(
+      document
+        .querySelector("meta[property='og:url']")
+        .getAttribute("content")
+        .endsWith("/about"),
+      "it should update OG URL"
+    );
+  });
+});

--- a/app/views/qunit/index.html.erb
+++ b/app/views/qunit/index.html.erb
@@ -6,6 +6,8 @@
     <%= javascript_include_tag "test_helper" %>
     <%= csrf_meta_tags %>
     <script src="<%= ExtraLocalesController.url('admin') %>"></script>
+    <meta property="og:title" content="">
+    <meta property="og:url" content="">
   </head>
   <body>
     <div id="qunit"></div>


### PR DESCRIPTION
This fixes an issue reported by customers when sharing using Safari on iOS 14.3. As a user navigates the site, Safari doesn't use the current URL and page title, but instead it uses the meta OG tags, which are only set on the first page load. 

This PR updates those OG tags when navigating the site (on all browsers, not just Safari, given that the updated data is correct everywhere).