### PR TITLE
UX: Fallback locale warning improvements.

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-site-text-index.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-site-text-index.js
@@ -42,6 +42,15 @@ export default Controller.extend({
     }
   },
 
+  @discourseComputed("locale")
+  showFallbackLocaleWarning() {
+    return (
+      (this.siteSettings.allow_user_locale ||
+        this.siteSettings.set_locale_from_accept_language_header) &&
+      this.fallbackLocaleFullName
+    );
+  },
+
   actions: {
     edit(siteText) {
       this.transitionToRoute("adminSiteText.edit", siteText.get("id"), {

--- a/app/assets/javascripts/admin/addon/templates/site-text-index.hbs
+++ b/app/assets/javascripts/admin/addon/templates/site-text-index.hbs
@@ -39,7 +39,7 @@
 </div>
 
 {{#conditional-loading-spinner condition=searching}}
-  {{#if fallbackLocaleFullName}}
+  {{#if showFallbackLocaleWarning}}
     <div class="alert alert-info">
       {{d-icon "exclamation-circle"}}
       {{i18n "admin.site_text.fallback_locale_warning" fallback=fallbackLocaleFullName}}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4847,7 +4847,7 @@ en:
         recommended: "We recommend customizing the following text to suit your needs:"
         show_overriden: "Only show overridden"
         locale: "Language:"
-        fallback_locale_warning: "You are editing a variety of %{fallback}. Users who choose %{fallback} as their interface language won't see your changes."
+        fallback_locale_warning: "You are editing a language based on %{fallback}. Users who choose %{fallback} as their interface language won't see your changes."
         more_than_50_results: "There are more than 50 results. Please refine your search."
 
       settings: # used by theme and site settings

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -118,6 +118,7 @@ basic:
     default: false
   set_locale_from_accept_language_header:
     default: false
+    client: true
     validator: "AllowUserLocaleEnabledValidator"
   support_mixed_text_direction:
     client: true


### PR DESCRIPTION
- Improve warning message.
- Only display the warning if the language has a fallback and either "allow_user_locale", or "set_locale_from_accept_language_header" are enabled.

