### PR TITLE
DEV: adds within_one_minute time matcher

### DIFF
--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -1629,7 +1629,7 @@ describe Topic do
 
             expect(topic_timer.user).to eq(Discourse.system_user)
             expect(topic_timer.topic).to eq(topic)
-            expect(topic_timer.execute_at).to be_within_one_second_of(now + 5.hours)
+            expect(topic_timer.execute_at).to be_within_one_minute_of(now + 5.hours)
           end
 
           describe 'when topic is already closed' do

--- a/spec/support/time_matcher.rb
+++ b/spec/support/time_matcher.rb
@@ -2,7 +2,7 @@
 
 RSpec::Matchers.define :be_within_one_second_of do |expected_time|
   match do |actual_time|
-    (actual_time - expected_time).abs <= 1
+    (actual_time - expected_time).abs < 1
   end
   failure_message do |actual_time|
     "#{actual_time} is not within 1 second of #{expected_time}"
@@ -11,7 +11,7 @@ end
 
 RSpec::Matchers.define :be_within_one_minute_of do |expected_time|
   match do |actual_time|
-    (actual_time - expected_time).abs <= 60
+    (actual_time - expected_time).abs < 60
   end
   failure_message do |actual_time|
     "#{actual_time} is not within 1 minute of #{expected_time}"

--- a/spec/support/time_matcher.rb
+++ b/spec/support/time_matcher.rb
@@ -11,7 +11,7 @@ end
 
 RSpec::Matchers.define :be_within_one_minute_of do |expected_time|
   match do |actual_time|
-    (actual_time - expected_time).abs <= 69
+    (actual_time - expected_time).abs <= 60
   end
   failure_message do |actual_time|
     "#{actual_time} is not within 1 minute of #{expected_time}"

--- a/spec/support/time_matcher.rb
+++ b/spec/support/time_matcher.rb
@@ -9,6 +9,15 @@ RSpec::Matchers.define :be_within_one_second_of do |expected_time|
   end
 end
 
+RSpec::Matchers.define :be_within_one_minute_of do |expected_time|
+  match do |actual_time|
+    (actual_time - expected_time).abs <= 69
+  end
+  failure_message do |actual_time|
+    "#{actual_time} is not within 1 minute of #{expected_time}"
+  end
+end
+
 RSpec::Matchers.define :eq_time do |expected_time|
   match do |actual_time|
     (actual_time - expected_time).abs < 0.001


### PR DESCRIPTION
This matcher helps for cases where 1 second precision is not needed and might sometimes cause flaky specs.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
