### PR TITLE
FIX: Render fancy title correctly in composer

### DIFF
--- a/app/assets/javascripts/discourse/app/models/composer.js
+++ b/app/assets/javascripts/discourse/app/models/composer.js
@@ -311,7 +311,7 @@ const Composer = RestModel.extend({
     if (topic) {
       options.topicLink = {
         href: topic.url,
-        anchor: topic.fancy_title || escapeExpression(topicTitle),
+        anchor: topic.fancyTitle || escapeExpression(topicTitle),
       };
     }
 


### PR DESCRIPTION
Previously we were using `fancy_title` rather than `fancyTitle`... not sure why. I logged the difference and I don't see why we shouldn't use `fancyTitle`.

![Screenshot 2021-01-14 122735](https://user-images.githubusercontent.com/16214023/104633243-7d124600-5664-11eb-979e-8b3aae5fcaa7.png)

From 

![Screenshot 2021-01-14 123023](https://user-images.githubusercontent.com/16214023/104633248-7daadc80-5664-11eb-8bd8-32117fe40bf3.png)

To

![Screenshot 2021-01-14 123002](https://user-images.githubusercontent.com/16214023/104633250-7daadc80-5664-11eb-8084-a627958cf029.png)
