### PR TITLE
FIX: adjust topic loading container width to avoid horizontal overflow

### DIFF
--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -604,8 +604,8 @@ blockquote {
       (#{$topic-body-width-padding} * 2)
   );
   @media all and (max-width: 790px) {
-    // 16px is the left + right padding on .wrap in common/base/discourse.scss
-    max-width: calc(100vw - 16px);
+    // 32px is (left + right padding * 2) from .wrap in common/base/discourse.scss
+    max-width: calc(100vw - 32px);
   }
 }
 


### PR DESCRIPTION
There was a miscalculation here and as a result at narrow desktop sizes there was a horizontal scrollbar. This fixes that!

Before:
![Screen Shot 2021-02-10 at 11 16 53 PM](https://user-images.githubusercontent.com/1681963/107602005-45aca000-6bf6-11eb-9b76-7e69a2b03201.png)

After:
![Screen Shot 2021-02-10 at 11 17 02 PM](https://user-images.githubusercontent.com/1681963/107602006-45aca000-6bf6-11eb-8bd8-bf14dc08c543.png)


