### PR TITLE
DEV: Drop old SSO site setting rows from the database

### DIFF
--- a/db/migrate/20210204135429_rename_sso_site_settings.rb
+++ b/db/migrate/20210204135429_rename_sso_site_settings.rb
@@ -25,7 +25,7 @@ class RenameSsoSiteSettings < ActiveRecord::Migration[6.0]
 
   def up
     # Copying the rows so that things keep working during deploy
-    # TODO: Add a post-deploy migration to drop the old rows
+    # They will be dropped in post_migrate/20210219171329_drop_old_sso_site_settings
 
     RENAME_SETTINGS.each do |old_name, new_name|
       execute <<~SQL

--- a/db/post_migrate/20210219171329_drop_old_sso_site_settings.rb
+++ b/db/post_migrate/20210219171329_drop_old_sso_site_settings.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class DropOldSsoSiteSettings < ActiveRecord::Migration[6.0]
+  def up
+    # These were copied to their new names in migrate/20210204135429_rename_sso_site_settings
+    execute <<~SQL
+      DELETE FROM site_settings
+      WHERE name IN (
+        'enable_sso',
+        'sso_allows_all_return_paths',
+        'enable_sso_provider',
+        'verbose_sso_logging',
+        'sso_url',
+        'sso_secret',
+        'sso_provider_secrets',
+        'sso_overrides_groups',
+        'sso_overrides_bio',
+        'sso_overrides_email',
+        'sso_overrides_username',
+        'sso_overrides_name',
+        'sso_overrides_avatar',
+        'sso_overrides_profile_background',
+        'sso_overrides_location',
+        'sso_overrides_website',
+        'sso_overrides_card_background',
+        'external_auth_skip_create_confirm',
+        'external_auth_immediately'
+      )
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
These were copied to their new names in 821bb1e8cb72bee56cf5c2a878043112cc7ea2fd

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
