### PR TITLE
FIX: IMAP post alerter race condition and code improvements

### DIFF
--- a/app/models/incoming_email.rb
+++ b/app/models/incoming_email.rb
@@ -29,6 +29,14 @@ class IncomingEmail < ActiveRecord::Base
     SQL
   end
 
+  def to_addresses_split
+    self.to_addresses&.split(";") || []
+  end
+
+  def cc_addresses_split
+    self.cc_addresses&.split(";") || []
+  end
+
   def to_addresses=(to)
     if to&.is_a?(Array)
       to = to.map(&:downcase).join(";")

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1633,11 +1633,7 @@ class Topic < ActiveRecord::Base
   end
 
   def incoming_email_addresses(group: nil, received_before: Time.zone.now)
-    if group.present?
-      email_addresses = Set[group.email_username]
-    else
-      email_addresses = Set.new
-    end
+    email_addresses = group.present? ? Set[group.email_username] : Set.new
 
     # TODO(martin) Look at improving this N1, it will just get slower the
     # more replies/incoming emails there are for the topic.

--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -416,8 +416,9 @@ class PostAlerter
     if opts[:skip_send_email_to]&.include?(user.email)
       skip_send_email = true
     elsif original_post.via_email && (incoming_email = original_post.incoming_email)
-      skip_send_email = contains_email_address?(incoming_email.to_addresses, user) ||
-        contains_email_address?(incoming_email.cc_addresses, user)
+      skip_send_email =
+        incoming_email.to_addresses_split.include?(user.email) ||
+        incoming_email.cc_addresses_split.include?(user.email)
     else
       skip_send_email = opts[:skip_send_email]
     end
@@ -456,11 +457,6 @@ class PostAlerter
       push_notification(user, payload)
       DiscourseEvent.trigger(:post_notification_alert, user, payload)
     end
-  end
-
-  def contains_email_address?(addresses, user)
-    return false if addresses.blank?
-    addresses.split(";").include?(user.email)
   end
 
   def push_notification(user, payload)

--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -578,7 +578,7 @@ class PostAlerter
     if group = group_notifying_via_smtp(post)
       email_addresses = post.topic.incoming_email_addresses(group: group)
 
-      if email_addresses.size > 1
+      if email_addresses.any?
         Jobs.enqueue(:group_smtp_email, group_id: group.id, post_id: post.id, email: email_addresses)
       end
     end

--- a/lib/imap/sync.rb
+++ b/lib/imap/sync.rb
@@ -309,8 +309,8 @@ module Imap
       tags = Set.new
 
       # "Plus" part from the destination email address
-      to_addresses = incoming_email.to_addresses&.split(";") || []
-      cc_addresses = incoming_email.cc_addresses&.split(";") || []
+      to_addresses = incoming_email.to_addresses_split
+      cc_addresses = incoming_email.cc_addresses_split
       (to_addresses + cc_addresses).each do |address|
         if plus_part = address&.scan(group_email_regex)&.first&.first
           tags.add("plus:#{plus_part[1..-1]}") if plus_part.length > 0

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -2790,11 +2790,6 @@ describe Topic do
     end
 
     context "when the group is present" do
-      it "excludes the group email username address" do
-        expect(topic.incoming_email_addresses(group: group)).to match_array(
-          ["johnsmith@user.com", "otherguy@user.com"]
-        )
-      end
       it "excludes incoming emails that are not to or CCd to the group" do
         expect(topic.incoming_email_addresses(group: group)).not_to include(
           "unrelated@test.com"

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -2744,4 +2744,62 @@ describe Topic do
       expect(topic.like_count).to eq(1)
     end
   end
+
+  describe "#incoming_email_addresses" do
+    fab!(:group) do
+      Fabricate(
+        :group,
+        smtp_server: "imap.gmail.com",
+        smtp_port: 587,
+        email_username: "discourse@example.com",
+        email_password: "discourse@example.com"
+      )
+    end
+
+    fab!(:topic) do
+      Fabricate(:private_message_topic,
+        topic_allowed_groups: [
+          Fabricate.build(:topic_allowed_group, group: group)
+        ]
+      )
+    end
+
+    let!(:incoming1) do
+      Fabricate(:incoming_email, to_addresses: "discourse@example.com", from_address: "johnsmith@user.com", topic: topic, post: topic.posts.first, created_at: 20.minutes.ago)
+    end
+    let!(:incoming2) do
+      Fabricate(:incoming_email, from_address: "discourse@example.com", to_addresses: "johnsmith@user.com", topic: topic, post: Fabricate(:post, topic: topic), created_at: 10.minutes.ago)
+    end
+    let!(:incoming3) do
+      Fabricate(:incoming_email, to_addresses: "discourse@example.com", from_address: "johnsmith@user.com", topic: topic, post: topic.posts.first, cc_addresses: "otherguy@user.com", created_at: 2.minutes.ago)
+    end
+    let!(:incoming4) do
+      Fabricate(:incoming_email, to_addresses: "unrelated@test.com", from_address: "discourse@example.com", topic: topic, post: topic.posts.first, created_at: 1.minutes.ago)
+    end
+
+    it "returns an array of all the incoming email addresses" do
+      expect(topic.incoming_email_addresses).to match_array(
+        ["discourse@example.com", "johnsmith@user.com", "otherguy@user.com", "unrelated@test.com"]
+      )
+    end
+
+    it "returns an array of all the incoming email addresses where incoming was received before X" do
+      expect(topic.incoming_email_addresses(received_before: 5.minutes.ago)).to match_array(
+        ["discourse@example.com", "johnsmith@user.com"]
+      )
+    end
+
+    context "when the group is present" do
+      it "excludes the group email username address" do
+        expect(topic.incoming_email_addresses(group: group)).to match_array(
+          ["johnsmith@user.com", "otherguy@user.com"]
+        )
+      end
+      it "excludes incoming emails that are not to or CCd to the group" do
+        expect(topic.incoming_email_addresses(group: group)).not_to include(
+          "unrelated@test.com"
+        )
+      end
+    end
+  end
 end

--- a/spec/services/post_alerter_spec.rb
+++ b/spec/services/post_alerter_spec.rb
@@ -1244,7 +1244,7 @@ describe PostAlerter do
     end
   end
 
-  context "SMTP" do
+  context "SMTP (group_smtp_email)" do
     before do
       SiteSetting.enable_smtp = true
       Jobs.run_immediately!


### PR DESCRIPTION
This PR fixes a race condition with the IMAP notification code. In the `Email::Receiver` we call the `NewPostManager` to create the post and enqueue jobs and sends alerts via `PostAlerter`. However, if the post alerter reaches the `notify_pm_users` and the `group_notifying_via_smtp` method _before_ the incoming email is updated with the post and topic, we unnecessarily send a notification to the person who just posted. The result of this is that the IMAP syncer re-imports the email sent to the user about their own post, which looks like this in the group inbox:

![image](https://user-images.githubusercontent.com/920448/104551849-5b748700-5683-11eb-89ff-f9ac61b34cb7.png)

To fix this, we skip the jobs enqueued by `NewPostManager` and only enqueue them with `PostJobsEnqueuer` manually _after_ the incoming email record has been updated with the post and topic.

Other improvements:

* Moved code to calculate email addresses from `IncomingEmail` records into the topic, with a group passed in, for easier testing and debugging. It is not the responsibility of the post alerter to figure this stuff out.
* Add shortcut methods on `IncomingEmail` to split or provide an empty array for to and cc addresses to avoid repetition.