### PR TITLE
UX: Simplify narrative bot bio

### DIFF
--- a/plugins/discourse-narrative-bot/config/locales/server.en.yml
+++ b/plugins/discourse-narrative-bot/config/locales/server.en.yml
@@ -21,7 +21,7 @@ en:
         This badge is granted upon successful completion of the interactive advanced user tutorial. You’ve mastered the advanced tools of discussion — and now you’re fully licensed!
 
   discourse_narrative_bot:
-    bio: "Hi, I’m not a real person. I’m a bot that can teach you about this site. To interact with me, send me a message or mention **`@%{discobot_username}`** anywhere."
+    bio: "Hi, I’m not a real person. I’m a bot that can teach you about this site. To interact with me, send me a message or mention me by name."
 
     tl2_promotion_message:
       subject_template: "Now that you’ve been promoted, it’s time to learn about some advanced features!"

--- a/plugins/discourse-narrative-bot/db/fixtures/001_discobot.rb
+++ b/plugins/discourse-narrative-bot/db/fixtures/001_discobot.rb
@@ -49,7 +49,7 @@ bot.create_user_profile! if !bot.user_profile
 
 if !bot.user_profile.bio_raw
   bot.user_profile.update!(
-    bio_raw: I18n.t('discourse_narrative_bot.bio', site_title: SiteSetting.title, discobot_username: bot.username)
+    bio_raw: I18n.t('discourse_narrative_bot.bio')
   )
 end
 


### PR DESCRIPTION
This addresses the change requested here: https://meta.discourse.org/t/how-to-customize-discobot/103633/17

<img width="1161" alt="discobio" src="https://user-images.githubusercontent.com/22733864/105555367-16bda100-5cbe-11eb-8a79-ab62d424a5d5.png">


It also removes the `site_title` translation variable that has been unused since https://github.com/discourse/discourse-narrative-bot/commit/acfe224e2c8971f197a15f6779b404065a75e049