### PR TITLE
FEATURE: when moving posts to existing topic auto-select single topic

### DIFF
--- a/app/assets/javascripts/discourse/app/components/choose-topic.js
+++ b/app/assets/javascripts/discourse/app/components/choose-topic.js
@@ -95,6 +95,9 @@ export default Component.extend({
                 .mapBy("topic")
                 .filter((t) => t.id !== currentTopicId)
             );
+            if (this.topics.length === 1) {
+              this.send("chooseTopic", this.topics[0]);
+            }
           } else {
             this.setProperties({ topics: null, loading: false });
           }


### PR DESCRIPTION
When moving posts to an existing topic if the search result returns a single topic then that topic's radio field will be auto-selected.

<img width="568" alt="Screenshot 2021-02-12 at 12 59 12 PM" src="https://user-images.githubusercontent.com/5732281/107740890-1c912a00-6d32-11eb-9533-f832b99d5a93.png">
