### PR TITLE
FIX: Dismissing unread topics with a tag

### DIFF
--- a/app/assets/javascripts/discourse/app/mixins/bulk-topic-selection.js
+++ b/app/assets/javascripts/discourse/app/mixins/bulk-topic-selection.js
@@ -3,8 +3,11 @@ import { NotificationLevels } from "discourse/lib/notification-levels";
 import Topic from "discourse/models/topic";
 import { alias } from "@ember/object/computed";
 import { on } from "discourse-common/utils/decorators";
+import { inject as service } from "@ember/service";
 
 export default Mixin.create({
+  router: service(),
+
   bulkSelectEnabled: false,
   selected: null,
 


### PR DESCRIPTION
This commits add missing router service to the mixin. It did not work
because 'router' was undefined.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
