### PR TITLE
DEV: Allow autospec to run full test suite in parallel

### DIFF
--- a/lib/autospec/simple_runner.rb
+++ b/lib/autospec/simple_runner.rb
@@ -23,7 +23,7 @@ module Autospec
 
       command = begin
         line_specified = specs.split.any? { |s| s =~ /\:/ } # Parallel spec can't run specific line
-        multiple_files = specs.split.count > 1 # Only paralellize multiple files
+        multiple_files = specs.split.count > 1 || specs == "spec" # Only paralellize multiple files
         if ENV["PARALLEL_SPEC"] == '1' && multiple_files && !line_specified
           "bin/turbo_rspec #{args.join(" ")} #{specs.split.join(" ")}"
         else


### PR DESCRIPTION
The definition of 'multiple_files' did not consider that 'spec' refers to the entire `spec/` directory, and therefore includes multiple files

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
