### PR TITLE
FIX: Allow a single invite per email address

### DIFF
--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -94,8 +94,7 @@ class InvitesController < ApplicationController
     guardian.ensure_can_invite_to_forum!(groups)
     group_ids = groups.map(&:id)
 
-    invite_exists = Invite.exists?(email: params[:email], invited_by_id: current_user.id)
-    if invite_exists && !guardian.can_send_multiple_invites?(current_user)
+    if Invite.exists?(email: params[:email])
       return render json: failed_json, status: 422
     end
 

--- a/spec/requests/invites_controller_spec.rb
+++ b/spec/requests/invites_controller_spec.rb
@@ -145,11 +145,11 @@ describe InvitesController do
         expect(Invite.find_by(email: email).invited_groups.count).to eq(1)
       end
 
-      it "allows admin to send multiple invites to same email" do
+      it "does not allow admins to send multiple invites to same email" do
         user = sign_in(admin)
         invite = Invite.invite_by_email("invite@example.com", user)
         post "/invites.json", params: { email: invite.email }
-        expect(response.status).to eq(200)
+        expect(response.status).to eq(422)
       end
 
       it "responds with error message in case of validation failure" do


### PR DESCRIPTION
Staff users could still send multiple invites to the same user.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
