### PR TITLE
FIX: Handle empty email address from authentication provider

### DIFF
--- a/lib/auth/managed_authenticator.rb
+++ b/lib/auth/managed_authenticator.rb
@@ -103,7 +103,7 @@ class Auth::ManagedAuthenticator < Auth::Authenticator
       result.name = nil
     end
     result.username = info[:nickname]
-    result.email_valid = primary_email_verified?(auth_token) if result.email
+    result.email_valid = primary_email_verified?(auth_token) if result.email.present?
     result.extra_data = {
       provider: auth_token[:provider],
       uid: auth_token[:uid]

--- a/spec/components/auth/managed_authenticator_spec.rb
+++ b/spec/components/auth/managed_authenticator_spec.rb
@@ -53,6 +53,18 @@ describe Auth::ManagedAuthenticator do
       expect(associated.extra["raw_info"]["randominfo"]).to eq("some info")
     end
 
+    it 'only sets email valid for present strings' do
+      # (Twitter sometimes sends empty email strings)
+      result = authenticator.after_authenticate(create_hash.merge(info: { email: "email@example.com" }))
+      expect(result.email_valid).to eq(true)
+
+      result = authenticator.after_authenticate(create_hash.merge(info: { email: "" }))
+      expect(result.email_valid).to be_falsey
+
+      result = authenticator.after_authenticate(create_hash.merge(info: { email: nil }))
+      expect(result.email_valid).to be_falsey
+    end
+
     describe 'connecting to another user account' do
       fab!(:user1) { Fabricate(:user) }
       fab!(:user2) { Fabricate(:user) }


### PR DESCRIPTION
If no email is provided, email_valid should be set false, so that
Discourse can prompt the user for an email and verify it.

This fixes signups via twitter for accounts with no email address.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
