### PR TITLE
A11Y: sets has-popup as menu for select-kit components

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-header.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-header.js
@@ -71,7 +71,7 @@ export default Component.extend(UtilsMixin, {
     return this.selectKit.isExpanded ? "true" : "false";
   }),
 
-  ariaHasPopup: true,
+  ariaHasPopup: "menu",
 
   ariaOwns: computed("selectKit.uniqueID", function () {
     return `[data-select-kit-id=${this.selectKit.uniqueID}-body]`;


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
