### PR TITLE
UX: trim `@` char from start of the username string in search.

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/user-chooser.js
+++ b/app/assets/javascripts/select-kit/addon/components/user-chooser.js
@@ -51,6 +51,7 @@ export default MultiSelectComponent.extend({
 
   search(filter = "") {
     filter = filter || "";
+    filter = filter.replace(/^@/, "");
     const options = this.selectKit.options;
 
     // prevents doing ajax request for nothing


### PR DESCRIPTION
Currently, we're unable to search users by their username with the `@` symbol in the "Posted by" filter on the advanced search page.
