### PR TITLE
FEATURE: support DISCOURSE_SMTP_FORCE_TLS option

### DIFF
--- a/config/discourse_defaults.conf
+++ b/config/discourse_defaults.conf
@@ -92,6 +92,9 @@ smtp_enable_start_tls = true
 # to disable, set to 'none'
 smtp_openssl_verify_mode =
 
+# force implicit TLS as per RFC 8314 3.3
+smtp_force_tls = false
+
 # load MiniProfiler in production, to be used by developers
 load_mini_profiler = true
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -37,6 +37,10 @@ Discourse::Application.configure do
 
     settings[:openssl_verify_mode] = GlobalSetting.smtp_openssl_verify_mode if GlobalSetting.smtp_openssl_verify_mode
 
+    if GlobalSetting.smtp_force_tls
+      settings[:tls] = true
+    end
+
     config.action_mailer.smtp_settings = settings.reject { |_, y| y.nil? }
   else
     config.action_mailer.delivery_method = :sendmail


### PR DESCRIPTION
Background: [RFC 8314 Section 3.3](https://tools.ietf.org/html/rfc8314#section-3.3) asks that:

```
(...) clients and servers SHOULD implement both STARTTLS on port 587 and Implicit TLS on port 465 (...)
```

I believe that Discourse currently cannot be configured this way, making it impossible to use with mail servers that do not support port 587. In this case, a `Net::ReadTimeout` results. 

This has led to numerous users (including myself) complaining about being unable to set up Discourse,
see [1](https://meta.discourse.org/t/email-not-working-but-i-can-access-smtp-server-from-container/168132), [2](https://meta.discourse.org/t/problem-with-smtp-configuration/65892/8), [3](https://meta.discourse.org/t/problem-with-smtp-configuration/65892/7) to name three that are possibly related to a lack of support for implicit TLS on port 465.

With this patch, it should be possible to set
```
DISCOURSE_SMTP_FORCE_TLS=true
```
to use implicit TLS on port 465 (or any port).

This was tested on a container installed via the 30 minute procedure by directly changing `config/environments/production.rb`.
I did not bootstrap the entire Discourse images etc., so there may be issues I do not see.

The same problem has been [reported in other ActionMailer applications](https://github.com/rails/rails/pull/30483); this ultimately abandoned PR also discussed the idea of automatically enabling this option if port 465 is chosen (which would be more user friendly and could be considered here.)

Feedback is welcome.
