### PR TITLE
DEV: Add CSRF meta tags to pages served by Ember CLI server

### DIFF
--- a/app/assets/javascripts/discourse/public/assets/scripts/discourse-boot.js
+++ b/app/assets/javascripts/discourse/public/assets/scripts/discourse-boot.js
@@ -195,6 +195,16 @@
 
       let locale = data.bootstrap.locale_script;
 
+      if (data.bootstrap.csrf_token) {
+        const csrfParam = document.createElement("meta");
+        csrfParam.setAttribute("name", "csrf-param");
+        csrfParam.setAttribute("content", "authenticity_token");
+        head.append(csrfParam);
+        const csrfToken = document.createElement("meta");
+        csrfToken.setAttribute("name", "csrf-token");
+        csrfToken.setAttribute("content", data.bootstrap.csrf_token);
+        head.append(csrfToken);
+      }
       (data.bootstrap.stylesheets || []).forEach((s) => {
         let link = document.createElement("link");
         link.setAttribute("rel", "stylesheet");

--- a/app/controllers/bootstrap_controller.rb
+++ b/app/controllers/bootstrap_controller.rb
@@ -60,6 +60,7 @@ class BootstrapController < ApplicationController
       preloaded: @preloaded,
     }
     bootstrap[:extra_locales] = extra_locales if extra_locales.present?
+    bootstrap[:csrf_token] = form_authenticity_token if current_user
 
     render_json_dump(bootstrap: bootstrap)
   end


### PR DESCRIPTION
This PR adds the CSRF token in the bootstrap data so that they can be added to the DOM when using Ember CLI.