### PR TITLE
FIX: vBulletin importers should hide soft-deleted posts

### DIFF
--- a/script/bulk_import/vbulletin.rb
+++ b/script/bulk_import/vbulletin.rb
@@ -359,7 +359,7 @@ class BulkImport::VBulletin < BulkImport::Base
         reply_to_post_number: reply_to_post_number,
         user_id: user_id_from_imported_id(row[3]),
         created_at: Time.zone.at(row[4]),
-        hidden: row[5] == 0,
+        hidden: row[5] != 1,
         raw: normalize_text(row[6]),
       }
 

--- a/script/import_scripts/vbulletin.rb
+++ b/script/import_scripts/vbulletin.rb
@@ -398,7 +398,7 @@ EOM
           topic_id: topic[:topic_id],
           raw: raw,
           created_at: parse_timestamp(post["dateline"]),
-          hidden: post["visible"].to_i == 0,
+          hidden: post["visible"].to_i != 1,
         }
         if parent = topic_lookup_from_imported_post_id(post["parentid"])
           p[:reply_to_post_number] = parent[:post_number]

--- a/script/import_scripts/vbulletin5.rb
+++ b/script/import_scripts/vbulletin5.rb
@@ -327,7 +327,7 @@ class ImportScripts::VBulletin < ImportScripts::Base
           topic_id: topic[:topic_id],
           raw: raw,
           created_at: parse_timestamp(post["dateline"]),
-          hidden: post["visible"].to_i == 0,
+          hidden: post["visible"].to_i != 1,
         }
         if parent = topic_lookup_from_imported_post_id(post["parentid"])
           p[:reply_to_post_number] = parent[:post_number]


### PR DESCRIPTION
Posts can be soft-deleted which results in a visible = 2 state. At the moment those posts will be imported fully visible.
For Threads/Topics this is already taken care of - we should do the same for posts.

Unfortunately I did not find a test-suite for importers.

This problem seems super obvious. I am not sure why it wasn't reported earlier or if did something wrong.