### PR TITLE
UX: when auto-selecting topic make sure the focus is on selected topic

### DIFF
--- a/app/assets/javascripts/discourse/app/components/choose-topic.js
+++ b/app/assets/javascripts/discourse/app/components/choose-topic.js
@@ -113,6 +113,7 @@ export default Component.extend({
       this.set("selectedTopicId", topic.id);
       next(() => {
         document.getElementById(`choose-topic-${topic.id}`).checked = true;
+        document.getElementById(`choose-topic-${topic.id}`).focus();
       });
       if (this.topicChangedCallback) {
         this.topicChangedCallback(topic);


### PR DESCRIPTION
This commit sets the focus to selected topic instead of search bar when moving posts to an existing topic .

<img width="574" alt="Screenshot 2021-02-15 at 12 08 30 PM" src="https://user-images.githubusercontent.com/5732281/107913539-9ae60a00-6f86-11eb-83ff-b09255eca578.png">

Earlier the focus was on search bar and pressing enter key was reloading the page.