### PR TITLE
FIX: Don't try to focus on a missing element

### DIFF
--- a/app/assets/javascripts/admin/addon/components/embeddable-host.js
+++ b/app/assets/javascripts/admin/addon/components/embeddable-host.js
@@ -1,16 +1,12 @@
-import discourseComputed, {
-  observes,
-  on,
-} from "discourse-common/utils/decorators";
 import Category from "discourse/models/category";
 import Component from "@ember/component";
 import I18n from "I18n";
 import bootbox from "bootbox";
 import { bufferedProperty } from "discourse/mixins/buffered-content";
+import discourseComputed from "discourse-common/utils/decorators";
 import { isEmpty } from "@ember/utils";
 import { or } from "@ember/object/computed";
 import { popupAjaxError } from "discourse/lib/ajax-error";
-import { schedule } from "@ember/runloop";
 
 export default Component.extend(bufferedProperty("host"), {
   editToggled: false,
@@ -18,14 +14,6 @@ export default Component.extend(bufferedProperty("host"), {
   categoryId: null,
 
   editing: or("host.isNew", "editToggled"),
-
-  @on("didInsertElement")
-  @observes("editing")
-  _focusOnInput() {
-    schedule("afterRender", () => {
-      this.element.querySelector(".host-name").focus();
-    });
-  },
 
   @discourseComputed("buffered.host", "host.isSaving")
   cantSave(host, isSaving) {

--- a/app/assets/javascripts/admin/addon/templates/components/embeddable-host.hbs
+++ b/app/assets/javascripts/admin/addon/templates/components/embeddable-host.hbs
@@ -1,7 +1,7 @@
 {{#if editing}}
   <td class="editing-input">
     <div class="label">{{i18n "admin.embedding.host"}}</div>
-    {{input value=buffered.host placeholder="example.com" enter=(action "save") class="host-name"}}
+    {{input value=buffered.host placeholder="example.com" enter=(action "save") class="host-name" autofocus=true}}
   </td>
   <td class="editing-input">
     <div class="label">{{i18n "admin.embedding.class_name"}}</div>


### PR DESCRIPTION
Replacing 3 imports and flawed fragile logic with a single html attribute 💆

Fixes "TypeError: Cannot read property 'focus' of null" on /admin/customize/embedding.