### PR TITLE
FIX: In FastImage 2.2.2 an error is raised with a `nil` path

### DIFF
--- a/app/jobs/onceoff/fix_invalid_gravatar_uploads.rb
+++ b/app/jobs/onceoff/fix_invalid_gravatar_uploads.rb
@@ -6,7 +6,7 @@ module Jobs
       Upload.where(original_filename: "gravatar.png").find_each do |upload|
         # note, this still feels pretty expensive for a once off
         # we may need to re-evaluate this
-        extension = FastImage.type(Discourse.store.path_for(upload))
+        extension = FastImage.type(Discourse.store.path_for(upload) || '')
         current_extension = upload.extension
 
         if extension.to_s.downcase != current_extension.to_s.downcase

--- a/app/jobs/onceoff/fix_invalid_gravatar_uploads.rb
+++ b/app/jobs/onceoff/fix_invalid_gravatar_uploads.rb
@@ -6,7 +6,7 @@ module Jobs
       Upload.where(original_filename: "gravatar.png").find_each do |upload|
         # note, this still feels pretty expensive for a once off
         # we may need to re-evaluate this
-        extension = FastImage.type(Discourse.store.path_for(upload) || '')
+        extension = FastImage.type(Discourse.store.path_for(upload)) rescue nil
         current_extension = upload.extension
 
         if extension.to_s.downcase != current_extension.to_s.downcase


### PR DESCRIPTION
Sometimes Discourse.store.path_for would return `nil`, which the job
handled gracefully before, but raises an error with the new version of
the gem.

Note the logic of this job is a bit awkward since it depends on `nil`
being a string, but at least now it's no longer filling logs with
errors.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
