### PR TITLE
UX: respect `email_editable` site setting in user activation page.

### DIFF
--- a/app/assets/javascripts/discourse/app/components/activation-controls.js
+++ b/app/assets/javascripts/discourse/app/components/activation-controls.js
@@ -1,4 +1,10 @@
 import Component from "@ember/component";
+import { or } from "@ember/object/computed";
+
 export default Component.extend({
   classNames: "activation-controls",
+  canEditEmail: or(
+    "siteSettings.enable_local_logins",
+    "siteSettings.email_editable"
+  ),
 });

--- a/app/assets/javascripts/discourse/app/templates/components/activation-controls.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/activation-controls.hbs
@@ -5,7 +5,9 @@
              class="btn-primary resend"}}
 {{/unless}}
 
-{{d-button action=editActivationEmail
-           label="login.change_email"
-           icon="pencil-alt"
-           class="edit-email"}}
+{{#if canEditEmail}}
+  {{d-button action=editActivationEmail
+            label="login.change_email"
+            icon="pencil-alt"
+            class="edit-email"}}
+{{/if}}

--- a/app/assets/javascripts/discourse/tests/integration/components/activation-controls-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/activation-controls-test.js
@@ -1,0 +1,25 @@
+import componentTest, {
+  setupRenderingTest,
+} from "discourse/tests/helpers/component-test";
+import {
+  discourseModule,
+  queryAll,
+} from "discourse/tests/helpers/qunit-helpers";
+
+discourseModule("Integration | Component | activation-controls", function (
+  hooks
+) {
+  setupRenderingTest(hooks);
+
+  componentTest("hides change email button", {
+    template: `{{activation-controls}}`,
+    beforeEach() {
+      this.siteSettings.enable_local_logins = false;
+      this.siteSettings.email_editable = false;
+    },
+
+    test(assert) {
+      assert.equal(queryAll("button.edit-email").length, 0);
+    },
+  });
+});

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -541,7 +541,9 @@ users:
     max: 10
   block_common_passwords: true
   username_change_period: 3
-  email_editable: true
+  email_editable:
+    client: true
+    default: true
   logout_redirect:
     client: true
     default: ""


### PR DESCRIPTION
Previously, even when both `enable_local_logins` and `email_editable` are disabled users can change the email on the user activation page.