### PR TITLE
Plugin-outlet for user-notifications page

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/user/notifications.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user/notifications.hbs
@@ -27,6 +27,10 @@
         {{i18n "user_action_groups.11"}}
       {{/link-to}}
     </li>
+    {{plugin-outlet
+      name="user-notifications-bottom"
+      connectorTagName="li"
+      args=(hash model=model)}}
   {{/mobile-nav}}
 
 {{/d-section}}


### PR DESCRIPTION
Plugin-outlet for the user-notifications page will be used for adding a new item in the user-notifications filter navigation bar

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
