### PR TITLE
FIX: Cannot calculate color scheme id when no theme id is present

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/preferences/interface.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/interface.js
@@ -153,7 +153,7 @@ export default Controller.extend({
     "themeId"
   )
   currentSchemeCanBeSelected(userThemes, userColorSchemes, themeId) {
-    if (!userThemes) {
+    if (!userThemes || !themeId) {
       return false;
     }
 


### PR DESCRIPTION
Fixes a broken user preferences > interface screen in some edge cases
where no `themeId` is available (for example, while on safe mode).

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
