### PR TITLE
FIX: Adding a custom scope should not modify the original ones.

### DIFF
--- a/app/models/api_key_scope.rb
+++ b/app/models/api_key_scope.rb
@@ -59,10 +59,11 @@ class ApiKeyScope < ActiveRecord::Base
 
     def scope_mappings
       plugin_mappings = DiscoursePluginRegistry.api_key_scope_mappings
+      return default_mappings if plugin_mappings.empty?
 
-      default_mappings.tap do |mappings|
+      default_mappings.deep_dup.tap do |mappings|
+
         plugin_mappings.each do |resource|
-
           resource.each_value do |resource_actions|
             resource_actions.each_value do |action_data|
               action_data[:urls] = find_urls(action_data[:actions])


### PR DESCRIPTION
Default scopes are stored inside a class variable, which shouldn't be modified when a custom scope is added. If this happens, we're no longer to remove the scope when the plugin is disabled.

