### PR TITLE
FIX: Do not allow bookmarks to use post date in past for reminder

### DIFF
--- a/app/assets/javascripts/discourse/app/components/bookmark.js
+++ b/app/assets/javascripts/discourse/app/components/bookmark.js
@@ -294,8 +294,8 @@ export default Component.extend({
     }
 
     let postLocalDateTime = this._postLocalDate();
-    if (postLocalDateTime < now()) {
-      return false;
+    if (postLocalDateTime < now(this.userTimezone)) {
+      return;
     }
 
     return true;

--- a/app/assets/javascripts/discourse/app/components/bookmark.js
+++ b/app/assets/javascripts/discourse/app/components/bookmark.js
@@ -20,7 +20,7 @@ import { ajax } from "discourse/lib/ajax";
 import bootbox from "bootbox";
 import discourseComputed, { on } from "discourse-common/utils/decorators";
 import { formattedReminderTime } from "discourse/lib/bookmark";
-import { and, notEmpty, or } from "@ember/object/computed";
+import { and, notEmpty } from "@ember/object/computed";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { later } from "@ember/runloop";
 
@@ -284,9 +284,22 @@ export default Component.extend({
   showExistingReminderAt: notEmpty("model.reminderAt"),
   showDelete: notEmpty("model.id"),
   userHasTimezoneSet: notEmpty("userTimezone"),
-  showPostLocalDate: or("postDetectedLocalDate", "postDetectedLocalTime"),
   editingExistingBookmark: and("model", "model.id"),
   existingBookmarkHasReminder: and("model", "model.reminderAt"),
+
+  @discourseComputed("postDetectedLocalDate", "postDetectedLocalTime")
+  showPostLocalDate(postDetectedLocalDate, postDetectedLocalTime) {
+    if (!postDetectedLocalTime || !postDetectedLocalDate) {
+      return;
+    }
+
+    let postLocalDateTime = this._postLocalDate();
+    if (postLocalDateTime < now()) {
+      return false;
+    }
+
+    return true;
+  },
 
   @discourseComputed()
   autoDeletePreferences: () => {

--- a/app/assets/javascripts/discourse/tests/acceptance/bookmarks-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/bookmarks-test.js
@@ -11,11 +11,11 @@ import { test } from "qunit";
 import topicFixtures from "discourse/tests/fixtures/topic";
 import KeyboardShortcutInitializer from "discourse/initializers/keyboard-shortcuts";
 
-async function openBookmarkModal() {
-  if (exists(".topic-post:first-child button.show-more-actions")) {
-    await click(".topic-post:first-child button.show-more-actions");
+async function openBookmarkModal(postNumber = 1) {
+  if (exists(`#post_${postNumber} button.show-more-actions`)) {
+    await click(`#post_${postNumber} button.show-more-actions`);
   }
-  await click(".topic-post:first-child button.bookmark");
+  await click(`#post_${postNumber} button.bookmark`);
 }
 
 async function openEditBookmarkModal() {
@@ -32,7 +32,16 @@ acceptance("Bookmarking", function (needs) {
   });
 
   const topicResponse = topicFixtures["/t/280/1.json"];
-  topicResponse.post_stream.posts[0].cooked += `<span data-date="2021-01-15" data-time="00:35:00" class="discourse-local-date cooked-date past" data-timezone="Europe/London">
+  topicResponse.post_stream.posts[0].cooked += `<span data-date="2036-01-15" data-time="00:35:00" class="discourse-local-date cooked-date past" data-timezone="Europe/London">
+  <span>
+    <svg class="fa d-icon d-icon-globe-americas svg-icon" xmlns="http://www.w3.org/2000/svg">
+      <use xlink:href="#globe-americas"></use>
+    </svg>
+    <span class="relative-time">January 15, 2036 12:35 AM</span>
+  </span>
+</span>`;
+
+  topicResponse.post_stream.posts[1].cooked += `<span data-date="2021-01-15" data-time="00:35:00" class="discourse-local-date cooked-date past" data-timezone="Europe/London">
   <span>
     <svg class="fa d-icon d-icon-globe-americas svg-icon" xmlns="http://www.w3.org/2000/svg">
       <use xlink:href="#globe-americas"></use>
@@ -225,7 +234,7 @@ acceptance("Bookmarking", function (needs) {
   test("Using a post date for the reminder date", async function (assert) {
     await visit("/t/internationalization-localization/280");
     let postDate = moment.tz(
-      "2021-01-15",
+      "2036-01-15",
       loggedInUser().resolvedTimezone(loggedInUser())
     );
     let postDateFormatted = postDate.format("YYYY-MM-DD");
@@ -248,6 +257,15 @@ acceptance("Bookmarking", function (needs) {
       queryAll("#custom-time").val(),
       "10:35",
       "it should prefill the bookmark time"
+    );
+  });
+
+  test("Cannot use the post date for a reminder when the post date is in the past", async function (assert) {
+    await visit("/t/internationalization-localization/280");
+    await openBookmarkModal(2);
+    assert.notOk(
+      exists("#tap_tile_post_local_date"),
+      "it does not show the local date tile"
     );
   });
 });


### PR DESCRIPTION
See https://meta.discourse.org/t/bookmark-reminder-date-in-post-in-the-past/180128