### PR TITLE
FIX: Validate duration minutes values for topic timer

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/edit-topic-timer.js
+++ b/app/assets/javascripts/discourse/app/controllers/edit-topic-timer.js
@@ -121,6 +121,9 @@ export default Controller.extend(ModalFunctionality, {
 
   actions: {
     onChangeStatusType(value) {
+      if (value !== CLOSE_STATUS_TYPE) {
+        this.set("topicTimer.based_on_last_post", false);
+      }
       this.set("topicTimer.status_type", value);
     },
 
@@ -145,14 +148,24 @@ export default Controller.extend(ModalFunctionality, {
 
       if (
         this.get("topicTimer.duration_minutes") &&
-        !this.get("topicTimer.updateTime") &&
-        this.get("topicTimer.duration_minutes") <= 0
+        !this.get("topicTimer.updateTime")
       ) {
-        this.flash(
-          I18n.t("topic.topic_status_update.min_duration"),
-          "alert-error"
-        );
-        return;
+        if (this.get("topicTimer.duration_minutes") <= 0) {
+          this.flash(
+            I18n.t("topic.topic_status_update.min_duration"),
+            "alert-error"
+          );
+          return;
+        }
+
+        // cannot be more than 2 years
+        if (this.get("topicTimer.duration_minutes") > 2 * 365 * 1440) {
+          this.flash(
+            I18n.t("topic.topic_status_update.max_duration"),
+            "alert-error"
+          );
+          return;
+        }
       }
 
       this._setTimer(

--- a/app/models/topic_timer.rb
+++ b/app/models/topic_timer.rb
@@ -22,7 +22,7 @@ class TopicTimer < ActiveRecord::Base
   validates :category_id, presence: true, if: :publishing_to_category?
 
   validate :executed_at_in_future?
-  validate :duration_ok?
+  validate :duration_in_range?
 
   scope :scheduled_bump_topics, -> { where(status_type: TopicTimer.types[:bump], deleted_at: nil).pluck(:topic_id) }
   scope :pending_timers, ->(before_time = Time.now.utc) do
@@ -137,7 +137,7 @@ class TopicTimer < ActiveRecord::Base
 
   private
 
-  def duration_ok?
+  def duration_in_range?
     return if duration_minutes.blank?
 
     if duration_minutes.to_i <= 0

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2425,6 +2425,7 @@ en:
         when: "When:"
         time_frame_required: "Please select a time frame"
         min_duration: "Duration must be greater than 0"
+        max_duration: "Duration must be less than 2 years"
       auto_update_input:
         none: "Select a timeframe"
         now: "Now"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -615,6 +615,9 @@ en:
           attributes:
             execute_at:
               in_the_past: "must be in the future."
+            duration_minutes:
+              cannot_be_zero: "must be greater than 0."
+              exceeds_maximum: "cannot be more than 2 years."
         translation_overrides:
           attributes:
             value:

--- a/spec/models/topic_timer_spec.rb
+++ b/spec/models/topic_timer_spec.rb
@@ -23,6 +23,20 @@ RSpec.describe TopicTimer, type: :model do
         topic_timer.update!(execute_at: 1.minute.ago, created_at: 10.minutes.ago)
         expect(TopicTimer.pending_timers.pluck(:id)).to include(topic_timer.id)
       end
+
+      describe "duration values" do
+        it "does not allow durations <= 0" do
+          topic_timer.duration_minutes = -1
+          topic_timer.save
+          expect(topic_timer.errors.full_messages.first).to include("Duration minutes must be greater than 0.")
+        end
+
+        it "does not allow crazy big durations (2 years in minutes)" do
+          topic_timer.duration_minutes = 3.years.to_i / 60
+          topic_timer.save
+          expect(topic_timer.errors.full_messages.first).to include("Duration minutes cannot be more than 2 years.")
+        end
+      end
     end
     describe '#status_type' do
       it 'should ensure that only one active public topic status update exists' do


### PR DESCRIPTION
Add server and client side validations to ensure topic timer durations cannot exceed 2 years and cannot be less than or equal to 0.