### PR TITLE
FIX: Bump max topic timer duration to 20 years

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/edit-topic-timer.js
+++ b/app/assets/javascripts/discourse/app/controllers/edit-topic-timer.js
@@ -178,8 +178,8 @@ export default Controller.extend(ModalFunctionality, {
           return;
         }
 
-        // cannot be more than 2 years
-        if (this.get("topicTimer.duration_minutes") > 2 * 365 * 1440) {
+        // cannot be more than 20 years
+        if (this.get("topicTimer.duration_minutes") > 20 * 365 * 1440) {
           this.flash(
             I18n.t("topic.topic_status_update.max_duration"),
             "alert-error"

--- a/app/models/topic_timer.rb
+++ b/app/models/topic_timer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class TopicTimer < ActiveRecord::Base
-  MAX_DURATION_MINUTES = 2.years.to_i / 60
+  MAX_DURATION_MINUTES = 20.years.to_i / 60
 
   self.ignored_columns = [
     "duration" # TODO(2021-06-01): remove

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2446,7 +2446,7 @@ en:
         when: "When:"
         time_frame_required: "Please select a time frame"
         min_duration: "Duration must be greater than 0"
-        max_duration: "Duration must be less than 2 years"
+        max_duration: "Duration must be less than 20 years"
       auto_update_input:
         none: "Select a timeframe"
         now: "Now"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -618,7 +618,7 @@ en:
               in_the_past: "must be in the future."
             duration_minutes:
               cannot_be_zero: "must be greater than 0."
-              exceeds_maximum: "cannot be more than 2 years."
+              exceeds_maximum: "cannot be more than 20 years."
         translation_overrides:
           attributes:
             value:

--- a/spec/models/topic_timer_spec.rb
+++ b/spec/models/topic_timer_spec.rb
@@ -31,10 +31,10 @@ RSpec.describe TopicTimer, type: :model do
           expect(topic_timer.errors.full_messages.first).to include("Duration minutes must be greater than 0.")
         end
 
-        it "does not allow crazy big durations (2 years in minutes)" do
-          topic_timer.duration_minutes = 3.years.to_i / 60
+        it "does not allow crazy big durations (20 years in minutes)" do
+          topic_timer.duration_minutes = 21.years.to_i / 60
           topic_timer.save
-          expect(topic_timer.errors.full_messages.first).to include("Duration minutes cannot be more than 2 years.")
+          expect(topic_timer.errors.full_messages.first).to include("Duration minutes cannot be more than 20 years.")
         end
       end
     end


### PR DESCRIPTION
This way it has some sort of cap, even if it seems pretty
high, and we don't have to worry about requests for increasing
it from 2 to 5 to 10 etc.

