### PR TITLE
DEV: add helper script to run ember cli

### DIFF
--- a/bin/ember-cli
+++ b/bin/ember-cli
@@ -1,0 +1,33 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'pathname'
+
+RAILS_ROOT = File.expand_path("../../", Pathname.new(__FILE__).realpath)
+PORT = ENV["UNICORN_PORT"] ||= "9292"
+
+Dir.chdir(RAILS_ROOT) # rubocop:disable Discourse/NoChdir
+Dir.chdir("app/assets/javascripts/discourse") # rubocop:disable Discourse/NoChdir
+
+PROXY =
+  if ARGV.include?("--try")
+    "https://try.discourse.org"
+  else
+    "http://localhost:#{PORT}"
+  end
+
+if ARGV.include?("-h") || ARGV.include?("--help")
+  puts "ember-cli OPTIONS"
+  puts "--try To proxy try.discourse.org", ""
+  puts "The rest of the arguments are passed to ember server per:", ""
+  exec "yarn run ember server --help"
+end
+
+args = ["run", "ember", "server"] + ARGV.reject { |a| a == "--try" }
+
+if !args.include?("--proxy")
+  args << "--proxy"
+  args << PROXY
+end
+
+exec "yarn", *args.to_a.flatten


### PR DESCRIPTION
This little helper script allows for easy ember cli development.

To see the options run `bin/ember-cli -h`

It allows you to proxy try.discourse.org with the `bin/ember-cli --try`
switch, which effectively allows for some development without a rails installed.

It passes on arguments to ember-cli so you can customize port and so on.

It makes the assumption that on local people are using `bin/unicorn` for
development. (it includes some extra discourse specific helpers)
