### PR TITLE
UX: make tag input full width for PMs

### DIFF
--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -215,6 +215,13 @@
     .title-input {
       flex: 1 1 100%;
     }
+
+    .archetype-private_message & {
+      // PMs don's have categories, so we need a wider tag input
+      .mini-tag-chooser {
+        width: 100%;
+      }
+    }
   }
 
   .category-input {


### PR DESCRIPTION

Before:
![Screen Shot 2021-02-19 at 7 02 10 PM](https://user-images.githubusercontent.com/1681963/108574331-1debc500-72e5-11eb-99c4-928b0e9272ac.png)


After:
![Screen Shot 2021-02-19 at 7 00 54 PM](https://user-images.githubusercontent.com/1681963/108574312-0d3b4f00-72e5-11eb-8f10-977fa055dcba.png)

I did consider putting them both on the same line, but PM titles can be long (especially in shared inboxes when tagging is used) so I thought having two wide inputs grants a slight edge to editing speed (because we're not obscuring titles as much) 
