### PR TITLE
FIX: Don't create email invites when SSO is on or local logins are off

### DIFF
--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -395,7 +395,9 @@ class Guardian
   end
 
   def can_bulk_invite_to_forum?(user)
-    user.admin?
+    user.admin? &&
+    !SiteSetting.enable_sso &&
+    SiteSetting.enable_local_logins
   end
 
   def can_send_invite_links?(user)

--- a/spec/models/invite_spec.rb
+++ b/spec/models/invite_spec.rb
@@ -50,6 +50,17 @@ describe Invite do
     end
   end
 
+  context "SSO validation" do
+    it "prevents creating an email invite when SSO is enabled" do
+      SiteSetting.sso_url = "https://www.example.com/sso"
+      SiteSetting.enable_sso = true
+
+      invite = Fabricate.build(:invite, email: "test@mail.com")
+      expect(invite).not_to be_valid
+      expect(invite.errors.details[:email].first[:error]).to eq(I18n.t("invite.disabled_errors.sso_enabled"))
+    end
+  end
+
   context '#create' do
     context 'saved' do
       subject { Fabricate(:invite) }

--- a/spec/requests/invites_controller_spec.rb
+++ b/spec/requests/invites_controller_spec.rb
@@ -443,6 +443,7 @@ describe InvitesController do
             end
 
             it "does not send password reset email if sso is enabled" do
+              invite # create the invite before enabling SSO
               SiteSetting.sso_url = "https://www.example.com/sso"
               SiteSetting.enable_sso = true
               put "/invites/show/#{invite.invite_key}.json"

--- a/spec/requests/invites_controller_spec.rb
+++ b/spec/requests/invites_controller_spec.rb
@@ -454,6 +454,7 @@ describe InvitesController do
             end
 
             it "does not send password reset email if local login is disabled" do
+              invite # create the invite before enabling SSO
               SiteSetting.enable_local_logins = false
               put "/invites/show/#{invite.invite_key}.json"
               expect(response.status).to eq(200)


### PR DESCRIPTION
A more general, lower-level change in addition to #11950.

Most code paths already check if SSO is enabled or if local logins are disabled before trying to create an email invite.
This is a safety net to ensure no invalid invites sneak by. 

Also includes:
FIX: Don't allow to bulk invite when SSO is on (or when local logins are disabled)
This mirrors can_invite_to_forum? and other email invite code paths.