### PR TITLE
FIX: Composer upload icon regression because of WEBP

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/upload-selector.js
+++ b/app/assets/javascripts/discourse/app/controllers/upload-selector.js
@@ -56,7 +56,7 @@ export default Controller.extend(ModalFunctionality, {
         const imageUrl = this.imageUrl || "";
         const toolbarEvent = this.toolbarEvent;
 
-        if (imageUrl.match(/\.(jpg|jpeg|png|gif|heic|heif)$/)) {
+        if (imageUrl.match(/\.(jpg|jpeg|png|gif|heic|heif|webp)$/)) {
           toolbarEvent.addText(`![](${imageUrl})`);
         } else {
           toolbarEvent.addText(imageUrl);

--- a/app/assets/javascripts/discourse/app/lib/uploads.js
+++ b/app/assets/javascripts/discourse/app/lib/uploads.js
@@ -118,7 +118,7 @@ function validateUploadedFile(file, opts) {
   return true;
 }
 
-const IMAGES_EXTENSIONS_REGEX = /(png|jpe?g|gif|svg|ico|heic|heif)/i;
+const IMAGES_EXTENSIONS_REGEX = /(png|jpe?g|gif|svg|ico|heic|heif|webp)/i;
 
 function extensionsToArray(exts) {
   return exts
@@ -182,7 +182,7 @@ export function authorizedExtensions(staff, siteSettings) {
 
 function authorizedImagesExtensions(staff, siteSettings) {
   return authorizesAllExtensions(staff, siteSettings)
-    ? "png, jpg, jpeg, gif, svg, ico, heic, heif"
+    ? "png, jpg, jpeg, gif, svg, ico, heic, heif, webp"
     : imagesExtensions(staff, siteSettings).join(", ");
 }
 


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
