### PR TITLE
DEV: Remove an unused i18n string

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1811,8 +1811,6 @@ en:
     date_time_picker:
       from: From
       to: To
-      errors:
-        to_before_from: "To date must be later than from date."
 
     emoji_picker:
       filter_placeholder: Search for emoji


### PR DESCRIPTION
Originally added in 95ad4f90776. The only usage removed in 3bbd8b12583.