### PR TITLE
FEATURE: reason to reject user signup

### DIFF
--- a/app/assets/javascripts/discourse/app/components/reviewable-item.js
+++ b/app/assets/javascripts/discourse/app/components/reviewable-item.js
@@ -239,7 +239,7 @@ export default Component.extend({
           model: this.reviewable,
         }).setProperties({
           performConfirmed: this._performConfirmed.bind(this),
-          action: action,
+          action,
         });
       } else {
         return this._performConfirmed(action);

--- a/app/assets/javascripts/discourse/app/components/reviewable-item.js
+++ b/app/assets/javascripts/discourse/app/components/reviewable-item.js
@@ -226,14 +226,14 @@ export default Component.extend({
       }
 
       let msg = action.get("confirm_message");
-      let require_reject_reason = action.get("require_reject_reason");
+      let requireRejectReason = action.get("require_reject_reason");
       if (msg) {
         bootbox.confirm(msg, (answer) => {
           if (answer) {
             return this._performConfirmed(action);
           }
         });
-      } else if (require_reject_reason) {
+      } else if (requireRejectReason) {
         showModal("reject-reason-reviewable", {
           title: "review.reject_reason.title",
           model: this.reviewable,

--- a/app/assets/javascripts/discourse/app/components/reviewable-item.js
+++ b/app/assets/javascripts/discourse/app/components/reviewable-item.js
@@ -110,6 +110,10 @@ export default Component.extend({
         `/review/${reviewable.id}/perform/${action.id}?version=${version}`,
         {
           type: "PUT",
+          data: {
+            send_email: reviewable.sendEmail,
+            reject_reason: reviewable.rejectReason,
+          },
         }
       )
         .then((result) => {
@@ -222,11 +226,20 @@ export default Component.extend({
       }
 
       let msg = action.get("confirm_message");
+      let require_reject_reason = action.get("require_reject_reason");
       if (msg) {
         bootbox.confirm(msg, (answer) => {
           if (answer) {
             return this._performConfirmed(action);
           }
+        });
+      } else if (require_reject_reason) {
+        showModal("reject-reason-reviewable", {
+          title: "review.reject_reason.title",
+          model: this.reviewable,
+        }).setProperties({
+          performConfirmed: this._performConfirmed.bind(this),
+          action: action,
         });
       } else {
         return this._performConfirmed(action);

--- a/app/assets/javascripts/discourse/app/controllers/reject-reason-reviewable.js
+++ b/app/assets/javascripts/discourse/app/controllers/reject-reason-reviewable.js
@@ -1,0 +1,16 @@
+import Controller from "@ember/controller";
+import ModalFunctionality from "discourse/mixins/modal-functionality";
+
+export default Controller.extend(ModalFunctionality, {
+  onShow() {
+    this.setProperties({ rejectReason: "", sendEmail: false });
+  },
+
+  actions: {
+    perform() {
+      this.model.set("rejectReason", this.rejectReason);
+      this.send("closeModal");
+      this.performConfirmed(this.action);
+    },
+  },
+});

--- a/app/assets/javascripts/discourse/app/controllers/reject-reason-reviewable.js
+++ b/app/assets/javascripts/discourse/app/controllers/reject-reason-reviewable.js
@@ -1,5 +1,6 @@
 import Controller from "@ember/controller";
 import ModalFunctionality from "discourse/mixins/modal-functionality";
+import { action } from "@ember/object";
 
 export default Controller.extend(ModalFunctionality, {
   rejectReason: null,
@@ -9,14 +10,13 @@ export default Controller.extend(ModalFunctionality, {
     this.setProperties({ rejectReason: null, sendEmail: false });
   },
 
-  actions: {
-    perform() {
-      this.model.setProperties({
-        rejectReason: this.rejectReason,
-        sendEmail: this.sendEmail,
-      });
-      this.send("closeModal");
-      this.performConfirmed(this.action);
-    },
+  @action
+  perform() {
+    this.model.setProperties({
+      rejectReason: this.rejectReason,
+      sendEmail: this.sendEmail,
+    });
+    this.send("closeModal");
+    this.performConfirmed(this.action);
   },
 });

--- a/app/assets/javascripts/discourse/app/controllers/reject-reason-reviewable.js
+++ b/app/assets/javascripts/discourse/app/controllers/reject-reason-reviewable.js
@@ -2,13 +2,19 @@ import Controller from "@ember/controller";
 import ModalFunctionality from "discourse/mixins/modal-functionality";
 
 export default Controller.extend(ModalFunctionality, {
+  rejectReason: null,
+  sendEmail: false,
+
   onShow() {
-    this.setProperties({ rejectReason: "", sendEmail: false });
+    this.setProperties({ rejectReason: null, sendEmail: false });
   },
 
   actions: {
     perform() {
-      this.model.set("rejectReason", this.rejectReason);
+      this.model.setProperties({
+        rejectReason: this.rejectReason,
+        sendEmail: this.sendEmail,
+      });
       this.send("closeModal");
       this.performConfirmed(this.action);
     },

--- a/app/assets/javascripts/discourse/app/templates/components/reviewable-user.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/reviewable-user.hbs
@@ -34,6 +34,10 @@
       </div>
     {{/if}}
 
+    {{reviewable-field classes="reviewable-user-details reject-reason"
+                       name=(i18n "review.user.reject_reason")
+                       value=reviewable.reject_reason}}
+
     {{#each userFields as |f|}}
       {{reviewable-field classes="reviewable-user-details user-field"
                          name=f.name

--- a/app/assets/javascripts/discourse/app/templates/modal/reject-reason-reviewable.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/reject-reason-reviewable.hbs
@@ -4,7 +4,7 @@
     <label>
       {{input type="checkbox"
         class="inline"
-        checked=model.sendEmail
+        checked=sendEmail
       }}
       {{i18n "review.reject_reason.send_email"}}
     </label>

--- a/app/assets/javascripts/discourse/app/templates/modal/reject-reason-reviewable.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/reject-reason-reviewable.hbs
@@ -1,0 +1,19 @@
+{{#d-modal-body class="explain-reviewable"}}
+  {{textarea value=rejectReason}}
+  <div class="control-group">
+    <label>
+      {{input type="checkbox"
+        class="inline"
+        checked=model.sendEmail
+      }}
+      {{i18n "review.reject_reason.send_email"}}
+    </label>
+  </div>
+{{/d-modal-body}}
+
+<div class="modal-footer">
+  {{d-button action=(route-action "closeModal") label="close"}}
+  <div class="pull-right">
+    {{d-button icon="trash-alt" class="btn-danger" action=(action "perform")}}
+  </div>
+</div>

--- a/app/assets/javascripts/discourse/tests/acceptance/review-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/review-test.js
@@ -1,5 +1,6 @@
 import { acceptance, queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { click, fillIn, visit } from "@ember/test-helpers";
+import I18n from "I18n";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { test } from "qunit";
 
@@ -32,6 +33,33 @@ acceptance("Review", function (needs) {
     assert.ok(
       queryAll(".reviewable-topic").length,
       "it has a list of reviewable topics"
+    );
+  });
+
+  test("Reject user", async function (assert) {
+    await visit("/review");
+    await click(
+      `${user} .reviewable-actions button[data-name="Delete User..."]`
+    );
+    await click(`${user} li[data-value="reject_user_delete"]`);
+    assert.ok(
+      queryAll(".reject-reason-reviewable-modal:visible .title")
+        .html()
+        .includes(I18n.t("review.reject_reason.title")),
+      "it opens reject reason modal when user is rejected"
+    );
+
+    await click(".modal-footer button[aria-label='Close']");
+
+    await click(
+      `${user} .reviewable-actions button[data-name="Delete User..."]`
+    );
+    await click(`${user} li[data-value="reject_user_block"]`);
+    assert.ok(
+      queryAll(".reject-reason-reviewable-modal:visible .title")
+        .html()
+        .includes(I18n.t("review.reject_reason.title")),
+      "it opens reject reason modal when user is rejected and blocked"
     );
   });
 

--- a/app/assets/javascripts/discourse/tests/helpers/review-pretender.js
+++ b/app/assets/javascripts/discourse/tests/helpers/review-pretender.js
@@ -24,7 +24,7 @@ export default function (helpers) {
           created_at: "2019-01-14T19:49:53.571Z",
           username: "newbie",
           email: "newbie@example.com",
-          bundled_action_ids: ["approve", "reject"],
+          bundled_action_ids: ["approve", "reject", "reject_user"],
         },
         {
           id: 4321,
@@ -58,6 +58,12 @@ export default function (helpers) {
           id: "reject",
           action_ids: ["reject"],
         },
+        {
+          id: "reject_user",
+          icon: "user-times",
+          label: "Delete User...",
+          action_ids: ["reject_user_delete", "reject_user_block"],
+        },
       ],
       actions: [
         {
@@ -69,6 +75,23 @@ export default function (helpers) {
           id: "reject",
           label: "Reject",
           icon: "far-thumbs-down",
+        },
+        {
+          id: "reject_user_delete",
+          icon: "user-times",
+          button_class: null,
+          label: "Delete User",
+          description: "The user will be deleted from the forum.",
+          require_reject_reason: true,
+        },
+        {
+          id: "reject_user_block",
+          icon: "ban",
+          button_class: null,
+          label: "Delete and Block User",
+          description:
+            "The user will be deleted, and we'll block their IP and email address.",
+          require_reject_reason: true,
         },
       ],
       reviewable_scores: [{ id: 1 }, { id: 2 }],

--- a/app/controllers/reviewables_controller.rb
+++ b/app/controllers/reviewables_controller.rb
@@ -179,7 +179,7 @@ class ReviewablesController < ApplicationController
   end
 
   def perform
-    args = { version: params[:version].to_i, reject_reason: params[:reject_reason], send_email: params[:send_email] == "true" }
+    args = { version: params[:version].to_i }
 
     result = nil
     begin
@@ -188,6 +188,8 @@ class ReviewablesController < ApplicationController
       if error = claim_error?(reviewable)
         return render_json_error(error)
       end
+
+      args.merge!(reject_reason: params[:reject_reason], send_email: params[:send_email] == "true") if reviewable.type == 'ReviewableUser'
 
       result = reviewable.perform(current_user, params[:action_id].to_sym, args)
     rescue Reviewable::InvalidAction => e

--- a/app/controllers/reviewables_controller.rb
+++ b/app/controllers/reviewables_controller.rb
@@ -179,7 +179,7 @@ class ReviewablesController < ApplicationController
   end
 
   def perform
-    args = { version: params[:version].to_i }
+    args = { version: params[:version].to_i, reject_reason: params[:reject_reason], send_email: params[:send_email] == "true" }
 
     result = nil
     begin

--- a/app/jobs/regular/user_email.rb
+++ b/app/jobs/regular/user_email.rb
@@ -193,6 +193,8 @@ module Jobs
         email_args[:user_history] = UserHistory.where(id: args[:user_history_id]).first
       end
 
+      email_args[:reject_reason] = args[:reject_reason]
+
       message = EmailLog.unique_email_per_post(post, user) do
         UserNotifications.public_send(type, user, email_args)
       end

--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -37,6 +37,14 @@ class UserNotifications < ActionMailer::Base
                 new_user_tips: tips)
   end
 
+  def signup_after_reject(user, opts = {})
+    locale = user_locale(user)
+    build_email(user.email,
+                template: 'user_notifications.signup_after_reject',
+                locale: locale,
+                reject_reason: opts[:reject_reason])
+  end
+
   def suspicious_login(user, opts = {})
     ipinfo = DiscourseIpInfo.get(opts[:client_ip])
     location = ipinfo[:location]

--- a/app/models/reviewable.rb
+++ b/app/models/reviewable.rb
@@ -704,6 +704,8 @@ end
 #  latest_score            :datetime
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
+#  force_review            :boolean          default(FALSE), not null
+#  reject_reason           :text
 #
 # Indexes
 #

--- a/app/serializers/reviewable_action_serializer.rb
+++ b/app/serializers/reviewable_action_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ReviewableActionSerializer < ApplicationSerializer
-  attributes :id, :icon, :button_class, :label, :confirm_message, :description, :client_action
+  attributes :id, :icon, :button_class, :label, :confirm_message, :description, :client_action, :require_reject_reason
 
   def label
     I18n.t(object.label)
@@ -27,4 +27,7 @@ class ReviewableActionSerializer < ApplicationSerializer
     object.client_action.present?
   end
 
+  def include_require_reject_reason?
+    object.require_reject_reason.present?
+  end
 end

--- a/app/serializers/reviewable_user_serializer.rb
+++ b/app/serializers/reviewable_user_serializer.rb
@@ -2,7 +2,7 @@
 
 class ReviewableUserSerializer < ReviewableSerializer
 
-  attributes :link_admin, :user_fields
+  attributes :link_admin, :user_fields, :reject_reason
 
   payload_attributes(
     :username,

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -468,6 +468,7 @@ en:
         email: "Email"
         name: "Name"
         fields: "Fields"
+        reject_reason: "Reason"
 
       user_percentage:
         summary:
@@ -566,6 +567,9 @@ en:
           other: "You have <strong>%{count}</strong> posts pending."
         ok: "OK"
       example_username: "username"
+      reject_reason: 
+        title: "Why do you want to reject user?"
+        send_email: "Send rejection email"
 
     user_action:
       user_posted_topic: "<a href='%{userUrl}'>%{user}</a> posted <a href='%{topicUrl}'>the topic</a>"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -568,7 +568,7 @@ en:
         ok: "OK"
       example_username: "username"
       reject_reason: 
-        title: "Why do you want to reject user?"
+        title: "Why are you rejecting this user?"
         send_email: "Send rejection email"
 
     user_action:

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -3842,6 +3842,14 @@ en:
 
         Enjoy your stay!
 
+    signup_after_reject:
+      title: "Signup After Reject"
+      subject_template: "You've been rejected on %{site_name}!"
+      text_body_template: |
+        A staff member rejected your account on %{site_name}.
+
+        %{reject_reason}
+
     signup:
       title: "Signup"
       subject_template: "[%{email_prefix}] Confirm your new account"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -3844,7 +3844,7 @@ en:
 
     signup_after_reject:
       title: "Signup After Reject"
-      subject_template: "You've been rejected on %{site_name}!"
+      subject_template: "You've been rejected on %{site_name}"
       text_body_template: |
         A staff member rejected your account on %{site_name}.
 

--- a/db/migrate/20210111025920_add_reject_reason_to_reviewables.rb
+++ b/db/migrate/20210111025920_add_reject_reason_to_reviewables.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddRejectReasonToReviewables < ActiveRecord::Migration[6.0]
+  def change
+    add_column :reviewables, :reject_reason, :text
+  end
+end

--- a/lib/reviewable/actions.rb
+++ b/lib/reviewable/actions.rb
@@ -33,7 +33,7 @@ class Reviewable < ActiveRecord::Base
     end
 
     class Action < Item
-      attr_accessor :icon, :button_class, :label, :description, :confirm_message, :client_action
+      attr_accessor :icon, :button_class, :label, :description, :confirm_message, :client_action, :require_reject_reason
 
       def initialize(id, icon = nil, button_class = nil, label = nil)
         super(id)


### PR DESCRIPTION
Feature for `Must Approve Users` setup. When a user is rejected, a staff member can optionally set a reason for audit purposes. In addition, feedback email can be sent to the user.

Meta: https://meta.discourse.org/t/account-rejection-email/103112/8
