### PR TITLE
FIX: Stop incorrect emailing of group email from PostAlerter

### DIFF
--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -581,6 +581,12 @@ class PostAlerter
       if email_addresses.any?
         Jobs.enqueue(:group_smtp_email, group_id: group.id, post_id: post.id, email: email_addresses)
       end
+
+      # add the group's email back into the array, because it is used for
+      # skip_send_email_to in the case of user private message notifications
+      # (we do not want the group to be sent any emails from here because it
+      # will make another email for IMAP to pick up in the group's mailbox)
+      email_addresses << group.email_username
     end
 
     # users that aren't part of any mentioned groups

--- a/spec/services/post_alerter_spec.rb
+++ b/spec/services/post_alerter_spec.rb
@@ -1269,6 +1269,7 @@ describe PostAlerter do
     end
 
     it "sends notifications for new posts in topic" do
+      PostAlerter.any_instance.expects(:create_notification).at_least_once
       post = Fabricate(
         :post,
         topic: topic,
@@ -1281,6 +1282,11 @@ describe PostAlerter do
             cc_addresses: "bar@discourse.org"
           )
       )
+      staged_group_user = Fabricate(:staged, email: "discourse@example.com")
+      Fabricate(:topic_user, user: staged_group_user, topic: post.topic)
+      topic.allowed_users << staged_group_user
+      topic.save
+
       expect { PostAlerter.new.after_save_post(post, true) }.to change { ActionMailer::Base.deliveries.size }.by(0)
 
       post = Fabricate(:post, topic: topic)
@@ -1303,6 +1309,9 @@ describe PostAlerter do
           )
       )
       expect { PostAlerter.new.after_save_post(post, true) }.to change { ActionMailer::Base.deliveries.size }.by(0)
+
+      # we never want the group to be notified by email about these posts
+      PostAlerter.any_instance.expects(:create_notification).with(kind_of(User), Notification.types[:private_message], kind_of(Post), skip_send_email_to: ["foo@discourse.org", "bar@discourse.org", "baz@discourse.org", "discourse@example.com"]).at_least_once
 
       post = Fabricate(:post, topic: topic.reload)
       expect { PostAlerter.new.after_save_post(post, true) }.to change { ActionMailer::Base.deliveries.size }.by(1)


### PR DESCRIPTION
Fixes bug introduced by https://github.com/discourse/discourse/commit/bd25627198dd74442cc4014975e7af2d3b142622

What happens is we send notifications to everyone involved in the group inbox topic about new posts, however we pass the param `skip_send_email_to: email_addresses`. In the above commit I removed the group email address from this `email_addresses` array. This breaks the IMAP inbox because we email the group with the reply, and the IMAP sync tool finds this email and opens a new unrelated topic with it.