### PR TITLE
FIX: Fix subcategory, tag drops and none values

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/url.js
+++ b/app/assets/javascripts/discourse/app/lib/url.js
@@ -494,4 +494,23 @@ export function prefixProtocol(url) {
     : url;
 }
 
+export function getCategoryAndTagUrl(category, subcategories, tag) {
+  let url;
+
+  if (category) {
+    url = category.url;
+    if (!subcategories) {
+      url += "/none";
+    }
+  }
+
+  if (tag) {
+    url = url
+      ? "/tags" + url + "/" + tag.toLowerCase()
+      : "/tag/" + tag.toLowerCase();
+  }
+
+  return url || "/";
+}
+
 export default _urlInstance;

--- a/app/assets/javascripts/discourse/app/templates/components/bread-crumbs.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/bread-crumbs.hbs
@@ -18,7 +18,7 @@
   {{#unless additionalTags}}
     {{!-- the tag filter doesn't work with tag intersections, so hide it --}}
     {{#if siteSettings.show_filter_by_tag}}
-      {{tag-drop firstCategory=category tagId=tag.id}}
+      {{tag-drop firstCategory=category noSubcategories=noSubcategories tagId=tag.id}}
     {{/if}}
   {{/unless}}
 {{/if}}

--- a/app/assets/javascripts/discourse/app/templates/components/bread-crumbs.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/bread-crumbs.hbs
@@ -18,7 +18,7 @@
   {{#unless additionalTags}}
     {{!-- the tag filter doesn't work with tag intersections, so hide it --}}
     {{#if siteSettings.show_filter_by_tag}}
-      {{tag-drop firstCategory=category noSubcategories=noSubcategories tagId=tag.id}}
+      {{tag-drop currentCategory=category noSubcategories=noSubcategories tagId=tag.id}}
     {{/if}}
   {{/unless}}
 {{/if}}

--- a/app/assets/javascripts/select-kit/addon/components/category-drop.js
+++ b/app/assets/javascripts/select-kit/addon/components/category-drop.js
@@ -159,27 +159,27 @@ export default ComboBoxComponent.extend({
 
   actions: {
     onChange(categoryId) {
-      let categoryURL;
+      const category =
+        categoryId === ALL_CATEGORIES_ID || categoryId === NO_CATEGORIES_ID
+          ? this.selectKit.options.parentCategory
+          : Category.findById(parseInt(categoryId, 10));
 
-      if (this.tagId && !this.category) {
-        const category = Category.findById(parseInt(categoryId, 10));
-        categoryURL = getURL(
-          `/tags/c/${Category.slugFor(category)}/${
-            category.id
-          }/${this.tagId.toLowerCase()}`
-        );
-      } else if (categoryId === ALL_CATEGORIES_ID) {
-        categoryURL = this.allCategoriesUrl;
-      } else if (categoryId === NO_CATEGORIES_ID) {
-        categoryURL = this.noCategoriesUrl;
-      } else {
-        const category = Category.findById(parseInt(categoryId, 10));
-        categoryURL = category.url;
+      let url;
+
+      if (category) {
+        url = category.url;
+        if (categoryId === NO_CATEGORIES_ID) {
+          url += "/none";
+        }
       }
 
-      DiscourseURL.routeToUrl(categoryURL);
+      if (this.tagId) {
+        url = url
+          ? "/tags" + url + "/" + this.tagId.toLowerCase()
+          : "/tag/" + this.tagId.toLowerCase();
+      }
 
-      return false;
+      DiscourseURL.routeToUrl(url || "/");
     },
   },
 

--- a/app/assets/javascripts/select-kit/addon/components/category-drop.js
+++ b/app/assets/javascripts/select-kit/addon/components/category-drop.js
@@ -1,10 +1,9 @@
 import Category from "discourse/models/category";
 import ComboBoxComponent from "select-kit/components/combo-box";
-import DiscourseURL from "discourse/lib/url";
+import DiscourseURL, { getCategoryAndTagUrl } from "discourse/lib/url";
 import I18n from "I18n";
 import { categoryBadgeHTML } from "discourse/helpers/category-link";
 import { computed } from "@ember/object";
-import getURL from "discourse-common/lib/get-url";
 import { readOnly } from "@ember/object/computed";
 
 export const NO_CATEGORIES_ID = "no-categories";
@@ -107,8 +106,6 @@ export default ComboBoxComponent.extend({
 
   parentCategoryName: readOnly("selectKit.options.parentCategory.name"),
 
-  parentCategoryUrl: readOnly("selectKit.options.parentCategory.url"),
-
   allCategoriesLabel: computed(
     "parentCategoryName",
     "selectKit.options.subCategory",
@@ -122,22 +119,6 @@ export default ComboBoxComponent.extend({
       return I18n.t("categories.all");
     }
   ),
-
-  allCategoriesUrl: computed(
-    "parentCategoryUrl",
-    "selectKit.options.subCategory",
-    function () {
-      return getURL(
-        this.selectKit.options.subCategory
-          ? `${this.parentCategoryUrl}/all` || "/"
-          : "/"
-      );
-    }
-  ),
-
-  noCategoriesUrl: computed("parentCategoryUrl", function () {
-    return getURL(`${this.parentCategoryUrl}/none`);
-  }),
 
   search(filter) {
     if (filter) {
@@ -164,22 +145,13 @@ export default ComboBoxComponent.extend({
           ? this.selectKit.options.parentCategory
           : Category.findById(parseInt(categoryId, 10));
 
-      let url;
-
-      if (category) {
-        url = category.url;
-        if (categoryId === NO_CATEGORIES_ID) {
-          url += "/none";
-        }
-      }
-
-      if (this.tagId) {
-        url = url
-          ? "/tags" + url + "/" + this.tagId.toLowerCase()
-          : "/tag/" + this.tagId.toLowerCase();
-      }
-
-      DiscourseURL.routeToUrl(url || "/");
+      DiscourseURL.routeToUrl(
+        getCategoryAndTagUrl(
+          category,
+          categoryId !== NO_CATEGORIES_ID,
+          this.tagId
+        )
+      );
     },
   },
 

--- a/app/assets/javascripts/select-kit/addon/components/tag-drop.js
+++ b/app/assets/javascripts/select-kit/addon/components/tag-drop.js
@@ -171,32 +171,30 @@ export default ComboBoxComponent.extend(TagsMixin, {
 
   actions: {
     onChange(tagId, tag) {
-      let url;
-
-      switch (tagId) {
-        case ALL_TAGS_ID:
-          url = this.allTagsUrl;
-          break;
-        case NO_TAG_ID:
-          url = this.noTagsUrl;
-          break;
-        default:
-          if (this.currentCategory) {
-            url = `/tags/c/${Category.slugFor(this.currentCategory)}/${
-              this.currentCategory.id
-            }`;
-          } else {
-            url = "/tag";
-          }
-
-          if (tag && tag.targetTagId) {
-            url += `/${tag.targetTagId.toLowerCase()}`;
-          } else {
-            url += `/${tagId.toLowerCase()}`;
-          }
+      const category = this.currentCategory;
+      if (tag && tag.targetTagId) {
+        tagId = tag.targetTagId;
+      }
+      if (tagId === NO_TAG_ID) {
+        tagId = NONE_TAG_ID;
       }
 
-      DiscourseURL.routeTo(getURL(url));
+      let url;
+
+      if (category) {
+        url = category.url;
+        if (this.noSubcategories) {
+          url += "/none";
+        }
+      }
+
+      if (tagId !== ALL_TAGS_ID) {
+        url = url
+          ? "/tags" + url + "/" + tagId.toLowerCase()
+          : "/tag/" + tagId.toLowerCase();
+      }
+
+      DiscourseURL.routeToUrl(url || "/");
     },
   },
 });

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -452,7 +452,7 @@ class TagsController < ::ApplicationController
       search: params[:search],
       q: params[:q]
     )
-    options[:no_subcategories] = true if params[:no_subcategories] == 'true'
+    options[:no_subcategories] = true if params[:no_subcategories] == true || params[:no_subcategories] == 'true'
     options[:per_page] = params[:per_page].to_i.clamp(1, 30) if params[:per_page].present?
 
     if params[:tag_id] == 'none'


### PR DESCRIPTION
Subcategory and tag drops could not simultaneously be none because of
client and server sided problems.

On the client side, tag drop did not allow for a 'none' category.

On the server side, the 'category none' + tag route did not set
'no_subcategories'.