### PR TITLE
UX: Makes the theme editor display placeholders correctly for RTL languages

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-theme-editor.js
+++ b/app/assets/javascripts/admin/addon/components/admin-theme-editor.js
@@ -2,6 +2,7 @@ import Component from "@ember/component";
 import I18n from "I18n";
 import discourseComputed from "discourse-common/utils/decorators";
 import { fmt } from "discourse/lib/computed";
+import { isDocumentRTL } from "discourse/lib/text-direction";
 import { next } from "@ember/runloop";
 
 export default Component.extend({
@@ -43,9 +44,17 @@ export default Component.extend({
 
   @discourseComputed("currentTargetName", "fieldName")
   placeholder(targetName, fieldName) {
-    return fieldName && fieldName === "color_definitions"
-      ? I18n.t("admin.customize.theme.color_definitions.placeholder")
-      : "";
+    if (fieldName && fieldName === "color_definitions") {
+      const example =
+        ":root {\n" +
+        "  --mytheme-tertiary-or-quaternary: #{dark-light-choose($tertiary, $quaternary)};\n" +
+        "}";
+
+      return I18n.t("admin.customize.theme.color_definitions.placeholder", {
+        example: isDocumentRTL() ? `<div dir="ltr">${example}</div>` : example,
+      });
+    }
+    return "";
   },
 
   @discourseComputed("fieldName", "currentTargetName", "theme")

--- a/app/assets/javascripts/admin/addon/templates/components/admin-theme-editor.hbs
+++ b/app/assets/javascripts/admin/addon/templates/components/admin-theme-editor.hbs
@@ -87,4 +87,4 @@
   <pre class="field-error">{{error}}</pre>
 {{/if}}
 
-{{ace-editor content=activeSection editorId=editorId mode=activeSectionMode autofocus="true" placeholder=placeholder}}
+{{ace-editor content=activeSection editorId=editorId mode=activeSectionMode autofocus="true" placeholder=placeholder htmlPlaceholder=true}}

--- a/app/assets/javascripts/discourse/app/lib/text-direction.js
+++ b/app/assets/javascripts/discourse/app/lib/text-direction.js
@@ -29,3 +29,7 @@ export function siteDir() {
   }
   return _siteDir;
 }
+
+export function isDocumentRTL() {
+  return siteDir() === "rtl";
+}

--- a/app/assets/stylesheets/common/base/rtl.scss
+++ b/app/assets/stylesheets/common/base/rtl.scss
@@ -120,3 +120,12 @@
     }
   }
 }
+
+.rtl .ace_placeholder {
+  direction: rtl !important;
+  text-align: right !important;
+
+  [dir="ltr"] {
+    text-align: left !important;
+  }
+}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4164,9 +4164,7 @@ en:
 
               Example:
 
-              :root {
-                --mytheme-tertiary-or-quaternary: #{dark-light-choose($tertiary, $quaternary)};
-              }
+              %{example}
 
               Prefixing the property names is highly recommended to avoid conflicts with plugins and/or core.
           head_tag:


### PR DESCRIPTION
The theme editor for Color Definitions shows a placeholder with some helpful text as well as a code sample. That placeholder didn't support RTL text.

This PR makes it work by changing CSS and setting the placeholders `innerHTML` instead of the `textContent` attribute. The latter was needed because the code sample should always be LTR. I'm not sure if my solution is a good idea -- I needed to do some hacky stuff in order to override the editor's behavior.

I couldn't think of a better solution and the end result looks quite nice, so I'm not sure... :man_shrugging: 

![image](https://user-images.githubusercontent.com/473736/105419396-ef73bf00-5c3e-11eb-9fb4-11980a3d7f3b.png)

This fixes https://discourse.crowdin.com/translate/f3230e7607a36bb0a2f97fd90605a44e/246/en-he#53834