### PR TITLE
FIX: Blocked tags were too aggressive

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/tag-chooser.js
+++ b/app/assets/javascripts/select-kit/addon/components/tag-chooser.js
@@ -112,12 +112,6 @@ export default MultiSelectComponent.extend(TagsMixin, {
       termMatchErrorMessage: json.forbidden_message,
     });
 
-    if (context.blockedTags) {
-      results = results.filter((result) => {
-        return !context.blockedTags.includes(result.id);
-      });
-    }
-
     if (context.get("siteSettings.tags_sort_alphabetically")) {
       results = results.sort((a, b) => a.id > b.id);
     }


### PR DESCRIPTION
In the context of tag synonyms, any tag that is a substring of the main tag is not listed as an available synonym. Removing the section of code in this PR fixes the issue, while not hindering the ability to block a tag.

**Before**

<img width="1230" alt="Screen Shot 2021-01-15 at 7 34 09 PM" src="https://user-images.githubusercontent.com/22733864/104796350-40c90d80-576a-11eb-93a6-ea221ae5b07c.png">


**After** 

<img width="1230" alt="Screen Shot 2021-01-15 at 7 35 06 PM" src="https://user-images.githubusercontent.com/22733864/104796354-458dc180-576a-11eb-81a1-aedc3191186f.png">


The `blockedTags` attribute is used in one other template ([tag notification user preferences](https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/app/templates/preferences/tags.hbs)). Interestingly, in this context, the behavior appears correct both before and after the change.

It's possible I've overlooked something, or there's a better solution. Please let me know if so!