### PR TITLE
FEATURE: check `blocked_onebox_domains` setting for inline oneboxes

### DIFF
--- a/lib/inline_oneboxer.rb
+++ b/lib/inline_oneboxer.rb
@@ -50,9 +50,10 @@ class InlineOneboxer
     end
 
     always_allow = SiteSetting.enable_inline_onebox_on_all_domains
-    domains = SiteSetting.allowed_inline_onebox_domains&.split('|') unless always_allow
+    allowed_domains = SiteSetting.allowed_inline_onebox_domains&.split('|') unless always_allow
+    blocked_domains = SiteSetting.blocked_onebox_domains&.split('|')
 
-    if always_allow || domains
+    if always_allow || allowed_domains
       uri = begin
         URI(url)
       rescue URI::Error
@@ -60,7 +61,8 @@ class InlineOneboxer
 
       if uri.present? &&
         uri.hostname.present? &&
-        (always_allow || domains.include?(uri.hostname))
+        (always_allow || allowed_domains.include?(uri.hostname)) &&
+        !blocked_domains.include?(uri.hostname)
         title = RetrieveTitle.crawl(url)
         title = nil if title && title.length < MIN_TITLE_LENGTH
         return onebox_for(url, title, opts)

--- a/spec/components/inline_oneboxer_spec.rb
+++ b/spec/components/inline_oneboxer_spec.rb
@@ -153,6 +153,12 @@ describe InlineOneboxer do
       expect(onebox).to be_blank
     end
 
+    it "will not crawl domains that are blocked" do
+      SiteSetting.blocked_onebox_domains = "eviltrout.com"
+      onebox = InlineOneboxer.lookup("https://eviltrout.com", skip_cache: true)
+      expect(onebox).to be_blank
+    end
+
     it "will crawl anything if allowed to" do
       SiteSetting.enable_inline_onebox_on_all_domains = true
 


### PR DESCRIPTION
If a domain is present in `blocked_onebox_domains` then the inline oneboxing for that domain should be disabled.