### PR TITLE
FEATURE: Add "Recently read topics" tab to  user activity page

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/user.js
+++ b/app/assets/javascripts/discourse/app/controllers/user.js
@@ -102,6 +102,11 @@ export default Controller.extend(CanCheckEmails, {
     return viewingSelf;
   },
 
+  @discourseComputed("viewingSelf")
+  showRead(viewingSelf) {
+    return viewingSelf;
+  },
+
   @discourseComputed("viewingSelf", "currentUser.admin")
   showPrivateMessages(viewingSelf, isAdmin) {
     return (

--- a/app/assets/javascripts/discourse/app/routes/app-route-map.js
+++ b/app/assets/javascripts/discourse/app/routes/app-route-map.js
@@ -125,6 +125,7 @@ export default function () {
           });
           this.route("pending");
           this.route("drafts");
+          this.route("read");
         }
       );
 

--- a/app/assets/javascripts/discourse/app/routes/user-activity-read.js
+++ b/app/assets/javascripts/discourse/app/routes/user-activity-read.js
@@ -1,0 +1,12 @@
+import UserAction from "discourse/models/user-action";
+import UserTopicListRoute from "discourse/routes/user-topic-list";
+
+export default UserTopicListRoute.extend({
+  userActionType: UserAction.TYPES.topics,
+
+  model() {
+    return this.store.findFiltered("topicList", {
+      filter: "read",
+    });
+  },
+});

--- a/app/assets/javascripts/discourse/app/templates/user/activity.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user/activity.hbs
@@ -9,6 +9,11 @@
     <li>
       {{#link-to "userActivity.replies"}}{{i18n "user_action_groups.5"}}{{/link-to}}
     </li>
+    {{#if user.showRead}}
+      <li>
+        {{#link-to "userActivity.read" title=(i18n "user.read_help")}}{{i18n "user.read"}}{{/link-to}}
+      </li>
+    {{/if}}
     {{#if user.showDrafts}}
       <li>
         {{#link-to "userActivity.drafts"}}{{i18n "user_action_groups.15"}}{{/link-to}}

--- a/app/assets/javascripts/discourse/tests/unit/models/user-stream-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/user-stream-test.js
@@ -31,6 +31,9 @@ module("Unit | Model | user-stream", function () {
     // defaults to posts/topics
     assert.equal(stream.get("filterParam"), "4,5");
 
+    stream.set("filter", UserAction.TYPES.topics);
+    assert.equal(stream.get("filterParam"), "4");
+
     stream.set("filter", UserAction.TYPES.likes_given);
     assert.equal(stream.get("filterParam"), UserAction.TYPES.likes_given);
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -967,6 +967,8 @@ en:
         sunday: "Sunday"
         to: "to"
       activity_stream: "Activity"
+      read: "Read"
+      read_help: "Recently read topics"
       preferences: "Preferences"
       feature_topic_on_profile:
         open_search: "Select a New Topic"


### PR DESCRIPTION
Reference: https://meta.discourse.org/t/continue-where-you-left-off-hand-off-feature-for-reading-posts/179000/8