### PR TITLE
UX: warn about messages to be orphaned while deleting a group.

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/group.js
+++ b/app/assets/javascripts/discourse/app/controllers/group.js
@@ -142,13 +142,22 @@ export default Controller.extend({
   destroyGroup() {
     this.set("destroying", true);
 
+    const model = this.model;
+    let message = I18n.t("admin.groups.delete_confirm");
+
+    if (model.has_messages && model.message_count > 0) {
+      message = I18n.t("admin.groups.delete_with_messages_confirm", {
+        count: model.message_count,
+      });
+    }
+
     bootbox.confirm(
-      I18n.t("admin.groups.delete_confirm"),
+      message,
       I18n.t("no_value"),
       I18n.t("yes_value"),
       (confirmed) => {
         if (confirmed) {
-          this.model
+          model
             .destroy()
             .then(() => this.transitionToRoute("groups.index"))
             .catch((error) => {

--- a/app/assets/javascripts/discourse/tests/acceptance/group-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-test.js
@@ -261,6 +261,18 @@ acceptance("Group - Authenticated", function (needs) {
       "Awesome Team",
       "it should display the group name"
     );
+
+    await click(".group-details-button button[aria-label='Delete']");
+
+    assert.equal(
+      queryAll(".bootbox .modal-body").html(),
+      I18n.t("admin.groups.delete_with_messages_confirm", {
+        count: 2,
+      }),
+      "it should warn about orphan messages"
+    );
+
+    await click(".modal-footer .btn-default");
   });
 
   test("Moderator Viewing Group", async function (assert) {

--- a/app/assets/javascripts/discourse/tests/acceptance/group-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-test.js
@@ -262,7 +262,7 @@ acceptance("Group - Authenticated", function (needs) {
       "it should display the group name"
     );
 
-    await click(".group-details-button button[aria-label='Delete']");
+    await click(".group-details-button button.btn-danger");
 
     assert.equal(
       queryAll(".bootbox .modal-body").html(),

--- a/app/assets/javascripts/discourse/tests/fixtures/group-fixtures.js
+++ b/app/assets/javascripts/discourse/tests/fixtures/group-fixtures.js
@@ -46,7 +46,9 @@ export default {
       is_group_owner: true,
       mentionable: true,
       messageable: true,
-      can_see_members: true
+      can_see_members: true,
+      has_messages: true,
+      message_count: 2
     },
     extras: {
       visible_group_names: ["discourse"]

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -838,6 +838,11 @@ class Group < ActiveRecord::Base
     )
   end
 
+  def message_count
+    return 0 unless self.has_messages
+    TopicAllowedGroup.where(group_id: self.id).joins(:topic).count
+  end
+
   protected
 
   def name_format_validator

--- a/app/serializers/group_show_serializer.rb
+++ b/app/serializers/group_show_serializer.rb
@@ -25,7 +25,8 @@ class GroupShowSerializer < BasicGroupSerializer
                    :email_password,
                    :imap_last_error,
                    :imap_old_emails,
-                   :imap_new_emails
+                   :imap_new_emails,
+                   :message_count
 
   def self.admin_or_owner_attributes(*attrs)
     attributes(*attrs)

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3720,6 +3720,7 @@ en:
         group_members: "Group members"
         delete: "Delete"
         delete_confirm: "Delete this group?"
+        delete_with_messages_confirm: "Deleting this group will cause %{count} messages to be orphaned, group members will no longer have access to them.<br><br>Are you sure?"
         delete_failed: "Unable to delete group. If this is an automatic group, it cannot be destroyed."
         delete_owner_confirm: "Remove owner privilege for '%{username}'?"
         add: "Add"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3720,7 +3720,9 @@ en:
         group_members: "Group members"
         delete: "Delete"
         delete_confirm: "Delete this group?"
-        delete_with_messages_confirm: "Deleting this group will cause %{count} messages to be orphaned, group members will no longer have access to them.<br><br>Are you sure?"
+        delete_with_messages_confirm:
+          one: "Deleting this group will cause %{count} message to be orphaned, group members will no longer have access to it.<br><br>Are you sure?"
+          other: "Deleting this group will cause %{count} messages to be orphaned, group members will no longer have access to them.<br><br>Are you sure?"
         delete_failed: "Unable to delete group. If this is an automatic group, it cannot be destroyed."
         delete_owner_confirm: "Remove owner privilege for '%{username}'?"
         add: "Add"

--- a/spec/serializers/group_show_serializer_spec.rb
+++ b/spec/serializers/group_show_serializer_spec.rb
@@ -79,6 +79,7 @@ describe GroupShowSerializer do
       it 'are visible' do
         expect(subject.as_json[:email_username]).to eq('foo@bar.com')
         expect(subject.as_json[:email_password]).to eq('pa$$w0rd')
+        expect(subject.as_json[:message_count]).to eq(0)
       end
     end
   end


### PR DESCRIPTION
Currently, after destroying a group its messages are inaccessible to everyone. Only admins can access using direct URLs.