### PR TITLE
DEV: Add schema checking to api doc testing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -167,6 +167,7 @@ group :test, :development do
   gem 'parallel_tests'
 
   gem 'rswag-specs'
+  gem 'json-schema_builder'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -167,7 +167,7 @@ group :test, :development do
   gem 'parallel_tests'
 
   gem 'rswag-specs'
-  gem 'json-schema_builder'
+  gem 'json_schemer'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,6 +159,9 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
+    json-schema_builder (0.8.2)
+      activesupport (>= 4.0)
+      json-schema (>= 2.1)
     jwt (2.2.2)
     kgio (2.11.3)
     libv8 (8.4.255.0)
@@ -494,6 +497,7 @@ DEPENDENCIES
   htmlentities
   http_accept_language
   json
+  json-schema_builder
   listen
   lograge
   logstash-event

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,6 +114,8 @@ GEM
       in_threads (~> 1.3)
       progress (~> 3.0, >= 3.0.1)
     docile (1.3.5)
+    ecma-re-validator (0.3.0)
+      regexp_parser (~> 2.0)
     email_reply_trimmer (0.1.13)
     ember-data-source (3.0.2)
       ember-source (>= 2, < 3.0)
@@ -141,6 +143,7 @@ GEM
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     guess_html_encoding (0.0.11)
+    hana (1.3.7)
     hashdiff (1.0.1)
     hashie (4.1.0)
     highline (2.0.3)
@@ -159,9 +162,11 @@ GEM
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    json-schema_builder (0.8.2)
-      activesupport (>= 4.0)
-      json-schema (>= 2.1)
+    json_schemer (0.2.17)
+      ecma-re-validator (~> 0.3)
+      hana (~> 1.3)
+      regexp_parser (~> 2.0)
+      uri_template (~> 0.7)
     jwt (2.2.2)
     kgio (2.11.3)
     libv8 (8.4.255.0)
@@ -435,6 +440,7 @@ GEM
       kgio (~> 2.6)
       raindrops (~> 0.7)
     uniform_notifier (1.13.2)
+    uri_template (0.7.0)
     webmock (3.11.1)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -497,7 +503,7 @@ DEPENDENCIES
   htmlentities
   http_accept_language
   json
-  json-schema_builder
+  json_schemer
   listen
   lograge
   logstash-event

--- a/spec/requests/api/schemas/tag_group_schemas.rb
+++ b/spec/requests/api/schemas/tag_group_schemas.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module SpecSchemas
+
+  class TagGroupCreateRequest
+    include JSON::SchemaBuilder
+
+    def schema
+      object do
+        string :name, required: true
+      end
+    end
+  end
+
+  class TagGroupResponse
+    include JSON::SchemaBuilder
+
+    def schema
+      object do
+        object :tag_group do
+          integer :id, required: true
+          string :name, required: true
+          array :tag_names do
+            items type: :string
+          end
+          array :parent_tag_name do
+            items type: :string
+          end
+          boolean :one_per_topic
+          object :permissions do
+            integer :everyone
+          end
+        end
+      end
+    end
+  end
+
+end

--- a/spec/requests/api/schemas/tag_group_schemas.rb
+++ b/spec/requests/api/schemas/tag_group_schemas.rb
@@ -3,35 +3,63 @@
 module SpecSchemas
 
   class TagGroupCreateRequest
-    include JSON::SchemaBuilder
-
-    def schema
-      object do
-        string :name, required: true
-      end
+    def schemer
+      schema = {
+        'type' => 'object',
+        'properties' => {
+          'name' => {
+            'type' => 'string',
+            'required' => true
+          }
+        }
+      }
     end
   end
 
   class TagGroupResponse
-    include JSON::SchemaBuilder
-
-    def schema
-      object do
-        object :tag_group do
-          integer :id, required: true
-          string :name, required: true
-          array :tag_names do
-            items type: :string
-          end
-          array :parent_tag_name do
-            items type: :string
-          end
-          boolean :one_per_topic
-          object :permissions do
-            integer :everyone
-          end
-        end
-      end
+    def schemer
+      schema = {
+        'type' => 'object',
+        'properties' => {
+          'tag_group' => {
+            'type' => 'object',
+            'properties' => {
+              'id' => {
+                'type' => 'integer',
+                'required' => true
+              },
+              'name' => {
+                'type' => 'string',
+                'required' => true
+              },
+              'tag_names' => {
+                'type' => 'array',
+                'items' => {
+                  'type' => 'string'
+                }
+              },
+              'parent_tag_name' => {
+                'type' => 'array',
+                'items' => {
+                  'type' => 'string'
+                }
+              },
+              'one_per_topic' => {
+                'type' => 'boolean',
+              },
+              'permissions' => {
+                'type' => 'object',
+                'properties' => {
+                  'everyone' => {
+                    'type' => 'integer',
+                    'example' => 1
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     end
   end
 

--- a/spec/requests/api/schemas/tag_group_schemas.rb
+++ b/spec/requests/api/schemas/tag_group_schemas.rb
@@ -6,12 +6,13 @@ module SpecSchemas
     def schemer
       schema = {
         'type' => 'object',
+        'additionalProperties' => false,
         'properties' => {
           'name' => {
             'type' => 'string',
-            'required' => true
           }
-        }
+        },
+        'required' => ['name']
       }
     end
   end
@@ -20,17 +21,16 @@ module SpecSchemas
     def schemer
       schema = {
         'type' => 'object',
+        'additionalProperties' => false,
         'properties' => {
           'tag_group' => {
             'type' => 'object',
             'properties' => {
               'id' => {
                 'type' => 'integer',
-                'required' => true
               },
               'name' => {
                 'type' => 'string',
-                'required' => true
               },
               'tag_names' => {
                 'type' => 'array',
@@ -56,9 +56,20 @@ module SpecSchemas
                   }
                 }
               }
-            }
+            },
+            'required' => [
+              'id',
+              'name',
+              'tag_names',
+              'parent_tag_name',
+              'one_per_topic',
+              'permissions'
+            ]
           }
-        }
+        },
+        'required' => [
+          'tag_group'
+        ]
       }
     end
   end

--- a/spec/requests/api/shared/shared_examples.rb
+++ b/spec/requests/api/shared/shared_examples.rb
@@ -15,7 +15,10 @@ RSpec.shared_examples "a JSON endpoint" do |expected_response_status|
     it "matches the documented request schema" do |example|
       schemer = JSONSchemer.schema(expected_request_schema.schemer)
       valid = schemer.valid?(params)
-      puts params unless valid # for debugging
+      unless valid # for debugging
+        puts params
+        puts schemer.validate(params).to_a[0]["details"]
+      end
       expect(valid).to eq(true)
     end
   end
@@ -24,9 +27,14 @@ RSpec.shared_examples "a JSON endpoint" do |expected_response_status|
     let(:json_response) { JSON.parse(response.body) }
 
     it "matches the documented response schema" do  |example|
-      schemer = JSONSchemer.schema(expected_response_schema.schemer)
+      schemer = JSONSchemer.schema(
+        expected_response_schema.schemer,
+      )
       valid = schemer.valid?(json_response)
-      puts json_response unless valid # for debugging
+      unless valid # for debugging
+        puts json_response
+        puts schemer.validate(json_response).to_a[0]["details"]
+      end
       expect(valid).to eq(true)
     end
   end

--- a/spec/requests/api/shared/shared_examples.rb
+++ b/spec/requests/api/shared/shared_examples.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "a JSON endpoint" do |expected_response_status|
+  before do |example|
+    submit_request(example.metadata)
+  end
+
+  describe "response status" do
+    it "returns expected response status" do
+      expect(response.status).to eq(expected_response_status)
+    end
+  end
+
+  describe "request body" do
+    it "matches the documented request schema" do |example|
+      errors = expected_request_schema.schema.fully_validate(params)
+      puts params if errors.count > 0 # for debugging
+      expect(errors).to be_empty
+    end
+  end
+
+  describe "response body" do
+    let(:json_response) { JSON.parse(response.body) }
+
+    it "matches the documented response schema" do  |example|
+      errors = expected_response_schema.schema.fully_validate(json_response)
+      puts json_response if errors.count > 0 # for debugging
+      expect(errors).to be_empty
+    end
+  end
+end

--- a/spec/requests/api/shared/shared_examples.rb
+++ b/spec/requests/api/shared/shared_examples.rb
@@ -13,9 +13,10 @@ RSpec.shared_examples "a JSON endpoint" do |expected_response_status|
 
   describe "request body" do
     it "matches the documented request schema" do |example|
-      errors = expected_request_schema.schema.fully_validate(params)
-      puts params if errors.count > 0 # for debugging
-      expect(errors).to be_empty
+      schemer = JSONSchemer.schema(expected_request_schema.schemer)
+      valid = schemer.valid?(params)
+      puts params unless valid # for debugging
+      expect(valid).to eq(true)
     end
   end
 
@@ -23,9 +24,10 @@ RSpec.shared_examples "a JSON endpoint" do |expected_response_status|
     let(:json_response) { JSON.parse(response.body) }
 
     it "matches the documented response schema" do  |example|
-      errors = expected_response_schema.schema.fully_validate(json_response)
-      puts json_response if errors.count > 0 # for debugging
-      expect(errors).to be_empty
+      schemer = JSONSchemer.schema(expected_response_schema.schemer)
+      valid = schemer.valid?(json_response)
+      puts json_response unless valid # for debugging
+      expect(valid).to eq(true)
     end
   end
 end

--- a/spec/requests/api/tags_spec.rb
+++ b/spec/requests/api/tags_spec.rb
@@ -68,7 +68,7 @@ describe 'tags' do
       response '200', 'tag group created' do
         expected_response_schema = SpecSchemas::TagGroupResponse.new
 
-        let(:params) { { name: 'todo' } }
+        let(:params) { { 'name' => 'todo' } }
 
         schema(expected_response_schema.schemer)
 

--- a/spec/requests/api/tags_spec.rb
+++ b/spec/requests/api/tags_spec.rb
@@ -62,7 +62,7 @@ describe 'tags' do
       consumes 'application/json'
       expected_request_schema = SpecSchemas::TagGroupCreateRequest.new
 
-      parameter name: :params, in: :body, schema: expected_request_schema.schema.as_json
+      parameter name: :params, in: :body, schema: expected_request_schema.schemer
 
       produces 'application/json'
       response '200', 'tag group created' do
@@ -70,7 +70,7 @@ describe 'tags' do
 
         let(:params) { { name: 'todo' } }
 
-        schema(expected_response_schema.schema.as_json)
+        schema(expected_response_schema.schemer)
 
         it_behaves_like "a JSON endpoint", 200 do
           let(:expected_response_schema) { expected_response_schema }

--- a/spec/requests/api/tags_spec.rb
+++ b/spec/requests/api/tags_spec.rb
@@ -60,46 +60,22 @@ describe 'tags' do
     post 'Creates a tag group' do
       tags 'Tags'
       consumes 'application/json'
-      parameter name: :post_body, in: :body, schema: {
-        type: :object,
-        properties: {
-          name: { type: :string }
-        },
-        required: [ 'name' ]
-      }
+      expected_request_schema = SpecSchemas::TagGroupCreateRequest.new
+
+      parameter name: :params, in: :body, schema: expected_request_schema.schema.as_json
 
       produces 'application/json'
       response '200', 'tag group created' do
-        schema type: :object, properties: {
-          tag_group: {
-            type: :object,
-            properties: {
-              id: { type: :integer },
-              name: { type: :string },
-              tag_names: {
-                type: :array,
-                items: {
-                },
-              },
-              parent_tag_name: {
-                type: :array,
-                items: {
-                },
-              },
-              one_per_topic: { type: :boolean },
-              permissions: {
-                type: :object,
-                properties: {
-                  everyone: { type: :integer },
-                }
-              },
-            }
-          },
-        }
+        expected_response_schema = SpecSchemas::TagGroupResponse.new
 
-        let(:post_body) { { name: 'todo' } }
+        let(:params) { { name: 'todo' } }
 
-        run_test!
+        schema(expected_response_schema.schema.as_json)
+
+        it_behaves_like "a JSON endpoint", 200 do
+          let(:expected_response_schema) { expected_response_schema }
+          let(:expected_request_schema) { expected_request_schema }
+        end
       end
     end
 

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -1,6 +1,21 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require "json/schema_builder"
+
+# json-schema_builder config
+# We want to validate and be strict here so that we error when we detect
+# differences with the schema and the json response/request.
+JSON::SchemaBuilder.configure do |opts|
+  opts.validate_schema = true
+  opts.strict = true
+end
+
+# Require schema files
+Dir["./spec/requests/api/schemas/*.rb"].each { |file| require file }
+
+# Require shared examples
+Dir["./spec/requests/api/shared/*.rb"].each { |file| require file }
 
 RSpec.configure do |config|
   # Specify a root folder where Swagger JSON files are generated

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -1,20 +1,12 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require "json/schema_builder"
-
-# json-schema_builder config
-# We want to validate and be strict here so that we error when we detect
-# differences with the schema and the json response/request.
-JSON::SchemaBuilder.configure do |opts|
-  opts.validate_schema = true
-  opts.strict = true
-end
+require 'json_schemer'
 
 # Require schema files
 Dir["./spec/requests/api/schemas/*.rb"].each { |file| require file }
 
-# Require shared examples
+# Require shared spec examples
 Dir["./spec/requests/api/shared/*.rb"].each { |file| require file }
 
 RSpec.configure do |config|


### PR DESCRIPTION
This commit improves upon rswag which lacks schema checking. rswag
really only checks that the https status matches, but this change adds
in the json-schema_builder gem which also has schema validation.

Now we can define schemas for each of our requests/responses in the
`spec/requests/api/schemas` directory which will make our documentation
specs a lot cleaner.

If we update a serializer by either adding or removing an attribute the
tests will now fail (this is a good thing!). Also if you change the type
of an attribute say from an array to a string the tests will now fail.
This will help significantly with keeping the docs in sync with actual
code changes! Now if you change how an endpoint will respond you will
have to update the docs too in order for the tests to pass. :D

This PR is inspired by:

 https://www.tealhq.com/post/how-teal-keeps-their-api-tests-and-documentation-in-sync
