### PR TITLE
ensure category breadcrumbs have consistent height

### DIFF
--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -51,10 +51,19 @@
   list-style: none;
   padding: 0;
   margin: 0;
-  li {
+  > li {
+    // only target the top-level li, not dropdowns
+    display: flex;
     float: left;
-    margin-bottom: var(--nav-space);
     margin-right: 0.5em;
+    height: 100%;
+    margin-bottom: 0;
+  }
+
+  .select-kit-header {
+    align-self: stretch;
+    height: 100%;
+    margin-bottom: var(--nav-space);
   }
 }
 


### PR DESCRIPTION
Follow-up to d15159d

This makes the breadcrumbs more flexible if button or nav-pill height changes (due to different fonts, font sizes, padding, etc)... now the breadcrumbs will stretch to the height of their siblings. 🧒 👦 👧 

Before:
![Screen Shot 2021-02-03 at 10 16 25 PM](https://user-images.githubusercontent.com/1681963/106840141-8b54f000-666d-11eb-916b-5d6d6d10ea94.png)

After:
![Screen Shot 2021-02-03 at 10 16 12 PM](https://user-images.githubusercontent.com/1681963/106840162-9740b200-666d-11eb-91c4-135223136015.png)

