### PR TITLE
DEV: Remove deprecated bootsnap options

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -23,8 +23,6 @@ if (ENV['DISABLE_BOOTSNAP'] != '1')
     Bootsnap.setup(
       cache_dir: 'tmp/cache',     # Path to your cache
       load_path_cache: true,      # Should we optimize the LOAD_PATH with a cache?
-      autoload_paths_cache: true, # Should we optimize ActiveSupport autoloads with cache?
-      disable_trace: false,       # Sets `RubyVM::InstructionSequence.compile_option = { trace_instruction: false }`
       compile_cache_iseq: true,   # Should compile Ruby code into ISeq cache?
       compile_cache_yaml: false   # Skip YAML cache for now, cause we were seeing issues with it
     )


### PR DESCRIPTION
Bootsnap started printing these warnings:

```
[DEPRECATED] Bootsnap's `autoload_paths_cache:` option is deprecated and will be removed. If you use Zeitwerk this option is useless, and if you are still using the classic autoloader upgrading is recommended.
[DEPRECATED] Bootsnap's `disable_trace:` option is deprecated and will be removed. If you use Ruby 2.5 or newer this option is useless, if not upgrading is recommended.
```