### PR TITLE
FIX: Do not cache translated trust level names in site settings

### DIFF
--- a/app/models/trust_level_setting.rb
+++ b/app/models/trust_level_setting.rb
@@ -9,7 +9,7 @@ class TrustLevelSetting < EnumSiteSetting
 
   def self.values
     levels = TrustLevel.all
-    @values ||= valid_values.map { |x|
+    valid_values.map { |x|
       {
         name: x.is_a?(Integer) ? "#{x}: #{levels[x.to_i].name}" : x,
         value: x


### PR DESCRIPTION
There's no real need to cache these, and the caching can introduce
problems when different sites/users are using different locales.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
