### PR TITLE
UX: change emailLogin to info class when input isEmpty

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-modal-body.js
+++ b/app/assets/javascripts/discourse/app/components/d-modal-body.js
@@ -62,7 +62,11 @@ export default Component.extend({
   },
 
   _clearFlash() {
-    $("#modal-alert").hide().removeClass("alert-error", "alert-success");
+    const modalAlert = document.getElementById("modal-alert");
+    if (modalAlert) {
+      modalAlert.style.display = "none";
+      modalAlert.classList.remove("alert-info", "alert-error", "alert-success");
+    }
   },
 
   _flash(msg) {

--- a/app/assets/javascripts/discourse/app/controllers/login.js
+++ b/app/assets/javascripts/discourse/app/controllers/login.js
@@ -310,7 +310,7 @@ export default Controller.extend(ModalFunctionality, {
       }
 
       if (isEmpty(this.loginName)) {
-        this.flash(I18n.t("login.blank_username"), "error");
+        this.flash(I18n.t("login.blank_username"), "info");
         return;
       }
 


### PR DESCRIPTION
When logging in via email it's not unusual to skip inputting your email first. Calling it an error (in red) is a bit harsh, a friendlier blue (info) works.

![Screen Shot 2021-02-16 at 9 54 25 PM](https://user-images.githubusercontent.com/1681963/108150010-eccf8280-70a1-11eb-96dd-e4af7110bab8.png)
