### PR TITLE
FIX: ensures rects is present before using it

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/select-kit.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit.js
@@ -883,16 +883,20 @@ export default Component.extend(
                   wrapper.style.height = `${height}px`;
                   if (placementStrategy === "fixed") {
                     const rects = this.element.getClientRects()[0];
-                    const bodyRects = body && body.getClientRects()[0];
-                    wrapper.style.position = "fixed";
-                    wrapper.style.left = `${rects.left}px`;
-                    if (topPlacement && bodyRects) {
-                      wrapper.style.top = `${rects.top - bodyRects.height}px`;
-                    } else {
-                      wrapper.style.top = `${rects.top}px`;
-                    }
-                    if (isDocumentRTL()) {
-                      wrapper.style.right = "unset";
+
+                    if (rects) {
+                      const bodyRects = body && body.getClientRects()[0];
+
+                      wrapper.style.position = "fixed";
+                      wrapper.style.left = `${rects.left}px`;
+                      if (topPlacement && bodyRects) {
+                        wrapper.style.top = `${rects.top - bodyRects.height}px`;
+                      } else {
+                        wrapper.style.top = `${rects.top}px`;
+                      }
+                      if (isDocumentRTL()) {
+                        wrapper.style.right = "unset";
+                      }
                     }
                   }
                 }


### PR DESCRIPTION
I don't have a clear reproduction ATM, but I imagine that in fast tests element can get destroyed before we get to use it.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
