### PR TITLE
FIX: Stop trying to set values on destroyed bookmark component

### DIFF
--- a/app/assets/javascripts/discourse/app/components/bookmark.js
+++ b/app/assets/javascripts/discourse/app/components/bookmark.js
@@ -203,18 +203,17 @@ export default Component.extend({
       return ajax(`/bookmarks/${this.model.id}`, {
         type: "PUT",
         data,
-      }).then(() => {
-        this._executeAfterSave(reminderAtISO);
+      }).then((response) => {
+        this._executeAfterSave(response, reminderAtISO);
       });
     } else {
       return ajax("/bookmarks", { type: "POST", data }).then((response) => {
-        this.set("model.id", response.id);
-        this._executeAfterSave(reminderAtISO);
+        this._executeAfterSave(response, reminderAtISO);
       });
     }
   },
 
-  _executeAfterSave(reminderAtISO) {
+  _executeAfterSave(response, reminderAtISO) {
     if (!this.afterSave) {
       return;
     }
@@ -222,7 +221,7 @@ export default Component.extend({
       reminderAt: reminderAtISO,
       reminderType: this.selectedReminderType,
       autoDeletePreference: this.autoDeletePreference,
-      id: this.model.id,
+      id: this.model.id || response.id,
       name: this.model.name,
     });
   },


### PR DESCRIPTION
* sometimes the AJAX promise to create/save the bookmark did
  not come back before the component destroyed, causing an error
  when trying to set the model id afterward. this just eliminates
  the set code and uses the response.id instead
