### PR TITLE
DEV: Use $upstream for logging performance headers in NGINX

### DIFF
--- a/config/nginx.sample.conf
+++ b/config/nginx.sample.conf
@@ -29,7 +29,7 @@ map $http_x_forwarded_proto $thescheme {
   https https;
 }
 
-log_format log_discourse '[$time_local] "$http_host" $remote_addr "$request" "$http_user_agent" "$sent_http_x_discourse_route" $status $bytes_sent "$http_referer" $upstream_response_time $request_time "$sent_http_x_discourse_username" "$sent_http_x_discourse_trackview" "$sent_http_x_queue_time" "$sent_http_x_redis_calls" "$sent_http_x_redis_time" "$sent_http_x_sql_calls" "$sent_http_x_sql_time"';
+log_format log_discourse '[$time_local] "$http_host" $remote_addr "$request" "$http_user_agent" "$sent_http_x_discourse_route" $status $bytes_sent "$http_referer" $upstream_response_time $request_time "$upstream_http_x_discourse_username" "$upstream_http_x_discourse_trackview" "$upstream_http_x_queue_time" "$upstream_http_x_redis_calls" "$upstream_http_x_redis_time" "$upstream_http_x_sql_calls" "$upstream_http_x_sql_time"';
 
 server {
 


### PR DESCRIPTION
This ensures that the logs will still work, even if the headers are
hidden with `proxy_hide_header`

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
