### PR TITLE
FIX: return 404 `not found` error if a topic is deleted.

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -850,7 +850,7 @@ class TopicsController < ApplicationController
 
     begin
       @topic_view = TopicView.new(params[:topic_id])
-    rescue Discourse::NotLoggedIn => ex
+    rescue Discourse::NotLoggedIn
       raise Discourse::NotFound
     rescue Discourse::InvalidAccess => ex
 

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -848,7 +848,24 @@ class TopicsController < ApplicationController
   def feed
     raise Discourse::NotFound if !Post.exists?(topic_id: params[:topic_id])
 
-    @topic_view = TopicView.new(params[:topic_id])
+    begin
+      @topic_view = TopicView.new(params[:topic_id])
+    rescue Discourse::NotLoggedIn => ex
+      raise Discourse::NotFound
+    rescue Discourse::InvalidAccess => ex
+
+      deleted = guardian.can_see_topic?(ex.obj, false) ||
+        (!guardian.can_see_topic?(ex.obj) &&
+         ex.obj&.access_topic_via_group &&
+         ex.obj.deleted_at)
+
+      raise Discourse::NotFound.new(
+        nil,
+        check_permalinks: deleted,
+        original_path: ex.obj.relative_url
+      )
+    end
+
     discourse_expires_in 1.minute
     render 'topics/show', formats: [:rss]
   end

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -2540,6 +2540,12 @@ RSpec.describe TopicsController do
       get "/t/foo/#{topic.id}.rss"
       expect(response.status).to eq(404)
     end
+
+    it 'returns 404 when the topic is deleted' do
+      topic.trash!
+      get "/t/foo/#{topic.id}.rss"
+      expect(response.status).to eq(404)
+    end
   end
 
   describe '#invite_group' do


### PR DESCRIPTION
Currently, it's returning 403 invalid access error which causes issues in Google webmaster tools.