### PR TITLE
REFACTOR: Remove d-button block helpers

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/components/email-styles-editor.hbs
+++ b/app/assets/javascripts/admin/addon/templates/components/email-styles-editor.hbs
@@ -13,8 +13,6 @@
 
 <div class="admin-footer">
   <div class="buttons">
-    {{#d-button action=(action "reset") disabled=resetDisabled class="btn-default"}}
-      {{i18n "admin.customize.email_style.reset"}}
-    {{/d-button}}
+    {{d-button action=(action "reset") disabled=resetDisabled class="btn-default" label="admin.customize.email_style.reset"}}
   </div>
 </div>

--- a/app/assets/javascripts/admin/addon/templates/customize-email-style-edit.hbs
+++ b/app/assets/javascripts/admin/addon/templates/customize-email-style-edit.hbs
@@ -2,8 +2,6 @@
 
 <div class="admin-footer">
   <div class="buttons">
-    {{#d-button action=(action "save") disabled=saveDisabled class="btn-primary"}}
-      {{saveButtonText}}
-    {{/d-button}}
+    {{d-button action=(action "save") disabled=saveDisabled class="btn-primary" translatedLabel=saveButtonText}}
   </div>
 </div>

--- a/app/assets/javascripts/admin/addon/templates/customize-themes-edit.hbs
+++ b/app/assets/javascripts/admin/addon/templates/customize-themes-edit.hbs
@@ -43,13 +43,12 @@
       </div>
 
       <div class="buttons">
-        {{#d-button
+        {{d-button
           action=(action "save")
           disabled=saveDisabled
           class="btn-primary"
+          translatedLabel=saveButtonText
         }}
-          {{saveButtonText}}
-        {{/d-button}}
       </div>
     </div>
   </div>

--- a/app/assets/javascripts/discourse/app/templates/components/group-manage-logs-filter.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/group-manage-logs-filter.hbs
@@ -1,6 +1,3 @@
 {{#if value}}
-  {{#d-button class="btn-default group-manage-logs-filter" action=(action "clearFilter") actionParam=type}}
-    <span>{{label}}</span>: {{filterText}}
-    {{d-icon "times-circle"}}
-  {{/d-button}}
+  {{d-button class="btn-default group-manage-logs-filter" action=(action "clearFilter") actionParam=type icon="times-circle" translatedLabel=(concat label ": " filterText)}}
 {{/if}}

--- a/app/assets/javascripts/discourse/app/templates/components/group-manage-logs-row.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/group-manage-logs-row.hbs
@@ -1,33 +1,23 @@
 <tr class="group-manage-logs-row">
   <td>
-    {{#d-button class="btn-default" action=(action "filter") actionParam=(hash value=log.action key="action")}}
-      {{log.actionTitle}}
-    {{/d-button}}
+    {{d-button class="btn-default" action=(action "filter") actionParam=(hash value=log.action key="action") translatedLabel=log.actionTitle}}
   </td>
 
   <td>
     <span>{{avatar log.acting_user imageSize="tiny"}}</span>
-
-    {{#d-button class="btn-default" action=(action "filter") actionParam=(hash value=log.acting_user.username key="acting_user")}}
-      {{log.acting_user.username}}
-    {{/d-button}}
+    {{d-button class="btn-default" action=(action "filter") actionParam=(hash value=log.acting_user.username key="acting_user") translatedLabel=log.acting_user.username}}
   </td>
 
   <td>
     {{#if log.target_user}}
       <span>{{avatar log.target_user imageSize="tiny"}}</span>
-
-      {{#d-button class="btn-default" action=(action "filter") actionParam=(hash value=log.target_user.username key="target_user")}}
-        {{log.target_user.username}}
-      {{/d-button}}
+      {{d-button class="btn-default" action=(action "filter") actionParam=(hash value=log.target_user.username key="target_user") translatedLabel=log.target_user.username}}
     {{/if}}
   </td>
 
   <td>
     {{#if log.subject}}
-      {{#d-button class="btn-default" action=(action "filter") actionParam=(hash value=log.subject key="subject")}}
-        {{log.subject}}
-      {{/d-button}}
+      {{d-button class="btn-default" action=(action "filter") actionParam=(hash value=log.subject key="subject") translatedLabel=log.subject}}
     {{/if}}
   </td>
 

--- a/app/assets/javascripts/discourse/app/templates/components/group-manage-save-button.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/group-manage-save-button.hbs
@@ -1,11 +1,9 @@
 <div class="control-group buttons">
-  {{#d-button action=(action "save")
+  {{d-button action=(action "save")
     disabled=saving
     class="btn btn-primary group-manage-save"
+    translatedLabel=savingText
   }}
-    {{savingText}}
-  {{/d-button}}
-
   {{#if saved}}
     <span>{{i18n "saved"}}</span>
   {{/if}}

--- a/app/assets/javascripts/discourse/app/templates/components/ip-lookup.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/ip-lookup.hbs
@@ -45,13 +45,12 @@
         {{i18n "ip_lookup.other_accounts"}}
         <strong>{{totalOthersWithSameIP}}</strong>
         {{#if other_accounts.length}}
-          {{#d-button
+          {{d-button
             class="btn-danger pull-right"
             action=(action "deleteOtherAccounts")
             icon="exclamation-triangle"
+            translatedLabel=(i18n "ip_lookup.delete_other_accounts" count=otherAccountsToDelete)
           }}
-            {{i18n "ip_lookup.delete_other_accounts" count=otherAccountsToDelete}}
-          {{/d-button}}
         {{/if}}
       </dt>
 

--- a/app/assets/javascripts/discourse/app/templates/components/top-period-buttons.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/top-period-buttons.hbs
@@ -1,3 +1,3 @@
 {{#each periods as |p|}}
-  {{d-button action=(action "changePeriod") class="btn-default" actionParam=p  translatedLabel=(period-title p)}}
+  {{d-button action=(action "changePeriod") class="btn-default" actionParam=p translatedLabel=(period-title p)}}
 {{/each}}

--- a/app/assets/javascripts/discourse/app/templates/components/top-period-buttons.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/top-period-buttons.hbs
@@ -1,5 +1,3 @@
 {{#each periods as |p|}}
-  {{#d-button action=(action "changePeriod") class="btn-default" actionParam=p}}
-    {{period-title p}}
-  {{/d-button}}
+  {{d-button action=(action "changePeriod") class="btn-default" actionParam=p  translatedLabel=(period-title p)}}
 {{/each}}

--- a/app/assets/javascripts/discourse/app/templates/mobile/modal/login.hbs
+++ b/app/assets/javascripts/discourse/app/templates/mobile/modal/login.hbs
@@ -75,9 +75,7 @@
       {{/unless}}
 
       {{#if showSignupLink}}
-        {{#d-button class="btn-large" id="new-account-link" action=(route-action "showCreateAccount")}}
-          {{i18n "create_account.title"}}
-        {{/d-button}}
+        {{d-button class="btn-large" id="new-account-link" action=(route-action "showCreateAccount") label="create_account.title"}}
       {{/if}}
     {{/if}}
   </div>

--- a/app/assets/javascripts/discourse/app/templates/modal/create-account.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/create-account.hbs
@@ -182,9 +182,7 @@
         }}
 
         {{#unless hasAuthOptions}}
-          {{#d-button class="btn-large" id="login-link" action=(route-action "showLogin") disabled=formSubmitted}}
-            {{i18n "log_in"}}
-          {{/d-button}}
+          {{d-button class="btn-large" id="login-link" action=(route-action "showLogin") disabled=formSubmitted label="log_in"}}
         {{/unless}}
 
         <div class="disclaimer">{{html-safe disclaimerHtml}}</div>

--- a/app/assets/javascripts/discourse/app/templates/modal/move-to-topic.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/move-to-topic.hbs
@@ -110,7 +110,5 @@
 {{/d-modal-body}}
 
 <div class="modal-footer">
-  {{#d-button class="btn-primary" disabled=buttonDisabled action=(action "performMove")}}
-    {{d-icon "sign-out-alt"}} {{buttonTitle}}
-  {{/d-button}}
+  {{d-button class="btn-primary" disabled=buttonDisabled action=(action "performMove") icon="sign-out-alt" translatedLabel=buttonTitle}}
 </div>

--- a/app/assets/javascripts/discourse/app/templates/preferences-email.hbs
+++ b/app/assets/javascripts/discourse/app/templates/preferences-email.hbs
@@ -43,14 +43,13 @@
 
       <div class="control-group">
         <div class="controls">
-          {{#d-button
+          {{d-button
             class="btn-primary"
             action=(action "saveEmail")
             type="submit"
             disabled=saveDisabled
+            translatedLabel=saveButtonText
           }}
-            {{saveButtonText}}
-          {{/d-button}}
         </div>
       </div>
     {{/if}}

--- a/app/assets/javascripts/discourse/app/templates/preferences-username.hbs
+++ b/app/assets/javascripts/discourse/app/templates/preferences-username.hbs
@@ -24,15 +24,13 @@
 
     <div class="control-group">
       <div class="controls">
-        {{#d-button
+        {{d-button
           class="btn-primary"
           action=(action "changeUsername")
           type="submit"
           disabled=saveDisabled
+          translatedLabel=saveButtonText
         }}
-          {{saveButtonText}}
-        {{/d-button}}
-
         {{#if saved}}{{i18n "saved"}}{{/if}}
       </div>
     </div>

--- a/app/assets/stylesheets/common/base/groups.scss
+++ b/app/assets/stylesheets/common/base/groups.scss
@@ -160,3 +160,13 @@
     }
   }
 }
+
+.group-manage-logs-controls {
+  button {
+    .d-icon {
+      // flip the icon order for the remove button
+      order: 2;
+      margin: 0 0 0 0.45em;
+    }
+  }
+}


### PR DESCRIPTION
A lot of these were creating d-buttons without the correct markup... classes were missing as well as `d-button-label` wrappers, which made for inconsistent buttons and missing spaces between icons and text (now that they use flexbox). 

With useful things like `translatedLabel` the block helper really only needs to be used in special ❄️ button situations. 