### PR TITLE
UX: Small fix for Chrome focus style on replies button

### DIFF
--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -202,7 +202,9 @@ nav.post-controls {
     font-size: inherit;
     padding: 10px;
     color: var(--primary-medium);
-    &:hover {
+    &:hover,
+    &:focus {
+      outline: none;
       color: var(--primary);
       background: var(--primary-low);
     }


### PR DESCRIPTION
Removes the border on focus in screenshot below (Chrome, most prominent in dark color scheme): 

<img width="180" alt="image" src="https://user-images.githubusercontent.com/368961/107075376-062a2200-67b8-11eb-987e-770817039d0a.png">
