### PR TITLE
FIX: broken URL when username contains subfolder.

### DIFF
--- a/app/assets/javascripts/discourse-common/addon/lib/get-url.js
+++ b/app/assets/javascripts/discourse-common/addon/lib/get-url.js
@@ -15,9 +15,9 @@ export default function getURL(url) {
     return url;
   }
 
-  const found = url.indexOf(baseUri);
+  const found = url.startsWith(baseUri);
 
-  if (found >= 0 && found < 3) {
+  if (found) {
     return url;
   }
   if (url[0] !== "/") {

--- a/app/assets/javascripts/discourse/tests/unit/lib/get-url-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/get-url-test.js
@@ -61,6 +61,12 @@ module("Unit | Utility | get-url", function () {
     );
 
     assert.equal(
+      getURL("/u/forumadmin"),
+      "/forum/u/forumadmin",
+      "relative url has subfolder even if username contains subfolder"
+    );
+
+    assert.equal(
       getURL(""),
       "/forum",
       "relative url has subfolder without trailing slash"


### PR DESCRIPTION
The bug was mentioned on [meta](https://meta.discourse.org/t/two-bugs-with-usernames-starting-with-subfolder-name/169505)

When discourse is installed on `/subfolder` and username is containing subfolder name like for example `subfolderadmin` - user URLs were incorrect.

Instead of having `/subfolder/u/subfolderadmin/summary/` we were leading to `/subfolder/uadmin/summary`.

The reason for that was incorrect check in `getUrl` helper:

```javascript
  const found = url.indexOf(baseUri);
  if (found >= 0 && found < 3) {
    return url;
  }
  return baseUri + url;
```
baseUri is `/subfolder`, url is `/u/subfolderadmin` and indexOf returned position which in the end returned incorrect URL.

I think that we should check if the URL starts with baseUri and not if contains baseUri.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
