### PR TITLE
UX: make desktop category page topics match mobile

### DIFF
--- a/app/assets/stylesheets/desktop/category-list.scss
+++ b/app/assets/stylesheets/desktop/category-list.scss
@@ -38,6 +38,7 @@
 
     .value {
       font-size: $font-up-1;
+      font-weight: bold;
     }
     .unit {
       font-size: $font-down-1;

--- a/app/assets/stylesheets/desktop/latest-topic-list.scss
+++ b/app/assets/stylesheets/desktop/latest-topic-list.scss
@@ -11,6 +11,11 @@
   .more-topics {
     margin-top: 1em;
   }
+
+  .posts-map {
+    font-size: $font-up-1;
+    font-weight: bold;
+  }
 }
 
 .latest-topic-list-item {
@@ -53,6 +58,6 @@
   }
 
   .topic-last-activity a {
-    color: var(--primary-med-or-secondary-high);
+    color: var(--primary-low-mid-or-secondary-high);
   }
 }


### PR DESCRIPTION
Before (the post count on the right)

![Screen Shot 2021-01-26 at 5 41 25 PM](https://user-images.githubusercontent.com/1681963/105916148-8bfede00-5ffe-11eb-9860-e000e7a7f614.png)

After (now consistent with mobile topic list layout)

![Screen Shot 2021-01-26 at 5 37 34 PM](https://user-images.githubusercontent.com/1681963/105916211-97520980-5ffe-11eb-99f4-94507cafbd56.png)
