### PR TITLE
UX: Show caret icon on user notification dropdown

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/user-notifications-dropdown.js
+++ b/app/assets/javascripts/select-kit/addon/components/user-notifications-dropdown.js
@@ -9,6 +9,7 @@ export default DropdownSelectBox.extend({
 
   selectKitOptions: {
     headerIcon: "userNotificationicon",
+    showCaret: true,
   },
 
   userNotificationicon: computed("mainCollection.[]", "value", function () {

--- a/app/assets/stylesheets/common/select-kit/user-notifications-dropdown.scss
+++ b/app/assets/stylesheets/common/select-kit/user-notifications-dropdown.scss
@@ -3,6 +3,10 @@
     &.user-notifications-dropdown {
       text-align: left;
 
+      .d-icon {
+        margin-left: 0;
+      }
+
       .select-kit-body {
         width: 485px;
         max-width: 485px;


### PR DESCRIPTION
Discussion here: https://meta.discourse.org/t/the-notifications-dropdown-on-user-profile-lacks-a-caret-down-icon/178349

![Screen Shot 2021-02-04 at 10 47 31 PM](https://user-images.githubusercontent.com/1681963/106987297-25369e80-673b-11eb-9838-d18828c69807.png)
