### PR TITLE
UX: fix bulk-select top positioning

### DIFF
--- a/app/assets/javascripts/discourse/app/components/bulk-select-button.js
+++ b/app/assets/javascripts/discourse/app/components/bulk-select-button.js
@@ -9,13 +9,11 @@ export default Component.extend({
     this._super(...arguments);
 
     schedule("afterRender", () => {
-      let mainOutletPadding =
-        window.getComputedStyle(document.querySelector("#main-outlet"))
-          .paddingTop || 0;
+      let headerHeight =
+        document.querySelector(".d-header-wrap").offsetHeight || 0;
 
-      document.querySelector(
-        ".bulk-select-container"
-      ).style.top = mainOutletPadding;
+      document.querySelector(".bulk-select-container").style.top =
+        headerHeight + 20 + "px";
     });
   },
 

--- a/app/assets/stylesheets/desktop/topic-list.scss
+++ b/app/assets/stylesheets/desktop/topic-list.scss
@@ -173,7 +173,6 @@
 #bulk-select {
   position: fixed;
   right: 20px;
-  top: 130px;
   background-color: var(--secondary);
   z-index: z("dropdown");
   @supports (position: sticky) {


### PR DESCRIPTION
Previously the bulk select top positioning was dictated by padding on `#main-outlet`... but when the header was converted to `position: sticky` that padding was set to 0, so the positioning needed to be updated to be based on the header height instead.  