### PR TITLE
DEV: Replace 'processed' column on notifications with new table

### DIFF
--- a/app/controllers/do_not_disturb_controller.rb
+++ b/app/controllers/do_not_disturb_controller.rb
@@ -25,9 +25,10 @@ class DoNotDisturbController < ApplicationController
   def destroy
     current_user.active_do_not_disturb_timings.destroy_all
     current_user.publish_do_not_disturb(ends_at: nil)
-    current_user.notifications.unprocessed.each do |notification|
-      NotificationEmailer.process_notification(notification, no_delay: true)
+    current_user.shelved_notifications.each do |shelved_notification|
+      shelved_notification.process
     end
+    current_user.shelved_notifications.destroy_all
     render json: success_json
   end
 

--- a/app/controllers/do_not_disturb_controller.rb
+++ b/app/controllers/do_not_disturb_controller.rb
@@ -25,9 +25,7 @@ class DoNotDisturbController < ApplicationController
   def destroy
     current_user.active_do_not_disturb_timings.destroy_all
     current_user.publish_do_not_disturb(ends_at: nil)
-    current_user.shelved_notifications.each do |shelved_notification|
-      shelved_notification.process
-    end
+    current_user.shelved_notifications.each(&:process)
     current_user.shelved_notifications.destroy_all
     render json: success_json
   end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -284,9 +284,7 @@ class Notification < ActiveRecord::Base
   end
 
   def send_email
-    if skip_send_email
-      return update(processed: true)
-    end
+    return if skip_send_email
 
     user.do_not_disturb? ?
       ShelvedNotification.create(notification_id: self.id) :

--- a/app/models/shelved_notification.rb
+++ b/app/models/shelved_notification.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class ShelvedNotification < ActiveRecord::Base
+  belongs_to :notification
+
+  def process
+    NotificationEmailer.process_notification(notification, no_delay: true)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -79,6 +79,7 @@ class User < ActiveRecord::Base
   has_many :topics_allowed, through: :topic_allowed_users, source: :topic
   has_many :groups, through: :group_users
   has_many :secure_categories, through: :groups, source: :categories
+  has_many :shelved_notifications, through: :notification
 
   # deleted in user_second_factors relationship
   has_many :totps, -> {
@@ -1389,10 +1390,6 @@ class User < ActiveRecord::Base
 
   def do_not_disturb_until
     active_do_not_disturb_timings.maximum(:ends_at)
-  end
-
-  def shelved_notifications
-    ShelvedNotification.joins(:notification).where("notifications.user_id = ?", self.id)
   end
 
   protected

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1391,6 +1391,10 @@ class User < ActiveRecord::Base
     active_do_not_disturb_timings.maximum(:ends_at)
   end
 
+  def shelved_notifications
+    ShelvedNotification.joins(:notification).where("notifications.user_id = ?", self.id)
+  end
+
   protected
 
   def badge_grant

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -79,7 +79,6 @@ class User < ActiveRecord::Base
   has_many :topics_allowed, through: :topic_allowed_users, source: :topic
   has_many :groups, through: :group_users
   has_many :secure_categories, through: :groups, source: :categories
-  has_many :shelved_notifications, through: :notification
 
   # deleted in user_second_factors relationship
   has_many :totps, -> {
@@ -1390,6 +1389,10 @@ class User < ActiveRecord::Base
 
   def do_not_disturb_until
     active_do_not_disturb_timings.maximum(:ends_at)
+  end
+
+  def shelved_notifications
+    ShelvedNotification.joins(:notification).where("notifications.user_id = ?", self.id)
   end
 
   protected

--- a/app/services/notification_emailer.rb
+++ b/app/services/notification_emailer.rb
@@ -125,7 +125,6 @@ class NotificationEmailer
   end
 
   def self.process_notification(notification, no_delay: false)
-    notification.update(processed: true)
     return if @disabled
 
     email_user   = EmailUser.new(notification, no_delay: no_delay)

--- a/db/migrate/20210105165605_add_processed_to_notifications.rb
+++ b/db/migrate/20210105165605_add_processed_to_notifications.rb
@@ -2,13 +2,16 @@
 
 class AddProcessedToNotifications < ActiveRecord::Migration[6.0]
   def up
-    add_column :notifications, :processed, :boolean, default: false
-    execute "UPDATE notifications SET processed = true"
-    change_column_null(:notifications, :processed, false)
-    add_index :notifications, [:processed], unique: false
+    # Commented out because this was causing issues with large databases.
+    # Creating a new table instead of adding this column.
+    #
+    # add_column :notifications, :processed, :boolean, default: false
+    # execute "UPDATE notifications SET processed = true"
+    # change_column_null(:notifications, :processed, false)
+    # add_index :notifications, [:processed], unique: false
   end
 
   def down
-    remove_column :notifications, :processed
+    # remove_column :notifications, :processed
   end
 end

--- a/db/migrate/20210105165605_add_processed_to_notifications.rb
+++ b/db/migrate/20210105165605_add_processed_to_notifications.rb
@@ -1,17 +1,6 @@
 # frozen_string_literal: true
 
 class AddProcessedToNotifications < ActiveRecord::Migration[6.0]
-  def up
-    # Commented out because this was causing issues with large databases.
-    # Creating a new table instead of adding this column.
-    #
-    # add_column :notifications, :processed, :boolean, default: false
-    # execute "UPDATE notifications SET processed = true"
-    # change_column_null(:notifications, :processed, false)
-    # add_index :notifications, [:processed], unique: false
-  end
-
-  def down
-    # remove_column :notifications, :processed
+  def change
   end
 end

--- a/db/migrate/20210126222142_create_shelved_notifications.rb
+++ b/db/migrate/20210126222142_create_shelved_notifications.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+class CreateShelvedNotifications < ActiveRecord::Migration[6.0]
+  def change
+    create_table :shelved_notifications do |t|
+      t.integer :notification_id, null: false
+    end
+    add_index :shelved_notifications, [:notification_id]
+  end
+end

--- a/db/post_migrate/20210127140730_undo_add_processed_to_notifications.rb
+++ b/db/post_migrate/20210127140730_undo_add_processed_to_notifications.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class UndoAddProcessedToNotifications < ActiveRecord::Migration[6.0]
+  def up
+    execute "ALTER TABLE notifications DROP COLUMN IF EXISTS processed"
+  end
+end

--- a/spec/fabricators/shelved_notification_fabricator.rb
+++ b/spec/fabricators/shelved_notification_fabricator.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Fabricator(:shelved_notification) do
+  notification
+end

--- a/spec/fabricators/shelved_notification_fabricator.rb
+++ b/spec/fabricators/shelved_notification_fabricator.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-Fabricator(:shelved_notification) do
-  notification
-end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -495,7 +495,6 @@ describe Notification do
         expect { notification.reload }.to raise_error(ActiveRecord::RecordNotFound)
 
         notification = Notification.last
-        expect(notification.processed).to eq(true)
         expect(notification.notification_type).to eq(Notification.types[:membership_request_consolidated])
 
         data = notification.data_hash
@@ -516,7 +515,7 @@ describe Notification do
 
         notification = Notification.last
         expect(notification.notification_type).to eq(Notification.types[:membership_request_consolidated])
-        expect(notification.processed).to eq(false)
+        expect(notification.shelved_notification).to be_present
       end
     end
   end
@@ -543,18 +542,18 @@ describe Notification do
     end
   end
 
-  describe "processed" do
+  describe "do not disturb" do
     fab!(:user) { Fabricate(:user) }
 
-    it "is false after creation when the user is in do not disturb" do
+    it "creates a shelved_notification record when created while user is in DND" do
       user.do_not_disturb_timings.create(starts_at: Time.now, ends_at: 3.days.from_now)
       notification = Notification.create(read: false, user_id: user.id, topic_id: 2, post_number: 1, data: '{}', notification_type: 1)
-      expect(notification.processed).to be(false)
+      expect(notification.shelved_notification).to be_present
     end
 
-    it "is true after creation when the user isn't in do not disturb" do
+    it "doesn't create a shelved_notification record when created while user is isn't DND" do
       notification = Notification.create(read: false, user_id: user.id, topic_id: 2, post_number: 1, data: '{}', notification_type: 1)
-      expect(notification.processed).to be(true)
+      expect(notification.shelved_notification).to be_nil
     end
   end
 end

--- a/spec/requests/do_not_disturb_controller_spec.rb
+++ b/spec/requests/do_not_disturb_controller_spec.rb
@@ -52,7 +52,6 @@ describe DoNotDisturbController do
         delete "/do-not-disturb.json"
         expect { notification.shelved_notification.reload }.to raise_error(ActiveRecord::RecordNotFound)
         expect(user.do_not_disturb?).to eq(false)
-
       end
     end
   end

--- a/spec/requests/do_not_disturb_controller_spec.rb
+++ b/spec/requests/do_not_disturb_controller_spec.rb
@@ -44,13 +44,15 @@ describe DoNotDisturbController do
     end
 
     describe "#destroy" do
-      it "process notifications that came in during DND" do
+      it "process shelved notifications that came in during DND" do
         user.do_not_disturb_timings.create(starts_at: 2.days.ago, ends_at: 2.days.from_now)
         notification = Notification.create(read: false, user_id: user.id, topic_id: 2, post_number: 1, data: '{}', notification_type: 1)
 
-        expect(notification.processed).to eq(false)
+        expect(notification.shelved_notification).to be_present
         delete "/do-not-disturb.json"
-        expect(notification.reload.processed).to eq(true)
+        expect { notification.shelved_notification.reload }.to raise_error(ActiveRecord::RecordNotFound)
+        expect(user.do_not_disturb?).to eq(false)
+
       end
     end
   end


### PR DESCRIPTION
This is more simple than it may look. Instead of adding a `processed` column on the notifications table, this creates a new table: `shelved_notifications`. 

Every time a notification is created while the user is in DND mode, a new `shelved_notifications` record is created that simple stores the `notification_id`. The same `ProcessShelvedNotifications` job runs every 5 minutes and joins this table to the do_not_disturb_timings table and finds and notifications that should be sent out. The `shelved_notification` records are then destroyed.