### PR TITLE
FEATURE: Allow onebox images to be used as topic thumbnails

### DIFF
--- a/lib/cooked_post_processor.rb
+++ b/lib/cooked_post_processor.rb
@@ -209,8 +209,8 @@ class CookedPostProcessor
     @doc.css("img.site-icon") -
     # minus onebox avatars
     @doc.css("img.onebox-avatar") -
-    # minus small onebox images (large images are .aspect-image-full-size)
-    @doc.css(".onebox .aspect-image img")
+    # minus github onebox profile images
+    @doc.css(".onebox.githubfolder img")
   end
 
   def oneboxed_images


### PR DESCRIPTION
Still excludes GitHub avatars. Those were the original reason for adding
this broad exclusion. Context at https://meta.discourse.org/t/165713/4

If we find more oneboxes which are unsuitable for thumbnails, we can add
them to this selector.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
