### PR TITLE
FIX: Allow users to opt-out of using the site's small logo as the system user avatar.

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -868,7 +868,10 @@ class User < ActiveRecord::Base
   end
 
   def avatar_template
-    if id == Discourse::SYSTEM_USER_ID && SiteSetting.logo_small
+    use_small_logo = id == Discourse::SYSTEM_USER_ID &&
+      SiteSetting.logo_small && SiteSetting.use_site_small_logo_as_system_avatar
+
+    if use_small_logo
       UrlHelper.absolute(SiteSetting.logo_small.url)
     else
       self.class.avatar_template(username, uploaded_avatar_id)

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1776,6 +1776,7 @@ en:
 
     external_system_avatars_enabled: "Use external system avatars service."
     external_system_avatars_url: "URL of the external system avatars service. Allowed substitutions are {username} {first_letter} {color} {size}"
+    use_site_small_logo_as_system_avatar: "Use the site's small logo instead of the system user's avatar. Requires the logo to be present."
     restrict_letter_avatar_colors: "A list of 6-digit hexadecimal color values to be used for letter avatar background."
 
     selectable_avatars_enabled: "Force users to choose an avatar from the list."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2083,6 +2083,9 @@ uncategorized:
     hidden: true
     default: true
 
+  use_site_small_logo_as_system_avatar:
+    default: true
+
   disable_system_edit_notifications: true
 
   notification_consolidation_threshold:


### PR DESCRIPTION
We should be more flexible with this default and let admins opt-out.

Context here: 

- https://meta.discourse.org/t/i-am-not-able-to-change-avatar-of-system-user/175552
- https://meta.discourse.org/t/cant-change-system-user-profile-picture-independently-of-small-logo/176379
