### PR TITLE
FIX: Approving a user was not sending an email

### DIFF
--- a/app/controllers/reviewables_controller.rb
+++ b/app/controllers/reviewables_controller.rb
@@ -189,7 +189,7 @@ class ReviewablesController < ApplicationController
         return render_json_error(error)
       end
 
-      args.merge!(reject_reason: params[:reject_reason], send_email: params[:send_email] == "true") if reviewable.type == 'ReviewableUser'
+      args.merge!(reject_reason: params[:reject_reason], send_email: params[:send_email] != "false") if reviewable.type == 'ReviewableUser'
 
       result = reviewable.perform(current_user, params[:action_id].to_sym, args)
     rescue Reviewable::InvalidAction => e


### PR DESCRIPTION
When we made rejection emails optional we accidentally changed the
default for approval emails from true to false.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
