### PR TITLE
DEV: Update Gemfile.lock for arm64-darwin-20

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,6 +170,7 @@ GEM
     jwt (2.2.2)
     kgio (2.11.3)
     libv8 (8.4.255.0)
+    libv8 (8.4.255.0-universal-darwin-20)
     libv8 (8.4.255.0-x86_64-darwin-18)
     libv8 (8.4.255.0-x86_64-darwin-19)
     libv8 (8.4.255.0-x86_64-darwin-20)
@@ -219,6 +220,8 @@ GEM
     nio4r (2.5.4)
     nokogiri (1.11.1)
       mini_portile2 (~> 2.5.0)
+      racc (~> 1.4)
+    nokogiri (1.11.1-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.11.1-x86_64-darwin)
       racc (~> 1.4)
@@ -453,6 +456,7 @@ GEM
     zeitwerk (2.4.2)
 
 PLATFORMS
+  arm64-darwin-20
   ruby
   x86_64-darwin-18
   x86_64-darwin-19
@@ -585,4 +589,4 @@ DEPENDENCIES
   yaml-lint
 
 BUNDLED WITH
-   2.2.3
+   2.2.6


### PR DESCRIPTION
After this, the only remaining issue preventing Discourse from booting on apple silicon is mini_racer/libv8. See upstream discussion at https://github.com/rubyjs/mini_racer/pull/186 for an experimental solution.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
