### PR TITLE
DEV: Trigger appEvent when topic progress component moves

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-progress.js
+++ b/app/assets/javascripts/discourse/app/components/topic-progress.js
@@ -187,7 +187,7 @@ export default Component.extend({
     );
     this.appEvents.trigger("topic-progress:docked-status-changed", {
       docked: isDocked,
-      element: $wrapper,
+      element: this.element,
     });
   },
 

--- a/app/assets/javascripts/discourse/app/components/topic-progress.js
+++ b/app/assets/javascripts/discourse/app/components/topic-progress.js
@@ -185,6 +185,10 @@ export default Component.extend({
       "margin-bottom",
       !isDocked && composerHeight > draftComposerHeight ? "0px" : ""
     );
+    this.appEvents.trigger("topic-progress:docked-status-changed", {
+      docked: isDocked,
+      element: $wrapper,
+    });
   },
 
   click(e) {


### PR DESCRIPTION
The topic progress div is moved around based on the scroll position. The `bottom` style is set in this function to move the element around. If you have a theme/plugin that modifies the topic view in certain ways, you may have to reposition this element again. With this appEvent, themes can hook into it and correct the position for the theme.