### PR TITLE
FIX: Save auto-updated theme/component fields

### DIFF
--- a/lib/tasks/themes.rake
+++ b/lib/tasks/themes.rake
@@ -53,11 +53,12 @@ end
 
 desc "Update themes & theme components"
 task "themes:update" => :environment do |task, args|
-  Theme.where(auto_update: true).find_each do |theme|
+  Theme.where(auto_update: true, enabled: true).find_each do |theme|
     begin
       if theme.remote_theme.present?
         puts "Updating #{theme.name}..."
         theme.remote_theme.update_from_remote
+        theme.save!
       end
     rescue => e
       STDERR.puts "Failed to update #{theme.name}"


### PR DESCRIPTION
Was running into strange issues that looked like they were cache problems, but on closer inspection of theme field values, I noticed that the auto-update was not saving the pulled changes. 

The PR also limits updates to enabled themes/components. 