### PR TITLE
FIX: Don't update `posts_read_count` when the post is from a PM.

### DIFF
--- a/app/models/post_timing.rb
+++ b/app/models/post_timing.rb
@@ -40,6 +40,8 @@ class PostTiming < ActiveRecord::Base
     # still happen, if it happens we just don't care, its an invalid record anyway
     return if row_count == 0
     Post.where(['topic_id = :topic_id and post_number = :post_number', args]).update_all 'reads = reads + 1'
+
+    return if Topic.exists?(id: args[:topic_id], archetype: Archetype.private_message)
     UserStat.where(user_id: args[:user_id]).update_all 'posts_read_count = posts_read_count + 1'
   end
 

--- a/spec/models/post_timing_spec.rb
+++ b/spec/models/post_timing_spec.rb
@@ -148,6 +148,15 @@ describe PostTiming do
       }.to change(@post, :reads).by(1)
     end
 
+    it "doesn't update the posts read count if the topic is a PM" do
+      pm = Fabricate(:private_message_post).topic
+      @timing_attrs = @timing_attrs.merge(topic_id: pm.id)
+
+      PostTiming.record_timing(@timing_attrs)
+
+      expect(@coding_horror.user_stat.posts_read_count).to eq(0)
+    end
+
     describe 'multiple calls' do
       it 'correctly works' do
         PostTiming.record_timing(@timing_attrs)


### PR DESCRIPTION
We don't want TL0 users doing the discobot tutorial to increase their read count.

