### PR TITLE
FIX: Show the fallback locale warning when both settings are enabled.

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-site-text-index.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-site-text-index.js
@@ -45,8 +45,8 @@ export default Controller.extend({
   @discourseComputed("locale")
   showFallbackLocaleWarning() {
     return (
-      (this.siteSettings.allow_user_locale ||
-        this.siteSettings.set_locale_from_accept_language_header) &&
+      this.siteSettings.allow_user_locale &&
+      this.siteSettings.set_locale_from_accept_language_header &&
       this.fallbackLocaleFullName
     );
   },


### PR DESCRIPTION
We only want to warn admins when both settings are enabled. When "set locale from accept language header" setting is enabled, the user locale will be set based on the header when they register an account on the site, which could be confusing. This setting can only be enabled if `allow user locale` is also enabled.

