### PR TITLE
FIX: Return the CDN's URL when using the site's small logo as the system's user avatar.

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -873,7 +873,7 @@ class User < ActiveRecord::Base
       SiteSetting.logo_small && SiteSetting.use_site_small_logo_as_system_avatar
 
     if use_small_logo
-      UrlHelper.absolute(SiteSetting.logo_small.url)
+      Discourse.store.cdn_url(SiteSetting.logo_small.url)
     else
       self.class.avatar_template(username, uploaded_avatar_id)
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1339,7 +1339,7 @@ describe User do
 
   describe '#avatar_template' do
     it 'uses the small logo if the user is the system user' do
-      logo_small_url = UrlHelper.absolute(SiteSetting.logo_small.url)
+      logo_small_url = Discourse.store.cdn_url(SiteSetting.logo_small.url)
 
       expect(Discourse.system_user.avatar_template).to eq(logo_small_url)
     end


### PR DESCRIPTION
Using "UrlHelper#absolute" returns the S3 URL, which is fine for the client because it modifies it to use the CDN instead. On the other hand, this replacement doesn't happen when the URL is server-side rendered, returning a 403 for the system's avatar.
