### PR TITLE
UX: relative-time-picker should use pluralized strings

### DIFF
--- a/app/assets/javascripts/discourse/app/components/relative-time-picker.js
+++ b/app/assets/javascripts/discourse/app/components/relative-time-picker.js
@@ -36,13 +36,27 @@ export default Component.extend({
     }
   },
 
-  @discourseComputed
-  intervals() {
+  @discourseComputed("duration")
+  intervals(duration) {
+    const count = duration ? parseFloat(duration) : 0;
+
     return [
-      { id: "mins", name: I18n.t("relative_time_picker.minutes") },
-      { id: "hours", name: I18n.t("relative_time_picker.hours") },
-      { id: "days", name: I18n.t("relative_time_picker.days") },
-      { id: "months", name: I18n.t("relative_time_picker.months") },
+      {
+        id: "mins",
+        name: I18n.t("relative_time_picker.minutes", { count }),
+      },
+      {
+        id: "hours",
+        name: I18n.t("relative_time_picker.hours", { count }),
+      },
+      {
+        id: "days",
+        name: I18n.t("relative_time_picker.days", { count }),
+      },
+      {
+        id: "months",
+        name: I18n.t("relative_time_picker.months", { count }),
+      },
     ];
   },
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -576,10 +576,18 @@ en:
         send_email: "Send rejection email"
 
     relative_time_picker:
-      minutes: "minute(s)"
-      hours: "hour(s)"
-      days: "day(s)"
-      months: "month(s)"
+      minutes:
+        one: "minute"
+        other: "minutes"
+      hours:
+        one: "hour"
+        other: "hours"
+      days:
+        one: "day"
+        other: "days"
+      months:
+        one: "month"
+        other: "months"
 
     time_shortcut:
       later_today: "Later today"


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
