### PR TITLE
UX: Clarify user rejection modal

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/modal/reject-reason-reviewable.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/reject-reason-reviewable.hbs
@@ -12,8 +12,6 @@
 {{/d-modal-body}}
 
 <div class="modal-footer">
-  {{d-button action=(route-action "closeModal") label="close"}}
-  <div class="pull-right">
-    {{d-button icon="trash-alt" class="btn-danger" action=(action "perform")}}
-  </div>
+  {{d-button icon="trash-alt" class="btn-danger" action=(action "perform") label="admin.user.delete"}}
+  {{d-button action=(route-action "closeModal") label="cancel"}}
 </div>

--- a/app/assets/javascripts/discourse/tests/acceptance/review-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/review-test.js
@@ -49,7 +49,7 @@ acceptance("Review", function (needs) {
       "it opens reject reason modal when user is rejected"
     );
 
-    await click(".modal-footer button[aria-label='Close']");
+    await click(".modal-footer button[aria-label='cancel']");
 
     await click(
       `${user} .reviewable-actions button[data-name="Delete User..."]`

--- a/app/assets/stylesheets/common/base/modal.scss
+++ b/app/assets/stylesheets/common/base/modal.scss
@@ -167,16 +167,16 @@
   align-items: center;
   padding: 14px 15px 10px;
   border-top: 1px solid var(--primary-low);
+  --btn-bottom-margin: 0.3em;
   .btn {
-    margin: 0 0.3em 0 0;
+    margin: 0 0.75em var(--btn-bottom-margin) 0;
     &[href] {
       min-height: unset;
     }
   }
 
-  .btn,
   a {
-    margin-bottom: 0.3em;
+    margin-bottom: var(--btn-bottom-margin);
   }
 }
 


### PR DESCRIPTION
Before: 

![image](https://user-images.githubusercontent.com/1681963/106841725-9f4e2100-6670-11eb-871e-c48a822bb392.png)


After:

![Screen Shot 2021-02-03 at 10 34 22 PM](https://user-images.githubusercontent.com/1681963/106841728-a117e480-6670-11eb-84ac-5d8c75c65938.png)
