### PR TITLE
FIX: Can't remove selection from group chooser in tag group settings

### DIFF
--- a/app/assets/javascripts/discourse/app/components/tag-groups-form.js
+++ b/app/assets/javascripts/discourse/app/components/tag-groups-form.js
@@ -107,6 +107,8 @@ export default Component.extend(bufferedProperty("model"), {
       this.allGroups.forEach((group) => {
         if (groupIds.includes(group.id)) {
           updatedPermissions[group.name] = PermissionType.FULL;
+        } else {
+          delete updatedPermissions[group.name];
         }
       });
 

--- a/app/assets/javascripts/discourse/app/templates/components/tag-groups-form.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/tag-groups-form.hbs
@@ -62,8 +62,7 @@
           content=allGroups
           value=selectedGroupIds
           labelProperty="name"
-          onChange=(action "setPermissionsGroups")
-        }}
+          onChange=(action "setPermissionsGroups")}}
       </div>
     </div>
     <div>

--- a/app/assets/javascripts/discourse/app/templates/components/tag-groups-form.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/tag-groups-form.hbs
@@ -62,7 +62,8 @@
           content=allGroups
           value=selectedGroupIds
           labelProperty="name"
-          onChange=(action "setPermissionsGroups")}}
+          onChange=(action "setPermissionsGroups")
+        }}
       </div>
     </div>
     <div>


### PR DESCRIPTION
This change fixes an issue with the user group chooser of a tag group's settings. It was impossible to clear any selected groups through the UI.

The `setPermissionsGroups` function determines which groups appear selected in the group-chooser based on the passed-in `groupIds` array.

It starts with `updatedPermissions` being set to the group permissions as they were prior the action that called the function. From there, we were correctly adding a group permission to `updatedPermissions` whenever a group appeared in `groupIds`. This addressed newly added groups and also maintained any group permissions that had been set before. The problem was that there was no logic to **_remove_** a group permission when the associated group no longer appeared in `groupIds`. If a group isn't included in `groupIds`, we can simply attempt to delete an associated group permission if it exists.

**Before fix:**

<img src="https://user-images.githubusercontent.com/22733864/105566986-eb4dad00-5ce3-11eb-8972-35251ca7da50.gif" width=400>

**After fix:**

<img src="https://user-images.githubusercontent.com/22733864/105566983-e7ba2600-5ce3-11eb-9ceb-420b65996ce4.gif" width=400>

Let me know if I should write a test for this.