### PR TITLE
DEV: apply cdn headers to public javascripts endpoint too.

### DIFF
--- a/config/initializers/008-rack-cors.rb
+++ b/config/initializers/008-rack-cors.rb
@@ -32,8 +32,9 @@ class Discourse::Cors
 
   def self.apply_headers(cors_origins, env, headers)
     request_method = env['REQUEST_METHOD']
+    cdn_endpoints = ["/assets", "/javascripts"]
 
-    if env['SCRIPT_NAME'] == "/assets" && Discourse.is_cdn_request?(env, request_method)
+    if cdn_endpoints.include?(env['SCRIPT_NAME']) && Discourse.is_cdn_request?(env, request_method)
       Discourse.apply_cdn_headers(headers)
     elsif cors_origins
       origin = nil


### PR DESCRIPTION
It will add CORS header `Access-Control-Allow-Origin: '*'` to the files inside `public/javascripts` folder.