### PR TITLE
A11Y: hamburger menu aria-{expanded,haspopup} and user title

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/header.js
+++ b/app/assets/javascripts/discourse/app/widgets/header.js
@@ -146,8 +146,10 @@ createWidget(
           "a.icon",
           {
             attributes: {
-              href: attrs.user.get("path"),
-              title: attrs.user.get("name"),
+              "aria-haspopup": true,
+              "aria-expanded": attrs.active,
+              href: attrs.user.path,
+              title: attrs.user.name || attrs.user.username,
               "data-auto-route": true,
             },
           },
@@ -177,6 +179,8 @@ createWidget(
           "a.icon.btn-flat",
           {
             attributes: {
+              "aria-expanded": attrs.active,
+              "aria-haspopup": true,
               href: attrs.href,
               "data-auto-route": true,
               title,
@@ -441,7 +445,7 @@ export default createWidget("header", {
     if (this.site.mobileView) {
       const searchService = this.register.lookup("search-service:main");
       const context = searchService.get("searchContext");
-      var params = "";
+      let params = "";
 
       if (context) {
         params = `?context=${context.type}&context_id=${context.id}&skip_context=${this.state.skipSearchContext}`;


### PR DESCRIPTION
User title in the current-user header-dropdown was sometimes `title="null"` if user doesn’t have a name. This is fixed as part of this commit to improve accessibility of this part of the UI.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
