### PR TITLE
FIX: log warning when context is missing when a user is destroyed

### DIFF
--- a/app/services/user_destroyer.rb
+++ b/app/services/user_destroyer.rb
@@ -93,6 +93,7 @@ class UserDestroyer
             deleted_by = @actor
           end
           StaffActionLogger.new(deleted_by).log_user_deletion(user, opts.slice(:context))
+          Rails.logger.warn("User destroyed without context from: #{caller_locations(14, 1)[0]}") if opts.slice(:context).blank?
         end
         MessageBus.publish "/logout", result.id, user_ids: [result.id]
       end

--- a/spec/services/user_destroyer_spec.rb
+++ b/spec/services/user_destroyer_spec.rb
@@ -85,6 +85,15 @@ describe UserDestroyer do
       end
     end
 
+    context 'context is missing' do
+      it "logs warning message if context is missing" do
+        messages = track_log_messages(level: Logger::WARN) do
+          UserDestroyer.new(admin).destroy(user)
+        end
+        expect(messages[0][2]).to include("User destroyed without context from:")
+      end
+    end
+
     context "with a reviewable post" do
       let!(:reviewable) { Fabricate(:reviewable, created_by: user) }
 


### PR DESCRIPTION
in reference to: https://github.com/discourse/discourse/commit/f75e1867ff44a8c955994f8f4bc94af681086ebd