### PR TITLE
DEV: Move logic for rate limiting user second factor to one place

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -542,6 +542,16 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def rate_limit_second_factor!(user)
+    return if params[:second_factor_token].blank?
+
+    RateLimiter.new(nil, "second-factor-min-#{request.remote_ip}", 3, 1.minute).performed!
+
+    if user
+      RateLimiter.new(nil, "second-factor-min-#{user.username}", 3, 1.minute).performed!
+    end
+  end
+
   private
 
   def locale_from_header

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -545,10 +545,10 @@ class ApplicationController < ActionController::Base
   def rate_limit_second_factor!(user)
     return if params[:second_factor_token].blank?
 
-    RateLimiter.new(nil, "second-factor-min-#{request.remote_ip}", 3, 1.minute).performed!
+    RateLimiter.new(nil, "second-factor-min-#{request.remote_ip}", 6, 1.minute).performed!
 
     if user
-      RateLimiter.new(nil, "second-factor-min-#{user.username}", 3, 1.minute).performed!
+      RateLimiter.new(nil, "second-factor-min-#{user.username}", 6, 1.minute).performed!
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -729,9 +729,7 @@ class UsersController < ApplicationController
     token = params[:token]
     password_reset_find_user(token, committing_change: true)
 
-    if params[:second_factor_token].present?
-      RateLimiter.new(nil, "second-factor-min-#{request.remote_ip}", 3, 1.minute).performed!
-    end
+    rate_limit_second_factor!(@user)
 
     # no point doing anything else if we can't even find
     # a user from the token

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1389,9 +1389,7 @@ class UsersController < ApplicationController
     totp_data = secure_session["staged-totp-#{current_user.id}"]
     totp_object = current_user.get_totp_object(totp_data)
 
-    [request.remote_ip, current_user.id].each do |key|
-      RateLimiter.new(nil, "second-factor-min-#{key}", 3, 1.minute).performed!
-    end
+    rate_limit_second_factor!(current_user)
 
     authenticated = !auth_token.blank? && totp_object.verify(
       auth_token,

--- a/app/controllers/users_email_controller.rb
+++ b/app/controllers/users_email_controller.rb
@@ -77,7 +77,7 @@ class UsersEmailController < ApplicationController
 
     redirect_url = path("/u/confirm-new-email/#{params[:token]}")
 
-    RateLimiter.new(nil, "second-factor-min-#{request.remote_ip}", 3, 1.minute).performed! if params[:second_factor_token].present?
+    rate_limit_second_factor!(@user)
 
     if !@error
       # this is needed becase the form posts this field as JSON and it can be a

--- a/spec/requests/session_controller_spec.rb
+++ b/spec/requests/session_controller_spec.rb
@@ -1735,7 +1735,7 @@ RSpec.describe SessionController do
         RateLimiter.enable
         RateLimiter.clear_all!
 
-        3.times do |x|
+        6.times do |x|
           post "/session.json", params: {
             login: "#{user.username}#{x}",
             password: 'myawesomepassword',
@@ -1761,7 +1761,7 @@ RSpec.describe SessionController do
         RateLimiter.enable
         RateLimiter.clear_all!
 
-        3.times do |x|
+        6.times do |x|
           post "/session.json", params: {
             login: user.username,
             password: 'myawesomepassword',

--- a/spec/requests/session_controller_spec.rb
+++ b/spec/requests/session_controller_spec.rb
@@ -1739,7 +1739,8 @@ RSpec.describe SessionController do
           post "/session.json", params: {
             login: "#{user.username}#{x}",
             password: 'myawesomepassword',
-            second_factor_token: '000000'
+            second_factor_token: '000000',
+            second_factor_method: UserSecondFactor.methods[:totp]
           }
           expect(response.status).to eq(200)
         end
@@ -1747,7 +1748,8 @@ RSpec.describe SessionController do
         post "/session.json", params: {
           login: user.username,
           password: 'myawesomepassword',
-          second_factor_token: '000000'
+          second_factor_token: '000000',
+          second_factor_method: UserSecondFactor.methods[:totp]
         }
 
         expect(response.status).to eq(429)
@@ -1763,7 +1765,8 @@ RSpec.describe SessionController do
           post "/session.json", params: {
             login: user.username,
             password: 'myawesomepassword',
-            second_factor_token: '000000'
+            second_factor_token: '000000',
+            second_factor_method: UserSecondFactor.methods[:totp]
           }, env: { "REMOTE_ADDR": "1.2.3.#{x}" }
 
           expect(response.status).to eq(200)
@@ -1773,7 +1776,8 @@ RSpec.describe SessionController do
           post "/session.json", params: {
             login: username,
             password: 'myawesomepassword',
-            second_factor_token: '000000'
+            second_factor_token: '000000',
+            second_factor_method: UserSecondFactor.methods[:totp]
           }, env: { "REMOTE_ADDR": "1.2.4.#{x}" }
 
           expect(response.status).to eq(429)

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -331,7 +331,7 @@ describe UsersController do
 
           token = user.email_tokens.create!(email: user.email).token
 
-          3.times do
+          6.times do
             put "/u/password-reset/#{token}", params: {
               second_factor_token: 123456,
               second_factor_method: 1
@@ -353,7 +353,7 @@ describe UsersController do
 
           token = user.email_tokens.create!(email: user.email).token
 
-          3.times do |x|
+          6.times do |x|
             put "/u/password-reset/#{token}", params: {
               second_factor_token: 123456,
               second_factor_method: 1
@@ -4025,7 +4025,7 @@ describe UsersController do
       staged_totp_key = read_secure_session["staged-totp-#{user.id}"]
       token = ROTP::TOTP.new(staged_totp_key).now
 
-      4.times do |x|
+      7.times do |x|
         post "/users/enable_second_factor_totp.json", params: { name: "test", second_factor_token: token  }
       end
 
@@ -4040,7 +4040,7 @@ describe UsersController do
       staged_totp_key = read_secure_session["staged-totp-#{user.id}"]
       token = ROTP::TOTP.new(staged_totp_key).now
 
-      4.times do |x|
+      7.times do |x|
         post "/users/enable_second_factor_totp.json", params: { name: "test", second_factor_token: token  }, env: { "REMOTE_ADDR": "1.2.3.#{x}"  }
       end
 

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -323,7 +323,6 @@ describe UsersController do
       end
 
       context "rate limiting" do
-
         before { RateLimiter.clear_all!; RateLimiter.enable }
         after  { RateLimiter.disable }
 
@@ -349,6 +348,27 @@ describe UsersController do
           expect(response.status).to eq(429)
         end
 
+        it "rate limits reset passwords by username" do
+          freeze_time
+
+          token = user.email_tokens.create!(email: user.email).token
+
+          3.times do |x|
+            put "/u/password-reset/#{token}", params: {
+              second_factor_token: 123456,
+              second_factor_method: 1
+            }, env: { "REMOTE_ADDR": "1.2.3.#{x}" }
+
+            expect(response.status).to eq(200)
+          end
+
+          put "/u/password-reset/#{token}", params: {
+            second_factor_token: 123456,
+            second_factor_method: 1
+          }, env: { "REMOTE_ADDR": "1.2.3.4" }
+
+          expect(response.status).to eq(429)
+        end
       end
 
       context '2 factor authentication required' do
@@ -3995,6 +4015,36 @@ describe UsersController do
 
       expect(response.status).to eq(200)
       expect(user.user_second_factors.count).to eq(1)
+    end
+
+    it "rate limits by IP address" do
+      RateLimiter.enable
+      RateLimiter.clear_all!
+
+      create_totp
+      staged_totp_key = read_secure_session["staged-totp-#{user.id}"]
+      token = ROTP::TOTP.new(staged_totp_key).now
+
+      4.times do |x|
+        post "/users/enable_second_factor_totp.json", params: { name: "test", second_factor_token: token  }
+      end
+
+      expect(response.status).to eq(429)
+    end
+
+    it "rate limits by username" do
+      RateLimiter.enable
+      RateLimiter.clear_all!
+
+      create_totp
+      staged_totp_key = read_secure_session["staged-totp-#{user.id}"]
+      token = ROTP::TOTP.new(staged_totp_key).now
+
+      4.times do |x|
+        post "/users/enable_second_factor_totp.json", params: { name: "test", second_factor_token: token  }, env: { "REMOTE_ADDR": "1.2.3.#{x}"  }
+      end
+
+      expect(response.status).to eq(429)
     end
 
     context "when an incorrect token is provided" do

--- a/spec/requests/users_email_controller_spec.rb
+++ b/spec/requests/users_email_controller_spec.rb
@@ -162,7 +162,7 @@ describe UsersEmailController do
             freeze_time
 
             3.times do |x|
-              user.email_change_requests.last.update(change_state: 1)
+              user.email_change_requests.last.update(change_state: EmailChangeRequest.states[:complete])
               put "/u/confirm-new-email", params: {
                 token: user.email_tokens.last.token,
                 second_factor_token: "000000",
@@ -172,7 +172,7 @@ describe UsersEmailController do
               expect(response.status).to eq(302)
             end
 
-              user.email_change_requests.last.update(change_state: 2)
+            user.email_change_requests.last.update(change_state: EmailChangeRequest.states[:authorizing_new])
             put "/u/confirm-new-email", params: {
               token: user.email_tokens.last.token,
               second_factor_token: "000000",

--- a/spec/requests/users_email_controller_spec.rb
+++ b/spec/requests/users_email_controller_spec.rb
@@ -139,7 +139,7 @@ describe UsersEmailController do
           it "rate limits by IP" do
             freeze_time
 
-            3.times do
+            6.times do
               put "/u/confirm-new-email", params: {
                 token: "blah",
                 second_factor_token: "000000",
@@ -161,7 +161,7 @@ describe UsersEmailController do
           it "rate limits by username" do
             freeze_time
 
-            3.times do |x|
+            6.times do |x|
               user.email_change_requests.last.update(change_state: EmailChangeRequest.states[:complete])
               put "/u/confirm-new-email", params: {
                 token: user.email_tokens.last.token,


### PR DESCRIPTION
This moves all the rate limiting for user second factor (based on `params[:second_factor_token]` existing) to the one place, which rate limits by IP and also by username if a user is found.