### PR TITLE
FIX: paste table with multiline cell

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-editor.js
+++ b/app/assets/javascripts/discourse/app/components/d-editor.js
@@ -882,7 +882,19 @@ export default Component.extend({
       text = text.substring(0, text.length - 1);
     }
 
-    let rows = text.split("\n");
+    text = text.split("");
+    let cell = false;
+    text.forEach((char, index) => {
+      if (char === "\n" && cell) {
+        text[index] = "\r";
+      }
+      if (char === '"') {
+        text[index] = "";
+        cell = !cell;
+      }
+    });
+
+    let rows = text.join("").replace(/\r/g, "<br>").split("\n");
 
     if (rows.length > 1) {
       const columns = rows.map((r) => r.split("\t").length);

--- a/app/assets/javascripts/discourse/tests/integration/components/d-editor-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/d-editor-test.js
@@ -721,6 +721,11 @@ third line`
       let element = queryAll(".d-editor")[0];
       await paste(element, "\ta\tb\n1\t2\t3");
       assert.equal(this.value, "||a|b|\n|---|---|---|\n|1|2|3|\n");
+
+      this.set("value", "");
+
+      await paste(element, '\ta\tb\n1\t"2\n2.5"\t3');
+      assert.equal(this.value, "||a|b|\n|---|---|---|\n|1|2<br>2.5|3|\n");
     },
   });
 


### PR DESCRIPTION
When a cell is multiline, it is wrapped with quotes. It can be used to determine if it is a "real" new line or not.

Meta: https://meta.discourse.org/t/pasting-google-sheets-table-with-a-cell-that-contain-a-line-break/173106

https://user-images.githubusercontent.com/72780/108951042-61ff1100-76bb-11eb-8e51-c53348c2ec03.mov