### PR TITLE
FIX: Use autocomplete=discourse in select-kit to disable autocomplete in Chrome

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/modal/admin-merge-users-prompt.hbs
+++ b/app/assets/javascripts/admin/addon/templates/modal/admin-merge-users-prompt.hbs
@@ -3,7 +3,6 @@
     <p>{{html-safe (i18n "admin.user.merge.prompt.description" username=username)}}</p>
     {{email-group-user-chooser
       value=targetUsername
-      autocomplete="discourse"
       onChange=(action "updateUsername")
       options=(hash
         maximum=1

--- a/app/assets/javascripts/discourse/app/templates/components/composer-user-selector.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/composer-user-selector.hbs
@@ -1,7 +1,6 @@
 {{email-group-user-chooser
   id="private-message-users"
   tabindex="1"
-  autocomplete="discourse"
   value=splitRecipients
   onChange=(action "updateRecipients")
   options=(hash

--- a/app/assets/javascripts/discourse/app/templates/components/invite-panel.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/invite-panel.hbs
@@ -20,7 +20,6 @@
         {{#if allowExistingMembers}}
           {{email-group-user-chooser
             class="invite-user-input"
-            autocomplete="discourse"
             value=invitee
             onChange=(action "updateInvitee")
             options=(hash

--- a/app/assets/javascripts/discourse/app/templates/modal/change-owner.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/change-owner.hbs
@@ -11,7 +11,6 @@
     <label></label>
     {{email-group-user-chooser
       value=newOwner
-      autocomplete="discourse"
       autofocus=true
       onChange=(action "updateNewOwner")
       options=(hash

--- a/app/assets/javascripts/select-kit/addon/templates/components/select-kit/select-kit-filter.hbs
+++ b/app/assets/javascripts/select-kit/addon/templates/components/select-kit/select-kit-filter.hbs
@@ -3,7 +3,7 @@
     tabindex=-1
     class="filter-input"
     placeholder=placeholder
-    autocomplete="off"
+    autocomplete="discourse"
     autocorrect="off"
     autocapitalize="off"
     spellcheck=false


### PR DESCRIPTION
Chrome ignores `autocomplete="off"` on input fields, but as a workaround we can supply a nonsensical value (`discourse` or anything else) to the `autocomplete` attribute and it'll disable autocomplete.

Context: https://meta.discourse.org/t/-/107484/66?u=osama and https://meta.discourse.org/t/-/140884/13?u=osama.