### PR TITLE
FIX: Reduce the time_read threshold to one minute.

### DIFF
--- a/app/jobs/scheduled/enqueue_suspect_users.rb
+++ b/app/jobs/scheduled/enqueue_suspect_users.rb
@@ -16,7 +16,7 @@ module Jobs
         .joins(:user_profile, :user_stat)
         .where("users.created_at <= ? AND users.created_at >= ?", 1.day.ago, 6.months.ago)
         .where("LENGTH(COALESCE(user_profiles.bio_raw, user_profiles.website, '')) > 0")
-        .where("user_stats.posts_read_count <= 1 OR user_stats.topics_entered <= 1 OR user_stats.time_read < ?", 5.minutes.to_i)
+        .where("user_stats.posts_read_count <= 1 OR user_stats.topics_entered <= 1 OR user_stats.time_read < ?", 1.minute.to_i)
         .joins("LEFT OUTER JOIN reviewables r ON r.target_id = users.id AND r.target_type = 'User'")
         .where('r.id IS NULL')
         .joins(

--- a/spec/jobs/enqueue_suspect_users_spec.rb
+++ b/spec/jobs/enqueue_suspect_users_spec.rb
@@ -97,7 +97,7 @@ describe Jobs::EnqueueSuspectUsers do
       expect(ReviewableUser.count).to eq(1)
     end
 
-    it 'ignores users if their time read is higher than one minutes' do
+    it 'ignores users if their time read is higher than one minute' do
       suspect_user.user_stat.update!(posts_read_count: 2, topics_entered: 2, time_read: 2.minutes.to_i)
 
       subject.execute({})

--- a/spec/jobs/enqueue_suspect_users_spec.rb
+++ b/spec/jobs/enqueue_suspect_users_spec.rb
@@ -90,15 +90,15 @@ describe Jobs::EnqueueSuspectUsers do
     end
 
     it 'enqueues a suspect user with not enough time read' do
-      suspect_user.user_stat.update!(posts_read_count: 2, topics_entered: 2, time_read: 1.minute.to_i)
+      suspect_user.user_stat.update!(posts_read_count: 2, topics_entered: 2, time_read: 30.seconds.to_i)
 
       subject.execute({})
 
       expect(ReviewableUser.count).to eq(1)
     end
 
-    it 'ignores users if their time read is higher than five minutes' do
-      suspect_user.user_stat.update!(posts_read_count: 2, topics_entered: 2, time_read: 10.minutes.to_i)
+    it 'ignores users if their time read is higher than one minutes' do
+      suspect_user.user_stat.update!(posts_read_count: 2, topics_entered: 2, time_read: 2.minutes.to_i)
 
       subject.execute({})
 


### PR DESCRIPTION
Five minutes is too much and could fill the queue with false positives.


