### PR TITLE
FIX: Delete topic timers far in the future

### DIFF
--- a/db/post_migrate/20210207232853_fix_topic_timer_duration_minutes.rb
+++ b/db/post_migrate/20210207232853_fix_topic_timer_duration_minutes.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 class FixTopicTimerDurationMinutes < ActiveRecord::Migration[6.0]
   def up
+    DB.exec("DELETE FROM topic_timers WHERE status_type = 7 AND duration > 20 * 365")
+    DB.exec("DELETE FROM topic_timers WHERE status_type != 7 AND duration > 20 * 365 * 24")
+
     DB.exec("UPDATE topic_timers SET duration_minutes = (duration * 60 * 24) WHERE duration_minutes IS NULL AND status_type = 7 AND duration IS NOT NULL")
     DB.exec("UPDATE topic_timers SET duration_minutes = (duration * 60) WHERE duration_minutes IS NULL AND status_type != 7 AND duration IS NOT NULL")
   end


### PR DESCRIPTION
The migration used to fail because the same duration in minutes was out
of the integer range. The '20 years' limit was introduced in e0f0fe5.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
