### PR TITLE
UX: specify width and height for onebox preview error image

### DIFF
--- a/app/assets/stylesheets/common/base/onebox.scss
+++ b/app/assets/stylesheets/common/base/onebox.scss
@@ -322,7 +322,8 @@ aside.onebox {
   }
 }
 
-aside.onebox .onebox-body .onebox-avatar {
+aside.onebox .onebox-body .onebox-avatar,
+aside.onebox.preview-error .site-icon {
   max-height: none;
   max-width: none;
   height: 60px;


### PR DESCRIPTION
Before:

<img width="620" alt="Screenshot 2021-01-22 at 12 43 48 PM" src="https://user-images.githubusercontent.com/5732281/105460979-9776a000-5cb2-11eb-9763-0d1b005cdadc.png">

After:

<img width="628" alt="Screenshot 2021-01-22 at 12 43 30 PM" src="https://user-images.githubusercontent.com/5732281/105460970-93e31900-5cb2-11eb-92fa-b501787db62e.png">