### PR TITLE
DEV: Correct DeprecatedSettings test cleanup

### DIFF
--- a/spec/models/site_setting_spec.rb
+++ b/spec/models/site_setting_spec.rb
@@ -163,7 +163,7 @@ describe SiteSetting do
 
     it 'should act as a proxy to the new methods' do
       begin
-        original_settings = SiteSettings::DeprecatedSettings::SETTINGS
+        original_settings = SiteSettings::DeprecatedSettings::SETTINGS.dup
         SiteSettings::DeprecatedSettings::SETTINGS.clear
 
         SiteSettings::DeprecatedSettings::SETTINGS.push([


### PR DESCRIPTION
If this test ran before the new SiteSettingsController spec from 8cd7c9b2593462ad64512ac7e4bd208a4d560fa3, it would fail the run. We need to `dup` the array before calling `.clear` on the original

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
