### PR TITLE
A11Y: uses role=button and supports ariaPressed for tapTile

### DIFF
--- a/app/assets/javascripts/discourse/app/components/tap-tile.js
+++ b/app/assets/javascripts/discourse/app/components/tap-tile.js
@@ -1,13 +1,26 @@
+import { reads } from "@ember/object/computed";
 import Component from "@ember/component";
 import { propertyEqual } from "discourse/lib/computed";
 
 export default Component.extend({
   init() {
     this._super(...arguments);
+
     this.set("elementId", `tap_tile_${this.tileId}`);
   },
+
   classNames: ["tap-tile"],
+
   classNameBindings: ["active"],
+
+  attributeBindings: ["role", "ariaPressed", "tabIndex"],
+
+  role: "button",
+
+  tabIndex: 0,
+
+  ariaPressed: reads("active"),
+
   click() {
     this.onChange(this.tileId);
   },


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
