### PR TITLE
FIX: NewPostManager should respect category_group_moderator settings

### DIFF
--- a/lib/new_post_manager.rb
+++ b/lib/new_post_manager.rb
@@ -120,9 +120,12 @@ class NewPostManager
     if manager.args[:topic_id].present?
       cat = Category.joins(:topics).find_by(topics: { id: manager.args[:topic_id] })
       return false unless cat
-      cat.require_reply_approval?
+
+      topic = Topic.find(manager.args[:topic_id])
+      cat.require_reply_approval? && !manager.user.guardian.can_review_topic?(topic)
     elsif manager.args[:category].present?
-      Category.find(manager.args[:category]).require_topic_approval?
+      cat = Category.find(manager.args[:category])
+      cat.require_topic_approval? && !manager.user.guardian.is_category_group_moderator?(cat)
     else
       false
     end


### PR DESCRIPTION
NewPostManager’s `post_needs_approval_in_its_category` method should allow category group moderators to create topics/reply to topics that where they have appropraite permissions.

(ie, if a user has permission to moderate a post, any posts made by them shouldn’t be sent to moderation)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
