### PR TITLE
left align popup-menu button text

### DIFF
--- a/app/assets/stylesheets/common/base/popup-menu.scss
+++ b/app/assets/stylesheets/common/base/popup-menu.scss
@@ -20,6 +20,7 @@
 
   .btn {
     justify-content: left;
+    text-align: left;
     background: none;
     width: 100%;
     padding: 0.75em;
@@ -28,6 +29,7 @@
 
     .d-icon {
       color: var(--primary-medium);
+      align-self: flex-start;
     }
 
     &:hover {


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/1681963/106344152-0b96e200-6277-11eb-877c-6f9ef0c93df4.png)


After: 
![Screen Shot 2021-01-29 at 9 12 26 PM](https://user-images.githubusercontent.com/1681963/106344145-06399780-6277-11eb-9ea9-a1e2e9b6a3e0.png)
