### PR TITLE
UX: Remove margin from security key login button

### DIFF
--- a/app/assets/stylesheets/common/base/login.scss
+++ b/app/assets/stylesheets/common/base/login.scss
@@ -304,9 +304,6 @@ button#new-account-link {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  button {
-    margin-right: 1.5em;
-  }
   p {
     margin: 0;
     font-size: $font-0;


### PR DESCRIPTION
This commit removes the right margin from the security key button in the login with security key screen.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
