### PR TITLE
FIX: Skip shared drafts logic if disabled

### DIFF
--- a/app/controllers/list_controller.rb
+++ b/app/controllers/list_controller.rb
@@ -58,7 +58,7 @@ class ListController < ApplicationController
 
       list = TopicQuery.new(user, list_opts).public_send("list_#{filter}")
 
-      if guardian.can_see_shared_draft? && @category.present?
+      if guardian.can_create_shared_draft? && @category.present?
         if @category.id == SiteSetting.shared_drafts_category.to_i
           # On shared drafts, show the destination category
           list.topics.each do |t|


### PR DESCRIPTION
It always showed shared drafts if no category was set.

Follow-up to dd175537f3fb5f4a62a5935f65443fc9bedb37e3.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
