### PR TITLE
UX: Remove redundant focus style

### DIFF
--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -186,10 +186,6 @@ textarea {
     border-color: var(--primary-low);
   }
 
-  &:not([type="checkbox"]):not([type="radio"]):focus {
-    @include default-focus;
-  }
-
   &:focus:required:invalid {
     color: var(--danger);
     border-color: var(--danger);


### PR DESCRIPTION
This style is unnecessary because text inputs and textareas have focus styles set elsewhere (lines 228 and 288 of the same file, respectively) and we don't have any `select` elements. (This also fixes an issue where textareas in other contexts, like the composer, were overriden by this rule, due to its specificity.) 