### PR TITLE
A11Y: Add rowheader to topic title TDs

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/bookmark-list.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/bookmark-list.hbs
@@ -26,7 +26,7 @@
                 {{/if}}
               </td>
             {{/if}}
-            <td class="main-link">
+            <td class="main-link" role="rowheader">
               <span class="link-top-line">
                 <div class="bookmark-metadata">
                   {{#if bookmark.name}}

--- a/app/assets/javascripts/discourse/app/templates/list/topic-list-item.hbr
+++ b/app/assets/javascripts/discourse/app/templates/list/topic-list-item.hbr
@@ -13,7 +13,7 @@
   This causes the topic-post-badge to be considered the same word as "text"
   at the end of the link, preventing it from line wrapping onto its own line.
 --}}
-<td class='main-link clearfix' colspan="1">
+<td class='main-link clearfix' colspan="1" role="rowheader">
   {{~raw-plugin-outlet name="topic-list-before-link"}}
   <span class='link-top-line'>
     {{~raw-plugin-outlet name="topic-list-before-status"}}


### PR DESCRIPTION
By setting the topic title cells as rowheaders they will be announced by screen readers when someone navigates vertically through the replies/views/activity column. 

We could also have switched to `th` here instead of keeping `td` and adding the role, but this avoids potentially messing with some CSS targets.  

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Row_Role
https://webaim.org/techniques/tables/data