### PR TITLE
FIX: The invite success email translation variable was renamed

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2655,7 +2655,7 @@ en:
         to_username: "Enter the username of the person you'd like to invite. We'll send a notification with a link inviting them to this topic."
 
         email_placeholder: "name@example.com"
-        success_email: "We mailed out an invitation to <b>%{emailOrUsername}</b>. We'll notify you when the invitation is redeemed. Check the invitations tab on your user page to keep track of your invites."
+        success_email: "We mailed out an invitation to <b>%{invitee}</b>. We'll notify you when the invitation is redeemed. Check the invitations tab on your user page to keep track of your invites."
         success_username: "We've invited that user to participate in this topic."
         error: "Sorry, we couldn't invite that person. Perhaps they have already been invited? (Invites are rate limited)"
         success_existing_email: "A user with email <b>%{emailOrUsername}</b> already exists. We've invited that user to participate in this topic."


### PR DESCRIPTION
`emailOrUsername` was renamed to `invitee` in [a recent change to app/assets/javascripts/discourse/app/components/invite-panel.js](https://github.com/discourse/discourse/pull/11726/files#diff-17b64667da82989866410d84787103d805033bb98900496d4338716a4e988bceR267) and needs to be updated in `client.en.yml`.

Users were reporting seeing the following when receiving the related email:

>We mailed out an invitation to [missing %{emailOrUsername} value]. We’ll notify you when the invitation is redeemed. Check the invitations tab on your user page to keep track of your invites.

