### PR TITLE
UX: On very short screens switch quick-access-profile to 2-columns

### DIFF
--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -365,7 +365,6 @@
       }
       @media screen and (max-height: 360px) {
         // two column grid to avoid scroll
-
         ul {
           display: grid;
           grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -360,10 +360,12 @@
         color: var(--primary);
         display: flex;
       }
-    }
+      ul button {
+        line-height: 1.4; // match 'ul a' link height
+      }
+      @media screen and (max-height: 360px) {
+        // two column grid to avoid scroll
 
-    @media screen and (max-height: 450px) {
-      &.quick-access-profile {
         ul {
           display: grid;
           grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -372,7 +374,9 @@
             @include ellipsis;
           }
           button {
-            line-height: 1.4; // match link style
+            span:not(.relative-date) {
+              @include ellipsis;
+            }
           }
         }
         li:not(.show-all) a {

--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -356,16 +356,29 @@
 
     &.quick-access-profile {
       display: inline;
-      overflow-y: auto; // There's no "show all" for this content, so it always needs to be scrollable
-      ul {
-        display: inline;
-        a {
-          box-sizing: border-box; // without this you end up with horizontal scroll
-        }
-      }
       li:not(.show-all) a {
         color: var(--primary);
         display: flex;
+      }
+    }
+
+    @media screen and (max-height: 450px) {
+      &.quick-access-profile {
+        ul {
+          display: grid;
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+          grid-gap: 0 1em;
+          a {
+            @include ellipsis;
+          }
+          button {
+            line-height: 1.4; // match link style
+          }
+        }
+        li:not(.show-all) a {
+          color: var(--primary);
+          display: flex;
+        }
       }
     }
   }

--- a/app/assets/stylesheets/mobile/menu-panel.scss
+++ b/app/assets/stylesheets/mobile/menu-panel.scss
@@ -30,6 +30,11 @@
   button {
     // accounts for menu "ears" 4px + border 1px
     padding: 0.75em calc(0.5em + 4px + 1px);
+    @media screen and (max-height: 380px) {
+      // reduce padding to avoid scroll
+      padding-top: 0.5em;
+      padding-bottom: 0.5em;
+    }
   }
 }
 


### PR DESCRIPTION
We've eliminated scrolling from these panels and truncate content instead, but the user panel has some important links (like logout) that need to be visible. Previously I tried to make these scrollable but scrolling was a bit problematic on iOS.

Now they'll display in 2-columns with reduced padding on very short screens (360px and shorter). 

![Screen Shot 2021-02-15 at 11 35 09 PM](https://user-images.githubusercontent.com/1681963/108304548-443f2280-7176-11eb-84bc-c261ca8f9615.png)
