### PR TITLE
DEV: Cleanup detection of user summary route for header collapsing

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/user.js
+++ b/app/assets/javascripts/discourse/app/controllers/user.js
@@ -1,6 +1,6 @@
 import Controller, { inject } from "@ember/controller";
 import EmberObject, { computed, set } from "@ember/object";
-import { alias, and, gt, not, or } from "@ember/object/computed";
+import { alias, and, equal, gt, not, or } from "@ember/object/computed";
 import CanCheckEmails from "discourse/mixins/can-check-emails";
 import User from "discourse/models/user";
 import I18n from "I18n";
@@ -14,7 +14,6 @@ import { prioritizeNameInUx } from "discourse/lib/settings";
 import { inject as service } from "@ember/service";
 
 export default Controller.extend(CanCheckEmails, {
-  indexStream: false,
   router: service(),
   userNotifications: inject("user-notifications"),
   currentPath: alias("router._router.currentPath"),
@@ -36,17 +35,19 @@ export default Controller.extend(CanCheckEmails, {
     return !isEmpty(background.toString());
   },
 
+  isSummaryRoute: equal("router.currentRouteName", "user.summary"),
+
   @discourseComputed(
     "model.profile_hidden",
-    "indexStream",
+    "isSummaryRoute",
     "viewingSelf",
     "forceExpand"
   )
-  collapsedInfo(profileHidden, indexStream, viewingSelf, forceExpand) {
+  collapsedInfo(profileHidden, isSummaryRoute, viewingSelf, forceExpand) {
     if (profileHidden) {
       return true;
     }
-    return (!indexStream || viewingSelf) && !forceExpand;
+    return (!isSummaryRoute || viewingSelf) && !forceExpand;
   },
   canMuteOrIgnoreUser: or("model.can_ignore_user", "model.can_mute_user"),
   hasGivenFlags: gt("model.number_of_flags_given", 0),

--- a/app/assets/javascripts/discourse/app/routes/build-admin-user-posts-route.js
+++ b/app/assets/javascripts/discourse/app/routes/build-admin-user-posts-route.js
@@ -6,7 +6,6 @@ export default function (filter) {
   return DiscourseRoute.extend({
     actions: {
       didTransition() {
-        this.controllerFor("user").set("indexStream", true);
         this.controllerFor("user-posts")._showFooter();
         return true;
       },

--- a/app/assets/javascripts/discourse/app/routes/user-summary.js
+++ b/app/assets/javascripts/discourse/app/routes/user-summary.js
@@ -11,10 +11,4 @@ export default DiscourseRoute.extend({
 
     return user.summary();
   },
-
-  actions: {
-    didTransition() {
-      this.controllerFor("user").set("indexStream", true);
-    },
-  },
 });

--- a/app/assets/javascripts/discourse/app/routes/user.js
+++ b/app/assets/javascripts/discourse/app/routes/user.js
@@ -11,14 +11,6 @@ export default DiscourseRoute.extend({
   },
 
   actions: {
-    willTransition(transition) {
-      // will reset the indexStream when transitioning to routes that aren't "indexStream"
-      // otherwise the "header" will jump
-      const isIndexStream = transition.targetName === "user.summary";
-      this.controllerFor("user").set("indexStream", isIndexStream);
-      return true;
-    },
-
     undoRevokeApiKey(key) {
       key.undoRevoke();
     },


### PR DESCRIPTION
Previously it was using various willTransition and didTransition hooks
which can be quite fragile, especially when removing the
intermediate loading state.

https://meta.discourse.org/t/177939/74

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
