### PR TITLE
FIX: Restore user summary's delete button behavior.

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-user-index.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-user-index.js
@@ -396,7 +396,6 @@ export default Controller.extend(CanCheckEmails, {
     destroy() {
       const postCount = this.get("model.post_count");
       const maxPostCount = this.siteSettings.delete_all_posts_max;
-      const user = this.model;
       const message = I18n.t("admin.user.delete_confirm");
       const location = document.location.pathname;
 
@@ -422,13 +421,9 @@ export default Controller.extend(CanCheckEmails, {
               }
             } else {
               bootbox.alert(I18n.t("admin.user.delete_failed"));
-              if (data.user) {
-                user.setProperties(data.user);
-              }
             }
           })
           .catch(() => {
-            AdminUser.find(user.get("id")).then((u) => user.setProperties(u));
             bootbox.alert(I18n.t("admin.user.delete_failed"));
           });
       };

--- a/app/assets/javascripts/admin/addon/models/admin-user.js
+++ b/app/assets/javascripts/admin/addon/models/admin-user.js
@@ -264,7 +264,17 @@ const AdminUser = User.extend({
     return ajax(`/admin/users/${this.id}.json`, {
       type: "DELETE",
       data: formData,
-    });
+    })
+      .then((data) => {
+        if (!data.deleted && data.user) {
+          this.setProperties(data.user);
+        }
+
+        return data;
+      })
+      .catch(() => {
+        this.find(this.id).then((u) => this.setProperties(u));
+      });
   },
 
   merge(formData) {

--- a/app/assets/javascripts/admin/addon/services/admin-tools.js
+++ b/app/assets/javascripts/admin/addon/services/admin-tools.js
@@ -33,8 +33,8 @@ export default Service.extend({
     return AdminUser.find(userId).then((au) => this.spammerDetails(au));
   },
 
-  deleteUser(id) {
-    AdminUser.find(id).then((user) => user.destroy({ deletePosts: true }));
+  deleteUser(id, formData) {
+    return AdminUser.find(id).then((user) => user.destroy(formData));
   },
 
   spammerDetails(adminUser) {

--- a/app/assets/javascripts/discourse/app/controllers/user.js
+++ b/app/assets/javascripts/discourse/app/controllers/user.js
@@ -3,7 +3,11 @@ import EmberObject, { computed, set } from "@ember/object";
 import { alias, and, gt, not, or } from "@ember/object/computed";
 import CanCheckEmails from "discourse/mixins/can-check-emails";
 import User from "discourse/models/user";
+import I18n from "I18n";
+import bootbox from "bootbox";
 import discourseComputed from "discourse-common/utils/decorators";
+import getURL from "discourse-common/lib/get-url";
+import { iconHTML } from "discourse-common/lib/icon-library";
 import { isEmpty } from "@ember/utils";
 import optionalService from "discourse/lib/optional-service";
 import { prioritizeNameInUx } from "discourse/lib/settings";
@@ -168,7 +172,57 @@ export default Controller.extend(CanCheckEmails, {
     },
 
     adminDelete() {
-      this.adminTools.deleteUser(this.get("model.id"));
+      const userId = this.get("model.id");
+      const message = I18n.t("admin.user.delete_confirm");
+      const location = document.location.pathname;
+
+      const performDestroy = (block) => {
+        bootbox.dialog(I18n.t("admin.user.deleting_user"));
+        let formData = { context: location };
+        if (block) {
+          formData["block_email"] = true;
+          formData["block_urls"] = true;
+          formData["block_ip"] = true;
+        }
+        formData["delete_posts"] = true;
+
+        this.adminTools
+          .deleteUser(userId, formData)
+          .then((data) => {
+            if (data.deleted) {
+              document.location = getURL("/admin/users/list/active");
+            } else {
+              bootbox.alert(I18n.t("admin.user.delete_failed"));
+            }
+          })
+          .catch(() => bootbox.alert(I18n.t("admin.user.delete_failed")));
+      };
+
+      const buttons = [
+        {
+          label: I18n.t("composer.cancel"),
+          class: "btn",
+          link: true,
+        },
+        {
+          label:
+            `${iconHTML("exclamation-triangle")} ` +
+            I18n.t("admin.user.delete_and_block"),
+          class: "btn btn-danger",
+          callback: function () {
+            performDestroy(true);
+          },
+        },
+        {
+          label: I18n.t("admin.user.delete_dont_block"),
+          class: "btn btn-primary",
+          callback: function () {
+            performDestroy(false);
+          },
+        },
+      ];
+
+      bootbox.dialog(message, buttons, { classes: "delete-user-modal" });
     },
 
     updateNotificationLevel(level) {


### PR DESCRIPTION
The user summary's delete button UX relied on the "admin-user.js" destroy function, which was called through the "admin-tools" service. After #11724, we no longer put UX behavior on Ember models.


