### PR TITLE
FIX: Show a better error message when under load

### DIFF
--- a/app/assets/javascripts/discourse/app/components/global-notice.js
+++ b/app/assets/javascripts/discourse/app/components/global-notice.js
@@ -72,7 +72,9 @@ export default Component.extend({
         removeCookie("dosp", { path: "/" });
         notices.push(
           Notice.create({
-            text: I18n.t("forced_anonymous"),
+            text: this.siteSettings.login_required
+              ? I18n.t("forced_anonymous_login_required")
+              : I18n.t("forced_anonymous"),
             id: "forced-anonymous",
           })
         );

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3632,6 +3632,7 @@ en:
       custom_message_template_topic: "Hey, I thought you might enjoy this topic!"
 
     forced_anonymous: "Due to extreme load, this is temporarily being shown to everyone as a logged out user would see it."
+    forced_anonymous_login_required: "The site is under extreme load and cannot be loaded at this time, try again in a few minutes."
 
     footer_nav:
       back: "Back"


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
