### PR TITLE
FIX: Don't show "bulk" icon on group-index for unauthorized users

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/group-index.hbs
+++ b/app/assets/javascripts/discourse/app/templates/group-index.hbs
@@ -25,7 +25,9 @@
         <thead>
           <tr>
             <th class="bulk-select">
-              {{flat-button class="bulk-select" icon="list" action=(action "toggleBulkSelect") title="topics.bulk.toggle"}}
+              {{#if canManageGroup}}
+                {{flat-button class="bulk-select" icon="list" action=(action "toggleBulkSelect") title="topics.bulk.toggle"}}
+              {{/if}}
             </th>
             {{#if isBulk}}
               <th class="bulk-select-buttons">

--- a/app/assets/javascripts/discourse/app/templates/group-index.hbs
+++ b/app/assets/javascripts/discourse/app/templates/group-index.hbs
@@ -12,8 +12,8 @@
     <div class="group-members-manage">
       {{#if canManageGroup}}
         {{d-button icon="plus"
-        action=(route-action "showAddMembersModal")
-        label="groups.manage.add_members"
+          action=(route-action "showAddMembersModal")
+          label="groups.manage.add_members"
         class="group-members-add"}}
       {{/if}}
     </div>
@@ -23,29 +23,31 @@
     {{#load-more selector=".group-members tr" action=(action "loadMore")}}
       <table class="group-members">
         <thead>
-          <th class="bulk-select">
-            {{flat-button class="bulk-select" icon="list" action=(action "toggleBulkSelect") title="topics.bulk.toggle"}}
-          </th>
-          {{#if isBulk}}
-            <th class="bulk-select-buttons">
-              {{d-button action=(action "bulkSelectAll") label="topics.bulk.select_all"}}
-              {{d-button action=(action "bulkClearAll") label="topics.bulk.clear_all"}}
+          <tr>
+            <th class="bulk-select">
+              {{flat-button class="bulk-select" icon="list" action=(action "toggleBulkSelect") title="topics.bulk.toggle"}}
             </th>
-          {{/if}}
-          {{table-header-toggle order=order asc=asc field="username_lower" labelKey="username" class="username"}}
-          <th class="group-owner"></th>
-          {{table-header-toggle order=order asc=asc field="added_at" labelKey="groups.member_added"}}
-          {{table-header-toggle order=order asc=asc field="last_posted_at" labelKey="last_post"}}
-          {{table-header-toggle order=order asc=asc field="last_seen_at" labelKey="last_seen"}}
-          <th>
             {{#if isBulk}}
-              {{group-member-dropdown
-                bulkSelection=bulkSelection
-                canAdminGroup=model.can_admin_group
-                onChange=(action "actOnSelection" bulkSelection)
-              }}
+              <th class="bulk-select-buttons">
+                {{d-button action=(action "bulkSelectAll") label="topics.bulk.select_all"}}
+                {{d-button action=(action "bulkClearAll") label="topics.bulk.clear_all"}}
+              </th>
             {{/if}}
-          </th>
+            {{table-header-toggle order=order asc=asc field="username_lower" labelKey="username" class="username"}}
+            <th class="group-owner"></th>
+            {{table-header-toggle order=order asc=asc field="added_at" labelKey="groups.member_added"}}
+            {{table-header-toggle order=order asc=asc field="last_posted_at" labelKey="last_post"}}
+            {{table-header-toggle order=order asc=asc field="last_seen_at" labelKey="last_seen"}}
+            <th>
+              {{#if isBulk}}
+                {{group-member-dropdown
+                  bulkSelection=bulkSelection
+                  canAdminGroup=model.can_admin_group
+                  onChange=(action "actOnSelection" bulkSelection)
+                }}
+              {{/if}}
+            </th>
+          </tr>
         </thead>
 
         <tbody>


### PR DESCRIPTION
Closes https://meta.discourse.org/t/group-management-tools-show-up-for-all-users/179259/9