### PR TITLE
FIX: Include extra SCSS in child theme

### DIFF
--- a/lib/stylesheet/importer.rb
+++ b/lib/stylesheet/importer.rb
@@ -193,10 +193,21 @@ module Stylesheet
           // Theme: #{field.theme.name}
           // Target: #{field.target_name} #{field.name}
           // Last Edited: #{field.updated_at}
-
-          #{value}
           COMMENT
+
+          if field.theme_id == theme.id
+            contents << value
+          else
+            css, source_map = begin
+              field.compile_scss
+            rescue SassC::SyntaxError => e
+              raise Discourse::ScssError, e.message
+            end
+
+            contents << css
+          end
         end
+
       end
       contents
     end

--- a/spec/models/theme_spec.rb
+++ b/spec/models/theme_spec.rb
@@ -795,7 +795,7 @@ HTML
       expect(css).to include("p{color:blue}")
     end
 
-    it "works for child themes" do
+    it "works for child themes and includes child theme SCSS in parent theme" do
       child_theme.set_field(target: :common, name: :scss, value: '@import "my_files/moremagic"')
       child_theme.save!
 

--- a/spec/models/theme_spec.rb
+++ b/spec/models/theme_spec.rb
@@ -802,6 +802,9 @@ HTML
       manager = Stylesheet::Manager.new(:desktop_theme, child_theme.id)
       css, _map = manager.compile(force: true)
       expect(css).to include("body{background:green}")
+
+      parent_css, _parent_map = compiler
+      expect(parent_css).to include("body{background:green}")
     end
 
   end

--- a/spec/services/themes_spec.rb
+++ b/spec/services/themes_spec.rb
@@ -38,7 +38,7 @@ describe ThemesInstallTask do
     end
 
     let :scss_data do
-      "@font-face { font-family: magic; src: url($font)}; body {color: $color; content: $name;}"
+      "@font-face { font-family: magic; src: url($font)}; body {color: fuchsia;}"
     end
 
     let :theme_repo do


### PR DESCRIPTION
Fixes a regression in e8b82724fd303424f042b2b0d0b98a463676659d that affected theme components with extra SCSS files.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
