### PR TITLE
UX: Remove transparent 2px border from some select-kit buttons

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/selected-color.js
+++ b/app/assets/javascripts/select-kit/addon/components/selected-color.js
@@ -13,6 +13,7 @@ export default SelectedNameComponent.extend({
         el = document.querySelector(`[data-value="${color}"]`);
 
       if (el) {
+        el.style.borderBottom = "2px solid transparent";
         el.style.borderBottomColor = `#${color}`;
       }
     });

--- a/app/assets/stylesheets/common/select-kit/select-kit.scss
+++ b/app/assets/stylesheets/common/select-kit/select-kit.scss
@@ -71,7 +71,6 @@
       color: inherit;
       display: flex;
       outline: none;
-      border-bottom: 2px solid transparent;
 
       .d-icon + .name {
         margin-left: 0.5em;


### PR DESCRIPTION
Looks like this style was being applied to various select kits and not just when hex colors were input, which caused some 2px button height differences like this:

![image](https://user-images.githubusercontent.com/1681963/107285326-f8c99d80-6a2c-11eb-80ba-db82bc8fa4e5.png)

Moved the style so it's only applied when there's a color present. Keeping it separate from the color assignment allows the transparent 2px border to remain even when there's an invalid color (combining them inherited the color, so it would show a border color even with an invalid hex)

![Screen Shot 2021-02-08 at 4 47 16 PM](https://user-images.githubusercontent.com/1681963/107285519-4f36dc00-6a2d-11eb-9d72-5a62f59cd9ff.png)
