### PR TITLE
FIX: Allow entering blank values in relative-time-picker

### DIFF
--- a/app/assets/javascripts/discourse/app/components/edit-category-settings.js
+++ b/app/assets/javascripts/discourse/app/components/edit-category-settings.js
@@ -135,7 +135,7 @@ export default buildCategoryPanel("settings", {
 
   @action
   onAutoCloseDurationChange(minutes) {
-    let hours = minutes / 60;
+    let hours = minutes ? minutes / 60 : null;
     this.set("category.auto_close_hours", hours);
   },
 });

--- a/app/assets/javascripts/discourse/app/components/relative-time-picker.js
+++ b/app/assets/javascripts/discourse/app/components/relative-time-picker.js
@@ -1,5 +1,5 @@
 import discourseComputed, { on } from "discourse-common/utils/decorators";
-
+import { isBlank } from "@ember/utils";
 import Component from "@ember/component";
 import I18n from "I18n";
 import { action } from "@ember/object";
@@ -114,6 +114,9 @@ export default Component.extend({
 
   @discourseComputed("selectedInterval", "duration")
   calculatedMinutes(interval, duration) {
+    if (isBlank(duration)) {
+      return null;
+    }
     duration = parseFloat(duration);
 
     let mins = 0;


### PR DESCRIPTION
In certain cases such as the category auto-close hours setting, it makes sense to blank out the relative time picker duration so 
`null` is sent to the server to clear the value.

Meta example: https://meta.discourse.org/t/how-do-i-disable-topic-auto-close/180487