### PR TITLE
DEV: Use discourse/discourse_test in CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
   build:
     name: "${{ matrix.target }}-${{ matrix.build_types }}"
     runs-on: ${{ matrix.os }}
+    container: discourse/discourse_test:release
     timeout-minutes: 60
 
     env:
@@ -20,7 +21,7 @@ jobs:
       BUILD_TYPE: ${{ matrix.build_types }}
       TARGET: ${{ matrix.target }}
       RAILS_ENV: test
-      PGHOST: localhost
+      PGHOST: postgres
       PGUSER: discourse
       PGPASSWORD: discourse
 
@@ -61,49 +62,27 @@ jobs:
           git config --global user.email "ci@ci.invalid"
           git config --global user.name "Discourse CI"
 
-      - name: Setup packages
-        if: env.BUILD_TYPE != 'LINT'
-        run: |
-          sudo apt-get update
-          sudo apt-get -yqq install postgresql-client libpq-dev jpegoptim optipng jhead pngcrush pngquant
-          wget -qO- https://raw.githubusercontent.com/discourse/discourse_docker/master/image/base/install-pngquant | sudo sh
-
-      - name: Update imagemagick
-        if: env.BUILD_TYPE == 'BACKEND'
-        run: |
-          wget https://raw.githubusercontent.com/discourse/discourse_docker/master/image/base/install-imagemagick
-          chmod +x install-imagemagick
-          sudo ./install-imagemagick
-
       - name: Setup redis
         uses: shogo82148/actions-setup-redis@v1
         if: env.BUILD_TYPE != 'LINT'
         with:
           redis-version: ${{ matrix.redis }}
 
-      - name: Setup ruby
-        uses: actions/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.ruby }}
-
-      - name: Setup bundler
-        run: |
-          gem install bundler -v 2.1.4 --no-doc
-          bundle config deployment 'true'
-          bundle config without 'development'
-          bundle config path vendor/bundle
-
       - name: Bundler cache
         uses: actions/cache@v2
-        id: bundler-cache
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
+          key: ${{ runner.os }}-${{ matrix.ruby }}-gem-${{ hashFiles('**/Gemfile.lock') }}
           restore-keys: |
-            ${{ runner.os }}-gem-
+            ${{ runner.os }}-${{ matrix.ruby }}-gem-
 
       - name: Setup gems
-        run: bundle install --jobs 4
+        run: |
+          bundle config --local path vendor/bundle
+          bundle config --local deployment true
+          bundle config --local without development
+          bundle install --jobs 4
+          bundle clean
 
       - name: Get yarn cache directory
         id: yarn-cache-dir

--- a/config/unicorn.conf.rb
+++ b/config/unicorn.conf.rb
@@ -25,7 +25,7 @@ end
 # feel free to point this anywhere accessible on the filesystem
 pid (ENV["UNICORN_PID_PATH"] || "#{discourse_path}/tmp/pids/unicorn.pid")
 
-if ENV["RAILS_ENV"] == "development" || !ENV["RAILS_ENV"]
+if ENV["RAILS_ENV"] != "production"
   logger Logger.new($stdout)
   # we want a longer timeout in dev cause first request can be really slow
   timeout (ENV["UNICORN_TIMEOUT"] && ENV["UNICORN_TIMEOUT"].to_i || 60)

--- a/lib/tasks/qunit.rake
+++ b/lib/tasks/qunit.rake
@@ -109,6 +109,7 @@ task "qunit:test", [:timeout, :qunit_path] do |_, args|
   ensure
     # was having issues with HUP
     Process.kill "KILL", pid
+    FileUtils.rm("#{Rails.root}/tmp/pids/unicorn_test_#{port}.pid")
   end
 
   if success


### PR DESCRIPTION
Using our testing Docker image (`discourse/discourse_test:release`) allows us to drop "Update imagemagick" step which shaves ~10 minutes from all runs.
