### PR TITLE
Include UI commits when generating release notes.

### DIFF
--- a/lib/tasks/release_note.rake
+++ b/lib/tasks/release_note.rake
@@ -88,7 +88,7 @@ end
 def normalize_terms(text)
   text = text.gsub(/(BUGFIX|FIX|BUG):/i, "FIX:")
   text = text.gsub(/FEATURE:/i, "FEATURE:")
-  text = text.gsub(/UX:/i, "UX:")
+  text = text.gsub(/(UX|UI):/i, "UX:")
   text = text.gsub(/(SECURITY):/i, "SECURITY:")
   text = text.gsub(/(PERF):/i, "PERF:")
   text = text.gsub(/(A11Y):/i, "A11Y:")


### PR DESCRIPTION
UX is the officially supported prefix per https://meta.discourse.org/t/19392, but sometimes UI is used instead. We should still include those commits.
