### PR TITLE
FIX: Remove scheduled DND timings when schedule is disabed

### DIFF
--- a/app/models/user_notification_schedule.rb
+++ b/app/models/user_notification_schedule.rb
@@ -18,8 +18,12 @@ class UserNotificationSchedule < ActiveRecord::Base
   scope :enabled, -> { where(enabled: true) }
 
   def create_do_not_disturb_timings(delete_existing: false)
-    user.do_not_disturb_timings.where(scheduled: true).destroy_all if delete_existing
+    destroy_scheduled_timings if delete_existing
     UserNotificationScheduleProcessor.create_do_not_disturb_timings_for(self)
+  end
+
+  def destroy_scheduled_timings
+    user.do_not_disturb_timings.where(scheduled: true).destroy_all
   end
 
   private

--- a/app/services/user_updater.rb
+++ b/app/services/user_updater.rb
@@ -200,7 +200,9 @@ class UserUpdater
 
     if saved
       if user_notification_schedule
-        user_notification_schedule.create_do_not_disturb_timings(delete_existing: true)
+        user_notification_schedule.enabled ?
+          user_notification_schedule.create_do_not_disturb_timings(delete_existing: true) :
+          user_notification_schedule.destroy_scheduled_timings
       end
       DiscourseEvent.trigger(:user_updated, user)
     end

--- a/spec/services/user_updater_spec.rb
+++ b/spec/services/user_updater_spec.rb
@@ -251,6 +251,18 @@ describe UserUpdater do
           updater.update(user_notification_schedule: schedule_attrs)
         }.to change { user.do_not_disturb_timings.count }.by(4)
       end
+
+      it "removes do_not_disturb_timings when the schedule is disabled" do
+        updater = UserUpdater.new(acting_user, user)
+        updater.update(user_notification_schedule: schedule_attrs)
+        expect(user.user_notification_schedule.enabled).to eq(true)
+
+        schedule_attrs[:enabled] = false
+        updater.update(user_notification_schedule: schedule_attrs)
+
+        expect(user.user_notification_schedule.enabled).to eq(false)
+        expect(user.do_not_disturb_timings.count).to eq(0)
+      end
     end
 
     context 'when sso overrides bio' do


### PR DESCRIPTION
I noticed that I was still in Do Not Disturb after I disabled my schedule. Timings previously were not immidiately removed when a users' notification schedule was disabled. This does that :)