### PR TITLE
DEV: Show warning message when using ember css selectors

### DIFF
--- a/app/assets/stylesheets/common/admin/customize.scss
+++ b/app/assets/stylesheets/common/admin/customize.scss
@@ -89,6 +89,7 @@
     margin-bottom: 10px;
     background-color: var(--quaternary-low);
     padding: 5px;
+    white-space: pre-wrap;
   }
 
   .admin-container {

--- a/app/controllers/admin/themes_controller.rb
+++ b/app/controllers/admin/themes_controller.rb
@@ -222,6 +222,7 @@ class Admin::ThemesController < Admin::AdminController
         format.json do
           error = @theme.errors.full_messages.join(", ").presence
           error = I18n.t("themes.bad_color_scheme") if @theme.errors[:color_scheme].present?
+          error = I18n.t("themes.ember_selector_error") if @theme.theme_fields.each { |tf| tf.errors.messages[:value].present? }
           error ||= I18n.t("themes.other_error")
 
           render json: { errors: [ error ] }, status: :unprocessable_entity

--- a/app/controllers/admin/themes_controller.rb
+++ b/app/controllers/admin/themes_controller.rb
@@ -222,7 +222,6 @@ class Admin::ThemesController < Admin::AdminController
         format.json do
           error = @theme.errors.full_messages.join(", ").presence
           error = I18n.t("themes.bad_color_scheme") if @theme.errors[:color_scheme].present?
-          error = I18n.t("themes.ember_selector_error") if @theme.theme_fields.each { |tf| tf.errors.messages[:value].present? }
           error ||= I18n.t("themes.other_error")
 
           render json: { errors: [ error ] }, status: :unprocessable_entity

--- a/app/models/theme_field.rb
+++ b/app/models/theme_field.rb
@@ -64,9 +64,6 @@ class ThemeField < ActiveRecord::Base
   validates :name, format: { with: /\A[a-z_][a-z0-9_-]*\z/i },
                    if: Proc.new { |field| ThemeField.theme_var_type_ids.include?(field.type_id) }
 
-  validates :value, format: { without: /#ember\d+|[.]ember-view/ },
-                    if: Proc.new { |field| ThemeField.css_theme_type_ids.include?(field.type_id) }
-
   belongs_to :theme
 
   def process_html(html)
@@ -379,6 +376,8 @@ class ThemeField < ActiveRecord::Base
       result = compile_scss
       if contains_optimized_link?(self.value)
         self.error = I18n.t("themes.errors.optimized_link")
+      elsif contains_ember_css_selector?(self.value)
+        self.error = I18n.t("themes.ember_selector_error")
       else
         self.error = nil unless error.nil?
       end
@@ -395,6 +394,10 @@ class ThemeField < ActiveRecord::Base
 
   def contains_optimized_link?(text)
     OptimizedImage::URL_REGEX.match?(text)
+  end
+
+  def contains_ember_css_selector?(text)
+    text.match(/#ember\d+|[.]ember-view/)
   end
 
   class ThemeFileMatcher

--- a/app/models/theme_field.rb
+++ b/app/models/theme_field.rb
@@ -50,6 +50,10 @@ class ThemeField < ActiveRecord::Base
     @theme_var_type_ids ||= [2]
   end
 
+  def self.css_theme_type_ids
+    @css_theme_type_ids ||= [0, 1]
+  end
+
   def self.force_recompilation!
     find_each do |field|
       field.compiler_version = 0
@@ -59,6 +63,9 @@ class ThemeField < ActiveRecord::Base
 
   validates :name, format: { with: /\A[a-z_][a-z0-9_-]*\z/i },
                    if: Proc.new { |field| ThemeField.theme_var_type_ids.include?(field.type_id) }
+
+  validates :value, format: { without: /#ember\d+|[.]ember-view/ },
+                    if: Proc.new { |field| ThemeField.css_theme_type_ids.include?(field.type_id) }
 
   belongs_to :theme
 

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -65,7 +65,7 @@ en:
   themes:
     bad_color_scheme: "Can not update theme, invalid color palette"
     other_error: "Something went wrong updating theme"
-    ember_selector_error: "Using #ember or .ember-view css selectors is not permitted."
+    ember_selector_error: "Sorry – using #ember or .ember-view CSS selectors is not permitted, because these names are dynamically generated at runtime and will change over time, eventually resulting in broken CSS. Try a different selector."
     compile_error:
       unrecognized_extension: "Unrecognized file extension: %{extension}"
     import_error:

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -65,6 +65,7 @@ en:
   themes:
     bad_color_scheme: "Can not update theme, invalid color palette"
     other_error: "Something went wrong updating theme"
+    ember_selector_error: "Using #ember or .ember-view css selectors is not permitted."
     compile_error:
       unrecognized_extension: "Unrecognized file extension: %{extension}"
     import_error:

--- a/spec/requests/admin/themes_controller_spec.rb
+++ b/spec/requests/admin/themes_controller_spec.rb
@@ -384,7 +384,12 @@ describe Admin::ThemesController do
         }
       }
 
-      expect(response.status).to eq(422)
+      expect(response.status).to eq(200)
+
+      json = response.parsed_body
+
+      fields = json["theme"]["theme_fields"].sort { |a, b| a["value"] <=> b["value"] }
+      expect(fields[0]["error"]).to eq(I18n.t("themes.ember_selector_error"))
 
       put "/admin/themes/#{theme.id}.json", params: {
         theme: {
@@ -397,7 +402,11 @@ describe Admin::ThemesController do
         }
       }
 
-      expect(response.status).to eq(422)
+      expect(response.status).to eq(200)
+      json = response.parsed_body
+
+      fields = json["theme"]["theme_fields"].sort { |a, b| a["value"] <=> b["value"] }
+      expect(fields[0]["error"]).to eq(I18n.t("themes.ember_selector_error"))
     end
 
     it 'blocks remote theme fields from being locally edited' do

--- a/spec/requests/admin/themes_controller_spec.rb
+++ b/spec/requests/admin/themes_controller_spec.rb
@@ -370,6 +370,36 @@ describe Admin::ThemesController do
       expect(UserHistory.where(action: UserHistory.actions[:change_theme]).count).to eq(1)
     end
 
+    it 'prevents theme update when using ember css selectors' do
+      child_theme = Fabricate(:theme, component: true)
+
+      put "/admin/themes/#{theme.id}.json", params: {
+        theme: {
+          child_theme_ids: [child_theme.id],
+          name: 'my test name',
+          theme_fields: [
+            { name: 'scss', target: 'common', value: '' },
+            { name: 'scss', target: 'desktop', value: '.ember-view{color: blue;}' },
+          ]
+        }
+      }
+
+      expect(response.status).to eq(422)
+
+      put "/admin/themes/#{theme.id}.json", params: {
+        theme: {
+          child_theme_ids: [child_theme.id],
+          name: 'my test name',
+          theme_fields: [
+            { name: 'scss', target: 'common', value: '' },
+            { name: 'scss', target: 'desktop', value: '#ember392{color: blue;}' },
+          ]
+        }
+      }
+
+      expect(response.status).to eq(422)
+    end
+
     it 'blocks remote theme fields from being locally edited' do
       r = RemoteTheme.create!(remote_url: "https://magic.com/repo.git")
       theme.update!(remote_theme_id: r.id)


### PR DESCRIPTION
When editing the theme css via the admin UI a warning message
will be displayed if it detects that the `#emberXXX` or `.ember-view`
css selectors are being used. These are dynamic selectors that ember
generates, but they can change so they should not be used.

This error message will be displayed:

![image](https://user-images.githubusercontent.com/1490496/107596340-ae832080-6bd4-11eb-9f39-8841079004ab.png)


