### PR TITLE
FIX: Cleanup authentication_data cookie after login

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -562,13 +562,14 @@ module ApplicationHelper
   end
 
   def authentication_data
-    @authentication_data ||= begin
+    return @authentication_data if defined?(@authentication_data)
+
+    @authentication_data = begin
       value = cookies[:authentication_data]
       if value
         cookies.delete(:authentication_data, path: Discourse.base_path("/"))
       end
-      value = nil if current_user
-      value
+      current_user ? nil : value
     end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -560,4 +560,15 @@ module ApplicationHelper
       end
     end
   end
+
+  def authentication_data
+    @authentication_data ||= begin
+      value = cookies[:authentication_data]
+      if value
+        cookies.delete(:authentication_data, path: Discourse.base_path("/"))
+      end
+      value = nil if current_user
+      value
+    end
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -60,8 +60,8 @@
 
     <%= tag.meta id: 'data-discourse-setup', data: client_side_setup_data %>
 
-    <%- if !current_user && (data = cookies.delete(:authentication_data, path: Discourse.base_path("/"))) %>
-      <meta id="data-authentication" data-authentication-data="<%= data %>">
+    <%- if authentication_data %>
+      <meta id="data-authentication" data-authentication-data="<%= authentication_data %>">
     <%- end %>
   </head>
 

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe ApplicationController do
 
     it 'contains authentication data when cookies exist' do
       cookie_data = "someauthenticationdata"
-      cookies['authentication_data'] = "someauthenticationdata"
+      cookies['authentication_data'] = cookie_data
       get '/login'
       expect(response.status).to eq(200)
       expect(response.body).to include("data-authentication-data=\"#{cookie_data}\"")

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -104,11 +104,21 @@ RSpec.describe ApplicationController do
     end
 
     it 'contains authentication data when cookies exist' do
-      COOKIE_DATA = "someauthenticationdata"
-      cookies['authentication_data'] = COOKIE_DATA
+      cookie_data = "someauthenticationdata"
+      cookies['authentication_data'] = "someauthenticationdata"
       get '/login'
       expect(response.status).to eq(200)
-      expect(response.body).to include("data-authentication-data=\"#{COOKIE_DATA }\"")
+      expect(response.body).to include("data-authentication-data=\"#{cookie_data}\"")
+      expect(response.headers["Set-Cookie"]).to include("authentication_data=;") # Delete cookie
+    end
+
+    it 'deletes authentication data cookie even if already authenticated' do
+      sign_in(Fabricate(:user))
+      cookies['authentication_data'] = "someauthenticationdata"
+      get '/'
+      expect(response.status).to eq(200)
+      expect(response.body).not_to include("data-authentication-data=")
+      expect(response.headers["Set-Cookie"]).to include("authentication_data=;") # Delete cookie
     end
   end
 


### PR DESCRIPTION
This cookie is only used during login. Having it persist after that can
cause some unusual behavior, especially for sites with short session
lengths.

We were already deleting the cookie following a new signup, but not for
existing users.

This commit moves the cookie deletion logic out of the erb template, and
adds logic and tests to ensure it is always deleted consistently.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
