### PR TITLE
popup menu buttons need focus style

### DIFF
--- a/app/assets/stylesheets/common/base/popup-menu.scss
+++ b/app/assets/stylesheets/common/base/popup-menu.scss
@@ -32,6 +32,7 @@
       align-self: flex-start;
     }
 
+    &:focus,
     &:hover {
       color: var(--primary);
       background: var(--tertiary-low);
@@ -50,6 +51,7 @@
         color: var(--primary);
       }
 
+      &:focus,
       &:hover {
         .d-icon,
         .d-button-label {


### PR DESCRIPTION
follow-up to 2dc48fd

before:

![Screen Shot 2021-02-03 at 9 25 53 PM](https://user-images.githubusercontent.com/1681963/106836060-71fc7580-6666-11eb-8a86-2de7d4aa09fb.png)


after:

![Screen Shot 2021-02-03 at 9 25 57 PM](https://user-images.githubusercontent.com/1681963/106836053-70cb4880-6666-11eb-969e-593f934f7915.png)


