### PR TITLE
A11Y: makes quote controls accessible

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/post-cooked.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-cooked.js
@@ -252,13 +252,16 @@ export default class PostCooked {
       let icon = iconHTML("arrow-up");
       navLink = `<a href='${this._urlForPostNumber(
         postNumber
-      )}' title='${quoteTitle}' class='back'>${icon}</a>`;
+      )}' title='${quoteTitle}' class='btn-flat back'>${icon}</a>`;
     }
 
     // Only add the expand/contract control if it's not a full post
     let expandContract = "";
+    const isExpanded = $aside.data("expanded") === true;
     if (!$aside.data("full")) {
-      expandContract = iconHTML(desc, { title: "post.expand_collapse" });
+      let icon = iconHTML(desc, { title: "post.expand_collapse" });
+      const quoteId = $aside.find("blockquote").attr("id");
+      expandContract = `<button aria-controls="${quoteId}" aria-expanded="${isExpanded}" class="quote-toggle btn-flat">${icon}</button>`;
       $(".title", $aside).css("cursor", "pointer");
     }
     if (this.ignoredUsers && this.ignoredUsers.length > 0) {
@@ -277,9 +280,14 @@ export default class PostCooked {
       return;
     }
 
-    $quotes.each((i, e) => {
+    $quotes.each((index, e) => {
       const $aside = $(e);
       if ($aside.data("post")) {
+        const quoteId = `quote-id-${$aside.data("topic")}-${$aside.data(
+          "post"
+        )}-${index}`;
+        $aside.find("blockquote").attr("id", quoteId);
+
         this._updateQuoteElements($aside, "chevron-down");
         const $title = $(".title", $aside);
 

--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -247,6 +247,12 @@ blockquote {
   color: var(--primary-low-mid-or-secondary-high);
 }
 
+.quote-controls {
+  .quote-toggle {
+    padding: 0;
+  }
+}
+
 .cooked .highlight {
   background-color: var(--tertiary-low);
   padding: 2px;


### PR DESCRIPTION
Note this commit is also changing the hover style of the toggler and the back arrow. It seems highly odd for such UI elements to have no hover states.

<img width="105" alt="Capture d’écran 2021-02-14 à 17 05 32" src="https://user-images.githubusercontent.com/339945/107881969-1bedc480-6ee7-11eb-8d5a-346731775ccb.png">

<img width="105" alt="Capture d’écran 2021-02-14 à 17 05 30" src="https://user-images.githubusercontent.com/339945/107881968-1b552e00-6ee7-11eb-865c-9b547b21520b.png">

TODO: this whole quote controls component is in dire need of a full refactoring, most of the code here is 5yo+ and is relying heavily on jquery.
