### PR TITLE
FIX: Embedded comments should only return regular posts

### DIFF
--- a/app/controllers/embed_controller.rb
+++ b/app/controllers/embed_controller.rb
@@ -74,6 +74,7 @@ class EmbedController < ApplicationController
       @topic_view = TopicView.new(topic_id,
                                   current_user,
                                   limit: SiteSetting.embed_post_limit,
+                                  only_regular: true,
                                   exclude_first: true,
                                   exclude_deleted_users: true,
                                   exclude_hidden: true)

--- a/lib/topic_view.rb
+++ b/lib/topic_view.rb
@@ -686,8 +686,9 @@ class TopicView
   end
 
   def filter_post_types(posts)
-    visible_types = Topic.visible_post_types(@user)
+    return posts.where(post_type: Post.types[:regular]) if @only_regular
 
+    visible_types = Topic.visible_post_types(@user)
     if @user.present?
       posts.where("posts.user_id = ? OR post_type IN (?)", @user.id, visible_types)
     else

--- a/spec/components/topic_view_spec.rb
+++ b/spec/components/topic_view_spec.rb
@@ -36,6 +36,25 @@ describe TopicView do
     expect { TopicView.new(topic.id, admin) }.not_to raise_error
   end
 
+  context "filter options" do
+    fab!(:p0) { Fabricate(:post, topic: topic) }
+    fab!(:p1) { Fabricate(:post, topic: topic, post_type: Post.types[:moderator_action]) }
+    fab!(:p2) { Fabricate(:post, topic: topic, post_type: Post.types[:small_action]) }
+
+    it "omits moderator actions and small posts when only_regular is set" do
+      tv = TopicView.new(topic.id, nil)
+      expect(tv.filtered_post_ids).to eq([p0.id, p1.id, p2.id])
+
+      tv = TopicView.new(topic.id, nil, only_regular: true)
+      expect(tv.filtered_post_ids).to eq([p0.id])
+    end
+
+    it "omits the first post when exclude_first is set" do
+      tv = TopicView.new(topic.id, nil, exclude_first: true)
+      expect(tv.filtered_post_ids).to eq([p0.id, p1.id, p2.id])
+    end
+  end
+
   context "setup_filtered_posts" do
     describe "filters posts with ignored users" do
       fab!(:ignored_user) { Fabricate(:ignored_user, user: evil_trout, ignored_user: user) }


### PR DESCRIPTION
There shoudln't be a situation where you'd want to see moderator actions
or small posts.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
