### PR TITLE
A11Y: makes edit username and avatar accessible

### DIFF
--- a/app/assets/javascripts/discourse/app/initializers/ember-link-component-extension.js
+++ b/app/assets/javascripts/discourse/app/initializers/ember-link-component-extension.js
@@ -1,0 +1,9 @@
+export default {
+  name: "ember-link-component-extensions",
+
+  initialize() {
+    Ember.LinkComponent.reopen({
+      attributeBindings: ["name"],
+    });
+  },
+};

--- a/app/assets/javascripts/discourse/app/templates/preferences/account.hbs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/account.hbs
@@ -3,7 +3,7 @@
   <div class="controls">
     <span class="static">{{model.username}}</span>
     {{#if model.can_edit_username}}
-      {{#link-to "preferences.username" class="btn btn-default btn-small btn-icon pad-left no-text"}}
+      {{#link-to "preferences.username" name=(i18n "user.username.edit") class="btn btn-default btn-small btn-icon pad-left no-text"}}
         {{d-icon "pencil-alt"}}
       {{/link-to}}
     {{/if}}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1323,6 +1323,7 @@ en:
         checking: "Checking username availability..."
         prefilled: "Email matches this registered username"
         required: "Please enter a username"
+        edit: "Edit username"
 
       locale:
         title: "Interface language"
@@ -1558,6 +1559,7 @@ en:
         title: "Profile Picture"
         header_title: "profile, messages, bookmarks and preferences"
         name_and_description: "%{name} - %{description}"
+        edit: "Edit Profile Picture"
       title:
         title: "Title"
         none: "(none)"


### PR DESCRIPTION
This commit also adds name as a bindable attribute of link-to

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
