### PR TITLE
fix topic entrance button layout

### DIFF
--- a/app/assets/stylesheets/common/topic-entrance.scss
+++ b/app/assets/stylesheets/common/topic-entrance.scss
@@ -12,10 +12,12 @@
   button.full {
     width: 100%;
     margin-bottom: 5px;
+    flex-wrap: wrap;
 
     .d-icon {
       display: block;
       margin: 2px auto;
+      width: 100%;
       transform: rotate(90deg);
     }
   }


### PR DESCRIPTION
follow up to f1d5d2b

Before:
<img width="201" alt="Screen Shot 2021-01-28 at 3 04 58 PM" src="https://user-images.githubusercontent.com/1681963/106192469-39e2c780-617a-11eb-8098-c3de463d688d.png">

After:
<img width="190" alt="Screen Shot 2021-01-28 at 3 03 05 PM" src="https://user-images.githubusercontent.com/1681963/106192481-3e0ee500-617a-11eb-83e6-a23a209a21a6.png">

