### PR TITLE
FIX: Check if post.topic exists before publishing topic updates

### DIFF
--- a/app/jobs/regular/post_update_topic_tracking_state.rb
+++ b/app/jobs/regular/post_update_topic_tracking_state.rb
@@ -6,7 +6,7 @@ module Jobs
     def execute(args)
       post = Post.find_by(id: args[:post_id])
 
-      if post
+      if post && post.topic
         TopicTrackingState.publish_unmuted(post.topic)
         if post.post_number > 1
           TopicTrackingState.publish_muted(post.topic)

--- a/spec/jobs/post_update_topic_tracking_state_spec.rb
+++ b/spec/jobs/post_update_topic_tracking_state_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Jobs::PostUpdateTopicTrackingState do
+  fab!(:post) { Fabricate(:post) }
+
+  it 'should publish messages' do
+    messages = MessageBus.track_publish { subject.execute({ post_id: post.id }) }
+    expect(messages.size).not_to eq(0)
+  end
+
+  it 'should not publish messages for deleted topics' do
+    post.topic.trash!
+    messages = MessageBus.track_publish { subject.execute({ post_id: post.id }) }
+    expect(messages.size).to eq(0)
+  end
+end


### PR DESCRIPTION
Publishing topic tracking state and deleting the topic at the same time could raise.