### PR TITLE
UX: More consistent group mention style

### DIFF
--- a/app/assets/stylesheets/common/base/group.scss
+++ b/app/assets/stylesheets/common/base/group.scss
@@ -3,11 +3,7 @@
 // For example: .group .user-secondary-navigation
 
 span.mention-group {
-  color: var(--primary-high-or-secondary-low);
-  padding: 2px 4px;
-  border-radius: 8px;
-  font-weight: 600;
-  font-size: $font-down-1;
+  color: var(--primary);
 }
 
 .group-details-container {


### PR DESCRIPTION
Lived with the current style for a while, but it bugs me a little because it's not really in the style of notifications _or_ mentions... it exists in its own in-between state.

We had extra space, a smaller font, and bold before... removing that for black text at the same size without bold. 

Before:
![Screen Shot 2021-02-19 at 5 41 38 PM](https://user-images.githubusercontent.com/1681963/108569455-eaf00400-72d9-11eb-9106-9c179a00864b.png)

After:
![Screen Shot 2021-02-19 at 5 39 49 PM](https://user-images.githubusercontent.com/1681963/108569468-ef1c2180-72d9-11eb-95cc-26c9e0118660.png)

