### PR TITLE
DEV: Scope `query` to the testing container

### DIFF
--- a/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
+++ b/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
@@ -413,7 +413,7 @@ export function queryAll(selector, context) {
 }
 
 export function query() {
-  return document.querySelector(...arguments);
+  return document.querySelector("#ember-testing").querySelector(...arguments);
 }
 
 export function invisible(selector) {


### PR DESCRIPTION
We don't want it to find QUnit UI elements… This fixes some Ember CLI test failures.
