### PR TITLE
Add bad_destination_address template to email_templates_controller

### DIFF
--- a/app/controllers/admin/email_templates_controller.rb
+++ b/app/controllers/admin/email_templates_controller.rb
@@ -20,6 +20,7 @@ class Admin::EmailTemplatesController < Admin::AdminController
       "system_messages.download_remote_images_disabled",
       "system_messages.email_error_notification",
       "system_messages.email_reject_auto_generated",
+      "system_messages.email_reject_bad_destination_address",
       "system_messages.email_reject_empty",
       "system_messages.email_reject_invalid_access",
       "system_messages.email_reject_parsing",

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -3163,7 +3163,7 @@ en:
 
           - Was the Message-ID header in the email modified? The Message-ID must be consistent and unchanged.
 
-        Need more help? Reach out to us via the Contact Us details at  %{base_url}/about
+        Need more help? Reach out to us via the Contact Us details at %{base_url}/about
 
     email_reject_old_destination:
       title: "Email Reject Old Destination"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -3155,7 +3155,15 @@ en:
       text_body_template: |
         We're sorry, but your email message to %{destination} (titled %{former_title}) didn't work.
 
-        Do you use more than one email address? Did you reply from a different email address? Email replies require that you use the same email address when replying. Alternately, the Message-ID header in the email may have been modified.
+        Here are some things to check:
+
+          - Do you use more than one email address? Did you reply from a different email address than the one you originally used? Email replies require that you use the same email address when replying.
+
+          - Did your email software properly use the Reply-To: email address when replying? Unfortunately, some email software incorrectly sends replies to the From: address, which won’t work.
+
+          - Was the Message-ID header in the email modified? The Message-ID must be consistent and unchanged.
+
+        Need more help? Reach out to us via the Contact Us details at  %{base_url}/about
 
     email_reject_old_destination:
       title: "Email Reject Old Destination"


### PR DESCRIPTION
This PR adds the `email_reject_bad_destination_address` template to the list of editable email templates. It also updates the email's copy in an attempt to help users resolve the error.

Related discussion on Meta: https://meta.discourse.org/t/confusion-due-to-replying-to-discourse-email-notifications/179513/1

If needed, I can create a separate PR for the copy changes.