### PR TITLE
UX: Use bright color for primary button hover on dark schemes

### DIFF
--- a/app/assets/stylesheets/common/foundation/color_transformations.scss
+++ b/app/assets/stylesheets/common/foundation/color_transformations.scss
@@ -26,7 +26,10 @@ $secondary-very-high: dark-light-diff($secondary, $primary, 7%, -7%) !default;
 $tertiary-low: dark-light-diff($tertiary, $secondary, 85%, -65%) !default;
 $tertiary-medium: dark-light-diff($tertiary, $secondary, 50%, -45%) !default;
 $tertiary-high: dark-light-diff($tertiary, $secondary, 20%, -25%) !default;
-$tertiary-hover: dark-light-diff($tertiary, $secondary, -25%, -25%) !default;
+$tertiary-hover: dark-light-choose(
+  dark-light-diff($tertiary, $secondary, -25%, -25%),
+  dark-light-diff($tertiary, $primary, 20%, 70%)
+) !default;
 
 //quaternary
 $quaternary-low: dark-light-diff($quaternary, $secondary, 70%, -70%) !default;


### PR DESCRIPTION
Affects hover and focus states, for dark themes only. 

Before: 
<img width="463" alt="image" src="https://user-images.githubusercontent.com/368961/106934643-5cc82b00-66e8-11eb-9045-46b1ed65dfc7.png">

After: 
<img width="463" alt="image" src="https://user-images.githubusercontent.com/368961/106934467-268aab80-66e8-11eb-86ff-dfb857bb640d.png">
