### PR TITLE
UX: Second Factor + Alert Display

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/login.js
+++ b/app/assets/javascripts/discourse/app/controllers/login.js
@@ -83,23 +83,28 @@ export default Controller.extend(ModalFunctionality, {
     "awaitingApproval",
     "hasAtLeastOneLoginButton",
     "showSecondFactor",
-    "canLoginLocal"
+    "canLoginLocal",
+    "showSecurityKey"
   )
   modalBodyClasses(
     awaitingApproval,
     hasAtLeastOneLoginButton,
     showSecondFactor,
-    canLoginLocal
+    canLoginLocal,
+    showSecurityKey
   ) {
     const classes = ["login-modal"];
     if (awaitingApproval) {
       classes.push("awaiting-approval");
     }
-    if (hasAtLeastOneLoginButton && !showSecondFactor) {
+    if (hasAtLeastOneLoginButton && !showSecondFactor && !showSecurityKey) {
       classes.push("has-alt-auth");
     }
     if (!canLoginLocal) {
       classes.push("no-local-login");
+    }
+    if (showSecondFactor || showSecurityKey) {
+      classes.push("second-factor");
     }
     return classes.join(" ");
   },
@@ -166,8 +171,6 @@ export default Controller.extend(ModalFunctionality, {
               (result.security_key_enabled || result.totp_enabled) &&
               !this.secondFactorRequired
             ) {
-              document.getElementById("modal-alert").style.display = "none";
-
               this.setProperties({
                 otherMethodAllowed: result.multiple_second_factor_methods,
                 secondFactorRequired: true,

--- a/app/assets/stylesheets/common/base/login.scss
+++ b/app/assets/stylesheets/common/base/login.scss
@@ -27,6 +27,18 @@
   }
 }
 
+.d-modal.login-modal {
+  #modal-alert:empty {
+    display: none !important;
+  }
+  
+  #modal-alert:not(:empty) {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
+}
+
 // Create Account + Login
 .d-modal.create-account,
 .d-modal.login-modal {

--- a/app/assets/stylesheets/common/base/login.scss
+++ b/app/assets/stylesheets/common/base/login.scss
@@ -29,7 +29,7 @@
 
 .d-modal.login-modal {
   #modal-alert:empty {
-    display: none !important;
+    display: none;
   }
 
   #modal-alert:not(:empty) {

--- a/app/assets/stylesheets/common/base/login.scss
+++ b/app/assets/stylesheets/common/base/login.scss
@@ -31,7 +31,7 @@
   #modal-alert:empty {
     display: none !important;
   }
-  
+
   #modal-alert:not(:empty) {
     display: flex;
     flex-direction: column;

--- a/app/assets/stylesheets/desktop/login.scss
+++ b/app/assets/stylesheets/desktop/login.scss
@@ -106,7 +106,7 @@
     max-width: 350px;
   }
   .modal-footer {
-    margin-top: 1em !important;
+    margin-top: 1em;
   }
 }
 

--- a/app/assets/stylesheets/desktop/login.scss
+++ b/app/assets/stylesheets/desktop/login.scss
@@ -55,7 +55,7 @@
   #modal-alert {
     max-width: 100%;
     margin-bottom: 0;
-    padding: 8px 40px 8px 16px;
+    padding: 8px 50px 8px 16px;
     min-height: 35px;
   }
 
@@ -98,6 +98,12 @@
         }
       }
     }
+  }
+}
+
+.login-modal.modal-body:not(.hidden).second-factor {
+  .login-left-side {
+    max-width: 500px;
   }
 }
 

--- a/app/assets/stylesheets/desktop/login.scss
+++ b/app/assets/stylesheets/desktop/login.scss
@@ -105,6 +105,9 @@
   .login-left-side {
     max-width: 500px;
   }
+  .modal-footer {
+    margin-top: 1em !important;
+  }
 }
 
 // styles used on

--- a/app/assets/stylesheets/desktop/login.scss
+++ b/app/assets/stylesheets/desktop/login.scss
@@ -103,7 +103,7 @@
 
 .login-modal.modal-body:not(.hidden).second-factor {
   .login-left-side {
-    max-width: 500px;
+    max-width: 350px;
   }
   .modal-footer {
     margin-top: 1em !important;


### PR DESCRIPTION
This commit removes JS edits of the modal-alert and uses CSS instead. This commit also adds some styling to the 2FA login when using a key instead of a 2FA authenticator.

### New
![image](https://user-images.githubusercontent.com/30537603/107818871-d9d54f00-6d3d-11eb-917c-2b3326c93817.png)


### Old
![image](https://user-images.githubusercontent.com/30537603/107818439-35530d00-6d3d-11eb-8b36-86e9457cd3b1.png)


<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
