### PR TITLE
FIX: ensures timeline_lookup includes last tuple

### DIFF
--- a/lib/timeline_lookup.rb
+++ b/lib/timeline_lookup.rb
@@ -12,7 +12,10 @@ module TimelineLookup
     last_days_ago = -1
     tuples.each_with_index do |t, idx|
       return result unless t.is_a?(Array)
-      next unless (idx % every) === 0
+
+      if idx != tuples.size - 1
+        next unless (idx % every) === 0
+      end
 
       days_ago = t[1]
 

--- a/spec/lib/timeline_lookup_spec.rb
+++ b/spec/lib/timeline_lookup_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe TimelineLookup do
+
+  context '.build' do
+    it 'keeps the last tuple in the lookup' do
+      tuples = [
+        [7173, 400], [7174, 390], [7175, 380], [7176, 370], [7177, 1]
+      ]
+
+      expect(TimelineLookup.build(tuples, 2)).to eq([[1, 400], [4, 370], [5, 1]])
+    end
+  end
+
+end


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
