### PR TITLE
UX: Add editing guidance for remote themes

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/customize-themes-show.hbs
+++ b/app/assets/javascripts/admin/addon/templates/customize-themes-show.hbs
@@ -84,6 +84,9 @@
 
       <div class="control-unit">
         {{#if model.remote_theme.is_git}}
+          <div class="alert alert-info">
+            {{html-safe (i18n "admin.customize.theme.remote_theme_edits" repoURL=remoteThemeLink)}}
+          </div>
 
           {{#if showRemoteError}}
             <div class="error-message">

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4230,6 +4230,7 @@ en:
             one: "Theme is %{count} commit behind!"
             other: "Theme is %{count} commits behind!"
           compare_commits: "(See new commits)"
+          remote_theme_edits: "If you want to edit this theme, you must <a href='%{repoURL}' target='_blank'>submit a change on its repository</a>"
           repo_unreachable: "Couldn't contact the Git repository of this theme. Error message:"
           imported_from_archive: "This theme was imported from a .zip file"
           scss:


### PR DESCRIPTION
Context: https://meta.discourse.org/t/unable-to-find-edit-html-css-for-default-selected-theme/178516 

@eviltrout 95% of theme/component repos are in Github, but that last 5% made me change the link copy from "submit a change on GitHub" to "submit a change on its repository". 