### PR TITLE
FIX: emails.rake-use domain when sending mail test

### DIFF
--- a/lib/tasks/emails.rake
+++ b/lib/tasks/emails.rake
@@ -86,7 +86,8 @@ task 'emails:test', [:email] => [:environment] do |_, args|
     #  s.auth_login(smtp[:user_name], smtp[:password])
     #end
 
-    Net::SMTP.start(smtp[:address], smtp[:port], 'localhost', smtp[:user_name], smtp[:password], smtp[:authentication])
+    Net::SMTP.start(smtp[:address], smtp[:port], smtp[:domain] || 'localhost',  smtp[:user_name], smtp[:password], smtp[:authentication])
+
   rescue Exception => e
 
     if e.to_s.match(/execution expired/)


### PR DESCRIPTION
`rake emails:test` task was always sending `localhost` as the domain name rather than using `smtp[:domain]` (aka `DISCOURSE_SMTP_DOMAIN`. `discourse-setup` has recently been modified to always set `DISCOURSE_SMTP_DOMAIN`, so it's important that this test rake task actually use the value.

I tested this change on a standard production install, and it's working as expected. Hopefully I managed not to bungle the copy/paste of the single line here in the github edit window.
