### PR TITLE
FIX: Make sure login required skipped for confirm new email routes

### DIFF
--- a/app/controllers/users_email_controller.rb
+++ b/app/controllers/users_email_controller.rb
@@ -13,7 +13,9 @@ class UsersEmailController < ApplicationController
 
   skip_before_action :redirect_to_login_if_required, only: [
     :confirm_old_email,
-    :show_confirm_old_email
+    :show_confirm_old_email,
+    :confirm_new_email,
+    :show_confirm_new_email
   ]
 
   before_action :require_login, only: [

--- a/spec/requests/users_email_controller_spec.rb
+++ b/spec/requests/users_email_controller_spec.rb
@@ -15,6 +15,13 @@ describe UsersEmailController do
       expect(response.status).to eq(200)
     end
 
+    it 'does not redirect to login for signed out accounts on login_required sites, this route works fine as anon user' do
+      SiteSetting.login_required = true
+      get "/u/confirm-new-email/asdfasdf"
+
+      expect(response.status).to eq(200)
+    end
+
     it 'errors out for invalid tokens' do
       sign_in(user)
 


### PR DESCRIPTION
As per @davidtaylorhq 's comment at https://github.com/discourse/discourse/commit/6e2be3e60bb882dd92d270d11c71fba9b0901b5e#r46069906, this fixes an oversight where if `login_required` is enabled and an anon user follows a confirm new email link they are forced to login, which is not what the intent of https://github.com/discourse/discourse/pull/10830 was.