### PR TITLE
A11Y: Add aria markup for topic toolbars, timeline

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/d-editor.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/d-editor.hbs
@@ -1,6 +1,6 @@
 <div class="d-editor-container">
   <div class="d-editor-textarea-wrapper {{if disabled "disabled"}} {{if isEditorFocused "in-focus"}}">
-    <div class="d-editor-button-bar">
+    <div class="d-editor-button-bar" role="toolbar" aria-label={{i18n "composer.toolbar"}}>
       {{#each toolbar.groups as |group|}}
         {{#each group.buttons as |b|}}
           {{#if b.popupMenu}}

--- a/app/assets/javascripts/discourse/app/templates/components/topic-footer-buttons.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/topic-footer-buttons.hbs
@@ -1,4 +1,4 @@
-<div class="topic-footer-main-buttons">
+<div class="topic-footer-main-buttons" role="toolbar" aria-label={{i18n "topic.topic_footer_controls"}}>
   {{topic-admin-menu-button
     topic=topic
     openUpwards="true"

--- a/app/assets/javascripts/discourse/app/widgets/post-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-menu.js
@@ -1,5 +1,6 @@
 import { applyDecorators, createWidget } from "discourse/widgets/widget";
 import { next, run } from "@ember/runloop";
+import I18n from "I18n";
 import { Promise } from "rsvp";
 import { formattedReminderTime } from "discourse/lib/bookmark";
 import { h } from "virtual-dom";
@@ -413,6 +414,15 @@ export default createWidget("post-menu", {
     collapseButtons: true,
     buttonType: "flat-button",
     showReplyTitleOnMobile: false,
+  },
+
+  buildAttributes() {
+    const attributes = {};
+
+    attributes["role"] = "toolbar";
+    attributes["aria-label"] = I18n.t("topic.post_controls");
+
+    return attributes;
   },
 
   defaultState() {

--- a/app/assets/javascripts/discourse/app/widgets/topic-timeline.js
+++ b/app/assets/javascripts/discourse/app/widgets/topic-timeline.js
@@ -82,8 +82,18 @@ createWidget("timeline-scroller", {
     return { dragging: false };
   },
 
-  buildAttributes() {
-    return { style: `height: ${SCROLLER_HEIGHT}px` };
+  buildAttributes(attrs) {
+    const attributes = {};
+
+    attributes["style"] = `height: ${SCROLLER_HEIGHT}px`;
+    attributes["role"] = "scrollbar";
+    attributes["aria-orientation"] = "vertical";
+    attributes["aria-valuemin"] = "1";
+    attributes["aria-valuemax"] = attrs.total;
+    attributes["aria-valuenow"] = attrs.current;
+    attributes["aria-label"] = I18n.t("topic.progress.jump_prompt_long");
+
+    return attributes;
   },
 
   html(attrs, state) {
@@ -413,6 +423,15 @@ export default createWidget("topic-timeline", {
 
   buildKey: () => "topic-timeline-area",
 
+  buildAttributes() {
+    const attributes = {};
+
+    attributes["role"] = "toolbar";
+    attributes["aria-label"] = I18n.t("topic.timeline.title");
+
+    return attributes;
+  },
+
   defaultState() {
     return { position: null, excerpt: null };
   },
@@ -550,6 +569,10 @@ export default createWidget("topic-timeline", {
             className: "start-date",
             rawLabel: timelineDate(createdAt),
             action: "jumpTop",
+            attributes: {
+              "aria-description": I18n.t("topic.progress.jump_top"),
+              role: "button",
+            },
           })
         ),
         this.attach("timeline-scrollarea", attrs),
@@ -559,6 +582,10 @@ export default createWidget("topic-timeline", {
             className: "now-date",
             rawLabel: bottomAge,
             action: "jumpBottom",
+            attributes: {
+              "aria-description": I18n.t("topic.progress.jump_bottom"),
+              role: "button",
+            },
           })
         ),
       ];

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1894,6 +1894,8 @@ en:
       whisper: "whisper"
       unlist: "unlisted"
 
+      toolbar: "formatting and options"
+
       add_warning: "This is an official warning."
       toggle_whisper: "Toggle Whisper"
       toggle_unlisted: "Toggle Unlisted"
@@ -2490,6 +2492,7 @@ en:
         other: "The last post in the topic is already %{count} hours old, so the topic will be closed momentarily."
 
       timeline:
+        title: "Topic timeline"
         back: "Back"
         back_description: "Go back to your last unread post"
         replies_short: "%{current} / %{total}"
@@ -2499,6 +2502,7 @@ en:
         go_top: "top"
         go_bottom: "bottom"
         go: "go"
+        jump_top: "jump to first post"
         jump_bottom: "jump to last post"
         jump_prompt: "jump to..."
         jump_prompt_of:
@@ -2650,6 +2654,8 @@ en:
         group_name: "group name"
 
       controls: "Topic Controls"
+      post_controls: "Post controls"
+      topic_footer_controls: "Topic footer controls"
 
       invite_reply:
         title: "Invite"


### PR DESCRIPTION
This adds some ARIA markup to some of elements on a topic page:

* Controls under each post as a toolbar
* The timeline as a toolbar region
* The timeline itself as a scrollbar
* The topic footer as a toolbar
* The composer formatting bar as a toolbar

ARIA reference: 
https://www.w3.org/TR/wai-aria-practices/examples/toolbar/toolbar.html
https://www.digitala11y.com/scrollbar-role/
