### PR TITLE
UX: Fix excess line breaks in login modal alerts

### DIFF
--- a/app/assets/stylesheets/common/base/login.scss
+++ b/app/assets/stylesheets/common/base/login.scss
@@ -27,18 +27,6 @@
   }
 }
 
-.d-modal.login-modal {
-  #modal-alert:empty {
-    display: none;
-  }
-
-  #modal-alert:not(:empty) {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-  }
-}
-
 // Create Account + Login
 .d-modal.create-account,
 .d-modal.login-modal {
@@ -55,6 +43,19 @@
     top: 1em;
     right: 1em;
     z-index: z("max");
+  }
+  #modal-alert {
+    box-sizing: border-box;
+    display: inline-block;
+    // if you want to use flexbox here make sure child elements like <b> don't cause line breaks
+    padding: 1em 3.5em 1em 1em; // large right padding to make sure long text isn't under the close button
+    width: 100%;
+    max-width: 100%;
+    margin-bottom: 0;
+    min-height: 35px;
+  }
+  #modal-alert:empty {
+    display: none;
   }
   .login-welcome-header {
     z-index: z("modal", "content");

--- a/app/assets/stylesheets/desktop/login.scss
+++ b/app/assets/stylesheets/desktop/login.scss
@@ -13,9 +13,6 @@
       }
     }
   }
-  #modal-alert {
-    padding: 15px 16px;
-  }
   .btn-flat.btn.modal-close svg {
     color: rgba(var(--primary-rgb), 0.5);
     &:hover {
@@ -50,13 +47,6 @@
         }
       }
     }
-  }
-
-  #modal-alert {
-    max-width: 100%;
-    margin-bottom: 0;
-    padding: 8px 50px 8px 16px;
-    min-height: 35px;
   }
 
   .tip {


### PR DESCRIPTION
Flexbox was messing up the layout when there were child elements 

Before:

![image](https://user-images.githubusercontent.com/1681963/108145954-49c73a80-709a-11eb-8522-c65f2ac6bfa4.png)

After:

![IMG_3A27E0396AFA-1](https://user-images.githubusercontent.com/1681963/108146637-847da280-709b-11eb-9c7e-55f02715497f.jpeg)
