### PR TITLE
DEV: adds below-suggested-topics plugin outlet

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/suggested-topics.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/suggested-topics.hbs
@@ -20,3 +20,5 @@
     {{html-safe browseMoreMessage}}
   </h3>
 </div>
+
+{{plugin-outlet name="below-suggested-topics" args=(hash topic=topic)}}


### PR DESCRIPTION
We need this to avoid template overrides in themes.
