### PR TITLE
A11Y: associate search controls with their labels

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/search-advanced-options.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/search-advanced-options.hbs
@@ -7,6 +7,7 @@
     </label>
     <div class="controls">
       {{user-chooser
+        id="search-posted-by"
         value=searchedTerms.username
         onChange=(action "onChangeSearchTermForUsername")
         options=(hash
@@ -20,6 +21,7 @@
     <label class="control-label" for="search-in-category">{{i18n "search.advanced.in_category.label"}}</label>
     <div class="controls">
       {{search-advanced-category-chooser
+        id="search-in-category"
         value=searchedTerms.category.id
         onChange=(action "onChangeSearchTermForCategory")
       }}
@@ -33,6 +35,7 @@
       <label class="control-label" for="search-with-tags">{{i18n "search.advanced.with_tags.label"}}</label>
       <div class="controls">
         {{tag-chooser
+          id="search-with-tags"
           tags=searchedTerms.tags
           allowCreate=false
           everyTag=true
@@ -116,7 +119,7 @@
     <label class="control-label" for="search-status-options">{{i18n "search.advanced.statuses.label"}}</label>
     <div class="controls">
       {{combo-box
-        id="status"
+        id="search-status-options"
         valueProperty="value"
         content=statusOptions
         value=searchedTerms.status
@@ -179,7 +182,7 @@
   </div>
 
   <div class="count-group control-group pull-left">
-    <label class="control-label">{{i18n "search.advanced.views.label"}}</label>
+    <label class="control-label" for="search-min-views">{{i18n "search.advanced.views.label"}}</label>
     <div class="count pull-left">
       <div class="controls">
         {{input

--- a/app/assets/javascripts/discourse/tests/acceptance/search-full-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-full-test.js
@@ -310,7 +310,7 @@ acceptance("Search - Full Page", function (needs) {
 
   test("update status through advanced search ui", async function (assert) {
     const statusSelector = selectKit(
-      ".search-advanced-options .select-kit#status"
+      ".search-advanced-options .select-kit#search-status-options"
     );
 
     await visit("/search");
@@ -333,7 +333,7 @@ acceptance("Search - Full Page", function (needs) {
 
   test("doesn't update status filter header if wrong value entered through searchbox", async function (assert) {
     const statusSelector = selectKit(
-      ".search-advanced-options .select-kit#status"
+      ".search-advanced-options .select-kit#search-status-options"
     );
 
     await visit("/search");


### PR DESCRIPTION
We already had most of the labels, but they needed to be bound with IDs. 