### PR TITLE
FIX: Update categories without full page refresh

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/reorder-categories.js
+++ b/app/assets/javascripts/discourse/app/controllers/reorder-categories.js
@@ -15,7 +15,7 @@ export default Controller.extend(ModalFunctionality, Evented, {
     this.categoriesSorting = ["position"];
   },
 
-  @discourseComputed("site.categories")
+  @discourseComputed("site.categories.[]")
   categoriesBuffered(categories) {
     const bufProxy = EmberObjectProxy.extend(BufferedProxy);
     return categories.map((c) => bufProxy.create({ content: c }));

--- a/app/models/category_list.rb
+++ b/app/models/category_list.rb
@@ -109,7 +109,7 @@ class CategoryList < DraftableList
           to_delete << c
         end
       end
-      @categories.each { |c| c.subcategory_ids = subcategories[c.id] }
+      @categories.each { |c| c.subcategory_ids = subcategories[c.id] || [] }
       @categories.delete_if { |c| to_delete.include?(c) }
     end
 

--- a/app/serializers/category_detailed_serializer.rb
+++ b/app/serializers/category_detailed_serializer.rb
@@ -26,10 +26,6 @@ class CategoryDetailedSerializer < BasicCategorySerializer
     is_uncategorized
   end
 
-  def include_subcategory_ids?
-    subcategory_ids.present?
-  end
-
   def topics_day
     count_with_subcategories(:topics_day)
   end


### PR DESCRIPTION
Creating or moving a category required a full page refresh until it
showed up correctly.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
