### PR TITLE
DEV: Performance fixes to filtered replies

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/topic.js
+++ b/app/assets/javascripts/discourse/app/controllers/topic.js
@@ -67,6 +67,7 @@ export default Controller.extend(bufferedProperty("model"), {
   replies_to_post_number: null,
   filter: null,
   quoteState: null,
+  currentPostId: null,
 
   init() {
     this._super(...arguments);
@@ -360,6 +361,7 @@ export default Controller.extend(bufferedProperty("model"), {
         return;
       }
 
+      this.set("currentPostId", post.id);
       const postNumber = post.get("post_number");
       const topic = this.model;
       topic.set("currentPost", postNumber);
@@ -429,19 +431,28 @@ export default Controller.extend(bufferedProperty("model"), {
         });
     },
 
-    cancelFilter(previousFilters) {
-      this.get("model.postStream").cancelFilter();
-      this.get("model.postStream")
-        .refresh()
+    cancelFilter(nearestPost = null) {
+      const postStream = this.get("model.postStream");
+
+      if (!nearestPost) {
+        const loadedPost = postStream.findLoadedPost(this.currentPostId);
+        if (loadedPost) {
+          nearestPost = loadedPost.post_number;
+        } else {
+          postStream.findPostsByIds([this.currentPostId]).then((arr) => {
+            nearestPost = arr[0].post_number;
+          });
+        }
+      }
+
+      postStream.cancelFilter();
+      postStream
+        .refresh({
+          nearPost: nearestPost,
+          forceLoad: true,
+        })
         .then(() => {
-          if (previousFilters) {
-            if (previousFilters.replies_to_post_number) {
-              this._jumpToPostNumber(previousFilters.replies_to_post_number);
-            }
-            if (previousFilters.filter_upwards_post_id) {
-              this._jumpToPostId(previousFilters.filter_upwards_post_id);
-            }
-          }
+          DiscourseURL.routeTo(this.model.urlForPostNumber(nearestPost));
           this.updateQueryParams();
         });
     },

--- a/app/assets/javascripts/discourse/app/widgets/post-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-menu.js
@@ -241,7 +241,8 @@ registerButton("replies", (attrs, state, siteSettings) => {
     icon = state.repliesShown ? "chevron-up" : "chevron-down";
 
   if (siteSettings.enable_filtered_replies_view) {
-    action = "filterRepliesView";
+    action = "toggleFilteredRepliesView";
+    icon = state.filteredRepliesShown ? "chevron-up" : "chevron-down";
   }
 
   // Omit replies if the setting `suppress_reply_directly_below` is enabled
@@ -259,7 +260,9 @@ registerButton("replies", (attrs, state, siteSettings) => {
     className: "show-replies",
     titleOptions: { count: replyCount },
     title: siteSettings.enable_filtered_replies_view
-      ? "post.filtered_replies_hint"
+      ? state.filteredRepliesShown
+        ? "post.view_all_posts"
+        : "post.filtered_replies_hint"
       : "post.has_replies",
     labelOptions: { count: replyCount },
     label: attrs.mobileView ? "post.has_replies_count" : "post.has_replies",

--- a/app/assets/javascripts/discourse/app/widgets/post-stream.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-stream.js
@@ -174,7 +174,7 @@ createWidget("filter-show-all", {
   },
 
   click() {
-    this.sendWidgetAction("cancelFilter", this.attrs.streamFilters);
+    this.sendWidgetAction("cancelFilter");
     this.appEvents.trigger(
       "post-stream:filter-show-all",
       this.attrs.streamFilters

--- a/app/assets/javascripts/discourse/app/widgets/post.js
+++ b/app/assets/javascripts/discourse/app/widgets/post.js
@@ -403,7 +403,12 @@ createWidget("post-contents", {
       result.push(this.attach("expand-post-button", attrs));
     }
 
-    const extraState = { state: { repliesShown: !!state.repliesBelow.length } };
+    const extraState = {
+      state: {
+        repliesShown: !!state.repliesBelow.length,
+        filteredRepliesShown: state.filteredRepliesShown,
+      },
+    };
     result.push(this.attach("post-menu", attrs, extraState));
 
     const repliesBelow = state.repliesBelow;
@@ -434,15 +439,24 @@ createWidget("post-contents", {
     return lastWikiEdit ? lastWikiEdit : createdAt;
   },
 
-  filterRepliesView() {
+  toggleFilteredRepliesView() {
     const post = this.findAncestorModel();
     const controller = this.register.lookup("controller:topic");
-    post
-      .get("topic.postStream")
-      .filterReplies(post.post_number, post.id)
-      .then(() => {
-        controller.updateQueryParams();
-      });
+    if (post.get("topic.postStream.filterRepliesToPostNumber")) {
+      controller.send(
+        "cancelFilter",
+        post.get("topic.postStream.filterRepliesToPostNumber")
+      );
+      this.state.filteredRepliesShown = false;
+    } else {
+      this.state.filteredRepliesShown = true;
+      post
+        .get("topic.postStream")
+        .filterReplies(post.post_number, post.id)
+        .then(() => {
+          controller.updateQueryParams();
+        });
+    }
   },
 
   toggleRepliesBelow(goToPost = "false") {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2773,11 +2773,13 @@ en:
       filtered_replies_hint:
         one: "View this post and its reply"
         other: "View this post and its %{count} replies"
+
       filtered_replies_viewing:
         one: "Viewing %{count} reply to"
         other: "Viewing %{count} replies to"
 
       in_reply_to: "Load parent post"
+      view_all_posts: "View all posts"
 
       errors:
         create: "Sorry, there was an error creating your post. Please try again."


### PR DESCRIPTION
- Improves the performance of cancelling a post stream filter (i.e. clicking "Show All"), previously we were making two consecutive requests to the backend, now it's only one.
- The "n replies" button is now a toggle when using the `enable_filtered_replies_view` site setting
- When cancelling a filter, the position of the currently visible post in the stream is maintained

