### PR TITLE
FIX: I18n couldn't find translations.

### DIFF
--- a/app/serializers/site_text_serializer.rb
+++ b/app/serializers/site_text_serializer.rb
@@ -15,7 +15,7 @@ class SiteTextSerializer < ApplicationSerializer
     if options[:overridden_keys]
       options[:overridden_keys].include?(object[:id])
     else
-      TranslationOverride.exists?(locale: I18n.locale, translation_key: object[:id])
+      TranslationOverride.exists?(locale: object[:locale], translation_key: object[:id])
     end
   end
 


### PR DESCRIPTION
"I18n.t(key, locale: locale)" fails to find the correct translation in some cases. We should always wrap it with the "I18n.with_locale(locale)" method.

Also, reverting an override wasn't always possible because the serializer always used "I18n.locale" as the locale.

