### PR TITLE
UX: use default browser focus styling for checkbox and radio inputs

### DIFF
--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -148,9 +148,6 @@ input {
     line-height: $line-height-small;
     cursor: pointer;
     flex-shrink: 0; // Adding for safety, Safari will shrink checkboxes
-    &:focus {
-      outline: none;
-    }
   }
   &[type="submit"],
   &[type="reset"],
@@ -189,7 +186,7 @@ textarea {
     border-color: var(--primary-low);
   }
 
-  &:focus {
+  &:not([type="checkbox"]):not([type="radio"]):focus {
     @include default-focus;
   }
 

--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -148,6 +148,9 @@ input {
     line-height: $line-height-small;
     cursor: pointer;
     flex-shrink: 0; // Adding for safety, Safari will shrink checkboxes
+    &:focus {
+      outline: none;
+    }
   }
   &[type="submit"],
   &[type="reset"],


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
