### PR TITLE
FIX: move post_search_data migration into onceoff job

### DIFF
--- a/app/jobs/onceoff/fix_post_search_data_after_default_locale_rename.rb
+++ b/app/jobs/onceoff/fix_post_search_data_after_default_locale_rename.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Jobs
+  class FixPostSearchDataAfterDefaultLocaleRename < ::Jobs::Onceoff
+    def execute_onceoff(args)
+      return if SearchIndexer::POST_INDEX_VERSION != 4
+
+      sql = <<~SQL
+        UPDATE post_search_data
+           SET locale = 'en'
+         WHERE post_id IN (
+                SELECT post_id
+                  FROM post_search_data
+                 WHERE locale = 'en_US'
+                 LIMIT 100000
+             )
+      SQL
+
+      loop { break if DB.exec(sql) == 0 }
+    end
+  end
+end

--- a/db/post_migrate/20210125100452_migrate_search_data_after_default_locale_rename.rb
+++ b/db/post_migrate/20210125100452_migrate_search_data_after_default_locale_rename.rb
@@ -4,7 +4,7 @@ class MigrateSearchDataAfterDefaultLocaleRename < ActiveRecord::Migration[6.0]
   disable_ddl_transaction!
 
   def up
-    %w{category tag topic post user}.each { |model| fix_search_data(model) }
+    %w{category tag topic user}.each { |model| fix_search_data(model) }
   end
 
   def down
@@ -17,6 +17,8 @@ class MigrateSearchDataAfterDefaultLocaleRename < ActiveRecord::Migration[6.0]
     key = "#{model}_id"
     table = "#{model}_search_data"
 
+    puts "Migrating #{table} to new locale."
+
     sql = <<~SQL
       UPDATE #{table}
          SET locale = 'en'
@@ -24,7 +26,7 @@ class MigrateSearchDataAfterDefaultLocaleRename < ActiveRecord::Migration[6.0]
               SELECT #{key}
                 FROM #{table}
                WHERE locale = 'en_US'
-               LIMIT 500000
+               LIMIT 100000
            )
     SQL
 


### PR DESCRIPTION
And reduce the size of the batches to 100k.

That should hopefully make the migrations run smoother...

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
