### PR TITLE
FIX: Make category change work with shared drafts

### DIFF
--- a/app/assets/javascripts/discourse/app/components/shared-draft-controls.js
+++ b/app/assets/javascripts/discourse/app/components/shared-draft-controls.js
@@ -21,11 +21,15 @@ export default Component.extend({
       bootbox.confirm(I18n.t("shared_drafts.confirm_publish"), (result) => {
         if (result) {
           this.set("publishing", true);
-          let destId = this.get("topic.destination_category_id");
+          const destinationCategoryId = this.topic.destination_category_id;
           this.topic
             .publish()
             .then(() => {
-              this.set("topic.category_id", destId);
+              this.topic.setProperties({
+                category_id: destinationCategoryId,
+                destination_category_id: undefined,
+                is_shared_draft: false,
+              });
             })
             .finally(() => {
               this.set("publishing", false);

--- a/app/assets/javascripts/discourse/app/controllers/topic.js
+++ b/app/assets/javascripts/discourse/app/controllers/topic.js
@@ -111,21 +111,9 @@ export default Controller.extend(bufferedProperty("model"), {
     }
   },
 
-  @discourseComputed(
-    "model.postStream.loaded",
-    "model.category_id",
-    "model.is_shared_draft"
-  )
-  showSharedDraftControls(loaded, categoryId, isSharedDraft) {
-    let draftCat = this.site.shared_drafts_category_id;
-
-    return (
-      loaded &&
-      draftCat &&
-      categoryId &&
-      draftCat === categoryId &&
-      isSharedDraft
-    );
+  @discourseComputed("model.postStream.loaded", "model.is_shared_draft")
+  showSharedDraftControls(loaded, isSharedDraft) {
+    return loaded && isSharedDraft;
   },
 
   @discourseComputed("site.mobileView", "model.posts_count")

--- a/app/assets/javascripts/discourse/app/models/topic.js
+++ b/app/assets/javascripts/discourse/app/models/topic.js
@@ -719,6 +719,10 @@ Topic.reopenClass({
       // The title can be cleaned up server side
       props.title = result.basic_topic.title;
       props.fancy_title = result.basic_topic.fancy_title;
+      if (topic.is_shared_draft) {
+        props.destination_category_id = props.category_id;
+        delete props.category_id;
+      }
       topic.setProperties(props);
     });
   },

--- a/app/assets/javascripts/discourse/tests/acceptance/shared-drafts-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/shared-drafts-test.js
@@ -4,7 +4,7 @@ import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { test } from "qunit";
 
 acceptance("Shared Drafts", function () {
-  test("Viewing", async function (assert) {
+  test("Viewing and publishing", async function (assert) {
     await visit("/t/some-topic/9");
     assert.ok(queryAll(".shared-draft-controls").length === 1);
     let categoryChooser = selectKit(".shared-draft-controls .category-chooser");
@@ -14,5 +14,21 @@ acceptance("Shared Drafts", function () {
     await click(".bootbox .btn-primary");
 
     assert.ok(queryAll(".shared-draft-controls").length === 0);
+  });
+
+  test("Updating category", async function (assert) {
+    await visit("/t/some-topic/9");
+    assert.ok(queryAll(".shared-draft-controls").length === 1);
+
+    await click(".edit-topic");
+
+    let categoryChooser = selectKit(".edit-topic-title .category-chooser");
+    await categoryChooser.expand();
+    await categoryChooser.selectRowByValue(7);
+
+    await click(".edit-controls .btn-primary");
+
+    categoryChooser = selectKit(".shared-draft-controls .category-chooser");
+    assert.equal(categoryChooser.header().value(), "7");
   });
 });

--- a/app/serializers/topic_view_serializer.rb
+++ b/app/serializers/topic_view_serializer.rb
@@ -237,14 +237,13 @@ class TopicViewSerializer < ApplicationSerializer
   end
 
   def include_destination_category_id?
-    scope.can_create_shared_draft? &&
-      object.topic.category_id == SiteSetting.shared_drafts_category.to_i &&
-      object.topic.shared_draft.present?
+    scope.can_create_shared_draft? && object.topic.shared_draft.present?
   end
 
   def is_shared_draft
     include_destination_category_id?
   end
+
   alias_method :include_is_shared_draft?, :include_destination_category_id?
 
   def include_pending_posts?

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -1205,6 +1205,21 @@ RSpec.describe TopicsController do
         expect(topic.reload.category_id).not_to eq(category.id)
       end
 
+      context 'updating shared drafts' do
+        fab!(:shared_drafts_category) { Fabricate(:category) }
+        fab!(:topic) { Fabricate(:topic, category: shared_drafts_category) }
+        fab!(:shared_draft) { Fabricate(:shared_draft, topic: topic, category: Fabricate(:category)) }
+
+        it 'changes destination category' do
+          category = Fabricate(:category)
+
+          put "/t/#{topic.id}.json", params: { category_id: category.id }
+
+          expect(response.status).to eq(403)
+          expect(topic.shared_draft.category_id).not_to eq(category.id)
+        end
+      end
+
       describe 'without permission' do
         it "raises an exception when the user doesn't have permission to update the topic" do
           topic.update!(archived: true)


### PR DESCRIPTION
It used to change the category of the topic, instead of the destination
category (topic.category_id instead of topic.shared_draft.category_id).

The shared drafts controls were displayed only if the current category
matched the 'shared drafts category', which was not true for shared
drafts that had their categories changed (affected by the previous bug).

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
