### PR TITLE
DEV: prevents heisentest in processor spec

### DIFF
--- a/spec/support/fake_logger.rb
+++ b/spec/support/fake_logger.rb
@@ -6,6 +6,7 @@ class FakeLogger
   def initialize
     @warnings = []
     @errors = []
+    @debug = []
     @infos = []
     @fatals = []
   end
@@ -24,6 +25,10 @@ class FakeLogger
 
   def fatal(message)
     @fatals << message
+  end
+
+  def debug(message)
+    @debug << message
   end
 
   def formatter


### PR DESCRIPTION
This test failure was caused by rails calling `.debug` on our FakeLogger which was not supporting it, resulting in more errors than what the test was expecting.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
