### PR TITLE
Improve invite to forum modal description

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2596,7 +2596,7 @@ en:
         username_placeholder: "username"
         action: "Send Invite"
         help: "invite others to this topic via email or notifications"
-        to_forum: "We'll send a brief email allowing your friend to immediately join by clicking a link, no login required."
+        to_forum: "We'll send a brief email allowing your friend to immediately join by clicking a link."
         sso_enabled: "Enter the username of the person you'd like to invite to this topic."
         to_topic_blank: "Enter the username or email address of the person you'd like to invite to this topic."
         to_topic_email: "You've entered an email address. We'll email an invitation that allows your friend to immediately reply to this topic."


### PR DESCRIPTION
This PR is the result of a question on Meta: https://meta.discourse.org/t/invite-by-email-without-registering/177055.

The text displayed when inviting a user to a topic currently says "no login required." That is not technically correct - invited users are logged into the forum. The invite process just bypasses the email confirmation (and optionally password) steps.
