### PR TITLE
PERF: Migrate search data after locale rename

### DIFF
--- a/db/post_migrate/20210125100452_migrate_search_data_after_default_locale_rename.rb
+++ b/db/post_migrate/20210125100452_migrate_search_data_after_default_locale_rename.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class MigrateSearchDataAfterDefaultLocaleRename < ActiveRecord::Migration[6.0]
+  def up
+    move_search_data("category_search_data")
+    move_search_data("post_search_data")
+    move_search_data("tag_search_data")
+    move_search_data("topic_search_data")
+    move_search_data("user_search_data")
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+  private
+
+  def move_search_data(table_name)
+    execute <<~SQL
+      UPDATE #{table_name} x
+      SET locale = 'en'
+      WHERE locale = 'en_US'
+    SQL
+  rescue
+    # Probably a unique key constraint violation. A background job might have inserted conflicting data during the UPDATE.
+    # We can safely ignore this error. The ReindexSearch job will eventually fix the data.
+  end
+end


### PR DESCRIPTION
The default locale `en_US` has been renamed into `en`. This tries to migrate existing search data to avoid resource intensive reindexing.