### PR TITLE
FIX: It seems sometimes shims are evaluated by older JS engines

### DIFF
--- a/app/assets/javascripts/handlebars-shim.js
+++ b/app/assets/javascripts/handlebars-shim.js
@@ -7,7 +7,7 @@ if (typeof define !== "undefined") {
       __exports__.default = Handlebars;
       __exports__.compile = function () {
         // eslint-disable-next-line
-        return Handlebars.compile(...arguments);
+        return Handlebars.compile.apply(this, arguments);
       };
     }
   });


### PR DESCRIPTION
This gives us backwards compatibility with those.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
