### PR TITLE
DEV: More refactoring of SCSS importers

### DIFF
--- a/app/assets/stylesheets/common/foundation/variables.scss
+++ b/app/assets/stylesheets/common/foundation/variables.scss
@@ -77,7 +77,6 @@ $line-height-large: 1.4; // Normal or small text
 // These files don't actually exist. They're injected by Stylesheet::Compiler.
 // --------------------------------------------------
 
-@import "theme_colors";
 @import "plugins_variables";
 @import "common/foundation/math";
 

--- a/lib/stylesheet/compiler.rb
+++ b/lib/stylesheet/compiler.rb
@@ -9,12 +9,13 @@ module Stylesheet
   class Compiler
 
     def self.compile_asset(asset, options = {})
-      file = "@import \"common/foundation/variables\"; @import \"common/foundation/mixins\";"
+      importer = Importer.new(options)
+      file = importer.prepended_scss
 
       if Importer::THEME_TARGETS.include?(asset.to_s)
         filename = "theme_#{options[:theme_id]}.scss"
         file += options[:theme_variables].to_s
-        file += Importer.new({ theme_id: options[:theme_id] }).theme_import(asset)
+        file += importer.theme_import(asset)
       elsif Importer.special_imports[asset.to_s]
         filename = "theme_#{options[:theme_id]}.scss"
         file += " @import \"#{asset}\";"
@@ -24,13 +25,12 @@ module Stylesheet
         file += File.read path
 
         if asset.to_s == Stylesheet::Manager::COLOR_SCHEME_STYLESHEET
-          file += Stylesheet::Importer.import_color_definitions(options[:theme_id])
-          file += Stylesheet::Importer.import_wcag_overrides(options[:color_scheme_id])
+          file += importer.import_color_definitions
+          file += importer.import_wcag_overrides
         end
       end
 
       compile(file, filename, options)
-
     end
 
     def self.compile(stylesheet, filename, options = {})

--- a/spec/components/stylesheet/importer_spec.rb
+++ b/spec/components/stylesheet/importer_spec.rb
@@ -80,7 +80,7 @@ describe Stylesheet::Importer do
     }}
 
     it "should include color definitions in the theme" do
-      styles = Stylesheet::Importer.import_color_definitions(theme.id)
+      styles = Stylesheet::Importer.new({ theme_id: theme.id }).import_color_definitions
       expect(styles).to include(scss)
     end
 
@@ -88,14 +88,14 @@ describe Stylesheet::Importer do
       theme.add_relative_theme!(:child, child)
       theme.save!
 
-      styles = Stylesheet::Importer.import_color_definitions(theme.id)
+      styles = Stylesheet::Importer.new({ theme_id: theme.id }).import_color_definitions
       expect(styles).to include(scss_child)
       expect(styles).to include("Color definitions from Child Theme")
     end
 
     it "should include default theme color definitions" do
       SiteSetting.default_theme_id = theme.id
-      styles = Stylesheet::Importer.import_color_definitions(nil)
+      styles = Stylesheet::Importer.new({}).import_color_definitions
       expect(styles).to include(scss)
     end
   end
@@ -103,12 +103,12 @@ describe Stylesheet::Importer do
   context "#import_wcag_overrides" do
     it "should do nothing on a regular scheme" do
       scheme = ColorScheme.create_from_base(name: 'Regular')
-      expect(Stylesheet::Importer.import_wcag_overrides(scheme.id)).to eq("")
+      expect(Stylesheet::Importer.new({ color_scheme_id: scheme.id }).import_wcag_overrides).to eq("")
     end
 
     it "should include WCAG overrides for WCAG based scheme" do
       scheme = ColorScheme.create_from_base(name: 'WCAG New', base_scheme_id: "WCAG Dark")
-      expect(Stylesheet::Importer.import_wcag_overrides(scheme.id)).to eq("@import \"wcag\";")
+      expect(Stylesheet::Importer.new({ color_scheme_id: scheme.id }).import_wcag_overrides).to eq("@import \"wcag\";")
     end
   end
 end

--- a/spec/components/stylesheet/manager_spec.rb
+++ b/spec/components/stylesheet/manager_spec.rb
@@ -315,7 +315,6 @@ describe Stylesheet::Manager do
         theme.add_relative_theme!(:child, child)
         theme.save!
 
-        # the correct base colors are passed
         stylesheet = Stylesheet::Manager.new(:color_definitions, theme.id, dark_scheme).compile(force: true)
         expect(stylesheet).to include("--special: rebeccapurple")
         expect(stylesheet).to include("--child-definition: #fff")


### PR DESCRIPTION
- Removes the `theme_colors` custom importer (styles are prepended instead)
- Fixes a regression whereby the current color scheme was not being used when compiling color definitions in a theme component

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
