### PR TITLE
FIX: Invisible is not always the opposite of visible

### DIFF
--- a/app/assets/javascripts/discourse/app/models/topic.js
+++ b/app/assets/javascripts/discourse/app/models/topic.js
@@ -1,4 +1,4 @@
-import { and, equal, not, notEmpty, or } from "@ember/object/computed";
+import { and, equal, notEmpty, or } from "@ember/object/computed";
 import { fmt, propertyEqual } from "discourse/lib/computed";
 import ActionSummary from "discourse/models/action-summary";
 import Category from "discourse/models/category";
@@ -211,7 +211,11 @@ const Topic = RestModel.extend({
     });
   },
 
-  invisible: not("visible"),
+  @discourseComputed("visible")
+  invisible(visible) {
+    return visible !== undefined ? !visible : undefined;
+  },
+
   deleted: notEmpty("deleted_at"),
 
   @discourseComputed("id")

--- a/app/assets/javascripts/discourse/tests/unit/models/topic-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/topic-test.js
@@ -163,4 +163,18 @@ discourseModule("Unit | Model | topic", function () {
       "supports emojis"
     );
   });
+
+  test("visible & invisible", function (assert) {
+    const topic = Topic.create();
+    assert.equal(topic.visible, undefined);
+    assert.equal(topic.invisible, undefined);
+
+    const visibleTopic = Topic.create({ visible: true });
+    assert.equal(visibleTopic.visible, true);
+    assert.equal(visibleTopic.invisible, false);
+
+    const invisibleTopic = Topic.create({ visible: false });
+    assert.equal(invisibleTopic.visible, false);
+    assert.equal(invisibleTopic.invisible, true);
+  });
 });


### PR DESCRIPTION
If visible is undefined, then invisible should be too.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
