### PR TITLE
FIX: print raw html of logo image to skip unwanted html encoding

### DIFF
--- a/plugins/discourse-narrative-bot/lib/discourse_narrative_bot/templates/advanced_user.svg.erb
+++ b/plugins/discourse-narrative-bot/lib/discourse_narrative_bot/templates/advanced_user.svg.erb
@@ -46,7 +46,7 @@
   <text x="<%= @width / 2 %>" y="270" text-anchor="middle" fill="#020403" font-family="'Tangerine'" font-size="34.8841px">
     <%= @name %>
   </text>
-  <%= @logo_group %>
+  <%== @logo_group %>
 
   <g>
     <g fill="#8CC63F">

--- a/plugins/discourse-narrative-bot/lib/discourse_narrative_bot/templates/new_user.svg.erb
+++ b/plugins/discourse-narrative-bot/lib/discourse_narrative_bot/templates/new_user.svg.erb
@@ -457,7 +457,7 @@
     <text x="<%= @width / 2 %>" y="240.94" text-anchor="middle" font-size="24" fill="#020403" font-family="Tangerine, Tangerine">
       <%= @name %>
     </text>
-    <%= @logo_group %>
+    <%== @logo_group %>
   </g>
   <g id="Layer_1-2" data-name="Layer 1">
     <path d="M339.328 47.187c-.034 1.193 3.25 2.2 6.51 3.383 5.5 1.994 13.1 3.73 17.68 3.112 5.05-.55 4.982-2.217 4.054-4.8-.1-4.647.258-9.493.156-14.142l-27.128-.458c.5 4.698-1.778 8.207-1.272 12.905z" transform="translate(-.108)" fill-rule="evenodd" fill="url(#GradientFill_24)"/>

--- a/plugins/discourse-narrative-bot/spec/requests/discobot_certificate_spec.rb
+++ b/plugins/discourse-narrative-bot/spec/requests/discobot_certificate_spec.rb
@@ -36,6 +36,7 @@ describe "Discobot Certificate" do
         get '/discobot/certificate.svg', params: params
 
         expect(response.status).to eq(200)
+        expect(response.body).to include('<image height="55px" width="55px" />')
       end
 
       describe 'when params are missing' do


### PR DESCRIPTION
Currently, the image logo is broken since the image tag is rendering incorrectly.
