### PR TITLE
FIX: hide sso payload behind a button click and log views

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-user-index.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-user-index.js
@@ -22,6 +22,7 @@ export default Controller.extend(CanCheckEmails, {
   availableGroups: null,
   userTitleValue: null,
   ssoExternalEmail: null,
+  ssoLastPayload: null,
 
   showBadges: setting("enable_badges"),
   hasLockedTrustLevel: notEmpty("model.manual_locked_trust_level"),
@@ -137,7 +138,7 @@ export default Controller.extend(CanCheckEmails, {
       .catch(() => bootbox.alert(I18n.t("generic_error")));
   },
 
-  @discourseComputed("model.single_sign_on_record.last_payload")
+  @discourseComputed("ssoLastPayload")
   ssoPayload(lastPayload) {
     return lastPayload.split("&");
   },
@@ -607,6 +608,16 @@ export default Controller.extend(CanCheckEmails, {
       }).then((result) => {
         if (result) {
           this.set("ssoExternalEmail", result.email);
+        }
+      });
+    },
+
+    checkSsoPayload() {
+      return ajax(userPath(`${this.model.username_lower}/sso-payload.json`), {
+        data: { context: window.location.pathname },
+      }).then((result) => {
+        if (result) {
+          this.set("ssoLastPayload", result.payload);
         }
       });
     },

--- a/app/assets/javascripts/admin/addon/templates/user-index.hbs
+++ b/app/assets/javascripts/admin/addon/templates/user-index.hbs
@@ -690,14 +690,23 @@
         <div class="field">{{i18n "admin.user.discourse_connect.external_avatar_url"}}</div>
         <div class="value">{{sso.external_avatar_url}}</div>
       </div>
-      {{#if sso.last_payload}}
+      {{#if canAdminCheckEmails}}
         <div class="display-row">
           <div class="field">{{i18n "admin.user.discourse_connect.last_payload"}}</div>
-          <div class="value">
-            {{#each ssoPayload as |line|}}
-              {{line}}<br>
-            {{/each}}
-          </div>
+          {{#if ssoLastPayload}}
+            <div class="value">
+              {{#each ssoPayload as |line|}}
+                {{line}}<br>
+              {{/each}}
+            </div>
+          {{else}}
+            {{d-button
+              class="btn-default"
+              action=(action "checkSsoPayload")
+              actionParam=model icon="far-list-alt"
+              label="admin.users.check_sso.text"
+              title="admin.users.check_sso.title"}}
+          {{/if}}
         </div>
       {{/if}}
     {{/with}}

--- a/app/serializers/single_sign_on_record_serializer.rb
+++ b/app/serializers/single_sign_on_record_serializer.rb
@@ -2,13 +2,9 @@
 
 class SingleSignOnRecordSerializer < ApplicationSerializer
   attributes :user_id, :external_id,
-             :last_payload, :created_at,
-             :updated_at, :external_username,
-             :external_name, :external_avatar_url,
+             :created_at, :updated_at,
+             :external_username, :external_name,
+             :external_avatar_url,
              :external_profile_background_url,
              :external_card_background_url
-
-  def include_last_payload?
-    scope.is_admin?
-  end
 end

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4676,6 +4676,9 @@ en:
         check_email:
           title: "Reveal this user's email address"
           text: "Show"
+        check_sso:
+          title: "Reveal SSO payload"
+          text: "Show"
 
       user:
         suspend_failed: "Something went wrong suspending this user %{error}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -446,6 +446,7 @@ Discourse::Application.routes.draw do
       put "#{root_path}/:username" => "users#update", constraints: { username: RouteFormat.username }, defaults: { format: :json }
       get "#{root_path}/:username/emails" => "users#check_emails", constraints: { username: RouteFormat.username }
       get "#{root_path}/:username/sso-email" => "users#check_sso_email", constraints: { username: RouteFormat.username }
+      get "#{root_path}/:username/sso-payload" => "users#check_sso_payload", constraints: { username: RouteFormat.username }
       get "#{root_path}/:username/preferences" => "users#preferences", constraints: { username: RouteFormat.username }
       get "#{root_path}/:username/preferences/email" => "users_email#index", constraints: { username: RouteFormat.username }
       get "#{root_path}/:username/preferences/account" => "users#preferences", constraints: { username: RouteFormat.username }

--- a/lib/guardian/user_guardian.rb
+++ b/lib/guardian/user_guardian.rb
@@ -92,7 +92,7 @@ module UserGuardian
     is_admin? || (is_staff? && SiteSetting.moderators_view_emails)
   end
 
-  def can_check_sso_email?(user)
+  def can_check_sso_details?(user)
     user && is_admin?
   end
 


### PR DESCRIPTION
The SSO payload on admin user page will now be behind a button click. Clicking on which "check email" entry will be logged.

<img width="422" alt="Screenshot 2021-02-17 at 17 26 26" src="https://user-images.githubusercontent.com/5732281/108203335-60c46600-7148-11eb-930b-8f0b22787023.png">
