### PR TITLE
FIX: Support for single use invite links

### DIFF
--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -60,7 +60,7 @@ class Invite < ActiveRecord::Base
   end
 
   def is_invite_link?
-    max_redemptions_allowed > 1
+    email.blank?
   end
 
   def redeemed?

--- a/app/models/invite_redeemer.rb
+++ b/app/models/invite_redeemer.rb
@@ -100,9 +100,8 @@ InviteRedeemer = Struct.new(:invite, :email, :username, :name, :password, :user_
     end
 
     @invited_user_record = InvitedUser.create!(invite_id: invite.id, redeemed_at: Time.zone.now)
-    if invite.is_invite_link? && @invited_user_record.present?
+    if @invited_user_record.present?
       Invite.increment_counter(:redemption_count, invite.id)
-    elsif @invited_user_record.present?
       delete_duplicate_invites
     end
 

--- a/spec/models/invite_redeemer_spec.rb
+++ b/spec/models/invite_redeemer_spec.rb
@@ -212,7 +212,7 @@ describe InviteRedeemer do
     end
 
     context 'invite_link' do
-      fab!(:invite_link) { Fabricate(:invite, max_redemptions_allowed: 5, expires_at: 1.month.from_now, emailed_status: Invite.emailed_status_types[:not_required]) }
+      fab!(:invite_link) { Fabricate(:invite, email: nil, max_redemptions_allowed: 5, expires_at: 1.month.from_now, emailed_status: Invite.emailed_status_types[:not_required]) }
       let(:invite_redeemer) { InviteRedeemer.new(invite: invite_link, email: 'foo@example.com') }
 
       it 'works as expected' do

--- a/spec/models/invite_spec.rb
+++ b/spec/models/invite_spec.rb
@@ -197,6 +197,12 @@ describe Invite do
     context 'invite links' do
       let(:inviter) { Fabricate(:user) }
 
+      it 'with single use can exist' do
+        Invite.generate_multiple_use_invite_link(invited_by: inviter, max_redemptions_allowed: 1)
+        invite_link = Invite.last
+        expect(invite_link.is_invite_link?).to eq(true)
+      end
+
       it "has sane defaults" do
         Invite.generate_multiple_use_invite_link(invited_by: inviter)
         invite_link = Invite.last


### PR DESCRIPTION
The "invite link" checked if the number of uses was greater than 1. This
is not always true as single use invite links are perfectly valid.