### PR TITLE
UX: Small tweak to category delete warning

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/edit-category-tabs.js
+++ b/app/assets/javascripts/discourse/app/controllers/edit-category-tabs.js
@@ -15,7 +15,7 @@ export default Controller.extend({
   saving: false,
   deleting: false,
   panels: null,
-  hiddenTooltip: true,
+  showTooltip: false,
   createdCategory: false,
   expandedMenu: false,
   mobileView: readOnly("site.mobileView"),
@@ -74,6 +74,11 @@ export default Controller.extend({
   @discourseComputed("selectedTab")
   selectedTabTitle(tab) {
     return I18n.t(`category.${underscore(tab)}`);
+  },
+
+  @discourseComputed("showTooltip", "model.cannot_delete_reason")
+  showDeleteReason(showTooltip, reason) {
+    return showTooltip && reason;
   },
 
   actions: {
@@ -143,7 +148,7 @@ export default Controller.extend({
     },
 
     toggleDeleteTooltip() {
-      this.toggleProperty("hiddenTooltip");
+      this.toggleProperty("showTooltip");
     },
 
     goBack() {

--- a/app/assets/javascripts/discourse/app/controllers/edit-category-tabs.js
+++ b/app/assets/javascripts/discourse/app/controllers/edit-category-tabs.js
@@ -1,3 +1,4 @@
+import { and, readOnly } from "@ember/object/computed";
 import discourseComputed, { on } from "discourse-common/utils/decorators";
 import Category from "discourse/models/category";
 import Controller from "@ember/controller";
@@ -7,7 +8,6 @@ import { NotificationLevels } from "discourse/lib/notification-levels";
 import PermissionType from "discourse/models/permission-type";
 import bootbox from "bootbox";
 import { extractError } from "discourse/lib/ajax-error";
-import { readOnly } from "@ember/object/computed";
 import { underscore } from "@ember/string";
 
 export default Controller.extend({
@@ -20,6 +20,7 @@ export default Controller.extend({
   expandedMenu: false,
   mobileView: readOnly("site.mobileView"),
   parentParams: null,
+  showDeleteReason: and("showTooltip", "model.cannot_delete_reason"),
 
   @on("init")
   _initPanels() {
@@ -74,11 +75,6 @@ export default Controller.extend({
   @discourseComputed("selectedTab")
   selectedTabTitle(tab) {
     return I18n.t(`category.${underscore(tab)}`);
-  },
-
-  @discourseComputed("showTooltip", "model.cannot_delete_reason")
-  showDeleteReason(showTooltip, reason) {
-    return showTooltip && reason;
   },
 
   actions: {

--- a/app/assets/javascripts/discourse/app/routes/edit-category-tabs.js
+++ b/app/assets/javascripts/discourse/app/routes/edit-category-tabs.js
@@ -13,6 +13,7 @@ export default DiscourseRoute.extend({
     controller.setProperties({
       parentParams,
       selectedTab: transition.to.params.tab,
+      showTooltip: false,
     });
   },
 });

--- a/app/assets/javascripts/discourse/app/templates/edit-category-tabs.hbs
+++ b/app/assets/javascripts/discourse/app/templates/edit-category-tabs.hbs
@@ -34,6 +34,12 @@
     {{/each}}
   </div>
 
+  {{#if showDeleteReason}}
+    <div class="edit-category-delete-warning">
+      <p class="warning">{{html-safe model.cannot_delete_reason}}</p>
+    </div>
+  {{/if}}
+
   <div class="edit-category-footer">
     {{d-button id="save-category" class="btn-primary" disabled=disabled action=(action "saveCategory") label=saveLabel}}
 
@@ -54,10 +60,6 @@
           icon="question-circle"
           label="category.delete"
         }}
-
-        <div class="cannot-delete-reason {{if hiddenTooltip "hidden" ""}}">
-          {{html-safe model.cannot_delete_reason}}
-        </div>
       </div>
     {{/if}}
   </div>

--- a/app/assets/stylesheets/common/base/edit-category.scss
+++ b/app/assets/stylesheets/common/base/edit-category.scss
@@ -7,7 +7,7 @@ div.edit-category {
   grid-template-rows: auto auto auto;
   grid-row-gap: 1em;
   grid-column-gap: 1.5em;
-  grid-template-areas: "header header" "sidebar content" "sidebar footer";
+  grid-template-areas: "header header" "sidebar content" "sidebar warning" "sidebar footer";
 
   .edit-category-title {
     grid-area: header;
@@ -141,37 +141,16 @@ div.edit-category {
     }
   }
 
+  .edit-category-delete-warning {
+    grid-area: warning;
+  }
+
   .edit-category-footer {
     grid-area: footer;
     display: flex;
     justify-content: space-between;
     align-self: start;
     padding: 0 1.5em 2em 0;
-
-    .disable-info {
-      position: relative;
-      .cannot-delete-reason {
-        position: absolute;
-        bottom: 125%;
-        right: 0px;
-        width: 250px;
-        background: var(--primary);
-        color: var(--secondary);
-        text-align: center;
-        border-radius: 2px;
-        padding: 12px 8px;
-
-        &::after {
-          top: 100%;
-          left: 57%;
-          border: solid transparent;
-          content: " ";
-          position: absolute;
-          border-top-color: var(--primary);
-          border-width: 8px;
-        }
-      }
-    }
   }
 }
 


### PR DESCRIPTION
We previously had very specific styling for the warning shown when a category cannot be deleted: 

<img width="977" alt="image" src="https://user-images.githubusercontent.com/368961/105413127-a8b4a380-5c03-11eb-9e48-743c7e3b066a.png">

This was not working well on some dark themes, especially for the link in the copy: 

![image](https://user-images.githubusercontent.com/368961/105413329-f3ceb680-5c03-11eb-8f85-ee39d13ba48f.png)

This PR proposes switching to the more consistent style of warning across the app : 

<img width="985" alt="image" src="https://user-images.githubusercontent.com/368961/105413159-b66a2900-5c03-11eb-8616-da3312d7ff86.png">
