### PR TITLE
UX: publishes page, on public change, only when page is published

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/publish-page.js
+++ b/app/assets/javascripts/discourse/app/controllers/publish-page.js
@@ -122,6 +122,9 @@ export default Controller.extend(ModalFunctionality, StateHelpers, {
   @action
   onChangePublic(isPublic) {
     this.publishedPage.set("public", isPublic);
-    this.publish();
+
+    if (this.showUnpublish) {
+      this.publish();
+    }
   },
 });

--- a/app/assets/javascripts/discourse/app/templates/modal/publish-page.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/publish-page.hbs
@@ -23,7 +23,7 @@
           <p class="description">
             {{input
               type="checkbox"
-              checked=publishedPage.public
+              checked=(readonly publishedPage.public)
               click=(action "onChangePublic" value="target.checked")
             }}
             {{i18n "topic.publish_page.public_description"}}


### PR DESCRIPTION
Note that this commit also prevents a side effect to happen with the checkbox directly mutating publishedPage.public

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
