### PR TITLE
UX: don't display tag notification menu on category page.

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-navigation.js
+++ b/app/assets/javascripts/discourse/app/components/d-navigation.js
@@ -22,6 +22,12 @@ export default Component.extend(FilterModeMixin, {
     return category && this.currentUser;
   },
 
+  // don't show tag notification menu on tag intersections
+  @discourseComputed("tagNotification", "additionalTags")
+  showTagNotifications(tagNotification, additionalTags) {
+    return tagNotification && !additionalTags;
+  },
+
   @discourseComputed("category", "createTopicDisabled")
   categoryReadOnlyBanner(category, createTopicDisabled) {
     if (category && this.currentUser && createTopicDisabled) {

--- a/app/assets/javascripts/discourse/app/templates/components/d-navigation.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/d-navigation.hbs
@@ -65,15 +65,15 @@
   {{/if}}
 
   {{#if tag}}
-    {{#if tagNotification}}
-      {{#unless additionalTags}}
-        {{!-- don't show tag notification menu on tag intersections --}}
+    {{#unless category}}
+      {{!-- don't show tag notification menu on category pages --}}
+      {{#if showTagNotifications}}
         {{tag-notifications-button
           onChange=changeTagNotificationLevel
           value=tagNotification.notification_level
         }}
-      {{/unless}}
-    {{/if}}
+      {{/if}}
+    {{/unless}}
   {{/if}}
 
 </div>

--- a/app/assets/javascripts/discourse/tests/acceptance/tags-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/tags-test.js
@@ -77,6 +77,28 @@ acceptance("Tags", function (needs) {
     );
 
     server.put("/topics/bulk", () => helper.response({}));
+
+    server.get("/tags/c/faq/4/test/l/latest.json", () => {
+      return helper.response({
+        users: [],
+        primary_groups: [],
+        topic_list: {
+          can_create_topic: true,
+          draft: null,
+          draft_key: "new_topic",
+          draft_sequence: 1,
+          per_page: 30,
+          tags: [
+            {
+              id: 1,
+              name: "planters",
+              topic_count: 1,
+            },
+          ],
+          topics: [],
+        },
+      });
+    });
   });
 
   test("list the tags", async function (assert) {
@@ -94,6 +116,11 @@ acceptance("Tags", function (needs) {
     await click("button.dismiss-read");
     await click(".dismiss-read-modal button.btn-primary");
     assert.ok(invisible(".dismiss-read-modal"));
+  });
+
+  test("hide tag notifications menu", async function (assert) {
+    await visit("/tags/c/faq/4/test");
+    assert.ok(invisible(".tag-notifications-button"));
   });
 });
 


### PR DESCRIPTION
If both category and tag are selected then we shouldn't display a notification menu.