### PR TITLE
DEV: Remove deprecated plugins variables importer

### DIFF
--- a/app/assets/stylesheets/common/foundation/variables.scss
+++ b/app/assets/stylesheets/common/foundation/variables.scss
@@ -74,10 +74,6 @@ $line-height-small: 1;
 $line-height-medium: 1.2; // Headings or large text
 $line-height-large: 1.4; // Normal or small text
 
-// These files don't actually exist. They're injected by Stylesheet::Compiler.
-// --------------------------------------------------
-
-@import "plugins_variables";
 @import "common/foundation/math";
 
 // Z-index

--- a/lib/discourse_plugin_registry.rb
+++ b/lib/discourse_plugin_registry.rb
@@ -55,7 +55,6 @@ class DiscoursePluginRegistry
   define_register :mobile_stylesheets, Hash
   define_register :desktop_stylesheets, Hash
   define_register :color_definition_stylesheets, Hash
-  define_register :sass_variables, Set
   define_register :handlebars, Set
   define_register :serialized_current_user_fields, Set
   define_register :seed_data, HashWithIndifferentAccess
@@ -161,9 +160,6 @@ class DiscoursePluginRegistry
         self.desktop_stylesheets[plugin_directory_name] << asset
       elsif opts == :color_definitions
         self.color_definition_stylesheets[plugin_directory_name] = asset
-      elsif opts == :variables
-        Discourse.deprecate(":variables is deprecated", drop_from: "2.7")
-        self.sass_variables << asset
       else
         self.stylesheets[plugin_directory_name] ||= Set.new
         self.stylesheets[plugin_directory_name] << asset

--- a/lib/stylesheet/importer.rb
+++ b/lib/stylesheet/importer.rb
@@ -91,10 +91,6 @@ module Stylesheet
         Import.new("wizard_fonts.scss", source: contents)
       end
 
-      register_import "plugins_variables" do
-        import_files(DiscoursePluginRegistry.sass_variables)
-      end
-
       register_import "category_backgrounds" do
         contents = +""
         Category.where('uploaded_background_id IS NOT NULL').each do |c|

--- a/spec/components/discourse_plugin_registry_spec.rb
+++ b/spec/components/discourse_plugin_registry_spec.rb
@@ -233,13 +233,6 @@ describe DiscoursePluginRegistry do
       expect(registry.stylesheets[plugin_directory_name]).to eq(nil)
     end
 
-    it "registers sass variable properly" do
-      registry.register_asset("test.css", :variables)
-
-      expect(registry.sass_variables.count).to eq(1)
-      expect(registry.stylesheets.count).to eq(0)
-    end
-
     it "registers admin javascript properly" do
       registry.register_asset("my_admin.js", :admin)
 

--- a/spec/components/plugin/instance_spec.rb
+++ b/spec/components/plugin/instance_spec.rb
@@ -258,9 +258,6 @@ describe Plugin::Instance do
       plugin.register_asset("desktop.css", :desktop)
       plugin.register_asset("desktop2.css", :desktop)
 
-      plugin.register_asset("variables1.scss", :variables)
-      plugin.register_asset("variables2.scss", :variables)
-
       plugin.register_asset("code.js")
 
       plugin.register_asset("my_admin.js", :admin)
@@ -271,7 +268,6 @@ describe Plugin::Instance do
       expect(DiscoursePluginRegistry.javascripts.count).to eq(2)
       expect(DiscoursePluginRegistry.admin_javascripts.count).to eq(2)
       expect(DiscoursePluginRegistry.desktop_stylesheets[plugin.directory_name].count).to eq(2)
-      expect(DiscoursePluginRegistry.sass_variables.count).to eq(2)
       expect(DiscoursePluginRegistry.stylesheets[plugin.directory_name].count).to eq(2)
       expect(DiscoursePluginRegistry.mobile_stylesheets[plugin.directory_name].count).to eq(1)
     end


### PR DESCRIPTION
Previously deprecated in https://github.com/discourse/discourse/commit/7f1bafcf6356637fc397baa723da84b35ef91b65. 