### PR TITLE
FIX: Make sure current user timezone is used for bookmark reminders from post dates

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/bookmark.js
+++ b/app/assets/javascripts/discourse/app/controllers/bookmark.js
@@ -64,6 +64,7 @@ export default Controller.extend(ModalFunctionality, {
   lastCustomReminderTime: null,
   postDetectedLocalDate: null,
   postDetectedLocalTime: null,
+  postDetectedLocalTimezone: null,
   mouseTrap: null,
   userTimezone: null,
   showOptions: false,
@@ -80,6 +81,7 @@ export default Controller.extend(ModalFunctionality, {
       lastCustomReminderTime: null,
       postDetectedLocalDate: null,
       postDetectedLocalTime: null,
+      postDetectedLocalTimezone: null,
       userTimezone: this.currentUser.resolvedTimezone(this.currentUser),
       showOptions: false,
       model: this.model || {},
@@ -385,9 +387,15 @@ export default Controller.extend(ModalFunctionality, {
     });
   },
 
-  _parseCustomDateTime(date, time) {
+  _parseCustomDateTime(date, time, parseTimezone = this.userTimezone) {
     let dateTime = isPresent(time) ? date + " " + time : date;
-    return moment.tz(dateTime, this.userTimezone);
+    let parsed = moment.tz(dateTime, parseTimezone);
+
+    if (parseTimezone !== this.userTimezone) {
+      parsed = parsed.tz(this.userTimezone);
+    }
+
+    return parsed;
   },
 
   _defaultCustomReminderTime() {
@@ -449,7 +457,8 @@ export default Controller.extend(ModalFunctionality, {
   postLocalDate() {
     let parsedPostLocalDate = this._parseCustomDateTime(
       this.model.postDetectedLocalDate,
-      this.model.postDetectedLocalTime
+      this.model.postDetectedLocalTime,
+      this.model.postDetectedLocalTimezone
     );
 
     if (!this.model.postDetectedLocalTime) {

--- a/app/assets/javascripts/discourse/app/models/post.js
+++ b/app/assets/javascripts/discourse/app/models/post.js
@@ -321,6 +321,9 @@ const Post = RestModel.extend({
           name: this.bookmark_name,
           postDetectedLocalDate: localDateEl ? localDateEl.dataset.date : null,
           postDetectedLocalTime: localDateEl ? localDateEl.dataset.time : null,
+          postDetectedLocalTimezone: localDateEl
+            ? localDateEl.dataset.timezone
+            : null,
         },
         title: this.bookmark_id
           ? "post.bookmarks.edit"

--- a/app/assets/javascripts/discourse/tests/acceptance/bookmarks-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/bookmarks-test.js
@@ -27,7 +27,7 @@ acceptance("Bookmarking", function (needs) {
 
   needs.hooks.beforeEach(() => (steps = []));
 
-  const topicResponse = Object.assign({}, topicFixtures["/t/280/1.json"]);
+  const topicResponse = topicFixtures["/t/280/1.json"];
   topicResponse.post_stream.posts[0].cooked += `<span data-date="2021-01-15" data-time="00:35:00" class="discourse-local-date cooked-date past" data-timezone="Europe/London">
   <span>
     <svg class="fa d-icon d-icon-globe-americas svg-icon" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
When selecting the "date in post" option from the bookmark reminder modal, it was not converting the date from the post, which may be in a completely different timezone, to the current user's timezone.

![image](https://user-images.githubusercontent.com/920448/104668098-30da0b00-5723-11eb-9b62-dc56754f971e.png)

This PR fixes it so the timezone from the post is used to parse the date then converted to the user's timezone.