### PR TITLE
FIX: Prioritizing pinned topics when sorted by any order

### DIFF
--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -462,7 +462,7 @@ class TopicQuery
     topics = yield(topics) if block_given?
 
     options = options.merge(@options)
-    if ["activity", "default"].include?(options[:order] || "activity") &&
+    if (["activity", "default", "posts", "views", "likes", "posters"].include?(options[:order]) || options[:order].nil?) &&
         !options[:unordered] &&
         filter != :private_messages
       topics = prioritize_pinned_topics(topics, options)

--- a/spec/components/topic_query_spec.rb
+++ b/spec/components/topic_query_spec.rb
@@ -543,29 +543,36 @@ describe TopicQuery do
         end
 
         it "returns the topics in correct order" do
+
+          # returns the topics while prioritizing pinned_topic when order is unspecified
+          expect(ids_in_order(nil)).to eq([pinned_topic, future_topic, closed_topic, invisible_topic, archived_topic, regular_topic].map(&:id))
+
+          # returns the topics while prioritizing pinned_topic when order is unspecified and descending is false
+          expect(ids_in_order(nil, false)).to eq([pinned_topic, regular_topic, archived_topic, invisible_topic, closed_topic, future_topic].map(&:id))
+
           # returns the topics in likes order if requested
-          expect(ids_in_order('posts')).to eq([future_topic, pinned_topic, archived_topic, regular_topic, invisible_topic, closed_topic].map(&:id))
+          expect(ids_in_order('posts')).to eq([pinned_topic, future_topic, archived_topic, regular_topic, invisible_topic, closed_topic].map(&:id))
 
           # returns the topics in reverse likes order if requested
-          expect(ids_in_order('posts', false)).to eq([closed_topic, invisible_topic, regular_topic, archived_topic, pinned_topic, future_topic].map(&:id))
+          expect(ids_in_order('posts', false)).to eq([pinned_topic, closed_topic, invisible_topic, regular_topic, archived_topic, future_topic].map(&:id))
 
           # returns the topics in likes order if requested
           expect(ids_in_order('likes')).to eq([pinned_topic, regular_topic, archived_topic, future_topic, invisible_topic, closed_topic].map(&:id))
 
           # returns the topics in reverse likes order if requested
-          expect(ids_in_order('likes', false)).to eq([closed_topic, invisible_topic, future_topic, archived_topic, regular_topic, pinned_topic].map(&:id))
+          expect(ids_in_order('likes', false)).to eq([pinned_topic, closed_topic, invisible_topic, future_topic, archived_topic, regular_topic].map(&:id))
 
           # returns the topics in views order if requested
-          expect(ids_in_order('views')).to eq([regular_topic, archived_topic, future_topic, pinned_topic, closed_topic, invisible_topic].map(&:id))
+          expect(ids_in_order('views')).to eq([pinned_topic, regular_topic, archived_topic, future_topic, closed_topic, invisible_topic].map(&:id))
 
           # returns the topics in reverse views order if requested" do
-          expect(ids_in_order('views', false)).to eq([invisible_topic, closed_topic, pinned_topic, future_topic, archived_topic, regular_topic].map(&:id))
+          expect(ids_in_order('views', false)).to eq([pinned_topic, invisible_topic, closed_topic, future_topic, archived_topic, regular_topic].map(&:id))
 
           # returns the topics in posters order if requested" do
           expect(ids_in_order('posters')).to eq([pinned_topic, regular_topic, future_topic, invisible_topic, closed_topic, archived_topic].map(&:id))
 
           # returns the topics in reverse posters order if requested" do
-          expect(ids_in_order('posters', false)).to eq([archived_topic, closed_topic, invisible_topic, future_topic, regular_topic, pinned_topic].map(&:id))
+          expect(ids_in_order('posters', false)).to eq([pinned_topic, archived_topic, closed_topic, invisible_topic, future_topic, regular_topic].map(&:id))
 
           # sets a custom field for each topic to emulate a plugin
           regular_topic.custom_fields["sheep"] = 26


### PR DESCRIPTION
When the topics are sorted by a column which is anything except activity, the pinned topics do not remain at the top. 
This does not happen when sorted by activity in both ascending and descending order. 
This resulted in an inconsistent behaviour.

This PR fixes the issue so that the behaviour remains consistent across the columns i.e. views, posts (and likes or posters).