### PR TITLE
A11Y: gives autocomplete in search a more accessible name

### DIFF
--- a/app/assets/javascripts/discourse/app/components/search-text-field.js
+++ b/app/assets/javascripts/discourse/app/components/search-text-field.js
@@ -4,7 +4,7 @@ import TextField from "discourse/components/text-field";
 import { applySearchAutocomplete } from "discourse/lib/search";
 
 export default TextField.extend({
-  autocomplete: "discourse",
+  autocomplete: "discourse-search",
 
   @discourseComputed("searchService.searchContextEnabled")
   placeholder(searchContextEnabled) {


### PR DESCRIPTION
s/discourse/discourse-search

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
