### PR TITLE
FIX: Close navigation dropdown when item selected

### DIFF
--- a/app/assets/javascripts/discourse/app/components/navigation-bar.js
+++ b/app/assets/javascripts/discourse/app/components/navigation-bar.js
@@ -52,7 +52,7 @@ export default Component.extend(FilterModeMixin, {
   },
 
   ensureDropClosed() {
-    if (!this.expanded) {
+    if (this.expanded) {
       this.set("expanded", false);
     }
     $(window).off("click.navigation-bar");


### PR DESCRIPTION
This `if` statement was backwards, such that it was a no-op. This hasn't
caused a problem because clicking an item triggers a page load, which
destroys and recreates the component.

However, we are soon planning to remove the intermediate loading screen,
which means the component will not be removed/recreated.

https://meta.discourse.org/t/177939/202

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
