### PR TITLE
DOCS: Updates docs for OSX dev with fontforge

### DIFF
--- a/docs/DEVELOPMENT-OSX-NATIVE.md
+++ b/docs/DEVELOPMENT-OSX-NATIVE.md
@@ -183,15 +183,17 @@ ImageMagick is used for generating avatars (including for test fixtures).
     brew install imagemagick
 
 ImageMagick is going to want to use the Helvetica font to generate the
-letter-avatars:
+letter-avatars. To make it available we need to extract it from the system
+fonts:
 
 ```sh
-brew install fondu
+brew install fontforge
 cd ~/Library/Fonts
-fondu /System/Library/Fonts/Helvetica.dfont
+export HELVETICA_FONT=/System/Library/Fonts/Helvetica.ttc # The extension might be dfont instead
+fontforge -c "[open(u'%s(%s)' % ('$HELVETICA_FONT', font)).generate('%s.ttf' % font) for font in fontsInFile('$HELVETICA_FONT')]"
 mkdir ~/.magick
 cd ~/.magick
-curl https://www.imagemagick.org/Usage/scripts/imagick_type_gen > type_gen
+curl https://legacy.imagemagick.org/Usage/scripts/imagick_type_gen > 
 find /System/Library/Fonts /Library/Fonts ~/Library/Fonts -name "*.[to]tf" | perl type_gen -f - > type.xml
 cd /usr/local/Cellar/imagemagick/<version>/etc/ImageMagick-6
 ```

--- a/docs/DEVELOPMENT-OSX-NATIVE.md
+++ b/docs/DEVELOPMENT-OSX-NATIVE.md
@@ -193,7 +193,7 @@ export HELVETICA_FONT=/System/Library/Fonts/Helvetica.ttc # The extension might 
 fontforge -c "[open(u'%s(%s)' % ('$HELVETICA_FONT', font)).generate('%s.ttf' % font) for font in fontsInFile('$HELVETICA_FONT')]"
 mkdir ~/.magick
 cd ~/.magick
-curl https://legacy.imagemagick.org/Usage/scripts/imagick_type_gen > 
+curl https://legacy.imagemagick.org/Usage/scripts/imagick_type_gen > type_gen
 find /System/Library/Fonts /Library/Fonts ~/Library/Fonts -name "*.[to]tf" | perl type_gen -f - > type.xml
 cd /usr/local/Cellar/imagemagick/<version>/etc/ImageMagick-6
 ```


### PR DESCRIPTION
`fondu` is no longer available via homebrew: _Error: fondu has been disabled because it is not maintained upstream!_ (since
Homebrew/homebrew-core#66396) and the `pkg` file available on `fondu`'s site doesn't seem to work on Big Sur. An alternative option is to use`fontforge`, which a little `python` script (it's definitely less short an harder to read, but it works). Additionally, it looks like the file *might* be called `ttc` instead.

I have also updated the URL for ImageMagick's `type_gen` because it now lives under `legacy.imagemagick.org` which causes `curl` to capture a 301 page instead.

cc @ZogStriP 
