### PR TITLE
Update a couple buttons to use consistent markup

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/modals/admin-merge-users-confirmation.js
+++ b/app/assets/javascripts/admin/addon/controllers/modals/admin-merge-users-confirmation.js
@@ -22,6 +22,13 @@ export default Controller.extend(ModalFunctionality, {
     });
   },
 
+  @discourseComputed("username")
+  mergeButtonText(username) {
+    return I18n.t(`admin.user.merge.confirmation.transfer_and_delete`, {
+      username,
+    });
+  },
+
   @discourseComputed("value", "text")
   mergeDisabled(value, text) {
     return !value || text !== value;

--- a/app/assets/javascripts/admin/addon/controllers/modals/admin-merge-users-prompt.js
+++ b/app/assets/javascripts/admin/addon/controllers/modals/admin-merge-users-prompt.js
@@ -1,4 +1,5 @@
 import Controller, { inject as controller } from "@ember/controller";
+import I18n from "I18n";
 import ModalFunctionality from "discourse/mixins/modal-functionality";
 import { action, get } from "@ember/object";
 import { alias } from "@ember/object/computed";
@@ -15,6 +16,13 @@ export default Controller.extend(ModalFunctionality, {
   @discourseComputed("username", "targetUsername")
   mergeDisabled(username, targetUsername) {
     return !targetUsername || username === targetUsername;
+  },
+
+  @discourseComputed("username")
+  mergeButtonText(username) {
+    return I18n.t(`admin.user.merge.confirmation.transfer_and_delete`, {
+      username,
+    });
   },
 
   @action

--- a/app/assets/javascripts/admin/addon/templates/modal/admin-merge-users-confirmation.hbs
+++ b/app/assets/javascripts/admin/addon/templates/modal/admin-merge-users-confirmation.hbs
@@ -5,14 +5,13 @@
   {{/d-modal-body}}
 
   <div class="modal-footer">
-    {{#d-button
+    {{d-button
       class="btn-danger"
       action=(action "confirm")
       icon="trash-alt"
       disabled=mergeDisabled
+      translatedLabel=mergeButtonText
     }}
-      {{i18n "admin.user.merge.confirmation.transfer_and_delete" username=username}}
-    {{/d-button}}
     {{d-button
       action=(action "close")
       label="admin.user.merge.confirmation.cancel"

--- a/app/assets/javascripts/admin/addon/templates/modal/admin-merge-users-prompt.hbs
+++ b/app/assets/javascripts/admin/addon/templates/modal/admin-merge-users-prompt.hbs
@@ -13,14 +13,13 @@
   {{/d-modal-body}}
 
   <div class="modal-footer">
-    {{#d-button
+    {{d-button
       class="btn-primary"
       action=(action "showConfirmation")
       icon="trash-alt"
       disabled=mergeDisabled
+      translatedLabel=mergeButtonText
     }}
-      {{i18n "admin.user.merge.prompt.transfer_and_delete" username=username}}
-    {{/d-button}}
     {{d-button
       action=(action "close")
       label="admin.user.merge.prompt.cancel"


### PR DESCRIPTION
Moved the translation + username to the controller so these buttons would get the correct markup (with the old way they weren't getting `d-button-label` and `btn-icon-text`)