### PR TITLE
UX: show onebox error preview image as favicon

### DIFF
--- a/app/assets/stylesheets/common/base/onebox.scss
+++ b/app/assets/stylesheets/common/base/onebox.scss
@@ -322,8 +322,7 @@ aside.onebox {
   }
 }
 
-aside.onebox .onebox-body .onebox-avatar,
-aside.onebox.preview-error .site-icon {
+aside.onebox .onebox-body .onebox-avatar {
   max-height: none;
   max-width: none;
   height: 60px;
@@ -803,4 +802,10 @@ aside.onebox.stackexchange .onebox-body {
       }
     }
   }
+}
+
+aside.onebox.preview-error .site-icon {
+  width: 16px;
+  height: 16px;
+  margin-right: 0.5em;
 }


### PR DESCRIPTION
Before:

<img width="628" alt="Screenshot 2021-01-22 at 12 43 30 PM" src="https://user-images.githubusercontent.com/5732281/105460970-93e31900-5cb2-11eb-92fa-b501787db62e.png">

After:

<img width="721" alt="Screenshot 2021-01-22 at 7 18 16 PM" src="https://user-images.githubusercontent.com/5732281/105498802-9c554700-5ce6-11eb-86c9-e9ff97ea9230.png">
