### PR TITLE
DEV: Support setting deprecated site settings via the API

### DIFF
--- a/app/controllers/admin/site_settings_controller.rb
+++ b/app/controllers/admin/site_settings_controller.rb
@@ -14,6 +14,12 @@ class Admin::SiteSettingsController < Admin::AdminController
     id = params[:id]
     value = params[id]
     value.strip! if value.is_a?(String)
+
+    new_setting_name = SiteSettings::DeprecatedSettings::SETTINGS.find do |old_name, new_name, _, _|
+      break new_name if old_name == id
+    end
+    id = new_setting_name if new_setting_name
+
     raise_access_hidden_setting(id)
 
     if SiteSetting.type_supervisor.get_type(id) == :uploaded_image_list

--- a/spec/requests/admin/site_settings_controller_spec.rb
+++ b/spec/requests/admin/site_settings_controller_spec.rb
@@ -45,6 +45,14 @@ describe Admin::SiteSettingsController do
         expect(SiteSetting.test_setting).to eq('hello')
       end
 
+      it 'works for deprecated settings' do
+        put "/admin/site_settings/sso_url.json", params: {
+          sso_url: "https://example.com"
+        }
+        expect(response.status).to eq(200)
+        expect(SiteSetting.discourse_connect_url).to eq("https://example.com")
+      end
+
       it 'allows value to be a blank string' do
         put "/admin/site_settings/test_setting.json", params: {
           test_setting: ''


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
