### PR TITLE
FEATURE: add contact emails metadata entry to optional plugin meta

### DIFF
--- a/lib/plugin/metadata.rb
+++ b/lib/plugin/metadata.rb
@@ -82,7 +82,7 @@ class Plugin::Metadata
     "discourse-staff-alias",
   ])
 
-  FIELDS ||= [:name, :about, :version, :authors, :url, :required_version, :transpile_js]
+  FIELDS ||= [:name, :about, :version, :authors, :contact_emails, :url, :required_version, :transpile_js]
   attr_accessor(*FIELDS)
 
   def self.parse(text)

--- a/spec/components/plugin/metadata_spec.rb
+++ b/spec/components/plugin/metadata_spec.rb
@@ -10,6 +10,7 @@ describe Plugin::Metadata do
 # about: about: my plugin
 # version: 0.1
 # authors: Frank Zappa
+# contact emails: frankz@example.com
 # url: http://discourse.org
 # required version: 1.3.0beta6+48
 
@@ -20,6 +21,7 @@ TEXT
       expect(metadata.about).to eq("about: my plugin")
       expect(metadata.version).to eq("0.1")
       expect(metadata.authors).to eq("Frank Zappa")
+      expect(metadata.contact_emails).to eq("frankz@example.com")
       expect(metadata.url).to eq("http://discourse.org")
       expect(metadata.required_version).to eq("1.3.0beta6+48")
     end


### PR DESCRIPTION
We are in the process of adding some automation in our org and would love to add contact emails to plugin meta if at all possible.  The current way the code is structured makes this hard to override in a plugin so a commitment to core makes sense?
