### PR TITLE
UX: Warn when changing category to the Schedule Publishing target

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/topic.js
+++ b/app/assets/javascripts/discourse/app/controllers/topic.js
@@ -5,6 +5,7 @@ import discourseComputed, { observes } from "discourse-common/utils/decorators";
 import { isEmpty, isPresent } from "@ember/utils";
 import { later, next, schedule } from "@ember/runloop";
 import { AUTO_DELETE_PREFERENCES } from "discourse/models/bookmark";
+import Category from "discourse/models/category";
 import Composer from "discourse/models/composer";
 import EmberObject from "@ember/object";
 import I18n from "I18n";
@@ -13,6 +14,7 @@ import { Promise } from "rsvp";
 import QuoteState from "discourse/lib/quote-state";
 import Topic from "discourse/models/topic";
 import TopicTimer from "discourse/models/topic-timer";
+import { PUBLISH_TO_CATEGORY_STATUS_TYPE } from "discourse/controllers/edit-topic-timer";
 import { ajax } from "discourse/lib/ajax";
 import bootbox from "bootbox";
 import { bufferedProperty } from "discourse/mixins/buffered-content";
@@ -115,6 +117,27 @@ export default Controller.extend(bufferedProperty("model"), {
   @discourseComputed("model.postStream.loaded", "model.is_shared_draft")
   showSharedDraftControls(loaded, isSharedDraft) {
     return loaded && isSharedDraft;
+  },
+
+  @discourseComputed(
+    "model.topic_timer.status_type",
+    "model.topic_timer.category_id",
+    "buffered.category_id"
+  )
+  showScheduledPublishWarning(statusType, plannedCategoryId, newCategoryId) {
+    return (
+      statusType === PUBLISH_TO_CATEGORY_STATUS_TYPE &&
+      plannedCategoryId === newCategoryId
+    );
+  },
+
+  @discourseComputed("model.topic_timer.category_id")
+  scheduledPublishCategoryName(categoryId) {
+    const category = Category.findById(categoryId);
+    if (!category) {
+      return I18n.t("category.none");
+    }
+    return category.get("slug");
   },
 
   @discourseComputed("site.mobileView", "model.posts_count")

--- a/app/assets/javascripts/discourse/app/templates/topic.hbs
+++ b/app/assets/javascripts/discourse/app/templates/topic.hbs
@@ -43,6 +43,12 @@
 
             {{plugin-outlet name="edit-topic" args=(hash model=model buffered=buffered)}}
 
+            {{#if showScheduledPublishWarning}}
+              <div class="alert alert-danger category-change-warning">
+                {{i18n "topic.publish_to_category.category_change_warning" categoryName=this.scheduledPublishCategoryName}}
+              </div>
+            {{/if}}
+
             <div class="edit-controls">
               {{d-button action=(action "finishedEditingTopic") class="btn-primary submit-edit" icon="check"}}
               {{d-button action=(action "cancelEditingTopic") class="btn-default cancel-edit" icon="times"}}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2467,6 +2467,7 @@ en:
         set_based_on_last_post: "Close based on last post"
       publish_to_category:
         title: "Schedule Publishing"
+        category_change_warning: "This topic is already scheduled to be published to #%{categoryName}. Remove the topic timer first."
       temp_open:
         title: "Open Temporarily"
       auto_reopen:


### PR DESCRIPTION
The scheduled publishing topic timer can be very far away from the category edit controls. Surface the fact that it's present when you try to edit the category.

This is a non-blocking warning only, you aren't actually prevented from saving the change.

![image](https://user-images.githubusercontent.com/627891/108429750-3c729300-71f5-11eb-9065-93a4387bc05e.png)


<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->

