### PR TITLE
UX: Allow some overflow in composer preview

### DIFF
--- a/app/assets/stylesheets/common/d-editor.scss
+++ b/app/assets/stylesheets/common/d-editor.scss
@@ -95,6 +95,9 @@
   overflow: auto;
   cursor: default;
   -webkit-overflow-scrolling: touch;
+  // the below gives text little space to overflow without being cropped (e.g., Õ in headings)
+  padding-top: 1em;
+  margin-top: -1em;
 }
 
 .d-editor-input,
@@ -167,12 +170,15 @@
   }
   .d-editor-preview-wrapper {
     max-width: 100%;
-    margin: 10px 0 0 0;
+    margin: 0;
+    padding: 0;
   }
   .d-editor-preview {
     background-color: var(--primary-very-low);
-    padding: 5px;
+    margin-top: 1em;
+    padding: 0.667em;
     &:empty {
+      margin: 0;
       padding: 0;
     }
   }

--- a/app/assets/stylesheets/desktop/compose.scss
+++ b/app/assets/stylesheets/desktop/compose.scss
@@ -27,20 +27,24 @@
 }
 
 .edit-title {
+  --overflow-buffer: 1em;
+  // this gives text little space to overflow without being cropped (e.g., Õ in headings)
+
   .d-editor-preview-wrapper {
-    margin-top: -43px;
+    margin-top: calc(-41px - var(--overflow-buffer));
+    padding-top: var(--overflow-buffer);
   }
   &:not(.private-message) {
     .d-editor-preview-wrapper {
       @media screen and (max-width: 955px) {
-        margin-top: -77px;
+        margin-top: calc(-75px - var(--overflow-buffer));
       }
     }
   }
 
   .with-tags {
     .d-editor-preview-wrapper {
-      margin-top: -77px;
+      margin-top: calc(-75px - var(--overflow-buffer));
     }
   }
 }


### PR DESCRIPTION
This adds a little padding (position change negated with negative margin) so that some characters like Õ can overflow the preview without cropping at the top. 

Before:
![Screen Shot 2021-01-29 at 6 56 26 PM](https://user-images.githubusercontent.com/1681963/106339267-08dec180-6264-11eb-8fb8-75a883fe5536.png)

After:
![Screen Shot 2021-01-29 at 6 56 15 PM](https://user-images.githubusercontent.com/1681963/106339266-07ad9480-6264-11eb-999e-aab738c49640.png)


Related discussion: https://meta.discourse.org/t/in-the-composer-preview-special-character-o-is-cut-at-the-top-inside-first-line-headings/175919
