### PR TITLE
UX: Make moment.js produce Arabic numerals instead of Hindu numerals in the Arabic locale

### DIFF
--- a/app/assets/javascripts/locales/ar.js.erb
+++ b/app/assets/javascripts/locales/ar.js.erb
@@ -1,3 +1,11 @@
 //= depend_on 'client.ar.yml'
 //= require locales/i18n
 <%= JsLocaleHelper.output_locale(:ar) %>
+
+// original moment.js implementation can be found here:
+// https://github.com/moment/moment/blob/b7ec8e2ec068e03de4f832f28362675bb9e02261/locale/ar.js#L185-L191
+moment.updateLocale("ar", {
+  postformat(string) {
+    return string;
+  }
+});


### PR DESCRIPTION
To be clear, by Arabic numerals I mean `0123456789` and by Hindu numerals I mean `٠١٢٣٤٥٦٧٨٩`.

When you use Discourse in the Arabic locale, moment.js produces strings with Hindu numerals, but all the other strings that are not produced by moment.js use the Arabic numerals. This PR addresses the problem by making moment.js use the Arabic numerals.