### PR TITLE
DEV: Update label and icon structure in bootbox buttons

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-user-index.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-user-index.js
@@ -315,9 +315,8 @@ export default Controller.extend(CanCheckEmails, {
           link: true,
         },
         {
-          label:
-            `${iconHTML("exclamation-triangle")} ` +
-            I18n.t("admin.user.delete_all_posts"),
+          icon: iconHTML("exclamation-triangle"),
+          label: I18n.t("admin.user.delete_all_posts"),
           class: "btn btn-danger",
           callback: () => {
             const progressModal = openProgressModal();
@@ -367,10 +366,9 @@ export default Controller.extend(CanCheckEmails, {
           link: true,
         },
         {
-          label:
-            `${iconHTML("exclamation-triangle")} ` +
-            I18n.t("admin.user.anonymize_yes"),
+          label: I18n.t("admin.user.anonymize_yes"),
           class: "btn btn-danger",
+          icon: iconHTML("exclamation-triangle"),
           callback: () => {
             performAnonymize();
           },
@@ -435,9 +433,8 @@ export default Controller.extend(CanCheckEmails, {
           link: true,
         },
         {
-          label:
-            `${iconHTML("exclamation-triangle")} ` +
-            I18n.t("admin.user.delete_and_block"),
+          icon: iconHTML("exclamation-triangle"),
+          label: I18n.t("admin.user.delete_and_block"),
           class: "btn btn-danger",
           callback: () => {
             performDestroy(true);

--- a/app/assets/javascripts/discourse/app/controllers/preferences/second-factor.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/second-factor.js
@@ -131,7 +131,8 @@ export default Controller.extend(CanCheckEmails, {
           link: true,
         },
         {
-          label: `${iconHTML("ban")}${I18n.t("user.second_factor.disable")}`,
+          icon: iconHTML("ban"),
+          label: I18n.t("user.second_factor.disable"),
           class: "btn-danger btn-icon-text",
           callback: () => {
             this.model

--- a/vendor/assets/javascripts/bootbox.js
+++ b/vendor/assets/javascripts/bootbox.js
@@ -340,7 +340,7 @@ var bootbox = window.bootbox || (function(document, $) {
             }
 
             if (handlers[i]['icon']) {
-                icon = "<i class='"+handlers[i]['icon']+"'></i> ";
+                icon = handlers[i]['icon'];
             }
 
             if (handlers[i]['href']) {
@@ -350,7 +350,7 @@ var bootbox = window.bootbox || (function(document, $) {
                 href = _defaultHref;
             }
 
-            buttons = buttons + "<a data-handler='"+i+"' class='"+_class+"' href='" + href + "'>"+icon+""+label+"</a>";
+            buttons = buttons + "<a data-handler='"+i+"' class='"+_class+"' href='" + href + "'>"+icon+"<span class='d-button-label'>"+label+"</span></a>";
 
             callbacks[i] = callback;
         }


### PR DESCRIPTION
These buttons weren't marked up consistently with our d-buttons (which have a `d-button-label` wrapper around the text) so in order to get that consistency I had to separate icons from the labels.