### PR TITLE
DEV: prevents time difference causing flaky spec

### DIFF
--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -1612,12 +1612,12 @@ describe Topic do
 
         describe 'when new category is set to auto close by default' do
           before do
+            freeze_time
             new_category.update!(auto_close_hours: 5)
             topic.user.update!(admin: true)
           end
 
           it 'should set a topic timer' do
-            freeze_time
             now = Time.zone.now
 
             expect { topic.change_category_to_id(new_category.id) }

--- a/spec/support/time_matcher.rb
+++ b/spec/support/time_matcher.rb
@@ -2,7 +2,7 @@
 
 RSpec::Matchers.define :be_within_one_second_of do |expected_time|
   match do |actual_time|
-    (actual_time - expected_time).abs < 1
+    (actual_time - expected_time).abs <= 1
   end
   failure_message do |actual_time|
     "#{actual_time} is not within 1 second of #{expected_time}"


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
