### PR TITLE
FIX: ensure corrected migration runs

### DIFF
--- a/db/post_migrate/20210218022739_move_new_since_to_new_table_again.rb
+++ b/db/post_migrate/20210218022739_move_new_since_to_new_table_again.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class MoveNewSinceToNewTable < ActiveRecord::Migration[6.0]
+class MoveNewSinceToNewTableAgain < ActiveRecord::Migration[6.0]
   disable_ddl_transaction!
   BATCH_SIZE = 30_000
 


### PR DESCRIPTION
Some instances may have ran earier version of the migration. Ensure newer
one runs instead.
