### PR TITLE
DEV: Use absolute path for popper.js sourcemap

### DIFF
--- a/lib/tasks/javascript.rake
+++ b/lib/tasks/javascript.rake
@@ -321,7 +321,7 @@ task 'javascript:update' => 'clean_up' do
       File.open(dest) do |file|
         contents = file.read
         contents.gsub!("sourceMappingURL=popper", "sourceMappingURL=/popper")
-        File.open(dest, "w+") { |f| f.write(contents) }
+        File.open(dest, "w+") { |d| d.write(contents) }
       end
     end
   end

--- a/lib/tasks/javascript.rake
+++ b/lib/tasks/javascript.rake
@@ -314,6 +314,16 @@ task 'javascript:update' => 'clean_up' do
     else
       FileUtils.cp_r(src, dest)
     end
+
+    # use absolute path for popper.js's sourcemap
+    # avoids noisy console warnings in dev environment for non-homepage paths
+    if dest.end_with? "popper.js"
+      File.open(dest) do |file|
+        contents = file.read
+        contents.gsub!("sourceMappingURL=popper", "sourceMappingURL=/popper")
+        File.open(dest, "w+") { |f| f.write(contents) }
+      end
+    end
   end
 
   write_template("discourse/app/lib/public-js-versions.js", "update", <<~JS)

--- a/vendor/assets/javascripts/popper.js
+++ b/vendor/assets/javascripts/popper.js
@@ -1731,4 +1731,4 @@
   Object.defineProperty(exports, '__esModule', { value: true });
 
 })));
-//# sourceMappingURL=popper.js.map
+//# sourceMappingURL=/popper.js.map


### PR DESCRIPTION
Switches Popper.js relative sourcemap path to absolute, thus fixing the
reference locally when loading non-homepage paths and avoiding noisy
console warnings. 

(Production should not be affected.)
