### PR TITLE
FIX: do not show SSO last payload to moderators

### DIFF
--- a/app/serializers/single_sign_on_record_serializer.rb
+++ b/app/serializers/single_sign_on_record_serializer.rb
@@ -7,4 +7,8 @@ class SingleSignOnRecordSerializer < ApplicationSerializer
              :external_name, :external_avatar_url,
              :external_profile_background_url,
              :external_card_background_url
+
+  def include_last_payload?
+    scope.is_admin?
+  end
 end

--- a/spec/serializers/single_sign_on_record_serializer_spec.rb
+++ b/spec/serializers/single_sign_on_record_serializer_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe SingleSignOnRecordSerializer do
   fab!(:user) { Fabricate(:user) }
   let :sso do
-    SingleSignOnRecord.create!(user_id: user.id, external_id: '12345', external_email: user.email, last_payload: '')
+    SingleSignOnRecord.create!(user_id: user.id, external_id: '12345', external_email: user.email, last_payload: 'foobar')
   end
 
   context "admin" do
@@ -19,6 +19,20 @@ RSpec.describe SingleSignOnRecordSerializer do
       expect(payload[:user_id]).to eq(user.id)
       expect(payload[:external_id]).to eq('12345')
       expect(payload[:external_email]).to be_nil
+    end
+  end
+
+  context "moderator" do
+    let(:moderator) { Fabricate(:moderator) }
+    let :serializer do
+      SingleSignOnRecordSerializer.new(sso, scope: Guardian.new(moderator), root: false)
+    end
+
+    it "should not include user sso payload" do
+      payload = serializer.as_json
+      expect(payload[:user_id]).to eq(user.id)
+      expect(payload[:external_id]).to eq('12345')
+      expect(payload[:last_payload]).to be_nil
     end
   end
 end


### PR DESCRIPTION
ref: https://meta.discourse.org/t/sso-payload-can-be-seen-be-moderators-again/174822/