### PR TITLE
FIX: Show bookmark name in quick access hover

### DIFF
--- a/app/assets/javascripts/discourse/app/components/bookmark.js
+++ b/app/assets/javascripts/discourse/app/components/bookmark.js
@@ -22,6 +22,7 @@ import discourseComputed, { on } from "discourse-common/utils/decorators";
 import { formattedReminderTime } from "discourse/lib/bookmark";
 import { and, notEmpty, or } from "@ember/object/computed";
 import { popupAjaxError } from "discourse/lib/ajax-error";
+import { later } from "@ember/runloop";
 
 // global shortcuts that interfere with these modal shortcuts, they are rebound when the
 // modal is closed
@@ -83,9 +84,11 @@ export default Component.extend({
 
   @on("didInsertElement")
   _prepareUI() {
-    if (this.site.isMobileDevice) {
-      document.getElementById("bookmark-name").blur();
-    }
+    later(() => {
+      if (this.site.isMobileDevice) {
+        document.getElementById("bookmark-name").blur();
+      }
+    });
 
     // we want to make sure the options panel opens so the user
     // knows they have set these options previously.
@@ -319,9 +322,11 @@ export default Component.extend({
   additionalTimeShortcutOptions() {
     let additional = [];
 
-    let later = laterToday(this.userTimezone);
     if (
-      !later.isSame(tomorrow(this.userTimezone), "date") &&
+      !laterToday(this.userTimezone).isSame(
+        tomorrow(this.userTimezone),
+        "date"
+      ) &&
       now(this.userTimezone).hour() < LATER_TODAY_CUTOFF_HOUR
     ) {
       additional.push(TIME_SHORTCUT_TYPES.LATER_TODAY);

--- a/app/assets/javascripts/discourse/app/widgets/quick-access-bookmarks.js
+++ b/app/assets/javascripts/discourse/app/widgets/quick-access-bookmarks.js
@@ -30,6 +30,7 @@ createWidgetFrom(QuickAccessPanel, "quick-access-bookmarks", {
         bookmark.topic_id,
         bookmark.post_number || bookmark.linked_post_number
       ),
+      title: bookmark.name,
       content: bookmark.title,
       username: bookmark.post_user_username,
     });

--- a/app/assets/javascripts/discourse/app/widgets/quick-access-item.js
+++ b/app/assets/javascripts/discourse/app/widgets/quick-access-item.js
@@ -33,7 +33,7 @@ export default createWidget("quick-access-item", {
     return result;
   },
 
-  html({ href, icon }) {
+  html({ href, title, icon }) {
     let content = this._contentHtml();
 
     if (href) {
@@ -44,7 +44,7 @@ export default createWidget("quick-access-item", {
       }
     }
 
-    return h("a", { attributes: this._linkAttributes(href) }, [
+    return h("a", { attributes: this._linkAttributes(href, title) }, [
       iconNode(icon),
       new RawHtml({
         html: `<div>${this._usernameHtml()}${content}</div>`,
@@ -60,8 +60,8 @@ export default createWidget("quick-access-item", {
     }
   },
 
-  _linkAttributes(href) {
-    return { href };
+  _linkAttributes(href, title) {
+    return { href, title };
   },
 
   _contentHtml() {


### PR DESCRIPTION
This PR makes it so the bookmark name shows on hover in the quick access menu:

![image](https://user-images.githubusercontent.com/920448/106552098-6162d700-6562-11eb-9b57-64b48b23e325.png)

A change was necessary to `quick-access-item` for the title to render for the link.