### PR TITLE
FEATURE: Give user menu icons alt attributes

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/default-notification-item.js
+++ b/app/assets/javascripts/discourse/app/widgets/default-notification-item.js
@@ -100,8 +100,9 @@ export const DefaultNotificationItem = createWidget(
 
     icon(notificationName) {
       let icon = iconNode(`notification.${notificationName}`);
-      let alt = notificationName.replace(/_/g, " ");
-      icon.properties.attributes["alt"] = alt;
+      icon.properties.attributes["alt"] = I18n.t(
+        `notifications.titles.${notificationName}`
+      );
       icon.properties.attributes["aria-hidden"] = false;
       return icon;
     },

--- a/app/assets/javascripts/discourse/app/widgets/default-notification-item.js
+++ b/app/assets/javascripts/discourse/app/widgets/default-notification-item.js
@@ -99,7 +99,11 @@ export const DefaultNotificationItem = createWidget(
     },
 
     icon(notificationName) {
-      return iconNode(`notification.${notificationName}`);
+      let icon = iconNode(`notification.${notificationName}`);
+      let alt = notificationName.replace(/_/g, " ");
+      icon.properties.attributes["alt"] = alt;
+      icon.properties.attributes["aria-hidden"] = false;
+      return icon;
     },
 
     notificationTitle(notificationName) {

--- a/app/assets/javascripts/discourse/app/widgets/link.js
+++ b/app/assets/javascripts/discourse/app/widgets/link.js
@@ -67,7 +67,7 @@ export default createWidget("link", {
     if (attrs.icon) {
       if (attrs.alt) {
         let icon = iconNode(attrs.icon);
-        icon.properties.attributes["alt"] = attrs.alt;
+        icon.properties.attributes["alt"] = I18n.t(attrs.alt);
         icon.properties.attributes["aria-hidden"] = false;
         result.push(icon);
       } else {

--- a/app/assets/javascripts/discourse/app/widgets/link.js
+++ b/app/assets/javascripts/discourse/app/widgets/link.js
@@ -65,7 +65,14 @@ export default createWidget("link", {
 
     const result = [];
     if (attrs.icon) {
-      result.push(iconNode(attrs.icon));
+      if (attrs.alt) {
+        let icon = iconNode(attrs.icon);
+        icon.properties.attributes["alt"] = attrs.alt;
+        icon.properties.attributes["aria-hidden"] = false;
+        result.push(icon);
+      } else {
+        result.push(iconNode(attrs.icon));
+      }
       result.push(" ");
     }
 

--- a/app/assets/javascripts/discourse/app/widgets/user-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/user-menu.js
@@ -31,7 +31,7 @@ createWidget("user-menu-links", {
       href: `${this.attrs.path}/summary`,
       action: UserMenuAction.QUICK_ACCESS,
       actionParam: QuickAccess.PROFILE,
-      alt: "user preferences icon",
+      alt: "user.preferences",
     };
   },
 
@@ -43,7 +43,7 @@ createWidget("user-menu-links", {
       href: `${this.attrs.path}/notifications`,
       action: UserMenuAction.QUICK_ACCESS,
       actionParam: QuickAccess.NOTIFICATIONS,
-      alt: "user notifications icon",
+      alt: "user.notifications",
     };
   },
 
@@ -55,7 +55,7 @@ createWidget("user-menu-links", {
       className: "user-bookmarks-link",
       icon: "bookmark",
       href: `${this.attrs.path}/activity/bookmarks`,
-      alt: "user bookmarks icon",
+      alt: "user.bookmarks",
     };
   },
 
@@ -67,7 +67,7 @@ createWidget("user-menu-links", {
       className: "user-pms-link",
       icon: "envelope",
       href: `${this.attrs.path}/messages`,
-      alt: "user messages icon",
+      alt: "user.private_messages",
     };
   },
 

--- a/app/assets/javascripts/discourse/app/widgets/user-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/user-menu.js
@@ -31,6 +31,7 @@ createWidget("user-menu-links", {
       href: `${this.attrs.path}/summary`,
       action: UserMenuAction.QUICK_ACCESS,
       actionParam: QuickAccess.PROFILE,
+      alt: "user preferences icon",
     };
   },
 
@@ -42,6 +43,7 @@ createWidget("user-menu-links", {
       href: `${this.attrs.path}/notifications`,
       action: UserMenuAction.QUICK_ACCESS,
       actionParam: QuickAccess.NOTIFICATIONS,
+      alt: "user notifications icon",
     };
   },
 
@@ -53,6 +55,7 @@ createWidget("user-menu-links", {
       className: "user-bookmarks-link",
       icon: "bookmark",
       href: `${this.attrs.path}/activity/bookmarks`,
+      alt: "user bookmarks icon",
     };
   },
 
@@ -64,6 +67,7 @@ createWidget("user-menu-links", {
       className: "user-pms-link",
       icon: "envelope",
       href: `${this.attrs.path}/messages`,
+      alt: "user messages icon",
     };
   },
 


### PR DESCRIPTION
This commit gives user menu icons + notifications alt attributes. 

- [X] The icons in the notifications tabs have meaning that is not apparent from the text, for example “bookmark reminder” or “badge granted”. Although this information is in the title attribute of the links, title attribute text is not reliably announced and therefore should not be used to provide this information. The icons should be given an accessible text alternative.
 
![image](https://user-images.githubusercontent.com/30537603/104976280-75370680-59c2-11eb-81c4-392fd966897e.png)

- [X]  The icons for the tabs have no accessible alternative.

![image](https://user-images.githubusercontent.com/30537603/104976357-a6afd200-59c2-11eb-8600-5761fe5e4689.png)


