### PR TITLE
DEV: Remove tabindex property from selected name template

### DIFF
--- a/app/assets/javascripts/select-kit/addon/templates/components/selected-name.hbs
+++ b/app/assets/javascripts/select-kit/addon/templates/components/selected-name.hbs
@@ -1,5 +1,5 @@
 {{#if selectKit.options.showFullTitle}}
-  <div role="button" lang={{lang}} {{action "onSelectedNameClick"}} tabindex="0" title={{title}} data-value={{value}} data-name={{name}} class="select-kit-selected-name selected-name choice">
+  <div role="button" lang={{lang}} {{action "onSelectedNameClick"}} title={{title}} data-value={{value}} data-name={{name}} class="select-kit-selected-name selected-name choice">
     {{#if item.icon}}
       {{d-icon item.icon}}
     {{/if}}
@@ -24,7 +24,7 @@
   </div>
 {{else}}
   {{#if item.icon}}
-    <div role="textbox" lang={{lang}} tabindex="0" class="select-kit-selected-name selected-name choice">
+    <div role="textbox" lang={{lang}} class="select-kit-selected-name selected-name choice">
       {{d-icon item.icon}}
     </div>
   {{/if}}


### PR DESCRIPTION
The parent element already has a tabindex, adding one to the button/icon here means forcing `tab` to be pressed a few extra times while navigating. 