### PR TITLE
FIX: Restore support for pasting multiple PM recipients

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/email-group-user-chooser-filter.js
+++ b/app/assets/javascripts/select-kit/addon/components/email-group-user-chooser-filter.js
@@ -1,0 +1,35 @@
+import MultiSelectFilterComponent from "select-kit/components/multi-select/multi-select-filter";
+
+export default MultiSelectFilterComponent.extend({
+  classNames: ["email-group-user-chooser-filter"],
+
+  actions: {
+    onPaste(event) {
+      const data = event.originalEvent.clipboardData;
+
+      if (!data) {
+        return;
+      }
+
+      const recipients = [];
+      data
+        .getData("text")
+        .split(/[, \n]+/)
+        .forEach((recipient) => {
+          recipient = recipient.replace(/^@+/, "").trim();
+          if (recipient.length > 0) {
+            recipients.push(recipient);
+          }
+        });
+
+      if (recipients.length > 0) {
+        event.stopPropagation();
+        event.preventDefault();
+
+        this.selectKit.append(recipients);
+
+        return false;
+      }
+    },
+  },
+});

--- a/app/assets/javascripts/select-kit/addon/components/email-group-user-chooser.js
+++ b/app/assets/javascripts/select-kit/addon/components/email-group-user-chooser.js
@@ -12,6 +12,7 @@ export default UserChooserComponent.extend({
 
   selectKitOptions: {
     headerComponent: "email-group-user-chooser-header",
+    filterComponent: "email-group-user-chooser-filter",
     autoWrap: false,
   },
 


### PR DESCRIPTION
This is a regression from https://github.com/discourse/discourse/commit/98201ecc24d5e5c262f1292f416dc6dd11f82d3e.

Meta topic: https://meta.discourse.org/t/-/178167?u=osama.