### PR TITLE
DEV: makes aria-expanded boolean check strict

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-button.js
+++ b/app/assets/javascripts/discourse/app/components/d-button.js
@@ -4,6 +4,7 @@ import DiscourseURL from "discourse/lib/url";
 import I18n from "I18n";
 import { computed } from "@ember/object";
 import discourseComputed from "discourse-common/utils/decorators";
+import { isPresent } from "@ember/utils";
 
 export default Component.extend({
   tagName: "button",
@@ -96,7 +97,14 @@ export default Component.extend({
 
   @discourseComputed("ariaExpanded")
   computedAriaExpanded(ariaExpanded) {
-    return ariaExpanded ? "true" : "false";
+    if (isPresent(ariaExpanded)) {
+      if (ariaExpanded === true) {
+        return "true";
+      }
+      if (ariaExpanded === false) {
+        return "false";
+      }
+    }
   },
 
   click(event) {

--- a/app/assets/javascripts/discourse/app/components/d-button.js
+++ b/app/assets/javascripts/discourse/app/components/d-button.js
@@ -4,7 +4,6 @@ import DiscourseURL from "discourse/lib/url";
 import I18n from "I18n";
 import { computed } from "@ember/object";
 import discourseComputed from "discourse-common/utils/decorators";
-import { isPresent } from "@ember/utils";
 
 export default Component.extend({
   tagName: "button",
@@ -97,13 +96,11 @@ export default Component.extend({
 
   @discourseComputed("ariaExpanded")
   computedAriaExpanded(ariaExpanded) {
-    if (isPresent(ariaExpanded)) {
-      if (ariaExpanded === true) {
-        return "true";
-      }
-      if (ariaExpanded === false) {
-        return "false";
-      }
+    if (ariaExpanded === true) {
+      return "true";
+    }
+    if (ariaExpanded === false) {
+      return "false";
     }
   },
 

--- a/app/assets/javascripts/discourse/tests/integration/components/d-button-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/d-button-test.js
@@ -206,10 +206,12 @@ discourseModule("Integration | Component | d-button", function (hooks) {
     },
   });
 
-  componentTest("ariaExpanded", {
-    template: "{{d-button ariaExpanded=ariaExpanded}}",
+  componentTest("aria-expanded", {
+    template: hbs`{{d-button ariaExpanded=ariaExpanded}}`,
 
     test(assert) {
+      assert.equal(query("button").ariaExpanded, null);
+
       this.set("ariaExpanded", true);
 
       assert.equal(query("button").ariaExpanded, "true");
@@ -220,16 +222,16 @@ discourseModule("Integration | Component | d-button", function (hooks) {
 
       this.set("ariaExpanded", "false");
 
-      assert.equal(query("button").ariaExpanded, "true");
+      assert.equal(query("button").ariaExpanded, null);
 
       this.set("ariaExpanded", "true");
 
-      assert.equal(query("button").ariaExpanded, "true");
+      assert.equal(query("button").ariaExpanded, null);
     },
   });
 
-  componentTest("ariaControls", {
-    template: "{{d-button ariaControls=ariaControls}}",
+  componentTest("aria-controls", {
+    template: hbs`{{d-button ariaControls=ariaControls}}`,
 
     test(assert) {
       this.set("ariaControls", "foo-bar");


### PR DESCRIPTION
{{d-button ariaExpanded=xxx}} only accepts Boolean now.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
