### PR TITLE
remove hidden area in flagged removed post msg

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2842,11 +2842,9 @@ en:
 
         This post was flagged by the community and a staff member opted to remove it.
 
-        [details="Click to expand removed post"]
         ``` markdown
         %{flagged_post_raw_content}
         ```
-        [/details]
 
         Please review our [community guidelines](%{base_url}/guidelines) for details.
 


### PR DESCRIPTION
because users were having trouble figuring out how to expand the hidden post to determine "what post of mine was removed??", per customer reports
