### PR TITLE
UX: Show bullets for some composer popup lists

### DIFF
--- a/app/assets/stylesheets/desktop/compose.scss
+++ b/app/assets/stylesheets/desktop/compose.scss
@@ -137,9 +137,13 @@
   }
 
   ul {
-    list-style: none;
     margin: 0;
-    padding: 0;
+    padding: 0 0 0 1.5em;
+    &.list,
+    &.topics {
+      list-style: none;
+      padding: 0;
+    }
 
     li {
       font-weight: normal;


### PR DESCRIPTION
They need to be suppressed in lists of topics, but not text lists. 

Before:
![Screen Shot 2021-02-18 at 12 23 05 AM](https://user-images.githubusercontent.com/1681963/108309416-802ab580-717f-11eb-828c-1c8400603c68.png)

After:
![Screen Shot 2021-02-18 at 12 21 09 AM](https://user-images.githubusercontent.com/1681963/108309406-7bfe9800-717f-11eb-8f63-ca9b9ec7e106.png)
