### PR TITLE
A11Y: correctly sets role=dialog and aria-labelledby for d-modals

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-modal.js
+++ b/app/assets/javascripts/discourse/app/components/d-modal.js
@@ -1,3 +1,4 @@
+import { computed } from "@ember/object";
 import Component from "@ember/component";
 import I18n from "I18n";
 import afterTransition from "discourse/lib/after-transition";
@@ -12,10 +13,16 @@ export default Component.extend({
     "modalStyle",
     "hasPanels",
   ],
-  attributeBindings: ["data-keyboard", "aria-modal"],
+  attributeBindings: [
+    "data-keyboard",
+    "aria-modal",
+    "role",
+    "ariaLabelledby:aria-labelledby",
+  ],
   dismissable: true,
   title: null,
   subtitle: null,
+  role: "dialog",
 
   init() {
     this._super(...arguments);
@@ -32,6 +39,10 @@ export default Component.extend({
   "data-keyboard": "false",
   // Inform screenreaders of the modal
   "aria-modal": "true",
+
+  ariaLabelledby: computed("title", function () {
+    return this.title ? "discourse-modal-title" : null;
+  }),
 
   @on("didInsertElement")
   setUp() {

--- a/app/assets/javascripts/discourse/app/templates/components/d-modal.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/d-modal.hbs
@@ -8,7 +8,7 @@
 
         {{#if title}}
           <div class="title">
-            <h3>{{title}}</h3>
+            <h3 id="discourse-modal-title">{{title}}</h3>
 
             {{#if subtitle}}
               <p>{{subtitle}}</p>


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
