### PR TITLE
FIX: Topic progress bar should be on the left in RTL layouts

### DIFF
--- a/app/assets/stylesheets/mobile/topic.scss
+++ b/app/assets/stylesheets/mobile/topic.scss
@@ -50,8 +50,14 @@
     margin-bottom: env(safe-area-inset-bottom);
   }
   html.rtl & {
-    right: 0;
-    left: 1em;
+    /**
+     * This should be the other way around, but it has to be "wrong" here
+     * because our RTL CSS is generated using the `rtlit` gem which flips
+     * left to right and right to left, so this will be corrected when it
+     * goes through rtlit.
+     */
+    left: unset;
+    right: 1em;
   }
 }
 


### PR DESCRIPTION
When using Discourse in LTR layout, the topic progress bar is on the right hand side. However when you switch to RTL, it should move to the left hand side so that it doesn't cover posts content and controls, but right now it stays on the right. This PR will move the topic progress bar to left when using Discourse in RTL layout.

Screenshot with this change:

![107119989-f7b53680-689b-11eb-825d-53afb82a2df011](https://user-images.githubusercontent.com/17474474/107120186-2e3f8100-689d-11eb-8216-9c2f849e105c.png)
