### PR TITLE
DEV: Remove dead code (`latestTopicOnly`)

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/discovery/categories.js
+++ b/app/assets/javascripts/discourse/app/controllers/discovery/categories.js
@@ -19,15 +19,6 @@ export default DiscoveryController.extend({
 
   canEdit: reads("currentUser.staff"),
 
-  @discourseComputed("model.categories.[].featuredTopics.length")
-  latestTopicOnly() {
-    return (
-      this.get("model.categories").find(
-        (c) => c.get("featuredTopics.length") > 1
-      ) === undefined
-    );
-  },
-
   @discourseComputed("model.parentCategory")
   categoryPageStyle(parentCategory) {
     let style = this.site.mobileView

--- a/app/assets/javascripts/discourse/app/templates/components/categories-with-featured-topics.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/categories-with-featured-topics.hbs
@@ -1,3 +1,2 @@
 {{categories-only categories=categories
-                  latestTopicOnly=latestTopicOnly
                   showTopics="true"}}

--- a/app/assets/javascripts/discourse/app/templates/components/featured-topic.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/featured-topic.hbs
@@ -2,11 +2,4 @@
 <a href={{topic.lastUnreadUrl}} class="title">{{html-safe topic.fancyTitle}}</a>
 {{topic-post-badges newPosts=topic.totalUnread unseen=topic.unseen url=topic.lastUnreadUrl}}
 
-{{#if latestTopicOnly}}
-  <div class="last-user-info">
-    {{i18n "categories.latest_by"}} <a href={{html-safe topic.lastPosterUrl}}>{{topic.last_poster.username}}</a>
-    <a href={{topic.lastPostUrl}}>{{format-age topic.last_posted_at}}</a>
-  </div>
-{{else}}
-  <a href={{topic.lastPostUrl}} class="last-posted-at">{{format-age topic.last_posted_at}}</a>
-{{/if}}
+<a href={{topic.lastPostUrl}} class="last-posted-at">{{format-age topic.last_posted_at}}</a>

--- a/app/assets/javascripts/discourse/app/templates/components/parent-category-row.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/parent-category-row.hbs
@@ -32,7 +32,7 @@
       {{#if showTopics}}
         <td class="latest">
           {{#each category.featuredTopics as |t|}}
-            {{featured-topic topic=t latestTopicOnly=latestTopicOnly}}
+            {{featured-topic topic=t}}
           {{/each}}
         </td>
       {{/if}}

--- a/app/assets/javascripts/discourse/app/templates/discovery/categories.hbs
+++ b/app/assets/javascripts/discourse/app/templates/discovery/categories.hbs
@@ -1,6 +1,5 @@
 {{#discovery-categories refresh=(action "refresh")}}
   {{component categoryPageStyle
               categories=model.categories
-              latestTopicOnly=latestTopicOnly
               topics=model.topics}}
 {{/discovery-categories}}

--- a/app/assets/javascripts/discourse/app/templates/mobile/components/categories-with-featured-topics.hbs
+++ b/app/assets/javascripts/discourse/app/templates/mobile/components/categories-with-featured-topics.hbs
@@ -1,3 +1,2 @@
 {{categories-only categories=categories
-                  latestTopicOnly=latestTopicOnly
                   showTopics="true"}}

--- a/app/assets/javascripts/discourse/app/templates/mobile/discovery/categories.hbs
+++ b/app/assets/javascripts/discourse/app/templates/mobile/discovery/categories.hbs
@@ -1,6 +1,5 @@
 {{#discovery-categories refresh=(action "refresh")}}
   {{component categoryPageStyle
               categories=model.categories
-              latestTopicOnly=latestTopicOnly
               topics=model.topics}}
 {{/discovery-categories}}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -838,7 +838,6 @@ en:
       posts: "Posts"
       topics: "Topics"
       latest: "Latest"
-      latest_by: "latest by"
       toggle_ordering: "toggle ordering control"
       subcategories: "Subcategories"
       muted: "Muted categories"


### PR DESCRIPTION
Background: I wanted to see `categories.latest_by` translation in context in a live app but couldn't find it, so I traced it throughout the code.

My step-by-step reasoning for the removal is:

1. `categories-only` does not use `latestTopicOnly`, so there's no need to call it with that argument
2. `parent-category-row` is never called with `latestTopicOnly` argument, so the reference to that arg can be removed from its template
3. after that, `featured-topic` is now no longer ever called with `latestTopicOnly` argument (except in the `ghost` theme, but that's because its override of `categories-only` template https://github.com/discourse/ghost/blob/4e2fba963c5f3fa6159c1a14d45ac9e82ce7b214/common/header.html#L119 is based on the old version of that template from core), so it seems safe to remove it there too (`categories.latest_by` i18n string is also no longer needed)
4. then, nothing is using `latestTopicOnly` anymore so it can be removed from `categories` hbs/js

I checked in each step that there are no plugins or themes (in all-the-plugins/all-the-themes) using those properties/arguments/strings.

Requesting a review from @ZogStriP, since git blame pointed you out in a couple of places, via [this commit from just 5 years ago](https://github.com/discourse/discourse/commit/4d6028ea2db6f1abf1041a10b26692b3b41a7b42) so I'm sure you have all the necessary knowledge to confirm this is remove. 😂 