### PR TITLE
UX: Skip github commit avatars for topic/post thumbnails

### DIFF
--- a/lib/cooked_post_processor.rb
+++ b/lib/cooked_post_processor.rb
@@ -209,6 +209,7 @@ class CookedPostProcessor
     @doc.css("img.site-icon") -
     # minus onebox avatars
     @doc.css("img.onebox-avatar") -
+    @doc.css("img.onebox-avatar-inline") -
     # minus github onebox profile images
     @doc.css(".onebox.githubfolder img")
   end


### PR DESCRIPTION
GitHub oneboxes use `.onebox-avatar-inline`, not `.onebox-avatar`

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
