### PR TITLE
FIX: Update topic_count when updating visibility

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -132,7 +132,7 @@ class Topic < ActiveRecord::Base
 
   def trash!(trashed_by = nil)
     if deleted_at.nil?
-      update_category_topic_count_by(-1)
+      update_category_topic_count_by(-1) if visible?
       CategoryTagStat.topic_deleted(self) if self.tags.present?
       DiscourseEvent.trigger(:topic_trashed, self)
     end
@@ -142,7 +142,7 @@ class Topic < ActiveRecord::Base
 
   def recover!(recovered_by = nil)
     unless deleted_at.nil?
-      update_category_topic_count_by(1)
+      update_category_topic_count_by(1) if visible?
       CategoryTagStat.topic_recovered(self) if self.tags.present?
       DiscourseEvent.trigger(:topic_recovered, self)
     end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1648,8 +1648,9 @@ class Topic < ActiveRecord::Base
   def update_category_topic_count_by(num)
     if category_id.present?
       Category
-        .where(['id = ?', category_id])
-        .update_all("topic_count = topic_count " + (num > 0 ? '+' : '') + "#{num}")
+        .where('id = ?', category_id)
+        .where('topic_id != ?', self.id)
+        .update_all("topic_count = topic_count + #{num.to_i}")
     end
   end
 

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1649,7 +1649,7 @@ class Topic < ActiveRecord::Base
     if category_id.present?
       Category
         .where('id = ?', category_id)
-        .where('topic_id != ?', self.id)
+        .where('topic_id != ? OR topic_id IS NULL', self.id)
         .update_all("topic_count = topic_count + #{num.to_i}")
     end
   end

--- a/app/services/topic_status_updater.rb
+++ b/app/services/topic_status_updater.rb
@@ -46,6 +46,14 @@ TopicStatusUpdater = Struct.new(:topic, :user) do
       UserProfile.remove_featured_topic_from_all_profiles(topic)
     end
 
+    if status.visible?
+      if status.enabled?
+        topic.update_category_topic_count_by(1)
+      else
+        topic.update_category_topic_count_by(-1)
+      end
+    end
+
     if @topic_timer
       if status.manually_closing_topic? || status.closing_topic?
         topic.delete_topic_timer(TopicTimer.types[:close])

--- a/app/services/topic_status_updater.rb
+++ b/app/services/topic_status_updater.rb
@@ -47,11 +47,7 @@ TopicStatusUpdater = Struct.new(:topic, :user) do
     end
 
     if status.visible?
-      if status.enabled?
-        topic.update_category_topic_count_by(1)
-      else
-        topic.update_category_topic_count_by(-1)
-      end
+      topic.update_category_topic_count_by(status.enabled? ? 1 : -1)
     end
 
     if @topic_timer


### PR DESCRIPTION
Updating a topic's visibility did not increase or decrease the
topic_count of a category, but Category.update_stats does ignore
unlisted topics which resulted in inconsistencies when deleting
such topics.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
