### PR TITLE
FIX: Some error messages used wrong translation key

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -333,14 +333,14 @@ class GroupsController < ApplicationController
     end
 
     if users.empty? && emails.empty?
-      raise Discourse::InvalidParameters.new(I18n.t("usernames_or_emails_required"))
+      raise Discourse::InvalidParameters.new(I18n.t("groups.errors.usernames_or_emails_required"))
     end
 
     if emails.any?
       if SiteSetting.enable_sso?
-        raise Discourse::InvalidParameters.new(I18n.t("no_invites_with_discourse_connect"))
+        raise Discourse::InvalidParameters.new(I18n.t("groups.errors.no_invites_with_discourse_connect"))
       elsif !SiteSetting.enable_local_logins?
-        raise Discourse::InvalidParameters.new(I18n.t("no_invites_without_local_logins"))
+        raise Discourse::InvalidParameters.new(I18n.t("groups.errors.no_invites_without_local_logins"))
       end
     end
 


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
