### PR TITLE
FIX: Refresh category order after save

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/reorder-categories.js
+++ b/app/assets/javascripts/discourse/app/controllers/reorder-categories.js
@@ -135,7 +135,7 @@ export default Controller.extend(ModalFunctionality, Evented, {
         type: "POST",
         data: { mapping: JSON.stringify(data) },
       })
-        .then(() => this.send("closeModal"))
+        .then(() => window.location.reload())
         .catch(popupAjaxError);
     },
   },


### PR DESCRIPTION
The changes were not visible immediately after saving reordered
categories.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
