### PR TITLE
FIX: external auth account creation when `destination_url` is set

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/login.js
+++ b/app/assets/javascripts/discourse/app/controllers/login.js
@@ -403,6 +403,8 @@ export default Controller.extend(ModalFunctionality, {
       skipConfirmation,
     });
 
-    showModal("createAccount", { modalClass: "create-account" });
+    next(() => {
+      showModal("createAccount", { modalClass: "create-account" });
+    });
   },
 });


### PR DESCRIPTION

Reproduction steps: 

- add `try.discourse.org` to the DiscourseHub app and tap Connect 
- OR go to `try.discourse.org/new-topic` in your browser
- use an external login method (Apple, Twitter, etc.) that is not already linked with an account 

After authentication, the login form is shown, where the expected behaviour is to show the Create New Account form.

Delaying `createNewAccount` so it runs after the current run loop seems to fix the issue. 