### PR TITLE
FIX: Don't cancel filtering on second "n replies" tap

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/post.js
+++ b/app/assets/javascripts/discourse/app/widgets/post.js
@@ -440,13 +440,17 @@ createWidget("post-contents", {
   },
 
   toggleFilteredRepliesView() {
-    const post = this.findAncestorModel();
-    const controller = this.register.lookup("controller:topic");
-    if (post.get("topic.postStream.filterRepliesToPostNumber")) {
-      controller.send(
-        "cancelFilter",
-        post.get("topic.postStream.filterRepliesToPostNumber")
+    const post = this.findAncestorModel(),
+      controller = this.register.lookup("controller:topic"),
+      currentFilterPostNumber = post.get(
+        "topic.postStream.filterRepliesToPostNumber"
       );
+
+    if (
+      currentFilterPostNumber &&
+      currentFilterPostNumber === post.post_number
+    ) {
+      controller.send("cancelFilter", currentFilterPostNumber);
       this.state.filteredRepliesShown = false;
     } else {
       this.state.filteredRepliesShown = true;


### PR DESCRIPTION
Fixes an issue introduced in 0f31a221c9f9edbd8ed78502bd16fc6ead74b30d.

Bug report: https://meta.discourse.org/t/filtered-replies-view-issue/178359
