### PR TITLE
DEV: Remove bulk group admin endpoints

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3752,10 +3752,6 @@ en:
             available: "Group name is available"
             not_available: "Group name is not available"
             blank: "Group name cannot be blank"
-        bulk_add:
-          title: "Bulk Add to Group"
-          complete_users_not_added: "These users were not added (make sure they have an account):"
-          paste: "Paste a list of usernames or emails, one per line:"
         add_members:
           as_owner: "Set user(s) as owner(s) of this group"
         manage:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -100,9 +100,6 @@ Discourse::Application.routes.draw do
       end
       resources :groups, except: [:create], constraints: AdminConstraint.new do
         collection do
-          get 'bulk'
-          get 'bulk-complete' => 'groups#bulk'
-          put 'bulk' => 'groups#bulk_perform'
           put "automatic_membership_count" => "groups#automatic_membership_count"
         end
       end

--- a/spec/requests/admin/groups_controller_spec.rb
+++ b/spec/requests/admin/groups_controller_spec.rb
@@ -237,44 +237,6 @@ RSpec.describe Admin::GroupsController do
     end
   end
 
-  describe "#bulk_perform" do
-    fab!(:group) do
-      Fabricate(:group,
-        name: "test",
-        primary_group: true,
-        title: 'WAT',
-        grant_trust_level: 3
-      )
-    end
-
-    fab!(:user) { Fabricate(:user, trust_level: 2) }
-    fab!(:user2) { Fabricate(:user, trust_level: 4) }
-
-    it "can assign users to a group by email or username" do
-      Jobs.run_immediately!
-
-      put "/admin/groups/bulk.json", params: {
-        group_id: group.id, users: [user.username.upcase, user2.email, 'doesnt_exist']
-      }
-
-      expect(response.status).to eq(200)
-
-      user.reload
-      expect(user.primary_group).to eq(group)
-      expect(user.title).to eq("WAT")
-      expect(user.trust_level).to eq(3)
-
-      user2.reload
-      expect(user2.primary_group).to eq(group)
-      expect(user2.title).to eq("WAT")
-      expect(user2.trust_level).to eq(4)
-
-      json = response.parsed_body
-      expect(json['message']).to eq("2 users have been added to the group.")
-      expect(json['users_not_added'][0]).to eq("doesnt_exist")
-    end
-  end
-
   context "#destroy" do
     it 'should return the right response for an invalid group_id' do
       max_id = Group.maximum(:id).to_i


### PR DESCRIPTION
Originally added in 47e25648dfa200ac266a6311ba585827638d2bcc. Looks like all related code was removed in c82b2dcc24c06634e64a6c388c18a815f039c608 and b76731d722c099f64446f18fbf92026be7cfd225.

If anyone knows if this endpoint is used anywhere else, speak now or forever hold your peace. 😜 