### PR TITLE
FEATURE: Use the "time_read" stat to flag users as suspicious.

### DIFF
--- a/app/jobs/scheduled/enqueue_suspect_users.rb
+++ b/app/jobs/scheduled/enqueue_suspect_users.rb
@@ -16,7 +16,7 @@ module Jobs
         .joins(:user_profile, :user_stat)
         .where("users.created_at <= ? AND users.created_at >= ?", 1.day.ago, 6.months.ago)
         .where("LENGTH(COALESCE(user_profiles.bio_raw, user_profiles.website, '')) > 0")
-        .where("user_stats.posts_read_count <= 1 AND user_stats.topics_entered <= 1")
+        .where("user_stats.posts_read_count <= 1 OR user_stats.topics_entered <= 1 OR user_stats.time_read < ?", 5.minutes.to_i)
         .joins("LEFT OUTER JOIN reviewables r ON r.target_id = users.id AND r.target_type = 'User'")
         .where('r.id IS NULL')
         .joins(

--- a/spec/jobs/enqueue_suspect_users_spec.rb
+++ b/spec/jobs/enqueue_suspect_users_spec.rb
@@ -12,7 +12,7 @@ describe Jobs::EnqueueSuspectUsers do
   end
 
   context 'with suspect users' do
-    fab!(:suspect_user) { Fabricate(:active_user, created_at: 1.day.ago) }
+    let!(:suspect_user) { Fabricate(:active_user, created_at: 1.day.ago) }
 
     it 'creates a reviewable when there is a suspect user' do
       subject.execute({})
@@ -87,6 +87,22 @@ describe Jobs::EnqueueSuspectUsers do
       subject.execute({})
 
       expect(ReviewableUser.where(target: suspect_user).exists?).to eq(false)
+    end
+
+    it 'enqueues a suspect user with not enough time read' do
+      suspect_user.user_stat.update!(posts_read_count: 2, topics_entered: 2, time_read: 1.minute.to_i)
+
+      subject.execute({})
+
+      expect(ReviewableUser.count).to eq(1)
+    end
+
+    it 'ignores users if their time read is higher than five minutes' do
+      suspect_user.user_stat.update!(posts_read_count: 2, topics_entered: 2, time_read: 10.minutes.to_i)
+
+      subject.execute({})
+
+      expect(ReviewableUser.count).to eq(0)
     end
   end
 end


### PR DESCRIPTION
Completing the discobot tutorial gives you ~3m of reading time, so we set the limit at 5m. Additionally, we use an "OR" clause to cover the case when you just scroll through a single topic.

