### PR TITLE
FIX: process new invites when existing users are already group members

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -351,7 +351,9 @@ class GroupsController < ApplicationController
     end
 
     usernames_already_in_group = group.users.where(id: users.map(&:id)).pluck(:username)
-    if usernames_already_in_group.present? && usernames_already_in_group.length == users.length
+    if usernames_already_in_group.present? &&
+      usernames_already_in_group.length == users.length &&
+      emails.blank?
       render_json_error(I18n.t(
         "groups.errors.member_already_exist",
         username: usernames_already_in_group.sort.join(", "),

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -1246,6 +1246,23 @@ describe GroupsController do
           expect(response.status).to eq(200)
         end
 
+        it 'sends invites to new users and ignores existing users' do
+          user1.update!(username: 'john')
+          user2.update!(username: 'alice')
+          [user1, user2].each { |user| group.add(user) }
+          emails = ["something@gmail.com", "anotherone@yahoo.com"]
+          put "/groups/#{group.id}/members.json",
+            params: { user_emails: [user1.email, user2.email].join(","), emails: emails.join(",") }
+
+          expect(response.status).to eq(200)
+          expect(response.parsed_body["emails"]).to eq(emails)
+
+          emails.each do |email|
+            invite = Invite.find_by(email: email)
+            expect(invite.groups).to eq([group])
+          end
+        end
+
         it 'displays warning when all members already exists' do
           user1.update!(username: 'john')
           user2.update!(username: 'alice')


### PR DESCRIPTION
If a list of email addresses is pasted into a group’s Add Members form that has one or more email addresses of users who already belong to the group and all other email addresses are for users who do not yet exist on the forum then no invites were being sent. This commit ensures that we send invites to new users.