### PR TITLE
FIX: Prevent white screen on Safari on back navigation in the same tab

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/push-notifications.js
+++ b/app/assets/javascripts/discourse/app/lib/push-notifications.js
@@ -53,7 +53,7 @@ export function isPushNotificationsSupported(mobileView) {
   if (
     !(
       "serviceWorker" in navigator &&
-      ServiceWorkerRegistration &&
+      typeof ServiceWorkerRegistration !== "undefined" &&
       typeof Notification !== "undefined" &&
       "showNotification" in ServiceWorkerRegistration.prototype &&
       "PushManager" in window


### PR DESCRIPTION
Fixes an issue on Safari/macOS where the browser returns a white screen with `ReferenceError: Can't find variable: ServiceWorkerRegistration` in the console when going back to the instance from an external link opened in the same tab. 